### PR TITLE
Fix ruby-doc comments for String#rstrip, lstrip

### DIFF
--- a/string.c
+++ b/string.c
@@ -7684,7 +7684,7 @@ lstrip_offset(VALUE str, const char *s, const char *e, rb_encoding *enc)
  *
  *  Refer to <code>strip</code> for the definition of whitespace.
  *
- *     "  hello  ".lstrip   #=> "hello  "
+ *     "  hello  ".lstrip!  #=> "hello  "
  *     "hello".lstrip!      #=> nil
  */
 
@@ -7773,7 +7773,7 @@ rstrip_offset(VALUE str, const char *s, const char *e, rb_encoding *enc)
  *
  *  Refer to <code>strip</code> for the definition of whitespace.
  *
- *     "  hello  ".rstrip   #=> "  hello"
+ *     "  hello  ".rstrip!  #=> "  hello"
  *     "hello".rstrip!      #=> nil
  */
 


### PR DESCRIPTION
It looks like dropped bang.