### PR TITLE
Error happened when using "indented heredoc" on irb

### DIFF
--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -405,7 +405,7 @@ class RubyLex
       if @lex_state != EXPR_END && @lex_state != EXPR_CLASS &&
           (@lex_state != EXPR_ARG || @space_seen)
         c = peek(0)
-        if /\S/ =~ c && (/["'`]/ =~ c || /\w/ =~ c || c == "-")
+        if /\S/ =~ c && (/["'`]/ =~ c || /\w/ =~ c || c == "-" || c == "~")
           tk = identify_here_document
         end
       end
@@ -854,7 +854,7 @@ class RubyLex
 
   def identify_here_document
     ch = getc
-    if ch == "-"
+    if ch == "-" || ch == "~"
       ch = getc
       indent = true
     end


### PR DESCRIPTION
## Expected

```
$ irb
> RUBY_VERSION
=> "2.3.0"
> RUBY_RELEASE_DATE
=> "2015-12-08"
> expected_result = <<~SQUIGGLY_HEREDOC
"   This would contain specially formatted text.
"
"   That might span many lines
" SQUIGGLY_HEREDOC
=> "This would contain specially formatted text.\n\nThat might span many lines\n"
```

## Actual

```
$ irb
> RUBY_VERSION
=> "2.3.0"
> RUBY_RELEASE_DATE
=> "2015-12-08"
> expected_result = <<~SQUIGGLY_HEREDOC
SyntaxError: (irb):3: can't find string "SQUIGGLY_HEREDOC" anywhere before EOF
(irb):3: syntax error, unexpected end-of-input, expecting tSTRING_CONTENT or tSTRING_DBEG or tSTRING_DVAR or tSTRING_END
        from /Users/koic/.rbenv/versions/2.3.0-dev/bin/irb:11:in `<main>'
```

I have little confidence in my codes...