### PR TITLE
Update rfc2396_parser.rb

### DIFF
--- a/lib/uri/rfc2396_parser.rb
+++ b/lib/uri/rfc2396_parser.rb
@@ -298,6 +298,7 @@ module URI
     # replacing them with codes.
     #
     def escape(str, unsafe = @regexp[:UNSAFE])
+      return "" unless str # str = nil
       unless unsafe.kind_of?(Regexp)
         # perhaps unsafe is String object
         unsafe = Regexp.new("[#{Regexp.quote(unsafe)}]", false)


### PR DESCRIPTION
```ruby
str = nil
URI.escape(str) 
=>  NoMethodError: undefined method `gsub' for nil:NilClass
```