### PR TITLE
erb.rb: improvement about magic comments

### DIFF
--- a/lib/erb.rb
+++ b/lib/erb.rb
@@ -905,10 +905,9 @@ class ERB
   #   erb.def_method(MyClass, 'render(arg1, arg2)', filename)
   #   print MyClass.new.render('foo', 123)
   def def_method(mod, methodname, fname='(ERB)')
-    src = self.src
-    magic_comment = "#coding:#{@encoding}\n"
+    src = self.src.sub(/^(?!#|$)/) {"def #{methodname}\n"} << "\nend\n"
     mod.module_eval do
-      eval(magic_comment + "def #{methodname}\n" + src + "\nend\n", binding, fname, -2)
+      eval(src, binding, fname, -1)
     end
   end
 

--- a/test/erb/test_erb.rb
+++ b/test/erb/test_erb.rb
@@ -530,6 +530,11 @@ EOS
       '# -*- \1; frozen-string-literal: true -*-'
     }
     assert_equal("a", e.result, bug12031)
+
+    %w(false true).each do |flag|
+      erb = @erb.new("<%#frozen-string-literal: #{flag}%><%=''.frozen?%>")
+      assert_equal(flag, erb.result)
+    end
   end
 end
 


### PR DESCRIPTION
* lib/erb.rb (ERB#def_method): insert def line just before the
  first non-comment and non-empty line, not to leave duplicated
  and stale magic comments.