### PR TITLE
Add Regexp Heredoc support

### DIFF
--- a/doc/syntax/literals.rdoc
+++ b/doc/syntax/literals.rdoc
@@ -221,11 +221,19 @@ quotes:
   p expected_result # prints: "One plus one is \#{1 + 1}\n"
 
 The identifier may also be surrounded with double quotes (which is the same as
-no quotes) or with backticks.  When surrounded by backticks the HEREDOC
-behaves like Kernel#`:
+no quotes), with backticks or with forward slashes.  When surrounded by
+backticks the HEREDOC behaves like the heredoc text was surrounded by backticks
 
   puts <<-`HEREDOC`
   cat #{__FILE__}
+  HEREDOC
+
+When surrounded by forward slashes the HEREDOC creates regular expresion and
+can be followed by switches.
+
+  "0123a bob".match <<-/HEREDOC/x
+[0-9]*[a-z] # search for 0 or more digits followed by one lowercase letter and the word 'bob'
+\sbob
   HEREDOC
 
 To call a method on a heredoc place it after the opening identifier:

--- a/parse.y
+++ b/parse.y
@@ -3925,8 +3925,15 @@ regexp		: tREGEXP_BEG regexp_contents tREGEXP_END
 		    {
 		    /*%%%*/
 			int options = $3;
-			NODE *node = $2;
 			NODE *list, *prev;
+			NODE *node = $2;
+		    /*%
+			VALUE re = $2, opt = $3, src = 0, err;
+			int options = 0;
+		    %*/
+			heredoc_dedent($2);
+			heredoc_indent = 0;
+		    /*%%%*/
 			if (!node) {
 			    node = NEW_LIT(reg_compile(STR_NEW0(), options));
 			}
@@ -3981,8 +3988,6 @@ regexp		: tREGEXP_BEG regexp_contents tREGEXP_END
 			}
 			$$ = node;
 		    /*%
-			VALUE re = $2, opt = $3, src = 0, err;
-			int options = 0;
 			if (ripper_is_node_yylval(re)) {
 			    $2 = RNODE(re)->nd_rval;
 			    src = RNODE(re)->nd_cval;
@@ -6430,6 +6435,11 @@ parser_parse_string(struct parser_params *parser, NODE *quote)
     rb_encoding *enc = current_enc;
 
     if (func == -1) return tSTRING_END;
+    if (func == -2) {
+	set_yylval_num(regx_options());
+	dispatch_scan_event(tREGEXP_END);
+	return tREGEXP_END;
+    }
     c = nextc();
     if ((func & STR_FUNC_QWORDS) && ISSPACE(c)) {
 	do {c = nextc();} while (ISSPACE(c));
@@ -6501,7 +6511,9 @@ parser_heredoc_identifier(struct parser_params *parser)
       case '"':
 	func |= str_dquote; goto quoted;
       case '`':
-	func |= str_xquote;
+	func |= str_xquote; goto quoted;
+      case '/':
+	func |= str_regexp;
       quoted:
 	newtok();
 	tokadd(func);
@@ -6543,7 +6555,7 @@ parser_heredoc_identifier(struct parser_params *parser)
 				  lex_lastline);		/* nd_orig */
     nd_set_line(lex_strterm, ruby_sourceline);
     ripper_flush(parser);
-    return term == '`' ? tXSTRING_BEG : tSTRING_BEG;
+    return term == '`' ? tXSTRING_BEG : term == '/' ? tREGEXP_BEG : tSTRING_BEG;
 }
 
 static void
@@ -6790,6 +6802,11 @@ parser_here_document(struct parser_params *parser, NODE *here)
     if (was_bol() && whole_match_p(eos, len, indent)) {
 	dispatch_heredoc_end();
 	heredoc_restore(lex_strterm);
+	if (func & STR_FUNC_REGEXP) {
+	    set_yylval_num(regx_options());
+	    dispatch_scan_event(tREGEXP_END);
+	    return tREGEXP_END;
+	} // else
 	return tSTRING_END;
     }
 
@@ -6873,7 +6890,11 @@ parser_here_document(struct parser_params *parser, NODE *here)
 			    yylval.val, str);
 #endif
     heredoc_restore(lex_strterm);
-    lex_strterm = NEW_STRTERM(-1, 0, 0);
+    if (func & STR_FUNC_REGEXP) {
+	lex_strterm = NEW_STRTERM(-2, 0, 0);
+    } else {
+	lex_strterm = NEW_STRTERM(-1, 0, 0);
+    }
     set_yylval_str(str);
     return tSTRING_CONTENT;
 }

--- a/test/ruby/test_syntax.rb
+++ b/test/ruby/test_syntax.rb
@@ -832,6 +832,46 @@ eom
     assert_valid_syntax("foo (bar rescue nil)")
   end
 
+  def test_regex_heredoc_x
+    expected = eval("/a\n/x")
+    result = eval("<</eos/x\na\neos")
+    assert_equal(expected, result)
+  end
+
+  def test_regex_heredoc
+    expected = eval("/a\n/")
+    result = eval("<</eos/\na\neos")
+    assert_equal(expected, result)
+  end
+
+  def test_regex_indent_heredoc
+    expected = eval("/  a\n/x")
+    result = eval("  <<-/eos/x\n  a\n  eos")
+    assert_equal(expected, result)
+  end
+
+  def test_regex_deindent_heredoc
+    expected = eval("/a\n b\nc\n/x")
+    result = eval("<<~/eos/x\n  a\n   b\n  c\neos")
+    assert_equal(expected, result)
+  end
+
+  def test_regex_deindent_indented_heredoc
+    expected = eval("/a\n b\nc\n/x")
+    result = eval("  <<~/eos/x\n    a\n     b\n    c\n  eos")
+    assert_equal(expected, result)
+  end
+
+  def test_regex_deindent_indented2_heredoc
+    expected = eval("/  a\n   b\nc\n/x")
+    result = eval("  <<~/eos/x\n      a\n       b\n    c\n  eos")
+    assert_equal(expected, result)
+  end
+
+  def test_regex_heredoc_bad_switch
+    assert_raise(SyntaxError, "bad switch") { eval("<</eos/xz\nbob\neos") }
+  end
+
   private
 
   def not_label(x) @result = x; @not_label ||= nil end


### PR DESCRIPTION
There is a feature request open at: https://bugs.ruby-lang.org/issues/12700

This pull request adds regular expression heredocs to Ruby.

``` ruby
so /match\s # first 
these\s       #second
words         # last
/x
```

can be replaced with

```
<</HEREDOC/x
match\s # first 
these\s       #second
words         # last
HEREDOC

the '-' and '~' indentation works and switches can be applied.

The 'x' switch should be used in most cases.  There is a trailing `\n` applied as in the string heredoc.

```
