### PR TITLE
vm_method.c: add new ruby::constant-cache-clear dtrace probe

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+Mon Oct 17 09:56:57 2016  Alessandro Lepore  <a.lepore@freegoweb.it>
+
+	* vm_method.c (rb_clear_constant_cache): fire ruby::constant-cache-clear
+	  probe on constant cache clear
+	* probes.d (provider ruby): new dtrace probe
+	* doc/dtrace_probes.rdoc: docs for new probe
+	* test/dtrace/test_constant_cache.rb: test for new probe
+
 Mon Oct 17 16:20:37 2016  Nobuyoshi Nakada  <nobu@ruby-lang.org>
 
 	* win32/configure.bat: add option to enable/disable to install

--- a/doc/dtrace_probes.rdoc
+++ b/doc/dtrace_probes.rdoc
@@ -176,3 +176,8 @@ with when they are fired and the arguments they take:
     sourcefile the file being parsed (string)
     lineno the line number where the source ended (int)
 
+[ruby:::constant-cache-clear(sourcefile, lineno);]
+  Fired when the constant cache is cleared.
+
+    sourcefile the file being parsed (string)
+    lineno the line number where the source ended (int)

--- a/probes.d
+++ b/probes.d
@@ -225,6 +225,16 @@ provider ruby {
      * `lineno` the line number where the cache is _being cleared_ (an int)
   */
   probe method__cache__clear(const char *class, const char *filename, int lineno);
+
+  /*
+     ruby:::constant-cache-clear(class, filename, lineno);
+
+     This probe is fired when the constant cache is cleared.
+
+     * `filename` the file name where the cache is _being cleared_ (a string)
+     * `lineno` the line number where the cache is _being cleared_ (an int)
+  */
+  probe constant__cache__clear(const char *filename, int lineno);
 };
 
 #pragma D attributes Stable/Evolving/Common provider ruby provider

--- a/test/dtrace/test_constant_cache.rb
+++ b/test/dtrace/test_constant_cache.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: false
+require_relative 'helper'
+
+module DTrace
+  class TestConstantCacheClear < TestCase
+    def test_constant_cache_clear
+      trap_probe(probe, code) do |_,rbfile,lines|
+        assert_not_include lines, "#{rbfile} 1\n"
+        assert_include     lines, "#{rbfile} 2\n"
+        assert_include     lines, "#{rbfile} 3\n"
+      end
+    end
+
+    private
+    def probe
+      <<-eoprobe
+        ruby$target:::constant-cache-clear
+        /arg1/
+        {
+          printf("%s %d\\n", copyinstr(arg0), arg1);
+        }
+      eoprobe
+    end
+
+    def code
+      <<-code
+        class String; end
+        class NewClass; end
+        NEW_CONSTANT = ''
+      code
+    end
+  end
+end if defined?(DTrace::TestCase)

--- a/vm_method.c
+++ b/vm_method.c
@@ -90,6 +90,10 @@ void
 rb_clear_constant_cache(void)
 {
     INC_GLOBAL_CONSTANT_STATE();
+
+    if (RUBY_DTRACE_CONSTANT_CACHE_CLEAR_ENABLED()) {
+        RUBY_DTRACE_CONSTANT_CACHE_CLEAR(rb_sourcefile(), rb_sourceline());
+    }
 }
 
 void


### PR DESCRIPTION
Hi!

I added a DTrace probe on the constant cache clear, it's basically the same thing @tmm1 did for the method cache.
This helped me to debug some apps, consider a merge if it's interesting!

Cheers
