### PR TITLE
Remove delegation from WeakRef. See #6308 in MRI's bug tracker.

### DIFF
--- a/test/test_weakref.rb
+++ b/test/test_weakref.rb
@@ -3,26 +3,23 @@ require 'weakref'
 require_relative './ruby/envutil'
 
 class TestWeakRef < Test::Unit::TestCase
-  def make_weakref(level = 10)
+  def make_weakref
     obj = Object.new
     str = obj.to_s
-    level.times {obj = WeakRef.new(obj)}
-    return WeakRef.new(obj), str
+    return WeakReference.new(obj), str
   end
 
   def test_ref
     weak, str = make_weakref
-    assert_equal(str, weak.to_s)
+    assert_equal(str, weak.get.to_s)
   end
 
   def test_recycled
     weak, str = make_weakref
-    assert_nothing_raised(WeakRef::RefError) {weak.to_s}
-    assert_predicate(weak, :weakref_alive?)
+    assert_equal str, weak.get.to_s
     ObjectSpace.garbage_collect
     ObjectSpace.garbage_collect
-    assert_raise(WeakRef::RefError) {weak.to_s}
-    assert_not_predicate(weak, :weakref_alive?)
+    assert_equal nil, weak.get
   end
 
   def test_not_reference_different_object
@@ -31,17 +28,13 @@ class TestWeakRef < Test::Unit::TestCase
     3.times do
       obj = Object.new
       def obj.foo; end
-      weakrefs << WeakRef.new(obj)
+      weakrefs << WeakReference.new(obj)
       ObjectSpace.garbage_collect
     end
-    assert_nothing_raised(NoMethodError, bug7304) {
-      weakrefs.each do |weak|
-        begin
-          weak.foo
-        rescue WeakRef::RefError
-        end
-      end
-    }
+    weakrefs.each do |weak|
+      obj = weak.get
+      assert obj == nil || obj.respond_to?(:foo)
+    end
   end
 
   def test_weakref_finalize
@@ -50,7 +43,7 @@ class TestWeakRef < Test::Unit::TestCase
       require 'weakref'
       obj = Object.new
       3.times do
-        WeakRef.new(obj)
+        WeakReference.new(obj)
         ObjectSpace.garbage_collect
       end
     }, bug7304


### PR DESCRIPTION
- lib/weakref.rb: Modify weakref to not use delegation. See #6308.
- test/test_weakref.rb: Alter tests that use delegation.
