### PR TITLE
Improve performance of string interpolation

### DIFF
--- a/string.c
+++ b/string.c
@@ -2880,16 +2880,17 @@ rb_str_concat_literals(size_t num, const VALUE *strary)
 {
     VALUE str;
     size_t i, s;
+    long len = 1;
 
     if (UNLIKELY(!num)) return rb_str_new(0, 0);
     if (UNLIKELY(num == 1)) return rb_str_resurrect(strary[0]);
 
-    long len = 1;
     for (i = 0; i < num; ++i) { len += RSTRING_LEN(strary[i]); }
     if (LIKELY(len < MIN_PRE_ALLOC_SIZE)) {
       str = rb_str_resurrect(strary[0]);
       s = 1;
-    } else {
+    }
+    else {
       str = rb_str_buf_new(len);
       s = 0;
     }

--- a/string.c
+++ b/string.c
@@ -2892,6 +2892,7 @@ rb_str_concat_literals(size_t num, const VALUE *strary)
     }
     else {
       str = rb_str_buf_new(len);
+      rb_enc_copy(str, strary[0]);
       s = 0;
     }
 

--- a/test/ruby/test_string.rb
+++ b/test/ruby/test_string.rb
@@ -513,6 +513,11 @@ CODE
     assert_raise(RuntimeError) { 'foo'.freeze.concat('bar') }
   end
 
+  def test_concat_literals
+    s="."*50; "#{s}x".encoding
+    assert_equal("#{s}x".encoding, Encoding::UTF_8)
+  end
+
   def test_count
     a = S("hello world")
     assert_equal(5, a.count(S("lo")))

--- a/test/ruby/test_string.rb
+++ b/test/ruby/test_string.rb
@@ -515,7 +515,7 @@ CODE
 
   def test_concat_literals
     s="."*50; "#{s}x".encoding
-    assert_equal("#{s}x".encoding, Encoding::UTF_8)
+    assert_equal(Encoding::UTF_8, "#{s}x".encoding)
   end
 
   def test_count

--- a/test/ruby/test_string.rb
+++ b/test/ruby/test_string.rb
@@ -514,7 +514,7 @@ CODE
   end
 
   def test_concat_literals
-    s="."*50; "#{s}x".encoding
+    s="." * 50
     assert_equal(Encoding::UTF_8, "#{s}x".encoding)
   end
 


### PR DESCRIPTION
This patch will add pre-allocation in string interpolation.
By this, unnecessary capacity resizing is avoided.

For small strings, optimized `rb_str_resurrect` operation is faster, so pre-allocation is done only when concatenated strings are large.
`MIN_PRE_ALLOC_SIZE` was decided by experimenting with my local machine (x86_64-apple-darwin 16.5.0, Apple LLVM version 8.1.0 (clang - 802.0.42)).

String interpolation will be faster around **72%** when large string is created.

* Before

```
Calculating -------------------------------------
Large string interpolation
                          1.276M (± 5.9%) i/s -      6.358M in   5.002022s
Small string interpolation
                          5.156M (± 5.5%) i/s -     25.728M in   5.005731s
```

* After

```
Calculating -------------------------------------
Large string interpolation
                          2.201M (± 5.8%) i/s -     11.063M in   5.043724s   <- 72% faster!!
Small string interpolation
                          5.192M (± 5.7%) i/s -     25.971M in   5.020516s   <- no degradation
```

* Test code

```
require 'benchmark/ips'

Benchmark.ips do |x|
  x.report "Large string interpolation" do |t|
    a = "Hellooooooooooooooooooooooooooooooooooooooooooooooooooo"
    b = "Wooooooooooooooooooooooooooooooooooooooooooooooooooorld"

    t.times do
      "#{a}, #{b}!"
    end
  end

  x.report "Small string interpolation" do |t|
    a = "Hello"
    b = "World"

    t.times do
      "#{a}, #{b}!"
    end
  end
end
```

Issue
https://bugs.ruby-lang.org/issues/13587