### PR TITLE
Fix spec\ruby\command_line\rubylib_spec.rb for use with test-spec

### DIFF
--- a/spec/ruby/command_line/rubylib_spec.rb
+++ b/spec/ruby/command_line/rubylib_spec.rb
@@ -2,6 +2,8 @@ require_relative '../spec_helper'
 
 describe "The RUBYLIB environment variable" do
   before :each do
+    @pre  = ENV['RUBYLIB'] ? "#{ENV['RUBYLIB']}#{File::PATH_SEPARATOR}" : ''
+    @post = ENV['RUBYLIB'] ? "#{File::PATH_SEPARATOR}#{ENV['RUBYLIB']}" : ''
     @rubylib, ENV["RUBYLIB"] = ENV["RUBYLIB"], nil
   end
 
@@ -11,14 +13,14 @@ describe "The RUBYLIB environment variable" do
 
   it "adds a directory to $LOAD_PATH" do
     dir = tmp("rubylib/incl")
-    ENV["RUBYLIB"] = dir
+    ENV["RUBYLIB"] = @pre + dir
     paths = ruby_exe("puts $LOAD_PATH").lines.map(&:chomp)
     paths.should include(dir)
   end
 
   it "adds a File::PATH_SEPARATOR-separated list of directories to $LOAD_PATH" do
     dir1, dir2 = tmp("rubylib/incl1"), tmp("rubylib/incl2")
-    ENV["RUBYLIB"] = "#{dir1}#{File::PATH_SEPARATOR}#{dir2}"
+    ENV["RUBYLIB"] = @pre + "#{dir1}#{File::PATH_SEPARATOR}#{dir2}"
     paths = ruby_exe("puts $LOAD_PATH").lines.map(&:chomp)
     paths.should include(dir1)
     paths.should include(dir2)
@@ -27,7 +29,7 @@ describe "The RUBYLIB environment variable" do
 
   it "adds the directory at the front of $LOAD_PATH" do
     dir = tmp("rubylib/incl_front")
-    ENV["RUBYLIB"] = dir
+    ENV["RUBYLIB"] = dir + @post
     paths = ruby_exe("puts $LOAD_PATH").lines.map(&:chomp)
     if PlatformGuard.implementation? :ruby
       # In a MRI checkout, $PWD and some extra -I entries end up as
@@ -42,7 +44,7 @@ describe "The RUBYLIB environment variable" do
   it "adds the directory after directories added by -I" do
     dash_i_dir = tmp("dash_I_include")
     rubylib_dir = tmp("rubylib_include")
-    ENV["RUBYLIB"] = rubylib_dir
+    ENV["RUBYLIB"] = @pre + rubylib_dir
     paths = ruby_exe("puts $LOAD_PATH", options: "-I #{dash_i_dir}").lines.map(&:chomp)
     paths.should include(dash_i_dir)
     paths.should include(rubylib_dir)
@@ -52,7 +54,7 @@ describe "The RUBYLIB environment variable" do
   it "adds the directory after directories added by -I within RUBYOPT" do
     rubyopt_dir = tmp("rubyopt_include")
     rubylib_dir = tmp("rubylib_include")
-    ENV["RUBYLIB"] = rubylib_dir
+    ENV["RUBYLIB"] = @pre + rubylib_dir
     paths = ruby_exe("puts $LOAD_PATH", env: { "RUBYOPT" => "-I#{rubyopt_dir}" }).lines.map(&:chomp)
     paths.should include(rubyopt_dir)
     paths.should include(rubylib_dir)
@@ -60,7 +62,7 @@ describe "The RUBYLIB environment variable" do
   end
 
   it "keeps spaces in the value" do
-    ENV["RUBYLIB"] = " rubylib/incl "
+    ENV["RUBYLIB"] = @pre + " rubylib/incl "
     out = ruby_exe("puts $LOAD_PATH")
     out.should include(" rubylib/incl ")
   end


### PR DESCRIPTION
Current code clears ENV['RUBYLIB'], but on Windows it's needed when running from src (or running `make test-spec`).