### PR TITLE
Loading a key example contains a filename that does not seem to match the intended output

### DIFF
--- a/ext/openssl/ossl.c
+++ b/ext/openssl/ossl.c
@@ -504,7 +504,7 @@ ossl_fips_mode_set(VALUE self, VALUE enabled)
  *
  * A key can also be loaded from a file.
  *
- *   key2 = OpenSSL::PKey::RSA.new File.read 'private_key.pem'
+ *   key2 = OpenSSL::PKey::RSA.new File.read 'public_key.pem'
  *   key2.public? # => true
  *
  * or


### PR DESCRIPTION
In documentation, if you're constructing a Key class from a file named `private_key.pem`, it's probably going to not return true on #public? .
