### PR TITLE
Restore signal if previous/old signal was intructed to be ignored

### DIFF
--- a/signal.c
+++ b/signal.c
@@ -1250,8 +1250,11 @@ trap(int sig, sighandler_t func, VALUE command)
     switch (oldcmd) {
       case 0:
       case Qtrue:
-	if (oldfunc == SIG_IGN) oldcmd = rb_str_new2("IGNORE");
-        else if (oldfunc == SIG_DFL) oldcmd = rb_str_new2("SYSTEM_DEFAULT");
+	if (oldfunc == SIG_IGN){
+        // Restore old handler if it was previously instructed to be ignored.
+        oldcmd = rb_str_new2("IGNORE");
+        ruby_signal(sig, oldfunc);
+    } else if (oldfunc == SIG_DFL) oldcmd = rb_str_new2("SYSTEM_DEFAULT");
 	else if (oldfunc == sighandler) oldcmd = rb_str_new2("DEFAULT");
 	else oldcmd = Qnil;
 	break;

--- a/spec/ruby/core/signal/trap_spec.rb
+++ b/spec/ruby/core/signal/trap_spec.rb
@@ -112,6 +112,23 @@ platform_is_not :windows do
       Signal.trap :HUP, "IGNORE"
       Signal.trap(:HUP, "IGNORE").should == "IGNORE"
     end
+
+    it "respects 'IGNORE' on a process if such a signal already exits" do
+      pid = fork do
+        Signal.trap :HUP, "IGNORE"
+        Signal.trap :HUP, "DEFAULT"
+
+        sleep 10
+      end
+
+      lambda {
+        Process.detach(pid)
+        sleep 2
+        Process.kill(:HUP, pid)
+        sleep 2
+        Process.getpgid(pid)
+      }.should_not raise_error
+    end
   end
 end
 


### PR DESCRIPTION
This way, if a process already has a reserved `SIG_IGN` handler
the same will be respected, restored and return backed when an
attempt is being made to restored the same signal for a different
handler.

Issue at: https://bugs.ruby-lang.org/issues/14196