### PR TITLE
doc/extension.rdoc: Add missing enc arg to rb_enc_str_new_literal

### DIFF
--- a/doc/extension.ja.rdoc
+++ b/doc/extension.ja.rdoc
@@ -259,7 +259,7 @@ rb_enc_str_new_cstr(const char *ptr, rb_encoding *enc) ::
 
   指定されたエンコーディングでRubyの文字列を生成する.
 
-rb_enc_str_new_literal(const char *ptr) ::
+rb_enc_str_new_literal(const char *ptr, rb_encoding *enc) ::
 
   Cのリテラル文字列から指定されたエンコーディングでRubyの文字列を生成する．
 

--- a/doc/extension.rdoc
+++ b/doc/extension.rdoc
@@ -233,7 +233,7 @@ rb_enc_str_new_cstr(const char *ptr, rb_encoding *enc) ::
 
   Creates a new Ruby string with the specified encoding.
 
-rb_enc_str_new_literal(const char *ptr) ::
+rb_enc_str_new_literal(const char *ptr, rb_encoding *enc) ::
 
   Creates a new Ruby string from a C string literal with the specified
   encoding.


### PR DESCRIPTION
The documentation had the signature as

```ruby
rb_enc_str_new_literal(const char *ptr)
```

but in the code it is effectively (i.e. through a macro)

```ruby
rb_enc_str_new_literal(const char *ptr, rb_encoding *enc)
```