### PR TITLE
Use safe navigation operator where possible

### DIFF
--- a/bootstraptest/runner.rb
+++ b/bootstraptest/runner.rb
@@ -347,7 +347,7 @@ def assert_normal_exit(testsrc, *rest)
       $stderr.reopen(old_stderr)
       old_stderr.close
     end
-    if status && status.signaled?
+    if status&.signaled?
       signo = status.termsig
       signame = Signal.list.invert[signo]
       unless ignore_signals and ignore_signals.include?(signame)

--- a/ext/socket/lib/socket.rb
+++ b/ext/socket/lib/socket.rb
@@ -1102,7 +1102,7 @@ class Socket < BasicSocket
         st = File.lstat(path)
       rescue Errno::ENOENT
       end
-      if st && st.socket? && st.owned?
+      if st&.socket? && st.owned?
         File.unlink path
       end
     end

--- a/ext/tk/lib/tk.rb
+++ b/ext/tk/lib/tk.rb
@@ -4460,7 +4460,7 @@ module TkConfigMethod
           __font_optkeys.each{|optkey|
             optkey = optkey.to_s
             fontconf = ret.assoc(optkey)
-            if fontconf && fontconf.size > 2
+            if fontconf&.size > 2
               ret.delete_if{|inf| inf[0] =~ /^(|latin|ascii|kanji)#{optkey}$/}
               fnt = fontconf[__configinfo_struct[:default_value]]
               if TkFont.is_system_font?(fnt)

--- a/ext/tk/lib/tk/itemconfig.rb
+++ b/ext/tk/lib/tk/itemconfig.rb
@@ -404,7 +404,7 @@ module TkItemConfigMethod
 
   def __itemconfiginfo_core(tagOrId, slot = nil)
     if TkComm::GET_CONFIGINFO_AS_ARRAY
-      if (slot && slot.to_s =~ /^(|latin|ascii|kanji)(#{__item_font_optkeys(tagid(tagOrId)).join('|')})$/)
+      if (slot&.to_s =~ /^(|latin|ascii|kanji)(#{__item_font_optkeys(tagid(tagOrId)).join('|')})$/)
         fontkey  = $2
         # conf = tk_split_simplelist(_fromUTF8(tk_call_without_enc(*(__item_confinfo_cmd(tagid(tagOrId)) << "-#{fontkey}"))))
         conf = tk_split_simplelist(tk_call_without_enc(*(__item_confinfo_cmd(tagid(tagOrId)) << "-#{fontkey}")), false, true)
@@ -756,7 +756,7 @@ module TkItemConfigMethod
           __item_font_optkeys(tagid(tagOrId)).each{|optkey|
             optkey = optkey.to_s
             fontconf = ret.assoc(optkey)
-            if fontconf && fontconf.size > 2
+            if fontconf&.size > 2
               ret.delete_if{|inf| inf[0] =~ /^(|latin|ascii|kanji)#{optkey}$/}
               fnt = fontconf[__item_configinfo_struct(tagid(tagOrId))[:default_value]]
               if TkFont.is_system_font?(fnt)
@@ -776,7 +776,7 @@ module TkItemConfigMethod
       end
 
     else # ! TkComm::GET_CONFIGINFO_AS_ARRAY
-      if (slot && slot.to_s =~ /^(|latin|ascii|kanji)(#{__item_font_optkeys(tagid(tagOrId)).join('|')})$/)
+      if (slot&.to_s =~ /^(|latin|ascii|kanji)(#{__item_font_optkeys(tagid(tagOrId)).join('|')})$/)
         fontkey  = $2
         # conf = tk_split_simplelist(_fromUTF8(tk_call_without_enc(*(__item_confinfo_cmd(tagid(tagOrId)) << "-#{fontkey}"))))
         conf = tk_split_simplelist(tk_call_without_enc(*(__item_confinfo_cmd(tagid(tagOrId)) << "-#{fontkey}")), false, true)

--- a/ext/tk/lib/tkextlib/tile/treeview.rb
+++ b/ext/tk/lib/tkextlib/tile/treeview.rb
@@ -24,7 +24,7 @@ module Tk::Tile::TreeviewConfig
 
   def __itemconfiginfo_core(tagOrId, slot = nil)
     if TkComm::GET_CONFIGINFO_AS_ARRAY
-      if (slot && slot.to_s =~ /^(|latin|ascii|kanji)(#{__item_font_optkeys(tagid(tagOrId)).join('|')})$/)
+      if (slot&.to_s =~ /^(|latin|ascii|kanji)(#{__item_font_optkeys(tagid(tagOrId)).join('|')})$/)
         fontkey  = $2
         return [slot.to_s, tagfontobj(tagid(tagOrId), fontkey)]
       else
@@ -195,7 +195,7 @@ module Tk::Tile::TreeviewConfig
       end
 
     else # ! TkComm::GET_CONFIGINFO_AS_ARRAY
-      if (slot && slot.to_s =~ /^(|latin|ascii|kanji)(#{__item_font_optkeys(tagid(tagOrId)).join('|')})$/)
+      if (slot&.to_s =~ /^(|latin|ascii|kanji)(#{__item_font_optkeys(tagid(tagOrId)).join('|')})$/)
         fontkey  = $2
         return {slot.to_s => tagfontobj(tagid(tagOrId), fontkey)}
       else

--- a/ext/tk/sample/demos-en/pendulum.rb
+++ b/ext/tk/sample/demos-en/pendulum.rb
@@ -181,7 +181,7 @@ class PendulumAnimationDemo
       last = -1 if last >= 0
       next if first > last
       lst = @points[first..last]
-      @graph[i].coords(lst) if lst && lst.length >= 4
+      @graph[i].coords(lst) if lst&.length >= 4
     }
   end
 

--- a/ext/tk/sample/demos-en/toolbar.rb
+++ b/ext/tk/sample/demos-en/toolbar.rb
@@ -65,7 +65,7 @@ if Tk.windowingsystem != 'aqua'
   to2.    bind('B1-Motion', '%X %Y'){|x, y| tbar_base.tearoff(to_base, x, y)}
   def tbar_base.tearoff(w, x, y)
     on_win = TkWinfo.containing(x, y)
-    return unless (on_win && on_win.path =~ /^#{@path}(\.|$)/)
+    return unless (on_win&.path =~ /^#{@path}(\.|$)/)
     self.grid_remove
     w.grid_remove
     self.wm_manage

--- a/ext/tk/sample/demos-jp/pendulum.rb
+++ b/ext/tk/sample/demos-jp/pendulum.rb
@@ -183,7 +183,7 @@ class PendulumAnimationDemo
       last = -1 if last >= 0
       next if first > last
       lst = @points[first..last]
-      @graph[i].coords(lst) if lst && lst.length >= 4
+      @graph[i].coords(lst) if lst&.length >= 4
     }
   end
 

--- a/ext/tk/sample/demos-jp/toolbar.rb
+++ b/ext/tk/sample/demos-jp/toolbar.rb
@@ -68,7 +68,7 @@ if Tk.windowingsystem != 'aqua'
   to2.    bind('B1-Motion', '%X %Y'){|x, y| tbar_base.tearoff(to_base, x, y)}
   def tbar_base.tearoff(w, x, y)
     on_win = TkWinfo.containing(x, y)
-    return unless (on_win && on_win.path =~ /^#{@path}(\.|$)/)
+    return unless (on_win&.path =~ /^#{@path}(\.|$)/)
     self.grid_remove
     w.grid_remove
     self.wm_manage

--- a/lib/drb/drb.rb
+++ b/lib/drb/drb.rb
@@ -1713,7 +1713,7 @@ module DRb
   # error is raised.
   def current_server
     drb = Thread.current['DRb']
-    server = (drb && drb['server']) ? drb['server'] : @primary_server
+    server = drb&['server'] || @primary_server
     raise DRbServerNotFound unless server
     return server
   end
@@ -1734,7 +1734,7 @@ module DRb
   # This is the URI of the current server.  See #current_server.
   def uri
     drb = Thread.current['DRb']
-    client = (drb && drb['client'])
+    client = drb&['client']
     if client
       uri = client.uri
       return uri if uri

--- a/lib/drb/extservm.rb
+++ b/lib/drb/extservm.rb
@@ -37,7 +37,7 @@ module DRb
       synchronize do
         while true
           server = @servers[name]
-          return server if server && server.alive?
+          return server if server&.alive?
           invoke_service(name)
           @cond.wait
         end

--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -1,4 +1,4 @@
-#
+f#
 # = net/http.rb
 #
 # Copyright (c) 1999-2007 Yukihiro Matsumoto
@@ -566,7 +566,7 @@ module Net   #:nodoc:
     def HTTP.start(address, *arg, &block) # :yield: +http+
       arg.pop if opt = Hash.try_convert(arg[-1])
       port, p_addr, p_port, p_user, p_pass = *arg
-      port = https_default_port if !port && opt && opt[:use_ssl]
+      port = https_default_port if !port && opt&[:use_ssl]
       http = new(address, port, p_addr, p_port, p_user, p_pass)
 
       if opt
@@ -1055,7 +1055,7 @@ module Net   #:nodoc:
     # The address of the proxy server, if one is configured.
     def proxy_address
       if @proxy_from_env then
-        proxy_uri && proxy_uri.hostname
+        proxy_uri&.hostname
       else
         @proxy_address
       end
@@ -1064,7 +1064,7 @@ module Net   #:nodoc:
     # The port of the proxy server, if one is configured.
     def proxy_port
       if @proxy_from_env then
-        proxy_uri && proxy_uri.port
+        proxy_uri&.port
       else
         @proxy_port
       end

--- a/lib/net/http/response.rb
+++ b/lib/net/http/response.rb
@@ -251,7 +251,7 @@ class Net::HTTPResponse
     return yield @socket if self['content-range']
 
     v = self['content-encoding']
-    case v && v.downcase
+    case v&.downcase
     when 'deflate', 'gzip', 'x-gzip' then
       self.delete 'content-encoding'
 

--- a/lib/rdoc/context.rb
+++ b/lib/rdoc/context.rb
@@ -795,7 +795,7 @@ class RDoc::Context < RDoc::CodeObject
   # Find a module at a higher scope
 
   def find_enclosing_module_named(name)
-    parent && parent.find_module_named(name)
+    parent&.find_module_named(name)
   end
 
   ##

--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -1509,7 +1509,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
         end
       when TkRPAREN then
         nest -= 1
-      when method && method.block_params.nil? && TkCOMMENT then
+      when method&.block_params.nil? && TkCOMMENT then
         unget_tk tk
         read_documentation_modifiers method, modifiers
         @read.pop

--- a/lib/rubygems/dependency.rb
+++ b/lib/rubygems/dependency.rb
@@ -326,7 +326,7 @@ class Gem::Dependency
   def to_spec
     matches = self.to_specs
 
-    active = matches.find { |spec| spec && spec.activated? }
+    active = matches.find { |spec| spec&.activated? }
 
     return active if active
 

--- a/lib/rubygems/resolver/molinillo/lib/molinillo/dependency_graph.rb
+++ b/lib/rubygems/resolver/molinillo/lib/molinillo/dependency_graph.rb
@@ -133,7 +133,7 @@ module Gem::Resolver::Molinillo
     # @return [Vertex,nil] the root vertex with the given name
     def root_vertex_named(name)
       vertex = vertex_named(name)
-      vertex if vertex && vertex.root?
+      vertex if vertex&.root?
     end
 
     # Adds a new {Edge} to the dependency graph

--- a/lib/rubygems/resolver/molinillo/lib/molinillo/resolution.rb
+++ b/lib/rubygems/resolver/molinillo/lib/molinillo/resolution.rb
@@ -221,7 +221,7 @@ module Gem::Resolver::Molinillo
           seen ||= s.requirement == requirement || s.requirements.include?(requirement)
           seen && s.requirement != requirement && !s.requirements.include?(requirement)
         end
-        state && state.requirement
+        state&.requirement
       end
 
       # @return [Object] the requirement that led to a version of a possibility
@@ -241,7 +241,7 @@ module Gem::Resolver::Molinillo
       # @return [Boolean] whether or not the given state has any possibilities
       #   left.
       def state_any?(state)
-        state && state.possibilities.any?
+        state&.possibilities.any?
       end
 
       # @return [Conflict] a {Conflict} that reflects the failure to activate
@@ -372,7 +372,7 @@ module Gem::Resolver::Molinillo
       #   is found on {#base}
       def locked_requirement_named(requirement_name)
         vertex = base.vertex_named(requirement_name)
-        vertex && vertex.payload
+        vertex&.payload
       end
 
       # Add the current {#possibility} to the dependency graph of the current

--- a/lib/rubygems/server.rb
+++ b/lib/rubygems/server.rb
@@ -631,7 +631,7 @@ div.method-source-code pre { color: #ffdead; overflow: hidden; }
         "dependencies"        => deps,
         "doc_path"            => doc_root(spec.full_name),
         "executables"         => executables,
-        "only_one_executable" => (executables && executables.size == 1),
+        "only_one_executable" => executables&.size == 1,
         "full_name"           => spec.full_name,
         "has_deps"            => !deps.empty?,
         "homepage"            => spec.homepage,

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1046,7 +1046,7 @@ class Gem::Specification < Gem::BasicSpecification
     stub = stubs.find { |s|
       s.contains_requirable_file? path unless s.activated?
     }
-    stub && stub.to_spec
+    stub&.to_spec
   end
 
   def self.find_active_stub_by_path path

--- a/lib/rubygems/stub_specification.rb
+++ b/lib/rubygems/stub_specification.rb
@@ -83,8 +83,7 @@ class Gem::StubSpecification < Gem::BasicSpecification
   def activated?
     @activated ||=
     begin
-      loaded = Gem.loaded_specs[name]
-      loaded && loaded.version == version
+      Gem.loaded_specs[name]&.version == version
     end
   end
 

--- a/lib/scanf.rb
+++ b/lib/scanf.rb
@@ -471,8 +471,7 @@ module Scanf
     end
 
     def width
-      w = @spec_string[/%\*?(\d+)/, 1]
-      w && w.to_i
+      @spec_string[/%\*?(\d+)/, 1]&.to_i
     end
 
     def mid_match?

--- a/lib/uri/generic.rb
+++ b/lib/uri/generic.rb
@@ -1326,7 +1326,7 @@ module URI
     # Destructive version of #normalize
     #
     def normalize!
-      if path && path.empty?
+      if path&.empty?
         set_path('/')
       end
       if scheme && scheme != scheme.downcase

--- a/lib/uri/ldap.rb
+++ b/lib/uri/ldap.rb
@@ -133,10 +133,10 @@ module URI
       if @query
         attrs, scope, filter, extensions = @query.split('?')
 
-        @attributes = attrs if attrs && attrs.size > 0
-        @scope      = scope if scope && scope.size > 0
-        @filter     = filter if filter && filter.size > 0
-        @extensions = extensions if extensions && extensions.size > 0
+        @attributes = attrs      if attrs&.size > 0
+        @scope      = scope      if scope&.size > 0
+        @filter     = filter     if filter&.size > 0
+        @extensions = extensions if extensions&.size > 0
       end
     end
     private :parse_query

--- a/test/openssl/test_pair.rb
+++ b/test/openssl/test_pair.rb
@@ -49,7 +49,7 @@ module OpenSSL::SSLPairM
       return c, s
     end
   ensure
-    if th && th.alive?
+    if th&.alive?
       th.kill
       th.join
     end

--- a/test/ruby/test_econv.rb
+++ b/test/ruby/test_econv.rb
@@ -22,8 +22,8 @@ class TestEncodingConverter < Test::Unit::TestCase
 
   def assert_errinfo(e_res, e_enc1, e_enc2, e_error_bytes, e_readagain_bytes, ec)
     assert_equal([e_res, e_enc1, e_enc2,
-                  e_error_bytes && e_error_bytes.dup.force_encoding("ASCII-8BIT"),
-                  e_readagain_bytes && e_readagain_bytes.dup.force_encoding("ASCII-8BIT")],
+                  e_error_bytes&.dup.force_encoding("ASCII-8BIT"),
+                  e_readagain_bytes&.dup.force_encoding("ASCII-8BIT")],
                  ec.primitive_errinfo)
   end
 

--- a/test/ruby/test_settracefunc.rb
+++ b/test/ruby/test_settracefunc.rb
@@ -464,7 +464,7 @@ class TestSetTraceFunc < Test::Unit::TestCase
     EOF
     self.class.class_eval{remove_const(:XYZZY)}
     ensure
-      trace.disable if trace && trace.enabled?
+      trace.disable if trace&.enabled?
     end
 
     answer_events = [

--- a/test/thread/test_queue.rb
+++ b/test/thread/test_queue.rb
@@ -427,7 +427,7 @@ class TestQueue < Test::Unit::TestCase
 
       # wait for all threads to be finished, because of exceptions
       # NOTE: thr.status will be nil (raised) or false (terminated)
-      sleep 0.01 until prod_threads && prod_threads.all?{|thr| !thr.status}
+      sleep 0.01 until prod_threads&.all?{|thr| !thr.status}
 
       # check that all threads failed to call push
       prod_threads.each do |thr|


### PR DESCRIPTION
Did this using a regex, so not all changes might preserve semantics.