### PR TITLE
Don't retry streaming idempotent HTTP methods

### DIFF
--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -1452,7 +1452,7 @@ module Net   #:nodoc:
              # avoid a dependency on OpenSSL
              defined?(OpenSSL::SSL) ? OpenSSL::SSL::SSLError : IOError,
              Timeout::Error => exception
-        if count == 0 && IDEMPOTENT_METHODS_.include?(req.method)
+        if count == 0 && IDEMPOTENT_METHODS_.include?(req.method) && !block_given?
           count += 1
           @socket.close if @socket and not @socket.closed?
           D "Conn close because of error #{exception}, and retry"

--- a/test/net/http/test_http.rb
+++ b/test/net/http/test_http.rb
@@ -866,31 +866,42 @@ class TestNetHTTPKeepAlive < Test::Unit::TestCase
   include TestNetHTTPUtils
 
   def test_keep_alive_get_auto_reconnect
-    start {|http|
+    http = new
+    res = http.get('/')
+    http.keep_alive_timeout = 1
+    assert_kind_of Net::HTTPResponse, res
+    assert_kind_of String, res.body
+    sleep 1.5
+    assert_nothing_raised {
       res = http.get('/')
-      http.keep_alive_timeout = 1
-      assert_kind_of Net::HTTPResponse, res
-      assert_kind_of String, res.body
-      sleep 1.5
-      assert_nothing_raised {
-        res = http.get('/')
-      }
-      assert_kind_of Net::HTTPResponse, res
-      assert_kind_of String, res.body
     }
+    assert_kind_of Net::HTTPResponse, res
+    assert_kind_of String, res.body
   end
 
   def test_keep_alive_get_auto_retry
-    start {|http|
+    http = new
+    res = http.get('/')
+    http.keep_alive_timeout = 5
+    assert_kind_of Net::HTTPResponse, res
+    assert_kind_of String, res.body
+    sleep 1.5
+    res = http.get('/')
+    assert_kind_of Net::HTTPResponse, res
+    assert_kind_of String, res.body
+  end
+
+  def test_keep_alive_no_auto_retry_block
+    start do |http|
       res = http.get('/')
       http.keep_alive_timeout = 5
       assert_kind_of Net::HTTPResponse, res
       assert_kind_of String, res.body
       sleep 1.5
-      res = http.get('/')
+      assert_raises(EOFError) { res = http.get('/') }
       assert_kind_of Net::HTTPResponse, res
       assert_kind_of String, res.body
-    }
+    end
   end
 
   def test_keep_alive_server_close


### PR DESCRIPTION
Hello!

A colleague of mine ran into an issue today where he discovered that streaming HTTP requests made with Net::HTTP would retry some types of errors without giving any indication that an error had occurred and the request stream had been rewound. This ultimately resulted in a response body that contained an incomplete response followed by the complete response body.

I think when the request is being streamed it cannot be considered idempotent because there's no telling what sort of side effects might occur in the block that the response chunk is yielded to.

**I've also created an issue [here](https://bugs.ruby-lang.org/issues/11526) as I suspect this change warrants further discussion.**

We are not the first to run into this issue. One of the developers of the aws-sdk gem ran into this same issue in the last 6 months and chose to handle the issue by clearing out the IDEMPOTENT_METHODS_ collection such that no requests would automatically retry. This seems like overkill to me, but makes sense for a minimally evasive monkeypatch.

The author of that patch, Trevor Rowe, suggested that he would create an issue here, but I have been unable to find such an issue.

The related aws-sdk GitHub issue: https://github.com/aws/aws-sdk-ruby/pull/799
The related aws-sdk GitHub commit: https://github.com/aws/aws-sdk-ruby/commit/5a005974afcda0ec0c8e9332bed4c70a78443500

If I can provide any further information on this matter, please let me know.

Thanks in advance for any and all help!