### PR TITLE
Add IPAddr#link_local?, loopback?, multicast?

### DIFF
--- a/test/test_ipaddr.rb
+++ b/test/test_ipaddr.rb
@@ -33,6 +33,9 @@ class TC_IPAddr < Test::Unit::TestCase
     assert_equal(Socket::AF_INET6, a.family)
     assert_equal(false, a.ipv4?)
     assert_equal(true, a.ipv6?)
+    assert_equal(false, a.loopback?)
+    assert_equal(false, a.link_local?)
+    assert_equal(false, a.multicast?)
     assert_equal("#<IPAddr: IPv6:3ffe:0505:0002:0000:0000:0000:0000:0000/ffff:ffff:ffff:0000:0000:0000:0000:0000>", a.inspect)
 
     a = IPAddr.new("3ffe:505:2::/ffff:ffff:ffff::")
@@ -51,6 +54,39 @@ class TC_IPAddr < Test::Unit::TestCase
     assert_equal(Socket::AF_INET, a.family)
     assert_equal(true, a.ipv4?)
     assert_equal(false, a.ipv6?)
+    assert_equal(false, a.loopback?)
+    assert_equal(false, a.link_local?)
+    assert_equal(false, a.multicast?)
+
+    a = IPAddr.new("127.0.0.1/8")
+    assert_equal(true, a.loopback?)
+    assert_equal(false, a.link_local?)
+    assert_equal(false, a.multicast?)
+
+    a = IPAddr.new("169.254.0.1")
+    assert_equal(false, a.loopback?)
+    assert_equal(true, a.link_local?)
+    assert_equal(false, a.multicast?)
+
+    a = IPAddr.new("224.0.0.1/4")
+    assert_equal(false, a.loopback?)
+    assert_equal(false, a.link_local?)
+    assert_equal(true, a.multicast?)
+
+    a = IPAddr.new("::1")
+    assert_equal(true, a.loopback?)
+    assert_equal(false, a.link_local?)
+    assert_equal(false, a.multicast?)
+
+    a = IPAddr.new("fe80::1/10")
+    assert_equal(false, a.loopback?)
+    assert_equal(true, a.link_local?)
+    assert_equal(false, a.multicast?)
+
+    a = IPAddr.new("ff00::1/8")
+    assert_equal(false, a.loopback?)
+    assert_equal(false, a.link_local?)
+    assert_equal(true, a.multicast?)
 
     a = IPAddr.new("192.168.1.2/24")
     assert_equal("192.168.1.0", a.to_s)


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/10912

I also want a method to determine whether an address is link-local.
It seemed that nobody responded, so I tried implementing `IPAddr#link_local?`.

In addition, I implemented `IPAddr#loopback?` and `IPAddr#multicast?`.
The reason for choosing these is because these addresses are clearly defined in RFC for both IPv4 and IPv6.

|Address Type| RFC |
|---|---|
|Loopback(IPv4)|RFC 6890|
|Link-Local(IPv4)|RFC 3927, RFC 6890|
|Multicast(IPv4) | RFC 5771, RFC 6890|
|Loopback(IPv6) | RFC 4291 2.5.3 |
|Link-Local(IPv6) | RFC 4291 2.5.6|
|Multicast(IPv6)|RFC 4291 2.7|

Please tell me if there is a reason not to implement them.