### PR TITLE
Let ruby bugs be considered unlikely brances

### DIFF
--- a/array.c
+++ b/array.c
@@ -1623,7 +1623,7 @@ rb_ary_set_len(VALUE ary, long len)
     if (ARY_SHARED_P(ary)) {
 	rb_raise(rb_eRuntimeError, "can't set length of shared ");
     }
-    if (len > (capa = (long)ARY_CAPA(ary))) {
+    if (UNLIKELY(len > (capa = (long)ARY_CAPA(ary)))) {
 	rb_bug("probable buffer overflow: %ld for %ld", len, capa);
     }
     ARY_SET_LEN(ary, len);

--- a/bignum.c
+++ b/bignum.c
@@ -4664,7 +4664,7 @@ power_cache_get_power(int base, int power_level, size_t *numdigits_ret)
      * (256**SIZEOF_SIZE_T)*(sizeof(BDIGIT_DBL)-1) >
      * 256**SIZEOF_SIZE_T
      */
-    if (MAX_BASE36_POWER_TABLE_ENTRIES <= power_level)
+    if (UNLIKELY(MAX_BASE36_POWER_TABLE_ENTRIES <= power_level))
         rb_bug("too big power number requested: maxpow_in_bdigit_dbl(%d)**(2**%d)", base, power_level);
 
     if (NIL_P(base36_power_cache[base - 2][power_level])) {

--- a/class.c
+++ b/class.c
@@ -1601,7 +1601,7 @@ singleton_class_of(VALUE obj)
     }
     if (SPECIAL_CONST_P(obj)) {
 	klass = special_singleton_class_of(obj);
-	if (NIL_P(klass))
+	if (UNLIKELY(NIL_P(klass)))
 	    rb_bug("unknown immediate %p", (void *)obj);
 	return klass;
     }

--- a/compile.c
+++ b/compile.c
@@ -533,7 +533,7 @@ verify_list(ISEQ_ARG_DECLARE const char *info, LINK_ANCHOR *const anchor)
 	flag |= 0x70000;
     }
 
-    if (flag != 0) {
+    if (UNLIKELY(flag != 0)) {
 	rb_bug("list verify error: %08x (%s)", flag, info);
     }
 #endif
@@ -1424,7 +1424,7 @@ get_local_var_idx(const rb_iseq_t *iseq, ID id)
 {
     int idx = get_dyna_var_idx_at_raw(iseq->body->local_iseq, id);
 
-    if (idx < 0) {
+    if (UNLIKELY(idx < 0)) {
 	rb_bug("get_local_var_idx: %d", idx);
     }
 
@@ -1445,7 +1445,7 @@ get_dyna_var_idx(const rb_iseq_t *iseq, ID id, int *level, int *ls)
 	lv++;
     }
 
-    if (idx < 0) {
+    if (UNLIKELY(idx < 0)) {
 	rb_bug("get_dyna_var_idx: -1");
     }
 
@@ -8401,7 +8401,7 @@ ibf_dump_overwrite(struct ibf_dump *dump, void *buff, unsigned int size, long of
 {
     VALUE str = dump->str;
     char *ptr = RSTRING_PTR(str);
-    if ((unsigned long)(size + offset) > (unsigned long)RSTRING_LEN(str))
+    if (UNLIKELY((unsigned long)(size + offset)) > (unsigned long)RSTRING_LEN(str))
 	rb_bug("ibf_dump_overwrite: overflow");
     memcpy(ptr + offset, buff, size);
 }

--- a/cont.c
+++ b/cont.c
@@ -364,7 +364,7 @@ cont_free(void *ptr)
 	}
 #else /* not WIN32 */
 	if (fib->ss_sp != NULL) {
-	    if (cont->type == ROOT_FIBER_CONTEXT) {
+	    if (UNLIKELY(cont->type == ROOT_FIBER_CONTEXT)) {
 		rb_bug("Illegal root fiber parameter");
 	    }
 	    munmap((void*)fib->ss_sp, fib->ss_size);
@@ -905,7 +905,7 @@ fiber_setcontext(rb_fiber_t *newfib, rb_fiber_t *oldfib)
     fiber_restore_thread(th, newfib);
 
 #ifndef _WIN32
-    if (!newfib->context.uc_stack.ss_sp && th->root_fiber != newfib) {
+    if (UNLIKELY(!newfib->context.uc_stack.ss_sp && th->root_fiber != newfib)) {
 	rb_bug("non_root_fiber->context.uc_stac.ss_sp should not be NULL");
     }
 #endif
@@ -1508,7 +1508,7 @@ root_fiber_alloc(rb_thread_t *th)
 #ifdef _WIN32
     /* setup fib_handle for root Fiber */
     if (fib->fib_handle == 0) {
-        if ((fib->fib_handle = ConvertThreadToFiber(0)) == 0) {
+        if (UNLIKELY((fib->fib_handle = ConvertThreadToFiber(0)) == 0)) {
             rb_bug("root_fiber_alloc: ConvertThreadToFiber() failed - %s\n", rb_w32_strerror(-1));
         }
     }

--- a/encoding.c
+++ b/encoding.c
@@ -104,11 +104,11 @@ rb_enc_from_encoding_index(int idx)
 {
     VALUE list, enc;
 
-    if (!(list = rb_encoding_list)) {
+    if (UNLIKELY(!(list = rb_encoding_list))) {
 	rb_bug("rb_enc_from_encoding_index(%d): no rb_encoding_list", idx);
     }
     enc = rb_ary_entry(list, idx);
-    if (NIL_P(enc)) {
+    if (UNLIKELY(NIL_P(enc))) {
 	rb_bug("rb_enc_from_encoding_index(%d): not created yet", idx);
     }
     return enc;
@@ -819,7 +819,7 @@ rb_enc_get_index(VALUE obj)
 static void
 enc_set_index(VALUE obj, int idx)
 {
-    if (!enc_capable(obj)) rb_bug("enc_set_index: not capable object");
+    if (UNLIKELY(!enc_capable(obj))) rb_bug("enc_set_index: not capable object");
 
     if (idx < ENCODING_INLINE_MAX) {
 	ENCODING_SET_INLINED(obj, idx);

--- a/error.c
+++ b/error.c
@@ -790,7 +790,7 @@ rb_check_type(VALUE x, int t)
 {
     int xt;
 
-    if (x == Qundef) {
+    if (UNLIKELY(x == Qundef)) {
 	rb_bug(UNDEF_LEAKED);
     }
 
@@ -803,7 +803,7 @@ rb_check_type(VALUE x, int t)
 void
 rb_unexpected_type(VALUE x, int t)
 {
-    if (x == Qundef) {
+    if (UNLIKELY(x == Qundef)) {
 	rb_bug(UNDEF_LEAKED);
     }
 
@@ -2609,7 +2609,7 @@ make_errno_exc(const char *mesg)
     int n = errno;
 
     errno = 0;
-    if (n == 0) {
+    if (UNLIKELY(n == 0)) {
 	rb_bug("rb_sys_fail(%s) - errno == 0", mesg ? mesg : "");
     }
     return rb_syserr_new(n, mesg);
@@ -2622,7 +2622,7 @@ make_errno_exc_str(VALUE mesg)
 
     errno = 0;
     if (!mesg) mesg = Qnil;
-    if (n == 0) {
+    if (UNLIKELY(n == 0)) {
 	const char *s = !NIL_P(mesg) ? RSTRING_PTR(mesg) : "";
 	rb_bug("rb_sys_fail_str(%s) - errno == 0", s);
     }

--- a/ext/objspace/objspace.c
+++ b/ext/objspace/objspace.c
@@ -804,7 +804,7 @@ reachable_object_from_root_i(const char *category, VALUE obj, void *ptr)
 	data->last_category = category;
 	category_str = data->last_category_str = rb_str_new2(category);
 	category_objects = data->last_category_objects = rb_ident_hash_new();
-	if (!NIL_P(rb_hash_lookup(data->categories, category_str))) {
+	if (UNLIKELY(!NIL_P(rb_hash_lookup(data->categories, category_str)))) {
 	    rb_bug("reachable_object_from_root_i: category should insert at once");
 	}
 	rb_hash_aset(data->categories, category_str, category_objects);

--- a/gc.c
+++ b/gc.c
@@ -1071,10 +1071,10 @@ check_rvalue_consistency(const VALUE obj)
 {
     rb_objspace_t *objspace = &rb_objspace;
 
-    if (SPECIAL_CONST_P(obj)) {
+    if (UNLIKELY((SPECIAL_CONST_P(obj)))) {
 	rb_bug("check_rvalue_consistency: %p is a special const.", (void *)obj);
     }
-    else if (!is_pointer_to_heap(objspace, (void *)obj)) {
+    else if (UNLIKELY((!is_pointer_to_heap(objspace, (void *)obj)))) {
 	rb_bug("check_rvalue_consistency: %p is not a Ruby object.", (void *)obj);
     }
     else {
@@ -1084,27 +1084,27 @@ check_rvalue_consistency(const VALUE obj)
 	const int marking_bit = RVALUE_MARKING_BITMAP(obj) != 0, remembered_bit = marking_bit;
 	const int age = RVALUE_FLAGS_AGE(RBASIC(obj)->flags);
 
-	if (BUILTIN_TYPE(obj) == T_NONE)   rb_bug("check_rvalue_consistency: %s is T_NONE", obj_info(obj));
-	if (BUILTIN_TYPE(obj) == T_ZOMBIE) rb_bug("check_rvalue_consistency: %s is T_ZOMBIE", obj_info(obj));
+	if (UNLIKELY((BUILTIN_TYPE(obj) == T_NONE)))   rb_bug("check_rvalue_consistency: %s is T_NONE", obj_info(obj));
+	if (UNLIKELY((BUILTIN_TYPE(obj) == T_ZOMBIE))) rb_bug("check_rvalue_consistency: %s is T_ZOMBIE", obj_info(obj));
 	obj_memsize_of((VALUE)obj, FALSE);
 
 	/* check generation
 	 *
 	 * OLD == age == 3 && old-bitmap && mark-bit (except incremental marking)
 	 */
-	if (age > 0 && wb_unprotected_bit) {
+	if (UNLIKELY((age > 0 && wb_unprotected_bit))) {
 	    rb_bug("check_rvalue_consistency: %s is not WB protected, but age is %d > 0.", obj_info(obj), age);
 	}
 
-	if (!is_marking(objspace) && uncollectible_bit && !mark_bit) {
+	if (UNLIKELY((!is_marking(objspace) && uncollectible_bit && !mark_bit))) {
 	    rb_bug("check_rvalue_consistency: %s is uncollectible, but is not marked while !gc.", obj_info(obj));
 	}
 
-	if (!is_full_marking(objspace)) {
-	    if (uncollectible_bit && age != RVALUE_OLD_AGE && !wb_unprotected_bit) {
+	if (UNLIKELY((!is_full_marking(objspace)))) {
+	    if (UNLIKELY(uncollectible_bit && age != RVALUE_OLD_AGE && !wb_unprotected_bit)) {
 		rb_bug("check_rvalue_consistency: %s is uncollectible, but not old (age: %d) and not WB unprotected.", obj_info(obj), age);
 	    }
-	    if (remembered_bit && age != RVALUE_OLD_AGE) {
+	    if (UNLIKELY(remembered_bit && age != RVALUE_OLD_AGE)) {
 		rb_bug("check_rvalue_consistency: %s is remembered, but not old (age: %d).", obj_info(obj), age);
 	    }
 	}
@@ -1117,7 +1117,7 @@ check_rvalue_consistency(const VALUE obj)
 	 * marked:true   black         grey
 	 */
 	if (is_incremental_marking(objspace) && marking_bit) {
-	    if (!is_marking(objspace) && !mark_bit) rb_bug("check_rvalue_consistency: %s is marking, but not marked.", obj_info(obj));
+	    if (UNLIKELY((!is_marking(objspace) && !mark_bit))) rb_bug("check_rvalue_consistency: %s is marking, but not marked.", obj_info(obj));
 	}
     }
     return obj;
@@ -1216,7 +1216,7 @@ RVALUE_AGE_INC(rb_objspace_t *objspace, VALUE obj)
     VALUE flags = RBASIC(obj)->flags;
     int age = RVALUE_FLAGS_AGE(flags);
 
-    if (RGENGC_CHECK_MODE && age == RVALUE_OLD_AGE) {
+    if (UNLIKELY(RGENGC_CHECK_MODE && age == RVALUE_OLD_AGE)) {
 	rb_bug("RVALUE_AGE_INC: can not increment age of OLD object %s.", obj_info(obj));
     }
 
@@ -1343,7 +1343,7 @@ static void heap_page_free(rb_objspace_t *objspace, struct heap_page *page);
 void
 rb_objspace_free(rb_objspace_t *objspace)
 {
-    if (is_lazy_sweeping(heap_eden))
+    if (UNLIKELY(is_lazy_sweeping(heap_eden)))
 	rb_bug("lazy sweeping underway when freeing object space");
 
     if (objspace->profile.records) {
@@ -1438,7 +1438,7 @@ heap_page_add_freeobj(rb_objspace_t *objspace, struct heap_page *page, VALUE obj
     p->as.free.next = page->freelist;
     page->freelist = p;
 
-    if (RGENGC_CHECK_MODE && !is_pointer_to_heap(objspace, p)) {
+    if (UNLIKELY(RGENGC_CHECK_MODE && !is_pointer_to_heap(objspace, p))) {
 	rb_bug("heap_page_add_freeobj: %p is not rvalue.", (void *)p);
     }
 
@@ -1575,7 +1575,7 @@ heap_page_allocate(rb_objspace_t *objspace)
 
     objspace->profile.total_allocated_pages++;
 
-    if (heap_allocated_pages > heap_pages_sorted_length) {
+    if (UNLIKELY(heap_allocated_pages > heap_pages_sorted_length)) {
 	rb_bug("heap_page_allocate: allocated(%"PRIdSIZE") > sorted(%"PRIdSIZE")",
 	       heap_allocated_pages, heap_pages_sorted_length);
     }
@@ -1837,16 +1837,16 @@ newobj_init(VALUE klass, VALUE flags, VALUE v1, VALUE v2, VALUE v3, int wb_prote
     GC_ASSERT(RVALUE_WB_UNPROTECTED(obj) == FALSE);
 
     if (flags & FL_PROMOTED1) {
-	if (RVALUE_AGE(obj) != 2) rb_bug("newobj: %s of age (%d) != 2.", obj_info(obj), RVALUE_AGE(obj));
+	if (UNLIKELY(RVALUE_AGE(obj) != 2)) rb_bug("newobj: %s of age (%d) != 2.", obj_info(obj), RVALUE_AGE(obj));
     }
     else {
-	if (RVALUE_AGE(obj) > 0) rb_bug("newobj: %s of age (%d) > 0.", obj_info(obj), RVALUE_AGE(obj));
+	if (UNLIKELY(RVALUE_AGE(obj) > 0)) rb_bug("newobj: %s of age (%d) > 0.", obj_info(obj), RVALUE_AGE(obj));
     }
-    if (rgengc_remembered(objspace, (VALUE)obj)) rb_bug("newobj: %s is remembered.", obj_info(obj));
+    if (UNLIKELY(rgengc_remembered(objspace, (VALUE)obj))) rb_bug("newobj: %s is remembered.", obj_info(obj));
 #endif
 
 #if USE_RGENGC
-    if (UNLIKELY(wb_protected == FALSE)) {
+    if ((UNLIKELY(wb_protected == FALSE))) {
 	MARK_IN_BITMAP(GET_HEAP_WB_UNPROTECTED_BITS(obj), obj);
     }
 #endif
@@ -1903,7 +1903,7 @@ newobj_slowpath(VALUE klass, VALUE flags, VALUE v1, VALUE v2, VALUE v3, rb_objsp
     VALUE obj;
 
     if (UNLIKELY(during_gc || ruby_gc_stressful)) {
-	if (during_gc) {
+	if (UNLIKELY(during_gc)) {
 	    dont_gc = 1;
 	    during_gc = 0;
 	    rb_bug("object allocation during garbage collection phase");
@@ -3527,8 +3527,8 @@ gc_page_sweep(rb_objspace_t *objspace, rb_heap_t *heap, struct heap_page *sweep_
 			  gc_report(2, objspace, "page_sweep: free %p\n", (void *)p);
 #if USE_RGENGC && RGENGC_CHECK_MODE
 			  if (!is_full_marking(objspace)) {
-			      if (RVALUE_OLD_P((VALUE)p)) rb_bug("page_sweep: %p - old while minor GC.", (void *)p);
-			      if (rgengc_remembered(objspace, (VALUE)p)) rb_bug("page_sweep: %p - remembered.", (void *)p);
+			      if (UNLIKELY(RVALUE_OLD_P((VALUE)p))) rb_bug("page_sweep: %p - old while minor GC.", (void *)p);
+			      if (UNLIKELY(rgengc_remembered(objspace, (VALUE)p))) rb_bug("page_sweep: %p - remembered.", (void *)p);
 			  }
 #endif
 			  if (obj_free(objspace, (VALUE)p)) {
@@ -4402,8 +4402,8 @@ static void
 gc_grey(rb_objspace_t *objspace, VALUE obj)
 {
 #if RGENGC_CHECK_MODE
-    if (RVALUE_MARKED(obj) == FALSE) rb_bug("gc_grey: %s is not marked.", obj_info(obj));
-    if (RVALUE_MARKING(obj) == TRUE) rb_bug("gc_grey: %s is marking/remembered.", obj_info(obj));
+    if (UNLIKELY(RVALUE_MARKED(obj) == FALSE)) rb_bug("gc_grey: %s is not marked.", obj_info(obj));
+    if (UNLIKELY(RVALUE_MARKING(obj) == TRUE)) rb_bug("gc_grey: %s is marking/remembered.", obj_info(obj));
 #endif
 
 #if GC_ENABLE_INCREMENTAL_MARK
@@ -4699,8 +4699,8 @@ gc_mark_children(rb_objspace_t *objspace, VALUE obj)
 #if GC_DEBUG
 	rb_gcdebug_print_obj_condition((VALUE)obj);
 #endif
-	if (BUILTIN_TYPE(obj) == T_NONE)   rb_bug("rb_gc_mark(): %p is T_NONE", (void *)obj);
-	if (BUILTIN_TYPE(obj) == T_ZOMBIE) rb_bug("rb_gc_mark(): %p is T_ZOMBIE", (void *)obj);
+	if (UNLIKELY(BUILTIN_TYPE(obj)) == T_NONE)   rb_bug("rb_gc_mark(): %p is T_NONE", (void *)obj);
+	if (UNLIKELY(BUILTIN_TYPE(obj)) == T_ZOMBIE) rb_bug("rb_gc_mark(): %p is T_ZOMBIE", (void *)obj);
 	rb_bug("rb_gc_mark(): unknown data type 0x%x(%p) %s",
 	       BUILTIN_TYPE(obj), (void *)any,
 	       is_pointer_to_heap(objspace, any) ? "corrupted object" : "non object");
@@ -4731,7 +4731,7 @@ gc_mark_stacked_objects(rb_objspace_t *objspace, int incremental, size_t count)
 
 #if GC_ENABLE_INCREMENTAL_MARK
 	if (incremental) {
-	    if (RGENGC_CHECK_MODE && !RVALUE_MARKING(obj)) {
+	    if (UNLIKELY(RGENGC_CHECK_MODE && !RVALUE_MARKING(obj))) {
 		rb_bug("gc_mark_stacked_objects: incremental, but marking bit is 0");
 	    }
 	    CLEAR_IN_BITMAP(GET_HEAP_MARKING_BITS(obj), obj);
@@ -4978,7 +4978,7 @@ static void
 allrefs_roots_i(VALUE obj, void *ptr)
 {
     struct allrefs *data = (struct allrefs *)ptr;
-    if (strlen(data->category) == 0) rb_bug("!!!");
+    if (UNLIKELY(strlen(data->category) == 0)) rb_bug("!!!");
     data->root_obj = MAKE_ROOTSIG(data->category);
 
     if (allrefs_add(data, obj)) {
@@ -5097,7 +5097,7 @@ gc_marks_check(rb_objspace_t *objspace, int (*checker_func)(ANYARGS), const char
 #if RGENGC_CHECK_MODE >= 5
 	allrefs_dump(objspace);
 #endif
-	if (checker_name) rb_bug("%s: GC has problem.", checker_name);
+	if (UNLIKELY(checker_name)) rb_bug("%s: GC has problem.", checker_name);
     }
 
     objspace_allrefs_destruct(objspace->rgengc.allrefs_table);
@@ -5247,18 +5247,18 @@ gc_verify_heap_page(rb_objspace_t *objspace, struct heap_page *page, VALUE obj)
 	       (void *)page, remembered_old_objects, obj ? obj_info(obj) : "");
     }
 
-    if (page->flags.has_uncollectible_shady_objects == FALSE && has_remembered_shady == TRUE) {
+    if (UNLIKELY(page->flags.has_uncollectible_shady_objects == FALSE && has_remembered_shady == TRUE)) {
 	rb_bug("page %p's has_remembered_shady should be false, but there are remembered shady objects. %s",
 	       (void *)page, obj ? obj_info(obj) : "");
     }
 
     if (0) {
 	/* free_slots may not equal to free_objects */
-	if (page->free_slots != free_objects) {
+	if (UNLIKELY(page->free_slots != free_objects)) {
 	    rb_bug("page %p's free_slots should be %d, but %d\n", (void *)page, (int)page->free_slots, free_objects);
 	}
     }
-    if (page->final_slots != zombie_objects) {
+    if (UNLIKELY(page->final_slots != zombie_objects)) {
 	rb_bug("page %p's final_slots should be %d, but %d\n", (void *)page, (int)page->final_slots, zombie_objects);
     }
 
@@ -5333,7 +5333,7 @@ gc_verify_internal_consistency(VALUE dummy)
     /* check counters */
 
     if (!is_lazy_sweeping(heap_eden) && !finalizing) {
-	if (objspace_live_slots(objspace) != data.live_object_count) {
+	if (UNLIKELY(objspace_live_slots(objspace) != data.live_object_count)) {
 	    fprintf(stderr, "heap_pages_final_slots: %d, objspace->profile.total_freed_objects: %d\n",
 		    (int)heap_pages_final_slots, (int)objspace->profile.total_freed_objects);
 	    rb_bug("inconsistent live slot number: expect %"PRIuSIZE", but %"PRIuSIZE".", objspace_live_slots(objspace), data.live_object_count);
@@ -5342,10 +5342,10 @@ gc_verify_internal_consistency(VALUE dummy)
 
 #if USE_RGENGC
     if (!is_marking(objspace)) {
-	if (objspace->rgengc.old_objects != data.old_object_count) {
+	if (UNLIKELY(objspace->rgengc.old_objects != data.old_object_count)) {
 	    rb_bug("inconsistent old slot number: expect %"PRIuSIZE", but %"PRIuSIZE".", objspace->rgengc.old_objects, data.old_object_count);
 	}
-	if (objspace->rgengc.uncollectible_wb_unprotected_objects != data.remembered_shady_count) {
+	if (UNLIKELY(objspace->rgengc.uncollectible_wb_unprotected_objects != data.remembered_shady_count)) {
 	    rb_bug("inconsistent old slot number: expect %"PRIuSIZE", but %"PRIuSIZE".", objspace->rgengc.uncollectible_wb_unprotected_objects, data.remembered_shady_count);
 	}
     }
@@ -5362,8 +5362,8 @@ gc_verify_internal_consistency(VALUE dummy)
 	    }
 	}
 
-	if (heap_pages_final_slots != data.zombie_object_count ||
-	    heap_pages_final_slots != list_count) {
+	if (UNLIKELY(heap_pages_final_slots != data.zombie_object_count ||
+	    heap_pages_final_slots != list_count)) {
 
 	    rb_bug("inconsistent finalizing object count:\n"
 		   "  expect %"PRIuSIZE"\n"
@@ -5488,7 +5488,7 @@ gc_marks_finish(rb_objspace_t *objspace)
 	    return FALSE; /* continue marking phase */
 	}
 
-	if (RGENGC_CHECK_MODE && is_mark_stack_empty(&objspace->mark_stack) == 0) {
+	if (UNLIKELY(RGENGC_CHECK_MODE && is_mark_stack_empty(&objspace->mark_stack) == 0)) {
 	    rb_bug("gc_marks_finish: mark stack is not empty (%d).", (int)mark_stack_size(&objspace->mark_stack));
 	}
 
@@ -5500,7 +5500,7 @@ gc_marks_finish(rb_objspace_t *objspace)
 	}
 
 #if RGENGC_CHECK_MODE >= 2
-	if (gc_verify_heap_pages(objspace) != 0) {
+	if (UNLIKELY(gc_verify_heap_pages(objspace) != 0)) {
 	    rb_bug("gc_marks_finish (incremental): there are remembered old objects.");
 	}
 #endif
@@ -5791,7 +5791,7 @@ rgengc_remember(rb_objspace_t *objspace, VALUE obj)
     check_rvalue_consistency(obj);
 
     if (RGENGC_CHECK_MODE) {
-	if (RVALUE_WB_UNPROTECTED(obj)) rb_bug("rgengc_remember: %s is not wb protected.", obj_info(obj));
+	if (UNLIKELY(RVALUE_WB_UNPROTECTED(obj))) rb_bug("rgengc_remember: %s is not wb protected.", obj_info(obj));
     }
 
 #if RGENGC_PROFILE > 0
@@ -5906,9 +5906,9 @@ static void
 gc_writebarrier_generational(VALUE a, VALUE b, rb_objspace_t *objspace)
 {
     if (RGENGC_CHECK_MODE) {
-	if (!RVALUE_OLD_P(a)) rb_bug("gc_writebarrier_generational: %s is not an old object.", obj_info(a));
-	if ( RVALUE_OLD_P(b)) rb_bug("gc_writebarrier_generational: %s is an old object.", obj_info(b));
-	if (is_incremental_marking(objspace)) rb_bug("gc_writebarrier_generational: called while incremental marking: %s -> %s", obj_info(a), obj_info(b));
+	if (UNLIKELY(!RVALUE_OLD_P(a))) rb_bug("gc_writebarrier_generational: %s is not an old object.", obj_info(a));
+	if (UNLIKELY( RVALUE_OLD_P(b))) rb_bug("gc_writebarrier_generational: %s is an old object.", obj_info(b));
+	if (UNLIKELY(is_incremental_marking(objspace))) rb_bug("gc_writebarrier_generational: called while incremental marking: %s -> %s", obj_info(a), obj_info(b));
     }
 
 #if 1
@@ -5985,8 +5985,8 @@ rb_gc_writebarrier(VALUE a, VALUE b)
 {
     rb_objspace_t *objspace = &rb_objspace;
 
-    if (RGENGC_CHECK_MODE && SPECIAL_CONST_P(a)) rb_bug("rb_gc_writebarrier: a is special const");
-    if (RGENGC_CHECK_MODE && SPECIAL_CONST_P(b)) rb_bug("rb_gc_writebarrier: b is special const");
+    if (UNLIKELY(RGENGC_CHECK_MODE && SPECIAL_CONST_P(a))) rb_bug("rb_gc_writebarrier: a is special const");
+    if (UNLIKELY(RGENGC_CHECK_MODE && SPECIAL_CONST_P(b))) rb_bug("rb_gc_writebarrier: b is special const");
 
     if (!is_incremental_marking(objspace)) {
 	if (!RVALUE_OLD_P(a) || RVALUE_OLD_P(b)) {
@@ -7847,7 +7847,7 @@ objspace_malloc_increase(rb_objspace_t *objspace, void *mem, size_t new_size, si
 	size_t allocated_size = objspace->malloc_params.allocated_size;
 
 #if MALLOC_ALLOCATED_SIZE_CHECK
-	if (allocated_size < dec_size) {
+	if (UNLIKELY(allocated_size < dec_size)) {
 	    rb_bug("objspace_malloc_increase: underflow malloc_params.allocated_size.");
 	}
 #endif
@@ -8101,7 +8101,7 @@ objspace_xfree(rb_objspace_t *objspace, void *ptr, size_t old_size)
             }
             else {
                 data = malloc(sizeof(size_t) * 2);
-                if (data == NULL) rb_bug("objspace_xfree: can not allocate memory");
+                if (UNLIKELY(data == NULL)) rb_bug("objspace_xfree: can not allocate memory");
                 data[0] = data[1] = 0;
                 st_insert(malloc_info_file_table, key, (st_data_t)data);
             }
@@ -8826,7 +8826,7 @@ gc_prof_setup_new_record(rb_objspace_t *objspace, int reason)
 	    if (!ptr) rb_memerror();
 	    objspace->profile.records = ptr;
 	}
-	if (!objspace->profile.records) {
+	if (UNLIKELY(!objspace->profile.records)) {
 	    rb_bug("gc_profile malloc or realloc miss");
 	}
 	record = objspace->profile.current_record = &objspace->profile.records[objspace->profile.next_index - 1];
@@ -9124,7 +9124,7 @@ gc_profile_dump_major_reason(int flags, char *buff)
 #define C(x, s) \
   if (reason & GPR_FLAG_MAJOR_BY_##x) { \
       buff[i++] = #x[0]; \
-      if (i >= MAJOR_REASON_MAX) rb_bug("gc_profile_dump_major_reason: overflow"); \
+      if (UNLIKELY(i >= MAJOR_REASON_MAX)) rb_bug("gc_profile_dump_major_reason: overflow"); \
       buff[i] = 0; \
   }
 	C(NOFREE, N);

--- a/io.c
+++ b/io.c
@@ -192,7 +192,7 @@ rb_update_max_fd(int fd)
     if (afd <= max_fd)
         return;
 
-    if (fstat(fd, &buf) != 0 && errno == EBADF) {
+    if (UNLIKELY(fstat(fd, &buf) != 0 && errno == EBADF)) {
         rb_bug("rb_update_max_fd: invalid fd (%d) given.", fd);
     }
 
@@ -208,7 +208,7 @@ rb_maygvl_fd_fix_cloexec(int fd)
 #if defined(HAVE_FCNTL) && defined(F_GETFD) && defined(F_SETFD) && defined(FD_CLOEXEC)
     int flags, flags2, ret;
     flags = fcntl(fd, F_GETFD); /* should not fail except EBADF. */
-    if (flags == -1) {
+    if (UNLIKELY(flags == -1)) {
         rb_bug("rb_maygvl_fd_fix_cloexec: fcntl(%d, F_GETFD) failed: %s", fd, strerror(errno));
     }
     if (fd <= 2)
@@ -217,7 +217,7 @@ rb_maygvl_fd_fix_cloexec(int fd)
         flags2 = flags | FD_CLOEXEC; /* Set CLOEXEC for non-standard file descriptors: 3, 4, 5, ... */
     if (flags != flags2) {
         ret = fcntl(fd, F_SETFD, flags2);
-        if (ret == -1) {
+        if (UNLIKELY(ret == -1)) {
             rb_bug("rb_maygvl_fd_fix_cloexec: fcntl(%d, F_SETFD, %d) failed: %s", fd, flags2, strerror(errno));
         }
     }
@@ -238,7 +238,7 @@ rb_fix_detect_o_cloexec(int fd)
 #if defined(O_CLOEXEC) && defined(F_GETFD)
     int flags = fcntl(fd, F_GETFD);
 
-    if (flags == -1)
+    if (UNLIKELY(flags == -1))
         rb_bug("rb_fix_detect_o_cloexec: fcntl(%d, F_GETFD) failed: %s", fd, strerror(errno));
 
     if (flags & FD_CLOEXEC)

--- a/iseq.c
+++ b/iseq.c
@@ -1585,7 +1585,7 @@ validate_get_insn_info(const rb_iseq_t *iseq)
     const struct rb_iseq_constant_body *const body = iseq->body;
     size_t i;
     for (i = 0; i < body->iseq_size; i++) {
-	if (get_insn_info_linear_search(iseq, i) != get_insn_info(iseq, i)) {
+	if (UNLIKELY(get_insn_info_linear_search(iseq, i) != get_insn_info(iseq, i))) {
 	    rb_bug("validate_get_insn_info: get_insn_info_linear_search(iseq, %"PRIuSIZE") != get_insn_info(iseq, %"PRIuSIZE")", i, i);
 	}
     }

--- a/numeric.c
+++ b/numeric.c
@@ -3439,8 +3439,8 @@ rb_fix2str(VALUE x, int base)
     }
 #if SIZEOF_LONG < SIZEOF_VOIDP
 # if SIZEOF_VOIDP == SIZEOF_LONG_LONG
-    if ((val >= 0 && (x & 0xFFFFFFFF00000000ull)) ||
-	(val < 0 && (x & 0xFFFFFFFF00000000ull) != 0xFFFFFFFF00000000ull)) {
+    if (UNLIKELY((val >= 0 && (x & 0xFFFFFFFF00000000ull)) ||
+	(val < 0 && (x & 0xFFFFFFFF00000000ull) != 0xFFFFFFFF00000000ull))) {
 	rb_bug("Unnormalized Fixnum value %p", (void *)x);
     }
 # else

--- a/object.c
+++ b/object.c
@@ -1333,7 +1333,7 @@ rb_obj_freeze(VALUE obj)
 {
     if (!OBJ_FROZEN(obj)) {
 	OBJ_FREEZE(obj);
-	if (SPECIAL_CONST_P(obj)) {
+	if (UNLIKELY(SPECIAL_CONST_P(obj))) {
 	    rb_bug("special consts should be frozen.");
 	}
     }

--- a/pack.c
+++ b/pack.c
@@ -623,7 +623,7 @@ pack_pack(int argc, VALUE *argv, VALUE ary)
 	    if (explicit_endian) {
 		bigendian_p = explicit_endian == '>';
 	    }
-            if (integer_size > MAX_INTEGER_PACK_SIZE)
+            if (UNLIKELY(integer_size > MAX_INTEGER_PACK_SIZE))
                 rb_bug("unexpected intger size for pack: %d", integer_size);
             while (len-- > 0) {
                 char intbuf[MAX_INTEGER_PACK_SIZE];
@@ -831,7 +831,7 @@ pack_pack(int argc, VALUE *argv, VALUE ary)
 
                 if (sign < 0)
                     rb_raise(rb_eArgError, "can't compress negative numbers");
-                if (sign == 2)
+                if (UNLIKELY(sign == 2))
                     rb_bug("buffer size problem?");
 
                 cp = RSTRING_PTR(buf);
@@ -930,7 +930,7 @@ encodes(VALUE str, const char *s0, long len, int type, int tail_lf)
     }
     if (tail_lf) buff[i++] = '\n';
     rb_str_buf_cat(str, buff, i);
-    if ((size_t)i > sizeof(buff)) rb_bug("encodes() buffer overrun");
+    if (UNLIKELY((size_t)i > sizeof(buff))) rb_bug("encodes() buffer overrun");
 }
 
 static const char hex_table[] = "0123456789ABCDEF";

--- a/proc.c
+++ b/proc.c
@@ -2087,7 +2087,7 @@ rb_method_call(int argc, const VALUE *argv, VALUE method)
 static const rb_callable_method_entry_t *
 method_callable_method_entry(const struct METHOD *data)
 {
-    if (data->me->defined_class == 0) rb_bug("method_callable_method_entry: not callable.");
+    if (UNLIKELY(data->me->defined_class == 0)) rb_bug("method_callable_method_entry: not callable.");
     return (const rb_callable_method_entry_t *)data->me;
 }
 

--- a/re.c
+++ b/re.c
@@ -109,7 +109,7 @@ rb_memsearch_ss(const unsigned char *xs, long m, const unsigned char *ys, long n
 #define VALUE_MAX ((VALUE)~(VALUE)0)
     VALUE hx, hy, mask = VALUE_MAX >> ((SIZEOF_VALUE - m) * CHAR_BIT);
 
-    if (m > SIZEOF_VALUE)
+    if (UNLIKELY(m > SIZEOF_VALUE))
 	rb_bug("!!too long pattern string!!");
 
     if (!(y = memchr(y, *x, n - m + 1)))

--- a/signal.c
+++ b/signal.c
@@ -821,7 +821,7 @@ reset_sigmask(int sig)
 #if defined(ruby_sigunmask)
     sigemptyset(&mask);
     sigaddset(&mask, sig);
-    if (ruby_sigunmask(SIG_UNBLOCK, &mask, NULL)) {
+    if (UNLIKELY(ruby_sigunmask(SIG_UNBLOCK, &mask, NULL))) {
 	rb_bug_errno(STRINGIZE(ruby_sigunmask)":unblock", errno);
     }
 #endif
@@ -1433,7 +1433,7 @@ sig_list(void)
 #define INSTALL_SIGHANDLER(cond, signame, signum) do {	\
 	static const char failed[] = "failed to install "signame" handler"; \
 	if (!(cond)) break; \
-	if (reserved_signal_p(signum)) rb_bug(failed); \
+	if (UNLIKELY(reserved_signal_p(signum))) rb_bug(failed); \
 	perror(failed); \
     } while (0)
 static int

--- a/string.c
+++ b/string.c
@@ -2656,7 +2656,7 @@ rb_str_set_len(VALUE str, long len)
     if (STR_SHARED_P(str)) {
 	rb_raise(rb_eRuntimeError, "can't set length of shared string");
     }
-    if (len > (capa = (long)str_capacity(str, termlen)) || len < 0) {
+    if (UNLIKELY(len > (capa = (long)str_capacity(str, termlen)) || len < 0)) {
 	rb_bug("probable buffer overflow: %ld for %ld", len, capa);
     }
     STR_SET_LEN(str, len);
@@ -8422,7 +8422,7 @@ get_reg_grapheme_cluster(rb_encoding *enc)
 	const OnigUChar source[] = "\\X";
 	int r = onig_new(&reg_grapheme_cluster, source, source + sizeof(source) - 1,
 			 ONIG_OPTION_DEFAULT, enc, OnigDefaultSyntax, NULL);
-	if (r) {
+	if (UNLIKELY(r)) {
 	    rb_bug("cannot compile grapheme cluster regexp");
 	}
 	if (encidx == rb_utf8_encindex()) {

--- a/symbol.c
+++ b/symbol.c
@@ -432,7 +432,7 @@ static void
 unregister_sym(VALUE str, VALUE sym)
 {
     st_data_t str_data = (st_data_t)str;
-    if (!st_delete(global_symbols.str_sym, &str_data, NULL)) {
+    if (UNLIKELY(!st_delete(global_symbols.str_sym, &str_data, NULL))) {
 	rb_bug("%p can't remove str from str_id (%s)", (void *)sym, RSTRING_PTR(str));
     }
 }

--- a/thread.c
+++ b/thread.c
@@ -541,7 +541,7 @@ rb_threadptr_unlock_all_locking_mutexes(rb_thread_t *th)
 		(void *)mutexes); */
 	mutexes = mutex->next_mutex;
 	err = rb_mutex_unlock_th(mutex, th);
-	if (err) rb_bug("invalid keeping_mutexes: %s", err);
+	if (UNLIKELY(err)) rb_bug("invalid keeping_mutexes: %s", err);
     }
 }
 
@@ -553,7 +553,7 @@ rb_thread_terminate_all(void)
     rb_vm_t *volatile vm = th->vm;
     volatile int sleeping = 0;
 
-    if (vm->main_thread != th) {
+    if (UNLIKELY(vm->main_thread != th)) {
 	rb_bug("rb_thread_terminate_all: called by child thread (%p, %p)",
 	       (void *)vm->main_thread, (void *)th);
     }
@@ -682,7 +682,7 @@ thread_start_func_2(rb_thread_t *th, VALUE *stack_start, VALUE *register_stack_s
     rb_thread_t *main_th;
     VALUE errinfo = Qnil;
 
-    if (th == th->vm->main_thread)
+    if (UNLIKELY(th == th->vm->main_thread))
 	rb_bug("thread_start_func_2 must not be used for main thread");
 
     ruby_thread_set_native(th);
@@ -744,7 +744,7 @@ thread_start_func_2(rb_thread_t *th, VALUE *stack_start, VALUE *register_stack_s
 	rb_ec_clear_current_thread_trace_func(th->ec);
 
 	/* locking_mutex must be Qfalse */
-	if (th->locking_mutex != Qfalse) {
+	if (UNLIKELY(th->locking_mutex != Qfalse)) {
 	    rb_bug("thread_start_func_2: locking_mutex must not be set (%p:%"PRIxVALUE")",
 		   (void *)th, th->locking_mutex);
 	}
@@ -1623,7 +1623,7 @@ rb_thread_call_with_gvl(void *(*func)(void *), void *data1)
     brb = (struct rb_blocking_region_buffer *)th->blocking_region_buffer;
     prev_unblock = th->unblock;
 
-    if (brb == 0) {
+    if (UNLIKELY(brb == 0)) {
 	rb_bug("rb_thread_call_with_gvl: called by a thread which has GVL.");
     }
 
@@ -5078,7 +5078,7 @@ rb_check_deadlock(rb_vm_t *vm)
     rb_thread_t *th = 0;
 
     if (vm_living_thread_num(vm) > vm->sleeper) return;
-    if (vm_living_thread_num(vm) < vm->sleeper) rb_bug("sleeper must not be more than vm_living_thread_num(vm)");
+    if (UNLIKELY(vm_living_thread_num(vm) < vm->sleeper)) rb_bug("sleeper must not be more than vm_living_thread_num(vm)");
     if (patrol_thread && patrol_thread != GET_THREAD()) return;
 
     list_for_each(&vm->living_threads, th, vmlt_node) {

--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -215,7 +215,7 @@ rb_native_mutex_lock(pthread_mutex_t *lock)
 {
     int r;
     mutex_debug("lock", lock);
-    if ((r = pthread_mutex_lock(lock)) != 0) {
+    if (UNLIKELY((r = pthread_mutex_lock(lock))) != 0) {
 	rb_bug_errno("pthread_mutex_lock", r);
     }
 }
@@ -225,7 +225,7 @@ rb_native_mutex_unlock(pthread_mutex_t *lock)
 {
     int r;
     mutex_debug("unlock", lock);
-    if ((r = pthread_mutex_unlock(lock)) != 0) {
+    if (UNLIKELY((r = pthread_mutex_unlock(lock))) != 0) {
 	rb_bug_errno("pthread_mutex_unlock", r);
     }
 }
@@ -251,7 +251,7 @@ rb_native_mutex_initialize(pthread_mutex_t *lock)
 {
     int r = pthread_mutex_init(lock, 0);
     mutex_debug("init", lock);
-    if (r != 0) {
+    if (UNLIKELY(r != 0)) {
 	rb_bug_errno("pthread_mutex_init", r);
     }
 }
@@ -261,7 +261,7 @@ rb_native_mutex_destroy(pthread_mutex_t *lock)
 {
     int r = pthread_mutex_destroy(lock);
     mutex_debug("destroy", lock);
-    if (r != 0) {
+    if (UNLIKELY(r != 0)) {
 	rb_bug_errno("pthread_mutex_destroy", r);
     }
 }
@@ -270,7 +270,7 @@ void
 rb_native_cond_initialize(rb_nativethread_cond_t *cond)
 {
     int r = pthread_cond_init(cond, condattr_monotonic);
-    if (r != 0) {
+    if (UNLIKELY(r != 0)) {
 	rb_bug_errno("pthread_cond_init", r);
     }
 }
@@ -279,7 +279,7 @@ void
 rb_native_cond_destroy(rb_nativethread_cond_t *cond)
 {
     int r = pthread_cond_destroy(cond);
-    if (r != 0) {
+    if (UNLIKELY(r != 0)) {
 	rb_bug_errno("pthread_cond_destroy", r);
     }
 }
@@ -301,7 +301,7 @@ rb_native_cond_signal(rb_nativethread_cond_t *cond)
     do {
 	r = pthread_cond_signal(cond);
     } while (r == EAGAIN);
-    if (r != 0) {
+    if (UNLIKELY(r != 0)) {
 	rb_bug_errno("pthread_cond_signal", r);
     }
 }
@@ -313,7 +313,7 @@ rb_native_cond_broadcast(rb_nativethread_cond_t *cond)
     do {
 	r = pthread_cond_broadcast(cond);
     } while (r == EAGAIN);
-    if (r != 0) {
+    if (UNLIKELY(r != 0)) {
         rb_bug_errno("rb_native_cond_broadcast", r);
     }
 }
@@ -322,7 +322,7 @@ void
 rb_native_cond_wait(rb_nativethread_cond_t *cond, pthread_mutex_t *mutex)
 {
     int r = pthread_cond_wait(cond, mutex);
-    if (r != 0) {
+    if (UNLIKELY(r != 0)) {
 	rb_bug_errno("pthread_cond_wait", r);
     }
 }
@@ -342,7 +342,7 @@ native_cond_timedwait(rb_nativethread_cond_t *cond, pthread_mutex_t *mutex, cons
 	r = pthread_cond_timedwait(cond, mutex, ts);
     } while (r == EINTR);
 
-    if (r != 0 && r != ETIMEDOUT) {
+    if (UNLIKELY(r != 0 && r != ETIMEDOUT)) {
 	rb_bug_errno("pthread_cond_timedwait", r);
     }
 
@@ -792,7 +792,7 @@ ruby_init_stack(volatile VALUE *addr
 }
 
 #define CHECK_ERR(expr) \
-    {int err = (expr); if (err) {rb_bug_errno(#expr, err);}}
+    {int err = (expr); if (UNLIKELY(err)) {rb_bug_errno(#expr, err);}}
 
 static int
 native_thread_init_stack(rb_thread_t *th)
@@ -1582,7 +1582,7 @@ rb_thread_create_timer_thread(void)
 		stack_size += +((BUFSIZ - 1) / stack_min + 1) * stack_min;
 	    }
 	    err = pthread_attr_setstacksize(&attr, stack_size);
-	    if (err != 0) {
+	    if (UNLIKELY(err != 0)) {
 		rb_bug("pthread_attr_setstacksize(.., %"PRIuSIZE") failed: %s",
 			stack_size, strerror(err));
 	    }
@@ -1595,7 +1595,7 @@ rb_thread_create_timer_thread(void)
 #endif /* TIMER_THREAD_SLEEPY */
 
 	/* create timer thread */
-	if (timer_thread.created) {
+	if (UNLIKELY(timer_thread.created)) {
 	    rb_bug("rb_thread_create_timer_thread: Timer thread was already created\n");
 	}
 	err = pthread_create(&timer_thread.id, &attr, thread_timer, vm);

--- a/thread_sync.c
+++ b/thread_sync.c
@@ -106,7 +106,7 @@ mutex_free(void *ptr)
     if (mutex->th) {
 	/* rb_warn("free locked mutex"); */
 	const char *err = rb_mutex_unlock_th(mutex, mutex->th);
-	if (err) rb_bug("%s", err);
+	if (UNLIKELY(err)) rb_bug("%s", err);
     }
     ruby_xfree(ptr);
 }

--- a/thread_win32.c
+++ b/thread_win32.c
@@ -430,7 +430,7 @@ native_cond_timedwait_ms(rb_nativethread_cond_t *cond, rb_nativethread_lock_t *m
     rb_native_mutex_unlock(mutex);
     {
 	r = WaitForSingleObject(entry.event, msec);
-	if ((r != WAIT_OBJECT_0) && (r != WAIT_TIMEOUT)) {
+	if (UNLIKELY((r != WAIT_OBJECT_0) && (r != WAIT_TIMEOUT))) {
             rb_bug("rb_native_cond_wait: WaitForSingleObject returns %lu", r);
 	}
     }
@@ -528,7 +528,7 @@ ruby_init_stack(volatile VALUE *addr)
 }
 
 #define CHECK_ERR(expr) \
-    {if (!(expr)) {rb_bug("err: %lu - %s", GetLastError(), #expr);}}
+    {if (UNLIKELY(!(expr))) {rb_bug("err: %lu - %s", GetLastError(), #expr);}}
 
 static void
 native_thread_init_stack(rb_thread_t *th)

--- a/transcode.c
+++ b/transcode.c
@@ -2581,7 +2581,7 @@ rb_econv_open_opts(const char *source_encoding, const char *destination_encoding
         replacement = Qnil;
     }
     else {
-        if (!RB_TYPE_P(opthash, T_HASH) || !OBJ_FROZEN(opthash))
+        if (UNLIKELY(!RB_TYPE_P(opthash, T_HASH) || !OBJ_FROZEN(opthash)))
             rb_bug("rb_econv_open_opts called with invalid opthash");
         replacement = rb_hash_aref(opthash, sym_replace);
     }
@@ -3874,7 +3874,7 @@ econv_convert(VALUE self, VALUE source_string)
         rb_raise(rb_eArgError, "converter already finished");
     }
 
-    if (ret != sym_source_buffer_empty) {
+    if (UNLIKELY(ret != sym_source_buffer_empty)) {
         rb_bug("unexpected result of econv_primitive_convert");
     }
 
@@ -3918,7 +3918,7 @@ econv_finish(VALUE self)
         rb_exc_raise(exc);
     }
 
-    if (ret != sym_finished) {
+    if (UNLIKELY(ret != sym_finished)) {
         rb_bug("unexpected result of econv_primitive_convert");
     }
 

--- a/variable.c
+++ b/variable.c
@@ -213,7 +213,7 @@ classname(VALUE klass, int *permanent)
 	else {
 	    path = (VALUE)n;
 	}
-	if (!RB_TYPE_P(path, T_STRING)) {
+	if (UNLIKELY(!RB_TYPE_P(path, T_STRING))) {
 	    rb_bug("class path is not set properly");
 	}
 	return path;

--- a/vm.c
+++ b/vm.c
@@ -2457,10 +2457,10 @@ thread_free(void *ptr)
     rb_thread_t *th = ptr;
     RUBY_FREE_ENTER("thread");
 
-    if (th->locking_mutex != Qfalse) {
+    if (UNLIKELY(th->locking_mutex != Qfalse)) {
 	rb_bug("thread_free: locking_mutex must be NULL (%p:%p)", (void *)th, (void *)th->locking_mutex);
     }
-    if (th->keeping_mutexes != NULL) {
+    if (UNLIKELY(th->keeping_mutexes != NULL)) {
 	rb_bug("thread_free: keeping_mutexes must be NULL (%p:%p)", (void *)th, (void *)th->keeping_mutexes);
     }
 

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -218,7 +218,7 @@ vm_call_super(rb_execution_context_t *ec, int argc, const VALUE *argv)
     rb_control_frame_t *cfp = ec->cfp;
     const rb_callable_method_entry_t *me = rb_vm_frame_method_entry(cfp);
 
-    if (VM_FRAME_RUBYFRAME_P(cfp)) {
+    if (UNLIKELY(VM_FRAME_RUBYFRAME_P(cfp))) {
 	rb_bug("vm_call_super: should not be reached");
     }
 
@@ -1576,7 +1576,7 @@ rb_yield_refine_block(VALUE refinement, VALUE refinements)
     rb_execution_context_t *ec = GET_EC();
     VALUE block_handler = VM_CF_BLOCK_HANDLER(ec->cfp);
 
-    if (vm_block_handler_type(block_handler) != block_handler_type_iseq) {
+    if (UNLIKELY(vm_block_handler_type(block_handler) != block_handler_type_iseq)) {
 	rb_bug("rb_yield_refine_block: an iseq block is required");
     }
     else {

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -120,20 +120,20 @@ vm_check_frame_detail(VALUE type, int req_block, int req_me, int req_cref, VALUE
 	req_me = TRUE;
     }
 
-    if (req_block && (type & VM_ENV_FLAG_LOCAL) == 0) {
+    if (UNLIKELY(req_block && (type & VM_ENV_FLAG_LOCAL) == 0)) {
 	rb_bug("vm_push_frame: specval (%p) should be a block_ptr on %x frame", (void *)specval, magic);
     }
-    if (!req_block && (type & VM_ENV_FLAG_LOCAL) != 0) {
+    if (UNLIKELY(!req_block && (type & VM_ENV_FLAG_LOCAL) != 0)) {
 	rb_bug("vm_push_frame: specval (%p) should not be a block_ptr on %x frame", (void *)specval, magic);
     }
 
     if (req_me) {
-	if (cref_or_me_type != imemo_ment) {
+	if (UNLIKELY(cref_or_me_type != imemo_ment)) {
 	    rb_bug("vm_push_frame: (%s) should be method entry on %x frame", rb_obj_info(cref_or_me), magic);
 	}
     }
     else {
-	if (req_cref && cref_or_me_type != imemo_cref) {
+	if (UNLIKELY(req_cref && cref_or_me_type != imemo_cref)) {
 	    rb_bug("vm_push_frame: (%s) should be CREF on %x frame", rb_obj_info(cref_or_me), magic);
 	}
 	else { /* cref or Qfalse */
@@ -151,7 +151,7 @@ vm_check_frame_detail(VALUE type, int req_block, int req_me, int req_cref, VALUE
     if (cref_or_me_type == imemo_ment) {
 	const rb_callable_method_entry_t *me = (const rb_callable_method_entry_t *)cref_or_me;
 
-	if (!callable_method_entry_p(me)) {
+	if (UNLIKELY(!callable_method_entry_p(me))) {
 	    rb_bug("vm_push_frame: ment (%s) should be callable on %x frame.", rb_obj_info(cref_or_me), magic);
 	}
     }
@@ -515,7 +515,7 @@ check_method_entry(VALUE obj, int can_be_svar)
     if (obj == Qfalse) return NULL;
 
 #if VM_CHECK_MODE > 0
-    if (!RB_TYPE_P(obj, T_IMEMO)) rb_bug("check_method_entry: unknown type: %s", rb_obj_info(obj));
+    if (UNLIKELY(!RB_TYPE_P(obj, T_IMEMO))) rb_bug("check_method_entry: unknown type: %s", rb_obj_info(obj));
 #endif
 
     switch (imemo_type(obj)) {
@@ -569,7 +569,7 @@ check_cref(VALUE obj, int can_be_svar)
     if (obj == Qfalse) return NULL;
 
 #if VM_CHECK_MODE > 0
-    if (!RB_TYPE_P(obj, T_IMEMO)) rb_bug("check_cref: unknown type: %s", rb_obj_info(obj));
+    if (UNLIKELY(!RB_TYPE_P(obj, T_IMEMO))) rb_bug("check_cref: unknown type: %s", rb_obj_info(obj));
 #endif
 
     switch (imemo_type(obj)) {
@@ -888,7 +888,7 @@ vm_get_cvar_base(const rb_cref_t *cref, rb_control_frame_t *cfp)
 {
     VALUE klass;
 
-    if (!cref) {
+    if (UNLIKELY(!cref)) {
 	rb_bug("vm_get_cvar_base: no cref");
     }
 
@@ -1551,7 +1551,7 @@ vm_base_ptr(const rb_control_frame_t *cfp)
 	    bp += 1;
 	}
 #if VM_DEBUG_BP_CHECK
-	if (bp != cfp->bp_check) {
+	if (UNLIKELY(bp != cfp->bp_check)) {
 	    fprintf(stderr, "bp_check: %ld, bp: %ld\n",
 		    (long)(cfp->bp_check - GET_EC()->vm_stack),
 		    (long)(bp - GET_EC()->vm_stack));
@@ -1583,7 +1583,7 @@ static const rb_iseq_t *
 def_iseq_ptr(rb_method_definition_t *def)
 {
 #if VM_CHECK_MODE > 0
-    if (def->type != VM_METHOD_TYPE_ISEQ) rb_bug("def_iseq_ptr: not iseq (%d)", def->type);
+    if (UNLIKELY(def->type != VM_METHOD_TYPE_ISEQ)) rb_bug("def_iseq_ptr: not iseq (%d)", def->type);
 #endif
     return rb_iseq_check(def->body.iseq.iseqptr);
 }
@@ -2773,7 +2773,7 @@ vm_make_proc_with_iseq(const rb_iseq_t *blockiseq)
     const rb_control_frame_t *cfp = rb_vm_get_ruby_level_next_cfp(ec, ec->cfp);
     struct rb_captured_block *captured;
 
-    if (cfp == 0) {
+    if (UNLIKELY(cfp == 0)) {
 	rb_bug("vm_make_proc_with_iseq: unreachable");
     }
 

--- a/vm_method.c
+++ b/vm_method.c
@@ -72,7 +72,7 @@ rb_class_clear_method_cache(VALUE klass, VALUE arg)
 	}
     }
     else {
-	if (RCLASS_CALLABLE_M_TBL(klass) != 0) {
+	if (UNLIKELY(RCLASS_CALLABLE_M_TBL(klass) != 0)) {
 	    rb_obj_info_dump(klass);
 	    rb_bug("RCLASS_CALLABLE_M_TBL(klass) != 0");
 	}
@@ -787,7 +787,7 @@ verify_method_cache(VALUE klass, ID id, VALUE defined_class, rb_method_entry_t *
     rb_method_entry_t *actual_me =
       method_entry_get_without_cache(klass, id, &actual_defined_class);
 
-    if (me != actual_me || defined_class != actual_defined_class) {
+    if (UNLIKELY(me != actual_me || defined_class != actual_defined_class)) {
 	rb_bug("method cache verification failed");
     }
 }

--- a/vm_trace.c
+++ b/vm_trace.c
@@ -897,7 +897,7 @@ rb_tracearg_return_value(rb_trace_arg_t *trace_arg)
     else {
 	rb_raise(rb_eRuntimeError, "not supported by this event");
     }
-    if (trace_arg->data == Qundef) {
+    if (UNLIKELY(trace_arg->data == Qundef)) {
         rb_bug("rb_tracearg_return_value: unreachable");
     }
     return trace_arg->data;
@@ -912,7 +912,7 @@ rb_tracearg_raised_exception(rb_trace_arg_t *trace_arg)
     else {
 	rb_raise(rb_eRuntimeError, "not supported by this event");
     }
-    if (trace_arg->data == Qundef) {
+    if (UNLIKELY(trace_arg->data == Qundef)) {
         rb_bug("rb_tracearg_raised_exception: unreachable");
     }
     return trace_arg->data;
@@ -927,7 +927,7 @@ rb_tracearg_object(rb_trace_arg_t *trace_arg)
     else {
 	rb_raise(rb_eRuntimeError, "not supported by this event");
     }
-    if (trace_arg->data == Qundef) {
+    if (UNLIKELY(trace_arg->data == Qundef)) {
         rb_bug("rb_tracearg_object: unreachable");
     }
     return trace_arg->data;


### PR DESCRIPTION
Ruby bug branches (that invoke `rb_bug`) should be extreme exceptional cases and I noticed quite a few of them were in critical paths. I think it makes sense to hint them as unlikely CPU branches given they're so rare in a production environment and more useful as first class VM level exceptions for development stages by a smaller representative chunk of the community (ruby core).

* Probably should not bother much for cases turned off by the `*CHECK*` macros (most of gc.c)
* This changeset does not handle branches (mostly fall through anyways) from case statements and a few other if / else blocks that would make this patch much larger.

Processor used is a `Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz`, optlevel 03

```
lourens@CarbonX1:~/src/optcarrot$ benchmark-driver -e "cache-miss-rb-bug::~/src/ruby/ruby/ruby -I~/src/ruby/ruby/lib -I~/src/ruby/ruby/. -I~/src/ruby/ruby/.ext/x86_64-linux" -e "trunk::~/src/ruby/trunk/ruby -I~/src/ruby/trunk/lib -I~/src/ruby/trunk/. -I~/src/ruby/trunk/.ext/x86_64-linux" benchmark.yml
Calculating -------------------------------------
                     cache-miss-rb-bug       trunk 
           optcarrot            46.889      43.714 fps

Comparison:
                        optcarrot
   cache-miss-rb-bug:        46.9 fps 
               trunk:        43.7 fps - 1.07x  slower

lourens@CarbonX1:~/src/optcarrot$ benchmark-driver -e "cache-miss-rb-bug::~/src/ruby/ruby/ruby -I~/src/ruby/ruby/lib -I~/src/ruby/ruby/. -I~/src/ruby/ruby/.ext/x86_64-linux" -e "trunk::~/src/ruby/trunk/ruby -I~/src/ruby/trunk/lib -I~/src/ruby/trunk/. -I~/src/ruby/trunk/.ext/x86_64-linux" benchmark.yml
Calculating -------------------------------------
                     cache-miss-rb-bug       trunk 
           optcarrot            47.596      46.251 fps

Comparison:
                        optcarrot
   cache-miss-rb-bug:        47.6 fps 
               trunk:        46.3 fps - 1.03x  slower

```

The ruby bench results are quite noisy, but with repeatable improvements in the following benchmarks:

* Thread mutexes
* Thread condition variables
* Structs (aref and aset)
* Hash (aref)
* String (index and scan)
* Some of the GC benches

```
lourens@CarbonX1:~/src/ruby/ruby$ make benchmark COMPARE_RUBY="~/src/ruby/trunk/ruby -I~/src/ruby/trunk/lib -I~/src/ruby/trunk"
/usr/bin/ruby --disable=gems -rrubygems -I./benchmark/lib ./benchmark/benchmark-driver/exe/benchmark-driver \
            --executables="compare-ruby::~/src/ruby/trunk/ruby -I~/src/ruby/trunk/lib -I~/src/ruby/trunk -I.ext/common --disable-gem" \
            --executables="built-ruby::./miniruby -I./lib -I. -I.ext/common  -r./prelude --disable-gem" \
            $(find ./benchmark -maxdepth 1 -name '**.yml' -o -name '**.rb' | sort) 
Calculating -------------------------------------
                               compare-ruby  built-ruby 
                    app_answer       41.581      40.506 i/s -       1.000 times in 0.024049s 0.024688s
                   app_aobench        0.033       0.030 i/s -       1.000 times in 30.743316s 32.793860s
                       app_erb      10.231k      9.721k i/s -     15.000k times in 1.466105s 1.543120s
                 app_factorial        1.352       1.634 i/s -       1.000 times in 0.739519s 0.611961s
                       app_fib        3.581       3.609 i/s -       1.000 times in 0.279222s 0.277061s
               app_lc_fizzbuzz        0.039       0.039 i/s -       1.000 times in 25.943501s 25.456991s
                app_mandelbrot        1.133       1.237 i/s -       1.000 times in 0.882955s 0.808304s
                 app_pentomino        0.108       0.104 i/s -       1.000 times in 9.293541s 9.603090s
                     app_raise        7.362       7.118 i/s -       1.000 times in 0.135840s 0.140494s
                 app_strconcat        1.489       1.500 i/s -       1.000 times in 0.671503s 0.666687s
                       app_tak        2.546       2.505 i/s -       1.000 times in 0.392753s 0.399223s
                     app_tarai        3.054       3.154 i/s -       1.000 times in 0.327484s 0.317011s
                       app_uri        2.597       2.681 i/s -       1.000 times in 0.385024s 0.373031s
        array_sample_100k__100       12.967      17.244 i/s -       1.000 times in 0.077116s 0.057993s
       array_sample_100k___10k        0.381       0.394 i/s -       1.000 times in 2.625965s 2.536483s
          array_sample_100k_10      137.166      84.932 i/s -       1.000 times in 0.007290s 0.011774s
          array_sample_100k_11       62.697      61.376 i/s -       1.000 times in 0.015950s 0.016293s
         array_sample_100k__1k        1.962       2.065 i/s -       1.000 times in 0.509636s 0.484341s
       array_sample_100k___50k        0.103       0.095 i/s -       1.000 times in 9.682130s 10.548641s
         array_sample_100k__6k        0.522       0.542 i/s -       1.000 times in 1.915074s 1.845479s
                   array_shift        0.543       0.546 i/s -       1.000 times in 1.841085s 1.830841s
               array_small_and       78.316      64.880 i/s -       1.000 times in 0.012769s 0.015413s
              array_small_diff       55.552      61.319 i/s -       1.000 times in 0.018001s 0.016308s
                array_small_or       43.651      55.990 i/s -       1.000 times in 0.022909s 0.017860s
              array_sort_block        0.245       0.224 i/s -       1.000 times in 4.079722s 4.462622s
              array_sort_float        0.690       0.687 i/s -       1.000 times in 1.448829s 1.455223s
           array_values_at_int      157.476     133.990 i/s -       1.000 times in 0.006350s 0.007463s
         array_values_at_range        4.049       4.449 i/s -       1.000 times in 0.246967s 0.224787s
                       bighash        0.527       0.555 i/s -       1.000 times in 1.897818s 1.800224s
                   dir_empty_p        3.053       3.250 i/s -       1.000 times in 0.327569s 0.307684s
                    erb_render       1.041M      1.035M i/s -      1.500M times in 1.441357s 1.449378s
                    file_chmod        3.308       3.211 i/s -       1.000 times in 0.302284s 0.311454s
                   file_rename        0.946       0.825 i/s -       1.000 times in 1.057532s 1.212242s
           hash_aref_dsym_long        0.276       0.312 i/s -       1.000 times in 3.625854s 3.204785s
                hash_aref_dsym        4.257       4.302 i/s -       1.000 times in 0.234929s 0.232453s
                 hash_aref_fix        3.634       4.769 i/s -       1.000 times in 0.275189s 0.209690s
                 hash_aref_flo       30.425      30.860 i/s -       1.000 times in 0.032867s 0.032405s
                hash_aref_miss        3.094       3.072 i/s -       1.000 times in 0.323198s 0.325565s
                 hash_aref_str        3.665       3.851 i/s -       1.000 times in 0.272868s 0.259652s
            hash_aref_sym_long        2.939       3.076 i/s -       1.000 times in 0.340296s 0.325117s
                 hash_aref_sym        4.310       4.371 i/s -       1.000 times in 0.232010s 0.228796s
                  hash_flatten        6.355       6.532 i/s -       1.000 times in 0.157358s 0.153090s
                hash_ident_flo       30.957      29.803 i/s -       1.000 times in 0.032303s 0.033554s
                hash_ident_num        4.622       4.459 i/s -       1.000 times in 0.216340s 0.224284s
                hash_ident_obj        4.704       4.511 i/s -       1.000 times in 0.212590s 0.221703s
                hash_ident_str        4.580       4.623 i/s -       1.000 times in 0.218345s 0.216329s
                hash_ident_sym        4.104       3.905 i/s -       1.000 times in 0.243692s 0.256100s
                     hash_keys        9.877      10.579 i/s -       1.000 times in 0.101250s 0.094530s
                     hash_long        1.919       2.000 i/s -       1.000 times in 0.521156s 0.499926s
                    hash_shift      133.266      74.905 i/s -       1.000 times in 0.007504s 0.013350s
                hash_shift_u16       13.519      16.672 i/s -       1.000 times in 0.073969s 0.059981s
                hash_shift_u24       13.085      17.884 i/s -       1.000 times in 0.076425s 0.055916s
                hash_shift_u32       13.216      17.808 i/s -       1.000 times in 0.075663s 0.056154s
                   hash_small2        1.936       1.872 i/s -       1.000 times in 0.516579s 0.534210s
                   hash_small4        1.548       1.162 i/s -       1.000 times in 0.645870s 0.860884s
                   hash_small8        0.831       0.950 i/s -       1.000 times in 1.203646s 1.052602s
                  hash_to_proc      346.910     350.763 i/s -       1.000 times in 0.002883s 0.002851s
                   hash_values       10.262      10.477 i/s -       1.000 times in 0.097445s 0.095447s
                       int_quo        1.231       1.264 i/s -       1.000 times in 0.812566s 0.791269s
          io_copy_stream_write        5.812       5.992 i/s -       1.000 times in 0.172072s 0.166882s
   io_copy_stream_write_socket      666.232     504.645 i/s -       1.000 times in 0.001501s 0.001982s
                io_file_create        0.714       0.690 i/s -       1.000 times in 1.399797s 1.448469s
                  io_file_read        0.970       1.081 i/s -       1.000 times in 1.030439s 0.925112s
                 io_file_write        1.357       1.389 i/s -       1.000 times in 0.737083s 0.719893s
             io_nonblock_noex2        0.687       0.668 i/s -       1.000 times in 1.456604s 1.495931s
              io_nonblock_noex        0.531       0.506 i/s -       1.000 times in 1.884241s 1.977196s
                    io_pipe_rw        0.838       0.950 i/s -       1.000 times in 1.192840s 1.052344s
                    io_select2        0.739       0.828 i/s -       1.000 times in 1.352384s 1.208381s
                    io_select3        8.413       7.396 i/s -       1.000 times in 0.118860s 0.135202s
                     io_select        0.944       0.950 i/s -       1.000 times in 1.059259s 1.052917s
                      loop_for        1.274       1.200 i/s -       1.000 times in 0.784806s 0.833670s
                loop_generator        2.213       2.225 i/s -       1.000 times in 0.451933s 0.449449s
                    loop_times        1.106       1.433 i/s -       1.000 times in 0.904102s 0.697810s
               loop_whileloop2       13.421      14.766 i/s -       1.000 times in 0.074507s 0.067721s
                loop_whileloop        2.887       2.517 i/s -       1.000 times in 0.346348s 0.397335s
              marshal_dump_flo        4.612       4.147 i/s -       1.000 times in 0.216808s 0.241150s
       marshal_dump_load_geniv        3.056       3.241 i/s -       1.000 times in 0.327183s 0.308556s
        marshal_dump_load_time        1.305       1.273 i/s -       1.000 times in 0.766473s 0.785586s
                require_thread        0.022       0.031 i/s -       1.000 times in 45.475971s 32.170094s
                       require        0.510       0.989 i/s -       1.000 times in 1.961127s 1.011449s
                  securerandom        3.192       3.185 i/s -       1.000 times in 0.313288s 0.313924s
                  so_ackermann        1.512       1.437 i/s -       1.000 times in 0.661173s 0.695831s
                      so_array        0.822       0.866 i/s -       1.000 times in 1.216740s 1.154984s
               so_binary_trees        0.151       0.173 i/s -       1.000 times in 6.623954s 5.794379s
                so_concatenate        0.272       0.288 i/s -       1.000 times in 3.673035s 3.474519s
                so_count_words        4.178       4.349 i/s -       1.000 times in 0.239329s 0.229913s
                  so_exception        3.778       3.908 i/s -       1.000 times in 0.264704s 0.255911s
                   so_fannkuch        0.917       0.971 i/s -       1.000 times in 1.090646s 1.029562s
                      so_fasta        0.586       0.600 i/s -       1.000 times in 1.707123s 1.667171s
               so_k_nucleotidepreparing /tmp/fasta.output.100000
        0.998       1.029 i/s -       1.000 times in 1.001640s 0.971858s
                      so_lists        2.272       2.102 i/s -       1.000 times in 0.440088s 0.475662s
                 so_mandelbrot        0.514       0.536 i/s -       1.000 times in 1.945867s 1.866160s
                     so_matrix        2.369       2.338 i/s -       1.000 times in 0.422134s 0.427757s
             so_meteor_contest        0.407       0.436 i/s -       1.000 times in 2.455156s 2.293353s
                      so_nbody        0.943       0.989 i/s -       1.000 times in 1.060446s 1.010852s
                so_nested_loop        1.119       1.345 i/s -       1.000 times in 0.893973s 0.743771s
                so_nsieve_bits        0.583       0.601 i/s -       1.000 times in 1.714529s 1.664338s
                     so_nsieve        0.754       0.804 i/s -       1.000 times in 1.325964s 1.243743s
                     so_object        2.044       1.905 i/s -       1.000 times in 0.489284s 0.524931s
               so_partial_sums        0.661       0.702 i/s -       1.000 times in 1.512156s 1.424558s
                   so_pidigits        1.175       1.225 i/s -       1.000 times in 0.850993s 0.816555s
                     so_random        2.462       2.499 i/s -       1.000 times in 0.406157s 0.400225s
         so_reverse_complementpreparing /tmp/fasta.output.2500000
        0.928       0.812 i/s -       1.000 times in 1.077990s 1.230913s
                      so_sieve        2.967       2.904 i/s -       1.000 times in 0.337086s 0.344331s
               so_spectralnorm        0.870       0.886 i/s -       1.000 times in 1.148820s 1.128915s
                  string_index        3.108       3.280 i/s -       1.000 times in 0.321717s 0.304916s
                string_scan_re        6.244       6.315 i/s -       1.000 times in 0.160166s 0.158351s
               string_scan_str        7.861      10.338 i/s -       1.000 times in 0.127213s 0.096732s
                   time_subsec        1.051       1.098 i/s -       1.000 times in 0.951235s 0.910680s
             vm1_attr_ivar_set      49.846M     50.222M i/s -     30.000M times in 0.601848s 0.597353s
                 vm1_attr_ivar      53.120M     55.660M i/s -     30.000M times in 0.564758s 0.538987s
           vm1_blockparam_call      20.180M     21.899M i/s -     30.000M times in 1.486652s 1.369914s
           vm1_blockparam_pass      17.933M     15.442M i/s -     30.000M times in 1.672887s 1.942758s
          vm1_blockparam_yield      23.600M     25.206M i/s -     30.000M times in 1.271166s 1.190190s
                vm1_blockparam      38.725M     39.010M i/s -     30.000M times in 0.774686s 0.769043s
                     vm1_block      35.990M     34.632M i/s -     30.000M times in 0.833568s 0.866245s
                     vm1_const     156.265M    238.176M i/s -     30.000M times in 0.191981s 0.125957s
                    vm1_ensure        2.933       2.756 i/s -       1.000 times in 0.340953s 0.362861s
              vm1_float_simple      16.558M     17.113M i/s -     30.000M times in 1.811778s 1.753015s
            vm1_gc_short_lived       8.332M      8.420M i/s -     30.000M times in 3.600524s 3.562971s
vm1_gc_short_with_complex_long       9.853M     10.038M i/s -     30.000M times in 3.044647s 2.988552s
        vm1_gc_short_with_long       7.455M      8.091M i/s -     30.000M times in 4.024212s 3.707898s
      vm1_gc_short_with_symbol       8.319M      8.849M i/s -     30.000M times in 3.606384s 3.390103s
        vm1_gc_wb_ary_promoted      65.450M     61.952M i/s -     30.000M times in 0.458365s 0.484244s
                 vm1_gc_wb_ary      68.025M     63.761M i/s -     30.000M times in 0.441014s 0.470504s
        vm1_gc_wb_obj_promoted      82.000M     79.283M i/s -     30.000M times in 0.365855s 0.378390s
                 vm1_gc_wb_obj      77.665M     70.540M i/s -     30.000M times in 0.386276s 0.425291s
                  vm1_ivar_set     122.838M    139.704M i/s -     30.000M times in 0.244224s 0.214739s
                      vm1_ivar     124.952M    123.339M i/s -     30.000M times in 0.240093s 0.243232s
                    vm1_length      70.362M     69.399M i/s -     30.000M times in 0.426364s 0.432285s
                 vm1_lvar_init        0.734       0.633 i/s -       1.000 times in 1.361938s 1.578726s
                  vm1_lvar_set      19.751M     20.146M i/s -     30.000M times in 1.518905s 1.489115s
                       vm1_neq      83.405M     81.111M i/s -     30.000M times in 0.359690s 0.369862s
                       vm1_not     154.510M    148.481M i/s -     30.000M times in 0.194162s 0.202047s
                    vm1_rescue     399.796M    431.581M i/s -     30.000M times in 0.075038s 0.069512s
              vm1_simplereturn      75.274M     68.856M i/s -     30.000M times in 0.398542s 0.435690s
                      vm1_swap     173.073M    178.941M i/s -     30.000M times in 0.173337s 0.167653s
                     vm1_yield        1.126       1.123 i/s -       1.000 times in 0.888029s 0.890337s
                     vm2_array      12.173M     12.902M i/s -      6.000M times in 0.492878s 0.465030s
                  vm2_bigarray       1.803M      1.854M i/s -      6.000M times in 3.326915s 3.236397s
                   vm2_bighash     130.773k    122.793k i/s -     60.000k times in 0.458811s 0.488628s
                  vm2_case_lit        1.739       1.720 i/s -       1.000 times in 0.575167s 0.581297s
                      vm2_case      85.959M     75.454M i/s -      6.000M times in 0.069801s 0.079518s
            vm2_defined_method       3.344M      3.100M i/s -      6.000M times in 1.794125s 1.935680s
                      vm2_dstr       7.249M      7.240M i/s -      6.000M times in 0.827754s 0.828753s
                      vm2_eval     370.223k    312.643k i/s -      6.000M times in 16.206455s 19.191230s
              vm2_fiber_switch       1.514M      1.515M i/s -      6.000M times in 3.963203s 3.960816s
            vm2_method_missing       3.236M      3.429M i/s -      6.000M times in 1.854332s 1.749976s
         vm2_method_with_block       8.616M      7.842M i/s -      6.000M times in 0.696388s 0.765064s
                    vm2_method       8.997M      8.445M i/s -      6.000M times in 0.666902s 0.710482s
      vm2_module_ann_const_set       1.390M      1.382M i/s -      6.000M times in 4.317288s 4.339978s
          vm2_module_const_set       1.518M      1.396M i/s -      6.000M times in 3.952762s 4.297200s
                     vm2_mutex      15.037M     15.300M i/s -      6.000M times in 0.399017s 0.392165s
                 vm2_newlambda      10.499M     10.265M i/s -      6.000M times in 0.571501s 0.584482s
            vm2_poly_method_ov        5.102       5.182 i/s -       1.000 times in 0.195996s 0.192969s
               vm2_poly_method        0.573       0.541 i/s -       1.000 times in 1.745710s 1.848372s
            vm2_poly_singleton        1.087       1.059 i/s -       1.000 times in 0.919906s 0.944466s
                      vm2_proc      31.308M     36.048M i/s -      6.000M times in 0.191647s 0.166445s
                    vm2_raise1       1.991M      1.902M i/s -      6.000M times in 3.014017s 3.154826s
                    vm2_raise2       1.244M      1.183M i/s -      6.000M times in 4.822355s 5.069829s
                    vm2_regexp       6.983M      6.547M i/s -      6.000M times in 0.859229s 0.916477s
                      vm2_send      25.150M     25.429M i/s -      6.000M times in 0.238570s 0.235951s
            vm2_string_literal      50.862M     47.134M i/s -      6.000M times in 0.117967s 0.127298s
        vm2_struct_big_aref_hi      41.638M     49.486M i/s -      6.000M times in 0.144100s 0.121245s
        vm2_struct_big_aref_lo      46.817M     48.674M i/s -      6.000M times in 0.128160s 0.123269s
           vm2_struct_big_aset        4.566       4.755 i/s -       1.000 times in 0.219019s 0.210292s
        vm2_struct_big_href_hi      31.399M     28.009M i/s -      6.000M times in 0.191089s 0.214217s
        vm2_struct_big_href_lo      31.615M     27.579M i/s -      6.000M times in 0.189783s 0.217559s
           vm2_struct_big_hset        3.405       3.455 i/s -       1.000 times in 0.293707s 0.289449s
         vm2_struct_small_aref      72.683M     80.954M i/s -      6.000M times in 0.082550s 0.074116s
         vm2_struct_small_aset        4.274       4.828 i/s -       1.000 times in 0.233987s 0.207135s
         vm2_struct_small_href      31.042M     34.654M i/s -      6.000M times in 0.193285s 0.173140s
         vm2_struct_small_hset      28.799M     30.033M i/s -      6.000M times in 0.208344s 0.199782s
                     vm2_super      21.890M     19.266M i/s -      6.000M times in 0.274103s 0.311437s
                     vm2_unif1      62.436M     64.168M i/s -      6.000M times in 0.096098s 0.093505s
                    vm2_zsuper      19.903M     17.574M i/s -      6.000M times in 0.301467s 0.341422s
                 vm3_backtrace        8.631       9.842 i/s -       1.000 times in 0.115857s 0.101608s
          vm3_clearmethodcache        4.650       4.242 i/s -       1.000 times in 0.215059s 0.235729s
               vm3_gc_old_full        0.451       0.433 i/s -       1.000 times in 2.216302s 2.310409s
          vm3_gc_old_immediate        0.585       0.580 i/s -       1.000 times in 1.710567s 1.725386s
               vm3_gc_old_lazy        0.419       0.444 i/s -       1.000 times in 2.387562s 2.252505s
                        vm3_gc        0.924       1.039 i/s -       1.000 times in 1.082526s 0.962153s
          vm_symbol_block_pass        1.609       1.424 i/s -       1.000 times in 0.621613s 0.702416s
        vm_thread_alive_check1       17.568      16.455 i/s -       1.000 times in 0.056920s 0.060771s
               vm_thread_close        1.817       1.931 i/s -       1.000 times in 0.550240s 0.517845s
            vm_thread_condvar1        1.521       1.804 i/s -       1.000 times in 0.657425s 0.554238s
            vm_thread_condvar2        1.861       1.888 i/s -       1.000 times in 0.537455s 0.529735s
         vm_thread_create_join        1.060       1.073 i/s -       1.000 times in 0.943406s 0.931924s
              vm_thread_mutex1        2.541       2.771 i/s -       1.000 times in 0.393478s 0.360876s
              vm_thread_mutex2        2.859       2.950 i/s -       1.000 times in 0.349765s 0.338983s
              vm_thread_mutex3        0.766       1.279 i/s -       1.000 times in 1.305466s 0.781697s
          vm_thread_pass_flood       18.427      26.424 i/s -       1.000 times in 0.054267s 0.037845s
                vm_thread_pass        2.230       2.111 i/s -       1.000 times in 0.448391s 0.473659s
                vm_thread_pipe        2.555       3.019 i/s -       1.000 times in 0.391394s 0.331258s
               vm_thread_queue       12.705      13.172 i/s -       1.000 times in 0.078706s 0.075919s
        vm_thread_sized_queue2        1.986       1.952 i/s -       1.000 times in 0.503614s 0.512358s
        vm_thread_sized_queue3        1.948       1.704 i/s -       1.000 times in 0.513393s 0.586702s
        vm_thread_sized_queue4        3.153       2.262 i/s -       1.000 times in 0.317202s 0.442153s
         vm_thread_sized_queue        6.212       6.623 i/s -       1.000 times in 0.160969s 0.150982s

Comparison:
                                 app_answer
                  compare-ruby:        41.6 i/s 
                    built-ruby:        40.5 i/s - 1.03x  slower

                                app_aobench
                  compare-ruby:         0.0 i/s 
                    built-ruby:         0.0 i/s - 1.07x  slower

                                    app_erb
                  compare-ruby:     10231.2 i/s 
                    built-ruby:      9720.6 i/s - 1.05x  slower

                              app_factorial
                    built-ruby:         1.6 i/s 
                  compare-ruby:         1.4 i/s - 1.21x  slower

                                    app_fib
                    built-ruby:         3.6 i/s 
                  compare-ruby:         3.6 i/s - 1.01x  slower

                            app_lc_fizzbuzz
                    built-ruby:         0.0 i/s 
                  compare-ruby:         0.0 i/s - 1.02x  slower

                             app_mandelbrot
                    built-ruby:         1.2 i/s 
                  compare-ruby:         1.1 i/s - 1.09x  slower

                              app_pentomino
                  compare-ruby:         0.1 i/s 
                    built-ruby:         0.1 i/s - 1.03x  slower

                                  app_raise
                  compare-ruby:         7.4 i/s 
                    built-ruby:         7.1 i/s - 1.03x  slower

                              app_strconcat
                    built-ruby:         1.5 i/s 
                  compare-ruby:         1.5 i/s - 1.01x  slower

                                    app_tak
                  compare-ruby:         2.5 i/s 
                    built-ruby:         2.5 i/s - 1.02x  slower

                                  app_tarai
                    built-ruby:         3.2 i/s 
                  compare-ruby:         3.1 i/s - 1.03x  slower

                                    app_uri
                    built-ruby:         2.7 i/s 
                  compare-ruby:         2.6 i/s - 1.03x  slower

                     array_sample_100k__100
                    built-ruby:        17.2 i/s 
                  compare-ruby:        13.0 i/s - 1.33x  slower

                    array_sample_100k___10k
                    built-ruby:         0.4 i/s 
                  compare-ruby:         0.4 i/s - 1.04x  slower

                       array_sample_100k_10
                  compare-ruby:       137.2 i/s 
                    built-ruby:        84.9 i/s - 1.62x  slower

                       array_sample_100k_11
                  compare-ruby:        62.7 i/s 
                    built-ruby:        61.4 i/s - 1.02x  slower

                      array_sample_100k__1k
                    built-ruby:         2.1 i/s 
                  compare-ruby:         2.0 i/s - 1.05x  slower

                    array_sample_100k___50k
                  compare-ruby:         0.1 i/s 
                    built-ruby:         0.1 i/s - 1.09x  slower

                      array_sample_100k__6k
                    built-ruby:         0.5 i/s 
                  compare-ruby:         0.5 i/s - 1.04x  slower

                                array_shift
                    built-ruby:         0.5 i/s 
                  compare-ruby:         0.5 i/s - 1.01x  slower

                            array_small_and
                  compare-ruby:        78.3 i/s 
                    built-ruby:        64.9 i/s - 1.21x  slower

                           array_small_diff
                    built-ruby:        61.3 i/s 
                  compare-ruby:        55.6 i/s - 1.10x  slower

                             array_small_or
                    built-ruby:        56.0 i/s 
                  compare-ruby:        43.7 i/s - 1.28x  slower

                           array_sort_block
                  compare-ruby:         0.2 i/s 
                    built-ruby:         0.2 i/s - 1.09x  slower

                           array_sort_float
                  compare-ruby:         0.7 i/s 
                    built-ruby:         0.7 i/s - 1.00x  slower

                        array_values_at_int
                  compare-ruby:       157.5 i/s 
                    built-ruby:       134.0 i/s - 1.18x  slower

                      array_values_at_range
                    built-ruby:         4.4 i/s 
                  compare-ruby:         4.0 i/s - 1.10x  slower

                                    bighash
                    built-ruby:         0.6 i/s 
                  compare-ruby:         0.5 i/s - 1.05x  slower

                                dir_empty_p
                    built-ruby:         3.3 i/s 
                  compare-ruby:         3.1 i/s - 1.06x  slower

                                 erb_render
                  compare-ruby:   1040686.2 i/s 
                    built-ruby:   1034926.5 i/s - 1.01x  slower

                                 file_chmod
                  compare-ruby:         3.3 i/s 
                    built-ruby:         3.2 i/s - 1.03x  slower

                                file_rename
                  compare-ruby:         0.9 i/s 
                    built-ruby:         0.8 i/s - 1.15x  slower

                        hash_aref_dsym_long
                    built-ruby:         0.3 i/s 
                  compare-ruby:         0.3 i/s - 1.13x  slower

                             hash_aref_dsym
                    built-ruby:         4.3 i/s 
                  compare-ruby:         4.3 i/s - 1.01x  slower

                              hash_aref_fix
                    built-ruby:         4.8 i/s 
                  compare-ruby:         3.6 i/s - 1.31x  slower

                              hash_aref_flo
                    built-ruby:        30.9 i/s 
                  compare-ruby:        30.4 i/s - 1.01x  slower

                             hash_aref_miss
                  compare-ruby:         3.1 i/s 
                    built-ruby:         3.1 i/s - 1.01x  slower

                              hash_aref_str
                    built-ruby:         3.9 i/s 
                  compare-ruby:         3.7 i/s - 1.05x  slower

                         hash_aref_sym_long
                    built-ruby:         3.1 i/s 
                  compare-ruby:         2.9 i/s - 1.05x  slower

                              hash_aref_sym
                    built-ruby:         4.4 i/s 
                  compare-ruby:         4.3 i/s - 1.01x  slower

                               hash_flatten
                    built-ruby:         6.5 i/s 
                  compare-ruby:         6.4 i/s - 1.03x  slower

                             hash_ident_flo
                  compare-ruby:        31.0 i/s 
                    built-ruby:        29.8 i/s - 1.04x  slower

                             hash_ident_num
                  compare-ruby:         4.6 i/s 
                    built-ruby:         4.5 i/s - 1.04x  slower

                             hash_ident_obj
                  compare-ruby:         4.7 i/s 
                    built-ruby:         4.5 i/s - 1.04x  slower

                             hash_ident_str
                    built-ruby:         4.6 i/s 
                  compare-ruby:         4.6 i/s - 1.01x  slower

                             hash_ident_sym
                  compare-ruby:         4.1 i/s 
                    built-ruby:         3.9 i/s - 1.05x  slower

                                  hash_keys
                    built-ruby:        10.6 i/s 
                  compare-ruby:         9.9 i/s - 1.07x  slower

                                  hash_long
                    built-ruby:         2.0 i/s 
                  compare-ruby:         1.9 i/s - 1.04x  slower

                                 hash_shift
                  compare-ruby:       133.3 i/s 
                    built-ruby:        74.9 i/s - 1.78x  slower

                             hash_shift_u16
                    built-ruby:        16.7 i/s 
                  compare-ruby:        13.5 i/s - 1.23x  slower

                             hash_shift_u24
                    built-ruby:        17.9 i/s 
                  compare-ruby:        13.1 i/s - 1.37x  slower

                             hash_shift_u32
                    built-ruby:        17.8 i/s 
                  compare-ruby:        13.2 i/s - 1.35x  slower

                                hash_small2
                  compare-ruby:         1.9 i/s 
                    built-ruby:         1.9 i/s - 1.03x  slower

                                hash_small4
                  compare-ruby:         1.5 i/s 
                    built-ruby:         1.2 i/s - 1.33x  slower

                                hash_small8
                    built-ruby:         1.0 i/s 
                  compare-ruby:         0.8 i/s - 1.14x  slower

                               hash_to_proc
                    built-ruby:       350.8 i/s 
                  compare-ruby:       346.9 i/s - 1.01x  slower

                                hash_values
                    built-ruby:        10.5 i/s 
                  compare-ruby:        10.3 i/s - 1.02x  slower

                                    int_quo
                    built-ruby:         1.3 i/s 
                  compare-ruby:         1.2 i/s - 1.03x  slower

                       io_copy_stream_write
                    built-ruby:         6.0 i/s 
                  compare-ruby:         5.8 i/s - 1.03x  slower

                io_copy_stream_write_socket
                  compare-ruby:       666.2 i/s 
                    built-ruby:       504.6 i/s - 1.32x  slower

                             io_file_create
                  compare-ruby:         0.7 i/s 
                    built-ruby:         0.7 i/s - 1.03x  slower

                               io_file_read
                    built-ruby:         1.1 i/s 
                  compare-ruby:         1.0 i/s - 1.11x  slower

                              io_file_write
                    built-ruby:         1.4 i/s 
                  compare-ruby:         1.4 i/s - 1.02x  slower

                          io_nonblock_noex2
                  compare-ruby:         0.7 i/s 
                    built-ruby:         0.7 i/s - 1.03x  slower

                           io_nonblock_noex
                  compare-ruby:         0.5 i/s 
                    built-ruby:         0.5 i/s - 1.05x  slower

                                 io_pipe_rw
                    built-ruby:         1.0 i/s 
                  compare-ruby:         0.8 i/s - 1.13x  slower

                                 io_select2
                    built-ruby:         0.8 i/s 
                  compare-ruby:         0.7 i/s - 1.12x  slower

                                 io_select3
                  compare-ruby:         8.4 i/s 
                    built-ruby:         7.4 i/s - 1.14x  slower

                                  io_select
                    built-ruby:         0.9 i/s 
                  compare-ruby:         0.9 i/s - 1.01x  slower

                                   loop_for
                  compare-ruby:         1.3 i/s 
                    built-ruby:         1.2 i/s - 1.06x  slower

                             loop_generator
                    built-ruby:         2.2 i/s 
                  compare-ruby:         2.2 i/s - 1.01x  slower

                                 loop_times
                    built-ruby:         1.4 i/s 
                  compare-ruby:         1.1 i/s - 1.30x  slower

                            loop_whileloop2
                    built-ruby:        14.8 i/s 
                  compare-ruby:        13.4 i/s - 1.10x  slower

                             loop_whileloop
                  compare-ruby:         2.9 i/s 
                    built-ruby:         2.5 i/s - 1.15x  slower

                           marshal_dump_flo
                  compare-ruby:         4.6 i/s 
                    built-ruby:         4.1 i/s - 1.11x  slower

                    marshal_dump_load_geniv
                    built-ruby:         3.2 i/s 
                  compare-ruby:         3.1 i/s - 1.06x  slower

                     marshal_dump_load_time
                  compare-ruby:         1.3 i/s 
                    built-ruby:         1.3 i/s - 1.02x  slower

                             require_thread
                    built-ruby:         0.0 i/s 
                  compare-ruby:         0.0 i/s - 1.41x  slower

                                    require
                    built-ruby:         1.0 i/s 
                  compare-ruby:         0.5 i/s - 1.94x  slower

                               securerandom
                  compare-ruby:         3.2 i/s 
                    built-ruby:         3.2 i/s - 1.00x  slower

                               so_ackermann
                  compare-ruby:         1.5 i/s 
                    built-ruby:         1.4 i/s - 1.05x  slower

                                   so_array
                    built-ruby:         0.9 i/s 
                  compare-ruby:         0.8 i/s - 1.05x  slower

                            so_binary_trees
                    built-ruby:         0.2 i/s 
                  compare-ruby:         0.2 i/s - 1.14x  slower

                             so_concatenate
                    built-ruby:         0.3 i/s 
                  compare-ruby:         0.3 i/s - 1.06x  slower

                             so_count_words
                    built-ruby:         4.3 i/s 
                  compare-ruby:         4.2 i/s - 1.04x  slower

                               so_exception
                    built-ruby:         3.9 i/s 
                  compare-ruby:         3.8 i/s - 1.03x  slower

                                so_fannkuch
                    built-ruby:         1.0 i/s 
                  compare-ruby:         0.9 i/s - 1.06x  slower

                                   so_fasta
                    built-ruby:         0.6 i/s 
                  compare-ruby:         0.6 i/s - 1.02x  slower

                            so_k_nucleotide
                    built-ruby:         1.0 i/s 
                  compare-ruby:         1.0 i/s - 1.03x  slower

                                   so_lists
                  compare-ruby:         2.3 i/s 
                    built-ruby:         2.1 i/s - 1.08x  slower

                              so_mandelbrot
                    built-ruby:         0.5 i/s 
                  compare-ruby:         0.5 i/s - 1.04x  slower

                                  so_matrix
                  compare-ruby:         2.4 i/s 
                    built-ruby:         2.3 i/s - 1.01x  slower

                          so_meteor_contest
                    built-ruby:         0.4 i/s 
                  compare-ruby:         0.4 i/s - 1.07x  slower

                                   so_nbody
                    built-ruby:         1.0 i/s 
                  compare-ruby:         0.9 i/s - 1.05x  slower

                             so_nested_loop
                    built-ruby:         1.3 i/s 
                  compare-ruby:         1.1 i/s - 1.20x  slower

                             so_nsieve_bits
                    built-ruby:         0.6 i/s 
                  compare-ruby:         0.6 i/s - 1.03x  slower

                                  so_nsieve
                    built-ruby:         0.8 i/s 
                  compare-ruby:         0.8 i/s - 1.07x  slower

                                  so_object
                  compare-ruby:         2.0 i/s 
                    built-ruby:         1.9 i/s - 1.07x  slower

                            so_partial_sums
                    built-ruby:         0.7 i/s 
                  compare-ruby:         0.7 i/s - 1.06x  slower

                                so_pidigits
                    built-ruby:         1.2 i/s 
                  compare-ruby:         1.2 i/s - 1.04x  slower

                                  so_random
                    built-ruby:         2.5 i/s 
                  compare-ruby:         2.5 i/s - 1.01x  slower

                      so_reverse_complement
                  compare-ruby:         0.9 i/s 
                    built-ruby:         0.8 i/s - 1.14x  slower

                                   so_sieve
                  compare-ruby:         3.0 i/s 
                    built-ruby:         2.9 i/s - 1.02x  slower

                            so_spectralnorm
                    built-ruby:         0.9 i/s 
                  compare-ruby:         0.9 i/s - 1.02x  slower

                               string_index
                    built-ruby:         3.3 i/s 
                  compare-ruby:         3.1 i/s - 1.06x  slower

                             string_scan_re
                    built-ruby:         6.3 i/s 
                  compare-ruby:         6.2 i/s - 1.01x  slower

                            string_scan_str
                    built-ruby:        10.3 i/s 
                  compare-ruby:         7.9 i/s - 1.32x  slower

                                time_subsec
                    built-ruby:         1.1 i/s 
                  compare-ruby:         1.1 i/s - 1.04x  slower

                          vm1_attr_ivar_set
                    built-ruby:  50221534.3 i/s 
                  compare-ruby:  49846473.5 i/s - 1.01x  slower

                              vm1_attr_ivar
                    built-ruby:  55659966.4 i/s 
                  compare-ruby:  53120063.1 i/s - 1.05x  slower

                        vm1_blockparam_call
                    built-ruby:  21899190.1 i/s 
                  compare-ruby:  20179567.3 i/s - 1.09x  slower

                        vm1_blockparam_pass
                  compare-ruby:  17933071.6 i/s 
                    built-ruby:  15441964.9 i/s - 1.16x  slower

                       vm1_blockparam_yield
                    built-ruby:  25206062.3 i/s 
                  compare-ruby:  23600375.0 i/s - 1.07x  slower

                             vm1_blockparam
                    built-ruby:  39009523.3 i/s 
                  compare-ruby:  38725361.1 i/s - 1.01x  slower

                                  vm1_block
                  compare-ruby:  35989883.7 i/s 
                    built-ruby:  34632239.7 i/s - 1.04x  slower

                                  vm1_const
                    built-ruby: 238175798.2 i/s 
                  compare-ruby: 156265480.9 i/s - 1.52x  slower

                                 vm1_ensure
                  compare-ruby:         2.9 i/s 
                    built-ruby:         2.8 i/s - 1.06x  slower

                           vm1_float_simple
                    built-ruby:  17113371.9 i/s 
                  compare-ruby:  16558317.1 i/s - 1.03x  slower

                         vm1_gc_short_lived
                    built-ruby:   8419938.7 i/s 
                  compare-ruby:   8332119.6 i/s - 1.01x  slower

             vm1_gc_short_with_complex_long
                    built-ruby:  10038306.9 i/s 
                  compare-ruby:   9853358.3 i/s - 1.02x  slower

                     vm1_gc_short_with_long
                    built-ruby:   8090837.3 i/s 
                  compare-ruby:   7454876.4 i/s - 1.09x  slower

                   vm1_gc_short_with_symbol
                    built-ruby:   8849289.5 i/s 
                  compare-ruby:   8318580.6 i/s - 1.06x  slower

                     vm1_gc_wb_ary_promoted
                  compare-ruby:  65450030.4 i/s 
                    built-ruby:  61952280.0 i/s - 1.06x  slower

                              vm1_gc_wb_ary
                  compare-ruby:  68025026.2 i/s 
                    built-ruby:  63761457.5 i/s - 1.07x  slower

                     vm1_gc_wb_obj_promoted
                  compare-ruby:  81999647.8 i/s 
                    built-ruby:  79283360.7 i/s - 1.03x  slower

                              vm1_gc_wb_obj
                  compare-ruby:  77664650.7 i/s 
                    built-ruby:  70539926.1 i/s - 1.10x  slower

                               vm1_ivar_set
                    built-ruby: 139704298.9 i/s 
                  compare-ruby: 122837982.4 i/s - 1.14x  slower

                                   vm1_ivar
                  compare-ruby: 124951652.6 i/s 
                    built-ruby: 123339098.8 i/s - 1.01x  slower

                                 vm1_length
                  compare-ruby:  70362445.9 i/s 
                    built-ruby:  69398695.3 i/s - 1.01x  slower

                              vm1_lvar_init
                  compare-ruby:         0.7 i/s 
                    built-ruby:         0.6 i/s - 1.16x  slower

                               vm1_lvar_set
                    built-ruby:  20146188.9 i/s 
                  compare-ruby:  19751071.9 i/s - 1.02x  slower

                                    vm1_neq
                  compare-ruby:  83405075.4 i/s 
                    built-ruby:  81111308.2 i/s - 1.03x  slower

                                    vm1_not
                  compare-ruby: 154509829.0 i/s 
                    built-ruby: 148480637.0 i/s - 1.04x  slower

                                 vm1_rescue
                    built-ruby: 431580711.3 i/s 
                  compare-ruby: 399795821.7 i/s - 1.08x  slower

                           vm1_simplereturn
                  compare-ruby:  75274309.0 i/s 
                    built-ruby:  68856300.7 i/s - 1.09x  slower

                                   vm1_swap
                    built-ruby: 178941377.1 i/s 
                  compare-ruby: 173073320.8 i/s - 1.03x  slower

                                  vm1_yield
                  compare-ruby:         1.1 i/s 
                    built-ruby:         1.1 i/s - 1.00x  slower

                                  vm2_array
                    built-ruby:  12902386.6 i/s 
                  compare-ruby:  12173409.1 i/s - 1.06x  slower

                               vm2_bigarray
                    built-ruby:   1853913.4 i/s 
                  compare-ruby:   1803472.6 i/s - 1.03x  slower

                                vm2_bighash
                  compare-ruby:    130772.8 i/s 
                    built-ruby:    122792.8 i/s - 1.06x  slower

                               vm2_case_lit
                  compare-ruby:         1.7 i/s 
                    built-ruby:         1.7 i/s - 1.01x  slower

                                   vm2_case
                  compare-ruby:  85958932.3 i/s 
                    built-ruby:  75454166.2 i/s - 1.14x  slower

                         vm2_defined_method
                  compare-ruby:   3344248.0 i/s 
                    built-ruby:   3099686.2 i/s - 1.08x  slower

                                   vm2_dstr
                  compare-ruby:   7248528.2 i/s 
                    built-ruby:   7239791.8 i/s - 1.00x  slower

                                   vm2_eval
                  compare-ruby:    370222.9 i/s 
                    built-ruby:    312642.8 i/s - 1.18x  slower

                           vm2_fiber_switch
                    built-ruby:   1514839.5 i/s 
                  compare-ruby:   1513926.9 i/s - 1.00x  slower

                         vm2_method_missing
                    built-ruby:   3428618.2 i/s 
                  compare-ruby:   3235667.0 i/s - 1.06x  slower

                      vm2_method_with_block
                  compare-ruby:   8615884.8 i/s 
                    built-ruby:   7842484.6 i/s - 1.10x  slower

                                 vm2_method
                  compare-ruby:   8996824.3 i/s 
                    built-ruby:   8444976.2 i/s - 1.07x  slower

                   vm2_module_ann_const_set
                  compare-ruby:   1389761.3 i/s 
                    built-ruby:   1382495.5 i/s - 1.01x  slower

                       vm2_module_const_set
                  compare-ruby:   1517926.0 i/s 
                    built-ruby:   1396258.0 i/s - 1.09x  slower

                                  vm2_mutex
                    built-ruby:  15299696.0 i/s 
                  compare-ruby:  15036968.8 i/s - 1.02x  slower

                              vm2_newlambda
                  compare-ruby:  10498665.8 i/s 
                    built-ruby:  10265491.4 i/s - 1.02x  slower

                         vm2_poly_method_ov
                    built-ruby:         5.2 i/s 
                  compare-ruby:         5.1 i/s - 1.02x  slower

                            vm2_poly_method
                  compare-ruby:         0.6 i/s 
                    built-ruby:         0.5 i/s - 1.06x  slower

                         vm2_poly_singleton
                  compare-ruby:         1.1 i/s 
                    built-ruby:         1.1 i/s - 1.03x  slower

                                   vm2_proc
                    built-ruby:  36047939.9 i/s 
                  compare-ruby:  31307588.8 i/s - 1.15x  slower

                                 vm2_raise1
                  compare-ruby:   1990698.7 i/s 
                    built-ruby:   1901848.0 i/s - 1.05x  slower

                                 vm2_raise2
                  compare-ruby:   1244205.3 i/s 
                    built-ruby:   1183471.9 i/s - 1.05x  slower

                                 vm2_regexp
                  compare-ruby:   6983007.5 i/s 
                    built-ruby:   6546807.0 i/s - 1.07x  slower

                                   vm2_send
                    built-ruby:  25429024.4 i/s 
                  compare-ruby:  25149825.7 i/s - 1.01x  slower

                         vm2_string_literal
                  compare-ruby:  50861580.3 i/s 
                    built-ruby:  47133526.7 i/s - 1.08x  slower

                     vm2_struct_big_aref_hi
                    built-ruby:  49486425.8 i/s 
                  compare-ruby:  41637664.3 i/s - 1.19x  slower

                     vm2_struct_big_aref_lo
                    built-ruby:  48674103.6 i/s 
                  compare-ruby:  46816538.6 i/s - 1.04x  slower

                        vm2_struct_big_aset
                    built-ruby:         4.8 i/s 
                  compare-ruby:         4.6 i/s - 1.04x  slower

                     vm2_struct_big_href_hi
                  compare-ruby:  31398936.0 i/s 
                    built-ruby:  28008993.8 i/s - 1.12x  slower

                     vm2_struct_big_href_lo
                  compare-ruby:  31615128.0 i/s 
                    built-ruby:  27578744.5 i/s - 1.15x  slower

                        vm2_struct_big_hset
                    built-ruby:         3.5 i/s 
                  compare-ruby:         3.4 i/s - 1.01x  slower

                      vm2_struct_small_aref
                    built-ruby:  80954130.8 i/s 
                  compare-ruby:  72682826.9 i/s - 1.11x  slower

                      vm2_struct_small_aset
                    built-ruby:         4.8 i/s 
                  compare-ruby:         4.3 i/s - 1.13x  slower

                      vm2_struct_small_href
                    built-ruby:  34654094.0 i/s 
                  compare-ruby:  31042180.5 i/s - 1.12x  slower

                      vm2_struct_small_hset
                    built-ruby:  30032686.1 i/s 
                  compare-ruby:  28798548.3 i/s - 1.04x  slower

                                  vm2_super
                  compare-ruby:  21889606.5 i/s 
                    built-ruby:  19265503.6 i/s - 1.14x  slower

                                  vm2_unif1
                    built-ruby:  64167568.7 i/s 
                  compare-ruby:  62436201.9 i/s - 1.03x  slower

                                 vm2_zsuper
                  compare-ruby:  19902692.2 i/s 
                    built-ruby:  17573572.9 i/s - 1.13x  slower

                              vm3_backtrace
                    built-ruby:         9.8 i/s 
                  compare-ruby:         8.6 i/s - 1.14x  slower

                       vm3_clearmethodcache
                  compare-ruby:         4.6 i/s 
                    built-ruby:         4.2 i/s - 1.10x  slower

                            vm3_gc_old_full
                  compare-ruby:         0.5 i/s 
                    built-ruby:         0.4 i/s - 1.04x  slower

                       vm3_gc_old_immediate
                  compare-ruby:         0.6 i/s 
                    built-ruby:         0.6 i/s - 1.01x  slower

                            vm3_gc_old_lazy
                    built-ruby:         0.4 i/s 
                  compare-ruby:         0.4 i/s - 1.06x  slower

                                     vm3_gc
                    built-ruby:         1.0 i/s 
                  compare-ruby:         0.9 i/s - 1.13x  slower

                       vm_symbol_block_pass
                  compare-ruby:         1.6 i/s 
                    built-ruby:         1.4 i/s - 1.13x  slower

                     vm_thread_alive_check1
                  compare-ruby:        17.6 i/s 
                    built-ruby:        16.5 i/s - 1.07x  slower

                            vm_thread_close
                    built-ruby:         1.9 i/s 
                  compare-ruby:         1.8 i/s - 1.06x  slower

                         vm_thread_condvar1
                    built-ruby:         1.8 i/s 
                  compare-ruby:         1.5 i/s - 1.19x  slower

                         vm_thread_condvar2
                    built-ruby:         1.9 i/s 
                  compare-ruby:         1.9 i/s - 1.01x  slower

                      vm_thread_create_join
                    built-ruby:         1.1 i/s 
                  compare-ruby:         1.1 i/s - 1.01x  slower

                           vm_thread_mutex1
                    built-ruby:         2.8 i/s 
                  compare-ruby:         2.5 i/s - 1.09x  slower

                           vm_thread_mutex2
                    built-ruby:         2.9 i/s 
                  compare-ruby:         2.9 i/s - 1.03x  slower

                           vm_thread_mutex3
                    built-ruby:         1.3 i/s 
                  compare-ruby:         0.8 i/s - 1.67x  slower

                       vm_thread_pass_flood
                    built-ruby:        26.4 i/s 
                  compare-ruby:        18.4 i/s - 1.43x  slower

                             vm_thread_pass
                  compare-ruby:         2.2 i/s 
                    built-ruby:         2.1 i/s - 1.06x  slower

                             vm_thread_pipe
                    built-ruby:         3.0 i/s 
                  compare-ruby:         2.6 i/s - 1.18x  slower

                            vm_thread_queue
                    built-ruby:        13.2 i/s 
                  compare-ruby:        12.7 i/s - 1.04x  slower

                     vm_thread_sized_queue2
                  compare-ruby:         2.0 i/s 
                    built-ruby:         2.0 i/s - 1.02x  slower

                     vm_thread_sized_queue3
                  compare-ruby:         1.9 i/s 
                    built-ruby:         1.7 i/s - 1.14x  slower

                     vm_thread_sized_queue4
                  compare-ruby:         3.2 i/s 
                    built-ruby:         2.3 i/s - 1.39x  slower

                      vm_thread_sized_queue
                    built-ruby:         6.6 i/s 
                  compare-ruby:         6.2 i/s - 1.07x  slower
```