### PR TITLE
Add #adjugate method to matrix class

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -59,6 +59,7 @@ with all sufficient information, see the ChangeLog file.
       by deleting the specified row and column.
     * Matrix#cofactor(row, column) returns the (row, column) cofactor
       which is obtained by multiplying the first minor by (-1)**(row + column).
+    * Matrix#adjugate returns the adjugate of the matrix.
 
 * Method
   * New methods:

--- a/lib/matrix.rb
+++ b/lib/matrix.rb
@@ -60,6 +60,7 @@ end
 # * #minor(*param)
 # * #first_minor(row, column)
 # * #cofactor(row, column)
+# * #adjugate
 #
 # Properties of a matrix:
 # * #diagonal?
@@ -634,6 +635,20 @@ class Matrix
 
     det_of_minor = first_minor(row, column).determinant
     det_of_minor * (-1) ** (row + column)
+  end
+
+  #
+  # Returns the adjugate of the matrix.
+  #
+  #   Matrix[ [7,6],[3,9] ].adjugate
+  #     => 9 -6
+  #        -3 7
+  #
+  def adjugate
+    Matrix.Raise ErrDimensionMismatch unless square?
+    Matrix.build(row_count, column_count) do |row, column|
+      cofactor(column, row)
+    end
   end
 
   #--

--- a/test/matrix/test_matrix.rb
+++ b/test/matrix/test_matrix.rb
@@ -273,6 +273,17 @@ class TestMatrix < Test::Unit::TestCase
     assert_raise(ExceptionForMatrix::ErrDimensionMismatch) { Matrix[[2,0,1],[0,-2,2]].cofactor(0, 0) }
   end
 
+  def test_adjugate
+    assert_equal(Matrix.empty, Matrix.empty.adjugate)
+    assert_equal(Matrix[[1]], Matrix[[5]].adjugate)
+    assert_equal(Matrix[[0,0],[0,0]], Matrix[[0,0],[0,0]].adjugate)
+    assert_equal(Matrix[[9,-6],[-3,7]], Matrix[[7,6],[3,9]].adjugate)
+    assert_equal(Matrix[[45,3,-7],[6,-1,0],[-7,0,0]], Matrix[[0,0,1],[0,7,6],[1,3,9]].adjugate)
+    m = Matrix[[2, 0, 9, 3, 9], [8, 7, 0, 1, 9], [7, 5, 6, 6, 5], [0, 7, 8, 3, 0], [7, 8, 2, 3, 1]]
+    assert_equal(Matrix.identity(5), (m.adjugate * m) / m.det)
+    assert_raise(ExceptionForMatrix::ErrDimensionMismatch) { @m1.adjugate }
+  end
+
   def test_regular?
     assert(Matrix[[1, 0], [0, 1]].regular?)
     assert(Matrix[[1, 0, 0], [0, 1, 0], [0, 0, 1]].regular?)


### PR DESCRIPTION
Add Matrix#adjugate to make a matrix adjugate.

Adjugate is really important operator to handle matrix (especially Exploring Data with ruby)

``` ruby:
# Property

* Any n-th matrix  `m`(object of Matrix class) Satisfy the following conditions

Matrix.identity(n) == (m.adjugate * m) / m.det

# Differential vector or matrix
Let A = (a(i, j)) is n-th matrix, A(i, j) is adjugate matrix excluding the j and column i row A.

def. ∂det(A)/∂a(i,j) = (-1) ** (i + j) * det(A(i, j))
```

Some people regards adjugate matrix as Hermitian adjoint.

I regard adjuate matrix as transpose of the cofactor matrix by  referencing http://en.wikipedia.org/wiki/Adjugate_matrix.
