### PR TITLE
In bin/erb keeping 'c' vs. ?c consistent

### DIFF
--- a/bin/erb
+++ b/bin/erb
@@ -13,11 +13,11 @@ class ERB
       return nil if arg == '--'
       case arg
       when /\A-(.)(.*)/
-        if $1 == '-'
-          arg, @maybe_arg = arg.split(/=/, 2)
+        if $1 == ?-
+          arg, @maybe_arg = arg.split( /=/, 2)
           return arg
         end
-        raise 'unknown switch "-"' if $2[0] == ?- and $1 != 'T'
+        raise 'unknown switch "-"' if $2[0] == ?- and $1 != ?T
         if $2.size > 0
           self.unshift "-#{$2}"
           @maybe_arg = $2

--- a/bin/erb
+++ b/bin/erb
@@ -43,12 +43,12 @@ class ERB
       return trim_mode if disable_percent
       case trim_mode
       when 0
-        return '%'
+        return ?%
       when 1
         return '%>'
       when 2
         return '%<>'
-      when '-'
+      when ?-
         return '%-'
       end
     end
@@ -80,7 +80,7 @@ class ERB
             safe_level = arg.to_i
           when '-T'                        # trim mode
             arg = ARGV.req_arg
-            if arg == '-'
+            if arg == ?-
               trim_mode = arg
               next
             end
@@ -98,7 +98,7 @@ class ERB
           when /\A-/
             raise "unknown switch #{switch.dump}"
           else
-            var, val = *switch.split('=', 2)
+            var, val = *switch.split(?=, 2)
             (variables ||= {})[var] = val
           end
         end

--- a/bin/erb
+++ b/bin/erb
@@ -14,7 +14,7 @@ class ERB
       case arg
       when /\A-(.)(.*)/
         if $1 == ?-
-          arg, @maybe_arg = arg.split( /=/, 2)
+          arg, @maybe_arg = arg.split(/=/, 2)
           return arg
         end
         raise 'unknown switch "-"' if $2[0] == ?- and $1 != ?T


### PR DESCRIPTION
In `bin/erb` there are times a char (`'n'` for example) is represented as `?n` and othertimes as `'n'`. I changed all occurrences to `?n` for consistency. 