### PR TITLE
Share the exception local ID table

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -106,6 +106,8 @@ struct iseq_compile_data_ensure_node_stack {
     struct ensure_range *erange;
 };
 
+const ID rb_iseq_shared_exc_local_tbl[] = {idERROR_INFO};
+
 /**
  * debug function(macro) interface depend on CPDEBUG
  * if it is less than 0, runtime option is in effect.
@@ -1361,14 +1363,8 @@ iseq_setup(rb_iseq_t *iseq, LINK_ANCHOR *const anchor)
 static int
 iseq_set_exception_local_table(rb_iseq_t *iseq)
 {
-    /* TODO: every id table is same -> share it.
-     * Current problem is iseq_free().
-     */
-    ID *ids = (ID *)ALLOC_N(ID, 1);
-
     iseq->body->local_table_size = 1;
-    ids[0] = idERROR_INFO;
-    iseq->body->local_table = ids;
+    iseq->body->local_table = rb_iseq_shared_exc_local_tbl;
     return COMPILE_OK;
 }
 

--- a/iseq.c
+++ b/iseq.c
@@ -91,7 +91,8 @@ rb_iseq_free(const rb_iseq_t *iseq)
 #if VM_INSN_INFO_TABLE_IMPL == 2
 	if (body->insns_info.succ_index_table) ruby_xfree(body->insns_info.succ_index_table);
 #endif
-	ruby_xfree((void *)body->local_table);
+        if (LIKELY(body->local_table != rb_iseq_shared_exc_local_tbl))
+            ruby_xfree((void *)body->local_table);
 	ruby_xfree((void *)body->is_entries);
 
 	if (body->ci_entries) {

--- a/iseq.h
+++ b/iseq.h
@@ -21,6 +21,8 @@ typedef struct rb_iseq_struct rb_iseq_t;
 #define rb_iseq_t rb_iseq_t
 #endif
 
+extern const ID rb_iseq_shared_exc_local_tbl[];
+
 static inline size_t
 rb_call_info_kw_arg_bytes(int keyword_len)
 {


### PR DESCRIPTION
Introduces a new `ISEQ_SHARED_EXC_LOCAL_TBL` flag that facilitates conditional free of the locals table in `rb_iseq_free`. This allows for sharing a single constant ID table via `iseq_set_exception_local_table` for the lifetime of the process.

I don't like the fact that the allocation isn't freed, however in `gc.c` `id_to_obj_tbl` and `obj_to_id_tbl` for example aren't explicitly freed on exit either.

Debug counters dumped on exit from booting up a redmine server process - the exception local table was shared about `1500` times:

```
[RUBY_DEBUG_COUNTER]	lvar_get                      	       2121321
[RUBY_DEBUG_COUNTER]	lvar_get_dynamic              	        196824
[RUBY_DEBUG_COUNTER]	lvar_set                      	        240395
[RUBY_DEBUG_COUNTER]	lvar_set_dynamic              	         19189
[RUBY_DEBUG_COUNTER]	lvar_set_slowpath             	           866
[RUBY_DEBUG_COUNTER]	iseq_shared_exc_local_tbl     	          1595 <<<<<<<<<<<<<<
[RUBY_DEBUG_COUNTER]	gc_count                      	            54
[RUBY_DEBUG_COUNTER]	gc_minor_newobj               	            43
[RUBY_DEBUG_COUNTER]	gc_minor_malloc               	             0
[RUBY_DEBUG_COUNTER]	gc_minor_method               	             0
[RUBY_DEBUG_COUNTER]	gc_minor_capi                 	             0
[RUBY_DEBUG_COUNTER]	gc_minor_stress               	             0
[RUBY_DEBUG_COUNTER]	gc_major_nofree               	            11
```