### PR TITLE
Fix bug: Vector#angle_with with linearly dependent vectors

### DIFF
--- a/lib/matrix.rb
+++ b/lib/matrix.rb
@@ -2080,8 +2080,9 @@ class Vector
     Vector.Raise ErrDimensionMismatch if size != v.size
     prod = magnitude * v.magnitude
     raise ZeroVectorError, "Can't get angle of zero vector" if prod == 0
-
-    Math.acos( inner_product(v) / prod )
+    return Math.acos(inner_product(v) / prod) if independent?(v)
+    non_zero_index = find_index { |el| !el.zero? }
+    (self[non_zero_index] * v[non_zero_index]).positive? ? 0.0 : Math::PI
   end
 
   #--

--- a/test/matrix/test_vector.rb
+++ b/test/matrix/test_vector.rb
@@ -222,7 +222,9 @@ class TestVector < Test::Unit::TestCase
     assert_in_epsilon(Math::PI, Vector[1, 0].angle_with(Vector[-1, 0]))
     assert_in_epsilon(Math::PI/2, Vector[1, 0].angle_with(Vector[0, -1]))
     assert_in_epsilon(Math::PI/4, Vector[2, 2].angle_with(Vector[0, 1]))
-    assert_in_delta(0.0, Vector[1, 1].angle_with(Vector[1, 1]), 0.00001)
+    assert_equal(Vector[1, 1].angle_with(Vector[1, 1]), 0.0)
+    assert_equal(Vector[6, 6].angle_with(Vector[7, 7]), 0.0)
+    assert_equal(Vector[6, 6].angle_with(Vector[-7, -7]), Math::PI)
 
     assert_raise(Vector::ZeroVectorError) { Vector[1, 1].angle_with(Vector[0, 0]) }
     assert_raise(Vector::ZeroVectorError) { Vector[0, 0].angle_with(Vector[1, 1]) }


### PR DESCRIPTION
Vector#angle_with sometimes raises error with linearly dependent vectors:

```
require 'matrix'
Vector[6, 6].angle_with(Vector[7, 7]) # => Math::DomainError (Numerical argument is out of domain - "acos")
```

This is due to rounding errors:

```
prod = magnitude * v.magnitude # =>  8.48528137423857 * 9.899494936611665 -> 83.99999999999999
Math.acos(inner_product(v) / prod) # => Math.acos(84 / 83.99) -> Math.acos(1.0000000000000002)
```

This patch explicitly return zero/Math::PI for linearly dependent vectors.