### PR TITLE
Add `ifnone` example to `find` documentation

### DIFF
--- a/enum.c
+++ b/enum.c
@@ -278,13 +278,15 @@ find_i(RB_BLOCK_CALL_FUNC_ARGLIST(i, memop))
  *
  *  If no block is given, an enumerator is returned instead.
  *
- *     (1..100).detect  #=> #<Enumerator: 1..100:detect>
- *     (1..100).find    #=> #<Enumerator: 1..100:find>
+ *     (1..100).detect        #=> #<Enumerator: 1..100:detect>
+ *     (1..100).find          #=> #<Enumerator: 1..100:find>
  *
- *     (1..10).detect   { |i| i % 5 == 0 and i % 7 == 0 }   #=> nil
- *     (1..10).find     { |i| i % 5 == 0 and i % 7 == 0 }   #=> nil
- *     (1..100).detect  { |i| i % 5 == 0 and i % 7 == 0 }   #=> 35
- *     (1..100).find    { |i| i % 5 == 0 and i % 7 == 0 }   #=> 35
+ *     (1..10).detect         { |i| i % 5 == 0 and i % 7 == 0 }   #=> nil
+ *     (1..10).find           { |i| i % 5 == 0 and i % 7 == 0 }   #=> nil
+ *     (1..10).detect(-> {0}) { |i| i % 5 == 0 and i % 7 == 0 }   #=> 0
+ *     (1..10).find(-> {0})   { |i| i % 5 == 0 and i % 7 == 0 }   #=> 0
+ *     (1..100).detect        { |i| i % 5 == 0 and i % 7 == 0 }   #=> 35
+ *     (1..100).find          { |i| i % 5 == 0 and i % 7 == 0 }   #=> 35
  *
  */
 


### PR DESCRIPTION
`find` method accepts `ifnone` argument and it is written in doc.
However, examples below the doc don't include the case when `ifnone` is present.
This is slightly confusing so I added some examples for those cases.