### PR TITLE
fix a typo [ci skip]

### DIFF
--- a/array.c
+++ b/array.c
@@ -2382,7 +2382,7 @@ static VALUE
 sort_reentered(VALUE ary)
 {
     if (RBASIC(ary)->klass) {
-	rb_raise(rb_eRuntimeError, "sort reentered");
+	rb_raise(rb_eRuntimeError, "sort re-entered");
     }
     return Qnil;
 }


### PR DESCRIPTION
There was an small spelling mistake at array.c, written `reentered` which should be `re-entered`. 

