### PR TITLE
struct.c: show keyword_init: true on inspect

### DIFF
--- a/struct.c
+++ b/struct.c
@@ -295,6 +295,16 @@ define_aset_method(VALUE nstr, VALUE name, VALUE off)
 }
 
 static VALUE
+rb_struct_s_inspect(VALUE klass)
+{
+    VALUE inspect = rb_class_name(klass);
+    if (RTEST(struct_ivar_get(klass, id_keyword_init))) {
+	rb_str_cat_cstr(inspect, "(keyword_init: true)");
+    }
+    return inspect;
+}
+
+static VALUE
 setup_struct(VALUE nstr, VALUE members)
 {
     const VALUE *ptr_members;
@@ -306,6 +316,7 @@ setup_struct(VALUE nstr, VALUE members)
     rb_define_singleton_method(nstr, "new", rb_class_new_instance, -1);
     rb_define_singleton_method(nstr, "[]", rb_class_new_instance, -1);
     rb_define_singleton_method(nstr, "members", rb_struct_s_members_m, 0);
+    rb_define_singleton_method(nstr, "inspect", rb_struct_s_inspect, 0);
     ptr_members = RARRAY_CONST_PTR(members);
     len = RARRAY_LEN(members);
     for (i=0; i< len; i++) {

--- a/test/ruby/test_struct.rb
+++ b/test/ruby/test_struct.rb
@@ -102,6 +102,8 @@ module TestStruct
     assert_raise(ArgumentError) { @Struct::KeywordInitTrue.new(1, b: 2) }
     assert_raise(ArgumentError) { @Struct::KeywordInitTrue.new(a: 1, b: 2, c: 3) }
     assert_equal @Struct::KeywordInitTrue.new(a: 1, b: 2).values, @Struct::KeywordInitFalse.new(1, 2).values
+    assert_equal "#{@Struct}::KeywordInitFalse", @Struct::KeywordInitFalse.inspect
+    assert_equal "#{@Struct}::KeywordInitTrue(keyword_init: true)", @Struct::KeywordInitTrue.inspect
 
     @Struct.instance_eval do
       remove_const(:KeywordInitTrue)


### PR DESCRIPTION
This follows up https://github.com/ruby/ruby/pull/1771. 

This feature is suggested by @znz.