### PR TITLE
lib/resolv.rb: pass rcode to OtherResolvError

### DIFF
--- a/lib/resolv.rb
+++ b/lib/resolv.rb
@@ -545,7 +545,7 @@ class Resolv
           when RCode::NXDomain
             raise Config::NXDomain.new(reply_name.to_s)
           else
-            raise Config::OtherResolvError.new(reply_name.to_s)
+            raise Config::OtherResolvError.new(reply_name.to_s, reply.rcode)
           end
         }
       ensure
@@ -1106,6 +1106,11 @@ class Resolv
       # Indicates some other unhandled resolver error was encountered.
 
       class OtherResolvError < ResolvError
+        attr_reader :rcode
+        def initialize(message, rcode)
+          super(message)
+          @rcode = rcode
+        end
       end
     end
 


### PR DESCRIPTION
This makes it possible to detect the reason for the failure.
