### PR TITLE
Exclude Changelog files from documentation.

### DIFF
--- a/.document
+++ b/.document
@@ -18,8 +18,6 @@ lib
 ext
 
 # rdoc files
-ChangeLog
-
 NEWS
 
 README.md

--- a/doc/.document
+++ b/doc/.document
@@ -1,4 +1,3 @@
 *.rdoc
-ChangeLog*
 NEWS-*
 syntax


### PR DESCRIPTION
The changelogs are almost 7 MBytes large, so that the ri or rdoc output is even bigger. Therefore the changelogs take almost half of the size of the entire output. However the changelog is not really valuable as part of ri or rdoc, IMHO. It may also slows down searches in rdoc.

This issue arose originally at [RubyInstaller2](https://github.com/oneclick/rubyinstaller2) and is patched there: https://github.com/oneclick/rubyinstaller2/commit/ca359aa3d827a3cbba6c715dcaeca0b03b717d62