### PR TITLE
add Range tests to improve coverage with `make test-all`

### DIFF
--- a/test/ruby/test_range.rb
+++ b/test/ruby/test_range.rb
@@ -240,6 +240,18 @@ class TestRange < Test::Unit::TestCase
     assert_equal(["a"], a)
 
     a = []
+    (:a .. :z).step(2) {|x| a << x }
+    assert_equal(%i(a c e g i k m o q s u w y), a)
+
+    a = []
+    (:a .. ).step(2) {|x| a << x; break if a.size == 13 }
+    assert_equal(%i(a c e g i k m o q s u w y), a)
+
+    a = []
+    (:a .. :z).step(2**32) {|x| a << x }
+    assert_equal([:a], a)
+
+    a = []
     (2**32-1 .. 2**32+1).step(2) {|x| a << x }
     assert_equal([4294967295, 4294967297], a)
     zero = (2**32).coerce(0).first
@@ -493,6 +505,8 @@ class TestRange < Test::Unit::TestCase
     assert_include("a"..."z", "y")
     assert_not_include("a"..."z", "z")
     assert_not_include("a".."z", "cc")
+    assert_include("a".., "c")
+    assert_not_include("a".., "5")
     assert_include(0...10, 5)
     assert_include(5..., 10)
     assert_not_include(5..., 0)


### PR DESCRIPTION
This patch will improve the result of coverage from 91.3% to 95.0%.

Before | After
-- | --
<img src="https://user-images.githubusercontent.com/199156/41816552-2bc19a58-77c3-11e8-957e-2f49476a3d48.png" /> | <img src="https://user-images.githubusercontent.com/199156/41816553-36a22708-77c3-11e8-9e19-989250c134a0.png" />

