### PR TITLE
Fix Marshal.dump to dump some numbers as Fixnum

### DIFF
--- a/marshal.c
+++ b/marshal.c
@@ -290,7 +290,7 @@ w_long(long x, struct dump_arg *arg)
     int i;
 
 #if SIZEOF_LONG > 4
-    if (!(RSHIFT(x, 31) == 0 || RSHIFT(x, 31) == -1)) {
+    if (!(RSHIFT(x, 32) == 0 || RSHIFT(x, 32) == -1)) {
 	/* big long does not fit in 4 bytes */
 	rb_raise(rb_eTypeError, "long too big to dump");
     }
@@ -683,7 +683,7 @@ w_object(VALUE obj, struct dump_arg *arg, int limit)
 	w_byte(TYPE_FIXNUM, arg);
 	w_long(FIX2INT(obj), arg);
 #else
-	if (RSHIFT((long)obj, 31) == 0 || RSHIFT((long)obj, 31) == -1) {
+	if (RSHIFT(FIX2LONG(obj), 32) == 0 || RSHIFT(FIX2LONG(obj), 32) == -1) {
 	    w_byte(TYPE_FIXNUM, arg);
 	    w_long(FIX2LONG(obj), arg);
 	}

--- a/test/ruby/test_marshal.rb
+++ b/test/ruby/test_marshal.rb
@@ -735,4 +735,21 @@ class TestMarshal < Test::Unit::TestCase
       end
     RUBY
   end
+
+  def test_test_marshal_dump_fixnum_value
+    [
+      "\x04\bi\x04\xff\xff\xff\xff", #  4294967295
+      "\x04\bi\x04\x00\x00\x00\x40", #  1073741824
+      "\x04\bi\x04\xff\xff\xff\x3f", #  1073741823
+      "\x04\bi\xfc\x00\x00\x00\xc0", # -1073741824
+      "\x04\bi\xfc\xff\xff\xff\xbf", # -1073741825
+      "\x04\bi\xfc\x00\x00\x00\x00", # -4294967296
+    ].each do |src|
+      assert_equal src.b, Marshal.dump(Marshal.load(src))
+    end
+
+    [4294967296, -4294967297].each do |n|
+      assert_equal n, Marshal.load(Marshal.dump(n))
+    end
+  end
 end


### PR DESCRIPTION
Currently, `Marshal.dump` dumps numbers between 1073741824 and 4294967295 and between -4294967296 and -1073741825 as `Bignum` in environment where sizeof long is 8.

```
irb(main):001:0> Marshal.load("\x04\bi\x04\x00\x00\x00\x40")
=> 1073741824
irb(main):002:0> Marshal.dump(1073741824)
=> "\x04\bl+\a\x00\x00\x00@"
irb(main):003:0> Marshal.load("\x04\bi\xfc\x00\x00\x00\x00")
=> -4294967296
irb(main):004:0> Marshal.dump(-4294967296)
=> "\x04\bl-\b\x00\x00\x00\x00\x01\x00"
```

This patch fixes to dump as `Fixnum`.

```
irb(main):001:0> Marshal.dump(1073741824)
=> "\x04\bi\x04\x00\x00\x00@"
irb(main):002:0> Marshal.dump(-4294967296)
=> "\x04\bi\xfc\x00\x00\x00\x00"
```