### PR TITLE
[DOC] Add rdoc to describe URI.unescape is obsolete

### DIFF
--- a/lib/uri/common.rb
+++ b/lib/uri/common.rb
@@ -114,6 +114,12 @@ module URI
     # +str+::
     #   Unescapes the string.
     #
+    # == Description
+    #
+    # This method is obsolete and should not be used. Instead, use
+    # CGI.unescape, URI.decode_www_form or URI.decode_www_form_component
+    # depending on your specific use case.
+    #
     # == Usage
     #
     #   require 'uri'


### PR DESCRIPTION
Just like https://github.com/sonots/ruby/blob/c433a1822d24cc026ff453dbcca569ba38f3f07a/lib/uri/common.rb#L84-L86