### PR TITLE
lib/logger.rb: Add Logger#reopen

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -86,6 +86,10 @@ Mon Nov 16 21:27:54 2015  Naohisa Goto  <ngotogenome@gmail.com>
 	* test/dtrace/helper.rb (Dtrace::TestCase#trap_probe): dtrace buffer
 	  size is set as 8m on Solaris (default 4m). [Bug #11697]
 
+Mon Nov 16 20:03:14 2015  Naotoshi Seo  <sonots@gmail.com>
+
+	* lib/logger.rb: Add Logger#reopen
+
 Mon Nov 16 18:21:52 2015  Nobuyoshi Nakada  <nobu@ruby-lang.org>
 
 	* object.c (rb_obj_dig): dig in nested structs too.

--- a/NEWS
+++ b/NEWS
@@ -77,6 +77,9 @@ with all sufficient information, see the ChangeLog file.
   * Kernel#loop, when stopped by a StopIteration exception, returns
     what the enumerator has returned instead of nil. [Feature #11498]
 
+* Logger
+  * Logger#reopen is added to reopen a log device. [Feature #11696]
+
 * Module
   * Module#deprecate_constant [Feature #11398]
 

--- a/test/logger/test_logdevice.rb
+++ b/test/logger/test_logdevice.rb
@@ -99,6 +99,72 @@ class TestLogDevice < Test::Unit::TestCase
     r.close
   end
 
+  def test_reopen_io
+    logdev  = d(STDERR)
+    old_dev = logdev.dev
+    logdev.reopen
+    assert_equal(STDERR, logdev.dev)
+    assert(!old_dev.closed?)
+  end
+
+  def test_reopen_io_by_io
+    logdev  = d(STDERR)
+    old_dev = logdev.dev
+    logdev.reopen(STDOUT)
+    assert_equal(STDOUT, logdev.dev)
+    assert(!old_dev.closed?)
+  end
+
+  def test_reopen_io_by_file
+    logdev  = d(STDERR)
+    old_dev = logdev.dev
+    logdev.reopen(@filename)
+    begin
+      assert(File.exist?(@filename))
+      assert_equal(@filename, logdev.filename)
+      assert(!old_dev.closed?)
+    ensure
+      logdev.close
+    end
+  end
+
+  def test_reopen_file
+    logdev = d(@filename)
+    old_dev = logdev.dev
+    File.unlink(@filename) if File.exist?(@filename) # remove once, then reopen
+    logdev.reopen
+    begin
+      assert(File.exist?(@filename))
+      assert_equal(@filename, logdev.filename)
+      assert(old_dev.closed?)
+    ensure
+      logdev.close
+    end
+  end
+
+  def test_reopen_file_by_io
+    logdev = d(@filename)
+    old_dev = logdev.dev
+    logdev.reopen(STDOUT)
+    assert_equal(STDOUT, logdev.dev)
+    assert_nil(logdev.filename)
+    assert(old_dev.closed?)
+  end
+
+  def test_reopen_file_by_file
+    logdev = d(@filename)
+    old_dev = logdev.dev
+    File.unlink(@filename) if File.exist?(@filename) # remove once, then reopen
+    logdev.reopen(@filename)
+    begin
+      assert(File.exist?(@filename))
+      assert_equal(@filename, logdev.filename)
+      assert(old_dev.closed?)
+    ensure
+      logdev.close
+    end
+  end
+
   def test_shifting_size
     tmpfile = Tempfile.new([File.basename(__FILE__, '.*'), '_1.log'])
     logfile = tmpfile.path

--- a/test/logger/test_logger.rb
+++ b/test/logger/test_logger.rb
@@ -121,6 +121,12 @@ class TestLogger < Test::Unit::TestCase
     assert_nil(logger.datetime_format)
   end
 
+  def test_reopen
+    logger = Logger.new(STDERR)
+    logger.reopen(STDOUT)
+    assert_equal(STDOUT, logger.instance_variable_get(:@logdev).dev)
+  end
+
   def test_add
     logger = Logger.new(nil)
     logger.progname = "my_progname"


### PR DESCRIPTION
@nalsh @nahi ( cc: @frsyuki )

Added `Logger#reopen`as we talked at https://twitter.com/frsyuki/status/664862229490089984. 

This enables to reopen another log file (or same log file) without creating a new Logger instance. This is useful when an application is passing a logger instance everywhere inside it, but want to change log file as https://github.com/fluent/serverengine does on config reloading. 
