### PR TITLE
Follow symlinks.

### DIFF
--- a/lib/find.rb
+++ b/lib/find.rb
@@ -47,15 +47,15 @@ module Find
           yield file.dup.taint
           begin
             s = File.lstat(file)
+            fs = if s.directory?
+                   Dir.entries(file, encoding: enc)
+                 elsif s.symlink?
+                   Dir.entries(File.readlink(file), encoding: enc)
+                 end
           rescue Errno::ENOENT, Errno::EACCES, Errno::ENOTDIR, Errno::ELOOP, Errno::ENAMETOOLONG
             next
           end
-          if s.directory? then
-            begin
-              fs = Dir.entries(file, encoding: enc)
-            rescue Errno::ENOENT, Errno::EACCES, Errno::ENOTDIR, Errno::ELOOP, Errno::ENAMETOOLONG
-              next
-            end
+          if fs then
             fs.sort!
             fs.reverse_each {|f|
               next if f == "." or f == ".."


### PR DESCRIPTION
This issue was originally reported against JRuby here: https://github.com/jruby/jruby/issues/1647

I can reproduce it with MRI 1.9.3-p484 and MRI 2.1.1-p76.

``` Ruby
require 'tmpdir'
require 'find'
require 'set'
require 'minitest/autorun'

class FindInSymlinkedDirectoryTest < Minitest::Test

  def test_find_in_symlink
    Dir.mktmpdir('jruby-file-find-test') do |fn|
      FileUtils.cd(fn) do
        # Create real dir with file
        FileUtils.mkdir_p('dir')
        File.write('dir/foo.txt', 'Hello world!')

        # Create symlink
        File.symlink('dir', 'dir-link')

        # Find files in symlinked dir
        filenames = Set.new
        Find.find('dir-link/') do |fn|
          filenames << fn
        end

        expected_filenames = Set.new(['dir-link/', 'dir-link/foo.txt'])
        assert_equal expected_filenames, filenames
      end
    end
  end

end
```

The above test _should_ pass.
Instead, this is the output:

``` bash
F

Failures:

  1) Dir.entries follows symlinks
     Failure/Error: filenames.should == expected_filenames
       expected: #<Set: {"dir-link/", "dir-link/foo.txt"}>
            got: #<Set: {}> (using ==)
       Diff:
       @@ -1,2 +1,2 @@
       -#<Set: {"dir-link/", "dir-link/foo.txt"}>
       +#<Set: {}>
     # ./dir_entries.rb:24:in `block (4 levels) in <top (required)>'
     # ./dir_entries.rb:9:in `block (3 levels) in <top (required)>'
     # ./dir_entries.rb:8:in `block (2 levels) in <top (required)>'

Finished in 0.00124 seconds
1 example, 1 failure

Failed examples:

rspec ./dir_entries.rb:7 # Dir.entries follows symlinks
```
