### PR TITLE
node.c: fix NODE_OP_ASGN1 operator

### DIFF
--- a/node.c
+++ b/node.c
@@ -427,9 +427,9 @@ dump_node(VALUE buf, VALUE indent, int comment, NODE *node)
 	ANN("example: ary[1] += foo");
 	F_NODE(nd_recv, "receiver");
 	F_ID(nd_vid, "operator");
-	F_NODE(nd_args->nd_body, "index");
+	F_NODE(nd_args->nd_head, "index");
 	LAST_NODE;
-	F_NODE(nd_args->nd_head, "rvalue");
+	F_NODE(nd_args->nd_body, "rvalue");
 	break;
 
       case NODE_OP_ASGN2:

--- a/node.c
+++ b/node.c
@@ -426,7 +426,13 @@ dump_node(VALUE buf, VALUE indent, int comment, NODE *node)
 	ANN("format: [nd_value] [ [nd_args->nd_body] ] [nd_vid]= [nd_args->nd_head]");
 	ANN("example: ary[1] += foo");
 	F_NODE(nd_recv, "receiver");
-	F_ID(nd_vid, "operator");
+	F_CUSTOM1(nd_mid, "operator") {
+	   switch (node->nd_mid) {
+	     case 0: A("0 (||)"); break;
+	     case 1: A("1 (&&)"); break;
+	     default: A_ID(node->nd_mid);
+	   }
+	};
 	F_NODE(nd_args->nd_head, "index");
 	LAST_NODE;
 	F_NODE(nd_args->nd_body, "rvalue");


### PR DESCRIPTION
``` ruby
ary[1] &&= foo
```

old:
```
# @ NODE_SCOPE (line: 1)
# +- nd_tbl: (empty)
# +- nd_args:
# |   (null node)
# +- nd_body:
#     @ NODE_PRELUDE (line: 1)
#     +- nd_head:
#     |   (null node)
#     +- nd_body:
#     |   @ NODE_OP_ASGN1 (line: 1)
#     |   +- nd_recv:
#     |   |   @ NODE_VCALL (line: 1)
#     |   |   +- nd_mid: :ary
#     |   +- nd_vid: (internal variable)
#     |   +- nd_args->nd_body:
#     |   |   @ NODE_VCALL (line: 1)
#     |   |   +- nd_mid: :foo
#     |   +- nd_args->nd_head:
#     |       @ NODE_ARRAY (line: 1)
#     |       +- nd_alen: 1
#     |       +- nd_head:
#     |       |   @ NODE_LIT (line: 1)
#     |       |   +- nd_lit: 1
#     |       +- nd_next:
#     |           (null node)
#     +- nd_compile_option: false
```

nd_vid: (internal variable), It should use nd_mid


new:
```
# @ NODE_SCOPE (line: 1)
# +- nd_tbl: (empty)
# +- nd_args:
# |   (null node)
# +- nd_body:
#     @ NODE_PRELUDE (line: 1)
#     +- nd_head:
#     |   (null node)
#     +- nd_body:
#     |   @ NODE_OP_ASGN1 (line: 1)
#     |   +- nd_recv:
#     |   |   @ NODE_VCALL (line: 1)
#     |   |   +- nd_mid: :ary
#     |   +- nd_mid: 1 (&&)
#     |   +- nd_args->nd_head:
#     |   |   @ NODE_ARRAY (line: 1)
#     |   |   +- nd_alen: 1
#     |   |   +- nd_head:
#     |   |   |   @ NODE_LIT (line: 1)
#     |   |   |   +- nd_lit: 1
#     |   |   +- nd_next:
#     |   |       (null node)
#     |   +- nd_args->nd_body:
#     |       @ NODE_VCALL (line: 1)
#     |       +- nd_mid: :foo
#     +- nd_compile_option: false
```