### PR TITLE
Improve performance of some Time methods

### DIFF
--- a/internal.h
+++ b/internal.h
@@ -1536,6 +1536,7 @@ VALUE rb_rational_reciprocal(VALUE x);
 VALUE rb_cstr_to_rat(const char *, int);
 VALUE rb_rational_abs(VALUE self);
 VALUE rb_rational_cmp(VALUE self, VALUE other);
+VALUE rb_numeric_quo(VALUE x, VALUE y);
 
 /* re.c */
 VALUE rb_reg_compile(VALUE str, int options, const char *sourcefile, int sourceline);

--- a/rational.c
+++ b/rational.c
@@ -2015,8 +2015,8 @@ numeric_denominator(VALUE self)
  *  Returns the most exact division (rational for integers, float for floats).
  */
 
-static VALUE
-numeric_quo(VALUE x, VALUE y)
+VALUE
+rb_numeric_quo(VALUE x, VALUE y)
 {
     if (RB_FLOAT_TYPE_P(y)) {
         return rb_funcall(x, rb_intern("fdiv"), 1, y);
@@ -2726,7 +2726,7 @@ Init_Rational(void)
 
     rb_define_method(rb_cNumeric, "numerator", numeric_numerator, 0);
     rb_define_method(rb_cNumeric, "denominator", numeric_denominator, 0);
-    rb_define_method(rb_cNumeric, "quo", numeric_quo, 1);
+    rb_define_method(rb_cNumeric, "quo", rb_numeric_quo, 1);
 
     rb_define_method(rb_cInteger, "numerator", integer_numerator, 0);
     rb_define_method(rb_cInteger, "denominator", integer_denominator, 0);

--- a/time.c
+++ b/time.c
@@ -143,7 +143,7 @@ quov(VALUE x, VALUE y)
             return LONG2FIX(c);
         }
     }
-    ret = rb_funcall(x, id_quo, 1, y);
+    ret = rb_numeric_quo(x, y);
     if (RB_TYPE_P(ret, T_RATIONAL) &&
         RRATIONAL(ret)->den == INT2FIX(1)) {
         ret = RRATIONAL(ret)->num;


### PR DESCRIPTION
This is related to https://github.com/ruby/ruby/pull/1596

Some Time methods will call internal quov() function and
quov() calls Numeric#quo -> Rational#quo -> ...

This patch will add rb_numeric_quo() as internal C API to call Numeric#quo directly.
And this will use rb_numeric_quo() instead of rb_funcall() for Numeric#quo to internal objects.

Time#- will be faster around 15%.

* Before
```
Calculating -------------------------------------
         Time#subsec      2.029M (± 8.6%) i/s -     10.078M in   5.003036s
              Time#-      4.225M (± 2.1%) i/s -     21.130M in   5.003600s
           Time#to_f      5.580M (± 2.1%) i/s -     27.955M in   5.011881s
           Time#to_r      1.862M (± 9.8%) i/s -      9.253M in   5.016749s
```

* After
```
Calculating -------------------------------------
         Time#subsec      2.196M (±10.7%) i/s -     10.879M in   5.010285s
              Time#-      4.991M (± 2.2%) i/s -     24.966M in   5.005041s
           Time#to_f      6.809M (±13.5%) i/s -     32.204M in   5.005536s
           Time#to_r      1.980M (± 9.6%) i/s -      9.854M in   5.020879s
```

* Test code
```
require 'benchmark/ips'

Benchmark.ips do |x|
  x.report "Time#subsec" do |t|
    time = Time.now
    t.times { time.subsec }
  end

  x.report "Time#-" do |t|
    time1 = Time.now
    time2 = Time.now
    t.times { time1 - time2 }
  end

  x.report "Time#to_f" do |t|
    time = Time.now
    t.times { time.to_f }
  end

  x.report "Time#to_r" do |t|
    time = Time.now
    t.times { time.to_r }
  end
end
```

https://bugs.ruby-lang.org/issues/13519