### PR TITLE
InvalidURIError should escape uri string debug output

### DIFF
--- a/lib/uri/rfc3986_parser.rb
+++ b/lib/uri/rfc3986_parser.rb
@@ -15,7 +15,7 @@ module URI
       begin
         uri = uri.to_str
       rescue NoMethodError
-        raise InvalidURIError, "bad URI(is not URI?): #{uri}"
+        raise InvalidURIError, "bad URI(is not URI?): #{uri.inspect}"
       end
       uri.ascii_only? or
         raise InvalidURIError, "URI must be ascii only #{uri.dump}"
@@ -64,7 +64,7 @@ module URI
           m["fragment".freeze]
         ]
       else
-        raise InvalidURIError, "bad URI(is not URI?): #{uri}"
+        raise InvalidURIError, "bad URI(is not URI?): #{uri.inspect}"
       end
     end
 


### PR DESCRIPTION
This pull request alters `raise` calls within `URI::RFC3986_Parser` to output an escaped version of the string by using `String#inspect`.

Via [Twitter, Richard Schneeman noticed](https://twitter.com/schneems/status/1007320680738803713) that `InvalideURIError` exceptions provide debug output of the `uri` parameter passed to `URI::parse`. However, this output is not wrapped in quotes or escaped, so users are unable to determine if the string contains unprintable characters or leading/trailing whitespace. An example:

        require 'uri'
        URI.parse("'uri://here'")
        # => URI::InvalidURIError (bad URI(is not URI?): 'uri://here')

In this example, a user might be confused by the presence of single quotes around the string, and mistakenly believe that quoted output is being provided. After the patch, output would be:

        # => URI::InvalidURIError (bad URI(is not URI?): "'uri://here'")

In this output, it is clear that the string contains erroneous quotes.