### PR TITLE
Added element reference operator to methods.rdoc

### DIFF
--- a/doc/syntax/methods.rdoc
+++ b/doc/syntax/methods.rdoc
@@ -93,7 +93,6 @@ operators.
 <code><=</code>  :: less-than or equal
 <code>></code>   :: greater-than
 <code>>=</code>  :: greater-than or equal
-<code>[]</code>  :: element reference
 
 To define unary methods minus, plus, tilde and not (<code>!</code>) follow the
 operator with an <code>@</code> as in <code>+@</code> or <code>!@</code>:
@@ -109,6 +108,25 @@ operator with an <code>@</code> as in <code>+@</code> or <code>!@</code>:
   -obj # prints "you inverted this object"
 
 Unary methods accept zero arguments.
+
+Additionally, methods for element reference and assignment may be defined: 
+<code>[]</code> and <code>[]=</code> respectively. Both can take one or more 
+arguments, and element reference can take none.
+
+  class C
+    def [](a, b)
+      puts a + b
+    end
+    
+    def []=(a, b, c)
+      puts a * b + c
+    end
+  end
+  
+  obj = C.new
+  
+  obj[2, 3]     # prints "5"
+  obj[2, 3] = 4 # prints "10"
 
 == Return Values
 


### PR DESCRIPTION
It seems strange to me that the element reference operator is missing from the methods documentation. While it doesn't use infix notation like the others listed, it is still a special operator method available for people to implement.

[]= is missing as well, but assignment methods are described in the paragraphs above, as well as in assignment.rdoc
