### PR TITLE
Check fptr before trying to dump FILE object fd

### DIFF
--- a/ext/objspace/objspace_dump.c
+++ b/ext/objspace/objspace_dump.c
@@ -230,7 +230,8 @@ dump_object(VALUE obj, struct dump_config *dc)
 
       case T_FILE:
 	fptr = RFILE(obj)->fptr;
-	dump_append(dc, ", \"fd\":%d", fptr->fd);
+	if (fptr)
+	    dump_append(dc, ", \"fd\":%d", fptr->fd);
 	break;
 
       case T_ZOMBIE:


### PR DESCRIPTION
Check that `fptr` is not NULL before dereferencing in `dump_object`.
