### PR TITLE
Add 'guards' for mswin, mingw, update test_readline.rb

### DIFF
--- a/test/lib/minitest/unit.rb
+++ b/test/lib/minitest/unit.rb
@@ -1171,6 +1171,21 @@ module MiniTest
       def windows? platform = RUBY_PLATFORM
         /mswin|mingw/ =~ platform
       end
+
+      ##
+      # Is this running on mingw?
+
+      def mingw? platform = RUBY_PLATFORM
+        /mingw/ =~ platform
+      end
+
+      ##
+      # Is this running on mswin?
+
+      def mswin? platform = RUBY_PLATFORM
+        /mswin/ =~ platform
+      end
+
     end
 
     ##


### PR DESCRIPTION
Add mswin? & mingw? methods to MiniTest::Unit::Guard, fixup readline test for mingw

See [Ruby Issue 15020](https://bugs.ruby-lang.org/issues/15020)