### PR TITLE
Unify class methods definitions.

### DIFF
--- a/lib/tempfile.rb
+++ b/lib/tempfile.rb
@@ -296,43 +296,42 @@ class Tempfile < DelegateClass(File)
     end
   end
   # :startdoc:
+end
 
-  class << self
-    # Creates a new Tempfile.
-    #
-    # If no block is given, this is a synonym for Tempfile.new.
-    #
-    # If a block is given, then a Tempfile object will be constructed,
-    # and the block is run with said object as argument. The Tempfile
-    # object will be automatically closed after the block terminates.
-    # The call returns the value of the block.
-    #
-    # In any case, all arguments (+*args+) will be passed to Tempfile.new.
-    #
-    #   Tempfile.open('foo', '/home/temp') do |f|
-    #      ... do something with f ...
-    #   end
-    #
-    #   # Equivalent:
-    #   f = Tempfile.open('foo', '/home/temp')
-    #   begin
-    #      ... do something with f ...
-    #   ensure
-    #      f.close
-    #   end
-    def open(*args)
-      tempfile = new(*args)
 
-      if block_given?
-        begin
-          yield(tempfile)
-        ensure
-          tempfile.close
-        end
-      else
-        tempfile
-      end
+# Creates a new Tempfile.
+#
+# If no block is given, this is a synonym for Tempfile.new.
+#
+# If a block is given, then a Tempfile object will be constructed,
+# and the block is run with said object as argument. The Tempfile
+# object will be automatically closed after the block terminates.
+# The call returns the value of the block.
+#
+# In any case, all arguments (+*args+) will be passed to Tempfile.new.
+#
+#   Tempfile.open('foo', '/home/temp') do |f|
+#      ... do something with f ...
+#   end
+#
+#   # Equivalent:
+#   f = Tempfile.open('foo', '/home/temp')
+#   begin
+#      ... do something with f ...
+#   ensure
+#      f.close
+#   end
+def Tempfile.open(*args)
+  tempfile = new(*args)
+
+  if block_given?
+    begin
+      yield(tempfile)
+    ensure
+      tempfile.close
     end
+  else
+    tempfile
   end
 end
 


### PR DESCRIPTION
The [RDoc is not being generated for open](http://ruby-doc.org/stdlib-2.1.2/libdoc/tempfile/rdoc/Tempfile.html) (the documentation is readable only in the [yard](http://yard.ruby-doc.org/stdlib-2.1.2/Tempfile.html#open-class_method) version). This change should make it work.
