### PR TITLE
revises the documentation of Module#const_defined?

### DIFF
--- a/object.c
+++ b/object.c
@@ -2221,20 +2221,39 @@ rb_mod_const_set(VALUE mod, VALUE name, VALUE value)
  *     mod.const_defined?(sym, inherit=true)   -> true or false
  *     mod.const_defined?(str, inherit=true)   -> true or false
  *
- *  Checks for a constant with the given name in <i>mod</i>
- *  If +inherit+ is set, the lookup will also search
- *  the ancestors (and +Object+ if <i>mod</i> is a +Module+.)
+ *  Says whether _mod_ or its ancestors have a constant with the given name:
  *
- *  Returns whether or not a definition is found:
+ *    Float.const_defined?(:EPSILON)      #=> true, found in Float itself
+ *    Float.const_defined?("String")      #=> true, found in Object (ancestor)
+ *    BasicObject.const_defined?(:Hash)   #=> false
  *
- *     Math.const_defined? "PI"   #=> true
- *     IO.const_defined? :SYNC   #=> true
- *     IO.const_defined? :SYNC, false   #=> false
+ *  If _mod_ is a +Module+, additionally +Object+ and its ancestors are checked:
  *
- *  If neither +sym+ nor +str+ is not a valid constant name a NameError will be
- *  raised with a warning "wrong constant name".
+ *    Math.const_defined?(:String)   #=> true, found in Object
  *
- *	Hash.const_defined? 'foobar' #=> NameError: wrong constant name foobar
+ *  In each of the checked classes or modules, if the constant is not present
+ *  but there is an autoload for it, +true+ is returned directly without
+ *  autoloading:
+ *
+ *    module Admin
+ *      autoload :User, 'admin/user'
+ *    end
+ *    Admin.const_defined?(:User)   #=> true
+ *
+ *  If the constant is not found the callback +const_missing+ is *not* called
+ *  and the method returns +false+.
+ *
+ *  If +inherit+ is false, the lookup only checks the constants in the receiver:
+ *
+ *    IO.const_defined?(:SYNC)          #=> true, found in File::Constants (ancestor)
+ *    IO.const_defined?(:SYNC, false)   #=> false, not found in IO itself
+ *
+ *  In this case, the same logic for autoloading applies.
+ *
+ *  If the argument is not a valid constant name +NameError+ is raised with the
+ *  message "wrong constant name _name_":
+ *
+ *    Hash.const_defined? 'foobar'   #=> NameError: wrong constant name foobar
  *
  */
 


### PR DESCRIPTION
This patch revises the documentation of `Module#const_defined?`. Changes are:
- Describes first the default behavior.
- Documents autoload logic.
- Documents that `const_missing` is not called if the constant is not present.
- Inserts examples as the material they depict is introduced (instead of just one chunk at the end).
- Removes parens from the sentence that says that `Object` is checked if the receiver is a module since that's a regular step of the lookup algorithm, not something to be deemphasized.
- Revises some indentation.
- Uniformizes the distance from code to "#=>"s to 3 spaces (mod vertical alignment).
