### PR TITLE
Let sub-directory exts depend on their parent ext

### DIFF
--- a/ext/extmk.rb
+++ b/ext/extmk.rb
@@ -722,7 +722,16 @@ begin
     end
     targets.each do |tgt|
       exts.each do |d|
-        mf.puts "#{d[0..-2]}#{tgt}:\n\t$(Q)#{submake} $(MFLAGS) V=$(V) $(@F)"
+        d = d[0..-2]
+        t = "#{d}#{tgt}"
+        if  /^(dist|real)?clean$/ =~ tgt
+          deps = exts.select {|e|e.start_with?(d)}.map {|e|"#{e[0..-2]}#{tgt}"} - [t]
+          pd = ' ' + deps.join(' ') unless deps.empty?
+        else
+          pext = File.dirname(d)
+          pd = " #{pext}/#{tgt}" if exts.include?("#{pext}/.")
+        end
+        mf.puts "#{t}:#{pd}\n\t$(Q)#{submake} $(MFLAGS) V=$(V) $(@F)"
       end
     end
     mf.puts "\n""extso:\n"

--- a/template/exts.mk.tmpl
+++ b/template/exts.mk.tmpl
@@ -128,14 +128,25 @@ libencs:
 ext/extinit.<%=objext%>:
 	$(Q)$(MAKE)<%=mflags%> V=$(V) EXTINITS="$(EXTINITS)" $@
 
-% targets.product(macros["extensions"].map {|e|e.chomp("/.")}) do |t, e|
-<%=e%>/<%=t%>:
-%   if /^(dist|real)clean$/ =~ t
+% exts = macros["extensions"].map {|e|e.chomp("/.")}.sort
+% targets.each do |tgt|
+%   exts.each do |d|
+%     t = "#{d}/#{tgt}"
+%     if /^(dist|real)?clean$/ =~ tgt
+%       deps = exts.select {|e|e.start_with?("#{d}/")}.map {|e|"#{e}/#{tgt}"}
+%       pd = ' ' + deps.join(' ') unless deps.empty?
+%     else
+%       pext = File.dirname(d)
+%       pd = " #{pext}/#{tgt}" if exts.include?(pext)
+%     end
+<%=t%>:<%=pd%>
+%     if /^(dist|real)clean$/ =~ tgt
 	$(ECHO) $(@F)ing $(@D)
-%   end
+%     end
 	$(Q)<%= submake %><%=mflags%> V=$(V) $(@F)
-%   if /^(dist|real)clean$/ =~ t
+%     if /^(dist|real)clean$/ =~ tgt
 	$(Q)$(RMDIRS) $(@D)
+%     end
 %   end
 % end
 


### PR DESCRIPTION
I want to make dependency from sub-directory extensions to their parent extension.
For example, in bigdecimal on Windows platform, bigdecimal/util.so depends on the import library generated when compiling bigdecimal.so.