### PR TITLE
Fix wrong example output for reject example

### DIFF
--- a/array.c
+++ b/array.c
@@ -5425,7 +5425,7 @@ rb_ary_drop_while(VALUE ary)
  *
  *     arr = [1, 2, 3, 4, 5, 6]
  *     arr.select { |a| a > 3 }     #=> [4, 5, 6]
- *     arr.reject { |a| a < 3 }     #=> [4, 5, 6]
+ *     arr.reject { |a| a <= 3 }     #=> [4, 5, 6]
  *     arr.drop_while { |a| a < 4 } #=> [4, 5, 6]
  *     arr                          #=> [1, 2, 3, 4, 5, 6]
  *


### PR DESCRIPTION
Fixing a wrong example for Array#reject as noticed in the comments online.

I don't know what the original author intended but since all the other operations return [4, 5, 6] I changed it to <= instead of changing the result to [3, 4, 5, 6]

Thanks for your work on Ruby!
Tobi
