### PR TITLE
Remove member char_offset_updated from struct rmatch as member char_offset_num_allocated can serve the same purpose as that predicate

### DIFF
--- a/include/ruby/re.h
+++ b/include/ruby/re.h
@@ -36,9 +36,8 @@ struct rmatch_offset {
 struct rmatch {
     struct re_registers regs;
 
-    int char_offset_updated;
-    int char_offset_num_allocated;
     struct rmatch_offset *char_offset;
+    int char_offset_num_allocated;
 };
 
 struct RMatch {

--- a/re.c
+++ b/re.c
@@ -984,7 +984,7 @@ update_char_offset(VALUE match)
     rb_encoding *enc;
     pair_t *pairs;
 
-    if (rm->char_offset_updated)
+    if (rm->char_offset_num_allocated)
         return;
 
     regs = &rm->regs;
@@ -1001,7 +1001,6 @@ update_char_offset(VALUE match)
             rm->char_offset[i].beg = BEG(i);
             rm->char_offset[i].end = END(i);
         }
-        rm->char_offset_updated = 1;
         return;
     }
 
@@ -1040,8 +1039,6 @@ update_char_offset(VALUE match)
         found = bsearch(&key, pairs, num_pos, sizeof(pair_t), pair_byte_cmp);
         rm->char_offset[i].end = found->char_pos;
     }
-
-    rm->char_offset_updated = 1;
 }
 
 static void
@@ -1067,17 +1064,13 @@ match_init_copy(VALUE obj, VALUE orig)
     if (rb_reg_region_copy(&rm->regs, RMATCH_REGS(orig)))
 	rb_memerror();
 
-    if (!RMATCH(orig)->rmatch->char_offset_updated) {
-        rm->char_offset_updated = 0;
-    }
-    else {
+    if (RMATCH(orig)->rmatch->char_offset_num_allocated) {
         if (rm->char_offset_num_allocated < rm->regs.num_regs) {
             REALLOC_N(rm->char_offset, struct rmatch_offset, rm->regs.num_regs);
             rm->char_offset_num_allocated = rm->regs.num_regs;
         }
         MEMCPY(rm->char_offset, RMATCH(orig)->rmatch->char_offset,
                struct rmatch_offset, rm->regs.num_regs);
-        rm->char_offset_updated = 1;
 	RB_GC_GUARD(orig);
     }
 
@@ -1338,7 +1331,6 @@ match_set_string(VALUE m, VALUE string, long pos, long len)
     onig_region_resize(&rmatch->regs, 1);
     rmatch->regs.beg[0] = pos;
     rmatch->regs.end[0] = pos + len;
-    rmatch->char_offset_updated = 0;
     OBJ_INFECT(match, string);
 }
 
@@ -1613,7 +1605,6 @@ rb_reg_search0(VALUE re, VALUE str, long pos, int reverse, int set_backref_str)
     }
 
     RMATCH(match)->regexp = re;
-    RMATCH(match)->rmatch->char_offset_updated = 0;
     rb_backref_set(match);
 
     OBJ_INFECT(match, re);
@@ -1696,7 +1687,6 @@ rb_reg_start_with_p(VALUE re, VALUE str)
     OBJ_INFECT(match, str);
 
     RMATCH(match)->regexp = re;
-    RMATCH(match)->rmatch->char_offset_updated = 0;
     rb_backref_set(match);
 
     OBJ_INFECT(match, re);


### PR DESCRIPTION
Builds on but not coupled to https://github.com/ruby/ruby/pull/2095

I noticed that the `char_offset_updated` predicate member is only ever set in context of `update_char_offset` and `match_init_copy` and these are also the only places where allocation of the `char_offset` array of structs happen.

Given `struct rmatch` is allocated with `ZALLOC`, it should be zeroed out and we can rely on semantics of `char_offset_num_allocated = 0` effectively replacing the `char_offset_updated` member.

```
lourens@CarbonX1:~/src/ruby/ruby$ /usr/local/bin/ruby --disable=gems -rrubygems -I./benchmark/lib ./benchmark/benchmark-driver/exe/benchmark-driver             --executables="compare-ruby::~/src/ruby/trunk/ruby --disable=gems -I.ext/common --disable-gem"             --executables="built-ruby::./miniruby -I./lib -I. -I.ext/common  -r./prelude --disable-gem" -v --repeat-count=12 -r memory $(ls ./benchmark/*erb*.{yml,rb} 2>/dev/null)
compare-ruby: ruby 2.7.0dev (2019-03-16 trunk 67272) [x86_64-linux]
built-ruby: ruby 2.7.0dev (2019-03-16 oust-char-offs.. 67272) [x86_64-linux]
Calculating -------------------------------------
                     compare-ruby  built-ruby 
             app_erb      12.040M     11.644M bytes -     15.000k times
          erb_render      13.372M     13.288M bytes -      1.500M times

Comparison:
                          app_erb
          built-ruby:  11644000.0 bytes 
        compare-ruby:  12040000.0 bytes - 1.03x  larger

                       erb_render
          built-ruby:  13288000.0 bytes 
        compare-ruby:  13372000.0 bytes - 1.01x  larger
```