### PR TITLE
CVE-2015-9096: backport SMTP injection fix to 2.3

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+Sun Jun 11 21:25:09 2017  Shugo Maeda  <shugo@ruby-lang.org>
+
+	* lib/net/smtp.rb (getok, get_response): raise an ArgumentError when
+	  CR or LF is included in a line, because they are not allowed in
+	  RFC5321. https://hackerone.com/reports/137631 [Backport 0827a7e]
+
 Mon May  1 06:36:57 2017  NAKAMURA Usaku  <usa@ruby-lang.org>
 
 	* parse.y (parser_parse_string): set the mark of term to `nd_func`

--- a/lib/net/smtp.rb
+++ b/lib/net/smtp.rb
@@ -926,7 +926,15 @@ module Net
 
     private
 
+    def validate_line(line)
+      # A bare CR or LF is not allowed in RFC5321.
+      if /[\r\n]/ =~ line
+        raise ArgumentError, "A line must not contain CR or LF"
+      end
+    end
+
     def getok(reqline)
+      validate_line reqline
       res = critical {
         @socket.writeline reqline
         recv_response()
@@ -936,6 +944,7 @@ module Net
     end
 
     def get_response(reqline)
+      validate_line reqline
       @socket.writeline reqline
       recv_response()
     end


### PR DESCRIPTION
Backports 0827a7e52ba3d957a634b063bf5a391239b9ffee to 2.3

* lib/net/smtp.rb (getok, get_response): raise an ArgumentError when
CR or LF is included in a line, because they are not allowed in
RFC5321.

https://hackerone.com/reports/137631

/cc @unak 