### PR TITLE
[DOC] Added documentation for rational literal

### DIFF
--- a/rational.c
+++ b/rational.c
@@ -2465,13 +2465,14 @@ nurat_s_convert(int argc, VALUE *argv, VALUE klass)
  * a/b (b>0).  Where a is numerator and b is denominator.  Integer a
  * equals rational a/1 mathematically.
  *
- * In ruby, you can create rational object with Rational, to_r or
- * rationalize method.  The return values will be irreducible.
+ * In ruby, you can create rational object with Rational, to_r, 
+ * rationalize method or suffixing r to a literal.  The return values will be irreducible.
  *
  *    Rational(1)      #=> (1/1)
  *    Rational(2, 3)   #=> (2/3)
  *    Rational(4, -6)  #=> (-2/3)
  *    3.to_r           #=> (3/1)
+ *    2/3r             #=> (2/3)
  *
  * You can also create rational object from floating-point numbers or
  * strings.


### PR DESCRIPTION
[Bug #11075] (https://bugs.ruby-lang.org/issues/11075) mentioned that the rational literal was undocumented. This is my first PR to Ruby so please let me know if I am not following any conventions.