### PR TITLE
Minor typo in Time#dst? documentation

### DIFF
--- a/time.c
+++ b/time.c
@@ -4959,7 +4959,7 @@ time_load(VALUE klass, VALUE str)
  *
  *    t.year #=> 1993
  *
- *  Was is daylight savings at the time?
+ *  Was it daylight savings at the time?
  *
  *    t.dst? #=> false
  *


### PR DESCRIPTION
There was a slight typo that I noticed while looking at through the Time documentation.