### PR TITLE
Fix chmod specs on mingw32 where mode_t is ushort

### DIFF
--- a/spec/ruby/core/file/chmod_spec.rb
+++ b/spec/ruby/core/file/chmod_spec.rb
@@ -15,7 +15,7 @@ describe "File#chmod" do
     @file.chmod(0755).should == 0
   end
 
-  platform_is_not :freebsd, :netbsd, :openbsd, :darwin do
+  platform_is_not :freebsd, :netbsd, :openbsd, :darwin, :mingw32 do
     it "always succeeds with any numeric values" do
       vals = [-2**30, -2**16, -2**8, -2, -1,
         -0.5, 0, 1, 2, 5.555575, 16, 32, 64, 2**8, 2**16, 2**30]
@@ -37,7 +37,7 @@ describe "File#chmod" do
   end
 
   # -256, -2 and -1 raise Errno::EINVAL on OpenBSD
-  platform_is :freebsd, :openbsd, :darwin do
+  platform_is :freebsd, :openbsd, :darwin, :mingw32 do
     it "always succeeds with any numeric values" do
       vals = [#-2**30, -2**16, -2**8, -2, -1,
         -0.5, 0, 1, 2, 5.555575, 16, 32, 64, 2**8]#, 2**16, 2**30
@@ -123,7 +123,7 @@ describe "File.chmod" do
     @count.should == 1
   end
 
-  platform_is_not :freebsd, :netbsd, :openbsd, :darwin do
+  platform_is_not :freebsd, :netbsd, :openbsd, :darwin, :mingw32 do
     it "always succeeds with any numeric values" do
       vals = [-2**30, -2**16, -2**8, -2, -1,
         -0.5, 0, 1, 2, 5.555575, 16, 32, 64, 2**8, 2**16, 2**30]
@@ -144,7 +144,7 @@ describe "File.chmod" do
     end
   end
 
-  platform_is :darwin do
+  platform_is :darwin, :mingw32 do
     it "succeeds with valid values" do
       vals = [-2**8, -2, -1, -0.5, 0, 1, 2, 5.555575, 16, 32, 64, 2**8]
       vals.each { |v|

--- a/spec/ruby/core/file/umask_spec.rb
+++ b/spec/ruby/core/file/umask_spec.rb
@@ -30,7 +30,7 @@ describe "File.umask" do
     end
   end
 
-  platform_is_not :freebsd, :darwin do
+  platform_is_not :freebsd, :darwin, :mingw32 do
     it "always succeeds with any integer values" do
       vals = [-2**30, -2**16, -2**8, -2,
               -1.5, -1, 0.5, 0, 1, 2, 7.77777, 16, 32, 64, 2**8, 2**16, 2**30]
@@ -40,7 +40,7 @@ describe "File.umask" do
     end
   end
 
-  platform_is :freebsd, :darwin do
+  platform_is :freebsd, :darwin, :mingw32 do
     it "always succeeds with any integer values" do
       vals = [-2**8, -2,
               -1.5, -1, 0.5, 0, 1, 2, 7.77777, 16, 32, 64, 2**8]


### PR DESCRIPTION
[r61950](https://github.com/ruby/ruby/commit/de9d264026c870afd79a8843764ccbf60367bb0e) changes `mode_t` to `unsigned short` on MinGW32.

Specs therefore fail with `RangeError (integer -1073741824 too small to convert to unsigned short)`

In contrary `mode_t` is not defined by MSVC but in `ruby.h` as `int`. This is why the platform specifier is set to `:mingw32` instead of `:windows` .

Would be nice, if this could be merged soon, because it [blockes rubyinstaller-head](https://ci.appveyor.com/project/larskanis/rubyinstaller2-hbuor/branch/master) currently.