### PR TITLE
Update trick2013/yhara for Ruby 2.5

### DIFF
--- a/sample/trick2013/yhara/entry.rb
+++ b/sample/trick2013/yhara/entry.rb
@@ -2,7 +2,7 @@ def _(&b)$><<->(x){x ? (String===x ?x.upcase:
 (Class===x ? x : x.class).name[$a?0:($a=5)]):
 " "}[ begin b[];rescue Exception;$!;end ] end
 
-_ {                 return                  }
+_ {                  yield                  }
 _ {            method(:p).unbind            }
 _ {                eval "{ "                }
 _ {           Thread.current.join           }


### PR DESCRIPTION
Hello,

At the RubyKaigi nobu notified me that sample/trick2013/yhara is broken in ruby trunk.
With this patch, sample/trick2013/yhara/entry.rb works with ruby trunk too.