### PR TITLE
Support git in tool/redmine-backporter.rb

### DIFF
--- a/tool/redmine-backporter.rb
+++ b/tool/redmine-backporter.rb
@@ -262,9 +262,11 @@ end
 def backport_command_string
   unless @changesets.respond_to?(:validated)
     @changesets = @changesets.select do |c|
-      # check if the revision is included in trunk
+      next false if c.match(/\A\d{1,6}\z/) # skip SVN revision
+
+      # check if the Git revision is included in trunk
       begin
-        uri = URI("#{REDMINE_BASE}/projects/ruby-trunk/repository/trunk/revisions/#{c}")
+        uri = URI("#{REDMINE_BASE}/projects/ruby-trunk/repository/ruby-git/revisions/#{c}")
         uri.read($openuri_options)
         true
       rescue


### PR DESCRIPTION
I believe this pull request includes minimum git support requirements before git migration. `find_svn_log` is not modified yet because `RUBY_REPO_PATH` repository should have backport commits and thus it would be an SVN repository until ruby_2_7 branch is created.

`backport` only shows git revision because svn revision may be just identical to the git-svn commit of it.

cc: @nurse @nagachika @unak 