### PR TITLE
doc change for string hash()

### DIFF
--- a/string.c
+++ b/string.c
@@ -2337,7 +2337,7 @@ rb_str_hash_cmp(VALUE str1, VALUE str2)
  * call-seq:
  *    str.hash   -> fixnum
  *
- * Return a hash based on the string's length and content.
+ * Return a hash based on the string's length, content, and instance.
  */
 
 static VALUE


### PR DESCRIPTION
Documentation for `hash` suggests that `hash` is only based on string length and content. However, running: `'a'.hash()` in two different irb sessions produces different results.
