### PR TITLE
Optimize CGI.escape performance by C ext

### DIFF
--- a/ext/cgi/escape/escape.c
+++ b/ext/cgi/escape/escape.c
@@ -73,6 +73,66 @@ optimized_escape_html(VALUE str)
     }
 }
 
+static int url_unreserved_char(unsigned char c)
+{
+    switch (c) {
+      case '0': case '1': case '2': case '3': case '4': case '5': case '6': case '7': case '8': case '9':
+      case 'a': case 'b': case 'c': case 'd': case 'e': case 'f': case 'g': case 'h': case 'i': case 'j':
+      case 'k': case 'l': case 'm': case 'n': case 'o': case 'p': case 'q': case 'r': case 's': case 't':
+      case 'u': case 'v': case 'w': case 'x': case 'y': case 'z':
+      case 'A': case 'B': case 'C': case 'D': case 'E': case 'F': case 'G': case 'H': case 'I': case 'J':
+      case 'K': case 'L': case 'M': case 'N': case 'O': case 'P': case 'Q': case 'R': case 'S': case 'T':
+      case 'U': case 'V': case 'W': case 'X': case 'Y': case 'Z':
+      case '-': case '.': case '_':
+        return 1;
+      default:
+        break;
+    }
+    return 0;
+}
+
+static VALUE
+optimized_escape(VALUE str)
+{
+  long i, len, modified = 0, beg = 0;
+  VALUE dest;
+  const char *cstr;
+  char *buf;
+
+  buf = malloc(sizeof(unsigned char) * 4);
+  len  = RSTRING_LEN(str);
+  cstr = RSTRING_PTR(str);
+
+  for (i = 0; i < len; i++) {
+    if (!url_unreserved_char(cstr[i])) {
+      if (!modified) {
+        modified = 1;
+        dest = rb_str_buf_new(len);
+      }
+
+      rb_str_cat(dest, cstr + beg, i - beg);
+      beg = i + 1;
+
+      if (cstr[i] == ' ') {
+        rb_str_cat_cstr(dest, "+");
+      } else {
+        sprintf(buf, "%%%02X", (unsigned char)cstr[i]);
+        rb_str_cat_cstr(dest, buf);
+      }
+    }
+  }
+  free(buf);
+
+  if (modified) {
+    rb_str_cat(dest, cstr + beg, len - beg);
+    preserve_original_state(str, dest);
+    return dest;
+  }
+  else {
+    return rb_str_dup(str);
+  }
+}
+
 /*
  *  call-seq:
  *     CGI.escapeHTML(string) -> string
@@ -93,6 +153,26 @@ cgiesc_escape_html(VALUE self, VALUE str)
     }
 }
 
+/*
+ *  call-seq:
+ *     CGI.escape(string) -> string
+ *
+ *  Returns URL-escaped string.
+ *
+ */
+static VALUE
+cgiesc_escape(VALUE self, VALUE str)
+{
+    StringValue(str);
+
+    if (rb_enc_str_asciicompat_p(str)) {
+	return optimized_escape(str);
+    }
+    else {
+	return rb_call_super(1, &str);
+    }
+}
+
 void
 Init_escape(void)
 {
@@ -100,6 +180,7 @@ Init_escape(void)
     rb_mEscape = rb_define_module_under(rb_cCGI, "Escape");
     rb_mUtil   = rb_define_module_under(rb_cCGI, "Util");
     rb_define_method(rb_mEscape, "escapeHTML", cgiesc_escape_html, 1);
+    rb_define_method(rb_mEscape, "escape", cgiesc_escape, 1);
     rb_prepend_module(rb_mUtil, rb_mEscape);
     rb_extend_object(rb_cCGI, rb_mEscape);
 }


### PR DESCRIPTION
This patch makes `CGI.escape` 7x - 8x faster than current.

`CGI.escape` is used by url helper of Rails.
If `CGI.escape` becomes faster, HTML rendering of Rails applications becomes faster.

## Benchmark
###before
CGI.escape
```
irb(main):001:0> Benchmark.ips do |x|
irb(main):002:1*     x.config(time: 15, warmup: 5)
irb(main):003:1>   x.report("cgi_escape")  { CGI.escape("'Stop!' said~Fred") }
irb(main):004:1>   end
Calculating -------------------------------------
          cgi_escape     8.791k i/100ms
-------------------------------------------------
          cgi_escape     96.828k (± 4.4%) i/s -      1.451M
```

Rails url helper
```
irb(main):005:0> Benchmark.ips do |x|
irb(main):006:1*     x.config(time: 15, warmup: 5)
irb(main):007:1>   x.report("url_for")  { app.users_path(foo: "bar", page: 1, per_page: 20, tags: ["hoge", "fuga"]) }
irb(main):008:1>   end
Calculating -------------------------------------
             url_for     1.163k i/100ms
-------------------------------------------------
             url_for     11.879k (± 9.4%) i/s -    176.776k
```

###after
CGI.escape
```
irb(main):004:0> Benchmark.ips do |x|
irb(main):005:1*     x.config(time: 15, warmup: 5)
irb(main):006:1>   x.report("cgi_escape")  { CGI.escape("'Stop!' said~Fred") }
irb(main):007:1>   end
Calculating -------------------------------------
          cgi_escape    40.977k i/100ms
-------------------------------------------------
          cgi_escape    661.480k (± 5.9%) i/s -      9.916M
```

Rails url helper
```
irb(main):008:0> Benchmark.ips do |x|
irb(main):009:1*     x.config(time: 15, warmup: 5)
irb(main):010:1>   x.report("url_for")  { app.users_path(foo: "bar", page: 1, per_page: 20, tags: ["hoge", "fuga"]) }
irb(main):011:1>   end
Calculating -------------------------------------
             url_for     1.586k i/100ms
-------------------------------------------------
             url_for     16.786k (± 5.8%) i/s -    252.174k
```