### PR TITLE
rescue SignalException so rack apps can shutdown properly

### DIFF
--- a/lib/webrick/server.rb
+++ b/lib/webrick/server.rb
@@ -130,6 +130,8 @@ module WEBrick
                   end
                 }
               end
+            rescue Interrupt
+              shutdown
             rescue Errno::EBADF, IOError => ex
               # if the listening socket was closed in GenericServer#shutdown,
               # IO::select raise it.


### PR DESCRIPTION
When control-c'ing a rack app, WEBrick will not catch SIGINT and shutdown. Instead it hands back the following error:

ERROR Interrupt: 
    /Users/macbook/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/webrick/server.rb:99:in `select'
