### PR TITLE
The import argument to Win32API.new can be either an Array or a String.

### DIFF
--- a/ext/win32/lib/Win32API.rb
+++ b/ext/win32/lib/Win32API.rb
@@ -15,7 +15,7 @@ class Win32API
 
     @func = Fiddle::Function.new(
       handle[func],
-      import.chars.map { |win_type| TYPEMAP[win_type.tr("VPpNnLlIi", "0SSI")] },
+      @proto.split(""),
       TYPEMAP[export.tr("VPpNnLlIi", "0SSI")],
       Fiddle::Importer.const_get(:CALL_TYPE_TO_ABI)[calltype]
     )


### PR DESCRIPTION
After the conversion to Fiddle, back-to-back commits assumed either an Array or
a String, however both have been allowed for the history of this module, as seen
in the line of code: 
```ruby
     @proto = [import].join.tr("VPpNnLlIi", "0SSI").sub(/^(.)0*$/, '\1')
```
Since `@proto` has already been set, let's use it in the Fiddle.new args argument.

_That said, I don't really understand the purpose of `.sub(/^(.)0*$/, '\1')` - it removes all trailing void arguments after an initial non-void argument? Huh?_

While converting the Fiddle, these commits were the source of the confusion:
@unak expects a string in 2e5610353fd3c0067e2528763a53c2a635067f02
``` diff
     @func = Fiddle::Function.new(
       handle[func],
-      import.map { |win_type| TYPEMAP[win_type.tr("VPpNnLlIi", "0SSI")] },
+      import.chars.map { |win_type| TYPEMAP[win_type.tr("VPpNnLlIi", "0SSI")] },
       TYPEMAP[export.tr("VPpNnLlIi", "0SSI")],
-      Fiddle::Importer::CALL_TYPE_TO_ABI[calltype]
+      Fiddle::Importer.const_get(:CALL_TYPE_TO_ABI)[calltype]
     )
```
@tenderlove expects an array in 07308c4d30b8c5260e5366c8eed2abf054d86fe7
``` diff
+    @func = Fiddle::Function.new(
+      handle[func],
+      import.map { |win_type| TYPEMAP[win_type.tr("VPpNnLlIi", "0SSI")] },
+      TYPEMAP[export.tr("VPpNnLlIi", "0SSI")],
+      Fiddle::Importer::CALL_TYPE_TO_ABI[calltype]
+     )
```

This came to my attention for Ruby 2.2 incompatibility in brianmario/mysql2#584