### PR TITLE
Implement Proc#* and Method#* for Proc and Method composition

### DIFF
--- a/proc.c
+++ b/proc.c
@@ -2999,6 +2999,30 @@ proc_compose(VALUE self, VALUE g)
     return proc;
 }
 
+ /*
+  *  call-seq:
+  *     meth * g -> a_proc
+  *
+  *  Returns a proc that is the composition of this method and the given proc <i>g</i>.
+  *  The returned proc takes a variable number of arguments, calls <i>g</i> with them
+  *  then calls this method with the result.
+  *
+  *     def f(x)
+  *       x * 2
+  *     end
+  *
+  *     f = self.method(:f)
+  *     g = proc {|x, y| x + y }
+  *     h = f * g
+  *     p h.call(1, 2) #=> 6
+  */
+static VALUE
+rb_method_compose(VALUE self, VALUE g)
+{
+    VALUE proc = method_to_proc(self);
+    return proc_compose(proc, g);
+}
+
 /*
  *  Document-class: LocalJumpError
  *
@@ -3120,6 +3144,7 @@ Init_Proc(void)
     rb_define_method(rb_cMethod, "clone", method_clone, 0);
     rb_define_method(rb_cMethod, "call", rb_method_call, -1);
     rb_define_method(rb_cMethod, "curry", rb_method_curry, -1);
+    rb_define_method(rb_cMethod, "*", rb_method_compose, 1);
     rb_define_method(rb_cMethod, "[]", rb_method_call, -1);
     rb_define_method(rb_cMethod, "arity", method_arity_m, 0);
     rb_define_method(rb_cMethod, "inspect", method_inspect, 0);

--- a/proc.c
+++ b/proc.c
@@ -2946,6 +2946,59 @@ rb_method_curry(int argc, const VALUE *argv, VALUE self)
     return proc_curry(argc, argv, proc);
 }
 
+static VALUE
+compose(VALUE dummy, VALUE args, int argc, VALUE *argv, VALUE passed_proc)
+{
+    VALUE f, g, fargs;
+    f = RARRAY_AREF(args, 0);
+    g = RARRAY_AREF(args, 1);
+    fargs = rb_ary_new3(1, rb_proc_call_with_block(g, argc, argv, passed_proc));
+
+    return rb_proc_call(f, fargs);
+}
+
+ /*
+  *  call-seq:
+  *     prc * g -> a_proc
+  *
+  *  Returns a proc that is the composition of this proc and the given proc <i>g</i>.
+  *  The returned proc takes a variable number of arguments, calls <i>g</i> with them
+  *  then calls this proc with the result.
+  *
+  *     f = proc {|x| x * 2 }
+  *     g = proc {|x, y| x + y }
+  *     h = f * g
+  *     p h.call(1, 2) #=> 6
+  */
+static VALUE
+proc_compose(VALUE self, VALUE g)
+{
+    VALUE proc, args;
+    rb_proc_t *procp;
+    int is_lambda;
+
+    if (!rb_obj_is_method(g) && !rb_obj_is_proc(g)) {
+        rb_raise(rb_eTypeError,
+                "wrong argument type %s (expected Proc/Method)",
+                rb_obj_classname(g));
+    }
+
+    if (rb_obj_is_method(g)) {
+        g = method_to_proc(g);
+    }
+
+    args = rb_ary_new3(2, self, g);
+
+    GetProcPtr(self, procp);
+    is_lambda = procp->is_lambda;
+
+    proc = rb_proc_new(compose, args);
+    GetProcPtr(proc, procp);
+    procp->is_lambda = is_lambda;
+
+    return proc;
+}
+
 /*
  *  Document-class: LocalJumpError
  *
@@ -3041,6 +3094,7 @@ Init_Proc(void)
     rb_define_method(rb_cProc, "lambda?", rb_proc_lambda_p, 0);
     rb_define_method(rb_cProc, "binding", proc_binding, 0);
     rb_define_method(rb_cProc, "curry", proc_curry, -1);
+    rb_define_method(rb_cProc, "*", proc_compose, 1);
     rb_define_method(rb_cProc, "source_location", rb_proc_location, 0);
     rb_define_method(rb_cProc, "parameters", rb_proc_parameters, 0);
 

--- a/proc.c
+++ b/proc.c
@@ -2952,7 +2952,7 @@ compose(VALUE dummy, VALUE args, int argc, VALUE *argv, VALUE passed_proc)
     VALUE f, g, fargs;
     f = RARRAY_AREF(args, 0);
     g = RARRAY_AREF(args, 1);
-    fargs = rb_ary_new3(1, rb_proc_call_with_block(g, argc, argv, passed_proc));
+    fargs = rb_ary_new3(1, rb_funcall_with_block(g, idCall, argc, argv, passed_proc));
 
     return rb_proc_call(f, fargs);
 }
@@ -2961,7 +2961,7 @@ compose(VALUE dummy, VALUE args, int argc, VALUE *argv, VALUE passed_proc)
   *  call-seq:
   *     prc * g -> a_proc
   *
-  *  Returns a proc that is the composition of this proc and the given proc <i>g</i>.
+  *  Returns a proc that is the composition of this proc and the given <i>g</i>.
   *  The returned proc takes a variable number of arguments, calls <i>g</i> with them
   *  then calls this proc with the result.
   *
@@ -2976,16 +2976,6 @@ proc_compose(VALUE self, VALUE g)
     VALUE proc, args;
     rb_proc_t *procp;
     int is_lambda;
-
-    if (!rb_obj_is_method(g) && !rb_obj_is_proc(g)) {
-        rb_raise(rb_eTypeError,
-                "wrong argument type %s (expected Proc/Method)",
-                rb_obj_classname(g));
-    }
-
-    if (rb_obj_is_method(g)) {
-        g = method_to_proc(g);
-    }
 
     args = rb_ary_new3(2, self, g);
 
@@ -3003,7 +2993,7 @@ proc_compose(VALUE self, VALUE g)
   *  call-seq:
   *     meth * g -> a_proc
   *
-  *  Returns a proc that is the composition of this method and the given proc <i>g</i>.
+  *  Returns a proc that is the composition of this method and the given <i>g</i>.
   *  The returned proc takes a variable number of arguments, calls <i>g</i> with them
   *  then calls this method with the result.
   *

--- a/test/ruby/test_method.rb
+++ b/test/ruby/test_method.rb
@@ -949,4 +949,38 @@ class TestMethod < Test::Unit::TestCase
     assert_equal('1', obj.foo(1))
     assert_equal('1', obj.bar(1))
   end
+
+  def test_compose_with_method
+    c = Class.new {
+      def f(x) x * 2 end
+      def g(x) x + 1 end
+    }
+    f = c.new.method(:f)
+    g = c.new.method(:g)
+    h = f * g
+
+    assert_equal(6, h.call(2))
+  end
+
+  def test_compose_with_proc
+    c = Class.new {
+      def f(x) x * 2 end
+    }
+    f = c.new.method(:f)
+    g = proc{|x| x + 1}
+    h = f * g
+
+    assert_equal(6, h.call(2))
+  end
+
+  def test_compose_with_nonproc_or_method
+    c = Class.new {
+      def f(x) x * 2 end
+    }
+    f = c.new.method(:f)
+
+    assert_raise(TypeError) {
+      f * 5
+    }
+  end
 end

--- a/test/ruby/test_method.rb
+++ b/test/ruby/test_method.rb
@@ -973,14 +973,28 @@ class TestMethod < Test::Unit::TestCase
     assert_equal(6, h.call(2))
   end
 
-  def test_compose_with_nonproc_or_method
+  def test_compose_with_callable
+    c = Class.new {
+      def f(x) x * 2 end
+    }
+    c2 = Class.new {
+      def call(x) x + 1 end
+    }
+    f = c.new.method(:f)
+    g = f * c2.new
+
+    assert_equal(6, g.call(2))
+  end
+
+  def test_compose_with_noncallable
     c = Class.new {
       def f(x) x * 2 end
     }
     f = c.new.method(:f)
+    g = f * 5
 
-    assert_raise(TypeError) {
-      f * 5
+    assert_raise(NoMethodError) {
+      g.call(2)
     }
   end
 end

--- a/test/ruby/test_proc.rb
+++ b/test/ruby/test_proc.rb
@@ -1393,11 +1393,22 @@ class TestProc < Test::Unit::TestCase
     assert_equal(6, h.call(2))
   end
 
-  def test_compose_with_nonproc_or_method
+  def test_compose_with_callable
     f = proc{|x| x * 2}
+    c = Class.new {
+      def call(x) x + 1 end
+    }
+    g = f * c.new
 
-    assert_raise(TypeError) {
-      f * 5
+    assert_equal(6, g.call(2))
+  end
+
+  def test_compose_with_noncallable
+    f = proc{|x| x * 2}
+    g = f * 5
+
+    assert_raise(NoMethodError) {
+      g.call(2)
     }
   end
 end

--- a/test/ruby/test_proc.rb
+++ b/test/ruby/test_proc.rb
@@ -1349,4 +1349,55 @@ class TestProc < Test::Unit::TestCase
       e.each {}
     EOS
   end
+
+  def test_compose
+    f = proc{|x| x * 2}
+    g = proc{|x| x + 1}
+    h = f * g
+
+    assert_equal(6, h.call(2))
+  end
+
+  def test_compose_with_multiple_args
+    f = proc{|x| x * 2}
+    g = proc{|x, y| x + y}
+    h = f * g
+
+    assert_equal(6, h.call(1, 2))
+  end
+
+  def test_compose_with_block
+    f = proc{|x| x * 2}
+    g = proc{|&blk| blk.call(1) }
+    h = f * g
+
+    assert_equal(8, h.call { |x| x + 3 })
+  end
+
+  def test_compose_with_lambda
+    f = lambda{|x| x * 2}
+    g = lambda{|x| x}
+    h = f * g
+
+    assert(h.lambda?)
+  end
+
+  def test_compose_with_method
+    f = proc{|x| x * 2}
+    c = Class.new {
+      def g(x) x + 1 end
+    }
+    g = c.new.method(:g)
+    h = f * g
+
+    assert_equal(6, h.call(2))
+  end
+
+  def test_compose_with_nonproc_or_method
+    f = proc{|x| x * 2}
+
+    assert_raise(TypeError) {
+      f * 5
+    }
+  end
 end


### PR DESCRIPTION
c.f. https://bugs.ruby-lang.org/issues/6284

Allow `Proc`s and `Method`s to be [composed](https://en.wikipedia.org/wiki/Function_composition_%28computer_science%29) together with `*`.

``` ruby
f = proc { |x| x * 2 }
g = proc { |x, y| x + y }
h = f * g

h.call(1, 2) #=> 6
```

Support composition with any object that has a `call` method, e.g.

``` ruby
class Foo
  def call(x, y)
    x + y
  end
end

f = proc { |x| x * 2 }
g = f * Foo.new

g.call(1, 2) #=> 6
```

This implementation should be largely equivalent to the following Ruby (excepting that the `lambda?` property is preserved):

``` ruby
class Proc
  def *(g)
    proc { |*args, &blk| call(g.call(*args, &blk)) }
  end
end
```
