### PR TITLE
tool/ruby_vm/helpers/dumper.rb: check ERB version

### DIFF
--- a/tool/ruby_vm/helpers/dumper.rb
+++ b/tool/ruby_vm/helpers/dumper.rb
@@ -32,7 +32,8 @@ class RubyVM::Dumper
   rescue Errno::ENOENT
     raise "don't know how to generate #{path}"
   else
-    if RUBY_VERSION >= '2.6'
+    match = ERB.version.match(/\Aerb\.rb \[(?<version>[^ ]+) /)
+    if match && match[:version] >= '2.2.0' # Ruby 2.6+
       erb = ERB.new(src, trim_mode: '%-')
     else
       erb = ERB.new(src, nil, '%-')


### PR DESCRIPTION
I can not `make` trunk (62585) without this patch.
Log:

```
$ make -j4 && make install
        BASERUBY = /home/pocke/.rbenv/shims/ruby --disable=gems
        CC = gcc
        LD = ld
        LDSHARED = gcc -shared
        CFLAGS = -O3 -ggdb3 -Wall -Wextra -Wno-unused-parameter -Wno-parentheses -Wno-long-long -Wno-missing-field-initializers -Wno-tautological-compare -Wno-parentheses-equality -Wno-constant-logical-operand -Wno-self-assign -Wunused-variable -Werror=implicit-int -Werror=pointer-arith -Werror=write-strings -Werror=declaration-after-statement -Werror=implicit-function-declaration -Werror=deprecated-declarations -Werror=misleading-indentation -Wno-overlength-strings -Wno-packed-bitfield-compat -Wsuggest-attribute=noreturn -Wsuggest-attribute=format -Wmissing-noreturn -Wimplicit-fallthrough=0 -Werror=duplicated-cond -Werror=restrict -std=gnu99  -fPIC
        XCFLAGS = -D_FORTIFY_SOURCE=2 -fstack-protector -fno-strict-overflow -DRUBY_DEVEL=1 -fvisibility=hidden -fexcess-precision=standard -DRUBY_EXPORT
        CPPFLAGS =   -I. -I.ext/include/x86_64-linux -I./include -I. -I./enc/unicode/10.0.0
        DLDFLAGS = -Wl,--compress-debug-sections=zlib -Wl,-soname,libruby.so.2.6  -fstack-protector
        SOLIBS = -lpthread -lgmp -ldl -lcrypt -lm
        LANG = en_GB.UTF-8
        LC_ALL =
        LC_CTYPE =
gcc (GCC) 7.3.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

generating opt_sc.inc
generating optunifs.inc
generating insns.inc
generating insns_info.inc
Traceback (most recent call last):
        6: from ./tool/insns2vm.rb:9:in `<main>'
        5: from ./tool/insns2vm.rb:9:in `each'
        4: from ./tool/insns2vm.rb:10:in `block in <main>'
        3: from /home/pocke/ghq/github.com/ruby/ruby/tool/ruby_vm/helpers/dumper.rb:98:in `generate'
        2: from /home/pocke/ghq/github.com/ruby/ruby/tool/ruby_vm/helpers/dumper.rb:76:in `do_render'
        1: from /home/pocke/.rbenv/versions/trunk/lib/ruby/2.6.0/erb.rb:873:in `result'
/home/pocke/.rbenv/versions/trunk/lib/ruby/2.6.0/erb.rb:869:in `block in result': no implicit conversion of Hash into Integer (TypeError)
make: *** [Makefile:534: opt_sc.inc] Error 1
make: *** Waiting for unfinished jobs....
Traceback (most recent call last):
        6: from ./tool/insns2vm.rb:9:in `<main>'
        5: from ./tool/insns2vm.rb:9:in `each'
        4: from ./tool/insns2vm.rb:10:in `block in <main>'
        3: from /home/pocke/ghq/github.com/ruby/ruby/tool/ruby_vm/helpers/dumper.rb:98:in `generate'
        2: from /home/pocke/ghq/github.com/ruby/ruby/tool/ruby_vm/helpers/dumper.rb:76:in `do_render'
        1: from /home/pocke/.rbenv/versions/trunk/lib/ruby/2.6.0/erb.rb:873:in `result'
/home/pocke/.rbenv/versions/trunk/lib/ruby/2.6.0/erb.rb:869:in `block in result': no implicit conversion of Hash into Integer (TypeError)
make: *** [Makefile:534: optunifs.inc] Error 1
Traceback (most recent call last):
        6: from ./tool/insns2vm.rb:9:in `<main>'
        5: from ./tool/insns2vm.rb:9:in `each'
        4: from ./tool/insns2vm.rb:10:in `block in <main>'
        3: from /home/pocke/ghq/github.com/ruby/ruby/tool/ruby_vm/helpers/dumper.rb:98:in `generate'
        2: from /home/pocke/ghq/github.com/ruby/ruby/tool/ruby_vm/helpers/dumper.rb:76:in `do_render'
        1: from /home/pocke/.rbenv/versions/trunk/lib/ruby/2.6.0/erb.rb:873:in `result'
/home/pocke/.rbenv/versions/trunk/lib/ruby/2.6.0/erb.rb:869:in `block in result': no implicit conversion of Hash into Integer (TypeError)
Traceback (most recent call last):
        6: from ./tool/insns2vm.rb:9:in `<main>'
        5: from ./tool/insns2vm.rb:9:in `each'
        4: from ./tool/insns2vm.rb:10:in `block in <main>'
        3: from /home/pocke/ghq/github.com/ruby/ruby/tool/ruby_vm/helpers/dumper.rb:98:in `generate'
        2: from /home/pocke/ghq/github.com/ruby/ruby/tool/ruby_vm/helpers/dumper.rb:76:in `do_render'
        1: from /home/pocke/.rbenv/versions/trunk/lib/ruby/2.6.0/erb.rb:873:in `result'
/home/pocke/.rbenv/versions/trunk/lib/ruby/2.6.0/erb.rb:869:in `block in result': no implicit conversion of Hash into Integer (TypeError)
make: *** [Makefile:534: insns.inc] Error 1
make: *** [Makefile:534: insns_info.inc] Error 1
```

I guess this issue is same as https://bugs.ruby-lang.org/projects/ruby-trunk/repository/revisions/62531
So I applied the same change to tool/ruby_vm/helpers/dumper.rb also.

I'm not sure the cause. What do you think this patch? @k0kubun 