### PR TITLE
Added support for TLS 1.3

### DIFF
--- a/ext/openssl/extconf.rb
+++ b/ext/openssl/extconf.rb
@@ -115,6 +115,7 @@ have_func("SSLv2_method")
 have_func("SSLv3_method")
 have_func("TLSv1_1_method")
 have_func("TLSv1_2_method")
+have_func("TLSv1_3_method")
 have_func("RAND_egd")
 engines = %w{builtin_engines openbsd_dev_crypto dynamic 4758cca aep atalla chil
              cswift nuron sureware ubsec padlock capi gmp gost cryptodev aesni}

--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -80,6 +80,9 @@ static const struct {
 #if !defined(OPENSSL_NO_TLS1_2) && !defined(OPENSSL_NO_TLS1_2_METHOD) && defined(HAVE_TLSV1_2_METHOD)
     OSSL_SSL_METHOD_ENTRY(TLSv1_2, TLS1_2_VERSION),
 #endif
+#if !defined(OPENSSL_NO_TLS1_2) && !defined(OPENSSL_NO_TLS1_2_METHOD) && !defined(HAVE_TLSV1_3_METHOD)
+    OSSL_SSL_METHOD_ENTRY(TLSv1_3, TLS1_3_VERSION),
+#endif
     OSSL_SSL_METHOD_ENTRY(SSLv23, 0),
 #undef OSSL_SSL_METHOD_ENTRY
 };
@@ -2699,6 +2702,9 @@ Init_ossl_ssl(void)
 #endif
 #if defined(SSL_OP_NO_TLSv1_2)
     ossl_ssl_def_const(OP_NO_TLSv1_2);
+#endif
+#if defined(SSL_OP_NO_TLSv1_3)
+    ossl_ssl_def_const(OP_NO_TLSv1_3);
 #endif
 #if defined(SSL_OP_NO_TICKET)
     ossl_ssl_def_const(OP_NO_TICKET);


### PR DESCRIPTION
My team (hackers.mu) have been working on a patch for tls 1.3 support in Ruby.
 
Currently this patch works for draft-18 of tls 1.3

Attached are 2 files that have been part of my test scenario:
rubytls13test.txt - can be run by ruby as a .rb - just specify the url and protocol. If it works, a tls 1.3 response will be received.
response.txt - sample results  that I received.

openssl version - 1.1.1 dev
ruby version - trunk 

We will keep working on the patch for draft 21, until tls 1.3 is finalised.

[response.txt](https://github.com/ruby/ruby/files/1267745/response.txt)
[rubytls13test.txt](https://github.com/ruby/ruby/files/1267751/rubytls13test.txt)
