### PR TITLE
Don't include locals in envvar when calling to_proc

### DIFF
--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1017,6 +1017,8 @@ vm_caller_setup_args(const rb_thread_t *th, rb_control_frame_t *cfp, rb_call_inf
 	if (proc != Qnil) {
 	    if (!rb_obj_is_proc(proc)) {
 		VALUE b;
+		rb_env_t *env;
+		int i;
 
 		SAVE_RESTORE_CI(b = rb_check_convert_type(proc, T_DATA, "Proc", "to_proc"), ci);
 
@@ -1026,8 +1028,14 @@ vm_caller_setup_args(const rb_thread_t *th, rb_control_frame_t *cfp, rb_call_inf
 			     rb_obj_classname(proc));
 		}
 		proc = b;
+		GetProcPtr(proc, po);
+		GetEnvPtr(po->envval, env);
+		for (i = 0; i < env->local_size; ++i) {
+		    env->env[i] = Qnil;
+		}
+	    } else {
+		GetProcPtr(proc, po);
 	    }
-	    GetProcPtr(proc, po);
 	    ci->blockptr = &po->block;
 	    RUBY_VM_GET_BLOCK_PTR_IN_CFP(cfp)->proc = proc;
 	}


### PR DESCRIPTION
We've encountered a problem in Shopify production where unnecessary controller context is being retained by the [`sym_proc_cache`](https://github.com/ruby/ruby/blob/f2606d6250d5f4b2e7d02b97567b74de6435864a/string.c#L8485-L8513). The problem is the creation of the proc from the symbol is in the context of a controller - as a result, when the proc is cached in `sym_proc_cache`, the controller and all of its context is being cached along with it. This causes memory to be unnecessarily retained beyond the lifetime of a request.

Our proposed solution is to not include local variables in the proc's environment context. As far as I can tell, it should not be possible to access local variables from a Proc when using `to_proc`.
