### PR TITLE
csv.rb: honor encoding option

### DIFF
--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -1148,9 +1148,9 @@ class CSV
       io.seek(0, IO::SEEK_END)
       args.unshift(io)
     else
-      encoding = (args[-1] = args[-1].dup).delete(:encoding) if args.last.is_a?(Hash)
+      encoding = args[-1][:encoding] if args.last.is_a?(Hash)
       str      = ""
-      str.encode!(encoding) if encoding
+      str.force_encoding(encoding) if encoding
       args.unshift(str)
     end
     csv = new(*args)  # wrap
@@ -1515,7 +1515,7 @@ class CSV
     init_headers(options)
     init_comments(options)
 
-    options.delete(:encoding)
+    @force_encoding = !!(encoding || options.delete(:encoding))
     options.delete(:internal_encoding)
     options.delete(:external_encoding)
     unless options.empty?
@@ -1655,10 +1655,13 @@ class CSV
 
     output = row.map(&@quote).join(@col_sep) + @row_sep  # quote and separate
     if @io.is_a?(StringIO)             and
-       output.encoding != raw_encoding and
-       (compatible_encoding = Encoding.compatible?(@io.string, output))
-      @io.set_encoding(compatible_encoding)
-      @io.seek(0, IO::SEEK_END)
+       output.encoding != (encodign = raw_encoding)
+      if @force_encoding
+        output = output.encode(encoding)
+      elsif (compatible_encoding = Encoding.compatible?(@io.string, output))
+        @io.set_encoding(compatible_encoding)
+        @io.seek(0, IO::SEEK_END)
+      end
     end
     @io << output
 

--- a/test/csv/test_encodings.rb
+++ b/test/csv/test_encodings.rb
@@ -247,6 +247,14 @@ class TestCSV::Encodings < TestCSV
     assert_equal("UTF-8",      data.to_csv.encoding.name)
   end
 
+  def test_explicit_encoding
+    bug9766 = '[ruby-core:62113] [Bug #9766]'
+    s = CSV.generate(encoding: "Windows-31J") do |csv|
+      csv << ["foo".force_encoding("ISO-8859-1"), "\u3042"]
+    end
+    assert_equal(["foo,\u3042\n".encode(Encoding::Windows_31J), Encoding::Windows_31J], [s, s.encoding], bug9766)
+  end
+
   private
 
   def assert_parses(fields, encoding, options = { })


### PR DESCRIPTION
- lib/csv.rb (CSV#<<): honor explicity given encoding.  based on
  the patch by DAISUKE TANIWAKI <daisuketaniwaki AT gmail.com> at
  [ruby-core:62113].  [Bug #9766]
