### PR TITLE
Use friendlier terminology in rubysocket.h

### DIFF
--- a/ext/socket/rubysocket.h
+++ b/ext/socket/rubysocket.h
@@ -408,7 +408,7 @@ NORETURN(void rsock_sys_fail_raddrinfo_or_sockaddr(const char *, VALUE addr, VAL
  * all cases.  For some syscalls (e.g. accept/accept4), blocking on the
  * syscall instead of relying on select/poll allows the kernel to use
  * "wake-one" behavior and avoid the thundering herd problem.
- * This is likely safe on all other *nix-like systems, so this whitelist
+ * This is likely safe on all other *nix-like systems, so this safelist
  * can be expanded by interested parties.
  */
 #if defined(__linux__)


### PR DESCRIPTION
This Pull Request updates the socket header file.

Allowlist is easier to understand and better terminology.

[Original motivation](https://github.com/rails/rails/issues/33677), community efforts examples:

- https://github.com/rails/rails/pull/33681
- https://github.com/graphiti-api/graphiti/pull/10
- https://github.com/rails/rails/pull/33718
- https://github.com/ruby/psych/pull/378
- https://github.com/ruby/ruby/pull/2009
- https://github.com/rubocop-hq/rubocop/pull/6464
- https://github.com/rubygems/rubygems/pull/2463
- https://github.com/dtao/safe_yaml/pull/93
- https://github.com/rubygems/rubygems/pull/2463
- https://github.com/rack/rack/pull/1314
- https://github.com/rubocop-hq/rubocop/pull/6464
- https://github.com/rubocop-hq/rubocop/pull/6466
- https://github.com/rubocop-hq/rubocop/pull/6467
- https://github.com/rspec/rspec-core/pull/2576
- https://github.com/rspec/rspec-expectations/pull/1083
- https://github.com/rspec/rspec-mocks/pull/1246
- https://github.com/rspec/rspec-support/pull/356
- https://github.com/flavorjones/loofah/pull/158
- https://github.com/pry/pry/pull/1874
- https://github.com/pry/pry/pull/1875