### PR TITLE
Repack rb_thread_struct, rb_execution_context_struct, args_info, iseq_compile_data and re_pattern_buffer to save 8 bytes per struct

### DIFF
--- a/include/ruby/onigmo.h
+++ b/include/ruby/onigmo.h
@@ -766,6 +766,7 @@ typedef struct re_pattern_buffer {
   int repeat_range_alloc;
 
   OnigOptionType    options;
+  int            sub_anchor;        /* start-anchor for exact or map */
 
   OnigRepeatRange* repeat_range;
 
@@ -780,7 +781,6 @@ typedef struct re_pattern_buffer {
   int            anchor;            /* BEGIN_BUF, BEGIN_POS, (SEMI_)END_BUF */
   OnigDistance   anchor_dmin;       /* (SEMI_)END_BUF anchor distance */
   OnigDistance   anchor_dmax;       /* (SEMI_)END_BUF anchor distance */
-  int            sub_anchor;        /* start-anchor for exact or map */
   unsigned char *exact;
   unsigned char *exact_end;
   unsigned char  map[ONIG_CHAR_TABLE_SIZE]; /* used as BM skip or char-map */

--- a/iseq.h
+++ b/iseq.h
@@ -94,13 +94,13 @@ struct iseq_compile_data {
     VALUE for_iseq;
     struct iseq_compile_data_ensure_node_stack *ensure_node_stack;
     int loopval_popped;	/* used by NODE_BREAK */
+    unsigned int ci_kw_index;
     struct iseq_compile_data_storage *storage_head;
     struct iseq_compile_data_storage *storage_current;
     int last_line;
     int label_no;
     int node_level;
     unsigned int ci_index;
-    unsigned int ci_kw_index;
     const rb_compile_option_t *option;
     struct rb_id_table *ivar_cache_table;
 #if SUPPORT_JOKE

--- a/vm_args.c
+++ b/vm_args.c
@@ -19,10 +19,10 @@ struct args_info {
     /* basic args info */
     VALUE *argv;
     int argc;
+    int rest_index;
     const struct rb_call_info_kw_arg *kw_arg;
 
     /* additional args info */
-    int rest_index;
     VALUE *kw_argv;
     VALUE rest;
 };

--- a/vm_core.h
+++ b/vm_core.h
@@ -813,6 +813,8 @@ typedef struct rb_execution_context_struct {
     rb_atomic_t interrupt_flag;
     rb_atomic_t interrupt_mask; /* size should match flag */
 
+    enum method_missing_reason method_missing_reason;
+
     rb_fiber_t *fiber_ptr;
     struct rb_thread_struct *thread_ptr;
 
@@ -835,7 +837,6 @@ typedef struct rb_execution_context_struct {
     VALUE errinfo;
     VALUE passed_block_handler; /* for rb_iterate */
     const rb_callable_method_entry_t *passed_bmethod_me; /* for bmethod */
-    enum method_missing_reason method_missing_reason;
     VALUE private_const_reference;
 
     /* for GC */
@@ -878,6 +879,7 @@ typedef struct rb_thread_struct {
     enum rb_thread_status status;
     int to_kill;
     int priority;
+    int pending_interrupt_queue_checked;
 
     native_thread_data_t native_thread_data;
     void *blocking_region_buffer;
@@ -893,7 +895,6 @@ typedef struct rb_thread_struct {
     /* async errinfo queue */
     VALUE pending_interrupt_queue;
     VALUE pending_interrupt_mask_stack;
-    int pending_interrupt_queue_checked;
 
     /* interrupt management */
     rb_nativethread_lock_t interrupt_lock;
@@ -915,8 +916,8 @@ typedef struct rb_thread_struct {
     rb_jmpbuf_t root_jmpbuf;
 
     /* misc */
-    unsigned int abort_on_exception: 1;
-    unsigned int report_on_exception: 1;
+    unsigned char abort_on_exception: 1;
+    unsigned char report_on_exception: 1;
     uint32_t running_time_us; /* 12500..800000 */
     VALUE name;
 } rb_thread_t;


### PR DESCRIPTION
A few structs repacked with pahole - very very small difference - saves 8 bytes per instance on 64 bit platforms.

Only args_info is still smaller than a cache line with iseq_compile_data possibly fitting into exactly 2 if possible to shave another 8 bytes off the struct.

Pending further testing an a larger application like discourse and the benchmark suite is inconclusive with lots of noise.

Memory bench:

````~/src/ruby/trunk/ruby  -Ilib -I. -I.ext/x86_64-linux  /home/lourens/src/ruby/ruby/benchmark/memory_wrapper.rb /tmp/benchmark-memory-wrapper-data20180706-12640-129al77 size /home/lourens/src/ruby/ruby/benchmark/bm_vm_thread_pass.rb' exited with abnormal status (pid 19768 exit 1)

-----------------------------------------------------------
benchmark results:
Memory usage (last size) (B)
name                            packed  trunk
app_answer                      9687040.000 9314304.000
app_aobench                     9715712.000 9338880.000
app_erb                         9768960.000 9728000.000
app_factorial                   24195072.000 24363008.000
app_fib                         9007104.000 9498624.000
app_lc_fizzbuzz                 27164672.000 28061696.000
app_mandelbrot                  9240576.000 9445376.000
app_pentomino                   9699328.000 9822208.000
app_raise                       9461760.000 9330688.000
app_strconcat                   9248768.000 9236480.000
app_tak                         9502720.000 9404416.000
app_tarai                       8871936.000 9519104.000
app_uri                         9699328.000 9723904.000
array_sample_100k_10            11493376.000 11427840.000
array_sample_100k_11            11186176.000 11124736.000
array_sample_100k__100erer          13524992.000 13230080.000
array_sample_100k__1k           36900864.000 39854080.000
array_sample_100k__6k           45600768.000 45899776.000
array_sample_100k___10k         45875200.000 44806144.000
array_sample_100k___50k         45694976.000 45776896.000
array_shift                     2409746432.000 2409660416.000
array_small_and                 9519104.000 9408512.000
array_small_diff                9793536.000 9936896.000
array_small_or                  9486336.000 9744384.000
array_sort_block                41451520.000 38420480.000
array_sort_float                41447424.000 38440960.000
array_values_at_int             9519104.000 9457664.000
array_values_at_range           97591296.000 97378304.000
bighash                         196845568.000 196268032.000
dir_empty_p                     9936896.000 9977856.000
erb_render                      11689984.000 11546624.000
file_chmod                      10010624.000 10059776.000
file_rename                     10031104.000 9949184.000
hash_aref_dsym                  9211904.000 9474048.000
hash_aref_dsym_long             120307712.000 119721984.000
hash_aref_fix                   9461760.000 9502720.000
hash_aref_flo                   10096640.000 10317824.000
hash_aref_miss                  9474048.000 8896512.000
hash_aref_str                   8990720.000 9383936.000
hash_aref_sym                   9523200.000 9322496.000
hash_aref_sym_long              9494528.000 9527296.000
hash_flatten                    42180608.000 42659840.000
hash_ident_flo                  10223616.000 10215424.000
hash_ident_num                  9310208.000 8810496.000
hash_ident_obj                  8912896.000 8974336.000
hash_ident_str                  9404416.000 9236480.000
hash_ident_sym                  8974336.000 9453568.000
hash_keys                       78041088.000 77049856.000
hash_long                       9289728.000 9519104.000
hash_shift                      10596352.000 10686464.000
hash_shift_u16                  13459456.000 14045184.000
hash_shift_u24                  13926400.000 13955072.000
hash_shift_u32                  13848576.000 14020608.000
hash_small2                     239067136.000 239063040.000
hash_small4                     239087616.000 239063040.000
hash_small8                     335089664.000 335093760.000
hash_to_proc                    9719808.000 9641984.000
hash_values                     43139072.000 77295616.000
int_quo                         9326592.000 9285632.000
io_copy_stream_write            9388032.000 9338880.000
io_copy_stream_write_socket     9838592.000 9814016.000
io_file_create                  10051584.000 9818112.000
io_file_read                    28782592.000 32886784.000
io_file_write                   10027008.000 10018816.000
io_nonblock_noex                10129408.000 10199040.000
io_nonblock_noex2               9461760.000 9494528.000
io_pipe_rw                      9293824.000 9527296.000
io_select                       9285632.000 9478144.000
io_select2                      9449472.000 9719808.000
io_select3                      11005952.000 11186176.000
loop_for                        9506816.000 9494528.000
loop_generator                  9408512.000 9347072.000
loop_times                      9338880.000 9342976.000
loop_whileloop                  9420800.000 9265152.000
loop_whileloop2                 9195520.000 9334784.000
marshal_dump_flo                16343040.000 16044032.000
marshal_dump_load_geniv         9527296.000 9515008.000
marshal_dump_load_time          9670656.000 9408512.000
require                         30441472.000 30388224.000
require_thread                  9494528.000 9773056.000
securerandom                    9400320.000 9478144.000
so_ackermann                    9437184.000 10067968.000
so_array                        9510912.000 9269248.000
so_binary_trees                 32460800.000 45740032.000
so_concatenate                  33681408.000 105328640.000
so_count_words                  22736896.000 20168704.000
so_exception                    10088448.000 9908224.000
so_fannkuch                     9854976.000 9646080.000
so_fasta                        9375744.000 9330688.000
so_k_nucleotide                 41082880.000 40079360.000
so_lists                        61755392.000 61878272.000
so_mandelbrot                   9408512.000 9510912.000
so_matrix                       9551872.000 9297920.000
so_meteor_contest               10473472.000 10137600.000
so_nbody                        9326592.000 9506816.000
so_nested_loop                  9502720.000 9478144.000
so_nsieve                       145309696.000 145207296.000
so_nsieve_bits                  10436608.000 10444800.000
so_object                       9424896.000 9273344.000
so_partial_sums                 9912320.000 9367552.000
so_pidigits                     69033984.000 60682240.000
so_random                       9383936.000 9531392.000
so_reverse_complement           83750912.000 83779584.000
so_sieve                        38072320.000 38031360.000
so_spectralnorm                 9539584.000 9293824.000
string_index                    8908800.000 9457664.000
string_scan_re                  9904128.000 9838592.000
string_scan_str                 9560064.000 9441280.000
time_subsec                     9211904.000 9555968.000
vm1_attr_ivar*                    0.000 16384.000
vm1_attr_ivar_set*              20480.000 77824.000
vm1_block*                      114688.000 229376.000
vm1_blockparam*                 49152.000 200704.000
vm1_blockparam_call*              0.000 200704.000
vm1_blockparam_pass*              0.000 86016.000
vm1_blockparam_yield*             0.000 53248.000
vm1_const*                        0.000 237568.000
vm1_ensure*                       0.000 159744.000
vm1_float_simple*                 0.000   0.000
vm1_gc_short_lived*               0.000 20480.000
vm1_gc_short_with_complex_long* 168431616.000 188018688.000
vm1_gc_short_with_long*         72744960.000 72704000.000
vm1_gc_short_with_symbol*       1667072.000 1609728.000
vm1_gc_wb_ary*                  61440.000 196608.000
vm1_gc_wb_ary_promoted*           0.000 200704.000
vm1_gc_wb_obj*                    0.000 180224.000
vm1_gc_wb_obj_promoted*           0.000 286720.000
vm1_ivar*                       24576.000   0.000
vm1_ivar_set*                     0.000 262144.000
vm1_length*                       0.000 229376.000
vm1_lvar_init*                    0.000 106496.000
vm1_lvar_set*                     0.000 94208.000
vm1_neq*                          0.000 139264.000
vm1_not*                          0.000   0.000
vm1_rescue*                       0.000 311296.000
vm1_simplereturn*                 0.000 282624.000
vm1_swap*                         0.000 204800.000
vm1_yield*                        0.000 245760.000
vm2_array*                      634880.000 503808.000
vm2_bigarray*                   58408960.000 58073088.000
vm2_bighash*                    71925760.000 82608128.000
vm2_case*                       126976.000 135168.000
vm2_case_lit*                     0.000 151552.000
vm2_defined_method*             225280.000 61440.000
vm2_dstr*                       151552.000 12288.000
vm2_eval*                       1003520.000 323584.000
vm2_fiber_switch*               262144.000 163840.000
vm2_method*                       0.000 217088.000
vm2_method_missing*             28672.000   0.000
vm2_method_with_block*            0.000   0.000
vm2_module_ann_const_set*       1662976.000 1052672.000
vm2_module_const_set*           839680.000 524288.000
vm2_mutex*                      163840.000   0.000
vm2_newlambda*                  364544.000 307200.000
vm2_poly_method*                290816.000   0.000
vm2_poly_method_ov*             126976.000   0.000
vm2_poly_singleton*               0.000   0.000
vm2_proc*                       192512.000 40960.000
vm2_raise1*                     630784.000 479232.000
vm2_raise2*                     909312.000 835584.000
vm2_regexp*                     184320.000   0.000
vm2_send*                       118784.000 172032.000
vm2_string_literal*             262144.000   0.000
vm2_struct_big_aref_hi*           0.000   0.000
vm2_struct_big_aref_lo*         131072.000 143360.000
vm2_struct_big_aset*            65536.000 184320.000
vm2_struct_big_href_hi*         163840.000 4096.000
vm2_struct_big_href_lo*         180224.000   0.000
vm2_struct_big_hset*            90112.000   0.000
vm2_struct_small_aref*          114688.000 167936.000
vm2_struct_small_aset*            0.000 86016.000
vm2_struct_small_href*            0.000 16384.000
vm2_struct_small_hset*          286720.000 12288.000
vm2_super*                      294912.000 28672.000
vm2_unif1*                      290816.000   0.000
vm2_zsuper*                     245760.000 217088.000
vm3_backtrace                   13352960.000 13336576.000
vm3_clearmethodcache            10383360.000 10063872.000
vm3_gc                          8929280.000 9007104.000
vm3_gc_old_full                 66011136.000 65998848.000
vm3_gc_old_immediate            60362752.000 60833792.000
vm3_gc_old_lazy                 63115264.000 60350464.000
vm_symbol_block_pass            10686464.000 10571776.000
vm_thread_alive_check1          11304960.000 11202560.000
vm_thread_close                 33255424.000 33415168.000
vm_thread_condvar1              9441280.000 9494528.000
vm_thread_condvar2              11669504.000 11579392.000
vm_thread_create_join           11255808.000 11378688.000
vm_thread_mutex1                9318400.000 9334784.000
vm_thread_mutex2                9342976.000 9445376.000
vm_thread_mutex3                43577344.000 42201088.000
vm_thread_pass                    0.000   0.000
vm_thread_pass_flood            32354304.000 32321536.000
vm_thread_pipe                  9359360.000 9531392.000
vm_thread_queue                 12242944.000 12644352.000
vm_thread_sized_queue           9347072.000 9338880.000
vm_thread_sized_queue2          9252864.000 9605120.000
vm_thread_sized_queue3          9633792.000 9568256.000
vm_thread_sized_queue4          9736192.000 9748480.000

Memory consuming ratio (size) with the result of `packed' (greater is better)
name                            trunk
app_answer                        1.040
app_aobench                       1.040
app_erb                           1.004
app_factorial                     0.993
app_fib                           0.948
app_lc_fizzbuzz                   0.968
app_mandelbrot                    0.978
app_pentomino                     0.987
app_raise                         1.014
app_strconcat                     1.001
app_tak                           1.010
app_tarai                         0.932
app_uri                           0.997
array_sample_100k_10              1.006
array_sample_100k_11              1.006
array_sample_100k__100            1.022
array_sample_100k__1k             0.926
array_sample_100k__6k             0.993
array_sample_100k___10k           1.024
array_sample_100k___50k           0.998
array_shift                       1.000
array_small_and                   1.012
array_small_diff                  0.986
array_small_or                    0.974
array_sort_block                  1.079
array_sort_float                  1.078
array_values_at_int               1.006
array_values_at_range             1.002
bighash                           1.003
dir_empty_p                       0.996
erb_render                        1.012
file_chmod                        0.995
file_rename                       1.008
hash_aref_dsym                    0.972
hash_aref_dsym_long               1.005
hash_aref_fix                     0.996
hash_aref_flo                     0.979
hash_aref_miss                    1.065
hash_aref_str                     0.958
hash_aref_sym                     1.022
hash_aref_sym_long                0.997
hash_flatten                      0.989
hash_ident_flo                    1.001
hash_ident_num                    1.057
hash_ident_obj                    0.993
hash_ident_str                    1.018
hash_ident_sym                    0.949
hash_keys                         1.013
hash_long                         0.976
hash_shift                        0.992
hash_shift_u16                    0.958
hash_shift_u24                    0.998
hash_shift_u32                    0.988
hash_small2                       1.000
hash_small4                       1.000
hash_small8                       1.000
hash_to_proc                      1.008
hash_values                       0.558
int_quo                           1.004
io_copy_stream_write              1.005
io_copy_stream_write_socket       1.003
io_file_create                    1.024
io_file_read                      0.875
io_file_write                     1.001
io_nonblock_noex                  0.993
io_nonblock_noex2                 0.997
io_pipe_rw                        0.975
io_select                         0.980
io_select2                        0.972
io_select3                        0.984
loop_for                          1.001
loop_generator                    1.007
loop_times                        1.000
loop_whileloop                    1.017
loop_whileloop2                   0.985
marshal_dump_flo                  1.019
marshal_dump_load_geniv           1.001
marshal_dump_load_time            1.028
require                           1.002
require_thread                    0.972
securerandom                      0.992
so_ackermann                      0.937
so_array                          1.026
so_binary_trees                   0.710
so_concatenate                    0.320
so_count_words                    1.127
so_exception                      1.018
so_fannkuch                       1.022
so_fasta                          1.005
so_k_nucleotide                   1.025
so_lists                          0.998
so_mandelbrot                     0.989
so_matrix                         1.027
so_meteor_contest                 1.033
so_nbody                          0.981
so_nested_loop                    1.003
so_nsieve                         1.001
so_nsieve_bits                    0.999
so_object                         1.016
so_partial_sums                   1.058
so_pidigits                       1.138
so_random                         0.985
so_reverse_complement             1.000
so_sieve                          1.001
so_spectralnorm                   1.026
string_index                      0.942
string_scan_re                    1.007
string_scan_str                   1.013
time_subsec                       0.964
vm1_attr_ivar*                    0.000
vm1_attr_ivar_set*                0.263
vm1_block*                        0.500
vm1_blockparam*                   0.245
vm1_blockparam_call*              0.000
vm1_blockparam_pass*              0.000
vm1_blockparam_yield*             0.000
vm1_const*                        0.000
vm1_ensure*                       0.000
vm1_float_simple*              Error
vm1_gc_short_lived*               0.000
vm1_gc_short_with_complex_long*   0.896
vm1_gc_short_with_long*           1.001
vm1_gc_short_with_symbol*         1.036
vm1_gc_wb_ary*                    0.312
vm1_gc_wb_ary_promoted*           0.000
vm1_gc_wb_obj*                    0.000
vm1_gc_wb_obj_promoted*           0.000
vm1_ivar*                      Error
vm1_ivar_set*                     0.000
vm1_length*                       0.000
vm1_lvar_init*                    0.000
vm1_lvar_set*                     0.000
vm1_neq*                          0.000
vm1_not*                       Error
vm1_rescue*                       0.000
vm1_simplereturn*                 0.000
vm1_swap*                         0.000
vm1_yield*                        0.000
vm2_array*                        1.260
vm2_bigarray*                     1.006
vm2_bighash*                      0.871
vm2_case*                         0.939
vm2_case_lit*                     0.000
vm2_defined_method*               3.667
vm2_dstr*                        12.333
vm2_eval*                         3.101
vm2_fiber_switch*                 1.600
vm2_method*                       0.000
vm2_method_missing*            Error
vm2_method_with_block*         Error
vm2_module_ann_const_set*         1.580
vm2_module_const_set*             1.602
vm2_mutex*                     Error
vm2_newlambda*                    1.187
vm2_poly_method*               Error
vm2_poly_method_ov*            Error
vm2_poly_singleton*            Error
vm2_proc*                         4.700
vm2_raise1*                       1.316
vm2_raise2*                       1.088
vm2_regexp*                    Error
vm2_send*                         0.690
vm2_string_literal*            Error
vm2_struct_big_aref_hi*        Error
vm2_struct_big_aref_lo*           0.914
vm2_struct_big_aset*              0.356
vm2_struct_big_href_hi*          40.000
vm2_struct_big_href_lo*        Error
vm2_struct_big_hset*           Error
vm2_struct_small_aref*            0.683
vm2_struct_small_aset*            0.000
vm2_struct_small_href*            0.000
vm2_struct_small_hset*           23.333
vm2_super*                       10.286
vm2_unif1*                     Error
vm2_zsuper*                       1.132
vm3_backtrace                     1.001
vm3_clearmethodcache              1.032
vm3_gc                            0.991
vm3_gc_old_full                   1.000
vm3_gc_old_immediate              0.992
vm3_gc_old_lazy                   1.046
vm_symbol_block_pass              1.011
vm_thread_alive_check1            1.009
vm_thread_close                   0.995
vm_thread_condvar1                0.994
vm_thread_condvar2                1.008
vm_thread_create_join             0.989
vm_thread_mutex1                  0.998
vm_thread_mutex2                  0.989
vm_thread_mutex3                  1.033
vm_thread_pass                 Error
vm_thread_pass_flood              1.001
vm_thread_pipe                    0.982
vm_thread_queue                   0.968
vm_thread_sized_queue             1.001
vm_thread_sized_queue2            0.963
vm_thread_sized_queue3            1.007
vm_thread_sized_queue4            0.999

Log file: bmlog-20180706-121110.12640.txt
```

Realtime bench:

```
lourens@CarbonX1:~/src/ruby/ruby$ ruby ~/src/ruby/ruby/benchmark/driver.rb -f plain --measure-target real -e packed::~/src/ruby/ruby/ruby -e trunk::~/src/ruby/trunk/ruby  --ruby-arg ' -Ilib -I. -I.ext/x86_64-linux '

-----------------------------------------------------------
benchmark results:
Execution time (sec)
name                            packed  trunk
app_answer                        0.168   0.169
app_aobench                     139.677 189.927
app_erb                           2.086   2.368
app_factorial                     3.542   3.416
app_fib                           1.848   1.866
app_lc_fizzbuzz                  74.078 110.006
app_mandelbrot                    4.699   4.744
app_pentomino                    42.503  72.669
app_raise                         0.818   0.838
app_strconcat                     3.513   3.552
app_tak                           2.982   3.003
app_tarai                         2.205   2.199
app_uri                           1.858   1.918
array_sample_100k_10              0.123   0.121
array_sample_100k_11              0.135   0.135
array_sample_100k__100            0.291   0.289
array_sample_100k__1k             1.916   1.926
array_sample_100k__6k             4.331   4.239
array_sample_100k___10k           6.218   6.035
array_sample_100k___50k          23.573  23.150
array_shift                      10.510  10.810
array_small_and                   0.113   0.113
array_small_diff                  0.118   0.116
array_small_or                    0.132   0.133
array_sort_block                 19.530  21.581
array_sort_float                 36.211   6.400
array_values_at_int               0.164   0.162
array_values_at_range             0.561   0.573
bighash                           4.754   4.414
dir_empty_p                       0.525   0.550
erb_render                        3.789   3.776
file_chmod                        0.643   0.629
file_rename                       1.864   1.861
hash_aref_dsym                    1.617   1.456
hash_aref_dsym_long               9.751   9.156
hash_aref_fix                     1.321   1.287
hash_aref_flo                     0.209   0.209
hash_aref_miss                    1.665   1.648
hash_aref_str                     1.503   1.482
hash_aref_sym                     1.241   1.232
hash_aref_sym_long                1.737   1.741
hash_flatten                      0.604   0.585
hash_ident_flo                    0.186   0.184
hash_ident_num                    1.170   1.158
hash_ident_obj                    1.157   1.215
hash_ident_str                    1.178   1.201
hash_ident_sym                    1.148   1.152
hash_keys                         0.254   0.254
hash_long                         2.255   2.126
hash_shift                        0.104   0.105
hash_shift_u16                    0.276   0.268
hash_shift_u24                    0.275   0.269
hash_shift_u32                    0.295   0.278
hash_small2                       1.790   1.961
hash_small4                       2.448   2.636
hash_small8                       4.061   4.849
hash_to_proc                      0.079   0.079
hash_values                       0.242   0.235
int_quo                           2.874   2.963
io_copy_stream_write              0.332   0.333
io_copy_stream_write_socket       0.525   0.532
io_file_create                    1.781   1.858
io_file_read                      2.161   2.191
io_file_write                     1.148   1.128
io_nonblock_noex                  3.174   3.461
io_nonblock_noex2                 2.177   2.143
io_pipe_rw                        1.575   1.535
io_select                         2.046   1.934
io_select2                        2.323   2.242
io_select3                        0.170   0.172
loop_for                          4.552   4.538
loop_generator                    0.812   0.787
loop_times                        4.033   3.730
loop_whileloop                    1.807   1.770
loop_whileloop2                   0.406   0.447
marshal_dump_flo                  0.564   0.606
marshal_dump_load_geniv           0.905   0.940
marshal_dump_load_time            1.882   1.867
require                           1.216   1.263
require_thread                   28.115  26.918
securerandom                      0.721   4.407
so_ackermann                      9.907   3.834
so_array                          5.507   5.015
so_binary_trees                  25.721  21.208
so_concatenate                   10.139   9.730
so_count_words                    0.499   0.488
so_exception                      0.725   0.706
so_fannkuch                       2.976   2.807
so_fasta                          5.366   6.118
so_k_nucleotide                   2.904   2.881
so_lists                          1.756   1.649
so_mandelbrot                     7.542   7.171
so_matrix                         2.211   2.028
so_meteor_contest                 9.043   8.397
so_nbody                          4.527   3.997
so_nested_loop                    3.734   3.392
so_nsieve                         4.876   5.360
so_nsieve_bits                    6.212   6.330
so_object                         2.523   2.288
so_partial_sums                   5.495   5.011
so_pidigits                       1.535   1.534
so_random                         1.365   1.224
so_reverse_complement             2.774   2.782
so_sieve                          1.742   1.609
so_spectralnorm                   6.213   6.338
string_index                      0.572   0.557
string_scan_re                    0.590   0.595
string_scan_str                   0.350   0.354
time_subsec                       3.033   3.311
vm1_attr_ivar*                    2.731   3.253
vm1_attr_ivar_set*                2.881   3.099
vm1_block*                        5.494   4.967
vm1_blockparam*                   3.752   4.064
vm1_blockparam_call*              8.274  29.398
vm1_blockparam_pass*             15.481  12.786
vm1_blockparam_yield*             7.582   7.151
vm1_const*                        1.538   1.759
vm1_ensure*                       0.432   0.307
vm1_float_simple*                14.142  14.095
vm1_gc_short_lived*              15.246  15.115
vm1_gc_short_with_complex_long*  17.029  16.062
vm1_gc_short_with_long*          15.887  15.503
vm1_gc_short_with_symbol*        13.570  15.558
vm1_gc_wb_ary*                    2.935   3.271
vm1_gc_wb_ary_promoted*           3.951   3.626
vm1_gc_wb_obj*                    3.604   3.202
vm1_gc_wb_obj_promoted*           3.047   2.993
vm1_ivar*                         1.913   2.003
vm1_ivar_set*                     1.640   1.438
vm1_length*                       1.662   1.462
vm1_lvar_init*                    4.793   4.916
vm1_lvar_set*                     9.052   9.959
vm1_neq*                          1.718   1.750
vm1_not*                          0.823   0.904
vm1_rescue*                       0.500   0.300
vm1_simplereturn*                 2.391   2.598
vm1_swap*                         1.316   1.399
vm1_yield*                        2.852   2.729
vm2_array*                        1.828   1.548
vm2_bigarray*                     4.065   4.019
vm2_bighash*                      1.584   1.671
vm2_case*                         0.336   0.368
vm2_case_lit*                     2.252   2.232
vm2_defined_method*               7.024   7.402
vm2_dstr*                         2.712   2.906
vm2_eval*                        62.182  57.959
vm2_fiber_switch*                 6.092   5.908
vm2_method*                       3.490   3.340
vm2_method_missing*               6.886   6.457
vm2_method_with_block*            4.063   3.831
vm2_module_ann_const_set*        11.403  12.348
vm2_module_const_set*            11.859  12.917
vm2_mutex*                        1.745   1.907
vm2_newlambda*                    2.027   2.173
vm2_poly_method*                  7.505  18.055
vm2_poly_method_ov*               1.550   1.448
vm2_poly_singleton*               7.132   6.435
vm2_proc*                         1.465   1.434
vm2_raise1*                      14.254  13.034
vm2_raise2*                      21.677  19.944
vm2_regexp*                       2.593   2.841
vm2_send*                         1.006   0.977
vm2_string_literal*               0.740   0.611
vm2_struct_big_aref_hi*           0.648   0.547
vm2_struct_big_aref_lo*           0.640   0.520
vm2_struct_big_aset*              0.798   0.666
vm2_struct_big_href_hi*           0.833   0.824
vm2_struct_big_href_lo*           0.942   0.806
vm2_struct_big_hset*              0.986   1.010
vm2_struct_small_aref*            0.452   0.411
vm2_struct_small_aset*            0.712   0.773
vm2_struct_small_href*            0.762   0.711
vm2_struct_small_hset*            0.848   0.841
vm2_super*                        1.403   1.354
vm2_unif1*                        0.490   0.449
vm2_zsuper*                       1.457   1.627
vm3_backtrace                     0.330   0.312
vm3_clearmethodcache              0.652   0.648
vm3_gc                           14.507  14.436
vm3_gc_old_full                  10.866  10.805
vm3_gc_old_immediate              5.590   5.689
vm3_gc_old_lazy                   6.514   6.297
vm_symbol_block_pass              2.840   2.789
vm_thread_alive_check1            0.126   0.131
vm_thread_close                   1.245   1.255
vm_thread_condvar1                0.779   0.762
vm_thread_condvar2                0.582   0.589
vm_thread_create_join             1.188   1.198
vm_thread_mutex1                  1.721   1.941
vm_thread_mutex2                  1.823   1.814
vm_thread_mutex3                  4.201   3.772
vm_thread_pass                    0.958   0.999
vm_thread_pass_flood              0.177   0.181
vm_thread_pipe                    0.599   0.580
vm_thread_queue                   0.405   0.427
vm_thread_sized_queue             0.483   0.492
vm_thread_sized_queue2            0.847   0.851
vm_thread_sized_queue3            0.839   0.854
vm_thread_sized_queue4            1.206   0.611

Speedup ratio: compare with the result of `packed' (greater is better)
name                            trunk
app_answer                        0.998
app_aobench                       0.735
app_erb                           0.881
app_factorial                     1.037
app_fib                           0.990
app_lc_fizzbuzz                   0.673
app_mandelbrot                    0.990
app_pentomino                     0.585
app_raise                         0.976
app_strconcat                     0.989
app_tak                           0.993
app_tarai                         1.003
app_uri                           0.969
array_sample_100k_10              1.012
array_sample_100k_11              1.000
array_sample_100k__100            1.004
array_sample_100k__1k             0.995
array_sample_100k__6k             1.022
array_sample_100k___10k           1.030
array_sample_100k___50k           1.018
array_shift                       0.972
array_small_and                   0.997
array_small_diff                  1.022
array_small_or                    0.990
array_sort_block                  0.905
array_sort_float                  5.658
array_values_at_int               1.010
array_values_at_range             0.978
bighash                           1.077
dir_empty_p                       0.954
erb_render                        1.003
file_chmod                        1.022
file_rename                       1.002
hash_aref_dsym                    1.110
hash_aref_dsym_long               1.065
hash_aref_fix                     1.026
hash_aref_flo                     1.000
hash_aref_miss                    1.010
hash_aref_str                     1.014
hash_aref_sym                     1.007
hash_aref_sym_long                0.998
hash_flatten                      1.033
hash_ident_flo                    1.010
hash_ident_num                    1.011
hash_ident_obj                    0.952
hash_ident_str                    0.981
hash_ident_sym                    0.996
hash_keys                         0.999
hash_long                         1.061
hash_shift                        0.990
hash_shift_u16                    1.031
hash_shift_u24                    1.021
hash_shift_u32                    1.063
hash_small2                       0.913
hash_small4                       0.929
hash_small8                       0.837
hash_to_proc                      1.002
hash_values                       1.027
int_quo                           0.970
io_copy_stream_write              0.998
io_copy_stream_write_socket       0.988
io_file_create                    0.959
io_file_read                      0.986
io_file_write                     1.018
io_nonblock_noex                  0.917
io_nonblock_noex2                 1.016
io_pipe_rw                        1.026
io_select                         1.058
io_select2                        1.036
io_select3                        0.986
loop_for                          1.003
loop_generator                    1.031
loop_times                        1.081
loop_whileloop                    1.021
loop_whileloop2                   0.909
marshal_dump_flo                  0.930
marshal_dump_load_geniv           0.963
marshal_dump_load_time            1.008
require                           0.963
require_thread                    1.044
securerandom                      0.164
so_ackermann                      2.584
so_array                          1.098
so_binary_trees                   1.213
so_concatenate                    1.042
so_count_words                    1.022
so_exception                      1.027
so_fannkuch                       1.060
so_fasta                          0.877
so_k_nucleotide                   1.008
so_lists                          1.065
so_mandelbrot                     1.052
so_matrix                         1.090
so_meteor_contest                 1.077
so_nbody                          1.133
so_nested_loop                    1.101
so_nsieve                         0.910
so_nsieve_bits                    0.981
so_object                         1.103
so_partial_sums                   1.097
so_pidigits                       1.001
so_random                         1.115
so_reverse_complement             0.997
so_sieve                          1.082
so_spectralnorm                   0.980
string_index                      1.027
string_scan_re                    0.992
string_scan_str                   0.990
time_subsec                       0.916
vm1_attr_ivar*                    0.840
vm1_attr_ivar_set*                0.930
vm1_block*                        1.106
vm1_blockparam*                   0.923
vm1_blockparam_call*              0.281
vm1_blockparam_pass*              1.211
vm1_blockparam_yield*             1.060
vm1_const*                        0.874
vm1_ensure*                       1.408
vm1_float_simple*                 1.003
vm1_gc_short_lived*               1.009
vm1_gc_short_with_complex_long*   1.060
vm1_gc_short_with_long*           1.025
vm1_gc_short_with_symbol*         0.872
vm1_gc_wb_ary*                    0.898
vm1_gc_wb_ary_promoted*           1.089
vm1_gc_wb_obj*                    1.126
vm1_gc_wb_obj_promoted*           1.018
vm1_ivar*                         0.955
vm1_ivar_set*                     1.141
vm1_length*                       1.137
vm1_lvar_init*                    0.975
vm1_lvar_set*                     0.909
vm1_neq*                          0.982
vm1_not*                          0.910
vm1_rescue*                       1.667
vm1_simplereturn*                 0.921
vm1_swap*                         0.941
vm1_yield*                        1.045
vm2_array*                        1.181
vm2_bigarray*                     1.011
vm2_bighash*                      0.948
vm2_case*                         0.912
vm2_case_lit*                     1.009
vm2_defined_method*               0.949
vm2_dstr*                         0.933
vm2_eval*                         1.073
vm2_fiber_switch*                 1.031
vm2_method*                       1.045
vm2_method_missing*               1.066
vm2_method_with_block*            1.061
vm2_module_ann_const_set*         0.923
vm2_module_const_set*             0.918
vm2_mutex*                        0.915
vm2_newlambda*                    0.933
vm2_poly_method*                  0.416
vm2_poly_method_ov*               1.070
vm2_poly_singleton*               1.108
vm2_proc*                         1.022
vm2_raise1*                       1.094
vm2_raise2*                       1.087
vm2_regexp*                       0.913
vm2_send*                         1.030
vm2_string_literal*               1.210
vm2_struct_big_aref_hi*           1.185
vm2_struct_big_aref_lo*           1.230
vm2_struct_big_aset*              1.198
vm2_struct_big_href_hi*           1.010
vm2_struct_big_href_lo*           1.170
vm2_struct_big_hset*              0.976
vm2_struct_small_aref*            1.100
vm2_struct_small_aset*            0.922
vm2_struct_small_href*            1.072
vm2_struct_small_hset*            1.008
vm2_super*                        1.036
vm2_unif1*                        1.091
vm2_zsuper*                       0.896
vm3_backtrace                     1.057
vm3_clearmethodcache              1.008
vm3_gc                            1.005
vm3_gc_old_full                   1.006
vm3_gc_old_immediate              0.983
vm3_gc_old_lazy                   1.034
vm_symbol_block_pass              1.018
vm_thread_alive_check1            0.957
vm_thread_close                   0.992
vm_thread_condvar1                1.022
vm_thread_condvar2                0.990
vm_thread_create_join             0.992
vm_thread_mutex1                  0.887
vm_thread_mutex2                  1.005
vm_thread_mutex3                  1.114
vm_thread_pass                    0.959
vm_thread_pass_flood              0.981
vm_thread_pipe                    1.032
vm_thread_queue                   0.947
vm_thread_sized_queue             0.982
vm_thread_sized_queue2            0.995
vm_thread_sized_queue3            0.982
vm_thread_sized_queue4            1.973

Log file: bmlog-20180706-131439.22195.txt
```