### PR TITLE
Line Directive Patch

### DIFF
--- a/KNOWNBUGS.rb
+++ b/KNOWNBUGS.rb
@@ -8,8 +8,11 @@
 
 assert_equal "ArgumentError", %{
   def s(a) yield a; end
+  def raz
+    raise ArgumentError;
+  end
   begin
-    s([1, 2], &lambda { |a,b| [a,b] })
+    s([1, 2], &lambda { |a,b=raz| [a,b] })
   rescue ArgumentError => e
     e.class
   end

--- a/ext/objspace/objspace.c
+++ b/ext/objspace/objspace.c
@@ -495,6 +495,7 @@ count_nodes(int argc, VALUE *argv, VALUE os)
 		COUNT_NODE(NODE_ATTRASGN);
 		COUNT_NODE(NODE_PRELUDE);
 		COUNT_NODE(NODE_LAMBDA);
+		COUNT_NODE(NODE_FILES);
 #undef COUNT_NODE
 	      default: node = INT2FIX(i);
 	    }

--- a/include/ruby/ruby.h
+++ b/include/ruby/ruby.h
@@ -563,7 +563,7 @@ volatile VALUE *rb_gc_guarded_ptr_val(volatile VALUE *ptr, VALUE val);
 #endif
 
 #ifndef FILE_CNT_BITS
-  #define FILE_CNT_BITS 4
+  #define FILE_CNT_BITS 8
 #endif
 
 void rb_check_type(VALUE,int);

--- a/include/ruby/ruby.h
+++ b/include/ruby/ruby.h
@@ -562,6 +562,10 @@ volatile VALUE *rb_gc_guarded_ptr_val(volatile VALUE *ptr, VALUE val);
 #define RB_UNUSED_VAR(x) x
 #endif
 
+#ifndef FILE_CNT_BITS
+  #define FILE_CNT_BITS 4
+#endif
+
 void rb_check_type(VALUE,int);
 #define Check_Type(v,t) rb_check_type((VALUE)(v),(t))
 

--- a/node.c
+++ b/node.c
@@ -996,6 +996,10 @@ dump_node(VALUE buf, VALUE indent, int comment, NODE *node)
 	F_NODE(nd_body, "body");
 	break;
 
+      case NODE_FILES:
+	ANN("filenames array");
+        break;
+
       default:
 	rb_bug("dump_node: unknown node: %s", ruby_node_name(nd_type(node)));
     }

--- a/node.h
+++ b/node.h
@@ -228,6 +228,8 @@ enum node_type {
 #define NODE_PRELUDE     NODE_PRELUDE
     NODE_LAMBDA,
 #define NODE_LAMBDA      NODE_LAMBDA
+    NODE_FILES,
+#define NODE_FILES       NODE_FILES
     NODE_LAST
 #define NODE_LAST        NODE_LAST
 };
@@ -453,6 +455,7 @@ typedef struct RNode {
 #define NEW_BMETHOD(b) NEW_NODE(NODE_BMETHOD,0,0,b)
 #define NEW_ATTRASGN(r,m,a) NEW_NODE(NODE_ATTRASGN,r,m,a)
 #define NEW_PRELUDE(p,b,o) NEW_NODE(NODE_PRELUDE,p,b,o)
+#define NEW_FILES(a) NEW_NODE(NODE_FILES,a,0,0)
 
 RUBY_SYMBOL_EXPORT_BEGIN
 
@@ -516,5 +519,7 @@ RUBY_SYMBOL_EXPORT_END
 #endif
 }  /* extern "C" { */
 #endif
+
+#define FILE_CNT_MAX 10
 
 #endif /* RUBY_NODE_H */

--- a/parse.y
+++ b/parse.y
@@ -390,6 +390,9 @@ static int parser_yyerror(struct parser_params*, const char*);
 # define disp_ruby_sourcefile   ((ruby_sourceline >> FILE_LINE_BITS) ? \
                                 RSTRING_PTR(rb_ary_entry(ruby_sourcefile_array, (ruby_sourceline >> FILE_LINE_BITS))) : \
                                 ruby_sourcefile)
+# define disp_ruby_sourcefile_string   ((ruby_sourceline >> FILE_LINE_BITS) ? \
+                                rb_ary_entry(ruby_sourcefile_array, (ruby_sourceline >> FILE_LINE_BITS)) : \
+                                ruby_sourcefile_string)
 # define disp_ruby_sourcefile_line(line) \
                                 (((line) >> FILE_LINE_BITS) ? \
                                 RSTRING_PTR(rb_ary_entry(ruby_sourcefile_array, ((line) >> FILE_LINE_BITS))) : \
@@ -11012,8 +11015,8 @@ parser_compile_error(struct parser_params *parser, const char *fmt, ...)
     va_start(ap, fmt);
     parser->error_buffer =
 	rb_syntax_error_append(parser->error_buffer,
-			       ruby_sourcefile_string,
-			       ruby_sourceline,
+			       disp_ruby_sourcefile_string,
+			       disp_ruby_sourceline,
 			       rb_long2int(lex_p - lex_pbeg),
 			       current_enc, fmt, ap);
     va_end(ap);

--- a/parse.y
+++ b/parse.y
@@ -868,7 +868,7 @@ static void ripper_compile_error(struct parser_params*, const char *fmt, ...);
 # define WARN_I(i) i
 # define PRIsWARN PRIsVALUE
 # define WARN_ARGS(fmt,n) WARN_ARGS_L(ruby_sourceline,fmt,n)
-# define WARN_ARGS_L(l,fmt,n) ruby_sourcefile, (l), (fmt)
+# define WARN_ARGS_L(l,fmt,n) disp_ruby_sourcefile, (FIX_LINE(l)), (fmt)
 # define WARN_CALL rb_compile_warn
 # define WARNING_ARGS(fmt,n) WARN_ARGS(fmt,n)
 # define WARNING_ARGS_L(l,fmt,n) WARN_ARGS_L(l,fmt,n)
@@ -6874,7 +6874,7 @@ parser_get_bool(struct parser_params *parser, const char *name, const char *val)
 	}
 	break;
     }
-    rb_compile_warning(ruby_sourcefile, ruby_sourceline, "invalid value for %s: %s", name, val);
+    rb_compile_warning(disp_ruby_sourcefile, disp_ruby_sourceline, "invalid value for %s: %s", name, val);
     return -1;
 }
 
@@ -8615,14 +8615,14 @@ fixpos(NODE *node, NODE *orig)
 static void
 parser_warning(struct parser_params *parser, NODE *node, const char *mesg)
 {
-    rb_compile_warning(ruby_sourcefile, nd_line(node), "%s", mesg);
+    rb_compile_warning(disp_ruby_sourcefile, FIX_LINE(nd_line(node)), "%s", mesg);
 }
 #define parser_warning(node, mesg) parser_warning(parser, (node), (mesg))
 
 static void
 parser_warn(struct parser_params *parser, NODE *node, const char *mesg)
 {
-    rb_compile_warn(ruby_sourcefile, nd_line(node), "%s", mesg);
+    rb_compile_warn(disp_ruby_sourcefile, FIX_LINE(nd_line(node)), "%s", mesg);
 }
 #define parser_warn(node, mesg) parser_warn(parser, (node), (mesg))
 
@@ -10072,7 +10072,7 @@ remove_duplicate_keys(struct parser_params *parser, NODE *hash)
 	st_data_t data;
 	if (nd_type(head) == NODE_LIT &&
 	    st_lookup(literal_keys, (key = head->nd_lit), &data)) {
-	    rb_compile_warn(ruby_sourcefile, nd_line((NODE *)data),
+	    rb_compile_warn(disp_ruby_sourcefile, FIX_LINE(nd_line((NODE *)data)),
 			    "key %+"PRIsVALUE" is duplicated and overwritten on line %d",
 			    head->nd_lit, nd_line(head));
 	    head = ((NODE *)data)->nd_next;

--- a/test/ruby/test_magic_line.rb
+++ b/test/ruby/test_magic_line.rb
@@ -26,20 +26,85 @@ class TestMagicLine < Test::Unit::TestCase
 
   def test_unused_variable_with_line_file
     o = Object.new
-    assert_warning(/assigned but unused variable/) {o.instance_eval("def foo; a=1; nil; end")}
-    a = "\u{3042}"
+    assert_warning(/\(eval\):1:/) {o.instance_eval("def foo; a=1; nil; end")}
+    o = Object.new
     assert_warning(/bob:100:/) {
-      o.instance_eval("# -*- line: bob 100 -*-\ndef foo; #{a}=1; nil; end")
+      o.instance_eval("# -*- line: bob 100 -*-\ndef foo; a=1; nil; end")
     }
+  end
+
+  def test_compile_error_line
+    o = Object.new
+    out, err = capture_io do
+       begin
+         o.instance_eval("def foo; a=1 nil; end")
+       rescue Exception => error
+         assert_match(/^.eval.:1: syntax error/, error.message);
+       else
+         assert(false, 'no exception');
+       end
+    end
+    o = Object.new
+    out, err = capture_io do
+       begin
+         o.instance_eval("# -*- line: 100 -*-\ndef foo; a=1 nil; end")
+       rescue Exception => error
+         assert_match("(eval):100: syntax error", error.message);
+       else
+         assert(false, 'no exception');
+       end
+    end
+    o = Object.new
+    out, err = capture_io do
+       begin
+         o.instance_eval("# -*- line: joe.rb 100 -*-\ndef foo; a=1 nil; end")
+       rescue Exception => error
+         assert_match("joe.rb:100: syntax error", error.message);
+       else
+         assert(false, 'no exception');
+       end
+    end
   end
 
   def test_line_exception_out
     Tempfile.create(["test_ruby_test_magicline", ".rb"]) {|t|
-      err = ["bob.rb:100:in `<main>': Error: bob.rb:100: (RuntimeError)"]
+      t.puts "# "
+      t.puts "# "
+      t.puts "raise 'Error: #{t.path}:100:'"
+      t.flush
+      err = ["#{t.path}:3:in `<main>': Error: #{t.path}:100: (RuntimeError)"]
+      assert_in_out_err(["-w", t.path], "", [], err)
+
+      t.rewind
       t.puts "# -*- line: bob.rb 100 -*-"
       t.puts "raise 'Error: bob.rb:100:'"
+      t.puts "__END__"
       t.flush
-      assert_in_out_err(["-w", t.path], "", [], err, '[ruby-core:25442]')
+      err = ["bob.rb:100:in `<main>': Error: bob.rb:100: (RuntimeError)"]
+      assert_in_out_err(["-w", t.path], "", [], err)
+
+      t.rewind
+      t.puts "# -*- line: bill.rb 100 -*-"
+      t.puts "# empty line"
+      t.puts "raise 'Error: bill.rb:101:'"
+      t.puts "__END__"
+      t.flush
+      err = ["bill.rb:101:in `<main>': Error: bill.rb:101: (RuntimeError)"]
+      assert_in_out_err(["-w", t.path], "", [], err)
+    }
+  end
+
+  def test_line_warning_out
+    Tempfile.create(["test_ruby_test_magicline", ".rb"]) {|t|
+      t.rewind
+      t.puts "# -*- line: bill.rb 100 -*-"
+      t.puts "def foo; a=1; nil; end"
+      t.puts "__END__"
+      t.flush
+      err = ["bill.rb:100: warning: assigned but unused variable - a"]
+      assert_in_out_err(["-w", t.path], "", [], err)
+
+      t.rewind
     }
   end
 
@@ -65,6 +130,74 @@ ensure
   untrace_var :$x
 end
     EOF
+  end
+
+  # test message from parser_set_compile_option_flag
+  def test_frozen_string_literal
+    Tempfile.create(["test_ruby_test_rubyoption", ".rb"]) {|t|
+      t.puts "# "
+      t.puts "# -*- frozen-string-literal: notbool -*-"
+      t.puts "__END__"
+      t.flush
+      err = ["#{t.path}:2: warning: invalid value for frozen_string_literal: notbool"]
+      assert_in_out_err(["-w", t.path], "", [], err)
+      assert_in_out_err(["-wr", t.path, "-e", ""], "", [], err)
+
+      t.rewind
+      t.puts "# -*- line: 100 -*-"
+      t.puts "# -*- frozen-string-literal: notbool -*-"
+      t.puts "__END__"
+      t.flush
+      err = ["#{t.path}:100: warning: invalid value for frozen_string_literal: notbool"]
+      assert_in_out_err(["-w", t.path], "", [], err)
+      assert_in_out_err(["-wr", t.path, "-e", ""], "", [], err)
+
+      t.rewind
+      t.puts "# -*- line: annette 100 -*-"
+      t.puts "# -*- frozen-string-literal: notbool -*-"
+      t.puts "__END__"
+      t.flush
+      err = ["annette:100: warning: invalid value for frozen_string_literal: notbool"]
+      assert_in_out_err(["-w", t.path], "", [], err)
+      assert_in_out_err(["-wr", t.path, "-e", ""], "", [], err)
+    }
+  end
+
+  # test parser_set_token_info
+  def test_indentation_check
+    Tempfile.create(["test_ruby_test_rubyoption", ".rb"]) {|t|
+      t.puts "# "
+      t.puts "# -*- warn-indent: bill -*-"
+      t.puts "begin"
+      t.puts "end"
+      t.puts "__END__"
+      t.flush
+      err = ["#{t.path}:2: warning: invalid value for warn_indent: bill"]
+      assert_in_out_err(["-w", t.path], "", [], err)
+      assert_in_out_err(["-wr", t.path, "-e", ""], "", [], err)
+
+      t.rewind
+      t.puts "# -*- line: 100 -*-"
+      t.puts "# -*- warn-indent: bill -*-"
+      t.puts "begin"
+      t.puts "end"
+      t.puts "__END__"
+      t.flush
+      err = ["#{t.path}:100: warning: invalid value for warn_indent: bill"]
+      assert_in_out_err(["-w", t.path], "", [], err)
+      assert_in_out_err(["-wr", t.path, "-e", ""], "", [], err)
+
+      t.rewind
+      t.puts "# -*- line: annette 100 -*-"
+      t.puts "# -*- warn-indent: bill -*-"
+      t.puts "begin"
+      t.puts "end"
+      t.puts "__END__"
+      t.flush
+      err = ["annette:100: warning: invalid value for warn_indent: bill"]
+      assert_in_out_err(["-w", t.path], "", [], err)
+      assert_in_out_err(["-wr", t.path, "-e", ""], "", [], err)
+    }
   end
 
 end

--- a/test/ruby/test_magic_line.rb
+++ b/test/ruby/test_magic_line.rb
@@ -1,0 +1,70 @@
+# coding: US-ASCII
+require 'test/unit'
+require 'stringio'
+
+require 'tmpdir'
+require 'tempfile'
+
+class TestMagicLine < Test::Unit::TestCase
+  def setup
+    @verbose = $VERBOSE
+    $VERBOSE = nil
+  end
+
+  def teardown
+    $VERBOSE = @verbose
+  end
+
+  def test_unused_variable_with_line
+    o = Object.new
+    assert_warning(/assigned but unused variable/) {o.instance_eval("def foo; a=1; nil; end")}
+    a = "\u{3042}"
+    assert_warning(/:100:/) {
+      o.instance_eval("# -*- line: 100 -*-\ndef foo; #{a}=1; nil; end")
+    }
+  end
+
+  def test_unused_variable_with_line_file
+    o = Object.new
+    assert_warning(/assigned but unused variable/) {o.instance_eval("def foo; a=1; nil; end")}
+    a = "\u{3042}"
+    assert_warning(/bob:100:/) {
+      o.instance_eval("# -*- line: bob 100 -*-\ndef foo; #{a}=1; nil; end")
+    }
+  end
+
+  def test_line_exception_out
+    Tempfile.create(["test_ruby_test_magicline", ".rb"]) {|t|
+      err = ["bob.rb:100:in `<main>': Error: bob.rb:100: (RuntimeError)"]
+      t.puts "# -*- line: bob.rb 100 -*-"
+      t.puts "raise 'Error: bob.rb:100:'"
+      t.flush
+      assert_in_out_err(["-w", t.path], "", [], err, '[ruby-core:25442]')
+    }
+  end
+
+  def test_thread_backtrace_location
+    eval <<-'EOF', nil, __FILE__, __LINE__
+      # -*- line: bob.rb 100 -*-
+      l = caller_locations(0)[0];
+      assert_equal('bob.rb', l.path);
+      assert_equal(100, l.lineno);
+    EOF
+  end
+
+  def test_trace_string
+      eval <<-'EOF', nil, __FILE__, __LINE__
+begin
+  $x = 1
+  trace_var :$x, "# -*- line: trace 1 -*-
+$y = :bar; raise 'HI'"
+  $x = 42
+rescue => error
+  assert_equal("trace:1:in `test_trace_string'", error.backtrace_locations[0].to_s);
+ensure
+  untrace_var :$x
+end
+    EOF
+  end
+
+end

--- a/test/ruby/test_magic_line.rb
+++ b/test/ruby/test_magic_line.rb
@@ -33,6 +33,19 @@ class TestMagicLine < Test::Unit::TestCase
     }
   end
 
+  def test_compile_error_line_eof
+    o = Object.new
+    out, err = capture_io do
+       begin
+         o.instance_eval("# -*- line: test.rb 100 -*-\ndef foo; a=<<EOF; end")
+       rescue Exception => error
+         assert_match(/^test.rb:100: syntax error/, error.message);
+       else
+         assert(false, 'no exception');
+       end
+    end
+  end
+
   def test_compile_error_line
     o = Object.new
     out, err = capture_io do

--- a/test/ruby/test_parse.rb
+++ b/test/ruby/test_parse.rb
@@ -964,3 +964,4 @@ x = __ENCODING__
   end
 =end
 end
+

--- a/vm.c
+++ b/vm.c
@@ -1210,7 +1210,7 @@ rb_sourcefilename(void)
     rb_control_frame_t *cfp = rb_vm_get_ruby_level_next_cfp(th, th->cfp);
 
     if (cfp) {
-	return cfp->iseq->body->location.path;
+	return rb_vm_get_sourcefilename(cfp);
     }
     else {
 	return Qnil;
@@ -1224,7 +1224,7 @@ rb_sourcefile(void)
     rb_control_frame_t *cfp = rb_vm_get_ruby_level_next_cfp(th, th->cfp);
 
     if (cfp) {
-	return RSTRING_PTR(cfp->iseq->body->location.path);
+	return RSTRING_PTR(rb_vm_get_sourcefilename(cfp));
     }
     else {
 	return 0;

--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -46,7 +46,7 @@ rb_vm_get_sourcefilename(const rb_control_frame_t *cfp)
     if (TYPE(cfp->iseq->body->location.path_array) == T_ARRAY) {
 	unsigned int idx = 0;
 	const rb_iseq_t *iseq = cfp->iseq;
-	if (RUBY_VM_NORMAL_ISEQ_P(iseq)) {
+	if (VM_FRAME_RUBYFRAME_P(cfp) && cfp->iseq) {
 	    idx = calc_lineno(cfp->iseq, cfp->pc) >> FILE_LINE_BITS;
 	}
 	file = rb_ary_entry(cfp->iseq->body->location.path_array, idx);

--- a/vm_core.h
+++ b/vm_core.h
@@ -267,6 +267,7 @@ typedef struct rb_iseq_location_struct {
     VALUE base_label;
     VALUE label;
     VALUE first_lineno; /* TODO: may be unsigned short */
+    const VALUE path_array;
 } rb_iseq_location_t;
 
 struct rb_iseq_constant_body {
@@ -1465,6 +1466,7 @@ typedef int rb_backtrace_iter_func(void *, VALUE, int, VALUE);
 rb_control_frame_t *rb_vm_get_ruby_level_next_cfp(const rb_thread_t *th, const rb_control_frame_t *cfp);
 rb_control_frame_t *rb_vm_get_binding_creatable_next_cfp(const rb_thread_t *th, const rb_control_frame_t *cfp);
 int rb_vm_get_sourceline(const rb_control_frame_t *);
+VALUE rb_vm_get_sourcefilename(const rb_control_frame_t *cfp);
 VALUE rb_name_err_mesg_new(VALUE mesg, VALUE recv, VALUE method);
 void rb_vm_stack_to_heap(rb_thread_t *th);
 void ruby_thread_init_stack(rb_thread_t *th);

--- a/vm_core.h
+++ b/vm_core.h
@@ -267,7 +267,7 @@ typedef struct rb_iseq_location_struct {
     VALUE base_label;
     VALUE label;
     VALUE first_lineno; /* TODO: may be unsigned short */
-    const VALUE path_array;
+    VALUE path_array;
 } rb_iseq_location_t;
 
 struct rb_iseq_constant_body {


### PR DESCRIPTION
Add a **line directive** to Ruby

```
  # -*- line: [filename] {line}  -*-
```

The filename is parsed by the _standard_ magic comment code.  if only one argument is passes it is assumed to be a line number.  If there is a parse error or the line number evaluates to 0, the directive is ignored.

This is done by creating a array of filenames and using the upper bits of the line_number to determine the current filename.  The original filename is in position 0.

An extra node is added by the parser that informs the compiler of the filenames so the backtrace code can follow it.

The **__LINE__** and **__FILE__** _constants_ are updated and compile time warnings are also effected.

https://bugs.ruby-lang.org/issues/11181
