### PR TITLE
Add missing punctuation to File docs

### DIFF
--- a/file.c
+++ b/file.c
@@ -5873,7 +5873,7 @@ static const char null_device[] =
 
 /*
  *  A <code>File</code> is an abstraction of any file object accessible
- *  by the program and is closely associated with class <code>IO</code>
+ *  by the program and is closely associated with class <code>IO</code>.
  *  <code>File</code> includes the methods of module
  *  <code>FileTest</code> as class methods, allowing you to write (for
  *  example) <code>File.exist?("foo")</code>.


### PR DESCRIPTION
Otherwise the sentence in ruby-doc is confusing, because it reads like
this:

"(...) associated with class IO File includes the methods of (...)"

instead of

"(...) associated with class IO. File includes the methods of (...)"