### PR TITLE
Improve performance of Complex#{+,-,*,/,**,abs2}

### DIFF
--- a/complex.c
+++ b/complex.c
@@ -86,6 +86,9 @@ f_add(VALUE x, VALUE y)
     else if (FIXNUM_P(x) && FIXNUM_ZERO_P(x))
 	return y;
 #endif
+    if (FIXNUM_P(x) && FIXNUM_P(y)) {
+	return rb_fix_plus_fix(x, y);
+    }
     return rb_funcall(x, '+', 1, y);
 }
 
@@ -94,6 +97,10 @@ f_div(VALUE x, VALUE y)
 {
     if (FIXNUM_P(y) && FIX2LONG(y) == 1)
 	return x;
+    if (FIXNUM_P(x) && FIXNUM_P(y)) {
+	if (FIXNUM_ZERO_P(y)) rb_num_zerodiv();
+	return rb_fix_div_fix(x, y);
+    }
     return rb_funcall(x, '/', 1, y);
 }
 
@@ -137,6 +144,9 @@ f_mul(VALUE x, VALUE y)
 	    return y;
     }
 #endif
+    if (FIXNUM_P(x) && FIXNUM_P(y)) {
+	return rb_fix_mul_fix(x, y);
+    }
     return rb_funcall(x, '*', 1, y);
 }
 
@@ -147,6 +157,9 @@ f_sub(VALUE x, VALUE y)
     if (FIXNUM_P(y) && FIXNUM_ZERO_P(y))
 	return x;
 #endif
+    if (FIXNUM_P(x) && FIXNUM_P(y)) {
+	return rb_fix_minus_fix(x, y);
+    }
     return rb_funcall(x, '-', 1, y);
 }
 


### PR DESCRIPTION
At the internal calculation in Complex methods,
it will just call Ruby #{+,-,*,/} methods via rb_funcall().

This patch will provide the optimization path for calculation
using #{+,-,/,*} methods for internal Fixnum objects.

* Before
```
Calculating -------------------------------------
           Complex#+      5.186M (± 4.9%) i/s -     25.937M in   5.013851s
           Complex#-      5.209M (± 5.9%) i/s -     26.038M in   5.017972s
           Complex#*      3.211M (± 5.2%) i/s -     16.170M in   5.051605s
           Complex#/    537.251k (± 3.9%) i/s -      2.691M in   5.017513s
          Complex#**      1.540M (± 3.0%) i/s -      7.726M in   5.019918s
        Complex#abs2      7.050M (± 7.9%) i/s -     35.047M in   5.009324s
```

* After
```
Calculating -------------------------------------
           Complex#+      7.265M (± 4.6%) i/s -     36.341M in   5.013803s
           Complex#-      7.310M (± 4.5%) i/s -     36.540M in   5.009521s
           Complex#*      6.402M (± 4.0%) i/s -     32.060M in   5.016835s
           Complex#/    541.564k (± 3.3%) i/s -      2.744M in   5.072620s
          Complex#**      1.490M (± 4.0%) i/s -      7.506M in   5.046460s
        Complex#abs2     17.799M (± 6.6%) i/s -     88.688M in   5.007732s
```

* Test code
```
require 'benchmark/ips'

Benchmark.ips do |x|
  c1 = Complex(2, 3)
  c2 = Complex(2, 3)

  x.report "Complex#+" do |t|
    t.times { c1 + c2 }
  end

  x.report "Complex#-" do |t|
    t.times { c1 - c2 }
  end

  x.report "Complex#*" do |t|
    t.times { c1 * c2 }
  end

  x.report "Complex#/" do |t|
    t.times { c1 / c2 }
  end

  x.report "Complex#**" do |t|
    t.times { c1 ** c2 }
  end

  x.report "Complex#abs2" do |t|
    t.times { c1.abs2 }
  end
end
```

https://bugs.ruby-lang.org/issues/13506