### PR TITLE
Don't attempt to close a closed IO object

### DIFF
--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -1272,7 +1272,7 @@ class CSV
       begin
         yield csv
       ensure
-        csv.close
+        csv.closed? || csv.close
       end
     else
       csv

--- a/test/csv/test_interface.rb
+++ b/test/csv/test_interface.rb
@@ -136,6 +136,14 @@ class TestCSV::Interface < TestCSV
     end
   end
 
+  def test_open_handles_file_descriptor_gracefully
+    assert_nothing_raised(Exception) do
+      CSV.open(@path) do |csv|
+        csv.close
+      end
+    end
+  end
+
   ### Test Write Interface ###
 
   def test_generate


### PR DESCRIPTION
Because the yield runs arbitrary application code it's possible the
underlying file descriptor is closed during the block.
This prevents developers from having to wrap all `CSV.open` calls in a `begin`...`rescue` block to catch `Errno::EBADF`
