### PR TITLE
delegate.rb: don't look for methods on Kernel

### DIFF
--- a/lib/delegate.rb
+++ b/lib/delegate.rb
@@ -81,7 +81,7 @@ class Delegator < BasicObject
 
     if r && target.respond_to?(m)
       target.__send__(m, *args, &block)
-    elsif ::Kernel.respond_to?(m, true)
+    elsif ::Kernel.method_defined?(m) || ::Kernel.private_method_defined?(m)
       ::Kernel.instance_method(m).bind(self).(*args, &block)
     else
       super(m, *args, &block)

--- a/test/test_delegate.rb
+++ b/test/test_delegate.rb
@@ -238,4 +238,11 @@ class TestDelegateClass < Test::Unit::TestCase
   def test_dir_in_delegator_class
     assert_equal(__dir__, Bug9403::DC.dir_name, Bug9403::Name)
   end
+
+  def test_module_methods_vs_kernel_methods
+    delegate = SimpleDelegator.new(Object.new)
+    assert_raise(NoMethodError) do
+      delegate.constants
+    end
+  end
 end


### PR DESCRIPTION
Instead, look for instance methods of Kernel.
Otherwise, instance methods of Module (which are methods of Kernel
itself) are mistakenly believed to exist, and it fails when calling
Kernel.instance_method().

@nobu 
