### PR TITLE
(win32) Rescue Errno::EINVAL in SecureRandom.random_bytes

### DIFF
--- a/lib/securerandom.rb
+++ b/lib/securerandom.rb
@@ -78,7 +78,7 @@ module SecureRandom
           end
           return ret
         }
-      rescue Errno::ENOENT
+      rescue Errno::ENOENT, Errno::EINVAL
         @has_urandom = false
       end
     end


### PR DESCRIPTION
If not rescued, may error out if the current working directory is on a network drive (windows only). 
