### PR TITLE
Test for crashing Ruby when object doesn't have :=== method in case

### DIFF
--- a/test/ruby/test_case.rb
+++ b/test/ruby/test_case.rb
@@ -75,6 +75,18 @@ class TestCase < Test::Unit::TestCase
     end
   end
 
+  def test_basic_object
+    klass_without_tree_equals = Class.new do
+                                  undef_method :===
+                                end
+
+    assert_raise(NameError) do
+      case ''
+      when klass_without_tree_equals.new
+      end
+    end
+  end
+
   def test_deoptimization
     assert_in_out_err(['-e', <<-EOS], '', %w[42], [])
       class Symbol; undef ===; def ===(o); p 42; true; end; end; case :foo; when :foo; end


### PR DESCRIPTION
This commit tests recently [fixed bug](http://svn.ruby-lang.org/cgi-bin/viewvc.cgi/trunk/vm_insnhelper.c?r1=43913&r2=43912&pathrev=43913). The problem is consists of the following: when we have object which doesn't have defined `:===` method Ruby crashes in case statement. `BasicObject` doesn't have this method and the bug is reproduced on this object:

``` ruby
case 1
when BasicObject.new
end
```

And we have crash.
