### PR TITLE
fix target location for installing bundled gems

### DIFF
--- a/tool/rbinstall.rb
+++ b/tool/rbinstall.rb
@@ -719,7 +719,7 @@ install?(:ext, :comm, :gem) do
     directories = Gem.ensure_gem_subdirectories(gem_dir, :mode => $dir_mode)
     prepare "bundle gems", gem_dir, directories
     Dir.glob(srcdir+'/gems/*.gem').each do |gem|
-      Gem.install gem, Gem::Requirement.default, :install_dir => with_destdir(Gem.dir), :domain => :local, :ignore_dependencies => true
+      Gem.install gem, Gem::Requirement.default, :install_dir => with_destdir(gem_dir), :domain => :local, :ignore_dependencies => true
       gemname = Pathname(gem).basename
       puts "#{" "*30}#{gemname}"
     end


### PR DESCRIPTION
when `GEM_HOME` is set the `Gem.dir` points to it during installation and the bundled gems are installed in wrong location, this PR fixes it by using proper `gem_dir` which is displayed earlier as the target for installation.
