### PR TITLE
Irb#start should set STDOUT.sync to true

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -18,8 +18,6 @@ require "irb/ruby-lex"
 require "irb/input-method"
 require "irb/locale"
 
-STDOUT.sync = true
-
 # IRB stands for "interactive Ruby" and is a tool to interactively execute Ruby
 # expressions read from the standard input.
 #
@@ -373,6 +371,7 @@ module IRB
 
   # Initializes IRB and creates a new Irb.irb object at the +TOPLEVEL_BINDING+
   def IRB.start(ap_path = nil)
+    STDOUT.sync = true
     $0 = File::basename(ap_path, ".rb") if ap_path
 
     IRB.setup(ap_path)


### PR DESCRIPTION
current code in irb.rb assumes that STDOUT is not changed from the moment the file
is loaded till Irb.start is called.  But this is not always the case.
E.g. suppose we run rails console using spring pre-loader.  First time we run the console (which uses Irb)
it loads irb.rb and OUTPUT.sync set to true, but next time we run the console irb.rb already loaded and
thus OUTPUT.sync is not set to true and may be false.
This causes problem described in https://youtrack.jetbrains.com/issue/RUBY-16344

The solution I propose is to set OUTPUT.sycn to true in Irb#start.