### PR TITLE
[doc] Fix grammar typo in Pty_init() docstring

### DIFF
--- a/ext/pty/pty.c
+++ b/ext/pty/pty.c
@@ -680,7 +680,7 @@ static VALUE cPTY;
 /*
  * Document-class: PTY
  *
- * Creates and managed pseudo terminals (PTYs).  See also
+ * Creates and manages pseudo terminals (PTYs).  See also
  * http://en.wikipedia.org/wiki/Pseudo_terminal
  *
  * PTY allows you to allocate new terminals using ::open or ::spawn a new


### PR DESCRIPTION
This is a grammar fix in the user-visible documentation of PTY.

This fix was proposed in the wrong place to start with: https://github.com/rubysl/rubysl-pty/pull/12