### PR TITLE
Thread Scheduler for light weight concurrency.

### DIFF
--- a/cont.c
+++ b/cont.c
@@ -241,11 +241,16 @@ struct rb_fiber_struct {
      */
     unsigned int transferred : 1;
 
+    /* Whether the fiber is allowed to implicitly yield. */
+    unsigned int blocking : 1;
+
     struct coroutine_context context;
     struct fiber_pool_stack stack;
 };
 
 static struct fiber_pool shared_fiber_pool = {NULL, NULL, 0, 0, 0, 0};
+
+static ID fiber_initialize_keywords[2] = {0};
 
 /*
  * FreeBSD require a first (i.e. addr) argument of mmap(2) is not NULL
@@ -1731,7 +1736,7 @@ fiber_alloc(VALUE klass)
 }
 
 static rb_fiber_t*
-fiber_t_alloc(VALUE fiber_value)
+fiber_t_alloc(VALUE fiber_value, unsigned int blocking)
 {
     rb_fiber_t *fiber;
     rb_thread_t *th = GET_THREAD();
@@ -1744,6 +1749,7 @@ fiber_t_alloc(VALUE fiber_value)
     fiber = ZALLOC(rb_fiber_t);
     fiber->cont.self = fiber_value;
     fiber->cont.type = FIBER_CONTEXT;
+    fiber->blocking = blocking;
     cont_init(&fiber->cont, th);
 
     fiber->cont.saved_ec.fiber_ptr = fiber;
@@ -1761,9 +1767,9 @@ fiber_t_alloc(VALUE fiber_value)
 }
 
 static VALUE
-fiber_initialize(VALUE self, VALUE proc, struct fiber_pool * fiber_pool)
+fiber_initialize(VALUE self, VALUE proc, struct fiber_pool * fiber_pool, unsigned int blocking)
 {
-    rb_fiber_t *fiber = fiber_t_alloc(self);
+    rb_fiber_t *fiber = fiber_t_alloc(self, blocking);
 
     fiber->first_proc = proc;
     fiber->stack.base = NULL;
@@ -1791,29 +1797,57 @@ fiber_prepare_stack(rb_fiber_t *fiber)
     sec->local_storage_recursive_hash_for_trace = Qnil;
 }
 
+static struct fiber_pool *
+rb_fiber_pool_default(VALUE pool)
+{
+    return &shared_fiber_pool;
+}
+
+/* :nodoc: */
+static VALUE
+rb_fiber_initialize_kw(int argc, VALUE* argv, VALUE self, int kw_splat)
+{
+    VALUE pool = Qnil;
+    VALUE blocking = Qtrue;
+
+    if (kw_splat != RB_NO_KEYWORDS) {
+      VALUE options = Qnil;
+      VALUE arguments[2] = {Qundef};
+
+      argc = rb_scan_args_kw(kw_splat, argc, argv, ":", &options);
+      rb_get_kwargs(options, fiber_initialize_keywords, 0, 2, arguments);
+
+      blocking = arguments[0];
+      pool = arguments[1];
+    }
+
+    return fiber_initialize(self, rb_block_proc(), rb_fiber_pool_default(pool), RTEST(blocking));
+}
+
 /* :nodoc: */
 static VALUE
 rb_fiber_initialize(int argc, VALUE* argv, VALUE self)
 {
-    return fiber_initialize(self, rb_block_proc(), &shared_fiber_pool);
+    return rb_fiber_initialize_kw(argc, argv, self, rb_keyword_given_p());
 }
 
 VALUE
 rb_fiber_new(rb_block_call_func_t func, VALUE obj)
 {
-    return fiber_initialize(fiber_alloc(rb_cFiber), rb_proc_new(func, obj), &shared_fiber_pool);
+    return fiber_initialize(fiber_alloc(rb_cFiber), rb_proc_new(func, obj), rb_fiber_pool_default(Qnil), 1);
 }
 
 static VALUE
 rb_f_fiber_kw(int argc, VALUE* argv, int kw_splat)
 {
-    VALUE scheduler = rb_current_thread_scheduler();
+    rb_thread_t * th = GET_THREAD();
+    VALUE scheduler = th->scheduler;
     VALUE fiber = Qnil;
     
     if (scheduler != Qnil) {
         fiber = rb_funcall_passing_block_kw(scheduler, rb_intern("fiber"), argc, argv, kw_splat);
     } else {
-        fiber = fiber_initialize(fiber_alloc(rb_cFiber), rb_block_proc(), &shared_fiber_pool);
+        fiber = fiber_initialize(fiber_alloc(rb_cFiber), rb_block_proc(), rb_fiber_pool_default(Qnil), 1);
     }
 
     rb_funcall(fiber, rb_intern("resume"), 0);
@@ -1840,6 +1874,10 @@ rb_fiber_start(void)
 
     VM_ASSERT(th->ec == ruby_current_execution_context_ptr);
     VM_ASSERT(FIBER_RESUMED_P(fiber));
+
+    if (fiber->blocking) {
+        th->blocking += 1;
+    }
 
     EC_PUSH_TAG(th->ec);
     if ((state = EC_EXEC_TAG()) == TAG_NONE) {
@@ -1873,6 +1911,10 @@ rb_fiber_start(void)
         }
         need_interrupt = TRUE;
     }
+
+    // if (fiber->blocking) {
+    //     th->blocking -= 1;
+    // }
 
     rb_fiber_terminate(fiber, need_interrupt);
     VM_UNREACHABLE(rb_fiber_start);
@@ -1913,6 +1955,7 @@ rb_threadptr_root_fiber_setup(rb_thread_t *th)
     fiber->cont.type = FIBER_CONTEXT;
     fiber->cont.saved_ec.fiber_ptr = fiber;
     fiber->cont.saved_ec.thread_ptr = th;
+    fiber->blocking = 1;
     fiber_status_set(fiber, FIBER_RESUMED); /* skip CREATED */
     th->ec = &fiber->cont.saved_ec;
 }
@@ -2065,11 +2108,15 @@ fiber_switch(rb_fiber_t *fiber, int argc, const VALUE *argv, int is_resume, int 
         }
     }
 
+    VM_ASSERT(FIBER_RUNNABLE_P(fiber));
+
     if (is_resume) {
         fiber->prev = fiber_current();
     }
 
-    VM_ASSERT(FIBER_RUNNABLE_P(fiber));
+    if (fiber_current()->blocking) {
+        th->blocking -= 1;
+    }
 
     cont->argc = argc;
     cont->kw_splat = kw_splat;
@@ -2079,6 +2126,10 @@ fiber_switch(rb_fiber_t *fiber, int argc, const VALUE *argv, int is_resume, int 
 
     if (is_resume && FIBER_TERMINATED_P(fiber)) {
         fiber_stack_release(fiber);
+    }
+
+    if (fiber_current()->blocking) {
+        th->blocking += 1;
     }
 
     RUBY_VM_CHECK_INTS(th->ec);
@@ -2092,6 +2143,12 @@ VALUE
 rb_fiber_transfer(VALUE fiber_value, int argc, const VALUE *argv)
 {
     return fiber_switch(fiber_ptr(fiber_value), argc, argv, 0, RB_NO_KEYWORDS);
+}
+
+VALUE
+rb_fiber_blocking_p(VALUE fiber)
+{
+    return (fiber_ptr(fiber)->blocking == 0) ? Qfalse : Qtrue;
 }
 
 void
@@ -2463,6 +2520,9 @@ Init_Cont(void)
 
     fiber_pool_initialize(&shared_fiber_pool, stack_size, FIBER_POOL_INITIAL_SIZE, vm_stack_size);
 
+    fiber_initialize_keywords[0] = rb_intern_const("blocking");
+    fiber_initialize_keywords[1] = rb_intern_const("pool");
+
     char * fiber_shared_fiber_pool_free_stacks = getenv("RUBY_SHARED_FIBER_POOL_FREE_STACKS");
     if (fiber_shared_fiber_pool_free_stacks) {
         shared_fiber_pool.free_stacks = atoi(fiber_shared_fiber_pool_free_stacks);
@@ -2473,6 +2533,7 @@ Init_Cont(void)
     rb_eFiberError = rb_define_class("FiberError", rb_eStandardError);
     rb_define_singleton_method(rb_cFiber, "yield", rb_fiber_s_yield, -1);
     rb_define_method(rb_cFiber, "initialize", rb_fiber_initialize, -1);
+    rb_define_method(rb_cFiber, "blocking?", rb_fiber_blocking_p, 0);
     rb_define_method(rb_cFiber, "resume", rb_fiber_m_resume, -1);
     rb_define_method(rb_cFiber, "raise", rb_fiber_raise, -1);
     rb_define_method(rb_cFiber, "to_s", fiber_to_s, 0);

--- a/doc/fiber.rdoc
+++ b/doc/fiber.rdoc
@@ -1,10 +1,9 @@
-= Fibers
+= Fiber
 
-Fibers are a flow-control primitive which allows the system to suspend and
-resume a block of code explicitly. This is in contrast to threads which can be
-preemptively scheduled at any time. While having a similar memory overhead,
-context switching fibers is typically significantly faster as it does not
-involve a system call.
+Fiber is a flow-control primitive which enable cooperative scheduling of code.
+This is in contrast to threads which can be preemptively scheduled at any time.
+While having a similar memory profiles, the cost of context switching fibers can
+be significantly less than threads as it does not involve a system call.
 
 == Design
 

--- a/doc/fiber.rdoc
+++ b/doc/fiber.rdoc
@@ -1,85 +1,19 @@
 = Fiber
 
-Fiber is a flow-control primitive which enable cooperative scheduling of code.
-This is in contrast to threads which can be preemptively scheduled at any time.
-While having a similar memory profiles, the cost of context switching fibers can
-be significantly less than threads as it does not involve a system call.
+Fiber is a flow-control primitive which enable cooperative scheduling. This is
+in contrast to threads which can be preemptively scheduled at any time. While
+having a similar memory profiles, the cost of context switching fibers can be
+significantly less than threads as it does not involve a system call.
 
 == Design
 
-=== Non-blocking Fibers
-
-We introduce the concept of blocking and non-blocking fibers. This allows us to
-retain compatibility with the existing semantic model which existing code
-expects.
-
-  # The default:
-  Fiber.new(blocking: true) do
-    puts Fiber.current.blocking? # true
-  end.resume
-
-  Fiber.new(blocking: false) do
-    puts Fiber.current.blocking? # false
-  end.resume
-
-We also introduce a new method which simplifes the creation of these
-non-blocking fibers:
-
-  Fiber do
-    puts Fiber.current.blocking? # false
-  end
-
-The purpose of this method is to allow the scheduler to internally decide the
-policy for when to start the fiber, and whether to use symmetric or asymmetric
-fibers.
-
-=== Non-blocking Threads
-
-Threads, by default, are blocking. When switching to a non-blocking fiber, we
-update this state.
-
-  puts Thread.current.blocking? # 1 (true)
-
-  Fiber.new(blocking: false) do
-    puts Thread.current.blocking? # false
-  end.resume
-
-In addition, locking a mutex causes the thread to become blocking:
-
-  mutex = Mutex.new
-
-  puts Thread.current.blocking? # 1 (true)
-
-  Fiber.new(blocking: false) do
-    puts Thread.current.blocking? # false
-    mutex.synchronize do
-      puts Thread.current.blocking? # (1) true
-    end
-
-    puts Thread.current.blocking? # false
-  end.resume
-
-=== Non-blocking Mutex
-
-As a future feature, we may consider introducing non-blocking mutex.
-
-  mutex = Mutex.new(blocking: false)
-  
-  Fiber.new(blocking: false) do
-    puts Thread.current.blocking? # false
-
-    mutex.synchronize do
-      puts Thread.current.blocking? # false
-    end
-  end.resume
-
-Such a design will require extensions to the scheduler interface to support fair
-scheduling of tasks waiting on a non-blocking mutex.
-
 === Thread Scheduler
 
-We introduce a new interface for intercepting blocking operations that occur on
-non-blocking fibers:
+The per-thread fiber scheduler interface is used to intercept blocking
+operations. A typical implementation would be a wrapper for a gem like
+EventMachine or Async. This design provides separation of concerns between the
+event loop implementation and application code. It also allows for layered
+schedulers which can perform instrumentation.
 
   class Scheduler
     # Wait for the given file descriptor to become readable.
@@ -125,9 +59,87 @@ non-blocking fibers:
     end
   end
 
+=== Non-blocking Fibers
+
+We introduce the concept of blocking and non-blocking fibers. By default, fibers
+are blocking and there is no change in behaviour. In contrast, non-blocking
+fibers may invoke specific scheduler hooks when a blocking operation occurs, and
+these hooks may introduce context switching points.
+
+  Fiber.new(blocking: false) do
+    puts Fiber.current.blocking? # false
+
+    # May invoke `Thread.scheduler&.wait_readable`.
+    io.read(...)
+
+    # May invoke `Thread.scheduler&.wait_writable`.
+    io.write(...)
+
+    # Will invoke `Thread.scheduler&.wait_sleep`.
+    sleep(n)
+  end.resume
+
+We also introduce a new method which simplifes the creation of these
+non-blocking fibers:
+
+  Fiber do
+    puts Fiber.current.blocking? # false
+  end
+
+The purpose of this method is to allow the scheduler to internally decide the
+policy for when to start the fiber, and whether to use symmetric or asymmetric
+fibers.
+
+=== Non-blocking Threads
+
+We introduce the concept of blocking and non-blocking threads. By default,
+threads are blocking. When switching to a non-blocking fiber, we track this
+state, and the thread may become non-blocking. When a non-blocking thread
+invokes a blocking operation, it may defer the operation to the thread
+scheduler.
+
+  puts Thread.current.blocking? # 1 (true)
+
+  Fiber.new(blocking: false) do
+    puts Thread.current.blocking? # false
+  end.resume
+
+In addition, locking a mutex causes the thread to become blocking:
+
+  mutex = Mutex.new
+
+  puts Thread.current.blocking? # 1 (true)
+
+  Fiber.new(blocking: false) do
+    puts Thread.current.blocking? # false
+    mutex.synchronize do
+      puts Thread.current.blocking? # (1) true
+    end
+
+    puts Thread.current.blocking? # false
+  end.resume
+
+=== Non-blocking Mutex
+
+As a future feature, we may consider introducing non-blocking mutex.
+
+  mutex = Mutex.new(blocking: false)
+  
+  Fiber.new(blocking: false) do
+    puts Thread.current.blocking? # false
+
+    mutex.synchronize do
+      puts Thread.current.blocking? # false
+    end
+  end.resume
+
+Such a design will require extensions to the scheduler interface to support fair
+scheduling of tasks waiting on a non-blocking mutex.
+
 === Non-blocking I/O
 
-By default, I/O should be marked as non-blocking:
+By default, I/O should be non-blocking. This ensures non-blocking fibers
+provide maximum concurrency.
 
   static int
   rsock_socket0(int domain, int type, int proto)

--- a/doc/fibers.rdoc
+++ b/doc/fibers.rdoc
@@ -30,6 +30,10 @@ non-blocking fibers:
     puts Fiber.current.blocking? # false
   end
 
+The purpose of this method is to allow the scheduler to internally decide the
+policy for when to start the fiber, and whether to use symmetric or asymmetric
+fibers.
+
 === Non-blocking Threads
 
 Threads, by default, are blocking. When switching to a non-blocking fiber, we

--- a/doc/fibers.rdoc
+++ b/doc/fibers.rdoc
@@ -14,61 +14,61 @@ We introduce the concept of blocking and non-blocking fibers. This allows us to
 retain compatibility with the existing semantic model which existing code
 expects.
 
-	# The default:
-	Fiber.new(blocking: true) do
-		puts Fiber.current.blocking? # true
-	end.resume
+  # The default:
+  Fiber.new(blocking: true) do
+    puts Fiber.current.blocking? # true
+  end.resume
 
-	Fiber.new(blocking: false) do
-		puts Fiber.current.blocking? # false
-	end.resume
+  Fiber.new(blocking: false) do
+    puts Fiber.current.blocking? # false
+  end.resume
 
 We also introduce a new method which simplifes the creation of these
 non-blocking fibers:
 
-	Fiber do
-		puts Fiber.current.blocking? # false
-	end
+  Fiber do
+    puts Fiber.current.blocking? # false
+  end
 
 === Non-blocking Threads
 
 Threads, by default, are blocking. When switching to a non-blocking fiber, we
 update this state.
 
-	puts Thread.current.blocking? # 1 (true)
+  puts Thread.current.blocking? # 1 (true)
 
-	Fiber.new(blocking: false) do
-		puts Thread.current.blocking? # false
-	end.resume
+  Fiber.new(blocking: false) do
+    puts Thread.current.blocking? # false
+  end.resume
 
 In addition, locking a mutex causes the thread to become blocking:
 
-	mutex = Mutex.new
+  mutex = Mutex.new
 
-	puts Thread.current.blocking? # 1 (true)
+  puts Thread.current.blocking? # 1 (true)
 
-	Fiber.new(blocking: false) do
-		puts Thread.current.blocking? # false
-		mutex.synchronize do
-			puts Thread.current.blocking? # (1) true
-		end
-		
-		puts Thread.current.blocking? # false
-	end.resume
+  Fiber.new(blocking: false) do
+    puts Thread.current.blocking? # false
+    mutex.synchronize do
+      puts Thread.current.blocking? # (1) true
+    end
+
+    puts Thread.current.blocking? # false
+  end.resume
 
 === Non-blocking Mutex
 
 As a future feature, we may consider introducing non-blocking mutex.
 
-	mutex = Mutex.new(blocking: false)
-	
-	Fiber.new(blocking: false) do
-		puts Thread.current.blocking? # false
-		
-		mutex.synchronize do
-			puts Thread.current.blocking? # false
-		end
-	end.resume
+  mutex = Mutex.new(blocking: false)
+  
+  Fiber.new(blocking: false) do
+    puts Thread.current.blocking? # false
+
+    mutex.synchronize do
+      puts Thread.current.blocking? # false
+    end
+  end.resume
 
 Such a design will require extensions to the scheduler interface to support fair
 scheduling of tasks waiting on a non-blocking mutex.
@@ -78,75 +78,75 @@ scheduling of tasks waiting on a non-blocking mutex.
 We introduce a new interface for intercepting blocking operations that occur on
 non-blocking fibers:
 
-	class Scheduler
-		# Wait for the given file descriptor to become readable.
-		def wait_readable(fd)
-		end
-		
-		# Wait for the given file descriptor to become writable.
-		def wait_writable(fd)
-		end
-		
-		# Wait for the given file descriptor to match the specified events within
-		# the specified timeout.
-		# @param event [Integer] a bit mask of +IO::WAIT_READABLE+,
-		#   `IO::WAIT_WRITABLE` and `IO::WAIT_PRIORITY`.
-		# @param timeout [#to_f] the amount of time to wait for the event.
-		def wait_for_single_fd(fd, events, timeout)
-		end
-		
-		# Sleep the current task for the specified duration, or forever if not
-		# specified.
-		# @param duration [#to_f] the amount of time to sleep.
-		def wait_sleep(duration = nil)
-		end
-		
-		# The Ruby virtual machine is going to enter a system level blocking
-		# operation.
-		def enter_blocking_region
-		end
-		
-		# The Ruby virtual machine has completed the system level blocking
-		# operation.
-		def exit_blocking_region
-		end
-		
-		# Intercept the creation of a non-blocking fiber.
-		def fiber(&block)
-			Fiber.new(blocking: false, &block)
-		end
-		
-		# Invoked when the thread exits.
-		def run
-			# Implement event loop here.
-		end
-	end
+  class Scheduler
+    # Wait for the given file descriptor to become readable.
+    def wait_readable(fd)
+    end
+
+    # Wait for the given file descriptor to become writable.
+    def wait_writable(fd)
+    end
+
+    # Wait for the given file descriptor to match the specified events within
+    # the specified timeout.
+    # @param event [Integer] a bit mask of +IO::WAIT_READABLE+,
+    #   `IO::WAIT_WRITABLE` and `IO::WAIT_PRIORITY`.
+    # @param timeout [#to_f] the amount of time to wait for the event.
+    def wait_for_single_fd(fd, events, timeout)
+    end
+
+    # Sleep the current task for the specified duration, or forever if not
+    # specified.
+    # @param duration [#to_f] the amount of time to sleep.
+    def wait_sleep(duration = nil)
+    end
+
+    # The Ruby virtual machine is going to enter a system level blocking
+    # operation.
+    def enter_blocking_region
+    end
+
+    # The Ruby virtual machine has completed the system level blocking
+    # operation.
+    def exit_blocking_region
+    end
+
+    # Intercept the creation of a non-blocking fiber.
+    def fiber(&block)
+      Fiber.new(blocking: false, &block)
+    end
+
+    # Invoked when the thread exits.
+    def run
+      # Implement event loop here.
+    end
+  end
 
 === Non-blocking I/O
 
 By default, I/O should be marked as non-blocking:
 
-	static int
-	rsock_socket0(int domain, int type, int proto)
-	{
-	#ifdef SOCK_CLOEXEC
-		type |= SOCK_CLOEXEC;
-	#endif
+  static int
+  rsock_socket0(int domain, int type, int proto)
+  {
+  #ifdef SOCK_CLOEXEC
+    type |= SOCK_CLOEXEC;
+  #endif
 
-	#ifdef SOCK_NONBLOCK
-		type |= SOCK_NONBLOCK;
-	#endif
+  #ifdef SOCK_NONBLOCK
+    type |= SOCK_NONBLOCK;
+  #endif
 
-		int result = socket(domain, type, proto);
+    int result = socket(domain, type, proto);
 
-		if (result == -1)
-			return -1;
+    if (result == -1)
+      return -1;
 
-		rb_fd_fix_cloexec(result);
+    rb_fd_fix_cloexec(result);
 
-	#ifndef SOCK_NONBLOCK
-		rsock_make_fd_nonblock(result);
-	#endif
+  #ifndef SOCK_NONBLOCK
+    rsock_make_fd_nonblock(result);
+  #endif
 
-		return result;
-	}
+    return result;
+  }

--- a/doc/fibers.rdoc
+++ b/doc/fibers.rdoc
@@ -1,0 +1,152 @@
+= Fibers
+
+Fibers are a flow-control primitive which allows you to suspend and resume a
+block of code explicitly. This is in contrast to threads which can be
+preemptively scheduled at any time. While having a similar memory overhead,
+context switching fibers is typically significantly faster as it does not
+involve a system call.
+
+== Design
+
+=== Non-blocking Fibers
+
+We introduce the concept of blocking and non-blocking fibers. This allows us to
+retain compatibility with the existing semantic model which existing code
+expects.
+
+	# The default:
+	Fiber.new(blocking: true) do
+		puts Fiber.current.blocking? # true
+	end.resume
+
+	Fiber.new(blocking: false) do
+		puts Fiber.current.blocking? # false
+	end.resume
+
+We also introduce a new method which simplifes the creation of these
+non-blocking fibers:
+
+	Fiber do
+		puts Fiber.current.blocking? # false
+	end
+
+=== Non-blocking Threads
+
+Threads, by default, are blocking. When switching to a non-blocking fiber, we
+update this state.
+
+	puts Thread.current.blocking? # 1 (true)
+
+	Fiber.new(blocking: false) do
+		puts Thread.current.blocking? # false
+	end.resume
+
+In addition, locking a mutex causes the thread to become blocking:
+
+	mutex = Mutex.new
+
+	puts Thread.current.blocking? # 1 (true)
+
+	Fiber.new(blocking: false) do
+		puts Thread.current.blocking? # false
+		mutex.synchronize do
+			puts Thread.current.blocking? # (1) true
+		end
+		
+		puts Thread.current.blocking? # false
+	end.resume
+
+=== Non-blocking Mutex
+
+As a future feature, we may consider introducing non-blocking mutex.
+
+	mutex = Mutex.new(blocking: false)
+	
+	Fiber.new(blocking: false) do
+		puts Thread.current.blocking? # false
+		
+		mutex.synchronize do
+			puts Thread.current.blocking? # false
+		end
+	end.resume
+
+Such a design will require extensions to the scheduler interface to support fair
+scheduling of tasks waiting on a non-blocking mutex.
+
+=== Thread Scheduler
+
+We introduce a new interface for intercepting blocking operations that occur on
+non-blocking fibers:
+
+	class Scheduler
+		# Wait for the given file descriptor to become readable.
+		def wait_readable(fd)
+		end
+		
+		# Wait for the given file descriptor to become writable.
+		def wait_writable(fd)
+		end
+		
+		# Wait for the given file descriptor to match the specified events within
+		# the specified timeout.
+		# @param event [Integer] a bit mask of +IO::WAIT_READABLE+,
+		#   `IO::WAIT_WRITABLE` and `IO::WAIT_PRIORITY`.
+		# @param timeout [#to_f] the amount of time to wait for the event.
+		def wait_for_single_fd(fd, events, timeout)
+		end
+		
+		# Sleep the current task for the specified duration, or forever if not
+		# specified.
+		# @param duration [#to_f] the amount of time to sleep.
+		def wait_sleep(duration = nil)
+		end
+		
+		# The Ruby virtual machine is going to enter a system level blocking
+		# operation.
+		def enter_blocking_region
+		end
+		
+		# The Ruby virtual machine has completed the system level blocking
+		# operation.
+		def exit_blocking_region
+		end
+		
+		# Intercept the creation of a non-blocking fiber.
+		def fiber(&block)
+			Fiber.new(blocking: false, &block)
+		end
+		
+		# Invoked when the thread exits.
+		def run
+			# Implement event loop here.
+		end
+	end
+
+=== Non-blocking I/O
+
+By default, I/O should be marked as non-blocking:
+
+	static int
+	rsock_socket0(int domain, int type, int proto)
+	{
+	#ifdef SOCK_CLOEXEC
+		type |= SOCK_CLOEXEC;
+	#endif
+
+	#ifdef SOCK_NONBLOCK
+		type |= SOCK_NONBLOCK;
+	#endif
+
+		int result = socket(domain, type, proto);
+
+		if (result == -1)
+			return -1;
+
+		rb_fd_fix_cloexec(result);
+
+	#ifndef SOCK_NONBLOCK
+		rsock_make_fd_nonblock(result);
+	#endif
+
+		return result;
+	}

--- a/doc/fibers.rdoc
+++ b/doc/fibers.rdoc
@@ -1,7 +1,7 @@
 = Fibers
 
-Fibers are a flow-control primitive which allows you to suspend and resume a
-block of code explicitly. This is in contrast to threads which can be
+Fibers are a flow-control primitive which allows the system to suspend and
+resume a block of code explicitly. This is in contrast to threads which can be
 preemptively scheduled at any time. While having a similar memory overhead,
 context switching fibers is typically significantly faster as it does not
 involve a system call.

--- a/ext/socket/ancdata.c
+++ b/ext/socket/ancdata.c
@@ -2,7 +2,6 @@
 
 #include <time.h>
 
-int rsock_cmsg_cloexec_state = -1; /* <0: unknown, 0: ignored, >0: working */
 static VALUE sym_wait_readable, sym_wait_writable;
 
 #if defined(HAVE_STRUCT_MSGHDR_MSG_CONTROL)
@@ -1429,10 +1428,7 @@ make_io_for_unix_rights(VALUE ctl, struct cmsghdr *cmh, char *msg_end)
             if (fstat(fd, &stbuf) == -1)
                 rb_raise(rb_eSocket, "invalid fd in SCM_RIGHTS");
             rb_update_max_fd(fd);
-            if (rsock_cmsg_cloexec_state < 0)
-                rsock_cmsg_cloexec_state = rsock_detect_cloexec(fd);
-            if (rsock_cmsg_cloexec_state == 0 || fd <= 2)
-                rb_maygvl_fd_fix_cloexec(fd);
+            rb_maygvl_fd_fix_cloexec(fd);
             if (S_ISSOCK(stbuf.st_mode))
                 io = rsock_init_sock(rb_obj_alloc(rb_cSocket), fd);
             else

--- a/ext/socket/init.c
+++ b/ext/socket/init.c
@@ -408,84 +408,30 @@ rsock_write_nonblock(VALUE sock, VALUE str, VALUE ex)
 }
 #endif /* MSG_DONTWAIT_RELIABLE */
 
-/* returns true if SOCK_CLOEXEC is supported */
-int rsock_detect_cloexec(int fd)
+static int
+rsock_socket0(int domain, int type, int proto)
 {
 #ifdef SOCK_CLOEXEC
-    int flags = fcntl(fd, F_GETFD);
-
-    if (flags == -1)
-	rb_bug("rsock_detect_cloexec: fcntl(%d, F_GETFD) failed: %s", fd, strerror(errno));
-
-    if (flags & FD_CLOEXEC)
-	return 1;
+    type |= SOCK_CLOEXEC;
 #endif
-    return 0;
-}
 
-#ifdef SOCK_CLOEXEC
-static int
-rsock_socket0(int domain, int type, int proto)
-{
-    int ret;
-    static int cloexec_state = -1; /* <0: unknown, 0: ignored, >0: working */
+#ifdef SOCK_NONBLOCK
+    type |= SOCK_NONBLOCK;
+#endif
 
-    if (cloexec_state > 0) { /* common path, if SOCK_CLOEXEC is defined */
-        ret = socket(domain, type|SOCK_CLOEXEC|RSOCK_NONBLOCK_DEFAULT, proto);
-        if (ret >= 0) {
-            if (ret <= 2)
-                goto fix_cloexec;
-            goto update_max_fd;
-        }
-    }
-    else if (cloexec_state < 0) { /* usually runs once only for detection */
-        ret = socket(domain, type|SOCK_CLOEXEC|RSOCK_NONBLOCK_DEFAULT, proto);
-        if (ret >= 0) {
-            cloexec_state = rsock_detect_cloexec(ret);
-            if (cloexec_state == 0 || ret <= 2)
-                goto fix_cloexec;
-            goto update_max_fd;
-        }
-        else if (ret == -1 && errno == EINVAL) {
-            /* SOCK_CLOEXEC is available since Linux 2.6.27.  Linux 2.6.18 fails with EINVAL */
-            ret = socket(domain, type, proto);
-            if (ret != -1) {
-                cloexec_state = 0;
-                /* fall through to fix_cloexec */
-            }
-        }
-    }
-    else { /* cloexec_state == 0 */
-        ret = socket(domain, type, proto);
-    }
-    if (ret == -1)
+    int result = socket(domain, type, proto);
+
+    if (result == -1)
         return -1;
-fix_cloexec:
-    rb_maygvl_fd_fix_cloexec(ret);
-    if (RSOCK_NONBLOCK_DEFAULT) {
-        rsock_make_fd_nonblock(ret);
-    }
-update_max_fd:
-    rb_update_max_fd(ret);
 
-    return ret;
+    rb_fd_fix_cloexec(result);
+
+#ifndef SOCK_NONBLOCK
+    rsock_make_fd_nonblock(result);
+#endif
+
+    return result;
 }
-#else /* !SOCK_CLOEXEC */
-static int
-rsock_socket0(int domain, int type, int proto)
-{
-    int ret = socket(domain, type, proto);
-
-    if (ret == -1)
-        return -1;
-    rb_fd_fix_cloexec(ret);
-    if (RSOCK_NONBLOCK_DEFAULT) {
-        rsock_make_fd_nonblock(ret);
-    }
-
-    return ret;
-}
-#endif /* !SOCK_CLOEXEC */
 
 int
 rsock_socket(int domain, int type, int proto)
@@ -637,6 +583,10 @@ rsock_connect(int fd, const struct sockaddr *sockaddr, int len, int socks)
 void
 rsock_make_fd_nonblock(int fd)
 {
+#ifdef _WIN32
+    return;
+#endif
+
     int flags;
 #ifdef F_GETFL
     flags = fcntl(fd, F_GETFL);
@@ -653,56 +603,34 @@ rsock_make_fd_nonblock(int fd)
 }
 
 static int
-cloexec_accept(int socket, struct sockaddr *address, socklen_t *address_len,
-	       int nonblock)
+cloexec_accept(int socket, struct sockaddr *address, socklen_t *address_len)
 {
-    int ret;
     socklen_t len0 = 0;
-#ifdef HAVE_ACCEPT4
-    static int try_accept4 = 1;
-#endif
-    if (RSOCK_NONBLOCK_DEFAULT) {
-        nonblock = 1;
-    }
     if (address_len) len0 = *address_len;
+
 #ifdef HAVE_ACCEPT4
-    if (try_accept4) {
-        int flags = 0;
-#ifdef SOCK_CLOEXEC
-        flags |= SOCK_CLOEXEC;
-#endif
+    int flags = SOCK_CLOEXEC;
+
 #ifdef SOCK_NONBLOCK
-        if (nonblock) {
-            flags |= SOCK_NONBLOCK;
-        }
+    flags |= SOCK_NONBLOCK;
 #endif
-        ret = accept4(socket, address, address_len, flags);
-        /* accept4 is available since Linux 2.6.28, glibc 2.10. */
-        if (ret != -1) {
-            if (ret <= 2)
-                rb_maygvl_fd_fix_cloexec(ret);
+
+    int result = accept4(socket, address, address_len, flags);
+    if (result == -1) return -1;
+
 #ifndef SOCK_NONBLOCK
-            if (nonblock) {
-                rsock_make_fd_nonblock(ret);
-            }
+    rsock_make_fd_nonblock(result);
 #endif
-            if (address_len && len0 < *address_len) *address_len = len0;
-            return ret;
-        }
-        if (errno != ENOSYS) {
-            return -1;
-        }
-        try_accept4 = 0;
-    }
+#else
+    int result = accept(socket, address, address_len);
+    if (result == -1) return -1;
+
+    rb_maygvl_fd_fix_cloexec(result);
+    rsock_make_fd_nonblock(result);
 #endif
-    ret = accept(socket, address, address_len);
-    if (ret == -1) return -1;
+
     if (address_len && len0 < *address_len) *address_len = len0;
-    rb_maygvl_fd_fix_cloexec(ret);
-    if (nonblock) {
-        rsock_make_fd_nonblock(ret);
-    }
-    return ret;
+    return result;
 }
 
 VALUE
@@ -712,7 +640,7 @@ rsock_s_accept_nonblock(VALUE klass, VALUE ex, rb_io_t *fptr,
     int fd2;
 
     rb_io_set_nonblock(fptr);
-    fd2 = cloexec_accept(fptr->fd, (struct sockaddr*)sockaddr, len, 1);
+    fd2 = cloexec_accept(fptr->fd, (struct sockaddr*)sockaddr, len);
     if (fd2 < 0) {
 	int e = errno;
 	switch (e) {
@@ -744,7 +672,7 @@ static VALUE
 accept_blocking(void *data)
 {
     struct accept_arg *arg = data;
-    return (VALUE)cloexec_accept(arg->fd, arg->sockaddr, arg->len, 0);
+    return (VALUE)cloexec_accept(arg->fd, arg->sockaddr, arg->len);
 }
 
 VALUE

--- a/ext/socket/rubysocket.h
+++ b/ext/socket/rubysocket.h
@@ -42,7 +42,7 @@
  */
 #  define RSOCK_NONBLOCK_DEFAULT (0)
 #else
-#  define RSOCK_NONBLOCK_DEFAULT (0)
+#  define RSOCK_NONBLOCK_DEFAULT (SOCK_NONBLOCK)
 #  include <sys/socket.h>
 #  include <netinet/in.h>
 #  ifdef HAVE_NETINET_IN_SYSTM_H

--- a/ext/socket/rubysocket.h
+++ b/ext/socket/rubysocket.h
@@ -42,7 +42,11 @@
  */
 #  define RSOCK_NONBLOCK_DEFAULT (0)
 #else
-#  define RSOCK_NONBLOCK_DEFAULT (SOCK_NONBLOCK)
+#  if defined(SOCK_NONBLOCK)
+#    define RSOCK_NONBLOCK_DEFAULT (SOCK_NONBLOCK)
+#  else
+#    define RSOCK_NONBLOCK_DEFAULT (1)
+#  endif
 #  include <sys/socket.h>
 #  include <netinet/in.h>
 #  ifdef HAVE_NETINET_IN_SYSTM_H

--- a/ext/socket/rubysocket.h
+++ b/ext/socket/rubysocket.h
@@ -36,17 +36,7 @@
 #  if defined(_MSC_VER)
 #    undef HAVE_TYPE_STRUCT_SOCKADDR_DL
 #  endif
-/*
- * FIXME: failures if we make nonblocking the default
- * [ruby-core:89973] [ruby-core:89976] [ruby-core:89977] [Bug #14968]
- */
-#  define RSOCK_NONBLOCK_DEFAULT (0)
 #else
-#  if defined(SOCK_NONBLOCK)
-#    define RSOCK_NONBLOCK_DEFAULT (SOCK_NONBLOCK)
-#  else
-#    define RSOCK_NONBLOCK_DEFAULT (1)
-#  endif
 #  include <sys/socket.h>
 #  include <netinet/in.h>
 #  ifdef HAVE_NETINET_IN_SYSTM_H
@@ -264,7 +254,6 @@ typedef union {
 #define INET_SOCKS  2
 
 extern int rsock_do_not_reverse_lookup;
-extern int rsock_cmsg_cloexec_state;
 #define FMODE_NOREVLOOKUP 0x100
 
 /* common socket families only */

--- a/ext/socket/socket.c
+++ b/ext/socket/socket.c
@@ -168,93 +168,47 @@ pair_yield(VALUE pair)
 #endif
 
 #if defined HAVE_SOCKETPAIR
-
+static int
+rsock_socketpair0(int domain, int type, int protocol, int descriptors[2])
+{
 #ifdef SOCK_CLOEXEC
-static int
-rsock_socketpair0(int domain, int type, int protocol, int sv[2])
-{
-    int ret;
-    static int cloexec_state = -1; /* <0: unknown, 0: ignored, >0: working */
-    static const int default_flags = SOCK_CLOEXEC|RSOCK_NONBLOCK_DEFAULT;
+    type |= SOCK_CLOEXEC;
+#endif
 
-    if (cloexec_state > 0) { /* common path, if SOCK_CLOEXEC is defined */
-        ret = socketpair(domain, type|default_flags, protocol, sv);
-        if (ret == 0 && (sv[0] <= 2 || sv[1] <= 2)) {
-            goto fix_cloexec; /* highly unlikely */
-        }
-        goto update_max_fd;
-    }
-    else if (cloexec_state < 0) { /* usually runs once only for detection */
-        ret = socketpair(domain, type|default_flags, protocol, sv);
-        if (ret == 0) {
-            cloexec_state = rsock_detect_cloexec(sv[0]);
-            if ((cloexec_state == 0) || (sv[0] <= 2 || sv[1] <= 2))
-                goto fix_cloexec;
-            goto update_max_fd;
-        }
-        else if (ret == -1 && errno == EINVAL) {
-            /* SOCK_CLOEXEC is available since Linux 2.6.27.  Linux 2.6.18 fails with EINVAL */
-            ret = socketpair(domain, type, protocol, sv);
-            if (ret != -1) {
-                /* The reason of EINVAL may be other than SOCK_CLOEXEC.
-                 * So disable SOCK_CLOEXEC only if socketpair() succeeds without SOCK_CLOEXEC.
-                 * Ex. Socket.pair(:UNIX, 0xff) fails with EINVAL.
-                 */
-                cloexec_state = 0;
-            }
-        }
-    }
-    else { /* cloexec_state == 0 */
-        ret = socketpair(domain, type, protocol, sv);
-    }
-    if (ret == -1) {
+#ifdef SOCK_NONBLOCK
+    type |= SOCK_NONBLOCK;
+#endif
+
+    int result = socketpair(domain, type, protocol, descriptors);
+
+    if (result == -1)
         return -1;
-    }
 
-fix_cloexec:
-    rb_maygvl_fd_fix_cloexec(sv[0]);
-    rb_maygvl_fd_fix_cloexec(sv[1]);
-    if (RSOCK_NONBLOCK_DEFAULT) {
-        rsock_make_fd_nonblock(sv[0]);
-        rsock_make_fd_nonblock(sv[1]);
-    }
+#ifndef SOCK_CLOEXEC
+    rb_fd_fix_cloexec(descriptors[0]);
+    rb_fd_fix_cloexec(descriptors[1]);
+#endif
 
-update_max_fd:
-    rb_update_max_fd(sv[0]);
-    rb_update_max_fd(sv[1]);
+#ifndef SOCK_NONBLOCK
+    rsock_make_fd_nonblock(descriptors[0]);
+    rsock_make_fd_nonblock(descriptors[1]);
+#endif
 
-    return ret;
+    return result;
 }
-#else /* !SOCK_CLOEXEC */
-static int
-rsock_socketpair0(int domain, int type, int protocol, int sv[2])
-{
-    int ret = socketpair(domain, type, protocol, sv);
-
-    if (ret == -1)
-	return -1;
-
-    rb_fd_fix_cloexec(sv[0]);
-    rb_fd_fix_cloexec(sv[1]);
-    if (RSOCK_NONBLOCK_DEFAULT) {
-        rsock_make_fd_nonblock(sv[0]);
-        rsock_make_fd_nonblock(sv[1]);
-    }
-    return ret;
-}
-#endif /* !SOCK_CLOEXEC */
 
 static int
-rsock_socketpair(int domain, int type, int protocol, int sv[2])
+rsock_socketpair(int domain, int type, int protocol, int descriptors[2])
 {
-    int ret;
+    int result;
 
-    ret = rsock_socketpair0(domain, type, protocol, sv);
-    if (ret < 0 && rb_gc_for_fd(errno)) {
-        ret = rsock_socketpair0(domain, type, protocol, sv);
+    result = rsock_socketpair0(domain, type, protocol, descriptors);
+
+    if (result < 0 && rb_gc_for_fd(errno)) {
+        result = rsock_socketpair0(domain, type, protocol, descriptors);
     }
 
-    return ret;
+    return result;
 }
 
 /*

--- a/ext/socket/unixsocket.c
+++ b/ext/socket/unixsocket.c
@@ -455,11 +455,7 @@ retry:
 #endif
 
     rb_update_max_fd(fd);
-
-    if (rsock_cmsg_cloexec_state < 0)
-	rsock_cmsg_cloexec_state = rsock_detect_cloexec(fd);
-    if (rsock_cmsg_cloexec_state == 0 || fd <= 2)
-	rb_maygvl_fd_fix_cloexec(fd);
+    rb_maygvl_fd_fix_cloexec(fd);
 
     if (klass == Qnil)
 	return INT2FIX(fd);

--- a/include/ruby/3/intern/cont.h
+++ b/include/ruby/3/intern/cont.h
@@ -28,6 +28,7 @@ RUBY3_SYMBOL_EXPORT_BEGIN()
 
 /* cont.c */
 VALUE rb_fiber_new(rb_block_call_func_t, VALUE);
+VALUE rb_fiber_new_kw(rb_block_call_func_t, VALUE, int kw_splat);
 VALUE rb_fiber_resume(VALUE fib, int argc, const VALUE *argv);
 VALUE rb_fiber_resume_kw(VALUE fib, int argc, const VALUE *argv, int kw_splat);
 VALUE rb_fiber_yield(int argc, const VALUE *argv);

--- a/include/ruby/3/intern/thread.h
+++ b/include/ruby/3/intern/thread.h
@@ -72,6 +72,10 @@ VALUE rb_mutex_unlock(VALUE mutex);
 VALUE rb_mutex_sleep(VALUE self, VALUE timeout);
 VALUE rb_mutex_synchronize(VALUE mutex, VALUE (*func)(VALUE arg), VALUE arg);
 
+VALUE rb_thread_scheduler_get(VALUE);
+VALUE rb_thread_scheduler_set(VALUE, VALUE);
+VALUE rb_current_thread_scheduler(void);
+
 RUBY3_SYMBOL_EXPORT_END()
 
 #endif /* RUBY3_INTERN_THREAD_H */

--- a/io.c
+++ b/io.c
@@ -399,8 +399,6 @@ rb_fd_set_nonblock(int fd)
 int
 rb_cloexec_pipe(int descriptors[2])
 {
-    int ret;
-
 #ifdef HAVE_PIPE2
     int result = pipe2(descriptors, O_CLOEXEC | O_NONBLOCK);
 #else

--- a/io.c
+++ b/io.c
@@ -181,7 +181,7 @@ off_t __syscall(quad_t number, ...);
 #  define RUBY_PIPE_NONBLOCK_DEFAULT    (0)
 #elif defined(O_NONBLOCK)
   /* disabled for [Bug #15356] (Rack::Deflater + rails) failure: */
-#  define RUBY_PIPE_NONBLOCK_DEFAULT    (0)
+#  define RUBY_PIPE_NONBLOCK_DEFAULT    (O_NONBLOCK)
 #else /* any platforms where O_NONBLOCK does not exist? */
 #  define RUBY_PIPE_NONBLOCK_DEFAULT    (0)
 #endif

--- a/io.c
+++ b/io.c
@@ -13303,6 +13303,10 @@ Init_IO(void)
     rb_cIO = rb_define_class("IO", rb_cObject);
     rb_include_module(rb_cIO, rb_mEnumerable);
 
+    rb_define_const(rb_cIO, "WAIT_READABLE", INT2NUM(RB_WAITFD_IN));
+    rb_define_const(rb_cIO, "WAIT_PRIORITY", INT2NUM(RB_WAITFD_PRI));
+    rb_define_const(rb_cIO, "WAIT_WRITABLE", INT2NUM(RB_WAITFD_OUT));
+
     /* exception to wait for reading. see IO.select. */
     rb_mWaitReadable = rb_define_module_under(rb_cIO, "WaitReadable");
     /* exception to wait for writing. see IO.select. */

--- a/process.c
+++ b/process.c
@@ -4894,9 +4894,14 @@ rb_f_spawn(int argc, VALUE *argv, VALUE _)
 static VALUE
 rb_f_sleep(int argc, VALUE *argv, VALUE _)
 {
-    time_t beg, end;
+    VALUE scheduler = rb_current_thread_scheduler();
 
-    beg = time(0);
+    if (scheduler != Qnil) {
+        VALUE result = rb_funcallv(scheduler, rb_intern("wait_sleep"), argc, argv);
+        return RTEST(result);
+    }
+
+    time_t beg = time(0);
     if (argc == 0) {
 	rb_thread_sleep_forever();
     }
@@ -4905,7 +4910,7 @@ rb_f_sleep(int argc, VALUE *argv, VALUE _)
 	rb_thread_wait_for(rb_time_interval(argv[0]));
     }
 
-    end = time(0) - beg;
+    time_t end = time(0) - beg;
 
     return INT2FIX(end);
 }

--- a/spec/ruby/library/socket/basicsocket/read_nonblock_spec.rb
+++ b/spec/ruby/library/socket/basicsocket/read_nonblock_spec.rb
@@ -24,7 +24,7 @@ describe "BasicSocket#read_nonblock" do
     platform_is :linux do
       it 'does not set the IO in nonblock mode' do
         require 'io/nonblock'
-        @r.nonblock?.should == false
+        @r.nonblock = false
         IO.select([@r], nil, nil, 2)
         @r.read_nonblock(3).should == "aaa"
         @r.nonblock?.should == false
@@ -34,7 +34,7 @@ describe "BasicSocket#read_nonblock" do
     platform_is_not :linux, :windows do
       it 'sets the IO in nonblock mode' do
         require 'io/nonblock'
-        @r.nonblock?.should == false
+        @r.nonblock = false
         IO.select([@r], nil, nil, 2)
         @r.read_nonblock(3).should == "aaa"
         @r.nonblock?.should == true

--- a/spec/ruby/library/socket/basicsocket/write_nonblock_spec.rb
+++ b/spec/ruby/library/socket/basicsocket/write_nonblock_spec.rb
@@ -25,7 +25,7 @@ describe "BasicSocket#write_nonblock" do
     platform_is :linux do
       it 'does not set the IO in nonblock mode' do
         require 'io/nonblock'
-        @w.nonblock?.should == false
+        @w.nonblock = false
         @w.write_nonblock("aaa").should == 3
         @w.nonblock?.should == false
       end
@@ -34,7 +34,7 @@ describe "BasicSocket#write_nonblock" do
     platform_is_not :linux, :windows do
       it 'sets the IO in nonblock mode' do
         require 'io/nonblock'
-        @w.nonblock?.should == false
+        @w.nonblock = false
         @w.write_nonblock("aaa").should == 3
         @w.nonblock?.should == true
       end

--- a/test/io/nonblock/http.rb
+++ b/test/io/nonblock/http.rb
@@ -33,27 +33,34 @@ def fetch_topics(topics, blocking: true)
 	return responses
 end
 
-scheduler = Scheduler.new
-Thread.current.scheduler = scheduler
-
 Benchmark.benchmark do |benchmark|
 	benchmark.report("blocking") do
 		puts
 		
-		Fiber.new(blocking: true) do
-			pp fetch_topics(TOPICS, blocking: true)
-		end.resume
-		
-		scheduler.run
+		Thread.new do
+			scheduler = Scheduler.new
+			Thread.current.scheduler = scheduler
+			
+			Fiber.new(blocking: true) do
+				pp fetch_topics(TOPICS, blocking: true)
+			end.resume
+			
+			scheduler.run
+		end.join
 	end
 	
 	benchmark.report("nonblocking") do
 		puts
 		
-		Fiber.new(blocking: false) do
-			pp fetch_topics(TOPICS, blocking: false)
-		end.resume
-		
-		scheduler.run
+		Thread.new do
+			scheduler = Scheduler.new
+			Thread.current.scheduler = scheduler
+			
+			Fiber.new(blocking: false) do
+				pp fetch_topics(TOPICS, blocking: false)
+			end.resume
+			
+			scheduler.run
+		end
 	end
 end

--- a/test/io/nonblock/http.rb
+++ b/test/io/nonblock/http.rb
@@ -1,0 +1,59 @@
+
+require 'benchmark'
+
+TOPICS = ["cats", "dogs", "pigs", "skeletons"]
+
+require 'net/http'
+require 'uri'
+require_relative 'scheduler'
+
+def fetch_topics(topics, blocking: true)
+	responses = {}
+	
+	conditions = topics.map do |topic|
+		condition = Scheduler::Condition.new
+		
+		Fiber.new(blocking: blocking) do
+			puts "Fetching #{topic} (#{Thread.current.blocking?})"
+			
+			uri = URI("https://www.google.com/search?q=#{topic}")
+			responses[topic] = Net::HTTP.get(uri).scan(topic).size
+			
+			puts "Finished fetching #{topic}"
+			
+			condition.signal
+		end.resume
+		
+		condition
+	end
+	
+	# Wait for all requests to finish:
+	conditions.each(&:wait)
+	
+	return responses
+end
+
+scheduler = Scheduler.new
+Thread.current.scheduler = scheduler
+
+Benchmark.benchmark do |benchmark|
+	benchmark.report("blocking") do
+		puts
+		
+		Fiber.new(blocking: true) do
+			pp fetch_topics(TOPICS, blocking: true)
+		end.resume
+		
+		scheduler.run
+	end
+	
+	benchmark.report("nonblocking") do
+		puts
+		
+		Fiber.new(blocking: false) do
+			pp fetch_topics(TOPICS, blocking: false)
+		end.resume
+		
+		scheduler.run
+	end
+end

--- a/test/io/nonblock/scheduler.rb
+++ b/test/io/nonblock/scheduler.rb
@@ -126,17 +126,17 @@ class Scheduler
 
     return true
   end
-  
+
   def enter_blocking_region
     # puts "Enter blocking region: #{caller.first}"
   end
-  
+
   def exit_blocking_region
     # puts "Exit blocking region: #{caller.first}"
     @blocking << caller.first
   end
-  
+
   def fiber(&block)
-    Fiber.new(&block)
+    Fiber.new(blocking: false, &block)
   end
 end

--- a/test/io/nonblock/scheduler.rb
+++ b/test/io/nonblock/scheduler.rb
@@ -133,11 +133,11 @@ class Scheduler
     # puts "wait_for_single_fd(#{fd}, #{events}, #{duration})"
     io = IO.for_fd(fd, autoclose: false)
 
-    unless (events & 1).zero?
+    unless (events & IO::WAIT_READABLE).zero?
       @readable[io] = Fiber.current
     end
 
-    unless (events & 2).zero?
+    unless (events & IO::WAIT_WRITABLE).zero?
       @writable[io] = Fiber.current
     end
 

--- a/test/io/nonblock/scheduler.rb
+++ b/test/io/nonblock/scheduler.rb
@@ -9,6 +9,28 @@ rescue LoadError
 end
 
 class Scheduler
+  class Condition
+    def initialize
+      @waiting = []
+      @signalled = false
+    end
+
+    def signal
+      @signalled = true
+
+      while fiber = @waiting.shift
+        fiber.resume
+      end
+    end
+
+    def wait
+      unless @signalled
+        @waiting << Fiber.current
+        Fiber.yield
+      end
+    end
+  end
+  
   def initialize
     @readable = {}
     @writable = {}

--- a/test/io/nonblock/scheduler.rb
+++ b/test/io/nonblock/scheduler.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+require 'fiber'
+
+begin
+  require 'io/nonblock'
+rescue LoadError
+  # Ignore.
+end
+
+class Scheduler
+  def initialize
+    @readable = {}
+    @writable = {}
+    @waiting = {}
+    @blocking = []
+
+    @fiber = Fiber.current
+  end
+
+  attr :fiber
+
+  attr :readable
+  attr :writable
+  attr :waiting
+  attr :blocking
+
+  def next_timeout
+    fiber, timeout = @waiting.min_by{|key, value| value}
+
+    if timeout
+      offset = timeout - current_time
+
+      if offset < 0
+        return 0
+      else
+        return offset
+      end
+    end
+  end
+
+  def run
+    while @readable.any? or @writable.any? or @waiting.any?
+      # Can only handle file descriptors up to 1024...
+      readable, writable = IO.select(@readable.keys, @writable.keys, [], next_timeout)
+
+      # puts "readable: #{readable}" if readable&.any?
+      # puts "writable: #{writable}" if writable&.any?
+
+      readable&.each do |io|
+        @readable[io]&.transfer
+      end
+
+      writable&.each do |io|
+        @writable[io]&.transfer
+      end
+
+      if @waiting.any?
+        time = current_time
+        waiting = @waiting
+        @waiting = {}
+
+        waiting.each do |fiber, timeout|
+          if timeout <= time
+            fiber.transfer
+          else
+            @waiting[fiber] = timeout
+          end
+        end
+      end
+    end
+  end
+
+  def wait_readable(fd)
+    io = IO.for_fd(fd, autoclose: false)
+
+    @readable[io] = Fiber.current
+
+    @fiber.transfer
+
+    @readable.delete(io)
+
+    return true
+  end
+
+  def wait_writable(fd)
+    io = IO.for_fd(fd, autoclose: false)
+
+    @writable[io] = Fiber.current
+
+    @fiber.transfer
+
+    @writable.delete(io)
+
+    return true
+  end
+
+  def current_time
+    Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  end
+
+  def wait_sleep(duration = nil)
+    @waiting[Fiber.current] = current_time + duration
+
+    @fiber.transfer
+
+    return true
+  end
+
+  def wait_for_single_fd(fd, events, duration)
+    # puts "wait_for_single_fd(#{fd}, #{events}, #{duration})"
+    io = IO.for_fd(fd, autoclose: false)
+
+    unless (events & 1).zero?
+      @readable[io] = Fiber.current
+    end
+
+    unless (events & 2).zero?
+      @writable[io] = Fiber.current
+    end
+
+    @fiber.transfer
+
+    @readable.delete(io)
+    @writable.delete(io)
+
+    return true
+  end
+  
+  def enter_blocking_region
+    # puts "Enter blocking region: #{caller.first}"
+  end
+  
+  def exit_blocking_region
+    # puts "Exit blocking region: #{caller.first}"
+    @blocking << caller.first
+  end
+  
+  def fiber(&block)
+    Fiber.new(&block)
+  end
+end

--- a/test/io/nonblock/test_enumerator.rb
+++ b/test/io/nonblock/test_enumerator.rb
@@ -16,8 +16,6 @@ class TestIOEnumerator < Test::Unit::TestCase
       Thread.current.scheduler = scheduler
 
       i, o = UNIXSocket.pair
-      i.nonblock = true
-      o.nonblock = true
       e = i.to_enum(:each_char)
 
       Fiber do

--- a/test/io/nonblock/test_enumerator.rb
+++ b/test/io/nonblock/test_enumerator.rb
@@ -7,8 +7,10 @@ class TestIOEnumerator < Test::Unit::TestCase
   MESSAGE = "Hello World"
 
   def test_read
+    skip unless defined?(UNIXSocket)
+
     i, o = UNIXSocket.pair
-    return unless i.nonblock? && o.nonblock?
+    skip unless i.nonblock? && o.nonblock?
 
     message = String.new
 

--- a/test/io/nonblock/test_enumerator.rb
+++ b/test/io/nonblock/test_enumerator.rb
@@ -7,7 +7,8 @@ class TestIOEnumerator < Test::Unit::TestCase
   MESSAGE = "Hello World"
 
   def test_read
-    return unless defined?(UNIXSocket)
+    i, o = UNIXSocket.pair
+    return unless i.nonblock? && o.nonblock?
 
     message = String.new
 
@@ -15,7 +16,6 @@ class TestIOEnumerator < Test::Unit::TestCase
       scheduler = Scheduler.new
       Thread.current.scheduler = scheduler
 
-      i, o = UNIXSocket.pair
       e = i.to_enum(:each_char)
 
       Fiber do

--- a/test/io/nonblock/test_enumerator.rb
+++ b/test/io/nonblock/test_enumerator.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+require 'test/unit'
+require 'socket'
+require_relative 'scheduler'
+
+class TestIOEnumerator < Test::Unit::TestCase
+  MESSAGE = "Hello World"
+
+  def test_read
+    return unless defined?(UNIXSocket)
+
+    message = String.new
+
+    thread = Thread.new do
+      scheduler = Scheduler.new
+      Thread.current.scheduler = scheduler
+
+      i, o = UNIXSocket.pair
+      i.nonblock = true
+      o.nonblock = true
+      e = i.to_enum(:each_char)
+
+      Fiber do
+        o.write("Hello World")
+        o.close
+      end
+
+      Fiber do
+        begin
+          while c = e.next
+            message << c
+          end
+        rescue StopIteration
+          # Ignore.
+        end
+
+        i.close
+      end
+    end
+
+    thread.join
+
+    assert_equal(MESSAGE, message)
+  end
+end

--- a/test/io/nonblock/test_http.rb
+++ b/test/io/nonblock/test_http.rb
@@ -13,13 +13,13 @@ class TestIONonblockHTTP < Test::Unit::TestCase
       scheduler = Scheduler.new
       Thread.current.scheduler = scheduler
 
-      Fiber.new(blocking: false) do
+      Fiber do
         uri = URI("https://www.ruby-lang.org/en/")
 
         response = Net::HTTP.get(uri)
 
         assert !response.empty?
-      end.transfer
+      end
     end.join
   end
 end

--- a/test/io/nonblock/test_http.rb
+++ b/test/io/nonblock/test_http.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'net/http'
+require 'uri'
+
+require 'test/unit'
+require 'socket'
+require_relative 'scheduler'
+
+class TestIONonblockHTTP < Test::Unit::TestCase
+  def test_get
+    Thread.new do
+      scheduler = Scheduler.new
+      Thread.current.scheduler = scheduler
+
+      Fiber.new(blocking: false) do
+        uri = URI("https://www.ruby-lang.org/en/")
+
+        response = Net::HTTP.get(uri)
+
+        assert !response.empty?
+      end.transfer
+    end.join
+  end
+end

--- a/test/io/nonblock/test_scheduler.rb
+++ b/test/io/nonblock/test_scheduler.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+require 'test/unit'
+require 'socket'
+require_relative 'scheduler'
+
+class TestIOScheduler < Test::Unit::TestCase
+  MESSAGE = "Hello World"
+
+  def test_read
+    return unless defined?(UNIXSocket)
+
+    message = nil
+
+    thread = Thread.new do
+      scheduler = Scheduler.new
+      Thread.current.scheduler = scheduler
+
+      i, o = UNIXSocket.pair
+      i.nonblock = true
+      o.nonblock = true # Eric wanted this to be the default for all IO
+
+      Fiber do
+        message = i.read(20)
+        i.close
+      end
+
+      Fiber do
+        o.write("Hello World")
+        o.close
+      end
+    end
+
+    thread.join
+
+    assert_equal MESSAGE, message
+  end
+
+  ITEMS = [0, 1, 2, 3, 4]
+
+  def test_sleep
+    items = []
+
+    thread = Thread.new do
+      scheduler = Scheduler.new
+      Thread.current.scheduler = scheduler
+
+      5.times do |i|
+        Fiber do
+          sleep(i/100.0)
+          items << i
+        end
+      end
+
+      # Should be 5 fibers waiting:
+      assert_equal scheduler.waiting.size, 5
+    end
+
+    thread.join
+
+    assert_equal ITEMS, items
+  end
+
+  def test_mutex
+    mutex = Mutex.new
+
+    thread = Thread.new do
+      scheduler = Scheduler.new
+      Thread.current.scheduler = scheduler
+
+      assert_equal Thread.scheduler, scheduler
+
+      mutex.synchronize do
+        assert_nil Thread.scheduler
+      end
+    end
+
+    thread.join
+  end
+
+  def test_blocking
+    scheduler = Scheduler.new
+
+    thread = Thread.new do
+      Thread.current.scheduler = scheduler
+
+      # Close is always a blocking operation.
+      IO.pipe.each(&:close)
+    end
+
+    thread.join
+
+    assert_not_empty scheduler.blocking
+    assert_match /test_scheduler.rb:\d+:in `close'/, scheduler.blocking.last
+  end
+end

--- a/test/io/nonblock/test_scheduler.rb
+++ b/test/io/nonblock/test_scheduler.rb
@@ -7,8 +7,10 @@ class TestIOScheduler < Test::Unit::TestCase
   MESSAGE = "Hello World"
 
   def test_read
+    skip unless defined?(UNIXSocket)
+
     i, o = UNIXSocket.pair
-    return unless i.nonblock? && o.nonblock?
+    skip unless i.nonblock? && o.nonblock?
 
     message = nil
 

--- a/test/io/nonblock/test_scheduler.rb
+++ b/test/io/nonblock/test_scheduler.rb
@@ -16,8 +16,6 @@ class TestIOScheduler < Test::Unit::TestCase
       Thread.current.scheduler = scheduler
 
       i, o = UNIXSocket.pair
-      i.nonblock = true
-      o.nonblock = true # Eric wanted this to be the default for all IO
 
       Fiber do
         message = i.read(20)
@@ -67,10 +65,12 @@ class TestIOScheduler < Test::Unit::TestCase
       scheduler = Scheduler.new
       Thread.current.scheduler = scheduler
 
-      assert_equal Thread.scheduler, scheduler
+      Fiber do
+        assert_equal Thread.scheduler, scheduler
 
-      mutex.synchronize do
-        assert_nil Thread.scheduler
+        mutex.synchronize do
+          assert_nil Thread.scheduler
+        end
       end
     end
 

--- a/test/io/nonblock/test_scheduler.rb
+++ b/test/io/nonblock/test_scheduler.rb
@@ -7,15 +7,14 @@ class TestIOScheduler < Test::Unit::TestCase
   MESSAGE = "Hello World"
 
   def test_read
-    return unless defined?(UNIXSocket)
+    i, o = UNIXSocket.pair
+    return unless i.nonblock? && o.nonblock?
 
     message = nil
 
     thread = Thread.new do
       scheduler = Scheduler.new
       Thread.current.scheduler = scheduler
-
-      i, o = UNIXSocket.pair
 
       Fiber do
         message = i.read(20)

--- a/test/ruby/test_stack.rb
+++ b/test/ruby/test_stack.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: false
+require 'test/unit'
+require 'tmpdir'
+
+class TestStack < Test::Unit::TestCase
+  LARGE_VM_STACK_SIZE = 1024*1024*5
+  LARGE_MACHINE_STACK_SIZE = 1024*1024*10
+
+  def initialize(*)
+    super
+
+    @h_default = nil
+    @h_0 = nil
+    @h_large = nil
+  end
+
+  def invoke_ruby script, vm_stack_size: nil, machine_stack_size: nil
+    env = {}
+    env['RUBY_FIBER_VM_STACK_SIZE'] = vm_stack_size.to_s if vm_stack_size
+    env['RUBY_FIBER_MACHINE_STACK_SIZE'] = machine_stack_size.to_s if machine_stack_size
+
+    stdout, stderr, status = EnvUtil.invoke_ruby([env, '-e', script], '', true, true, timeout: 30)
+    assert(!status.signaled?, FailDesc[status, nil, stderr])
+
+    return stdout
+  end
+
+  def h_default
+    @h_default ||= eval(invoke_ruby('p RubyVM::DEFAULT_PARAMS'))
+  end
+
+  def h_0
+    @h_0 ||= eval(invoke_ruby('p RubyVM::DEFAULT_PARAMS',
+      vm_stack_size: 0,
+      machine_stack_size: 0
+    ))
+  end
+
+  def h_large
+    @h_large ||= eval(invoke_ruby('p RubyVM::DEFAULT_PARAMS',
+      vm_stack_size: LARGE_VM_STACK_SIZE,
+      machine_stack_size: LARGE_MACHINE_STACK_SIZE
+    ))
+  end
+
+  def test_relative_stack_sizes
+    assert_operator(h_default[:fiber_vm_stack_size], :>, h_0[:fiber_vm_stack_size])
+    assert_operator(h_default[:fiber_vm_stack_size], :<, h_large[:fiber_vm_stack_size])
+    assert_operator(h_default[:fiber_machine_stack_size], :>=, h_0[:fiber_machine_stack_size])
+    assert_operator(h_default[:fiber_machine_stack_size], :<=, h_large[:fiber_machine_stack_size])
+  end
+
+  def test_vm_stack_size
+    script = '$stdout.sync=true; def rec; print "."; rec; end; Fiber.new{rec}.resume'
+    
+    size_default = invoke_ruby(script).bytesize
+    assert_operator(size_default, :>, 0)
+    
+    size_0 = invoke_ruby(script, vm_stack_size: 0).bytesize
+    assert_operator(size_default, :>, size_0)
+    
+    size_large = invoke_ruby(script, vm_stack_size: LARGE_VM_STACK_SIZE).bytesize
+    assert_operator(size_default, :<, size_large)
+  end
+
+  # Depending on OS, machine stack size may not change size.
+  def test_machine_stack_size
+    return if /mswin|mingw/ =~ RUBY_PLATFORM
+
+    script = '$stdout.sync=true; def rec; print "."; 1.times{1.times{1.times{rec}}}; end; Fiber.new{rec}.resume'
+
+    vm_stack_size = 1024 * 1024
+    size_default = invoke_ruby(script, vm_stack_size: vm_stack_size).bytesize
+
+    size_0 = invoke_ruby(script, vm_stack_size: vm_stack_size, machine_stack_size: 0).bytesize
+    assert_operator(size_default, :>=, size_0)
+
+    size_large = invoke_ruby(script, vm_stack_size: vm_stack_size, machine_stack_size: LARGE_MACHINE_STACK_SIZE).bytesize
+    assert_operator(size_default, :<=, size_large)
+  end
+end

--- a/test/socket/test_basicsocket.rb
+++ b/test/socket/test_basicsocket.rb
@@ -159,8 +159,6 @@ class TestSocket_BasicSocket < Test::Unit::TestCase
       set_nb = true
       buf = String.new
       if ssock.respond_to?(:nonblock?)
-        assert_not_predicate(ssock, :nonblock?)
-        assert_not_predicate(csock, :nonblock?)
         csock.nonblock = ssock.nonblock = false
 
         # Linux may use MSG_DONTWAIT to avoid setting O_NONBLOCK

--- a/thread.c
+++ b/thread.c
@@ -4202,6 +4202,15 @@ rb_thread_fd_select(int max, rb_fdset_t * read, rb_fdset_t * write, rb_fdset_t *
     return (int)rb_ensure(do_select, (VALUE)&set, select_set_free, (VALUE)&set);
 }
 
+static VALUE
+rb_thread_timeout(struct timeval *timeout) {
+    if (timeout) {
+        return rb_float_new((double)timeout->tv_sec + (0.000001f * timeout->tv_usec));
+    }
+
+    return Qnil;
+}
+
 #ifdef USE_POLL
 
 /* The same with linux kernel. TODO: make platform independent definition. */
@@ -4230,8 +4239,8 @@ rb_wait_for_single_fd(int fd, int events, struct timeval *timeout)
 
     VALUE scheduler = rb_current_thread_scheduler();
     if (scheduler != Qnil) {
-        VALUE result = rb_funcall(scheduler, id_wait_for_single_fd, 3, INT2NUM(fd), INT2NUM(events), 
-            rb_float_new((double)timeout->tv_sec + (0.000001f * timeout->tv_usec))
+        VALUE result = rb_funcall(scheduler, id_wait_for_single_fd, 3, INT2NUM(fd), INT2NUM(events),
+            rb_thread_timeout(timeout)
         );
         return RTEST(result);
     }
@@ -4373,7 +4382,7 @@ rb_wait_for_single_fd(int fd, int events, struct timeval *timeout)
     VALUE scheduler = rb_current_thread_scheduler();
     if (scheduler != Qnil) {
         VALUE result = rb_funcall(scheduler, id_wait_for_single_fd, 3, INT2NUM(fd), INT2NUM(events),
-            rb_float_new((double)timeout->tv_sec + (0.000001f * timeout->tv_usec))
+            rb_thread_timeout(timeout)
         );
         return RTEST(result);
     }

--- a/thread_sync.c
+++ b/thread_sync.c
@@ -190,6 +190,8 @@ mutex_locked(rb_thread_t *th, VALUE self)
 	mutex->next_mutex = th->keeping_mutexes;
     }
     th->keeping_mutexes = mutex;
+
+    th->blocking += 1;
 }
 
 /*
@@ -313,8 +315,6 @@ do_mutex_lock(VALUE self, int interruptible_p)
     // assertion
     if (mutex_owned_p(th, mutex) == Qfalse) rb_bug("do_mutex_lock: mutex is not owned.");
 
-    th->blocking += 1;
-
     return self;
 }
 
@@ -367,6 +367,8 @@ rb_mutex_unlock_th(rb_mutex_t *mutex, rb_thread_t *th)
 	struct sync_waiter *cur = 0, *next;
 	rb_mutex_t **th_mutex = &th->keeping_mutexes;
 
+        th->blocking -= 1;
+
 	mutex->th = 0;
 	list_for_each_safe(&mutex->waitq, cur, next, node) {
 	    list_del_init(&cur->node);
@@ -410,8 +412,6 @@ rb_mutex_unlock(VALUE self)
 
     err = rb_mutex_unlock_th(mutex, th);
     if (err) rb_raise(rb_eThreadError, "%s", err);
-
-    th->blocking -= 1;
 
     return self;
 }

--- a/thread_sync.c
+++ b/thread_sync.c
@@ -313,7 +313,7 @@ do_mutex_lock(VALUE self, int interruptible_p)
     // assertion
     if (mutex_owned_p(th, mutex) == Qfalse) rb_bug("do_mutex_lock: mutex is not owned.");
 
-    th->exclusive += 1;
+    th->blocking += 1;
 
     return self;
 }
@@ -411,7 +411,7 @@ rb_mutex_unlock(VALUE self)
     err = rb_mutex_unlock_th(mutex, th);
     if (err) rb_raise(rb_eThreadError, "%s", err);
 
-    th->exclusive -= 1;
+    th->blocking -= 1;
 
     return self;
 }

--- a/thread_sync.c
+++ b/thread_sync.c
@@ -313,6 +313,8 @@ do_mutex_lock(VALUE self, int interruptible_p)
     // assertion
     if (mutex_owned_p(th, mutex) == Qfalse) rb_bug("do_mutex_lock: mutex is not owned.");
 
+    th->exclusive += 1;
+
     return self;
 }
 
@@ -404,9 +406,12 @@ rb_mutex_unlock(VALUE self)
 {
     const char *err;
     rb_mutex_t *mutex = mutex_ptr(self);
+    rb_thread_t *th = GET_THREAD();
 
-    err = rb_mutex_unlock_th(mutex, GET_THREAD());
+    err = rb_mutex_unlock_th(mutex, th);
     if (err) rb_raise(rb_eThreadError, "%s", err);
+
+    th->exclusive -= 1;
 
     return self;
 }

--- a/vm.c
+++ b/vm.c
@@ -2736,7 +2736,8 @@ th_init(rb_thread_t *th, VALUE self)
     th->self = self;
     rb_threadptr_root_fiber_setup(th);
 
-    th->exclusive = 0;
+    /* All threads are blocking until a non-blocking fiber is scheduled */
+    th->blocking = 1;
     th->scheduler = Qnil;
 
     if (self == 0) {

--- a/vm_core.h
+++ b/vm_core.h
@@ -977,13 +977,15 @@ typedef struct rb_thread_struct {
     rb_fiber_t *root_fiber;
     rb_jmpbuf_t root_jmpbuf;
 
+    VALUE scheduler;
+    unsigned exclusive;
+
     /* misc */
     VALUE name;
 
 #ifdef USE_SIGALTSTACK
     void *altstack;
 #endif
-
 } rb_thread_t;
 
 typedef enum {

--- a/vm_core.h
+++ b/vm_core.h
@@ -978,7 +978,7 @@ typedef struct rb_thread_struct {
     rb_jmpbuf_t root_jmpbuf;
 
     VALUE scheduler;
-    unsigned exclusive;
+    unsigned blocking;
 
     /* misc */
     VALUE name;


### PR DESCRIPTION
Ruby concurrency can be greatly enhanced by concurrent, deterministic IO.

Fibers have been shown many times to be a great abstraction for this purpose. They retain normal code flow and don't require any kind of Thread synchronisation. They are enjoyable to write code with because you don't have to concern yourself with thread synchronisation or other complicated issues.

The basic idea is that if some operation would block, it yields the Fiber, and other Fibers within the thread can continue to execute.

There are a number of ways to implement this. Here is a proof of concept to amend the existing rb_io_wait_readable/rb_io_wait_writable.

This design minimally affects the Ruby implementation and allows flexibility for selector implementation. With a small amount of work, we can support EventMachine (65 million downloads), NIO4r (21 million downloads). It would be trivial to back port.

This PR isn't complete but I am seeking feedback. If it's a good idea, I will do my best to see it through to completion, including support for EventMachine and NIO4r.

https://bugs.ruby-lang.org/issues/14736