### PR TITLE
Remove unused merger.rb features

### DIFF
--- a/tool/merger.rb
+++ b/tool/merger.rb
@@ -227,9 +227,6 @@ else
   when /--ticket=(.*)/
     tickets = $1.split(/,/).map{|num| " [Backport ##{num}]"}.join
     ARGV.shift
-  when /merge revision\(s\) ([\d,\-]+):( \[.*)/
-    tickets = $2
-    ARGV[0] = $1
   else
     tickets = ''
   end

--- a/tool/merger.rb
+++ b/tool/merger.rb
@@ -239,11 +239,6 @@ else
 
   revs.each do |rev|
     case rev
-    when /\A\d+:\d+\z/
-      r = ['-r', rev]
-    when /\A(\d+)-(\d+)\z/
-      rev = "#{$1.to_i-1}:#$2"
-      r = ['-r', rev]
     when /\A\d+\z/
       r = ['-c', rev]
     when nil then


### PR DESCRIPTION
tool/merger.rb support the variations of notation to specify revisions/tickets.
Some of them seems unused or hard to support for trunk on git repo.

See https://gist.github.com/nagachika/cbd4da96bc612323bca86ac5fc9119ee.

