### PR TITLE
Add a mention about File.expand_path (File#exist?)

### DIFF
--- a/file.c
+++ b/file.c
@@ -1383,7 +1383,9 @@ rb_file_chardev_p(VALUE obj, VALUE fname)
  *
  * Return <code>true</code> if the named file exists.
  *
- * _file_name_ can be an IO object.
+ * _file_name_ can be an IO object. If you are working on Windows
+ * or with paths containing whitespaces, it's recommended to use
+ * File.expand_path on the _file_name_ to correctly escape backslashes.
  *
  * "file exists" means that stat() or fstat() system call is successful.
  */


### PR DESCRIPTION
Hello,

When using `File#exist?`, if we are working on Windows or with paths containing whitespaces, the result is unexpected if we do not use File.expand_path on the given name.

I hope this could save some time for people hitting the same issue.

Have a nice day!
