### PR TITLE
Fix an error handling in `shell` library

### DIFF
--- a/lib/shell/system-command.rb
+++ b/lib/shell/system-command.rb
@@ -16,7 +16,7 @@ class Shell
   class SystemCommand < Filter
     def initialize(sh, command, *opts)
       if t = opts.find{|opt| !opt.kind_of?(String) && opt.class}
-        Shell.Fail Error::TypeError, t.class, "String"
+        Shell.Fail TypeError, t.class, "String"
       end
       super(sh)
       @command = command

--- a/test/shell/test_command_processor.rb
+++ b/test/shell/test_command_processor.rb
@@ -66,4 +66,17 @@ class TestShell::CommandProcessor < Test::Unit::TestCase
     Process.waitall
     Dir.rmdir(path)
   end
+
+  def test_option_type
+    name = 'foo'
+    path = File.join(@tmpdir, name)
+
+    open(path, 'w', 0755) {}
+    assert_raise(TypeError) {
+      catch(catch_command_start) {@shell.system(name, 42)}
+    }
+  ensure
+    Process.waitall
+    File.unlink(path)
+  end
 end


### PR DESCRIPTION
Before
---

```shell
ruby -v #=> ruby 2.5.0dev (2017-06-20 trunk 59122) [x86_64-darwin16]
```

```ruby
require 'shell'

shell = Shell.new
shell.system 'echo', 42
```

The error
```
/Users/kachick/.rubies/ruby-2.5.0dev.8ae9de372a/lib/ruby/2.5.0/shell/system-command.rb:19:in `initialize': uninitialized constant Shell::Error::TypeError (NameError)
```

After
---

The error
```
/Users/kachick/.rubies/ruby-2.5.0dev.8ae9de372a/lib/ruby/2.5.0/shell/system-command.rb:19:in `initialize': wrong argument type Integer (expected String) (TypeError)
```