### PR TITLE
Use safe navigation operator

### DIFF
--- a/bootstraptest/runner.rb
+++ b/bootstraptest/runner.rb
@@ -347,7 +347,7 @@ def assert_normal_exit(testsrc, *rest)
       $stderr.reopen(old_stderr)
       old_stderr.close
     end
-    if status && status.signaled?
+    if status&.signaled?
       signo = status.termsig
       signame = Signal.list.invert[signo]
       unless ignore_signals and ignore_signals.include?(signame)

--- a/ext/socket/lib/socket.rb
+++ b/ext/socket/lib/socket.rb
@@ -1102,7 +1102,7 @@ class Socket < BasicSocket
         st = File.lstat(path)
       rescue Errno::ENOENT
       end
-      if st && st.socket? && st.owned?
+      if st&.socket? && st.owned?
         File.unlink path
       end
     end

--- a/lib/drb/extservm.rb
+++ b/lib/drb/extservm.rb
@@ -37,7 +37,7 @@ module DRb
       synchronize do
         while true
           server = @servers[name]
-          return server if server && server.alive?
+          return server if server&.alive?
           invoke_service(name)
           @cond.wait
         end

--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -1055,7 +1055,7 @@ module Net   #:nodoc:
     # The address of the proxy server, if one is configured.
     def proxy_address
       if @proxy_from_env then
-        proxy_uri && proxy_uri.hostname
+        proxy_uri&.hostname
       else
         @proxy_address
       end
@@ -1064,7 +1064,7 @@ module Net   #:nodoc:
     # The port of the proxy server, if one is configured.
     def proxy_port
       if @proxy_from_env then
-        proxy_uri && proxy_uri.port
+        proxy_uri&.port
       else
         @proxy_port
       end

--- a/lib/net/http/response.rb
+++ b/lib/net/http/response.rb
@@ -251,7 +251,7 @@ class Net::HTTPResponse
     return yield @socket if self['content-range']
 
     v = self['content-encoding']
-    case v && v.downcase
+    case v&.downcase
     when 'deflate', 'gzip', 'x-gzip' then
       self.delete 'content-encoding'
 

--- a/lib/scanf.rb
+++ b/lib/scanf.rb
@@ -471,8 +471,7 @@ module Scanf
     end
 
     def width
-      w = @spec_string[/%\*?(\d+)/, 1]
-      w && w.to_i
+      @spec_string[/%\*?(\d+)/, 1]&.to_i
     end
 
     def mid_match?

--- a/lib/uri/generic.rb
+++ b/lib/uri/generic.rb
@@ -1326,7 +1326,7 @@ module URI
     # Destructive version of #normalize
     #
     def normalize!
-      if path && path.empty?
+      if path&.empty?
         set_path('/')
       end
       if scheme && scheme != scheme.downcase

--- a/test/openssl/test_pair.rb
+++ b/test/openssl/test_pair.rb
@@ -49,7 +49,7 @@ module OpenSSL::SSLPairM
       return c, s
     end
   ensure
-    if th && th.alive?
+    if th&.alive?
       th.kill
       th.join
     end

--- a/test/ruby/test_econv.rb
+++ b/test/ruby/test_econv.rb
@@ -18,8 +18,8 @@ class TestEncodingConverter < Test::Unit::TestCase
 
   def assert_errinfo(e_res, e_enc1, e_enc2, e_error_bytes, e_readagain_bytes, ec)
     assert_equal([e_res, e_enc1, e_enc2,
-                  e_error_bytes && e_error_bytes.b,
-                  e_readagain_bytes && e_readagain_bytes.b],
+                  e_error_bytes&.b,
+                  e_readagain_bytes&.b],
                  ec.primitive_errinfo)
   end
 

--- a/test/ruby/test_settracefunc.rb
+++ b/test/ruby/test_settracefunc.rb
@@ -464,7 +464,7 @@ class TestSetTraceFunc < Test::Unit::TestCase
     EOF
     self.class.class_eval{remove_const(:XYZZY)}
     ensure
-      trace.disable if trace && trace.enabled?
+      trace.disable if trace&.enabled?
     end
 
     answer_events = [

--- a/test/thread/test_queue.rb
+++ b/test/thread/test_queue.rb
@@ -427,7 +427,7 @@ class TestQueue < Test::Unit::TestCase
 
       # wait for all threads to be finished, because of exceptions
       # NOTE: thr.status will be nil (raised) or false (terminated)
-      sleep 0.01 until prod_threads && prod_threads.all?{|thr| !thr.status}
+      sleep 0.01 until prod_threads&.all?{|thr| !thr.status}
 
       # check that all threads failed to call push
       prod_threads.each do |thr|


### PR DESCRIPTION
Took feedback from https://github.com/ruby/ruby/pull/1141 and pared the changes down to be more conservative.

Avoids any comparisons, collection accessors, and basically anything other than a method call. Also doesn't affect RubyGems or RDoc.

Again, I think this should just work, but I may well have missed something, so would appreciate a closer look.