### PR TITLE
a more consistent doc style for blocks in enum.c

### DIFF
--- a/enum.c
+++ b/enum.c
@@ -60,8 +60,8 @@ grep_iter_i(VALUE i, VALUE args, int argc, VALUE *argv)
 
 /*
  *  call-seq:
- *     enum.grep(pattern)                   -> array
- *     enum.grep(pattern) {| obj | block }  -> array
+ *     enum.grep(pattern)                 -> array
+ *     enum.grep(pattern) {|obj| block }  -> array
  *
  *  Returns an array of every element in <i>enum</i> for which
  *  <code>Pattern === element</code>. If the optional <em>block</em> is
@@ -125,9 +125,9 @@ count_all_i(VALUE i, VALUE memop, int argc, VALUE *argv)
 
 /*
  *  call-seq:
- *     enum.count                   -> int
- *     enum.count(item)             -> int
- *     enum.count {| obj | block }  -> int
+ *     enum.count                 -> int
+ *     enum.count(item)           -> int
+ *     enum.count {|obj| block }  -> int
  *
  *  Returns the number of items in <i>enum</i>, where #size is called
  *  if it responds to it, otherwise the items are counted through
@@ -183,10 +183,10 @@ find_i(VALUE i, VALUE *memo, int argc, VALUE *argv)
 
 /*
  *  call-seq:
- *     enum.detect(ifnone = nil) {| obj | block }  -> obj or nil
- *     enum.find(ifnone = nil)   {| obj | block }  -> obj or nil
- *     enum.detect(ifnone = nil)                   -> an_enumerator
- *     enum.find(ifnone = nil)                     -> an_enumerator
+ *     enum.detect(ifnone = nil) {|obj| block }  -> obj or nil
+ *     enum.find(ifnone = nil)   {|obj| block }  -> obj or nil
+ *     enum.detect(ifnone = nil)                 -> an_enumerator
+ *     enum.find(ifnone = nil)                   -> an_enumerator
  *
  *  Passes each entry in <i>enum</i> to <em>block</em>. Returns the
  *  first for which <em>block</em> is not false.  If no
@@ -248,9 +248,9 @@ find_index_iter_i(VALUE i, VALUE memop, int argc, VALUE *argv)
 
 /*
  *  call-seq:
- *     enum.find_index(value)            -> int or nil
- *     enum.find_index {| obj | block }  -> int or nil
- *     enum.find_index                   -> an_enumerator
+ *     enum.find_index(value)          -> int or nil
+ *     enum.find_index {|obj| block }  -> int or nil
+ *     enum.find_index                 -> an_enumerator
  *
  *  Compares each entry in <i>enum</i> with <em>value</em> or passes
  *  to <em>block</em>.  Returns the index for the first for which the
@@ -302,10 +302,10 @@ find_all_i(VALUE i, VALUE ary, int argc, VALUE *argv)
 
 /*
  *  call-seq:
- *     enum.find_all {| obj | block }  -> array
- *     enum.select   {| obj | block }  -> array
- *     enum.find_all                   -> an_enumerator
- *     enum.select                     -> an_enumerator
+ *     enum.find_all {|obj| block }  -> array
+ *     enum.select   {|obj| block }  -> array
+ *     enum.find_all                 -> an_enumerator
+ *     enum.select                   -> an_enumerator
  *
  *  Returns an array containing all elements of <i>enum</i> for which
  *  <em>block</em> is not <code>false</code> (see also
@@ -344,8 +344,8 @@ reject_i(VALUE i, VALUE ary, int argc, VALUE *argv)
 
 /*
  *  call-seq:
- *     enum.reject {| obj | block }  -> array
- *     enum.reject                   -> an_enumerator
+ *     enum.reject {|obj| block } -> array
+ *     enum.reject                -> an_enumerator
  *
  *  Returns an array for all elements of <i>enum</i> for which
  *  <em>block</em> is false (see also <code>Enumerable#find_all</code>).
@@ -388,10 +388,10 @@ collect_all(VALUE i, VALUE ary, int argc, VALUE *argv)
 
 /*
  *  call-seq:
- *     enum.collect {| obj | block }  -> array
- *     enum.map     {| obj | block }  -> array
- *     enum.collect                   -> an_enumerator
- *     enum.map                       -> an_enumerator
+ *     enum.collect {|obj| block }  -> array
+ *     enum.map     {|obj| block }  -> array
+ *     enum.collect                 -> an_enumerator
+ *     enum.map                     -> an_enumerator
  *
  *  Returns a new array with the results of running <em>block</em> once
  *  for every element in <i>enum</i>.
@@ -435,10 +435,10 @@ flat_map_i(VALUE i, VALUE ary, int argc, VALUE *argv)
 
 /*
  *  call-seq:
- *     enum.flat_map       {| obj | block }  -> array
- *     enum.collect_concat {| obj | block }  -> array
- *     enum.flat_map                         -> an_enumerator
- *     enum.collect_concat                   -> an_enumerator
+ *     enum.flat_map       {|obj| block }  -> array
+ *     enum.collect_concat {|obj| block }  -> array
+ *     enum.flat_map                       -> an_enumerator
+ *     enum.collect_concat                 -> an_enumerator
  *
  *  Returns a new array with the concatenated results of running
  *  <em>block</em> once for every element in <i>enum</i>.
@@ -464,8 +464,8 @@ enum_flat_map(VALUE obj)
 
 /*
  *  call-seq:
- *     enum.to_a      ->    array
- *     enum.entries   ->    array
+ *     enum.to_a      -> array
+ *     enum.entries   -> array
  *
  *  Returns an array containing the items in <i>enum</i>.
  *
@@ -519,12 +519,12 @@ inject_op_i(VALUE i, VALUE p, int argc, VALUE *argv)
  *  call-seq:
  *     enum.inject(initial, sym) -> obj
  *     enum.inject(sym)          -> obj
- *     enum.inject(initial) {| memo, obj | block }  -> obj
- *     enum.inject          {| memo, obj | block }  -> obj
+ *     enum.inject(initial) {|memo, obj| block }  -> obj
+ *     enum.inject          {|memo, obj| block }  -> obj
  *     enum.reduce(initial, sym) -> obj
  *     enum.reduce(sym)          -> obj
- *     enum.reduce(initial) {| memo, obj | block }  -> obj
- *     enum.reduce          {| memo, obj | block }  -> obj
+ *     enum.reduce(initial) {|memo, obj| block }  -> obj
+ *     enum.reduce          {|memo, obj| block }  -> obj
  *
  *  Combines all elements of <i>enum</i> by applying a binary
  *  operation, specified by a block or a symbol that names a
@@ -606,8 +606,8 @@ partition_i(VALUE i, VALUE *ary, int argc, VALUE *argv)
 
 /*
  *  call-seq:
- *     enum.partition {| obj | block }  -> [ true_array, false_array ]
- *     enum.partition                   -> an_enumerator
+ *     enum.partition {|obj| block }  -> [ true_array, false_array ]
+ *     enum.partition                 -> an_enumerator
  *
  *  Returns two arrays, the first containing the elements of
  *  <i>enum</i> for which the block evaluates to true, the second
@@ -655,8 +655,8 @@ group_by_i(VALUE i, VALUE hash, int argc, VALUE *argv)
 
 /*
  *  call-seq:
- *     enum.group_by {| obj | block }  -> a_hash
- *     enum.group_by                   -> an_enumerator
+ *     enum.group_by {|obj| block }  -> a_hash
+ *     enum.group_by                 -> an_enumerator
  *
  *  Returns a hash, which keys are evaluated result from the
  *  block, and values are arrays of elements in <i>enum</i>
@@ -748,8 +748,8 @@ enum_first(int argc, VALUE *argv, VALUE obj)
 
 /*
  *  call-seq:
- *     enum.sort                     -> array
- *     enum.sort {| a, b | block }   -> array
+ *     enum.sort                  -> array
+ *     enum.sort {|a, b| block }  -> array
  *
  *  Returns an array containing the items in <i>enum</i> sorted,
  *  either according to their own <code><=></code> method, or by using
@@ -823,15 +823,15 @@ sort_by_cmp(const void *ap, const void *bp, void *data)
 
 /*
  *  call-seq:
- *     enum.sort_by {| obj | block }    -> array
- *     enum.sort_by                     -> an_enumerator
+ *     enum.sort_by {|obj| block }    -> array
+ *     enum.sort_by                   -> an_enumerator
  *
  *  Sorts <i>enum</i> using a set of keys generated by mapping the
  *  values in <i>enum</i> through the given block.
  *
  *  If no block is given, an enumerator is returned instead.
  *
- *     %w{ apple pear fig }.sort_by {|word| word.length}
+ *     %w{apple pear fig}.sort_by {|word| word.length}
  *                   #=> ["fig", "pear", "apple"]
  *
  *  The current implementation of <code>sort_by</code> generates an
@@ -845,7 +845,7 @@ sort_by_cmp(const void *ap, const void *bp, void *data)
  *
  *     Benchmark.bm(10) do |b|
  *       b.report("Sort")    { a.sort }
- *       b.report("Sort by") { a.sort_by {|a| a} }
+ *       b.report("Sort by") { a.sort_by {|a| a } }
  *     end
  *
  *  <em>produces:</em>
@@ -859,7 +859,7 @@ sort_by_cmp(const void *ap, const void *bp, void *data)
  *  using the basic <code>sort</code> method.
  *
  *     files = Dir["*"]
- *     sorted = files.sort {|a,b| File.new(a).mtime <=> File.new(b).mtime}
+ *     sorted = files.sort {|a,b| File.new(a).mtime <=> File.new(b).mtime }
  *     sorted   #=> ["mon", "tues", "wed", "thurs"]
  *
  *  This sort is inefficient: it generates two new <code>File</code>
@@ -965,7 +965,7 @@ DEFINE_ENUMFUNCS(all)
 
 /*
  *  call-seq:
- *     enum.all? [{|obj| block } ]   -> true or false
+ *     enum.all? [{|obj| block }]   -> true or false
  *
  *  Passes each element of the collection to the given block. The method
  *  returns <code>true</code> if the block never returns
@@ -1000,7 +1000,7 @@ DEFINE_ENUMFUNCS(any)
 
 /*
  *  call-seq:
- *     enum.any? [{|obj| block } ]   -> true or false
+ *     enum.any? [{|obj| block }]   -> true or false
  *
  *  Passes each element of the collection to the given block. The method
  *  returns <code>true</code> if the block ever returns a value other
@@ -1141,8 +1141,8 @@ min_ii(VALUE i, VALUE *memo, int argc, VALUE *argv)
 
 /*
  *  call-seq:
- *     enum.min                    -> obj
- *     enum.min {| a,b | block }   -> obj
+ *     enum.min                 -> obj
+ *     enum.min {|a,b| block }  -> obj
  *
  *  Returns the object in <i>enum</i> with the minimum value. The
  *  first form assumes all objects implement <code>Comparable</code>;
@@ -1208,8 +1208,8 @@ max_ii(VALUE i, VALUE *memo, int argc, VALUE *argv)
 
 /*
  *  call-seq:
- *     enum.max                   -> obj
- *     enum.max {|a,b| block }    -> obj
+ *     enum.max                 -> obj
+ *     enum.max {|a,b| block }  -> obj
  *
  *  Returns the object in _enum_ with the maximum value. The
  *  first form assumes all objects implement <code>Comparable</code>;
@@ -1347,8 +1347,8 @@ minmax_ii(VALUE i, VALUE _memo, int argc, VALUE *argv)
 
 /*
  *  call-seq:
- *     enum.minmax                   -> [min,max]
- *     enum.minmax {|a,b| block }    -> [min,max]
+ *     enum.minmax                -> [min,max]
+ *     enum.minmax {|a,b| block } -> [min,max]
  *
  *  Returns two elements array which contains the minimum and the
  *  maximum value in the enumerable.  The first form assumes all
@@ -1406,8 +1406,8 @@ min_by_i(VALUE i, VALUE *memo, int argc, VALUE *argv)
 
 /*
  *  call-seq:
- *     enum.min_by {|obj| block }   -> obj
- *     enum.min_by                  -> an_enumerator
+ *     enum.min_by {|obj| block } -> obj
+ *     enum.min_by                -> an_enumerator
  *
  *  Returns the object in <i>enum</i> that gives the minimum
  *  value from the given block.
@@ -1452,8 +1452,8 @@ max_by_i(VALUE i, VALUE *memo, int argc, VALUE *argv)
 
 /*
  *  call-seq:
- *     enum.max_by {|obj| block }   -> obj
- *     enum.max_by                  -> an_enumerator
+ *     enum.max_by {|obj| block } -> obj
+ *     enum.max_by                -> an_enumerator
  *
  *  Returns the object in <i>enum</i> that gives the maximum
  *  value from the given block.
@@ -1549,8 +1549,8 @@ minmax_by_i(VALUE i, VALUE _memo, int argc, VALUE *argv)
 
 /*
  *  call-seq:
- *     enum.minmax_by {|obj| block }   -> [min, max]
- *     enum.minmax_by                  -> an_enumerator
+ *     enum.minmax_by {|obj| block } -> [min, max]
+ *     enum.minmax_by                -> an_enumerator
  *
  *  Returns two elements array array containing the objects in
  *  <i>enum</i> that gives the minimum and maximum values respectively
@@ -1625,8 +1625,8 @@ each_with_index_i(VALUE i, VALUE memo, int argc, VALUE *argv)
 
 /*
  *  call-seq:
- *     enum.each_with_index(*args) {|obj, i| block }   ->  enum
- *     enum.each_with_index(*args)                     ->  an_enumerator
+ *     enum.each_with_index(*args) {|obj, i| block } ->  enum
+ *     enum.each_with_index(*args)                   ->  an_enumerator
  *
  *  Calls <em>block</em> with two arguments, the item and its index,
  *  for each item in <i>enum</i>.  Given arguments are passed through
@@ -1657,8 +1657,8 @@ enum_each_with_index(int argc, VALUE *argv, VALUE obj)
 
 /*
  *  call-seq:
- *     enum.reverse_each(*args) {|item| block }   ->  enum
- *     enum.reverse_each(*args)                   ->  an_enumerator
+ *     enum.reverse_each(*args) {|item| block } ->  enum
+ *     enum.reverse_each(*args)                 ->  an_enumerator
  *
  *  Builds a temporary array and traverses that array in reverse order.
  *
@@ -1701,8 +1701,8 @@ each_val_i(VALUE i, VALUE p, int argc, VALUE *argv)
 
 /*
  *  call-seq:
- *     enum.each_entry {|obj| block}  -> enum
- *     enum.each_entry                -> an_enumerator
+ *     enum.each_entry {|obj| block }  -> enum
+ *     enum.each_entry                 -> an_enumerator
  *
  *  Calls <i>block</i> once for each element in +self+, passing that
  *  element as a parameter, converting multiple values from yield to an
@@ -1763,7 +1763,7 @@ each_slice_i(VALUE i, VALUE *memo, int argc, VALUE *argv)
  *  block is given, returns an enumerator.
  *
  *  e.g.:
- *      (1..10).each_slice(3) {|a| p a}
+ *      (1..10).each_slice(3) {|a| p a }
  *      # outputs below
  *      [1, 2, 3]
  *      [4, 5, 6]
@@ -1817,7 +1817,7 @@ each_cons_i(VALUE i, VALUE *memo, int argc, VALUE *argv)
  *  elements.  If no block is given, returns an enumerator.
  *
  *  e.g.:
- *      (1..10).each_cons(3) {|a| p a}
+ *      (1..10).each_cons(3) {|a| p a }
  *      # outputs below
  *      [1, 2, 3]
  *      [2, 3, 4]
@@ -1956,8 +1956,8 @@ zip_i(VALUE val, NODE *memo, int argc, VALUE *argv)
 
 /*
  *  call-seq:
- *     enum.zip(arg, ...)                   -> an_array_of_array
- *     enum.zip(arg, ...) {|arr| block }    -> nil
+ *     enum.zip(arg, ...)                 -> an_array_of_array
+ *     enum.zip(arg, ...) {|arr| block }  -> nil
  *
  *  Takes one element from <i>enum</i> and merges corresponding
  *  elements from each <i>args</i>.  This generates a sequence of
@@ -2059,8 +2059,8 @@ take_while_i(VALUE i, VALUE *ary, int argc, VALUE *argv)
 
 /*
  *  call-seq:
- *     enum.take_while {|arr| block }   -> array
- *     enum.take_while                  -> an_enumerator
+ *     enum.take_while {|arr| block } -> array
+ *     enum.take_while                -> an_enumerator
  *
  *  Passes elements to the block until the block returns +nil+ or +false+,
  *  then stops iterating and returns an array of all prior elements.


### PR DESCRIPTION
There isn't much consistency in the docs when it comes to blocks. So I decided to go with the style that is most often used: `{|obj| block }`
No spaces, only around `block`.

I can fix the other classes as well but before I do this maybe someone comments on this pr first.

What about multiline blocks? They tend to look ugly. Curly braces everywhere and never ending chains.
See https://github.com/ruby/ruby/blob/trunk/enum.c#L2359-2364
