### PR TITLE
* lib/rdoc/parser/c.rb (RDoc#handle_attr): parse rb_intern_const correctly.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+Thu Jan 21 15:24:44 2016  Sho Hashimoto  <sho-h@ruby-lang.org>
+
+	* lib/rdoc/parser/c.rb (RDoc#handle_attr): parse rb_intern_const
+	  correctly.
+
 Wed Jan 20 20:58:25 2016  NAKAMURA Usaku  <usa@ruby-lang.org>
 
 	* common.mk, Makefile.in: update-config_files is only for Unix

--- a/lib/rdoc/parser/c.rb
+++ b/lib/rdoc/parser/c.rb
@@ -841,7 +841,7 @@ class RDoc::Parser::C < RDoc::Parser
     comment = find_attr_comment var_name, attr_name
     comment.normalize
 
-    name = attr_name.gsub(/rb_intern\("([^"]+)"\)/, '\1')
+    name = attr_name.gsub(/rb_intern(?:_const)?\("([^"]+)"\)/, '\1')
 
     attr = RDoc::Attr.new '', name, rw, comment
 

--- a/test/rdoc/test_rdoc_parser_c.rb
+++ b/test/rdoc/test_rdoc_parser_c.rb
@@ -176,6 +176,50 @@ void Init_Blah(void) {
     assert_equal 'This is a writer', writer.comment.text
   end
 
+  def test_do_attr_rb_attr_2
+    content = <<-EOF
+void Init_Blah(void) {
+  cBlah = rb_define_class("Blah", rb_cObject);
+
+  /*
+   * This is an accessor
+   */
+  rb_attr(cBlah, rb_intern_const("accessor"), 1, 1, Qfalse);
+
+  /*
+   * This is a reader
+   */
+  rb_attr(cBlah, rb_intern_const("reader"), 1, 0, Qfalse);
+
+  /*
+   * This is a writer
+   */
+  rb_attr(cBlah, rb_intern_const("writer"), 0, 1, Qfalse);
+}
+    EOF
+
+    klass = util_get_class content, 'cBlah'
+
+    attrs = klass.attributes
+    assert_equal 3, attrs.length, attrs.inspect
+
+    accessor = attrs.shift
+    assert_equal 'accessor',            accessor.name
+    assert_equal 'RW',                  accessor.rw
+    assert_equal 'This is an accessor', accessor.comment.text
+    assert_equal @top_level,            accessor.file
+
+    reader = attrs.shift
+    assert_equal 'reader',           reader.name
+    assert_equal 'R',                reader.rw
+    assert_equal 'This is a reader', reader.comment.text
+
+    writer = attrs.shift
+    assert_equal 'writer',           writer.name
+    assert_equal 'W',                writer.rw
+    assert_equal 'This is a writer', writer.comment.text
+  end
+
   def test_do_attr_rb_define_attr
     content = <<-EOF
 void Init_Blah(void) {


### PR DESCRIPTION
LoadError#path's rdoc is parsed as `rb_intern_const("path")`.

* http://docs.ruby-lang.org/en/2.3.0/LoadError.html