### PR TITLE
Optimize range_eqq

### DIFF
--- a/range.c
+++ b/range.c
@@ -1134,7 +1134,8 @@ range_inspect(VALUE range)
 static VALUE
 range_eqq(VALUE range, VALUE val)
 {
-    return rb_funcall(range, rb_intern("include?"), 1, val);
+	return rb_funcall(range, rb_intern("cover?"), 1, val);
+    //return rb_funcall(range, rb_intern("include?"), 1, val);
 }
 
 


### PR DESCRIPTION
`include` iterates over the range to check inclusion while `cover` does the same using range boundaries which is much more faster.