### PR TITLE
Pathname['abc'] instead of Pathname('abc') global method as constructor alternative

### DIFF
--- a/ext/pathname/pathname.c
+++ b/ext/pathname/pathname.c
@@ -858,6 +858,15 @@ path_s_getwd(VALUE klass)
 }
 
 /*
+ * Returns a new instance of Pathname initialized with string
+ */
+static VALUE
+path_s_square_brackets(VALUE self, VALUE string)
+{
+    return rb_class_new_instance(1, &string, rb_cPathname);
+}
+
+/*
  * Return the entries (files and subdirectories) in the directory, each as a
  * Pathname object.
  *
@@ -969,6 +978,7 @@ path_unlink(VALUE self)
 static VALUE
 path_f_pathname(VALUE self, VALUE str)
 {
+    rb_warn("Kernel#Pathname is deprecated; use Pathname.[] instead");
     return rb_class_new_instance(1, &str, rb_cPathname);
 }
 
@@ -1225,6 +1235,7 @@ Init_pathname()
     rb_define_method(rb_cPathname, "world_writable?", path_world_writable_p, 0);
     rb_define_method(rb_cPathname, "writable_real?", path_writable_real_p, 0);
     rb_define_method(rb_cPathname, "zero?", path_zero_p, 0);
+    rb_define_singleton_method(rb_cPathname, "[]", path_s_square_brackets, 1);
     rb_define_singleton_method(rb_cPathname, "glob", path_s_glob, -1);
     rb_define_singleton_method(rb_cPathname, "getwd", path_s_getwd, 0);
     rb_define_singleton_method(rb_cPathname, "pwd", path_s_getwd, 0);


### PR DESCRIPTION
[ruby-core#7363](https://bugs.ruby-lang.org/issues/7363)

I made it possible to use Pathname.[] as an alternative to Pathname.new, as the Set class does it already. Also I did mark the global Pathname() method deprecated because I think poisoning the global namespace with methods named after classes should be considered bad style. I hope you share that opinion.

I've also written a patch for rubyspec which tests the new methods and runs at least in MRI 1.9.2 and 1.9.3. It does although not test for the deprecation warnings, because Brian Ford wouldn't accept the patch if it would do so. It is available here: https://github.com/aef/rubyspec/tree/pathname_brackets_instead_global_method
