### PR TITLE
rdoc: do not store current timestamps in gz headers

### DIFF
--- a/lib/rdoc/generator/json_index.rb
+++ b/lib/rdoc/generator/json_index.rb
@@ -175,7 +175,7 @@ class RDoc::Generator::JsonIndex
     debug_msg "Writing gzipped search index to %s" % outfile
 
     Zlib::GzipWriter.open(outfile) do |gz|
-      gz.mtime = File.mtime(search_index_file)
+      gz.mtime = 1 # make output reproducible
       gz.orig_name = search_index_file.basename.to_s
       gz.write search_index
       gz.close
@@ -193,7 +193,7 @@ class RDoc::Generator::JsonIndex
         debug_msg "Writing gzipped file to %s" % outfile
 
         Zlib::GzipWriter.open(outfile) do |gz|
-          gz.mtime = File.mtime(dest)
+          gz.mtime = 1 # make output reproducible
           gz.orig_name = dest.basename.to_s
           gz.write data
           gz.close


### PR DESCRIPTION
to enable reproducible builds of rdoc

Normally, 0 would be the preferred value to indicate "no date"
but that value is handled differently in Zlib::GzipWriter
to put in the current time