### PR TITLE
Shrink struct re_pattern_buffer from 448 to 440 bytes

### DIFF
--- a/include/ruby/onigmo.h
+++ b/include/ruby/onigmo.h
@@ -767,20 +767,21 @@ typedef struct re_pattern_buffer {
 
   OnigOptionType    options;
 
+  OnigCaseFoldType  case_fold_flag;
+
   OnigRepeatRange* repeat_range;
 
   OnigEncoding      enc;
   const OnigSyntaxType* syntax;
   void*             name_table;
-  OnigCaseFoldType  case_fold_flag;
 
   /* optimization info (string search, char-map and anchors) */
   int            optimize;          /* optimize flag */
   int            threshold_len;     /* search str-length for apply optimize */
   int            anchor;            /* BEGIN_BUF, BEGIN_POS, (SEMI_)END_BUF */
+  int            sub_anchor;        /* start-anchor for exact or map */
   OnigDistance   anchor_dmin;       /* (SEMI_)END_BUF anchor distance */
   OnigDistance   anchor_dmax;       /* (SEMI_)END_BUF anchor distance */
-  int            sub_anchor;        /* start-anchor for exact or map */
   unsigned char *exact;
   unsigned char *exact_end;
   unsigned char  map[ONIG_CHAR_TABLE_SIZE]; /* used as BM skip or char-map */


### PR DESCRIPTION
Gist of the changes:

* Moves `case_fold_flag` up, fits within the first cache line now
* Moves `sub_anchor` from the optimization specific struct members up, squeezing into the 2nd cache line
* No further locality of reference side effects for the other members

Trunk, 448 bytes:

```
lourens@CarbonX1:~/src/ruby/trunk$ pahole -C re_pattern_buffer ./miniruby
struct re_pattern_buffer {
	unsigned char *            p;                    /*     0     8 */
	unsigned int               used;                 /*     8     4 */
	unsigned int               alloc;                /*    12     4 */
	int                        num_mem;              /*    16     4 */
	int                        num_repeat;           /*    20     4 */
	int                        num_null_check;       /*    24     4 */
	int                        num_comb_exp_check;   /*    28     4 */
	int                        num_call;             /*    32     4 */
	unsigned int               capture_history;      /*    36     4 */
	unsigned int               bt_mem_start;         /*    40     4 */
	unsigned int               bt_mem_end;           /*    44     4 */
	int                        stack_pop_level;      /*    48     4 */
	int                        repeat_range_alloc;   /*    52     4 */
	OnigOptionType             options;              /*    56     4 */

	/* XXX 4 bytes hole, try to pack */

	/* --- cacheline 1 boundary (64 bytes) --- */
	OnigRepeatRange *          repeat_range;         /*    64     8 */
	OnigEncoding               enc;                  /*    72     8 */
	const OnigSyntaxType  *    syntax;               /*    80     8 */
	void *                     name_table;           /*    88     8 */
	OnigCaseFoldType           case_fold_flag;       /*    96     4 */
	int                        optimize;             /*   100     4 */
	int                        threshold_len;        /*   104     4 */
	int                        anchor;               /*   108     4 */
	OnigDistance               anchor_dmin;          /*   112     8 */
	OnigDistance               anchor_dmax;          /*   120     8 */
	/* --- cacheline 2 boundary (128 bytes) --- */
	int                        sub_anchor;           /*   128     4 */

	/* XXX 4 bytes hole, try to pack */

	unsigned char *            exact;                /*   136     8 */
	unsigned char *            exact_end;            /*   144     8 */
	unsigned char              map[256];             /*   152   256 */
	/* --- cacheline 6 boundary (384 bytes) was 24 bytes ago --- */
	int *                      int_map;              /*   408     8 */
	int *                      int_map_backward;     /*   416     8 */
	OnigDistance               dmin;                 /*   424     8 */
	OnigDistance               dmax;                 /*   432     8 */
	struct re_pattern_buffer * chain;                /*   440     8 */

	/* size: 448, cachelines: 7, members: 33 */<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
	/* sum members: 440, holes: 2, sum holes: 8 */
};
```

This branch:

```
lourens@CarbonX1:~/src/ruby/ruby$ pahole -C re_pattern_buffer ./miniruby
struct re_pattern_buffer {
	unsigned char *            p;                    /*     0     8 */
	unsigned int               used;                 /*     8     4 */
	unsigned int               alloc;                /*    12     4 */
	int                        num_mem;              /*    16     4 */
	int                        num_repeat;           /*    20     4 */
	int                        num_null_check;       /*    24     4 */
	int                        num_comb_exp_check;   /*    28     4 */
	int                        num_call;             /*    32     4 */
	unsigned int               capture_history;      /*    36     4 */
	unsigned int               bt_mem_start;         /*    40     4 */
	unsigned int               bt_mem_end;           /*    44     4 */
	int                        stack_pop_level;      /*    48     4 */
	int                        repeat_range_alloc;   /*    52     4 */
	OnigOptionType             options;              /*    56     4 */
	OnigCaseFoldType           case_fold_flag;       /*    60     4 */<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
	/* --- cacheline 1 boundary (64 bytes) --- */
	OnigRepeatRange *          repeat_range;         /*    64     8 */
	OnigEncoding               enc;                  /*    72     8 */
	const OnigSyntaxType  *    syntax;               /*    80     8 */
	void *                     name_table;           /*    88     8 */
	int                        optimize;             /*    96     4 */
	int                        threshold_len;        /*   100     4 */
	int                        anchor;               /*   104     4 */
	int                        sub_anchor;           /*   108     4 */ <<<<<<<<<<<<<<<<<<<<<<<<<<<<<
	OnigDistance               anchor_dmin;          /*   112     8 */
	OnigDistance               anchor_dmax;          /*   120     8 */
	/* --- cacheline 2 boundary (128 bytes) --- */
	unsigned char *            exact;                /*   128     8 */
	unsigned char *            exact_end;            /*   136     8 */
	unsigned char              map[256];             /*   144   256 */
	/* --- cacheline 6 boundary (384 bytes) was 16 bytes ago --- */
	int *                      int_map;              /*   400     8 */
	int *                      int_map_backward;     /*   408     8 */
	OnigDistance               dmin;                 /*   416     8 */
	OnigDistance               dmax;                 /*   424     8 */
	struct re_pattern_buffer * chain;                /*   432     8 */

	/* size: 440, cachelines: 7, members: 33 */<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
	/* last cacheline: 56 bytes */
};
```