### PR TITLE
switch SipHash from SipHash24 to SipHash13 variant

### DIFF
--- a/random.c
+++ b/random.c
@@ -1457,7 +1457,7 @@ random_s_rand(int argc, VALUE *argv, VALUE obj)
 }
 
 #define SIP_HASH_STREAMING 0
-#define sip_hash24 ruby_sip_hash24
+#define sip_hash13 ruby_sip_hash13
 #if !defined _WIN32 && !defined BYTE_ORDER
 # ifdef WORDS_BIGENDIAN
 #   define BYTE_ORDER BIG_ENDIAN
@@ -1501,7 +1501,7 @@ rb_hash_start(st_index_t h)
 st_index_t
 rb_memhash(const void *ptr, long len)
 {
-    sip_uint64_t h = sip_hash24(seed.key.sip, ptr, len);
+    sip_uint64_t h = sip_hash13(seed.key.sip, ptr, len);
 #ifdef HAVE_UINT64_T
     return (st_index_t)h;
 #else

--- a/siphash.c
+++ b/siphash.c
@@ -386,16 +386,15 @@ sip_hash_dump(sip_hash *h)
 }
 #endif /* SIP_HASH_STREAMING */
 
-#define SIP_2_ROUND(m, v0, v1, v2, v3)	\
+#define SIP_ROUND(m, v0, v1, v2, v3)	\
 do {					\
     XOR64_TO((v3), (m));		\
-    SIP_COMPRESS(v0, v1, v2, v3);	\
     SIP_COMPRESS(v0, v1, v2, v3);	\
     XOR64_TO((v0), (m));		\
 } while (0)
 
 uint64_t
-sip_hash24(const uint8_t key[16], const uint8_t *data, size_t len)
+sip_hash13(const uint8_t key[16], const uint8_t *data, size_t len)
 {
     uint64_t k0, k1;
     uint64_t v0, v1, v2, v3;
@@ -415,13 +414,13 @@ sip_hash24(const uint8_t key[16], const uint8_t *data, size_t len)
         uint64_t *data64 = (uint64_t *)data;
         while (data64 != (uint64_t *) end) {
 	    m = *data64++;
-	    SIP_2_ROUND(m, v0, v1, v2, v3);
+	    SIP_ROUND(m, v0, v1, v2, v3);
         }
     }
 #else
     for (; data != end; data += sizeof(uint64_t)) {
 	m = U8TO64_LE(data);
-	SIP_2_ROUND(m, v0, v1, v2, v3);
+	SIP_ROUND(m, v0, v1, v2, v3);
     }
 #endif
 
@@ -468,11 +467,10 @@ sip_hash24(const uint8_t key[16], const uint8_t *data, size_t len)
 	    break;
     }
 
-    SIP_2_ROUND(last, v0, v1, v2, v3);
+    SIP_ROUND(last, v0, v1, v2, v3);
 
     XOR64_INT(v2, 0xff);
 
-    SIP_COMPRESS(v0, v1, v2, v3);
     SIP_COMPRESS(v0, v1, v2, v3);
     SIP_COMPRESS(v0, v1, v2, v3);
     SIP_COMPRESS(v0, v1, v2, v3);

--- a/siphash.h
+++ b/siphash.h
@@ -43,6 +43,6 @@ int sip_hash_digest_integer(sip_hash *h, const uint8_t *data, size_t data_len, u
 void sip_hash_free(sip_hash *h);
 void sip_hash_dump(sip_hash *h);
 
-uint64_t sip_hash24(const uint8_t key[16], const uint8_t *data, size_t len);
+uint64_t sip_hash13(const uint8_t key[16], const uint8_t *data, size_t len);
 
 #endif


### PR DESCRIPTION
SipHash13 is secure enough to be used in hash-tables,
and SipHash's author confirms that.
Rust already considered switch to SipHash13:
  https://github.com/rust-lang/rust/issues/29754#issue-116174313
Jean-Philippe Aumasson confirmation:
  https://github.com/rust-lang/rust/issues/29754#issuecomment-156073946
Merged pull request:
  https://github.com/rust-lang/rust/pull/33940