### PR TITLE
Fix r65926 test_dir.rb for windows (tilde)

### DIFF
--- a/test/ruby/test_dir.rb
+++ b/test/ruby/test_dir.rb
@@ -377,8 +377,9 @@ class TestDir < Test::Unit::TestCase
       assert_equal(@nodir, Dir.home(""))
     end
     if user = ENV["USER"]
+      tilde = windows? ? "~" : "~#{user}"
       assert_nothing_raised(ArgumentError) do
-        assert_equal(File.expand_path("~#{user}"), Dir.home(user))
+        assert_equal(File.expand_path(tilde), Dir.home(user))
       end
     end
     %W[no:such:user \u{7559 5b88}:\u{756a}].each do |user|


### PR DESCRIPTION
I believe a simple tilde (`~`) is only recognized by (recent versions of) windows.  r65926 added a test with the following statement:

```ruby
File.expand_path("~#{user}")
```

PR changes the test to use `File.expand_path("~")` on Windows.