### PR TITLE
rb_ary_dup_of_p - stricter change for array's copy

### DIFF
--- a/array.c
+++ b/array.c
@@ -353,6 +353,28 @@ rb_ary_frozen_p(VALUE ary)
    something does modify the array it will pay the cost of copying
    it. */
 VALUE
+rb_ary_dup_of_p(VALUE ary1, VALUE ary2)
+{
+    VALUE *p1, *p2;
+    long len = RARRAY_LEN(ary1);
+
+    if (len != RARRAY_LEN(ary2)) return Qfalse;
+
+    p1 = RARRAY_PTR(ary1);
+    p2 = RARRAY_PTR(ary2);
+
+    if (ARY_EMBED_P(ary1) && ARY_EMBED_P(ary2)) {
+        for (; len; len--, p1++, p2++) {
+            if (*p1 != *p2) return Qfalse;
+        }
+        return Qtrue;
+    }
+
+    if (p1 == p2) return Qtrue;
+    return Qfalse;
+}
+
+VALUE
 rb_ary_shared_with_p(VALUE ary1, VALUE ary2)
 {
     if (!ARY_EMBED_P(ary1) && ARY_SHARED_P(ary1)

--- a/include/ruby/intern.h
+++ b/include/ruby/intern.h
@@ -56,6 +56,7 @@ VALUE rb_ary_tmp_new(long);
 void rb_ary_free(VALUE);
 void rb_ary_modify(VALUE);
 VALUE rb_ary_freeze(VALUE);
+VALUE rb_ary_dup_of_p(VALUE, VALUE);
 VALUE rb_ary_shared_with_p(VALUE, VALUE);
 VALUE rb_ary_aref(int, VALUE*, VALUE);
 VALUE rb_ary_subseq(VALUE, long, long);

--- a/load.c
+++ b/load.c
@@ -110,7 +110,7 @@ rb_get_expanded_load_path(void)
     rb_vm_t *vm = GET_VM();
     const VALUE non_cache = Qtrue;
 
-    if (!rb_ary_shared_with_p(vm->load_path_snapshot, vm->load_path)) {
+    if (!rb_ary_dup_of_p(vm->load_path_snapshot, vm->load_path)) {
 	/* The load path was modified. Rebuild the expanded load path. */
 	int has_relative = 0, has_non_cache = 0;
 	rb_construct_expanded_load_path(EXPAND_ALL, &has_relative, &has_non_cache);
@@ -247,7 +247,7 @@ get_loaded_features_index(void)
     int i;
     rb_vm_t *vm = GET_VM();
 
-    if (!rb_ary_shared_with_p(vm->loaded_features_snapshot, vm->loaded_features)) {
+    if (!rb_ary_dup_of_p(vm->loaded_features_snapshot, vm->loaded_features)) {
 	/* The sharing was broken; something (other than us in rb_provide_feature())
 	   modified loaded_features.  Rebuild the index. */
 	rb_hash_clear(vm->loaded_features_index);


### PR DESCRIPTION
- array.c (rb_ary_dup_of_p): new function
  stricter check for equality of previously dup-ed array,
  because rb_ary_shared_with_p doesn't handle case when #shift or #pop
  were applied to original array
- include/ruby/intern.h (rb_ary_dup_of_p): declare
- load.c (rb_get_expanded_load_path, get_loaded_features_index):
  use rb_ary_dup_of_p instead of rb_ary_shared_with_p
