### PR TITLE
Use connect_nonblock to open TCP connections in Net::HTTP#connect

### DIFF
--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -881,14 +881,29 @@ module Net   #:nodoc:
       end
 
       D "opening connection to #{conn_address}:#{conn_port}..."
-      s = Timeout.timeout(@open_timeout, Net::OpenTimeout) {
-        begin
-          TCPSocket.open(conn_address, conn_port, @local_host, @local_port)
-        rescue => e
-          raise e, "Failed to open TCP connection to " +
-            "#{conn_address}:#{conn_port} (#{e.message})"
+      begin
+        if @open_timeout
+          s = Socket.new(:INET, :STREAM)
+          s.bind(Socket.pack_sockaddr_in(@local_port || 0, @local_host)) if @local_host
+
+          sockaddr = Socket.sockaddr_in(conn_port, conn_address)
+
+          start = Process.clock_gettime Process::CLOCK_MONOTONIC
+          begin
+            s.connect_nonblock(sockaddr)
+          rescue IO::WaitWritable
+            timeout = @open_timeout - (Process.clock_gettime(Process::CLOCK_MONOTONIC) - start)
+            raise Net::OpenTimeout unless timeout > 0 && IO.select(nil, [s], nil, timeout)
+            retry
+          rescue Errno::EISCONN
+          end
+        else
+          s = TCPSocket.open(conn_address, conn_port, @local_host, @local_port)
         end
-      }
+      rescue => e
+        raise e, "Failed to open TCP connection to " +
+            "#{conn_address}:#{conn_port} (#{e.message})"
+      end
       s.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1)
       D "opened"
       if use_ssl?


### PR DESCRIPTION
This fix should make opening a TCP connection in Net::HTTP#connect more efficient since we won't have to spin up a Timeout.timeout thread each time we open a connection. Also, we avoid the race conditions inherent in the use of Timeout.timeout, as detailed at http://blog.headius.com/2008/02/ruby-threadraise-threadkill-timeoutrb.html