### PR TITLE
CVE-2015-9096: backport SMTP injection fix to 2.2

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+Sun Jun 11 21:25:09 2017  Shugo Maeda  <shugo@ruby-lang.org>
+
+	* lib/net/smtp.rb (getok, get_response): raise an ArgumentError when
+	  CR or LF is included in a line, because they are not allowed in
+	  RFC5321. https://hackerone.com/reports/137631 [Backport 0827a7e]
+
 Tue Mar 28 15:39:26 2017  Nobuyoshi Nakada  <nobu@ruby-lang.org>
 
 	configure.in: syscall is deprecated on macOS

--- a/lib/net/smtp.rb
+++ b/lib/net/smtp.rb
@@ -925,7 +925,15 @@ module Net
 
     private
 
+    def validate_line(line)
+      # A bare CR or LF is not allowed in RFC5321.
+      if /[\r\n]/ =~ line
+        raise ArgumentError, "A line must not contain CR or LF"
+      end
+    end
+
     def getok(reqline)
+      validate_line reqline
       res = critical {
         @socket.writeline reqline
         recv_response()
@@ -935,6 +943,7 @@ module Net
     end
 
     def get_response(reqline)
+      validate_line reqline
       @socket.writeline reqline
       recv_response()
     end

--- a/test/net/smtp/test_smtp.rb
+++ b/test/net/smtp/test_smtp.rb
@@ -5,6 +5,8 @@ require 'minitest/autorun'
 module Net
   class TestSMTP < MiniTest::Unit::TestCase
     class FakeSocket
+      attr_reader :write_io
+
       def initialize out = "250 OK\n"
         @write_io = StringIO.new
         @read_io  = StringIO.new out
@@ -49,6 +51,51 @@ module Net
       smtp.instance_variable_set :@socket, FakeSocket.new
 
       assert smtp.rset
+    end
+
+    def test_mailfrom
+      sock = FakeSocket.new
+      smtp = Net::SMTP.new 'localhost', 25
+      smtp.instance_variable_set :@socket, sock
+      assert smtp.mailfrom("foo@example.com").success?
+      assert_equal "MAIL FROM:<foo@example.com>\r\n", sock.write_io.string
+    end
+
+    def test_rcptto
+      sock = FakeSocket.new
+      smtp = Net::SMTP.new 'localhost', 25
+      smtp.instance_variable_set :@socket, sock
+      assert smtp.rcptto("foo@example.com").success?
+      assert_equal "RCPT TO:<foo@example.com>\r\n", sock.write_io.string
+    end
+
+    def test_auth_plain
+      sock = FakeSocket.new
+      smtp = Net::SMTP.new 'localhost', 25
+      smtp.instance_variable_set :@socket, sock
+      assert smtp.auth_plain("foo", "bar").success?
+      assert_equal "AUTH PLAIN AGZvbwBiYXI=\r\n", sock.write_io.string
+    end
+
+    def test_crlf_injection
+      smtp = Net::SMTP.new 'localhost', 25
+      smtp.instance_variable_set :@socket, FakeSocket.new
+
+      assert_raises(ArgumentError) do
+        smtp.mailfrom("foo\r\nbar")
+      end
+
+      assert_raises(ArgumentError) do
+        smtp.mailfrom("foo\rbar")
+      end
+
+      assert_raises(ArgumentError) do
+        smtp.mailfrom("foo\nbar")
+      end
+
+      assert_raises(ArgumentError) do
+        smtp.rcptto("foo\r\nbar")
+      end
     end
   end
 end


### PR DESCRIPTION
Backports 0827a7e52ba3d957a634b063bf5a391239b9ffee to 2.2

* lib/net/smtp.rb (getok, get_response): raise an ArgumentError when
CR or LF is included in a line, because they are not allowed in
RFC5321.

https://hackerone.com/reports/137631

/cc @unak 