### PR TITLE
[DOC] Remove trailing comma from Array#push example

### DIFF
--- a/array.c
+++ b/array.c
@@ -935,7 +935,7 @@ rb_ary_cat(VALUE ary, const VALUE *argv, long len)
  *     a = [ "a", "b", "c" ]
  *     a.push("d", "e", "f")
  *             #=> ["a", "b", "c", "d", "e", "f"]
- *     [1, 2, 3,].push(4).push(5)
+ *     [1, 2, 3].push(4).push(5)
  *             #=> [1, 2, 3, 4, 5]
  */
 


### PR DESCRIPTION
other Array examples doesn't put trailing comma.