### PR TITLE
Better wording for __ENCODING__

### DIFF
--- a/encoding.c
+++ b/encoding.c
@@ -1545,7 +1545,7 @@ rb_enc_default_internal(void)
  * Additionally String#encode and String#encode! use the default internal
  * encoding if no encoding is given.
  *
- * The locale encoding (__ENCODING__), not default_internal, is used as the
+ * The script encoding (__ENCODING__), not default_internal, is used as the
  * encoding of created strings.
  *
  * Encoding::default_internal is initialized by the source file's


### PR DESCRIPTION
"locale encoding" is misleading since it doesn't mean Encoding.find("locale")
but the encoding used to interpret the script file. It's therefore better to
call it "script encoding" as in the paragraphs above.