### PR TITLE
nodoc, `ConditionVariable#marshal_dump`

### DIFF
--- a/ext/thread/thread.c
+++ b/ext/thread/thread.c
@@ -546,6 +546,7 @@ rb_szqueue_num_waiting(VALUE self)
 #define UNDER_THREAD 1
 #endif
 
+/* :nodoc: */
 static VALUE
 undumpable(VALUE obj)
 {


### PR DESCRIPTION
nodoc, `ConditionVariable#marshal_dump` which is unsupported and raises exception.
