### PR TITLE
Fix String#+ when subclassed

### DIFF
--- a/string.c
+++ b/string.c
@@ -1486,7 +1486,7 @@ rb_str_plus(VALUE str1, VALUE str2)
     enc = rb_enc_check(str1, str2);
     RSTRING_GETMEM(str1, ptr1, len1);
     RSTRING_GETMEM(str2, ptr2, len2);
-    str3 = rb_str_new(0, len1+len2);
+    str3 = rb_str_new_with_class(str1, 0, len1+len2);
     ptr3 = RSTRING_PTR(str3);
     memcpy(ptr3, ptr1, len1);
     memcpy(ptr3+len1, ptr2, len2);

--- a/test/ruby/test_string.rb
+++ b/test/ruby/test_string.rb
@@ -1946,6 +1946,13 @@ class TestString < Test::Unit::TestCase
     assert_equal((15..54).to_a.to_a.join, s3)
   end
 
+  def test_str_plus_subclassed
+    foo = S2.new("foo")
+    bar = S2.new("bar")
+    baz = foo + bar
+    assert_equal(TestString::S2, baz.class)
+  end
+
   def test_rb_str_new4
     s = "a" * 100
     s2 = s[10,90]


### PR DESCRIPTION
When String is subclassed, the :+ method
would result in a String instance instead
of an instance of the subclass.

This commit uses rb_str_new_with_class()
to ensure that it returns an instance of
this subclass.

See #10845.