### PR TITLE
RUBY_EVENT_SPECIFIED_INSN implementation

### DIFF
--- a/include/ruby/ruby.h
+++ b/include/ruby/ruby.h
@@ -2181,6 +2181,7 @@ int ruby_native_thread_p(void);
 #define RUBY_EVENT_THREAD_BEGIN      0x0400
 #define RUBY_EVENT_THREAD_END        0x0800
 #define RUBY_EVENT_FIBER_SWITCH      0x1000
+#define RUBY_EVENT_SPECIFIED_INSN    0x2000
 #define RUBY_EVENT_TRACEPOINT_ALL    0xffff
 
 /* special events */

--- a/iseq.h
+++ b/iseq.h
@@ -169,6 +169,7 @@ VALUE rb_iseq_load(VALUE data, VALUE parent, VALUE opt);
 VALUE rb_iseq_parameters(const rb_iseq_t *iseq, int is_proc);
 struct st_table *ruby_insn_make_insn_table(void);
 unsigned int rb_iseq_line_no(const rb_iseq_t *iseq, size_t pos);
+static VALUE rb_iseqw_insn_trace_specify(VALUE iseqw, VALUE insn_ordinalw, VALUE set);
 void rb_iseq_trace_set(const rb_iseq_t *iseq, rb_event_flag_t turnon_events);
 void rb_iseq_trace_set_all(rb_event_flag_t turnon_events);
 void rb_iseq_trace_on_all(void);

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -3880,6 +3880,12 @@ vm_trace(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, const VALUE *p
 	    EXEC_EVENT_HOOK(ec, RUBY_EVENT_LINE, GET_SELF(), 0, 0, 0, Qundef);
 	    reg_cfp->pc--;
 	}
+	if (events & RUBY_EVENT_SPECIFIED_INSN) {
+            reg_cfp->pc++;
+            vm_dtrace(RUBY_EVENT_SPECIFIED_INSN, ec);
+            EXEC_EVENT_HOOK(ec, RUBY_EVENT_SPECIFIED_INSN, GET_SELF(), 0, 0, 0, Qundef);
+            reg_cfp->pc--;
+        }
 	if (events & RUBY_EVENT_COVERAGE_LINE) {
 	    reg_cfp->pc++;
 	    vm_dtrace(RUBY_EVENT_COVERAGE_LINE, ec);

--- a/vm_trace.c
+++ b/vm_trace.c
@@ -596,6 +596,7 @@ get_event_id(rb_event_flag_t event)
 	C(b_return, B_RETURN);
 	C(thread_begin, THREAD_BEGIN);
 	C(thread_end, THREAD_END);
+	C(specified_insn, SPECIFIED_INSN);
 	C(fiber_switch, FIBER_SWITCH);
 #undef C
       default:
@@ -725,6 +726,7 @@ symbol2event_flag(VALUE v)
     C(b_return, B_RETURN);
     C(thread_begin, THREAD_BEGIN);
     C(thread_end, THREAD_END);
+    C(specified_insn, SPECIFIED_INSN);
     C(fiber_switch, FIBER_SWITCH);
     C(a_call, A_CALL);
     C(a_return, A_RETURN);


### PR DESCRIPTION
To implement a very fast debugger it would be convenient to use something like RUBY_EVENT_SPECIFIED_INSN. It will help to avoid using such trace events like :line, :call, :return in debuggers (using of which have a rather big overhead). So instead of stopping on every line and checking position, it is possible to specify flags for needed instructions in needed iseqs. One can do it using load_iseq function(if breakpoint was added earlier than iseq compilation), or using rb_objspace_each_objects otherwise.

Testing this approach on 2.5.0-ruby showed a pretty good perfomance results (tested on https://bitbucket.org/railstutorial/sample_app_4th_ed specs)
2.240s run
2.427s (new debugger with RUBY_EVENT_SPECIFIED_INSN)
10.584s (https://rubygems.org/gems/ruby-debug-ide/versions/0.6.0)

To set a RUBY_EVENT_SPECIFIED_INSN flag for a specific instruction, you must pass its ordinal number to the insn_trace_specify(rb_iseqw_insn_trace_specify) method.

It is not very clear how to get PC of the instruction by its ordinal number. So the for-loop, which counts this PC can be optimized.

Any feedback will be very helpful)