### PR TITLE
add hostname to "hostname does not match server cert." error

### DIFF
--- a/ext/openssl/lib/openssl/ssl.rb
+++ b/ext/openssl/lib/openssl/ssl.rb
@@ -126,7 +126,7 @@ module OpenSSL
 
       def post_connection_check(hostname)
         unless OpenSSL::SSL.verify_certificate_identity(peer_cert, hostname)
-          raise SSLError, "hostname does not match the server certificate"
+          raise SSLError, "hostname \"#{hostname}\" does not match the server certificate"
         end
         return true
       end


### PR DESCRIPTION
When the openssl library cannot verify a server certificate because the hostnames don't match, it outputs the error message: "hostname does not match the server certificate".

This causes people to throw their hands up and circumvent the security by disabling the cert verification or turning off SSL/TLS altogether.

It would be a huge improvement towards helping people debug and fix their mismatched certs if the error included the hostname that wasn't matching.

That's what my commit does.
