### PR TITLE
rb_vm_bugreport() improvements

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -2878,7 +2878,10 @@ AS_CASE(["$target_cpu-$target_os"],
     if test "x$ac_cv_header_execinfo_h" = xyes; then
 	AC_CHECK_LIB([execinfo], [backtrace])
 	AC_CHECK_LIB([unwind], [unw_backtrace])
-    fi])
+    fi],
+[*-linux*], [
+	AC_CHECK_LIB([unwind], [_U_dyn_register])
+])
 AC_CHECK_FUNCS(backtrace)
 
 if test "x$ac_cv_func_backtrace" = xyes; then

--- a/signal.c
+++ b/signal.c
@@ -679,6 +679,8 @@ check_stack_overflow(const void *addr)
 #define MESSAGE_FAULT_ADDRESS
 #endif
 
+void * ruby_signal_ctx = NULL;
+
 #ifdef SIGBUS
 static RETSIGTYPE
 sigbus(int sig SIGINFO_ARG)
@@ -691,6 +693,7 @@ sigbus(int sig SIGINFO_ARG)
 #if defined __APPLE__
     CHECK_STACK_OVERFLOW();
 #endif
+    ruby_signal_ctx = ctx;
     rb_bug("Bus Error" MESSAGE_FAULT_ADDRESS);
 }
 #endif
@@ -728,6 +731,7 @@ sigsegv(int sig SIGINFO_ARG)
 
     segv_received = 1;
     ruby_disable_gc_stress = 1;
+    ruby_signal_ctx = ctx;
     rb_bug("Segmentation fault" MESSAGE_FAULT_ADDRESS);
 }
 #endif

--- a/vm_dump.c
+++ b/vm_dump.c
@@ -428,8 +428,14 @@ rb_vmdebug_thread_dump_state(VALUE self)
 
 #if defined(HAVE_BACKTRACE)
 # if HAVE_LIBUNWIND
-#  undef backtrace
-#  define backtrace unw_backtrace
+#  define UNW_LOCAL_ONLY
+#  include <libunwind.h>
+#  if defined(__linux__)
+
+#  else
+#   undef backtrace
+#   define backtrace unw_backtrace
+#  endif
 # elif defined(__APPLE__) && defined(__x86_64__)
 #  define UNW_LOCAL_ONLY
 #  include <libunwind.h>

--- a/vm_dump.c
+++ b/vm_dump.c
@@ -427,12 +427,8 @@ rb_vmdebug_thread_dump_state(VALUE self)
 }
 
 #if defined(HAVE_BACKTRACE)
-# if HAVE_LIBUNWIND
-#  define UNW_LOCAL_ONLY
-#  include <libunwind.h>
-#  if defined(__linux__)
-
-#  else
+# if defined(HAVE_LIBUNWIND)
+#  if !defined(__linux__)
 #   undef backtrace
 #   define backtrace unw_backtrace
 #  endif

--- a/vm_dump.c
+++ b/vm_dump.c
@@ -678,6 +678,8 @@ dump_thread(void *arg)
 }
 #endif
 
+extern void * ruby_signal_ctx;
+
 void
 rb_print_backtrace(void)
 {
@@ -685,22 +687,22 @@ rb_print_backtrace(void)
 #define MAX_NATIVE_TRACE 1024
     static void *trace[MAX_NATIVE_TRACE];
     int n = backtrace(trace, MAX_NATIVE_TRACE);
-#if defined(USE_BACKTRACE_SYMBOLS_FD)
-    backtrace_symbols_fd(trace, n, STDERR_FILENO);
-#else
+    if (ruby_signal_ctx) {
+	backtrace_symbols_fd(trace, n, STDERR_FILENO);
+    } else {
 # if defined(USE_ELF) && defined(HAVE_DLADDR)
-    rb_dump_backtrace_with_lines(n, trace);
+	rb_dump_backtrace_with_lines(n, trace);
 # else
-    char **syms = backtrace_symbols(trace, n);
-    if (syms) {
-	int i;
-	for (i=0; i<n; i++) {
-	    fprintf(stderr, "%s\n", syms[i]);
+	char **syms = backtrace_symbols(trace, n);
+	if (syms) {
+	    int i;
+	    for (i=0; i<n; i++) {
+		fprintf(stderr, "%s\n", syms[i]);
+	    }
+	    free(syms);
 	}
-	free(syms);
-    }
 # endif
-#endif
+    }
 #elif defined(_WIN32)
     DWORD tid = GetCurrentThreadId();
     HANDLE th = (HANDLE)_beginthread(dump_thread, 0, &tid);
@@ -821,8 +823,6 @@ print_machine_register(mcontext_t *ctx, greg_t reg, const char *reg_name, int *c
     fputs(buf, stderr);
 }
 #endif
-
-extern void * ruby_signal_ctx;
 
 void
 rb_vm_bugreport(void)

--- a/vm_dump.c
+++ b/vm_dump.c
@@ -689,9 +689,12 @@ rb_print_backtrace(void)
 #define MAX_NATIVE_TRACE 1024
     static void *trace[MAX_NATIVE_TRACE];
     int n = backtrace(trace, MAX_NATIVE_TRACE);
-#if defined(USE_ELF) && defined(HAVE_DLADDR)
-    rb_dump_backtrace_with_lines(n, trace);
+#if defined(USE_BACKTRACE_SYMBOLS_FD)
+    backtrace_symbols_fd(trace, n, STDERR_FILENO);
 #else
+# if defined(USE_ELF) && defined(HAVE_DLADDR)
+    rb_dump_backtrace_with_lines(n, trace);
+# else
     char **syms = backtrace_symbols(trace, n);
     if (syms) {
 	int i;
@@ -700,6 +703,7 @@ rb_print_backtrace(void)
 	}
 	free(syms);
     }
+# endif
 #endif
 #elif defined(_WIN32)
     DWORD tid = GetCurrentThreadId();


### PR DESCRIPTION
@charliesome /cc: @Sirupsen, @camilo, @arthurnn

This adds a few things:
- Support for libunwind on Linux. There's no need to `#undef backtrace` on Linux because libunwind's global `backtrace` symbol will take precedence over glibc.
- ~~If `USE_BACKTRACE_SYMBOLS_FD` is defined, MRI will use `backtrace_symbols_fd` rather than `backtrace_symbols` or `rb_dump_backtrace_with_lines`, which are both potentially unsafe when being called from a signal handler. The latter methods also allocate memory from the heap, which can also be unsafe in that context.~~
- Always use `backtrace_symbols_fd` when attempting to dump a backtrace when `rb_print_backtrace` is called from a signal handler.
- Dump machine registers on x64. In cases where core dumps are not being generated, it's still useful to know register contents.
