### PR TITLE
correct the spelling of "usage" in a few files

### DIFF
--- a/sample/freq.rb
+++ b/sample/freq.rb
@@ -1,5 +1,5 @@
 # word occurrence listing
-# usege: ruby freq.rb file..
+# usage: ruby freq.rb file..
 freq = Hash.new(0)
 while line = gets()
   line.scan(/\w+/) do |word|

--- a/sample/occur.rb
+++ b/sample/occur.rb
@@ -1,5 +1,5 @@
 # word occurrence listing
-# usege: ruby occur.rb file..
+# usage: ruby occur.rb file..
 freq = Hash.new(0)
 while line = gets()
   for word in line.split(/\W+/)

--- a/sample/occur2.rb
+++ b/sample/occur2.rb
@@ -1,5 +1,5 @@
 # word occurrence listing
-# usege: ruby occur2.rb file..
+# usage: ruby occur2.rb file..
 freq = {}
 ARGF.each_line do |line|
   for word in line.split(/\W+/)


### PR DESCRIPTION
while perusing the documentation of many files in the Ruby trunk I noticed these apparent typos.  If the spelling was not intentional I would love to see this merged in.
