### PR TITLE
generic_erb.rb compile error fix

### DIFF
--- a/tool/generic_erb.rb
+++ b/tool/generic_erb.rb
@@ -28,7 +28,7 @@ end
 unchanged = "unchanged"
 updated = "updated"
 if color or (color == nil && STDOUT.tty?)
-  if (/\A\e\[.*m\z/ =~ IO.popen("tput smso", "r", err: IO::NULL, &:read) rescue nil)
+  if (/\A\e\[.*m\z/ =~ IO.popen("tput smso", "r", err:IO::NULL, &:read) rescue nil)
     beg = "\e["
     colors = (colors = ENV['TEST_COLORS']) ? Hash[colors.scan(/(\w+)=([^:\n]*)/)] : {}
     reset = "#{beg}m"


### PR DESCRIPTION
This PR fixes the following ruby make compile error:

root@narinemdogfood  # make
        CC = gcc
        LD = ld
        LDSHARED = gcc -shared
        CFLAGS = -O3 -fno-fast-math -ggdb3 -Wall -Wextra -Wno-unused-parameter -Wno-parentheses -Wno-long-long -Wno-missing-field-initializers -Wunused-variable -Wpointer-arith -Wwrite-strings -Wdeclaration-after-statement -Wimplicit-function-declaration -Wdeprecated-declarations -std=iso9899:1999
        XCFLAGS = -D_FORTIFY_SOURCE=2 -fstack-protector -fvisibility=hidden -DRUBY_EXPORT -fPIE
        CPPFLAGS =   -I. -I.ext/include/x86_64-linux -I./include -I.
        DLDFLAGS = -fstack-protector -pie
        SOLIBS =
Using built-in specs.
Target: x86_64-redhat-linux
Configured with: ../configure --prefix=/usr --mandir=/usr/share/man --infodir=/usr/share/info --enable-shared --enable-threads=posix --enable-checking=release --with-system-zlib --enable-__cxa_atexit --disable-libunwind-exceptions --enable-libgcj-multifile --enable-languages=c,c++,objc,obj-c++,java,fortran,ada --enable-java-awt=gtk --disable-dssi --enable-plugin --with-java-home=/usr/lib/jvm/java-1.4.2-gcj-1.4.2.0/jre --with-cpu=generic --host=x86_64-redhat-linux
Thread model: posix
gcc version 4.1.1 20070105 (Red Hat 4.1.1-52)
generating id.h
./tool/generic_erb.rb:27: syntax error
  if (/\A\e\[.*m\z/ =~ IO.popen("tput smso", "r", err: IO::NULL, &:read) rescue nil)
                                                      ^
./tool/generic_erb.rb:27: syntax error
  if (/\A\e\[.*m\z/ =~ IO.popen("tput smso", "r", err: IO::NULL, &:read) rescue nil)
                                                                  ^
./tool/generic_erb.rb:27: syntax error
  if (/\A\e\[.*m\z/ =~ IO.popen("tput smso", "r", err: IO::NULL, &:read) rescue nil)
                                                                               ^
./tool/generic_erb.rb:34: syntax error
make: *** [id.h] Error 1
