### PR TITLE
Use RB_GC_GUARD to prevent GC from freeing String copies used by iterators

### DIFF
--- a/string.c
+++ b/string.c
@@ -6133,6 +6133,7 @@ rb_str_each_line(int argc, VALUE *argv, VALUE str)
 	return orig;
     }
     str = rb_str_new4(str);
+    RB_GC_GUARD(str);
     ptr = p = s = RSTRING_PTR(str);
     pend = p + RSTRING_LEN(str);
     len = RSTRING_LEN(str);
@@ -6267,6 +6268,7 @@ rb_str_each_char(VALUE str)
 
     RETURN_ENUMERATOR(str, 0, 0);
     str = rb_str_new4(str);
+    RB_GC_GUARD(str);
     ptr = RSTRING_PTR(str);
     len = RSTRING_LEN(str);
     enc = rb_enc_get(str);
@@ -6320,6 +6322,7 @@ rb_str_each_codepoint(VALUE str)
     if (single_byte_optimizable(str)) return rb_str_each_byte(str);
     RETURN_ENUMERATOR(str, 0, 0);
     str = rb_str_new4(str);
+    RB_GC_GUARD(str);
     ptr = RSTRING_PTR(str);
     end = RSTRING_END(str);
     enc = STR_ENC_GET(str);


### PR DESCRIPTION
This fixes the bug which I reported yesterday at: http://bugs.ruby-lang.org/issues/7135

I was having a problem with incorrect values yielded by String#codepoints, because the frozen string copy which it uses internally was being freed by the GC. I noticed that very similar code is used in String#lines and String#chars, so I added RB_GC_GUARD to those also to make sure that similar problems do not happen to anyone when using those methods.
