### PR TITLE
Windows fix r64578

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -771,18 +771,19 @@ TEXT
   # return the stub script text used to launch the true Ruby script
 
   def windows_stub_script(bindir, bin_file_name)
+    rb_bindir = RbConfig::CONFIG["bindir"]
     # All comparisons should be case insensitive
-    if bindir.downcase == RbConfig::CONFIG["bindir"].downcase
+    if bindir.downcase == rb_bindir.downcase
       # stub & ruby.exe withing same folder.  Portable
       <<-TEXT
 @ECHO OFF
 @"%~dp0ruby.exe" "%~dpn0" %*
       TEXT
-    elsif bindir.downcase.start_with? RbConfig::TOPDIR.downcase
+    elsif bindir.downcase.start_with? (RbConfig::TOPDIR || File.dirname(rb_bindir)).downcase
       # stub within ruby folder, but not standard bin.  Not portable
       require 'pathname'
       from = Pathname.new bindir
-      to   = Pathname.new RbConfig::CONFIG["bindir"]
+      to   = Pathname.new rb_bindir
       rel  = to.relative_path_from from
       <<-TEXT
 @ECHO OFF

--- a/spec/ruby/command_line/dash_encoding_spec.rb
+++ b/spec/ruby/command_line/dash_encoding_spec.rb
@@ -3,31 +3,32 @@ require_relative '../spec_helper'
 describe 'The --encoding command line option' do
   before :each do
     @test_string = "print [Encoding.default_external.name, Encoding.default_internal&.name].inspect"
+    @enc2 = /mswin|mingw/ !~ RUBY_PLATFORM ? 'UTF-32BE' : 'Windows-1256'
   end
 
   describe 'sets Encoding.default_external and optionally Encoding.default_internal' do
     it "if given a single encoding with an =" do
-      ruby_exe(@test_string, options: '--disable-gems --encoding=big5').should == [Encoding::Big5.name, nil].inspect
+      ruby_exe(@test_string, options: "--disable-gems --encoding=big5").should == [Encoding::Big5.name, nil].inspect
     end
 
     it "if given a single encoding as a separate argument" do
-      ruby_exe(@test_string, options: '--disable-gems --encoding big5').should == [Encoding::Big5.name, nil].inspect
+      ruby_exe(@test_string, options: "--disable-gems --encoding big5").should == [Encoding::Big5.name, nil].inspect
     end
 
     it "if given two encodings with an =" do
-      ruby_exe(@test_string, options: '--disable-gems --encoding=big5:utf-32be').should == [Encoding::Big5.name, Encoding::UTF_32BE.name].inspect
+      ruby_exe(@test_string, options: "--disable-gems --encoding=big5:#{@enc2}").should == [Encoding::Big5.name, @enc2].inspect
     end
 
     it "if given two encodings as a separate argument" do
-      ruby_exe(@test_string, options: '--disable-gems --encoding big5:utf-32be').should == [Encoding::Big5.name, Encoding::UTF_32BE.name].inspect
+      ruby_exe(@test_string, options: "--disable-gems --encoding big5:#{@enc2}").should == [Encoding::Big5.name, @enc2].inspect
     end
 
     it "if given two encodings as a separate argument" do
-      ruby_exe(@test_string, options: '--disable-gems --encoding big5:utf-32be').should == [Encoding::Big5.name, Encoding::UTF_32BE.name].inspect
+      ruby_exe(@test_string, options: "--disable-gems --encoding big5:#{@enc2}").should == [Encoding::Big5.name, @enc2].inspect
     end
   end
 
   it "does not accept a third encoding" do
-    ruby_exe(@test_string, options: '--disable-gems --encoding big5:utf-32be:utf-32le', args: '2>&1').should =~ /extra argument for --encoding: utf-32le/
+    ruby_exe(@test_string, options: "--disable-gems --encoding big5:#{@enc2}:#{@enc2}", args: '2>&1').should =~ /extra argument for --encoding: #{@enc2}/
   end
 end

--- a/spec/ruby/language/predefined/data_spec.rb
+++ b/spec/ruby/language/predefined/data_spec.rb
@@ -33,8 +33,12 @@ describe "The DATA constant" do
 
   it "is set even if there is no newline after __END__" do
     path = tmp("no_newline_data.rb")
-    code = File.binread(fixture(__FILE__, "empty_data.rb"))
-    touch(path) { |f| f.write code.chomp }
+    code = File.read(fixture(__FILE__, "empty_data.rb"))
+    if /mswin|mingw/ !~ RUBY_PLATFORM
+      touch(path) { |f| f.write code.chomp }
+    else
+      File.open(path, 'wb:UTF-8') { |f| f.write code.chomp }
+    end
     begin
       ruby_exe(path).should == "30\n\"\"\n"
     ensure

--- a/tool/rbinstall.rb
+++ b/tool/rbinstall.rb
@@ -792,7 +792,8 @@ install?(:ext, :comm, :gem, :'bundled-gems') do
   }
   gem_ext_dir = "#$extout/gems/#{CONFIG['arch']}"
   extensions_dir = Gem::StubSpecification.gemspec_stub("", gem_dir, gem_dir).extensions_dir
-  Gem::Specification.each_gemspec([srcdir+'/gems/*']) do |path|
+  dirs = Gem::Util.glob_files_in_dir "*/", "#{srcdir}/gems"
+  Gem::Specification.each_gemspec(dirs) do |path|
     spec = load_gemspec(path)
     next unless spec.platform == Gem::Platform::RUBY
     next unless spec.full_name == path[srcdir.size..-1][/\A\/gems\/([^\/]+)/, 1]


### PR DESCRIPTION
Fix lib/rubygems/installer.rb, tool/rbinstall.rb

* `lib/rubygems/installer.rb` - update for installation use, where `RbConfig::TOPDIR` may be nil
* `tool/rbinstall.rb` - updates for use with changes to RubyGems

Updates spec files to pass on Windows 

* `command_line/dash_encoding_spec.rb`  - use encoding available on Windows
* `language/predefined/data_spec.rb` - DATA.pos off due to windows `\r` character.  Change file writing.
