### PR TITLE
Let obj_memsize_of also respect the auxiliary imemo_env buffer

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -3412,6 +3412,9 @@ obj_memsize_of(VALUE obj, int use_all_types)
 	if (imemo_type_p(obj, imemo_tmpbuf)) {
 	    size += RANY(obj)->as.imemo.alloc.cnt * sizeof(VALUE);
 	}
+	if (imemo_type_p(obj, imemo_env)) {
+	    size += RANY(obj)->as.imemo.env.env_size * sizeof(VALUE);
+	}
 	break;
 
       case T_FLOAT:


### PR DESCRIPTION
Similar layout as `imemo_tmpbuf` with regards to the `VALUE` array buffer and size / count member.

The following also needs to be factored in for memory sizes of `T_IMEMO` objects to be accurate:

* `imemo_ment`
* `imemo_iseq`
* `imemo_ast`

But can be handled in incremental units of work as neither is trivial.