### PR TITLE
Handle PUT requests similar to Perl CGI

### DIFF
--- a/lib/cgi/core.rb
+++ b/lib/cgi/core.rb
@@ -646,6 +646,9 @@ class CGI
         boundary = $1.dup
         @multipart = true
         @params = read_multipart(boundary, Integer(env_table['CONTENT_LENGTH']))
+      elsif ("PUT" == env_table['REQUEST_METHOD'])
+	stdinput.binmode if defined? stdinput.binmode
+	@params = {'PUTDATA' => stdinput.read(Integer(env_table['CONTENT_LENGTH'])) || ''}
       else
         @multipart = false
         @params = CGI::parse(


### PR DESCRIPTION
Hi,
ruby cgi.rb doesn't seem to handle PUT requests. In Perl the raw data of a PUT request is available in the params-hash as 'PUTDATA'. This patch implements the same for ruby.