### PR TITLE
silence warning in ossl_pkey_dh.c

### DIFF
--- a/ext/openssl/ossl_pkey_dh.c
+++ b/ext/openssl/ossl_pkey_dh.c
@@ -262,7 +262,7 @@ ossl_dh_initialize_copy(VALUE self, VALUE other)
 	BIGNUM *pub2 = BN_dup(pub);
 	BIGNUM *priv2 = BN_dup(priv);
 
-	if (!pub2 || priv && !priv2) {
+	if (!pub2 || (priv && !priv2)) {
 	    BN_clear_free(pub2);
 	    BN_clear_free(priv2);
 	    ossl_raise(eDHError, "BN_dup");


### PR DESCRIPTION
```c
ossl_pkey_dh.c:265:20: warning: '&&' within '||' [-Wlogical-op-parentheses]
        if (!pub2 || priv && !priv2) {
                  ~~ ~~~~~^~~~~~~~~
ossl_pkey_dh.c:265:20: note: place parentheses around the '&&' expression to silence this warning
        if (!pub2 || priv && !priv2) {
                          ^
                     (             )
1 warning generated.
```