### PR TITLE
Fix Float#to_d behaviour

### DIFF
--- a/ext/bigdecimal/lib/bigdecimal/util.rb
+++ b/ext/bigdecimal/lib/bigdecimal/util.rb
@@ -28,7 +28,7 @@ class Float < Numeric
   #     # => #<BigDecimal:1dc69e0,'0.5E0',9(18)>
   #
   def to_d(precision=nil)
-    BigDecimal(self, precision || Float::DIG+1)
+    BigDecimal(self, precision || Float::DIG)
   end
 end
 

--- a/test/bigdecimal/test_bigdecimal_util.rb
+++ b/test/bigdecimal/test_bigdecimal_util.rb
@@ -14,9 +14,10 @@ class TestBigDecimalUtil < Test::Unit::TestCase
   end
 
   def test_Float_to_d_without_precision
-    delta = 1.0/10**(Float::DIG + 1)
-    assert_in_delta(BigDecimal(0.5, Float::DIG+1), 0.5.to_d, delta)
-    assert_in_delta(BigDecimal(355.0/113.0, Float::DIG+1), (355.0/113.0).to_d, delta)
+    delta = 1.0/10**(Float::DIG)
+    assert_in_delta(BigDecimal(0.5, Float::DIG), 0.5.to_d, delta)
+    assert_in_delta(BigDecimal(355.0/113.0, Float::DIG), (355.0/113.0).to_d, delta)
+    assert_equal(9.05.to_d.to_s('F'), "9.05")
   end
 
   def test_Float_to_d_with_precision


### PR DESCRIPTION
Currently

``` ruby

9.05.to_d.to_s('F') => "9.050000000000001"

```

which adds the extra '1'
This patch tries to fix this behaviour and associated tests
