### PR TITLE
URI::Generic.build should accept port as a string

### DIFF
--- a/lib/uri/rfc2396_parser.rb
+++ b/lib/uri/rfc2396_parser.rb
@@ -401,7 +401,7 @@ module URI
       # host          = hostname | IPv4address | IPv6reference (RFC 2732)
       ret[:HOST] = host = "(?:#{hostname}|#{ipv4addr}|#{ipv6ref})"
       # port          = *digit
-      port = '\d*'
+      ret[:PORT] = port = '\d*'
       # hostport      = host [ ":" port ]
       ret[:HOSTPORT] = hostport = "#{host}(?::#{port})?"
 

--- a/test/uri/test_generic.rb
+++ b/test/uri/test_generic.rb
@@ -761,6 +761,10 @@ class URI::TestGeneric < Test::Unit::TestCase
     u = URI::Generic.build(['http', nil, 'example.com', 80, nil, '/foo', nil, nil, nil])
     assert_equal('http://example.com:80/foo', u.to_s)
 
+    u = URI::Generic.build(:port => "5432")
+    assert_equal(":5432", u.to_s)
+    assert_equal(5432, u.port)
+
     u = URI::Generic.build(:scheme => "http", :host => "::1", :path => "/bar/baz")
     assert_equal("http://[::1]/bar/baz", u.to_s)
     assert_equal("[::1]", u.host)


### PR DESCRIPTION
The provision for this is in the implementation but a minor bug causes the regex
to be /\A\z/. This commit fixes that bug.