### PR TITLE
Resolv: Multiple strings should be concatenated in a DNS record's data

### DIFF
--- a/lib/resolv.rb
+++ b/lib/resolv.rb
@@ -1965,7 +1965,7 @@ class Resolv
         # Returns the first string from +strings+.
 
         def data
-          @strings[0]
+          @strings.join("")
         end
 
         def encode_rdata(msg) # :nodoc:


### PR DESCRIPTION
As per http://tools.ietf.org/html/rfc4408#section-3.1.3, when a TXT or SPF record contains multiple strings, those strings should be concatenated without any delimiter. Resolv was taking the first string, which meant that valid data in a TXT record wouldn't be available. This change just concatenates the strings together.
