### PR TITLE
Fix doc for using SingleForwardable with Module

### DIFF
--- a/lib/forwardable.rb
+++ b/lib/forwardable.rb
@@ -196,17 +196,21 @@ end
 #    printer.def_delegator "STDOUT", "puts"  # add delegation for STDOUT.puts()
 #    printer.puts "Howdy!"
 #
-# Also, SingleForwardable can be use to Class or Module.
+# Also, SingleForwardable can be used to set up delegation for a Class or Module.
 #
-#    module Facade
-#      extend SingleForwardable
-#      def_delegator :Implementation, :service
+#   class Implementation
+#     def self.service
+#       puts "serviced!"
+#     end
+#   end
+#   
+#   module Facade
+#     extend SingleForwardable
+#     def_delegator :Implementation, :service
+#   end
 #
-#      class Implementation
-#         def service...
-#      end
-#    end
-#
+#   Facade.service #=> serviced!
+#   
 # If you want to use both Forwardable and SingleForwardable, you can
 # use methods def_instance_delegator and def_single_delegator, etc.
 module SingleForwardable


### PR DESCRIPTION
The example for using SingleForwardable with a Class or Module was incorrect Ruby
(it resulted in an exception).

Since the English sentence was not clear about what the example was trying to document,
this is my best guess. The new example illustrates that a Module can be delegated from
by extending it with SingleForwardable and using `def_delegator`.
