### PR TITLE
net/protocol.rb: fix SMTP dot stuffing

### DIFF
--- a/lib/net/protocol.rb
+++ b/lib/net/protocol.rb
@@ -267,7 +267,7 @@ module Net # :nodoc:
     def write_message_0(src)
       prev = @written_bytes
       each_crlf_line(src) do |line|
-        write0 line.sub(/\A\./, '..')
+        write0 dot_stuff(line)
       end
       @written_bytes - prev
     end
@@ -307,12 +307,16 @@ module Net # :nodoc:
     end
 
     private
+    
+    def dot_stuff(s)
+      s.sub(/\A\./, '..')
+    end
 
     def using_each_crlf_line
       @wbuf = ''
       yield
       if not @wbuf.empty?   # unterminated last line
-        write0 @wbuf.chomp + "\r\n"
+        write0 dot_stuff(@wbuf.chomp) + "\r\n"
       elsif @written_bytes == 0   # empty src
         write0 "\r\n"
       end

--- a/test/net/protocol/test_protocol.rb
+++ b/test/net/protocol/test_protocol.rb
@@ -3,6 +3,14 @@ require "net/protocol"
 require "stringio"
 
 class TestProtocol < Test::Unit::TestCase
+  def test_should_properly_dot_stuff_period_with_no_endline
+    sio = StringIO.new("")
+    imio = Net::InternetMessageIO.new(sio)
+    email = "To: bob@aol.com\nlook, a period with no endline\n."
+    imio.write_message email
+    assert_equal "To: bob@aol.com\r\nlook, a period with no endline\r\n..\r\n.\r\n", sio.string
+  end
+  
   def test_each_crlf_line
     assert_output('', '') do
       sio = StringIO.new("")


### PR DESCRIPTION
- fix SMTP dot-stuffing for messages not ending with a new-line

When a message body ends with just a "." and no new-line Ruby does not dot-stuff correctly.  The remaining butter (after the last new-line) also needs to be dot-stuffed properly to avoid SMTP errors.

This includes a patch as well as passing test.

Reference:
- https://bugs.ruby-lang.org/issues/9627
- https://github.com/mikel/mail/pull/683
