### PR TITLE
Add test for initialize_clone/initialize_dup behavior.

### DIFF
--- a/test/ruby/test_object.rb
+++ b/test/ruby/test_object.rb
@@ -21,6 +21,17 @@ class TestObject < Test::Unit::TestCase
     end
   end
 
+  def test_init_dupclone
+    cls = Class.new do
+      def initialize_clone(orig); throw :initialize_clone; end
+      def initialize_dup(orig); throw :initialize_dup; end
+    end
+
+    obj = cls.new
+    assert_throws(:initialize_clone) {obj.clone}
+    assert_throws(:initialize_dup) {obj.dup}
+  end
+
   def test_instance_of
     assert_raise(TypeError) { 1.instance_of?(1) }
   end


### PR DESCRIPTION
There did not appear to be any tests for initialize_clone/initialize_dup in MRI's suite.
