### PR TITLE
Remove unnecessary require of fileutils

### DIFF
--- a/tool/mkconfig.rb
+++ b/tool/mkconfig.rb
@@ -16,7 +16,6 @@ version = $version or raise "missing -version"
 srcdir = File.expand_path('../..', __FILE__)
 $:.unshift(".")
 
-require "fileutils"
 mkconfig = File.basename($0)
 
 fast = {'prefix'=>true, 'ruby_install_name'=>true, 'INSTALL'=>true, 'EXEEXT'=>true}


### PR DESCRIPTION
Today I updated my ruby core clone, and I run the usual steps to compile ruby. When running "make", I run into the following error:

```
(... stuff ...)
encdb.h unchanged
Traceback (most recent call last):
	5: from ./tool/mkconfig.rb:19:in `<main>'
	4: from ./tool/mkconfig.rb:19:in `require'
	3: from /home/deivid/Code/ruby/lib/fileutils.rb:4:in `<top (required)>'
	2: from /home/deivid/Code/ruby/lib/fileutils.rb:4:in `require'
	1: from /home/deivid/Code/ruby/rbconfig.rb:11:in `<top (required)>'
/home/deivid/Code/ruby/rbconfig.rb:13:in `<module:RbConfig>': ruby lib version (2.5.0) doesn't match executable version (2.6.0) (RuntimeError)
uncommon.mk:780: recipe for target '.rbconfig.time' failed
make: *** [.rbconfig.time] Error 1
```

Apparently, the script that generates the root `rbconfig.rb` file requires `fileutils`, which in turn requires 'rbconfig', which uses the `rbconfig.rb` config file in the root folder if it exists. In my case, this file existed but had been generated on 2.5.0, thus causing the error.

We can avoid this sort of circular dependency by not requiring `fileutils`, since it does not seem to be used anywhere in the `tool/mkconfig.rb` script since r55338.