### PR TITLE
[ruby-core:64039] [Feature #10095] Object#itself with block

### DIFF
--- a/object.c
+++ b/object.c
@@ -404,18 +404,22 @@ rb_obj_dup(VALUE obj)
 
 /*
  *  call-seq:
- *     obj.itself -> an_object
+ *     obj.itself               -> an_object
+ *     obj.itself { |o| block } -> an_object
  *
- *  Returns <i>obj</i>.
+ *  Returns <i>obj</i>.  If the optional <em>block</em> is supplied,
+ *  the object is passed to it, and the block's result is returned.
  *
  *	string = 'my string' #=> "my string"
  *	string.itself.object_id == string.object_id #=> true
+ *	string.itself { |s| s.upcase } #=> "MY STRING"
  *
  */
 
 static VALUE
 rb_obj_itself(VALUE obj)
 {
+	if (rb_block_given_p()) return rb_yield(obj);
     return obj;
 }
 

--- a/object.c
+++ b/object.c
@@ -419,7 +419,7 @@ rb_obj_dup(VALUE obj)
 static VALUE
 rb_obj_itself(VALUE obj)
 {
-	if (rb_block_given_p()) return rb_yield(obj);
+    if (rb_block_given_p()) return rb_yield(obj);
     return obj;
 }
 

--- a/test/ruby/test_object.rb
+++ b/test/ruby/test_object.rb
@@ -14,8 +14,14 @@ class TestObject < Test::Unit::TestCase
 
   def test_itself
     feature6373 = '[ruby-core:44704] [Feature #6373]'
+    feature10095 = '[ruby-core:64039] [Feature #10095]'
     object = Object.new
     assert_same(object, object.itself, feature6373)
+    assert_same(object, object.itself{|o| o}, feature10095)
+
+    string = 'foo'
+    assert_equal('FOO', string.itself {|o| o.upcase}, feature10095)
+    assert_equal('foo', string, feature10095)
   end
 
   def test_dup


### PR DESCRIPTION
Possible resolution for [ruby-core:64039] [Feature #10095], adds an optional block to Object#itself
