### PR TITLE
Improve performance of Range#{min,max}

### DIFF
--- a/range.c
+++ b/range.c
@@ -932,9 +932,10 @@ range_min(int argc, VALUE *argv, VALUE range)
 	return range_first(argc, argv, range);
     }
     else {
+	struct cmp_opt_data cmp_opt = { 0, 0 };
 	VALUE b = RANGE_BEG(range);
 	VALUE e = RANGE_END(range);
-	int c = rb_cmpint(rb_funcall(b, id_cmp, 1, e), b, e);
+	int c = OPTIMIZED_CMP(b, e, cmp_opt);
 
 	if (c > 0 || (c == 0 && EXCL(range)))
 	    return Qnil;
@@ -969,8 +970,9 @@ range_max(int argc, VALUE *argv, VALUE range)
 	return rb_call_super(argc, argv);
     }
     else {
+	struct cmp_opt_data cmp_opt = { 0, 0 };
 	VALUE b = RANGE_BEG(range);
-	int c = rb_cmpint(rb_funcall(b, id_cmp, 1, e), b, e);
+	int c = OPTIMIZED_CMP(b, e, cmp_opt);
 
 	if (c > 0)
 	    return Qnil;


### PR DESCRIPTION
Range#{min,max} will be faster around 30%.
This is similar with https://github.com/ruby/ruby/pull/1584

* Before
```
                user     system      total        real
Range#min   1.270000   0.010000   1.280000 (  1.279449)
Range#max   1.300000   0.000000   1.300000 (  1.310150)
```

* After
```
                user     system      total        real
Range#min   0.940000   0.010000   0.950000 (  0.967873)
Range#max   0.960000   0.010000   0.970000 (  0.983417)
```

* Test code
```
require 'benchmark'

Benchmark.bmbm do |x|

  x.report "Range#min" do
    10000000.times do
      (1..100).min
    end
  end

  x.report "Range#max" do
    10000000.times do
      (1..100).max
    end
  end

end
```

https://bugs.ruby-lang.org/issues/13443