### PR TITLE
Move one line Contributing info to main README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,0 @@
-Please see the [official issue tracker] and wiki [HowToContribute].
-
-[official issue tracker]: https://bugs.ruby-lang.org
-[HowToContribute]: https://bugs.ruby-lang.org/projects/ruby/wiki/HowToContribute

--- a/README.md
+++ b/README.md
@@ -160,8 +160,10 @@ Bug reports should be filed at https://bugs.ruby-lang.org. Read [HowToReport] fo
 
 ## Contributing
 
-See the file [CONTRIBUTING.md](CONTRIBUTING.md)
+Please see the [official issue tracker] and wiki [HowToContribute].
 
+[official issue tracker]: https://bugs.ruby-lang.org
+[HowToContribute]: https://bugs.ruby-lang.org/projects/ruby/wiki/HowToContribute
 
 ## The Author
 


### PR DESCRIPTION
Clicking the current link basically takes you to one line of information. Makes it easier for people to click once rather than twice to get the contributing information.