### PR TITLE
Shrink the instruction sequence mark array capacity to exact fit when encoded

### DIFF
--- a/array.c
+++ b/array.c
@@ -444,6 +444,21 @@ ary_shrink_capa(VALUE ary)
     ary_verify(ary);
 }
 
+void rb_ary_shrink_capa(VALUE ary)
+{
+    long capacity, old_capa;
+    /* OK to modify a frozen array by only reducing capacity */
+    if (ARY_OWNS_HEAP_P(ary))
+    {
+       capacity = ARY_HEAP_LEN(ary);
+       old_capa = ARY_HEAP_CAPA(ary);
+       if (old_capa > capacity) {
+           ary_heap_realloc(ary, capacity);
+           RARRAY(ary)->as.heap.aux.capa = capacity;
+       }
+    }
+}
+
 static void
 ary_double_capa(VALUE ary, long min)
 {

--- a/array.c
+++ b/array.c
@@ -635,6 +635,8 @@ ary_ensure_room_for_push(VALUE ary, long add_len)
 VALUE
 rb_ary_freeze(VALUE ary)
 {
+    if (OBJ_FROZEN(ary)) return ary;
+    rb_ary_shrink_capa(ary);
     return rb_obj_freeze(ary);
 }
 

--- a/compile.c
+++ b/compile.c
@@ -752,6 +752,14 @@ rb_iseq_translate_threaded_code(rb_iseq_t *iseq)
 	encoded[i] = (VALUE)table[insn];
 	i += len;
     }
+
+    // Exact fit resize mark array capacity on iseq translation
+    if (FL_TEST_RAW(iseq, ISEQ_USE_COMPILE_DATA)) {
+        const struct iseq_compile_data *const compile_data = ISEQ_COMPILE_DATA(iseq);
+        if (compile_data->mark_ary != Qnil) {
+            rb_ary_shrink_capa(compile_data->mark_ary);
+        }
+    }
     FL_SET(iseq, ISEQ_TRANSLATED);
 #endif
     return COMPILE_OK;

--- a/compile.c
+++ b/compile.c
@@ -757,7 +757,7 @@ rb_iseq_translate_threaded_code(rb_iseq_t *iseq)
     if (FL_TEST_RAW(iseq, ISEQ_USE_COMPILE_DATA)) {
         const struct iseq_compile_data *const compile_data = ISEQ_COMPILE_DATA(iseq);
         if (compile_data->mark_ary != Qnil) {
-            rb_ary_shrink_capa(compile_data->mark_ary);
+            rb_ary_freeze(compile_data->mark_ary);
         }
     }
     FL_SET(iseq, ISEQ_TRANSLATED);

--- a/internal.h
+++ b/internal.h
@@ -1251,7 +1251,7 @@ VALUE rb_gvar_defined(struct rb_global_entry *);
 #define RARY_TRANSIENT_UNSET(ary) ((void)0)
 #endif
 
-
+void rb_ary_shrink_capa(VALUE);
 VALUE rb_ary_last(int, const VALUE *, VALUE);
 void rb_ary_set_len(VALUE, long);
 void rb_ary_delete_same(VALUE, VALUE);


### PR DESCRIPTION
Resurrects the `rb_ary_shrink_capa` API from the proof of concept in https://github.com/ruby/ruby/pull/2037 , apply it to `rb_ary_freeze` and subsequently also freezes the iseq mark array as it should be immutable.

I don't see any significant / relevant boot time penalty on booting redmine compared to trunk.

`388kb` reduction on redmine dev mode boot, with an expected increase relative to the amount of iseqs with compile data in larger Rails apps:

```
lourens@CarbonX1:~/src/redmine$ bundle exec rails c
Loading development environment (Rails 5.2.1.1)
irb(main):001:0> RUBY_DESCRIPTION
=> "ruby 2.7.0dev (2019-03-17 shrink-iseq-ma.. 67275) [x86_64-linux]"
irb(main):002:0> GC.start
=> nil
irb(main):003:0> puts 'RAM USAGE: ' + `pmap #{Process.pid} | tail -1`[10,40].strip
RAM USAGE: 364652K
=> nil
irb(main):004:0> exit
lourens@CarbonX1:~/src/redmine$ bundle exec rails c
Loading development environment (Rails 5.2.1.1)
irb(main):001:0> RUBY_DESCRIPTION
=> "ruby 2.7.0dev (2019-03-17 trunk 67275) [x86_64-linux]"
irb(main):002:0> GC.start
=> nil
irb(main):003:0> puts 'RAM USAGE: ' + `pmap #{Process.pid} | tail -1`[10,40].strip
RAM USAGE: 365040K
=> nil
irb(main):004:0> 
```

There's further spots where the pattern of using arrays as a mark stack piggy backing off existing GC recursive mark patterns for `T_ARRAY` in `gc.c` is applied. Notably the catch table on iseqs, the AST (see `rb_node_buffer_new`) etc.

The primary reason for splitting out `rb_ary_shrink_capa` in this PR is to enable further scavenging of over allocated arrays in a few other spots.

@tenderlove I *think* this also covers most of https://twitter.com/tenderlove/status/951204087382491136