### PR TITLE
Update range.c

### DIFF
--- a/range.c
+++ b/range.c
@@ -1134,7 +1134,8 @@ range_inspect(VALUE range)
 static VALUE
 range_eqq(VALUE range, VALUE val)
 {
-    return rb_funcall(range, rb_intern("include?"), 1, val);
+	return range_cover(range, val);
+    //return rb_funcall(range, rb_intern("include?"), 1, val);
 }
 
 


### PR DESCRIPTION
"include" iterates over the range while "cover" does check inclusion using boundaries which is much more efficient.