### PR TITLE
Improve performance of Array#sort with float elements

### DIFF
--- a/array.c
+++ b/array.c
@@ -2420,6 +2420,9 @@ sort_2(const void *ap, const void *bp, void *dummy)
     if (STRING_P(a) && STRING_P(b) && CMP_OPTIMIZABLE(data->cmp_opt, String)) {
 	return rb_str_cmp(a, b);
     }
+    if (RB_FLOAT_TYPE_P(a) && RB_FLOAT_TYPE_P(b) && CMP_OPTIMIZABLE(data->cmp_opt, Float)) {
+	return rb_float_cmp(a, b);
+    }
 
     retval = rb_funcallv(a, id_cmp, 1, &b);
     n = rb_cmpint(retval, a, b);

--- a/array.c
+++ b/array.c
@@ -2420,7 +2420,7 @@ sort_2(const void *ap, const void *bp, void *dummy)
     if (STRING_P(a) && STRING_P(b) && CMP_OPTIMIZABLE(data->cmp_opt, String)) {
 	return rb_str_cmp(a, b);
     }
-    if (RB_FLOAT_TYPE_P(a) && RB_FLOAT_TYPE_P(b) && CMP_OPTIMIZABLE(data->cmp_opt, Float)) {
+    if (RB_FLOAT_TYPE_P(a) && CMP_OPTIMIZABLE(data->cmp_opt, Float)) {
 	return rb_float_cmp(a, b);
     }
 

--- a/internal.h
+++ b/internal.h
@@ -965,7 +965,7 @@ struct cmp_opt_data {
      (((long)a > (long)b) ? 1 : ((long)a < (long)b) ? -1 : 0) : \
      (STRING_P(a) && STRING_P(b) && CMP_OPTIMIZABLE(data, String)) ? \
      rb_str_cmp(a, b) : \
-     (RB_FLOAT_TYPE_P(a) && RB_FLOAT_TYPE_P(b) && CMP_OPTIMIZABLE(data, Float)) ? \
+     (RB_FLOAT_TYPE_P(a) && CMP_OPTIMIZABLE(data, Float)) ? \
      rb_float_cmp(a, b) : \
      rb_cmpint(rb_funcallv(a, id_cmp, 1, &b), a, b))
 

--- a/internal.h
+++ b/internal.h
@@ -940,6 +940,7 @@ struct MEMO {
 
 enum {
     cmp_opt_Fixnum,
+    cmp_opt_Float,
     cmp_opt_String,
     cmp_optimizable_count
 };
@@ -964,6 +965,8 @@ struct cmp_opt_data {
      (((long)a > (long)b) ? 1 : ((long)a < (long)b) ? -1 : 0) : \
      (STRING_P(a) && STRING_P(b) && CMP_OPTIMIZABLE(data, String)) ? \
      rb_str_cmp(a, b) : \
+     (RB_FLOAT_TYPE_P(a) && RB_FLOAT_TYPE_P(b) && CMP_OPTIMIZABLE(data, Float)) ? \
+     rb_float_cmp(a, b) : \
      rb_cmpint(rb_funcallv(a, id_cmp, 1, &b), a, b))
 
 /* ment is in method.h */
@@ -1293,6 +1296,7 @@ VALUE rb_int2str(VALUE num, int base);
 VALUE rb_dbl_hash(double d);
 VALUE rb_fix_plus(VALUE x, VALUE y);
 VALUE rb_int_gt(VALUE x, VALUE y);
+int rb_float_cmp(VALUE x, VALUE y);
 VALUE rb_float_gt(VALUE x, VALUE y);
 VALUE rb_int_ge(VALUE x, VALUE y);
 enum ruby_num_rounding_mode rb_num_get_rounding_option(VALUE opts);

--- a/numeric.c
+++ b/numeric.c
@@ -1520,6 +1520,12 @@ flo_cmp(VALUE x, VALUE y)
     return rb_dbl_cmp(a, b);
 }
 
+int
+rb_float_cmp(VALUE x, VALUE y)
+{
+    return FIX2INT(flo_cmp(x, y));
+}
+
 /*
  * call-seq:
  *   float > real  ->  true or false

--- a/numeric.c
+++ b/numeric.c
@@ -1523,7 +1523,7 @@ flo_cmp(VALUE x, VALUE y)
 int
 rb_float_cmp(VALUE x, VALUE y)
 {
-    return FIX2INT(flo_cmp(x, y));
+    return NUM2INT(flo_cmp(x, y));
 }
 
 /*


### PR DESCRIPTION
Array#sort with float elements will be over 2 times faster.

* Before
```
       user     system      total        real
   5.650000   0.020000   5.670000 (  5.661151)
```

* After
```
       user     system      total        real
   2.410000   0.010000   2.420000 (  2.427718)
```

* Test code
```
require 'benchmark'

Benchmark.bmbm do |x|

  ary = []
  1000.times { |i| ary << Random.rand }

  x.report do

    10000.times do
      ary.sort
    end

  end

end
```

https://bugs.ruby-lang.org/issues/13340