### PR TITLE
Fix lowercase module names

### DIFF
--- a/ext/io/console/console.c
+++ b/ext/io/console/console.c
@@ -803,7 +803,7 @@ InitVM_console(void)
     rb_define_method(rb_cIO, "ioflush", console_ioflush, 0);
     rb_define_singleton_method(rb_cIO, "console", console_dev, 0);
     {
-	VALUE mReadable = rb_define_module_under(rb_cIO, "readable");
+	VALUE mReadable = rb_define_module_under(rb_cIO, "Readable");
 	rb_define_method(mReadable, "getch", io_getch, -1);
     }
 }

--- a/ext/stringio/stringio.c
+++ b/ext/stringio/stringio.c
@@ -1536,7 +1536,7 @@ Init_stringio()
     rb_define_method(StringIO, "set_encoding", strio_set_encoding, -1);
 
     {
-	VALUE mReadable = rb_define_module_under(rb_cIO, "readable");
+	VALUE mReadable = rb_define_module_under(rb_cIO, "Readable");
 	rb_define_method(mReadable, "readchar", strio_readchar, 0);
 	rb_define_method(mReadable, "readbyte", strio_readbyte, 0);
 	rb_define_method(mReadable, "readline", strio_readline, -1);
@@ -1546,7 +1546,7 @@ Init_stringio()
 	rb_include_module(StringIO, mReadable);
     }
     {
-	VALUE mWritable = rb_define_module_under(rb_cIO, "writable");
+	VALUE mWritable = rb_define_module_under(rb_cIO, "Writable");
 	rb_define_method(mWritable, "<<", strio_addstr, 1);
 	rb_define_method(mWritable, "print", strio_print, -1);
 	rb_define_method(mWritable, "printf", strio_printf, -1);


### PR DESCRIPTION
A couple of C-exts (stringio and io/console) define modules with lowercase
names. This fixes it, given that in Ruby constants must be capitalized.
