### PR TITLE
[Docs] Backport 62734 to ruby_2_5

### DIFF
--- a/error.c
+++ b/error.c
@@ -2234,6 +2234,7 @@ syserr_eqq(VALUE self, VALUE exc)
  *      * FloatDomainError
  *    * RegexpError
  *    * RuntimeError -- default for +raise+
+ *      * FrozenError
  *    * SystemCallError
  *      * Errno::*
  *    * ThreadError


### PR DESCRIPTION
Hi,

This is a trivial backport (small documentation fix) request for ruby_2_5.

It was originally merged in trunk (revision 62734) at: https://github.com/ruby/ruby/commit/175c514a0dd4134b43e613934caeaa1c115aefa8

Cheers,

1. https://github.com/ruby/ruby/pull/1818