### PR TITLE
Time.new will accept seconds as string or int

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+Fri Mar 23 21:21:17 2012  Sambasiva Rao Suda  <sambasivarao@gmail.org>
+
+	* time.c (time_init_1): Time.new will accept seconds as string or int.
+	  [ruby-core:43569] [Bug #6193]
+
 Sun Mar 18 13:23:28 2012  NARUSE, Yui  <naruse@ruby-lang.org>
 
 	* encoding.c (rb_enc_compatible): return ASCII-8BIT even if 2nd string

--- a/test/test_time.rb
+++ b/test/test_time.rb
@@ -404,4 +404,10 @@ class TestTimeExtension < Test::Unit::TestCase # :nodoc:
     bug4456 = '[ruby-dev:43284]'
     assert_normal_exit %q{ Time.now.strftime("%1000000000F") }, bug4456
   end
+
+  def test_sec_str
+    bug6193 = '[ruby-core:43569]'
+    assert_normal_exit %q{ Time.new(2012, 1, 2, 3, 4, "5") }, bug6193
+    assert_equal(Time.new(2012, 1, 2, 3, 4, 5), Time.new(2012, 1, 2, 3, 4, "5"))
+  end
 end

--- a/time.c
+++ b/time.c
@@ -2160,7 +2160,7 @@ time_init_1(int argc, VALUE *argv, VALUE time)
     vtm.sec = 0;
     vtm.subsecx = INT2FIX(0);
     if (!NIL_P(v[5])) {
-        VALUE sec = num_exact(v[5]);
+        VALUE sec = obj2vint(v[5]);
         VALUE subsec;
         divmodv(sec, INT2FIX(1), &sec, &subsec);
         vtm.sec = NUM2INT(sec);


### PR DESCRIPTION
All parameters of Time.new can be string or int except seconds
This will fix that
