### PR TITLE
Download by AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,14 +11,14 @@ install:
   - mkdir \usr\local\bin
   - mkdir \usr\local\include
   - mkdir \usr\local\lib
-  - ps: Start-FileDownload 'http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.3.7-windows.zip'
+  - appveyor DownloadFile http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.3.7-windows.zip
   - 7z x libressl-2.3.7-windows.zip
   - copy libressl-2.3.7-windows\x64\libcrypto-37.lib \usr\local\lib\crypto.lib
   - copy libressl-2.3.7-windows\x64\libssl-38.lib    \usr\local\lib\ssl.lib
   - copy libressl-2.3.7-windows\x64\libcrypto-37.dll \usr\local\bin
   - copy libressl-2.3.7-windows\x64\libssl-38.dll    \usr\local\bin
   - xcopy /e libressl-2.3.7-windows\include          \usr\local\include
-  - ps: Start-FileDownload 'http://zlib.net/zlib128.zip'
+  - appveyor DownloadFile http://zlib.net/zlib128.zip
   - 7z x zlib128.zip
   - cd zlib-1.2.8
   - nmake -f win32/Makefile.msc


### PR DESCRIPTION
* appveyor.yml (install): use AppVeyor command-line utility to
  download files, instead of Start-FileDownload cmdlet which no
  longer works more than once.