### PR TITLE
Improve duplicate key warning.

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -9934,8 +9934,8 @@ remove_duplicate_keys(struct parser_params *parser, NODE *hash)
 	if (nd_type(head) == NODE_LIT &&
 	    st_lookup(literal_keys, (key = head->nd_lit), &data)) {
 	    rb_compile_warn(ruby_sourcefile, nd_line((NODE *)data),
-			    "duplicated key at line %d ignored: %+"PRIsVALUE,
-			    nd_line(head), head->nd_lit);
+			    "key %+"PRIsVALUE" is duplicated and overwritten on line %d",
+			    head->nd_lit, nd_line(head));
 	    head = ((NODE *)data)->nd_next;
 	    head->nd_head = block_append(head->nd_head, value->nd_head);
 	}


### PR DESCRIPTION
This change rephrases the duplicate key warning from this:

```
/Users/andre/bug.rb:4: warning: duplicated key at line 5 ignored: :max_instances
```

which causes some confusion, to:

```
/Users/andre/bug.rb:4: warning: key :max_instances is duplicated and overwritten on line 5
```

/cc @ko1 @tenderlove @rafaelfranca