### PR TITLE
OpenSSL Segfault Fix

### DIFF
--- a/ext/openssl/ossl_x509store.c
+++ b/ext/openssl/ossl_x509store.c
@@ -131,6 +131,7 @@ ossl_x509store_initialize(int argc, VALUE *argv, VALUE self)
 
 /* BUG: This method takes any number of arguments but appears to ignore them. */
     GetX509Store(self, store);
+    store->ex_data.sk = NULL;
     X509_STORE_set_verify_cb_func(store, ossl_verify_cb);
     ossl_x509store_set_vfy_cb(self, Qnil);
 


### PR DESCRIPTION
I'm not sure why this wasn't also put into 1_8_7 a year ago when it was fixed in ruby 1.9.1, but hopefully this will find it's way in. It still causes a fair amount of trouble for people.
