### PR TITLE
Update contributing.rdoc

### DIFF
--- a/doc/contributing.rdoc
+++ b/doc/contributing.rdoc
@@ -312,7 +312,7 @@ Now let's build CRuby:
     autoconf
     mkdir build && cd build # its good practice to build outside of source dir
     mkdir ~/.rubies # we will install to .rubies/ruby-trunk in our home dir
-    ../configure --prefix=~/.rubies/ruby-trunk
+    ../configure --prefix='$(~/).rubies/ruby-trunk'
     make && make install
 
 After adding Ruby to your PATH, you should be ready to run the test suite:


### PR DESCRIPTION
On OS X you must give an absolute path to the prefix or you get an error

```
$ ../configure --prefix=~/.rubies/ruby-trunk
configure: error: expected an absolute directory name for --prefix: ~/.rubies/ruby-trunk
```

I believe this shell substitution should work on most systems.