### PR TITLE
Showed unmodified case in string.strip docs

### DIFF
--- a/string.c
+++ b/string.c
@@ -9015,6 +9015,7 @@ rb_str_strip_bang(VALUE str)
  *
  *     "    hello    ".strip   #=> "hello"
  *     "\tgoodbye\r\n".strip   #=> "goodbye"
+ *     "electric boogaloo".strip   #=> "electric boogaloo"
  *     "\x00\t\n\v\f\r ".strip #=> ""
  */
 

--- a/string.c
+++ b/string.c
@@ -9015,7 +9015,7 @@ rb_str_strip_bang(VALUE str)
  *
  *     "    hello    ".strip   #=> "hello"
  *     "\tgoodbye\r\n".strip   #=> "goodbye"
- *     "electric boogaloo".strip   #=> "electric boogaloo"
+ *     "hello world".strip     #=> "hello world"
  *     "\x00\t\n\v\f\r ".strip #=> ""
  */
 


### PR DESCRIPTION
As a Ruby newcomer, I was worried that `str.strip` would return `nil` for some reason (the `!` precedence is new and scary to me). Having an example here would have saved the fifteen seconds of booting up `repl.it/languages/ruby` 😊.