### PR TITLE
Update documentation for `Object#display`

### DIFF
--- a/io.c
+++ b/io.c
@@ -7276,6 +7276,7 @@ rb_f_p(int argc, VALUE *argv, VALUE self)
  *
  *     def display(port=$>)
  *       port.write self
+ *       nil
  *     end
  *
  *  For example:


### PR DESCRIPTION
`IO#write` returns the number of bytes written, whereas `Object#display` always returns `nil`.