### PR TITLE
WIP Let most error handling functions and shared object init hooks be flagged as cold and be optimized for size to improve CPU frontend throughput and branch prediction

### DIFF
--- a/addr2line.c
+++ b/addr2line.c
@@ -11,6 +11,7 @@
 #include "ruby/config.h"
 #include "ruby/defines.h"
 #include "ruby/missing.h"
+#include "ruby/defines.h"
 #include "addr2line.h"
 
 #include <stdio.h>
@@ -514,7 +515,7 @@ parse_compressed_debug_line(int num_traces, void **traces,
     obj->uncompressed_debug_line = uncompressed_debug_line;
     return 0;
 
-fail:
+fail: COLDLABEL
     free(uncompressed_debug_line);
     return -1;
 }

--- a/array.c
+++ b/array.c
@@ -5943,7 +5943,7 @@ rb_ary_sum(int argc, VALUE *argv, VALUE ary)
     v = finish_exact_sum(n, r, v, argc!=0);
     return v;
 
-  not_exact:
+  not_exact: COLDLABEL
     v = finish_exact_sum(n, r, v, i!=0);
 
     if (RB_FLOAT_TYPE_P(e)) {
@@ -6250,6 +6250,7 @@ rb_ary_sum(int argc, VALUE *argv, VALUE ary)
  *
  */
 
+COLDFUNC(void Init_Array(void));
 void
 Init_Array(void)
 {

--- a/ast.c
+++ b/ast.c
@@ -599,6 +599,7 @@ rb_ast_node_inspect(VALUE self)
     return str;
 }
 
+COLDFUNC(void Init_ast(void));
 void
 Init_ast(void)
 {

--- a/bignum.c
+++ b/bignum.c
@@ -3758,7 +3758,7 @@ str2big_scan_digits(const char *s, const char *str, int base, int badcheck, size
 	    if (len > 0 && !--len) break;
 	}
 	if (len && *str) {
-	  bad:
+	  bad: COLDLABEL
 	    return FALSE;
 	}
     }
@@ -4053,7 +4053,7 @@ rb_int_parse_cstr(const char *str, ssize_t len, char **endp, size_t *ndigits,
     } while (0)
 
     if (!str) {
-      bad:
+      bad: COLDLABEL
 	if (endp) *endp = (char *)str;
 	if (ndigits) *ndigits = num_digits;
 	return z;
@@ -6644,7 +6644,7 @@ rb_big_aref(VALUE x, VALUE y)
 	    return INT2FIX(0);
 	bigtrunc(y);
 	if (BIGSIZE(y) > sizeof(size_t)) {
-	  out_of_range:
+	  out_of_range: COLDLABEL
 	    return BIGNUM_SIGN(x) ? INT2FIX(0) : INT2FIX(1);
 	}
 #if SIZEOF_SIZE_T <= SIZEOF_LONG
@@ -7118,6 +7118,7 @@ rb_int_powm(int const argc, VALUE * const argv, VALUE const num)
  *
  */
 
+COLDFUNC(void Init_Bignum(void));
 void
 Init_Bignum(void)
 {

--- a/class.c
+++ b/class.c
@@ -542,6 +542,7 @@ boot_defclass(const char *name, VALUE super)
     return obj;
 }
 
+COLDFUNC(void Init_class_hierarchy(void));
 void
 Init_class_hierarchy(void)
 {
@@ -932,7 +933,7 @@ include_modules_at(const VALUE klass, VALUE c, VALUE module, int search_super)
 
 	tbl = RMODULE_CONST_TBL(module);
 	if (tbl && rb_id_table_size(tbl)) constant_changed = 1;
-      skip:
+      skip: COLDLABEL
 	module = RCLASS_SUPER(module);
     }
 
@@ -1596,7 +1597,7 @@ singleton_class_of(VALUE obj)
     VALUE klass;
 
     if (FIXNUM_P(obj) || FLONUM_P(obj) || STATIC_SYM_P(obj)) {
-      no_singleton:
+      no_singleton: COLDLABEL
 	rb_raise(rb_eTypeError, "can't define singleton");
     }
     if (SPECIAL_CONST_P(obj)) {
@@ -1794,14 +1795,14 @@ rb_keyword_error_new(const char *error, VALUE keys)
     return rb_exc_new_str(rb_eArgError, error_message);
 }
 
-NORETURN(static void rb_keyword_error(const char *error, VALUE keys));
+NORETURN(COLDFUNC(static void rb_keyword_error(const char *error, VALUE keys)));
 static void
 rb_keyword_error(const char *error, VALUE keys)
 {
     rb_exc_raise(rb_keyword_error_new(error, keys));
 }
 
-NORETURN(static void unknown_keyword_error(VALUE hash, const ID *table, int keywords));
+NORETURN(COLDFUNC(static void unknown_keyword_error(VALUE hash, const ID *table, int keywords)));
 static void
 unknown_keyword_error(VALUE hash, const ID *table, int keywords)
 {
@@ -2053,7 +2054,7 @@ rb_scan_args(int argc, const VALUE *argv, const char *fmt, ...)
     va_end(vargs);
 
     if (argi < argc) {
-      argc_error:
+      argc_error: COLDLABEL
 	rb_error_arity(argc, n_mand, f_var ? UNLIMITED_ARGUMENTS : n_mand + n_opt);
     }
 

--- a/compar.c
+++ b/compar.c
@@ -245,6 +245,7 @@ cmp_clamp(VALUE x, VALUE min, VALUE max)
  *
  */
 
+COLDFUNC(void Init_Comparable(void));
 void
 Init_Comparable(void)
 {

--- a/compile.c
+++ b/compile.c
@@ -371,7 +371,7 @@ static void iseq_add_setlocal(rb_iseq_t *iseq, LINK_ANCHOR *const seq, int line,
 
 /* error */
 #if CPDEBUG > 0
-NORETURN(static void append_compile_error(rb_iseq_t *iseq, int line, const char *fmt, ...));
+NORETURN(COLDFUNC(static void append_compile_error(rb_iseq_t *iseq, int line, const char *fmt, ...)));
 #endif
 
 static void
@@ -396,6 +396,7 @@ append_compile_error(rb_iseq_t *iseq, int line, const char *fmt, ...)
 }
 
 #if 0
+COLDFUNC(static void compile_bug(rb_iseq_t *iseq, int line, const char *fmt, ...));
 static void
 compile_bug(rb_iseq_t *iseq, int line, const char *fmt, ...)
 {
@@ -712,7 +713,7 @@ rb_iseq_compile_node(rb_iseq_t *iseq, const NODE *node)
 	  default:
 	    COMPILE_ERROR(ERROR_ARGS "unknown scope: %d", iseq->body->type);
 	    return COMPILE_NG;
-	  invalid_iseq_type:
+	  invalid_iseq_type: COLDLABEL
 	    COMPILE_ERROR(ERROR_ARGS "compile/ISEQ_TYPE_%s should not be reached", m);
 	    return COMPILE_NG;
 	}
@@ -7456,7 +7457,7 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
       }
       default:
 	UNKNOWN_NODE("iseq_compile_each", node, COMPILE_NG);
-      ng:
+      ng: COLDLABEL
 	debug_node_end();
 	return COMPILE_NG;
     }
@@ -9220,7 +9221,7 @@ ibf_load_check_offset(const struct ibf_load *load, size_t offset)
     return load->buff + offset;
 }
 
-NORETURN(static void ibf_dump_object_unsupported(struct ibf_dump *dump, VALUE obj));
+NORETURN(COLDFUNC(static void ibf_dump_object_unsupported(struct ibf_dump *dump, VALUE obj)));
 
 static void
 ibf_dump_object_unsupported(struct ibf_dump *dump, VALUE obj)
@@ -9228,6 +9229,8 @@ ibf_dump_object_unsupported(struct ibf_dump *dump, VALUE obj)
     rb_obj_info_dump(obj);
     rb_bug("ibf_dump_object_unsupported: unsupported");
 }
+
+COLDFUNC(static VALUE ibf_load_object_unsupported(const struct ibf_load *load, const struct ibf_object_header *header, ibf_offset_t offset));
 
 static VALUE
 ibf_load_object_unsupported(const struct ibf_load *load, const struct ibf_object_header *header, ibf_offset_t offset)

--- a/complex.c
+++ b/complex.c
@@ -2137,6 +2137,7 @@ float_arg(VALUE self)
  *    Complex(1, 1) / 2    #=> ((1/2)+(1/2)*i)
  *    Complex(1, 1) / 2.0  #=> (0.5+0.5i)
  */
+COLDFUNC(void Init_Complex(void));
 void
 Init_Complex(void)
 {

--- a/configure.ac
+++ b/configure.ac
@@ -1303,6 +1303,7 @@ AS_IF([test "$rb_cv_have_alignof" != no], [
 RUBY_FUNC_ATTRIBUTE(__const__, CONSTFUNC)
 RUBY_FUNC_ATTRIBUTE(__pure__, PUREFUNC)
 RUBY_FUNC_ATTRIBUTE(__noreturn__, NORETURN)
+RUBY_FUNC_ATTRIBUTE(__cold__, COLDFUNC)
 RUBY_FUNC_ATTRIBUTE(__deprecated__, DEPRECATED)
 RUBY_FUNC_ATTRIBUTE(__deprecated__("by "@%:@n), DEPRECATED_BY(n,x), rb_cv_func_deprecated_by)
 RUBY_TYPE_ATTRIBUTE(__deprecated__ mesg, DEPRECATED_TYPE(mesg,x), rb_cv_type_deprecated)

--- a/cont.c
+++ b/cont.c
@@ -1986,6 +1986,7 @@ fiber_to_s(VALUE fibval)
  *     fiber.resume #=> FiberError: dead fiber called
  */
 
+COLDFUNC(void Init_Cont(void));
 void
 Init_Cont(void)
 {
@@ -2014,6 +2015,7 @@ Init_Cont(void)
 
 RUBY_SYMBOL_EXPORT_BEGIN
 
+COLDFUNC(void ruby_Init_Continuation_body(void));
 void
 ruby_Init_Continuation_body(void)
 {
@@ -2025,6 +2027,7 @@ ruby_Init_Continuation_body(void)
     rb_define_global_function("callcc", rb_callcc, 0);
 }
 
+COLDFUNC(void ruby_Init_Fiber_as_Coroutine(void));
 void
 ruby_Init_Fiber_as_Coroutine(void)
 {

--- a/dir.c
+++ b/dir.c
@@ -377,7 +377,7 @@ fnmatch_helper(
 	Inc(s, send, enc);
 	continue;
 
-      failed: /* try next '*' position */
+      failed: COLDLABEL /* try next '*' position */
 	if (ptmp && stmp) {
 	    p = ptmp;
 	    Inc(stmp, send, enc); /* !ISEND(*stmp) */
@@ -612,7 +612,7 @@ dir_s_open(int argc, VALUE *argv, VALUE klass)
     return dir;
 }
 
-NORETURN(static void dir_closed(void));
+NORETURN(COLDFUNC(static void dir_closed(void)));
 
 static void
 dir_closed(void)
@@ -1702,7 +1702,7 @@ glob_make_pattern(const char *p, const char *e, int flags, rb_encoding *enc)
 
     tmp = GLOB_ALLOC(struct glob_pattern);
     if (!tmp) {
-      error:
+      error: COLDLABEL
 	*tail = 0;
 	glob_free_pattern(list);
 	return 0;
@@ -3250,6 +3250,7 @@ rb_dir_s_empty_p(VALUE obj, VALUE dirname)
  *  directory (<code>..</code>), and the directory itself
  *  (<code>.</code>).
  */
+COLDFUNC(void Init_Dir(void));
 void
 Init_Dir(void)
 {

--- a/dln.c
+++ b/dln.c
@@ -19,7 +19,7 @@
 #define dln_notimplement --->>> dln not implemented <<<---
 #define dln_memerror abort
 #define dln_exit exit
-static void dln_loaderror(const char *format, ...);
+COLDFUNC(static void dln_loaderror(const char *format, ...));
 #endif
 #include "dln.h"
 #include "internal.h"
@@ -319,7 +319,7 @@ load_sym(int fd, struct exec *hdrp, long disp)
     }
     return buffer;
 
-  err_noexec:
+  err_noexec: COLDLABEL
     dln_errno = DLN_ENOEXEC;
     return NULL;
 }
@@ -882,7 +882,7 @@ load_1(int fd, long disp, const char *need_init)
     }
     return 0;
 
-  err_exit:
+  err_exit: COLDLABEL
     if (syms) free(syms);
     if (reloc) free(reloc);
     if (block) free((char*)block);
@@ -1040,9 +1040,9 @@ load_lib(const char *lib)
     close(fd);
     return 0;
 
-  syserr:
+  syserr: COLDLABEL
     dln_errno = errno;
-  badlib:
+  badlib: COLDLABEL
     if (fd >= 0) close(fd);
     return -1;
 }
@@ -1172,6 +1172,7 @@ dln_strerror(void)
 #endif
 
 #if defined(_AIX) && ! defined(_IA64)
+COLDFUNC(static void aix_loaderror(const char *pathname));
 static void
 aix_loaderror(const char *pathname)
 {
@@ -1463,7 +1464,7 @@ dln_load(const char *file)
 #endif /* USE_DLN_A_OUT */
 #endif
 #if !defined(_AIX) && !defined(NeXT)
-  failed:
+  failed: COLDLABEL
     dln_loaderror("%s - %s", error, file);
 #endif
 

--- a/enc/encdb.c
+++ b/enc/encdb.c
@@ -19,6 +19,7 @@
 #define ENC_SET_DUMMY(name, orig) rb_enc_set_dummy(name)
 #define ENC_DUMMY_UNICODE(name) rb_encdb_set_unicode(rb_enc_set_dummy(ENC_REPLICATE((name), name "BE")))
 
+COLDFUNC(void Init_encdb(void));
 void
 Init_encdb(void)
 {

--- a/enc/encinit.c.erb
+++ b/enc/encinit.c.erb
@@ -11,7 +11,7 @@
 #define init_enc(name) init(Init_##name, "enc/"#name".so")
 #define init_trans(name) init(Init_trans_##name, "enc/trans/"#name".so")
 #define provide(func, name) { \
-    extern void Init_##func(void); \
+    COLDFUNC(extern void Init_##func(void)); \
     Init_##func(); \
     rb_provide(name".so"); \
 }
@@ -19,6 +19,7 @@
 void ruby_init_ext(const char *name, void (*init)(void));
 void rb_provide(const char *feature);
 
+COLDFUNC(void Init_enc(void));
 void
 Init_enc(void)
 {

--- a/enc/gb2312.c
+++ b/enc/gb2312.c
@@ -2,6 +2,7 @@
 #include <ruby/encoding.h>
 #include "regenc.h"
 
+COLDFUNC(void Init_gb2312(void));
 void
 Init_gb2312(void)
 {

--- a/encoding.c
+++ b/encoding.c
@@ -158,7 +158,7 @@ enc_check_encoding(VALUE obj)
     return check_encoding(RDATA(obj)->data);
 }
 
-NORETURN(static void not_encoding(VALUE enc));
+NORETURN(COLDFUNC(static void not_encoding(VALUE enc)));
 static void
 not_encoding(VALUE enc)
 {
@@ -1930,6 +1930,7 @@ rb_enc_aliases(VALUE klass)
  *
  */
 
+COLDFUNC(void Init_Encoding(void));
 void
 Init_Encoding(void)
 {

--- a/enum.c
+++ b/enum.c
@@ -4025,6 +4025,7 @@ enum_uniq(VALUE obj)
  *  rely on an ordering between members of the collection.
  */
 
+COLDFUNC(void Init_Enumerable(void));
 void
 Init_Enumerable(void)
 {

--- a/enumerator.c
+++ b/enumerator.c
@@ -2875,6 +2875,7 @@ InitVM_Enumerator(void)
 }
 
 #undef rb_intern
+COLDFUNC(void Init_Enumerator(void));
 void
 Init_Enumerator(void)
 {

--- a/error.c
+++ b/error.c
@@ -612,7 +612,6 @@ rb_bug_context(const void *ctx, const char *fmt, ...)
     die();
 }
 
-
 void
 rb_bug_errno(const char *mesg, int errno_arg)
 {
@@ -756,7 +755,7 @@ rb_builtin_class_name(VALUE x)
     return etype;
 }
 
-NORETURN(static void unexpected_type(VALUE, int, int));
+NORETURN(COLDFUNC(static void unexpected_type(VALUE, int, int)));
 #define UNDEF_LEAKED "undef leaked to the Ruby space"
 
 static void
@@ -836,12 +835,12 @@ rb_check_typeddata(VALUE obj, const rb_data_type_t *data_type)
     const char *etype;
 
     if (!RB_TYPE_P(obj, T_DATA)) {
-      wrong_type:
+      wrong_type: COLDLABEL
 	etype = builtin_class_name(obj);
 	if (!etype)
 	    rb_raise(rb_eTypeError, "wrong argument type %"PRIsVALUE" (expected %s)",
 		     rb_obj_class(obj), data_type->wrap_struct_name);
-      wrong_datatype:
+      wrong_datatype: COLDLABEL
 	rb_raise(rb_eTypeError, "wrong argument type %s (expected %s)",
 		 etype, data_type->wrap_struct_name);
     }
@@ -2418,6 +2417,7 @@ syserr_eqq(VALUE self, VALUE exc)
  *  * fatal -- impossible to rescue
  */
 
+COLDFUNC(void Init_Exception(void));
 void
 Init_Exception(void)
 {
@@ -2549,7 +2549,7 @@ rb_raise(VALUE exc, const char *fmt, ...)
     rb_exc_raise(rb_exc_new3(exc, mesg));
 }
 
-NORETURN(static void raise_loaderror(VALUE path, VALUE mesg));
+NORETURN(COLDFUNC(static void raise_loaderror(VALUE path, VALUE mesg)));
 
 static void
 raise_loaderror(VALUE path, VALUE mesg)
@@ -2630,7 +2630,7 @@ make_errno_exc_str(VALUE mesg)
     return rb_syserr_new_str(n, mesg);
 }
 
-VALUE
+ VALUE
 rb_syserr_new(int n, const char *mesg)
 {
     VALUE arg;
@@ -2894,6 +2894,7 @@ rb_check_copyable(VALUE obj, VALUE orig)
     }
 }
 
+COLDFUNC(void Init_syserr(void));
 void
 Init_syserr(void)
 {

--- a/eval.c
+++ b/eval.c
@@ -419,7 +419,7 @@ void
 rb_class_modify_check(VALUE klass)
 {
     if (SPECIAL_CONST_P(klass)) {
-      noclass:
+      noclass: COLDLABEL
 	Check_Type(klass, T_CLASS);
     }
     if (OBJ_FROZEN(klass)) {
@@ -1902,6 +1902,7 @@ f_current_dirname(void)
     return base;
 }
 
+COLDFUNC(void Init_eval(void));
 void
 Init_eval(void)
 {

--- a/eval_error.c
+++ b/eval_error.c
@@ -22,7 +22,7 @@
 #define write_warn_str(str,x) NIL_P(str) ? rb_write_error_str(x) : (void)rb_str_concat((str), (x))
 #define warn_print_str(x) rb_write_error_str(x)
 
-static VALUE error_pos_str(void);
+COLDFUNC(static VALUE error_pos_str(void));
 
 static void
 error_pos(const VALUE str)
@@ -73,6 +73,7 @@ set_backtrace(VALUE info, VALUE bt)
     rb_check_funcall(info, set_backtrace, 1, &bt);
 }
 
+COLDFUNC(static void error_print(rb_execution_context_t *ec));
 static void
 error_print(rb_execution_context_t *ec)
 {
@@ -86,6 +87,7 @@ static const char underline[] = CSI_BEGIN"1;4"CSI_SGR;
 static const char bold[] = CSI_BEGIN"1"CSI_SGR;
 static const char reset[] = CSI_BEGIN""CSI_SGR;
 
+COLDFUNC(static void print_errinfo(const VALUE eclass, const VALUE errat, const VALUE emesg, const VALUE str, int highlight));
 static void
 print_errinfo(const VALUE eclass, const VALUE errat, const VALUE emesg, const VALUE str, int highlight)
 {
@@ -187,6 +189,7 @@ print_errinfo(const VALUE eclass, const VALUE errat, const VALUE emesg, const VA
     }
 }
 
+COLDFUNC(static void print_backtrace(const VALUE eclass, const VALUE errat, const VALUE str, int reverse));
 static void
 print_backtrace(const VALUE eclass, const VALUE errat, const VALUE str, int reverse)
 {
@@ -220,6 +223,7 @@ print_backtrace(const VALUE eclass, const VALUE errat, const VALUE str, int reve
     }
 }
 
+COLDFUNC(void rb_error_write(VALUE errinfo, VALUE emesg, VALUE errat, VALUE str, VALUE highlight, VALUE reverse));
 void
 rb_error_write(VALUE errinfo, VALUE emesg, VALUE errat, VALUE str, VALUE highlight, VALUE reverse)
 {

--- a/eval_intern.h
+++ b/eval_intern.h
@@ -284,21 +284,21 @@ int rb_ec_reset_raised(rb_execution_context_t *ec);
 int rb_ec_stack_check(rb_execution_context_t *ec);
 
 VALUE rb_f_eval(int argc, const VALUE *argv, VALUE self);
-VALUE rb_make_exception(int argc, const VALUE *argv);
+COLDFUNC(VALUE rb_make_exception(int argc, const VALUE *argv));
 
-NORETURN(void rb_method_name_error(VALUE, VALUE));
+NORETURN(COLDFUNC(void rb_method_name_error(VALUE, VALUE)));
 
 NORETURN(void rb_fiber_start(void));
 
-NORETURN(void rb_print_undef(VALUE, ID, rb_method_visibility_t));
-NORETURN(void rb_print_undef_str(VALUE, VALUE));
-NORETURN(void rb_print_inaccessible(VALUE, ID, rb_method_visibility_t));
-NORETURN(void rb_vm_localjump_error(const char *,VALUE, int));
+NORETURN(COLDFUNC(void rb_print_undef(VALUE, ID, rb_method_visibility_t)));
+NORETURN(COLDFUNC(void rb_print_undef_str(VALUE, VALUE)));
+NORETURN(COLDFUNC(void rb_print_inaccessible(VALUE, ID, rb_method_visibility_t)));
+NORETURN(COLDFUNC(void rb_vm_localjump_error(const char *,VALUE, int)));
 #if 0
 NORETURN(void rb_vm_jump_tag_but_local_jump(int));
 #endif
 
-VALUE rb_vm_make_jump_tag_but_local_jump(int state, VALUE val);
+COLDFUNC(VALUE rb_vm_make_jump_tag_but_local_jump(int state, VALUE val));
 rb_cref_t *rb_vm_cref(void);
 rb_cref_t *rb_vm_cref_replace_with_duplicated_cref(void);
 VALUE rb_vm_call_cfunc(VALUE recv, VALUE (*func)(VALUE), VALUE arg, VALUE block_handler, VALUE filename);

--- a/eval_jump.c
+++ b/eval_jump.c
@@ -132,6 +132,7 @@ rb_exec_end_proc(void)
     ec->errinfo = errinfo;
 }
 
+COLDFUNC(void Init_jump(void));
 void
 Init_jump(void)
 {

--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -308,13 +308,13 @@ again:
 	goto SomeOneMayDoIt;
     }
 
-SomeOneMayDoIt:
+SomeOneMayDoIt: COLDLABEL
     if (must) {
 	cannot_be_coerced_into_BigDecimal(rb_eTypeError, v);
     }
     return NULL; /* NULL means to coerce */
 
-unable_to_coerce_without_prec:
+unable_to_coerce_without_prec: COLDLABEL
     if (must) {
 	rb_raise(rb_eArgError,
 		 "%"PRIsVALUE" can't be coerced into BigDecimal without a precision",
@@ -492,7 +492,7 @@ check_rounding_mode_option(VALUE const opts)
       default:
         break;
     }
-  invalid:
+  invalid: COLDLABEL
     if (NIL_P(mode))
 	rb_raise(rb_eArgError, "invalid rounding mode: nil");
     else
@@ -822,14 +822,14 @@ BigDecimal_to_f(VALUE self)
     }
     return rb_float_new(d);
 
-overflow:
+overflow: COLDLABEL
     VpException(VP_EXCEPTION_OVERFLOW, "BigDecimal to Float conversion", 0);
     if (BIGDECIMAL_NEGATIVE_P(p))
 	return rb_float_new(VpGetDoubleNegInf());
     else
 	return rb_float_new(VpGetDoublePosInf());
 
-underflow:
+underflow: COLDLABEL
     VpException(VP_EXCEPTION_UNDERFLOW, "BigDecimal to Float conversion", 0);
     if (BIGDECIMAL_NEGATIVE_P(p))
 	return rb_float_new(-0.0);
@@ -1429,7 +1429,7 @@ BigDecimal_DoDivmod(VALUE self, VALUE r, Real **div, Real **mod)
     }
     return Qtrue;
 
-NaN:
+NaN: COLDLABEL
     GUARD_OBJ(c, VpCreateRbObject(1, "NaN"));
     GUARD_OBJ(d, VpCreateRbObject(1, "NaN"));
     *div = d;
@@ -3263,6 +3263,7 @@ get_vp_value:
  * Documented by zzak <zachary@zacharyscott.net>, mathew <meta@pobox.com>, and
  * many other contributors.
  */
+COLDFUNC(void Init_bigdecimal(void));
 void
 Init_bigdecimal(void)
 {
@@ -4020,11 +4021,11 @@ AddExponent(Real *a, SIGNED_VALUE n)
     return 1;
 
 /* Overflow/Underflow ==> Raise exception or returns 0 */
-underflow:
+underflow: COLDLABEL
     VpSetZero(a, VpGetSign(a));
     return VpException(VP_EXCEPTION_UNDERFLOW, "Exponent underflow", 0);
 
-overflow:
+overflow: COLDLABEL
     VpSetInf(a, VpGetSign(a));
     return VpException(VP_EXCEPTION_OVERFLOW, "Exponent overflow", 0);
 }
@@ -5025,7 +5026,7 @@ out_side:
     VpNmlz(r);            /* normalize r(remainder) */
     goto Exit;
 
-space_error:
+space_error: COLDLABEL
 #ifdef BIGDECIMAL_DEBUG
     if (gfDebug) {
 	printf("   word_a=%"PRIuSIZE"\n", word_a);
@@ -5656,7 +5657,7 @@ VpCtoV(Real *a, const char *int_chr, size_t ni, const char *frac, size_t nf, con
     }
     goto Final;
 
-over_flow:
+over_flow: COLDLABEL
     rb_warn("Conversion from String to BigDecimal overflow (last few digits discarded).");
 
 Final:

--- a/ext/cgi/escape/escape.c
+++ b/ext/cgi/escape/escape.c
@@ -400,6 +400,7 @@ cgiesc_unescape(int argc, VALUE *argv, VALUE self)
     }
 }
 
+COLDFUNC(void Init_escape(void));
 void
 Init_escape(void)
 {
@@ -407,6 +408,7 @@ Init_escape(void)
     InitVM(escape);
 }
 
+COLDFUNC(void InitVM_escape(void));
 void
 InitVM_escape(void)
 {

--- a/ext/continuation/continuation.c
+++ b/ext/continuation/continuation.c
@@ -1,8 +1,9 @@
 
 #include "ruby/ruby.h"
 
-void ruby_Init_Continuation_body(void);
+COLDFUNC(void ruby_Init_Continuation_body(void));
 
+COLDFUNC(void Init_continuation(void));
 void
 Init_continuation(void)
 {

--- a/ext/coverage/coverage.c
+++ b/ext/coverage/coverage.c
@@ -292,6 +292,7 @@ rb_coverage_running(VALUE klass)
  *   require "foo.rb"
  *   p Coverage.result  #=> {"foo.rb"=>[1, 1, 10, nil, nil, 1, 1, nil, 0, nil]}
  */
+COLDFUNC(void Init_coverage(void));
 void
 Init_coverage(void)
 {

--- a/ext/date/date_core.c
+++ b/ext/date/date_core.c
@@ -9011,6 +9011,7 @@ mk_ary_of_str(long len, const char *a[])
     return o;
 }
 
+COLDFUNC(void Init_date_core(void));
 void
 Init_date_core(void)
 {

--- a/ext/date/date_strftime.c
+++ b/ext/date/date_strftime.c
@@ -81,7 +81,7 @@ date_strftime_with_tmx(char *s, const size_t maxsize, const char *format,
 
     /* quick check if we even need to bother */
     if (strchr(format, '%') == NULL && strlen(format) + 1 >= maxsize) {
-      err:
+      err: COLDLABEL
 	errno = ERANGE;
 	return 0;
     }

--- a/ext/dbm/dbm.c
+++ b/ext/dbm/dbm.c
@@ -39,7 +39,7 @@ struct dbmdata {
     DBM *di_dbm;
 };
 
-NORETURN(static void closed_dbm(void));
+NORETURN(COLDFUNC(static void closed_dbm(void)));
 
 static void
 closed_dbm(void)
@@ -1038,6 +1038,7 @@ fdbm_reject(VALUE obj)
  *  db['3068'] = 'An Anycast Prefix for 6to4 Relay Routers'
  *  puts db['822']
  */
+COLDFUNC(void Init_dbm(void));
 void
 Init_dbm(void)
 {

--- a/ext/digest/bubblebabble/bubblebabble.c
+++ b/ext/digest/bubblebabble/bubblebabble.c
@@ -121,6 +121,7 @@ rb_digest_instance_bubblebabble(VALUE self)
  * This module adds some methods to Digest classes to perform
  * BubbleBabble encoding.
  */
+COLDFUNC(void Init_bubblebabble(void));
 void
 Init_bubblebabble(void)
 {

--- a/ext/digest/digest.c
+++ b/ext/digest/digest.c
@@ -23,7 +23,7 @@ static VALUE rb_cDigest_Base;
 static ID id_reset, id_update, id_finish, id_digest, id_hexdigest, id_digest_length;
 static ID id_metadata;
 
-RUBY_EXTERN void Init_digest_base(void);
+COLDFUNC(RUBY_EXTERN void Init_digest_base(void));
 
 /*
  * Document-module: Digest
@@ -141,7 +141,7 @@ rb_digest_s_hexencode(VALUE klass, VALUE str)
     return hexencode_str_new(str);
 }
 
-NORETURN(static void rb_digest_instance_method_unimpl(VALUE self, const char *method));
+NORETURN(COLDFUNC(static void rb_digest_instance_method_unimpl(VALUE self, const char *method)));
 
 /*
  * Document-module: Digest::Instance
@@ -150,6 +150,7 @@ NORETURN(static void rb_digest_instance_method_unimpl(VALUE self, const char *me
  * object to calculate message digest values.
  */
 
+COLDFUNC(static void rb_digest_instance_method_unimpl(VALUE self, const char *method));
 static void
 rb_digest_instance_method_unimpl(VALUE self, const char *method)
 {
@@ -725,6 +726,7 @@ rb_digest_base_block_length(VALUE self)
     return INT2NUM(algo->block_len);
 }
 
+COLDFUNC(void Init_digest(void));
 void
 Init_digest(void)
 {

--- a/ext/digest/md5/md5init.c
+++ b/ext/digest/md5/md5init.c
@@ -46,6 +46,7 @@ static const rb_digest_metadata_t md5 = {
  *  md5 << "message"
  *  md5.hexdigest                        # => "78e73102..."
  */
+COLDFUNC(void Init_md5(void));
 void
 Init_md5(void)
 {

--- a/ext/digest/rmd160/rmd160init.c
+++ b/ext/digest/rmd160/rmd160init.c
@@ -44,6 +44,7 @@ static const rb_digest_metadata_t rmd160 = {
  *  rmd160 << "message"
  *  rmd160.hexdigest                        # => "1dddbe1b..."
  */
+COLDFUNC(void Init_rmd160(void));
 void
 Init_rmd160(void)
 {

--- a/ext/digest/sha1/sha1init.c
+++ b/ext/digest/sha1/sha1init.c
@@ -48,6 +48,7 @@ static const rb_digest_metadata_t sha1 = {
  *  sha1 << "message"
  *  sha1.hexdigest                        # => "6f9b9af3..."
  */
+COLDFUNC(void Init_sha1(void));
 void
 Init_sha1(void)
 {

--- a/ext/digest/sha2/sha2init.c
+++ b/ext/digest/sha2/sha2init.c
@@ -31,6 +31,7 @@ FOREACH_BITLEN(DEFINE_ALGO_METADATA)
  * Secure Hash Algorithm(s) by NIST (the US' National Institute of
  * Standards and Technology), described in FIPS PUB 180-2.
  */
+COLDFUNC(void Init_sha2(void));
 void
 Init_sha2(void)
 {

--- a/ext/etc/etc.c
+++ b/ext/etc/etc.c
@@ -1062,6 +1062,7 @@ etc_nprocessors(VALUE obj)
  * All operations defined in this module are class methods, so that you can
  * include the Etc module into your class.
  */
+COLDFUNC(void Init_etc(void));
 void
 Init_etc(void)
 {

--- a/ext/fcntl/fcntl.c
+++ b/ext/fcntl/fcntl.c
@@ -61,6 +61,7 @@ pack up your own arguments to pass as args for locking functions, etc.
  *   f.fcntl(Fcntl::F_SETFL, Fcntl::O_NONBLOCK|m)
  *
  */
+COLDFUNC(void Init_fcntl(void));
 void
 Init_fcntl(void)
 {

--- a/ext/fiddle/closure.c
+++ b/ext/fiddle/closure.c
@@ -288,6 +288,7 @@ to_i(VALUE self)
     return PTR2NUM(code);
 }
 
+COLDFUNC(void Init_fiddle_closure(void));
 void
 Init_fiddle_closure(void)
 {

--- a/ext/fiddle/closure.h
+++ b/ext/fiddle/closure.h
@@ -3,6 +3,6 @@
 
 #include <fiddle.h>
 
-void Init_fiddle_closure(void);
+COLDFUNC(void Init_fiddle_closure(void));
 
 #endif

--- a/ext/fiddle/fiddle.c
+++ b/ext/fiddle/fiddle.c
@@ -35,7 +35,7 @@ VALUE rb_eFiddleError;
 #endif
 #define TYPE_UINTPTR_T (-TYPE_INTPTR_T)
 
-void Init_fiddle_pointer(void);
+COLDFUNC(void Init_fiddle_pointer(void));
 
 /*
  * call-seq: Fiddle.malloc(size)
@@ -123,8 +123,9 @@ rb_fiddle_value2ptr(VALUE self, VALUE val)
     return PTR2NUM((void*)val);
 }
 
-void Init_fiddle_handle(void);
+COLDFUNC(void Init_fiddle_handle(void));
 
+COLDFUNC(void Init_fiddle(void));
 void
 Init_fiddle(void)
 {

--- a/ext/fiddle/function.h
+++ b/ext/fiddle/function.h
@@ -3,6 +3,6 @@
 
 #include <fiddle.h>
 
-void Init_fiddle_function(void);
+COLDFUNC(void Init_fiddle_function(void));
 
 #endif

--- a/ext/fiddle/handle.c
+++ b/ext/fiddle/handle.c
@@ -374,6 +374,7 @@ fiddle_handle_sym(void *handle, VALUE symbol)
     return PTR2NUM(func);
 }
 
+COLDFUNC(void Init_fiddle_handle(void));
 void
 Init_fiddle_handle(void)
 {

--- a/ext/fiddle/pointer.c
+++ b/ext/fiddle/pointer.c
@@ -674,6 +674,7 @@ rb_fiddle_ptr_s_to_ptr(VALUE self, VALUE val)
     return ptr;
 }
 
+COLDFUNC(void Init_fiddle_pointer(void));
 void
 Init_fiddle_pointer(void)
 {

--- a/ext/gdbm/gdbm.c
+++ b/ext/gdbm/gdbm.c
@@ -84,8 +84,8 @@ static VALUE rb_cGDBM, rb_eGDBMError, rb_eGDBMFatalError;
 #define MY_BLOCK_SIZE (2048)
 #define MY_FATAL_FUNC rb_gdbm_fatal
 
-NORETURN(static void rb_gdbm_fatal(const char *msg));
-NORETURN(static void closed_dbm(void));
+NORETURN(COLDFUNC(static void rb_gdbm_fatal(const char *msg)));
+NORETURN(COLDFUNC(static void closed_dbm(void)));
 
 static void
 rb_gdbm_fatal(const char *msg)
@@ -1224,6 +1224,7 @@ fgdbm_reject(VALUE obj)
     return rb_hash_delete_if(fgdbm_to_hash(obj));
 }
 
+COLDFUNC(void Init_gdbm(void));
 void
 Init_gdbm(void)
 {

--- a/ext/io/console/console.c
+++ b/ext/io/console/console.c
@@ -949,6 +949,7 @@ io_getpass(int argc, VALUE *argv, VALUE io)
 /*
  * IO console methods
  */
+COLDFUNC(void Init_console(void));
 void
 Init_console(void)
 {

--- a/ext/io/nonblock/nonblock.c
+++ b/ext/io/nonblock/nonblock.c
@@ -131,6 +131,7 @@ rb_io_nonblock_block(int argc, VALUE *argv, VALUE io)
 #define rb_io_nonblock_block rb_f_notimplement
 #endif
 
+COLDFUNC(void Init_nonblock(void));
 void
 Init_nonblock(void)
 {

--- a/ext/io/wait/wait.c
+++ b/ext/io/wait/wait.c
@@ -42,7 +42,7 @@
 static VALUE io_ready_p _((VALUE io));
 static VALUE io_wait_readable _((int argc, VALUE *argv, VALUE io));
 static VALUE io_wait_writable _((int argc, VALUE *argv, VALUE io));
-void Init_wait _((void));
+COLDFUNC(void Init_wait _((void)));
 
 static struct timeval *
 get_timeout(int argc, VALUE *argv, struct timeval *timerec)
@@ -243,6 +243,7 @@ io_wait_readwrite(int argc, VALUE *argv, VALUE io)
  * IO wait methods
  */
 
+COLDFUNC(void Init_wait(void));
 void
 Init_wait(void)
 {

--- a/ext/json/generator/generator.c
+++ b/ext/json/generator/generator.c
@@ -1333,6 +1333,7 @@ static VALUE cState_buffer_initial_length_set(VALUE self, VALUE buffer_initial_l
 /*
  *
  */
+COLDFUNC(void Init_generator(void));
 void Init_generator(void)
 {
 #undef rb_intern

--- a/ext/json/parser/parser.c
+++ b/ext/json/parser/parser.c
@@ -2064,6 +2064,7 @@ static VALUE cParser_source(VALUE self)
     return rb_str_dup(json->Vsource);
 }
 
+COLDFUNC(void Init_parser(void));
 void Init_parser(void)
 {
 #undef rb_intern

--- a/ext/nkf/nkf.c
+++ b/ext/nkf/nkf.c
@@ -474,6 +474,7 @@ rb_nkf_guess(VALUE obj, VALUE src)
  *  Ignore rest of -option.
  */
 
+COLDFUNC(void Init_nkf(void));
 void
 Init_nkf(void)
 {

--- a/ext/objspace/object_tracing.c
+++ b/ext/objspace/object_tracing.c
@@ -470,6 +470,7 @@ allocation_generation(VALUE self, VALUE obj)
     }
 }
 
+COLDFUNC(void Init_object_tracing(VALUE rb_mObjSpace));
 void
 Init_object_tracing(VALUE rb_mObjSpace)
 {

--- a/ext/objspace/objspace.c
+++ b/ext/objspace/objspace.c
@@ -933,6 +933,7 @@ void Init_objspace_dump(VALUE rb_mObjSpace);
  * memory usage.
  */
 
+COLDFUNC(void Init_objspace(void));
 void
 Init_objspace(void)
 {

--- a/ext/objspace/objspace_dump.c
+++ b/ext/objspace/objspace_dump.c
@@ -495,6 +495,7 @@ objspace_dump_all(int argc, VALUE *argv, VALUE os)
     return dump_result(&dc, output);
 }
 
+COLDFUNC(void Init_objspace_dump(VALUE rb_mObjSpace));
 void
 Init_objspace_dump(VALUE rb_mObjSpace)
 {

--- a/ext/openssl/ossl.h
+++ b/ext/openssl/ossl.h
@@ -120,7 +120,7 @@ int ossl_pem_passwd_cb(char *, int, int, void *);
 /*
  * ERRor messages
  */
-NORETURN(void ossl_raise(VALUE, const char *, ...));
+NORETURN(COLDFUNC(void ossl_raise(VALUE, const char *, ...)));
 /* Clear OpenSSL error queue. If dOSSL is set, rb_warn() them. */
 void ossl_clear_error(void);
 
@@ -173,6 +173,6 @@ void ossl_debug(const char *, ...);
 #include "ossl_engine.h"
 #include "ossl_kdf.h"
 
-void Init_openssl(void);
+COLDFUNC(void Init_openssl(void));
 
 #endif /* _OSSL_H_ */

--- a/ext/openssl/ossl_asn1.h
+++ b/ext/openssl/ossl_asn1.h
@@ -57,6 +57,6 @@ extern VALUE cASN1Sequence, cASN1Set;                /* CONSTRUCTIVE      */
 
 ASN1_TYPE *ossl_asn1_get_asn1type(VALUE);
 
-void Init_ossl_asn1(void);
+COLDFUNC(void Init_ossl_asn1(void));
 
 #endif

--- a/ext/openssl/ossl_bn.h
+++ b/ext/openssl/ossl_bn.h
@@ -19,7 +19,7 @@ extern BN_CTX *ossl_bn_ctx;
 
 VALUE ossl_bn_new(const BIGNUM *);
 BIGNUM *ossl_bn_value_ptr(volatile VALUE *);
-void Init_ossl_bn(void);
+COLDFUNC(void Init_ossl_bn(void));
 
 
 #endif /* _OSS_BN_H_ */

--- a/ext/openssl/ossl_cipher.h
+++ b/ext/openssl/ossl_cipher.h
@@ -15,6 +15,6 @@ extern VALUE eCipherError;
 
 const EVP_CIPHER *ossl_evp_get_cipherbyname(VALUE);
 VALUE ossl_cipher_new(const EVP_CIPHER *);
-void Init_ossl_cipher(void);
+COLDFUNC(void Init_ossl_cipher(void));
 
 #endif /* _OSSL_CIPHER_H_ */

--- a/ext/openssl/ossl_config.h
+++ b/ext/openssl/ossl_config.h
@@ -14,6 +14,6 @@ extern VALUE cConfig;
 extern VALUE eConfigError;
 
 CONF* DupConfigPtr(VALUE obj);
-void Init_ossl_config(void);
+COLDFUNC(void Init_ossl_config(void));
 
 #endif /* _OSSL_CONFIG_H_ */

--- a/ext/openssl/ossl_digest.h
+++ b/ext/openssl/ossl_digest.h
@@ -15,6 +15,6 @@ extern VALUE eDigestError;
 
 const EVP_MD *ossl_evp_get_digestbyname(VALUE);
 VALUE ossl_digest_new(const EVP_MD *);
-void Init_ossl_digest(void);
+COLDFUNC(void Init_ossl_digest(void));
 
 #endif /* _OSSL_DIGEST_H_ */

--- a/ext/openssl/ossl_engine.h
+++ b/ext/openssl/ossl_engine.h
@@ -14,6 +14,6 @@
 extern VALUE cEngine;
 extern VALUE eEngineError;
 
-void Init_ossl_engine(void);
+COLDFUNC(void Init_ossl_engine(void));
 
 #endif /* OSSL_ENGINE_H */

--- a/ext/openssl/ossl_hmac.h
+++ b/ext/openssl/ossl_hmac.h
@@ -13,6 +13,6 @@
 extern VALUE cHMAC;
 extern VALUE eHMACError;
 
-void Init_ossl_hmac(void);
+COLDFUNC(void Init_ossl_hmac(void));
 
 #endif /* _OSSL_HMAC_H_ */

--- a/ext/openssl/ossl_kdf.h
+++ b/ext/openssl/ossl_kdf.h
@@ -1,6 +1,6 @@
 #if !defined(OSSL_KDF_H)
 #define OSSL_KDF_H
 
-void Init_ossl_kdf(void);
+COLDFUNC(void Init_ossl_kdf(void));
 
 #endif

--- a/ext/openssl/ossl_ns_spki.h
+++ b/ext/openssl/ossl_ns_spki.h
@@ -14,6 +14,6 @@ extern VALUE mNetscape;
 extern VALUE cSPKI;
 extern VALUE eSPKIError;
 
-void Init_ossl_ns_spki(void);
+COLDFUNC(void Init_ossl_ns_spki(void));
 
 #endif /* _OSSL_NS_SPKI_H_ */

--- a/ext/openssl/ossl_ocsp.c
+++ b/ext/openssl/ossl_ocsp.c
@@ -870,7 +870,7 @@ ossl_ocspbres_add_status(VALUE self, VALUE cid, VALUE status,
 	}
     }
 
- err:
+ err: COLDLABEL
     ASN1_TIME_free(ths);
     ASN1_TIME_free(nxt);
     ASN1_TIME_free(rev);

--- a/ext/openssl/ossl_ocsp.h
+++ b/ext/openssl/ossl_ocsp.h
@@ -18,6 +18,6 @@ extern VALUE cOPCSRes;
 extern VALUE cOPCSBasicRes;
 #endif
 
-void Init_ossl_ocsp(void);
+COLDFUNC(void Init_ossl_ocsp(void));
 
 #endif /* _OSSL_OCSP_H_ */

--- a/ext/openssl/ossl_pkcs12.c
+++ b/ext/openssl/ossl_pkcs12.c
@@ -198,7 +198,7 @@ ossl_pkcs12_initialize(int argc, VALUE *argv, VALUE self)
 	if (st) goto err;
     }
 
-  err:
+  err: COLDLABEL
     X509_free(x509);
     sk_X509_pop_free(x509s, X509_free);
     ossl_pkcs12_set_key(self, pkey);

--- a/ext/openssl/ossl_pkcs12.h
+++ b/ext/openssl/ossl_pkcs12.h
@@ -8,6 +8,6 @@
 extern VALUE cPKCS12;
 extern VALUE ePKCS12Error;
 
-void Init_ossl_pkcs12(void);
+COLDFUNC(void Init_ossl_pkcs12(void));
 
 #endif /* _OSSL_PKCS12_H_ */

--- a/ext/openssl/ossl_pkcs7.c
+++ b/ext/openssl/ossl_pkcs7.c
@@ -843,7 +843,7 @@ ossl_pkcs7_add_data(VALUE self, VALUE data)
     if(!PKCS7_dataFinal(pkcs7, out)) goto err;
     ossl_pkcs7_set_data(self, Qnil);
 
- err:
+ err: COLDLABEL
     BIO_free_all(out);
     BIO_free(in);
     if(ERR_peek_error()){

--- a/ext/openssl/ossl_pkcs7.h
+++ b/ext/openssl/ossl_pkcs7.h
@@ -15,6 +15,6 @@ extern VALUE cPKCS7Signer;
 extern VALUE cPKCS7Recipient;
 extern VALUE ePKCS7Error;
 
-void Init_ossl_pkcs7(void);
+COLDFUNC(void Init_ossl_pkcs7(void));
 
 #endif /* _OSSL_PKCS7_H_ */

--- a/ext/openssl/ossl_pkey.h
+++ b/ext/openssl/ossl_pkey.h
@@ -48,7 +48,7 @@ void ossl_pkey_check_public_key(const EVP_PKEY *);
 EVP_PKEY *GetPKeyPtr(VALUE);
 EVP_PKEY *DupPKeyPtr(VALUE);
 EVP_PKEY *GetPrivPKeyPtr(VALUE);
-void Init_ossl_pkey(void);
+COLDFUNC(void Init_ossl_pkey(void));
 
 /*
  * RSA
@@ -57,7 +57,7 @@ extern VALUE cRSA;
 extern VALUE eRSAError;
 
 VALUE ossl_rsa_new(EVP_PKEY *);
-void Init_ossl_rsa(void);
+COLDFUNC(void Init_ossl_rsa(void));
 
 /*
  * DSA
@@ -66,7 +66,7 @@ extern VALUE cDSA;
 extern VALUE eDSAError;
 
 VALUE ossl_dsa_new(EVP_PKEY *);
-void Init_ossl_dsa(void);
+COLDFUNC(void Init_ossl_dsa(void));
 
 /*
  * DH
@@ -75,7 +75,7 @@ extern VALUE cDH;
 extern VALUE eDHError;
 
 VALUE ossl_dh_new(EVP_PKEY *);
-void Init_ossl_dh(void);
+COLDFUNC(void Init_ossl_dh(void));
 
 /*
  * EC
@@ -87,7 +87,7 @@ extern VALUE eEC_GROUP;
 extern VALUE cEC_POINT;
 extern VALUE eEC_POINT;
 VALUE ossl_ec_new(EVP_PKEY *);
-void Init_ossl_ec(void);
+COLDFUNC(void Init_ossl_ec(void));
 
 #define OSSL_PKEY_BN_DEF_GETTER0(_keytype, _type, _name, _get)		\
 /*									\

--- a/ext/openssl/ossl_pkey_rsa.c
+++ b/ext/openssl/ossl_pkey_rsa.c
@@ -628,7 +628,7 @@ ossl_rsa_sign_pss(int argc, VALUE *argv, VALUE self)
     EVP_MD_CTX_free(md_ctx);
     return signature;
 
-  err:
+  err: COLDLABEL
     EVP_MD_CTX_free(md_ctx);
     ossl_raise(eRSAError, NULL);
 }
@@ -721,7 +721,7 @@ ossl_rsa_verify_pss(int argc, VALUE *argv, VALUE self)
 	goto err;
     }
 
-  err:
+  err: COLDLABEL
     EVP_MD_CTX_free(md_ctx);
     ossl_raise(eRSAError, NULL);
 }

--- a/ext/openssl/ossl_rand.h
+++ b/ext/openssl/ossl_rand.h
@@ -13,6 +13,6 @@
 extern VALUE mRandom;
 extern VALUE eRandomError;
 
-void Init_ossl_rand(void);
+COLDFUNC(void Init_ossl_rand(void));
 
 #endif /* _OSSL_RAND_H_ */

--- a/ext/openssl/ossl_ssl.h
+++ b/ext/openssl/ossl_ssl.h
@@ -30,7 +30,7 @@ extern VALUE mSSL;
 extern VALUE cSSLSocket;
 extern VALUE cSSLSession;
 
-void Init_ossl_ssl(void);
-void Init_ossl_ssl_session(void);
+COLDFUNC(void Init_ossl_ssl(void));
+COLDFUNC(void Init_ossl_ssl_session(void));
 
 #endif /* _OSSL_SSL_H_ */

--- a/ext/openssl/ossl_x509.h
+++ b/ext/openssl/ossl_x509.h
@@ -22,7 +22,7 @@ extern VALUE mX509;
  */
 ASN1_TIME *ossl_x509_time_adjust(ASN1_TIME *, VALUE);
 
-void Init_ossl_x509(void);
+COLDFUNC(void Init_ossl_x509(void));
 
 /*
  * X509Attr
@@ -32,7 +32,7 @@ extern VALUE eX509AttrError;
 
 VALUE ossl_x509attr_new(X509_ATTRIBUTE *);
 X509_ATTRIBUTE *GetX509AttrPtr(VALUE);
-void Init_ossl_x509attr(void);
+COLDFUNC(void Init_ossl_x509attr(void));
 
 /*
  * X509Cert
@@ -43,7 +43,7 @@ extern VALUE eX509CertError;
 VALUE ossl_x509_new(X509 *);
 X509 *GetX509CertPtr(VALUE);
 X509 *DupX509CertPtr(VALUE);
-void Init_ossl_x509cert(void);
+COLDFUNC(void Init_ossl_x509cert(void));
 
 /*
  * X509CRL
@@ -53,7 +53,7 @@ extern VALUE eX509CRLError;
 
 VALUE ossl_x509crl_new(X509_CRL *);
 X509_CRL *GetX509CRLPtr(VALUE);
-void Init_ossl_x509crl(void);
+COLDFUNC(void Init_ossl_x509crl(void));
 
 /*
  * X509Extension
@@ -64,7 +64,7 @@ extern VALUE eX509ExtError;
 
 VALUE ossl_x509ext_new(X509_EXTENSION *);
 X509_EXTENSION *GetX509ExtPtr(VALUE);
-void Init_ossl_x509ext(void);
+COLDFUNC(void Init_ossl_x509ext(void));
 
 /*
  * X509Name
@@ -74,7 +74,7 @@ extern VALUE eX509NameError;
 
 VALUE ossl_x509name_new(X509_NAME *);
 X509_NAME *GetX509NamePtr(VALUE);
-void Init_ossl_x509name(void);
+COLDFUNC(void Init_ossl_x509name(void));
 
 /*
  * X509Request
@@ -83,7 +83,7 @@ extern VALUE cX509Req;
 extern VALUE eX509ReqError;
 
 X509_REQ *GetX509ReqPtr(VALUE);
-void Init_ossl_x509req(void);
+COLDFUNC(void Init_ossl_x509req(void));
 
 /*
  * X509Revoked
@@ -93,7 +93,7 @@ extern VALUE eX509RevError;
 
 VALUE ossl_x509revoked_new(X509_REVOKED *);
 X509_REVOKED *DupX509RevokedPtr(VALUE);
-void Init_ossl_x509revoked(void);
+COLDFUNC(void Init_ossl_x509revoked(void));
 
 /*
  * X509Store and X509StoreContext
@@ -104,7 +104,7 @@ extern VALUE eX509StoreError;
 
 X509_STORE *GetX509StorePtr(VALUE);
 
-void Init_ossl_x509store(void);
+COLDFUNC(void Init_ossl_x509store(void));
 
 /*
  * Calls the verify callback Proc (the first parameter) with given pre-verify

--- a/ext/pathname/pathname.c
+++ b/ext/pathname/pathname.c
@@ -1505,6 +1505,7 @@ path_f_pathname(VALUE self, VALUE str)
  * anyway, and its documentation (e.g. through +ri+) will contain more
  * information.  In some cases, a brief description will follow.
  */
+COLDFUNC(void Init_pathname(void));
 void
 Init_pathname(void)
 {

--- a/ext/psych/psych_emitter.h
+++ b/ext/psych/psych_emitter.h
@@ -3,6 +3,6 @@
 
 #include <psych.h>
 
-void Init_psych_emitter(void);
+COLDFUNC(void Init_psych_emitter(void));
 
 #endif

--- a/ext/psych/psych_parser.h
+++ b/ext/psych/psych_parser.h
@@ -1,6 +1,6 @@
 #ifndef PSYCH_PARSER_H
 #define PSYCH_PARSER_H
 
-void Init_psych_parser(void);
+COLDFUNC(void Init_psych_parser(void));
 
 #endif

--- a/ext/psych/psych_to_ruby.h
+++ b/ext/psych/psych_to_ruby.h
@@ -3,6 +3,6 @@
 
 #include <psych.h>
 
-void Init_psych_to_ruby(void);
+COLDFUNC(void Init_psych_to_ruby(void));
 
 #endif

--- a/ext/psych/psych_yaml_tree.h
+++ b/ext/psych/psych_yaml_tree.h
@@ -3,6 +3,6 @@
 
 #include <psych.h>
 
-void Init_psych_yaml_tree(void);
+COLDFUNC(void Init_psych_yaml_tree(void));
 
 #endif

--- a/ext/psych/yaml/api.c
+++ b/ext/psych/yaml/api.c
@@ -192,7 +192,7 @@ yaml_parser_initialize(yaml_parser_t *parser)
 
     return 1;
 
-error:
+error: COLDLABEL
 
     BUFFER_DEL(parser, parser->raw_buffer);
     BUFFER_DEL(parser, parser->buffer);
@@ -366,7 +366,7 @@ yaml_emitter_initialize(yaml_emitter_t *emitter)
 
     return 1;
 
-error:
+error: COLDLABEL
 
     BUFFER_DEL(emitter, emitter->buffer);
     BUFFER_DEL(emitter, emitter->raw_buffer);
@@ -753,7 +753,7 @@ yaml_document_start_event_initialize(yaml_event_t *event,
 
     return 1;
 
-error:
+error: COLDLABEL
     yaml_free(version_directive_copy);
     while (!STACK_EMPTY(context, tag_directives_copy)) {
         yaml_tag_directive_t value = POP(context, tag_directives_copy);
@@ -853,7 +853,7 @@ yaml_scalar_event_initialize(yaml_event_t *event,
 
     return 1;
 
-error:
+error: COLDLABEL
     yaml_free(anchor_copy);
     yaml_free(tag_copy);
     yaml_free(value_copy);
@@ -893,7 +893,7 @@ yaml_sequence_start_event_initialize(yaml_event_t *event,
 
     return 1;
 
-error:
+error: COLDLABEL
     yaml_free(anchor_copy);
     yaml_free(tag_copy);
 
@@ -948,7 +948,7 @@ yaml_mapping_start_event_initialize(yaml_event_t *event,
 
     return 1;
 
-error:
+error: COLDLABEL
     yaml_free(anchor_copy);
     yaml_free(tag_copy);
 
@@ -1094,7 +1094,7 @@ yaml_document_initialize(yaml_document_t *document,
 
     return 1;
 
-error:
+error: COLDLABEL
     STACK_DEL(&context, nodes);
     yaml_free(version_directive_copy);
     while (!STACK_EMPTY(&context, tag_directives_copy)) {
@@ -1229,7 +1229,7 @@ yaml_document_add_scalar(yaml_document_t *document,
 
     return document->nodes.top - document->nodes.start;
 
-error:
+error: COLDLABEL
     yaml_free(tag_copy);
     yaml_free(value_copy);
 
@@ -1274,7 +1274,7 @@ yaml_document_add_sequence(yaml_document_t *document,
 
     return document->nodes.top - document->nodes.start;
 
-error:
+error: COLDLABEL
     STACK_DEL(&context, items);
     yaml_free(tag_copy);
 
@@ -1319,7 +1319,7 @@ yaml_document_add_mapping(yaml_document_t *document,
 
     return document->nodes.top - document->nodes.start;
 
-error:
+error: COLDLABEL
     STACK_DEL(&context, pairs);
     yaml_free(tag_copy);
 

--- a/ext/psych/yaml/dumper.c
+++ b/ext/psych/yaml/dumper.c
@@ -152,7 +152,7 @@ yaml_emitter_dump(yaml_emitter_t *emitter, yaml_document_t *document)
 
     return 1;
 
-error:
+error: COLDLABEL
 
     yaml_emitter_delete_document_and_anchors(emitter);
 

--- a/ext/psych/yaml/emitter.c
+++ b/ext/psych/yaml/emitter.c
@@ -389,7 +389,7 @@ yaml_emitter_append_tag_directive(yaml_emitter_t *emitter,
 
     return 1;
 
-error:
+error: COLDLABEL
     yaml_free(copy.handle);
     yaml_free(copy.prefix);
     return 0;

--- a/ext/psych/yaml/loader.c
+++ b/ext/psych/yaml/loader.c
@@ -102,7 +102,7 @@ yaml_parser_load(yaml_parser_t *parser, yaml_document_t *document)
 
     return 1;
 
-error:
+error: COLDLABEL
 
     yaml_parser_delete_aliases(parser);
     yaml_document_delete(document);
@@ -307,7 +307,7 @@ yaml_parser_load_scalar(yaml_parser_t *parser, yaml_event_t *first_event)
 
     return index;
 
-error:
+error: COLDLABEL
     yaml_free(tag);
     yaml_free(first_event->data.scalar.anchor);
     yaml_free(first_event->data.scalar.value);
@@ -370,7 +370,7 @@ yaml_parser_load_sequence(yaml_parser_t *parser, yaml_event_t *first_event)
 
     return index;
 
-error:
+error: COLDLABEL
     yaml_free(tag);
     yaml_free(first_event->data.sequence_start.anchor);
     return 0;
@@ -436,7 +436,7 @@ yaml_parser_load_mapping(yaml_parser_t *parser, yaml_event_t *first_event)
 
     return index;
 
-error:
+error: COLDLABEL
     yaml_free(tag);
     yaml_free(first_event->data.mapping_start.anchor);
     return 0;

--- a/ext/psych/yaml/parser.c
+++ b/ext/psych/yaml/parser.c
@@ -419,7 +419,7 @@ yaml_parser_parse_document_start(yaml_parser_t *parser, yaml_event_t *event,
         return 1;
     }
 
-error:
+error: COLDLABEL
     yaml_free(version_directive);
     while (tag_directives.start != tag_directives.end) {
         yaml_free(tag_directives.end[-1].handle);
@@ -707,7 +707,7 @@ yaml_parser_parse_node(yaml_parser_t *parser, yaml_event_t *event,
         }
     }
 
-error:
+error: COLDLABEL
     yaml_free(anchor);
     yaml_free(tag_handle);
     yaml_free(tag_suffix);
@@ -1318,7 +1318,7 @@ yaml_parser_process_directives(yaml_parser_t *parser,
 
     return 1;
 
-error:
+error: COLDLABEL
     yaml_free(version_directive);
     while (!STACK_EMPTY(parser, tag_directives)) {
         yaml_tag_directive_t tag_directive = POP(parser, tag_directives);
@@ -1362,7 +1362,7 @@ yaml_parser_append_tag_directive(yaml_parser_t *parser,
 
     return 1;
 
-error:
+error: COLDLABEL
     yaml_free(copy.handle);
     yaml_free(copy.prefix);
     return 0;

--- a/ext/psych/yaml/scanner.c
+++ b/ext/psych/yaml/scanner.c
@@ -2090,7 +2090,7 @@ yaml_parser_scan_directive(yaml_parser_t *parser, yaml_token_t *token)
 
     return 1;
 
-error:
+error: COLDLABEL
     yaml_free(prefix);
     yaml_free(handle);
     yaml_free(name);
@@ -2145,7 +2145,7 @@ yaml_parser_scan_directive_name(yaml_parser_t *parser,
 
     return 1;
 
-error:
+error: COLDLABEL
     STRING_DEL(parser, string);
     return 0;
 }
@@ -2310,7 +2310,7 @@ yaml_parser_scan_tag_directive_value(yaml_parser_t *parser,
 
     return 1;
 
-error:
+error: COLDLABEL
     yaml_free(handle_value);
     yaml_free(prefix_value);
     return 0;
@@ -2373,7 +2373,7 @@ yaml_parser_scan_anchor(yaml_parser_t *parser, yaml_token_t *token,
 
     return 1;
 
-error:
+error: COLDLABEL
     STRING_DEL(parser, string);
     return 0;
 }
@@ -2487,7 +2487,7 @@ yaml_parser_scan_tag(yaml_parser_t *parser, yaml_token_t *token)
 
     return 1;
 
-error:
+error: COLDLABEL
     yaml_free(handle);
     yaml_free(suffix);
     return 0;
@@ -2555,7 +2555,7 @@ yaml_parser_scan_tag_handle(yaml_parser_t *parser, int directive,
 
     return 1;
 
-error:
+error: COLDLABEL
     STRING_DEL(parser, string);
     return 0;
 }
@@ -2650,7 +2650,7 @@ yaml_parser_scan_tag_uri(yaml_parser_t *parser, int directive,
 
     return 1;
 
-error:
+error: COLDLABEL
     STRING_DEL(parser, string);
     return 0;
 }
@@ -2937,7 +2937,7 @@ yaml_parser_scan_block_scalar(yaml_parser_t *parser, yaml_token_t *token,
 
     return 1;
 
-error:
+error: COLDLABEL
     STRING_DEL(parser, string);
     STRING_DEL(parser, leading_break);
     STRING_DEL(parser, trailing_breaks);
@@ -3367,7 +3367,7 @@ yaml_parser_scan_flow_scalar(yaml_parser_t *parser, yaml_token_t *token,
 
     return 1;
 
-error:
+error: COLDLABEL
     STRING_DEL(parser, string);
     STRING_DEL(parser, leading_break);
     STRING_DEL(parser, trailing_breaks);
@@ -3563,7 +3563,7 @@ yaml_parser_scan_plain_scalar(yaml_parser_t *parser, yaml_token_t *token)
 
     return 1;
 
-error:
+error: COLDLABEL
     STRING_DEL(parser, string);
     STRING_DEL(parser, leading_break);
     STRING_DEL(parser, trailing_breaks);

--- a/ext/psych/yaml/yaml_private.h
+++ b/ext/psych/yaml/yaml_private.h
@@ -2,6 +2,8 @@
 #include RUBY_EXTCONF_H
 #endif
 
+#include <ruby.h>
+
 #if HAVE_CONFIG_H
 #include <config.h>
 #endif

--- a/ext/pty/pty.c
+++ b/ext/pty/pty.c
@@ -285,7 +285,7 @@ get_device_once(int *master, int *slave, char SlaveName[DEVICELEN], int nomesg, 
     strlcpy(SlaveName, slavedevice, DEVICELEN);
     return 0;
 
-  error:
+  error: COLDLABEL
     if (slavefd != -1) close(slavefd);
     if (masterfd != -1) close(masterfd);
     if (fail) {
@@ -362,7 +362,7 @@ get_device_once(int *master, int *slave, char SlaveName[DEVICELEN], int nomesg, 
     strlcpy(SlaveName, slavedevice, DEVICELEN);
     return 0;
 
-  error:
+  error: COLDLABEL
     if (slavefd != -1) close(slavefd);
     if (masterfd != -1) close(masterfd);
     if (fail) rb_raise(rb_eRuntimeError, "can't get Master/Slave device");
@@ -418,7 +418,7 @@ get_device_once(int *master, int *slave, char SlaveName[DEVICELEN], int nomesg, 
 	    close(masterfd);
 	}
     }
-  error:
+  error: COLDLABEL
     if (slavefd != -1) close(slavefd);
     if (masterfd != -1) close(masterfd);
     if (fail) rb_raise(rb_eRuntimeError, "can't get %s", SlaveName);
@@ -736,6 +736,7 @@ static VALUE cPTY;
  *  results obtained from use of this software.
  */
 
+COLDFUNC(void Init_pty(void));
 void
 Init_pty(void)
 {

--- a/ext/racc/cparse/cparse.c
+++ b/ext/racc/cparse/cparse.c
@@ -591,7 +591,7 @@ parse_main(struct cparse_params *v, VALUE tok, VALUE val, int resume)
     return;
 
 
-  error:
+  error: COLDLABEL
     D_printf("error detected, status=%ld\n", v->errstatus);
     if (v->errstatus == 0) {
         v->nerr++;
@@ -812,6 +812,7 @@ reduce0(VALUE val, VALUE data, VALUE self)
                           Ruby Interface
 ----------------------------------------------------------------------- */
 
+COLDFUNC(void Init_cparse(void));
 void
 Init_cparse(void)
 {

--- a/ext/readline/readline.c
+++ b/ext/readline/readline.c
@@ -1885,6 +1885,7 @@ username_completion_proc_call(VALUE self, VALUE str)
 }
 
 #undef rb_intern
+COLDFUNC(void Init_readline(void));
 void
 Init_readline(void)
 {

--- a/ext/sdbm/_sdbm.c
+++ b/ext/sdbm/_sdbm.c
@@ -252,7 +252,7 @@ sdbm_prep(char *dirname, char *pagname, int flags, int mode)
  */
         return db;
 
-    err:
+    err: COLDLABEL
         if (db->pagf != -1)
                 (void) close(db->pagf);
         if (db->dirf != -1)

--- a/ext/sdbm/init.c
+++ b/ext/sdbm/init.c
@@ -1012,6 +1012,7 @@ fsdbm_reject(VALUE obj)
     return rb_hash_delete_if(fsdbm_to_hash(obj));
 }
 
+COLDFUNC(void Init_sdbm(void));
 void
 Init_sdbm(void)
 {

--- a/ext/socket/ancdata.c
+++ b/ext/socket/ancdata.c
@@ -1691,8 +1691,7 @@ rsock_bsock_recvmsg_nonblock(VALUE sock, VALUE dlen, VALUE flags, VALUE clen,
 }
 #endif
 
-void
-rsock_init_ancdata(void)
+void rsock_init_ancdata(void)
 {
 #if defined(HAVE_STRUCT_MSGHDR_MSG_CONTROL)
     /*

--- a/ext/socket/getaddrinfo.c
+++ b/ext/socket/getaddrinfo.c
@@ -671,7 +671,7 @@ get_addr(const char *hostname, int af, struct addrinfo **res, struct addrinfo *p
 	if (hp)
 		freehostent(hp);
 #endif
- bad:
+ bad: COLDLABEL
 	*res = NULL;
 	return error;
 }

--- a/ext/socket/rubysocket.h
+++ b/ext/socket/rubysocket.h
@@ -376,20 +376,20 @@ ssize_t rsock_recvmsg(int socket, struct msghdr *message, int flags);
 void rsock_discard_cmsg_resource(struct msghdr *mh, int msg_peek_p);
 #endif
 
-void rsock_init_basicsocket(void);
-void rsock_init_ipsocket(void);
-void rsock_init_tcpsocket(void);
-void rsock_init_tcpserver(void);
-void rsock_init_sockssocket(void);
-void rsock_init_udpsocket(void);
-void rsock_init_unixsocket(void);
-void rsock_init_unixserver(void);
-void rsock_init_socket_constants(void);
-void rsock_init_ancdata(void);
-void rsock_init_addrinfo(void);
-void rsock_init_sockopt(void);
-void rsock_init_sockifaddr(void);
-void rsock_init_socket_init(void);
+COLDFUNC(void rsock_init_basicsocket(void));
+COLDFUNC(void rsock_init_ipsocket(void));
+COLDFUNC(void rsock_init_tcpsocket(void));
+COLDFUNC(void rsock_init_tcpserver(void));
+COLDFUNC(void rsock_init_sockssocket(void));
+COLDFUNC(void rsock_init_udpsocket(void));
+COLDFUNC(void rsock_init_unixsocket(void));
+COLDFUNC(void rsock_init_unixserver(void));
+COLDFUNC(void rsock_init_socket_constants(void));
+COLDFUNC(void rsock_init_ancdata(void));
+COLDFUNC(void rsock_init_addrinfo(void));
+COLDFUNC(void rsock_init_sockopt(void));
+COLDFUNC(void rsock_init_sockifaddr(void));
+COLDFUNC(void rsock_init_socket_init(void));
 
 NORETURN(void rsock_syserr_fail_host_port(int err, const char *, VALUE, VALUE));
 NORETURN(void rsock_syserr_fail_path(int err, const char *, VALUE));

--- a/ext/socket/socket.c
+++ b/ext/socket/socket.c
@@ -1369,13 +1369,13 @@ sock_s_getnameinfo(int argc, VALUE *argv)
     }
     return rb_assoc_new(rb_str_new2(hbuf), rb_str_new2(pbuf));
 
-  error_exit_addr:
+  error_exit_addr: COLDLABEL
     saved_errno = errno;
     if (res) rb_freeaddrinfo(res);
     errno = saved_errno;
     rsock_raise_socket_error("getaddrinfo", error);
 
-  error_exit_name:
+  error_exit_name: COLDLABEL
     saved_errno = errno;
     if (res) rb_freeaddrinfo(res);
     errno = saved_errno;
@@ -1929,6 +1929,7 @@ socket_s_ip_address_list(VALUE self)
 #define socket_s_ip_address_list rb_f_notimplement
 #endif
 
+COLDFUNC(void Init_socket(void));
 void
 Init_socket(void)
 {

--- a/ext/syslog/syslog.c
+++ b/ext/syslog/syslog.c
@@ -418,6 +418,7 @@ static VALUE mSyslogMacros_included(VALUE mod, VALUE target)
  *
  * The syslog protocol is standardized in RFC 5424.
  */
+COLDFUNC(void Init_syslog(void));
 void Init_syslog(void)
 {
 #undef rb_intern

--- a/ext/win32/resolv/resolv.c
+++ b/ext/win32/resolv/resolv.c
@@ -58,6 +58,7 @@ InitVM_resolv(void)
     rb_define_private_method(singl, "get_dns_server_list", get_dns_server_list, 0);
 }
 
+COLDFUNC(void Init_resolv(void));
 void
 Init_resolv(void)
 {

--- a/ext/win32ole/win32ole.c
+++ b/ext/win32ole/win32ole.c
@@ -3975,6 +3975,7 @@ check_nano_server(void)
 }
 
 
+COLDFUNC(void Init_win32ole(void));
 void
 Init_win32ole(void)
 {

--- a/ext/win32ole/win32ole_error.h
+++ b/ext/win32ole/win32ole_error.h
@@ -4,6 +4,6 @@
 VALUE eWIN32OLERuntimeError;
 VALUE eWIN32OLEQueryInterfaceError;
 NORETURN(PRINTF_ARGS(void ole_raise(HRESULT hr, VALUE ecs, const char *fmt, ...), 3, 4));
-void Init_win32ole_error(void);
+COLDFUNC(void Init_win32ole_error(void));
 
 #endif

--- a/ext/win32ole/win32ole_event.c
+++ b/ext/win32ole/win32ole_event.c
@@ -1261,6 +1261,7 @@ fev_get_handler(VALUE self)
     return rb_ivar_get(self, rb_intern("handler"));
 }
 
+COLDFUNC(void Init_win32ole_event(void));
 void
 Init_win32ole_event(void)
 {

--- a/ext/win32ole/win32ole_event.h
+++ b/ext/win32ole/win32ole_event.h
@@ -1,6 +1,6 @@
 #ifndef WIN32OLE_EVENT_H
 #define WIN32OLE_EVENT_H 1
 
-void Init_win32ole_event(void);
+COLDFUNC(void Init_win32ole_event(void));
 
 #endif

--- a/ext/win32ole/win32ole_method.h
+++ b/ext/win32ole/win32ole_method.h
@@ -12,5 +12,5 @@ VALUE folemethod_s_allocate(VALUE klass);
 VALUE ole_methods_from_typeinfo(ITypeInfo *pTypeInfo, int mask);
 VALUE create_win32ole_method(ITypeInfo *pTypeInfo, VALUE name);
 struct olemethoddata *olemethod_data_get_struct(VALUE obj);
-void Init_win32ole_method(void);
+COLDFUNC(void Init_win32ole_method(void));
 #endif

--- a/ext/win32ole/win32ole_param.h
+++ b/ext/win32ole/win32ole_param.h
@@ -2,7 +2,7 @@
 #define WIN32OLE_PARAM_H
 
 VALUE create_win32ole_param(ITypeInfo *pTypeInfo, UINT method_index, UINT index, VALUE name);
-void Init_win32ole_param(void);
+COLDFUNC(void Init_win32ole_param(void));
 
 #endif
 

--- a/ext/win32ole/win32ole_record.h
+++ b/ext/win32ole/win32ole_record.h
@@ -5,6 +5,6 @@ VALUE cWIN32OLE_RECORD;
 void ole_rec2variant(VALUE rec, VARIANT *var);
 void olerecord_set_ivar(VALUE obj, IRecordInfo *pri, void *prec);
 VALUE create_win32ole_record(IRecordInfo *pri, void *prec);
-void Init_win32ole_record(void);
+COLDFUNC(void Init_win32ole_record(void));
 
 #endif

--- a/ext/win32ole/win32ole_type.h
+++ b/ext/win32ole/win32ole_type.h
@@ -4,5 +4,5 @@ VALUE cWIN32OLE_TYPE;
 VALUE create_win32ole_type(ITypeInfo *pTypeInfo, VALUE name);
 ITypeInfo *itypeinfo(VALUE self);
 VALUE ole_type_from_itypeinfo(ITypeInfo *pTypeInfo);
-void Init_win32ole_type(void);
+COLDFUNC(void Init_win32ole_type(void));
 #endif

--- a/ext/win32ole/win32ole_typelib.h
+++ b/ext/win32ole/win32ole_typelib.h
@@ -3,7 +3,7 @@
 
 VALUE cWIN32OLE_TYPELIB;
 
-void Init_win32ole_typelib(void);
+COLDFUNC(void Init_win32ole_typelib(void));
 ITypeLib * itypelib(VALUE self);
 VALUE typelib_file(VALUE ole);
 VALUE create_win32ole_typelib(ITypeLib *pTypeLib);

--- a/ext/win32ole/win32ole_variable.h
+++ b/ext/win32ole/win32ole_variable.h
@@ -3,6 +3,6 @@
 
 VALUE cWIN32OLE_VARIABLE;
 VALUE create_win32ole_variable(ITypeInfo *pTypeInfo, UINT index, VALUE name);
-void Init_win32ole_variable(void);
+COLDFUNC(void Init_win32ole_variable(void));
 
 #endif

--- a/ext/win32ole/win32ole_variant.h
+++ b/ext/win32ole/win32ole_variant.h
@@ -3,7 +3,7 @@
 
 VALUE cWIN32OLE_VARIANT;
 void ole_variant2variant(VALUE val, VARIANT *var);
-void Init_win32ole_variant(void);
+COLDFUNC(void Init_win32ole_variant(void));
 
 #endif
 

--- a/ext/win32ole/win32ole_variant_m.h
+++ b/ext/win32ole/win32ole_variant_m.h
@@ -2,6 +2,6 @@
 #define WIN32OLE_VARIANT_M_H 1
 
 VALUE mWIN32OLE_VARIANT;
-void Init_win32ole_variant_m(void);
+COLDFUNC(void Init_win32ole_variant_m(void));
 
 #endif

--- a/ext/zlib/zlib.c
+++ b/ext/zlib/zlib.c
@@ -291,7 +291,7 @@ static VALUE rb_gzreader_readlines(int, VALUE*, VALUE);
  *   - Zlib::GzipFile::NoFooter
  *
  */
-void Init_zlib(void);
+COLDFUNC(void Init_zlib(void));
 
 /*--------- Exceptions --------*/
 

--- a/file.c
+++ b/file.c
@@ -5005,7 +5005,7 @@ rb_f_test(int argc, VALUE *argv)
     if (argc == 0) rb_check_arity(argc, 2, 3);
     cmd = NUM2CHR(argv[0]);
     if (cmd == 0) {
-      unknown:
+      unknown: COLDLABEL
 	/* unknown command */
 	if (ISPRINT(cmd)) {
 	    rb_raise(rb_eArgError, "unknown command '%s%c'", cmd == '\'' || cmd == '\\' ? "\\" : "", cmd);
@@ -6201,6 +6201,7 @@ const char ruby_null_device[] =
  *  Various constants for the methods in File can be found in File::Constants.
  */
 
+COLDFUNC(void Init_File(void));
 void
 Init_File(void)
 {

--- a/gc.c
+++ b/gc.c
@@ -6651,6 +6651,7 @@ garbage_collect_with_gvl(rb_objspace_t *objspace, int reason)
 
 #undef Init_stack
 
+COLDFUNC(void Init_stack(volatile VALUE *addr));
 void
 Init_stack(volatile VALUE *addr)
 {
@@ -7648,6 +7649,7 @@ rb_objspace_reachable_objects_from_root(void (func)(const char *category, VALUE,
 
 static void objspace_xfree(rb_objspace_t *objspace, void *ptr, size_t size);
 
+COLDFUNC(static void *negative_size_allocation_error_with_gvl(void *ptr));
 static void *
 negative_size_allocation_error_with_gvl(void *ptr)
 {
@@ -7655,6 +7657,7 @@ negative_size_allocation_error_with_gvl(void *ptr)
     return 0; /* should not be reached */
 }
 
+COLDFUNC(static void negative_size_allocation_error(const char *msg));
 static void
 negative_size_allocation_error(const char *msg)
 {
@@ -9780,6 +9783,7 @@ rb_gcdebug_remove_stress_to_class(int argc, VALUE *argv, VALUE self)
  *  GC::Profiler.
  */
 
+COLDFUNC(void Init_GC(void));
 void
 Init_GC(void)
 {

--- a/hash.c
+++ b/hash.c
@@ -508,7 +508,7 @@ rb_hash_modify(VALUE hash)
     hash_tbl(hash);
 }
 
-NORETURN(static void no_new_key(void));
+NORETURN(COLDFUNC(static void no_new_key(void)));
 static void
 no_new_key(void)
 {
@@ -3651,7 +3651,7 @@ ruby_setenv(const char *name, const char *value)
 	    GetLastError() != ERROR_ENVVAR_NOT_FOUND) goto fail;
     }
     if (failed) {
-      fail:
+      fail: COLDLABEL
 	invalid_envname(name);
     }
 #elif defined(HAVE_SETENV) && defined(HAVE_UNSETENV)
@@ -4684,6 +4684,7 @@ env_update(VALUE env, VALUE hash)
  *  See also Object#hash and Object#eql?
  */
 
+COLDFUNC(void Init_Hash(void));
 void
 Init_Hash(void)
 {

--- a/include/ruby/defines.h
+++ b/include/ruby/defines.h
@@ -29,8 +29,11 @@ extern "C" {
 #ifndef PUREFUNC
 # define PUREFUNC(x) x
 #endif
-#ifndef DEPRECATED
-# define DEPRECATED(x) x
+#ifndef COLDFUNC
+# define COLDFUNC(x) x
+#endif
+#ifndef HOTFUNC
+# define HOTFUNC(x) x
 #endif
 #ifndef DEPRECATED_BY
 # define DEPRECATED_BY(n,x) DEPRECATED(x)
@@ -88,6 +91,13 @@ extern "C" {
 #define RB_LIKELY(x)   (x)
 #define RB_UNLIKELY(x) (x)
 #endif /* __GNUC__ >= 3 */
+
+/* label attrs */
+#if GCC_VERSION_SINCE(5,0,0)
+# define COLDLABEL __attribute__((__cold__));
+#else
+# define COLDLABEL
+#endif
 
 #ifdef __GNUC__
 #define PRINTF_ARGS(decl, string_index, first_to_check) \

--- a/include/ruby/encoding.h
+++ b/include/ruby/encoding.h
@@ -165,7 +165,7 @@ VALUE rb_str_conv_enc_opts(VALUE str, rb_encoding *from, rb_encoding *to, int ec
 )
 #endif
 
-PRINTF_ARGS(NORETURN(void rb_enc_raise(rb_encoding *, VALUE, const char*, ...)), 3, 4);
+PRINTF_ARGS(NORETURN(COLDFUNC(void rb_enc_raise(rb_encoding *, VALUE, const char*, ...))), 3, 4);
 
 /* index -> rb_encoding */
 rb_encoding *rb_enc_from_index(int idx);
@@ -327,7 +327,6 @@ int rb_econv_set_replacement(rb_econv_t *ec, const unsigned char *str, size_t le
 /* result: 0:success -1:failure */
 int rb_econv_decorate_at_first(rb_econv_t *ec, const char *decorator_name);
 int rb_econv_decorate_at_last(rb_econv_t *ec, const char *decorator_name);
-
 VALUE rb_econv_open_exc(const char *senc, const char *denc, int ecflags);
 
 /* result: 0:success -1:failure */

--- a/include/ruby/intern.h
+++ b/include/ruby/intern.h
@@ -210,7 +210,7 @@ void rb_define_singleton_method(VALUE, const char*, VALUE(*)(ANYARGS), int);
 VALUE rb_singleton_class(VALUE);
 /* compar.c */
 int rb_cmpint(VALUE, VALUE, VALUE);
-NORETURN(void rb_cmperr(VALUE, VALUE));
+NORETURN(COLDFUNC(void rb_cmperr(VALUE, VALUE)));
 /* cont.c */
 VALUE rb_fiber_new(VALUE (*)(ANYARGS), VALUE);
 VALUE rb_fiber_resume(VALUE fib, int argc, const VALUE *argv);
@@ -241,14 +241,14 @@ VALUE rb_exc_new_cstr(VALUE, const char*);
 VALUE rb_exc_new_str(VALUE, VALUE);
 #define rb_exc_new2 rb_exc_new_cstr
 #define rb_exc_new3 rb_exc_new_str
-PRINTF_ARGS(NORETURN(void rb_loaderror(const char*, ...)), 1, 2);
-PRINTF_ARGS(NORETURN(void rb_loaderror_with_path(VALUE path, const char*, ...)), 2, 3);
-PRINTF_ARGS(NORETURN(void rb_name_error(ID, const char*, ...)), 2, 3);
-PRINTF_ARGS(NORETURN(void rb_name_error_str(VALUE, const char*, ...)), 2, 3);
-NORETURN(void rb_invalid_str(const char*, const char*));
-NORETURN(void rb_error_frozen(const char*));
-NORETURN(void rb_error_frozen_object(VALUE));
-void rb_error_untrusted(VALUE);
+PRINTF_ARGS(NORETURN(COLDFUNC(void rb_loaderror(const char*, ...))), 1, 2);
+PRINTF_ARGS(NORETURN(COLDFUNC(void rb_loaderror_with_path(VALUE path, const char*, ...))), 2, 3);
+PRINTF_ARGS(NORETURN(COLDFUNC(void rb_name_error(ID, const char*, ...))), 2, 3);
+PRINTF_ARGS(NORETURN(COLDFUNC(void rb_name_error_str(VALUE, const char*, ...))), 2, 3);
+NORETURN(COLDFUNC(void rb_invalid_str(const char*, const char*)));
+NORETURN(COLDFUNC(void rb_error_frozen(const char*)));
+NORETURN(COLDFUNC(void rb_error_frozen_object(VALUE)));
+COLDFUNC(void rb_error_untrusted(VALUE));
 void rb_check_frozen(VALUE);
 void rb_check_trusted(VALUE);
 #define rb_check_frozen_internal(obj) do { \
@@ -286,7 +286,7 @@ int rb_sourceline(void);
 const char *rb_sourcefile(void);
 VALUE rb_check_funcall(VALUE, ID, int, const VALUE*);
 
-NORETURN(void rb_error_arity(int, int, int));
+NORETURN(COLDFUNC(void rb_error_arity(int, int, int)));
 static inline int
 rb_check_arity(int argc, int min, int max)
 {
@@ -367,10 +367,10 @@ typedef fd_set rb_fdset_t;
 
 #endif
 
-NORETURN(void rb_exc_raise(VALUE));
-NORETURN(void rb_exc_fatal(VALUE));
-NORETURN(VALUE rb_f_exit(int, const VALUE*));
-NORETURN(VALUE rb_f_abort(int, const VALUE*));
+NORETURN(COLDFUNC(void rb_exc_raise(VALUE)));
+NORETURN(COLDFUNC(void rb_exc_fatal(VALUE)));
+NORETURN(COLDFUNC(VALUE rb_f_exit(int, const VALUE*)));
+NORETURN(COLDFUNC(VALUE rb_f_abort(int, const VALUE*)));
 void rb_remove_method(VALUE, const char*);
 void rb_remove_method_id(VALUE, ID);
 #define HAVE_RB_DEFINE_ALLOC_FUNC 1
@@ -387,12 +387,12 @@ int rb_method_basic_definition_p(VALUE, ID);
 VALUE rb_eval_cmd(VALUE, VALUE, int);
 int rb_obj_respond_to(VALUE, ID, int);
 int rb_respond_to(VALUE, ID);
-NORETURN(VALUE rb_f_notimplement(int argc, const VALUE *argv, VALUE obj));
+NORETURN(COLDFUNC(VALUE rb_f_notimplement(int argc, const VALUE *argv, VALUE obj)));
 #if !defined(RUBY_EXPORT) && defined(_WIN32)
-RUBY_EXTERN VALUE (*const rb_f_notimplement_)(int, const VALUE *, VALUE);
+COLDFUNC(RUBY_EXTERN VALUE (*const rb_f_notimplement_)(int, const VALUE *, VALUE));
 #define rb_f_notimplement (*rb_f_notimplement_)
 #endif
-NORETURN(void rb_interrupt(void));
+NORETURN(COLDFUNC(void rb_interrupt(void)));
 VALUE rb_apply(VALUE, ID, VALUE);
 void rb_backtrace(void);
 ID rb_frame_this_func(void);
@@ -470,7 +470,7 @@ VALUE rb_file_directory_p(VALUE,VALUE);
 VALUE rb_str_encode_ospath(VALUE);
 int rb_is_absolute_path(const char *);
 /* gc.c */
-NORETURN(void rb_memerror(void));
+NORETURN(COLDFUNC(void rb_memerror(void)));
 PUREFUNC(int rb_during_gc(void));
 void rb_gc_mark_locations(const VALUE*, const VALUE*);
 void rb_mark_tbl(struct st_table*);
@@ -542,8 +542,8 @@ VALUE rb_io_get_io(VALUE);
 VALUE rb_file_open(const char*, const char*);
 VALUE rb_file_open_str(VALUE, const char*);
 VALUE rb_gets(void);
-void rb_write_error(const char*);
-void rb_write_error2(const char*, long);
+COLDFUNC(void rb_write_error(const char*));
+COLDFUNC(void rb_write_error2(const char*, long));
 void rb_close_before_exec(int lowfd, int maxhint, VALUE noclose_fds);
 int rb_pipe(int *pipes);
 int rb_reserved_fd_p(int fd);
@@ -560,7 +560,7 @@ VALUE rb_marshal_dump(VALUE, VALUE);
 VALUE rb_marshal_load(VALUE);
 void rb_marshal_define_compat(VALUE newclass, VALUE oldclass, VALUE (*dumper)(VALUE), VALUE (*loader)(VALUE, VALUE));
 /* numeric.c */
-NORETURN(void rb_num_zerodiv(void));
+NORETURN(COLDFUNC(void rb_num_zerodiv(void)));
 #define RB_NUM_COERCE_FUNCS_NEED_OPID 1
 VALUE rb_num_coerce_bin(VALUE, VALUE, ID);
 VALUE rb_num_coerce_cmp(VALUE, VALUE, ID);
@@ -630,7 +630,7 @@ NORETURN(VALUE rb_f_exec(int, const VALUE*));
 rb_pid_t rb_waitpid(rb_pid_t pid, int *status, int flags);
 void rb_syswait(rb_pid_t pid);
 rb_pid_t rb_spawn(int, const VALUE*);
-rb_pid_t rb_spawn_err(int, const VALUE*, char*, size_t);
+COLDFUNC(rb_pid_t rb_spawn_err(int, const VALUE*, char*, size_t));
 VALUE rb_proc_times(VALUE);
 VALUE rb_detach_process(rb_pid_t pid);
 /* range.c */

--- a/include/ruby/io.h
+++ b/include/ruby/io.h
@@ -160,7 +160,7 @@ ssize_t rb_io_bufwrite(VALUE io, const void *buf, size_t size);
 #define rb_io_modenum_flags(oflags) [<"rb_io_modenum_flags() is obsolete; use rb_io_oflags_fmode()">]
 
 VALUE rb_io_taint_check(VALUE);
-NORETURN(void rb_eof_error(void));
+NORETURN(COLDFUNC(void rb_eof_error(void)));
 
 void rb_io_read_check(rb_io_t*);
 int rb_io_read_pending(rb_io_t*);

--- a/include/ruby/onigmo.h
+++ b/include/ruby/onigmo.h
@@ -814,8 +814,13 @@ ONIG_EXTERN
 int onig_initialize(OnigEncoding encodings[], int n);
 ONIG_EXTERN
 int onig_init(void);
+#ifdef RUBY
 ONIG_EXTERN
 int onig_error_code_to_str(OnigUChar* s, OnigPosition err_code, ...);
+#else
+ONIG_EXTERN
+int onig_error_code_to_str(OnigUChar* s, OnigPosition err_code, ...);
+#endif
 ONIG_EXTERN
 void onig_set_warn_func(OnigWarnFunc f);
 ONIG_EXTERN

--- a/include/ruby/ruby.h
+++ b/include/ruby/ruby.h
@@ -313,7 +313,7 @@ VALUE rb_ull2inum(unsigned LONG_LONG);
 #endif
 
 #if SIZEOF_INT < SIZEOF_VALUE
-NORETURN(void rb_out_of_int(SIGNED_VALUE num));
+NORETURN(COLDFUNC(void rb_out_of_int(SIGNED_VALUE num)));
 #endif
 
 #if SIZEOF_INT < SIZEOF_LONG
@@ -641,7 +641,7 @@ int ruby_safe_level_2_warning(void) __attribute__((const,warning("$SAFE=2 to 4 a
 #endif
 void rb_set_safe_level_force(int);
 void rb_secure_update(VALUE);
-NORETURN(void rb_insecure_operation(void));
+NORETURN(COLDFUNC(void rb_insecure_operation(void)));
 
 VALUE rb_errinfo(void);
 void rb_set_errinfo(VALUE);
@@ -1852,34 +1852,34 @@ enum rb_io_wait_readwrite {RB_IO_WAIT_READABLE, RB_IO_WAIT_WRITABLE};
 #define RB_IO_WAIT_READABLE RB_IO_WAIT_READABLE
 #define RB_IO_WAIT_WRITABLE RB_IO_WAIT_WRITABLE
 
-PRINTF_ARGS(NORETURN(void rb_raise(VALUE, const char*, ...)), 2, 3);
-PRINTF_ARGS(NORETURN(void rb_fatal(const char*, ...)), 1, 2);
-PRINTF_ARGS(NORETURN(void rb_bug(const char*, ...)), 1, 2);
-NORETURN(void rb_bug_errno(const char*, int));
-NORETURN(void rb_sys_fail(const char*));
-NORETURN(void rb_sys_fail_str(VALUE));
-NORETURN(void rb_mod_sys_fail(VALUE, const char*));
-NORETURN(void rb_mod_sys_fail_str(VALUE, VALUE));
-NORETURN(void rb_readwrite_sys_fail(enum rb_io_wait_readwrite, const char*));
+PRINTF_ARGS(NORETURN(COLDFUNC(void rb_raise(VALUE, const char*, ...))), 2, 3);
+PRINTF_ARGS(NORETURN(COLDFUNC(void rb_fatal(const char*, ...))), 1, 2);
+PRINTF_ARGS(NORETURN(COLDFUNC(void rb_bug(const char*, ...))), 1, 2);
+NORETURN(COLDFUNC(void rb_bug_errno(const char*, int)));
+NORETURN(COLDFUNC(void rb_sys_fail(const char*)));
+NORETURN(COLDFUNC(void rb_sys_fail_str(VALUE)));
+NORETURN(COLDFUNC(void rb_mod_sys_fail(VALUE, const char*)));
+NORETURN(COLDFUNC(void rb_mod_sys_fail_str(VALUE, VALUE)));
+NORETURN(COLDFUNC(void rb_readwrite_sys_fail(enum rb_io_wait_readwrite, const char*)));
 NORETURN(void rb_iter_break(void));
 NORETURN(void rb_iter_break_value(VALUE));
-NORETURN(void rb_exit(int));
-NORETURN(void rb_notimplement(void));
+NORETURN(COLDFUNC(void rb_exit(int)));
+NORETURN(COLDFUNC(void rb_notimplement(void)));
 VALUE rb_syserr_new(int, const char *);
 VALUE rb_syserr_new_str(int n, VALUE arg);
-NORETURN(void rb_syserr_fail(int, const char*));
-NORETURN(void rb_syserr_fail_str(int, VALUE));
-NORETURN(void rb_mod_syserr_fail(VALUE, int, const char*));
-NORETURN(void rb_mod_syserr_fail_str(VALUE, int, VALUE));
-NORETURN(void rb_readwrite_syserr_fail(enum rb_io_wait_readwrite, int, const char*));
+NORETURN(COLDFUNC(void rb_syserr_fail(int, const char*)));
+NORETURN(COLDFUNC(void rb_syserr_fail_str(int, VALUE)));
+NORETURN(COLDFUNC(void rb_mod_syserr_fail(VALUE, int, const char*)));
+NORETURN(COLDFUNC(void rb_mod_syserr_fail_str(VALUE, int, VALUE)));
+NORETURN(COLDFUNC(void rb_readwrite_syserr_fail(enum rb_io_wait_readwrite, int, const char*)));
 
 /* reports if `-W' specified */
-PRINTF_ARGS(void rb_warning(const char*, ...), 1, 2);
-PRINTF_ARGS(void rb_compile_warning(const char *, int, const char*, ...), 3, 4);
-PRINTF_ARGS(void rb_sys_warning(const char*, ...), 1, 2);
+PRINTF_ARGS(COLDFUNC(void rb_warning(const char*, ...)), 1, 2);
+PRINTF_ARGS(COLDFUNC(void rb_compile_warning(const char *, int, const char*, ...)), 3, 4);
+PRINTF_ARGS(COLDFUNC(void rb_sys_warning(const char*, ...)), 1, 2);
 /* reports always */
-PRINTF_ARGS(void rb_warn(const char*, ...), 1, 2);
-PRINTF_ARGS(void rb_compile_warn(const char *, int, const char*, ...), 3, 4);
+PRINTF_ARGS(COLDFUNC(void rb_warn(const char*, ...)), 1, 2);
+PRINTF_ARGS(COLDFUNC(void rb_compile_warn(const char *, int, const char*, ...)), 3, 4);
 
 #define RUBY_BLOCK_CALL_FUNC_TAKES_BLOCKARG 1
 #define RB_BLOCK_CALL_FUNC_ARGLIST(yielded_arg, callback_arg) \

--- a/internal.h
+++ b/internal.h
@@ -1183,7 +1183,7 @@ void rb_fiber_reset_root_local_storage(VALUE);
 void ruby_register_rollback_func_for_ensure(VALUE (*ensure_func)(ANYARGS), VALUE (*rollback_func)(ANYARGS));
 
 /* debug.c */
-PRINTF_ARGS(void ruby_debug_printf(const char*, ...), 1, 2);
+PRINTF_ARGS(COLDFUNC(void ruby_debug_printf(const char*, ...)), 1, 2);
 
 /* dir.c */
 VALUE rb_dir_getwd_ospath(void);
@@ -1215,23 +1215,23 @@ VALUE rb_nmin_run(VALUE obj, VALUE num, int by, int rev, int ary);
 extern VALUE rb_eEAGAIN;
 extern VALUE rb_eEWOULDBLOCK;
 extern VALUE rb_eEINPROGRESS;
-void rb_report_bug_valist(VALUE file, int line, const char *fmt, va_list args);
+COLDFUNC(void rb_report_bug_valist(VALUE file, int line, const char *fmt, va_list args));
 VALUE rb_check_backtrace(VALUE);
-NORETURN(void rb_async_bug_errno(const char *,int));
+NORETURN(COLDFUNC(void rb_async_bug_errno(const char *,int)));
 const char *rb_builtin_type_name(int t);
 const char *rb_builtin_class_name(VALUE x);
-PRINTF_ARGS(void rb_sys_warn(const char *fmt, ...), 1, 2);
-PRINTF_ARGS(void rb_syserr_warn(int err, const char *fmt, ...), 2, 3);
-PRINTF_ARGS(void rb_sys_warning(const char *fmt, ...), 1, 2);
-PRINTF_ARGS(void rb_syserr_warning(int err, const char *fmt, ...), 2, 3);
+PRINTF_ARGS(COLDFUNC(void rb_sys_warn(const char *fmt, ...)), 1, 2);
+PRINTF_ARGS(COLDFUNC(void rb_syserr_warn(int err, const char *fmt, ...)), 2, 3);
+PRINTF_ARGS(COLDFUNC(void rb_sys_warning(const char *fmt, ...)), 1, 2);
+PRINTF_ARGS(COLDFUNC(void rb_syserr_warning(int err, const char *fmt, ...)), 2, 3);
 #ifdef RUBY_ENCODING_H
-VALUE rb_syntax_error_append(VALUE, VALUE, int, int, rb_encoding*, const char*, va_list);
-PRINTF_ARGS(void rb_enc_warn(rb_encoding *enc, const char *fmt, ...), 2, 3);
-PRINTF_ARGS(void rb_sys_enc_warn(rb_encoding *enc, const char *fmt, ...), 2, 3);
-PRINTF_ARGS(void rb_syserr_enc_warn(int err, rb_encoding *enc, const char *fmt, ...), 3, 4);
-PRINTF_ARGS(void rb_enc_warning(rb_encoding *enc, const char *fmt, ...), 2, 3);
-PRINTF_ARGS(void rb_sys_enc_warning(rb_encoding *enc, const char *fmt, ...), 2, 3);
-PRINTF_ARGS(void rb_syserr_enc_warning(int err, rb_encoding *enc, const char *fmt, ...), 3, 4);
+COLDFUNC(VALUE rb_syntax_error_append(VALUE, VALUE, int, int, rb_encoding*, const char*, va_list));
+PRINTF_ARGS(COLDFUNC(void rb_enc_warn(rb_encoding *enc, const char *fmt, ...)), 2, 3);
+PRINTF_ARGS(COLDFUNC(void rb_sys_enc_warn(rb_encoding *enc, const char *fmt, ...)), 2, 3);
+PRINTF_ARGS(COLDFUNC(void rb_syserr_enc_warn(int err, rb_encoding *enc, const char *fmt, ...)), 3, 4);
+PRINTF_ARGS(COLDFUNC(void rb_enc_warning(rb_encoding *enc, const char *fmt, ...)), 2, 3);
+PRINTF_ARGS(COLDFUNC(void rb_sys_enc_warning(rb_encoding *enc, const char *fmt, ...)), 2, 3);
+PRINTF_ARGS(COLDFUNC(void rb_syserr_enc_warning(int err, rb_encoding *enc, const char *fmt, ...)), 3, 4);
 #endif
 
 #define rb_raise_cstr(etype, mesg) \
@@ -1244,14 +1244,14 @@ VALUE rb_name_err_new(VALUE mesg, VALUE recv, VALUE method);
     rb_exc_raise(rb_name_err_new(mesg, recv, name))
 #define rb_name_err_raise(mesg, recv, name) \
     rb_name_err_raise_str(rb_fstring_cstr(mesg), (recv), (name))
-VALUE rb_nomethod_err_new(VALUE mesg, VALUE recv, VALUE method, VALUE args, int priv);
+COLDFUNC(VALUE rb_nomethod_err_new(VALUE mesg, VALUE recv, VALUE method, VALUE args, int priv));
 VALUE rb_key_err_new(VALUE mesg, VALUE recv, VALUE name);
 #define rb_key_err_raise(mesg, recv, name) \
     rb_exc_raise(rb_key_err_new(mesg, recv, name))
-NORETURN(void ruby_deprecated_internal_feature(const char *));
+NORETURN(COLDFUNC(void ruby_deprecated_internal_feature(const char *)));
 #define DEPRECATED_INTERNAL_FEATURE(func) \
     (ruby_deprecated_internal_feature(func), UNREACHABLE)
-VALUE rb_warning_warn(VALUE mod, VALUE str);
+COLDFUNC(VALUE rb_warning_warn(VALUE mod, VALUE str));
 PRINTF_ARGS(VALUE rb_warning_string(const char *fmt, ...), 1, 2);
 
 /* eval.c */
@@ -1303,7 +1303,7 @@ NORETURN(void rb_syserr_fail_path_in(const char *func_name, int err, VALUE path)
 /* gc.c */
 extern VALUE *ruby_initial_gc_stress_ptr;
 extern int ruby_disable_gc;
-void Init_heap(void);
+COLDFUNC(void Init_heap(void));
 void *ruby_mimmalloc(size_t size);
 void ruby_mimfree(void *ptr);
 void rb_objspace_set_event_hook(const rb_event_flag_t event);
@@ -1382,7 +1382,7 @@ void rb_io_fptr_finalize_internal(void *ptr);
 VALUE rb_get_load_path(void);
 VALUE rb_get_expanded_load_path(void);
 int rb_require_internal(VALUE fname, int safe);
-NORETURN(void rb_load_fail(VALUE, const char*));
+NORETURN(COLDFUNC(void rb_load_fail(VALUE, const char*)));
 
 /* loadpath.c */
 extern const char ruby_exec_prefix[];
@@ -1601,7 +1601,7 @@ void rb_obj_copy_ivar(VALUE dest, VALUE obj);
 CONSTFUNC(VALUE rb_obj_equal(VALUE obj1, VALUE obj2));
 CONSTFUNC(VALUE rb_obj_not(VALUE obj));
 VALUE rb_class_search_ancestor(VALUE klass, VALUE super);
-NORETURN(void rb_undefined_alloc(VALUE klass));
+NORETURN(COLDFUNC(void rb_undefined_alloc(VALUE klass)));
 double rb_num_to_dbl(VALUE val);
 VALUE rb_obj_dig(int argc, VALUE *argv, VALUE self, VALUE notfound);
 VALUE rb_immutable_obj_clone(int, VALUE *, VALUE);
@@ -1930,7 +1930,7 @@ PUREFUNC(st_table *rb_vm_fstring_table(void));
 
 
 /* vm_dump.c */
-void rb_print_backtrace(void);
+COLDFUNC(void rb_print_backtrace(void));
 
 /* vm_eval.c */
 void Init_vm_eval(void);
@@ -1964,7 +1964,7 @@ VALUE rb_vm_thread_backtrace(int argc, const VALUE *argv, VALUE thval);
 VALUE rb_vm_thread_backtrace_locations(int argc, const VALUE *argv, VALUE thval);
 
 VALUE rb_make_backtrace(void);
-void rb_backtrace_print_as_bugreport(void);
+COLDFUNC(void rb_backtrace_print_as_bugreport(void));
 int rb_backtrace_p(VALUE obj);
 VALUE rb_backtrace_to_str_ary(VALUE obj);
 VALUE rb_backtrace_to_location_ary(VALUE obj);

--- a/io.c
+++ b/io.c
@@ -4041,7 +4041,7 @@ rb_io_each_codepoint(VALUE io)
 	    rb_yield(UINT2NUM(c));
 	}
 	else if (MBCLEN_INVALID_P(r)) {
-	  invalid:
+	  invalid: COLDLABEL
 	    rb_raise(rb_eArgError, "invalid byte sequence in %s", rb_enc_name(enc));
 	}
 	else if (MBCLEN_NEEDMORE_P(r)) {
@@ -5402,7 +5402,7 @@ rb_io_modestr_fmode(const char *modestr)
 	fmode |= FMODE_WRITABLE | FMODE_APPEND | FMODE_CREATE;
 	break;
       default:
-      error:
+      error: COLDLABEL
 	rb_raise(rb_eArgError, "invalid access mode %s", modestr);
     }
 
@@ -6388,7 +6388,7 @@ linux_get_maxfd(void)
     }
     /* fall through */
 
-  err:
+  err: COLDLABEL
     close(fd);
     return -1;
 }
@@ -7828,7 +7828,6 @@ rb_stderr_to_original_p(void)
 {
     return (rb_stderr == orig_stderr || RFILE(orig_stderr)->fptr->fd < 0);
 }
-
 void
 rb_write_error2(const char *mesg, long len)
 {
@@ -12924,6 +12923,7 @@ rb_readwrite_syserr_fail(enum rb_io_wait_readwrite writable, int n, const char *
  *    puts "Your screen is #{columns} wide and #{rows} tall"
  */
 
+COLDFUNC(void Init_IO(void));
 void
 Init_IO(void)
 {

--- a/iseq.c
+++ b/iseq.c
@@ -3122,6 +3122,7 @@ succ_index_lookup(const struct succ_index_table *sd, int x)
  *  you see.
  */
 
+COLDFUNC(void Init_ISeq(void));
 void
 Init_ISeq(void)
 {

--- a/load.c
+++ b/load.c
@@ -1170,6 +1170,7 @@ rb_f_autoload_p(VALUE obj, VALUE sym)
     return rb_mod_autoload_p(klass, sym);
 }
 
+COLDFUNC(void Init_load(void));
 void
 Init_load(void)
 {

--- a/marshal.c
+++ b/marshal.c
@@ -964,7 +964,7 @@ clear_dump_arg(struct dump_arg *arg)
     }
 }
 
-NORETURN(static inline void io_needed(void));
+NORETURN(COLDFUNC(static inline void io_needed(void)));
 static inline void
 io_needed(void)
 {
@@ -1128,7 +1128,7 @@ static VALUE r_object(struct load_arg *arg);
 static VALUE r_symbol(struct load_arg *arg);
 static VALUE path2class(VALUE path);
 
-NORETURN(static void too_short(void));
+NORETURN(COLDFUNC(static void too_short(void)));
 static void
 too_short(void)
 {
@@ -1189,7 +1189,7 @@ r_byte(struct load_arg *arg)
     return c;
 }
 
-NORETURN(static void long_toobig(int size));
+NORETURN(COLDFUNC(static void long_toobig(int size)));
 
 static void
 long_toobig(int size)
@@ -1646,7 +1646,7 @@ r_object0(struct load_arg *arg, int *ivp, VALUE extmod)
 	    }
 	    v = r_object0(arg, 0, extmod);
 	    if (rb_special_const_p(v) || RB_TYPE_P(v, T_OBJECT) || RB_TYPE_P(v, T_CLASS)) {
-	      format_error:
+	      format_error: COLDLABEL
 		rb_raise(rb_eArgError, "dump format error (user class)");
 	    }
 	    if (RB_TYPE_P(v, T_MODULE) || !RTEST(rb_class_inherited_p(c, RBASIC(v)->klass))) {
@@ -2227,6 +2227,7 @@ rb_marshal_load_with_proc(VALUE port, VALUE proc)
  * Since Marshal.dump outputs a string you can have _dump return a Marshal
  * string which is Marshal.loaded in _load for complex objects.
  */
+COLDFUNC(void Init_marshal(void));
 void
 Init_marshal(void)
 {

--- a/math.c
+++ b/math.c
@@ -1024,6 +1024,7 @@ InitVM_Math(void)
     rb_define_module_function(rb_mMath, "lgamma", math_lgamma, 1);
 }
 
+COLDFUNC(void Init_Math(void));
 void
 Init_Math(void)
 {

--- a/miniinit.c
+++ b/miniinit.c
@@ -38,6 +38,7 @@ Init_enc_set_filesystem_encoding(void)
 
 void rb_encdb_declare(const char *name);
 int rb_encdb_alias(const char *alias, const char *orig);
+COLDFUNC(void Init_enc(void));
 void
 Init_enc(void)
 {

--- a/numeric.c
+++ b/numeric.c
@@ -230,7 +230,7 @@ rb_num_get_rounding_option(VALUE opts)
 		return RUBY_NUM_ROUND_HALF_DOWN;
 	    break;
 	}
-      invalid:
+      invalid: COLDLABEL
 	rb_raise(rb_eArgError, "invalid rounding mode: % "PRIsVALUE, rounding);
     }
   noopt:
@@ -2962,7 +2962,7 @@ rb_fix2int(VALUE val)
 }
 #endif
 
-NORETURN(static void rb_out_of_short(SIGNED_VALUE num));
+NORETURN(COLDFUNC(static void rb_out_of_short(SIGNED_VALUE num)));
 static void
 rb_out_of_short(SIGNED_VALUE num)
 {
@@ -5387,6 +5387,7 @@ rb_int_s_isqrt(VALUE self, VALUE num)
  *   puts tally * 2            #=> "||||"
  *   puts tally > 1            #=> true
  */
+COLDFUNC(void Init_Numeric(void));
 void
 Init_Numeric(void)
 {

--- a/object.c
+++ b/object.c
@@ -763,7 +763,7 @@ class_or_module_required(VALUE c)
 	break;
 
       default:
-      not_class:
+      not_class: COLDLABEL
 	rb_raise(rb_eTypeError, "class or module required");
     }
     return c;
@@ -2444,7 +2444,7 @@ rb_mod_const_get(int argc, VALUE *argv, VALUE mod)
     pend = path + RSTRING_LEN(name);
 
     if (p >= pend || !*p) {
-      wrong_name:
+      wrong_name: COLDLABEL
 	rb_name_err_raise(wrong_constant_name, mod, name);
     }
 
@@ -2602,7 +2602,7 @@ rb_mod_const_defined(int argc, VALUE *argv, VALUE mod)
     pend = path + RSTRING_LEN(name);
 
     if (p >= pend || !*p) {
-      wrong_name:
+      wrong_name: COLDLABEL
 	rb_name_err_raise(wrong_constant_name, mod, name);
     }
 
@@ -2939,7 +2939,7 @@ convert_type(VALUE val, const char *tname, const char *method, int raise)
 }
 
 /*! \private */
-NORETURN(static void conversion_mismatch(VALUE, const char *, const char *, VALUE));
+NORETURN(COLDFUNC(static void conversion_mismatch(VALUE, const char *, const char *, VALUE)));
 static void
 conversion_mismatch(VALUE val, const char *tname, const char *method, VALUE result)
 {
@@ -3142,7 +3142,7 @@ rb_convert_to_integer(VALUE val, int base, int raise_exception)
     if (base != 0) {
         tmp = rb_check_string_type(val);
         if (!NIL_P(tmp)) return rb_str_convert_to_inum(tmp, base, TRUE, raise_exception);
-      arg_error:
+      arg_error: COLDLABEL
         if (!raise_exception) return Qnil;
         rb_raise(rb_eArgError, "base specified for non string value");
     }
@@ -3264,7 +3264,7 @@ rb_cstr_to_dbl_raise(const char *p, int badcheck, int raise, int *error)
     }
     if (p == end) {
         if (badcheck) {
-          bad:
+          bad: COLDLABEL
             if (raise)
                 rb_invalid_str(q, "Float()");
             else {
@@ -4238,6 +4238,7 @@ InitVM_Object(void)
     rb_deprecate_constant(rb_cObject, "FALSE");
 }
 
+COLDFUNC(void Init_Object(void));
 void
 Init_Object(void)
 {

--- a/pack.c
+++ b/pack.c
@@ -1999,6 +1999,7 @@ utf8_to_uv(const char *p, long *lenp)
     return uv;
 }
 
+COLDFUNC(void Init_pack(void));
 void
 Init_pack(void)
 {

--- a/proc.c
+++ b/proc.c
@@ -494,7 +494,7 @@ bind_local_variable_get(VALUE bindval, VALUE sym)
     env = VM_ENV_ENVVAL_PTR(vm_block_ep(&bind->block));
     if ((ptr = get_local_variable_ptr(&env, lid)) == NULL) {
 	sym = ID2SYM(lid);
-      undefined:
+      undefined: COLDLABEL
 	rb_name_err_raise("local variable `%1$s' is not defined for %2$s",
 			  bindval, sym);
     }
@@ -1767,7 +1767,7 @@ rb_obj_singleton_method(VALUE obj, VALUE vid)
     ID id = rb_check_id(&vid);
 
     if (NIL_P(klass) || NIL_P(klass = RCLASS_ORIGIN(klass))) {
-      undef:
+      undef: COLDLABEL
 	rb_name_err_raise("undefined singleton method `%1$s' for `%2$s'",
 			  obj, vid);
     }
@@ -2833,7 +2833,7 @@ proc_binding(VALUE self)
 		break;
 	    }
 	    else {
-	      error:
+	      error: COLDLABEL
 		rb_raise(rb_eArgError, "Can't create Binding from C level Proc");
 		return Qnil;
 	    }
@@ -3065,6 +3065,7 @@ rb_method_curry(int argc, const VALUE *argv, VALUE self)
  *
  */
 
+COLDFUNC(void Init_Proc(void));
 void
 Init_Proc(void)
 {
@@ -3209,6 +3210,7 @@ Init_Proc(void)
  *
  */
 
+COLDFUNC(void Init_Binding(void));
 void
 Init_Binding(void)
 {

--- a/process.c
+++ b/process.c
@@ -1885,7 +1885,7 @@ check_exec_redirect_fd(VALUE v, int iskey)
         fd = fptr->fd;
     }
     else {
-      wrong:
+      wrong: COLDLABEL
         rb_raise(rb_eArgError, "wrong exec redirect");
     }
     if (fd < 0) {
@@ -1949,7 +1949,7 @@ check_exec_redirect(VALUE key, VALUE val, struct rb_execarg *eargp)
             eargp->fd_dup2 = check_exec_redirect1(eargp->fd_dup2, key, param);
         }
         else {
-	  wrong_symbol:
+	  wrong_symbol: COLDLABEL
             rb_raise(rb_eArgError, "wrong exec redirect symbol: %"PRIsVALUE,
                                    val);
         }
@@ -3272,7 +3272,7 @@ run_exec_dup2(VALUE ary, VALUE tmpbuf, struct rb_execarg *sargp, char *errmsg, s
 
     return 0;
 
-  fail:
+  fail: COLDLABEL
     return -1;
 }
 
@@ -8447,6 +8447,7 @@ InitVM_process(void)
     rb_define_module_function(rb_mProcID_Syscall, "issetugid", p_sys_issetugid, 0);
 }
 
+COLDFUNC(void Init_process(void));
 void
 Init_process(void)
 {

--- a/random.c
+++ b/random.c
@@ -1204,6 +1204,7 @@ rand_int(VALUE obj, rb_random_t *rnd, VALUE vmax, int restrictive)
     }
 }
 
+NORETURN(COLDFUNC(static void domain_error(void)));
 static void
 domain_error(void)
 {
@@ -1211,7 +1212,7 @@ domain_error(void)
     rb_exc_raise(rb_class_new_instance(1, &error, rb_eSystemCallError));
 }
 
-NORETURN(static void invalid_argument(VALUE));
+NORETURN(COLDFUNC(static void invalid_argument(VALUE)));
 static void
 invalid_argument(VALUE arg0)
 {
@@ -1563,6 +1564,7 @@ rb_memhash(const void *ptr, long len)
 
 /* Initialize Ruby internal seeds. This function is called at very early stage
  * of Ruby startup. Thus, you can't use Ruby's object. */
+COLDFUNC(void Init_RandomSeedCore(void));
 void
 Init_RandomSeedCore(void)
 {
@@ -1640,6 +1642,7 @@ rb_reset_random_seed(void)
  * of 2**19937-1.
  */
 
+COLDFUNC(void InitVM_Random(void));
 void
 InitVM_Random(void)
 {
@@ -1686,6 +1689,7 @@ InitVM_Random(void)
 }
 
 #undef rb_intern
+COLDFUNC(void Init_Random(void));
 void
 Init_Random(void)
 {

--- a/range.c
+++ b/range.c
@@ -1189,7 +1189,7 @@ rb_range_beg_len(VALUE range, long *begp, long *lenp, long len, int err)
     *lenp = len;
     return Qtrue;
 
-  out_of_range:
+  out_of_range: COLDLABEL
     if (err) {
 	rb_raise(rb_eRangeError, "%ld..%s%ld out of range",
 		 origbeg, excl ? "." : "", origend);
@@ -1469,6 +1469,7 @@ range_alloc(VALUE klass)
  *
  */
 
+COLDFUNC(void Init_Range(void));
 void
 Init_Range(void)
 {

--- a/rational.c
+++ b/rational.c
@@ -2660,6 +2660,7 @@ nurat_s_convert(int argc, VALUE *argv, VALUE klass)
  *    Rational(-8) ** Rational(1, 3)
  *                       #=> (1.0000000000000002+1.7320508075688772i)
  */
+COLDFUNC(void Init_Rational(void));
 void
 Init_Rational(void)
 {

--- a/re.c
+++ b/re.c
@@ -651,7 +651,7 @@ rb_reg_str_with_term(VALUE re, int term)
     return str;
 }
 
-NORETURN(static void rb_reg_raise(const char *s, long len, const char *err, VALUE re));
+NORETURN(COLDFUNC(static void rb_reg_raise(const char *s, long len, const char *err, VALUE re)));
 
 static void
 rb_reg_raise(const char *s, long len, const char *err, VALUE re)
@@ -678,7 +678,7 @@ rb_enc_reg_error_desc(const char *s, long len, rb_encoding *enc, int options, co
     return rb_exc_new3(rb_eRegexpError, desc);
 }
 
-NORETURN(static void rb_enc_reg_raise(const char *s, long len, rb_encoding *enc, int options, const char *err));
+NORETURN(COLDFUNC(static void rb_enc_reg_raise(const char *s, long len, rb_encoding *enc, int options, const char *err)));
 
 static void
 rb_enc_reg_raise(const char *s, long len, rb_encoding *enc, int options, const char *err)
@@ -693,7 +693,7 @@ rb_reg_error_desc(VALUE str, int options, const char *err)
 				 rb_enc_get(str), options, err);
 }
 
-NORETURN(static void rb_reg_raise_str(VALUE str, int options, const char *err));
+NORETURN(COLDFUNC(static void rb_reg_raise_str(VALUE str, int options, const char *err)));
 
 static void
 rb_reg_raise_str(VALUE str, int options, const char *err)
@@ -1357,7 +1357,7 @@ static VALUE
 rb_reg_preprocess(const char *p, const char *end, rb_encoding *enc,
         rb_encoding **fixed_enc, onig_errmsg_buffer err);
 
-NORETURN(static void reg_enc_error(VALUE re, VALUE str));
+NORETURN(COLDFUNC(static void reg_enc_error(VALUE re, VALUE str)));
 
 static void
 reg_enc_error(VALUE re, VALUE str)
@@ -1896,7 +1896,7 @@ name_to_backref_number(struct re_registers *regs, VALUE regexp, const char* name
 	(const unsigned char *)name, (const unsigned char *)name_end, regs);
 }
 
-NORETURN(static void name_to_backref_error(VALUE name));
+NORETURN(COLDFUNC(static void name_to_backref_error(VALUE name)));
 static void
 name_to_backref_error(VALUE name)
 {
@@ -2544,7 +2544,7 @@ unescape_nonascii(const char *p, const char *end, rb_encoding *enc,
     while (p < end) {
         int chlen = rb_enc_precise_mbclen(p, end, enc);
         if (!MBCLEN_CHARFOUND_P(chlen)) {
-          invalid_multibyte:
+          invalid_multibyte: COLDLABEL
             errcpy(err, "invalid multibyte character");
             return -1;
         }
@@ -3996,6 +3996,7 @@ re_warn(const char *s)
  *  :include: doc/regexp.rdoc
  */
 
+COLDFUNC(void Init_Regexp(void));
 void
 Init_Regexp(void)
 {

--- a/regerror.c
+++ b/regerror.c
@@ -245,8 +245,13 @@ static int to_ascii(OnigEncoding enc, UChar *s, UChar *end,
 /* for ONIG_MAX_ERROR_MESSAGE_LEN */
 #define MAX_ERROR_PAR_LEN   30
 
+#ifdef RUBY
 extern int
 onig_error_code_to_str(UChar* s, OnigPosition code, ...)
+#else
+extern int
+onig_error_code_to_str(UChar* s, OnigPosition code, ...)
+#endif
 {
   UChar *p, *q;
   OnigErrorInfo* einfo;
@@ -310,9 +315,15 @@ onig_error_code_to_str(UChar* s, OnigPosition code, ...)
   return (int )len;
 }
 
+#ifdef RUBY
 void
 onig_vsnprintf_with_pattern(UChar buf[], int bufsize, OnigEncoding enc,
                            UChar* pat, UChar* pat_end, const UChar *fmt, va_list args)
+#else
+void
+onig_vsnprintf_with_pattern(UChar buf[], int bufsize, OnigEncoding enc,
+                           UChar* pat, UChar* pat_end, const UChar *fmt, va_list args)
+#endif
 {
   size_t need;
   int n, len;

--- a/regint.h
+++ b/regint.h
@@ -903,8 +903,13 @@ extern void onig_print_statistics(FILE* f);
 # endif
 #endif
 
+#ifdef RUBY
 extern UChar* onig_error_code_to_format(OnigPosition code);
 extern void onig_vsnprintf_with_pattern(UChar buf[], int bufsize, OnigEncoding enc, UChar* pat, UChar* pat_end, const UChar *fmt, va_list args);
+#else
+extern UChar* onig_error_code_to_format(OnigPosition code);
+extern void onig_vsnprintf_with_pattern(UChar buf[], int bufsize, OnigEncoding enc, UChar* pat, UChar* pat_end, const UChar *fmt, va_list args);
+#endif
 extern void onig_snprintf_with_pattern(UChar buf[], int bufsize, OnigEncoding enc, UChar* pat, UChar* pat_end, const UChar *fmt, ...);
 extern int  onig_bbuf_init(BBuf* buf, OnigDistance size);
 extern int  onig_compile(regex_t* reg, const UChar* pattern, const UChar* pattern_end, OnigErrorInfo* einfo);

--- a/regparse.c
+++ b/regparse.c
@@ -2840,8 +2840,14 @@ fetch_name(OnigCodePoint start_code, UChar** src, UChar* end,
 #endif /* USE_NAMED_GROUP */
 
 
+#ifdef RUBY
+COLDFUNC(static void onig_syntax_warn(ScanEnv *env, const char *fmt, ...));
 static void
 onig_syntax_warn(ScanEnv *env, const char *fmt, ...)
+#else
+static void
+onig_syntax_warn(ScanEnv *env, const char *fmt, ...)
+#endif
 {
     va_list args;
     UChar buf[WARN_BUFSIZE];
@@ -7034,9 +7040,15 @@ onig_parse_make_tree(Node** root, const UChar* pattern, const UChar* end,
   return r;
 }
 
+#ifdef RUBY
 extern void
 onig_scan_env_set_error_string(ScanEnv* env, int ecode ARG_UNUSED,
 				UChar* arg, UChar* arg_end)
+#else
+extern void
+onig_scan_env_set_error_string(ScanEnv* env, int ecode ARG_UNUSED,
+				UChar* arg, UChar* arg_end)
+#endif
 {
   env->error     = arg;
   env->error_end = arg_end;

--- a/regparse.h
+++ b/regparse.h
@@ -341,7 +341,11 @@ extern int    onig_renumber_name_table(regex_t* reg, GroupNumRemap* map);
 
 extern int    onig_strncmp(const UChar* s1, const UChar* s2, int n);
 extern void   onig_strcpy(UChar* dest, const UChar* src, const UChar* end);
+#ifdef RUBY
 extern void   onig_scan_env_set_error_string(ScanEnv* env, int ecode, UChar* arg, UChar* arg_end);
+#else
+extern void   onig_scan_env_set_error_string(ScanEnv* env, int ecode, UChar* arg, UChar* arg_end);
+#endif
 extern int    onig_scan_unsigned_number(UChar** src, const UChar* end, OnigEncoding enc);
 extern void   onig_reduce_nested_quantifier(Node* pnode, Node* cnode);
 extern void   onig_node_conv_to_str_node(Node* node, int raw);

--- a/safe.c
+++ b/safe.c
@@ -120,7 +120,8 @@ rb_check_safe_obj(VALUE x)
     }
 }
 
-void
+COLDFUNC(void Init_safe(void));
+ void
 Init_safe(void)
 {
     rb_define_virtual_variable("$SAFE", safe_getter, safe_setter);

--- a/signal.c
+++ b/signal.c
@@ -240,7 +240,7 @@ signm2signo(VALUE *sig_ptr, int negative, int exit, int *prefix_ptr)
 	    prefix += signame_prefix_len;
     }
     if (len <= (long)prefix) {
-      unsupported:
+      unsupported: COLDLABEL
 	if (prefix == signame_prefix_len) {
 	    prefix = 0;
 	}
@@ -1518,6 +1518,7 @@ int ruby_enable_coredump = 0;
  * system dependent. Signal delivery semantics may also vary between
  * systems; in particular signal delivery may not always be reliable.
  */
+COLDFUNC(void Init_signal(void));
 void
 Init_signal(void)
 {

--- a/string.c
+++ b/string.c
@@ -10903,6 +10903,7 @@ rb_to_symbol(VALUE name)
  *
  */
 
+COLDFUNC(void Init_String(void));
 void
 Init_String(void)
 {

--- a/struct.c
+++ b/struct.c
@@ -938,7 +938,7 @@ rb_struct_pos(VALUE s, VALUE *name)
     }
 }
 
-NORETURN(static void invalid_struct_pos(VALUE s, VALUE idx));
+NORETURN(COLDFUNC(static void invalid_struct_pos(VALUE s, VALUE idx)));
 static void
 invalid_struct_pos(VALUE s, VALUE idx)
 {
@@ -1304,6 +1304,7 @@ InitVM_Struct(void)
 }
 
 #undef rb_intern
+COLDFUNC(void Init_Struct(void));
 void
 Init_Struct(void)
 {

--- a/symbol.c
+++ b/symbol.c
@@ -72,6 +72,7 @@ static const struct st_hash_type symhash = {
     rb_str_hash,
 };
 
+COLDFUNC(void Init_sym(void));
 void
 Init_sym(void)
 {

--- a/template/extinit.c.tmpl
+++ b/template/extinit.c.tmpl
@@ -9,6 +9,7 @@
 
 void ruby_init_ext(const char *name, void (*init)(void));
 
+COLDFUNC(void Init_ext(void));
 void Init_ext(void)
 {
 % extinits.each do |f, n|

--- a/template/id.c.tmpl
+++ b/template/id.c.tmpl
@@ -30,6 +30,7 @@ static const struct {
 % end
 };
 
+COLDFUNC(static void Init_id(void));
 static void
 Init_id(void)
 {

--- a/template/limits.c.tmpl
+++ b/template/limits.c.tmpl
@@ -51,6 +51,7 @@
 # include <float.h>
 #endif
 
+COLDFUNC(void Init_limits(void));
 void
 Init_limits(void)
 {

--- a/template/sizes.c.tmpl
+++ b/template/sizes.c.tmpl
@@ -25,7 +25,8 @@ conditions = {
 #endif
 
 % end
-extern void Init_limits(void);
+COLDFUNC(extern void Init_limits(void));
+COLDFUNC(void Init_sizeof(void));
 void
 Init_sizeof(void)
 {

--- a/thread.c
+++ b/thread.c
@@ -648,7 +648,7 @@ thread_cleanup_func(void *th_ptr, int atfork)
     native_thread_destroy(th);
 }
 
-static VALUE rb_threadptr_raise(rb_thread_t *, int, VALUE *);
+COLDFUNC(static VALUE rb_threadptr_raise(rb_thread_t *, int, VALUE *));
 static VALUE rb_thread_to_s(VALUE thread);
 
 void
@@ -2289,6 +2289,7 @@ rb_threadptr_signal_raise(rb_thread_t *th, int sig)
     rb_threadptr_raise(th->vm->main_thread, 2, argv);
 }
 
+COLDFUNC(void rb_threadptr_signal_exit(rb_thread_t *th));
 void
 rb_threadptr_signal_exit(rb_thread_t *th)
 {
@@ -4947,7 +4948,7 @@ exec_recursive(VALUE (*func) (VALUE, VALUE, int), VALUE obj, VALUE pairid, VALUE
 	    }
 	    EC_POP_TAG();
 	    if (!recursive_pop(p.list, p.objid, p.pairid)) {
-	      invalid:
+	      invalid: COLDLABEL
 		rb_raise(rb_eTypeError, "invalid inspect_tbl pair_list "
 			 "for %+"PRIsVALUE" in %+"PRIsVALUE,
 			 sym, rb_thread_current());
@@ -5052,6 +5053,7 @@ rb_thread_backtrace_locations_m(int argc, VALUE *argv, VALUE thval)
  *     note: use sleep to stop forever
  */
 
+COLDFUNC(void Init_Thread(void));
 void
 Init_Thread(void)
 {

--- a/thread_sync.c
+++ b/thread_sync.c
@@ -697,7 +697,7 @@ queue_closed_p(VALUE self)
  *  Queue.  See Queue#close and SizedQueue#close.
  */
 
-NORETURN(static void raise_closed_queue_error(VALUE self));
+NORETURN(COLDFUNC(static void raise_closed_queue_error(VALUE self)));
 
 static void
 raise_closed_queue_error(VALUE self)
@@ -1154,7 +1154,7 @@ rb_szqueue_push(int argc, VALUE *argv, VALUE self)
     }
 
     if (queue_closed_p(self)) {
-      closed:
+      closed: COLDLABEL
 	raise_closed_queue_error(self);
     }
 
@@ -1427,6 +1427,7 @@ rb_condvar_broadcast(VALUE self)
 }
 
 /* :nodoc: */
+COLDFUNC(static VALUE undumpable(VALUE obj));
 static VALUE
 undumpable(VALUE obj)
 {
@@ -1442,6 +1443,7 @@ define_thread_class(VALUE outer, const char *name, VALUE super)
     return klass;
 }
 
+COLDFUNC(static void Init_thread_sync(void));
 static void
 Init_thread_sync(void)
 {

--- a/thread_win32.c
+++ b/thread_win32.c
@@ -142,6 +142,7 @@ ruby_thread_set_native(rb_thread_t *th)
     return TlsSetValue(ruby_native_thread_key, th);
 }
 
+COLDFUNC(void Init_native_thread(rb_thread_t *th));
 void
 Init_native_thread(rb_thread_t *th)
 {

--- a/time.c
+++ b/time.c
@@ -523,7 +523,7 @@ num_exact(VALUE v)
             v = RRATIONAL(v)->num;
     }
     else {
-      typeerror:
+      typeerror: COLDLABEL
 	rb_raise(rb_eTypeError, "can't convert %"PRIsVALUE" into an exact number",
 		 rb_obj_class(v));
     }
@@ -2023,7 +2023,7 @@ utc_offset_arg(VALUE arg)
         int n = 0;
         char *s = RSTRING_PTR(tmp);
         if (!rb_enc_str_asciicompat_p(tmp)) {
-	  invalid_utc_offset:
+	  invalid_utc_offset: COLDLABEL
             rb_raise(rb_eArgError, "\"+HH:MM\" or \"-HH:MM\" expected for utc_offset");
 	}
 	switch (RSTRING_LEN(tmp)) {
@@ -3028,10 +3028,10 @@ find_time_t(struct tm *tptr, int utc_p, time_t *tp)
 
     return NULL;
 
-  out_of_range:
+  out_of_range: COLDLABEL
     return "time out of range";
 
-  error:
+  error: COLDLABEL
     return "gmtime/localtime error";
 }
 
@@ -4896,6 +4896,7 @@ time_load(VALUE klass, VALUE str)
  *    Time.new(2010,10,31).between?(t1, t2) #=> true
  */
 
+COLDFUNC(void Init_Time(void));
 void
 Init_Time(void)
 {

--- a/transcode.c
+++ b/transcode.c
@@ -708,15 +708,15 @@ transcode_restartable0(const unsigned char **in_pos, unsigned char **out_pos,
 	}
 	continue;
 
-      invalid:
+      invalid: COLDLABEL
         SUSPEND(econv_invalid_byte_sequence, 1);
         continue;
 
-      incomplete:
+      incomplete: COLDLABEL
         SUSPEND(econv_incomplete_input, 27);
         continue;
 
-      undef:
+      undef: COLDLABEL
         SUSPEND(econv_undefined_conversion, 2);
         continue;
     }
@@ -1432,7 +1432,7 @@ output_hex_charref(rb_econv_t *ec)
         xfree((void *)utf);
     return 0;
 
-  fail:
+  fail: COLDLABEL
     if (utf_allocated)
         xfree((void *)utf);
     return -1;
@@ -4412,6 +4412,7 @@ ecerr_incomplete_input(VALUE self)
  */
 
 #undef rb_intern
+COLDFUNC(void Init_transcode(void));
 void
 Init_transcode(void)
 {

--- a/variable.c
+++ b/variable.c
@@ -48,6 +48,7 @@ struct ivar_update {
     int iv_extended;
 };
 
+COLDFUNC(void Init_var_tables(void));
 void
 Init_var_tables(void)
 {
@@ -1737,7 +1738,7 @@ rb_obj_remove_instance_variable(VALUE obj, VALUE name)
     UNREACHABLE_RETURN(Qnil);
 }
 
-NORETURN(static void uninitialized_constant(VALUE, VALUE));
+NORETURN(COLDFUNC(static void uninitialized_constant(VALUE, VALUE)));
 static void
 uninitialized_constant(VALUE klass, VALUE name)
 {
@@ -2396,7 +2397,7 @@ rb_const_search(VALUE klass, ID id, int exclude, int recurse, int visibility)
 	goto retry;
     }
 
-  not_found:
+  not_found: COLDLABEL
     GET_EC()->private_const_reference = 0;
     return Qundef;
 }
@@ -3210,7 +3211,7 @@ rb_mod_remove_cvar(VALUE mod, VALUE name)
     st_data_t val, n = id;
 
     if (!id) {
-      not_defined:
+      not_defined: COLDLABEL
 	rb_name_err_raise("class variable %1$s not defined for %2$s",
 			  mod, name);
     }

--- a/version.c
+++ b/version.c
@@ -38,6 +38,7 @@ const char ruby_copyright[] = RUBY_COPYRIGHT;
 const char ruby_engine[] = "ruby";
 
 /*! Defines platform-depended Ruby-level constants */
+COLDFUNC(void Init_version(void));
 void
 Init_version(void)
 {

--- a/vm.c
+++ b/vm.c
@@ -1403,6 +1403,7 @@ make_localjump_error(const char *mesg, VALUE value, int reason)
     return exc;
 }
 
+COLDFUNC(MJIT_FUNC_EXPORTED void rb_vm_localjump_error(const char *mesg, VALUE value, int reason));
 MJIT_FUNC_EXPORTED void
 rb_vm_localjump_error(const char *mesg, VALUE value, int reason)
 {
@@ -2834,6 +2835,7 @@ static VALUE usage_analysis_operand_stop(VALUE self);
 static VALUE usage_analysis_register_stop(VALUE self);
 #endif
 
+COLDFUNC(void Init_VM(void));
 void
 Init_VM(void)
 {
@@ -3148,7 +3150,7 @@ rb_vm_set_progname(VALUE filename)
 }
 
 extern const struct st_hash_type rb_fstring_hash_type;
-
+COLDFUNC(void Init_BareVM(void));
 void
 Init_BareVM(void)
 {
@@ -3172,6 +3174,7 @@ Init_BareVM(void)
     ruby_thread_init_stack(th);
 }
 
+COLDFUNC(void Init_vm_objects(void));
 void
 Init_vm_objects(void)
 {
@@ -3199,6 +3202,7 @@ rb_vm_top_self(void)
     return GET_VM()->top_self;
 }
 
+COLDFUNC(void Init_top_self(void));
 void
 Init_top_self(void)
 {

--- a/vm_args.c
+++ b/vm_args.c
@@ -8,9 +8,9 @@
 
 **********************************************************************/
 
-NORETURN(static void raise_argument_error(rb_execution_context_t *ec, const rb_iseq_t *iseq, const VALUE exc));
-NORETURN(static void argument_arity_error(rb_execution_context_t *ec, const rb_iseq_t *iseq, const int miss_argc, const int min_argc, const int max_argc));
-NORETURN(static void argument_kw_error(rb_execution_context_t *ec, const rb_iseq_t *iseq, const char *error, const VALUE keys));
+NORETURN(COLDFUNC(static void raise_argument_error(rb_execution_context_t *ec, const rb_iseq_t *iseq, const VALUE exc)));
+NORETURN(COLDFUNC(static void argument_arity_error(rb_execution_context_t *ec, const rb_iseq_t *iseq, const int miss_argc, const int min_argc, const int max_argc)));
+NORETURN(COLDFUNC(static void argument_kw_error(rb_execution_context_t *ec, const rb_iseq_t *iseq, const char *error, const VALUE keys)));
 VALUE rb_keyword_error_new(const char *error, VALUE keys); /* class.c */
 static VALUE method_missing(VALUE obj, ID id, int argc, const VALUE *argv,
 			    enum method_missing_reason call_status);

--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -776,6 +776,7 @@ oldbt_bugreport(void *arg, VALUE file, int line, VALUE method)
     }
 }
 
+COLDFUNC(void rb_backtrace_print_as_bugreport(void));
 void
 rb_backtrace_print_as_bugreport(void)
 {
@@ -1008,6 +1009,7 @@ rb_f_caller_locations(int argc, VALUE *argv)
 }
 
 /* called from Init_vm() in vm.c */
+COLDFUNC(void Init_vm_backtrace(void));
 void
 Init_vm_backtrace(void)
 {

--- a/vm_core.h
+++ b/vm_core.h
@@ -1534,14 +1534,14 @@ VALUE rb_proc_alloc(VALUE klass);
 VALUE rb_proc_dup(VALUE self);
 
 /* for debug */
-extern void rb_vmdebug_stack_dump_raw(const rb_execution_context_t *ec, const rb_control_frame_t *cfp);
-extern void rb_vmdebug_debug_print_pre(const rb_execution_context_t *ec, const rb_control_frame_t *cfp, const VALUE *_pc);
-extern void rb_vmdebug_debug_print_post(const rb_execution_context_t *ec, const rb_control_frame_t *cfp);
+COLDFUNC(extern void rb_vmdebug_stack_dump_raw(const rb_execution_context_t *ec, const rb_control_frame_t *cfp));
+COLDFUNC(extern void rb_vmdebug_debug_print_pre(const rb_execution_context_t *ec, const rb_control_frame_t *cfp, const VALUE *_pc));
+COLDFUNC(extern void rb_vmdebug_debug_print_post(const rb_execution_context_t *ec, const rb_control_frame_t *cfp));
 
 #define SDR() rb_vmdebug_stack_dump_raw(GET_EC(), GET_EC()->cfp)
 #define SDR2(cfp) rb_vmdebug_stack_dump_raw(GET_EC(), (cfp))
-void rb_vm_bugreport(const void *);
-NORETURN(void rb_bug_context(const void *, const char *fmt, ...));
+COLDFUNC(void rb_vm_bugreport(const void *));
+NORETURN(COLDFUNC(void rb_bug_context(const void *, const char *fmt, ...)));
 
 /* functions about thread/vm execution */
 RUBY_SYMBOL_EXPORT_BEGIN
@@ -1738,14 +1738,14 @@ VALUE rb_exc_set_backtrace(VALUE exc, VALUE bt);
 int rb_signal_buff_size(void);
 void rb_signal_exec(rb_thread_t *th, int sig);
 void rb_threadptr_check_signal(rb_thread_t *mth);
-void rb_threadptr_signal_raise(rb_thread_t *th, int sig);
-void rb_threadptr_signal_exit(rb_thread_t *th);
+COLDFUNC(void rb_threadptr_signal_raise(rb_thread_t *th, int sig));
+COLDFUNC(void rb_threadptr_signal_exit(rb_thread_t *th));
 void rb_threadptr_execute_interrupts(rb_thread_t *, int);
 void rb_threadptr_interrupt(rb_thread_t *th);
 void rb_threadptr_unlock_all_locking_mutexes(rb_thread_t *th);
 void rb_threadptr_pending_interrupt_clear(rb_thread_t *th);
 void rb_threadptr_pending_interrupt_enque(rb_thread_t *th, VALUE v);
-void rb_ec_error_print(rb_execution_context_t * volatile ec, volatile VALUE errinfo);
+COLDFUNC(void rb_ec_error_print(rb_execution_context_t * volatile ec, volatile VALUE errinfo));
 void rb_execution_context_mark(const rb_execution_context_t *ec);
 void rb_fiber_close(rb_fiber_t *fib);
 void Init_native_thread(rb_thread_t *th);

--- a/vm_debug.h
+++ b/vm_debug.h
@@ -24,10 +24,10 @@ RUBY_SYMBOL_EXPORT_BEGIN
 
 #define bp()     ruby_debug_breakpoint()
 
-VALUE ruby_debug_print_value(int level, int debug_level, const char *header, VALUE v);
-ID    ruby_debug_print_id(int level, int debug_level, const char *header, ID id);
-NODE *ruby_debug_print_node(int level, int debug_level, const char *header, const NODE *node);
-int   ruby_debug_print_indent(int level, int debug_level, int indent_level);
+COLDFUNC(VALUE ruby_debug_print_value(int level, int debug_level, const char *header, VALUE v));
+COLDFUNC(ID    ruby_debug_print_id(int level, int debug_level, const char *header, ID id));
+COLDFUNC(NODE *ruby_debug_print_node(int level, int debug_level, const char *header, const NODE *node));
+COLDFUNC(int  ruby_debug_print_indent(int level, int debug_level, int indent_level));
 void  ruby_debug_breakpoint(void);
 void  ruby_debug_gc_check_func(void);
 void ruby_set_debug_option(const char *str);

--- a/vm_dump.c
+++ b/vm_dump.c
@@ -25,6 +25,7 @@
   ((rb_control_frame_t *)((ec)->vm_stack + (ec)->vm_stack_size) - \
    (rb_control_frame_t *)(cfp))
 
+COLDFUNC(static void control_frame_dump(const rb_execution_context_t *ec, const rb_control_frame_t *cfp));
 static void
 control_frame_dump(const rb_execution_context_t *ec, const rb_control_frame_t *cfp)
 {
@@ -137,6 +138,7 @@ control_frame_dump(const rb_execution_context_t *ec, const rb_control_frame_t *c
     fprintf(stderr, "\n");
 }
 
+COLDFUNC(void rb_vmdebug_stack_dump_raw(const rb_execution_context_t *ec, const rb_control_frame_t *cfp));
 void
 rb_vmdebug_stack_dump_raw(const rb_execution_context_t *ec, const rb_control_frame_t *cfp)
 {
@@ -177,6 +179,7 @@ rb_vmdebug_stack_dump_raw_current(void)
     rb_vmdebug_stack_dump_raw(ec, ec->cfp);
 }
 
+COLDFUNC(void rb_vmdebug_env_dump_raw(const rb_env_t *env, const VALUE *ep));
 void
 rb_vmdebug_env_dump_raw(const rb_env_t *env, const VALUE *ep)
 {
@@ -196,6 +199,7 @@ rb_vmdebug_env_dump_raw(const rb_env_t *env, const VALUE *ep)
     fprintf(stderr, "---------------------------\n");
 }
 
+COLDFUNC(void rb_vmdebug_proc_dump_raw(rb_proc_t *proc));
 void
 rb_vmdebug_proc_dump_raw(rb_proc_t *proc)
 {
@@ -303,6 +307,7 @@ vm_stack_dump_each(const rb_execution_context_t *ec, const rb_control_frame_t *c
 }
 #endif
 
+COLDFUNC(void rb_vmdebug_debug_print_register(const rb_execution_context_t *ec));
 void
 rb_vmdebug_debug_print_register(const rb_execution_context_t *ec)
 {
@@ -330,6 +335,7 @@ rb_vmdebug_thread_dump_regs(VALUE thval)
     rb_vmdebug_debug_print_register(rb_thread_ptr(thval)->ec);
 }
 
+COLDFUNC(void rb_vmdebug_debug_print_pre(const rb_execution_context_t *ec, const rb_control_frame_t *cfp, const VALUE *_pc));
 void
 rb_vmdebug_debug_print_pre(const rb_execution_context_t *ec, const rb_control_frame_t *cfp, const VALUE *_pc)
 {
@@ -359,6 +365,11 @@ rb_vmdebug_debug_print_pre(const rb_execution_context_t *ec, const rb_control_fr
 #endif
 }
 
+#if OPT_STACK_CACHING
+COLDFUNC(void rb_vmdebug_debug_print_post(const rb_execution_context_t *ec, const rb_control_frame_t *cfp, VALUE reg_a, VALUE reg_b));
+#else
+COLDFUNC(void rb_vmdebug_debug_print_post(const rb_execution_context_t *ec, const rb_control_frame_t *cfp));
+#endif
 void
 rb_vmdebug_debug_print_post(const rb_execution_context_t *ec, const rb_control_frame_t *cfp
 #if OPT_STACK_CACHING
@@ -695,6 +706,7 @@ dump_thread(void *arg)
 }
 #endif
 
+COLDFUNC(void rb_print_backtrace(void));
 void
 rb_print_backtrace(void)
 {
@@ -947,6 +959,7 @@ rb_dump_machine_register(const ucontext_t *ctx)
 # define rb_dump_machine_register(ctx) ((void)0)
 #endif /* HAVE_PRINT_MACHINE_REGISTERS */
 
+COLDFUNC(void rb_vm_bugreport(const void *ctx));
 void
 rb_vm_bugreport(const void *ctx)
 {

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -539,7 +539,7 @@ rb_method_call_status(rb_execution_context_t *ec, const rb_callable_method_entry
     rb_method_visibility_t visi;
 
     if (UNDEFINED_METHOD_ENTRY_P(me)) {
-      undefined:
+      undefined: COLDLABEL
 	return scope == CALL_VCALL ? MISSING_VCALL : MISSING_NOENTRY;
     }
     if (me->def->type == VM_METHOD_TYPE_REFINED) {
@@ -720,7 +720,7 @@ method_missing(VALUE obj, ID id, int argc, const VALUE *argv, enum method_missin
     ec->method_missing_reason = call_status;
 
     if (id == idMethodMissing) {
-      missing:
+      missing: COLDLABEL
 	raise_method_missing(ec, argc, argv, obj, call_status | MISSING_MISSING);
     }
 
@@ -2140,6 +2140,7 @@ rb_current_realfilepath(void)
     return Qnil;
 }
 
+COLDFUNC(void Init_vm_eval(void));
 void
 Init_vm_eval(void)
 {

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -47,7 +47,7 @@ ec_stack_overflow(rb_execution_context_t *ec, int setup)
     EC_JUMP_TAG(ec, TAG_RAISE);
 }
 
-NORETURN(static void vm_stackoverflow(void));
+NORETURN(COLDFUNC(static void vm_stackoverflow(void)));
 
 static void
 vm_stackoverflow(void)
@@ -55,7 +55,7 @@ vm_stackoverflow(void)
     ec_stack_overflow(GET_EC(), TRUE);
 }
 
-NORETURN(void rb_ec_stack_overflow(rb_execution_context_t *ec, int crit));
+NORETURN(COLDFUNC(void rb_ec_stack_overflow(rb_execution_context_t *ec, int crit)));
 void
 rb_ec_stack_overflow(rb_execution_context_t *ec, int crit)
 {
@@ -2365,7 +2365,7 @@ vm_call_method_each_type(rb_execution_context_t *ec, rb_control_frame_t *cfp, st
     rb_bug("vm_call_method: unsupported method type (%d)", cc->me->def->type);
 }
 
-NORETURN(static void vm_raise_method_missing(rb_execution_context_t *ec, int argc, const VALUE *argv, VALUE obj, int call_status));
+NORETURN(COLDFUNC(static void vm_raise_method_missing(rb_execution_context_t *ec, int argc, const VALUE *argv, VALUE obj, int call_status)));
 
 static VALUE
 vm_call_method_nome(rb_execution_context_t *ec, rb_control_frame_t *cfp, struct rb_calling_info *calling, const struct rb_call_info *ci, struct rb_call_cache *cc)
@@ -2460,7 +2460,7 @@ vm_search_normal_superclass(VALUE klass)
     return RCLASS_SUPER(klass);
 }
 
-NORETURN(static void vm_super_outside(void));
+NORETURN(COLDFUNC(static void vm_super_outside(void)));
 
 static void
 vm_super_outside(void)

--- a/vm_method.c
+++ b/vm_method.c
@@ -2106,6 +2106,7 @@ obj_respond_to_missing(VALUE obj, VALUE mid, VALUE priv)
     return Qfalse;
 }
 
+COLDFUNC(void Init_Method(void));
 void
 Init_Method(void)
 {
@@ -2131,6 +2132,7 @@ Init_Method(void)
 #endif
 }
 
+COLDFUNC(void Init_eval_method(void));
 void
 Init_eval_method(void)
 {

--- a/vm_trace.c
+++ b/vm_trace.c
@@ -1468,9 +1468,10 @@ tracepoint_stat_s(VALUE self)
     return stat;
 }
 
-static void Init_postponed_job(void);
+COLDFUNC(static void Init_postponed_job(void));
 
 /* This function is called from inits.c */
+COLDFUNC(void Init_vm_trace(void));
 void
 Init_vm_trace(void)
 {

--- a/vsnprintf.c
+++ b/vsnprintf.c
@@ -1226,7 +1226,7 @@ long_len:
 	}
 done:
 	FLUSH();
-error:
+error: COLDLABEL
 	return (BSD__sferror(fp) ? EOF : ret);
 	/* NOTREACHED */
 }

--- a/win32/file.c
+++ b/win32/file.c
@@ -704,6 +704,7 @@ rb_freopen(VALUE fname, const char *mode, FILE *file)
     return e;
 }
 
+COLDFUNC(void Init_w32_codepage(void));
 void
 Init_w32_codepage(void)
 {


### PR DESCRIPTION
I distilled the feedback given on https://github.com/ruby/ruby/pull/1915 for a while and also concluded that:

* Sprinkling branch predictor hints for callsites of specific functions leads to bloat, complexity and also a standard / contract very difficult to enforce
* It's essentially a higher level version of what modern compilers already do.

Also for [ruby 3x3](https://rubykaigi.org/2017/presentations/codefolio.html) I feel we should look towards "hardware empathy" more - help the compiler generate better code with hints, take a pass through the memory layout of internal structures ( [SOA vs OAS](https://en.wikipedia.org/wiki/AOS_and_SOA) ), data locality and possibility also have a look @ how modern game engines push hardware to get the maximum work done per game loop (essentially a VM tick in Ruby land).

This lead me to the `hot` and `cold` [attributes](https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#Common-Function-Attributes) supported by `GCC` and `clang`, extensively used in the [kernel](https://github.com/torvalds/linux/blob/ca04b3cca11acbaf904f707f2d9ca9654d7cc226/include/linux/compiler-gcc.h#L191-L206), PHP (especially the swift 7.x releases) and other projects. 

### Implementation details

This PR only focuses on the `cold` [cold](https://gcc.gnu.org/onlinedocs/gcc-4.6.4/gcc/Function-Attributes.html), which works in the following way (from GCC docs):

```
The cold attribute is used to inform the compiler that a function is unlikely executed. The function is optimized for size rather than speed and on many targets it is placed into special subsection of the text section so all cold functions appears close together improving code locality of non-cold parts of program. The paths leading to call of cold functions within code are marked as unlikely by the branch prediction mechanism. It is thus useful to mark functions used to handle unlikely conditions, such as perror, as cold to improve optimization of hot functions that do call marked functions in rare occasions.
When profile feedback is available, via -fprofile-use, hot functions are automatically detected and this attribute is ignored.
```
By declaring a function as `cold` when defined we get the following benefits:

* No excessive `unlikely` macros sprinkled about
* We get the branch prediction hints for free @ every callsite
* No-op on platforms that does not support the attributes
* Size optimization of cold functions with a smaller footprint in the instruction cache
* Therefore CPU frontend throughput increases due to a lower ratio of instruction cache misses and a lower ITLB overhead.
* This effect can further be amplified in future work with the `hot` attribute

This pattern also translates well to `Init_` hooks of extensions and other shared ruby libs.  Therefore this PR also defines `Init_` entry point functions for core extensions as cold - smaller icache as they are generally referenced from within requires which should not be in a hot path and thus fine to optimize for size. And only ever called once.

GCC 5+ also supports `cold` [labels](https://gcc.gnu.org/onlinedocs/gcc/Label-Attributes.html), to inform the compiler that a particular label is unlikely to be executed. There's several error and similar labels in the codebase and I was targeting those primarily.

Binary sizes this branch:

```
lourens@CarbonX1:~/src/ruby/ruby$ size ruby
   text	   data	    bss	    dec	    hex	filename
3462225	  21088	  71344	3554657	 363d61	ruby
```

VS trunk (`2832` bytes smaller text segment)

```
lourens@CarbonX1:~/src/ruby/trunk$ size ruby
   text	   data	    bss	    dec	    hex	filename
3465057	  21088	  71344	3557489	 364871	ruby
```

The cold functions are placed in the special section `.text.unlikely` section below (number 6)

```
lourens@CarbonX1:~/src/ruby/ruby$ readelf -S error.o
There are 32 section headers, starting at offset 0x85848:

Section Headers:
  [Nr] Name              Type             Address           Offset
       Size              EntSize          Flags  Link  Info  Align
  [ 0]                   NULL             0000000000000000  00000000
       0000000000000000  0000000000000000           0     0     0
  [ 1] .text             PROGBITS         0000000000000000  00000040
       000000000000666d  0000000000000000  AX       0     0     16
  [ 2] .rela.text        RELA             0000000000000000  000397d0
       000000000000acf8  0000000000000018   I      29     1     8
  [ 3] .data             PROGBITS         0000000000000000  000066ad
       0000000000000000  0000000000000000  WA       0     0     1
  [ 4] .bss              NOBITS           0000000000000000  000066c0
       00000000000010d8  0000000000000000  WA       0     0     32
  [ 5] .rodata.str1.1    PROGBITS         0000000000000000  000066c0
       000000000000097b  0000000000000001 AMS       0     0     1
  [ 6] .text.unlikely    PROGBITS         0000000000000000  0000703b
       0000000000001f0b  0000000000000000  AX       0     0     1
  [ 7] .rela.text.unlike RELA             0000000000000000  000444c8
       0000000000002190  0000000000000018   I      29     6     8
  [ 8] .rodata.str1.8    PROGBITS         0000000000000000  00008f48
       000000000000023f  0000000000000001 AMS       0     0     8
  [ 9] .rodata           PROGBITS         0000000000000000  000091a0
       0000000000000226  0000000000000000   A       0     0     32
 --- truncated for brevity ---
```

Proof of the error specific functions migrated to the `.text.unlikely` section.

```
lourens@CarbonX1:~/src/ruby/ruby$ ld -M error.o

--- only a small snippet for brevity ----

.text           0x0000000000400120     0x857d
 *(.text.unlikely .text.*_unlikely .text.unlikely.*)
 .text.unlikely
                0x0000000000400120     0x1f25 error.o
                0x0000000000400ac2                rb_syntax_error_append
                0x0000000000400c9f                rb_warning_warn
                0x0000000000400d1d                rb_compile_warn
                0x0000000000400ddb                rb_compile_warning
                0x0000000000400e9c                rb_warn
                0x0000000000400f54                rb_enc_warn
                0x000000000040100d                rb_warning
                0x00000000004010c8                rb_bug
                0x00000000004011a5                rb_bug_context
                0x0000000000401283                rb_bug_errno
                0x00000000004012e7                rb_async_bug_errno
                0x000000000040142a                rb_report_bug_valist
                0x000000000040147a                rb_exc_new
                0x00000000004014aa                rb_exc_new_cstr
                0x00000000004014c7                rb_exc_new_str
                0x000000000040152b                rb_name_error
                0x00000000004015e9                rb_name_error_str
                0x000000000040174f                rb_name_err_new
                0x000000000040177d                rb_nomethod_err_new
                0x00000000004017f6                rb_key_err_new
                0x0000000000401869                rb_raise
                0x000000000040190a                rb_exc_set_backtrace
                0x000000000040190f                rb_invalid_str
                0x0000000000401933                rb_loaderror
                0x00000000004019db                rb_loaderror_with_path
                0x0000000000401a80                rb_notimplement
                0x0000000000401aa9                rb_fatal
                0x0000000000401b4c                ruby_deprecated_internal_feature
                0x0000000000401b66                rb_syserr_new_str
                0x0000000000401b8b                rb_syserr_new
                0x0000000000401c41                rb_syserr_fail
                0x0000000000401c52                rb_syserr_fail_str
                0x0000000000401c63                rb_sys_fail
                0x0000000000401c74                rb_sys_fail_str
                0x0000000000401c85                rb_mod_sys_fail
                0x0000000000401cac                rb_mod_sys_fail_str
                0x0000000000401cd3                rb_mod_syserr_fail
                0x0000000000401cfc                rb_mod_syserr_fail_str
                0x0000000000401d25                rb_sys_warning
                0x0000000000401ded                rb_sys_enc_warning
                0x0000000000401eb8                rb_syserr_enc_warning
                0x0000000000401f70                rb_load_fail
                0x0000000000401fae                rb_error_frozen
                0x0000000000401fca                rb_error_frozen_object
                0x0000000000402044                rb_error_untrusted

lourens@CarbonX1:~/src/ruby/ruby$ ld -M vm.o

--- only a small snippet for brevity ----
.text           0x0000000000400120    0x1e1bf
 *(.text.unlikely .text.*_unlikely .text.unlikely.*)
 .text.unlikely
                0x0000000000400120      0x767 vm.o
                0x0000000000400192                rb_f_notimplement
                0x0000000000400572                rb_error_arity
                0x000000000040063c                rb_make_no_method_exception
                0x0000000000400807                rb_vm_localjump_error
                0x0000000000400818                rb_vm_make_jump_tag_but_local_jump

lourens@CarbonX1:~/src/ruby/ruby$ ld -M eval.o

--- only a small snippet for brevity ----

.text           0x0000000000400120     0x5302
 *(.text.unlikely .text.*_unlikely .text.unlikely.*)
 .text.unlikely
                0x0000000000400120     0x131f eval.o
                0x0000000000400b04                rb_error_write
                0x0000000000400c85                rb_ec_error_print
                0x0000000000400fbf                rb_ec_setup_exception
                0x000000000040100e                rb_exc_raise
                0x000000000040104e                rb_print_undef
                0x0000000000401131                rb_print_undef_str
                0x0000000000401190                rb_print_inaccessible
                0x0000000000401273                rb_exc_fatal
                0x00000000004012b3                rb_interrupt
                0x00000000004012cf                rb_make_exception
                0x00000000004013f8                rb_errinfo
                0x0000000000401404                rb_set_errinfo

```

Some `Init_` functions relocated to the cold section as well:

```
lourens@CarbonX1:~/src/ruby/ruby$ ld -M eval.o

--- only a small snippet for brevity ----

.text           0x0000000000400120    0x10769
 *(.text.unlikely .text.*_unlikely .text.unlikely.*)
 .text.unlikely
                0x0000000000400120      0xbfe array.o
                0x0000000000400139                Init_Array
 *(.text.exit .text.exit.*)
 *(.text.startup .text.startup.*)
 *(.text.hot .text.hot.*)
 *(.text .stub .text.* .gnu.linkonce.t.*)
 *fill*         0x0000000000400d1e        0x2 
 .text          0x0000000000400d20     0xfb69 array.o
                0x0000000000401950                rb_ary_rassoc
                0x0000000000401a20                rb_ary_includes
                0x0000000000401aa0                rb_ary_assoc

lourens@CarbonX1:~/src/ruby/ruby$ ld -M hash.o

--- only a small snippet for brevity ----

.text           0x0000000000400120     0xae07
 *(.text.unlikely .text.*_unlikely .text.unlikely.*)
 .text.unlikely
                0x0000000000400120      0xece hash.o
                0x0000000000400156                Init_Hash
 *(.text.exit .text.exit.*)
 *(.text.startup .text.startup.*)
 *(.text.hot .text.hot.*)
 *(.text .stub .text.* .gnu.linkonce.t.*)
 *fill*         0x0000000000400fee        0x2 
 .text          0x0000000000400ff0     0x9f37 hash.o
                0x00000000004010c0                rb_hash_size
                0x00000000004011d0                rb_hash_compare_by_id_p
                0x0000000000401340                rb_hash_has_key
                0x0000000000401700                rb_hash_keys

```

### What this PR does NOT do, and future work

* Completely ignores the `hot` attribute for now as it's a completely different concern and references future work.
* Implement support for [Intel VTune tracing technology APIs](https://software.intel.com/en-us/vtune-amplifier-help-instrumentation-and-tracing-technology-apis) for better insights on what bytecode is actually doing with the hardware. Primarily to determine where else we're frontend bound still in the VM
* Opt in hugepages support to reduce [TLB](https://en.wikipedia.org/wiki/Translation_lookaside_buffer) overhead for the code segment (map it to a few 2MB pages instead of several 4k ones). Possibly useful for object layouts / the ruby heap for large Rails applications (not database server territory, but there may be some benefit)
* Look into the benefits of [link time optimization](https://en.wikipedia.org/wiki/Interprocedural_optimization)

### Downsides

* Mostly GCC specific (possibly works nicely with clang too, no tests with it yet)
* Higher rate of mispredictions and stalls for code that rely on exceptions and errors for flow control (not a great pattern to use anyways)
* Keeping tabs on / awareness of the `COLDFUNC` and `COLDLABEL` macros - didn't seem to burden kernel, PHP and other core devs very much ...

### Benchmarks

Benchmarks, especially instructions p/s, instruction cache performance and branch prediction in progress

#### Branches

```
Samples: 17K of event 'branches', Event count (approx.): 8707306167
Overhead  Command         Shared Object      Symbol
  66,22%  ruby            ruby               [.] vm_exec_core
   5,24%  ruby            ruby               [.] vm_setivar.isra.230
   3,88%  ruby            ruby               [.] vm_call_iseq_setup_normal_0start_0params_0locals
   2,65%  ruby            ruby               [.] vm_call_cfunc
   1,75%  ruby            ruby               [.] rb_class_of
   1,58%  ruby            ruby               [.] rb_ary_push
   1,16%  ruby            ruby               [.] vm_call_iseq_setup_normal_0start_0params_2locals
   1,08%  ruby            ruby               [.] ary_ensure_room_for_push
   0,88%  ruby            ruby               [.] vm_call_iseq_setup_normal_0start_0params_1locals
   0,84%  ruby            ruby               [.] invoke_iseq_block_from_c
   0,80%  ruby            ruby               [.] vm_call_iseq_setup
   0,74%  ruby            ruby               [.] rb_ary_transpose
   0,58%  ruby            ruby               [.] rb_ary_rotate_bang
   0,55%  ruby            ruby               [.] vm_call_iseq_setup_normal_0start_1params_1locals
   0,55%  ruby            ruby               [.] rb_vm_exec
```

VS trunk

```
Samples: 16K of event 'branches', Event count (approx.): 8714006421
Overhead  Command         Shared Object      Symbol
  68,15%  ruby            ruby               [.] vm_exec_core
   4,98%  ruby            ruby               [.] vm_setivar.isra.230
   3,12%  ruby            ruby               [.] vm_call_iseq_setup_normal_0start_0params_0locals
   2,74%  ruby            ruby               [.] vm_call_cfunc
   1,76%  ruby            ruby               [.] rb_class_of
   1,73%  ruby            ruby               [.] rb_ary_push
   0,95%  ruby            ruby               [.] ary_ensure_room_for_push
   0,88%  ruby            ruby               [.] vm_call_iseq_setup_normal_0start_0params_2locals
   0,75%  ruby            ruby               [.] vm_call_iseq_setup
   0,72%  ruby            ruby               [.] rb_ary_transpose
   0,68%  ruby            ruby               [.] invoke_iseq_block_from_c
   0,61%  ruby            ruby               [.] rb_vm_exec
   0,61%  ruby            ruby               [.] vm_call_iseq_setup_normal_0start_0params_1locals
   0,57%  ruby            ruby               [.] rb_yield
   0,50%  ruby            ruby               [.] opt_eq_func
   0,50%  ruby            ruby               [.] rb_ary_rotate_bang
   0,49%  ruby            ruby               [.] vm_call_iseq_setup_normal_0start_1params_1locals
   0,47%  ruby            ruby               [.] vm_call_opt_send
```

#### Branch misses

```
Samples: 15K of event 'branch-misses', Event count (approx.): 43797451
Overhead  Command         Shared Object      Symbol
  73,94%  ruby            ruby               [.] vm_exec_core
   6,77%  ruby            ruby               [.] vm_call_cfunc
   5,31%  ruby            ruby               [.] vm_setivar.isra.230
   2,69%  ruby            ruby               [.] vm_call_iseq_setup_normal_0start_0params_2locals
   2,41%  ruby            ruby               [.] vm_call_iseq_setup_normal_0start_0params_0locals
   1,88%  ruby            ruby               [.] vm_call_iseq_setup_normal_0start_1params_1locals
   1,03%  ruby            ruby               [.] rb_class_of
   0,53%  ruby            ruby               [.] ruby_yyparse
```

VS trunk

```
Samples: 15K of event 'branch-misses', Event count (approx.): 45440490
Overhead  Command         Shared Object      Symbol
  80,53%  ruby            ruby               [.] vm_exec_core
   7,00%  ruby            ruby               [.] vm_setivar.isra.230
   2,68%  ruby            ruby               [.] vm_call_cfunc
   1,65%  ruby            ruby               [.] rb_class_of
   1,11%  ruby            ruby               [.] vm_call_iseq_setup_normal_0start_0params_0locals
   0,70%  ruby            ruby               [.] vm_call_iseq_setup_normal_0start_0params_2locals
   0,64%  ruby            ruby               [.] vm_call_iseq_setup_normal_0start_1params_1locals
   0,59%  ruby            ruby               [.] ruby_yyparse

```
### CPU frontend utilization improvements

Lower instruction TLB overhead and instruction cache misses. The goal with this PR is to improve throughput of instructions for the CPU frontend as ruby seems to stall the CPU significantly for some workloads. Trying to reduce frontend stalls with relocating cold functions and branch predictor hints of code executing less is the primary objective here. An expected side effect would be noticing backend optimization opportunities more easily as the frontend throughput increases

VTune output from `benchmark/app_erb.yml`

![frontend_cold](https://user-images.githubusercontent.com/379/44204858-4c085100-a14c-11e8-86b8-d87fcb5e4985.png)

VS trunk

![frontend_trunk](https://user-images.githubusercontent.com/379/44204870-4f9bd800-a14c-11e8-9bee-14c8ad8d3a7d.png)

#### Observations from the above

* Less stalls and a larger fraction utilized for work
* Better CPI(cycles per instruction) rate (lower is better)
* Less frontend bound (not supplying instructions fast enough to the backend). 30% is still very high.
* No icache misses
* Ditto for ITLB misses
* Higher rate of retired instructions (more is better)
* Slight improvement in branch prediction
* This branch is more backend bound (expected because the frontend stalls less)

#### Initial benchmarks

General improvement in [optcarrot](https://github.com/mame/optcarrot) FPS

```
lourens@CarbonX1:~/src/optcarrot$ benchmark-driver -e "cold::~/src/ruby/ruby/ruby -I~/src/ruby/ruby/lib -I~/src/ruby/ruby/. -I~/src/ruby/ruby/.ext/x86_64-linux" -e "trunk::~/src/ruby/trunk/ruby -I~/src/ruby/trunk/lib -I~/src/ruby/trunk/. -I~/src/ruby/trunk/.ext/x86_64-linux" --repeat-count 1 --repeat-result average -vv benchmark.yml
cold: ruby 2.6.0dev (2018-08-16 cold-error-paths 64392) [x86_64-linux]
last_commit=Let most error handling functions and shared object init hooks be flagged as cold and be optimized for size
trunk: ruby 2.6.0dev (2018-08-16 trunk 64382) [x86_64-linux]
Calculating -------------------------------------
                           cold       trunk 
           optcarrot     45.679      44.141 fps

Comparison:
                        optcarrot
                cold:        45.7 fps 
               trunk:        44.1 fps - 1.03x  slower
```