### PR TITLE
symbol.c: Symbol#gen

### DIFF
--- a/string.c
+++ b/string.c
@@ -8881,6 +8881,11 @@ sym_inspect(VALUE sym)
     long len;
     char *dest;
 
+    if (UNLIKELY(!str)) {
+	str = rb_any_to_s(sym);
+	dest = RSTRING_PTR(str);
+    }
+    else
     if (!rb_str_symname_p(str)) {
 	str = rb_str_inspect(str);
 	len = RSTRING_LEN(str);
@@ -9214,6 +9219,7 @@ rb_to_symbol(VALUE name)
 void
 Init_String(void)
 {
+    VALUE rb_sym_s_generate(VALUE klass);
 #undef rb_intern
 #define rb_intern(str) rb_intern_const(str)
 
@@ -9359,6 +9365,7 @@ Init_String(void)
     rb_undef_alloc_func(rb_cSymbol);
     rb_undef_method(CLASS_OF(rb_cSymbol), "new");
     rb_define_singleton_method(rb_cSymbol, "all_symbols", rb_sym_all_symbols, 0); /* in symbol.c */
+    rb_define_singleton_method(rb_cSymbol, "gen", rb_sym_s_generate, 0); /* in symbol.c */
 
     rb_define_method(rb_cSymbol, "==", sym_equal, 1);
     rb_define_method(rb_cSymbol, "===", sym_equal, 1);

--- a/symbol.c
+++ b/symbol.c
@@ -873,6 +873,23 @@ rb_sym_immortal_count(void)
     return (size_t)global_symbols.last_id;
 }
 
+VALUE
+rb_sym_s_generate(VALUE klass)
+{
+    const VALUE dsym = rb_newobj_of(klass, T_SYMBOL | FL_WB_PROTECTED);
+    long hashval = rb_objid_hash((st_index_t)dsym);
+
+    OBJ_FREEZE(dsym);
+    RSYMBOL(dsym)->id = ID_JUNK;
+    RSYMBOL(dsym)->hashval = RSHIFT(hashval, 1);
+
+    if (RUBY_DTRACE_SYMBOL_CREATE_ENABLED()) {
+	RUBY_DTRACE_SYMBOL_CREATE(NULL, rb_sourcefile(), rb_sourceline());
+    }
+
+    return dsym;
+}
+
 int
 rb_is_const_id(ID id)
 {


### PR DESCRIPTION
- string.c (sym_inspect): support anonymous Symbols.
- symbol.c (rb_sym_s_generate): add Symbol#gen method.
