### PR TITLE
enumerator extended with lazy select and map

### DIFF
--- a/enumerator.c
+++ b/enumerator.c
@@ -451,11 +451,10 @@ enumerator_map(VALUE obj)
         entry->proc = rb_block_proc();
         entry->type = T_PROC_MAP;
         rb_ary_push(e->procs, entry_obj);
+        return obj;
     } else {
-        rb_call_super(0, 0);
+        return rb_call_super(0, 0);
     }
-
-    return obj;
 }
 
 static VALUE
@@ -471,11 +470,10 @@ enumerator_select(VALUE obj)
         entry->proc = rb_block_proc();
         entry->type = T_PROC_SELECT;
         rb_ary_push(e->procs, entry_obj);
+        return obj;
     } else {
-        rb_call_super(0, 0);
+        return rb_call_super(0, 0);
     }
-
-    return obj;
 }
 
 /*


### PR DESCRIPTION
Please, see http://bugs.ruby-lang.org/issues/4890 for more info about enumerator laziness.

I've added `Enumerator#lazy` method that marks enumerator as lazy.
Also lazy `Enumerator#map` and `Enumerator#select` defined.
The idea is very simple - block that passed to lazy method (select or map) is converted to `Proc` and stored in enumerator itself. 
When next element requested - all `Proc` objects are called for this value and the result returned. `Proc#call` result handling depends on `proc_entry` type.

Example:

```
a = [1,2,3,4].to_enum.lazy
a.map { |a| a*10 }.select { |a| a > 10 }
puts a.next #=> 20
puts a.next #=> 30
puts a.next #=> 40
```

Keep in mind - I'm kinda a newbie in ruby patching, so please, let me know your thoughts/fixes/comments.
Does it make any sense to add laziness this way?

Thanks. 
