### PR TITLE
Optimize Integer#& and Integer#|

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -3245,6 +3245,7 @@ iseq_specialized_instruction(rb_iseq_t *iseq, INSN *iobj)
 		  case idGE:	 SP_INSN(ge);	  return COMPILE_OK;
 		  case idLTLT:	 SP_INSN(ltlt);	  return COMPILE_OK;
 		  case idAREF:	 SP_INSN(aref);	  return COMPILE_OK;
+                  case idAnd:    SP_INSN(and);    return COMPILE_OK;
 		}
 		break;
 	      case 2:

--- a/compile.c
+++ b/compile.c
@@ -3246,6 +3246,7 @@ iseq_specialized_instruction(rb_iseq_t *iseq, INSN *iobj)
 		  case idLTLT:	 SP_INSN(ltlt);	  return COMPILE_OK;
 		  case idAREF:	 SP_INSN(aref);	  return COMPILE_OK;
                   case idAnd:    SP_INSN(and);    return COMPILE_OK;
+                  case idOr:     SP_INSN(or);    return COMPILE_OK;
 		}
 		break;
 	      case 2:

--- a/defs/id.def
+++ b/defs/id.def
@@ -98,6 +98,7 @@ token_ops = %[\
   Neq           !=      NEQ
   Not           !
   And           &
+  Or            |
   Backquote     `
   EqTilde       =~      MATCH
   NeqTilde      !~      NMATCH

--- a/defs/id.def
+++ b/defs/id.def
@@ -97,6 +97,7 @@ token_ops = %[\
   Eqq           ===     EQQ
   Neq           !=      NEQ
   Not           !
+  And           &
   Backquote     `
   EqTilde       =~      MATCH
   NeqTilde      !~      NMATCH

--- a/insns.def
+++ b/insns.def
@@ -1230,6 +1230,20 @@ opt_and
     }
 }
 
+/* optimized X|Y. */
+DEFINE_INSN
+opt_or
+(CALL_INFO ci, CALL_CACHE cc)
+(VALUE recv, VALUE obj)
+(VALUE val)
+{
+    val = vm_opt_or(recv, obj);
+
+    if (val == Qundef) {
+        CALL_SIMPLE_METHOD();
+    }
+}
+
 /* [] */
 DEFINE_INSN
 opt_aref

--- a/insns.def
+++ b/insns.def
@@ -1216,6 +1216,20 @@ opt_ltlt
     }
 }
 
+/* optimized X&Y. */
+DEFINE_INSN
+opt_and
+(CALL_INFO ci, CALL_CACHE cc)
+(VALUE recv, VALUE obj)
+(VALUE val)
+{
+    val = vm_opt_and(recv, obj);
+
+    if (val == Qundef) {
+        CALL_SIMPLE_METHOD();
+    }
+}
+
 /* [] */
 DEFINE_INSN
 opt_aref

--- a/test/ruby/test_jit.rb
+++ b/test/ruby/test_jit.rb
@@ -478,6 +478,14 @@ class TestJIT < Test::Unit::TestCase
     assert_compile_once('[1] << 2', result_inspect: '[1, 2]', insns: %i[opt_ltlt])
   end
 
+  def test_compile_insn_opt_and
+    assert_compile_once('1 & 3', result_inspect: '1', insns: %i[opt_and])
+  end
+
+  def test_compile_insn_opt_or
+    assert_compile_once('1 | 3', result_inspect: '3', insns: %i[opt_or])
+  end
+
   def test_compile_insn_opt_aref
     skip_on_mswin
     # optimized call (optimized JIT) -> send call

--- a/test/ruby/test_optimization.rb
+++ b/test/ruby/test_optimization.rb
@@ -187,6 +187,16 @@ class TestRubyOptimization < Test::Unit::TestCase
     assert_redefine_method('String', '<<', 'assert_equal "b", "a" << "b"')
   end
 
+  def test_fixnum_and
+    assert_equal 1, 1&3
+    assert_redefine_method('Integer', '&', 'assert_equal 3, 1&3')
+  end
+
+  def test_fixnum_or
+    assert_equal 3, 1|3
+    assert_redefine_method('Integer', '|', 'assert_equal 1, 3|1')
+  end
+
   def test_array_plus
     assert_equal [1,2], [1]+[2]
     assert_redefine_method('Array', '+', 'assert_equal [2], [1]+[2]')

--- a/tool/transform_mjit_header.rb
+++ b/tool/transform_mjit_header.rb
@@ -53,6 +53,7 @@ module MJITHeader
     'vm_opt_ge',
     'vm_opt_ltlt',
     'vm_opt_and',
+    'vm_opt_or',
     'vm_opt_aref',
     'vm_opt_aset',
     'vm_opt_aref_with',

--- a/tool/transform_mjit_header.rb
+++ b/tool/transform_mjit_header.rb
@@ -52,6 +52,7 @@ module MJITHeader
     'vm_opt_gt',
     'vm_opt_ge',
     'vm_opt_ltlt',
+    'vm_opt_and',
     'vm_opt_aref',
     'vm_opt_aset',
     'vm_opt_aref_with',

--- a/vm.c
+++ b/vm.c
@@ -1611,6 +1611,7 @@ vm_init_redefined_flag(void)
     OP(Min, MIN), (C(Array));
     OP(Call, CALL), (C(Proc));
     OP(And, AND), (C(Integer));
+    OP(Or, OR), (C(Integer));
 #undef C
 #undef OP
 }

--- a/vm.c
+++ b/vm.c
@@ -1610,6 +1610,7 @@ vm_init_redefined_flag(void)
     OP(Max, MAX), (C(Array));
     OP(Min, MIN), (C(Array));
     OP(Call, CALL), (C(Proc));
+    OP(And, AND), (C(Integer));
 #undef C
 #undef OP
 }

--- a/vm_core.h
+++ b/vm_core.h
@@ -531,6 +531,7 @@ enum ruby_basic_operators {
     BOP_MAX,
     BOP_MIN,
     BOP_CALL,
+    BOP_AND,
 
     BOP_LAST_
 };

--- a/vm_core.h
+++ b/vm_core.h
@@ -532,6 +532,7 @@ enum ruby_basic_operators {
     BOP_MIN,
     BOP_CALL,
     BOP_AND,
+    BOP_OR,
 
     BOP_LAST_
 };

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -3665,6 +3665,18 @@ vm_opt_and(VALUE recv, VALUE obj)
 }
 
 static VALUE
+vm_opt_or(VALUE recv, VALUE obj)
+{
+    if (FIXNUM_2_P(recv, obj) &&
+        BASIC_OP_UNREDEFINED_P(BOP_OR, INTEGER_REDEFINED_OP_FLAG)) {
+        return LONG2NUM(FIX2LONG(recv) | FIX2LONG(obj));
+    }
+    else {
+        return Qundef;
+    }
+}
+
+static VALUE
 vm_opt_aref(VALUE recv, VALUE obj)
 {
     if (SPECIAL_CONST_P(recv)) {

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -3653,6 +3653,18 @@ vm_opt_ltlt(VALUE recv, VALUE obj)
 }
 
 static VALUE
+vm_opt_and(VALUE recv, VALUE obj)
+{
+    if (FIXNUM_2_P(recv, obj) &&
+        BASIC_OP_UNREDEFINED_P(BOP_AND, INTEGER_REDEFINED_OP_FLAG)) {
+        return LONG2NUM(FIX2LONG(recv) & FIX2LONG(obj));
+    }
+    else {
+        return Qundef;
+    }
+}
+
+static VALUE
 vm_opt_aref(VALUE recv, VALUE obj)
 {
     if (SPECIAL_CONST_P(recv)) {


### PR DESCRIPTION
```
$ benchmark-driver benchmark.yml --rbenv 'before::before --disable-gems;before+JIT::before --disable-gems --jit;after::after --disable-gems;after+JIT::after --disable-gems --jit' -v --repeat-count 24
before: ruby 2.6.0dev (2018-09-24 trunk 64821) [x86_64-linux]
before+JIT: ruby 2.6.0dev (2018-09-24 trunk 64821) +JIT [x86_64-linux]
after: ruby 2.6.0dev (2018-09-24 opt_and 64821) [x86_64-linux]
last_commit=opt_or
after+JIT: ruby 2.6.0dev (2018-09-24 opt_and 64821) +JIT [x86_64-linux]
last_commit=opt_or
Calculating -------------------------------------
                             before  before+JIT       after   after+JIT
Optcarrot Lan_Master.nes     51.460      66.315      53.023      71.173 fps

Comparison:
             Optcarrot Lan_Master.nes
               after+JIT:        71.2 fps
              before+JIT:        66.3 fps - 1.07x  slower
                   after:        53.0 fps - 1.34x  slower
                  before:        51.5 fps - 1.38x  slower

```