### PR TITLE
URI.decode_www_form: update URI WEB_ENCODINGS_ hash

### DIFF
--- a/lib/uri/common.rb
+++ b/lib/uri/common.rb
@@ -487,7 +487,7 @@ module URI
   end
 
   private
-  # curl http://encoding.spec.whatwg.org/encodings.json|rb -rpp -rjson -e'H={};h={"shift_jis"=>"Windows-31J","euc-jp"=>"cp51932","iso-2022-jp"=>"cp50221","x-mac-cyrillic"=>"macCyrillic"};JSON($<.read).map{|x|x["encodings"]}.flatten.each{|x|Encoding.find(n=h.fetch(n=x["name"],n))rescue next;x["labels"].each{|y|H[y]=n}};pp H'
+  # curl https://encoding.spec.whatwg.org/encodings.json|ruby -rpp -rjson -e'H={};h={"shift_jis"=>"Windows-31J","euc-jp"=>"cp51932","iso-2022-jp"=>"cp50221","x-mac-cyrillic"=>"macCyrillic"};JSON($<.read).map{|x|x["encodings"]}.flatten.each{|x|Encoding.find(n=h.fetch(n=x["name"].downcase,n))rescue next;x["labels"].each{|y|H[y]=n}};pp H'
   WEB_ENCODINGS_ = {
     "unicode-1-1-utf-8"=>"utf-8",
     "utf-8"=>"utf-8",
@@ -593,6 +593,7 @@ module URI
     "koi8"=>"koi8-r",
     "koi8-r"=>"koi8-r",
     "koi8_r"=>"koi8-r",
+    "koi8-ru"=>"koi8-u",
     "koi8-u"=>"koi8-u",
     "dos-874"=>"windows-874",
     "iso-8859-11"=>"windows-874",
@@ -673,6 +674,7 @@ module URI
     "csiso2022jp"=>"cp50221",
     "iso-2022-jp"=>"cp50221",
     "csshiftjis"=>"Windows-31J",
+    "ms932"=>"Windows-31J",
     "ms_kanji"=>"Windows-31J",
     "shift-jis"=>"Windows-31J",
     "shift_jis"=>"Windows-31J",


### PR DESCRIPTION
Updates to the Hash of encoding mappings used by `URI.decode_www_form`:

* fix the documented command (`https` instead of `http`, `ruby` instead of `rb`, and downcase the now-uppercase `"name"` field that's returned)
* update the mapping (that was introduced [here](https://github.com/ruby/ruby/commit/4a50d447d9618b2e3df126e159aa1d735e429a70)) that is used to map encodings with two new mappings: `"koi8-ru", "ms932"`