### PR TITLE
Raise ArgumentError when string passed to String#crypt contains null.

### DIFF
--- a/string.c
+++ b/string.c
@@ -7695,6 +7695,9 @@ rb_str_crypt(VALUE str, VALUE salt)
     }
 
     s = RSTRING_PTR(str);
+    if (!s || memchr(s, '\0', RSTRING_LEN(str)))
+        rb_raise(rb_eArgError, "string contains null character");
+
     if (!s) s = "";
     saltp = RSTRING_PTR(salt);
     if (!saltp[0] || !saltp[1]) goto short_salt;

--- a/string.c
+++ b/string.c
@@ -7694,9 +7694,7 @@ rb_str_crypt(VALUE str, VALUE salt)
 	rb_raise(rb_eArgError, "salt too short (need >=2 bytes)");
     }
 
-    s = RSTRING_PTR(str);
-    if (!s || memchr(s, '\0', RSTRING_LEN(str)))
-        rb_raise(rb_eArgError, "string contains null character");
+    s = StringValueCStr(str);
 
     if (!s) s = "";
     saltp = RSTRING_PTR(salt);

--- a/test/ruby/test_string.rb
+++ b/test/ruby/test_string.rb
@@ -507,6 +507,7 @@ class TestString < Test::Unit::TestCase
     assert_raise(ArgumentError) {S("mypassword").crypt(S(""))}
     assert_raise(ArgumentError) {S("mypassword").crypt(S("\0a"))}
     assert_raise(ArgumentError) {S("mypassword").crypt(S("a\0"))}
+    assert_raise(ArgumentError) {S("poison\u0000null").crypt(S("aa"))}
     [Encoding::UTF_16BE, Encoding::UTF_16LE,
      Encoding::UTF_32BE, Encoding::UTF_32LE].each do |enc|
       assert_raise(ArgumentError) {S("mypassword").crypt(S("aa".encode(enc)))}


### PR DESCRIPTION
Currently String#crypt assumes that it is called on a password typed
by the user, specifically, that it does not contain null character.
When it does:

> "abc\0def".crypt("pass") == "abc".crypt("pass")
=> true

This may not be desirable, and developers invoking crypt on strings
that potentially include null may expect different results. To
prevent security failures, this patch changes String#crypt to throw
ArgumentError when invoked on String that includes null character.