### PR TITLE
Fix for using send_request with HEAD

### DIFF
--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -1345,7 +1345,8 @@ module Net   #:nodoc:
     #    puts response.body
     #
     def send_request(name, path, data = nil, header = nil)
-      r = HTTPGenericRequest.new(name,(data ? true : false),true,path,header)
+      has_response_body = name != 'HEAD'
+      r = HTTPGenericRequest.new(name,(data ? true : false),has_response_body,path,header)
       request r, data
     end
 


### PR DESCRIPTION
The 3rd parameter on HTTPGenericRequest.new means if a request has a response body. When using send_request and passing "HEAD" as the first parameters it fails while trying to read the response body.

I got the fix, but I couldn't find a way to create a test for this.

I will be glad to update this PR if someone could give me the directions to create this test.