### PR TITLE
range.c: include_range?

### DIFF
--- a/range.c
+++ b/range.c
@@ -1165,9 +1165,15 @@ range_include(VALUE range, VALUE val)
 	!NIL_P(rb_check_to_integer(end, "to_int"))) {
 	return r_cover_p(range, beg, end, val);
     }
-    else if (RB_TYPE_P(beg, T_STRING) && RB_TYPE_P(end, T_STRING)) {
-	VALUE rb_str_include_range_p(VALUE beg, VALUE end, VALUE val, VALUE exclusive);
-	return rb_str_include_range_p(beg, end, val, RANGE_EXCL(range));
+    else {
+	ID id_include_range_p;
+	VALUE r, args[3];
+	CONST_ID(id_include_range_p, "include_range?");
+	args[0] = end;
+	args[1] = val;
+	args[2] = EXCL(range) ? Qtrue : Qfalse;
+	r = rb_check_funcall(beg, id_include_range_p, 3, args);
+	if (r != Qundef) return r;
     }
     /* TODO: ruby_frame->this_func = rb_intern("include?"); */
     return rb_call_super(1, &val);

--- a/string.c
+++ b/string.c
@@ -3911,7 +3911,7 @@ include_range_i(VALUE str, VALUE arg)
     return 1;
 }
 
-VALUE
+static VALUE
 rb_str_include_range_p(VALUE beg, VALUE end, VALUE val, VALUE exclusive)
 {
     beg = rb_str_new_frozen(beg);
@@ -9761,6 +9761,7 @@ Init_String(void)
     rb_define_method(rb_cString, "b", rb_str_b, 0);
     rb_define_method(rb_cString, "valid_encoding?", rb_str_valid_encoding_p, 0);
     rb_define_method(rb_cString, "ascii_only?", rb_str_is_ascii_only_p, 0);
+    rb_define_method(rb_cString, "include_range?", rb_str_include_range_p, 3);
 
     rb_fs = Qnil;
     rb_define_variable("$;", &rb_fs);


### PR DESCRIPTION
make r50502 (80e0ef3a8167dddc8434e981a5df5925e667919e) more generic.
