### PR TITLE
proc.c: Binding svar

### DIFF
--- a/test/ruby/test_method.rb
+++ b/test/ruby/test_method.rb
@@ -918,6 +918,10 @@ class TestMethod < Test::Unit::TestCase
     assert_equal(456, b.local_variable_set(:bar, 456))
     assert_equal(123, b.local_variable_get(:foo))
     assert_equal(456, b.local_variable_get(:bar))
+    assert_equal("lastline", b.local_variable_set(:$_, "lastline"))
+    assert_equal("backref", b.local_variable_set(:$~, "backref"))
+    assert_equal("lastline", b.local_variable_get(:$_))
+    assert_equal("backref", b.local_variable_get(:$~))
     assert_equal([:bar, :foo], b.local_variables.sort)
   end
 

--- a/test/ruby/test_proc.rb
+++ b/test/ruby/test_proc.rb
@@ -213,6 +213,10 @@ class TestProc < Test::Unit::TestCase
     assert_equal 42, b.local_variable_set(:value, 42)
     assert_send [b, :local_variable_defined?, :value]
     assert_equal 42, b.local_variable_get(:value)
+    assert_equal("lastline", b.local_variable_set(:$_, "lastline"))
+    assert_equal("backref", b.local_variable_set(:$~, "backref"))
+    assert_equal("lastline", b.local_variable_get(:$_))
+    assert_equal("backref", b.local_variable_get(:$~))
   end
 
   def test_block_given_method
@@ -1300,16 +1304,24 @@ class TestProc < Test::Unit::TestCase
     b = get_binding
     b.local_variable_set(:a, 10)
     b.local_variable_set(:b, 20)
+    b.local_variable_set(:$_, "lastline")
+    b.local_variable_set(:$~, "backref")
     assert_equal(10, b.local_variable_get(:a))
     assert_equal(20, b.local_variable_get(:b))
+    assert_equal("lastline", b.local_variable_get(:$_))
+    assert_equal("backref", b.local_variable_get(:$~))
     assert_equal(10, b.eval("a"))
     assert_equal(20, b.eval("b"))
+    assert_equal("lastline", b.eval("$_"))
+    assert_equal("backref", b.eval("$~"))
   end
 
   def test_local_variable_defined?
     b = get_binding
     assert_equal(true, b.local_variable_defined?(:a))
     assert_equal(false, b.local_variable_defined?(:b))
+    assert_equal(true, b.local_variable_defined?(:$_))
+    assert_equal(true, b.local_variable_defined?(:$~))
   end
 
   def test_binding_receiver

--- a/vm.c
+++ b/vm.c
@@ -1134,6 +1134,18 @@ rb_lastline_set(VALUE val)
     vm_svar_set(VM_SVAR_LASTLINE, val);
 }
 
+VALUE
+rb_vm_env_svar_get(const rb_env_t *env, VALUE key)
+{
+    return lep_svar_get(NULL, VM_EP_LEP(env->block.ep), key);
+}
+
+void
+rb_vm_env_svar_set(const rb_env_t *env, VALUE key, VALUE val)
+{
+    lep_svar_set(NULL, VM_EP_LEP(env->block.ep), key, val);
+}
+
 /* misc */
 
 VALUE

--- a/vm_core.h
+++ b/vm_core.h
@@ -1025,6 +1025,8 @@ VALUE rb_vm_make_proc(rb_thread_t *th, const rb_block_t *block, VALUE klass);
 VALUE rb_vm_make_binding(rb_thread_t *th, const rb_control_frame_t *src_cfp);
 VALUE rb_vm_env_local_variables(const rb_env_t *env);
 VALUE rb_vm_env_prev_envval(const rb_env_t *env);
+VALUE rb_vm_env_svar_get(const rb_env_t *env, VALUE key);
+void rb_vm_env_svar_set(const rb_env_t *env, VALUE key, VALUE val);
 VALUE rb_vm_proc_envval(const rb_proc_t *proc);
 VALUE *rb_binding_add_dynavars(rb_binding_t *bind, int dyncount, const ID *dynvars);
 void rb_vm_inc_const_missing_count(void);


### PR DESCRIPTION
- proc.c (bind_local_variable_get, bind_local_variable_set): deal
  with special method-local variables, `$_` and `$~`.
  [Feature #12083]
