### PR TITLE
change lingering dtrace probe documentation from function- to method-

### DIFF
--- a/doc/dtrace_probes.rdoc
+++ b/doc/dtrace_probes.rdoc
@@ -9,10 +9,10 @@ specified. Probe definitions are in the format of:
 Since module and function cannot be specified, they will be blank. An example
 probe definition for Ruby would then be:
 
-  ruby:::function-entry(class name, method name, file name, line number)
+  ruby:::method-entry(class name, method name, file name, line number)
 
 Where "ruby" is the provider name, module and function names are blank, the
-probe name is "function-entry", and the probe takes four arguments:
+probe name is "method-entry", and the probe takes four arguments:
 
 * class name
 * method name
@@ -59,15 +59,15 @@ with when they are fired and the arguments they take:
 
 [ruby:::method-return(classname, methodname, filename, lineno);]
   This probe is fired just after a method has returned. The arguments are the
-  same as "ruby:::function-entry".
+  same as "ruby:::method-entry".
 
 [ruby:::cmethod-entry(classname, methodname, filename, lineno);]
   This probe is fired just before a C method is entered. The arguments are the
-  same as "ruby:::function-entry".
+  same as "ruby:::method-entry".
 
 [ruby:::cmethod-return(classname, methodname, filename, lineno);]
   This probe is fired just before a C method returns. The arguments are the
-  same as "ruby:::function-entry".
+  same as "ruby:::method-entry".
 
 [ruby:::require-entry(requiredfile, filename, lineno);]
   This probe is fired on calls to rb_require_safe (when a file is required).

--- a/probes.d
+++ b/probes.d
@@ -17,7 +17,7 @@ provider ruby {
      ruby:::method-return(classname, methodname, filename, lineno);
 
      This probe is fired just after a method has returned. The arguments are
-     the same as "ruby:::function-entry".
+     the same as "ruby:::method-entry".
   */
   probe method__return(const char *classname, const char *methodname, const char *filename, int lineno);
 
@@ -25,14 +25,14 @@ provider ruby {
      ruby:::cmethod-entry(classname, methodname, filename, lineno);
 
      This probe is fired just before a C method is entered. The arguments are
-     the same as "ruby:::function-entry".
+     the same as "ruby:::method-entry".
   */
   probe cmethod__entry(const char *classname, const char *methodname, const char *filename, int lineno);
   /*
      ruby:::cmethod-return(classname, methodname, filename, lineno);
 
      This probe is fired just before a C method returns. The arguments are
-     the same as "ruby:::function-entry".
+     the same as "ruby:::method-entry".
   */
   probe cmethod__return(const char *classname, const char *methodname, const char *filename, int lineno);
 


### PR DESCRIPTION
Fix dtrace documentation discrepancy introduced when `function-entry` was renamed to `method-entry` in 4bdd9095183666d515635946085becc66a418b16