### PR TITLE
Fix documentation for OpenSSL::Cipher#final

### DIFF
--- a/ext/openssl/ossl_cipher.c
+++ b/ext/openssl/ossl_cipher.c
@@ -418,7 +418,7 @@ ossl_cipher_update(int argc, VALUE *argv, VALUE self)
  *  Returns the remaining data held in the cipher object. Further calls to
  *  Cipher#update or Cipher#final will return garbage. This call should always
  *  be made as the last call of an encryption or decryption operation, after
- *  after having fed the entire plaintext or ciphertext to the Cipher instance.
+ *  having fed the entire plaintext or ciphertext to the Cipher instance.
  *
  *  If an authenticated cipher was used, a CipherError is raised if the tag
  *  could not be authenticated successfully. Only call this method after


### PR DESCRIPTION
Typo in RDoc

![screenshot_4_21_17__5_48_pm](https://cloud.githubusercontent.com/assets/30538/25274688/79498e34-26bb-11e7-9707-ad3dd995dbfb.png)


"after after having fed the entire plaintext..." is changed to
"after having fed the entire plaintext..."