### PR TITLE
Add verbose failure messages and avoid infamous DRb::DRbConnError

### DIFF
--- a/lib/drb/drb.rb
+++ b/lib/drb/drb.rb
@@ -1661,7 +1661,14 @@ module DRb
                 puts x
               end
             end
-            client.send_reply(succ, result) rescue nil
+            begin
+              client.send_reply(succ, result)
+            rescue Exception => e
+              puts e
+              nil
+            end
+          rescue Exception => e
+            puts e
           ensure
             client.close unless succ
             if Thread.current['DRb']['stop_service']


### PR DESCRIPTION
Avoid the generic "DRb::DRbConnError" which gives very little information and make errors hard to debug.

When I stared using DRuby, I kept getting a strange and cryptic error message `DRb::DRbConnError 'connection closed'`. Turns out it was due to some silly mistake on the server side of the relationship. It took hours to figure out. The only way I was able to do it was to patch ruby drb after closely studying the source.

Others have had the same issues:

http://stackoverflow.com/questions/27293817/ruby-connection-closed-drbdrbconnerror
https://www.ruby-forum.com/topic/193984
https://github.com/Mon-Ouie/pry-remote/issues/8

Here is an example where this makes a difference: 

```ruby
# drb_server.rb
require 'drb'

class FrontObject
  def foo
    # generates Runtime Exception of Insecure Operation
    result = `ls -l`
  end
end

DRb.start_service("druby://localhost:8787", FrontObject.new, safe_level: 3)
DRb.thread.join
```

``` ruby
# drb_client.rb
require 'drb'

object = DRbObject.new_with_uri("druby://localhost:8787")
puts object.foo
```

Output before patch is applied:

```
$ ruby drb_server.rb
```

```
$ ruby drb_client.rb
/Users/mike/.rbenv/versions/2.2.3/lib/ruby/2.2.0/drb/drb.rb:578:in `load': connection closed (DRb::DRbConnError)
```

Output after patch is applied:

```
$ ruby drb_server.rb
Insecure operation ``' at level 3
```

```
$ ruby drb_client.rb
/Users/mike/.rbenv/versions/2.2.3/lib/ruby/2.2.0/drb/drb.rb:578:in `load': connection closed (DRb::DRbConnError)
```