### PR TITLE
lib/ipaddr.rb : Return false instead of throwing an exception in == test

### DIFF
--- a/lib/ipaddr.rb
+++ b/lib/ipaddr.rb
@@ -338,7 +338,11 @@ class IPAddr
 
   # Compares the ipaddr with another.
   def <=>(other)
-    other = coerce_other(other)
+    begin
+      other = coerce_other(other)
+    rescue
+      return nil
+    end
 
     return nil if other.family != @family
 

--- a/lib/ipaddr.rb
+++ b/lib/ipaddr.rb
@@ -148,7 +148,11 @@ class IPAddr
 
   # Returns true if two ipaddrs are equal.
   def ==(other)
-    other = coerce_other(other)
+    begin
+      other = coerce_other(other)
+    rescue
+      return false
+    end
     return @family == other.family && @addr == other.to_i
   end
 

--- a/test/test_ipaddr.rb
+++ b/test/test_ipaddr.rb
@@ -169,6 +169,8 @@ class TC_Operator < Test::Unit::TestCase
     @a = IPAddr.new("3ffe:505:2::/48")
     @b = IPAddr.new("0:0:0:1::")
     @c = IPAddr.new(IN6MASK32)
+    @inconvertible_range = 1..5
+    @inconvertible_string = "sometext"
   end
   alias set_up setup
 
@@ -220,6 +222,13 @@ class TC_Operator < Test::Unit::TestCase
     assert_equal(false, @a == IPAddr.new("3ffe:505:3::"))
     assert_equal(true, @a != IPAddr.new("3ffe:505:3::"))
     assert_equal(false, @a != IPAddr.new("3ffe:505:2::"))
+    assert_equal(false, @a == @inconvertible_range)
+    assert_equal(false, @a == @inconvertible_string)
+  end
+
+  def test_compare
+    assert_equal(nil, @a <=> @inconvertible_range)
+    assert_equal(nil, @a <=> @inconvertible_string)
   end
 
   def test_mask


### PR DESCRIPTION
Currently the IPAddr class throws an exception if you test for equality against an object that cannot be converted into an IPAddr object.

This causes fatal errors when trying to delete an IPAddr from an array that contains non-compatible objects (such as a Range).

This patch causes the equality test to correctly return false.

This is my first contribution to Ruby (I hope that this is right!) - do you need me to raise an issue ticket or something to associate with this?
