### PR TITLE
Fixed bug: Using 'open-uri' with 'tempfile' causes an exception.

### DIFF
--- a/lib/open-uri.rb
+++ b/lib/open-uri.rb
@@ -27,18 +27,7 @@ module Kernel
   # We can accept URIs and strings that begin with http://, https:// and
   # ftp://. In these cases, the opened file object is extended by OpenURI::Meta.
   def open(name, *rest, &block) # :doc:
-    if name.respond_to?(:to_io)
-      io = name.to_io.dup
-      if block
-        begin
-          yield io
-        ensure
-          io.close
-        end
-      else
-        io
-      end
-    elsif name.respond_to?(:open)
+    if name.respond_to?(:open) && !name.method(:open).parameters.empty?
       name.open(*rest, &block)
     elsif name.respond_to?(:to_str) &&
           %r{\A[A-Za-z][A-Za-z0-9+\-\.]*://} =~ name &&

--- a/lib/open-uri.rb
+++ b/lib/open-uri.rb
@@ -27,7 +27,18 @@ module Kernel
   # We can accept URIs and strings that begin with http://, https:// and
   # ftp://. In these cases, the opened file object is extended by OpenURI::Meta.
   def open(name, *rest, &block) # :doc:
-    if name.respond_to?(:open)
+    if name.respond_to?(:to_io)
+      io = name.to_io.dup
+      if block
+        begin
+          yield io
+        ensure
+          io.close
+        end
+      else
+        io
+      end
+    elsif name.respond_to?(:open)
       name.open(*rest, &block)
     elsif name.respond_to?(:to_str) &&
           %r{\A[A-Za-z][A-Za-z0-9+\-\.]*://} =~ name &&

--- a/test/open-uri/test_open-uri.rb
+++ b/test/open-uri/test_open-uri.rb
@@ -3,6 +3,7 @@ require 'test/unit'
 require 'open-uri'
 require 'webrick'
 require 'webrick/httpproxy'
+require 'tempfile'
 begin
   require 'zlib'
 rescue LoadError
@@ -113,6 +114,13 @@ class TestOpenURI < Test::Unit::TestCase
 
   def test_open_too_many_arg
     assert_raise(ArgumentError) { open("http://192.0.2.1/tma", "r", 0666, :extra) {} }
+  end
+
+  def test_tempfile_rest_parameter
+    temp_file = Tempfile.new
+    assert_nothing_raised { open(temp_file, 'a') }
+  ensure
+    temp_file.close!
   end
 
   def test_read_timeout


### PR DESCRIPTION
This is the successor of #1675 with the feedback of @nobu applied.

Ticket: https://bugs.ruby-lang.org/issues/13835