### PR TITLE
Change date_strgtime documentation of %Z format

### DIFF
--- a/ext/date/date_core.c
+++ b/ext/date/date_core.c
@@ -6802,7 +6802,7 @@ date_strftime_internal(int argc, VALUE *argv, VALUE self,
  *              %::z - hour, minute and second offset from UTC (e.g. +09:00:00)
  *              %:::z - hour, minute and second offset from UTC
  *                                                (e.g. +09, +09:30, +09:30:30)
- *      %Z - Time zone abbreviation name or something similar information.
+ *      %Z - Time zone the same as above %:z (e.g. +09:00)
  *
  *    Weekday:
  *      %A - The full weekday name (``Sunday'')
@@ -8247,7 +8247,7 @@ dt_lite_to_s(VALUE self)
  *              %::z - hour, minute and second offset from UTC (e.g. +09:00:00)
  *              %:::z - hour, minute and second offset from UTC
  *                                                (e.g. +09, +09:30, +09:30:30)
- *      %Z - Time zone abbreviation name or something similar information.
+ *      %Z - Time zone the same as above %:z (e.g. +09:00)
  *
  *    Weekday:
  *      %A - The full weekday name (``Sunday'')


### PR DESCRIPTION
related: https://bugs.ruby-lang.org/issues/13231

DateTime.strftime("%Z") does not return time zone abbreviation, returns hour and minute offset from UTC with colon.

But it looks tough to change the spec of DateTime.strftime("%Z").
So, for the moment, I changed the documentation to conform its implementation.