### PR TITLE
Allow per-class whitelisting of methods safe to expose through DRb

### DIFF
--- a/lib/drb/drb.rb
+++ b/lib/drb/drb.rb
@@ -1441,7 +1441,8 @@ module DRb
     # front object, is this method not included in that list?
     def insecure_method?(obj, msg_id)
       INSECURE_METHOD.include?(msg_id) ||
-        (obj.respond_to?(:drb_safe_methods_list) &&
+        (obj.public_methods.include?(:drb_safe_methods_list)  &&
+         obj.public_methods.include?(msg_id) &&
          !obj.drb_safe_methods_list.include?(msg_id))
     end
 


### PR DESCRIPTION
Allows the optional declaration of a whitelist of methods to expose through DRb for any class DRb will be sharing an instance of. (The current behavior of exposing all public methods of a class can leave a pretty scary security hole in some applications)

If drb_safe_methods is used in a class's definition, then any attempt to call a non-whitelisted method on that class through DRb will fail. There is no change to DRb's normal behavior if drb_safe_methods has not been called in a class's definition.
