### PR TITLE
io.c: use copy_file_range with every types of files

### DIFF
--- a/io.c
+++ b/io.c
@@ -10787,27 +10787,8 @@ simple_copy_file_range(int in_fd, off_t *in_offset, int out_fd, off_t *out_offse
 static int
 nogvl_copy_file_range(struct copy_stream_struct *stp)
 {
-    struct stat src_stat, dst_stat;
     ssize_t ss;
-    int ret;
-
     off_t copy_length, src_offset, *src_offset_ptr;
-
-    ret = fstat(stp->src_fd, &src_stat);
-    if (ret == -1) {
-        stp->syserr = "fstat";
-        stp->error_no = errno;
-        return -1;
-    }
-    if (!S_ISREG(src_stat.st_mode))
-        return 0;
-
-    ret = fstat(stp->dst_fd, &dst_stat);
-    if (ret == -1) {
-        stp->syserr = "fstat";
-        stp->error_no = errno;
-        return -1;
-    }
 
     src_offset = stp->src_offset;
     if (src_offset != (off_t)-1) {
@@ -10819,6 +10800,16 @@ nogvl_copy_file_range(struct copy_stream_struct *stp)
 
     copy_length = stp->copy_length;
     if (copy_length == (off_t)-1) {
+	int ret;
+	struct stat src_stat;
+
+	ret = fstat(stp->src_fd, &src_stat);
+	if (ret == -1) {
+	    stp->syserr = "fstat";
+	    stp->error_no = errno;
+	    return -1;
+	}
+
 	if (src_offset == (off_t)-1) {
 	    off_t current_offset;
             errno = 0;


### PR DESCRIPTION
Ref: https://bugs.ruby-lang.org/issues/13867

`IO.copy_stream` only attempt to use `copy_file_range` if the source is a regular file.

However contrary to `sendfile` and `splice`, `copy_file_range` has no file type restriction, it should be able to copy from and to sockets and pipes just fine.

It does have very optimized paths for regular files on specific file systems, but for other `fd` types it will fallback to do the copy using the page cache:

https://lwn.net/Articles/659523/

> If the function is absent or returns failure, the kernel will, if the COPY_FR_COPY flag is set, fall back to copying through the page cache.

So if it's available, it's preferable to `nogvl_copy_stream_read_write`.

cc @methodmissing @DazWorrall (that might interest you)