### PR TITLE
decrement highbound on is_pointer_to_heap b-search more efficiently

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -1447,7 +1447,7 @@ is_pointer_to_heap(rb_objspace_t *objspace, void *ptr)
 	    lo = mid + 1;
 	}
 	else {
-	    hi = mid;
+	    hi = mid - 1;
 	}
     }
     return FALSE;


### PR DESCRIPTION
decrement highbound on is_pointer_to_heap's b-search more efficiently.
