### PR TITLE
Add rb_funcall_ci

### DIFF
--- a/array.c
+++ b/array.c
@@ -18,6 +18,7 @@
 #include "internal.h"
 #include "probes.h"
 #include "id.h"
+#include "vm_core.h"
 
 #ifndef ARRAY_DEBUG
 # define NDEBUG
@@ -2350,7 +2351,8 @@ sort_2(const void *ap, const void *bp, void *dummy)
 	return rb_str_cmp(a, b);
     }
 
-    retval = rb_funcallv(a, id_cmp, 1, &b);
+    retval = rb_funcall_ci(&data->ci, a, &b);
+
     n = rb_cmpint(retval, a, b);
     sort_reentered(data->ary);
 

--- a/internal.h
+++ b/internal.h
@@ -715,6 +715,9 @@ VALUE rb_check_block_call(VALUE, ID, int, VALUE *, VALUE (*)(ANYARGS), VALUE);
 typedef void rb_check_funcall_hook(int, VALUE, ID, int, const VALUE *, VALUE);
 VALUE rb_check_funcall_with_hook(VALUE recv, ID mid, int argc, const VALUE *argv,
 				 rb_check_funcall_hook *hook, VALUE arg);
+struct rb_call_info_struct;
+
+VALUE rb_funcall_ci(struct rb_call_info_struct *ci, VALUE recv, VALUE *argv);
 
 /* vm_insnhelper.c */
 VALUE rb_equal_opt(VALUE obj1, VALUE obj2);

--- a/internal.h
+++ b/internal.h
@@ -717,7 +717,7 @@ VALUE rb_check_funcall_with_hook(VALUE recv, ID mid, int argc, const VALUE *argv
 				 rb_check_funcall_hook *hook, VALUE arg);
 struct rb_call_info_struct;
 
-VALUE rb_funcall_ci(struct rb_call_info_struct *ci, VALUE recv, VALUE *argv);
+VALUE rb_funcall_ci(struct rb_call_info_struct *ci, VALUE recv, const VALUE *argv);
 
 /* vm_insnhelper.c */
 VALUE rb_equal_opt(VALUE obj1, VALUE obj2);

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -761,6 +761,15 @@ rb_apply(VALUE recv, ID mid, VALUE args)
     return rb_call(recv, mid, argc, argv, CALL_FCALL);
 }
 
+VALUE
+rb_funcall_ci(rb_call_info_t *ci, VALUE recv, VALUE *argv)
+{
+    rb_thread_t *th = GET_THREAD();
+    ci->recv = recv;
+    vm_search_method(ci, recv);
+    return vm_call0_body(th, ci, argv);
+}
+
 /*!
  * Calls a method
  * \param recv   receiver of the method

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -762,7 +762,7 @@ rb_apply(VALUE recv, ID mid, VALUE args)
 }
 
 VALUE
-rb_funcall_ci(rb_call_info_t *ci, VALUE recv, VALUE *argv)
+rb_funcall_ci(rb_call_info_t *ci, VALUE recv, const VALUE *argv)
 {
     rb_thread_t *th = GET_THREAD();
     ci->recv = recv;

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -765,9 +765,18 @@ VALUE
 rb_funcall_ci(rb_call_info_t *ci, VALUE recv, const VALUE *argv)
 {
     rb_thread_t *th = GET_THREAD();
+    rb_control_frame_t *cfp = th->cfp;
+    int i;
+
     ci->recv = recv;
     vm_search_method(ci, recv);
-    return vm_call0_body(th, ci, argv);
+
+    *cfp->sp++ = recv;
+    for (i = 0; i < ci->argc; i++) {
+	*cfp->sp++ = argv[i];
+    }
+
+    return (*ci->call)(th, cfp, ci);
 }
 
 /*!


### PR DESCRIPTION
This pull request adds an internal function called `rb_funcall_ci`. This function takes an `rb_call_info_t *` and allows method calls from C to take advantage of method caching.

This gives a large performance improvement when repeatedly calling methods, for example in `Array#sort`.

I used this benchmark script to compare the performance of `Array#sort` when using `rb_funcall` vs. using `rb_funcall_ci`:

``` ruby
require "benchmark"

int_ary = (1..1_000_000).to_a.shuffle
float_ary = int_ary.map(&:to_f)

Benchmark.bm do |bm|
  5.times do
    bm.report "int_ary.sort  " do
      # uses optimized comparison that does not call any methods
      int_ary.sort
    end
  end
  5.times do
    bm.report "float_ary.sort" do
      # calls Float#<=>
      float_ary.sort
    end
  end
end
```

Results for `rb_funcall`:

```
       user     system      total        real
int_ary.sort    0.160000   0.000000   0.160000 (  0.170144)
int_ary.sort    0.170000   0.000000   0.170000 (  0.168473)
int_ary.sort    0.170000   0.000000   0.170000 (  0.169287)
int_ary.sort    0.170000   0.010000   0.180000 (  0.176867)
int_ary.sort    0.170000   0.000000   0.170000 (  0.166630)
float_ary.sort  0.910000   0.000000   0.910000 (  0.911482)
float_ary.sort  0.910000   0.000000   0.910000 (  0.914818)
float_ary.sort  0.910000   0.000000   0.910000 (  0.912684)
float_ary.sort  0.920000   0.000000   0.920000 (  0.915842)
float_ary.sort  0.920000   0.010000   0.930000 (  0.925721)
```

Results for `rb_funcall_ci`:

```
       user     system      total        real
int_ary.sort    0.170000   0.000000   0.170000 (  0.170202)
int_ary.sort    0.170000   0.000000   0.170000 (  0.169039)
int_ary.sort    0.170000   0.000000   0.170000 (  0.168966)
int_ary.sort    0.170000   0.010000   0.180000 (  0.177495)
int_ary.sort    0.170000   0.000000   0.170000 (  0.166742)
float_ary.sort  0.680000   0.000000   0.680000 (  0.683508)
float_ary.sort  0.680000   0.000000   0.680000 (  0.685977)
float_ary.sort  0.690000   0.000000   0.690000 (  0.685701)
float_ary.sort  0.690000   0.000000   0.690000 (  0.692503)
float_ary.sort  0.700000   0.010000   0.710000 (  0.708043)
```

cc @ko1
