### PR TITLE
Only define history_root member of the Oniguruma re_registers struct if USE_CAPTURE_HISTORY is enabled

### DIFF
--- a/include/ruby/onigmo.h
+++ b/include/ruby/onigmo.h
@@ -701,6 +701,7 @@ ONIG_EXTERN const OnigSyntaxType*   OnigDefaultSyntax;
 #define ONIG_IS_CAPTURE_HISTORY_GROUP(r, i) \
   ((i) <= ONIG_MAX_CAPTURE_HISTORY_GROUP && (r)->list && (r)->list[i])
 
+#ifdef USE_CAPTURE_HISTORY
 typedef struct OnigCaptureTreeNodeStruct {
   int group;   /* group number */
   OnigPosition beg;
@@ -709,6 +710,7 @@ typedef struct OnigCaptureTreeNodeStruct {
   int num_childs;
   struct OnigCaptureTreeNodeStruct** childs;
 } OnigCaptureTreeNode;
+#endif
 
 /* match result region type */
 struct re_registers {
@@ -716,8 +718,10 @@ struct re_registers {
   int  num_regs;
   OnigPosition* beg;
   OnigPosition* end;
+#ifdef USE_CAPTURE_HISTORY
   /* extended */
   OnigCaptureTreeNode* history_root;  /* capture history tree root */
+#endif
 };
 
 /* capture tree traverse */
@@ -866,8 +870,10 @@ ONIG_EXTERN
 int onig_number_of_captures(const OnigRegexType *reg);
 ONIG_EXTERN
 int onig_number_of_capture_histories(const OnigRegexType *reg);
+#ifdef USE_CAPTURE_HISTORY
 ONIG_EXTERN
 OnigCaptureTreeNode* onig_get_capture_tree(OnigRegion* region);
+#endif
 ONIG_EXTERN
 int onig_capture_tree_traverse(OnigRegion* region, int at, int(*callback_func)(int,OnigPosition,OnigPosition,int,int,void*), void* arg);
 ONIG_EXTERN

--- a/regexec.c
+++ b/regexec.c
@@ -323,7 +323,9 @@ onig_region_init(OnigRegion* region)
   region->allocated    = 0;
   region->beg          = (OnigPosition* )0;
   region->end          = (OnigPosition* )0;
+#ifdef USE_CAPTURE_HISTORY
   region->history_root = (OnigCaptureTreeNode* )0;
+#endif
 }
 
 extern OnigRegion*


### PR DESCRIPTION
Shaves 8 bytes on 64bit off `struct rmatch`:

```
struct rmatch {
    struct re_registers regs; <<<<<

    int char_offset_updated;
    int char_offset_num_allocated;
    struct rmatch_offset *char_offset;
};
```

```
lourens@CarbonX1:~/src/ruby/ruby$ pahole -C rmatch ./miniruby
struct rmatch {
	struct re_registers        regs;                 /*     0    24 */
	int                        char_offset_updated;  /*    24     4 */
	int                        char_offset_num_allocated; /*    28     4 */
	struct rmatch_offset *     char_offset;          /*    32     8 */

	/* size: 40, cachelines: 1, members: 4 */
	/* last cacheline: 40 bytes */
};
```

```
lourens@CarbonX1:~/src/ruby/trunk$ pahole -C rmatch ./miniruby
struct rmatch {
	struct re_registers        regs;                 /*     0    32 */
	int                        char_offset_updated;  /*    32     4 */
	int                        char_offset_num_allocated; /*    36     4 */
	struct rmatch_offset *     char_offset;          /*    40     8 */

	/* size: 48, cachelines: 1, members: 4 */
	/* last cacheline: 48 bytes */
};
```

```
lourens@CarbonX1:~/src/ruby/ruby$ /usr/local/bin/ruby --disable=gems -rrubygems -I./benchmark/lib ./benchmark/benchmark-driver/exe/benchmark-driver             --executables="compare-ruby::~/src/ruby/trunk/ruby --disable=gems -I.ext/common --disable-gem"             --executables="built-ruby::./miniruby -I./lib -I. -I.ext/common  -r./prelude --disable-gem" -v --repeat-count=12 -r memory $(ls ./benchmark/*erb*.{yml,rb} 2>/dev/null)
compare-ruby: ruby 2.7.0dev (2019-03-16 trunk 67272) [x86_64-linux]
built-ruby: ruby 2.7.0dev (2019-03-16 conditional-hi.. 67272) [x86_64-linux]
last_commit=Only define history_root member of the OnigRegion struct if USE_CAPTURE_HISTORY is enabled
Calculating -------------------------------------
                     compare-ruby  built-ruby 
             app_erb      12.076M     11.684M bytes -     15.000k times
          erb_render      13.428M     13.156M bytes -      1.500M times

Comparison:
                          app_erb
          built-ruby:  11684000.0 bytes 
        compare-ruby:  12076000.0 bytes - 1.03x  larger

                       erb_render
          built-ruby:  13156000.0 bytes 
        compare-ruby:  13428000.0 bytes - 1.02x  larger
```