### PR TITLE
adding #round to Vector as well as Matrix

### DIFF
--- a/lib/matrix.rb
+++ b/lib/matrix.rb
@@ -1713,6 +1713,7 @@ end
 # * #norm
 # * #normalize
 # * #r
+# * #round
 # * #size
 #
 # Conversion to other data types:
@@ -1789,6 +1790,13 @@ class Vector
   alias set_element []=
   alias set_component []=
   private :[]=, :set_element, :set_component
+
+  # Returns a vector with entries rounded to the given precision
+  # (see Float#round)
+  #
+  def round(ndigits=0)
+    map{|e| e.round(ndigits)}
+  end
 
   #
   # Returns the number of elements in the vector.

--- a/test/matrix/test_matrix.rb
+++ b/test/matrix/test_matrix.rb
@@ -190,6 +190,12 @@ class TestMatrix < Test::Unit::TestCase
     assert_equal(@m1, Matrix[o, [4,5,6]])
   end
 
+  def test_round
+    a = Matrix[[1.0111, 2.32320, 3.04343], [4.81, 5.0, 6.997]]
+    b = Matrix[[1.01, 2.32, 3.04], [4.81, 5.0, 7.0]]
+    assert_equal(a.round(2), b)
+  end
+
   def test_rows
     assert_equal(@m1, Matrix.rows([[1, 2, 3], [4, 5, 6]]))
   end

--- a/test/matrix/test_vector.rb
+++ b/test/matrix/test_vector.rb
@@ -157,6 +157,10 @@ class TestVector < Test::Unit::TestCase
     assert_equal(5, Vector[3, 4].r)
   end
 
+  def test_round
+    assert_equal(Vector[1.234, 2.345, 3.40].round(2), Vector[1.23, 2.35, 3.4])
+  end
+
   def test_covector
     assert_equal(Matrix[[1,2,3]], @v1.covector)
   end


### PR DESCRIPTION
It looks like @marcandre added `#round` to `Matrix` some years ago, but I would also like to be able to use this method with instances of `Vector`.

Because both `Matrix` and `Vector` both store their components in an underlying `Array`, and implement `#map` over that `Array`, I propose moving `Matrix#round` to `Matrix::RoundHelper` so that it may be included in both the `Matrix` and `Vector` classes and the functionality may be shared between them.