### PR TITLE
Document Timeout::timeout 0 and nil argument behavior

### DIFF
--- a/lib/timeout.rb
+++ b/lib/timeout.rb
@@ -33,11 +33,12 @@ module Timeout
   CALLER_OFFSET = ((c = caller[0]) && THIS_FILE =~ c) ? 1 : 0
   # :startdoc:
 
-  # Perform an operation in a block, timing it out if it takes longer
-  # than +sec+ seconds to complete.
+  # Perform an operation in a block, raising an error if it takes longer than
+  # +sec+ seconds to complete.
   #
   # +sec+:: Number of seconds to wait for the block to terminate. Any number
-  #         may be used, including Floats to specify fractional seconds.
+  #         may be used, including Floats to specify fractional seconds. A
+  #         value of 0 or +nil+ will execute the block without any timeout.
   # +klass+:: Exception Class to raise if the block fails to terminate
   #           in +sec+ seconds.  Omitting will use the default, Timeout::Error
   #


### PR DESCRIPTION
Many parts of Ruby accept timeout values which are passed to `Timeout::timeout`. This raises questions about timeout's behaviour with certain types of input, such as `0` and `nil`.

This patches adds documentation for the behaviour timeout when given a `0` or `nil` argument.

If this patch is accepted I can backport it to the Ruby 1.9 branch.
