### PR TITLE
Set ssl version from params

### DIFF
--- a/test/openssl/test_ssl.rb
+++ b/test/openssl/test_ssl.rb
@@ -564,6 +564,16 @@ if OpenSSL::SSL::SSLContext::METHODS.include? :TLSv1_1
     }
   end
 
+  def test_allow_tls_v1_for_client
+    start_server_version(:TLSv1) { |server, port|
+      ctx = OpenSSL::SSL::SSLContext.new
+      ctx.set_params(ssl_version: :TLSv1)
+      # It appears that explicitly calling 'ssl_version=' is required
+      # ctx.ssl_version = :TLSv1
+      assert_nothing_raised(*HANDSHAKE_ERRORS) { server_connect(port, ctx) { |ssl| } }
+    }
+  end
+
   def test_forbid_tls_v1_from_server
     start_server_version(:TLSv1) { |server, port|
       ctx = OpenSSL::SSL::SSLContext.new


### PR DESCRIPTION
`Net::Http` supports an `ssl_version` parameter.  Unfortunately, the `Net::Http#connect` method passes the parameter via the `OpenSSL::SSL::SSLContext#set_params` method:

```
@ssl_context = OpenSSL::SSL::SSLContext.new
@ssl_context.set_params(ssl_parameters)
```

It appears based on debugging that `set_params` should not set the `ssl_version` despite it being a key in `DEFAULT_PARAMS` and `Net::Http#connect` should do something like the following:

```
@ssl_context = OpenSSL::SSL::SSLContext.new
@ssl_context.set_params(ssl_parameters)
@ssl_context.ssl_version = ssl_version
```

The included test fails when `set_params` is called, but passes when only `ssl_version=` is called. 