### PR TITLE
Fix for two Net::HTTP retry bugs.

### DIFF
--- a/lib/net/http/generic_request.rb
+++ b/lib/net/http/generic_request.rb
@@ -9,6 +9,7 @@ class Net::HTTPGenericRequest
 
   def initialize(m, reqbody, resbody, uri_or_path, initheader = nil)
     @method = m
+    @retry_networking_errors = Net::HTTP::IDEMPOTENT_METHODS_.include?(m)
     @request_has_body = reqbody
     @response_has_body = resbody
 
@@ -58,6 +59,11 @@ class Net::HTTPGenericRequest
   # themselves.
   attr_reader :decode_content
 
+  # When true, this request may be retried if a networking error is
+  # encountered. Set to false to disable retries. Defaults to
+  # true for idempotent HTTP methods.
+  attr_accessor :retry_networking_errors
+
   def inspect
     "\#<#{self.class} #{@method}>"
   end
@@ -97,6 +103,7 @@ class Net::HTTPGenericRequest
   attr_reader :body_stream
 
   def body_stream=(input)
+    @retry_networking_errors = input.respond_to?(:rewind)
     @body = nil
     @body_stream = input
     @body_data = nil

--- a/test/net/http/test_http_retries.rb
+++ b/test/net/http/test_http_retries.rb
@@ -1,0 +1,175 @@
+# coding: US-ASCII
+require 'test/unit'
+require 'net/http'
+require 'stringio'
+require 'socket'
+
+class TestNetHTTPIdempotentRetries < Test::Unit::TestCase
+
+  class SimpleHttpServer
+
+    def initialize
+      @address = '127.0.0.1'
+      @port = 3000
+      @handlers = []
+    end
+
+    attr_reader :address, :port
+
+    # The given proc should accept the follow block arguments:
+    #
+    # * `http_method` - String
+    # * `request_uri` - String
+    # * `request_headers` - Hash<String,String>
+    # * `socket` - Socket
+    #
+    # The block is expected to read the request body and to write
+    # the full response.
+    def handle(&handler)
+      @handlers << Proc.new
+    end
+
+    def start
+      @server = TCPServer.new(@address, @port)
+      @thread = Thread.new do
+        loop do
+          begin
+            socket = @server.accept
+            method, uri, _ = socket.gets.split(/\s+/)
+            @handlers.shift.call(method, uri, headers(socket), socket)
+            socket.close unless socket.closed?
+          rescue
+            @server.close
+            @server = TCPServer.new(@address, @port)
+            retry
+          end
+        end
+      end
+    end
+
+    def stop
+      @thread.kill
+      @server.close
+    end
+
+    private
+
+    def headers(socket)
+      headers = {}
+      line = socket.gets
+      until line == "\r\n"
+        key, value = line.split(/:\s*/, 2)
+        headers[key.downcase] = value
+        line = socket.gets
+      end
+      headers
+    end
+
+  end
+
+  def setup
+    @server = SimpleHttpServer.new
+  end
+
+  def teardown
+    @server.stop
+  end
+
+  def test_idempotent_retry_default
+    @server.handle do |_, _, headers, socket|
+      socket.close # close without responding
+    end
+    @server.handle do |_, _, headers, socket|
+      socket.print("HTTP/1.1 200 OK\r\n")
+      socket.print("\r\n")
+    end
+    @server.start
+
+    req = Net::HTTP::Get.new('/')
+    http = Net::HTTP.new(@server.address, @server.port)
+    res = http.request(req)
+
+    assert_equal('200', res.code)
+  end
+
+  def test_retry_can_be_disabled
+    @server.handle do |_, _, headers, socket|
+      socket.close # close without responding
+    end
+    @server.handle do |_, _, headers, socket|
+      socket.print("HTTP/1.1 200 OK\r\n")
+      socket.print("\r\n")
+    end
+    @server.start
+
+    req = Net::HTTP::Get.new('/')
+    req.retry_networking_errors = false
+
+    http = Net::HTTP.new(@server.address, @server.port)
+    assert_raises {
+      http.request(req)
+    }
+  end
+
+  def test_idempotent_retry_rewinds_put_body_stream
+    @server.handle do |_, _, headers, socket|
+      # intentionally read some of the data, not all
+      socket.read(headers['content-length'].to_i / 2)
+      socket.close
+    end
+    @server.handle do |_, _, headers, socket|
+      body = socket.read(headers['content-length'].to_i)
+      socket.print("HTTP/1.1 200 OK\r\n")
+      socket.print("Content-Length: #{body.size}\n")
+      socket.print("\r\n")
+      socket.print(body)
+    end
+    @server.start
+
+    body = StringIO.new('io-body')
+    req = Net::HTTP::Put.new('/', 'Content-Length' => body.size.to_s )
+    req.body_stream = body
+
+    http = Net::HTTP.new(@server.address, @server.port)
+    http.read_timeout = 0.5
+
+    assert_nothing_raised {
+      http.request(req)
+    }
+  end
+
+  def test_idempotent_retry_disabled_with_request_block
+    one_meg = 1024 * 1024
+    @server.handle do |_, _, headers, socket|
+      socket.print("HTTP/1.1 200 OK\r\n")
+      socket.print("Content-Length: #{one_meg}\n")
+      socket.print("\r\n")
+      socket.print('.' * (one_meg / 2))
+      raise 'error' # forcefully close the connection
+    end
+    @server.handle do |_, _, headers, socket|
+      socket.print("HTTP/1.1 200 OK\r\n")
+      socket.print("Content-Length: #{one_meg}\n")
+      socket.print("\r\n")
+      socket.print('.' * one_meg)
+    end
+    @server.start
+
+    http = Net::HTTP.new(@server.address, @server.port)
+    http.read_timeout = 0.5
+
+    yield_count = 0
+    byte_count = 0
+
+    assert_raises {
+      http.request(Net::HTTP::Get.new('/')) do |resp|
+        yield_count += 1
+        resp.read_body do |bytes|
+          byte_count += bytes.bytesize
+        end
+      end
+    }
+    assert_equal(one_meg / 2, byte_count)
+    assert_equal(1, yield_count)
+  end
+end


### PR DESCRIPTION
Net::HTTP retries networking errors for idempotent http requests. This feature was added back in version 2.0. Retrying idempotent HTTP requests based on their HTTP method, e.g. GET, PUT, etc, has introduced 2 issues. This pull request addresses these two issues and adds a facility to disable retries on a per-request basis.
## Issue 1: PUT requests with body stream not rewound

When making a PUT request with a `#body_stream` it is possible for some bytes to be read from the stream and then to encounter a networking error. Net::HTTP retries this attempt without
first rewinding the body stream. This causes the follow-up request to send fewer than all of the bytes.
## Fix 1: Rewind #body_stream

This commit causes Net::HTTP to attempt to rewind the `#body_stream` before resending the request. If the body does not respond to `#rewind` then the request will not be retried and the original
error is raised.
## Issue 2: GET requests with block and #read_body

When making a GET request you may pass a block so that you can stream data from the response with a `#read_body` block. For example:

```
# stream a large file straight to disk
File.open('target', 'wb') do |file|
  http = Net::HTTP.new(hostname, port)
  http.request(Net::HTTP::Get.new('/')) do |resp|
    resp.read_body do |chunk|
      file.write(chunk)
    end
  end
end
```

If half of the response is downloaded and then a networking error occurs, Net::HTTP will retry the request, yielding to the request block a second time. In the example above, the resultant
file will contain the first half of the file followed by the full file.

Currently the only way to avoid this is a bit of a hack:

```
File.open('target', 'wb') do |file|

  attempts = 0
  http = Net::HTTP.new(hostname, port)
  http.request(Net::HTTP::Get.new('/')) do |resp|
    if attempts == 0
      attempts += 1
    else
      raise 'yielding twice, bad download'
    end
    resp.read_body do |chunk|
      file.write(chunk)
    end
  end

end
```

This is undesirable because it is no longer to get at the original error that has been swallowed by Net::HTTP.
## Fix 2: Disable retries when a request block is given

To avoid scenarios where the user is un-aware that their block is being yielded to twice, idempotent retries are disabled if a block is given.
## Fix 3: Disabling retries per request

In addition to the above bug fixes for the default retry logic, a new attribute has been added to Net::HTTPGenericRequest called `#retry_networking_errors`. This is a boolean attribute which
defaults to true for all idempotent http methods, e.g. GET, PUT, etc. It is disabled when setting a non-rewindable `#body_stream` and when passing a request read block.

```
# request has side-effects, should not be retried
req = Net::HTTP::Get.new('/something/dangerous')
req.retry_networking_errors = false
http.request(req)
```

This is excellent for scenarios where the remote end has performed some destructive or expensive operation but the error occurred while receiving the response. Simply retrying on the state of the HTTP
verb is not granular enough.
