### PR TITLE
Update comments describing dig methods

### DIFF
--- a/array.c
+++ b/array.c
@@ -5535,8 +5535,8 @@ rb_ary_any_p(VALUE ary)
  * call-seq:
  *   ary.dig(idx, ...)                 -> object
  *
- * Retrieves the value object corresponding to the each <i>idx</i>
- * objects repeatedly.
+ * Extracts the nested array value specified by the sequence of <i>idx</i>
+ * objects.
  *
  *   a = [[1, [2, 3]]]
  *

--- a/hash.c
+++ b/hash.c
@@ -2695,9 +2695,8 @@ rb_hash_any_p(VALUE hash)
  * call-seq:
  *   hsh.dig(key, ...)                 -> object
  *
- * Retrieves the value object corresponding to the each <i>key</i>
- * objects repeatedly.
- *
+ * Extracts the nested hash value specified by the sequence of <i>key</i>
+ * objects.
  *   h = { foo: {bar: {baz: 1}}}
  *
  *   h.dig(:foo, :bar, :baz)           #=> 1


### PR DESCRIPTION
I thought the commented descriptions for `Array#dig` and `Hash#dig` sounded a little unnatural so I have updated the wording slightly.