### PR TITLE
Fix bug #9155. Problem with delegate class.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+Thu Nov 29 12:57:00 2013  Simon Mathieu <simon.math@gmail.com>
+
+	* lib/delegate.rb: allow method call in class delegate constuctor.
+	[bug:#9155] 
+
+	* test/test_delegatei.rb (test_use_delegated_method_in_constuctor): Test for above.
+
 Thu Nov 28 21:43:48 2013  Zachary Scott  <e@zzak.io>
 
 	* doc/dtrace_probes.rdoc: [DOC] Import dtrace probes doc from wiki

--- a/lib/delegate.rb
+++ b/lib/delegate.rb
@@ -68,15 +68,16 @@ class Delegator < BasicObject
   #
   def initialize(obj)
     __setobj__(obj)
+    @delegate_sd_obj_initialized = true
   end
 
   #
   # Handles the magic of delegation through \_\_getobj\_\_.
   #
   def method_missing(m, *args, &block)
-    target = self.__getobj__
     begin
-      if target.respond_to?(m)
+      target = self.__getobj__ if @delegate_sd_obj_initialized
+      if @delegate_sd_obj_initialized && target.respond_to?(m)
         target.__send__(m, *args, &block)
       elsif ::Kernel.respond_to?(m, true)
         ::Kernel.instance_method(m).bind(self).(*args, &block)

--- a/test/test_delegate.rb
+++ b/test/test_delegate.rb
@@ -168,4 +168,16 @@ class TestDelegateClass < Test::Unit::TestCase
       d.__getobj__
     }
   end
+
+  class X < DelegateClass(Integer)
+    def initialize(value)
+      value = Integer(value)
+      super(value)
+    end
+  end
+
+  def test_use_delegated_method_in_constuctor
+    x = X.new(1)
+    assert_equal(1, x.to_i)
+  end
 end


### PR DESCRIPTION
Problem was that a simple class like:

```
class X < DelegateClass(Integer)
  def initialize(value)
    value = Integer(value)
    super(value)
  end
end
```

would fail because Integer would call method_missing of SimpleDelegate, but that would raise an exception since the object to delegate to is not yet set (it will be when super is called).

/cc @nobu
