### PR TITLE
Add missing word in transform_values method descriptions

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -1809,7 +1809,7 @@ transform_values_i(VALUE key, VALUE value, VALUE result)
  *     hsh.transform_values {|value| block } -> hsh
  *     hsh.transform_values                  -> an_enumerator
  *
- *  Return a new with the results of running block once for every value.
+ *  Return a new hash with the results of running block once for every value.
  *  This method does not change the keys.
  *
  *     h = { a: 1, b: 2, c: 3 }
@@ -1839,7 +1839,7 @@ rb_hash_transform_values(VALUE hash)
  *     hsh.transform_values! {|value| block } -> hsh
  *     hsh.transform_values!                  -> an_enumerator
  *
- *  Return a new with the results of running block once for every value.
+ *  Return a new hash with the results of running block once for every value.
  *  This method does not change the keys.
  *
  *     h = { a: 1, b: 2, c: 3 }


### PR DESCRIPTION
Explicitly says that the methods return a new hash rather than just
stating it return a new "something" we don't know about.