### PR TITLE
stringio.c(writable): remove unnecessary check

### DIFF
--- a/ext/stringio/stringio.c
+++ b/ext/stringio/stringio.c
@@ -139,8 +139,6 @@ writable(VALUE strio)
     if (!WRITABLE(strio)) {
 	rb_raise(rb_eIOError, "not opened for writing");
     }
-    if (!OBJ_TAINTED(ptr->string)) {
-    }
     return ptr;
 }
 


### PR DESCRIPTION
`OBJ_TAINTED` macro seems only flag check.

```
#define OBJ_TAINTED(x) (!!FL_TEST((x), FL_TAINT))
```

I think this statement is not need.

ref: https://github.com/ruby/ruby/commit/1f828497d1e8df2b7b68ac2a093ab4439585d88a#diff-bbe6b0bc1cf60b1f4369362b4fb4899c