### PR TITLE
Fix CSV delegation to missing StringIO methods

### DIFF
--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -1670,12 +1670,40 @@ class CSV
   ### IO and StringIO Delegation ###
 
   extend Forwardable
-  def_delegators :@io, :binmode, :binmode?, :close, :close_read, :close_write,
+  def_delegators :@io, :binmode, :close, :close_read, :close_write,
                        :closed?, :eof, :eof?, :external_encoding, :fcntl,
-                       :fileno, :flock, :flush, :fsync, :internal_encoding,
-                       :ioctl, :isatty, :path, :pid, :pos, :pos=, :reopen,
-                       :seek, :stat, :string, :sync, :sync=, :tell, :to_i,
+                       :fileno, :flush, :fsync, :internal_encoding,
+                       :isatty, :pid, :pos, :pos=, :reopen,
+                       :seek, :string, :sync, :sync=, :tell, :to_i,
                        :to_io, :truncate, :tty?
+
+  def binmode? # :nodoc:
+    @io.binmode? if @io.respond_to?(:binmode?)
+  end
+
+  def flock(*args) # :nodoc:
+    @io.flock(*args) if @io.respond_to?(:flock)
+  end
+
+  def ioctl(*args) # :nodoc:
+    @io.ioctl(*args) if @io.respond_to?(:ioctl)
+  end
+
+  def path # :nodoc:
+    @io.path if @io.respond_to?(:path)
+  end
+
+  def stat(*args) # :nodoc:
+    @io.stat(*args) if @io.respond_to?(:stat)
+  end
+
+  def to_i # :nodoc:
+    @io.respond_to?(:to_i) ? @io.to_i : 0
+  end
+
+  def to_io # :nodoc:
+    @io.respond_to?(:to_io) ? @io.to_io : @io
+  end
 
   # Rewinds the underlying IO object and resets CSV's lineno() counter.
   def rewind

--- a/test/csv/test_interface.rb
+++ b/test/csv/test_interface.rb
@@ -306,4 +306,18 @@ class TestCSVInterface < Test::Unit::TestCase
     assert_equal(STDOUT, CSV.instance.instance_eval { @io })
     assert_equal(STDOUT, CSV { |new_csv| new_csv.instance_eval { @io } })
   end
+
+  ### Test IO and StringIO Delegation ###
+
+  def test_stringio_missing_methods_delegation
+    csv = CSV.new("h1,h2")
+
+    assert_equal(nil, csv.binmode?)
+    assert_equal(nil, csv.flock(0))
+    assert_equal(nil, csv.ioctl(0, 0))
+    assert_equal(nil, csv.path)
+    assert_equal(nil, csv.stat)
+    assert_equal(0, csv.to_i)
+    assert_instance_of(StringIO, csv.to_io)
+  end
 end


### PR DESCRIPTION
If you create a CSV from raw content like:

    csv = CSV.new("h1,h2")

You'll get method missing when calling `csv.path` but still get `true` when you call `csv.respond_to?(:path)`.

This tricks 3rd party libraries like carrierwave which try to call `path` on their input if it responds to it.

See https://github.com/carrierwaveuploader/carrierwave/blob/a91ab69fdd8052cdf5a5e48ef8baf40939e441fb/lib/carrierwave/sanitized_file.rb#L109-L123

This stops me from passing CSV objects as StringIO's into carrierwave uploads, for example, but the problem can also be manifested in other 3rd party libraries, as responding to a method and returning a
`NoMethodError` when calling it is still an unexpected behavior.

I have went through the CSV delegation scheme and made sure that every method that StringIO doesn't respond to returns a meaningful zero value and does not raise a `NoMethodError` while used through a CSV Instance.