### PR TITLE
Fix typo (wich -> which) in ccan/list/list.h [skip ci]

### DIFF
--- a/ccan/list/list.h
+++ b/ccan/list/list.h
@@ -639,7 +639,7 @@ static inline void list_prepend_list_(struct list_head *to,
 /**
  * list_for_each_off - iterate through a list of memory regions.
  * @h: the list_head
- * @i: the pointer to a memory region wich contains list node data.
+ * @i: the pointer to a memory region which contains list node data.
  * @off: offset(relative to @i) at which list node data resides.
  *
  * This is a low-level wrapper to iterate @i over the entire list, used to
@@ -671,7 +671,7 @@ static inline void list_prepend_list_(struct list_head *to,
 /**
  * list_for_each_rev_off - iterate through a list of memory regions backwards
  * @h: the list_head
- * @i: the pointer to a memory region wich contains list node data.
+ * @i: the pointer to a memory region which contains list node data.
  * @off: offset(relative to @i) at which list node data resides.
  *
  * See list_for_each_off for details
@@ -683,7 +683,7 @@ static inline void list_prepend_list_(struct list_head *to,
  * list_for_each_safe_off - iterate through a list of memory regions, maybe
  * during deletion
  * @h: the list_head
- * @i: the pointer to a memory region wich contains list node data.
+ * @i: the pointer to a memory region which contains list node data.
  * @nxt: the structure containing the list_node
  * @off: offset(relative to @i) at which list node data resides.
  *
@@ -702,7 +702,7 @@ static inline void list_prepend_list_(struct list_head *to,
  * list_for_each_rev_safe_off - iterate backwards through a list of
  * memory regions, maybe during deletion
  * @h: the list_head
- * @i: the pointer to a memory region wich contains list node data.
+ * @i: the pointer to a memory region which contains list node data.
  * @nxt: the structure containing the list_node
  * @off: offset(relative to @i) at which list node data resides.
  *


### PR DESCRIPTION
:cat: 