### PR TITLE
Fast and safe connect timeout for net

### DIFF
--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -976,7 +976,7 @@ module Net   #:nodoc:
           raise Net::OpenTimeout, "Timeout to open " +
               "#{conn_address}:#{conn_port} (exceeds #{open_timeout} seconds)"
         end
-      rescue Errno::EINCONN
+      rescue Errno::EISCONN
         # It is connected.
       rescue => e
         raise e, "Failed to open TCP connection to" +

--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -899,29 +899,8 @@ module Net   #:nodoc:
       end
 
       D "opening connection to #{conn_address}:#{conn_port}..."
-      s = Socket.new(Socket::AF_INET, Socket::SOCK_STREAM)
-      if @local_host && @local_port
-        local_addr = Socket.pack_sockaddr_in(@local_port, @local_host)
-        s.bind(local_addr)
-      end
-      conn_addr = Socket.pack_sockaddr_in(conn_port, conn_address)
 
-      begin
-        s.connect_nonblock(conn_addr)
-      rescue Errno::EINPROGRESS
-        _, rs, _ = IO.select(nil, [s], nil, @open_timeout)
-        if rs
-          retry
-        else
-          raise Net::OpenTimeout, "Timeout to open " +
-              "#{conn_address}:#{conn_port} (exceeds #{@open_timeout} seconds)"
-        end
-      rescue Errno::EINCONN
-        # It is connected.
-      rescue => e
-        raise e, "Failed to open TCP connection to" +
-            "#{conn_address}:#{conn_port} (#{e.message})"
-      end
+      s = open_socket(conn_address, conn_port, @open_timeout)
 
       s.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1)
       D "opened"
@@ -978,6 +957,34 @@ module Net   #:nodoc:
       on_connect
     end
     private :connect
+
+    def open_socket(conn_address, conn_port, open_timeout)
+      socket = Socket.new(Socket::AF_INET, Socket::SOCK_STREAM)
+      if @local_host && @local_port
+        local_addr = Socket.pack_sockaddr_in(@local_port, @local_host)
+        socket.bind(local_addr)
+      end
+      conn_addr = Socket.pack_sockaddr_in(conn_port, conn_address)
+
+      begin
+        socket.connect_nonblock(conn_addr)
+      rescue Errno::EINPROGRESS
+        _, rs, _ = IO.select(nil, [socket], nil, open_timeout)
+        if rs
+          retry
+        else
+          raise Net::OpenTimeout, "Timeout to open " +
+              "#{conn_address}:#{conn_port} (exceeds #{open_timeout} seconds)"
+        end
+      rescue Errno::EINCONN
+        # It is connected.
+      rescue => e
+        raise e, "Failed to open TCP connection to" +
+            "#{conn_address}:#{conn_port} (#{e.message})"
+      end
+      socket
+    end
+    private :open_socket
 
     def on_connect
     end

--- a/lib/net/pop.rb
+++ b/lib/net/pop.rb
@@ -541,9 +541,8 @@ module Net
 
     # internal method for Net::POP3.start
     def do_start(account, password) # :nodoc:
-      s = Timeout.timeout(@open_timeout, Net::OpenTimeout) do
-        TCPSocket.open(@address, port)
-      end
+      s = open_socket(@address, port)
+
       if use_ssl?
         raise 'openssl library not installed' unless defined?(OpenSSL)
         context = OpenSSL::SSL::SSLContext.new
@@ -576,6 +575,30 @@ module Net
       end
     end
     private :do_start
+
+    def open_socket(conn_address, conn_port, open_timeout)
+      socket = Socket.new(Socket::AF_INET, Socket::SOCK_STREAM)
+      conn_addr = Socket.pack_sockaddr_in(conn_port, conn_address)
+
+      begin
+        socket.connect_nonblock(conn_addr)
+      rescue Errno::EINPROGRESS
+        _, rs, _ = IO.select(nil, [socket], nil, open_timeout)
+        if rs
+          retry
+        else
+          raise Net::OpenTimeout, "Timeout to open " +
+              "#{conn_address}:#{conn_port} (exceeds #{open_timeout} seconds)"
+        end
+      rescue Errno::EINCONN
+        # It is connected.
+      rescue => e
+        raise e, "Failed to open TCP connection to" +
+            "#{conn_address}:#{conn_port} (#{e.message})"
+      end
+      socket
+    end
+    private :open_socket
 
     # Does nothing
     def on_connect # :nodoc:

--- a/lib/net/pop.rb
+++ b/lib/net/pop.rb
@@ -590,7 +590,7 @@ module Net
           raise Net::OpenTimeout, "Timeout to open " +
               "#{conn_address}:#{conn_port} (exceeds #{open_timeout} seconds)"
         end
-      rescue Errno::EINCONN
+      rescue Errno::EISCONN
         # It is connected.
       rescue => e
         raise e, "Failed to open TCP connection to" +

--- a/lib/net/pop.rb
+++ b/lib/net/pop.rb
@@ -541,7 +541,7 @@ module Net
 
     # internal method for Net::POP3.start
     def do_start(account, password) # :nodoc:
-      s = open_socket(@address, port)
+      s = open_socket(@address, port, @open_timeout)
 
       if use_ssl?
         raise 'openssl library not installed' unless defined?(OpenSSL)


### PR DESCRIPTION
Use socket's `connect_nonblock` and `IO.select` to tigger connecting timeout for net/http and net/pop.

`Timeout.timeout` is bad for performance. It will create and kill one thread every time.
Use socket's connecting timeout is better than `Timeout.timeout`.
