### PR TITLE
Finish defining OpenStruct attributes lazily

### DIFF
--- a/test/ostruct/test_ostruct.rb
+++ b/test/ostruct/test_ostruct.rb
@@ -9,6 +9,19 @@ class TC_OpenStruct < Test::Unit::TestCase
     assert_equal h, OpenStruct.new(Struct.new(*h.keys).new(*h.values)).to_h
   end
 
+  def test_respond_to
+    o = OpenStruct.new
+    o.a = 1
+    assert_respond_to(o, :a)
+    assert_respond_to(o, :a=)
+  end
+
+  def test_respond_to_with_lazy_getter
+    o = OpenStruct.new a: 1
+    assert_respond_to(o, :a)
+    assert_respond_to(o, :a=)
+  end
+
   def test_equality
     o1 = OpenStruct.new
     o2 = OpenStruct.new


### PR DESCRIPTION
This commit is an addendum to https://github.com/ruby/ruby/pull/1033.

It:
1. lazily defines attribute accessors for copied and marshaled objects,
2. returns `nil` when an attribute reader is not defined, and
3. defines `respond_to_missing?` to maintain the same `respond_to?` behavior.

cc: @zzak @Arsen7