### PR TITLE
vm_insnhelper.c (check_cref): check for nil

### DIFF
--- a/test/ruby/test_eval.rb
+++ b/test/ruby/test_eval.rb
@@ -126,6 +126,10 @@ class TestEval < Test::Unit::TestCase
     }
   end
 
+  def test_module_eval_block_symbol
+    assert_equal "Math", Math.module_eval(&:to_s)
+  end
+
   def forall_TYPE
     objects = [Object.new, [], nil, true, false] # TODO: check
     objects.each do |obj|
@@ -197,6 +201,12 @@ class TestEval < Test::Unit::TestCase
     o = Object.new
     assert_equal o, o.instance_eval(&pr)
     assert_equal self, pr.call
+  end
+
+  def test_instance_eval_block_symbol
+    forall_TYPE do |o|
+      assert_equal o.to_s, o.instance_eval(&:to_s)
+    end
   end
 
   def test_instance_eval_cvar

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -409,7 +409,7 @@ method_entry_cref(rb_callable_method_entry_t *me)
 static rb_cref_t *
 check_cref(VALUE obj, int can_be_svar)
 {
-    if (obj == Qfalse) return NULL;
+    if (!RTEST(obj)) return NULL;
 
 #if VM_CHECK_MODE > 0
     if (!RB_TYPE_P(obj, T_IMEMO)) rb_bug("check_cref: unknown type: %s", rb_obj_info(obj));


### PR DESCRIPTION
Checking only for `Qfalse` misses the `Qnil` that might end up in this
function as a result of `instance_eval(&:foo)`, which leads to `Qnil`
being dereferenced and causing the interpreter to segfault. [Bug #11409]