### PR TITLE
Rename drop_while/take_while block parameter to obj

### DIFF
--- a/enum.c
+++ b/enum.c
@@ -2575,7 +2575,7 @@ take_while_i(RB_BLOCK_CALL_FUNC_ARGLIST(i, ary))
 
 /*
  *  call-seq:
- *     enum.take_while { |arr| block } -> array
+ *     enum.take_while { |obj| block } -> array
  *     enum.take_while                 -> an_enumerator
  *
  *  Passes elements to the block until the block returns +nil+ or +false+,
@@ -2659,7 +2659,7 @@ drop_while_i(RB_BLOCK_CALL_FUNC_ARGLIST(i, args))
 
 /*
  *  call-seq:
- *     enum.drop_while { |arr| block }  -> array
+ *     enum.drop_while { |obj| block }  -> array
  *     enum.drop_while                  -> an_enumerator
  *
  *  Drops elements up to, but not including, the first element for


### PR DESCRIPTION
The Enumerable methods drop_while and take_while uses 'arr' as the block parameter name.

```
enum.drop_while { |arr| block } -> array
enum.take_while { |arr| block } -> array
```

This gives the false impression that the block will receive some kind of array as argument, which is false unless the iteration is over an array of arrays or something like that. The simpler alternatives are 'obj', 'elt', or 'item'. I changed it to 'obj' because that's the one with more occurrences in the Enumerable documentation.

Please review, thank you.
