### PR TITLE
remove extra call to OleInitialize

### DIFF
--- a/ext/win32ole/win32ole.c
+++ b/ext/win32ole/win32ole.c
@@ -824,7 +824,6 @@ ole_initialize(void)
         } else {
             hr = OleInitialize(NULL);
         }
-        hr = OleInitialize(NULL);
         if(FAILED(hr)) {
             ole_raise(hr, rb_eRuntimeError, "fail: OLE initialize");
         }


### PR DESCRIPTION
[As observed](https://github.com/ruby/ruby/pull/1423#issuecomment-303816294) by @MosesMendoza, my previous PR #1423 was misapplied in https://github.com/ruby/ruby/commit/8feb9779182bd4285f3881029fe850dac188c1ac. This corrects the extra OleInitialize call.

Signed-off-by: Matt Wrock <matt@mattwrock.com>