### PR TITLE
Significant CSV parsing performance improvement

### DIFF
--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -1876,7 +1876,7 @@ class CSV
           # If we are continuing a previous column
           if part.end_with?(@quote_char) && part.count(@quote_char) % 2 != 0
             # extended column ends
-            csv[-1] = csv[-1].push(part[0..-2]).join("")
+            csv.last << part[0..-2]
             if csv.last =~ @parsers[:stray_quote]
               raise MalformedCSVError,
                     "Missing or stray quote in line #{lineno + 1}"
@@ -1884,13 +1884,13 @@ class CSV
             csv.last.gsub!(@double_quote_char, @quote_char)
             in_extended_col = false
           else
-            csv.last.push(part, @col_sep)
+            csv.last << part << @col_sep
           end
         elsif part.start_with?(@quote_char)
           # If we are starting a new quoted column
           if part.count(@quote_char) % 2 != 0
             # start an extended column
-            csv << [part[1..-1], @col_sep]
+            csv << (part[1..-1] << @col_sep)
             in_extended_col =  true
           elsif part.end_with?(@quote_char)
             # regular quoted column
@@ -1933,7 +1933,7 @@ class CSV
         if @io.eof?
           raise MalformedCSVError,
                 "Unclosed quoted field on line #{lineno + 1}."
-        elsif @field_size_limit and csv.last.sum(&:size) >= @field_size_limit
+        elsif @field_size_limit and csv.last.size >= @field_size_limit
           raise MalformedCSVError, "Field size exceeded on line #{lineno + 1}."
         end
         # otherwise, we need to loop and pull some more data to complete the row


### PR DESCRIPTION
## Summary:

This pull request significantly reduces the number of allocations made when parsing CSV files using the `csv` standard library. The performance improvement is particularly marked when the CSV data is quoted.

Three related changes were made to the so-called "hot path", that I've left (for now) as separate commits on this branch.

There are no regressions in the test suite:

```
$ make test-all TESTS=csv/ts_all.rb
[...]
# Running tests:

Finished tests in 1.079541s, 311.2434 tests/s, 7875.5693 assertions/s.
336 tests, 8502 assertions, 0 failures, 0 errors, 0 skips

ruby -v: ruby 2.5.0dev (2017-05-07 trunk 58601) [x86_64-darwin16]
```

## Benchmarking:

I have benchmarked both IPS and object allocations, using CSV data with 100 rows and 100 columns, where each cell has the value `"cell, value"`.

Full scripts and output can be found in this Gist:
https://gist.github.com/joshpencheon/e9a930c4cd88d3abbd280d76228b02f6

**Allocations:**

Using @SamSaffron's `memory_profiler`:

```
                Without Patch                    |                  With Patch
-------------------------------------------------+-------------------------------------------------
                                                 |
Git revision: fd6853a2292a4d                     | Git revision: 17ba724422f0f
                                                 |
Total allocated: 55349270 bytes (906503 objects) | Total allocated: 22561210 bytes (406624 objects)
Total retained:  0 bytes (0 objects)             | Total retained:  0 bytes (0 objects)
                                                 |
allocated memory by class                        | allocated memory by class
-----------------------------------              | -----------------------------------
  47548090  String                               |   18753090  String
   7454320  Array                                |    3456320  Array
    294000  MatchData                            |     294000  MatchData
     37340  Regexp                               |      42280  Regexp
      9600  Hash                                 |       9600  Hash
      2240  CSV                                  |       2240  CSV
      1600  Proc                                 |       1600  Proc
      1280  Method                               |       1280  Method
       800  StringIO                             |        800  StringIO
                                                 |
allocated objects by class                       | allocated objects by class
-----------------------------------              | -----------------------------------
    802813  String                               |     402874  String
    102480  Array                                |       2530  Array
      1050  MatchData                            |       1050  MatchData
        70  Regexp                               |         80  Regexp
        30  Hash                                 |         30  Hash
        20  Method                               |         20  Method
        20  Proc                                 |         20  Proc
        10  CSV                                  |         10  CSV
        10  StringIO                             |         10  StringIO
```

**Iterations per second:**

```
Calculating:
  without patch    24.304  (± 8.2%) i/s -     1.450k in  60.017254s
     with patch    38.916  (± 2.6%) i/s -     2.334k in  60.066885s
   
Comparison:
     with patch    38.916 i/s
  without patch    24.304 i/s - 1.60x slower
```

So for the non-trivial sample data generated, performance with the patch show a >50% improvement, along with ~60% reduction in allocations.

With unquoted CSV data, allocations are still avoided per cell, but the improvements are not as marked.

Please let me know if there's anything else I can do.

Thanks,
Josh
