### PR TITLE
sprintf.c: suppress 'too many arguments' warning if sole argument is a Hash

### DIFF
--- a/sprintf.c
+++ b/sprintf.c
@@ -1181,9 +1181,10 @@ rb_str_format(int argc, const VALUE *argv, VALUE fmt)
 
   sprint_exit:
     rb_str_tmp_frozen_release(orig, fmt);
-    /* XXX - We cannot validate the number of arguments if (digit)$ style used.
-     */
-    if (posarg >= 0 && nextarg < argc) {
+    /* Don't validate the number of arguments if:
+     * - (digit)$ flag used (in that case, posarg is set to -1)
+     * - the sole argument is a Hash (as for %{name} format directives) */
+    if (posarg >= 0 && (argc > 2 || !RB_TYPE_P(argv[1], T_HASH)) && nextarg < argc) {
 	const char *mesg = "too many arguments for format string";
 	if (RTEST(ruby_debug)) rb_raise(rb_eArgError, "%s", mesg);
 	if (RTEST(ruby_verbose)) rb_warn("%s", mesg);

--- a/test/ruby/test_sprintf.rb
+++ b/test/ruby/test_sprintf.rb
@@ -532,4 +532,23 @@ class TestSprintf < Test::Unit::TestCase
     assert_equal before + 1, after, 'only new string is the created one'
     assert_equal '1970-01-01', val
   end
+
+  def test_warning_for_too_many_args
+    assert_warning(/too many arguments for format string/) { sprintf('blah', 1) }
+    assert_warning(/too many arguments for format string/) { sprintf('blah', 1, 2) }
+
+    assert_warning('') { sprintf('blah') }
+    assert_warning('') { sprintf('%d', 1) }
+    assert_warning('') { sprintf('%d %d', 1, 2) }
+
+    # Using <digit>$ syntax in format string suppresses warning
+    assert_warning('') { sprintf('%2$d', 1, 2) }
+
+    # Hash is special-cased, because of '%{arg1} %{arg2}' % {arg1: 1, arg2: 2} syntax
+    assert_warning('') { sprintf('blah', {}) }
+    assert_warning('') { sprintf('blah', {arg1: 1}) }
+    assert_warning('') { sprintf('%{arg1}', {arg1: 1, arg2: 2}) }
+
+    assert_warning(/too many arguments for format string/) { sprintf('blah', {}, 2) }
+  end
 end


### PR DESCRIPTION
sprintf has a very useful feature whereby arguments can be provided in a Hash, like this:

    sprintf 'format %{arg1} %{arg2}', {arg1: 1, arg2: 2}
    => format 1 2
    sprintf 'format %{arg1}', {arg1: 1}
    => format 1

But, when Ruby is run with -w, there is an inconsistency:

    sprintf 'format', {}
    => warning: too many arguments for format string
    => format

When arguments are being provided in a Hash, passing an empty Hash is equivalent to passing no arguments at all. So there is no need to print a warning in that case.

Therefore, suppress this warning. At the same time, add tests to check whether the warning is printed when expected.