### PR TITLE
Fix typo on line 83 in the documentation for time.rb

### DIFF
--- a/lib/time.rb
+++ b/lib/time.rb
@@ -80,7 +80,7 @@ require 'date'
 #
 # #strptime works similar to +parse+ except that instead of using a heuristic
 # to detect the format of the input string, you provide a second argument that
-# is describes the format of the string. For example:
+# describes the format of the string. For example:
 #
 #   Time.strptime("2000-10-31", "%Y-%m-%d") #=> 2000-10-31 00:00:00 -0500
 


### PR DESCRIPTION
This update fixes a typo in the documentation on line 83 in time.rb
