### PR TITLE
Conditionally declare the next member of the rb_imemo_tmpbuf_struct if RIPPER is defined

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -4665,9 +4665,13 @@ gc_mark_imemo(rb_objspace_t *objspace, VALUE obj)
       case imemo_tmpbuf:
 	{
 	    const rb_imemo_tmpbuf_t *m = &RANY(obj)->as.imemo.alloc;
+#ifndef RIPPER
 	    do {
+#endif
 		rb_gc_mark_locations(m->ptr, m->ptr + m->cnt);
+#ifndef RIPPER
 	    } while ((m = m->next) != NULL);
+#endif
 	}
 	return;
       case imemo_ast:

--- a/internal.h
+++ b/internal.h
@@ -1107,7 +1107,9 @@ typedef struct rb_imemo_tmpbuf_struct {
     VALUE flags;
     VALUE reserved;
     VALUE *ptr; /* malloc'ed buffer */
+#ifndef RIPPER
     struct rb_imemo_tmpbuf_struct *next; /* next imemo */
+#endif
     size_t cnt; /* buffer size in VALUE */
 } rb_imemo_tmpbuf_t;
 


### PR DESCRIPTION
While working on something else, I noticed the loop on marking type `imemo_tmpbuf` never called `rb_gc_mark_locations` more than once and further investigation into `parse.y` revealed that we can conditionally define the link pointer on `rb_imemo_tmpbuf_t` only then `RIPPER` is not set.