### PR TITLE
Optparse passes incorrect options when casting to a Regexp

### DIFF
--- a/lib/optparse.rb
+++ b/lib/optparse.rb
@@ -1709,7 +1709,7 @@ XXX
       f |= Regexp::IGNORECASE if /i/ =~ o
       f |= Regexp::MULTILINE if /m/ =~ o
       f |= Regexp::EXTENDED if /x/ =~ o
-      k = o.delete("[^imx]")
+      k = o.delete("imx")
     end
     Regexp.new(s || all, f, k)
   end


### PR DESCRIPTION
In the optparse library, the wrong string is used to remove the `i`, `m`, and `x` options from the encoding options when casting an argument to a `Regexp`.  It removes all characters that are NOT `i`, `m`, or `x`.  This results in the wrong options being passed as the third argument of `Regexp.new`.

`optparse.rb:1714: warning: encoding option is ignored - %s` is thrown when valid options are passed as an argument, even though the options `i`, `m`, and `x` are correctly interpreted.  Also, the encoding of a Regexp argument cannot be set.
