### PR TITLE
[Docs]Fix links of cve

### DIFF
--- a/lib/fileutils.rb
+++ b/lib/fileutils.rb
@@ -656,8 +656,8 @@ module FileUtils
   #
   # For details of this security vulnerability, see Perl's case:
   #
-  # * http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=CAN-2005-0448
-  # * http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=CAN-2004-0452
+  # * http://cve.mitre.org/cgi-bin/cvename.cgi?name=CAN-2005-0448
+  # * http://cve.mitre.org/cgi-bin/cvename.cgi?name=CAN-2004-0452
   #
   # For fileutils.rb, this vulnerability is reported in [ruby-dev:26100].
   #


### PR DESCRIPTION
`http://www.cve.mitre.org/` seem to move `http://cve.mitre.org/`.
I can't access `http://www.cve.mitre.org/`.