### PR TITLE
Expose rb_fstring and its family

### DIFF
--- a/include/ruby/encoding.h
+++ b/include/ruby/encoding.h
@@ -141,6 +141,9 @@ VALUE rb_obj_encoding(VALUE);
 VALUE rb_enc_str_buf_cat(VALUE str, const char *ptr, long len, rb_encoding *enc);
 VALUE rb_enc_uint_chr(unsigned int code, rb_encoding *enc);
 
+VALUE rb_fstring_enc_new(const char *ptr, long len, rb_encoding *enc);
+VALUE rb_fstring_enc_cstr(const char *ptr, rb_encoding *enc);
+
 VALUE rb_external_str_new_with_enc(const char *ptr, long len, rb_encoding *);
 VALUE rb_str_export_to_enc(VALUE, rb_encoding *);
 VALUE rb_str_conv_enc(VALUE str, rb_encoding *from, rb_encoding *to);
@@ -156,6 +159,11 @@ VALUE rb_str_conv_enc_opts(VALUE str, rb_encoding *from, rb_encoding *to, int ec
     (__builtin_constant_p(str)) ?	       \
 	rb_enc_str_new_static((str), (long)strlen(str), (enc)) : \
 	rb_enc_str_new_cstr((str), (enc)) \
+)
+#define rb_fstring_enc_cstr(str, enc) RB_GNUC_EXTENSION_BLOCK( \
+    (__builtin_constant_p(str)) ?		\
+	rb_fstring_enc_new((str), (long)strlen(str), (enc)) : \
+	rb_fstring_enc_cstr(str, enc) \
 )
 #endif
 

--- a/include/ruby/intern.h
+++ b/include/ruby/intern.h
@@ -766,6 +766,9 @@ long rb_str_offset(VALUE, long);
 PUREFUNC(size_t rb_str_capacity(VALUE));
 VALUE rb_str_ellipsize(VALUE, long);
 VALUE rb_str_scrub(VALUE, VALUE);
+VALUE rb_fstring(VALUE);
+VALUE rb_fstring_new(const char *ptr, long len);
+VALUE rb_fstring_cstr(const char *str);
 /* symbol.c */
 VALUE rb_sym_all_symbols(void);
 
@@ -831,6 +834,11 @@ VALUE rb_sym_all_symbols(void);
 	rb_exc_new((klass), (ptr), (long)strlen(ptr)) : \
 	rb_exc_new_cstr((klass), (ptr))		\
 )
+#define rb_fstring_cstr(str) RB_GNUC_EXTENSION_BLOCK(	\
+    (__builtin_constant_p(str)) ?		\
+	rb_fstring_new((str), (long)strlen(str)) : \
+	rb_fstring_cstr(str) \
+)
 #endif
 #define rb_str_new2 rb_str_new_cstr
 #define rb_str_new3 rb_str_new_shared
@@ -851,6 +859,10 @@ VALUE rb_sym_all_symbols(void);
 #define rb_usascii_str_new_literal(str) rb_usascii_str_new_lit(str)
 #define rb_utf8_str_new_literal(str) rb_utf8_str_new_lit(str)
 #define rb_enc_str_new_literal(str, enc) rb_enc_str_new_lit(str, enc)
+#define rb_fstring_lit(str) rb_fstring_new((str), rb_strlen_lit(str))
+#define rb_fstring_literal(str) rb_fstring_lit(str)
+#define rb_fstring_enc_lit(str, enc) rb_fstring_enc_new((str), rb_strlen_lit(str), (enc))
+#define rb_fstring_enc_literal(str, enc) rb_fstring_enc_lit(str, enc)
 
 /* struct.c */
 VALUE rb_struct_new(VALUE, ...);

--- a/internal.h
+++ b/internal.h
@@ -1536,31 +1536,6 @@ VALUE rb_strftime(const char *format, size_t format_len, rb_encoding *enc,
 #endif
 
 /* string.c */
-VALUE rb_fstring(VALUE);
-VALUE rb_fstring_new(const char *ptr, long len);
-#define rb_fstring_lit(str) rb_fstring_new((str), rb_strlen_lit(str))
-#define rb_fstring_literal(str) rb_fstring_lit(str)
-VALUE rb_fstring_cstr(const char *str);
-#ifdef HAVE_BUILTIN___BUILTIN_CONSTANT_P
-# define rb_fstring_cstr(str) RB_GNUC_EXTENSION_BLOCK(	\
-    (__builtin_constant_p(str)) ?		\
-	rb_fstring_new((str), (long)strlen(str)) : \
-	rb_fstring_cstr(str) \
-)
-#endif
-#ifdef RUBY_ENCODING_H
-VALUE rb_fstring_enc_new(const char *ptr, long len, rb_encoding *enc);
-#define rb_fstring_enc_lit(str, enc) rb_fstring_enc_new((str), rb_strlen_lit(str), (enc))
-#define rb_fstring_enc_literal(str, enc) rb_fstring_enc_lit(str, enc)
-VALUE rb_fstring_enc_cstr(const char *ptr, rb_encoding *enc);
-# ifdef HAVE_BUILTIN___BUILTIN_CONSTANT_P
-#  define rb_fstring_enc_cstr(str, enc) RB_GNUC_EXTENSION_BLOCK( \
-    (__builtin_constant_p(str)) ?		\
-	rb_fstring_enc_new((str), (long)strlen(str), (enc)) : \
-	rb_fstring_enc_cstr(str, enc) \
-)
-# endif
-#endif
 int rb_str_buf_cat_escaped_char(VALUE result, unsigned int c, int unicode_p);
 int rb_str_symname_p(VALUE);
 VALUE rb_str_quote_unprintable(VALUE);


### PR DESCRIPTION
Currently, C extensions cannot use fstrings. I'd like to use
rb_fstring_cstr instead of rb_str_new_cstr for static strings in C
extensions.