### PR TITLE
Use `userinfo` for authenticated proxy 

### DIFF
--- a/lib/open-uri.rb
+++ b/lib/open-uri.rb
@@ -270,6 +270,9 @@ module OpenURI
     if URI::HTTP === target
       # HTTP or HTTPS
       if proxy
+        unless proxy_user && proxy_pass
+          proxy_user, proxy_pass = proxy_uri.userinfo.split(':') if proxy_uri.userinfo
+        end
         if proxy_user && proxy_pass
           klass = Net::HTTP::Proxy(proxy_uri.hostname, proxy_uri.port, proxy_user, proxy_pass)
         else


### PR DESCRIPTION
From pull #1148 

In spite of proxy_uri.userinfo has username and password for authenticated proxy, open_http method of open-uri.rb ignores it. Actually, lots of softwares expect this value as a credential for authenticated proxy.

I have retained his original change & added a unit test for it.  cc/ @hsbt 