### PR TITLE
Fix a typo in extension.rdoc: s/SaveStringValue/SafeStringValue/

### DIFF
--- a/doc/extension.rdoc
+++ b/doc/extension.rdoc
@@ -1176,7 +1176,7 @@ void Check_Type(VALUE value, int type) ::
 
   Ensures +value+ is of the given internal +type+ or raises a TypeError
 
-SaveStringValue(value) ::
+SafeStringValue(value) ::
 
   Checks that +value+ is a String and is not tainted
 


### PR DESCRIPTION
As defined in [ruby.h](https://github.com/ruby/ruby/blob/c2ebf056efb44204d465d65680e52705610d7c0f/include/ruby/ruby.h#L570).