### PR TITLE
Add {Enumerator,Range}#length aliases for their respective #size's

### DIFF
--- a/enumerator.c
+++ b/enumerator.c
@@ -2010,6 +2010,7 @@ InitVM_Enumerator(void)
     rb_define_method(rb_cEnumerator, "rewind", enumerator_rewind, 0);
     rb_define_method(rb_cEnumerator, "inspect", enumerator_inspect, 0);
     rb_define_method(rb_cEnumerator, "size", enumerator_size, 0);
+    rb_define_alias(rb_cEnumerator,  "length", "size");
 
     /* Lazy */
     rb_cLazy = rb_define_class_under(rb_cEnumerator, "Lazy", rb_cEnumerator);

--- a/range.c
+++ b/range.c
@@ -1346,6 +1346,7 @@ Init_Range(void)
     rb_define_method(rb_cRange, "min", range_min, 0);
     rb_define_method(rb_cRange, "max", range_max, 0);
     rb_define_method(rb_cRange, "size", range_size, 0);
+    rb_define_alias(rb_cRange,  "length", "size");
     rb_define_method(rb_cRange, "to_s", range_to_s, 0);
     rb_define_method(rb_cRange, "inspect", range_inspect, 0);
 

--- a/test/ruby/test_range.rb
+++ b/test/ruby/test_range.rb
@@ -368,6 +368,13 @@ class TestRange < Test::Unit::TestCase
     assert_equal 42, (1..42).each.size
   end
 
+  def test_length
+    assert_equal 42, (1..42).length
+    assert_equal 41, (1...42).length
+    assert_equal 6, (1...6.3).length
+    assert_equal 5, (1.1...6).length
+  end
+
   def test_bsearch_typechecks_return_values
     assert_raise(TypeError) do
       (1..42).bsearch{ "not ok" }

--- a/test/ruby/test_range.rb
+++ b/test/ruby/test_range.rb
@@ -373,6 +373,7 @@ class TestRange < Test::Unit::TestCase
     assert_equal 41, (1...42).length
     assert_equal 6, (1...6.3).length
     assert_equal 5, (1.1...6).length
+    assert_equal 42, (1..42).each.length
   end
 
   def test_bsearch_typechecks_return_values


### PR DESCRIPTION
`Array`, `Hash`, and `String` support both `#length` and `#size`. `Range` and `Enumerator` recently added `#size` but do not remain consistent with the rest of core with the exclusion of `#length`. This pull request aliases `Range`'s and `Enumerator`'s `#size` to `#length`.
