### PR TITLE
Couple of tiny changes to string

### DIFF
--- a/string.c
+++ b/string.c
@@ -729,7 +729,7 @@ str_new_empty(VALUE str)
     return v;
 }
 
-#define STR_BUF_MIN_SIZE 79
+#define STR_BUF_MIN_SIZE 127
 
 VALUE
 rb_str_buf_new(long capa)
@@ -1807,6 +1807,7 @@ rb_str_resize(VALUE str, long len)
     return str;
 }
 
+#define STR_MIN_NOEMBED (sizeof(void*) * 8 - 1)
 static VALUE
 str_buf_cat(VALUE str, const char *ptr, long len)
 {
@@ -1832,6 +1833,8 @@ str_buf_cat(VALUE str, const char *ptr, long len)
     }
     total = RSTRING_LEN(str)+len;
     if (capa <= total) {
+	if (capa < STR_MIN_NOEMBED)
+	    capa = STR_MIN_NOEMBED;
 	while (total > capa) {
 	    if (capa + 1 >= LONG_MAX / 2) {
 		capa = (total + 4095) / 4096;


### PR DESCRIPTION
- change capacity increment from `(capa + 1) * 2` to `capa * 2 + 1` .
  
  previous increment formula leads to inconvenient allocation patterns: 25bytes, 51bytes, etc
  new formula leads to more comfortable allocation pattern: 24b, 48b, 96b
- change STR_BUF_MIN_SIZE from 128 to 79
  
  128 leads to allocation of 129 bytes, which is very uncomfortable for allocators and unnecessary large.
  (during Redmine startup this method is called about 3000000 times with capa < 128)
