### PR TITLE
Call init_mkmf for main

### DIFF
--- a/lib/mkmf.rb
+++ b/lib/mkmf.rb
@@ -2542,6 +2542,7 @@ realclean: distclean
 end
 
 include MakeMakefile
+init_mkmf
 
 if not $extmk and /\A(extconf|makefile).rb\z/ =~ File.basename($0)
   END {mkmf_failed($0)}


### PR DESCRIPTION
When MakeMakefile is extended on itself there is a call to init_mkmf.
This method mainly setups various global variables, but it also sets @libdir_basename to default value "lib".

When MakeMakefile is included in main object there is no call to init_mkmf.
That's why @libdir_basename is not set for main object.

Therefore when we invoke mkmf methods on main object @libdir_basename is nil.
That leads to incorrect lib path when --with-XXX-dir is used.
