### PR TITLE
Export symbols of shared variables in VM

### DIFF
--- a/vm_core.h
+++ b/vm_core.h
@@ -1570,9 +1570,14 @@ VALUE rb_catch_protect(VALUE t, rb_block_call_func *func, VALUE data, enum ruby_
 /* for thread */
 
 #if RUBY_VM_THREAD_MODEL == 2
+
+RUBY_SYMBOL_EXPORT_BEGIN
+
 extern rb_thread_t *ruby_current_thread;
 extern rb_vm_t *ruby_current_vm;
 extern rb_event_flag_t ruby_vm_event_flags;
+
+RUBY_SYMBOL_EXPORT_END
 
 #define GET_VM() ruby_current_vm
 #define GET_THREAD() ruby_current_thread

--- a/vm_insnhelper.h
+++ b/vm_insnhelper.h
@@ -12,7 +12,11 @@
 #ifndef RUBY_INSNHELPER_H
 #define RUBY_INSNHELPER_H
 
+RUBY_SYMBOL_EXPORT_BEGIN
+
 extern VALUE ruby_vm_const_missing_count;
+
+RUBY_SYMBOL_EXPORT_END
 
 #if VM_COLLECT_USAGE_DETAILS
 #define COLLECT_USAGE_INSN(insn)           vm_collect_usage_insn(insn)


### PR DESCRIPTION
All changes are for reducing changes required to introduce JIT compiler. This patch would reduce risk of its introduction and conflicts on rebase against upstream.

Unlike functions that can be inlined by header, those variables must be shared with JIT-ed code in the future.