### PR TITLE
Add new version OpenSSL 1.1.1 to Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,10 +33,11 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - gcc-8
-      env:
-        - OPENSSL_VERSION=1.1.1
       install:
-        - source ./tool/install_openssl.sh "${OPENSSL_VERSION}"
+        - |
+          if [ "${TRAVIS_EVENT_TYPE}" = "cron" ]; then
+            source ./tool/install_openssl.sh 1.1.1
+          fi
         - openssl version
     - os: linux
       language: ruby

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,11 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - gcc-8
+      env:
+        - OPENSSL_VERSION=1.1.1
+      install:
+        - source ./tool/install_openssl.sh "${OPENSSL_VERSION}"
+        - openssl version
     - os: linux
       language: ruby
       rvm: 2.3

--- a/tool/install_openssl.sh
+++ b/tool/install_openssl.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+if [ ${#} -lt 1 ]; then
+  echo "OpenSSL version required." 1>&2
+  exit 1
+fi
+
+OPENSSL_VERSION="${1}"
+OPENSSL_DIR="${HOME}/openssl/openssl-${OPENSSL_VERSION}"
+TMP_DIR="/tmp/openssl"
+JOBS="-j$(nproc)"
+
+if [ -d "${TMP_DIR}" ]; then
+  rm -rf "${TMP_DIR}"
+fi
+mkdir -p "${TMP_DIR}"
+curl -s https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz | \
+  tar -C "${TMP_DIR}" -xzf -
+pushd "${TMP_DIR}/openssl-${OPENSSL_VERSION}"
+if [ -d "${OPENSSL_DIR}" ]; then
+  rm -rf "${OPENSSL_DIR}"
+fi
+./Configure \
+  --prefix=${OPENSSL_DIR} \
+  enable-crypto-mdebug enable-crypto-mdebug-backtrace \
+  linux-x86_64
+make -s $JOBS
+make install_sw
+popd
+
+export PATH="${OPENSSL_DIR}/bin:${PATH}"
+export CFLAGS="-I${OPENSSL_DIR}/include"
+export LDFLAGS="-L${OPENSSL_DIR}/lib"
+export LD_LIBRARY_PATH="${OPENSSL_DIR}/lib"
+export PKG_CONFIG_PATH="${OPENSSL_DIR}/lib/pkgconfig"


### PR DESCRIPTION
This PR is to enable the OpenSSL latest stable version 1.1.1 on Travis CI GCC latest version gcc-8 test case. Current used OpenSSL version is 1.0.1f.
I am going to open the ticket on Ruby bug tracking system soon.

The discussion can be in https://bugs.ruby-lang.org/issues/15220 .