### PR TITLE
* array.c (rb_ary_shift_m): use shared instead of MEMMOVE if with arguments

### DIFF
--- a/array.c
+++ b/array.c
@@ -1056,6 +1056,7 @@ rb_ary_shift_m(int argc, VALUE *argv, VALUE ary)
 {
     VALUE result;
     long n;
+    long len = RARRAY_LEN(ary);
 
     if (argc == 0) {
 	return rb_ary_shift(ary);
@@ -1068,13 +1069,21 @@ rb_ary_shift_m(int argc, VALUE *argv, VALUE ary)
 	if (ARY_SHARED_OCCUPIED(ARY_SHARED(ary))) {
 	    ary_mem_clear(ary, 0, n);
 	}
-        ARY_INCREASE_PTR(ary, n);
     }
     else {
-	RARRAY_PTR_USE(ary, ptr, {
-	    MEMMOVE(ptr, ptr + n, VALUE, RARRAY_LEN(ary)-n);
-	}); /* WB: no new reference */
+	if (len < ARY_DEFAULT_SIZE) {
+	    RARRAY_PTR_USE(ary, ptr, {
+		MEMMOVE(ptr, ptr+n, VALUE, len-n);
+	    }); /* WB: no new reference */
+	    ARY_INCREASE_LEN(ary, -n);
+	    return result;
+	}
+	assert(!ARY_EMBED_P(ary)); /* ARY_EMBED_LEN_MAX < ARY_DEFAULT_SIZE */
+
+	ary_mem_clear(ary, 0, n);
+	ary_make_shared(ary);
     }
+    ARY_INCREASE_PTR(ary, n);
     ARY_INCREASE_LEN(ary, -n);
 
     return result;

--- a/test/ruby/test_array.rb
+++ b/test/ruby/test_array.rb
@@ -1886,6 +1886,8 @@ class TestArray < Test::Unit::TestCase
     a[3] = 3
     a.shift(2)
     assert_equal([2, 3], a)
+
+    assert_equal([1,1,1], ([1] * 100).shift(3))
   end
 
   def test_unshift_error

--- a/test/ruby/test_array.rb
+++ b/test/ruby/test_array.rb
@@ -2315,6 +2315,11 @@ class TestArray < Test::Unit::TestCase
     b.replace(a)
     assert_equal((1..10).to_a, a.shift(10))
     assert_equal((11..100).to_a, a)
+
+    a = (1..30).to_a
+    assert_equal((1..3).to_a, a.shift(3))
+    # occupied
+    assert_equal((4..6).to_a, a.shift(3))
   end
 
   def test_replace_shared_ary


### PR DESCRIPTION
Array#shift is not make shared array when arguments is 0,1,2,3.
Therefore, call memmove() even if too big array.

I change make shared array if length over ARY_DEFAULT_SIZE and add test code about this.

I send benchmark this patch.

```ruby
require 'benchmark'

Benchmark.bm do |x|
  [10_000,1_000_000,100_000_000].each do |n|
    ary = Array.new(n,0)
    GC.start
    x.report("#{n}:shift"){ ary.shift }
    (0..4).each do |i|
      ary = Array.new(n,0)
      GC.start
      x.report("#{n}:shift(#{i})"){ ary.shift(i) }
    end
  end
end
```

before

```
       user     system      total        real
10000:shift  0.000000   0.000000   0.000000 (  0.000004)
10000:shift(0)  0.000000   0.000000   0.000000 (  0.000009)
10000:shift(1)  0.000000   0.000000   0.000000 (  0.000008)
10000:shift(2)  0.000000   0.000000   0.000000 (  0.000007)
10000:shift(3)  0.000000   0.000000   0.000000 (  0.000008)
10000:shift(4)  0.000000   0.000000   0.000000 (  0.000004)
1000000:shift  0.000000   0.000000   0.000000 (  0.000006)
1000000:shift(0)  0.000000   0.000000   0.000000 (  0.000750)
1000000:shift(1)  0.000000   0.000000   0.000000 (  0.000865)
1000000:shift(2)  0.000000   0.000000   0.000000 (  0.000796)
1000000:shift(3)  0.000000   0.000000   0.000000 (  0.000774)
1000000:shift(4)  0.000000   0.000000   0.000000 (  0.000006)
100000000:shift  0.000000   0.000000   0.000000 (  0.000006)
100000000:shift(0)  0.090000   0.000000   0.090000 (  0.096063)
100000000:shift(1)  0.090000   0.010000   0.100000 (  0.093355)
100000000:shift(2)  0.100000   0.000000   0.100000 (  0.092509)
100000000:shift(3)  0.100000   0.000000   0.100000 (  0.096386)
100000000:shift(4)  0.000000   0.000000   0.000000 (  0.000006)
```

after

```
       user     system      total        real
10000:shift  0.000000   0.000000   0.000000 (  0.000005)
10000:shift(0)  0.000000   0.000000   0.000000 (  0.000004)
10000:shift(1)  0.000000   0.000000   0.000000 (  0.000003)
10000:shift(2)  0.000000   0.000000   0.000000 (  0.000004)
10000:shift(3)  0.000000   0.000000   0.000000 (  0.000004)
10000:shift(4)  0.000000   0.000000   0.000000 (  0.000004)
1000000:shift  0.000000   0.000000   0.000000 (  0.000005)
1000000:shift(0)  0.000000   0.000000   0.000000 (  0.000005)
1000000:shift(1)  0.000000   0.000000   0.000000 (  0.000006)
1000000:shift(2)  0.000000   0.000000   0.000000 (  0.000006)
1000000:shift(3)  0.000000   0.000000   0.000000 (  0.000005)
1000000:shift(4)  0.000000   0.000000   0.000000 (  0.000006)
100000000:shift  0.000000   0.000000   0.000000 (  0.000005)
100000000:shift(0)  0.000000   0.000000   0.000000 (  0.000006)
100000000:shift(1)  0.000000   0.000000   0.000000 (  0.000006)
100000000:shift(2)  0.000000   0.000000   0.000000 (  0.000006)
100000000:shift(3)  0.000000   0.000000   0.000000 (  0.000006)
100000000:shift(4)  0.000000   0.000000   0.000000 (  0.000006)
```