### PR TITLE
Fix hidden bug in `rb_feature_p`

### DIFF
--- a/load.c
+++ b/load.c
@@ -183,7 +183,7 @@ rb_feature_p(const char *feature, const char *ext, int rb, int expanded, const c
 	    fs.name = feature;
 	    fs.len = len;
 	    fs.type = type;
-	    fs.load_path = load_path ? load_path : rb_get_load_path();
+	    fs.load_path = load_path ? load_path : rb_get_expanded_load_path();
 	    fs.result = 0;
 	    st_foreach(loading_tbl, loaded_feature_path_i, (st_data_t)&fs);
 	    if ((f = fs.result) != 0) {


### PR DESCRIPTION
lazy assigned load_path searched in loading_table were not expanded (line #186),
but all features, pushed to loading table, are expanded.

This bug is hidden because load_path is allways filled in loaded_features loop (line #160),
but if we try to optimize this loop (http://redmine.ruby-lang.org/issues/5427 , https://gist.github.com/1272991), 
then load_path could be not filled, and bug exposed.
