### PR TITLE
Add negotiated SSL protocol and cipher to Net::HTTP debug output

### DIFF
--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -1000,7 +1000,7 @@ module Net   #:nodoc:
         if @ssl_context.verify_mode != OpenSSL::SSL::VERIFY_NONE
           s.post_connection_check(@address)
         end
-        D "SSL established"
+        D "SSL established, protocol: #{s.ssl_version}, cipher: #{s.cipher[0]}"
       end
       @socket = BufferedIO.new(s, read_timeout: @read_timeout,
                                write_timeout: @write_timeout,


### PR DESCRIPTION
This makes is easier to verify what Ruby has negotiated with the server. An example of why you'd want to double check; for credit card payment data the PCI DSS [mandates](https://blog.pcisecuritystandards.org/are-you-ready-for-30-june-2018-sayin-goodbye-to-ssl-early-tls) that TLS 1.1 or newer is used after June 30.

Example output:
```
opening connection to stripe.com:443...
opened
starting SSL for stripe.com:443...
SSL established, protocol: TLSv1.2, cipher: ECDHE-RSA-AES128-GCM-SHA256
```