### PR TITLE
beos: Drop support for BeOS now that Haiku is stable

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -242,6 +242,8 @@ with all sufficient information, see the ChangeLog file.
 
 * OS/2 is no longer supported
 
+* BeOS is no longer supported
+
 * Borland-C is no longer supported
 
 * Haiku now stable and best effort

--- a/configure.in
+++ b/configure.in
@@ -1139,15 +1139,8 @@ main()
 		  fi
 		fi
 		],
-[beos*], [
-		ac_cv_func_link=no
-		ac_cv_func_sched_yield=no
-		ac_cv_func_pthread_attr_setinheritsched=no
-		ac_cv_header_net_socket_h=yes
-		LIBS="$LIBS" # m lib is include in root under BeOS
-		],
 [haiku*], [
-		LIBS="$LIBS"
+		LIBS="$LIBS" # m lib is include in root
 		],
 [cygwin*], [	ac_cv_header_langinfo_h=yes
 		AC_CHECK_FUNCS(cygwin_conv_path)
@@ -3072,7 +3065,7 @@ if test "$with_dln_a_out" != yes; then
       # mkmf.rb's have_header() to fail if the desired resource happens to be
       # installed in the /usr/local tree.
       RUBY_APPEND_OPTION(CCDLFLAGS, -fno-common)],
-    [bsdi*|beos*|cygwin*|mingw*|aix*|interix*], [ ],
+    [bsdi*|cygwin*|mingw*|aix*|interix*], [ ],
     [
       RUBY_APPEND_OPTION(CCDLFLAGS, -fPIC)])
   else
@@ -3169,20 +3162,6 @@ if test "$with_dln_a_out" != yes; then
                         TRY_LINK="$TRY_LINK"' $(CFLAGS) $(src) $(LIBPATH) $(LOCAL_LIBS) $(LIBS)'
 			: ${LIBPATHENV=LIBPATH}
 			RPATHFLAG=" ${linker_flag}-blibpath:%1\$-s:${prefix}/lib:${LIBPATH:-/usr/lib:/lib}"
-			rb_cv_dlopen=yes],
-	[beos*], [	AS_CASE(["$target_cpu"],
-			  [powerpc*], [
-			    : ${LDSHARED='$(LD) -xms'}
-			    EXTDLDFLAGS='-export $(TARGET_ENTRY)'
-			    DLDFLAGS="$DLDFLAGS -lbe -lroot glue-noinit.a init_term_dyn.o start_dyn.o"
-			    LDFLAGS="$LDFLAGS -L/boot/home/config/lib -lbe -lroot"
-			    ],
-			  [i586*], [
-			    : ${LDSHARED='$(LD) -shared'}
-			    DLDFLAGS="$DLDFLAGS -L/boot/develop/lib/x86 -L/boot/home/config/lib \$(topdir)/_APP_ -lroot"
-			    LDFLAGS="$LDFLAGS -L/boot/develop/lib/x86 -L/boot/home/config/lib -lroot"
-			    ])
-			: ${LIBPATHENV=LIBRARY_PATH}
 			rb_cv_dlopen=yes],
 	[nto-qnx*], [	DLDFLAGS="$DLDFLAGS -L/lib -L/usr/lib -L/usr/local/lib"
 			: ${LDSHARED='$(LD) -Bshareable -x'}
@@ -3565,7 +3544,7 @@ LIBRUBYARG='$(LIBRUBYARG_STATIC)'
 SOLIBS=
 
 AS_CASE(["$target_os"],
-  [cygwin*|mingw*|beos*|haiku*|darwin*], [
+  [cygwin*|mingw*|haiku*|darwin*], [
     : ${DLDLIBS=""}
     ],
   [
@@ -3684,12 +3663,6 @@ AS_CASE("$enable_shared", [yes], [
 	LIBRUBY_DLDFLAGS="${linker_flag}-bnoentry $XLDFLAGS $LDFLAGS_OPTDIR"
 	LIBRUBYARG_SHARED='-L${libdir} -l${RUBY_SO_NAME}'
 	SOLIBS='-lm -lc'
-	],
-    [beos*], [
-	AS_CASE(["$target_cpu"],
-	[powerpc*], [
-	    LIBRUBY_DLDFLAGS="-f ruby.exp -lnet -lbe -lroot glue-noinit.a init_term_dyn.o start_dyn.o $LDFLAGS_OPTDIR"
-	    ])
 	],
     [darwin*], [
 	RUBY_SO_NAME="$RUBY_SO_NAME"'.$(MAJOR).$(MINOR).$(TEENY)'
@@ -3916,10 +3889,6 @@ AS_CASE(["$target_os"],
 	  rm -f /tmp/main.o
 	  CFLAGS="$CFLAGS -std"
 	fi
-	],
-    [beos*], [
-	AS_CASE(["$target_cpu"],[powerpc*], [CFLAGS="$CFLAGS -relax_pointers"])
-	CPPFLAGS="$CPPFLAGS -I/boot/home/config/include"
 	],
     [cygwin*|mingw*], [
 	RUBY_SO_NAME="${RUBY_SO_NAME}"'$(MAJOR)$(MINOR)$(TEENY)'

--- a/dln.c
+++ b/dln.c
@@ -85,10 +85,6 @@ char *getenv();
 # endif
 #endif
 
-#if defined(__BEOS__)
-# include <image.h>
-#endif
-
 #ifndef dln_loaderror
 static void
 dln_loaderror(const char *format, ...)
@@ -1441,54 +1437,6 @@ dln_load(const char *file)
 	return (void*)init_fct;
     }
 #endif
-
-#if defined(__BEOS__)
-# define DLN_DEFINED
-    {
-      status_t err_stat;  /* BeOS error status code */
-      image_id img_id;    /* extension module unique id */
-      void (*init_fct)(); /* initialize function for extension module */
-
-      /* load extension module */
-      img_id = load_add_on(file);
-      if (img_id <= 0) {
-	dln_loaderror("Failed to load add_on %.200s error_code=%x",
-	  file, img_id);
-      }
-
-      /* find symbol for module initialize function. */
-      /* The Be Book KernelKit Images section described to use
-	 B_SYMBOL_TYPE_TEXT for symbol of function, not
-	 B_SYMBOL_TYPE_CODE. Why ? */
-      /* strcat(init_fct_symname, "__Fv"); */  /* parameter nothing. */
-      /* "__Fv" dont need! The Be Book Bug ? */
-      err_stat = get_image_symbol(img_id, buf,
-				  B_SYMBOL_TYPE_TEXT, (void **)&init_fct);
-
-      if (err_stat != B_NO_ERROR) {
-	char real_name[MAXPATHLEN];
-
-	strlcpy(real_name, buf, MAXPATHLEN);
-	strlcat(real_name, "__Fv", MAXPATHLEN);
-        err_stat = get_image_symbol(img_id, real_name,
-				    B_SYMBOL_TYPE_TEXT, (void **)&init_fct);
-      }
-
-      if ((B_BAD_IMAGE_ID == err_stat) || (B_BAD_INDEX == err_stat)) {
-	unload_add_on(img_id);
-	dln_loaderror("Failed to lookup Init function %.200s", file);
-      }
-      else if (B_NO_ERROR != err_stat) {
-	char errmsg[] = "Internal of BeOS version. %.200s (symbol_name = %s)";
-	unload_add_on(img_id);
-	dln_loaderror(errmsg, strerror(err_stat), buf);
-      }
-
-      /* call module initialize function. */
-      (*init_fct)();
-      return (void*)img_id;
-    }
-#endif /* __BEOS__ */
 
 #ifndef DLN_DEFINED
     dln_notimplement();

--- a/ext/extmk.rb
+++ b/ext/extmk.rb
@@ -616,9 +616,6 @@ void Init_ext(void)\n{\n#$extinit}
     open(extinit.c, "w") {|fe| fe.print src}
   end
 
-  if RUBY_PLATFORM =~ /beos/
-    $extflags.delete("-L/usr/local/lib")
-  end
   $extpath.delete("$(topdir)")
   $extflags = libpathflag($extpath) << " " << $extflags.strip
   conf = [

--- a/ext/socket/basicsocket.c
+++ b/ext/socket/basicsocket.c
@@ -244,7 +244,6 @@ bsock_setsockopt(int argc, VALUE *argv, VALUE sock)
     return INT2FIX(0);
 }
 
-#if !defined(__BEOS__)
 /*
  * Document-method: getsockopt
  * call-seq:
@@ -324,9 +323,6 @@ bsock_getsockopt(VALUE sock, VALUE lev, VALUE optname)
 
     return rsock_sockopt_new(family, level, option, rb_str_new(buf, len));
 }
-#else
-#define bsock_getsockopt rb_f_notimplement
-#endif
 
 /*
  * call-seq:

--- a/ext/socket/extconf.rb
+++ b/ext/socket/extconf.rb
@@ -435,9 +435,6 @@ when /mswin(32|64)|mingw/
   have_library("ws2_32", "WSACleanup", headers)
 when /cygwin/
   test_func = "socket(0,0,0)"
-when /beos/
-  test_func = "socket(0,0,0)"
-  have_library("net", "socket(0,0,0)", headers)
 when /haiku/
   test_func = "socket(0,0,0)"
   have_library("network", "socket(0,0,0)", headers)
@@ -507,7 +504,7 @@ EOF
   end
 
   ipv6 = false
-  default_ipv6 = /beos|haiku/ !~ RUBY_PLATFORM
+  default_ipv6 = /haiku/ !~ RUBY_PLATFORM
   if enable_config("ipv6", default_ipv6)
     if checking_for("ipv6") {try_link(AF_INET6_SOCKET_CREATION_TEST)}
       $defs << "-DENABLE_IPV6" << "-DINET6"

--- a/ext/socket/getaddrinfo.c
+++ b/ext/socket/getaddrinfo.c
@@ -45,11 +45,7 @@
 #include <sys/types.h>
 #ifndef _WIN32
 #include <sys/param.h>
-#if defined(__BEOS__) && !defined(BONE)
-# include <net/socket.h>
-#else
-# include <sys/socket.h>
-#endif
+#include <sys/socket.h>
 #include <netinet/in.h>
 #if defined(HAVE_ARPA_INET_H)
 #include <arpa/inet.h>
@@ -439,11 +435,8 @@ getaddrinfo(const char *hostname, const char *servname, const struct addrinfo *h
 			s = socket(afd->a_af, SOCK_DGRAM, 0);
 			if (s < 0)
 				continue;
-#if defined(__BEOS__)
-			closesocket(s);
-#else
+
 			close(s);
-#endif
 
 			if (pai->ai_flags & AI_PASSIVE) {
 				GET_AI(cur->ai_next, afd, afd->a_addrany, port);

--- a/ext/socket/getnameinfo.c
+++ b/ext/socket/getnameinfo.c
@@ -41,11 +41,7 @@
 #include <stdio.h>
 #include <sys/types.h>
 #ifndef _WIN32
-#if defined(__BEOS__) && !defined(BONE)
-# include <net/socket.h>
-#else
-# include <sys/socket.h>
-#endif
+#include <sys/socket.h>
 #include <netinet/in.h>
 #if defined(HAVE_ARPA_INET_H)
 #include <arpa/inet.h>

--- a/ext/socket/rubysocket.h
+++ b/ext/socket/rubysocket.h
@@ -27,11 +27,7 @@
 #    undef HAVE_TYPE_STRUCT_SOCKADDR_DL
 #  endif
 #else
-#  if defined(__BEOS__) && !defined(BONE)
-#    include <net/socket.h>
-#  else
-#    include <sys/socket.h>
-#  endif
+#  include <sys/socket.h>
 #  include <netinet/in.h>
 #  ifdef HAVE_NETINET_IN_SYSTM_H
 #    include <netinet/in_systm.h>
@@ -220,11 +216,6 @@ typedef union {
 #  ifndef CMSG_LEN
 #    define CMSG_LEN(len) (_CMSG_ALIGN(sizeof(struct cmsghdr)) + (len))
 #  endif
-#endif
-
-#ifdef __BEOS__
-#  undef close
-#  define close closesocket
 #endif
 
 #define INET_CLIENT 0

--- a/file.c
+++ b/file.c
@@ -120,33 +120,6 @@ int flock(int, int);
 #define STAT(p, s)	stat((p), (s))
 #endif
 
-#if defined(__BEOS__) /* should not change ID if -1 */
-static int
-be_chown(const char *path, uid_t owner, gid_t group)
-{
-    if (owner == (uid_t)-1 || group == (gid_t)-1) {
-	struct stat st;
-	if (STAT(path, &st) < 0) return -1;
-	if (owner == (uid_t)-1) owner = st.st_uid;
-	if (group == (gid_t)-1) group = st.st_gid;
-    }
-    return chown(path, owner, group);
-}
-#define chown be_chown
-static int
-be_fchown(int fd, uid_t owner, gid_t group)
-{
-    if (owner == (uid_t)-1 || group == (gid_t)-1) {
-	struct stat st;
-	if (fstat(fd, &st) < 0) return -1;
-	if (owner == (uid_t)-1) owner = st.st_uid;
-	if (group == (gid_t)-1) group = st.st_gid;
-    }
-    return fchown(fd, owner, group);
-}
-#define fchown be_fchown
-#endif /* __BEOS__ */
-
 VALUE rb_cFile;
 VALUE rb_mFileTest;
 VALUE rb_cStat;

--- a/include/ruby/defines.h
+++ b/include/ruby/defines.h
@@ -168,10 +168,6 @@ void xfree(void*);
 #include "ruby/win32.h"
 #endif
 
-#if defined(__BEOS__) && !defined(BONE)
-#include <net/socket.h> /* intern.h needs fd_set definition */
-#endif
-
 #ifdef RUBY_EXPORT
 #undef RUBY_EXTERN
 

--- a/io.c
+++ b/io.c
@@ -35,7 +35,7 @@
 # include <sys/socket.h>
 #endif
 
-#if defined(__BOW__) || defined(__CYGWIN__) || defined(_WIN32) || defined(__BEOS__)
+#if defined(__BOW__) || defined(__CYGWIN__) || defined(_WIN32)
 # define NO_SAFE_RENAME
 #endif
 
@@ -98,12 +98,6 @@
 
 #ifdef HAVE_SYS_WAIT_H
 # include <sys/wait.h>		/* for WNOHANG on BSD */
-#endif
-
-#if defined(__BEOS__)
-# ifndef NOFILE
-#  define NOFILE (OPEN_MAX)
-# endif
 #endif
 
 #include "ruby/util.h"
@@ -2179,7 +2173,7 @@ remain_size(rb_io_t *fptr)
     off_t pos;
 
     if (fstat(fptr->fd, &st) == 0  && S_ISREG(st.st_mode)
-#if defined(__BEOS__) || defined(__HAIKU__)
+#if defined(__HAIKU__)
 	&& (st.st_dev > 3)
 #endif
 	)

--- a/lib/mkmf.rb
+++ b/lib/mkmf.rb
@@ -132,7 +132,6 @@ module MakeMakefile
   $mingw = /mingw/ =~ RUBY_PLATFORM
   $cygwin = /cygwin/ =~ RUBY_PLATFORM
   $netbsd = /netbsd/ =~ RUBY_PLATFORM
-  $beos = /beos/ =~ RUBY_PLATFORM
   $haiku = /haiku/ =~ RUBY_PLATFORM
   $solaris = /solaris/ =~ RUBY_PLATFORM
   $universal = /universal/ =~ RUBY_PLATFORM

--- a/signal.c
+++ b/signal.c
@@ -69,10 +69,6 @@ ruby_atomic_compare_and_swap(rb_atomic_t *ptr, rb_atomic_t cmp,
 }
 #endif
 
-#if defined(__BEOS__)
-#undef SIGBUS
-#endif
-
 #ifndef NSIG
 # define NSIG (_SIGMAX + 1)      /* For QNX */
 #endif


### PR DESCRIPTION
As a developer of Haiku, I can say the chances of BeOS (gcc2) still compiling are minimal. Given Haiku offers binary compatibility, more modern hardware support (BeOS won't run on hardware over Pentium I without binary patching) , and is open source.. lets finally lay BeOS to rest.