### PR TITLE
Fix Object spaceship operator (<=>) doc to reflect that it uses ==, not ===

### DIFF
--- a/object.c
+++ b/object.c
@@ -1357,7 +1357,7 @@ rb_obj_not_match(VALUE obj1, VALUE obj2)
  *  call-seq:
  *     obj <=> other -> 0 or nil
  *
- *  Returns 0 if obj === other, otherwise nil.
+ *  Returns 0 if obj == other, otherwise nil.
  *
  *  The <=> is used by various methods to compare objects, for example
  *  Enumerable#sort, Enumerable#max etc.


### PR DESCRIPTION
The docs for Object#<=> say that it is implemented in terms of case equality (===), which I'm pretty sure is untrue.
