### PR TITLE
Use directive hack to make ARGF documentable in other tools [DOC]

### DIFF
--- a/io.c
+++ b/io.c
@@ -11426,10 +11426,11 @@ Init_IO(void)
     /* Holds the original stderr */
     rb_define_global_const("STDERR", rb_stderr);
 
-    /*
-     * Hack to get rdoc to regard ARGF as a class:
-     * rb_cARGF = rb_define_class("ARGF", rb_cObject);
-     */
+#if 0
+     /* Hack to get rdoc to regard ARGF as a class: */
+     rb_cARGF = rb_define_class("ARGF", rb_cObject);
+#endif
+
     rb_cARGF = rb_class_new(rb_cObject);
     rb_set_class_path(rb_cARGF, rb_cObject, "ARGF.class");
     rb_define_alloc_func(rb_cARGF, argf_alloc);


### PR DESCRIPTION
RDoc is able to parse commented blocks of code (inside `/**/`) as a side-effect of its parsing, but other tools will ignore commented blocks. Using the "#if 0" directive hack is more portable among tools (like YARD) and still allows developers to properly ignore code by commenting it out (assuming the doc tool supports this). Note that the directive hack is already used in io.c (above this line), so this is not a novel methodology.
