### PR TITLE
[Docs] Improve Array#sample with random optional parameter documentation

### DIFF
--- a/array.c
+++ b/array.c
@@ -4868,11 +4868,14 @@ rb_ary_shuffle(int argc, VALUE *argv, VALUE ary)
  *  If the array is empty the first form returns +nil+ and the second form
  *  returns an empty array.
  *
- *  The optional +rng+ argument will be used as the random number generator.
- *
  *     a = [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ]
  *     a.sample         #=> 7
  *     a.sample(4)      #=> [6, 4, 2, 5]
+ *
+ *  The optional +rng+ argument will be used as the random number generator.
+ *
+ *     a.sample(random: Random.new(1))     #=> 6
+ *     a.sample(4, random: Random.new(1))  #=> [6, 10, 9, 2]
  */
 
 


### PR DESCRIPTION
# Summary
While I was reading the documentation of `Array#sample` and I saw that I could provide `random: rng`, my first though was that I could provide a `Range`. To avoid this confusion I decided to document this optional extra parameter as the `Array#shuffle` method.

So, this patch:
* Adds examples for the use of the optional parameter random in `Array#sample`
* Unifies the style with the documentation of `Array#shuffle`. This means, documentation has been added in the same fashion of already existing methods like `Array#shuffle`

Many thanks