### PR TITLE
Add missing options in documentation of FileUtils.touch

### DIFF
--- a/lib/fileutils.rb
+++ b/lib/fileutils.rb
@@ -1130,7 +1130,7 @@ module FileUtils
   private_module_function :fu_get_gid
 
   #
-  # Options: noop verbose
+  # Options: noop verbose mtime nocreate
   #
   # Updates modification time (mtime) and access time (atime) of file(s) in
   # +list+.  Files are created if they don't exist.


### PR DESCRIPTION
This pull request adds the missing `:mtime` and `:nocreate` options to the documentation of `FileUtils.touch`.

Those options are currently supported but not documented.
