### PR TITLE
Strip punctuation from CSV headers in symbol converter

### DIFF
--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -996,8 +996,8 @@ class CSV
   HeaderConverters = {
     downcase: lambda { |h| h.encode(ConverterEncoding).downcase },
     symbol:   lambda { |h|
-      h.encode(ConverterEncoding).downcase.strip.gsub(/\s+/, "_").
-                                                 gsub(/\W+/, "").to_sym
+      h.encode(ConverterEncoding).downcase.gsub(/[^[\s\w]]+/, "").strip.
+                                           gsub(/\s+/, "_").to_sym
     }
   }
 

--- a/test/csv/test_headers.rb
+++ b/test/csv/test_headers.rb
@@ -224,6 +224,13 @@ class TestCSV::Headers < TestCSV
     assert_equal([:one, :two_three], csv.headers)
   end
 
+  def test_builtin_symbol_converter_with_punctuation
+    csv = CSV.parse( "One, Two & Three ($)", headers:           true,
+                                             return_headers:    true,
+                                             header_converters: :symbol )
+    assert_equal([:one, :two_three], csv.headers)
+  end
+
   def test_builtin_converters_with_blank_header
     csv = CSV.parse( "one,,three", headers:           true,
                                    return_headers:    true,


### PR DESCRIPTION
The current symbol converter for CSV headers strips the string, then removes punctuation.
Instead, it should remove punctuation first, to avoid trailing or multiple adjacent underscores.

|  | "Full $ Amounts" | Full Amounts ($) |
| --- | --- | --- |
| Without this patch | :full__amounts | :full_amounts_ |
| With this patch | :full_amounts | :full_amounts |

Without this patch:
1. Strips it
2. Converts spaces to underscores
3. Removes punctuation characters

With this patch:
1. Removes punctuation characters
2. Strips it
3. Converts spaces to underscores

This is notable because `CSV.table(...)` is an alias to `CSV.read(...)` with this option set.
