### PR TITLE
fix FileUtils.mkdir('/')

### DIFF
--- a/lib/fileutils.rb
+++ b/lib/fileutils.rb
@@ -154,6 +154,11 @@ module FileUtils
   end
   module_function :uptodate?
 
+  def remove_tailing_slash(dir)
+    dir == '/' ? dir : dir.chomp(?/)
+  end
+  private_module_function :remove_tailing_slash
+
   #
   # Options: mode noop verbose
   #
@@ -200,7 +205,7 @@ module FileUtils
     fu_output_message "mkdir -p #{options[:mode] ? ('-m %03o ' % options[:mode]) : ''}#{list.join ' '}" if options[:verbose]
     return *list if options[:noop]
 
-    list.map {|path| path.chomp(?/) }.each do |path|
+    list.map {|path| remove_tailing_slash(path)}.each do |path|
       # optimize for the most common case
       begin
         fu_mkdir path, options[:mode]
@@ -237,7 +242,7 @@ module FileUtils
   OPT_TABLE['makedirs'] = [:mode, :noop, :verbose]
 
   def fu_mkdir(path, mode)   #:nodoc:
-    path = path.chomp(?/)
+    path = remove_tailing_slash(path)
     if mode
       Dir.mkdir path, mode
       File.chmod mode, path

--- a/test/fileutils/test_fileutils.rb
+++ b/test/fileutils/test_fileutils.rb
@@ -758,6 +758,10 @@ class TestFileUtils
     assert_directory 'tmp/tmp'
     assert_equal 0700, (File.stat('tmp/tmp').mode & 0777) if have_file_perm?
     Dir.rmdir 'tmp/tmp'
+
+    assert_raise(Errno::EISDIR) {
+      mkdir '/'
+    }
   end
 
   def test_mkdir_file_perm
@@ -831,6 +835,8 @@ class TestFileUtils
     # (rm(1) try to chdir to parent directory, it fails to remove directory.)
     Dir.rmdir 'tmp/tmp'
     Dir.rmdir 'tmp'
+
+    mkdir_p '/'
   end
 
   def test_mkdir_p_file_perm


### PR DESCRIPTION
FileUtils.mkdir and mkdir_p can't handle root directory, so I fixed them.

```
$ ruby -rfileutils -e 'FileUtils.mkdir("/")'
/Users/komamitsu/.rbenv/versions/1.9.3-p392/lib/ruby/1.9.1/fileutils.rb:247:in `mkdir': No such file or directory -  (Errno::ENOENT)
    from /Users/komamitsu/.rbenv/versions/1.9.3-p392/lib/ruby/1.9.1/fileutils.rb:247:in `fu_mkdir'
    from /Users/komamitsu/.rbenv/versions/1.9.3-p392/lib/ruby/1.9.1/fileutils.rb:176:in `block in mkdir'
    from /Users/komamitsu/.rbenv/versions/1.9.3-p392/lib/ruby/1.9.1/fileutils.rb:175:in `each'
    from /Users/komamitsu/.rbenv/versions/1.9.3-p392/lib/ruby/1.9.1/fileutils.rb:175:in `mkdir'
    from -e:1:in `<main>'
$ ruby -rfileutils -e 'FileUtils.mkdir_p("/")'
/Users/komamitsu/.rbenv/versions/1.9.3-p392/lib/ruby/1.9.1/fileutils.rb:247:in `mkdir': No such file or directory -  (Errno::ENOENT)
    from /Users/komamitsu/.rbenv/versions/1.9.3-p392/lib/ruby/1.9.1/fileutils.rb:247:in `fu_mkdir'
    from /Users/komamitsu/.rbenv/versions/1.9.3-p392/lib/ruby/1.9.1/fileutils.rb:221:in `block (2 levels) in mkdir_p'
    from /Users/komamitsu/.rbenv/versions/1.9.3-p392/lib/ruby/1.9.1/fileutils.rb:219:in `reverse_each'
    from /Users/komamitsu/.rbenv/versions/1.9.3-p392/lib/ruby/1.9.1/fileutils.rb:219:in `block in mkdir_p'
    from /Users/komamitsu/.rbenv/versions/1.9.3-p392/lib/ruby/1.9.1/fileutils.rb:205:in `each'
    from /Users/komamitsu/.rbenv/versions/1.9.3-p392/lib/ruby/1.9.1/fileutils.rb:205:in `mkdir_p'
    from -e:1:in `<main>'
```
