### PR TITLE
Fix Vector multiplication documentation

### DIFF
--- a/lib/matrix.rb
+++ b/lib/matrix.rb
@@ -1907,7 +1907,7 @@ class Vector
   #++
 
   #
-  # Multiplies the vector by +x+, where +x+ is a number or another vector.
+  # Multiplies the vector by +x+, where +x+ is a number or a matrix.
   #
   def *(x)
     case x


### PR DESCRIPTION
You cannot multiply two vectors.  This has been a problem in the documentation for over a year sadly.  It's about time to fix it.