### PR TITLE
Aliased / to + in Pathname

### DIFF
--- a/ext/pathname/lib/pathname.rb
+++ b/ext/pathname/lib/pathname.rb
@@ -308,6 +308,7 @@ class Pathname
     other = Pathname.new(other) unless Pathname === other
     Pathname.new(plus(@path, other.to_s))
   end
+  alias_method :/, :+
 
   def plus(path1, path2) # -> path
     prefix2 = path2


### PR DESCRIPTION
This commit adds a little of syntactic sugar by aliasing / to the + method in Pathname.

Example:
    require 'pathname'
    Pathname.pwd / "directory" / "to" / "some" / "stuff"

Thank you :)
