### PR TITLE
Should Enumerator#initialize check frozen status?

### DIFF
--- a/enumerator.c
+++ b/enumerator.c
@@ -336,6 +336,7 @@ enumerator_initialize(int argc, VALUE *argv, VALUE obj)
 
     if (rb_block_given_p()) {
 	rb_check_arity(argc, 0, 1);
+	rb_check_frozen(obj);
 	recv = generator_init(generator_allocate(rb_cGenerator), rb_block_proc());
 	if (argc) {
             if (NIL_P(argv[0]) || rb_obj_is_proc(argv[0]) ||
@@ -350,6 +351,7 @@ enumerator_initialize(int argc, VALUE *argv, VALUE obj)
     }
     else {
 	rb_check_arity(argc, 1, UNLIMITED_ARGUMENTS);
+	rb_check_frozen(obj);
 	rb_warn("Enumerator.new without a block is deprecated; use Object#to_enum");
 	recv = *argv++;
 	if (--argc) {

--- a/test/ruby/test_enumerator.rb
+++ b/test/ruby/test_enumerator.rb
@@ -67,6 +67,8 @@ class TestEnumerator < Test::Unit::TestCase
     assert_match 'Enumerator.new without a block is deprecated', err
     assert_equal([1, 2, 3], Enumerator.new { |y| i = 0; loop { y << (i += 1) } }.take(3))
     assert_raise(ArgumentError) { Enumerator.new }
+    assert_raise(ArgumentError) { @obj.to_enum.freeze.instance_eval { initialize } }
+    assert_raise(RuntimeError) { @obj.to_enum.freeze.instance_eval { initialize self } }
   end
 
   def test_initialize_copy

--- a/test/ruby/test_lazy_enumerator.rb
+++ b/test/ruby/test_lazy_enumerator.rb
@@ -22,6 +22,8 @@ class TestLazyEnumerator < Test::Unit::TestCase
     assert_equal([1, 2, 3], [1, 2, 3].lazy.to_a)
     assert_equal([1, 2, 3], Enumerator::Lazy.new([1, 2, 3]){|y, v| y << v}.to_a)
     assert_raise(ArgumentError) { Enumerator::Lazy.new([1, 2, 3]) }
+    assert_raise(ArgumentError) { Enumerator::Lazy.new([], &->{}).freeze.instance_eval { initialize(&->{}) } }
+    assert_raise(RuntimeError) { Enumerator::Lazy.new([], &->{}).freeze.instance_eval { initialize self, &->{} } }
   end
 
   def test_each_args


### PR DESCRIPTION
ruby -v #=> ruby 2.0.0p247 (2013-06-27 revision 41674) [i686-linux]

Frozen Enumerator can modify positions. 

``` ruby
enum = [1, 2].to_enum.freeze
enum.next #=> 1
enum.rewind
enum.next #=> 1
```

But it can't replace receiver-object/block on following methods.
- Enumerator#initialize_copy
- Enumerator::Lazy#initialize_copy
- Enumerator::Lazy#initialize

``` ruby
enum = [1, 2].to_enum.freeze
enum.send :initialize_copy, [1, 2]   #=> RuntimeError: can't modify frozen Enumerator

lazy = [1, 2].to_enum.lazy.freeze
lazy.send :initialize_copy, [1, 2]   #=> RuntimeError: can't modify frozen Enumerator::Lazy
lazy.send :initialize, [1, 2], &->{} #=> RuntimeError: can't modify frozen Enumerator::Lazy
```

Except Enumerator#initialize.

``` ruby
enum = [1, 2].to_enum.freeze
enum.send :initialize, [3, 4] #=> warning: Enumerator.new without a block is deprecated; use Object#to_enum
                              #   <Enumerator: [3, 4]:each>
enum.send :initialize, &->{}  #=> #<Enumerator: #<Enumerator::Generator:0xb7fa7258>:each>
```

Is this a spec?
