### PR TITLE
win32/win32.c: fix a buffer over-read

### DIFF
--- a/win32/win32.c
+++ b/win32/win32.c
@@ -1811,6 +1811,9 @@ w32_cmdvector(const WCHAR *cmd, char ***vec, UINT cp, rb_encoding *enc)
 	curr = (NtCmdLineElement *)calloc(sizeof(NtCmdLineElement), 1);
 	if (!curr) goto do_nothing;
 	curr->str = rb_w32_wstr_to_mbstr(cp, base, len, &curr->len);
+	if (curr->str && (curr->str = realloc(curr->str, curr->len + 1))) {
+	    curr->str[curr->len] = '\0';
+	}
 	curr->flags |= NTMALLOC;
 
 	if (globbing && (tail = cmdglob(curr, cmdtail, cp, enc))) {


### PR DESCRIPTION
On Windows, when passing parameters to ruby.exe, say "ruby.exe -I./lib", the line `curr->str = rb_w32_wstr_to_mbstr` will create a string "-I./lib" from a newly allocated memory of size `7` instead of `8`. That is to say, `NULL` is not appended at the end of `curr->str`.

That is fine as long as `curr->str` is not treated as a NULL-terminated string. However that's not the case. Later in the same function, `strlcpy` is called upon `curr->str`. By reading the source code of `strlcpy` in `missing/strlcpy.c`, we can observe that `strlcpy` is definitely expecting a NULL-terminated string. So a buffer over-read is spotted.

This patch fixes this buffer over-read.