### PR TITLE
Add a missing line for rb_str_equal of string.c

### DIFF
--- a/string.c
+++ b/string.c
@@ -2312,6 +2312,7 @@ str_eql(const VALUE str1, const VALUE str2)
 	return Qtrue;
     return Qfalse;
 }
+
 /*
  *  call-seq:
  *     str == obj    -> true or false


### PR DESCRIPTION
The doc for `==` and `===` do not show up in the [Ruby Doc 2.0 String](http://ruby-doc.org/core-2.0/String.html#method-i-3D-3D), I think it's because there is a missing line.
