### PR TITLE
Escape MINIRUBY in --make-flags to extmk.rb

### DIFF
--- a/template/configure-ext.mk.tmpl
+++ b/template/configure-ext.mk.tmpl
@@ -24,7 +24,7 @@ end
 MINIRUBY = <%=miniruby%>
 SCRIPT_ARGS = <%=script_args%>
 EXTMK_ARGS = $(SCRIPT_ARGS) --gnumake=$(gnumake) --extflags="$(EXTLDFLAGS)" \
-	   --make-flags='MINIRUBY=$(MINIRUBY)'
+	   --make-flags="MINIRUBY='$(MINIRUBY)'"
 
 all: exts gems
 exts:


### PR DESCRIPTION
If MINIRUBY had arguments, which is the case of cross compiling
they wouldn't be parsed correctly and compiling would fail as a RUBY
without arguments would then be present in the Makefile's in ext/*