### PR TITLE
Improve efficiency of drb ID hash using reference queues

### DIFF
--- a/lib/drb/drb.rb
+++ b/lib/drb/drb.rb
@@ -48,6 +48,7 @@
 
 require 'socket'
 require 'io/wait'
+require 'weakref'
 require_relative 'eq'
 
 #
@@ -355,21 +356,25 @@ module DRb
 
   # Class responsible for converting between an object and its id.
   #
-  # This, the default implementation, uses an object's local ObjectSpace
+  # This, the default implementation, uses an object's runtime-assigned
   # __id__ as its id.  This means that an object's identification over
   # drb remains valid only while that object instance remains alive
   # within the server runtime.
   #
   # For alternative mechanisms, see DRb::TimerIdConv in drb/timeridconv.rb
   # and DRbNameIdConv in sample/name.rb in the full drb distribution.
+  #
   class DRbIdConv
+    def initialize
+      @id2ref = {}
+    end
 
     # Convert an object reference id to an object.
     #
     # This implementation looks up the reference id in the local object
     # space and returns the object it refers to.
     def to_obj(ref)
-      ObjectSpace._id2ref(ref)
+      _get(ref)
     end
 
     # Convert an object into a reference id.
@@ -377,8 +382,34 @@ module DRb
     # This implementation returns the object's __id__ in the local
     # object space.
     def to_id(obj)
-      obj.nil? ? nil : obj.__id__
+      obj.nil? ? nil : _put(obj)
     end
+
+    def _clean
+      dead = []
+      @id2ref.each {|id,weakref| dead << id unless weakref.weakref_alive?}
+      dead.each {|id| @id2ref.delete(id)}
+    end
+
+    def _put(obj)
+      _clean
+      @id2ref[obj.__id__] = WeakRef.new(obj)
+      obj.__id__
+    end
+
+    def _get(id)
+      weakref = @id2ref[id]
+      if weakref
+        result = weakref.__getobj__ rescue nil
+        if result
+          return result
+        else
+          @id2ref.delete id
+        end
+      end
+      nil
+    end
+    private :_clean, :_put, :_get
   end
 
   # Mixin module making an object undumpable or unmarshallable.


### PR DESCRIPTION
This PR builds on #2102, which is for https://bugs.ruby-lang.org/issues/15711.

This version requires the "weakling" library, for its
implementation of weak reference queues. It improves on the
weakref-only implementation by reducing the periodic reference
scan to a queue poll, which should be a no-op when there are no
queued references.

In order for this implementation to work in CRuby, the weakref
library would need to support reference queues, ideally backed by
the CRuby GC to make them efficient.