### PR TITLE
Fix undefined method 'dump' for nil:NilClass (NoMethodError)

### DIFF
--- a/lib/net/http/response.rb
+++ b/lib/net/http/response.rb
@@ -117,7 +117,9 @@ class Net::HTTPResponse
   end
 
   def error!   #:nodoc:
-    raise error_type().new(@code + ' ' + @message.dump, self)
+    message = @code
+    message += ' ' + @message.dump if @message
+    raise error_type().new(message, self)
   end
 
   def error_type   #:nodoc:

--- a/test/net/http/test_httpresponse.rb
+++ b/test/net/http/test_httpresponse.rb
@@ -385,6 +385,22 @@ EOS
     assert_equal(nil, res.message)
   end
 
+  def test_raises_exception_with_missing_reason
+    io = dummy_io(<<EOS)
+HTTP/1.1 404
+Content-Length: 5
+Connection: close
+
+hello
+EOS
+
+    res = Net::HTTPResponse.read_new(io)
+    assert_equal(nil, res.message)
+    assert_raise Net::HTTPServerException do
+      res.error!
+    end
+  end
+
 private
 
   def dummy_io(str)


### PR DESCRIPTION
As stated in this PR https://github.com/ruby/ruby/pull/782 and HTTP RFC https://tools.ietf.org/html/rfc1945#section-6.1 reason phrase is optional in status line, thus `@message` variable can be nil and `error!` method can throw error because we try to call `dump` on nil. I think we can simply avoid this just checking it straightforward.