### PR TITLE
document File.join returns a string

### DIFF
--- a/file.c
+++ b/file.c
@@ -4291,7 +4291,7 @@ rb_file_join(VALUE ary, VALUE sep)
 
 /*
  *  call-seq:
- *     File.join(string, ...)  ->  path
+ *     File.join(string, ...)  ->  string
  *
  *  Returns a new string formed by joining the strings using
  *  <code>File::SEPARATOR</code>.


### PR DESCRIPTION
The documented return from `File.join` is `path`.  This patch changes it
to `string` to avoid confusion with `Pathname#join`, which returns a
`Pathname` object.
