### PR TITLE
* string.c: [DOC] Make #end_with? example doc symmetry with #start_with?

### DIFF
--- a/string.c
+++ b/string.c
@@ -8224,6 +8224,12 @@ rb_str_start_with(int argc, VALUE *argv, VALUE str)
  *     str.end_with?([suffixes]+)   -> true or false
  *
  *  Returns true if +str+ ends with one of the +suffixes+ given.
+ *
+ *    "hello".end_with?("ello")               #=> true
+ *
+ *    # returns true if one of the +suffixes+ matches.
+ *    "hello".end_with?("heaven", "ello")     #=> true
+ *    "hello".end_with?("heaven", "paradise") #=> false
  */
 
 static VALUE


### PR DESCRIPTION
This pull request adds documentations for `String#end_with?`.

Put `String#start_with?` documentations here for reviewer's reference:

```c
...
/*
 *  call-seq:
 *     str.start_with?([prefixes]+)   -> true or false
 *
 *  Returns true if +str+ starts with one of the +prefixes+ given.
 *
 *    "hello".start_with?("hell")               #=> true
 *
 *    # returns true if one of the prefixes matches.
 *    "hello".start_with?("heaven", "hell")     #=> true
 *    "hello".start_with?("heaven", "paradise") #=> false
 */

static VALUE
rb_str_start_with(int argc, VALUE *argv, VALUE str)
...
```

--

[Ruby 2.2.2's `#start_with?` documentation](http://ruby-doc.org/core-2.2.2/String.html#method-i-start_with-3F)
[Ruby 2.2.2's `#end_with?` documentation](http://ruby-doc.org/core-2.2.2/String.html#method-i-end_with-3F)

