### PR TITLE
add #to_str to URI::Generic

### DIFF
--- a/lib/uri/generic.rb
+++ b/lib/uri/generic.rb
@@ -1376,6 +1376,7 @@ module URI
       end
       str
     end
+    alias to_str to_s
 
     #
     # Compares two URIs.


### PR DESCRIPTION
## Use Case

I had a case where I was performing
```ruby
some_uri = URI::HTTP.build(host: 'example.com')
case some_uri
when /example/ then :example
else :other_stuff
end
```

This does not work because URIs do not respond to #to_str (instead I had to manually call #to_s), but it seems reasonable to me to be able to make this comparison.

I was not able to find any examples of implementing #to_str appropriately, so I took my best guess. Sorry if I've got any protocol wrong; first time here.