### PR TITLE
support *elements in escape synonyms

### DIFF
--- a/lib/cgi/util.rb
+++ b/lib/cgi/util.rb
@@ -143,14 +143,14 @@ module CGI::Util
     end
   end
 
-  # Synonym for CGI::escapeElement(str)
-  def escape_element(str)
-    escapeElement(str)
+  # Synonym for CGI::escapeElement(str, *elements)
+  def escape_element(str, *elements)
+    escapeElement(str, *elements)
   end
 
-  # Synonym for CGI::unescapeElement(str)
-  def unescape_element(str)
-    unescapeElement(str)
+  # Synonym for CGI::unescapeElement(str, *elements)
+  def unescape_element(str, *elements)
+    unescapeElement(str, *elements)
   end
 
   # Abbreviated day-of-week names specified by RFC 822


### PR DESCRIPTION
The current implementation of `escape_element` and `unescape_element` don't suppor the `*elements` argument. This result in both methods always simply returning the original `str` passed to them.
