### PR TITLE
It's not recommended to escape ' to &apos;

### DIFF
--- a/lib/cgi/util.rb
+++ b/lib/cgi/util.rb
@@ -22,7 +22,7 @@ class CGI
 
   # The set of special characters and their escaped values
   TABLE_FOR_ESCAPE_HTML__ = {
-    "'" => '&apos;',
+    "'" => '&#x27;',
     '&' => '&amp;',
     '"' => '&quot;',
     '<' => '&lt;',

--- a/test/cgi/test_cgi_util.rb
+++ b/test/cgi/test_cgi_util.rb
@@ -54,7 +54,7 @@ class CGIUtilTest < Test::Unit::TestCase
   end
 
   def test_cgi_escapeHTML
-    assert_equal(CGI::escapeHTML("'&\"><"),"&apos;&amp;&quot;&gt;&lt;")
+    assert_equal(CGI::escapeHTML("'&\"><"),"&#x27;&amp;&quot;&gt;&lt;")
   end
 
   def test_cgi_unescapeHTML

--- a/test/erb/test_erb.rb
+++ b/test/erb/test_erb.rb
@@ -39,8 +39,7 @@ class TestERB < Test::Unit::TestCase
   end
 
   def test_html_escape
-    # TODO: &apos; should be changed to &#x27;
-    assert_equal(" !&quot;\#$%&amp;&apos;()*+,-./0123456789:;&lt;=&gt;?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~",
+    assert_equal(" !&quot;\#$%&amp;&#x27;()*+,-./0123456789:;&lt;=&gt;?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~",
                  ERB::Util.html_escape(" !\"\#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"))
 
     assert_equal("", ERB::Util.html_escape(""))


### PR DESCRIPTION
OWASP doesn't recommend it https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet#RULE_.231_-_HTML_Escape_Before_Inserting_Untrusted_Data_into_HTML_Element_Content
and &apos; is not a valid in HTML4 http://www.w3.org/TR/html4/sgml/entities.html
