### PR TITLE
[Bug #8182] XMLRPC request fails with "Wrong size. Was 31564, should be 1501"

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,16 @@
+Thu May 16 18:09:03 2013 Duncan Mac-Vicar P. <dmacvicar@suse.de>
+
+	* lib/net/http/response.rb: transparently deflates the response body,
+	  removes the "content-encoding" response header, but does not adjust
+	  the "content-length" header accordingly.
+	  So, pass the context to the Inflater so that we count the
+	  uncompressed data for every chunk inflated, and then on finish we
+	  set the right Content-Length.
+	  [Bug #8182]
+
+	* test/net/http/test_httpresponse.rb: enhance testcase to check
+	  the right Content-Length
+
 Wed May 15 17:55:49 2013  Nobuyoshi Nakada  <nobu@ruby-lang.org>
 
 	* configure.in (RUBY_PLATFORM): move to config.h as needed by

--- a/test/net/http/test_httpresponse.rb
+++ b/test/net/http/test_httpresponse.rb
@@ -96,9 +96,11 @@ EOS
 
     if Net::HTTP::HAVE_ZLIB
       assert_equal nil, res['content-encoding']
+      assert_equal '5', res['content-length'], "Bug #8182"
       assert_equal 'hello', body
     else
       assert_equal 'deflate', res['content-encoding']
+      assert_equal '13', res['content-length'], "Bug #8182"
       assert_equal "x\x9C\xCBH\xCD\xC9\xC9\a\x00\x06,\x02\x15", body
     end
   end


### PR DESCRIPTION
- lib/net/http/response.rb: transparently deflates the response body,
  removes the "content-encoding" response header, but does not adjust
  the "content-length" header accordingly.
  So, pass the context to the Inflater so that we count the
  uncompressed data for every chunk inflated, and then on finish we
  set the right Content-Length.
  [Bug #8182]
- test/net/http/test_httpresponse.rb: enhance testcase to check
  the right Content-Length
