### PR TITLE
Coerce header value to string

### DIFF
--- a/lib/net/http/header.rb
+++ b/lib/net/http/header.rb
@@ -14,7 +14,7 @@ module Net::HTTPHeader
     return unless initheader
     initheader.each do |key, value|
       warn "net/http: warning: duplicated HTTP header: #{key}" if key?(key) and $VERBOSE
-      @header[key.downcase] = [value.strip]
+      @header[key.downcase] = [value.to_s.strip]
     end
   end
 


### PR DESCRIPTION
Prevent exception if a header value is `nil`