### PR TITLE
lib/delegate.rb (.#DelegateClass): Separate delegator visibility on some reflections

### DIFF
--- a/lib/delegate.rb
+++ b/lib/delegate.rb
@@ -388,9 +388,11 @@ end
 #
 def DelegateClass(superclass)
   klass = Class.new(Delegator)
-  methods = superclass.instance_methods
-  methods -= ::Delegator.public_api
-  methods -= [:to_s,:inspect,:=~,:!~,:===]
+  ignores = [*::Delegator.public_api, :to_s, :inspect, :=~, :!~, :===]
+  protected_instance_methods = superclass.protected_instance_methods
+  protected_instance_methods -= ignores
+  public_instance_methods = superclass.public_instance_methods
+  public_instance_methods -= ignores
   klass.module_eval do
     def __getobj__  # :nodoc:
       unless defined?(@delegate_dc_obj)
@@ -403,12 +405,16 @@ def DelegateClass(superclass)
       __raise__ ::ArgumentError, "cannot delegate to self" if self.equal?(obj)
       @delegate_dc_obj = obj
     end
-    methods.each do |method|
+    protected_instance_methods.each do |method|
+      define_method(method, Delegator.delegating_block(method))
+      protected method
+    end
+    public_instance_methods.each do |method|
       define_method(method, Delegator.delegating_block(method))
     end
   end
   klass.define_singleton_method :public_instance_methods do |all=true|
-    super(all) - superclass.protected_instance_methods
+    super(all) | superclass.public_instance_methods
   end
   klass.define_singleton_method :protected_instance_methods do |all=true|
     super(all) | superclass.protected_instance_methods

--- a/test/test_delegate.rb
+++ b/test/test_delegate.rb
@@ -69,6 +69,37 @@ class TestDelegateClass < Test::Unit::TestCase
     assert_equal(:m, bar.send(:delegate_test_m), bug)
   end
 
+  class Parent
+    def parent_public; end
+
+    protected
+
+    def parent_protected; end
+  end
+
+  class Child < DelegateClass(Parent)
+  end
+
+  class Parent
+    def parent_public_added; end
+
+    protected
+
+    def parent_protected_added; end
+  end
+
+  def test_public_instance_methods
+    ignores = Object.public_instance_methods | Delegator.public_instance_methods
+    assert_equal([:parent_public, :parent_public_added], Child.public_instance_methods - ignores)
+    assert_equal([:parent_public, :parent_public_added], Child.new(Parent.new).public_methods - ignores)
+  end
+
+  def test_protected_instance_methods
+    ignores = Object.protected_instance_methods | Delegator.protected_instance_methods
+    assert_equal([:parent_protected, :parent_protected_added], Child.protected_instance_methods - ignores)
+    assert_equal([:parent_protected, :parent_protected_added], Child.new(Parent.new).protected_methods - ignores)
+  end
+
   class IV < DelegateClass(Integer)
     attr_accessor :var
 


### PR DESCRIPTION
Is this intended behavior?

``` shell
# ruby -v
ruby 2.2.2p95 (2015-04-13 revision 50295) [x86_64-linux]
```

``` ruby
require 'delegate'

class Parent
  def parent_public; end

  protected

  def parent_protected; end
end

class Child < Parent
end

class DelegatorChild < DelegateClass(Parent)
end

class Parent
  def parent_public_added; end

  protected

  def parent_protected_added; end
end

ignores = Object.public_instance_methods | Delegator.public_instance_methods

p(Child.public_instance_methods - ignores)                 #=> [:parent_public, :parent_public_added]
p(Child.new.public_methods - ignores)                      #=> [:parent_public, :parent_public_added]

p(DelegatorChild.public_instance_methods - ignores)        #=> [:parent_public]
p(DelegatorChild.new(Parent.new).public_methods - ignores) #=> [:parent_public, :parent_public_added, :parent_protected]
```
