### PR TITLE
intern.h: mark rb_num_zerodiv as NORETURN

### DIFF
--- a/include/ruby/intern.h
+++ b/include/ruby/intern.h
@@ -512,7 +512,7 @@ VALUE rb_marshal_dump(VALUE, VALUE);
 VALUE rb_marshal_load(VALUE);
 void rb_marshal_define_compat(VALUE newclass, VALUE oldclass, VALUE (*dumper)(VALUE), VALUE (*loader)(VALUE, VALUE));
 /* numeric.c */
-void rb_num_zerodiv(void);
+NORETURN(void rb_num_zerodiv(void));
 #define RB_NUM_COERCE_FUNCS_NEED_OPID 1
 VALUE rb_num_coerce_bin(VALUE, VALUE, ID);
 VALUE rb_num_coerce_cmp(VALUE, VALUE, ID);


### PR DESCRIPTION
Consider the following code in time.c (quo).

```
if (b == 0) rb_num_zerodiv();
c = a / b;
```

This patch informs the compiler that rb_num_zerodiv doesn't return.
Otherwise some compilers may conclude that the division a / b is always
reachable, leading to misoptimization.

https://bugs.ruby-lang.org/issues/6736
