### PR TITLE
Fix Time.parse/strptime to utilize timezone :offset

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+Fri Mar 18 02:35:12 2016  Naotoshi Seo  <sonots@gmail.com>
+
+	* lib/time.rb (parse, strptime): Fix Time.parse/strptime does not
+	  have compatibility with DateTime.parse/strptime in terms of parsing
+	  timezone [Bug #12190] [Fix GH-1297]
+
 Fri Mar 18 02:17:00 2016  Kenta Murata  <mrkn@mrkn.jp>
 
 	* numeric.c (fix_zero_p, fix_even_p, fix_odd_p): remove needless

--- a/lib/time.rb
+++ b/lib/time.rb
@@ -249,14 +249,18 @@ class Time
     end
     private :apply_offset
 
-    def make_time(date, year, mon, day, hour, min, sec, sec_fraction, zone, now)
+    def make_time(date, year, mon, day, hour, min, sec, sec_fraction, zone, offset, now)
       if !year && !mon && !day && !hour && !min && !sec && !sec_fraction
         raise ArgumentError, "no time information in #{date.inspect}"
       end
 
-      off_year = year || now.year
       off = nil
-      off = zone_offset(zone, off_year) if zone
+      if offset
+        off = offset
+      else
+        off_year = year || now.year
+        off = zone_offset(zone, off_year) if zone
+      end
 
       if off
         now = now.getlocal(off) if now.utc_offset != off
@@ -287,8 +291,10 @@ class Time
       sec ||= 0
       usec ||= 0
 
-      if year != off_year
-        off = nil
+      off = nil
+      if offset
+        off = offset
+      elsif year != off_year
         off = zone_offset(zone, year) if zone
       end
 
@@ -363,7 +369,7 @@ class Time
       d = Date._parse(date, comp)
       year = d[:year]
       year = yield(year) if year && !comp
-      make_time(date, year, d[:mon], d[:mday], d[:hour], d[:min], d[:sec], d[:sec_fraction], d[:zone], now)
+      make_time(date, year, d[:mon], d[:mday], d[:hour], d[:min], d[:sec], d[:sec_fraction], d[:zone], d[:offset], now)
     end
 
     #
@@ -441,7 +447,7 @@ class Time
       else
         year = d[:year]
         year = yield(year) if year && block_given?
-        t = make_time(date, year, d[:mon], d[:mday], d[:hour], d[:min], d[:sec], d[:sec_fraction], d[:zone], now)
+        t = make_time(date, year, d[:mon], d[:mday], d[:hour], d[:min], d[:sec], d[:sec_fraction], d[:zone], d[:offset], now)
       end
       t
     end

--- a/test/test_time.rb
+++ b/test/test_time.rb
@@ -429,6 +429,23 @@ class TestTimeExtension < Test::Unit::TestCase # :nodoc:
     assert_equal(500000, Time.parse("2000-01-01T00:00:00.5+00:00").tv_usec)
   end
 
+  def test_parse_with_zone
+    t = Time.parse('2000-01-01T00:00:00 CET')
+    assert_equal(2000, t.year)
+    assert_equal(1, t.mon)
+    assert_equal(1, t.day)
+    assert_equal(0, t.hour)
+    assert_equal(0, t.min)
+    assert_equal(0, t.sec)
+    assert_equal(3600, t.utc_offset)
+    assert_equal(false, t.utc?)
+
+    Time.instance_eval("ZoneOffset").each do |zone, offset|
+      t = Time.parse("2000-01-01T00:00:00 #{zone}")
+      assert_equal(offset*3600, t.utc_offset)
+    end
+  end
+
   def test_strptime
     assert_equal(Time.utc(2005, 8, 28, 06, 54, 20), Time.strptime("28/Aug/2005:06:54:20 +0000", "%d/%b/%Y:%T %z"))
     assert_equal(Time.at(1).localtime, Time.strptime("1", "%s"))
@@ -479,6 +496,21 @@ class TestTimeExtension < Test::Unit::TestCase # :nodoc:
     assert_equal(0, t.sec)
     assert_equal(0, t.utc_offset)
     assert_equal(true, t.utc?)
+
+    t = Time.strptime('20010203 CET', '%Y%m%d %z')
+    assert_equal(2001, t.year)
+    assert_equal(2, t.mon)
+    assert_equal(3, t.day)
+    assert_equal(0, t.hour)
+    assert_equal(0, t.min)
+    assert_equal(0, t.sec)
+    assert_equal(3600, t.utc_offset)
+    assert_equal(false, t.utc?)
+
+    Time.instance_eval("ZoneOffset").each do |zone, offset|
+      t = Time.strptime("2000-01-01 #{zone}", '%Y-%m-%d %z')
+      assert_equal(offset*3600, t.utc_offset)
+    end
   end
 
   def test_nsec


### PR DESCRIPTION
* lib/time.rb (parse, strptime): Fix Time.parse/strptime does not have compatibility with DateTime.parse/strptime in terms of parsing timezone [Bug #12190] [Fix GH-1297]