### PR TITLE
Add alisases for the start_with? and end_with? methods

### DIFF
--- a/string.c
+++ b/string.c
@@ -7931,7 +7931,9 @@ Init_String(void)
 
     rb_define_method(rb_cString, "include?", rb_str_include, 1);
     rb_define_method(rb_cString, "start_with?", rb_str_start_with, -1);
+    rb_define_method(rb_cString, "starts_with?", rb_str_start_with, -1);
     rb_define_method(rb_cString, "end_with?", rb_str_end_with, -1);
+    rb_define_method(rb_cString, "ends_with?", rb_str_end_with, -1);
 
     rb_define_method(rb_cString, "scan", rb_str_scan, 1);
 


### PR DESCRIPTION
Hello,

I just add aliases for the `start_with?` and `end_with?` methods because an object can be designed by "it" and each verbs ends with an "s" when it's conjugated with the third person. 

Is there a better way to define aliases ? Sorry if I don't do it the right way, I can change it if you want.

I have also a question : Why the `start_with?` and `end_with?` method (in the C sources) don't end with a _p like all other predicate methods ?

Have a nice day.
