### PR TITLE
Tests/struct question mark

### DIFF
--- a/test/ruby/test_struct.rb
+++ b/test/ruby/test_struct.rb
@@ -290,6 +290,12 @@ module TestStruct
     assert_true(o.b?)
   end
 
+  def test_bang_mark_in_member
+    klass = @Struct.new(:a, :b!)
+    o = klass.new("test", true)
+    assert_true(o.b!)
+  end
+
   class TopStruct < Test::Unit::TestCase
     include TestStruct
 


### PR DESCRIPTION
While developing some software on 1.8, I discovered that question marks in struct members break everything.

I assumed it was still broken, so I wrote a test and found it's fixed on trunk, but since there's no regression test for it I'm pushing it upstream.

The error on 1.8:

```
irb(main):001:0> k = Struct.new(:a, :b?)
=> #<Class:0x107387108>
irb(main):002:0> o = k.new("a", false)
=> #<struct #<Class:0x107387108> a="a", :b?=false>
irb(main):003:0> o.b?
NoMethodError: undefined method `b?' for #<struct #<Class:0x107387108> a="a", :b?=false>
        from (irb):3
irb(main):004:0>
```
