### PR TITLE
error.c: fixed doc regarding the presence of to_str

### DIFF
--- a/error.c
+++ b/error.c
@@ -894,9 +894,7 @@ exc_to_s(VALUE exc)
  *   exception.message   ->  string
  *
  * Returns the result of invoking <code>exception.to_s</code>.
- * Normally this returns the exception's message or name. By
- * supplying a to_str method, exceptions are agreeing to
- * be used where Strings are expected.
+ * Normally this returns the exception's message or name.
  */
 
 static VALUE


### PR DESCRIPTION
It seems like the documentation still references an old behavior where `Exception` would define `to_str`, which is not the case anymore

```c
2.3.1 :004 > "foo" + Exception.new("bar")
TypeError: no implicit conversion of Exception into String
```

Looking at the 1.8.7 documentation in `error.c` we see the current wording with a definition of `exc_to_str`:

```C
/*
 * call-seq:
 *   exception.message   =>  string
 *   exception.to_str    =>  string
 *
 * Returns the result of invoking <code>exception.to_s</code>.
 * Normally this returns the exception's message or name. By
 * supplying a to_str method, exceptions are agreeing to
 * be used where Strings are expected.
 */

static VALUE
exc_to_str(exc)
	VALUE exc;
{
	return rb_funcall(exc, rb_intern("to_s"), 0, 0);
}
```

Nowadays in trunk there is to definition of `to_str`, but the wording "By supplying a to_str method, exceptions are agreeing to be used where Strings are expected." is still present and used for `exc_message`.

This PR fixes that.