### PR TITLE
Add missing class FrozenError to Exception subclasses list documentation

### DIFF
--- a/error.c
+++ b/error.c
@@ -2234,6 +2234,7 @@ syserr_eqq(VALUE self, VALUE exc)
  *      * FloatDomainError
  *    * RegexpError
  *    * RuntimeError -- default for +raise+
+ *      * FrozenError
  *    * SystemCallError
  *      * Errno::*
  *    * ThreadError


### PR DESCRIPTION
Hi,

I just noticed Exception class documentation [1] doesn't mention the new class FrozenError introduced in 2.5 [2].

If my PR is correct, this should be very straightforward to fix.

Thanks for your feedback.

1. https://ruby-doc.org/core-2.5.0/Exception.html
2. https://github.com/ruby/ruby/commit/b57915eddc91ce0369ae8bcf82d8c4364f42ea05