### PR TITLE
fix doc about frozen object

### DIFF
--- a/error.c
+++ b/error.c
@@ -1669,7 +1669,7 @@ syserr_eqq(VALUE self, VALUE exc)
  *
  *  <em>raises the exception:</em>
  *
- *     RuntimeError: can't modify frozen array
+ *     RuntimeError: can't modify frozen Array
  *
  *  Kernel.raise will raise a RuntimeError if no Exception class is
  *  specified.

--- a/object.c
+++ b/object.c
@@ -1073,7 +1073,7 @@ rb_obj_infect(VALUE obj1, VALUE obj2)
  *
  *  <em>produces:</em>
  *
- *     prog.rb:3:in `<<': can't modify frozen array (RuntimeError)
+ *     prog.rb:3:in `<<': can't modify frozen Array (RuntimeError)
  *     	from prog.rb:3
  *
  *  Objects of the following classes are always frozen: Fixnum,


### PR DESCRIPTION
Currently, the error message about frozen object contains camel cased class name.

For example:

``` ruby
[].freeze << 'hi'
```

throws

```
RuntimeError: can't modify frozen Array
```

not 

```
RuntimeError: can't modify frozen array
```
