### PR TITLE
Retrive proxy user and password from http_proxy

### DIFF
--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -1051,12 +1051,20 @@ module Net   #:nodoc:
 
     # The proxy username, if one is configured
     def proxy_user
-      @proxy_user
+      if @proxy_from_env then
+        proxy_uri && proxy_uri.user
+      else
+        @proxy_user
+      end
     end
 
     # The proxy password, if one is configured
     def proxy_pass
-      @proxy_pass
+      if @proxy_from_env then
+        proxy_uri && proxy_uri.password
+      else
+        @proxy_pass
+      end
     end
 
     alias proxyaddr proxy_address   #:nodoc: obsolete


### PR DESCRIPTION
Get user and pass from http_proxy variable when specified, so that NET::HTTP can handle connections behind authenticated proxies automatically.
