### PR TITLE
change call CGI methods from :: to .

### DIFF
--- a/lib/cgi.rb
+++ b/lib/cgi.rb
@@ -253,7 +253,7 @@
 #           end
 #         end +
 #         cgi.pre do
-#           CGI::escapeHTML(
+#           CGI.escapeHTML(
 #             "params: #{cgi.params.inspect}\n" +
 #             "cookies: #{cgi.cookies.inspect}\n" +
 #             ENV.collect do |key, value|

--- a/lib/cgi/cookie.rb
+++ b/lib/cgi/cookie.rb
@@ -146,7 +146,7 @@ class CGI
       buf = "#{@name}=#{val}".dup
       buf << "; domain=#{@domain}" if @domain
       buf << "; path=#{@path}"     if @path
-      buf << "; expires=#{CGI::rfc1123_date(@expires)}" if @expires
+      buf << "; expires=#{CGI.rfc1123_date(@expires)}" if @expires
       buf << "; secure"            if @secure
       buf << "; HttpOnly"          if @httponly
       buf

--- a/lib/cgi/core.rb
+++ b/lib/cgi/core.rb
@@ -375,14 +375,14 @@ class CGI
 
   # Parse an HTTP query string into a hash of key=>value pairs.
   #
-  #   params = CGI::parse("query_string")
+  #   params = CGI.parse("query_string")
   #     # {"name1" => ["value1", "value2", ...],
   #     #  "name2" => ["value1", "value2", ...], ... }
   #
-  def CGI::parse(query)
+  def self.parse(query)
     params = {}
     query.split(/[&;]/).each do |pairs|
-      key, value = pairs.split('=',2).collect{|v| CGI::unescape(v) }
+      key, value = pairs.split('=',2).collect{|v| CGI.unescape(v) }
 
       next unless key
 
@@ -656,7 +656,7 @@ class CGI
         @params = read_multipart(boundary, Integer(env_table['CONTENT_LENGTH']))
       else
         @multipart = false
-        @params = CGI::parse(
+        @params = CGI.parse(
                     case env_table['REQUEST_METHOD']
                     when "GET", "HEAD"
                       if defined?(MOD_RUBY)
@@ -686,7 +686,7 @@ class CGI
         end
       end
 
-      @cookies = CGI::Cookie::parse((env_table['HTTP_COOKIE'] or env_table['COOKIE']))
+      @cookies = CGI::Cookie.parse((env_table['HTTP_COOKIE'] or env_table['COOKIE']))
     end
     private :initialize_query
 

--- a/lib/cgi/html.rb
+++ b/lib/cgi/html.rb
@@ -30,10 +30,10 @@ class CGI
       attributes.each do|name, value|
         next unless value
         s << " "
-        s << CGI::escapeHTML(name.to_s)
+        s << CGI.escapeHTML(name.to_s)
         if value != true
           s << '="'
-          s << CGI::escapeHTML(value.to_s)
+          s << CGI.escapeHTML(value.to_s)
           s << '"'
         end
       end
@@ -423,7 +423,7 @@ class CGI
       buf << super(attributes)
 
       if pretty
-        CGI::pretty(buf, pretty)
+        CGI.pretty(buf, pretty)
       else
         buf
       end

--- a/lib/cgi/session.rb
+++ b/lib/cgi/session.rb
@@ -403,7 +403,7 @@ class CGI
             for line in f
               line.chomp!
               k, v = line.split('=',2)
-              @hash[CGI::unescape(k)] = Marshal.restore(CGI::unescape(v))
+              @hash[CGI.unescape(k)] = Marshal.restore(CGI.unescape(v))
             end
           ensure
             f.close unless f.nil?
@@ -421,7 +421,7 @@ class CGI
           lockf.flock File::LOCK_EX
           f = File.open(@path+".new", File::CREAT|File::TRUNC|File::WRONLY, 0600)
           for k,v in @hash
-            f.printf "%s=%s\n", CGI::escape(k), CGI::escape(String(Marshal.dump(v)))
+            f.printf "%s=%s\n", CGI.escape(k), CGI.escape(String(Marshal.dump(v)))
           end
           f.close
           File.rename @path+".new", @path

--- a/lib/cgi/util.rb
+++ b/lib/cgi/util.rb
@@ -7,7 +7,7 @@ end
 module CGI::Util
   @@accept_charset="UTF-8" unless defined?(@@accept_charset)
   # URL-encode a string.
-  #   url_encoded_string = CGI::escape("'Stop!' said Fred")
+  #   url_encoded_string = CGI.escape("'Stop!' said Fred")
   #      # => "%27Stop%21%27+said+Fred"
   def escape(string)
     encoding = string.encoding
@@ -17,7 +17,7 @@ module CGI::Util
   end
 
   # URL-decode a string with encoding(optional).
-  #   string = CGI::unescape("%27Stop%21%27+said+Fred")
+  #   string = CGI.unescape("%27Stop%21%27+said+Fred")
   #      # => "'Stop!' said Fred"
   def unescape(string,encoding=@@accept_charset)
     str=string.tr('+', ' ').b.gsub(/((?:%[0-9a-fA-F]{2})+)/) do |m|
@@ -36,7 +36,7 @@ module CGI::Util
   }
 
   # Escape special characters in HTML, namely '&\"<>
-  #   CGI::escapeHTML('Usage: foo "bar" <baz>')
+  #   CGI.escapeHTML('Usage: foo "bar" <baz>')
   #      # => "Usage: foo &quot;bar&quot; &lt;baz&gt;"
   def escapeHTML(string)
     enc = string.encoding
@@ -60,7 +60,7 @@ module CGI::Util
   end
 
   # Unescape a string that has been HTML-escaped
-  #   CGI::unescapeHTML("Usage: foo &quot;bar&quot; &lt;baz&gt;")
+  #   CGI.unescapeHTML("Usage: foo &quot;bar&quot; &lt;baz&gt;")
   #      # => "Usage: foo \"bar\" <baz>"
   def unescapeHTML(string)
     enc = string.encoding
@@ -118,10 +118,10 @@ module CGI::Util
     end
   end
 
-  # Synonym for CGI::escapeHTML(str)
+  # Synonym for CGI.escapeHTML(str)
   alias escape_html escapeHTML
 
-  # Synonym for CGI::unescapeHTML(str)
+  # Synonym for CGI.unescapeHTML(str)
   alias unescape_html unescapeHTML
 
   # Escape only the tags of certain HTML elements in +string+.
@@ -132,30 +132,30 @@ module CGI::Util
   # The attribute list of the open tag will also be escaped (for
   # instance, the double-quotes surrounding attribute values).
   #
-  #   print CGI::escapeElement('<BR><A HREF="url"></A>', "A", "IMG")
+  #   print CGI.escapeElement('<BR><A HREF="url"></A>', "A", "IMG")
   #     # "<BR>&lt;A HREF=&quot;url&quot;&gt;&lt;/A&gt"
   #
-  #   print CGI::escapeElement('<BR><A HREF="url"></A>', ["A", "IMG"])
+  #   print CGI.escapeElement('<BR><A HREF="url"></A>', ["A", "IMG"])
   #     # "<BR>&lt;A HREF=&quot;url&quot;&gt;&lt;/A&gt"
   def escapeElement(string, *elements)
     elements = elements[0] if elements[0].kind_of?(Array)
     unless elements.empty?
       string.gsub(/<\/?(?:#{elements.join("|")})(?!\w)(?:.|\n)*?>/i) do
-        CGI::escapeHTML($&)
+        CGI.escapeHTML($&)
       end
     else
       string
     end
   end
 
-  # Undo escaping such as that done by CGI::escapeElement()
+  # Undo escaping such as that done by CGI.escapeElement()
   #
-  #   print CGI::unescapeElement(
-  #           CGI::escapeHTML('<BR><A HREF="url"></A>'), "A", "IMG")
+  #   print CGI.unescapeElement(
+  #           CGI.escapeHTML('<BR><A HREF="url"></A>'), "A", "IMG")
   #     # "&lt;BR&gt;<A HREF="url"></A>"
   #
-  #   print CGI::unescapeElement(
-  #           CGI::escapeHTML('<BR><A HREF="url"></A>'), ["A", "IMG"])
+  #   print CGI.unescapeElement(
+  #           CGI.escapeHTML('<BR><A HREF="url"></A>'), ["A", "IMG"])
   #     # "&lt;BR&gt;<A HREF="url"></A>"
   def unescapeElement(string, *elements)
     elements = elements[0] if elements[0].kind_of?(Array)
@@ -168,10 +168,10 @@ module CGI::Util
     end
   end
 
-  # Synonym for CGI::escapeElement(str)
+  # Synonym for CGI.escapeElement(str)
   alias escape_element escapeElement
 
-  # Synonym for CGI::unescapeElement(str)
+  # Synonym for CGI.unescapeElement(str)
   alias unescape_element unescapeElement
 
   # Abbreviated day-of-week names specified by RFC 822
@@ -182,7 +182,7 @@ module CGI::Util
 
   # Format a +Time+ object as a String using the format specified by RFC 1123.
   #
-  #   CGI::rfc1123_date(Time.now)
+  #   CGI.rfc1123_date(Time.now)
   #     # Sat, 01 Jan 2000 00:00:00 GMT
   def rfc1123_date(time)
     t = time.clone.gmtime
@@ -196,13 +196,13 @@ module CGI::Util
   # +string+ is the HTML string to indent.  +shift+ is the indentation
   # unit to use; it defaults to two spaces.
   #
-  #   print CGI::pretty("<HTML><BODY></BODY></HTML>")
+  #   print CGI.pretty("<HTML><BODY></BODY></HTML>")
   #     # <HTML>
   #     #   <BODY>
   #     #   </BODY>
   #     # </HTML>
   #
-  #   print CGI::pretty("<HTML><BODY></BODY></HTML>", "\t")
+  #   print CGI.pretty("<HTML><BODY></BODY></HTML>", "\t")
   #     # <HTML>
   #     #         <BODY>
   #     #         </BODY>

--- a/test/cgi/test_cgi_util.rb
+++ b/test/cgi/test_cgi_util.rb
@@ -25,30 +25,30 @@ class CGIUtilTest < Test::Unit::TestCase
 
 
   def test_cgi_escape
-    assert_equal('%26%3C%3E%22+%E3%82%86%E3%82%93%E3%82%86%E3%82%93', CGI::escape(@str1))
-    assert_equal('%26%3C%3E%22+%E3%82%86%E3%82%93%E3%82%86%E3%82%93'.ascii_only?, CGI::escape(@str1).ascii_only?) if defined?(::Encoding)
+    assert_equal('%26%3C%3E%22+%E3%82%86%E3%82%93%E3%82%86%E3%82%93', CGI.escape(@str1))
+    assert_equal('%26%3C%3E%22+%E3%82%86%E3%82%93%E3%82%86%E3%82%93'.ascii_only?, CGI.escape(@str1).ascii_only?) if defined?(::Encoding)
   end
 
   def test_cgi_escape_with_unreserved_characters
     assert_equal("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~",
-                 CGI::escape("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"),
+                 CGI.escape("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"),
                  "should not escape any unreserved characters, as per RFC3986 Section 2.3")
   end
 
   def test_cgi_escape_with_invalid_byte_sequence
     assert_nothing_raised(ArgumentError) do
-      assert_equal('%C0%3C%3C', CGI::escape("\xC0\<\<".dup.force_encoding("UTF-8")))
+      assert_equal('%C0%3C%3C', CGI.escape("\xC0\<\<".dup.force_encoding("UTF-8")))
     end
   end
 
   def test_cgi_escape_preserve_encoding
-    assert_equal(Encoding::US_ASCII, CGI::escape("\xC0\<\<".dup.force_encoding("US-ASCII")).encoding)
-    assert_equal(Encoding::ASCII_8BIT, CGI::escape("\xC0\<\<".dup.force_encoding("ASCII-8BIT")).encoding)
-    assert_equal(Encoding::UTF_8, CGI::escape("\xC0\<\<".dup.force_encoding("UTF-8")).encoding)
+    assert_equal(Encoding::US_ASCII, CGI.escape("\xC0\<\<".dup.force_encoding("US-ASCII")).encoding)
+    assert_equal(Encoding::ASCII_8BIT, CGI.escape("\xC0\<\<".dup.force_encoding("ASCII-8BIT")).encoding)
+    assert_equal(Encoding::UTF_8, CGI.escape("\xC0\<\<".dup.force_encoding("UTF-8")).encoding)
   end
 
   def test_cgi_unescape
-    str = CGI::unescape('%26%3C%3E%22+%E3%82%86%E3%82%93%E3%82%86%E3%82%93')
+    str = CGI.unescape('%26%3C%3E%22+%E3%82%86%E3%82%93%E3%82%86%E3%82%93')
     assert_equal(@str1, str)
     return unless defined?(::Encoding)
 
@@ -57,9 +57,9 @@ class CGIUtilTest < Test::Unit::TestCase
   end
 
   def test_cgi_unescape_preserve_encoding
-    assert_equal(Encoding::US_ASCII, CGI::unescape("%C0%3C%3C".dup.force_encoding("US-ASCII")).encoding)
-    assert_equal(Encoding::ASCII_8BIT, CGI::unescape("%C0%3C%3C".dup.force_encoding("ASCII-8BIT")).encoding)
-    assert_equal(Encoding::UTF_8, CGI::unescape("%C0%3C%3C".dup.force_encoding("UTF-8")).encoding)
+    assert_equal(Encoding::US_ASCII, CGI.unescape("%C0%3C%3C".dup.force_encoding("US-ASCII")).encoding)
+    assert_equal(Encoding::ASCII_8BIT, CGI.unescape("%C0%3C%3C".dup.force_encoding("ASCII-8BIT")).encoding)
+    assert_equal(Encoding::UTF_8, CGI.unescape("%C0%3C%3C".dup.force_encoding("UTF-8")).encoding)
   end
 
   def test_cgi_unescape_accept_charset
@@ -73,23 +73,23 @@ class CGIUtilTest < Test::Unit::TestCase
   end
 
   def test_cgi_pretty
-    assert_equal("<HTML>\n  <BODY>\n  </BODY>\n</HTML>\n",CGI::pretty("<HTML><BODY></BODY></HTML>"))
-    assert_equal("<HTML>\n\t<BODY>\n\t</BODY>\n</HTML>\n",CGI::pretty("<HTML><BODY></BODY></HTML>","\t"))
+    assert_equal("<HTML>\n  <BODY>\n  </BODY>\n</HTML>\n",CGI.pretty("<HTML><BODY></BODY></HTML>"))
+    assert_equal("<HTML>\n\t<BODY>\n\t</BODY>\n</HTML>\n",CGI.pretty("<HTML><BODY></BODY></HTML>","\t"))
   end
 
   def test_cgi_escapeHTML
-    assert_equal("&#39;&amp;&quot;&gt;&lt;", CGI::escapeHTML("'&\"><"))
+    assert_equal("&#39;&amp;&quot;&gt;&lt;", CGI.escapeHTML("'&\"><"))
   end
 
   def test_cgi_escape_html_duplicated
     orig = "Ruby".dup.force_encoding("US-ASCII")
-    str = CGI::escapeHTML(orig)
+    str = CGI.escapeHTML(orig)
     assert_equal(orig, str)
     assert_not_same(orig, str)
   end
 
   def assert_cgi_escape_html_preserve_encoding(str, encoding)
-    assert_equal(encoding, CGI::escapeHTML(str.dup.force_encoding(encoding)).encoding)
+    assert_equal(encoding, CGI.escapeHTML(str.dup.force_encoding(encoding)).encoding)
   end
 
   def test_cgi_escape_html_preserve_encoding
@@ -100,25 +100,25 @@ class CGIUtilTest < Test::Unit::TestCase
   end
 
   def test_cgi_escape_html_preserve_tainted
-    assert_not_predicate CGI::escapeHTML("'&\"><"),           :tainted?
-    assert_predicate     CGI::escapeHTML("'&\"><".dup.taint), :tainted?
-    assert_not_predicate CGI::escapeHTML("Ruby"),             :tainted?
-    assert_predicate     CGI::escapeHTML("Ruby".dup.taint),   :tainted?
+    assert_not_predicate CGI.escapeHTML("'&\"><"),           :tainted?
+    assert_predicate     CGI.escapeHTML("'&\"><".dup.taint), :tainted?
+    assert_not_predicate CGI.escapeHTML("Ruby"),             :tainted?
+    assert_predicate     CGI.escapeHTML("Ruby".dup.taint),   :tainted?
   end
 
   def test_cgi_escape_html_dont_freeze
-    assert_not_predicate CGI::escapeHTML("'&\"><".dup),    :frozen?
-    assert_not_predicate CGI::escapeHTML("'&\"><".freeze), :frozen?
-    assert_not_predicate CGI::escapeHTML("Ruby".dup),      :frozen?
-    assert_not_predicate CGI::escapeHTML("Ruby".freeze),   :frozen?
+    assert_not_predicate CGI.escapeHTML("'&\"><".dup),    :frozen?
+    assert_not_predicate CGI.escapeHTML("'&\"><".freeze), :frozen?
+    assert_not_predicate CGI.escapeHTML("Ruby".dup),      :frozen?
+    assert_not_predicate CGI.escapeHTML("Ruby".freeze),   :frozen?
   end
 
   def test_cgi_unescapeHTML
-    assert_equal("'&\"><", CGI::unescapeHTML("&#39;&amp;&quot;&gt;&lt;"))
+    assert_equal("'&\"><", CGI.unescapeHTML("&#39;&amp;&quot;&gt;&lt;"))
   end
 
   def test_cgi_unescapeHTML_invalid
-    assert_equal('&<&amp>&quot&abcdefghijklmn', CGI::unescapeHTML('&&lt;&amp&gt;&quot&abcdefghijklmn'))
+    assert_equal('&<&amp>&quot&abcdefghijklmn', CGI.unescapeHTML('&&lt;&amp&gt;&quot&abcdefghijklmn'))
   end
 
   Encoding.list.each do |enc|
@@ -129,10 +129,10 @@ class CGIUtilTest < Test::Unit::TestCase
       next
     else
       define_method("test_cgi_escapeHTML:#{enc.name}") do
-        assert_equal(escaped, CGI::escapeHTML(unescaped))
+        assert_equal(escaped, CGI.escapeHTML(unescaped))
       end
       define_method("test_cgi_unescapeHTML:#{enc.name}") do
-        assert_equal(unescaped, CGI::unescapeHTML(escaped))
+        assert_equal(unescaped, CGI.unescapeHTML(escaped))
       end
     end
   end
@@ -146,16 +146,16 @@ class CGIUtilTest < Test::Unit::TestCase
       next
     else
       define_method("test_cgi_escape:#{enc.name}") do
-        assert_equal(escaped, CGI::escape(unescaped))
+        assert_equal(escaped, CGI.escape(unescaped))
       end
       define_method("test_cgi_unescape:#{enc.name}") do
-        assert_equal(unescaped, CGI::unescape(escaped, enc))
+        assert_equal(unescaped, CGI.unescape(escaped, enc))
       end
     end
   end
 
   def test_cgi_unescapeHTML_uppercasecharacter
-    assert_equal("\xE3\x81\x82\xE3\x81\x84\xE3\x81\x86", CGI::unescapeHTML("&#x3042;&#x3044;&#X3046;"))
+    assert_equal("\xE3\x81\x82\xE3\x81\x84\xE3\x81\x86", CGI.unescapeHTML("&#x3042;&#x3044;&#X3046;"))
   end
 
   def test_cgi_include_escape


### PR DESCRIPTION
Hi.
I think `::` for call methods may cause confusion. In this pr `::` call notation changed to `.` dot call. 
Maybe it makes sense only for documentation.