### PR TITLE
Fix a binary compatibility issue with the size of the EVP_MD_CTX struct.

### DIFF
--- a/ext/openssl/ossl_pkey.c
+++ b/ext/openssl/ossl_pkey.c
@@ -272,7 +272,8 @@ static VALUE
 ossl_pkey_sign(VALUE self, VALUE digest, VALUE data)
 {
     EVP_PKEY *pkey;
-    EVP_MD_CTX ctx;
+    EVP_MD_CTX *ctx;
+    int result;
     unsigned int buf_len;
     VALUE str;
 
@@ -280,11 +281,14 @@ ossl_pkey_sign(VALUE self, VALUE digest, VALUE data)
 	ossl_raise(rb_eArgError, "Private key is needed.");
     }
     GetPKey(self, pkey);
-    EVP_SignInit(&ctx, GetDigestPtr(digest));
     StringValue(data);
-    EVP_SignUpdate(&ctx, RSTRING_PTR(data), RSTRING_LEN(data));
+    ctx = EVP_MD_CTX_create();
+    EVP_SignInit(ctx, GetDigestPtr(digest));
+    EVP_SignUpdate(ctx, RSTRING_PTR(data), RSTRING_LEN(data));
     str = rb_str_new(0, EVP_PKEY_size(pkey)+16);
-    if (!EVP_SignFinal(&ctx, (unsigned char *)RSTRING_PTR(str), &buf_len, pkey))
+    result = EVP_SignFinal(ctx, (unsigned char *)RSTRING_PTR(str), &buf_len, pkey);
+    EVP_MD_CTX_destroy(ctx);
+    if (!result)
 	ossl_raise(ePKeyError, NULL);
     assert((long)buf_len <= RSTRING_LEN(str));
     rb_str_set_len(str, buf_len);
@@ -317,16 +321,17 @@ static VALUE
 ossl_pkey_verify(VALUE self, VALUE digest, VALUE sig, VALUE data)
 {
     EVP_PKEY *pkey;
-    EVP_MD_CTX ctx;
+    EVP_MD_CTX *ctx;
     int result;
 
     GetPKey(self, pkey);
     StringValue(sig);
     StringValue(data);
-    EVP_VerifyInit(&ctx, GetDigestPtr(digest));
-    EVP_VerifyUpdate(&ctx, RSTRING_PTR(data), RSTRING_LEN(data));
-    result = EVP_VerifyFinal(&ctx, (unsigned char *)RSTRING_PTR(sig), RSTRING_LENINT(sig), pkey);
-    EVP_MD_CTX_cleanup(&ctx);
+    ctx = EVP_MD_CTX_create();
+    EVP_VerifyInit(ctx, GetDigestPtr(digest));
+    EVP_VerifyUpdate(ctx, RSTRING_PTR(data), RSTRING_LEN(data));
+    result = EVP_VerifyFinal(ctx, (unsigned char *)RSTRING_PTR(sig), RSTRING_LENINT(sig), pkey);
+    EVP_MD_CTX_destroy(ctx);
     switch (result) {
     case 0:
 	return Qfalse;


### PR DESCRIPTION
OpenSSL 0.9.x vs OpenSSL 1.0.x uses a different struct definition, which
will cause problems if the ssl libraries are dynamically loaded, and if
the application is built against 0.9 and run against 1.0.

http://bugs.python.org/issue21564 details the same issue in python's
hashlib extension.

Instead of declaring the EVP_MD_CTX struct directly as a stack variable,
use the provided API functions to allocate and deallocate instances.