### PR TITLE
Fix docs for Array#sort and Array#sort! [ci skip]

### DIFF
--- a/array.c
+++ b/array.c
@@ -2449,9 +2449,9 @@ sort_2(const void *ap, const void *bp, void *dummy)
  *  The result is not guaranteed to be stable.  When the comparison of two
  *  elements returns +0+, the order of the elements is unpredictable.
  *
- *     a = [ "d", "a", "e", "c", "b" ]
- *     a.sort!                    #=> ["a", "b", "c", "d", "e"]
- *     a.sort! { |x,y| y <=> x }  #=> ["e", "d", "c", "b", "a"]
+ *     ary = [ "d", "a", "e", "c", "b" ]
+ *     ary.sort!                    #=> ["a", "b", "c", "d", "e"]
+ *     ary.sort! { |a,b| a <=> b }  #=> ["e", "d", "c", "b", "a"]
  *
  *  See also Enumerable#sort_by.
  */
@@ -2533,9 +2533,9 @@ rb_ary_sort_bang(VALUE ary)
  *  The result is not guaranteed to be stable.  When the comparison of two
  *  elements returns +0+, the order of the elements is unpredictable.
  *
- *     a = [ "d", "a", "e", "c", "b" ]
- *     a.sort                    #=> ["a", "b", "c", "d", "e"]
- *     a.sort { |x,y| y <=> x }  #=> ["e", "d", "c", "b", "a"]
+ *     ary = [ "d", "a", "e", "c", "b" ]
+ *     ary.sort                    #=> ["a", "b", "c", "d", "e"]
+ *     ary.sort { |a,b| a <=> b }  #=> ["e", "d", "c", "b", "a"]
  *
  *  See also Enumerable#sort_by.
  */


### PR DESCRIPTION
For better understanding, the block documentation should use `x` and `y`
(not `a` and `b`) to match the example given bellow.