### PR TITLE
gc: increment heaps on lazy_sweep only if necessary

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -2312,7 +2312,6 @@ lazy_sweep(rb_objspace_t *objspace)
 {
     struct heaps_slot *next;
 
-    heaps_increment(objspace);
     while (objspace->heap.sweep_slots) {
         next = objspace->heap.sweep_slots->next;
 	slot_sweep(objspace, objspace->heap.sweep_slots);
@@ -2321,6 +2320,10 @@ lazy_sweep(rb_objspace_t *objspace)
             during_gc = 0;
             return TRUE;
         }
+    }
+    if (heaps_increment(objspace)) {
+        during_gc = 0;
+        return TRUE;
     }
     return FALSE;
 }
@@ -2624,7 +2627,6 @@ gc_clear_mark_on_sweep_slots(rb_objspace_t *objspace)
     struct heaps_slot *scan;
 
     if (objspace->heap.sweep_slots) {
-        while (heaps_increment(objspace));
         while (objspace->heap.sweep_slots) {
             scan = objspace->heap.sweep_slots;
             gc_clear_slot_bits(scan);


### PR DESCRIPTION
Too early call in `lazy_sweep` slows down sweep phase, cause while loop breaks on `if (has_free_object) { ... return TRUE;}` .

Heap expand in `gc_clear_mark_on_sweep_slots` unnecessary expands number of heaps, which slows down iterations in `rb_objspace_call_finalizer`, and `gc_marks` (cause we often need to binary search heap for pointer).

Testing suit: https://gist.github.com/1702301

Before:

```
$ sh siege.sh
Transaction rate:         114.71 trans/sec
Transaction rate:         117.84 trans/sec
Transaction rate:         121.62 trans/sec
$ sh siege.sh
Transaction rate:         118.72 trans/sec
Transaction rate:         120.32 trans/sec
Transaction rate:         121.12 trans/sec
```

After:

```
$ sh siege.sh
Transaction rate:         121.62 trans/sec
Transaction rate:         122.12 trans/sec
Transaction rate:         123.12 trans/sec
$ sh siege.sh
Transaction rate:         123.25 trans/sec
Transaction rate:         121.94 trans/sec
Transaction rate:         123.52 trans/sec
```
