### PR TITLE
opt_regexpmatch1 is actually making things slower.

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -3269,6 +3269,7 @@ iseq_specialized_instruction(rb_iseq_t *iseq, INSN *iobj)
 		  case idMOD:	 SP_INSN(mod);	  return COMPILE_OK;
 		  case idEq:	 SP_INSN(eq);	  return COMPILE_OK;
 		  case idNeq:	 SP_INSN(neq);	  return COMPILE_OK;
+		  case idEqTilde:SP_INSN(regexpmatch2);return COMPILE_OK;
 		  case idLT:	 SP_INSN(lt);	  return COMPILE_OK;
 		  case idLE:	 SP_INSN(le);	  return COMPILE_OK;
 		  case idGT:	 SP_INSN(gt);	  return COMPILE_OK;
@@ -7569,26 +7570,9 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
 	    break;
 	}
 
-	if (ISEQ_COMPILE_DATA(iseq)->option->specialized_instruction) {
-	    /* TODO: detect by node */
-	    if (recv->last == recv->anchor.next &&
-		INSN_OF(recv->last) == BIN(putobject) &&
-		nd_type(node) == NODE_MATCH2) {
-		ADD_SEQ(ret, val);
-		ADD_INSN1(ret, line, opt_regexpmatch1,
-			  OPERAND_AT(recv->last, 0));
-	    }
-	    else {
-		ADD_SEQ(ret, recv);
-		ADD_SEQ(ret, val);
-		ADD_INSN2(ret, line, opt_regexpmatch2, new_callinfo(iseq, idEqTilde, 1, 0, NULL, FALSE), Qnil);
-	    }
-	}
-	else {
-	    ADD_SEQ(ret, recv);
-	    ADD_SEQ(ret, val);
-	    ADD_SEND(ret, line, idEqTilde, INT2FIX(1));
-	}
+        ADD_SEQ(ret, recv);
+        ADD_SEQ(ret, val);
+        ADD_SEND(ret, line, idEqTilde, INT2FIX(1));
 
 	if (node->nd_args) {
 	    compile_named_capture_assign(iseq, ret, node->nd_args);

--- a/insns.def
+++ b/insns.def
@@ -1427,17 +1427,6 @@ opt_not
     }
 }
 
-/* optimized regexp match */
-DEFINE_INSN
-opt_regexpmatch1
-(VALUE recv)
-(VALUE obj)
-(VALUE val)
-// attr bool leaf = false; /* rb_reg_prepare_enc() may rb_raise() that calls rb_funcallv() */
-{
-    val = vm_opt_regexpmatch1(recv, obj);
-}
-
 /* optimized regexp match 2 */
 DEFINE_INSN
 opt_regexpmatch2

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -4319,6 +4319,7 @@ static VALUE
 vm_opt_regexpmatch2(VALUE recv, VALUE obj)
 {
     if (CLASS_OF(recv) == rb_cString &&
+        CLASS_OF(obj) == rb_cRegexp &&
 	BASIC_OP_UNREDEFINED_P(BOP_MATCH, STRING_REDEFINED_OP_FLAG)) {
 	return rb_reg_match(obj, recv);
     }

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -4333,6 +4333,10 @@ vm_opt_regexpmatch2(VALUE recv, VALUE obj)
 	BASIC_OP_UNREDEFINED_P(BOP_MATCH, STRING_REDEFINED_OP_FLAG)) {
 	return rb_reg_match(obj, recv);
     }
+    else if (CLASS_OF(recv) == rb_cRegexp &&
+        BASIC_OP_UNREDEFINED_P(BOP_MATCH, REGEXP_REDEFINED_OP_FLAG)) {
+	return rb_reg_match(recv, obj);
+    }
     else {
 	return Qundef;
     }

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -4316,17 +4316,6 @@ vm_opt_not(CALL_INFO ci, CALL_CACHE cc, VALUE recv)
 }
 
 static VALUE
-vm_opt_regexpmatch1(VALUE recv, VALUE obj)
-{
-    if (BASIC_OP_UNREDEFINED_P(BOP_MATCH, REGEXP_REDEFINED_OP_FLAG)) {
-	return rb_reg_match(recv, obj);
-    }
-    else {
-	return rb_funcall(recv, idEqTilde, 1, obj);
-    }
-}
-
-static VALUE
 vm_opt_regexpmatch2(VALUE recv, VALUE obj)
 {
     if (CLASS_OF(recv) == rb_cString &&


### PR DESCRIPTION
@ko1 do you have any reason why this instruction exist?

```
trunk: ruby 2.6.0dev (2018-09-18 trunk 64767) [x86_64-darwin15]
ours: ruby 2.6.0dev (2018-09-18 opt_regexpmatch 64775) [x86_64-darwin15]
last_commit=opt_regexpmatch1 is actually making things slower.
Calculating -------------------------------------
                              trunk        ours
Optcarrot Lan_Master.nes     33.877      35.282 fps

Comparison:
             Optcarrot Lan_Master.nes
                    ours:        35.3 fps
                   trunk:        33.9 fps - 1.04x  slower
```