### PR TITLE
parser: improve error messages

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -776,55 +776,55 @@ static void token_info_warn(struct parser_params *p, const char *token, token_in
 }
 
 %token <id>
-	keyword_class
-	keyword_module
-	keyword_def
-	keyword_undef
-	keyword_begin
-	keyword_rescue
-	keyword_ensure
-	keyword_end
-	keyword_if
-	keyword_unless
-	keyword_then
-	keyword_elsif
-	keyword_else
-	keyword_case
-	keyword_when
-	keyword_while
-	keyword_until
-	keyword_for
-	keyword_break
-	keyword_next
-	keyword_redo
-	keyword_retry
-	keyword_in
-	keyword_do
-	keyword_do_cond
-	keyword_do_block
-	keyword_do_LAMBDA
-	keyword_return
-	keyword_yield
-	keyword_super
-	keyword_self
-	keyword_nil
-	keyword_true
-	keyword_false
-	keyword_and
-	keyword_or
-	keyword_not
-	modifier_if
-	modifier_unless
-	modifier_while
-	modifier_until
-	modifier_rescue
-	keyword_alias
-	keyword_defined
-	keyword_BEGIN
-	keyword_END
-	keyword__LINE__
-	keyword__FILE__
-	keyword__ENCODING__
+        keyword_class      "class"
+        keyword_module     "module"
+        keyword_def        "def"
+        keyword_undef      "undef"
+        keyword_begin      "begin"
+        keyword_rescue     "rescue"
+        keyword_ensure     "ensure"
+        keyword_end        "end"
+        keyword_if         "if"
+        keyword_unless     "unless"
+        keyword_then       "then"
+        keyword_elsif      "elsif"
+        keyword_else       "else"
+        keyword_case       "case"
+        keyword_when       "when"
+        keyword_while      "while"
+        keyword_until      "until"
+        keyword_for        "for"
+        keyword_break      "break"
+        keyword_next       "next"
+        keyword_redo       "redo"
+        keyword_retry      "retry"
+        keyword_in         "in"
+        keyword_do         "do"
+        keyword_do_cond    "do (for condition)"
+        keyword_do_block   "do (for block)"
+        keyword_do_LAMBDA  "do (for lambda)"
+        keyword_return     "return"
+        keyword_yield      "yield"
+        keyword_super      "super"
+        keyword_self       "self"
+        keyword_nil        "nil"
+        keyword_true       "true"
+        keyword_false      "false"
+        keyword_and        "and"
+        keyword_or         "or"
+        keyword_not        "not"
+        modifier_if        "if (modifier)"
+        modifier_unless    "unless (modifier)"
+        modifier_while     "while (modifier)"
+        modifier_until     "until (modifier)"
+        modifier_rescue    "rescue (modifier)"
+        keyword_alias      "alias"
+        keyword_defined    "defined"
+        keyword_BEGIN      "BEGIN"
+        keyword_END        "END"
+        keyword__LINE__      "__LINE__"
+        keyword__FILE__      "__FILE__"
+        keyword__ENCODING__  "__ENCODING__"
 
 %token <id>   tIDENTIFIER tFID tGVAR tIVAR tCONSTANT tCVAR tLABEL
 %token <node> tINTEGER tFLOAT tRATIONAL tIMAGINARY tSTRING_CONTENT tCHAR

--- a/parse.y
+++ b/parse.y
@@ -819,7 +819,7 @@ static void token_info_warn(struct parser_params *p, const char *token, token_in
         modifier_until     "until (modifier)"
         modifier_rescue    "rescue (modifier)"
         keyword_alias      "alias"
-        keyword_defined    "defined"
+        keyword_defined    "defined?"
         keyword_BEGIN      "BEGIN"
         keyword_END        "END"
         keyword__LINE__      "__LINE__"

--- a/test/ruby/test_ast.rb
+++ b/test/ruby/test_ast.rb
@@ -155,7 +155,7 @@ class TestAst < Test::Unit::TestCase
   end
 
   def test_parse_raises_syntax_error
-    assert_raise_with_message(SyntaxError, /keyword_end/) do
+    assert_raise_with_message(SyntaxError, /\bend\b/) do
       RubyVM::AbstractSyntaxTree.parse("end")
     end
   end
@@ -164,7 +164,7 @@ class TestAst < Test::Unit::TestCase
     Tempfile.create(%w"test_ast .rb") do |f|
       f.puts "end"
       f.close
-      assert_raise_with_message(SyntaxError, /keyword_end/) do
+      assert_raise_with_message(SyntaxError, /\bend\b/) do
         RubyVM::AbstractSyntaxTree.parse_file(f.path)
       end
     end

--- a/test/ruby/test_iseq.rb
+++ b/test/ruby/test_iseq.rb
@@ -256,7 +256,7 @@ class TestISeq < Test::Unit::TestCase
       f.puts "end"
       f.close
       path = f.path
-      assert_in_out_err(%W[- #{path}], "#{<<-"begin;"}\n#{<<-"end;"}", /keyword_end/, [], success: true)
+      assert_in_out_err(%W[- #{path}], "#{<<-"begin;"}\n#{<<-"end;"}", /unexpected end/, [], success: true)
       begin;
         path = ARGV[0]
         begin

--- a/test/ruby/test_syntax.rb
+++ b/test/ruby/test_syntax.rb
@@ -989,7 +989,7 @@ eom
   end
 
   def test_parenthesised_statement_argument
-    assert_syntax_error("foo(bar rescue nil)", /unexpected modifier_rescue/)
+    assert_syntax_error("foo(bar rescue nil)", /unexpected rescue \(modifier\)/)
     assert_valid_syntax("foo (bar rescue nil)")
   end
 


### PR DESCRIPTION
Dear Ruby maintainers,

I think this commit is fairly straightforward.  Actually, it seems so obvious that I must be missing something, otherwise, someone would have already done it.

The point of this commit is to move from error messages such as

```
/tmp/wrong.rb:1: syntax error, unexpected keyword_end
while end
      ^~~
```

to

```
/tmp/wrong.rb:1: syntax error, unexpected end
while end
      ^~~
```

Cheers!