### PR TITLE
Add Bitrig to rubygems platforms.

### DIFF
--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -95,6 +95,7 @@ class Gem::Platform
                         [os, version]
                       when /netbsdelf/ then             [ 'netbsdelf', nil ]
                       when /openbsd(\d+\.\d+)?/ then    [ 'openbsd',   $1  ]
+                      when /bitrig(\d+\.\d+)?/ then     [ 'bitrig',    $1  ]
                       when /solaris(\d+\.\d+)?/ then    [ 'solaris',   $1  ]
                       # test
                       when /^(\w+_platform)(\d+)?/ then [ $1,          $2  ]


### PR DESCRIPTION
This adds support for Bitrig (a BSD Unix forked from OpenBSD) to rubygems.