### PR TITLE
Typed digest

### DIFF
--- a/ext/digest/digest.c
+++ b/ext/digest/digest.c
@@ -25,6 +25,12 @@ static ID id_metadata;
 
 RUBY_EXTERN void Init_digest_base(void);
 
+rb_data_type_t rb_digest_data_type = {
+    "digest_metadata",
+    {0, 0, 0,},
+};
+
+
 /*
  * Document-module: Digest
  *
@@ -518,9 +524,7 @@ get_digest_base_metadata(VALUE klass)
     if (NIL_P(p))
         rb_raise(rb_eRuntimeError, "Digest::Base cannot be directly inherited in Ruby");
 
-#undef RUBY_UNTYPED_DATA_WARNING
-#define RUBY_UNTYPED_DATA_WARNING 0
-    Data_Get_Struct(obj, rb_digest_metadata_t, algo);
+    TypedData_Get_Struct(obj, rb_digest_metadata_t, &rb_digest_data_type, algo);
 
     switch (algo->api_version) {
       case 3:

--- a/ext/digest/digest.h
+++ b/ext/digest/digest.h
@@ -30,3 +30,5 @@ typedef struct {
     rb_digest_hash_update_func_t update_func;
     rb_digest_hash_finish_func_t finish_func;
 } rb_digest_metadata_t;
+
+extern rb_data_type_t rb_digest_data_type;

--- a/ext/digest/md5/md5init.c
+++ b/ext/digest/md5/md5init.c
@@ -38,8 +38,6 @@ Init_md5()
 
     cDigest_MD5 = rb_define_class_under(mDigest, "MD5", cDigest_Base);
 
-#undef RUBY_UNTYPED_DATA_WARNING
-#define RUBY_UNTYPED_DATA_WARNING 0
     rb_ivar_set(cDigest_MD5, rb_intern("metadata"),
-      Data_Wrap_Struct(rb_cObject, 0, 0, (void *)&md5));
+      TypedData_Wrap_Struct(rb_cObject, &rb_digest_data_type, (void *)&md5));
 }

--- a/ext/digest/rmd160/rmd160init.c
+++ b/ext/digest/rmd160/rmd160init.c
@@ -38,8 +38,6 @@ Init_rmd160()
 
     cDigest_RMD160 = rb_define_class_under(mDigest, "RMD160", cDigest_Base);
 
-#undef RUBY_UNTYPED_DATA_WARNING
-#define RUBY_UNTYPED_DATA_WARNING 0
     rb_ivar_set(cDigest_RMD160, rb_intern("metadata"),
-      Data_Wrap_Struct(rb_cObject, 0, 0, (void *)&rmd160));
+      TypedData_Wrap_Struct(rb_cObject, &rb_digest_data_type, (void *)&rmd160));
 }

--- a/ext/digest/sha1/sha1init.c
+++ b/ext/digest/sha1/sha1init.c
@@ -38,8 +38,6 @@ Init_sha1()
 
     cDigest_SHA1 = rb_define_class_under(mDigest, "SHA1", cDigest_Base);
 
-#undef RUBY_UNTYPED_DATA_WARNING
-#define RUBY_UNTYPED_DATA_WARNING 0
     rb_ivar_set(cDigest_SHA1, rb_intern("metadata"),
-      Data_Wrap_Struct(rb_cObject, 0, 0, (void *)&sha1));
+      TypedData_Wrap_Struct(rb_cObject, &rb_digest_data_type, (void *)&sha1));
 }

--- a/ext/digest/sha2/sha2init.c
+++ b/ext/digest/sha2/sha2init.c
@@ -50,9 +50,7 @@ Init_sha2()
     cDigest_SHA##bitlen = rb_define_class_under(mDigest, "SHA" #bitlen, cDigest_Base); \
 \
     rb_ivar_set(cDigest_SHA##bitlen, id_metadata, \
-      Data_Wrap_Struct(rb_cObject, 0, 0, (void *)&sha##bitlen));
+      TypedData_Wrap_Struct(rb_cObject, &rb_digest_data_type, (void *)&sha##bitlen));
 
-#undef RUBY_UNTYPED_DATA_WARNING
-#define RUBY_UNTYPED_DATA_WARNING 0
     FOREACH_BITLEN(DEFINE_ALGO_CLASS)
 }


### PR DESCRIPTION
from the recent commits (and trying to write my own bindings against TypedData) i think that the stuff that is shipped with ruby itself like stdlib should follow the rules of the new TypedData even for hidden stuff like that metadata, and should not just disable that warnings 
and shouldnt the untypedData removed somhow later?

sorry that this are singlefile commits i did it with the github interface
