### PR TITLE
Add test for invalid attribute names.

### DIFF
--- a/test/ruby/test_module.rb
+++ b/test/ruby/test_module.rb
@@ -1452,4 +1452,17 @@ class TestModule < Test::Unit::TestCase
     assert_nothing_raised(NoMethodError, Bug6891) {Class.new(x)}
     assert_equal(['public', 'protected'], list)
   end
+
+  def test_invalid_attr
+    %w[
+      foo?
+      @foo
+      @@foo
+      $foo
+    ].each do |name|
+      assert_raises(NameError) do
+        Module.new { attr_accessor name.to_sym }
+      end
+    end
+  end
 end


### PR DESCRIPTION
For http://jira.codehaus.org/browse/JRUBY-6865 we discovered JRuby allows attributes to be named like "foo?" when passed to attr_accessor. A fix is going into JRuby 1.7.0.RC1, but there did not appear to be a test for invalid attr names in MRI.

This pull request adds a test. I was not exhaustive, but I covered a few key cases including the "foo?" form.
