### PR TITLE
Optimize ERB string concat using opt_ltlt

### DIFF
--- a/lib/erb.rb
+++ b/lib/erb.rb
@@ -867,8 +867,8 @@ class ERB
   # requires the setup of an ERB _compiler_ object.
   #
   def set_eoutvar(compiler, eoutvar = '_erbout')
-    compiler.put_cmd = "#{eoutvar}.concat"
-    compiler.insert_cmd = "#{eoutvar}.concat"
+    compiler.put_cmd = "#{eoutvar}.<<"
+    compiler.insert_cmd = "#{eoutvar}.<<"
     compiler.pre_cmd = ["#{eoutvar} = String.new"]
     compiler.post_cmd = ["#{eoutvar}.force_encoding(__ENCODING__)"]
   end


### PR DESCRIPTION
Using `opt_ltlt` instruction instead of `opt_send_without_block` for `#concat`, we can bypass method call and use `rb_str_concat` directly. So I changed ERB to generate `#<<`.

## Benchmark
With [trunk ruby](https://github.com/ruby/ruby/commit/b7ff46b7a4690974e98d090e3e4de89ef73e533a) and [compiled result of bm_app_erb.rb's erb template](https://github.com/ruby/ruby/blob/v2_4_1/benchmark/bm_app_erb.rb#L18-L26) like this,

```rb
require 'benchmark/ips'

Benchmark.ips do |x|
  title = "hello world!"
  content = "hello world!\n" * 10

  x.report('concat') do
    _erbout = String.new; _erbout.concat "<html>\n  <head> "
    ; _erbout.concat(( title ).to_s); _erbout.concat " </head>\n  <body>\n    <h1> "
    ; _erbout.concat(( title ).to_s); _erbout.concat " </h1>\n    <p>\n      "
    ; _erbout.concat(( content ).to_s); _erbout.concat "\n    </p>\n  </body>\n</html>\n"
    ; _erbout.force_encoding(__ENCODING__)
  end
  x.report('<<') do
    _erbout = String.new; _erbout.<< "<html>\n  <head> "
    ; _erbout.<<(( title ).to_s); _erbout.<< " </head>\n  <body>\n    <h1> "
    ; _erbout.<<(( title ).to_s); _erbout.<< " </h1>\n    <p>\n      "
    ; _erbout.<<(( content ).to_s); _erbout.<< "\n    </p>\n  </body>\n</html>\n"
    ; _erbout.force_encoding(__ENCODING__)
  end
  x.compare!
end
```

the rendering performance benchmark result is:

```
Calculating -------------------------------------
              concat    301.067k (± 9.1%) i/s -      1.510M in   5.056566s
                  <<    533.025k (±11.3%) i/s -      2.654M in   5.042675s

Comparison:
                  <<:   533024.6 i/s
              concat:   301066.7 i/s - 1.77x  slower
```