### PR TITLE
Fix comment in rb_str_slice_bang()

### DIFF
--- a/string.c
+++ b/string.c
@@ -3782,7 +3782,7 @@ rb_str_insert(VALUE str, VALUE idx, VALUE str2)
 
 /*
  *  call-seq:
- *     str.slice!(fixnum)           -> fixnum or nil
+ *     str.slice!(fixnum)           -> new_str or nil
  *     str.slice!(fixnum, fixnum)   -> new_str or nil
  *     str.slice!(range)            -> new_str or nil
  *     str.slice!(regexp)           -> new_str or nil


### PR DESCRIPTION
str.slice!(fixnum) does not return fixnum and it returns new_str.
