### PR TITLE
each_address should resolve for AAAA first

### DIFF
--- a/lib/resolv.rb
+++ b/lib/resolv.rb
@@ -401,10 +401,10 @@ class Resolv
     # be a Resolv::IPv4 or Resolv::IPv6
 
     def each_address(name)
-      each_resource(name, Resource::IN::A) {|resource| yield resource.address}
       if use_ipv6?
         each_resource(name, Resource::IN::AAAA) {|resource| yield resource.address}
       end
+      each_resource(name, Resource::IN::A) {|resource| yield resource.address}
     end
 
     def use_ipv6? # :nodoc:


### PR DESCRIPTION
AAAA over A is standards track behaviour as per [RFC 6724](https://tools.ietf.org/html/rfc6724#section-10.3).

This also matches behaviour on host OSes such as Linux and Windows.