### PR TITLE
Use `rb_method_visibility_t` instead of `int` in `rb_print_undef`

### DIFF
--- a/eval_error.c
+++ b/eval_error.c
@@ -215,7 +215,7 @@ ruby_error_print(void)
 	undef_mesg_for(v, "class"))
 
 void
-rb_print_undef(VALUE klass, ID id, int visi)
+rb_print_undef(VALUE klass, ID id, rb_method_visibility_t visi)
 {
     const int is_mod = RB_TYPE_P(klass, T_MODULE);
     VALUE mesg;

--- a/eval_intern.h
+++ b/eval_intern.h
@@ -286,7 +286,7 @@ NORETURN(void rb_method_name_error(VALUE, VALUE));
 
 NORETURN(void rb_fiber_start(void));
 
-NORETURN(void rb_print_undef(VALUE, ID, int));
+NORETURN(void rb_print_undef(VALUE, ID, rb_method_visibility_t));
 NORETURN(void rb_print_undef_str(VALUE, VALUE));
 NORETURN(void rb_print_inaccessible(VALUE, ID, rb_method_visibility_t));
 NORETURN(void rb_vm_localjump_error(const char *,VALUE, int));

--- a/proc.c
+++ b/proc.c
@@ -1255,7 +1255,7 @@ mnew_internal(const rb_method_entry_t *me, VALUE klass,
 	    return mnew_missing(klass, obj, id, rid, mclass);
 	}
 	if (!error) return Qnil;
-	rb_print_undef(klass, id, 0);
+	rb_print_undef(klass, id, METHOD_VISI_UNDEF);
     }
     if (visi == METHOD_VISI_UNDEF) {
 	visi = METHOD_ENTRY_VISI(me);

--- a/vm_method.c
+++ b/vm_method.c
@@ -984,7 +984,7 @@ rb_export_method(VALUE klass, ID name, rb_method_visibility_t visi)
 
     if (UNDEFINED_METHOD_ENTRY_P(me) ||
 	UNDEFINED_REFINED_METHOD_P(me->def)) {
-	rb_print_undef(klass, name, 0);
+	rb_print_undef(klass, name, METHOD_VISI_UNDEF);
     }
 
     if (METHOD_ENTRY_VISI(me) != visi) {
@@ -1474,7 +1474,7 @@ rb_alias(VALUE klass, ID alias_name, ID original_name)
 	if ((!RB_TYPE_P(klass, T_MODULE)) ||
 	    (orig_me = search_method(rb_cObject, original_name, &defined_class),
 	     UNDEFINED_METHOD_ENTRY_P(orig_me))) {
-	    rb_print_undef(klass, original_name, 0);
+	    rb_print_undef(klass, original_name, METHOD_VISI_UNDEF);
 	}
     }
 
@@ -1777,7 +1777,7 @@ rb_mod_modfunc(int argc, VALUE *argv, VALUE module)
 		me = search_method(rb_cObject, id, 0);
 	    }
 	    if (UNDEFINED_METHOD_ENTRY_P(me)) {
-		rb_print_undef(module, id, 0);
+		rb_print_undef(module, id, METHOD_VISI_UNDEF);
 	    }
 	    if (me->def->type != VM_METHOD_TYPE_ZSUPER) {
 		break; /* normal case: need not to follow 'super' link */


### PR DESCRIPTION
Same as `rb_print_inaccessible`, change `rb_print_undef` to use
`rb_method_visibility_t`.