### PR TITLE
new VM timestamp variable

### DIFF
--- a/vm.c
+++ b/vm.c
@@ -311,6 +311,7 @@ static VALUE rb_block_param_proxy;
 rb_serial_t
 rb_next_class_serial(void)
 {
+    INC_GLOBAL_TIMESTAMP();
     return NEXT_CLASS_SERIAL();
 }
 
@@ -324,6 +325,7 @@ rb_vm_t *ruby_current_vm_ptr = NULL;
 rb_execution_context_t *ruby_current_execution_context_ptr = NULL;
 rb_event_flag_t ruby_vm_event_flags;
 rb_event_flag_t ruby_vm_event_enabled_flags;
+rb_serial_t ruby_vm_global_timestamp = 1;
 rb_serial_t ruby_vm_global_method_state = 1;
 rb_serial_t ruby_vm_global_constant_state = 1;
 rb_serial_t ruby_vm_class_serial = 1;
@@ -400,6 +402,7 @@ static VALUE
 vm_stat(int argc, VALUE *argv, VALUE self)
 {
     static VALUE sym_global_method_state, sym_global_constant_state, sym_class_serial;
+    static VALUE sym_global_timestamp;
     VALUE arg = Qnil;
     VALUE hash = Qnil, key = Qnil;
 
@@ -417,6 +420,7 @@ vm_stat(int argc, VALUE *argv, VALUE self)
 
     if (sym_global_method_state == 0) {
 #define S(s) sym_##s = ID2SYM(rb_intern_const(#s))
+	S(global_timestamp);
 	S(global_method_state);
 	S(global_constant_state);
 	S(class_serial);
@@ -429,6 +433,7 @@ vm_stat(int argc, VALUE *argv, VALUE self)
     else if (hash != Qnil) \
 	rb_hash_aset(hash, sym_##name, SERIALT2NUM(attr));
 
+    SET(global_timestamp, ruby_vm_global_timestamp);
     SET(global_method_state, ruby_vm_global_method_state);
     SET(global_constant_state, ruby_vm_global_constant_state);
     SET(class_serial, ruby_vm_class_serial);

--- a/vm_insnhelper.h
+++ b/vm_insnhelper.h
@@ -15,6 +15,7 @@
 RUBY_SYMBOL_EXPORT_BEGIN
 
 extern VALUE ruby_vm_const_missing_count;
+extern rb_serial_t ruby_vm_global_timestamp;
 extern rb_serial_t ruby_vm_global_method_state;
 extern rb_serial_t ruby_vm_global_constant_state;
 extern rb_serial_t ruby_vm_class_serial;
@@ -184,6 +185,14 @@ enum vm_regan_acttype {
 #define INC_GLOBAL_METHOD_STATE() (++ruby_vm_global_method_state)
 #define GET_GLOBAL_CONSTANT_STATE() (ruby_vm_global_constant_state)
 #define INC_GLOBAL_CONSTANT_STATE() (++ruby_vm_global_constant_state)
+
+#if RUBY_ATOMIC_GENERIC_MACRO
+# define INC_GLOBAL_TIMESTAMP() ATOMIC_INC(ruby_vm_global_timestamp)
+#elif defined(HAVE_LONG_LONG) && (SIZEOF_SIZE_T == SIZEOF_LONG_LONG)
+# define INC_GLOBAL_TIMESTAMP() ATOMIC_SIZE_INC(ruby_vm_global_timestamp)
+#else
+# define INC_GLOBAL_TIMESTAMP() (++ruby_vm_global_timestamp)
+#endif
 
 static VALUE make_no_method_exception(VALUE exc, VALUE format, VALUE obj,
 				      int argc, const VALUE *argv, int priv);

--- a/vm_method.c
+++ b/vm_method.c
@@ -83,6 +83,7 @@ rb_class_clear_method_cache(VALUE klass, VALUE arg)
 void
 rb_clear_constant_cache(void)
 {
+    INC_GLOBAL_TIMESTAMP();
     INC_GLOBAL_CONSTANT_STATE();
 }
 
@@ -93,6 +94,8 @@ rb_clear_method_cache_by_class(VALUE klass)
 	int global = klass == rb_cBasicObject || klass == rb_cObject || klass == rb_mKernel;
 
 	RUBY_DTRACE_HOOK(METHOD_CACHE_CLEAR, (global ? "global" : rb_class2name(klass)));
+
+	INC_GLOBAL_TIMESTAMP();
 
 	if (global) {
 	    INC_GLOBAL_METHOD_STATE();


### PR DESCRIPTION
This variable is expected to be an integer type which can be incremented
atomically.  Expected to be used where certain object's "freshness" is
vital, e.g. when invalidating a cache.