### PR TITLE
Fix example that trace method is called outside block [ci skip]

### DIFF
--- a/vm_trace.c
+++ b/vm_trace.c
@@ -1263,7 +1263,7 @@ rb_tracepoint_new(VALUE target_thval, rb_event_flag_t events, void (*func)(VALUE
  *      TracePoint.trace(:line) do |tp|
  *        $tp = tp
  *      end
- *      $tp.line #=> access from outside (RuntimeError)
+ *      $tp.lineno #=> access from outside (RuntimeError)
  *
  * Access from other threads is also forbidden.
  *


### PR DESCRIPTION
`TracePoint` doesn't have the `line` method.
Therefore, this example will raise `NoMethodError`.
But since it does not seem to be the intended error, use the existing `lineno` method instead.