### PR TITLE
24% reduction of compiled vm_exec_core function

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -2798,6 +2798,7 @@ vm.$(OBJEXT): {$(VPATH)}id.h
 vm.$(OBJEXT): {$(VPATH)}id_table.h
 vm.$(OBJEXT): {$(VPATH)}insns.def
 vm.$(OBJEXT): {$(VPATH)}insns.inc
+vm.$(OBJEXT): {$(VPATH)}insns_info.inc
 vm.$(OBJEXT): {$(VPATH)}intern.h
 vm.$(OBJEXT): {$(VPATH)}internal.h
 vm.$(OBJEXT): {$(VPATH)}io.h

--- a/compile.c
+++ b/compile.c
@@ -2954,9 +2954,9 @@ insn_set_specialized_instruction(rb_iseq_t *iseq, INSN *iobj, int insn_id)
 	VALUE *old_operands = iobj->operands;
 	iobj->operand_size = 4;
 	iobj->operands = (VALUE *)compile_data_alloc(iseq, iobj->operand_size * sizeof(VALUE));
-	iobj->operands[0] = old_operands[0];
+	iobj->operands[0] = (VALUE)new_callinfo(iseq, idEq, 1, 0, NULL, FALSE);
 	iobj->operands[1] = Qfalse; /* CALL_CACHE */
-	iobj->operands[2] = (VALUE)new_callinfo(iseq, idEq, 1, 0, NULL, FALSE);
+	iobj->operands[2] = old_operands[0];
 	iobj->operands[3] = Qfalse; /* CALL_CACHE */
     }
 
@@ -6092,9 +6092,9 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
 	    ISEQ_COMPILE_DATA(iseq)->option->specialized_instruction) {
 	    VALUE str = freeze_literal(iseq, node->nd_args->nd_head->nd_lit);
 	    CHECK(COMPILE(ret, "recv", node->nd_recv));
-	    ADD_INSN3(ret, line, opt_aref_with,
+	    ADD_INSN3(ret, line, opt_aref_with, str,
 		      new_callinfo(iseq, idAREF, 1, 0, NULL, FALSE),
-		      NULL/* CALL_CACHE */, str);
+		      NULL/* CALL_CACHE */);
 	    if (popped) {
 		ADD_INSN(ret, line, pop);
 	    }
@@ -7106,9 +7106,9 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
 		ADD_INSN(ret, line, swap);
 		ADD_INSN1(ret, line, topn, INT2FIX(1));
 	    }
-	    ADD_INSN3(ret, line, opt_aset_with,
+	    ADD_INSN3(ret, line, opt_aset_with, str,
 		      new_callinfo(iseq, idASET, 2, 0, NULL, FALSE),
-		      NULL/* CALL_CACHE */, str);
+		      NULL/* CALL_CACHE */);
 	    ADD_INSN(ret, line, pop);
 	    break;
 	}

--- a/insns.def
+++ b/insns.def
@@ -709,6 +709,7 @@ send
 (CALL_INFO ci, CALL_CACHE cc, ISEQ blockiseq)
 (...)
 (VALUE val)
+// attr bool handles_frame = true;
 // attr rb_snum_t sp_inc = - (int)(ci->orig_argc + ((ci->flag & VM_CALL_ARGS_BLOCKARG) ? 1 : 0));
 {
     struct rb_calling_info calling;
@@ -772,6 +773,7 @@ opt_send_without_block
 (CALL_INFO ci, CALL_CACHE cc)
 (...)
 (VALUE val)
+// attr bool handles_frame = true;
 // attr rb_snum_t sp_inc = -ci->orig_argc;
 {
     struct rb_calling_info calling;
@@ -786,6 +788,7 @@ invokesuper
 (CALL_INFO ci, CALL_CACHE cc, ISEQ blockiseq)
 (...)
 (VALUE val)
+// attr bool handles_frame = true;
 // attr rb_snum_t sp_inc = - (int)(ci->orig_argc + ((ci->flag & VM_CALL_ARGS_BLOCKARG) ? 1 : 0));
 {
     struct rb_calling_info calling;
@@ -803,6 +806,7 @@ invokeblock
 (CALL_INFO ci)
 (...)
 (VALUE val)
+// attr bool handles_frame = true;
 // attr rb_snum_t sp_inc = 1 - ci->orig_argc;
 {
     struct rb_calling_info calling;
@@ -1002,10 +1006,7 @@ opt_plus
     val = vm_opt_plus(recv, obj);
 
     if (val == Qundef) {
-	/* other */
-	PUSH(recv);
-	PUSH(obj);
-	CALL_SIMPLE_METHOD(recv);
+	DISPATCH_ORIGINAL_INSN(opt_send_without_block);
     }
 }
 
@@ -1019,10 +1020,7 @@ opt_minus
     val = vm_opt_minus(recv, obj);
 
     if (val == Qundef) {
-	/* other */
-	PUSH(recv);
-	PUSH(obj);
-	CALL_SIMPLE_METHOD(recv);
+	DISPATCH_ORIGINAL_INSN(opt_send_without_block);
     }
 }
 
@@ -1036,10 +1034,7 @@ opt_mult
     val = vm_opt_mult(recv, obj);
 
     if (val == Qundef) {
-	/* other */
-	PUSH(recv);
-	PUSH(obj);
-	CALL_SIMPLE_METHOD(recv);
+	DISPATCH_ORIGINAL_INSN(opt_send_without_block);
     }
 }
 
@@ -1053,10 +1048,7 @@ opt_div
     val = vm_opt_div(recv, obj);
 
     if (val == Qundef) {
-	/* other */
-	PUSH(recv);
-	PUSH(obj);
-	CALL_SIMPLE_METHOD(recv);
+	DISPATCH_ORIGINAL_INSN(opt_send_without_block);
     }
 }
 
@@ -1070,10 +1062,7 @@ opt_mod
     val = vm_opt_mod(recv, obj);
 
     if (val == Qundef) {
-	/* other */
-	PUSH(recv);
-	PUSH(obj);
-	CALL_SIMPLE_METHOD(recv);
+	DISPATCH_ORIGINAL_INSN(opt_send_without_block);
     }
 }
 
@@ -1087,10 +1076,7 @@ opt_eq
     val = opt_eq_func(recv, obj, ci, cc);
 
     if (val == Qundef) {
-	/* other */
-	PUSH(recv);
-	PUSH(obj);
-	CALL_SIMPLE_METHOD(recv);
+	DISPATCH_ORIGINAL_INSN(opt_send_without_block);
     }
 }
 
@@ -1100,6 +1086,7 @@ opt_neq
 (CALL_INFO ci, CALL_CACHE cc, CALL_INFO ci_eq, CALL_CACHE cc_eq)
 (VALUE recv, VALUE obj)
 (VALUE val)
+// attr bool handles_frame = true;
 {
     val = vm_opt_neq(ci, cc, ci_eq, cc_eq, recv, obj);
 
@@ -1121,10 +1108,7 @@ opt_lt
     val = vm_opt_lt(recv, obj);
 
     if (val == Qundef) {
-	/* other */
-	PUSH(recv);
-	PUSH(obj);
-	CALL_SIMPLE_METHOD(recv);
+	DISPATCH_ORIGINAL_INSN(opt_send_without_block);
     }
 }
 
@@ -1138,10 +1122,7 @@ opt_le
     val = vm_opt_le(recv, obj);
 
     if (val == Qundef) {
-	/* other */
-	PUSH(recv);
-	PUSH(obj);
-	CALL_SIMPLE_METHOD(recv);
+	DISPATCH_ORIGINAL_INSN(opt_send_without_block);
     }
 }
 
@@ -1155,10 +1136,7 @@ opt_gt
     val = vm_opt_gt(recv, obj);
 
     if (val == Qundef) {
-	/* other */
-	PUSH(recv);
-	PUSH(obj);
-	CALL_SIMPLE_METHOD(recv);
+	DISPATCH_ORIGINAL_INSN(opt_send_without_block);
     }
 }
 
@@ -1172,10 +1150,7 @@ opt_ge
     val = vm_opt_ge(recv, obj);
 
     if (val == Qundef) {
-	/* other */
-	PUSH(recv);
-	PUSH(obj);
-	CALL_SIMPLE_METHOD(recv);
+	DISPATCH_ORIGINAL_INSN(opt_send_without_block);
     }
 }
 
@@ -1189,10 +1164,7 @@ opt_ltlt
     val = vm_opt_ltlt(recv, obj);
 
     if (val == Qundef) {
-	/* other */
-	PUSH(recv);
-	PUSH(obj);
-	CALL_SIMPLE_METHOD(recv);
+	DISPATCH_ORIGINAL_INSN(opt_send_without_block);
     }
 }
 
@@ -1206,10 +1178,7 @@ opt_aref
     val = vm_opt_aref(recv, obj);
 
     if (val == Qundef) {
-	/* other */
-	PUSH(recv);
-	PUSH(obj);
-	CALL_SIMPLE_METHOD(recv);
+	DISPATCH_ORIGINAL_INSN(opt_send_without_block);
     }
 }
 
@@ -1223,11 +1192,7 @@ opt_aset
     val = vm_opt_aset(recv, obj, set);
 
     if (val == Qundef) {
-	/* other */
-	PUSH(recv);
-	PUSH(obj);
-	PUSH(set);
-	CALL_SIMPLE_METHOD(recv);
+	DISPATCH_ORIGINAL_INSN(opt_send_without_block);
     }
 }
 
@@ -1237,6 +1202,7 @@ opt_aset_with
 (CALL_INFO ci, CALL_CACHE cc, VALUE key)
 (VALUE recv, VALUE val)
 (VALUE val)
+// attr bool handles_frame = true;
 {
     VALUE tmp = vm_opt_aset_with(recv, key, val);
 
@@ -1258,6 +1224,7 @@ opt_aref_with
 (CALL_INFO ci, CALL_CACHE cc, VALUE key)
 (VALUE recv)
 (VALUE val)
+// attr bool handles_frame = true;
 {
     val = vm_opt_aref_with(recv, key);
 
@@ -1279,9 +1246,7 @@ opt_length
     val = vm_opt_length(recv, BOP_LENGTH);
 
     if (val == Qundef) {
-	/* other */
-	PUSH(recv);
-	CALL_SIMPLE_METHOD(recv);
+	DISPATCH_ORIGINAL_INSN(opt_send_without_block);
     }
 }
 
@@ -1295,9 +1260,7 @@ opt_size
     val = vm_opt_length(recv, BOP_SIZE);
 
     if (val == Qundef) {
-	/* other */
-	PUSH(recv);
-	CALL_SIMPLE_METHOD(recv);
+	DISPATCH_ORIGINAL_INSN(opt_send_without_block);
     }
 }
 
@@ -1311,9 +1274,7 @@ opt_empty_p
     val = vm_opt_empty_p(recv);
 
     if (val == Qundef) {
-	/* other */
-	PUSH(recv);
-	CALL_SIMPLE_METHOD(recv);
+	DISPATCH_ORIGINAL_INSN(opt_send_without_block);
     }
 }
 
@@ -1327,9 +1288,7 @@ opt_succ
     val = vm_opt_succ(recv);
 
     if (val == Qundef) {
-	/* other */
-	PUSH(recv);
-	CALL_SIMPLE_METHOD(recv);
+	DISPATCH_ORIGINAL_INSN(opt_send_without_block);
     }
 }
 
@@ -1343,9 +1302,7 @@ opt_not
     val = vm_opt_not(ci, cc, recv);
 
     if (val == Qundef) {
-	/* other */
-	PUSH(recv);
-	CALL_SIMPLE_METHOD(recv);
+	DISPATCH_ORIGINAL_INSN(opt_send_without_block);
     }
 }
 
@@ -1369,10 +1326,7 @@ opt_regexpmatch2
     val = vm_opt_regexpmatch2(obj2, obj1);
 
     if (val == Qundef) {
-	/* other */
-	PUSH(obj2);
-	PUSH(obj1);
-	CALL_SIMPLE_METHOD(obj2);
+	DISPATCH_ORIGINAL_INSN(opt_send_without_block);
     }
 }
 

--- a/insns.def
+++ b/insns.def
@@ -1083,18 +1083,15 @@ opt_eq
 /* optimized X!=Y. */
 DEFINE_INSN
 opt_neq
-(CALL_INFO ci, CALL_CACHE cc, CALL_INFO ci_eq, CALL_CACHE cc_eq)
+(CALL_INFO ci_eq, CALL_CACHE cc_eq, CALL_INFO ci, CALL_CACHE cc)
 (VALUE recv, VALUE obj)
 (VALUE val)
-// attr bool handles_frame = true;
 {
     val = vm_opt_neq(ci, cc, ci_eq, cc_eq, recv, obj);
 
     if (val == Qundef) {
-	/* other */
-	PUSH(recv);
-	PUSH(obj);
-	CALL_SIMPLE_METHOD(recv);
+	ADD_PC(2); /* !!! */
+	DISPATCH_ORIGINAL_INSN(opt_send_without_block);
     }
 }
 
@@ -1199,10 +1196,9 @@ opt_aset
 /* recv[str] = set */
 DEFINE_INSN
 opt_aset_with
-(CALL_INFO ci, CALL_CACHE cc, VALUE key)
+(VALUE key, CALL_INFO ci, CALL_CACHE cc)
 (VALUE recv, VALUE val)
 (VALUE val)
-// attr bool handles_frame = true;
 {
     VALUE tmp = vm_opt_aset_with(recv, key, val);
 
@@ -1210,29 +1206,26 @@ opt_aset_with
 	val = tmp;
     }
     else {
-	/* other */
-	PUSH(recv);
-	PUSH(rb_str_resurrect(key));
+	TOPN(0) = rb_str_resurrect(key);
 	PUSH(val);
-	CALL_SIMPLE_METHOD(recv);
+	ADD_PC(1); /* !!! */
+	DISPATCH_ORIGINAL_INSN(opt_send_without_block);
     }
 }
 
 /* recv[str] */
 DEFINE_INSN
 opt_aref_with
-(CALL_INFO ci, CALL_CACHE cc, VALUE key)
+(VALUE key, CALL_INFO ci, CALL_CACHE cc)
 (VALUE recv)
 (VALUE val)
-// attr bool handles_frame = true;
 {
     val = vm_opt_aref_with(recv, key);
 
     if (val == Qundef) {
-	/* other */
-	PUSH(recv);
 	PUSH(rb_str_resurrect(key));
-	CALL_SIMPLE_METHOD(recv);
+	ADD_PC(1); /* !!! */
+	DISPATCH_ORIGINAL_INSN(opt_send_without_block);
     }
 }
 

--- a/insns.def
+++ b/insns.def
@@ -366,7 +366,6 @@ concatstrings
 // attr rb_snum_t sp_inc = 1 - num;
 {
     val = rb_str_concat_literals(num, STACK_ADDR_FROM_TOP(num));
-    POPN(num);
 }
 
 /* push the result of to_s. */
@@ -403,7 +402,6 @@ toregexp
     VALUE rb_reg_new_ary(VALUE ary, int options);
     VALUE rb_ary_tmp_new_from_values(VALUE, long, const VALUE *);
     const VALUE ary = rb_ary_tmp_new_from_values(0, cnt, STACK_ADDR_FROM_TOP(cnt));
-    POPN(cnt);
     val = rb_reg_new_ary(ary, (int)opt);
     rb_ary_clear(ary);
 }
@@ -427,7 +425,6 @@ newarray
 // attr rb_snum_t sp_inc = 1 - num;
 {
     val = rb_ary_new4(num, STACK_ADDR_FROM_TOP(num));
-    POPN(num);
 }
 
 /* dup array */
@@ -494,7 +491,6 @@ newhash
     if (num) {
         rb_hash_bulk_insert(num, STACK_ADDR_FROM_TOP(num), val);
     }
-    POPN(num);
 }
 
 /* put new Range object.(Range.new(low, high, flag)) */
@@ -545,6 +541,7 @@ dupn
 
     INC_SP(n); /* alloca */
     MEMCPY(dst, src, VALUE, n);
+    DEC_SP(n);
 }
 
 /* swap top 2 vals */
@@ -606,7 +603,7 @@ setn
 (VALUE val)
 // attr rb_snum_t sp_inc = 0;
 {
-    TOPN(n-1) = val;
+    TOPN(n) = val;
 }
 
 /* empty current stack */
@@ -617,7 +614,7 @@ adjuststack
 (...)
 // attr rb_snum_t sp_inc = -(rb_snum_t)n;
 {
-    DEC_SP(n);
+    /* none */
 }
 
 /**********************************************************/
@@ -757,7 +754,6 @@ opt_newarray_max
 // attr rb_snum_t sp_inc = 1 - num;
 {
     val = vm_opt_newarray_max(num, STACK_ADDR_FROM_TOP(num));
-    POPN(num);
 }
 
 DEFINE_INSN
@@ -768,7 +764,6 @@ opt_newarray_min
 // attr rb_snum_t sp_inc = 1 - num;
 {
     val = vm_opt_newarray_min(num, STACK_ADDR_FROM_TOP(num));
-    POPN(num);
 }
 
 /* Invoke method without block */

--- a/tool/ruby_vm/models/bare_instructions.rb
+++ b/tool/ruby_vm/models/bare_instructions.rb
@@ -69,9 +69,11 @@ class RubyVM::BareInstructions
     return @variables                                        \
       . values                                               \
       . group_by {|h| h[:type] }                             \
+      . sort_by  {|t, v| t }                                 \
       . map      {|t, v| [t, v.map {|i| i[:name] }.sort ] }  \
-      . map      {|t, v| sprintf("%s %s", t, v.join(', ')) } \
-      . sort
+      . map      {|t, v|
+        sprintf("MAYBE_UNUSED(%s) %s", t, v.join(', '))
+      }
   end
 
   def preamble
@@ -127,8 +129,7 @@ class RubyVM::BareInstructions
     generate_attribute 'rb_num_t', 'retn', rets.size
     generate_attribute 'rb_num_t', 'width', width
     generate_attribute 'rb_num_t', 'sp_inc', rets.size - pops.size
-    generate_attribute 'bool', 'handles_frame', \
-      opes.any? {|o| /CALL_INFO/ =~ o[:type] }
+    generate_attribute 'bool', 'handles_frame', false
   end
 
   def typesplit a

--- a/tool/ruby_vm/views/_insn_entry.erb
+++ b/tool/ruby_vm/views/_insn_entry.erb
@@ -19,7 +19,6 @@ INSN_ENTRY(<%= insn.name %>)
 % insn.preamble.each do |konst|
 <%= render_c_expr konst -%>
 % end
-%
 % insn.opes.each_with_index do |ope, i|
     <%= ope[:name] %> = (<%= ope[:type] %>)GET_OPERAND(<%= i + 1 %>);
 % end
@@ -30,8 +29,6 @@ INSN_ENTRY(<%= insn.name %>)
     DEBUG_ENTER_INSN(INSN_ATTR(name));
 % if insn.handles_frame?
     ADD_PC(INSN_ATTR(width));
-% end
-% unless insn.pops.empty?
     POPN(INSN_ATTR(popn));
 % end
     COLLECT_USAGE_INSN(INSN_ATTR(bin));
@@ -39,13 +36,16 @@ INSN_ENTRY(<%= insn.name %>)
     COLLECT_USAGE_OPERAND(INSN_ATTR(bin), <%= i %>, <%= ope[:name] %>);
 % end
 <%= render_c_expr insn.expr -%>
-% unless insn.rets.empty?
     CHECK_VM_STACK_OVERFLOW_FOR_INSN(VM_REG_CFP, INSN_ATTR(retn));
-%   insn.rets.each_with_index do |ret, i|
+% if insn.handles_frame?
+%   insn.rets.reverse_each do |ret|
     PUSH(<%= insn.cast_to_VALUE ret %>);
 %   end
-% end
-% unless insn.handles_frame?
+% else
+    ADJ_SP(INSN_ATTR(sp_inc));
+%   insn.rets.reverse_each.with_index do |ret, i|
+    TOPN(<%= i %>) = <%= insn.cast_to_VALUE ret %>;
+%   end
     ADD_PC(INSN_ATTR(width));
     PREFETCH(GET_PC());
 % end

--- a/tool/ruby_vm/views/_insn_entry.erb
+++ b/tool/ruby_vm/views/_insn_entry.erb
@@ -8,9 +8,9 @@
 %;
 
 /* insn <%= insn.pretty_name %> */
-#define NAME_OF_CURRENT_INSN <%= insn.name %>
 INSN_ENTRY(<%= insn.name %>)
 {
+#   define INSN_ATTR(x) <%= insn.call_attribute(' ## x ## ') %>
 % unless insn.declarations.empty?
     <%= insn.declarations.join(";\n    ") %>;
 
@@ -27,28 +27,28 @@ INSN_ENTRY(<%= insn.name %>)
 % insn.pops.reverse_each.with_index.reverse_each do |pop, i|
     <%= pop[:name] %> = <%= insn.cast_from_VALUE pop, "TOPN(#{i})"%>;
 % end
-    DEBUG_ENTER_INSN(<%=cstr insn.name %>);
+    DEBUG_ENTER_INSN(INSN_ATTR(name));
 % if insn.handles_frame?
-    ADD_PC(<%= insn.width %>);
+    ADD_PC(INSN_ATTR(width));
 % end
 % unless insn.pops.empty?
-    POPN(<%= insn.pops.size %>);
+    POPN(INSN_ATTR(popn));
 % end
-    COLLECT_USAGE_INSN(<%= insn.bin %>);
+    COLLECT_USAGE_INSN(INSN_ATTR(bin));
 % insn.opes.each_with_index do |ope, i|
-    COLLECT_USAGE_OPERAND(<%= insn.bin %>, <%= i %>, <%= ope[:name] %>);
+    COLLECT_USAGE_OPERAND(INSN_ATTR(bin), <%= i %>, <%= ope[:name] %>);
 % end
 <%= render_c_expr insn.expr -%>
 % unless insn.rets.empty?
-    CHECK_VM_STACK_OVERFLOW_FOR_INSN(VM_REG_CFP, <%= insn.rets.size %>);
+    CHECK_VM_STACK_OVERFLOW_FOR_INSN(VM_REG_CFP, INSN_ATTR(retn));
 %   insn.rets.each_with_index do |ret, i|
     PUSH(<%= insn.cast_to_VALUE ret %>);
 %   end
 % end
 % unless insn.handles_frame?
-    ADD_PC(<%= insn.width %>);
+    ADD_PC(INSN_ATTR(width));
     PREFETCH(GET_PC());
 % end
     END_INSN(<%= insn.name %>);
+#   undef INSN_ATTR
 }
-#undef NAME_OF_CURRENT_INSN

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1235,7 +1235,7 @@ vm_expandarray(rb_control_frame_t *cfp, VALUE ary, rb_num_t num, int flag)
 {
     int is_splat = flag & 0x01;
     rb_num_t space_size = num + is_splat;
-    VALUE *base = cfp->sp;
+    VALUE *base = cfp->sp - 1;
     const VALUE *ptr;
     rb_num_t len;
     const VALUE obj = ary;
@@ -1249,8 +1249,6 @@ vm_expandarray(rb_control_frame_t *cfp, VALUE ary, rb_num_t num, int flag)
 	ptr = RARRAY_CONST_PTR(ary);
 	len = (rb_num_t)RARRAY_LEN(ary);
     }
-
-    cfp->sp += space_size;
 
     if (flag & 0x02) {
 	/* post: ..., nil ,ary[-1], ..., ary[0..-num] # top */

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -10,6 +10,7 @@
 
 /* finish iseq array */
 #include "insns.inc"
+#include "insns_info.inc"
 #include <math.h>
 #include "constant.h"
 #include "internal.h"

--- a/vm_insnhelper.h
+++ b/vm_insnhelper.h
@@ -101,6 +101,22 @@ enum vm_regan_acttype {
 #define DEC_SP(x)  (VM_REG_SP -= (COLLECT_USAGE_REGISTER_HELPER(SP, SET, (x))))
 #define SET_SV(x)  (*GET_SP() = (x))
   /* set current stack value as x */
+#ifdef _MSC_VER
+/* Workaround needed for adding negative number to a pointer */
+#define ADJ_SP(x)  do { \
+    rb_snum_t adj = (x); \
+    if (adj >= 0) { \
+        INC_SP(adj); \
+    } \
+    else { \
+        SIGNED_VALUE dec = -1; \
+        dec *= adj; \
+        DEC_SP(dec); \
+    } \
+} while (0)
+#else
+#define ADJ_SP(x)  INC_SP(x)
+#endif
 
 /* instruction sequence C struct */
 #define GET_ISEQ() (GET_CFP()->iseq)

--- a/vm_insnhelper.h
+++ b/vm_insnhelper.h
@@ -194,14 +194,6 @@ enum vm_regan_acttype {
 #define USE_IC_FOR_SPECIALIZED_METHOD 1
 #endif
 
-#define CALL_SIMPLE_METHOD(recv_) do { \
-    struct rb_calling_info calling; \
-    calling.block_handler = VM_BLOCK_HANDLER_NONE; \
-    calling.argc = ci->orig_argc; \
-    vm_search_method(ci, cc, calling.recv = (recv_)); \
-    CALL_METHOD(&calling, ci, cc); \
-} while (0)
-
 #define NEXT_CLASS_SERIAL() (++ruby_vm_class_serial)
 #define GET_GLOBAL_METHOD_STATE() (ruby_vm_global_method_state)
 #define INC_GLOBAL_METHOD_STATE() (++ruby_vm_global_method_state)


### PR DESCRIPTION
By carefully arranging PC and SP manipulations, this changeset reduces the binary size of vm_exec_core from 37,040 bytes to 28,304 bytes on my machine.

For instance, instruction `opt_plus` changes like this (indentation modified):

```diff
--- trunk/vm.inc:opt_plus	2017-12-22 16:07:21.000000000 +0900
+++ ours/vm.inc:opt_plus	2017-12-22 16:07:18.000000000 +0900
@@ -1,32 +1,30 @@
 INSN_ENTRY(opt_plus){
+    MAYBE_UNUSED(CALL_CACHE) cc;
+    MAYBE_UNUSED(CALL_INFO) ci;
+    MAYBE_UNUSED(VALUE) obj, recv, val;
+
     START_OF_ORIGINAL_INSN(opt_plus);
-    {
-    VALUE val;
-    CALL_CACHE cc = (CALL_CACHE)GET_OPERAND(2);
-    CALL_INFO ci = (CALL_INFO)GET_OPERAND(1);
-    VALUE recv = TOPN(1);
-    VALUE obj = TOPN(0);
+    ci = (CALL_INFO)GET_OPERAND(1);
+    cc = (CALL_CACHE)GET_OPERAND(2);
+    recv = TOPN(1);
+    obj = TOPN(0);
     DEBUG_ENTER_INSN("opt_plus");
-    ADD_PC(1+2);
-    PREFETCH(GET_PC());
-    POPN(2);
     COLLECT_USAGE_INSN(BIN(opt_plus));
     COLLECT_USAGE_OPERAND(BIN(opt_plus), 0, ci);
     COLLECT_USAGE_OPERAND(BIN(opt_plus), 1, cc);
     {
 #line nnnn "insns.def"
     val = vm_opt_plus(recv, obj);
 
     if (val == Qundef) {
-        /* other */
-        PUSH(recv);
-        PUSH(obj);
-        CALL_SIMPLE_METHOD(recv);
+        DISPATCH_ORIGINAL_INSN(opt_send_without_block);
     }
 #line nnnn "vm.inc"
     }
+    ADD_PC(3);
+    PREFETCH(GET_PC());
+    ADJ_SP(-1);
+    TOPN(0) = val;
     CHECK_VM_STACK_OVERFLOW_FOR_INSN(VM_REG_CFP, 1);
-    PUSH(val);
     END_INSN(opt_plus);
-    }
 }
```

Here you can see the `ADD_PC` and `POPN` / `INC_SP` macros moved from the prelude of the instruction to the finale.  This makes it possible to replace `CALL_SIMPLE_METHOD(recv)` with `DISPATCH_ORIGINAL_INSN(opt_send_without_block)`.  These two macros differ in size very much and results in this big difference in compiled binary size.

And here you are the benchmark results:

![screen shot 2017-12-22 at 14 10 53](https://user-images.githubusercontent.com/15377/34289337-63f4921e-e735-11e7-9964-8440f53f2568.png)

<details>
```
Elapsed time: 347.98301 (sec)
-----------------------------------------------------------
benchmark results:
minimum results in each 3 measurements.
Execution time (sec)
name	2.4	trunk	ours
so_ackermann	0.521	0.479	0.475
so_array	0.843	0.952	0.810
so_binary_trees	6.277	6.304	5.971
so_concatenate	4.758	4.475	3.752
so_count_words	0.171	0.171	0.172
so_exception	0.303	0.269	0.265
so_fannkuch	1.153	1.103	1.078
so_fasta	1.712	1.655	1.596
so_k_nucleotide	1.312	1.311	1.316
so_lists	0.534	0.506	0.520
so_mandelbrot	2.661	2.851	2.412
so_matrix	0.556	0.579	0.491
so_meteor_contest	3.263	3.318	3.126
so_nbody	1.470	1.537	1.561
so_nested_loop	1.310	1.370	1.151
so_nsieve	1.782	1.804	1.771
so_nsieve_bits	2.427	2.425	2.343
so_object	0.806	0.755	0.753
so_partial_sums	1.867	2.064	2.054
so_pidigits	1.192	1.179	1.175
so_random	0.420	0.409	0.388
so_reverse_complement	0.609	0.610	0.578
so_sieve	0.501	0.514	0.522
so_spectralnorm	1.876	1.984	1.812

Speedup ratio: compare with the result of `2.4' (greater is better)
name	trunk	ours
so_ackermann	1.087	1.097
so_array	0.886	1.041
so_binary_trees	0.996	1.051
so_concatenate	1.063	1.268
so_count_words	0.999	0.992
so_exception	1.128	1.142
so_fannkuch	1.046	1.069
so_fasta	1.035	1.073
so_k_nucleotide	1.000	0.997
so_lists	1.054	1.027
so_mandelbrot	0.933	1.103
so_matrix	0.960	1.131
so_meteor_contest	0.983	1.044
so_nbody	0.957	0.942
so_nested_loop	0.957	1.138
so_nsieve	0.988	1.006
so_nsieve_bits	1.001	1.036
so_object	1.067	1.070
so_partial_sums	0.905	0.909
so_pidigits	1.011	1.015
so_random	1.029	1.083
so_reverse_complement	1.000	1.055
so_sieve	0.974	0.960
so_spectralnorm	0.945	1.035
```
</details>
