### PR TITLE
Avoid explicit `Pathname ===` which breaks rspec-mock.

### DIFF
--- a/ext/pathname/lib/pathname.rb
+++ b/ext/pathname/lib/pathname.rb
@@ -503,7 +503,7 @@ class Pathname
   # ArgumentError is raised when it cannot find a relative path.
   #
   def relative_path_from(base_directory)
-    base_directory = Pathname.new(base_directory) unless Pathname === base_directory
+    base_directory = Pathname.new(base_directory) unless base_directory.is_a?(Pathname)
     dest_directory = self.cleanpath.to_s
     base_directory = base_directory.cleanpath.to_s
     dest_prefix = dest_directory


### PR DESCRIPTION
@ko1 this broke `guard` specs because they use `rspec-mock` and `Pathname === mock` fails. Can I commit this to trunk?