### PR TITLE
Updated documentation examples for Hash#value?

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -2155,8 +2155,8 @@ rb_hash_search_value(VALUE key, VALUE value, VALUE arg)
  *  in <i>hsh</i>.
  *
  *     h = { "a" => 100, "b" => 200 }
- *     h.has_value?(100)   #=> true
- *     h.has_value?(999)   #=> false
+ *     h.value?(100)   #=> true
+ *     h.value?(999)   #=> false
  */
 
 static VALUE


### PR DESCRIPTION
The same code is used for has_value? and value?, but according to
http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/43765
has_value is deprecated. Use the non-deprecated syntax in the examples.