### PR TITLE
fixup stying of `Json#generate` parameter docs

### DIFF
--- a/ext/json/lib/json/common.rb
+++ b/ext/json/lib/json/common.rb
@@ -179,9 +179,10 @@ module JSON
   end
 
   # Generate a JSON document from the Ruby data structure _obj_ and return
-  # it. _state_ is * a JSON::State object,
+  # it. _state_ is
+  # * a JSON::State object,
   # * or a Hash like object (responding to to_hash),
-  # * an object convertible into a hash by a to_h method,
+  # * or an object convertible into a hash by a to_h method,
   # that is used as or to configure a State object.
   #
   # It defaults to a state object, that creates the shortest possible JSON text


### PR DESCRIPTION
I noticed that the first option for _state_ was not appearing as a bullet point and decided to correct that if possible.  If this is sufficient I'd love to see it merged.  If not, how can I improve this patch?
