### PR TITLE
Speed up hash literals by duping

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -3984,7 +3984,12 @@ compile_array(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node_ro
 			    ADD_INSN1(ret, line, duparray, ary);
 			}
 			else { /* COMPILE_ARRAY_TYPE_HASH */
-                            ADD_INSN2(ret, line, newhashfromarray, INT2FIX(RARRAY_LEN(ary)/2), ary);
+			    VALUE hash;
+
+			    hash = rb_hash_new_with_size(RARRAY_LEN(ary) / 2);
+			    rb_hash_bulk_insert(RARRAY_LEN(ary), RARRAY_CONST_PTR_TRANSIENT(ary), hash);
+			    iseq_add_mark_object_compile_time(iseq, hash);
+			    ADD_INSN1(ret, line, duphash, hash);
 			}
 		    }
 		    else {

--- a/insns.def
+++ b/insns.def
@@ -454,6 +454,16 @@ duparray
     val = rb_ary_resurrect(ary);
 }
 
+/* dup hash */
+DEFINE_INSN
+duphash
+(VALUE hash)
+()
+(VALUE val)
+{
+    val = rb_hash_dup(hash);
+}
+
 /* if TOS is an array expand, expand it to num objects.
      if the number of the array is less than num, push nils to fill.
      if it is greater than num, exceeding elements are dropped.
@@ -512,19 +522,6 @@ newhash
     if (num) {
         rb_hash_bulk_insert(num, STACK_ADDR_FROM_TOP(num), val);
     }
-}
-
-/* make new Hash object from (frozen) Array object */
-DEFINE_INSN
-newhashfromarray
-(rb_num_t num, VALUE ary)
-()
-(VALUE hash)
-// attr bool leaf = false; /* rb_hash_bulk_insert() can call methods. */
-{
-    VM_ASSERT(num * 2 == (rb_num_t)RARRAY_LEN(ary));
-    hash = rb_hash_new_with_size(num);
-    rb_hash_bulk_insert(num * 2, RARRAY_CONST_PTR_TRANSIENT(ary), hash);
 }
 
 /* put new Range object.(Range.new(low, high, flag)) */

--- a/test/ruby/test_jit.rb
+++ b/test/ruby/test_jit.rb
@@ -239,8 +239,8 @@ class TestJIT < Test::Unit::TestCase
     assert_compile_once('a = 1; { a: a }', result_inspect: '{:a=>1}', insns: %i[newhash])
   end
 
-  def test_compile_insn_newhashfromarray
-    assert_compile_once('{ a: 1 }', result_inspect: '{:a=>1}', insns: %i[newhashfromarray])
+  def test_compile_insn_duphash
+    assert_compile_once('{ a: 1 }', result_inspect: '{:a=>1}', insns: %i[duphash])
   end
 
   def test_compile_insn_newrange


### PR DESCRIPTION
This commit replaces the `newhashfromarray` instruction with a `duphash`
instruction.  Instead of allocating a new hash from an array stored in
the Instruction Sequences, store a hash directly in the instruction
sequences and dup it on execution.

== Instruction sequence changes ==

```ruby
code = <<-eorby
  { "foo" => "bar", "baz" => "lol" }
eorby

insns = RubyVM::InstructionSequence.compile(code, __FILE__, nil, 0, frozen_string_literal: true)
puts insns.disasm
```

On Ruby 2.5:

```
== disasm: #<ISeq:<compiled>@test.rb:0 (0,0)-(0,36)>====================
0000 putobject        "foo"
0002 putobject        "bar"
0004 putobject        "baz"
0006 putobject        "lol"
0008 newhash          4
0010 leave
```

Ruby 2.6@r66174 3b6321083a2e3525da3b34d08a0b68bac094bd7f:

```
$ ./ruby test.rb
== disasm: #<ISeq:<compiled>@test.rb:0 (0,0)-(0,36)> (catch: FALSE)
0000 newhashfromarray             2, ["foo", "bar", "baz", "lol"]
0003 leave
```

Ruby 2.6 + This commit:

```
$ ./ruby test.rb
== disasm: #<ISeq:<compiled>@test.rb:0 (0,0)-(0,36)> (catch: FALSE)
0000 duphash                      {"foo"=>"bar", "baz"=>"lol"}
0002 leave
```

== Benchmark Results ==

Here is the benchmark used:

```ruby
require "benchmark/ips"

code = <<-eorby
def foo
  { "foo" => "bar", "baz" => "lol" }
end
eorby

insns = RubyVM::InstructionSequence.compile(code, __FILE__, nil, 0, frozen_string_literal: true)
insns.eval

Benchmark.ips do |x|
  x.report("hash speed") do
    foo
  end
end
```

On Ruby 2.5.3:

```
$ ruby -v test.rb
ruby 2.5.3p105 (2018-10-18 revision 65156) [x86_64-darwin18]
Warming up --------------------------------------
          hash speed   159.660k i/100ms
Calculating -------------------------------------
          hash speed      2.318M (± 3.2%) i/s -     11.655M in   5.033357s
```

Ruby 2.6@r66174 3b6321083a2e3525da3b34d08a0b68bac094bd7f:

```
$ ./ruby -v test.rb
ruby 2.6.0dev (2018-12-04 trunk 66174) [x86_64-darwin18]
Warming up --------------------------------------
          hash speed   315.900k i/100ms
Calculating -------------------------------------
          hash speed      8.361M (± 6.8%) i/s -     41.699M in   5.017030s
```

Ruby 2.6 + This commit:

```
$ ./ruby -v test.rb
ruby 2.6.0dev (2018-12-04 duphash 66174) [x86_64-darwin18]
last_commit=Speed up hash literals by duping
Warming up --------------------------------------
          hash speed   366.653k i/100ms
Calculating -------------------------------------
          hash speed     12.800M (±12.3%) i/s -     63.064M in   5.020517s
```