### PR TITLE
Fix for GC::start and GC#garbage_collect docs

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -5138,8 +5138,8 @@ Init_stack(volatile VALUE *addr)
  *  call-seq:
  *     GC.start                     -> nil
  *     GC.garbage_collect           -> nil
- *     ObjectSpace.garbage_collect  -> nil
- *     GC.start(full_mark: false)   -> nil
+ *     GC.start(full_mark: true, immediate_sweep: true)           -> nil
+ *     GC.garbage_collect(full_mark: true, immediate_sweep: true) -> nil
  *
  *  Initiates garbage collection, unless manually disabled.
  *


### PR DESCRIPTION
The `GC::start` method documentation was inconsistent with the text listing the
currently available keyword parameters.

`GC#garbage_collect` was further out of date. The `ObjectSpace.garbage_collect`
line resulted in the docs showing "garbage_collect -> nil" twice, and it was
missing the keyword parameter flavor.
