### PR TITLE
Fix wrong attr_reader `modifieer` => `modifier` from irb locale

### DIFF
--- a/lib/irb/locale.rb
+++ b/lib/irb/locale.rb
@@ -39,7 +39,7 @@ module IRB # :nodoc:
       @encoding ||= (Encoding.find('locale') rescue Encoding::ASCII_8BIT)
     end
 
-    attr_reader :lang, :territory, :encoding, :modifieer
+    attr_reader :lang, :territory, :encoding, :modifier
 
     def String(mes)
       mes = super(mes)


### PR DESCRIPTION
Fix wrong attr_reader `modifieer` => `modifier` from irb locale
