### PR TITLE
New reserved char at URI regex

### DIFF
--- a/lib/uri/rfc2396_parser.rb
+++ b/lib/uri/rfc2396_parser.rb
@@ -43,7 +43,7 @@ module URI
       #                 "$" | ","
       # reserved      = ";" | "/" | "?" | ":" | "@" | "&" | "=" | "+" |
       #                 "$" | "," | "[" | "]" (RFC 2732)
-      RESERVED = ";/?:@&=+$,\\[\\]"
+      RESERVED = ";/?:@&=+$,\\[\\]|"
 
       # domainlabel   = alphanum | alphanum *( alphanum | "-" ) alphanum
       DOMLABEL = "(?:[#{ALNUM}](?:[-#{ALNUM}]*[#{ALNUM}])?)"


### PR DESCRIPTION
This fix allow to use URI with pipe marks inside