### PR TITLE
Pasted rb_obj_cmp doc fix from trunk and 2.0 into 1.9.3 branch.

### DIFF
--- a/object.c
+++ b/object.c
@@ -1234,7 +1234,8 @@ rb_obj_not_match(VALUE obj1, VALUE obj2)
  *  call-seq:
  *     obj <=> other -> 0 or nil
  *
- *  Returns 0 if obj === other, otherwise nil.
+ * Returns 0 if +obj+ and +other+ are the same object
+ * or <code>obj == other</code>, otherwise nil.
  */
 static VALUE
 rb_obj_cmp(VALUE obj1, VALUE obj2)


### PR DESCRIPTION
This doc fix is in trunk and 2.0 but is also valid and important in 1.9.3, which is still in wide use.  Could you include the fix in this branch as well?
