### PR TITLE
modified XMLRPC::Parser faultCode to accept String along with Integer see comment below

### DIFF
--- a/lib/xmlrpc/parser.rb
+++ b/lib/xmlrpc/parser.rb
@@ -169,12 +169,12 @@ module XMLRPC # :nodoc:
     # Raises an Exception if the given +hash+ doesn't meet the requirements.
     # Those requirements being:
     # * 2 keys
-    # * <code>'faultCode'</code> key is an Integer
+    # * <code>'faultCode'</code> key is an Integer or a String
     # * <code>'faultString'</code> key is a String
     def self.fault(hash)
       if hash.kind_of? Hash and hash.size == 2 and
         hash.has_key? "faultCode" and hash.has_key? "faultString" and
-        hash["faultCode"].kind_of? Integer and hash["faultString"].kind_of? String
+        hash["faultCode"].kind_of? Integer or hash["faultCode"].kind_of? String and hash["faultString"].kind_of? String
 
         XMLRPC::FaultException.new(hash["faultCode"], hash["faultString"])
       else

--- a/test/xmlrpc/data/string_fault_code.xml
+++ b/test/xmlrpc/data/string_fault_code.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<methodResponse>
+    <fault>
+        <value><struct>
+            <member>
+                <name>faultCode</name>
+                <value>serverError</value>
+            </member>
+            <member>
+                <name>faultString</name>
+                <value>an error message</value>
+            </member>
+        </struct></value>
+    </fault>
+</methodResponse>
+

--- a/test/xmlrpc/test_parser.rb
+++ b/test/xmlrpc/test_parser.rb
@@ -24,6 +24,7 @@ module GenericParserTest
     @datetime_expected = XMLRPC::DateTime.new(2004, 11, 5, 1, 15, 23)
 
     @fault_doc = File.read(datafile('fault.xml'))
+    @string_fault_code_doc = File.read(datafile('string_fault_code.xml'))
   end
 
   # test parseMethodResponse --------------------------------------------------
@@ -56,14 +57,23 @@ module GenericParserTest
 
   # test fault ----------------------------------------------------------------
 
+  def helper_doc_fault(doc,code)
+    flag, fault = @p.parseMethodResponse(doc)
+    assert_equal(flag, false)
+    unless fault.is_a? XMLRPC::FaultException
+      assert(false, "must be an instance of class XMLRPC::FaultException")
+    end
+    assert_equal(fault.faultCode, code)
+    assert_equal(fault.faultString, "an error message")
+  end
+
   def test_fault
-    flag, fault = @p.parseMethodResponse(@fault_doc)
-     assert_equal(flag, false)
-     unless fault.is_a? XMLRPC::FaultException
-       assert(false, "must be an instance of class XMLRPC::FaultException")
-     end
-     assert_equal(fault.faultCode, 4)
-     assert_equal(fault.faultString, "an error message")
+    helper_doc_fault(@fault_doc,4)
+  end
+
+
+  def test_fault_code_document
+    helper_doc_fault(@string_fault_code_doc, "serverError")
   end
 
   def test_fault_message
@@ -71,6 +81,7 @@ module GenericParserTest
     assert_equal('an error message', fault.to_s)
     assert_equal('#<XMLRPC::FaultException: an error message>', fault.inspect)
   end
+
 end
 
 # create test class for each installed parser


### PR DESCRIPTION
XMLRPC specification never stated that faultCode must be a integer.
see http://xmlrpc.scripting.com/spec.html

The Python xmlrpclib accepts Strings and maybe other implementation does.
This proposal is a try to stay in conformity with the specification and compatible with other implementations
