### PR TITLE
parse.y: label with percent

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -7478,13 +7478,15 @@ parse_qmark(struct parser_params *parser)
 }
 
 static int
-parse_percent(struct parser_params *parser, const int space_seen, const enum lex_state_e last_state)
+parse_percent(struct parser_params *parser, const int space_seen, int cmd_state,
+	      const enum lex_state_e last_state)
 {
     register int c;
 
     if (IS_lex_state(EXPR_BEG_ANY)) {
 	int term;
 	int paren;
+	int label;
 
 	c = nextc();
       quotation:
@@ -7512,11 +7514,13 @@ parse_percent(struct parser_params *parser, const int space_seen, const enum lex
 
 	switch (c) {
 	  case 'Q':
-	    lex_strterm = NEW_STRTERM(str_dquote, term, paren);
+	    label = (IS_LABEL_POSSIBLE() ? str_label : 0);
+	    lex_strterm = NEW_STRTERM(str_dquote | label, term, paren);
 	    return tSTRING_BEG;
 
 	  case 'q':
-	    lex_strterm = NEW_STRTERM(str_squote, term, paren);
+	    label = (IS_LABEL_POSSIBLE() ? str_label : 0);
+	    lex_strterm = NEW_STRTERM(str_squote | label, term, paren);
 	    return tSTRING_BEG;
 
 	  case 'W':
@@ -8517,7 +8521,7 @@ parser_yylex(struct parser_params *parser)
 	return '\\';
 
       case '%':
-	return parse_percent(parser, space_seen, last_state);
+	return parse_percent(parser, space_seen, cmd_state, last_state);
 
       case '$':
 	return parse_gvar(parser, last_state);

--- a/test/ruby/test_syntax.rb
+++ b/test/ruby/test_syntax.rb
@@ -304,13 +304,12 @@ WARN
     assert_not_label(:foo, 'class Foo < not_label:foo; end', bug6347)
   end
 
-  def test_no_label_with_percent
-    assert_syntax_error('{%"a": 1}', /unexpected ':'/)
-    assert_syntax_error("{%'a': 1}", /unexpected ':'/)
-    assert_syntax_error('{%Q"a": 1}', /unexpected ':'/)
-    assert_syntax_error("{%Q'a': 1}", /unexpected ':'/)
-    assert_syntax_error('{%q"a": 1}', /unexpected ':'/)
-    assert_syntax_error("{%q'a': 1}", /unexpected ':'/)
+  def test_label_with_percent
+    ["", "Q", "q"].product(%w[" ']) {|c, q|
+      code = "{%#{c}#{q}a#{q}: 1}"
+      assert_valid_syntax(code)
+      assert_equal({:a => 1}, eval(code), code)
+    }
   end
 
   def test_block_after_cond

--- a/test/ruby/test_syntax.rb
+++ b/test/ruby/test_syntax.rb
@@ -305,11 +305,14 @@ WARN
   end
 
   def test_label_with_percent
-    ["", "Q", "q"].product(%w[" ']) {|c, q|
-      code = "{%#{c}#{q}a#{q}: 1}"
-      assert_valid_syntax(code)
-      assert_equal({:a => 1}, eval(code), code)
-    }
+    all_assertions do |a|
+      ["", "Q", "q"].product(%w[" ']) {|c, q|
+        a.for(code = "{%#{c}#{q}a#{q}: 1}") {
+          assert_valid_syntax(code)
+          assert_equal({:a => 1}, eval(code), code)
+        }
+      }
+    end
   end
 
   def test_block_after_cond


### PR DESCRIPTION
allow percent strings to be labels.
[Bug #10653] [Bug #11456]
