### PR TITLE
Fix documentation syntax error

### DIFF
--- a/ext/zlib/zlib.c
+++ b/ext/zlib/zlib.c
@@ -1855,7 +1855,7 @@ rb_inflate_s_allocate(VALUE klass)
  *     begin
  *       open "uncompressed.file", "w+" do |uncompressed_io|
  *         uncompressed_io << zi.inflate(compressed_io.read)
- *       }
+ *       end
  *     ensure
  *       zi.close
  *     end


### PR DESCRIPTION
Hello,

Just a little pull request for a syntax error fix in the Zlib documentation.

Have a nice day.
