### PR TITLE
Add Tau as a constant to math.c

### DIFF
--- a/math.c
+++ b/math.c
@@ -974,6 +974,9 @@ InitVM_Math(void)
     /*  Definition of the mathematical constant PI as a Float number. */
     rb_define_const(rb_mMath, "PI", DBL2NUM(M_PI));
 
+    /* Definition of the mathematical constant Tau as a Float number. */
+    rb_define_const(rb_mMath, "TAU", DBL2NUM(M_PI * 2));
+
 #ifdef M_E
     /*  Definition of the mathematical constant E (e) as a Float number. */
     rb_define_const(rb_mMath, "E", DBL2NUM(M_E));


### PR DESCRIPTION
Thank you for looking at my pull request!

I saw #644 from a couple of years ago, but I think it may be time to revisit adding the Tau constant to Ruby. Here is my reasoning:

* Comparable languages (such as Python) have [added it](https://tauday.com/state-of-the-tau)
* Tau simplifies many mathematical expressions (_e.g._ circumference can be expressed as τ * r instead of 2 * π * r)
* Ruby makes us happy and I think [Tau day](https://tauday.com/) can too 🙂

Please let me know if you have any questions or if there's anything else I can add to this pull request.