### PR TITLE
* lib/net/http.rb: fixed https doc error

### DIFF
--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -256,7 +256,7 @@ module Net   #:nodoc:
   #   uri = URI('https://secure.example.com/some_path?query=string')
   #
   #   Net::HTTP.start(uri.host, uri.port,
-  #     :use_ssl => uri.scheme == 'https').start do |http|
+  #     :use_ssl => uri.scheme == 'https') do |http|
   #     request = Net::HTTP::Get.new uri.request_uri
   #
   #     response = http.request request # Net::HTTPResponse object


### PR DESCRIPTION
Hello,

I found an error in net/http documentation :

``` ruby
Net::HTTP.start(uri.host, uri.port,
  :use_ssl => uri.scheme == 'https').start do |http|
  request = Net::HTTP::Get.new uri.request_uri

  response = http.request request # Net::HTTPResponse object
end
```

The first line call start() method 2 times here.
