### PR TITLE
Fix a typo in doc/regexp.rdoc (remove a backslash)

### DIFF
--- a/doc/regexp.rdoc
+++ b/doc/regexp.rdoc
@@ -611,7 +611,7 @@ The following patterns match instantly as you would expect:
 
     /(b|a)/ =~ s #=> 0
     /(b|a+)/ =~ s #=> 0
-    /(b|a+)*\/ =~ s #=> 0
+    /(b|a+)*/ =~ s #=> 0
 
 However, the following pattern takes appreciably longer:
 


### PR DESCRIPTION
Remove a backslash `\` in Line 614 of regexp.rdoc.

``` ruby
[1] pry(main)> s = 'a' * 25 + 'd' + 'a' * 4 + 'c'
=> "aaaaaaaaaaaaaaaaaaaaaaaaadaaaac"
[2] pry(main)> /(b|a)/ =~ s
=> 0
[3] pry(main)> /(b|a+)/ =~ s
=> 0
[4] pry(main)> /(b|a+)*/ =~ s
=> 0
```
