### PR TITLE
Fix error message for argument error

### DIFF
--- a/vm_eval.c
+++ b/vm_eval.c
@@ -694,7 +694,7 @@ raise_method_missing(rb_thread_t *th, int argc, const VALUE *argv, VALUE obj,
     const char *format = 0;
 
     if (argc == 0 || !SYMBOL_P(argv[0])) {
-	rb_raise(rb_eArgError, "no id given");
+	rb_raise(rb_eArgError, "no symbol given");
     }
 
     stack_check();


### PR DESCRIPTION
I think it's a bit cryptic and misleading. [Few people](https://www.google.pl/webhp?sourceid=chrome-instant&ion=1&espv=2&ie=UTF-8#q=ruby+no+id+given) got confused what exactly this error message mean

I'm suggesting to change it for something more obvious.