### PR TITLE
Let all Init_xxx and extension APIs frequently called from init code paths be considered cold

### DIFF
--- a/array.c
+++ b/array.c
@@ -6250,6 +6250,7 @@ rb_ary_sum(int argc, VALUE *argv, VALUE ary)
  *
  */
 
+COLDFUNC(void Init_Array(void));
 void
 Init_Array(void)
 {

--- a/ast.c
+++ b/ast.c
@@ -599,6 +599,7 @@ rb_ast_node_inspect(VALUE self)
     return str;
 }
 
+COLDFUNC(void Init_ast(void));
 void
 Init_ast(void)
 {

--- a/bignum.c
+++ b/bignum.c
@@ -7118,6 +7118,7 @@ rb_int_powm(int const argc, VALUE * const argv, VALUE const num)
  *
  */
 
+COLDFUNC(void Init_Bignum(void));
 void
 Init_Bignum(void)
 {

--- a/compar.c
+++ b/compar.c
@@ -245,6 +245,7 @@ cmp_clamp(VALUE x, VALUE min, VALUE max)
  *
  */
 
+COLDFUNC(void Init_Comparable(void));
 void
 Init_Comparable(void)
 {

--- a/complex.c
+++ b/complex.c
@@ -2137,6 +2137,7 @@ float_arg(VALUE self)
  *    Complex(1, 1) / 2    #=> ((1/2)+(1/2)*i)
  *    Complex(1, 1) / 2.0  #=> (0.5+0.5i)
  */
+COLDFUNC(void Init_Complex(void));
 void
 Init_Complex(void)
 {

--- a/configure.ac
+++ b/configure.ac
@@ -1302,6 +1302,7 @@ AS_IF([test "$rb_cv_have_alignof" != no], [
 
 RUBY_FUNC_ATTRIBUTE(__const__, CONSTFUNC)
 RUBY_FUNC_ATTRIBUTE(__pure__, PUREFUNC)
+RUBY_FUNC_ATTRIBUTE(__cold__, COLDFUNC)
 RUBY_FUNC_ATTRIBUTE(__noreturn__, NORETURN)
 RUBY_FUNC_ATTRIBUTE(__deprecated__, DEPRECATED)
 RUBY_FUNC_ATTRIBUTE(__deprecated__("by "@%:@n), DEPRECATED_BY(n,x), rb_cv_func_deprecated_by)

--- a/cont.c
+++ b/cont.c
@@ -1991,6 +1991,7 @@ fiber_to_s(VALUE fibval)
  *     fiber.resume #=> FiberError: dead fiber called
  */
 
+COLDFUNC(void Init_Cont(void));
 void
 Init_Cont(void)
 {
@@ -2019,6 +2020,7 @@ Init_Cont(void)
 
 RUBY_SYMBOL_EXPORT_BEGIN
 
+COLDFUNC(void ruby_Init_Continuation_body(void));
 void
 ruby_Init_Continuation_body(void)
 {
@@ -2030,6 +2032,7 @@ ruby_Init_Continuation_body(void)
     rb_define_global_function("callcc", rb_callcc, 0);
 }
 
+COLDFUNC(void ruby_Init_Fiber_as_Coroutine(void));
 void
 ruby_Init_Fiber_as_Coroutine(void)
 {

--- a/dir.c
+++ b/dir.c
@@ -3250,6 +3250,7 @@ rb_dir_s_empty_p(VALUE obj, VALUE dirname)
  *  directory (<code>..</code>), and the directory itself
  *  (<code>.</code>).
  */
+COLDFUNC(void Init_Dir(void));
 void
 Init_Dir(void)
 {

--- a/enc/encdb.c
+++ b/enc/encdb.c
@@ -19,6 +19,7 @@
 #define ENC_SET_DUMMY(name, orig) rb_enc_set_dummy(name)
 #define ENC_DUMMY_UNICODE(name) rb_encdb_set_unicode(rb_enc_set_dummy(ENC_REPLICATE((name), name "BE")))
 
+COLDFUNC(void Init_encdb(void));
 void
 Init_encdb(void)
 {

--- a/enc/encinit.c.erb
+++ b/enc/encinit.c.erb
@@ -11,7 +11,7 @@
 #define init_enc(name) init(Init_##name, "enc/"#name".so")
 #define init_trans(name) init(Init_trans_##name, "enc/trans/"#name".so")
 #define provide(func, name) { \
-    extern void Init_##func(void); \
+    COLDFUNC(extern void Init_##func(void)); \
     Init_##func(); \
     rb_provide(name".so"); \
 }
@@ -19,6 +19,7 @@
 void ruby_init_ext(const char *name, void (*init)(void));
 void rb_provide(const char *feature);
 
+COLDFUNC(void Init_enc(void));
 void
 Init_enc(void)
 {

--- a/enc/gb2312.c
+++ b/enc/gb2312.c
@@ -2,6 +2,7 @@
 #include <ruby/encoding.h>
 #include "regenc.h"
 
+COLDFUNC(void Init_gb2312(void));
 void
 Init_gb2312(void)
 {

--- a/encoding.c
+++ b/encoding.c
@@ -1375,7 +1375,7 @@ rb_locale_encindex(void)
 
     if (rb_enc_registered("locale") < 0) {
 # if defined _WIN32
-	void Init_w32_codepage(void);
+	COLDFUNC(void Init_w32_codepage(void));
 	Init_w32_codepage();
 # endif
 	enc_alias_internal("locale", idx);
@@ -1930,6 +1930,7 @@ rb_enc_aliases(VALUE klass)
  *
  */
 
+COLDFUNC(void Init_Encoding(void));
 void
 Init_Encoding(void)
 {

--- a/enum.c
+++ b/enum.c
@@ -4025,6 +4025,7 @@ enum_uniq(VALUE obj)
  *  rely on an ordering between members of the collection.
  */
 
+COLDFUNC(void Init_Enumerable(void));
 void
 Init_Enumerable(void)
 {

--- a/enumerator.c
+++ b/enumerator.c
@@ -2778,6 +2778,7 @@ arith_seq_size(VALUE self)
     return len;
 }
 
+COLDFUNC(void InitVM_Enumerator(void));
 void
 InitVM_Enumerator(void)
 {
@@ -2875,6 +2876,7 @@ InitVM_Enumerator(void)
 }
 
 #undef rb_intern
+COLDFUNC(void Init_Enumerator(void));
 void
 Init_Enumerator(void)
 {

--- a/error.c
+++ b/error.c
@@ -2418,6 +2418,7 @@ syserr_eqq(VALUE self, VALUE exc)
  *  * fatal -- impossible to rescue
  */
 
+COLDFUNC(void Init_Exception(void));
 void
 Init_Exception(void)
 {
@@ -2894,6 +2895,7 @@ rb_check_copyable(VALUE obj, VALUE orig)
     }
 }
 
+COLDFUNC(void Init_syserr(void));
 void
 Init_syserr(void)
 {

--- a/eval.c
+++ b/eval.c
@@ -1902,6 +1902,7 @@ f_current_dirname(void)
     return base;
 }
 
+COLDFUNC(void Init_eval(void));
 void
 Init_eval(void)
 {

--- a/eval_jump.c
+++ b/eval_jump.c
@@ -132,6 +132,7 @@ rb_exec_end_proc(void)
     ec->errinfo = errinfo;
 }
 
+COLDFUNC(void Init_jump(void));
 void
 Init_jump(void)
 {

--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -3263,6 +3263,7 @@ get_vp_value:
  * Documented by zzak <zachary@zacharyscott.net>, mathew <meta@pobox.com>, and
  * many other contributors.
  */
+COLDFUNC(void Init_bigdecimal(void));
 void
 Init_bigdecimal(void)
 {

--- a/ext/cgi/escape/escape.c
+++ b/ext/cgi/escape/escape.c
@@ -400,6 +400,7 @@ cgiesc_unescape(int argc, VALUE *argv, VALUE self)
     }
 }
 
+COLDFUNC(void Init_escape(void));
 void
 Init_escape(void)
 {
@@ -407,6 +408,7 @@ Init_escape(void)
     InitVM(escape);
 }
 
+COLDFUNC(void InitVM_escape(void));
 void
 InitVM_escape(void)
 {

--- a/ext/continuation/continuation.c
+++ b/ext/continuation/continuation.c
@@ -3,6 +3,7 @@
 
 void ruby_Init_Continuation_body(void);
 
+COLDFUNC(void Init_continuation(void));
 void
 Init_continuation(void)
 {

--- a/ext/coverage/coverage.c
+++ b/ext/coverage/coverage.c
@@ -292,6 +292,7 @@ rb_coverage_running(VALUE klass)
  *   require "foo.rb"
  *   p Coverage.result  #=> {"foo.rb"=>[1, 1, 10, nil, nil, 1, 1, nil, 0, nil]}
  */
+COLDFUNC(void Init_coverage(void));
 void
 Init_coverage(void)
 {

--- a/ext/date/date_core.c
+++ b/ext/date/date_core.c
@@ -9011,6 +9011,7 @@ mk_ary_of_str(long len, const char *a[])
     return o;
 }
 
+COLDFUNC(void Init_date_core(void));
 void
 Init_date_core(void)
 {

--- a/ext/dbm/dbm.c
+++ b/ext/dbm/dbm.c
@@ -1038,6 +1038,7 @@ fdbm_reject(VALUE obj)
  *  db['3068'] = 'An Anycast Prefix for 6to4 Relay Routers'
  *  puts db['822']
  */
+COLDFUNC(void Init_dbm(void));
 void
 Init_dbm(void)
 {

--- a/ext/digest/bubblebabble/bubblebabble.c
+++ b/ext/digest/bubblebabble/bubblebabble.c
@@ -121,6 +121,7 @@ rb_digest_instance_bubblebabble(VALUE self)
  * This module adds some methods to Digest classes to perform
  * BubbleBabble encoding.
  */
+COLDFUNC(void Init_bubblebabble(void));
 void
 Init_bubblebabble(void)
 {

--- a/ext/digest/digest.c
+++ b/ext/digest/digest.c
@@ -23,7 +23,7 @@ static VALUE rb_cDigest_Base;
 static ID id_reset, id_update, id_finish, id_digest, id_hexdigest, id_digest_length;
 static ID id_metadata;
 
-RUBY_EXTERN void Init_digest_base(void);
+COLDFUNC(RUBY_EXTERN void Init_digest_base(void));
 
 /*
  * Document-module: Digest
@@ -725,6 +725,7 @@ rb_digest_base_block_length(VALUE self)
     return INT2NUM(algo->block_len);
 }
 
+COLDFUNC(void Init_digest(void));
 void
 Init_digest(void)
 {

--- a/ext/digest/md5/md5init.c
+++ b/ext/digest/md5/md5init.c
@@ -46,6 +46,7 @@ static const rb_digest_metadata_t md5 = {
  *  md5 << "message"
  *  md5.hexdigest                        # => "78e73102..."
  */
+COLDFUNC(void Init_md5(void));
 void
 Init_md5(void)
 {

--- a/ext/digest/rmd160/rmd160init.c
+++ b/ext/digest/rmd160/rmd160init.c
@@ -44,6 +44,7 @@ static const rb_digest_metadata_t rmd160 = {
  *  rmd160 << "message"
  *  rmd160.hexdigest                        # => "1dddbe1b..."
  */
+COLDFUNC(void Init_rmd160(void));
 void
 Init_rmd160(void)
 {

--- a/ext/digest/sha1/sha1init.c
+++ b/ext/digest/sha1/sha1init.c
@@ -48,6 +48,7 @@ static const rb_digest_metadata_t sha1 = {
  *  sha1 << "message"
  *  sha1.hexdigest                        # => "6f9b9af3..."
  */
+COLDFUNC(void Init_sha1(void));
 void
 Init_sha1(void)
 {

--- a/ext/digest/sha2/sha2init.c
+++ b/ext/digest/sha2/sha2init.c
@@ -31,6 +31,7 @@ FOREACH_BITLEN(DEFINE_ALGO_METADATA)
  * Secure Hash Algorithm(s) by NIST (the US' National Institute of
  * Standards and Technology), described in FIPS PUB 180-2.
  */
+COLDFUNC(void Init_sha2(void));
 void
 Init_sha2(void)
 {

--- a/ext/etc/etc.c
+++ b/ext/etc/etc.c
@@ -1062,6 +1062,7 @@ etc_nprocessors(VALUE obj)
  * All operations defined in this module are class methods, so that you can
  * include the Etc module into your class.
  */
+COLDFUNC(void Init_etc(void));
 void
 Init_etc(void)
 {

--- a/ext/fcntl/fcntl.c
+++ b/ext/fcntl/fcntl.c
@@ -61,6 +61,7 @@ pack up your own arguments to pass as args for locking functions, etc.
  *   f.fcntl(Fcntl::F_SETFL, Fcntl::O_NONBLOCK|m)
  *
  */
+COLDFUNC(void Init_fcntl(void));
 void
 Init_fcntl(void)
 {

--- a/ext/fiddle/closure.c
+++ b/ext/fiddle/closure.c
@@ -288,6 +288,7 @@ to_i(VALUE self)
     return PTR2NUM(code);
 }
 
+COLDFUNC(void Init_fiddle_closure(void));
 void
 Init_fiddle_closure(void)
 {

--- a/ext/fiddle/closure.h
+++ b/ext/fiddle/closure.h
@@ -3,6 +3,6 @@
 
 #include <fiddle.h>
 
-void Init_fiddle_closure(void);
+COLDFUNC(void Init_fiddle_closure(void));
 
 #endif

--- a/ext/fiddle/function.h
+++ b/ext/fiddle/function.h
@@ -3,6 +3,6 @@
 
 #include <fiddle.h>
 
-void Init_fiddle_function(void);
+COLDFUNC(void Init_fiddle_function(void));
 
 #endif

--- a/ext/fiddle/handle.c
+++ b/ext/fiddle/handle.c
@@ -374,6 +374,7 @@ fiddle_handle_sym(void *handle, VALUE symbol)
     return PTR2NUM(func);
 }
 
+COLDFUNC(void Init_fiddle_handle(void));
 void
 Init_fiddle_handle(void)
 {

--- a/ext/fiddle/pointer.c
+++ b/ext/fiddle/pointer.c
@@ -674,6 +674,7 @@ rb_fiddle_ptr_s_to_ptr(VALUE self, VALUE val)
     return ptr;
 }
 
+COLDFUNC(void Init_fiddle_pointer(void));
 void
 Init_fiddle_pointer(void)
 {

--- a/ext/gdbm/gdbm.c
+++ b/ext/gdbm/gdbm.c
@@ -1224,6 +1224,7 @@ fgdbm_reject(VALUE obj)
     return rb_hash_delete_if(fgdbm_to_hash(obj));
 }
 
+COLDFUNC(void Init_gdbm(void));
 void
 Init_gdbm(void)
 {

--- a/ext/io/console/console.c
+++ b/ext/io/console/console.c
@@ -949,6 +949,7 @@ io_getpass(int argc, VALUE *argv, VALUE io)
 /*
  * IO console methods
  */
+COLDFUNC(void Init_console(void));
 void
 Init_console(void)
 {

--- a/ext/io/nonblock/nonblock.c
+++ b/ext/io/nonblock/nonblock.c
@@ -131,6 +131,7 @@ rb_io_nonblock_block(int argc, VALUE *argv, VALUE io)
 #define rb_io_nonblock_block rb_f_notimplement
 #endif
 
+COLDFUNC(void Init_nonblock(void));
 void
 Init_nonblock(void)
 {

--- a/ext/io/wait/wait.c
+++ b/ext/io/wait/wait.c
@@ -42,7 +42,7 @@
 static VALUE io_ready_p _((VALUE io));
 static VALUE io_wait_readable _((int argc, VALUE *argv, VALUE io));
 static VALUE io_wait_writable _((int argc, VALUE *argv, VALUE io));
-void Init_wait _((void));
+COLDFUNC(void Init_wait _((void)));
 
 static struct timeval *
 get_timeout(int argc, VALUE *argv, struct timeval *timerec)

--- a/ext/json/generator/generator.c
+++ b/ext/json/generator/generator.c
@@ -1333,6 +1333,7 @@ static VALUE cState_buffer_initial_length_set(VALUE self, VALUE buffer_initial_l
 /*
  *
  */
+COLDFUNC(void Init_generator(void));
 void Init_generator(void)
 {
 #undef rb_intern

--- a/ext/json/parser/parser.c
+++ b/ext/json/parser/parser.c
@@ -2064,6 +2064,7 @@ static VALUE cParser_source(VALUE self)
     return rb_str_dup(json->Vsource);
 }
 
+COLDFUNC(void Init_parser(void));
 void Init_parser(void)
 {
 #undef rb_intern

--- a/ext/nkf/nkf.c
+++ b/ext/nkf/nkf.c
@@ -474,6 +474,7 @@ rb_nkf_guess(VALUE obj, VALUE src)
  *  Ignore rest of -option.
  */
 
+COLDFUNC(void Init_nkf(void));
 void
 Init_nkf(void)
 {

--- a/ext/objspace/objspace.c
+++ b/ext/objspace/objspace.c
@@ -915,8 +915,8 @@ objspace_internal_super_of(VALUE self, VALUE obj)
     return wrap_klass_iow(super);
 }
 
-void Init_object_tracing(VALUE rb_mObjSpace);
-void Init_objspace_dump(VALUE rb_mObjSpace);
+COLDFUNC(void Init_object_tracing(VALUE rb_mObjSpace));
+COLDFUNC(void Init_objspace_dump(VALUE rb_mObjSpace));
 
 /*
  * Document-module: ObjectSpace
@@ -933,6 +933,7 @@ void Init_objspace_dump(VALUE rb_mObjSpace);
  * memory usage.
  */
 
+COLDFUNC(void Init_objspace(void));
 void
 Init_objspace(void)
 {

--- a/ext/openssl/ossl.h
+++ b/ext/openssl/ossl.h
@@ -173,6 +173,7 @@ void ossl_debug(const char *, ...);
 #include "ossl_engine.h"
 #include "ossl_kdf.h"
 
+COLDFUNC(void Init_openssl(void));
 void Init_openssl(void);
 
 #endif /* _OSSL_H_ */

--- a/ext/openssl/ossl_asn1.h
+++ b/ext/openssl/ossl_asn1.h
@@ -57,6 +57,7 @@ extern VALUE cASN1Sequence, cASN1Set;                /* CONSTRUCTIVE      */
 
 ASN1_TYPE *ossl_asn1_get_asn1type(VALUE);
 
+COLDFUNC(void Init_ossl_asn1(void));
 void Init_ossl_asn1(void);
 
 #endif

--- a/ext/openssl/ossl_bn.h
+++ b/ext/openssl/ossl_bn.h
@@ -19,7 +19,7 @@ extern BN_CTX *ossl_bn_ctx;
 
 VALUE ossl_bn_new(const BIGNUM *);
 BIGNUM *ossl_bn_value_ptr(volatile VALUE *);
-void Init_ossl_bn(void);
+COLDFUNC(void Init_ossl_bn(void));
 
 
 #endif /* _OSS_BN_H_ */

--- a/ext/openssl/ossl_cipher.h
+++ b/ext/openssl/ossl_cipher.h
@@ -15,6 +15,6 @@ extern VALUE eCipherError;
 
 const EVP_CIPHER *ossl_evp_get_cipherbyname(VALUE);
 VALUE ossl_cipher_new(const EVP_CIPHER *);
-void Init_ossl_cipher(void);
+COLDFUNC(void Init_ossl_cipher(void));
 
 #endif /* _OSSL_CIPHER_H_ */

--- a/ext/openssl/ossl_config.h
+++ b/ext/openssl/ossl_config.h
@@ -14,6 +14,6 @@ extern VALUE cConfig;
 extern VALUE eConfigError;
 
 CONF* DupConfigPtr(VALUE obj);
-void Init_ossl_config(void);
+COLDFUNC(void Init_ossl_config(void));
 
 #endif /* _OSSL_CONFIG_H_ */

--- a/ext/openssl/ossl_digest.h
+++ b/ext/openssl/ossl_digest.h
@@ -15,6 +15,6 @@ extern VALUE eDigestError;
 
 const EVP_MD *ossl_evp_get_digestbyname(VALUE);
 VALUE ossl_digest_new(const EVP_MD *);
-void Init_ossl_digest(void);
+COLDFUNC(void Init_ossl_digest(void));
 
 #endif /* _OSSL_DIGEST_H_ */

--- a/ext/openssl/ossl_engine.h
+++ b/ext/openssl/ossl_engine.h
@@ -14,6 +14,6 @@
 extern VALUE cEngine;
 extern VALUE eEngineError;
 
-void Init_ossl_engine(void);
+COLDFUNC(void Init_ossl_engine(void));
 
 #endif /* OSSL_ENGINE_H */

--- a/ext/openssl/ossl_hmac.h
+++ b/ext/openssl/ossl_hmac.h
@@ -13,6 +13,6 @@
 extern VALUE cHMAC;
 extern VALUE eHMACError;
 
-void Init_ossl_hmac(void);
+COLDFUNC(void Init_ossl_hmac(void));
 
 #endif /* _OSSL_HMAC_H_ */

--- a/ext/openssl/ossl_kdf.h
+++ b/ext/openssl/ossl_kdf.h
@@ -1,6 +1,6 @@
 #if !defined(OSSL_KDF_H)
 #define OSSL_KDF_H
 
-void Init_ossl_kdf(void);
+COLDFUNC(void Init_ossl_kdf(void));
 
 #endif

--- a/ext/openssl/ossl_ns_spki.h
+++ b/ext/openssl/ossl_ns_spki.h
@@ -14,6 +14,6 @@ extern VALUE mNetscape;
 extern VALUE cSPKI;
 extern VALUE eSPKIError;
 
-void Init_ossl_ns_spki(void);
+COLDFUNC(void Init_ossl_ns_spki(void));
 
 #endif /* _OSSL_NS_SPKI_H_ */

--- a/ext/openssl/ossl_ocsp.h
+++ b/ext/openssl/ossl_ocsp.h
@@ -18,6 +18,6 @@ extern VALUE cOPCSRes;
 extern VALUE cOPCSBasicRes;
 #endif
 
-void Init_ossl_ocsp(void);
+COLDFUNC(void Init_ossl_ocsp(void));
 
 #endif /* _OSSL_OCSP_H_ */

--- a/ext/openssl/ossl_pkcs12.h
+++ b/ext/openssl/ossl_pkcs12.h
@@ -8,6 +8,6 @@
 extern VALUE cPKCS12;
 extern VALUE ePKCS12Error;
 
-void Init_ossl_pkcs12(void);
+COLDFUNC(void Init_ossl_pkcs12(void));
 
 #endif /* _OSSL_PKCS12_H_ */

--- a/ext/openssl/ossl_pkcs7.h
+++ b/ext/openssl/ossl_pkcs7.h
@@ -15,6 +15,6 @@ extern VALUE cPKCS7Signer;
 extern VALUE cPKCS7Recipient;
 extern VALUE ePKCS7Error;
 
-void Init_ossl_pkcs7(void);
+COLDFUNC(void Init_ossl_pkcs7(void));
 
 #endif /* _OSSL_PKCS7_H_ */

--- a/ext/openssl/ossl_pkey.h
+++ b/ext/openssl/ossl_pkey.h
@@ -48,7 +48,7 @@ void ossl_pkey_check_public_key(const EVP_PKEY *);
 EVP_PKEY *GetPKeyPtr(VALUE);
 EVP_PKEY *DupPKeyPtr(VALUE);
 EVP_PKEY *GetPrivPKeyPtr(VALUE);
-void Init_ossl_pkey(void);
+COLDFUNC(void Init_ossl_pkey(void));
 
 /*
  * RSA
@@ -57,7 +57,7 @@ extern VALUE cRSA;
 extern VALUE eRSAError;
 
 VALUE ossl_rsa_new(EVP_PKEY *);
-void Init_ossl_rsa(void);
+COLDFUNC(void Init_ossl_rsa(void));
 
 /*
  * DSA
@@ -66,7 +66,7 @@ extern VALUE cDSA;
 extern VALUE eDSAError;
 
 VALUE ossl_dsa_new(EVP_PKEY *);
-void Init_ossl_dsa(void);
+COLDFUNC(void Init_ossl_dsa(void));
 
 /*
  * DH
@@ -75,7 +75,7 @@ extern VALUE cDH;
 extern VALUE eDHError;
 
 VALUE ossl_dh_new(EVP_PKEY *);
-void Init_ossl_dh(void);
+COLDFUNC(void Init_ossl_dh(void));
 
 /*
  * EC
@@ -87,7 +87,7 @@ extern VALUE eEC_GROUP;
 extern VALUE cEC_POINT;
 extern VALUE eEC_POINT;
 VALUE ossl_ec_new(EVP_PKEY *);
-void Init_ossl_ec(void);
+COLDFUNC(void Init_ossl_ec(void));
 
 #define OSSL_PKEY_BN_DEF_GETTER0(_keytype, _type, _name, _get)		\
 /*									\

--- a/ext/openssl/ossl_rand.h
+++ b/ext/openssl/ossl_rand.h
@@ -13,6 +13,6 @@
 extern VALUE mRandom;
 extern VALUE eRandomError;
 
-void Init_ossl_rand(void);
+COLDFUNC(void Init_ossl_rand(void));
 
 #endif /* _OSSL_RAND_H_ */

--- a/ext/openssl/ossl_ssl.h
+++ b/ext/openssl/ossl_ssl.h
@@ -30,7 +30,7 @@ extern VALUE mSSL;
 extern VALUE cSSLSocket;
 extern VALUE cSSLSession;
 
-void Init_ossl_ssl(void);
-void Init_ossl_ssl_session(void);
+COLDFUNC(void Init_ossl_ssl(void));
+COLDFUNC(void Init_ossl_ssl_session(void));
 
 #endif /* _OSSL_SSL_H_ */

--- a/ext/openssl/ossl_x509.h
+++ b/ext/openssl/ossl_x509.h
@@ -22,7 +22,7 @@ extern VALUE mX509;
  */
 ASN1_TIME *ossl_x509_time_adjust(ASN1_TIME *, VALUE);
 
-void Init_ossl_x509(void);
+COLDFUNC(void Init_ossl_x509(void));
 
 /*
  * X509Attr
@@ -32,7 +32,7 @@ extern VALUE eX509AttrError;
 
 VALUE ossl_x509attr_new(X509_ATTRIBUTE *);
 X509_ATTRIBUTE *GetX509AttrPtr(VALUE);
-void Init_ossl_x509attr(void);
+COLDFUNC(void Init_ossl_x509attr(void));
 
 /*
  * X509Cert
@@ -43,7 +43,7 @@ extern VALUE eX509CertError;
 VALUE ossl_x509_new(X509 *);
 X509 *GetX509CertPtr(VALUE);
 X509 *DupX509CertPtr(VALUE);
-void Init_ossl_x509cert(void);
+COLDFUNC(void Init_ossl_x509cert(void));
 
 /*
  * X509CRL
@@ -53,7 +53,7 @@ extern VALUE eX509CRLError;
 
 VALUE ossl_x509crl_new(X509_CRL *);
 X509_CRL *GetX509CRLPtr(VALUE);
-void Init_ossl_x509crl(void);
+COLDFUNC(void Init_ossl_x509crl(void));
 
 /*
  * X509Extension
@@ -64,7 +64,7 @@ extern VALUE eX509ExtError;
 
 VALUE ossl_x509ext_new(X509_EXTENSION *);
 X509_EXTENSION *GetX509ExtPtr(VALUE);
-void Init_ossl_x509ext(void);
+COLDFUNC(void Init_ossl_x509ext(void));
 
 /*
  * X509Name
@@ -74,7 +74,7 @@ extern VALUE eX509NameError;
 
 VALUE ossl_x509name_new(X509_NAME *);
 X509_NAME *GetX509NamePtr(VALUE);
-void Init_ossl_x509name(void);
+COLDFUNC(void Init_ossl_x509name(void));
 
 /*
  * X509Request
@@ -83,7 +83,7 @@ extern VALUE cX509Req;
 extern VALUE eX509ReqError;
 
 X509_REQ *GetX509ReqPtr(VALUE);
-void Init_ossl_x509req(void);
+COLDFUNC(void Init_ossl_x509req(void));
 
 /*
  * X509Revoked
@@ -93,7 +93,7 @@ extern VALUE eX509RevError;
 
 VALUE ossl_x509revoked_new(X509_REVOKED *);
 X509_REVOKED *DupX509RevokedPtr(VALUE);
-void Init_ossl_x509revoked(void);
+COLDFUNC(void Init_ossl_x509revoked(void));
 
 /*
  * X509Store and X509StoreContext
@@ -104,7 +104,7 @@ extern VALUE eX509StoreError;
 
 X509_STORE *GetX509StorePtr(VALUE);
 
-void Init_ossl_x509store(void);
+COLDFUNC(void Init_ossl_x509store(void));
 
 /*
  * Calls the verify callback Proc (the first parameter) with given pre-verify

--- a/ext/pathname/pathname.c
+++ b/ext/pathname/pathname.c
@@ -1505,6 +1505,7 @@ path_f_pathname(VALUE self, VALUE str)
  * anyway, and its documentation (e.g. through +ri+) will contain more
  * information.  In some cases, a brief description will follow.
  */
+COLDFUNC(void Init_pathname(void));
 void
 Init_pathname(void)
 {

--- a/ext/psych/psych_emitter.h
+++ b/ext/psych/psych_emitter.h
@@ -3,6 +3,6 @@
 
 #include <psych.h>
 
-void Init_psych_emitter(void);
+COLDFUNC(void Init_psych_emitter(void));
 
 #endif

--- a/ext/psych/psych_parser.h
+++ b/ext/psych/psych_parser.h
@@ -1,6 +1,6 @@
 #ifndef PSYCH_PARSER_H
 #define PSYCH_PARSER_H
 
-void Init_psych_parser(void);
+COLDFUNC(void Init_psych_parser(void));
 
 #endif

--- a/ext/psych/psych_to_ruby.h
+++ b/ext/psych/psych_to_ruby.h
@@ -3,6 +3,6 @@
 
 #include <psych.h>
 
-void Init_psych_to_ruby(void);
+COLDFUNC(void Init_psych_to_ruby(void));
 
 #endif

--- a/ext/psych/psych_yaml_tree.h
+++ b/ext/psych/psych_yaml_tree.h
@@ -3,6 +3,6 @@
 
 #include <psych.h>
 
-void Init_psych_yaml_tree(void);
+COLDFUNC(void Init_psych_yaml_tree(void));
 
 #endif

--- a/ext/pty/pty.c
+++ b/ext/pty/pty.c
@@ -736,6 +736,7 @@ static VALUE cPTY;
  *  results obtained from use of this software.
  */
 
+COLDFUNC(void Init_pty(void));
 void
 Init_pty(void)
 {

--- a/ext/racc/cparse/cparse.c
+++ b/ext/racc/cparse/cparse.c
@@ -812,6 +812,7 @@ reduce0(VALUE val, VALUE data, VALUE self)
                           Ruby Interface
 ----------------------------------------------------------------------- */
 
+COLDFUNC(void Init_cparse(void));
 void
 Init_cparse(void)
 {

--- a/ext/readline/readline.c
+++ b/ext/readline/readline.c
@@ -1885,6 +1885,7 @@ username_completion_proc_call(VALUE self, VALUE str)
 }
 
 #undef rb_intern
+COLDFUNC(void Init_readline(void));
 void
 Init_readline(void)
 {

--- a/ext/sdbm/init.c
+++ b/ext/sdbm/init.c
@@ -1012,6 +1012,7 @@ fsdbm_reject(VALUE obj)
     return rb_hash_delete_if(fsdbm_to_hash(obj));
 }
 
+COLDFUNC(void Init_sdbm(void));
 void
 Init_sdbm(void)
 {

--- a/ext/socket/rubysocket.h
+++ b/ext/socket/rubysocket.h
@@ -376,20 +376,20 @@ ssize_t rsock_recvmsg(int socket, struct msghdr *message, int flags);
 void rsock_discard_cmsg_resource(struct msghdr *mh, int msg_peek_p);
 #endif
 
-void rsock_init_basicsocket(void);
-void rsock_init_ipsocket(void);
-void rsock_init_tcpsocket(void);
-void rsock_init_tcpserver(void);
-void rsock_init_sockssocket(void);
-void rsock_init_udpsocket(void);
-void rsock_init_unixsocket(void);
-void rsock_init_unixserver(void);
-void rsock_init_socket_constants(void);
-void rsock_init_ancdata(void);
-void rsock_init_addrinfo(void);
-void rsock_init_sockopt(void);
-void rsock_init_sockifaddr(void);
-void rsock_init_socket_init(void);
+COLDFUNC(void rsock_init_basicsocket(void));
+COLDFUNC(void rsock_init_ipsocket(void));
+COLDFUNC(void rsock_init_tcpsocket(void));
+COLDFUNC(void rsock_init_tcpserver(void));
+COLDFUNC(void rsock_init_sockssocket(void));
+COLDFUNC(void rsock_init_udpsocket(void));
+COLDFUNC(void rsock_init_unixsocket(void));
+COLDFUNC(void rsock_init_unixserver(void));
+COLDFUNC(void rsock_init_socket_constants(void));
+COLDFUNC(void rsock_init_ancdata(void));
+COLDFUNC(void rsock_init_addrinfo(void));
+COLDFUNC(void rsock_init_sockopt(void));
+COLDFUNC(void rsock_init_sockifaddr(void));
+COLDFUNC(void rsock_init_socket_init(void));
 
 NORETURN(void rsock_syserr_fail_host_port(int err, const char *, VALUE, VALUE));
 NORETURN(void rsock_syserr_fail_path(int err, const char *, VALUE));

--- a/ext/socket/socket.c
+++ b/ext/socket/socket.c
@@ -1929,6 +1929,7 @@ socket_s_ip_address_list(VALUE self)
 #define socket_s_ip_address_list rb_f_notimplement
 #endif
 
+COLDFUNC(void Init_socket(void));
 void
 Init_socket(void)
 {

--- a/ext/syslog/syslog.c
+++ b/ext/syslog/syslog.c
@@ -418,6 +418,7 @@ static VALUE mSyslogMacros_included(VALUE mod, VALUE target)
  *
  * The syslog protocol is standardized in RFC 5424.
  */
+COLDFUNC(void Init_syslog(void));
 void Init_syslog(void)
 {
 #undef rb_intern

--- a/ext/win32/resolv/resolv.c
+++ b/ext/win32/resolv/resolv.c
@@ -49,6 +49,7 @@ get_dns_server_list(VALUE self)
     return nameservers;
 }
 
+COLDFUNC(void InitVM_resolv(void));
 void
 InitVM_resolv(void)
 {
@@ -58,6 +59,7 @@ InitVM_resolv(void)
     rb_define_private_method(singl, "get_dns_server_list", get_dns_server_list, 0);
 }
 
+COLDFUNC(void Init_resolv(void));
 void
 Init_resolv(void)
 {

--- a/ext/win32ole/win32ole.c
+++ b/ext/win32ole/win32ole.c
@@ -3975,6 +3975,7 @@ check_nano_server(void)
 }
 
 
+COLDFUNC(void Init_win32ole(void));
 void
 Init_win32ole(void)
 {

--- a/ext/win32ole/win32ole_event.h
+++ b/ext/win32ole/win32ole_event.h
@@ -1,6 +1,6 @@
 #ifndef WIN32OLE_EVENT_H
 #define WIN32OLE_EVENT_H 1
 
-void Init_win32ole_event(void);
+COLDFUNC(void Init_win32ole_event(void));
 
 #endif

--- a/ext/win32ole/win32ole_method.h
+++ b/ext/win32ole/win32ole_method.h
@@ -12,5 +12,5 @@ VALUE folemethod_s_allocate(VALUE klass);
 VALUE ole_methods_from_typeinfo(ITypeInfo *pTypeInfo, int mask);
 VALUE create_win32ole_method(ITypeInfo *pTypeInfo, VALUE name);
 struct olemethoddata *olemethod_data_get_struct(VALUE obj);
-void Init_win32ole_method(void);
+COLDFUNC(void Init_win32ole_method(void));
 #endif

--- a/ext/win32ole/win32ole_param.h
+++ b/ext/win32ole/win32ole_param.h
@@ -2,7 +2,7 @@
 #define WIN32OLE_PARAM_H
 
 VALUE create_win32ole_param(ITypeInfo *pTypeInfo, UINT method_index, UINT index, VALUE name);
-void Init_win32ole_param(void);
+COLDFUNC(void Init_win32ole_param(void));
 
 #endif
 

--- a/ext/win32ole/win32ole_record.h
+++ b/ext/win32ole/win32ole_record.h
@@ -5,6 +5,6 @@ VALUE cWIN32OLE_RECORD;
 void ole_rec2variant(VALUE rec, VARIANT *var);
 void olerecord_set_ivar(VALUE obj, IRecordInfo *pri, void *prec);
 VALUE create_win32ole_record(IRecordInfo *pri, void *prec);
-void Init_win32ole_record(void);
+COLDFUNC(void Init_win32ole_record(void));
 
 #endif

--- a/ext/win32ole/win32ole_type.h
+++ b/ext/win32ole/win32ole_type.h
@@ -4,5 +4,5 @@ VALUE cWIN32OLE_TYPE;
 VALUE create_win32ole_type(ITypeInfo *pTypeInfo, VALUE name);
 ITypeInfo *itypeinfo(VALUE self);
 VALUE ole_type_from_itypeinfo(ITypeInfo *pTypeInfo);
-void Init_win32ole_type(void);
+COLDFUNC(void Init_win32ole_type(void));
 #endif

--- a/ext/win32ole/win32ole_typelib.h
+++ b/ext/win32ole/win32ole_typelib.h
@@ -3,7 +3,7 @@
 
 VALUE cWIN32OLE_TYPELIB;
 
-void Init_win32ole_typelib(void);
+COLDFUNC(void Init_win32ole_typelib(void));
 ITypeLib * itypelib(VALUE self);
 VALUE typelib_file(VALUE ole);
 VALUE create_win32ole_typelib(ITypeLib *pTypeLib);

--- a/ext/win32ole/win32ole_variable.h
+++ b/ext/win32ole/win32ole_variable.h
@@ -3,6 +3,6 @@
 
 VALUE cWIN32OLE_VARIABLE;
 VALUE create_win32ole_variable(ITypeInfo *pTypeInfo, UINT index, VALUE name);
-void Init_win32ole_variable(void);
+COLDFUNC(void Init_win32ole_variable(void));
 
 #endif

--- a/ext/win32ole/win32ole_variant.h
+++ b/ext/win32ole/win32ole_variant.h
@@ -3,7 +3,7 @@
 
 VALUE cWIN32OLE_VARIANT;
 void ole_variant2variant(VALUE val, VARIANT *var);
-void Init_win32ole_variant(void);
+COLDFUNC(void Init_win32ole_variant(void));
 
 #endif
 

--- a/ext/win32ole/win32ole_variant_m.h
+++ b/ext/win32ole/win32ole_variant_m.h
@@ -2,6 +2,7 @@
 #define WIN32OLE_VARIANT_M_H 1
 
 VALUE mWIN32OLE_VARIANT;
+COLDFUNC(void Init_win32ole_variant_m(void));
 void Init_win32ole_variant_m(void);
 
 #endif

--- a/ext/zlib/zlib.c
+++ b/ext/zlib/zlib.c
@@ -291,7 +291,7 @@ static VALUE rb_gzreader_readlines(int, VALUE*, VALUE);
  *   - Zlib::GzipFile::NoFooter
  *
  */
-void Init_zlib(void);
+COLDFUNC(void Init_zlib(void));
 
 /*--------- Exceptions --------*/
 

--- a/gc.c
+++ b/gc.c
@@ -6651,6 +6651,7 @@ garbage_collect_with_gvl(rb_objspace_t *objspace, int reason)
 
 #undef Init_stack
 
+COLDFUNC(void Init_stack(volatile VALUE *addr));
 void
 Init_stack(volatile VALUE *addr)
 {
@@ -9780,6 +9781,7 @@ rb_gcdebug_remove_stress_to_class(int argc, VALUE *argv, VALUE self)
  *  GC::Profiler.
  */
 
+COLDFUNC(void Init_GC(void));
 void
 Init_GC(void)
 {

--- a/hash.c
+++ b/hash.c
@@ -4684,6 +4684,7 @@ env_update(VALUE env, VALUE hash)
  *  See also Object#hash and Object#eql?
  */
 
+COLDFUNC(void Init_Hash(void));
 void
 Init_Hash(void)
 {

--- a/include/ruby/defines.h
+++ b/include/ruby/defines.h
@@ -29,6 +29,9 @@ extern "C" {
 #ifndef PUREFUNC
 # define PUREFUNC(x) x
 #endif
+#ifndef COLDFUNC
+# define COLDFUNC(x) x
+#endif
 #ifndef DEPRECATED
 # define DEPRECATED(x) x
 #endif

--- a/include/ruby/intern.h
+++ b/include/ruby/intern.h
@@ -202,11 +202,11 @@ VALUE rb_class_public_instance_methods(int, const VALUE*, VALUE);
 VALUE rb_class_protected_instance_methods(int, const VALUE*, VALUE);
 VALUE rb_class_private_instance_methods(int, const VALUE*, VALUE);
 VALUE rb_obj_singleton_methods(int, const VALUE*, VALUE);
-void rb_define_method_id(VALUE, ID, VALUE (*)(ANYARGS), int);
-void rb_undef(VALUE, ID);
-void rb_define_protected_method(VALUE, const char*, VALUE (*)(ANYARGS), int);
-void rb_define_private_method(VALUE, const char*, VALUE (*)(ANYARGS), int);
-void rb_define_singleton_method(VALUE, const char*, VALUE(*)(ANYARGS), int);
+COLDFUNC(void rb_define_method_id(VALUE, ID, VALUE (*)(ANYARGS), int));
+COLDFUNC(void rb_undef(VALUE, ID));
+COLDFUNC(void rb_define_protected_method(VALUE, const char*, VALUE (*)(ANYARGS), int));
+COLDFUNC(void rb_define_private_method(VALUE, const char*, VALUE (*)(ANYARGS), int));
+COLDFUNC(void rb_define_singleton_method(VALUE, const char*, VALUE(*)(ANYARGS), int));
 VALUE rb_singleton_class(VALUE);
 /* compar.c */
 int rb_cmpint(VALUE, VALUE, VALUE);
@@ -375,8 +375,8 @@ void rb_remove_method(VALUE, const char*);
 void rb_remove_method_id(VALUE, ID);
 #define HAVE_RB_DEFINE_ALLOC_FUNC 1
 typedef VALUE (*rb_alloc_func_t)(VALUE);
-void rb_define_alloc_func(VALUE, rb_alloc_func_t);
-void rb_undef_alloc_func(VALUE);
+COLDFUNC(void rb_define_alloc_func(VALUE, rb_alloc_func_t));
+COLDFUNC(void rb_undef_alloc_func(VALUE));
 rb_alloc_func_t rb_get_alloc_func(VALUE);
 void rb_clear_constant_cache(void);
 void rb_clear_method_cache_by_class(VALUE);

--- a/include/ruby/ruby.h
+++ b/include/ruby/ruby.h
@@ -1699,10 +1699,10 @@ void rb_glob(const char*,void(*)(const char*,VALUE,void*),VALUE);
 int ruby_glob(const char*,int,ruby_glob_func*,VALUE);
 int ruby_brace_glob(const char*,int,ruby_glob_func*,VALUE);
 
-VALUE rb_define_class(const char*,VALUE);
-VALUE rb_define_module(const char*);
-VALUE rb_define_class_under(VALUE, const char*, VALUE);
-VALUE rb_define_module_under(VALUE, const char*);
+COLDFUNC(VALUE rb_define_class(const char*,VALUE));
+COLDFUNC(VALUE rb_define_module(const char*));
+COLDFUNC(VALUE rb_define_class_under(VALUE, const char*, VALUE));
+COLDFUNC(VALUE rb_define_module_under(VALUE, const char*));
 
 void rb_include_module(VALUE,VALUE);
 void rb_extend_object(VALUE,VALUE);
@@ -1728,26 +1728,26 @@ void  rb_gvar_var_marker(VALUE *var);
 
 NORETURN(void  rb_gvar_readonly_setter(VALUE val, ID id, void *data, struct rb_global_variable *gvar));
 
-void rb_define_variable(const char*,VALUE*);
-void rb_define_virtual_variable(const char*,VALUE(*)(ANYARGS),void(*)(ANYARGS));
-void rb_define_hooked_variable(const char*,VALUE*,VALUE(*)(ANYARGS),void(*)(ANYARGS));
-void rb_define_readonly_variable(const char*,const VALUE*);
-void rb_define_const(VALUE,const char*,VALUE);
-void rb_define_global_const(const char*,VALUE);
+COLDFUNC(void rb_define_variable(const char*,VALUE*));
+COLDFUNC(void rb_define_virtual_variable(const char*,VALUE(*)(ANYARGS),void(*)(ANYARGS)));
+COLDFUNC(void rb_define_hooked_variable(const char*,VALUE*,VALUE(*)(ANYARGS),void(*)(ANYARGS)));
+COLDFUNC(void rb_define_readonly_variable(const char*,const VALUE*));
+COLDFUNC(void rb_define_const(VALUE,const char*,VALUE));
+COLDFUNC(void rb_define_global_const(const char*,VALUE));
 
 #define RUBY_METHOD_FUNC(func) ((VALUE (*)(ANYARGS))(func))
-void rb_define_method(VALUE,const char*,VALUE(*)(ANYARGS),int);
-void rb_define_module_function(VALUE,const char*,VALUE(*)(ANYARGS),int);
-void rb_define_global_function(const char*,VALUE(*)(ANYARGS),int);
+COLDFUNC(void rb_define_method(VALUE,const char*,VALUE(*)(ANYARGS),int));
+COLDFUNC(void rb_define_module_function(VALUE,const char*,VALUE(*)(ANYARGS),int));
+COLDFUNC(void rb_define_global_function(const char*,VALUE(*)(ANYARGS),int));
 
-void rb_undef_method(VALUE,const char*);
-void rb_define_alias(VALUE,const char*,const char*);
-void rb_define_attr(VALUE,const char*,int,int);
+COLDFUNC(void rb_undef_method(VALUE,const char*));
+COLDFUNC(void rb_define_alias(VALUE,const char*,const char*));
+COLDFUNC(void rb_define_attr(VALUE,const char*,int,int));
 
-void rb_global_variable(VALUE*);
-void rb_gc_register_mark_object(VALUE);
-void rb_gc_register_address(VALUE*);
-void rb_gc_unregister_address(VALUE*);
+COLDFUNC(void rb_global_variable(VALUE*));
+COLDFUNC(void rb_gc_register_mark_object(VALUE));
+COLDFUNC(void rb_gc_register_address(VALUE*));
+COLDFUNC(void rb_gc_unregister_address(VALUE*));
 
 ID rb_intern(const char*);
 ID rb_intern2(const char*, long);

--- a/inits.c
+++ b/inits.c
@@ -13,6 +13,7 @@
 
 #define CALL(n) {void Init_##n(void); Init_##n();}
 
+COLDFUNC(void rb_call_inits(void));
 void
 rb_call_inits(void)
 {

--- a/internal.h
+++ b/internal.h
@@ -1154,7 +1154,7 @@ VALUE rb_obj_public_methods(int argc, const VALUE *argv, VALUE obj);
 VALUE rb_special_singleton_class(VALUE);
 VALUE rb_singleton_class_clone_and_attach(VALUE obj, VALUE attach);
 VALUE rb_singleton_class_get(VALUE obj);
-void Init_class_hierarchy(void);
+COLDFUNC(void Init_class_hierarchy(void));
 
 int rb_class_has_methods(VALUE c);
 void rb_undef_methods_from(VALUE klass, VALUE super);
@@ -1281,7 +1281,7 @@ VALUE rb_file_expand_path_internal(VALUE, VALUE, int, int, VALUE);
 VALUE rb_get_path_check_to_string(VALUE, int);
 VALUE rb_get_path_check_convert(VALUE, VALUE, int);
 VALUE rb_get_path_check(VALUE, int);
-void Init_File(void);
+COLDFUNC(void Init_File(void));
 int ruby_is_fd_loadable(int fd);
 
 #ifdef RUBY_FUNCTION_NAME_STRING
@@ -1303,7 +1303,7 @@ NORETURN(void rb_syserr_fail_path_in(const char *func_name, int err, VALUE path)
 /* gc.c */
 extern VALUE *ruby_initial_gc_stress_ptr;
 extern int ruby_disable_gc;
-void Init_heap(void);
+COLDFUNC(void Init_heap(void));
 void *ruby_mimmalloc(size_t size);
 void ruby_mimfree(void *ptr);
 void rb_objspace_set_event_hook(const rb_event_flag_t event);
@@ -1389,7 +1389,7 @@ extern const char ruby_exec_prefix[];
 extern const char ruby_initial_load_paths[];
 
 /* localeinit.c */
-int Init_enc_set_filesystem_encoding(void);
+COLDFUNC(int Init_enc_set_filesystem_encoding(void));
 
 /* math.c */
 VALUE rb_math_atan2(VALUE, VALUE);
@@ -1408,7 +1408,7 @@ VALUE mjit_pause(int wait_p);
 VALUE mjit_resume(void);
 
 /* newline.c */
-void Init_newline(void);
+COLDFUNC(void Init_newline(void));
 
 /* numeric.c */
 
@@ -1909,8 +1909,8 @@ rb_serial_t rb_next_class_serial(void);
 /* vm.c */
 VALUE rb_obj_is_thread(VALUE obj);
 void rb_vm_mark(void *ptr);
-void Init_BareVM(void);
-void Init_vm_objects(void);
+COLDFUNC(void Init_BareVM(void));
+COLDFUNC(void Init_vm_objects(void));
 PUREFUNC(VALUE rb_vm_top_self(void));
 void rb_thread_recycle_stack_release(VALUE *);
 void rb_vm_change_state(void);
@@ -1930,7 +1930,7 @@ PUREFUNC(st_table *rb_vm_fstring_table(void));
 void rb_print_backtrace(void);
 
 /* vm_eval.c */
-void Init_vm_eval(void);
+COLDFUNC(void Init_vm_eval(void));
 VALUE rb_current_realfilepath(void);
 VALUE rb_check_block_call(VALUE, ID, int, const VALUE *, rb_block_call_func_t, VALUE);
 typedef void rb_check_funcall_hook(int, VALUE, ID, int, const VALUE *, VALUE);
@@ -1949,14 +1949,14 @@ VALUE rb_equal_opt(VALUE obj1, VALUE obj2);
 VALUE rb_eql_opt(VALUE obj1, VALUE obj2);
 
 /* vm_method.c */
-void Init_eval_method(void);
+COLDFUNC(void Init_eval_method(void));
 int rb_method_defined_by(VALUE obj, ID mid, VALUE (*cfunc)(ANYARGS));
 
 /* miniprelude.c, prelude.c */
-void Init_prelude(void);
+COLDFUNC(void Init_prelude(void));
 
 /* vm_backtrace.c */
-void Init_vm_backtrace(void);
+COLDFUNC(void Init_vm_backtrace(void));
 VALUE rb_vm_thread_backtrace(int argc, const VALUE *argv, VALUE thval);
 VALUE rb_vm_thread_backtrace_locations(int argc, const VALUE *argv, VALUE thval);
 

--- a/io.c
+++ b/io.c
@@ -12924,6 +12924,7 @@ rb_readwrite_syserr_fail(enum rb_io_wait_readwrite writable, int n, const char *
  *    puts "Your screen is #{columns} wide and #{rows} tall"
  */
 
+COLDFUNC(void Init_IO(void));
 void
 Init_IO(void)
 {

--- a/iseq.c
+++ b/iseq.c
@@ -3197,6 +3197,7 @@ succ_index_lookup(const struct succ_index_table *sd, int x)
  *  you see.
  */
 
+COLDFUNC(void Init_ISeq(void));
 void
 Init_ISeq(void)
 {

--- a/load.c
+++ b/load.c
@@ -1170,6 +1170,7 @@ rb_f_autoload_p(VALUE obj, VALUE sym)
     return rb_mod_autoload_p(klass, sym);
 }
 
+COLDFUNC(void Init_load(void));
 void
 Init_load(void)
 {

--- a/marshal.c
+++ b/marshal.c
@@ -2227,6 +2227,7 @@ rb_marshal_load_with_proc(VALUE port, VALUE proc)
  * Since Marshal.dump outputs a string you can have _dump return a Marshal
  * string which is Marshal.loaded in _load for complex objects.
  */
+COLDFUNC(void Init_marshal(void));
 void
 Init_marshal(void)
 {

--- a/math.c
+++ b/math.c
@@ -972,6 +972,7 @@ exp1(sqrt)
  */
 
 
+COLDFUNC(void InitVM_Math(void));
 void
 InitVM_Math(void)
 {
@@ -1024,6 +1025,7 @@ InitVM_Math(void)
     rb_define_module_function(rb_mMath, "lgamma", math_lgamma, 1);
 }
 
+COLDFUNC(void Init_Math(void));
 void
 Init_Math(void)
 {

--- a/numeric.c
+++ b/numeric.c
@@ -5387,6 +5387,7 @@ rb_int_s_isqrt(VALUE self, VALUE num)
  *   puts tally * 2            #=> "||||"
  *   puts tally > 1            #=> true
  */
+COLDFUNC(void Init_Numeric(void));
 void
 Init_Numeric(void)
 {

--- a/object.c
+++ b/object.c
@@ -4009,6 +4009,7 @@ rb_obj_dig(int argc, VALUE *argv, VALUE obj, VALUE notfound)
  *++
  */
 
+COLDFUNC(void InitVM_Object(void));
 void
 InitVM_Object(void)
 {
@@ -4238,6 +4239,7 @@ InitVM_Object(void)
     rb_deprecate_constant(rb_cObject, "FALSE");
 }
 
+COLDFUNC(void Init_Object(void));
 void
 Init_Object(void)
 {

--- a/pack.c
+++ b/pack.c
@@ -1999,6 +1999,7 @@ utf8_to_uv(const char *p, long *lenp)
     return uv;
 }
 
+COLDFUNC(void Init_pack(void));
 void
 Init_pack(void)
 {

--- a/parse.y
+++ b/parse.y
@@ -11474,6 +11474,7 @@ ripper_lex_state_name(VALUE self, VALUE state)
     return rb_parser_lex_state_name(NUM2INT(state));
 }
 
+COLDFUNC(void Init_ripper(void));
 void
 Init_ripper(void)
 {
@@ -11486,6 +11487,7 @@ Init_ripper(void)
     InitVM(ripper);
 }
 
+COLDFUNC(void InitVM_ripper(void));
 void
 InitVM_ripper(void)
 {

--- a/proc.c
+++ b/proc.c
@@ -3065,6 +3065,7 @@ rb_method_curry(int argc, const VALUE *argv, VALUE self)
  *
  */
 
+COLDFUNC(void Init_Proc(void));
 void
 Init_Proc(void)
 {
@@ -3209,6 +3210,7 @@ Init_Proc(void)
  *
  */
 
+COLDFUNC(void Init_Binding(void));
 void
 Init_Binding(void)
 {

--- a/process.c
+++ b/process.c
@@ -8453,6 +8453,7 @@ InitVM_process(void)
     rb_define_module_function(rb_mProcID_Syscall, "issetugid", p_sys_issetugid, 0);
 }
 
+COLDFUNC(void Init_process(void));
 void
 Init_process(void)
 {

--- a/random.c
+++ b/random.c
@@ -1563,6 +1563,7 @@ rb_memhash(const void *ptr, long len)
 
 /* Initialize Ruby internal seeds. This function is called at very early stage
  * of Ruby startup. Thus, you can't use Ruby's object. */
+COLDFUNC(void Init_RandomSeedCore(void));
 void
 Init_RandomSeedCore(void)
 {
@@ -1595,6 +1596,7 @@ init_randomseed(struct MT *mt)
 }
 
 /* construct Random::DEFAULT bits */
+COLDFUNC(static VALUE Init_Random_default(void));
 static VALUE
 Init_Random_default(void)
 {
@@ -1640,6 +1642,7 @@ rb_reset_random_seed(void)
  * of 2**19937-1.
  */
 
+COLDFUNC(void InitVM_Random(void));
 void
 InitVM_Random(void)
 {
@@ -1686,6 +1689,7 @@ InitVM_Random(void)
 }
 
 #undef rb_intern
+COLDFUNC(void Init_Random(void));
 void
 Init_Random(void)
 {

--- a/range.c
+++ b/range.c
@@ -1469,6 +1469,7 @@ range_alloc(VALUE klass)
  *
  */
 
+COLDFUNC(void Init_Range(void));
 void
 Init_Range(void)
 {

--- a/rational.c
+++ b/rational.c
@@ -2660,6 +2660,7 @@ nurat_s_convert(int argc, VALUE *argv, VALUE klass)
  *    Rational(-8) ** Rational(1, 3)
  *                       #=> (1.0000000000000002+1.7320508075688772i)
  */
+COLDFUNC(void Init_Rational(void));
 void
 Init_Rational(void)
 {

--- a/re.c
+++ b/re.c
@@ -3996,6 +3996,7 @@ re_warn(const char *s)
  *  :include: doc/regexp.rdoc
  */
 
+COLDFUNC(void Init_Regexp(void));
 void
 Init_Regexp(void)
 {

--- a/ruby.c
+++ b/ruby.c
@@ -54,7 +54,7 @@
 
 #include "mjit.h"
 
-void Init_ruby_description(void);
+COLDFUNC(void Init_ruby_description(void));
 
 #ifndef HAVE_STDLIB_H
 char *getenv();

--- a/safe.c
+++ b/safe.c
@@ -120,6 +120,7 @@ rb_check_safe_obj(VALUE x)
     }
 }
 
+COLDFUNC(void Init_safe(void));
 void
 Init_safe(void)
 {

--- a/signal.c
+++ b/signal.c
@@ -1533,6 +1533,7 @@ int ruby_enable_coredump = 0;
  * system dependent. Signal delivery semantics may also vary between
  * systems; in particular signal delivery may not always be reliable.
  */
+COLDFUNC(void Init_signal(void));
 void
 Init_signal(void)
 {

--- a/string.c
+++ b/string.c
@@ -10903,6 +10903,7 @@ rb_to_symbol(VALUE name)
  *
  */
 
+COLDFUNC(void Init_String(void));
 void
 Init_String(void)
 {

--- a/struct.c
+++ b/struct.c
@@ -1304,6 +1304,7 @@ InitVM_Struct(void)
 }
 
 #undef rb_intern
+COLDFUNC(void Init_Struct(void));
 void
 Init_Struct(void)
 {

--- a/symbol.c
+++ b/symbol.c
@@ -35,6 +35,7 @@ static ID register_static_symid_str(ID, VALUE);
 STATIC_ASSERT(op_tbl_name_size, sizeof(op_tbl[0].name) == 3);
 #define op_tbl_len(i) (!op_tbl[i].name[1] ? 1 : !op_tbl[i].name[2] ? 2 : 3)
 
+COLDFUNC(static void Init_op_tbl(void));
 static void
 Init_op_tbl(void)
 {
@@ -72,6 +73,7 @@ static const struct st_hash_type symhash = {
     rb_str_hash,
 };
 
+COLDFUNC(void Init_sym(void));
 void
 Init_sym(void)
 {

--- a/template/extinit.c.tmpl
+++ b/template/extinit.c.tmpl
@@ -9,6 +9,7 @@
 
 void ruby_init_ext(const char *name, void (*init)(void));
 
+COLDFUNC(void Init_ext(void));
 void Init_ext(void)
 {
 % extinits.each do |f, n|

--- a/template/id.c.tmpl
+++ b/template/id.c.tmpl
@@ -30,6 +30,7 @@ static const struct {
 % end
 };
 
+COLDFUNC(static void Init_id(void));
 static void
 Init_id(void)
 {

--- a/template/limits.c.tmpl
+++ b/template/limits.c.tmpl
@@ -51,6 +51,7 @@
 # include <float.h>
 #endif
 
+COLDFUNC(void Init_limits(void));
 void
 Init_limits(void)
 {

--- a/template/prelude.c.tmpl
+++ b/template/prelude.c.tmpl
@@ -200,6 +200,9 @@ prelude_require(VALUE self, VALUE nth)
 
 % end
 %end
+%unless @preludes.empty?
+COLDFUNC(void Init_<%=@init_name%><%=%>(void));
+%end
 void
 Init_<%=@init_name%><%=%>(void)
 {

--- a/template/sizes.c.tmpl
+++ b/template/sizes.c.tmpl
@@ -25,7 +25,8 @@ conditions = {
 #endif
 
 % end
-extern void Init_limits(void);
+COLDFUNC(extern void Init_limits(void));
+COLDFUNC(void Init_sizeof(void));
 void
 Init_sizeof(void)
 {

--- a/thread.c
+++ b/thread.c
@@ -5061,6 +5061,7 @@ rb_thread_backtrace_locations_m(int argc, VALUE *argv, VALUE thval)
  *     note: use sleep to stop forever
  */
 
+COLDFUNC(void Init_Thread(void));
 void
 Init_Thread(void)
 {

--- a/thread_sync.c
+++ b/thread_sync.c
@@ -1453,6 +1453,7 @@ define_thread_class(VALUE outer, const char *name, VALUE super)
     return klass;
 }
 
+COLDFUNC(static void Init_thread_sync(void));
 static void
 Init_thread_sync(void)
 {

--- a/thread_win32.c
+++ b/thread_win32.c
@@ -143,6 +143,7 @@ ruby_thread_set_native(rb_thread_t *th)
     return TlsSetValue(ruby_native_thread_key, th);
 }
 
+COLDFUNC(void Init_native_thread(rb_thread_t *th));
 void
 Init_native_thread(rb_thread_t *th)
 {

--- a/time.c
+++ b/time.c
@@ -4896,6 +4896,7 @@ time_load(VALUE klass, VALUE str)
  *    Time.new(2010,10,31).between?(t1, t2) #=> true
  */
 
+COLDFUNC(void Init_Time(void));
 void
 Init_Time(void)
 {

--- a/transcode.c
+++ b/transcode.c
@@ -4412,6 +4412,7 @@ ecerr_incomplete_input(VALUE self)
  */
 
 #undef rb_intern
+COLDFUNC(void Init_transcode(void));
 void
 Init_transcode(void)
 {

--- a/variable.c
+++ b/variable.c
@@ -48,6 +48,7 @@ struct ivar_update {
     int iv_extended;
 };
 
+COLDFUNC(void Init_var_tables(void));
 void
 Init_var_tables(void)
 {

--- a/version.c
+++ b/version.c
@@ -38,6 +38,7 @@ const char ruby_copyright[] = RUBY_COPYRIGHT;
 const char ruby_engine[] = "ruby";
 
 /*! Defines platform-depended Ruby-level constants */
+COLDFUNC(void Init_version(void));
 void
 Init_version(void)
 {

--- a/vm.c
+++ b/vm.c
@@ -2835,6 +2835,7 @@ static VALUE usage_analysis_operand_stop(VALUE self);
 static VALUE usage_analysis_register_stop(VALUE self);
 #endif
 
+COLDFUNC(void Init_VM(void));
 void
 Init_VM(void)
 {
@@ -3206,6 +3207,7 @@ rb_vm_top_self(void)
     return GET_VM()->top_self;
 }
 
+COLDFUNC(void Init_top_self(void));
 void
 Init_top_self(void)
 {

--- a/vm_method.c
+++ b/vm_method.c
@@ -2106,6 +2106,7 @@ obj_respond_to_missing(VALUE obj, VALUE mid, VALUE priv)
     return Qfalse;
 }
 
+COLDFUNC(void Init_Method(void));
 void
 Init_Method(void)
 {

--- a/vm_trace.c
+++ b/vm_trace.c
@@ -1468,9 +1468,10 @@ tracepoint_stat_s(VALUE self)
     return stat;
 }
 
-static void Init_postponed_job(void);
+COLDFUNC(static void Init_postponed_job(void));
 
 /* This function is called from inits.c */
+COLDFUNC(void Init_vm_trace(void));
 void
 Init_vm_trace(void)
 {


### PR DESCRIPTION
### Why?

An incremental extraction from PR https://github.com/ruby/ruby/pull/1922, specifically addressing the feedback from @nurse  in https://github.com/ruby/ruby/pull/1922#issuecomment-413796710

The [Linux kernel](https://github.com/torvalds/linux/blob/ca04b3cca11acbaf904f707f2d9ca9654d7cc226/include/linux/compiler-gcc.h#L191-L206), [PHP 7](https://github.com/php/php-src/blob/2d71a28954a4f20709718ee7cb2b850d334c561c/Zend/zend_portability.h#L220) and other projects use the `hot` and `cold` function attributes to help with better code layout.

I noticed Ruby is very much CPU frontend bound (not feeding instructions into the CPU pipelines as fast as it maybe could) and therefore even most micro benchmarks have a high CPI (cycles per instruction) rate. This PR is part of a larger chunk of work I'd like to do around improving CPU frontend throughput and can take a stab at formally writing up those ideas if there's any interest from the community. I don't know.

### Implementation

This PR has an exclusive focus on having the `Init_xxx` functions for the core classes and those bundled in `ext` being flagged to be optimized for size as they're called only once at runtime.

The GCC specific [cold](https://gcc.gnu.org/onlinedocs/gcc-4.6.4/gcc/Function-Attributes.html) function attribute works in the following way (from GCC docs):

```
The cold attribute is used to inform the compiler that a function is unlikely executed. The function is optimized for size rather than speed and on many targets it is placed into special subsection of the text section so all cold functions appears close together improving code locality of non-cold parts of program. The paths leading to call of cold functions within code are marked as unlikely by the branch prediction mechanism. It is thus useful to mark functions used to handle unlikely conditions, such as perror, as cold to improve optimization of hot functions that do call marked functions in rare occasions.
When profile feedback is available, via -fprofile-use, hot functions are automatically detected and this attribute is ignored.
```
By declaring a function as `cold` when defined we get the following benefits:

* No-op on platforms that does not support the attribute
* Size optimization of cold functions with a smaller footprint in the instruction cache
* Therefore CPU frontend throughput increases due to a lower ratio of instruction cache misses and a lower ITLB overhead - see [original chunky PR](https://user-images.githubusercontent.com/379/44204858-4c085100-a14c-11e8-86b8-d87fcb5e4985.png) VS [then trunk](https://user-images.githubusercontent.com/379/44204870-4f9bd800-a14c-11e8-9bee-14c8ad8d3a7d.png)
* This effect can further be amplified in future work with the `hot` attribute

#### Extension APIs flagged as cold

These are and should typically only be called on extension init, and thus safe to optimize for size as well.

* `void rb_define_method_id(VALUE, ID, VALUE (*)(ANYARGS), int));`
* `void rb_undef(VALUE, ID));`
* `void rb_define_protected_method(VALUE, const char*, VALUE (*)(ANYARGS), int));`
* `void rb_define_private_method(VALUE, const char*, VALUE (*)(ANYARGS), int));`
* `void rb_define_singleton_method(VALUE, const char*, VALUE(*)(ANYARGS), int));`
* `void rb_define_alloc_func(VALUE, rb_alloc_func_t));`
* `void rb_undef_alloc_func(VALUE));`
* `VALUE rb_define_class(const char*,VALUE));`
* `VALUE rb_define_module(const char*));`
* `VALUE rb_define_class_under(VALUE, const char*, VALUE));`
* `VALUE rb_define_module_under(VALUE, const char*));`
* `void rb_define_variable(const char*,VALUE*));`
* `void rb_define_virtual_variable(const char*,VALUE(*)(ANYARGS),void(*)(ANYARGS)));`
* `void rb_define_hooked_variable(const char*,VALUE*,VALUE(*)(ANYARGS),void(*)(ANYARGS)));`
* `void rb_define_readonly_variable(const char*,const VALUE*));`
* `void rb_define_const(VALUE,const char*,VALUE));`
* `void rb_define_global_const(const char*,VALUE));`
* `void rb_define_method(VALUE,const char*,VALUE(*)(ANYARGS),int));`
* `(void rb_define_module_function(VALUE,const char*,VALUE(*)(ANYARGS),int));`
* `void rb_define_global_function(const char*,VALUE(*)(ANYARGS),int));`
* `void rb_undef_method(VALUE,const char*));`
* `void rb_define_alias(VALUE,const char*,const char*));`
* `void rb_define_attr(VALUE,const char*,int,int));`
* `void rb_global_variable(VALUE*));`
* `void rb_gc_register_mark_object(VALUE));`
* `void rb_gc_register_address(VALUE*));`
* `void rb_gc_unregister_address(VALUE*));`

#### Text segment reductions

Small changes (`3144` bytes reduction of the text segment) because this is incremental groundwork and and initial low risk PR.

this branch:

```
lourens@CarbonX1:~/src/ruby/ruby$ size ruby
   text	   data	    bss	    dec	    hex	filename
3462153	  21056	  71344	3554553	 363cf9	ruby
```

trunk:

```
lourens@CarbonX1:~/src/ruby/trunk$ size ruby
   text	   data	    bss	    dec	    hex	filename
3465297	  21056	  71344	3557697	 364941	ruby
```

Diffs for individual object files: https://www.diffchecker.com/T0GVzX1q

Default `text.unlikely` section where init functions are moved to:

```
lourens@CarbonX1:~/src/ruby/ruby$ readelf -S vm.o
There are 34 section headers, starting at offset 0x2a04f8:

Section Headers:
  [Nr] Name              Type             Address           Offset
       Size              EntSize          Flags  Link  Info  Align
  [ 0]                   NULL             0000000000000000  00000000
       0000000000000000  0000000000000000           0     0     0
  [ 1] .text             PROGBITS         0000000000000000  00000040
       000000000001c37f  0000000000000000  AX       0     0     16
  [ 2] .rela.text        RELA             0000000000000000  00114100
       000000000000a7d0  0000000000000018   I      31     1     8
  [ 3] .data             PROGBITS         0000000000000000  0001c3c0
       0000000000000030  0000000000000000  WA       0     0     16
  [ 4] .bss              NOBITS           0000000000000000  0001c400
       00000000000002b0  0000000000000000  WA       0     0     32
  [ 5] .rodata.str1.8    PROGBITS         0000000000000000  0001c400
       0000000000000d6f  0000000000000001 AMS       0     0     8
  [ 6] .text.unlikely    PROGBITS         0000000000000000  0001d16f <<<<<<<<<<<<<<<
       0000000000001aa9  0000000000000000  AX       0     0     1
```

The relocations for `vm.o`:

```
lourens@CarbonX1:~/src/ruby/ruby$ ld -M vm.o
--- truncated ---
.text           0x0000000000400120    0x1de2f
 *(.text.unlikely .text.*_unlikely .text.unlikely.*)
 .text.unlikely
                0x0000000000400120     0x1aa9 vm.o
                0x000000000040038f                rb_define_alloc_func
                0x00000000004003bf                rb_undef_alloc_func
                0x00000000004003c5                Init_Method
                0x0000000000400512                Init_vm_eval
                0x00000000004007a1                Init_eval_method
                0x0000000000400a54                rb_undef
                0x0000000000400c1d                Init_VM
                0x000000000040185f                Init_BareVM
                0x0000000000401b16                Init_vm_objects
                0x0000000000401b61                Init_top_self
 *(.text.exit .text.exit.*)
 *(.text.startup .text.startup.*)
 *(.text.hot .text.hot.*)
 *(.text .stub .text.* .gnu.linkonce.t.*)
 *fill*         0x0000000000401bc9        0x7 
 .text          0x0000000000401bd0    0x1c37f vm.o
                0x00000000004022f0                rb_f_notimplement
                0x0000000000404780                rb_vm_ep_local_ep
                0x00000000004047b0                rb_vm_frame_block_handler
                0x00000000004047e0                rb_vm_cref_new_toplevel
                0x0000000000404870                rb_vm_block_ep_update
                0x0000000000404890                ruby_vm_special_exception_copy
                0x0000000000406960                rb_ec_stack_overflow
                0x00000000004069c0                rb_vm_push_frame
                0x0000000000406b20                rb_vm_pop_frame
                0x0000000000406b30                rb_error_arity
                0x0000000000407180                rb_vm_frame_method_entry
                0x00000000004075e0                rb_vm_rewrite_cref
                0x00000000004076f0                rb_simple_iseq_p
                0x0000000000407700                rb_vm_opt_struct_aref
                0x0000000000407730                rb_vm_opt_struct_aset
                0x0000000000407750                rb_clear_constant_cache
--- truncated ---
```
I also dabbled with the idea of an `INITFUNC` macro that also places the `Init_xxx` functions into a `text.init` section as the [kernel does](https://linuxgazette.net/157/amurray.html) for a possible future optimization of stripping out ELF sections for setup / init specific functions. I don't think that makes sense for now and possibly only interesting for mruby or embedded.

### Possible next units of work

#### Cold code specific

* Incrementally PR corner case error handling functions such as `rb_bug` from https://github.com/ruby/ruby/pull/1922
* Ditto for generic error handling functions (`rb_raise` and friends) from https://github.com/ruby/ruby/pull/1922
* Class specific error handling functions (load errors, encoding errors in the IO module, sys errors etc.) from https://github.com/ruby/ruby/pull/1922
* GCC 5+ also supports `cold` [labels](https://gcc.gnu.org/onlinedocs/gcc/Label-Attributes.html) , which I took a stab with in the bloated https://github.com/ruby/ruby/pull/1922

#### TLB (translation lookaside buffer) specific

* Further ITLB overhead investigation
* Ruby binaries built with O3 and debug symbols come in at just short of 18MB, or roughly 9 hugepages on linux. PHP core developers were able to squeeze a few % by remapping code to hugepages on supported systems - http://developers-club.com/posts/270685/ . Implementation [here](https://github.com/php/php-src/blob/fb0389b1010de5a6459bcf286409423f69e74aaf/ext/opcache/ZendAccelerator.c#L2645-L2750)

#### Bytecode specific

* The [Intel Tracing Task API](https://software.intel.com/en-us/vtune-amplifier-help-task-api) is very well suited for the instruction sequences YARV generates and to infer better per instruction CPU utilization and identify any stalls (frontend, backend, branches etc.) to drive further work.