### PR TITLE
Fix memoization in logger

### DIFF
--- a/lib/logger.rb
+++ b/lib/logger.rb
@@ -457,7 +457,9 @@ class Logger
     if @logdev.nil? or severity < @level
       return true
     end
-    progname ||= @progname
+    if progname.nil?
+      progname = @progname
+    end
     if message.nil?
       if block_given?
         message = yield

--- a/test/logger/test_logger.rb
+++ b/test/logger/test_logger.rb
@@ -235,6 +235,10 @@ class TestLogger < Test::Unit::TestCase
     log = log_add(logger, WARN, nil, "progname?")
     assert_equal("progname?\n", log.msg)
     assert_equal("my_progname", log.progname)
+    #
+    logger = Logger.new(nil)
+    log = log_add(logger, INFO, nil, false)
+    assert_equal("false\n", log.msg)
   end
 
   def test_level_log


### PR DESCRIPTION
Because progname was memoized with `||=` a logger call that involved
outputting `false` would be `nil`. Example code:

```ruby
  logger = Logger.new(STDOUT)
  logger.info(false)  # => nil
```

Perform an explicit `nil` check instead of `||=` so that `false` will be output.