### PR TITLE
Fix DateTime#to_time to preserve timezone info

### DIFF
--- a/ext/date/date_core.c
+++ b/ext/date/date_core.c
@@ -8587,21 +8587,24 @@ date_to_datetime(VALUE self)
 static VALUE
 datetime_to_time(VALUE self)
 {
-    volatile VALUE dup = dup_obj_with_new_offset(self, 0);
+    volatile VALUE dup = dup_obj(self);
     {
 	VALUE t;
 
 	get_d1(dup);
 
-	t = f_utc6(rb_cTime,
+	t = rb_funcall(rb_cTime,
+		   rb_intern("new"),
+                   7,
 		   m_real_year(dat),
 		   INT2FIX(m_mon(dat)),
 		   INT2FIX(m_mday(dat)),
 		   INT2FIX(m_hour(dat)),
 		   INT2FIX(m_min(dat)),
 		   f_add(INT2FIX(m_sec(dat)),
-			 m_sf_in_sec(dat)));
-	return f_getlocal(t);
+			 m_sf_in_sec(dat)),
+		   INT2FIX(m_of(dat)));
+	return t;
     }
 }
 

--- a/test/date/test_date_conv.rb
+++ b/test/date/test_date_conv.rb
@@ -32,12 +32,10 @@ class TestDateConv < Test::Unit::TestCase
   end
 
   def test_to_time__from_datetime
-    d = DateTime.new(2004, 9, 19, 1, 2, 3, 9.to_r/24) + 456789.to_r/86400000000
+    d = DateTime.new(2004, 9, 19, 1, 2, 3, 8.to_r/24) + 456789.to_r/86400000000
     t = d.to_time
-    if t.utc_offset == 9*60*60
-      assert_equal([2004, 9, 19, 1, 2, 3, 456789],
-		   [t.year, t.mon, t.mday, t.hour, t.min, t.sec, t.usec])
-    end
+    assert_equal([2004, 9, 19, 1, 2, 3, 456789, 8*60*60],
+     [t.year, t.mon, t.mday, t.hour, t.min, t.sec, t.usec, t.utc_offset])
 
     d = DateTime.new(2004, 9, 19, 1, 2, 3, 0) + 456789.to_r/86400000000
     t = d.to_time.utc


### PR DESCRIPTION
 * ext/date/date_core.c (datetime_to_time): preserve timezone info  [Bug #12189]