### PR TITLE
Improve branch misses on frozen object predicate checks negatively affecting performance of most setters as most objects are not frozen

### DIFF
--- a/include/ruby/intern.h
+++ b/include/ruby/intern.h
@@ -254,7 +254,7 @@ void rb_check_frozen(VALUE);
 void rb_check_trusted(VALUE);
 #define rb_check_frozen_internal(obj) do { \
 	VALUE frozen_obj = (obj); \
-	if (RB_OBJ_FROZEN(frozen_obj)) { \
+	if (RB_UNLIKELY(RB_OBJ_FROZEN(frozen_obj))) { \
 	    rb_error_frozen_object(frozen_obj); \
 	} \
     } while (0)


### PR DESCRIPTION

```
lourens@CarbonX1:~/src/ruby/trunk$ benchmark-driver -e "cache-miss-frozen::~/src/ruby/ruby/ruby -Ilib -I. -I.ext/x86_64-linux" -e "trunk::~/src/ruby/trunk/ruby -Ilib -I. -I.ext/x86_64-linux" benchmark/array_shift.rb
Calculating -------------------------------------
                     cache-miss-frozen       trunk 
         array_shift             0.097       0.093 i/s -       1.000 times in 10.320955s 10.794341s

Comparison:
                      array_shift
   cache-miss-frozen:         0.1 i/s 
               trunk:         0.1 i/s - 1.05x  slower

```

```
lourens@CarbonX1:~/src/ruby/trunk$ benchmark-driver -e "cache-miss-frozen::~/src/ruby/ruby/ruby -Ilib -I. -I.ext/x86_64-linux" -e "trunk::~/src/ruby/trunk/ruby -Ilib -I. -I.ext/x86_64-linux" benchmark/hash_ident_num.rb
Calculating -------------------------------------
                     cache-miss-frozen       trunk 
      hash_ident_num             0.922       0.836 i/s -       1.000 times in 1.085063s 1.196463s

Comparison:
                   hash_ident_num
   cache-miss-frozen:         0.9 i/s 
               trunk:         0.8 i/s - 1.10x  slower

```

```
lourens@CarbonX1:~/src/ruby/trunk$ benchmark-driver -e "cache-miss-frozen::~/src/ruby/ruby/ruby -Ilib -I. -I.ext/x86_64-linux" -e "trunk::~/src/ruby/trunk/ruby -Ilib -I. -I.ext/x86_64-linux" benchmark/so_array.rb
Calculating -------------------------------------
                     cache-miss-frozen       trunk 
            so_array             0.358       0.338 i/s -       1.000 times in 2.794432s 2.960024s

Comparison:
                         so_array
   cache-miss-frozen:         0.4 i/s 
               trunk:         0.3 i/s - 1.06x  slower
```

```
sudo perf record -e branch-misses ./miniruby -Ilib benchmark/app_strconcat.rb
```
#### This branch

![screenshot from 2018-07-12 01-12-04](https://user-images.githubusercontent.com/379/42605591-c1feb4fa-8570-11e8-9592-1b2a4a33d2d2.png)

![screenshot from 2018-07-12 01-12-31](https://user-images.githubusercontent.com/379/42605592-c648bd94-8570-11e8-830c-46d3ee6dd041.png)

#### Trunk

![screenshot from 2018-07-12 01-14-01](https://user-images.githubusercontent.com/379/42605605-e90f77f0-8570-11e8-9e81-d517793d5486.png)

![screenshot from 2018-07-12 01-14-51](https://user-images.githubusercontent.com/379/42605632-0b068740-8571-11e8-9579-e5b50d4b2d0f.png)


