### PR TITLE
Doc Array#delete_at inconsistence fix

### DIFF
--- a/array.c
+++ b/array.c
@@ -2481,7 +2481,7 @@ rb_ary_delete_at(VALUE ary, long pos)
  *  or <code>nil</code> if the index is out of range. See also
  *  <code>Array#slice!</code>.
  *
- *     a = %w( ant bat cat dog )
+ *     a = ["ant", "bat", "cat", "dog"]
  *     a.delete_at(2)    #=> "cat"
  *     a                 #=> ["ant", "bat", "dog"]
  *     a.delete_at(99)   #=> nil


### PR DESCRIPTION
The documentation for the #delete_at method is inconsistent concerning the example array initialization. For all array examples brackets are used for the creation, except the #delete_at is uses the '%w' flavor.
In terms of a consistent documentation i would recommend to revise this.
