### PR TITLE
WEBRick: Util.create_listeners doesn't make use of logger param

### DIFF
--- a/lib/webrick/server.rb
+++ b/lib/webrick/server.rb
@@ -129,7 +129,7 @@ module WEBrick
     # WEBrick::Utils::create_listeners for details.
 
     def listen(address, port)
-      @listeners += Utils::create_listeners(address, port, @logger)
+      @listeners += Utils::create_listeners(address, port)
     end
 
     ##

--- a/lib/webrick/ssl.rb
+++ b/lib/webrick/ssl.rb
@@ -149,7 +149,7 @@ module WEBrick
     # Updates +listen+ to enable SSL when the SSL configuration is active.
 
     def listen(address, port) # :nodoc:
-      listeners = Utils::create_listeners(address, port, @logger)
+      listeners = Utils::create_listeners(address, port)
       if @config[:SSLEnable]
         unless ssl_context
           @ssl_context = setup_ssl_context(@config)

--- a/lib/webrick/utils.rb
+++ b/lib/webrick/utils.rb
@@ -68,7 +68,7 @@ module WEBrick
     # Creates TCP server sockets bound to +address+:+port+ and returns them.
     #
     # It will create IPV4 and IPV6 sockets on all interfaces.
-    def create_listeners(address, port, logger=nil)
+    def create_listeners(address, port)
       unless port
         raise ArgumentError, "must specify port"
       end

--- a/test/webrick/test_utils.rb
+++ b/test/webrick/test_utils.rb
@@ -58,7 +58,11 @@ class TestWEBrickUtils < Test::Unit::TestCase
     do_test_timeout(WEBrick::Utils)
   end
 
-  #def test_timeout
-  #  do_test_timeout(Timeout)
-  #end
+  def test_create_listeners
+    listeners = WEBrick::Utils.create_listeners("127.0.0.1", "9999")
+    srv = listeners.first
+    assert_equal true, srv.is_a?(TCPServer)
+    assert_equal ["AF_INET", 9999, "127.0.0.1", "127.0.0.1"], srv.addr
+  end
+
 end


### PR DESCRIPTION
WEBRick: `Util.create_listeners` doesn't make use of logger param