### PR TITLE
Fixed documentation where Fixnum was referred directly to use Integer

### DIFF
--- a/array.c
+++ b/array.c
@@ -5716,7 +5716,7 @@ rb_ary_dig(int argc, VALUE *argv, VALUE self)
  *
  *
  * Array#sum method may not respect method redefinition of "+" methods
- * such as Fixnum#+.
+ * such as Integer#+.
  *
  */
 

--- a/class.c
+++ b/class.c
@@ -1645,7 +1645,7 @@ rb_singleton_class_get(VALUE obj)
  * Returns the singleton class of \a obj. Creates it if necessary.
  *
  * \param obj an arbitrary object.
- * \throw TypeError if \a obj is a Fixnum or a Symbol.
+ * \throw TypeError if \a obj is a Integer or a Symbol.
  * \return the singleton class.
  *
  * \post \a obj has its own singleton class.


### PR DESCRIPTION
- As Fixnum and Bignum are now unified into Integer and direct usage is deprecated.