### PR TITLE
Scan from start to end in erb scanner

### DIFF
--- a/lib/erb.rb
+++ b/lib/erb.rb
@@ -506,14 +506,14 @@ class ERB
       require 'strscan'
       class SimpleScanner2 < Scanner # :nodoc:
         def scan
-          stag_reg = /(.*?)(<%[%=#]?|\z)/m
-          etag_reg = /(.*?)(%%?>|\z)/m
           scanner = StringScanner.new(@src)
-          while ! scanner.eos?
-            scanner.scan(@stag ? etag_reg : stag_reg)
+          while scanner.scan(/(.*?)(<%[%=#]?)(.*?)((?<!%)%>|\z)/m)
             yield(scanner[1])
             yield(scanner[2])
+            yield(scanner[3].gsub('%%>', '%>'))
+            yield(scanner[4])
           end
+          yield(scanner.rest)
         end
       end
       Scanner.regist_scanner(SimpleScanner2, nil, false)


### PR DESCRIPTION
This is much faster version of https://github.com/ruby/ruby/pull/1144.
With this patch, you can reduce number of times to call `StringScanner#scan`.
## before

```
$ make benchmark-each COMPARE_RUBY= ITEM=bm_app_erb
benchmark results:
Execution time (sec)
name    built-ruby
app_erb      0.955
```
## after

```
benchmark results:
Execution time (sec)
name    built-ruby
app_erb      0.911
```
