### PR TITLE
WEBrick doc clarification

### DIFF
--- a/lib/webrick.rb
+++ b/lib/webrick.rb
@@ -42,7 +42,8 @@
 #     res.body = 'Hello, world!'
 #   end
 #
-# Remember that <tt>server.mount_proc</tt> must <tt>server.start</tt>.
+# Remember that <tt>server.mount_proc</tt>
+# calls must precede <tt>server.start</tt>.
 #
 # == Servlets
 #


### PR DESCRIPTION
The sentence on #mount_proc and #start call order seems somewhat incomplete; this clarifies it.
