### PR TITLE
[ci skip] Fix test name

### DIFF
--- a/test/ruby/test_object.rb
+++ b/test/ruby/test_object.rb
@@ -248,7 +248,7 @@ class TestObject < Test::Unit::TestCase
     assert_raise(TypeError) { String(o) }
   end
 
-  def test_check_convert_type
+  def test_convert_array
     o = Object.new
     def o.to_a; 1; end
     assert_raise(TypeError) { Array(o) }


### PR DESCRIPTION
This test case tests not `rb_check_convert_type` but `Kernel#Array`.
If we test `rb_check_convert_type`, `assert_equal([o], Array(o))` should be `assert_equal(nil, Array(o))`.