### PR TITLE
Backport [ruby-core:29501] to 1.8.7 

### DIFF
--- a/lib/resolv.rb
+++ b/lib/resolv.rb
@@ -2066,7 +2066,11 @@ class Resolv
     ##
     # Regular expression IPv4 addresses must match.
 
-    Regex = /\A(\d+)\.(\d+)\.(\d+)\.(\d+)\z/
+    Regex256 = /0
+               |1(?:[0-9][0-9]?)?
+               |2(?:[0-4][0-9]?|5[0-5]?|[6-9])?
+               |[3-9][0-9]?/x
+    Regex = /\A(#{Regex256})\.(#{Regex256})\.(#{Regex256})\.(#{Regex256})\z/
 
     def self.create(arg)
       case arg

--- a/test/resolv/test_addr.rb
+++ b/test/resolv/test_addr.rb
@@ -1,0 +1,16 @@
+require 'test/unit'
+require 'resolv'
+require 'socket'
+
+class TestResolvAddr < Test::Unit::TestCase
+  def test_invalid_ipv4_address
+    assert_no_match(Resolv::IPv4::Regex, "1.2.3.256", "[ruby-core:29501]")
+    1000.times {|i|
+      if i < 256
+        assert_match(Resolv::IPv4::Regex, "#{i}.#{i}.#{i}.#{i}")
+      else
+        assert_no_match(Resolv::IPv4::Regex, "#{i}.#{i}.#{i}.#{i}")
+      end
+    }
+  end
+end


### PR DESCRIPTION
Resolv still has the wrong regex for IPv4
