### PR TITLE
Improve String#prepend performance if only one argument is given

### DIFF
--- a/string.c
+++ b/string.c
@@ -3077,7 +3077,10 @@ rb_str_prepend_multi(int argc, VALUE *argv, VALUE str)
 {
     str_modifiable(str);
 
-    if (argc > 0) {
+    if (argc == 1) {
+	rb_str_update(str, 0L, 0L, argv[0]);
+    }
+    else if (argc > 1) {
 	int i;
 	VALUE arg_str = rb_str_tmp_new(0);
 	rb_enc_copy(arg_str, str);


### PR DESCRIPTION
This is very similar with https://github.com/ruby/ruby/pull/1634
If only one argument is given, this will prepend the string without
generating temporary object.

```
String#prepend -> 47.5 % up
```

### Before
```
      String#prepend      1.517M (± 1.8%) i/s -      7.614M in   5.019819s
```

### After
```
      String#prepend      2.236M (± 3.4%) i/s -     11.234M in   5.029716s
```

### Test code
```
require 'benchmark/ips'

Benchmark.ips do |x|
  x.report "String#prepend" do |loop|
    loop.times { "!".prepend("hello") }
  end
end
```

https://bugs.ruby-lang.org/issues/13773