### PR TITLE
Fast path argument parsing for the "01" format with rb_scan_args_fastpath_0_1

### DIFF
--- a/array.c
+++ b/array.c
@@ -2347,7 +2347,7 @@ rb_ary_join_m(int argc, VALUE *argv, VALUE ary)
 {
     VALUE sep;
 
-    rb_scan_args(argc, argv, "01", &sep);
+    rb_scan_args_fastpath_0_1(argc, argv, &sep);
     if (NIL_P(sep)) sep = rb_output_fs;
 
     return rb_ary_join(ary, sep);
@@ -2595,7 +2595,7 @@ rb_ary_rotate_bang(int argc, VALUE *argv, VALUE ary)
     switch (argc) {
       case 1: n = NUM2LONG(argv[0]);
       case 0: break;
-      default: rb_scan_args(argc, argv, "01", NULL);
+      default: rb_scan_args_fastpath_0_1(argc, argv, NULL);
     }
     rb_ary_rotate(ary, n);
     return ary;
@@ -2628,7 +2628,7 @@ rb_ary_rotate_m(int argc, VALUE *argv, VALUE ary)
     switch (argc) {
       case 1: cnt = NUM2LONG(argv[0]);
       case 0: break;
-      default: rb_scan_args(argc, argv, "01", NULL);
+      default: rb_scan_args_fastpath_0_1(argc, argv, NULL);
     }
 
     len = RARRAY_LEN(ary);
@@ -4742,7 +4742,7 @@ rb_ary_max(int argc, VALUE *argv, VALUE ary)
     VALUE num;
     long i;
 
-    rb_scan_args(argc, argv, "01", &num);
+    rb_scan_args_fastpath_0_1(argc, argv, &num);
 
     if (!NIL_P(num))
        return rb_nmin_run(ary, num, 0, 1, 1);
@@ -4797,7 +4797,7 @@ rb_ary_min(int argc, VALUE *argv, VALUE ary)
     VALUE num;
     long i;
 
-    rb_scan_args(argc, argv, "01", &num);
+    rb_scan_args_fastpath_0_1(argc, argv, &num);
 
     if (!NIL_P(num))
        return rb_nmin_run(ary, num, 0, 0, 1);
@@ -5118,7 +5118,7 @@ rb_ary_flatten_bang(int argc, VALUE *argv, VALUE ary)
     int mod = 0, level = -1;
     VALUE result, lv;
 
-    rb_scan_args(argc, argv, "01", &lv);
+    rb_scan_args_fastpath_0_1(argc, argv, &lv);
     rb_ary_modify_check(ary);
     if (!NIL_P(lv)) level = NUM2INT(lv);
     if (level == 0) return Qnil;
@@ -5163,7 +5163,7 @@ rb_ary_flatten(int argc, VALUE *argv, VALUE ary)
     int mod = 0, level = -1;
     VALUE result, lv;
 
-    rb_scan_args(argc, argv, "01", &lv);
+    rb_scan_args_fastpath_0_1(argc, argv, &lv);
     if (!NIL_P(lv)) level = NUM2INT(lv);
     if (level == 0) return ary_make_shared_copy(ary);
 
@@ -5466,7 +5466,7 @@ rb_ary_cycle(int argc, VALUE *argv, VALUE ary)
     long n, i;
     VALUE nv = Qnil;
 
-    rb_scan_args(argc, argv, "01", &nv);
+    rb_scan_args_fastpath_0_1(argc, argv, &nv);
 
     RETURN_SIZED_ENUMERATOR(ary, argc, argv, rb_ary_cycle_size);
     if (NIL_P(nv)) {
@@ -5640,7 +5640,7 @@ rb_ary_permutation(int argc, VALUE *argv, VALUE ary)
 
     n = RARRAY_LEN(ary);                  /* Array length */
     RETURN_SIZED_ENUMERATOR(ary, argc, argv, rb_ary_permutation_size);   /* Return enumerator if no block */
-    rb_scan_args(argc, argv, "01", &num);
+    rb_scan_args_fastpath_0_1(argc, argv, &num);
     r = NIL_P(num) ? n : NUM2LONG(num);   /* Permutation size from argument */
 
     if (r < 0 || n < r) {
@@ -6313,7 +6313,7 @@ rb_ary_sum(int argc, VALUE *argv, VALUE ary)
     long i, n;
     int block_given;
 
-    if (rb_scan_args(argc, argv, "01", &v) == 0)
+    if (rb_scan_args_fastpath_0_1(argc, argv, &v) == 0)
         v = LONG2FIX(0);
 
     block_given = rb_block_given_p();

--- a/array.c
+++ b/array.c
@@ -2595,7 +2595,7 @@ rb_ary_rotate_bang(int argc, VALUE *argv, VALUE ary)
     switch (argc) {
       case 1: n = NUM2LONG(argv[0]);
       case 0: break;
-      default: rb_scan_args_fastpath_0_1(argc, argv, NULL);
+      default: rb_error_arity(argc, 0, 1);
     }
     rb_ary_rotate(ary, n);
     return ary;
@@ -2628,7 +2628,7 @@ rb_ary_rotate_m(int argc, VALUE *argv, VALUE ary)
     switch (argc) {
       case 1: cnt = NUM2LONG(argv[0]);
       case 0: break;
-      default: rb_scan_args_fastpath_0_1(argc, argv, NULL);
+      default: rb_error_arity(argc, 0, 1);
     }
 
     len = RARRAY_LEN(ary);

--- a/class.c
+++ b/class.c
@@ -1186,7 +1186,7 @@ class_instance_method_list(int argc, const VALUE *argv, VALUE mod, int obj, int 
     }
     else {
 	VALUE r;
-	rb_scan_args(argc, argv, "01", &r);
+	rb_scan_args_fastpath_0_1(argc, argv, &r);
 	recur = RTEST(r);
     }
 
@@ -1425,7 +1425,7 @@ rb_obj_singleton_methods(int argc, const VALUE *argv, VALUE obj)
 	recur = Qtrue;
     }
     else {
-	rb_scan_args(argc, argv, "01", &recur);
+	rb_scan_args_fastpath_0_1(argc, argv, &recur);
     }
     klass = CLASS_OF(obj);
     origin = RCLASS_ORIGIN(klass);

--- a/complex.c
+++ b/complex.c
@@ -1491,7 +1491,7 @@ nucomp_rationalize(int argc, VALUE *argv, VALUE self)
 {
     get_dat1(self);
 
-    rb_scan_args_fastpath_0_1(argc, argv, NULL);
+    if (argc > 1) rb_error_arity(argc, 0, 1);
 
     if (!k_exact_zero_p(dat->imag)) {
        rb_raise(rb_eRangeError, "can't convert %"PRIsVALUE" into Rational",

--- a/complex.c
+++ b/complex.c
@@ -1491,7 +1491,7 @@ nucomp_rationalize(int argc, VALUE *argv, VALUE self)
 {
     get_dat1(self);
 
-    rb_scan_args(argc, argv, "01", NULL);
+    rb_scan_args_fastpath_0_1(argc, argv, NULL);
 
     if (!k_exact_zero_p(dat->imag)) {
        rb_raise(rb_eRangeError, "can't convert %"PRIsVALUE" into Rational",

--- a/dir.c
+++ b/dir.c
@@ -1080,7 +1080,7 @@ dir_s_chdir(int argc, VALUE *argv, VALUE obj)
 {
     VALUE path = Qnil;
 
-    if (rb_scan_args(argc, argv, "01", &path) == 1) {
+    if (rb_scan_args_fastpath_0_1(argc, argv, &path) == 1) {
 	FilePathValue(path);
 	path = rb_str_encode_ospath(path);
     }

--- a/enum.c
+++ b/enum.c
@@ -294,7 +294,7 @@ enum_find(int argc, VALUE *argv, VALUE obj)
     struct MEMO *memo;
     VALUE if_none;
 
-    rb_scan_args(argc, argv, "01", &if_none);
+    rb_scan_args_fastpath_0_1(argc, argv, &if_none);
     RETURN_ENUMERATOR(obj, argc, argv);
     memo = MEMO_NEW(Qundef, 0, 0);
     rb_block_call(obj, id_each, 0, 0, find_i, (VALUE)memo);
@@ -1700,7 +1700,7 @@ enum_min(int argc, VALUE *argv, VALUE obj)
     VALUE result;
     VALUE num;
 
-    rb_scan_args(argc, argv, "01", &num);
+    rb_scan_args_fastpath_0_1(argc, argv, &num);
 
     if (!NIL_P(num))
        return rb_nmin_run(obj, num, 0, 0, 0);
@@ -1794,7 +1794,7 @@ enum_max(int argc, VALUE *argv, VALUE obj)
     VALUE result;
     VALUE num;
 
-    rb_scan_args(argc, argv, "01", &num);
+    rb_scan_args_fastpath_0_1(argc, argv, &num);
 
     if (!NIL_P(num))
        return rb_nmin_run(obj, num, 0, 1, 0);
@@ -2015,7 +2015,7 @@ enum_min_by(int argc, VALUE *argv, VALUE obj)
     struct MEMO *memo;
     VALUE num;
 
-    rb_scan_args(argc, argv, "01", &num);
+    rb_scan_args_fastpath_0_1(argc, argv, &num);
 
     RETURN_SIZED_ENUMERATOR(obj, argc, argv, enum_size);
 
@@ -2122,7 +2122,7 @@ enum_max_by(int argc, VALUE *argv, VALUE obj)
     struct MEMO *memo;
     VALUE num;
 
-    rb_scan_args(argc, argv, "01", &num);
+    rb_scan_args_fastpath_0_1(argc, argv, &num);
 
     RETURN_SIZED_ENUMERATOR(obj, argc, argv, enum_size);
 
@@ -2977,7 +2977,7 @@ enum_cycle(int argc, VALUE *argv, VALUE obj)
     VALUE nv = Qnil;
     long n, i, len;
 
-    rb_scan_args(argc, argv, "01", &nv);
+    rb_scan_args_fastpath_0_1(argc, argv, &nv);
 
     RETURN_SIZED_ENUMERATOR(obj, argc, argv, enum_cycle_size);
     if (NIL_P(nv)) {
@@ -3950,7 +3950,7 @@ enum_sum(int argc, VALUE* argv, VALUE obj)
     VALUE beg, end;
     int excl;
 
-    if (rb_scan_args(argc, argv, "01", &memo.v) == 0)
+    if (rb_scan_args_fastpath_0_1(argc, argv, &memo.v) == 0)
         memo.v = LONG2FIX(0);
 
     memo.block_given = rb_block_given_p();

--- a/enumerator.c
+++ b/enumerator.c
@@ -604,7 +604,7 @@ enumerator_with_index(int argc, VALUE *argv, VALUE obj)
 {
     VALUE memo;
 
-    rb_scan_args(argc, argv, "01", &memo);
+    rb_scan_args_fastpath_0_1(argc, argv, &memo);
     RETURN_SIZED_ENUMERATOR(obj, argc, argv, enumerator_enum_size);
     if (NIL_P(memo))
 	memo = INT2FIX(0);

--- a/error.c
+++ b/error.c
@@ -940,7 +940,7 @@ exc_initialize(int argc, VALUE *argv, VALUE exc)
 {
     VALUE arg;
 
-    rb_scan_args(argc, argv, "01", &arg);
+    rb_scan_args_fastpath_0_1(argc, argv, &arg);
     return exc_init(exc, arg);
 }
 

--- a/gc.c
+++ b/gc.c
@@ -2728,7 +2728,7 @@ os_each_obj(int argc, VALUE *argv, VALUE os)
 	of = 0;
     }
     else {
-	rb_scan_args(argc, argv, "01", &of);
+	rb_scan_args_fastpath_0_1(argc, argv, &of);
     }
     RETURN_ENUMERATOR(os, 1, &of);
     return os_obj_of(of);
@@ -3491,7 +3491,7 @@ count_objects(int argc, VALUE *argv, VALUE os)
     size_t i;
     VALUE hash;
 
-    if (rb_scan_args(argc, argv, "01", &hash) == 1) {
+    if (rb_scan_args_fastpath_0_1(argc, argv, &hash) == 1) {
         if (!RB_TYPE_P(hash, T_HASH))
             rb_raise(rb_eTypeError, "non-hash given");
     }
@@ -7078,7 +7078,7 @@ gc_latest_gc_info(int argc, VALUE *argv, VALUE self)
     rb_objspace_t *objspace = &rb_objspace;
     VALUE arg = Qnil;
 
-    if (rb_scan_args(argc, argv, "01", &arg) == 1) {
+    if (rb_scan_args_fastpath_0_1(argc, argv, &arg) == 1) {
 	if (!SYMBOL_P(arg) && !RB_TYPE_P(arg, T_HASH)) {
 	    rb_raise(rb_eTypeError, "non-hash or symbol given");
 	}
@@ -7453,7 +7453,7 @@ gc_stat(int argc, VALUE *argv, VALUE self)
 {
     VALUE arg = Qnil;
 
-    if (rb_scan_args(argc, argv, "01", &arg) == 1) {
+    if (rb_scan_args_fastpath_0_1(argc, argv, &arg) == 1) {
 	if (SYMBOL_P(arg)) {
 	    size_t value = gc_stat_internal(arg);
 	    return SIZET2NUM(value);
@@ -9460,7 +9460,7 @@ gc_profile_report(int argc, VALUE *argv, VALUE self)
 	out = rb_stdout;
     }
     else {
-	rb_scan_args(argc, argv, "01", &out);
+	rb_scan_args_fastpath_0_1(argc, argv, &out);
     }
     gc_profile_dump_on(out, rb_io_write);
 

--- a/internal.h
+++ b/internal.h
@@ -1369,14 +1369,15 @@ void Init_class_hierarchy(void);
 int rb_class_has_methods(VALUE c);
 void rb_undef_methods_from(VALUE klass, VALUE super);
 
+/* Internal optmisation API - caller responsibiity to not pass NULL as arg value */
 static inline int
 rb_scan_args_fastpath_0_1(int argc, const VALUE *argv, VALUE *arg)
 {
     if (argc == 0 ) {
-        if (arg) *arg = Qnil;
+        *arg = Qnil;
         return argc;
     } else if (argc == 1) {
-        if (arg) *arg = argv[0];
+        *arg = argv[0];
         return argc;
     }
     rb_error_arity(argc, 0, 1);

--- a/internal.h
+++ b/internal.h
@@ -1369,6 +1369,19 @@ void Init_class_hierarchy(void);
 int rb_class_has_methods(VALUE c);
 void rb_undef_methods_from(VALUE klass, VALUE super);
 
+static inline int
+rb_scan_args_fastpath_0_1(int argc, const VALUE *argv, VALUE *arg)
+{
+    if (argc == 0 ) {
+        if (arg) *arg = Qnil;
+        return argc;
+    } else if (argc == 1) {
+        if (arg) *arg = argv[0];
+        return argc;
+    }
+    rb_error_arity(argc, 0, 1);
+}
+
 /* compar.c */
 VALUE rb_invcmp(VALUE, VALUE);
 

--- a/io.c
+++ b/io.c
@@ -7876,7 +7876,7 @@ rb_obj_display(int argc, VALUE *argv, VALUE self)
 	out = rb_stdout;
     }
     else {
-	rb_scan_args(argc, argv, "01", &out);
+	rb_scan_args_fastpath_0_1(argc, argv, &out);
     }
     rb_io_write(out, self);
 

--- a/iseq.c
+++ b/iseq.c
@@ -3047,7 +3047,7 @@ static VALUE
 iseqw_to_binary(int argc, VALUE *argv, VALUE self)
 {
     VALUE opt;
-    rb_scan_args(argc, argv, "01", &opt);
+    rb_scan_args_fastpath_0_1(argc, argv, &opt);
     return rb_iseq_ibf_dump(iseqw_check(self), opt);
 }
 

--- a/object.c
+++ b/object.c
@@ -2051,7 +2051,7 @@ rb_class_initialize(int argc, VALUE *argv, VALUE klass)
 	super = rb_cObject;
     }
     else {
-	rb_scan_args(argc, argv, "01", &super);
+	rb_scan_args_fastpath_0_1(argc, argv, &super);
 	rb_check_inheritable(super);
 	if (super != rb_cBasicObject && !RCLASS_SUPER(super)) {
 	    rb_raise(rb_eTypeError, "can't inherit uninitialized class");

--- a/proc.c
+++ b/proc.c
@@ -2993,7 +2993,7 @@ proc_curry(int argc, const VALUE *argv, VALUE self)
     int sarity, max_arity, min_arity = rb_proc_min_max_arity(self, &max_arity);
     VALUE arity;
 
-    rb_scan_args(argc, argv, "01", &arity);
+    rb_scan_args_fastpath_0_1(argc, argv, &arity);
     if (NIL_P(arity)) {
 	arity = INT2FIX(min_arity);
     }

--- a/range.c
+++ b/range.c
@@ -401,7 +401,7 @@ range_step(int argc, VALUE *argv, VALUE range)
         step = INT2FIX(1);
     }
     else {
-        rb_scan_args(argc, argv, "01", &step);
+        rb_scan_args_fastpath_0_1(argc, argv, &step);
     }
 
     if (!rb_block_given_p()) {

--- a/rational.c
+++ b/rational.c
@@ -1388,7 +1388,7 @@ f_round_common(int argc, VALUE *argv, VALUE self, VALUE (*func)(VALUE))
     if (argc == 0)
 	return (*func)(self);
 
-    rb_scan_args(argc, argv, "01", &n);
+    rb_scan_args_fastpath_0_1(argc, argv, &n);
 
     if (!k_integer_p(n))
 	rb_raise(rb_eTypeError, "not an integer");
@@ -1717,7 +1717,7 @@ nurat_rationalize(int argc, VALUE *argv, VALUE self)
     if (nurat_negative_p(self))
 	return rb_rational_uminus(nurat_rationalize(argc, argv, rb_rational_uminus(self)));
 
-    rb_scan_args(argc, argv, "01", &e);
+    rb_scan_args_fastpath_0_1(argc, argv, &e);
     e = f_abs(e);
     a = f_sub(self, e);
     b = f_add(self, e);
@@ -2121,7 +2121,7 @@ nilclass_to_r(VALUE self)
 static VALUE
 nilclass_rationalize(int argc, VALUE *argv, VALUE self)
 {
-    rb_scan_args(argc, argv, "01", NULL);
+    rb_scan_args_fastpath_0_1(argc, argv, NULL);
     return nilclass_to_r(self);
 }
 
@@ -2150,7 +2150,7 @@ integer_to_r(VALUE self)
 static VALUE
 integer_rationalize(int argc, VALUE *argv, VALUE self)
 {
-    rb_scan_args(argc, argv, "01", NULL);
+    rb_scan_args_fastpath_0_1(argc, argv, NULL);
     return integer_to_r(self);
 }
 
@@ -2289,7 +2289,7 @@ float_rationalize(int argc, VALUE *argv, VALUE self)
     if (d < 0.0)
         return rb_rational_uminus(float_rationalize(argc, argv, DBL2NUM(-d)));
 
-    rb_scan_args(argc, argv, "01", &e);
+    rb_scan_args_fastpath_0_1(argc, argv, &e);
 
     if (argc != 0) {
         return rb_flt_rationalize_with_prec(self, e);

--- a/rational.c
+++ b/rational.c
@@ -2121,7 +2121,7 @@ nilclass_to_r(VALUE self)
 static VALUE
 nilclass_rationalize(int argc, VALUE *argv, VALUE self)
 {
-    rb_scan_args_fastpath_0_1(argc, argv, NULL);
+    if (argc > 1) rb_error_arity(argc, 0, 1);
     return nilclass_to_r(self);
 }
 
@@ -2150,7 +2150,7 @@ integer_to_r(VALUE self)
 static VALUE
 integer_rationalize(int argc, VALUE *argv, VALUE self)
 {
-    rb_scan_args_fastpath_0_1(argc, argv, NULL);
+    if (argc > 1) rb_error_arity(argc, 0, 1);
     return integer_to_r(self);
 }
 

--- a/re.c
+++ b/re.c
@@ -3962,7 +3962,7 @@ rb_reg_s_last_match(int argc, VALUE *argv)
 {
     VALUE nth;
 
-    if (argc > 0 && rb_scan_args(argc, argv, "01", &nth) == 1) {
+    if (argc > 0 && rb_scan_args_fastpath_0_1(argc, argv, &nth) == 1) {
         VALUE match = rb_backref_get();
         int n;
         if (NIL_P(match)) return Qnil;

--- a/signal.c
+++ b/signal.c
@@ -391,7 +391,7 @@ interrupt_init(int argc, VALUE *argv, VALUE self)
     VALUE args[2];
 
     args[0] = INT2FIX(SIGINT);
-    rb_scan_args(argc, argv, "01", &args[1]);
+    rb_scan_args_fastpath_0_1(argc, argv, &args[1]);
     return rb_call_super(2, args);
 }
 

--- a/string.c
+++ b/string.c
@@ -5730,7 +5730,7 @@ rb_str_to_i(int argc, VALUE *argv, VALUE str)
     else {
 	VALUE b;
 
-	rb_scan_args(argc, argv, "01", &b);
+	rb_scan_args_fastpath_0_1(argc, argv, &b);
 	base = NUM2INT(b);
     }
     if (base < 0) {
@@ -9336,7 +9336,7 @@ rb_str_sum(int argc, VALUE *argv, VALUE str)
 	bits = 16;
     }
     else {
-	rb_scan_args(argc, argv, "01", &vbits);
+	rb_scan_args_fastpath_0_1(argc, argv, &vbits);
 	bits = NUM2INT(vbits);
         if (bits < 0)
             bits = 0;
@@ -10354,7 +10354,7 @@ unicode_normalize_common(int argc, VALUE *argv, VALUE str, ID id)
 	UnicodeNormalizeRequired = 1;
     }
     argv2[0] = str;
-    rb_scan_args(argc, argv, "01", &argv2[1]);
+    rb_scan_args_fastpath_0_1(argc, argv, &argv2[1]);
     return rb_funcallv(mUnicodeNormalize, id, argc+1, argv2);
 }
 

--- a/thread.c
+++ b/thread.c
@@ -1110,7 +1110,7 @@ thread_join_m(int argc, VALUE *argv, VALUE self)
     VALUE limit;
     rb_hrtime_t rel, *to = 0;
 
-    rb_scan_args(argc, argv, "01", &limit);
+    rb_scan_args_fastpath_0_1(argc, argv, &limit);
 
     /*
      * This supports INFINITY and negative values, so we can't use
@@ -2043,7 +2043,7 @@ rb_thread_pending_interrupt_p(int argc, VALUE *argv, VALUE target_thread)
     else {
 	if (argc == 1) {
 	    VALUE err;
-	    rb_scan_args(argc, argv, "01", &err);
+	    rb_scan_args_fastpath_0_1(argc, argv, &err);
 	    if (!rb_obj_is_kind_of(err, rb_cModule)) {
 		rb_raise(rb_eTypeError, "class or module required for rescue clause");
 	    }

--- a/thread_sync.c
+++ b/thread_sync.c
@@ -506,7 +506,7 @@ mutex_sleep(int argc, VALUE *argv, VALUE self)
 {
     VALUE timeout;
 
-    rb_scan_args(argc, argv, "01", &timeout);
+    rb_scan_args_fastpath_0_1(argc, argv, &timeout);
     return rb_mutex_sleep(self, timeout);
 }
 

--- a/time.c
+++ b/time.c
@@ -3701,7 +3701,7 @@ static VALUE
 time_localtime_m(int argc, VALUE *argv, VALUE time)
 {
     VALUE off;
-    rb_scan_args(argc, argv, "01", &off);
+    rb_scan_args_fastpath_0_1(argc, argv, &off);
 
     if (!NIL_P(off)) {
         if (zone_localtime(off, time)) return time;
@@ -3824,7 +3824,7 @@ static VALUE
 time_getlocaltime(int argc, VALUE *argv, VALUE time)
 {
     VALUE off;
-    rb_scan_args(argc, argv, "01", &off);
+    rb_scan_args_fastpath_0_1(argc, argv, &off);
 
     if (!NIL_P(off)) {
         if (maybe_tzobj_p(off)) {
@@ -4073,7 +4073,7 @@ time_round(int argc, VALUE *argv, VALUE time)
     long nd;
     struct time_object *tobj;
 
-    rb_scan_args(argc, argv, "01", &ndigits);
+    rb_scan_args_fastpath_0_1(argc, argv, &ndigits);
 
     if (NIL_P(ndigits))
         ndigits = INT2FIX(0);
@@ -4896,7 +4896,7 @@ time_dump(int argc, VALUE *argv, VALUE time)
 {
     VALUE str;
 
-    rb_scan_args(argc, argv, "01", 0);
+    rb_scan_args_fastpath_0_1(argc, argv, 0);
     str = time_mdump(time);
 
     return str;

--- a/time.c
+++ b/time.c
@@ -4896,7 +4896,7 @@ time_dump(int argc, VALUE *argv, VALUE time)
 {
     VALUE str;
 
-    rb_scan_args_fastpath_0_1(argc, argv, 0);
+    if (argc > 1) rb_error_arity(argc, 0, 1);
     str = time_mdump(time);
 
     return str;

--- a/transcode.c
+++ b/transcode.c
@@ -4115,7 +4115,7 @@ econv_putback(int argc, VALUE *argv, VALUE self)
     int putbackable;
     VALUE str, max;
 
-    rb_scan_args(argc, argv, "01", &max);
+    rb_scan_args_fastpath_0_1(argc, argv, &max);
 
     if (NIL_P(max))
         n = rb_econv_putbackable(ec);

--- a/variable.c
+++ b/variable.c
@@ -2734,7 +2734,7 @@ rb_mod_constants(int argc, const VALUE *argv, VALUE mod)
 	inherit = Qtrue;
     }
     else {
-	rb_scan_args(argc, argv, "01", &inherit);
+	rb_scan_args_fastpath_0_1(argc, argv, &inherit);
     }
 
     if (RTEST(inherit)) {
@@ -3301,7 +3301,7 @@ rb_mod_class_variables(int argc, const VALUE *argv, VALUE mod)
 	inherit = Qtrue;
     }
     else {
-	rb_scan_args(argc, argv, "01", &inherit);
+	rb_scan_args_fastpath_0_1(argc, argv, &inherit);
     }
     if (RTEST(inherit)) {
 	tbl = mod_cvar_of(mod, 0);

--- a/vm.c
+++ b/vm.c
@@ -419,7 +419,7 @@ vm_stat(int argc, VALUE *argv, VALUE self)
     VALUE arg = Qnil;
     VALUE hash = Qnil, key = Qnil;
 
-    if (rb_scan_args(argc, argv, "01", &arg) == 1) {
+    if (rb_scan_args_fastpath_0_1(argc, argv, &arg) == 1) {
 	if (SYMBOL_P(arg))
 	    key = arg;
 	else if (RB_TYPE_P(arg, T_HASH))

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -1957,7 +1957,7 @@ rb_f_catch(int argc, VALUE *argv)
 	tag = rb_obj_alloc(rb_cObject);
     }
     else {
-	rb_scan_args(argc, argv, "01", &tag);
+	rb_scan_args_fastpath_0_1(argc, argv, &tag);
     }
     return rb_catch_obj(tag, catch_i, 0);
 }


### PR DESCRIPTION
I noticed a bunch of core APIs invoking `rb_scan_args` with the `"01"` format string. This argument parser helper method is quite heavy weight for the special case of parsing a single optional argument.

This is an internal only API and another low hanging fruit is the `"02"` format string.