### PR TITLE
Add documentation in the case of return nil

### DIFF
--- a/signal.c
+++ b/signal.c
@@ -238,9 +238,10 @@ signo2signm(int no)
 
 /*
  * call-seq:
- *     Signal.signame(signo)  ->  string
+ *     Signal.signame(signo)  ->  string or nil
  *
- *  convert signal number to signal name
+ *  Convert signal number to signal name.
+ *  Returns +nil+ if the signo is an invalid signal number.
  *
  *     Signal.trap("INT") { |signo| puts Signal.signame(signo) }
  *     Process.kill("INT", 0)


### PR DESCRIPTION
Signal.signame return nil if argument is an invalid signal number from v2.3.0.
change commit: https://github.com/ruby/ruby/commit/76d1d5269f72e72e8fb39877bb1850aca823158d