### PR TITLE
IPAddr should reject invalid format with EOL

### DIFF
--- a/lib/ipaddr.rb
+++ b/lib/ipaddr.rb
@@ -410,7 +410,7 @@ class IPAddr
   # Set current netmask to given mask.
   def mask!(mask)
     if mask.kind_of?(String)
-      if mask =~ /^\d+$/
+      if mask =~ /\A\d+\z/
         prefixlen = mask.to_i
       else
         m = IPAddr.new(mask)
@@ -478,7 +478,7 @@ class IPAddr
       end
     end
     prefix, prefixlen = addr.split('/')
-    if prefix =~ /^\[(.*)\]$/i
+    if prefix =~ /\A\[(.*)\]\z/i
       prefix = $1
       family = Socket::AF_INET6
     end

--- a/test/test_ipaddr.rb
+++ b/test/test_ipaddr.rb
@@ -73,6 +73,8 @@ class TC_IPAddr < Test::Unit::TestCase
     assert_raise(IPAddr::InvalidAddressError) { IPAddr.new("192.168.0.011") }
     assert_raise(IPAddr::InvalidAddressError) { IPAddr.new("fe80::1%fxp0") }
     assert_raise(IPAddr::InvalidAddressError) { IPAddr.new("[192.168.1.2]/120") }
+    assert_raise(IPAddr::InvalidAddressError) { IPAddr.new("[2001:200:300::]\nINVALID") }
+    assert_raise(IPAddr::InvalidAddressError) { IPAddr.new("192.168.0.1/32\nINVALID") }
     assert_raise(IPAddr::InvalidPrefixError) { IPAddr.new("::1/255.255.255.0") }
     assert_raise(IPAddr::InvalidPrefixError) { IPAddr.new("::1/129") }
     assert_raise(IPAddr::InvalidPrefixError) { IPAddr.new("192.168.0.1/33") }


### PR DESCRIPTION
ruby 2.3.0dev (2015-06-20 trunk 50978) [x86_64-linux]

```ruby
require 'ipaddr'

IPAddr.new "[2001:200:300::] INVALID" #=> IPAddr::InvalidAddressError: invalid address
IPAddr.new "192.168.0.1/32 INVALID"  #=> IPAddr::InvalidAddressError: invalid address
IPAddr.new "[2001:200:300::]\nINVALID" #=> #<IPAddr: IPv6:2001:0200:0300:0000:0000:0000:0000:0000/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff>, expected: IPAddr::InvalidAddressError
IPAddr.new "192.168.0.1/32\nINVALID"  #=> #<IPAddr: IPv4:192.168.0.1/255.255.255.255>, expected: IPAddr::InvalidAddressError or IPAddr::InvalidPrefixError
```