### PR TITLE
[DOC] Improve documentation of Kernel#Array

### DIFF
--- a/object.c
+++ b/object.c
@@ -3253,8 +3253,14 @@ rb_Array(VALUE val)
  *  Returns +arg+ as an Array.
  *
  *  First tries to call <code>to_ary</code> on +arg+, then <code>to_a</code>.
+ *  If +arg+ does not respond to <code>to_ary</code> or <code>to_a</code>,
+ *  returns an Array of length 1 containing +arg+.
  *
- *     Array(1..5)   #=> [1, 2, 3, 4, 5]
+ *     Array(["a", "b"])  #=> ["a", "b"]
+ *     Array(1..5)        #=> [1, 2, 3, 4, 5]
+ *     Array(key: :value) #=> [[:key, :value]]
+ *     Array(nil)         #=> []
+ *     Array(1)           #=> [1]
  */
 
 static VALUE

--- a/object.c
+++ b/object.c
@@ -3256,6 +3256,9 @@ rb_Array(VALUE val)
  *  If +arg+ does not respond to <code>to_ary</code> or <code>to_a</code>,
  *  returns an Array of length 1 containing +arg+.
  *
+ *  If <code>to_ary</code> or <code>to_a</code> returns something other than
+ *  an Array, raises a <code>TypeError</code>.
+ *
  *     Array(["a", "b"])  #=> ["a", "b"]
  *     Array(1..5)        #=> [1, 2, 3, 4, 5]
  *     Array(key: :value) #=> [[:key, :value]]


### PR DESCRIPTION
Array(arg) does more than just call to_ary or to_a on the argument. It also falls back to returning [arg] if neither method is available. This patch extends the description and adds a few examples of how it handles common types of arguments, including an integer (which does not implement to_ary or to_a).