### PR TITLE
Fixes minor bug introduced by typo in backport of [#10712]

### DIFF
--- a/lib/resolv.rb
+++ b/lib/resolv.rb
@@ -665,7 +665,7 @@ class Resolv
         begin
           sender.send
         rescue Errno::EHOSTUNREACH, # multi-homed IPv6 may generate this
-               Erron::ENETUNREACH
+               Errno::ENETUNREACH
           raise ResolvTimeout
         end
         while true


### PR DESCRIPTION
Just a minor typo that may lead to `uninitialized constant Resolv::DNS::Requester::Erron` in case of the `rescue` block gets executed.