### PR TITLE
Ruby 1.9.3 p0 symbol visibility

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -493,7 +493,6 @@ if test "$GCC" = ""; then
     AS_CASE(["$target_os"],[aix*],[warnflags="-qinfo=por"])
 fi
 if test "$GCC" = yes; then
-    RUBY_TRY_CFLAGS(-fvisibility=hidden, [RUBY_APPEND_OPTION(XCFLAGS, -fvisibility=hidden)])
     AC_SUBST(WERRORFLAG, "-Werror")
     if test "$visibility_option" = yes; then
 	RUBY_APPEND_OPTION(XCFLAGS, -fvisibility=hidden)


### PR DESCRIPTION
Removing visibility flag hiding required symbols in ruby binary.

Makes sure all libruby symbols are available from within the executable after final linking. Fixes ruby-debug19, passenger, and many other extensions.
