### PR TITLE
Fix Delegator#eql? is missing

### DIFF
--- a/lib/delegate.rb
+++ b/lib/delegate.rb
@@ -40,7 +40,7 @@ class Delegator < BasicObject
   kernel = ::Kernel.dup
   kernel.class_eval do
     alias __raise__ raise
-    [:to_s, :inspect, :=~, :!~, :===, :<=>, :eql?, :hash].each do |m|
+    [:to_s, :inspect, :=~, :!~, :===, :<=>, :hash].each do |m|
       undef_method m
     end
     private_instance_methods.each do |m|
@@ -136,6 +136,7 @@ class Delegator < BasicObject
     return true if obj.equal?(self)
     self.__getobj__ == obj
   end
+  alias :eql? :==
 
   #
   # Returns true if two objects are not considered of equal value.

--- a/test/test_delegate.rb
+++ b/test/test_delegate.rb
@@ -119,6 +119,17 @@ class TestDelegateClass < Test::Unit::TestCase
     assert_equal([:bar], s.methods(false))
   end
 
+  def test_eql?
+    s0 = SimpleDelegator.new("foo")
+    s1 = SimpleDelegator.new("bar")
+    s2 = SimpleDelegator.new("foo")
+    assert_equal(s0.eql?(s0), true)
+    assert_equal(s0.eql?("foo"), true)
+    assert_equal(s0.eql?(s2), true)
+    assert_equal(s0.eql?(s1), false)
+    assert_equal(s0.eql?("bar"), false)
+  end
+
   class Foo
     private
     def delegate_test_private


### PR DESCRIPTION
Related issue : https://bugs.ruby-lang.org/issues/12684

## Context

In the current implementation, `Delegator#eql?` is delegated to the inner object.
So it is failed to compare with itself.

```
2.3.1 :001 > s = 'test'
=> "test" 
2.3.1 :002 > d = SimpleDelegator.new(s)
=> "test" 
2.3.1 :003 > d.eql?(d)
=> false 
2.3.1 :004 > d == d
=> true 
2.3.1 :005 > d.hash == d.hash
=> true
```

```
2.3.1 :001 > s = 'test'
=> "test" 
2.3.1 :002 > a = [SimpleDelegator.new(s), SimpleDelegator.new(s)]
=> ["test", "test"] 
2.3.1 :003 > a[0] == a[1]
=> true 
2.3.1 :004 > a.uniq()
=> ["test", "test"]
2.3.1 :005 > a[0].hash == a[1].hash
=> true
```

## This patch

This patch make `eql?` to be alias to `==`. And I added tests for its behavior.

```
2.5.0-dev :001 > s = 'test'
=> "test" 
2.5.0-dev :002 > d = SimpleDelegator.new(s)
=> "test" 
2.5.0-dev :003 > d.eql?(d)
=> true
2.5.0-dev :004 > d == d
=> true 
2.5.0-dev :005 > d.hash == d.hash
=> true
```

```
2.5.0-dev :001 > s = 'test'
=> "test" 
2.5.0-dev :002 > a = [SimpleDelegator.new(s), SimpleDelegator.new(s)]
=> ["test", "test"] 
2.5.0-dev :003 > a[0] == a[1]
=> true 
2.5.0-dev :004 > a.uniq()
=> ["test"]
2.5.0-dev :005 > a[0].hash == a[1].hash
=> true
```