### PR TITLE
webrick: raise EOFError in parse when read line is nil

### DIFF
--- a/lib/webrick/httprequest.rb
+++ b/lib/webrick/httprequest.rb
@@ -445,12 +445,14 @@ module WEBrick
 
     def read_request_line(socket)
       @request_line = read_line(socket, MAX_URI_LENGTH) if socket
+      raise HTTPStatus::EOFError unless @request_line
+
       @request_bytes = @request_line.bytesize
       if @request_bytes >= MAX_URI_LENGTH and @request_line[-1, 1] != LF
         raise HTTPStatus::RequestURITooLarge
       end
+
       @request_time = Time.now
-      raise HTTPStatus::EOFError unless @request_line
       if /^(\S+)\s+(\S++)(?:\s+HTTP\/(\d+\.\d+))?\r?\n/mo =~ @request_line
         @request_method = $1
         @unparsed_uri   = $2

--- a/test/webrick/test_httprequest.rb
+++ b/test/webrick/test_httprequest.rb
@@ -422,4 +422,11 @@ GET /
       req.body
     }
   end
+
+  def test_eof_raised_when_line_is_nil
+    assert_raise(WEBrick::HTTPStatus::EOFError) {
+      req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+      req.parse(StringIO.new(""))
+    }
+  end
 end


### PR DESCRIPTION
Prior to this patch, if the IO object being read during parse returned `nil` from `gets`, a NoMethodError would be raised calling `bytesize` on `nil`. Instead, an `EOFError` should be returned. This bug has been present since 1e8c6e2ba4eb4305a756f650248283ecad4f36cb.
