### PR TITLE
Undefine SimpleDelegator#open

### DIFF
--- a/lib/delegate.rb
+++ b/lib/delegate.rb
@@ -43,7 +43,7 @@
 class Delegator < BasicObject
   kernel = ::Kernel.dup
   kernel.class_eval do
-    [:to_s,:inspect,:=~,:!~,:===,:<=>,:eql?,:hash].each do |m|
+    [:to_s,:inspect,:=~,:!~,:===,:<=>,:eql?,:hash,:open].each do |m|
       undef_method m
     end
   end


### PR DESCRIPTION
Including `::Kernel.dup` brings across the #open method into
SimpleDelegator with undesirable consequences.

e.g.

``` Ruby
  class A
  end
  SimpleDelegator.new(A.new).open
  # => NoMethodError: private method `open' called for #<A:0x007fca1aa1fbd0>
```
