### PR TITLE
Install only files explicitly referenced by bundled gems.

### DIFF
--- a/tool/rbinstall.rb
+++ b/tool/rbinstall.rb
@@ -678,10 +678,12 @@ module RbInstall
         return if path == destination_dir
         File.chmod(0700, destination_dir)
         mode = pattern == "bin/*" ? $script_mode : $data_mode
-        install_recursive(path, without_destdir(destination_dir),
-                          :glob => pattern,
-                          :no_install => "*.gemspec",
-                          :mode => mode)
+        spec.files.each do |f|
+          src = File.join(path, f)
+          dest = File.join(without_destdir(destination_dir), f)
+          makedirs(dest[/.*(?=\/)/m])
+          install src, dest, :mode => mode
+        end
         File.chmod($dir_mode, destination_dir)
       end
     end


### PR DESCRIPTION
The idea is, that only files referenced by .gemspec should be installed. It doesn't make sense to install files which are not in the gem. This should help avoid issues such as https://bugs.ruby-lang.org/issues/13417