### PR TITLE
add timing-safe hmac verify method

### DIFF
--- a/test/openssl/test_hmac.rb
+++ b/test/openssl/test_hmac.rb
@@ -24,6 +24,12 @@ class OpenSSL::TestHMAC < Test::Unit::TestCase
 
     assert_equal(OpenSSL::HMAC.digest("MD5", @key, @data), @h2.digest, "digest")
     assert_equal(OpenSSL::HMAC.hexdigest("MD5", @key, @data), @h2.hexdigest, "hexdigest")
+
+    assert_same(false, @h1.verify("\x9EPYl\x0F\xA1\x19\x7F\x85\x87D:\x94-\x8A\xFD"))
+    assert_same(true, @h1.verify("\x9EPYl\x0F\xA1\x19\x7F\x85\x87D:\x94-\x8A\xFC"))
+  end
+
+  def test_hmac_verify
   end
 
   def test_dup


### PR DESCRIPTION
I could be totally wrong, but it seems the standard library doesn't provide a reliable way of comparing hashes in constant-time.
- The docs for OpenSSL::HMAC [encourage the use of `Digest#to_s`](http://ruby-doc.org/stdlib-2.1.0/libdoc/openssl/rdoc/OpenSSL/HMAC.html#method-c-new).
- Ruby's string comparison [uses memcmp](http://rxr.whitequark.org/mri/source/string.c#2382), which isn't timing safe.

With this patch I propose to add an additional method, `OpenSSL::HMAC#verify`, which takes a binary string with a digest and compares it against the computed hash.

I've also logged a feature request at https://bugs.ruby-lang.org/issues/10098 - since this is my first time contributing I'm not sure what constitutes a "tiny fix"; here's a pull request too.
