### PR TITLE
Fixed descriptions of String#==

### DIFF
--- a/string.c
+++ b/string.c
@@ -2396,13 +2396,13 @@ str_eql(const VALUE str1, const VALUE str2)
 }
 
 /*
- *  call-seq:
- *     str == obj    -> true or false
- *     str === obj   -> true or false
+ * call-seq:
+ *   str == obj    -> true or false
+ *   str === obj   -> true or false
  *
- *  Equality---If <i>obj</i> is not a <code>String</code>, returns
- *  <code>false</code>. Otherwise, returns <code>true</code> if <i>str</i>
- *  <code><=></code> <i>obj</i> returns zero.
+ * Equality--—If <i>obj</i> is a <code>String</code>, returns <i>true</i> if
+ * <i>obj</i> has the same length and content. Otherwise, returns <i>true</i> if
+ * <i>obj</i> implements <code>to_str</code> and <code>obj == str</code>.
  */
 
 VALUE


### PR DESCRIPTION
This describes what the code actually does. The old
version referenced a class check and the spaceship operator,
both of which aren't used.

Also fixed formatting of the whole comment to be one space from
the \* as per the style guide

I must admit that I do not fully follow the C code, and when reading it I would expect it to call === on obj, instead of ==, but this is the behaviour I get, so I think I misinterpreted the C code there.

Small demonstration of current behaviour:

``` ruby
class FakeString
  def initialize string
    @string = string
  end

  def to_str
    'i must exist, but i am not actually used'
  end

  def ==(other)
    @string == other
  end
end


fake = FakeString.new('a')

puts 'a' == fake # true
puts fake == 'a' # true
puts 'b' == fake # false
puts fake == 'b' #false
```
