### PR TITLE
Removed deprecated mathn extensions.

### DIFF
--- a/doc/maintainers.rdoc
+++ b/doc/maintainers.rdoc
@@ -183,10 +183,6 @@ Zachary Scott (zzak)
   Nobuyuki Nakada (nobu)
 [ext/io/wait]
   Nobuyuki Nakada (nobu)
-[ext/mathn/complex]
-  Keiju ISHITSUKA (keiju)
-[ext/mathn/rational]
-  Keiju ISHITSUKA (keiju)
 [ext/nkf]
   NARUSE, Yui (narse)
 [ext/objspace]

--- a/ext/Setup
+++ b/ext/Setup
@@ -23,8 +23,6 @@
 #json
 #json/generator
 #json/parser
-#mathn/complex
-#mathn/rational
 #nkf
 #objspace
 #openssl

--- a/ext/Setup.nacl
+++ b/ext/Setup.nacl
@@ -25,8 +25,6 @@
 # #json
 # json/generator
 # json/parser
-# mathn/complex
-# mathn/rational
 # nkf
 # objspace
 # #openssl

--- a/ext/mathn/complex/complex.c
+++ b/ext/mathn/complex/complex.c
@@ -1,7 +1,0 @@
-extern void nucomp_canonicalization(int);
-
-void
-Init_complex(void)
-{
-    nucomp_canonicalization(1);
-}

--- a/ext/mathn/complex/extconf.rb
+++ b/ext/mathn/complex/extconf.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: false
-require "mkmf"
-
-create_makefile "mathn/complex"

--- a/ext/mathn/rational/extconf.rb
+++ b/ext/mathn/rational/extconf.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: false
-require "mkmf"
-
-create_makefile "mathn/rational"

--- a/ext/mathn/rational/rational.c
+++ b/ext/mathn/rational/rational.c
@@ -1,7 +1,0 @@
-extern void nurat_canonicalization(int);
-
-void
-Init_rational(void)
-{
-    nurat_canonicalization(1);
-}

--- a/lib/mathn.rb
+++ b/lib/mathn.rb
@@ -46,9 +46,6 @@ require "cmath.rb"
 require "matrix.rb"
 require "prime.rb"
 
-require "mathn/rational"
-require "mathn/complex"
-
 unless defined?(Math.exp!)
   Object.instance_eval{remove_const :Math}
   Math = CMath # :nodoc:

--- a/test/ruby/test_extlibs.rb
+++ b/test/ruby/test_extlibs.rb
@@ -61,8 +61,6 @@ class TestExtLibs < Test::Unit::TestCase
   check_existence "io/nonblock"
   check_existence "io/wait"
   check_existence "json"
-  check_existence "mathn/complex"
-  check_existence "mathn/rational"
   check_existence "nkf"
   check_existence "objspace"
   check_existence "openssl", "this may be false positive, but should assert because rubygems requires this"

--- a/test/test_mathn.rb
+++ b/test/test_mathn.rb
@@ -7,8 +7,6 @@ class TestMathn < Test::Unit::TestCase
     stderr = $VERBOSE ? ["lib/mathn.rb is deprecated"] : []
     assert_in_out_err ['-r', 'mathn', '-e', 'a=1**2;!a'], "", [], stderr, '[ruby-core:25740]'
     assert_in_out_err ['-r', 'mathn', '-e', 'a=(1 << 126)**2;!a'], "", [], stderr, '[ruby-core:25740]'
-    assert_in_out_err ['-r', 'mathn/complex', '-e', 'a=Complex(0,1)**4;!a'], "", [], [], '[ruby-core:44170]'
-    assert_in_out_err ['-r', 'mathn/complex', '-e', 'a=Complex(0,1)**5;!a'], "", [], [], '[ruby-core:44170]'
   end
 
   def test_quo


### PR DESCRIPTION
`mathn/complex` and `mathn/rational` is deprecated from 2008. We should remove it before Ruby 3.0 release.
