### PR TITLE
test-all class renames for parallel testing

### DIFF
--- a/test/-ext-/array/test_resize.rb
+++ b/test/-ext-/array/test_resize.rb
@@ -2,7 +2,7 @@
 require 'test/unit'
 require '-test-/array/resize'
 
-class TestArray < Test::Unit::TestCase
+class Test_Array < Test::Unit::TestCase
   class TestResize < Test::Unit::TestCase
     def test_expand
       feature = '[ruby-dev:42912]'

--- a/test/-ext-/bignum/test_big2str.rb
+++ b/test/-ext-/bignum/test_big2str.rb
@@ -2,7 +2,7 @@
 require 'test/unit'
 require "-test-/bignum"
 
-class TestBignum < Test::Unit::TestCase
+class Test_Bignum < Test::Unit::TestCase
   class TestBig2str < Test::Unit::TestCase
 
     SIZEOF_BDIGIT = Integer::SIZEOF_BDIGIT

--- a/test/-ext-/bignum/test_bigzero.rb
+++ b/test/-ext-/bignum/test_bigzero.rb
@@ -2,7 +2,7 @@
 require 'test/unit'
 require "-test-/bignum"
 
-class TestBignum < Test::Unit::TestCase
+class Test_Bignum < Test::Unit::TestCase
   class TestBigZero < Test::Unit::TestCase
     def test_equal_0
       bug8204 = '[ruby-core:53893] [Bug #8204]'

--- a/test/-ext-/bignum/test_div.rb
+++ b/test/-ext-/bignum/test_div.rb
@@ -2,7 +2,7 @@
 require 'test/unit'
 require "-test-/bignum"
 
-class TestBignum < Test::Unit::TestCase
+class Test_Bignum < Test::Unit::TestCase
   class TestDiv < Test::Unit::TestCase
 
     SIZEOF_BDIGIT = Integer::SIZEOF_BDIGIT

--- a/test/-ext-/bignum/test_mul.rb
+++ b/test/-ext-/bignum/test_mul.rb
@@ -2,7 +2,7 @@
 require 'test/unit'
 require "-test-/bignum"
 
-class TestBignum < Test::Unit::TestCase
+class Test_Bignum < Test::Unit::TestCase
   class TestMul < Test::Unit::TestCase
 
     SIZEOF_BDIGIT = Integer::SIZEOF_BDIGIT

--- a/test/-ext-/bignum/test_pack.rb
+++ b/test/-ext-/bignum/test_pack.rb
@@ -4,7 +4,7 @@
 require 'test/unit'
 require "-test-/bignum"
 
-class TestBignum < Test::Unit::TestCase
+class Test_Bignum < Test::Unit::TestCase
   class TestPack < Test::Unit::TestCase
 
     MSWORD_FIRST = Integer::INTEGER_PACK_MSWORD_FIRST

--- a/test/-ext-/bignum/test_str2big.rb
+++ b/test/-ext-/bignum/test_str2big.rb
@@ -2,7 +2,7 @@
 require 'test/unit'
 require "-test-/bignum"
 
-class TestBignum < Test::Unit::TestCase
+class Test_Bignum < Test::Unit::TestCase
   class TestStr2big < Test::Unit::TestCase
 
     SIZEOF_BDIGIT = Integer::SIZEOF_BDIGIT

--- a/test/-ext-/exception/test_enc_raise.rb
+++ b/test/-ext-/exception/test_enc_raise.rb
@@ -3,7 +3,7 @@ require 'test/unit'
 require '-test-/exception'
 
 module Bug
-  class TestException < Test::Unit::TestCase
+  class Test_Exception < Test::Unit::TestCase
     def test_enc_raise
       feature5650 = '[ruby-core:41160]'
       Encoding.list.each do |enc|

--- a/test/-ext-/hash/test_delete.rb
+++ b/test/-ext-/hash/test_delete.rb
@@ -2,7 +2,7 @@
 require 'test/unit'
 require '-test-/hash'
 
-class TestHash < Test::Unit::TestCase
+class Test_Hash < Test::Unit::TestCase
   class TestDelete < Test::Unit::TestCase
     def test_delete
       hash = Bug::Hash.new

--- a/test/-ext-/integer/test_integer.rb
+++ b/test/-ext-/integer/test_integer.rb
@@ -2,7 +2,7 @@
 require 'test/unit'
 require '-test-/integer'
 
-class TestInteger < Test::Unit::TestCase
+class Test_Integer < Test::Unit::TestCase
   FIXNUM_MIN = RbConfig::LIMITS['FIXNUM_MIN']
   FIXNUM_MAX = RbConfig::LIMITS['FIXNUM_MAX']
 

--- a/test/-ext-/integer/test_my_integer.rb
+++ b/test/-ext-/integer/test_my_integer.rb
@@ -2,7 +2,7 @@
 require 'test/unit'
 require "-test-/integer"
 
-class TestIntegerExt < Test::Unit::TestCase
+class Test_MyInteger < Test::Unit::TestCase
   def test_my_integer_to_f
     assert_raise(NotImplementedError) do
       Bug::Integer::MyInteger.new.to_f

--- a/test/-ext-/method/test_arity.rb
+++ b/test/-ext-/method/test_arity.rb
@@ -2,7 +2,7 @@
 require '-test-/method'
 require 'test/unit'
 
-class TestMethod < Test::Unit::TestCase
+class Test_Method < Test::Unit::TestCase
   class TestArity < Test::Unit::TestCase
     class A
       def foo0()

--- a/test/-ext-/proc/test_bmethod.rb
+++ b/test/-ext-/proc/test_bmethod.rb
@@ -2,12 +2,12 @@
 require 'test/unit'
 require '-test-/proc'
 
-class TestProc < Test::Unit::TestCase
+class Test_Proc < Test::Unit::TestCase
   class TestBMethod < Test::Unit::TestCase
   end
 end
 
-class TestProc::TestBMethod
+class Test_Proc::TestBMethod
   class Base
     def foo(*a)
       a

--- a/test/-ext-/test_notimplement.rb
+++ b/test/-ext-/test_notimplement.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: false
 require '-test-/notimplement'
 
-class TestNotImplement < Test::Unit::TestCase
+class Test_NotImplement < Test::Unit::TestCase
   def test_funcall_notimplement
     bug3662 = '[ruby-dev:41953]'
     assert_raise(NotImplementedError, bug3662) {

--- a/test/erb/test_erb.rb
+++ b/test/erb/test_erb.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: false
 require 'test/unit'
 require 'erb'
+require 'stringio'
 
 class TestERB < Test::Unit::TestCase
   class MyError < RuntimeError ; end
@@ -235,6 +236,7 @@ EOS
     $stdout = orig
     out.rewind
     assert_equal('9', out.read)
+    return unless num               # to remove warning
   end
 
   class Foo; end

--- a/test/erb/test_erb_m17n.rb
+++ b/test/erb/test_erb_m17n.rb
@@ -3,7 +3,7 @@
 require 'test/unit'
 require 'erb'
 
-class TestERB < Test::Unit::TestCase
+class TestERBEncoding < Test::Unit::TestCase
   def test_result_encoding
     erb = ERB.new("hello")
     assert_equal __ENCODING__, erb.result.encoding

--- a/test/fileutils/test_dryrun.rb
+++ b/test/fileutils/test_dryrun.rb
@@ -8,7 +8,7 @@ require_relative 'visibility_tests'
 class TestFileUtilsDryRun < Test::Unit::TestCase
 
   include FileUtils::DryRun
-  include TestFileUtils::Visibility
+  include TestFileUtilsInc::Visibility
 
   def setup
     super

--- a/test/fileutils/test_nowrite.rb
+++ b/test/fileutils/test_nowrite.rb
@@ -8,7 +8,7 @@ require_relative 'visibility_tests'
 class TestFileUtilsNoWrite < Test::Unit::TestCase
 
   include FileUtils::NoWrite
-  include TestFileUtils::Visibility
+  include TestFileUtilsInc::Visibility
 
   def setup
     super

--- a/test/fileutils/test_verbose.rb
+++ b/test/fileutils/test_verbose.rb
@@ -8,7 +8,7 @@ require_relative 'visibility_tests'
 class TestFileUtilsVerbose < Test::Unit::TestCase
 
   include FileUtils::Verbose
-  include TestFileUtils::Visibility
+  include TestFileUtilsInc::Visibility
 
   def setup
     super

--- a/test/fileutils/visibility_tests.rb
+++ b/test/fileutils/visibility_tests.rb
@@ -2,14 +2,14 @@
 require 'test/unit'
 require 'fileutils'
 
-class TestFileUtils < Test::Unit::TestCase
+class TestFileUtilsInc < Test::Unit::TestCase
 end
 
 ##
 # These tests are reused in the FileUtils::Verbose, FileUtils::NoWrite and
 # FileUtils::DryRun tests
 
-module TestFileUtils::Visibility
+module TestFileUtilsInc::Visibility
 
   FileUtils::METHODS.each do |m|
     define_method "test_singleton_visibility_#{m}" do

--- a/test/optparse/test_zsh_completion.rb
+++ b/test/optparse/test_zsh_completion.rb
@@ -4,7 +4,7 @@ require 'optparse'
 
 class TestOptionParser < Test::Unit::TestCase
 end
-class TestOptionParser::BashCompletion < Test::Unit::TestCase
+class TestOptionParser::BashCompletionZSH < Test::Unit::TestCase
   def setup
     @opt = OptionParser.new
     @opt.define("-z", "zzz") {}

--- a/test/rexml/test_martin_fowler.rb
+++ b/test/rexml/test_martin_fowler.rb
@@ -3,7 +3,7 @@ require 'test/unit'
 require 'rexml/document'
 
 module REXMLTests
-  class OrderTester < Test::Unit::TestCase
+  class OrderTesterMF < Test::Unit::TestCase
     DOC = <<END
 <paper>
 <title>Remove this element and figs order differently</title>

--- a/test/ruby/test_ifunless.rb
+++ b/test/ruby/test_ifunless.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: false
 require 'test/unit'
 
-class TestIfunless < Test::Unit::TestCase
+class TestIfUnless < Test::Unit::TestCase
   def test_if_unless
     x = 'test';
     assert(if x == x then true else false end)

--- a/test/ruby/test_not.rb
+++ b/test/ruby/test_not.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: false
 require 'test/unit'
 
-class TestIfunless < Test::Unit::TestCase
+class TestNot < Test::Unit::TestCase
   def test_not_with_grouped_expression
     assert_equal(false, (not (true)))
     assert_equal(true, (not (false)))

--- a/test/ruby/test_weakmap.rb
+++ b/test/ruby/test_weakmap.rb
@@ -39,7 +39,7 @@ class TestWeakMap < Test::Unit::TestCase
       x = nil
     end
     GC.start
-    skip # TODO: failure introduced from r60440
+    # skip('TODO: failure introduced from r60440')
     assert_not_send([@wm, m, k])
   end
   alias test_member? test_include?


### PR DESCRIPTION
When running test-all with a `-j` option, duplicate class names intermittently cause incorrect test results.

This should result in a higher and more stable test count for the mswin build.  'Underscore' style renames followed style used in `TestString`.

See [Ruby Issue 14064](https://bugs.ruby-lang.org/issues/14064?next_issue_id=14062&prev_issue_id=14066#note-1)