### PR TITLE
lib/open3.rb: fix code formatting in documentation

### DIFF
--- a/lib/open3.rb
+++ b/lib/open3.rb
@@ -214,11 +214,11 @@ module Open3
   #   stdout_str, stderr_str, status = Open3.capture3([env,] cmd... [, opts])
   #
   # The arguments env, cmd and opts are passed to Open3.popen3 except
-  # opts[:stdin_data] and opts[:binmode].  See Process.spawn.
+  # <code>opts[:stdin_data]</code> and <code>opts[:binmode]</code>.  See Process.spawn.
   #
-  # If opts[:stdin_data] is specified, it is sent to the command's standard input.
+  # If <code>opts[:stdin_data]</code> is specified, it is sent to the command's standard input.
   #
-  # If opts[:binmode] is true, internal pipes are set to binary mode.
+  # If <code>opts[:binmode]</code> is true, internal pipes are set to binary mode.
   #
   # Examples:
   #
@@ -272,11 +272,11 @@ module Open3
   #   stdout_str, status = Open3.capture2([env,] cmd... [, opts])
   #
   # The arguments env, cmd and opts are passed to Open3.popen3 except
-  # opts[:stdin_data] and opts[:binmode].  See Process.spawn.
+  # <code>opts[:stdin_data]</code> and <code>opts[:binmode]</code>.  See Process.spawn.
   #
-  # If opts[:stdin_data] is specified, it is sent to the command's standard input.
+  # If <code>opts[:stdin_data]</code> is specified, it is sent to the command's standard input.
   #
-  # If opts[:binmode] is true, internal pipes are set to binary mode.
+  # If <code>opts[:binmode]</code> is true, internal pipes are set to binary mode.
   #
   # Example:
   #
@@ -320,11 +320,11 @@ module Open3
   #   stdout_and_stderr_str, status = Open3.capture2e([env,] cmd... [, opts])
   #
   # The arguments env, cmd and opts are passed to Open3.popen3 except
-  # opts[:stdin_data] and opts[:binmode].  See Process.spawn.
+  # <code>opts[:stdin_data]</code> and <code>opts[:binmode]</code>.  See Process.spawn.
   #
-  # If opts[:stdin_data] is specified, it is sent to the command's standard input.
+  # If <code>opts[:stdin_data]</code> is specified, it is sent to the command's standard input.
   #
-  # If opts[:binmode] is true, internal pipes are set to binary mode.
+  # If <code>opts[:binmode]</code> is true, internal pipes are set to binary mode.
   #
   # Example:
   #


### PR DESCRIPTION
Docs currently lose information when parsing `Open3` comments (notice the `opts` hash with missing key [here](http://www.rubydoc.info/stdlib/open3/Open3.capture2e) and [here](http://www.ruby-doc.org/stdlib-2.1.3/libdoc/open3/rdoc/Open3.html#method-c-capture2e)). This commit wraps them in `<code>` tags, b/c that's what I saw used [elsewhere](https://github.com/ruby/ruby/blob/512c0364b3f526bef5bed1b224fbe6bb7f253eff/io.c#L9584)

![docs-update](https://cloud.githubusercontent.com/assets/77495/4784000/89fcbad8-5d3e-11e4-9a4e-7c96ad95f46a.png)

I'd do more, but couldn't figure out how docs officially get built (there's a number of tools), or if there was a documentation standard that I could use to guide my efforts (e.g. there appears to be cross-linking, but I don't really understand how the doc tool figures out what to apply it to, or when it should/shouldn't be used). A documentation standard (or even a paragraph of prose listing the tool/command and stream-of-consciousness thoughts) would make it a lot easier to contribute here, because more work went into inferring the right thing to do than into making the changes. If one does exist, maybe link it in README.\* or CONTRIBUTING.md or https://bugs.ruby-lang.org/projects/ruby/wiki/HowToContribute
