### PR TITLE
Fix FrozenError on `Ripper.slice`

### DIFF
--- a/ext/ripper/lib/ripper/lexer.rb
+++ b/ext/ripper/lib/ripper/lexer.rb
@@ -186,7 +186,7 @@ class Ripper
       if m = /[^\w\s$()\[\]{}?*+\.]/.match(pattern)
         raise CompileError, "invalid char in pattern: #{m[0].inspect}"
       end
-      buf = ''
+      buf = +''
       pattern.scan(/(?:\w+|\$\(|[()\[\]\{\}?*+\.]+)/) do |tok|
         case tok
         when /\w/


### PR DESCRIPTION
Currently `Ripper.slice` raises a FrozenError

```ruby
require 'ripper'
p Ripper.slice('foo', 'ident')
```

```
/path/to/g/lib/ruby/2.6.0/ripper/lexer.rb:193:in `concat': can't modify frozen String (FrozenError)
	from /path/to/g/lib/ruby/2.6.0/ripper/lexer.rb:193:in `block in compile'
	from /path/to/g/lib/ruby/2.6.0/ripper/lexer.rb:190:in `scan'
	from /path/to/g/lib/ruby/2.6.0/ripper/lexer.rb:190:in `compile'
	from /path/to/g/lib/ruby/2.6.0/ripper/lexer.rb:169:in `initialize'
	from /path/to/g/lib/ruby/2.6.0/ripper/lexer.rb:151:in `new'
	from /path/to/g/lib/ruby/2.6.0/ripper/lexer.rb:151:in `token_match'
	from /path/to/g/lib/ruby/2.6.0/ripper/lexer.rb:144:in `slice'
	from /path2/to/test.rb:2:in `<main>'
```

This patch will fix the problem.
