### PR TITLE
Fix for using Kernel.printf for tracing output instead of stdout.printf

### DIFF
--- a/lib/tracer.rb
+++ b/lib/tracer.rb
@@ -205,12 +205,12 @@ class Tracer
         else
           source = get_line(file, line)
         end
-        printf("%s:%d:%s:%s: %s",
-               file,
-               line,
-               klass || '',
-               EVENT_SYMBOL[event],
-               source)
+        stdout.printf("%s:%d:%s:%s: %s",
+                      file,
+                      line,
+                      klass || '',
+                      EVENT_SYMBOL[event],
+                      source)
       end
     end
 


### PR DESCRIPTION
The patch fixes a simple omission:
Tracer allows setting of the attribute 'stdout', but the method 'trace_func' does not respect it in the main output. - The optional output of process id and thread id respects the attribute.

BTW: The info on http://www.ruby-lang.org/en/community/ruby-core about how to submit patches via github seems outdated!? @shyouhei's fork of this repo is way behind... That's why I am sending this request to this repo.
