### PR TITLE
Pathname#ascend, #descend returning Enumerator

### DIFF
--- a/ext/pathname/lib/pathname.rb
+++ b/ext/pathname/lib/pathname.rb
@@ -285,6 +285,7 @@ class Pathname
   # It doesn't access the filesystem.
   #
   def descend
+    return to_enum(__method__) unless block_given?
     vs = []
     ascend {|v| vs << v }
     vs.reverse_each {|v| yield v }
@@ -310,6 +311,7 @@ class Pathname
   # It doesn't access the filesystem.
   #
   def ascend
+    return to_enum(__method__) unless block_given?
     path = @path
     yield self
     while r = chop_basename(path)

--- a/test/pathname/test_pathname.rb
+++ b/test/pathname/test_pathname.rb
@@ -431,7 +431,9 @@ class TestPathname < Test::Unit::TestCase
   end
 
   def descend(path)
-    Pathname.new(path).enum_for(:descend).map {|v| v.to_s }
+    result = []
+    Pathname.new(path).descend {|v| result << v.to_s }
+    result
   end
 
   defassert(:descend, %w[/ /a /a/b /a/b/c], "/a/b/c")
@@ -439,14 +441,25 @@ class TestPathname < Test::Unit::TestCase
   defassert(:descend, %w[. ./a ./a/b ./a/b/c], "./a/b/c")
   defassert(:descend, %w[a/], "a/")
 
+  def test_descend_enum
+    assert_equal(%w[/ /a /a/b /a/b/c], Pathname.new('/a/b/c').descend.to_a.map {|v| v.to_s })
+  end
+
   def ascend(path)
-    Pathname.new(path).enum_for(:ascend).map {|v| v.to_s }
+    result = []
+    Pathname.new(path).ascend {|v| result << v.to_s }
+    result
   end
 
   defassert(:ascend, %w[/a/b/c /a/b /a /], "/a/b/c")
   defassert(:ascend, %w[a/b/c a/b a], "a/b/c")
   defassert(:ascend, %w[./a/b/c ./a/b ./a .], "./a/b/c")
   defassert(:ascend, %w[a/], "a/")
+
+  def test_ascend_enum
+    assert_equal(%w[/a/b/c /a/b /a /], Pathname.new('/a/b/c').ascend.to_a.map {|v| v.to_s })
+  end
+
 
   def test_initialize
     p1 = Pathname.new('a')


### PR DESCRIPTION
This pull request changes Pathname#ascend and Pathname#descend to return an Enumerator if no block is given.

I also had to change the existing tests from using #to_enum to block form to test the existing behavior, not the new.
