### PR TITLE
Backport nonblocking connect in net/http to Ruby 2.1

### DIFF
--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -21,6 +21,7 @@
 
 require 'net/protocol'
 require 'uri'
+require 'io/wait'
 
 module Net   #:nodoc:
   autoload :OpenSSL, 'openssl'
@@ -920,7 +921,24 @@ module Net   #:nodoc:
              Time.now < @ssl_session.time + @ssl_session.timeout
             s.session = @ssl_session if @ssl_session
           end
-          Timeout.timeout(@open_timeout, Net::OpenTimeout) { s.connect }
+          if timeout = @open_timeout
+            while true
+              raise Net::OpenTimeout if timeout <= 0
+              start = Time.now
+              # to_io is requied because SSLSocket doesn't have wait_readable yet
+              begin
+                s.connect_nonblock
+                break
+              rescue OpenSSL::SSL::SSLErrorWaitReadable
+                s.to_io.wait_readable(timeout)
+              rescue OpenSSL::SSL::SSLErrorWaitWritable
+                s.to_io.wait_writable(timeout)
+              end
+              timeout -= Time.now - start
+            end
+          else
+            s.connect
+          end
           if @ssl_context.verify_mode != OpenSSL::SSL::VERIFY_NONE
             s.post_connection_check(@address)
           end


### PR DESCRIPTION
Backport https://github.com/ruby/ruby/commit/bab5bf0c79ba310eb2606c079315de417a3cccc9 to Ruby 2.1.

Time.new is used instead of `Process.clock_gettime` in order of being
consistent with https://github.com/ruby/ruby/blob/v2_1_7/lib/net/http.rb#L918.

Also, the code was rewritten to use exceptions instead of return value,
because Ruby < 2.3 does not support passing options to `connect_nonblock`.