### PR TITLE
Optimize CGI.escapeHTML for ASCII-compatible encodings

### DIFF
--- a/ext/Setup
+++ b/ext/Setup
@@ -1,6 +1,7 @@
 #option nodynamic
 
 #bigdecimal
+#cgi/escape
 #continuation
 #coverage
 #date

--- a/ext/Setup.atheos
+++ b/ext/Setup.atheos
@@ -2,6 +2,7 @@ option nodynamic
 
 #Win32API
 bigdecimal
+cgi/escape
 dbm
 digest
 digest/md5

--- a/ext/Setup.nacl
+++ b/ext/Setup.nacl
@@ -2,6 +2,7 @@
 #
 # #Win32API
 # bigdecimal
+# cgi/escape
 # continuation
 # coverage
 # date

--- a/ext/Setup.nt
+++ b/ext/Setup.nt
@@ -3,6 +3,7 @@
 
 Win32API
 bigdecimal
+cgi/escape
 #dbm
 digest
 digest/md5

--- a/ext/cgi/escape/escape.c
+++ b/ext/cgi/escape/escape.c
@@ -28,7 +28,7 @@ html_escaped_cat(VALUE str, char c)
 static VALUE
 optimized_escape_html(VALUE str)
 {
-    long i, len, modified = 0, beg = 0, offset = 0;
+    long i, len, modified = 0, beg = 0;
     VALUE dest;
     const char *cstr;
 

--- a/ext/cgi/escape/escape.c
+++ b/ext/cgi/escape/escape.c
@@ -1,0 +1,94 @@
+#include "ruby.h"
+#include "ruby/encoding.h"
+
+static VALUE rb_cCGI, rb_mUtil, rb_mEscape;
+
+static VALUE
+html_escaped_cat(VALUE str, char c)
+{
+    switch (c) {
+      case '\'':
+	rb_str_cat_cstr(str, "&#39;");
+	break;
+      case '&':
+	rb_str_cat_cstr(str, "&amp;");
+	break;
+      case '"':
+	rb_str_cat_cstr(str, "&quot;");
+	break;
+      case '<':
+	rb_str_cat_cstr(str, "&lt;");
+	break;
+      case '>':
+	rb_str_cat_cstr(str, "&gt;");
+	break;
+    }
+}
+
+static VALUE
+optimized_escape_html(VALUE str)
+{
+    long i, len, modified = 0, beg = 0, offset = 0;
+    VALUE dest;
+    const char *cstr;
+
+    len  = RSTRING_LEN(str);
+    cstr = RSTRING_PTR(str);
+
+    for (i = 0; i < len; i++) {
+	switch (cstr[i]) {
+	  case '\'':
+	  case '&':
+	  case '"':
+	  case '<':
+	  case '>':
+	    if (!modified) {
+		modified = 1;
+		dest = rb_str_buf_new(len);
+	    }
+
+	    rb_str_cat(dest, cstr + beg, i - beg);
+	    beg = i + 1;
+
+	    html_escaped_cat(dest, cstr[i]);
+	    break;
+	}
+    }
+
+    if (modified) {
+	rb_str_cat(dest, cstr + beg, len - beg);
+	return dest;
+    } else {
+	return str;
+    }
+}
+
+/*
+ *  call-seq:
+ *     CGI.escapeHTML(string) -> string
+ *
+ *  Returns HTML-escaped string.
+ *
+ */
+static VALUE
+cgiesc_escape_html(VALUE self, VALUE str)
+{
+    Check_Type(str, T_STRING);
+
+    if (rb_enc_str_asciicompat_p(str)) {
+	return optimized_escape_html(str);
+    } else {
+	return rb_call_super(1, &str);
+    }
+}
+
+void
+Init_escape(void)
+{
+    rb_cCGI    = rb_define_class("CGI", rb_cObject);
+    rb_mEscape = rb_define_module_under(rb_cCGI, "Escape");
+    rb_mUtil   = rb_define_module_under(rb_cCGI, "Util");
+    rb_define_method(rb_mEscape, "escapeHTML", cgiesc_escape_html, 1);
+    rb_prepend_module(rb_mUtil, rb_mEscape);
+    rb_extend_object(rb_cCGI, rb_mEscape);
+}

--- a/ext/cgi/escape/escape.c
+++ b/ext/cgi/escape/escape.c
@@ -3,7 +3,7 @@
 
 static VALUE rb_cCGI, rb_mUtil, rb_mEscape;
 
-static VALUE
+static void
 html_escaped_cat(VALUE str, char c)
 {
     switch (c) {

--- a/ext/cgi/escape/escape.c
+++ b/ext/cgi/escape/escape.c
@@ -57,6 +57,7 @@ optimized_escape_html(VALUE str)
 
     if (modified) {
 	rb_str_cat(dest, cstr + beg, len - beg);
+	rb_enc_associate(dest, rb_enc_get(str));
 	return dest;
     } else {
 	return str;

--- a/ext/cgi/escape/extconf.rb
+++ b/ext/cgi/escape/extconf.rb
@@ -1,0 +1,3 @@
+require 'mkmf'
+
+create_makefile 'cgi/escape'

--- a/lib/cgi/util.rb
+++ b/lib/cgi/util.rb
@@ -38,6 +38,11 @@ module CGI::Util
     string.gsub(/['&\"<>]/, TABLE_FOR_ESCAPE_HTML__)
   end
 
+  begin
+    require 'cgi/escape'
+  rescue LoadError
+  end
+
   # Unescape a string that has been HTML-escaped
   #   CGI::unescapeHTML("Usage: foo &quot;bar&quot; &lt;baz&gt;")
   #      # => "Usage: foo \"bar\" <baz>"

--- a/test/cgi/test_cgi_util.rb
+++ b/test/cgi/test_cgi_util.rb
@@ -62,6 +62,12 @@ class CGIUtilTest < Test::Unit::TestCase
     assert_equal(CGI::escapeHTML("'&\"><"),"&#39;&amp;&quot;&gt;&lt;")
   end
 
+  def test_cgi_escape_html_preserve_encoding
+    assert_equal(Encoding::US_ASCII, CGI::escapeHTML("'&\"><".force_encoding("US-ASCII")).encoding)
+    assert_equal(Encoding::ASCII_8BIT, CGI::escapeHTML("'&\"><".force_encoding("ASCII-8BIT")).encoding)
+    assert_equal(Encoding::UTF_8, CGI::escapeHTML("'&\"><".force_encoding("UTF-8")).encoding)
+  end
+
   def test_cgi_unescapeHTML
     assert_equal(CGI::unescapeHTML("&#39;&amp;&quot;&gt;&lt;"),"'&\"><")
   end


### PR DESCRIPTION
As commented in https://github.com/ruby/ruby/pull/156#issuecomment-7680054, I rewrote `CGI.escapeHTML` in C, which is used by `ERB::Util#html_escape`.
Since escaping HTML is expensive in rendering a template, I want it to be faster.
For now, I optimized it only for strings whose encoding is ASCII-compatible.

With this benchmark https://gist.github.com/k0kubun/b6af6062bc876190e280, it's about 7 times faster than original implementation in escaping html.

```
$ ruby bench_escape_html.rb
Calculating -------------------------------------
              before    11.448k i/100ms
               after    31.189k i/100ms
-------------------------------------------------
              before    216.403k (± 7.0%) i/s -      2.152M
               after      1.637M (±10.0%) i/s -     16.125M

Comparison:
               after:  1637408.5 i/s
              before:   216403.5 i/s - 7.57x slower
```