### PR TITLE
Simplify regexp to optimize erb scanner

### DIFF
--- a/lib/erb.rb
+++ b/lib/erb.rb
@@ -506,8 +506,8 @@ class ERB
       require 'strscan'
       class SimpleScanner2 < Scanner # :nodoc:
         def scan
-          stag_reg = /(.*?)(<%%|<%=|<%#|<%|\z)/m
-          etag_reg = /(.*?)(%%>|%>|\z)/m
+          stag_reg = /(.*?)(<%[%=#]?|\z)/m
+          etag_reg = /(.*?)(%%?>|\z)/m
           scanner = StringScanner.new(@src)
           while ! scanner.eos?
             scanner.scan(@stag ? etag_reg : stag_reg)


### PR DESCRIPTION
I fixed regexp of scanner in erb for performance.

## before

```
$ make benchmark-each COMPARE_RUBY= ITEM=bm_app_erb
benchmark results:
Execution time (sec)
name    built-ruby
app_erb      4.381
```

## after

```
$ make benchmark-each COMPARE_RUBY= ITEM=bm_app_erb
benchmark results:
Execution time (sec)
name    built-ruby
app_erb      4.177
```