### PR TITLE
Improve Time#<=> performance

### DIFF
--- a/time.c
+++ b/time.c
@@ -63,6 +63,7 @@ cmp(VALUE x, VALUE y)
             return 1;
         return 0;
     }
+    if (RB_TYPE_P(x, T_BIGNUM)) return FIX2INT(rb_big_cmp(x, y));
     return rb_cmpint(rb_funcall(x, id_cmp, 1, y), x, y);
 }
 

--- a/time.c
+++ b/time.c
@@ -322,7 +322,7 @@ wcmp(wideval_t wx, wideval_t wy)
 #endif
     x = w2v(wx);
     y = w2v(wy);
-    return rb_cmpint(rb_funcall(x, id_cmp, 1, y), x, y);
+    return cmp(x, y);
 }
 
 #define wne(x,y) (!weq((x),(y)))


### PR DESCRIPTION
Time#<=> will be faster around 60%.
If internal values would have Fixnum,
optimized function improves performance.
(https://github.com/ruby/ruby/blob/9b69e9fafc329aaa540d5adeb55124f020abfe3c/time.c#L57-L67)

* Before
```
       user     system      total        real
   1.410000   0.000000   1.410000 (  1.407848)
```

* After
```
       user     system      total        real
   0.880000   0.000000   0.880000 (  0.886662)
```

* Test code
```
require 'benchmark'

Benchmark.bmbm do |x|

  x.report do
    t1 = Time.now
    t2 = Time.now
    10000000.times do
      t1 <=> t2
    end
  end

end
```

https://bugs.ruby-lang.org/issues/13354