### PR TITLE
Add Symbol.count

### DIFF
--- a/include/ruby/intern.h
+++ b/include/ruby/intern.h
@@ -615,6 +615,7 @@ void rb_backref_set(VALUE);
 VALUE rb_lastline_get(void);
 void rb_lastline_set(VALUE);
 VALUE rb_sym_all_symbols(void);
+VALUE rb_sym_count(void);
 /* process.c */
 void rb_last_status_set(int status, rb_pid_t pid);
 VALUE rb_last_status_get(void);

--- a/parse.y
+++ b/parse.y
@@ -10946,6 +10946,21 @@ rb_sym_all_symbols(void)
     return ary;
 }
 
+/*
+ *  call-seq:
+ *     Symbol.count    => int
+ *
+ *  Returns the number of symbols currently in Ruby's symbol table.
+ *
+ *     Symbol.count    #=> 903
+ */
+
+VALUE
+rb_sym_count(void)
+{
+    return INT2NUM(global_symbols.sym_id->num_entries);
+}
+
 int
 rb_is_const_id(ID id)
 {

--- a/string.c
+++ b/string.c
@@ -8858,6 +8858,7 @@ Init_String(void)
     rb_undef_alloc_func(rb_cSymbol);
     rb_undef_method(CLASS_OF(rb_cSymbol), "new");
     rb_define_singleton_method(rb_cSymbol, "all_symbols", rb_sym_all_symbols, 0); /* in parse.y */
+    rb_define_singleton_method(rb_cSymbol, "count", rb_sym_count, 0); /* in parse.y */
     rb_define_singleton_method(rb_cSymbol, "find", sym_find, 1);
 
     rb_define_method(rb_cSymbol, "==", sym_equal, 1);

--- a/test/ruby/test_parse.rb
+++ b/test/ruby/test_parse.rb
@@ -828,6 +828,11 @@ x = __ENCODING__
     assert_empty(x.reject {|s| s.is_a?(Symbol) })
   end
 
+  def test_symbol_count
+    x = Symbol.count
+    assert_kind_of(Integer, x)
+  end
+
   def test_is_class_id
     c = Class.new
     assert_raise(NameError) do


### PR DESCRIPTION
Provides a more efficient way to get the number of symbols in Ruby's symbol table which comes in handy when trying to detect accidental conversion of user strings into symbols.

Using `Symbol.all_symbols` for this is inefficient.
