### PR TITLE
Initialize autoload_state::result to Qnil to fix valgrind warning: conditional jump on uninitialised value

### DIFF
--- a/variable.c
+++ b/variable.c
@@ -2428,6 +2428,7 @@ rb_autoload_load(VALUE mod, ID id)
     }
     state.ac = ac;
     state.thread = rb_thread_current();
+    state.result = Qnil;
     if (!ele->state) {
 	ele->state = &state;
 	ele->fork_gen = GET_VM()->fork_gen;


### PR DESCRIPTION
Fixes this warning:

```
==8804== Conditional jump or move depends on uninitialised value(s)
==8804==    at 0x2C0000: autoload_reset (variable.c:2349)
==8804==    by 0x1350DD: rb_ensure (eval.c:1084)
==8804==    by 0x2C84D2: rb_autoload_load (variable.c:2452)
==8804==    by 0x2C92C4: rb_const_search (variable.c:2521)
==8804==    by 0x2C92C4: rb_const_get_0 (variable.c:2491)
==8804==    by 0x2C92C4: rb_const_get (variable.c:2552)
==8804==    by 0x1C5715: rb_mod_const_get (object.c:2536)
==8804==    by 0x2D278E: vm_call_cfunc_with_frame (vm_insnhelper.c:2207)
==8804==    by 0x2D278E: vm_call_cfunc (vm_insnhelper.c:2225)
==8804==    by 0x2DEB92: vm_call_method (vm_insnhelper.c:2712)
==8804==    by 0x2E48BC: vm_sendish (vm_insnhelper.c:3623)
==8804==    by 0x2E48BC: vm_exec_core (insns.def:789)
==8804==    by 0x2DAF7D: rb_vm_exec (vm.c:1892)
==8804==    by 0x2DC0A3: invoke_iseq_block_from_c (vm.c:1104)
==8804==    by 0x2DC0A3: invoke_block_from_c_bh.constprop.405 (vm.c:1122)
==8804==    by 0x375AD7: inject_i (enum.c:676)
==8804==    by 0x2DBC9F: vm_yield_with_cfunc (vm_insnhelper.c:2860)
==8804==    by 0x2DBC9F: invoke_block_from_c_bh (vm.c:1127)
==8804==    by 0x2DBC9F: vm_yield (vm.c:1167)
==8804==    by 0x2DBC9F: rb_yield_0 (vm_eval.c:979)
==8804==    by 0x2DBC9F: rb_yield_1 (vm_eval.c:985)
==8804==    by 0x2DBC9F: rb_yield (vm_eval.c:995)
==8804==  Uninitialised value was created by a stack allocation
==8804==    at 0x2C8260: rb_autoload_load (variable.c:2412)
==8804== 
```