### PR TITLE
optimize performance of  `rb_str_resurrect`

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -1784,10 +1784,10 @@ newobj_of_init(rb_objspace_t *objspace, VALUE klass, VALUE flags, VALUE v1, VALU
     return obj;
 }
 
-NOINLINE(static VALUE newobj_of_slowpass(rb_objspace_t *objspace, VALUE klass, VALUE flags, VALUE v1, VALUE v2, VALUE v3, int hook_needed));
+NOINLINE(static VALUE newobj_of_slowpass(rb_objspace_t *objspace, VALUE klass, VALUE flags, VALUE v1, VALUE v2, VALUE v3));
 
 static VALUE
-newobj_of_slowpass(rb_objspace_t *objspace, VALUE klass, VALUE flags, VALUE v1, VALUE v2, VALUE v3, int hook_needed)
+newobj_of_slowpass(rb_objspace_t *objspace, VALUE klass, VALUE flags, VALUE v1, VALUE v2, VALUE v3)
 {
     VALUE obj;
 
@@ -1806,7 +1806,7 @@ newobj_of_slowpass(rb_objspace_t *objspace, VALUE klass, VALUE flags, VALUE v1, 
     }
 
     obj = heap_get_freeobj(objspace, heap_eden);
-    return newobj_of_init(objspace, klass, flags, v1, v2, v3, obj, hook_needed);
+    return newobj_of_init(objspace, klass, flags, v1, v2, v3, obj, gc_event_hook_needed_p(objspace, RUBY_INTERNAL_EVENT_NEWOBJ));
 }
 
 static VALUE
@@ -1814,7 +1814,6 @@ newobj_of(VALUE klass, VALUE flags, VALUE v1, VALUE v2, VALUE v3)
 {
     rb_objspace_t *objspace = &rb_objspace;
     VALUE obj;
-    int hook_needed = gc_event_hook_needed_p(objspace, RUBY_INTERNAL_EVENT_NEWOBJ);
 
 #if GC_DEBUG_STRESS_TO_CLASS
     if (UNLIKELY(stress_to_class)) {
@@ -1826,12 +1825,12 @@ newobj_of(VALUE klass, VALUE flags, VALUE v1, VALUE v2, VALUE v3)
     }
 #endif
 
-    if (LIKELY(!(during_gc || ruby_gc_stressful) && hook_needed == FALSE &&
+    if (LIKELY(!(during_gc || ruby_gc_stressful) && gc_event_hook_needed_p(objspace, RUBY_INTERNAL_EVENT_NEWOBJ) == FALSE &&
 	       (obj = heap_get_freeobj_head(objspace, heap_eden)) != Qfalse)) {
 	return newobj_of_init(objspace, klass, flags, v1, v2, v3, obj, FALSE);
     }
     else {
-	return newobj_of_slowpass(objspace, klass, flags, v1, v2, v3, hook_needed);
+	return newobj_of_slowpass(objspace, klass, flags, v1, v2, v3);
     }
 }
 

--- a/gc.c
+++ b/gc.c
@@ -1809,7 +1809,7 @@ newobj_of_slowpass(rb_objspace_t *objspace, VALUE klass, VALUE flags, VALUE v1, 
     return newobj_of_init(objspace, klass, flags, v1, v2, v3, obj, gc_event_hook_needed_p(objspace, RUBY_INTERNAL_EVENT_NEWOBJ));
 }
 
-static VALUE
+static inline VALUE
 newobj_of(VALUE klass, VALUE flags, VALUE v1, VALUE v2, VALUE v3)
 {
     rb_objspace_t *objspace = &rb_objspace;

--- a/gc.c
+++ b/gc.c
@@ -1784,10 +1784,10 @@ newobj_of_init(rb_objspace_t *objspace, VALUE klass, VALUE flags, VALUE v1, VALU
     return obj;
 }
 
-NOINLINE(static VALUE newobj_of_slowpass(rb_objspace_t *objspace, VALUE klass, VALUE flags, VALUE v1, VALUE v2, VALUE v3));
+NOINLINE(static VALUE newobj_of_slowpass(VALUE klass, VALUE flags, VALUE v1, VALUE v2, VALUE v3, rb_objspace_t *objspace));
 
 static VALUE
-newobj_of_slowpass(rb_objspace_t *objspace, VALUE klass, VALUE flags, VALUE v1, VALUE v2, VALUE v3)
+newobj_of_slowpass(VALUE klass, VALUE flags, VALUE v1, VALUE v2, VALUE v3, rb_objspace_t *objspace)
 {
     VALUE obj;
 
@@ -1830,7 +1830,7 @@ newobj_of(VALUE klass, VALUE flags, VALUE v1, VALUE v2, VALUE v3)
 	return newobj_of_init(objspace, klass, flags, v1, v2, v3, obj, FALSE);
     }
     else {
-	return newobj_of_slowpass(objspace, klass, flags, v1, v2, v3);
+	return newobj_of_slowpass(klass, flags, v1, v2, v3, objspace);
     }
 }
 

--- a/string.c
+++ b/string.c
@@ -1233,7 +1233,7 @@ str_replace(VALUE str, VALUE str2)
     return str;
 }
 
-static VALUE
+static inline VALUE
 str_duplicate(VALUE klass, VALUE str)
 {
     enum {embed_size = RSTRING_EMBED_LEN_MAX + 1};


### PR DESCRIPTION
Thank you for applying the proposed approach in e2cabc2.

Unfortunately, there were issues in the commit (and other related commits) that failed to gain the maximum from the division of fast and slow passes.  This PR addresses the issue.

The numbers I see when running the code below is as follows:

compiler | trunk | this PR |
---|---:|---:|
gcc 4.8.2 (linux) | 1.31 | 1.27 |
gcc 5.1.0 (OS X) | 1.49 | 1.42 |
clang-600.0.56 (OS X) | 1.58 | 1.51 |

benchmark code:
```
require "benchmark"
N = 20_000_000
GC.start; GC.start # magic
Benchmark.bm{|bm|
  bm.report{N.times{str = "a"}}
}
```