### PR TITLE
Clear calling.recv after method calling to avoid marking it as accessible from machine context

### DIFF
--- a/vm_insnhelper.h
+++ b/vm_insnhelper.h
@@ -123,6 +123,7 @@ enum vm_regan_acttype {
 
 #define CALL_METHOD(calling, ci, cc) do { \
     VALUE v = (*(cc)->call)(th, GET_CFP(), (calling), (ci), (cc)); \
+    (calling)->recv = 0; \
     if (v == Qundef) { \
 	RESTORE_REGS(); \
 	NEXT_INSN(); \


### PR DESCRIPTION
Take this script for example:

``` ruby
GC.disable

class Foo
  def exists?; end
  def empty?; end
end

def main
  foo = Foo.new
  puts foo.inspect
  foo.exists?
end

main

GC.enable
GC.start(full_mark: true, immediate_sweep: true)

require 'objspace'
puts ObjectSpace.each_object(Foo).to_a.first.inspect
```

Expected output:

```
#<Foo:0x00563762229c10>
nil
```

Actual output:

```
#<Foo:0x00563762229c10>
#<Foo:0x00563762229c10>
```

Because calling `empty?` is translated into a specific instruction (`opt_empty_p`), the receiver `foo` can still be referenced on the machine stack through `calling.recv`, assuming all calls happen in a single `vm_exec_core` call. That's why calling `exists?` instead of `empty?` works as expected because it's translated into the generic instruction `opt_send_without_block`, so calling `GC.start` or `GC.enable`) should override the value of `calling.recv`.
