### PR TITLE
Add example for Dir.pwd in Dir.getwd doc

### DIFF
--- a/dir.c
+++ b/dir.c
@@ -906,6 +906,7 @@ rb_dir_getwd(void)
  *
  *     Dir.chdir("/tmp")   #=> 0
  *     Dir.getwd           #=> "/tmp"
+ *     Dir.pwd             #=> "/tmp"
  */
 static VALUE
 dir_s_getwd(VALUE dir)


### PR DESCRIPTION
Since `Dir.pwd` aliases `Dir.getwd`, their docs are identical. However, looking up `Dir.pwd` is a bit awkward given the example doesn't even show the `pwd` method.

This change clarifies that and shows how the usages are equivalent.
