### PR TITLE
Make ERB::Util.html_escape reuse CGI.escapeHTML

### DIFF
--- a/lib/erb.rb
+++ b/lib/erb.rb
@@ -896,6 +896,16 @@ class ERB
   # A utility module for conversion routines, often handy in HTML generation.
   module Util
     public
+
+    # The set of special characters and their escaped values
+    TABLE_FOR_ESCAPE_HTML__ = {
+      "'" => '&#x27;',
+      '&' => '&amp;',
+      '"' => '&quot;',
+      '<' => '&lt;',
+      '>' => '&gt;',
+    }
+
     #
     # A utility method for escaping HTML tag characters in _s_.
     #
@@ -909,7 +919,7 @@ class ERB
     #   is a &gt; 0 &amp; a &lt; 10?
     #
     def html_escape(s)
-      s.to_s.gsub(/&/, "&amp;").gsub(/\"/, "&quot;").gsub(/>/, "&gt;").gsub(/</, "&lt;")
+      s.to_s.gsub(/['&\"<>]/, TABLE_FOR_ESCAPE_HTML__)
     end
     alias h html_escape
     module_function :h


### PR DESCRIPTION
We just fixed this issue in Rails
https://groups.google.com/forum/#!msg/rubyonrails-security/kKGNeMrnmiY/r2yM7xy-G48J%5B1-25%5D

Ruby's ERB is not escaping single quotes and this could lead to
issues like ...

<a href='<%= h link %>' >My Link!</a>
being link = " '; alert(hax) "

OWASP suggest escaping &, <, >, ", ' and /
https://www.owasp.org/index.php/XSS_%28Cross_Site_Scripting%29_Prevention_Cheat_Sheet#RULE_.231_-_HTML_Escape_Before_Inserting_Untrusted_Data_into_HTML_Element_Content

About / I don't think could lead to issues but that's another story.

You have the right code in CGI.escapeHTML
https://github.com/ruby/ruby/blob/c47cca2f/lib/cgi/util.rb#L36 so my
suggestion is to reuse CGI.escapeHTML from ERB::Util
