### PR TITLE
thread_win32.c: unify signature with pthread's one

### DIFF
--- a/thread_win32.c
+++ b/thread_win32.c
@@ -24,8 +24,8 @@
 static volatile DWORD ruby_native_thread_key = TLS_OUT_OF_INDEXES;
 
 static int w32_wait_events(HANDLE *events, int count, DWORD timeout, rb_thread_t *th);
-static int native_mutex_lock(rb_nativethread_lock_t *lock);
-static int native_mutex_unlock(rb_nativethread_lock_t *lock);
+static void native_mutex_lock(rb_nativethread_lock_t *lock);
+static void native_mutex_unlock(rb_nativethread_lock_t *lock);
 
 static void
 w32_error(const char *func)
@@ -302,7 +302,7 @@ native_sleep(rb_thread_t *th, struct timeval *tv)
     GVL_UNLOCK_END();
 }
 
-static int
+static void
 native_mutex_lock(rb_nativethread_lock_t *lock)
 {
 #if USE_WIN32_MUTEX
@@ -310,18 +310,16 @@ native_mutex_lock(rb_nativethread_lock_t *lock)
 #else
     EnterCriticalSection(&lock->crit);
 #endif
-    return 0;
 }
 
-static int
+static void
 native_mutex_unlock(rb_nativethread_lock_t *lock)
 {
 #if USE_WIN32_MUTEX
     thread_debug("release mutex: %p\n", lock->mutex);
-    return ReleaseMutex(lock->mutex);
+    ReleaseMutex(lock->mutex);
 #else
     LeaveCriticalSection(&lock->crit);
-    return 0;
 #endif
 }
 


### PR DESCRIPTION
For future JIT introduction, those functions are useful for abstracting native threads and I want their signatures to be unified in upstream to avoid conflict. 

As their return values are not used, I want to drop return values of win32 version.