### PR TITLE
insns.def: dynamically change optimized instructions

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -3225,28 +3225,14 @@ iseq_specialized_instruction(rb_iseq_t *iseq, INSN *iobj)
 		switch (ci->mid) {
 		  case idLength: SP_INSN(length); return COMPILE_OK;
 		  case idSize:	 SP_INSN(size);	  return COMPILE_OK;
-		  case idEmptyP: SP_INSN(empty_p);return COMPILE_OK;
-		  case idSucc:	 SP_INSN(succ);	  return COMPILE_OK;
 		  case idNot:	 SP_INSN(not);	  return COMPILE_OK;
 		}
 		break;
 	      case 1:
 		switch (ci->mid) {
-		  case idPLUS:	 SP_INSN(plus);	  return COMPILE_OK;
-		  case idMINUS:	 SP_INSN(minus);  return COMPILE_OK;
-		  case idMULT:	 SP_INSN(mult);	  return COMPILE_OK;
-		  case idDIV:	 SP_INSN(div);	  return COMPILE_OK;
-		  case idMOD:	 SP_INSN(mod);	  return COMPILE_OK;
 		  case idEq:	 SP_INSN(eq);	  return COMPILE_OK;
 		  case idNeq:	 SP_INSN(neq);	  return COMPILE_OK;
-		  case idLT:	 SP_INSN(lt);	  return COMPILE_OK;
-		  case idLE:	 SP_INSN(le);	  return COMPILE_OK;
-		  case idGT:	 SP_INSN(gt);	  return COMPILE_OK;
-		  case idGE:	 SP_INSN(ge);	  return COMPILE_OK;
-		  case idLTLT:	 SP_INSN(ltlt);	  return COMPILE_OK;
 		  case idAREF:	 SP_INSN(aref);	  return COMPILE_OK;
-                  case idAnd:    SP_INSN(and);    return COMPILE_OK;
-                  case idOr:     SP_INSN(or);    return COMPILE_OK;
 		}
 		break;
 	      case 2:

--- a/insns.def
+++ b/insns.def
@@ -770,9 +770,11 @@ opt_send_without_block
     if (LIKELY(INLINE_METHOD_CACHE_HIT(cc, klass))) {
         CALL_METHOD(&calling, ci, cc);
     }
+#ifndef MJIT_HEADER
     else if ((val = vm_specialize_insn(GET_CFP(), PC_OFFSET(opt_send_without_block, ci, cc), ci)) != Qundef) {
         INC_SP(INSN_ATTR(sp_inc) - 1 /* recv */);
     }
+#endif
     else {
         rb_vm_search_method_slowpath(ci, cc, klass);
         CALL_METHOD(&calling, ci, cc);

--- a/insns.def
+++ b/insns.def
@@ -761,10 +761,19 @@ opt_send_without_block
 // attr bool handles_sp = true;
 // attr rb_snum_t sp_inc = -ci->orig_argc;
 {
+    VALUE klass;
     struct rb_calling_info calling;
+
     calling.block_handler = VM_BLOCK_HANDLER_NONE;
-    vm_search_method(ci, cc, calling.recv = TOPN(calling.argc = ci->orig_argc));
-    CALL_METHOD(&calling, ci, cc);
+    calling.recv = TOPN(calling.argc = ci->orig_argc);
+    klass = CLASS_OF(calling.recv);
+    if (LIKELY(INLINE_METHOD_CACHE_HIT(cc, klass))) {
+        CALL_METHOD(&calling, ci, cc);
+    }
+    else if ((val = vm_specialize_insn(GET_CFP(), PC_OFFSET(opt_send_without_block, ci, cc), ci)) == Qundef) {
+        rb_vm_search_method_slowpath(ci, cc, klass);
+        CALL_METHOD(&calling, ci, cc);
+    }
 }
 
 DEFINE_INSN
@@ -1052,6 +1061,7 @@ opt_plus
     val = vm_opt_plus(recv, obj);
 
     if (val == Qundef) {
+        vm_change_insn(GET_CFP(), PC_OFFSET(opt_plus, ci, cc), BIN(opt_send_without_block));
         CALL_SIMPLE_METHOD();
     }
 }
@@ -1066,6 +1076,7 @@ opt_minus
     val = vm_opt_minus(recv, obj);
 
     if (val == Qundef) {
+        vm_change_insn(GET_CFP(), PC_OFFSET(opt_minus, ci, cc), BIN(opt_send_without_block));
         CALL_SIMPLE_METHOD();
     }
 }
@@ -1080,6 +1091,7 @@ opt_mult
     val = vm_opt_mult(recv, obj);
 
     if (val == Qundef) {
+        vm_change_insn(GET_CFP(), PC_OFFSET(opt_mult, ci, cc), BIN(opt_send_without_block));
         CALL_SIMPLE_METHOD();
     }
 }
@@ -1094,6 +1106,7 @@ opt_div
     val = vm_opt_div(recv, obj);
 
     if (val == Qundef) {
+        vm_change_insn(GET_CFP(), PC_OFFSET(opt_div, ci, cc), BIN(opt_send_without_block));
         CALL_SIMPLE_METHOD();
     }
 }
@@ -1108,6 +1121,7 @@ opt_mod
     val = vm_opt_mod(recv, obj);
 
     if (val == Qundef) {
+        vm_change_insn(GET_CFP(), PC_OFFSET(opt_mod, ci, cc), BIN(opt_send_without_block));
         CALL_SIMPLE_METHOD();
     }
 }
@@ -1156,6 +1170,7 @@ opt_lt
     val = vm_opt_lt(recv, obj);
 
     if (val == Qundef) {
+        vm_change_insn(GET_CFP(), PC_OFFSET(opt_lt, ci, cc), BIN(opt_send_without_block));
         CALL_SIMPLE_METHOD();
     }
 }
@@ -1170,6 +1185,7 @@ opt_le
     val = vm_opt_le(recv, obj);
 
     if (val == Qundef) {
+        vm_change_insn(GET_CFP(), PC_OFFSET(opt_le, ci, cc), BIN(opt_send_without_block));
         CALL_SIMPLE_METHOD();
     }
 }
@@ -1184,6 +1200,7 @@ opt_gt
     val = vm_opt_gt(recv, obj);
 
     if (val == Qundef) {
+        vm_change_insn(GET_CFP(), PC_OFFSET(opt_gt, ci, cc), BIN(opt_send_without_block));
         CALL_SIMPLE_METHOD();
     }
 }
@@ -1198,6 +1215,7 @@ opt_ge
     val = vm_opt_ge(recv, obj);
 
     if (val == Qundef) {
+        vm_change_insn(GET_CFP(), PC_OFFSET(opt_ge, ci, cc), BIN(opt_send_without_block));
         CALL_SIMPLE_METHOD();
     }
 }
@@ -1212,6 +1230,7 @@ opt_ltlt
     val = vm_opt_ltlt(recv, obj);
 
     if (val == Qundef) {
+        vm_change_insn(GET_CFP(), PC_OFFSET(opt_ltlt, ci, cc), BIN(opt_send_without_block));
         CALL_SIMPLE_METHOD();
     }
 }
@@ -1226,6 +1245,7 @@ opt_and
     val = vm_opt_and(recv, obj);
 
     if (val == Qundef) {
+        vm_change_insn(GET_CFP(), PC_OFFSET(opt_and, ci, cc), BIN(opt_send_without_block));
         CALL_SIMPLE_METHOD();
     }
 }
@@ -1240,6 +1260,7 @@ opt_or
     val = vm_opt_or(recv, obj);
 
     if (val == Qundef) {
+        vm_change_insn(GET_CFP(), PC_OFFSET(opt_or, ci, cc), BIN(opt_send_without_block));
         CALL_SIMPLE_METHOD();
     }
 }
@@ -1360,6 +1381,7 @@ opt_empty_p
     val = vm_opt_empty_p(recv);
 
     if (val == Qundef) {
+        vm_change_insn(GET_CFP(), PC_OFFSET(opt_empty_p, ci, cc), BIN(opt_send_without_block));
         CALL_SIMPLE_METHOD();
     }
 }
@@ -1374,6 +1396,7 @@ opt_succ
     val = vm_opt_succ(recv);
 
     if (val == Qundef) {
+        vm_change_insn(GET_CFP(), PC_OFFSET(opt_succ, ci, cc), BIN(opt_send_without_block));
         CALL_SIMPLE_METHOD();
     }
 }

--- a/insns.def
+++ b/insns.def
@@ -770,7 +770,10 @@ opt_send_without_block
     if (LIKELY(INLINE_METHOD_CACHE_HIT(cc, klass))) {
         CALL_METHOD(&calling, ci, cc);
     }
-    else if ((val = vm_specialize_insn(GET_CFP(), PC_OFFSET(opt_send_without_block, ci, cc), ci)) == Qundef) {
+    else if ((val = vm_specialize_insn(GET_CFP(), PC_OFFSET(opt_send_without_block, ci, cc), ci)) != Qundef) {
+        INC_SP(INSN_ATTR(sp_inc) - 1 /* recv */);
+    }
+    else {
         rb_vm_search_method_slowpath(ci, cc, klass);
         CALL_METHOD(&calling, ci, cc);
     }

--- a/iseq.c
+++ b/iseq.c
@@ -2919,6 +2919,17 @@ rb_vm_insn_addr2insn(const void *addr)
     rb_bug("rb_vm_insn_addr2insn: invalid insn address: %p", addr);
 }
 
+void *
+rb_vm_insn_insn2addr(int insn, int trace_p)
+{
+    if (trace_p) {
+        return insn_data[insn].trace_encoded_insn;
+    }
+    else {
+        return insn_data[insn].notrace_encoded_insn;
+    }
+}
+
 static inline int
 encoded_iseq_trace_instrument(VALUE *iseq_encoded_insn, rb_event_flag_t turnon)
 {

--- a/iseq.c
+++ b/iseq.c
@@ -2919,14 +2919,14 @@ rb_vm_insn_addr2insn(const void *addr)
     rb_bug("rb_vm_insn_addr2insn: invalid insn address: %p", addr);
 }
 
-void *
+VALUE
 rb_vm_insn_insn2addr(int insn, int trace_p)
 {
     if (trace_p) {
-        return insn_data[insn].trace_encoded_insn;
+        return (VALUE)insn_data[insn].trace_encoded_insn;
     }
     else {
-        return insn_data[insn].notrace_encoded_insn;
+        return (VALUE)insn_data[insn].notrace_encoded_insn;
     }
 }
 

--- a/iseq.h
+++ b/iseq.h
@@ -182,6 +182,7 @@ VALUE rb_iseq_method_name(const rb_iseq_t *iseq);
 void rb_iseq_code_location(const rb_iseq_t *iseq, int *first_lineno, int *first_column, int *last_lineno, int *last_column);
 
 void rb_iseq_remove_coverage_all(void);
+void *rb_vm_insn_insn2addr(int insn, int trace_p);
 
 /* proc.c */
 const rb_iseq_t *rb_method_iseq(VALUE body);

--- a/iseq.h
+++ b/iseq.h
@@ -182,7 +182,7 @@ VALUE rb_iseq_method_name(const rb_iseq_t *iseq);
 void rb_iseq_code_location(const rb_iseq_t *iseq, int *first_lineno, int *first_column, int *last_lineno, int *last_column);
 
 void rb_iseq_remove_coverage_all(void);
-void *rb_vm_insn_insn2addr(int insn, int trace_p);
+VALUE rb_vm_insn_insn2addr(int insn, int trace_p);
 
 /* proc.c */
 const rb_iseq_t *rb_method_iseq(VALUE body);

--- a/mjit_compile.c
+++ b/mjit_compile.c
@@ -205,8 +205,12 @@ mjit_compile(FILE *f, const struct rb_iseq_constant_body *body, const char *func
     /* For performance, we verify stack size only on compilation time (mjit_compile.inc.erb) without --jit-debug */
     if (!mjit_opts.debug) {
         fprintf(f, "#undef OPT_CHECKED_RUN\n");
-        fprintf(f, "#define OPT_CHECKED_RUN 0\n\n");
+        fprintf(f, "#define OPT_CHECKED_RUN 0\n");
     }
+
+    /* Instruction change should be finished on VM */
+    fprintf(f, "#define vm_change_insn(cfp, pc_offset, insn)\n");
+    fprintf(f, "#define vm_specialize_insn(cfp, pc_offset, ci) Qundef\n\n");
 
 #ifdef _WIN32
     fprintf(f, "__declspec(dllexport)\n");

--- a/mjit_compile.c
+++ b/mjit_compile.c
@@ -210,7 +210,6 @@ mjit_compile(FILE *f, const struct rb_iseq_constant_body *body, const char *func
 
     /* Instruction change should be finished on VM */
     fprintf(f, "#define vm_change_insn(cfp, pc_offset, insn)\n");
-    fprintf(f, "#define vm_specialize_insn(cfp, pc_offset, ci) Qundef\n\n");
 
 #ifdef _WIN32
     fprintf(f, "__declspec(dllexport)\n");

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -3853,7 +3853,7 @@ vm_opt_regexpmatch2(VALUE recv, VALUE obj)
 static void
 vm_change_insn(rb_control_frame_t *cfp, int pc_offset, int insn)
 {
-    *((VALUE *)cfp->pc - pc_offset) = (VALUE)rb_vm_insn_insn2addr(insn, ruby_vm_event_enabled_flags & ISEQ_TRACE_EVENTS);
+    *((VALUE *)cfp->pc - pc_offset) = rb_vm_insn_insn2addr(insn, ruby_vm_event_enabled_flags & ISEQ_TRACE_EVENTS);
 }
 
 static VALUE

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -3863,7 +3863,6 @@ vm_specialize_insn(rb_control_frame_t *cfp, int pc_offset, const struct rb_call_
     recv = *(cfp->sp - 1); \
     if ((val = vm_opt_##opt(recv)) != Qundef) { \
         vm_change_insn(cfp, pc_offset, BIN(opt_##opt)); \
-        cfp->sp -= 1; \
         return val; \
     }
 #define SP_INSN1(opt) \
@@ -3871,7 +3870,6 @@ vm_specialize_insn(rb_control_frame_t *cfp, int pc_offset, const struct rb_call_
     obj = *(cfp->sp - 1); \
     if ((val = vm_opt_##opt(recv, obj)) != Qundef) { \
         vm_change_insn(cfp, pc_offset, BIN(opt_##opt)); \
-        cfp->sp -= 2; \
         return val; \
     }
 

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -3848,7 +3848,7 @@ vm_opt_regexpmatch2(VALUE recv, VALUE obj)
     }
 }
 
-#define PC_OFFSET(insn, ci, cc) leaf ? 0 : attr_width_##insn(ci, cc)
+#define PC_OFFSET(insn, ci, cc) leaf ? 0 : (int)attr_width_##insn(ci, cc)
 
 static void
 vm_change_insn(rb_control_frame_t *cfp, int pc_offset, int insn)


### PR DESCRIPTION
## Summary
For some simple opt_xxx insns,

* Dynamically change opt_send_without_block to opt_xxx when it can be optimized
* Dynamically change opt_xxx to opt_send_without_block when given classes can't be optimized

## Benchmark
### Micro benchmark
```yml
benchmark:
  - name: Integer+Integer
    prelude: a, b = 1, 2
    script: a + b
  - name: Integer+Float
    prelude: a, b = 1, 2.0
    script: a + b
  - name: Float+Float
    prelude: a, b = 1.0, 2.0
    script: a + b
  - name: Float+Integer
    prelude: a, b = 1.0, 2
    script: a + b
loop_count: 200000000
```

```
$ benchmark-driver benchmark.yml --rbenv 'before;after' --repeat-count 4 -v
before: ruby 2.6.0dev (2018-09-29 trunk 64883) [x86_64-linux]
after: ruby 2.6.0dev (2018-09-29 dynamic-opt-insn 64883) [x86_64-linux]
last_commit=insns.def: dynamically change optimized instructions
Calculating -------------------------------------
                         before       after
     Integer+Integer   177.459M    179.086M i/s -    200.000M times in 1.127018s 1.116782s
       Integer+Float    63.275M     70.256M i/s -    200.000M times in 3.160796s 2.846746s
         Float+Float   131.861M    140.073M i/s -    200.000M times in 1.516747s 1.427829s
       Float+Integer    65.284M     72.772M i/s -    200.000M times in 3.063536s 2.748319s

Comparison:
                  Integer+Integer
               after: 179086060.3 i/s
              before: 177459462.8 i/s - 1.01x  slower

                    Integer+Float
               after:  70255643.7 i/s
              before:  63275207.3 i/s - 1.11x  slower

                      Float+Float
               after: 140072791.0 i/s
              before: 131861107.5 i/s - 1.06x  slower

                    Float+Integer
               after:  72771766.9 i/s
              before:  65284029.4 i/s - 1.11x  slower

```

As expected, Integer+Integer and Float+Float are not changed so much, and Integer+Float and Float+Integer are made faster.

### Optcarrot

```
$ benchmark-driver benchmark.yml --rbenv 'before::before --disable-gems;before+JIT::before --disable-gems --jit;after::after --disable-gems;after+JIT::after --disable-gems --jit' -v --repeat-count 24
before: ruby 2.6.0dev (2018-09-29 trunk 64883) [x86_64-linux]
before+JIT: ruby 2.6.0dev (2018-09-29 trunk 64883) +JIT [x86_64-linux]
after: ruby 2.6.0dev (2018-09-29 dynamic-opt-insn 64883) [x86_64-linux]
last_commit=insns.def: dynamically change optimized instructions
after+JIT: ruby 2.6.0dev (2018-09-29 dynamic-opt-insn 64883) +JIT [x86_64-linux]
last_commit=insns.def: dynamically change optimized instructions
Calculating -------------------------------------
                             before  before+JIT       after   after+JIT
Optcarrot Lan_Master.nes     53.214      69.846      54.157      70.609 fps

Comparison:
             Optcarrot Lan_Master.nes
               after+JIT:        70.6 fps
              before+JIT:        69.8 fps - 1.01x  slower
                   after:        54.2 fps - 1.30x  slower
                  before:        53.2 fps - 1.33x  slower

```