### PR TITLE
OptionParser Documentation

### DIFF
--- a/lib/optparse.rb
+++ b/lib/optparse.rb
@@ -298,7 +298,7 @@
 #         end
 #         # Another typical switch to print the version.
 #         parser.on_tail("--version", "Show version") do
-#           puts ::Version.join('.')
+#           puts OptionParser::Version.join('.')
 #           exit
 #         end
 #       end


### PR DESCRIPTION
Reading through the `OptionParser` documentation I noticed [this](https://github.com/ruby/ruby/blob/trunk/lib/optparse.rb#L299-L303):

```ruby
# Another typical switch to print the version.
opts.on_tail("--version", "Show version") do
  puts ::Version.join('.')
  exit
end
```
While the [`OptionParser.version()`](https://github.com/ruby/ruby/blob/trunk/lib/optparse.rb#L1163-L1165) instance method is defined, `::Version` is not accessible outside the class. This causes the example program to error out when supplied with the `--version` flag.