### PR TITLE
Net::FTP support pathnames

### DIFF
--- a/lib/net/ftp.rb
+++ b/lib/net/ftp.rb
@@ -618,7 +618,7 @@ module Net
       end
       begin
         f.binmode if localfile
-        retrbinary("RETR " + remotefile.to_s, blocksize, rest_offset) do |data|
+        retrbinary("RETR #{remotefile}", blocksize, rest_offset) do |data|
           f.write(data) if localfile
           yield(data) if block_given?
           result.concat(data) if result
@@ -758,7 +758,7 @@ module Net
     def list(*args, &block) # :yield: line
       cmd = "LIST"
       args.each do |arg|
-        cmd = cmd + " " + arg.to_s
+        cmd = "#{cmd} #{arg}"
       end
       if block
         retrlines(cmd, &block)

--- a/lib/net/ftp.rb
+++ b/lib/net/ftp.rb
@@ -644,7 +644,7 @@ module Net
         result = ""
       end
       begin
-        retrlines("RETR " + remotefile) do |line, newline|
+        retrlines("RETR #{remotefile}") do |line, newline|
           l = newline ? line + "\n" : line
           f.print(l) if localfile
           yield(line, newline) if block_given?
@@ -689,9 +689,9 @@ module Net
       begin
         f.binmode
         if rest_offset
-          storbinary("APPE " + remotefile, f, blocksize, rest_offset, &block)
+          storbinary("APPE #{remotefile}", f, blocksize, rest_offset, &block)
         else
-          storbinary("STOR " + remotefile, f, blocksize, rest_offset, &block)
+          storbinary("STOR #{remotefile}", f, blocksize, rest_offset, &block)
         end
       ensure
         f.close
@@ -706,7 +706,7 @@ module Net
     def puttextfile(localfile, remotefile = File.basename(localfile), &block) # :yield: line
       f = open(localfile)
       begin
-        storlines("STOR " + remotefile, f, &block)
+        storlines("STOR #{remotefile}", f, &block)
       ensure
         f.close
       end
@@ -742,7 +742,7 @@ module Net
     def nlst(dir = nil)
       cmd = "NLST"
       if dir
-        cmd = cmd + " " + dir
+        cmd = "#{cmd} #{dir}"
       end
       files = []
       retrlines(cmd) do |line|
@@ -777,18 +777,18 @@ module Net
     # Renames a file on the server.
     #
     def rename(fromname, toname)
-      resp = sendcmd("RNFR " + fromname)
+      resp = sendcmd("RNFR #{fromname}")
       if resp[0] != ?3
         raise FTPReplyError, resp
       end
-      voidcmd("RNTO " + toname)
+      voidcmd("RNTO #{toname}")
     end
 
     #
     # Deletes a file on the server.
     #
     def delete(filename)
-      resp = sendcmd("DELE " + filename)
+      resp = sendcmd("DELE #{filename}")
       if resp[0, 3] == "250"
         return
       elsif resp[0] == ?5
@@ -812,7 +812,7 @@ module Net
           end
         end
       end
-      cmd = "CWD " + dirname
+      cmd = "CWD #{dirname}"
       voidcmd(cmd)
     end
 
@@ -821,7 +821,7 @@ module Net
     #
     def size(filename)
       with_binary(true) do
-        resp = sendcmd("SIZE " + filename)
+        resp = sendcmd("SIZE #{filename}")
         if resp[0, 3] != "213"
           raise FTPReplyError, resp
         end
@@ -845,7 +845,7 @@ module Net
     # Creates a remote directory.
     #
     def mkdir(dirname)
-      resp = sendcmd("MKD " + dirname)
+      resp = sendcmd("MKD #{dirname}")
       return parse257(resp)
     end
 
@@ -853,7 +853,7 @@ module Net
     # Removes a remote directory.
     #
     def rmdir(dirname)
-      voidcmd("RMD " + dirname)
+      voidcmd("RMD #{dirname}")
     end
 
     #
@@ -907,7 +907,7 @@ module Net
     # Use +mtime+ if you want a parsed Time instance.
     #
     def mdtm(filename)
-      resp = sendcmd("MDTM " + filename)
+      resp = sendcmd("MDTM #{filename}")
       if resp[0, 3] == "213"
         return resp[3 .. -1].strip
       end

--- a/test/net/ftp/test_ftp.rb
+++ b/test/net/ftp/test_ftp.rb
@@ -767,6 +767,75 @@ class FTPTest < Test::Unit::TestCase
     end
   end
 
+  def test_pathnames
+    require 'pathname'
+
+    commands = []
+    server = create_ftp_server(0.2) { |sock|
+      sock.print("220 (test_ftp).\r\n")
+      commands.push(sock.gets)
+      sock.print("331 Please specify the password.\r\n")
+      commands.push(sock.gets)
+      sock.print("230 Login successful.\r\n")
+      commands.push(sock.gets)
+      sock.print("200 Switching to Binary mode.\r\n")
+      commands.push(sock.gets)
+      sock.print("257 'foo' directory created.\r\n")
+      commands.push(sock.gets)
+      sock.print("250 CWD command successful.\r\n")
+      commands.push(sock.gets)
+      sock.print("250 CWD command successful.\r\n")
+      commands.push(sock.gets)
+      sock.print("250 RMD command successful.\r\n")
+      commands.push(sock.gets)
+      sock.print("213 test.txt  Fri, 11 Jan 2013 11:20:41 -0500.\r\n")
+      commands.push(sock.gets)
+      sock.print("213 test.txt  16.\r\n")
+      commands.push(sock.gets)
+      sock.print("350 File exists, ready for destination name\r\n")
+      commands.push(sock.gets)
+      sock.print("250 RNTO command successful.\r\n")
+      commands.push(sock.gets)
+      sock.print("250 DELE command successful.\r\n")
+    }
+
+    begin
+      begin
+        dir   = Pathname.new("foo")
+        file  = Pathname.new("test.txt")
+        file2 = Pathname.new("test2.txt")
+        ftp   = Net::FTP.new
+        ftp.connect(SERVER_ADDR, server.port)
+        ftp.login
+        ftp.mkdir(dir)
+        ftp.chdir(dir)
+        ftp.chdir("..")
+        ftp.rmdir(dir)
+        ftp.mdtm(file)
+        ftp.size(file)
+        ftp.rename(file, file2)
+        ftp.delete(file)
+
+        assert_match(/\AUSER /, commands.shift)
+        assert_match(/\APASS /, commands.shift)
+        assert_match(/\ATYPE /, commands.shift)
+        assert_match(/\AMKD /, commands.shift)
+        assert_match(/\ACWD /, commands.shift)
+        assert_match(/\ACDUP/, commands.shift)
+        assert_match(/\ARMD /, commands.shift)
+        assert_match(/\AMDTM /, commands.shift)
+        assert_match(/\ASIZE /, commands.shift)
+        assert_match(/\ARNFR /, commands.shift)
+        assert_match(/\ARNTO /, commands.shift)
+        assert_match(/\ADELE /, commands.shift)
+      ensure
+        ftp.close if ftp
+      end
+    ensure
+      server.close
+    end
+  end
+
   private
 
 

--- a/test/net/ftp/test_ftp.rb
+++ b/test/net/ftp/test_ftp.rb
@@ -816,6 +816,15 @@ class FTPTest < Test::Unit::TestCase
         ftp.rename(file, file2)
         ftp.delete(file)
 
+        # TODO: These commented tests below expose the error but don't test anything:
+        #   TypeError: no implicit conversion of Pathname into String
+        # ftp.nlst(dir)
+        # ftp.putbinaryfile(Pathname.new("/etc/hosts"), file2)
+        # ftp.puttextfile(Pathname.new("/etc/hosts"), file2)
+        # ftp.gettextfile(Pathname.new("/etc/hosts"), file2)
+        # ftp.getbinaryfile(Pathname.new("/etc/hosts"), file2)
+        # ftp.list(dir, dir, dir)
+
         assert_match(/\AUSER /, commands.shift)
         assert_match(/\APASS /, commands.shift)
         assert_match(/\ATYPE /, commands.shift)


### PR DESCRIPTION
Pathname support was added to Net::FTP list and getbinaryfile methods by @shugo in 613a324.

This pull request fixes the following error when calling String#+ with a Pathname:
  TypeError: no implicit conversion of Pathname into String

Found in the following Net::FTP instance methods:
chdir
delete
gettextfile
mdtm
mkdir
nlst
putbinaryfile
puttextfile
rename
rmdir
size

Note, this pull request normalizes the changes from 613a324 so each of these methods support Pathnames in the same way, via String interpolation (see the second commit).  It's my opinion this is more readable and seems to creates less String objects.

The third commit adds commented tests that I used to recreate the TypeError but don't actually test the methods correctly.  I can either do correct tests with someone's help (nlst with returning filelists was not easy to test), remove the commented tests, or leave them commented.  

I wasn't sure if I should add a ChangeLog entry or if someone on ruby-core is supposed to do that.

Please advise. 

Thanks in advance for your review!

cc @tenderlove 