### PR TITLE
Remove redundant freeze calls from lib/

### DIFF
--- a/lib/rdoc/markup/attribute_manager.rb
+++ b/lib/rdoc/markup/attribute_manager.rb
@@ -7,7 +7,7 @@ class RDoc::Markup::AttributeManager
   ##
   # The NUL character
 
-  NULL = "\000".freeze
+  NULL = "\000"
 
   #--
   # We work by substituting non-printing characters in to the text. For now

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -933,7 +933,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   def self.env_requirement(gem_name)
     @env_requirements_by_name ||= {}
     @env_requirements_by_name[gem_name] ||= begin
-      req = ENV["GEM_REQUIREMENT_#{gem_name.upcase}"] || '>= 0'.freeze
+      req = ENV["GEM_REQUIREMENT_#{gem_name.upcase}"] || '>= 0'
       Gem::Requirement.create(req)
     end
   end

--- a/lib/rubygems/dependency.rb
+++ b/lib/rubygems/dependency.rb
@@ -280,7 +280,7 @@ class Gem::Dependency
       requirement.satisfied_by?(spec.version) && env_req.satisfied_by?(spec.version)
     }.map(&:to_spec)
 
-    Gem::BundlerVersionFinder.filter!(matches) if name == "bundler".freeze
+    Gem::BundlerVersionFinder.filter!(matches) if name == "bundler"
 
     if platform_only
       matches.reject! { |spec|

--- a/lib/rubygems/resolver/molinillo/lib/molinillo/gem_metadata.rb
+++ b/lib/rubygems/resolver/molinillo/lib/molinillo/gem_metadata.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 module Gem::Resolver::Molinillo
   # The version of Gem::Resolver::Molinillo.
-  VERSION = '0.5.7'.freeze
+  VERSION = '0.5.7'
 end

--- a/lib/rubygems/resolver/molinillo/lib/molinillo/resolution.rb
+++ b/lib/rubygems/resolver/molinillo/lib/molinillo/resolution.rb
@@ -465,7 +465,7 @@ module Gem::Resolver::Molinillo
       def push_state_for_requirements(new_requirements, requires_sort = true, new_activated = activated)
         new_requirements = sort_dependencies(new_requirements.uniq, new_activated, conflicts) if requires_sort
         new_requirement = new_requirements.shift
-        new_name = new_requirement ? name_for(new_requirement) : ''.freeze
+        new_name = new_requirement ? name_for(new_requirement) : ''
         possibilities = new_requirement ? search_for(new_requirement) : []
         handle_missing_or_push_dependency_state DependencyState.new(
           new_name, new_requirements, new_activated,

--- a/lib/rubygems/stub_specification.rb
+++ b/lib/rubygems/stub_specification.rb
@@ -23,9 +23,9 @@ class Gem::StubSpecification < Gem::BasicSpecification
 
     # These are common require paths.
     REQUIRE_PATHS = { # :nodoc:
-      'lib'  => 'lib'.freeze,
-      'test' => 'test'.freeze,
-      'ext'  => 'ext'.freeze,
+      'lib'  => 'lib',
+      'test' => 'test',
+      'ext'  => 'ext',
     }
 
     # These are common require path lists.  This hash is used to optimize
@@ -37,7 +37,7 @@ class Gem::StubSpecification < Gem::BasicSpecification
     }
 
     def initialize data, extensions
-      parts          = data[PREFIX.length..-1].split(" ".freeze, 4)
+      parts          = data[PREFIX.length..-1].split(" ", 4)
       @name          = parts[0].freeze
       @version       = if Gem::Version.correct?(parts[1])
                          Gem::Version.new(parts[1])
@@ -54,7 +54,7 @@ class Gem::StubSpecification < Gem::BasicSpecification
                        end
 
       path_list = parts.last
-      @require_paths = REQUIRE_PATH_LIST[path_list] || path_list.split("\0".freeze).map! { |x|
+      @require_paths = REQUIRE_PATH_LIST[path_list] || path_list.split("\0").map! { |x|
         REQUIRE_PATHS[x] || x
       }
     end

--- a/lib/rubygems/text.rb
+++ b/lib/rubygems/text.rb
@@ -10,7 +10,7 @@ module Gem::Text
   # Remove any non-printable characters and make the text suitable for
   # printing.
   def clean_text(text)
-    text.gsub(/[\000-\b\v-\f\016-\037\177]/, ".".freeze)
+    text.gsub(/[\000-\b\v-\f\016-\037\177]/, ".")
   end
 
   def truncate_text(text, description, max_length = 100_000)

--- a/lib/rubygems/util/licenses.rb
+++ b/lib/rubygems/util/licenses.rb
@@ -4,7 +4,7 @@ require 'rubygems/text'
 class Gem::Licenses
   extend Gem::Text
 
-  NONSTANDARD = 'Nonstandard'.freeze
+  NONSTANDARD = 'Nonstandard'
 
   # Software Package Data Exchange (SPDX) standard open-source software
   # license identifiers


### PR DESCRIPTION
Following up on #1873 , removing the rest of the redundant freeze calls from `lib/` for files which contain
`# frozen_string_literal: true`.