### PR TITLE
Cleaning up the initialize method, improving performance

### DIFF
--- a/lib/ostruct.rb
+++ b/lib/ostruct.rb
@@ -96,13 +96,11 @@ class OpenStruct
   #   p australia   # -> <OpenStruct country="Australia" population=20000000>
   #
   def initialize(hash=nil)
-    @table = {}
-    if hash
-      for k,v in hash
-        @table[k.to_sym] = v
-        new_ostruct_member(k)
-      end
-    end
+    @table ||= {}
+    hash.each do |key, value|
+      @table[key.to_sym] = value
+      new_ostruct_member key
+    end if hash
   end
 
   # Duplicate an OpenStruct object members.


### PR DESCRIPTION
- Using friendlier variable names
- Dropping `for..in` block for `#each`
- Inlining if statement

I used this as a general benchmark:

``` ruby
require 'benchmark'

def new_ostruct_member(arg); end

def generate_data
  (0..1000).map do |i|
    {"#{'k' * rand(100)}#{i}" => "#{'v' * rand(100)}#{i}"}
  end.inject &:merge
end

hash = generate_data


report = Benchmark.bmbm do |x|
  x.report("old") { 1000.times {
    @table = {}
      for k,v in hash
        @table[k.to_sym] = v
        new_ostruct_member(k)
      end
  } }

  x.report("new") { 1000.times {
    @ntable = {}
    hash.each do |key, value|
      @ntable[key.to_sym] = value
      new_ostruct_member key
    end
  } }
end

puts "Is new result equal to old result? #{@table == @ntable}"
puts "New is #{report.map(&:to_s).map(&:split).map(&:last).map(&:to_f).inject(:/) * 100 - 100}% faster"
```

General speed improvement: ~27% faster, after fixing benchmark.
