### PR TITLE
coverage w/o thread context 

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -5953,8 +5953,13 @@ iseq_compile_each(rb_iseq_t *iseq, LINK_ANCHOR *ret, NODE * node, int poped)
 	const rb_compile_option_t *orig_opt = ISEQ_COMPILE_DATA(iseq)->option;
 	if (node->nd_orig) {
 	    rb_compile_option_t new_opt = *orig_opt;
+	    VALUE coverage = rb_hash_lookup(node->nd_orig, rb_intern("coverage"));
 	    rb_iseq_make_compile_option(&new_opt, node->nd_orig);
 	    ISEQ_COMPILE_DATA(iseq)->option = &new_opt;
+	    if (RB_TYPE_P(coverage, T_ARRAY) && !RBASIC_CLASS(coverage)) {
+		new_opt.coverage = coverage;
+		ISEQ_COVERAGE_SET(iseq, coverage);
+	    }
 	}
 	COMPILE_POPED(ret, "prelude", node->nd_head);
 	COMPILE_(ret, "body", node->nd_body, poped);

--- a/iseq.c
+++ b/iseq.c
@@ -296,15 +296,7 @@ prepare_iseq_build(rb_iseq_t *iseq,
     ISEQ_COMPILE_DATA(iseq)->option = option;
     ISEQ_COMPILE_DATA(iseq)->last_coverable_line = -1;
 
-    ISEQ_COVERAGE_SET(iseq, Qfalse);
-
-    if (!GET_THREAD()->parse_in_eval) {
-	VALUE coverages = rb_get_coverages();
-	if (RTEST(coverages)) {
-	    ISEQ_COVERAGE_SET(iseq, rb_hash_lookup(coverages, path));
-	    if (NIL_P(ISEQ_COVERAGE(iseq))) ISEQ_COVERAGE_SET(iseq, Qfalse);
-	}
-    }
+    ISEQ_COVERAGE_SET(iseq, option->coverage);
 
     return Qtrue;
 }

--- a/iseq.h
+++ b/iseq.h
@@ -135,6 +135,7 @@ struct rb_compile_option_struct {
     int frozen_string_literal;
     int debug_frozen_string_literal;
     int debug_level;
+    VALUE coverage;
 };
 
 struct iseq_line_info_entry {

--- a/parse.y
+++ b/parse.y
@@ -5516,6 +5516,7 @@ yycompile0(VALUE arg)
     int n;
     NODE *tree;
     struct parser_params *parser = (struct parser_params *)arg;
+    VALUE cov;
 
     if (!compile_for_eval && rb_safe_level() == 0) {
 	ruby_debug_lines = debug_lines(ruby_sourcefile_string);
@@ -5544,6 +5545,7 @@ yycompile0(VALUE arg)
 #ifndef RIPPER
     RUBY_DTRACE_PARSE_HOOK(END);
 #endif
+    cov = ruby_coverage;
     ruby_debug_lines = 0;
     ruby_coverage = 0;
     compile_for_eval = 0;
@@ -5559,7 +5561,12 @@ yycompile0(VALUE arg)
 	tree = NEW_NIL();
     }
     else {
-	tree->nd_body = NEW_PRELUDE(ruby_eval_tree_begin, tree->nd_body, parser->compile_option);
+	VALUE opt = parser->compile_option;
+	if (cov) {
+	    if (!opt) opt = rb_obj_hide(rb_ident_hash_new());
+	    rb_hash_aset(opt, rb_intern("coverage"), cov);
+	}
+	tree->nd_body = NEW_PRELUDE(ruby_eval_tree_begin, tree->nd_body, opt);
     }
     return (VALUE)tree;
 }

--- a/thread.c
+++ b/thread.c
@@ -4774,7 +4774,7 @@ static void
 update_coverage(rb_event_flag_t event, VALUE proc, VALUE self, ID id, VALUE klass)
 {
     VALUE coverage = rb_iseq_coverage(GET_THREAD()->cfp->iseq);
-    if (coverage && RBASIC(coverage)->klass == 0) {
+    if (RB_TYPE_P(coverage, T_ARRAY) && !RBASIC_CLASS(coverage)) {
 	long line = rb_sourceline() - 1;
 	long count;
 	if (RARRAY_AREF(coverage, line) == Qnil) {


### PR DESCRIPTION
- compile.c (iseq_compile_each), parse.y (yycompile0): pass
  coverage array via the option hash, without thread context.
