### PR TITLE
Fix up default GC params

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -154,8 +154,8 @@ typedef struct {
 } ruby_gc_params_t;
 
 static ruby_gc_params_t gc_params = {
-    GC_HEAP_FREE_SLOTS,
     GC_HEAP_INIT_SLOTS,
+    GC_HEAP_FREE_SLOTS,
     GC_HEAP_GROWTH_FACTOR,
     GC_HEAP_GROWTH_MAX_SLOTS,
     GC_HEAP_OLDOBJECT_LIMIT_FACTOR,


### PR DESCRIPTION
The default values for `GC_HEAP_FREE_SLOTS` and `GC_HEAP_INIT_SLOTS` are reversed, which causes incorrect default values to be set for these GC parameters.
