### PR TITLE
Fix release post output for tool/format-release

### DIFF
--- a/tool/format-release
+++ b/tool/format-release
@@ -49,6 +49,7 @@ class Tarball
       SHA1:   #{@sha1}
       SHA256: #{@sha256}
       SHA512: #{@sha512}
+
 eom
   end
 


### PR DESCRIPTION
Different entries should be separated by an empty line.