### PR TITLE
Enumerator fiber yield

### DIFF
--- a/include/ruby/intern.h
+++ b/include/ruby/intern.h
@@ -240,6 +240,7 @@ NORETURN(void rb_cmperr(VALUE, VALUE));
 /* cont.c */
 VALUE rb_fiber_new(VALUE (*)(ANYARGS), VALUE);
 VALUE rb_fiber_resume(VALUE fib, int argc, const VALUE *argv);
+VALUE rb_fiber_transfer(VALUE fib, int argc, const VALUE *argv);
 VALUE rb_fiber_yield(int argc, const VALUE *argv);
 VALUE rb_fiber_current(void);
 VALUE rb_fiber_alive_p(VALUE);

--- a/test/ruby/test_enumerator.rb
+++ b/test/ruby/test_enumerator.rb
@@ -697,6 +697,21 @@ class TestEnumerator < Test::Unit::TestCase
     assert_equal([0, 1], u.force)
   end
 
+  def test_fiber
+    e = Enumerator.new do |y|
+      Fiber.yield 10
+      y << 20
+    end
+
+    f = Fiber.new do
+      Fiber.yield e.next
+    end
+
+    assert_equal(10, f.resume)
+    assert_equal(20, f.resume)
+  end
+end
+
   def test_enum_chain_and_plus
     r = 1..5
 


### PR DESCRIPTION
This makes it so that it is possible to call `Fiber.yield` within a Enumerator block.

This is breaking `async` when non-blocking IO is used in an Enumerator: https://github.com/socketry/async/issues/23

I'm not sure if this is the best solution, but it feels like the right approach.

The general idea is that user should not worry about how Enumerator is implemented, `Fiber.yield` should work as expected.