### PR TITLE
Prepare 'fasta.output' before running benchmarks.

### DIFF
--- a/benchmark/run.rb
+++ b/benchmark/run.rb
@@ -23,7 +23,15 @@ def prepare_wc_input
   end
 end
 
+# prepare 'fasta.output'
+def prepare_fasta_output
+  Dir['prepare_so_*'].each do |file|
+    system("ruby #{file}")
+  end
+end
+
 prepare_wc_input
+prepare_fasta_output
 
 def bm file
   prog = File.readlines(file).map{|e| e.rstrip}.join("\n")


### PR DESCRIPTION
We have to generate the files which are required for a few of the benchmarks. IMO `benchmark/run.rb` should handle this.
