### PR TITLE
Document single-quoted strings more accurately

### DIFF
--- a/doc/syntax/literals.rdoc
+++ b/doc/syntax/literals.rdoc
@@ -100,7 +100,8 @@ single-quote strings:
   '#{1 + 1}' #=> "\#{1 + 1}"
 
 In addition to disabling interpolation, single-quoted strings also disable all
-escape sequences except for the single-quote (<tt>\'</tt>).
+escape sequences except for the single-quote (<tt>\'</tt>) and backslash
+(<tt>\\\\ </tt>).
 
 You may also create strings using <tt>%</tt>:
 


### PR DESCRIPTION
`'\a'` and `'\\a'` are both the same as `"\\a"` because single-quoted strings let `\` escape `\`.

(This fact makes it possible to write the string backslash+singlequote, `"\\'"`, as a single-quoted string `'\\\''`.)

What is the correct way in the .rdoc to escape the backslashes surrounded by `<tt>`? I'm not confident that I did _that_ perfectly.  According to github preview, the last backslash kept trying to escape the `</tt>` instead of being a backslash character, so I sadly separated them with a space character.
