### PR TITLE
Add test case for new safe call syntax about arguments evaluation

### DIFF
--- a/test/ruby/test_call.rb
+++ b/test/ruby/test_call.rb
@@ -52,4 +52,17 @@ class TestCall < Test::Unit::TestCase
     assert_nothing_raised(NoMethodError) {o.?x = 6}
     assert_nothing_raised(NoMethodError) {o.?x *= 7}
   end
+
+  def test_safe_call_evaluate_arguments_only_method_call_is_made
+    count = 0
+    proc = proc { count += 1; 1 }
+    s = Struct.new(:x, :y)
+    o = s.new(["a", "b", "c"])
+
+    o.y.?at(proc.call)
+    assert_equal(0, count)
+
+    o.x.?at(proc.call)
+    assert_equal(1, count)
+  end
 end


### PR DESCRIPTION
This commit is follows up of r52251.
Validate safe call syntax evaluating arguments only if method call is made.