### PR TITLE
FileUtils : Use Dir.children instead of Dir.entries

### DIFF
--- a/lib/fileutils.rb
+++ b/lib/fileutils.rb
@@ -1193,8 +1193,7 @@ module FileUtils
     def entries
       opts = {}
       opts[:encoding] = ::Encoding::UTF_8 if fu_windows?
-      Dir.entries(path(), opts)\
-          .reject {|n| n == '.' or n == '..' }\
+      Dir.children(path, opts)\
           .map {|n| Entry_.new(prefix(), join(rel(), n.untaint)) }
     end
 


### PR DESCRIPTION
Feature [#14109](https://bugs.ruby-lang.org/issues/14109)

Dir.children is available since Feature [#11302](https://bugs.ruby-lang.org/issues/11302).
FileUtils uses Dir.each on an internal method encapsulated on a private class `Entry_#entry`, having no '.' neither '..' entries would make now superfluous a chained reject filtering.

This change can improve the performance of these `FileUtils` methods when the provided path covers thousands of files or directories:

- chmod_R
- chown_R
- remove_entry
- remove_entry_secure
- rm_r
- remove_dir
- copy_entry

Related: Feature #[13896](https://bugs.ruby-lang.org/issues/13896) 