### PR TITLE
Mutex#synchronize doesn't yield block params.

### DIFF
--- a/test/ruby/test_thread.rb
+++ b/test/ruby/test_thread.rb
@@ -120,6 +120,12 @@ class TestThread < Test::Unit::TestCase
     assert_equal(max * max * max, r)
   end
 
+  def test_mutex_synchronize_yields_no_block_params
+    Mutex.new.synchronize do |*params|
+      assert_equal([], params)
+    end
+  end
+
   def test_local_barrier
     dir = File.dirname(__FILE__)
     lbtest = File.join(dir, "lbtest.rb")

--- a/thread.c
+++ b/thread.c
@@ -4567,7 +4567,7 @@ rb_mutex_synchronize_m(VALUE self, VALUE args)
 	rb_raise(rb_eThreadError, "must be called with a block");
     }
 
-    return rb_mutex_synchronize(self, rb_yield, Qnil);
+    return rb_mutex_synchronize(self, rb_yield, Qundef);
 }
 
 void rb_mutex_allow_trap(VALUE self, int val)


### PR DESCRIPTION
This fixes [Bug #8097].

See http://bugs.ruby-lang.org/issues/8097
