### PR TITLE
Resolv::MDNS#each_address not work

### DIFF
--- a/lib/resolv.rb
+++ b/lib/resolv.rb
@@ -2604,7 +2604,7 @@ class Resolv
     def each_address(name)
       name = Resolv::DNS::Name.create(name)
 
-      return unless name.to_a.last == 'local'
+      return unless name.to_a.last.to_s == 'local'
 
       super(name)
     end

--- a/test/resolv/test_mdns.rb
+++ b/test/resolv/test_mdns.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: false
+require 'test/unit'
+require 'resolv'
+
+class TestResolvMDNS < Test::Unit::TestCase
+  def setup
+  end
+
+  def test_mdns_each_address
+    mdns = Resolv::MDNS.new
+    mdns.each_resource '_http._tcp.local', Resolv::DNS::Resource::IN::PTR do |r|
+      srv = mdns.getresource r.name, Resolv::DNS::Resource::IN::SRV
+      mdns.each_address(srv.target) do |result|
+        assert_not_nil(result)
+      end
+    end
+  end
+end


### PR DESCRIPTION
```
irb(main):001:0> name = Resolv::DNS::Name.create('example.local')
=> #<Resolv::DNS::Name: example.local>
irb(main):002:0> name.to_a.last == 'local'
=> false
irb(main):003:0> name.to_a.last.to_s == 'local'
=> true
```

Resolv::DNS::Label::Str cannot direct compare with string.
I add `to_s` and let it work.