### PR TITLE
Unnecessary declaration. It's maybe OBSOLETE.

### DIFF
--- a/file.c
+++ b/file.c
@@ -4301,7 +4301,6 @@ rb_file_truncate(VALUE obj, VALUE len)
 
 #ifdef __CYGWIN__
 #include <winerror.h>
-extern unsigned long __attribute__((stdcall)) GetLastError(void);
 #endif
 
 static VALUE


### PR DESCRIPTION
1. This source code already included "windows.h", therefore it's already declared:
   WINBASEAPI DWORD WINAPI GetLastError (VOID);
2. At cygwin64, still sizeof(DWORD) is 4, but sizeof(unsigned long) is 8, it make confliction.
