### PR TITLE
Implemented String#match?

### DIFF
--- a/string.c
+++ b/string.c
@@ -3565,6 +3565,33 @@ rb_str_match_m(int argc, VALUE *argv, VALUE str)
     return result;
 }
 
+/*
+ *  call-seq:
+ *     str.match?(pattern)        -> true or false
+ *     str.match?(pattern, pos)   -> true or false
+ *
+ *  Converts <i>pattern</i> to a <code>Regexp</code> (if it isn't already one),
+ *  then invokes its <code>match?</code> method on <i>str</i>.  If the second
+ *  parameter is present, it specifies the position in the string to begin the
+ *  search.
+ *
+ *     "Ruby".match?(/R.../)    #=> true
+ *     "Ruby".match?(/R.../, 1) #=> false
+ *     "Ruby".match?(/P.../)    #=> false
+ *     $&                       #=> nil
+ */
+
+static VALUE
+rb_str_match_m_p(int argc, VALUE *argv, VALUE str)
+{
+    VALUE re;
+    if (argc < 1)
+	rb_check_arity(argc, 1, 2);
+    re = argv[0];
+    argv[0] = str;
+    return rb_funcallv(get_pat(re), rb_intern("match?"), argc, argv);
+}
+
 enum neighbor_char {
     NEIGHBOR_NOT_CHAR,
     NEIGHBOR_FOUND,
@@ -9643,6 +9670,19 @@ sym_match_m(int argc, VALUE *argv, VALUE sym)
 
 /*
  * call-seq:
+ *   sym.match?(obj)   -> true or false
+ *
+ * Returns <code>sym.to_s.match?(obj)</code>.
+ */
+
+static VALUE
+sym_match_m_p(int argc, VALUE *argv, VALUE sym)
+{
+    return rb_str_match_m_p(argc, argv, rb_sym2str(sym));
+}
+
+/*
+ * call-seq:
  *   sym[idx]      -> char
  *   sym[b, n]     -> string
  *   sym.slice(idx)      -> char
@@ -9826,6 +9866,7 @@ Init_String(void)
     rb_define_method(rb_cString, "empty?", rb_str_empty, 0);
     rb_define_method(rb_cString, "=~", rb_str_match, 1);
     rb_define_method(rb_cString, "match", rb_str_match_m, -1);
+    rb_define_method(rb_cString, "match?", rb_str_match_m_p, -1);
     rb_define_method(rb_cString, "succ", rb_str_succ, 0);
     rb_define_method(rb_cString, "succ!", rb_str_succ_bang, 0);
     rb_define_method(rb_cString, "next", rb_str_succ, 0);
@@ -9971,6 +10012,7 @@ Init_String(void)
     rb_define_method(rb_cSymbol, "size", sym_length, 0);
     rb_define_method(rb_cSymbol, "empty?", sym_empty, 0);
     rb_define_method(rb_cSymbol, "match", sym_match_m, -1);
+    rb_define_method(rb_cSymbol, "match?", sym_match_m_p, -1);
 
     rb_define_method(rb_cSymbol, "upcase", sym_upcase, -1);
     rb_define_method(rb_cSymbol, "downcase", sym_downcase, -1);

--- a/test/ruby/test_string.rb
+++ b/test/ruby/test_string.rb
@@ -2087,6 +2087,27 @@ CODE
     assert_raise(ArgumentError) { "foo".match }
   end
 
+  def test_match_p_method
+    /backref/ =~ 'backref'
+    # must match here, but not in a separate method, e.g., assert_send,
+    # to check if $~ is affected or not.
+    assert_equal(true, "".match?(//))
+    assert_equal(true, :abc.match?(/.../))
+    assert_equal(true, 'abc'.match?(/b/))
+    assert_equal(true, 'abc'.match?(/b/, 1))
+    assert_equal(true, 'abc'.match?(/../, 1))
+    assert_equal(true, 'abc'.match?(/../, -2))
+    assert_equal(false, 'abc'.match?(/../, -4))
+    assert_equal(false, 'abc'.match?(/../, 4))
+    assert_equal(true, ("\u3042" + '\x').match?(/../n, 1))
+    assert_equal(true, ''.match?(/\z/))
+    assert_equal(true, 'abc'.match?(/\z/))
+    assert_equal(true, 'Ruby'.match?(/R.../))
+    assert_equal(false, 'Ruby'.match?(/R.../, 1))
+    assert_equal(false, 'Ruby'.match?(/P.../))
+    assert_equal('backref', $&)
+  end
+
   def test_clear
     s = "foo" * 100
     s.clear


### PR DESCRIPTION
The behaviour equals that of Regexp#match? It was requested as Feature 12898 (https://bugs.ruby-lang.org/issues/12898)