### PR TITLE
Requiring pp is not required now [ci skip]

### DIFF
--- a/lib/pp.rb
+++ b/lib/pp.rb
@@ -5,9 +5,6 @@ require 'prettyprint'
 ##
 # A pretty-printer for Ruby objects.
 #
-# All examples assume you have loaded the PP class with:
-#   require 'pp'
-#
 ##
 # == What PP Does
 #
@@ -560,4 +557,3 @@ module Kernel
   end
   module_function :pp
 end
-


### PR DESCRIPTION
- Followup of https://bugs.ruby-lang.org/issues/14123