### PR TITLE
Fix implicit conversion from int to VALUE in Hash#eql?

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -1944,10 +1944,15 @@ hash_equal(VALUE hash1, VALUE hash2, int eql)
 	if (!rb_respond_to(hash2, idTo_hash)) {
 	    return Qfalse;
 	}
-	if (eql)
-	    return rb_eql(hash2, hash1);
-	else
+	if (eql) {
+	    if (rb_eql(hash2, hash1)) {
+		return Qtrue;
+	    } else {
+		return Qfalse;
+	    }
+	} else {
 	    return rb_equal(hash2, hash1);
+	}
     }
     if (RHASH_SIZE(hash1) != RHASH_SIZE(hash2))
 	return Qfalse;

--- a/test/ruby/test_hash.rb
+++ b/test/ruby/test_hash.rb
@@ -927,9 +927,9 @@ class TestHash < Test::Unit::TestCase
     o.instance_variable_set(:@cls, @cls)
     def o.to_hash; @cls[]; end
     def o.eql?(x); true; end
-    assert_send([@cls[], :eql?, o])
+    assert_equal(true, @cls[].eql?(o))
     def o.eql?(x); false; end
-    assert_not_send([@cls[], :eql?, o])
+    assert_equal(false, @cls[].eql?(o))
   end
 
   def test_hash2


### PR DESCRIPTION
`rb_eql` returns an `int`, but `hash_equal` implicitly casts it to `VALUE`. This means that `my_hash.eql?(my_hash_like_object)` returns `0` instead of `true` when the two instances are eql.
