### PR TITLE
Update set doc

### DIFF
--- a/lib/set.rb
+++ b/lib/set.rb
@@ -152,8 +152,8 @@ class Set
     self
   end
 
-  # Converts the set to an array.  The order of elements is corresponding to when
-  # they were inserted.
+  # Converts the set to an array.  The order of elements is 
+  # corresponding to when they were inserted.
   def to_a
     @hash.keys
   end


### PR DESCRIPTION
 "which deals with a collection of unordered values with no duplicates" is not clear to me. There is an order which is reflected by Hash since 1.9. The set is unsorted. I could be wrong and it does not keep Hash's order but the comments allude to it working that way.
