### PR TITLE
Fix DecimalInteger converting to octal bug

### DIFF
--- a/lib/optparse.rb
+++ b/lib/optparse.rb
@@ -1865,7 +1865,7 @@ XXX
   DecimalInteger = /\A[-+]?#{decimal}\z/io
   accept(DecimalInteger, DecimalInteger) {|s,|
     begin
-      Integer(s)
+      Integer(s, 10)
     rescue ArgumentError
       raise OptionParser::InvalidArgument, s
     end if s


### PR DESCRIPTION
This bug has been reported redmine: https://bugs.ruby-lang.org/issues/13722

Previously if the input started with a '0' then it will be converted as octal even though it has been specified as a decimal. This commit forces the number to be interpreted as a decimal