### PR TITLE
Allow gethostname to succeed when hostname length == RUBY_MAX_HOST_NAME_LEN

### DIFF
--- a/ext/socket/socket.c
+++ b/ext/socket/socket.c
@@ -1058,7 +1058,7 @@ sock_gethostname(VALUE obj)
 
     char buf[RUBY_MAX_HOST_NAME_LEN+1];
 
-    if (gethostname(buf, (int)sizeof buf - 1) < 0)
+    if (gethostname(buf, (int)sizeof buf) < 0)
 	rb_sys_fail("gethostname(3)");
 
     buf[sizeof buf - 1] = '\0';


### PR DESCRIPTION
gethostname() returns a null-terminated string, so the second parameter passed
must be sized for the max hostname length + space for the null terminator.
By specifying the sizeof buf as RUBY_MAX_HOST_NAME_LEN the call to
gethostname() will fail if the hostname length is equal to
RUBY_MAX_HOST_NAME_LEN.

This can be seen on Linux which has a 64 character limit on hostnames:

Setting a 65 character hostname:
```
# hostname abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz012
hostname: name too long
```

Setting a 64 character hostname:
```
# hostname abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz01
# hostname
abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz01
# irb
irb(main):001:0> require 'socket'
=> true
irb(main):002:0> Socket.gethostname
Errno::ENAMETOOLONG: File name too long - gethostname
	from (irb):2:in `gethostname'
	from (irb):2
	from /usr/local/bin/irb:12:in `<main>'
```

Setting a 63 character hostname:
```
# hostname abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0
# hostname
abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0
# irb
irb(main):001:0> require 'socket'
=> true
irb(main):002:0> Socket.gethostname
=> "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0"
irb(main):003:0> Socket.gethostname.length
=> 63
```