### PR TITLE
URI.Generic#find_proxy with IP format proxy and domain format uri raises an exception

### DIFF
--- a/lib/uri/generic.rb
+++ b/lib/uri/generic.rb
@@ -1535,10 +1535,10 @@ module URI
               require 'ipaddr'
               return nil if
                 begin
-                  IPAddr.new(host)
+                  IPAddr.new(host).include?(self.host)
                 rescue IPAddr::InvalidAddressError
                   next
-                end.include?(self.host)
+                end
             end
           end
         }

--- a/test/uri/test_generic.rb
+++ b/test/uri/test_generic.rb
@@ -838,6 +838,7 @@ class URI::TestGeneric < Test::Unit::TestCase
   def test_find_proxy_no_proxy
     with_proxy_env('http_proxy'=>'http://127.0.0.1:8080', 'no_proxy'=>'192.0.2.2') {|env|
       assert_equal(URI('http://127.0.0.1:8080'), URI("http://192.0.2.1/").find_proxy(env))
+      assert_equal(URI('http://127.0.0.1:8080'), URI("http://example.org/").find_proxy(env))
       assert_nil(URI("http://192.0.2.2/").find_proxy(env))
     }
     with_proxy_env('http_proxy'=>'http://127.0.0.1:8080', 'no_proxy'=>'example.org') {|env|


### PR DESCRIPTION
I think ruby 2.4.0 and later versions (including edge version) have this bug.
If you need more information or something, please let me know.

# Bug

```ruby
# The name of this file is bug.rb
require 'uri'
ENV['http_proxy']='http://127.0.0.1'
ENV['no_proxy']='192.0.2.2'
URI("http://example.org/").find_proxy
```

```sh
$ ruby bug.rb
/home/m/.rbenv/versions/2.4.0/lib/ruby/2.4.0/ipaddr.rb:563:in `in6_addr': invalid address (IPAddr::InvalidAddressError)
        from /home/m/.rbenv/versions/2.4.0/lib/ruby/2.4.0/ipaddr.rb:500:in `initialize'
        from /home/m/.rbenv/versions/2.4.0/lib/ruby/2.4.0/ipaddr.rb:518:in `new'
        from /home/m/.rbenv/versions/2.4.0/lib/ruby/2.4.0/ipaddr.rb:518:in `coerce_other'
        from /home/m/.rbenv/versions/2.4.0/lib/ruby/2.4.0/ipaddr.rb:174:in `include?'
        from /home/m/.rbenv/versions/2.4.0/lib/ruby/2.4.0/uri/generic.rb:1541:in `block in find_proxy'
        from /home/m/.rbenv/versions/2.4.0/lib/ruby/2.4.0/uri/generic.rb:1530:in `scan'
        from /home/m/.rbenv/versions/2.4.0/lib/ruby/2.4.0/uri/generic.rb:1530:in `find_proxy'
        from bug.rb:4:in `<main>'
```

or you can check it out with this command.

```sh
$ http_proxy=http://127.0.0.1 no_proxy=192.0.2.2 ruby -ropen-uri -e 'open("http://example.org")'
```

# Analysis

I found this line https://github.com/ruby/ruby/commit/1ee9cad027e910b36bd4191ef2339d02e6711a32#diff-66cc3d0ae5a8886f51f0d2e670324bf3R1560 runs like that:

```ruby
IPAddr.new(host).include?(self.host)
```

In this code, self.host is the `string` and #include? tries converting self.host to IPAddr and IPAddr.new(self.host) will be called. But IPAddr.new with a string argument raises an IPAddr::InvalidAddressError exception and there is no guard for that exception.

# Solution

Apply this pull request.

# Environment and Information

I found this bug on `ruby 2.4.0p0 (2016-12-24 revision 57164) [x86_64-linux]` and 1ee9cad027e910b36bd4191ef2339d02e6711a32 makes it and it have not been fixed on trunk yet.