### PR TITLE
date_parse.c: missing wday

### DIFF
--- a/ext/date/date_parse.c
+++ b/ext/date/date_parse.c
@@ -2848,7 +2848,9 @@ rfc2822_cb(VALUE m, VALUE hash)
 	    s[i] = rb_reg_nth_match(i, m);
     }
 
-    set_hash("wday", INT2FIX(day_num(s[1])));
+    if (!NIL_P(s[1])) {
+	set_hash("wday", INT2FIX(day_num(s[1])));
+    }
     set_hash("mday", str2num(s[2]));
     set_hash("mon", INT2FIX(mon_num(s[3])));
     y = str2num(s[4]);

--- a/test/date/test_date_parse.rb
+++ b/test/date/test_date_parse.rb
@@ -1053,8 +1053,14 @@ class TestDateParse < Test::Unit::TestCase
     d = Date.rfc2822('Sat, 3 Feb 2001 04:05:06 +0700', Date::ITALY + 10)
     assert_equal(Date.new(2001,2,3), d)
     assert_equal(Date::ITALY + 10, d.start)
+    d = Date.rfc2822('3 Feb 2001 04:05:06 +0700', Date::ITALY + 10)
+    assert_equal(Date.new(2001,2,3), d)
+    assert_equal(Date::ITALY + 10, d.start)
 
     d = DateTime.rfc2822('Sat, 3 Feb 2001 04:05:06 +0700', Date::ITALY + 10)
+    assert_equal(DateTime.new(2001,2,3,4,5,6,'+07:00'), d)
+    assert_equal(Date::ITALY + 10, d.start)
+    d = DateTime.rfc2822('3 Feb 2001 04:05:06 +0700', Date::ITALY + 10)
     assert_equal(DateTime.new(2001,2,3,4,5,6,'+07:00'), d)
     assert_equal(Date::ITALY + 10, d.start)
   end


### PR DESCRIPTION
- ext/date/date_parse.c (rfc2822_cb): check if wday is given, since it
  can be omitted.
