### PR TITLE
Pack rb_iseq_constant_body from 296 to 288 bytes

### DIFF
--- a/vm_core.h
+++ b/vm_core.h
@@ -460,6 +460,8 @@ struct rb_iseq_constant_body {
     unsigned int ci_kw_size;
     unsigned int stack_max; /* for stack overflow check */
 
+    char catch_except_p; /* If a frame of this ISeq may catch exception, set TRUE */
+
 #if USE_MJIT
     /* The following fields are MJIT related info.  */
     VALUE (*jit_func)(struct rb_execution_context_struct *,
@@ -467,7 +469,6 @@ struct rb_iseq_constant_body {
     long unsigned total_calls; /* number of total calls with `mjit_exec()` */
     struct rb_mjit_unit *jit_unit;
 #endif
-    char catch_except_p; /* If a frame of this ISeq may catch exception, set TRUE */
 };
 
 /* T_IMEMO/iseq */


### PR DESCRIPTION
Another small change, gist of it:

* Move `catch_except_p` up to above the conditional MJIT specific members
* I think this grouping still makes functional sense as `catch_except_p` is the last member on a default build that includes MJIT support and I don't see moving it after the stack specific ones breaking semantics
* No locality of reference changes - all shuffled members still on cache line 5 

Trunk, 296 bytes:
```
lourens@CarbonX1:~/src/ruby/ruby$ pahole -C rb_iseq_constant_body ./miniruby
struct rb_iseq_constant_body {
	enum iseq_type             type;                 /*     0     4 */
	unsigned int               iseq_size;            /*     4     4 */
	const VALUE  *             iseq_encoded;         /*     8     8 */
	struct {
		struct {
			unsigned int has_lead:1;         /*    16:31  4 */
			unsigned int has_opt:1;          /*    16:30  4 */
			unsigned int has_rest:1;         /*    16:29  4 */
			unsigned int has_post:1;         /*    16:28  4 */
			unsigned int has_kw:1;           /*    16:27  4 */
			unsigned int has_kwrest:1;       /*    16:26  4 */
			unsigned int has_block:1;        /*    16:25  4 */
			unsigned int ambiguous_param0:1; /*    16:24  4 */
		} flags;                                 /*    16     4 */
		unsigned int       size;                 /*    20     4 */
		int                lead_num;             /*    24     4 */
		int                opt_num;              /*    28     4 */
		int                rest_start;           /*    32     4 */
		int                post_start;           /*    36     4 */
		int                post_num;             /*    40     4 */
		int                block_start;          /*    44     4 */
		const VALUE  *     opt_table;            /*    48     8 */
		const struct rb_iseq_param_keyword  * keyword; /*    56     8 */
	} param;                                         /*    16    48 */
	/* --- cacheline 1 boundary (64 bytes) --- */
	rb_iseq_location_t         location;             /*    64    56 */
	struct iseq_insn_info      insns_info;           /*   120    32 */
	/* --- cacheline 2 boundary (128 bytes) was 24 bytes ago --- */
	const ID  *                local_table;          /*   152     8 */
	const struct iseq_catch_table  * catch_table;    /*   160     8 */
	const struct rb_iseq_struct  * parent_iseq;      /*   168     8 */
	struct rb_iseq_struct *    local_iseq;           /*   176     8 */
	union iseq_inline_storage_entry * is_entries;    /*   184     8 */
	/* --- cacheline 3 boundary (192 bytes) --- */
	struct rb_call_info *      ci_entries;           /*   192     8 */
	struct rb_call_cache *     cc_entries;           /*   200     8 */
	struct {
		rb_snum_t          flip_count;           /*   208     8 */
		VALUE              coverage;             /*   216     8 */
		VALUE              pc2branchindex;       /*   224     8 */
		VALUE *            original_iseq;        /*   232     8 */
	} variable;                                      /*   208    32 */
	unsigned int               local_table_size;     /*   240     4 */
	unsigned int               is_size;              /*   244     4 */
	unsigned int               ci_size;              /*   248     4 */
	unsigned int               ci_kw_size;           /*   252     4 */
	/* --- cacheline 4 boundary (256 bytes) --- */
	unsigned int               stack_max;            /*   256     4 */

	/* XXX 4 bytes hole, try to pack */

	VALUE                      (*jit_func)(struct rb_execution_context_struct *, struct rb_control_frame_struct *); /*   264     8 */
	long unsigned int          total_calls;          /*   272     8 */
	struct rb_mjit_unit *      jit_unit;             /*   280     8 */
	char                       catch_except_p;       /*   288     1 */<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<

	/* size: 296, cachelines: 5, members: 23 */<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
	/* sum members: 285, holes: 1, sum holes: 4 */
	/* padding: 7 */
	/* last cacheline: 40 bytes */
};
```

This branch, 288 bytes:
```
lourens@CarbonX1:~/src/ruby/ruby$ pahole -C rb_iseq_constant_body ./miniruby
struct rb_iseq_constant_body {
	enum iseq_type             type;                 /*     0     4 */
	unsigned int               iseq_size;            /*     4     4 */
	const VALUE  *             iseq_encoded;         /*     8     8 */
	struct {
		struct {
			unsigned int has_lead:1;         /*    16:31  4 */
			unsigned int has_opt:1;          /*    16:30  4 */
			unsigned int has_rest:1;         /*    16:29  4 */
			unsigned int has_post:1;         /*    16:28  4 */
			unsigned int has_kw:1;           /*    16:27  4 */
			unsigned int has_kwrest:1;       /*    16:26  4 */
			unsigned int has_block:1;        /*    16:25  4 */
			unsigned int ambiguous_param0:1; /*    16:24  4 */
		} flags;                                 /*    16     4 */
		unsigned int       size;                 /*    20     4 */
		int                lead_num;             /*    24     4 */
		int                opt_num;              /*    28     4 */
		int                rest_start;           /*    32     4 */
		int                post_start;           /*    36     4 */
		int                post_num;             /*    40     4 */
		int                block_start;          /*    44     4 */
		const VALUE  *     opt_table;            /*    48     8 */
		const struct rb_iseq_param_keyword  * keyword; /*    56     8 */
	} param;                                         /*    16    48 */
	/* --- cacheline 1 boundary (64 bytes) --- */
	rb_iseq_location_t         location;             /*    64    56 */
	struct iseq_insn_info      insns_info;           /*   120    32 */
	/* --- cacheline 2 boundary (128 bytes) was 24 bytes ago --- */
	const ID  *                local_table;          /*   152     8 */
	const struct iseq_catch_table  * catch_table;    /*   160     8 */
	const struct rb_iseq_struct  * parent_iseq;      /*   168     8 */
	struct rb_iseq_struct *    local_iseq;           /*   176     8 */
	union iseq_inline_storage_entry * is_entries;    /*   184     8 */
	/* --- cacheline 3 boundary (192 bytes) --- */
	struct rb_call_info *      ci_entries;           /*   192     8 */
	struct rb_call_cache *     cc_entries;           /*   200     8 */
	struct {
		rb_snum_t          flip_count;           /*   208     8 */
		VALUE              coverage;             /*   216     8 */
		VALUE              pc2branchindex;       /*   224     8 */
		VALUE *            original_iseq;        /*   232     8 */
	} variable;                                      /*   208    32 */
	unsigned int               local_table_size;     /*   240     4 */
	unsigned int               is_size;              /*   244     4 */
	unsigned int               ci_size;              /*   248     4 */
	unsigned int               ci_kw_size;           /*   252     4 */
	/* --- cacheline 4 boundary (256 bytes) --- */
	unsigned int               stack_max;            /*   256     4 */
	char                       catch_except_p;       /*   260     1 */<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<

	/* XXX 3 bytes hole, try to pack */

	VALUE                      (*jit_func)(struct rb_execution_context_struct *, struct rb_control_frame_struct *); /*   264     8 */
	long unsigned int          total_calls;          /*   272     8 */
	struct rb_mjit_unit *      jit_unit;             /*   280     8 */

	/* size: 288, cachelines: 5, members: 23 */<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
	/* sum members: 285, holes: 1, sum holes: 3 */
	/* last cacheline: 32 bytes */
};
```