### PR TITLE
support --with-arch=x86_64h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3687,7 +3687,7 @@ AS_IF([test "${universal_binary-no}" = yes ], [
 	for archs in ${universal_archnames}; do
 	    cpu=`echo $archs | sed 's/.*=//'`
 	    archs=`echo $archs | sed 's/=.*//'`
-	    RUBY_DEFINE_IF([defined __${archs}__], RUBY_PLATFORM_CPU, ["${cpu}"])
+	    RUBY_DEFINE_IF([defined __${archs}__ &&! defined RUBY_PLATFORM_CPU], RUBY_PLATFORM_CPU, ["${cpu}"])
 	done
     ])
     ints='long int short'

--- a/tool/m4/ruby_universal_arch.m4
+++ b/tool/m4/ruby_universal_arch.m4
@@ -14,11 +14,7 @@ AS_IF([test ${target_archs+set}], [
     for archs in $target_archs
     do
 	AS_CASE([",$universal_binary,"],[*",$archs,"*], [],[
-	    cpu=`$SHELL "$ac_aux_dir/config.sub" "${archs}-${target_os}" 2>&1` || {
-	        AC_MSG_RESULT([failed])
-		AC_MSG_ERROR([$cpu])
-	    }
-	    cpu=`echo $cpu | sed 's/-.*-.*//'`
+	    cpu=`echo $archs | sed 's/-.*-.*//'`
 	    universal_binary="${universal_binary+$universal_binary,}$cpu"
 	    universal_archnames="${universal_archnames} ${archs}=${cpu}"
 	    ARCH_FLAG="${ARCH_FLAG+$ARCH_FLAG }-arch $archs"


### PR DESCRIPTION
Recent apple machines describe themselves being x86_64h and that architecture is somehow supported by their c compiler and at least by recent clang.  However config.sub does not know that fact so making universal binary targeting it is rejected by the program.

Why not skip the check by config.sub.