### PR TITLE
Appveyor - vc120 use OpenSSL 1.0.2, vc140 use 1.1.1

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,9 +15,11 @@ environment:
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
     - build: vs
       vs: 120
+      ssl: OpenSSL
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
     - build: vs
       vs: 140
+      ssl: OpenSSL-v111
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
   RELINE_TEST_ENCODING: "Windows-31J"
   GEMS_FOR_TEST: "timezone tzinfo"
@@ -32,7 +34,7 @@ for:
     - chcp
     - SET BITS=%Platform:x86=32%
     - SET BITS=%BITS:x=%
-    - SET OPENSSL_DIR=c:\OpenSSL-Win%BITS%
+    - SET OPENSSL_DIR=C:\%ssl%-Win%BITS%
     - CALL SET vcvars=%%^VS%VS%COMNTOOLS^%%..\..\VC\vcvarsall.bat
     - SET vcvars
     - '"%vcvars%" %Platform:x64=amd64%'
@@ -65,6 +67,8 @@ for:
     - nmake install-nodoc
     - \usr\bin\ruby -v -e "p :locale => Encoding.find('locale'), :filesystem => Encoding.find('filesystem')"
     - if not "%GEMS_FOR_TEST%" == "" \usr\bin\gem install --no-document %GEMS_FOR_TEST%
+  before_test:
+    - \usr\bin\ruby -ropenssl -e "puts 'Build    ' + OpenSSL::OPENSSL_VERSION, 'Runtime  ' + OpenSSL::OPENSSL_LIBRARY_VERSION"
   test_script:
     - set /a JOBS=%NUMBER_OF_PROCESSORS%
     - nmake -l "TESTOPTS=-v -q" btest
@@ -73,6 +77,7 @@ for:
     # separately execute tests without -j which may crash worker with -j.
     - nmake -l "TESTOPTS=-v --timeout-scale=3.0 --excludes=../test/excludes/_appveyor" test-all TESTS="../test/win32ole ../test/ruby/test_bignum.rb ../test/ruby/test_syntax.rb ../test/open-uri/test_open-uri.rb ../test/rubygems/test_bundled_ca.rb"
     - nmake -l test-spec MSPECOPT=-fs # not using `-j` because sometimes `mspec -j` silently dies on Windows
+
 -
   matrix:
     only:
@@ -110,12 +115,16 @@ for:
     - mingw32-make -j%JOBS% V=1
     - mingw32-make DESTDIR=../install install-nodoc
     - if not "%GEMS_FOR_TEST%" == "" ..\install\bin\gem install --no-document %GEMS_FOR_TEST%
+  before_test:
+    - cd %APPVEYOR_BUILD_FOLDER%
+    - ..\install\bin\ruby.exe -v -ropenssl -e "puts 'Build    ' + OpenSSL::OPENSSL_VERSION, 'Runtime  ' + OpenSSL::OPENSSL_LIBRARY_VERSION"
   test_script:
     - mingw32-make test
     - mingw32-make test-all TESTOPTS="--retry --job-status=normal --show-skip --timeout-scale=1.5 --excludes=../ruby/test/excludes/_appveyor -j %JOBS% --exclude win32ole --exclude test_open-uri"
     # separately execute tests without -j which may crash worker with -j.
     - mingw32-make test-all TESTOPTS="--retry --job-status=normal --show-skip --timeout-scale=1.5 --excludes=../ruby/test/excludes/_appveyor" TESTS="../ruby/test/win32ole ../ruby/test/open-uri/test_open-uri.rb"
     - mingw32-make test-spec MSPECOPT=-fs # not using `-j` because sometimes `mspec -j` silently dies on Windows
+
 notifications:
   # Using "Webhook" with templated body to skip notification on Pull Request
   - provider: Webhook

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -77,7 +77,6 @@ for:
     # separately execute tests without -j which may crash worker with -j.
     - nmake -l "TESTOPTS=-v --timeout-scale=3.0 --excludes=../test/excludes/_appveyor" test-all TESTS="../test/win32ole ../test/ruby/test_bignum.rb ../test/ruby/test_syntax.rb ../test/open-uri/test_open-uri.rb ../test/rubygems/test_bundled_ca.rb"
     - nmake -l test-spec MSPECOPT=-fs # not using `-j` because sometimes `mspec -j` silently dies on Windows
-
 -
   matrix:
     only:
@@ -115,8 +114,6 @@ for:
     - mingw32-make -j%JOBS% V=1
     - mingw32-make DESTDIR=../install install-nodoc
     - if not "%GEMS_FOR_TEST%" == "" ..\install\bin\gem install --no-document %GEMS_FOR_TEST%
-  before_test:
-    - cd %APPVEYOR_BUILD_FOLDER%
     - ..\install\bin\ruby.exe -v -ropenssl -e "puts 'Build    ' + OpenSSL::OPENSSL_VERSION, 'Runtime  ' + OpenSSL::OPENSSL_LIBRARY_VERSION"
   test_script:
     - mingw32-make test
@@ -124,7 +121,6 @@ for:
     # separately execute tests without -j which may crash worker with -j.
     - mingw32-make test-all TESTOPTS="--retry --job-status=normal --show-skip --timeout-scale=1.5 --excludes=../ruby/test/excludes/_appveyor" TESTS="../ruby/test/win32ole ../ruby/test/open-uri/test_open-uri.rb"
     - mingw32-make test-spec MSPECOPT=-fs # not using `-j` because sometimes `mspec -j` silently dies on Windows
-
 notifications:
   # Using "Webhook" with templated body to skip notification on Pull Request
   - provider: Webhook


### PR DESCRIPTION
Windows builds are currently using OpenSSL 1.0.2.  PR updates mswin builds to use 1.1.0, mingw to use 1.1.1.

Notes:
1. A new or fully updated MSYS2 system uses 1.1.1.  To use an older version requires downloading files using a utility other than pacman.
2. Appveyor currently has 1.0.2 & 1.1.0 vc OpenSSL builds installed.  They may add 1.1.1 in a future image update (possibly the next one).
3. PR adds some preventative code to make sure duplicate OpenSSL dll's are not available.
4. Given that Appveyer testing can be intermittent in terms of failures, this has passed in my fork a few times.
5. appveyor.yml is partially set up to change between 32 & 64 bit builds, but currently only runs 64 bit.  The code in this PR is 64 bit specific.  It could be updated to allow script or matrix variables for the bit choice.