### PR TITLE
Implement Hash#choice method.

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -1350,6 +1350,30 @@ rb_hash_values_at(int argc, VALUE *argv, VALUE hash)
 
 /*
  * call-seq:
+ *   hsh.pick(key, ...)   -> Hash
+ *
+ * Return a key-value pair associated with given keys. 
+ *
+ * { :a => 1, 2 => "2", "c" => true }.pick(:a, 2) # => { :a => 1, 2 => "2" }
+ * { :a => 1, 2 => "2", "c" => true }.pick("c", 10000) # => { "c" => true, 10000 => nil }
+ */
+
+VALUE
+rb_hash_pick(int argc, VALUE *argv, VALUE self){
+  int i;
+  VALUE result, value;
+  result = rb_hash_new();
+
+  for(i=0; i < argc; i++){
+    value = rb_hash_aref(self, argv[i]);
+    rb_hash_aset(result, argv[i], value);
+  }
+
+  return result;
+}
+
+/*
+ * call-seq:
  *   hsh.fetch_values(key, ...)                 -> array
  *   hsh.fetch_values(key, ...) { |key| block } -> array
  *
@@ -4485,6 +4509,7 @@ Init_Hash(void)
     rb_define_method(rb_cHash, "keys", rb_hash_keys, 0);
     rb_define_method(rb_cHash, "values", rb_hash_values, 0);
     rb_define_method(rb_cHash, "values_at", rb_hash_values_at, -1);
+    rb_define_method(rb_cHash, "pick", rb_hash_pick, -1);
     rb_define_method(rb_cHash, "fetch_values", rb_hash_fetch_values, -1);
 
     rb_define_method(rb_cHash, "shift", rb_hash_shift, 0);

--- a/test/ruby/test_hash.rb
+++ b/test/ruby/test_hash.rb
@@ -572,6 +572,21 @@ class TestHash < Test::Unit::TestCase
     assert_equal ['three', nil, 'one', 'nil'], res
   end
 
+  def test_pick
+    res = @h.pick()
+    assert_equal({}, res)
+
+    res = @h.pick(1,2)
+    assert_equal({1 => "one", 2 => "two"}, res)
+
+    res = @h.pick(1,2,1000)
+    assert_equal({1 => "one", 2 => "two", 1000 => nil}, res)
+
+    h = { a: 10 } 
+    h.default= "default"
+    assert_equal({1000 => "default"}, h.pick(1000))
+  end
+
   def test_fetch_values
     res = @h.fetch_values
     assert_equal(0, res.length)


### PR DESCRIPTION
Hi,

I propose Hash#choice method.

It pick up key and value pairs in Hash like a below code.

```ruby
{ :a => 1, 2 => "2", "c" => true }.choice(:a, 2) # => { :a => 1, 2 => "2" }
{ :a => 1, 2 => "2", "c" => true }.choice("c", 10000) # => { "c" => true, 10000 => nil }
```

This method is useful when Hash have many keys, but programer need few key's.

For instance, it pick up personal data in ActiveRecord model's data, and migrate to new device.

```ruby
feature_phone_user = User.find(params[:src_user_id])
profile = feature_phone_user.attributes.choice(*%i[nickname email sex birthday prefecture])
smart_phone_user   = User.new
smart_phone_user.attributes = profile
```

In other case, it pick up latest log from http request parameter.

```ruby
condition = params.to_h.choice("user_id", "service_id")
latest_payment_log = PaymentLog.find_by(condition).last
```

If this method exist, I guess that many cases change to comfortable just a little.

Please think about it.
