### PR TITLE
net/http: use connect_timeout in Socket.tcp

### DIFF
--- a/spec/ruby/library/net/http/http/resolv_timeout_spec.rb
+++ b/spec/ruby/library/net/http/http/resolv_timeout_spec.rb
@@ -1,0 +1,24 @@
+require_relative '../../../../spec_helper'
+require 'net/http'
+
+describe "Net::HTTP#resolv_timeout" do
+  it "returns the seconds to wait until reading one block" do
+    net = Net::HTTP.new("localhost")
+    net.resolv_timeout.should eql(nil)
+    net.resolv_timeout = 10
+    net.resolv_timeout.should eql(10)
+  end
+end
+
+describe "Net::HTTP#resolv_timeout=" do
+  it "sets the seconds to wait till the connection is open" do
+    net = Net::HTTP.new("localhost")
+    net.resolv_timeout = 10
+    net.resolv_timeout.should eql(10)
+  end
+
+  it "returns the newly set value" do
+    net = Net::HTTP.new("localhost")
+    (net.resolv_timeout = 10).should eql(10)
+  end
+end

--- a/spec/ruby/library/socket/socket/tcp_spec.rb
+++ b/spec/ruby/library/socket/socket/tcp_spec.rb
@@ -67,4 +67,10 @@ describe 'Socket.tcp' do
       connection.close
     end
   end
+
+  it 'accepts tcp timeout' do
+    @client = Socket.tcp(@host, @port, resolv_timeout: 1)
+    @client.write('hello')
+    @client.close
+  end
 end


### PR DESCRIPTION
Instead of wrapping TCPSocket.open with a Timeout.timeout, we rely on the kernel's socket connect timeout, avoiding a temporary thread just for the timeout.