### PR TITLE
Fix bug where week-type arguments are parsed-and-ignored in Time::strptime

### DIFF
--- a/lib/time.rb
+++ b/lib/time.rb
@@ -401,6 +401,11 @@ class Time
       else
         year = d[:year]
         year = yield(year) if year && block_given?
+        if d[:wnum1] || d[:wnum0]
+          date = Date.strptime(date, format)
+          d[:mon]  ||= date.mon
+          d[:mday] ||= date.mday
+        end
         make_time(year, d[:mon], d[:mday], d[:hour], d[:min], d[:sec], d[:sec_fraction], d[:zone], now)
       end
     end


### PR DESCRIPTION
The underlying `Date::_strptime` returns a hash with week elements that are
ignored in the arguments passed to `Time::make_time`:

``` ruby
Date._strptime('2013-W46-4', '%Y-W%W-%w')
# => {:year=>2013, :wnum1=>46, :wday=>4}
Date.strptime('2013-W46-4', '%Y-W%W-%w')
# => #<Date: 2013-11-21 (4913235/2,0,2299161)>
```

This patch ensures that if these arguments are present, the resulting month
and day resolved from Date::strptime are not lost.

Before Patch (WRONG):

``` ruby
Time.strptime('2013-W46-4', '%Y-W%W-%w')
# => 2013-01-01 00:00:00 UTC
```

After Patch (CORRECT):

``` ruby
Time.strptime('2013-W46-4', '%Y-W%W-%w')
# => 2013-11-21 00:00:00 UTC
```

I am unsure of where to add tests for this, but believe that the fix should be back-ported to the 1.9 branch.
