### PR TITLE
Correct documentation of CGI::Util::escapeHTML

### DIFF
--- a/lib/cgi/util.rb
+++ b/lib/cgi/util.rb
@@ -31,7 +31,7 @@ module CGI::Util
     '>' => '&gt;',
   }
 
-  # Escape special characters in HTML, namely &\"<>
+  # Escape special characters in HTML, namely '&\"<>
   #   CGI::escapeHTML('Usage: foo "bar" <baz>')
   #      # => "Usage: foo &quot;bar&quot; &lt;baz&gt;"
   def escapeHTML(string)


### PR DESCRIPTION
escapeHTML also escapes the single quote character (since Ruby 2.0)