### PR TITLE
Test for undef'ed method in class hierachy

### DIFF
--- a/test/ruby/test_undef.rb
+++ b/test/ruby/test_undef.rb
@@ -25,7 +25,7 @@ class TestUndef < Test::Unit::TestCase
     y = Undef1.new
     assert_equal "bar", y.bar
     z = Undef2.new
-    assert_raise(NoMethodError) { z.foo }
+    assert_raise(NoMethodError) { z.bar }
   end
 
   def test_special_const_undef


### PR DESCRIPTION
This probably should have been `#bar` on the instance of class `Undef2` all along, right?
But maybe I'm missing something and a test case needs adding maybe?