### PR TITLE
Add Matrix#antisymmetric?

### DIFF
--- a/lib/matrix.rb
+++ b/lib/matrix.rb
@@ -802,6 +802,18 @@ class Matrix
   end
 
   #
+  # Returns +true+ if this is an antisymmetric matrix.
+  # Raises an error if matrix is not square.
+  #
+  def antisymmetric?
+    Matrix.Raise ErrDimensionMismatch unless square?
+    each_with_index(:upper) do |e, row, col|
+      return false unless e == -rows[col][row]
+    end
+    true
+  end
+
+  #
   # Returns +true+ if this is a unitary matrix
   # Raises an error if matrix is not square.
   #

--- a/spec/ruby/library/matrix/antisymmetric_spec.rb
+++ b/spec/ruby/library/matrix/antisymmetric_spec.rb
@@ -1,0 +1,35 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+require 'matrix'
+
+describe "Matrix#antisymmetric?" do
+  it "returns true for an antisymmetric Matrix" do
+    Matrix[[0, -2, Complex(1, 3)], [2, 0, 5], [-Complex(1, 3), -5, 0]].antisymmetric?.should be_true
+  end
+
+  it "returns true for a 0x0 empty matrix" do
+    Matrix.empty.antisymmetric?.should be_true
+  end
+
+  it "returns false for non-antisymmetric matrices" do
+    [
+      Matrix[[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+      Matrix[[1, -2, 3], [2, 0, 6], [-3, -6, 0]],  # wrong diagonal element
+      Matrix[[0, 2, -3], [2, 0, 6], [-3, 6, 0]]    # only signs wrong
+    ].each do |matrix|
+      matrix.antisymmetric?.should be_false
+    end
+  end
+
+  it "raises an error for rectangular matrices" do
+    [
+      Matrix[[0], [0]],
+      Matrix[[0, 0]],
+      Matrix.empty(0, 2),
+      Matrix.empty(2, 0),
+    ].each do |rectangular_matrix|
+      lambda {
+        rectangular_matrix.antisymmetric?
+      }.should raise_error(Matrix::ErrDimensionMismatch)
+    end
+  end
+end


### PR DESCRIPTION
@marcandre 

IMO `antisymmetric?` (as proposed in #1730) is a valid addition to the `Matrix` library, but the implementation provided there is still logically wrong, and it seemed more productive to me to provide a working implementation instead of reviewing again. This patch also provides better test coverage.

If you approve I can commit to SVN.

_BTW. I do not care very much about `reflexive?`, and it is not related, so I would let this be another changeset. And regarding the style (returning true/false): this was adopted from `symmetric?` and various other existing methods; when you prefer a different style that also should be handled in another changeset, IMO._
