### PR TITLE
parse.y: add heredoc <<~ syntax (Feature #9098)

### DIFF
--- a/doc/syntax/literals.rdoc
+++ b/doc/syntax/literals.rdoc
@@ -210,6 +210,11 @@ the content.  Note that empty lines and lines consisting solely of literal tabs
 and spaces will be ignored for the purposes of determining indentation, but
 escaped tabs and spaces are considered non-indentation characters.
 
+If both tabs and spaces are used as indentation in the same heredoc,
+tabs are considered as equal to 8 spaces.  If the indentation of the
+least-indented line falls in the middle of a leading tab, only
+indentation to the left of that tab will be removed.
+
 A heredoc allows interpolation and escaped characters.  You may disable
 interpolation and escaping by surrounding the opening identifier with single
 quotes:

--- a/doc/syntax/literals.rdoc
+++ b/doc/syntax/literals.rdoc
@@ -206,8 +206,9 @@ a "squiggly" heredoc, which uses a "~" instead of a "-" after <tt><<</tt>:
     SQUIGGLY_HEREDOC
 
 The indentation of the least-indented line will be removed from each line of
-the content.  Note that empty lines and lines consisting solely of tabs and
-spaces will be ignored for the purposes of determining indentation.
+the content.  Note that empty lines and lines consisting solely of literal tabs
+and spaces will be ignored for the purposes of determining indentation, but
+escaped tabs and spaces are considered non-indentation characters.
 
 A heredoc allows interpolation and escaped characters.  You may disable
 interpolation and escaping by surrounding the opening identifier with single

--- a/doc/syntax/literals.rdoc
+++ b/doc/syntax/literals.rdoc
@@ -206,7 +206,8 @@ a "squiggly" heredoc, which uses a "~" instead of a "-" after <tt><<</tt>:
     SQUIGGLY_HEREDOC
 
 The indentation of the least-indented line will be removed from each line of
-the content.
+the content.  Note that empty lines and lines consisting solely of tabs and
+spaces will be ignored for the purposes of determining indentation.
 
 A heredoc allows interpolation and escaped characters.  You may disable
 interpolation and escaping by surrounding the opening identifier with single

--- a/doc/syntax/literals.rdoc
+++ b/doc/syntax/literals.rdoc
@@ -196,6 +196,18 @@ Note that the while the closing identifier may be indented, the content is
 always treated as if it is flush left.  If you indent the content those spaces
 will appear in the output.
 
+To have indented content as well as an indented closing identifier, you can use
+a "squiggly" heredoc, which uses a "~" instead of a "-" after <tt><<</tt>:
+
+    expected_result = <<~SQUIGGLY_HEREDOC
+      This would contain specially formatted text.
+
+      That might span many lines
+    SQUIGGLY_HEREDOC
+
+The indentation of the least-indented line will be removed from each line of
+the content.
+
 A heredoc allows interpolation and escaped characters.  You may disable
 interpolation and escaping by surrounding the opening identifier with single
 quotes:

--- a/parse.y
+++ b/parse.y
@@ -3947,9 +3947,10 @@ xstring		: tXSTRING_BEG xstring_contents tSTRING_END
 				break;
 			    }
 			}
-			$$ = node;
+			$$ = heredoc_dedent(node);
 		    /*%
-			$$ = dispatch1(xstring_literal, $2);
+			$$ = dispatch1(xstring_literal, 
+				       heredoc_dedent_ripper($2));
 		    %*/
 		    }
 		;

--- a/parse.y
+++ b/parse.y
@@ -6216,16 +6216,16 @@ parser_tokadd_string(struct parser_params *parser,
     } while (0)
 
     while ((c = nextc()) != -1) {
-        if (reading_indentation) {
-            if (c == ' ' || c == '\t') {
-                line_indent++;
-            } else {
-                if (heredoc_indent > line_indent && c != '\r' && c != '\n') {
-                    heredoc_indent = line_indent;
-                }
-                reading_indentation = 0;
-            }
-        }
+	if (reading_indentation) {
+	    if (c == ' ' || c == '\t') {
+		line_indent++;
+	    } else {
+		if (heredoc_indent > line_indent && c != '\r' && c != '\n') {
+		    heredoc_indent = line_indent;
+		}
+		reading_indentation = 0;
+	    }
+	}
 
 	if (paren && c == paren) {
 	    ++*nest;
@@ -6491,7 +6491,6 @@ parser_heredoc_identifier(struct parser_params *parser)
         c = nextc();
         func = STR_FUNC_INDENT | STR_FUNC_DEDENT;
     }
-    
     switch (c) {
       case '\'':
 	func |= str_squote; goto quoted;
@@ -6574,19 +6573,19 @@ parser_heredoc_dedent(struct parser_params *parser, VALUE input)
     
     p = str;
     while (p < end) {
-        for (i = 0; p < end && i < heredoc_indent; i++) {
-            if (*p != ' ' && *p != '\t') break;
-            p++;
-        }
-        for (; p < end && *p != '\r' && *p != '\n'; p++) out_len++;
-        if (p < end && *p == '\r') {
-            out_len++;
-            p++;
-        }
-        if (p < end && *p == '\n') {
-            out_len++;
-            p++;
-        }
+	for (i = 0; p < end && i < heredoc_indent; i++) {
+	    if (*p != ' ' && *p != '\t') break;
+	    p++;
+	}
+	for (; p < end && *p != '\r' && *p != '\n'; p++) out_len++;
+	if (p < end && *p == '\r') {
+	    out_len++;
+	    p++;
+	}
+	if (p < end && *p == '\n') {
+	    out_len++;
+	    p++;
+	}
     }
 
     output = rb_str_new(0, out_len);
@@ -6594,13 +6593,13 @@ parser_heredoc_dedent(struct parser_params *parser, VALUE input)
 
     p = str;
     while (p < end) {
-        for (i = 0; p < end && i < heredoc_indent; i++) {
-            if (*p != ' ' && *p != '\t') break;
-            p++;
-        }
-        while (p < end && *p != '\r' && *p != '\n') *out_p++ = *p++;
-        if (p < end && *p == '\r') *out_p++ = *p++;
-        if (p < end && *p == '\n') *out_p++ = *p++;
+	for (i = 0; p < end && i < heredoc_indent; i++) {
+	    if (*p != ' ' && *p != '\t') break;
+	    p++;
+	}
+	while (p < end && *p != '\r' && *p != '\n') *out_p++ = *p++;
+	if (p < end && *p == '\r') *out_p++ = *p++;
+	if (p < end && *p == '\n') *out_p++ = *p++;
     }
 
     dispose_string(input);

--- a/test/ripper/test_ripper.rb
+++ b/test/ripper/test_ripper.rb
@@ -60,4 +60,37 @@ class TestRipper::Ripper < Test::Unit::TestCase
     assert_predicate @ripper, :yydebug
   end
 
+  def test_squiggly_heredoc
+    assert_equal(Ripper.sexp(<<-eos), Ripper.sexp(<<-eos))
+    <<-eot
+asdf
+    eot
+    eos
+    <<~eot
+      asdf
+    eot
+    eos
+  end
+
+  def test_squiggly_heredoc_with_interpolated_expression
+    sexp1 = Ripper.sexp(<<-eos)
+<<-eot
+a\#{1}z
+eot
+    eos
+
+    sexp2 = Ripper.sexp(<<-eos)
+<<~eot
+  a\#{1}z
+eot
+    eos
+
+    pos = lambda do |s|
+      s.fetch(1).fetch(0).fetch(1).fetch(2).fetch(1).fetch(0).fetch(2)
+    end
+    assert_not_equal pos[sexp1], pos[sexp2]
+    pos[sexp1].clear
+    pos[sexp2].clear
+    assert_equal sexp1, sexp2
+  end
 end if ripper_test

--- a/test/ruby/test_syntax.rb
+++ b/test/ruby/test_syntax.rb
@@ -556,6 +556,26 @@ zy
     eos
   end
 
+  def test_dedented_heredoc_mixing_tab_with_space
+    assert_equal(<<-eos, <<~eos)
+16 spaces
+2 tabs
+    eos
+                16 spaces
+		2 tabs
+    eos
+  end
+
+  def test_dedented_heredoc_with_inconsistent_indentation_preserves_tab
+    assert_equal(<<-eos, <<~eos)
+	2 tabs
+  10 spaces
+    eos
+		2 tabs
+          10 spaces
+    eos
+  end
+
   def test_lineno_after_heredoc
     bug7559 = '[ruby-dev:46737]'
     expected, _, actual = __LINE__, <<eom, __LINE__

--- a/test/ruby/test_syntax.rb
+++ b/test/ruby/test_syntax.rb
@@ -489,6 +489,34 @@ z
     eos
   end
 
+  def test_dedented_heredoc_with_blank_less_indented_line
+    assert_equal("a\n\nb\n", <<~eos)
+    a
+\ \ 
+    b
+    eos
+  end
+
+  def test_dedented_heredoc_with_blank_more_indented_line
+    assert_equal("a\n  \nb\n", <<~eos)
+    a
+\ \ \ \ \ \ 
+    b
+    eos
+  end
+
+  def test_dedented_heredoc_with_empty_line
+    assert_equal(<<-eos, <<~eos)
+This would contain specially formatted text.
+
+That might span many lines
+    eos
+      This would contain specially formatted text.
+
+      That might span many lines
+    eos
+  end
+
   def test_lineno_after_heredoc
     bug7559 = '[ruby-dev:46737]'
     expected, _, actual = __LINE__, <<eom, __LINE__

--- a/test/ruby/test_syntax.rb
+++ b/test/ruby/test_syntax.rb
@@ -535,7 +535,7 @@ That might span many lines
     eos
   end
 
-  def test_dedented_heredoc_with_interpolation
+  def test_dedented_heredoc_with_interpolated_expression
       assert_equal(<<-eos, <<~eos)
  #{1}a
 zy
@@ -543,6 +543,17 @@ zy
   #{1}a
  zy
       eos
+  end
+
+  def test_dedented_heredoc_with_interpolated_string
+    w = ""
+    assert_equal(<<-eos, <<~eos)
+#{w} a
+ zy
+    eos
+ #{w} a
+  zy
+    eos
   end
 
   def test_lineno_after_heredoc

--- a/test/ruby/test_syntax.rb
+++ b/test/ruby/test_syntax.rb
@@ -475,6 +475,20 @@ e"
     assert_equal(expected, actual, "#{Bug7559}: ")
   end
 
+  def test_dedented_heredoc_without_indentation
+    assert_equal(" y\nz\n", <<~eos)
+ y
+z
+    eos
+  end
+
+  def test_dedented_heredoc_with_indentation
+    assert_equal(" a\nb\n", <<~eos)
+     a
+    b
+    eos
+  end
+
   def test_lineno_after_heredoc
     bug7559 = '[ruby-dev:46737]'
     expected, _, actual = __LINE__, <<eom, __LINE__

--- a/test/ruby/test_syntax.rb
+++ b/test/ruby/test_syntax.rb
@@ -490,7 +490,16 @@ z
   end
 
   def test_dedented_heredoc_with_blank_less_indented_line
+    # the blank line has two leading spaces
     assert_equal("a\n\nb\n", <<~eos)
+    a
+  
+    b
+    eos
+  end
+
+  def test_dedented_heredoc_with_blank_less_indented_line_escaped
+    assert_equal("    a\n  \n    b\n", <<~eos)
     a
 \ \ 
     b
@@ -498,7 +507,16 @@ z
   end
 
   def test_dedented_heredoc_with_blank_more_indented_line
+    # the blank line has six leading spaces
     assert_equal("a\n  \nb\n", <<~eos)
+    a
+      
+    b
+    eos
+  end
+
+  def test_dedented_heredoc_with_blank_more_indented_line_escaped
+    assert_equal("    a\n      \n    b\n", <<~eos)
     a
 \ \ \ \ \ \ 
     b

--- a/test/ruby/test_syntax.rb
+++ b/test/ruby/test_syntax.rb
@@ -535,6 +535,16 @@ That might span many lines
     eos
   end
 
+  def test_dedented_heredoc_with_interpolation
+      assert_equal(<<-eos, <<~eos)
+ #{1}a
+zy
+      eos
+  #{1}a
+ zy
+      eos
+  end
+
   def test_lineno_after_heredoc
     bug7559 = '[ruby-dev:46737]'
     expected, _, actual = __LINE__, <<eom, __LINE__


### PR DESCRIPTION
Allows for the use of heredocs which appear nicely indented in ruby source code, but the indentation is removed during parsing.

Original proposal: https://bugs.ruby-lang.org/issues/9098

Uses the syntax suggested by Avdi Grimm (`<<~`), and should have the same semantics as `String#strip_heredoc` from ActiveSupport, that is, the indentation of the least-indented line is removed from each line of the string.

No attempt was made to deal with inconsistent indentation (tabs are considered equal to spaces).

Please let me know if I can improve this patch. Thanks!