### PR TITLE
sprintf.c: hash substitution using the default hash value

### DIFF
--- a/sprintf.c
+++ b/sprintf.c
@@ -605,13 +605,10 @@ rb_str_format(int argc, const VALUE *argv, VALUE fmt)
 		}
 		CHECKNAMEARG(start, len, enc);
 		get_hash(&hash, argc, argv);
-		sym = rb_check_symbol_cstr(start + 1,
-					   len - 2 /* without parenthesis */,
-					   enc);
-		if (sym != Qnil) nextvalue = rb_hash_lookup2(hash, sym, Qundef);
-		if (nextvalue == Qundef) {
-		    rb_enc_raise(enc, rb_eKeyError, "key%.*s not found", len, start);
-		}
+		sym = rb_cstr_intern(start + 1,
+				     len - 2 /* without parenthesis */,
+				     enc);
+		nextvalue = rb_hash_aref(hash, sym);
 		if (term == '}') goto format_s;
 		p++;
 		goto retry;


### PR DESCRIPTION
This PR is in reference to [this issue I filed](https://bugs.ruby-lang.org/issues/11661) where the rationale is explained.

In this PR, calling `sprintf` using hash substitution no longer causes a `KeyError`:

```ruby
my_hash = Hash.new('world')

# Before
puts "hello %{location}" % my_hash
# > KeyError: key{location} not found

# After
puts "hello %{location}" % my_hash
# > hello world
```