### PR TITLE
Fix call-seq of Encoding::Converter#putback

### DIFF
--- a/transcode.c
+++ b/transcode.c
@@ -4084,7 +4084,7 @@ econv_insert_output(VALUE self, VALUE string)
 }
 
 /*
- * call-seq
+ * call-seq:
  *   ec.putback                    -> string
  *   ec.putback(max_numbytes)      -> string
  *


### PR DESCRIPTION
I fixed `call-seq` typo and confirmed the layout problem was fixed on my laptop. 

## before

![2018-10-31 20 35 44](https://user-images.githubusercontent.com/952100/47786312-bcd40800-dd4e-11e8-8c8e-879744bab58d.png)

## after

![2018-10-31 20 36 34](https://user-images.githubusercontent.com/952100/47786316-c3627f80-dd4e-11e8-8af6-54b81a3e0a21.png)
