### PR TITLE
WEBrick::HTTPResponse: move error_body to method

### DIFF
--- a/lib/webrick/httpresponse.rb
+++ b/lib/webrick/httpresponse.rb
@@ -352,6 +352,14 @@ module WEBrick
         host, port = @config[:ServerName], @config[:Port]
       end
 
+      error_body(backtrace, ex, host, port)
+    end
+
+    private
+
+    # :stopdoc:
+
+    def error_body(backtrace, ex, host, port)
       @body = ''
       @body << <<-_end_of_html_
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN">
@@ -380,10 +388,6 @@ module WEBrick
 </HTML>
       _end_of_html_
     end
-
-    private
-
-    # :stopdoc:
 
     def send_body_io(socket)
       begin

--- a/test/webrick/test_httpresponse.rb
+++ b/test/webrick/test_httpresponse.rb
@@ -146,5 +146,15 @@ module WEBrick
       }
       assert_equal 0, logger.messages.length
     end
+
+    def test_set_error
+      status = 400
+      message = 'missing attribute'
+      @res.status = status
+      error = WEBrick::HTTPStatus[status].new(message)
+      body = @res.set_error(error)
+      assert_match(/#{@res.reason_phrase}/, body)
+      assert_match(/#{message}/, body)
+    end
   end
 end


### PR DESCRIPTION
This allow to override the body more easily.
Cheers