### PR TITLE
Dump Delegator itself instead of the delegated

### DIFF
--- a/lib/delegate.rb
+++ b/lib/delegate.rb
@@ -153,6 +153,13 @@ class Delegator < BasicObject
   end
 
   #
+  # Dumps the \_\_getobj\_\_
+  #
+  def inspect
+    "<#{self.class} __getobj__: #{__getobj__.inspect}>"
+  end
+
+  #
   # This method must be overridden by subclasses and should return the object
   # method calls are being delegated to.
   #


### PR DESCRIPTION
I would like to let `Delegator` dump itself instead of the delegated object. Let's consider the following scenario.

```
require "delegate"

class Foo < Delegator
  def initialize(the_obj)
    @the_obj = the_obj
  end

  def __getobj__
    @the_obj
  end
end

foo = Foo.new(nil)
foo.inspect
# nil
```

This dump message might cause confusion because `foo` object itself is not `nil`. Why don't we be clear and have a dump message like "foo is an Foo class with `nil` as the delegated object"?