### PR TITLE
Fix regression bug in WEBrick's :DoNotReverseLookup config option implementation

### DIFF
--- a/lib/webrick/server.rb
+++ b/lib/webrick/server.rb
@@ -178,7 +178,9 @@ module WEBrick
                 svrs[0].each{|svr|
                   @tokens.pop          # blocks while no token is there.
                   if sock = accept_client(svr)
-                    sock.do_not_reverse_lookup = config[:DoNotReverseLookup]
+                    unless config[:DoNotReverseLookup].nil?
+                      sock.do_not_reverse_lookup = !!config[:DoNotReverseLookup]
+                    end
                     th = start_thread(sock, &block)
                     th[:WEBrickThread] = true
                     thgroup.add(th)

--- a/test/webrick/test_do_not_reverse_lookup.rb
+++ b/test/webrick/test_do_not_reverse_lookup.rb
@@ -1,0 +1,84 @@
+require "test/unit"
+require "webrick"
+require_relative "utils"
+
+class TestDoNotReverseLookup < Test::Unit::TestCase
+  class DNRL < WEBrick::GenericServer
+    def run(sock)
+      sock << sock.do_not_reverse_lookup.to_s
+    end
+  end
+
+  # +--------------------------------------------------------------------------+
+  # |        Expected interaction between Socket.do_not_reverse_lookup         |
+  # |            and WEBrick::Config::General[:DoNotReverseLookup]             |
+  # +----------------------------+---------------------------------------------+
+  # |                            |WEBrick::Config::General[:DoNotReverseLookup]|
+  # +----------------------------+--------------+---------------+--------------+
+  # |Socket.do_not_reverse_lookup|     TRUE     |     FALSE     |     NIL      |
+  # +----------------------------+--------------+---------------+--------------+
+  # |            TRUE            |     true     |     false     |     true     |
+  # +----------------------------+--------------+---------------+--------------+
+  # |            FALSE           |     true     |     false     |     false    |
+  # +----------------------------+--------------+---------------+--------------+
+
+  def test_socket_dnrl_true_server_dnrl_true
+    Socket.do_not_reverse_lookup = true
+    config = {:DoNotReverseLookup => true}
+    TestWEBrick.start_server(DNRL, config) do |server, addr, port, log|
+      TCPSocket.open(addr, port) do |sock|
+        assert_equal('true', sock.gets, log.call)
+      end
+    end
+  end
+
+  def test_socket_dnrl_true_server_dnrl_false
+    Socket.do_not_reverse_lookup = true
+    config = {:DoNotReverseLookup => false}
+    TestWEBrick.start_server(DNRL, config) do |server, addr, port, log|
+      TCPSocket.open(addr, port) do |sock|
+        assert_equal('false', sock.gets, log.call)
+      end
+    end
+  end
+
+  def test_socket_dnrl_true_server_dnrl_nil
+    Socket.do_not_reverse_lookup = true
+    config = {:DoNotReverseLookup => nil}
+    TestWEBrick.start_server(DNRL, config) do |server, addr, port, log|
+      TCPSocket.open(addr, port) do |sock|
+        assert_equal('true', sock.gets, log.call)
+      end
+    end
+  end
+
+  def test_socket_dnrl_false_server_dnrl_true
+    Socket.do_not_reverse_lookup = false
+    config = {:DoNotReverseLookup => true}
+    TestWEBrick.start_server(DNRL, config) do |server, addr, port, log|
+      TCPSocket.open(addr, port) do |sock|
+        assert_equal('true', sock.gets, log.call)
+      end
+    end
+  end
+
+  def test_socket_dnrl_false_server_dnrl_false
+    Socket.do_not_reverse_lookup = false
+    config = {:DoNotReverseLookup => false}
+    TestWEBrick.start_server(DNRL, config) do |server, addr, port, log|
+      TCPSocket.open(addr, port) do |sock|
+        assert_equal('false', sock.gets, log.call)
+      end
+    end
+  end
+
+  def test_socket_dnrl_false_server_dnrl_nil
+    Socket.do_not_reverse_lookup = false
+    config = {:DoNotReverseLookup => nil}
+    TestWEBrick.start_server(DNRL, config) do |server, addr, port, log|
+      TCPSocket.open(addr, port) do |sock|
+        assert_equal('false', sock.gets, log.call)
+      end
+    end
+  end
+end

--- a/test/webrick/test_do_not_reverse_lookup.rb
+++ b/test/webrick/test_do_not_reverse_lookup.rb
@@ -9,6 +9,22 @@ class TestDoNotReverseLookup < Test::Unit::TestCase
     end
   end
 
+  @@original_do_not_reverse_lookup_value = Socket.do_not_reverse_lookup
+
+  def teardown
+    Socket.do_not_reverse_lookup = @@original_do_not_reverse_lookup_value
+  end
+
+  def do_not_reverse_lookup?(config)
+    result = nil
+    TestWEBrick.start_server(DNRL, config) do |server, addr, port, log|
+      TCPSocket.open(addr, port) do |sock|
+        result = {'true' => true, 'false' => false}[sock.gets]
+      end
+    end
+    result
+  end
+
   # +--------------------------------------------------------------------------+
   # |        Expected interaction between Socket.do_not_reverse_lookup         |
   # |            and WEBrick::Config::General[:DoNotReverseLookup]             |
@@ -24,61 +40,31 @@ class TestDoNotReverseLookup < Test::Unit::TestCase
 
   def test_socket_dnrl_true_server_dnrl_true
     Socket.do_not_reverse_lookup = true
-    config = {:DoNotReverseLookup => true}
-    TestWEBrick.start_server(DNRL, config) do |server, addr, port, log|
-      TCPSocket.open(addr, port) do |sock|
-        assert_equal('true', sock.gets, log.call)
-      end
-    end
+    assert_equal(true, do_not_reverse_lookup?(:DoNotReverseLookup => true))
   end
 
   def test_socket_dnrl_true_server_dnrl_false
     Socket.do_not_reverse_lookup = true
-    config = {:DoNotReverseLookup => false}
-    TestWEBrick.start_server(DNRL, config) do |server, addr, port, log|
-      TCPSocket.open(addr, port) do |sock|
-        assert_equal('false', sock.gets, log.call)
-      end
-    end
+    assert_equal(false, do_not_reverse_lookup?(:DoNotReverseLookup => false))
   end
 
   def test_socket_dnrl_true_server_dnrl_nil
     Socket.do_not_reverse_lookup = true
-    config = {:DoNotReverseLookup => nil}
-    TestWEBrick.start_server(DNRL, config) do |server, addr, port, log|
-      TCPSocket.open(addr, port) do |sock|
-        assert_equal('true', sock.gets, log.call)
-      end
-    end
+    assert_equal(true, do_not_reverse_lookup?(:DoNotReverseLookup => nil))
   end
 
   def test_socket_dnrl_false_server_dnrl_true
     Socket.do_not_reverse_lookup = false
-    config = {:DoNotReverseLookup => true}
-    TestWEBrick.start_server(DNRL, config) do |server, addr, port, log|
-      TCPSocket.open(addr, port) do |sock|
-        assert_equal('true', sock.gets, log.call)
-      end
-    end
+    assert_equal(true, do_not_reverse_lookup?(:DoNotReverseLookup => true))
   end
 
   def test_socket_dnrl_false_server_dnrl_false
     Socket.do_not_reverse_lookup = false
-    config = {:DoNotReverseLookup => false}
-    TestWEBrick.start_server(DNRL, config) do |server, addr, port, log|
-      TCPSocket.open(addr, port) do |sock|
-        assert_equal('false', sock.gets, log.call)
-      end
-    end
+    assert_equal(false, do_not_reverse_lookup?(:DoNotReverseLookup => false))
   end
 
   def test_socket_dnrl_false_server_dnrl_nil
     Socket.do_not_reverse_lookup = false
-    config = {:DoNotReverseLookup => nil}
-    TestWEBrick.start_server(DNRL, config) do |server, addr, port, log|
-      TCPSocket.open(addr, port) do |sock|
-        assert_equal('false', sock.gets, log.call)
-      end
-    end
+    assert_equal(false, do_not_reverse_lookup?(:DoNotReverseLookup => nil))
   end
 end


### PR DESCRIPTION
When the `:DoNotReverseLookup` option was originally added to `WEBrick::Config::General` hash in [this commit](https://github.com/ruby/ruby/commit/0d8a0904d93e9600ccd095eabd5e4165c15987ff), the intent was to set `sock.do_not_reverse_lookup` to true **only if** the value of `:DoNotReverseLookup` is **truthy**. Here is the original implementation in webrick/server.rb in that original commit:
```
if @config[:DoNotReverseLookup]
  sock.do_not_reverse_lookup = true
end
```
However, at a later point in time, this code in webrick/server.rb got inadvertently simplified to this:
```
sock.do_not_reverse_lookup = config[:DoNotReverseLookup]
```
This new code does not represent the original intent of the `:DoNotReverseLookup` option. Since `:DoNotReverseLookup` is `nil` by default, this code effectively sets `sock.do_not_reverse_lookup` to **false** unless `:DoNotReverseLookup` is **explicitly** set to true. The original code left `sock.do_not_reverse_lookup` alone unless `:DoNotReverseLookup` was explicitly set to true. When left alone, `sock.do_not_reverse_lookup` would naturally default to the global `Socket.do_not_reverse_lookup` value currently in effect. And since the default value of `Socket.do_not_reverse_lookup` is true, `sock.do_not_reverse_lookup` would be **true** as well, which is the opposite of the result we are currently getting.

This is a very subtle and insidious bug, since reverse look-up rarely causes slowness in development, but it becomes an intermittent bug in production, depending on the host's network environment. This strange intermittent slowness problem is then very difficult to trace back to its root cause in WEBrick's default configuration.

This pull request resolves the issue and provides test coverage for the `:DoNotReverseLookup` option based on the following expected behavior:
```
+--------------------------------------------------------------------------+
|        Expected interaction between Socket.do_not_reverse_lookup         |
|            and WEBrick::Config::General[:DoNotReverseLookup]             |
+----------------------------+---------------------------------------------+
|                            |WEBrick::Config::General[:DoNotReverseLookup]|
+----------------------------+--------------+---------------+--------------+
|Socket.do_not_reverse_lookup|     TRUE     |     FALSE     |     NIL      |
+----------------------------+--------------+---------------+--------------+
|            TRUE            |     true     |     false     |     true     |
+----------------------------+--------------+---------------+--------------+
|            FALSE           |     true     |     false     |     false    |
+----------------------------+--------------+---------------+--------------+
```
