### PR TITLE
Use `Net::HTTPClientException` instead of `Net::HTTPServerException`

### DIFF
--- a/lib/net/http/responses.rb
+++ b/lib/net/http/responses.rb
@@ -19,7 +19,7 @@ class Net::HTTPRedirection < Net::HTTPResponse           # 3xx
 end
 class Net::HTTPClientError < Net::HTTPResponse           # 4xx
   HAS_BODY = true
-  EXCEPTION_TYPE = Net::HTTPServerException   # for backward compatibility
+  EXCEPTION_TYPE = Net::HTTPClientException   # for backward compatibility
 end
 class Net::HTTPServerError < Net::HTTPResponse           # 5xx
   HAS_BODY = true


### PR DESCRIPTION
`Net::HTTPServerException` has been deprecated since 8e37f17671848859c6c9749a19909c3fd0d133aa (https://bugs.ruby-lang.org/issues/14688).
And `net/http/responses.rb` uses the deprecated constant, so Ruby warns of the deprecation.

Example:

```bash
$ ruby -r net/http -e ''
/home/pocke/.rbenv/versions/trunk/lib/ruby/2.6.0/net/http/responses.rb:22: warning: constant Net::HTTPServerException is deprecated
```

This change suppresses the warning.

cc/ @nurse @unasuke
