### PR TITLE
Fix bug that causes YAML serialization problem for Exception.

### DIFF
--- a/ext/syck/lib/syck/rubytypes.rb
+++ b/ext/syck/lib/syck/rubytypes.rb
@@ -122,7 +122,10 @@ end
 class Exception
     yaml_as "tag:ruby.yaml.org,2002:exception"
     def Exception.yaml_new( klass, tag, val )
-        o = YAML.object_maker( klass, { 'mesg' => val.delete( 'message' ) } )
+        o = klass.allocate
+        Exception.instance_method(:initialize).
+                  bind(o).
+                  call( val.delete( 'message' )  )
         val.each_pair do |k,v|
             o.instance_variable_set("@#{k}", v)
         end

--- a/test/syck/test_exception.rb
+++ b/test/syck/test_exception.rb
@@ -13,7 +13,7 @@ module Syck
     end
 
     def setup
-      @wups = Wups.new
+      @wups = Wups.new('test_message')
     end
 
     def test_to_yaml


### PR DESCRIPTION
The implementation of YAML.object_maker allocates an object and
instance_variable_set the instance variables passed as the second
argument, while Exception doesn't seem to use such instance variable to
return the exception message (Exception#message). This bug can be
reproduced by typing
YAML::load(YAML::dump(Exception.new('test_message'))) in IRB, e.g.,

ruby-1.9.2-p290 :001 > require 'yaml'
 => true 
ruby-1.9.2-p290 :002 > YAML::load(YAML::dump(Exception.new('test_message')))
 => #<Exception: Exception> 
# <Exception: "test_message"> is expected while the result is #<Exception: Exception>.
