### PR TITLE
Implement Set#collect method, so it return Set instead of Array

### DIFF
--- a/lib/set.rb
+++ b/lib/set.rb
@@ -348,6 +348,12 @@ class Set
   end
   alias map! collect!
 
+  # Returns new set with replaced elements
+  def collect(&block)
+    dup.collect!(&block)
+  end
+  alias map collect
+
   # Equivalent to Set#delete_if, but returns nil if no changes were
   # made.
   def reject!(&block)

--- a/test/test_set.rb
+++ b/test/test_set.rb
@@ -448,6 +448,25 @@ class TC_Set < Test::Unit::TestCase
     assert_equal(Set[2,4,6,'A','B','C',nil], set)
   end
 
+  def test_collect
+    set = Set[1,2,3,'a','b','c',-1..1,2..4]
+
+    ret = set.collect { |i|
+      case i
+      when Numeric
+        i * 2
+      when String
+        i.upcase
+      else
+        nil
+      end
+    }
+
+    assert_not_same(set, ret)
+    assert_equal(Set[1,2,3,'a','b','c',-1..1,2..4], set)
+    assert_equal(Set[2,4,6,'A','B','C',nil], ret)
+  end
+
   def test_reject!
     set = Set.new(1..10)
 


### PR DESCRIPTION
```ruby
Set['a','b','c'].collect!(&:upcase) => #<Set: {"A", "B", "C"}>
Set['a','b','c'].collect(&:upcase) => ["A", "B", "C"]
```

This pull request fixes inconsistency, so `Set#collect` method returns `Set` 

```ruby
Set['a','b','c'].collect(&:upcase) => #<Set: {"A", "B", "C"}>
```