### PR TITLE
Fixed syntax in curses example

### DIFF
--- a/ext/curses/hello.rb
+++ b/ext/curses/hello.rb
@@ -7,7 +7,7 @@ def show_message(message)
   width = message.length + 6
   win = Window.new(5, width,
 		   (lines - 5) / 2, (cols - width) / 2)
-  win.box(?|, ?-)
+  win.box('|', '-')
   win.setpos(2, 3)
   win.addstr(message)
   win.refresh


### PR DESCRIPTION
This file is purely for include in rdoc, 
but rdoc fails to properly escape the single character string.
This fix allows copy/paste directly from the docs:
http://www.ruby-doc.org/stdlib-2.0/libdoc/curses/rdoc/Curses.html
