### PR TITLE
Make prettyprint’s cycle detection aware of Delegator instances. Fixes #13144.

### DIFF
--- a/lib/pp.rb
+++ b/lib/pp.rb
@@ -149,6 +149,10 @@ class PP < PrettyPrint
     # Object#pretty_print_cycle is used when +obj+ is already
     # printed, a.k.a the object reference chain has a cycle.
     def pp(obj)
+      # If obj is a Delegator then use the object being delegated to for cycle
+      # detection
+      obj = obj.__getobj__ if defined?(::Delegator) and obj.is_a?(::Delegator)
+
       if check_inspect_key(obj)
         group {obj.pretty_print_cycle self}
         return

--- a/test/test_pp.rb
+++ b/test/test_pp.rb
@@ -184,6 +184,18 @@ class PPDelegateTest < Test::Unit::TestCase
   def test_delegate
     assert_equal("[]\n", A.new([]).pretty_inspect, "[ruby-core:25804]")
   end
+
+  def test_delegate_cycle
+    a = HasPrettyPrint.new nil
+
+    a.instance_eval {@a = a}
+    cycle_pretty_inspect = a.pretty_inspect
+
+    a.instance_eval {@a = SimpleDelegator.new(a)}
+    delegator_cycle_pretty_inspect = a.pretty_inspect
+
+    assert_equal(cycle_pretty_inspect, delegator_cycle_pretty_inspect)
+  end
 end
 
 class PPFileStatTest < Test::Unit::TestCase


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/13144