### PR TITLE
Drop TLSv1.0 from Ruby SSL::SSLContext::DEFAULT_PARAMS

### DIFF
--- a/ext/openssl/lib/openssl/ssl.rb
+++ b/ext/openssl/lib/openssl/ssl.rb
@@ -21,7 +21,7 @@ module OpenSSL
   module SSL
     class SSLContext
       DEFAULT_PARAMS = {
-        :ssl_version => "SSLv23",
+        :ssl_version => "TLSv1_2",
         :verify_mode => OpenSSL::SSL::VERIFY_PEER,
         :ciphers => %w{
           ECDHE-ECDSA-AES128-GCM-SHA256
@@ -64,6 +64,7 @@ module OpenSSL
           opts |= OpenSSL::SSL::OP_NO_COMPRESSION if defined?(OpenSSL::SSL::OP_NO_COMPRESSION)
           opts |= OpenSSL::SSL::OP_NO_SSLv2 if defined?(OpenSSL::SSL::OP_NO_SSLv2)
           opts |= OpenSSL::SSL::OP_NO_SSLv3 if defined?(OpenSSL::SSL::OP_NO_SSLv3)
+          opts |= OpenSSL::SSL::OP_NO_TLSv1 if defined?(OpenSSL::SSL::OP_NO_TLSv1)
           opts
         }.call
       }

--- a/ext/openssl/lib/openssl/ssl.rb
+++ b/ext/openssl/lib/openssl/ssl.rb
@@ -21,7 +21,7 @@ module OpenSSL
   module SSL
     class SSLContext
       DEFAULT_PARAMS = {
-        :ssl_version => "TLSv1_2",
+        :ssl_version => "SSLv23",
         :verify_mode => OpenSSL::SSL::VERIFY_PEER,
         :ciphers => %w{
           ECDHE-ECDSA-AES128-GCM-SHA256


### PR DESCRIPTION
With TLSv1.0 being no longer considered "strong encryption" by NIST and the PCI SSC, I figured I'd propose this patch to remove it from the defaults list.

I can totally understand if this is too early to be this strict as a default, but figured I'd propose anyways just in case Ruby was ready for it.

**References:**

- https://www.pcisecuritystandards.org/pdfs/15_02_12_PCI_SSC_Bulletin_on_DSS_revisions_SSL_update.pdf
https://www.pcisecuritystandards.org/pdfs/15_03_25_PCI_SSC_FAQ_SSL_Protocol_Vulnerability_Revisions_to_PCI_DSS_PAD.pdf (this should become effective tomorrow in the PCI DSS 3.1 update)
- NIST SP 800-57: Recommendation for Key Management – Part 1: General (Revision 3)
- NIST SP 800-52: Guidelines for the Selection, Configuration, and Use of Transport Layer Security (TLS)
Implementations (Revision 1)
- https://www.trustwave.com/Resources/SpiderLabs-Blog/Bring-Out-Your-Dead--An-Update-on-the-PCI-relevance-of-SSLv3/?page=1&year=0&month=0