### PR TITLE
env for Process#exec in CYGWIN

### DIFF
--- a/process.c
+++ b/process.c
@@ -1327,7 +1327,7 @@ proc_exec_sh(const char *str, VALUE envp_str)
     rb_w32_uspawn(P_OVERLAY, (char *)str, 0);
     return -1;
 #else
-#if defined(__CYGWIN32__) || defined(__EMX__)
+#if defined(__EMX__)
     {
         char fbuf[MAXPATHLEN];
         char *shell = dln_find_exe_r("sh", 0, fbuf, sizeof(fbuf));


### PR DESCRIPTION
This pull request fixes a bug in CYGWIN.

The processes created with `Process#exec` not receive environment variables specified in the parameter `env`. Related methods (`Process#spawn`, `Kernel#exec`, `Kernel#spawn`, ... ) are also affected.

This sentence:
`ruby -e 'Process.exec( {"MYVAR" => "42"}, "echo MYVAR: $MYVAR" )'`
should prints:
`MYVAR: 42`
but it prints:
`MYVAR:`
