### PR TITLE
lib/net/http.rb: include query parameters in Net::HTTP.post

### DIFF
--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -503,7 +503,7 @@ module Net   #:nodoc:
     def HTTP.post(url, data, header = nil)
       start(url.hostname, url.port,
             :use_ssl => url.scheme == 'https' ) {|http|
-        http.post(url.path, data, header)
+        http.post(url, data, header)
       }
     end
 

--- a/test/net/http/test_http.rb
+++ b/test/net/http/test_http.rb
@@ -431,12 +431,13 @@ module TestNetHTTP_version_1_1_methods
   end
 
   def test_s_post
-    url = "http://#{config('host')}:#{config('port')}/"
+    url = "http://#{config('host')}:#{config('port')}/?q=a"
     res = Net::HTTP.post(
               URI.parse(url),
               "a=x")
     assert_equal "application/x-www-form-urlencoded", res["Content-Type"]
     assert_equal "a=x", res.body
+    assert_equal url, res["X-request-uri"]
 
     res = Net::HTTP.post(
               URI.parse(url),


### PR DESCRIPTION
This fixes a head scratcher for me where calling `Net::HTTP.post` would silently throw away query parameters in the URL I was passing it