### PR TITLE
improves Float#round documentation to better highlight the half keyword

### DIFF
--- a/doc/contributors.rdoc
+++ b/doc/contributors.rdoc
@@ -57,6 +57,9 @@ Oliver M. Bolzer
 Alexey Borzenkov
 * a patch for mkmf.rb
 
+Evan Brodie
+* documentation
+
 Richard Brown
 * a patch for configure.in
 

--- a/numeric.c
+++ b/numeric.c
@@ -2254,8 +2254,8 @@ rb_int_truncate(VALUE num, int ndigits)
  *     2.5.round(half: :even) #=> 2
  *     2.5.round(half: :down) #=> 2
  *     3.5.round(half: :up)   #=> 4
- *     3.5.round(half: :down) #=> 4
- *     3.5.round(half: :even) #=> 3
+ *     3.5.round(half: :even) #=> 4
+ *     3.5.round(half: :down) #=> 3
  */
 
 static VALUE

--- a/numeric.c
+++ b/numeric.c
@@ -2215,7 +2215,7 @@ rb_int_truncate(VALUE num, int ndigits)
 
 /*
  *  call-seq:
- *     float.round([ndigits])  ->  integer or float
+ *     float.round([ndigits] [, half: symbol])  ->  integer or float
  *
  *  Rounds +float+ to a given precision in decimal digits (default 0 digits).
  *
@@ -2242,13 +2242,20 @@ rb_int_truncate(VALUE num, int ndigits)
  *     34567.89.round(2)  #=> 34567.89
  *     34567.89.round(3)  #=> 34567.89
  *
- *  If <code>half:</code> optional keyword is given, just-half number
+ *  If the <code>half:</code> optional keyword is given, just-half number
  *  will be rounded according to that value.
  *  Supported values for this keyword are follows.
  *
  *  * <code>:up</code> or +nil+: the result will be rounded away from zero
  *  * <code>:even</code>: the result will be rounded to nearest even number
  *  * <code>:down</code>: the result will be rounded close to zero
+ *
+ *     2.5.round(half: :up)   #=> 3
+ *     2.5.round(half: :even) #=> 2
+ *     2.5.round(half: :down) #=> 2
+ *     3.5.round(half: :up)   #=> 4
+ *     3.5.round(half: :down) #=> 4
+ *     3.5.round(half: :even) #=> 3
  */
 
 static VALUE


### PR DESCRIPTION
This PR improves documentation for `Float#round`. Most notably, to better highlight the `half` keyword that was added in **Ruby 2.4.0**.

When I first learned about changes to `round` in this newest Ruby version, I went to check out the official docs on the web to see what keywords were supported. I was able to find the information I was looking for, but it was buried into the last paragraph of the function's documentation. For a user checking out these docs but not aware of the new functionality in Ruby 2.4.0 like I am, support for specifying a rounding method may not be apparent because:

* The keyword was not provided in the function's contract
* There were no code examples for the keyword's values

This PR hopefully makes this documentation more clear for Ruby developers.

**NOTE:** I am not entirely sure if my edit to the function's contract, to highlight the optional `half` argument, follow existing guidelines. I had trouble finding another method in Ruby core or stdlib to use as an example. Please feel free to suggest a change to this line.