### PR TITLE
proc.c: Fix proc_dup to avoid duplicated sym_procs.

### DIFF
--- a/proc.c
+++ b/proc.c
@@ -65,11 +65,13 @@ typedef struct {
     VALUE env[3]; /* me, specval, envval */
 } cfunc_proc_t;
 
+#define IS_SYM_PROC(proc) (proc->block.ep == ((const cfunc_proc_t *)proc)->env+1)
+
 static size_t
 proc_memsize(const void *ptr)
 {
     const rb_proc_t *proc = ptr;
-    if (proc->block.ep == ((const cfunc_proc_t *)ptr)->env+1)
+    if (IS_SYM_PROC(proc))
 	return sizeof(cfunc_proc_t);
     return sizeof(rb_proc_t);
 }
@@ -111,6 +113,8 @@ proc_dup(VALUE self)
     rb_proc_t *dst;
 
     GetProcPtr(self, src);
+    if (IS_SYM_PROC(src))
+	return self;
     procval = rb_proc_alloc(rb_cProc);
     GetProcPtr(procval, dst);
     *dst = *src;


### PR DESCRIPTION
When you copy a sym proc, the copy keeps a pointer to the environment of the original sym_proc.
The problem is that when a sym_proc frees its memory, it also frees the environment because its part of the same struct.
So duplicated sym procs ends up pointing to corrupted memory. If after that, this position of memory is filled with random data, the process stops with a SEG FAULT.

For more information please see this:
https://bugs.ruby-lang.org/issues/12927