### PR TITLE
Added #join method as a shortcut for to_a.join

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+Sat Oct 27 17:32:23 2012  Nathan Broadbent <nathan.f77@gmail.com>
+
+	* lib/set.rb: Added #join method as a shortcut for to_a.join
+
 Fri Oct 12 18:18:03 2012  Nobuyoshi Nakada  <nobu@ruby-lang.org>
 
 	* file.c (rb_get_path_check): path name must not contain NUL bytes.

--- a/lib/set.rb
+++ b/lib/set.rb
@@ -152,6 +152,10 @@ class Set
     @hash.keys
   end
 
+  def join(sep = nil)
+    to_a.join(sep)
+  end
+
   def flatten_merge(set, seen = Set.new) # :nodoc:
     set.each { |e|
       if e.is_a?(Set)


### PR DESCRIPTION
I was suprised that `Set.new.join` gives me a NoMethodError. I have attached a small patch that adds a #join method to Set, which is a shortcut for `to_a.join`.

I've also opened an issue at [bugs.ruby-lang.org](http://bugs.ruby-lang.org/issues/7226#change-31829).
