### PR TITLE
Bugfix for missing module method error in FileUtils#chmod

### DIFF
--- a/lib/fileutils.rb
+++ b/lib/fileutils.rb
@@ -936,6 +936,7 @@ module FileUtils
   def mode_to_s(mode)  #:nodoc:
     mode.is_a?(String) ? mode : "%o" % mode
   end
+  private_module_function :mode_to_s
 
   #
   # Options: noop verbose


### PR DESCRIPTION
This should fix the following error when using FileUtils#chmod. Unfortunately I can't find any instructions on how to run the test suite, so I haven't put a test in for it yet. If you could point me in the right direction for that then I'll happily add one :)

```
[00:30:36] Creating deploy account...                                              

useradd --create-home --shell /bin/bash --groups adm deploy
mkdir -p /home/deploy/.ssh
setting up sudoers...
adding id_teleport.pub to authorized_keys...
/usr/local/lib/ruby/2.0.0/fileutils.rb:970:in `chmod': undefined method `mode_to_s' for File
Utils:Module (NoMethodError)
        from /tmp/_teleported/gem/teleport/util.rb:214:in `chmod'
        from /tmp/_teleported/gem/teleport/util.rb:123:in `mkdir'
        from /tmp/_teleported/gem/teleport/util.rb:130:in `mkdir_if_necessary'
        from /tmp/_teleported/gem/teleport/install.rb:189:in `_create_user'
        from /tmp/_teleported/gem/teleport/install.rb:40:in `block (2 levels) in initialize'
        from /tmp/_teleported/gem/teleport/install.rb:261:in `_with_callback'
        from /tmp/_teleported/gem/teleport/install.rb:39:in `block in initialize'
        from /tmp/_teleported/gem/teleport/install.rb:261:in `_with_callback'
        from /tmp/_teleported/gem/teleport/install.rb:36:in `initialize'
        from /tmp/_teleported/gem/teleport/main.rb:164:in `new'
        from /tmp/_teleported/gem/teleport/main.rb:164:in `install'
        from /tmp/_teleported/gem/teleport/main.rb:20:in `initialize'
        from -e:1:in `new'
        from -e:1:in `<main>'
[01:30:36] Failed!       
```
