### PR TITLE
object.c: use a sized enumerator with #yield_self

### DIFF
--- a/object.c
+++ b/object.c
@@ -497,6 +497,12 @@ rb_obj_itself(VALUE obj)
     return obj;
 }
 
+static VALUE
+rb_obj_size(VALUE self, VALUE args, VALUE obj)
+{
+    return LONG2FIX(1);
+}
+
 /*
  *  call-seq:
  *     obj.yield_self {|_obj|...} -> an_object
@@ -510,7 +516,7 @@ rb_obj_itself(VALUE obj)
 static VALUE
 rb_obj_yield_self(VALUE obj)
 {
-    RETURN_ENUMERATOR(obj, 0, 0);
+    RETURN_SIZED_ENUMERATOR(obj, 0, 0, rb_obj_size);
     return rb_yield_values2(1, &obj);
 }
 

--- a/test/ruby/test_object.rb
+++ b/test/ruby/test_object.rb
@@ -23,6 +23,7 @@ class TestObject < Test::Unit::TestCase
     object = Object.new
     assert_same(self, object.yield_self {self}, feature)
     assert_same(object, object.yield_self {|x| break x}, feature)
+    assert_same(1, object.yield_self.size)
     assert_instance_of(Enumerator, object.yield_self)
   end
 


### PR DESCRIPTION
The #yield_self Enumerator instance always has a #count of `1`.
This provides a lazy #size of `1` to match the count instead of `nil`.