### PR TITLE
[DOC] Fix a dead link in Psych

### DIFF
--- a/ext/psych/lib/psych.rb
+++ b/ext/psych/lib/psych.rb
@@ -21,7 +21,7 @@ require 'psych/class_loader'
 #
 # Psych is a YAML parser and emitter.
 # Psych leverages libyaml [Home page: http://pyyaml.org/wiki/LibYAML]
-# or [Git repo: https://github.com/zerotao/libyaml] for its YAML parsing
+# or [HG repo: https://bitbucket.org/xi/libyaml] for its YAML parsing
 # and emitting capabilities. In addition to wrapping libyaml, Psych also
 # knows how to serialize and de-serialize most Ruby objects to and from
 # the YAML format.


### PR DESCRIPTION
Git Repo URL is not actual linked in overview.
I think not github but bitbucket is right. (https://bitbucket.org/xi/libyaml)
