### PR TITLE
More consistent and meaningful test names

### DIFF
--- a/test/ruby/test_object.rb
+++ b/test/ruby/test_object.rb
@@ -177,7 +177,7 @@ class TestObject < Test::Unit::TestCase
     assert_equal(false, o.instance_variable_defined?(:@foo))
   end
 
-  def test_convert_type
+  def test_convert_string
     o = Object.new
     def o.to_s; 1; end
     assert_raise(TypeError) { String(o) }
@@ -187,7 +187,7 @@ class TestObject < Test::Unit::TestCase
     assert_raise(TypeError) { String(o) }
   end
 
-  def test_check_convert_type
+  def test_convert_array
     o = Object.new
     def o.to_a; 1; end
     assert_raise(TypeError) { Array(o) }
@@ -210,7 +210,7 @@ class TestObject < Test::Unit::TestCase
     assert_raise(TypeError) { Hash(o) }
   end
 
-  def test_to_integer
+  def test_convert_integer
     o = Object.new
     def o.to_i; nil; end
     assert_raise(TypeError) { Integer(o) }


### PR DESCRIPTION
Unify the test names for the `String`, `Array`, `Hash` and `Integer` method tests.
