### PR TITLE
Bug Fix Enumerator::Lazy#uniq state for multiple call

### DIFF
--- a/enumerator.c
+++ b/enumerator.c
@@ -2240,27 +2240,35 @@ lazy_drop_while(VALUE obj)
 }
 
 static VALUE
-lazy_uniq_i(VALUE i, VALUE hash, int argc, const VALUE *argv, VALUE yielder)
+lazy_uniq_i(VALUE i, int argc, const VALUE *argv, VALUE yielder)
 {
+    VALUE hash;
+
+    hash = rb_attr_get(yielder, id_memo);
+    if (NIL_P(hash)) {
+        hash = rb_obj_hide(rb_hash_new());
+        rb_ivar_set(yielder, id_memo, hash);
+    }
+
     if (rb_hash_add_new_element(hash, i, Qfalse))
 	return Qnil;
     return rb_funcallv(yielder, id_yield, argc, argv);
 }
 
 static VALUE
-lazy_uniq_func(RB_BLOCK_CALL_FUNC_ARGLIST(i, hash))
+lazy_uniq_func(RB_BLOCK_CALL_FUNC_ARGLIST(i, m))
 {
     VALUE yielder = (--argc, *argv++);
     i = rb_enum_values_pack(argc, argv);
-    return lazy_uniq_i(i, hash, argc, argv, yielder);
+    return lazy_uniq_i(i, argc, argv, yielder);
 }
 
 static VALUE
-lazy_uniq_iter(RB_BLOCK_CALL_FUNC_ARGLIST(i, hash))
+lazy_uniq_iter(RB_BLOCK_CALL_FUNC_ARGLIST(i, m))
 {
     VALUE yielder = (--argc, *argv++);
     i = rb_yield_values2(argc, argv);
-    return lazy_uniq_i(i, hash, argc, argv, yielder);
+    return lazy_uniq_i(i, argc, argv, yielder);
 }
 
 static VALUE
@@ -2268,9 +2276,8 @@ lazy_uniq(VALUE obj)
 {
     rb_block_call_func *const func =
 	rb_block_given_p() ? lazy_uniq_iter : lazy_uniq_func;
-    VALUE hash = rb_obj_hide(rb_hash_new());
     return lazy_set_method(rb_block_call(rb_cLazy, id_new, 1, &obj,
-					 func, hash),
+					 func, 0),
 			   0, 0);
 }
 

--- a/spec/ruby/core/enumerator/lazy/uniq_spec.rb
+++ b/spec/ruby/core/enumerator/lazy/uniq_spec.rb
@@ -3,6 +3,26 @@ require File.expand_path('../fixtures/classes', __FILE__)
 
 ruby_version_is '2.4' do
   describe 'Enumerator::Lazy#uniq' do
+    context 'without block' do
+      before :each do
+        @lazy = [0, 1, 0, 1].to_enum.lazy.uniq
+      end
+
+      it 'returns a lazy enumerator' do
+        @lazy.should be_an_instance_of(Enumerator::Lazy)
+        @lazy.force.should == [0, 1]
+      end
+
+      it 'return same value after rewind' do
+        @lazy.force.should == [0, 1]
+        @lazy.force.should == [0, 1]
+      end
+
+      it 'sets the size to nil' do
+        @lazy.size.should == nil
+      end
+    end
+
     context 'when yielded with an argument' do
       before :each do
         @lazy = [0, 1, 2, 3].to_enum.lazy.uniq(&:even?)
@@ -10,6 +30,11 @@ ruby_version_is '2.4' do
 
       it 'returns a lazy enumerator' do
         @lazy.should be_an_instance_of(Enumerator::Lazy)
+        @lazy.force.should == [0, 1]
+      end
+
+      it 'return same value after rewind' do
+        @lazy.force.should == [0, 1]
         @lazy.force.should == [0, 1]
       end
 
@@ -29,6 +54,12 @@ ruby_version_is '2.4' do
           end
         end
         @lazy = enum.lazy
+      end
+
+      it 'return same value after rewind' do
+        enum = @lazy.uniq { |_, label| label.downcase }
+        enum.force.should == [[0, 'foo'], [2, 'bar']]
+        enum.force.should == [[0, 'foo'], [2, 'bar']]
       end
 
       it 'returns all yield arguments as an array' do


### PR DESCRIPTION
Currently

	2.5.0-preview1 :001 > arr = (0..100).lazy.uniq{|i| i % 10}
	 => #<Enumerator::Lazy: #<Enumerator::Lazy: 0..100>:uniq>
	2.5.0-preview1 :002 > arr.to_a
	 => [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
	2.5.0-preview1 :003 > arr.to_a
	 => []


Expected

arr.to_a to always return same output

Fixes https://bugs.ruby-lang.org/issues/14495