### PR TITLE
Pathname: Have #relative_path_from accept String argument

### DIFF
--- a/ext/pathname/lib/pathname.rb
+++ b/ext/pathname/lib/pathname.rb
@@ -503,6 +503,7 @@ class Pathname
   # ArgumentError is raised when it cannot find a relative path.
   #
   def relative_path_from(base_directory)
+    base_directory = Pathname.new(base_directory) unless Pathname === base_directory
     dest_directory = self.cleanpath.to_s
     base_directory = base_directory.cleanpath.to_s
     dest_prefix = dest_directory

--- a/test/pathname/test_pathname.rb
+++ b/test/pathname/test_pathname.rb
@@ -291,9 +291,10 @@ class TestPathname < Test::Unit::TestCase
   end
 
   def relative_path_from(dest_directory, base_directory)
-    Pathname.new(dest_directory).relative_path_from(Pathname.new(base_directory)).to_s
+    Pathname.new(dest_directory).relative_path_from(base_directory).to_s
   end
 
+  defassert(:relative_path_from, "../a", Pathname.new("a"), "b")
   defassert(:relative_path_from, "../a", "a", "b")
   defassert(:relative_path_from, "../a", "a", "b/")
   defassert(:relative_path_from, "../a", "a/", "b")


### PR DESCRIPTION
Many instance methods of `Pathname` accept a path argument (`#+`, `#join`, `#rename`, `#make_symlink`, ...)

All these methods accept either a `String` or a `Pathname`. All but one exception `#relative_path_from` which requires a `Pathname`.

This PR makes it compatible with a `String`.

@akr: should I commit it, or do you prefer handling it?