### PR TITLE
* lib/webrick/httprequest.rb: [DOC] Change document link

### DIFF
--- a/lib/webrick/httprequest.rb
+++ b/lib/webrick/httprequest.rb
@@ -369,7 +369,8 @@ module WEBrick
 
     # This method provides the metavariables defined by the revision 3
     # of "The WWW Common Gateway Interface Version 1.1"
-    # http://Web.Golux.Com/coar/cgi/
+    # To browse the current document of CGI Version 1.1, see below:
+    # http://tools.ietf.org/html/rfc3875
 
     def meta_vars
       meta = Hash.new


### PR DESCRIPTION
http://Web.Golux.Com/coar/cgi/ doesn't seem to work now.
It is currently redirected to [Apache Software webring](http://www.webring.org/hub/apachesupport?w=1440;rh=http%3A%2F%2Fcgi-spec.golux.com%2F;rd=1), which is not directly referring to CGI.

And RFC 3875 does not contain this link. So I propose to change the link to RFC's.
