### PR TITLE
FileUtils.ln_r

### DIFF
--- a/lib/fileutils.rb
+++ b/lib/fileutils.rb
@@ -342,7 +342,7 @@ module FileUtils
   # TODO: Why --remove-destination and not --force?
   def ln_r(src, dest, options = {})
     fu_check_options options, OPT_TABLE['ln_r']
-    fu_output_message "cp -r#{options[:remove_destination] ? ' --remove-destination' : ''} #{[src,dest].flatten.join ' '}" if options[:verbose]
+    fu_output_message "ln -r#{options[:remove_destination] ? ' --remove-destination' : ''} #{[src,dest].flatten.join ' '}" if options[:verbose]
     return if options[:noop]
     options = options.dup
     options[:dereference_root] = true unless options.key?(:dereference_root)


### PR DESCRIPTION
This patch adds `FileUtils.ln_r` (recursive hard link). It is patterned after `#cp_r` and I have used it in an app of mine, and thus far it has worked fine.

The only thing about it that I am not 100% sure, is it's handling of non-file and non-directory file types. I just assumed any other type other than a directory can be hard linked.

Also I made a note about using `--remove-destination` vs. `--force` I'm not sure why one would be used over the other. `#ln` uses `--force` while `#cp_r` uses `--remove-destination`. I went with the later.
