### PR TITLE
lib/irb.rb: include trailing newline when >16 backtrace levels

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -525,7 +525,7 @@ module IRB
             print messages.join("\n"), "\n"
             unless lasts.empty?
               printf "... %d levels...\n", levels if levels > 0
-              print lasts.join("\n")
+              print lasts.join("\n"), "\n"
             end
             print "Maybe IRB bug!\n" if irb_bug
           end


### PR DESCRIPTION
Fixes the whole thing where exceptions with more than 16 frames in their backtraces cause the irb prompt to appear on the same line as the last line of the backtrace.