### PR TITLE
Enumerable#uniq with non single yield arguments

### DIFF
--- a/enum.c
+++ b/enum.c
@@ -3855,6 +3855,7 @@ enum_sum(int argc, VALUE* argv, VALUE obj)
 static VALUE
 uniq_func(RB_BLOCK_CALL_FUNC_ARGLIST(i, hash))
 {
+    ENUM_WANT_SVALUE();
     rb_hash_add_new_element(hash, i, i);
     return Qnil;
 }
@@ -3862,6 +3863,7 @@ uniq_func(RB_BLOCK_CALL_FUNC_ARGLIST(i, hash))
 static VALUE
 uniq_iter(RB_BLOCK_CALL_FUNC_ARGLIST(i, hash))
 {
+    ENUM_WANT_SVALUE();
     rb_hash_add_new_element(hash, rb_yield_values2(argc, argv), i);
     return Qnil;
 }

--- a/test/ruby/test_enum.rb
+++ b/test/ruby/test_enum.rb
@@ -977,5 +977,6 @@ class TestEnumerable < Test::Unit::TestCase
     assert_equal([[1896, "Athens"], [1900, "Paris"], [1904, "Chicago"], [1908, "Rome"]],
                  olympics.uniq{|k,v| v})
     assert_equal([1, 2, 3, 4, 5, 10], (1..100).uniq{|x| (x**2) % 10 }.first(6))
+    assert_equal([1, [1, 2]], Foo.new.to_enum.uniq)
   end
 end


### PR DESCRIPTION
ticket: https://bugs.ruby-lang.org/issues/13669

```
ruby -v: ruby 2.5.0dev (2017-06-20 trunk 59122) [x86_64-darwin16]
```

```ruby
enum = Object.new.to_enum
class << enum
  def each
    yield
    yield nil
    yield 0
    yield 1
    yield 0, :LABEL
    yield [0, :LABEL]
    yield 1, :LABEL
    yield 1, :LABEL
    yield 1, :DIFFERENT
  end
end

p enum.uniq
```

Before
---

```ruby
[nil, 0, 1, [0, :LABEL]]
```

Is this intentional?

After this PR
---

```ruby
[nil, 0, 1, [0, :LABEL], [1, :LABEL], [1, :DIFFERENT]]
```