### PR TITLE
util.h: POSIX-noncompliant setenv

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -3350,8 +3350,6 @@ ruby_setenv(const char *name, const char *value)
 	invalid_envname(name);
     }
 #elif defined(HAVE_SETENV) && defined(HAVE_UNSETENV)
-#undef setenv
-#undef unsetenv
     if (value) {
 	if (setenv(name, value, 1))
 	    rb_sys_fail_str(rb_sprintf("setenv(%s)", name));

--- a/include/ruby/util.h
+++ b/include/ruby/util.h
@@ -64,10 +64,6 @@ void ruby_qsort(void *, const size_t, const size_t,
 
 void ruby_setenv(const char *, const char *);
 void ruby_unsetenv(const char *);
-#undef setenv
-#undef unsetenv
-#define setenv(name,val) ruby_setenv((name),(val))
-#define unsetenv(name,val) ruby_unsetenv(name)
 
 char *ruby_strdup(const char *);
 #undef strdup


### PR DESCRIPTION
- include/ruby/util.h (setenv): remove POSIX-noncompliant
  definition with 2 arguments.
