### PR TITLE
lib/delegate.rb: More strictly regexp

### DIFF
--- a/lib/delegate.rb
+++ b/lib/delegate.rb
@@ -48,7 +48,7 @@ class Delegator < BasicObject
       undef_method m
     end
     private_instance_methods.each do |m|
-      if /\Ablock_given\?\z|iterator\?\z|\A__.*__\z/ =~ m
+      if /\A(?:block_given\?|iterator\?|__.*__)\z/ =~ m
         next
       end
       undef_method m


### PR DESCRIPTION
``` ruby
/\Ablock_given\?\z|iterator\?\z|\A__.*__\z/ =~ 'foo_iterator?' #=> 4

/\A(?:block_given\?|iterator\?|__.*__)\z/ =~ 'foo_iterator?'   #=> nil
```
