### PR TITLE
Use RB_GC_GUARD to prevent GC from freeing String copies used by iterators

### DIFF
--- a/string.c
+++ b/string.c
@@ -6204,6 +6204,7 @@ rb_str_each_line(int argc, VALUE *argv, VALUE str)
 	rb_yield(line);
     }
 
+    RB_GC_GUARD(str);
     return orig;
 }
 
@@ -6284,6 +6285,7 @@ rb_str_each_char(VALUE str)
 	    rb_yield(rb_str_subseq(str, i, n));
 	}
     }
+    RB_GC_GUARD(str);
     return orig;
 }
 
@@ -6328,6 +6330,7 @@ rb_str_each_codepoint(VALUE str)
 	rb_yield(UINT2NUM(c));
 	ptr += n;
     }
+    RB_GC_GUARD(str);
     return orig;
 }
 


### PR DESCRIPTION
This fixes the following bug: http://bugs.ruby-lang.org/issues/7135

Although the problem I encountered was from String#codepoints, String#chars and String#lines are implemented in a similar way, and it looks like the same problem could potentially affect them too. So this patch includes "preemptive" fixes for those 2 as well.

The bug affects Ruby 1.9.2, 1.9.3, and 2.0. I've checked that the patch applies cleanly to both v1_9_2_381 and v1_9_3_195. I recommend you cherry-pick it onto both the 1.9.2 and 1.9.3 maintenance branches.
