### PR TITLE
Improve performance in where copy array elements

### DIFF
--- a/array.c
+++ b/array.c
@@ -165,13 +165,15 @@ ary_memfill(VALUE ary, long beg, long size, VALUE val)
     });
 }
 
+static const int array_cache_line_size = (int)(128/sizeof(VALUE)); /* is magic number (cache line size) */
+
 static void
 ary_memcpy0(VALUE ary, long beg, long argc, const VALUE *argv, VALUE buff_owner_ary)
 {
 #if 1
     assert(!ARY_SHARED_P(buff_owner_ary));
 
-    if (argc > (int)(128/sizeof(VALUE)) /* is magic number (cache line size) */) {
+    if (argc > array_cache_line_size) {
 	rb_gc_writebarrier_remember(buff_owner_ary);
 	RARRAY_PTR_USE(ary, ptr, {
 	    MEMCPY(ptr+beg, argv, VALUE, argc);


### PR DESCRIPTION
ary_memcpy0() has calculated the cache line size every time when copy array elements.
This patch will replace it with pre calculated value of cache line size.

Array#+ will be faster around 2%.

### Before
```
      Array#+(other)      5.167M (± 0.1%) i/s -     25.928M in   5.017629s
```

### After
```
      Array#+(other)      5.256M (± 0.2%) i/s -     26.410M in   5.025261s
```

### Test code
```
require 'benchmark/ips'

Benchmark.ips do |x|
  x.report "Array#+(other)" do |loop|
    ary1 = [1, 2, 3]
    ary2 = [4, 5]
    i = 0
    while i < loop
      ary1 + ary2
      i += 1
    end
  end
end
```

https://bugs.ruby-lang.org/issues/13629