### PR TITLE
Fix problem with `defined?(@@foo) && @@foo`

### DIFF
--- a/insns.def
+++ b/insns.def
@@ -773,11 +773,14 @@ defined
 	}
 	break;
       case DEFINED_CVAR:
-	klass = vm_get_cbase(GET_ISEQ(), GET_LFP(), GET_DFP());
+	{
+	NODE *cref = vm_get_cref(GET_ISEQ(), GET_LFP(), GET_DFP());
+	klass = vm_get_cvar_base(cref);
 	if (rb_cvar_defined(klass, SYM2ID(obj))) {
 	    expr_type = "class variable";
 	}
 	break;
+	}
       case DEFINED_CONST:
 	klass = v;
 	if (vm_get_ev_const(th, GET_ISEQ(), klass, SYM2ID(obj), 1)) {

--- a/test/ruby/test_variable.rb
+++ b/test/ruby/test_variable.rb
@@ -55,6 +55,11 @@ class TestVariable < Test::Unit::TestCase
     assert_equal("Cronus", atlas.ruler0)
     assert_equal("Zeus", atlas.ruler3)
     assert_equal("Cronus", atlas.ruler4)
+    assert_nothing_raised do
+      class << Gods
+        defined?(@@rule) && @@rule
+      end
+    end
   end
 
   def test_local_variables


### PR DESCRIPTION
`defined?(@@foo) && @@foo` will sometimes raise an error.

Test and patch is provided.
