### PR TITLE
Missing method

### DIFF
--- a/lib/webrick/httpstatus.rb
+++ b/lib/webrick/httpstatus.rb
@@ -28,6 +28,7 @@ module WEBrick
       end
       class << self
         attr_reader :code, :reason_phrase # :nodoc:
+        alias to_i code # :nodoc:
       end
 
       # Returns the HTTP status code


### PR DESCRIPTION
Webrick HTTP Status class has no metod `to_i` (unlike instance).  
