### PR TITLE
Improve document for YARD doc.

### DIFF
--- a/io.c
+++ b/io.c
@@ -8671,10 +8671,7 @@ rb_io_advise(int argc, VALUE *argv, VALUE io)
 
 /*
  *  call-seq:
- *     IO.select(read_array
- *               [, write_array
- *               [, error_array
- *               [, timeout]]]) -> array  or  nil
+ *     IO.select(read_array [, write_array [, error_array [, timeout]]]) -> array  or  nil
  *
  *  Calls select(2) system call.
  *  It monitors given arrays of <code>IO</code> objects, waits one or more

--- a/process.c
+++ b/process.c
@@ -978,7 +978,7 @@ rb_detach_process(rb_pid_t pid)
  *
  *  Some operating systems retain the status of terminated child
  *  processes until the parent collects that status (normally using
- *  some variant of <code>wait()</code>. If the parent never collects
+ *  some variant of <code>wait()</code>). If the parent never collects
  *  this status, the child stays around as a <em>zombie</em> process.
  *  <code>Process::detach</code> prevents this by setting up a
  *  separate Ruby thread whose sole job is to reap the status of the


### PR DESCRIPTION
 It breaks YARD doc method summary: http://www.rubydoc.info/stdlib/core/IO and http://www.rubydoc.info/stdlib/core/Process.
