### PR TITLE
fix tesself_find_files_with_gemfile since it depends on local environments

### DIFF
--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -492,7 +492,7 @@ class TestGem < Gem::TestCase
     skip if RUBY_VERSION <= "1.8.7"
 
     cwd = File.expand_path("test/rubygems", @@project_dir)
-    $LOAD_PATH.unshift cwd
+    actual_load_path = $LOAD_PATH.unshift(cwd).dup
 
     discover_path = File.join 'lib', 'sff', 'discover.rb'
 
@@ -518,12 +518,12 @@ class TestGem < Gem::TestCase
     expected = [
       File.expand_path('test/rubygems/sff/discover.rb', @@project_dir),
       File.join(foo1.full_gem_path, discover_path)
-    ]
+    ].sort
 
-    assert_equal expected, Gem.find_files('sff/discover')
-    assert_equal expected, Gem.find_files('sff/**.rb'), '[ruby-core:31730]'
+    assert_equal expected, Gem.find_files('sff/discover').sort
+    assert_equal expected, Gem.find_files('sff/**.rb').sort, '[ruby-core:31730]'
   ensure
-    assert_equal cwd, $LOAD_PATH.shift unless RUBY_VERSION <= "1.8.7"
+    assert_equal cwd, actual_load_path.shift unless RUBY_VERSION <= "1.8.7"
   end
 
   def test_self_find_latest_files


### PR DESCRIPTION
In my environments, `make test-all TESTS='../ruby/test/rubygems/test_gem.rb'` cause the following failure.

This error comes from:

- the order of files
- Stored variables in `$LOAD_PATH`
    - Unexpected paths are added in `$LOAD_PATH` between L495 and L526.
    - So, I stored the path in a local variable.


## after

```
$ make test-all TESTS='../ruby/test/rubygems/test_gem.rb'

....

# Running tests:

Finished tests in 2.146005s, 54.9859 tests/s, 108.1079 assertions/s.
118 tests, 232 assertions, 0 failures, 0 errors, 0 skips
```

## before

```
$ make test-all TESTS='../ruby/test/rubygems/test_gem.rb'

....

[ 6279/17079] TestGem#test_self_find_files_with_gemfile = 0.07 s
  1) Failure:
TestGem#test_self_find_files_with_gemfile [/Users/kazuaki-matsuo/Documents/github/hackaride/ruby/test/rubygems/test_gem.rb:526]:
--- expected
+++ actual
@@ -1 +1 @@
-"/Users/kazu/Documents/github/hackaride/ruby/test/rubygems"
+"/private/var/folders/45/rztq_0190zv17z9z32t6msp00000gp/T/test_rubygems_98901/gemhome/gems/sff-1/lib"
```