### PR TITLE
Restore documentation of ARGF

### DIFF
--- a/io.c
+++ b/io.c
@@ -12426,7 +12426,7 @@ Init_IO(void)
 
 #if 0
     /* Hack to get rdoc to regard ARGF as a class: */
-    rb_cARGF = rb_define_class("ARGF.class", rb_cObject);
+    rb_cARGF = rb_define_class("ARGF", rb_cObject);
 #endif
 
     rb_cARGF = rb_class_new(rb_cObject);


### PR DESCRIPTION
Versions of Ruby more recent than 1.9.3 appear to not generate documentation for ARGF.

Changing a reference from `"ARGF.class"` to `"ARGF"` seems to restore rdoc’s ability to generate ARGF documentation.