### PR TITLE
Spec#files are not used anymore.

### DIFF
--- a/tool/rbinstall.rb
+++ b/tool/rbinstall.rb
@@ -775,7 +775,6 @@ def install_default_gem(dir, srcdir)
     file_collector = RbInstall::Specs::FileCollector.new(src)
     files = file_collector.collect
     next if files.empty?
-    spec.files = files
     spec
   }
   gems.compact.sort_by(&:name).each do |gemspec|


### PR DESCRIPTION
This line should not be needed (at least) since #1578. The file list should be included in the original .gemspec anyway.