### PR TITLE
Add description of `BigDecimal.new` exceptions

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -2466,19 +2466,16 @@ static Real *BigDecimal_new(int argc, VALUE *argv);
  *
  * ==== Exceptions
  *
- * TypeError:: If the initial value type is neither Fixnum, Bignum, Float,
+ * TypeError:: If the +initial+ type is neither Fixnum, Bignum, Float,
  *             Rational, nor BigDecimal, this exception is raised.
  *
- * TypeError:: If the digits value is not a Fixnum,
- *             this exception is raised.
+ * TypeError:: If the +digits+ is not a Fixnum, this exception is raised.
  *
- * ArgumentError:: If the initial value is a Float,
- *                 and the digits value is larger than Float::DIG + 1,
- *                 this exception is raised.
+ * ArgumentError:: If +initial+ is a Float, and the +digits+ is larger than
+ *                 Float::DIG + 1, this exception is raised.
  *
- * ArgumentError:: If the initial value is a Float or Rational,
- *                 and the digits value is omitted,
- *                 this exception is raised.
+ * ArgumentError:: If the +initial+ is a Float or Rational, and the +digits+
+ *                 value is omitted, this exception is raised.
  */
 static VALUE
 BigDecimal_initialize(int argc, VALUE *argv, VALUE self)


### PR DESCRIPTION
`BigDecimal.new` raises some Exceptions.
But it is undocumented.

this PR is very similar to #680.
But #680 seems still not enough. 

Especially, ArgumentError by larger digits value than Float::DIG + 1 causes some trouble.
