### PR TITLE
Invalid TracePoint#disable example (without block)

### DIFF
--- a/vm_trace.c
+++ b/vm_trace.c
@@ -1108,7 +1108,7 @@ tracepoint_enable_m(VALUE tpval)
  * Return false if trace was disabled.
  *
  *	trace.enabled?	#=> true
- *	trace.disable	#=> false (previous status)
+ *	trace.disable	#=> true (previous status)
  *	trace.enabled?	#=> false
  *	trace.disable	#=> false
  *


### PR DESCRIPTION
Invalid documentation. If _enabled?_ returns `true` than _disable_ also returns `true` the first time.