### PR TITLE
Update error message in readline

### DIFF
--- a/ext/readline/extconf.rb
+++ b/ext/readline/extconf.rb
@@ -59,7 +59,7 @@ else
             have_library("edit", "readline"))) ||
             (readline.have_header("editline/readline.h") &&
              have_library("edit", "readline"))
-    raise "readline nor libedit not found"
+    raise "Neither readline nor libedit was found"
   end
 end
 


### PR DESCRIPTION
The previous error phrase wasn't correct English.  This change updates the wording to make it clear that neither package was found.