### PR TITLE
Feature 4890 lazy enumerator

### DIFF
--- a/enumerator.c
+++ b/enumerator.c
@@ -1244,7 +1244,7 @@ lazy_select_func(VALUE val, VALUE m, int argc, VALUE *argv)
     VALUE element = rb_ary_entry(val, 1);
     VALUE result = rb_funcall(rb_block_proc(), id_call, 1, element);
 
-    if (result) {
+    if (RTEST(result)) {
         return rb_funcall(rb_ary_entry(val, 0), id_yield, 1, element);
     } else {
         return result;
@@ -1267,7 +1267,7 @@ lazy_reject_func(VALUE val, VALUE m, int argc, VALUE *argv)
     VALUE element = rb_ary_entry(val, 1);
     VALUE result = rb_funcall(rb_block_proc(), id_call, 1, element);
 
-    if (!result) {
+    if (!RTEST(result)) {
         return rb_funcall(rb_ary_entry(val, 0), id_yield, 1, element);
     } else {
         return result;

--- a/test/ruby/test_lazy_enumerator.rb
+++ b/test/ruby/test_lazy_enumerator.rb
@@ -10,6 +10,8 @@ class TestLazyEnumerator < Test::Unit::TestCase
   def test_select
     a = [1, 2, 3, 4, 5, 6]
     assert_equal([4, 5, 6], a.lazy.select { |x| x > 3 }.to_a)
+    a = ['word', nil, 1]
+    assert_equal(['word', 1], a.lazy.select { |x| x }.to_a)
   end
 
   def test_map
@@ -20,6 +22,8 @@ class TestLazyEnumerator < Test::Unit::TestCase
   def test_reject
     a = [1, 2, 3, 4, 5, 6]
     assert_equal([1, 2, 3], a.lazy.reject { |x| x > 3 }.to_a)
+    a = ['word', nil, 1]
+    assert_equal([nil], a.lazy.reject { |x| x }.to_a)
   end
 
   def test_grep


### PR DESCRIPTION
Please, see http://bugs.ruby-lang.org/issues/4890 for more info about enumerator laziness.

Last week I've made this PR #100. But I've faced some problems while trying to push the idea further.

So, here's a straight C implementation of the `Enumerable::Lazy` based on ruby code, suggested in original feature request on bugs.ruby-lang.org.

`Enumerable::Lazy#map`, `Enumerable::Lazy#select`, `Enumerable::Lazy#reject`, `Enumerable::Lazy#grep` added so far but I'm keep working on other methods as well.
