### PR TITLE
Add #empty? to Tempfile, StringIO, File::Stat

### DIFF
--- a/ext/stringio/stringio.c
+++ b/ext/stringio/stringio.c
@@ -1760,6 +1760,23 @@ strio_size(VALUE self)
 
 /*
  * call-seq:
+ *   strio.empty? -> true or false
+ *
+ * Returns the true when there is no content.
+ */
+static VALUE
+strio_empty(VALUE self)
+{
+    VALUE string = StringIO(self)->string;
+    if (NIL_P(string)) {
+      rb_raise(rb_eIOError, "not opened");
+    }
+    if (RSTRING_LEN(string) == 0) { return Qtrue; }
+    return Qfalse;
+}
+
+/*
+ * call-seq:
  *   strio.truncate(integer)    -> 0
  *
  * Truncates the buffer string to at most _integer_ bytes. The stream
@@ -1973,6 +1990,7 @@ Init_stringio(void)
     rb_define_method(StringIO, "fileno", strio_fileno, 0);
     rb_define_method(StringIO, "size", strio_size, 0);
     rb_define_method(StringIO, "length", strio_size, 0);
+    rb_define_method(StringIO, "empty?", strio_empty, 0);
     rb_define_method(StringIO, "truncate", strio_truncate, 1);
 
     rb_define_method(StringIO, "external_encoding", strio_external_encoding, 0);

--- a/file.c
+++ b/file.c
@@ -7974,6 +7974,7 @@ Init_File(void)
     rb_define_method(rb_cStat, "executable_real?",  rb_stat_X, 0);
     rb_define_method(rb_cStat, "file?",  rb_stat_f, 0);
     rb_define_method(rb_cStat, "zero?",  rb_stat_z, 0);
+    rb_define_method(rb_cStat, "empty?",  rb_stat_z, 0);
     rb_define_method(rb_cStat, "size?",  rb_stat_s, 0);
     rb_define_method(rb_cStat, "owned?",  rb_stat_owned, 0);
     rb_define_method(rb_cStat, "grpowned?",  rb_stat_grpowned, 0);

--- a/lib/tempfile.rb
+++ b/lib/tempfile.rb
@@ -353,6 +353,11 @@ class Tempfile < DelegateClass(File)
   end
   alias length size
 
+  # Returns true if the file has no content.
+  def empty?
+    size.zero?
+  end
+
   # :stopdoc:
   def inspect
     if __getobj__.closed?

--- a/test/stringio/test_stringio.rb
+++ b/test/stringio/test_stringio.rb
@@ -792,6 +792,16 @@ class TestStringIO < Test::Unit::TestCase
     assert_equal(4, f.size)
   end
 
+  def test_empty_with_some_content
+    f = StringIO.new("1234")
+    assert !f.empty?
+  end
+
+  def test_empty_with_no_content
+    f = StringIO.new("")
+    assert f.empty?
+  end
+
   # This test is should in ruby/test_method.rb
   # However this test depends on stringio library,
   # we write it here.

--- a/test/test_tempfile.rb
+++ b/test/test_tempfile.rb
@@ -293,6 +293,20 @@ puts Tempfile.new('foo').path
     assert_equal 0, t.size
   end
 
+  def test_empty_on_empty_file
+    t = tempfile("foo")
+    t.write("")
+    t.close
+    assert t.empty?
+  end
+
+  def test_empty_on_file_with_some_content
+    t = tempfile("foo")
+    t.write("bar")
+    t.close
+    assert !t.empty?
+  end
+
   def test_concurrency
     threads = []
     tempfiles = []


### PR DESCRIPTION
Rubocop prefers `empty?` over `length == 0` and `size == 0`, which is great for String, Array, Hash, etc. It would be nice if more classes implemented `#empty?` for consistency.

See related discussion at https://github.com/bbatsov/rubocop/issues/2841

https://bugs.ruby-lang.org/issues/14136