### PR TITLE
Fixing a typo in FileUtils#ln_sf documentation

### DIFF
--- a/lib/fileutils.rb
+++ b/lib/fileutils.rb
@@ -435,7 +435,7 @@ public
   # Options: noop verbose
   #
   # Same as
-  #   #ln_s(src, dest, :force)
+  #   #ln_s(src, dest, :force => true)
   #
   def ln_sf(src, dest, options = {})
     fu_check_options options, OPT_TABLE['ln_sf']


### PR DESCRIPTION
The `FileUtils#ln_sf` documentation indicates that calling it is the same as calling `ln_s(src, dest, :force)` which is wrong.

This commit fixes it by replacing `:force` with `:force => true`.
