### PR TITLE
Improve Array#== and Hash#== performance

### DIFF
--- a/array.c
+++ b/array.c
@@ -3872,7 +3872,7 @@ recursive_equal(VALUE ary1, VALUE ary2, int recur)
  *
  */
 
-static VALUE
+VALUE
 rb_ary_equal(VALUE ary1, VALUE ary2)
 {
     if (ary1 == ary2) return Qtrue;

--- a/hash.c
+++ b/hash.c
@@ -2236,7 +2236,7 @@ hash_equal(VALUE hash1, VALUE hash2, int eql)
  *
  */
 
-static VALUE
+VALUE
 rb_hash_equal(VALUE hash1, VALUE hash2)
 {
     return hash_equal(hash1, hash2, FALSE);

--- a/internal.h
+++ b/internal.h
@@ -957,6 +957,7 @@ VALUE rb_gvar_defined(struct rb_global_entry *);
 struct vtm; /* defined by timev.h */
 
 /* array.c */
+VALUE rb_ary_equal(VALUE ary1, VALUE ary2);
 VALUE rb_ary_last(int, const VALUE *, VALUE);
 void rb_ary_set_len(VALUE, long);
 void rb_ary_delete_same(VALUE, VALUE);
@@ -1166,6 +1167,7 @@ void rb_gc_resurrect(VALUE ptr);
 
 /* hash.c */
 struct st_table *rb_hash_tbl_raw(VALUE hash);
+VALUE rb_hash_equal(VALUE hash1, VALUE hash2);
 VALUE rb_hash_has_key(VALUE hash, VALUE key);
 VALUE rb_hash_default_value(VALUE hash, VALUE key);
 VALUE rb_hash_set_default_proc(VALUE hash, VALUE proc);

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1290,6 +1290,16 @@ opt_eq_func(VALUE recv, VALUE obj, CALL_INFO ci, CALL_CACHE cc)
 		 BASIC_OP_UNREDEFINED_P(BOP_EQ, STRING_REDEFINED_OP_FLAG)) {
 	    return rb_str_equal(recv, obj);
 	}
+	else if (RBASIC_CLASS(recv) == rb_cArray &&
+		 RBASIC_CLASS(obj) == rb_cArray &&
+		 BASIC_OP_UNREDEFINED_P(BOP_EQ, ARRAY_REDEFINED_OP_FLAG)) {
+	    return rb_ary_equal(recv, obj);
+	}
+	else if (RBASIC_CLASS(recv) == rb_cHash &&
+		 RBASIC_CLASS(obj) == rb_cHash &&
+		 BASIC_OP_UNREDEFINED_P(BOP_EQ, HASH_REDEFINED_OP_FLAG)) {
+	    return rb_hash_equal(recv, obj);
+	}
     }
 
     {


### PR DESCRIPTION
This introduce shortcut to call Array#== and Hash#== then improve these methods performance around 5%.

### Before
```
               user     system      total        real
Hash#==    0.850000   0.000000   0.850000 (  0.853143)
Array#==   0.650000   0.010000   0.660000 (  0.654546)
```

### After
```
Hash#==    0.800000   0.000000   0.800000 (  0.803759)
Array#==   0.610000   0.000000   0.610000 (  0.606047)
```

### Test code
```
require 'benchmark'

Benchmark.bmbm do |x|
  $hash1 = {}
  1000.times { |i| $hash1[i.to_s] = i }
  $hash2 = {}
  1000.times { |i| $hash2[(i*2).to_s] = i*2 }

  x.report "Hash#==" do
    2000000.times do
      $hash1 == $hash2
    end
  end

  $ary1 = []
  1000.times { |i| $ary1 << i }
  $ary2 = []
  1000.times { |i| $ary2 << i*2 }

  x.report "Array#==" do
    2000000.times do
      $ary1 == $ary2
    end
  end
end
```