### PR TITLE
Windows - TestRubyOptions#test_search - append to paths instead of replacing

### DIFF
--- a/test/ruby/test_rubyoptions.rb
+++ b/test/ruby/test_rubyoptions.rb
@@ -296,11 +296,15 @@ class TestRubyOptions < Test::Unit::TestCase
       @verbose = $VERBOSE
       $VERBOSE = nil
 
-      ENV['PATH'] = File.dirname(t.path)
+      ENV['PATH'] = path_orig ?
+        path_orig + File::PATH_SEPARATOR + File.dirname(t.path) :
+        File.dirname(t.path)
 
       assert_in_out_err(%w(-S) + [File.basename(t.path)], "", %w(1), [])
 
-      ENV['RUBYPATH'] = File.dirname(t.path)
+      ENV['RUBYPATH'] = rubypath_orig ?
+        rubypath_orig + File::PATH_SEPARATOR + File.dirname(t.path) :
+        File.dirname(t.path)
 
       assert_in_out_err(%w(-S) + [File.basename(t.path)], "", %w(1), [])
     }


### PR DESCRIPTION
Current Test fails on Windows/MinGW.  The assert shells out to ruby, on windows, ENV['PATH'] must still include ruby/bin.  Also, both variables are now normally arrays, so tests check split/enumerate.