### PR TITLE
enum.c: sort_by order

### DIFF
--- a/enum.c
+++ b/enum.c
@@ -1086,10 +1086,12 @@ enum_sort_by(int argc, VALUE *argv, VALUE obj)
 	for (j = 0; j < argc; ++j) {
 	    VALUE arg = argv[j];
 	    Check_Type(arg, T_SYMBOL);
-	    if (arg == ID2SYM(rb_intern("ascend"))) {
+	    if (arg == ID2SYM(rb_intern("ascend")) ||
+		arg == ID2SYM(rb_intern("asc"))) {
 		cmp = sort_by_cmp;
 	    }
-	    else if (arg == ID2SYM(rb_intern("descend"))) {
+	    else if (arg == ID2SYM(rb_intern("descend")) ||
+		     arg == ID2SYM(rb_intern("desc"))) {
 		cmp = sort_by_cmp_descend;
 	    }
 	    else {

--- a/enum.c
+++ b/enum.c
@@ -993,6 +993,12 @@ sort_by_cmp(const void *ap, const void *bp, void *data)
     return rb_cmpint(rb_funcall(a, id_cmp, 1, b), a, b);
 }
 
+static int
+sort_by_cmp_descend(const void *ap, const void *bp, void *data)
+{
+    return -sort_by_cmp(ap, bp, data);
+}
+
 /*
  *  call-seq:
  *     enum.sort_by { |obj| block }   -> array
@@ -1065,15 +1071,32 @@ sort_by_cmp(const void *ap, const void *bp, void *data)
  */
 
 static VALUE
-enum_sort_by(VALUE obj)
+enum_sort_by(int argc, VALUE *argv, VALUE obj)
 {
     VALUE ary, buf;
     struct MEMO *memo;
     long i;
     struct sort_by_data *data;
+    int (*cmp)(const void *, const void *, void *) = sort_by_cmp;
 
-    RETURN_SIZED_ENUMERATOR(obj, 0, 0, enum_size);
+    RETURN_SIZED_ENUMERATOR(obj, argc, argv, enum_size);
 
+    if (argc) {
+	int j;
+	for (j = 0; j < argc; ++j) {
+	    VALUE arg = argv[j];
+	    Check_Type(arg, T_SYMBOL);
+	    if (arg == ID2SYM(rb_intern("ascend"))) {
+		cmp = sort_by_cmp;
+	    }
+	    else if (arg == ID2SYM(rb_intern("descend"))) {
+		cmp = sort_by_cmp_descend;
+	    }
+	    else {
+		rb_raise(rb_eArgError, "unknown option: %"PRIsVALUE, arg);
+	    }
+	}
+    }
     if (RB_TYPE_P(obj, T_ARRAY) && RARRAY_LEN(obj) <= LONG_MAX/2) {
 	ary = rb_ary_new2(RARRAY_LEN(obj)*2);
     }
@@ -1099,7 +1122,7 @@ enum_sort_by(VALUE obj)
     if (RARRAY_LEN(ary) > 2) {
 	RARRAY_PTR_USE(ary, ptr,
 		      ruby_qsort(ptr, RARRAY_LEN(ary)/2, 2*sizeof(VALUE),
-				 sort_by_cmp, (void *)ary));
+				 cmp, (void *)ary));
     }
     if (RBASIC(ary)->klass) {
 	rb_raise(rb_eRuntimeError, "sort_by reentered");
@@ -3855,7 +3878,7 @@ Init_Enumerable(void)
     rb_define_method(rb_mEnumerable, "to_h", enum_to_h, -1);
 
     rb_define_method(rb_mEnumerable, "sort", enum_sort, 0);
-    rb_define_method(rb_mEnumerable, "sort_by", enum_sort_by, 0);
+    rb_define_method(rb_mEnumerable, "sort_by", enum_sort_by, -1);
     rb_define_method(rb_mEnumerable, "grep", enum_grep, 1);
     rb_define_method(rb_mEnumerable, "grep_v", enum_grep_v, 1);
     rb_define_method(rb_mEnumerable, "count", enum_count, -1);

--- a/test/ruby/test_enum.rb
+++ b/test/ruby/test_enum.rb
@@ -278,6 +278,12 @@ class TestEnumerable < Test::Unit::TestCase
 
     cond = ->(x, i) { [-x, i] }
     assert_equal([[3, 2], [2, 1], [2, 4], [1, 0], [1, 3]], @obj.each_with_index.sort_by(&cond))
+
+    assert_equal([3, 2, 2, 1, 1], @obj.sort_by(:descend) {|x| x })
+    assert_equal((1..300).to_a.reverse, (1..300).sort_by(:descend) {|x| x })
+
+    cond = ->(x, i) { [x, i] }
+    assert_equal([[3, 2], [2, 4], [2, 1], [1, 3], [1, 0]], @obj.each_with_index.sort_by(:descend, &cond))
   end
 
   def test_all

--- a/test/ruby/test_enum.rb
+++ b/test/ruby/test_enum.rb
@@ -288,12 +288,28 @@ class TestEnumerable < Test::Unit::TestCase
     assert_equal([[3, 2], [2, 1], [2, 4], [1, 0], [1, 3]], @obj.each_with_index.sort_by(:ascend, &cond))
   end
 
+  def test_sort_by_asc
+    assert_equal([3, 2, 2, 1, 1], @obj.sort_by(:asc) {|x| -x })
+    assert_equal((1..300).to_a.reverse, (1..300).sort_by(:asc) {|x| -x })
+
+    cond = ->(x, i) { [-x, i] }
+    assert_equal([[3, 2], [2, 1], [2, 4], [1, 0], [1, 3]], @obj.each_with_index.sort_by(:asc, &cond))
+  end
+
   def test_sort_by_descend
     assert_equal([3, 2, 2, 1, 1], @obj.sort_by(:descend) {|x| x })
     assert_equal((1..300).to_a.reverse, (1..300).sort_by(:descend) {|x| x })
 
     cond = ->(x, i) { [x, i] }
     assert_equal([[3, 2], [2, 4], [2, 1], [1, 3], [1, 0]], @obj.each_with_index.sort_by(:descend, &cond))
+  end
+
+  def test_sort_by_desc
+    assert_equal([3, 2, 2, 1, 1], @obj.sort_by(:desc) {|x| x })
+    assert_equal((1..300).to_a.reverse, (1..300).sort_by(:desc) {|x| x })
+
+    cond = ->(x, i) { [x, i] }
+    assert_equal([[3, 2], [2, 4], [2, 1], [1, 3], [1, 0]], @obj.each_with_index.sort_by(:desc, &cond))
   end
 
   def test_all

--- a/test/ruby/test_enum.rb
+++ b/test/ruby/test_enum.rb
@@ -278,7 +278,17 @@ class TestEnumerable < Test::Unit::TestCase
 
     cond = ->(x, i) { [-x, i] }
     assert_equal([[3, 2], [2, 1], [2, 4], [1, 0], [1, 3]], @obj.each_with_index.sort_by(&cond))
+  end
 
+  def test_sort_by_ascend
+    assert_equal([3, 2, 2, 1, 1], @obj.sort_by(:ascend) {|x| -x })
+    assert_equal((1..300).to_a.reverse, (1..300).sort_by(:ascend) {|x| -x })
+
+    cond = ->(x, i) { [-x, i] }
+    assert_equal([[3, 2], [2, 1], [2, 4], [1, 0], [1, 3]], @obj.each_with_index.sort_by(:ascend, &cond))
+  end
+
+  def test_sort_by_descend
     assert_equal([3, 2, 2, 1, 1], @obj.sort_by(:descend) {|x| x })
     assert_equal((1..300).to_a.reverse, (1..300).sort_by(:descend) {|x| x })
 


### PR DESCRIPTION
- enum.c (enum_sort_by): add optional argument for order.
  [Feature #12648]
