### PR TITLE
Improve yielding block performance

### DIFF
--- a/vm.c
+++ b/vm.c
@@ -948,6 +948,11 @@ rb_binding_add_dynavars(rb_binding_t *bind, int dyncount, const ID *dynvars)
 
 /* C -> Ruby: block */
 
+ALWAYS_INLINE(
+    static VALUE
+    invoke_block(rb_thread_t *th, const rb_iseq_t *iseq, VALUE self, const struct rb_captured_block *captured, const rb_cref_t *cref, VALUE type, int opt_pc)
+);
+
 static inline VALUE
 invoke_block(rb_thread_t *th, const rb_iseq_t *iseq, VALUE self, const struct rb_captured_block *captured, const rb_cref_t *cref, VALUE type, int opt_pc)
 {
@@ -1080,6 +1085,13 @@ vm_yield_with_block(rb_thread_t *th, int argc, const VALUE *argv, VALUE block_ha
 {
     return invoke_block_from_c_splattable(th, check_block_handler(th), argc, argv, block_handler, NULL, FALSE);
 }
+
+ALWAYS_INLINE(
+    static VALUE
+    invoke_block_from_c_unsplattable(rb_thread_t *th, const struct rb_block *block,
+				     VALUE self, int argc, const VALUE *argv,
+				     VALUE passed_block_handler, int is_lambda)
+);
 
 static inline VALUE
 invoke_block_from_c_unsplattable(rb_thread_t *th, const struct rb_block *block,

--- a/vm.c
+++ b/vm.c
@@ -984,6 +984,12 @@ invoke_bmethod(rb_thread_t *th, const rb_iseq_t *iseq, VALUE self, const struct 
     return ret;
 }
 
+ALWAYS_INLINE(
+    static VALUE
+    invoke_iseq_block_from_c(rb_thread_t *th, const struct rb_captured_block *captured,
+			     VALUE self, int argc, const VALUE *argv, VALUE passed_block_handler,
+			     const rb_cref_t *cref, const int splattable, int is_lambda)
+);
 static inline VALUE
 invoke_iseq_block_from_c(rb_thread_t *th, const struct rb_captured_block *captured,
 			 VALUE self, int argc, const VALUE *argv, VALUE passed_block_handler,
@@ -1011,6 +1017,13 @@ invoke_iseq_block_from_c(rb_thread_t *th, const struct rb_captured_block *captur
     }
 }
 
+ALWAYS_INLINE(
+    static VALUE
+    invoke_block_from_c_splattable(rb_thread_t *th, VALUE block_handler,
+				   int argc, const VALUE *argv,
+				   VALUE passed_block_handler, const rb_cref_t *cref,
+				   int is_lambda)
+);
 static inline VALUE
 invoke_block_from_c_splattable(rb_thread_t *th, VALUE block_handler,
 			       int argc, const VALUE *argv,

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -1003,6 +1003,7 @@ rb_f_public_send(int argc, VALUE *argv, VALUE recv)
 
 /* yield */
 
+ALWAYS_INLINE(static VALUE rb_yield_0(int argc, const VALUE * argv));
 static inline VALUE
 rb_yield_0(int argc, const VALUE * argv)
 {


### PR DESCRIPTION
The yielding block will be faster around 9%.
This patch ensures that expand to inline codes in where invoke yielding block.

* Environment
  - macOS 10.12.3
  - clang 8.0.0 in Xcode 8.2

* Before
```
                    user     system      total        real
Integer#times   0.930000   0.000000   0.930000 (  0.932125)
Array#each      0.950000   0.000000   0.950000 (  0.957962)
Array#map       1.220000   0.030000   1.250000 (  1.249174)
```

* After
```
                    user     system      total        real
Integer#times   0.850000   0.000000   0.850000 (  0.853202)
Array#each      0.860000   0.010000   0.870000 (  0.865507)
Array#map       1.120000   0.020000   1.140000 (  1.149939)
```

* Test code
```
require 'benchmark'

Benchmark.bmbm do |x|

  ary = (1..10000).to_a

  x.report "Integer#times" do
    20000000.times do
    end
  end

  x.report "Array#each" do
    2000.times do
      ary.each { |x| }
    end
  end

  x.report "Array#map" do
    2000.times do
      ary.map { |x| }
    end
  end

end
```

https://bugs.ruby-lang.org/issues/13342