### PR TITLE
Fix Segmentation Fault when getting binding of method made to proc

### DIFF
--- a/proc.c
+++ b/proc.c
@@ -2453,9 +2453,7 @@ proc_binding(VALUE self)
 
     GetProcPtr(self, proc);
     if (RB_TYPE_P((VALUE)proc->block.iseq, T_NODE)) {
-	if (!IS_METHOD_PROC_NODE((NODE *)proc->block.iseq)) {
-	    rb_raise(rb_eArgError, "Can't create Binding from C level Proc");
-	}
+	   rb_raise(rb_eArgError, "Can't create Binding from C level Proc");
     }
 
     bindval = rb_binding_alloc(rb_cBinding);

--- a/proc.c
+++ b/proc.c
@@ -2453,7 +2453,11 @@ proc_binding(VALUE self)
 
     GetProcPtr(self, proc);
     if (RB_TYPE_P((VALUE)proc->block.iseq, T_NODE)) {
-	   rb_raise(rb_eArgError, "Can't create Binding from C level Proc");
+        if (IS_METHOD_PROC_NODE((NODE *)proc->block.iseq)) {
+            return rb_f_binding(proc->block.self);
+        } else {
+            rb_raise(rb_eArgError, "Can't create Binding from C level Proc");
+        }
     }
 
     bindval = rb_binding_alloc(rb_cBinding);


### PR DESCRIPTION
The issue pops up when `Method#to_proc` is called, then the binding of that proc is obtained, and one tries to modify (get/set) the local variables in that binding.

Lets examine the code below.

```ruby
class Foo
  def bar
  end
end

instance = Foo.new
method_proc = instance.method(:bar).to_proc
b = method_proc.binding

b.local_variable_set(:value, [1, 2, 3])
```

Running this code with `ruby 2.1.3p242 (2014-09-19 revision 47630)` on OS X results in Segmentation Fault:
```
bug.rb:10: [BUG] Segmentation fault at 0x00000000000070
ruby 2.1.3p242 (2014-09-19 revision 47630) [x86_64-darwin14.0]

-- Crash Report log information --------------------------------------------
   See Crash Report log file under the one of following:
     * ~/Library/Logs/CrashReporter
     * /Library/Logs/CrashReporter
     * ~/Library/Logs/DiagnosticReports
     * /Library/Logs/DiagnosticReports
   for more details.

-- Control frame information -----------------------------------------------
c:0003 p:---- s:0012 e:000011 CFUNC  :local_variable_set
c:0002 p:0053 s:0007 E:001780 EVAL   bug.rb:10 [FINISH]
c:0001 p:0000 s:0002 E:001838 TOP    [FINISH]

bug.rb:10:in `<main>'
bug.rb:10:in `local_variable_set'

-- C level backtrace information -------------------------------------------
0   libruby.2.1.0.dylib                 0x0000000104099ff0 rb_vm_bugreport + 144
1   libruby.2.1.0.dylib                 0x0000000103f4b251 report_bug + 305
2   libruby.2.1.0.dylib                 0x0000000103f4b114 rb_bug + 180
3   libruby.2.1.0.dylib                 0x000000010401c04c sigsegv + 156
4   libsystem_platform.dylib            0x00007fff8fb45f1a _sigtramp + 26
5   libruby.2.1.0.dylib                 0x0000000103f5cfe0 bind_local_variable_set + 128
6   ???                                 0x0000000000003170 0x0 + 12656

-- Other runtime information -----------------------------------------------

* Loaded script: bug.rb

* Loaded features:

    0 enumerator.so
    1 /Users/s2gatev/.rvm/rubies/ruby-2.1.3/lib/ruby/2.1.0/x86_64-darwin14.0/enc/encdb.bundle
    2 /Users/s2gatev/.rvm/rubies/ruby-2.1.3/lib/ruby/2.1.0/x86_64-darwin14.0/enc/trans/transdb.bundle
    3 /Users/s2gatev/.rvm/rubies/ruby-2.1.3/lib/ruby/2.1.0/x86_64-darwin14.0/rbconfig.rb
    4 /Users/s2gatev/.rvm/rubies/ruby-2.1.3/lib/ruby/site_ruby/2.1.0/rubygems/compatibility.rb
    5 /Users/s2gatev/.rvm/rubies/ruby-2.1.3/lib/ruby/site_ruby/2.1.0/rubygems/defaults.rb
    6 /Users/s2gatev/.rvm/rubies/ruby-2.1.3/lib/ruby/site_ruby/2.1.0/rubygems/deprecate.rb
    7 /Users/s2gatev/.rvm/rubies/ruby-2.1.3/lib/ruby/site_ruby/2.1.0/rubygems/errors.rb
    8 /Users/s2gatev/.rvm/rubies/ruby-2.1.3/lib/ruby/site_ruby/2.1.0/rubygems/version.rb
    9 /Users/s2gatev/.rvm/rubies/ruby-2.1.3/lib/ruby/site_ruby/2.1.0/rubygems/requirement.rb
   10 /Users/s2gatev/.rvm/rubies/ruby-2.1.3/lib/ruby/site_ruby/2.1.0/rubygems/platform.rb
   11 /Users/s2gatev/.rvm/rubies/ruby-2.1.3/lib/ruby/site_ruby/2.1.0/rubygems/basic_specification.rb
   12 /Users/s2gatev/.rvm/rubies/ruby-2.1.3/lib/ruby/site_ruby/2.1.0/rubygems/stub_specification.rb
   13 /Users/s2gatev/.rvm/rubies/ruby-2.1.3/lib/ruby/site_ruby/2.1.0/rubygems/specification.rb
   14 /Users/s2gatev/.rvm/rubies/ruby-2.1.3/lib/ruby/site_ruby/2.1.0/rubygems/exceptions.rb
   15 /Users/s2gatev/.rvm/rubies/ruby-2.1.3/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_gem.rb
   16 thread.rb
   17 /Users/s2gatev/.rvm/rubies/ruby-2.1.3/lib/ruby/2.1.0/x86_64-darwin14.0/thread.bundle
   18 /Users/s2gatev/.rvm/rubies/ruby-2.1.3/lib/ruby/2.1.0/monitor.rb
   19 /Users/s2gatev/.rvm/rubies/ruby-2.1.3/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb
   20 /Users/s2gatev/.rvm/rubies/ruby-2.1.3/lib/ruby/site_ruby/2.1.0/rubygems.rb

[NOTE]
You may have encountered a bug in the Ruby interpreter or extension libraries.
Bug reports are welcome.
Don't forget to include the above Crash Report log file.
For details: http://www.ruby-lang.org/bugreport.html
```

I noticed the same issue is present in the trunk. The functionality for getting `Proc` out of `Method` seems to be discussed and accepted. I noticed that it was introduced with f331b5584edbf106ab85f4663ddbe55031176b3a.

Perhaps I am not getting something right but I'm wondering if you have considered this scenario when introducing the change? Perhaps the fix should be different if so. I don't know if you are the right person to ask @nobu, but I am tagging you since you committed the change. I'd be very thankful if you can shed some light on this issue.

Thanks in advance!