### PR TITLE
Fix the number of Struct#dig issue number [ci skip]

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -102,7 +102,7 @@ with all sufficient information, see the ChangeLog file.
 * Regexp/String: Updated Unicode version from 7.0.0 to 8.0.0
 
 * Struct
-  * Struct#dig [Feature #11686]
+  * Struct#dig [Feature #11688]
 
 * Thread
   * Thread#name, Thread#name= are added to handle thread names [Feature #11251]


### PR DESCRIPTION
This Pull Request fixes an issue number typo in NEWS file.

`Struct#dig` Should be Feature #11688: https://bugs.ruby-lang.org/issues/11688