### PR TITLE
Fixes/clarifies Observer.rb documentation

### DIFF
--- a/lib/observer.rb
+++ b/lib/observer.rb
@@ -15,12 +15,13 @@
 # module, which provides the methods for managing the associated observer
 # objects.
 #
-# The observers must implement a method called +update+ to receive
-# notifications.
-#
 # The observable object must:
 # * assert that it has +#changed+
 # * call +#notify_observers+
+#
+# An observer subscribes to updates using +Observable#add_observer+, which 
+# also specifies the method the observable will call when +#notify_observers+ is 
+# called. By default, the method +#notify_observers+ calls is +#update+.
 #
 # === Example
 #


### PR DESCRIPTION
I had trouble reading through the Observer.rb documentation before I realized that it was technically incorrect: “The observers must implement a method called +update+ to receive notifications” is simply not true; it’s whatever #add_observer sets it to, and #update is just the default.
