### PR TITLE
Negative numbers can't be primes by definition.

### DIFF
--- a/lib/prime.rb
+++ b/lib/prime.rb
@@ -157,7 +157,6 @@ class Prime
   # +value+:: an arbitrary integer to be checked.
   # +generator+:: optional. A pseudo-prime generator.
   def prime?(value, generator = Prime::Generator23.new)
-    value = -value if value < 0
     return false if value < 2
     for num in generator
       q,r = value.divmod num

--- a/test/test_prime.rb
+++ b/test/test_prime.rb
@@ -141,8 +141,8 @@ class TestPrime < Test::Unit::TestCase
 
       # negative
       assert !-1.prime?
-      assert(-2.prime?)
-      assert(-3.prime?)
+      assert !-2.prime?
+      assert !-3.prime?
       assert !-4.prime?
     end
   end


### PR DESCRIPTION
By definition, a prime number can be a _positive_ integer greater than 1.

http://mathworld.wolfram.com/PrimeNumber.html
