### PR TITLE
Cache multiple compiled regexps

### DIFF
--- a/ext/strscan/strscan.c
+++ b/ext/strscan/strscan.c
@@ -447,9 +447,6 @@ strscan_set_pos(VALUE self, VALUE v)
 static VALUE
 strscan_do_scan(VALUE self, VALUE regex, int succptr, int getstr, int headonly)
 {
-    regex_t *rb_reg_prepare_re(VALUE re, VALUE str);
-    void rb_reg_release_re(regex_t *reg, VALUE re, VALUE str);
-
     struct strscanner *p;
     regex_t *re;
     long ret;

--- a/ext/strscan/strscan.c
+++ b/ext/strscan/strscan.c
@@ -973,7 +973,7 @@ name_to_backref_number(struct re_registers *regs, VALUE regexp, const char* name
 {
     int num;
 
-    num = onig_name_to_backref_number(RREGEXP(regexp)->ptr,
+    num = onig_name_to_backref_number(RREGEXP_PTR(regexp),
 	(const unsigned char* )name, (const unsigned char* )name_end, regs);
     if (num >= 1) {
 	return num;

--- a/gc.c
+++ b/gc.c
@@ -1555,10 +1555,13 @@ obj_free(rb_objspace_t *objspace, VALUE obj)
 	    onig_free(RREGEXP_PTR(obj));
 	}
 	for (i = 0; i < RREGEXP_CACHE_SIZE; ++i) {
-	    if (RREGEXP(obj)->cache[i]) {
-		onig_free(RREGEXP(obj)->cache[i]);
+	    if (RREGEXP_EXT(obj)->cache[i]) {
+		onig_free(RREGEXP_EXT(obj)->cache[i]);
 	    }
 	}
+	if (RREGEXP_EXT(obj))
+	    xfree(RREGEXP_EXT(obj));
+
 	break;
       case T_DATA:
 	if (DATA_PTR(obj)) {
@@ -2481,8 +2484,9 @@ obj_memsize_of(VALUE obj, int use_tdata)
 	    size += onig_memsize(RREGEXP_PTR(obj));
 	}
 	for (i = 0; i < RREGEXP_CACHE_SIZE; ++i) {
-	    size += onig_memsize(RREGEXP(obj)->cache[i]);
+	    size += onig_memsize(RREGEXP_EXT(obj)->cache[i]);
 	}
+	size += sizeof(rb_regexpext_t);
 
 	break;
       case T_DATA:

--- a/gc.c
+++ b/gc.c
@@ -1551,12 +1551,12 @@ obj_free(rb_objspace_t *objspace, VALUE obj)
 	}
 	break;
       case T_REGEXP:
-	if (RANY(obj)->as.regexp.ptr) {
-	    onig_free(RANY(obj)->as.regexp.ptr);
+	if (RREGEXP_PTR(obj)) {
+	    onig_free(RREGEXP_PTR(obj));
 	}
 	for (i = 0; i < RREGEXP_CACHE_SIZE; ++i) {
-	    if (RANY(obj)->as.regexp.cache[i]) {
-		onig_free(RANY(obj)->as.regexp.cache[i]);
+	    if (RREGEXP(obj)->cache[i]) {
+		onig_free(RREGEXP(obj)->cache[i]);
 	    }
 	}
 	break;
@@ -2477,8 +2477,8 @@ obj_memsize_of(VALUE obj, int use_tdata)
 	}
 	break;
       case T_REGEXP:
-	if (RREGEXP(obj)->ptr) {
-	    size += onig_memsize(RREGEXP(obj)->ptr);
+	if (RREGEXP_PTR(obj)) {
+	    size += onig_memsize(RREGEXP_PTR(obj));
 	}
 	for (i = 0; i < RREGEXP_CACHE_SIZE; ++i) {
 	    size += onig_memsize(RREGEXP(obj)->cache[i]);

--- a/include/ruby/re.h
+++ b/include/ruby/re.h
@@ -58,6 +58,7 @@ long rb_reg_adjust_startpos(VALUE, VALUE, long, int);
 void rb_match_busy(VALUE);
 VALUE rb_reg_quote(VALUE);
 regex_t *rb_reg_prepare_re(VALUE re, VALUE str);
+void rb_reg_release_re(regex_t *, VALUE re, VALUE str);
 
 RUBY_SYMBOL_EXPORT_END
 

--- a/include/ruby/ruby.h
+++ b/include/ruby/ruby.h
@@ -917,7 +917,9 @@ struct RRegexp {
     const VALUE src;
     unsigned long usecnt;
 };
-#define RREGEXP_SRC(r) RREGEXP(r)->src
+
+#define RREGEXP_PTR(r) (RREGEXP(r)->ptr)
+#define RREGEXP_SRC(r) (RREGEXP(r)->src)
 #define RREGEXP_SRC_PTR(r) RSTRING_PTR(RREGEXP(r)->src)
 #define RREGEXP_SRC_LEN(r) RSTRING_LEN(RREGEXP(r)->src)
 #define RREGEXP_SRC_END(r) RSTRING_END(RREGEXP(r)->src)

--- a/include/ruby/ruby.h
+++ b/include/ruby/ruby.h
@@ -908,9 +908,12 @@ struct RArray {
 
 #define RARRAY_PTR(a) ((VALUE *)RARRAY_CONST_PTR(RGENGC_WB_PROTECTED_ARRAY ? OBJ_WB_UNPROTECT((VALUE)a) : ((VALUE)a)))
 
+#define RREGEXP_CACHE_SIZE 3
+
 struct RRegexp {
     struct RBasic basic;
     struct re_pattern_buffer *ptr;
+    struct re_pattern_buffer *cache[RREGEXP_CACHE_SIZE];
     const VALUE src;
     unsigned long usecnt;
 };

--- a/include/ruby/ruby.h
+++ b/include/ruby/ruby.h
@@ -909,13 +909,13 @@ struct RArray {
 #define RARRAY_PTR(a) ((VALUE *)RARRAY_CONST_PTR(RGENGC_WB_PROTECTED_ARRAY ? OBJ_WB_UNPROTECT((VALUE)a) : ((VALUE)a)))
 
 #define RREGEXP_CACHE_SIZE 3
+typedef struct rb_regexpext_struct rb_regexpext_t;
 
 struct RRegexp {
     struct RBasic basic;
     struct re_pattern_buffer *ptr;
-    struct re_pattern_buffer *cache[RREGEXP_CACHE_SIZE];
     const VALUE src;
-    unsigned long usecnt;
+    rb_regexpext_t *ext;
 };
 
 #define RREGEXP_PTR(r) (RREGEXP(r)->ptr)

--- a/internal.h
+++ b/internal.h
@@ -688,6 +688,14 @@ VALUE rb_lcm(VALUE x, VALUE y);
 VALUE rb_rational_reciprocal(VALUE x);
 
 /* re.c */
+
+#define RREGEXP_EXT(r) (RREGEXP(r)->ext)
+
+struct rb_regexpext_struct {
+    struct re_pattern_buffer *cache[RREGEXP_CACHE_SIZE];
+    unsigned long usecnt;
+};
+
 VALUE rb_reg_compile(VALUE str, int options, const char *sourcefile, int sourceline);
 VALUE rb_reg_check_preprocess(VALUE);
 

--- a/parse.y
+++ b/parse.y
@@ -9943,7 +9943,7 @@ reg_named_capture_assign_gen(struct parser_params* parser, VALUE regexp, NODE *m
     arg.succ_block = 0;
     arg.fail_block = 0;
     arg.num = 0;
-    onig_foreach_name(RREGEXP(regexp)->ptr, reg_named_capture_assign_iter, (void*)&arg);
+    onig_foreach_name(RREGEXP_PTR(regexp), reg_named_capture_assign_iter, (void*)&arg);
 
     if (arg.num == 0)
         return match;

--- a/string.c
+++ b/string.c
@@ -2899,7 +2899,7 @@ rb_str_rindex_m(int argc, VALUE *argv, VALUE str)
 	pos = str_offset(RSTRING_PTR(str), RSTRING_END(str), pos,
 			 STR_ENC_GET(str), single_byte_optimizable(str));
 
-	if (!RREGEXP(sub)->ptr || RREGEXP_SRC_LEN(sub)) {
+	if (!RREGEXP_PTR(sub) || RREGEXP_SRC_LEN(sub)) {
 	    pos = rb_reg_search(sub, str, pos, 1);
 	    pos = rb_str_sublen(str, pos);
 	}


### PR DESCRIPTION
This caches compiled versions of different encoded regular expressions.
This helps performance wise in cases where the same regular expression
gets used against different encodings.

In Rails this is a pretty common scenario if templates with user
generated content sometimes only contain ASCII characters, other times
binary and sometimes UTF-8.

This caches the encodings with the lowest three encoding id's, which is
US-ASCII, BINARY and UTF-8. They are also the most commonly used and
provides a compromise between additional size usage and performance.
