### PR TITLE
Clarify the behavior of IO.write without offset in write mode

### DIFF
--- a/io.c
+++ b/io.c
@@ -10103,8 +10103,8 @@ io_s_write(int argc, VALUE *argv, int binary)
  *  Opens the file, optionally seeks to the given <i>offset</i>, writes
  *  <i>string</i>, then returns the length written.
  *  <code>write</code> ensures the file is closed before returning.
- *  If <i>offset</i> is not given, the file is truncated.  Otherwise,
- *  it is not truncated.
+ *  If <i>offset</i> is not given in write mode, the file is truncated.
+ *  Otherwise, it is not truncated.
  *
  *    IO.write("testfile", "0123456789", 20)  #=> 10
  *    # File could contain:  "This is line one\nThi0123456789two\nThis is line three\nAnd so on...\n"


### PR DESCRIPTION
Clarify the behaviour of IO.write without offset in write mode. There is an explanation as follows.

>If offset is not given, the file is truncated. Otherwise, it is not truncated.

But when we use appending mode without offset, the file is not  truncated. Truncating files are occurred in write mode only. So it seems that we should just add the behaviour in write mode rather than adding behaviour in append mode.

## investigation

```
>ruby -v
ruby 2.2.4p230 (2015-12-16 revision 53155) [x86_64-darwin15]

>cat check_behaviour_of_io_write_in_a_mode
File.write('/tmp/io_write_without_offset_in_appeding_mode.txt', 'hello', mode: 'a')
puts(File.open("/tmp/io_write_without_offset_in_appeding_mode.txt").read)

File.write('/tmp/io_write_without_offset_in_appeding_mode.txt', 'hello', mode: 'a')
puts(File.open("/tmp/io_write_without_offset_in_appeding_mode.txt").read)

> ruby check_behaviour_of_io_write_in_a_mode
hello
hellohello
```

## Redmine original ticket
* https://bugs.ruby-lang.org/issues/11638