### PR TITLE
Define aliases private? and public? for OpenSSL::PKey::EC

### DIFF
--- a/ext/openssl/ossl_pkey_ec.c
+++ b/ext/openssl/ossl_pkey_ec.c
@@ -1598,7 +1598,9 @@ void Init_ossl_ec()
     rb_define_method(cEC, "public_key", ossl_ec_key_get_public_key, 0);
     rb_define_method(cEC, "public_key=", ossl_ec_key_set_public_key, 1);
     rb_define_method(cEC, "private_key?", ossl_ec_key_is_private_key, 0);
+    rb_define_alias (cEC, "private?", "private_key?"); /* Required by OpenSSL::PKey::PKey.sign */
     rb_define_method(cEC, "public_key?", ossl_ec_key_is_public_key, 0);
+    rb_define_alias (cEC, "public?", "public_key?");
 /*  rb_define_method(cEC, "", ossl_ec_key_get_, 0);
     rb_define_method(cEC, "=", ossl_ec_key_set_ 1);
     set/get enc_flags


### PR DESCRIPTION
I've discovered this bug [when I was trying to work with GOST keys](https://bugs.ruby-lang.org/issues/9830) (which are EC keys), and I was unable to do signing as `sign` method in `OpenSSL::PKey` class (superclass of `OpenSSL::PKey::EC`) calls `private?` method on self, but `OpenSSL::PKey::EC` doesn't implement it, but implement method `private_key?` with the same meaning.