### PR TITLE
drop array allocations on anonymous splat args

### DIFF
--- a/vm.c
+++ b/vm.c
@@ -2838,6 +2838,9 @@ Init_vm_objects(void)
     /* initialize mark object array, hash */
     vm->mark_object_ary = rb_ary_tmp_new(128);
     vm->loading_table = st_init_strtable();
+    vm->empty_args = rb_ary_new();
+    rb_obj_freeze(vm->empty_args);
+    rb_gc_register_mark_object(vm->empty_args);
     vm->frozen_strings = st_init_table_with_size(&rb_fstring_hash_type, 1000);
 }
 

--- a/vm_args.c
+++ b/vm_args.c
@@ -170,6 +170,21 @@ args_rest_array(struct args_info *args)
     return ary;
 }
 
+static inline VALUE
+args_rest_array2(struct args_info *args)
+{
+    VALUE ary;
+
+    if (args->rest) {
+	ary = args->rest;
+	args->rest = 0;
+    }
+    else {
+	ary = GET_VM()->empty_args;
+    }
+    return ary;
+}
+
 static int
 keyword_hash_p(VALUE *kw_hash_ptr, VALUE *rest_hash_ptr, rb_thread_t *th)
 {
@@ -342,8 +357,13 @@ args_setup_opt_parameters(struct args_info *args, int opt_max, VALUE *locals)
 static inline void
 args_setup_rest_parameter(struct args_info *args, VALUE *locals)
 {
-    args_copy(args);
     *locals = args_rest_array(args);
+}
+
+static inline void
+anon_args_setup_rest_parameter(struct args_info *args, VALUE *locals)
+{
+    *locals = args_rest_array2(args);
 }
 
 static VALUE
@@ -644,7 +664,16 @@ setup_parameters_complex(rb_thread_t * const th, const rb_iseq_t * const iseq,
     }
 
     if (iseq->body->param.flags.has_rest) {
-	args_setup_rest_parameter(args, locals + iseq->body->param.rest_start);
+	const ID *tbl = iseq->body->local_table;
+	ID param_name = tbl[iseq->body->param.rest_start];
+
+	args_copy(args);
+
+	if (is_junk_id(param_name)) {
+	    anon_args_setup_rest_parameter(args, locals + iseq->body->param.rest_start);
+	} else {
+	    args_setup_rest_parameter(args, locals + iseq->body->param.rest_start);
+	}
     }
 
     if (iseq->body->param.flags.has_kw) {

--- a/vm_core.h
+++ b/vm_core.h
@@ -483,6 +483,7 @@ typedef struct rb_vm_struct {
     VALUE coverages;
 
     VALUE defined_module_hash;
+    VALUE empty_args;
 
     struct rb_objspace *objspace;
 

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1233,6 +1233,7 @@ vm_base_ptr(rb_control_frame_t *cfp)
 
 /* method call processes with call_info */
 
+#include "symbol.h"
 #include "vm_args.c"
 
 static inline VALUE vm_call_iseq_setup_2(rb_thread_t *th, rb_control_frame_t *cfp, struct rb_calling_info *calling, const struct rb_call_info *ci, struct rb_call_cache *cc, int opt_pc);


### PR DESCRIPTION
Since we can't get a reference to the anonymous splat, I think we can
eliminate allocations when calling one.

Here is a sample program:

```ruby
require 'allocation_tracer'

class A
  def foo(*)
  end
end

class B < A
  def foo(*)
    super
  end
end

ObjectSpace::AllocationTracer.setup %i{ type }

p ObjectSpace::AllocationTracer.trace {
  A.new.foo
}

p ObjectSpace::AllocationTracer.trace {
  B.new.foo
}
```

Before this patch:

```
[aaron@TC ruby (trunk)]$ ./ruby test3.rb
{[:T_OBJECT]=>[1, 0, 0, 0, 0, 0], [:T_ARRAY]=>[1, 0, 0, 0, 0, 0]}
{[:T_OBJECT]=>[1, 0, 0, 0, 0, 0], [:T_ARRAY]=>[3, 0, 0, 0, 0, 0]}
```

After this patch:

```
[aaron@TC ruby (anonysplat)]$ ./ruby test3.rb
{[:T_OBJECT]=>[1, 0, 0, 0, 0, 0]}
{[:T_OBJECT]=>[1, 0, 0, 0, 0, 0], [:T_ARRAY]=>[1, 0, 0, 0, 0, 0]}
```

I'm not really happy with the function names `args_rest_array2`.  I could just put it in the body of `anon_args_setup_rest_parameter`.

/cc @ko1 @nobu