### PR TITLE
Fix a warning in ruby/win32.h which can cause failures with mkmf

### DIFF
--- a/include/ruby/win32.h
+++ b/include/ruby/win32.h
@@ -781,7 +781,7 @@ RUBY_SYMBOL_EXPORT_END
 static inline double
 rb_w32_pow(double x, double y)
 {
-    return powl(x, y);
+    return (double)powl(x, y);
 }
 #elif defined(__MINGW64_VERSION_MAJOR)
 double rb_w32_pow(double x, double y);


### PR DESCRIPTION
The return value is implicit type casted from 'long double' to 'double', currently.
This causes a gcc warning like this:

```
In file included from
C:\Ruby24-x64\include\ruby-2.4.0/ruby/defines.h:243:0,
                 from C:\Ruby24-x64\include\ruby-2.4.0/ruby/ruby.h:36,
		                  from C:\Ruby24-x64\include\ruby-2.4.0/ruby.h:33,
				                   from conftest.c:1:
						   C:\Ruby24-x64\include\ruby-2.4.0/ruby/win32.h:
						   In function 'rb_w32_pow':
						   C:\Ruby24-x64\include\ruby-2.4.0/ruby/win32.h:786:12:
						   warning: conversion to 'double' from 'long double' may alter its value [-Wfloat-conversion]
						        return powl(x, y);
							        ^~~~~~~~~~
```

This is fixed by the attached explicit type cast.

Moreover when CFLAGS is set to '-Wconversion', it prevents the compiler from
building. This is the case at the nokogiri gem.

The original issue arose at RubyInstaller2: https://github.com/oneclick/rubyinstaller2/commit/576a0eb70aa9348b366c3ecfe83c67811b7bcb9b