### PR TITLE
Fix cross build

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -258,7 +258,7 @@ ruby-runner.c: template/ruby-runner.c.in
 ruby-runner$(EXEEXT): ruby-runner.c
 	$(Q) $(PURIFY) $(CC) $(CFLAGS) $(CPPFLAGS) -DRUBY_INSTALL_NAME=$(RUBY_INSTALL_NAME) $(LDFLAGS) $(LIBS) $(OUTFLAG)$@ ruby-runner.c
 
-$(RBCONFIG): $($(CROSS_COMPILING:no=)PREP)
+$(RBCONFIG): $(PREP)
 
 rbconfig.rb: $(RBCONFIG)
 

--- a/tool/fake.rb
+++ b/tool/fake.rb
@@ -46,7 +46,7 @@ prehook = proc do |extmk|
   end
   join = proc {|*args| File.join(*args).sub!(/\A(?:\.\/)*/, '')}
   $topdir ||= builddir
-  $top_srcdir ||= join[$topdir, srcdir]
+  $top_srcdir ||= File.realpath(srcdir, $topdir)
   $extout = '$(topdir)/.ext'
   $extout_prefix = '$(extout)$(target_prefix)/'
   config = RbConfig::CONFIG

--- a/win32/Makefile.sub
+++ b/win32/Makefile.sub
@@ -1061,9 +1061,7 @@ clean-enc distclean-enc realclean-enc:
 	@-$(MAKE) -f $(ENC_MK) $(MFLAGS) V=$(V) $(@:-enc=)
 !endif
 
-!if "$(CROSS_COMPILING)" == "no"
 $(RBCONFIG): $(PREP)
-!endif
 
 $(RCFILES): $(RBCONFIG) $(srcdir)/revision.h $(srcdir)/win32/resource.rb
 		@$(MINIRUBY) $(srcdir)/win32/resource.rb \


### PR DESCRIPTION
[rake-compiler-dock](https://github.com/rake-compiler/rake-compiler-dock) makes use of the cross build capability of ruby to provide a build environment targeting to the Windows-RubyInstaller. Unfortunately ruby-2.3.0-preview1 doesn't cross build because of two issues. These are addressed in the attached commits.