### PR TITLE
cleanup some Win9x/ME/NT4 support leftovers

### DIFF
--- a/cont.c
+++ b/cont.c
@@ -54,13 +54,7 @@
 #     define FIBER_USE_NATIVE 1
 #   endif
 # elif defined(_WIN32)
-#   if _WIN32_WINNT >= 0x0400
-/* only when _WIN32_WINNT >= 0x0400 on Windows because Fiber APIs are
- * supported only such building (and running) environments.
- * [ruby-dev:41192]
- */
-#     define FIBER_USE_NATIVE 1
-#   endif
+#  define FIBER_USE_NATIVE 1
 # endif
 #endif
 #if !defined(FIBER_USE_NATIVE)

--- a/hash.c
+++ b/hash.c
@@ -3163,7 +3163,7 @@ getenvsize(const WCHAR* p)
 static size_t
 getenvblocksize(void)
 {
-    return (rb_w32_osver() >= 5) ? 32767 : 5120;
+    return 32767;
 }
 #endif
 

--- a/random.c
+++ b/random.c
@@ -84,11 +84,6 @@ The original copyright notice follows.
 #endif
 
 #ifdef _WIN32
-# if !defined(_WIN32_WINNT) || _WIN32_WINNT < 0x0400
-#  undef _WIN32_WINNT
-#  define _WIN32_WINNT 0x400
-#  undef __WINCRYPT_H__
-# endif
 #include <windows.h>
 #include <wincrypt.h>
 #endif

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -5920,23 +5920,21 @@ rb_w32_getppid(void)
     static query_func *pNtQueryInformationProcess = NULL;
     rb_pid_t ppid = 0;
 
-    if (rb_w32_osver() >= 5) {
-	if (!pNtQueryInformationProcess)
-	    pNtQueryInformationProcess = (query_func *)get_proc_address("ntdll.dll", "NtQueryInformationProcess", NULL);
-	if (pNtQueryInformationProcess) {
-	    struct {
-		long ExitStatus;
-		void* PebBaseAddress;
-		uintptr_t AffinityMask;
-		uintptr_t BasePriority;
-		uintptr_t UniqueProcessId;
-		uintptr_t ParentProcessId;
-	    } pbi;
-	    ULONG len;
-	    long ret = pNtQueryInformationProcess(GetCurrentProcess(), 0, &pbi, sizeof(pbi), &len);
-	    if (!ret) {
-		ppid = pbi.ParentProcessId;
-	    }
+    if (!pNtQueryInformationProcess)
+	pNtQueryInformationProcess = (query_func *)get_proc_address("ntdll.dll", "NtQueryInformationProcess", NULL);
+    if (pNtQueryInformationProcess) {
+	struct {
+	    long ExitStatus;
+	    void* PebBaseAddress;
+	    uintptr_t AffinityMask;
+	    uintptr_t BasePriority;
+	    uintptr_t UniqueProcessId;
+	    uintptr_t ParentProcessId;
+	} pbi;
+	ULONG len;
+	long ret = pNtQueryInformationProcess(GetCurrentProcess(), 0, &pbi, sizeof(pbi), &len);
+	if (!ret) {
+	    ppid = pbi.ParentProcessId;
 	}
     }
 

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -4685,21 +4685,7 @@ kill(int pid, int sig)
 static int
 wlink(const WCHAR *from, const WCHAR *to)
 {
-    typedef BOOL (WINAPI link_func)(LPCWSTR, LPCWSTR, LPSECURITY_ATTRIBUTES);
-    static link_func *pCreateHardLinkW = NULL;
-    static int myerrno = 0;
-
-    if (!pCreateHardLinkW && !myerrno) {
-	pCreateHardLinkW = (link_func *)get_proc_address("kernel32", "CreateHardLinkW", NULL);
-	if (!pCreateHardLinkW)
-	    myerrno = ENOSYS;
-    }
-    if (!pCreateHardLinkW) {
-	errno = myerrno;
-	return -1;
-    }
-
-    if (!pCreateHardLinkW(to, from, NULL)) {
+    if (!CreateHardLinkW(to, from, NULL)) {
 	errno = map_errno(GetLastError());
 	return -1;
     }

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -4766,25 +4766,12 @@ reparse_symlink(const WCHAR *path, rb_w32_reparse_buffer_t *rp, size_t size)
     DWORD ret;
     int e = 0;
 
-    typedef BOOL (WINAPI *device_io_control_func)(HANDLE, DWORD, LPVOID,
-						  DWORD, LPVOID, DWORD,
-						  LPDWORD, LPOVERLAPPED);
-    static device_io_control_func device_io_control = (device_io_control_func)-1;
-
-    if (device_io_control == (device_io_control_func)-1) {
-	device_io_control = (device_io_control_func)
-	    get_proc_address("kernel32", "DeviceIoControl", NULL);
-    }
-    if (!device_io_control) {
-	return ENOSYS;
-    }
-
     f = open_special(path, 0, FILE_FLAG_OPEN_REPARSE_POINT);
     if (f == INVALID_HANDLE_VALUE) {
 	return GetLastError();
     }
 
-    if (!device_io_control(f, FSCTL_GET_REPARSE_POINT, NULL, 0,
+    if (!DeviceIoControl(f, FSCTL_GET_REPARSE_POINT, NULL, 0,
 			   rp, size, &ret, NULL)) {
 	e = GetLastError();
     }


### PR DESCRIPTION
A somewhat larger patch this time - especially the last two commits. Let me know if I should create an issue on the bug tracker.

Also: no new test-all failures/errors with VC6 and VC10 on WinXP SP3.