### PR TITLE
CSV: Reject nil as a data source.

### DIFF
--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -1484,6 +1484,10 @@ class CSV
   # so be sure to set what you want here.
   #
   def initialize(data, options = Hash.new)
+    if data.nil?
+      raise ArgumentError.new("Cannot parse nil as CSV")
+    end
+
     # build the options for this read/write
     options = DEFAULT_OPTIONS.merge(options)
 

--- a/test/csv/test_interface.rb
+++ b/test/csv/test_interface.rb
@@ -130,6 +130,12 @@ class TestCSV::Interface < TestCSV
     end
   end
 
+  def test_nil_is_not_acceptable
+    assert_raise_with_message ArgumentError, "Cannot parse nil as CSV" do
+      CSV.new(nil)
+    end
+  end
+
   ### Test Write Interface ###
 
   def test_generate


### PR DESCRIPTION
CSV currently accepts `nil` as a data source, and treats it like an `IO`. Since it's not an `IO`, it blows up in the internals, sometimes much later.

I noticed the issue when I accidentally passed `nil` into `CSV.parse`:

```
irb(main):001:0> CSV.parse(nil)
NoMethodError: undefined method `close' for nil:NilClass
        from /Users/peeja/.rubies/ruby-2.0.0-p353/lib/ruby/2.0.0/csv.rb:1293:in `ensure in parse'
        from /Users/peeja/.rubies/ruby-2.0.0-p353/lib/ruby/2.0.0/csv.rb:1293:in `parse'
        from (irb):1
        from /Users/peeja/.rubies/ruby-2.0.0-p353/bin/irb:12:in `<main>'
```

It took me a while to track down what was going on. This should provide a better message.
