### PR TITLE
Set and Prime should set Enumerator#size

### DIFF
--- a/lib/prime.rb
+++ b/lib/prime.rb
@@ -273,10 +273,15 @@ class Prime
 
     # see +Enumerator+#with_object.
     def with_object(obj)
-      return enum_for(:with_object) unless block_given?
+      return enum_for(:with_object) { Float::INFINITY } unless block_given?
       each do |prime|
         yield prime, obj
       end
+    end
+    
+    # see +Enumerator+#size.
+    def size
+      Float::INFINITY
     end
   end
 

--- a/lib/set.rb
+++ b/lib/set.rb
@@ -284,7 +284,7 @@ class Set
   # the element as parameter.  Returns an enumerator if no block is
   # given.
   def each(&block)
-    block or return enum_for(__method__)
+    block or return enum_for(__method__) { size }
     @hash.each_key(&block)
     self
   end

--- a/lib/set.rb
+++ b/lib/set.rb
@@ -663,7 +663,7 @@ class SortedSet < Set
           end
 
           def each(&block)
-            block or return enum_for(__method__)
+            block or return enum_for(__method__) { size }
             to_a.each(&block)
             self
           end

--- a/test/test_prime.rb
+++ b/test/test_prime.rb
@@ -86,6 +86,13 @@ class TestPrime < Test::Unit::TestCase
     end
   end
 
+  def test_enumerator_size
+    enum = Prime.each
+    assert_equal Float::INFINITY, enum.size
+    assert_equal Float::INFINITY, enum.with_object(nil).size
+    assert_equal Float::INFINITY, enum.with_index.size
+  end
+
   def test_default_instance_does_not_have_compatibility_methods
     assert !Prime.instance.respond_to?(:succ)
     assert !Prime.instance.respond_to?(:next)

--- a/test/test_set.rb
+++ b/test/test_set.rb
@@ -673,6 +673,29 @@ class TC_SortedSet < Test::Unit::TestCase
     assert_equal(['four', 'one', 'three', 'two'], s.to_a)
     assert_equal(['four', 'one', 'three', 'two'], a)
   end
+  
+  def test_each
+    ary = [1,3,5,7,10,20]
+    set = SortedSet.new(ary)
+
+    ret = set.each { |o| }
+    assert_same(set, ret)
+
+    e = set.each
+    assert_instance_of(Enumerator, e)
+
+    assert_nothing_raised {
+      set.each { |o|
+        ary.delete(o) or raise "unexpected element: #{o}"
+      }
+
+      ary.empty? or raise "forgotten elements: #{ary.join(', ')}"
+    }
+    
+    assert_equal(6, e.size)
+    set << 42
+    assert_equal(7, e.size)
+  end
 end
 
 class TC_Enumerable < Test::Unit::TestCase

--- a/test/test_set.rb
+++ b/test/test_set.rb
@@ -364,6 +364,10 @@ class TC_Set < Test::Unit::TestCase
 
       ary.empty? or raise "forgotten elements: #{ary.join(', ')}"
     }
+    
+    assert_equal(6, e.size)
+    set << 42
+    assert_equal(7, e.size)
   end
 
   def test_add


### PR DESCRIPTION
ruby 2.3.0dev (2015-06-12 trunk 50846) [x86_64-linux]

```ruby
require 'set'

set = Set.new [2, 4, 6]
p set.map.size  #=> 3
p set.each.size #=> nil, expected: 3
```

```ruby
require 'prime'

p Prime.each_with_index.size #=> nil, expected: Infinity
```