### PR TITLE
Remove TLSv1 support from DEFAULT_PARAMS

### DIFF
--- a/ext/openssl/lib/openssl/ssl.rb
+++ b/ext/openssl/lib/openssl/ssl.rb
@@ -59,6 +59,7 @@ module OpenSSL
           opts |= OpenSSL::SSL::OP_NO_COMPRESSION if defined?(OpenSSL::SSL::OP_NO_COMPRESSION)
           opts |= OpenSSL::SSL::OP_NO_SSLv2 if defined?(OpenSSL::SSL::OP_NO_SSLv2)
           opts |= OpenSSL::SSL::OP_NO_SSLv3 if defined?(OpenSSL::SSL::OP_NO_SSLv3)
+          opts |= OpenSSL::SSL::OP_NO_TLSv1 if defined?(OpenSSL::SSL::OP_NO_TLSv1)
           opts
         }.call
       }


### PR DESCRIPTION
Reviving #873 since I think there was some confusion in the original PR.

* `:ssl_version` maps to the `SSL_METHOD` param that is passed into `SSL_CTX_new()`. 
  * https://www.openssl.org/docs/manmaster/ssl/SSL_CTX_new.html
* The naming of `SSLv23_method` is disingenuous. It has the effect of enabling SSLv3 and *newer*.
* `SSLv3_method`,  `TLSv1_method`, `TLSv1_1_method`, `TLSv1_2_method` pin the SSL/TLS to a *specific version*, which seem like a poor default.
* `SSLv23_method` is being renamed to `TLS_method` in OpenSSL 1.1.0, which is a better reflection of its usage. `SSLv23_method` becomes an alias for `TLS_method` and is deprecated. Ruby should use `TLS_method` by default on OpenSSL 1.1.0 or later and retain `SSLv23_method` as the default with previous versions.

If there is consensus that we don't want to remove support for client TLSv1, I think the next step should be to break `DEFAULT_PARAMS` into separate client and server settings. Shipping a TLS server with badly configured defaults is definitely harmful. 
