### PR TITLE
Catch Process.kill(sig, 0) and make sure we only kill ourselves

### DIFF
--- a/signal.c
+++ b/signal.c
@@ -304,11 +304,11 @@ ruby_default_signal(int sig)
  *  call-seq:
  *     Process.kill(signal, pid, ...)    -> fixnum
  *
- *  Sends the given signal to the specified process id(s), or to the
- *  current process if _pid_ is zero. _signal_ may be an
- *  integer signal number or a POSIX signal name (either with or without
- *  a +SIG+ prefix). If _signal_ is negative (or starts
- *  with a minus sign), kills process groups instead of
+ *  Sends the given signal to the specified process id(s) if _pid_ is positive.
+ *  If _pid_ is zero _signal_ is sent to all processes whose group ID is equal
+ *  to the group ID of the process. _signal_ may be an integer signal number or
+ *  a POSIX signal name (either with or without a +SIG+ prefix). If _signal_ is
+ *  negative (or starts with a minus sign), kills process groups instead of
  *  processes. Not all signals are available on all platforms.
  *
  *     pid = fork do


### PR DESCRIPTION
As it stands, it passes on the call to kill(2) which sends to everything
in the process group of the caller.
