### PR TITLE
implement Array-specific #all? #none? #one?

### DIFF
--- a/array.c
+++ b/array.c
@@ -6212,6 +6212,124 @@ rb_ary_any_p(int argc, VALUE *argv, VALUE ary)
 }
 
 /*
+ *  call-seq:
+ *     ary.all? [{|obj| block}  ]   -> true or false
+ *     ary.all?(pattern)            -> true or false
+ *
+ *  See also Enumerable#all?
+ */
+
+static VALUE
+rb_ary_all_p(int argc, VALUE *argv, VALUE ary)
+{
+    long i, len = RARRAY_LEN(ary);
+
+    rb_check_arity(argc, 0, 1);
+    if (!len) return Qtrue;
+    if (argc) {
+        if (rb_block_given_p()) {
+            rb_warn("given block not used");
+        }
+        for (i = 0; i < RARRAY_LEN(ary); ++i) {
+            if (!RTEST(rb_funcall(argv[0], idEqq, 1, RARRAY_AREF(ary, i)))) return Qfalse;
+        }
+    }
+    else if (!rb_block_given_p()) {
+        for (i = 0; i < len; ++i) {
+            if (!RTEST(RARRAY_AREF(ary, i))) return Qfalse;
+        }
+    }
+    else {
+        for (i = 0; i < RARRAY_LEN(ary); ++i) {
+            if (!RTEST(rb_yield(RARRAY_AREF(ary, i)))) return Qfalse;
+        }
+    }
+    return Qtrue;
+}
+
+/*
+ *  call-seq:
+ *     ary.none? [{|obj| block}  ]   -> true or false
+ *     ary.none?(pattern)            -> true or false
+ *
+ *  See also Enumerable#none?
+ */
+
+static VALUE
+rb_ary_none_p(int argc, VALUE *argv, VALUE ary)
+{
+    long i, len = RARRAY_LEN(ary);
+
+    rb_check_arity(argc, 0, 1);
+    if (!len) return Qtrue;
+    if (argc) {
+        if (rb_block_given_p()) {
+            rb_warn("given block not used");
+        }
+        for (i = 0; i < RARRAY_LEN(ary); ++i) {
+            if (RTEST(rb_funcall(argv[0], idEqq, 1, RARRAY_AREF(ary, i)))) return Qfalse;
+        }
+    }
+    else if (!rb_block_given_p()) {
+        for (i = 0; i < len; ++i) {
+            if (RTEST(RARRAY_AREF(ary, i))) return Qfalse;
+        }
+    }
+    else {
+        for (i = 0; i < RARRAY_LEN(ary); ++i) {
+            if (RTEST(rb_yield(RARRAY_AREF(ary, i)))) return Qfalse;
+        }
+    }
+    return Qtrue;
+}
+
+/*
+ *  call-seq:
+ *     ary.one? [{|obj| block}  ]   -> true or false
+ *     ary.one?(pattern)            -> true or false
+ *
+ *  See also Enumerable#one?
+ */
+
+static VALUE
+rb_ary_one_p(int argc, VALUE *argv, VALUE ary)
+{
+    long i, len = RARRAY_LEN(ary);
+    VALUE result = Qfalse;
+
+    rb_check_arity(argc, 0, 1);
+    if (!len) return Qfalse;
+    if (argc) {
+        if (rb_block_given_p()) {
+            rb_warn("given block not used");
+        }
+        for (i = 0; i < RARRAY_LEN(ary); ++i) {
+            if (RTEST(rb_funcall(argv[0], idEqq, 1, RARRAY_AREF(ary, i)))) {
+                if (RTEST(result)) return Qfalse;
+                result = Qtrue;
+            }
+        }
+    }
+    else if (!rb_block_given_p()) {
+        for (i = 0; i < len; ++i) {
+            if (RTEST(RARRAY_AREF(ary, i))) {
+              if (RTEST(result)) return Qfalse;
+              result = Qtrue;
+            }
+        }
+    }
+    else {
+        for (i = 0; i < RARRAY_LEN(ary); ++i) {
+            if (RTEST(rb_yield(RARRAY_AREF(ary, i)))) {
+              if (RTEST(result)) return Qfalse;
+              result = Qtrue;
+            }
+        }
+    }
+    return result;
+}
+
+/*
  * call-seq:
  *   ary.dig(idx, ...)                 -> object
  *
@@ -6770,6 +6888,9 @@ Init_Array(void)
     rb_define_method(rb_cArray, "bsearch", rb_ary_bsearch, 0);
     rb_define_method(rb_cArray, "bsearch_index", rb_ary_bsearch_index, 0);
     rb_define_method(rb_cArray, "any?", rb_ary_any_p, -1);
+    rb_define_method(rb_cArray, "all?", rb_ary_all_p, -1);
+    rb_define_method(rb_cArray, "none?", rb_ary_none_p, -1);
+    rb_define_method(rb_cArray, "one?", rb_ary_one_p, -1);
     rb_define_method(rb_cArray, "dig", rb_ary_dig, -1);
     rb_define_method(rb_cArray, "sum", rb_ary_sum, -1);
 


### PR DESCRIPTION
This PR proposes Array-specific implementations for `#all?` , `#none?` and `#one?` to enable faster method lookup.

### what it does

Before this patch `Array#all?` was not implemented in Array class, so alternatively, Enumerator#all? has been used each time the method is called, while `#any?` has its own [method entry](https://github.com/ruby/ruby/blob/846f4205e7ac7231d185e23494b1c7a32e28559c/array.c#L6183) in Array class for faster method calls.
`Array#none?` and `#one?` also lacked its own implementation.

This patch provides above three methods with equivalent implementations to `Array#any?`,

### benchmark

[A quick enchmarking](https://gist.github.com/fursich/21e8faaecb2a44de7d43176fcc603900) shows each method calls become approx. 20% faster.

It basically impacts on method lookup (not execution itself), but hopefully it contributes to make our ruby applications faster even at slightest level.

### estimate of impact

Just to provide a rough picture on how frequently these methods are used in real world app, here shows a quick-and-dirty example from [rails](https://github.com/rails/rails) (using its latest master as of Dec 5):

```bash
rails (master)$ git grep '\.all?' | wc -l
      80
rails (master)$ git grep '\.one?' | wc -l
      13
rails (master)$ git grep '\.none?' | wc -l
      25
```

while
```bash
rails (master)$ git grep '\.any?' | wc -l
     276
```

(* the result includes non-Array method, such as Hash#all? or Set#any?. The purpose here is just to give ballpark estimate on how frequently these methods are used compared with each other)

Wildly speaking, all these three methods together appears in 118 LOC, which is somewhere around 40% of LOC that contains `#any?`. It's probably fair to say the use of the methods are *not* ignorably rare.
