### PR TITLE
cparser.rb: Adding require to examples

### DIFF
--- a/ext/fiddle/lib/fiddle/cparser.rb
+++ b/ext/fiddle/lib/fiddle/cparser.rb
@@ -21,6 +21,7 @@ module Fiddle
     # Parses a C struct's members
     #
     # Example:
+    #   require 'fiddle/import'
     #
     #   include Fiddle::CParser
     #     #=> Object
@@ -66,6 +67,7 @@ module Fiddle
     # be looked up.
     #
     # Example:
+    #   require 'fiddle/import'
     #
     #   include Fiddle::CParser
     #     #=> Object
@@ -102,6 +104,7 @@ module Fiddle
     # value will be the C type to be looked up.
     #
     # Example:
+    #   require 'fiddle/import'
     #
     #   include Fiddle::CParser
     #     #=> Object


### PR DESCRIPTION
Adding require 'fiddle/import' in all Fiddle::CParser usage examples.

This is just a detail, I think it would help to have the require in all examples so people don't spend time wondering where is the Fiddle::CParser defined.

Cheers,