### PR TITLE
Fix `rb_eval_string_wrap` documentation.

### DIFF
--- a/vm_eval.c
+++ b/vm_eval.c
@@ -1442,7 +1442,7 @@ rb_eval_string_protect(const char *str, int *state)
 
 /**
  * Evaluates the given string under a module binding in an isolated binding.
- * This is same as the binding for required libraries on "require('foo', true)".
+ * This is same as the binding for loaded libraries on "load('foo', true)".
  *
  * __FILE__ will be "(eval)", and __LINE__ starts from 1 in the evaluation.
  *


### PR DESCRIPTION
It is referencing `require` instead of `load`.
