### PR TITLE
Improve Prime:prime? algorithm up to 4 times faster

### DIFF
--- a/array.c
+++ b/array.c
@@ -4953,7 +4953,7 @@ rb_ary_sample(int argc, VALUE *argv, VALUE ary)
 	long max_idx = 0;
 #undef RUBY_UNTYPED_DATA_WARNING
 #define RUBY_UNTYPED_DATA_WARNING 0
-	VALUE vmemo = Data_Wrap_Struct(0, 0, 0, st_free_table);
+	VALUE vmemo = Data_Wrap_Struct(0, 0, st_free_table, 0);
 	st_table *memo = st_init_numtable_with_size(n);
 	DATA_PTR(vmemo) = memo;
 	result = rb_ary_new_capa(n);

--- a/compile.c
+++ b/compile.c
@@ -7985,7 +7985,11 @@ struct ibf_id_entry {
 	ibf_id_enc_ascii,
 	ibf_id_enc_utf8,
 	ibf_id_enc_other
-    } enc : 2;
+    } enc
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)
+    : 2
+#endif
+    ;
     char body[1];
 };
 

--- a/dln.c
+++ b/dln.c
@@ -22,6 +22,7 @@
 static void dln_loaderror(const char *format, ...);
 #endif
 #include "dln.h"
+#include "internal.h"
 
 #ifdef HAVE_STDLIB_H
 # include <stdlib.h>

--- a/dln.c
+++ b/dln.c
@@ -1242,6 +1242,27 @@ rb_w32_check_imported(HMODULE ext, HMODULE mine)
 #define translit_separator(str) (void)(str)
 #endif
 
+MAYBE_UNUSED(static bool xmalloc_mismatch_p(void *handle));
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__) && (__GNUC__ >= 5)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+bool
+xmalloc_mismatch_p(void *handle)
+{
+    void *ex = dlsym(handle, EXTERNAL_PREFIX"ruby_xmalloc");
+    return ex && ex != ruby_xmalloc;
+}
+#ifdef __clang__
+#pragma clang diagnostic pop
+#elif defined(__GNUC__) && (__GNUC__ >= 5)
+#pragma GCC diagnostic pop
+#endif
+
 void*
 dln_load(const char *file)
 {
@@ -1329,8 +1350,7 @@ dln_load(const char *file)
 	}
 # if defined RUBY_EXPORT
 	{
-	    void *ex = dlsym(handle, EXTERNAL_PREFIX"ruby_xmalloc");
-	    if (ex && ex != ruby_xmalloc) {
+	    if (xmalloc_mismatch_p(handle)) {
 
 #   if defined __APPLE__ && \
     defined(MAC_OS_X_VERSION_MIN_REQUIRED) && \

--- a/eval_error.c
+++ b/eval_error.c
@@ -220,7 +220,7 @@ void
 rb_ec_error_print(rb_execution_context_t * volatile ec, volatile VALUE errinfo)
 {
     volatile int raised_flag = ec->raised_flag;
-    volatile VALUE errat;
+    volatile VALUE errat = Qundef;
 
     if (NIL_P(errinfo))
 	return;

--- a/ext/-test-/memory_status/memory_status.c
+++ b/ext/-test-/memory_status/memory_status.c
@@ -32,6 +32,10 @@ read_status(VALUE self)
     error = task_info(mach_task_self(), flavor,
 		      (task_info_t)&taskinfo, &out_count);
     if (error != KERN_SUCCESS) return Qnil;
+#ifndef ULL2NUM
+/* "long long" does not exist here, use size_t instead.  */
+#define ULL2NUM SIZET2NUM
+#endif
     size = ULL2NUM(taskinfo.virtual_size);
     rss = ULL2NUM(taskinfo.resident_size);
     rb_struct_aset(self, INT2FIX(1), rss);

--- a/ext/bigdecimal/bigdecimal.h
+++ b/ext/bigdecimal/bigdecimal.h
@@ -227,7 +227,9 @@ extern VALUE rb_cBigDecimal;
 #define VP_SIGN_POSITIVE_INFINITE  3 /* Positive infinite number */
 #define VP_SIGN_NEGATIVE_INFINITE -3 /* Negative infinite number */
 
-#ifdef __GNUC__
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)
+#define	FLEXIBLE_ARRAY_SIZE /* */
+#elif defined(__GNUC__) && !defined(__STRICT_ANSI__)
 #define	FLEXIBLE_ARRAY_SIZE 0
 #else
 #define	FLEXIBLE_ARRAY_SIZE 1

--- a/gc.c
+++ b/gc.c
@@ -9359,7 +9359,7 @@ rb_raw_obj_info(char *buff, const int buff_size, VALUE obj)
 	    break;
 	  }
 	  case T_IMEMO: {
-	    const char *imemo_name;
+	    const char *imemo_name = "\0";
 	    switch (imemo_type(obj)) {
 #define IMEMO_NAME(x) case imemo_##x: imemo_name = #x; break;
 		IMEMO_NAME(env);

--- a/gc.c
+++ b/gc.c
@@ -3526,11 +3526,11 @@ gc_page_sweep(rb_objspace_t *objspace, rb_heap_t *heap, struct heap_page *sweep_
 		if (bitset & 1) {
 		    switch (BUILTIN_TYPE(p)) {
 		      default: { /* majority case */
-			  gc_report(2, objspace, "page_sweep: free %s\n", obj_info((VALUE)p));
+			  gc_report(2, objspace, "page_sweep: free %p\n", (void *)p);
 #if USE_RGENGC && RGENGC_CHECK_MODE
 			  if (!is_full_marking(objspace)) {
-			      if (RVALUE_OLD_P((VALUE)p)) rb_bug("page_sweep: %s - old while minor GC.", obj_info((VALUE)p));
-			      if (rgengc_remembered(objspace, (VALUE)p)) rb_bug("page_sweep: %s - remembered.", obj_info((VALUE)p));
+			      if (RVALUE_OLD_P((VALUE)p)) rb_bug("page_sweep: %p - old while minor GC.", (void *)p);
+			      if (rgengc_remembered(objspace, (VALUE)p)) rb_bug("page_sweep: %p - remembered.", (void *)p);
 			  }
 #endif
 			  if (obj_free(objspace, (VALUE)p)) {

--- a/gc.c
+++ b/gc.c
@@ -9272,10 +9272,11 @@ rb_raw_iseq_info(char *buff, const int buff_size, const rb_iseq_t *iseq)
 {
     if (iseq->body && iseq->body->location.label) {
 	VALUE path = rb_iseq_path(iseq);
+	VALUE n = iseq->body->location.first_lineno;
 	snprintf(buff, buff_size, "%s %s@%s:%d", buff,
 		 RSTRING_PTR(iseq->body->location.label),
 		 RSTRING_PTR(path),
-		 FIX2INT(iseq->body->location.first_lineno));
+		 n ? FIX2INT(n) : 0 );
     }
 }
 

--- a/gc.c
+++ b/gc.c
@@ -9270,7 +9270,7 @@ method_type_name(rb_method_type_t type)
 static void
 rb_raw_iseq_info(char *buff, const int buff_size, const rb_iseq_t *iseq)
 {
-    if (iseq->body->location.label) {
+    if (iseq->body && iseq->body->location.label) {
 	VALUE path = rb_iseq_path(iseq);
 	snprintf(buff, buff_size, "%s %s@%s:%d", buff,
 		 RSTRING_PTR(iseq->body->location.label),

--- a/gc.c
+++ b/gc.c
@@ -5960,18 +5960,18 @@ NOINLINE(static void gc_writebarrier_incremental(VALUE a, VALUE b, rb_objspace_t
 static void
 gc_writebarrier_incremental(VALUE a, VALUE b, rb_objspace_t *objspace)
 {
-    gc_report(2, objspace, "gc_writebarrier_incremental: [LG] %s -> %s\n", obj_info(a), obj_info(b));
+    gc_report(2, objspace, "gc_writebarrier_incremental: [LG] %p -> %s\n", (void *)a, obj_info(b));
 
     if (RVALUE_BLACK_P(a)) {
 	if (RVALUE_WHITE_P(b)) {
 	    if (!RVALUE_WB_UNPROTECTED(a)) {
-		gc_report(2, objspace, "gc_writebarrier_incremental: [IN] %s -> %s\n", obj_info(a), obj_info(b));
+		gc_report(2, objspace, "gc_writebarrier_incremental: [IN] %p -> %s\n", (void *)a, obj_info(b));
 		gc_mark_from(objspace, b, a);
 	    }
 	}
 	else if (RVALUE_OLD_P(a) && !RVALUE_OLD_P(b)) {
 	    if (!RVALUE_WB_UNPROTECTED(b)) {
-		gc_report(1, objspace, "gc_writebarrier_incremental: [GN] %s -> %s\n", obj_info(a), obj_info(b));
+		gc_report(1, objspace, "gc_writebarrier_incremental: [GN] %p -> %s\n", (void *)a, obj_info(b));
 		RVALUE_AGE_SET_OLD(objspace, b);
 
 		if (RVALUE_BLACK_P(b)) {
@@ -5979,7 +5979,7 @@ gc_writebarrier_incremental(VALUE a, VALUE b, rb_objspace_t *objspace)
 		}
 	    }
 	    else {
-		gc_report(1, objspace, "gc_writebarrier_incremental: [LL] %s -> %s\n", obj_info(a), obj_info(b));
+		gc_report(1, objspace, "gc_writebarrier_incremental: [LL] %p -> %s\n", (void *)a, obj_info(b));
 		gc_remember_unprotected(objspace, b);
 	    }
 	}

--- a/gc.c
+++ b/gc.c
@@ -9346,8 +9346,12 @@ rb_raw_obj_info(char *buff, const int buff_size, VALUE obj)
 	    break;
 	  }
 	  case T_DATA: {
+	    const struct rb_block *block;
 	    const rb_iseq_t *iseq;
-	    if (rb_obj_is_proc(obj) && (iseq = vm_proc_iseq(obj)) != NULL) {
+	    if (rb_obj_is_proc(obj) &&
+		(block = vm_proc_block(obj)) != NULL &&
+		(vm_block_type(block) == block_type_iseq) &&
+		(iseq = vm_block_iseq(block)) != NULL) {
 		rb_raw_iseq_info(buff, buff_size, iseq);
 	    }
 	    else {

--- a/gc.c
+++ b/gc.c
@@ -9378,12 +9378,17 @@ rb_raw_obj_info(char *buff, const int buff_size, VALUE obj)
 	    switch (imemo_type(obj)) {
 	      case imemo_ment: {
 		const rb_method_entry_t *me = &RANY(obj)->as.imemo.ment;
-		snprintf(buff, buff_size, "%s (called_id: %s, type: %s, alias: %d, owner: %s, defined_class: %s)", buff,
-			 rb_id2name(me->called_id),
-			 method_type_name(me->def->type),
-			 me->def->alias_count,
-			 obj_info(me->owner),
-			 obj_info(me->defined_class));
+		if (me->def) {
+		    snprintf(buff, buff_size, "%s (called_id: %s, type: %s, alias: %d, owner: %s, defined_class: %s)", buff,
+			     rb_id2name(me->called_id),
+			     method_type_name(me->def->type),
+			     me->def->alias_count,
+			     obj_info(me->owner),
+			     obj_info(me->defined_class));
+		}
+		else {
+		    snprintf(buff, buff_size, "%s", rb_id2name(me->called_id));
+		}
 		break;
 	      }
 	      case imemo_iseq: {

--- a/include/ruby/ruby.h
+++ b/include/ruby/ruby.h
@@ -2172,7 +2172,7 @@ unsigned long ruby_strtoul(const char *str, char **endptr, int base);
 PRINTF_ARGS(int ruby_snprintf(char *str, size_t n, char const *fmt, ...), 3, 4);
 int ruby_vsnprintf(char *str, size_t n, char const *fmt, va_list ap);
 
-#if defined(HAVE_BUILTIN___BUILTIN_CHOOSE_EXPR_CONSTANT_P) && defined(__OPTIMIZE__)
+#if defined(HAVE_BUILTIN___BUILTIN_CHOOSE_EXPR_CONSTANT_P) && defined(HAVE_VA_ARGS_MACRO) && defined(__OPTIMIZE__)
 # define rb_scan_args(argc,argvp,fmt,...) \
     __builtin_choose_expr(__builtin_constant_p(fmt), \
         rb_scan_args0(argc,argvp,fmt,\
@@ -2448,7 +2448,7 @@ rb_scan_args_set(int argc, const VALUE *argv,
 }
 #endif
 
-#if defined(__GNUC__) && defined(__OPTIMIZE__)
+#if defined(__GNUC__) && defined(HAVE_VA_ARGS_MACRO) && defined(__OPTIMIZE__)
 # define rb_yield_values(argc, ...) \
 __extension__({ \
 	const int rb_yield_values_argc = (argc); \

--- a/include/ruby/ruby.h
+++ b/include/ruby/ruby.h
@@ -1151,10 +1151,10 @@ void *rb_check_typeddata(VALUE, const rb_data_type_t *);
     (void)((sval) = (type *)DATA_PTR(result));
 
 #ifdef __GNUC__
-#define Data_Make_Struct(klass,type,mark,free,sval) ({\
+#define Data_Make_Struct(klass,type,mark,free,sval) RB_GNUC_EXTENSION_BLOCK(\
     Data_Make_Struct0(data_struct_obj, klass, type, sizeof(type), mark, free, sval); \
-    data_struct_obj; \
-})
+    data_struct_obj \
+)
 #else
 #define Data_Make_Struct(klass,type,mark,free,sval) (\
     rb_data_object_make((klass),(RUBY_DATA_FUNC)(mark),(RUBY_DATA_FUNC)(free),(void **)&(sval),sizeof(type)) \
@@ -1169,10 +1169,10 @@ void *rb_check_typeddata(VALUE, const rb_data_type_t *);
     (void)((sval) = (type *)DATA_PTR(result));
 
 #ifdef __GNUC__
-#define TypedData_Make_Struct(klass, type, data_type, sval) ({\
+#define TypedData_Make_Struct(klass, type, data_type, sval) RB_GNUC_EXTENSION_BLOCK(\
     TypedData_Make_Struct0(data_struct_obj, klass, type, sizeof(type), data_type, sval); \
-    data_struct_obj; \
-})
+    data_struct_obj \
+)
 #else
 #define TypedData_Make_Struct(klass, type, data_type, sval) (\
     rb_data_typed_object_make((klass),(data_type),(void **)&(sval),sizeof(type)) \

--- a/internal.h
+++ b/internal.h
@@ -512,12 +512,18 @@ rb_fix_mod_fix(VALUE x, VALUE y)
     return mod;
 }
 
-#if defined(HAVE_UINT128_T)
+#if defined(HAVE_UINT128_T) && defined(HAVE_LONG_LONG)
 #   define bit_length(x) \
     (unsigned int) \
     (sizeof(x) <= SIZEOF_INT ? SIZEOF_INT * CHAR_BIT - nlz_int((unsigned int)(x)) : \
      sizeof(x) <= SIZEOF_LONG ? SIZEOF_LONG * CHAR_BIT - nlz_long((unsigned long)(x)) : \
      sizeof(x) <= SIZEOF_LONG_LONG ? SIZEOF_LONG_LONG * CHAR_BIT - nlz_long_long((unsigned LONG_LONG)(x)) : \
+     SIZEOF_INT128_T * CHAR_BIT - nlz_int128((uint128_t)(x)))
+#elif defined(HAVE_UINT128_T)
+#   define bit_length(x) \
+    (unsigned int) \
+    (sizeof(x) <= SIZEOF_INT ? SIZEOF_INT * CHAR_BIT - nlz_int((unsigned int)(x)) : \
+     sizeof(x) <= SIZEOF_LONG ? SIZEOF_LONG * CHAR_BIT - nlz_long((unsigned long)(x)) : \
      SIZEOF_INT128_T * CHAR_BIT - nlz_int128((uint128_t)(x)))
 #elif defined(HAVE_LONG_LONG)
 #   define bit_length(x) \

--- a/internal.h
+++ b/internal.h
@@ -109,7 +109,7 @@ extern "C" {
     __builtin_mul_overflow_p((a), (b), (__typeof__(a * b))0)
 #elif defined HAVE_BUILTIN___BUILTIN_MUL_OVERFLOW
 #define MUL_OVERFLOW_P(a, b) \
-    ({__typeof__(a) c; __builtin_mul_overflow((a), (b), &c);})
+    RB_GNUC_EXTENSION_BLOCK(__typeof__(a) c; __builtin_mul_overflow((a), (b), &c))
 #endif
 
 #define MUL_OVERFLOW_SIGNED_INTEGER_P(a, b, min, max) ( \
@@ -122,10 +122,10 @@ extern "C" {
 #ifdef HAVE_BUILTIN___BUILTIN_MUL_OVERFLOW_P
 /* __builtin_mul_overflow_p can take bitfield */
 /* and GCC permits bitfields for integers other than int */
-#define MUL_OVERFLOW_FIXNUM_P(a, b) ({ \
+#define MUL_OVERFLOW_FIXNUM_P(a, b) RB_GNUC_EXTENSION_BLOCK( \
     struct { long fixnum : SIZEOF_LONG * CHAR_BIT - 1; } c; \
     __builtin_mul_overflow_p((a), (b), c.fixnum); \
-})
+)
 #else
 #define MUL_OVERFLOW_FIXNUM_P(a, b) MUL_OVERFLOW_SIGNED_INTEGER_P(a, b, FIXNUM_MIN, FIXNUM_MAX)
 #endif

--- a/internal.h
+++ b/internal.h
@@ -1053,7 +1053,7 @@ VALUE rb_ary_aref1(VALUE ary, VALUE i);
 VALUE rb_ary_aref2(VALUE ary, VALUE b, VALUE e);
 size_t rb_ary_memsize(VALUE);
 VALUE rb_to_array_type(VALUE obj);
-#ifdef __GNUC__
+#if defined(__GNUC__) && defined(HAVE_VA_ARGS_MACRO)
 #define rb_ary_new_from_args(n, ...) \
     __extension__ ({ \
 	const VALUE args_to_new_ary[] = {__VA_ARGS__}; \

--- a/internal.h
+++ b/internal.h
@@ -79,8 +79,10 @@ extern "C" {
 # define __has_extension __has_feature
 #endif
 
-#if GCC_VERSION_SINCE(4, 6, 0) || __has_extension(c_static_assert)
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)
 # define STATIC_ASSERT(name, expr) _Static_assert(expr, #name ": " #expr)
+#elif GCC_VERSION_SINCE(4, 6, 0) || __has_extension(c_static_assert)
+# define STATIC_ASSERT(name, expr) RB_GNUC_EXTENSION _Static_assert(expr, #name ": " #expr)
 #else
 # define STATIC_ASSERT(name, expr) typedef int static_assert_##name##_check[1 - 2*!(expr)]
 #endif

--- a/internal.h
+++ b/internal.h
@@ -293,10 +293,15 @@ nlz_int128(uint128_t x)
 static inline unsigned int
 nlz_intptr(uintptr_t x)
 {
-#if SIZEOF_VOIDP == 8
-    return nlz_long_long(x);
-#elif SIZEOF_VOIDP == 4
+#if SIZEOF_UINTPTR_T == SIZEOF_INT
     return nlz_int(x);
+#elif SIZEOF_UINTPTR_T == SIZEOF_LONG
+    return nlz_long(x);
+#elif SIZEOF_UINTPTR_T == SIZEOF_LONG_LONG
+    return nlz_long_long(x);
+#else
+    #error no known integer type corresponds uintptr_t
+    return /* sane compiler */ ~0;
 #endif
 }
 

--- a/lib/mkmf.rb
+++ b/lib/mkmf.rb
@@ -2584,7 +2584,8 @@ MESSAGE
       src = src.sub(/\{/) do
         $& +
           "\n  if (argc > 1000000) {\n" +
-          refs.map {|n|"    printf(\"%p\", &#{n});\n"}.join("") +
+          refs.map {|n|"    int (* volatile #{n}p)(void)=(int (*)(void))&#{n};\n"}.join("") +
+          refs.map {|n|"    printf(\"%d\", (*#{n}p)());\n"}.join("") +
           "  }\n"
       end
     end

--- a/lib/prime.rb
+++ b/lib/prime.rb
@@ -42,7 +42,7 @@ class Integer
         i += w
         w = 6 - w
     end
-    return true
+    true
   end
 
   # Iterates the given block over all prime numbers.

--- a/lib/prime.rb
+++ b/lib/prime.rb
@@ -32,7 +32,7 @@ class Integer
 
   # Returns true if +self+ is a prime number, else returns false.
   def prime?
-    return false if self == 1
+    return false if self <= 1
     return true  if self == 2 || self == 3
     return false if self % 2 == 0 || self % 3 == 0
     i = 5

--- a/lib/prime.rb
+++ b/lib/prime.rb
@@ -32,13 +32,13 @@ class Integer
 
   # Returns true if +self+ is a prime number, else returns false.
   def prime?
-    return false if n == 1
-    return true  if n == 2 || n == 3
-    return false if n % 2 == 0 || n % 3 == 0
+    return false if self == 1
+    return true  if self == 2 || self == 3
+    return false if self % 2 == 0 || self % 3 == 0
     i = 5
     w = 2
-    while i * i <= n
-        return false if n % i == 0
+    while i * i <= self
+        return false if self % i == 0
         i += w
         w = 6 - w
     end

--- a/lib/prime.rb
+++ b/lib/prime.rb
@@ -32,15 +32,17 @@ class Integer
 
   # Returns true if +self+ is a prime number, else returns false.
   def prime?
-    return self >= 2 if self <= 3
-    return true if self == 5
-    return false unless 30.gcd(self) == 1
-    (7..Integer.sqrt(self)).step(30) do |p|
-      return false if
-        self%(p)    == 0 || self%(p+4)  == 0 || self%(p+6)  == 0 || self%(p+10) == 0 ||
-        self%(p+12) == 0 || self%(p+16) == 0 || self%(p+22) == 0 || self%(p+24) == 0
+    return false if n == 1
+    return true  if n == 2 || n == 3
+    return false if n % 2 == 0 || n % 3 == 0
+    i = 5
+    w = 2
+    while i * i <= n
+        return false if n % i == 0
+        i += w
+        w = 6 - w
     end
-    true
+    return true
   end
 
   # Iterates the given block over all prime numbers.

--- a/method.h
+++ b/method.h
@@ -32,10 +32,16 @@ typedef enum {
     METHOD_VISI_MASK = 0x03
 } rb_method_visibility_t;
 
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)
+#define bits_t rb_method_visibility_t
+#else
+#define bits_t unsigned int
+#endif
 typedef struct rb_scope_visi_struct {
-    rb_method_visibility_t method_visi : 3;
+    bits_t method_visi : 3;
     unsigned int module_func : 1;
 } rb_scope_visibility_t;
+#undef bits_t
 
 /*! CREF (Class REFerence) */
 typedef struct rb_cref_struct {

--- a/regenc.h
+++ b/regenc.h
@@ -122,7 +122,7 @@ typedef struct {
 } PosixBracketEntryType;
 
 #define POSIX_BRACKET_ENTRY_INIT(name, ctype) \
-  {(short int )(sizeof(name) - 1), (name), (ctype)}
+  {(short int )(sizeof(name) - 1), name, (ctype)}
 
 #ifndef numberof
 # define numberof(array) (int )(sizeof(array) / sizeof((array)[0]))

--- a/regexec.c
+++ b/regexec.c
@@ -1461,9 +1461,9 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 # define CASE(x) L_##x: sbegin = s; OPCODE_EXEC_HOOK;
 # define DEFAULT L_DEFAULT:
 # define NEXT sprev = sbegin; JUMP
-# define JUMP goto *oplabels[*p++]
+# define JUMP RB_GNUC_EXTENSION_BLOCK(goto *oplabels[*p++])
 
-  static const void *oplabels[] = {
+  RB_GNUC_EXTENSION static const void *oplabels[] = {
     &&L_OP_FINISH,               /* matching process terminator (no more alternative) */
     &&L_OP_END,                  /* pattern code terminator (success end) */
 
@@ -4617,4 +4617,3 @@ onig_copy_encoding(OnigEncodingType *to, OnigEncoding from)
 {
   *to = *from;
 }
-

--- a/ruby_assert.h
+++ b/ruby_assert.h
@@ -33,8 +33,14 @@ NORETURN(void rb_assert_failure(const char *, int, const char *, const char *));
 #define RUBY_ASSERT(expr) RUBY_ASSERT_MESG_WHEN(!RUBY_NDEBUG+0, expr, #expr)
 #define RUBY_ASSERT_WHEN(cond, expr) RUBY_ASSERT_MESG_WHEN(cond, expr, #expr)
 
+#if !defined(__STDC_VERSION__) || (__STDC_VERSION__ < 199901L)
+/* C89 compilers are required to support strings of only 509 chars. */
+/* can't use RUBY_ASSERT for such compilers. */
+#include <assert.h>
+#else
 #undef assert
 #define assert RUBY_ASSERT
+#endif
 
 #ifndef RUBY_NDEBUG
 # ifdef NDEBUG

--- a/ruby_atomic.h
+++ b/ruby_atomic.h
@@ -9,10 +9,10 @@ typedef unsigned int rb_atomic_t;
 # define ATOMIC_DEC(var) __atomic_fetch_sub(&(var), 1, __ATOMIC_SEQ_CST)
 # define ATOMIC_OR(var, val) __atomic_fetch_or(&(var), (val), __ATOMIC_SEQ_CST)
 # define ATOMIC_EXCHANGE(var, val) __atomic_exchange_n(&(var), (val), __ATOMIC_SEQ_CST)
-# define ATOMIC_CAS(var, oldval, newval) \
-({ __typeof__(var) oldvaldup = (oldval); /* oldval should not be modified */ \
+# define ATOMIC_CAS(var, oldval, newval) RB_GNUC_EXTENSION_BLOCK( \
+   __typeof__(var) oldvaldup = (oldval); /* oldval should not be modified */ \
    __atomic_compare_exchange_n(&(var), &oldvaldup, (newval), 0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST); \
-   oldvaldup; })
+   oldvaldup )
 
 # define ATOMIC_SIZE_ADD(var, val) __atomic_fetch_add(&(var), (val), __ATOMIC_SEQ_CST)
 # define ATOMIC_SIZE_SUB(var, val) __atomic_fetch_sub(&(var), (val), __ATOMIC_SEQ_CST)

--- a/template/insns_info.inc.tmpl
+++ b/template/insns_info.inc.tmpl
@@ -13,6 +13,13 @@
 #define <%=t%> '<%=c%>'
 % end
 
+#if !defined(__STDC_VERSION__) || (__STDC_VERSION__ < 199901L)
+static const char *insn_name_info[] = {
+% @insns.each do |insn|
+    "<%= insn.name %>",
+% end
+};
+#else
 static const unsigned short insn_name_info_offset[] = {
 % insn_name_length = @insns.inject(0) do |ofs, insn|
     <%= ofs %>,
@@ -29,6 +36,7 @@ static const char insn_name_info_base[<%=insn_name_length%>] = ""
 ;
 
 #define insn_name_info insn_name_info_base+insn_name_info_offset
+#endif
 
 static const char insn_operand_info[][8] = {
 % @insns.each do |insn|

--- a/test/ruby/test_pack.rb
+++ b/test/ruby/test_pack.rb
@@ -428,6 +428,7 @@ class TestPack < Test::Unit::TestCase
     assert_operator(4, :<=, [1].pack("L!").bytesize)
   end
 
+  require 'rbconfig'
   def test_pack_unpack_qQ
     s1 = [578437695752307201, -506097522914230529].pack("q*")
     s2 = [578437695752307201, 17940646550795321087].pack("Q*")
@@ -437,6 +438,7 @@ class TestPack < Test::Unit::TestCase
 
     # Note: q! and Q! should not work on platform which has no long long type.
     # Is there a such platform now?
+    # @shyouhei: Yes. gcc -ansi is one of such platform.
     s1 = [578437695752307201, -506097522914230529].pack("q!*")
     s2 = [578437695752307201, 17940646550795321087].pack("Q!*")
     assert_equal([578437695752307201, -506097522914230529], s2.unpack("q!*"))
@@ -446,7 +448,7 @@ class TestPack < Test::Unit::TestCase
     assert_equal(8, [1].pack("Q").bytesize)
     assert_operator(8, :<=, [1].pack("q!").bytesize)
     assert_operator(8, :<=, [1].pack("Q!").bytesize)
-  end
+  end if RbConfig::CONFIG['HAVE_LONG_LONG']
 
   def test_pack_unpack_jJ
     # Note: we assume that the size of intptr_t and uintptr_t equals to the size

--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -1221,11 +1221,13 @@ static void
 ubf_wakeup_all_threads(void)
 {
     rb_thread_t *th;
+    native_thread_data_t *dat;
 
     if (!ubf_threads_empty()) {
 	native_mutex_lock(&ubf_list_lock);
-	list_for_each(&ubf_list_head, th,
-		      native_thread_data.ubf_list) {
+	list_for_each(&ubf_list_head, dat, ubf_list) {
+	    th = (rb_thread_t *)(
+		((char *)dat) - offsetof(rb_thread_t, native_thread_data));
 	    ubf_wakeup_thread(th);
 	}
 	native_mutex_unlock(&ubf_list_lock);

--- a/time.c
+++ b/time.c
@@ -1596,12 +1596,18 @@ localtimew(wideval_t timew, struct vtm *result)
     return result;
 }
 
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)
+#define bits_t uint8_t
+#else
+#define bits_t unsigned int
+#endif
 PACKED_STRUCT_UNALIGNED(struct time_object {
     wideval_t timew; /* time_t value * TIME_SCALE.  possibly Rational. */
     struct vtm vtm;
-    uint8_t gmt:3; /* 0:localtime 1:utc 2:fixoff 3:init */
-    uint8_t tm_got:1;
+    bits_t gmt:3; /* 0:localtime 1:utc 2:fixoff 3:init */
+    bits_t tm_got:1;
 });
+#undef bits_t
 
 #define GetTimeval(obj, tobj) ((tobj) = get_timeval(obj))
 #define GetNewTimeval(obj, tobj) ((tobj) = get_new_timeval(obj))

--- a/timev.h
+++ b/timev.h
@@ -1,20 +1,29 @@
 #ifndef RUBY_TIMEV_H
 #define RUBY_TIMEV_H
 
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)
+#define bits8_t uint8_t
+#define bits16_t uint16_t
+#else
+#define bits8_t unsigned int
+#define bits16_t unsigned int
+#endif
 PACKED_STRUCT_UNALIGNED(struct vtm {
     VALUE year; /* 2000 for example.  Integer. */
     VALUE subsecx; /* 0 <= subsecx < TIME_SCALE.  possibly Rational. */
     VALUE utc_offset; /* -3600 as -01:00 for example.  possibly Rational. */
     const char *zone; /* "JST", "EST", "EDT", etc. */
-    uint16_t yday:9; /* 1..366 */
-    uint8_t mon:4; /* 1..12 */
-    uint8_t mday:5; /* 1..31 */
-    uint8_t hour:5; /* 0..23 */
-    uint8_t min:6; /* 0..59 */
-    uint8_t sec:6; /* 0..60 */
-    uint8_t wday:3; /* 0:Sunday, 1:Monday, ..., 6:Saturday 7:init */
-    uint8_t isdst:2; /* 0:StandardTime 1:DayLightSavingTime 3:init */
+    bits16_t yday:9; /* 1..366 */
+    bits8_t mon:4; /* 1..12 */
+    bits8_t mday:5; /* 1..31 */
+    bits8_t hour:5; /* 0..23 */
+    bits8_t min:6; /* 0..59 */
+    bits8_t sec:6; /* 0..60 */
+    bits8_t wday:3; /* 0:Sunday, 1:Monday, ..., 6:Saturday 7:init */
+    bits8_t isdst:2; /* 0:StandardTime 1:DayLightSavingTime 3:init */
 });
+#undef bits8_t
+#undef bits16_t
 
 #define TIME_SCALE 1000000000
 

--- a/variable.c
+++ b/variable.c
@@ -1846,10 +1846,8 @@ struct autoload_state {
     VALUE result;
     ID id;
     VALUE thread;
-    union {
-	struct list_node node;
-	struct list_head head;
-    } waitq;
+    struct list_node node;
+    struct list_head head;
 };
 
 struct autoload_data_i {
@@ -2102,11 +2100,11 @@ autoload_reset(VALUE arg)
     if (need_wakeups) {
 	struct autoload_state *cur = 0, *nxt;
 
-	list_for_each_safe(&state->waitq.head, cur, nxt, waitq.node) {
+	list_for_each_safe(&state->head, cur, nxt, node) {
 	    VALUE th = cur->thread;
 
 	    cur->thread = Qfalse;
-	    list_del_init(&cur->waitq.node); /* idempotent */
+	    list_del_init(&cur->node); /* idempotent */
 
 	    /*
 	     * cur is stored on the stack of cur->waiting_th,
@@ -2141,7 +2139,7 @@ autoload_sleep_done(VALUE arg)
     struct autoload_state *state = (struct autoload_state *)arg;
 
     if (state->thread != Qfalse && rb_thread_to_be_killed(state->thread)) {
-	list_del(&state->waitq.node); /* idempotent after list_del_init */
+	list_del(&state->node); /* idempotent after list_del_init */
     }
 
     return Qfalse;
@@ -2177,13 +2175,13 @@ rb_autoload_load(VALUE mod, ID id)
 	 * autoload_reset will wake up any threads added to this
 	 * iff the GVL is released during autoload_require
 	 */
-	list_head_init(&state.waitq.head);
+	list_head_init(&state.head);
     }
     else if (state.thread == ele->state->thread) {
 	return Qfalse;
     }
     else {
-	list_add_tail(&ele->state->waitq.head, &state.waitq.node);
+	list_add_tail(&ele->state->head, &state.node);
 
 	rb_ensure(autoload_sleep, (VALUE)&state,
 		autoload_sleep_done, (VALUE)&state);

--- a/variable.c
+++ b/variable.c
@@ -318,10 +318,11 @@ rb_class_path_no_cache(VALUE klass)
 VALUE
 rb_class_path_cached(VALUE klass)
 {
-    st_table *ivtbl = RCLASS_IV_TBL(klass);
+    st_table *ivtbl;
     st_data_t n;
 
-    if (!ivtbl) return Qnil;
+    if (!RCLASS_EXT(klass)) return Qnil;
+    if (!(ivtbl = RCLASS_IV_TBL(klass))) return Qnil;
     if (st_lookup(ivtbl, (st_data_t)classpath, &n)) return (VALUE)n;
     if (st_lookup(ivtbl, (st_data_t)tmp_classpath, &n)) return (VALUE)n;
     return Qnil;

--- a/version.h
+++ b/version.h
@@ -4,7 +4,7 @@
 
 #define RUBY_RELEASE_YEAR 2018
 #define RUBY_RELEASE_MONTH 1
-#define RUBY_RELEASE_DAY 2
+#define RUBY_RELEASE_DAY 3
 
 #include "ruby/version.h"
 

--- a/vm_core.h
+++ b/vm_core.h
@@ -1406,7 +1406,6 @@ vm_proc_ep(VALUE procval)
 static inline const rb_iseq_t *
 vm_block_iseq(const struct rb_block *block)
 {
-    if (!block) return NULL;
     switch (vm_block_type(block)) {
       case block_type_iseq: return rb_iseq_check(block->as.captured.code.iseq);
       case block_type_proc: return vm_proc_iseq(block->as.proc);

--- a/vm_core.h
+++ b/vm_core.h
@@ -1018,7 +1018,7 @@ enum {
      * X   : tag for GC marking (It seems as Fixnum)
      * EEE : 3 bits Env flags
      * FF..: 6 bits Frame flags
-     * MM..: 16 bits frame magic (to check frame corruption)
+     * MM..: 15 bits frame magic (to check frame corruption)
      */
 
     /* frame types */
@@ -1029,10 +1029,10 @@ enum {
     VM_FRAME_MAGIC_CFUNC  = 0x55550001,
     VM_FRAME_MAGIC_IFUNC  = 0x66660001,
     VM_FRAME_MAGIC_EVAL   = 0x77770001,
-    VM_FRAME_MAGIC_RESCUE = 0x88880001,
-    VM_FRAME_MAGIC_DUMMY  = 0x99990001,
+    VM_FRAME_MAGIC_RESCUE = 0x78880001,
+    VM_FRAME_MAGIC_DUMMY  = 0x79990001,
 
-    VM_FRAME_MAGIC_MASK   = 0xffff0001,
+    VM_FRAME_MAGIC_MASK   = 0x7fff0001,
 
     /* frame flag */
     VM_FRAME_FLAG_PASSED    = 0x0010,

--- a/vm_core.h
+++ b/vm_core.h
@@ -1406,6 +1406,7 @@ vm_proc_ep(VALUE procval)
 static inline const rb_iseq_t *
 vm_block_iseq(const struct rb_block *block)
 {
+    if (!block) return NULL;
     switch (vm_block_type(block)) {
       case block_type_iseq: return rb_iseq_check(block->as.captured.code.iseq);
       case block_type_proc: return vm_proc_iseq(block->as.proc);

--- a/vm_dump.c
+++ b/vm_dump.c
@@ -827,10 +827,11 @@ print_machine_register(size_t reg, const char *reg_name, int col_count, int max_
     char buf[64];
 
 #ifdef __LP64__
-    ret = snprintf(buf, sizeof(buf), " %3.3s: 0x%016zx", reg_name, reg);
+    ret = snprintf(buf, sizeof(buf), " %3.3s: 0x%016" PRIxSIZE, reg_name, reg);
 #else
-    ret = snprintf(buf, sizeof(buf), " %3.3s: 0x%08zx", reg_name, reg);
+    ret = snprintf(buf, sizeof(buf), " %3.3s: 0x%08" PRIxSIZE, reg_name, reg);
 #endif
+#undef zx
     if (col_count + ret > max_col) {
 	fputs("\n", stderr);
 	col_count = 0;

--- a/vm_exec.h
+++ b/vm_exec.h
@@ -75,7 +75,7 @@ error !
 
 #define LABEL(x)  INSN_LABEL_##x
 #define ELABEL(x) INSN_ELABEL_##x
-#define LABEL_PTR(x) &&LABEL(x)
+#define LABEL_PTR(x) RB_GNUC_EXTENSION(&&LABEL(x))
 
 #define INSN_ENTRY_SIG(insn) \
   if (0) fprintf(stderr, "exec: %s@(%d, %d)@%s:%d\n", #insn, \
@@ -106,7 +106,7 @@ error !
 /* for GCC 3.4.x */
 #define TC_DISPATCH(insn) \
   INSN_DISPATCH_SIG(insn); \
-  goto *(void const *)GET_CURRENT_INSN(); \
+  RB_GNUC_EXTENSION_BLOCK(goto *(void const *)GET_CURRENT_INSN()); \
   ;
 
 #else
@@ -115,7 +115,7 @@ error !
 #define TC_DISPATCH(insn)  \
   DISPATCH_ARCH_DEPEND_WAY(insns_address_table[GET_CURRENT_INSN()]); \
   INSN_DISPATCH_SIG(insn); \
-  goto *insns_address_table[GET_CURRENT_INSN()]; \
+  RB_GNUC_EXTENSION_BLOCK(goto *insns_address_table[GET_CURRENT_INSN()]); \
   rb_bug("tc error");
 
 

--- a/vm_insnhelper.h
+++ b/vm_insnhelper.h
@@ -66,11 +66,11 @@ enum vm_regan_regtype {
     VM_REGAN_EP = 2,
     VM_REGAN_CFP = 3,
     VM_REGAN_SELF = 4,
-    VM_REGAN_ISEQ = 5,
+    VM_REGAN_ISEQ = 5
 };
 enum vm_regan_acttype {
     VM_REGAN_ACT_GET = 0,
-    VM_REGAN_ACT_SET = 1,
+    VM_REGAN_ACT_SET = 1
 };
 
 #if VM_COLLECT_USAGE_DETAILS


### PR DESCRIPTION
**Add a faster Prime:prime? algorithm**
I worked the other day on a problem from the Euler Project and found myself using Prime:prime? to iterate over a large set of numbers. While doing that I noticed that the Prime:prime? method was a little slow. I swapped it with another algorithm I found on [SO](https://stackoverflow.com/questions/1801391/what-is-the-best-algorithm-for-checking-if-a-number-is-prime). The result was incredible:
```bash
$ (Prime:prime?) Time to complete (10 million): 205.742023
$ (Prime:prime?) 664579 prime numbers found

$ (new_prime?) Time to complete (10 million): 50.634685
$ (new_prime?) 664579 prime numbers found
```
As you can see iterating over 10 million numbers, the new algorithm is able to find the same prime numbers 4 times faster. I ran the tests locally and everything seems to work fine.
Could you double check ?
  