### PR TITLE
variable.c: Module#deprecate_constant

### DIFF
--- a/constant.h
+++ b/constant.h
@@ -12,15 +12,21 @@
 #define CONSTANT_H
 
 typedef enum {
+    CONST_DEPRECATED = 0x100,
+
+    CONST_VISIBILITY_MASK = 0xff,
     CONST_PUBLIC    = 0x00,
     CONST_PRIVATE,
     CONST_VISIBILITY_MAX
 } rb_const_flag_t;
 
 #define RB_CONST_PRIVATE_P(ce) \
-    ((ce)->flag == CONST_PRIVATE)
+    (((ce)->flag & CONST_VISIBILITY_MASK) == CONST_PRIVATE)
 #define RB_CONST_PUBLIC_P(ce) \
-    ((ce)->flag == CONST_PUBLIC)
+    (((ce)->flag & CONST_VISIBILITY_MASK) == CONST_PUBLIC)
+
+#define RB_CONST_DEPRECATED_P(ce) \
+    ((ce)->flag & CONST_DEPRECATED)
 
 typedef struct rb_const_entry_struct {
     rb_const_flag_t flag;
@@ -31,6 +37,7 @@ typedef struct rb_const_entry_struct {
 
 VALUE rb_mod_private_constant(int argc, const VALUE *argv, VALUE obj);
 VALUE rb_mod_public_constant(int argc, const VALUE *argv, VALUE obj);
+VALUE rb_mod_deprecate_constant(int argc, const VALUE *argv, VALUE obj);
 void rb_free_const_table(st_table *tbl);
 VALUE rb_public_const_get(VALUE klass, ID id);
 VALUE rb_public_const_get_at(VALUE klass, ID id);

--- a/lib/timeout.rb
+++ b/lib/timeout.rb
@@ -120,3 +120,6 @@ end
 # Another name for Timeout::Error, defined for backwards compatibility with
 # earlier versions of timeout.rb.
 TimeoutError = Timeout::Error
+class Object
+  deprecate_constant :TimeoutError
+end

--- a/object.c
+++ b/object.c
@@ -3410,6 +3410,7 @@ Init_Object(void)
     rb_define_method(rb_cModule, "class_variable_defined?", rb_mod_cvar_defined, 1);
     rb_define_method(rb_cModule, "public_constant", rb_mod_public_constant, -1); /* in variable.c */
     rb_define_method(rb_cModule, "private_constant", rb_mod_private_constant, -1); /* in variable.c */
+    rb_define_method(rb_cModule, "deprecate_constant", rb_mod_deprecate_constant, -1); /* in variable.c */
     rb_define_method(rb_cModule, "singleton_class?", rb_mod_singleton_p, 0);
 
     rb_define_method(rb_cClass, "allocate", rb_obj_alloc, 0);

--- a/test/ruby/test_module.rb
+++ b/test/ruby/test_module.rb
@@ -1360,6 +1360,13 @@ class TestModule < Test::Unit::TestCase
     assert_equal("foo", c::FOO)
   end
 
+  def test_deprecate_constant
+    c = Class.new
+    c.const_set(:FOO, "foo")
+    c.deprecate_constant(:FOO)
+    assert_warn(/deprecated/) {c::FOO}
+  end
+
   def test_constants_with_private_constant
     assert_not_include(::TestModule.constants, :PrivateClass)
   end


### PR DESCRIPTION
* variable.c (rb_const_get_0): warn deprecated constant reference.

* variable.c (rb_mod_deprecate_constant): mark constants to be
  warned as deprecated.