### PR TITLE
string.c: Optimize String#concat when argc is 1

### DIFF
--- a/string.c
+++ b/string.c
@@ -2935,7 +2935,9 @@ rb_str_concat_multi(int argc, VALUE *argv, VALUE str)
 {
     str_modifiable(str);
 
-    if (argc > 0) {
+    if (argc == 1) {
+	return rb_str_concat(str, argv[0]);
+    } else if (argc > 1) {
 	int i;
 	VALUE arg_str = rb_str_tmp_new(0);
 	rb_enc_copy(arg_str, str);


### PR DESCRIPTION
This patch optimizes performance drawbacks introduced in https://github.com/ruby/ruby/commit/9387ff7315b498a6e7c8ab2a4b1582fd6c717524.

## Benchmark (i7-4790K @ 4.00GH, x86_64 GNU/Linux)

```rb
Benchmark.ips do |x|
  x.report("String#concat (1)") { "a".concat("b") }
  x.report("String#concat (2)") { "a".concat("b", "c") }
end
```

### Before

```
Calculating -------------------------------------
   String#concat (1)      4.458M (± 8.9%) i/s -     22.298M in   5.058084s
   String#concat (2)      3.660M (± 5.6%) i/s -     18.314M in   5.020527s
```

### After

```
Calculating -------------------------------------
   String#concat (1)      6.448M (± 5.2%) i/s -     32.215M in   5.010833s
   String#concat (2)      3.633M (± 9.0%) i/s -     18.056M in   5.022603s
```

"String#concat (1)" became 1.44x faster without "String#concat (2)" regression.