### PR TITLE
Use Array#concat in CSV::Table#to_a.

### DIFF
--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -868,7 +868,7 @@ class CSV
         if row.header_row?
           array
         else
-          array + [row.fields]
+          array.concat [row.fields]
         end
       end
     end


### PR DESCRIPTION
Use Array#concat in CSV::Table#to_a.

This significantly impacts performance of large CSV files being converted to arrays and should avoid any side-effects since the array is constructed and modified only within the `#to_a` method.
