### PR TITLE
[Bug #15488] Add supported `Module#const_defined?` with `include` module.

### DIFF
--- a/object.c
+++ b/object.c
@@ -2688,7 +2688,6 @@ rb_mod_const_defined(int argc, VALUE *argv, VALUE mod)
 		return Qfalse;
 	    mod = rb_const_get_at(mod, id);
 	}
-	recur = Qfalse;
 
 	if (p < pend && !RB_TYPE_P(mod, T_MODULE) && !RB_TYPE_P(mod, T_CLASS)) {
 	    rb_raise(rb_eTypeError, "%"PRIsVALUE" does not refer to class/module",

--- a/test/ruby/test_module.rb
+++ b/test/ruby/test_module.rb
@@ -341,6 +341,10 @@ class TestModule < Test::Unit::TestCase
   def test_nested_defined_with_include
     assert_send([Object, :const_defined?, [self.class.name, 'User', 'MIXIN'].join('::')])
     assert_send([self.class, :const_defined?, 'User::MIXIN'])
+
+    # const_defined? with `false`
+    assert_not_send([Object, :const_defined?, [self.class.name, 'User', 'MIXIN'].join('::'), false])
+    assert_not_send([self.class, :const_defined?, 'User::MIXIN', false])
   end
 
   def test_nested_defined_bad_class

--- a/test/ruby/test_module.rb
+++ b/test/ruby/test_module.rb
@@ -338,6 +338,11 @@ class TestModule < Test::Unit::TestCase
     assert_raise(NameError) {self.class.const_defined?(const)}
   end
 
+  def test_nested_defined_with_include
+    assert_send([Object, :const_defined?, [self.class.name, 'User', 'MIXIN'].join('::')])
+    assert_send([self.class, :const_defined?, 'User::MIXIN'])
+  end
+
   def test_nested_defined_bad_class
     assert_raise(TypeError) do
       self.class.const_defined?('User::USER::Foo')


### PR DESCRIPTION
bugs.ruby : https://bugs.ruby-lang.org/issues/15488
base patch : https://github.com/ruby/ruby/commit/241ca7bfff26b1f624ef64212b68d76efcb78f9d