### PR TITLE
Removed references to NQXML in xmlrpc

### DIFF
--- a/lib/xmlrpc.rb
+++ b/lib/xmlrpc.rb
@@ -53,10 +53,6 @@
 #   * HTTPS protocol (SSL)
 #
 # * Parsers
-#   * NQXML (XMLParser::NQXMLStreamParser, XMLParser::NQXMLTreeParser)
-#     * Not compiled (pure ruby)
-#     * Note: NQXML's website recommends rexml and isn't available on rubygems.org
-#     * See http://nqxml.sourceforge.net/
 #   * Expat (XMLParser::XMLStreamParser, XMLParser::XMLTreeParser)
 #     * Compiled
 #     * Fastest parser and also uses the least memory
@@ -70,7 +66,7 @@
 #   * Fastest parser is Expat's XMLParser::XMLStreamParser!
 #
 # * General
-#   * possible to choose between XMLParser module (Expat wrapper) and REXML/NQXML (pure Ruby) parsers
+#   * possible to choose between XMLParser module (Expat wrapper) and REXML (pure Ruby) parsers
 #   * Marshalling Ruby objects to Hashes and reconstruct them later from a Hash
 #   * SandStorm component architecture XMLRPC::Client interface
 #
@@ -295,18 +291,11 @@
 #   s.set_parser(XMLRPC::XMLParser::XMLStreamParser.new)
 #   # ...
 #
-# or:
-#
-#   # ...
-#   server = XMLRPC::Server.new(8080)
-#   server.set_parser(XMLRPC::XMLParser::NQXMLParser.new)
-#   # ...
-#
 #
 # Note XMLParser::XMLStreamParser (xmlparser gem) is faster and uses less memory than any
 # other parser and scales well for large documents. For example for a 0.5 MB XML
-# document with many tags, XMLParser::XMLStreamParser is ~350 (!) times faster than
-# XMLParser::NQXMLTreeParser and still ~18 times as fast as XMLParser::XMLTreeParser.
+# document with many tags, XMLParser::XMLStreamParser is ~18 times as fast as
+# XMLParser::XMLTreeParser.
 #
 # You can change the XML-writer by calling method ParserWriterChooseMixin#set_writer.
 module XMLRPC; end

--- a/lib/xmlrpc/config.rb
+++ b/lib/xmlrpc/config.rb
@@ -13,8 +13,6 @@ module XMLRPC # :nodoc:
 
     # === Available parsers
     #
-    # * XMLParser::NQXMLTreeParser
-    # * XMLParser::NQXMLStreamParser
     # * XMLParser::XMLTreeParser
     # * XMLParser::XMLStreamParser (fastest)
     # * XMLParser::REXMLStreamParser

--- a/lib/xmlrpc/parser.rb
+++ b/lib/xmlrpc/parser.rb
@@ -10,42 +10,6 @@ require "xmlrpc/base64"
 require "xmlrpc/datetime"
 
 
-module NQXML
-  class Node
-
-    def removeChild(node)
-      @children.delete(node)
-    end
-    def childNodes
-      @children
-    end
-    def hasChildNodes
-      not @children.empty?
-    end
-    def [] (index)
-      @children[index]
-    end
-
-    def nodeType
-      if @entity.instance_of? NQXML::Text then :TEXT
-      elsif @entity.instance_of? NQXML::Comment then :COMMENT
-      #elsif @entity.instance_of? NQXML::Element then :ELEMENT
-      elsif @entity.instance_of? NQXML::Tag then :ELEMENT
-      else :ELSE
-      end
-    end
-
-    def nodeValue
-      #TODO: error when wrong Entity-type
-      @entity.text
-    end
-    def nodeName
-      #TODO: error when wrong Entity-type
-      @entity.name
-    end
-  end # class Node
-end # module NQXML
-
 module XMLRPC # :nodoc:
 
   # Raised when the remote procedure returns a fault-structure, which has two
@@ -612,35 +576,6 @@ module XMLRPC # :nodoc:
       end
     end # class XMLStreamParser
 
-    class NQXMLStreamParser < AbstractStreamParser
-      def initialize
-        require "nqxml/streamingparser"
-        @parser_class = XMLRPCParser
-      end
-
-      class XMLRPCParser
-        include StreamParserMixin
-
-        def parse(str)
-          parser = NQXML::StreamingParser.new(str)
-          parser.each do |ele|
-            case ele
-            when NQXML::Text
-              @data = ele.text
-              #character(ele.text)
-            when NQXML::Tag
-              if ele.isTagEnd
-                endElement(ele.name)
-              else
-                startElement(ele.name, ele.attrs)
-              end
-            end
-          end # do
-        end # method parse
-      end # class XMLRPCParser
-
-    end # class NQXMLStreamParser
-
     class XMLTreeParser < AbstractTreeParser
 
       def initialize
@@ -692,34 +627,6 @@ module XMLRPC # :nodoc:
       end
 
     end # class XMLParser
-
-    class NQXMLTreeParser < AbstractTreeParser
-
-      def initialize
-        require "nqxml/treeparser"
-      end
-
-      private
-
-      def _nodeType(node)
-        node.nodeType
-      end
-
-      def methodResponse_document(node)
-        methodResponse(node)
-      end
-
-      def methodCall_document(node)
-        methodCall(node)
-      end
-
-      def createCleanedTree(str)
-        doc = ::NQXML::TreeParser.new(str).document.rootNode
-        removeWhitespacesAndComments(doc)
-        doc
-      end
-
-    end # class NQXMLTreeParser
 
     class REXMLStreamParser < AbstractStreamParser
       def initialize
@@ -847,10 +754,8 @@ module XMLRPC # :nodoc:
     end
 
     XMLParser   = XMLTreeParser
-    NQXMLParser = NQXMLTreeParser
 
     Classes = [XMLStreamParser, XMLTreeParser,
-               NQXMLStreamParser, NQXMLTreeParser,
                REXMLStreamParser, XMLScanStreamParser,
                LibXMLStreamParser]
 


### PR DESCRIPTION
There is no gem for this library, the sourceforge page shows this library hasn't been updated for almost 12 years, and the official page has the following line on the main page: "Ruby 1.8 now ships with REXML, an excellent XML parser for Ruby by Sean Russell. It includes XPath support. You should probably use that instead of NQXML."

Also see https://bugs.ruby-lang.org/issues/9371