### PR TITLE
MinGW test_basicsocket update

### DIFF
--- a/test/socket/test_basicsocket.rb
+++ b/test/socket/test_basicsocket.rb
@@ -194,7 +194,7 @@ class TestSocket_BasicSocket < Test::Unit::TestCase
       when nil
         break
       else
-        flunk "unexpected read_nonblock return: #{r.inspect}"
+        flunk "unexpected read_nonblock return: #{r.inspect}" unless set_nb # unless for MinGW
       end while true
 
       assert_raise(EOFError) { ssock.read_nonblock(1) }


### PR DESCRIPTION
This change allows MinGW builds to pass the newly added (58400) test
`TestSocket_BasicSocket#test_read_write_nonblock`