### PR TITLE
Add support for Windows Nano Server

### DIFF
--- a/ext/win32ole/win32ole.c
+++ b/ext/win32ole/win32ole.c
@@ -50,6 +50,7 @@ static volatile DWORD g_ole_initialized_key = TLS_OUT_OF_INDEXES;
 static BOOL g_uninitialize_hooked = FALSE;
 static BOOL g_cp_installed = FALSE;
 static BOOL g_lcid_installed = FALSE;
+static BOOL g_running_nano = FALSE;
 static HINSTANCE ghhctrl = NULL;
 static HINSTANCE gole32 = NULL;
 static FNCOCREATEINSTANCEEX *gCoCreateInstanceEx = NULL;
@@ -817,16 +818,22 @@ ole_initialize(void)
     }
 
     if(g_ole_initialized == FALSE) {
-        hr = OleInitialize(NULL);
+        if(g_running_nano == TRUE) {
+            hr = CoInitializeEx(NULL, COINIT_MULTITHREADED);
+        } else {
+            hr = OleInitialize(NULL);
+        }
         if(FAILED(hr)) {
             ole_raise(hr, rb_eRuntimeError, "fail: OLE initialize");
         }
         g_ole_initialized_set(TRUE);
 
-        hr = CoRegisterMessageFilter(&imessage_filter, &previous_filter);
-        if(FAILED(hr)) {
-            previous_filter = NULL;
-            ole_raise(hr, rb_eRuntimeError, "fail: install OLE MessageFilter");
+        if(g_running_nano == FALSE) {
+            hr = CoRegisterMessageFilter(&imessage_filter, &previous_filter);
+            if(FAILED(hr)) {
+                previous_filter = NULL;
+                ole_raise(hr, rb_eRuntimeError, "fail: install OLE MessageFilter");
+            }
         }
     }
 }
@@ -3892,10 +3899,29 @@ com_hash_size(const void *ptr)
 }
 
 void
+check_nano_server(void)
+{
+    HKEY hsubkey;
+    LONG err;
+    const char * subkey = "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Server\\ServerLevels";
+    const char * regval = "NanoServer";
+
+    err = RegOpenKeyEx(HKEY_LOCAL_MACHINE, subkey, 0, KEY_READ, &hsubkey);
+    if (err == ERROR_SUCCESS) {
+        err = RegQueryValueEx(hsubkey, regval, NULL, NULL, NULL, NULL);
+        if (err == ERROR_SUCCESS) {
+            g_running_nano = TRUE;
+        }
+        RegCloseKey(hsubkey);
+    }
+}
+
+void
 Init_win32ole(void)
 {
     cWIN32OLE_lcid = LOCALE_SYSTEM_DEFAULT;
     g_ole_initialized_init();
+    check_nano_server();
 
     com_vtbl.QueryInterface = QueryInterface;
     com_vtbl.AddRef = AddRef;


### PR DESCRIPTION
Windows Nano does not support apartment theaded concurrency in its COM libraries. However, multi threaded concurrency is supported. The technical preview of nano available at the time of this submission (TP5), contains a hack in its win32ole.dll forwarder that causes calls to `OleInitialize` which normally call `CoInitializeEx` with `STA` to use `MTA` instead. This hack will be removed from the final RTM Windows nano and cause all calls to `require 'win32ole'` to fail

@alexpilotti, on behalf of microsoft,  suggested a change to https://github.com/ruby/ruby/blob/32674b167bddc0d737c38f84722986b0f228b44b/ext/win32ole/win32ole.c#L820-L830:

```
       hr = CoInitializeEx(NULL, COINIT_MULTITHREADED);
        if(FAILED(hr)) {
            ole_raise(hr, rb_eRuntimeError, "fail: OLE initialize");
        }
        g_ole_initialized_set(TRUE);
```

I have confirmed that this does work with the TP5 hack removed.

I have added a check to determine if ruby is running on nano so that the above code will only be used on nano. I anticipate the vast majority of usages of win32ole would be fine with this implementation and only certain multithreaded scenarios might experience unexpected results. However it seems best to preserve the current behavior for all non nano environments.

Note that I am not a c++ developer but I have done my best to comply with the conventions of the win32ole.c code. I have added static flags to prevent registry lookups on every call. If there is a cleaner approach, I'd be happy to tweak accordingly.
