### PR TITLE
Fix IO::foreach doc code not producing the desired result

### DIFF
--- a/io.c
+++ b/io.c
@@ -10288,7 +10288,7 @@ io_s_foreach(struct getline_arg *arg)
  *
  *  If no block is given, an enumerator is returned instead.
  *
- *     IO.foreach("testfile") {|x| print "GOT ", x }
+ *     IO.foreach("testfile") {|x| puts "GOT #{x}" }
  *
  *  <em>produces:</em>
  *


### PR DESCRIPTION
The code in the documentation wasn't producing the result shown in the example.