### PR TITLE
Fix broken --exact parameter to gem command

### DIFF
--- a/lib/rubygems/commands/query_command.rb
+++ b/lib/rubygems/commands/query_command.rb
@@ -86,7 +86,7 @@ is too hard to use.
       name = Array(options[:name])
     else
       args = options[:args].to_a
-      name = options[:exact] ? args : args.map{|arg| /#{arg}/i }
+      name = options[:exact] ? args.map{|arg| /\A#{arg}\Z/i } : args.map{|arg| /#{arg}/i }
     end
 
     prerelease = options[:prerelease]

--- a/test/rubygems/test_gem_commands_query_command.rb
+++ b/test/rubygems/test_gem_commands_query_command.rb
@@ -642,7 +642,7 @@ pl (1)
     assert_equal expected, @ui.output
   end
 
-  def test_execute_exact
+  def test_execute_exact_remote
     spec_fetcher do |fetcher|
       fetcher.spec 'coolgem-omg', 3
       fetcher.spec 'coolgem', '4.2.1'
@@ -660,6 +660,60 @@ pl (1)
 *** REMOTE GEMS ***
 
 coolgem (4.2.1)
+    EOF
+
+    assert_equal expected, @ui.output
+  end
+
+  def test_execute_exact
+    spec_fetcher do |fetcher|
+      fetcher.spec 'coolgem-omg', 3
+      fetcher.spec 'coolgem', '4.2.1'
+      fetcher.spec 'wow_coolgem', 1
+    end
+
+    @cmd.handle_options %w[--exact coolgem]
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    expected = <<-EOF
+
+*** LOCAL GEMS ***
+
+coolgem (4.2.1)
+    EOF
+
+    assert_equal expected, @ui.output
+  end
+
+  def test_execute_exact_multiple
+    spec_fetcher do |fetcher|
+      fetcher.spec 'coolgem-omg', 3
+      fetcher.spec 'coolgem', '4.2.1'
+      fetcher.spec 'wow_coolgem', 1
+
+      fetcher.spec 'othergem-omg', 3
+      fetcher.spec 'othergem', '1.2.3'
+      fetcher.spec 'wow_othergem', 1
+    end
+
+    @cmd.handle_options %w[--exact coolgem othergem]
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    expected = <<-EOF
+
+*** LOCAL GEMS ***
+
+coolgem (4.2.1)
+
+*** LOCAL GEMS ***
+
+othergem (1.2.3)
     EOF
 
     assert_equal expected, @ui.output


### PR DESCRIPTION
Before this patch `gem list --exact` fails with the following error:

    > gem list --exact aws-sdk

    *** LOCAL GEMS ***

    ERROR:  While executing gem ... (TypeError)
        type mismatch: String given

---

I have also verified that this fails on ruby 2.3.3 and ruby 2.4.0, and if possible would like it to be backported.