### PR TITLE
Remove needless `nacl` check

### DIFF
--- a/ext/pty/extconf.rb
+++ b/ext/pty/extconf.rb
@@ -3,7 +3,7 @@ require 'mkmf'
 
 $INCFLAGS << " -I$(topdir) -I$(top_srcdir)"
 
-if /mswin|mingw|bccwin|nacl/ !~ RUBY_PLATFORM
+if /mswin|mingw|bccwin/ !~ RUBY_PLATFORM
   have_header("sys/stropts.h")
   have_func("setresuid")
   have_header("libutil.h")


### PR DESCRIPTION
`nacl` support already removed by https://github.com/ruby/ruby/pull/1726.