### PR TITLE
Render erb with array buffer

### DIFF
--- a/lib/erb.rb
+++ b/lib/erb.rb
@@ -589,7 +589,7 @@ class ERB
     end
 
     def add_insert_cmd(out, content)
-      out.push("#{@insert_cmd}((#{content}).to_s)")
+      out.push("#{@insert_cmd}((#{content}))")
     end
 
     # Compiles an ERB template into Ruby code.  Returns an array of the code
@@ -834,10 +834,10 @@ class ERB
   # requires the setup of an ERB _compiler_ object.
   #
   def set_eoutvar(compiler, eoutvar = '_erbout')
-    compiler.put_cmd = "#{eoutvar}.concat"
-    compiler.insert_cmd = "#{eoutvar}.concat"
-    compiler.pre_cmd = ["#{eoutvar} = ''"]
-    compiler.post_cmd = ["#{eoutvar}.force_encoding(__ENCODING__)"]
+    compiler.put_cmd = "#{eoutvar}.push"
+    compiler.insert_cmd = "#{eoutvar}.push"
+    compiler.pre_cmd = ["#{eoutvar} = []"]
+    compiler.post_cmd = ["#{eoutvar}.join.force_encoding(__ENCODING__)"]
   end
 
   # Generate results and print them. (see ERB#result)

--- a/lib/rdoc/erb_partial.rb
+++ b/lib/rdoc/erb_partial.rb
@@ -11,7 +11,7 @@ class RDoc::ERBPartial < ERB
   def set_eoutvar compiler, eoutvar = '_erbout'
     super
 
-    compiler.pre_cmd = ["#{eoutvar} ||= ''"]
+    compiler.pre_cmd = ["#{eoutvar} ||= []"]
   end
 
 end

--- a/template/verconf.h.tmpl
+++ b/template/verconf.h.tmpl
@@ -52,7 +52,7 @@
 % R["exec_prefix"] = '"RUBY_EXEC_PREFIX"'
 % R["prefix"] = '"RUBY_EXEC_PREFIX"'
 % exec_prefix_pat = /\A"#{Regexp.quote(rbconfig::CONFIG['exec_prefix'])}(?=\/|\z)/
-% _erbout.gsub!(/^(#define\s+(\S+)\s+)(.*)/) {
+% _erbout = [_erbout.join.gsub!(/^(#define\s+(\S+)\s+)(.*)/) {
 %   pre, name, repl = $1, $2, $3
 %   pat = %["#{name}"]
 %   c = C.merge(R.reject {|key, value| key == name or value.include?(pat)})
@@ -60,4 +60,4 @@
 %   repl.gsub!(/^""(?!$)|(.)""$/, '\1')
 %   repl.sub!(exec_prefix_pat, 'RUBY_EXEC_PREFIX"')
 %   pre + repl
-% }
+% }]


### PR DESCRIPTION
I changed a buffer of erb from String to Array.
I guess calling `Array#join` once is faster than calling `#to_s` N times.

## before
```
$ make benchmark-each COMPARE_RUBY= ITEM=bm_app_erb
benchmark results:
Execution time (sec)
name    built-ruby
app_erb      4.365
```

## after
```
$ make benchmark-each COMPARE_RUBY= ITEM=bm_app_erb
benchmark results:
Execution time (sec)
name    built-ruby
app_erb      4.269
```