### PR TITLE
Clarifies Array#reject! documentation

### DIFF
--- a/array.c
+++ b/array.c
@@ -3168,8 +3168,8 @@ ary_reject_bang(VALUE ary)
  *     ary.reject! { |item| block }  -> ary or nil
  *     ary.reject!                   -> Enumerator
  *
- *  Equivalent to Array#delete_if, deleting elements from +self+ for which the
- *  block evaluates to +true+, but returns +nil+ if no changes were made.
+ *  Deletes every element of +self+ for which the block evaluates to +true+,
+ *  if no changes were made returns +nil+.
  *
  *  The array may not be changed instantly every time the block is called.
  *


### PR DESCRIPTION
The key difference between `Array#reject!` and `Array#delete_if` (apart from mutating `self`) is the return value when the given block always evaluates `false`.

Also, leading the documentation with "Equivalent to Array#delete_if" was distracting and perhaps redundant with the "See also" section.