### PR TITLE
(Feature #10090) Fix setproctitle bug on AIX

### DIFF
--- a/missing/setproctitle.c
+++ b/missing/setproctitle.c
@@ -119,7 +119,6 @@ compat_init_setproctitle(int argc, char *argv[])
 			lastenvp = envp[i] + strlen(envp[i]);
 	}
 
-	argv[1] = NULL;
 	argv_start = argv[0];
 	argv_len = lastargv - argv[0];
 	argv_env_len = lastenvp - argv[0];


### PR DESCRIPTION
This commit removes the line argv[1] = NULL; This is to ensure that the
ps command performs correctly on operating systems that take the process
title from memory, such as AIX or Solaris. Before this fix it would stop
writing the process title when it encountered the NULL pointer that
argv[x] is getting assigned to. If a different argument is set to NULL
besides 1 it truncates after that argument. This fix allows for the
entire argument to be written to process title since the logic is in
place to account for varying lengths of arguments.