### PR TITLE
is_integer? method declaration in prelude, generally wanted from develop...

### DIFF
--- a/golf_prelude.rb
+++ b/golf_prelude.rb
@@ -84,6 +84,10 @@ class String
     split('')
   end
 
+  def is_integer?
+    self == self.to_i.to_s
+  end
+  
   (Array.instance_methods-instance_methods-[:to_ary,:transpose,:flatten,:flatten!,:compact,:compact!,:assoc,:rassoc]).each{|meth|
     eval"
     def #{meth}(*args, &block)


### PR DESCRIPTION
Dear Rubyists, can we add "is_integer?" method to our core for main purposes of checking integerITY?
I add it to "golf_prelude.rb" below of "to_a" stub.
