### PR TITLE
Count trace_running for internal event

### DIFF
--- a/vm_trace.c
+++ b/vm_trace.c
@@ -318,10 +318,12 @@ rb_threadptr_exec_event_hooks_orig(rb_trace_arg_t *trace_arg, int pop_p)
 	}
 	else {
 	    rb_trace_arg_t *prev_trace_arg = th->trace_arg;
+	    th->vm->trace_running++;
 	    th->trace_arg = trace_arg;
 	    exec_hooks_unprotected(th, &th->event_hooks, trace_arg);
 	    exec_hooks_unprotected(th, &th->vm->event_hooks, trace_arg);
 	    th->trace_arg = prev_trace_arg;
+	    th->vm->trace_running--;
 	}
     }
     else {


### PR DESCRIPTION
When I run tests of byebug gem with this patch https://github.com/deivid-rodriguez/byebug/pull/160, I've encountered random SEGV. The crash report is here: https://gist.github.com/k0kubun/86fd9fbff32423bd4974

I noticed that [clean_hooks](https://gist.github.com/k0kubun/3d8e15c12200553a1ec4#file-clean_hooks_backtrace-log-L25) is executed inside [exec_hooks_body](https://gist.github.com/k0kubun/3d8e15c12200553a1ec4#file-clean_hooks_backtrace-log-L44). The hooks of `list->hooks` can be `xfree`d during `exec_hooks_body`. That's because `th->vm->trace_running` is not incremented for `exec_hooks_unprotected`.

So I fixed `rb_threadptr_exec_event_hooks_orig` to count `exec_hooks_unprotected` as `th->vm->trace_running` too. With this patch, the tests have never crashed.