### PR TITLE
Adds more examples to the documentation of Enumerable#detect

### DIFF
--- a/enum.c
+++ b/enum.c
@@ -225,7 +225,10 @@ find_i(RB_BLOCK_CALL_FUNC_ARGLIST(i, memop))
  *
  *  If no block is given, an enumerator is returned instead.
  *
+ *     (1..100).detect  => #<Enumerator: 1..100:detect>
+ *
  *     (1..10).detect	{ |i| i % 5 == 0 and i % 7 == 0 }   #=> nil
+ *     (1..100).detect	{ |i| i % 5 == 0 and i % 7 == 0 } #=> 35
  *     (1..100).find	{ |i| i % 5 == 0 and i % 7 == 0 }   #=> 35
  *
  */


### PR DESCRIPTION
The documentation shows two examples that if not read carefully it makes
it look like that `detect` returns nil when find returns 35, because the
former has a range from 1 to 10 and the later from 1 to 100.

Hopefully you will agree that this will be more readable.