### PR TITLE
signal.c: reserved signals

### DIFF
--- a/signal.c
+++ b/signal.c
@@ -485,6 +485,12 @@ rb_f_kill(int argc, const VALUE *argv)
 #ifdef SIGKILL
 		  case SIGKILL:
 #endif
+#ifdef SIGILL
+		  case SIGILL:
+#endif
+#ifdef SIGFPE
+		  case SIGFPE:
+#endif
 #ifdef SIGSTOP
 		  case SIGSTOP:
 #endif


### PR DESCRIPTION
* signal.c (rb_f_kill): should immediately deliver reserved
  signals SIGILL and SIGFPE, ont only SIGSEGV and SIGBUS.