### PR TITLE
fix marshal.c typo [ci skip]

### DIFF
--- a/marshal.c
+++ b/marshal.c
@@ -2118,7 +2118,7 @@ marshal_load(int argc, VALUE *argv)
  *     end
  *   end
  *
- * Since Marhsal.dump outputs a string you can have _dump return a Marshal
+ * Since Marshal.dump outputs a string you can have _dump return a Marshal
  * string which is Marshal.loaded in _load for complex objects.
  */
 void


### PR DESCRIPTION
Fixed typo for "Marhsal.dump"

Thanks!
