### PR TITLE
Escape backslash in String#tr documentation.

### DIFF
--- a/string.c
+++ b/string.c
@@ -6106,7 +6106,7 @@ rb_str_tr_bang(VALUE str, VALUE src, VALUE repl)
  *     "hello".tr('a-y', 'b-z')    #=> "ifmmp"
  *     "hello".tr('^aeiou', '*')   #=> "*e**o"
  *
- *  The backslash character <code>\</code> can be used to escape
+ *  The backslash character <code>\\</code> can be used to escape
  *  <code>^</code> or <code>-</code> and is otherwise ignored unless it
  *  appears at the end of a range or the end of the +from_str+ or +to_str+:
  *


### PR DESCRIPTION
## before:
![screenshot- domain date time 1](https://cloud.githubusercontent.com/assets/193936/10668110/f05fc2b2-78da-11e5-82db-c5030df557af.png)

## after:
![screenshot- domain date time](https://cloud.githubusercontent.com/assets/193936/10668111/f0667daa-78da-11e5-9630-4a880b4dff72.png)