### PR TITLE
* st.c: set packed size same as second table size

### DIFF
--- a/st.c
+++ b/st.c
@@ -35,7 +35,7 @@ typedef struct st_packed_entry {
 #define ST_DEFAULT_MAX_DENSITY 5
 #define ST_DEFAULT_INIT_TABLE_SIZE 11
 #define ST_DEFAULT_SECOND_TABLE_SIZE 19
-#define ST_DEFAULT_PACKED_TABLE_SIZE 18
+#define ST_DEFAULT_PACKED_TABLE_SIZE 19
 #define PACKED_UNIT (int)(sizeof(st_packed_entry) / sizeof(st_table_entry*))
 #define MAX_PACKED_HASH (int)(ST_DEFAULT_PACKED_TABLE_SIZE * sizeof(st_table_entry*) / sizeof(st_packed_entry))
 


### PR DESCRIPTION
It seems that tcmalloc and jemalloc suffers from difference from
ST_DEFAULT_PACKET_TABLE_SIZE and ST_DEFAULT_SECOND_TABLE_SIZE on 64bit
platform, cause 18_8 and 19_8 fall into the different allocation buckets.
It is not an issue on 32bit platform though.

Difference in web application could reach 8% (tested with backported patch on ruby 1.9.3 using Redmine)
