### PR TITLE
rsock_addrinfo: specify address family

### DIFF
--- a/ext/socket/ipsocket.c
+++ b/ext/socket/ipsocket.c
@@ -44,20 +44,20 @@ init_inetsock_internal(struct inetsock_arg *arg)
     int error = 0;
     int type = arg->type;
     struct addrinfo *res, *lres;
-    int fd, status = 0, local = 0;
+    int fd = -1, status = 0, local = 0;
     const char *syscall = 0;
 
-    arg->remote.res = rsock_addrinfo(arg->remote.host, arg->remote.serv, SOCK_STREAM,
+    arg->remote.res = rsock_addrinfo(arg->remote.host, arg->remote.serv, fd, SOCK_STREAM,
 				    (type == INET_SERVER) ? AI_PASSIVE : 0);
     /*
      * Maybe also accept a local address
      */
 
     if (type != INET_SERVER && (!NIL_P(arg->local.host) || !NIL_P(arg->local.serv))) {
-	arg->local.res = rsock_addrinfo(arg->local.host, arg->local.serv, SOCK_STREAM, 0);
+	arg->local.res = rsock_addrinfo(arg->local.host, arg->local.serv, fd, SOCK_STREAM, 0);
     }
 
-    arg->fd = fd = -1;
+    arg->fd = fd;
     for (res = arg->remote.res->ai; res; res = res->ai_next) {
 #if !defined(INET6) && defined(AF_INET6)
 	if (res->ai_family == AF_INET6)
@@ -308,7 +308,7 @@ static VALUE
 ip_s_getaddress(VALUE obj, VALUE host)
 {
     union_sockaddr addr;
-    struct rb_addrinfo *res = rsock_addrinfo(host, Qnil, SOCK_STREAM, 0);
+    struct rb_addrinfo *res = rsock_addrinfo(host, Qnil, -1, SOCK_STREAM, 0);
     socklen_t len = res->ai->ai_addrlen;
 
     /* just take the first one */

--- a/ext/socket/ipsocket.c
+++ b/ext/socket/ipsocket.c
@@ -44,20 +44,20 @@ init_inetsock_internal(struct inetsock_arg *arg)
     int error = 0;
     int type = arg->type;
     struct addrinfo *res, *lres;
-    int fd = -1, status = 0, local = 0;
+    int fd, status = 0, local = 0;
     const char *syscall = 0;
 
-    arg->remote.res = rsock_addrinfo(arg->remote.host, arg->remote.serv, fd, SOCK_STREAM,
+    arg->remote.res = rsock_addrinfo(arg->remote.host, arg->remote.serv, Qnil, SOCK_STREAM,
 				    (type == INET_SERVER) ? AI_PASSIVE : 0);
     /*
      * Maybe also accept a local address
      */
 
     if (type != INET_SERVER && (!NIL_P(arg->local.host) || !NIL_P(arg->local.serv))) {
-	arg->local.res = rsock_addrinfo(arg->local.host, arg->local.serv, fd, SOCK_STREAM, 0);
+	arg->local.res = rsock_addrinfo(arg->local.host, arg->local.serv, Qnil, SOCK_STREAM, 0);
     }
 
-    arg->fd = fd;
+    arg->fd = fd = -1;
     for (res = arg->remote.res->ai; res; res = res->ai_next) {
 #if !defined(INET6) && defined(AF_INET6)
 	if (res->ai_family == AF_INET6)
@@ -308,7 +308,7 @@ static VALUE
 ip_s_getaddress(VALUE obj, VALUE host)
 {
     union_sockaddr addr;
-    struct rb_addrinfo *res = rsock_addrinfo(host, Qnil, -1, SOCK_STREAM, 0);
+    struct rb_addrinfo *res = rsock_addrinfo(host, Qnil, Qnil, SOCK_STREAM, 0);
     socklen_t len = res->ai->ai_addrlen;
 
     /* just take the first one */

--- a/ext/socket/raddrinfo.c
+++ b/ext/socket/raddrinfo.c
@@ -519,16 +519,17 @@ rsock_getaddrinfo(VALUE host, VALUE port, struct addrinfo *hints, int socktype_h
 }
 
 struct rb_addrinfo*
-rsock_addrinfo(VALUE host, VALUE port, int fd, int socktype, int flags)
+rsock_addrinfo(VALUE host, VALUE port, VALUE sock, int socktype, int flags)
 {
     struct addrinfo hints;
-    struct sockaddr sa;
-    socklen_t sa_len;
+    rb_io_t *fptr;
+    struct sockaddr sa = { 0 };
+    socklen_t sa_len = sizeof(sa);
     int family = AF_UNSPEC;
 
-    if (fd >= 0) {
-        sa_len = sizeof(sa);
-        if (getsockname(fd, &sa, &sa_len) == 0) {
+    if (sock != Qnil) {
+        GetOpenFile(sock, fptr);
+        if (fptr->fd >= 0 && getsockname(fptr->fd, &sa, &sa_len) == 0) {
             family = sa.sa_family;
         }
     }

--- a/ext/socket/raddrinfo.c
+++ b/ext/socket/raddrinfo.c
@@ -529,7 +529,7 @@ rsock_addrinfo(VALUE host, VALUE port, VALUE sock, int socktype, int flags)
 
     if (sock != Qnil) {
         GetOpenFile(sock, fptr);
-        if (fptr->fd >= 0 && getsockname(fptr->fd, &sa, &sa_len) == 0) {
+        if (fptr && fptr->fd >= 0 && getsockname(fptr->fd, &sa, &sa_len) == 0) {
             family = sa.sa_family;
         }
     }

--- a/ext/socket/raddrinfo.c
+++ b/ext/socket/raddrinfo.c
@@ -519,12 +519,22 @@ rsock_getaddrinfo(VALUE host, VALUE port, struct addrinfo *hints, int socktype_h
 }
 
 struct rb_addrinfo*
-rsock_addrinfo(VALUE host, VALUE port, int socktype, int flags)
+rsock_addrinfo(VALUE host, VALUE port, int fd, int socktype, int flags)
 {
     struct addrinfo hints;
+    struct sockaddr sa;
+    socklen_t sa_len;
+    int family = AF_UNSPEC;
+
+    if (fd >= 0) {
+        sa_len = sizeof(sa);
+        if (getsockname(fd, &sa, &sa_len) == 0) {
+            family = sa.sa_family;
+        }
+    }
 
     MEMZERO(&hints, struct addrinfo, 1);
-    hints.ai_family = AF_UNSPEC;
+    hints.ai_family = family;
     hints.ai_socktype = socktype;
     hints.ai_flags = flags;
     return rsock_getaddrinfo(host, port, &hints, 1);

--- a/ext/socket/rubysocket.h
+++ b/ext/socket/rubysocket.h
@@ -295,7 +295,7 @@ int rb_getaddrinfo(const char *node, const char *service, const struct addrinfo 
 void rb_freeaddrinfo(struct rb_addrinfo *ai);
 VALUE rsock_freeaddrinfo(VALUE arg);
 int rb_getnameinfo(const struct sockaddr *sa, socklen_t salen, char *host, size_t hostlen, char *serv, size_t servlen, int flags);
-struct rb_addrinfo *rsock_addrinfo(VALUE host, VALUE port, int fd, int socktype, int flags);
+struct rb_addrinfo *rsock_addrinfo(VALUE host, VALUE port, VALUE sock, int socktype, int flags);
 struct rb_addrinfo *rsock_getaddrinfo(VALUE host, VALUE port, struct addrinfo *hints, int socktype_hack);
 VALUE rsock_fd_socket_addrinfo(int fd, struct sockaddr *addr, socklen_t len);
 VALUE rsock_io_socket_addrinfo(VALUE io, struct sockaddr *addr, socklen_t len);

--- a/ext/socket/rubysocket.h
+++ b/ext/socket/rubysocket.h
@@ -295,7 +295,7 @@ int rb_getaddrinfo(const char *node, const char *service, const struct addrinfo 
 void rb_freeaddrinfo(struct rb_addrinfo *ai);
 VALUE rsock_freeaddrinfo(VALUE arg);
 int rb_getnameinfo(const struct sockaddr *sa, socklen_t salen, char *host, size_t hostlen, char *serv, size_t servlen, int flags);
-struct rb_addrinfo *rsock_addrinfo(VALUE host, VALUE port, int socktype, int flags);
+struct rb_addrinfo *rsock_addrinfo(VALUE host, VALUE port, int fd, int socktype, int flags);
 struct rb_addrinfo *rsock_getaddrinfo(VALUE host, VALUE port, struct addrinfo *hints, int socktype_hack);
 VALUE rsock_fd_socket_addrinfo(int fd, struct sockaddr *addr, socklen_t len);
 VALUE rsock_io_socket_addrinfo(VALUE io, struct sockaddr *addr, socklen_t len);

--- a/ext/socket/socket.c
+++ b/ext/socket/socket.c
@@ -1140,7 +1140,7 @@ sock_sockaddr(struct sockaddr *addr, socklen_t len)
 static VALUE
 sock_s_gethostbyname(VALUE obj, VALUE host)
 {
-    return rsock_make_hostent(host, rsock_addrinfo(host, Qnil, -1, SOCK_STREAM, AI_CANONNAME), sock_sockaddr);
+    return rsock_make_hostent(host, rsock_addrinfo(host, Qnil, Qnil, SOCK_STREAM, AI_CANONNAME), sock_sockaddr);
 }
 
 /*
@@ -1518,7 +1518,7 @@ sock_s_getnameinfo(int argc, VALUE *argv)
 static VALUE
 sock_s_pack_sockaddr_in(VALUE self, VALUE port, VALUE host)
 {
-    struct rb_addrinfo *res = rsock_addrinfo(host, port, -1, 0, 0);
+    struct rb_addrinfo *res = rsock_addrinfo(host, port, Qnil, 0, 0);
     VALUE addr = rb_str_new((char*)res->ai->ai_addr, res->ai->ai_addrlen);
 
     rb_freeaddrinfo(res);

--- a/ext/socket/socket.c
+++ b/ext/socket/socket.c
@@ -1140,7 +1140,7 @@ sock_sockaddr(struct sockaddr *addr, socklen_t len)
 static VALUE
 sock_s_gethostbyname(VALUE obj, VALUE host)
 {
-    return rsock_make_hostent(host, rsock_addrinfo(host, Qnil, SOCK_STREAM, AI_CANONNAME), sock_sockaddr);
+    return rsock_make_hostent(host, rsock_addrinfo(host, Qnil, -1, SOCK_STREAM, AI_CANONNAME), sock_sockaddr);
 }
 
 /*
@@ -1518,7 +1518,7 @@ sock_s_getnameinfo(int argc, VALUE *argv)
 static VALUE
 sock_s_pack_sockaddr_in(VALUE self, VALUE port, VALUE host)
 {
-    struct rb_addrinfo *res = rsock_addrinfo(host, port, 0, 0);
+    struct rb_addrinfo *res = rsock_addrinfo(host, port, -1, 0, 0);
     VALUE addr = rb_str_new((char*)res->ai->ai_addr, res->ai->ai_addrlen);
 
     rb_freeaddrinfo(res);

--- a/ext/socket/tcpsocket.c
+++ b/ext/socket/tcpsocket.c
@@ -50,7 +50,7 @@ tcp_sockaddr(struct sockaddr *addr, socklen_t len)
 static VALUE
 tcp_s_gethostbyname(VALUE obj, VALUE host)
 {
-    return rsock_make_hostent(host, rsock_addrinfo(host, Qnil, SOCK_STREAM, AI_CANONNAME),
+    return rsock_make_hostent(host, rsock_addrinfo(host, Qnil, -1, SOCK_STREAM, AI_CANONNAME),
 			tcp_sockaddr);
 }
 

--- a/ext/socket/tcpsocket.c
+++ b/ext/socket/tcpsocket.c
@@ -50,7 +50,7 @@ tcp_sockaddr(struct sockaddr *addr, socklen_t len)
 static VALUE
 tcp_s_gethostbyname(VALUE obj, VALUE host)
 {
-    return rsock_make_hostent(host, rsock_addrinfo(host, Qnil, -1, SOCK_STREAM, AI_CANONNAME),
+    return rsock_make_hostent(host, rsock_addrinfo(host, Qnil, Qnil, SOCK_STREAM, AI_CANONNAME),
 			tcp_sockaddr);
 }
 

--- a/ext/socket/udpsocket.c
+++ b/ext/socket/udpsocket.c
@@ -84,8 +84,8 @@ udp_connect(VALUE sock, VALUE host, VALUE port)
     struct udp_arg arg;
     VALUE ret;
 
+    arg.res = rsock_addrinfo(host, port, sock, SOCK_DGRAM, 0);
     GetOpenFile(sock, fptr);
-    arg.res = rsock_addrinfo(host, port, fptr->fd, SOCK_DGRAM, 0);
     arg.fd = fptr->fd;
     ret = rb_ensure(udp_connect_internal, (VALUE)&arg,
 		    rsock_freeaddrinfo, (VALUE)arg.res);
@@ -112,8 +112,8 @@ udp_bind(VALUE sock, VALUE host, VALUE port)
     struct rb_addrinfo *res0;
     struct addrinfo *res;
 
+    res0 = rsock_addrinfo(host, port, sock, SOCK_DGRAM, 0);
     GetOpenFile(sock, fptr);
-    res0 = rsock_addrinfo(host, port, fptr->fd, SOCK_DGRAM, 0);
     for (res = res0->ai; res; res = res->ai_next) {
 	if (bind(fptr->fd, res->ai_addr, res->ai_addrlen) < 0) {
 	    continue;
@@ -166,8 +166,8 @@ udp_send(int argc, VALUE *argv, VALUE sock)
     rb_scan_args(argc, argv, "4", &arg.mesg, &flags, &host, &port);
 
     StringValue(arg.mesg);
+    res0 = rsock_addrinfo(host, port, sock, SOCK_DGRAM, 0);
     GetOpenFile(sock, fptr);
-    res0 = rsock_addrinfo(host, port, fptr->fd, SOCK_DGRAM, 0);
     arg.fd = fptr->fd;
     arg.flags = NUM2INT(flags);
     for (res = res0->ai; res; res = res->ai_next) {

--- a/ext/socket/udpsocket.c
+++ b/ext/socket/udpsocket.c
@@ -85,7 +85,7 @@ udp_connect(VALUE sock, VALUE host, VALUE port)
     VALUE ret;
 
     GetOpenFile(sock, fptr);
-    arg.res = rsock_addrinfo(host, port, arg.fd, SOCK_DGRAM, 0);
+    arg.res = rsock_addrinfo(host, port, fptr->fd, SOCK_DGRAM, 0);
     arg.fd = fptr->fd;
     ret = rb_ensure(udp_connect_internal, (VALUE)&arg,
 		    rsock_freeaddrinfo, (VALUE)arg.res);

--- a/ext/socket/udpsocket.c
+++ b/ext/socket/udpsocket.c
@@ -84,8 +84,8 @@ udp_connect(VALUE sock, VALUE host, VALUE port)
     struct udp_arg arg;
     VALUE ret;
 
-    arg.res = rsock_addrinfo(host, port, SOCK_DGRAM, 0);
     GetOpenFile(sock, fptr);
+    arg.res = rsock_addrinfo(host, port, arg.fd, SOCK_DGRAM, 0);
     arg.fd = fptr->fd;
     ret = rb_ensure(udp_connect_internal, (VALUE)&arg,
 		    rsock_freeaddrinfo, (VALUE)arg.res);
@@ -112,8 +112,8 @@ udp_bind(VALUE sock, VALUE host, VALUE port)
     struct rb_addrinfo *res0;
     struct addrinfo *res;
 
-    res0 = rsock_addrinfo(host, port, SOCK_DGRAM, 0);
     GetOpenFile(sock, fptr);
+    res0 = rsock_addrinfo(host, port, fptr->fd, SOCK_DGRAM, 0);
     for (res = res0->ai; res; res = res->ai_next) {
 	if (bind(fptr->fd, res->ai_addr, res->ai_addrlen) < 0) {
 	    continue;
@@ -166,8 +166,8 @@ udp_send(int argc, VALUE *argv, VALUE sock)
     rb_scan_args(argc, argv, "4", &arg.mesg, &flags, &host, &port);
 
     StringValue(arg.mesg);
-    res0 = rsock_addrinfo(host, port, SOCK_DGRAM, 0);
     GetOpenFile(sock, fptr);
+    res0 = rsock_addrinfo(host, port, fptr->fd, SOCK_DGRAM, 0);
     arg.fd = fptr->fd;
     arg.flags = NUM2INT(flags);
     for (res = res0->ai; res; res = res->ai_next) {

--- a/ext/socket/udpsocket.c
+++ b/ext/socket/udpsocket.c
@@ -84,8 +84,8 @@ udp_connect(VALUE sock, VALUE host, VALUE port)
     struct udp_arg arg;
     VALUE ret;
 
-    arg.res = rsock_addrinfo(host, port, sock, SOCK_DGRAM, 0);
     GetOpenFile(sock, fptr);
+    arg.res = rsock_addrinfo(host, port, sock, SOCK_DGRAM, 0);
     arg.fd = fptr->fd;
     ret = rb_ensure(udp_connect_internal, (VALUE)&arg,
 		    rsock_freeaddrinfo, (VALUE)arg.res);
@@ -112,12 +112,8 @@ udp_bind(VALUE sock, VALUE host, VALUE port)
     struct rb_addrinfo *res0;
     struct addrinfo *res;
 
-<<<<<<< HEAD
-    res0 = rsock_addrinfo(host, port, sock, SOCK_DGRAM, 0);
-=======
->>>>>>> 1331f80a1e420a5d0644efb78559e1647e58ffb8
     GetOpenFile(sock, fptr);
-    res0 = rsock_addrinfo(host, port, SOCK_DGRAM, 0);
+    res0 = rsock_addrinfo(host, port, sock, SOCK_DGRAM, 0);
     for (res = res0->ai; res; res = res->ai_next) {
 	if (bind(fptr->fd, res->ai_addr, res->ai_addrlen) < 0) {
 	    continue;
@@ -170,12 +166,8 @@ udp_send(int argc, VALUE *argv, VALUE sock)
     rb_scan_args(argc, argv, "4", &arg.mesg, &flags, &host, &port);
 
     StringValue(arg.mesg);
-<<<<<<< HEAD
-    res0 = rsock_addrinfo(host, port, sock, SOCK_DGRAM, 0);
-=======
->>>>>>> 1331f80a1e420a5d0644efb78559e1647e58ffb8
     GetOpenFile(sock, fptr);
-    res0 = rsock_addrinfo(host, port, SOCK_DGRAM, 0);
+    res0 = rsock_addrinfo(host, port, sock, SOCK_DGRAM, 0);
     arg.fd = fptr->fd;
     arg.flags = NUM2INT(flags);
     for (res = res0->ai; res; res = res->ai_next) {


### PR DESCRIPTION
While running strace, I noticed that a ruby script sending a UDP datagram to localhost would call `sendto` twice. The first `sendto` used an IPv6 address, and would fail, and the second `sendto` used an IPv4 address and would succeed.

The issue seems to be that sockets are created with a domain of PF_INET by default, but hostname lookups (`getaddrinfo`) are done with no address family hint. I have attempted to fix this here.

Here is a short script that illustrates the problem.
```
require 'socket'
socket = UDPSocket.new
socket.send("123", 0, "localhost", 5556)
```

Here is the strace output, before my patch:
```
$ strace ~/ruby-master/bin/ruby ~/udp.rb 2>&1 | grep INET | egrep '(send|socket)'
socket(PF_INET, SOCK_DGRAM|SOCK_CLOEXEC, IPPROTO_IP) = 7
socket(PF_INET, SOCK_DGRAM, IPPROTO_IP) = 8
socket(PF_INET6, SOCK_DGRAM, IPPROTO_IP) = 8
sendto(7, "123", 3, 0, {sa_family=AF_INET6, sin6_port=htons(5556), inet_pton(AF_INET6, "::1", &sin6_addr), sin6_flowinfo=0, sin6_scope_id=0}, 28) = -1 EAFNOSUPPORT (Address family not supported by protocol)
sendto(7, "123", 3, 0, {sa_family=AF_INET, sin_port=htons(5556), sin_addr=inet_addr("127.0.0.1")}, 16) = 3
```

And after my patch:
```
$ strace ~/ruby-fix-getaddrinfo/bin/ruby ~/udp.rb 2>&1 | grep INET | egrep '(send|socket)'
socket(PF_INET, SOCK_DGRAM|SOCK_CLOEXEC, IPPROTO_IP) = 7
socket(PF_INET, SOCK_DGRAM, IPPROTO_IP) = 8
sendto(7, "123", 3, 0, {sa_family=AF_INET, sin_port=htons(5556), sin_addr=inet_addr("127.0.0.1")}, 16) = 3
```
