### PR TITLE
check CALL_CACHE instead of BASIC_OP_UNREDEFINED_P

### DIFF
--- a/array.c
+++ b/array.c
@@ -1735,7 +1735,7 @@ rb_ary_resize(VALUE ary, long len)
  *     a[3, 0] = "B"               #=> [1, 2, "A", "B"]
  */
 
-static VALUE
+VALUE
 rb_ary_aset(int argc, VALUE *argv, VALUE ary)
 {
     long offset, beg, len;
@@ -1808,7 +1808,7 @@ rb_ary_insert(int argc, VALUE *argv, VALUE ary)
     return ary;
 }
 
-static VALUE
+VALUE
 rb_ary_length(VALUE ary);
 
 static VALUE
@@ -1920,7 +1920,7 @@ rb_ary_reverse_each(VALUE ary)
  *     [].length                  #=> 0
  */
 
-static VALUE
+VALUE
 rb_ary_length(VALUE ary)
 {
     long len = RARRAY_LEN(ary);
@@ -1936,7 +1936,7 @@ rb_ary_length(VALUE ary)
  *     [].empty?   #=> true
  */
 
-static VALUE
+VALUE
 rb_ary_empty_p(VALUE ary)
 {
     if (RARRAY_LEN(ary) == 0)

--- a/hash.c
+++ b/hash.c
@@ -1755,7 +1755,7 @@ rb_hash_size(VALUE hash)
  *
  */
 
-static VALUE
+VALUE
 rb_hash_empty_p(VALUE hash)
 {
     return RHASH_EMPTY_P(hash) ? Qtrue : Qfalse;

--- a/insns.def
+++ b/insns.def
@@ -1003,7 +1003,7 @@ opt_plus
 (VALUE recv, VALUE obj)
 (VALUE val)
 {
-    val = vm_opt_plus(recv, obj);
+    val = vm_opt_plus(recv, obj, cc);
 
     if (val == Qundef) {
 	DISPATCH_ORIGINAL_INSN(opt_send_without_block);
@@ -1017,7 +1017,7 @@ opt_minus
 (VALUE recv, VALUE obj)
 (VALUE val)
 {
-    val = vm_opt_minus(recv, obj);
+    val = vm_opt_minus(recv, obj, cc);
 
     if (val == Qundef) {
 	DISPATCH_ORIGINAL_INSN(opt_send_without_block);
@@ -1031,7 +1031,7 @@ opt_mult
 (VALUE recv, VALUE obj)
 (VALUE val)
 {
-    val = vm_opt_mult(recv, obj);
+    val = vm_opt_mult(recv, obj, cc);
 
     if (val == Qundef) {
 	DISPATCH_ORIGINAL_INSN(opt_send_without_block);
@@ -1045,7 +1045,7 @@ opt_div
 (VALUE recv, VALUE obj)
 (VALUE val)
 {
-    val = vm_opt_div(recv, obj);
+    val = vm_opt_div(recv, obj, cc);
 
     if (val == Qundef) {
 	DISPATCH_ORIGINAL_INSN(opt_send_without_block);
@@ -1059,7 +1059,7 @@ opt_mod
 (VALUE recv, VALUE obj)
 (VALUE val)
 {
-    val = vm_opt_mod(recv, obj);
+    val = vm_opt_mod(recv, obj, cc);
 
     if (val == Qundef) {
 	DISPATCH_ORIGINAL_INSN(opt_send_without_block);
@@ -1102,7 +1102,7 @@ opt_lt
 (VALUE recv, VALUE obj)
 (VALUE val)
 {
-    val = vm_opt_lt(recv, obj);
+    val = vm_opt_lt(recv, obj, cc);
 
     if (val == Qundef) {
 	DISPATCH_ORIGINAL_INSN(opt_send_without_block);
@@ -1116,7 +1116,7 @@ opt_le
 (VALUE recv, VALUE obj)
 (VALUE val)
 {
-    val = vm_opt_le(recv, obj);
+    val = vm_opt_le(recv, obj, cc);
 
     if (val == Qundef) {
 	DISPATCH_ORIGINAL_INSN(opt_send_without_block);
@@ -1130,7 +1130,7 @@ opt_gt
 (VALUE recv, VALUE obj)
 (VALUE val)
 {
-    val = vm_opt_gt(recv, obj);
+    val = vm_opt_gt(recv, obj, cc);
 
     if (val == Qundef) {
 	DISPATCH_ORIGINAL_INSN(opt_send_without_block);
@@ -1144,7 +1144,7 @@ opt_ge
 (VALUE recv, VALUE obj)
 (VALUE val)
 {
-    val = vm_opt_ge(recv, obj);
+    val = vm_opt_ge(recv, obj, cc);
 
     if (val == Qundef) {
 	DISPATCH_ORIGINAL_INSN(opt_send_without_block);
@@ -1158,7 +1158,7 @@ opt_ltlt
 (VALUE recv, VALUE obj)
 (VALUE val)
 {
-    val = vm_opt_ltlt(recv, obj);
+    val = vm_opt_ltlt(recv, obj, cc);
 
     if (val == Qundef) {
 	DISPATCH_ORIGINAL_INSN(opt_send_without_block);
@@ -1172,7 +1172,7 @@ opt_aref
 (VALUE recv, VALUE obj)
 (VALUE val)
 {
-    val = vm_opt_aref(recv, obj);
+    val = vm_opt_aref(recv, obj, cc);
 
     if (val == Qundef) {
 	DISPATCH_ORIGINAL_INSN(opt_send_without_block);
@@ -1186,7 +1186,7 @@ opt_aset
 (VALUE recv, VALUE obj, VALUE set)
 (VALUE val)
 {
-    val = vm_opt_aset(recv, obj, set);
+    val = vm_opt_aset(recv, obj, set, cc);
 
     if (val == Qundef) {
 	DISPATCH_ORIGINAL_INSN(opt_send_without_block);
@@ -1200,7 +1200,7 @@ opt_aset_with
 (VALUE recv, VALUE val)
 (VALUE val)
 {
-    VALUE tmp = vm_opt_aset_with(recv, key, val);
+    VALUE tmp = vm_opt_aset_with(recv, key, val, cc);
 
     if (tmp != Qundef) {
 	val = tmp;
@@ -1220,7 +1220,7 @@ opt_aref_with
 (VALUE recv)
 (VALUE val)
 {
-    val = vm_opt_aref_with(recv, key);
+    val = vm_opt_aref_with(recv, key, cc);
 
     if (val == Qundef) {
 	PUSH(rb_str_resurrect(key));
@@ -1236,7 +1236,7 @@ opt_length
 (VALUE recv)
 (VALUE val)
 {
-    val = vm_opt_length(recv, BOP_LENGTH);
+    val = vm_opt_length(recv, cc);
 
     if (val == Qundef) {
 	DISPATCH_ORIGINAL_INSN(opt_send_without_block);
@@ -1250,7 +1250,7 @@ opt_size
 (VALUE recv)
 (VALUE val)
 {
-    val = vm_opt_length(recv, BOP_SIZE);
+    val = vm_opt_length(recv, cc);
 
     if (val == Qundef) {
 	DISPATCH_ORIGINAL_INSN(opt_send_without_block);
@@ -1264,7 +1264,7 @@ opt_empty_p
 (VALUE recv)
 (VALUE val)
 {
-    val = vm_opt_empty_p(recv);
+    val = vm_opt_empty_p(recv, cc);
 
     if (val == Qundef) {
 	DISPATCH_ORIGINAL_INSN(opt_send_without_block);
@@ -1278,7 +1278,7 @@ opt_succ
 (VALUE recv)
 (VALUE val)
 {
-    val = vm_opt_succ(recv);
+    val = vm_opt_succ(recv, cc);
 
     if (val == Qundef) {
 	DISPATCH_ORIGINAL_INSN(opt_send_without_block);
@@ -1316,7 +1316,7 @@ opt_regexpmatch2
 (VALUE obj2, VALUE obj1)
 (VALUE val)
 {
-    val = vm_opt_regexpmatch2(obj2, obj1);
+    val = vm_opt_regexpmatch2(obj2, obj1, cc);
 
     if (val == Qundef) {
 	DISPATCH_ORIGINAL_INSN(opt_send_without_block);

--- a/numeric.c
+++ b/numeric.c
@@ -1006,7 +1006,7 @@ rb_float_uminus(VALUE flt)
  * Returns a new Float which is the sum of +float+ and +other+.
  */
 
-static VALUE
+VALUE
 flo_plus(VALUE x, VALUE y)
 {
     if (RB_TYPE_P(y, T_FIXNUM)) {
@@ -1030,7 +1030,7 @@ flo_plus(VALUE x, VALUE y)
  * Returns a new Float which is the difference of +float+ and +other+.
  */
 
-static VALUE
+VALUE
 flo_minus(VALUE x, VALUE y)
 {
     if (RB_TYPE_P(y, T_FIXNUM)) {
@@ -1054,7 +1054,7 @@ flo_minus(VALUE x, VALUE y)
  * Returns a new Float which is the product of +float+ and +other+.
  */
 
-static VALUE
+VALUE
 flo_mul(VALUE x, VALUE y)
 {
     if (RB_TYPE_P(y, T_FIXNUM)) {
@@ -1078,7 +1078,7 @@ flo_mul(VALUE x, VALUE y)
  * Returns a new Float which is the result of dividing +float+ by +other+.
  */
 
-static VALUE
+VALUE
 flo_div(VALUE x, VALUE y)
 {
     long f_y;
@@ -1176,7 +1176,7 @@ ruby_float_mod(double x, double y)
  *     6543.21.modulo(137.24)   #=> 92.92999999999961
  */
 
-static VALUE
+VALUE
 flo_mod(VALUE x, VALUE y)
 {
     double fy;
@@ -1489,7 +1489,7 @@ rb_float_gt(VALUE x, VALUE y)
  * so an implementation-dependent value is returned.
  */
 
-static VALUE
+VALUE
 flo_ge(VALUE x, VALUE y)
 {
     double a, b;
@@ -1526,7 +1526,7 @@ flo_ge(VALUE x, VALUE y)
  * so an implementation-dependent value is returned.
  */
 
-static VALUE
+VALUE
 flo_lt(VALUE x, VALUE y)
 {
     double a, b;
@@ -1563,7 +1563,7 @@ flo_lt(VALUE x, VALUE y)
  * so an implementation-dependent value is returned.
  */
 
-static VALUE
+VALUE
 flo_le(VALUE x, VALUE y)
 {
     double a, b;
@@ -4212,7 +4212,7 @@ fix_lt(VALUE x, VALUE y)
     }
 }
 
-static VALUE
+VALUE
 int_lt(VALUE x, VALUE y)
 {
     if (FIXNUM_P(x)) {
@@ -4252,7 +4252,7 @@ fix_le(VALUE x, VALUE y)
     }
 }
 
-static VALUE
+VALUE
 int_le(VALUE x, VALUE y)
 {
     if (FIXNUM_P(x)) {

--- a/string.c
+++ b/string.c
@@ -1859,7 +1859,7 @@ rb_str_bytesize(VALUE str)
  *     "".empty?        #=> true
  */
 
-static VALUE
+VALUE
 rb_str_empty(VALUE str)
 {
     if (RSTRING_LEN(str) == 0)
@@ -3764,7 +3764,7 @@ rb_str_rindex_m(int argc, VALUE *argv, VALUE str)
  *     "cat o' 9 tails" =~ 9      #=> nil
  */
 
-static VALUE
+VALUE
 rb_str_match(VALUE x, VALUE y)
 {
     if (SPECIAL_CONST_P(y)) goto generic;


### PR DESCRIPTION
for instance opt_aset_with is changed like this:

```diff
@@ -3690,10 +3630,9 @@ vm_opt_aref_with(VALUE recv, VALUE key)
 }

 static VALUE
-vm_opt_aset_with(VALUE recv, VALUE key, VALUE val)
+vm_opt_aset_with(VALUE recv, VALUE key, VALUE val, CALL_CACHE cc)
 {
-    if (!SPECIAL_CONST_P(recv) && RBASIC_CLASS(recv) == rb_cHash &&
-       BASIC_OP_UNREDEFINED_P(BOP_ASET, HASH_REDEFINED_OP_FLAG) &&
+    if ((vm_method_cfunc(cc, recv) == rb_hash_aset) &&
        rb_hash_compare_by_id_p(recv) == Qfalse) {
        return rb_hash_aset(recv, key, val);
     }
```

Several macro checks are replaced with vm_method_cfunc(), which returns the function pointer stored in the call cache.

I thought it should reduce memory reads.  However it turned out to be slower than the original.