### PR TITLE
Made Hash#select and Hash#reject return an Array instead of a Hash.

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -1294,39 +1294,6 @@ reject_i(VALUE key, VALUE value, VALUE result)
 }
 
 /*
- *  call-seq:
- *     hsh.reject {|key, value| block}   -> a_hash
- *     hsh.reject                        -> an_enumerator
- *
- *  Returns a new hash consisting of entries for which the block returns false.
- *
- *  If no block is given, an enumerator is returned instead.
- *
- *     h = { "a" => 100, "b" => 200, "c" => 300 }
- *     h.reject {|k,v| k < "b"}  #=> {"b" => 200, "c" => 300}
- *     h.reject {|k,v| v > 100}  #=> {"a" => 100}
- */
-
-VALUE
-rb_hash_reject(VALUE hash)
-{
-    VALUE result;
-
-    RETURN_SIZED_ENUMERATOR(hash, 0, 0, hash_enum_size);
-    if (RTEST(ruby_verbose)) {
-	VALUE klass;
-	if (HAS_EXTRA_STATES(hash, klass)) {
-	    rb_warn("extra states are no longer copied: %+"PRIsVALUE, hash);
-	}
-    }
-    result = rb_hash_new();
-    if (!RHASH_EMPTY_P(hash)) {
-	rb_hash_foreach(hash, reject_i, result);
-    }
-    return result;
-}
-
-/*
  * call-seq:
  *   hsh.values_at(key, ...)   -> array
  *
@@ -1384,33 +1351,6 @@ select_i(VALUE key, VALUE value, VALUE result)
 	rb_hash_aset(result, key, value);
     }
     return ST_CONTINUE;
-}
-
-/*
- *  call-seq:
- *     hsh.select {|key, value| block}   -> a_hash
- *     hsh.select                        -> an_enumerator
- *
- *  Returns a new hash consisting of entries for which the block returns true.
- *
- *  If no block is given, an enumerator is returned instead.
- *
- *     h = { "a" => 100, "b" => 200, "c" => 300 }
- *     h.select {|k,v| k > "a"}  #=> {"b" => 200, "c" => 300}
- *     h.select {|k,v| v < 200}  #=> {"a" => 100}
- */
-
-VALUE
-rb_hash_select(VALUE hash)
-{
-    VALUE result;
-
-    RETURN_SIZED_ENUMERATOR(hash, 0, 0, hash_enum_size);
-    result = rb_hash_new();
-    if (!RHASH_EMPTY_P(hash)) {
-	rb_hash_foreach(hash, select_i, result);
-    }
-    return result;
 }
 
 static int
@@ -4583,9 +4523,7 @@ Init_Hash(void)
     rb_define_method(rb_cHash, "delete", rb_hash_delete_m, 1);
     rb_define_method(rb_cHash, "delete_if", rb_hash_delete_if, 0);
     rb_define_method(rb_cHash, "keep_if", rb_hash_keep_if, 0);
-    rb_define_method(rb_cHash, "select", rb_hash_select, 0);
     rb_define_method(rb_cHash, "select!", rb_hash_select_bang, 0);
-    rb_define_method(rb_cHash, "reject", rb_hash_reject, 0);
     rb_define_method(rb_cHash, "reject!", rb_hash_reject_bang, 0);
     rb_define_method(rb_cHash, "clear", rb_hash_clear, 0);
     rb_define_method(rb_cHash, "invert", rb_hash_invert, 0);

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -169,7 +169,7 @@ class Gem::Specification < Gem::BasicSpecification
   end
 
   @@attributes = @@default_value.keys.sort_by { |s| s.to_s }
-  @@array_attributes = @@default_value.reject { |k,v| v != [] }.keys
+  @@array_attributes = @@default_value.reject { |k,v| v != [] }.to_h.keys
   @@nil_attributes, @@non_nil_attributes = @@default_value.keys.partition { |k|
     @@default_value[k].nil?
   }

--- a/lib/uri/generic.rb
+++ b/lib/uri/generic.rb
@@ -1493,7 +1493,7 @@ module URI
         # HTTP_PROXY conflicts with *_proxy for proxy settings and
         # HTTP_* for header information in CGI.
         # So it should be careful to use it.
-        pairs = env.reject {|k, v| /\Ahttp_proxy\z/i !~ k }
+        pairs = env.reject {|k, v| /\Ahttp_proxy\z/i !~ k }.to_h
         case pairs.length
         when 0 # no proxy setting anyway.
           proxy_uri = nil

--- a/spec/rubyspec/core/encoding/names_spec.rb
+++ b/spec/rubyspec/core/encoding/names_spec.rb
@@ -28,7 +28,7 @@ with_feature :encoding do
     it "includes any aliases the encoding has" do
       Encoding.name_list.each do |name|
         e = Encoding.find(name) or next
-        aliases = Encoding.aliases.select{|a,n| n == name}.keys
+        aliases = Encoding.aliases.select{|a,n| n == name}.to_h.keys
         names = e.names
         aliases.each {|a| names.include?(a).should be_true}
       end

--- a/spec/rubyspec/core/hash/reject_spec.rb
+++ b/spec/rubyspec/core/hash/reject_spec.rb
@@ -4,37 +4,37 @@ require File.expand_path('../shared/iteration', __FILE__)
 require File.expand_path('../../enumerable/shared/enumeratorized', __FILE__)
 
 describe "Hash#reject" do
-  it "returns a new hash removing keys for which the block yields true" do
+  it "returns a new Array removing keys for which the block yields true" do
     h = { 1=>false, 2=>true, 3=>false, 4=>true }
-    h.reject { |k,v| v }.keys.sort.should == [1,3]
+    h.reject { |k,v| v }.to_h.keys.sort.should == [1,3]
   end
 
-  it "is equivalent to hsh.dup.delete_if" do
+  it "returns an Array whose to_h is equivalent to hsh.dup.delete_if" do
     h = { a: 'a', b: 'b', c: 'd' }
-    h.reject { |k,v| k == 'd' }.should == (h.dup.delete_if { |k, v| k == 'd' })
+    h.reject { |k,v| k == 'd' }.to_h.should == (h.dup.delete_if { |k, v| k == 'd' })
 
     all_args_reject = []
     all_args_delete_if = []
     h = { 1 => 2, 3 => 4 }
-    h.reject { |*args| all_args_reject << args }
+    h.reject { |args| all_args_reject << args }
     h.delete_if { |*args| all_args_delete_if << args }
     all_args_reject.should == all_args_delete_if
 
     h = { 1 => 2 }
     # dup doesn't copy singleton methods
-    def h.to_a() end
-    h.reject { false }.to_a.should == [[1, 2]]
+    def h.to_h() end
+    h.reject { false }.to_h.should == {1=>2}
   end
 
   context "with extra state" do
-    it "returns Hash instance for subclasses" do
-      HashSpecs::MyHash[1 => 2, 3 => 4].reject { false }.should be_kind_of(Hash)
-      HashSpecs::MyHash[1 => 2, 3 => 4].reject { true }.should be_kind_of(Hash)
+    it "returns Array instance for subclasses" do
+      HashSpecs::MyHash[1 => 2, 3 => 4].reject { false }.should be_kind_of(Array)
+      HashSpecs::MyHash[1 => 2, 3 => 4].reject { true }.should be_kind_of(Array)
     end
 
     it "does not taint the resulting hash" do
       h = { a: 1 }.taint
-      h.reject {false}.tainted?.should == false
+      h.reject {false}.to_h.tainted?.should == false
     end
   end
 
@@ -43,7 +43,7 @@ describe "Hash#reject" do
 
     reject_pairs = []
     reject_bang_pairs = []
-    h.dup.reject { |*pair| reject_pairs << pair }
+    h.dup.reject { |pair| reject_pairs << pair }
     h.reject! { |*pair| reject_bang_pairs << pair }
 
     reject_pairs.should == reject_bang_pairs

--- a/spec/rubyspec/core/hash/select_spec.rb
+++ b/spec/rubyspec/core/hash/select_spec.rb
@@ -11,7 +11,7 @@ describe "Hash#select" do
 
   it "yields two arguments: key and value" do
     all_args = []
-    { 1 => 2, 3 => 4 }.select { |*args| all_args << args }
+    { 1 => 2, 3 => 4 }.select { |args| all_args << args }
     all_args.sort.should == [[1, 2], [3, 4]]
   end
 

--- a/spec/rubyspec/core/hash/select_spec.rb
+++ b/spec/rubyspec/core/hash/select_spec.rb
@@ -15,9 +15,9 @@ describe "Hash#select" do
     all_args.sort.should == [[1, 2], [3, 4]]
   end
 
-  it "returns a Hash of entries for which block is true" do
+  it "returns an Array of entries for which block is true" do
     a_pairs = { 'a' => 9, 'c' => 4, 'b' => 5, 'd' => 2 }.select { |k,v| v % 2 == 0 }
-    a_pairs.should be_an_instance_of(Hash)
+    a_pairs.should be_an_instance_of(Array)
     a_pairs.sort.should == [['c', 4], ['d', 2]]
   end
 

--- a/template/verconf.h.tmpl
+++ b/template/verconf.h.tmpl
@@ -55,7 +55,7 @@
 % _erbout.gsub!(/^(#define\s+(\S+)\s+)(.*)/) {
 %   pre, name, repl = $1, $2, $3
 %   pat = %["#{name}"]
-%   c = C.merge(R.reject {|key, value| key == name or value.include?(pat)})
+%   c = C.merge(R.reject {|key, value| key == name or value.include?(pat)}.to_h)
 %   rbconfig.expand(repl, c)
 %   repl.gsub!(/^""(?!$)|(.)""$/, '\1')
 %   repl.sub!(exec_prefix_pat, 'RUBY_EXEC_PREFIX"')

--- a/test/psych/test_yamldbm.rb
+++ b/test/psych/test_yamldbm.rb
@@ -156,9 +156,9 @@ module Psych
       @yamldbm['a'] = 'b'
       @yamldbm['c'] = 'd'
       @yamldbm['e'] = 'f'
-      assert_equal({'c'=>'d','e'=>'f'}, @yamldbm.reject {|k,v| k == 'a'})
-      assert_equal({'a'=>'b','e'=>'f'}, @yamldbm.reject {|k,v| v == 'd'})
-      assert_equal({'a'=>'b','c'=>'d','e'=>'f'}, @yamldbm.reject {false})
+      assert_equal({'c'=>'d','e'=>'f'}, @yamldbm.reject {|k,v| k == 'a'}.to_h)
+      assert_equal({'a'=>'b','e'=>'f'}, @yamldbm.reject {|k,v| v == 'd'}.to_h)
+      assert_equal({'a'=>'b','c'=>'d','e'=>'f'}, @yamldbm.reject {false}.to_h)
     end
 
     def test_values

--- a/test/rss/test_setup_maker_atom_entry.rb
+++ b/test/rss/test_setup_maker_atom_entry.rb
@@ -139,7 +139,7 @@ module RSS
           :term => category.term,
           :scheme => category.scheme,
           :label => category.label,
-        }.reject {|key, value| value.nil?}
+        }.reject {|key, value| value.nil?}.to_h
       end
       assert_equal(categories, new_categories)
 

--- a/test/ruby/test_hash.rb
+++ b/test/ruby/test_hash.rb
@@ -658,7 +658,7 @@ class TestHash < Test::Unit::TestCase
   end
 
   def test_reject
-    assert_equal({3=>4,5=>6}, @cls[1=>2,3=>4,5=>6].reject {|k, v| k + v < 7 })
+    assert_equal({3=>4,5=>6}, @cls[1=>2,3=>4,5=>6].reject {|k, v| k + v < 7 }.to_h)
 
     base = @cls[ 1 => 'one', 2 => false, true => 'true', 'cat' => 99 ]
     h1   = @cls[ 1 => 'one', 2 => false, true => 'true' ]
@@ -965,7 +965,7 @@ class TestHash < Test::Unit::TestCase
   end
 
   def test_select
-    assert_equal({3=>4,5=>6}, @cls[1=>2,3=>4,5=>6].select {|k, v| k + v >= 7 })
+    assert_equal({3=>4,5=>6}, @cls[1=>2,3=>4,5=>6].select {|k, v| k + v >= 7 }.to_h)
 
     base = @cls[ 1 => 'one', '2' => false, true => 'true', 'cat' => 99 ]
     h1   = @cls[ '2' => false, 'cat' => 99 ]


### PR DESCRIPTION
This references https://bugs.ruby-lang.org/issues/13795

Essentially, Hash#select and Hash#reject are currently inconsistent with the behavior of other Hash and Enumerable methods, returning Hashes instead of Arrays.