### PR TITLE
Fix a Ruby-Doc comment for Module#constants

### DIFF
--- a/variable.c
+++ b/variable.c
@@ -2457,6 +2457,9 @@ rb_const_list(void *data)
  *  modules (example at start of section), unless the <i>inherit</i>
  *  parameter is set to <code>false</code>.
  *
+ *  The implementation makes no guarantees about the order in which the
+ *  constants are yielded.
+ *
  *    IO.constants.include?(:SYNC)        #=> true
  *    IO.constants(false).include?(:SYNC) #=> false
  *


### PR DESCRIPTION
Added some documentation for the Module#constants behaviour pointed out in Bug [#12121](https://bugs.ruby-lang.org/issues/12121) on the Ruby trunk issue tracker.