### PR TITLE
fix empty RbConfig::CONFIG["prefix"] when configured --with-rubyarchprefix

### DIFF
--- a/tool/mkconfig.rb
+++ b/tool/mkconfig.rb
@@ -167,10 +167,10 @@ def vars.expand(val, config = self)
   val.replace(newval) unless newval == val
   val
 end
-vars["prefix"] = ""
-vars["exec_prefix"] = ""
-prefix = vars.expand(vars["rubyarchdir"])
-print "  TOPDIR = File.dirname(__FILE__).chomp!(#{prefix.dump})\n"
+prefix = vars.expand(vars["prefix"])
+rubyarchdir = vars.expand(vars["rubyarchdir"])
+relative_archdir = rubyarchdir.gsub(prefix, '')
+print "  TOPDIR = File.dirname(__FILE__).chomp!(#{relative_archdir.dump})\n"
 print "  DESTDIR = ", (drive ? "TOPDIR && TOPDIR[/\\A[a-z]:/i] || " : ""), "'' unless defined? DESTDIR\n"
 print <<'ARCH' if universal
   arch_flag = ENV['ARCHFLAGS'] || ((e = ENV['RC_ARCHS']) && e.split.uniq.map {|a| "-arch #{a}"}.join(' '))


### PR DESCRIPTION
This fixes RbConfig::CONFIG["prefix"] being empty when ruby was configured
--with-rubyarchprefix. The 'why' is pretty convoluted:

rbconfig.rb is _not_ generated by autoconf for some reason I cannot fathom, but
instead, at compile-time, miniruby is used to run tool/mkconfig.rb to generate
it. mkconfig.rb parses the config.status shell script to do that; that's weird,
but okay. The actually relevant lines in the script look like this:

```
S["rubyarchdir"]="${rubyarchprefix}/${ruby_version}"
```

So mkconfig.rb has code to expand these variables as well. But it doesn't end
here. TOPDIR in rbconfig.rb is what is used to figure out CONFIG["prefix"];
this is done by chopping off the part without the prefix from the full path of
the file:

```
TOPDIR = File.dirname(__FILE__).chomp!("/lib/amd64/ruby/2.0.0")
```

and

```
CONFIG["prefix"] = (TOPDIR || DESTDIR + "/opt/niksula")
```

I don't know why this needs to be done at runtime. Anyway, the bug lies in the
mkconfig.rb code that generates the TOPDIR line above. After reading the
variables from config.status, "prefix" and "exec_prefix" are set to the empty
string, and the expansion is only done _after_ this. That means, if your
rubyarchprefix happens to begin with either "${prefix}" or "${exec_prefix}",
you will get a correctly generated TOPDIR line (one that does not contain your
prefix). However, if you used --with-rubyarchprefix to set it explicitly,
you're not so lucky: there is no prefix or exec_prefix variable there, so you
get the full rubyarchdir path on the TOPDIR line in rbconfig.rb, and thus the
prefix resolves to empty at runtime.

Because I don't know why TOPDIR is decided at runtime, I'm leaving it like that
with this patch; otherwise I'd just set it to be prefix.

I tested this against ruby 2.1.2 release version.
