### PR TITLE
eagerly allocate `loading_table`

### DIFF
--- a/load.c
+++ b/load.c
@@ -463,7 +463,6 @@ rb_feature_p(const char *feature, const char *ext, int rb, int expanded, const c
     }
 
     loading_tbl = get_loading_table();
-    if (loading_tbl) {
 	f = 0;
 	if (!expanded) {
 	    struct loaded_feature_searching fs;
@@ -513,7 +512,6 @@ rb_feature_p(const char *feature, const char *ext, int rb, int expanded, const c
 	    }
 	    rb_str_resize(bufstr, 0);
 	}
-    }
     return 0;
 }
 
@@ -716,11 +714,7 @@ load_lock(const char *ftptr)
     st_data_t data;
     st_table *loading_tbl = get_loading_table();
 
-    if (!loading_tbl || !st_lookup(loading_tbl, (st_data_t)ftptr, &data)) {
-	/* loading ruby library should be serialized. */
-	if (!loading_tbl) {
-	    GET_VM()->loading_table = loading_tbl = st_init_strtable();
-	}
+    if (!st_lookup(loading_tbl, (st_data_t)ftptr, &data)) {
 	/* partial state */
 	ftptr = ruby_strdup(ftptr);
 	data = (st_data_t)rb_thread_shield_new();
@@ -1090,9 +1084,6 @@ ruby_init_ext(const char *name, void (*init)(void))
 
     if (rb_provided(name))
 	return;
-    if (!loading_tbl) {
-	GET_VM()->loading_table = loading_tbl = st_init_strtable();
-    }
     st_update(loading_tbl, (st_data_t)name, register_init_ext, (st_data_t)init);
 }
 

--- a/vm.c
+++ b/vm.c
@@ -2856,6 +2856,7 @@ Init_vm_objects(void)
 
     /* initialize mark object array, hash */
     vm->mark_object_ary = rb_ary_tmp_new(128);
+    vm->loading_table = st_init_strtable();
 }
 
 /* top self */


### PR DESCRIPTION
Eliminates some branches from `rb_feature_p`, `load_lock`, and `ruby_init_ext`.

It seems like we call `load_lock` very early in the Ruby boot process.  If we eagerly allocate the `loading_table` hash, then we can delete some branches.

@nobu what do you think?

Here's the backtrace from the first place we hit `load_lock()`:

```
[aaron@TC ruby (trunk)]$ lldb `rbenv which ruby`
(lldb) target create "/Users/aaron/.rbenv/versions/ruby-trunk/bin/ruby"
Current executable set to '/Users/aaron/.rbenv/versions/ruby-trunk/bin/ruby' (x86_64).
(lldb) b load_lock
Breakpoint 1: where = ruby`load_lock + 12 at load.c:717, address = 0x000000010007547c
(lldb) r -e'puts "hello"'
Process 64415 launched: '/Users/aaron/.rbenv/versions/ruby-trunk/bin/ruby' (x86_64)
Process 64415 stopped
* thread #1: tid = 0x1dfdd0, 0x000000010007547c ruby`load_lock(ftptr=0x0000000101900340) + 12 at load.c:717, queue = 'com.apple.main-thread', stop reason = breakpoint 1.1
    frame #0: 0x000000010007547c ruby`load_lock(ftptr=0x0000000101900340) + 12 at load.c:717
   714 	load_lock(const char *ftptr)
   715 	{
   716 	    st_data_t data;
-> 717 	    st_table *loading_tbl = get_loading_table();
   718 	
   719 	    if (!loading_tbl || !st_lookup(loading_tbl, (st_data_t)ftptr, &data)) {
   720 		/* loading ruby library should be serialized. */
(lldb) bt
* thread #1: tid = 0x1dfdd0, 0x000000010007547c ruby`load_lock(ftptr=0x0000000101900340) + 12 at load.c:717, queue = 'com.apple.main-thread', stop reason = breakpoint 1.1
  * frame #0: 0x000000010007547c ruby`load_lock(ftptr=0x0000000101900340) + 12 at load.c:717
    frame #1: 0x0000000100074b42 ruby`rb_require_internal(fname=4312369800, safe=0) + 722 at load.c:993
    frame #2: 0x0000000100075993 ruby`ruby_require_internal(fname=0x0000000100288e87, len=12) + 51 at load.c:1042
    frame #3: 0x0000000100001599 ruby`Init_enc + 25 at dmyenc.c:7
    frame #4: 0x00000001001995fc ruby`process_options(argc=0, argv=0x00007fff5fbffb50, opt=0x00007fff5fbff970) + 1372 at ruby.c:1389
    frame #5: 0x000000010019907d ruby`ruby_process_options(argc=2, argv=0x00007fff5fbffb40) + 205 at ruby.c:1988
    frame #6: 0x000000010006d63b ruby`ruby_options(argc=2, argv=0x00007fff5fbffb40) + 219 at eval.c:105
    frame #7: 0x0000000100001557 ruby`main(argc=2, argv=0x00007fff5fbffb40) + 87 at main.c:36
    frame #8: 0x00007fff8af205c9 libdyld.dylib`start + 1
(lldb) 
```

Since `load_lock` will allocate the table, and we always seem to call `load_lock`, I think we could eagerly allocate the table.