### PR TITLE
Improve documentation of Range#size

### DIFF
--- a/range.c
+++ b/range.c
@@ -711,9 +711,12 @@ sym_each_i(RB_BLOCK_CALL_FUNC_ARGLIST(v, arg))
  *  call-seq:
  *     rng.size                   -> num
  *
- *  Returns the number of elements in the range.
+ *  Returns the number of elements in the range. Both the begin and the end of
+ *  the Range must be Numeric, otherwise nil is returned.
  *
  *    (10..20).size    #=> 11
+ *    ('a'..'z').size  #=> nil
+ *    (-Float::INFINITY..Float::INFINITY).size #=> Infinity
  */
 
 static VALUE


### PR DESCRIPTION
Documents the case where the range is not Numeric.
Adds an example for the case where the range is not Numeric.
Adds an example for the case where the method returns Infinity.
