### PR TITLE
configure.bat: --with-libdir

### DIFF
--- a/win32/Makefile.sub
+++ b/win32/Makefile.sub
@@ -158,8 +158,11 @@ prefix = /usr
 !if !defined(exec_prefix)
 exec_prefix = $(prefix)
 !endif
+!if !defined(libdir_basename)
+libdir_basename = lib
+!endif
 !if !defined(libdir)
-libdir = $(exec_prefix)/lib
+libdir = $(exec_prefix)/$(libdir_basename)
 !endif
 !if !defined(datadir)
 datadir = $(prefix)/share
@@ -813,7 +816,7 @@ s,@datadir@,$${prefix}/share,;t t
 s,@sysconfdir@,$${prefix}/etc,;t t
 s,@sharedstatedir@,/etc,;t t
 s,@localstatedir@,/var,;t t
-s,@libdir@,$${exec_prefix}/lib,;t t
+s,@libdir@,$${exec_prefix}/$(libdir_basename),;t t
 s,@includedir@,$${prefix}/include,;t t
 s,@oldincludedir@,/usr/include,;t t
 s,@infodir@,$${datadir}/info,;t t

--- a/win32/configure.bat
+++ b/win32/configure.bat
@@ -38,6 +38,7 @@ if "%1" == "--extout" goto :extout
 if "%1" == "--path" goto :path
 if "%1" == "--with-baseruby" goto :baseruby
 if "%1" == "--with-ntver" goto :ntver
+if "%1" == "--with-libdir" goto :libdir
 if "%1" == "--without-ext" goto :witharg
 if "%1" == "--without-extensions" goto :witharg
 if "%opt:~0,10%" == "--without-" goto :withoutarg
@@ -156,6 +157,12 @@ goto :loop
 goto :loop
 :baseruby
   echo>> ~tmp~.mak 	"BASERUBY=%~2" \
+  echo>>confargs.tmp  %1=%2 \
+  shift
+  shift
+goto :loop
+:libdir
+  echo>> ~tmp~.mak 	"libdir_basename=%~2" \
   echo>>confargs.tmp  %1=%2 \
   shift
   shift

--- a/win32/setup.mak
+++ b/win32/setup.mak
@@ -44,6 +44,9 @@ ia64-mswin64: -prologue64- -ia64- -epilogue-
 MAKE = nmake
 srcdir = $(srcdir:\=/)
 prefix = $(prefix:\=/)
+!if defined(libdir_basename)
+libdir_basename = $(libdir_basename)
+!endif
 EXTSTATIC = $(EXTSTATIC)
 !if defined(RDOCTARGET)
 RDOCTARGET = $(RDOCTARGET)


### PR DESCRIPTION
* win32/configure.bat: add --with-libdir option for basename of
  libdir.  on Windows it must be placed under exec_prefix always.