### PR TITLE
Bug fix: Vector.magnitude: Complex numberes

### DIFF
--- a/lib/matrix.rb
+++ b/lib/matrix.rb
@@ -1784,7 +1784,7 @@ class Vector
   #   Vector[5,8,2].r => 9.643650761
   #
   def magnitude
-    Math.sqrt(@elements.inject(0) {|v, e| v + e.abs2})
+    Math.sqrt(@elements.inject(0) {|v, e| v + e*e.conjugate})
   end
   alias r magnitude
   alias norm magnitude


### PR DESCRIPTION
From Euclidean complex vector product: second vector needs to be conjugated.
(Theoretically is now slower but more importantly doesn't cause havoc.)
