### PR TITLE
Access to ephemeral TLS session key

### DIFF
--- a/ext/openssl/extconf.rb
+++ b/ext/openssl/extconf.rb
@@ -111,6 +111,7 @@ have_func("TLSv1_2_server_method")
 have_func("TLSv1_2_client_method")
 have_func("SSL_CTX_set_alpn_select_cb")
 have_func("SSL_CTX_set_next_proto_select_cb")
+have_macro("SSL_get_server_tmp_key", ['openssl/ssl.h']) && $defs.push("-DHAVE_SSL_GET_SERVER_TMP_KEY")
 unless have_func("SSL_set_tlsext_host_name", ['openssl/ssl.h'])
   have_macro("SSL_set_tlsext_host_name", ['openssl/ssl.h']) && $defs.push("-DHAVE_SSL_SET_TLSEXT_HOST_NAME")
 end

--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -1914,6 +1914,25 @@ ossl_ssl_alpn_protocol(VALUE self)
 # endif
 #endif /* !defined(OPENSSL_NO_SOCK) */
 
+#if OPENSSL_VERSION_NUMBER >= 0x10002000L
+/*
+ * call-seq:
+ *    ssl.tmp_key => PKey or nil
+ *
+ * Returns the ephemeral key used in case of forward secrecy cipher
+ */
+static VALUE
+ossl_ssl_tmp_key(VALUE self)
+{
+       SSL *ssl;
+       EVP_PKEY *key;
+       ossl_ssl_data_get_struct(self, ssl);
+       if (!SSL_get_server_tmp_key(ssl, &key))
+               return Qnil;
+       return ossl_pkey_new(key);
+}
+#endif
+
 void
 Init_ossl_ssl(void)
 {
@@ -2306,6 +2325,9 @@ Init_ossl_ssl(void)
     rb_define_method(cSSLSocket, "session=",    ossl_ssl_set_session, 1);
     rb_define_method(cSSLSocket, "verify_result", ossl_ssl_get_verify_result, 0);
     rb_define_method(cSSLSocket, "client_ca", ossl_ssl_get_client_ca_list, 0);
+#if OPENSSL_VERSION_NUMBER >= 0x10002000L
+    rb_define_method(cSSLSocket, "tmp_key", ossl_ssl_tmp_key, 0);
+#endif
 # ifdef HAVE_SSL_CTX_SET_ALPN_SELECT_CB
     rb_define_method(cSSLSocket, "alpn_protocol", ossl_ssl_alpn_protocol, 0);
 # endif

--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -1912,9 +1912,8 @@ ossl_ssl_alpn_protocol(VALUE self)
 	return rb_str_new((const char *) out, outlen);
 }
 # endif
-#endif /* !defined(OPENSSL_NO_SOCK) */
 
-#if OPENSSL_VERSION_NUMBER >= 0x10002000L
+# ifdef HAVE_SSL_GET_SERVER_TMP_KEY
 /*
  * call-seq:
  *    ssl.tmp_key => PKey or nil
@@ -1924,14 +1923,15 @@ ossl_ssl_alpn_protocol(VALUE self)
 static VALUE
 ossl_ssl_tmp_key(VALUE self)
 {
-       SSL *ssl;
-       EVP_PKEY *key;
-       ossl_ssl_data_get_struct(self, ssl);
-       if (!SSL_get_server_tmp_key(ssl, &key))
-               return Qnil;
-       return ossl_pkey_new(key);
+   SSL *ssl;
+   EVP_PKEY *key;
+   ossl_ssl_data_get_struct(self, ssl);
+   if (!SSL_get_server_tmp_key(ssl, &key))
+       return Qnil;
+   return ossl_pkey_new(key);
 }
-#endif
+# endif /* defined(HAVE_SSL_GET_SERVER_TMP_KEY) */
+#endif /* !defined(OPENSSL_NO_SOCK) */
 
 void
 Init_ossl_ssl(void)
@@ -2325,9 +2325,9 @@ Init_ossl_ssl(void)
     rb_define_method(cSSLSocket, "session=",    ossl_ssl_set_session, 1);
     rb_define_method(cSSLSocket, "verify_result", ossl_ssl_get_verify_result, 0);
     rb_define_method(cSSLSocket, "client_ca", ossl_ssl_get_client_ca_list, 0);
-#if OPENSSL_VERSION_NUMBER >= 0x10002000L
+# ifdef HAVE_SSL_GET_SERVER_TMP_KEY
     rb_define_method(cSSLSocket, "tmp_key", ossl_ssl_tmp_key, 0);
-#endif
+# endif
 # ifdef HAVE_SSL_CTX_SET_ALPN_SELECT_CB
     rb_define_method(cSSLSocket, "alpn_protocol", ossl_ssl_alpn_protocol, 0);
 # endif

--- a/test/openssl/test_ssl.rb
+++ b/test/openssl/test_ssl.rb
@@ -1169,6 +1169,29 @@ end
     }
   end
 
+  def test_get_ephemeral_key
+    return unless OpenSSL::SSL::SSLSocket.method_defined?(:tmp_key)
+    ciphers = {
+        'ECDHE-RSA-AES128-SHA' => OpenSSL::PKey::EC,
+        'DHE-RSA-AES128-SHA' => OpenSSL::PKey::DH,
+        'AES128-SHA' => nil
+    }
+    conf_proc = Proc.new { |ctx| ctx.ciphers = 'ALL' }
+    start_server(OpenSSL::SSL::VERIFY_NONE, true, :ctx_proc => conf_proc){|server, port|
+        ciphers.each do |cipher, ephemeral|
+            ctx = OpenSSL::SSL::SSLContext.new
+            ctx.ciphers = cipher
+            server_connect(port, ctx) { |ssl|
+                if ephemeral
+                    assert_equal(ephemeral, ssl.tmp_key.class)
+                else
+                    assert_nil(ssl.tmp_key)
+                end
+            }
+        end
+    }
+  end
+
   private
 
   def start_server_version(version, ctx_proc=nil, server_proc=nil, &blk)

--- a/test/openssl/utils.rb
+++ b/test/openssl/utils.rb
@@ -277,6 +277,7 @@ AQjjxMXhwULlmuR/K+WwlaZPiLIBYalLAZQ7ZbOPeVkJ8ePao0eLAgEC
         ctx.cert = @svr_cert
         ctx.key = @svr_key
         ctx.tmp_dh_callback = proc { OpenSSL::TestUtils::TEST_KEY_DH1024 }
+        ctx.tmp_ecdh_callback = proc { OpenSSL::TestUtils::TEST_KEY_EC_P256V1 }
         ctx.verify_mode = verify_mode
         ctx_proc.call(ctx) if ctx_proc
 


### PR DESCRIPTION
Hi,

Here is a small patch to have access to ephemeral session key in case of forward secrecy cipher.
Only available since [OpenSSL 1.0.2](https://marc.info/?l=openssl-cvs&m=135653902602326&w=2).

Regards,