### PR TITLE
Add a secondary heap

### DIFF
--- a/class.c
+++ b/class.c
@@ -162,7 +162,7 @@ rb_class_detach_module_subclasses(VALUE klass)
 static VALUE
 class_alloc(VALUE flags, VALUE klass)
 {
-    NEWOBJ_OF(obj, struct RClass, klass, (flags & T_MASK) | FL_PROMOTED1 /* start from age == 2 */ | (RGENGC_WB_PROTECTED_CLASS ? FL_WB_PROTECTED : 0));
+    NEW_OLDISH_OBJ_OF(obj, struct RClass, klass, (flags & T_MASK) | FL_PROMOTED1 /* start from age == 2 */ | (RGENGC_WB_PROTECTED_CLASS ? FL_WB_PROTECTED : 0));
     obj->ptr = ZALLOC(rb_classext_t);
     /* ZALLOC
       RCLASS_IV_TBL(obj) = 0;

--- a/class.c
+++ b/class.c
@@ -162,7 +162,7 @@ rb_class_detach_module_subclasses(VALUE klass)
 static VALUE
 class_alloc(VALUE flags, VALUE klass)
 {
-    NEW_OLDISH_OBJ_OF(obj, struct RClass, klass, (flags & T_MASK) | FL_PROMOTED1 /* start from age == 2 */ | (RGENGC_WB_PROTECTED_CLASS ? FL_WB_PROTECTED : 0));
+    NEW_TCLASS_OBJ_OF(obj, struct RClass, klass, (flags & T_MASK) | FL_PROMOTED1 /* start from age == 2 */ | (RGENGC_WB_PROTECTED_CLASS ? FL_WB_PROTECTED : 0));
     obj->ptr = ZALLOC(rb_classext_t);
     /* ZALLOC
       RCLASS_IV_TBL(obj) = 0;

--- a/gc.c
+++ b/gc.c
@@ -527,6 +527,7 @@ typedef struct rb_objspace {
     size_t total_allocated_objects;
 
     rb_heap_t eden_heap;
+    rb_heap_t oldish_heap;
     rb_heap_t tomb_heap; /* heap for zombies and ghosts */
 
     struct {
@@ -732,6 +733,7 @@ VALUE *ruby_initial_gc_stress_ptr = &ruby_initial_gc_stress;
 #define heap_pages_final_slots		objspace->heap_pages.final_slots
 #define heap_pages_deferred_final	objspace->heap_pages.deferred_final
 #define heap_eden               (&objspace->eden_heap)
+#define heap_oldish             (&objspace->oldish_heap)
 #define heap_tomb               (&objspace->tomb_heap)
 #define dont_gc 		objspace->flags.dont_gc
 #define during_gc		objspace->flags.during_gc
@@ -1320,7 +1322,7 @@ static void heap_page_free(rb_objspace_t *objspace, struct heap_page *page);
 void
 rb_objspace_free(rb_objspace_t *objspace)
 {
-    if (is_lazy_sweeping(heap_eden))
+    if (is_lazy_sweeping(heap_eden) || is_lazy_sweeping(heap_oldish))
 	rb_bug("lazy sweeping underway when freeing object space");
 
     if (objspace->profile.records) {
@@ -1349,6 +1351,9 @@ rb_objspace_free(rb_objspace_t *objspace)
 	objspace->eden_heap.total_pages = 0;
 	objspace->eden_heap.total_slots = 0;
 	objspace->eden_heap.pages = NULL;
+	objspace->oldish_heap.total_pages = 0;
+	objspace->oldish_heap.total_slots = 0;
+	objspace->oldish_heap.pages = NULL;
     }
     free_stack_chunks(&objspace->mark_stack);
 #if !(defined(ENABLE_VM_OBJSPACE) && ENABLE_VM_OBJSPACE)
@@ -1362,6 +1367,7 @@ heap_pages_expand_sorted(rb_objspace_t *objspace)
 {
     size_t next_length = heap_allocatable_pages;
     next_length += heap_eden->total_pages;
+    next_length += heap_oldish->total_pages;
     next_length += heap_tomb->total_pages;
 
     if (next_length > heap_pages_sorted_length) {
@@ -1647,7 +1653,7 @@ heap_extend_pages(rb_objspace_t *objspace, size_t free_slots, size_t total_slots
 static void
 heap_set_increment(rb_objspace_t *objspace, size_t additional_pages)
 {
-    size_t used = heap_eden->total_pages;
+    size_t used = heap_eden->total_pages + heap_oldish->total_pages;
     size_t next_used_limit = used + additional_pages;
 
     if (next_used_limit == heap_allocated_pages) next_used_limit++;
@@ -1933,6 +1939,12 @@ VALUE
 rb_newobj(void)
 {
     return newobj_of(0, T_NONE, 0, 0, 0, FALSE);
+}
+
+VALUE
+rb_new_oldish_obj_of(VALUE klass, VALUE flags)
+{
+    return newobj_of(klass, flags & ~FL_WB_PROTECTED, 0, 0, 0, flags & FL_WB_PROTECTED);
 }
 
 VALUE
@@ -2315,6 +2327,7 @@ Init_heap(void)
 #endif
 
     heap_add_pages(objspace, heap_eden, gc_params.heap_init_slots / HEAP_PAGE_OBJ_LIMIT);
+    heap_add_pages(objspace, heap_oldish, gc_params.heap_init_slots / HEAP_PAGE_OBJ_LIMIT);
     init_mark_stack(&objspace->mark_stack);
 
 #ifdef USE_SIGALTSTACK
@@ -2936,7 +2949,7 @@ heap_is_swept_object(rb_objspace_t *objspace, rb_heap_t *heap, VALUE ptr)
 static inline int
 is_swept_object(rb_objspace_t *objspace, VALUE ptr)
 {
-    if (heap_is_swept_object(objspace, heap_eden, ptr)) {
+    if (heap_is_swept_object(objspace, heap_eden, ptr) || heap_is_swept_object(objspace, heap_oldish, ptr)) {
 	return TRUE;
     }
     else {
@@ -2949,6 +2962,7 @@ static inline int
 is_garbage_object(rb_objspace_t *objspace, VALUE ptr)
 {
     if (!is_lazy_sweeping(heap_eden) ||
+	!is_lazy_sweeping(heap_oldish) ||
 	is_swept_object(objspace, ptr) ||
 	MARKED_IN_BITMAP(GET_HEAP_MARK_BITS(ptr), ptr)) {
 
@@ -3386,7 +3400,7 @@ count_objects(int argc, VALUE *argv, VALUE os)
 static size_t
 objspace_available_slots(rb_objspace_t *objspace)
 {
-    return heap_eden->total_slots + heap_tomb->total_slots;
+    return heap_eden->total_slots + heap_tomb->total_slots + heap_oldish->total_slots;
 }
 
 static size_t
@@ -3573,6 +3587,7 @@ gc_sweep_start(rb_objspace_t *objspace)
 {
     gc_mode_transition(objspace, gc_mode_sweeping);
     gc_sweep_start_heap(objspace, heap_eden);
+    gc_sweep_start_heap(objspace, heap_oldish);
 }
 
 static void
@@ -3670,6 +3685,12 @@ gc_sweep_rest(rb_objspace_t *objspace)
     while (has_sweeping_pages(heap)) {
 	gc_sweep_step(objspace, heap);
     }
+
+    heap = heap_oldish;
+
+    while (has_sweeping_pages(heap)) {
+	gc_sweep_step(objspace, heap);
+    }
 }
 
 #if GC_ENABLE_LAZY_SWEEP
@@ -3690,6 +3711,17 @@ gc_sweep_continue(rb_objspace_t *objspace, rb_heap_t *heap)
 #endif
 
 static void
+gc_mark_before_sweep(rb_heap_t *heap)
+{
+    struct heap_page *page;
+    page = heap->sweep_pages;
+    while (page) {
+	page->flags.before_sweep = TRUE;
+	page = page->next;
+    }
+}
+
+static void
 gc_sweep(rb_objspace_t *objspace)
 {
     const unsigned int immediate_sweep = objspace->flags.immediate_sweep;
@@ -3707,17 +3739,15 @@ gc_sweep(rb_objspace_t *objspace)
 #endif
     }
     else {
-	struct heap_page *page;
 	gc_sweep_start(objspace);
-	page = heap_eden->sweep_pages;
-	while (page) {
-	    page->flags.before_sweep = TRUE;
-	    page = page->next;
-	}
+	gc_mark_before_sweep(heap_eden);
+	gc_mark_before_sweep(heap_oldish);
 	gc_sweep_step(objspace, heap_eden);
+	gc_sweep_step(objspace, heap_oldish);
     }
 
     gc_heap_prepare_minimum_pages(objspace, heap_eden);
+    gc_heap_prepare_minimum_pages(objspace, heap_oldish);
 }
 
 /* Marking - Marking stack */
@@ -5183,6 +5213,7 @@ gc_verify_heap_pages(rb_objspace_t *objspace)
 {
     int rememberd_old_objects = 0;
     rememberd_old_objects = gc_verify_heap_pages_(objspace, heap_eden->pages);
+    rememberd_old_objects = gc_verify_heap_pages_(objspace, heap_oldish->pages);
     rememberd_old_objects = gc_verify_heap_pages_(objspace, heap_tomb->pages);
     return rememberd_old_objects;
 }
@@ -5227,7 +5258,7 @@ gc_verify_internal_consistency(VALUE dummy)
 
     /* check counters */
 
-    if (!is_lazy_sweeping(heap_eden) && !finalizing) {
+    if ((!is_lazy_sweeping(heap_eden) || !is_lazy_sweeping(heap_oldish)) && !finalizing) {
 	if (objspace_live_slots(objspace) != data.live_object_count) {
 	    fprintf(stderr, "heap_pages_final_slots: %d, objspace->profile.total_freed_objects: %d\n",
 		    (int)heap_pages_final_slots, (int)objspace->profile.total_freed_objects);
@@ -5305,6 +5336,7 @@ gc_marks_start(rb_objspace_t *objspace, int full_mark)
 	objspace->rgengc.last_major_gc = objspace->profile.count;
 	objspace->marked_slots = 0;
 	rgengc_mark_and_rememberset_clear(objspace, heap_eden);
+	rgengc_mark_and_rememberset_clear(objspace, heap_oldish);
     }
     else {
 	objspace->flags.during_minor_gc = TRUE;
@@ -5312,6 +5344,7 @@ gc_marks_start(rb_objspace_t *objspace, int full_mark)
 	  objspace->rgengc.old_objects + objspace->rgengc.uncollectible_wb_unprotected_objects; /* uncollectible objects are marked already */
 	objspace->profile.minor_gc_count++;
 	rgengc_rememberset_mark(objspace, heap_eden);
+	rgengc_rememberset_mark(objspace, heap_oldish);
     }
 #endif
 
@@ -5322,9 +5355,9 @@ gc_marks_start(rb_objspace_t *objspace, int full_mark)
 
 #if GC_ENABLE_INCREMENTAL_MARK
 static void
-gc_marks_wb_unprotected_objects(rb_objspace_t *objspace)
+gc_marks_wb_unprotected_objects(rb_objspace_t *objspace, rb_heap_t *heap)
 {
-    struct heap_page *page = heap_eden->pages;
+    struct heap_page *page = heap->pages;
 
     while (page) {
 	bits_t *mark_bits = page->mark_bits;
@@ -5387,6 +5420,12 @@ gc_marks_finish(rb_objspace_t *objspace)
 	    return FALSE; /* continue marking phase */
 	}
 
+	if (heap_oldish->pooled_pages) {
+	    heap_move_pooled_pages_to_free_pages(heap_oldish);
+	    gc_report(1, objspace, "gc_marks_finish: pooled pages are exists. retry.\n");
+	    return FALSE; /* continue marking phase */
+	}
+
 	if (RGENGC_CHECK_MODE && is_mark_stack_empty(&objspace->mark_stack) == 0) {
 	    rb_bug("gc_marks_finish: mark stack is not empty (%d).", (int)mark_stack_size(&objspace->mark_stack));
 	}
@@ -5406,7 +5445,8 @@ gc_marks_finish(rb_objspace_t *objspace)
 
 	objspace->flags.during_incremental_marking = FALSE;
 	/* check children of all marked wb-unprotected objects */
-	gc_marks_wb_unprotected_objects(objspace);
+	gc_marks_wb_unprotected_objects(objspace, heap_eden);
+	gc_marks_wb_unprotected_objects(objspace, heap_oldish);
     }
 #endif /* GC_ENABLE_INCREMENTAL_MARK */
 
@@ -5430,14 +5470,15 @@ gc_marks_finish(rb_objspace_t *objspace)
     {
 	/* decide full GC is needed or not */
 	rb_heap_t *heap = heap_eden;
-	size_t total_slots = heap_allocatable_pages * HEAP_PAGE_OBJ_LIMIT + heap->total_slots;
+	rb_heap_t *oheap = heap_oldish;
+	size_t total_slots = heap_allocatable_pages * HEAP_PAGE_OBJ_LIMIT + heap->total_slots + oheap->total_slots;
 	size_t sweep_slots = total_slots - objspace->marked_slots; /* will be swept slots */
 	size_t max_free_slots = (size_t)(total_slots * gc_params.heap_free_slots_max_ratio);
 	size_t min_free_slots = (size_t)(total_slots * gc_params.heap_free_slots_min_ratio);
 	int full_marking = is_full_marking(objspace);
 
 #if RGENGC_CHECK_MODE
-	assert(heap->total_slots >= objspace->marked_slots);
+	assert((heap->total_slots + oheap->total_slots) >= objspace->marked_slots);
 #endif
 
 	/* setup free-able page counts */
@@ -5531,6 +5572,7 @@ gc_marks_rest(rb_objspace_t *objspace)
 
 #if GC_ENABLE_INCREMENTAL_MARK
     heap_eden->pooled_pages = NULL;
+    heap_oldish->pooled_pages = NULL;
 #endif
 
     if (is_incremental_marking(objspace)) {
@@ -5634,7 +5676,7 @@ gc_report_body(int level, rb_objspace_t *objspace, const char *fmt, ...)
 	    status = is_full_marking(objspace) ? "+" : "-";
 	}
 	else {
-	    if (is_lazy_sweeping(heap_eden)) {
+	    if (is_lazy_sweeping(heap_eden) || is_lazy_sweeping(heap_oldish)) {
 		status = "S";
 	    }
 	    if (is_incremental_marking(objspace)) {
@@ -6214,6 +6256,7 @@ ready_to_gc(rb_objspace_t *objspace)
 {
     if (dont_gc || during_gc || ruby_disable_gc) {
 	heap_ready_to_gc(objspace, heap_eden);
+	heap_ready_to_gc(objspace, heap_oldish);
 	return FALSE;
     }
     else {
@@ -6318,6 +6361,7 @@ gc_start(rb_objspace_t *objspace, const int full_mark, const int immediate_mark,
     if (RGENGC_CHECK_MODE) {
 	assert(gc_mode(objspace) == gc_mode_none);
 	assert(!is_lazy_sweeping(heap_eden));
+	assert(!is_lazy_sweeping(heap_oldish));
 	assert(!is_incremental_marking(objspace));
 #if RGENGC_CHECK_MODE >= 2
 	gc_verify_internal_consistency(Qnil);
@@ -6397,7 +6441,7 @@ static void
 gc_rest(rb_objspace_t *objspace)
 {
     int marking = is_incremental_marking(objspace);
-    int sweeping = is_lazy_sweeping(heap_eden);
+    int sweeping = is_lazy_sweeping(heap_eden) || is_lazy_sweeping(heap_oldish);
 
     if (marking || sweeping) {
 	gc_enter(objspace, "gc_rest");
@@ -6409,7 +6453,7 @@ gc_rest(rb_objspace_t *objspace)
 	    gc_marks_rest(objspace);
 	    POP_MARK_FUNC_DATA();
 	}
-	if (is_lazy_sweeping(heap_eden)) {
+	if (is_lazy_sweeping(heap_eden) || is_lazy_sweeping(heap_oldish)) {
 	    gc_sweep_rest(objspace);
 	}
 	gc_exit(objspace, "gc_rest");
@@ -6439,7 +6483,7 @@ gc_current_status_fill(rb_objspace_t *objspace, char *buff)
     }
     else if (is_sweeping(objspace)) {
 	buff[i++] = 'S';
-	if (is_lazy_sweeping(heap_eden))      buff[i++] = 'L';
+	if (is_lazy_sweeping(heap_eden) || is_lazy_sweeping(heap_oldish))      buff[i++] = 'L';
     }
     else {
 	buff[i++] = 'N';
@@ -6824,6 +6868,7 @@ enum gc_stat_sym {
     gc_stat_sym_heap_final_slots,
     gc_stat_sym_heap_marked_slots,
     gc_stat_sym_heap_eden_pages,
+    gc_stat_sym_heap_oldish_pages,
     gc_stat_sym_heap_tomb_pages,
     gc_stat_sym_total_allocated_pages,
     gc_stat_sym_total_freed_pages,
@@ -6857,6 +6902,7 @@ enum gc_stat_sym {
 enum gc_stat_compat_sym {
     gc_stat_compat_sym_gc_stat_heap_used,
     gc_stat_compat_sym_heap_eden_page_length,
+    gc_stat_compat_sym_heap_oldish_page_length,
     gc_stat_compat_sym_heap_tomb_page_length,
     gc_stat_compat_sym_heap_increment,
     gc_stat_compat_sym_heap_length,
@@ -6900,6 +6946,7 @@ setup_gc_stat_symbols(void)
 	S(heap_final_slots);
 	S(heap_marked_slots);
 	S(heap_eden_pages);
+	S(heap_oldish_pages);
 	S(heap_tomb_pages);
 	S(total_allocated_pages);
 	S(total_freed_pages);
@@ -6931,6 +6978,7 @@ setup_gc_stat_symbols(void)
 #define S(s) gc_stat_compat_symbols[gc_stat_compat_sym_##s] = ID2SYM(rb_intern_const(#s))
 	S(gc_stat_heap_used);
 	S(heap_eden_page_length);
+	S(heap_oldish_page_length);
 	S(heap_tomb_page_length);
 	S(heap_increment);
 	S(heap_length);
@@ -6964,6 +7012,7 @@ setup_gc_stat_symbols(void)
 #define NEW_SYM(s) gc_stat_symbols[gc_stat_sym_##s]
 	    rb_hash_aset(table, OLD_SYM(gc_stat_heap_used), NEW_SYM(heap_allocated_pages));
 	    rb_hash_aset(table, OLD_SYM(heap_eden_page_length), NEW_SYM(heap_eden_pages));
+	    rb_hash_aset(table, OLD_SYM(heap_oldish_page_length), NEW_SYM(heap_oldish_pages));
 	    rb_hash_aset(table, OLD_SYM(heap_tomb_page_length), NEW_SYM(heap_tomb_pages));
 	    rb_hash_aset(table, OLD_SYM(heap_increment), NEW_SYM(heap_allocatable_pages));
 	    rb_hash_aset(table, OLD_SYM(heap_length), NEW_SYM(heap_sorted_length));
@@ -7072,6 +7121,7 @@ gc_stat_internal(VALUE hash_or_sym)
     SET(heap_final_slots, heap_pages_final_slots);
     SET(heap_marked_slots, objspace->marked_slots);
     SET(heap_eden_pages, heap_eden->total_pages);
+    SET(heap_oldish_pages, heap_oldish->total_pages);
     SET(heap_tomb_pages, heap_tomb->total_pages);
     SET(total_allocated_pages, objspace->profile.total_allocated_pages);
     SET(total_freed_pages, objspace->profile.total_freed_pages);
@@ -7146,6 +7196,7 @@ gc_stat_internal(VALUE hash_or_sym)
  *          :heap_final_slots=>0,
  *          :heap_marked_slots=>0,
  *          :heap_eden_pages=>24,
+ *          :heap_oldish_pages=>24,
  *          :heap_tomb_pages=>0,
  *          :total_allocated_pages=>24,
  *          :total_freed_pages=>0,
@@ -7406,6 +7457,7 @@ gc_set_initial_pages(void)
     if (min_pages > heap_eden->total_pages) {
 	heap_add_pages(objspace, heap_eden, min_pages - heap_eden->total_pages);
     }
+    heap_add_pages(objspace, heap_oldish, 10);
 }
 
 /*
@@ -7724,7 +7776,7 @@ objspace_malloc_increase(rb_objspace_t *objspace, void *mem, size_t new_size, si
     if (type == MEMOP_TYPE_MALLOC) {
       retry:
 	if (malloc_increase > malloc_limit && ruby_native_thread_p() && !dont_gc) {
-	    if (ruby_thread_has_gvl_p() && is_lazy_sweeping(heap_eden)) {
+	    if (ruby_thread_has_gvl_p() && (is_lazy_sweeping(heap_eden) || is_lazy_sweeping(heap_oldish))) {
 		gc_rest(objspace); /* gc_rest can reduce malloc_increase */
 		goto retry;
 	    }
@@ -9377,7 +9429,7 @@ rb_gcdebug_print_obj_condition(VALUE obj)
     fprintf(stderr, "remembered?  : %s\n", RVALUE_REMEMBERED(obj) ? "true" : "false");
 #endif
 
-    if (is_lazy_sweeping(heap_eden)) {
+    if (is_lazy_sweeping(heap_eden) || is_lazy_sweeping(heap_oldish)) {
         fprintf(stderr, "lazy sweeping?: true\n");
         fprintf(stderr, "swept?: %s\n", is_swept_object(objspace, obj) ? "done" : "not yet");
     }

--- a/include/ruby/ruby.h
+++ b/include/ruby/ruby.h
@@ -737,9 +737,11 @@ VALUE rb_newobj(void);
 VALUE rb_newobj_of(VALUE, VALUE);
 VALUE rb_obj_setup(VALUE obj, VALUE klass, VALUE type);
 #define RB_NEWOBJ(obj,type) type *(obj) = (type*)rb_newobj()
-#define RB_NEWOBJ_OF(obj,type,klass,flags) type *(obj) = (type*)rb_newobj_of(klass, flags)
+#define RB_NEWOBJ_OF(obj,type,klass,flags) type *(obj) = (type*)rb_new_oldish_obj_of(klass, flags)
+#define RB_NEW_OLDISH_OBJ_OF(obj,type,klass,flags) type *(obj) = (type*)rb_newobj_of(klass, flags)
 #define NEWOBJ(obj,type) RB_NEWOBJ(obj,type)
 #define NEWOBJ_OF(obj,type,klass,flags) RB_NEWOBJ_OF(obj,type,klass,flags) /* core has special NEWOBJ_OF() in internal.h */
+#define NEW_OLDISH_OBJ_OF(obj,type,klass,flags) RB_NEW_OLDISH_OBJ_OF(obj,type,klass,flags) /* core has special NEWOBJ_OF() in internal.h */
 #define OBJSETUP(obj,c,t) rb_obj_setup(obj, c, t) /* use NEWOBJ_OF instead of NEWOBJ()+OBJSETUP() */
 #define CLONESETUP(clone,obj) rb_clone_setup(clone,obj)
 #define DUPSETUP(dup,obj) rb_dup_setup(dup,obj)

--- a/include/ruby/ruby.h
+++ b/include/ruby/ruby.h
@@ -735,10 +735,11 @@ VALUE rb_int2big(SIGNED_VALUE);
 
 VALUE rb_newobj(void);
 VALUE rb_newobj_of(VALUE, VALUE);
+VALUE rb_new_oldish_obj_of(VALUE, VALUE);
 VALUE rb_obj_setup(VALUE obj, VALUE klass, VALUE type);
 #define RB_NEWOBJ(obj,type) type *(obj) = (type*)rb_newobj()
-#define RB_NEWOBJ_OF(obj,type,klass,flags) type *(obj) = (type*)rb_new_oldish_obj_of(klass, flags)
-#define RB_NEW_OLDISH_OBJ_OF(obj,type,klass,flags) type *(obj) = (type*)rb_newobj_of(klass, flags)
+#define RB_NEWOBJ_OF(obj,type,klass,flags) type *(obj) = (type*)rb_newobj_of(klass, flags)
+#define RB_NEW_OLDISH_OBJ_OF(obj,type,klass,flags) type *(obj) = (type*)rb_new_oldish_obj_of(klass, flags)
 #define NEWOBJ(obj,type) RB_NEWOBJ(obj,type)
 #define NEWOBJ_OF(obj,type,klass,flags) RB_NEWOBJ_OF(obj,type,klass,flags) /* core has special NEWOBJ_OF() in internal.h */
 #define NEW_OLDISH_OBJ_OF(obj,type,klass,flags) RB_NEW_OLDISH_OBJ_OF(obj,type,klass,flags) /* core has special NEWOBJ_OF() in internal.h */

--- a/include/ruby/ruby.h
+++ b/include/ruby/ruby.h
@@ -735,14 +735,14 @@ VALUE rb_int2big(SIGNED_VALUE);
 
 VALUE rb_newobj(void);
 VALUE rb_newobj_of(VALUE, VALUE);
-VALUE rb_new_oldish_obj_of(VALUE, VALUE);
+VALUE rb_new_tclass_obj_of(VALUE, VALUE);
 VALUE rb_obj_setup(VALUE obj, VALUE klass, VALUE type);
 #define RB_NEWOBJ(obj,type) type *(obj) = (type*)rb_newobj()
 #define RB_NEWOBJ_OF(obj,type,klass,flags) type *(obj) = (type*)rb_newobj_of(klass, flags)
-#define RB_NEW_OLDISH_OBJ_OF(obj,type,klass,flags) type *(obj) = (type*)rb_new_oldish_obj_of(klass, flags)
+#define RB_NEW_TCLASS_OBJ_OF(obj,type,klass,flags) type *(obj) = (type*)rb_new_tclass_obj_of(klass, flags)
 #define NEWOBJ(obj,type) RB_NEWOBJ(obj,type)
 #define NEWOBJ_OF(obj,type,klass,flags) RB_NEWOBJ_OF(obj,type,klass,flags) /* core has special NEWOBJ_OF() in internal.h */
-#define NEW_OLDISH_OBJ_OF(obj,type,klass,flags) RB_NEW_OLDISH_OBJ_OF(obj,type,klass,flags) /* core has special NEWOBJ_OF() in internal.h */
+#define NEW_TCLASS_OBJ_OF(obj,type,klass,flags) RB_NEW_TCLASS_OBJ_OF(obj,type,klass,flags) /* core has special NEWOBJ_OF() in internal.h */
 #define OBJSETUP(obj,c,t) rb_obj_setup(obj, c, t) /* use NEWOBJ_OF instead of NEWOBJ()+OBJSETUP() */
 #define CLONESETUP(clone,obj) rb_clone_setup(clone,obj)
 #define DUPSETUP(dup,obj) rb_dup_setup(dup,obj)


### PR DESCRIPTION
This PR adds a secondary heap to `objspace`.  It's currently called the "tclass heap" since we're only allocating TCLASS objects in to that heap, but there's no reason we couldn't allocate other objects in.

Rationale:

We know that TCLASS objects are likely to become old and stick around.  In fact they are [already pre-tenured](https://github.com/ruby/ruby/blob/trunk/class.c#L165) (they only have to make it through 1 GC before they are considered "old").  Objects are allocated using a [bump pointer](https://github.com/ruby/ruby/blob/trunk/gc.c#L1906) technique, and we end up with "probably old" objects mixed with "probably new" objects on a page.  Since objects aren't moved in our GC, the new objects die and we end up with holes on a page (fragmentation).  Fragmentation isn't great because it ensures poor locality (where related objects are close to each other in memory), and also fragmentation will lead to poor CoW performance.  Since holes in the pages are eventually re-used, the heap pages will get copied to child processes.

This PR allocates class objects to a separate heap for two benefits: 1) better CoW performance and 2) possibly better locality.  We'll get better CoW performance because the pages should have less fragmentation since we know the objects allocated to this heap will likely not be collected.  We *may* see better locality since subclasses should be allocated more closely to their superclasses.

Things I need to do:

- [ ] Measure fragmentation
- [ ] Check CoW improvement
- [ ] Check locality improvements (if any)