### PR TITLE
drop FreeBSD < 4 support

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -108,6 +108,8 @@ with all sufficient information, see the ChangeLog file or Redmine
 
 === Supported platform changes
 
+* FreeBSD < 4 is no longer supported
+
 === Implementation improvements
 
 * In some condition, `[x, y].max` and `[x, y].min` are optimized

--- a/numeric.c
+++ b/numeric.c
@@ -16,10 +16,6 @@
 #include <math.h>
 #include <stdio.h>
 
-#if defined(__FreeBSD__) && __FreeBSD__ < 4
-#include <floatingpoint.h>
-#endif
-
 #ifdef HAVE_FLOAT_H
 #include <float.h>
 #endif
@@ -4872,10 +4868,7 @@ Init_Numeric(void)
 #undef rb_intern
 #define rb_intern(str) rb_intern_const(str)
 
-#if defined(__FreeBSD__) && __FreeBSD__ < 4
-    /* allow divide by zero -- Inf */
-    fpsetmask(fpgetmask() & ~(FP_X_DZ|FP_X_INV|FP_X_OFL));
-#elif defined(_UNICOSMP)
+#ifdef _UNICOSMP
     /* Turn off floating point exceptions for divide by zero, etc. */
     _set_Creg(0, 0);
 #endif


### PR DESCRIPTION
The most recent version affected by this is 3.5 and was released in 2000.

https://www.freebsd.org/releases/3.5R/announce.html
https://en.wikipedia.org/wiki/History_of_FreeBSD#Version_history