### PR TITLE
HTTP Keep-Alive should be honored for 304 response

### DIFF
--- a/lib/webrick/httpresponse.rb
+++ b/lib/webrick/httpresponse.rb
@@ -162,7 +162,7 @@ module WEBrick
     ##
     # Sets up the headers for sending
 
-    def setup_header()
+    def setup_header
       @reason_phrase    ||= HTTPStatus::reason_phrase(@status)
       @header['server'] ||= @config[:ServerSoftware]
       @header['date']   ||= Time.now.httpdate
@@ -184,7 +184,7 @@ module WEBrick
       end
 
       # Determine the message length (RFC2616 -- 4.4 Message Length)
-      if @status == 304 || @status == 204 || HTTPStatus::info?(@status)
+      if has_empty_response?
         @header.delete('content-length')
         @body = ""
       elsif chunked?
@@ -202,7 +202,7 @@ module WEBrick
       if @header['connection'] == "close"
          @keep_alive = false
       elsif keep_alive?
-        if chunked? || @header['content-length']
+        if has_empty_response? || chunked? || @header['content-length']
           @header['connection'] = "Keep-Alive"
         else
           msg = "Could not determine content-length of response body. Set content-length of the response or set Response#chunked = true"
@@ -395,5 +395,10 @@ module WEBrick
     def _write_data(socket, data)
       socket << data
     end
+
+    def has_empty_response?
+      @status == 304 || @status == 204 || HTTPStatus::info?(@status)
+    end
+
   end
 end


### PR DESCRIPTION
The problem are discussed here: https://github.com/rails/rails/issues/3164. 

To summarize, if the HTTP connection type is Keep-Alive, and the response is 304(Empty body and no Content-Length), then webrick will close the connection and generate a warning. 

This was introduced in https://github.com/ruby/ruby/commit/4ce158147502304af431c820c227134628578e74
