### PR TITLE
load.c: lightweight loaded features index

### DIFF
--- a/vm.c
+++ b/vm.c
@@ -1572,9 +1572,7 @@ rb_vm_mark(void *ptr)
 	if (vm->loading_table) {
 	    rb_mark_tbl(vm->loading_table);
 	}
-	if (vm->loaded_features_index) {
-	    rb_mark_tbl(vm->loaded_features_index);
-	}
+	RUBY_MARK_UNLESS_NULL(vm->loaded_features_index);
 
 	rb_vm_trace_mark_event_hooks(&vm->event_hooks);
 

--- a/vm_core.h
+++ b/vm_core.h
@@ -367,7 +367,7 @@ typedef struct rb_vm_struct {
     VALUE expanded_load_path;
     VALUE loaded_features;
     VALUE loaded_features_snapshot;
-    struct st_table *loaded_features_index;
+    VALUE loaded_features_index;
     struct st_table *loading_table;
 
     /* signal */


### PR DESCRIPTION
- load.c use lightweight structure for loaded features index
  since loaded_feature_path checks name of feature, there is no
  need to store feature string in an index - only hash value
  is stored. And used hash structure need only one memory chunk,
  so that there is no need for memory allocation per feature.
  Offsets in LOADED_FEATURES could be organized in many
  single linked lists inside of single allocated array, to
  avoid many memory allocations.
  And since there is no referred Ruby objects, there is not impact
  on GC.
