### PR TITLE
lib/logger.rb: support symbol and string log level setting

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -176,6 +176,10 @@ Mon Nov 16 15:42:36 2015  Akinori MUSHA  <knu@iDaemons.org>
 	* lib/set.rb (#>=, #>, #<=, #<): Make use of Hash#>=, #>, #<, and
 	  #<= when comparing against an instance of the same kind.
 
+Mon Nov 16 15:37:11 2015  Naotoshi Seo  <sonots@gmail.com>
+
+	* lib/logger.rb: Support symbol and string log level setting
+
 Mon Nov 16 15:33:11 2015  SHIBATA Hiroshi  <hsbt@ruby-lang.org>
 
 	* tool/rbinstall.rb: fix wrong permission for gem specification without

--- a/NEWS
+++ b/NEWS
@@ -78,6 +78,9 @@ with all sufficient information, see the ChangeLog file.
     what the enumerator has returned instead of nil. [Feature #11498]
 
 * Logger
+
+  * Logger#level= now supports symbol and string levels such as :debug, :info,
+    :warn, :error, :fatal (case insensitive) [Feature #11695]
   * Logger#reopen is added to reopen a log device. [Feature #11696]
 
 * Module

--- a/doc/maintainers.rdoc
+++ b/doc/maintainers.rdoc
@@ -98,7 +98,7 @@ Zachary Scott (zzak)
   * 1.8: _unmaintained_
   * 1.9: _deprecated_
 [lib/logger.rb]
-  Hiroshi Nakamura (nahi)
+  Naotoshi Seo (sonots)
 [lib/mathn.rb]
   Keiju ISHITSUKA (keiju)
 [lib/matrix.rb]

--- a/lib/logger.rb
+++ b/lib/logger.rb
@@ -176,6 +176,13 @@ require 'monitor'
 #
 #      # DEBUG < INFO < WARN < ERROR < FATAL < UNKNOWN
 #
+# 3. Symbol or String (case insensitive)
+#
+#      logger.level = :info
+#      logger.level = 'INFO'
+#
+#      # :debug < :info < :warn < :error < :fatal < :unknown
+#
 # == Format
 #
 # Log messages are rendered in the output stream in a certain format by
@@ -234,7 +241,34 @@ class Logger
   include Severity
 
   # Logging severity threshold (e.g. <tt>Logger::INFO</tt>).
-  attr_accessor :level
+  attr_reader :level
+
+  # Set logging severity threshold.
+  #
+  # +severity+:: The Severity of the log message.
+  def level=(severity)
+    if severity.is_a?(Integer)
+      @level = severity
+    else
+      _severity = severity.to_s.downcase
+      case _severity
+      when 'debug'.freeze
+        @level = DEBUG
+      when 'info'.freeze
+        @level = INFO
+      when 'warn'.freeze
+        @level = WARN
+      when 'error'.freeze
+        @level = ERROR
+      when 'fatal'.freeze
+        @level = FATAL
+      when 'unknown'.freeze
+        @level = UNKNOWN
+      else
+        raise ArgumentError, "invalid log level: #{severity}"
+      end
+    end
+  end
 
   # Program name to include in log messages.
   attr_accessor :progname

--- a/test/logger/test_logger.rb
+++ b/test/logger/test_logger.rb
@@ -69,6 +69,50 @@ class TestLogger < Test::Unit::TestCase
     assert(!@logger.fatal?)
   end
 
+  def test_symbol_level
+    logger_symbol_levels = {
+      debug:   DEBUG,
+      info:    INFO,
+      warn:    WARN,
+      error:   ERROR,
+      fatal:   FATAL,
+      unknown: UNKNOWN,
+      DEBUG:   DEBUG,
+      INFO:    INFO,
+      WARN:    WARN,
+      ERROR:   ERROR,
+      FATAL:   FATAL,
+      UNKNOWN: UNKNOWN,
+    }
+    logger_symbol_levels.each do |symbol, level|
+      @logger.level = symbol
+      assert(@logger.level == level)
+    end
+    assert_raise(ArgumentError) { @logger.level = :something_wrong }
+  end
+
+  def test_string_level
+    logger_string_levels = {
+      'debug'   => DEBUG,
+      'info'    => INFO,
+      'warn'    => WARN,
+      'error'   => ERROR,
+      'fatal'   => FATAL,
+      'unknown' => UNKNOWN,
+      'DEBUG'   => DEBUG,
+      'INFO'    => INFO,
+      'WARN'    => WARN,
+      'ERROR'   => ERROR,
+      'FATAL'   => FATAL,
+      'UNKNOWN' => UNKNOWN,
+    }
+    logger_string_levels.each do |string, level|
+      @logger.level = string
+      assert(@logger.level == level)
+    end
+    assert_raise(ArgumentError) { @logger.level = 'something_wrong' }
+  end
+
   def test_progname
     assert_nil(@logger.progname)
     @logger.progname = "name"


### PR DESCRIPTION
@nalsh @nahi ( cc: @frsyuki )

Added `Logger#level=:symbol` and `Logger#level=string` as we talked at https://twitter.com/frsyuki/status/664862229490089984. 

This is useful especially when we configure log_level with yaml (typically, on rails application) like

settings.yml

```
log_level: DEBUG
```

and

```
logger.level = Settings.log_level
```

