### PR TITLE
Make Resolv::DNS::Name validation similar to host and dig commands.

### DIFF
--- a/lib/resolv.rb
+++ b/lib/resolv.rb
@@ -1162,9 +1162,23 @@ class Resolv
     end
 
     module Label # :nodoc:
+      # RFC 1035, RFC 1123 and RFC 2181
+      # Label size is 1..63 octets
+      # Total size max is 255 - (str len byte) - root = 253 octets
       def self.split(arg)
-        labels = []
-        arg.scan(/[^\.]+/) {labels << Str.new($&)}
+        errors = []
+        errors << 'unexpected end of input' if arg.bytes.empty?
+        len = arg.bytes.size
+        len -= 1 if /\.\z/ =~ arg
+        errors << 'ran out of space' if len > 253
+        labels = arg.split( '.' ).map do |label|
+          errors << 'empty label' if label.bytes.empty?
+          errors << 'label too long' if label.bytes.size > 63
+          Str.new(label)
+        end
+        if errors.any?
+          raise ArgumentError.new("#{arg.inspect} is not a legal name (#{errors.first})")
+        end
         return labels
       end
 

--- a/test/resolv/test_domain_name.rb
+++ b/test/resolv/test_domain_name.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: false
+require 'test/unit'
+require 'resolv'
+
+class TestResolvDomainName < Test::Unit::TestCase
+  def test_valid_names
+    longest_valid_name = ('a' * 63 + '.') * 3 + 'b' * 61
+    valid_names = [
+      'com',
+      'com.',
+      'example.com',
+      'example.com.',
+      longest_valid_name,
+      longest_valid_name + '.']
+    
+    valid_names.each do |domain_name|
+      assert_nothing_raised(ArgumentError) do
+        Resolv::DNS::Name.create(domain_name)
+      end
+    end
+  end
+
+  def test_invalid_names
+    invalid_names = [
+      '',
+      '.example.com',
+      'example..com',
+      'a' * 64 + '.com',
+      ('a' * 63 + '.') * 3 + 'b' * 62]
+    
+    invalid_names.each do |domain_name|
+      assert_raise(ArgumentError) do
+        Resolv::DNS::Name.create(domain_name)
+      end
+    end
+  end
+end


### PR DESCRIPTION
`Resolv::DNS::Name.create(str)` does not make any validation.
And it returns false positive results for queries like

`Resolv::DNS.new.getresources('.gmail....com', Resolv::DNS::Resource::IN::MX)`

I added basic RFC validations in `Resolv::DNS::Label.split` to get ArgumentError with messages similar to host and dig commands.