### PR TITLE
Set SSLContext default parameters to the Ruby defaults

### DIFF
--- a/ext/openssl/lib/openssl/ssl.rb
+++ b/ext/openssl/lib/openssl/ssl.rb
@@ -74,6 +74,10 @@ module OpenSSL
         DEFAULT_CERT_STORE.flags = OpenSSL::X509::V_FLAG_CRL_CHECK_ALL
       end
 
+      def initialize
+        set_params
+      end
+
       ##
       # Sets the parameters for this SSL context to the values in +params+.
       # The keys in +params+ must be assignment methods on SSLContext.

--- a/test/openssl/test_ssl.rb
+++ b/test/openssl/test_ssl.rb
@@ -332,6 +332,8 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
     start_server(OpenSSL::SSL::VERIFY_NONE, true, :ignore_listener_error => true){|server, port|
       sock = TCPSocket.new("127.0.0.1", port)
       ctx = OpenSSL::SSL::SSLContext.new
+      assert_equal(OpenSSL::SSL::VERIFY_PEER, ctx.verify_mode)
+      assert_equal(OpenSSL::SSL::SSLContext::DEFAULT_PARAMS[:options], ctx.options)
       ctx.set_params
       assert_equal(OpenSSL::SSL::VERIFY_PEER, ctx.verify_mode)
       assert_equal(OpenSSL::SSL::SSLContext::DEFAULT_PARAMS[:options], ctx.options)


### PR DESCRIPTION
This was mentioned in:

https://bugs.ruby-lang.org/issues/9424#note-64

This change will set the defaults of a new SSLContext to those defined in `DEFAULT_PARAMS`. 

Clients such as `Net::SMTP` call `default_ssl_context`, which initializes a `SSLContext`. If `set_params` is not called, all the values will remain nil, and OpenSSL may not set them at all to anything. This can lead to issues with certificate stores not being set properly.