### PR TITLE
Feature/win ssl 1.1 win32ole

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,11 +52,13 @@ for:
     only:
       - build: vs
   install:
+    - ren C:\Windows\System32\libssl-1_1-x64.dll    libssl-1_1-x64.dll_
+    - ren C:\Windows\System32\libcrypto-1_1-x64.dll libcrypto-1_1-x64.dll_
     - ver
     - chcp
     - SET BITS=%Platform:x86=32%
     - SET BITS=%BITS:x=%
-    - SET OPENSSL_DIR=c:\OpenSSL-Win%BITS%
+    - SET OPENSSL_DIR=c:\OpenSSL-v11-Win%BITS%
     - CALL SET vcvars=%%^VS%VS%COMNTOOLS^%%..\..\VC\vcvarsall.bat
     - SET vcvars
     - '"%vcvars%" %Platform:x64=amd64%'
@@ -90,6 +92,8 @@ for:
     - nmake install-nodoc
     - \usr\bin\ruby -v -e "p :locale => Encoding.find('locale'), :filesystem => Encoding.find('filesystem')"
   test_script:
+    # make sure mingw dll's are not in path, but allow *nix exe's in C:\msys64\usr\bin
+    - SET PATH=\usr\local\bin;%ruby_path%\bin;%PATH%;C:\msys64\usr\bin
     - set /a JOBS=%NUMBER_OF_PROCESSORS%
     - nmake -l "TESTOPTS=-v -q" btest
     - nmake -l "TESTOPTS=-v -q" test-basic
@@ -97,11 +101,16 @@ for:
     # separately execute tests that may crash worker without -j.
     - nmake -l "TESTOPTS=-v --subprocess-timeout-scale=3.0" test-all TESTS="../test/win32ole ../test/ruby/test_syntax.rb ../test/open-uri/test_open-uri.rb ../test/rubygems/test_bundled_ca.rb"
     - nmake -l test-spec MSPECOPT=-fs # not using `-j` because sometimes `mspec -j` silently dies on Windows
+  on_finish:
+    - cd %APPVEYOR_BUILD_FOLDER%
+    - \usr\bin\ruby.exe -ropenssl -e "puts '', 'Build    ' + OpenSSL::OPENSSL_VERSION, 'Runtime  ' + OpenSSL::OPENSSL_LIBRARY_VERSION"
 -
   matrix:
     only:
       - build: msys2
   install:
+    - ren C:\Windows\System32\libssl-1_1-x64.dll    libssl-1_1-x64.dll_
+    - ren C:\Windows\System32\libcrypto-1_1-x64.dll libcrypto-1_1-x64.dll_
     - ver
     - chcp
     - set /a JOBS=%NUMBER_OF_PROCESSORS%
@@ -122,7 +131,9 @@ for:
     # always update database
     - pacman -Sy
     - pacman -S --noconfirm --needed --noprogressbar mingw-w64-x86_64-toolchain
-    - pacman -S --noconfirm --needed --noprogressbar mingw-w64-x86_64-gdbm mingw-w64-x86_64-gmp mingw-w64-x86_64-libffi mingw-w64-x86_64-ncurses mingw-w64-x86_64-readline mingw-w64-x86_64-zlib
+    # 2018-10 below needed until next Appveyor MSYS2 update 
+    - pacman -Rdd --noconfirm --noprogressbar mingw-w64-x86_64-openssl
+    - pacman -S --noconfirm --needed --noprogressbar mingw-w64-x86_64-gdbm mingw-w64-x86_64-gmp mingw-w64-x86_64-libffi mingw-w64-x86_64-ncurses mingw-w64-x86_64-openssl mingw-w64-x86_64-readline mingw-w64-x86_64-zlib
     - cd %APPVEYOR_BUILD_FOLDER%
     - set CFLAGS=-march=%MSYS2_ARCH:_=-% -mtune=generic -O3 -pipe
     - set CXXFLAGS=%CFLAGS%
@@ -140,3 +151,6 @@ for:
     # separately execute tests that may crash worker without -j.
     - mingw32-make test-all TESTOPTS="--retry --job-status=normal --show-skip --subprocess-timeout-scale=1.5" TESTS="../ruby/test/win32ole"
     - mingw32-make test-spec MSPECOPT=-fs # not using `-j` because sometimes `mspec -j` silently dies on Windows
+  on_finish:
+    - cd %APPVEYOR_BUILD_FOLDER%
+    - ..\install\bin\ruby.exe -ropenssl -e "puts '', 'Build    ' + OpenSSL::OPENSSL_VERSION, 'Runtime  ' + OpenSSL::OPENSSL_LIBRARY_VERSION"

--- a/spec/ruby/library/win32ole/fixtures/classes.rb
+++ b/spec/ruby/library/win32ole/fixtures/classes.rb
@@ -1,4 +1,8 @@
+require 'win32ole'
+  
 module WIN32OLESpecs
+  MSXML_AVAILABLE = !!WIN32OLE_TYPELIB.typelibs.find { |t| t.name.start_with?('Microsoft XML') }
+
   def self.new_ole(name)
     tries = 0
     begin

--- a/spec/ruby/library/win32ole/fixtures/event.xml
+++ b/spec/ruby/library/win32ole/fixtures/event.xml
@@ -1,0 +1,4 @@
+<program>
+  <name>Ruby</name>
+  <version>trunk</version>
+</program>

--- a/spec/ruby/library/win32ole/win32ole/_getproperty_spec.rb
+++ b/spec/ruby/library/win32ole/win32ole/_getproperty_spec.rb
@@ -1,19 +1,19 @@
-require_relative '../fixtures/classes'
-
 platform_is :windows do
-  require 'win32ole'
+  require_relative '../fixtures/classes'
+  guard -> { WIN32OLESpecs::MSXML_AVAILABLE } do
 
-  describe "WIN32OLE#_getproperty" do
-    before :each do
-      @ie = WIN32OLESpecs.new_ole('InternetExplorer.Application')
-    end
+    describe "WIN32OLE#_getproperty" do
+      before :all do
+        @xml_dom = WIN32OLESpecs.new_ole('MSXML.DOMDocument')
+      end
 
-    after :each do
-      @ie.Quit
-    end
+      after :all do
+        @xml_dom = nil
+      end
 
-    it "gets name" do
-      @ie._getproperty(0, [], []).should =~ /explorer/i
+      it "gets validateOnParse" do
+        @xml_dom._getproperty(65, [], []).should be_true
+      end
     end
   end
 end

--- a/spec/ruby/library/win32ole/win32ole/_invoke_spec.rb
+++ b/spec/ruby/library/win32ole/win32ole/_invoke_spec.rb
@@ -1,7 +1,5 @@
-require_relative '../fixtures/classes'
-
 platform_is :windows do
-  require 'win32ole'
+  require_relative '../fixtures/classes'
 
   describe "WIN32OLE#_invoke" do
     before :each do

--- a/spec/ruby/library/win32ole/win32ole/codepage_spec.rb
+++ b/spec/ruby/library/win32ole/win32ole/codepage_spec.rb
@@ -1,7 +1,5 @@
-require_relative '../fixtures/classes'
-
 platform_is :windows do
-  require 'win32ole'
+  require_relative '../fixtures/classes'
 
   describe "WIN32OLE.codepage=" do
     it "sets codepage" do

--- a/spec/ruby/library/win32ole/win32ole/connect_spec.rb
+++ b/spec/ruby/library/win32ole/win32ole/connect_spec.rb
@@ -1,7 +1,5 @@
-require_relative '../fixtures/classes'
-
 platform_is :windows do
-  require 'win32ole'
+  require_relative '../fixtures/classes'
 
   describe "WIN32OLE.connect" do
     it "creates WIN32OLE object given valid argument" do

--- a/spec/ruby/library/win32ole/win32ole/const_load_spec.rb
+++ b/spec/ruby/library/win32ole/win32ole/const_load_spec.rb
@@ -1,7 +1,5 @@
-require_relative '../fixtures/classes'
-
 platform_is :windows do
-  require 'win32ole'
+  require_relative '../fixtures/classes'
 
   describe "WIN32OLE.const_load when passed Shell.Application OLE object" do
     before :each do

--- a/spec/ruby/library/win32ole/win32ole/constants_spec.rb
+++ b/spec/ruby/library/win32ole/win32ole/constants_spec.rb
@@ -1,7 +1,5 @@
-require_relative '../fixtures/classes'
-
 platform_is :windows do
-  require 'win32ole'
+  require_relative '../fixtures/classes'
 
   describe "WIN32OLE class" do
     it "defines constant CP_ACP" do

--- a/spec/ruby/library/win32ole/win32ole/create_guid_spec.rb
+++ b/spec/ruby/library/win32ole/win32ole/create_guid_spec.rb
@@ -1,7 +1,5 @@
-require_relative '../fixtures/classes'
-
 platform_is :windows do
-  require 'win32ole'
+  require_relative '../fixtures/classes'
 
   describe "WIN32OLE.create_guid" do
     it "generates guid with valid format" do

--- a/spec/ruby/library/win32ole/win32ole/invoke_spec.rb
+++ b/spec/ruby/library/win32ole/win32ole/invoke_spec.rb
@@ -1,19 +1,19 @@
-require_relative '../fixtures/classes'
-
 platform_is :windows do
-  require 'win32ole'
+  require_relative '../fixtures/classes'
+  guard -> { WIN32OLESpecs::MSXML_AVAILABLE } do
 
-  describe "WIN32OLE#invoke" do
-    before :each do
-      @ie = WIN32OLESpecs.new_ole('InternetExplorer.Application')
-    end
+    describe "WIN32OLE#invoke" do
+      before :all do
+        @xml_dom = WIN32OLESpecs.new_ole('MSXML.DOMDocument')
+      end
 
-    after :each do
-      @ie.Quit
-    end
+      after :all do
+        @xml_dom = nil
+      end
 
-    it "get name by invoking 'Name' OLE method" do
-      @ie.invoke('Name').should =~ /explorer/i
+      it "get name by invoking 'validateOnParse' OLE method" do
+        @xml_dom.invoke('validateOnParse').should be_true
+      end
     end
   end
 end

--- a/spec/ruby/library/win32ole/win32ole/locale_spec.rb
+++ b/spec/ruby/library/win32ole/win32ole/locale_spec.rb
@@ -1,7 +1,5 @@
-require_relative '../fixtures/classes'
-
 platform_is :windows do
-  require 'win32ole'
+  require_relative '../fixtures/classes'
 
   describe "WIN32OLE.locale" do
     it "gets locale" do

--- a/spec/ruby/library/win32ole/win32ole/new_spec.rb
+++ b/spec/ruby/library/win32ole/win32ole/new_spec.rb
@@ -1,7 +1,5 @@
-require_relative '../fixtures/classes'
-
 platform_is :windows do
-  require 'win32ole'
+  require_relative '../fixtures/classes'
 
   describe "WIN32OLESpecs.new_ole" do
     it "creates a WIN32OLE object from OLE server name" do

--- a/spec/ruby/library/win32ole/win32ole/ole_func_methods_spec.rb
+++ b/spec/ruby/library/win32ole/win32ole/ole_func_methods_spec.rb
@@ -1,27 +1,27 @@
-require_relative '../fixtures/classes'
-
 platform_is :windows do
-  require 'win32ole'
+  require_relative '../fixtures/classes'
+  guard -> { WIN32OLESpecs::MSXML_AVAILABLE } do
 
-  describe "WIN32OLE#ole_func_methods" do
-    before :each do
-      @ie = WIN32OLESpecs.new_ole('InternetExplorer.Application')
-    end
+    describe "WIN32OLE#ole_func_methods" do
+      before :all do
+        @xml_dom = WIN32OLESpecs.new_ole('MSXML.DOMDocument')
+      end
 
-    after :each do
-      @ie.Quit if @ie
-    end
+      after :all do
+        @xml_dom =nil
+      end
 
-    it "raises ArgumentError if argument is given" do
-      lambda { @ie.ole_func_methods(1) }.should raise_error ArgumentError
-    end
+      it "raises ArgumentError if argument is given" do
+        lambda { @xml_dom.ole_func_methods(1) }.should raise_error ArgumentError
+      end
 
-    it "returns an array of WIN32OLE_METHODs" do
-      @ie.ole_func_methods.all? { |m| m.kind_of? WIN32OLE_METHOD }.should be_true
-    end
+      it "returns an array of WIN32OLE_METHODs" do
+        @xml_dom.ole_func_methods.all? { |m| m.kind_of? WIN32OLE_METHOD }.should be_true
+      end
 
-    it "contains a 'AddRef' method for Internet Explorer" do
-      @ie.ole_func_methods.map { |m| m.name }.include?('AddRef').should be_true
+      it "contains a 'AddRef' method for Internet Explorer" do
+        @xml_dom.ole_func_methods.map { |m| m.name }.include?('AddRef').should be_true
+      end
     end
   end
 end

--- a/spec/ruby/library/win32ole/win32ole/ole_get_methods_spec.rb
+++ b/spec/ruby/library/win32ole/win32ole/ole_get_methods_spec.rb
@@ -1,7 +1,5 @@
-require_relative '../fixtures/classes'
-
 platform_is :windows do
-  require 'win32ole'
+  require_relative '../fixtures/classes'
 
   describe "WIN32OLE#ole_get_methods" do
 

--- a/spec/ruby/library/win32ole/win32ole/ole_method_help_spec.rb
+++ b/spec/ruby/library/win32ole/win32ole/ole_method_help_spec.rb
@@ -1,8 +1,5 @@
-require_relative '../fixtures/classes'
-require_relative 'shared/ole_method'
-
 platform_is :windows do
-  require 'win32ole'
+  require_relative 'shared/ole_method'
 
   describe "WIN32OLE#ole_method_help" do
     it_behaves_like :win32ole_ole_method, :ole_method_help

--- a/spec/ruby/library/win32ole/win32ole/ole_method_spec.rb
+++ b/spec/ruby/library/win32ole/win32ole/ole_method_spec.rb
@@ -1,12 +1,8 @@
-require_relative '../fixtures/classes'
-require_relative 'shared/ole_method'
-
 platform_is :windows do
-  require 'win32ole'
+  require_relative 'shared/ole_method'
 
   describe "WIN32OLE#ole_method" do
     it_behaves_like :win32ole_ole_method, :ole_method
-
   end
 
 end

--- a/spec/ruby/library/win32ole/win32ole/ole_methods_spec.rb
+++ b/spec/ruby/library/win32ole/win32ole/ole_methods_spec.rb
@@ -1,27 +1,27 @@
-require_relative '../fixtures/classes'
-
 platform_is :windows do
-  require 'win32ole'
+  require_relative '../fixtures/classes'
+  guard -> { WIN32OLESpecs::MSXML_AVAILABLE } do
 
-  describe "WIN32OLE#ole_methods" do
-    before :each do
-      @ie = WIN32OLESpecs.new_ole('InternetExplorer.Application')
-    end
+    describe "WIN32OLE#ole_methods" do
+      before :all do
+        @xml_dom = WIN32OLESpecs.new_ole('MSXML.DOMDocument')
+      end
 
-    after :each do
-      @ie.Quit
-    end
+      after :all do
+        @xml_dom = nil
+      end
 
-    it "raises ArgumentError if argument is given" do
-      lambda { @ie.ole_methods(1) }.should raise_error ArgumentError
-    end
+      it "raises ArgumentError if argument is given" do
+        lambda { @xml_dom.ole_methods(1) }.should raise_error ArgumentError
+      end
 
-    it "returns an array of WIN32OLE_METHODs" do
-      @ie.ole_methods.all? { |m| m.kind_of? WIN32OLE_METHOD }.should be_true
-    end
+      it "returns an array of WIN32OLE_METHODs" do
+        @xml_dom.ole_methods.all? { |m| m.kind_of? WIN32OLE_METHOD }.should be_true
+      end
 
-    it "contains a 'AddRef' method for Internet Explorer" do
-      @ie.ole_methods.map { |m| m.name }.include?('AddRef').should be_true
+      it "contains a 'validateOnParse' method for Internet Explorer" do
+        @xml_dom.ole_methods.map { |m| m.name }.include?('validateOnParse').should be_true
+      end
     end
   end
 end

--- a/spec/ruby/library/win32ole/win32ole/ole_obj_help_spec.rb
+++ b/spec/ruby/library/win32ole/win32ole/ole_obj_help_spec.rb
@@ -1,23 +1,23 @@
-require_relative '../fixtures/classes'
-
 platform_is :windows do
-  require 'win32ole'
+  require_relative '../fixtures/classes'
+  guard -> { WIN32OLESpecs::MSXML_AVAILABLE } do
 
-  describe "WIN32OLE#ole_obj_help" do
-    before :each do
-      @ie = WIN32OLESpecs.new_ole('InternetExplorer.Application')
-    end
+    describe "WIN32OLE#ole_obj_help" do
+      before :all do
+        @xml_dom = WIN32OLESpecs.new_ole('MSXML.DOMDocument')
+      end
 
-    after :each do
-      @ie.Quit
-    end
+      after :all do
+        @xml_dom = nil
+      end
 
-    it "raises ArgumentError if argument is given" do
-      lambda { @ie.ole_obj_help(1) }.should raise_error ArgumentError
-    end
+      it "raises ArgumentError if argument is given" do
+        lambda { @xml_dom.ole_obj_help(1) }.should raise_error ArgumentError
+      end
 
-    it "returns an instance of WIN32OLE_TYPE" do
-      @ie.ole_obj_help.kind_of?(WIN32OLE_TYPE).should be_true
+      it "returns an instance of WIN32OLE_TYPE" do
+        @xml_dom.ole_obj_help.kind_of?(WIN32OLE_TYPE).should be_true
+      end
     end
   end
 end

--- a/spec/ruby/library/win32ole/win32ole/ole_put_methods_spec.rb
+++ b/spec/ruby/library/win32ole/win32ole/ole_put_methods_spec.rb
@@ -1,27 +1,27 @@
-require_relative '../fixtures/classes'
-
 platform_is :windows do
-  require 'win32ole'
+  require_relative '../fixtures/classes'
+  guard -> { WIN32OLESpecs::MSXML_AVAILABLE } do
 
-  describe "WIN32OLE#ole_put_methods" do
-    before :each do
-      @ie = WIN32OLESpecs.new_ole('InternetExplorer.Application')
-    end
+    describe "WIN32OLE#ole_put_methods" do
+      before :all do
+        @xml_dom = WIN32OLESpecs.new_ole('MSXML.DOMDocument')
+      end
 
-    after :each do
-      @ie.Quit
-    end
+      after :all do
+        @xml_dom = nil
+      end
 
-    it "raises ArgumentError if argument is given" do
-      lambda { @ie.ole_put_methods(1) }.should raise_error ArgumentError
-    end
+      it "raises ArgumentError if argument is given" do
+        lambda { @xml_dom.ole_put_methods(1) }.should raise_error ArgumentError
+      end
 
-    it "returns an array of WIN32OLE_METHODs" do
-      @ie.ole_put_methods.all? { |m| m.kind_of? WIN32OLE_METHOD }.should be_true
-    end
+      it "returns an array of WIN32OLE_METHODs" do
+        @xml_dom.ole_put_methods.all? { |m| m.kind_of? WIN32OLE_METHOD }.should be_true
+      end
 
-    it "contains a 'Height' method for Internet Explorer" do
-      @ie.ole_put_methods.map { |m| m.name }.include?('Height').should be_true
+      it "contains a 'preserveWhiteSpace' method" do
+        @xml_dom.ole_put_methods.map { |m| m.name }.include?('preserveWhiteSpace').should be_true
+      end
     end
   end
 end

--- a/spec/ruby/library/win32ole/win32ole/setproperty_spec.rb
+++ b/spec/ruby/library/win32ole/win32ole/setproperty_spec.rb
@@ -1,8 +1,5 @@
-require_relative '../fixtures/classes'
-require_relative 'shared/setproperty'
-
 platform_is :windows do
-  require 'win32ole'
+  require_relative 'shared/setproperty'
 
   describe "WIN32OLE#setproperty" do
     it_behaves_like :win32ole_setproperty, :setproperty

--- a/spec/ruby/library/win32ole/win32ole/shared/ole_method.rb
+++ b/spec/ruby/library/win32ole/win32ole/shared/ole_method.rb
@@ -1,25 +1,25 @@
-require_relative '../../fixtures/classes'
-
 platform_is :windows do
-  require 'win32ole'
+  require_relative '../../fixtures/classes'
+  guard -> { WIN32OLESpecs::MSXML_AVAILABLE } do
 
-  describe :win32ole_ole_method, shared: true do
-    before :each do
-      @ie = WIN32OLESpecs.new_ole('InternetExplorer.Application')
-    end
+    describe :win32ole_ole_method, shared: true do
+      before :all do
+        @xml_dom = WIN32OLESpecs.new_ole('MSXML.DOMDocument')
+      end
 
-    after :each do
-      @ie.Quit
-    end
+      after :all do
+        @xml_dom = nil
+      end
 
-    it "raises ArgumentError if no argument is given" do
-      lambda { @ie.send(@method) }.should raise_error ArgumentError
-    end
+      it "raises ArgumentError if no argument is given" do
+        lambda { @xml_dom.send(@method) }.should raise_error ArgumentError
+      end
 
-    it "returns the WIN32OLE_METHOD 'Quit' if given 'Quit'" do
-      result = @ie.send(@method, "Quit")
-      result.kind_of?(WIN32OLE_METHOD).should be_true
-      result.name.should == 'Quit'
+      it "returns the WIN32OLE_METHOD 'abort' if given 'abort'" do
+        result = @xml_dom.send(@method, "abort")
+        result.kind_of?(WIN32OLE_METHOD).should be_true
+        result.name.should == 'abort'
+      end
     end
   end
 end

--- a/spec/ruby/library/win32ole/win32ole/shared/setproperty.rb
+++ b/spec/ruby/library/win32ole/win32ole/shared/setproperty.rb
@@ -1,25 +1,24 @@
-require_relative '../../fixtures/classes'
-
 platform_is :windows do
-  require 'win32ole'
+  require_relative '../../fixtures/classes'
+  guard -> { WIN32OLESpecs::MSXML_AVAILABLE } do
 
-  describe :win32ole_setproperty, shared: true do
-    before :each do
-      @ie = WIN32OLESpecs.new_ole('InternetExplorer.Application')
-    end
+    describe :win32ole_setproperty, shared: true do
+      before :all do
+        @xml_dom = WIN32OLESpecs.new_ole('MSXML.DOMDocument')
+      end
 
-    after :each do
-      @ie.Quit
-    end
+      after :all do
+        @xml_dom = nil
+      end
 
-    it "raises ArgumentError if no argument is given" do
-      lambda { @ie.send(@method) }.should raise_error ArgumentError
-    end
+      it "raises ArgumentError if no argument is given" do
+        lambda { @xml_dom.send(@method) }.should raise_error ArgumentError
+      end
 
-    it "sets height to 500 and returns nil" do
-      height = 500
-      result = @ie.send(@method, 'Height', height)
-      result.should == nil
+      it "sets async true and returns nil" do
+        result = @xml_dom.send(@method, 'async', true)
+        result.should == nil
+      end
     end
   end
 end

--- a/spec/ruby/library/win32ole/win32ole_event/new_spec.rb
+++ b/spec/ruby/library/win32ole/win32ole_event/new_spec.rb
@@ -1,33 +1,33 @@
-require_relative '../fixtures/classes'
-
 platform_is :windows do
-  require 'win32ole'
+  require_relative '../fixtures/classes'
+  guard -> { WIN32OLESpecs::MSXML_AVAILABLE } do
+  
+    describe "WIN32OLE_EVENT.new" do
+      before :all do
+        @xml_dom = WIN32OLESpecs.new_ole('MSXML.DOMDocument')
+      end
 
-  describe "WIN32OLE_EVENT.new" do
-    before :each do
-      @ie = WIN32OLESpecs.new_ole('InternetExplorer.Application')
-    end
+      after :all do
+        @xml_dom = nil
+      end
 
-    after :each do
-      @ie.Quit if @ie
-    end
+      it "raises TypeError given invalid argument" do
+        lambda { WIN32OLE_EVENT.new "A" }.should raise_error TypeError
+      end
 
-    it "raises TypeError given invalid argument" do
-      lambda { WIN32OLE_EVENT.new "A" }.should raise_error TypeError
-    end
+      it "raises RuntimeError if event does not exist" do
+        lambda { WIN32OLE_EVENT.new(@xml_dom, 'A') }.should raise_error RuntimeError
+      end
 
-    it "raises RuntimeError if event does not exist" do
-      lambda { WIN32OLE_EVENT.new(@ie, 'A') }.should raise_error RuntimeError
-    end
+      it "raises RuntimeError if OLE object has no events" do
+        dict = WIN32OLESpecs.new_ole('Scripting.Dictionary')
+        lambda { WIN32OLE_EVENT.new(dict) }.should raise_error RuntimeError
+      end
 
-    it "raises RuntimeError if OLE object has no events" do
-      dict = WIN32OLESpecs.new_ole('Scripting.Dictionary')
-      lambda { WIN32OLE_EVENT.new(dict) }.should raise_error RuntimeError
-    end
-
-    it "creates WIN32OLE_EVENT object" do
-      ev = WIN32OLE_EVENT.new(@ie, 'DWebBrowserEvents')
-      ev.should be_kind_of WIN32OLE_EVENT
+      it "creates WIN32OLE_EVENT object" do
+        ev = WIN32OLE_EVENT.new(@xml_dom)
+        ev.should be_kind_of WIN32OLE_EVENT
+      end
     end
   end
 end

--- a/spec/ruby/library/win32ole/win32ole_event/on_event_spec.rb
+++ b/spec/ruby/library/win32ole/win32ole_event/on_event_spec.rb
@@ -1,62 +1,71 @@
-require_relative '../fixtures/classes'
-
 platform_is :windows do
-  require 'win32ole'
+  require_relative '../fixtures/classes'
+  guard -> { WIN32OLESpecs::MSXML_AVAILABLE } do
 
-  def default_handler(event, *args)
-    @event += event
-  end
-
-  def alternate_handler(event, *args)
-    @event2 = "alternate"
-  end
-
-  def handler3(event, *args)
-    @event3 += event
-  end
-
-
-  describe "WIN32OLE_EVENT#on_event with no argument" do
-    before :each do
-      @ie     = WIN32OLESpecs.new_ole('InternetExplorer.Application')
-      @ev     = WIN32OLE_EVENT.new(@ie, 'DWebBrowserEvents')
-      @event  = ''
-      @event2 = ''
-      @event3 = ''
-      @ie.StatusBar = true
+    def handler_global(event, *args)
+      @event_global += event
     end
 
-    after :each do
-      @ie.Quit
+    def handler_specific(*args)
+      @event_specific = "specific"
     end
 
-    it "sets event handler properly, and the handler is invoked by event loop" do
-      @ev.on_event { |*args| default_handler(*args) }
-      @ie.StatusText='hello'
-      WIN32OLE_EVENT.message_loop
-      @event.should =~ /StatusTextChange/
+    def handler_spec_alt(*args)
+      @event_spec_alt = "spec_alt"
     end
 
-    it "accepts a String argument, sets event handler properly, and the handler is invoked by event loop" do
-      @ev.on_event("StatusTextChange") { |*args| @event = 'foo' }
-      @ie.StatusText='hello'
-      WIN32OLE_EVENT.message_loop
-      @event.should =~ /foo/
-    end
+    describe "WIN32OLE_EVENT#on_event" do
+    
+      before :all do
+        @fn_xml = File.absolute_path "../fixtures/event.xml", __dir__
+      end
+    
+      before :each do
+        @xml_dom = WIN32OLESpecs.new_ole 'MSXML.DOMDocument'
+        @xml_dom.async = true
+        @ev = WIN32OLE_EVENT.new @xml_dom
+        @event_global   = ''
+        @event_specific = ''
+        @event_spec_alt = ''
+      end
 
-    it "registers multiple event handlers for the same event" do
-      @ev.on_event("StatusTextChange") { |*args| default_handler(*args) }
-      @ev.on_event("StatusTextChange") { |*args| alternate_handler(*args) }
-      @ie.StatusText= 'hello'
-      WIN32OLE_EVENT.message_loop
-      @event2.should == 'alternate'
-    end
+      after :each do
+        @xml_dom = nil
+        @ev = nil
+      end
 
-    it "accepts a Symbol argument, sets event handler properly, and the handler is invoked by event loop" do
-      @ev.on_event(:StatusTextChange) { |*args| @event = 'foo' }
-      @ie.StatusText='hello'
-      WIN32OLE_EVENT.message_loop
-      @event.should =~ /foo/
+      it "sets global event handler properly, and the handler is invoked by event loop" do
+        @ev.on_event { |*args| handler_global(*args) }
+        @xml_dom.loadXML "<program><name>Ruby</name><version>trunk</version></program>"
+        WIN32OLE_EVENT.message_loop
+        @event_global.should =~ /onreadystatechange/
+      end
+
+      it "accepts a String argument and the handler is invoked by event loop" do
+        @ev.on_event("onreadystatechange") { |*args| @event = 'foo' }
+        @xml_dom.loadXML "<program><name>Ruby</name><version>trunk</version></program>"
+        WIN32OLE_EVENT.message_loop
+        @event.should =~ /foo/
+      end
+
+      it "accepts a Symbol argument and the handler is invoked by event loop" do
+        @ev.on_event(:onreadystatechange) { |*args| @event = 'bar' }
+        @xml_dom.loadXML "<program><name>Ruby</name><version>trunk</version></program>"
+        WIN32OLE_EVENT.message_loop
+        @event.should =~ /bar/
+      end
+
+      it "accepts a specific event handler and overrides a global event handler" do
+        @ev.on_event                       { |*args| handler_global(*args)   }
+        @ev.on_event("onreadystatechange") { |*args| handler_specific(*args) }
+        @ev.on_event("onreadystatechange") { |*args| handler_spec_alt(*args) }
+        @xml_dom.load @fn_xml
+        WIN32OLE_EVENT.message_loop
+        @event_global.should == 'ondataavailable'
+        @event_global.should_not =~ /onreadystatechange/
+        @event_specific.should == ''
+        @event_spec_alt.should == "spec_alt"
+      end
     end
   end
 end


### PR DESCRIPTION
Two commits in PR, both only affect Windows Appveyor builds:

1. change spec win32ole tests from IE to MSXML - Replaces IE OLE object with MSXML.  See [Ruby Issue 15239](https://bugs.ruby-lang.org/issues/15239).  The commit/patch here has been updated for changes that occurred after the issue was posted.  Hence, use this patch, not the issue patch.


2. Update mswin to OpenSSL 1.1.0, mingw to 1.1.1 - Changes mswin/vc builds to use a vc build of OpenSSL 1.1.0i, changes mingw build to use 1.1.1.  See Ruby issues [15171](https://bugs.ruby-lang.org/issues/15171) and [15235](https://bugs.ruby-lang.org/issues/15235).  The commit/patch here is an improved combination of the two.