### PR TITLE
Changed misleading String#[]= doc

### DIFF
--- a/string.c
+++ b/string.c
@@ -3531,7 +3531,7 @@ rb_str_aset(VALUE str, VALUE indx, VALUE val)
  *  <code>Fixnum</code> will raise an <code>IndexError</code> if the value is
  *  out of range; the <code>Range</code> form will raise a
  *  <code>RangeError</code>, and the <code>Regexp</code> and <code>String</code>
- *  forms will silently ignore the assignment.
+ *  will raise an <code>IndexError</code> on negative match.
  */
 
 static VALUE


### PR DESCRIPTION
I found doc in string.c incorrect as for current MRI. `@aref_re_silent` in corresponding [test](/ruby/ruby/blob/trunk/test/ruby/test_string.rb#L106-L122) hints it could be not an issue in some implimentations.
