### PR TITLE
* include/ruby/ruby.h (RARRAY_LEN):  change more faster get embed array length

### DIFF
--- a/include/ruby/ruby.h
+++ b/include/ruby/ruby.h
@@ -878,8 +878,7 @@ struct RArray {
 #define RARRAY_EMBED_LEN_SHIFT (FL_USHIFT+3)
 #define RARRAY_LEN(a) \
     ((RBASIC(a)->flags & RARRAY_EMBED_FLAG) ? \
-     (long)((RBASIC(a)->flags >> RARRAY_EMBED_LEN_SHIFT) & \
-	 (RARRAY_EMBED_LEN_MASK >> RARRAY_EMBED_LEN_SHIFT)) : \
+     (long)((RBASIC(a)->flags & RARRAY_EMBED_LEN_MASK) >> RARRAY_EMBED_LEN_SHIFT) : \
      RARRAY(a)->as.heap.len)
 
 #define RARRAY_LENINT(ary) rb_long2int(RARRAY_LEN(ary))


### PR DESCRIPTION
i try benchmark this change.

``` ruby
require 'benchmark'

n = 10000000

Benchmark.bm do |x|
  GC.start
  empty_time = x.report("empty"){n.times{ }}
  GC.start
  embed_time = x.report("embed length"){n.times{ [].length }}
  puts embed_time.real / empty_time.real
end
```

result of 10 times average.

before: 1.681396211600276
after: 1.6629606856866217

it's more faster but just a little :ant: 
