### PR TITLE
Add a tiny note about rb_call_super

### DIFF
--- a/README.EXT
+++ b/README.EXT
@@ -412,6 +412,11 @@ func has to take the klass as the argument and return a newly
 allocated instance.  This instance should be as empty as possible,
 without any expensive (including external) resources.
 
+If you are overriding an existing method of any ancestor of your class,
+you may rely on:
+
+  VALUE rb_call_super(int argc, const VALUE *argv)
+
 === Constant Definition
 
 We have 2 functions to define constants:


### PR DESCRIPTION
Hello,

This is just a tiny pull request that adds a mention about `rb_call_super` in the README.EXT file. This method can be pretty useful when overriding existing methods with inheritance but we need to look at Ruby's code to find it.

I'm not sure if this is intentional not to speak about it though.

Have a nice day.
