### PR TITLE
doc/extension.rdoc: update rb_rescue description

### DIFF
--- a/doc/extension.rdoc
+++ b/doc/extension.rdoc
@@ -1523,12 +1523,13 @@ VALUE rb_yield(VALUE val) ::
 
   Evaluates the block with value val.
 
-VALUE rb_rescue(VALUE (*func1)(), VALUE arg1, VALUE (*func2)(), VALUE arg2) ::
+VALUE rb_rescue(VALUE (*func1)(ANYARGS), VALUE arg1, VALUE (*func2)(ANYARGS), VALUE arg2) ::
 
   Calls the function func1, with arg1 as the argument.  If an exception
-  occurs during func1, it calls func2 with arg2 as the argument.  The
-  return value of rb_rescue() is the return value from func1 if no
-  exception occurs, from func2 otherwise.
+  occurs during func1, it calls func2 with arg2 as the first argument
+  and the exception object as the second argument.  The return value
+  of rb_rescue() is the return value from func1 if no exception occurs,
+  from func2 otherwise.
 
 VALUE rb_ensure(VALUE (*func1)(), VALUE arg1, VALUE (*func2)(), VALUE arg2) ::
 


### PR DESCRIPTION
* set ANYARGS as arguments for func1 and func2

* mention the exception object which is passed to func2 as
  the second argument

To make it easier for review:

 - [rb_rescue: signature](https://github.com/ruby/ruby/blob/trunk/eval.c#L855-L857)
 - [rb_rescue2: invocation of func2 (r_proc)](https://github.com/ruby/ruby/blob/trunk/eval.c#L841-L843)