### PR TITLE
Document number conversion of `nil`

### DIFF
--- a/complex.c
+++ b/complex.c
@@ -478,6 +478,8 @@ f_complex_new2(VALUE klass, VALUE x, VALUE y)
  *
  *    Complex(1, 2)    #=> (1+2i)
  *    Complex('1+2i')  #=> (1+2i)
+ *    Complex(nil)     #=> TypeError
+ *    Complex(1, nil)  #=> TypeError
  *
  * Syntax of string form:
  *

--- a/object.c
+++ b/object.c
@@ -2733,13 +2733,15 @@ rb_Integer(VALUE val)
  *  In any case, strings should be strictly conformed to numeric
  *  representation. This behavior is different from that of
  *  <code>String#to_i</code>.  Non string values will be converted using
- *  <code>to_int</code>, and <code>to_i</code>.
+ *  <code>to_int</code>, and <code>to_i</code>. Passing <code>nil</code>
+ *  raises a TypeError.
  *
  *     Integer(123.999)    #=> 123
  *     Integer("0x1a")     #=> 26
  *     Integer(Time.new)   #=> 1204973019
  *     Integer("0930", 10) #=> 930
  *     Integer("111", 2)   #=> 7
+ *     Integer(nil)        #=> TypeError
  */
 
 static VALUE

--- a/rational.c
+++ b/rational.c
@@ -617,6 +617,8 @@ f_rational_new_no_reduce2(VALUE klass, VALUE x, VALUE y)
  *
  *    Rational(1, 2)   #=> (1/2)
  *    Rational('1/2')  #=> (1/2)
+ *    Rational(nil)    #=> TypeError
+ *    Rational(1, nil) #=> TypeError
  *
  * Syntax of string form:
  *


### PR DESCRIPTION
All number conversion methods have special treatment of `nil` -
they don't convert it using `to_i` but instead raise a TypeError.

This patch fixes the documentation so that this case is specifically
mentioned for all.
