### PR TITLE
Override Prime.include? to avoid nontermination

### DIFF
--- a/lib/prime.rb
+++ b/lib/prime.rb
@@ -155,6 +155,8 @@ class Prime
     end
   end
 
+  alias_method :include?, :prime?
+
   # Re-composes a prime factorization and returns the product.
   #
   # == Parameters

--- a/test/test_prime.rb
+++ b/test/test_prime.rb
@@ -124,6 +124,10 @@ class TestPrime < Test::Unit::TestCase
     assert_raise(ArgumentError) { Prime.prime?(1.2) }
   end
 
+  def test_prime_include_alias
+    assert_equal(false, Prime.include?(4))
+  end
+
   class TestInteger < Test::Unit::TestCase
     def test_prime_division
       pd = PRIMES.inject(&:*).prime_division


### PR DESCRIPTION
Enumerable's `include?` calls `each` until a matching value is found. This means `Prime.include?` will not terminate for composite arguments. The solution is override `Prime.include?` to alias the existing `Prime.prime?`, to better implement the Enumerable interface.
