### PR TITLE
Preserve original state for tainted and frozen

### DIFF
--- a/ext/cgi/escape/escape.c
+++ b/ext/cgi/escape/escape.c
@@ -25,6 +25,20 @@ html_escaped_cat(VALUE str, char c)
     }
 }
 
+static void
+preserve_original_state(VALUE orig, VALUE dest)
+{
+    rb_enc_associate(dest, rb_enc_get(orig));
+
+    if (rb_obj_frozen_p(orig)) {
+	rb_str_freeze(dest);
+    }
+
+    if (OBJ_TAINTED(orig)) {
+	rb_obj_taint(dest);
+    }
+}
+
 static VALUE
 optimized_escape_html(VALUE str)
 {
@@ -57,7 +71,7 @@ optimized_escape_html(VALUE str)
 
     if (modified) {
 	rb_str_cat(dest, cstr + beg, len - beg);
-	rb_enc_associate(dest, rb_enc_get(str));
+	preserve_original_state(str, dest);
 	return dest;
     }
     else {

--- a/test/cgi/test_cgi_util.rb
+++ b/test/cgi/test_cgi_util.rb
@@ -68,6 +68,16 @@ class CGIUtilTest < Test::Unit::TestCase
     assert_equal(Encoding::UTF_8, CGI::escapeHTML("'&\"><".force_encoding("UTF-8")).encoding)
   end
 
+  def test_cgi_escape_html_preserve_tainted
+    assert_equal(false, CGI::escapeHTML("'&\"><").tainted?)
+    assert_equal(true, CGI::escapeHTML("'&\"><".taint).tainted?)
+  end
+
+  def test_cgi_escape_html_preserve_frozen
+    assert_equal(false, CGI::escapeHTML("'&\"><".dup).frozen?)
+    assert_equal(true, CGI::escapeHTML("'&\"><".freeze).frozen?)
+  end
+
   def test_cgi_unescapeHTML
     assert_equal("'&\"><", CGI::unescapeHTML("&#39;&amp;&quot;&gt;&lt;"))
   end


### PR DESCRIPTION
I fixed `CGI.escapeHTML` https://github.com/ruby/ruby/pull/1164 to preserve original state of `tainted?` and `frozen?`.

ref: https://bugs.ruby-lang.org/issues/11855