### PR TITLE
parse.y: quoted label

### DIFF
--- a/ext/ripper/eventids2.c
+++ b/ext/ripper/eventids2.c
@@ -46,6 +46,7 @@ static ID ripper_id_rational;
 static ID ripper_id_regexp_beg;
 static ID ripper_id_regexp_end;
 static ID ripper_id_label;
+static ID ripper_id_label_end;
 static ID ripper_id_tlambda;
 static ID ripper_id_tlambeg;
 
@@ -103,6 +104,7 @@ ripper_init_eventids2(void)
     ripper_id_regexp_beg = rb_intern_const("on_regexp_beg");
     ripper_id_regexp_end = rb_intern_const("on_regexp_end");
     ripper_id_label = rb_intern_const("on_label");
+    ripper_id_label_end = rb_intern_const("on_label_end");
     ripper_id_tlambda = rb_intern_const("on_tlambda");
     ripper_id_tlambeg = rb_intern_const("on_tlambeg");
 
@@ -259,6 +261,7 @@ static const struct token_assoc {
     {tWORDS_BEG,	&ripper_id_words_beg},
     {tXSTRING_BEG,	&ripper_id_backtick},
     {tLABEL,		&ripper_id_label},
+    {tLABEL_END,	&ripper_id_label_end},
     {tLAMBDA,		&ripper_id_tlambda},
     {tLAMBEG,		&ripper_id_tlambeg},
 

--- a/test/ripper/test_parser_events.rb
+++ b/test/ripper/test_parser_events.rb
@@ -548,6 +548,10 @@ class TestRipper::ParserEvents < Test::Unit::TestCase
     thru_dyna_symbol = false
     parse(':"#{foo}"', :on_dyna_symbol) {thru_dyna_symbol = true}
     assert_equal true, thru_dyna_symbol
+
+    thru_dyna_symbol = false
+    parse('{"#{foo}": 1}', :on_dyna_symbol) {thru_dyna_symbol = true}
+    assert_equal true, thru_dyna_symbol
   end
 
   def test_else

--- a/test/ripper/test_scanner_events.rb
+++ b/test/ripper/test_scanner_events.rb
@@ -874,6 +874,13 @@ class TestRipper::ScannerEvents < Test::Unit::TestCase
   end
 
   def test_label
+    assert_equal %w(foo:),
+                 scan('label', '{foo: 1}')
+  end
+
+  def test_label_end
+    assert_equal %w(":),
+                 scan('label_end', '{"foo-bar": 1}')
   end
 
   def test_tlambda

--- a/test/ruby/test_hash.rb
+++ b/test/ruby/test_hash.rb
@@ -1269,6 +1269,17 @@ class TestHash < Test::Unit::TestCase
     assert_equal(bug9381, hash[wrapper.new(5)])
   end
 
+  def test_label_syntax
+    return unless @cls == Hash
+
+    feature4935 = '[ruby-core:37553] [Feature #4935]'
+    x = 'world'
+    hash = assert_nothing_raised(SyntaxError) do
+      break eval '{foo: 1, "foo-bar": 2, "hello-#{x}": 3}'
+    end
+    assert_equal({:foo => 1, :'foo-bar' => 2, :'hello-world' => 3}, hash)
+  end
+
   class TestSubHash < TestHash
     class SubHash < Hash
       def reject(*)


### PR DESCRIPTION
- parse.y (assoc): allow quoted labels in hash literals.
  [ruby-core:34453] [Feature #4276]
