### PR TITLE
set real path to __FILE__ and __dir__ in Binding#irb

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -850,6 +850,8 @@ class Binding
     IRB.setup(source_location[0], argv: [])
     workspace = IRB::WorkSpace.new(self)
     STDOUT.print(workspace.code_around_binding)
-    IRB::Irb.new(workspace).run(IRB.conf)
+    binding_irb = IRB::Irb.new(workspace)
+    binding_irb.context.irb_path = File.expand_path(source_location[0])
+    binding_irb.run(IRB.conf)
   end
 end


### PR DESCRIPTION
When reading `Binding#irb`, the file of the calling source is reflected in `__FILE__` and `__dir__`.

before

```shell
$ cat binding_irb.rb
binding.irb

$ ruby binding_irb.rb

From: binding_irb.rb @ line 1 :

 => 1: binding.irb

irb(main):001:0> __FILE__
=> "(irb)"
irb(main):002:0> __dir__
=> "."
```

after

```shell
$ cat binding_patch.rb
class Binding
  require 'irb'
  # :nodoc:
  def irb
    caller_path = eval("__FILE__")
    IRB.setup(caller_path, argv: [])
    workspace = IRB::WorkSpace.new(self)
    STDOUT.print(workspace.code_around_binding)
    irb_irb = IRB::Irb.new(workspace)
    irb_irb.context.irb_path = File.expand_path(caller_path)
    irb_irb.run(IRB.conf)
  end
end

$ ruby -r ./binding_patch.rb binding_irb.rb

From: binding_irb.rb @ line 1 :

 => 1: binding.irb

irb(main):001:0> __FILE__
=> "/Users/takkanm/tmp/binding_irb.rb"
irb(main):002:0> __dir__
=> "/Users/takkanm/tmp"
irb(main):003:0>
```