### PR TITLE
optparse.rb-getopts() : Add printing default value and comment

### DIFF
--- a/lib/optparse.rb
+++ b/lib/optparse.rb
@@ -1522,12 +1522,12 @@ XXX
       opt, val = predesc.split(':', 2)
       str_val = ""
       if val
-        str_val << "VAL"
+        str_val << "\tVAL"
         str_val << "(=#{val})" if !val.empty?
       end
       str_desc = ""
       str_desc = "\t# #{desc}" if desc
-      str = "--#{opt} #{str_val}#{str_desc}"
+      str = "--#{opt}#{str_val}#{str_desc}"
 
       if val
         result[opt] = val.empty? ? nil : val


### PR DESCRIPTION
getopts() can receive default value, but it doesn't print in '--help' output.
I'd like to add printing default values. And also I add printing comment for options.
Please see the below example. 

``` ruby
#!/bin/env ruby
require 'optparse'
opt = ARGV.getopts("",
                   "alpha:",
                   "beta:B",
                   "gamma:G;This is description"
                   )

# expected output with '--help' option are below
#
#  --alpha VAL
#  --beta  VAL(=B)
#  --gamma VAL(=G) # This is description
```

And if you don't mind, please merge it to official repos.
Thanks,
