### PR TITLE
Add a test case to Kernel#String

### DIFF
--- a/test/ruby/test_object.rb
+++ b/test/ruby/test_object.rb
@@ -244,6 +244,8 @@ class TestObject < Test::Unit::TestCase
     assert_raise(TypeError) { String(o) }
     def o.to_s; "o"; end
     assert_equal("o", String(o))
+    def o.to_str; "O"; end
+    assert_equal("O", String(o))
     def o.respond_to?(*) false; end
     assert_raise(TypeError) { String(o) }
   end


### PR DESCRIPTION
This method first tries to call `to_str`.
So add test checking this behavior.