### PR TITLE
Enable assigning :modifiable attribute to OpenStruct.

### DIFF
--- a/lib/ostruct.rb
+++ b/lib/ostruct.rb
@@ -148,7 +148,7 @@ class OpenStruct
   # Used internally to check if the OpenStruct is able to be
   # modified before granting access to the internal Hash table to be modified.
   #
-  def modifiable
+  def __modifiable
     begin
       @modifiable = true
     rescue
@@ -156,7 +156,7 @@ class OpenStruct
     end
     @table
   end
-  protected :modifiable
+  protected :__modifiable
 
   #
   # Used internally to defined properties on the
@@ -167,7 +167,7 @@ class OpenStruct
     name = name.to_sym
     unless respond_to?(name)
       define_singleton_method(name) { @table[name] }
-      define_singleton_method("#{name}=") { |x| modifiable[name] = x }
+      define_singleton_method("#{name}=") { |x| __modifiable[name] = x }
     end
     name
   end
@@ -180,7 +180,7 @@ class OpenStruct
       if len != 1
         raise ArgumentError, "wrong number of arguments (#{len} for 1)", caller(1)
       end
-      modifiable[new_ostruct_member(mname)] = args[0]
+      __modifiable[new_ostruct_member(mname)] = args[0]
     elsif len == 0
       @table[mid]
     else
@@ -207,7 +207,7 @@ class OpenStruct
   #   person.age # => 42
   #
   def []=(name, value)
-    modifiable[new_ostruct_member(name)] = value
+    __modifiable[new_ostruct_member(name)] = value
   end
 
   #

--- a/test/ostruct/test_ostruct.rb
+++ b/test/ostruct/test_ostruct.rb
@@ -135,4 +135,10 @@ class TC_OpenStruct < Test::Unit::TestCase
     e = assert_raise(ArgumentError) { os.send :foo=, true, true }
     assert_match(/#{__callee__}/, e.backtrace[0])
   end
+
+  def test_modifiable
+    os = OpenStruct.new(modifiable: true)
+    assert_equal true, os.modifiable
+    assert_nothing_raised { os.foo = true }
+  end
 end


### PR DESCRIPTION
So far if a key named 'modifiable' is assigned to OpenStruct such as:

``` ruby
os = OpenStruct.new(modifiable: true)
```

the OpenStruct instance will define a public method called 'modifiable', overriding the already defined method for checking if the object is frozen. Everytime afterwards we will get an error when assigning attributes:

``` ruby
os.foo = :bar
#=> NoMethodError: undefined method `[]=' for true:TrueClass
```

This way we will be able to avoid that.
