### PR TITLE
README.md simplified

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,8 @@
 # What's Ruby
 
 Ruby is the interpreted scripting language for quick and easy object-oriented
-programming. It has many features to process text files and to do system
-management tasks (as in Perl). It is simple, straight-forward, and
-extensible.
+programming. It has many features to process text files and to manage system (as in Perl). 
+It is simple, straight-forward, and extensible.
 
 ## Features of Ruby
 
@@ -51,13 +50,11 @@ Or if you are using git then use the following command:
 
 ## Ruby home page
 
-The URL of the Ruby home page is:
-
 https://www.ruby-lang.org/
 
 ## Mailing list
 
-There is a mailing list to talk about Ruby. To subscribe to this list, please
+There is a mailing list to discuss Ruby. To subscribe to this list, please
 send the following phrase:
 
     subscribe
@@ -66,8 +63,6 @@ in the mail body (not subject) to the address
 <ruby-talk-request@ruby-lang.org>.
 
 ## How to compile and install
-
-This is what you need to do to compile and install Ruby:
 
 1.  If you want to use Microsoft Visual C++ to compile Ruby, read
     [win32/README.win32](win32/README.win32) instead of this document.
@@ -155,7 +150,7 @@ Questions about the Ruby language can be asked on the Ruby-Talk mailing list
 (https://www.ruby-lang.org/en/community/mailing-lists) or on websites like
 (https://stackoverflow.com).
 
-Bug reports should be filed at https://bugs.ruby-lang.org. Read [HowToReport] for more information.
+Bugs should be reported at https://bugs.ruby-lang.org. Read [HowToReport] for more information.
 
 [HowToReport]: https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport
 


### PR DESCRIPTION
- "do system management tasks" -> "manage the system"
- "talk about" -> "discuss"
- "The URL of the Ruby home page is:" and "This is what you need to do to compile and install Ruby:" are removed because of redundancy.
- "Bugs reports should be filed" -> "Bugs should be reported"