### PR TITLE
bigdecimal.c: avoid undefined overflow checking

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -3677,15 +3677,16 @@ AddExponent(Real *a, SIGNED_VALUE n)
     SIGNED_VALUE e = a->exponent;
     SIGNED_VALUE m = e+n;
     SIGNED_VALUE eb, mb;
+    /* Use unsigned VALUE to avoid undefined behavior */
     if(e>0) {
         if(n>0) {
-            mb = m*(SIGNED_VALUE)BASE_FIG;
-            eb = e*(SIGNED_VALUE)BASE_FIG;
+            mb = m*(VALUE)BASE_FIG;
+            eb = e*(VALUE)BASE_FIG;
             if(mb<eb) goto overflow;
         }
     } else if(n<0) {
-        mb = m*(SIGNED_VALUE)BASE_FIG;
-        eb = e*(SIGNED_VALUE)BASE_FIG;
+        mb = m*(VALUE)BASE_FIG;
+        eb = e*(VALUE)BASE_FIG;
         if(mb>eb) goto underflow;
     }
     a->exponent = m;


### PR DESCRIPTION
http://bugs.ruby-lang.org/issues/7371

Compilers may optimize away the overflow/underflow checks since signed integer overflow is undefined behavior in C.  This patch uses unsigned multiplications instead.

One can compile the code using `gcc -ftrapv` and should notice traps at run time.

One can also try to compile the following (simplified) code using gcc 4.8 with `gcc -S -O2`; the resulting assembly code is an _empty_ function. 

```
#define SIGNED_VALUE    long
#define BASE_FIG        9

void bar(void);

void AddExponent(SIGNED_VALUE e, SIGNED_VALUE n)
{
    n = 1;
    SIGNED_VALUE m = e+n;
    SIGNED_VALUE eb, mb;
    if(e>0) {
        if(n>0) {
            mb = m*(SIGNED_VALUE)BASE_FIG;
            eb = e*(SIGNED_VALUE)BASE_FIG;
            if(mb<eb) goto overflow;
        }
    }
    return;
overflow:
    bar();
}
```

Ruby currently uses "-fno-strict-overflow" to disable such offending optimizations in gcc, but this workaround option is not supported by other compilers, thus not portable.
