### PR TITLE
Remove `$LOADED_FEATURES` from examples in `lib/English.rb`

### DIFF
--- a/doc/globals.rdoc
+++ b/doc/globals.rdoc
@@ -31,6 +31,7 @@ $DEBUG::     The debug flag, which is set by the -d switch.  Enabling debug
              backtrace).  Setting this to a true value enables debug output as
              if -d were given on the command line.  Setting this to a false
              value disables debug output.
+$LOADED_FEATURES:: The alias to the $".
 $FILENAME::  Current input file from $<. Same as $<.filename.
 $LOAD_PATH:: The alias to the $:.
 $stderr::    The current standard error output.

--- a/lib/English.rb
+++ b/lib/English.rb
@@ -6,7 +6,7 @@
 #
 #      $\ = ' -- '
 #      "waterbuffalo" =~ /buff/
-#      print $", $', $$, "\n"
+#      print $', $$, "\n"
 #
 #  With English:
 #
@@ -14,7 +14,7 @@
 #
 #      $OUTPUT_FIELD_SEPARATOR = ' -- '
 #      "waterbuffalo" =~ /buff/
-#      print $LOADED_FEATURES, $POSTMATCH, $PID, "\n"
+#      print $POSTMATCH, $PID, "\n"
 #
 #  Below is a full list of descriptive aliases and their associated global
 #  variable:


### PR DESCRIPTION
When the docs for `lib/English.rb` were first written [1](https://github.com/ruby/ruby/commit/f8c7b41165042b3d398a6a237aac9207e2856aea#diff-2c060ee58c8d1169e19a88d41b3f0259L3),
`$LOADED_FEATURES` was an alias for `$"` defined in `lib/English.rb`.

Currently, however, `$LOADED_FEATURES` is defined in `load.c` along with
`$"` itself [2](https://github.com/ruby/ruby/blob/5cc1d57c3957ecabe02c5ad79dd75c523457187f/load.c#L1179).

Update the documentation present in `lib/English.rb` to reflect that and
don't misguide the reader.
