### PR TITLE
Remove block from Logger.add as it's not needed

### DIFF
--- a/lib/logger.rb
+++ b/lib/logger.rb
@@ -365,7 +365,7 @@ class Logger
   # * Append open does not need to lock file.
   # * If the OS supports multi I/O, records possibly may be mixed.
   #
-  def add(severity, message = nil, progname = nil, &block)
+  def add(severity, message = nil, progname = nil)
     severity ||= UNKNOWN
     if @logdev.nil? or severity < @level
       return true


### PR DESCRIPTION
As per [#12054](https://bugs.ruby-lang.org/issues/12054)

Logger add (lib/logger.rb) takes as arguments severity, message, progname and &block

The method runs the block through yield. In this case, we can just omit the argument and we'd be saving the instantiation of a new proc object (see http://mudge.name/2011/01/26/passing-blocks-in-ruby-without-block.html)