### PR TITLE
optparse: Suppress warnings

### DIFF
--- a/lib/optparse.rb
+++ b/lib/optparse.rb
@@ -1165,14 +1165,14 @@ XXX
   # Version
   #
   def version
-    @version || (defined?(::Version) && ::Version)
+    (defined?(@version) && @version) || (defined?(::Version) && ::Version)
   end
 
   #
   # Release code
   #
   def release
-    @release || (defined?(::Release) && ::Release) || (defined?(::RELEASE) && ::RELEASE)
+    (defined?(@release) && @release) || (defined?(::Release) && ::Release) || (defined?(::RELEASE) && ::RELEASE)
   end
 
   #


### PR DESCRIPTION
Ruby warns "instance variable `@version` not initialized" for optparse when it receives `--version` option.

`test.rb`

```ruby
require 'optparse'
Version = '1'
OptionParser.new.parse(ARGV)
```

```
$ ruby test.rb --version
/home/pocke/.rbenv/versions/2.5.1/lib/ruby/2.5.0/optparse.rb:1168: warning: instance variable @version not initialized
/home/pocke/.rbenv/versions/2.5.1/lib/ruby/2.5.0/optparse.rb:1175: warning: instance variable @release not initialized
test 1
```

This change will suppress the warnings.