### PR TITLE
no_proxy with whitespaces and leading dots.

### DIFF
--- a/lib/uri/generic.rb
+++ b/lib/uri/generic.rb
@@ -1659,7 +1659,8 @@ module URI
         proxy_uri = URI.parse(proxy_uri)
         name = 'no_proxy'
         if no_proxy = ENV[name] || ENV[name.upcase]
-          no_proxy.scan(/([^:,]*)(?::(\d+))?/) {|host, port|
+          no_proxy.scan(/([^:,;\s]+)(?::(\d+))?/) {|host, port|
+            host.slice!(0,1) if host[0] == '.'
             if /(\A|\.)#{Regexp.quote host}\z/i =~ self.host &&
                (!port || self.port == port.to_i)
               proxy_uri = nil


### PR DESCRIPTION
The previous implementation wouldn't allow for white-spaces nor a leading dot
in the no_proxy list. The latter is described in the wget documentation as a valid case.

By being more strict on the characters, which are counted to a domainname,
we allow for white-spaces.
Also, a possible leading dot will be handled gracefully.
