### PR TITLE
Make `SSL_SESSION_cmp` use `CRYPTO_memcmp`

### DIFF
--- a/ext/openssl/ossl.h
+++ b/ext/openssl/ossl.h
@@ -64,6 +64,7 @@ extern "C" {
 #include <openssl/rand.h>
 #include <openssl/conf.h>
 #include <openssl/conf_api.h>
+#include <openssl/crypto.h>
 #undef X509_NAME
 #undef PKCS7_SIGNER_INFO
 #if defined(HAVE_OPENSSL_ENGINE_H) && defined(HAVE_EVP_CIPHER_CTX_ENGINE)

--- a/ext/openssl/ossl_ssl_session.c
+++ b/ext/openssl/ossl_ssl_session.c
@@ -78,7 +78,7 @@ int SSL_SESSION_cmp(const SSL_SESSION *a,const SSL_SESSION *b)
     if (a->ssl_version != b->ssl_version ||
 	a->session_id_length != b->session_id_length)
 	return 1;
-    return memcmp(a->session_id,b-> session_id, a->session_id_length);
+    return CRYPTO_memcmp(a->session_id, b->session_id, a->session_id_length);
 }
 #endif
 


### PR DESCRIPTION
There could be potential issues with leaking session ids between clients, using a timing attack. This patch doesn't guarantee constant time for `SSL_SESSION_cmp`, but at least makes it constant time if the `ssl_version` and `session_id_length` are equal, which would make certain types of attacks more difficult.

For example, if one was attempting to determine the number of active SSL sessions on a server, this would largely thwart such an attacker.

To be clear: I do not believe this is a significant security issue, but rather a place where we might be able to more closely match a developer's expectations of the function.

For reference, see:
- http://seclists.org/fulldisclosure/2014/Apr/117
- https://news.ycombinator.com/item?id=7570043