### PR TITLE
Fix documentation on WEBrick FileHandler

### DIFF
--- a/lib/webrick/httpservlet/filehandler.rb
+++ b/lib/webrick/httpservlet/filehandler.rb
@@ -151,7 +151,8 @@ module WEBrick
     #
     # Example:
     #
-    #   server.mount '/assets', WEBrick::FileHandler, '/path/to/assets'
+    #   server.mount('/assets', WEBrick::HTTPServlet::FileHandler,
+    #                '/path/to/assets')
 
     class FileHandler < AbstractServlet
       HandlerTable = Hash.new # :nodoc:


### PR DESCRIPTION
The example was broken.

Before: `WEBrick::FileHandler`.

After: `WEBrick::HTTPServlet::FileHandler`.