### PR TITLE
Remove webhook notification to Travis CI [skip ci]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,13 +73,6 @@ notifications:
     template:
       - "%{message} by @%{author}: See %{build_url}"
 
-  # Update ruby-head installed on Travis CI so other projects can test against it.
-  webhooks:
-    urls:
-      - "https://rubies.travis-ci.org/rebuild/ruby-head"
-    on_success: always
-    on_failure: never
-
   email:
     - ko1c-failure@atdot.net
     - shibata.hiroshi@gmail.com


### PR DESCRIPTION
`travis-rubies` now uses 3 Mac jobs to create archives for various OS
releases.

This is a bit wasteful if multiple builds pass in a short period.

Instead, Travis CI is now running a nightly build of ruby-head
(around 22:30 UTC). This will happen regardless of the state of the
master branch.