### PR TITLE
Performance change: should only attempt unescaping if escape character may be present

### DIFF
--- a/lib/cgi/util.rb
+++ b/lib/cgi/util.rb
@@ -42,7 +42,8 @@ module CGI::Util
   #      # => "Usage: foo \"bar\" <baz>"
   def unescapeHTML(string)
     enc = string.encoding
-    if [Encoding::UTF_16BE, Encoding::UTF_16LE, Encoding::UTF_32BE, Encoding::UTF_32LE].include?(enc)
+    return string unless string.include? "&".encode(enc)
+    if enc != Encoding::UTF_8 && [Encoding::UTF_16BE, Encoding::UTF_16LE, Encoding::UTF_32BE, Encoding::UTF_32LE].include?(enc)
       return string.gsub(Regexp.new('&(apos|amp|quot|gt|lt|#[0-9]+|#x[0-9A-Fa-f]+);'.encode(enc))) do
         case $1.encode(Encoding::US_ASCII)
         when 'apos'                then "'".encode(enc)


### PR DESCRIPTION
Encoding changes from 1.8 to 1.9 has made calls to CGI::unescapeHTML more expensive, even if no escaping needs to be done. While a few calls will have negligible difference, unescaping each line of a large CSV file will cause the losses to stack up.

Benchmarking
```ruby
require 'cgi'
require 'benchmark'

Benchmark.bm(5) do |x|
  puts RUBY_VERSION
  string = CGI.escapeHTML("A") # => "A"
	x.report("CGI::unescapeHTML") do
    100_000.times do
      CGI.unescapeHTML(string)
    end
  end
end
```

1.8.7-p371

    user     system      total        real
    CGI::unescapeHTML  0.040000   0.000000   0.040000 (  0.041975)

1.9.3-p429 (with railsexpress patches and GC tuning)

    RUBY_GC_MALLOC_LIMIT=1000000000
    RUBY_FREE_MIN=500000
    RUBY_HEAP_MIN_SLOTS=40000

    user     system      total        real
    CGI::unescapeHTML  0.120000   0.010000   0.130000 (  0.127006)

    user     system      total        real
    CGI::unescapeHTML with performance change  0.060000   0.000000   0.060000 (  0.058035)