### PR TITLE
Adding parens around assignments to get rid of Wparentheses warnings

### DIFF
--- a/ext/etc/etc.c
+++ b/ext/etc/etc.c
@@ -241,7 +241,7 @@ passwd_iterate(void)
     struct passwd *pw;
 
     setpwent();
-    while (pw = getpwent()) {
+    while ((pw = getpwent())) {
 	rb_yield(setup_passwd(pw));
     }
     return Qnil;
@@ -287,7 +287,7 @@ etc_passwd(VALUE obj)
     if (rb_block_given_p()) {
 	each_passwd();
     }
-    else if (pw = getpwent()) {
+    else if ((pw = getpwent())) {
 	return setup_passwd(pw);
     }
 #endif
@@ -369,7 +369,7 @@ etc_getpwent(VALUE obj)
 #ifdef HAVE_GETPWENT
     struct passwd *pw;
 
-    if (pw = getpwent()) {
+    if ((pw = getpwent())) {
 	return setup_passwd(pw);
     }
 #endif
@@ -485,7 +485,7 @@ group_iterate(void)
     struct group *pw;
 
     setgrent();
-    while (pw = getgrent()) {
+    while ((pw = getgrent())) {
 	rb_yield(setup_group(pw));
     }
     return Qnil;
@@ -527,7 +527,7 @@ etc_group(VALUE obj)
     if (rb_block_given_p()) {
 	each_group();
     }
-    else if (grp = getgrent()) {
+    else if ((grp = getgrent())) {
 	return setup_group(grp);
     }
 #endif
@@ -606,7 +606,7 @@ etc_getgrent(VALUE obj)
 #ifdef HAVE_GETGRENT
     struct group *gr;
 
-    if (gr = getgrent()) {
+    if ((gr = getgrent())) {
 	return setup_group(gr);
     }
 #endif

--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -1124,7 +1124,7 @@ ossl_ssl_shutdown(SSL *ssl)
 	     * Ignore the case SSL_shutdown returns -1. Empty handshake_func
 	     * must not happen.
 	     */
-	    if (rc = SSL_shutdown(ssl))
+	    if ((rc = SSL_shutdown(ssl)))
 		break;
 	}
 	SSL_clear(ssl);

--- a/ext/tk/tkutil/tkutil.c
+++ b/ext/tk/tkutil/tkutil.c
@@ -1356,7 +1356,7 @@ cbsubst_sym_to_subst(self, sym)
 
     *(ptr++) = '%';
 
-    if (len = inf->keylen[idx]) {
+    if ((len = inf->keylen[idx])) {
       /* longname */
       strncpy(ptr, inf->key[idx], len);
       ptr += len;
@@ -1426,7 +1426,7 @@ cbsubst_get_subst_arg(argc, argv, self)
 
 	*(ptr++) = '%';
 
-	if (len = inf->keylen[idx]) {
+	if ((len = inf->keylen[idx])) {
 	  /* longname */
 	  strncpy(ptr, inf->key[idx], len);
 	  ptr += len;
@@ -1523,7 +1523,7 @@ cbsubst_get_all_subst_keys(self)
 
       *(ptr++) = '%';
 
-      if (len = inf->keylen[idx]) {
+      if ((len = inf->keylen[idx])) {
 	/* longname */
 	strncpy(ptr, inf->key[idx], len);
 	ptr += len;
@@ -1691,7 +1691,7 @@ cbsubst_scan_args(self, arg_key, val_ary)
       } else if (*(keyptr + idx) == ' ') {
 	proc = Qnil;
       } else {
-	if (type_chr = inf->type[*(keyptr + idx)]) {
+	if ((type_chr = inf->type[*(keyptr + idx)])) {
 	  proc = rb_hash_aref(inf->proc, INT2FIX((int)type_chr));
 	} else {
 	  proc = Qnil;


### PR DESCRIPTION
Clean up warnings clang is emitting.