### PR TITLE
compile.c: toplevel return

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -4535,7 +4535,13 @@ iseq_compile_each(rb_iseq_t *iseq, LINK_ANCHOR *ret, NODE * node, int poped)
 	    ADD_INSN(ret, line, nop);
 	}
 	else {
+	    if (iseq->body->type == ISEQ_TYPE_MAIN) {
+		ADD_ADJUST(ret, line, lstart);
+	    }
 	    ADD_SEQ(ret, ensr);
+	    if (iseq->body->type == ISEQ_TYPE_MAIN) {
+		ADD_ADJUST(ret, line, lstart);
+	    }
 	}
 	ADD_LABEL(ret, lcont);
 
@@ -5346,7 +5352,10 @@ iseq_compile_each(rb_iseq_t *iseq, LINK_ANCHOR *ret, NODE * node, int poped)
 	if (is) {
 	    enum iseq_type type = is->body->type;
 
-	    if (type == ISEQ_TYPE_TOP || type == ISEQ_TYPE_MAIN) {
+	    if (type == ISEQ_TYPE_TOP ||
+		type == ISEQ_TYPE_MAIN ||
+		type == ISEQ_TYPE_ENSURE ||
+		0) {
 		ADD_INSN(ret, line, putnil);
 		ADD_INSN(ret, line, leave);
 	    }
@@ -5361,7 +5370,7 @@ iseq_compile_each(rb_iseq_t *iseq, LINK_ANCHOR *ret, NODE * node, int poped)
 
 		COMPILE(ret, "return nd_stts (return val)", node->nd_stts);
 
-		if (type == ISEQ_TYPE_METHOD) {
+		if (splabel) {
 		    add_ensure_iseq(ret, iseq, 1);
 		    ADD_TRACE(ret, line, RUBY_EVENT_RETURN);
 		    ADD_INSN(ret, line, leave);

--- a/compile.c
+++ b/compile.c
@@ -5344,13 +5344,16 @@ iseq_compile_each(rb_iseq_t *iseq, LINK_ANCHOR *ret, NODE * node, int poped)
 	rb_iseq_t *is = iseq;
 
 	if (is) {
-	    if (is->body->type == ISEQ_TYPE_TOP) {
-		COMPILE_ERROR(ERROR_ARGS "Invalid return");
+	    enum iseq_type type = is->body->type;
+
+	    if (type == ISEQ_TYPE_TOP || type == ISEQ_TYPE_MAIN) {
+		ADD_INSN(ret, line, putnil);
+		ADD_INSN(ret, line, leave);
 	    }
 	    else {
 		LABEL *splabel = 0;
 
-		if (is->body->type == ISEQ_TYPE_METHOD) {
+		if (type == ISEQ_TYPE_METHOD) {
 		    splabel = NEW_LABEL(0);
 		    ADD_LABEL(ret, splabel);
 		    ADD_ADJUST(ret, line, 0);
@@ -5358,7 +5361,7 @@ iseq_compile_each(rb_iseq_t *iseq, LINK_ANCHOR *ret, NODE * node, int poped)
 
 		COMPILE(ret, "return nd_stts (return val)", node->nd_stts);
 
-		if (is->body->type == ISEQ_TYPE_METHOD) {
+		if (type == ISEQ_TYPE_METHOD) {
 		    add_ensure_iseq(ret, iseq, 1);
 		    ADD_TRACE(ret, line, RUBY_EVENT_RETURN);
 		    ADD_INSN(ret, line, leave);

--- a/iseq.c
+++ b/iseq.c
@@ -2419,6 +2419,7 @@ Init_ISeq(void)
 {
     /* declare ::RubyVM::InstructionSequence */
     rb_cISeq = rb_define_class_under(rb_cRubyVM, "InstructionSequence", rb_cObject);
+    rb_define_global_const("ISeq", rb_cISeq);
     rb_define_method(rb_cISeq, "inspect", iseqw_inspect, 0);
     rb_define_method(rb_cISeq, "disasm", iseqw_disasm, 0);
     rb_define_method(rb_cISeq, "disassemble", iseqw_disasm, 0);
@@ -2450,9 +2451,9 @@ Init_ISeq(void)
 #if 0 /* TBD */
     rb_define_private_method(rb_cISeq, "marshal_dump", iseqw_marshal_dump, 0);
     rb_define_private_method(rb_cISeq, "marshal_load", iseqw_marshal_load, 1);
+#endif
     /* disable this feature because there is no verifier. */
     rb_define_singleton_method(rb_cISeq, "load", iseq_s_load, -1);
-#endif
     (void)iseq_s_load;
 
     rb_define_singleton_method(rb_cISeq, "compile", iseqw_s_compile, -1);

--- a/test/ruby/test_syntax.rb
+++ b/test/ruby/test_syntax.rb
@@ -832,6 +832,26 @@ eom
     assert_valid_syntax("foo (bar rescue nil)")
   end
 
+  def test_return_toplevel
+    feature4840 = '[ruby-core:36785] [Feature #4840]'
+    code = <<~'CODE'
+    return; raise
+    begin return; rescue SystemExit; exit false; end
+    begin return; ensure exit false; end
+    begin ensure return; end
+    begin raise; ensure; return; end
+    begin raise; rescue; return; end
+    return false; raise
+    return 1; raise
+    CODE
+    all_assertions(feature4840) do |a|
+      code.each_line do |s|
+        s.chomp!
+        a.for(s) {assert_ruby_status([], s)}
+      end
+    end
+  end
+
   private
 
   def not_label(x) @result = x; @not_label ||= nil end


### PR DESCRIPTION
- compile.c (iseq_compile_each): stop execution of the current source
  by toplevel return.  [ruby-core:36785] [Feature #4840]
