### PR TITLE
Fix gems require paths

### DIFF
--- a/ext/bigdecimal/bigdecimal.gemspec
+++ b/ext/bigdecimal/bigdecimal.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.email = "mrkn@mrkn.jp"
   s.description = "This library provides arbitrary-precision decimal floating-point number class."
   s.authors = ["Kenta Murata", "Zachary Scott", "Shigeo Kobayashi"]
-  s.require_path = %[.]
+  s.require_path = %[lib]
   s.files = %w[
     bigdecimal.gemspec
     bigdecimal.c

--- a/ext/io/console/io-console.gemspec
+++ b/ext/io/console/io-console.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.0.0"
   s.homepage = "http://www.ruby-lang.org"
   s.authors = ["Nobu Nakada"]
-  s.require_path = %[.]
+  s.require_path = %[lib]
   s.files = %w[console.c extconf.rb lib/console/size.rb]
   s.extensions = %w[extconf.rb]
   s.licenses = "ruby"


### PR DESCRIPTION
The .rb files under the lib directory will never get on the load path with the currently specified require paths, hence if someone installed the gem from RubyGems, only the binary extension would get loaded, but the original bundled Ruby files will be used instead of the new ones. This patches should narrow the situation.