### PR TITLE
Remove Shell.debug_output_exclusive_unlock because Mutex#exclusive_unlock was already deleted.

### DIFF
--- a/lib/shell.rb
+++ b/lib/shell.rb
@@ -168,7 +168,7 @@ class Shell
     end
 
     # os resource mutex
-    mutex_methods = ["unlock", "lock", "locked?", "synchronize", "try_lock", "exclusive_unlock"]
+    mutex_methods = ["unlock", "lock", "locked?", "synchronize", "try_lock"]
     for m in mutex_methods
       def_delegator("@debug_output_mutex", m, "debug_output_"+m.to_s)
     end


### PR DESCRIPTION
Mutex#exclusive_unlock was deleted in 1.9.1