### PR TITLE
Net::IMAP parse failure on FETCHed BODYSTRUCTURE with "mixed" body type

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+Sat May 31 06:11:08 2014  David Raynes  <rayners@gmail.com>
+
+	* lib/net/imap.rb (body_type_1part): Gmail IMAP reports a body
+	  type as "MIXED" followed immediately by params
+	  [ruby-core:62864] [Bug #9885]
+
 Fri May 30 21:23:26 2014  Tanaka Akira  <akr@fsij.org>
 
 	* lib/webrick/server.rb: Use a pipe to detect server shutdown.

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -2374,6 +2374,8 @@ module Net
           return body_type_msg
         when /\A(?:ATTACHMENT)\z/ni
           return body_type_attachment
+        when /\A(?:MIXED)\z/ni
+          return body_type_mixed
         else
           return body_type_basic
         end
@@ -2454,6 +2456,13 @@ module Net
         match(T_SPACE)
         param = body_fld_param
         return BodyTypeAttachment.new(mtype, nil, param)
+      end
+
+      def body_type_mixed
+        mtype = "MULTIPART"
+        msubtype = case_insensitive_string
+        param, disposition, language, extension = body_ext_mpart
+        return BodyTypeBasic.new(mtype, msubtype, param, nil, nil, nil, nil, nil, disposition, language, extension)
       end
 
       def body_type_mpart

--- a/test/net/imap/test_imap_response_parser.rb
+++ b/test/net/imap/test_imap_response_parser.rb
@@ -248,4 +248,14 @@ EOF
     assert_equal("CAPABILITY", response.name)
     assert_equal("AUTH=PLAIN", response.data.last)
   end
+
+  def test_mixed_boundry
+    parser = Net::IMAP::ResponseParser.new
+    response = parser.parse("* 2688 FETCH (UID 179161 BODYSTRUCTURE ((\"TEXT\" \"PLAIN\" (\"CHARSET\" \"iso-8859-1\") NIL NIL \"QUOTED-PRINTABLE\" 200 4 NIL NIL NIL)(\"MESSAGE\" \"DELIVERY-STATUS\" NIL NIL NIL \"7BIT\" 318 NIL NIL NIL)(\"MESSAGE\" \"RFC822\" NIL NIL NIL \"7BIT\" 2177 (\"Tue, 11 May 2010 18:28:16 -0400\" \"Re: Welcome letter\" ((\"David\" NIL \"info\" \"xxxxxxxx.si\")) ((\"David\" NIL \"info\" \"xxxxxxxx.si\")) ((\"David\" NIL \"info\" \"xxxxxxxx.si\")) ((\"Doretha\" NIL \"doretha.info\" \"xxxxxxxx.si\")) NIL NIL \"<AC1D15E06EA82F47BDE18E851CC32F330717704E@localdomain>\" \"<AANLkTikKMev1I73L2E7XLjRs67IHrEkb23f7ZPmD4S_9@localdomain>\") (\"MIXED\" (\"BOUNDARY\" \"000e0cd29212e3e06a0486590ae2\") NIL NIL) 37 NIL NIL NIL) \"REPORT\" (\"BOUNDARY\" \"16DuG.4XbaNOvCi.9ggvq.8Ipnyp3\" \"REPORT-TYPE\" \"delivery-status\") NIL NIL))\r\n")
+    empty_part = response.data.attr['BODYSTRUCTURE'].parts[2]
+    assert_equal(empty_part.lines, 37)
+    assert_equal(empty_part.body.media_type, 'MULTIPART')
+    assert_equal(empty_part.body.subtype, 'MIXED')
+    assert_equal(empty_part.body.param['BOUNDARY'], '000e0cd29212e3e06a0486590ae2')
+  end
 end


### PR DESCRIPTION
```
* lib/net/imap.rb (body_type_1part): Gmail IMAP reports a body
  type as "MIXED" followed immediately by params
  [ruby-core:62864] [Bug #9885]
```

This is to address: https://bugs.ruby-lang.org/issues/9885
