### PR TITLE
optimize Set#include? not to use Hash#[]

### DIFF
--- a/lib/set.rb
+++ b/lib/set.rb
@@ -81,7 +81,7 @@ class Set
   # If a block is given, the elements of enum are preprocessed by the
   # given block.
   def initialize(enum = nil, &block) # :yields: o
-    @hash ||= Hash.new(false)
+    @hash = {}
 
     enum.nil? and return
 
@@ -230,7 +230,7 @@ class Set
   #
   # See also Enumerable#include?
   def include?(o)
-    @hash[o]
+    @hash.include?(o)
   end
   alias member? include?
 


### PR DESCRIPTION
`Hash#include?` is 10% faster than `Hash#[]` because of the default value requires some checks. This is a micro optimization but somewhat useful because `Set#include?` is the most important method in `Set`

---

benchmark program:

```ruby
require 'benchmark'

hash = Hash.new(false)

Benchmark.bm(10) do |x|
  x.report('include?') do
    10000000.times { hash[:foo] }
  end

  x.report('aref') do
    10000000.times { hash.include?(:foo) }
  end
end
```

results (Ruby v2.4.1):

```
                 user     system      total        real
include?     0.640000   0.010000   0.650000 (  0.650482)
aref         0.760000   0.010000   0.770000 (  0.856820)
```

