### PR TITLE
#9316 BigDecimal division in Ruby 2.1

### DIFF
--- a/test/bigdecimal/test_bigmath.rb
+++ b/test/bigdecimal/test_bigmath.rb
@@ -14,6 +14,10 @@ class TestBigMath < Test::Unit::TestCase
     assert_in_delta(Math::E, E(N))
   end
 
+  def test_division
+    assert_in_delta(1486.868686869, (BigDecimal.new("1472.0") / BigDecimal.new("0.99")).to_f)
+  end
+
   def test_sqrt
     assert_in_delta(2**0.5, sqrt(BigDecimal("2"), N))
     assert_equal(10, sqrt(BigDecimal("100"), N))


### PR DESCRIPTION
This is a _failing_ test that illustrates the problem.

./miniruby -I./lib -I. -I.ext/common  ./tool/runruby.rb test/bigdecimal/test_bigmath.rb
...
[4/6] TestBigMath#test_division = 0.00 s  
  1) Failure:
TestBigMath#test_division [test/bigdecimal/test_bigmath.rb:18]:
Expected |1486.868686869 - 1487.0| (0.13131313100006992) to be <= 0.001.
