### PR TITLE
Update Hash#delete documentation

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -1058,7 +1058,7 @@ rb_hash_delete(VALUE hash, VALUE key)
  *
  *  Deletes the key-value pair and returns the value from <i>hsh</i> whose
  *  key is equal to <i>key</i>. If the key is not found, returns the
- *  <em>default value</em>. If the optional code block is given and the
+ *  <em>nil</em>. If the optional code block is given and the
  *  key is not found, pass in the key and return the result of
  *  <i>block</i>.
  *


### PR DESCRIPTION
Documentation implies that #delete method has a `default` paramater, but it doesn't.