### PR TITLE
Brace expansion possible edge case fix

### DIFF
--- a/dir.c
+++ b/dir.c
@@ -2038,17 +2038,17 @@ ruby_brace_expand(const char *str, int flags, ruby_glob_func *func, VALUE arg,
     int nest = 0, status = 0;
 
     while (*p) {
-	if (*p == '{' && nest++ == 0) {
-	    lbrace = p;
-	}
-	if (*p == '}' && --nest <= 0) {
-	    rbrace = p;
-	    break;
-	}
-	if (*p == '\\' && escape) {
-	    if (!*++p) break;
-	}
-	Inc(p, pend, enc);
+      if (*p == '{' && nest++ == 0) {
+        lbrace = p;
+      }
+      if (*p == '}' && lbrace && --nest == 0) {
+        rbrace = p;
+        break;
+      }
+      if (*p == '\\' && escape) {
+        if (!*++p) break;
+      }
+      Inc(p, pend, enc);
     }
 
     if (lbrace && rbrace) {

--- a/test/ruby/test_dir.rb
+++ b/test/ruby/test_dir.rb
@@ -150,6 +150,12 @@ class TestDir < Test::Unit::TestCase
 
     assert_equal([File.join(@root, "a")], Dir.glob(File.join(@root, 'a\\')))
     assert_equal(("a".."f").map {|f| File.join(@root, f) }.sort, Dir.glob(File.join(@root, '[abc/def]')).sort)
+
+
+    FileUtils.touch(File.join(@root, "}}{}"))
+    FileUtils.touch(File.join(@root, "}}a"))
+    assert_equal(%w(}}{} }}a).map{|f| File.join(@root, f) }, Dir.glob(File.join(@root, '}}{\{\},a}')))
+    assert_equal(%w(}}{} }}a b c).map{|f| File.join(@root, f) }, Dir.glob(File.join(@root, '{\}\}{\{\},a},b,c}')))
   end
 
   def test_glob_recursive


### PR DESCRIPTION
When there are  closing braces '}' before a open brace '{' it must be ignored and considered as literal otherwise the brace expansion won't work properly.
This make the brace expansion more robust since it make the brace expansion work with files that starts with closing braces.

I hope to cover all the cases. I'm not sure if i should put a test case for the File.fnmatch with the File::FNM_EXTGLOB option and if there are more side effects than File.fnmatch.
