### PR TITLE
Render example correctly

### DIFF
--- a/ext/socket/unixsocket.c
+++ b/ext/socket/unixsocket.c
@@ -278,6 +278,7 @@ recvmsg_blocking(void *data)
  * call-seq:
  *   unixsocket.recv_io([klass [, mode]]) => io
  *
+ * Example
  *   UNIXServer.open("/tmp/sock") {|serv|
  *     UNIXSocket.open("/tmp/sock") {|c|
  *       s = serv.accept
@@ -475,7 +476,7 @@ unix_peeraddr(VALUE sock)
  *   UNIXSocket.pair([type [, protocol]])       => [unixsocket1, unixsocket2]
  *   UNIXSocket.socketpair([type [, protocol]]) => [unixsocket1, unixsocket2]
  *
- * Creates a pair of sockets connected each other.
+ * Creates a pair of sockets connected to each other.
  *
  * _socktype_ should be a socket type such as: :STREAM, :DGRAM, :RAW, etc.
  *


### PR DESCRIPTION
- Fix rendering of [UNIXSocket.html#recv_io](http://www.ruby-doc.org/stdlib-2.1.0/libdoc/socket/rdoc/UNIXSocket.html#method-i-recv_io)
- Fix sentence
### Rendering before

![screen shot 2014-10-08 at 13 11 24](https://cloud.githubusercontent.com/assets/290596/4558160/5ab90652-4edc-11e4-9ed3-01f01a108165.png)
### After

![screen shot 2014-10-08 at 13 11 41](https://cloud.githubusercontent.com/assets/290596/4558161/5fd1f4f0-4edc-11e4-8d60-3cb43e2a3d8c.png)
