### PR TITLE
Added a nil check in Net::HTTPHeader#initialize_http_header for keys …

### DIFF
--- a/lib/net/http/header.rb
+++ b/lib/net/http/header.rb
@@ -14,11 +14,8 @@ module Net::HTTPHeader
     return unless initheader
     initheader.each do |key, value|
       warn "net/http: warning: duplicated HTTP header: #{key}" if key?(key) and $VERBOSE
-      if value.nil? 
-        @header[key.downcase] = ""
-      else  
-        @header[key.downcase] = [value.strip]
-      end
+      next if value.nil?
+      @header[key.downcase] = [value.strip]
     end
   end
 

--- a/lib/net/http/header.rb
+++ b/lib/net/http/header.rb
@@ -14,7 +14,11 @@ module Net::HTTPHeader
     return unless initheader
     initheader.each do |key, value|
       warn "net/http: warning: duplicated HTTP header: #{key}" if key?(key) and $VERBOSE
-      @header[key.downcase] = [value.strip]
+      if value.nil? 
+        @header[key.downcase] = ""
+      else  
+        @header[key.downcase] = [value.strip]
+      end
     end
   end
 


### PR DESCRIPTION
### Added a nil check in the method initialize_http_header in Net::HTTPHeader

This is a patch for this bug in the issue tracker - https://bugs.ruby-lang.org/issues/11281

If the value for a key in the headers hash is nil, a NoMethodError is thrown.  A nil check was added that assigns a blank string in case the value is nil.