### PR TITLE
Allow using C99

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -226,25 +226,23 @@ env:
           - zlib1g:i386
 
   - &pedanticism
-    name: -ansi -pedantic
+    name: -std=c99 -pedantic
     <<: *linux
     <<: *make-test-only
     compiler: clang
     env:
-      - GCC_FLAGS='-ansi -Werror=pedantic -pedantic-errors -std=iso9899:1990'
+      - GCC_FLAGS='-std=c99 -Werror=pedantic -pedantic-errors'
       - CONFIG_FLAG=
       - JOBS=
       - >-
         warnflags='
         -Wall
         -Wextra
-        -Werror=declaration-after-statement
         -Werror=deprecated-declarations
         -Werror=division-by-zero
         -Werror=extra-tokens
         -Werror=implicit-function-declaration
         -Werror=implicit-int
-        -Werror=long-long
         -Werror=pointer-arith
         -Werror=shorten-64-to-32
         -Werror=write-strings


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/15347

To be discussed at [DevelopersMeeting 20190110 Japan](https://bugs.ruby-lang.org/issues/15462). We already started to use some C99 features since [r66597](https://github.com/ruby/ruby/commit/24b1b433c5abf02e9f9c7eb3851f4417dc5d8751), and enabled C99 in configure level since [r66598](https://github.com/ruby/ruby/commit/1095705c4218f8f752210f1a0b4f78d96ad675ac) and [r66605](https://github.com/ruby/ruby/commit/61885c9b7ca8ccdaf53d7c365fbb86bad3294d88). This patch just changes C90 build check on Travis to C99.

Here is the **draft** of our C99 dialect documentation to be posted:

<hr>

# C99 usage guideline

From Ruby 2.7, we require C compiler to support C99 features that work on environments supported by [platforms maintainers](https://github.com/ruby/ruby/blob/trunk/doc/contributing.rdoc#platform-maintainers).

## General rule

* C99 features that cannot be built on Travis/AppVeyor/RubyCI are prohibited.
  * Ruby 2.7 requires Visual Studio 2013+, which is tested on AppVeyor and RubyCI.
  * Ruby 2.7 requires Oracle Developer Studio 12+ or GCC on Solaris 10+, which are tested on RubyCI. (adding 12.4 and/or earlier is pending, but planned)

## Known supported features

Here is a list of features that are known to work on both Visual Studio 2013 and Oracle Developer Studio 12.5, confirmed by this [c99.c](https://gist.github.com/k0kubun/1719cbccd7738c02e5b8d7d1c12d7469).

This is just for a quick reference to bypass testing on CI, and you do **NOT** need to update this list to use your favorite C99 feature as long as it works on Travis/AppVeyor/RubyCI.

* // comments
* mixed declarations and code
* designated initializers
* compound literals
* relaxed constraints on aggregate and union initialization
* trailing comma allowed in enum declaration

See also:
* [ISO/IEC 9899:1999](http://www.open-std.org/jtc1/sc22/wg14/www/docs/n1124.pdf)
* [C99 library support in Visual Studio 2013](https://blogs.msdn.microsoft.com/vcblog/2013/07/19/c99-library-support-in-visual-studio-2013/)

### Discussions

* stdbool.h seems to have been [added in Oracle Solaris Studio 12.3](https://docs.oracle.com/cd/E24457_01/html/E21987/gkeza.html), so we need to use [missing/stdbool.h header](https://github.com/ruby/ruby/blob/trunk/missing/stdbool.h) for Oracle Solaris Studio 12.2 or earlier, which is included in our internal.h. See [r66739](https://github.com/ruby/ruby/commit/d8931259d0bfd8f4d97402250488a590be2a4453).
* `restrict` keyword does not exist on Visual Studio 2013, but [`__restrict`](https://docs.microsoft.com/en-us/cpp/cpp/extension-restrict?view=vs-2015) exists and is used instead.
  * See also: [r66598](https://github.com/ruby/ruby/commit/1095705c4218f8f752210f1a0b4f78d96ad675ac) and [r66715](https://github.com/ruby/ruby/commit/6c1ed519ef51fe8afb7e0ed7f0df2cd2fc0db13d).
* Switching `va_copy` definition like [r62220](https://github.com/ruby/ruby/commit/779c18bf238aba630e40c26e10ce8aa278c45d61) was problematic for cross compiling and removed in [r62463](https://github.com/ruby/ruby/commit/0f0c32f24e9556cf3d605df2891841659e6293f6).
  * [r62191](https://github.com/ruby/ruby/commit/8a0678b4c3120196321c4d4670b13ed099183dca) was initially introduced for old Visual Studio. We may be able to just use `va_copy` with Ruby 2.7's Visual Studio 2013 requirement.

## Known missing features

* Visual Studio 2013
  * variable length arrays
  * `_Complex`
  * snprintf
  * some format specifier behaviors:
     * size_t length modifier: %z
     * [infinite/indefinite/NaN conversion of floating point number](https://docs.microsoft.com/en-us/cpp/c-runtime-library/format-specification-syntax-printf-and-wprintf-functions?view=vs-2017)