### PR TITLE
Terminate String when moved from heap to embedded.

### DIFF
--- a/string.c
+++ b/string.c
@@ -1593,6 +1593,7 @@ str_make_independent_expand(VALUE str, long expand)
 	ptr = RSTRING(str)->as.heap.ptr;
 	STR_SET_EMBED(str);
 	memcpy(RSTRING(str)->as.ary, ptr, len);
+	RSTRING(str)->as.ary[len] = '\0'; /* Ensure string is terminated */
 	STR_SET_EMBED_LEN(str, len);
 	return;
     }


### PR DESCRIPTION
BCrypt Ruby currently uses StringValuePtr to access strings and make comparisons with password. When updating to 2.2.0 we noticed that some passwords didn't work.
After tracking the problem down to only form encoded requests of passwords with url encoded characters I found that the mri functions that Bcrypt Ruby is using are returning incorrectly terminated strings, resulting in password hashing being broken.

I've narrowed it down to `str_buf_cat` when a string is in the heap but then moved to within the embedded section and then appending a zero length string. This results in the the string then being corrupt when being accessed through the `StringValuePtr` without taking account of the defined length within the `RString` object.

Ensuring that the string is terminated in `str_make_independent_expand` when it is moved to an embedded string resolves the issue I've been seeing.

I don't know whether this should be addressed here or whether the way that BCrypt Ruby is using the mri functions and whether it should be taking into account the length attribute within `RString`?

Replicate the issue
```ruby
#!/usr/bin/env ruby

embedded_string = "abcdefghi"
string = embedded_string.gsub("efg", "123")
# This returns a non-embedded String object

puts string
# Without a puts the string is modified some where between the gsub and being
# used in the str_append to be in the `ary` section of `RString`.
# When puts is uses the string object is also modified:
#  capa & shared within aux are modified

nil_embedded_string = nil.to_s
non_terminated = "#{string}#{nil_embedded_string}"
# as the length of `nil_embedded_string` is zero the string within `ary` is not
# correctly terminated. (str_buf_cat)

# Accessing non_terminated through mri method calls results in using an
# unterminated string.
# eg:
# __some_function(non_terminated)
#
# void some_function(VALUE str) {
#   printf("%s\n", StringValuePtr(str));
# }
# // This uses `ary` which is not correctly terminated