### PR TITLE
vm_core.h: Increase the Fiber stack size on powerpc64

### DIFF
--- a/vm_core.h
+++ b/vm_core.h
@@ -585,8 +585,12 @@ typedef struct rb_vm_struct {
 
 #define RUBY_VM_FIBER_VM_STACK_SIZE           (  16 * 1024 * sizeof(VALUE)) /*   64 KB or  128 KB */
 #define RUBY_VM_FIBER_VM_STACK_SIZE_MIN       (   2 * 1024 * sizeof(VALUE)) /*    8 KB or   16 KB */
-#define RUBY_VM_FIBER_MACHINE_STACK_SIZE      (  64 * 1024 * sizeof(VALUE)) /*  256 KB or  512 KB */
+#define RUBY_VM_FIBER_MACHINE_STACK_SIZE      (  64 * 1024 * sizeof(VALUE)) /*  256 KB or  512 KB */ 
+#if defined(__powerpc64__)
+#define RUBY_VM_FIBER_MACHINE_STACK_SIZE_MIN  (  32 * 1024 * sizeof(VALUE)) /*   128 KB or  256 KB */
+#else
 #define RUBY_VM_FIBER_MACHINE_STACK_SIZE_MIN  (  16 * 1024 * sizeof(VALUE)) /*   64 KB or  128 KB */
+#endif
 
 /* optimize insn */
 #define INTEGER_REDEFINED_OP_FLAG (1 << 0)


### PR DESCRIPTION
Currently the Fiber stack size is small for powerpc64 and it causes
test/ruby/test_backtrace.rb test to break, since it is using a 8kb stack
size.

It breaks on powerpc64 due to the fact that a frame in the stack is
usually 50% bigger on powerpc64 compared to Intel, due to some
considerations:

 * The powerpc64 minimum frame is 2x bigger than on Intel
 * Powerpc has more registers that might be saved in the frame compared
   to Intel.

I ran the same ruby test that is failing on both Intel and Powerpc, and
each Fiber frame is ~50% bigger on powerpc64 for every single lambda
function, thus, we need to increase the stack size on powerpc64 to
accomodate the same tests/applications.

This fixes bug#13757.

Signed-off-by: Breno Leitao <leitao@debian.org>