### PR TITLE
Line directive

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -3214,7 +3214,16 @@ iseq_compile_each(rb_iseq_t *iseq, LINK_ANCHOR *ret, NODE * node, int poped)
 
     switch (type) {
       case NODE_FILES:{
-fprintf(stderr, "NODE_FILES\n");
+	VALUE path = iseq->location.path;
+	rb_iseq_location_t *loc = &iseq->location;
+	if (TYPE( path ) != T_STRING)
+	    rb_bug("NODE_FILE: must be string");
+	path = node->u1.value;
+
+	if (TYPE( path ) != T_ARRAY)
+	    rb_bug("NODE_FILE: must be array");
+	RB_OBJ_WRITE(iseq->self, &loc->path, path);
+	break;
       }
       case NODE_BLOCK:{
 	while (node && nd_type(node) == NODE_BLOCK) {

--- a/compile.c
+++ b/compile.c
@@ -985,12 +985,11 @@ new_child_iseq(rb_iseq_t *iseq, NODE *node,
 {
     VALUE ret;
     VALUE path = iseq_path(iseq->self);
-    if (path != iseq->location.path)
-      fprintf(stderr, "%p %p\n", path, iseq->location.path);
+    VALUE path_array = iseq->location.path_array;
 
     debugs("[new_child_iseq]> ---------------------------------------\n");
     ret = rb_iseq_new_with_opt(node, name,
-			       path, iseq_absolute_path(iseq->self),
+			       path_array == Qnil ? path : path_array, iseq_absolute_path(iseq->self),
 			       INT2FIX(line_no), parent, type, iseq->compile_data->option);
     debugs("[new_child_iseq]< ---------------------------------------\n");
     iseq_add_mark_object(iseq, ret);

--- a/compile.c
+++ b/compile.c
@@ -984,10 +984,13 @@ new_child_iseq(rb_iseq_t *iseq, NODE *node,
 	       VALUE name, VALUE parent, enum iseq_type type, int line_no)
 {
     VALUE ret;
+    VALUE path = iseq_path(iseq->self);
+    if (path != iseq->location.path)
+      fprintf(stderr, "%p %p\n", path, iseq->location.path);
 
     debugs("[new_child_iseq]> ---------------------------------------\n");
     ret = rb_iseq_new_with_opt(node, name,
-			       iseq_path(iseq->self), iseq_absolute_path(iseq->self),
+			       path, iseq_absolute_path(iseq->self),
 			       INT2FIX(line_no), parent, type, iseq->compile_data->option);
     debugs("[new_child_iseq]< ---------------------------------------\n");
     iseq_add_mark_object(iseq, ret);
@@ -3214,15 +3217,16 @@ iseq_compile_each(rb_iseq_t *iseq, LINK_ANCHOR *ret, NODE * node, int poped)
 
     switch (type) {
       case NODE_FILES:{
-	VALUE path = iseq->location.path;
+	VALUE path_array = iseq->location.path_array;
 	rb_iseq_location_t *loc = &iseq->location;
-	if (TYPE( path ) != T_STRING)
-	    rb_bug("NODE_FILE: must be string");
-	path = node->u1.value;
+	if (TYPE( path_array ) != T_NIL)
+	    rb_bug("NODE_FILE: path array must be nil");
+	
+	path_array = node->u1.value;
 
-	if (TYPE( path ) != T_ARRAY)
+	if (TYPE( path_array ) != T_ARRAY)
 	    rb_bug("NODE_FILE: must be array");
-	RB_OBJ_WRITE(iseq->self, &loc->path, path);
+	RB_OBJ_WRITE(iseq->self, &loc->path_array, path_array);
 	break;
       }
       case NODE_BLOCK:{

--- a/compile.c
+++ b/compile.c
@@ -3213,6 +3213,9 @@ iseq_compile_each(rb_iseq_t *iseq, LINK_ANCHOR *ret, NODE * node, int poped)
     }
 
     switch (type) {
+      case NODE_FILES:{
+fprintf(stderr, "NODE_FILES\n");
+      }
       case NODE_BLOCK:{
 	while (node && nd_type(node) == NODE_BLOCK) {
 	    COMPILE_(ret, "BLOCK body", node->nd_head,

--- a/ext/objspace/objspace.c
+++ b/ext/objspace/objspace.c
@@ -408,6 +408,7 @@ count_nodes(int argc, VALUE *argv, VALUE os)
 		COUNT_NODE(NODE_ATTRASGN);
 		COUNT_NODE(NODE_PRELUDE);
 		COUNT_NODE(NODE_LAMBDA);
+		COUNT_NODE(NODE_FILES);
 #undef COUNT_NODE
 	      default: node = INT2FIX(i);
 	    }

--- a/include/ruby/ruby.h
+++ b/include/ruby/ruby.h
@@ -528,6 +528,10 @@ volatile VALUE *rb_gc_guarded_ptr(volatile VALUE *ptr);
 #define RB_UNUSED_VAR(x) x
 #endif
 
+#ifndef FILE_CNT_BITS
+  #define FILE_CNT_BITS 10
+#endif
+
 void rb_check_type(VALUE,int);
 #define Check_Type(v,t) rb_check_type((VALUE)(v),(t))
 

--- a/iseq.c
+++ b/iseq.c
@@ -259,21 +259,31 @@ prepare_iseq_build(rb_iseq_t *iseq,
 		   VALUE parent, enum iseq_type type, VALUE block_opt,
 		   const rb_compile_option_t *option)
 {
+    VALUE path_array = Qnil;
     iseq->type = type;
     iseq->arg_rest = -1;
     iseq->arg_block = -1;
     iseq->arg_keyword = -1;
+
     RB_OBJ_WRITE(iseq->self, &iseq->klass, 0);
     set_relation(iseq, parent);
 
     name = rb_fstring(name);
-    path = rb_fstring(path);
+    if (TYPE(path) == T_ARRAY) {
+        path_array = path;
+        path = rb_fstring(rb_ary_entry(path_array, 0));
+    } else {
+        path = rb_fstring(path);
+    }
     if (RTEST(absolute_path))
 	absolute_path = rb_fstring(absolute_path);
 
     iseq_location_setup(iseq, path, absolute_path, name, first_lineno);
     if (iseq != iseq->local_iseq) {
 	RB_OBJ_WRITE(iseq->self, &iseq->location.base_label, iseq->local_iseq->location.label);
+    }
+    if (path_array != Qnil ) {
+	RB_OBJ_WRITE(iseq->self, &iseq->location.path_array, path_array);
     }
 
     iseq->defined_method_id = 0;

--- a/iseq.c
+++ b/iseq.c
@@ -107,6 +107,7 @@ iseq_mark(void *ptr)
 	RUBY_MARK_UNLESS_NULL(iseq->location.label);
 	RUBY_MARK_UNLESS_NULL(iseq->location.base_label);
 	RUBY_MARK_UNLESS_NULL(iseq->location.path);
+	RUBY_MARK_UNLESS_NULL(iseq->location.path_array);
 	RUBY_MARK_UNLESS_NULL(iseq->location.absolute_path);
 
 	RUBY_MARK_UNLESS_NULL((VALUE)iseq->cref_stack);

--- a/iseq.c
+++ b/iseq.c
@@ -183,7 +183,9 @@ static rb_iseq_location_t *
 iseq_location_setup(rb_iseq_t *iseq, VALUE path, VALUE absolute_path, VALUE name, size_t first_lineno)
 {
     rb_iseq_location_t *loc = &iseq->location;
+
     RB_OBJ_WRITE(iseq->self, &loc->path, path);
+    RB_OBJ_WRITE(iseq->self, &loc->path_array, Qnil);
     if (RTEST(absolute_path) && rb_str_cmp(path, absolute_path) == 0) {
 	RB_OBJ_WRITE(iseq->self, &loc->absolute_path, path);
     }

--- a/node.h
+++ b/node.h
@@ -232,6 +232,8 @@ enum node_type {
 #define NODE_PRELUDE     NODE_PRELUDE
     NODE_LAMBDA,
 #define NODE_LAMBDA      NODE_LAMBDA
+    NODE_FILES,
+#define NODE_FILES       NODE_FILES
     NODE_LAST
 #define NODE_LAST        NODE_LAST
 };
@@ -464,6 +466,7 @@ typedef struct RNode {
 #define NEW_ATTRASGN(r,m,a) NEW_NODE(NODE_ATTRASGN,r,m,a)
 #define NEW_PRELUDE(p,b) NEW_NODE(NODE_PRELUDE,p,b,0)
 #define NEW_MEMO(a,b,c) NEW_NODE(NODE_MEMO,a,b,c)
+#define NEW_FILES(a) NEW_NODE(NODE_FILES,a,0,0)
 
 #define roomof(x, y) ((sizeof(x) + sizeof(y) - 1) / sizeof(y))
 #define MEMO_FOR(type, value) ((type *)RARRAY_PTR(value))
@@ -539,5 +542,7 @@ RUBY_SYMBOL_EXPORT_END
 #endif
 }  /* extern "C" { */
 #endif
+
+#define FILE_CNT_MAX 10
 
 #endif /* RUBY_NODE_H */

--- a/parse.y
+++ b/parse.y
@@ -7052,7 +7052,7 @@ parser_yylex(struct parser_params *parser)
 			    while (isspace(filename[0]))
 			        filename++;
 			    if (filename[0] == '"') {
-				int len = strlen(++filename);
+				unsigned long len = strlen(++filename);
 				while (isspace(filename[len-1]))
 				    len--;
 				if (filename[len-1] == '"') {

--- a/parse.y
+++ b/parse.y
@@ -267,6 +267,9 @@ struct parser_params {
     char *parser_ruby_sourcefile; /* current source file */
     int parser_ruby_sourceline;	/* current line no. */
     VALUE parser_ruby_sourcefile_string;
+    char parser_ruby_sourcefile_count;
+    VALUE parser_ruby_sourcefile_array;
+    VALUE parser_ruby_sourcefile_hash;
     rb_encoding *enc;
 
     int parser_yydebug;
@@ -340,6 +343,22 @@ static int parser_yyerror(struct parser_params*, const char*);
 #define ruby_sourceline		(parser->parser_ruby_sourceline)
 #define ruby_sourcefile		(parser->parser_ruby_sourcefile)
 #define ruby_sourcefile_string	(parser->parser_ruby_sourcefile_string)
+#define ruby_sourcefile_count	(parser->parser_ruby_sourcefile_count)
+#define ruby_sourcefile_array	(parser->parser_ruby_sourcefile_array)
+#define ruby_sourcefile_hash	(parser->parser_ruby_sourcefile_hash)
+#if FILE_CNT_BITS > 0
+# define FILE_LINE_BITS         ((sizeof(ruby_sourceline) * 8) - FILE_CNT_BITS)
+# define FILE_SET(lineno)       (((ruby_sourcefile_count) << FILE_LINE_BITS) + lineno)
+# define FILE_LINE_MASK         ((UINT_MAX >> FILE_CNT_BITS))
+# define FIX_LINE(line)         ((UINT_MAX >> FILE_CNT_BITS) & (line))
+# define disp_ruby_sourceline   ((UINT_MAX >> FILE_CNT_BITS) & ruby_sourceline)
+# define disp_ruby_sourcefile   ((ruby_sourceline >> FILE_CNT_BITS) ? \
+                                RSTRING_PTR(rb_ary_entry(ruby_sourcefile_array, (ruby_sourceline >> FILE_LINE_BITS) - 1)) : \
+                                ruby_sourcefile)
+#else
+# define FILE_SET(lineno)       (lineno)
+# define FILE_LINE_MASK         (UINT_MAX)
+#endif
 #define current_enc		(parser->enc)
 #define yydebug			(parser->parser_yydebug)
 #ifdef RIPPER
@@ -638,17 +657,17 @@ new_args_tail_gen(struct parser_params *parser, VALUE k, VALUE kr, VALUE b)
 #endif
 
 #ifndef RIPPER
-# define rb_warn0(fmt)    rb_compile_warn(ruby_sourcefile, ruby_sourceline, (fmt))
-# define rb_warnI(fmt,a)  rb_compile_warn(ruby_sourcefile, ruby_sourceline, (fmt), (a))
-# define rb_warnS(fmt,a)  rb_compile_warn(ruby_sourcefile, ruby_sourceline, (fmt), (a))
-# define rb_warn4S(file,line,fmt,a)  rb_compile_warn((file), (line), (fmt), (a))
-# define rb_warning0(fmt) rb_compile_warning(ruby_sourcefile, ruby_sourceline, (fmt))
-# define rb_warningS(fmt,a) rb_compile_warning(ruby_sourcefile, ruby_sourceline, (fmt), (a))
+# define rb_warn0(fmt)    rb_compile_warn(disp_ruby_sourcefile, disp_ruby_sourceline, (fmt))
+# define rb_warnI(fmt,a)  rb_compile_warn(disp_ruby_sourcefile, disp_ruby_sourceline, (fmt), (a))
+# define rb_warnS(fmt,a)  rb_compile_warn(disp_ruby_sourcefile, disp_ruby_sourceline, (fmt), (a))
+# define rb_warn3S(line,fmt,a)  rb_compile_warn(disp_ruby_sourcefile, (line), (fmt), (a))
+# define rb_warning0(fmt) rb_compile_warning(disp_ruby_sourcefile, disp_ruby_sourceline, (fmt))
+# define rb_warningS(fmt,a) rb_compile_warning(disp_ruby_sourcefile, disp_ruby_sourceline, (fmt), (a))
 #else
 # define rb_warn0(fmt)    ripper_warn0(parser, (fmt))
 # define rb_warnI(fmt,a)  ripper_warnI(parser, (fmt), (a))
 # define rb_warnS(fmt,a)  ripper_warnS(parser, (fmt), (a))
-# define rb_warn4S(file,line,fmt,a)  ripper_warnS(parser, (fmt), (a))
+# define rb_warn3S(line,fmt,a)  ripper_warnS(parser, (fmt), (a))
 # define rb_warning0(fmt) ripper_warning0(parser, (fmt))
 # define rb_warningS(fmt,a) ripper_warningS(parser, (fmt), (a))
 static void ripper_warn0(struct parser_params*, const char*);
@@ -879,7 +898,8 @@ program		:  {
 				void_expr(node->nd_head);
 			    }
 			}
-			ruby_eval_tree = NEW_SCOPE(0, block_append(ruby_eval_tree, $2));
+fprintf(stderr, "ruby_eval_tree %p\n", ruby_eval_tree);
+			ruby_eval_tree = NEW_SCOPE(0, block_append(ruby_eval_tree, block_append(NEW_FILES(ruby_sourcefile_array), $2)));
 		    /*%
 			$$ = $2;
 			parser->result = dispatch1(program, $$);
@@ -5379,8 +5399,14 @@ yycompile0(VALUE arg)
 static NODE*
 yycompile(struct parser_params *parser, VALUE fname, int line)
 {
+    VALUE str;
+#if 0
     ruby_sourcefile_string = rb_str_new_frozen(fname);
     ruby_sourcefile = RSTRING_PTR(fname);
+#else
+    ruby_sourcefile_string = rb_str_new_frozen( str = rb_str_new("asdf", 4));
+    ruby_sourcefile = RSTRING_PTR(str);
+#endif
     ruby_sourceline = line - 1;
     return (NODE *)rb_suppress_tracing(yycompile0, (VALUE)parser);
 }
@@ -6998,7 +7024,76 @@ parser_yylex(struct parser_params *parser)
 	    if (comment_at_top(parser)) {
 		set_file_encoding(parser, lex_p, lex_pend);
 	    }
+            /* check for #line directives */
+	    while (lex_p < lex_pend - 6 && isspace(*lex_p))
+	        lex_p++;
+            if (
+	        lex_p < lex_pend - 6 && isspace(lex_p[4]) &&
+	        lex_p[0] == 'l' &&
+	        lex_p[1] == 'i' &&
+	        lex_p[2] == 'n' &&
+	        lex_p[3] == 'e'
+	       ) {
+		lex_p += 4;
+	        while (lex_p < lex_pend - 1 && isspace(*lex_p))
+		    lex_p++;
+		if (lex_p < lex_pend - 1) {
+		    int line;
+		    char *filestring = NULL;
+		    int ret = sscanf(lex_p, "%d %as", &line, &filestring);
+		    if (ret > 0 && line > 0) {
+			if (ret == 2) {
+			    char *filename = filestring;
+			    while (isspace(filename[0]))
+			        filename++;
+			    if (filename[0] == '"') {
+				int len = strlen(++filename);
+				while (isspace(filename[len-1]))
+				    len--;
+				if (filename[len-1] == '"') {
+				    VALUE val;
+				    long  idx = -1;
+				    len--;
+				    filename[len] = '\0';
+				    if (ruby_sourcefile_hash == Qnil) {
+fprintf(stderr, "allocat hash\n");
+					ruby_sourcefile_hash = rb_hash_new();
+				    }
+				    if (ruby_sourcefile_array == Qnil) {
+fprintf(stderr, "allocat array\n");
+					ruby_sourcefile_array = rb_ary_new();
+				    }
+                                    val = rb_hash_aref(ruby_sourcefile_hash, rb_str_new2(filename));
+				    if (val == Qnil) {
+				        VALUE string;
+					string = rb_str_new2(filename);
+				        idx = RARRAY_LEN(ruby_sourcefile_array);
+					rb_ary_push(ruby_sourcefile_array, string);
+					rb_hash_aset(ruby_sourcefile_hash, string, INT2FIX(idx));
+fprintf(stderr, "added filename \"%s\" @ %ld\n", filename, idx);
+				    } else {
+				       idx = FIX2LONG(val);
+fprintf(stderr, "found filename \"%s\" @ %ld\n", filename, idx);
+				    }
+				    ruby_sourcefile_count = idx + 1;
+			        } else {
+				    line = 0;
+				}
+			    } else {
+			        line = 0;
+			    }
+			}
+			if (line > 0) {
+fprintf(stderr, "set line to %d %d\n", ruby_sourcefile_count, line - 1);
+			    ruby_sourceline = (ruby_sourcefile_count << FILE_LINE_BITS) + line - 1;
+			}
+		    }
+		    if (filestring)
+		        free(filestring);
+		}
+	    }
 	}
+
 	lex_p = lex_pend;
 #ifdef RIPPER
         ripper_dispatch_scan_event(parser, tCOMMENT);
@@ -8580,7 +8675,7 @@ gettable_gen(struct parser_params *parser, ID id)
       case keyword__FILE__:
 	return NEW_STR(rb_str_dup(ruby_sourcefile_string));
       case keyword__LINE__:
-	return NEW_LIT(INT2FIX(tokline));
+	return NEW_LIT(INT2FIX(FIX_LINE(tokline)));
       case keyword__ENCODING__:
 	return NEW_LIT(rb_enc_from_encoding(current_enc));
     }
@@ -9632,7 +9727,8 @@ warn_unused_var(struct parser_params *parser, struct local_vars *local)
     for (i = 0; i < cnt; ++i) {
 	if (!v[i] || (u[i] & LVAR_USED)) continue;
 	if (is_private_local_id(v[i])) continue;
-	rb_warn4S(ruby_sourcefile, (int)u[i], "assigned but unused variable - %s", rb_id2name(v[i]));
+
+	rb_warn3S(FIX_LINE((int)u[i]), "assigned but unused variable - %s", rb_id2name(v[i]));
     }
 }
 
@@ -10855,6 +10951,9 @@ parser_initialize(struct parser_params *parser)
     parser->parser_ruby__end__seen = 0;
     parser->parser_ruby_sourcefile = 0;
     parser->parser_ruby_sourcefile_string = Qnil;
+    parser->parser_ruby_sourcefile_count = 0;
+    parser->parser_ruby_sourcefile_array = Qnil;
+    parser->parser_ruby_sourcefile_hash = Qnil;
 #ifndef RIPPER
     parser->is_ripper = 0;
     parser->parser_eval_tree_begin = 0;

--- a/parse.y
+++ b/parse.y
@@ -7044,8 +7044,8 @@ parser_yylex(struct parser_params *parser)
 		    lex_p++;
 		if (lex_p < lex_pend - 1) {
 		    int line;
-		    char *filestring = NULL;
-		    int ret = sscanf(lex_p, "%d %as", &line, &filestring);
+		    char *filestring = xcalloc(1, 257);
+		    int ret = sscanf(lex_p, "%d %256s", &line, filestring);
 		    if (ret > 0 && line > 0) {
 			if (ret == 2) {
 			    char *filename = filestring;

--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -330,7 +330,6 @@ location_to_str(rb_backtrace_location_t *loc)
 
 	if (TYPE(loc->body.iseq.iseq->location.path_array) == T_ARRAY) {
 	    int idx = lineno >> FILE_LINE_BITS;
-fprintf(stderr, "type %d addr %p idx %d\n", TYPE(loc->body.iseq.iseq->location.path_array), loc->body.iseq.iseq->location.path_array, idx);
 	    file = rb_ary_entry(loc->body.iseq.iseq->location.path_array, idx);
 	}
 

--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -328,8 +328,9 @@ location_to_str(rb_backtrace_location_t *loc)
 
 	lineno = loc->body.iseq.lineno.lineno = calc_lineno(loc->body.iseq.iseq, loc->body.iseq.lineno.pc);
 
-	if (loc->body.iseq.iseq->location.path_array != Qnil) {
+	if (TYPE(loc->body.iseq.iseq->location.path_array) == T_ARRAY) {
 	    int idx = lineno >> FILE_LINE_BITS;
+fprintf(stderr, "type %d addr %p idx %d\n", TYPE(loc->body.iseq.iseq->location.path_array), loc->body.iseq.iseq->location.path_array, idx);
 	    file = rb_ary_entry(loc->body.iseq.iseq->location.path_array, idx);
 	}
 

--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -132,7 +132,6 @@ location_ptr(VALUE locobj)
 static int
 location_lineno(rb_backtrace_location_t *loc)
 {
-fprintf(stderr, "location_lineno\n");
     switch (loc->type) {
       case LOCATION_TYPE_ISEQ:
 	loc->type = LOCATION_TYPE_ISEQ_CALCED;
@@ -328,11 +327,20 @@ location_to_str(rb_backtrace_location_t *loc)
 	name = loc->body.iseq.iseq->location.label;
 
 	lineno = loc->body.iseq.lineno.lineno = calc_lineno(loc->body.iseq.iseq, loc->body.iseq.lineno.pc);
+
+	if (loc->body.iseq.iseq->location.path_array != Qnil) {
+	    int idx = lineno >> FILE_LINE_BITS;
+	    file = rb_ary_entry(loc->body.iseq.iseq->location.path_array, idx);
+	}
+
 	loc->type = LOCATION_TYPE_ISEQ_CALCED;
 	break;
       case LOCATION_TYPE_ISEQ_CALCED:
 	file = loc->body.iseq.iseq->location.path;
 	lineno = loc->body.iseq.lineno.lineno;
+	if (loc->body.iseq.iseq->location.path_array != Qnil) {
+	    int idx = lineno >> FILE_LINE_BITS;
+	}
 	name = loc->body.iseq.iseq->location.label;
 	break;
       case LOCATION_TYPE_CFUNC:

--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -29,6 +29,9 @@ calc_lineno(const rb_iseq_t *iseq, const VALUE *pc)
     return rb_iseq_line_no(iseq, pc - iseq->iseq_encoded);
 }
 
+#define FILE_LINE_MASK ((UINT_MAX >> FILE_CNT_BITS))
+#define FILE_LINE_BITS ((sizeof(unsigned int) * 8) - FILE_CNT_BITS)
+
 int
 rb_vm_get_sourceline(const rb_control_frame_t *cfp)
 {
@@ -38,6 +41,9 @@ rb_vm_get_sourceline(const rb_control_frame_t *cfp)
     if (RUBY_VM_NORMAL_ISEQ_P(iseq)) {
 	lineno = calc_lineno(cfp->iseq, cfp->pc);
     }
+
+    lineno &= FILE_LINE_MASK;
+
     return lineno;
 }
 
@@ -126,6 +132,7 @@ location_ptr(VALUE locobj)
 static int
 location_lineno(rb_backtrace_location_t *loc)
 {
+fprintf(stderr, "location_lineno\n");
     switch (loc->type) {
       case LOCATION_TYPE_ISEQ:
 	loc->type = LOCATION_TYPE_ISEQ_CALCED;
@@ -344,6 +351,8 @@ location_to_str(rb_backtrace_location_t *loc)
       default:
 	rb_bug("location_to_str: unreachable");
     }
+
+    lineno &= FILE_LINE_MASK;		/* FIXME */
 
     return location_format(file, lineno, name);
 }

--- a/vm_core.h
+++ b/vm_core.h
@@ -199,6 +199,7 @@ typedef struct rb_iseq_location_struct {
     const VALUE base_label;
     const VALUE label;
     size_t first_lineno;
+    const VALUE path_array;
 } rb_iseq_location_t;
 
 struct rb_iseq_struct;


### PR DESCRIPTION
Add a __line directive__ to Ruby

```
  #line {nn} ["filename"]
```

This is done by creating a array of filenames and using the upper bits of the line_number to determine the current filename.  The original filename is in position 0.

An extra node is added by the parser that informs the compiler of the filenames so the backtrace code can follow it.

The __\_\_LINE____ and __\_\_FILE____ _constants_ are updated and compile time warnings are also effected.