### PR TITLE
Modify the return value of Gem::Version.correct?

### DIFF
--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -170,7 +170,7 @@ class Gem::Version
   # True if the +version+ string matches RubyGems' requirements.
 
   def self.correct? version
-    version.to_s =~ ANCHORED_VERSION_PATTERN
+    ANCHORED_VERSION_PATTERN.match?(version.to_s)
   end
 
   ##

--- a/test/rubygems/test_gem_version.rb
+++ b/test/rubygems/test_gem_version.rb
@@ -41,6 +41,11 @@ class TestGemVersion < Gem::TestCase
     assert_equal v('1.1'), Gem::Version.create(ver)
   end
 
+  def test_class_correct
+    assert Gem::Version.correct?("5.1")
+    refute Gem::Version.correct?("an incorrect version")
+  end
+
   def test_class_new_subclass
     v1 = Gem::Version.new '1'
     v2 = V.new '1'


### PR DESCRIPTION
Before:

```ruby
Gem::Version.correct?("5.1") # => 0
Gem::Version.correct?("an incorrect version") # => nil
```

After:

```ruby
Gem::Version.correct?("5.1") # => true
Gem::Version.correct?("an incorrect version") # => false
```