### PR TITLE
Update date_core.c

### DIFF
--- a/ext/date/date_core.c
+++ b/ext/date/date_core.c
@@ -7186,7 +7186,8 @@ datetime_s_jd(int argc, VALUE *argv, VALUE klass)
 
     jd = INT2FIX(0);
 
-    h = min = s = 0;
+    h   = 12;
+    min = s = 0;
     fr2 = INT2FIX(0);
     rof = 0;
     sg = DEFAULT_SG;


### PR DESCRIPTION
Of course the tests in place have not been modified. So go red green refactor and think about it.
Why did I change just one number? The results that I have been getting from `DateTime.jd`(any good `ajd` with some time in it) is off by 12 or half a day short. Maybe I don't know what I'm doing but it's in that method somewhere and my install of the trunk gives me better results. Make check did fail there though but then so did so many other tests that by that time I didn't care because my old piece of junk laptop has been spitting up chunks and I end up having to reload the system anyway. So I installed Ruby in root not a user. It defaults to `/usr/local/bin` and so does not mess up my system install of 1.9.1 from Debian of old behind the times wheezy kali dragon that never did any metasploitation for any reason because it's selfish and just wants to hoard the treasure. ;-D
