### PR TITLE
[DOC]Mutex#owned? is no longer experimental since 2.1.0

### DIFF
--- a/thread.c
+++ b/thread.c
@@ -4356,7 +4356,6 @@ rb_mutex_lock(VALUE self)
  *    mutex.owned?  -> true or false
  *
  * Returns +true+ if this lock is currently held by current thread.
- * <em>This API is experimental, and subject to change.</em>
  */
 VALUE
 rb_mutex_owned_p(VALUE self)


### PR DESCRIPTION
This is a quote form [NEWS-2.1.0](https://github.com/ruby/ruby/blob/trunk/doc/NEWS-2.1.0#L100).

> Mutex#owned? is no longer experimental.