### PR TITLE
Remove outdated section about symbol gc

### DIFF
--- a/doc/security.rdoc
+++ b/doc/security.rdoc
@@ -58,25 +58,6 @@ deserialized:
 Because of this, many of the security considerations applying to Marshal are
 also applicable to YAML. Do not use YAML to deserialize untrusted data.
 
-== Symbols
-
-Symbols are often seen as syntax sugar for simple strings, but they play a much
-more crucial role. The MRI Ruby implementation uses Symbols internally for
-method, variable and constant names. The reason for this is that symbols are
-simply integers with names attached to them, so they are faster to look up in
-hashtables.
-
-Be careful with passing user input to methods such as +send+,
-+instance_variable_get+ or +_set+, +const_get+ or +_set+, etc.
-as these methods will convert string parameters to immortal symbols internally.
-This means that the memory used by the symbols are never freed.  This could
-allow a user to mount a denial of service attack against your application by
-flooding it with unique strings, which will cause memory to grow indefinitely
-until the Ruby process is killed or causes the system to slow to a halt.
-
-The workaround to this is simple - don't call reflection/metaprogramming
-methods with user input.
-
 == Regular expressions
 
 Ruby's regular expression syntax has some minor differences when compared to


### PR DESCRIPTION
Symbols can be garbage collected as of ruby 2.2 . Remove docs
saying that they can't be GC'ed.