### PR TITLE
fix lhs splat in massign

### DIFF
--- a/test/ruby/test_assignment.rb
+++ b/test/ruby/test_assignment.rb
@@ -758,4 +758,12 @@ class TestAssignmentGen < Test::Unit::TestCase
     o = bug9448.new
     assert_equal("ok", o['current'] = "ok")
   end
+
+  def test_massign_aref_lhs_splat
+    bug11970 = '[ruby-core:72777] [Bug #11970]'
+    h = {}
+    k = [:key]
+    h[*k], = ["ok", "ng"]
+    assert_equal("ok", h[:key], bug11970)
+  end
 end


### PR DESCRIPTION
* compile.c (compile_massign_lhs): move splat flag in massign lhs.

* vm_args.c (vm_caller_setup_arg_splat): splat lhs before rhs for
  aset.  [ruby-core:72777] [Bug #11970]