### PR TITLE
mkmf.rb: sort lists of source and object files

### DIFF
--- a/lib/mkmf.rb
+++ b/lib/mkmf.rb
@@ -2200,11 +2200,15 @@ RULES
     RbConfig.expand(srcdir = srcprefix.dup)
 
     ext = ".#{$OBJEXT}"
-    orig_srcs = Dir[File.join(srcdir, "*.{#{SRC_EXT.join(%q{,})}}")]
+    orig_srcs = Dir[File.join(srcdir, "*.{#{SRC_EXT.join(%q{,})}}")].sort
     if not $objs
       srcs = $srcs || orig_srcs
-      objs = srcs.inject(Hash.new {[]}) {|h, f| h[File.basename(f, ".*") << ext] <<= f; h}
-      $objs = objs.keys
+      $objs = []
+      objs = srcs.inject(Hash.new {[]}) {|h, f|
+        h.key?(o = File.basename(f, ".*") << ext) or $objs << o
+        h[o] <<= f
+        h
+      }
       unless objs.delete_if {|b, f| f.size == 1}.empty?
         dups = objs.sort.map {|b, f|
           "#{b[/.*\./]}{#{f.collect {|n| n[/([^.]+)\z/]}.join(',')}}"


### PR DESCRIPTION
* lib/mkmf.rb (create_makefile): sort lists of source and object
  files in generated Makefile, unless given by extconf.rb.
  [Fix GH-1367]

Without sorting the list of object files explicitely, its order is
indeterministic, because readdir() is also not deterministic.
When the list of object files varies between builds, they are
linked in a different order, which results in an unreproducible
build.

git-svn-id: svn+ssh://ci.ruby-lang.org/ruby/trunk@55265 b2dd03c8-39d4-4d8f-98ff-823fe69b080e

Cherry-picked from trunk commit 15dba481a28