### PR TITLE
node.c: fix nd_ainfo->kw_rest_arg

### DIFF
--- a/node.c
+++ b/node.c
@@ -974,9 +974,14 @@ dump_node(VALUE buf, VALUE indent, int comment, NODE *node)
 	F_ID(nd_ainfo->rest_arg, "rest argument");
 	F_ID(nd_ainfo->block_arg, "block argument");
 	F_NODE(nd_ainfo->opt_args, "optional arguments");
-	LAST_NODE;
 	F_NODE(nd_ainfo->kw_args, "keyword arguments");
-	F_NODE(nd_ainfo->kw_rest_arg, "keyword rest argument");
+	LAST_NODE;
+	if (node->nd_ainfo->kw_args) {
+	    F_ID(nd_ainfo->kw_rest_arg->nd_cflag, "keyword rest argument");
+	} 
+	else {
+	    F_NODE(nd_ainfo->kw_rest_arg, "keyword rest argument");
+	}
 	break;
 
       case NODE_SCOPE:


### PR DESCRIPTION
```ruby
def foo1(a: 1, **kwrest)
end
```

old:
```
# @ NODE_SCOPE (line: 2)
# +- nd_tbl: (empty)
# +- nd_args:
# |   (null node)
# +- nd_body:
#     @ NODE_PRELUDE (line: 2)
#     +- nd_head:
#     |   (null node)
#     +- nd_body:
#     |   @ NODE_DEFN (line: 1)
#     |   +- nd_mid: :foo1
#     |   +- nd_defn:
#     |       @ NODE_SCOPE (line: 2)
#     |       +- nd_tbl: :a,(internal variable),:kwrest
#     |       +- nd_args:
#     |       |   @ NODE_ARGS (line: 1)
#     |       |   +- nd_ainfo->pre_args_num: 0
#     |       |   +- nd_ainfo->pre_init:
#     |       |   |   (null node)
#     |       |   +- nd_ainfo->post_args_num: 0
#     |       |   +- nd_ainfo->post_init:
#     |       |   |   (null node)
#     |       |   +- nd_ainfo->first_post_arg: (null)
#     |       |   +- nd_ainfo->rest_arg: (null)
#     |       |   +- nd_ainfo->block_arg: (null)
#     |       |   +- nd_ainfo->opt_args:
#     |       |   |   (null node)
#     |       |   +- nd_ainfo->kw_args:
#     |       |       @ NODE_KW_ARG (line: 1)
#     |       |       +- nd_body:
#     |       |       |   @ NODE_LASGN (line: 1)
#     |       |       |   +- nd_vid: :a
#     |       |       |   +- nd_value:
#     |       |       |       @ NODE_LIT (line: 1)
#     |       |       |       +- nd_lit: 1
#     |       |       +- nd_next:
#     |       |           (null node)
#     |       |   +- nd_ainfo->kw_rest_arg:
#     |       |       @ NODE_DVAR (line: 1)
#     |       |       +- nd_vid: (internal variable)
#     |       +- nd_body:
#     |           (null node)
#     +- nd_compile_option: false
```

if nd_ainfo->kw_args is not null, It should use nd_cflag

new
```
# @ NODE_SCOPE (line: 2)
# +- nd_tbl: (empty)
# +- nd_args:
# |   (null node)
# +- nd_body:
#     @ NODE_PRELUDE (line: 2)
#     +- nd_head:
#     |   (null node)
#     +- nd_body:
#     |   @ NODE_DEFN (line: 1)
#     |   +- nd_mid: :foo1
#     |   +- nd_defn:
#     |       @ NODE_SCOPE (line: 2)
#     |       +- nd_tbl: :a,(internal variable),:kwrest
#     |       +- nd_args:
#     |       |   @ NODE_ARGS (line: 1)
#     |       |   +- nd_ainfo->pre_args_num: 0
#     |       |   +- nd_ainfo->pre_init:
#     |       |   |   (null node)
#     |       |   +- nd_ainfo->post_args_num: 0
#     |       |   +- nd_ainfo->post_init:
#     |       |   |   (null node)
#     |       |   +- nd_ainfo->first_post_arg: (null)
#     |       |   +- nd_ainfo->rest_arg: (null)
#     |       |   +- nd_ainfo->block_arg: (null)
#     |       |   +- nd_ainfo->opt_args:
#     |       |   |   (null node)
#     |       |   +- nd_ainfo->kw_args:
#     |       |   |   @ NODE_KW_ARG (line: 1)
#     |       |   |   +- nd_body:
#     |       |   |   |   @ NODE_LASGN (line: 1)
#     |       |   |   |   +- nd_vid: :a
#     |       |   |   |   +- nd_value:
#     |       |   |   |       @ NODE_LIT (line: 1)
#     |       |   |   |       +- nd_lit: 1
#     |       |   |   +- nd_next:
#     |       |   |       (null node)
#     |       |   +- nd_ainfo->kw_rest_arg->nd_cflag: :kwrest
#     |       +- nd_body:
#     |           (null node)
#     +- nd_compile_option: false
```