### PR TITLE
Use "%6N" (strftime) to format microseconds.

### DIFF
--- a/lib/logger.rb
+++ b/lib/logger.rb
@@ -511,7 +511,7 @@ private
 
     def format_datetime(time)
       if @datetime_format.nil?
-        time.strftime("%Y-%m-%dT%H:%M:%S.") << "%06d " % time.usec
+        time.strftime("%Y-%m-%dT%H:%M:%S.%6N ")
       else
         time.strftime(@datetime_format)
       end


### PR DESCRIPTION
Hello!
This PR contains tiny refactor for `lib/logger.rb`.
`%6N` - it's a microseconds with leading zeros, just what the doctor ordered. :)
