### PR TITLE
Fix ruby.h behaviour in old compilers: __builtin_choose_expr is different before 4.8.5

### DIFF
--- a/include/ruby/ruby.h
+++ b/include/ruby/ruby.h
@@ -35,6 +35,12 @@ extern "C" {
 
 #include "defines.h"
 
+/* __builtin_choose_expr has a different behavior befor gcc 4.8.5 
+* */
+#if !GCC_VERSION_SINCE(4,8,6)
+# undef HAVE_BUILTIN___BUILTIN_CHOOSE_EXPR_CONSTANT_P
+#endif
+
 #ifndef ASSUME
 # ifdef UNREACHABLE
 #   define ASSUME(x) (RB_LIKELY(!!(x)) ? (void)0 : UNREACHABLE)


### PR DESCRIPTION
When trying to install some native gems in a ruby-25-rc1 compiled using 4.8.5 (Centos 7 or Ubuntu 14.04) you get this error related to new functions in `ruby.h`

```
gem install nokogiri
Building native extensions. This could take a while...
ERROR:  Error installing nokogiri:
        ERROR: Failed to build gem native extension.
    current directory: /bitnami/rubystackDev-linux-x64/output/ruby/lib/ruby/gems/2.5.0/gems/nokogiri-1.8.1/ext/nokogiri
/bitnami/rubystackDev-linux-x64/output/ruby/bin/ruby -r ./siteconf20171218-47665-bs04dc.rb extconf.rb
checking if the C compiler accepts -fPIC -I/bitnami/rubystackDev-linux-x64/output/common/include -fPIC -I/bitnami/rubystackDev-linux-x64/output/common/include -I/bitnami/rubystackDe
v-linux-x64/output/common/include -fPIC -m64 -I/bitnami/rubystackDev-linux-x64/output/ImageMagick/include/ImageMagick-6 -I/bitnami/rubystackDev-linux-x64/output/ImageMagick/include/
ImageMagick-6/wand/ -I/bitnami/rubystackDev-linux-x64/output/ImageMagick/include/ImageMagick-6/MagickCore/ -I/bitnami/rubystackDev-linux-x64/output/ImageMagick/include/ImageMagick-6
 -I/bitnami/rubystackDev-linux-x64/output/ImageMagick/include/ImageMagick-6/wand/ -I/bitnami/rubystackDev-linux-x64/output/ImageMagick/include/ImageMagick-6/MagickCore/... yes
Building nokogiri using system libraries.
checking for xmlParseDoc() in libxml/parser.h... yes
checking for xsltParseStylesheetDoc() in libxslt/xslt.h... yes
checking for exsltFuncRegister() in libexslt/exslt.h... yes
checking for xmlHasFeature()... yes
checking for xmlFirstElementChild()... yes
checking for xmlRelaxNGSetParserStructuredErrors()... yes
checking for xmlRelaxNGSetParserStructuredErrors()... yes
checking for xmlRelaxNGSetValidStructuredErrors()... yes
checking for xmlSchemaSetValidStructuredErrors()... yes
checking for xmlSchemaSetParserStructuredErrors()... yes
creating Makefile
current directory: /bitnami/rubystackDev-linux-x64/output/ruby/lib/ruby/gems/2.5.0/gems/nokogiri-1.8.1/ext/nokogiri
make "DESTDIR=" clean
current directory: /bitnami/rubystackDev-linux-x64/output/ruby/lib/ruby/gems/2.5.0/gems/nokogiri-1.8.1/ext/nokogiri
make "DESTDIR="
compiling html_document.c
In file included from /bitnami/rubystackDev-linux-x64/output/ruby/include/ruby-2.5.0/ruby.h:33:0,
                 from ./nokogiri.h:33,
                 from ./html_document.h:4,
                 from html_document.c:1:
html_document.c: In function ‘new’:
/bitnami/rubystackDev-linux-x64/output/ruby/include/ruby-2.5.0/ruby/ruby.h:2222:12: warning: conversion to ‘int’ from ‘long unsigned int’ may alter its value [-Wconversion]
     ((varc)/(rb_scan_args_count(fmt, varc)))
            ^
/bitnami/rubystackDev-linux-x64/output/ruby/include/ruby-2.5.0/ruby/ruby.h:2230:11: note: in expansion of macro ‘rb_scan_args_verify_count’
  verify = rb_scan_args_verify_count(fmt, varc); \
           ^
/bitnami/rubystackDev-linux-x64/output/ruby/include/ruby-2.5.0/ruby/ruby.h:2345:9: note: in expansion of macro ‘rb_scan_args_verify’
        (rb_scan_args_verify(fmt, varc), vars))
         ^
/bitnami/rubystackDev-linux-x64/output/ruby/include/ruby-2.5.0/ruby/ruby.h:2172:9: note: in expansion of macro ‘rb_scan_args0’
         rb_scan_args0(argc,argvp,fmt,\
         ^
html_document.c:16:3: note: in expansion of macro ‘rb_scan_args’
   rb_scan_args(argc, argv, "0*", &rest);
   ^
In file included from /bitnami/rubystackDev-linux-x64/output/ruby/include/ruby-2.5.0/ruby.h:33:0,
                 from ./nokogiri.h:33,
                 from ./html_document.h:4,
                 from html_document.c:1:
html_document.c: In function ‘read_io’:
/bitnami/rubystackDev-linux-x64/output/ruby/include/ruby-2.5.0/ruby/ruby.h:1767:5: error: first argument to ‘__builtin_choose_expr’ not a constant
     __builtin_choose_expr(__builtin_constant_p(argc), \
     ^
/bitnami/rubystackDev-linux-x64/output/ruby/include/ruby-2.5.0/ruby/ruby.h:2464:6: note: in expansion of macro ‘rb_varargs_argc_check’
      rb_varargs_argc_check(rb_funcall_argc, rb_funcall_nargs), \
      ^
html_document.c:66:28: note: in expansion of macro ‘rb_funcall’
     VALUE encoding_found = rb_funcall(io, id_encoding_found, 0);
                            ^
make: *** [html_document.o] Error 1
make failed, exit code 2
Gem files will remain installed in /bitnami/rubystackDev-linux-x64/output/ruby/lib/ruby/gems/2.5.0/gems/nokogiri-1.8.1 for inspection.
Results logged to /bitnami/rubystackDev-linux-x64/output/ruby/lib/ruby/gems/2.5.0/extensions/x86_64-linux/2.5.0-static/nokogiri-1.8.1/gem_make.out
```

This patch just check GCC version and `undef` the conflicting part.
