### PR TITLE
Fix message when `order` was an invalid value

### DIFF
--- a/error.c
+++ b/error.c
@@ -1061,7 +1061,7 @@ exc_full_message(int argc, VALUE *argv, VALUE exc)
 	    if (id == id_bottom) args[kw_order] = Qtrue;
 	    else if (id == id_top) args[kw_order] = Qfalse;
 	    else {
-		rb_raise(rb_eArgError, "expected :top or :down as "
+		rb_raise(rb_eArgError, "expected :top or :bottom as "
 			 "order: %+"PRIsVALUE, args[kw_order]);
 	    }
 	}


### PR DESCRIPTION
The symbol that can be used is `:bottom`, not `:down`.
Ref: https://github.com/ruby/ruby/blob/e39b2cff8ac2dc93b35bd43ffcce3ded8e3b4c25/error.c#L1061