### PR TITLE
Fix xmlrpc fault message

### DIFF
--- a/lib/xmlrpc/parser.rb
+++ b/lib/xmlrpc/parser.rb
@@ -54,11 +54,10 @@ module XMLRPC
   class FaultException < StandardError
     attr_reader :faultCode, :faultString
 
-    alias message faultString
-
     def initialize(faultCode, faultString)
       @faultCode   = faultCode
       @faultString = faultString
+      super(@faultString)
     end
 
     # returns a hash

--- a/test/xmlrpc/test_parser.rb
+++ b/test/xmlrpc/test_parser.rb
@@ -65,6 +65,12 @@ module GenericParserTest
      assert_equal(fault.faultCode, 4)
      assert_equal(fault.faultString, "an error message")
   end
+
+  def test_fault_message
+    fault = XMLRPC::FaultException.new(1234, 'an error message')
+    assert_equal('an error message', fault.to_s)
+    assert_equal('#<XMLRPC::FaultException: an error message>', fault.inspect)
+  end
 end
 
 # create test class for each installed parser


### PR DESCRIPTION
Tiny patch to show exception fault message like all other exceptions should.

Should apply cleanly to all ruby versions since svn: 8258 (git: f1587ee5)
