### PR TITLE
Add support for iso8601 `YYYY-MM` format

### DIFF
--- a/ext/date/date_parse.c
+++ b/ext/date/date_parse.c
@@ -2265,7 +2265,11 @@ iso8601_ext_datetime_cb(VALUE m, VALUE hash)
 	    set_hash("mon", str2num(s[2]));
     }
     else if (!NIL_P(s[5])) {
-	set_hash("yday", str2num(s[5]));
+      if (RSTRING_LEN(s[5]) > 2) {
+	      set_hash("yday", str2num(s[5]));
+      } else {
+	      set_hash("month", str2num(s[5]));
+      }
 	if (!NIL_P(s[4])) {
 	    y = str2num(s[4]);
 	    if (RSTRING_LEN(s[4]) < 4)
@@ -2308,7 +2312,7 @@ iso8601_ext_datetime(VALUE str, VALUE hash)
 {
     static const char pat_source[] =
 	"\\A\\s*(?:([-+]?\\d{2,}|-)-(\\d{2})?-(\\d{2})|"
-		"([-+]?\\d{2,})?-(\\d{3})|"
+		"([-+]?\\d{2,})?-(\\d{2,3})|"
 		"(\\d{4}|\\d{2})?-w(\\d{2})-(\\d)|"
 		"-w-(\\d))"
 	"(?:t"

--- a/test/date/test_date_parse.rb
+++ b/test/date/test_date_parse.rb
@@ -758,6 +758,9 @@ class TestDateParse < Test::Unit::TestCase
     h = Date._iso8601('2001-023T04:05:06Z')
     assert_equal([2001, 23, 4, 5, 6, 0],
 		 h.values_at(:year, :yday, :hour, :min, :sec, :offset))
+    h = Date._iso8601('2001-23')
+    assert_equal([2001, 23],
+		 h.values_at(:year, :month))
     h = Date._iso8601('-023T04:05:06Z')
     assert_equal([nil, 23, 4, 5, 6, 0],
 		 h.values_at(:year, :yday, :hour, :min, :sec, :offset))


### PR DESCRIPTION
The iso 8601 spec allows for omission of the 'day' part of a date
representation. However, because it also allows omission of the month in
the case of `YYYY-DDD` (where `DDD` represents the day-of-year), there
is some abiguity.

If there are only two components, a four-digit year,
followed by a dash (`-`) followed by another series of digits, the
disambiguation is as follows:
- If there are two digits in the second component, that component
  represents the month.
- If there are three digits in the second component, that component
  represents the day-of-year.

The existing implementation has affordances for many things that are not
consistent with iso 8601. Rather than make a large,
backwards-incompatible change, I thought it best to fix this one edge
case.

https://bugs.ruby-lang.org/issues/12833
