### PR TITLE
Fast and safe connect timeout for net

### DIFF
--- a/lib/net/ftp.rb
+++ b/lib/net/ftp.rb
@@ -244,10 +244,7 @@ module Net
         }
       else
         begin
-          _sock = Socket.tcp(host, port, connect_timeout: @open_timeout)
-          _sock.autoclose = false
-          sock = TCPSocket.for_fd(_sock.fileno)
-          _sock.close
+          sock = Socket.tcp(host, port, connect_timeout: @open_timeout)
         rescue Errno::ETIMEDOUT
           raise Net::OpenTimeout, "Timeout to open TCP connection to " +
             "#{host}:#{port} (exceeds #{@open_timeout} seconds)"

--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -901,11 +901,8 @@ module Net   #:nodoc:
       D "opening connection to #{conn_address}:#{conn_port}..."
 
       begin
-        _s = Socket.tcp(conn_address, conn_port, @local_host, @local_port,
+        s = Socket.tcp(conn_address, conn_port, @local_host, @local_port,
               connect_timeout: @open_timeout)
-        _s.autoclose = false
-        s = TCPSocket.for_fd(_s.fileno)
-        _s.close
       rescue Errno::ETIMEDOUT
         raise Net::OpenTimeout, "Timeout to open TCP connection to " +
           "#{conn_address}:#{conn_port} (exceeds #{@open_timeout} seconds)"

--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -899,14 +899,21 @@ module Net   #:nodoc:
       end
 
       D "opening connection to #{conn_address}:#{conn_port}..."
-      s = Timeout.timeout(@open_timeout, Net::OpenTimeout) {
-        begin
-          TCPSocket.open(conn_address, conn_port, @local_host, @local_port)
-        rescue => e
-          raise e, "Failed to open TCP connection to " +
-            "#{conn_address}:#{conn_port} (#{e.message})"
-        end
-      }
+
+      begin
+        _s = Socket.tcp(conn_address, conn_port, @local_host, @local_port,
+              connect_timeout: @open_timeout)
+        _s.autoclose = false
+        s = TCPSocket.for_fd(_s.fileno)
+        _s.close
+      rescue Errno::ETIMEDOUT
+        raise Net::OpenTimeout, "Timeout to open TCP connection to " +
+          "#{conn_address}:#{conn_port} (exceeds #{@open_timeout} seconds)"
+      rescue => e
+        raise e, "Failed to open TCP connection to " +
+          "#{conn_address}:#{conn_port} (#{e.message})"
+      end
+
       s.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1)
       D "opened"
       if use_ssl?

--- a/lib/net/pop.rb
+++ b/lib/net/pop.rb
@@ -542,10 +542,7 @@ module Net
     # internal method for Net::POP3.start
     def do_start(account, password) # :nodoc:
       begin
-        _s = Socket.tcp(@address, port, connect_timeout: @open_timeout)
-        _s.autoclose = false
-        s = TCPSocket.for_fd(_s.fileno)
-        _s.close
+        s = Socket.tcp(@address, port, connect_timeout: @open_timeout)
       rescue Errno::ETIMEDOUT
         raise Net::OpenTimeout, "Timeout to open TCP connection to " +
           "#{@address}:#{port} (exceeds #{@open_timeout} seconds)"

--- a/lib/net/smtp.rb
+++ b/lib/net/smtp.rb
@@ -537,11 +537,7 @@ module Net
 
     def tcp_socket(address, port)
       begin
-        _sock = Socket.tcp(address, port, connect_timeout: @open_timeout)
-        _sock.autoclose = false
-        sock = TCPSocket.for_fd(_sock.fileno)
-        _sock.close
-        return sock
+        Socket.tcp(address, port, connect_timeout: @open_timeout)
       rescue Errno::ETIMEDOUT
         raise Net::OpenTimeout, "Timeout to open TCP connection to " +
           "#{address}:#{port} (exceeds #{@open_timeout} seconds)"


### PR DESCRIPTION
net/http, net/pop, net/smtp and net/ftp use `Timeout.timeout` to calculate connect_timeout.
Timeout.timeout is slow. It creates and destroys a thread every time.
Timeout.timeout is also dangerous. see [Timeout: Ruby's Most Dangerous API](http://www.mikeperham.com/2015/05/08/timeout-rubys-most-dangerous-api/)

It is more effective and safe to use socket timeout to accomplish that. 
Follow is the changes need to do.
1. Replace `TCPSocket.open` with `Socket.tcp`
2. Create `TCPSocket` with `TCPSocket.for_fd`

redmine issue is here:
[Use socket timeout for net/http and net/pop for open_timeout](https://bugs.ruby-lang.org/issues/12928)