### PR TITLE
support for symbols.

### DIFF
--- a/lib/net/http/header.rb
+++ b/lib/net/http/header.rb
@@ -169,7 +169,7 @@ module Net::HTTPHeader
   alias canonical_each each_capitalized
 
   def capitalize(name)
-    name.split(/-/).map {|s| s.capitalize }.join('-')
+    name.to_s.split(/-/).map {|s| s.capitalize }.join('-')
   end
   private :capitalize
 


### PR DESCRIPTION
Support for 1.9+ hash syntax, currently `capitalize` only accept as argument a string.
