### PR TITLE
Replace camelcase variable name in documentation

### DIFF
--- a/compar.c
+++ b/compar.c
@@ -173,8 +173,8 @@ cmp_between(VALUE x, VALUE min, VALUE max)
  *     class SizeMatters
  *       include Comparable
  *       attr :str
- *       def <=>(anOther)
- *         str.size <=> anOther.str.size
+ *       def <=>(other)
+ *         str.size <=> other.str.size
  *       end
  *       def initialize(str)
  *         @str = str


### PR DESCRIPTION
`anOther` looks quite strange, I've replaced it by `other`