### PR TITLE
Tiny Fix for ASYNC BUG error message copying

### DIFF
--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -1212,7 +1212,7 @@ async_bug_fd(const char *mesg, int errno_arg, int fd)
     char buff[64];
     size_t n = strlcpy(buff, mesg, sizeof(buff));
     if (n < sizeof(buff)-3) {
-	ruby_snprintf(buff, sizeof(buff)-n, "(%d)", fd);
+	ruby_snprintf(buff+n, sizeof(buff)-n, "(%d)", fd);
     }
     rb_async_bug_errno(buff, errno_arg);
 }


### PR DESCRIPTION
The previous logic would overwrite the error message, replacing the message with the `fd` number.

This tiny update will print the message in full.

(I'm trying to debug an issue with the timer thread on my machine and the lack of error messages makes it really hard).