### PR TITLE
Define OpenStruct attributes lazily

### DIFF
--- a/lib/ostruct.rb
+++ b/lib/ostruct.rb
@@ -90,7 +90,6 @@ class OpenStruct
       hash.each_pair do |k, v|
         k = k.to_sym
         @table[k] = v
-        new_ostruct_member(k)
       end
     end
   end


### PR DESCRIPTION
Instead of defining two methods—a reader and writer—for each OpenStruct attribute when it is initialized, define them lazily, the first time either one is called. This adheres to the principle of “pay for use”: methods that are never accessed are never defined. This optimization makes initialization an order of magnitude faster for objects with 100 attributes. In the worst-case scenario, where every attribute is accessed, performance is no worse than it is today.

Benchmark
---------
```ruby
require 'benchmark/ips'
require 'ostruct'

N = 100
ATTRS = (:aa..:zz).take(N)
HASH = Hash[ATTRS.map { |x| [x, x] }]

def ostruct
  OpenStruct.new(HASH)
end

Benchmark.ips do |x|
  x.report('ostruct') { ostruct }
end
```
```
-------------------------------------------------
   before       2.279k (± 8.8%) i/s -     11.395k
   after       24.702k (±12.8%) i/s -    122.600k
-------------------------------------------------
```