### PR TITLE
Improve Array#concat performance if only one argument is given

### DIFF
--- a/array.c
+++ b/array.c
@@ -3679,7 +3679,10 @@ rb_ary_concat_multi(int argc, VALUE *argv, VALUE ary)
 {
     rb_ary_modify_check(ary);
 
-    if (argc > 0) {
+    if (argc == 1) {
+	rb_ary_concat(ary, argv[0]);
+    }
+    else if (argc > 1) {
 	int i;
 	VALUE args = rb_ary_tmp_new(argc);
 	for (i = 0; i < argc; i++) {


### PR DESCRIPTION
This is very similar with https://github.com/ruby/ruby/pull/1631
If only one argument is given, this will concatenate the array without
generating temporary Array object.

Array#concat will be faster around 19%

* Before
```
Calculating -------------------------------------
        Array#concat      2.187M (± 3.5%) i/s -     10.926M in   5.002829s
```

* After
```
Calculating -------------------------------------
        Array#concat      2.598M (± 1.8%) i/s -     13.008M in   5.008201s
```

* Test code
```
require 'benchmark/ips'

Benchmark.ips do |x|
  x.report "Array#concat" do |i|
    other = [4]
    i.times { [1, 2, 3].concat(other) }
  end
end
```