### PR TITLE
nacl/nacl-config.rb: Use File.exist? instead of executable? for irt_core. 

### DIFF
--- a/nacl/nacl-config.rb
+++ b/nacl/nacl-config.rb
@@ -34,7 +34,7 @@ module NaClConfig
   IRT_CORE = [
     File.join(SDK_ROOT, 'toolchain', config['NACL_TOOLCHAIN'], 'bin', "irt_core_#{cpu_nick}.nexe"),
     File.join(SDK_ROOT, 'tools', "irt_core_#{cpu_nick}.nexe")
-  ].find{|path| File.executable?(path)} or raise "No irt_core found"
+  ].find{|path| File.exist?(path)} or raise "No irt_core found"
   RUNNABLE_LD = File.join(HOST_LIB, 'runnable-ld.so')
 
   module_function


### PR DESCRIPTION
Recent nacl_sdk has non-executable irt_core. You need to run

$ ./naclsdk update --force pepper_canary

to fetch the very recent nacl_sdk. The ruby package in naclports compiles with this patch.
