### PR TITLE
Validate year and days correctly

### DIFF
--- a/test/test_time.rb
+++ b/test/test_time.rb
@@ -311,6 +311,8 @@ class TestTimeExtension < Test::Unit::TestCase # :nodoc:
 
     # Out of range arguments
     assert_raise(ArgumentError) { Time.parse("2014-13-13T18:00:00-0900") }
+    assert_raise(ArgumentError) { Time.parse("2015-02-29T18:00:00+0900") }
+    assert_raise(ArgumentError) { Time.parse("2016-02-30T18:00:00+0900") }
   end
 
   def test_zone_0000
@@ -360,6 +362,11 @@ class TestTimeExtension < Test::Unit::TestCase # :nodoc:
     assert_equal(t, Time.parse("Fri Jan  1 01:00:00 +0100 1999"))
     assert_equal(t, Time.parse("Fri Jan  1 00:00:00 +0000 1999"))
     assert_equal(t, Time.parse("Fri Dec 31 23:00:00 -0100 1998"))
+  end
+
+  def test_parse_leap_year
+    t = Time.utc(2016,2,29,0,0,0)
+    assert_equal(t, Time.parse("Mon Feb 29 00:00:00 UTC 2016"))
   end
 
   def test_rfc2822_leap_second

--- a/time.c
+++ b/time.c
@@ -2515,7 +2515,9 @@ static void
 validate_vtm(struct vtm *vtm)
 {
     if (   vtm->mon  < 1 || vtm->mon  > 12
-	|| vtm->mday < 1 || vtm->mday > 31
+	|| vtm->mday < 1 || vtm->mday > (leap_year_p(FIX2LONG(vtm->year)) ?
+					 leap_year_days_in_month :
+					 common_year_days_in_month)[vtm->mon-1]
 	|| vtm->hour < 0 || vtm->hour > 24
 	|| (vtm->hour == 24 && (vtm->min > 0 || vtm->sec > 0))
 	|| vtm->min  < 0 || vtm->min  > 59


### PR DESCRIPTION
```ruby
Time.parse("2016-06-31T00:00:00+0900")
#=> 2016-07-01 00:00:00 +0900
```

Is this intentional? I expect this to raise `ArgumentError` since the argument date is invalid.