### PR TITLE
Switch appveyor.yml to use 2.4

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ shallow_clone: true
 platform:
   - x64
 environment:
-  ruby_version: "23-%Platform%"
+  ruby_version: "24-%Platform%"
   zlib_version: "1.2.11"
   matrix:
     - vs: "120"


### PR DESCRIPTION
Switch Appveyor to use ruby 2.4 for initial ruby scripts