### PR TITLE
Add webhook to rebuild ruby-head installed on Travis CI VMs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,13 @@ notifications:
     template:
       - "%{message} by @%{author}: See %{build_url}"
 
+  # Update ruby-head installed on Travis CI so other projects can test against it.
+  webhooks:
+    urls:
+      - "https://rubies.travis-ci.org/rebuild/ruby-head"
+    on_success: always
+    on_failure: never
+
 # Local Variables:
 # mode: YAML
 # coding: utf-8-unix


### PR DESCRIPTION
Ruby projects can specify which Ruby they test against on Travis CI, this includes ruby-head. We regularly fall behind the ruby-head version installed on Travis CI compared to trunk. With this change to the .travis.yml, after every successful build of ruby/ruby, we will update the ruby-head used by other projects on Travis CI, giving it more exposure and shortening the feedback cycle for Ruby trunk, as regressions might get discovered earlier and external libraries are better prepared for future releases.
