### PR TITLE
lib/fileutils.rb: refactor FileUtils

### DIFF
--- a/lib/fileutils.rb
+++ b/lib/fileutils.rb
@@ -83,14 +83,94 @@
 #
 
 module FileUtils
+  @fileutils_output  = $stderr
+  @fileutils_label   = ''
+  extend self
 
-  def self.private_module_function(name)   #:nodoc:
-    module_function name
-    private_class_method name
+  #
+  # This module has all methods of FileUtils module, but it outputs messages
+  # before acting.  This equates to passing the <tt>:verbose</tt> flag to
+  # methods in FileUtils.
+  #
+  module Verbose
+    include FileUtils
+    @fileutils_output  = $stderr
+    @fileutils_label   = ''
+    extend self
+  end
+
+  #
+  # This module has all methods of FileUtils module, but never changes
+  # files/directories.  This equates to passing the <tt>:noop</tt> flag
+  # to methods in FileUtils.
+  #
+  module NoWrite
+    include FileUtils
+    @fileutils_output  = $stderr
+    @fileutils_label   = ''
+    extend self
+  end
+
+  #
+  # This module has all methods of FileUtils module, but never changes
+  # files/directories, with printing message before acting.
+  # This equates to passing the <tt>:noop</tt> and <tt>:verbose</tt> flag
+  # to methods in FileUtils.
+  #
+  module DryRun
+    include FileUtils
+    @fileutils_output  = $stderr
+    @fileutils_label   = ''
+    extend self
   end
 
   # This hash table holds command options.
   OPT_TABLE = {}   #:nodoc: internal use only
+
+  #
+  def self.define_command(name, *options)
+    OPT_TABLE[name.to_s] = options
+
+    if options.include?(:verbose)
+      Verbose.module_eval(<<-EOS, __FILE__, __LINE__ + 1)
+        def #{name}(*args)
+          super(*fu_update_option(args, :verbose => true))
+        end
+      EOS
+    end
+    if options.include?(:noop)
+      NoWrite.module_eval(<<-EOS, __FILE__, __LINE__ + 1)
+        def #{name}(*args)
+          super(*fu_update_option(args, :noop => true))
+        end
+      EOS
+      DryRun.module_eval(<<-EOS, __FILE__, __LINE__ + 1)
+        def #{name}(*args)
+          super(*fu_update_option(args, :noop => true, :verbose => true))
+        end
+      EOS
+    else
+      NoWrite.module_eval(<<-EOS, __FILE__, __LINE__ + 1)
+        def #{name}(*); end
+      EOS
+      DryRun.module_eval(<<-EOS, __FILE__, __LINE__ + 1)
+        def #{name}(*); end
+      EOS
+    end
+
+    [self, Verbose, DryRun, NoWrite].each do |mod|
+      mod.module_eval(<<-EOS, __FILE__, __LINE__ + 1)
+        private :#{name}
+        class << self; public :#{name}; end
+      EOS
+    end
+  end
+
+  class << self
+    private :define_command
+  end
+
+public
 
   #
   # Options: (none)
@@ -100,10 +180,11 @@ module FileUtils
   def pwd
     Dir.pwd
   end
-  module_function :pwd
 
   alias getwd pwd
-  module_function :getwd
+
+  define_command('pwd')
+  define_command('getwd')
 
   #
   # Options: verbose
@@ -125,13 +206,11 @@ module FileUtils
     Dir.chdir(dir, &block)
     fu_output_message 'cd -' if options[:verbose] and block
   end
-  module_function :cd
 
   alias chdir cd
-  module_function :chdir
 
-  OPT_TABLE['cd']    =
-  OPT_TABLE['chdir'] = [:verbose]
+  define_command('cd', :verbose)
+  define_command('chdir', :verbose)
 
   #
   # Options: (none)
@@ -154,7 +233,8 @@ module FileUtils
     end
     true
   end
-  module_function :uptodate?
+
+  define_command('uptodate?')
 
   #
   # Options: mode noop verbose
@@ -176,9 +256,8 @@ module FileUtils
       fu_mkdir dir, options[:mode]
     end
   end
-  module_function :mkdir
 
-  OPT_TABLE['mkdir'] = [:mode, :noop, :verbose]
+  define_command('mkdir', :mode, :noop, :verbose)
 
   #
   # Options: mode noop verbose
@@ -227,16 +306,15 @@ module FileUtils
 
     return *list
   end
-  module_function :mkdir_p
 
   alias mkpath    mkdir_p
   alias makedirs  mkdir_p
-  module_function :mkpath
-  module_function :makedirs
 
-  OPT_TABLE['mkdir_p']  =
-  OPT_TABLE['mkpath']   =
-  OPT_TABLE['makedirs'] = [:mode, :noop, :verbose]
+  define_command('mkdir_p', :mode, :noop, :verbose)
+  define_command('mkpath', :mode, :noop, :verbose)
+  define_command('makedirs', :mode, :noop, :verbose)
+
+private
 
   def fu_mkdir(path, mode)   #:nodoc:
     path = path.sub(%r</\z>, '')
@@ -247,7 +325,8 @@ module FileUtils
       Dir.mkdir path
     end
   end
-  private_module_function :fu_mkdir
+
+public
 
   #
   # Options: noop, verbose
@@ -277,9 +356,8 @@ module FileUtils
       end
     end
   end
-  module_function :rmdir
 
-  OPT_TABLE['rmdir'] = [:parents, :noop, :verbose]
+  define_command('rmdir', :parents, :noop, :verbose)
 
   #
   # Options: force noop verbose
@@ -312,13 +390,11 @@ module FileUtils
       File.link s, d
     end
   end
-  module_function :ln
 
   alias link ln
-  module_function :link
 
-  OPT_TABLE['ln']   =
-  OPT_TABLE['link'] = [:force, :noop, :verbose]
+  define_command('ln', :force, :noop, :verbose)
+  define_command('link', :force, :noop, :verbose)
 
   #
   # Options: force noop verbose
@@ -351,13 +427,11 @@ module FileUtils
       File.symlink s, d
     end
   end
-  module_function :ln_s
 
   alias symlink ln_s
-  module_function :symlink
 
-  OPT_TABLE['ln_s']    =
-  OPT_TABLE['symlink'] = [:force, :noop, :verbose]
+  define_command('ln_s', :force, :noop, :verbose)
+  define_command('symlink', :force, :noop, :verbose)
 
   #
   # Options: noop verbose
@@ -371,9 +445,8 @@ module FileUtils
     options[:force] = true
     ln_s src, dest, options
   end
-  module_function :ln_sf
 
-  OPT_TABLE['ln_sf'] = [:noop, :verbose]
+  define_command('ln_sf', :noop, :verbose)
 
   #
   # Options: preserve noop verbose
@@ -396,13 +469,11 @@ module FileUtils
       copy_file s, d, options[:preserve]
     end
   end
-  module_function :cp
 
   alias copy cp
-  module_function :copy
 
-  OPT_TABLE['cp']   =
-  OPT_TABLE['copy'] = [:preserve, :noop, :verbose]
+  define_command('cp', :preserve, :noop, :verbose)
+  define_command('copy', :preserve, :noop, :verbose)
 
   #
   # Options: preserve noop verbose dereference_root remove_destination
@@ -437,10 +508,8 @@ module FileUtils
       copy_entry s, d, options[:preserve], options[:dereference_root], options[:remove_destination]
     end
   end
-  module_function :cp_r
 
-  OPT_TABLE['cp_r'] = [:preserve, :noop, :verbose,
-                       :dereference_root, :remove_destination]
+  define_command('cp_r', :preserve, :noop, :verbose, :dereference_root, :remove_destination)
 
   #
   # Copies a file system entry +src+ to +dest+.
@@ -466,7 +535,8 @@ module FileUtils
       ent.copy_metadata destent.path if preserve
     end
   end
-  module_function :copy_entry
+
+  define_command(:copy_entry)
 
   #
   # Copies file contents of +src+ to +dest+.
@@ -477,7 +547,8 @@ module FileUtils
     ent.copy_file dest
     ent.copy_metadata dest if preserve
   end
-  module_function :copy_file
+
+  define_command(:copy_file)
 
   #
   # Copies stream +src+ to +dest+.
@@ -487,7 +558,8 @@ module FileUtils
   def copy_stream(src, dest)
     IO.copy_stream(src, dest)
   end
-  module_function :copy_stream
+
+  define_command(:copy_stream)
 
   #
   # Options: force noop verbose
@@ -530,18 +602,19 @@ module FileUtils
       end
     end
   end
-  module_function :mv
 
   alias move mv
-  module_function :move
 
-  OPT_TABLE['mv']   =
-  OPT_TABLE['move'] = [:force, :noop, :verbose, :secure]
+  define_command('mv', :force, :noop, :verbose, :secure)
+  define_command('move', :force, :noop, :verbose, :secure)  
+
+private
 
   def rename_cannot_overwrite_file?   #:nodoc:
     /cygwin|mswin|mingw|bccwin|emx/ =~ RUBY_PLATFORM
   end
-  private_module_function :rename_cannot_overwrite_file?
+
+public
 
   #
   # Options: force noop verbose
@@ -563,13 +636,11 @@ module FileUtils
       remove_file path, options[:force]
     end
   end
-  module_function :rm
 
   alias remove rm
-  module_function :remove
 
-  OPT_TABLE['rm']     =
-  OPT_TABLE['remove'] = [:force, :noop, :verbose]
+  define_command('rm', :force, :noop, :verbose)
+  define_command('remove', :force, :noop, :verbose)
 
   #
   # Options: noop verbose
@@ -584,13 +655,11 @@ module FileUtils
     options[:force] = true
     rm list, options
   end
-  module_function :rm_f
 
   alias safe_unlink rm_f
-  module_function :safe_unlink
 
-  OPT_TABLE['rm_f']        =
-  OPT_TABLE['safe_unlink'] = [:noop, :verbose]
+  define_command('rm_f', :noop, :verbose)
+  define_command('safe_unlink', :noop, :verbose)
 
   #
   # Options: force noop verbose secure
@@ -627,9 +696,8 @@ module FileUtils
       end
     end
   end
-  module_function :rm_r
 
-  OPT_TABLE['rm_r'] = [:force, :noop, :verbose, :secure]
+  define_command('rm_r', :force, :noop, :verbose, :secure)
 
   #
   # Options: noop verbose secure
@@ -647,13 +715,11 @@ module FileUtils
     options[:force] = true
     rm_r list, options
   end
-  module_function :rm_rf
 
   alias rmtree rm_rf
-  module_function :rmtree
 
-  OPT_TABLE['rm_rf']  =
-  OPT_TABLE['rmtree'] = [:noop, :verbose, :secure]
+  define_command('rm_rf', :noop, :verbose, :secure)
+  define_command('rmtree', :noop, :verbose, :secure)
 
   #
   # This method removes a file system entry +path+.  +path+ shall be a
@@ -741,7 +807,10 @@ module FileUtils
   rescue
     raise unless force
   end
-  module_function :remove_entry_secure
+
+  define_command(:remove_entry_secure)
+
+private
 
   def fu_have_symlink?   #:nodoc:
     File.symlink nil, nil
@@ -750,12 +819,12 @@ module FileUtils
   rescue
     return true
   end
-  private_module_function :fu_have_symlink?
 
   def fu_stat_identical_entry?(a, b)   #:nodoc:
     a.dev == b.dev and a.ino == b.ino
   end
-  private_module_function :fu_stat_identical_entry?
+
+public
 
   #
   # This method removes a file system entry +path+.
@@ -775,7 +844,8 @@ module FileUtils
   rescue
     raise unless force
   end
-  module_function :remove_entry
+
+  define_command(:remove_entry)
 
   #
   # Removes a file +path+.
@@ -786,7 +856,8 @@ module FileUtils
   rescue
     raise unless force
   end
-  module_function :remove_file
+
+  define_command(:remove_file)
 
   #
   # Removes a directory +dir+ and its contents recursively.
@@ -795,7 +866,8 @@ module FileUtils
   def remove_dir(path, force = false)
     remove_entry path, force   # FIXME?? check if it is a directory
   end
-  module_function :remove_dir
+
+  define_command(:remove_dir)
 
   #
   # Returns true if the contents of a file A and a file B are identical.
@@ -811,28 +883,33 @@ module FileUtils
       }
     }
   end
-  module_function :compare_file
 
   alias identical? compare_file
   alias cmp compare_file
-  module_function :identical?
-  module_function :cmp
+
+  define_command(:compare_file)
+  define_command(:identical?)
+  define_command(:cmp)
 
   #
   # Returns true if the contents of a stream +a+ and +b+ are identical.
   #
   def compare_stream(a, b)
     bsize = fu_stream_blksize(a, b)
-    sa = ""
-    sb = ""
-    begin
-      a.read(bsize, sa)
-      b.read(bsize, sb)
-      return true if sa.empty? && sb.empty?
-    end while sa == sb
+    sa = sb = nil
+    while sa == sb
+      sa = a.read(bsize)
+      sb = b.read(bsize)
+      unless sa and sb
+        if sa.nil? and sb.nil?
+          return true
+        end
+      end
+    end
     false
   end
-  module_function :compare_stream
+
+  define_command(:compare_stream)
 
   #
   # Options: mode preserve noop verbose
@@ -857,9 +934,10 @@ module FileUtils
       end
     end
   end
-  module_function :install
 
-  OPT_TABLE['install'] = [:mode, :preserve, :noop, :verbose]
+  define_command('install', :mode, :preserve, :noop, :verbose)
+
+private
 
   def user_mask(target)  #:nodoc:
     mask = 0
@@ -877,7 +955,6 @@ module FileUtils
     end
     mask
   end
-  private_module_function :user_mask
 
   def mode_mask(mode, path)  #:nodoc:
     mask = 0
@@ -899,7 +976,6 @@ module FileUtils
     end
     mask
   end
-  private_module_function :mode_mask
 
   def symbolic_modes_to_i(modes, path)  #:nodoc:
     current_mode = (File.stat(path).mode & 07777)
@@ -920,12 +996,12 @@ module FileUtils
       end
     end
   end
-  private_module_function :symbolic_modes_to_i
 
   def fu_mode(mode, path)  #:nodoc:
     mode.is_a?(String) ? symbolic_modes_to_i(mode, path) : mode
   end
-  private_module_function :fu_mode
+
+public
 
   #
   # Options: noop verbose
@@ -967,9 +1043,8 @@ module FileUtils
       Entry_.new(path).chmod(fu_mode(mode, path))
     end
   end
-  module_function :chmod
 
-  OPT_TABLE['chmod'] = [:noop, :verbose]
+  define_command('chmod', :noop, :verbose)
 
   #
   # Options: noop verbose force
@@ -997,9 +1072,8 @@ module FileUtils
       end
     end
   end
-  module_function :chmod_R
 
-  OPT_TABLE['chmod_R'] = [:noop, :verbose, :force]
+  define_command('chmod_R', :noop, :verbose, :force)
 
   #
   # Options: noop verbose
@@ -1026,9 +1100,8 @@ module FileUtils
       Entry_.new(path).chown uid, gid
     end
   end
-  module_function :chown
 
-  OPT_TABLE['chown'] = [:noop, :verbose]
+  define_command('chown', :noop, :verbose)
 
   #
   # Options: noop verbose force
@@ -1063,9 +1136,10 @@ module FileUtils
       end
     end
   end
-  module_function :chown_R
 
-  OPT_TABLE['chown_R'] = [:noop, :verbose, :force]
+  define_command('chown_R', :noop, :verbose, :force)
+
+private
 
   begin
     require 'etc'
@@ -1081,7 +1155,6 @@ module FileUtils
         Etc.getpwnam(user).uid
       end
     end
-    private_module_function :fu_get_uid
 
     def fu_get_gid(group)   #:nodoc:
       return nil unless group
@@ -1094,7 +1167,6 @@ module FileUtils
         Etc.getgrnam(group).gid
       end
     end
-    private_module_function :fu_get_gid
 
   rescue LoadError
     # need Win32 support???
@@ -1102,13 +1174,13 @@ module FileUtils
     def fu_get_uid(user)   #:nodoc:
       user    # FIXME
     end
-    private_module_function :fu_get_uid
 
     def fu_get_gid(group)   #:nodoc:
       group   # FIXME
     end
-    private_module_function :fu_get_gid
   end
+
+public
 
   #
   # Options: noop verbose
@@ -1142,11 +1214,10 @@ module FileUtils
       end
     end
   end
-  module_function :touch
 
-  OPT_TABLE['touch'] = [:noop, :verbose, :mtime, :nocreate]
+  define_command('touch', :noop, :verbose, :mtime, :nocreate)
 
-  private
+private
 
   module StreamUtils_
     private
@@ -1271,7 +1342,7 @@ module FileUtils
 
     def entries
       opts = {}
-      opts[:encoding] = ::Encoding::UTF_8 if fu_windows?
+      opts[:encoding] = "UTF-8" if /mswin|mignw/ =~ RUBY_PLATFORM
       Dir.entries(path(), opts)\
           .reject {|n| n == '.' or n == '..' }\
           .map {|n| Entry_.new(prefix(), join(rel(), n.untaint)) }
@@ -1445,7 +1516,7 @@ module FileUtils
       yield self
     end
 
-    private
+  private
 
     $fileutils_rb_have_lchmod = nil
 
@@ -1501,10 +1572,11 @@ module FileUtils
     end
   end   # class Entry_
 
+private
+
   def fu_list(arg)   #:nodoc:
     [arg].flatten.map {|path| File.path(path) }
   end
-  private_module_function :fu_list
 
   def fu_each_src_dest(src, dest)   #:nodoc:
     fu_each_src_dest0(src, dest) do |s, d|
@@ -1512,7 +1584,6 @@ module FileUtils
       yield s, d, File.stat(s)
     end
   end
-  private_module_function :fu_each_src_dest
 
   def fu_each_src_dest0(src, dest)   #:nodoc:
     if tmp = Array.try_convert(src)
@@ -1529,12 +1600,10 @@ module FileUtils
       end
     end
   end
-  private_module_function :fu_each_src_dest0
 
   def fu_same?(a, b)   #:nodoc:
     File.identical?(a, b)
   end
-  private_module_function :fu_same?
 
   def fu_check_options(options, optdecl)   #:nodoc:
     h = options.dup
@@ -1543,7 +1612,6 @@ module FileUtils
     end
     raise ArgumentError, "no such option: #{h.keys.join(' ')}" unless h.empty?
   end
-  private_module_function :fu_check_options
 
   def fu_update_option(args, new)   #:nodoc:
     if tmp = Hash.try_convert(args.last)
@@ -1553,17 +1621,12 @@ module FileUtils
     end
     args
   end
-  private_module_function :fu_update_option
-
-  @fileutils_output = $stderr
-  @fileutils_label  = ''
 
   def fu_output_message(msg)   #:nodoc:
     @fileutils_output ||= $stderr
     @fileutils_label  ||= ''
     @fileutils_output.puts @fileutils_label + msg
   end
-  private_module_function :fu_output_message
 
   #
   # Returns an Array of method names which have any options.
@@ -1613,91 +1676,27 @@ module FileUtils
     OPT_TABLE.keys.select {|m| OPT_TABLE[m].include?(opt) }
   end
 
-  LOW_METHODS = singleton_methods(false) - collect_method(:noop).map(&:intern)
-  module LowMethods
-    module_eval("private\n" + ::FileUtils::LOW_METHODS.map {|name| "def #{name}(*)end"}.join("\n"),
-                __FILE__, __LINE__)
-  end
+  # LOW_METHODS
+  #
+  #   :pwd, :getwd, :cd, :chdir,
+  #   :uptodate?, :copy_entry, :copy_file, :copy_stream, :remove_entry_secure,
+  #   :remove_entry, :remove_file, :remove_dir, :compare_file, :identical?,
+  #   :cmp, :compare_stream
+  #
+  # DEPRECATED - Only here for backward compatibility.
+  LOW_METHODS = (commands - collect_method(:noop)).map(&:to_sym)
 
-  METHODS = singleton_methods() - [:private_module_function,
-      :commands, :options, :have_option?, :options_of, :collect_method]
 
+  # METHODS
   #
-  # This module has all methods of FileUtils module, but it outputs messages
-  # before acting.  This equates to passing the <tt>:verbose</tt> flag to
-  # methods in FileUtils.
+  #   :pwd, :getwd, :cd, :chdir, :uptodate?, :mkdir, :mkdir_p, :mkpath, :makedirs,
+  #   :rmdir, :ln, :link, :ln_s, :symlink, :ln_sf, :cp, :copy, :cp_r, :copy_entry,
+  #   :copy_file, :copy_stream, :mv, :move, :rm, :remove, :rm_f, :safe_unlink,
+  #   :rm_r, :rm_rf, :rmtree, :remove_entry_secure, :remove_entry, :remove_file,
+  #   :remove_dir, :compare_file, :identical?, :cmp, :compare_stream, :install,
+  #   :chmod, :chmod_R, :chown, :chown_R, :touch
   #
-  module Verbose
-    include FileUtils
-    @fileutils_output  = $stderr
-    @fileutils_label   = ''
-    ::FileUtils.collect_method(:verbose).each do |name|
-      module_eval(<<-EOS, __FILE__, __LINE__ + 1)
-        def #{name}(*args)
-          super(*fu_update_option(args, :verbose => true))
-        end
-        private :#{name}
-      EOS
-    end
-    extend self
-    class << self
-      ::FileUtils::METHODS.each do |m|
-        public m
-      end
-    end
-  end
-
-  #
-  # This module has all methods of FileUtils module, but never changes
-  # files/directories.  This equates to passing the <tt>:noop</tt> flag
-  # to methods in FileUtils.
-  #
-  module NoWrite
-    include FileUtils
-    include LowMethods
-    @fileutils_output  = $stderr
-    @fileutils_label   = ''
-    ::FileUtils.collect_method(:noop).each do |name|
-      module_eval(<<-EOS, __FILE__, __LINE__ + 1)
-        def #{name}(*args)
-          super(*fu_update_option(args, :noop => true))
-        end
-        private :#{name}
-      EOS
-    end
-    extend self
-    class << self
-      ::FileUtils::METHODS.each do |m|
-        public m
-      end
-    end
-  end
-
-  #
-  # This module has all methods of FileUtils module, but never changes
-  # files/directories, with printing message before acting.
-  # This equates to passing the <tt>:noop</tt> and <tt>:verbose</tt> flag
-  # to methods in FileUtils.
-  #
-  module DryRun
-    include FileUtils
-    include LowMethods
-    @fileutils_output  = $stderr
-    @fileutils_label   = ''
-    ::FileUtils.collect_method(:noop).each do |name|
-      module_eval(<<-EOS, __FILE__, __LINE__ + 1)
-        def #{name}(*args)
-          super(*fu_update_option(args, :noop => true, :verbose => true))
-        end
-        private :#{name}
-      EOS
-    end
-    extend self
-    class << self
-      ::FileUtils::METHODS.each do |m|
-        public m
-      end
-    end
-  end
+  # DEPRECATED - Only here for backward compatibility.
+  METHODS = commands.map(&:to_sym)
 
 end

--- a/test/fileutils/test_dryrun.rb
+++ b/test/fileutils/test_dryrun.rb
@@ -9,14 +9,15 @@ class TestFileUtilsDryRun < Test::Unit::TestCase
   include FileUtils::DryRun
   include TestFileUtils::Clobber
 
-  def test_visibility
-    FileUtils::METHODS.each do |m|
+  FileUtils::METHODS.each do |m|
+    define_method "test_singleton_visibility_#{m}" do
       assert_equal true, FileUtils::DryRun.respond_to?(m, true),
                    "FileUtils::DryRun.#{m} not defined"
       assert_equal true, FileUtils::DryRun.respond_to?(m, false),
                    "FileUtils::DryRun.#{m} not public"
     end
-    FileUtils::METHODS.each do |m|
+
+    define_method "test_instance_visibility_#{m}" do
       assert_equal true, respond_to?(m, true),
                    "FileUtils::DryRun\##{m} is not defined"
       assert_equal true, FileUtils::DryRun.private_method_defined?(m),

--- a/test/fileutils/test_nowrite.rb
+++ b/test/fileutils/test_nowrite.rb
@@ -9,18 +9,20 @@ class TestFileUtilsNoWrite < Test::Unit::TestCase
   include FileUtils::NoWrite
   include TestFileUtils::Clobber
 
-  def test_visibility
-    FileUtils::METHODS.each do |m|
+  FileUtils::METHODS.each do |m|
+    define_method "test_singleton_visibility_#{m}" do
       assert_equal true, FileUtils::NoWrite.respond_to?(m, true),
                    "FileUtils::NoWrite.#{m} is not defined"
       assert_equal true, FileUtils::NoWrite.respond_to?(m, false),
                    "FileUtils::NoWrite.#{m} is not public"
     end
-    FileUtils::METHODS.each do |m|
+
+    define_method "test_instance_visibility_#{m}" do
       assert_equal true, respond_to?(m, true),
                    "FileUtils::NoWrite\##{m} is not defined"
       assert_equal true, FileUtils::NoWrite.private_method_defined?(m),
                    "FileUtils::NoWrite\##{m} is not private"
     end
   end
+
 end

--- a/test/fileutils/test_verbose.rb
+++ b/test/fileutils/test_verbose.rb
@@ -7,18 +7,19 @@ class TestFileUtilsVerbose < Test::Unit::TestCase
 
   include FileUtils::Verbose
 
-  def test_visibility
-    FileUtils::METHODS.each do |m|
+  FileUtils::METHODS.each do |m|
+    define_method "test_singleton_visibility_#{m}" do
       assert_equal true, FileUtils::Verbose.respond_to?(m, true),
                    "FileUtils::Verbose.#{m} is not defined"
       assert_equal true, FileUtils::Verbose.respond_to?(m, false),
                    "FileUtils::Verbose.#{m} is not public"
     end
-    FileUtils::METHODS.each do |m|
+
+    define_method "test_visibility_#{m}" do
       assert_equal true, respond_to?(m, true),
-                   "FileUtils::Verbose.#{m} is not defined"
+                   "FileUtils::Verbose\##{m} is not defined"
       assert_equal true, FileUtils::Verbose.private_method_defined?(m),
-                   "FileUtils::Verbose.#{m} is not private"
+                   "FileUtils::Verbose\##{m} is not private"
     end
   end
 


### PR DESCRIPTION
Refactor FileUtils code to use more idiomatic Ruby and thus easier to read and work with:
- factor out post-facto dynamic method definitions
- use define_command to create each fileutils method

NOTE: OPT_TABLE keys should probably be Symbols instead of Strings, but held off on that at this point.
