### PR TITLE
Use an array instead of a hash table for id_str

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -10088,7 +10088,8 @@ static const struct {
 static struct symbols {
     ID last_id;
     st_table *sym_id;
-    st_table *id_str;
+    size_t id_str_cap;
+    VALUE *id_str;
 #if ENABLE_SELECTOR_NAMESPACE
     st_table *ivar2_id;
     st_table *id_ivar2;
@@ -10133,7 +10134,12 @@ void
 Init_sym(void)
 {
     global_symbols.sym_id = st_init_table_with_size(&symhash, 1000);
-    global_symbols.id_str = st_init_numtable_with_size(1000);
+
+    global_symbols.id_str_cap = 1024;
+    #undef calloc
+    global_symbols.id_str = calloc(1024, sizeof(VALUE));
+    #define calloc YYCALLOC
+
 #if ENABLE_SELECTOR_NAMESPACE
     global_symbols.ivar2_id = st_init_table_with_size(&ivar2_hash_type, 1000);
     global_symbols.id_ivar2 = st_init_numtable_with_size(1000);
@@ -10152,7 +10158,8 @@ void
 rb_gc_mark_symbols(int full_mark)
 {
     if (full_mark || global_symbols.minor_marked == 0) {
-	rb_mark_tbl(global_symbols.id_str);
+	rb_gc_mark_locations(global_symbols.id_str,
+	                     global_symbols.id_str + global_symbols.id_str_cap);
 	rb_gc_mark_locations(global_symbols.op_sym,
 			     global_symbols.op_sym + numberof(global_symbols.op_sym));
 
@@ -10340,7 +10347,18 @@ register_symid_str(ID id, VALUE str)
     }
 
     st_add_direct(global_symbols.sym_id, (st_data_t)str, id);
-    st_add_direct(global_symbols.id_str, id, (st_data_t)str);
+
+    if (id >= global_symbols.id_str_cap) {
+	size_t old_cap = global_symbols.id_str_cap;
+	global_symbols.id_str_cap *= 2;
+	#undef realloc
+	global_symbols.id_str = realloc(global_symbols.id_str,
+	    sizeof(VALUE) * global_symbols.id_str_cap);
+	#define realloc YYREALLOC
+	memset(global_symbols.id_str + old_cap, 0, old_cap / 2 * sizeof(VALUE));
+    }
+
+    global_symbols.id_str[id] = str;
     global_symbols.minor_marked = 0;
     return id;
 }
@@ -10563,7 +10581,7 @@ rb_id2str(ID id)
 	}
     }
 
-    if (st_lookup(global_symbols.id_str, id, &data)) {
+    if (id < global_symbols.id_str_cap && (data = global_symbols.id_str[id])) {
         VALUE str = (VALUE)data;
         if (RBASIC(str)->klass == 0)
             RBASIC_SET_CLASS_RAW(str, rb_cString);
@@ -10586,12 +10604,11 @@ rb_id2str(ID id)
 	str = rb_str_dup(str);
 	rb_str_cat(str, "=", 1);
 	register_symid_str(id, str);
-	if (st_lookup(global_symbols.id_str, id, &data)) {
-            VALUE str = (VALUE)data;
-            if (RBASIC(str)->klass == 0)
-                RBASIC_SET_CLASS_RAW(str, rb_cString);
-            return str;
-        }
+
+	str = global_symbols.id_str[id];
+	if (RBASIC(str)->klass == 0)
+	    RBASIC_SET_CLASS_RAW(str, rb_cString);
+	return str;
     }
     return 0;
 }


### PR DESCRIPTION
Ruby spends a non-trivial amount of time in `rb_id2str` when booting the GitHub Rails app:

![screen shot 2013-12-01 at 10 17 02 pm](https://f.cloud.github.com/assets/179065/1650278/9bdfef58-5a7a-11e3-8637-562ad91605e1.png)

This pull request changes `global_symbols.id_str` to be an array instead of a hash table. Because ID values are sequentially increasing integers, using a hashtable for `id_str` is unnecessary and slow.

This improves the boot time of our app by about 150-200ms.

Before:

```
        6.65 real         5.40 user         1.23 sys
        6.76 real         5.47 user         1.25 sys
        6.58 real         5.35 user         1.20 sys
        6.62 real         5.39 user         1.20 sys
        6.69 real         5.44 user         1.21 sys
```

After:

```
        6.41 real         5.19 user         1.19 sys
        6.45 real         5.22 user         1.20 sys
        6.45 real         5.21 user         1.20 sys
        6.46 real         5.22 user         1.20 sys
        6.43 real         5.20 user         1.20 sys
```

cc @ko1