### PR TITLE
Replace use of obsolete variable `last-command-char`

### DIFF
--- a/misc/ruby-mode.el
+++ b/misc/ruby-mode.el
@@ -874,7 +874,7 @@ Also ignores spaces after parenthesis when 'space."
 
 (defun ruby-electric-brace (arg)
   (interactive "P")
-  (insert-char last-command-char 1)
+  (insert-char last-command-event 1)
   (ruby-indent-line t)
   (delete-char -1)
   (self-insert-command (prefix-numeric-value arg)))


### PR DESCRIPTION
The variable was an alias of `last-command-event` but has been removed in Emacs 24.3.

The same thing has already been fixed in ruby-electric.el: https://github.com/ruby/ruby/pull/198
