### PR TITLE
Improve same directory detection in FileUtils

### DIFF
--- a/lib/fileutils.rb
+++ b/lib/fileutils.rb
@@ -1435,10 +1435,13 @@ module FileUtils
     else
       DIRECTORY_TERM = "(?=/|\\z)".freeze
     end
-    SYSCASE = File::FNM_SYSCASE.nonzero? ? "-i" : ""
 
     def descendant_directory?(descendant, ascendant)
-      /\A(?#{SYSCASE}:#{Regexp.quote(ascendant)})#{DIRECTORY_TERM}/ =~ File.dirname(descendant)
+      if File::FNM_SYSCASE.nonzero?
+        File.expand_path(File.dirname(descendant)).casecmp(File.expand_path(ascendant)) == 0
+      else
+        File.expand_path(File.dirname(descendant)) == File.expand_path(ascendant)
+      end
     end
   end   # class Entry_
 

--- a/test/fileutils/test_fileutils.rb
+++ b/test/fileutils/test_fileutils.rb
@@ -353,6 +353,16 @@ class TestFileUtils < Test::Unit::TestCase
     assert_same_file 'tmp/cpr_src/b', 'tmp/cpr_dest/b'
     assert_same_file 'tmp/cpr_src/c', 'tmp/cpr_dest/c'
     assert_directory 'tmp/cpr_dest/d'
+    assert_raise(ArgumentError) do
+      cp_r 'tmp/cpr_src', './tmp/cpr_src'
+    end
+    assert_raise(ArgumentError) do
+      cp_r './tmp/cpr_src', 'tmp/cpr_src'
+    end
+    assert_raise(ArgumentError) do
+      cp_r './tmp/cpr_src', File.expand_path('tmp/cpr_src')
+    end
+
     my_rm_rf 'tmp/cpr_src'
     my_rm_rf 'tmp/cpr_dest'
 


### PR DESCRIPTION
`FileUtils.cp_r` does not detect copying a directory to itself if either the source or destination contains a dot (`.`). Depending on order and platform, this can cause different errors like `File name too long` or `unknown file type` or just stack overflow.

This patch changes the current dynamic regex approach to comparing absolute paths.

The test commands in the Travis CI config did not show test failure for me, but `make test-all TESTOPTS="-q -- test/fileutils/test_fileutils.rb"` with the new tests but without the changes to `descendant_directory?` shows the failure clearly.

Example of not detecting same directory:
<details>
  <summary>

Click for example</summary>



```
2.3.1 :001 > require 'fileutils'
 => true 
2.3.1 :002 > FileUtils.cp_r 'test_rec', './test_rec'
Errno::ENAMETOOLONG: File name too long @ dir_s_mkdir - ./test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec/test_rec
    from /home/justin/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/fileutils.rb:1366:in `mkdir'
    from /home/justin/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/fileutils.rb:1366:in `copy'
    from /home/justin/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/fileutils.rb:472:in `block in copy_entry'
    from /home/justin/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/fileutils.rb:1498:in `wrap_traverse'
    from /home/justin/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/fileutils.rb:1501:in `block in wrap_traverse'
    from /home/justin/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/fileutils.rb:1500:in `each'
    from /home/justin/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/fileutils.rb:1500:in `wrap_traverse'
    from /home/justin/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/fileutils.rb:1501:in `block in wrap_traverse'
    from /home/justin/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/fileutils.rb:1500:in `each'
    from /home/justin/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/fileutils.rb:1500:in `wrap_traverse'
    from /home/justin/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/fileutils.rb:1501:in `block in wrap_traverse'
    from /home/justin/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/fileutils.rb:1500:in `each'
    from /home/justin/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/fileutils.rb:1500:in `wrap_traverse'
    from /home/justin/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/fileutils.rb:1501:in `block in wrap_traverse'
    from /home/justin/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/fileutils.rb:1500:in `each'
    from /home/justin/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/fileutils.rb:1500:in `wrap_traverse'
... 1339 levels...
    from /home/justin/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/fileutils.rb:1500:in `each'
    from /home/justin/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/fileutils.rb:1500:in `wrap_traverse'
    from /home/justin/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/fileutils.rb:1501:in `block in wrap_traverse'
    from /home/justin/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/fileutils.rb:1500:in `each'
    from /home/justin/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/fileutils.rb:1500:in `wrap_traverse'
    from /home/justin/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/fileutils.rb:1501:in `block in wrap_traverse'
    from /home/justin/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/fileutils.rb:1500:in `each'
    from /home/justin/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/fileutils.rb:1500:in `wrap_traverse'
    from /home/justin/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/fileutils.rb:469:in `copy_entry'
    from /home/justin/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/fileutils.rb:444:in `block in cp_r'
    from /home/justin/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/fileutils.rb:1571:in `block in fu_each_src_dest'
    from /home/justin/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/fileutils.rb:1585:in `fu_each_src_dest0'
    from /home/justin/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/fileutils.rb:1569:in `fu_each_src_dest'
    from /home/justin/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/fileutils.rb:443:in `cp_r'
    from (irb):2
    from /home/justin/.rvm/rubies/ruby-2.3.1/bin/irb:11:in `<main>'
```

</details>
