### PR TITLE
Reword error message for shebang ending with \r

### DIFF
--- a/ruby.c
+++ b/ruby.c
@@ -1876,7 +1876,7 @@ static void
 warn_cr_in_shebang(const char *str, long len)
 {
     if (str[len-1] == '\n' && str[len-2] == '\r') {
-	rb_warn("shebang line ending with \\r may cause problems");
+	rb_warn("shebang ending with \\r may cause problems");
     }
 }
 #else

--- a/test/ruby/test_rubyoptions.rb
+++ b/test/ruby/test_rubyoptions.rb
@@ -393,7 +393,7 @@ class TestRubyOptions < Test::Unit::TestCase
     assert_in_out_err([], "#! /test_r_u_b_y_test_r_u_b_y_options_foobarbazqux -foo -bar\r\np 1\r\n",
                       [], /: no Ruby script found in input/)
 
-    warning = /mswin|mingw/ =~ RUBY_PLATFORM ? [] : /shebang line ending with \\r/
+    warning = /mswin|mingw/ =~ RUBY_PLATFORM ? [] : /shebang ending with \\r/
     assert_in_out_err([{'RUBYOPT' => nil}], "#!ruby -KU -Eutf-8\r\np \"\u3042\"\r\n",
                       ["\"\u3042\""], warning,
                       encoding: Encoding::UTF_8)


### PR DESCRIPTION
Ruby prints a warning if a shebang ends with `\r`. The warning messages is:

> shebang line ending with \r may cause problems

This is a bit misleading because the the _line_ actually ends with `\r\n`. It's just the shebang which ends with `\r`. I've changed the error message accordingly:

> shebang ending with \r may cause problems