### PR TITLE
Removing duplicated assertions on test_array.rb - MINUS method

### DIFF
--- a/test/ruby/test_array.rb
+++ b/test/ruby/test_array.rb
@@ -259,10 +259,6 @@ class TestArray < Test::Unit::TestCase
     assert_equal(@cls[],  @cls[1] - @cls[1])
     assert_equal(@cls[1], @cls[1, 2, 3, 4, 5] - @cls[2, 3, 4, 5])
     assert_equal(@cls[1, 1, 1, 1], @cls[1, 2, 1, 3, 1, 4, 1, 5] - @cls[2, 3, 4, 5])
-    a = @cls[]
-    1000.times { a << 1 }
-    assert_equal(1000, a.length)
-    assert_equal(@cls[1] * 1000, a - @cls[2])
     assert_equal(@cls[1, 1],  @cls[1, 2, 1] - @cls[2])
     assert_equal(@cls[1, 2, 3], @cls[1, 2, 3] - @cls[4, 5, 6])
   end


### PR DESCRIPTION
[Feature #13884](https://bugs.ruby-lang.org/issues/13884) added some improvements to `and`, `or` and `diff` operations, and also new assertions grouped on their own namespace, some of those assertions needed to be removed from `test_MINUS` since are already on `test_MINUS_big_array`:
https://github.com/ruby/ruby/blob/42bb73cf64bc4a122b80eb2262f5b9c47381a024/test/ruby/test_array.rb#L260-L264

https://github.com/ruby/ruby/blob/42bb73cf64bc4a122b80eb2262f5b9c47381a024/test/ruby/test_array.rb#L275-L279
