### PR TITLE
internal.h: allocator function in rb_classext_t

### DIFF
--- a/class.c
+++ b/class.c
@@ -59,6 +59,7 @@ class_alloc(VALUE flags, VALUE klass)
     RCLASS_ORIGIN(obj) = (VALUE)obj;
     RCLASS_IV_INDEX_TBL(obj) = 0;
     RCLASS_REFINED_CLASS(obj) = Qnil;
+    RCLASS_EXT(obj)->allocator = 0;
     return (VALUE)obj;
 }
 
@@ -169,6 +170,7 @@ rb_mod_init_copy(VALUE clone, VALUE orig)
 	rb_singleton_class_attached(RBASIC(clone)->klass, (VALUE)clone);
     }
     RCLASS_SUPER(clone) = RCLASS_SUPER(orig);
+    RCLASS_EXT(clone)->allocator = RCLASS_EXT(orig)->allocator;
     if (RCLASS_IV_TBL(orig)) {
 	st_data_t id;
 
@@ -236,6 +238,7 @@ rb_singleton_class_clone(VALUE obj)
 	}
 
 	RCLASS_SUPER(clone) = RCLASS_SUPER(klass);
+	RCLASS_EXT(clone)->allocator = RCLASS_EXT(klass)->allocator;
 	if (RCLASS_IV_TBL(klass)) {
 	    RCLASS_IV_TBL(clone) = st_copy(RCLASS_IV_TBL(klass));
 	}
@@ -896,10 +899,6 @@ method_entry_i(st_data_t key, st_data_t value, st_data_t data)
     const rb_method_entry_t *me = (const rb_method_entry_t *)value;
     st_table *list = (st_table *)data;
     long type;
-
-    if ((ID)key == ID_ALLOCATOR) {
-	return ST_CONTINUE;
-    }
 
     if (!st_lookup(list, key, 0)) {
 	if (UNDEFINED_METHOD_ENTRY_P(me)) {

--- a/include/ruby/intern.h
+++ b/include/ruby/intern.h
@@ -42,7 +42,6 @@ extern "C" {
  * the kernel.
  */
 
-#define ID_ALLOCATOR 1
 #define UNLIMITED_ARGUMENTS (-1)
 
 /* array.c */

--- a/internal.h
+++ b/internal.h
@@ -29,6 +29,7 @@ struct rb_classext_struct {
     struct st_table *const_tbl;
     VALUE origin;
     VALUE refined_class;
+    rb_alloc_func_t allocator;
 };
 
 #undef RCLASS_SUPER

--- a/object.c
+++ b/object.c
@@ -1655,6 +1655,7 @@ VALUE
 rb_obj_alloc(VALUE klass)
 {
     VALUE obj;
+    rb_alloc_func_t allocator;
 
     if (RCLASS_SUPER(klass) == 0 && klass != rb_cBasicObject) {
 	rb_raise(rb_eTypeError, "can't instantiate uninitialized class");
@@ -1662,7 +1663,13 @@ rb_obj_alloc(VALUE klass)
     if (FL_TEST(klass, FL_SINGLETON)) {
 	rb_raise(rb_eTypeError, "can't create instance of singleton class");
     }
-    obj = rb_funcall(klass, ID_ALLOCATOR, 0, 0);
+    allocator = rb_get_alloc_func(klass);
+    if (!allocator) {
+	rb_raise(rb_eTypeError, "allocator undefined for %"PRIsVALUE,
+		 klass);
+    }
+
+    obj = (*allocator)(klass);
     if (rb_obj_class(obj) != rb_class_real(klass)) {
 	rb_raise(rb_eTypeError, "wrong instance allocation");
     }

--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -401,9 +401,7 @@ backtrace_each(rb_thread_t *th,
 	else if (RUBYVM_CFUNC_FRAME_P(cfp)) {
 	    ID mid = cfp->me->def ? cfp->me->def->original_id : cfp->me->called_id;
 
-	    if (mid != ID_ALLOCATOR) {
-		iter_cfunc(arg, mid);
-	    }
+	    iter_cfunc(arg, mid);
 	}
     }
 }

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -571,10 +571,6 @@ method_missing(VALUE obj, ID id, int argc, const VALUE *argv, int call_status)
     if (id == idMethodMissing) {
 	raise_method_missing(th, argc, argv, obj, call_status | NOEX_MISSING);
     }
-    else if (id == ID_ALLOCATOR) {
-	rb_raise(rb_eTypeError, "allocator undefined for %s",
-		 rb_class2name(obj));
-    }
 
     if (argc < 0x100) {
 	nargv = ALLOCA_N(VALUE, argc + 1);

--- a/vm_trace.c
+++ b/vm_trace.c
@@ -554,9 +554,6 @@ call_trace_func(rb_event_flag_t event, VALUE proc, VALUE self, ID id, VALUE klas
 	rb_thread_method_id_and_class(th, &id, &klass);
     }
 
-    if (id == ID_ALLOCATOR)
-      return;
-
     if (klass) {
 	if (RB_TYPE_P(klass, T_ICLASS)) {
 	    klass = RBASIC(klass)->klass;
@@ -777,10 +774,6 @@ tp_call_trace(VALUE tpval, rb_trace_arg_t *trace_arg)
     rb_tp_t *tp = tpptr(tpval);
     rb_thread_t *th = GET_THREAD();
     int state;
-
-    if (UNLIKELY(trace_arg->id == ID_ALLOCATOR)) {
-	return;
-    }
 
     tp->trace_arg = trace_arg;
 


### PR DESCRIPTION
- internal.h (struct rb_classext_struct): move allocator function into
  rb_classext_t from ordinary method table.  [ruby-dev:46121]
  [Feature #6993]
- object.c (rb_obj_alloc): call allocator function directly.
- vm_method.c (rb_define_alloc_func, rb_undef_alloc_func)
  (rb_get_alloc_func): use allocator function in rb_classext_t.
