### PR TITLE
Test String#each_line when separator is longer than the string.

### DIFF
--- a/test/ruby/test_string.rb
+++ b/test/ruby/test_string.rb
@@ -637,6 +637,13 @@ class TestString < Test::Unit::TestCase
     assert_equal(S("hello!"), res[0])
     assert_equal(S("world"),  res[1])
 
+    $/ = "ab"
+
+    res=[]
+    S("a").lines.each {|x| res << x}
+    assert_equal(1, res.size)
+    assert_equal(S("a"), res[0])
+
     $/ = save
 
     s = nil


### PR DESCRIPTION
For [JRUBY-6819](http://jira.codehaus.org/browse/JRUBY-6819) we had a bug when the separator string is longer than the string on which you call each_line that caused it to walk off the end. There did not appear to be a test that covered this in MRI's suite.
