### PR TITLE
lib/drb/timeridconv.rb: Provide a way to shutdown the timer thread.

### DIFF
--- a/lib/drb/timeridconv.rb
+++ b/lib/drb/timeridconv.rb
@@ -62,6 +62,14 @@ module DRb
         end
       end
 
+      def shutdown_keeper
+        return unless @keeper
+
+        @keeper.kill
+        Thread.pass while @keeper.alive?
+        @keeper = nil
+      end
+
       private
       def alternate
         synchronize do
@@ -95,6 +103,10 @@ module DRb
 
     def to_id(obj) # :nodoc:
       return @holder.add(obj)
+    end
+
+    def shutdown
+      @holder.shutdown_keeper
     end
   end
 end

--- a/test/drb/test_timeridconv.rb
+++ b/test/drb/test_timeridconv.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: false
+require 'test/unit'
+require 'drb/drb'
+require 'drb/timeridconv'
+
+require 'thread'
+
+module DRbTests
+
+class TestDRbTimerIdConv < Test::Unit::TestCase
+  def test_shutdown_kills_timer_thread
+    threads_before = Thread.list.select(&:alive?)
+    timer = DRb::TimerIdConv.new
+
+    threads_after = Thread.list.select(&:alive?)
+    assert_equal(1, threads_after.length - threads_before.length)
+
+    timer.shutdown
+    threads_after = Thread.list.select(&:alive?)
+    assert_equal(0, threads_after.length - threads_before.length)
+  end
+end
+end


### PR DESCRIPTION
- lib/drb/timeridconv.rb: Provide a way to shutdown the timer thread.
- test/drb/test_timeridconv.rb: Test for above

Fixes: https://bugs.ruby-lang.org/issues/12342

TimerIdConv.new creates a Thread that never ends.

Previously, a client could would have do this to kill this thread:

``` ruby
timer = DRb::TimerIdConv.new

... # other DRb code

thread = timer.instance_variable_get('@holder').instance_variable_get('@keeper')
thread.kill
Thread.pass while thread.alive?
```

Now, we can do this:

``` ruby
timer = DRb::TimerIdConv.new

... # other DRb code

timer.shutdown
```
