### PR TITLE
Remove WARN when using minitest5 and test unit

### DIFF
--- a/lib/test/unit/testcase.rb
+++ b/lib/test/unit/testcase.rb
@@ -4,8 +4,8 @@ module Test
   module Unit
     # remove silly TestCase class
     remove_const(:TestCase) if defined?(self::TestCase)
-
-    class TestCase < MiniTest::Unit::TestCase # :nodoc: all
+    base_test_case = defined?(MiniTest::Test) ? MiniTest::Test : MiniTest::Unit::TestCase
+    class TestCase < base_test_case # :nodoc: all
       include Assertions
 
       def on_parallel_worker?


### PR DESCRIPTION
I am using rails 4.1, which includes minitest 5.
Getting this warning when running tests:

``` ruby
MiniTest::Unit::TestCase is now Minitest::Test. From /Users/arthurnn/.rbenv/versions/2.1.1/lib/ruby/2.1.0/test/unit/testcase.rb:8:in `<module:Unit>'
```

This PR should fix the warning on test unit when using minitest 5+
review @zzak
