### PR TITLE
[Doc] Recover example about Queue

### DIFF
--- a/thread_sync.c
+++ b/thread_sync.c
@@ -747,6 +747,8 @@ queue_closed_result(VALUE self, struct rb_queue *q)
  *	  end
  *	end
  *
+ *	consumer.join
+ *
  */
 
 /*


### PR DESCRIPTION
`trunk@42862` dropped example's last line.

https://github.com/ruby/ruby/commit/e334bb2ce5d8876b020ab681f21595e2e1c9d601#diff-8783a9b452e430bcf0d7b0c6e34f1db0L144
https://github.com/ruby/ruby/commit/e334bb2ce5d8876b020ab681f21595e2e1c9d601#diff-38e7b9d781319cfbc49445f8f6625b8aR195

This brings no output.

queue_example1.rb
```ruby
queue = Queue.new

producer = Thread.new do
  5.times do |i|
    sleep rand(i) # simulate expense
    queue << i
    puts "#{i} produced"
  end
end

consumer = Thread.new do
  5.times do |i|
    value = queue.pop
    sleep rand(i/2) # simulate expense
    puts "consumed #{value}"
  end
end
```

queue_example2.rb
```ruby
queue = Queue.new

producer = Thread.new do
  5.times do |i|
    sleep rand(i) # simulate expense
    queue << i
    puts "#{i} produced"
  end
end

consumer = Thread.new do
  5.times do |i|
    value = queue.pop
    sleep rand(i/2) # simulate expense
    puts "consumed #{value}"
  end
end

consumer.join
```

```
$ ruby queue_example1.rb
$
```

```
$ ruby queue_example2.rb
0 produced
1 produced
consumed 0
consumed 1
2 produced
consumed 2
3 produced
consumed 3
4 produced
consumed 4
$
```