### PR TITLE
Net::Http: Fixed missing SNI in Client Hello packet when resuming a SSL session.

### DIFF
--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -919,12 +919,12 @@ module Net   #:nodoc:
             @socket.write(buf)
             HTTPResponse.read_new(@socket).value
           end
+          # Server Name Indication (SNI) RFC 3546
+          s.hostname = @address if s.respond_to? :hostname=
           if @ssl_session and
              Process.clock_gettime(Process::CLOCK_REALTIME) < @ssl_session.time.to_f + @ssl_session.timeout
             s.session = @ssl_session if @ssl_session
           end
-          # Server Name Indication (SNI) RFC 3546
-          s.hostname = @address if s.respond_to? :hostname=
           if timeout = @open_timeout
             while true
               raise Net::OpenTimeout if timeout <= 0


### PR DESCRIPTION
See https://bugs.ruby-lang.org/issues/11401

Net::Http calls `s.session=` (C-method `ossl_ssl_set_session`), which calls C-method `ossl_ssl_setup`, which only sets up the ssl client (`ssl`) once due to "if(!ssl){". The problem is that the hostname setting (the call to `SSL_set_tlsext_host_name`) is done within that "if(!ssl){" block.

When later Net::Http calls `s.connect` (C-method `ossl_ssl_connect`), `ossl_ssl_setup` is called a second time, but it does not set up the hostname.

Placing `s.hostname=` above `s.session=` handles this correctly.