### PR TITLE
Fix compilation error with VMDEBUG=3

### DIFF
--- a/vm_dump.c
+++ b/vm_dump.c
@@ -289,7 +289,7 @@ vm_stack_dump_each(rb_thread_t *th, rb_control_frame_t *cfp)
 	}
     }
     else if (VM_FRAME_FINISHED_P(cfp)) {
-	if ((th)->stack + (th)->stack_size > (VALUE *)(cfp + 1)) {
+	if ((th)->ec.vm_stack + (th)->ec.vm_stack_size > (VALUE *)(cfp + 1)) {
 	    vm_stack_dump_each(th, cfp + 1);
 	}
 	else {


### PR DESCRIPTION
This fixed compilation error with VMDEBUG=3.

```
../ruby/vm_dump.c:292:12: error: no member named 'stack' in 'struct rb_thread_struct'
        if ((th)->stack + (th)->stack_size > (VALUE *)(cfp + 1)) {
            ~~~~  ^
../ruby/vm_dump.c:292:26: error: no member named 'stack_size' in 'struct rb_thread_struct'
        if ((th)->stack + (th)->stack_size > (VALUE *)(cfp + 1)) {
                          ~~~~  ^
2 errors generated.
make: *** [vm_dump.o] Error 1
```