### PR TITLE
Fix typo in refinement sample code

### DIFF
--- a/doc/syntax/refinements.rdoc
+++ b/doc/syntax/refinements.rdoc
@@ -42,7 +42,7 @@ Activate the refinement with #using:
 
   using M
 
-  x = C.new
+  c = C.new
 
   c.foo # prints "C#foo in M"
 


### PR DESCRIPTION
The sample code in `refinements.rdoc` invokes a method using the wrong
variable name.
