### PR TITLE
Net::Http: Fixed missing SNI in Client Hello packet when resuming a SSL session.

### DIFF
--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -919,12 +919,12 @@ module Net   #:nodoc:
             @socket.write(buf)
             HTTPResponse.read_new(@socket).value
           end
+          # Server Name Indication (SNI) RFC 3546
+          s.hostname = @address if s.respond_to? :hostname=
           if @ssl_session and
              Process.clock_gettime(Process::CLOCK_REALTIME) < @ssl_session.time.to_f + @ssl_session.timeout
             s.session = @ssl_session if @ssl_session
           end
-          # Server Name Indication (SNI) RFC 3546
-          s.hostname = @address if s.respond_to? :hostname=
           if timeout = @open_timeout
             while true
               raise Net::OpenTimeout if timeout <= 0


### PR DESCRIPTION
When resuming a SSL Session, the SNI was missing in the Client Hello packet. 

See https://bugs.ruby-lang.org/issues/10533 for details