### PR TITLE
Documentation for Hash#merge and shallow copies.

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -1893,6 +1893,20 @@ rb_hash_update_block_i(VALUE key, VALUE value, VALUE hash)
  *     h2 = { "b" => 254, "c" => 300 }
  *     h1.merge!(h2) { |key, v1, v2| v1 }
  *                     #=> {"a"=>100, "b"=>200, "c"=>300}
+ *
+ *  Note that this method creates a shallow copy of the value in
+ *  <i>other_hash</i>. This means that when for example
+ *  <code>Array#select!</code> is used on one of the values in
+ *  <i>other_hash</i> both the original object as well as the copy will
+ *  be modified. This is illustrated in the following example:
+ *
+ *    original = { 'numbers' => [10, 20, 30] }
+ *    copy     = {}.merge(original)
+ *
+ *    copy['numbers'].select! { |number| number <= 20 }
+ *
+ *    puts copy     # => { 'numbers' => [10, 20] }
+ *    puts original # => { 'numbers' => [10, 20] }
  */
 
 static VALUE


### PR DESCRIPTION
The documentation of Hash#merge has been updated to clarify that this method
creates a shallow copy of the Hash specified in the method parameter.

Sidenote: if there is a particular set of standards I violated I'd love to hear so I can adjust the code to these standards.
