### PR TITLE
Utilize more idiomatic naming conventions for Socket class methods

### DIFF
--- a/ext/socket/lib/socket.rb
+++ b/ext/socket/lib/socket.rb
@@ -271,6 +271,7 @@ class Socket < BasicSocket
     alias :get_service_by_name :getservbyname
     alias :get_service_by_port :getservbyport
     alias :get_address_info :getaddrinfo
+    alias :get_name_info :getnameinfo
   end
 
   def ipv6only!


### PR DESCRIPTION
The current names of methods like Socket.gethostname are not very idiomatic of Ruby. In order to maintain backwards compatibility we decided to alias to the more idiomatic names.
## 

@adkron
@zph 
