### PR TITLE
Securerandom: only use random bytes, not extra Stringlib/securerandom.rb...

### DIFF
--- a/lib/securerandom.rb
+++ b/lib/securerandom.rb
@@ -62,7 +62,7 @@ module SecureRandom
       if @pid != pid
         now = Time.now
         ary = [now.to_i, now.nsec, @pid, pid]
-        OpenSSL::Random.seed(ary.to_s)
+        OpenSSL::Random.seed(ary.join("").to_s)
         @pid = pid
       end
       return OpenSSL::Random.random_bytes(n)


### PR DESCRIPTION
...inspect output

In our migration from Ruby 1.8 to 1.9 we added a monkey patch to identify places we were using an implicit Array#to_s for concatenating all the elements.  This item popped up.  I don't believe that the existing implementation breaks anything, however I'm confident this was the intent of the author
# Monkey Patch

``` ruby
class Array
  def to_s
    raise "check me"
  end
end
```
