### PR TITLE
Update Complex#finite? and Complex#infinite? documenation

### DIFF
--- a/complex.c
+++ b/complex.c
@@ -1255,7 +1255,7 @@ nucomp_inspect(VALUE self)
  * call-seq:
  *    cmp.finite?  ->  true or false
  *
- * Returns +true+ if +cmp+'s magnitude is a finite number,
+ * Returns +true+ if +cmp+'s real and imaginary values are both finite numbers,
  * otherwise returns +false+.
  */
 static VALUE

--- a/complex.c
+++ b/complex.c
@@ -1273,10 +1273,8 @@ rb_complex_finite_p(VALUE self)
  * call-seq:
  *    cmp.infinite?  ->  nil or 1
  *
- * Returns values corresponding to the value of +cmp+'s magnitude:
- *
- * +finite+::    +nil+
- * ++Infinity+:: ++1+
+ * Returns +1+ if +cmp+'s real or imaginary value is an infinite number,
+ * otherwise returns +nil+.
  *
  *  For example:
  *


### PR DESCRIPTION
to state what it really does.

According to the documentation, this would be wrong:

```
c = Complex(Float::MAX, Float::MAX)
=> (1.7976931348623157e+308+1.7976931348623157e+308i)
c.finite?
=> true
c.magnitude.finite?
=> false
c.magnitude
=> Infinity
```

Same is true for ``Complex#infinite?``