### PR TITLE
array.c: remove redundant modify check

### DIFF
--- a/array.c
+++ b/array.c
@@ -4378,7 +4378,6 @@ rb_ary_uniq_bang(VALUE ary)
     if (RARRAY_LEN(ary) == hash_size) {
 	return Qnil;
     }
-    rb_ary_modify_check(ary);
     ARY_SET_LEN(ary, 0);
     if (ARY_SHARED_P(ary) && !ARY_EMBED_P(ary)) {
 	rb_ary_unshare(ary);


### PR DESCRIPTION
There is no problem, but I just noticed it's redundant.