### PR TITLE
Fix ruby-2.3 OpenSSL 1.1.0 detection

### DIFF
--- a/ext/openssl/extconf.rb
+++ b/ext/openssl/extconf.rb
@@ -42,8 +42,8 @@ result = pkg_config("openssl") && have_header("openssl/ssl.h")
 
 unless result
   result = have_header("openssl/ssl.h")
-  result &&= %w[crypto libeay32].any? {|lib| have_library(lib, "OpenSSL_add_all_digests")}
-  result &&= %w[ssl ssleay32].any? {|lib| have_library(lib, "SSL_library_init")}
+  result &&= %w[crypto libeay32].any? {|lib| have_library(lib, "OpenSSL_add_all_digests") || have_library(lib, "OPENSSL_init_crypto")}
+  result &&= %w[ssl ssleay32].any? {|lib| have_library(lib, "SSL_library_init") || have_library(lib, "OPENSSL_init_ssl")}
   unless result
     Logging::message "=== Checking for required stuff failed. ===\n"
     Logging::message "Makefile wasn't created. Fix the errors above.\n"
@@ -54,7 +54,7 @@ end
 unless have_header("openssl/conf_api.h")
   raise "OpenSSL 0.9.6 or later required."
 end
-unless OpenSSL.check_func("SSL_library_init()", "openssl/ssl.h")
+unless OpenSSL.check_func("SSL_library_init()", "openssl/ssl.h") || OpenSSL.check_func("OPENSSL_init_ssl", "openssl/ssl.h")
   raise "Ignore OpenSSL broken by Apple.\nPlease use another openssl. (e.g. using `configure --with-openssl-dir=/path/to/openssl')"
 end
 


### PR DESCRIPTION
This PR is based of the Ruby 2.3 branch. Ruby trunk behaves differently and does not look like it needs fixing.

Currently `ext/openssl/extconf.rb` detects OpenSSL by checking for a bunch of functions in the OpenSSL headers. This fails with some builds of OpenSSL 1.1.0, since some functions (namely `OpenSSL_add_all_digests()` and `SSL_library_init()`) have been deprecated in 1.1.0 and are not declared any more without OpenSSL's compatibility layer.

This PR extends the checks to also look for OpenSSL 1.1.0-specific functions.

Note that I have *not* tested the branch where `pkg_config("openssl")` fails and manual detection is attempted.