### PR TITLE
Ruby 1.9.3 does not compile on Alpine Linux

### DIFF
--- a/io.c
+++ b/io.c
@@ -8072,7 +8072,7 @@ do_ioctl(int fd, ioctl_req_t cmd, long narg)
 
 #define DEFULT_IOCTL_NARG_LEN (256)
 
-#ifdef __linux__
+#if defined(__linux__) && defined(_IOC_SIZE)
 static long
 linux_iocparm_len(ioctl_req_t cmd)
 {
@@ -8105,7 +8105,7 @@ ioctl_narg_len(ioctl_req_t cmd)
 #endif
 #ifdef IOCPARM_LEN
     len = IOCPARM_LEN(cmd);	/* on BSDish systems we're safe */
-#elif defined(__linux__)
+#elif defined(__linux__) && defined(_IOC_SIZE)
     len = linux_iocparm_len(cmd);
 #else
     /* otherwise guess at what's safe */


### PR DESCRIPTION
Compiling legacy Ruby 1.9.3 on alpine linux 3.4 fails with the following error:

```
linking miniruby
io.o: In function `linux_iocparm_len':
/usr/src/ruby/io.c:8086: undefined reference to `_IOC_SIZE'
collect2: error: ld returned 1 exit status
Makefile:165: recipe for target 'miniruby' failed
make: *** [miniruby] Error 1

```

Screenshot:
![image](https://cloud.githubusercontent.com/assets/14018885/20359163/9f9b93d2-abfc-11e6-9758-e637a31df4c6.png)

I backported the same check for _IOC_SIZE located on `io.c` that is found on the latest version of Ruby (whatever is on master branch, I believe).

After applying fix compilation and install purrs like a kitten. Following usual install procedures `./configure && make && make install`.

I realize this might never get pulled in, but just publicly documenting it just in case anyone else runs into this, for example, http://stackoverflow.com/questions/39769271/trying-to-install-ruby-1-9-3-on-alpine-3-4-fails.

Thanks.
