### PR TITLE
Set#^ is XOR

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -208,6 +208,7 @@ with all sufficient information, see the ChangeLog file or Redmine
   * Add Set#to_s as alias to #inspect [Feature #13676]
   * Add Set#=== as alias to #include? [Feature #13801]
   * Add Set#reset [Feature #6589]
+  * Add Set#xor as alias to #^ [Feature #14105]
 
 * StringIO
   * StringIO#write accepts multiple arguments

--- a/lib/set.rb
+++ b/lib/set.rb
@@ -446,7 +446,8 @@ class Set
   alias intersection &  ##
 
   # Returns a new set containing elements exclusive between the set
-  # and the given enumerable object.  (set ^ enum) is equivalent to
+  # and the given enumerable object, what is commonly known as
+  # <em>exclusive or</em> and <em>XOR</em>.  (set ^ enum) is equivalent to
   # ((set | enum) - (set & enum)).
   def ^(enum)
     n = Set.new(enum)

--- a/lib/set.rb
+++ b/lib/set.rb
@@ -454,6 +454,7 @@ class Set
     each { |o| n.add(o) unless n.delete?(o) }
     n
   end
+  alias xor ^  ##
 
   # Returns true if two sets are equal.  The equality of each couple
   # of elements is defined according to Object#eql?.


### PR DESCRIPTION
The `^` operator in `Set` is commonly known as _ exclusive or_ and _XOR_ in mathematics, hardware and other programming languages. Adding _xor_ as an alias makes it much more readable and explicit and that is what we love of Ruby. ❤️

I also added to the documentation of `^`. 


