### PR TITLE
Raise a specific error when %-encoding is invalid

### DIFF
--- a/lib/uri/common.rb
+++ b/lib/uri/common.rb
@@ -349,6 +349,9 @@ module URI
   HTML5ASCIIINCOMPAT = [Encoding::UTF_7, Encoding::UTF_16BE, Encoding::UTF_16LE,
     Encoding::UTF_32BE, Encoding::UTF_32LE] # :nodoc:
 
+  # Raised when the "%"-encoding of a URI part is invalid
+  class InvalidPercentEncoding < ArgumentError
+  end
   # Encode given +str+ to URL-encoded form data.
   #
   # This method doesn't convert *, -, ., 0-9, A-Z, _, a-z, but does convert SP
@@ -379,7 +382,7 @@ module URI
   #
   # See URI.encode_www_form_component, URI.decode_www_form
   def self.decode_www_form_component(str, enc=Encoding::UTF_8)
-    raise ArgumentError, "invalid %-encoding (#{str})" unless /\A[^%]*(?:%\h\h[^%]*)*\z/ =~ str
+    raise InvalidPercentEncoding, "invalid %-encoding (#{str})" unless /\A[^%]*(?:%\h\h[^%]*)*\z/ =~ str
     str.b.gsub(/\+|%\h\h/, TBLDECWWWCOMP_).force_encoding(enc)
   end
 

--- a/test/uri/test_common.rb
+++ b/test/uri/test_common.rb
@@ -99,7 +99,7 @@ class TestCommon < Test::Unit::TestCase
     assert_equal("\xE3\x81\x82\xE3\x81\x82".force_encoding("UTF-8"),
                  URI.decode_www_form_component("\xE3\x81\x82%E3%81%82".force_encoding("UTF-8")))
 
-    assert_raise(ArgumentError){URI.decode_www_form_component("%")}
+    assert_raise(InvalidPercentEncoding){URI.decode_www_form_component("%")}
   end
 
   def test_encode_www_form


### PR DESCRIPTION
Prior to this commit it was difficult to catch and properly handle
invalid encodings in URIs. It's unsafe to `rescue ArgumentError` and
treat all caught exceptions similarly.
This commit allows application developers to properly handle malformed
URIs separate from other kinds of problems that may occur in their app.
