### PR TITLE
Make qsort_r() flavor detecting work if qsort_r() is a macro

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1950,7 +1950,7 @@ AS_IF([test "$ac_cv_func_qsort_r" != no], [
   AC_CACHE_CHECK(whether qsort_r is GNU version, rb_cv_gnu_qsort_r,
     [AC_TRY_COMPILE([
 @%:@include <stdlib.h>
-void qsort_r(void *base, size_t nmemb, size_t size,
+void (qsort_r)(void *base, size_t nmemb, size_t size,
 	    int (*compar)(const void *, const void *, void *),
 	    void *arg);
 ],[ ],
@@ -1960,7 +1960,7 @@ void qsort_r(void *base, size_t nmemb, size_t size,
   AC_CACHE_CHECK(whether qsort_r is BSD version, rb_cv_bsd_qsort_r,
     [AC_TRY_COMPILE([
 @%:@include <stdlib.h>
-void qsort_r(void *base, size_t nmemb, size_t size,
+void (qsort_r)(void *base, size_t nmemb, size_t size,
 	     void *arg, int (*compar)(void *, const void *, const void *));
 ],[ ],
       [rb_cv_bsd_qsort_r=yes],


### PR DESCRIPTION
On FreeBSD we're going to switch to the GNU-ish version of qsort_r().
POSIX is also considering standardizing that one. To prevent faulty
calls, we have a macro in place to throw a compiler error if a BSD-style
qsort_r() call is performed on a patched system. Such an approach tends
to be permitted by POSIX.

The configure check we have in Ruby would fail if qsort_r() is a
function macro. Add parentheses around it to prevent macro expansion and
force the declaration of a prototype.