### PR TITLE
Allow immediate objects to be used as WeakMap values

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -8807,12 +8807,9 @@ wmap_each_i(st_data_t key, st_data_t val, st_data_t arg)
 {
     rb_objspace_t *objspace = (rb_objspace_t *)arg;
     VALUE obj = (VALUE)val;
-    if (SPECIAL_CONST_P(obj)) {
+    if (RB_SPECIAL_CONST_P(obj) ||
+            (is_id_value(objspace, obj) && is_live_object(objspace, obj))) {
         rb_yield_values(2, (VALUE)key, obj);
-    } else {
-        if (is_id_value(objspace, obj) && is_live_object(objspace, obj)) {
-            rb_yield_values(2, (VALUE)key, obj);
-        }
     }
     return ST_CONTINUE;
 }
@@ -8834,12 +8831,9 @@ wmap_each_key_i(st_data_t key, st_data_t val, st_data_t arg)
 {
     rb_objspace_t *objspace = (rb_objspace_t *)arg;
     VALUE obj = (VALUE)val;
-    if (SPECIAL_CONST_P(obj)) {
+    if (RB_SPECIAL_CONST_P(obj) ||
+            (is_id_value(objspace, obj) && is_live_object(objspace, obj))) {
         rb_yield((VALUE)key);
-    } else {
-        if (is_id_value(objspace, obj) && is_live_object(objspace, obj)) {
-            rb_yield((VALUE)key);
-        }
     }
     return ST_CONTINUE;
 }

--- a/gc.c
+++ b/gc.c
@@ -8861,12 +8861,9 @@ wmap_each_value_i(st_data_t key, st_data_t val, st_data_t arg)
 {
     rb_objspace_t *objspace = (rb_objspace_t *)arg;
     VALUE obj = (VALUE)val;
-    if (RB_SPECIAL_CONST_P(obj)) {
+    if (RB_SPECIAL_CONST_P(obj) ||
+            (is_id_value(objspace, obj) && is_live_object(objspace, obj))) {
         rb_yield(obj);
-    } else {
-        if (is_id_value(objspace, obj) && is_live_object(objspace, obj)) {
-            rb_yield(obj);
-        }
     }
     return ST_CONTINUE;
 }
@@ -8890,12 +8887,9 @@ wmap_keys_i(st_data_t key, st_data_t val, st_data_t arg)
     rb_objspace_t *objspace = argp->objspace;
     VALUE ary = argp->value;
     VALUE obj = (VALUE)val;
-    if (RB_SPECIAL_CONST_P(obj)) {
+    if (RB_SPECIAL_CONST_P(obj) ||
+            (is_id_value(objspace, obj) && is_live_object(objspace, obj))) {
         rb_ary_push(ary, (VALUE)key);
-    } else {
-        if (is_id_value(objspace, obj) && is_live_object(objspace, obj)) {
-            rb_ary_push(ary, (VALUE)key);
-        }
     }
     return ST_CONTINUE;
 }
@@ -8921,12 +8915,9 @@ wmap_values_i(st_data_t key, st_data_t val, st_data_t arg)
     rb_objspace_t *objspace = argp->objspace;
     VALUE ary = argp->value;
     VALUE obj = (VALUE)val;
-    if (RB_SPECIAL_CONST_P(obj)) {
+    if (RB_SPECIAL_CONST_P(obj) ||
+            (is_id_value(objspace, obj) && is_live_object(objspace, obj))) {
         rb_ary_push(ary, obj);
-    } else {
-        if (is_id_value(objspace, obj) && is_live_object(objspace, obj)) {
-            rb_ary_push(ary, obj);
-        }
     }
     return ST_CONTINUE;
 }

--- a/lib/weakref.rb
+++ b/lib/weakref.rb
@@ -34,25 +34,15 @@ class WeakRef < Delegator
   # Integer, or Float.
 
   def initialize(orig)
-    case orig
-    when true, false, nil
-      @delegate_sd_obj = orig
-    else
-      @@__map[self] = orig
-    end
-    super
+    @@__map[self] = orig
   end
 
   def __getobj__ # :nodoc:
-    if defined?(@delegate_sd_obj)
-      @delegate_sd_obj
+    obj = @@__map[self]
+    if obj.is_a? ObjectSpace::WeakMap::DeadRef
+      Kernel::raise(RefError, "Invalid Reference - probably recycled", Kernel::caller(2))
     else
-      obj = @@__map[self]
-      if obj.is_a? ObjectSpace::WeakMap::DeadRef
-        Kernel::raise(RefError, "Invalid Reference - probably recycled", Kernel::caller(2))
-      else
-        obj
-      end
+      obj
     end
   end
 

--- a/lib/weakref.rb
+++ b/lib/weakref.rb
@@ -44,8 +44,16 @@ class WeakRef < Delegator
   end
 
   def __getobj__ # :nodoc:
-    @@__map[self] or defined?(@delegate_sd_obj) ? @delegate_sd_obj :
-      Kernel::raise(RefError, "Invalid Reference - probably recycled", Kernel::caller(2))
+    if defined?(@delegate_sd_obj)
+      @delegate_sd_obj
+    else
+      obj = @@__map[self]
+      if obj.is_a? ObjectSpace::WeakMap::DeadRef
+        Kernel::raise(RefError, "Invalid Reference - probably recycled", Kernel::caller(2))
+      else
+        obj
+      end
+    end
   end
 
   def __setobj__(obj) # :nodoc:

--- a/test/test_weakref.rb
+++ b/test/test_weakref.rb
@@ -11,6 +11,11 @@ class TestWeakRef < Test::Unit::TestCase
     end
   end
 
+  def test_fixnum
+    weak = WeakRef.new(10)
+    assert_equal 11, weak + 1
+  end
+
   def test_ref
     obj = Object.new
     weak = WeakRef.new(obj)


### PR DESCRIPTION
This PR allows immediate objects to be used as WeakMap values.   This means that the `WeakRef` class can wrap any object without any special cases.  The downside of this patch is that it introduces backwards incompatibility:

Before this patch `nil` was used to mean "the reference was recycled".  This patch introduces an `ObjectSpace::WeakMap::DeadRef` object to indicate that the reference has been recycled.  This allows us to represent any object in the weak map (besides dead refs of course).