### PR TITLE
IRB: add handling for non existant load paths

### DIFF
--- a/lib/irb/init.rb
+++ b/lib/irb/init.rb
@@ -147,7 +147,8 @@ module IRB # :nodoc:
         @CONF[:LOAD_MODULES].push opt if opt
       when /^-I(.+)?/
         opt = $1 || argv.shift
-        load_path.concat(opt.split(File::PATH_SEPARATOR)) if opt
+        IRB.fail(LoadPathDoesNotExist) if opt.nil? || !File.directory?(opt)
+        load_path.concat(opt.split(File::PATH_SEPARATOR))
       when '-U'
         set_encoding("UTF-8", "UTF-8")
       when /^-E(.+)?/, /^--encoding(?:=(.+))?/

--- a/lib/irb/init.rb
+++ b/lib/irb/init.rb
@@ -146,9 +146,12 @@ module IRB # :nodoc:
         opt = $1 || argv.shift
         @CONF[:LOAD_MODULES].push opt if opt
       when /^-I(.+)?/
-        opt = $1 || argv.shift
-        IRB.fail(LoadPathDoesNotExist) if opt.nil? || !File.directory?(opt)
-        load_path.concat(opt.split(File::PATH_SEPARATOR))
+        opt = ($1 || argv.shift).to_s
+        IRB.fail(LoadPathArgumentMissing) if opt.strip.empty?
+        paths = opt.split(File::PATH_SEPARATOR)
+        invalid_paths = paths.select { |path| !File.directory?(path) }
+        IRB.fail(LoadPathDoesNotExist, invalid_paths.join(', ')) if invalid_paths.any?
+        load_path.concat(paths)
       when '-U'
         set_encoding("UTF-8", "UTF-8")
       when /^-E(.+)?/, /^--encoding(?:=(.+))?/

--- a/lib/irb/lc/error.rb
+++ b/lib/irb/lc/error.rb
@@ -27,6 +27,6 @@ module IRB
   def_exception :CantChangeBinding, "Can't change binding to (%s)."
   def_exception :UndefinedPromptMode, "Undefined prompt mode(%s)."
   def_exception :IllegalRCGenerator, 'Define illegal RC_NAME_GENERATOR.'
-
+  def_exception :LoadPathDoesNotExist, 'Please pass a Load Path that exists'
 end
 # :startdoc:

--- a/lib/irb/lc/error.rb
+++ b/lib/irb/lc/error.rb
@@ -27,6 +27,7 @@ module IRB
   def_exception :CantChangeBinding, "Can't change binding to (%s)."
   def_exception :UndefinedPromptMode, "Undefined prompt mode(%s)."
   def_exception :IllegalRCGenerator, 'Define illegal RC_NAME_GENERATOR.'
-  def_exception :LoadPathDoesNotExist, 'Please pass a Load Path that exists'
+  def_exception :LoadPathDoesNotExist, "Load path does not exist: %s"
+  def_exception :LoadPathArgumentMissing, "Load path for -I flag missing"
 end
 # :startdoc:

--- a/test/irb/test_load_path_prepend_option.rb
+++ b/test/irb/test_load_path_prepend_option.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: false
+require 'test/unit'
+require 'irb'
+require 'irb/lc/error'
+
+module TestIRB
+  class TestLoadPathPrependOption < Test::Unit::TestCase
+    def test_valid_load_path
+      begin
+        path = File.expand_path('lib', Dir.pwd)
+        IRB.parse_opts(argv: ['-I', path])
+        assert_equal($LOAD_PATH.first, path)
+      ensure
+        $LOAD_PATH.delete($LOAD_PATH.first)
+      end
+    end
+
+    def test_invalid_load_path
+      path = File.expand_path('non-existant-path')
+
+      assert_raise(IRB::LoadPathDoesNotExist) do
+        IRB.parse_opts(argv: ['-I', path])
+      end
+    end
+
+    def test_nil_load_path
+      assert_raise(IRB::LoadPathDoesNotExist) do
+        IRB.parse_opts(argv: ['-I'])
+      end
+    end
+  end
+end

--- a/test/irb/test_load_path_prepend_option.rb
+++ b/test/irb/test_load_path_prepend_option.rb
@@ -7,25 +7,57 @@ module TestIRB
   class TestLoadPathPrependOption < Test::Unit::TestCase
     def test_valid_load_path
       begin
-        path = File.expand_path('lib', Dir.pwd)
+        path = File.dirname(__FILE__)
+
         IRB.parse_opts(argv: ['-I', path])
+
         assert_equal($LOAD_PATH.first, path)
       ensure
         $LOAD_PATH.delete($LOAD_PATH.first)
       end
     end
 
-    def test_invalid_load_path
-      path = File.expand_path('non-existant-path')
+    def test_multiple_valid_load_paths
+      begin
+        this_dir = __dir__
+        enclosing_dir = File.expand_path('..', __dir__)
 
-      assert_raise(IRB::LoadPathDoesNotExist) do
-        IRB.parse_opts(argv: ['-I', path])
+        IRB.parse_opts(argv: ['-I', this_dir + File::PATH_SEPARATOR + enclosing_dir])
+
+        assert_equal($LOAD_PATH[0], this_dir)
+        assert_equal($LOAD_PATH[1], enclosing_dir)
+      ensure
+        $LOAD_PATH.delete(this_dir)
+        $LOAD_PATH.delete(enclosing_dir)
+      end
+    end
+
+    def test_valid_and_invalid_load_paths
+      this_dir = __dir__
+      invalid_dir = File.expand_path('non-existant-path')
+
+      assert_raise_with_message(IRB::LoadPathDoesNotExist, "Load path does not exist: #{invalid_dir}") do
+        IRB.parse_opts(argv: ['-I', this_dir + File::PATH_SEPARATOR + invalid_dir])
+      end
+    end
+
+    def test_invalid_load_path
+      invalid_dir = File.expand_path('non-existant-path')
+
+      assert_raise_with_message(IRB::LoadPathDoesNotExist, "Load path does not exist: #{invalid_dir}") do
+        IRB.parse_opts(argv: ['-I', invalid_dir])
       end
     end
 
     def test_nil_load_path
-      assert_raise(IRB::LoadPathDoesNotExist) do
+      assert_raise(IRB::LoadPathArgumentMissing) do
         IRB.parse_opts(argv: ['-I'])
+      end
+    end
+
+    def test_empty_string_load_path
+      assert_raise(IRB::LoadPathArgumentMissing) do
+        IRB.parse_opts(argv: ['-I', '  '])
       end
     end
   end


### PR DESCRIPTION
Hi Ruby Core Team! 👋 

When someone uses IRB with the -I flag, the passed load path is not validated, so someone might pass in a load path that does not exist and get no error message. This has caused me some headache in the past.

This PR handles this by raising an error message when:
- someone passes an empty argument for the -I flag
- someone passes a non existing load path

The only thing that might need to be added is the Japanese error translation, unfortunately I'm not fluent in Japanese so I can't tackle that :)

Would this be something you'd consider merging in?