### PR TITLE
Improve performance of rb_eql()

### DIFF
--- a/internal.h
+++ b/internal.h
@@ -1730,6 +1730,7 @@ VALUE rb_yield_lambda(VALUE values);
 
 /* vm_insnhelper.c */
 VALUE rb_equal_opt(VALUE obj1, VALUE obj2);
+VALUE rb_eql_opt(VALUE obj1, VALUE obj2);
 
 /* vm_method.c */
 void Init_eval_method(void);

--- a/object.c
+++ b/object.c
@@ -96,7 +96,15 @@ rb_equal(VALUE obj1, VALUE obj2)
 int
 rb_eql(VALUE obj1, VALUE obj2)
 {
-    return RTEST(rb_funcall(obj1, id_eql, 1, obj2));
+    VALUE result;
+
+    if (obj1 == obj2) return Qtrue;
+    result = rb_eql_opt(obj1, obj2);
+    if (result == Qundef) {
+	result = rb_funcall(obj1, id_eql, 1, obj2);
+    }
+    if (RTEST(result)) return Qtrue;
+    return Qfalse;
 }
 
 /*

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1351,6 +1351,19 @@ rb_equal_opt(VALUE obj1, VALUE obj2)
     return opt_eq_func(obj1, obj2, &ci, &cc);
 }
 
+VALUE
+rb_eql_opt(VALUE obj1, VALUE obj2)
+{
+    struct rb_call_info ci;
+    struct rb_call_cache cc;
+
+    ci.mid = idEqlP;
+    cc.method_state = 0;
+    cc.class_serial = 0;
+    cc.me = NULL;
+    return opt_eq_func(obj1, obj2, &ci, &cc);
+}
+
 static VALUE vm_call0(rb_thread_t*, VALUE, ID, int, const VALUE*, const rb_callable_method_entry_t *);
 
 static VALUE


### PR DESCRIPTION
This is similar with https://github.com/ruby/ruby/pull/1552
At least, Array#eql? will be faster around 30% with following test code.

* Before
```
       user     system      total        real
   1.740000   0.000000   1.740000 (  1.738344)
```

* After
```
       user     system      total        real
   1.300000   0.000000   1.300000 (  1.303624)
```

* Test code
```
require 'benchmark'

Benchmark.bmbm do |x|
  ary1 = Array.new(1000) { rand(1000) }
  ary2 = Array.new(1000) { rand(1000) }

  x.report do
    5000000.times do
      ary1.eql?(ary2)
    end
  end

end
```

https://bugs.ruby-lang.org/issues/13447