### PR TITLE
move enum.one? documentation before the relevant method.

### DIFF
--- a/enum.c
+++ b/enum.c
@@ -1105,24 +1105,6 @@ DEFINE_ENUMFUNCS(one)
     return Qnil;
 }
 
-/*
- *  call-seq:
- *     enum.one? [{ |obj| block }]   -> true or false
- *
- *  Passes each element of the collection to the given block. The method
- *  returns <code>true</code> if the block returns <code>true</code>
- *  exactly once. If the block is not given, <code>one?</code> will return
- *  <code>true</code> only if exactly one of the collection members is
- *  true.
- *
- *     %w{ant bear cat}.one? { |word| word.length == 4 }  #=> true
- *     %w{ant bear cat}.one? { |word| word.length > 4 }   #=> false
- *     %w{ant bear cat}.one? { |word| word.length < 4 }   #=> false
- *     [ nil, true, 99 ].one?                             #=> false
- *     [ nil, true, false ].one?                          #=> true
- *
- */
-
 struct nmin_data {
   long n;
   long bufmax;
@@ -1307,6 +1289,23 @@ nmin_run(VALUE obj, VALUE num, int by, int rev)
 
 }
 
+/*
+ *  call-seq:
+ *     enum.one? [{ |obj| block }]   -> true or false
+ *
+ *  Passes each element of the collection to the given block. The method
+ *  returns <code>true</code> if the block returns <code>true</code>
+ *  exactly once. If the block is not given, <code>one?</code> will return
+ *  <code>true</code> only if exactly one of the collection members is
+ *  true.
+ *
+ *     %w{ant bear cat}.one? { |word| word.length == 4 }  #=> true
+ *     %w{ant bear cat}.one? { |word| word.length > 4 }   #=> false
+ *     %w{ant bear cat}.one? { |word| word.length < 4 }   #=> false
+ *     [ nil, true, 99 ].one?                             #=> false
+ *     [ nil, true, false ].one?                          #=> true
+ *
+ */
 static VALUE
 enum_one(VALUE obj)
 {


### PR DESCRIPTION
move `enum.one?` documentation before the relevant method.
