### PR TITLE
Update link to Email address specification (URI::MailTo)

### DIFF
--- a/lib/uri/mailto.rb
+++ b/lib/uri/mailto.rb
@@ -52,7 +52,7 @@ module URI
     # pct-encoded  = "%" HEXDIG HEXDIG
     HEADER_REGEXP  = /\A(?<hfield>(?:%\h\h|[!$'-.0-;@-Z_a-z~])*=(?:%\h\h|[!$'-.0-;@-Z_a-z~])*)(?:&\g<hfield>)*\z/
     # practical regexp for email address
-    # http://www.whatwg.org/specs/web-apps/current-work/multipage/states-of-the-type-attribute.html#valid-e-mail-address
+    # https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address
     EMAIL_REGEXP = /\A[a-zA-Z0-9.!\#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\z/
     # :startdoc:
 


### PR DESCRIPTION
The current link leads to 404, I updated to the actual one.