### PR TITLE
Refactor #test_include_module_with_constants_invalidates_method_cache

### DIFF
--- a/test/ruby/test_module.rb
+++ b/test/ruby/test_module.rb
@@ -1780,8 +1780,8 @@ class TestModule < Test::Unit::TestCase
     assert_raise(NoMethodError, bug8284) {Object.define_method}
   end
 
-  def test_include_module_with_constants_invalidates_method_cache
-    assert_in_out_err([], <<-RUBY, %w(123 456), [])
+  def test_include_module_with_constants_does_not_invalidate_method_cache
+    assert_in_out_err([], <<-RUBY, %w(123 456 true), [])
       A = 123
 
       class Foo
@@ -1795,8 +1795,13 @@ class TestModule < Test::Unit::TestCase
       end
 
       puts Foo.a
+      starting = RubyVM.stat[:global_method_state]
+
       Foo.send(:include, M)
+
+      ending = RubyVM.stat[:global_method_state]
       puts Foo.a
+      puts starting == ending
     RUBY
   end
 


### PR DESCRIPTION
* [Including modules containing constants no longer invalidate method cache](https://github.com/ruby/ruby/blob/trunk/ChangeLog#L2830-L2832)