### PR TITLE
Support for `squiggly heredoc' syntax in ruby-mode.el

### DIFF
--- a/misc/ruby-mode.el
+++ b/misc/ruby-mode.el
@@ -107,7 +107,7 @@
 (defconst ruby-block-end-re "\\_<end\\_>")
 
 (defconst ruby-here-doc-beg-re
-  "\\(<\\)<\\(-\\)?\\(\\([a-zA-Z0-9_]+\\)\\|[\"]\\([^\"]+\\)[\"]\\|[']\\([^']+\\)[']\\)")
+  "\\(<\\)<\\([-~]\\)?\\(\\([a-zA-Z0-9_]+\\)\\|[\"]\\([^\"]+\\)[\"]\\|[']\\([^']+\\)[']\\)")
 
 (defconst ruby-here-doc-end-re
   "^\\([ \t]+\\)?\\(.*\\)\\(.\\)$")
@@ -127,9 +127,9 @@
     (concat "<<"
             (let ((match (match-string 1)))
               (if (and match (> (length match) 0))
-                  (concat "\\(?:-\\([\"']?\\)\\|\\([\"']\\)" (match-string 1) "\\)"
+                  (concat "\\(?:[-~]\\([\"']?\\)\\|\\([\"']\\)" (match-string 1) "\\)"
                           contents "\\(\\1\\|\\2\\)")
-                (concat "-?\\([\"']\\|\\)" contents "\\1"))))))
+                (concat "[-~]?\\([\"']\\|\\)" contents "\\1"))))))
 
 (defconst ruby-delimiter
   (concat "[?$/%(){}#\"'`.:]\\|<<\\|\\[\\|\\]\\|\\_<\\("
@@ -679,7 +679,7 @@ Emacs to Ruby."
        ((looking-at "<<")
         (cond
          ((and (ruby-expr-beg 'heredoc)
-               (looking-at "<<\\(-\\)?\\(\\([\"'`]\\)\\([^\n]+?\\)\\3\\|\\(?:\\sw\\|\\s_\\)+\\)"))
+               (looking-at "<<\\([-~]\\)?\\(\\([\"'`]\\)\\([^\n]+?\\)\\3\\|\\(?:\\sw\\|\\s_\\)+\\)"))
           (setq re (regexp-quote (or (match-string 4) (match-string 2))))
           (if (match-beginning 1) (setq re (concat "\\s *" re)))
           (let* ((id-end (goto-char (match-end 0)))


### PR DESCRIPTION
This pull request adds the `squiggly heredoc' syntax to ruby-mode.el of Emacs.

That syntax is supported at Ruby 2.3 but it doesn't seem to be support in currently ruby-mode.el of Emacs.