### PR TITLE
If skip_lines is set to a String, convert it to a Regexp

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+Sat Nov 23 13:38:00 2013  Kyle Stevens  <kstevens715@gmail.com>
+
+	* lib/csv.rb: If skip_lines is set to a String, convert it to a Regexp
+	to prevent the alternative, which is that each line in the CSV gets
+	converted to a Regexp when calling skip_lines#match.
+
 Sat Nov 23 12:31:00 2013  Koichi Sasada  <ko1@atdot.net>
 
 	* gc.c: fix global variable name.

--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -1470,11 +1470,12 @@ class CSV
   # <b><tt>:skip_lines</tt></b>::         When set to an object responding to
   #                                       <tt>match</tt>, every line matching
   #                                       it is considered a comment and ignored
-  #                                       during parsing. When set to +nil+
-  #                                       no line is considered a comment.
-  #                                       If the passed object does not respond
-  #                                       to <tt>match</tt>, <tt>ArgumentError</tt>
-  #                                       is thrown.
+  #                                       during parsing. When set to a String,
+  #                                       it is first converted to a Regexp.
+  #                                       When set to +nil+ no line is considered
+  #                                       a comment. If the passed object does
+  #                                       not respond to <tt>match</tt>,
+  #                                       <tt>ArgumentError</tt> is thrown.
   #
   # See CSV::DEFAULT_OPTIONS for the default settings.
   #
@@ -2120,10 +2121,12 @@ class CSV
   # Stores the pattern of comments to skip from the provided options.
   #
   # The pattern must respond to +.match+, else ArgumentError is raised.
+  # Strings are converted to a Regexp.
   #
   # See also CSV.new
   def init_comments(options)
     @skip_lines = options.delete(:skip_lines)
+    @skip_lines = Regexp.new(@skip_lines) if @skip_lines.is_a? String
     if @skip_lines and not @skip_lines.respond_to?(:match)
       raise ArgumentError, ":skip_lines has to respond to matches"
     end

--- a/test/csv/test_features.rb
+++ b/test/csv/test_features.rb
@@ -299,12 +299,19 @@ class TestCSV::Features < TestCSV
   def test_comment_rows_are_ignored
     sample_data = "line,1,a\n#not,a,line\nline,2,b\n   #also,no,line"
     c = CSV.new sample_data, :skip_lines => /\A\s*#/
-    assert_equal c.each.to_a, [["line", "1", "a"], ["line", "2", "b"]]
+    assert_equal [["line", "1", "a"], ["line", "2", "b"]], c.each.to_a
   end
 
   def test_quoted_skip_line_markers_are_ignored
     sample_data = "line,1,a\n\"#not\",a,line\nline,2,b"
     c = CSV.new sample_data, :skip_lines => /\A\s*#/
-    assert_equal c.each.to_a, [["line", "1", "a"], ["#not", "a", "line"], ["line", "2", "b"]]
+    assert_equal [["line", "1", "a"], ["#not", "a", "line"], ["line", "2", "b"]], c.each.to_a
   end
+
+  def test_string_works_like_a_regexp
+    sample_data = "line,1,a\n#(not,a,line\nline,2,b\n   also,#no,line"
+    c = CSV.new sample_data, :skip_lines => "#"
+    assert_equal [["line", "1", "a"], ["line", "2", "b"]], c.each.to_a
+  end
+
 end


### PR DESCRIPTION
This pull request fixes the issue I described in: https://bugs.ruby-lang.org/issues/8560

Basically, skip_lines takes any object that responds to match and passes in each line of the csv as an argument to match. But when skip_lines is a string, string#match converts it's argument to a Regexp. In our case, that argument is each line in the CSV. So each line gets converted to a Regexp one at a time.

It is very unexpected behavior for each line in the CSV to act as a Regexp. And in many cases, it will cause an error similar to:

```
2.0.0-p247 :001 > "test".match "#("
RegexpError: end pattern with unmatched parenthesis: /#(/
    from (irb):1:in `match'
    from (irb):1
    from /home/kyle/.rvm/rubies/ruby-2.0.0-p247/bin/irb:12:in `<main>'
```

Forced to make the choice between converting skip_lines to a Regexp if it's a String and converting each line in the CSV to a Regexp, I've chosen the former.
