### PR TITLE
Updating the Crash Report bugs url

### DIFF
--- a/error.c
+++ b/error.c
@@ -48,7 +48,7 @@ extern const char ruby_description[];
 	"You may have encountered a bug in the Ruby interpreter" \
 	" or extension libraries.\n" \
 	"Bug reports are welcome.\n" \
-	"For details: http://www.ruby-lang.org/bugreport.html\n\n" \
+	"For details: http://bugs.ruby-lang.org/\n\n" \
 
 static const char *
 rb_strerrno(int err)


### PR DESCRIPTION
The new ruby-lang bug url is bugs.ruby-lang.org.  

Aside:  Can you direct me to documentation on the right correct way to contribute back to Ruby?  Is the github repo a mirror or main?  Thanks.
