### PR TITLE
Fix URI::HTML5ASCIIINCOMPAT backward compatibility issue

### DIFF
--- a/lib/uri/common.rb
+++ b/lib/uri/common.rb
@@ -357,7 +357,7 @@ module URI
   TBLDECWWWCOMP_['+'] = ' '
   TBLDECWWWCOMP_.freeze
 
-  HTML5ASCIIINCOMPAT = defined? Encoding::UTF_7 ? [Encoding::UTF_7, Encoding::UTF_16BE, Encoding::UTF_16LE,
+  HTML5ASCIIINCOMPAT = defined?(Encoding::UTF_7) ? [Encoding::UTF_7, Encoding::UTF_16BE, Encoding::UTF_16LE,
     Encoding::UTF_32BE, Encoding::UTF_32LE] : [] # :nodoc:
 
   # Encode given +str+ to URL-encoded form data.


### PR DESCRIPTION
Since ruby 2.3.0 it returns expression. This commit fixes it to return an
array. 

Bug in Redmine – https://bugs.ruby-lang.org/issues/14711