### PR TITLE
Fix socket configuration on OS X 10.10

### DIFF
--- a/ext/socket/extconf.rb
+++ b/ext/socket/extconf.rb
@@ -666,12 +666,13 @@ EOS
   end
 
   hdr = "netinet6/in6.h"
-  if /darwin/ =~ RUBY_PLATFORM and !try_compile(<<"SRC", nil, :werror=>true)
+  hdr_path = "/usr/include/#{hdr}"
+  if /darwin/ =~ RUBY_PLATFORM and !try_compile(<<"SRC", nil, :werror=>true) and File.exist?(hdr_path)
 #include <netinet/in.h>
 int t(struct in6_addr *addr) {return IN6_IS_ADDR_UNSPECIFIED(addr);}
 SRC
     print "fixing apple's netinet6/in6.rb ..."; $stdout.flush
-    in6 = File.read("/usr/include/#{hdr}")
+    in6 = File.read(hdr_path)
     if in6.gsub!(/\*\(const\s+__uint32_t\s+\*\)\(const\s+void\s+\*\)\(&(\(\w+\))->s6_addr\[(\d+)\]\)/) do
         i, r = $2.to_i.divmod(4)
         if r.zero?


### PR DESCRIPTION
OS X 10.10
ruby 2.1.4
Compiler: clang

```
./configure --prefix ~/.rbenv/versions/2.1.4 --disable-install-doc --without-gcc --with-out-ext=tk --with-opt-dir=/usr/local/opt/libyaml:/usr/local/opt/openssl:/usr/local/opt/readline
<..>
```

```
$ make
<..>
configuring socket
fixing apple's netinet6/in6.rb ...No such file or directory @ rb_sysopen - /usr/include/netinet6/in6.h
Failed to configure socket. It will not be installed.
<..>
```

```
ls /usr/include/netinet6/in6.h
gls: cannot access /usr/include/netinet6/in6.h: No such file or directory
```