### PR TITLE
Fix for Bug8771, Net::HTTP.start should pass proxy configuration from ENV

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,15 @@
+Sat  11 Aug 2013 23:04:52 BST  Sam Taylor  <sjltaylor@gmail.com>
+
+	* lib/net/http.rb (Net::HTTP.start): Proxy configuration can
+	  can come from ENV variables. [Bug #8771]
+
+	* test/net/test_http.rb (test_override_proxy_ENV_with_start):
+	  that proxy configuration can come from ENV. [Bug #8771]
+
+	* test/net/test_http.rb (test_proxy_ENV_with_start):
+	  test ENV proxy configuration can still be overridden
+	  [Bug #8771]
+
 Wed Aug  7 23:06:26 2013  Akinori MUSHA  <knu@iDaemons.org>
 
 	* ruby.c (Process.argv0): New method to return the original value

--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -566,6 +566,7 @@ module Net   #:nodoc:
       arg.pop if opt = Hash.try_convert(arg[-1])
       port, p_addr, p_port, p_user, p_pass = *arg
       port = https_default_port if !port && opt && opt[:use_ssl]
+      p_addr = :ENV if p_addr.nil? && arg.length < 2
       http = new(address, port, p_addr, p_port, p_user, p_pass)
 
       if opt


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/8771
