### PR TITLE
Lazy allocate the compile data catch table array

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -327,6 +327,8 @@ static void iseq_add_setlocal(rb_iseq_t *iseq, LINK_ANCHOR *const seq, int line,
     LABEL_UNREMOVABLE(ls);							\
     LABEL_REF(le);								\
     LABEL_REF(lc);								\
+    if (NIL_P(ISEQ_COMPILE_DATA(iseq)->catch_table_ary)) \
+        RB_OBJ_WRITE(iseq, &ISEQ_COMPILE_DATA(iseq)->catch_table_ary, rb_ary_tmp_new(3)); \
     rb_ary_push(ISEQ_COMPILE_DATA(iseq)->catch_table_ary, freeze_hide_obj(_e));	\
 } while (0)
 
@@ -1273,6 +1275,7 @@ static void
 iseq_insert_nop_between_end_and_cont(rb_iseq_t *iseq)
 {
     VALUE catch_table_ary = ISEQ_COMPILE_DATA(iseq)->catch_table_ary;
+    if (NIL_P(catch_table_ary)) return;
     unsigned int i, tlen = (unsigned int)RARRAY_LEN(catch_table_ary);
     const VALUE *tptr = RARRAY_CONST_PTR_TRANSIENT(catch_table_ary);
     for (i = 0; i < tlen; i++) {
@@ -2313,6 +2316,7 @@ iseq_set_exception_table(rb_iseq_t *iseq)
     unsigned int tlen, i;
     struct iseq_catch_table_entry *entry;
 
+    if (NIL_P(ISEQ_COMPILE_DATA(iseq)->catch_table_ary)) goto no_catch_table;
     tlen = (int)RARRAY_LEN(ISEQ_COMPILE_DATA(iseq)->catch_table_ary);
     tptr = RARRAY_CONST_PTR_TRANSIENT(ISEQ_COMPILE_DATA(iseq)->catch_table_ary);
 
@@ -2350,7 +2354,8 @@ iseq_set_exception_table(rb_iseq_t *iseq)
 	RB_OBJ_WRITE(iseq, &ISEQ_COMPILE_DATA(iseq)->catch_table_ary, 0); /* free */
     }
     else {
-	iseq->body->catch_table = NULL;
+        no_catch_table:
+          iseq->body->catch_table = NULL;
     }
 
     return COMPILE_OK;

--- a/iseq.c
+++ b/iseq.c
@@ -472,7 +472,7 @@ prepare_iseq_build(rb_iseq_t *iseq,
 	ALLOC_N(char, INITIAL_ISEQ_COMPILE_DATA_STORAGE_BUFF_SIZE +
 		offsetof(struct iseq_compile_data_storage, buff));
 
-    RB_OBJ_WRITE(iseq, &ISEQ_COMPILE_DATA(iseq)->catch_table_ary, rb_ary_tmp_new(3));
+    RB_OBJ_WRITE(iseq, &ISEQ_COMPILE_DATA(iseq)->catch_table_ary, Qnil);
     ISEQ_COMPILE_DATA(iseq)->storage_head->pos = 0;
     ISEQ_COMPILE_DATA(iseq)->storage_head->next = 0;
     ISEQ_COMPILE_DATA(iseq)->storage_head->size =


### PR DESCRIPTION
`iseq_setup` allocates an Array with embedded members (`rb_ary_tmp_new(RARRAY_EMBED_LEN_MAX)` effectively) for every instruction sequence in compile step `4.2` regardless of the presence of control flow constructs such as loops, iterators, exception handling etc.

This change reduces compile time GC pressure by allocating a few thousand less embedded array objects during a Redmine boot sequence:

### Debug counters, branch `lazy-catch-table-ary`

```
[RUBY_DEBUG_COUNTER]	obj_newobj                    	       1410801 <<<<<<<<<<
[RUBY_DEBUG_COUNTER]	obj_newobj_slowpath           	          8948
[RUBY_DEBUG_COUNTER]	obj_newobj_wb_unprotected     	         19300
[RUBY_DEBUG_COUNTER]	obj_free                      	       1058125 <<<<<<<<<<
[RUBY_DEBUG_COUNTER]	obj_promote                   	        239987
[RUBY_DEBUG_COUNTER]	obj_wb_unprotect              	          2268
[RUBY_DEBUG_COUNTER]	obj_obj_embed                 	          2541
[RUBY_DEBUG_COUNTER]	obj_obj_transient             	          2177
[RUBY_DEBUG_COUNTER]	obj_obj_ptr                   	           119
[RUBY_DEBUG_COUNTER]	obj_str_ptr                   	        243420
[RUBY_DEBUG_COUNTER]	obj_str_embed                 	        399399
[RUBY_DEBUG_COUNTER]	obj_str_shared                	         58885
[RUBY_DEBUG_COUNTER]	obj_str_nofree                	             0
[RUBY_DEBUG_COUNTER]	obj_str_fstr                  	          7127
[RUBY_DEBUG_COUNTER]	obj_ary_embed                 	        104421 <<<<<<<<<<
[RUBY_DEBUG_COUNTER]	obj_ary_transient             	         45537
[RUBY_DEBUG_COUNTER]	obj_ary_ptr                   	          2730
```

### Debug counters, `trunk`

```
[RUBY_DEBUG_COUNTER]	obj_newobj                    	       1437151 <<<<<<<<<<
[RUBY_DEBUG_COUNTER]	obj_newobj_slowpath           	          9531
[RUBY_DEBUG_COUNTER]	obj_newobj_wb_unprotected     	         19300
[RUBY_DEBUG_COUNTER]	obj_free                      	       1125067 <<<<<<<<<<
[RUBY_DEBUG_COUNTER]	obj_promote                   	        249154
[RUBY_DEBUG_COUNTER]	obj_wb_unprotect              	          2268
[RUBY_DEBUG_COUNTER]	obj_obj_embed                 	          3142
[RUBY_DEBUG_COUNTER]	obj_obj_transient             	          2511
[RUBY_DEBUG_COUNTER]	obj_obj_ptr                   	           121
[RUBY_DEBUG_COUNTER]	obj_str_ptr                   	        244024
[RUBY_DEBUG_COUNTER]	obj_str_embed                 	        401982
[RUBY_DEBUG_COUNTER]	obj_str_shared                	         59396
[RUBY_DEBUG_COUNTER]	obj_str_nofree                	             0
[RUBY_DEBUG_COUNTER]	obj_str_fstr                  	          7182
[RUBY_DEBUG_COUNTER]	obj_ary_embed                 	        142810 <<<<<<<<<<
[RUBY_DEBUG_COUNTER]	obj_ary_transient             	         46510
[RUBY_DEBUG_COUNTER]	obj_ary_ptr                   	          2854
```