### PR TITLE
[Docs] Remove outdated proc.c binding comment.

### DIFF
--- a/proc.c
+++ b/proc.c
@@ -2789,9 +2789,7 @@ env_clone(const rb_env_t *env, const rb_cref_t *cref)
  *  call-seq:
  *     prc.binding    -> binding
  *
- *  Returns the binding associated with <i>prc</i>. Note that
- *  <code>Kernel#eval</code> accepts either a <code>Proc</code> or a
- *  <code>Binding</code> object as its second parameter.
+ *  Returns the binding associated with <i>prc</i>.
  *
  *     def fred(param)
  *       proc {}


### PR DESCRIPTION
The `proc_binding()` has an outdated comment: passing a proc as the second argument to eval is no longer supported. In Ruby 2.4.1:

``` ruby
def fred(param)
  proc {}
end

b = fred(99)
eval("param", b.binding)   #=> 99
eval("param", b)           #=> TypeError: wrong argument type proc (expected binding)
```

The example for this was [removed in 2008](https://github.com/ruby/ruby/commit/861219ce4a8c91a6d94c0d138c2f2bf2b3c2337e#diff-7425ed078bca65febfb9834a8024f288L1590), so this just cleans up after that. 

Thank you!