### PR TITLE
[DOC] Show rb_data_type_t definition

### DIFF
--- a/doc/extension.ja.rdoc
+++ b/doc/extension.ja.rdoc
@@ -711,6 +711,8 @@ Dataから派生しない場合には, 必ずrb_undef_alloc_func(klass)
 
 rb_data_type_tは次のように定義されています．
 
+  typedef struct rb_data_type_struct rb_data_type_t;
+
   struct rb_data_type_struct {
           const char *wrap_struct_name;
           struct {

--- a/doc/extension.rdoc
+++ b/doc/extension.rdoc
@@ -658,6 +658,8 @@ If it doesn't, you have to call rb_undef_alloc_func(klass).
 rb_data_type_t is defined like this.  Let's take a look at each
 member of the struct.
 
+  typedef struct rb_data_type_struct rb_data_type_t;
+
   struct rb_data_type_struct {
           const char *wrap_struct_name;
           struct {


### PR DESCRIPTION
> rb_data_type_t is defined like this. 

The snippet needs `typedef` declaration, because "this" is a definition of `rb_data_type_struct`, not `rb_data_type_t`.