### PR TITLE
* lib/timeout.rb: freeze a string message

### DIFF
--- a/lib/timeout.rb
+++ b/lib/timeout.rb
@@ -71,7 +71,7 @@ module Timeout
   # a module method, so you can call it directly as Timeout.timeout().
   def timeout(sec, klass = nil)   #:yield: +sec+
     return yield(sec) if sec == nil or sec.zero?
-    message = "execution expired"
+    message = "execution expired".freeze
     e = Error
     bl = proc do |exception|
       begin


### PR DESCRIPTION
Why: Saves ~ 1M string allocations on every request

From benchmarking one of my rails app, I found this line allocating

many string objects.

1050056  /Users/Juan/.rubies/ruby-2.2.2/lib/ruby/2.2.0/timeout.rb:80

Before this patch

```
   2828765  activerecord-4.2.3
   2695930  ruby-2.2.2/lib
   1057453  activesupport-4.2.3
```

After this patch

```
allocated memory by gem
-----------------------------------
   2828765  activerecord-4.2.3
   1627551  ruby-2.2.2/lib
   1057213  activesupport-4.2.3
```

I use derailed_benchmarks gem to benchmark my Rails app, the exact command is

```
bundle exec derailed exec perf:objects
```