### PR TITLE
prevent an error when passing a frozen string to REXML::Text.new

### DIFF
--- a/lib/rexml/text.rb
+++ b/lib/rexml/text.rb
@@ -105,7 +105,7 @@ module REXML
       @normalized = @unnormalized = nil
 
       if arg.kind_of? String
-        @string = arg.clone
+        @string = arg.dup
         @string.squeeze!(" \n\t") unless respect_whitespace
       elsif arg.kind_of? Text
         @string = arg.to_s

--- a/test/rexml/test_core.rb
+++ b/test/rexml/test_core.rb
@@ -349,6 +349,9 @@ class Tester < Test::Unit::TestCase
     assert_equal(string, text.to_s)
     text2 = Text.new(text)
     assert_equal(text, text2)
+    string = "Frozen".freeze
+    text3 = Text.new(string)
+    assert_equal(string, text3.to_s)
     #testing substitution
     string = "0 < ( 1 & 1 )"
     correct = "0 &lt; ( 1 &amp; 1 )"


### PR DESCRIPTION
dup the string passed in instead of cloning so that it's frozen state is ignored.

This prevents the unexpected error that occurs when setting the text on an element to what happens to be a frozen string
