### PR TITLE
Resolve issue with Net::HTTP::PUT and Expect-100 continue.

### DIFF
--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -1426,10 +1426,10 @@ module Net   #:nodoc:
 
           res.uri = req.uri
 
-          res.reading_body(@socket, req.response_body_permitted?) {
-            yield res if block_given?
-          }
           res
+        }
+        res.reading_body(@socket, req.response_body_permitted?) {
+          yield res if block_given?
         }
       rescue Net::OpenTimeout
         raise


### PR DESCRIPTION
Net::HTTP raises an error when making a PUT request with the "Expect: 100-continue" header if the server responses with ANY non 100-continue response. The current implementation works fine for POST request, but raises the following error for PUT request:

    Conn close because of error undefined method `closed?' for
    nil:NilClass
    /Users/trevrowe/.rbenv/versions/2.2.2/lib/ruby/2.2.0/net/http/response.rb:329:in
    `stream_check': undefined method `closed?' for nil:NilClass
    (NoMethodError)
      from /Users/trevrowe/.rbenv/versions/2.2.2/lib/ruby/2.2.0/net/http/response.rb:199:in `read_body'
      from /Users/trevrowe/.rbenv/versions/2.2.2/lib/ruby/2.2.0/net/http/response.rb:226:in `body'
      from /Users/trevrowe/.rbenv/versions/2.2.2/lib/ruby/2.2.0/net/http.rb:1473:in `end_transport'
      from /Users/trevrowe/.rbenv/versions/2.2.2/lib/ruby/2.2.0/net/http.rb:1443:in `transport_request'
      from /Users/trevrowe/.rbenv/versions/2.2.2/lib/ruby/2.2.0/net/http.rb:1384:in `request'
      from /Users/trevrowe/.rbenv/versions/2.2.2/lib/ruby/2.2.0/net/http.rb:1377:in `block in request'
      from /Users/trevrowe/.rbenv/versions/2.2.2/lib/ruby/2.2.0/net/http.rb:853:in `start'
      from /Users/trevrowe/.rbenv/versions/2.2.2/lib/ruby/2.2.0/net/http.rb:1375:in `request'
      from client-3.rb:15:in `<main>'

This bug dates back to when the feature was added in Ruby 1.9.3. This commit resolves the above issue and adds a test to watch for regressions.

I've created a sample gist with a minimal server and client that demonstrates the bug.

https://gist.github.com/trevorrowe/c2353ab959c6852a2bd7