### PR TITLE
Fix failed example of delegator usage

### DIFF
--- a/lib/delegate.rb
+++ b/lib/delegate.rb
@@ -245,7 +245,7 @@ end
 #
 #   class User
 #     def born_on
-#       Date.new(1989, 09, 10)
+#       Date.new(1989, 9, 10)
 #     end
 #   end
 #


### PR DESCRIPTION
09 is not valid digit in Ruby:

``` shell
$ irb --simple-prompt                                                
>> 09
SyntaxError: (irb):1: Invalid octal digit
    from /usr/local/opt/rbenv/versions/2.1.0/bin/irb:11:in `<main>'
>> 
```
