### PR TITLE
added note on consistency to String#hash documentation

### DIFF
--- a/string.c
+++ b/string.c
@@ -2160,6 +2160,7 @@ rb_str_hash_cmp(VALUE str1, VALUE str2)
  *    str.hash   -> fixnum
  *
  * Return a hash based on the string's length and content.
+ * Note: hash is consistent only within the same process.
  */
 
 static VALUE


### PR DESCRIPTION
The existing documentation suggested that the hash depends only on the
string itself, and thus that it was consistently reproducible - this is
not the case though as a random per-process seed is involved as well.

(FWIW, I looked at existing instances of "Note:" for stylistic consistency.)
