### PR TITLE
fix incorrect example which had been caused by typo

### DIFF
--- a/lib/uri/http.rb
+++ b/lib/uri/http.rb
@@ -49,7 +49,7 @@ module URI
     # Example:
     #
     #     newuri = URI::HTTP.build({:host => 'www.example.com',
-    #       :path> => '/foo/bar'})
+    #       :path => '/foo/bar'})
     #
     #     newuri = URI::HTTP.build([nil, "www.example.com", nil, "/path",
     #       "query", 'fragment'])


### PR DESCRIPTION
Fixed incorrect example.  ":path>" error was introduced in 030e887
