### PR TITLE
Use -fstack-protector-strong instead of -fstack-protector conditionally.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -530,9 +530,15 @@ AS_IF([test "$GCC" = yes], [
 	])
     ])
     AS_IF([test "x$stack_protector" = xyes], [
-	RUBY_APPEND_OPTION(XCFLAGS, -fstack-protector)
-	RUBY_APPEND_OPTION(XLDFLAGS, -fstack-protector)
-	RUBY_APPEND_OPTION(LDFLAGS, -fstack-protector)
+        AS_IF([test $gcc_major -ge 5], [
+            RUBY_APPEND_OPTION(XCFLAGS, -fstack-protector-strong)
+            RUBY_APPEND_OPTION(XLDFLAGS, -fstack-protector-strong)
+            RUBY_APPEND_OPTION(LDFLAGS, -fstack-protector-strong)
+        ], [
+            RUBY_APPEND_OPTION(XCFLAGS, -fstack-protector)
+            RUBY_APPEND_OPTION(XLDFLAGS, -fstack-protector)
+            RUBY_APPEND_OPTION(LDFLAGS, -fstack-protector)
+        ])
     ])
 
     AS_CASE("${compress_debug_sections:-zlib}",


### PR DESCRIPTION
I am going to open the ticket soon on the issue tracking system to discuss this.

It seems better after this PR https://github.com/ruby/ruby/pull/1937 .
Because maybe we want to see the result on both gcc 4.8 and gcc 8 (>= 4.9 or 5)

The discussion could be on https://bugs.ruby-lang.org/issues/15053 .