### PR TITLE
defined? should return nil for toplevel constant referenced with scope for ruby 2.5.0

### DIFF
--- a/spec/ruby/language/defined_spec.rb
+++ b/spec/ruby/language/defined_spec.rb
@@ -752,8 +752,8 @@ describe "The defined? keyword for a scoped constant" do
     defined?(DefinedSpecs::String).should be_nil
   end
 
-  it "returns 'constant' when a constant is defined on top-level but not on the class" do
-    defined?(DefinedSpecs::Basic::String).should == "constant"
+  it "returns nil when a constant is defined on top-level but not on the class" do
+    defined?(DefinedSpecs::Basic::String).should be_nil
   end
 
   it "returns 'constant' if the scoped-scoped constant is defined" do

--- a/test/ruby/test_defined.rb
+++ b/test/ruby/test_defined.rb
@@ -253,4 +253,8 @@ class TestDefined < Test::Unit::TestCase
     assert_equal(nil, obj.func_defined_non_existing_func, bug_11212)
     assert_equal(true, obj.called, bug_11212)
   end
+
+  def test_top_level_constant_not_defined
+    assert_nil(defined?(TestDefined::Object))
+  end
 end

--- a/variable.c
+++ b/variable.c
@@ -2513,6 +2513,11 @@ rb_const_defined_0(VALUE klass, ID id, int exclude, int recurse, int visibility)
 	    if (ce->value == Qundef && !check_autoload_required(tmp, id, 0) &&
 		    !rb_autoloading_value(tmp, id, 0))
 		return (int)Qfalse;
+
+	    if (exclude && tmp == rb_cObject && klass != rb_cObject) {
+		return (int)Qfalse;
+	    }
+
 	    return (int)Qtrue;
 	}
 	if (!recurse) break;


### PR DESCRIPTION
Attempts to fix https://bugs.ruby-lang.org/issues/14407

