### PR TITLE
workaround for MSVC14

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,37 @@
+---
+branches:
+  only:
+    - msvc14
+shallow_clone: true
+platform: x64
+install:
+  - SET
+  - '"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64'
+  - SET PATH=C:\Ruby22-x64\bin;%PATH%
+  - ruby --version
+  - 'cl'
+  - SET
+  - ps: Start-FileDownload 'http://openssl.org/source/openssl-1.0.2d.tar.gz'
+  - 7z x openssl-1.0.2d.tar.gz
+  - 7z x openssl-1.0.2d.tar
+  - cd openssl-1.0.2d
+  - perl Configure VC-WIN64A --prefix=/projects/%APPVEYOR_PROJECT_SLUG% no-asm
+  - ms\do_win64a
+  - nmake -f ms\ntdll.mak
+  - nmake -f ms\ntdll.mak install
+  - cd ..
+  - ps: Start-FileDownload 'http://zlib.net/zlib128.zip'
+  - 7z x zlib128.zip
+  - cd zlib-1.2.8
+  - nmake -f win32/Makefile.msc
+  - move zlib1.dll ..
+  - cd ..
+build_script:
+  - cd %APPVEYOR_BUILD_FOLDER%
+  - win32\configure.bat --with-opt-dir=/projects/%APPVEYOR_PROJECT_SLUG% --with-zlib-include=/projects/%APPVEYOR_PROJECT_SLUG%/zlib-1.2.8 --with-zlib-lib=/projects/%APPVEYOR_PROJECT_SLUG%/zlib-1.2.8
+  - nmake up
+  - nmake
+test_script:
+  - nmake btest
+  - nmake test
+  - nmake RUBYOPT=-w TESTS="-v -j 2" test-all

--- a/win32/mkexports.rb
+++ b/win32/mkexports.rb
@@ -114,6 +114,7 @@ class Exports::Mswin < Exports
         when /OBJECT/, /LIBRARY/
           next if /^[[:xdigit:]]+ 0+ UNDEF / =~ l
           next unless /External/ =~ l
+          next if /(?:_local_stdio_printf_options|v(f|sn?)printf_l)\Z/ =~ l
           next unless l.sub!(/.*?\s(\(\)\s+)?External\s+\|\s+/, '')
           is_data = !$1
           if noprefix or /^[@_]/ =~ l

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -2321,6 +2321,21 @@ typedef struct {
 #endif
 
 /* License: Ruby's */
+#if RUBY_MSVCRT_VERSION >= 140
+typedef struct {
+    CRITICAL_SECTION           lock;
+    intptr_t                   osfhnd;          // underlying OS file HANDLE
+    __int64                    startpos;        // File position that matches buffer start
+    unsigned char              osfile;          // Attributes of file (e.g., open in text mode?)
+    char      textmode;
+    char _pipe_lookahead;
+
+    uint8_t unicode          : 1; // Was the file opened as unicode?
+    uint8_t utf8translations : 1; // Buffer contains translations other than CRLF
+    uint8_t dbcsBufferUsed   : 1; // Is the dbcsBuffer in use?
+    char    dbcsBuffer;           // Buffer for the lead byte of DBCS when converting from DBCS to Unicode
+} ioinfo;
+#else
 typedef struct	{
     intptr_t osfhnd;	/* underlying OS file HANDLE */
     char osfile;	/* attributes of file (e.g., open in text mode?) */
@@ -2332,16 +2347,21 @@ typedef struct	{
     char pipech2[2];
 #endif
 }	ioinfo;
+#endif
 
 #if !defined _CRTIMP || defined __MINGW32__
 #undef _CRTIMP
 #define _CRTIMP __declspec(dllimport)
 #endif
 
+#if RUBY_MSVCRT_VERSION >= 140
+static ioinfo ** __pioinfo = NULL;
+#else
 EXTERN_C _CRTIMP ioinfo * __pioinfo[];
+#endif
 static inline ioinfo* _pioinfo(int);
 
-#define IOINFO_L2E			5
+#define IOINFO_L2E	(RUBY_MSVCRT_VERSION >= 140 ? 6 : 5)
 #define IOINFO_ARRAY_ELTS	(1 << IOINFO_L2E)
 #define _osfhnd(i)  (_pioinfo(i)->osfhnd)
 #define _osfile(i)  (_pioinfo(i)->osfile)
@@ -2356,6 +2376,12 @@ static size_t pioinfo_extra = 0;	/* workaround for VC++8 SP1 */
 static void
 set_pioinfo_extra(void)
 {
+#if RUBY_MSVCRT_VERSION >= 140
+    HMODULE mod = GetModuleHandle("ucrtbase.dll");
+    FARPROC addr = GetProcAddress(mod, "_isatty");
+    intptr_t delta = 0xc07b0; /* __pioinfo - _isatty() */
+    __pioinfo = (ioinfo**)((intptr_t)addr + delta);
+#else
     int fd;
 
     fd = _open("NUL", O_RDONLY);
@@ -2370,6 +2396,7 @@ set_pioinfo_extra(void)
 	/* not found, maybe something wrong... */
 	pioinfo_extra = 0;
     }
+#endif
 }
 #else
 #define pioinfo_extra 0


### PR DESCRIPTION
This is not intended to merge but show a workaround.

Additionally how hard shadowing __pioinfo is for cruby.

https://bugs.ruby-lang.org/issues/11118
