### PR TITLE
When given Symbol names, {Single}Forwardable#def_delegators should reject #__id__ and #__send__ as String names.

### DIFF
--- a/lib/forwardable.rb
+++ b/lib/forwardable.rb
@@ -150,6 +150,7 @@ module Forwardable
   #   def_delegator :@records, :map
   #
   def def_instance_delegators(accessor, *methods)
+    methods.map!(&:to_s)
     methods.delete("__send__")
     methods.delete("__id__")
     for method in methods
@@ -255,6 +256,7 @@ module SingleForwardable
   #   def_delegator :@records, :map
   #
   def def_single_delegators(accessor, *methods)
+    methods.map!(&:to_s)
     methods.delete("__send__")
     methods.delete("__id__")
     for method in methods


### PR DESCRIPTION
I couldn't find `test_forwardable.rb`.

`ruby -v` ruby 2.1.0dev (2013-08-27 trunk 42710) [x86_64-linux]

``` ruby
# coding: us-ascii

$VERBOSE = true

require 'forwardable'

class Foo
  extend Forwardable

  attr_reader :destination

  def initialize
    @destination = []
  end

  def_delegators :@destination, '__id__'
end

foo = Foo.new

p foo.destination.__id__.equal?(foo.__id__) #=> false

class Foo
  def_delegators :@destination, :__id__
end

p foo.destination.__id__.equal?(foo.__id__) #=> true


DESTINATION = []
obj = Object.new
obj.extend SingleForwardable

obj.def_delegators :DESTINATION, '__id__'
p obj.__id__.equal?(DESTINATION.__id__) #=> false

obj.def_delegators :DESTINATION, :__id__
p obj.__id__.equal?(DESTINATION.__id__) #=> true
```
