### PR TITLE
Fix `make clean` errors

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -421,7 +421,7 @@ ext/distclean.sub gems/distclean.sub:: ext/distclean.mk
 ext/realclean.sub gems/realclean.sub:: ext/realclean.mk
 
 ext/clean.mk ext/distclean.mk ext/realclean.mk::
-	$(Q) [ -f $(EXTS_MK) ] && exec $(MAKE) -f $(EXTS_MK) $(@F:.mk=)
+	-$(Q) if [ -f $(EXTS_MK) ]; then exec $(MAKE) -f $(EXTS_MK) $(@F:.mk=); fi
 
 ext/clean:: ext/clean.sub
 ext/distclean:: ext/distclean.sub

--- a/common.mk
+++ b/common.mk
@@ -621,7 +621,7 @@ clean-platform:
 RUBYSPEC_CAPIEXT = spec/rubyspec/optional/capi/ext
 clean-rubyspec: PHONY
 	-$(Q) $(RM) $(RUBYSPEC_CAPIEXT)/*.$(OBJEXT) $(RUBYSPEC_CAPIEXT)/*.$(DLEXT)
-	-$(Q) $(RMDIRS) $(RUBYSPEC_CAPIEXT)
+	-$(Q) $(RMDIRS) $(RUBYSPEC_CAPIEXT) 2> $(NULL) || exit 0
 
 check: main test test-testframework test-almost
 	$(ECHO) check succeeded


### PR DESCRIPTION
- Fix error when running `make clean` just after `configure`
- Suppress error message when rubyspec files isn't present