### PR TITLE
Improve performance of Enumerable#{sort_by,min_by,max_by,minmax_by}

### DIFF
--- a/enum.c
+++ b/enum.c
@@ -1009,6 +1009,7 @@ sort_by_i(RB_BLOCK_CALL_FUNC_ARGLIST(i, _data))
 static int
 sort_by_cmp(const void *ap, const void *bp, void *data)
 {
+    struct cmp_opt_data cmp_opt = { 0, 0 };
     VALUE a;
     VALUE b;
     VALUE ary = (VALUE)data;
@@ -1020,7 +1021,7 @@ sort_by_cmp(const void *ap, const void *bp, void *data)
     a = *(VALUE *)ap;
     b = *(VALUE *)bp;
 
-    return rb_cmpint(rb_funcall(a, id_cmp, 1, b), a, b);
+    return OPTIMIZED_CMP(a, b, cmp_opt);
 }
 
 /*
@@ -1266,13 +1267,13 @@ struct nmin_data {
 static int
 nmin_cmp(const void *ap, const void *bp, void *_data)
 {
+    struct cmp_opt_data cmp_opt = { 0, 0 };
     struct nmin_data *data = (struct nmin_data *)_data;
     VALUE a = *(const VALUE *)ap, b = *(const VALUE *)bp;
-    VALUE cmp = rb_funcall(a, id_cmp, 1, b);
     if (RBASIC(data->buf)->klass) {
 	rb_raise(rb_eRuntimeError, "%s reentered", data->method);
     }
-    return rb_cmpint(cmp, a, b);
+    return OPTIMIZED_CMP(a, b, cmp_opt);
 }
 
 static int
@@ -1871,6 +1872,7 @@ enum_minmax(VALUE obj)
 static VALUE
 min_by_i(RB_BLOCK_CALL_FUNC_ARGLIST(i, args))
 {
+    struct cmp_opt_data cmp_opt = { 0, 0 };
     struct MEMO *memo = MEMO_CAST(args);
     VALUE v;
 
@@ -1881,7 +1883,7 @@ min_by_i(RB_BLOCK_CALL_FUNC_ARGLIST(i, args))
 	MEMO_V1_SET(memo, v);
 	MEMO_V2_SET(memo, i);
     }
-    else if (rb_cmpint(rb_funcall(v, id_cmp, 1, memo->v1), v, memo->v1) < 0) {
+    else if (OPTIMIZED_CMP(v, memo->v1, cmp_opt) < 0) {
 	MEMO_V1_SET(memo, v);
 	MEMO_V2_SET(memo, i);
     }
@@ -1932,6 +1934,7 @@ enum_min_by(int argc, VALUE *argv, VALUE obj)
 static VALUE
 max_by_i(RB_BLOCK_CALL_FUNC_ARGLIST(i, args))
 {
+    struct cmp_opt_data cmp_opt = { 0, 0 };
     struct MEMO *memo = MEMO_CAST(args);
     VALUE v;
 
@@ -1942,7 +1945,7 @@ max_by_i(RB_BLOCK_CALL_FUNC_ARGLIST(i, args))
 	MEMO_V1_SET(memo, v);
 	MEMO_V2_SET(memo, i);
     }
-    else if (rb_cmpint(rb_funcall(v, id_cmp, 1, memo->v1), v, memo->v1) > 0) {
+    else if (OPTIMIZED_CMP(v, memo->v1, cmp_opt) > 0) {
 	MEMO_V1_SET(memo, v);
 	MEMO_V2_SET(memo, i);
     }
@@ -2047,6 +2050,8 @@ struct minmax_by_t {
 static void
 minmax_by_i_update(VALUE v1, VALUE v2, VALUE i1, VALUE i2, struct minmax_by_t *memo)
 {
+    struct cmp_opt_data cmp_opt = { 0, 0 };
+
     if (memo->min_bv == Qundef) {
 	memo->min_bv = v1;
 	memo->max_bv = v2;
@@ -2054,11 +2059,11 @@ minmax_by_i_update(VALUE v1, VALUE v2, VALUE i1, VALUE i2, struct minmax_by_t *m
 	memo->max = i2;
     }
     else {
-	if (rb_cmpint(rb_funcall(v1, id_cmp, 1, memo->min_bv), v1, memo->min_bv) < 0) {
+	if (OPTIMIZED_CMP(v1, memo->min_bv, cmp_opt) < 0) {
 	    memo->min_bv = v1;
 	    memo->min = i1;
 	}
-	if (rb_cmpint(rb_funcall(v2, id_cmp, 1, memo->max_bv), v2, memo->max_bv) > 0) {
+	if (OPTIMIZED_CMP(v2, memo->max_bv, cmp_opt) > 0) {
 	    memo->max_bv = v2;
 	    memo->max = i2;
 	}
@@ -2068,6 +2073,7 @@ minmax_by_i_update(VALUE v1, VALUE v2, VALUE i1, VALUE i2, struct minmax_by_t *m
 static VALUE
 minmax_by_i(RB_BLOCK_CALL_FUNC_ARGLIST(i, _memo))
 {
+    struct cmp_opt_data cmp_opt = { 0, 0 };
     struct minmax_by_t *memo = MEMO_FOR(struct minmax_by_t, _memo);
     VALUE vi, vj, j;
     int n;
@@ -2085,7 +2091,7 @@ minmax_by_i(RB_BLOCK_CALL_FUNC_ARGLIST(i, _memo))
     j = memo->last;
     memo->last_bv = Qundef;
 
-    n = rb_cmpint(rb_funcall(vj, id_cmp, 1, vi), vj, vi);
+    n = OPTIMIZED_CMP(vj, vi, cmp_opt);
     if (n == 0) {
         i = j;
         vi = vj;


### PR DESCRIPTION
* Before
```
                user     system      total        real
sort_by     1.810000   0.010000   1.820000 (  1.824355)
min_by(n)   2.530000   0.000000   2.530000 (  2.534154)
min_by      2.450000   0.000000   2.450000 (  2.456396)
max_by(n)   3.240000   0.000000   3.240000 (  3.238680)
max_by      2.440000   0.010000   2.450000 (  2.444972)
minmax_by   3.080000   0.000000   3.080000 (  3.083867)
```

* After
```
                user     system      total        real
sort_by     1.100000   0.020000   1.120000 (  1.122831)
min_by(n)   1.650000   0.000000   1.650000 (  1.657220)
min_by      1.600000   0.010000   1.610000 (  1.625084)
max_by(n)   1.930000   0.010000   1.940000 (  1.953623)
max_by      1.630000   0.010000   1.640000 (  1.639236)
minmax_by   1.760000   0.000000   1.760000 (  1.759928)
```

* Test code
```
require 'benchmark'

Benchmark.bmbm do |x|

  enum = (1..1000).to_a.each

  x.report "sort_by" do
    10000.times do
      enum.sort_by { |a| a }
    end
  end

  x.report "min_by(n)" do
    20000.times do
      enum.min_by(2) { |a| a }
    end
  end

  x.report "min_by" do
    20000.times do
      enum.min_by { |a| a }
    end
  end

  x.report "max_by(n)" do
    10000.times do
      enum.max_by(2) { |a| a }
    end
  end

  x.report "max_by" do
    20000.times do
      enum.max_by { |a| a }
    end
  end

  x.report "minmax_by" do
    20000.times do
      enum.minmax_by { |a| a }
    end
  end

end
```

https://bugs.ruby-lang.org/issues/13437