### PR TITLE
process.c: uid gid exec options

### DIFF
--- a/internal.h
+++ b/internal.h
@@ -202,9 +202,13 @@ struct rb_execarg {
     unsigned chdir_given : 1;
     unsigned new_pgroup_given : 1;
     unsigned new_pgroup_flag : 1;
+    unsigned uid_given : 1;
+    unsigned gid_given : 1;
     rb_pid_t pgroup_pgid; /* asis(-1), new pgroup(0), specified pgroup (0<V). */
     VALUE rlimit_limits; /* Qfalse or [[rtype, softlim, hardlim], ...] */
     mode_t umask_mask;
+    rb_uid_t uid;
+    rb_gid_t gid;
     VALUE fd_dup2;
     VALUE fd_close;
     VALUE fd_open;


### PR DESCRIPTION
- process.c (rb_execarg_addopt, rb_execarg_run_options): add :uid and
  :gid options.  [ruby-core:47414] [Feature #6975]
