### PR TITLE
Omit executing methods/blocks that are side-effect free

### DIFF
--- a/insns.def
+++ b/insns.def
@@ -45,6 +45,9 @@
 
        * handles_sp: If it is true, VM deals with sp in the insn.
 
+       * purity: describes if the instruction has a side effect or
+         not.  There are four kinds of purity: see insns_info.inc.
+
    - Attributes can access operands, but not stack (push/pop) variables.
 
    - An instruction's body is a pure C block, copied verbatimly into
@@ -57,6 +60,7 @@ nop
 ()
 ()
 ()
+// attr enum rb_insn_purity purity = rb_insn_is_pure;
 {
     /* none */
 }
@@ -73,6 +77,7 @@ getlocal
 (lindex_t idx, rb_num_t level)
 ()
 (VALUE val)
+// attr enum rb_insn_purity purity = rb_insn_is_pure;
 {
     val = *(vm_get_ep(GET_EP(), level) - idx);
     RB_DEBUG_COUNTER_INC(lvar_get);
@@ -87,6 +92,7 @@ setlocal
 (lindex_t idx, rb_num_t level)
 (VALUE val)
 ()
+// attr enum rb_insn_purity purity = purity_of_lvar_access(level);
 {
     vm_env_write(vm_get_ep(GET_EP(), level), -(int)idx, val);
     RB_DEBUG_COUNTER_INC(lvar_set);
@@ -99,6 +105,7 @@ getblockparam
 (lindex_t idx, rb_num_t level)
 ()
 (VALUE val)
+// attr enum rb_insn_purity purity = rb_insn_is_pure;
 {
     const VALUE *ep = vm_get_ep(GET_EP(), level);
     VM_ASSERT(VM_ENV_LOCAL_P(ep));
@@ -121,6 +128,7 @@ setblockparam
 (lindex_t idx, rb_num_t level)
 (VALUE val)
 ()
+// attr enum rb_insn_purity purity = purity_of_lvar_access(level);
 {
     const VALUE *ep = vm_get_ep(GET_EP(), level);
     VM_ASSERT(VM_ENV_LOCAL_P(ep));
@@ -140,6 +148,7 @@ getblockparamproxy
 (lindex_t idx, rb_num_t level)
 ()
 (VALUE val)
+// attr enum rb_insn_purity purity = rb_insn_is_pure;
 {
     const VALUE *ep = vm_get_ep(GET_EP(), level);
     VM_ASSERT(VM_ENV_LOCAL_P(ep));
@@ -183,6 +192,7 @@ getspecial
 (rb_num_t key, rb_num_t type)
 ()
 (VALUE val)
+// attr enum rb_insn_purity purity = rb_insn_is_pure;
 {
     val = vm_getspecial(ec, GET_LEP(), key, type);
 }
@@ -193,6 +203,7 @@ setspecial
 (rb_num_t key)
 (VALUE obj)
 ()
+// attr enum rb_insn_purity purity = rb_insn_is_pure;
 {
     lep_svar_set(ec, GET_LEP(), key, obj);
 }
@@ -203,6 +214,7 @@ getinstancevariable
 (ID id, IC ic)
 ()
 (VALUE val)
+// attr enum rb_insn_purity purity = rb_insn_is_not_pure;
 {
     val = vm_getinstancevariable(GET_SELF(), id, ic);
 }
@@ -213,6 +225,7 @@ setinstancevariable
 (ID id, IC ic)
 (VALUE val)
 ()
+// attr enum rb_insn_purity purity = rb_insn_is_not_pure;
 {
     vm_setinstancevariable(GET_SELF(), id, val, ic);
 }
@@ -223,6 +236,7 @@ getclassvariable
 (ID id)
 ()
 (VALUE val)
+// attr enum rb_insn_purity purity = rb_insn_is_not_pure;
 {
     val = rb_cvar_get(vm_get_cvar_base(rb_vm_get_cref(GET_EP()), GET_CFP()), id);
 }
@@ -233,6 +247,7 @@ setclassvariable
 (ID id)
 (VALUE val)
 ()
+// attr enum rb_insn_purity purity = rb_insn_is_not_pure;
 {
     vm_ensure_not_refinement_module(GET_SELF());
     rb_cvar_set(vm_get_cvar_base(rb_vm_get_cref(GET_EP()), GET_CFP()), id, val);
@@ -247,6 +262,8 @@ getconstant
 (ID id)
 (VALUE klass)
 (VALUE val)
+/* getconstant can kick autoload, hence not pure. */
+// attr enum rb_insn_purity purity = rb_insn_is_not_pure;
 {
     val = vm_get_ev_const(ec, klass, id, 0);
 }
@@ -258,6 +275,7 @@ setconstant
 (ID id)
 (VALUE val, VALUE cbase)
 ()
+// attr enum rb_insn_purity purity = rb_insn_is_not_pure;
 {
     vm_check_if_namespace(cbase);
     vm_ensure_not_refinement_module(GET_SELF());
@@ -270,6 +288,8 @@ getglobal
 (GENTRY entry)
 ()
 (VALUE val)
+/* getglobal can be hooked, hence not pure. */
+// attr enum rb_insn_purity purity = rb_insn_is_not_pure;
 {
     val = GET_GLOBAL((VALUE)entry);
 }
@@ -280,6 +300,7 @@ setglobal
 (GENTRY entry)
 (VALUE val)
 ()
+// attr enum rb_insn_purity purity = rb_insn_is_not_pure;
 {
     SET_GLOBAL((VALUE)entry, val);
 }
@@ -294,6 +315,7 @@ putnil
 ()
 ()
 (VALUE val)
+// attr enum rb_insn_purity purity = rb_insn_is_pure;
 {
     val = Qnil;
 }
@@ -304,6 +326,7 @@ putself
 ()
 ()
 (VALUE val)
+// attr enum rb_insn_purity purity = rb_insn_is_pure;
 {
     val = GET_SELF();
 }
@@ -316,6 +339,7 @@ putobject
 (VALUE val)
 ()
 (VALUE val)
+// attr enum rb_insn_purity purity = rb_insn_is_pure;
 {
     /* */
 }
@@ -326,6 +350,7 @@ putspecialobject
 (rb_num_t value_type)
 ()
 (VALUE val)
+// attr enum rb_insn_purity purity = rb_insn_is_pure;
 {
     enum vm_special_object_type type;
 
@@ -339,6 +364,7 @@ putiseq
 (ISEQ iseq)
 ()
 (VALUE ret)
+// attr enum rb_insn_purity purity = rb_insn_is_pure;
 {
     ret = (VALUE)iseq;
 }
@@ -349,6 +375,7 @@ putstring
 (VALUE str)
 ()
 (VALUE val)
+// attr enum rb_insn_purity purity = rb_insn_is_pure;
 {
     val = rb_str_resurrect(str);
 }
@@ -359,6 +386,9 @@ concatstrings
 (rb_num_t num)
 (...)
 (VALUE val)
+/* This instruction does not convert things into strings.  That is
+ * expected to be done a priori. Hence it is pure. */
+// attr enum rb_insn_purity purity = rb_insn_is_pure;
 // attr rb_snum_t sp_inc = 1 - num;
 {
     val = rb_str_concat_literals(num, STACK_ADDR_FROM_TOP(num));
@@ -370,6 +400,8 @@ tostring
 ()
 (VALUE val, VALUE str)
 (VALUE val)
+/* Not pure because it calls methods */
+// attr enum rb_insn_purity purity = rb_insn_is_not_pure;
 {
     val = rb_obj_as_string_result(str, val);
 }
@@ -380,6 +412,7 @@ freezestring
 (VALUE debug_info)
 (VALUE str)
 (VALUE str)
+// attr enum rb_insn_purity purity = rb_insn_is_pure; /* no method calls. */
 {
     vm_freezestring(str, debug_info);
 }
@@ -392,6 +425,9 @@ toregexp
 (rb_num_t opt, rb_num_t cnt)
 (...)
 (VALUE val)
+/* In contrast to rb_str_concat_literals(), rb_reg_new_ary() DO call
+ * methods internally.  This instrtuction is not pure. */
+// attr enum rb_insn_purity purity = rb_insn_is_not_pure;
 // attr rb_snum_t sp_inc = 1 - cnt;
 {
     const VALUE ary = rb_ary_tmp_new_from_values(0, cnt, STACK_ADDR_FROM_TOP(cnt));
@@ -405,6 +441,7 @@ intern
 ()
 (VALUE str)
 (VALUE sym)
+// attr enum rb_insn_purity purity = rb_insn_is_pure;
 {
     sym = rb_str_intern(str);
 }
@@ -415,6 +452,7 @@ newarray
 (rb_num_t num)
 (...)
 (VALUE val)
+// attr enum rb_insn_purity purity = rb_insn_is_pure;
 // attr rb_snum_t sp_inc = 1 - num;
 {
     val = rb_ary_new4(num, STACK_ADDR_FROM_TOP(num));
@@ -426,6 +464,7 @@ duparray
 (VALUE ary)
 ()
 (VALUE val)
+// attr enum rb_insn_purity purity = rb_insn_is_pure;
 {
     val = rb_ary_resurrect(ary);
 }
@@ -444,6 +483,8 @@ expandarray
 (rb_num_t num, rb_num_t flag)
 (..., VALUE ary)
 (...)
+/* Not pure because it calls methods */
+// attr enum rb_insn_purity purity = rb_insn_is_not_pure;
 // attr rb_snum_t sp_inc = num - 1 + (flag & 1 ? 1 : 0);
 {
     vm_expandarray(GET_SP(), ary, num, (int)flag);
@@ -455,6 +496,8 @@ concatarray
 ()
 (VALUE ary1, VALUE ary2)
 (VALUE ary)
+/* Not pure because it calls methods */
+// attr enum rb_insn_purity purity = rb_insn_is_not_pure;
 {
     ary = vm_concat_array(ary1, ary2);
 }
@@ -465,6 +508,8 @@ splatarray
 (VALUE flag)
 (VALUE ary)
 (VALUE obj)
+/* Not pure because it calls methods */
+// attr enum rb_insn_purity purity = rb_insn_is_not_pure;
 {
     obj = vm_splat_array(flag, ary);
 }
@@ -475,6 +520,7 @@ newhash
 (rb_num_t num)
 (...)
 (VALUE val)
+// attr enum rb_insn_purity purity = rb_insn_is_pure;
 // attr rb_snum_t sp_inc = 1 - num;
 {
     RUBY_DTRACE_CREATE_HOOK(HASH, num);
@@ -492,6 +538,8 @@ newrange
 (rb_num_t flag)
 (VALUE low, VALUE high)
 (VALUE val)
+/* rb_range_new() exercises "bad value for range" check. Not pure. */
+// attr enum rb_insn_purity purity = rb_insn_is_not_pure;
 {
     val = rb_range_new(low, high, (int)flag);
 }
@@ -506,6 +554,7 @@ pop
 ()
 (VALUE val)
 ()
+// attr enum rb_insn_purity purity = rb_insn_is_pure;
 {
     (void)val;
     /* none */
@@ -517,6 +566,7 @@ dup
 ()
 (VALUE val)
 (VALUE val1, VALUE val2)
+// attr enum rb_insn_purity purity = rb_insn_is_pure;
 {
     val1 = val2 = val;
 }
@@ -527,6 +577,7 @@ dupn
 (rb_num_t n)
 (...)
 (...)
+// attr enum rb_insn_purity purity = rb_insn_is_pure;
 // attr rb_snum_t sp_inc = n;
 {
     void *dst = GET_SP();
@@ -541,6 +592,7 @@ swap
 ()
 (VALUE val, VALUE obj)
 (VALUE obj, VALUE val)
+// attr enum rb_insn_purity purity = rb_insn_is_pure;
 {
     /* none */
 }
@@ -551,6 +603,7 @@ reverse
 (rb_num_t n)
 (...)
 (...)
+// attr enum rb_insn_purity purity = rb_insn_is_pure;
 // attr rb_snum_t sp_inc = 0;
 {
     rb_num_t i;
@@ -570,6 +623,7 @@ reput
 ()
 (..., VALUE val)
 (VALUE val)
+// attr enum rb_insn_purity purity = rb_insn_is_pure;
 // attr rb_snum_t sp_inc = 0;
 {
     /* none */
@@ -581,6 +635,7 @@ topn
 (rb_num_t n)
 (...)
 (VALUE val)
+// attr enum rb_insn_purity purity = rb_insn_is_pure;
 // attr rb_snum_t sp_inc = 1;
 {
     val = TOPN(n);
@@ -592,6 +647,7 @@ setn
 (rb_num_t n)
 (..., VALUE val)
 (VALUE val)
+// attr enum rb_insn_purity purity = rb_insn_is_pure;
 // attr rb_snum_t sp_inc = 0;
 {
     TOPN(n) = val;
@@ -603,6 +659,7 @@ adjuststack
 (rb_num_t n)
 (...)
 (...)
+// attr enum rb_insn_purity purity = rb_insn_is_pure;
 // attr rb_snum_t sp_inc = -(rb_snum_t)n;
 {
     /* none */
@@ -618,6 +675,7 @@ defined
 (rb_num_t op_type, VALUE obj, VALUE needstr)
 (VALUE v)
 (VALUE val)
+// attr enum rb_insn_purity purity = purity_of_defined(op_type);
 {
     val = vm_defined(ec, GET_CFP(), op_type, obj, needstr, v);
 }
@@ -634,6 +692,8 @@ checkmatch
 (rb_num_t flag)
 (VALUE target, VALUE pattern)
 (VALUE result)
+/* Not pure because it calls methods */
+// attr enum rb_insn_purity purity = rb_insn_is_not_pure;
 {
     result = vm_check_match(ec, target, pattern, flag);
 }
@@ -644,6 +704,7 @@ checkkeyword
 (lindex_t kw_bits_index, lindex_t keyword_index)
 ()
 (VALUE ret)
+// attr enum rb_insn_purity purity = rb_insn_is_pure;
 {
     ret = vm_check_keyword(kw_bits_index, keyword_index, GET_EP());
 }
@@ -654,6 +715,7 @@ checktype
 (rb_num_t type)
 (VALUE val)
 (VALUE ret)
+// attr enum rb_insn_purity purity = rb_insn_is_pure;
 {
     ret = (TYPE(val) == (int)type) ? Qtrue : Qfalse;
 }
@@ -664,6 +726,7 @@ tracecoverage
 (rb_num_t nf, VALUE data)
 ()
 ()
+// attr enum rb_insn_purity purity = rb_insn_is_pure;
 {
     rb_event_flag_t flag = (rb_event_flag_t)nf;
 
@@ -683,6 +746,8 @@ defineclass
 (ID id, ISEQ class_iseq, rb_num_t flags)
 (VALUE cbase, VALUE super)
 (VALUE val)
+/* Has VM-global side effects; not pure. */
+// attr enum rb_insn_purity purity = rb_insn_is_not_pure;
 // attr bool handles_sp = true;
 {
     VALUE klass = vm_find_or_create_class_by_id(id, flags, cbase, super);
@@ -710,6 +775,7 @@ send
 (CALL_INFO ci, CALL_CACHE cc, ISEQ blockiseq)
 (...)
 (VALUE val)
+// attr enum rb_insn_purity purity = purity_of_sendish(ci, cc, blockiseq);
 // attr bool handles_sp = true;
 // attr rb_snum_t sp_inc = - (int)(ci->orig_argc + ((ci->flag & VM_CALL_ARGS_BLOCKARG) ? 1 : 0));
 {
@@ -718,6 +784,15 @@ send
     calling.block_handler = vm_caller_setup_arg_block(ec, reg_cfp, ci, blockiseq, FALSE);
     calling.recv = TOPN(calling.argc = ci->orig_argc);
     vm_search_method(ci, cc, calling.recv);
+
+#ifdef CURRENT_INSN_IS
+    if (vm_whether_we_can_skip_this_call_site_p(
+            CURRENT_INSN_IS(pop), cc, calling.block_handler)) {
+        ADJ_SP(INSN_ATTR(sp_inc) - 1); /* pop recv and argv from stack */
+        val = Qundef;                  /* dummy retval (not used) */
+    }
+    else
+#endif
     CALL_METHOD(&calling, ci, cc);
 }
 
@@ -726,6 +801,7 @@ opt_str_freeze
 (VALUE str)
 ()
 (VALUE val)
+// attr enum rb_insn_purity purity = purity_of_BOP(BOP_FREEZE, STRING_REDEFINED_OP_FLAG);
 {
     val = vm_opt_str_freeze(str, BOP_FREEZE, idFreeze);
 }
@@ -735,6 +811,7 @@ opt_str_uminus
 (VALUE str)
 ()
 (VALUE val)
+// attr enum rb_insn_purity purity = purity_of_BOP(BOP_UMINUS, STRING_REDEFINED_OP_FLAG);
 {
     val = vm_opt_str_freeze(str, BOP_UMINUS, idUMinus);
 }
@@ -744,6 +821,11 @@ opt_newarray_max
 (rb_num_t num)
 (...)
 (VALUE val)
+/* This instruction typically has no side effects.  But it compares
+ * array contents each other by nature.  That part can have side
+ * effects when redefined.  No way to detect such redefinition
+ * beforehand.  We cannot but mark it being not pure. */
+// attr enum rb_insn_purity purity = rb_insn_is_not_pure;
 // attr rb_snum_t sp_inc = 1 - num;
 {
     val = vm_opt_newarray_max(num, STACK_ADDR_FROM_TOP(num));
@@ -754,6 +836,8 @@ opt_newarray_min
 (rb_num_t num)
 (...)
 (VALUE val)
+/* Same discussion as opt_newarray_max. Not pure. */
+// attr enum rb_insn_purity purity = rb_insn_is_not_pure;
 // attr rb_snum_t sp_inc = 1 - num;
 {
     val = vm_opt_newarray_min(num, STACK_ADDR_FROM_TOP(num));
@@ -765,12 +849,22 @@ opt_send_without_block
 (CALL_INFO ci, CALL_CACHE cc)
 (...)
 (VALUE val)
+// attr enum rb_insn_purity purity = purity_of_cc(cc);
 // attr bool handles_sp = true;
 // attr rb_snum_t sp_inc = -ci->orig_argc;
 {
     struct rb_calling_info calling;
     calling.block_handler = VM_BLOCK_HANDLER_NONE;
     vm_search_method(ci, cc, calling.recv = TOPN(calling.argc = ci->orig_argc));
+
+#ifdef CURRENT_INSN_IS
+    if (vm_whether_we_can_skip_this_call_site_p(
+            CURRENT_INSN_IS(pop), cc, calling.block_handler)) {
+        ADJ_SP(INSN_ATTR(sp_inc) - 1); /* pop recv and argv from stack */
+        val = Qundef;                  /* dummy retval (not used) */
+    }
+    else
+#endif
     CALL_METHOD(&calling, ci, cc);
 }
 
@@ -780,6 +874,7 @@ invokesuper
 (CALL_INFO ci, CALL_CACHE cc, ISEQ blockiseq)
 (...)
 (VALUE val)
+// attr enum rb_insn_purity purity = purity_of_sendish(ci, cc, blockiseq);
 // attr bool handles_sp = true;
 // attr rb_snum_t sp_inc = - (int)(ci->orig_argc + ((ci->flag & VM_CALL_ARGS_BLOCKARG) ? 1 : 0));
 {
@@ -788,6 +883,15 @@ invokesuper
     calling.block_handler = vm_caller_setup_arg_block(ec, reg_cfp, ci, blockiseq, TRUE);
     calling.recv = TOPN(calling.argc = ci->orig_argc);
     vm_search_super_method(ec, GET_CFP(), &calling, ci, cc);
+
+#ifdef CURRENT_INSN_IS
+    if (vm_whether_we_can_skip_this_call_site_p(
+            CURRENT_INSN_IS(pop), cc, calling.block_handler)) {
+        ADJ_SP(INSN_ATTR(sp_inc) - 1); /* pop recv and argv from stack */
+        val = Qundef;                  /* dummy retval (not used) */
+    }
+    else
+#endif
     CALL_METHOD(&calling, ci, cc);
 }
 
@@ -797,6 +901,7 @@ invokeblock
 (CALL_INFO ci)
 (...)
 (VALUE val)
+// attr enum rb_insn_purity purity = purity_of_invokeblock(ci);
 // attr bool handles_sp = true;
 // attr rb_snum_t sp_inc = 1 - ci->orig_argc;
 {
@@ -812,6 +917,14 @@ invokeblock
 	rb_vm_localjump_error("no block given (yield)", Qnil, 0);
     }
 
+#ifdef CURRENT_INSN_IS
+    if (vm_whether_we_can_skip_this_call_site_p(
+            CURRENT_INSN_IS(pop), NULL, block_handler)) {
+        ADJ_SP(INSN_ATTR(sp_inc) - 1); /* pop recv and argv from stack */
+        val = Qfalse;                  /* dummy retval (not used) */
+    }
+    else
+#endif
     val = vm_invoke_block(ec, GET_CFP(), &calling, ci, block_handler);
     if (val == Qundef) {
         EXEC_EC_CFP(val);
@@ -824,6 +937,7 @@ leave
 ()
 (VALUE val)
 (VALUE val)
+// attr enum rb_insn_purity purity = rb_insn_is_pure;
 // attr bool handles_sp = true;
 {
     if (OPT_CHECKED_RUN) {
@@ -858,6 +972,7 @@ throw
 (rb_num_t throw_state)
 (VALUE throwobj)
 (VALUE val)
+// attr enum rb_insn_purity purity = purity_of_throw(throw_state);
 {
     RUBY_VM_CHECK_INTS(ec);
     val = vm_throw(ec, GET_CFP(), throw_state, throwobj);
@@ -875,6 +990,7 @@ jump
 (OFFSET dst)
 ()
 ()
+// attr enum rb_insn_purity purity = rb_insn_is_pure;
 {
     RUBY_VM_CHECK_INTS(ec);
     JUMP(dst);
@@ -886,6 +1002,7 @@ branchif
 (OFFSET dst)
 (VALUE val)
 ()
+// attr enum rb_insn_purity purity = rb_insn_is_pure;
 {
     if (RTEST(val)) {
 	RUBY_VM_CHECK_INTS(ec);
@@ -899,6 +1016,7 @@ branchunless
 (OFFSET dst)
 (VALUE val)
 ()
+// attr enum rb_insn_purity purity = rb_insn_is_pure;
 {
     if (!RTEST(val)) {
 	RUBY_VM_CHECK_INTS(ec);
@@ -912,6 +1030,7 @@ branchnil
 (OFFSET dst)
 (VALUE val)
 ()
+// attr enum rb_insn_purity purity = rb_insn_is_pure;
 {
     if (NIL_P(val)) {
 	RUBY_VM_CHECK_INTS(ec);
@@ -929,6 +1048,7 @@ getinlinecache
 (OFFSET dst, IC ic)
 ()
 (VALUE val)
+// attr enum rb_insn_purity purity = rb_insn_is_pure;
 {
     if (vm_ic_hit_p(ic, GET_EP())) {
 	val = ic->ic_value.value;
@@ -945,6 +1065,7 @@ setinlinecache
 (IC ic)
 (VALUE val)
 (VALUE val)
+// attr enum rb_insn_purity purity = rb_insn_is_pure;
 {
     vm_ic_update(ic, val, GET_EP());
 }
@@ -955,6 +1076,7 @@ once
 (ISEQ iseq, ISE ise)
 ()
 (VALUE val)
+/* Not pure because it can block other threads. */
 {
     val = vm_once_dispatch(ec, iseq, ise);
 }
@@ -965,6 +1087,7 @@ opt_case_dispatch
 (CDHASH hash, OFFSET else_offset)
 (..., VALUE key)
 ()
+// attr enum rb_insn_purity purity = rb_insn_is_pure;
 // attr rb_snum_t sp_inc = -1;
 {
     OFFSET dst = vm_case_dispatch(hash, else_offset, key);
@@ -982,6 +1105,7 @@ opt_plus
 (CALL_INFO ci, CALL_CACHE cc)
 (VALUE recv, VALUE obj)
 (VALUE val)
+// attr enum rb_insn_purity purity = purity_of_optinsn(BOP_PLUS, cc);
 {
     val = vm_opt_plus(recv, obj);
 
@@ -999,6 +1123,7 @@ opt_minus
 (CALL_INFO ci, CALL_CACHE cc)
 (VALUE recv, VALUE obj)
 (VALUE val)
+// attr enum rb_insn_purity purity = purity_of_optinsn(BOP_MINUS, cc);
 {
     val = vm_opt_minus(recv, obj);
 
@@ -1016,6 +1141,7 @@ opt_mult
 (CALL_INFO ci, CALL_CACHE cc)
 (VALUE recv, VALUE obj)
 (VALUE val)
+// attr enum rb_insn_purity purity = purity_of_optinsn(BOP_MULT, cc);
 {
     val = vm_opt_mult(recv, obj);
 
@@ -1033,6 +1159,7 @@ opt_div
 (CALL_INFO ci, CALL_CACHE cc)
 (VALUE recv, VALUE obj)
 (VALUE val)
+// attr enum rb_insn_purity purity = purity_of_optinsn(BOP_DIV, cc);
 {
     val = vm_opt_div(recv, obj);
 
@@ -1050,6 +1177,7 @@ opt_mod
 (CALL_INFO ci, CALL_CACHE cc)
 (VALUE recv, VALUE obj)
 (VALUE val)
+// attr enum rb_insn_purity purity = purity_of_optinsn(BOP_MOD, cc);
 {
     val = vm_opt_mod(recv, obj);
 
@@ -1067,6 +1195,8 @@ opt_eq
 (CALL_INFO ci, CALL_CACHE cc)
 (VALUE recv, VALUE obj)
 (VALUE val)
+/* This is complicated. */
+// attr enum rb_insn_purity purity = purity_of_opt_eq(cc);
 {
     val = opt_eq_func(recv, obj, ci, cc);
 
@@ -1084,6 +1214,8 @@ opt_neq
 (CALL_INFO ci_eq, CALL_CACHE cc_eq, CALL_INFO ci, CALL_CACHE cc)
 (VALUE recv, VALUE obj)
 (VALUE val)
+/* this is even more complicated than opt_eq. */
+// attr enum rb_insn_purity purity = purity_of_opt_neq(cc_eq, cc);
 {
     val = vm_opt_neq(ci, cc, ci_eq, cc_eq, recv, obj);
 
@@ -1101,6 +1233,7 @@ opt_lt
 (CALL_INFO ci, CALL_CACHE cc)
 (VALUE recv, VALUE obj)
 (VALUE val)
+// attr enum rb_insn_purity purity = purity_of_optinsn(BOP_LT, cc);
 {
     val = vm_opt_lt(recv, obj);
 
@@ -1118,6 +1251,7 @@ opt_le
 (CALL_INFO ci, CALL_CACHE cc)
 (VALUE recv, VALUE obj)
 (VALUE val)
+// attr enum rb_insn_purity purity = purity_of_optinsn(BOP_LE, cc);
 {
     val = vm_opt_le(recv, obj);
 
@@ -1135,6 +1269,7 @@ opt_gt
 (CALL_INFO ci, CALL_CACHE cc)
 (VALUE recv, VALUE obj)
 (VALUE val)
+// attr enum rb_insn_purity purity = purity_of_optinsn(BOP_GT, cc);
 {
     val = vm_opt_gt(recv, obj);
 
@@ -1152,6 +1287,7 @@ opt_ge
 (CALL_INFO ci, CALL_CACHE cc)
 (VALUE recv, VALUE obj)
 (VALUE val)
+// attr enum rb_insn_purity purity = purity_of_optinsn(BOP_GE, cc);
 {
     val = vm_opt_ge(recv, obj);
 
@@ -1169,6 +1305,8 @@ opt_ltlt
 (CALL_INFO ci, CALL_CACHE cc)
 (VALUE recv, VALUE obj)
 (VALUE val)
+/* TODO: we are on the safe side now, this can be improved. */
+// attr enum rb_insn_purity purity = rb_insn_is_not_pure;
 {
     val = vm_opt_ltlt(recv, obj);
 
@@ -1186,6 +1324,7 @@ opt_aref
 (CALL_INFO ci, CALL_CACHE cc)
 (VALUE recv, VALUE obj)
 (VALUE val)
+// attr enum rb_insn_purity purity = purity_of_optinsn(BOP_AREF, cc);
 {
     val = vm_opt_aref(recv, obj);
 
@@ -1203,6 +1342,8 @@ opt_aset
 (CALL_INFO ci, CALL_CACHE cc)
 (VALUE recv, VALUE obj, VALUE set)
 (VALUE val)
+/* TODO: we are on the safe side now, this can be improved. */
+// attr enum rb_insn_purity purity = rb_insn_is_not_pure;
 {
     val = vm_opt_aset(recv, obj, set);
 
@@ -1220,6 +1361,8 @@ opt_aset_with
 (VALUE key, CALL_INFO ci, CALL_CACHE cc)
 (VALUE recv, VALUE val)
 (VALUE val)
+/* TODO: we are on the safe side now, this can be improved. */
+// attr enum rb_insn_purity purity = rb_insn_is_not_pure;
 {
     VALUE tmp = vm_opt_aset_with(recv, key, val);
 
@@ -1242,6 +1385,7 @@ opt_aref_with
 (VALUE key, CALL_INFO ci, CALL_CACHE cc)
 (VALUE recv)
 (VALUE val)
+// attr enum rb_insn_purity purity = purity_of_optinsn(BOP_AREF, cc);
 {
     val = vm_opt_aref_with(recv, key);
 
@@ -1260,6 +1404,7 @@ opt_length
 (CALL_INFO ci, CALL_CACHE cc)
 (VALUE recv)
 (VALUE val)
+// attr enum rb_insn_purity purity = purity_of_optinsn(BOP_LENGTH, cc);
 {
     val = vm_opt_length(recv, BOP_LENGTH);
 
@@ -1277,6 +1422,7 @@ opt_size
 (CALL_INFO ci, CALL_CACHE cc)
 (VALUE recv)
 (VALUE val)
+// attr enum rb_insn_purity purity = purity_of_optinsn(BOP_SIZE, cc);
 {
     val = vm_opt_length(recv, BOP_SIZE);
 
@@ -1294,6 +1440,7 @@ opt_empty_p
 (CALL_INFO ci, CALL_CACHE cc)
 (VALUE recv)
 (VALUE val)
+// attr enum rb_insn_purity purity = purity_of_optinsn(BOP_EMPTY_P, cc);
 {
     val = vm_opt_empty_p(recv);
 
@@ -1311,6 +1458,7 @@ opt_succ
 (CALL_INFO ci, CALL_CACHE cc)
 (VALUE recv)
 (VALUE val)
+// attr enum rb_insn_purity purity = purity_of_optinsn(BOP_SUCC, cc);
 {
     val = vm_opt_succ(recv);
 
@@ -1328,6 +1476,7 @@ opt_not
 (CALL_INFO ci, CALL_CACHE cc)
 (VALUE recv)
 (VALUE val)
+// attr enum rb_insn_purity purity = purity_of_opt_not(cc);
 {
     val = vm_opt_not(ci, cc, recv);
 
@@ -1345,6 +1494,7 @@ opt_regexpmatch1
 (VALUE recv)
 (VALUE obj)
 (VALUE val)
+// attr enum rb_insn_purity purity = purity_of_BOP(BOP_MATCH, REGEXP_REDEFINED_OP_FLAG);
 {
     val = vm_opt_regexpmatch1(recv, obj);
 }
@@ -1355,6 +1505,7 @@ opt_regexpmatch2
 (CALL_INFO ci, CALL_CACHE cc)
 (VALUE obj2, VALUE obj1)
 (VALUE val)
+// attr enum rb_insn_purity purity = purity_of_optinsn(BOP_MATCH, cc);
 {
     val = vm_opt_regexpmatch2(obj2, obj1);
 
@@ -1372,6 +1523,8 @@ opt_call_c_function
 (rb_insn_func_t funcptr)
 ()
 ()
+/* Not pure; cannot say what would happen inside. */
+// attr enum rb_insn_purity purity = rb_insn_is_not_pure;
 // attr bool handles_sp = true;
 {
     reg_cfp = (funcptr)(ec, reg_cfp);
@@ -1392,6 +1545,7 @@ bitblt
 ()
 ()
 (VALUE ret)
+// attr enum rb_insn_purity purity = rb_insn_is_pure;
 {
     ret = rb_str_new2("a bit of bacon, lettuce and tomato");
 }
@@ -1402,6 +1556,7 @@ answer
 ()
 ()
 (VALUE ret)
+// attr enum rb_insn_purity purity = rb_insn_is_pure;
 {
     ret = INT2FIX(42);
 }

--- a/iseq.c
+++ b/iseq.c
@@ -1819,7 +1819,20 @@ rb_insn_operand_intern(const rb_iseq_t *iseq,
 	break;
 
       case TS_CALLCACHE:
-	ret = rb_str_new2("<callcache>");
+        {
+            const struct rb_call_cache *cc = (const struct rb_call_cache *)op;
+
+            if (cc->purity) {
+                const char *purity = name_of_purity(purity_of_VALUE(cc->purity));
+
+                ret = rb_sprintf("<callcache!%s@%"PRI_SERIALT_PREFIX"u>",
+                                 purity,
+                                 cc->updated_at);
+            }
+            else {
+                ret = rb_str_new2("<callcache>");
+            }
+        }
 	break;
 
       case TS_CDHASH:
@@ -1957,14 +1970,18 @@ iseq_inspect(const rb_iseq_t *iseq)
 	return rb_sprintf("#<ISeq: uninitialized>");
     }
     else {
-	const rb_code_location_t *loc = &body->location.code_location;
-	return rb_sprintf("#<ISeq:%"PRIsVALUE"@%"PRIsVALUE":%d (%d,%d)-(%d,%d)>",
-			  body->location.label, rb_iseq_path(iseq),
-			  loc->beg_pos.lineno,
-			  loc->beg_pos.lineno,
-			  loc->beg_pos.column,
-			  loc->end_pos.lineno,
-			  loc->end_pos.column);
+        const rb_code_location_t *loc = &body->location.code_location;
+        const char *purity = name_of_purity(purity_of_VALUE(body->purity));
+        return rb_sprintf("#<ISeq:%"PRIsVALUE"@%"PRIsVALUE":%d (%d,%d)-(%d,%d)"
+                          " %s@%"PRI_SERIALT_PREFIX"u>",
+                          body->location.label, rb_iseq_path(iseq),
+                          loc->beg_pos.lineno,
+                          loc->beg_pos.lineno,
+                          loc->beg_pos.column,
+                          loc->end_pos.lineno,
+                          loc->end_pos.column,
+                          purity,
+                          body->updated_at);
     }
 }
 

--- a/tool/ruby_vm/models/attribute.rb
+++ b/tool/ruby_vm/models/attribute.rb
@@ -15,12 +15,14 @@ require_relative 'c_expr'
 class RubyVM::Attribute
   include RubyVM::CEscape
   attr_reader :insn, :key, :type, :expr
+  attr_accessor :preambles
 
   def initialize opts = {}
     @insn = opts[:insn]
     @key = opts[:name]
     @expr = RubyVM::CExpr.new location: opts[:location], expr: opts[:expr]
     @type = opts[:type]
+    @preambles = []
   end
 
   def name

--- a/tool/ruby_vm/models/bare_instructions.rb
+++ b/tool/ruby_vm/models/bare_instructions.rb
@@ -130,6 +130,7 @@ class RubyVM::BareInstructions
     generate_attribute 'rb_num_t', 'width', width
     generate_attribute 'rb_snum_t', 'sp_inc', rets.size - pops.size
     generate_attribute 'bool', 'handles_sp', false
+    generate_attribute 'enum rb_insn_purity', 'purity', 'rb_insn_is_not_pure'
   end
 
   def typesplit a

--- a/tool/ruby_vm/views/_attributes.erb
+++ b/tool/ruby_vm/views/_attributes.erb
@@ -24,6 +24,9 @@ PUREFUNC(MAYBE_UNUSED(static <%= a.declaration %>));
 /* <%= a.pretty_name %> */
 <%= a.definition %>
 {
+% a.preambles.each do |konst|
+<%= render_c_expr konst -%>
+% end
 % str = render_c_expr a.expr
 % case str when /\A#/ then
     return

--- a/tool/ruby_vm/views/_insn_purity.erb
+++ b/tool/ruby_vm/views/_insn_purity.erb
@@ -1,0 +1,50 @@
+%# -*- mode:c; style:ruby; coding: utf-8; indent-tabs-mode: nil -*-
+%# Copyright (c) 2018 Urabe, Shyouhei.  All rights reserved.
+%#
+%# This file is a part of  the programming language Ruby.  Permission is hereby
+%# granted, to either  redistribute and/or modify this file,  provided that the
+%# conditions mentioned  in the  file COPYING  are met.   Consult the  file for
+%# details.
+%#
+enum rb_insn_purity
+insn_purity_dispatch(enum ruby_vminsn_type insn, const VALUE *opes)
+{
+#define rb_insn_purity_is_complex -127
+%
+% ary = RubyVM::Instructions.map do |i|
+%   p = i.attributes.find {|i| i.key=='purity' }
+%   case p when NilClass then
+%     next i, 'rb_insn_is_not_pure'
+%   else
+%     case p.expr.expr when /\(/ then
+%       next i, 'rb_insn_purity_is_complex'
+%     else
+%       next i, p.expr.expr.strip.chomp(';')
+%     end
+%   end
+% end
+%
+    static const signed char t[] = {
+% ary.each do |(_, a)|
+        <%= a %>,
+% end
+    };
+    signed char c = t[insn];
+
+    ASSERT_VM_INSTRUCTION_SIZE(t);
+    if (c != rb_insn_purity_is_complex) {
+        return c;
+    }
+    else switch(insn) {
+    default:
+        UNREACHABLE;
+% ary.each do |(i, a)|
+%   next unless a == 'rb_insn_purity_is_complex'
+    case <%= i.bin %>:
+        return attr_purity_<%= i.name %>(<%=
+          i.opes.map.with_index {|v, j| "(#{v[:type]})opes[#{j}]"}.join(", ")
+        %>);
+% end
+    }
+#undef rb_insn_purity_is_complex
+}

--- a/tool/ruby_vm/views/_insn_purity_helpers.erb
+++ b/tool/ruby_vm/views/_insn_purity_helpers.erb
@@ -1,0 +1,866 @@
+%# -*- mode:c; style:ruby; coding: utf-8; indent-tabs-mode: nil -*-
+%# Copyright (c) 2018 Urabe, Shyouhei.  All rights reserved.
+%#
+%# This file is a part of  the programming language Ruby.  Permission is hereby
+%# granted, to either  redistribute and/or modify this file,  provided that the
+%# conditions mentioned  in the  file COPYING  are met.   Consult the  file for
+%# details.
+%#
+%# This file actually is a plain C source code.
+%#
+#include "iseq.h"
+RUBY_SYMBOL_EXPORT_BEGIN
+RUBY_EXTERN rb_serial_t ruby_vm_global_timestamp; /* at vm.c */
+RUBY_EXTERN rb_serial_t ruby_vm_global_method_state; /* at vm.c */
+RUBY_SYMBOL_EXPORT_END
+
+/**
+ * The four kinds of purity.
+ */
+enum rb_insn_purity {
+    /**
+     * The instruction has "side effect"s. It touches off-stack values like
+     * global ones.
+     */
+    rb_insn_is_not_pure = 0,
+
+    /**
+     * The instruction has no side  effects.  It might manipulate stack pointer
+     * or the value pointed by that, but nothing else.
+     */
+    rb_insn_is_pure,
+
+    /**
+     * The instruction  is unpredictable _at  that moment_, maybe  because that
+     * instruction has never  been executed.  Thus when you  evaluate that part
+     * later, the purity of the instruction might vary from time to time.
+     */
+    rb_insn_purity_is_unpredictable,
+
+    /**
+     * Depends on  passed block.  This  makes sense  for method calls.   When a
+     * method itself had  no side effects, there still are  chances of breakage
+     * if the method  yields: the calling block could do  something nasty.  The
+     * purity of such  block can be checked beforehand.   This value represents
+     * such situations.
+     */
+    rb_insn_purity_depends_block
+};
+
+CONSTFUNC(MAYBE_UNUSED(
+/**
+ * name of the enum, for debug.
+ *
+ * @param [in] purity target
+ * @return C string representation of that enum
+ */
+static const char *name_of_purity(enum rb_insn_purity purity)));
+
+/**
+ * Purity of an ISeq as a whole.  An  ISeq is said to be pure if its conatining
+ * instructions are all pure.
+ *
+ * @param [in] iseq in question.
+ * @return the purity.
+ */
+static enum rb_insn_purity purity_of_iseq(const struct rb_iseq_struct *iseq);
+
+/**
+ * Like purity_of_iseq, but targets iseq_catch_table instead.
+ *
+ * @param [in] the table in quetion.
+ * @return the purity.
+ */
+static enum rb_insn_purity purity_of_catch_table(const struct iseq_catch_table *tbl);
+
+CONSTFUNC(
+/**
+ * Merge purity; a pure + pure is pure, pure + nonpure is nonpure, and so on.
+ *
+ * @param [in] p1 purity left hand side
+ * @param [in] p2 purity right hand side
+ * @return p1 + p2
+ */
+static enum rb_insn_purity purity_merge(enum rb_insn_purity p1, enum rb_insn_purity p2));
+
+PUREFUNC(
+/**
+ * Purity of the call cache's pointed entry.
+ *
+ * @param [in, out] cc call cache in question.
+ * @return purity of cc's method entry.
+ */
+static enum rb_insn_purity purity_of_cc(struct rb_call_cache *cc));
+
+PUREFUNC(
+/**
+ * Same as purity_of_cc. Internal use.
+ *
+ * @param [in, out] cc call cache in question.
+ * @return purity of cc's method entry.
+ */
+static enum rb_insn_purity purity_of_live_cc(struct rb_call_cache *cc));
+
+/**
+ * Purity might depend on global redefinition of basic methods.  This is to
+ * check those redefinitions.
+ *
+ * @param [in] op basic op
+ * @param [in] klass flags, ~0 means any class
+ * @return purity of the BOP
+ */
+static enum rb_insn_purity purity_of_BOP(int op, unsigned klass);
+
+CONSTFUNC(
+/**
+ * Very polite cast from bool to purity
+ *
+ * @param [in] b bool value
+ * @return static_cast<enum rb_insn_purity>(b);
+ */
+static enum rb_insn_purity purity_of_bool(bool b));
+
+CONSTFUNC(
+/**
+ * Very polite cast from VALUE to purity
+ *
+ * @param [in] v VALUE value
+ * @return static_cast<enum rb_insn_purity>(v);
+ */
+static enum rb_insn_purity purity_of_VALUE(VALUE v));
+
+CONSTFUNC(
+/**
+ * Very polite cast from purity to VALUE
+ *
+ * @param [in] p purity
+ * @return static_cast<VALUE>(p);
+ */
+static VALUE VALUE_of_purity(enum rb_insn_purity p));
+
+PUREFUNC(
+/**
+ * Utility attribute accessor.
+ *
+ * @param [in] def method definition
+ * @retval NULL it is not an ISeq-backended method.
+ * @retval otherwise a valid pointer to an iseq.
+ */
+static const struct rb_iseq_struct *iseq_of_def(const struct rb_method_definition_struct *def));
+
+#ifdef INSIDE_VM_INSNHELPER_C
+PUREFUNC(
+/**
+ * Utility attribute accessor.
+ *
+ * @param [in] bh block handler
+ * @retval NULL it is not an ISeq-backended block.
+ * @retval otherwise a valid pointer to an iseq.
+ */
+static const struct rb_iseq_struct *iseq_of_bh(VALUE bh));
+#endif
+
+MAYBE_UNUSED(
+/**
+ * Utility function.   A cache  entry can be  stale.  That's OK,  as far  as we
+ * don't touch the  stale cache contents because they can  already be GCed.  We
+ * need to check beforehand.
+ *
+ * @param [in] cc call cache in question
+ * @retval true it is dead.
+ * @retval false it is alive.
+ */
+static bool cc_is_stale(const struct rb_call_cache *cc));
+
+PUREFUNC(
+/**
+ * Utility function to check if a cc points to a specific C function.
+ *
+ * @param [in] cc call cache in question.
+ * @param [in] func possile function that cc might resolves to.
+ * @retval true it is dead.
+ * @retval false it is alive.
+ */
+static bool purity_cc_cfunc_is(const struct rb_call_cache *cc, VALUE (*func)()));
+
+PUREFUNC(
+/**
+ * Utility function for general opt_* instructions.
+ *
+ * @param [in] cc call cache.
+ * @param [in] bop basic op
+ */
+static enum rb_insn_purity purity_of_optinsn(int bop, struct rb_call_cache *cc));
+
+CONSTFUNC(
+/**
+ * Definition of attribute purity of instruction defined
+ *
+ * @param [in] op_type type of defined.
+ * @retval rb_insn_is_pure definitely pure
+ * @retval rb_insn_is_not_pure definitely not pure
+ */
+static enum rb_insn_purity purity_of_defined(rb_num_t op_type));
+
+CONSTFUNC(
+/**
+ * Definition of attribute purity of general setlocal_* instructions.
+ *
+ * @param [in] nesting nesting level.
+ * @retval rb_insn_is_pure definitely pure
+ * @retval rb_insn_is_not_pure definitely not pure
+ */
+static enum rb_insn_purity purity_of_lvar_access(rb_num_t nesting));
+
+/**
+ * Calculates purity of invokeblock instruction.
+ *
+ * @param [in]  ci call info
+ * @return the purity of the instruction.
+ */
+static enum rb_insn_purity purity_of_invokeblock(const struct rb_call_info *ci);
+
+/**
+ * Calculates purity of send and similar instructions.
+ *
+ * @param [in]  ci call info
+ * @param [out] cc call cache
+ * @param [in]  blockiseq iseq, if any
+ * @return the purity of the instruction.
+ */
+static enum rb_insn_purity purity_of_sendish(const struct rb_call_info *ci, struct rb_call_cache *cc, const struct rb_iseq_struct *blockiseq);
+
+/**
+ * Calculates purity of throw instruction.
+ *
+ * @param [in] state throw state
+ * @return the purity of the instruction.
+ */
+static enum rb_insn_purity purity_of_throw(rb_num_t throw_state);
+
+/**
+ * Definition of attribute purity of instruction opt_eq
+ *
+ * @param [in] cc cached method entry
+ * @return the purity of the instruction.
+ */
+static enum rb_insn_purity purity_of_opt_eq(struct rb_call_cache *cc);
+
+/**
+ * Definition of attribute purity of instruction opt_not
+ *
+ * @param [in] cc cached method entry
+ * @return the purity of the instruction.
+ */
+static enum rb_insn_purity purity_of_opt_not(struct rb_call_cache *cc);
+
+/**
+ * Definition of attribute purity of instruction opt_neq
+ *
+ * @param [in] cc_eq cached method entry for #==
+ * @param [in] cc_neq cached method entry for #!=
+ * @return the purity of the instruction.
+ */
+static enum rb_insn_purity purity_of_opt_neq(struct rb_call_cache *cc_eq, struct rb_call_cache *cc_neq);
+
+PUREFUNC(
+/**
+ * Calculates the actual purity of an instruction and its operands.
+ *
+ * @param [in] insn the (name of) instruction.
+ * @param [in] opes operands.
+ * @return the purity.
+ */
+static enum rb_insn_purity insn_purity_dispatch(enum ruby_vminsn_type insn, const VALUE *opes));
+
+#ifdef __OPTIMIZE__
+#define DONTCARE(p) UNREACHABLE;
+#else
+#define DONTCARE(p) \
+    rb_bug("unknown purity; blame @shyouhei: %"PRIxVALUE, (VALUE)p);
+#endif
+
+const char *
+name_of_purity(enum rb_insn_purity p)
+{
+    switch (p) {
+      case rb_insn_is_pure:                 return "pure";
+      case rb_insn_is_not_pure:             return "notpure";
+      case rb_insn_purity_is_unpredictable: return "unpredictable";
+      case rb_insn_purity_depends_block:    return "dependsblock";
+      default: DONTCARE(p);
+    }
+}
+
+enum rb_insn_purity
+purity_of_bool(bool b)
+{
+#ifdef __OPTIMIZE__
+    return (enum rb_insn_purity)b;
+#else
+    if (b) {
+        return rb_insn_is_pure;
+    }
+    else {
+        return rb_insn_is_not_pure;
+    }
+#endif
+}
+
+enum rb_insn_purity
+purity_of_VALUE(VALUE v)
+{
+#ifdef __OPTIMIZE__
+    /* This use of FIX2LONG instead of FIX2INT is intentional.
+     * FIX2LONG is a macro while FIX2INT is a function.
+     * FIX2INT adds unnecessary overheads. */
+    return LIKELY(FIXNUM_P(v)) ? FIX2LONG(v) : rb_insn_is_not_pure;
+#else
+    switch (v) {
+      case INT2FIX(rb_insn_is_not_pure):
+        return rb_insn_is_not_pure;
+      case INT2FIX(rb_insn_is_pure):
+        return rb_insn_is_pure;
+      case INT2FIX(rb_insn_purity_is_unpredictable):
+        return rb_insn_purity_is_unpredictable;
+      case INT2FIX(rb_insn_purity_depends_block):
+        return rb_insn_purity_depends_block;
+      default:
+        return rb_insn_is_not_pure;
+    }
+#endif
+}
+
+VALUE
+VALUE_of_purity(enum rb_insn_purity p)
+{
+#ifdef __OPTIMIZE__
+    return INT2FIX(p);
+#else
+    switch (p) {
+      case rb_insn_is_pure:
+        return INT2FIX(rb_insn_is_pure);
+      case rb_insn_is_not_pure:
+        return INT2FIX(rb_insn_is_not_pure);
+      case rb_insn_purity_is_unpredictable:
+        return INT2FIX(rb_insn_purity_is_unpredictable);
+      case rb_insn_purity_depends_block:
+        return INT2FIX(rb_insn_purity_depends_block);
+      default:
+        DONTCARE(p);
+    }
+#endif
+}
+
+enum rb_insn_purity
+purity_merge(enum rb_insn_purity p1, enum rb_insn_purity p2)
+{
+    /*
+     *       || NG | N/A | iter |  OK
+     * ======##====+=====+======+======
+     *   NG  || NG |  NG |  NG  |  NG
+     * ------++----+-----+------+------
+     *   N/A || NG | N/A |  N/A |  N/A
+     * ------++----+-----+------+------
+     *  iter || NG | N/A | iter | iter
+     * ------++----+-----+------+------
+     *   OK  || NG | N/A | iter |  OK
+     *
+     * OK:   rb_insn_is_pure
+     * NG:   rb_insn_is_not_pure
+     * N/A:  rb_insn_purity_is_unpredictable
+     * iter: rb_insn_purity_depends_block
+     */
+
+#ifdef __OPTIMIZE__
+    /* table lookup seems faster than using switch. */
+    /* This array takes only 16 bytes.  Must fit into a cache
+     * line for most modern CPUs. */
+    static RUBY_ALIGNAS(16) const char t[4][4] = {
+        /* NG: */ {
+            rb_insn_is_not_pure,             /* NG + NG */
+            rb_insn_is_not_pure,             /* NG + OK */
+            rb_insn_is_not_pure,             /* NG + N/A */
+            rb_insn_is_not_pure,             /* NG + iter */
+        },
+        /* OK: */ {
+            rb_insn_is_not_pure,             /* OK + NG */
+            rb_insn_is_pure,                 /* OK + OK */
+            rb_insn_purity_is_unpredictable, /* OK + N/A */
+            rb_insn_purity_depends_block,    /* OK + iter */
+        },
+        /* N/A: */ {
+            rb_insn_is_not_pure,             /* N/A + NG */
+            rb_insn_purity_is_unpredictable, /* N/A + OK */
+            rb_insn_purity_is_unpredictable, /* N/A + N/A */
+            rb_insn_purity_is_unpredictable, /* N/A + iter */
+        },
+        /* iter: */ {
+            rb_insn_is_not_pure,             /* iter + NG */
+            rb_insn_purity_depends_block,    /* iter + OK */
+            rb_insn_purity_is_unpredictable, /* iter + N/A */
+            rb_insn_purity_depends_block,    /* iter + iter */
+        },
+    };
+
+    return t[p1][p2];
+#else
+    switch(p1) {
+      case rb_insn_is_not_pure:
+        switch(p2) {
+          case rb_insn_is_not_pure:
+            return rb_insn_is_not_pure;
+          case rb_insn_purity_is_unpredictable:
+            return rb_insn_is_not_pure;
+          case rb_insn_purity_depends_block:
+            return rb_insn_is_not_pure;
+          case rb_insn_is_pure:
+            return rb_insn_is_not_pure;
+          default:
+            DONTCARE(p2);
+        }
+
+      case rb_insn_purity_is_unpredictable:
+        switch(p2) {
+          case rb_insn_is_not_pure:
+            return rb_insn_is_not_pure;
+          case rb_insn_purity_is_unpredictable:
+            return rb_insn_purity_is_unpredictable;
+          case rb_insn_purity_depends_block:
+            return rb_insn_purity_is_unpredictable;
+          case rb_insn_is_pure:
+            return rb_insn_purity_is_unpredictable;
+          default:
+            DONTCARE(p2);
+        }
+
+      case rb_insn_purity_depends_block:
+        switch(p2) {
+          case rb_insn_is_not_pure:
+            return rb_insn_is_not_pure;
+          case rb_insn_purity_is_unpredictable:
+            return rb_insn_purity_is_unpredictable;
+          case rb_insn_purity_depends_block:
+            return rb_insn_purity_depends_block;
+          case rb_insn_is_pure:
+            return rb_insn_purity_depends_block;
+          default:
+            DONTCARE(p2);
+        }
+
+      case rb_insn_is_pure:
+        switch(p2) {
+          case rb_insn_is_not_pure:
+            return rb_insn_is_not_pure;
+          case rb_insn_purity_is_unpredictable:
+            return rb_insn_purity_is_unpredictable;
+          case rb_insn_purity_depends_block:
+            return rb_insn_purity_depends_block;
+          case rb_insn_is_pure:
+            return rb_insn_is_pure;
+          default:
+            DONTCARE(p2);
+        }
+
+      default:
+        DONTCARE(p1);
+    }
+#endif
+}
+
+#undef DONTCARE
+
+enum rb_insn_purity
+purity_of_BOP(int bop, unsigned klass)
+{
+    return purity_of_bool(BASIC_OP_UNREDEFINED_P(bop, klass));
+}
+
+const rb_iseq_t *
+iseq_of_def(const struct rb_method_definition_struct *def)
+{
+    switch (def->type) {
+      case VM_METHOD_TYPE_ISEQ:
+        return def->body.iseq.iseqptr;
+      case VM_METHOD_TYPE_BMETHOD:
+        return rb_proc_get_iseq(def->body.proc, 0);
+      default:
+        return NULL;
+    }
+}
+
+bool
+cc_is_stale(const struct rb_call_cache *cc)
+{
+    if (! cc->me) {
+        return true;
+    }
+    else if (cc->method_state != ruby_vm_global_method_state) {
+        return true;
+    }
+    else if (! imemo_type_p((VALUE)cc->me, imemo_ment)) {
+        return true;           /* me already GCed. */
+    }
+    else if (cc->class_serial != RCLASS_SERIAL(cc->me->defined_class)) {
+        return true;
+    }
+    else {
+        return false;
+    }
+}
+
+/* @shyouhei wonders: where is the right place to define this function? */
+CONSTFUNC(extern bool vm_whether_we_can_skip_this_call_handler_p(vm_call_handler h));
+
+enum rb_insn_purity
+purity_of_live_cc(struct rb_call_cache *cc)
+{
+    const rb_iseq_t *i;
+    enum rb_insn_purity p;
+
+    if (cc->updated_at == ruby_vm_global_timestamp) {
+        return purity_of_VALUE(cc->purity);
+    }
+    else if (! vm_whether_we_can_skip_this_call_handler_p(cc->call)) {
+        p = rb_insn_is_not_pure;
+    }
+    else if (UNLIKELY(! (i = iseq_of_def(cc->me->def)))) {
+        p = rb_insn_is_not_pure;
+    }
+    else {
+        p = purity_of_iseq(i);
+    }
+
+    cc->updated_at = ruby_vm_global_timestamp;
+    cc->purity = VALUE_of_purity(p);
+    return p;
+}
+
+enum rb_insn_purity
+purity_of_cc(struct rb_call_cache *cc)
+{
+    if (cc_is_stale(cc)) {
+        return rb_insn_purity_is_unpredictable; /* method missing */
+    }
+    else {
+        return purity_of_live_cc(cc);
+    }
+}
+
+bool
+purity_cc_cfunc_is(const struct rb_call_cache *cc, VALUE (*func)())
+{
+    /* see also vm_insnhelper.c:vm_method_cfunc_is() */
+
+    const struct rb_method_definition_struct *def = cc->me->def;
+
+    if (def->type != VM_METHOD_TYPE_CFUNC) {
+        return false;
+    }
+    else if (def->body.cfunc.func != func) {
+        return false;
+    }
+    else {
+        return true;
+    }
+}
+
+enum rb_insn_purity
+purity_of_optinsn(int bop, struct rb_call_cache *cc)
+{
+    /* If cc is filled, that means this caller site is not for a basic class.
+     * That should be honored.  Otherwise check BOP. */
+    if (cc->me) {
+        return purity_of_cc(cc);
+    }
+    else {
+        return purity_of_BOP(bop, ~0);
+    }
+}
+
+enum rb_insn_purity
+purity_of_defined(rb_num_t op_type)
+{
+    switch (op_type) {
+    case DEFINED_IVAR:
+    case DEFINED_IVAR2:
+    case DEFINED_GVAR:
+    case DEFINED_CVAR:
+    case DEFINED_YIELD:
+    case DEFINED_REF:
+        return rb_insn_is_pure;
+    case DEFINED_CONST:
+        return rb_insn_is_not_pure; /* can kick autoload */
+    case DEFINED_FUNC:
+    case DEFINED_METHOD:
+        return rb_insn_is_not_pure; /* can kick respond_to_missing? */
+    case DEFINED_ZSUPER:
+        return rb_insn_is_not_pure; /* what if super is method missing? */
+    default:
+        rb_bug("unknown operand %ld: blame @shyouhei.", op_type);
+    }
+}
+
+enum rb_insn_purity
+purity_of_lvar_access(rb_num_t nesting)
+{
+    /* Consider:
+     *
+     * ```ruby
+     * def foo
+     *   var = x
+     *   bar.each do |i|
+     *     var = i # <- (1)
+     *   end
+     *   return var
+     * end
+     * ```
+     *
+     * Here, the setlocal at line marked (1) should _not_ be eliminated,
+     * because doing so shall change the result of the entire method.
+     */
+    return nesting ? rb_insn_is_not_pure : rb_insn_is_pure;
+}
+
+enum rb_insn_purity
+purity_of_invokeblock(const struct rb_call_info *ci)
+{
+    if (ci->flag & VM_CALL_ARGS_BLOCKARG) {
+        /* Hard to tell if we can skip this send or not. */
+        return rb_insn_is_not_pure;
+    }
+    else {
+        return rb_insn_purity_depends_block;
+    }
+}
+
+enum rb_insn_purity
+purity_of_sendish(
+    const struct rb_call_info *ci,
+    struct rb_call_cache *cc,
+    const struct rb_iseq_struct *blockiseq)
+{
+    enum rb_insn_purity p;
+
+    if ((p = purity_of_cc(cc)) != rb_insn_purity_depends_block) {
+        return p;               /* no block call */
+    }
+    else if ((p = purity_of_invokeblock(ci)) != rb_insn_purity_depends_block) {
+        return p;               /* block param not detectable */
+    }
+    else {
+        /* This is where "depends block" dependency is resolved */
+        return purity_of_iseq(blockiseq);
+    }
+}
+
+
+enum rb_insn_purity
+purity_of_throw(rb_num_t throw_state)
+{
+    /* In spite  of its pure-ish nature  (no side effect), this  instruction is
+     * not always optimisable. Consider the following:
+     *
+     * ```ruby
+     * def foo
+     *   each do
+     *     return true # <-- (1)
+     *   end
+     *   return false
+     * end
+     * ```
+     *
+     * Here, the line marked with "(1)"  shall take effect and the return value
+     * of this method must be true, not false.  We cannot skip this block.  */
+
+    /* TODO: can we say it's pure by looking at throw_state? */
+    return rb_insn_is_not_pure;
+}
+
+enum rb_insn_purity
+purity_of_opt_eq(struct rb_call_cache *cc)
+{
+    /* see also vm_insnhelper.c:opt_eq_func() */
+
+    if (cc_is_stale(cc)) {
+        /* cc not used, BOP in effect */
+        if (purity_of_BOP(BOP_EQ, ~0) == rb_insn_is_pure) {
+            return rb_insn_is_pure; /* yes it is */
+        }
+        else {
+            /* this caller site has never been reached yet */
+            return rb_insn_purity_is_unpredictable;
+        }
+    }
+    else {
+        /* cc filled, should honor that */
+        if (purity_cc_cfunc_is(cc, rb_obj_equal)) {
+            return rb_insn_is_pure; /* yes it is */
+        }
+        else {
+            return purity_of_live_cc(cc);
+        }
+    }
+}
+
+enum rb_insn_purity
+purity_of_opt_not(struct rb_call_cache *cc)
+{
+    /* see also vm_insnhelper.c:vm_opt_not() */
+
+    if (UNLIKELY(cc_is_stale(cc))) {
+        return rb_insn_purity_is_unpredictable;
+    }
+    else if (purity_cc_cfunc_is(cc, rb_obj_not)) {
+        return rb_insn_is_pure; /* yes it is */
+    }
+    else {
+        return purity_of_live_cc(cc);
+    }
+}
+
+enum rb_insn_purity
+purity_of_opt_neq(
+    struct rb_call_cache *cc_eq,
+    struct rb_call_cache *cc_neq)
+{
+    /* see also vm_insnhelper.c:opt_eq_func() */
+
+    if (UNLIKELY(cc_is_stale(cc_neq))) {
+        return rb_insn_purity_is_unpredictable;
+    }
+    else if (purity_cc_cfunc_is(cc_neq, rb_obj_not_equal)) {
+        return purity_of_opt_eq(cc_eq);
+    }
+    else {
+        return purity_of_live_cc(cc_eq);
+    }
+}
+
+enum rb_insn_purity
+purity_of_catch_table(const struct iseq_catch_table *c)
+{
+    enum rb_insn_purity p = rb_insn_is_pure;
+
+    if (c) {
+        unsigned int j;
+
+        for (j = 0; j < c->size; j++) {
+            const rb_iseq_t *i = c->entries[j].iseq;
+
+            if (i) {
+                enum rb_insn_purity q = purity_of_iseq(i);
+
+                p = purity_merge(p, q);
+#ifdef __OPTIMIZE__
+                if (p == rb_insn_is_not_pure) {
+                    break; /* bail out */
+                }
+#endif
+            }
+        }
+    }
+    return p;
+}
+
+enum rb_insn_purity
+purity_of_iseq(const rb_iseq_t *iseq)
+{
+    struct rb_iseq_constant_body *b;
+
+    if (!iseq) {
+        return rb_insn_purity_is_unpredictable; /* or ...? */
+    }
+    else if (!(b = iseq->body)) {
+        return rb_insn_purity_is_unpredictable; /* or ...? */
+    }
+    else if (b->updated_at == ruby_vm_global_timestamp) {
+        return purity_of_VALUE(b->purity);
+    }
+    else if (b->iter_lev) {
+        return rb_insn_purity_is_unpredictable;
+    }
+    else {
+        const VALUE *ptr         = rb_iseq_original_iseq(iseq);
+        enum rb_insn_purity p, q = purity_of_catch_table(b->catch_table);
+        int i, j, k              = b->iseq_size;
+
+        b->iter_lev = true;
+        for (i = j = 0; i < k; i += j) {
+            j = insn_len((int)ptr[i]);
+            p = insn_purity_dispatch((int)ptr[i], &ptr[i + 1]);
+            q = purity_merge(q, p);
+#ifdef __OPTIMIZE__
+            if (q == rb_insn_is_not_pure) {
+                break; /* bail out */
+            }
+#endif
+        }
+        b->iter_lev = false;
+
+        if (q != rb_insn_purity_is_unpredictable) {
+            b->updated_at = ruby_vm_global_timestamp;
+            b->purity = VALUE_of_purity(q);
+        }
+        return q;
+    }
+}
+
+#ifdef INSIDE_VM_INSNHELPER_C
+
+const rb_iseq_t *
+iseq_of_bh(VALUE block_handler)
+{
+    if (block_handler == VM_BLOCK_HANDLER_NONE) {
+        return NULL;
+    }
+    else if (VM_BH_IFUNC_P(block_handler)) {
+        return NULL;
+    }
+    else if (VM_BH_ISEQ_BLOCK_P(block_handler)) {
+        return VM_BH_TO_ISEQ_BLOCK(block_handler)->code.iseq;
+    }
+    else switch (vm_block_handler_type(block_handler)) {
+      default:
+      case block_handler_type_iseq:
+      case block_handler_type_ifunc:
+        VM_UNREACHABLE(iseq_of_bh);
+      case block_handler_type_symbol:
+        return NULL;
+      case block_handler_type_proc:
+          return rb_proc_get_iseq(VM_BH_TO_PROC(block_handler), 0);
+    }
+}
+
+static enum rb_insn_purity
+purity_of_ccish(struct rb_call_cache * cc)
+{
+    return cc ? purity_of_live_cc(cc) : rb_insn_purity_depends_block;
+}
+
+static bool
+vm_whether_we_can_skip_this_call_site_p(
+    bool whether_current_insn_is_pop_p,
+    struct rb_call_cache *cc,
+    VALUE block_handler)
+{
+    const rb_iseq_t *iseq;
+    enum rb_insn_purity p;
+
+    if (! whether_current_insn_is_pop_p) {
+        return false;                /* return value used */
+    }
+    else if ((p = purity_of_ccish(cc)) != rb_insn_purity_depends_block) {
+        return p == rb_insn_is_pure; /* not pure */
+    }
+    else if (block_handler == VM_BLOCK_HANDLER_NONE) {
+        return true;                 /* no block given */
+    }
+    else if (! (iseq = iseq_of_bh(block_handler))) {
+        return false;                /* ifunc, etc. */
+    }
+    else {
+        return purity_of_iseq(iseq) == rb_insn_is_pure;
+    }
+}
+#endif

--- a/tool/ruby_vm/views/insns_info.inc.erb
+++ b/tool/ruby_vm/views/insns_info.inc.erb
@@ -15,5 +15,7 @@
 <%= render 'insn_name_info' %>
 <%= render 'insn_len_info' %>
 <%= render 'insn_operand_info' %>
+<%= render 'insn_purity_helpers' %>
 <%= render 'attributes' %>
 <%= render 'insn_stack_increase' %>
+<%= render 'insn_purity' %>

--- a/vm.c
+++ b/vm.c
@@ -324,6 +324,7 @@ rb_serial_t
 rb_next_class_serial(void)
 {
     rb_serial_t class_serial = NEXT_CLASS_SERIAL();
+    INC_GLOBAL_TIMESTAMP();
     mjit_add_class_serial(class_serial);
     return class_serial;
 }
@@ -338,6 +339,7 @@ rb_vm_t *ruby_current_vm_ptr = NULL;
 rb_execution_context_t *ruby_current_execution_context_ptr = NULL;
 rb_event_flag_t ruby_vm_event_flags;
 rb_event_flag_t ruby_vm_event_enabled_flags;
+rb_serial_t ruby_vm_global_timestamp = 1;
 rb_serial_t ruby_vm_global_method_state = 1;
 rb_serial_t ruby_vm_global_constant_state = 1;
 rb_serial_t ruby_vm_class_serial = 1;
@@ -414,6 +416,7 @@ static VALUE
 vm_stat(int argc, VALUE *argv, VALUE self)
 {
     static VALUE sym_global_method_state, sym_global_constant_state, sym_class_serial;
+    static VALUE sym_global_timestamp;
     VALUE arg = Qnil;
     VALUE hash = Qnil, key = Qnil;
 
@@ -431,6 +434,7 @@ vm_stat(int argc, VALUE *argv, VALUE self)
 
     if (sym_global_method_state == 0) {
 #define S(s) sym_##s = ID2SYM(rb_intern_const(#s))
+	S(global_timestamp);
 	S(global_method_state);
 	S(global_constant_state);
 	S(class_serial);
@@ -443,6 +447,7 @@ vm_stat(int argc, VALUE *argv, VALUE self)
     else if (hash != Qnil) \
 	rb_hash_aset(hash, sym_##name, SERIALT2NUM(attr));
 
+    SET(global_timestamp, ruby_vm_global_timestamp);
     SET(global_method_state, ruby_vm_global_method_state);
     SET(global_constant_state, ruby_vm_global_constant_state);
     SET(class_serial, ruby_vm_class_serial);

--- a/vm_core.h
+++ b/vm_core.h
@@ -275,6 +275,9 @@ struct rb_call_cache {
 	enum method_missing_reason method_missing_reason; /* used by method_missing */
 	int inc_sp; /* used by cfunc */
     } aux;
+
+    rb_serial_t updated_at;
+    VALUE purity;
 };
 
 #if 1
@@ -455,6 +458,10 @@ struct rb_iseq_constant_body {
     long unsigned total_calls; /* number of total calls with `mjit_exec()` */
     struct rb_mjit_unit *jit_unit;
     char catch_except_p; /* If a frame of this ISeq may catch exception, set TRUE */
+
+    rb_serial_t updated_at;
+    VALUE purity;
+    bool iter_lev;
 };
 
 /* T_IMEMO/iseq */

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -154,11 +154,13 @@ vm_call0_body(rb_execution_context_t *ec, struct rb_calling_info *calling, const
 	    }
 	    else if (cc->me->def->body.refined.orig_me) {
 		cc->me = refined_method_callable_without_refinement(cc->me);
+		CC_RESET_PURITY(cc);
 		goto again;
 	    }
 
 	    super_class = RCLASS_SUPER(super_class);
 
+	    CC_RESET_PURITY(cc);
 	    if (!super_class || !(cc->me = rb_callable_method_entry(super_class, ci->mid))) {
 		enum method_missing_reason ex = (type == VM_METHOD_TYPE_ZSUPER) ? MISSING_SUPER : 0;
 		ret = method_missing(calling->recv, ci->mid, calling->argc, argv, ex);
@@ -169,6 +171,7 @@ vm_call0_body(rb_execution_context_t *ec, struct rb_calling_info *calling, const
 	}
       case VM_METHOD_TYPE_ALIAS:
 	cc->me = aliased_callable_method_entry(cc->me);
+	CC_RESET_PURITY(cc);
 	goto again;
       case VM_METHOD_TYPE_MISSING:
 	{

--- a/vm_exec.h
+++ b/vm_exec.h
@@ -69,6 +69,8 @@ error !
 #define START_OF_ORIGINAL_INSN(x) /* ignore */
 #define DISPATCH_ORIGINAL_INSN(x) return LABEL(x)(ec, reg_cfp);
 
+#define CURRENT_INSN_IS(pop) ((rb_insn_func_t)GET_CURRENT_INSN() == LABEL(pop))
+
 /************************************************/
 #elif OPT_TOKEN_THREADED_CODE || OPT_DIRECT_THREADED_CODE
 /* threaded code with gcc */
@@ -138,6 +140,8 @@ error !
 #define START_OF_ORIGINAL_INSN(x) start_of_##x:
 #define DISPATCH_ORIGINAL_INSN(x) goto  start_of_##x;
 
+#define CURRENT_INSN_IS(pop) (GET_CURRENT_INSN() == (VALUE)LABEL_PTR(pop))
+
 /************************************************/
 #else /* no threaded code */
 /* most common method */
@@ -165,11 +169,16 @@ default:                        \
 #define START_OF_ORIGINAL_INSN(x) start_of_##x:
 #define DISPATCH_ORIGINAL_INSN(x) goto  start_of_##x;
 
+#define CURRENT_INSN_IS(pop) (GET_CURRENT_INSN() == BIN(pop))
+
 #endif
 
 #define VM_SP_CNT(ec, sp) ((sp) - (ec)->vm_stack)
 
 #ifdef MJIT_HEADER
+/* MJIT_HEADER lacks LABEL_PTR() */
+#undef CURRENT_INSN_IS
+
 #define THROW_EXCEPTION(exc) do { \
     ec->errinfo = (VALUE)(exc); \
     EC_JUMP_TAG(ec, ec->tag->state); \

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -11,6 +11,7 @@
 /* finish iseq array */
 #include "insns.inc"
 #ifndef MJIT_HEADER
+#define INSIDE_VM_INSNHELPER_C
 #include "insns_info.inc"
 #endif
 #include <math.h>
@@ -1311,6 +1312,7 @@ rb_vm_search_method_slowpath(const struct rb_call_info *ci, struct rb_call_cache
     cc->method_state = GET_GLOBAL_METHOD_STATE();
     cc->class_serial = RCLASS_SERIAL(klass);
 #endif
+    CC_RESET_PURITY(cc);
 }
 
 static void
@@ -2059,6 +2061,7 @@ vm_call_opt_send(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, struct
 
     cc->me = rb_callable_method_entry_with_refinements(CLASS_OF(calling->recv), ci->mid, NULL);
     ci->flag = VM_CALL_FCALL | VM_CALL_OPT_SEND;
+    CC_RESET_PURITY(cc);
     return vm_call_method(ec, reg_cfp, calling, ci, cc);
 }
 
@@ -2154,6 +2157,7 @@ vm_call_zsuper(rb_execution_context_t *ec, rb_control_frame_t *cfp, struct rb_ca
 	cc->me->def->body.refined.orig_me) {
 	cc->me = refined_method_callable_without_refinement(cc->me);
     }
+    CC_RESET_PURITY(cc);
     return vm_call_method_each_type(ec, cfp, calling, ci, cc);
 }
 
@@ -2295,6 +2299,7 @@ vm_call_method_each_type(rb_execution_context_t *ec, rb_control_frame_t *cfp, st
       case VM_METHOD_TYPE_ALIAS:
 	cc->me = aliased_callable_method_entry(cc->me);
 	VM_ASSERT(cc->me != NULL);
+	CC_RESET_PURITY(cc);
 	return vm_call_method_each_type(ec, cfp, calling, ci, cc);
 
       case VM_METHOD_TYPE_OPTIMIZED:
@@ -2341,12 +2346,14 @@ vm_call_method_each_type(rb_execution_context_t *ec, rb_control_frame_t *cfp, st
 		}
 	    }
 	    cc->me = ref_me;
+	    CC_RESET_PURITY(cc);
 	    if (ref_me->def->type != VM_METHOD_TYPE_REFINED) {
 		return vm_call_method(ec, cfp, calling, ci, cc);
 	    }
 	}
 	else {
 	    cc->me = NULL;
+	    CC_RESET_PURITY(cc);
 	    return vm_call_method_nome(ec, cfp, calling, ci, cc);
 	}
 
@@ -2358,6 +2365,7 @@ vm_call_method_each_type(rb_execution_context_t *ec, rb_control_frame_t *cfp, st
 	    VALUE klass = RCLASS_SUPER(cc->me->defined_class);
 	    cc->me = klass ? rb_callable_method_entry(klass, ci->mid) : NULL;
 	}
+	CC_RESET_PURITY(cc);
 	return vm_call_method(ec, cfp, calling, ci, cc);
       }
     }
@@ -3820,6 +3828,39 @@ vm_opt_regexpmatch2(VALUE recv, VALUE obj)
     else {
 	return Qundef;
     }
+}
+
+/* @shyouhei wonders: where is the right place to define this function? */
+bool
+vm_whether_we_can_skip_this_call_handler_p(vm_call_handler h)
+{
+    /* We cannot write this function using a switch() because a case
+     * label cannot be a function pointer. */
+
+    /* Because there are lots of call handlers such as
+     * vm_call_iseq_setup_normal_0start_2params_4locals(),
+     * we cannot whitelist them all. See also
+     * tools/mk_call_iseq_optimzied.rb */
+    static const vm_call_handler blacklist[] = {
+        NULL,
+        vm_call_attrset,
+        vm_call_cfunc,
+        vm_call_general,
+        vm_call_ivar,
+        vm_call_method_missing,
+        vm_call_opt_block_call,
+        vm_call_opt_call,
+        vm_call_opt_send,
+        vm_call_super_method,
+    };
+    int i;
+
+    for (i = 0; i < numberof(blacklist); i++) {
+        if (h == blacklist[i]) {
+            return false;
+        }
+    }
+    return true;
 }
 
 rb_event_flag_t rb_iseq_event_flags(const rb_iseq_t *iseq, size_t pos);

--- a/vm_insnhelper.h
+++ b/vm_insnhelper.h
@@ -15,6 +15,7 @@
 RUBY_SYMBOL_EXPORT_BEGIN
 
 RUBY_EXTERN VALUE ruby_vm_const_missing_count;
+RUBY_EXTERN rb_serial_t ruby_vm_global_timestamp;
 RUBY_EXTERN rb_serial_t ruby_vm_global_method_state;
 RUBY_EXTERN rb_serial_t ruby_vm_global_constant_state;
 RUBY_EXTERN rb_serial_t ruby_vm_class_serial;
@@ -223,6 +224,14 @@ enum vm_regan_acttype {
 #define INC_GLOBAL_METHOD_STATE() (++ruby_vm_global_method_state)
 #define GET_GLOBAL_CONSTANT_STATE() (ruby_vm_global_constant_state)
 #define INC_GLOBAL_CONSTANT_STATE() (++ruby_vm_global_constant_state)
+
+#if RUBY_ATOMIC_GENERIC_MACRO
+# define INC_GLOBAL_TIMESTAMP() ATOMIC_INC(ruby_vm_global_timestamp)
+#elif defined(HAVE_LONG_LONG) && (SIZEOF_SIZE_T == SIZEOF_LONG_LONG)
+# define INC_GLOBAL_TIMESTAMP() ATOMIC_SIZE_INC(ruby_vm_global_timestamp)
+#else
+# define INC_GLOBAL_TIMESTAMP() (++ruby_vm_global_timestamp)
+#endif
 
 extern rb_method_definition_t *rb_method_definition_create(rb_method_type_t type, ID mid);
 extern void rb_method_definition_set(const rb_method_entry_t *me, rb_method_definition_t *def, void *opts);

--- a/vm_insnhelper.h
+++ b/vm_insnhelper.h
@@ -184,10 +184,17 @@ enum vm_regan_acttype {
 #endif
 
 #if OPT_CALL_FASTPATH
+#define CC_RESET_PURITY(cc) do { \
+    (cc)->purity = Qundef; \
+    (cc)->updated_at = ruby_vm_global_timestamp - 1; \
+} while (0)
+
 #define CI_SET_FASTPATH(cc, func, enabled) do { \
+    if (LIKELY(enabled)) CC_RESET_PURITY(cc); \
     if (LIKELY(enabled)) ((cc)->call = (func)); \
 } while (0)
 #else
+#define CC_RESET_PURITY(cc) /* do nothing */
 #define CI_SET_FASTPATH(ci, func, enabled) /* do nothing */
 #endif
 

--- a/vm_method.c
+++ b/vm_method.c
@@ -84,6 +84,7 @@ rb_class_clear_method_cache(VALUE klass, VALUE arg)
 void
 rb_clear_constant_cache(void)
 {
+    INC_GLOBAL_TIMESTAMP();
     INC_GLOBAL_CONSTANT_STATE();
 }
 
@@ -94,6 +95,8 @@ rb_clear_method_cache_by_class(VALUE klass)
 	int global = klass == rb_cBasicObject || klass == rb_cObject || klass == rb_mKernel;
 
 	RUBY_DTRACE_HOOK(METHOD_CACHE_CLEAR, (global ? "global" : rb_class2name(klass)));
+
+	INC_GLOBAL_TIMESTAMP();
 
 	if (global) {
 	    INC_GLOBAL_METHOD_STATE();


### PR DESCRIPTION
### Abstract

We propose a kind of optimisation so that known safe methods can be skipped.  In order to do so, we introduce a new instruction attribute called purity.  By checking the purity of every instruction inside of an instruction sequence, we can say if the sequence has any side effects or not.  This brings a room for optimisation, by skipping execution of such pure sequence.

The effect of this optimisation is somewhat limited (compared to #1419), but because we don't modify the form of instruction sequences at all, this pull request is safer to merge.  Passes test-all.

![untitled](https://user-images.githubusercontent.com/15377/44839026-ac34e200-ac78-11e8-9a59-51e3c32f2603.png)

### Related

- This changeset is another single-cut of #1419
- This changeset includes #1804 

### Purity of instructions and merging them into one

Each instruction is now categorised into the following 4 purity kinds namely "pure", "notpure", "unpredictable" and "dependsblock". Pure and not pure are intuitive.  Unpredictable means the instruction is unpredictable _at that moment_, maybe because that instruction has never been executed.  Thus when you evaluate that part later, the purity of the instruction might vary from time to time.  Depends block makes sense for method calls.  When a method itself had no side effects, there still are chances of breakage when the method yields and calling block that does something nasty.  But the purity of such block can be checked beforehand.  This value represents such situations.

Given this, a series of instructions are said to be pure or not by merging them altogether. An instruction sequence as a whole is not pure if it contains any instructions that are not pure.  It is unpredictable if it contains any unpredictable instructions (but no notpure ones).  Otherwise, the sequence is almost clean.  The purity then depends if it contains any dependsblock instruction or not.  In other words, an instruction sequence is said to be pure if and only if its containing instructions are all pure.

So far so simple.  The problem is, a call to a method (send instruction and such) can both be pure and not pure at the same time.  What is called at a specific call site cannot be determined until the very moment when we actually call it.  Of course, a method cannot be pure, until every and all of the methods it calls are pure.  So in short, we have to update a purity of a method on-the-fly.  This is done prior to we check the purity for skipping its execution.

### Purity caching and invalidating

Recursively reconstructing purity of each instruction sequences every time we call them is definitely a waste of time that we want to avoid.  Also, a method call is not always an execution of an instruction sequence; there are C methods.  So we are going to cache the calculated purity.

This is done in two places; first, the current effective purity is stored inside of `struct rb_iseq_constant_body`.  Then, at each call site, the purity is copied inside of `struct rb_call_cache`. The call cache also handles situations of non-Ruby methods.

These cached purites can become invalid on occasions.  For instance, a formerly pure instruction sequence can become not pure because of redefinitions.  In order to detect such things, we introduce per-VM global timestamp.  See #1804 for the details.  We consider cached purities invalid when its timestamp differs from the global one.

### Optimisation using the purity

In this pull request, we modify `CALL_METHOD` macro.  This is where a method is called.  We change it so that if a method is called, then the return value is immediately discarded, and the method is pure, this is subject to optimise.  We don't call it at all; just clean up the stack.

### Limitation of the proposed optimisation

The technique described above is in fact weak, compared to what we proposed in #1419.

Suppose we have a ruby snippet `foo.bar.baz` and the three methods are in fact all pure. #1419 could eliminate them all by gradually replacing the method calls into nops.  What is proposed here, however, is not possible to optimise `foo` and `bar`.  It can optimise `baz` call, but not until it actually tries to call `baz`.  In order to do so, `foo` and `bar` cannot be optimised out.  The same discussion goes with method arguments e.g. `foo(bar(baz()))`.

### Benchmarks

That being said, we believe the proposed method is not meaningless. We exercised ruby's standard benchmark set using benchmark-driver/benchmark-driver and got this result:

```
                              trunk        ours
           vm1_attr_ivar    43.410M     45.331M i/s -     30.000M times in 0.691083s 0.661802s
       vm1_attr_ivar_set    37.409M     29.019M i/s -     30.000M times in 0.801943s 1.033810s
               vm1_block    25.388M     56.543M i/s -     30.000M times in 1.181643s 0.530568s
          vm1_blockparam    26.034M     79.532M i/s -     30.000M times in 1.152326s 0.377207s
     vm1_blockparam_call    14.282M     13.995M i/s -     30.000M times in 2.100567s 2.143563s
     vm1_blockparam_pass    12.578M     12.652M i/s -     30.000M times in 2.385203s 2.371244s
    vm1_blockparam_yield    16.627M     58.780M i/s -     30.000M times in 1.804334s 0.510376s
               vm1_const   138.488M    138.751M i/s -     30.000M times in 0.216626s 0.216214s
              vm1_ensure      2.129       2.136 i/s -       1.000 times in 0.469715s 0.468274s
        vm1_float_simple    14.116M     14.545M i/s -     30.000M times in 2.125194s 2.062547s
                vm1_ivar   129.643M    138.232M i/s -     30.000M times in 0.231404s 0.217027s
            vm1_ivar_set    85.501M     91.704M i/s -     30.000M times in 0.350871s 0.327139s
              vm1_length    86.600M     87.724M i/s -     30.000M times in 0.346422s 0.341983s
           vm1_lvar_init      0.776       1.214 i/s -       1.000 times in 1.288198s 0.823900s
            vm1_lvar_set    14.897M     14.851M i/s -     30.000M times in 2.013887s 2.020001s
                 vm1_neq    69.289M     73.268M i/s -     30.000M times in 0.432969s 0.409453s
                 vm1_not   225.745M    259.525M i/s -     30.000M times in 0.132893s 0.115596s
              vm1_rescue   375.547M    241.017M i/s -     30.000M times in 0.079883s 0.124472s
        vm1_simplereturn    70.230M    104.059M i/s -     30.000M times in 0.427169s 0.288299s
                vm1_swap   126.279M    128.451M i/s -     30.000M times in 0.237569s 0.233552s
               vm1_yield      0.992       1.423 i/s -       1.000 times in 1.008184s 0.702558s
               vm2_array     5.358M      7.739M i/s -      6.000M times in 1.119869s 0.775304s
            vm2_bigarray   811.932k    853.831k i/s -      6.000M times in 7.389783s 7.027156s
             vm2_bighash    92.879k    112.642k i/s -     60.000k times in 0.646004s 0.532660s
                vm2_case    73.899M     62.589M i/s -      6.000M times in 0.081192s 0.095864s
            vm2_case_lit      1.389       1.320 i/s -       1.000 times in 0.720132s 0.757372s
      vm2_defined_method     2.156M     11.467M i/s -      6.000M times in 2.782473s 0.523226s
                vm2_dstr     5.175M      5.417M i/s -      6.000M times in 1.159329s 1.107629s
        vm2_fiber_switch   600.175k    572.593k i/s -      6.000M times in 9.997092s 10.478648s
              vm2_method     7.655M     11.707M i/s -      6.000M times in 0.783848s 0.512531s
      vm2_method_missing     2.734M      2.401M i/s -      6.000M times in 2.194879s 2.498677s
   vm2_method_with_block     6.299M      9.117M i/s -      6.000M times in 0.952600s 0.658145s
vm2_module_ann_const_set   663.286k    961.725k i/s -      6.000M times in 9.045878s 6.238790s
    vm2_module_const_set   804.539k      1.045M i/s -      6.000M times in 7.457687s 5.740310s
               vm2_mutex    10.657M     10.524M i/s -      6.000M times in 0.563004s 0.570145s
           vm2_newlambda     4.829M      7.083M i/s -      6.000M times in 1.242599s 0.847065s
         vm2_poly_method      0.484       0.376 i/s -       1.000 times in 2.066164s 2.661122s
      vm2_poly_method_ov      5.129       4.119 i/s -       1.000 times in 0.194978s 0.242782s
      vm2_poly_singleton      0.988       1.230 i/s -       1.000 times in 1.012463s 0.812685s
                vm2_proc    28.184M     27.420M i/s -      6.000M times in 0.212888s 0.218815s
              vm2_raise1     1.118M      1.430M i/s -      6.000M times in 5.367653s 4.195418s
              vm2_raise2   806.302k    931.697k i/s -      6.000M times in 7.441383s 6.439860s
              vm2_regexp     5.622M      5.567M i/s -      6.000M times in 1.067146s 1.077827s
                vm2_send    20.295M     17.299M i/s -      6.000M times in 0.295641s 0.346846s
      vm2_string_literal    38.817M     38.084M i/s -      6.000M times in 0.154573s 0.157546s
               vm2_super    16.609M     16.216M i/s -      6.000M times in 0.361260s 0.370014s
               vm2_unif1    57.266M     75.720M i/s -      6.000M times in 0.104774s 0.079239s
              vm2_zsuper    15.855M     15.090M i/s -      6.000M times in 0.378434s 0.397627s
           vm3_backtrace      7.237       8.713 i/s -       1.000 times in 0.138172s 0.114765s
    vm3_clearmethodcache      2.183       3.402 i/s -       1.000 times in 0.458154s 0.293988s
```

Trunk is `ruby 2.6.0dev (2018-08-28 trunk 64582) [x86_64-darwin15]`. Ours is a patch on top of it.  Both compiled using the same compiler (clang), same option.

Here, the result shows that for most test cases, the patch does nothing.  On some benchmarks where pure methods act a significant role, our approach outperforms the trunk.

### Conclusion

We propose a new kind of instruction attribute called purity.  By checking them, we can find a room for optimisation by skipping execution of such pure things.  It can boost benchmark performance for some instances, yet has no significant overhead.