### PR TITLE
popen: shell commands with envvars and execopts

### DIFF
--- a/internal.h
+++ b/internal.h
@@ -309,6 +309,8 @@ VALUE rb_execarg_init(int argc, VALUE *argv, int accept_shell, VALUE execarg_obj
 int rb_execarg_addopt(VALUE execarg_obj, VALUE key, VALUE val);
 void rb_execarg_fixup(VALUE execarg_obj);
 int rb_execarg_run_options(const struct rb_execarg *e, struct rb_execarg *s, char* errmsg, size_t errmsg_buflen);
+VALUE rb_execarg_extract_options(VALUE execarg_obj, VALUE opthash);
+void rb_execarg_setenv(VALUE execarg_obj, VALUE env);
 
 #if defined __GNUC__ && __GNUC__ >= 4
 #pragma GCC visibility pop


### PR DESCRIPTION
- io.c (is_popen_fork): check if fork and raise NotImplementedError if
  unavailable.
- io.c (rb_io_s_popen): allow environment variables hash and exec
  options as flat parameters, not in an array arguments.
- process.c (rb_execarg_extract_options): extract exec options, but no
  exceptions on non-exec options and returns them as a Hash.
- process.c (rb_execarg_setenv): set environment variables.
