### PR TITLE
Improvements to Time::strptime

### DIFF
--- a/lib/time.rb
+++ b/lib/time.rb
@@ -303,9 +303,9 @@ class Time
     private :make_time
 
     #
-    # Parses +date+ using Date._parse and converts it to a Time object.
+    # Parses +time+ using Date._parse and converts it to a Time object.
     #
-    # If a block is given, the year described in +date+ is converted by the
+    # If a block is given, the year described in +time+ is converted by the
     # block.  For example:
     #
     #     Time.parse(...) {|y| 0 <= y && y < 100 ? (y >= 69 ? y + 1900 : y + 2000) : y}
@@ -344,24 +344,24 @@ class Time
     # it is ignored and the given time is regarded as a local time.
     #
     # ArgumentError is raised if Date._parse cannot extract information from
-    # +date+ or if the Time class cannot represent specified date.
+    # +time+ or if the Time class cannot represent specified time.
     #
     # This method can be used as a fail-safe for other parsing methods as:
     #
-    #   Time.rfc2822(date) rescue Time.parse(date)
-    #   Time.httpdate(date) rescue Time.parse(date)
-    #   Time.xmlschema(date) rescue Time.parse(date)
+    #   Time.rfc2822(time) rescue Time.parse(time)
+    #   Time.httpdate(time) rescue Time.parse(time)
+    #   Time.xmlschema(time) rescue Time.parse(time)
     #
     # A failure of Time.parse should be checked, though.
     #
     # You must require 'time' to use this method.
     #
-    def parse(date, now=self.now)
+    def parse(time, now=self.now)
       comp = !block_given?
-      d = Date._parse(date, comp)
-      year = d[:year]
+      hash = Date._parse(time, comp)
+      year = hash[:year]
       year = yield(year) if year && !comp
-      make_time(date, year, d[:mon], d[:mday], d[:hour], d[:min], d[:sec], d[:sec_fraction], d[:zone], now)
+      make_time(time, year, hash[:mon], hash[:mday], hash[:hour], hash[:min], hash[:sec], hash[:sec_fraction], hash[:zone], now)
     end
 
     #

--- a/lib/time.rb
+++ b/lib/time.rb
@@ -365,9 +365,9 @@ class Time
     end
 
     #
-    # Parses +date+ using Date._strptime and converts it to a Time object.
+    # Parses +time+ using Date._strptime and converts it to a Time object.
     #
-    # If a block is given, the year described in +date+ is converted by the
+    # If a block is given, the year described in +time+ is converted by the
     # block.  For example:
     #
     #   Time.strptime(...) {|y| y < 100 ? (y >= 69 ? y + 1900 : y + 2000) : y}
@@ -421,19 +421,20 @@ class Time
     # %z :: Time zone as  hour offset from UTC (e.g. +0900)
     # %Z :: Time zone name
     # %% :: Literal "%" character
-
-    def strptime(date='-4712-01-01', format='%F', now=self.now)
-      d = Date._strptime(date, format)
-      raise ArgumentError, "invalid strptime format - `#{format}'" unless d
-      if seconds = d[:seconds]
+    #
+    def strptime(time='-4712-01-01', format='%F', now=self.now)
+      date = Date.strptime(time, format) # will raise an ArgumentError if the time is invalid
+      hash = Date._strptime(time, format)
+      raise ArgumentError, "invalid strptime format - `#{format}'" unless hash
+      if seconds = hash[:seconds]
         t = Time.at(seconds)
-        if zone = d[:zone]
+        if zone = hash[:zone]
           force_zone!(t, zone)
         end
       else
-        year = d[:year]
+        year = date.year
         year = yield(year) if year && block_given?
-        t = make_time(date, year, d[:mon], d[:mday], d[:hour], d[:min], d[:sec], d[:sec_fraction], d[:zone], now)
+        t = make_time(date, year, date.mon, date.mday, hash[:hour], hash[:min], hash[:sec], hash[:sec_fraction], hash[:zone], now)
       end
       t
     end

--- a/lib/time.rb
+++ b/lib/time.rb
@@ -422,7 +422,7 @@ class Time
     # %Z :: Time zone name
     # %% :: Literal "%" character
 
-    def strptime(date, format, now=self.now)
+    def strptime(date='-4712-01-01', format='%F', now=self.now)
       d = Date._strptime(date, format)
       raise ArgumentError, "invalid strptime format - `#{format}'" unless d
       if seconds = d[:seconds]

--- a/test/test_time.rb
+++ b/test/test_time.rb
@@ -432,6 +432,7 @@ class TestTimeExtension < Test::Unit::TestCase # :nodoc:
     assert_equal(Time.utc(2005, 8, 28, 06, 54, 20), Time.strptime("28/Aug/2005:06:54:20 +0000", "%d/%b/%Y:%T %z"))
     assert_equal(Time.at(1).localtime, Time.strptime("1", "%s"))
     assert_equal(false, Time.strptime('0', '%s').utc?)
+    assert_equal(Date.strptime.to_time, Time.strptime)
   end
 
   def test_strptime_empty

--- a/test/test_time.rb
+++ b/test/test_time.rb
@@ -433,6 +433,9 @@ class TestTimeExtension < Test::Unit::TestCase # :nodoc:
     assert_equal(Time.at(1).localtime, Time.strptime("1", "%s"))
     assert_equal(false, Time.strptime('0', '%s').utc?)
     assert_equal(Date.strptime.to_time, Time.strptime)
+    assert_raise(ArgumentError) {
+      Time.strptime('31/2/2014', '%d/%m/%Y')
+    }
   end
 
   def test_strptime_empty


### PR DESCRIPTION
This pull request includes three commits:
- [Add default arguments to `Time::strptime` to match `Date::strptime`.](https://github.com/sferik/ruby-1/commit/1679b909f51e9467b29e6ff84ba5f341ae7b961c) After this patch, `Time::strptime` may be invoked with 0, 1, or 2 arguments. When invoked with 0 or 1, it produces a result equivalent to `Date::strptime` invoked with the same arguments.
- [Raise ArgumentError if time passed to `Time::strptime` is invalid.](https://github.com/sferik/ruby-1/commit/70087ce27f605c3cc3265ad1c196544dfd0d8b08) This fixes a Ruby bug and adds a test to ensure it will not regress. Before this commit:

``` ruby
require 'date'
Date::strptime('31/02/2014', '%d/%m/%Y') # ArgumentError: invalid date
require 'time'
Time::strptime('31/02/2014', '%d/%m/%Y') # 2014-03-03 00:00:00 +0000
```
- I have also [renamed variables in `Time::parse` to be consistent with the changes I made to `Time::strptime`](https://github.com/sferik/ruby-1/commit/306938092e79f5581e466879fdb5abe538b7549f). Specifically, renaming `d` to `hash`, since it is not a `Date` and renaming the `date` parameter to `time`. I believe both of these changes make the code clearer.

Thank you for considering this patch.
