### PR TITLE
Improve Array#- efficiency 

### DIFF
--- a/array.c
+++ b/array.c
@@ -4163,7 +4163,7 @@ rb_ary_diff(VALUE ary1, VALUE ary2)
     ary2 = to_ary(ary2);
     ary3 = rb_ary_new();
 
-    if (RARRAY_LEN(ary2) <= SMALL_ARRAY_LEN) {
+    if (RARRAY_LEN(ary1) <= SMALL_ARRAY_LEN || RARRAY_LEN(ary2) <= SMALL_ARRAY_LEN) {
 	for (i=0; i<RARRAY_LEN(ary1); i++) {
 	    VALUE elt = rb_ary_elt(ary1, i);
 	    if (rb_ary_includes_by_eql(ary2, elt)) continue;


### PR DESCRIPTION
When doing the difference of a small array with a big one it is not efficient in both time and memory to convert the second one to a hash. It seems that the cost in both memory and time is not worthwhile if it is going to be used for too less elements.

For example, with the old code in my computer:

```
irb(main):001:0> def time(&block) puts Benchmark.measure(&block) end
=> :time

irb(main):002:0> time { a - (3..70000000).to_a }
 11.108770   0.719122  11.827892 ( 11.892380)
=> nil
irb(main):003:0> time { a - (3..70000000).to_a }
 11.429472   1.054554  12.484026 ( 12.522132)
=> nil
```

with the new one:

```
irb(main):004:0> time { a - (3..70000000).to_a }
  1.523477   0.059862   1.583339 (  1.648743)
=> nil
irb(main):005:0> time { a - (3..70000000).to_a }
  1.504628   0.067984   1.572612 (  1.629012)
=> nil

```
and even this one, which with the old version break my computer as it fulls the memory, works now:

```
irb(main):006:0> time { a - (3..100000000).to_a }
  2.161596   0.067738   2.229334 (  2.230705)
=> nil
```


This may be a very specific case, but it is an improvement anyway. :bowtie: 