### PR TITLE
Update refinements.rdoc

### DIFF
--- a/doc/syntax/refinements.rdoc
+++ b/doc/syntax/refinements.rdoc
@@ -44,7 +44,7 @@ Activate the refinement with #using:
 
   x = C.new
 
-  c.foo # prints "C#foo in M"
+  x.foo # prints "C#foo in M"
 
 == Scope
 


### PR DESCRIPTION
modify doc error:

``` ruby
    using M
    x = C.new
    c.foo # prints "C#foo in M"
```

change to:

``` ruby
    using M
    x = C.new
    x.foo # prints "C#foo in M"
```
