### PR TITLE
uri/rfc3986_parser.rb: allow opaque to be set

### DIFF
--- a/lib/uri/rfc3986_parser.rb
+++ b/lib/uri/rfc3986_parser.rb
@@ -83,7 +83,7 @@ module URI
         REL_PATH: /\A(?:%\h\h|[!$&-.0-;=@-Z_a-z~])+(?:\/(?:%\h\h|[!$&-.0-;=@-Z_a-z~])*)*\z/,
         QUERY: /\A(?:%\h\h|[!$&-.0-;=@-Z_a-z~\/?])*\z/,
         FRAGMENT: /\A(?:%\h\h|[!$&-.0-;=@-Z_a-z~\/?])*\z/,
-        OPAQUE: nil,
+        OPAQUE: /\A(?:[^\/].*)?\z/,
         PORT: /\A[\x09\x0a\x0c\x0d ]*\d*[\x09\x0a\x0c\x0d ]*\z/,
       }
     end

--- a/test/uri/test_generic.rb
+++ b/test/uri/test_generic.rb
@@ -730,6 +730,11 @@ class URI::TestGeneric < Test::Unit::TestCase
     assert_raise(URI::InvalidURIError) { uri.port = 'bar' }
     assert_raise(URI::InvalidURIError) { uri.path = 'bar' }
     assert_raise(URI::InvalidURIError) { uri.query = 'bar' }
+
+    uri = URI.parse('foo:bar')
+    assert_raise(URI::InvalidComponentError) { uri.opaque = '/baz' }
+    uri.opaque = 'xyzzy'
+    assert_equal('foo:xyzzy', uri.to_s)
   end
 
   def test_set_scheme


### PR DESCRIPTION
- lib/uri/rfc3986_parser.rb: specify a regexp for :OPAQUE; generic.rb
  assumes it is present, and will refuse all values otherwise.
