### PR TITLE
Better handling setting DefaultFileName in resolv.rb

### DIFF
--- a/lib/resolv.rb
+++ b/lib/resolv.rb
@@ -165,12 +165,10 @@ class Resolv
   # Resolv::Hosts is a hostname resolver that uses the system hosts file.
 
   class Hosts
-    begin
-      raise LoadError unless /mswin|mingw|cygwin/ =~ RUBY_PLATFORM
+    DefaultFileName = '/etc/hosts'
+    if /mswin|mingw|cygwin/ =~ RUBY_PLATFORM
       require 'win32/resolv'
       DefaultFileName = Win32::Resolv.get_hosts_path
-    rescue LoadError
-      DefaultFileName = '/etc/hosts'
     end
 
     ##


### PR DESCRIPTION
This particular piece of code in the resolv library seem to be using a very strange approach when trying to figure out which platform it is on. In stead of using a normal `if` it appears to be using `begin-raise-rescue`. This is a small patch to improve it. 

I ran all the tests on the code, and it does not appear to have introduced any new errors.
