### PR TITLE
Redmine 9927: Remove content-length when responding to HEAD request with webrick

### DIFF
--- a/lib/webrick/httpresponse.rb
+++ b/lib/webrick/httpresponse.rb
@@ -240,7 +240,7 @@ module WEBrick
       end
 
       # Determine the message length (RFC2616 -- 4.4 Message Length)
-      if @status == 304 || @status == 204 || HTTPStatus::info?(@status)
+      if @status == 304 || @status == 204 || HTTPStatus::info?(@status) || @request_method == 'HEAD'
         @header.delete('content-length')
         @body = ""
       elsif chunked?

--- a/test/webrick/test_httpresponse.rb
+++ b/test/webrick/test_httpresponse.rb
@@ -139,5 +139,13 @@ module WEBrick
         assert_equal "5\r\nhello\r\n0\r\n\r\n", r.read
       }
     end
+
+    def test_head_does_not_return_body
+      res.request_method = 'HEAD'
+      res.body = 'ignored'
+      res.setup_header
+      assert_equal nil, res.header['content-length']
+      assert_equal '', res.body
+    end
   end
 end


### PR DESCRIPTION
- lib/webrick/httpresponse.rb: unset content-length header when responding to
    HEAD requests.
  - test/webrick/test_httpresponse.rb: tests for above
