### PR TITLE
Fix Ripper.lex error in dedenting squiggly heredoc

### DIFF
--- a/ext/ripper/lib/ripper/lexer.rb
+++ b/ext/ripper/lib/ripper/lexer.rb
@@ -66,7 +66,7 @@ class Ripper
     private
 
     def on_heredoc_dedent(v, w)
-      @buf.each do |e|
+      @buf.last.each do |e|
         if e.event == :on_tstring_content
           if (n = dedent_string(e.tok, w)) > 0
             e.pos[1] += n

--- a/test/ripper/test_scanner_events.rb
+++ b/test/ripper/test_scanner_events.rb
@@ -103,6 +103,12 @@ class TestRipper::ScannerEvents < Test::Unit::TestCase
                   [[5, 0], :on_imaginary, "5.6ri"],
                  ],
                  Ripper.lex("1r\n2i\n3ri\n4.2r\n5.6ri")
+     assert_equal [[[1, 0], :on_heredoc_beg, "<<~EOS"],
+                   [[1, 6], :on_nl, "\n"],
+                   [[2, 2], :on_tstring_content, "heredoc\n"],
+                   [[3, 0], :on_heredoc_end, "EOS"]
+                 ],
+                 Ripper.lex("<<~EOS\n  heredoc\nEOS")
   end
 
   def test_location


### PR DESCRIPTION
Ripper.lex raises error for squiggly heredoc.

reproduce code:

```console
% ruby -v -rripper -e 'Ripper.lex("<<~EOS\n  hi\nEOS")'
ruby 2.3.0p0 (2015-12-25 revision 53290) [x86_64-darwin15]
/usr/local/var/rbenv/versions/2.3.0/lib/ruby/2.3.0/ripper/lexer.rb:70:in `block in on_heredoc_dedent': undefined method `event' for #<Array:0x007fef29875238> (NoMethodError)
	from /usr/local/var/rbenv/versions/2.3.0/lib/ruby/2.3.0/ripper/lexer.rb:69:in `each'
	from /usr/local/var/rbenv/versions/2.3.0/lib/ruby/2.3.0/ripper/lexer.rb:69:in `on_heredoc_dedent'
	from /usr/local/var/rbenv/versions/2.3.0/lib/ruby/2.3.0/ripper/lexer.rb:61:in `parse'
	from /usr/local/var/rbenv/versions/2.3.0/lib/ruby/2.3.0/ripper/lexer.rb:61:in `parse'
	from /usr/local/var/rbenv/versions/2.3.0/lib/ruby/2.3.0/ripper/lexer.rb:55:in `lex'
	from /usr/local/var/rbenv/versions/2.3.0/lib/ruby/2.3.0/ripper/lexer.rb:44:in `lex'
	from -e:1:in `<main>'
```