### PR TITLE
Fixing example in comments that raised an error

### DIFF
--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -671,7 +671,7 @@ module Net   #:nodoc:
     #
     # Sets an output stream for debugging.
     #
-    #   http = Net::HTTP.new
+    #   http = Net::HTTP.new(hostname)
     #   http.set_debug_output $stderr
     #   http.start { .... }
     #


### PR DESCRIPTION
There is a required first argument to HTTP.new. The example here was non-executable and would likely be confusing to anyone attempting to use it.
