### PR TITLE
Explicitly initialise encodings on init to remove branches on encoding lookup

### DIFF
--- a/encoding.c
+++ b/encoding.c
@@ -66,8 +66,6 @@ static struct {
 #define ENC_DUMMY_P(enc) ((enc)->ruby_encoding_index & ENC_DUMMY_FLAG)
 #define ENC_SET_DUMMY(enc) ((enc)->ruby_encoding_index |= ENC_DUMMY_FLAG)
 
-void rb_enc_init(void);
-
 #define ENCODING_COUNT ENCINDEX_BUILTIN_MAX
 #define UNSPECIFIED_ENCODING INT_MAX
 
@@ -555,9 +553,6 @@ rb_enc_alias(const char *alias, const char *orig)
     int idx;
 
     enc_check_duplication(alias);
-    if (!enc_table.list) {
-	rb_enc_init();
-    }
     if ((idx = rb_enc_find_index(orig)) < 0) {
 	return -1;
     }
@@ -611,9 +606,6 @@ rb_enc_init(void)
 rb_encoding *
 rb_enc_from_index(int index)
 {
-    if (!enc_table.list) {
-	rb_enc_init();
-    }
     if (index < 0 || enc_table.count <= (index &= ENC_INDEX_MASK)) {
 	return 0;
     }
@@ -1322,9 +1314,6 @@ enc_m_loader(VALUE klass, VALUE str)
 rb_encoding *
 rb_ascii8bit_encoding(void)
 {
-    if (!enc_table.list) {
-	rb_enc_init();
-    }
     return enc_table.list[ENCINDEX_ASCII].enc;
 }
 
@@ -1337,9 +1326,6 @@ rb_ascii8bit_encindex(void)
 rb_encoding *
 rb_utf8_encoding(void)
 {
-    if (!enc_table.list) {
-	rb_enc_init();
-    }
     return enc_table.list[ENCINDEX_UTF_8].enc;
 }
 
@@ -1352,9 +1338,6 @@ rb_utf8_encindex(void)
 rb_encoding *
 rb_usascii_encoding(void)
 {
-    if (!enc_table.list) {
-	rb_enc_init();
-    }
     return enc_table.list[ENCINDEX_US_ASCII].enc;
 }
 
@@ -1930,6 +1913,12 @@ rb_enc_aliases(VALUE klass)
  *   "R\u00E9sum\u00E9"
  *
  */
+
+void
+Init_encodings(void)
+{
+    rb_enc_init();
+}
 
 void
 Init_Encoding(void)

--- a/encoding.c
+++ b/encoding.c
@@ -606,7 +606,7 @@ rb_enc_init(void)
 rb_encoding *
 rb_enc_from_index(int index)
 {
-    if (index < 0 || enc_table.count <= (index &= ENC_INDEX_MASK)) {
+    if (UNLIKELY(index < 0 || enc_table.count <= (index &= ENC_INDEX_MASK))) {
 	return 0;
     }
     return enc_table.list[index].enc;

--- a/inits.c
+++ b/inits.c
@@ -22,6 +22,7 @@ rb_call_inits(void)
     CALL(vm_postponed_job);
     CALL(Method);
     CALL(RandomSeedCore);
+    CALL(encodings);
     CALL(sym);
     CALL(var_tables);
     CALL(Object);


### PR DESCRIPTION
I noticed that the encoding table is loaded on startup of even just `miniruby` through this backtrace during ruby setup:

```
/home/lourens/src/ruby/ruby/miniruby(rb_enc_init+0x12) [0x56197b0c0c72] encoding.c:587
/home/lourens/src/ruby/ruby/miniruby(rb_usascii_encoding+0x1a) [0x56197b0c948a] encoding.c:1357
/home/lourens/src/ruby/ruby/miniruby(Init_sym+0x7a) [0x56197b24810a] symbol.c:42
/home/lourens/src/ruby/ruby/miniruby(rb_call_inits+0x1d) [0x56197b11afed] inits.c:25
/home/lourens/src/ruby/ruby/miniruby(ruby_setup+0xf6) [0x56197b0ec9d6] eval.c:74
/home/lourens/src/ruby/ruby/miniruby(ruby_init+0x9) [0x56197b0eca39] eval.c:91
/home/lourens/src/ruby/ruby/miniruby(main+0x5a) [0x56197b051a2a] ./main.c:41
```

Therefore I think it makes sense to instead initialize encodings explicitly just prior to symbol init, which is the first entry point into the interpreter loading that currently triggers `rb_enc_init` and remove the initialization check branches from the various lookup methods.

Some of the branches collapsed, `cachegrind` output, columns are `Ir Bc Bcm Bi Bim` with `Ir` (instructions retired),  `Bc` (branches taken) and `Bcm` (branches missed) relevant here as there are no indirect branches (function pointers etc.):

(hot function, many instructions retired and branches taken and missed)
```
         .          .       .          .       .  rb_encoding *
         .          .       .          .       .  rb_enc_from_index(int index)
   835,669          0       0          0       0  {
13,133,536  6,337,652  50,267          0       0      if (!enc_table.list) {
         3          0       0          0       0  	rb_enc_init();
         .          .       .          .       .      }
23,499,349  8,006,202 293,161          0       0      if (index < 0 || enc_table.count <= (index &= ENC_INDEX_MASK)) {
         .          .       .          .       .  	return 0;
         .          .       .          .       .      }
30,024,494          0       0          0       0      return enc_table.list[index].enc;
 1,671,338          0       0          0       0  }
```

(cold function, representative of the utf8 variant more or less too)

```
         .          .       .          .       .  rb_encoding *
         .          .       .          .       .  rb_ascii8bit_encoding(void)
         .          .       .          .       .  {
    27,702      9,235     955          0       0      if (!enc_table.list) {
         .          .       .          .       .  	rb_enc_init();
         .          .       .          .       .      }
     9,238          0       0          0       0      return enc_table.list[ENCINDEX_ASCII].enc;
     9,232          0       0          0       0  }
```