### PR TITLE
Improve Array#sort performance

### DIFF
--- a/array.c
+++ b/array.c
@@ -2470,7 +2470,6 @@ rb_ary_sort_bang(VALUE ary)
 	    ruby_qsort(ptr, len, sizeof(VALUE),
 		       rb_block_given_p()?sort_1:sort_2, &data);
 	}); /* WB: no new reference */
-	rb_ary_modify(ary);
         if (ARY_EMBED_P(tmp)) {
             if (ARY_SHARED_P(ary)) { /* ary might be destructively operated in the given block */
                 rb_ary_unshare(ary);


### PR DESCRIPTION
Array#sort will be faster around 5%.
This patch remove dupliated rb_ary_modify() calling in Array#sort.
Seems that it is enough to call rb_ary_modify() once on top of rb_ary_sort_bang().

* Before
```
                 user     system      total        real
Array#sort   1.850000   0.000000   1.850000 (  1.851303)
```

* After
```
                 user     system      total        real
Array#sort   1.740000   0.010000   1.750000 (  1.751054)
```

* Test code
```
require 'benchmark'

Benchmark.bmbm do |x|

  ary = []
  100.times { |i| ary << Random.rand(500) }

  x.report "Array#sort" do
    300000.times do
      ary.sort
    end
  end

end
```