### PR TITLE
Add MonitorMinx#mon_locked? and #mon_owned? to check states of objects

### DIFF
--- a/lib/monitor.rb
+++ b/lib/monitor.rb
@@ -204,6 +204,20 @@ module MonitorMixin
   end
 
   #
+  # Returns true if this monitor is locked by any thread
+  #
+  def mon_locked?
+    @mon_mutex.locked?
+  end
+
+  #
+  # Returns true if this monitor is locked by current thread.
+  #
+  def mon_owned?
+    @mon_mutex.locked? && @mon_owner == Thread.current
+  end
+
+  #
   # Enters exclusive section and executes the block.  Leaves the exclusive
   # section automatically when the block exits.  See example under
   # +MonitorMixin+.

--- a/test/monitor/test_monitor.rb
+++ b/test/monitor/test_monitor.rb
@@ -146,6 +146,35 @@ class TestMonitor < Test::Unit::TestCase
     assert_join_threads([th, th2])
   end
 
+  def test_mon_locked_and_owned
+    queue1 = Queue.new
+    queue2 = Queue.new
+    th = Thread.start {
+      @monitor.enter
+      queue1.enq(nil)
+      queue2.deq
+      @monitor.exit
+      queue1.enq(nil)
+    }
+    queue1.deq
+    assert(@monitor.mon_locked?)
+    assert(!@monitor.mon_owned?)
+
+    queue2.enq(nil)
+    queue1.deq
+    assert(!@monitor.mon_locked?)
+
+    @monitor.enter
+    assert @monitor.mon_locked?
+    assert @monitor.mon_owned?
+    @monitor.exit
+
+    @monitor.synchronize do
+      assert @monitor.mon_locked?
+      assert @monitor.mon_owned?
+    end
+  end
+
   def test_cond
     cond = @monitor.new_cond
 


### PR DESCRIPTION
`Mutex` has `#locked?` and `#owned?`, but `MonitorMixin` (and `Monitor`) doesn't have it.
These methods make easy to write code to unlock monitors only when it's needed, or to log states of objects.

```ruby
    def prepare
      @buffers = @ids.map{|id| storage.get(id) }
      @buffers.sort!
      @buffers.each do |buffer|
        buffer.try_mon_enter # buffer includes MonitorMixin
      end
    end

    def free
      @buffers.reverse.each do |buffer|
        buffer.mon_exit if buffer.mon_owned?
      end
    end

    log.info("inconsistent buffer state", locked: buffer.locked?, owned: buffer.owned?)
```
