### PR TITLE
Fix of bugfix to #1145

### DIFF
--- a/lib/irb/completion.rb
+++ b/lib/irb/completion.rb
@@ -227,7 +227,7 @@ end
 
 if Readline.respond_to?("basic_word_break_characters=")
 #  Readline.basic_word_break_characters= " \t\n\"\\'`><=;|&{("
-  Readline.basic_word_break_characters= " \t\n`><=;|&{("
+  Readline.basic_word_break_characters= "\t\n\\`><=;|&{("
 end
 Readline.completion_append_character = nil
 Readline.completion_proc = IRB::InputCompletor::CompletionProc


### PR DESCRIPTION
Updated list of word breaking characters for Readline completion need to omit space character ` `as it breaks completion of`String` instance containing one or more spaces:

``` ruby
irb> 'test me'.u<press TAB for completions>
me'.uid            me'.unpack         me'.update         me'.usec
me'.unbind         me'.unshift        me'.upto           me'.utc
me'.ungetbyte      me'.untaint        me'.use_loader=    me'.utc?
me'.ungetc         me'.untrust        me'.use_readline   me'.utc_offset
me'.uniq           me'.untrusted?     me'.use_readline=  me'.utime
me'.uniq!          me'.upcase         me'.use_readline?  me'.utime=
me'.unlock         me'.upcase!        me'.use_tracer=
```

See, leading string is broken by space and completion is improperly processed and unrelated methods are offered.

With the fix, completion starts to work properly again:

``` ruby
irb> 'test me'.u<press TAB for completions>
'test me'.unpack      'test me'.untrusted?  'test me'.upto
'test me'.untaint     'test me'.upcase      
'test me'.untrust     'test me'.upcase!
```

I believe this fix won't touch completions for other objects. Also see no reason to omit backslash character `\\` from the default list.

Take care
