### PR TITLE
Fix one of performance regressions in method calling

### DIFF
--- a/probes_helper.h
+++ b/probes_helper.h
@@ -18,7 +18,7 @@ MJIT_SYMBOL_EXPORT_END
 
 #define RUBY_DTRACE_METHOD_HOOK(name, ec, klazz, id) \
 do { \
-    if (UNLIKELY(RUBY_DTRACE_##name##_ENABLED())) { \
+    if (RUBY_DTRACE_##name##_ENABLED()) { \
 	struct ruby_dtrace_method_hook_args args; \
 	if (rb_dtrace_setup(ec, klazz, id, &args)) { \
 	    RUBY_DTRACE_##name(args.classname, \

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1617,9 +1617,9 @@ vm_search_method_fastpath(struct rb_call_data *cd, VALUE klass)
     struct rb_call_cache *cc = &cd->cc;
 
 #if OPT_INLINE_METHOD_CACHE
-    if (LIKELY(RB_DEBUG_COUNTER_INC_UNLESS(mc_global_state_miss,
+    if (RB_DEBUG_COUNTER_INC_UNLESS(mc_global_state_miss,
 					   GET_GLOBAL_METHOD_STATE() == cc->method_state) &&
-               vm_cache_check_for_class_serial(cc, RCLASS_SERIAL(klass)))) {
+               vm_cache_check_for_class_serial(cc, RCLASS_SERIAL(klass))) {
 	/* cache hit! */
 	VM_ASSERT(cc->call != NULL);
 	RB_DEBUG_COUNTER_INC(mc_inline_hit);


### PR DESCRIPTION
Seems that LIKELY() introduces some penalties at branching.

* Ruby 2.4.1
```
$ ruby -v ~/tmp/bench.rb
ruby 2.4.1p111 (2017-03-22 revision 58053) [x86_64-darwin16]
       user     system      total        real
   1.460000   0.010000   1.470000 (  1.462540)
```

* Ruby trunk without patch
```
$ ./miniruby -v -Ilib ~/tmp/bench.rb
ruby 2.5.0dev (2017-03-28 trunk 58156) [x86_64-darwin16]
       user     system      total        real
   1.580000   0.000000   1.580000 (  1.579428)
```

* Ruby trunk with patch
```
$ ./miniruby -v -Ilib ~/tmp/bench.rb
ruby 2.5.0dev (2017-03-28 trunk 58156) [x86_64-darwin16]
       user     system      total        real
   1.510000   0.000000   1.510000 (  1.505948)
```

* Test code
```
require 'benchmark'

Benchmark.bm do |x|
  ary = [1,2,3]

  x.report do
    20000000.times do
      ary.at(2)
    end
  end

end
```