### PR TITLE
Fixes for CSV Header Conversion

### DIFF
--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -992,8 +992,8 @@ class CSV
   HeaderConverters = {
     downcase: lambda { |h| h.encode(ConverterEncoding).downcase },
     symbol:   lambda { |h|
-      h.encode(ConverterEncoding).downcase.gsub(/\s+/, "_").
-                                           gsub(/\W+/, "").to_sym
+      h.encode(ConverterEncoding).downcase.strip.gsub(/\s+/, "_").
+                                                 gsub(/\W+/, "").to_sym
     }
   }
 

--- a/test/csv/test_headers.rb
+++ b/test/csv/test_headers.rb
@@ -217,9 +217,10 @@ class TestCSV::Headers < TestCSV
   end
 
   def test_builtin_symbol_converter
-    csv = CSV.parse( "One,TWO Three", headers:           true,
-                                      return_headers:    true,
-                                      header_converters: :symbol )
+    # Note that the trailing space is intentional
+    csv = CSV.parse( "One,TWO Three ", headers:           true,
+                                       return_headers:    true,
+                                       header_converters: :symbol )
     assert_equal([:one, :two_three], csv.headers)
   end
 


### PR DESCRIPTION
1st commit: don't try to encode `nil` headers. Currently this causes: 

```
NoMethodError: undefined method `encode' for nil:NilClass
```

2nd commit: just makes sense for this converter, I think. Currently leading/trailing whitespace will create: `:_symbol_header` or `:symbol_header_`.
