### PR TITLE
V701. realloc() possible leak: when realloc() fails in allocating mem…

### DIFF
--- a/win32/file.c
+++ b/win32/file.c
@@ -166,8 +166,12 @@ code_page_i(st_data_t name, st_data_t idx, st_data_t arg)
 	    if (count <= idx) {
 		unsigned int i = count;
 		count = (((idx + 4) & ~31) | 28);
-		table = realloc(table, count * sizeof(*table));
-		if (!table) return ST_CONTINUE;
+		USHORT *new_table = realloc(table, count * sizeof(*table));
+		if (!new_table) {
+			free(table);
+			return ST_CONTINUE;
+		}
+		table = new_table;
 		cp->count = count;
 		cp->table = table;
 		while (i < count) table[i++] = INVALID_CODE_PAGE;

--- a/win32/file.c
+++ b/win32/file.c
@@ -168,7 +168,6 @@ code_page_i(st_data_t name, st_data_t idx, st_data_t arg)
 		count = (((idx + 4) & ~31) | 28);
 		USHORT *new_table = realloc(table, count * sizeof(*table));
 		if (!new_table) {
-			free(table);
 			return ST_CONTINUE;
 		}
 		table = new_table;


### PR DESCRIPTION
…ory, original pointer is lost. Consider assigning realloc() to a temporary pointer.

Details: http://www.viva64.com/en/examples/V701/