### PR TITLE
remove unnecessary :stag accessor

### DIFF
--- a/lib/erb.rb
+++ b/lib/erb.rb
@@ -399,7 +399,6 @@ class ERB
           @scan_line = self.method(:scan_line)
         end
       end
-      attr_accessor :stag
 
       def scan(&block)
         @stag = nil


### PR DESCRIPTION
The `:stag` accessor has already been available because it is defined in parent `Scanner` class.