### PR TITLE
[ci skip] Clarify object references example

### DIFF
--- a/doc/marshal.rdoc
+++ b/doc/marshal.rdoc
@@ -134,8 +134,8 @@ object is encountered again.  (The first object has an index of 1).
 "@" represents an object link.  Following the type byte is a long giving the
 index of the object.
 
-For example, the following stream contains an Array of the object
-<code>"hello"</code> twice:
+For example, the following stream contains an Array of the same <code>"hello"</code> 
+object twice:
 
   "\004\b[\a\"\nhello@\006"
 


### PR DESCRIPTION
From example description it's not obvious that `"hello"` object should be the same(meaning the same `object_id`). When I first saw this example I dumped `["hello", "hello"]` and got different stream. 
I think that it would make sense to clarify that "hello" object should be the same.  