### PR TITLE
Fix compile error when USE_COPY_FILE_RANGE is defined but not USE_SENDFILE

### DIFF
--- a/io.c
+++ b/io.c
@@ -11133,7 +11133,7 @@ static void *
 nogvl_copy_stream_func(void *arg)
 {
     struct copy_stream_struct *stp = (struct copy_stream_struct *)arg;
-#ifdef USE_SENDFILE
+#if defined(USE_SENDFILE) || defined(USE_COPY_FILE_RANGE)
     int ret;
 #endif
 
@@ -11151,7 +11151,7 @@ nogvl_copy_stream_func(void *arg)
 
     nogvl_copy_stream_read_write(stp);
 
-#ifdef USE_SENDFILE
+#if defined(USE_SENDFILE) || defined(USE_COPY_FILE_RANGE)
   finish:
 #endif
     return 0;


### PR DESCRIPTION
Variable and label definition are necessary in both cases. Usually USE_SENDFILE is defined whenever USE_COPY_FILE_RANGE is, but if not it fails to compile.

USE_COPY_FILE_RANGE was introduced in commit 0686d5f4eb4. So this might be backported to ruby-2.5.
