### PR TITLE
Documentation for Exception#cause

### DIFF
--- a/error.c
+++ b/error.c
@@ -804,6 +804,15 @@ rb_exc_set_backtrace(VALUE exc, VALUE bt)
     return exc_set_backtrace(exc, bt);
 }
 
+/*
+ * call-seq:
+ *   exception.cause   -> an_exception
+ *
+ * Returns the previous exception ($!) at the time this exception was raised.
+ * This is useful for wrapping exceptions and retaining the original exception
+ * information.
+ */
+
 VALUE
 exc_cause(VALUE exc)
 {


### PR DESCRIPTION
Noticed that the new `Exception#cause` didn't have documentation, which is a bummer since it's such a nice little feature for wrapping up exceptions.

Wasn't 100% certain whether my use of `an_exception` as the return was totally right--unclear what the conventions are around that based on what I saw in `error.c`
