### PR TITLE
Fixed bug: Using 'open-uri' with 'tempfile' causes an exception.

### DIFF
--- a/lib/open-uri.rb
+++ b/lib/open-uri.rb
@@ -27,7 +27,7 @@ module Kernel
   # We can accept URIs and strings that begin with http://, https:// and
   # ftp://. In these cases, the opened file object is extended by OpenURI::Meta.
   def open(name, *rest, &block) # :doc:
-    if name.respond_to?(:open)
+    if name.respond_to?(:open) && !name.method(:open).parameters.empty?
       name.open(*rest, &block)
     elsif name.respond_to?(:to_str) &&
           %r{\A[A-Za-z][A-Za-z0-9+\-\.]*://} =~ name &&

--- a/test/open-uri/test_open-uri.rb
+++ b/test/open-uri/test_open-uri.rb
@@ -3,6 +3,7 @@ require 'test/unit'
 require 'open-uri'
 require 'webrick'
 require 'webrick/httpproxy'
+require 'tempfile'
 begin
   require 'zlib'
 rescue LoadError
@@ -113,6 +114,13 @@ class TestOpenURI < Test::Unit::TestCase
 
   def test_open_too_many_arg
     assert_raise(ArgumentError) { open("http://192.0.2.1/tma", "r", 0666, :extra) {} }
+  end
+
+  def test_tempfile_rest_parameter
+    assert_nothing_raised {
+      temp_file = Tempfile.new
+      open(temp_file, 'a')
+    }
   end
 
   def test_read_timeout

--- a/test/open-uri/test_open-uri.rb
+++ b/test/open-uri/test_open-uri.rb
@@ -117,11 +117,10 @@ class TestOpenURI < Test::Unit::TestCase
   end
 
   def test_tempfile_rest_parameter
-    assert_nothing_raised {
-      temp_file = Tempfile.new
-      open(temp_file, 'a')
-      temp_file.close
-    }
+    temp_file = Tempfile.new
+    assert_nothing_raised { open(temp_file, 'a') }
+  ensure
+    temp_file.close
   end
 
   def test_read_timeout

--- a/test/open-uri/test_open-uri.rb
+++ b/test/open-uri/test_open-uri.rb
@@ -120,6 +120,7 @@ class TestOpenURI < Test::Unit::TestCase
     assert_nothing_raised {
       temp_file = Tempfile.new
       open(temp_file, 'a')
+      temp_file.close
     }
   end
 

--- a/test/open-uri/test_open-uri.rb
+++ b/test/open-uri/test_open-uri.rb
@@ -120,7 +120,7 @@ class TestOpenURI < Test::Unit::TestCase
     temp_file = Tempfile.new
     assert_nothing_raised { open(temp_file, 'a') }
   ensure
-    temp_file.close
+    temp_file.close!
   end
 
   def test_read_timeout


### PR DESCRIPTION
Hi there,

try this in your current ruby env:

```ruby
require 'tempfile'
require 'open-uri'

temp_file = Tempfile.new
open(temp_file, 'a')
```

Get this:
```
/Users/~/.rvm/rubies/ruby-2.4.1/lib/ruby/2.4.0/tempfile.rb:142:in `open': wrong number of arguments (given 1, expected 0) (ArgumentError)
  from /Users/~/.rvm/rubies/ruby-2.4.1/lib/ruby/2.4.0/open-uri.rb:31:in `open'
  from debug.rb:5:in `<main>'
```

Greetings.