### PR TITLE
ruby-electric.el: using variable `last-command-event' instead of obsolete `last-command-char'

### DIFF
--- a/misc/ruby-electric.el
+++ b/misc/ruby-electric.el
@@ -142,7 +142,7 @@ strings. Note that you must have Font Lock enabled."
 
 (defun ruby-electric-is-last-command-char-expandable-punct-p()
   (or (memq 'all ruby-electric-expand-delimiters-list)
-      (memq last-command-char ruby-electric-expand-delimiters-list)))
+      (memq last-command-event ruby-electric-expand-delimiters-list)))
 
 (defun ruby-electric-space-can-be-expanded-p()
   (if (ruby-electric-code-at-point-p)
@@ -188,7 +188,7 @@ strings. Note that you must have Font Lock enabled."
   (and (ruby-electric-is-last-command-char-expandable-punct-p)
        (ruby-electric-code-at-point-p)
        (save-excursion
-         (insert (cdr (assoc last-command-char
+         (insert (cdr (assoc last-command-event
                              ruby-electric-matching-delimeter-alist))))))
 
 (defun ruby-electric-bar(arg)


### PR DESCRIPTION
`last-command-char` is long obsolete and recently was removed in GNU Emacs trunk, which broke "ruby-electric.el".

From emacs documentation:

```
last-command-char is a variable defined in `subr.el'.

  This variable is an alias for `last-command-event'.
  This variable is obsolete since at least 19.34;
  use `last-command-event' instead.

Documentation:
Last input event that was part of a command.
```

This patch simply replaces uses of `last-command-char` with `last-command-event`.
