### PR TITLE
fix documentation typo

### DIFF
--- a/sprintf.c
+++ b/sprintf.c
@@ -401,7 +401,7 @@ get_hash(volatile VALUE *hash, int argc, const VALUE *argv)
  *  For more complex formatting, Ruby supports a reference by name.
  *  %<name>s style uses format style, but %{name} style doesn't.
  *
- *  Exapmles:
+ *  Examples:
  *    sprintf("%<foo>d : %<bar>f", { :foo => 1, :bar => 2 })
  *      #=> 1 : 2.000000
  *    sprintf("%{foo}f", { :foo => 1 })


### PR DESCRIPTION
Exapmles -> Examples
