### PR TITLE
Fix intermittent SIGBUS on x64 Linux

### DIFF
--- a/ruby.c
+++ b/ruby.c
@@ -2018,6 +2018,52 @@ fill_standard_fds(void)
     }
 }
 
+#if defined(__linux__) && defined(__x86_64__)
+#include <sys/resource.h>
+static void
+reserve_stack(void) {
+    char buf[1024];
+    char *p;
+    unsigned long long base = 0;
+    FILE *f;
+    struct rlimit rl;
+
+    if (getrlimit(RLIMIT_STACK, &rl) || rl.rlim_cur == RLIM_INFINITY) {
+	return;
+    }
+    f = fopen("/proc/self/maps", "r");
+    if (!f) {
+	return;
+    }
+
+    while (fgets(buf, 1024, f)) {
+	if (strstr(buf, "[stack]")) {
+	    *(strchr(buf, ' ')) = '\0';
+	    p = strchr(buf, '-') + 1;
+	    base = strtoull(p, NULL, 16);
+	    break;
+	}
+    }
+    fclose(f);
+    if (!base) {
+	return;
+    }
+
+    __asm__("movq %%rsp,%%rax;\
+             sub %%rsp,%0;\
+             sub %0,%1;\
+             sub %1,%%rsp;\
+             movq $0,(%%rsp);\
+             movq %%rax,%%rsp;"
+             :
+             :"r" (base), "r" (rl.rlim_cur)
+             :"%rax");
+}
+#else
+static void
+reserve_stack(void) { }
+#endif
+
 /*! Initializes the process for ruby(1).
  *
  * This function assumes this process is ruby(1) and it has just started.
@@ -2037,4 +2083,5 @@ ruby_sysinit(int *argc, char ***argv)
     dln_argv0 = origarg.argv[0];
 #endif
     fill_standard_fds();
+    reserve_stack();
 }


### PR DESCRIPTION
This fixes an intermittent SIGBUS observed on Linux x64. Possibly fixes https://bugs.ruby-lang.org/issues/10626.

The root problem is that if ASLR places the heap and stack regions too close together, the C stack can potentially grow into the heap. The Linux kernel handles this by raising a SIGBUS signal and terminating the process: http://lxr.free-electrons.com/source/mm/memory.c?v=3.16#L2635. Because Ruby C stacks grow dynamically, and Linux process stacks are not reserved/commited up front, it's possible for the heap the prevent the stack from growing to the size allowed by `ulimit`.

I have written a small proof of concept that can reproduce the problem on Ruby 2.1.5: https://gist.github.com/csfrancis/46e360d401609275246c

My solution is to fully reserve the stack virtual address space at process start up. I do this by determining the current stack bounds, and then subtracting the available stack space (according to the process' `rlimit`) from the current `rsp`. Touching memory at that value reserves the address range for the stack (but only commits one physical page of memory). 

Right now, this is Linux ~~x64~~ only (other platforms will just no-op)~~, but it wouldn't be too difficult to implement the same solution for i386 as well~~.
