### PR TITLE
alias MatchData#captures to #to_ary

### DIFF
--- a/re.c
+++ b/re.c
@@ -3599,6 +3599,7 @@ Init_Regexp(void)
     rb_define_method(rb_cMatch, "to_a", match_to_a, 0);
     rb_define_method(rb_cMatch, "[]", match_aref, -1);
     rb_define_method(rb_cMatch, "captures", match_captures, 0);
+    rb_define_alias(rb_cMatch, "to_ary", "captures");
     rb_define_method(rb_cMatch, "values_at", match_values_at, -1);
     rb_define_method(rb_cMatch, "pre_match", rb_reg_match_pre, 0);
     rb_define_method(rb_cMatch, "post_match", rb_reg_match_post, 0);


### PR DESCRIPTION
Currently, you can get something out of `MatchData` like this:

``` ruby
m = "2_apples".match /(\d+)_(apple|orange)s?/
count, thing = m[1], m[2]
# or
_, count, thing = "2_apples".match(/(\d+)_(apple|orange)s?/).to_a
# or
count, thing = "2_apples".match(/(\d+)_(apple|orange)s?/).captures
```

However, this extra `#to_a` or `#captures` that you have to add makes things slightly more verbose.

With this PR, it would be possible to do the following:

``` ruby
count, thing = "2_apples".match /(\d+)_(apple|orange)s?/
```

Which looks a bit cleaner and nicer.

I am unsure if we can get it into 1.9 but it would be still great to have it on 2.0.
