### PR TITLE
Create mac-ruby-install.shell

### DIFF
--- a/mac-ruby-install.shell
+++ b/mac-ruby-install.shell
@@ -1,0 +1,6 @@
+mkdir /tmp/ruby && cd /tmp/ruby
+curl --progress ftp://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p247.tar.gz | tar xz
+cd ruby-2.0.0-p247
+./configure
+make
+sudo make install


### PR DESCRIPTION
Mac Ruby Install By Cosmic Labs at https://github.com/cosmic-labs/Mac-Ruby-Install/blob/master/installruby.sh download and install Ruby Better!

Mac Version Only Windows in development!