### PR TITLE
Remove private attribute warning

### DIFF
--- a/test/ruby/test_module.rb
+++ b/test/ruby/test_module.rb
@@ -836,7 +836,7 @@ class TestModule < Test::Unit::TestCase
   end
 
   def test_attr
-    assert_in_out_err([], <<-INPUT, %w(:ok nil), /warning: private attribute\?$/)
+    assert_in_out_err([], <<-INPUT, %w(nil))
       $VERBOSE = true
       c = Class.new
       c.instance_eval do
@@ -844,7 +844,6 @@ class TestModule < Test::Unit::TestCase
         attr_reader :foo
       end
       o = c.new
-      o.foo rescue p(:ok)
       p(o.instance_eval { foo })
     INPUT
 

--- a/vm_method.c
+++ b/vm_method.c
@@ -917,9 +917,9 @@ rb_attr(VALUE klass, ID id, int read, int write, int ex)
     else {
 	if (SCOPE_TEST(NOEX_PRIVATE)) {
 	    noex = NOEX_PRIVATE;
-	    rb_warning((SCOPE_CHECK(NOEX_MODFUNC)) ?
-		       "attribute accessor as module_function" :
-		       "private attribute?");
+	    if (SCOPE_CHECK(NOEX_MODFUNC)) {
+		rb_warning("attribute accessor as module_function");
+	    }
 	}
 	else if (SCOPE_TEST(NOEX_PROTECTED)) {
 	    noex = NOEX_PROTECTED;


### PR DESCRIPTION
One possible fix for https://bugs.ruby-lang.org/issues/10967