### PR TITLE
Remove confusing doc comments from Queue and SizedQueue.

### DIFF
--- a/thread_sync.c
+++ b/thread_sync.c
@@ -1274,11 +1274,11 @@ Init_thread_sync(void)
     rb_define_method(rb_cQueue, "length", rb_queue_length, 0);
     rb_define_method(rb_cQueue, "num_waiting", rb_queue_num_waiting, 0);
 
-    rb_define_alias(rb_cQueue, "enq", "push");    /* Alias for #push. */
-    rb_define_alias(rb_cQueue, "<<", "push");     /* Alias for #push. */
-    rb_define_alias(rb_cQueue, "deq", "pop");     /* Alias for #pop. */
-    rb_define_alias(rb_cQueue, "shift", "pop");   /* Alias for #pop. */
-    rb_define_alias(rb_cQueue, "size", "length"); /* Alias for #length. */
+    rb_define_alias(rb_cQueue, "enq", "push");
+    rb_define_alias(rb_cQueue, "<<", "push");
+    rb_define_alias(rb_cQueue, "deq", "pop");
+    rb_define_alias(rb_cQueue, "shift", "pop");
+    rb_define_alias(rb_cQueue, "size", "length");
 
     rb_cSizedQueue = rb_struct_define_without_accessor_under(
 	rb_cThread,
@@ -1294,10 +1294,10 @@ Init_thread_sync(void)
     rb_define_method(rb_cSizedQueue, "clear", rb_szqueue_clear, 0);
     rb_define_method(rb_cSizedQueue, "num_waiting", rb_szqueue_num_waiting, 0);
 
-    rb_define_alias(rb_cSizedQueue, "enq", "push");  /* Alias for #push. */
-    rb_define_alias(rb_cSizedQueue, "<<", "push");   /* Alias for #push. */
-    rb_define_alias(rb_cSizedQueue, "deq", "pop");   /* Alias for #pop. */
-    rb_define_alias(rb_cSizedQueue, "shift", "pop"); /* Alias for #pop. */
+    rb_define_alias(rb_cSizedQueue, "enq", "push");
+    rb_define_alias(rb_cSizedQueue, "<<", "push");
+    rb_define_alias(rb_cSizedQueue, "deq", "pop");
+    rb_define_alias(rb_cSizedQueue, "shift", "pop");
 
     /* CVar */
     rb_cConditionVariable = rb_struct_define_without_accessor_under(


### PR DESCRIPTION
These comments were being up by rdoc as documentation, so that, for example, Queue#size says it is an alias for #pop: https://ruby-doc.org/core-2.3.1/Queue.html#method-i-size

I asked @drbrain about the correct way to fix this and he suggested just removing the comments.