### PR TITLE
error.c: bypass Exception.new

### DIFF
--- a/bootstraptest/test_exception.rb
+++ b/bootstraptest/test_exception.rb
@@ -402,7 +402,7 @@ assert_equal 'nil', %q{
   exc.inspect
 }, '[ruby-dev:32608]'
 
-assert_equal 'exception class/object expected', %q{
+assert_equal 'divided by 0', %q{
   class ZeroDivisionError
     def self.new(message)
       42

--- a/error.c
+++ b/error.c
@@ -656,7 +656,7 @@ VALUE rb_eSystemCallError;
 VALUE rb_mErrno;
 static VALUE rb_eNOERROR;
 
-static ID id_new, id_cause, id_message, id_backtrace;
+static ID id_cause, id_message, id_backtrace;
 static ID id_name, id_args, id_Errno, id_errno, id_i_path;
 static ID id_receiver, id_iseq, id_local_variables;
 static ID id_private_call_p;
@@ -671,7 +671,8 @@ extern ID ruby_static_id_status;
 VALUE
 rb_exc_new(VALUE etype, const char *ptr, long len)
 {
-    return rb_funcall(etype, id_new, 1, rb_str_new(ptr, len));
+    VALUE mesg = rb_str_new(ptr, len);
+    return rb_class_new_instance(1, &mesg, etype);
 }
 
 VALUE
@@ -684,7 +685,7 @@ VALUE
 rb_exc_new_str(VALUE etype, VALUE str)
 {
     StringValue(str);
-    return rb_funcall(etype, id_new, 1, str);
+    return rb_class_new_instance(1, &str, etype);
 }
 
 /*
@@ -2028,7 +2029,6 @@ Init_Exception(void)
 
     rb_define_global_function("warn", rb_warn_m, -1);
 
-    id_new = rb_intern_const("new");
     id_cause = rb_intern_const("cause");
     id_message = rb_intern_const("message");
     id_backtrace = rb_intern_const("backtrace");


### PR DESCRIPTION
- error.c (rb_exc_new, rb_exc_new_str): instantiate exception
  object directly without Exception.new method call.

Redefinition of class method `new` is outdated style, and
internal exception should not be affected by it.
