### PR TITLE
Return encoding in content_type

### DIFF
--- a/lib/net/http/header.rb
+++ b/lib/net/http/header.rb
@@ -305,7 +305,8 @@ module Net::HTTPHeader
   def content_type
     return nil unless main_type()
     if sub_type()
-    then "#{main_type()}/#{sub_type()}"
+      main_and_sub_type = "#{main_type()}/#{sub_type()}"
+      encoding() ? "#{main_and_sub_type};#{encoding()}" : main_and_sub_type
     else main_type()
     end
   end
@@ -325,6 +326,14 @@ module Net::HTTPHeader
     _, sub = *self['Content-Type'].split(';').first.to_s.split('/')
     return nil unless sub
     sub.strip
+  end
+
+  # Returns a content type encoding string such as "html".
+  # This method returns nil if Content-Type: header field does not exist
+  # or encoding is not given (e.g. "Content-Type: text/html").
+  def encoding
+    return nil unless @header['content-type']
+    self['Content-Type'].split(';')[1]
   end
 
   # Any parameters specified for the content type, returned as a Hash.
@@ -449,4 +458,3 @@ module Net::HTTPHeader
   private :tokens
 
 end
-

--- a/test/net/http/test_httpheader.rb
+++ b/test/net/http/test_httpheader.rb
@@ -270,6 +270,8 @@ class HTTPHeaderTest < Test::Unit::TestCase
     assert_equal 'application/pdf', @c.content_type
     @c.set_content_type 'text/html', {'charset' => 'iso-2022-jp'}
     assert_equal 'text/html', @c.content_type
+    @c.set_content_type 'text/html; charset=iso-2022-jp'
+    assert_equal 'text/html; charset=iso-2022-jp', @c.content_type
     @c.content_type = 'text'
     assert_equal 'text', @c.content_type
   end


### PR DESCRIPTION
Using net-http to create a request, we can set the content-type like this:

`request.content_type = 'application/json;  charset=utf-8'`

But, when trying to get the content-type back, it omits the charset information:
```
request.content_type
=> "application/json"
```

And using direct header access, it works like expected:
```
request['Content-Type']
=> "application/json; charset=utf-8"
```

This pull request is to avoid this inconsistency. I don't know if it's something planned, so sorry if I missed something.