### PR TITLE
Making StringIO#to_s behave as one would expect

### DIFF
--- a/ext/stringio/stringio.c
+++ b/ext/stringio/stringio.c
@@ -1423,6 +1423,7 @@ Init_stringio()
     rb_define_method(StringIO, "initialize_copy", strio_copy, 1);
     rb_define_method(StringIO, "reopen", strio_reopen, -1);
 
+    rb_define_method(StringIO, "to_s", strio_get_string, 0);
     rb_define_method(StringIO, "string", strio_get_string, 0);
     rb_define_method(StringIO, "string=", strio_set_string, 1);
     rb_define_method(StringIO, "lineno", strio_get_lineno, 0);


### PR DESCRIPTION
This patch just aliases StringIO#string to StringIO#to_s (as opposed to the default, inherited implementation of #to_s), in the interest of maintaining the POLS.
