### PR TITLE
uri: do not keep ? and # if given value is empty

### DIFF
--- a/lib/uri/generic.rb
+++ b/lib/uri/generic.rb
@@ -842,7 +842,7 @@ module URI
     #   #=> #<URI::HTTP:0x000000008e89e8 URL:http://my.example.com/?id=1>
     #
     def query=(v)
-      return @query = nil unless v
+      return @query = nil unless v && !v.empty?
       raise InvalidURIError, "query conflicts with opaque" if @opaque
 
       x = v.to_str
@@ -933,7 +933,7 @@ module URI
     #   #=> #<URI::HTTP:0x000000007a81f8 URL:http://my.example.com/?id=25#time=1305212086>
     #
     def fragment=(v)
-      return @fragment = nil unless v
+      return @fragment = nil unless v && !v.empty?
 
       x = v.to_str
       v = x.dup if x.equal? v

--- a/test/uri/test_generic.rb
+++ b/test/uri/test_generic.rb
@@ -156,6 +156,12 @@ class URI::TestGeneric < Test::Unit::TestCase
     assert_equal(nil, url.user)
     assert_equal(nil, url.password)
     assert_equal(nil, url.userinfo)
+
+    # 10
+    url = URI.parse('http://example.com/path?query#fragment')
+    url.query = ''
+    url.fragment = ''
+    assert_equal('http://example.com/path', url.to_s, "[Bug #11149]")
   end
 
   def test_merge


### PR DESCRIPTION
In compliance with WHATWG/URL specification, set to nil if each given values for query and fragment is an empty string.

Fixes: https://bugs.ruby-lang.org/issues/11149

---
Here are the referenced points from the [spec](https://url.spec.whatwg.org/).
```
**The search attribute’s setter must run these steps:**
...
If the given value is the empty string, set url’s query to null, empty context object’s query object’s list, and then return.
...

**The hash attribute’s getter must run these steps:**
...
If the given value is the empty string, then set context object’s url’s fragment to null and return.
...
```

Thanks.