### PR TITLE
test_pathname.rb: mountpoint enoent

### DIFF
--- a/test/pathname/test_pathname.rb
+++ b/test/pathname/test_pathname.rb
@@ -559,6 +559,11 @@ class TestPathname < Test::Unit::TestCase
     assert_include([true, false], r)
   end
 
+  def test_mountpoint_enoent
+    r = Pathname("/nonexistent").mountpoint?
+    assert_equal false, r
+  end
+
   def test_destructive_update
     path = Pathname.new("a")
     path.to_s.replace "b"


### PR DESCRIPTION
Test a mountpoint that does not exist.
Maybe `/outerspace` is enough ?
