### PR TITLE
Introduce a cold function attribute and apply to rb_memerror, rb_warn and rb_bug

### DIFF
--- a/include/ruby/defines.h
+++ b/include/ruby/defines.h
@@ -89,6 +89,16 @@ extern "C" {
 #define RB_UNLIKELY(x) (x)
 #endif /* __GNUC__ >= 3 */
 
+/*
+  cold attribute for code layout improvements
+  RUBY_FUNC_ATTRIBUTE not used because MSVC does not like nested func macros
+ */
+#if defined(__clang__) || GCC_VERSION_SINCE(4, 3, 0)
+#define COLDFUNC __attribute__((cold))
+#else
+#define COLDFUNC
+#endif
+
 #ifdef __GNUC__
 #if defined __MINGW_PRINTF_FORMAT
 #define PRINTF_ARGS(decl, string_index, first_to_check) \

--- a/include/ruby/intern.h
+++ b/include/ruby/intern.h
@@ -479,7 +479,7 @@ VALUE rb_file_directory_p(VALUE,VALUE);
 VALUE rb_str_encode_ospath(VALUE);
 int rb_is_absolute_path(const char *);
 /* gc.c */
-NORETURN(void rb_memerror(void));
+COLDFUNC NORETURN(void rb_memerror(void));
 PUREFUNC(int rb_during_gc(void));
 void rb_gc_mark_locations(const VALUE*, const VALUE*);
 void rb_mark_tbl(struct st_table*);

--- a/include/ruby/ruby.h
+++ b/include/ruby/ruby.h
@@ -1901,7 +1901,7 @@ enum rb_io_wait_readwrite {RB_IO_WAIT_READABLE, RB_IO_WAIT_WRITABLE};
 
 PRINTF_ARGS(NORETURN(void rb_raise(VALUE, const char*, ...)), 2, 3);
 PRINTF_ARGS(NORETURN(void rb_fatal(const char*, ...)), 1, 2);
-PRINTF_ARGS(NORETURN(void rb_bug(const char*, ...)), 1, 2);
+COLDFUNC PRINTF_ARGS(NORETURN(void rb_bug(const char*, ...)), 1, 2);
 NORETURN(void rb_bug_errno(const char*, int));
 NORETURN(void rb_sys_fail(const char*));
 NORETURN(void rb_sys_fail_str(VALUE));
@@ -1925,7 +1925,7 @@ PRINTF_ARGS(void rb_warning(const char*, ...), 1, 2);
 PRINTF_ARGS(void rb_compile_warning(const char *, int, const char*, ...), 3, 4);
 PRINTF_ARGS(void rb_sys_warning(const char*, ...), 1, 2);
 /* reports always */
-PRINTF_ARGS(void rb_warn(const char*, ...), 1, 2);
+COLDFUNC PRINTF_ARGS(void rb_warn(const char*, ...), 1, 2);
 PRINTF_ARGS(void rb_compile_warn(const char *, int, const char*, ...), 3, 4);
 
 #define RUBY_BLOCK_CALL_FUNC_TAKES_BLOCKARG 1


### PR DESCRIPTION
A continuation (toned down scope) of https://bugs.ruby-lang.org/issues/15007 , specifically https://bugs.ruby-lang.org/issues/15007#note-17

The GCC specific [cold](https://gcc.gnu.org/onlinedocs/gcc-4.6.4/gcc/Function-Attributes.html) function attribute works in the following way (from GCC docs):

```
The cold attribute is used to inform the compiler that a function is unlikely executed. The function is optimized for size rather than speed and on many targets it is placed into special subsection of the text section so all cold functions appears close together improving code locality of non-cold parts of program. The paths leading to call of cold functions within code are marked as unlikely by the branch prediction mechanism. It is thus useful to mark functions used to handle unlikely conditions, such as perror, as cold to improve optimization of hot functions that do call marked functions in rare occasions.
When profile feedback is available, via -fprofile-use, hot functions are automatically detected and this attribute is ignored.
```

Note that any code generated cannot directly control or instruct the CPU about which branches to take - it's only a hint for the compiler to correctly optimize the branch by knowing which is the unlikely (cold) one. The CPU's branch predictor mechanism may however override.

Therefor I focused investigation here on 3 facets of cold attributes across 2 compilers, `gcc` and `clang`. MSVC does not seem to support a cold attribute feature according to my investigation and thus was not evaluated here.

##### code layout

* Code size reduction of cold functions: a size reduction present with both `gcc` and `clang`
* Code size reduction of the `text` segment: reduced by 'gcc' and an explicit relocation to the `text.unlikely` segment. `clang` seem to increase the text segment size and also appears to not relocate to a distinct DWARF section 

##### branch optimization 

* The branch optimization feature references semantics of the `LIKELY` / `UNLIKELY` (`__builtin_expect`) macros but does not require explicit tagging of branches. The compiler may choose to flag a branch at a callsite as unlikely automatically
* Reorganization of instructions could be validated with both `gcc` and `clang`, specifically `jmp`, `jne` and `jn` instructions.

##### less instruction cache pollution and performance improvements

* This changeset's primary objective is to introduce the ability to flag certain known rare code paths as unlikely and the initial set of 3 functions would not have a strong measurable effect on VM performance or the ITLB
* Therefore I focused benchmarks on branch prediction events at runtime which was measurable
* No negative performance impact, especially for `vm_exec_core` and other hot paths that do have branches to the cold 3 cold functions flagged in this changeset

I also chose to use tools readily available on most linux systems to make it easier to reproduce in another environment for review and being verbose allows for pointing out  (excuse the pun) taking wrong branches in evaluating the impact of this feature :smile: 

## GCC 7 build

Build environment (`CFLAGS='-g -O3'`):

```
lourens@CarbonX1:~/src/ruby/ruby$ gcc --version
gcc (Ubuntu 7.3.0-27ubuntu1~18.04) 7.3.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

#### relocation to cold section in error.o and gc.o

```
lourens@CarbonX1:~/src/ruby/ruby$ ld -M error.o
.....
.text           0x0000000000400120     0x95b9
 *(.text.unlikely .text.*_unlikely .text.unlikely.*)
 .text.unlikely
                0x0000000000400120      0x275 error.o
                0x0000000000400120                rb_warn <<<<<<<<<<
                0x00000000004002a7                rb_bug   <<<<<<<<<<
 *(.text.exit .text.exit.*)
 *(.text.startup .text.startup.*)
 *(.text.hot .text.hot.*)
 *(.text .stub .text.* .gnu.linkonce.t.*)
 *fill*         0x0000000000400395        0xb 
 .text          0x00000000004003a0     0x9339 error.o
```

```
lourens@CarbonX1:~/src/ruby/ruby$ readelf -S error.o
There are 32 section headers, starting at offset 0x948f8:

Section Headers:
  [Nr] Name              Type             Address           Offset
       Size              EntSize          Flags  Link  Info  Align
  [ 0]                   NULL             0000000000000000  00000000
       0000000000000000  0000000000000000           0     0     0
  [ 1] .text             PROGBITS         0000000000000000  00000040
       0000000000009339  0000000000000000  AX       0     0     16
  [ 2] .rela.text        RELA             0000000000000000  0003f598
       000000000000de78  0000000000000018   I      29     1     8
  [ 3] .data             PROGBITS         0000000000000000  00009379
       0000000000000000  0000000000000000  WA       0     0     1
  [ 4] .bss              NOBITS           0000000000000000  00009380
       00000000000010d8  0000000000000000  WA       0     0     32
  [ 5] .rodata.str1.1    PROGBITS         0000000000000000  00009380
       000000000000097b  0000000000000001 AMS       0     0     1
  [ 6] .rodata.str1.8    PROGBITS         0000000000000000  00009d00
       000000000000023f  0000000000000001 AMS       0     0     8
  [ 7] .text.unlikely    PROGBITS         0000000000000000  00009f3f
       0000000000000275  0000000000000000  AX       0     0     1
  [ 8] .rela.text.unlike RELA             0000000000000000  0004d410
       0000000000000240  0000000000000018   I      29     7     8
.....
```

```
lourens@CarbonX1:~/src/ruby/ruby$ ld -M gc.o
.....
.text           0x0000000000400120    0x104e1
 *(.text.unlikely .text.*_unlikely .text.unlikely.*)
 .text.unlikely
                0x0000000000400120      0x124 gc.o
                0x00000000004001b7                rb_memerror <<<<<<<<<<
 *(.text.exit .text.exit.*)
 *(.text.startup .text.startup.*)
 *(.text.hot .text.hot.*)
 *(.text .stub .text.* .gnu.linkonce.t.*)
 *fill*         0x0000000000400244        0xc 
 .text          0x0000000000400250    0x103b1 gc.o
.....
```

```
lourens@CarbonX1:~/src/ruby/ruby$ readelf -S gc.o
There are 35 section headers, starting at offset 0x130770:

Section Headers:
  [Nr] Name              Type             Address           Offset
       Size              EntSize          Flags  Link  Info  Align
  [ 0]                   NULL             0000000000000000  00000000
       0000000000000000  0000000000000000           0     0     0
  [ 1] .text             PROGBITS         0000000000000000  00000040
       00000000000103b1  0000000000000000  AX       0     0     16
  [ 2] .rela.text        RELA             0000000000000000  00081620
       000000000000b580  0000000000000018   I      32     1     8
  [ 3] .data             PROGBITS         0000000000000000  00010400
       0000000000000098  0000000000000000  WA       0     0     32
  [ 4] .bss              NOBITS           0000000000000000  000104a0
       0000000000000df0  0000000000000000  WA       0     0     32
  [ 5] .rodata.str1.1    PROGBITS         0000000000000000  000104a0
       0000000000000bb2  0000000000000001 AMS       0     0     1
  [ 6] .rodata           PROGBITS         0000000000000000  00011054
       00000000000003a0  0000000000000000   A       0     0     4
  [ 7] .rela.rodata      RELA             0000000000000000  0008cba0
       00000000000015c0  0000000000000018   I      32     6     8
  [ 8] .rodata.str1.8    PROGBITS         0000000000000000  000113f8
       0000000000000c7b  0000000000000001 AMS       0     0     8
  [ 9] .text.unlikely    PROGBITS         0000000000000000  00012073
       0000000000000124  0000000000000000  AX       0     0     1
  [10] .rela.text.unlike RELA             0000000000000000  0008e160
       0000000000000210  0000000000000018   I      32     9     8
.....
```

#### code layout improvements

Small 360 byte difference of the text segment size:

```
lourens@CarbonX1:~/src/ruby/ruby$ size ruby
   text	   data	    bss	    dec	    hex	filename
3577351	  21224	  72944	3671519	 3805df	ruby
```

```
lourens@CarbonX1:~/src/ruby/trunk$ size ruby
   text	   data	    bss	    dec	    hex	filename
3577711	  21224	  72944	3671879	 380747	ruby
lourens@CarbonX1:~/src/ruby/trunk$ irb
irb(main):001:0> 3577711 - 3577351
=> 360
irb(main):002:0> 
```

Proof of size optimizations of the individual functions:

```
lourens@CarbonX1:~/src/ruby/trunk$ nm -S --size-sort -t d ./ruby | grep rb_warn$
0000000002594032 0000000000000406 T rb_warn
lourens@CarbonX1:~/src/ruby/ruby$ nm -S --size-sort -t d ./ruby | grep rb_warn$
0000000000152748 0000000000000391 T rb_warn
```

```
lourens@CarbonX1:~/src/ruby/trunk$ nm -S --size-sort -t d ./ruby | grep rb_bug$
0000000002595696 0000000000000240 T rb_bug
lourens@CarbonX1:~/src/ruby/ruby$ nm -S --size-sort -t d ./ruby | grep rb_bug$
0000000000153139 0000000000000238 T rb_bug
```

```
lourens@CarbonX1:~/src/ruby/trunk$ nm -S --size-sort -t d ./ruby | grep rb_memerror$
0000000000263440 0000000000000166 T rb_memerror
lourens@CarbonX1:~/src/ruby/ruby$ nm -S --size-sort -t d ./ruby | grep rb_memerror$
0000000000147285 0000000000000141 T rb_memerror
```

And `vm_exec_core` : 

```
lourens@CarbonX1:~/src/ruby/trunk$ nm -S --size-sort -t d ./ruby | grep vm_exec_core$
0000000001936992 0000000000027057 t vm_exec_core
lourens@CarbonX1:~/src/ruby/ruby$ nm -S --size-sort -t d ./ruby | grep vm_exec_core$
0000000001937168 0000000000027044 t vm_exec_core
```

#### generated code improvements

Generally applicable to `-O2` and higher - reduction in `jmp` instructions in `vm_exec_core`:

```
lourens@CarbonX1:~/src/ruby/trunk$ gdb -batch -ex 'file ./ruby' -ex 'disassemble vm_exec_core' | grep jmp | wc -l
368
lourens@CarbonX1:~/src/ruby/ruby$ gdb -batch -ex 'file ./ruby' -ex 'disassemble vm_exec_core' | grep jmp | wc -l
364
```

#### VM benchmarks (focused on branches to begin with)

Version `65790`

```
lourens@CarbonX1:~/src/optcarrot$ ~/src/ruby/trunk/ruby -v
ruby 2.6.0dev (2018-11-18 trunk 65790) [x86_64-linux]
lourens@CarbonX1:~/src/optcarrot$ ~/src/ruby/ruby/ruby -v
ruby 2.6.0dev (2018-11-18 cold-attr 65790) [x86_64-linux]
last_commit=Introduce a cold function attribute and apply to rb_memerror, rb_warn and rb_bug
````

Branch misses (`10000` frames, runs a few minutes, only good way I could think of to instrument a long running single optcarrot process - suggestions welcome)

```
lourens@CarbonX1:~/src/optcarrot$ sudo perf record -e branch-misses ~/src/ruby/trunk/ruby -I~/src/ruby/trunk/lib -I~/src/ruby/trunk/. -I~/src/ruby/trunk/.ext/x86_64-linux -r./tools/shim.rb bin/optcarrot --benchmark --frames 10000 examples/Lan_Master.nes
[sudo] password for lourens: 
fps: 38.144510954524165
checksum: 60838
[ perf record: Woken up 132 times to write data ]
[ perf record: Captured and wrote 33.236 MB perf.data (870698 samples) ]
lourens@CarbonX1:~/src/optcarrot$ sudo perf record -e branch-misses ~/src/ruby/ruby/ruby -I~/src/ruby/ruby/lib -I~/src/ruby/ruby/. -I~/src/ruby/ruby/.ext/x86_64-linux -r./tools/shim.rb bin/optcarrot --benchmark --frames 10000 examples/Lan_Master.nes
fps: 34.145352821306524
checksum: 60838
[ perf record: Woken up 143 times to write data ]
[ perf record: Captured and wrote 35.701 MB perf.data (935306 samples) ]
```

Output of `perf diff` - delta (specifically  `vm_exec_core`, `baseline` is trunk, computed delta is this branch):

```
# Event 'branch-misses'
#
# Baseline  Delta Abs  Shared Object       Symbol                                              
# ........  .........  ..................  ....................................................
#
     0.21%     +1.76%  ruby                [.] vm_call_iseq_setup_normal_0start_1params_1locals
     3.40%     -1.32%  ruby                [.] vm_call_iseq_setup_normal_0start_0params_0locals
     1.37%     -0.61%  ruby                [.] opt_eq_func
     0.38%     +0.24%  ruby                [.] rb_gc_writebarrier
     1.65%     -0.23%  ruby                [.] rb_class_of
     0.91%     +0.13%  ruby                [.] vm_call_iseq_setup_normal_0start_0params_2locals
     0.07%     +0.07%  ruby                [.] vm_call_iseq_setup_normal_0start_0params_1locals
     0.16%     +0.06%  ruby                [.] rb_gc_writebarrier_unprotect
     0.11%     -0.03%  ruby                [.] vm_search_method.isra.358
     0.23%     -0.03%  ruby                [.] vm_call_cfunc
     0.04%     -0.02%  ruby                [.] int_xor
     0.03%     -0.02%  ruby                [.] rb_vm_exec
     0.05%     -0.02%  ruby                [.] num_step
     0.17%     +0.02%  ruby                [.] rb_obj_written.isra.298.part.299
    90.19%     -0.01%  ruby                [.] vm_exec_core <<<<<<<<<<
     0.02%     +0.01%  ruby                [.] vm_call_ivar
     0.01%     +0.01%  ruby                [.] rb_check_convert_type_with_id
     0.03%     -0.01%  ruby                [.] rb_ary_rotate_bang
     0.17%     +0.01%  ruby                [.] invoke_block.isra.384
     0.04%     +0.01%  ruby                [.] vm_call_iseq_setup
     0.01%     -0.01%  ruby                [.] call_cfunc_m1
     0.01%     +0.01%  ruby                [.] vm_call_iseq_setup_normal_0start_1params_3locals
     0.02%     -0.01%  ruby                [.] rb_ary_aset
     0.08%     -0.01%  ruby                [.] rb_ary_splice
     0.01%     -0.01%  ruby                [.] vm_opt_length.part.335
     0.00%     +0.01%  ruby                [.] ruby_xrealloc2
     0.02%     -0.01%  ruby                [.] vm_call_iseq_setup_normal_0start_0params_3locals
     0.01%     +0.00%  ruby                [.] rb_int_lshift
     0.01%     +0.00%  libc-2.27.so        [.] __memmove_avx_unaligned_erms
     0.07%     +0.00%  ruby                [.] vm_caller_setup_arg_splat.isra.346
     0.01%     -0.00%  ruby                [.] rb_ary_modify.part.26
     0.01%     +0.00%  ruby                [.] vm_call_method
     0.01%     -0.00%  ruby                [.] rb_ary_modify
     0.01%     -0.00%  ruby                [.] rb_int_uminus
     0.07%     -0.00%  ruby                [.] vm_call_iseq_setup_normal_0start_0params_4locals
     0.01%     -0.00%  ruby                [.] int_even_p
     0.00%     +0.00%  ruby                [.] rb_yield
     0.00%     -0.00%  ruby                [.] rb_ary_modify_check
     0.02%     -0.00%  ruby                [.] st_lookup
     0.01%     -0.00%  ruby                [.] call_cfunc_1
     0.00%     +0.00%  ruby                [.] iseq_peephole_optimize
     0.00%     +0.00%  ruby                [.] exec_recursive
     0.01%     -0.00%  ruby                [.] int_aref
     0.01%     +0.00%  ruby                [.] method_entry_get
     0.10%     -0.00%  ruby                [.] vm_call_opt_send
     0.00%     -0.00%  ruby                [.] rb_iseq_mark
     0.01%     -0.00%  ruby                [.] iseq_setup
     0.00%     -0.00%  libc-2.27.so        [.] _int_realloc
     0.00%     +0.00%  ruby                [.] vm_call_iseq_setup_normal_0start_1params_2locals
     0.01%     -0.00%  [kernel.kallsyms]   [k] native_apic_msr_eoi_write
     0.01%     +0.00%  ruby                [.] ary_ensure_room_for_push
     0.00%     +0.00%  ruby                [.] rb_block_given_p
     0.00%     +0.00%  ruby                [.] vm_call0_body.constprop.402
               +0.00%  ruby                [.] rb_hash_delete_entry
     0.00%     +0.00%  ruby                [.] vm_yield_setup_args
     0.01%     +0.00%  ruby                [.] vm_call_iseq_setup_normal_0start_2params_2locals
     0.00%     +0.00%  [kernel.kallsyms]   [k] intel_pmu_disable_all
```

## clang 6 build

Opted for version 6 as it's still the mainline version in ubuntu and debian repos.

As per https://clang.llvm.org/docs/LanguageExtensions.html#non-standard-c-11-attributes :

```
Clang supports GCC’s gnu attribute namespace. All GCC attributes which are accepted with the __attribute__((foo)) syntax are also accepted as [[gnu::foo]]. This only extends to attributes which are specified by GCC (see the list of GCC function attributes, GCC variable attributes, and GCC type attributes). As with the GCC implementation, these attributes must appertain to the declarator-id in a declaration, which means they must go either at the start of the declaration or immediately after the name being declared.
```

Also related:

* [compat with GCC, not documented in clang]( https://github.com/llvm-mirror/clang/blob/4e6ca6e082c6b292a3492a70986d070b8f0673b0/include/clang/Basic/Attr.td#L836-L840) 
* [semantics test](https://github.com/llvm-mirror/clang/blob/915cb4dbc21080a91a9a6277c2bc81c2c6f79d09/test/Sema/attr-coldhot.c)

Build environment (`CFLAGS='-g -O3'`):

```
lourens@CarbonX1:~/src/ruby/ruby$ clang --version
clang version 6.0.0-1ubuntu2 (tags/RELEASE_600/final)
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
```

#### relocation to cold section in error.o and gc.o

Not able to infer any entries in the `text.unlikely` section, however the size of the `text` segment is actually larger. Also not seeing any clang specific linker that ships with the [clang package](https://packages.ubuntu.com/bionic/amd64/clang/filelist) on my platform.

Interesting that the size of the text section increased by 736 bytes:

```
lourens@CarbonX1:~/src/ruby/trunk$ size ruby
   text	   data	    bss	    dec	    hex	filename
3254510	  22700	  72528	3349738	 331cea	ruby
```

```
lourens@CarbonX1:~/src/ruby/trunk$ size ruby
   text	   data	    bss	    dec	    hex	filename
3254510	  22700	  72528	3349738	 331cea	ruby
lourens@CarbonX1:~/src/ruby/trunk$ irb
irb(main):001:0> 3254510 - 3255246
=> -736
```

Proof of size optimizations of the individual functions:

```
lourens@CarbonX1:~/src/ruby/trunk$ nm -S --size-sort -t d ./ruby | grep rb_warn$
0000000002357856 0000000000000276 T rb_warn
lourens@CarbonX1:~/src/ruby/ruby$ nm -S --size-sort -t d ./ruby | grep rb_warn$
0000000002358390 0000000000000272 T rb_warn
```

```
lourens@CarbonX1:~/src/ruby/trunk$ nm -S --size-sort -t d ./ruby | grep rb_memerror$
0000000000236736 0000000000000288 T rb_memerror
lourens@CarbonX1:~/src/ruby/ruby$ nm -S --size-sort -t d ./ruby | grep rb_memerror$
0000000000236565 0000000000000279 T rb_memerror
```

```
lourens@CarbonX1:~/src/ruby/trunk$ nm -S --size-sort -t d ./ruby | grep rb_bug$
0000000002359024 0000000000000555 T rb_bug
lourens@CarbonX1:~/src/ruby/ruby$ nm -S --size-sort -t d ./ruby | grep rb_bug$
0000000002359541 0000000000000225 T rb_bug
```

#### effect on generated code

Generally applicable to `-O2` and higher - interesting an increase in `jmp` instructions in `vm_exec_core`:

```
lourens@CarbonX1:~/src/ruby/trunk$ gdb -batch -ex 'file ./ruby' -ex 'disassemble vm_exec_core' | grep jmp | wc -l
435
lourens@CarbonX1:~/src/ruby/ruby$ gdb -batch -ex 'file ./ruby' -ex 'disassemble vm_exec_core' | grep jmp | wc -l
439
```

And decrease in `jne` instructions:

```
lourens@CarbonX1:~/src/ruby/trunk$ gdb -batch -ex 'file ./ruby' -ex 'disassemble vm_exec_core' | grep jne | wc -l
583
lourens@CarbonX1:~/src/ruby/ruby$ gdb -batch -ex 'file ./ruby' -ex 'disassemble vm_exec_core' | grep jne | wc -l
581
```

And increase in `je` instructions:

```
lourens@CarbonX1:~/src/ruby/trunk$ gdb -batch -ex 'file ./ruby' -ex 'disassemble vm_exec_core' | grep je | wc -l
485
lourens@CarbonX1:~/src/ruby/ruby$ gdb -batch -ex 'file ./ruby' -ex 'disassemble vm_exec_core' | grep je | wc -l
487
```

Code size of `vm_exec_core` also slightly larger:

```
lourens@CarbonX1:~/src/ruby/trunk$ nm -S --size-sort -t d ./ruby | grep vm_exec_core$
0000000001651616 0000000000033086 t vm_exec_core
lourens@CarbonX1:~/src/ruby/ruby$ nm -S --size-sort -t d ./ruby | grep vm_exec_core$
0000000001651888 0000000000033102 t vm_exec_core
```

#### VM benchmarks

As with the gcc benches, focused on branches as a first pass and also shows a reduction in misses for `vm_exec_core`

```
lourens@CarbonX1:~/src/optcarrot$ sudo perf record -e branch-misses ~/src/ruby/trunk/ruby -I~/src/ruby/trunk/lib -I~/src/ruby/trunk/. -I~/src/ruby/trunk/.ext/x86_64-linux -r./tools/shim.rb bin/optcarrot --benchmark --frames 10000 examples/Lan_Master.nes
[sudo] password for lourens: 
fps: 44.863383592136934
checksum: 60838
[ perf record: Woken up 143 times to write data ]
[ perf record: Captured and wrote 35.712 MB perf.data (935582 samples) ]
lourens@CarbonX1:~/src/optcarrot$ sudo perf record -e branch-misses ~/src/ruby/ruby/ruby -I~/src/ruby/ruby/lib -I~/src/ruby/ruby/. -I~/src/ruby/ruby/.ext/x86_64-linux -r./tools/shim.rb bin/optcarrot --benchmark --frames 10000 examples/Lan_Master.nes
fps: 45.547631010110834
checksum: 60838
[ perf record: Woken up 143 times to write data ]
[ perf record: Captured and wrote 35.523 MB perf.data (929708 samples) ]
```

Output of `perf diff` - delta (specifically  `vm_exec_core`, `baseline` is trunk, computed delta is this branch):

```
# Event 'branch-misses'
#
# Baseline  Delta Abs  Shared Object       Symbol                                              
# ........  .........  ..................  ....................................................
#
     1.40%     +0.86%  ruby                [.] vm_call_iseq_setup_normal_0start_0params_0locals
    86.92%     -0.86%  ruby                [.] vm_exec_core <<<<<<<<<<
     0.68%     -0.62%  ruby                [.] vm_call_iseq_setup_normal_0start_1params_1locals
     0.97%     +0.38%  ruby                [.] vm_call_iseq_setup_normal_0start_0params_2locals
     2.19%     +0.28%  ruby                [.] vm_call_opt_send
     0.33%     -0.17%  ruby                [.] opt_eq_func
     6.04%     +0.17%  ruby                [.] vm_setivar
     0.08%     -0.06%  ruby                [.] int_xor
     0.06%     +0.06%  ruby                [.] vm_call_iseq_setup_normal_0start_0params_1locals
     0.25%     -0.03%  ruby                [.] vm_call_cfunc
     0.30%     -0.02%  ruby                [.] rb_vm_exec
     0.03%     -0.02%  ruby                [.] vm_caller_setup_arg_block
     0.00%     +0.01%  ruby                [.] vm_call_iseq_setup_normal_0start_0params_4locals
     0.01%     -0.01%  ruby                [.] rb_check_id
     0.02%     +0.01%  ruby                [.] rb_ary_rotate
     0.02%     +0.01%  ruby                [.] vm_call_ivar
     0.00%     +0.01%  ruby                [.] method_entry_get
     0.02%     -0.01%  ruby                [.] rb_gc_writebarrier_unprotect
     0.00%     +0.01%  ruby                [.] rb_gc_writebarrier
     0.02%     -0.01%  ruby                [.] rb_int_lshift
     0.12%     -0.00%  ruby                [.] invoke_block_from_c_bh
     0.00%     +0.00%  ruby                [.] ary_resize_capa
     0.01%     -0.00%  ruby                [.] call_cfunc_1
     0.04%     +0.00%  ruby                [.] vm_call_iseq_setup
     0.00%     +0.00%  libc-2.27.so        [.] _int_free
     0.10%     +0.00%  ruby                [.] num_step
     0.01%     -0.00%  ruby                [.] rb_ary_modify
     0.01%     -0.00%  ruby                [.] ruby_yyparse
     0.01%     +0.00%  ruby                [.] rb_ary_rotate_bang
```