### PR TITLE
add support for hash literal shorthand

### DIFF
--- a/doc/syntax/literals.rdoc
+++ b/doc/syntax/literals.rdoc
@@ -297,6 +297,14 @@ is equal to
 
   { :"a 1" => 1, :"b 2" => 2 }
 
+You may also use the shorthand syntax for creating hash with symbol keys:
+
+  { a, b }
+
+which are equal to
+
+  { :a => a, :b => b }
+
 See Hash for the methods you may use with a hash.
 
 == Ranges

--- a/spec/ruby/language/hash_spec.rb
+++ b/spec/ruby/language/hash_spec.rb
@@ -78,14 +78,40 @@ describe "Hash literal" do
     {rbx: :cool, specs: 'fail_sometimes',}.should == h
   end
 
+  ruby_version_is "2.6" do
+    it "accepts short notation 'key' for 'key: value' syntax" do
+      a, b, c = 1, 2, 3
+      h = eval('{a}')
+      {a: 1}.should == h
+      h = eval('{a, b, c}')
+      {a: 1, b: 2, c: 3}.should == h
+    end
+
+    it "ignores hanging comma on short notation" do
+      a, b, c = 1, 2, 3
+      h = eval('{a, b, c,}')
+      {a: 1, b: 2, c: 3}.should == h
+    end
+  end
+
   it "accepts mixed 'key: value' and 'key => value' syntax" do
     h = {:a => 1, :b => 2, "c" => 3}
     {a: 1, b: 2, "c" => 3}.should == h
   end
 
-  it "accepts mixed 'key: value', 'key => value' and '\"key\"': value' syntax" do
-    h = {:a => 1, :b => 2, "c" => 3, :d => 4}
-    eval('{a: 1, :b => 2, "c" => 3, "d": 4}').should == h
+  ruby_version_is "2.6" do
+    it "accepts mixed 'key', 'key: value', 'key => value' and '\"key\"': value' syntax" do
+      a, e = 1, 5
+      h = eval('{a, :b => 2, "c" => 3, :d => 4, e}')
+      eval('{a: 1, :b => 2, "c" => 3, "d": 4, e: 5}').should == h
+    end
+  end
+
+  ruby_version_is ""..."2.6" do
+    it "accepts mixed 'key: value', 'key => value' and '\"key\"': value' syntax" do
+      h = {:a => 1, :b => 2, "c" => 3, :d => 4}
+      eval('{a: 1, :b => 2, "c" => 3, "d": 4}').should == h
+    end
   end
 
   it "expands an '**{}' element into the containing Hash literal initialization" do


### PR DESCRIPTION
redmine ticket: https://bugs.ruby-lang.org/issues/15236

inspired by javascript support for [object literal shorthand](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer#New_notations_in_ECMAScript_2015) `{ a }`, which will be expanded into `{ a: a }`..

to avoid ambiguity, this shorthand is only supported when hash is defined explicitly with `{ }` notation..

in other situation where the brackets is optional, e.g. function call, we still need to write it in full (`m(a: a)` instead of `m(a)`, or `m(a, b, c: c)` instead of `m(a, b, c)`..

PS: This is my first time contributing to ruby, and also my first time reading and modifying a parser.. I'm not quite sure if what I did is a good approach.. any help or guidance will be highly appreciated.. :bowing_man: 