### PR TITLE
Fix typo in documentation [ci skip]

### DIFF
--- a/io.c
+++ b/io.c
@@ -6416,7 +6416,7 @@ pipe_close(VALUE io)
  *
  *  If <i>cmd</i> is an +Array+ of +String+,
  *  then it will be used as the subprocess's +argv+ bypassing a shell.
- *  The array can contains a hash at first for environments and
+ *  The array can contain a hash at first for environments and
  *  a hash at last for options similar to <code>spawn</code>.
  *
  *  The default mode for the new file object is ``r'',


### PR DESCRIPTION
The sentence below from the `IO#popen` documentation contains a typo:

> The array can contains a hash at first for environments and a hash at last for options similar to `spawn`.

This PR fixes this by replacing `contains` with `contain`.