### PR TITLE
fix native fiber on MSYS2/MinGW

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2345,13 +2345,13 @@ AS_CASE(["$target_cpu-$target_os"],
     AC_DEFINE_UNQUOTED(FIBER_USE_COROUTINE, ["$COROUTINE_H"])
     AC_LIBOBJ([coroutine/x86/Context])
   ],
-  # TODO: Enable this after AppVeyor msys2 build succeeds
-  # [x64-mingw32], [
-  #   AC_MSG_RESULT(win64)
-  #   COROUTINE_H=coroutine/win64/Context.h
-  #   AC_DEFINE_UNQUOTED(FIBER_USE_COROUTINE, ["$COROUTINE_H"])
-  #   AC_LIBOBJ([coroutine/win64/Context])
-  # ],
+  # TODO: intermittent AppVeyor msys2 failures may occur
+  [x64-mingw32], [
+    AC_MSG_RESULT(win64)
+    COROUTINE_H=coroutine/win64/Context.h
+    AC_DEFINE_UNQUOTED(FIBER_USE_COROUTINE, ["$COROUTINE_H"])
+    AC_LIBOBJ([coroutine/win64/Context])
+  ],
   [*], [
     AC_MSG_RESULT(no)
   ]

--- a/test/ruby/test_enumerator.rb
+++ b/test/ruby/test_enumerator.rb
@@ -258,6 +258,7 @@ class TestEnumerator < Test::Unit::TestCase
   end
 
   def test_peek_values
+    skip "Windows MinGW 2018-11-20 native fiber" if mingw?
     o = Object.new
     def o.each
       yield


### PR DESCRIPTION
reverts parts of r65892

passed on ruby-loco [here](https://ci.appveyor.com/project/MSP-Greg/ruby-loco/builds/20436211#L2918)