### PR TITLE
Fix typo in openssl file

### DIFF
--- a/ext/openssl/ossl_cipher.c
+++ b/ext/openssl/ossl_cipher.c
@@ -189,7 +189,7 @@ ossl_cipher_init(int argc, VALUE *argv, VALUE self, int mode)
 	 * keeping this behaviour for backward compatibility.
 	 */
 	const char *cname  = rb_class2name(rb_obj_class(self));
-	rb_warn("argumtents for %s#encrypt and %s#decrypt were deprecated; "
+	rb_warn("arguments for %s#encrypt and %s#decrypt were deprecated; "
                 "use %s#pkcs5_keyivgen to derive key and IV",
                 cname, cname, cname);
 	StringValue(pass);


### PR DESCRIPTION
Changed "argumtents" to "arguments"
