### PR TITLE
* include/ruby/intern.h (rb_ary_first, rb_ary_last): export.

### DIFF
--- a/include/ruby/intern.h
+++ b/include/ruby/intern.h
@@ -85,6 +85,8 @@ VALUE rb_ary_cmp(VALUE, VALUE);
 VALUE rb_ary_replace(VALUE copy, VALUE orig);
 VALUE rb_get_values_at(VALUE, long, int, VALUE*, VALUE(*)(VALUE,long));
 VALUE rb_ary_resize(VALUE ary, long len);
+VALUE rb_ary_first(int argc, VALUE *argv, VALUE ary);
+VALUE rb_ary_last(int argc, VALUE *argv, VALUE ary);
 /* bignum.c */
 VALUE rb_big_new(long, int);
 int rb_bigzero_p(VALUE x);


### PR DESCRIPTION
Hi, these exports could be useful in C extensions.

Thanks
