### PR TITLE
String#gsub shouldn't allocate so many Strings in its loop

### DIFF
--- a/include/ruby/re.h
+++ b/include/ruby/re.h
@@ -52,6 +52,7 @@ struct RMatch {
 #define RMATCH_REGS(obj)  (&(R_CAST(RMatch)(obj))->rmatch->regs)
 
 VALUE rb_reg_regcomp(VALUE);
+long rb_reg_search0(VALUE, VALUE, long, int, int);
 long rb_reg_search(VALUE, VALUE, long, int);
 VALUE rb_reg_regsub(VALUE, VALUE, struct re_registers *, VALUE);
 long rb_reg_adjust_startpos(VALUE, VALUE, long, int);

--- a/re.c
+++ b/re.c
@@ -1375,7 +1375,7 @@ rb_reg_adjust_startpos(VALUE re, VALUE str, long pos, int reverse)
 
 /* returns byte offset */
 long
-rb_reg_search(VALUE re, VALUE str, long pos, int reverse)
+rb_reg_search0(VALUE re, VALUE str, long pos, int reverse, int set_backref_str)
 {
     long result;
     VALUE match;
@@ -1450,15 +1450,24 @@ rb_reg_search(VALUE re, VALUE str, long pos, int reverse)
 	    FL_UNSET(match, FL_TAINT);
     }
 
-    RMATCH(match)->str = rb_str_new4(str);
+    if (set_backref_str) {
+	RMATCH(match)->str = rb_str_new4(str);
+	OBJ_INFECT(match, str);
+    }
+
     RMATCH(match)->regexp = re;
     RMATCH(match)->rmatch->char_offset_updated = 0;
     rb_backref_set(match);
 
     OBJ_INFECT(match, re);
-    OBJ_INFECT(match, str);
 
     return result;
+}
+
+long
+rb_reg_search(VALUE re, VALUE str, long pos, int reverse)
+{
+	return rb_reg_search0(re, str, pos, reverse, 1);
 }
 
 VALUE

--- a/string.c
+++ b/string.c
@@ -4021,6 +4021,7 @@ str_gsub(int argc, VALUE *argv, VALUE str, int bang)
     int iter = 0;
     char *sp, *cp;
     int tainted = 0;
+    int str_replace;
     rb_encoding *str_enc;
 
     switch (argc) {
@@ -4041,7 +4042,8 @@ str_gsub(int argc, VALUE *argv, VALUE str, int bang)
     }
 
     pat = get_pat(argv[0], 1);
-    beg = rb_reg_search(pat, str, 0, 0);
+    str_replace = !iter && NIL_P(hash);
+    beg = rb_reg_search0(pat, str, 0, 0, !str_replace);
     if (beg < 0) {
 	if (bang) return Qnil;	/* no match, no substitution */
 	return rb_str_dup(str);
@@ -4064,7 +4066,7 @@ str_gsub(int argc, VALUE *argv, VALUE str, int bang)
 	regs = RMATCH_REGS(match);
 	beg0 = BEG(0);
 	end0 = END(0);
-	if (iter || !NIL_P(hash)) {
+	if (!str_replace) {
             if (iter) {
                 val = rb_obj_as_string(rb_yield(rb_reg_nth_match(0, match)));
             }
@@ -4104,7 +4106,7 @@ str_gsub(int argc, VALUE *argv, VALUE str, int bang)
 	}
 	cp = RSTRING_PTR(str) + offset;
 	if (offset > RSTRING_LEN(str)) break;
-	beg = rb_reg_search(pat, str, offset, 0);
+	beg = rb_reg_search0(pat, str, offset, 0, !str_replace);
     } while (beg >= 0);
     if (RSTRING_LEN(str) > offset) {
         rb_enc_str_buf_cat(dest, cp, RSTRING_LEN(str) - offset, str_enc);


### PR DESCRIPTION
### Summary

[This is also Bug #9676](https://bugs.ruby-lang.org/issues/9676)
`rb_reg_search()` [allocates (dups) a String to attach to the backreference object](https://github.com/ruby/ruby/blob/trunk/re.c#L1453). If `#gsub` has been passed 2 arguments (not Enumerator form) and the second argument is a String, then it shouldn't make these allocations when calling `rb_reg_search()` inside it's loop.
## Example

``` ruby
# gsub-allocates-too-much.rb
require File.join(__dir__, "lib", "allocation_stats")

def puts_object_list(name, stats)
  objects = stats.allocations.group_by(:sourcefile, :sourceline, :class).all.
    values.flatten.map(&:object).
    map {|o| o.is_a?(String) ? "#{o.inspect}<#{o.encoding.to_s}>" : o.inspect }
  puts "#{name} #{objects.flatten.size} new objects:"
  objects.group_by(&:hash).values.each { |ary| puts "#{ary.join(", ")}" }
end

slash = '/'; underscore = '_'; colon = ':' # allocate before the trace
str = "12:34:45:67"
stats = AllocationStats.trace { str.gsub(colon, underscore) }
puts '> "12:34:45:67".gsub(":", "_")'
puts_object_list("gsub substitutes 3x times:", stats)
```

```
$ ruby ../allocation_stats/gsub-allocates-too-much.rb
> "12:34:45:67".gsub(":", "_")
gsub substitutes 3x times: 12 new objects:
"12:34:45:67"<UTF-8>, "12:34:45:67"<UTF-8>, "12:34:45:67"<UTF-8>, "12:34:45:67"<UTF-8>
"12_34_45_67"<UTF-8>
":"<ASCII-8BIT>, ":"<ASCII-8BIT>
":"<US-ASCII>, ":"<US-ASCII>
#<MatchData ":">
#<MatchData nil>
/:/
```

The Strings that are copies of the original String are all unnecessary (except one).
## The Fix

The fix involves allocating the `str` attribute of the backreference object only when necessary. In order to do this without changing the signature of `rb_reg_search()`, this patch changes `rb_reg_search()` to wrap a new function `rb_reg_search0()`. So no calls to `rb_reg_search()` need to change, and `str_gsub()` changes just two calls into `rb_reg_search0()` to avoid the allocations.
## Impact

The impact of this fix is primarily faster garbage collection. I have two "real world" examples:
- ActiveRecord sqlite3 specs: total time in GC reduced from 11.2s to 10.4s (7% savings).
- Mail gem specs: total time in GC reduced from 0.220s to 0.215s (2% savings).

These numbers bounced around a lot though. I'm open to better benchmarking suggestions. I used ActiveRecord and Mail for real world examples of `#gsub`, where realistic Strings are gsubbed.
