### PR TITLE
fix sample code of Array#<<

### DIFF
--- a/array.c
+++ b/array.c
@@ -910,8 +910,11 @@ ary_take_first_or_last(int argc, const VALUE *argv, VALUE ary, enum ary_take_pos
  *  expression returns the array itself, so several appends
  *  may be chained together.
  *
- *     [ 1, 2 ] << "c" << "d" << [ 3, 4 ]
- *             #=>  [ 1, 2, "c", "d", [ 3, 4 ] ]
+ *     a = [ 1, 2 ]
+ *     a << "c" << "d" << [ 3, 4 ]
+ *          #=>  [ 1, 2, "c", "d", [ 3, 4 ] ]
+ *     a
+ *          #=>  [ 1, 2, "c", "d", [ 3, 4 ] ]
  *
  */
 


### PR DESCRIPTION
nice to meet you!
I felt something wrong with the sample code of the `<<` 
 in the array.c, so I sent you a PR.

Currently, the description of `<<` is as follows.

```
Append---Pushes the given object on to the end of this array. This
expression returns the array itself, so several appends
may be chained together.
```

However, we can get this result without updating the receiver.
For example, this result can be obtained also when writing code as follows.


```ruby
class Array
  def <<(other)
    self + [other]
  end
end
```

So, I will suggest another sample code

```
a = [1, 2]
a << "c" << "d" << [ 3, 4 ]
a #=> [1, 2, "c", "d", [3, 4]]
```

Please consider this proposal.