### PR TITLE
array.c: eql? identity check if immediate value

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+Tue 19 Jan 04:20:47 2016  Dwain Faithfull <dwfaithfull@gmail.com>
+
+	* array.c (recursive_eql): compare identity if immediate value
+	* test/ruby/test_array.rb: add test for comparing array of object
+	  with overridden eql? method
+
 Mon Jan 18 14:37:07 2016  Nobuyoshi Nakada  <nobu@ruby-lang.org>
 
 	* parse.y (parser_here_document): an escaped newline is not an

--- a/array.c
+++ b/array.c
@@ -3841,12 +3841,22 @@ rb_ary_equal(VALUE ary1, VALUE ary2)
 static VALUE
 recursive_eql(VALUE ary1, VALUE ary2, int recur)
 {
-    long i;
+    long i, len;
+    const VALUE *p1, *p2;
 
     if (recur) return Qtrue; /* Subtle! */
-    for (i=0; i<RARRAY_LEN(ary1); i++) {
-	if (!rb_eql(rb_ary_elt(ary1, i), rb_ary_elt(ary2, i)))
-	    return Qfalse;
+
+    len = RARRAY_LEN(ary1);
+
+    p1 = RARRAY_CONST_PTR(ary1);
+    p2 = RARRAY_CONST_PTR(ary2);
+    for (i=0; i<len; i++) {
+	if ((!IMMEDIATE_P(*p1)) || (*p1 != *p2)) {
+	    if (!rb_eql(*p1, *p2))
+		return Qfalse;
+	}
+	p1++;
+	p2++;
     }
     return Qtrue;
 }

--- a/test/ruby/test_array.rb
+++ b/test/ruby/test_array.rb
@@ -734,6 +734,14 @@ class TestArray < Test::Unit::TestCase
     assert_not_send([@cls[1.0, 1.0, 2.0, 2.0], :eql?, @cls[1, 1, 2, 2]])
   end
 
+  def test_eql_overridden
+    o = Object.new
+    def o.eql?(o)
+      false
+    end
+    assert_not_send([@cls[o], :eql?, @cls[o]])
+  end
+
   def test_fill
     assert_equal(@cls[],   @cls[].fill(99))
     assert_equal(@cls[],   @cls[].fill(99, 0))


### PR DESCRIPTION
I previously opened this: https://github.com/ruby/ruby/pull/1200

This PR introduces similar performance improvements for 'immediate' (Fixnum, floats, etc..) values, whilst not changing behaviour for `Float::NAN` or objects with redefined `eql?` methods.

_caveat:_ This does change behaviour if you monkey patch the `eql?` method for an immedate value class, but if you're doing that, I imagine Array#eql? is going to be low down on your list of problems.
## Benchmarks

Marked improvement for arrays of immediate values: https://gist.github.com/dwfait/da225dcc4687dcaff2a5

No apparent degradation of performance for arrays of objects / non-immediate values: https://gist.github.com/dwfait/9add4b6442897d68a2cd
## Float::NAN

As mentioned, in this PR treatment of Float::NAN is as before:

```
irb(main):001:0> [Float::NAN].eql? [Float::NAN]
=> false
```

However, I did not create a test for this, because Matz has stated comparison of NaN to NaN is undefined: https://bugs.ruby-lang.org/issues/1720

I have however included a test which I believe addresses the core of that issue - of objects where `eql?` will return false, even to itself.
