### PR TITLE
Add missing `buf` parameter to `recv_nonblock` doc [ci skip]

### DIFF
--- a/ext/socket/lib/socket.rb
+++ b/ext/socket/lib/socket.rb
@@ -336,6 +336,7 @@ class BasicSocket < IO
   # === Parameters
   # * +maxlen+ - the number of bytes to receive from the socket
   # * +flags+ - zero or more of the +MSG_+ options
+  # * +buf+ - destination String buffer
   # * +options+ - keyword hash, supporting `exception: false`
   #
   # === Example


### PR DESCRIPTION
Ref: https://github.com/ruby/ruby/blob/a25a39f91841312f3f2bf7b11cf0e7e6b9dd309b/ext/socket/lib/socket.rb#L325