### PR TITLE
[ci skip] Fix grammar on `respond_to?` warning message

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -24,6 +24,10 @@ Wed Oct  7 17:30:50 2015  Nobuyoshi Nakada  <nobu@ruby-lang.org>
 
 	* string.c (rb_str_times): optimize for the argument 0 and 1.
 
+Wed Oct  7 04:49:24 2015  Nick Cox  <nick@nickcox.me>
+
+	* vm_method.c: fix grammar in respond_to? warning.
+
 Wed Oct  7 01:20:46 2015  Koichi Sasada  <ko1@atdot.net>
 
 	* gc.h, gc.c: introduce new debug function rb_obj_info_dump(VALUE obj)

--- a/vm_method.c
+++ b/vm_method.c
@@ -1885,8 +1885,8 @@ vm_respond_to(rb_thread_t *th, VALUE klass, VALUE obj, ID id, int priv)
 	    }
 	    else if (!NIL_P(ruby_verbose)) {
 		VALUE location = rb_method_entry_location(me);
-		rb_warn("%"PRIsVALUE"%c""respond_to?(:%"PRIsVALUE") is"
-			" old fashion which takes only one parameter",
+		rb_warn("%"PRIsVALUE"%c""respond_to?(:%"PRIsVALUE") uses"
+			" the deprecated method signature, which takes one parameter",
 			(FL_TEST(klass, FL_SINGLETON) ? obj : klass),
 			(FL_TEST(klass, FL_SINGLETON) ? '.' : '#'),
 			QUOTE_ID(id));


### PR DESCRIPTION
This PR corrects the grammar on the `respond_to?` warning message. Notably, it also changes the wording from 'old fashion' to 'deprecated,' which I assume is the intended meaning. I couldn't find documentation that this was necessarily officially deprecated, but it didn't seem like there would be a warning otherwise. If this is not the case, then I can change the correction to read 'old fashioned,' which would be correct grammar.

I thought it might also help the user to let them know that they could add `include_all=false` as the second method parameter to git rid of the warnings, but I didn't add that yet.

This is my first commit to Ruby. I read the "How to Contribute" wiki as thoroughly as I could before submitting this patch. Please let me know if anything needs to be updated.