### PR TITLE
Check ruby_current_thread in cont_free

### DIFF
--- a/cont.c
+++ b/cont.c
@@ -237,7 +237,7 @@ cont_free(void *ptr)
 	    /* fiber */
 	    rb_fiber_t *fib = (rb_fiber_t*)cont;
 #ifdef _WIN32
-	    if (GET_THREAD()->fiber != fib && cont->type != ROOT_FIBER_CONTEXT) {
+	    if (GET_THREAD() && GET_THREAD()->fiber != fib && cont->type != ROOT_FIBER_CONTEXT) {
 		/* don't delete root fiber handle */
 		rb_fiber_t *fib = (rb_fiber_t*)cont;
 		if (fib->fib_handle) {
@@ -245,7 +245,7 @@ cont_free(void *ptr)
 		}
 	    }
 #else /* not WIN32 */
-	    if (GET_THREAD()->fiber != fib) {
+	    if (GET_THREAD() && GET_THREAD()->fiber != fib) {
                 rb_fiber_t *fib = (rb_fiber_t*)cont;
                 if (fib->ss_sp) {
                     if (cont->type == ROOT_FIBER_CONTEXT) {


### PR DESCRIPTION
We're running into an occasional segfault in Shopify production on Ruby 2.1.6 with the following stack trace:
```
(gdb) where
#0  rb_vm_bugreport () at vm_dump.c:775
#1  0x00007f31db6b0553 in report_bug (file=file@entry=0x0, line=<optimized out>, fmt=fmt@entry=0x7f31db8b1ccc "Segmentation fault at %p", args=args@entry=0x7f31dcaa5848) at error.c:312
#2  0x00007f31db6b1733 in rb_bug (fmt=fmt@entry=0x7f31db8b1ccc "Segmentation fault at %p") at error.c:339
#3  0x00007f31db79f51e in sigsegv (sig=<optimized out>, info=0x7f31dcaa5ab0, ctx=0x7f31dcaa5980) at signal.c:828
#4  <signal handler called>
#5  0x00007f31db84568f in cont_free (ptr=0x7f31a0001730) at cont.c:244
#6  fiber_free (ptr=0x7f31a0001730) at cont.c:348
#7  0x00007f31db6d7dc7 in obj_free (obj=139852186770800, objspace=0x7f31dca379a0) at gc.c:1580
#8  gc_page_sweep (sweep_page=0x7f31dfe788e0, heap=0x7f31dca379b0, objspace=0x7f31dca379a0) at gc.c:2747
#9  gc_heap_lazy_sweep (objspace=objspace@entry=0x7f31dca379a0, heap=heap@entry=0x7f31dca379b0) at gc.c:3018
#10 0x00007f31db6d87f3 in gc_heap_rest_sweep (heap=0x7f31dca379b0, objspace=0x7f31dca379a0) at gc.c:3043
#11 gc_rest_sweep (objspace=objspace@entry=0x7f31dca379a0) at gc.c:3053
#12 rb_objspace_free (objspace=objspace@entry=0x7f31dca379a0) at gc.c:892
#13 0x00007f31db82c961 in ruby_vm_destruct (vm=0x7f31dca36f20) at vm.c:1840
#14 0x00007f31db6ba1d6 in ruby_cleanup (ex=0) at eval.c:236
#15 0x00007f31db6ba414 in ruby_run_node (n=<optimized out>) at eval.c:310
#16 0x00007f31db659c6b in main (argc=3, argv=0x7fffdefe18b8) at main.c:36
```
The root cause in cont.c: https://github.com/Shopify/ruby/blob/v2_1_6_shopify2/cont.c#L244

The problem is that `ruby_current_thread` is being dereferenced here, but is `NULL` (relevant assembly):
```
(gdb) disas
Dump of assembler code for function fiber_free:
<...snip...>
   0x00007f31db845681 <+113>:   lea    0x2ceb28(%rip),%rdx        # 0x7f31dbb141b0 <ruby_current_thread>
   0x00007f31db845688 <+120>:   mov    0x8(%rbx),%rcx
   0x00007f31db84568c <+124>:   mov    (%rdx),%rdx
=> 0x00007f31db84568f <+127>:   cmp    %rcx,0x2f0(%rdx)
<...snip...>
(gdb) p $rdx
$7 = 0
```
I suspect what's happening here is a `rb_thread_t` is being freed before a fiber, and `ruby_current_thread` is set to `NULL`. Then, when the fiber is later freed, we run into the segmentation fault.

My fix is very naive - it just checks that `ruby_current_thread` is not `NULL` before trying to access the `fiber` member. It gets the job done, but there may be a better fix.

/cc: @camilo, @methodmissing 