### PR TITLE
[backport] mkmf.rb: ignore linker warnings

### DIFF
--- a/lib/mkmf.rb
+++ b/lib/mkmf.rb
@@ -657,7 +657,7 @@ MSG
   end
 
   def try_ldflags(flags, opts = {})
-    try_link(MAIN_DOES_NOTHING, flags, {:werror => true}.update(opts))
+    try_link(MAIN_DOES_NOTHING, flags, opts)
   end
 
   def append_ldflags(flags, *opts)


### PR DESCRIPTION
This is a pull-request for backport to ruby 2.5 branch from below commit.
https://github.com/ruby/ruby/commit/4f03a23

Could you merge this?
mkmf pkg_config method does not work when gcc flag "-Wunused-parameter" is enabled on Fedora rawhide, 
Do I need to open new ticket on Ruby Bug Tracking System for that?

References:
[1] The issue page: https://bugs.ruby-lang.org/issues/13069
[2] The situation on Fedora: https://src.fedoraproject.org/rpms/rubygem-nokogiri/pull-request/3