### PR TITLE
Improve Time#to_i performance

### DIFF
--- a/time.c
+++ b/time.c
@@ -103,7 +103,17 @@ mul(VALUE x, VALUE y)
     return rb_funcall(x, '*', 1, y);
 }
 
-#define div(x,y) (rb_funcall((x), id_div, 1, (y)))
+static VALUE
+_div(VALUE x, VALUE y)
+{
+    if (FIXNUM_P(x) && FIXNUM_P(y)) {
+	return rb_fix_div_fix(x, y);
+    }
+    if (RB_TYPE_P(x, T_BIGNUM))
+        return rb_big_div(x, y);
+    return rb_funcall(x, id_div, 1, y);
+}
+#define div(x,y) _div(x,y)
 
 static VALUE
 mod(VALUE x, VALUE y)


### PR DESCRIPTION
Time#to_i will be faster around 80%.

* Before
```
       user     system      total        real
   2.840000   0.000000   2.840000 (  2.847238)
```

* After
```
       user     system      total        real
   1.600000   0.000000   1.600000 (  1.598911)
```

* Test code
```
require 'benchmark'

Benchmark.bmbm do |x|
  x.report do
    t = Time.now
    20000000.times do
      t.to_i
    end
  end

end
```

https://bugs.ruby-lang.org/issues/13418