### PR TITLE
Improve Time#+ & Time#- performance

### DIFF
--- a/time.c
+++ b/time.c
@@ -344,33 +344,25 @@ wcmp(wideval_t wx, wideval_t wy)
 static wideval_t
 wadd(wideval_t wx, wideval_t wy)
 {
-    VALUE x;
 #if WIDEVALUE_IS_WIDER
     if (FIXWV_P(wx) && FIXWV_P(wy)) {
         wideint_t r = FIXWV2WINT(wx) + FIXWV2WINT(wy);
         return WINT2WV(r);
     }
-    else
 #endif
-    x = w2v(wx);
-    if (RB_TYPE_P(x, T_BIGNUM)) return v2w(rb_big_plus(x, w2v(wy)));
-    return v2w(rb_funcall(x, '+', 1, w2v(wy)));
+    return v2w(addv(w2v(wx), w2v(wy)));
 }
 
 static wideval_t
 wsub(wideval_t wx, wideval_t wy)
 {
-    VALUE x;
 #if WIDEVALUE_IS_WIDER
     if (FIXWV_P(wx) && FIXWV_P(wy)) {
         wideint_t r = FIXWV2WINT(wx) - FIXWV2WINT(wy);
         return WINT2WV(r);
     }
-    else
 #endif
-    x = w2v(wx);
-    if (RB_TYPE_P(x, T_BIGNUM)) return v2w(rb_big_minus(x, w2v(wy)));
-    return v2w(rb_funcall(x, '-', 1, w2v(wy)));
+    return v2w(subv(w2v(wx), w2v(wy)));
 }
 
 static wideval_t


### PR DESCRIPTION
Time#+ & Time#- will be faster around 15%.
If internal values would have Fixnum,
optimized function (add() & sub()) improves performance.

* Before
```
             user     system      total        real
Time#+   0.820000   0.000000   0.820000 (  0.818081)
Time#-   0.810000   0.000000   0.810000 (  0.813835)
```

* After
```
             user     system      total        real
Time#+   0.710000   0.000000   0.710000 (  0.710241)
Time#-   0.710000   0.010000   0.720000 (  0.714151)
```

* Test code
```
require 'benchmark'

Benchmark.bmbm do |x|

  x.report "Time#+" do
    t = Time.now
    2000000.times do
      t + 1
    end
  end

  x.report "Time#-" do
    t = Time.now
    2000000.times do
      t - 1
    end
  end

end
```

https://bugs.ruby-lang.org/issues/13357