### PR TITLE
Document the default Net timeout values

### DIFF
--- a/lib/net/ftp.rb
+++ b/lib/net/ftp.rb
@@ -97,13 +97,13 @@ module Net
     # Number of seconds to wait for the connection to open. Any number
     # may be used, including Floats for fractional seconds. If the FTP
     # object cannot open a connection in this many seconds, it raises a
-    # Net::OpenTimeout exception.
+    # Net::OpenTimeout exception. The default value is +nil+.
     attr_accessor :open_timeout
 
     # Number of seconds to wait for one block to be read (via one read(2)
     # call). Any number may be used, including Floats for fractional
     # seconds. If the FTP object cannot read data in this many seconds,
-    # it raises a TimeoutError exception.
+    # it raises a TimeoutError exception. The default value is 60 seconds.
     attr_reader :read_timeout
 
     # Setter for the read_timeout attribute.

--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -701,13 +701,13 @@ module Net   #:nodoc:
     # Number of seconds to wait for the connection to open. Any number
     # may be used, including Floats for fractional seconds. If the HTTP
     # object cannot open a connection in this many seconds, it raises a
-    # Net::OpenTimeout exception.
+    # Net::OpenTimeout exception. The default value is +nil+.
     attr_accessor :open_timeout
 
     # Number of seconds to wait for one block to be read (via one read(2)
     # call). Any number may be used, including Floats for fractional
     # seconds. If the HTTP object cannot read data in this many seconds,
-    # it raises a Net::ReadTimeout exception.
+    # it raises a Net::ReadTimeout exception. The default value is 60 seconds.
     attr_reader :read_timeout
 
     # Setter for the read_timeout attribute.
@@ -716,8 +716,9 @@ module Net   #:nodoc:
       @read_timeout = sec
     end
 
-    # Seconds to wait for 100 Continue response.  If the HTTP object does not
-    # receive a response in this many seconds it sends the request body.
+    # Seconds to wait for 100 Continue response. If the HTTP object does not
+    # receive a response in this many seconds it sends the request body. The
+    # default value is +nil+.
     attr_reader :continue_timeout
 
     # Setter for the continue_timeout attribute.

--- a/lib/net/pop.rb
+++ b/lib/net/pop.rb
@@ -496,12 +496,12 @@ module Net
 
     # Seconds to wait until a connection is opened.
     # If the POP3 object cannot open a connection within this time,
-    # it raises a Net::OpenTimeout exception.
+    # it raises a Net::OpenTimeout exception. The default value is 30 seconds.
     attr_accessor :open_timeout
 
     # Seconds to wait until reading one block (by one read(1) call).
     # If the POP3 object cannot complete a read() within this time,
-    # it raises a Net::ReadTimeout exception.
+    # it raises a Net::ReadTimeout exception. The default value is 60 seconds.
     attr_reader :read_timeout
 
     # Set the read timeout.

--- a/lib/net/smtp.rb
+++ b/lib/net/smtp.rb
@@ -362,12 +362,12 @@ module Net
 
     # Seconds to wait while attempting to open a connection.
     # If the connection cannot be opened within this time, a
-    # Net::OpenTimeout is raised.
+    # Net::OpenTimeout is raised. The default value is 30 seconds.
     attr_accessor :open_timeout
 
     # Seconds to wait while reading one block (by one read(2) call).
     # If the read(2) call does not complete within this time, a
-    # Net::ReadTimeout is raised.
+    # Net::ReadTimeout is raised. The default value is 60 seconds.
     attr_reader :read_timeout
 
     # Set the number of seconds to wait until timing-out a read(2)


### PR DESCRIPTION
Currently there is no documentation of the default timeout values in the Net libraries.

For example, Net:HTTP has a default [open_timeout](http://ruby-doc.org/stdlib-2.0/libdoc/net/http/rdoc/Net/HTTP.html#open_timeout-attribute-method) of nil (i.e. never timeout) and a [read_timeout](http://ruby-doc.org/stdlib-2.0/libdoc/net/http/rdoc/Net/HTTP.html#read_timeout-attribute-method) of 60 seconds.

This patch adds the documentation for the defaults of all the timeout options in Net::FTP, Net:HTTP, Net::POP and Net::SMTP.

If this patch is accepted I can backport it to the Ruby 1.9 branch.
