### PR TITLE
Small fix for Hash.store docs

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -1366,7 +1366,8 @@ NOINSERT_UPDATE_CALLBACK(hash_aset_str);
  *     h["a"] = 9
  *     h["c"] = 4
  *     h   #=> {"a"=>9, "b"=>200, "c"=>4}
- *     h.store("d", 42) #=> {"a"=>9, "b"=>200, "c"=>4, "d"=>42}
+ *     h.store("d", 42) #=> 42
+ *     h   #=> {"a"=>9, "b"=>200, "c"=>4, "d"=>42}
  *
  *  +key+ should not have its value changed while it is in use as a key (an
  *  <tt>unfrozen String</tt> passed as a key will be duplicated and frozen).


### PR DESCRIPTION
Currently docs example suggests that Hash.store will return self instead of value - this patch updates example to show that Hash.store is returning value and update itself.
