### PR TITLE
use rb_str_free for freeing string in parse.y

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -6409,9 +6409,7 @@ parser_regx_options(struct parser_params *parser)
 static void
 dispose_string(VALUE str)
 {
-    /* TODO: should use another API? */
-    if (RBASIC(str)->flags & RSTRING_NOEMBED)
-	xfree(RSTRING_PTR(str));
+    rb_str_free(str);
     rb_gc_force_recycle(str);
 }
 


### PR DESCRIPTION
Firstly, it is cosmetic cleanup.
Secondly, I could not understand, why, but it gives minor performance gain for rendering some rails page (about 1%)
