### PR TITLE
[Docs] Remove outdated example from Numeric documentation

### DIFF
--- a/numeric.c
+++ b/numeric.c
@@ -5277,10 +5277,11 @@ rb_int_s_isqrt(VALUE self, VALUE num)
  *   1.object_id == a.object_id   #=> true
  *
  * There can only ever be one instance of the integer +1+, for example. Ruby ensures this
- * by preventing instantiation and duplication.
+ * by preventing instantiation. If duplication is attempted, the same instance is returned.
  *
- *   Integer.new(1)   #=> NoMethodError: undefined method `new' for Integer:Class
- *   1.dup            #=> TypeError: can't dup Integer
+ *   Integer.new(1)                   #=> NoMethodError: undefined method `new' for Integer:Class
+ *   1.dup                            #=> 1
+ *   1.object_id == 1.dup.object_id   #=> true
  *
  * For this reason, Numeric should be used when defining other numeric classes.
  *


### PR DESCRIPTION
Hi,

While working on implementing some features in JRuby, I just noticed Numeric class documentation [1]  has an outdated example. It warns users that Integers can't be duplicated and that is not true since Ruby 2.4. Since 2.5, Numeric instances can be cloned and duplicated as well [2].

Thanks for your feedback.

1. https://ruby-doc.org/core-2.5.0/Numeric.html
2. https://github.com/ruby/ruby/commit/31ef3124a9db534abcc3e323f5d3cb696eda3bf5