### PR TITLE
test gdbm each_key called without a block

### DIFF
--- a/test/gdbm/test_gdbm.rb
+++ b/test/gdbm/test_gdbm.rb
@@ -390,6 +390,10 @@ if defined? GDBM
       assert_equal(@gdbm, ret)
     end
 
+    def test_each_key_without_block
+      assert_kind_of Enumerator, @gdbm.each_key
+    end
+
     def test_keys
       assert_equal([], @gdbm.keys)
 


### PR DESCRIPTION
- The aim of this test is to aid other implementations in being
  conformant with MRI.
- The existing test calls GDBM#each_key with a block,
- this commit tests that, when called without a block, the method
  returns an Enumerator, and does not assume there is a block,
- the 'gdbm' gem attempts to have identical behaviour to this
  implementation, but assumes there is a block.
