### PR TITLE
Treat bare hostnames as the host when parsing as into a URI

### DIFF
--- a/lib/uri/common.rb
+++ b/lib/uri/common.rb
@@ -121,6 +121,11 @@ module URI
       case uri
       when ''
         # null uri
+      when @regexp[:HOST]
+        scheme, opaque, userinfo, host, port,
+          registry, path, query, fragment = \
+        nil, nil, nil, $~[0], nil,
+          nil, nil, nil, nil
 
       when @regexp[:ABS_URI]
         scheme, opaque, userinfo, host, port,

--- a/test/uri/test_common.rb
+++ b/test/uri/test_common.rb
@@ -29,6 +29,18 @@ class TestCommon < Test::Unit::TestCase
 		 URI.extract('From: XXX [mailto:xxx@xxx.xxx.xxx]').sort)
   end
 
+  def test_parse
+    assert_equal('localhost',
+		 URI.parse('localhost').host)
+    assert_equal('127.0.0.1',
+		 URI.parse('127.0.0.1').host)
+    assert_equal('fe80::11:11:11',
+		 URI.parse('fe80::11:11:11').host)
+    assert_equal('www.ruby-lang.org',
+		 URI.parse('www.ruby-lang.org').host)
+  end
+
+
   def test_regexp
     assert_instance_of Regexp, URI.regexp
     assert_instance_of Regexp, URI.regexp(['http'])


### PR DESCRIPTION
The spec essentially leaves incomplete URI's as undefined behaviour

(http://www.ietf.org/rfc/rfc2396.txt Appendix F: Abbreviated URLs)

But inline with the behaviour of browsers and the like, it makes the
most sense to assume that a pattern that matches a hostname should be
treated as such.
