### PR TITLE
[Docs] Remove obsolete comment from Module#define_method documentation

### DIFF
--- a/proc.c
+++ b/proc.c
@@ -1853,16 +1853,14 @@ rb_mod_public_instance_method(VALUE mod, VALUE vid)
  *  Defines an instance method in the receiver. The _method_
  *  parameter can be a +Proc+, a +Method+ or an +UnboundMethod+ object.
  *  If a block is specified, it is used as the method body. This block
- *  is evaluated using <code>instance_eval</code>, a point that is
- *  tricky to demonstrate because <code>define_method</code> is private.
- *  (This is why we resort to the +send+ hack in this example.)
+ *  is evaluated using <code>instance_eval</code>.
  *
  *     class A
  *       def fred
  *         puts "In Fred"
  *       end
  *       def create_method(name, &block)
- *         self.class.send(:define_method, name, &block)
+ *         self.class.define_method(name, &block)
  *       end
  *       define_method(:wilma) { puts "Charge it!" }
  *     end


### PR DESCRIPTION
Hi,

I just noticed after reading Module class documentation [1] that since 2.5, Module#define_method is public. (Feature #14133) [2]

Thanks for your feedback.

1. https://ruby-doc.org/core-2.5.1/Module.html#method-i-define_method
2. https://github.com/ruby/ruby/commit/0c03a89ecd71ebdc1ea983264424ba5c46f8c4e1