### PR TITLE
Fix for MonitorMixin bug that appears after thread death

### DIFF
--- a/lib/monitor.rb
+++ b/lib/monitor.rb
@@ -170,6 +170,7 @@ module MonitorMixin
         return false
       end
       @mon_owner = Thread.current
+      @mon_count = 0
     end
     @mon_count += 1
     return true
@@ -184,6 +185,7 @@ module MonitorMixin
     if @mon_owner != Thread.current
       @mon_mutex.lock
       @mon_owner = Thread.current
+      @mon_count = 0
     end
     @mon_count += 1
   end

--- a/test/monitor/test_monitor.rb
+++ b/test/monitor/test_monitor.rb
@@ -33,6 +33,22 @@ class TestMonitor < Test::Unit::TestCase
     assert_equal((1..10).to_a, ary)
   end
 
+  def test_enter_second_after_killed_thread
+    th = Thread.start {
+      @monitor.enter
+      Thread.current.kill
+      @monitor.exit
+    }
+    th.join
+    @monitor.enter
+    @monitor.exit
+    th2 = Thread.start {
+      @monitor.enter
+      @monitor.exit
+    }
+    assert_join_threads([th, th2])
+  end
+
   def test_synchronize
     ary = []
     queue = Queue.new
@@ -107,6 +123,22 @@ class TestMonitor < Test::Unit::TestCase
       queue1.enq(nil)
       queue2.deq
       assert_equal(true, @monitor.try_enter)
+    }
+    assert_join_threads([th, th2])
+  end
+
+  def test_try_enter_second_after_killed_thread
+    th = Thread.start {
+      assert_equal(true, @monitor.try_enter)
+      Thread.current.kill
+      @monitor.exit
+    }
+    th.join
+    assert_equal(true, @monitor.try_enter)
+    @monitor.exit
+    th2 = Thread.start {
+      assert_equal(true, @monitor.try_enter)
+      @monitor.exit
     }
     assert_join_threads([th, th2])
   end


### PR DESCRIPTION
This fixes the following bug in `MonitorMixin`: if a thread dies in the exclusive section, the next thread to enter will do so successfully, but it will inadvertently hold the lock for the rest of its life, blocking others from entering.

I experienced this bug while using a `Logger` from multiple threads. When using `#synchronize`, as `Logger` does, the bug only appears if the timing is right (if it's a bit later the `ensure` block will clean up properly), but it always appears when using `#enter` or `#try_enter`.

This PR has one commit to add failing tests and one commit to fix the bug and make them pass.

#### Background

A monitor uses a `Mutex` to ensure that 'ownership' is exclusive to one thread. The owner thread can enter multiple times. Once all its entries have a corresponding exit, the monitor unlocks the `Mutex`.

The problem is that the `Mutex` will unlock automatically if the thread that locked it dies, but the `Monitor` does not clear the owner's entry counter if the owner thread dies.

The solution is to reset `@mon_count` every time the lock is obtained by a new owner thread.

#### Bug example

Given a monitor and threads `t1` and `t2`,

1. `t1` enters, gets the lock, is set as `@mon_owner` and increments `@mon_count` to `1`.
2. `t1` dies. `@mon_owner` and `@mon_count` are unchanged, but the lock is released.
3. `t2` enters, gets the lock, is set as `@mon_owner` and increments `@mon_count` to `2`.
4. `t2` exits, decrements `@mon_count` to `1`, remains owner and retains the lock.
5. `t2` has entered once and exited once, but retains the lock for the rest of its life, blocking other threads.

Original code relevant to the example:

    180   #
    181   # Enters exclusive section.
    182   #
    183   def mon_enter
    184     if @mon_owner != Thread.current
    185       @mon_mutex.lock
    186       @mon_owner = Thread.current
    187     end
    188     @mon_count += 1
    189   end
    190
    191   #
    192   # Leaves exclusive section.
    193   #
    194   def mon_exit
    195     mon_check_owner
    196     @mon_count -=1
    197     if @mon_count == 0
    198       @mon_owner = nil
    199       @mon_mutex.unlock
    200     end
    201   end
