### PR TITLE
Rewrite CC, LD, NM, AR, AS, RANLIB, OBJDUMP, and OBJCOPY instead of PATH

### DIFF
--- a/nacl/GNUmakefile.in
+++ b/nacl/GNUmakefile.in
@@ -7,7 +7,14 @@ include Makefile
 NACL_SDK_ROOT=@NACL_SDK_ROOT@
 NACL_TOOLCHAIN=@NACL_TOOLCHAIN@
 NACL_TOOLCHAIN_DIR=$(NACL_SDK_ROOT)/toolchain/$(NACL_TOOLCHAIN)
-PATH+=:$(NACL_TOOLCHAIN_DIR)/bin
+CC:=$(NACL_TOOLCHAIN_DIR)/bin/$(CC)
+LD:=$(NACL_TOOLCHAIN_DIR)/bin/$(LD)
+NM:=$(NACL_TOOLCHAIN_DIR)/bin/$(NM)
+AR:=$(NACL_TOOLCHAIN_DIR)/bin/$(AR)
+AS:=$(NACL_TOOLCHAIN_DIR)/bin/$(AS)
+RANLIB:=$(NACL_TOOLCHAIN_DIR)/bin/$(RANLIB)
+OBJDUMP:=$(NACL_TOOLCHAIN_DIR)/bin/$(OBJDUMP)
+OBJCOPY:=$(NACL_TOOLCHAIN_DIR)/bin/$(OBJCOPY)
 PYTHON=@PYTHON@
 
 PPROGRAM=pepper-$(PROGRAM)
@@ -53,8 +60,13 @@ package: pprogram install-lib install-ext-comm install-ext-arch
 showflags: show_naclflags
 
 show_naclflags:
-	@echo "      PATH = $(PATH)"
-	@echo "      NACL_SDK_ROOT = $(NACL_SDK_ROOT)"
+	@echo "        NACL_SDK_ROOT = $(NACL_SDK_ROOT)"
+	@echo "        NM = $(NM)"
+	@echo "        AR = $(AR)"
+	@echo "        AS = $(AS)"
+	@echo "        RANLIB = $(RANLIB)"
+	@echo "        OBJDUMP = $(OBJDUMP)"
+	@echo "        OBJCOPY = $(OBJCOPY)"
 
 clean-local::
 	-$(RM) $(PPROGRAM) pepper_main.$(OBJEXT) $(PROGRAM_NMF) $(PPRGORAM_NMF)


### PR DESCRIPTION
NaCl port uses a toolchain which is specified by NACL_SDK_ROOT environment
variable. Originally, NaCl build added the toolchain under the NACL_SDK_ROOT
to the PATH. But updating PATH doesn't work on Mac.
