### PR TITLE
Improve performance of some Complex methods where call Numeric#real? …

### DIFF
--- a/complex.c
+++ b/complex.c
@@ -179,10 +179,7 @@ fun1(numerator)
 inline static VALUE
 f_real_p(VALUE x)
 {
-    if (RB_INTEGER_TYPE_P(x)) {
-        return Qtrue;
-    }
-    else if (RB_FLOAT_TYPE_P(x)) {
+    if (RB_INTEGER_TYPE_P(x) || RB_FLOAT_TYPE_P(x)) {
         return Qtrue;
     }
     return rb_funcall(x, id_real_p, 0);

--- a/complex.c
+++ b/complex.c
@@ -175,7 +175,18 @@ f_negate(VALUE x)
 }
 
 fun1(numerator)
-fun1(real_p)
+
+inline static VALUE
+f_real_p(VALUE x)
+{
+    if (RB_INTEGER_TYPE_P(x)) {
+        return Qtrue;
+    }
+    else if (RB_FLOAT_TYPE_P(x)) {
+        return Qtrue;
+    }
+    return rb_funcall(x, id_real_p, 0);
+}
 
 inline static VALUE
 f_to_i(VALUE x)


### PR DESCRIPTION
…internally

Some Complex methods call Numeric#real? at f_real_p() using rb_funcall().
This patch will provide optimization in f_real_p() when Integer/Float is given as internal objects.

* Before
```
Calculating -------------------------------------
           Complex#+      5.226M (± 3.9%) i/s -     26.145M in   5.011147s
           Complex#-      5.274M (± 4.4%) i/s -     26.321M in   5.001267s
           Complex#*      3.217M (± 4.7%) i/s -     16.092M in   5.013429s
```

* After
```
Calculating -------------------------------------
           Complex#+      6.925M (± 5.4%) i/s -     34.559M in   5.006583s
           Complex#-      7.124M (± 4.8%) i/s -     35.652M in   5.017364s
           Complex#*      3.880M (± 4.1%) i/s -     19.363M in   5.000170s
```

* Test code
```
require 'benchmark/ips'

Benchmark.ips do |x|
  c1 = Complex(2, 3)
  c2 = Complex(2, 3)

  x.report "Complex#+" do |t|
    t.times { c1 + c2 }
  end

  x.report "Complex#-" do |t|
    t.times { c1 - c2 }
  end

  x.report "Complex#*" do |t|
    t.times { c1 * c2 }
  end

end
```
