### PR TITLE
resolv.rb: don't compress labels beyond offset 0x4000

### DIFF
--- a/lib/resolv.rb
+++ b/lib/resolv.rb
@@ -1477,7 +1477,9 @@ class Resolv
               self.put_pack("n", 0xc000 | idx)
               return
             else
-              @names[domain] = @data.length
+              if @data.length < 0x4000
+                @names[domain] = @data.length
+              end
               self.put_label(d[i])
             end
           }


### PR DESCRIPTION
The Resolv::MessageEncoder can deduplicate labels by encoding
references to earlier labels. Currently it tries to encode any offset
even if it doesn't fit in the 14 bit field. This patch stops it from
saving the offset if it's too wide.

Fix for https://bugs.ruby-lang.org/issues/11632