### PR TITLE
Improve performance of implicit type conversion using #to_r

### DIFF
--- a/defs/id.def
+++ b/defs/id.def
@@ -38,6 +38,7 @@ firstline, predefined = __LINE__+1, %[\
   to_a
   to_s
   to_i
+  to_r
   bt
   bt_locations
   call

--- a/object.c
+++ b/object.c
@@ -2619,6 +2619,7 @@ static const struct conv_method_tbl {
     M(a),
     M(s),
     M(i),
+    M(r),
 #undef M
 };
 #define IMPLICIT_CONVERSIONS 7


### PR DESCRIPTION
This patch will improve performance in implicit type conversion using #to_r
At least, Integer#quo will be faster around 40%.
And, this will improve some Time methods which calling quov() internally.

* Before
```
                   user     system      total        real
Integer#quo    2.030000   0.010000   2.040000 (  2.031988)
Time#subsec    2.410000   0.000000   2.410000 (  2.412172)
```

* After
```
                  user     system      total        real
Integer#quo   1.460000   0.000000   1.460000 (  1.463345)
Time#subsec   2.050000   0.010000   2.060000 (  2.056003)
```

* Test code
```
require 'benchmark'

Benchmark.bmbm do |x|
  x.report "Integer#quo" do
    5000000.times do
      42.quo(3)
    end
  end

  x.report "Time#subsec" do
    t = Time.now
    4000000.times do
      t.subsec
    end
  end

end
```