### PR TITLE
Added to rdoc for Hash#include? and Set#include?

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+Tue Feb 17 05:55:45 2015  Iain Beeston  <iain.beeston@gmail.com>
+
+	* hash.c: Added docs to explain that #include? and #member? do not
+	  check member equality
+	* lib/set.rb: ditto
+
 Mon Feb 16 20:58:49 2015  Nobuyoshi Nakada  <nobu@ruby-lang.org>
 
 	* compile.c (compile_massign): optimization for special case,

--- a/hash.c
+++ b/hash.c
@@ -1920,6 +1920,10 @@ rb_hash_values(VALUE hash)
  *     h.has_key?("a")   #=> true
  *     h.has_key?("z")   #=> false
  *
+ *  Note that <code>include?</code> and <code>member?</code> do not test member
+ *  equality using <code>==</code> as do other Enumerables.
+ *
+ *  See also Enumerable#include?
  */
 
 VALUE

--- a/lib/set.rb
+++ b/lib/set.rb
@@ -208,6 +208,11 @@ class Set
   end
 
   # Returns true if the set contains the given object.
+  #
+  # Note that <code>include?</code> and <code>member?</code> do not test member
+  # equality using <code>==</code> as do other Enumerables.
+  #
+  # See also Enumerable#include?
   def include?(o)
     @hash[o]
   end


### PR DESCRIPTION
I added to the rdoc for Hash#include? and Set#include? to explain that they override the implementation provided by Enumerable, and use `#hash` rather than `#==` to test for membership.