### PR TITLE
URI::Generic#to_s encoding incompatible

### DIFF
--- a/lib/uri/generic.rb
+++ b/lib/uri/generic.rb
@@ -1341,7 +1341,7 @@ module URI
     # Constructs String from URI
     #
     def to_s
-      str = String.new
+      str = ''.dup
       if @scheme
         str << @scheme
         str << ':'

--- a/test/uri/test_generic.rb
+++ b/test/uri/test_generic.rb
@@ -22,6 +22,11 @@ class URI::TestGeneric < Test::Unit::TestCase
     assert_not_predicate str, :frozen?, '[ruby-core:71785] [Bug #11759]'
   end
 
+  def test_encoding
+    encoding = URI::Generic.build(host: 'localhost').to_s.encoding.to_s
+    assert_equal('UTF-8', encoding)
+  end
+
   def test_parse
     # 0
     assert_kind_of(URI::HTTP, @base_url)


### PR DESCRIPTION
Is this intentionally changed?

## Ruby 2.2.4

```ruby
> require 'uri'; URI::Generic.build(host: 'localhost').to_s.encoding.to_s
=> "UTF-8"
```

## Ruby 2.3.0

```ruby
> require 'uri'; URI::Generic.build(host: 'localhost').to_s.encoding.to_s
=> "ASCII-8BIT"
```

This patch is compatible with Ruby 2.2.

Thanks.
