### PR TITLE
Fix spec/ruby/core/array/reject_spec.rb & misc

### DIFF
--- a/spec/ruby/core/array/fixtures/classes.rb
+++ b/spec/ruby/core/array/fixtures/classes.rb
@@ -13,15 +13,11 @@ module ArraySpecs
   SampleCount = 1000
 
   def self.frozen_array
-    frozen_array = [1,2,3]
-    frozen_array.freeze
-    frozen_array
+    [1,2,3].freeze
   end
 
   def self.empty_frozen_array
-    frozen_array = []
-    frozen_array.freeze
-    frozen_array
+    [].freeze
   end
 
   def self.recursive_array

--- a/spec/ruby/core/array/reject_spec.rb
+++ b/spec/ruby/core/array/reject_spec.rb
@@ -126,10 +126,13 @@ describe "Array#reject!" do
       a = [1, 2, 3, 4]
       begin
         a.reject! do |x|
-          return true if x == 2
-          raise raise StandardError, 'Oops' if x == 3
+          case x
+          when 2 then true
+          when 3 then raise StandardError, 'Oops'
+          else false
+          end
         end
-      rescue
+      rescue StandardError
       end
 
       a.should == [1, 3, 4]


### PR DESCRIPTION
1. Fix `spec/ruby/core/array/reject_spec.rb`, incorrect return and 'raise raise'

2. Minor cleanup to `spec/ruby/core/array/fixtures/classes.rb`

When test-spec is run parallel, failure in reject_spec causes additional missed specs in following files.

See https://bugs.ruby-lang.org/issues/15228