### PR TITLE
Update fileutils.rb

### DIFF
--- a/lib/fileutils.rb
+++ b/lib/fileutils.rb
@@ -47,7 +47,7 @@
 #
 # The <tt>options</tt> parameter is a hash of options, taken from the list
 # <tt>:force</tt>, <tt>:noop</tt>, <tt>:preserve</tt>, and <tt>:verbose</tt>.
-# <tt>:noop</tt> means that no changes are made.  The other two are obvious.
+# <tt>:noop</tt> means that no changes are made.  The other three are obvious.
 # Each method documents the options that it honours.
 #
 # All methods that have the concept of a "source" file or directory can take


### PR DESCRIPTION
There are 4 options for file utils. So that would make 3 obvious things since `:noop` is explained. I'll submit a followup PR that lists out what all 4 options do, incase it isn't obvious to a dev.