### PR TITLE
Document need for calling DRb.start_service on after fork hooks

### DIFF
--- a/lib/drb/drb.rb
+++ b/lib/drb/drb.rb
@@ -177,6 +177,9 @@ require 'drb/eq'
 #   # Not necessary for this small example, but will be required
 #   # as soon as we pass a non-marshallable object as an argument
 #   # to a dRuby call.
+#   # Notice that this must be called at least once per process
+#   # to take any effect and this is specially important if your
+#   # application forks (even Puma will fork in daemonized mode).
 #   DRb.start_service
 #
 #   timeserver = DRbObject.new_with_uri(SERVER_URI)


### PR DESCRIPTION
DRb.start_service must be called at least once per process

I'm not quite sure if this is true or if this is the proper way of handling with this problem.

But after several hours of investigation we could finally track down why our request didn't respond in some scenarios involving Unicorn and even Puma in daemonized mode.

I suspect the only reason is that the call is needed to be done at least once per process and this has made the trick for us.

I don't remember if Ruby has now any specific after_fork official hook so that this could be fixed on DRb code directly, but here's one suggestion on how to tackle this problem.
