### PR TITLE
Fixing some minimal formating on enum.c examples

### DIFF
--- a/enum.c
+++ b/enum.c
@@ -249,13 +249,13 @@ find_i(RB_BLOCK_CALL_FUNC_ARGLIST(i, memop))
  *
  *  If no block is given, an enumerator is returned instead.
  *
- *     (1..100).detect  => #<Enumerator: 1..100:detect>
- *     (1..100).find    => #<Enumerator: 1..100:find>
+ *     (1..100).detect  #=> #<Enumerator: 1..100:detect>
+ *     (1..100).find    #=> #<Enumerator: 1..100:find>
  *
- *     (1..10).detect	{ |i| i % 5 == 0 and i % 7 == 0 }   #=> nil
- *     (1..10).find	{ |i| i % 5 == 0 and i % 7 == 0 }   #=> nil
- *     (1..100).detect	{ |i| i % 5 == 0 and i % 7 == 0 }   #=> 35
- *     (1..100).find	{ |i| i % 5 == 0 and i % 7 == 0 }   #=> 35
+ *     (1..10).detect    { |i| i % 5 == 0 and i % 7 == 0 }   #=> nil
+ *     (1..10).find      { |i| i % 5 == 0 and i % 7 == 0 }   #=> nil
+ *     (1..100).detect   { |i| i % 5 == 0 and i % 7 == 0 }   #=> 35
+ *     (1..100).find     { |i| i % 5 == 0 and i % 7 == 0 }   #=> 35
  *
  */
 
@@ -2274,13 +2274,13 @@ enum_each_with_index(int argc, VALUE *argv, VALUE obj)
  *
  *  If no block is given, an enumerator is returned instead.
  *
- *      (1..3).reverse_each { |v| p v }
+ *     (1..3).reverse_each { |v| p v }
  *
- *    produces:
+ *  produces:
  *
- *      3
- *      2
- *      1
+ *     3
+ *     2
+ *     1
  */
 
 static VALUE


### PR DESCRIPTION
This will fix the formatting shown on `detect`|`find` and `revese_arch`
generated by RDoc.

## Find examples
### Before
![find_before](https://user-images.githubusercontent.com/1037088/36076245-6b21e144-0f0e-11e8-9078-72d57f7fd3c3.png)
### After

![find_after](https://user-images.githubusercontent.com/1037088/36076246-6e72bed6-0f0e-11e8-9703-b6a91014c787.png)

## reverse_each example code
### Before
![reverse_each_before](https://user-images.githubusercontent.com/1037088/36076259-9fa39336-0f0e-11e8-8ed6-2803ebc98d7a.png)
### After
![reverse_each_after](https://user-images.githubusercontent.com/1037088/36076261-a2041920-0f0e-11e8-80f2-88fbe026bb73.png)
