### PR TITLE
fix function name [ci skip]

### DIFF
--- a/doc/extension.ja.rdoc
+++ b/doc/extension.ja.rdoc
@@ -865,7 +865,7 @@ Rubyは拡張ライブラリをロードする時に「Init_ライブラリ名�
 DBMライブラリはdbmのデータと対応するオブジェクトになるはずで
 すから，Cの世界のdbmをRubyの世界に取り込む必要があります．
 
-dbm.cではData_Make_Structを以下のように使っています．
+dbm.cではTypedData_Make_Structを以下のように使っています．
 
   struct dbmdata {
       int  di_size;

--- a/doc/extension.rdoc
+++ b/doc/extension.rdoc
@@ -802,7 +802,7 @@ Here's the example of an initializing function.
   }
 
 The dbm extension wraps the dbm struct in the C environment using
-Data_Make_Struct.
+TypedData_Make_Struct.
 
   struct dbmdata {
       int  di_size;


### PR DESCRIPTION
Because following dbm's example uses `TypedData_Make_Struct`.