### PR TITLE
Pass header names as symbols

### DIFF
--- a/lib/net/http/header.rb
+++ b/lib/net/http/header.rb
@@ -169,7 +169,7 @@ module Net::HTTPHeader
   alias canonical_each each_capitalized
 
   def capitalize(name)
-    name.split(/-/).map {|s| s.capitalize }.join('-')
+    name.to_s.split(/-/).map {|s| s.capitalize }.join('-')
   end
   private :capitalize
 


### PR DESCRIPTION
This would give the ability to pass header names as symbols, e.g. when using httparty:

```ruby
HTTParty.get('https://api.github.com', headers: { token: 'secret-token' })
```

I might be wrong, but I believe this will bring more consistency to multiple libraries that are using net/http since most of the times passing symbols as hash keys has become a standard in Ruby (or atleast in Rails).