### PR TITLE
Add docs for max/min behavior with exclusive range

### DIFF
--- a/range.c
+++ b/range.c
@@ -911,7 +911,8 @@ range_last(int argc, VALUE *argv, VALUE range)
  *     rng.min(n) {| a,b | block }   -> array
  *
  *  Returns the minimum value in the range. Returns +nil+ if the begin
- *  value of the range is larger than the end value.
+ *  value of the range is larger than the end value. Returns +nil+ if
+ *  the begin value of an exclusive range is equal to the end value.
  *
  *  Can be given an optional block to override the default comparison
  *  method <code>a <=> b</code>.
@@ -948,7 +949,8 @@ range_min(int argc, VALUE *argv, VALUE range)
  *     rng.max(n) {| a,b | block }   -> obj
  *
  *  Returns the maximum value in the range. Returns +nil+ if the begin
- *  value of the range larger than the end value.
+ *  value of the range larger than the end value. Returns +nil+ if
+ *  the begin value of an exclusive range is equal to the end value.
  *
  *  Can be given an optional block to override the default comparison
  *  method <code>a <=> b</code>.


### PR DESCRIPTION
`(4…4).min => nil` is the expected behavior, but this isn’t mentioned in the doc and it ~~could be~~ was surprising.