### PR TITLE
Optimize rb_ary_and

### DIFF
--- a/array.c
+++ b/array.c
@@ -4225,7 +4225,7 @@ rb_ary_and(VALUE ary1, VALUE ary2)
 
     ary2 = to_ary(ary2);
     ary3 = rb_ary_new();
-    if (RARRAY_LEN(ary2) == 0) return ary3;
+    if (RARRAY_LEN(ary1) == 0 || RARRAY_LEN(ary2) == 0) return ary3;
 
     if (RARRAY_LEN(ary1) <= SMALL_ARRAY_LEN && RARRAY_LEN(ary2) <= SMALL_ARRAY_LEN) {
 	for (i=0; i<RARRAY_LEN(ary1); i++) {


### PR DESCRIPTION
`rb_ary_and` can return early if either the left-hand or right-hand argument is empty.