### PR TITLE
Alias Struct#filter as Array#filter

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -120,6 +120,12 @@ with all sufficient information, see the ChangeLog file or Redmine
 
   * String#split yields each substrings to the block if given. [Feature #4780]
 
+* Struct
+
+  * Aliased methods:
+
+    * Struct#filter is a new alias for Struct#select [Feature #13784]
+
 === Stdlib updates (outstanding ones only)
 
 * ERB

--- a/spec/ruby/core/struct/filter_spec.rb
+++ b/spec/ruby/core/struct/filter_spec.rb
@@ -1,0 +1,10 @@
+require_relative '../../spec_helper'
+require_relative 'shared/select'
+require_relative 'shared/accessor'
+require_relative '../enumerable/shared/enumeratorized'
+
+describe "Struct#filter" do
+  it_behaves_like :struct_select, :filter
+  it_behaves_like :struct_accessor, :filter
+  it_behaves_like :enumeratorized_with_origin_size, :filter, Struct.new(:foo).new
+end

--- a/spec/ruby/core/struct/select_spec.rb
+++ b/spec/ruby/core/struct/select_spec.rb
@@ -1,30 +1,10 @@
 require_relative '../../spec_helper'
-require_relative 'fixtures/classes'
+require_relative 'shared/select'
 require_relative 'shared/accessor'
 require_relative '../enumerable/shared/enumeratorized'
 
 describe "Struct#select" do
-  it "raises an ArgumentError if given any non-block arguments" do
-    lambda { StructClasses::Car.new.select(1) { } }.should raise_error(ArgumentError)
-  end
-
-  it "returns a new array of elements for which block is true" do
-    struct = StructClasses::Car.new("Toyota", "Tercel", "2000")
-    struct.select { |i| i == "2000" }.should == [ "2000" ]
-  end
-
-  it "returns an instance of Array" do
-    struct = StructClasses::Car.new("Ford", "Escort", "1995")
-    struct.select { true }.should be_an_instance_of(Array)
-  end
-
-  describe "without block" do
-    it "returns an instance of Enumerator" do
-      struct = Struct.new(:foo).new
-      struct.select.should be_an_instance_of(Enumerator)
-    end
-  end
-
+  it_behaves_like :struct_select, :select
   it_behaves_like :struct_accessor, :select
   it_behaves_like :enumeratorized_with_origin_size, :select, Struct.new(:foo).new
 end

--- a/spec/ruby/core/struct/shared/select.rb
+++ b/spec/ruby/core/struct/shared/select.rb
@@ -1,0 +1,25 @@
+require_relative '../../../spec_helper'
+require_relative '../fixtures/classes'
+
+describe :struct_select, shared: true do
+  it "raises an ArgumentError if given any non-block arguments" do
+    lambda { StructClasses::Car.new.send(@method, 1) { } }.should raise_error(ArgumentError)
+  end
+
+  it "returns a new array of elements for which block is true" do
+    struct = StructClasses::Car.new("Toyota", "Tercel", "2000")
+    struct.send(@method) { |i| i == "2000" }.should == [ "2000" ]
+  end
+
+  it "returns an instance of Array" do
+    struct = StructClasses::Car.new("Ford", "Escort", "1995")
+    struct.send(@method) { true }.should be_an_instance_of(Array)
+  end
+
+  describe "without block" do
+    it "returns an instance of Enumerator" do
+      struct = Struct.new(:foo).new
+      struct.send(@method).should be_an_instance_of(Enumerator)
+    end
+  end
+end

--- a/struct.c
+++ b/struct.c
@@ -1297,6 +1297,7 @@ InitVM_Struct(void)
     rb_define_method(rb_cStruct, "[]", rb_struct_aref, 1);
     rb_define_method(rb_cStruct, "[]=", rb_struct_aset, 2);
     rb_define_method(rb_cStruct, "select", rb_struct_select, -1);
+    rb_define_method(rb_cStruct, "filter", rb_struct_select, -1);
     rb_define_method(rb_cStruct, "values_at", rb_struct_values_at, -1);
 
     rb_define_method(rb_cStruct, "members", rb_struct_members_m, 0);

--- a/test/ruby/test_struct.rb
+++ b/test/ruby/test_struct.rb
@@ -212,6 +212,13 @@ module TestStruct
     assert_raise(ArgumentError) { o.select(1) }
   end
 
+  def test_filter
+    klass = @Struct.new(:a, :b, :c, :d, :e, :f)
+    o = klass.new(1, 2, 3, 4, 5, 6)
+    assert_equal([1, 3, 5], o.filter {|v| v % 2 != 0 })
+    assert_raise(ArgumentError) { o.filter(1) }
+  end
+
   def test_big_struct
     klass1 = @Struct.new(*('a'..'z').map(&:to_sym))
     o = klass1.new


### PR DESCRIPTION
ref: 
* https://bugs.ruby-lang.org/issues/13784
* https://github.com/ruby/ruby/pull/1784

Currently it is calling `Enumerable#filter`. Don't we have to alias Struct#filter as Array? 🤔 