### PR TITLE
fix typo in `IO#write_nonblock` example [ci skip]

### DIFF
--- a/prelude.rb
+++ b/prelude.rb
@@ -99,7 +99,7 @@ class IO
   #
   #   # write_nonblock writes only 65536 bytes and return 65536.
   #   # (The pipe size is 65536 bytes on this environment.)
-  #   s = "a"  #100000
+  #   s = "a" * 100000
   #   p w.write_nonblock(s)     #=> 65536
   #
   #   # write_nonblock cannot write a byte and raise EWOULDBLOCK (EAGAIN).


### PR DESCRIPTION
This example explains when writing a value greater than 65536,
so the value specify must be greater than 65536.
    
This seems to be wrong in cee7f69