### PR TITLE
Clarify documentation on xmlrpc xml parsers

### DIFF
--- a/lib/xmlrpc.rb
+++ b/lib/xmlrpc.rb
@@ -53,9 +53,19 @@
 #
 # * Parsers
 #   * NQXML (XMLParser::NQXMLStreamParser, XMLParser::NQXMLTreeParser)
+#     * Not compiled (pure ruby)
+#     * Note: NQXML's website recommends rexml and isn't available on rubygems.org
+#     * See http://nqxml.sourceforge.net/
 #   * Expat (XMLParser::XMLStreamParser, XMLParser::XMLTreeParser)
+#     * Compiled
+#     * Fastest parser and also uses the least memory
+#     * See https://rubygems.org/gems/xmlparser
 #   * REXML (XMLParser::REXMLStreamParser)
+#     * Not compiled (pure ruby)
+#     * See ruby standard library
 #   * xml-scan (XMLParser::XMLScanStreamParser)
+#     * Not compiled (pure ruby)
+#     * See https://rubygems.org/gems/xmlscan
 #   * Fastest parser is Expat's XMLParser::XMLStreamParser!
 #
 # * General
@@ -292,7 +302,7 @@
 #   # ...
 #
 #
-# Note that XMLParser::XMLStreamParser is incredible faster (and uses less memory) than any
+# Note XMLParser::XMLStreamParser (xmlparser gem) is faster and uses less memory than any
 # other parser and scales well for large documents. For example for a 0.5 MB XML
 # document with many tags, XMLParser::XMLStreamParser is ~350 (!) times faster than
 # XMLParser::NQXMLTreeParser and still ~18 times as fast as XMLParser::XMLTreeParser.


### PR DESCRIPTION
It's useful to know:
* If they're pure ruby or compiled
* Where they can be found
* If their own website says "just use rexml" (NQXML)

Finally, we should make it clear that the 'xmlparser' gem is the one
you want if a pure ruby solution is too slow or consumes too much
memory. Some users may not realize the 'xmlparser' gem is needed to
use the suggested XMLParser::XMLStreamParser class.