### PR TITLE
ext/objspace/objspace_dump.c: print addresses consistently

### DIFF
--- a/ext/objspace/objspace_dump.c
+++ b/ext/objspace/objspace_dump.c
@@ -172,9 +172,9 @@ reachable_object_i(VALUE ref, void *data)
 	return;
 
     if (dc->cur_obj_references == 0)
-	dump_append(dc, ", \"references\":[\"%p\"", (void *)ref);
+	dump_append(dc, ", \"references\":[\"0x%"PRIxPTR"\"", ref);
     else
-	dump_append(dc, ", \"%p\"", (void *)ref);
+	dump_append(dc, ", \"0x%"PRIxPTR"\"", ref);
 
     dc->cur_obj_references++;
 }
@@ -235,10 +235,10 @@ dump_object(VALUE obj, struct dump_config *dc)
     if (dc->cur_obj == dc->string)
 	return;
 
-    dump_append(dc, "{\"address\":\"%p\", \"type\":\"%s\"", (void *)obj, obj_type(obj));
+    dump_append(dc, "{\"address\":\"0x%"PRIxPTR"\", \"type\":\"%s\"", obj, obj_type(obj));
 
     if (dc->cur_obj_klass)
-	dump_append(dc, ", \"class\":\"%p\"", (void *)dc->cur_obj_klass);
+	dump_append(dc, ", \"class\":\"0x%"PRIxPTR"\"", dc->cur_obj_klass);
     if (rb_obj_frozen_p(obj))
 	dump_append(dc, ", \"frozen\":true");
 
@@ -274,7 +274,7 @@ dump_object(VALUE obj, struct dump_config *dc)
       case T_HASH:
 	dump_append(dc, ", \"size\":%"PRIuSIZE, (size_t)RHASH_SIZE(obj));
 	if (FL_TEST(obj, HASH_PROC_DEFAULT))
-	    dump_append(dc, ", \"default\":\"%p\"", (void *)RHASH_IFNONE(obj));
+	    dump_append(dc, ", \"default\":\"0x%"PRIxPTR"\"", RHASH_IFNONE(obj));
 	break;
 
       case T_ARRAY:
@@ -363,9 +363,9 @@ root_obj_i(const char *category, VALUE obj, void *data)
     if (dc->root_category != NULL && category != dc->root_category)
 	dump_append(dc, "]}\n");
     if (dc->root_category == NULL || category != dc->root_category)
-	dump_append(dc, "{\"type\":\"ROOT\", \"root\":\"%s\", \"references\":[\"%p\"", category, (void *)obj);
+	dump_append(dc, "{\"type\":\"ROOT\", \"root\":\"%s\", \"references\":[\"0x%"PRIxPTR"\"", category, obj);
     else
-	dump_append(dc, ", \"%p\"", (void *)obj);
+	dump_append(dc, ", \"0x%"PRIxPTR"\"", obj);
 
     dc->root_category = category;
     dc->roots++;


### PR DESCRIPTION
The format addresses are printed in are different if you use
`ObjectSpace.dump_all(output: :stdout)` vs.
`ObjectSpace.dump_all(output: :string)` (or `ObjectSpace.dump`) due to
differences in the underlying `vfprintf` implementation.

Use %"PRIxPTR" instead to be consistent across both.

/cc @tenderlove 