### PR TITLE
[DOC] Refinements on modules are allowed

### DIFF
--- a/doc/syntax/refinements.rdoc
+++ b/doc/syntax/refinements.rdoc
@@ -26,8 +26,7 @@ Here is a basic refinement:
   end
 
 First, a class +C+ is defined.  Next a refinement for +C+ is created using
-Module#refine.  Refinements only modify classes, not modules so the argument
-must be a class.
+Module#refine. Refinements can modify both classes and modules.
 
 Module#refine creates an anonymous module that contains the changes or
 refinements to the class (+C+ in the example).  +self+ in the refine block is


### PR DESCRIPTION
From https://bugs.ruby-lang.org/issues/12534 and https://github.com/ruby/ruby/commit/a463ab1f0536e24c72b700945203ef4685406f55

This change fixes the docs to reflect that refinements are now allowed on modules

