### PR TITLE
Re-arrange public .alphanumeric method to fix docs

### DIFF
--- a/lib/securerandom.rb
+++ b/lib/securerandom.rb
@@ -222,10 +222,28 @@ module Random::Formatter
     "%08x-%04x-%04x-%04x-%04x%08x" % ary
   end
 
-  private def gen_random(n)
-    self.bytes(n)
+  ALPHANUMERIC = [*'A'..'Z', *'a'..'z', *'0'..'9']
+  # SecureRandom.alphanumeric generates a random alphanumeric string.
+  #
+  # The argument _n_ specifies the length, in characters, of the alphanumeric
+  # string to be generated.
+  #
+  # If _n_ is not specified or is nil, 16 is assumed.
+  # It may be larger in the future.
+  #
+  # The result may contain A-Z, a-z and 0-9.
+  #
+  #   p SecureRandom.alphanumeric #=> "2BuBuLf3WfSKyQbR"
+  #   p SecureRandom.alphanumeric(10) #=> "i6K93NdqiH"
+  #
+  # If a secure random number generator is not available,
+  # +NotImplementedError+ is raised.
+  def alphanumeric(n=nil)
+    n = 16 if n.nil?
+    choose(ALPHANUMERIC, n)
   end
-
+  
+  
   # SecureRandom.choose generates a string that randomly draws from a
   # source array of characters.
   #
@@ -270,25 +288,8 @@ module Random::Formatter
     result
   end
 
-  ALPHANUMERIC = [*'A'..'Z', *'a'..'z', *'0'..'9']
-  # SecureRandom.alphanumeric generates a random alphanumeric string.
-  #
-  # The argument _n_ specifies the length, in characters, of the alphanumeric
-  # string to be generated.
-  #
-  # If _n_ is not specified or is nil, 16 is assumed.
-  # It may be larger in the future.
-  #
-  # The result may contain A-Z, a-z and 0-9.
-  #
-  #   p SecureRandom.alphanumeric #=> "2BuBuLf3WfSKyQbR"
-  #   p SecureRandom.alphanumeric(10) #=> "i6K93NdqiH"
-  #
-  # If a secure random number generator is not available,
-  # +NotImplementedError+ is raised.
-  def alphanumeric(n=nil)
-    n = 16 if n.nil?
-    choose(ALPHANUMERIC, n)
+  private def gen_random(n)
+    self.bytes(n)
   end
 end
 


### PR DESCRIPTION
The `private def` keywords for methods above `.alphanumeric` appear to have caused rdoc generation to not output anything for the method. See http://ruby-doc.org/stdlib-2.5.0/libdoc/securerandom/rdoc/SecureRandom.html

Speaking with one of the ruby-doc maintainers, he was the one who suggested this was the root cause of the missing entry.