### PR TITLE
create Class#to_proc method

### DIFF
--- a/class.c
+++ b/class.c
@@ -147,6 +147,27 @@ rb_class_detach_module_subclasses(VALUE klass)
     rb_class_foreach_subclass(klass, class_detach_module_subclasses, Qnil);
 }
 
+static VALUE
+class_proc_call(VALUE first_arg, VALUE klass, int argc, const VALUE *argv, VALUE passed_proc)
+{
+    return rb_funcallv(klass, rb_intern("new"), argc, argv);
+}
+
+/*
+ *  call-seq:
+ *     klass.to_proc -> Proc
+ *
+ *  Creates a proc that will create class instances with arguments:
+ *
+ *     [0, 1, 2].map(&Array) #=> [[], [nil], [nil, nil]]
+ */
+static VALUE
+rb_class_to_proc(VALUE klass)
+{
+    return rb_func_proc_new(class_proc_call, klass);
+}
+
+
 /**
  * Allocates a struct RClass for a new class.
  *
@@ -560,6 +581,8 @@ Init_class_hierarchy(void)
     RBASIC_SET_CLASS(rb_cModule, rb_cClass);
     RBASIC_SET_CLASS(rb_cObject, rb_cClass);
     RBASIC_SET_CLASS(rb_cBasicObject, rb_cClass);
+
+    rb_define_method(rb_cClass, "to_proc", rb_class_to_proc, 0);
 }
 
 

--- a/test/ruby/test_class.rb
+++ b/test/ruby/test_class.rb
@@ -105,6 +105,21 @@ class TestClass < Test::Unit::TestCase
     end
   end
 
+  def test_to_proc
+    c = Class.new do
+      attr_reader :value
+
+      def initialize(value)
+        @value = value
+      end
+    end
+
+    assert_equal(1, c.to_proc.call(1).value)
+    assert_equal(2, c.to_proc.call(2).value)
+    assert_equal([1, 2], c.to_proc.call([1, 2]).value)
+    assert_raise(ArgumentError) { c.to_proc.call(1, 2) }
+  end
+
   def test_extend_object
     c = Class.new
     assert_raise(TypeError) do


### PR DESCRIPTION
Hello!

This is for this suggestion:
https://bugs.ruby-lang.org/issues/14498

```
class Dog
  attr_reader :name

  def initialize(name)
    @name = name
  end
end

names = %w[Lucky Pluto Balto]
names.map(&Dog)
```


I am pretty sure there's a better way to create instances (without `rb_funcallv`).
And I am not sure if I should've let using only one argument