### PR TITLE
Update refinements docs

### DIFF
--- a/doc/syntax/refinements.rdoc
+++ b/doc/syntax/refinements.rdoc
@@ -247,11 +247,9 @@ Note that +super+ in a method of a refinement invokes the method in the
 refined class even if there is another refinement which has been activated in
 the same context.
 
-== Indirect Method Calls
+== Methods Introspection
 
-When using indirect method access such as Kernel#send, Kernel#method or
-Kernel#respond_to? refinements are not honored for the caller context during
-method lookup.
+When using introspection methods such as Kernel#method or Kernel#methods refinements are not honored.
 
 This behavior may be changed in the future.
 


### PR DESCRIPTION
`#public_send`, `#respond_to?` support has been added in 2.6.0 (https://bugs.ruby-lang.org/issues/15327, https://bugs.ruby-lang.org/issues/15326), `#send` worked before.