### PR TITLE
ruby: fix test failures

### DIFF
--- a/test/test_delegate.rb
+++ b/test/test_delegate.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require 'test/unit'
 require 'delegate'
+require 'minitest/autorun'
 
 class TestDelegateClass < Test::Unit::TestCase
   module PP

--- a/test/test_extlibs.rb
+++ b/test/test_extlibs.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: false
 require "envutil"
 require "shellwords"
+require "test/unit"
 
 class TestExtLibs < Test::Unit::TestCase
   @extdir = $".grep(/\/rbconfig\.rb\z/) {break "#$`/ext"}

--- a/test/test_forwardable.rb
+++ b/test/test_forwardable.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: false
 require 'test/unit'
 require 'forwardable'
+require 'minitest/autorun'
 
 class TestForwardable < Test::Unit::TestCase
   RECEIVER = BasicObject.new

--- a/test/test_pstore.rb
+++ b/test/test_pstore.rb
@@ -2,6 +2,7 @@
 require 'test/unit'
 require 'pstore'
 require 'tmpdir'
+require 'minitest/autorun'
 
 class PStoreTest < Test::Unit::TestCase
   def setup

--- a/test/test_securerandom.rb
+++ b/test/test_securerandom.rb
@@ -2,6 +2,7 @@
 require 'test/unit'
 require 'securerandom'
 require 'tempfile'
+require 'minitest/autorun'
 
 # This testcase does NOT aim to test cryptographically strongness and randomness.
 class TestSecureRandom < Test::Unit::TestCase

--- a/test/test_tempfile.rb
+++ b/test/test_tempfile.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require 'test/unit'
 require 'tempfile'
+require 'minitest/autorun'
 
 class TestTempfile < Test::Unit::TestCase
   def initialize(*)

--- a/test/test_time.rb
+++ b/test/test_time.rb
@@ -2,6 +2,7 @@
 
 require 'time'
 require 'test/unit'
+require 'minitest/autorun'
 
 class TestTimeExtension < Test::Unit::TestCase # :nodoc:
   def test_rfc822

--- a/test/test_timeout.rb
+++ b/test/test_timeout.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: false
 require 'test/unit'
 require 'timeout'
+require 'minitest/autorun'
 
 class TestTimeout < Test::Unit::TestCase
   def test_queue

--- a/test/test_tmpdir.rb
+++ b/test/test_tmpdir.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require 'test/unit'
 require 'tmpdir'
+require 'minitest/autorun'
 
 class TestTmpdir < Test::Unit::TestCase
   def test_tmpdir_modifiable

--- a/test/test_weakref.rb
+++ b/test/test_weakref.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require 'test/unit'
 require 'weakref'
+require 'minitest/autorun'
 
 class TestWeakRef < Test::Unit::TestCase
   def make_weakref(level = 10)


### PR DESCRIPTION
* test_exlibs.rb add require 'test/unit' for fix below error

test_extlibs.rb:6:in `<main>': uninitialized constant Test (NameError)

* other nine test_*.rb add require 'minitest/autorun' to fix below errors

1.Error: test_error_handling(TestCMath):
NoMethodError: undefined method `assert_raise_with_message' for #TestCMath:0x000056300b0c5800
Did you mean? assert_raise_message

2.test_cmath.rb:31:in `test_log'
Error: test_log(TestCMath): RangeError: can't convert 0.8047189562170503+1.1071487177940904i into Float

This commit is for fix issue: https://bugs.ruby-lang.org/issues/15746?next_issue_id=15745

Signed-off-by: Changqing Li <changqing.li@windriver.com>