### PR TITLE
Added tests for sprintf with a hash as parameter.

### DIFF
--- a/test/ruby/test_sprintf.rb
+++ b/test/ruby/test_sprintf.rb
@@ -147,6 +147,11 @@ class TestSprintf < Test::Unit::TestCase
       sprintf("%b", -2147483649), '[ruby-dev:32365]')
     assert_equal(" Inf", sprintf("% e", inf), '[ruby-dev:34002]')
   end
+  
+  def test_hash
+    options = {:capture=>/\d+/}
+    assert_equal("with options {:capture=>/\\d+/}", sprintf("with options %p" % options))
+  end
 
   def test_invalid
     # Star precision before star width:


### PR DESCRIPTION
This is something that is broken in JRuby and we realized that mri also doesn't have test coverage.
