### PR TITLE
tempfile.rb: provide default basename parameter

### DIFF
--- a/lib/tempfile.rb
+++ b/lib/tempfile.rb
@@ -125,7 +125,7 @@ class Tempfile < DelegateClass(File)
   #
   # If Tempfile.new cannot find a unique filename within a limited
   # number of tries, then it will raise an exception.
-  def initialize(basename, *rest)
+  def initialize(basename="", *rest)
     if block_given?
       warn "Tempfile.new doesn't call the given block."
     end

--- a/test/test_tempfile.rb
+++ b/test/test_tempfile.rb
@@ -57,6 +57,11 @@ class TestTempfile < Test::Unit::TestCase
     assert_match(/^foo/, File.basename(t.path))
   end
 
+  def test_default_basename
+    t = tempfile
+    assert File.exist?(t.path)
+  end
+
   def test_basename_with_suffix
     t = tempfile(["foo", ".txt"])
     assert_match(/^foo/, File.basename(t.path))


### PR DESCRIPTION
The basename parameter to Tempfile.new is mostly meaningless, as the
filename is made unique. An empty string default paremeter will still
give a valid unique filename, freeing the caller to not be concerned
with the filename at all.