### PR TITLE
freeze some hotspots in ruby

### DIFF
--- a/lib/base64.rb
+++ b/lib/base64.rb
@@ -70,7 +70,7 @@ module Base64
   # ArgumentError is raised if +str+ is incorrectly padded or contains
   # non-alphabet characters.  Note that CR or LF are also rejected.
   def strict_decode64(str)
-    str.unpack("m0").first
+    str.unpack('m0'.freeze).first
   end
 
   # Returns the Base64-encoded version of +bin+.

--- a/lib/fileutils.rb
+++ b/lib/fileutils.rb
@@ -157,7 +157,7 @@ module FileUtils
   module_function :uptodate?
 
   def remove_tailing_slash(dir)
-    dir == '/' ? dir : dir.chomp(?/)
+    dir == '/'.freeze ? dir : dir.chomp(?/)
   end
   private_module_function :remove_tailing_slash
 

--- a/lib/ipaddr.rb
+++ b/lib/ipaddr.rb
@@ -477,7 +477,7 @@ class IPAddr
         raise AddressFamilyError, "unsupported address family: #{family}"
       end
     end
-    prefix, prefixlen = addr.split('/')
+    prefix, prefixlen = addr.split('/'.freeze)
     if prefix =~ /^\[(.*)\]$/i
       prefix = $1
       family = Socket::AF_INET6

--- a/lib/securerandom.rb
+++ b/lib/securerandom.rb
@@ -110,7 +110,7 @@ module Random::Formatter
   # If a secure random number generator is not available,
   # +NotImplementedError+ is raised.
   def hex(n=nil)
-    random_bytes(n).unpack("H*")[0]
+    random_bytes(n).unpack('H*'.freeze)[0]
   end
 
   # SecureRandom.base64 generates a random base64 string.
@@ -227,13 +227,14 @@ module Random::Formatter
   # See RFC 4122 for details of UUID.
   #
   def uuid
-    ary = random_bytes(16).unpack("NnnnnN")
+    ary = random_bytes(16).unpack('NnnnnN'.freeze)
     ary[2] = (ary[2] & 0x0fff) | 0x4000
     ary[3] = (ary[3] & 0x3fff) | 0x8000
-    "%08x-%04x-%04x-%04x-%04x%08x" % ary
+    '%08x-%04x-%04x-%04x-%04x%08x'.freeze % ary
   end
 
   private
+
   def gen_random(n)
     self.bytes(n)
   end


### PR DESCRIPTION
While rending a basic rails page using [Let it Go](https://github.com/schneems/let_it_go) I received some interesting output:

```
00:32:44 web.1    |   6) /Users/BenAMorgan/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/base64.rb
00:32:44 web.1    |     - 3) String#unpack on line 73
00:32:44 web.1    |     - 2) String#unpack on line 73
00:32:44 web.1    |     - 1) String#unpack on line 73
00:32:44 web.1    |   2) /Users/BenAMorgan/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/fileutils.rb
00:32:44 web.1    |     - 1) String#chomp on line 160
00:32:44 web.1    |     - 1) String#chomp on line 160
00:32:44 web.1    |   2) /Users/BenAMorgan/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/securerandom.rb
00:32:44 web.1    |     - 1) String#unpack on line 173
00:32:44 web.1    |     - 1) String#unpack on line 288
00:32:44 web.1    |   1) /Users/BenAMorgan/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/ipaddr.rb
00:32:44 web.1    |     - 1) String#split on line 480
```

I decided to take the time and freeze these strings as to help lower the heap allocations inside of rails. I did not proceed to freeze any other strings, but my guess is is that there's lots of places inside of ruby to help lower the amount of sting allocations.

I hope that overtime this gem allows me, and other developers, to create PRs to ruby to help with its performance.