### PR TITLE
Fixed SupportedPlatforms URL in the README

### DIFF
--- a/README
+++ b/README
@@ -18,7 +18,7 @@ Perl).  It is simple, straight-forward, and extensible.
   + Dynamic Loading of Object files(on some architecture)
   + Highly Portable (works on many Unix-like/POSIX compatible platforms
     as well as Windows, Mac OS X, BeOS etc.)
-    cf. http://redmine.ruby-lang.org/wiki/ruby-19/SupportedPlatforms
+    cf. http://redmine.ruby-lang.org/projects/ruby-trunk/wiki/SupportedPlatforms
 
 
 * How to get Ruby


### PR DESCRIPTION
I noticed the SupportedPlatforms URL is leading to a 404, this fixes the link in the README
