### PR TITLE
Fix comment typo; Remove used variables from Rinda test

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -5255,7 +5255,7 @@ VpCtoV(Real *a, const char *int_chr, size_t ni, const char *frac, size_t nf, con
         ef = eb / (SIGNED_VALUE)BASE_FIG;
         ef = eb - ef * (SIGNED_VALUE)BASE_FIG;
         if (ef) {
-            ++j;        /* Means to add one more preceeding zero */
+            ++j;        /* Means to add one more preceding zero */
             ++e;
         }
     }

--- a/test/rinda/test_rinda.rb
+++ b/test/rinda/test_rinda.rb
@@ -150,7 +150,7 @@ module TupleSpaceTestModule
     assert(!tmpl.match({"message"=>"Hello", "no_name"=>"Foo"}))
 
     assert_raise(Rinda::InvalidHashTupleKey) do
-      tmpl = Rinda::Template.new({:message=>String, "name"=>String})
+      Rinda::Template.new({:message=>String, "name"=>String})
     end
     tmpl = Rinda::Template.new({"name"=>String})
     assert_equal(1, tmpl.size)
@@ -262,7 +262,7 @@ module TupleSpaceTestModule
   end
 
   def test_core_01
-    5.times do |n|
+    5.times do
       @ts.write([:req, 2])
     end
 
@@ -297,7 +297,7 @@ module TupleSpaceTestModule
       s
     end
 
-    5.times do |n|
+    5.times do
       @ts.write([:req, 2])
     end
 
@@ -310,7 +310,7 @@ module TupleSpaceTestModule
     notify1 = @ts.notify(nil, [:req, Integer])
     notify2 = @ts.notify(nil, {"message"=>String, "name"=>String})
 
-    5.times do |n|
+    5.times do
       @ts.write([:req, 2])
     end
 


### PR DESCRIPTION
1. Fix comment typo
2. Remove used variables from Rinda test
