### PR TITLE
Fix syntax for safe navigation operator documentation.

### DIFF
--- a/doc/syntax/calling_methods.rdoc
+++ b/doc/syntax/calling_methods.rdoc
@@ -27,7 +27,7 @@ This sends the +my_method+ message to +my_object+.  Any object can be a
 receiver but depending on the method's visibility sending a message may raise a
 NoMethodError.
 
-You may use <code>.?</code> to designate a receiver, then +my_method+ is not
+You may use <code>&.</code> to designate a receiver, then +my_method+ is not
 invoked and the result is +nil+ when the receiver is +nil+.  In that case, the
 arguments of +my_method+ are not evaluated.
 


### PR DESCRIPTION
The `.?` syntax was changed to `&.` (the lonely operator) for the 2.3.0 final release.