### PR TITLE
Remove warning for private attributes

### DIFF
--- a/vm_method.c
+++ b/vm_method.c
@@ -917,9 +917,11 @@ rb_attr(VALUE klass, ID id, int read, int write, int ex)
     else {
 	if (SCOPE_TEST(NOEX_PRIVATE)) {
 	    noex = NOEX_PRIVATE;
-	    rb_warning((SCOPE_CHECK(NOEX_MODFUNC)) ?
-		       "attribute accessor as module_function" :
-		       "private attribute?");
+      rb_warning(
+          if(SCOPE_CHECK(NOEX_MODFUNC)) {
+              "attribute accessor as module_function"
+          }
+      );
 	}
 	else if (SCOPE_TEST(NOEX_PROTECTED)) {
 	    noex = NOEX_PROTECTED;


### PR DESCRIPTION
Even thought this warning makes sense at first sight, there are actually
valid use cases for private attributes. So much so that Sandi Metz
advocates for it in her "Practical Object-Oriented Design in Ruby".

I'm not advocating for or against the usage of private accessors, but I
don't think we should raise a warning when someone uses them.