### PR TITLE
Declare `OP_MSIE_SSLV2_RSA_PADDING` only if the macro is defined.

### DIFF
--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -2229,7 +2229,9 @@ Init_ossl_ssl()
     ossl_ssl_def_const(OP_NETSCAPE_REUSE_CIPHER_CHANGE_BUG);
     ossl_ssl_def_const(OP_SSLREF2_REUSE_CERT_TYPE_BUG);
     ossl_ssl_def_const(OP_MICROSOFT_BIG_SSLV3_BUFFER);
+#if defined(SSL_OP_MSIE_SSLV2_RSA_PADDING)
     ossl_ssl_def_const(OP_MSIE_SSLV2_RSA_PADDING);
+#endif
     ossl_ssl_def_const(OP_SSLEAY_080_CLIENT_DH_BUG);
     ossl_ssl_def_const(OP_TLS_D5_BUG);
     ossl_ssl_def_const(OP_TLS_BLOCK_PADDING_BUG);


### PR DESCRIPTION
The `SSL_OP_MSIE_SSLV2_RSA_PADDING` has been removed from latest snapshot of OpenSSL 1.0.1. (it has been removed in https://github.com/openssl/openssl/commit/4b61f6d2a675fdb57dc93991e7b332a745b44d1f)

Because Debian's `openssl` package is made with backported patches from latest snapshot, I could not build the `openssl` module on Debian GNU/Linux sid (amd64) without this fix. (the Debian's `openssl>=1.0.1e-5` will corrupt the build) Yes, this is a problem of Debian package, but this has been merged into the release branch of OpenSSL 1.1.0, I think we need this before the next release of OpenSSL will come.
