### PR TITLE
[String] Make String#+ return an instance of self.class

### DIFF
--- a/string.c
+++ b/string.c
@@ -1486,7 +1486,7 @@ rb_str_plus(VALUE str1, VALUE str2)
     enc = rb_enc_check(str1, str2);
     RSTRING_GETMEM(str1, ptr1, len1);
     RSTRING_GETMEM(str2, ptr2, len2);
-    str3 = rb_str_new(0, len1+len2);
+    str3 = rb_str_new_with_class(str1, 0, len1+len2);
     ptr3 = RSTRING_PTR(str3);
     memcpy(ptr3, ptr1, len1);
     memcpy(ptr3+len1, ptr2, len2);


### PR DESCRIPTION
Fixes the first half of https://bugs.ruby-lang.org/issues/10845

(I tried to fix the second half but `rb_str_format` is scary and even when allocating the buffer to be of the correct class, the return value somehow was String anyways)