### PR TITLE
[ci skip] Fix indent of comment

### DIFF
--- a/file.c
+++ b/file.c
@@ -4237,7 +4237,7 @@ ruby_enc_find_extname(const char *name, long *len, rb_encoding *enc)
  *
  *     File.extname("test.rb")         #=> ".rb"
  *     File.extname("a/b/d/test.rb")   #=> ".rb"
- *     File.extname("foo.")	       #=> ""
+ *     File.extname("foo.")            #=> ""
  *     File.extname("test")            #=> ""
  *     File.extname(".profile")        #=> ""
  *     File.extname(".profile.sh")     #=> ".sh"


### PR DESCRIPTION
This PR replace tab with spaces.
I know c file in ruby, we use tab and space.
But maybe in comment, tab is rarely used, so I replace tab with spaces.