### PR TITLE
Don't interrupt the living main thread when a last sub-thread exits.

### DIFF
--- a/thread.c
+++ b/thread.c
@@ -629,7 +629,7 @@ thread_start_func_2(rb_thread_t *th, VALUE *stack_start, VALUE *register_stack_s
 
 	/* delete self other than main thread from living_threads */
 	rb_vm_living_threads_remove(th->vm, th);
-	if (rb_thread_alone()) {
+	if (main_th->status == THREAD_KILLED && rb_thread_alone()) {
 	    /* I'm last thread. wake up main thread from rb_thread_terminate_all */
 	    rb_threadptr_interrupt(main_th);
 	}


### PR DESCRIPTION
An un-blocking function passed to `rb_thread_call_without_gvl()` is involuntarily fired when a sub-thread exits and the main thread become only live thread.
This causes accidental interruption in native extension libraries.

This pull request fixes the issue and is tested by the test code in https://github.com/kubo/ruby-oci8/issues/74#issuecomment-100638168.
