### PR TITLE
Remove unused Init_frozen_strings declaration

### DIFF
--- a/internal.h
+++ b/internal.h
@@ -1536,7 +1536,6 @@ VALUE rb_strftime(const char *format, size_t format_len, rb_encoding *enc,
 #endif
 
 /* string.c */
-void Init_frozen_strings(void);
 VALUE rb_fstring(VALUE);
 VALUE rb_fstring_new(const char *ptr, long len);
 #define rb_fstring_lit(str) rb_fstring_new((str), rb_strlen_lit(str))


### PR DESCRIPTION
Init_frozen_strings definition is removed in r51511.
https://bugs.ruby-lang.org/issues/11423