### PR TITLE
Add a conditional job to test new version OpenSSL 1.1.1 to Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,18 +21,30 @@ dist: trusty
 
 sudo: false
 
+# Custom definitions
+.definitions:
+  if: &secondary type = cron OR env(RUBY_CI_SECONDARY) = 1
 matrix:
   include:
     - os: linux
       compiler: gcc
     - os: linux
       compiler: gcc-8
-      addons:
+      addons: &addons_gcc8
         apt:
           sources:
             - ubuntu-toolchain-r-test
           packages:
             - gcc-8
+    - os: linux
+      compiler: gcc-8
+      addons: *addons_gcc8
+      env:
+        - OPENSSL_VERSION=1.1.1
+      install:
+        - source ./tool/install_openssl.sh "${OPENSSL_VERSION}"
+        - openssl version
+      if: *secondary
     - os: linux
       language: ruby
       rvm: 2.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,6 @@ dist: trusty
 
 sudo: false
 
-# Custom definitions
-.definitions:
-  if: &secondary type = cron OR env(RUBY_CI_SECONDARY) = 1
 matrix:
   include:
     - os: linux
@@ -44,7 +41,7 @@ matrix:
       install:
         - source ./tool/install_openssl.sh "${OPENSSL_VERSION}"
         - openssl version
-      if: *secondary
+      if: type = cron OR env(RUBY_CI_SECONDARY) = 1
     - os: linux
       language: ruby
       rvm: 2.3

--- a/tool/install_openssl.sh
+++ b/tool/install_openssl.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+if [ ${#} -lt 1 ]; then
+  echo "OpenSSL version required." 1>&2
+  exit 1
+fi
+
+OPENSSL_VERSION="${1}"
+OPENSSL_DIR="${HOME}/openssl/openssl-${OPENSSL_VERSION}"
+TMP_DIR="/tmp/openssl"
+JOBS="-j$(nproc)"
+
+if [ -d "${TMP_DIR}" ]; then
+  rm -rf "${TMP_DIR}"
+fi
+mkdir -p "${TMP_DIR}"
+curl -s https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz | \
+  tar -C "${TMP_DIR}" -xzf -
+pushd "${TMP_DIR}/openssl-${OPENSSL_VERSION}"
+if [ -d "${OPENSSL_DIR}" ]; then
+  rm -rf "${OPENSSL_DIR}"
+fi
+./Configure \
+  --prefix=${OPENSSL_DIR} \
+  enable-crypto-mdebug enable-crypto-mdebug-backtrace \
+  linux-x86_64
+make -s $JOBS
+make install_sw
+popd
+
+export PATH="${OPENSSL_DIR}/bin:${PATH}"
+export CFLAGS="-I${OPENSSL_DIR}/include"
+export LDFLAGS="-L${OPENSSL_DIR}/lib"
+export LD_LIBRARY_PATH="${OPENSSL_DIR}/lib"
+export PKG_CONFIG_PATH="${OPENSSL_DIR}/lib/pkgconfig"


### PR DESCRIPTION
The discussion can be in https://bugs.ruby-lang.org/issues/15220 .

I sent 2 pull-requests previously 

* Add OpenSSL 1.1.1 test case to Travis CI: https://github.com/ruby/ruby/pull/1980
* Use docker image to test OpenSSL 1.1.1: https://github.com/ruby/ruby/pull/1983

And this pull-request is the 3rd pull-request related to OpenSSL 1.1.1.
This is the most recommended and realistic way that I think.

Here is the result on my repository.
https://travis-ci.org/junaruga/ruby/builds/442103286
You can see the added 1 test case for OpenSSL 1.1.1

But in this pull-request, you only see 3 test cases that is same with current master branch.
The reason is because I added "conditional" job for OpenSSL 1.1.1. [1]

We want to save the running time every time.
In other word, we regularly want to check supported cases. 

## Use case

Usually only 3 cases are run on Travis CI such as pull-request, and pushing to branches.
The conditional job is only run if the job is run on Travis cron mode or `RUBY_CI_SECONDARY` is set as `1` in Travis setting page.

![ruby-travis-ci-secondary](https://user-images.githubusercontent.com/121989/47012144-d452a480-d143-11e8-9301-9da74e5d20f3.png)

## Detail of implementation

I used YAML's anchor (`&`) and reference (`*`) feature. [2][3]

Finally I would recommend great example [4] to test C on several environments.

[1] Travis conditions: https://docs.travis-ci.com/user/conditions-v1
[2] YAML anchor and reference: https://en.wikipedia.org/wiki/YAML#Advanced_components
[3] YAML 1.1 is used for Travis: http://yaml.org/spec/1.1/
[4] https://github.com/Microsoft/GSL/blob/master/.travis.yml
