### PR TITLE
The * needs to be escaped to avoid formatting in fnmatch comment

### DIFF
--- a/dir.c
+++ b/dir.c
@@ -1907,7 +1907,7 @@ dir_entries(int argc, VALUE *argv, VALUE io)
  *                          match all files beginning with
  *                          <code>c</code>; <code>*c</code> will match
  *                          all files ending with <code>c</code>; and
- *                          <code>*c*</code> will match all files that
+ *                          <code>\*c*</code> will match all files that
  *                          have <code>c</code> in them (including at
  *                          the beginning or end). Equivalent to
  *                          <code>/ .* /x</code> in regexp.


### PR DESCRIPTION
The \* needs to be escaped because it was applying bold format (and removing the *s) to a comment where it was very import to show the *s.

  "and c will match all files that have c in them (including at the beginning or end)."

should be

  "and *c\* will match all files that have c in them (including at the beginning or end)."

Need to escape the surrounding *s around *c\* like  \*c*

See the row regarding \* in the fnmatch comment

http://ruby-doc.org/core-1.9.3/File.html#method-c-fnmatch-3F
