### PR TITLE
Fix race condition causing some mutexes to remain locked after forking

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+Fri Oct  4 20:29:06 2013  Aaron Pfeifer <aaron.pfeifer@gmail.com>
+
+	* thread.c (terminate_atfork_i): fix locking mutexes not unlocked in
+	  forks when not tracked in thread. [ruby-core:55102] [Bug #8433]
+	* test/ruby/test_thread.rb: test for above.
+
 Fri Oct  4 19:54:09 2013  Zachary Scott  <e@zzak.io>
 
 	* ext/dbm/dbm.c: [DOC] Fix wrong constant name in DBM by @edward


### PR DESCRIPTION
This patch fixes a race condition in which a mutex gets locked by a background thread and not properly unlocked after forking.  This occurs when the background thread is blocked waiting to lock the mutex and the mutex is unlocked right around the time that the process gets forked.  When this happens the mutex is not part of `keeping_mutexes`.  Instead, it's still tracked as `locking_mutex` even though the mutex _has_ actually been locked by the background thread.

This was originally reported by https://bugs.ruby-lang.org/issues/8433.  A test has been added verifying the fix.

Completely open to any / all feedback as I'm certainly not a c guru :)
