### PR TITLE
Fix a build problem with clang and --with-opt-dir.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,15 @@
+Thu Mar 20 23:41:45 2014  Akinori MUSHA  <knu@iDaemons.org>
+
+	* configure.in: Fix a build problem with clang and --with-opt-dir.
+	  If ruby is configured with --with-opt-dir=dir when using clang
+	  as compiler, a warning `clang: warning: argument unused during
+	  compilation: '-I dir'` is emitted almost every time clang
+	  compiles a file.  Unfortunately, RUBY_CHECK_PRINTF_PREFIX takes
+	  any output from the compiler as fatal error, and the check thus
+	  fails due to the warning.  This is an attempt to fix the problem
+	  by adding a flag -Qunused-arguments to CFLAGS locally in the
+	  function to suppress the warning.
+
 Thu Mar 20 16:53:07 2014  Koichi Sasada  <ko1@atdot.net>
 
 	* gc.c (objspace_malloc_increase): should not invoke

--- a/configure.in
+++ b/configure.in
@@ -779,6 +779,8 @@ if test "$GCC:${warnflags+set}:no" = yes::no; then
     rb_cv_warnflags="$warnflags"
     warnflags=
 fi
+RUBY_TRY_CFLAGS(-Qunused-arguments, [RUBY_APPEND_OPTIONS(rb_cv_wsuppress_flags, -Qunused-arguments)])
+
 if test "$GCC" = yes; then
     # -D_FORTIFY_SOURCE
     # When defined _FORTIFY_SOURCE, glibc enables some additional sanity
@@ -1302,7 +1304,8 @@ AC_DEFINE_UNQUOTED(PACKED_STRUCT_UNALIGNED(x), $packed_struct_unaligned)
 AC_DEFUN([RUBY_CHECK_PRINTF_PREFIX], [
 AC_CACHE_CHECK([for printf prefix for $1], [rb_cv_pri_prefix_]AS_TR_SH($1),[
     [rb_cv_pri_prefix_]AS_TR_SH($1)=[NONE]
-    RUBY_WERROR_FLAG(for pri in $2; do
+    RUBY_WERROR_FLAG(RUBY_APPEND_OPTIONS(CFLAGS, $rb_cv_wsuppress_flags)
+    for pri in $2; do
         AC_TRY_COMPILE(
             [@%:@include <stdio.h>
 	    @%:@include <stddef.h>


### PR DESCRIPTION
- configure.in: Fix a build problem with clang and --with-opt-dir.
  If ruby is configured with --with-opt-dir=dir when using clang
  as compiler, a warning `clang: warning: argument unused during
  compilation: '-I dir'` is emitted almost every time clang
  compiles a file.  Unfortunately, RUBY_CHECK_PRINTF_PREFIX takes
  any output from the compiler as fatal error, and the check thus
  fails due to the warning.  This is an attempt to fix the problem
  by adding a flag -Qunused-arguments to CFLAGS locally in the
  function to suppress the warning.
