### PR TITLE
Documented undocumented constants in time.rb

### DIFF
--- a/lib/time.rb
+++ b/lib/time.rb
@@ -174,7 +174,9 @@ class Time
     end
     private :zone_utc?
 
+    # An array with the number of days per month in a leap year.
     LeapYearMonthDays = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    # An array with the number of days per month in a regular year.
     CommonYearMonthDays = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
     def month_days(y, m)
       if ((y % 4 == 0) && (y % 100 != 0)) || (y % 400 == 0)
@@ -401,6 +403,13 @@ class Time
       end
     end
 
+    #
+    # A hash of upcased RFC2822 month-names mapped to number of the month.
+    # For example:
+    #
+    #   Time.MonthValue['JAN']
+    #   #=> 1
+    #
     MonthValue = {
       'JAN' => 1, 'FEB' => 2, 'MAR' => 3, 'APR' => 4, 'MAY' => 5, 'JUN' => 6,
       'JUL' => 7, 'AUG' => 8, 'SEP' => 9, 'OCT' =>10, 'NOV' =>11, 'DEC' =>12
@@ -577,9 +586,13 @@ class Time
   end
   alias rfc822 rfc2822
 
+
+  # An array of day names, as defined by RFC 2822
   RFC2822_DAY_NAME = [
     'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'
   ]
+
+  # An array of month names, as defined by RFC 2822
   RFC2822_MONTH_NAME = [
     'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
     'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'


### PR DESCRIPTION
Added documentation to some constants missing documentation yet. If you feel any of them should have nodoc instead, I will add those.

To be honest, some of those feel strange to me, for instance the nr of days per months are only used in a private method, so should be private imho, but I guess we can't for backwards compatibility reasons?
