### PR TITLE
Fix incorrect array.c concat documentation

### DIFF
--- a/array.c
+++ b/array.c
@@ -3357,8 +3357,8 @@ rb_ary_fill(int argc, VALUE *argv, VALUE ary)
  *
  *     [ 1, 2, 3 ] + [ 4, 5 ]    #=> [ 1, 2, 3, 4, 5 ]
  *     a = [ "a", "b", "c" ]
- *     a + [ "d", "e", "f" ]
- *     a                         #=> [ "a", "b", "c", "d", "e", "f" ]
+ *     c = a + [ "d", "e", "f" ]
+ *     c                         #=> [ "a", "b", "c", "d", "e", "f" ]
  *
  *  See also Array#concat.
  */


### PR DESCRIPTION
The array concatenation example is incorrect. Concatenation returns a new array, it does not concatenate in place as the example suggests.

In the current documentation, `a` would still be `["a", "b", "c"]`, not `["a", "b", "c", "d", "e", "f"]`.
