### PR TITLE
Document raise/__raise__ usage on the Delegator class.

### DIFF
--- a/lib/delegate.rb
+++ b/lib/delegate.rb
@@ -62,6 +62,12 @@ class Delegator < BasicObject
   end
   # :startdoc:
 
+  ##
+  # :method: raise
+  # Use __raise__ if your Delegator does not have a object to delegate the
+  # raise method call.
+  #
+
   #
   # Pass in the _obj_ to delegate method calls to.  All methods supported by
   # _obj_ will be delegated to.


### PR DESCRIPTION
The `raise` method is delegated to the source object, so calling `raise` inside `__getobj__` will fail. The available alternative is to call `__raise__` instead.

/cc @zzak
