### PR TITLE
Update expoennt to exponent to match member name.

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -4453,7 +4453,7 @@ VpSetPTR(Real *a, Real *b, Real *c, size_t *a_pos, size_t *b_pos, size_t *c_pos,
 
     size_t const round_limit = (VpGetPrecLimit() + BASE_FIG - 1) / BASE_FIG;
 
-    assert(a->exponent >= b->expoennt);
+    assert(a->exponent >= b->exponent);
 
     c->frac[0] = 0;
     *av = *bv = 0;


### PR DESCRIPTION
`expoennt` was causing a bigdecimal build to fail with:

    bigdecimal.c: In function âVpSetPTRâ:
    bigdecimal.c:4421:5: error: âRealâ has no member named âexpoenntâ