### PR TITLE
* gc.c: Fix stack overflow calculation in stack_check()

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -2114,7 +2114,7 @@ stack_check(int water_mark)
     int ret;
     rb_thread_t *th = GET_THREAD();
     SET_STACK_END;
-    ret = STACK_LENGTH > STACK_LEVEL_MAX - water_mark;
+    ret = STACK_LENGTH/sizeof(VALUE) > STACK_LEVEL_MAX - water_mark;
 #ifdef __ia64
     if (!ret) {
         ret = (VALUE*)rb_ia64_bsp() - th->machine_register_stack_start >


### PR DESCRIPTION
Originally, 'size in bytes' and 'VALUE counts' are compared in this check logic.
This is apparently wrong. Both side of the equation must be consistent from the viewpoint of unit.
