### PR TITLE
process.c: add :exception option to Kernel.#system

### DIFF
--- a/ext/pty/pty.c
+++ b/ext/pty/pty.c
@@ -182,7 +182,7 @@ establishShell(int argc, VALUE *argv, struct pty_info *info,
 	argv = &v;
     }
 
-    carg.execarg_obj = rb_execarg_new(argc, argv, 1);
+    carg.execarg_obj = rb_execarg_new(argc, argv, 1, 0);
     carg.eargp = rb_execarg_get(carg.execarg_obj);
     rb_execarg_parent_start(carg.execarg_obj);
 

--- a/internal.h
+++ b/internal.h
@@ -1631,6 +1631,7 @@ struct rb_execarg {
     unsigned new_pgroup_flag : 1;
     unsigned uid_given : 1;
     unsigned gid_given : 1;
+    unsigned exception : 1;
     rb_pid_t pgroup_pgid; /* asis(-1), new pgroup(0), specified pgroup (0<V). */
     VALUE rlimit_limits; /* Qfalse or [[rtype, softlim, hardlim], ...] */
     mode_t umask_mask;
@@ -1968,9 +1969,9 @@ VALUE rb_int_positive_pow(long x, unsigned long y);
 /* process.c (export) */
 int rb_exec_async_signal_safe(const struct rb_execarg *e, char *errmsg, size_t errmsg_buflen);
 rb_pid_t rb_fork_async_signal_safe(int *status, int (*chfunc)(void*, char *, size_t), void *charg, VALUE fds, char *errmsg, size_t errmsg_buflen);
-VALUE rb_execarg_new(int argc, const VALUE *argv, int accept_shell);
+VALUE rb_execarg_new(int argc, const VALUE *argv, int accept_shell, int allow_exc_opt);
 struct rb_execarg *rb_execarg_get(VALUE execarg_obj); /* dangerous.  needs GC guard. */
-VALUE rb_execarg_init(int argc, const VALUE *argv, int accept_shell, VALUE execarg_obj);
+VALUE rb_execarg_init(int argc, const VALUE *argv, int accept_shell, VALUE execarg_obj, int allow_exc_opt);
 int rb_execarg_addopt(VALUE execarg_obj, VALUE key, VALUE val);
 void rb_execarg_parent_start(VALUE execarg_obj);
 void rb_execarg_parent_end(VALUE execarg_obj);

--- a/io.c
+++ b/io.c
@@ -6633,7 +6633,7 @@ pipe_open_s(VALUE prog, const char *modestr, int fmode,
     VALUE execarg_obj = Qnil;
 
     if (!is_popen_fork(prog))
-	execarg_obj = rb_execarg_new(argc, argv, TRUE);
+	execarg_obj = rb_execarg_new(argc, argv, TRUE, FALSE);
     return pipe_open(execarg_obj, modestr, fmode, convconfig);
 }
 
@@ -6766,14 +6766,14 @@ rb_io_s_popen(int argc, VALUE *argv, VALUE klass)
 	    rb_raise(rb_eArgError, "too many arguments");
 	}
 #endif
-	execarg_obj = rb_execarg_new((int)len, RARRAY_CONST_PTR(tmp), FALSE);
+	execarg_obj = rb_execarg_new((int)len, RARRAY_CONST_PTR(tmp), FALSE, FALSE);
 	RB_GC_GUARD(tmp);
     }
     else {
 	SafeStringValue(pname);
 	execarg_obj = Qnil;
 	if (!is_popen_fork(pname))
-	    execarg_obj = rb_execarg_new(1, &pname, TRUE);
+	    execarg_obj = rb_execarg_new(1, &pname, TRUE, FALSE);
     }
     if (!NIL_P(execarg_obj)) {
 	if (!NIL_P(opt))

--- a/test/ruby/test_system.rb
+++ b/test/ruby/test_system.rb
@@ -160,4 +160,23 @@ class TestSystem < Test::Unit::TestCase
       assert_equal(true, system(tmpfilename), '[ruby-core:32745]')
     }
   end if File.executable?("/bin/sh")
+
+  def test_system_exception
+    ruby = EnvUtil.rubybin
+    assert_nothing_raised do
+      system('feature_14235', exception: false)
+      system("'#{ruby}' -e 'exit 1'", exception: false)
+    end
+    assert_raise(Errno::ENOENT) do
+      system('feature_14235', exception: true)
+    end
+    assert_raise(RuntimeError) do
+      system("'#{ruby}' -e 'exit 1'", exception: true)
+    end
+    begin
+      system("'#{ruby}' -e 'exit 1'", exception: true)
+    rescue RuntimeError => e
+      assert_equal true, e.message.include?('status (1)')
+    end
+  end
 end


### PR DESCRIPTION
```rb
system('bundle check || bundle install')
# The following gems are missing
# (snip)
# Install missing gems with `bundle install`
# Could not reach host index.rubygems.org. Check your network connection and try again.
# => false

system('bundle check || bundle install', exception: true)
# The following gems are missing
# (snip)
# Install missing gems with `bundle install`
# Could not reach host index.rubygems.org. Check your network connection and try again.
# => RuntimeError: Command failed with status (17): bundle check || bundle install

system('bundler2', exception: true)
# => Errno::ENOENT: No such file or directory - bundler2
```

https://bugs.ruby-lang.org/issues/14386