### PR TITLE
object.c: Fix misuse of counter variable.

### DIFF
--- a/object.c
+++ b/object.c
@@ -2538,7 +2538,7 @@ static VALUE
 convert_type(VALUE val, const char *tname, const char *method, int raise)
 {
     ID m = 0;
-    int i = numberof(conv_method_names);
+    int i;
     VALUE r;
     static const char prefix[] = "to_";
 
@@ -2556,7 +2556,7 @@ convert_type(VALUE val, const char *tname, const char *method, int raise)
     r = rb_check_funcall(val, m, 0, 0);
     if (r == Qundef) {
 	if (raise) {
-	    const char *msg = i < IMPLICIT_CONVERSIONS ?
+	    const char *msg = numberof(conv_method_names) < IMPLICIT_CONVERSIONS ?
 		"no implicit conversion of" : "can't convert";
 	    const char *cname = NIL_P(val) ? "nil" :
 		val == Qtrue ? "true" :


### PR DESCRIPTION
The variable used as a counter in the loop was being initialized with the result of `numberof(conv_method_names)` just to be referenced once on line 2259, so I replaced the use of `i` on that line with a direct call to the function.