### PR TITLE
Hash aset should deduplicate non tainted string

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -1587,10 +1587,14 @@ VALUE
 rb_hash_key_str(VALUE key)
 {
     VALUE k;
+    int not_tainted = !RB_OBJ_TAINTED(key);
 
-    if (!RB_OBJ_TAINTED(key) &&
+    if (not_tainted &&
 	(k = fstring_existing_str(key)) != Qnil) {
 	return k;
+    }
+    else if(not_tainted) {
+        return rb_fstring(key);
     }
     else {
 	return rb_str_new_frozen(key);

--- a/test/ruby/test_hash.rb
+++ b/test/ruby/test_hash.rb
@@ -280,6 +280,24 @@ class TestHash < Test::Unit::TestCase
     assert_same a.keys[0], b.keys[0]
   end
 
+  def test_ASET_fstring_non_literal_key
+    underscore = "_"
+    non_literal_strings = Proc.new{ ["abc#{underscore}def", "abc" * 5, "abc" + "def", "" << "ghi" << "jkl"] }
+
+    a, b = {}, {}
+    non_literal_strings.call.each do |string|
+      assert_equal 1, a[string] = 1
+    end
+
+    non_literal_strings.call.each do |string|
+      assert_equal 1, b[string] = 1
+    end
+
+    [a.keys, b.keys].transpose.each do |key_a, key_b|
+      assert_same key_a, key_b
+    end
+  end
+
   def test_hash_aset_fstring_identity
     h = {}.compare_by_identity
     h['abc'] = 1


### PR DESCRIPTION
Issue Tracker

https://bugs.ruby-lang.org/issues/15251