### PR TITLE
Array#{sample,shuffle} should use random_generator_result.to_int

### DIFF
--- a/random.c
+++ b/random.c
@@ -851,7 +851,7 @@ rb_random_ulong_limited(VALUE obj, unsigned long limit)
     if (!rnd) {
 	extern int rb_num_negative_p(VALUE);
 	VALUE lim = ulong_to_num_plus_1(limit);
-	VALUE v = rb_funcall2(obj, id_rand, 1, &lim);
+	VALUE v = rb_to_int(rb_funcall2(obj, id_rand, 1, &lim));
 	unsigned long r = NUM2ULONG(v);
 	if (rb_num_negative_p(v)) {
 	    rb_raise(rb_eRangeError, "random number too small %ld", r);

--- a/test/ruby/test_array.rb
+++ b/test/ruby/test_array.rb
@@ -2044,6 +2044,19 @@ class TestArray < Test::Unit::TestCase
       alias rand call
     end
     assert_raise(RuntimeError) {ary.shuffle!(random: gen)}
+
+    zero = Object.new
+    def zero.to_int
+      0
+    end
+    gen_to_int = proc do |max|
+      zero
+    end
+    class << gen_to_int
+      alias rand call
+    end
+    ary = (0...10000).to_a
+    assert_equal(ary.rotate, ary.shuffle(random: gen_to_int))
   end
 
   def test_sample
@@ -2127,6 +2140,19 @@ class TestArray < Test::Unit::TestCase
     assert_equal([5000, 0, 5001, 2, 5002, 4, 5003, 6, 5004, 8, 5005], ary.sample(11, random: gen0))
     ary.sample(11, random: gen1) # implementation detail, may change in the future
     assert_equal([], ary)
+
+    half = Object.new
+    def half.to_int
+      5000
+    end
+    gen_to_int = proc do |max|
+      half
+    end
+    class << gen_to_int
+      alias rand call
+    end
+    ary = (0...10000).to_a
+    assert_equal(5000, ary.sample(random: gen_to_int))
   end
 
   def test_cycle


### PR DESCRIPTION
Is this intended?

``` ruby
$VERBOSE = true

foo = Object.new

def foo.to_int
  0
end

rng = -> max { foo }

class << rng
  alias_method :rand, :call
end
```

ruby 2.0.0dev (2013-02-22 trunk 39375) [x86_64-linux]

``` ruby
[:a, :b].sample random: rng  #=> :a
[:a, :b].shuffle random: rng #=> [:b, :a]
```

ruby 2.1.0dev (2013-08-11 trunk 42503) [x86_64-linux]

``` ruby
[:a, :b].sample random: rng  #=> undefined method `<' for #<Object:0x007ff19d5a4f60> (NoMethodError)
[:a, :b].shuffle random: rng #=> undefined method `<' for #<Object:0x007ff19d5a4f60> (NoMethodError)
```
