### PR TITLE
Skip Win32 libraries in SecureRandom if OpenSSL::Random is available

### DIFF
--- a/lib/securerandom.rb
+++ b/lib/securerandom.rb
@@ -40,7 +40,7 @@ end
 #   p SecureRandom.random_bytes(10) #=> "\016\t{\370g\310pbr\301"
 #   p SecureRandom.random_bytes(10) #=> "\323U\030TO\234\357\020\a\337"
 module SecureRandom
-  if /mswin|mingw/ =~ RUBY_PLATFORM
+  if !defined?(OpenSSL::Random) && /mswin|mingw/ =~ RUBY_PLATFORM
     require "fiddle/import"
 
     module AdvApi32 # :nodoc:


### PR DESCRIPTION
Suggested by @unak to avoid the situation of trying to load the Win32 libraries while cross-compiling gems on a Linux host, as seen in tjschuck/rake-compiler-dev-box#20

Normally a PR would be against trunk, but trunk has moved all Win32-specific code out of `lib/securerandom.rb`, so if the same problem exists on trunk it will require a different solution.

https://bugs.ruby-lang.org/issues/10948