### PR TITLE
Remove -Wno-parentheses flag.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -458,7 +458,7 @@ AS_IF([test "$GCC:${warnflags+set}:no" = yes::no], [
     AS_IF([test $icc_version -gt 0], [
 	particular_werror_flags=no
     ])
-    for wflag in -Wno-unused-parameter -Wno-parentheses -Wno-long-long \
+    for wflag in -Wno-unused-parameter -Wno-long-long \
                  -diag-disable=175,188,2259 \
 		 -Wno-missing-field-initializers \
 		 -Wno-tautological-compare \

--- a/ext/openssl/ossl_pkey.h
+++ b/ext/openssl/ossl_pkey.h
@@ -133,9 +133,9 @@ static VALUE ossl_##_keytype##_set_##_group(VALUE self, VALUE v1, VALUE v2, VALU
 	BIGNUM *bn3 = NULL, *orig_bn3 = NIL_P(v3) ? NULL : GetBNPtr(v3);\
 									\
 	Get##_type(self, obj);						\
-	if (orig_bn1 && !(bn1 = BN_dup(orig_bn1)) ||			\
-	    orig_bn2 && !(bn2 = BN_dup(orig_bn2)) ||			\
-	    orig_bn3 && !(bn3 = BN_dup(orig_bn3))) {			\
+	if ((orig_bn1 && !(bn1 = BN_dup(orig_bn1))) ||			\
+	    (orig_bn2 && !(bn2 = BN_dup(orig_bn2))) ||			\
+	    (orig_bn3 && !(bn3 = BN_dup(orig_bn3)))) {			\
 		BN_clear_free(bn1);					\
 		BN_clear_free(bn2);					\
 		BN_clear_free(bn3);					\
@@ -163,8 +163,8 @@ static VALUE ossl_##_keytype##_set_##_group(VALUE self, VALUE v1, VALUE v2) \
 	BIGNUM *bn2 = NULL, *orig_bn2 = NIL_P(v2) ? NULL : GetBNPtr(v2);\
 									\
 	Get##_type(self, obj);						\
-	if (orig_bn1 && !(bn1 = BN_dup(orig_bn1)) ||			\
-	    orig_bn2 && !(bn2 = BN_dup(orig_bn2))) {			\
+	if ((orig_bn1 && !(bn1 = BN_dup(orig_bn1))) ||			\
+	    (orig_bn2 && !(bn2 = BN_dup(orig_bn2)))) {			\
 		BN_clear_free(bn1);					\
 		BN_clear_free(bn2);					\
 		ossl_raise(eBNError, NULL);				\

--- a/ext/openssl/ossl_pkey_dh.c
+++ b/ext/openssl/ossl_pkey_dh.c
@@ -262,7 +262,7 @@ ossl_dh_initialize_copy(VALUE self, VALUE other)
 	BIGNUM *pub2 = BN_dup(pub);
 	BIGNUM *priv2 = BN_dup(priv);
 
-	if (!pub2 || priv && !priv2) {
+	if (!pub2 || (priv && !priv2)) {
 	    BN_clear_free(pub2);
 	    BN_clear_free(priv2);
 	    ossl_raise(eDHError, "BN_dup");

--- a/ext/openssl/ossl_x509name.c
+++ b/ext/openssl/ossl_x509name.c
@@ -270,7 +270,7 @@ x509name_print(VALUE self, unsigned long iflag)
     if (!out)
 	ossl_raise(eX509NameError, NULL);
     ret = X509_NAME_print_ex(out, name, 0, iflag);
-    if (ret < 0 || iflag == XN_FLAG_COMPAT && ret == 0) {
+    if (ret < 0 || (iflag == XN_FLAG_COMPAT && ret == 0)) {
 	BIO_free(out);
 	ossl_raise(eX509NameError, "X509_NAME_print_ex");
     }

--- a/mjit_worker.c
+++ b/mjit_worker.c
@@ -1094,7 +1094,7 @@ convert_unit_to_func(struct rb_mjit_unit *unit)
     success = compile_c_to_so(c_file, so_file);
 #else
     /* splitting .c -> .o step and .o -> .so step, to cache .o files in the future */
-    if (success = compile_c_to_o(c_file, o_file)) {
+    if ((success = compile_c_to_o(c_file, o_file)) != 0) {
         const char *o_files[2] = { NULL, NULL };
         o_files[0] = o_file;
         success = link_o_to_so(o_files, so_file);

--- a/re.c
+++ b/re.c
@@ -95,7 +95,7 @@ rb_memsearch_ss(const unsigned char *xs, long m, const unsigned char *ys, long n
 {
     const unsigned char *y;
 
-    if (y = memmem(ys, n, xs, m))
+    if ((y = memmem(ys, n, xs, m)) != NULL)
 	return y - ys;
     else
 	return -1;

--- a/signal.c
+++ b/signal.c
@@ -886,7 +886,7 @@ check_stack_overflow(int sig, const uintptr_t addr, const ucontext_t *ctx)
     /* SP in ucontext is not decremented yet when `push` failed, so
      * the fault page can be the next. */
     if (sp_page == fault_page || sp_page == fault_page + 1 ||
-	sp_page <= fault_page && fault_page <= bp_page) {
+	(sp_page <= fault_page && fault_page <= bp_page)) {
 	rb_execution_context_t *ec = GET_EC();
 	int crit = FALSE;
 	if ((uintptr_t)ec->tag->buf / pagesize <= fault_page + 1) {

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -3868,7 +3868,7 @@ vm_trace(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, const VALUE *p
 	VM_ASSERT(vm_event_flags & events);
 
 	/* increment PC because source line is calculated with PC-1 */
-	if (event = (events & (RUBY_EVENT_CLASS | RUBY_EVENT_CALL | RUBY_EVENT_B_CALL))) {
+	if ((event = (events & (RUBY_EVENT_CLASS | RUBY_EVENT_CALL | RUBY_EVENT_B_CALL))) != 0) {
 	    VM_ASSERT(event == RUBY_EVENT_CLASS ||
 		      event == RUBY_EVENT_CALL  ||
 		      event == RUBY_EVENT_B_CALL);
@@ -3889,7 +3889,7 @@ vm_trace(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, const VALUE *p
 	    EXEC_EVENT_HOOK(ec, RUBY_EVENT_COVERAGE_LINE, GET_SELF(), 0, 0, 0, Qundef);
 	    reg_cfp->pc--;
 	}
-	if (event = (events & (RUBY_EVENT_END | RUBY_EVENT_RETURN | RUBY_EVENT_B_RETURN))) {
+	if ((event = (events & (RUBY_EVENT_END | RUBY_EVENT_RETURN | RUBY_EVENT_B_RETURN))) != 0) {
 	    VM_ASSERT(event == RUBY_EVENT_END ||
 		      event == RUBY_EVENT_RETURN  ||
 		      event == RUBY_EVENT_B_RETURN);


### PR DESCRIPTION
I fixed the warnings to remove `-Wno-parentheses` flag.

The discussion could be here.
https://bugs.ruby-lang.org/issues/15136
