### PR TITLE
Fix return value name in docs for Array#union

### DIFF
--- a/array.c
+++ b/array.c
@@ -4683,7 +4683,7 @@ rb_ary_or(VALUE ary1, VALUE ary2)
 
 /*
  *  call-seq:
- *     ary.union(other_ary1, other_ary2, ...)   -> ary
+ *     ary.union(other_ary1, other_ary2, ...)   -> new_ary
  *
  *  Set Union --- Returns a new array by joining <code>other_ary</code>s with +self+,
  *  excluding any duplicates and preserving the order from the given arrays.


### PR DESCRIPTION
Throughout the docs, `new_ary` is used to indicate a new array, whereas `ary` refers to the receiver.