### PR TITLE
fix RB_GC_GUARD_PTR on non-GCC/non-MSC builds

### DIFF
--- a/include/ruby/ruby.h
+++ b/include/ruby/ruby.h
@@ -561,12 +561,13 @@ static inline int rb_type(VALUE obj);
 #pragma optimize("", off)
 static inline volatile VALUE *rb_gc_guarded_ptr(volatile VALUE *ptr) {return ptr;}
 #pragma optimize("", on)
+#define RB_GC_GUARD_PTR(ptr) rb_gc_guarded_ptr(ptr)
 #else
 volatile VALUE *rb_gc_guarded_ptr_val(volatile VALUE *ptr, VALUE val);
 #define HAVE_RB_GC_GUARDED_PTR_VAL 1
 #define RB_GC_GUARD(v) (*rb_gc_guarded_ptr_val(&(v),(v)))
+#define RB_GC_GUARD_PTR(ptr) RB_GC_GUARD(ptr)
 #endif
-#define RB_GC_GUARD_PTR(ptr) rb_gc_guarded_ptr(ptr)
 #endif
 
 #ifndef RB_GC_GUARD


### PR DESCRIPTION
- the definition of RB_GC_GUARD_PTR needs to be moved into the block
which is MSC-specific since in the non-MSC/non-GCC codepath here we
do not have any rb_gc_guarded_ptr defined.

- i alised RB_GC_GUARD_PTR to RB_GC_GUARD which i think is how people
are intending to use this macro?

- people are in fact using this macro as a public API even though
there is the comment in the code not to.