### PR TITLE
Support RUBY_ENGINE_VERSION

### DIFF
--- a/version.c
+++ b/version.c
@@ -71,6 +71,10 @@ Init_version(void)
      * The engine or interpreter this ruby uses.
      */
     rb_define_global_const("RUBY_ENGINE", ruby_engine_name = MKSTR(engine));
+    /*
+     * The version of the engine or interpreter this ruby uses.
+     */
+    rb_define_global_const("RUBY_ENGINE_VERSION", MKSTR(version));
 }
 
 /*! Prints the version information of the CRuby interpreter to stdout. */


### PR DESCRIPTION
`RUBY_ENGINE_VERSION` was [added by Rubinius](https://github.com/rubinius/rubinius/commit/8212c460b97a6f277db35de5295f046a868eb8ac) for reporting the version of the Ruby engine. It has also [been proposed for JRuby](https://github.com/jruby/jruby/issues/2746), where it would be equivalent to `JRUBY_VERSION`. In CRuby `RUBY_ENGINE_VERSION` would be the same as `RUBY_VERSION`.

This would be a standard way to check the engine or interpreter version across Ruby implementations.