### PR TITLE
URI.try_parse - returns nil instead of raising InvalidURIError

### DIFF
--- a/lib/uri/common.rb
+++ b/lib/uri/common.rb
@@ -227,6 +227,12 @@ module URI
     RFC3986_PARSER.parse(uri)
   end
 
+  def self.try_parse(uri)
+    parse(uri)
+  rescue InvalidURIError
+    nil
+  end
+
   #
   # == Synopsis
   #

--- a/test/uri/test_common.rb
+++ b/test/uri/test_common.rb
@@ -55,6 +55,12 @@ class TestCommon < Test::Unit::TestCase
     assert_raise(NoMethodError) { Object.new.URI("http://www.ruby-lang.org/") }
   end
 
+  def test_try_parse
+    bad_uri = "http://www ruby lang org/"
+    assert_nil URI.try_parse(bad_uri)
+    assert_nothing_raised(URI::InvalidURIError) { URI.try_parse(bad_uri) }
+  end
+
   def test_encode_www_form_component
     assert_equal("%00+%21%22%23%24%25%26%27%28%29*%2B%2C-.%2F09%3A%3B%3C%3D%3E%3F%40" \
                  "AZ%5B%5C%5D%5E_%60az%7B%7C%7D%7E",


### PR DESCRIPTION
Handy method if you are bored of rescuing from bad uris

`URI.try_parse "a b c d" # => nil`
