### PR TITLE
Allowing proxy specified by http_env variable to use basic authentication

### DIFF
--- a/lib/open-uri.rb
+++ b/lib/open-uri.rb
@@ -190,7 +190,7 @@ module OpenURI
     end
     case opt_proxy
     when true
-      find_proxy = lambda {|u| pxy = u.find_proxy; pxy ? [pxy, nil, nil] : nil}
+      find_proxy = lambda {|u| pxy = u.find_proxy; pxy ? [pxy, pxy.user, pxy.password] : nil}
     when nil, false
       find_proxy = lambda {|u| nil}
     when String


### PR DESCRIPTION
Hi,

Not sure if this breaks anything else but it has solved a major frustration with our use of proxies and ruby tools.

Thanks,
Tom
