### PR TITLE
n+1 to include n in range

### DIFF
--- a/benchmark/other-lang/fact.py
+++ b/benchmark/other-lang/fact.py
@@ -3,7 +3,7 @@
 
 def factL(n):
 	r = 1
-	for x in range(2, n):
+	for x in range(2, n+1):
 		r *= x
 	return r
 


### PR DESCRIPTION
Python's `range` stop right before `n`, which means `factL` never returns the correct result.