### PR TITLE
Class should undef Module#prepend_features on own scope as Module#append_features

### DIFF
--- a/object.c
+++ b/object.c
@@ -3242,6 +3242,7 @@ Init_Object(void)
     rb_define_alloc_func(rb_cClass, rb_class_s_alloc);
     rb_undef_method(rb_cClass, "extend_object");
     rb_undef_method(rb_cClass, "append_features");
+    rb_undef_method(rb_cClass, "prepend_features");
 
     /*
      * Document-class: Data

--- a/test/ruby/test_class.rb
+++ b/test/ruby/test_class.rb
@@ -105,6 +105,32 @@ class TestClass < Test::Unit::TestCase
     end
   end
 
+  def test_extend_object
+    c = Class.new
+    assert_raise(TypeError) do
+      Module.instance_method(:extend_object).bind(c).call(Object.new)
+    end
+  end
+
+  def test_append_features
+    c = Class.new
+    assert_raise(TypeError) do
+      Module.instance_method(:append_features).bind(c).call(Module.new)
+    end
+  end
+
+  def test_prepend_features
+    c = Class.new
+    assert_raise(TypeError) do
+      Module.instance_method(:prepend_features).bind(c).call(Module.new)
+    end
+  end
+
+  def test_module_specific_methods
+    assert_empty(Class.private_instance_methods(true) & 
+      [:module_function, :extend_object, :append_features, :prepend_features])
+  end
+
   def test_method_redefinition
     feature2155 = '[ruby-dev:39400]'
 


### PR DESCRIPTION
Is this intended?

ruby -v
- ruby 2.0.0p247 (2013-06-27 revision 41674) [x86_64-linux]
- ruby 2.1.0dev (2013-08-09 trunk 42476) [x86_64-linux]

``` ruby
Class.new.__send__ :append_features, Module.new #=> NoMethodError: undefined method `append_features' for #<Class:0x007f4473d178b0>
Class.new.__send__ :prepend_features, Module.new #=> TypeError: wrong argument type Class (expected Module)
```
