### PR TITLE
`nul` should be uppercase.

### DIFF
--- a/doc/extension.ja.rdoc
+++ b/doc/extension.ja.rdoc
@@ -126,10 +126,10 @@ var は lvalue である必要があります．
 また，StringValuePtr() に類似した StringValueCStr() というマ
 クロもあります．StringValueCStr(var) は var を String に置き
 換えてから var の文字列表現に対する char* を返します．返され
-る文字列の末尾には nul 文字が付加されます．なお，途中に nul
+る文字列の末尾には NUL 文字が付加されます．なお，途中に NUL
 文字が含まれる場合は ArgumentError が発生します．
-一方，StringValuePtr() では，末尾に nul 文字がある保証はなく，
-途中に nul 文字が含まれている可能性もあります．
+一方，StringValuePtr() では，末尾に NUL 文字がある保証はなく，
+途中に NUL 文字が含まれている可能性もあります．
 
 それ以外のデータタイプは対応するCの構造体があります．対応す
 る構造体のあるVALUEはそのままキャスト(型変換)すれば構造体の

--- a/doc/extension.rdoc
+++ b/doc/extension.rdoc
@@ -115,11 +115,11 @@ is a String.  Notice that the macros take only the lvalue as their
 argument, to change the value of var in place.
 
 You can also use the macro named StringValueCStr(). This is just
-like StringValuePtr(), but always add nul character at the end of
-the result. If the result contains nul character, this macro causes
+like StringValuePtr(), but always add NUL character at the end of
+the result. If the result contains NUL character, this macro causes
 the ArgumentError exception.
-StringValuePtr() doesn't guarantee the existence of a nul at the end
-of the result, and the result may contain nul.
+StringValuePtr() doesn't guarantee the existence of a NUL at the end
+of the result, and the result may contain NUL.
 
 Other data types have corresponding C structures, e.g. struct RArray
 for T_ARRAY etc. The VALUE of the type which has the corresponding


### PR DESCRIPTION
[![2015-12-27 04 00 22](https://cloud.githubusercontent.com/assets/9990676/12007768/740e288c-ac4e-11e5-9415-7dc01615943c.png)](https://github.com/ruby/ruby/blob/trunk/addr2line.c#LC643)

I found many place use `NUL` instead of `nul` in some annotation, `NUL` is more straightforward