### PR TITLE
Prefer require_relative

### DIFF
--- a/lib/cgi/cookie.rb
+++ b/lib/cgi/cookie.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'cgi/util'
+require_relative 'util'
 class CGI
   # Class representing an HTTP cookie.
   #

--- a/lib/cgi/core.rb
+++ b/lib/cgi/core.rb
@@ -862,24 +862,24 @@ class CGI
 
     case @options[:tag_maker]
     when "html3"
-      require 'cgi/html'
+      require_relative 'html'
       extend Html3
       extend HtmlExtension
     when "html4"
-      require 'cgi/html'
+      require_relative 'html'
       extend Html4
       extend HtmlExtension
     when "html4Tr"
-      require 'cgi/html'
+      require_relative 'html'
       extend Html4Tr
       extend HtmlExtension
     when "html4Fr"
-      require 'cgi/html'
+      require_relative 'html'
       extend Html4Tr
       extend Html4Fr
       extend HtmlExtension
     when "html5"
-      require 'cgi/html'
+      require_relative 'html'
       extend Html5
       extend HtmlExtension
     end

--- a/lib/cgi/session/pstore.rb
+++ b/lib/cgi/session/pstore.rb
@@ -10,7 +10,7 @@
 # persistent of session data on top of the pstore library.  See
 # cgi/session.rb for more details on session storage managers.
 
-require 'cgi/session'
+require_relative '../session'
 require 'pstore'
 
 class CGI

--- a/lib/cgi/util.rb
+++ b/lib/cgi/util.rb
@@ -55,7 +55,7 @@ module CGI::Util
   end
 
   begin
-    require 'cgi/escape'
+    require_relative 'escape'
   rescue LoadError
   end
 

--- a/lib/drb/drb.rb
+++ b/lib/drb/drb.rb
@@ -48,7 +48,7 @@
 
 require 'socket'
 require 'io/wait'
-require 'drb/eq'
+require_relative 'eq'
 
 #
 # == Overview
@@ -1638,7 +1638,7 @@ module DRb
 
     end
 
-    require 'drb/invokemethod'
+    require_relative 'invokemethod'
     class InvokeMethod
       include InvokeMethod18Mixin
     end

--- a/lib/drb/extserv.rb
+++ b/lib/drb/extserv.rb
@@ -4,7 +4,7 @@
         Copyright (c) 2000,2002 Masatoshi SEKI
 =end
 
-require 'drb/drb'
+require_relative 'drb'
 require 'monitor'
 
 module DRb

--- a/lib/drb/extservm.rb
+++ b/lib/drb/extservm.rb
@@ -4,7 +4,7 @@
         Copyright (c) 2000 Masatoshi SEKI
 =end
 
-require 'drb/drb'
+require_relative 'drb'
 require 'monitor'
 
 module DRb

--- a/lib/drb/gw.rb
+++ b/lib/drb/gw.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: false
-require 'drb/drb'
+require_relative 'drb'
 require 'monitor'
 
 module DRb
@@ -109,7 +109,7 @@ s2.thread.join
 =begin
 # foo.rb
 
-require 'drb/drb'
+require_relative 'drb'
 
 class Foo
   include DRbUndumped
@@ -127,7 +127,7 @@ end
 
 =begin
 # gw_a.rb
-require 'drb/unix'
+require_relative 'unix'
 require 'foo'
 
 obj = Foo.new('a')
@@ -141,7 +141,7 @@ DRb.thread.join
 
 =begin
 # gw_c.rb
-require 'drb/unix'
+require_relative 'unix'
 require 'foo'
 
 foo = Foo.new('c', nil)

--- a/lib/drb/ssl.rb
+++ b/lib/drb/ssl.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: false
 require 'socket'
 require 'openssl'
-require 'drb/drb'
+require_relative 'drb'
 require 'singleton'
 
 module DRb

--- a/lib/drb/timeridconv.rb
+++ b/lib/drb/timeridconv.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: false
-require 'drb/drb'
+require_relative 'drb'
 require 'monitor'
 
 module DRb

--- a/lib/drb/unix.rb
+++ b/lib/drb/unix.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: false
 require 'socket'
-require 'drb/drb'
+require_relative 'drb'
 require 'tmpdir'
 
 raise(LoadError, "UNIXServer is required") unless defined?(UNIXServer)

--- a/lib/irb/cmd/load.rb
+++ b/lib/irb/cmd/load.rb
@@ -11,7 +11,7 @@
 #
 
 require "irb/cmd/nop.rb"
-require "irb/ext/loader"
+require_relative "../ext/loader"
 
 # :stopdoc:
 module IRB

--- a/lib/irb/context.rb
+++ b/lib/irb/context.rb
@@ -9,8 +9,8 @@
 #
 #
 #
-require "irb/workspace"
-require "irb/inspector"
+require_relative "workspace"
+require_relative "inspector"
 require "irb/input-method"
 require "irb/output-method"
 

--- a/lib/irb/ext/use-loader.rb
+++ b/lib/irb/ext/use-loader.rb
@@ -10,8 +10,8 @@
 #
 #
 
-require "irb/cmd/load"
-require "irb/ext/loader"
+require_relative "../cmd/load"
+require_relative "loader"
 
 class Object
   alias __original__load__IRB_use_loader__ load

--- a/lib/irb/init.rb
+++ b/lib/irb/init.rb
@@ -197,7 +197,7 @@ module IRB # :nodoc:
         print IRB.version, "\n"
         exit 0
       when "-h", "--help"
-        require "irb/help"
+        require_relative "help"
         IRB.print_usage
         exit 0
       when "--"

--- a/lib/irb/input-method.rb
+++ b/lib/irb/input-method.rb
@@ -9,7 +9,7 @@
 #
 #
 #
-require 'irb/src_encoding'
+require_relative 'src_encoding'
 require 'irb/magic-file'
 
 module IRB

--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -11,7 +11,7 @@
 #
 
 require "e2mmap"
-require "irb/slex"
+require_relative "slex"
 require "irb/ruby-token"
 
 # :stopdoc:

--- a/lib/irb/slex.rb
+++ b/lib/irb/slex.rb
@@ -11,7 +11,7 @@
 #
 
 require "e2mmap"
-require "irb/notifier"
+require_relative "notifier"
 
 # :stopdoc:
 module IRB

--- a/lib/irb/xmp.rb
+++ b/lib/irb/xmp.rb
@@ -11,7 +11,7 @@
 #
 
 require "irb"
-require "irb/frame"
+require_relative "frame"
 
 # An example printer for irb.
 #

--- a/lib/net/ftp.rb
+++ b/lib/net/ftp.rb
@@ -17,7 +17,7 @@
 
 require "socket"
 require "monitor"
-require "net/protocol"
+require_relative "protocol"
 require "time"
 begin
   require "openssl"

--- a/lib/net/http/status.rb
+++ b/lib/net/http/status.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require 'net/http'
+require_relative '../http'
 
 if $0 == __FILE__
   require 'open-uri'

--- a/lib/net/https.rb
+++ b/lib/net/https.rb
@@ -4,7 +4,7 @@
 = net/https -- SSL/TLS enhancement for Net::HTTP.
 
   This file has been merged with net/http.  There is no longer any need to
-  require 'net/https' to use HTTPS.
+  require_relative 'https' to use HTTPS.
 
   See Net::HTTP for details on how to make HTTPS connections.
 
@@ -19,5 +19,5 @@
 
 =end
 
-require 'net/http'
+require_relative 'http'
 require 'openssl'

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -18,7 +18,7 @@ require "socket"
 require "monitor"
 require "digest/md5"
 require "strscan"
-require 'net/protocol'
+require_relative 'protocol'
 begin
   require "openssl"
 rescue LoadError

--- a/lib/net/pop.rb
+++ b/lib/net/pop.rb
@@ -21,7 +21,7 @@
 # See Net::POP3 for documentation.
 #
 
-require 'net/protocol'
+require_relative 'protocol'
 require 'digest/md5'
 require 'timeout'
 

--- a/lib/net/smtp.rb
+++ b/lib/net/smtp.rb
@@ -17,7 +17,7 @@
 # See Net::SMTP for documentation.
 #
 
-require 'net/protocol'
+require_relative 'protocol'
 require 'digest/md5'
 require 'timeout'
 begin

--- a/lib/racc/parser.rb
+++ b/lib/racc/parser.rb
@@ -187,7 +187,7 @@ module Racc
     Racc_Runtime_Core_Version_R = '1.4.6'
     Racc_Runtime_Core_Revision_R = %w$originalRevision: 1.8 $[1]
     begin
-      require 'racc/cparse'
+      require_relative 'cparse'
     # Racc_Runtime_Core_Version_C  = (defined in extension)
       Racc_Runtime_Core_Revision_C = Racc_Runtime_Core_Id_C.split[2]
       unless new.respond_to?(:_racc_do_parse_c, true)

--- a/lib/rexml/attlistdecl.rb
+++ b/lib/rexml/attlistdecl.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: false
 #vim:ts=2 sw=2 noexpandtab:
-require 'rexml/child'
-require 'rexml/source'
+require_relative 'child'
+require_relative 'source'
 
 module REXML
   # This class needs:

--- a/lib/rexml/attribute.rb
+++ b/lib/rexml/attribute.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: false
-require "rexml/namespace"
-require 'rexml/text'
+require_relative "namespace"
+require_relative 'text'
 
 module REXML
   # Defines an Element Attribute; IE, a attribute=value pair, as in:

--- a/lib/rexml/cdata.rb
+++ b/lib/rexml/cdata.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: false
-require "rexml/text"
+require_relative "text"
 
 module REXML
   class CData < Text

--- a/lib/rexml/child.rb
+++ b/lib/rexml/child.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: false
-require "rexml/node"
+require_relative "node"
 
 module REXML
   ##

--- a/lib/rexml/comment.rb
+++ b/lib/rexml/comment.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: false
-require "rexml/child"
+require_relative "child"
 
 module REXML
   ##

--- a/lib/rexml/doctype.rb
+++ b/lib/rexml/doctype.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: false
-require "rexml/parent"
-require "rexml/parseexception"
-require "rexml/namespace"
-require 'rexml/entity'
-require 'rexml/attlistdecl'
-require 'rexml/xmltokens'
+require_relative "parent"
+require_relative "parseexception"
+require_relative "namespace"
+require_relative 'entity'
+require_relative 'attlistdecl'
+require_relative 'xmltokens'
 
 module REXML
   # Represents an XML DOCTYPE declaration; that is, the contents of <!DOCTYPE

--- a/lib/rexml/document.rb
+++ b/lib/rexml/document.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: false
-require "rexml/security"
-require "rexml/element"
-require "rexml/xmldecl"
-require "rexml/source"
-require "rexml/comment"
-require "rexml/doctype"
-require "rexml/instruction"
-require "rexml/rexml"
-require "rexml/parseexception"
-require "rexml/output"
-require "rexml/parsers/baseparser"
-require "rexml/parsers/streamparser"
-require "rexml/parsers/treeparser"
+require_relative "security"
+require_relative "element"
+require_relative "xmldecl"
+require_relative "source"
+require_relative "comment"
+require_relative "doctype"
+require_relative "instruction"
+require_relative "rexml"
+require_relative "parseexception"
+require_relative "output"
+require_relative "parsers/baseparser"
+require_relative "parsers/streamparser"
+require_relative "parsers/treeparser"
 
 module REXML
   # Represents a full XML document, including PIs, a doctype, etc.  A
@@ -226,7 +226,7 @@ module REXML
       end
       formatter = if indent > -1
           if transitive
-            require "rexml/formatters/transitive"
+            require_relative "formatters/transitive"
             REXML::Formatters::Transitive.new( indent, ie_hack )
           else
             REXML::Formatters::Pretty.new( indent, ie_hack )

--- a/lib/rexml/dtd/attlistdecl.rb
+++ b/lib/rexml/dtd/attlistdecl.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: false
-require "rexml/child"
+require_relative "../child"
 module REXML
   module DTD
     class AttlistDecl < Child

--- a/lib/rexml/dtd/dtd.rb
+++ b/lib/rexml/dtd/dtd.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: false
-require "rexml/dtd/elementdecl"
-require "rexml/dtd/entitydecl"
-require "rexml/comment"
-require "rexml/dtd/notationdecl"
-require "rexml/dtd/attlistdecl"
-require "rexml/parent"
+require_relative "elementdecl"
+require_relative "entitydecl"
+require_relative "../comment"
+require_relative "notationdecl"
+require_relative "attlistdecl"
+require_relative "../parent"
 
 module REXML
   module DTD

--- a/lib/rexml/dtd/elementdecl.rb
+++ b/lib/rexml/dtd/elementdecl.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: false
-require "rexml/child"
+require_relative "../child"
 module REXML
   module DTD
     class ElementDecl < Child

--- a/lib/rexml/dtd/entitydecl.rb
+++ b/lib/rexml/dtd/entitydecl.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: false
-require "rexml/child"
+require_relative "../child"
 module REXML
   module DTD
     class EntityDecl < Child

--- a/lib/rexml/dtd/notationdecl.rb
+++ b/lib/rexml/dtd/notationdecl.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: false
-require "rexml/child"
+require_relative "../child"
 module REXML
   module DTD
     class NotationDecl < Child

--- a/lib/rexml/element.rb
+++ b/lib/rexml/element.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: false
-require "rexml/parent"
-require "rexml/namespace"
-require "rexml/attribute"
-require "rexml/cdata"
-require "rexml/xpath"
-require "rexml/parseexception"
+require_relative "parent"
+require_relative "namespace"
+require_relative "attribute"
+require_relative "cdata"
+require_relative "xpath"
+require_relative "parseexception"
 
 module REXML
   # An implementation note about namespaces:
@@ -713,7 +713,7 @@ module REXML
       Kernel.warn("#{self.class.name}.write is deprecated.  See REXML::Formatters", uplevel: 1)
       formatter = if indent > -1
           if transitive
-            require "rexml/formatters/transitive"
+            require_relative "formatters/transitive"
             REXML::Formatters::Transitive.new( indent, ie_hack )
           else
             REXML::Formatters::Pretty.new( indent, ie_hack )

--- a/lib/rexml/entity.rb
+++ b/lib/rexml/entity.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: false
-require 'rexml/child'
-require 'rexml/source'
-require 'rexml/xmltokens'
+require_relative 'child'
+require_relative 'source'
+require_relative 'xmltokens'
 
 module REXML
   class Entity < Child

--- a/lib/rexml/formatters/pretty.rb
+++ b/lib/rexml/formatters/pretty.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: false
-require 'rexml/formatters/default'
+require_relative 'default'
 
 module REXML
   module Formatters

--- a/lib/rexml/formatters/transitive.rb
+++ b/lib/rexml/formatters/transitive.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: false
-require 'rexml/formatters/pretty'
+require_relative 'pretty'
 
 module REXML
   module Formatters

--- a/lib/rexml/instruction.rb
+++ b/lib/rexml/instruction.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: false
-require "rexml/child"
-require "rexml/source"
+require_relative "child"
+require_relative "source"
 
 module REXML
   # Represents an XML Instruction; IE, <? ... ?>

--- a/lib/rexml/light/node.rb
+++ b/lib/rexml/light/node.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: false
-require 'rexml/xmltokens'
+require_relative '../xmltokens'
 
 # [ :element, parent, name, attributes, children* ]
   # a = Node.new

--- a/lib/rexml/namespace.rb
+++ b/lib/rexml/namespace.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: false
-require 'rexml/xmltokens'
+require_relative 'xmltokens'
 
 module REXML
   # Adds named attributes to an object.

--- a/lib/rexml/node.rb
+++ b/lib/rexml/node.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: false
-require "rexml/parseexception"
-require "rexml/formatters/pretty"
-require "rexml/formatters/default"
+require_relative "parseexception"
+require_relative "formatters/pretty"
+require_relative "formatters/default"
 
 module REXML
   # Represents a node in the tree.  Nodes are never encountered except as

--- a/lib/rexml/output.rb
+++ b/lib/rexml/output.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: false
-require 'rexml/encoding'
+require_relative 'encoding'
 
 module REXML
   class Output

--- a/lib/rexml/parent.rb
+++ b/lib/rexml/parent.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: false
-require "rexml/child"
+require_relative "child"
 
 module REXML
   # A parent has children, and has methods for accessing them.  The Parent

--- a/lib/rexml/parsers/baseparser.rb
+++ b/lib/rexml/parsers/baseparser.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: false
-require 'rexml/parseexception'
-require 'rexml/undefinednamespaceexception'
-require 'rexml/source'
+require_relative '../parseexception'
+require_relative '../undefinednamespaceexception'
+require_relative '../source'
 require 'set'
 
 module REXML

--- a/lib/rexml/parsers/lightparser.rb
+++ b/lib/rexml/parsers/lightparser.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: false
-require 'rexml/parsers/streamparser'
-require 'rexml/parsers/baseparser'
-require 'rexml/light/node'
+require_relative 'streamparser'
+require_relative 'baseparser'
+require_relative '../light/node'
 
 module REXML
   module Parsers

--- a/lib/rexml/parsers/pullparser.rb
+++ b/lib/rexml/parsers/pullparser.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: false
 require 'forwardable'
 
-require 'rexml/parseexception'
-require 'rexml/parsers/baseparser'
-require 'rexml/xmltokens'
+require_relative '../parseexception'
+require_relative 'baseparser'
+require_relative '../xmltokens'
 
 module REXML
   module Parsers

--- a/lib/rexml/parsers/sax2parser.rb
+++ b/lib/rexml/parsers/sax2parser.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: false
-require 'rexml/parsers/baseparser'
-require 'rexml/parseexception'
-require 'rexml/namespace'
-require 'rexml/text'
+require_relative 'baseparser'
+require_relative '../parseexception'
+require_relative '../namespace'
+require_relative '../text'
 
 module REXML
   module Parsers

--- a/lib/rexml/parsers/streamparser.rb
+++ b/lib/rexml/parsers/streamparser.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: false
-require "rexml/parsers/baseparser"
+require_relative "baseparser"
 
 module REXML
   module Parsers

--- a/lib/rexml/parsers/treeparser.rb
+++ b/lib/rexml/parsers/treeparser.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: false
-require 'rexml/validation/validationexception'
-require 'rexml/undefinednamespaceexception'
+require_relative '../validation/validationexception'
+require_relative '../undefinednamespaceexception'
 
 module REXML
   module Parsers

--- a/lib/rexml/parsers/ultralightparser.rb
+++ b/lib/rexml/parsers/ultralightparser.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: false
-require 'rexml/parsers/streamparser'
-require 'rexml/parsers/baseparser'
+require_relative 'streamparser'
+require_relative 'baseparser'
 
 module REXML
   module Parsers

--- a/lib/rexml/parsers/xpathparser.rb
+++ b/lib/rexml/parsers/xpathparser.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: false
-require 'rexml/namespace'
-require 'rexml/xmltokens'
+require_relative '../namespace'
+require_relative '../xmltokens'
 
 module REXML
   module Parsers

--- a/lib/rexml/quickpath.rb
+++ b/lib/rexml/quickpath.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: false
-require 'rexml/functions'
-require 'rexml/xmltokens'
+require_relative 'functions'
+require_relative 'xmltokens'
 
 module REXML
   class QuickPath

--- a/lib/rexml/source.rb
+++ b/lib/rexml/source.rb
@@ -1,6 +1,6 @@
 # coding: US-ASCII
 # frozen_string_literal: false
-require 'rexml/encoding'
+require_relative 'encoding'
 
 module REXML
   # Generates Source-s.  USE THIS CLASS.

--- a/lib/rexml/text.rb
+++ b/lib/rexml/text.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: false
-require 'rexml/security'
-require 'rexml/entity'
-require 'rexml/doctype'
-require 'rexml/child'
-require 'rexml/doctype'
-require 'rexml/parseexception'
+require_relative 'security'
+require_relative 'entity'
+require_relative 'doctype'
+require_relative 'child'
+require_relative 'doctype'
+require_relative 'parseexception'
 
 module REXML
   # Represents text nodes in an XML document

--- a/lib/rexml/undefinednamespaceexception.rb
+++ b/lib/rexml/undefinednamespaceexception.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: false
-require 'rexml/parseexception'
+require_relative 'parseexception'
 module REXML
   class UndefinedNamespaceException < ParseException
     def initialize( prefix, source, parser )

--- a/lib/rexml/validation/relaxng.rb
+++ b/lib/rexml/validation/relaxng.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: false
-require "rexml/validation/validation"
-require "rexml/parsers/baseparser"
+require_relative "validation"
+require_relative "../parsers/baseparser"
 
 module REXML
   module Validation

--- a/lib/rexml/validation/validation.rb
+++ b/lib/rexml/validation/validation.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: false
-require 'rexml/validation/validationexception'
+require_relative 'validationexception'
 
 module REXML
   module Validation

--- a/lib/rexml/xmldecl.rb
+++ b/lib/rexml/xmldecl.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: false
-require 'rexml/encoding'
-require 'rexml/source'
+require_relative 'encoding'
+require_relative 'source'
 
 module REXML
   # NEEDS DOCUMENTATION

--- a/lib/rexml/xpath.rb
+++ b/lib/rexml/xpath.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: false
-require 'rexml/functions'
-require 'rexml/xpath_parser'
+require_relative 'functions'
+require_relative 'xpath_parser'
 
 module REXML
   # Wrapper class.  Use this class to access the XPath functions.

--- a/lib/rexml/xpath_parser.rb
+++ b/lib/rexml/xpath_parser.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: false
-require 'rexml/namespace'
-require 'rexml/xmltokens'
-require 'rexml/attribute'
-require 'rexml/syncenumerator'
-require 'rexml/parsers/xpathparser'
+require_relative 'namespace'
+require_relative 'xmltokens'
+require_relative 'attribute'
+require_relative 'syncenumerator'
+require_relative 'parsers/xpathparser'
 
 class Object
   # provides a unified +clone+ operation, for REXML::XPathParser

--- a/lib/rinda/ring.rb
+++ b/lib/rinda/ring.rb
@@ -3,7 +3,7 @@
 # Note: Rinda::Ring API is unstable.
 #
 require 'drb/drb'
-require 'rinda/rinda'
+require_relative 'rinda'
 require 'ipaddr'
 
 module Rinda

--- a/lib/rinda/tuplespace.rb
+++ b/lib/rinda/tuplespace.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: false
 require 'monitor'
 require 'drb/drb'
-require 'rinda/rinda'
+require_relative 'rinda'
 require 'forwardable'
 
 module Rinda

--- a/lib/rss/0.9.rb
+++ b/lib/rss/0.9.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: false
-require "rss/parser"
+require_relative "parser"
 
 module RSS
 

--- a/lib/rss/1.0.rb
+++ b/lib/rss/1.0.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: false
-require "rss/parser"
+require_relative "parser"
 
 module RSS
 

--- a/lib/rss/atom.rb
+++ b/lib/rss/atom.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: false
-require 'rss/parser'
+require_relative 'parser'
 
 module RSS
   ##

--- a/lib/rss/content.rb
+++ b/lib/rss/content.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: false
-require "rss/rss"
+require_relative "rss"
 
 module RSS
   # The prefix for the Content XML namespace.

--- a/lib/rss/converter.rb
+++ b/lib/rss/converter.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: false
-require "rss/utils"
+require_relative "utils"
 
 module RSS
 

--- a/lib/rss/dublincore.rb
+++ b/lib/rss/dublincore.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: false
-require "rss/rss"
+require_relative "rss"
 
 module RSS
   # The prefix for the Dublin Core XML namespace.
@@ -161,4 +161,4 @@ end
 
 require 'rss/dublincore/1.0'
 require 'rss/dublincore/2.0'
-require 'rss/dublincore/atom'
+require_relative 'dublincore/atom'

--- a/lib/rss/dublincore/atom.rb
+++ b/lib/rss/dublincore/atom.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: false
-require "rss/atom"
+require_relative "../atom"
 
 module RSS
   module Atom

--- a/lib/rss/image.rb
+++ b/lib/rss/image.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: false
 require 'rss/1.0'
-require 'rss/dublincore'
+require_relative 'dublincore'
 
 module RSS
 

--- a/lib/rss/maker.rb
+++ b/lib/rss/maker.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: false
-require "rss/rss"
+require_relative "rss"
 
 module RSS
   ##
@@ -67,13 +67,13 @@ end
 
 require "rss/maker/1.0"
 require "rss/maker/2.0"
-require "rss/maker/feed"
-require "rss/maker/entry"
-require "rss/maker/content"
-require "rss/maker/dublincore"
-require "rss/maker/slash"
-require "rss/maker/syndication"
-require "rss/maker/taxonomy"
-require "rss/maker/trackback"
-require "rss/maker/image"
-require "rss/maker/itunes"
+require_relative "maker/feed"
+require_relative "maker/entry"
+require_relative "maker/content"
+require_relative "maker/dublincore"
+require_relative "maker/slash"
+require_relative "maker/syndication"
+require_relative "maker/taxonomy"
+require_relative "maker/trackback"
+require_relative "maker/image"
+require_relative "maker/itunes"

--- a/lib/rss/maker/0.9.rb
+++ b/lib/rss/maker/0.9.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: false
 require "rss/0.9"
 
-require "rss/maker/base"
+require_relative "base"
 
 module RSS
   module Maker

--- a/lib/rss/maker/1.0.rb
+++ b/lib/rss/maker/1.0.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: false
 require "rss/1.0"
 
-require "rss/maker/base"
+require_relative "base"
 
 module RSS
   module Maker

--- a/lib/rss/maker/atom.rb
+++ b/lib/rss/maker/atom.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: false
-require "rss/atom"
+require_relative "../atom"
 
-require "rss/maker/base"
+require_relative "base"
 
 module RSS
   module Maker

--- a/lib/rss/maker/base.rb
+++ b/lib/rss/maker/base.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: false
 require 'forwardable'
 
-require 'rss/rss'
+require_relative '../rss'
 
 module RSS
   module Maker

--- a/lib/rss/maker/content.rb
+++ b/lib/rss/maker/content.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: false
-require 'rss/content'
+require_relative '../content'
 require 'rss/maker/1.0'
 require 'rss/maker/2.0'
 

--- a/lib/rss/maker/dublincore.rb
+++ b/lib/rss/maker/dublincore.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: false
-require 'rss/dublincore'
+require_relative '../dublincore'
 require 'rss/maker/1.0'
 
 module RSS

--- a/lib/rss/maker/entry.rb
+++ b/lib/rss/maker/entry.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: false
-require "rss/maker/atom"
-require "rss/maker/feed"
+require_relative "atom"
+require_relative "feed"
 
 module RSS
   module Maker

--- a/lib/rss/maker/feed.rb
+++ b/lib/rss/maker/feed.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: false
-require "rss/maker/atom"
+require_relative "atom"
 
 module RSS
   module Maker

--- a/lib/rss/maker/image.rb
+++ b/lib/rss/maker/image.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: false
-require 'rss/image'
+require_relative '../image'
 require 'rss/maker/1.0'
-require 'rss/maker/dublincore'
+require_relative 'dublincore'
 
 module RSS
   module Maker

--- a/lib/rss/maker/itunes.rb
+++ b/lib/rss/maker/itunes.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: false
-require 'rss/itunes'
+require_relative '../itunes'
 require 'rss/maker/2.0'
 
 module RSS

--- a/lib/rss/maker/slash.rb
+++ b/lib/rss/maker/slash.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: false
-require 'rss/slash'
+require_relative '../slash'
 require 'rss/maker/1.0'
 
 module RSS

--- a/lib/rss/maker/syndication.rb
+++ b/lib/rss/maker/syndication.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: false
-require 'rss/syndication'
+require_relative '../syndication'
 require 'rss/maker/1.0'
 
 module RSS

--- a/lib/rss/maker/taxonomy.rb
+++ b/lib/rss/maker/taxonomy.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: false
-require 'rss/taxonomy'
+require_relative '../taxonomy'
 require 'rss/maker/1.0'
-require 'rss/maker/dublincore'
+require_relative 'dublincore'
 
 module RSS
   module Maker

--- a/lib/rss/maker/trackback.rb
+++ b/lib/rss/maker/trackback.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: false
-require 'rss/trackback'
+require_relative '../trackback'
 require 'rss/maker/1.0'
 require 'rss/maker/2.0'
 

--- a/lib/rss/parser.rb
+++ b/lib/rss/parser.rb
@@ -2,8 +2,8 @@
 require "forwardable"
 require "open-uri"
 
-require "rss/rss"
-require "rss/xml"
+require_relative "rss"
+require_relative "xml"
 
 module RSS
 

--- a/lib/rss/rss.rb
+++ b/lib/rss/rss.rb
@@ -63,8 +63,8 @@ end
 
 
 require "English"
-require "rss/utils"
-require "rss/converter"
+require_relative "utils"
+require_relative "converter"
 require "rss/xml-stylesheet"
 
 module RSS

--- a/lib/rss/taxonomy.rb
+++ b/lib/rss/taxonomy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: false
 require "rss/1.0"
-require "rss/dublincore"
+require_relative "dublincore"
 
 module RSS
   # The prefix for the Taxonomy XML namespace.

--- a/lib/rss/xml-stylesheet.rb
+++ b/lib/rss/xml-stylesheet.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: false
-require "rss/utils"
+require_relative "utils"
 
 module RSS
 

--- a/lib/rss/xml.rb
+++ b/lib/rss/xml.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: false
-require "rss/utils"
+require_relative "utils"
 
 module RSS
   module XML

--- a/lib/shell/builtin-command.rb
+++ b/lib/shell/builtin-command.rb
@@ -10,7 +10,7 @@
 #
 #
 
-require "shell/filter"
+require_relative "filter"
 
 class Shell
   class BuiltInCommand < Filter

--- a/lib/shell/command-processor.rb
+++ b/lib/shell/command-processor.rb
@@ -12,8 +12,8 @@
 
 require "e2mmap"
 
-require "shell/error"
-require "shell/filter"
+require_relative "error"
+require_relative "filter"
 require "shell/system-command"
 require "shell/builtin-command"
 

--- a/lib/shell/system-command.rb
+++ b/lib/shell/system-command.rb
@@ -10,7 +10,7 @@
 #
 #
 
-require "shell/filter"
+require_relative "filter"
 
 class Shell
   class SystemCommand < Filter

--- a/lib/uri/common.rb
+++ b/lib/uri/common.rb
@@ -10,8 +10,8 @@
 # See URI for general documentation
 #
 
-require "uri/rfc2396_parser"
-require "uri/rfc3986_parser"
+require_relative "rfc2396_parser"
+require_relative "rfc3986_parser"
 
 module URI
   REGEXP = RFC2396_REGEXP

--- a/lib/uri/file.rb
+++ b/lib/uri/file.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'uri/generic'
+require_relative 'generic'
 
 module URI
 

--- a/lib/uri/ftp.rb
+++ b/lib/uri/ftp.rb
@@ -8,7 +8,7 @@
 # See URI for general documentation
 #
 
-require 'uri/generic'
+require_relative 'generic'
 
 module URI
 

--- a/lib/uri/generic.rb
+++ b/lib/uri/generic.rb
@@ -9,7 +9,7 @@
 # See URI for general documentation
 #
 
-require 'uri/common'
+require_relative 'common'
 autoload :IPSocket, 'socket'
 autoload :IPAddr, 'ipaddr'
 

--- a/lib/uri/http.rb
+++ b/lib/uri/http.rb
@@ -8,7 +8,7 @@
 # See URI for general documentation
 #
 
-require 'uri/generic'
+require_relative 'generic'
 
 module URI
 

--- a/lib/uri/https.rb
+++ b/lib/uri/https.rb
@@ -8,7 +8,7 @@
 # See URI for general documentation
 #
 
-require 'uri/http'
+require_relative 'http'
 
 module URI
 

--- a/lib/uri/ldap.rb
+++ b/lib/uri/ldap.rb
@@ -12,7 +12,7 @@
 # See URI for general documentation
 #
 
-require 'uri/generic'
+require_relative 'generic'
 
 module URI
 

--- a/lib/uri/ldaps.rb
+++ b/lib/uri/ldaps.rb
@@ -6,7 +6,7 @@
 # See URI for general documentation
 #
 
-require 'uri/ldap'
+require_relative 'ldap'
 
 module URI
 

--- a/lib/uri/mailto.rb
+++ b/lib/uri/mailto.rb
@@ -8,7 +8,7 @@
 # See URI for general documentation
 #
 
-require 'uri/generic'
+require_relative 'generic'
 
 module URI
 

--- a/lib/webrick/cgi.rb
+++ b/lib/webrick/cgi.rb
@@ -8,9 +8,9 @@
 #
 # $Id$
 
-require "webrick/httprequest"
-require "webrick/httpresponse"
-require "webrick/config"
+require_relative "httprequest"
+require_relative "httpresponse"
+require_relative "config"
 require "stringio"
 
 module WEBrick

--- a/lib/webrick/config.rb
+++ b/lib/webrick/config.rb
@@ -9,11 +9,11 @@
 #
 # $IPR: config.rb,v 1.52 2003/07/22 19:20:42 gotoyuzo Exp $
 
-require 'webrick/version'
-require 'webrick/httpversion'
-require 'webrick/httputils'
-require 'webrick/utils'
-require 'webrick/log'
+require_relative 'version'
+require_relative 'httpversion'
+require_relative 'httputils'
+require_relative 'utils'
+require_relative 'log'
 
 module WEBrick
   module Config

--- a/lib/webrick/cookie.rb
+++ b/lib/webrick/cookie.rb
@@ -10,7 +10,7 @@
 # $IPR: cookie.rb,v 1.16 2002/09/21 12:23:35 gotoyuzo Exp $
 
 require 'time'
-require 'webrick/httputils'
+require_relative 'httputils'
 
 module WEBrick
 

--- a/lib/webrick/httpauth.rb
+++ b/lib/webrick/httpauth.rb
@@ -9,11 +9,11 @@
 #
 # $IPR: httpauth.rb,v 1.14 2003/07/22 19:20:42 gotoyuzo Exp $
 
-require 'webrick/httpauth/basicauth'
-require 'webrick/httpauth/digestauth'
-require 'webrick/httpauth/htpasswd'
-require 'webrick/httpauth/htdigest'
-require 'webrick/httpauth/htgroup'
+require_relative 'httpauth/basicauth'
+require_relative 'httpauth/digestauth'
+require_relative 'httpauth/htpasswd'
+require_relative 'httpauth/htdigest'
+require_relative 'httpauth/htgroup'
 
 module WEBrick
 

--- a/lib/webrick/httpauth/basicauth.rb
+++ b/lib/webrick/httpauth/basicauth.rb
@@ -8,9 +8,9 @@
 #
 # $IPR: basicauth.rb,v 1.5 2003/02/20 07:15:47 gotoyuzo Exp $
 
-require 'webrick/config'
-require 'webrick/httpstatus'
-require 'webrick/httpauth/authenticator'
+require_relative '../config'
+require_relative '../httpstatus'
+require_relative 'authenticator'
 
 module WEBrick
   module HTTPAuth

--- a/lib/webrick/httpauth/digestauth.rb
+++ b/lib/webrick/httpauth/digestauth.rb
@@ -12,9 +12,9 @@
 #
 # $IPR: digestauth.rb,v 1.5 2003/02/20 07:15:47 gotoyuzo Exp $
 
-require 'webrick/config'
-require 'webrick/httpstatus'
-require 'webrick/httpauth/authenticator'
+require_relative '../config'
+require_relative '../httpstatus'
+require_relative 'authenticator'
 require 'digest/md5'
 require 'digest/sha1'
 

--- a/lib/webrick/httpauth/htdigest.rb
+++ b/lib/webrick/httpauth/htdigest.rb
@@ -8,8 +8,8 @@
 #
 # $IPR: htdigest.rb,v 1.4 2003/07/22 19:20:45 gotoyuzo Exp $
 
-require 'webrick/httpauth/userdb'
-require 'webrick/httpauth/digestauth'
+require_relative 'userdb'
+require_relative 'digestauth'
 require 'tempfile'
 
 module WEBrick

--- a/lib/webrick/httpauth/htpasswd.rb
+++ b/lib/webrick/httpauth/htpasswd.rb
@@ -8,8 +8,8 @@
 #
 # $IPR: htpasswd.rb,v 1.4 2003/07/22 19:20:45 gotoyuzo Exp $
 
-require 'webrick/httpauth/userdb'
-require 'webrick/httpauth/basicauth'
+require_relative 'userdb'
+require_relative 'basicauth'
 require 'tempfile'
 
 module WEBrick

--- a/lib/webrick/httpproxy.rb
+++ b/lib/webrick/httpproxy.rb
@@ -10,7 +10,7 @@
 # $IPR: httpproxy.rb,v 1.18 2003/03/08 18:58:10 gotoyuzo Exp $
 # $kNotwork: straw.rb,v 1.3 2002/02/12 15:13:07 gotoken Exp $
 
-require "webrick/httpserver"
+require_relative "httpserver"
 require "net/http"
 
 module WEBrick

--- a/lib/webrick/httprequest.rb
+++ b/lib/webrick/httprequest.rb
@@ -10,10 +10,10 @@
 # $IPR: httprequest.rb,v 1.64 2003/07/13 17:18:22 gotoyuzo Exp $
 
 require 'uri'
-require 'webrick/httpversion'
-require 'webrick/httpstatus'
-require 'webrick/httputils'
-require 'webrick/cookie'
+require_relative 'httpversion'
+require_relative 'httpstatus'
+require_relative 'httputils'
+require_relative 'cookie'
 
 module WEBrick
 

--- a/lib/webrick/httpresponse.rb
+++ b/lib/webrick/httpresponse.rb
@@ -11,10 +11,10 @@
 
 require 'time'
 require 'uri'
-require 'webrick/httpversion'
-require 'webrick/htmlutils'
-require 'webrick/httputils'
-require 'webrick/httpstatus'
+require_relative 'httpversion'
+require_relative 'htmlutils'
+require_relative 'httputils'
+require_relative 'httpstatus'
 
 module WEBrick
   ##

--- a/lib/webrick/https.rb
+++ b/lib/webrick/https.rb
@@ -9,8 +9,8 @@
 #
 # $IPR: https.rb,v 1.15 2003/07/22 19:20:42 gotoyuzo Exp $
 
-require 'webrick/ssl'
-require 'webrick/httpserver'
+require_relative 'ssl'
+require_relative 'httpserver'
 
 module WEBrick
   module Config

--- a/lib/webrick/httpserver.rb
+++ b/lib/webrick/httpserver.rb
@@ -10,13 +10,13 @@
 # $IPR: httpserver.rb,v 1.63 2002/10/01 17:16:32 gotoyuzo Exp $
 
 require 'io/wait'
-require 'webrick/server'
-require 'webrick/httputils'
-require 'webrick/httpstatus'
-require 'webrick/httprequest'
-require 'webrick/httpresponse'
-require 'webrick/httpservlet'
-require 'webrick/accesslog'
+require_relative 'server'
+require_relative 'httputils'
+require_relative 'httpstatus'
+require_relative 'httprequest'
+require_relative 'httpresponse'
+require_relative 'httpservlet'
+require_relative 'accesslog'
 
 module WEBrick
   class HTTPServerError < ServerError; end

--- a/lib/webrick/httpservlet.rb
+++ b/lib/webrick/httpservlet.rb
@@ -9,11 +9,11 @@
 #
 # $IPR: httpservlet.rb,v 1.21 2003/02/23 12:24:46 gotoyuzo Exp $
 
-require 'webrick/httpservlet/abstract'
-require 'webrick/httpservlet/filehandler'
-require 'webrick/httpservlet/cgihandler'
-require 'webrick/httpservlet/erbhandler'
-require 'webrick/httpservlet/prochandler'
+require_relative 'httpservlet/abstract'
+require_relative 'httpservlet/filehandler'
+require_relative 'httpservlet/cgihandler'
+require_relative 'httpservlet/erbhandler'
+require_relative 'httpservlet/prochandler'
 
 module WEBrick
   module HTTPServlet

--- a/lib/webrick/httpservlet/abstract.rb
+++ b/lib/webrick/httpservlet/abstract.rb
@@ -9,9 +9,9 @@
 #
 # $IPR: abstract.rb,v 1.24 2003/07/11 11:16:46 gotoyuzo Exp $
 
-require 'webrick/htmlutils'
-require 'webrick/httputils'
-require 'webrick/httpstatus'
+require_relative '../htmlutils'
+require_relative '../httputils'
+require_relative '../httpstatus'
 
 module WEBrick
   module HTTPServlet

--- a/lib/webrick/httpservlet/cgihandler.rb
+++ b/lib/webrick/httpservlet/cgihandler.rb
@@ -11,8 +11,8 @@
 
 require 'rbconfig'
 require 'tempfile'
-require 'webrick/config'
-require 'webrick/httpservlet/abstract'
+require_relative '../config'
+require_relative 'abstract'
 
 module WEBrick
   module HTTPServlet

--- a/lib/webrick/httpservlet/filehandler.rb
+++ b/lib/webrick/httpservlet/filehandler.rb
@@ -11,9 +11,9 @@
 
 require 'time'
 
-require 'webrick/htmlutils'
-require 'webrick/httputils'
-require 'webrick/httpstatus'
+require_relative '../htmlutils'
+require_relative '../httputils'
+require_relative '../httpstatus'
 
 module WEBrick
   module HTTPServlet

--- a/lib/webrick/httpstatus.rb
+++ b/lib/webrick/httpstatus.rb
@@ -9,7 +9,7 @@
 #
 # $IPR: httpstatus.rb,v 1.11 2003/03/24 20:18:55 gotoyuzo Exp $
 
-require 'webrick/accesslog'
+require_relative 'accesslog'
 
 module WEBrick
 

--- a/lib/webrick/server.rb
+++ b/lib/webrick/server.rb
@@ -10,8 +10,8 @@
 # $IPR: server.rb,v 1.62 2003/07/22 19:20:43 gotoyuzo Exp $
 
 require 'socket'
-require 'webrick/config'
-require 'webrick/log'
+require_relative 'config'
+require_relative 'log'
 
 module WEBrick
 


### PR DESCRIPTION
I wrote a small script to replace some calls to `require` with `require_relative`, as a small but free speed bump.

Special cases:
`rdoc`: I created a PR separately
`rubygems`: can't be updated yet as it may be gem installed from Ruby 2.2 to 2.4, which have [a potential issue](https://github.com/rubygems/rubygems/pull/2425#issuecomment-427535667) with `require_relative` and symlinks.