### PR TITLE
[Docs] Fixes the File::CREAT logger documentation

### DIFF
--- a/lib/logger.rb
+++ b/lib/logger.rb
@@ -109,7 +109,7 @@ require 'monitor'
 # 3. Create a logger for the specified file.
 #
 #      file = File.open('foo.log', File::WRONLY | File::APPEND)
-#      # To create new (and to remove old) logfile, add File::CREAT like:
+#      # To create new logfile, add File::CREAT like:
 #      # file = File.open('foo.log', File::WRONLY | File::APPEND | File::CREAT)
 #      logger = Logger.new(file)
 #


### PR DESCRIPTION
The documentation for Logger erroneously claimed that `File::CREAT` would truncate an existing log file. 

Actually the addition of `File::TRUNC` would also be required to truncate an existing file. `File::CREAT` just creates the file if it doesn't already exist.

I verified this on both macOS and Ubuntu.