### PR TITLE
Use locale encoding on resulting string from Array#join with empty array

### DIFF
--- a/array.c
+++ b/array.c
@@ -2033,7 +2033,7 @@ rb_ary_join(VALUE ary, VALUE sep)
     int taint = FALSE;
     VALUE val, tmp, result;
 
-    if (RARRAY_LEN(ary) == 0) return rb_usascii_str_new(0, 0);
+    if (RARRAY_LEN(ary) == 0) return rb_enc_str_new(0, 0, rb_locale_encoding());
     if (OBJ_TAINTED(ary)) taint = TRUE;
 
     if (!NIL_P(sep)) {

--- a/spec/ruby/core/array/shared/join.rb
+++ b/spec/ruby/core/array/shared/join.rb
@@ -14,8 +14,8 @@ describe :array_join_with_default_separator, shared: true do
     [].send(@method).should == ''
   end
 
-  it "returns a US-ASCII string for an empty Array" do
-    [].send(@method).encoding.should == Encoding::US_ASCII
+  it "returns a locale-encoded string for an empty Array" do
+    [].send(@method).encoding.should == Encoding.find('locale')
   end
 
   it "returns a string formed by concatenating each String element separated by $," do

--- a/test/ruby/test_array.rb
+++ b/test/ruby/test_array.rb
@@ -1057,7 +1057,7 @@ class TestArray < Test::Unit::TestCase
     a = @cls[]
     assert_equal("", a.join)
     assert_equal("", a.join(','))
-    assert_equal(Encoding::US_ASCII, a.join.encoding)
+    assert_equal(Encoding.find('locale'), a.join.encoding)
 
     $, = ""
     a = @cls[1, 2]


### PR DESCRIPTION
## Redmine issue
https://redmine.ruby-lang.org/issues/14863

## WHERE
Array#join, ruby <= 2.5.x

## WHAT
The Array#join method returns an empty string with locale encoding when the array is empty

## WHY
It is odd that the empty string returned by joining an empty array has a hardcoded US-ASCII encoding. 

That often breaks the expectations from the return encoding of Array#join since most of the other cases result in a locale-encoded string.