### PR TITLE
hash.c: Add traverse for clean nested access

### DIFF
--- a/test/ruby/test_hash.rb
+++ b/test/ruby/test_hash.rb
@@ -979,6 +979,17 @@ class TestHash < Test::Unit::TestCase
     end
   end
 
+  def test_traverse
+    hash = { :l1 => { :l2 => { :l3 => 100 } } }
+    assert_raise(ArgumentError) { hash.traverse }
+    assert_nothing_raised { hash.traverse 'gumby' }
+    assert_equal(nil, hash.traverse('nonexistent'))
+    assert_equal({ :l2 => { :l3 => 100 } }, hash.traverse(:l1))
+    assert_equal('gumbygumby', hash.traverse('gumby') {|k| k * 2 })
+    assert_equal(100, hash.traverse(:l1, :l2, :l3))
+    assert_equal(nil, hash.traverse(:l1, :l2, :l3, :l4))
+  end
+
   class TestSubHash < TestHash
     class SubHash < Hash
     end


### PR DESCRIPTION
Traverses the given levels of a hash and returns the value associated with the
last key provided.  Allows for concise access for deeply nested hashes - often encountered with dealing with external restful apis.

```
hash = { level1: { level2: { level3: 3 } } }
hash.traverse :level1, :level2, :level3 #=> 3
```

Also supports a default value block if the value is nil or the key is
not found.

```
hash.traverse(:level1, :level2, :non_existent_key) { 5 } #=> 5
```

I'm aware that the probability of getting a feature accepted via PR is slim, but this is something I've built into my rubies for a while and use often so it seemed worth the attempt.
