### PR TITLE
Use  `userinfo` for authenticated proxy

### DIFF
--- a/lib/open-uri.rb
+++ b/lib/open-uri.rb
@@ -273,7 +273,12 @@ module OpenURI
         if proxy_user && proxy_pass
           klass = Net::HTTP::Proxy(proxy_uri.hostname, proxy_uri.port, proxy_user, proxy_pass)
         else
-          klass = Net::HTTP::Proxy(proxy_uri.hostname, proxy_uri.port)
+          proxy_user, proxy_pass = proxy_uri.userinfo.split(':') if proxy_uri.userinfo
+          if proxy_user && proxy_pass
+            klass = Net::HTTP::Proxy(proxy_uri.hostname, proxy_uri.port, proxy_user, proxy_pass)
+          else
+            klass = Net::HTTP::Proxy(proxy_uri.hostname, proxy_uri.port)
+          end
         end
       end
       target_host = target.hostname


### PR DESCRIPTION
In spite of `proxy_uri.userinfo` has username and password for authenticated proxy, `open_http` method of `open-uri.rb` ignores it. Actually, lots of softwares expect this value as a credential for authenticated proxy.