### PR TITLE
Add regex heredoc for consistency.

### DIFF
--- a/doc/syntax/literals.rdoc
+++ b/doc/syntax/literals.rdoc
@@ -221,11 +221,19 @@ quotes:
   p expected_result # prints: "One plus one is \#{1 + 1}\n"
 
 The identifier may also be surrounded with double quotes (which is the same as
-no quotes) or with backticks.  When surrounded by backticks the HEREDOC
-behaves like Kernel#`:
+no quotes), with backticks or with forward slashes.  When surrounded by
+backticks the HEREDOC behaves like the heredoc text was surrounded by backticks
 
   puts <<-`HEREDOC`
   cat #{__FILE__}
+  HEREDOC
+
+When surrounded by forward slashes the HEREDOC creates regular expresion and
+can be followed by switches.
+
+  "0123a bob".match <<-/HEREDOC/x
+[0-9]*[a-z] # search for 0 or more digits followed by one lowercase letter and the word 'bob'
+\sbob
   HEREDOC
 
 To call a method on a heredoc place it after the opening identifier:

--- a/test/ruby/test_syntax.rb
+++ b/test/ruby/test_syntax.rb
@@ -528,7 +528,7 @@ e"
 
   def assert_dedented_heredoc(expect, result, mesg = "")
     all_assertions(mesg) do |a|
-      %w[eos "eos" 'eos' `eos`].each do |eos|
+      %w[eos "eos" 'eos' `eos`, /eos/].each do |eos|
         a.for(eos) do
           assert_equal(eval("<<-#{eos}\n#{expect}eos\n"),
                        eval("<<~#{eos}\n#{result}eos\n"))


### PR DESCRIPTION
While there is a heredoc for \`\` there is no heredoc for //.

For consistency sake I have added heredoc support for `<</HEREDOC/flags`.

There are very few tests for `<<\`HEREDOC\`` and so I did not add many tests for the regexp version.