### PR TITLE
webrick show local filesystem charset bug

### DIFF
--- a/lib/webrick/htmlutils.rb
+++ b/lib/webrick/htmlutils.rb
@@ -15,12 +15,12 @@ module WEBrick
     # Escapes &, ", > and < in +string+
 
     def escape(string)
-      str = string ? string.dup : ""
+      str = string ? string.b.dup : "".b
       str.gsub!(/&/n, '&amp;')
       str.gsub!(/\"/n, '&quot;')
       str.gsub!(/>/n, '&gt;')
       str.gsub!(/</n, '&lt;')
-      str
+      str.force_encoding(Encoding.default_external)
     end
     module_function :escape
 

--- a/lib/webrick/httpservlet/filehandler.rb
+++ b/lib/webrick/httpservlet/filehandler.rb
@@ -463,7 +463,7 @@ module WEBrick
             dname = name
           end
           s =  " <A HREF=\"#{HTTPUtils::escape(name)}\">#{HTMLUtils::escape(dname)}</A>"
-          s << " " * (30 - dname.bytesize)
+          s << " " * (30 - dname.bytesize) rescue nil
           s << (time ? time.strftime("%Y/%m/%d %H:%M      ") : " " * 22)
           s << (size >= 0 ? size.to_s : "-") << "\n"
           res.body << s

--- a/lib/webrick/httputils.rb
+++ b/lib/webrick/httputils.rb
@@ -452,14 +452,14 @@ module WEBrick
     # Escapes HTTP reserved and unwise characters in +str+
 
     def escape(str)
-      _escape(str, UNESCAPED)
+      _escape(str.b, UNESCAPED).force_encoding(Encoding.default_external)
     end
 
     ##
     # Unescapes HTTP reserved and unwise characters in +str+
 
     def unescape(str)
-      _unescape(str, ESCAPED)
+      _unescape(str.b, ESCAPED).force_encoding(Encoding.default_external)
     end
 
     ##


### PR DESCRIPTION
```
use ruby -run -e httpd .
```

run a webrick http server, can not show no 8bit-ascii directory/file name.

this patch can fix this problem, but not more other test.

```
modified:   webrick/htmlutils.rb
modified:   webrick/httpservlet/filehandler.rb
modified:   webrick/httputils.rb
```

ruby issue

```
https://bugs.ruby-lang.org/issues/8425
```
