### PR TITLE
ERB#result does not accept a proc.

### DIFF
--- a/lib/erb.rb
+++ b/lib/erb.rb
@@ -837,7 +837,7 @@ class ERB
   # the results of that code.  (See ERB::new for details on how this process
   # can be affected by _safe_level_.)
   #
-  # _b_ accepts a Binding or Proc object which is used to set the context of
+  # _b_ accepts a Binding object which is used to set the context of
   # code evaluation.
   #
   def result(b=new_toplevel)


### PR DESCRIPTION
The source shows that `#result` delegates to `Kernel.eval`.  The
documentation for `Kernel.eval` says:

>  Evaluates the Ruby expression(s) in string. If binding is given, which
>  must be a Binding object...

Furthermore, I demonstrated that `#result` does not accept a proc by
switching the example in the documentation to use a proc:

``` ruby
require "erb"

class Listings
  PRODUCT = { :name => "Chicken Fried Steak",
              :desc => "A well messages pattie, breaded and fried.",
              :cost => 9.95 }

  attr_reader :product, :price

  def initialize( product = "", price = "" )
    @product = product
    @price = price
  end

  def build
    # b = binding
    b = proc {}
    # create and run templates, filling member data variables
    ERB.new(<<-'END_PRODUCT'.gsub(/^\s+/, ""), 0, "", "@product").result b
      <%= PRODUCT[:name] %>
      <%= PRODUCT[:desc] %>
    END_PRODUCT
    ERB.new(<<-'END_PRICE'.gsub(/^\s+/, ""), 0, "", "@price").result b
      <%= PRODUCT[:name] %> -- <%= PRODUCT[:cost] %>
      <%= PRODUCT[:desc] %>
    END_PRICE
  end
end

listings = Listings.new
listings.build

puts listings.product + "\n" + listings.price
```

This outputs:

```
ruby-2.1.1/lib/ruby/2.1.0/erb.rb:847:in `eval': wrong argument type proc (expected binding) (TypeError)
    from ruby-2.1.1/lib/ruby/2.1.0/erb.rb:847:in `block in result'
    from ruby-2.1.1/lib/ruby/2.1.0/erb.rb:848:in `call'
    from ruby-2.1.1/lib/ruby/2.1.0/erb.rb:848:in `result'
    from -:21:in `build'
    from -:34:in `block in <main>'
    from -:37:in `call'
    from -:37:in `<main>'
```
