### PR TITLE
small fix for extension example

### DIFF
--- a/README.EXT
+++ b/README.EXT
@@ -689,7 +689,7 @@ Here's the example of an initializing function.
   Init_dbm(void)
   {
       /* define DBM class */
-      cDBM = rb_define_class("DBM", rb_cObject);
+      VALUE cDBM = rb_define_class("DBM", rb_cObject);
       /* DBM includes Enumerable module */
       rb_include_module(cDBM, rb_mEnumerable);
 


### PR DESCRIPTION
This example won't compile because the init is not valid C.

I didn't update the Japanese version, should I do that too?
