### PR TITLE
Privatize {Single}Forwardable API

### DIFF
--- a/lib/forwardable.rb
+++ b/lib/forwardable.rb
@@ -199,6 +199,8 @@ module Forwardable
   alias delegate instance_delegate
   alias def_delegators def_instance_delegators
   alias def_delegator def_instance_delegator
+
+  private(*instance_methods)
 end
 
 # SingleForwardable can be used to setup delegation at the object level as well.
@@ -286,4 +288,6 @@ module SingleForwardable
   alias delegate single_delegate
   alias def_delegators def_single_delegators
   alias def_delegator def_single_delegator
+
+  private(*instance_methods)
 end


### PR DESCRIPTION
For improve consistency with Module#define_method and Module#alias_method.

ticket: https://bugs.ruby-lang.org/issues/11554
