### PR TITLE
Magic comment "immutable: string" makes "literal".freeze the default for that file

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -3817,6 +3817,11 @@ strings		: string
 			else {
 			    node = evstr2dstr(node);
 			}
+
+			if (parser->immutable_strings) {
+			    node = NEW_CALL(node, idFreeze, 0); 
+			}
+
 			$$ = node;
 		    /*%
 			$$ = $1;
@@ -3839,12 +3844,9 @@ string		: tCHAR
 string1		: tSTRING_BEG string_contents tSTRING_END
 		    {
 		    /*%%%*/
+
 			$$ = $2;
-			if (parser->immutable_strings) {
-			    $$ = NEW_CALL($2, idFreeze, 0);
- 			} else {
-			    $$ = $2;
- 			}
+
 		    /*%
 			$$ = dispatch1(string_literal, $2);
 		    %*/

--- a/test/ruby/test_string_literal.rb
+++ b/test/ruby/test_string_literal.rb
@@ -1,14 +1,5 @@
 # -*- immutable: string -*-
 
-#class NilClass
-#  def freeze
-#    raise '!!!'
-#  end
-#end
-#
-#puts('', '')
-
-
 require 'test/unit'
 require_relative 'test_string_literal_mutable.rb'
 
@@ -46,14 +37,6 @@ class TestStringLiteral < Test::Unit::TestCase
     end
   end
 
-  def test_string_interpolation
-    str = interpolated_string("blah blah")
-    exception = assert_raise RuntimeError do
-      mutate(str)
-    end
-    assert_match /can't modify frozen String/, exception.message
-  end
-
   def test_strings_in_other_file_are_mutable
     mutate(TestStringLiteralMutable::CONSTANT)
     assert_equal "SING", TestStringLiteralMutable::CONSTANT
@@ -63,6 +46,20 @@ class TestStringLiteral < Test::Unit::TestCase
     s1 = some_string
     s2 = some_string
     assert_equal s1.object_id, s2.object_id
+  end
+
+  def test_different_literal_strings_with_the_same_value_in_the_same_file_should_have_the_same_object_id
+    s1 = some_string
+    s2 = "A nice frozen string!"
+    assert_equal s2.object_id, s2.object_id
+  end
+
+  def test_string_interpolation
+    str = interpolated_string("blah blah")
+    exception = assert_raise RuntimeError do
+      mutate(str)
+    end
+    assert_match /can't modify frozen String/, exception.message
   end
 
   def test_interpolated_strings_should_have_a_different_object_id

--- a/test/ruby/test_string_literal.rb
+++ b/test/ruby/test_string_literal.rb
@@ -1,0 +1,75 @@
+# -*- immutable: string -*-
+
+#class NilClass
+#  def freeze
+#    raise '!!!'
+#  end
+#end
+#
+#puts('', '')
+
+
+require 'test/unit'
+require_relative 'test_string_literal_mutable.rb'
+
+
+STRINGS = [
+  'hello',
+  "hello",
+  %{Hello},
+  %Q{Hello},
+  %q{Hello},
+  <<-EOS
+    Hello World
+  EOS
+]
+
+class TestStringLiteral < Test::Unit::TestCase
+  def mutate(str)
+    str.slice!(1, 2)
+  end
+
+  def interpolated_string(message)
+    "Interpolated: #{message}"
+  end
+
+  def some_string
+    "A nice frozen string!"
+  end
+
+  def test_strings_are_immutable_in_this_file
+    STRINGS.each do |s|
+      exception = assert_raise RuntimeError, s do
+        mutate(s)
+      end
+      assert_match /can't modify frozen String/, exception.message
+    end
+  end
+
+  def test_string_interpolation
+    str = interpolated_string("blah blah")
+    exception = assert_raise RuntimeError do
+      mutate(str)
+    end
+    assert_match /can't modify frozen String/, exception.message
+  end
+
+  def test_strings_in_other_file_are_mutable
+    mutate(TestStringLiteralMutable::CONSTANT)
+    assert_equal "SING", TestStringLiteralMutable::CONSTANT
+  end
+
+  def test_literal_strings_should_have_the_same_object_id
+    s1 = some_string
+    s2 = some_string
+    assert_equal s1.object_id, s2.object_id
+  end
+
+  def test_interpolated_strings_should_have_a_different_object_id
+    s1 = interpolated_string('x')
+    s2 = interpolated_string('x')
+    assert_equal "Interpolated: x", s1
+    assert_equal "Interpolated: x", s2
+    assert_not_equal s1.object_id, s2.object_id
+  end
+end

--- a/test/ruby/test_string_literal_mutable.rb
+++ b/test/ruby/test_string_literal_mutable.rb
@@ -1,0 +1,3 @@
+module TestStringLiteralMutable
+  CONSTANT = "STRING"
+end


### PR DESCRIPTION
Add magic comment `# -*- immutable: string -*-` to Ruby that implies `.freeze` on every string literal in the file. To get a mutable string in a file that starts with the magic comment, use `String.new` or `''.dup`.

For more details, background, and rationale, please see this blog post:

http://development.invoca.com/magic-comment-immutable-string-makes-ruby-2-1s-literal-freeze-optimization-the-default/