### PR TITLE
net/ftp.rb: add NullSocket#closed? to fix closing not opened connection

### DIFF
--- a/lib/net/ftp.rb
+++ b/lib/net/ftp.rb
@@ -1270,6 +1270,10 @@ module Net
       def read_timeout=(sec)
       end
 
+      def closed?
+        true
+      end
+
       def close
       end
 

--- a/test/net/ftp/test_ftp.rb
+++ b/test/net/ftp/test_ftp.rb
@@ -29,6 +29,11 @@ class FTPTest < Test::Unit::TestCase
     end
   end
 
+  def test_closed_when_not_connected
+    ftp = Net::FTP.new
+    assert_equal(true, ftp.closed?)
+  end
+
   def test_connect_fail
     server = create_ftp_server { |sock|
       sock.print("421 Service not available, closing control connection.\r\n")


### PR DESCRIPTION
Hi there,

An instance of `NullSocket` is stored in a `@sock` variable of a new `Net::FTP`, it also has a `#close` method (that obviously does nothing), but it is never called, because a wrapping `Net::FTP#close` checks that `@sock and not @sock.closed?` which crashes with `FTPConnectionError` because there is no method `#closed?` on `NullSocket`. This PR adds it and a test to verify that it works.

Below is the way to reproduce the error in the IRB. As you can see it's quite confusing, you'd expect `#closed?` not to raise an error, but return `true` instead.

```
>> ftp = Net::FTP.new
=> #<Net::FTP:0x007f90c38075e0 @mon_owner=nil, @mon_count=0, @mon_mutex=#<Thread::Mutex:0x007f90c3807590>, @binary=true, @passive=true, @debug_mode=false, @resume=false, @sock=#<Net::FTP::NullSocket:0x007f90c3807568>, @logged_in=false, @open_timeout=nil, @read_timeout=60>
>> ftp.close
Net::FTPConnectionError: not connected
	from /usr/local/var/rbenv/versions/2.3.0/lib/ruby/2.3.0/net/ftp.rb:1277:in `method_missing'
	from /usr/local/var/rbenv/versions/2.3.0/lib/ruby/2.3.0/net/ftp.rb:1168:in `close'
	from (irb):6
	from /usr/local/var/rbenv/versions/2.3.0/bin/irb:11:in `<main>'
>> ftp.closed?
Net::FTPConnectionError: not connected
	from /usr/local/var/rbenv/versions/2.3.0/lib/ruby/2.3.0/net/ftp.rb:1277:in `method_missing'
	from /usr/local/var/rbenv/versions/2.3.0/lib/ruby/2.3.0/net/ftp.rb:1184:in `closed?'
	from (irb):7
	from /usr/local/var/rbenv/versions/2.3.0/bin/irb:11:in `<main>'
```