### PR TITLE
IPAddr add helper commands get_ip and get_subnet

### DIFF
--- a/lib/ipaddr.rb
+++ b/lib/ipaddr.rb
@@ -386,6 +386,15 @@ class IPAddr
                    af, _to_string(@addr), _to_string(@mask_addr))
   end
 
+  def ip_address
+    return _to_string(@addr)
+  end
+
+  def subnet
+    return _to_string(@mask_addr)
+  end
+  
+
   protected
 
   # Set +@addr+, the internal stored ip address, to given +addr+. The

--- a/test/test_ipaddr.rb
+++ b/test/test_ipaddr.rb
@@ -53,6 +53,10 @@ class TC_IPAddr < Test::Unit::TestCase
     assert_equal(false, a.ipv6?)
 
     a = IPAddr.new("192.168.1.2/24")
+    assert_equal("192.168.0.0", a.ip_address)
+    assert_equal("255.255.255.0", a.subnet)
+
+    a = IPAddr.new("192.168.1.2/24")
     assert_equal("192.168.1.0", a.to_s)
     assert_equal("192.168.1.0", a.to_string)
     assert_equal(Socket::AF_INET, a.family)

--- a/test/test_ipaddr.rb
+++ b/test/test_ipaddr.rb
@@ -53,7 +53,7 @@ class TC_IPAddr < Test::Unit::TestCase
     assert_equal(false, a.ipv6?)
 
     a = IPAddr.new("192.168.1.2/24")
-    assert_equal("192.168.0.0", a.ip_address)
+    assert_equal("192.168.1.0", a.ip_address)
     assert_equal("255.255.255.0", a.subnet)
 
     a = IPAddr.new("192.168.1.2/24")


### PR DESCRIPTION
I had to implement the following for some nicer methods in another instance where I'm using the code. It's my first Ruby PR so please let me know if I've messed anything up!

```ruby
  def get_ip
    self.inspect.split(/[\/:]/).slice(2)
  end

  def get_subnet
    self.inspect.split(/[\/:>]/).slice(3)
  end
```