### PR TITLE
Use docker for Travis CI gcc-8 test case with OpenSSL 1.1.1.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,51 +33,27 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - gcc-8
+      env:
+        - OPENSSL_VERSION=1.1.1
+      install: docker build --rm -t ruby .
+      # Use "--net=host" to prevent "Cannot assign requested address" error
+      # Docker >= 17.06.
+      # https://docs.docker.com/network/host/
+      script: |
+        docker run \
+          -e CC="${CC}" \
+          -e OPENSSL_VERSION="${OPENSSL_VERSION}" \
+          --network=host \
+          ruby tool/ci/test.sh
     - os: linux
       language: ruby
       rvm: 2.3
       name: Running ruby/spec on 2.3 to ensure version guards are correctly added
-      before_install:
       install:
       before_script: chmod -R u+w spec/ruby
       script: ruby -C spec/ruby ../mspec/bin/mspec -j .
 
-before_install:
-  - "CONFIG_FLAG="
-  - "JOBS=-j`nproc`"
-
-before_script:
-  - "echo JOBS=$JOBS"
-  - "uname -a"
-  - "uname -r"
-  - "rm -fr .ext autom4te.cache"
-  - "echo $TERM"
-  - "> config.status"
-  - "sed -f tool/prereq.status Makefile.in common.mk > Makefile"
-  - "make update-config_files"
-  - "make touch-unicode-files"
-  - "make -s $JOBS srcs UNICODE_FILES=."
-  - "requests=; for req in ${RUBYSPEC_PULL_REQUEST//,/ }; do
-      requests=\"$requests +refs/pull/$req/merge:\";
-    done"
-  - "${requests:+git -C spec/ruby -c user.email=none -c user.name=none pull --no-edit origin $requests}"
-  - "${requests:+git -C spec/ruby log --oneline origin/master..@}"
-  - "rm config.status Makefile rbconfig.rb .rbconfig.time"
-  - "mkdir build config_1st config_2nd"
-  - "chmod -R a-w ."
-  - "chmod u+w build config_1st config_2nd"
-  - "cd build"
-  - "../configure -C --disable-install-doc --prefix=/tmp/ruby-prefix --with-gcc=$CC $CONFIG_FLAG"
-  - "cp -pr config.cache config.status .ext/include ../config_1st"
-  - "make reconfig"
-  - "cp -pr config.cache config.status .ext/include ../config_2nd"
-  - "(cd .. && exec diff -ru config_1st config_2nd)"
-  - "make -s $JOBS && make install"
-
-script:
-  - "make -s test TESTOPTS=--color=never"
-  - "make -s $JOBS test-all -o exts TESTOPTS='-q --color=never --job-status=normal' RUBY_FORCE_TEST_JIT=1"
-  - "make -s $JOBS test-spec MSPECOPT=-j"
+script: tool/ci/test.sh
 
 # Branch matrix.  Not all branches are Travis-ready so we limit branches here.
 branches:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM junaruga/ruby-docker:test
+
+ARG TEST_USER=ruby
+ARG WORK_DIR=/home/${TEST_USER}/code
+
+# Create test user to pass the test.
+RUN useradd "${TEST_USER}"
+WORKDIR "${WORK_DIR}"
+COPY . .
+RUN chown -R "${TEST_USER}:${TEST_USER}" "${WORK_DIR}"
+# Enable sudo without password for convenience.
+RUN echo "${TEST_USER} ALL = NOPASSWD: ALL" >> /etc/sudoers
+
+USER "${TEST_USER}"

--- a/tool/ci/Dockerfile
+++ b/tool/ci/Dockerfile
@@ -1,0 +1,45 @@
+FROM ubuntu:18.04
+
+# Copy tool/ci/* files.
+WORKDIR /home/ruby
+COPY . .
+
+ENV RUBY_INSTALLED_COMPILER gcc-8
+ENV RUBY_INSTALLED_OPENSSL_VERSION 1.1.1
+
+# Set the DEBIAN_FRONTEND to install tzdata.
+# Install git and sudo for convenience.
+RUN apt-get update -qq && \
+  export DEBIAN_FRONTEND=noninteractive && \
+  apt-get install -y --no-install-recommends -qq \
+  autoconf \
+  bison \
+  build-essential \
+  ca-certificates \
+  curl \
+  git \
+  gzip \
+  libffi-dev \
+  libssl-dev \
+  netbase \
+  patch \
+  pkg-config \
+  openssl \
+  ruby \
+  software-properties-common \
+  sudo \
+  tzdata \
+  zlib1g-dev
+RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test && \
+  apt-get update -qq && \
+  apt-get install -qq "${RUBY_INSTALLED_COMPILER}"
+RUN apt-get clean all
+# Set any time zone to pass the test.
+RUN ln -snf /usr/share/zoneinfo/Japan /etc/localtime
+RUN dpkg-reconfigure --frontend noninteractive tzdata
+
+RUN ./install_openssl.sh "${RUBY_INSTALLED_OPENSSL_VERSION}"
+# Copy certificates files to pass the test on source installed OpenSSL.
+RUN cp -rp /usr/lib/ssl "/opt/openssl/openssl-${RUBY_INSTALLED_OPENSSL_VERSION}/"
+
+ENTRYPOINT ["/home/ruby/init.sh"]

--- a/tool/ci/init.sh
+++ b/tool/ci/init.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if [ "${OPENSSL_VERSION}" != "" ]; then
+  OPENSSL_DIR="/opt/openssl/openssl-${OPENSSL_VERSION}"
+  export PATH="${OPENSSL_DIR}/bin:${PATH}"
+  export CFLAGS="-I${OPENSSL_DIR}/include"
+  export LDFLAGS="-L${OPENSSL_DIR}/lib"
+  export LD_LIBRARY_PATH="${OPENSSL_DIR}/lib"
+  export PKG_CONFIG_PATH="${OPENSSL_DIR}/lib/pkgconfig"
+fi
+
+echo "Using GCC ${CC:-default} and OpenSSL ${OPENSSL_VERSION:-default}."
+
+exec $*

--- a/tool/ci/install_openssl.sh
+++ b/tool/ci/install_openssl.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e
+
+if [ ${#} -lt 1 ]; then
+  echo "OpenSSL version required." 1>&2
+  exit 1
+fi
+
+OPENSSL_VERSION="${1}"
+OPENSSL_DIR="/opt/openssl/openssl-${OPENSSL_VERSION}"
+BUILD_DIR="/build/openssl"
+
+if [ -d "${BUILD_DIR}" ]; then
+  rm -rf "${BUILD_DIR}"
+fi
+mkdir -p "${BUILD_DIR}"
+curl -s https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz | \
+  tar -C "${BUILD_DIR}" -xzf -
+pushd "${BUILD_DIR}/openssl-${OPENSSL_VERSION}"
+if [ -d "${OPENSSL_DIR}" ]; then
+  rm -rf "${OPENSSL_DIR}"
+fi
+./Configure \
+  --prefix=${OPENSSL_DIR} \
+  enable-crypto-mdebug enable-crypto-mdebug-backtrace \
+  linux-x86_64
+make -s -j$(nproc)
+make install_sw
+popd

--- a/tool/ci/test.sh
+++ b/tool/ci/test.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -ex
+
+# Definitions
+CONFIG_FLAG=
+JOBS=-j`nproc`
+
+# Preparation
+echo JOBS=$JOBS
+uname -a
+uname -r
+rm -fr .ext autom4te.cache
+echo $TERM
+> config.status
+sed -f tool/prereq.status Makefile.in common.mk > Makefile
+make update-config_files
+make touch-unicode-files
+make -s $JOBS srcs UNICODE_FILES=.
+requests=; for req in ${RUBYSPEC_PULL_REQUEST//,/ }; do
+  requests=\"$requests +refs/pull/$req/merge:\";
+done
+${requests:+git -C spec/ruby -c user.email=none -c user.name=none pull --no-edit origin $requests}
+${requests:+git -C spec/ruby log --oneline origin/master..@}
+rm config.status Makefile rbconfig.rb .rbconfig.time
+mkdir build config_1st config_2nd
+chmod -R a-w .
+chmod u+w build config_1st config_2nd
+cd build
+../configure -C --disable-install-doc --prefix=/tmp/ruby-prefix --with-gcc=$CC $CONFIG_FLAG
+cp -pr config.cache config.status .ext/include ../config_1st
+make reconfig
+cp -pr config.cache config.status .ext/include ../config_2nd
+(cd .. && exec diff -ru config_1st config_2nd)
+make -s $JOBS && make install
+
+# Test
+make -s test TESTOPTS=--color=never
+make -s $JOBS test-all -o exts TESTOPTS='-q --color=never --job-status=normal' RUBY_FORCE_TEST_JIT=1
+make -s $JOBS test-spec MSPECOPT=-j


### PR DESCRIPTION
This PR is for experiment to replace Travis gcc-8 test case with docker.
The discussion can be in https://bugs.ruby-lang.org/issues/15220 .
