### PR TITLE
Remove unused variables

### DIFF
--- a/test/logger/test_logger.rb
+++ b/test/logger/test_logger.rb
@@ -326,7 +326,7 @@ class TestLogger < Test::Unit::TestCase
     r, w = IO.pipe
     logger = Logger.new(w)
     logger << "msg"
-    read_ready, = IO.select([r], nil, nil, 0.1)
+    IO.select([r], nil, nil, 0.1)
     w.close
     msg = r.read
     r.close
@@ -335,7 +335,7 @@ class TestLogger < Test::Unit::TestCase
     r, w = IO.pipe
     logger = Logger.new(w)
     logger << "msg2\n\n"
-    read_ready, = IO.select([r], nil, nil, 0.1)
+    IO.select([r], nil, nil, 0.1)
     w.close
     msg = r.read
     r.close


### PR DESCRIPTION
This fixes following warning:

```
test/logger/test_logger.rb:329: warning: assigned but unused variable - read_read
```