### PR TITLE
Fix Matrix.rows copy bug

### DIFF
--- a/lib/matrix.rb
+++ b/lib/matrix.rb
@@ -152,7 +152,7 @@ class Matrix
   #          -1 66
   #
   def Matrix.rows(rows, copy = true)
-    rows = convert_to_array(rows)
+    rows = convert_to_array(rows, copy)
     rows.map! do |row|
       convert_to_array(row, copy)
     end

--- a/test/matrix/test_matrix.rb
+++ b/test/matrix/test_matrix.rb
@@ -177,6 +177,20 @@ class TestMatrix < Test::Unit::TestCase
     assert_equal(@m1, Matrix.rows([[1, 2, 3], [4, 5, 6]]))
   end
 
+  def test_rows_copy
+    rows1 = [[1], [1]]
+    rows2 = [[1], [1]]
+
+    m1 = Matrix.rows(rows1, copy = false)
+    m2 = Matrix.rows(rows2, copy = true)
+
+    rows1.uniq!
+    rows2.uniq!
+
+    assert_equal([[1]],      m1.to_a)
+    assert_equal([[1], [1]], m2.to_a)
+  end
+
   def test_columns
     assert_equal(@m1, Matrix.columns([[1, 4], [2, 5], [3, 6]]))
   end


### PR DESCRIPTION
This fixes an issue where the `copy` argument was not properly being passed into `#convert_to_array`.
Thus making it possible for the internal structure of matrix to be mutated from outside the instance.

Thank you @shyouhei for the [git contributing guide](https://github.com/shyouhei/ruby/wiki/noncommitterhowto)

/cc @shyouhei @tenderlove
