### PR TITLE
ext/tk/lib/tkextlib/tcllib/plotchart.rb: pixel_to_coords should invoke pixelToCoords, not coordsToPixel.

### DIFF
--- a/ext/tk/lib/tkextlib/tcllib/plotchart.rb
+++ b/ext/tk/lib/tkextlib/tcllib/plotchart.rb
@@ -142,7 +142,7 @@ module Tk::Tcllib::Plotchart
   end
 
   def self.pixel_to_coords(w, x, y)
-    list(tk_call_without_enc('::Plotchart::coordsToPixel', w.path, x, y))
+    list(tk_call_without_enc('::Plotchart::pixelToCoords', w.path, x, y))
   end
 
   def self.determine_scale(*args) # (xmin, xmax, inverted=false)
@@ -311,7 +311,7 @@ module Tk::Tcllib::Plotchart
     end
 
     def pixel_to_coords(x, y)
-      list(tk_call_without_enc('::Plotchart::coordsToPixel', @path, x, y))
+      list(tk_call_without_enc('::Plotchart::pixelToCoords', @path, x, y))
     end
 
     def determine_scale(xmax, ymax)


### PR DESCRIPTION
This pull request changes 'Tk::Tcllib::Plotchart.pixel_to_coords' and 'Tk::Tcllib::Plotchart::ChartMethod#pixel_to_coords' to invoke the appropriate function of Tcl.
