### PR TITLE
Fix minor typo in comment in pkg_config method

### DIFF
--- a/lib/mkmf.rb
+++ b/lib/mkmf.rb
@@ -1758,7 +1758,7 @@ SRC
   # without modifying any of the global values mentioned above.
   def pkg_config(pkg, option=nil)
     if pkgconfig = with_config("#{pkg}-config") and find_executable0(pkgconfig)
-      # iff package specific config command is given
+      # if package specific config command is given
     elsif ($PKGCONFIG ||=
            (pkgconfig = with_config("pkg-config", ("pkg-config" unless CROSS_COMPILING))) &&
            find_executable0(pkgconfig) && pkgconfig) and


### PR DESCRIPTION
I noticed a minor typo in the comment when inspecting the source of the pkg_config method.
