### PR TITLE
Support bare ipv6 hosts in URI::Generic.build 

### DIFF
--- a/lib/uri/generic.rb
+++ b/lib/uri/generic.rb
@@ -184,7 +184,7 @@ module URI
       if arg_check
         self.scheme = scheme
         self.userinfo = userinfo
-        self.host = host
+        self.hostname = host
         self.port = port
         self.path = path
         self.query = query

--- a/test/uri/test_generic.rb
+++ b/test/uri/test_generic.rb
@@ -760,6 +760,16 @@ class URI::TestGeneric < Test::Unit::TestCase
   def test_build
     u = URI::Generic.build(['http', nil, 'example.com', 80, nil, '/foo', nil, nil, nil])
     assert_equal('http://example.com:80/foo', u.to_s)
+
+    u = URI::Generic.build(:scheme => "http", :host => "::1", :path => "/bar/baz")
+    assert_equal("http://[::1]/bar/baz", u.to_s)
+    assert_equal("[::1]", u.host)
+    assert_equal("::1", u.hostname)
+
+    u = URI::Generic.build(:scheme => "http", :host => "[::1]", :path => "/bar/baz")
+    assert_equal("http://[::1]/bar/baz", u.to_s)
+    assert_equal("[::1]", u.host)
+    assert_equal("::1", u.hostname)
   end
 
   def test_build2


### PR DESCRIPTION
URI::Generic.build accepts URI components and users may not expect that a host component needs to be wrapped with square brackets since it's not providing a URI.
#### Currently, we need to manually wrap ipv6 addess with brackets:

``` ruby
URI::HTTP.build(:host => "[::1]", :path => "/bar/baz")
```
#### An alternative below is not good because URI should be abstracting this:

``` ruby
uri = URI::HTTP.build(:path => "/bar/baz")
uri.hostname = "::1"
uri
```
#### When passing a uri to URI to parse, then it makes sense to require []:

``` ruby
URI("http://[::1]/bar/baz")
```
#### But, since I'm building from uri components, I would prefer to support either:

``` ruby
URI::HTTP.build(:host => "[::1]", :path => "/bar/baz")
# Or
URI::HTTP.build(:host => "::1", :path => "/bar/baz")
```

**Note**
- I added missing assertions to the existing build tests in the first commit.
- I did not modify the else case in initialize(when arg_check is false) since ipv6 check seems similar to the existing host checks and should be bypassed in that case.
