### PR TITLE
Tiny performance gain at Set#include?

### DIFF
--- a/lib/set.rb
+++ b/lib/set.rb
@@ -78,7 +78,7 @@ class Set
   # If a block is given, the elements of enum are preprocessed by the
   # given block.
   def initialize(enum = nil, &block) # :yields: o
-    @hash ||= Hash.new
+    @hash ||= Hash.new(false)
 
     enum.nil? and return
 
@@ -209,7 +209,7 @@ class Set
 
   # Returns true if the set contains the given object.
   def include?(o)
-    @hash.include?(o)
+    @hash[o]
   end
   alias member? include?
 


### PR DESCRIPTION
Use `Hash#[]` instead of `Hash#include?`

Here are some stupid benchmarks https://gist.github.com/ismaelga/68bb3ea51b4742f65699
For some reason the difference is not as linear as expected and in some rare cases `Hash#include?` actually runs faster. I must admit I don't know what could cause that.