### PR TITLE
Net::HTTPS should use SSLContext's defaults

### DIFF
--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -697,7 +697,12 @@ module Net   #:nodoc:
     attr_accessor :cert_store
 
     # Sets the available ciphers.  See OpenSSL::SSL::SSLContext#ciphers=
-    attr_accessor :ciphers
+    attr_writer :ciphers
+
+    # Gets the available ciphers.  See OpenSSL::SSL::SSLContext#ciphers
+    def ciphers
+      @ciphers ||= OpenSSL::SSL::SSLContext::DEFAULT_PARAMS[:ciphers]
+    end
 
     # Sets an OpenSSL::PKey::RSA or OpenSSL::PKey::DSA object.
     # (This method is appeared in Michal Rokos's OpenSSL extension.)
@@ -707,7 +712,12 @@ module Net   #:nodoc:
     attr_accessor :ssl_timeout
 
     # Sets the SSL version.  See OpenSSL::SSL::SSLContext#ssl_version=
-    attr_accessor :ssl_version
+    attr_writer :ssl_version
+
+    # Gets the SSL version.  See OpenSSL::SSL::SSLContext#ssl_version
+    def ssl_version
+      @ssl_version ||= OpenSSL::SSL::SSLContext::DEFAULT_PARAMS[:ssl_version]
+    end
 
     # Sets the verify callback for the server certification verification.
     attr_accessor :verify_callback
@@ -719,7 +729,13 @@ module Net   #:nodoc:
     # SSL/TLS session.
     #
     # OpenSSL::SSL::VERIFY_NONE or OpenSSL::SSL::VERIFY_PEER are acceptable.
-    attr_accessor :verify_mode
+    attr_writer :verify_mode
+
+    # Gets the flags for server the certification verification at beginning of
+    # SSL/TLS session. See OpenSSL:SSL::SSLContext#verify_mode
+    def verify_mode
+      @verify_mode ||= OpenSSL::SSL::SSLContext::DEFAULT_PARAMS[:verify_mode]
+    end
 
     # Returns the X.509 certificates the server presented.
     def peer_cert


### PR DESCRIPTION
Passing `nil` into `SSLContext` for `ssl_version` causes
OpenSSL to use its internal default.  For OpenSSL 1.0.1 this is
`:TLSv1_2`.

I added the defaults for the `SSLContext` options too, while
I was at it.

I found this when compiling ruby-1.9.3-p448 with OpenSSL 1.0.1.  I couldn't get gems from a local gem-server running with apache2 (SSL enabled) on CentOS 6.
