### PR TITLE
common.mk: probes.dmyh for nmake

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -854,6 +854,8 @@ $(PRELUDE_C): $(COMPILE_PRELUDE) \
 		$(srcdir)/template/prelude.c.tmpl golf_prelude.rb
 
 {$(VPATH)}probes.dmyh: {$(srcdir)}probes.d $(srcdir)/tool/gen_dummy_probes.rb
+
+probes.dmyh:
 	$(BASERUBY) $(srcdir)/tool/gen_dummy_probes.rb $(srcdir)/probes.d > $@
 
 probes.h: {$(VPATH)}probes.$(DTRACE_EXT)


### PR DESCRIPTION
* common.mk (probes.dmyh): separate the dependency and the
  command, get rid of weird VPATH behavior of nmake.