### PR TITLE
add Set() method to standard library to coerce objects into sets.

### DIFF
--- a/lib/set.rb
+++ b/lib/set.rb
@@ -494,6 +494,28 @@ class Set
 end
 
 #
+# The Set() method will create a new Set with the given argument
+# or will return the given argument if it is already a Set.
+#
+# == Example
+#
+#   require "set"
+#
+#   set = Set.new
+#   set << "new value"
+#
+#   other_set = Set(set)
+#   other_set.equal?(set) # => true
+#
+#   new_set = Set.new(set)
+#   new_set == set # => true
+#   new_set.equal?(set) # => false
+#
+def Set(possible_set)
+  possible_set.is_a?(Set) ? possible_set : Set.new(enum)
+end
+
+#
 # SortedSet implements a Set that guarantees that it's element are
 # yielded in sorted order (according to the return values of their
 # #<=> methods) when iterating over them.

--- a/test/test_set.rb
+++ b/test/test_set.rb
@@ -53,6 +53,14 @@ class TC_Set < Test::Unit::TestCase
     assert_equal([2,4,6], s.sort)
   end
 
+  def test_coerce
+    set1 = Set.new
+    set2 = Set(set1)
+    set3 = Set(nil)
+    assert set1.equal?(set2)
+    assert_instance_of(Set, set3)
+  end
+
   def test_clone
     set1 = Set.new
     set2 = set1.clone


### PR DESCRIPTION
Coerce an object to a set or return an existing set. Requested as a feature here http://bugs.ruby-lang.org/issues/8626
