### PR TITLE
Show hires Travis badge on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/ruby/ruby.png)](https://travis-ci.org/ruby/ruby)
+[![Build Status](https://travis-ci.org/ruby/ruby.svg)](https://travis-ci.org/ruby/ruby)
 [![Build status](https://ci.appveyor.com/api/projects/status/0sy8rrxut4o0k960/branch/trunk?svg=true)](https://ci.appveyor.com/project/ruby/ruby/branch/trunk)
 
 # What's Ruby


### PR DESCRIPTION
After this commit the README shows Travis' badge in higher resolution (SVG).

See the screenshots below.

## Before

![ruby-badge-lowres](https://cloud.githubusercontent.com/assets/28908/12514731/094fc9ec-c125-11e5-8498-edb53bf1da0d.png)

## After

![ruby-badge-hires](https://cloud.githubusercontent.com/assets/28908/12514732/0a3b53da-c125-11e5-861e-e309e45d6d3b.png)

Note the "build passing".