### PR TITLE
Net/http to_hash returns pair of key and values (where the values are arrays and not strings)

### DIFF
--- a/lib/net/http/header.rb
+++ b/lib/net/http/header.rb
@@ -145,11 +145,13 @@ module Net::HTTPHeader
     @header.key?(key.downcase)
   end
 
-  # Returns a Hash consisting of header names and values.
+  # Returns a Hash consisting of header names and array of values.
   # e.g.
-  # {"cache-control" => "private",
-  #  "content-type" => "text/html",
-  #  "date" => "Wed, 22 Jun 2005 22:11:50 GMT"}
+  # {"cache-control" => ["private"],
+  #  "content-type" => ["text/html"],
+  #  "date" => ["Wed, 22 Jun 2005 22:11:50 GMT"]
+  #   "set-cookie"=> ["PREF=ID=d1e913f2336ed0f7:FF=0:TM=1386208573:LM=1386208573:S=VAKJNSsp0fqk2KJo; expires=Sat, 05-Dec-2015 01:56:13 GMT; path=/; domain=.google.com",
+  #        "NID=67=n11-eGCvw3LfM3Uh9vPzB7mE5fC2B8QcLI01LoasujaIC3lm73DIFij78i40ibkMGx_FHxS6rC1MtlcJDnlLYbYbwecXI1PJM5qFE-D6-mOGgF69jvWws3QUzxtmKocO; expires=Fri, 06-Jun-2014 01:56:13 GMT; path=/; domain=.google.com; HttpOnly"],}
   def to_hash
     @header.dup
   end


### PR DESCRIPTION
The comment on the method <code>Net::HTTPHeader#to_hash</code> states pair of key and values however it is should be pair of key and values, the values should be arrays and not strings (as in the comment), below is a sample to prove this.

``` ruby
Net::HTTP.get_response(URI('http://www.google.com')).to_hash
=> {"date"=>["Thu, 05 Dec 2013 01:56:13 GMT"],
 "expires"=>["-1"],
 "cache-control"=>["private, max-age=0"],
 "content-type"=>["text/html; charset=ISO-8859-1"],
 "set-cookie"=>
  ["PREF=ID=d1e913f2336ed0f7:FF=0:TM=1386208573:LM=1386208573:S=VAKJNSsp0fqk2KJo; expires=Sat, 05-Dec-2015 01:56:13 GMT; path=/; domain=.google.com",
   "NID=67=n11-eGCvw3LfM3Uh9vPzB7mE5fC2B8QcLI01LoasujaIC3lm73DIFij78i40ibkMGx_FHxS6rC1MtlcJDnlLYbYbwecXI1PJM5qFE-D6-mOGgF69jvWws3QUzxtmKocO; expires=Fri, 06-Jun-2014 01:56:13 GMT; path=/; domain=.google.com; HttpOnly"],
 "p3p"=>
  ["CP=\"This is not a P3P policy! See http://www.google.com/support/accounts/bin/answer.py?hl=en&answer=151657 for more info.\""],
 "server"=>["gws"],
 "x-xss-protection"=>["1; mode=block"],
 "x-frame-options"=>["SAMEORIGIN"],
 "alternate-protocol"=>["80:quic"],
 "transfer-encoding"=>["chunked"]}
```
