### PR TITLE
TLS Fallback Signaling Cipher Suite Value

### DIFF
--- a/ext/openssl/lib/openssl/ssl.rb
+++ b/ext/openssl/lib/openssl/ssl.rb
@@ -117,9 +117,10 @@ YoaOffgTf5qxiwkjnlVZQc3whgnEt9FpVMvQ9eknyeGB5KHfayAc3+hUAvI3/Cr3
       # If an argument is given, #ssl_version= is called with the value. Note
       # that this form is deprecated. New applications should use #min_version=
       # and #max_version= as necessary.
-      def initialize(version = nil)
+      def initialize(version = nil, fallback_scsv: false)
         self.options |= OpenSSL::SSL::OP_ALL
         self.ssl_version = version if version
+        self.enable_fallback_scsv if fallback_scsv
       end
 
       ##

--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -1046,6 +1046,34 @@ ossl_sslctx_set_ciphers(VALUE self, VALUE v)
     return v;
 }
 
+/*
+ * call-seq:
+ *    ctx.enable_fallback_scsv() => nil
+ *
+ * Activate TLS_FALLBACK_SCSV for this context.
+ * See RFC 7507.
+ */
+static VALUE
+ossl_sslctx_enable_fallback_scsv(VALUE self)
+{
+#ifdef SSL_MODE_SEND_FALLBACK_SCSV
+    SSL_CTX *ctx;
+    long modes;
+
+    GetSSLCTX(self, ctx);
+    if(!ctx){
+        rb_warning("SSL_CTX is not initialized.");
+        return Qnil;
+    }
+
+    modes = SSL_CTX_get_mode(ctx);
+    modes |= SSL_MODE_SEND_FALLBACK_SCSV;
+    SSL_CTX_set_mode(ctx, modes);
+#endif
+
+    return Qnil;
+}
+
 #if !defined(OPENSSL_NO_EC)
 /*
  * call-seq:
@@ -2561,6 +2589,7 @@ Init_ossl_ssl(void)
     rb_define_method(cSSLContext, "ecdh_curves=", ossl_sslctx_set_ecdh_curves, 1);
     rb_define_method(cSSLContext, "security_level", ossl_sslctx_get_security_level, 0);
     rb_define_method(cSSLContext, "security_level=", ossl_sslctx_set_security_level, 1);
+    rb_define_method(cSSLContext, "enable_fallback_scsv", ossl_sslctx_enable_fallback_scsv, 0);
 
     rb_define_method(cSSLContext, "setup", ossl_sslctx_setup, 0);
     rb_define_alias(cSSLContext, "freeze", "setup");

--- a/test/openssl/utils.rb
+++ b/test/openssl/utils.rb
@@ -220,11 +220,15 @@ class OpenSSL::SSLTestCase < OpenSSL::TestCase
                 readable, = IO.select([ssls, stop_pipe_r])
                 break if readable.include? stop_pipe_r
                 ssl = ssls.accept
-              rescue OpenSSL::SSL::SSLError, IOError, Errno::EBADF, Errno::EINVAL,
+              rescue OpenSSL::SSL::SSLError => e
+                retry if ignore_listener_error
+                raise unless e.message =~ /inappropriate fallback/
+              rescue IOError, Errno::EBADF, Errno::EINVAL,
                      Errno::ECONNABORTED, Errno::ENOTSOCK, Errno::ECONNRESET
                 retry if ignore_listener_error
                 raise
               end
+              next unless ssl
 
               th = Thread.new do
                 begin


### PR DESCRIPTION
Support for fallback SCSV [RFC 7507](https://tools.ietf.org/html/rfc7507).

Expected behaviour is to refuse connection if the client signals a protocol with
the fallback flag but the server supports a better one (downgrade attack detection).