### PR TITLE
Mac OS X sometimes reports EPROTOTYPE when it actually means EPIPE.

### DIFF
--- a/ext/socket/ancdata.c
+++ b/ext/socket/ancdata.c
@@ -1290,6 +1290,16 @@ bsock_sendmsg_internal(VALUE sock, VALUE data, VALUE vflags,
 	    rb_readwrite_syserr_fail(RB_IO_WAIT_WRITABLE, e,
 				     "sendmsg(2) would block");
 	}
+
+#ifdef __APPLE__
+	/* Mac OS X sometimes reports EPROTOTYPE when it actually means EPIPE. 
+	 * https://bugs.ruby-lang.org/issues/14713
+	 */
+	if (e == EPROTOTYPE) {
+	    e = EPIPE;
+	}
+#endif
+
 	rb_syserr_fail(e, "sendmsg(2)");
     }
 #if defined(HAVE_STRUCT_MSGHDR_MSG_CONTROL)

--- a/io.c
+++ b/io.c
@@ -2941,6 +2941,16 @@ io_write_nonblock(VALUE io, VALUE str, VALUE ex)
 		rb_readwrite_syserr_fail(RB_IO_WAIT_WRITABLE, e, "write would block");
 	    }
 	}
+
+#ifdef __APPLE__
+	/* Mac OS X sometimes reports EPROTOTYPE when it actually means EPIPE. 
+	 * https://bugs.ruby-lang.org/issues/14713
+	 */
+	if (e == EPROTOTYPE) {
+	    e = EPIPE;
+	}
+#endif
+
 	rb_syserr_fail_path(e, fptr->pathv);
     }
 


### PR DESCRIPTION
Please see https://bugs.ruby-lang.org/issues/14713 for more details.

It's challenging to make a test case for this.