### PR TITLE
leakchecker.rb: remove temporary measure

### DIFF
--- a/test/lib/leakchecker.rb
+++ b/test/lib/leakchecker.rb
@@ -139,7 +139,7 @@ class LeakChecker
 
   def find_threads
     Thread.list.find_all {|t|
-      t != Thread.current && /\AWEBrick::/ !~ t.class.name && t.alive?
+      t != Thread.current && t.alive?
     }
   end
 

--- a/test/net/http/utils.rb
+++ b/test/net/http/utils.rb
@@ -36,6 +36,7 @@ module TestNetHTTPUtils
     if @server
       @server.shutdown
       @server_thread.join
+      WEBrick::Utils::TimeoutHandler.terminate
     end
     @log_tester.call(@log) if @log_tester
     # resume global state

--- a/test/open-uri/test_open-uri.rb
+++ b/test/open-uri/test_open-uri.rb
@@ -43,6 +43,8 @@ class TestOpenURI < Test::Unit::TestCase
       }
       assert_join_threads([client_thread, server_thread2])
     }
+  ensure
+    WEBrick::Utils::TimeoutHandler.terminate
   end
 
   def with_env(h)

--- a/test/open-uri/test_ssl.rb
+++ b/test/open-uri/test_ssl.rb
@@ -52,6 +52,8 @@ class TestOpenURISSL
       }
       assert_join_threads(threads)
     }
+  ensure
+    WEBrick::Utils::TimeoutHandler.terminate
   end
 
   def setup

--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -924,6 +924,7 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
         @ssl_server_thread.kill.join
         @ssl_server_thread = nil
       end
+      WEBrick::Utils::TimeoutHandler.terminate
     end
 
     def normal_server_port

--- a/test/webrick/test_cgi.rb
+++ b/test/webrick/test_cgi.rb
@@ -7,6 +7,11 @@ require "test/unit"
 class TestWEBrickCGI < Test::Unit::TestCase
   CRLF = "\r\n"
 
+  def teardown
+    WEBrick::Utils::TimeoutHandler.terminate
+    super
+  end
+
   def start_cgi_server(log_tester=TestWEBrick::DefaultLogTester, &block)
     config = {
       :CGIInterpreter => TestWEBrick::RubyBin,

--- a/test/webrick/test_filehandler.rb
+++ b/test/webrick/test_filehandler.rb
@@ -5,6 +5,11 @@ require "webrick"
 require "stringio"
 
 class WEBrick::TestFileHandler < Test::Unit::TestCase
+  def teardown
+    WEBrick::Utils::TimeoutHandler.terminate
+    super
+  end
+
   def default_file_handler(filename)
     klass = WEBrick::HTTPServlet::DefaultFileHandler
     klass.new(WEBrick::Config::HTTP, filename)

--- a/test/webrick/test_httpauth.rb
+++ b/test/webrick/test_httpauth.rb
@@ -7,6 +7,11 @@ require "webrick/httpauth/basicauth"
 require_relative "utils"
 
 class TestWEBrickHTTPAuth < Test::Unit::TestCase
+  def teardown
+    WEBrick::Utils::TimeoutHandler.terminate
+    super
+  end
+
   def test_basic_auth
     log_tester = lambda {|log, access_log|
       assert_equal(1, log.length)

--- a/test/webrick/test_httpproxy.rb
+++ b/test/webrick/test_httpproxy.rb
@@ -13,6 +13,11 @@ end
 require File.expand_path("utils.rb", File.dirname(__FILE__))
 
 class TestWEBrickHTTPProxy < Test::Unit::TestCase
+  def teardown
+    WEBrick::Utils::TimeoutHandler.terminate
+    super
+  end
+
   def test_fake_proxy
     assert_nil(WEBrick::FakeProxyURI.scheme)
     assert_nil(WEBrick::FakeProxyURI.host)

--- a/test/webrick/test_httprequest.rb
+++ b/test/webrick/test_httprequest.rb
@@ -4,6 +4,11 @@ require "stringio"
 require "test/unit"
 
 class TestWEBrickHTTPRequest < Test::Unit::TestCase
+  def teardown
+    WEBrick::Utils::TimeoutHandler.terminate
+    super
+  end
+
   def test_simple_request
     msg = <<-_end_of_message_
 GET /

--- a/test/webrick/test_httpserver.rb
+++ b/test/webrick/test_httpserver.rb
@@ -12,6 +12,11 @@ class TestWEBrickHTTPServer < Test::Unit::TestCase
   end
   NoLog = WEBrick::Log.new(empty_log, WEBrick::BasicLog::WARN)
 
+  def teardown
+    WEBrick::Utils::TimeoutHandler.terminate
+    super
+  end
+
   def test_mount
     httpd = WEBrick::HTTPServer.new(
       :Logger => NoLog,

--- a/test/webrick/test_utils.rb
+++ b/test/webrick/test_utils.rb
@@ -3,6 +3,11 @@ require "test/unit"
 require "webrick/utils"
 
 class TestWEBrickUtils < Test::Unit::TestCase
+  def teardown
+    WEBrick::Utils::TimeoutHandler.terminate
+    super
+  end
+
   def assert_expired(m)
     Thread.handle_interrupt(Timeout::Error => :never, EX => :never) do
       assert_empty(m::TimeoutHandler.instance.instance_variable_get(:@timeout_info))

--- a/test/xmlrpc/webrick_testing.rb
+++ b/test/xmlrpc/webrick_testing.rb
@@ -3,6 +3,11 @@ require 'timeout'
 
 module TestXMLRPC
 module WEBrick_Testing
+  def teardown
+    WEBrick::Utils::TimeoutHandler.terminate
+    super
+  end
+
   def start_server(logger, config={})
     raise "already started" if defined?(@__server) && @__server
     @__started = false


### PR DESCRIPTION
* lib/webrick/utils.rb (WEBrick::Utils::TimeoutHandler#watcher):
  make watcher thread restartable.

* lib/webrick/utils.rb (WEBrick::Utils::TimeoutHandler#terminate):
  new method to terminate watcher thread.

* test/lib/leakchecker.rb (LeakChecker#find_threads): revert
  r46941.