### PR TITLE
Find.find -> Use Dir.children instead of Dir.entries

### DIFF
--- a/lib/find.rb
+++ b/lib/find.rb
@@ -55,14 +55,13 @@ module Find
           end
           if s.directory? then
             begin
-              fs = Dir.entries(file, encoding: enc)
+              fs = Dir.children(file, encoding: enc)
             rescue Errno::ENOENT, Errno::EACCES, Errno::ENOTDIR, Errno::ELOOP, Errno::ENAMETOOLONG
               raise unless ignore_error
               next
             end
             fs.sort!
             fs.reverse_each {|f|
-              next if f == "." or f == ".."
               f = File.join(file, f)
               ps.unshift f.untaint
             }


### PR DESCRIPTION
Dir.children is available since Feature #11302. Find.find can
use of the new list (having no '.' neither '..' entries), making
now superflous an if statement.

This change can improve the performance of Find.find when the path
has lots of entries (thousands?).

https://bugs.ruby-lang.org/issues/11302