### PR TITLE
Improve comparison error message.

### DIFF
--- a/bignum.c
+++ b/bignum.c
@@ -2925,7 +2925,7 @@ int
 rb_cmpint(VALUE val, VALUE a, VALUE b)
 {
     if (NIL_P(val)) {
-	rb_cmperr(a, b);
+	rb_cmperr(a, b, "comparator returned nil");
     }
     if (FIXNUM_P(val)) {
         long l = FIX2LONG(val);

--- a/compar.c
+++ b/compar.c
@@ -21,7 +21,7 @@ rb_cmp(VALUE x, VALUE y)
 }
 
 void
-rb_cmperr(VALUE x, VALUE y)
+rb_cmperr(VALUE x, VALUE y, const char *reason)
 {
     VALUE classname;
 
@@ -31,8 +31,8 @@ rb_cmperr(VALUE x, VALUE y)
     else {
 	classname = rb_obj_class(y);
     }
-    rb_raise(rb_eArgError, "comparison of %"PRIsVALUE" with %"PRIsVALUE" failed",
-	     rb_obj_class(x), classname);
+    rb_raise(rb_eArgError, "comparison of %"PRIsVALUE" with %"PRIsVALUE" failed: %s",
+	     rb_obj_class(x), classname, reason);
 }
 
 static VALUE

--- a/include/ruby/intern.h
+++ b/include/ruby/intern.h
@@ -236,7 +236,7 @@ void rb_define_singleton_method(VALUE, const char*, VALUE(*)(ANYARGS), int);
 VALUE rb_singleton_class(VALUE);
 /* compar.c */
 int rb_cmpint(VALUE, VALUE, VALUE);
-NORETURN(void rb_cmperr(VALUE, VALUE));
+NORETURN(void rb_cmperr(VALUE, VALUE, const char*));
 /* cont.c */
 VALUE rb_fiber_new(VALUE (*)(ANYARGS), VALUE);
 VALUE rb_fiber_resume(VALUE fib, int argc, const VALUE *argv);

--- a/internal.h
+++ b/internal.h
@@ -1798,7 +1798,7 @@ rb_num_compare_with_zero(VALUE num, ID mid)
     VALUE zero = INT2FIX(0);
     VALUE r = rb_check_funcall(num, mid, 1, &zero);
     if (r == Qundef) {
-	rb_cmperr(num, zero);
+	rb_cmperr(num, zero, "unable to compare with zero");
     }
     return r;
 }

--- a/numeric.c
+++ b/numeric.c
@@ -462,9 +462,11 @@ rb_num_coerce_relop(VALUE x, VALUE y, ID func)
 {
     VALUE c, x0 = x, y0 = y;
 
-    if (!do_coerce(&x, &y, FALSE) ||
-	NIL_P(c = rb_funcall(x, func, 1, y))) {
-	rb_cmperr(x0, y0);
+    if (!do_coerce(&x, &y, FALSE)) {
+	rb_cmperr(x0, y0, "coercion was not possible");
+	return Qnil;		/* not reached */
+    } else if (NIL_P(c = rb_funcall(x, func, 1, y))) {
+	rb_cmperr(x0, y0, "comparator returned nil");
 	return Qnil;		/* not reached */
     }
     return c;
@@ -5110,7 +5112,7 @@ int_upto(VALUE from, VALUE to)
 	    rb_yield(i);
 	    i = rb_funcall(i, '+', 1, INT2FIX(1));
 	}
-	if (NIL_P(c)) rb_cmperr(i, to);
+	if (NIL_P(c)) rb_cmperr(i, to, "comparator returned nil");
     }
     return from;
 }
@@ -5156,7 +5158,7 @@ int_downto(VALUE from, VALUE to)
 	    rb_yield(i);
 	    i = rb_funcall(i, '-', 1, INT2FIX(1));
 	}
-	if (NIL_P(c)) rb_cmperr(i, to);
+	if (NIL_P(c)) rb_cmperr(i, to, "comparator returned nil");
     }
     return from;
 }


### PR DESCRIPTION
In certain cases, things like Array#sort can result in a confusing error
message. For instance where a and b are characters in a string,
"string":

  array.sort { |a, b| string.index(a) <=> string.index(b) }

If one of the index calls returns nil, we will get "comparison of String
with String failed", which is somewhat unhelpful, since it's easy to be
confused, given that what is really being compared is a Fixnum or
NilClass (the cause of the error). Yes, as far as Array#sort is
concerned, the two characters are the things being sorted, but it's
useful to call attention to the return value of the comparison in this
case.

This patch adds a "reason" argument to rb_cmperr, which will provide an
error message of "comparison of String with String failed: comparator
returned nil" in the case above, or, in the case of:

  1.upto('10').to_a

it will provide the message: "comparison of Fixnum with String failed:
coercion was not possible"
