### PR TITLE
casecmp(b).zero? add to_i avoid call nil.zero?

### DIFF
--- a/ext/pathname/lib/pathname.rb
+++ b/ext/pathname/lib/pathname.rb
@@ -22,7 +22,7 @@ class Pathname
   end
 
   SAME_PATHS = if File::FNM_SYSCASE.nonzero?
-    proc {|a, b| a.casecmp(b).zero?}
+    proc {|a, b| a.casecmp(b).to_i.zero?}
   else
     proc {|a, b| a == b}
   end


### PR DESCRIPTION
On win32 platform, file system encoding not UTF-8,

cd to a non-ascii directory and run rdoc xxx, that raise a error.

---

ruby 2.0.0p353 (2013-11-22) [i386-mingw32]
