### PR TITLE
irb.rb: clear last_error when error did not occur

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -498,8 +498,8 @@ module IRB
             raise
           rescue Exception => exc
           end
+          last_error = exc
           if exc
-            last_error = exc
             handle_exception(exc)
           end
         end


### PR DESCRIPTION
IRB does not clear `last_error` variable, so `last_error` conceals last evaluated value.
I guess it was introduced by r63150.
For example:

```
irb(main):001:0> 1
=> 1
irb(main):002:0> _
=> 1
irb(main):003:0> raise
Traceback (most recent call last):
        2: from /Users/pocke/.rbenv/versions/trunk/bin/irb:11:in `<main>'
        1: from (irb):3
RuntimeError ()
irb(main):004:0> _
=> RuntimeError
irb(main):005:0> 1
=> 1
irb(main):006:0> _
=> RuntimeError
```

`_` on `irb(main):006:0>` should be evaluated as `1`, but it is evaluated as `RuntoimeError`.

This patch fixes this problem.