### PR TITLE
sprintf.c: improve rational 'f' format

### DIFF
--- a/test/ruby/test_sprintf.rb
+++ b/test/ruby/test_sprintf.rb
@@ -150,8 +150,22 @@ class TestSprintf < Test::Unit::TestCase
 
   def test_rational
     assert_match(/\A0\.10+\z/, sprintf("%.60f", 0.1r))
+    assert_match(/\A0\.010+\z/, sprintf("%.60f", 0.01r))
+    assert_match(/\A0\.0010+\z/, sprintf("%.60f", 0.001r))
     assert_match(/\A0\.3+\z/, sprintf("%.60f", 1/3r))
     assert_match(/\A1\.20+\z/, sprintf("%.60f", 1.2r))
+
+    0.upto(9) do |len|
+      -1.upto(9) do |prec|
+        ['', '+', '-', ' ', '0', '+0', '-0', ' 0', '+ ', '- ', '+ 0', '- 0'].each do |flags|
+          fmt = "%#{flags}#{len > 0 ? len : ''}#{prec >= 0 ? ".#{prec}" : ''}f"
+          [0, 0.1, 0.01, 0.001, 1.001, 100.0, 100.001, 10000000000.0, 0.00000000001, 1/3r, 2/3r, 1.2r, 10r].each do |num|
+            assert_equal(sprintf(fmt, num.to_f), sprintf(fmt, num.to_r), "sprintf(#{fmt.inspect}, #{num.inspect}.to_r)")
+            assert_equal(sprintf(fmt, -num.to_f), sprintf(fmt, -num.to_r), "sprintf(#{fmt.inspect}, #{(-num).inspect}.to_r)") if num > 0
+          end
+        end
+      end
+    end
   end
 
   def test_hash


### PR DESCRIPTION
The sprintf handling for Rational added in 1d196e0d2bd99590d03a73d7e59aa87f7266f8e3 was only working for a limited subset of values.

In addition to specific tests for the first examples I encountered, I've added a (rather ugly) set of nested loops, which together will test many combinations of formatting options: we know that float formatting works correctly, so we can just assert that matching Rational values produce the same strings.

Though [I have tangled with sprintf in a past life](https://github.com/rubinius/rubinius/commit/d6712a7fd110edcbe1b641e1f2a92c88473565d8), this is just a result of trial & error to get the added tests passing – it seems to behave much better, but I won't claim it's a complete implementation. The TODO on the non-`f` formats is untouched.

This should fix the consistent segfault we're seeing in the Rails (ActiveSupport) test suite.

/cc @nobu :heart: :green_heart: :blue_heart: 
