### PR TITLE
Fix Bug#13833 String#scanf("%a") incorrectly requires a sign on the (binary) exponent

### DIFF
--- a/lib/scanf.rb
+++ b/lib/scanf.rb
@@ -295,7 +295,7 @@ module Scanf
 
     def extract_float(s)
       return nil unless s &&! skip
-      if /\A(?<sign>[-+]?)0[xX](?<frac>\.\h+|\h+(?:\.\h*)?)[pP](?<exp>[-+]\d+)/ =~ s
+      if /\A(?<sign>[-+]?)0[xX](?<frac>\.\h+|\h+(?:\.\h*)?)[pP](?<exp>[-+]?\d+)/ =~ s
         f1, f2 = frac.split('.')
         f = f1.hex
         if f2
@@ -411,11 +411,11 @@ module Scanf
 
           # %f
         when /%\*?[aefgAEFG]/
-          [ '([-+]?(?:0[xX](?:\.\h+|\h+(?:\.\h*)?)[pP][-+]\d+|\d+(?![\d.])|\d*\.\d*(?:[eE][-+]?\d+)?))', :extract_float ]
+          [ '([-+]?(?:0[xX](?:\.\h+|\h+(?:\.\h*)?)[pP][-+]?\d+|\d+(?![\d.])|\d*\.\d*(?:[eE][-+]?\d+)?))', :extract_float ]
 
           # %5f
         when /%\*?(\d+)[aefgAEFG]/
-          [ '(?=[-+]?(?:0[xX](?:\.\h+|\h+(?:\.\h*)?)[pP][-+]\d+|\d+(?![\d.])|\d*\.\d*(?:[eE][-+]?\d+)?))' +
+          [ '(?=[-+]?(?:0[xX](?:\.\h+|\h+(?:\.\h*)?)[pP][-+]?\d+|\d+(?![\d.])|\d*\.\d*(?:[eE][-+]?\d+)?))' +
             "(\\S{1,#{$1}})", :extract_float ]
 
           # %5s

--- a/test/scanf/test_scanf.rb
+++ b/test/scanf/test_scanf.rb
@@ -258,6 +258,7 @@ module ScanfTests
       [ "%G", "+3.25e2", [325.0] ],
       [ "%f", "3.z", [3.0] ],
       [ "%a", "0X1P+10", [1024.0] ],
+      [ "%a", "0X1P10", [1024.0] ],
       [ "%A", "0x1.deadbeefp+99", [1.1851510441583988e+30] ],
 
 # Testing embedded matches including literal '[' behavior


### PR DESCRIPTION
### Issue

- String#scanf("%a") incorrectly requires a sign on the (binary) exponent.
https://bugs.ruby-lang.org/issues/13833

### Implementation

- When we use String#scanf("%a"), it doesn't require a sign on the (binary) exponent similar to `Float` class.

Before : 
```
>> "0x1p+9".scanf("%a")
=> [512.0]
>> "0x1p9".scanf("%a")
=> [0.0]  
```

After :
```
>> "0x1p+9".scanf("%a")
=> [512.0]
>> "0x1p9".scanf("%a")
=> [512.0]  
```