### PR TITLE
Allow to use require_relative from eval and irb environment

### DIFF
--- a/load.c
+++ b/load.c
@@ -497,10 +497,8 @@ rb_f_require_relative(VALUE obj, VALUE fname)
 {
     VALUE base = rb_current_realfilepath();
     if (NIL_P(base)) {
-      VALUE path = FilePathValue(fname);
-      if (!path)
-        path = fname;
-      return rb_require_safe(path, rb_safe_level());
+      if(!NIL_P(fname))
+        return rb_require_safe(fname, rb_safe_level());
     }
     base = rb_file_dirname(base);
     return rb_require_safe(rb_file_absolute_path(fname, base), rb_safe_level());


### PR DESCRIPTION
**Before patch**

``` ruby
1.9.3p125 :001 > require_relative "file"
LoadError: cannot infer basepath
    from (irb):1:in `require_relative'
    from (irb):1
    from /home/lite/.rvm/rubies/ruby-1.9.3-p125-perf/bin/irb:16:in `<main>'
```

**After patch**

``` ruby
1.9.3p125 :001 > require_relative "file"
 => true 
```
