### PR TITLE
Kernel#lazy added

### DIFF
--- a/enumerator.c
+++ b/enumerator.c
@@ -1202,6 +1202,12 @@ generator_each(int argc, VALUE *argv, VALUE obj)
  *
  */
 
+static VALUE
+stop_result(VALUE self)
+{
+    return rb_attr_get(self, rb_intern("result"));
+}
+
 /* Lazy Enumerator methods */
 static VALUE
 lazy_init_iterator(VALUE val, VALUE m, int argc, VALUE *argv)
@@ -1242,6 +1248,12 @@ lazy_initialize(VALUE self, VALUE obj)
     enumerator_init(self, generator, sym_each, 0, 0);
 
     return self;
+}
+
+static VALUE
+obj_to_lazy(VALUE obj)
+{
+    return lazy_initialize(enumerator_allocate(rb_cLazy), obj);
 }
 
 /*
@@ -1367,17 +1379,12 @@ lazy_grep(VALUE obj, VALUE pattern)
     return rb_block_call(rb_cLazy, id_new, 1, &obj, lazy_grep_func, pattern);
 }
 
-static VALUE
-stop_result(VALUE self)
-{
-    return rb_attr_get(self, rb_intern("result"));
-}
-
 void
 Init_Enumerator(void)
 {
     rb_define_method(rb_mKernel, "to_enum", obj_to_enum, -1);
     rb_define_method(rb_mKernel, "enum_for", obj_to_enum, -1);
+    rb_define_method(rb_mKernel, "lazy", obj_to_lazy, 0);
 
     rb_cEnumerator = rb_define_class("Enumerator", rb_cObject);
     rb_include_module(rb_cEnumerator, rb_mEnumerable);

--- a/test/ruby/test_lazy_enumerator.rb
+++ b/test/ruby/test_lazy_enumerator.rb
@@ -20,6 +20,7 @@ class TestLazyEnumerator < Test::Unit::TestCase
   def test_initialize
     assert_equal([1, 2, 3], [1, 2, 3].lazy.to_a)
     assert_equal([1, 2, 3], Enumerable::Lazy.new([1, 2, 3]).to_a)
+    assert_equal([1, 2, 3], Step.new(1..3).lazy.to_a)
   end
 
   def test_each_args


### PR DESCRIPTION
Since Enumerable#lazy were added based on my [patch](http://bugs.ruby-lang.org/projects/ruby-trunk/repository/revisions/34951) I was thinking about adding `Kernel#lazy` - like `Kernel#to_enum` or `Kernel#enum_for`
To make possible this:

```
a = Object.new
def a.each
  yield 3
end
a.lazy #=> Enumerable::Lazy
```

lazy_initialize is [now](https://github.com/ruby/ruby/commit/e7d4e659a070f6e188f3924bd8efb65e6919d2ef) without additional arguments.  
Does it make sense to revert this so that additional arguments can be passed to Kernel#lazy (like `Kernel#to_enum` or `Kernel#enum_for`)?
Thanks in advance.

/cc @nobu
/cc @shugo
