### PR TITLE
Fix a Pathname#relative_path_from crash on Windows.

### DIFF
--- a/ext/pathname/lib/pathname.rb
+++ b/ext/pathname/lib/pathname.rb
@@ -22,7 +22,8 @@ class Pathname
   end
 
   SAME_PATHS = if File::FNM_SYSCASE.nonzero?
-    proc {|a, b| a.casecmp(b).zero?}
+    # Avoid #zero? here because #casecmp can return nil.
+    proc {|a, b| a.casecmp(b) == 0}
   else
     proc {|a, b| a == b}
   end


### PR DESCRIPTION
`Pathname#relative_path_from` uses `String#casecmp` to compare strings on Windows. This can return nil for strings with different encodings, and the code previously assumed that it always returned a Fixnum.

For example:

``` ruby
Pathname.new("foö".encode("UTF-8")).relative_path_from(
    Pathname.new("bär".encode("ISO-8859-1")))
```
