### PR TITLE
Fix size on Enumerable#cycle when the size is 0

### DIFF
--- a/enum.c
+++ b/enum.c
@@ -2845,6 +2845,7 @@ enum_cycle_size(VALUE self, VALUE args, VALUE eobj)
     VALUE size = enum_size(self, args, 0);
 
     if (size == Qnil) return Qnil;
+    if (FIXNUM_ZERO_P(size)) return size;
 
     if (args && (RARRAY_LEN(args) > 0)) {
 	n = RARRAY_AREF(args, 0);

--- a/test/ruby/test_enumerator.rb
+++ b/test/ruby/test_enumerator.rb
@@ -576,13 +576,20 @@ class TestEnumerator < Test::Unit::TestCase
     assert_equal Float::INFINITY, [:foo].cycle.size
     assert_equal 10, [:foo, :bar].cycle(5).size
     assert_equal 0,  [:foo, :bar].cycle(-10).size
+    assert_equal Float::INFINITY, {foo: 1}.cycle.size
+    assert_equal 10, {foo: 1, bar: 2}.cycle(5).size
+    assert_equal 0,  {foo: 1, bar: 2}.cycle(-10).size
     assert_equal 0,  [].cycle.size
     assert_equal 0,  [].cycle(5).size
+    assert_equal 0,  {}.cycle.size
+    assert_equal 0,  {}.cycle(5).size
 
     assert_equal nil, @obj.cycle.size
     assert_equal nil, @obj.cycle(5).size
     assert_equal Float::INFINITY, @sized.cycle.size
     assert_equal 126, @sized.cycle(3).size
+    assert_equal Float::INFINITY, [].to_enum { 42 }.cycle.size
+    assert_equal 0, [].to_enum { 0 }.cycle.size
   end
 
   def test_size_for_loops


### PR DESCRIPTION
Is this an intentional behavior?

```
ruby 2.4.2p198 (2017-09-14 revision 59899) [x86_64-darwin16]
```

```ruby
p([].cycle.size) #=> 0
p({}.cycle.size) #=> Infinity 
```

Array#cycle already special handled empty arrays. So similar behavior in Enumerable#cycle with the #size sounds reasonable to me.

( The CI 🔴 failures around Net tests looks an known issue in trunk )