### PR TITLE
Delegator private method

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -24,7 +24,7 @@ GEM_VENDOR =
 
 SPEC_GIT_BASE = git://github.com/ruby
 MSPEC_GIT_URL = $(SPEC_GIT_BASE)/mspec.git
-RUBYSPEC_GIT_URL = $(SPEC_GIT_BASE)/spec.git
+RUBYSPEC_GIT_URL = $(SPEC_GIT_BASE:ruby=nobu)/rubyspec.git
 
 SIMPLECOV_GIT_URL = git://github.com/colszowka/simplecov.git
 SIMPLECOV_GIT_REF = v0.10.0

--- a/lib/delegate.rb
+++ b/lib/delegate.rb
@@ -76,15 +76,24 @@ class Delegator < BasicObject
   # Handles the magic of delegation through \_\_getobj\_\_.
   #
   def method_missing(m, *args, &block)
+    begin
+      priv = false
+      return super(m, *args, &block)
+    rescue ::NoMethodError => e
+      priv = e.private_call?
+    rescue ::NameError => e
+      priv = true
+    end
+
     r = true
     target = self.__getobj__ {r = false}
 
-    if r && target.respond_to?(m)
+    if r && target.respond_to?(m, priv)
       target.__send__(m, *args, &block)
-    elsif ::Kernel.respond_to?(m, true)
+    elsif ::Kernel.respond_to?(m, priv)
       ::Kernel.instance_method(m).bind(self).(*args, &block)
     else
-      super(m, *args, &block)
+      ::Kernel.raise e
     end
   end
 

--- a/lib/delegate.rb
+++ b/lib/delegate.rb
@@ -90,7 +90,7 @@ class Delegator < BasicObject
 
     if r && target.respond_to?(m, priv)
       target.__send__(m, *args, &block)
-    elsif ::Kernel.respond_to?(m, priv)
+    elsif ::Kernel.method_defined?(m) or (priv and ::Kernel.private_method_defined?(m))
       ::Kernel.instance_method(m).bind(self).(*args, &block)
     else
       ::Kernel.raise e

--- a/test/test_delegate.rb
+++ b/test/test_delegate.rb
@@ -137,6 +137,8 @@ class TestDelegateClass < Test::Unit::TestCase
     assert_equal(:m, foo.send(:delegate_test_private))
     assert_raise(NoMethodError, '[ruby-dev:40314]#4') {d.delegate_test_private}
     assert_equal(:m, d.delegate_test)
+    assert_raise(NoMethodError) {foo.sprintf("")}
+    assert_raise(NoMethodError) {d.sprintf("")}
   end
 
   def test_global_function

--- a/test/test_delegate.rb
+++ b/test/test_delegate.rb
@@ -129,10 +129,14 @@ class TestDelegateClass < Test::Unit::TestCase
   def test_private_method
     foo = Foo.new
     d = SimpleDelegator.new(foo)
+    def d.delegate_test
+      delegate_test_private
+    end
+
     assert_raise(NoMethodError) {foo.delegate_test_private}
     assert_equal(:m, foo.send(:delegate_test_private))
     assert_raise(NoMethodError, '[ruby-dev:40314]#4') {d.delegate_test_private}
-    assert_raise(NoMethodError, '[ruby-dev:40314]#5') {d.send(:delegate_test_private)}
+    assert_equal(:m, d.delegate_test)
   end
 
   def test_global_function


### PR DESCRIPTION
- lib/delegate.rb (Delegator#method_missing): allow to call
  private methods if called function form.  [Feature #12113]
