### PR TITLE
Update ssl.rb to run https from command line

### DIFF
--- a/lib/webrick/ssl.rb
+++ b/lib/webrick/ssl.rb
@@ -105,7 +105,8 @@ module WEBrick
       cert = OpenSSL::X509::Certificate.new
       cert.version = 2
       cert.serial = 1
-      name = OpenSSL::X509::Name.new(cn)
+      name = (cn.kind_of? String) ? OpenSSL::X509::Name.parse(cn)
+                                  : OpenSSL::X509::Name.new(cn)
       cert.subject = name
       cert.issuer = name
       cert.not_before = Time.now


### PR DESCRIPTION
Change to allow SSLCertName param to be entered on rackup command line. Then serve rails app https://localhost:3430/ with:

rackup -p 3430 -r openssl -r webrick/https -O SSLEnable -O SSLCertName='CN=localhost'