### PR TITLE
add a URI::Generic.parser class method; fixes issue #6420

### DIFF
--- a/lib/uri/generic.rb
+++ b/lib/uri/generic.rb
@@ -290,6 +290,12 @@ module URI
     #
     attr_reader :fragment
 
+    # Returns the default parser
+    #
+    def self.parser
+      DEFAULT_PARSER
+    end
+
     # returns the parser to be used.
     #
     # Unless a URI::Parser is defined, then DEFAULT_PARSER is used.


### PR DESCRIPTION
I added a .parser class method that returns DEFAULT_PARSER. This restores the expected behavior of URI::Generic.build2.
