### PR TITLE
* test/ruby/test_array.rb (test_flatten!): fix typo test code

### DIFF
--- a/test/ruby/test_array.rb
+++ b/test/ruby/test_array.rb
@@ -798,9 +798,9 @@ class TestArray < Test::Unit::TestCase
     assert_nil(a5.flatten!(0), '[ruby-core:23382]')
     assert_equal(@cls[1, 2, 3, 4, 5, 6], a5)
 
-    assert_equal(@cls[], @cls[].flatten)
+    assert_nil(@cls[].flatten!)
     assert_equal(@cls[],
-                 @cls[@cls[@cls[@cls[],@cls[]],@cls[@cls[]],@cls[]],@cls[@cls[@cls[]]]].flatten)
+                 @cls[@cls[@cls[@cls[],@cls[]],@cls[@cls[]],@cls[]],@cls[@cls[@cls[]]]].flatten!)
 
     assert_nil(@cls[].flatten!(0), '[ruby-core:23382]')
   end


### PR DESCRIPTION
  Make a test of Array#flatten! in TestArray#test_flatten! test.
