### PR TITLE
dbm: add support of Berkeley DB 6.x

### DIFF
--- a/ext/dbm/dbm.c
+++ b/ext/dbm/dbm.c
@@ -994,7 +994,7 @@ fdbm_reject(VALUE obj)
  *   It is based on dbm library in Unix Version 7 but has different API to
  *   support multiple databases in a process.
  * - {Berkeley DB}[http://en.wikipedia.org/wiki/Berkeley_DB] versions
- *   1 thru 5, also known as BDB and Sleepycat DB, now owned by Oracle
+ *   1 thru 6, also known as BDB and Sleepycat DB, now owned by Oracle
  *   Corporation.
  * - Berkeley DB 1.x, still found in 4.4BSD derivatives (FreeBSD, OpenBSD, etc).
  * - {gdbm}[http://www.gnu.org/software/gdbm/], the GNU implementation of dbm.

--- a/ext/dbm/extconf.rb
+++ b/ext/dbm/extconf.rb
@@ -7,6 +7,7 @@
 #   db          Berkeley DB (libdb)
 #   db2         Berkeley DB (libdb2)
 #   db1         Berkeley DB (libdb1)
+#   db6         Berkeley DB (libdb6)
 #   db5         Berkeley DB (libdb5)
 #   db4         Berkeley DB (libdb4)
 #   db3         Berkeley DB (libdb3)
@@ -23,7 +24,7 @@ dir_config("dbm")
 if dblib = with_config("dbm-type", nil)
   dblib = dblib.split(/[ ,]+/)
 else
-  dblib = %w(libc db db2 db1 db5 db4 db3 gdbm_compat gdbm qdbm)
+  dblib = %w(libc db db2 db1 db6 db5 db4 db3 gdbm_compat gdbm qdbm)
 end
 
 headers = {
@@ -34,6 +35,7 @@ headers = {
   "db3" => ["db3/db.h", "db3.h", "db.h"],
   "db4" => ["db4/db.h", "db4.h", "db.h"],
   "db5" => ["db5/db.h", "db5.h", "db.h"],
+  "db6" => ["db6/db.h", "db6.h", "db.h"],
   "gdbm_compat" => ["gdbm-ndbm.h", "gdbm/ndbm.h", "ndbm.h"], # GDBM since 1.8.1
   "gdbm" => ["gdbm-ndbm.h", "gdbm/ndbm.h", "ndbm.h"], # GDBM until 1.8.0
   "qdbm" => ["qdbm/relic.h", "relic.h"],
@@ -131,7 +133,7 @@ def headers.db_check2(db, hdr)
   hsearch = nil
 
   case db
-  when /^db[2-5]?$/
+  when /^db[2-6]?$/
     hsearch = "-DDB_DBM_HSEARCH"
   when "gdbm_compat"
     have_library("gdbm") or return false


### PR DESCRIPTION
Add support of Berkeley DB 6.x to dbm.
