### PR TITLE
Replace map/flatten with flat_map

### DIFF
--- a/lib/net/http/header.rb
+++ b/lib/net/http/header.rb
@@ -442,7 +442,7 @@ module Net::HTTPHeader
 
   def tokens(vals)
     return [] unless vals
-    vals.map {|v| v.split(',') }.flatten\
+    vals.flat_map {|v| v.split(',') }\
         .reject {|str| str.strip.empty? }\
         .map {|tok| tok.strip.downcase }
   end

--- a/lib/rexml/formatters/default.rb
+++ b/lib/rexml/formatters/default.rb
@@ -63,9 +63,9 @@ module REXML
       def write_element( node, output )
         output << "<#{node.expanded_name}"
 
-        node.attributes.to_a.map { |a|
+        node.attributes.to_a.flat_map { |a|
           Hash === a ? a.values : a
-        }.flatten.sort_by {|attr| attr.name}.each do |attr|
+        }.sort_by {|attr| attr.name}.each do |attr|
           output << " "
           attr.write( output )
         end unless node.attributes.empty?

--- a/lib/rexml/validation/relaxng.rb
+++ b/lib/rexml/validation/relaxng.rb
@@ -412,13 +412,13 @@ module REXML
         #puts "IN CHOICE EXPECTED"
         #puts "EVENTS = #{@events.inspect}"
         return [@events[@current]] if @events.size > 0
-        return @choices.collect do |x|
+        return @choices.flat_map do |x|
           if x[0].kind_of? State
             x[0].expected
           else
             x[0]
           end
-        end.flatten
+        end
       end
 
       def inspect
@@ -530,13 +530,13 @@ module REXML
         #puts "IN CHOICE EXPECTED"
         #puts "EVENTS = #{@events.inspect}"
         return [@events[@current]] if @events[@current]
-        return @choices[@choice..-1].collect do |x|
+        return @choices[@choice..-1].flat_map do |x|
           if x[0].kind_of? State
             x[0].expected
           else
             x[0]
           end
-        end.flatten
+        end
       end
 
       def inspect


### PR DESCRIPTION
flat_map is faster and uses less object allocations.
See my bench setup & results: https://gist.github.com/wojtekmach/925a780b844dc1d7114a

Thanks to @sferik for a presentation on speeding up ruby: https://speakerdeck.com/sferik/writing-fast-ruby
