### PR TITLE
ext/tk/README.tcltklib: Fix Tcl/Tk library typo [ci skip]

### DIFF
--- a/ext/tk/README.tcltklib
+++ b/ext/tk/README.tcltklib
@@ -30,7 +30,7 @@ some or all of the following options.
 
  --with-tcltkversion=<version>
  --with-tcltkversion=<tclversion>,<tkversion>
-      force version of Tcl/Tk libaray
+      force version of Tcl/Tk library
       (e.g. libtcl8.4g.so & libtk8.4g.so ==> --with-tcltkversion=8.4g
             libtcl8.4.so  & libtk8.4g.so ==> --with-tcltkversion=8.4,8.4g)
 


### PR DESCRIPTION
Correct spelling of 'library'

Thanks!
