### PR TITLE
[DOC] Added CI build status for Japanese docs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,3 +1,6 @@
+[![Build Status](https://travis-ci.org/ruby/ruby.svg)](https://travis-ci.org/ruby/ruby)
+[![Build status](https://ci.appveyor.com/api/projects/status/0sy8rrxut4o0k960/branch/trunk?svg=true)](https://ci.appveyor.com/project/ruby/ruby/branch/trunk)
+
 # Rubyとは
 
 Rubyはシンプルかつ強力なオブジェクト指向スクリプト言語です． Rubyは純粋なオブジェクト指向言語として設計されているので，


### PR DESCRIPTION
Added the Travis CI and Appveyor badges to the Japanese Ruby documentation.

![screenshot_2018-07-31_11-10-31](https://user-images.githubusercontent.com/10160626/43472138-5baf3926-94b2-11e8-8535-fa7d25046dc4.png)
