### PR TITLE
string.c: Symbol#match

### DIFF
--- a/string.c
+++ b/string.c
@@ -9423,7 +9423,6 @@ sym_casecmp(VALUE sym, VALUE other)
 /*
  * call-seq:
  *   sym =~ obj   -> fixnum or nil
- *   sym.match(obj)   -> fixnum or nil
  *
  * Returns <code>sym.to_s =~ obj</code>.
  */
@@ -9432,6 +9431,19 @@ static VALUE
 sym_match(VALUE sym, VALUE other)
 {
     return rb_str_match(rb_sym2str(sym), other);
+}
+
+/*
+ * call-seq:
+ *   sym.match(obj)   -> MatchData or nil
+ *
+ * Returns <code>sym.to_s.match(obj)</code>.
+ */
+
+static VALUE
+sym_match_m(int argc, VALUE *argv, VALUE sym)
+{
+    return rb_str_match_m(argc, argv, rb_sym2str(sym));
 }
 
 /*
@@ -9763,7 +9775,7 @@ Init_String(void)
     rb_define_method(rb_cSymbol, "length", sym_length, 0);
     rb_define_method(rb_cSymbol, "size", sym_length, 0);
     rb_define_method(rb_cSymbol, "empty?", sym_empty, 0);
-    rb_define_method(rb_cSymbol, "match", sym_match, 1);
+    rb_define_method(rb_cSymbol, "match", sym_match_m, -1);
 
     rb_define_method(rb_cSymbol, "upcase", sym_upcase, -1);
     rb_define_method(rb_cSymbol, "downcase", sym_downcase, -1);

--- a/test/ruby/test_symbol.rb
+++ b/test/ruby/test_symbol.rb
@@ -246,6 +246,30 @@ class TestSymbol < Test::Unit::TestCase
     assert_equal(:fOo, :FoO.swapcase)
   end
 
+  def test_MATCH # '=~'
+    assert_equal(10,  :"FeeFieFoo-Fum" =~ /Fum$/)
+    assert_equal(nil, "FeeFieFoo-Fum" =~ /FUM$/)
+
+    o = Object.new
+    def o.=~(x); x + "bar"; end
+    assert_equal("foobar", :"foo" =~ o)
+
+    assert_raise(TypeError) { :"foo" =~ "foo" }
+  end
+
+  def test_match_method
+    assert_equal("bar", :"foobarbaz".match(/bar/).to_s)
+
+    o = Regexp.new('foo')
+    def o.match(x, y, z); x + y + z; end
+    assert_equal("foobarbaz", :"foo".match(o, "bar", "baz"))
+    x = nil
+    :"foo".match(o, "bar", "baz") {|y| x = y }
+    assert_equal("foobarbaz", x)
+
+    assert_raise(ArgumentError) { :"foo".match }
+  end
+
   def test_symbol_poped
     assert_nothing_raised { eval('a = 1; :"#{ a }"; 1') }
   end


### PR DESCRIPTION
- string.c (sym_match_m): delegate to String#match but not
  String#=~.  [ruby-core:72864] [Bug #11991]
