### PR TITLE
Bugfix 15360: release mutex before checking for interrupts

### DIFF
--- a/thread_sync.c
+++ b/thread_sync.c
@@ -282,14 +282,18 @@ do_mutex_lock(VALUE self, int interruptible_p)
 		th->status = prev_status;
 	    }
 	    th->vm->sleeper--;
-	    if (mutex->th == th) mutex_locked(th, self);
 
             if (interruptible_p) {
+                /* release mutex before checking for interrupts...as interrupt checking
+                 * code might call rb_raise() */
+                if (mutex->th == th) mutex->th = 0;
                 RUBY_VM_CHECK_INTS_BLOCKING(th->ec); /* may release mutex */
                 if (!mutex->th) {
                     mutex->th = th;
                     mutex_locked(th, self);
                 }
+            } else {
+                if (mutex->th == th) mutex_locked(th, self);
             }
 	}
     }


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/15360

do_mutex_lock: release mutex before checking for interrupts. Otherwise, if interrupt checking code raises an exception ( in case of Thread#raise), we end up with two scenarios:

- uncaught exception: forever locked mutex
- caught exception: "ThreadError: deadlock; recursive locking" on a subsequent mutex.lock call