### PR TITLE
set content-length to zero on empty post requests

### DIFF
--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -1908,6 +1908,9 @@ module Net   #:nodoc:
     def set_body_internal(str)   #:nodoc: internal use only
       raise ArgumentError, "both of body argument and HTTPRequest#body set" if str and (@body or @body_stream)
       self.body = str if str
+      if @body.nil? && @body_stream.nil? && @body_data.nil?
+        self.body = ''
+      end
     end
 
     #

--- a/test/net/http/test_http.rb
+++ b/test/net/http/test_http.rb
@@ -125,6 +125,7 @@ module TestNetHTTP_version_1_1_methods
     start {|http|
       _test_post__base http
       _test_post__file http
+      _test_post__no_data http
     }
   end
 
@@ -144,6 +145,14 @@ module TestNetHTTP_version_1_1_methods
     f = StringIO.new
     http.post('/', data, nil, f)
     assert_equal data, f.string
+  end
+
+  def _test_post__no_data(http)
+    unless self.is_a?(TestNetHTTP_v1_2_chunked)
+      data = nil
+      res = http.post('/', data)
+      assert_not_equal '411', res.code
+    end
   end
 
   def test_s_post_form


### PR DESCRIPTION
It is bad form to not set the content-length header on empty post requests. This will most likely end with a 411 response from the server. Sometimes post requests will be empty e.g. the initial request during a challenge-response authentication scenario.
