### PR TITLE
Optimise Array#eql?

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+Sat 16 Jan 02:17:29 2016  Dwain Faithfull <dwfaithfull@gmail.com>
+
+	* array.c (recursive_eql): Use pointer arithmetic to iterate array
+	elements, and check for VALUE equality early as optimisations.
+
 Fri Jan 15 20:20:20 2016  Naohisa Goto  <ngotogenome@gmail.com>
 
 	* regint.h (PLATFORM_UNALIGNED_WORD_ACCESS): The value of

--- a/array.c
+++ b/array.c
@@ -3841,12 +3841,22 @@ rb_ary_equal(VALUE ary1, VALUE ary2)
 static VALUE
 recursive_eql(VALUE ary1, VALUE ary2, int recur)
 {
-    long i;
+    long i, len;
+    const VALUE *p1, *p2;
 
     if (recur) return Qtrue; /* Subtle! */
-    for (i=0; i<RARRAY_LEN(ary1); i++) {
-	if (!rb_eql(rb_ary_elt(ary1, i), rb_ary_elt(ary2, i)))
-	    return Qfalse;
+
+    len = RARRAY_LEN(ary1);
+
+    p1 = RARRAY_CONST_PTR(ary1);
+    p2 = RARRAY_CONST_PTR(ary2);
+    for (i=0; i<len; i++) {
+	if (*p1 != *p2) {
+	    if (!rb_eql(*p1, *p2))
+		return Qfalse;
+	}
+	p1++;
+	p2++;
     }
     return Qtrue;
 }


### PR DESCRIPTION
I noticed that for arrays of literals, `.eql?` was about 37 times slower than `==`. After some digging, I noticed that `==` on an array used an exit-early optimisation comparing the elements as `VALUE`s first before dropping into invoking `==` on each element.

Benchmark for array of fixnums (with a build with both old and this new implementation):
https://gist.github.com/dwfait/c1f211c0d9201d087cc3


For arrays of objects, we get a tiny performance increase because of the pointer arithmetic way of element lookup (which is how `==` is implemented), and storing length instead of accessing the array struct for it each iteration. Small enough to possible be standard deviation, but seems to be consistently faster.

Benchmark with objects:
https://gist.github.com/dwfait/780e34f4916dd0aa5aeb

If anyone would like me to provide any other benchmarks, I'd happily provide them as soon as I get time. 

Edit:
Another (quite interesting) benchmark: https://gist.github.com/dwfait/4f4c4517dc0d0701e164

`.eql?` on an array of literals is now quite a bit faster than calling `==`. I know the semantics aren't quite the same, but can be used for the same effect in most use cases.

