### PR TITLE
Fix spelling from compliment to complement

### DIFF
--- a/include/ruby/ruby.h
+++ b/include/ruby/ruby.h
@@ -184,7 +184,7 @@ typedef char ruby_check_sizeof_voidp[SIZEOF_VOIDP == sizeof(void*) ? 1 : -1];
 #  ifdef HAVE_LIMITS_H
 #   include <limits.h>
 #  else
-    /* assuming 32bit(2's compliment) long */
+    /* assuming 32bit(2's complement) long */
 #   define LONG_MAX 2147483647
 #  endif
 # endif

--- a/vsnprintf.c
+++ b/vsnprintf.c
@@ -95,7 +95,7 @@
 #  ifdef HAVE_LIMITS_H
 #   include <limits.h>
 #  else
-    /* assuming 32bit(2's compliment) long */
+    /* assuming 32bit(2's complement) long */
 #   define LONG_MAX 2147483647
 #  endif
 # endif


### PR DESCRIPTION
http://public.wsu.edu/~brians/errors/complement.html

Compliment is when you say something nice.

Complement is when what you have matches something else.

https://en.wikipedia.org/wiki/Two's_complement indicates that it's spelt "complement".
