### PR TITLE
unecessary macros and k&r style coding

### DIFF
--- a/strftime.c
+++ b/strftime.c
@@ -127,14 +127,8 @@ extern char *strchr();
 
 /* min --- return minimum of two numbers */
 
-#ifndef __STDC__
-static inline int
-min(a, b)
-int a, b;
-#else
 static inline int
 min(int a, int b)
-#endif
 {
 	return (a < b ? a : b);
 }
@@ -143,14 +137,8 @@ min(int a, int b)
 
 /* max --- return maximum of two numbers */
 
-#ifndef __STDC__
-static inline int
-max(a, b)
-int a, b;
-#else
 static inline int
 max(int a, int b)
-#endif
 {
 	return (a > b ? a : b);
 }
@@ -820,14 +808,8 @@ rb_strftime_timespec(char *s, size_t maxsize, const char *format, rb_encoding *e
 
 /* isleap --- is a year a leap year? */
 
-#ifndef __STDC__
-static int
-isleap(year)
-long year;
-#else
 static int
 isleap(long year)
-#endif
 {
 	return ((year % 4 == 0 && year % 100 != 0) || year % 400 == 0);
 }
@@ -861,14 +843,8 @@ vtm2tm_noyear(const struct vtm *vtm, struct tm *result)
 #ifdef POSIX2_DATE
 /* iso8601wknum --- compute week number according to ISO 8601 */
 
-#ifndef __STDC__
-static int
-iso8601wknum(timeptr)
-const struct tm *timeptr;
-#else
 static int
 iso8601wknum(const struct tm *timeptr)
-#endif
 {
 	/*
 	 * From 1003.2:
@@ -988,15 +964,8 @@ iso8601wknum_v(const struct vtm *vtm)
 
 /* With thanks and tip of the hatlo to ado@elsie.nci.nih.gov */
 
-#ifndef __STDC__
-static int
-weeknumber(timeptr, firstweekday)
-const struct tm *timeptr;
-int firstweekday;
-#else
 static int
 weeknumber(const struct tm *timeptr, int firstweekday)
-#endif
 {
 	int wday = timeptr->tm_wday;
 	int ret;
@@ -1132,9 +1101,7 @@ static char *array[] =
 /* main routine. */
 
 int
-main(argc, argv)
-int argc;
-char **argv;
+main(int argc, char **argv)
 {
 	long time();
 

--- a/vsnprintf.c
+++ b/vsnprintf.c
@@ -242,9 +242,7 @@ struct __suio {
  * This routine is large and unsightly, but most of the ugliness due
  * to the three different kinds of output buffering is handled here.
  */
-static int BSD__sfvwrite(fp, uio)
-	register FILE *fp;
-	register struct __suio *uio;
+static int BSD__sfvwrite( register FILE *fp, register struct __suio *uio)
 {
 	register size_t len;
 	register const char *p;
@@ -1168,10 +1166,7 @@ extern char *BSD__dtoa __P((double, int, int, int *, int *, char **));
 extern char *BSD__hdtoa(double, const char *, int, int *, int *, char **);
 
 static char *
-cvt(value, ndigits, flags, sign, decpt, ch, length, buf)
-	double value;
-	int ndigits, flags, *decpt, ch, *length;
-	char *sign, *buf;
+cvt(double value, int ndigits, int flags, char *sign, int *decpt, int ch, int *length, char *buf)
 {
 	int mode, dsgn;
 	char *digits, *bp, *rve;
@@ -1217,9 +1212,7 @@ cvt(value, ndigits, flags, sign, decpt, ch, length, buf)
 }
 
 static int
-exponent(p0, exp, fmtch)
-	char *p0;
-	int exp, fmtch;
+exponent(char *p0, int exp, int fmtch)
 {
 	register char *p, *t;
 	char expbuf[MAXEXP];


### PR DESCRIPTION
- strftime.c: remove unnecessary macros to check traditional c
- vsnprintf.c: remove k&r
