### PR TITLE
Add test for `first`

### DIFF
--- a/enum.c
+++ b/enum.c
@@ -828,6 +828,7 @@ static VALUE enum_take(VALUE obj, VALUE n);
  *    %w[foo bar baz].first(2)  #=> ["foo", "bar"]
  *    %w[foo bar baz].first(10) #=> ["foo", "bar", "baz"]
  *    [].first                  #=> nil
+ *    [].first(10)              #=> []
  *
  */
 

--- a/test/ruby/test_enum.rb
+++ b/test/ruby/test_enum.rb
@@ -202,6 +202,7 @@ class TestEnumerable < Test::Unit::TestCase
     assert_equal(1, @obj.first)
     assert_equal([1, 2, 3], @obj.first(3))
     assert_nil(@empty.first)
+    assert_equal([], @empty.first(10))
 
     bug5801 = '[ruby-dev:45041]'
     assert_in_out_err([], <<-'end;', [], /unexpected break/)


### PR DESCRIPTION
Test case for if the enumerable is empty and arg is passed,
`first` returns an empty array.