### PR TITLE
Fix doc with default value to be consistent with code change in GH-523

### DIFF
--- a/lib/tempfile.rb
+++ b/lib/tempfile.rb
@@ -80,7 +80,7 @@ require 'tmpdir'
 # mutex.
 class Tempfile < DelegateClass(File)
   # call-seq:
-  #    new(basename, [tmpdir = Dir.tmpdir], [options])
+  #    new(basename = "", [tmpdir = Dir.tmpdir], [options])
   #
   # Creates a temporary file with permissions 0600 (= only readable and
   # writable by the owner) and opens it with mode "w+".


### PR DESCRIPTION
[GH-523](https://github.com/ruby/ruby/pull/523) added default `basename` parameter, but didn't update the doc. This will fix the doc to be consistent with the code change.