### PR TITLE
Updated documentation

### DIFF
--- a/lib/delegate.rb
+++ b/lib/delegate.rb
@@ -326,10 +326,6 @@ class SimpleDelegator < Delegator
   #
   # Changes the delegate object to _obj_.
   #
-  # It's important to note that this does *not* cause SimpleDelegator's methods
-  # to change.  Because of this, you probably only want to change delegation
-  # to objects of the same type as the original delegate.
-  #
   # Here's an example of changing the delegation object.
   #
   #   names = SimpleDelegator.new(%w{James Edward Gray II})


### PR DESCRIPTION
As far as I can tell, this is not true:

```
[14] pry(main)> require 'delegate'                                                                                                                                                           
=> false                                       
[15] pry(main)> names = SimpleDelegator.new([1,2,3])                                          
=> [1, 2, 3]                                   
[16] pry(main)> names.first                    
=> 1                                           
[17] pry(main)> class C                        
[17] pry(main)*   def foo                      
[17] pry(main)*     :foo                       
[17] pry(main)*   end                          
[17] pry(main)* end                            
=> :foo                                        
[18] pry(main)> names.__setobj__(C.new)        
=> #<C:0x00000004a97b18>                       
[19] pry(main)> names.foo                      
=> :foo                                        
[20] pry(main)> names.first                    
NoMethodError: undefined method `first' for #<C:0x00000004a97b18>                             
from /home/tim/.rvm/rubies/ruby-2.3.0/lib/ruby/2.3.0/delegate.rb:87:in `method_missing'       
[21] pry(main)>                                
```