### PR TITLE
Create code_of_conduct.md

### DIFF
--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -1,0 +1,17 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of this project, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free experience for everyone, regardless of gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, religion (or lack thereof), or any other intrinsic characteristic that makes us who we are.
+
+Harassment is the expression of ideas, through actions or words, intended or known to shame, intimidate, or harm another person. Harassment hurts people, and by extension destroys communities.
+
+Harassment may include, but is not limited to, offensive verbal comments related to any of those intrinsic characteristics by which we define our humanity, the display of sexually explicit images, deliberate physical intimidation, stalking, and unwelcome sexual attention.
+
+Our community does not tolerate harassment in any form.
+
+Community members asked to stop any harassing behavior are expected to comply immediately. People that violate our code may be sanctioned or removed from the project at the discretion of the Project maintainers.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting one or more of the project maintainers.
+
+This Code of Conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.1.0, and the [Conference Code of Conduct](https://github.com/confcodeofconduct/confcodeofconduct.com).


### PR DESCRIPTION
Code of conduct from https://github.com/lolazaza/Code_of_Conduct. The purpose of this CoC is to protect all potential contributors while not infringing on peoples free expression outside of the project space. The purpose in adapting the language used in several well known CoC's was to make a less caustic CoC that won't negatively impact the community while protecting those who are less privileged.