### PR TITLE
Re-raise dangerous exceptions in webrick server

### DIFF
--- a/lib/webrick/server.rb
+++ b/lib/webrick/server.rb
@@ -112,6 +112,9 @@ module WEBrick
             # if the listening socket was closed in GenericServer#shutdown,
             # IO::select raise it.
           rescue Exception => ex
+            if [NoMemoryError, SignalException, Interrupt, SystemExit].include?(ex.class)
+              raise ex
+            end
             msg = "#{ex.class}: #{ex.message}\n\t#{ex.backtrace[0]}"
             @logger.error msg
           end


### PR DESCRIPTION
Currently a SIGTERM is ignored by the webrick server. 
This commit re-raises any exception which is fatal to ruby. 
Or signals that the process should terminate. 
