### PR TITLE
strftime %v capitalized month abbreviation

### DIFF
--- a/ext/date/date_strftime.c
+++ b/ext/date/date_strftime.c
@@ -605,7 +605,7 @@ date_strftime_with_tmx(char *s, size_t maxsize, const char *format,
 
 #ifdef VMS_EXT
 		case 'v':	/* date as dd-bbb-YYYY */
-			STRFTIME("%e-%^b-%4Y");
+			STRFTIME("%e-%b-%4Y");
 			continue;
 #endif
 

--- a/test/date/test_date_strftime.rb
+++ b/test/date/test_date_strftime.rb
@@ -47,7 +47,7 @@ class TestDateStrftime < Test::Unit::TestCase
     '%t'=>["\t",{}],
     '%u'=>['6',{:cwday=>6}],
     '%V'=>['05',{:cweek=>5}],
-    '%v'=>[' 3-FEB-2001',{:mday=>3,:mon=>2,:year=>2001}],
+    '%v'=>[' 3-Feb-2001',{:mday=>3,:mon=>2,:year=>2001}],
     '%z'=>['+0000',{:zone=>'+0000',:offset=>0}],
     '%+'=>['Sat Feb  3 00:00:00 +00:00 2001',
       {:wday=>6,:mon=>2,:mday=>3,


### PR DESCRIPTION
Related to: http://redmine.ruby-lang.org/issues/4662
