### PR TITLE
Module extended doc

### DIFF
--- a/object.c
+++ b/object.c
@@ -810,7 +810,7 @@ rb_obj_tap(VALUE obj)
  * Document-method: extended
  *
  * call-seq:
- *    extended( othermod )
+ *    extended(othermod)
  *
  * The equivalent of <tt>included</tt>, but for extended modules.
  *
@@ -829,7 +829,7 @@ rb_obj_tap(VALUE obj)
  * Document-method: included
  *
  * call-seq:
- *    included( othermod )
+ *    included(othermod)
  *
  * Callback invoked whenever the receiver is included in another
  * module or class. This should be used in preference to
@@ -851,7 +851,7 @@ rb_obj_tap(VALUE obj)
  * Document-method: prepended
  *
  * call-seq:
- *    prepended( othermod )
+ *    prepended(othermod)
  *
  * The equivalent of <tt>included</tt>, but for prepended modules.
  *


### PR DESCRIPTION
I added some documentation for the undocumented Module#extended.
In the second commit I also fixed up some parentheses placing as it seemed odd that some have white space around the parameter and some don't - I found without white space to be commoner so I went with that. 

Cheers and thanks for your work!
Tobi
