### PR TITLE
Dir.c: properly refer to keyword argument by its actual name

### DIFF
--- a/dir.c
+++ b/dir.c
@@ -485,7 +485,7 @@ dir_s_alloc(VALUE klass)
  *
  *  Returns a new directory object for the named directory.
  *
- *  The optional <i>enc</i> argument specifies the encoding of the directory.
+ *  The optional <i>encoding</i> keyword argument specifies the encoding of the directory.
  *  If not specified, the filesystem encoding is used.
  */
 static VALUE
@@ -556,7 +556,7 @@ dir_initialize(int argc, VALUE *argv, VALUE dir)
  *     Dir.open( string ) {| aDir | block } -> anObject
  *     Dir.open( string, encoding: enc ) {| aDir | block } -> anObject
  *
- *  The optional <i>enc</i> argument specifies the encoding of the directory.
+ *  The optional <i>encoding</i> keyword argument specifies the encoding of the directory.
  *  If not specified, the filesystem encoding is used.
  *
  *  With no block, <code>open</code> is a synonym for
@@ -2430,8 +2430,8 @@ dir_foreach(int argc, VALUE *argv, VALUE io)
  *  directory. Will raise a <code>SystemCallError</code> if the named
  *  directory doesn't exist.
  *
- *  The optional <i>enc</i> argument specifies the encoding of the directory.
- *  If not specified, the filesystem encoding is used.
+ *  The optional <i>encoding</i> keyword argument specifies the encoding of the
+ *  directory. If not specified, the filesystem encoding is used.
  *
  *     Dir.entries("testdir")   #=> [".", "..", "config.h", "main.rb"]
  *


### PR DESCRIPTION
`enc` is the name of the variable used in the example, not the name of the
keyword argument: `encoding`.

The documentation used to wrongly suggest that the keyword argument name was
"enc" which could cause people try try to call `Dir.open("thing", enc: "utf-8")`

I don't know if this is a strange convention in Ruby documentation where we somehow use the name of the example variable (`enc` in this example) in the method call examples.

/cc @zzak 