### PR TITLE
test/logger/test_logdevice.rb - skip for Time.now= is undefined

### DIFF
--- a/test/logger/test_logdevice.rb
+++ b/test/logger/test_logdevice.rb
@@ -720,6 +720,7 @@ class TestLogDevice < Test::Unit::TestCase
       log = File.join(tmpdir, "log")
       cont = File.read(log)
       assert_match(/hello-2/, cont)
+      skip "Time.now= not defined on this platform" unless Time.respond_to?(:now=)
       assert_not_match(/hello-1/, cont)
       assert_file.for(bug).exist?(log+".20140102")
       assert_match(/hello-1/, File.read(log+".20140102"), bug)


### PR DESCRIPTION
Some versions of windows do not support setting Time.now without elevated privileges / permissions,

See [Issue 13644](https://bugs.ruby-lang.org/issues/13644)