### PR TITLE
Early return in gc_mark_children for types Float, Bignum and Symbol as they do not have references

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -4694,6 +4694,11 @@ gc_mark_children(rb_objspace_t *objspace, VALUE obj)
     }
 
     switch (BUILTIN_TYPE(obj)) {
+      /* Not immediates, but does not have references */
+      case T_FLOAT:
+      case T_BIGNUM:
+      case T_SYMBOL:
+    return;
       case T_NIL:
       case T_FIXNUM:
 	rb_bug("rb_gc_mark() called for broken object");
@@ -4803,11 +4808,6 @@ gc_mark_children(rb_objspace_t *objspace, VALUE obj)
 
       case T_REGEXP:
         gc_mark(objspace, any->as.regexp.src);
-	break;
-
-      case T_FLOAT:
-      case T_BIGNUM:
-      case T_SYMBOL:
 	break;
 
       case T_MATCH:


### PR DESCRIPTION
### Rationale

Besides generic ivars as per flag `FL_EXIVAR`, `Float`, `Bignum` and `Symbol` types do not have references to other objects (the string member on `RSymbol` is a `fstring`)

Therefore in the mark phase we can skip the following:

* `gc_mark(objspace, any->as.basic.klass)` - I *think* this is fine as `Float`, `Bignum` and `Symbol` are builtin types, but may be wrong on the assumption that it's OK to skip marking the class.
* Second switch statement on object type

### Benchmarks

I noticed the GC benchmarks favor specific types (`Hash`, `String`, `Array`, `Symbol`) and thus only exercise specific paths through the mark and sweep phases. Would a complex one with regex, match, struct etc. be useful for the suite moving forward?

```
lourens@CarbonX1:~/src/ruby/ruby$ /usr/local/bin/ruby --disable=gems -rrubygems -I./benchmark/lib ./benchmark/benchmark-driver/exe/benchmark-driver             --executables="compare-ruby::~/src/ruby/trunk/ruby --disable=gems -I.ext/common --disable-gem"             --executables="built-ruby::./miniruby -I./lib -I. -I.ext/common  -r./prelude --disable-gem" -v --repeat-count=12 $(ls ./benchmark/*gc*.{yml,rb} 2>/dev/null)
compare-ruby: ruby 2.7.0dev (2019-03-06 trunk 67187) [x86_64-linux]
built-ruby: ruby 2.7.0dev (2019-03-06 trunk 67187) [x86_64-linux]
Calculating -------------------------------------
                               compare-ruby  built-ruby 
            vm1_gc_short_lived       6.364M      6.915M i/s -     30.000M times in 4.714021s 4.338217s
vm1_gc_short_with_complex_long       8.073M      8.099M i/s -     30.000M times in 3.715946s 3.703985s
        vm1_gc_short_with_long       6.362M      6.290M i/s -     30.000M times in 4.715409s 4.769474s
      vm1_gc_short_with_symbol       7.300M      7.175M i/s -     30.000M times in 4.109534s 4.181343s
        vm1_gc_wb_ary_promoted      56.083M     54.238M i/s -     30.000M times in 0.534920s 0.553122s
                 vm1_gc_wb_ary      57.205M     54.741M i/s -     30.000M times in 0.524428s 0.548034s
        vm1_gc_wb_obj_promoted      71.012M     78.023M i/s -     30.000M times in 0.422465s 0.384504s
                 vm1_gc_wb_obj      71.611M     72.401M i/s -     30.000M times in 0.418932s 0.414359s
               vm3_gc_old_full        0.341       0.340 i/s -       1.000 times in 2.929841s 2.940783s
          vm3_gc_old_immediate        0.469       0.485 i/s -       1.000 times in 2.130472s 2.063423s
               vm3_gc_old_lazy        0.340       0.363 i/s -       1.000 times in 2.940200s 2.751479s
                        vm3_gc        0.701       0.771 i/s -       1.000 times in 1.427213s 1.296977s

Comparison:
                         vm1_gc_short_lived
                    built-ruby:   6915284.2 i/s 
                  compare-ruby:   6363993.5 i/s - 1.09x  slower

             vm1_gc_short_with_complex_long
                    built-ruby:   8099385.4 i/s 
                  compare-ruby:   8073315.0 i/s - 1.00x  slower

                     vm1_gc_short_with_long
                  compare-ruby:   6362120.8 i/s 
                    built-ruby:   6290001.2 i/s - 1.01x  slower

                   vm1_gc_short_with_symbol
                  compare-ruby:   7300098.5 i/s 
                    built-ruby:   7174728.6 i/s - 1.02x  slower

                     vm1_gc_wb_ary_promoted
                  compare-ruby:  56083164.4 i/s 
                    built-ruby:  54237542.7 i/s - 1.03x  slower

                              vm1_gc_wb_ary
                  compare-ruby:  57205144.8 i/s 
                    built-ruby:  54741091.5 i/s - 1.05x  slower

                     vm1_gc_wb_obj_promoted
                    built-ruby:  78022543.6 i/s 
                  compare-ruby:  71011791.2 i/s - 1.10x  slower

                              vm1_gc_wb_obj
                    built-ruby:  72401070.9 i/s 
                  compare-ruby:  71610641.3 i/s - 1.01x  slower

                            vm3_gc_old_full
                  compare-ruby:         0.3 i/s 
                    built-ruby:         0.3 i/s - 1.00x  slower

                       vm3_gc_old_immediate
                    built-ruby:         0.5 i/s 
                  compare-ruby:         0.5 i/s - 1.03x  slower

                            vm3_gc_old_lazy
                    built-ruby:         0.4 i/s 
                  compare-ruby:         0.3 i/s - 1.07x  slower

                                     vm3_gc
                    built-ruby:         0.8 i/s 
                  compare-ruby:         0.7 i/s - 1.10x  slower
```
