### PR TITLE
Make the number of arguments of  `Hash#merge` variable

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -2594,14 +2594,14 @@ rb_hash_update(int argc, VALUE *argv, VALUE self)
     bool block_given = rb_block_given_p();
 
     rb_hash_modify(self);
-    for(i = 0; i < argc; i++){
-      VALUE hash = to_hash(argv[i]);
-      if (block_given) {
-        rb_hash_foreach(hash, rb_hash_update_block_i, self);
-      }
-      else {
-        rb_hash_foreach(hash, rb_hash_update_i, self);
-      }
+    for (i = 0; i < argc; i++){
+       VALUE hash = to_hash(argv[i]);
+       if (block_given) {
+          rb_hash_foreach(hash, rb_hash_update_block_i, self);
+       }
+       else {
+          rb_hash_foreach(hash, rb_hash_update_i, self);
+       }
     }
     return self;
 }

--- a/hash.c
+++ b/hash.c
@@ -2578,10 +2578,10 @@ rb_hash_update(int argc, VALUE *argv, VALUE self)
     for(int i = 0; i < argc; i++){
       VALUE hash = to_hash(argv[i]);
       if (rb_block_given_p()) {
-    rb_hash_foreach(hash, rb_hash_update_block_i, self);
+        rb_hash_foreach(hash, rb_hash_update_block_i, self);
       }
       else {
-    rb_hash_foreach(hash, rb_hash_update_i, self);
+        rb_hash_foreach(hash, rb_hash_update_i, self);
       }
     }
     return self;

--- a/hash.c
+++ b/hash.c
@@ -2607,9 +2607,9 @@ static VALUE
 rb_hash_update(int argc, VALUE *argv, VALUE self)
 {
     int i;
+    bool block_given = rb_block_given_p();
 
     rb_hash_modify(self);
-    bool block_given = rb_block_given_p();
     for(i = 0; i < argc; i++){
       VALUE hash = to_hash(argv[i]);
       if (block_given) {
@@ -2694,7 +2694,7 @@ rb_hash_update_by(VALUE hash1, VALUE hash2, rb_hash_update_func *func)
  *  More than one hash can be given to this method as arguments, then
  *  the method returns a new hash containing the contents of the reciever
  *  itself and all hashes given as arguments. The method also can be called 
- *  with no argument, then the receiver itself will be returned;
+ *  with no argument, then a new hash, whose content is same as that of receiver, will be returned;
  *
  *     h1 = { "a" => 100, "b" => 200 }
  *     h2 = { "b" => 254, "c" => 300 }

--- a/hash.c
+++ b/hash.c
@@ -2568,7 +2568,6 @@ rb_hash_update_block_i(VALUE key, VALUE value, VALUE hash)
  *
  *     h1 = { "a" => 100, "b" => 200 }
  *     h2 = { "b" => 254, "c" => 300 }
- *     h3 = { "b" => 100, "d" => 400 }
  *     h1.merge!(h2)   #=> {"a"=>100, "b"=>254, "c"=>300}
  *     h1              #=> {"a"=>100, "b"=>254, "c"=>300}
  *

--- a/hash.c
+++ b/hash.c
@@ -2572,17 +2572,19 @@ rb_hash_update_block_i(VALUE key, VALUE value, VALUE hash)
  */
 
 static VALUE
-rb_hash_update(VALUE hash1, VALUE hash2)
+rb_hash_update(int argc, VALUE *argv, VALUE self)
 {
-    rb_hash_modify(hash1);
-    hash2 = to_hash(hash2);
-    if (rb_block_given_p()) {
-	rb_hash_foreach(hash2, rb_hash_update_block_i, hash1);
+    rb_hash_modify(self);
+    for(int i = 0; i < argc; i++){
+      VALUE hash = to_hash(argv[i]);
+      if (rb_block_given_p()) {
+    rb_hash_foreach(hash, rb_hash_update_block_i, self);
+      }
+      else {
+    rb_hash_foreach(hash, rb_hash_update_i, self);
+      }
     }
-    else {
-	rb_hash_foreach(hash2, rb_hash_update_i, hash1);
-    }
-    return hash1;
+    return self;
 }
 
 struct update_func_arg {
@@ -2660,9 +2662,9 @@ rb_hash_update_by(VALUE hash1, VALUE hash2, rb_hash_update_func *func)
  */
 
 static VALUE
-rb_hash_merge(VALUE hash1, VALUE hash2)
+rb_hash_merge(int argc, VALUE *argv, VALUE self)
 {
-    return rb_hash_update(rb_hash_dup(hash1), hash2);
+    return rb_hash_update(argc, argv, rb_hash_dup(self));
 }
 
 static int
@@ -4758,10 +4760,10 @@ Init_Hash(void)
     rb_define_method(rb_cHash, "slice", rb_hash_slice, -1);
     rb_define_method(rb_cHash, "clear", rb_hash_clear, 0);
     rb_define_method(rb_cHash, "invert", rb_hash_invert, 0);
-    rb_define_method(rb_cHash, "update", rb_hash_update, 1);
+    rb_define_method(rb_cHash, "update", rb_hash_update, -1);
     rb_define_method(rb_cHash, "replace", rb_hash_replace, 1);
-    rb_define_method(rb_cHash, "merge!", rb_hash_update, 1);
-    rb_define_method(rb_cHash, "merge", rb_hash_merge, 1);
+    rb_define_method(rb_cHash, "merge!", rb_hash_update, -1);
+    rb_define_method(rb_cHash, "merge", rb_hash_merge, -1);
     rb_define_method(rb_cHash, "assoc", rb_hash_assoc, 1);
     rb_define_method(rb_cHash, "rassoc", rb_hash_rassoc, 1);
     rb_define_method(rb_cHash, "flatten", rb_hash_flatten, -1);

--- a/hash.c
+++ b/hash.c
@@ -2548,28 +2548,18 @@ rb_hash_update_block_i(VALUE key, VALUE value, VALUE hash)
 
 /*
  *  call-seq:
- *     hsh.merge!()                                           -> hsh
- *     hsh.update()                                           -> hsh
- *     hsh.merge!(other_hash)                                 -> hsh
- *     hsh.update(other_hash)                                 -> hsh
- *     hsh.merge!(other_hash1, other_hash2)                   -> hsh
- *     hsh.update(other_hash1, other_hash2)                   -> hsh
- *     hsh.merge!(other_hash){|key, oldval, newval| block}    -> hsh
- *     hsh.update(other_hash){|key, oldval, newval| block}    -> hsh
- *     hsh.merge!(other_hash1, other_hash2){|key, oldval, newval| block}
+ *     hsh.merge!(other_hash1, other_hash2, ...)              -> hsh
+ *     hsh.update(other_hash1, other_hash2, ...)              -> hsh
+ *     hsh.merge!(other_hash1, other_hash2, ...){|key, oldval, newval| block}
  *                                                            -> hsh
- *     hsh.update(other_hash1, other_hash2){|key, oldval, newval| block}
+ *     hsh.update(other_hash1, other_hash2, ...){|key, oldval, newval| block}
  *                                                            -> hsh
  *
- *  Adds the contents of _other_hash_ to _hsh_.  If no block is specified,
- *  entries with duplicate keys are overwritten with the values from
- *  _other_hash_, otherwise the value of each duplicate key is determined by
+ *  Adds the contents of _other_hash_s to _hsh_ repeatedly. If no block is
+ *  specified, entries with duplicate keys are overwritten with the values from
+ *  each _other_hash_, otherwise the value of each duplicate key is determined by
  *  calling the block with the key, its value in _hsh_ and its value in
- *  _other_hash_.
- *
- *  More than one hash can be given to this method as arguments, then
- *  the method adds the contents of each hash to receiver repeatedly
- *  in the way written above. The method also can be called with no argument,
+ *  each _other_hash_. The method also can be called with no argument,
  *  then nothing will change in the receiver.
  *
  *     h1 = { "a" => 100, "b" => 200 }
@@ -2588,12 +2578,6 @@ rb_hash_update_block_i(VALUE key, VALUE value, VALUE hash)
  *     h1.merge!(h2, h3)
  *                     #=> {"a"=>100, "b"=>100, "c"=>300, "d"=>400}
  *     h1              #=> {"a"=>100, "b"=>100, "c"=>300, "d"=>400}
- *
- *     h1 = { "a" => 100, "b" => 200 }
- *     h2 = { "b" => 254, "c" => 300 }
- *     h1.merge!(h2) { |key, v1, v2| v1 }
- *                     #=> {"a"=>100, "b"=>200, "c"=>300}
- *     h1              #=> {"a"=>100, "b"=>200, "c"=>300}
  *
  *     h1 = { "a" => 100, "b" => 200 }
  *     h2 = { "b" => 254, "c" => 300 }
@@ -2678,23 +2662,18 @@ rb_hash_update_by(VALUE hash1, VALUE hash2, rb_hash_update_func *func)
 
 /*
  *  call-seq:
- *     hsh.merge()                                        ->
- *     hsh.merge(other_hash)                              -> new_hash
- *     hsh.merge(other_hash1, other_hash2)                -> new_hash
- *     hsh.merge(other_hash){|key, oldval, newval| block} -> new_hash
- *     hsh.merge(other_hash1, other_hash2){|key, oldval, newval| block}
+ *     hsh.merge(other_hash1, other_hash2, ...)           -> new_hash
+ *     hsh.merge(other_hash1, other_hash2, ...){|key, oldval, newval| block}
  *                                                        -> new_hash
  *
- *  Returns a new hash containing the contents of <i>other_hash</i> and
+ *  Returns a new hash containing the contents of <i>other_hash</i>s and
  *  the contents of <i>hsh</i>. If no block is specified, the value for
- *  entries with duplicate keys will be that of <i>other_hash</i>. Otherwise
- *  the value for each duplicate key is determined by calling the block
- *  with the key, its value in <i>hsh</i> and its value in <i>other_hash</i>.
- *
- *  More than one hash can be given to this method as arguments, then
- *  the method returns a new hash containing the contents of the reciever
- *  itself and all hashes given as arguments. The method also can be called 
- *  with no argument, then a new hash, whose content is same as that of receiver, will be returned;
+ *  entries with duplicate keys will be that of each <i>other_hash</i>.
+ *  Otherwise the value for each duplicate key is determined by calling
+ *  the block with the key, its value in <i>hsh</i> and its value
+ *  in each <i>other_hash</i>. The method also can be called with no argument,
+ *  then a new hash, whose content is same as that of the receiver,
+ *  will be returned;
  *
  *     h1 = { "a" => 100, "b" => 200 }
  *     h2 = { "b" => 254, "c" => 300 }

--- a/test/ruby/test_hash.rb
+++ b/test/ruby/test_hash.rb
@@ -1119,7 +1119,6 @@ class TestHash < Test::Unit::TestCase
   def test_update2
     h1 = @cls[1=>2, 3=>4]
     h2 = {1=>3, 5=>7}
-    h3 = {1=>1, 2=>4}
     h1.update(h2) {|k, v1, v2| k + v1 + v2 }
     assert_equal({1=>6, 3=>4, 5=>7}, h1)
   end

--- a/test/ruby/test_hash.rb
+++ b/test/ruby/test_hash.rb
@@ -1119,15 +1119,19 @@ class TestHash < Test::Unit::TestCase
   def test_update2
     h1 = @cls[1=>2, 3=>4]
     h2 = {1=>3, 5=>7}
-    h1.update(h2) {|k, v1, v2| k + v1 + v2 }
-    assert_equal({1=>6, 3=>4, 5=>7}, h1)
+    h3 = {1=>1, 2=>4}
+    h1.update(h2, h3) {|k, v1, v2| k + v1 + v2 }
+    assert_equal({1=>8, 2=>4, 3=>4, 5=>7}, h1)
   end
 
   def test_merge
     h1 = @cls[1=>2, 3=>4]
     h2 = {1=>3, 5=>7}
+    h3 = {1=>1, 2=>4}
     assert_equal({1=>3, 3=>4, 5=>7}, h1.merge(h2))
     assert_equal({1=>6, 3=>4, 5=>7}, h1.merge(h2) {|k, v1, v2| k + v1 + v2 })
+    assert_equal({1=>1, 2=>4, 3=>4, 5=>7}, h1.merge(h2, h3))
+    assert_equal({1=>8, 2=>4, 3=>4, 5=>7}, h1.merge(h2, h3) {|k, v1, v2| k + v1 + v2 })
   end
 
   def test_assoc

--- a/test/ruby/test_hash.rb
+++ b/test/ruby/test_hash.rb
@@ -1128,6 +1128,7 @@ class TestHash < Test::Unit::TestCase
     h1 = @cls[1=>2, 3=>4]
     h2 = {1=>3, 5=>7}
     h3 = {1=>1, 2=>4}
+    assert_equal({1=>2, 3=>4}, h1.merge())
     assert_equal({1=>3, 3=>4, 5=>7}, h1.merge(h2))
     assert_equal({1=>6, 3=>4, 5=>7}, h1.merge(h2) {|k, v1, v2| k + v1 + v2 })
     assert_equal({1=>1, 2=>4, 3=>4, 5=>7}, h1.merge(h2, h3))

--- a/test/ruby/test_hash.rb
+++ b/test/ruby/test_hash.rb
@@ -1120,7 +1120,27 @@ class TestHash < Test::Unit::TestCase
     h1 = @cls[1=>2, 3=>4]
     h2 = {1=>3, 5=>7}
     h3 = {1=>1, 2=>4}
-    h1.update(h2, h3) {|k, v1, v2| k + v1 + v2 }
+    h1.update(h2) {|k, v1, v2| k + v1 + v2 }
+    assert_equal({1=>6, 3=>4, 5=>7}, h1)
+  end
+
+  def test_update3
+    h1 = @cls[1=>2, 3=>4]
+    h1.update()
+    assert_equal({1=>2, 3=>4}, h1)
+    h2 = {1=>3, 5=>7}
+    h3 = {1=>1, 2=>4}
+    h1.update(h2, h3)
+    assert_equal({1=>1, 2=>4, 3=>4, 5=>7}, h1)
+  end
+
+  def test_update4
+    h1 = @cls[1=>2, 3=>4]
+    h1.update(){|k, v1, v2| k + v1 + v2 }
+    assert_equal({1=>2, 3=>4}, h1)
+    h2 = {1=>3, 5=>7}
+    h3 = {1=>1, 2=>4}
+    h1.update(h2, h3){|k, v1, v2| k + v1 + v2 }
     assert_equal({1=>8, 2=>4, 3=>4, 5=>7}, h1)
   end
 


### PR DESCRIPTION
# Abstract
Make the number of arguments of  `Hash#merge` variable.

# Background
In many websites such as  Stack Overflow and Qiita, many people are seeking how to merge more than three hashes. 

https://stackoverflow.com/questions/19548496/how-to-merge-multiple-hashes-in-ruby
https://qiita.com/hc0208/items/c662f5189fa383872f4e
https://stackoverrun.com/ja/q/4997431

Many ways, like using `Enumerable#inject` or calling `Hash#merge` multiple times, are proposed, but both don't seem intuitive. Especially when using block in `Hash#merge`, the code becomes too complicated.

# Proposal
Change the argument of `Hash#merge` from singular to variable length.
# Implementation
The code below.
# Evaluation
The code to merge more than three hashes became much simpler and more intuitive.

before
```ruby
hash1.merge(hash2).merge(hash3)

[hash1, hash2, hash3].inject do |result, part|
  result.merge(part) { |key, value1, value2| key + value1 + value2 }
end
```

after
```ruby
hash1.merge(hash2, hash3)
hash1.merge(hash2, hash3) { |key, value1, value2| key + value1 + value2 }
```
# Discussion
# Summary
The change is needed to make `Hash#merge` more useful and intuitive.