### PR TITLE
Tidying up string scrub tests

### DIFF
--- a/test/ruby/test_m17n.rb
+++ b/test/ruby/test_m17n.rb
@@ -1552,16 +1552,27 @@ class TestM17N < Test::Unit::TestCase
 
     assert_equal(u("\x81"), u("a\x81").scrub {|c| break c})
     assert_raise(ArgumentError) {u("a\x81").scrub {|c| c}}
+  end
 
+  def test_scrub_with_utf16be
     assert_equal("\uFFFD\u3042".encode("UTF-16BE"),
                  "\xD8\x00\x30\x42".force_encoding(Encoding::UTF_16BE).
                  scrub)
+  end
+
+  def test_scrub_with_utf16le
     assert_equal("\uFFFD\u3042".encode("UTF-16LE"),
                  "\x00\xD8\x42\x30".force_encoding(Encoding::UTF_16LE).
                  scrub)
+  end
+
+  def test_scrub_with_utf32be
     assert_equal("\uFFFD".encode("UTF-32BE"),
                  "\xff".force_encoding(Encoding::UTF_32BE).
                  scrub)
+  end
+
+  def test_strub_with_utf32le
     assert_equal("\uFFFD".encode("UTF-32LE"),
                  "\xff".force_encoding(Encoding::UTF_32LE).
                  scrub)

--- a/test/ruby/test_m17n.rb
+++ b/test/ruby/test_m17n.rb
@@ -1539,19 +1539,31 @@ class TestM17N < Test::Unit::TestCase
                  u("abcdefghijklmnopqrstuvwxyz\x61\xF1\x80\x80\xE1\x80\xC2\x62\x80\x63\x80\xBF\x64").scrub)
 
     assert_equal("\u3042\u3013", u("\xE3\x81\x82\xE3\x81").scrub("\u3013"))
-    assert_raise(Encoding::CompatibilityError){ u("\xE3\x81\x82\xE3\x81").scrub(e("\xA4\xA2")) }
-    assert_raise(TypeError){ u("\xE3\x81\x82\xE3\x81").scrub(1) }
-    assert_raise(ArgumentError){ u("\xE3\x81\x82\xE3\x81\x82\xE3\x81").scrub(u("\x81")) }
-    assert_equal(e("\xA4\xA2\xA2\xAE"), e("\xA4\xA2\xA4").scrub(e("\xA2\xAE")))
 
     assert_equal("\u3042<e381>", u("\xE3\x81\x82\xE3\x81").scrub{|x|'<'+x.unpack('H*')[0]+'>'})
-    assert_raise(Encoding::CompatibilityError){ u("\xE3\x81\x82\xE3\x81").scrub{e("\xA4\xA2")} }
-    assert_raise(TypeError){ u("\xE3\x81\x82\xE3\x81").scrub{1} }
-    assert_raise(ArgumentError){ u("\xE3\x81\x82\xE3\x81\x82\xE3\x81").scrub{u("\x81")} }
-    assert_equal(e("\xA4\xA2\xA2\xAE"), e("\xA4\xA2\xA4").scrub{e("\xA2\xAE")})
 
     assert_equal(u("\x81"), u("a\x81").scrub {|c| break c})
     assert_raise(ArgumentError) {u("a\x81").scrub {|c| c}}
+  end
+
+  def test_scrub_with_invalid_types
+    assert_raise(TypeError){ u("\xE3\x81\x82\xE3\x81").scrub(1) }
+    assert_raise(TypeError){ u("\xE3\x81\x82\xE3\x81").scrub{1} }
+  end
+
+  def test_scrub_with_incompatible_bytes
+    assert_raise(Encoding::CompatibilityError){ u("\xE3\x81\x82\xE3\x81").scrub(e("\xA4\xA2")) }
+    assert_raise(Encoding::CompatibilityError){ u("\xE3\x81\x82\xE3\x81").scrub{e("\xA4\xA2")} }
+  end
+
+  def test_scrub_replacement_with_valid_bytes
+    assert_equal(e("\xA4\xA2\xA2\xAE"), e("\xA4\xA2\xA4").scrub(e("\xA2\xAE")))
+    assert_equal(e("\xA4\xA2\xA2\xAE"), e("\xA4\xA2\xA4").scrub{e("\xA2\xAE")})
+  end
+
+  def test_scrub_replacement_with_invalid_bytes
+    assert_raise(ArgumentError){ u("\xE3\x81\x82\xE3\x81\x82\xE3\x81").scrub(u("\x81")) }
+    assert_raise(ArgumentError){ u("\xE3\x81\x82\xE3\x81\x82\xE3\x81").scrub{u("\x81")} }
   end
 
   def test_scrub_with_utf16be

--- a/test/ruby/test_m17n.rb
+++ b/test/ruby/test_m17n.rb
@@ -1519,12 +1519,6 @@ class TestM17N < Test::Unit::TestCase
   end
 
   def test_scrub
-    str = "\u3042\u3044"
-    assert_not_same(str, str.scrub)
-    str.force_encoding(Encoding::ISO_2022_JP) # dummy encoding
-    assert_not_same(str, str.scrub)
-    assert_nothing_raised(ArgumentError) {str.scrub(nil)}
-
     assert_equal("\uFFFD\uFFFD\uFFFD", u("\x80\x80\x80").scrub)
     assert_equal("\uFFFDA", u("\xF4\x80\x80A").scrub)
 
@@ -1546,7 +1540,19 @@ class TestM17N < Test::Unit::TestCase
     assert_raise(ArgumentError) {u("a\x81").scrub {|c| c}}
   end
 
-  def test_scrub_with_invalid_types
+  def test_scrub_returns_new_instance
+    str = "\u3042\u3044"
+    assert_not_same(str, str.scrub)
+    str.force_encoding(Encoding::ISO_2022_JP) # dummy encoding
+    assert_not_same(str, str.scrub)
+  end
+
+  def test_scrubbing_with_nil_doesnt_raise
+    str = "\u3042\u3044"
+    assert_nothing_raised(ArgumentError) {str.scrub(nil)}
+  end
+
+  def test_scrub_with_invalid_argument
     assert_raise(TypeError){ u("\xE3\x81\x82\xE3\x81").scrub(1) }
     assert_raise(TypeError){ u("\xE3\x81\x82\xE3\x81").scrub{1} }
   end


### PR DESCRIPTION
There was finger pointing earlier someone pointed at String#scrub tests for being incomprehensible. So I'm following @headius lead and opening a PR. Starting here and see where my time lets me go.

This is a pure refactoring, no functional code change in the slightest. Just moving code around to give each test case a more descriptive name.

I don't know exactly what all these tests cases are doing but I've tried to take a best guess to get started to see if there is interest. Starting on github because its easier for me, when I'm done with String#scrub tests I'll move to redmine or flatten as required.

Only 10 assertions left in the original #test_scrub, I don't fully understand what they're doing so any advice would be great. Similarly if my names are incorrect just let me know what they should be! If this is too much talking on a PR I'll take discussions elsewhere.

/cc @headius, @zzak.