### PR TITLE
string.c: add String#delete_suffix and String#delete_suffix! to remove trailing suffix

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -92,6 +92,8 @@ with all sufficient information, see the ChangeLog file or Redmine
     instead of raising a TypeError. [Bug #13312]
   * String#delete_prefix is added to remove prefix [Feature #12694]
   * String#delete_prefix! is added to remove prefix destructively [Feature #12694]
+  * String#delete_suffix is added to remove suffix [Feature #13665]
+  * String#delete_suffix! is added to remove suffix destructively [Feature #13665]
 
 * Thread
 


### PR DESCRIPTION
Fix https://bugs.ruby-lang.org/issues/13665