### PR TITLE
Fix `Time.parse` for out of range arguments with an offset

### DIFF
--- a/lib/time.rb
+++ b/lib/time.rb
@@ -214,7 +214,7 @@ class Time
         if o != 0 then hour += o; o, hour = hour.divmod(24); off += o end
         if off != 0
           day += off
-          if month_days(year, mon) < day
+          if month_days(year, mon) && month_days(year, mon) < day
             mon += 1
             if 12 < mon
               mon = 1

--- a/test/test_time.rb
+++ b/test/test_time.rb
@@ -307,6 +307,9 @@ class TestTimeExtension < Test::Unit::TestCase # :nodoc:
     assert_raise(ArgumentError) { Time.rfc2822("=?iso-8859-1?Q?(=C5=DA),?= 10   2 2001 23:32:26 +0900 (JST)") }
     assert_raise(ArgumentError) { Time.rfc2822("\307\341\314\343\332\311, 30 \344\346\335\343\310\321 2001 10:01:06") }
     assert_raise(ArgumentError) { Time.rfc2822("=?iso-8859-1?Q?(=BF=E5),?= 12  =?iso-8859-1?Q?9=B7=EE?= 2001 14:52:41\n+0900 (JST)") }
+
+    # Out of range arguments
+    assert_raise(ArgumentError) { Time.parse("2014-13-13T18:00:00-0900") }
   end
 
   def test_zone_0000


### PR DESCRIPTION
Guards against a `nil` return value from `Time.month_days` when offsetting date.
Out of range values are then caught when `Time.utc` is called (as usual).

Previously a `nil` return value from `Time.month_days` would have the `<`
operator called on it, and raise `NoMethodError`.
