### PR TITLE
Update comment about default constant

### DIFF
--- a/lib/uri/common.rb
+++ b/lib/uri/common.rb
@@ -73,7 +73,7 @@ module URI
     #   String to replaces in.
     # +unsafe+::
     #   Regexp that matches all symbols that must be replaced with codes.
-    #   By default uses <tt>REGEXP::UNSAFE</tt>.
+    #   By default uses <tt>UNSAFE</tt>.
     #   When this argument is a String, it represents a character set.
     #
     # == Description


### PR DESCRIPTION
While trying to find the exact default regexp for `URI.escape`, I was unable to find the constant mentioned in the documentation. 

After some digging, I found that the default is actually set via `URI::DEFAULT_PARSER.regexp[:UNSAFE]` which is then set as a higher level constant, `URI::UNSAFE`. 

There does not appear to be a `URI::REGEXP::UNSAFE` anymore. 