### PR TITLE
fix http_chunked_gzip_decoding_error

### DIFF
--- a/lib/net/http/response.rb
+++ b/lib/net/http/response.rb
@@ -374,9 +374,7 @@ class Net::HTTPResponse
         dest.force_encoding(Encoding::ASCII_8BIT)
       end
       block = proc do |compressed_chunk|
-        @inflate.inflate(compressed_chunk) do |chunk|
-          dest << chunk
-        end
+        dest << @inflate.inflate(compressed_chunk)
       end
 
       Net::ReadAdapter.new(block)


### PR DESCRIPTION
when net::http get response as chunked gzip.

it drops last inflation. so it cause Z_BUF_ERROR.

Actually, this bug is not exist in 1.8.7, but it appears when maybe 2.x

there is test ruby code for this problems.

``` ruby
require 'net/https'
require 'open-uri'

url = "http://xe.sketchbooks.co.kr/806541"
uri = URI.parse(url.to_s)
http = Net::HTTP::new(uri.host, uri.port)

http_get = Net::HTTP::Get.new(uri.request_uri)
response = http.request(http_get)
```
