### PR TITLE
Improve performance of rb_equal()

### DIFF
--- a/array.c
+++ b/array.c
@@ -1451,9 +1451,8 @@ rb_ary_fetch(int argc, VALUE *argv, VALUE ary)
 static VALUE
 rb_ary_index(int argc, VALUE *argv, VALUE ary)
 {
-    const VALUE *ptr;
     VALUE val;
-    long i, len;
+    long i;
 
     if (argc == 0) {
 	RETURN_ENUMERATOR(ary, 0, 0);
@@ -1468,20 +1467,11 @@ rb_ary_index(int argc, VALUE *argv, VALUE ary)
     val = argv[0];
     if (rb_block_given_p())
 	rb_warn("given block not used");
-    len = RARRAY_LEN(ary);
-    ptr = RARRAY_CONST_PTR(ary);
-    for (i=0; i<len; i++) {
-	VALUE e = ptr[i];
-	switch (rb_equal_opt(e, val)) {
-	  case Qundef:
-	    if (!rb_equal(e, val)) break;
-	  case Qtrue:
+    for (i=0; i<RARRAY_LEN(ary); i++) {
+	VALUE e = RARRAY_AREF(ary, i);
+	if (rb_equal(e, val)) {
 	    return LONG2NUM(i);
-	  case Qfalse:
-	    continue;
 	}
-	len = RARRAY_LEN(ary);
-	ptr = RARRAY_CONST_PTR(ary);
     }
     return Qnil;
 }
@@ -1513,7 +1503,6 @@ rb_ary_index(int argc, VALUE *argv, VALUE ary)
 static VALUE
 rb_ary_rindex(int argc, VALUE *argv, VALUE ary)
 {
-    const VALUE *ptr;
     VALUE val;
     long i = RARRAY_LEN(ary), len;
 
@@ -1532,21 +1521,14 @@ rb_ary_rindex(int argc, VALUE *argv, VALUE ary)
     val = argv[0];
     if (rb_block_given_p())
 	rb_warn("given block not used");
-    ptr = RARRAY_CONST_PTR(ary);
     while (i--) {
-	VALUE e = ptr[i];
-	switch (rb_equal_opt(e, val)) {
-	  case Qundef:
-	    if (!rb_equal(e, val)) break;
-	  case Qtrue:
+	VALUE e = RARRAY_AREF(ary, i);
+	if (rb_equal(e, val)) {
 	    return LONG2NUM(i);
-	  case Qfalse:
-	    continue;
 	}
 	if (i > (len = RARRAY_LEN(ary))) {
 	    i = len;
 	}
-	ptr = RARRAY_CONST_PTR(ary);
     }
     return Qnil;
 }
@@ -3967,11 +3949,7 @@ rb_ary_includes(VALUE ary, VALUE item)
 
     for (i=0; i<RARRAY_LEN(ary); i++) {
 	e = RARRAY_AREF(ary, i);
-	switch (rb_equal_opt(e, item)) {
-	  case Qundef:
-	    if (rb_equal(e, item)) return Qtrue;
-	    break;
-	  case Qtrue:
+	if (rb_equal(e, item)) {
 	    return Qtrue;
 	}
     }

--- a/object.c
+++ b/object.c
@@ -88,6 +88,8 @@ rb_equal(VALUE obj1, VALUE obj2)
     VALUE result;
 
     if (obj1 == obj2) return Qtrue;
+    if (SPECIAL_CONST_P(obj1) && SPECIAL_CONST_P(obj2)) return Qfalse;
+
     result = rb_funcall(obj1, id_eq, 1, obj2);
     if (RTEST(result)) return Qtrue;
     return Qfalse;

--- a/object.c
+++ b/object.c
@@ -22,7 +22,6 @@
 #include "constant.h"
 #include "id.h"
 #include "probes.h"
-#include "vm_core.h"
 
 VALUE rb_cBasicObject;
 VALUE rb_mKernel;
@@ -89,10 +88,10 @@ rb_equal(VALUE obj1, VALUE obj2)
     VALUE result;
 
     if (obj1 == obj2) return Qtrue;
-    if (FIXNUM_P(obj1) && FIXNUM_P(obj2) && BASIC_OP_UNREDEFINED_P(BOP_EQ, INTEGER_REDEFINED_OP_FLAG))
-	return Qfalse;
-
-    result = rb_funcall(obj1, id_eq, 1, obj2);
+    result = rb_equal_opt(obj1, obj2);
+    if (result == Qundef) {
+	result = rb_funcall(obj1, id_eq, 1, obj2);
+    }
     if (RTEST(result)) return Qtrue;
     return Qfalse;
 }

--- a/object.c
+++ b/object.c
@@ -88,7 +88,7 @@ rb_equal(VALUE obj1, VALUE obj2)
     VALUE result;
 
     if (obj1 == obj2) return Qtrue;
-    if (SPECIAL_CONST_P(obj1) && SPECIAL_CONST_P(obj2)) return Qfalse;
+    if (FIXNUM_P(obj1) && FIXNUM_P(obj2)) return Qfalse;
 
     result = rb_funcall(obj1, id_eq, 1, obj2);
     if (RTEST(result)) return Qtrue;

--- a/object.c
+++ b/object.c
@@ -22,6 +22,7 @@
 #include "constant.h"
 #include "id.h"
 #include "probes.h"
+#include "vm_core.h"
 
 VALUE rb_cBasicObject;
 VALUE rb_mKernel;
@@ -88,7 +89,8 @@ rb_equal(VALUE obj1, VALUE obj2)
     VALUE result;
 
     if (obj1 == obj2) return Qtrue;
-    if (FIXNUM_P(obj1) && FIXNUM_P(obj2)) return Qfalse;
+    if (FIXNUM_P(obj1) && FIXNUM_P(obj2) && BASIC_OP_UNREDEFINED_P(BOP_EQ, INTEGER_REDEFINED_OP_FLAG))
+	return Qfalse;
 
     result = rb_funcall(obj1, id_eq, 1, obj2);
     if (RTEST(result)) return Qtrue;


### PR DESCRIPTION
rb_equal() is been using in many places to compare the object.

If objects are special constants,
"if (obj1 == obj2) return Qtrue;" can check whether objects are equal or not.
(https://github.com/ruby/ruby/blob/0b1f6aed9414a4d7714910e61db08fdb2ac3ecd1/object.c#L90)
So, it can skip rb_funcall() calling to comfirm that special constant objects are not equal.

At least, Time#eql? will be faster around 60%.
Time object might have Finuxm (special constant) value internally on 64 bit environment.

* Before
```
                              user     system      total        real
Time#eql? with receiver   0.890000   0.000000   0.890000 (  0.891377)
Time#eql? with other      1.430000   0.000000   1.430000 (  1.429047)
```

* After
```
                              user     system      total        real
Time#eql? with receiver   0.890000   0.000000   0.890000 (  0.890050)
Time#eql? with other      0.900000   0.000000   0.900000 (  0.905941)
```

* Test code
```
require 'benchmark'

Benchmark.bmbm do |x|
  t1 = Time.now
  t2 = Time.now

  x.report "Time#eql? with receiver" do
    10000000.times do
      t1.eql?(t1)
    end
  end

  x.report "Time#eql? with other" do
    10000000.times do
      t1.eql?(t2)
    end
  end

end
```