### PR TITLE
Add the deprecation of flip-flops to NEWS page [ci skip]

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -46,6 +46,8 @@ sufficient information, see the ChangeLog file or Redmine
 * Print +cause+ of the exception if the exception is not caught and printed
   its backtraces and error message [Feature #8257]
 
+* Flip-flop syntax is deprecated. [Feature #5400]
+
 === Core classes updates (outstanding ones only)
 
 [Array]


### PR DESCRIPTION
Flip-flop syntax is not used so often, but many people know it as one of Ruby's strange features. So it should be listed in NEWS page.

https://bugs.ruby-lang.org/issues/5400