### PR TITLE
 Fix a Ruby-Doc comment for Array#dig

### DIFF
--- a/array.c
+++ b/array.c
@@ -5665,7 +5665,7 @@ rb_ary_any_p(VALUE ary)
  *
  *   a.dig(0, 1, 1)                    #=> 3
  *   a.dig(1, 2, 3)                    #=> nil
- *   a.dig(0, 0, 0)                    #=> TypeError: Fixnum does not have #dig method
+ *   a.dig(0, 0, 0)                    #=> TypeError: Integer does not have #dig method
  *   [42, {foo: :bar}].dig(1, :foo)    #=> :bar
  */
 


### PR DESCRIPTION
It seems that this error message was changed by [Integer unification](https://bugs.ruby-lang.org/issues/12005).

```ruby
RUBY_VERSION #=> "2.4.0"
[[1, [2, 3]]].dig(0, 0, 0) #=> TypeError: Integer does not have #dig method
```
