### PR TITLE
IPAddr has no public method to get the current subnet mask

### DIFF
--- a/lib/ipaddr.rb
+++ b/lib/ipaddr.rb
@@ -352,6 +352,11 @@ class IPAddr
     return ([@addr, @mask_addr].hash << 1) | (ipv4? ? 0 : 1)
   end
 
+  # Returns the network mask of the ipaddr
+  def mask_addr
+    return _to_string(@mask_addr)
+  end
+
   # Creates a Range object for the network address.
   def to_range
     begin_addr = (@addr & @mask_addr)

--- a/lib/ipaddr.rb
+++ b/lib/ipaddr.rb
@@ -194,10 +194,18 @@ class IPAddr
     return self.clone.set(addr_mask(~@addr))
   end
 
-  # Returns true if two ipaddrs are equal.
+  # Returns true if two ipaddrs are equal. Does not include the
+  # mask_addr in the check.
   def ==(other)
     other = coerce_other(other)
     return @family == other.family && @addr == other.to_i
+  end
+
+  # Returns true if two ipaddrs are equal, including their
+  # mask_addrs
+  def equal_with_mask(other)
+    other = coerce_other(other)
+    return self == other && self.mask_addr == other.mask_addr
   end
 
   # Returns a new ipaddr built by masking IP address with the given

--- a/lib/ipaddr.rb
+++ b/lib/ipaddr.rb
@@ -407,9 +407,9 @@ class IPAddr
     return ([@addr, @mask_addr].hash << 1) | (ipv4? ? 0 : 1)
   end
 
-  # Returns the network mask of the ipaddr
+  # Returns the network mask of the IPAddr as an IPAddr::Netmask object
   def mask_addr
-    return _to_string(@mask_addr)
+    return Netmask.new(@mask_addr, @family)
   end
 
   # Creates a Range object for the network address.
@@ -440,7 +440,7 @@ class IPAddr
       raise AddressFamilyError, "unsupported address family"
     end
     return sprintf("#<%s: %s:%s/%s>", self.class.name,
-                   af, _to_string(@addr), _to_string(@mask_addr))
+                   af, _to_string(@addr), self.mask_addr.to_s)
   end
 
   protected

--- a/lib/ipaddr.rb
+++ b/lib/ipaddr.rb
@@ -107,11 +107,11 @@ class IPAddr
       case family
       when Socket::AF_INET
         if netmask < 0 or netmask > IN4MASK
-          raise InvalidPrefixError, "Invalid prefix length"
+          raise InvalidPrefixError, "invalid prefix length"
         end
       when Socket::AF_INET6
         if netmask < 0 or netmask > IN6MASK
-          raise InvalidPrefixError, "Invalid prefix length"
+          raise InvalidPrefixError, "invalid prefix length"
         end
       else
         raise AddressFamilyError, "unsupported address family: #{family}"
@@ -203,7 +203,7 @@ class IPAddr
 
   # Returns true if two ipaddrs are equal, including their
   # mask_addrs
-  def equal_with_mask(other)
+  def equal_with_mask?(other)
     other = coerce_other(other)
     return self == other && self.mask_addr == other.mask_addr
   end

--- a/test/test_ipaddr.rb
+++ b/test/test_ipaddr.rb
@@ -20,6 +20,7 @@ class TC_IPAddr < Test::Unit::TestCase
     a = IPAddr.new
     assert_equal("::", a.to_s)
     assert_equal("0000:0000:0000:0000:0000:0000:0000:0000", a.to_string)
+    assert_equal("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", a.mask_addr)
     assert_equal(Socket::AF_INET6, a.family)
 
     a = IPAddr.new("0123:4567:89ab:cdef:0ABC:DEF0:1234:5678")
@@ -34,6 +35,7 @@ class TC_IPAddr < Test::Unit::TestCase
     assert_equal(false, a.ipv4?)
     assert_equal(true, a.ipv6?)
     assert_equal("#<IPAddr: IPv6:3ffe:0505:0002:0000:0000:0000:0000:0000/ffff:ffff:ffff:0000:0000:0000:0000:0000>", a.inspect)
+    assert_equal("ffff:ffff:ffff:0000:0000:0000:0000:0000", a.mask_addr)
 
     a = IPAddr.new("3ffe:505:2::/ffff:ffff:ffff::")
     assert_equal("3ffe:505:2::", a.to_s)
@@ -43,6 +45,7 @@ class TC_IPAddr < Test::Unit::TestCase
     a = IPAddr.new("0.0.0.0")
     assert_equal("0.0.0.0", a.to_s)
     assert_equal("0.0.0.0", a.to_string)
+    assert_equal("255.255.255.255", a.mask_addr)
     assert_equal(Socket::AF_INET, a.family)
 
     a = IPAddr.new("192.168.1.2")
@@ -55,6 +58,7 @@ class TC_IPAddr < Test::Unit::TestCase
     a = IPAddr.new("192.168.1.2/24")
     assert_equal("192.168.1.0", a.to_s)
     assert_equal("192.168.1.0", a.to_string)
+    assert_equal("255.255.255.0", a.mask_addr)
     assert_equal(Socket::AF_INET, a.family)
     assert_equal("#<IPAddr: IPv4:192.168.1.0/255.255.255.0>", a.inspect)
 

--- a/test/test_ipaddr.rb
+++ b/test/test_ipaddr.rb
@@ -78,7 +78,7 @@ class TC_IPAddr < Test::Unit::TestCase
     a = IPAddr.new
     assert_equal("::", a.to_s)
     assert_equal("0000:0000:0000:0000:0000:0000:0000:0000", a.to_string)
-    assert_equal("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", a.mask_addr)
+    assert_equal(IPAddr::Netmask.new(IPAddr::IN6MASK, a.family), a.mask_addr)
     assert_equal(Socket::AF_INET6, a.family)
 
     a = IPAddr.new("0123:4567:89ab:cdef:0ABC:DEF0:1234:5678")
@@ -93,7 +93,7 @@ class TC_IPAddr < Test::Unit::TestCase
     assert_equal(false, a.ipv4?)
     assert_equal(true, a.ipv6?)
     assert_equal("#<IPAddr: IPv6:3ffe:0505:0002:0000:0000:0000:0000:0000/ffff:ffff:ffff:0000:0000:0000:0000:0000>", a.inspect)
-    assert_equal("ffff:ffff:ffff:0000:0000:0000:0000:0000", a.mask_addr)
+    assert_equal(IPAddr::Netmask.new(((1<<48)-1) << 80, a.family), a.mask_addr)
 
     a = IPAddr.new("3ffe:505:2::/ffff:ffff:ffff::")
     assert_equal("3ffe:505:2::", a.to_s)
@@ -103,7 +103,7 @@ class TC_IPAddr < Test::Unit::TestCase
     a = IPAddr.new("0.0.0.0")
     assert_equal("0.0.0.0", a.to_s)
     assert_equal("0.0.0.0", a.to_string)
-    assert_equal("255.255.255.255", a.mask_addr)
+    assert_equal(IPAddr::Netmask.new(IPAddr::IN4MASK, a.family), a.mask_addr)
     assert_equal(Socket::AF_INET, a.family)
 
     a = IPAddr.new("192.168.1.2")
@@ -116,7 +116,7 @@ class TC_IPAddr < Test::Unit::TestCase
     a = IPAddr.new("192.168.1.2/24")
     assert_equal("192.168.1.0", a.to_s)
     assert_equal("192.168.1.0", a.to_string)
-    assert_equal("255.255.255.0", a.mask_addr)
+    assert_equal(IPAddr::Netmask.new(0xffffff00, a.family), a.mask_addr)
     assert_equal(Socket::AF_INET, a.family)
     assert_equal("#<IPAddr: IPv4:192.168.1.0/255.255.255.0>", a.inspect)
 

--- a/test/test_ipaddr.rb
+++ b/test/test_ipaddr.rb
@@ -284,6 +284,16 @@ class TC_Operator < Test::Unit::TestCase
     assert_equal(false, @a != IPAddr.new("3ffe:505:2::"))
   end
 
+  def test_equal_with_mask
+    assert_equal(true, @a.equal_with_mask(IPAddr.new("3FFE:505:2::/48")))
+    assert_equal(true, @a.equal_with_mask(IPAddr.new("3ffe:0505:0002::/48")))
+    assert_equal(true, @a.equal_with_mask(IPAddr.new("3ffe:0505:0002:0:0:0:0:0/48")))
+    assert_equal(false, @a.equal_with_mask(IPAddr.new("3ffe:505:3::/48")))
+    assert_equal(false, @a.equal_with_mask(IPAddr.new("3ffe:505:3::/48")))
+    assert_equal(true, @a.equal_with_mask(IPAddr.new("3ffe:505:2::/48")))
+    assert_equal(false, @a.equal_with_mask(@a.mask(128)))
+  end
+
   def test_mask
     a = @a.mask(32)
     assert_equal("3ffe:505::", a.to_s)

--- a/test/test_ipaddr.rb
+++ b/test/test_ipaddr.rb
@@ -284,14 +284,14 @@ class TC_Operator < Test::Unit::TestCase
     assert_equal(false, @a != IPAddr.new("3ffe:505:2::"))
   end
 
-  def test_equal_with_mask
-    assert_equal(true, @a.equal_with_mask(IPAddr.new("3FFE:505:2::/48")))
-    assert_equal(true, @a.equal_with_mask(IPAddr.new("3ffe:0505:0002::/48")))
-    assert_equal(true, @a.equal_with_mask(IPAddr.new("3ffe:0505:0002:0:0:0:0:0/48")))
-    assert_equal(false, @a.equal_with_mask(IPAddr.new("3ffe:505:3::/48")))
-    assert_equal(false, @a.equal_with_mask(IPAddr.new("3ffe:505:3::/48")))
-    assert_equal(true, @a.equal_with_mask(IPAddr.new("3ffe:505:2::/48")))
-    assert_equal(false, @a.equal_with_mask(@a.mask(128)))
+  def test_equal_with_mask?
+    assert_equal(true, @a.equal_with_mask?(IPAddr.new("3FFE:505:2::/48")))
+    assert_equal(true, @a.equal_with_mask?(IPAddr.new("3ffe:0505:0002::/48")))
+    assert_equal(true, @a.equal_with_mask?(IPAddr.new("3ffe:0505:0002:0:0:0:0:0/48")))
+    assert_equal(false, @a.equal_with_mask?(IPAddr.new("3ffe:505:3::/48")))
+    assert_equal(false, @a.equal_with_mask?(IPAddr.new("3ffe:505:3::/48")))
+    assert_equal(true, @a.equal_with_mask?(IPAddr.new("3ffe:505:2::/48")))
+    assert_equal(false, @a.equal_with_mask?(@a.mask(128)))
   end
 
   def test_mask


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/11210

Since there is not a single way to write a netmask for an IP address (e.g 192.168.1.2/24 is equal to 192.168.1.2/255.255.255.0), return an object instead, so the caller can get the kind of output he desires.
