### PR TITLE
Fix typo in code doc of proc.c

### DIFF
--- a/proc.c
+++ b/proc.c
@@ -199,7 +199,7 @@ proc_clone(VALUE self)
  *   C.new.e(1,2)       #=> ArgumentError
  *   C.new.method(:e).to_proc.lambda?   #=> true
  *
- * This exception insures that methods never have tricks
+ * This exception ensures that methods never have tricks
  * and makes it easy to have wrappers to define methods that behave as usual.
  *
  *   class C


### PR DESCRIPTION
Insure has a different meaning than ensure and we mean the latter in
this case.
---

_Ensure_ is to do or have what is necessary for success.
Example: These blankets ensure that you’ll be warm enough.

_Insure_ is to cover with an insurance policy.
Example: I will insure my home with additional fire and flood policies.
