### PR TITLE
Allow using Procs for single argument CSV converters

### DIFF
--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -2217,7 +2217,7 @@ class CSV
     fields.map.with_index do |field, index|
       converters.each do |converter|
         break if field.nil?
-        field = if converter.arity == 1  # straight field converter
+        field = if converter.arity.abs == 1  # straight field converter
           converter[field]
         else                             # FieldInfo converter
           header = @use_headers && !headers ? @headers[index] : nil

--- a/test/csv/test_data_converters.rb
+++ b/test/csv/test_data_converters.rb
@@ -161,6 +161,14 @@ class TestCSV::DataConverters < TestCSV
     assert_equal(["Numbers", ":integer", "1", ":float", 3], @parser.shift)
   end
 
+  def test_convert_with_custom_proc_one_arg
+    # define custom converter as a proc accepting one argument
+    assert_nothing_raised(Exception) { @parser.convert(&:upcase) }
+
+    # and use
+    assert_equal(["NUMBERS", ":INTEGER", "1", ":FLOAT", "3.015"], @parser.shift)
+  end
+
   def test_convert_with_custom_code_using_field_info_header
     @parser = CSV.new(@data, headers: %w{one two three four five})
 


### PR DESCRIPTION
Fixes [bug 12100](https://bugs.ruby-lang.org/issues/12100)

CSV#parse (and others) throw an ArgumentError when passing a single argument Proc as a converter because of a performance optimization check that assumes Proc#arity is always positive. Lambdas with one argument work fine as do Procs and lambdas with two arguments. The documentation suggests to me that either should work. Supporting the Proc variant is trivial and allows to_proc and to_proc shortcut syntax to be used eliminating the surprising behavior and uninformative error message. Illustration of the problem is below and a patch with tests is attached.

EDIT: It looks like this might actually stem from Symbol#to_proc returning a Proc with unspecified number of arguments, but I think the fix is still valid.

```ruby
require 'csv'
puts CSV.parse("  foo  ,  bar  ", converters: -> f { f.strip }).inspect
puts CSV.parse("  foo  ,  bar  ", converters: :strip.to_proc).inspect

# Without patch this outputs:
# [["foo", "bar"]]
# /home/mdaubert/.rbenv/versions/2.3.0/lib/ruby/2.3.0/csv.rb:2205:in `strip': wrong number of arguments (given 1, expected 0) (ArgumentError)

# With patch this outputs:
# [["foo", "bar"]]
# [["foo", "bar"]]
```