### PR TITLE
Update ruby-style.el

### DIFF
--- a/misc/ruby-style.el
+++ b/misc/ruby-style.el
@@ -63,8 +63,7 @@
     (statement-case-intro . *)
     (statement-case-open . *)
     (statement-block-intro . (ruby-style-case-indent +))
-    (access-label /)
-    )))
+    (access-label /))))
 
 ;;;###autoload
 (defun ruby-style-c-mode ()


### PR DESCRIPTION
Pull up lisp ending parens to be in common style.