### PR TITLE
Document require name for ObjectSpace methods

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -8489,6 +8489,8 @@ rb_gcdebug_sentinel(VALUE obj, const char *name)
  *  called when a specific object is about to be destroyed by garbage
  *  collection.
  *
+ *     require 'objspace'
+ *
  *     a = "A"
  *     b = "B"
  *


### PR DESCRIPTION
Not all ObjectSpace methods are available by default. This patch adds the appropriate require to the first example so it is clear how to require the correct file to get all examples to work correctly.