### PR TITLE
Increase test coverage for URI::MailTo

### DIFF
--- a/lib/uri/mailto.rb
+++ b/lib/uri/mailto.rb
@@ -84,7 +84,7 @@ module URI
     #    puts m3.to_s  ->  mailto:listman@example.com?subject=subscribe
     #
     def self.build(args)
-      tmp = Util::make_components_hash(self, args)
+      tmp = Util.make_components_hash(self, args)
 
       case tmp[:to]
       when Array
@@ -118,7 +118,7 @@ module URI
         end
       end
 
-      return super(tmp)
+      super(tmp)
     end
 
     #
@@ -187,7 +187,7 @@ module URI
         end
       end
 
-      return true
+      true
     end
     private :check_to
 
@@ -214,7 +214,7 @@ module URI
           "bad component(expected opaque component): #{v}"
       end
 
-      return true
+      true
     end
     private :check_headers
 
@@ -282,7 +282,7 @@ module URI
         end
       end
 
-      return "To: #{to}
+      "To: #{to}
 #{head}
 #{body}
 "


### PR DESCRIPTION
Reference to https://bugs.ruby-lang.org/issues/12750 issue

### Trunk
![screenshot 2016-09-11 18 49 17](https://cloud.githubusercontent.com/assets/1147484/18418533/6335eb62-7859-11e6-8b57-eb5176850d5e.jpg)

### Current patch
![screenshot 2016-09-11 18 49 24](https://cloud.githubusercontent.com/assets/1147484/18418535/68ca08b0-7859-11e6-949b-dac1c2a97165.jpg)