### PR TITLE
Make Base64.urlsafe methods actually urlsafe.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -27,6 +27,12 @@ with all sufficient information, see the ChangeLog file.
 * lib/drb/drb.rb
  * removed unused argument. https://github.com/ruby/ruby/pull/515
 
+* lib/base64.rb
+ * Base64.urlsafe_encode64: added a "padding" option to suppress
+   the padding character ("=").
+ * Base64.urlsafe_decode64: now it accepts not only correctly-padded
+   input but also unpadded input.
+
 === Built-in global variables compatibility issues
 
 === C API updates

--- a/lib/base64.rb
+++ b/lib/base64.rb
@@ -77,15 +77,26 @@ module Base64
   # This method complies with ``Base 64 Encoding with URL and Filename Safe
   # Alphabet'' in RFC 4648.
   # The alphabet uses '-' instead of '+' and '_' instead of '/'.
-  def urlsafe_encode64(bin)
-    strict_encode64(bin).tr("+/", "-_")
+  # The result may contain trailing '=' unless "padding" is false.
+  def urlsafe_encode64(bin, padding=true)
+    str = strict_encode64(bin).tr("+/", "-_")
+    str = str.delete("=") unless padding
+    str
   end
 
   # Returns the Base64-decoded version of +str+.
   # This method complies with ``Base 64 Encoding with URL and Filename Safe
   # Alphabet'' in RFC 4648.
   # The alphabet uses '-' instead of '+' and '_' instead of '/'.
+  #
+  # Trailing '=' characters are optional.
+  # This method accepts both correctly-padded and unpadded input,
+  # but rejects incorrectly-padded input.
   def urlsafe_decode64(str)
-    strict_decode64(str.tr("-_", "+/"))
+    str = str.tr("-_", "+/")
+    if !str.end_with?("=") && str.length % 4 != 0
+      str = str.ljust((str.length + 3) & ~3, "=")
+    end
+    strict_decode64(str)
   end
 end

--- a/test/base64/test_base64.rb
+++ b/test/base64/test_base64.rb
@@ -87,14 +87,39 @@ class TestBase64 < Test::Unit::TestCase
     assert_equal("_-8=", Base64.urlsafe_encode64("\xff\xef"))
   end
 
+  def test_urlsafe_encode64_unpadded
+    assert_equal("", Base64.urlsafe_encode64("", false))
+    assert_equal("AA", Base64.urlsafe_encode64("\0", false))
+    assert_equal("AAA", Base64.urlsafe_encode64("\0\0", false))
+    assert_equal("AAAA", Base64.urlsafe_encode64("\0\0\0", false))
+    assert_equal("_w", Base64.urlsafe_encode64("\377", false))
+    assert_equal("__8", Base64.urlsafe_encode64("\377\377", false))
+    assert_equal("____", Base64.urlsafe_encode64("\377\377\377", false))
+    assert_equal("_-8", Base64.urlsafe_encode64("\xff\xef", false))
+  end
+
   def test_urlsafe_decode64
     assert_equal("", Base64.urlsafe_decode64(""))
     assert_equal("\0", Base64.urlsafe_decode64("AA=="))
+    assert_equal("\0", Base64.urlsafe_decode64("AA"))
     assert_equal("\0\0", Base64.urlsafe_decode64("AAA="))
+    assert_equal("\0\0", Base64.urlsafe_decode64("AAA"))
     assert_equal("\0\0\0", Base64.urlsafe_decode64("AAAA"))
     assert_equal("\377", Base64.urlsafe_decode64("_w=="))
+    assert_equal("\377", Base64.urlsafe_decode64("_w"))
     assert_equal("\377\377", Base64.urlsafe_decode64("__8="))
+    assert_equal("\377\377", Base64.urlsafe_decode64("__8"))
     assert_equal("\377\377\377", Base64.urlsafe_decode64("____"))
     assert_equal("\xff\xef", Base64.urlsafe_decode64("_+8="))
+    assert_equal("\xff\xef", Base64.urlsafe_decode64("_+8"))
+
+    assert_raise(ArgumentError) { Base64.urlsafe_decode64("^") }
+    assert_raise(ArgumentError) { Base64.urlsafe_decode64("A^") }
+    assert_raise(ArgumentError) { Base64.urlsafe_decode64("AA=") }
+    assert_raise(ArgumentError) { Base64.urlsafe_decode64("AA===") }
+    assert_raise(ArgumentError) { Base64.urlsafe_decode64("AA=x") }
+    assert_raise(ArgumentError) { Base64.urlsafe_decode64("AAA^") }
+    assert_raise(ArgumentError) { Base64.urlsafe_decode64("AB==") }
+    assert_raise(ArgumentError) { Base64.urlsafe_decode64("AAB=") }
   end
 end

--- a/test/base64/test_base64.rb
+++ b/test/base64/test_base64.rb
@@ -101,17 +101,12 @@ class TestBase64 < Test::Unit::TestCase
   def test_urlsafe_decode64
     assert_equal("", Base64.urlsafe_decode64(""))
     assert_equal("\0", Base64.urlsafe_decode64("AA=="))
-    assert_equal("\0", Base64.urlsafe_decode64("AA"))
     assert_equal("\0\0", Base64.urlsafe_decode64("AAA="))
-    assert_equal("\0\0", Base64.urlsafe_decode64("AAA"))
     assert_equal("\0\0\0", Base64.urlsafe_decode64("AAAA"))
     assert_equal("\377", Base64.urlsafe_decode64("_w=="))
-    assert_equal("\377", Base64.urlsafe_decode64("_w"))
     assert_equal("\377\377", Base64.urlsafe_decode64("__8="))
-    assert_equal("\377\377", Base64.urlsafe_decode64("__8"))
     assert_equal("\377\377\377", Base64.urlsafe_decode64("____"))
     assert_equal("\xff\xef", Base64.urlsafe_decode64("_+8="))
-    assert_equal("\xff\xef", Base64.urlsafe_decode64("_+8"))
 
     assert_raise(ArgumentError) { Base64.urlsafe_decode64("^") }
     assert_raise(ArgumentError) { Base64.urlsafe_decode64("A^") }
@@ -121,5 +116,18 @@ class TestBase64 < Test::Unit::TestCase
     assert_raise(ArgumentError) { Base64.urlsafe_decode64("AAA^") }
     assert_raise(ArgumentError) { Base64.urlsafe_decode64("AB==") }
     assert_raise(ArgumentError) { Base64.urlsafe_decode64("AAB=") }
+  end
+
+  def test_urlsafe_decode64_unpadded
+    assert_equal("", Base64.urlsafe_decode64(""))
+    assert_equal("\0", Base64.urlsafe_decode64("AA"))
+    assert_equal("\0\0", Base64.urlsafe_decode64("AAA"))
+    assert_equal("\0\0\0", Base64.urlsafe_decode64("AAAA"))
+    assert_equal("\377", Base64.urlsafe_decode64("_w"))
+    assert_equal("\377\377", Base64.urlsafe_decode64("__8"))
+    assert_equal("\377\377\377", Base64.urlsafe_decode64("____"))
+    assert_equal("\xff\xef", Base64.urlsafe_decode64("_+8"))
+
+    assert_raise(ArgumentError) { Base64.urlsafe_decode64("AA=") }
   end
 end


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/10740