### PR TITLE
Add SO_REUSEADDR socket option for lib/drb/drb.rb

### DIFF
--- a/lib/drb/drb.rb
+++ b/lib/drb/drb.rb
@@ -1013,6 +1013,7 @@ module DRb
 
     def set_sockopt(soc) # :nodoc:
       soc.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1)
+      soc.setsockopt(Socket::SOL_SOCKET, Socket::SO_REUSEADDR, true)
     end
   end
 


### PR DESCRIPTION
Add SO_REUSEADDR socket option for lib/drb/drb.rb. We had an issue with Fluentd (https://github.com/fluent/fluentd/blob/335d3b2b709ad368da6655636e8ab401b116ae4b/lib/fluent/plugin/in_debug_agent.rb#L55), which throws with error:

```
2017-03-20 07:18:45 +0000 [info]: listening dRuby uri="druby://127.0.0.1:24230" object="Engine"
2017-03-20 07:18:45 +0000 [error]: unexpected error error_class=Errno::EADDRINUSE error=#<Errno::EADDRINUSE: Address already in use - bind(2) for "127.0.0.1" port 24230>
  2017-03-20 07:18:45 +0000 [error]: /opt/td-agent/embedded/lib/ruby/2.1.0/drb/drb.rb:879:in `initialize'
  2017-03-20 07:18:45 +0000 [error]: /opt/td-agent/embedded/lib/ruby/2.1.0/drb/drb.rb:879:in `open'
  2017-03-20 07:18:45 +0000 [error]: /opt/td-agent/embedded/lib/ruby/2.1.0/drb/drb.rb:879:in `open_server'
  2017-03-20 07:18:45 +0000 [error]: /opt/td-agent/embedded/lib/ruby/2.1.0/drb/drb.rb:764:in `block in open_server'
  2017-03-20 07:18:45 +0000 [error]: /opt/td-agent/embedded/lib/ruby/2.1.0/drb/drb.rb:762:in `each'
  2017-03-20 07:18:45 +0000 [error]: /opt/td-agent/embedded/lib/ruby/2.1.0/drb/drb.rb:762:in `open_server'
  2017-03-20 07:18:45 +0000 [error]: /opt/td-agent/embedded/lib/ruby/2.1.0/drb/drb.rb:1373:in `initialize'
  2017-03-20 07:18:45 +0000 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.31/lib/fluent/plugin/in_debug_agent.rb:53:in `new'
```

```
# ss -an | grep 24230
TIME-WAIT  0      0                 127.0.0.1:24230            127.0.0.1:6380
```

When this is set on socket, TIME_WAIT socket can be ignored and reused, no need to wait until socket is cleaned up. 