### PR TITLE
Add :err => :out option for the open3 pipeline

### DIFF
--- a/lib/open3.rb
+++ b/lib/open3.rb
@@ -636,10 +636,12 @@ module Open3
       if i != cmds.length - 1
         r2, w2 = IO.pipe
         cmd_opts[:out] = w2
+        cmd_opts[:err] = w2 if pipeline_opts[:err] == :out
       else
         if !cmd_opts.include?(:out)
           if pipeline_opts.include?(:out)
             cmd_opts[:out] = pipeline_opts[:out]
+            cmd_opts[:err] = pipeline_opts[:out] if pipeline_opts[:err] == :out
           end
         end
       end

--- a/test/test_open3.rb
+++ b/test/test_open3.rb
@@ -284,4 +284,15 @@ class TestOpen3 < Test::Unit::TestCase
     }
   end
 
+  def test_pipeline_err_to_out
+    cmd = [RUBY, '-e', 'STDERR.print "err"; STDOUT.print "out"']
+    cmd_expect_only_out = [RUBY, '-e', 's = STDIN.read; exit s == "out"']
+    cmd_expect_out_and_err = [RUBY, '-e', 's = STDIN.read; exit s == "errout"']
+    result_only_out = Open3.pipeline cmd, cmd_expect_only_out
+    result_out_and_err = Open3.pipeline cmd, cmd_expect_out_and_err, {:err => :out}
+    (result_only_out + result_out_and_err).each do |status|
+      assert status.success?
+    end
+  end
+
 end


### PR DESCRIPTION
This option allows a user to redirect command's stderr
to the stdout and then to the stdin of the next command in a
pipeline. It's a very common use case to capture both
streams.