### PR TITLE
Fix webrick handling of X-Forwarded-Proto header with multiple values

### DIFF
--- a/lib/webrick/httprequest.rb
+++ b/lib/webrick/httprequest.rb
@@ -567,7 +567,9 @@ module WEBrick
       if @forwarded_server = self["x-forwarded-server"]
         @forwarded_server = @forwarded_server.split(",", 2).first
       end
-      @forwarded_proto = self["x-forwarded-proto"]
+      if @forwarded_proto = self["x-forwarded-proto"]
+        @forwarded_proto = @forwarded_proto.split(",", 2).first
+      end
       if host_port = self["x-forwarded-host"]
         host_port = host_port.split(",", 2).first
         @forwarded_host, tmp = host_port.split(":", 2)

--- a/test/webrick/test_httprequest.rb
+++ b/test/webrick/test_httprequest.rb
@@ -301,7 +301,7 @@ GET /
       GET /foo HTTP/1.1
       Host: localhost:10080
       Client-IP: 234.234.234.234
-      X-Forwarded-Proto: https
+      X-Forwarded-Proto: https, http
       X-Forwarded-For: 192.168.1.10, 10.0.0.1, 123.123.123.123
       X-Forwarded-Host: forward.example.com
       X-Forwarded-Server: server.example.com


### PR DESCRIPTION
For HTTP requests that contain an `X-Forwarded-Proto` header with multiple values (i.e. https, http), webrick responds with a 400 error (**bad URI `/'.**),  since it is trying parse a URI when the scheme was set to the entire value of that header.  

For example:

```
 $ ruby -run -e httpd . -p 8080
```

```
$ curl localhost:8080 -H "X-Forwarded-Proto: http, https"
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN">
<HTML>
  <HEAD><TITLE>Bad Request</TITLE></HEAD>
  <BODY>
    <H1>Bad Request</H1>
    bad URI `/'.
    <HR>
    <ADDRESS>
     WEBrick/1.3.1 (Ruby/2.3.1/2016-04-26) at
     evilcorp.local:8080
    </ADDRESS>
  </BODY>
</HTML>

```

This PR is a small fix to use the first value in `X-Forwarded-Proto`, if header contains multiple values.