### PR TITLE
Documentation and Examples for BigMath ext module

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -3228,7 +3228,6 @@ Init_bigdecimal(void)
     rb_define_method(rb_cBigDecimal, "truncate",  BigDecimal_truncate, -1);
     rb_define_method(rb_cBigDecimal, "_dump", BigDecimal_dump, -1);
 
-    /* mathematical functions */
     rb_mBigMath = rb_define_module("BigMath");
     rb_define_singleton_method(rb_mBigMath, "exp", BigMath_s_exp, 2);
     rb_define_singleton_method(rb_mBigMath, "log", BigMath_s_log, 2);

--- a/ext/bigdecimal/lib/bigdecimal/math.rb
+++ b/ext/bigdecimal/lib/bigdecimal/math.rb
@@ -31,19 +31,29 @@ require 'bigdecimal'
 module BigMath
   module_function
 
-  # Computes the square root of x to the specified number of digits of
-  # precision.
+  # call-seq:
+  #   sqrt(BigDecimal, numeric) -> BigDecimal
   #
-  # BigDecimal.new('2').sqrt(16).to_s
-  #  -> "0.14142135623730950488016887242096975E1"
+  # Computes the square root of +x+ to the specified number of digits of
+  # precision, +prec+.
   #
-  def sqrt(x,prec)
+  #   BigMath::sqrt(BigDecimal.new('2'), 16).to_s
+  #   #=> "0.14142135623730950488016887242096975E1"
+  #
+  def sqrt(x, prec)
     x.sqrt(prec)
   end
 
-  # Computes the sine of x to the specified number of digits of precision.
+  # call-seq:
+  #   sin(BigDecimal, numeric) -> BigDecimal
   #
-  # If x is infinite or NaN, returns NaN.
+  # Computes the sine of +x+ to the specified number of digits of precision,
+  # +prec+.
+  # If +x+ is Infinity or NaN, returns NaN.
+  #
+  #   BigMath::sin(BigMath::PI(5)/4, 5).to_s
+  #   #=> "0.70710678118654752440082036563292800375E0"
+  #
   def sin(x, prec)
     raise ArgumentError, "Zero or negative precision for sin" if prec <= 0
     return BigDecimal("NaN") if x.infinite? || x.nan?
@@ -77,9 +87,17 @@ module BigMath
     neg ? -y : y
   end
 
-  # Computes the cosine of x to the specified number of digits of precision.
+  # call-seq:
+  #   cos(BigDecimal, numeric) -> BigDecimal
   #
-  # If x is infinite or NaN, returns NaN.
+  # Computes the cosine of +x+ to the specified number of digits of precision,
+  # +prec+.
+  #
+  # If +x+ is Infinity or NaN, returns NaN.
+  #
+  #   BigMath::cos(BigMath::PI(4), 16).to_s
+  #   #=> "-0.999999999999999999999999999999856613163740061349E0"
+  #
   def cos(x, prec)
     raise ArgumentError, "Zero or negative precision for cos" if prec <= 0
     return BigDecimal("NaN") if x.infinite? || x.nan?
@@ -113,9 +131,17 @@ module BigMath
     y
   end
 
-  # Computes the arctangent of x to the specified number of digits of precision.
+  # call-seq:
+  #   atan(BigDecimal, numeric) -> BigDecimal
   #
-  # If x is NaN, returns NaN.
+  # Computes the arctangent of +x+ to the specified number of digits of precision,
+  # +prec+
+  #
+  # If +x+ is NaN, returns NaN.
+  #
+  #   BigMath::atan(BigDecimal.new('-1'), 16).to_s
+  #   #=> "-0.785398163397448309615660845819878471907514682065E0"
+  #
   def atan(x, prec)
     raise ArgumentError, "Zero or negative precision for atan" if prec <= 0
     return BigDecimal("NaN") if x.nan?
@@ -144,7 +170,15 @@ module BigMath
     y
   end
 
-  # Computes the value of pi to the specified number of digits of precision.
+  # call-seq:
+  #   PI(numeric) -> BigDecimal
+  #
+  # Computes the value of pi to the specified number of digits of precision,
+  # +prec+.
+  #
+  #   BigMath::PI(10).to_s
+  #   #=> "0.3141592653589793238462643388813853786957412E1"
+  #
   def PI(prec)
     raise ArgumentError, "Zero or negative argument for PI" if prec <= 0
     n      = prec + BigDecimal.double_fig
@@ -181,8 +215,15 @@ module BigMath
     pi
   end
 
+  # call-seq:
+  #   E(numeric) -> BigDecimal
+  #
   # Computes e (the base of natural logarithms) to the specified number of
-  # digits of precision.
+  # digits of precision, +prec+
+  #
+  #   BigMath::E(10).to_s
+  #   #=> "0.271828182845904523536028752390026306410273E1"
+  #
   def E(prec)
     raise ArgumentError, "Zero or negative precision for E" if prec <= 0
     n    = prec + BigDecimal.double_fig


### PR DESCRIPTION
Pretty much what the commits say. I removed a line that should not be on BigMath's documentation (http://www.ruby-doc.org/stdlib-1.9.3/libdoc/bigdecimal/rdoc/BigMath.html) see top of that page,  'mathematical functions' should not be there. 

Also added a bunch of examples of usage and formatted method parameters on the existing doc.

Removed as BigMath is documented on lib/bigdecimal/math.rb
Documentation for BigMath module
