### PR TITLE
Documentation improvements in NEWS and timeout.rb

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -246,7 +246,7 @@ with all sufficient information, see the ChangeLog file.
     * Tempfile.create
 
 * Timeout
-  * No longer an exception to terminate the given block can be rescued
+  * The exception to terminate the given block can no longer be rescued
     inside the block, by default, unless the exception class is given
     explicitly.
 

--- a/lib/timeout.rb
+++ b/lib/timeout.rb
@@ -57,6 +57,9 @@ module Timeout
   # Returns the result of the block *if* the block completed before
   # +sec+ seconds, otherwise throws an exception, based on the value of +klass+.
   #
+  # The exception thrown to terminate the given block cannot be rescued inside
+  # the block unless +klass+ is given explicitly.
+  #
   # Note that this is both a method of module Timeout, so you can <tt>include
   # Timeout</tt> into your classes so they have a #timeout method, as well as
   # a module method, so you can call it directly as Timeout.timeout().


### PR DESCRIPTION
Two small documentation fixes:
- Grammar fix in NEWS for change to Timeout.timeout (It looks like bug numbers are generally not listed in NEWS, but otherwise I would include [Bug #8730] in the bullet point.)
- Add rdoc to Timeout.timeout stating behavior regarding this change.
