### PR TITLE
mkmf: Unquote directory strings in find_executable0

### DIFF
--- a/lib/mkmf.rb
+++ b/lib/mkmf.rb
@@ -1551,6 +1551,7 @@ SRC
     end
     file = nil
     path.each do |dir|
+      dir.gsub!(/\A"|"\Z/, '')
       return file if executable_file.call(file = File.join(dir, bin))
       if exts
         exts.each {|ext| executable_file.call(ext = file + ext) and return ext}


### PR DESCRIPTION
On Windows, it is actually valid to surround individual PATH directory
entries with double quotes. Remove these before joining the path as
otherwise the literal quotes would become part of the path, resulting in
the executable not to be found.