### PR TITLE
Fix a format of `NameError#message`

### DIFF
--- a/eval_error.c
+++ b/eval_error.c
@@ -208,7 +208,7 @@ ruby_error_print(void)
     error_print();
 }
 
-#define undef_mesg_for(v, k) rb_fstring_cstr("undefined"v" method `%1$s' for "k" `%$s'")
+#define undef_mesg_for(v, k) rb_fstring_cstr("undefined"v" method `%1$s' for "k" `%2$s'")
 #define undef_mesg(v) ( \
 	is_mod ? \
 	undef_mesg_for(v, "module") : \

--- a/test/ruby/test_exception.rb
+++ b/test/ruby/test_exception.rb
@@ -721,4 +721,16 @@ $stderr = $stdout; raise "\x82\xa0"') do |outs, errs, status|
     assert_raise(NameError) {a.instance_eval("foo")}
     assert_raise(NoMethodError, bug10969) {a.public_send("bar", true)}
   end
+
+  def test_message_of_name_error
+    begin
+      Module.new do
+        module_function :foo
+      end
+    rescue => e
+      error = e
+    end
+
+    assert_match /\Aundefined method `foo' for module `#<Module:.*>'\z/, error.message
+  end
 end


### PR DESCRIPTION
Before this commit `ArgumentError: malformed format string - %$`
was raised when `NameError#message` is called.