### PR TITLE
Fix useless operator warnings

### DIFF
--- a/ext/rubyvm/lib/forwardable/impl.rb
+++ b/ext/rubyvm/lib/forwardable/impl.rb
@@ -3,7 +3,7 @@ module Forwardable
   FILTER_EXCEPTION = ""
 
   def self._valid_method?(method)
-    iseq = RubyVM::InstructionSequence.compile("().#{method}", nil, nil, 0, false)
+    iseq = RubyVM::InstructionSequence.compile("_=().#{method}", nil, nil, 0, false)
   rescue SyntaxError
     false
   else

--- a/lib/forwardable/impl.rb
+++ b/lib/forwardable/impl.rb
@@ -10,7 +10,7 @@ module Forwardable
 
   def self._valid_method?(method)
     catch {|tag|
-      eval("BEGIN{throw tag}; ().#{method}", binding, __FILE__, __LINE__)
+      eval("BEGIN{throw tag}; _=().#{method}", binding, __FILE__, __LINE__)
     }
   rescue SyntaxError
     false


### PR DESCRIPTION
`Forwardable._valid_method?` warns about useless operator when it is received an operator such as `*` and `+`.

```bash
$ RUBYOPT='-w' ruby -rforwardable -e 'Forwardable._valid_method?(:*)'
<compiled>: warning: possibly useless use of * in void context
```

This behavior is problematic when a delegator is defined for an operator.
For example:

```ruby
require 'forwardable'

class A
  extend Forwardable

  def s
    's'
  end

  def_delegator :s, :* # <compiled>: warning: possibly useless use of * in void context
end

p(A.new * 10) # => "ssssssssss"
```