### PR TITLE
Dir::Tmpname.create: Only yield if a block was given

### DIFF
--- a/lib/tmpdir.rb
+++ b/lib/tmpdir.rb
@@ -127,7 +127,7 @@ class Dir
       n = nil
       begin
         path = File.join(tmpdir, make_tmpname(basename, n))
-        yield(path, n, opts)
+        yield(path, n, opts) if block_given?
       rescue Errno::EEXIST
         n ||= 0
         n += 1


### PR DESCRIPTION
This commit only yields the block if a block was given. The method already returns the path, but it is not possible to use without a block currently. This changes the function to be usable like this:

```ruby
path = Dir::Tmpname.create("my-tmp-name)
```

Currently the behavior is:

```ruby
path = Dir::Tmpname.create("my-tmp-name") {}
```