### PR TITLE
Set default cxxflags for extension

### DIFF
--- a/lib/mkmf.rb
+++ b/lib/mkmf.rb
@@ -1928,6 +1928,7 @@ COUTFLAG = #{COUTFLAG}$(empty)
 
 RUBY_EXTCONF_H = #{$extconf_h}
 cflags   = #{CONFIG['cflags']}
+cxxflags = #{CONFIG['cxxflags']}
 optflags = #{CONFIG['optflags']}
 debugflags = #{CONFIG['debugflags']}
 warnflags = #{$warnflags}


### PR DESCRIPTION
Currently in Makefiles created by ```Kernel#create_makefile```, there is no definition of ```cxxflags``` while the default value of ```$CXXFLAGS``` is ```"$(cxxflags)"```.

I think it is less astonishing to set the default value as bellow than the current value ```""```.
```ruby
cxxflags = "#{RbConfig::MAKEFILE_CONFIG['cxxflags']}"
```