### PR TITLE
Fix a typo in OpenStruct documentation

### DIFF
--- a/lib/ostruct.rb
+++ b/lib/ostruct.rb
@@ -61,8 +61,8 @@
 #
 # == Implementation:
 #
-# An OpenStruct utilizes Ruby's method lookup structure to and find and define
-# the necessary methods for properties. This is accomplished through the method
+# An OpenStruct utilizes Ruby's method lookup structure to find and define the
+# necessary methods for properties. This is accomplished through the method
 # method_missing and define_method.
 #
 # This should be a consideration if there is a concern about the performance of


### PR DESCRIPTION
The commit removes a redundant "and".

It makes

> An OpenStruct utilizes Ruby's method lookup structure to and find and define the necessary methods for properties.

to be

> An OpenStruct utilizes Ruby's method lookup structure to find and define the necessary methods for properties.
