### PR TITLE
Fix document of Kernel.Stirng

### DIFF
--- a/object.c
+++ b/object.c
@@ -3018,8 +3018,9 @@ rb_String(VALUE val)
  *  call-seq:
  *     String(arg)   -> string
  *
- *  Converts <i>arg</i> to a <code>String</code> by calling its
- *  <code>to_s</code> method.
+ *  Returns <i>arg</i> as an <code>String</code>.
+ *
+ *  First tries to call its <code>to_str</code> method, then its <code>to_s</code> method.
  *
  *     String(self)        #=> "main"
  *     String(self.class)  #=> "Object"


### PR DESCRIPTION
Kernel#String tries not `to_s` but `to_str` first.

The follwing source:
rb_String(VALUE val)
https://github.com/ruby/ruby/blob/trunk/object.c#L3010

rb_check_string_type
https://github.com/ruby/ruby/blob/trunk/string.c#L1745
