### PR TITLE
driver.rb: add option to specify target with rbenv

### DIFF
--- a/benchmark/driver.rb
+++ b/benchmark/driver.rb
@@ -381,6 +381,11 @@ if __FILE__ == $0
          opt[:execs] << path
        }
     }
+    o.on('--rbenv [VERSIONS]', 'Specify benchmark targets with rbenv version (vX.X.X;vX.X.X;...)'){|v|
+      v.split(/;/).each{|version|
+        opt[:execs] << "#{version}::#{`RBENV_VERSION='#{version}' rbenv which ruby`.rstrip}"
+      }
+    }
     o.on('-d', '--directory [DIRECTORY]', "Benchmark suites directory"){|d|
       opt[:dir] = d
     }


### PR DESCRIPTION
## Usage
With this change, for following usage,

```
ruby ./benchmark/driver.rb -e "trunk::/Users/k0kubun/.rbenv/versions/trunk/bin/ruby;2.4.2::/Users/k0kubun/.rbenv/versions/2.4.2/bin/ruby" -p app_erb
```

we can simply write as:

```
ruby ./benchmark/driver.rb --rbenv "trunk;2.4.2" -p app_erb
```