### PR TITLE
Fix setting method visibility on method wrapped with prepend

### DIFF
--- a/spec/ruby/core/module/private_spec.rb
+++ b/spec/ruby/core/module/private_spec.rb
@@ -51,4 +51,43 @@ describe "Module#private" do
       Module.new.send(:private, :undefined)
     end.should raise_error(NameError)
   end
+
+  it "only makes the method private in the class it is called on" do
+    base = Class.new do
+      def wrapped
+        1
+      end
+    end
+
+    klass = Class.new(base) do
+      def wrapped
+        super + 1
+      end
+      private :wrapped
+    end
+
+    base.new.wrapped.should == 1
+    lambda do
+      klass.new.wrapped
+    end.should raise_error(NameError)
+  end
+
+  it "continues to allow a prepended module method to call super" do
+    wrapper = Module.new do
+      def wrapped
+        super + 1
+      end
+    end
+
+    klass = Class.new do
+      prepend wrapper
+
+      def wrapped
+        1
+      end
+      private :wrapped
+    end
+
+    klass.new.wrapped.should == 2
+  end
 end

--- a/vm_method.c
+++ b/vm_method.c
@@ -1054,8 +1054,9 @@ rb_export_method(VALUE klass, ID name, rb_method_visibility_t visi)
 {
     rb_method_entry_t *me;
     VALUE defined_class;
+    VALUE origin_class = RCLASS_ORIGIN(klass);
 
-    me = search_method(klass, name, &defined_class);
+    me = search_method(origin_class, name, &defined_class);
     if (!me && RB_TYPE_P(klass, T_MODULE)) {
 	me = search_method(rb_cObject, name, &defined_class);
     }
@@ -1068,7 +1069,7 @@ rb_export_method(VALUE klass, ID name, rb_method_visibility_t visi)
     if (METHOD_ENTRY_VISI(me) != visi) {
 	rb_vm_check_redefinition_opt_method(me, klass);
 
-	if (klass == defined_class || RCLASS_ORIGIN(klass) == defined_class) {
+	if (klass == defined_class || origin_class == defined_class) {
 	    METHOD_ENTRY_VISI_SET(me, visi);
 
 	    if (me->def->type == VM_METHOD_TYPE_REFINED && me->def->body.refined.orig_me) {


### PR DESCRIPTION
Ignore prepended modules when looking for already defined methods on a
class to set the visibility on.