### PR TITLE
remove unnecessary preprocessor directives (Windows)

### DIFF
--- a/win32/win32.c
+++ b/win32/win32.c
@@ -90,13 +90,6 @@ static char *w32_getenv(const char *name, UINT cp);
 #undef dup2
 #undef strdup
 
-#if RUBY_MSVCRT_VERSION >= 140
-# define _filbuf _fgetc_nolock
-# define _flsbuf _fputc_nolock
-#endif
-#define enough_to_get(n) (--(n) >= 0)
-#define enough_to_put(n) (--(n) >= 0)
-
 #ifdef WIN32_DEBUG
 #define Debug(something) something
 #else

--- a/win32/winmain.c
+++ b/win32/winmain.c
@@ -1,5 +1,4 @@
 #include <windows.h>
-#include <stdio.h>
 
 extern int main(int, char**);
 


### PR DESCRIPTION
- `_filbuf`, `_flsbuf`, `enough_to_get()`,  `enough_to_put()` are unused since c15a74f3d0b31133c01a64334c6a660ad70fb442 / r50381
- including `<stdio.h>` is unnecessary as `printf()`, etc. are not used
