### PR TITLE
Refactor send

### DIFF
--- a/insns.def
+++ b/insns.def
@@ -738,7 +738,7 @@ send
 (CALL_INFO ci, CALL_CACHE cc, ISEQ blockiseq)
 (...)
 (VALUE val)
-// attr rb_snum_t sp_inc = - (int)(ci->orig_argc + ((ci->flag & VM_CALL_ARGS_BLOCKARG) ? 1 : 0));
+// attr rb_snum_t sp_inc = sp_inc_of_sendish(ci);
 {
     struct rb_calling_info calling;
 
@@ -755,7 +755,7 @@ opt_send_without_block
 (...)
 (VALUE val)
 // attr bool handles_sp = true;
-// attr rb_snum_t sp_inc = -ci->orig_argc;
+// attr rb_snum_t sp_inc = sp_inc_of_sendish(ci);
 {
     struct rb_calling_info calling;
     calling.block_handler = VM_BLOCK_HANDLER_NONE;
@@ -824,7 +824,7 @@ invokesuper
 (CALL_INFO ci, CALL_CACHE cc, ISEQ blockiseq)
 (...)
 (VALUE val)
-// attr rb_snum_t sp_inc = - (int)(ci->orig_argc + ((ci->flag & VM_CALL_ARGS_BLOCKARG) ? 1 : 0));
+// attr rb_snum_t sp_inc = sp_inc_of_sendish(ci);
 {
     struct rb_calling_info calling;
 
@@ -841,7 +841,7 @@ invokeblock
 (...)
 (VALUE val)
 // attr bool handles_sp = true;
-// attr rb_snum_t sp_inc = 1 - ci->orig_argc;
+// attr rb_snum_t sp_inc = sp_inc_of_invokeblock(ci);
 {
     struct rb_calling_info calling;
     VALUE block_handler;

--- a/insns.def
+++ b/insns.def
@@ -740,12 +740,13 @@ send
 (VALUE val)
 // attr rb_snum_t sp_inc = sp_inc_of_sendish(ci);
 {
-    struct rb_calling_info calling;
+    VALUE bh = vm_caller_setup_arg_block(ec, GET_CFP(), ci, blockiseq, false);
+    val = vm_sendish(ec, GET_CFP(), ci, cc, bh, vm_search_method_wrap);
 
-    calling.block_handler = vm_caller_setup_arg_block(ec, reg_cfp, ci, blockiseq, FALSE);
-    calling.recv = TOPN(calling.argc = ci->orig_argc);
-    vm_search_method(ci, cc, calling.recv);
-    CALL_METHOD(&calling, ci, cc);
+    if (val == Qundef) {
+        RESTORE_REGS();
+        NEXT_INSN();
+    }
 }
 
 /* Invoke method without block */
@@ -757,10 +758,13 @@ opt_send_without_block
 // attr bool handles_sp = true;
 // attr rb_snum_t sp_inc = sp_inc_of_sendish(ci);
 {
-    struct rb_calling_info calling;
-    calling.block_handler = VM_BLOCK_HANDLER_NONE;
-    vm_search_method(ci, cc, calling.recv = TOPN(calling.argc = ci->orig_argc));
-    CALL_METHOD(&calling, ci, cc);
+    VALUE bh = VM_BLOCK_HANDLER_NONE;
+    val = vm_sendish(ec, GET_CFP(), ci, cc, bh, vm_search_method_wrap);
+
+    if (val == Qundef) {
+        RESTORE_REGS();
+        NEXT_INSN();
+    }
 }
 
 DEFINE_INSN
@@ -826,12 +830,13 @@ invokesuper
 (VALUE val)
 // attr rb_snum_t sp_inc = sp_inc_of_sendish(ci);
 {
-    struct rb_calling_info calling;
+    VALUE bh = vm_caller_setup_arg_block(ec, GET_CFP(), ci, blockiseq, true);
+    val = vm_sendish(ec, GET_CFP(), ci, cc, bh, vm_search_super_method);
 
-    calling.block_handler = vm_caller_setup_arg_block(ec, reg_cfp, ci, blockiseq, TRUE);
-    calling.recv = TOPN(calling.argc = ci->orig_argc);
-    vm_search_super_method(ec, GET_CFP(), &calling, ci, cc);
-    CALL_METHOD(&calling, ci, cc);
+    if (val == Qundef) {
+        RESTORE_REGS();
+        NEXT_INSN();
+    }
 }
 
 /* yield(args) */
@@ -843,21 +848,16 @@ invokeblock
 // attr bool handles_sp = true;
 // attr rb_snum_t sp_inc = sp_inc_of_invokeblock(ci);
 {
-    struct rb_calling_info calling;
-    VALUE block_handler;
+    static struct rb_call_cache cc = {
+        0, 0, NULL, vm_invokeblock_i,
+    };
 
-    calling.argc = ci->orig_argc;
-    calling.block_handler = VM_BLOCK_HANDLER_NONE;
-    calling.recv = Qundef; /* should not be used */
+    VALUE bh = VM_BLOCK_HANDLER_NONE;
+    val = vm_sendish(ec, GET_CFP(), ci, &cc, bh, vm_search_invokeblock);
 
-    block_handler = VM_CF_BLOCK_HANDLER(GET_CFP());
-    if (block_handler == VM_BLOCK_HANDLER_NONE) {
-	rb_vm_localjump_error("no block given (yield)", Qnil, 0);
-    }
-
-    val = vm_invoke_block(ec, GET_CFP(), &calling, ci, block_handler);
     if (val == Qundef) {
-        EXEC_EC_CFP(val);
+        RESTORE_REGS();
+        NEXT_INSN();
     }
 }
 

--- a/tool/ruby_vm/views/_mjit_compile_insn.erb
+++ b/tool/ruby_vm/views/_mjit_compile_insn.erb
@@ -81,6 +81,6 @@
 % end
 %
 % # compiler: If insn returns (leave) or does longjmp (throw), the branch should no longer be compiled. TODO: create attr for it?
-% if insn.expr.expr =~ /\sTHROW_EXCEPTION\([^)]+\);/ || insn.expr.expr =~ /\sRESTORE_REGS\(\);/
+% if insn.expr.expr =~ /\sTHROW_EXCEPTION\([^)]+\);/ || insn.expr.expr =~ /\bvm_pop_frame\(/
     b->finish_p = TRUE;
 % end

--- a/tool/ruby_vm/views/_mjit_compile_insn_body.erb
+++ b/tool/ruby_vm/views/_mjit_compile_insn_body.erb
@@ -29,6 +29,12 @@
 %         #endif
 %       RESTORE_REGS
 %     end
+%     expr.gsub!(/^(?<indent>\s*)NEXT_INSN\(\);\n/) do
+%       indent = Regexp.last_match[:indent]
+%       <<-end.gsub(/^ +/, '')
+%         #{indent}UNREACHABLE_RETURN(Qundef);
+%       end
+%     end
 %   end
 % end
 %

--- a/tool/ruby_vm/views/_sp_inc_helpers.erb
+++ b/tool/ruby_vm/views/_sp_inc_helpers.erb
@@ -1,0 +1,35 @@
+%# -*- mode:c; style:ruby; coding: utf-8; indent-tabs-mode: nil -*-
+%# Copyright (c) 2018 Urabe, Shyouhei.  All rights reserved.
+%#
+%# This file is a part of  the programming language Ruby.  Permission is hereby
+%# granted, to either  redistribute and/or modify this file,  provided that the
+%# conditions mentioned  in the  file COPYING  are met.   Consult the  file for
+%# details.
+%;
+
+static rb_snum_t
+sp_inc_of_sendish(const struct rb_call_info *ci)
+{
+    /* Send-ish instructions will:
+     *
+     * 1. Pop block argument, if any.
+     * 2. Pop ordinal argumanes.
+     * 3. Pop receiver.
+     * 4. Push return value.
+     */
+    const int argc = ci->orig_argc;
+    const int argb = (ci->flag & VM_CALL_ARGS_BLOCKARG) ? 1 : 0;
+    const int recv = 1;
+    const int retn = 1;
+
+    /*         1.     2.     3.     4. */
+    return 0 - argb - argc - recv + retn;
+}
+
+static rb_snum_t
+sp_inc_of_invokeblock(const struct rb_call_info *ci)
+{
+    /* sp_inc of invokeblock is almost identical to that of sendish
+     * instructions, except that it does not pop receriver. */
+    return sp_inc_of_sendish(ci) + 1;
+}

--- a/tool/ruby_vm/views/insns_info.inc.erb
+++ b/tool/ruby_vm/views/insns_info.inc.erb
@@ -16,5 +16,6 @@
 <%= render 'insn_len_info' %>
 <%= render 'insn_operand_info' %>
 <%= render 'leaf_helpers' %>
+<%= render 'sp_inc_helpers' %>
 <%= render 'attributes' %>
 <%= render 'insn_stack_increase' %>

--- a/vm.c
+++ b/vm.c
@@ -28,6 +28,17 @@
 
 VALUE rb_str_concat_literals(size_t, const VALUE*);
 
+/* :FIXME: This #ifdef is because we build pch in case of mswin and
+ * not in case of other situations.  That distinction might change in
+ * a future.  We would better make it detectable in something better
+ * than just _MSC_VER. */
+#ifdef _MSC_VER
+RUBY_FUNC_EXPORTED
+#else
+MJIT_FUNC_EXPORTED
+#endif
+VALUE vm_exec(rb_execution_context_t *, int);
+
 PUREFUNC(static inline const VALUE *VM_EP_LEP(const VALUE *));
 static inline const VALUE *
 VM_EP_LEP(const VALUE *ep)
@@ -1870,7 +1881,7 @@ static inline VALUE
 vm_exec_handle_exception(rb_execution_context_t *ec, enum ruby_tag_type state,
                          VALUE errinfo, VALUE *initial);
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 vm_exec(rb_execution_context_t *ec, int mjit_enable_p)
 {
     enum ruby_tag_type state;

--- a/vm_args.c
+++ b/vm_args.c
@@ -875,7 +875,7 @@ refine_sym_proc_call(RB_BLOCK_CALL_FUNC_ARGLIST(yielded_arg, callback_arg))
 
 static VALUE
 vm_caller_setup_arg_block(const rb_execution_context_t *ec, rb_control_frame_t *reg_cfp,
-                          const struct rb_call_info *ci, rb_iseq_t *blockiseq, const int is_super)
+                          const struct rb_call_info *ci, const rb_iseq_t *blockiseq, const int is_super)
 {
     if (ci->flag & VM_CALL_ARGS_BLOCKARG) {
 	VALUE block_code = *(--reg_cfp->sp);


### PR DESCRIPTION
`send` and its variant instructions are the most frequently
called paths in the entire process.  Reducing macro expansions to
make them dedicated function called `vm_sendish()` is the main goal
of this changeset.  It reduces the size of `vm_exec_core` from
25,552 bytes to 23,728 bytes on my machine.

I see no significant slowdown.

```
vanilla: ruby 2.6.0dev (2018-12-19 trunk 66449) [x86_64-darwin15]
ours: ruby 2.6.0dev (2018-12-19 refactor-send 66449) [x86_64-darwin15]
last_commit=insns.def: refactor to avoid CALL_METHOD macro
Calculating -------------------------------------
                         vanilla        ours
   vm2_defined_method     2.645M      2.823M i/s -      6.000M times in 5.109888s 4.783254s
           vm2_method     8.553M      8.873M i/s -      6.000M times in 1.579892s 1.524026s
   vm2_method_missing     3.772M      3.858M i/s -      6.000M times in 3.579482s 3.499220s
vm2_method_with_block     8.494M      8.944M i/s -      6.000M times in 1.589774s 1.509463s
      vm2_poly_method      0.571       0.607 i/s -       1.000 times in 3.947570s 3.733528s
   vm2_poly_method_ov      5.514       5.168 i/s -       1.000 times in 0.408156s 0.436169s
 vm3_clearmethodcache      2.875       2.837 i/s -       1.000 times in 0.783018s 0.793493s

Comparison:
                vm2_defined_method
                 ours:   2822555.4 i/s
              vanilla:   2644878.1 i/s - 1.07x  slower

                        vm2_method
                 ours:   8872947.8 i/s
              vanilla:   8553433.1 i/s - 1.04x  slower

                vm2_method_missing
                 ours:   3858192.3 i/s
              vanilla:   3772296.3 i/s - 1.02x  slower

             vm2_method_with_block
                 ours:   8943825.1 i/s
              vanilla:   8493955.0 i/s - 1.05x  slower

                   vm2_poly_method
                 ours:         0.6 i/s
              vanilla:         0.6 i/s - 1.06x  slower

                vm2_poly_method_ov
              vanilla:         5.5 i/s
                 ours:         5.2 i/s - 1.07x  slower

              vm3_clearmethodcache
              vanilla:         2.9 i/s
                 ours:         2.8 i/s - 1.01x  slower
```