### PR TITLE
Fix typo in compar.c

### DIFF
--- a/compar.c
+++ b/compar.c
@@ -76,7 +76,7 @@ cmp_failed(void)
  *  _obj_ and _other_ are the same object.
  *
  *  Even if _obj_ <=> _other_ raised an exception, the exception
- *  is ignoread and returns false.
+ *  is ignored and returns false.
  */
 
 static VALUE


### PR DESCRIPTION
The word "ignored" was misspelt in the original.
