### PR TITLE
Make Numeric#nonzero? behavior consistent with Numeric#zero?

### DIFF
--- a/numeric.c
+++ b/numeric.c
@@ -574,6 +574,29 @@ num_zero_p(VALUE num)
 
 /*
  *  call-seq:
+ *     num.nonzero  ->  self or nil
+ *
+ *  Returns +self+ if +num+ is not zero, +nil+ otherwise.
+ *
+ *  This behavior is useful when chaining comparisons:
+ *
+ *     a = %w( z Bb bB bb BB a aA Aa AA A )
+ *     b = a.sort {|a,b| (a.downcase <=> b.downcase).nonzero || a <=> b }
+ *     b   #=> ["A", "a", "AA", "Aa", "aA", "BB", "Bb", "bB", "bb", "z"]
+ */
+
+static VALUE
+num_nonzero(VALUE num)
+{
+    if (RTEST(rb_funcall(num, rb_intern("zero?"), 0, 0))) {
+	return Qnil;
+    }
+    return num;
+}
+
+
+/*
+ *  call-seq:
  *     num.nonzero?  ->  true or false
  *
  *  Returns +true+ if +num+ is not zero, +false+ otherwise.
@@ -3846,6 +3869,7 @@ Init_Numeric(void)
     rb_define_method(rb_cNumeric, "real?", num_real_p, 0);
     rb_define_method(rb_cNumeric, "integer?", num_int_p, 0);
     rb_define_method(rb_cNumeric, "zero?", num_zero_p, 0);
+    rb_define_method(rb_cNumeric, "nonzero", num_nonzero, 0);
     rb_define_method(rb_cNumeric, "nonzero?", num_nonzero_p, 0);
 
     rb_define_method(rb_cNumeric, "floor", num_floor, 0);

--- a/numeric.c
+++ b/numeric.c
@@ -574,24 +574,18 @@ num_zero_p(VALUE num)
 
 /*
  *  call-seq:
- *     num.nonzero?  ->  self or nil
+ *     num.nonzero?  ->  true or false
  *
- *  Returns +self+ if +num+ is not zero, +nil+ otherwise.
- *
- *  This behavior is useful when chaining comparisons:
- *
- *     a = %w( z Bb bB bb BB a aA Aa AA A )
- *     b = a.sort {|a,b| (a.downcase <=> b.downcase).nonzero? || a <=> b }
- *     b   #=> ["A", "a", "AA", "Aa", "aA", "BB", "Bb", "bB", "bb", "z"]
+ *  Returns +true+ if +num+ is not zero, +false+ otherwise.
  */
 
 static VALUE
 num_nonzero_p(VALUE num)
 {
-    if (RTEST(rb_funcall(num, rb_intern("zero?"), 0, 0))) {
-	return Qnil;
+    if (rb_equal(num, INT2FIX(0))) {
+	return Qfalse;
     }
-    return num;
+    return Qtrue;
 }
 
 /*

--- a/test/ruby/test_integer_comb.rb
+++ b/test/ruby/test_integer_comb.rb
@@ -447,16 +447,19 @@ class TestIntegerComb < Test::Unit::TestCase
   def test_zero_nonzero
     VS.each {|a|
       z = a.zero?
-      n = a.nonzero?
+      n = a.nonzero
+      p = a.nonzero?
       if a == 0
         assert_equal(true, z, "(#{a}).zero?")
-        assert_equal(nil, n, "(#{a}).nonzero?")
+        assert_equal(nil, n, "(#{a}).nonzero")
+        assert_equal(false, p, "(#{a}).nonzero?")
       else
         assert_equal(false, z, "(#{a}).zero?")
-        assert_equal(a, n, "(#{a}).nonzero?")
+        assert_equal(a, n, "(#{a}).nonzero")
+        assert_equal(true, p, "(#{a}).nonzero?")
         check_class(n)
       end
-      assert(z ^ n, "(#{a}).zero? ^ (#{a}).nonzero?")
+      assert(z ^ p, "(#{a}).zero? ^ (#{a}).nonzero?")
     }
   end
 


### PR DESCRIPTION
`Numeric#zero?` returns `true` or `false`, while `Numeric#nonzero?` returns `self` or `nil`. This patch fixes this inconsistency and adds a `Numeric#nonzero` (non-predicate) method that returns `self` or `nil` for chaining comparisons.
