### PR TITLE
Reword ArgumentError message

### DIFF
--- a/bootstraptest/test_method.rb
+++ b/bootstraptest/test_method.rb
@@ -3,7 +3,7 @@ assert_equal '1',       'def m() 1 end; m()'
 assert_equal '1',       'def m(a) a end; m(1)'
 assert_equal '[1, 2]',  'def m(a,b) [a, b] end; m(1,2)'
 assert_equal '[1, 2, 3]', 'def m(a,b,c) [a, b, c] end; m(1,2,3)'
-assert_equal 'wrong number of arguments (1 for 0)', %q{
+assert_equal 'wrong number of arguments (1 instead of 0)', %q{
   def m; end
   begin
     m(1)
@@ -12,7 +12,7 @@ assert_equal 'wrong number of arguments (1 for 0)', %q{
   end
 }
 
-assert_equal 'wrong number of arguments (0 for 1)', %q{
+assert_equal 'wrong number of arguments (0 instead of 1)', %q{
   def m a; end
   begin
     m

--- a/error.c
+++ b/error.c
@@ -1431,7 +1431,7 @@ syserr_eqq(VALUE self, VALUE exc)
  *
  *  <em>raises the exception:</em>
  *
- *     ArgumentError: wrong number of arguments (2 for 1)
+ *     ArgumentError: wrong number of arguments (2 instead of 1)
  *
  *  Ex: passing an argument that is not acceptable:
  *

--- a/ext/fiddle/function.c
+++ b/ext/fiddle/function.c
@@ -120,7 +120,7 @@ function_call(int argc, VALUE argv[], VALUE self)
     cPointer = rb_const_get(mFiddle, rb_intern("Pointer"));
 
     if(argc != RARRAY_LENINT(types)) {
-	rb_raise(rb_eArgError, "wrong number of arguments (%d for %d)",
+	rb_raise(rb_eArgError, "wrong number of arguments (%d instead of %d)",
 		argc, RARRAY_LENINT(types));
     }
 

--- a/ext/openssl/lib/openssl/digest.rb
+++ b/ext/openssl/lib/openssl/digest.rb
@@ -46,7 +46,7 @@ module OpenSSL
         define_method(:initialize){|*data|
           if data.length > 1
             raise ArgumentError,
-              "wrong number of arguments (#{data.length} for 1)"
+              "wrong number of arguments (#{data.length} instead of 1)"
           end
           super(name, data.first)
         }

--- a/ext/ripper/tools/preproc.rb
+++ b/ext/ripper/tools/preproc.rb
@@ -21,7 +21,7 @@ def main
     exit false
   end
   unless ARGV.size == 1
-    abort "wrong number of arguments (#{ARGV.size} for 1)"
+    abort "wrong number of arguments (#{ARGV.size} instead of 1)"
   end
   out = ""
   File.open(ARGV[0]) {|f|

--- a/ext/socket/lib/socket.rb
+++ b/ext/socket/lib/socket.rb
@@ -298,7 +298,7 @@ class Socket < BasicSocket
   #
   def self.tcp(host, port, *rest) # :yield: socket
     opts = Hash === rest.last ? rest.pop : {}
-    raise ArgumentError, "wrong number of arguments (#{rest.length} for 2)" if 2 < rest.length
+    raise ArgumentError, "wrong number of arguments (#{rest.length} instead of 2)" if 2 < rest.length
     local_host, local_port = rest
     last_error = nil
     ret = nil

--- a/ext/stringio/stringio.c
+++ b/ext/stringio/stringio.c
@@ -1302,7 +1302,7 @@ strio_read(int argc, VALUE *argv, VALUE self)
 	}
 	break;
       default:
-	rb_raise(rb_eArgError, "wrong number of arguments (%d for 0)", argc);
+	rb_raise(rb_eArgError, "wrong number of arguments (%d instead of 0)", argc);
     }
     if (NIL_P(str)) {
 	str = strio_substr(ptr, ptr->pos, len);

--- a/ext/syslog/syslog.c
+++ b/ext/syslog/syslog.c
@@ -305,7 +305,7 @@ static VALUE mSyslog_log(int argc, VALUE *argv, VALUE self)
     VALUE pri;
 
     if (argc < 2) {
-        rb_raise(rb_eArgError, "wrong number of arguments (%d for 2+)", argc);
+        rb_raise(rb_eArgError, "wrong number of arguments (%d instead of 2+)", argc);
     }
 
     argc--;

--- a/ext/tk/tcltklib.c
+++ b/ext/tk/tcltklib.c
@@ -3413,13 +3413,13 @@ ip_ruby_eval(clientData, interp, argc, argv)
     if (argc != 2) {
 #if 0
         rb_raise(rb_eArgError,
-                 "wrong number of arguments (%d for 1)", argc - 1);
+                 "wrong number of arguments (%d instead of 1)", argc - 1);
 #else
         char buf[sizeof(int)*8 + 1];
         Tcl_ResetResult(interp);
         sprintf(buf, "%d", argc-1);
         Tcl_AppendResult(interp, "wrong number of arguments (",
-                         buf, " for 1)", (char *)NULL);
+                         buf, " instead of 1)", (char *)NULL);
         rbtk_pending_exception = rb_exc_new2(rb_eArgError,
                                              Tcl_GetStringResult(interp));
         return TCL_ERROR;

--- a/ext/win32ole/win32ole.c
+++ b/ext/win32ole/win32ole.c
@@ -5201,7 +5201,7 @@ foletypelib_initialize(VALUE self, VALUE args)
 
     len = RARRAY_LEN(args);
     if (len < 1 || len > 3) {
-        rb_raise(rb_eArgError, "wrong number of arguments (%d for 1..3)", len);
+        rb_raise(rb_eArgError, "wrong number of arguments (%d instead of 1..3)", len);
     }
 
     typelib = rb_ary_entry(args, 0);
@@ -8746,7 +8746,7 @@ folevariant_initialize(VALUE self, VALUE args)
 
     len = RARRAY_LEN(args);
     if (len < 1 || len > 3) {
-        rb_raise(rb_eArgError, "wrong number of arguments (%d for 1..3)", len);
+        rb_raise(rb_eArgError, "wrong number of arguments (%d instead of 1..3)", len);
     }
     VariantInit(&var);
     val = rb_ary_entry(args, 0);

--- a/ext/zlib/zlib.c
+++ b/ext/zlib/zlib.c
@@ -3055,7 +3055,7 @@ gzfile_s_open(int argc, VALUE *argv, VALUE klass, const char *mode)
     VALUE io, filename;
 
     if (argc < 1) {
-	rb_raise(rb_eArgError, "wrong number of arguments (0 for 1)");
+	rb_raise(rb_eArgError, "wrong number of arguments (0 instead of 1)");
     }
     filename = argv[0];
     io = rb_file_open_str(filename, mode);

--- a/lib/ostruct.rb
+++ b/lib/ostruct.rb
@@ -178,7 +178,7 @@ class OpenStruct
     len = args.length
     if mname.chomp!('=')
       if len != 1
-        raise ArgumentError, "wrong number of arguments (#{len} for 1)", caller(1)
+        raise ArgumentError, "wrong number of arguments (#{len} instead of 1)", caller(1)
       end
       modifiable[new_ostruct_member(mname)] = args[0]
     elsif len == 0

--- a/proc.c
+++ b/proc.c
@@ -543,7 +543,7 @@ rb_f_lambda(void)
  *
  *  <em>produces:</em>
  *
- *     prog.rb:4:in `block in <main>': wrong number of arguments (3 for 2) (ArgumentError)
+ *     prog.rb:4:in `block in <main>': wrong number of arguments (3 instead of 2) (ArgumentError)
  *     	from prog.rb:5:in `call'
  *     	from prog.rb:5:in `<main>'
  *
@@ -2297,16 +2297,16 @@ curry(VALUE dummy, VALUE args, int argc, VALUE *argv, VALUE passed_proc)
   *
   *     b = lambda {|x, y, z| (x||0) + (y||0) + (z||0) }
   *     p b.curry[1][2][3]           #=> 6
-  *     p b.curry[1, 2][3, 4]        #=> wrong number of arguments (4 for 3)
-  *     p b.curry(5)                 #=> wrong number of arguments (5 for 3)
-  *     p b.curry(1)                 #=> wrong number of arguments (1 for 3)
+  *     p b.curry[1, 2][3, 4]        #=> wrong number of arguments (4 instead of 3)
+  *     p b.curry(5)                 #=> wrong number of arguments (5 instead of 3)
+  *     p b.curry(1)                 #=> wrong number of arguments (1 instead of 3)
   *
   *     b = lambda {|x, y, z, *w| (x||0) + (y||0) + (z||0) + w.inject(0, &:+) }
   *     p b.curry[1][2][3]           #=> 6
   *     p b.curry[1, 2][3, 4]        #=> 10
   *     p b.curry(5)[1][2][3][4][5]  #=> 15
   *     p b.curry(5)[1, 2][3, 4][5]  #=> 15
-  *     p b.curry(1)                 #=> wrong number of arguments (1 for 3)
+  *     p b.curry(1)                 #=> wrong number of arguments (1 instead of 3)
   *
   *     b = proc { :foo }
   *     p b.curry[]                  #=> :foo

--- a/test/fileutils/test_fileutils.rb
+++ b/test/fileutils/test_fileutils.rb
@@ -1197,7 +1197,7 @@ class TestFileUtils
       uptodate? Pathname.new('tmp/a'), [Pathname.new('tmp/b'), Pathname.new('tmp/c')]
     }
     # [Bug #6708] [ruby-core:46256]
-    assert_raise_with_message(ArgumentError, "wrong number of arguments (3 for 2)") {
+    assert_raise_with_message(ArgumentError, "wrong number of arguments (3 instead of 2)") {
       uptodate?('new',['old', 'oldest'], {})
     }
   end

--- a/test/win32ole/test_win32ole_variant.rb
+++ b/test/win32ole/test_win32ole_variant.rb
@@ -35,7 +35,7 @@ if defined?(WIN32OLE_VARIANT)
         ex = $!
       end
       assert_instance_of(ArgumentError, ex)
-      assert_equal("wrong number of arguments (0 for 1..3)", ex.message);
+      assert_equal("wrong number of arguments (0 instead of 1..3)", ex.message);
     end
 
     def test_s_new_one_argument

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -111,13 +111,13 @@ rb_arg_error_new(int argc, int min, int max)
 {
     VALUE err_mess = 0;
     if (min == max) {
-	err_mess = rb_sprintf("wrong number of arguments (%d for %d)", argc, min);
+	err_mess = rb_sprintf("wrong number of arguments (%d instead of %d)", argc, min);
     }
     else if (max == UNLIMITED_ARGUMENTS) {
-	err_mess = rb_sprintf("wrong number of arguments (%d for %d+)", argc, min);
+	err_mess = rb_sprintf("wrong number of arguments (%d instead of %d+)", argc, min);
     }
     else {
-	err_mess = rb_sprintf("wrong number of arguments (%d for %d..%d)", argc, min, max);
+	err_mess = rb_sprintf("wrong number of arguments (%d instead of %d..%d)", argc, min, max);
     }
     return rb_exc_new3(rb_eArgError, err_mess);
 }


### PR DESCRIPTION
Change 'ArgumentError: wrong number of arguments (%d for %d)' to ArgumentError: wrong number of arguments (%d instead of %d).

This clarifies the meaning of the message without any room for doubt.

And looks like raises many doubts: http://stackoverflow.com/questions/7537450/what-does-wrong-number-of-arguments-1-for-0-mean-in-ruby

Personally, I did find the wording weird the first time I saw that error message and I had to google it to make sure I got it right. With this pull request, we leave no room for further doubt.
