### PR TITLE
Support hostnames longer than 64 chars

### DIFF
--- a/ext/socket/socket.c
+++ b/ext/socket/socket.c
@@ -1023,10 +1023,15 @@ sock_sysaccept(VALUE sock)
 static VALUE
 sock_gethostname(VALUE obj)
 {
-#ifndef HOST_NAME_MAX
-#  define HOST_NAME_MAX 1024
+#if defined(NI_MAXHOST)
+#  define RUBY_MAX_HOST_NAME_LEN NI_MAXHOST
+#elif defined(HOST_NAME_MAX)
+#  define RUBY_MAX_HOST_NAME_LEN HOST_NAME_MAX
+#else
+#  define RUBY_MAX_HOST_NAME_LEN 1024
 #endif
-    char buf[HOST_NAME_MAX+1];
+
+    char buf[RUBY_MAX_HOST_NAME_LEN+1];
 
     rb_secure(3);
     if (gethostname(buf, (int)sizeof buf - 1) < 0)


### PR DESCRIPTION
On Linux, `HOST_NAME_MAX` seems to default to 64.

There is however `NI_MAXHOST`, which is used by many tools already, and supports much longer hostnames by default.

On current Ruby on an Ubuntu 14.04 system, the current behavior can be reproduced with the following code IFF the hostname is >= 65 characters:

``` ruby
require 'socket'
Socket.gethostname
```

/cc @charliesome
