### PR TITLE
More descriptive error message when net/http fails to connect to a server

### DIFF
--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -876,7 +876,12 @@ module Net   #:nodoc:
 
       D "opening connection to #{conn_address}:#{conn_port}..."
       s = Timeout.timeout(@open_timeout, Net::OpenTimeout) {
-        TCPSocket.open(conn_address, conn_port, @local_host, @local_port)
+        begin
+          TCPSocket.open(conn_address, conn_port, @local_host, @local_port)
+        rescue => e
+          raise e, "Failed to open TCP connection to " +
+            "#{conn_address}:#{conn_port} (#{e.message})"
+        end
       }
       s.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1)
       D "opened"

--- a/test/net/http/test_http.rb
+++ b/test/net/http/test_http.rb
@@ -189,6 +189,15 @@ class TestNetHTTP < Test::Unit::TestCase
     end
   end
 
+  def test_failure_message_includes_failed_domain_and_port
+    begin
+      Net::HTTP.get(URI.parse("http://doesnotexist.bogus"))
+      fail "should have raised"
+    rescue => e
+      assert_includes e.message, "doesnotexist.bogus:80"
+    end
+  end
+
 end
 
 module TestNetHTTP_version_1_1_methods


### PR DESCRIPTION
Particularly when using libraries, I find myself often monkey patching in this code to get more information about what they are trying to connect to and why they are failing.

This keeps the exception type the same and only changes the message to include more information before, so I think it is a safe, backwards compatible change.