### PR TITLE
In regexp doc, two backslashes match one literally

### DIFF
--- a/doc/regexp.rdoc
+++ b/doc/regexp.rdoc
@@ -63,9 +63,10 @@ The following are <i>metacharacters</i> <tt>(</tt>, <tt>)</tt>,
 <tt>[</tt>, <tt>]</tt>, <tt>{</tt>, <tt>}</tt>, <tt>.</tt>, <tt>?</tt>,
 <tt>+</tt>, <tt>*</tt>. They have a specific meaning when appearing in a
 pattern. To match them literally they must be backslash-escaped. To match
-a backslash literally backslash-escape that: <tt>\\\\\\</tt>.
+a backslash literally, backslash-escape it: <tt>\\\\</tt>.
 
     /1 \+ 2 = 3\?/.match('Does 1 + 2 = 3?') #=> #<MatchData "1 + 2 = 3?">
+    /a\\\\b/.match('a\\\\b')                    #=> #<MatchData "a\\b">
 
 Patterns behave like double-quoted strings so can contain the same
 backslash escapes.


### PR DESCRIPTION
In the "Metacharacters and Escapes" section of regexp.rdoc, it said that to match a backslash literally, it must be backslash-escaped, but the [rendered HTML](http://ruby-doc.org/core-2.4.1/doc/regexp_rdoc.html) showed three backslashes (`\\\`). There should only be two backslashes (`\\`).

The backslashes in the example had to be escaped, so to be clear, the example code is:

```
/a\\b/.match('a\\b')
```

Note: These changes render correctly using RDoc 5.0.0.  They do *not* render correctly using RDoc 4.0.0 which erroneously renders the two backslashes in the paragraph as `<tt>\</tt>`.