### PR TITLE
Skip incomplete format specifier

### DIFF
--- a/sprintf.c
+++ b/sprintf.c
@@ -521,7 +521,7 @@ rb_str_format(int argc, const VALUE *argv, VALUE fmt)
 	for (t = p; t < end && *t != '%'; t++) ;
 	PUSH(p, t - p);
         if (t + 1 == end) {
-            if (*t == '%') rb_warning("incomplete format specifier");
+            if (*t == '%') rb_raise(rb_eArgError, "incomplete format specifier");
             ++t;
         }
 	if (coderange != ENC_CODERANGE_BROKEN && scanned < blen) {

--- a/sprintf.c
+++ b/sprintf.c
@@ -519,8 +519,8 @@ rb_str_format(int argc, const VALUE *argv, VALUE fmt)
 	VALUE sym = Qnil;
 
 	for (t = p; t < end && *t != '%'; t++) ;
-	if (t + 1 == end) ++t;
 	PUSH(p, t - p);
+	if (t + 1 == end) ++t;
 	if (coderange != ENC_CODERANGE_BROKEN && scanned < blen) {
 	    scanned += rb_str_coderange_scan_restartable(buf+scanned, buf+blen, enc, &coderange);
 	    ENC_CODERANGE_SET(result, coderange);

--- a/sprintf.c
+++ b/sprintf.c
@@ -520,7 +520,10 @@ rb_str_format(int argc, const VALUE *argv, VALUE fmt)
 
 	for (t = p; t < end && *t != '%'; t++) ;
 	PUSH(p, t - p);
-	if (t + 1 == end) ++t;
+        if (t + 1 == end) {
+            if (*t == '%') rb_warning("incomplete format specifier");
+            ++t;
+        }
 	if (coderange != ENC_CODERANGE_BROKEN && scanned < blen) {
 	    scanned += rb_str_coderange_scan_restartable(buf+scanned, buf+blen, enc, &coderange);
 	    ENC_CODERANGE_SET(result, coderange);

--- a/test/ruby/test_sprintf.rb
+++ b/test/ruby/test_sprintf.rb
@@ -373,6 +373,9 @@ class TestSprintf < Test::Unit::TestCase
   end
 
   def test_percent_sign_at_end
+    assert_warning(/incomplete format specifier/) {
+      sprintf("%")
+    }
     assert_equal("", sprintf("%"))
     assert_equal("abc", sprintf("abc%"))
   end

--- a/test/ruby/test_sprintf.rb
+++ b/test/ruby/test_sprintf.rb
@@ -373,11 +373,13 @@ class TestSprintf < Test::Unit::TestCase
   end
 
   def test_percent_sign_at_end
-    assert_warning(/incomplete format specifier/) {
+    assert_raise_with_message(ArgumentError, "incomplete format specifier") do
       sprintf("%")
-    }
-    assert_equal("", sprintf("%"))
-    assert_equal("abc", sprintf("abc%"))
+    end
+
+    assert_raise_with_message(ArgumentError, "incomplete format specifier") do
+      sprintf("abc%")
+    end
   end
 
   def test_rb_sprintf

--- a/test/ruby/test_sprintf.rb
+++ b/test/ruby/test_sprintf.rb
@@ -372,7 +372,7 @@ class TestSprintf < Test::Unit::TestCase
     assert_equal("%" * BSIZ, sprintf("%%" * BSIZ))
   end
 
-  def test_percent_sing_at_end
+  def test_percent_sign_at_end
     assert_equal("", sprintf("%"))
     assert_equal("abc", sprintf("abc%"))
   end

--- a/test/ruby/test_sprintf.rb
+++ b/test/ruby/test_sprintf.rb
@@ -372,6 +372,11 @@ class TestSprintf < Test::Unit::TestCase
     assert_equal("%" * BSIZ, sprintf("%%" * BSIZ))
   end
 
+  def test_percent_sing_at_end
+    assert_equal("", sprintf("%"))
+    assert_equal("abc", sprintf("abc%"))
+  end
+
   def test_rb_sprintf
     assert_match(/^#<TestSprintf::T012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789:0x[0-9a-f]+>$/,
                  T012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789.new.inspect)


### PR DESCRIPTION
Make ruby's `printf` raise an `ArgumentError` when format string is incomplete.

https://bugs.ruby-lang.org/issues/13315

In C language, `printf("%")` shows warning as follow.

```c
#include <stdio.h>

int main(void)
{
  printf("%");
  return 0;
}
```

```
5:11: warning: incomplete format specifier [-Wformat]
  printf("%");
          ^
1 warning generated.
```

I think it's nice to notify that incomplete format is invalid for developer in ruby too.
Since this change will drop displayed `"%"` silently, Raising an error is better than showing a warning.

