### PR TITLE
Improve performance of Array#sort with block

### DIFF
--- a/array.c
+++ b/array.c
@@ -2397,7 +2397,9 @@ sort_1(const void *ap, const void *bp, void *dummy)
     VALUE retval = sort_reentered(data->ary);
     VALUE a = *(const VALUE *)ap, b = *(const VALUE *)bp;
     int n;
-    VALUE args[2] = { a, b };
+    VALUE args[2];
+    args[0] = a;
+    args[1] = b;
 
     retval = rb_yield_values2(2, args);
     n = rb_cmpint(retval, a, b);

--- a/array.c
+++ b/array.c
@@ -2397,8 +2397,9 @@ sort_1(const void *ap, const void *bp, void *dummy)
     VALUE retval = sort_reentered(data->ary);
     VALUE a = *(const VALUE *)ap, b = *(const VALUE *)bp;
     int n;
+    VALUE args[2] = { a, b };
 
-    retval = rb_yield_values(2, a, b);
+    retval = rb_yield_values2(2, args);
     n = rb_cmpint(retval, a, b);
     sort_reentered(data->ary);
     return n;


### PR DESCRIPTION
Array#sort with block will be ~10% faster.
Seems that a performance was reduced at
https://github.com/ruby/ruby/blob/976becf7eb18aa1592c703ac4d86a2cf9dfa701e/vm_eval.c#L1042-L1046
So by this patch, a small argument will be given directly into rb_yield_values2()

* Before
```
       user     system      total        real
   0.860000   0.000000   0.860000 (  0.869366)
```

* After
```
       user     system      total        real
   0.790000   0.000000   0.790000 (  0.791408)
```

* Test code
```
require 'benchmark'

Benchmark.bmbm do |x|

  ary = []
  1000.times { |i| ary << Random.rand(1000) }

  x.report do

    1000.times do
      ary.sort{ |a,b| a<=>b}
    end

  end

end
```

https://bugs.ruby-lang.org/issues/13344