### PR TITLE
Handle Errno::ETIMEDOUT in Net::HTTP#transport_request

### DIFF
--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -1520,7 +1520,7 @@ module Net   #:nodoc:
       rescue Net::OpenTimeout
         raise
       rescue Net::ReadTimeout, IOError, EOFError,
-             Errno::ECONNRESET, Errno::ECONNABORTED, Errno::EPIPE,
+             Errno::ECONNRESET, Errno::ECONNABORTED, Errno::EPIPE, Errno::ETIMEDOUT,
              # avoid a dependency on OpenSSL
              defined?(OpenSSL::SSL) ? OpenSSL::SSL::SSLError : IOError,
              Timeout::Error => exception


### PR DESCRIPTION
We had this error happen infrequently on OSX since we upgraded to Mojave:

```
/versions/2.5.3/lib/ruby/2.5.0/openssl/buffering.rb:182:in `sysread_nonblock': Operation timed out (Errno::ETIMEDOUT)
/versions/2.5.3/lib/ruby/2.5.0/openssl/buffering.rb:182:in `read_nonblock'
/versions/2.5.3/lib/ruby/2.5.0/net/protocol.rb:175:in `rbuf_fill'
/versions/2.5.3/lib/ruby/2.5.0/net/protocol.rb:157:in `readuntil'
/versions/2.5.3/lib/ruby/2.5.0/net/protocol.rb:167:in `readline'
/versions/2.5.3/lib/ruby/2.5.0/net/http/response.rb:40:in `read_status_line'
/versions/2.5.3/lib/ruby/2.5.0/net/http/response.rb:29:in `read_new'
/versions/2.5.3/lib/ruby/2.5.0/net/http.rb:1494:in `block in transport_request'
/versions/2.5.3/lib/ruby/2.5.0/net/http.rb:1491:in `catch'
/versions/2.5.3/lib/ruby/2.5.0/net/http.rb:1491:in `transport_request'
/versions/2.5.3/lib/ruby/2.5.0/net/http.rb:1464:in `request'
/versions/2.5.3/lib/ruby/2.5.0/net/http.rb:1457:in `block in request'
/versions/2.5.3/lib/ruby/2.5.0/net/http.rb:910:in `start'
/versions/2.5.3/lib/ruby/2.5.0/net/http.rb:1455:in `request'
```
