### PR TITLE
Fix `OpenStruct#respond_to?` with lazy-get initializer

### DIFF
--- a/lib/ostruct.rb
+++ b/lib/ostruct.rb
@@ -172,6 +172,14 @@ class OpenStruct
   end
   protected :new_ostruct_member
 
+  def respond_to_missing?(mid, include_private = false) # :nodoc:
+    if mname = mid[/.*(?==\z)/m]
+      @table.include? mname.to_sym
+    else
+      @table.include? mid
+    end
+  end
+
   def method_missing(mid, *args) # :nodoc:
     len = args.length
     if mname = mid[/.*(?==\z)/m]

--- a/test/ostruct/test_ostruct.rb
+++ b/test/ostruct/test_ostruct.rb
@@ -9,6 +9,19 @@ class TC_OpenStruct < Test::Unit::TestCase
     assert_equal h, OpenStruct.new(Struct.new(*h.keys).new(*h.values)).to_h
   end
 
+  def test_respond_to
+    o = OpenStruct.new
+    o.a = 1
+    assert_respond_to(o, :a)
+    assert_respond_to(o, :a=)
+  end
+
+  def test_respond_to_with_lazy_getter
+    o = OpenStruct.new a: 1
+    assert_respond_to(o, :a)
+    assert_respond_to(o, :a=)
+  end
+
   def test_equality
     o1 = OpenStruct.new
     o2 = OpenStruct.new


### PR DESCRIPTION
https://github.com/ruby/ruby/pull/1033#issuecomment-145315772

After #1033:
```ruby
>> OpenStruct.new(a: true).respond_to?(:a)
=> false
```

Before #1033 and with this fix:
```ruby
>> OpenStruct.new(a: true).respond_to?(:a)
=> true
```