### PR TITLE
Use UINT128_T support flag from configure

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -230,7 +230,7 @@ static const uint64_t prime2 = ((uint64_t)0xcdb32970 << 32) | 0x830fcaa1;
 static inline uint64_t
 mult_and_mix(uint64_t m1, uint64_t m2)
 {
-#if defined(__GNUC__) && UINT_MAX != ULONG_MAX
+#if defined HAVE_UINT128_T
     __uint128_t r = (__uint128_t) m1 * (__uint128_t) m2;
     return (uint64_t) (r >> 64) ^ (uint64_t) r;
 #else


### PR DESCRIPTION
Current check for __uint128_t in hash.c is not valid, since it ignores
compilers other than gcc. We hit this on lcc on e2k platform.

Configure script properly checks from 128-bit data types support and
sets HAVE_UINT128_T accordingly. This approach is already used within
ruby at bignum.c, random.c, etc.

Probably hash.c is an overlooked remnant of old days. This patch fixes
this.