### PR TITLE
Add `Net::HTTP::Patch` to documentation

### DIFF
--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -299,6 +299,7 @@ module Net   #:nodoc:
   #   * Net::HTTP::Get
   #   * Net::HTTP::Head
   #   * Net::HTTP::Post
+  #   * Net::HTTP::Patch
   #   * Net::HTTP::Put
   #   * Net::HTTP::Proppatch
   #   * Net::HTTP::Lock


### PR DESCRIPTION
Http request class `Net::HTTP::Patch` is missing in documentation.
