### PR TITLE
Remove unneeded test-all skips, based on 34739 by nobu

### DIFF
--- a/test/date/test_date_attr.rb
+++ b/test/date/test_date_attr.rb
@@ -88,7 +88,6 @@ class TestDateAttr < Test::Unit::TestCase
   end
 
   def test_nth_kday
-    skip unless Date.new.respond_to?(:nth_kday?, true)
     assert_equal(false, Date.new(2001,1,14).__send__(:nth_kday?, 1,0))
     assert_equal(true, Date.new(2001,1,14).__send__(:nth_kday?, 2,0))
     assert_equal(false, Date.new(2001,1,14).__send__(:nth_kday?, 3,0))
@@ -99,6 +98,6 @@ class TestDateAttr < Test::Unit::TestCase
     assert_equal(true, Date.new(2001,1,14).__send__(:nth_kday?, -3,0))
     assert_equal(false, Date.new(2001,1,14).__send__(:nth_kday?, -4,0))
     assert_equal(false, Date.new(2001,1,14).__send__(:nth_kday?, -5,0))
-  end
+  end if Date.new.respond_to?(:nth_kday?, true)
 
 end

--- a/test/date/test_date_base.rb
+++ b/test/date/test_date_base.rb
@@ -54,7 +54,6 @@ class TestDateBase < Test::Unit::TestCase
   end
 
   def test_ordinal__julian
-    skip unless defined?(Calendar)
     for j in @from..@to
       m, d, y = julian_from_absolute(absolute_from_julian_day_number(j))
       j0 = julian_day_number_from_absolute(absolute_from_julian(12, 31, y - 1))
@@ -69,7 +68,6 @@ class TestDateBase < Test::Unit::TestCase
   end
 
   def test_ordinal__gregorian
-    skip unless defined?(Calendar)
     for j in @from..@to
       m, d, y = gregorian_from_absolute(absolute_from_julian_day_number(j))
       j0 =
@@ -85,7 +83,6 @@ class TestDateBase < Test::Unit::TestCase
   end
 
   def test_civil__julian
-    skip unless defined?(Calendar)
     for j in @from..@to
       m, d, y = julian_from_absolute(absolute_from_julian_day_number(j))
       j2 = julian_day_number_from_absolute(absolute_from_julian(m, d, y))
@@ -100,7 +97,6 @@ class TestDateBase < Test::Unit::TestCase
   end
 
   def test_civil__gregorian
-    skip unless defined?(Calendar)
     for j in @from..@to
       m, d, y = gregorian_from_absolute(absolute_from_julian_day_number(j))
       j2 = julian_day_number_from_absolute(absolute_from_gregorian(m, d, y))
@@ -115,7 +111,6 @@ class TestDateBase < Test::Unit::TestCase
   end
 
   def test_commercial__gregorian
-    skip unless defined?(Calendar)
     for j in @from..@to
       w, d, y = iso_from_absolute(absolute_from_julian_day_number(j))
       j2 = julian_day_number_from_absolute(absolute_from_iso(w, d, y))
@@ -130,7 +125,6 @@ class TestDateBase < Test::Unit::TestCase
   end
 
   def test_weeknum
-    skip unless defined?(Calendar)
     for j in @from..@to
       for k in 0..1
 	wy, ww, wd = Date.__send__(:jd_to_weeknum, j, k, Date::GREGORIAN)
@@ -141,7 +135,6 @@ class TestDateBase < Test::Unit::TestCase
   end
 
   def test_weeknum__2
-    skip unless defined?(Calendar)
     for j in @from4t..@to4t
       d = Date.jd(j)
       t = Time.mktime(d.year, d.mon, d.mday)
@@ -159,7 +152,6 @@ class TestDateBase < Test::Unit::TestCase
   end
 
   def test_nth_kday
-    skip unless defined?(Calendar)
     skip unless (Date.respond_to?(:nth_kday_to_jd, true) &&
 		 Date.respond_to?(:jd_to_nth_kday, true))
     for y in 1601..2401
@@ -440,4 +432,4 @@ class TestDateBase < Test::Unit::TestCase
     assert_nil(DateTime.__send__(valid_time_p, 24,1,1))
   end
 
-end
+end if defined?(Calendar)

--- a/test/date/test_date_new.rb
+++ b/test/date/test_date_new.rb
@@ -203,7 +203,6 @@ class TestDateNew < Test::Unit::TestCase
   end
 
   def test_weeknum
-    skip unless Date.respond_to?(:weeknum, true)
     d = Date.__send__(:weeknum)
     dt = DateTime.__send__(:weeknum)
     assert_equal([-4712, 1, 1], [d.year, d.mon, d.mday])
@@ -223,10 +222,9 @@ class TestDateNew < Test::Unit::TestCase
     assert_raise(ArgumentError) do
       Date.__send__(:weeknum, 1999,-53,-1, 0)
     end
-  end
+  end if Date.respond_to?(:weeknum, true)
 
   def test_nth_kday
-    skip unless Date.respond_to?(:nth_kday, true)
     d = Date.__send__(:nth_kday)
     dt = DateTime.__send__(:nth_kday)
     assert_equal([-4712, 1, 1], [d.year, d.mon, d.mday])
@@ -246,7 +244,7 @@ class TestDateNew < Test::Unit::TestCase
     assert_raise(ArgumentError) do
       Date.__send__(:nth_kday, 2006,5, -5,0)
     end
-  end
+  end if Date.respond_to?(:nth_kday, true)
 
   def test_today
     z = Time.now

--- a/test/date/test_switch_hitter.rb
+++ b/test/date/test_switch_hitter.rb
@@ -658,8 +658,7 @@ class TestSH < Test::Unit::TestCase
   end
 
   def test_base
-    skip unless defined?(Date.test_all)
     assert_equal(true, Date.test_all)
-  end
+  end if defined?(Date.test_all)
 
 end


### PR DESCRIPTION
While reviewing test-all results, several skips were listed from the test/date files.  A few years ago, @nobu commited [svn 34739](https://github.com/ruby/ruby/commit/b67bc8d722e9351b34e68ac77d397aead29961cc#diff-b9dd4c7779e6e659753c9eea9c365135), which was reverted (possibly due to rdoc changes?).

This PR uses just the date specific patches.  Old methods and require 'calendar'...

See https://bugs.ruby-lang.org/issues/14088