### PR TITLE
Clean up Forwardable documentation example

### DIFF
--- a/lib/forwardable.rb
+++ b/lib/forwardable.rb
@@ -48,10 +48,10 @@
 #
 # You can even extend regular objects with Forwardable.
 #
-#   printer = String.new
-#   printer.extend Forwardable              # prepare object for delegation
-#   printer.def_delegator "STDOUT", "puts"  # add delegation for STDOUT.puts()
-#   printer.puts "Howdy!"
+#   my_hash = Hash.new
+#   my_hash.extend Forwardable              # prepare object for delegation
+#   my_hash.def_delegator "STDOUT", "puts"  # add delegation for STDOUT.puts()
+#   my_hash.puts "Howdy!"
 #
 # == Another example
 #


### PR DESCRIPTION
This is a fix for  http://bugs.ruby-lang.org/issues/8392

More specifically, the second example in Forwardable's documentation was a poor combination of two examples, and it did not make sense. This commit cleans it up.
