### PR TITLE
Windows file - must close before unlink

### DIFF
--- a/test/test_tempfile.rb
+++ b/test/test_tempfile.rb
@@ -401,8 +401,9 @@ puts Tempfile.new('foo').path
     assert_equal expect, actual
   ensure
     if t
-      File.unlink(t.path)
+      # Windows - must close before unlinking
       t.close
+      File.unlink t.path
     end
   end
 end


### PR DESCRIPTION
Does path exist in other platforms after close?