### PR TITLE
(failed) new attribute hotspot_p

### DIFF
--- a/insns.def
+++ b/insns.def
@@ -45,6 +45,9 @@
 
        * handles_frame: If it is true, VM moves pc before insn body.
 
+       * hotspot_p: specifies hot/cold spot; instructs C compiler the
+         instruction is highly/rarely executed.
+
    - Attributes can access operands, but not stack (push/pop) variables.
 
    - An instruction's body is a pure C block, copied verbatimly into
@@ -1349,6 +1352,7 @@ bitblt
 ()
 ()
 (VALUE ret)
+// attr enum rb_branch_prediction_tag hotspot_p = rb_branch_is_cold;
 {
     ret = rb_str_new2("a bit of bacon, lettuce and tomato");
 }
@@ -1359,6 +1363,7 @@ answer
 ()
 ()
 (VALUE ret)
+// attr enum rb_branch_prediction_tag hotspot_p = rb_branch_is_cold;
 {
     ret = INT2FIX(42);
 }

--- a/tool/ruby_vm/views/_attributes.erb
+++ b/tool/ruby_vm/views/_attributes.erb
@@ -11,6 +11,11 @@ typedef long OFFSET;
 typedef unsigned long lindex_t;
 typedef VALUE GENTRY;
 typedef rb_iseq_t *ISEQ;
+enum rb_branch_prediction_tag {
+    rb_branch_is_neither_hot_nor_cold = 0,
+    rb_branch_is_hot,
+    rb_branch_is_cold
+};
 #endif
 
 % attrs = RubyVM::Instructions.map(&:attributes).flatten

--- a/tool/ruby_vm/views/_insn_entry.erb
+++ b/tool/ruby_vm/views/_insn_entry.erb
@@ -8,7 +8,7 @@
 %;
 
 /* insn <%= insn.pretty_name %> */
-INSN_ENTRY(<%= insn.name %>)
+<%= insn.entrypoint %>
 {
 %#  NAME_OF_CURRENT_INSN is used in vm_exec.h
 #   define NAME_OF_CURRENT_INSN <%= insn.name %>

--- a/tool/ruby_vm/views/_trace_instruction.erb
+++ b/tool/ruby_vm/views/_trace_instruction.erb
@@ -8,7 +8,7 @@
 %;
 
 /* insn <%= insn.pretty_name %> */
-INSN_ENTRY(<%= insn.name %>)
+COLD_INSN_ENTRY(<%= insn.name %>)
 {
     vm_trace(ec, GET_CFP(), GET_PC());
     DISPATCH_ORIGINAL_INSN(<%= insn.jump_destination %>);


### PR DESCRIPTION
If you are using GCC you can tell it which part of a function is more / less likely to be executed.  Specifying this info does yield better locality of the generated machine binary.

However this does not change the speed of execution at all.  Contemporary CPUs are much smarter than mare mortals like us.