### PR TITLE
Add Enumerator::Lazy#chunk_while like Enumerator::Lazy#slice_when.

### DIFF
--- a/enumerator.c
+++ b/enumerator.c
@@ -2074,6 +2074,7 @@ InitVM_Enumerator(void)
     rb_define_method(rb_cLazy, "slice_before", lazy_super, -1);
     rb_define_method(rb_cLazy, "slice_after", lazy_super, -1);
     rb_define_method(rb_cLazy, "slice_when", lazy_super, -1);
+    rb_define_method(rb_cLazy, "chunk_while", lazy_super, -1);
 
     rb_define_alias(rb_cLazy, "force", "to_a");
 


### PR DESCRIPTION
Enumerator::Lazy#chunk_while does not exist.
