### PR TITLE
vm_insnhelper.c: iclass as klass in cfp

### DIFF
--- a/cont.c
+++ b/cont.c
@@ -1161,7 +1161,7 @@ rb_fiber_start(void)
 	th->root_svar = Qnil;
 
 	fib->status = RUNNING;
-	cont->value = rb_vm_invoke_proc(th, proc, proc->block.self, argc, argv, 0);
+	cont->value = rb_vm_invoke_proc(th, proc, argc, argv, 0);
     }
     TH_POP_TAG();
 

--- a/proc.c
+++ b/proc.c
@@ -558,8 +558,7 @@ proc_call(int argc, VALUE *argv, VALUE procval)
 	}
     }
 
-    vret = rb_vm_invoke_proc(GET_THREAD(), proc, proc->block.self,
-			     argc, argv, blockptr);
+    vret = rb_vm_invoke_proc(GET_THREAD(), proc, argc, argv, blockptr);
     RB_GC_GUARD(procval);
     return vret;
 }
@@ -584,7 +583,7 @@ rb_proc_call(VALUE self, VALUE args)
     VALUE vret;
     rb_proc_t *proc;
     GetProcPtr(self, proc);
-    vret = rb_vm_invoke_proc(GET_THREAD(), proc, proc->block.self,
+    vret = rb_vm_invoke_proc(GET_THREAD(), proc,
 			     check_argc(RARRAY_LEN(args)), RARRAY_PTR(args), 0);
     RB_GC_GUARD(self);
     RB_GC_GUARD(args);
@@ -605,8 +604,7 @@ rb_proc_call_with_block(VALUE self, int argc, VALUE *argv, VALUE pass_procval)
 	block = &pass_proc->block;
     }
 
-    vret = rb_vm_invoke_proc(GET_THREAD(), proc, proc->block.self,
-			     argc, argv, block);
+    vret = rb_vm_invoke_proc(GET_THREAD(), proc, argc, argv, block);
     RB_GC_GUARD(self);
     RB_GC_GUARD(pass_procval);
     return vret;

--- a/thread.c
+++ b/thread.c
@@ -455,7 +455,7 @@ thread_start_func_2(rb_thread_t *th, VALUE *stack_start, VALUE *register_stack_s
 		    th->errinfo = Qnil;
 		    th->root_lep = rb_vm_ep_local_ep(proc->block.ep);
 		    th->root_svar = Qnil;
-		    th->value = rb_vm_invoke_proc(th, proc, proc->block.self,
+		    th->value = rb_vm_invoke_proc(th, proc,
 						  (int)RARRAY_LEN(args), RARRAY_PTR(args), 0);
 		}
 		else {

--- a/vm_core.h
+++ b/vm_core.h
@@ -731,7 +731,7 @@ VALUE rb_iseq_eval_main(VALUE iseqval);
 #endif
 int rb_thread_method_id_and_class(rb_thread_t *th, ID *idp, VALUE *klassp);
 
-VALUE rb_vm_invoke_proc(rb_thread_t *th, rb_proc_t *proc, VALUE self,
+VALUE rb_vm_invoke_proc(rb_thread_t *th, rb_proc_t *proc,
 			int argc, const VALUE *argv, const rb_block_t *blockptr);
 VALUE rb_vm_make_proc(rb_thread_t *th, const rb_block_t *block, VALUE klass);
 VALUE rb_vm_make_env_object(rb_thread_t *th, rb_control_frame_t *cfp);

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -126,7 +126,7 @@ vm_call0(rb_thread_t* th, VALUE recv, VALUE id, int argc, const VALUE *argv,
 	  case OPTIMIZED_METHOD_TYPE_CALL: {
 	    rb_proc_t *proc;
 	    GetProcPtr(recv, proc);
-	    val = rb_vm_invoke_proc(th, proc, proc->block.self, argc, argv, blockptr);
+	    val = rb_vm_invoke_proc(th, proc, argc, argv, blockptr);
 	    break;
 	  }
 	  default:

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -466,7 +466,7 @@ vm_call_bmethod(rb_thread_t *th, VALUE recv, int argc, const VALUE *argv,
     /* control block frame */
     th->passed_me = me;
     GetProcPtr(me->def->body.proc, proc);
-    val = rb_vm_invoke_proc(th, proc, recv, argc, argv, blockptr);
+    val = vm_invoke_proc(th, proc, recv, defined_class, argc, argv, blockptr);
 
     EXEC_EVENT_HOOK(th, RUBY_EVENT_RETURN, recv, me->called_id, me->klass);
 
@@ -655,7 +655,7 @@ vm_call_method(rb_thread_t *th, rb_control_frame_t *cfp,
 		    MEMCPY(argv, cfp->sp - num, VALUE, num);
 		    cfp->sp -= num + 1;
 
-		    val = rb_vm_invoke_proc(th, proc, proc->block.self, argc, argv, blockptr);
+		    val = rb_vm_invoke_proc(th, proc, argc, argv, blockptr);
 		    break;
 		  }
 		  default:
@@ -683,10 +683,6 @@ vm_call_method(rb_thread_t *th, rb_control_frame_t *cfp,
 		val = vm_method_missing(th, id, recv, num, blockptr, stat);
 	    }
 	    else if (!(flag & VM_CALL_OPT_SEND_BIT) && (me->flag & NOEX_MASK) & NOEX_PROTECTED) {
-		if (RB_TYPE_P(defined_class, T_ICLASS)) {
-		    defined_class = RBASIC(defined_class)->klass;
-		}
-
 		if (!rb_obj_is_kind_of(cfp->self, defined_class)) {
 		    val = vm_method_missing(th, id, recv, num, blockptr, NOEX_PROTECTED);
 		}


### PR DESCRIPTION
- vm_insnhelper.c (vm_call_method): follow iclasses as klass in cfp
  but not included modules.  [ruby-core:47241] [Bug #6891]
- vm_insnhelper.c (vm_call_bmethod): pass defined_class to follow
  proper ancestors.  [ruby-core:47241] [Bug #6891]
