### PR TITLE
Fix DESTDIR related 'make' issue when DESTDIR specified

### DIFF
--- a/lib/rubygems/ext/builder.rb
+++ b/lib/rubygems/ext/builder.rb
@@ -11,7 +11,7 @@ class Gem::Ext::Builder
     $1.downcase
   end
 
-  def self.make(dest_path, results)
+  def self.make(dest_path, results, disable_destdir = false)
     unless File.exist? 'Makefile' then
       raise Gem::InstallError, "Makefile not found:\n\n#{results.join "\n"}"
     end
@@ -23,7 +23,13 @@ class Gem::Ext::Builder
       make_program = (/mswin/ =~ RUBY_PLATFORM) ? 'nmake' : 'make'
     end
 
-    ['', ' install'].each do |target|
+    targets = if disable_destdir
+                [' DESTDIR=', ' install DESTDIR=']
+              else
+                ['', ' install']
+              end
+
+    targets.each do |target|
       cmd = "#{make_program}#{target}"
       run(cmd, results, "make#{target}")
     end

--- a/lib/rubygems/ext/ext_conf_builder.rb
+++ b/lib/rubygems/ext/ext_conf_builder.rb
@@ -38,7 +38,7 @@ class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
 
         ENV["DESTDIR"] = nil
 
-        make dest_path, results
+        make dest_path, results, true
 
         if tmp_dest
           FileEntry.new(tmp_dest).traverse do |ent|


### PR DESCRIPTION
`make` has an order which applies environment variable.
If we want to disable existence environment variable in Makefile,
then using make's argument is better.

I hit this issue when try to make [td-agent](https://github.com/treasure-data/td-agent) RPM package with Ruby 2.0 (this report seems related: https://bugzilla.redhat.com/show_bug.cgi?id=921650 ).
I don't know the better solution but this bug is critical for our RPM packaging.

And maybe, 2.1 has same bug.
