### PR TITLE
Improve Hash#merge performance

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -2502,7 +2502,7 @@ rb_hash_update_by(VALUE hash1, VALUE hash2, rb_hash_update_func *func)
 static VALUE
 rb_hash_merge(VALUE hash1, VALUE hash2)
 {
-    return rb_hash_update(rb_obj_dup(hash1), hash2);
+    return rb_hash_update(rb_hash_dup(hash1), hash2);
 }
 
 static int


### PR DESCRIPTION
Hash#merge will be faster around 60%.

* Before
```
                 user     system      total        real
Hash#merge   0.160000   0.020000   0.180000 (  0.182357)
```

* After
```
                 user     system      total        real
Hash#merge   0.110000   0.010000   0.120000 (  0.114404)
```

* Test code
```
require 'benchmark'

Benchmark.bmbm do |x|
  hash1 = {}
  100.times { |i| hash1[i.to_s] = i }
  hash2 = {}
  100.times { |i| hash2[(i*2).to_s] = i*2 }

  x.report "Hash#merge" do
    10000.times do
      hash1.merge(hash2)
    end
  end
end
```

https://bugs.ruby-lang.org/issues/13343