### PR TITLE
Fix typo [ci skip]

### DIFF
--- a/enum.c
+++ b/enum.c
@@ -1700,7 +1700,7 @@ minmax_ii(RB_BLOCK_CALL_FUNC_ARGLIST(i, _memo))
  *     enum.minmax                  -> [min, max]
  *     enum.minmax { |a, b| block } -> [min, max]
  *
- *  Returns two elements array which contains the minimum and the
+ *  Returns a two element array which contains the minimum and the
  *  maximum value in the enumerable.  The first form assumes all
  *  objects implement <code>Comparable</code>; the second uses the
  *  block to return <em>a <=> b</em>.


### PR DESCRIPTION
This is a grammar fix. It should read 'Returns a two element array', like line 1979 of the same file.