### PR TITLE
Add missing :nodoc: comment

### DIFF
--- a/lib/pp.rb
+++ b/lib/pp.rb
@@ -417,8 +417,8 @@ class Range # :nodoc:
   end
 end
 
-class String
-  def pretty_print(q)
+class String # :nodoc:
+  def pretty_print(q) # :nodoc:
     lines = self.lines
     if lines.size > 1
       q.group(0, '', '') do


### PR DESCRIPTION
We were missing a `:nodoc:` magic comment that was making automated tools show
that this method was missing documentation, when it really didn't need to be
documented.