### PR TITLE
net/http: detect closed connection to avoid EOFError

### DIFF
--- a/test/net/http/test_http.rb
+++ b/test/net/http/test_http.rb
@@ -880,6 +880,23 @@ class TestNetHTTPKeepAlive < Test::Unit::TestCase
     }
   end
 
+  def test_server_closed_connection_auto_reconnect
+    start {|http|
+      res = http.get('/')
+      http.keep_alive_timeout = 5
+      assert_kind_of Net::HTTPResponse, res
+      assert_kind_of String, res.body
+      sleep 1.5
+      assert_nothing_raised {
+        # Net::HTTP should detect the closed connection before attempting the
+        # request, since post requests cannot be retried.
+        res = http.post('/', 'query=foo')
+      }
+      assert_kind_of Net::HTTPResponse, res
+      assert_kind_of String, res.body
+    }
+  end
+
   def test_keep_alive_get_auto_retry
     start {|http|
       res = http.get('/')


### PR DESCRIPTION
This PR fixes a problem in `Net::HTTP`: When attempting a POST request on a keep-alive-connection, `Net::HTTP` will sometimes raise an unnecessary `EOFError`. 

Most HTTP servers close keep-alive connections after an idle timeout or when reaching some internal limit. For the HTTP client, this leads to the TCP socket reaching EOF (End-Of-File). Currently, `Net::HTTP` does not check this before using the socket, causing `EOFError`.

For idempotent requests (for example GET) `Net::HTTP` simply [retries the request](https://github.com/ruby/ruby/blob/3563d50c7af77b80ac12c0ff2506eb353c734a1a/lib/net/http.rb#L1449-L1458). But this does not work for requests that aren't idempotent like POST, so `HTTP#post` will raise an `EOFError`.

This PR fixes this by checking if the connection is healthy before attempting the request, using a non-blocking read on the socket. If an error is detected, `Net::HTTP` simply closes and reconnects before sending the request.

A unit test is included that checks if `HTTP#post` succeeds on a keep-alive connection that has been closed by the server.

See also: https://bugs.ruby-lang.org/issues/11671