### PR TITLE
Bootstrapping Ruby runtime might not have RubyVM::MJIT defined.

### DIFF
--- a/template/fake.rb.in
+++ b/template/fake.rb.in
@@ -32,7 +32,7 @@ class Object
   CROSS_COMPILING = RUBY_PLATFORM
   constants.grep(/^RUBY_/) {|n| remove_const n}
 % arg['versions'].each {|n, v|
-  <%=n%> = <%if n=='RUBY_DESCRIPTION' %>RubyVM::MJIT.enabled? ?
+  <%=n%> = <%if n=='RUBY_DESCRIPTION' %>RubyVM.const_defined?(:MJIT) && RubyVM::MJIT.enabled? ?
     <%=arg['RUBY_DESCRIPTION_WITH_JIT'].inspect%> :
     <%end%><%=v.inspect%>
 % }


### PR DESCRIPTION
It fails to build with the following set-up.
```
$ ruby --version
ruby 2.3.6p384 (2017-12-14 revision 9808) [x86_64-cygwin]
last_commit=ruby 2.3.3
$ ./configure --build=x86_64-pc-cygwin --host=x86_64-w64-mingw32
$ make incs
$ make
```

Generated  `x64-mingw32-fake.rb`:

```
baseruby="/usr/bin/ruby --disable=gems"
_\
=begin
_=
ruby="${RUBY-$baseruby}"
case "$ruby" in "echo "*) $ruby; exit $?;; esac
case "$0" in /*) r=-r"$0";; *) r=-r"./$0";; esac
exec $ruby "$r" "$@"
=end
=baseruby
class Object
  remove_const :CROSS_COMPILING if defined?(CROSS_COMPILING)
  CROSS_COMPILING = RUBY_PLATFORM
  constants.grep(/^RUBY_/) {|n| remove_const n}
  RUBY_VERSION = "2.6.0"
  RUBY_RELEASE_DATE = "2018-06-12"
  RUBY_PLATFORM = "x64-mingw32"
  RUBY_PATCHLEVEL = -1
  RUBY_REVISION = 63635
  RUBY_DESCRIPTION = RubyVM::MJIT.enabled? ?
    "ruby 2.6.0dev (2018-06-12 trunk 63635) +JIT [x64-mingw32]" :
    "ruby 2.6.0dev (2018-06-12 trunk 63635) [x64-mingw32]"
  RUBY_COPYRIGHT = "ruby - Copyright (C) 1993-2018 Yukihiro Matsumoto"
  RUBY_ENGINE = "ruby"
  RUBY_ENGINE_VERSION = "2.6.0"
end
builddir = File.dirname(File.expand_path(__FILE__))
srcdir = "."
top_srcdir = File.realpath(srcdir, builddir)
fake = File.join(top_srcdir, "tool/fake.rb")
eval(File.read(fake), nil, fake)
ENV["RUBYOPT"] = ["-r#{__FILE__}", ENV["RUBYOPT"]].compact.join(" ")
```

The error was:
```
$ ./x64-mingw32-fake.rb

/home/moriyoshi/Work/ruby-git/x64-mingw32-fake.rb:20:in `<class:Object>': uninitialized constant RubyVM::MJIT (NameError)
        from /home/moriyoshi/Work/ruby-git/x64-mingw32-fake.rb:11:in `<top (required)>'
        from -:1:in `require'
```

This patch should address the issue.
