### PR TITLE
Fix documentation for Enumerable#entries

### DIFF
--- a/enum.c
+++ b/enum.c
@@ -489,11 +489,11 @@ enum_flat_map(VALUE obj)
  *
  *  Returns an array containing the items in <i>enum</i>.
  *
- *     (1..7).to_a                       #=> [1, 2, 3, 4, 5, 6, 7]
- *     { 'a'=>1, 'b'=>2, 'c'=>3 }.to_a   #=> [["a", 1], ["b", 2], ["c", 3]]
+ *     (1..7).entries                       #=> [1, 2, 3, 4, 5, 6, 7]
+ *     { 'a'=>1, 'b'=>2, 'c'=>3 }.entries   #=> [["a", 1], ["b", 2], ["c", 3]]
  *
  *     require 'prime'
- *     Prime.entries 10                  #=> [2, 3, 5, 7]
+ *     Prime.entries 10                     #=> [2, 3, 5, 7]
  */
 static VALUE
 enum_to_a(int argc, VALUE *argv, VALUE obj)


### PR DESCRIPTION
The documentation appears to erroneously demonstrate the #to_a method instead of #entries.