### PR TITLE
Fix comment typo in OpenSSL::Digest

### DIFF
--- a/ext/openssl/lib/openssl/digest.rb
+++ b/ext/openssl/lib/openssl/digest.rb
@@ -31,7 +31,7 @@ module OpenSSL
     #
     # === Examples
     #
-    #   OpenSSL::Digest.digest("SHA256, "abc")
+    #   OpenSSL::Digest.digest("SHA256", "abc")
     #
     # which is equivalent to:
     #


### PR DESCRIPTION
Missing quote in an example code.
