### PR TITLE
Properly parse all allowed iTunes RSS explicit field values

### DIFF
--- a/lib/rss/utils.rb
+++ b/lib/rss/utils.rb
@@ -132,9 +132,9 @@ module RSS
           value
         else
           case value.to_s
-          when /\Ayes\z/i
+          when /\Aexplicit\z|\Ayes\z/i
             true
-          when /\Aclean\z/i
+          when /\Aclean\z|\Ano\z/i
             false
           else
             nil


### PR DESCRIPTION
Per the iTunes spec: https://help.apple.com/itc/podcasts_connect/#/itcb54353390
>If you specify `yes`, `explicit`, or `true`, indicating the presence of explicit content, the iTunes Store displays an Explicit parental advisory graphic for your podcast.

>If you specify `clean`, `no`, or `false`, indicating that none of your podcast episodes contain explicit language or adult content, the iTunes Store displays a Clean parental advisory graphic for your podcast.

Currently the parser only handles the values of `true` or `yes` for explicit and `false` or `clean` for clean.