### PR TITLE
Fixed atomic correctness for gcc intrinsics used by ATOMIC_INC/ATOMIC_DEC

### DIFF
--- a/ruby_atomic.h
+++ b/ruby_atomic.h
@@ -5,8 +5,8 @@
 #elif defined HAVE_GCC_ATOMIC_BUILTINS
 typedef unsigned int rb_atomic_t;
 # define ATOMIC_SET(var, val)  (void)__atomic_exchange_n(&(var), (val), __ATOMIC_SEQ_CST)
-# define ATOMIC_INC(var) __atomic_fetch_add(&(var), 1, __ATOMIC_SEQ_CST)
-# define ATOMIC_DEC(var) __atomic_fetch_sub(&(var), 1, __ATOMIC_SEQ_CST)
+# define ATOMIC_INC(var) __atomic_add_fetch(&(var), 1, __ATOMIC_SEQ_CST)
+# define ATOMIC_DEC(var) __atomic_sub_fetch(&(var), 1, __ATOMIC_SEQ_CST)
 # define ATOMIC_OR(var, val) __atomic_or_fetch(&(var), (val), __ATOMIC_SEQ_CST)
 # define ATOMIC_EXCHANGE(var, val) __atomic_exchange_n(&(var), (val), __ATOMIC_SEQ_CST)
 # define ATOMIC_CAS(var, oldval, newval) \
@@ -26,8 +26,8 @@ typedef unsigned int rb_atomic_t;
 
 typedef unsigned int rb_atomic_t; /* Anything OK */
 # define ATOMIC_SET(var, val)  (void)__sync_lock_test_and_set(&(var), (val))
-# define ATOMIC_INC(var) __sync_fetch_and_add(&(var), 1)
-# define ATOMIC_DEC(var) __sync_fetch_and_sub(&(var), 1)
+# define ATOMIC_INC(var) __sync_add_and_fetch(&(var), 1)
+# define ATOMIC_DEC(var) __sync_sub_and_fetch(&(var), 1)
 # define ATOMIC_OR(var, val) __sync_or_and_fetch(&(var), (val))
 # define ATOMIC_EXCHANGE(var, val) __sync_lock_test_and_set(&(var), (val))
 # define ATOMIC_CAS(var, oldval, newval) __sync_val_compare_and_swap(&(var), (oldval), (newval))

--- a/ruby_atomic.h
+++ b/ruby_atomic.h
@@ -95,8 +95,8 @@ rb_w32_atomic_cas(volatile rb_atomic_t *var, rb_atomic_t oldval, rb_atomic_t new
 typedef unsigned int rb_atomic_t;
 
 # define ATOMIC_SET(var, val) (void)atomic_swap_uint(&(var), (val))
-# define ATOMIC_INC(var) atomic_inc_uint(&(var))
-# define ATOMIC_DEC(var) atomic_dec_uint(&(var))
+# define ATOMIC_INC(var) atomic_inc_uint_nv(&(var))
+# define ATOMIC_DEC(var) atomic_dec_uint_nv(&(var))
 # define ATOMIC_OR(var, val) atomic_or_uint(&(var), (val))
 # define ATOMIC_EXCHANGE(var, val) atomic_swap_uint(&(var), (val))
 # define ATOMIC_CAS(var, oldval, newval) atomic_cas_uint(&(var), (oldval), (newval))


### PR DESCRIPTION
This pull request fixes the gcc and Sun atomic intrinsics used by the ATOMIC_INC and ATOMIC_DEC macros.
- For Win32, the macros return the new value after the increment/decrement
- For gcc and Sun, the macros return the value prior to the increment/decrement

Simply using *_fetch instead of fetch_* ensures the behavior is coherent for all platforms.
From a quick search, it seems the only place where ATOMIC_INC and ATOMIC_DEC is used is not affected by this issue as it doesn't really care about the atomic properties of the operation, so this is mostly future-proofing the macros.
