### PR TITLE
CAA DNS RR

### DIFF
--- a/lib/resolv.rb
+++ b/lib/resolv.rb
@@ -2378,7 +2378,9 @@ class Resolv
           # Creates a new CAA for +flag+, +tag+ and +value+.
 
           def initialize(flag, tag, value)
-            @flag, @tag, @value = flag, tag, value
+            @flag = flag
+            @tag = tag
+            @value = value
           end
 
           def encode_rdata(msg) # :nodoc:


### PR DESCRIPTION
Introduce CAA RR DNS record on `Resolv`, defined in [RFC 6844](https://tools.ietf.org/html/rfc6844).

Changes on the way `Resource::decode_rdata` works because CAA needs to know the
overall RR length, which was previously swallowed.