### PR TITLE
optimize gc sweep

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -2007,11 +2007,6 @@ struct obj_free_info_t {
 
 static inline void obj_free_prologue(rb_objspace_t *objspace, VALUE obj)
 {
-    if (FL_TEST(obj, FL_EXIVAR)) {
-	rb_free_generic_ivar((VALUE)obj);
-	FL_UNSET(obj, FL_EXIVAR);
-    }
-
 #if USE_RGENGC
     if (RVALUE_WB_UNPROTECTED(obj)) CLEAR_IN_BITMAP(GET_HEAP_WB_UNPROTECTED_BITS(obj), obj);
 
@@ -3447,6 +3442,10 @@ gc_page_sweep(rb_objspace_t *objspace, rb_heap_t *heap, struct heap_page *sweep_
 			    gc_event_hook_body(GET_THREAD(), objspace, RUBY_INTERNAL_EVENT_FREEOBJ, (VALUE)p);
 			    break;
 			}
+		    }
+		    if (FL_TEST((VALUE)p, FL_EXIVAR)) {
+			rb_free_generic_ivar((VALUE)p);
+			FL_UNSET((VALUE)p, FL_EXIVAR);
 		    }
 		    if (obj_free_handlers[BUILTIN_TYPE(p)](objspace, (VALUE)p, &free_info) == 0) {
 			++freed_slots;


### PR DESCRIPTION
This PR optimizes the `gc_page_sweep` function.

Consider the case of sweeping a string.

In case of trunk, the code path is: switch -> call obj_free -> switch -> switch -> call rb_str_free (note that obj_free does not get inlined).
This PR changes the code path to: call obj_free_string (via table lookup) -> jmp rb_str_free.

On my MacBook Pro using GCC 5.1.0, the following synthetic benchmark went from 7.57 sec. (trunk) to 7.21 sec (this PR).
```
require "benchmark"
N = 100_000_000
GC.start; GC.start # magic
Benchmark.bm{|bm|
  bm.report{N.times{str = "a"}}
}
```

The number of GC benchmarks changed as follows:

benchmark | trunk (user time / gc time) | this PR (user time / gc time) |
------------|-------:| --------:|
gcbench-rdoc | 97.5 / 5.27 | 95.0 / 5.15 |
gcbench-aobench | 72.3 / 4.15 | 69.3 / 3.98 |

Please take with a grain of salt when looking at the changes in user time; there were some variation between repetitive runs, and I am not sure why the numbers changed - does the incremental GC of ruby refer to some timer (in which case reduced number of sweep runs (as its faster) would lead to better CPU cache usage explaining the gain), or if not, it could be due to better use of branch prediction unit.
OTOH the gc time numbers observed were mostly consistent.