### PR TITLE
Use the word "heredocs" in Here Documents docs title

### DIFF
--- a/doc/syntax/literals.rdoc
+++ b/doc/syntax/literals.rdoc
@@ -193,7 +193,7 @@ a single codepoint in the script encoding:
   ?\C-\M-a #=> "\x81", same as above
   ?あ      #=> "あ"
 
-=== Here Documents
+=== Here Documents (heredocs)
 
 If you are writing a large block of text you may use a "here document" or
 "heredoc":


### PR DESCRIPTION
For reference, this is the current section before this change:
![image](https://user-images.githubusercontent.com/65950/54629521-1f077e00-4a4e-11e9-9810-6b9324758df1.png)
https://docs.ruby-lang.org/en/trunk/syntax/literals_rdoc.html#label-Here+Documents

After this change: 
![image](https://user-images.githubusercontent.com/65950/54629552-32b2e480-4a4e-11e9-9ba8-bc0cbfa46154.png)

Two advantages:
- higher relevance of the extremely common word "heredocs" which may
help people find this page when searching for "ruby heredocs"
- the anchor link becomes `#label-Here+Documents+-28heredocs-29`, which is
ugly due to the parentheses but includes the word "heredocs" in the URL to
this section

If anyone knows a way to prevent RDoc from turning invalid characters into
ugly and meaningless ASCII codes, I'm listening. I don't want to break existing
anchor links but RDoc should really ignore these characters or turn them into
dashes.