### PR TITLE
Disallow numbered parameter as the default value

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -4798,6 +4798,7 @@ f_label 	: tLABEL
 			ID id = get_id($1);
 			arg_var(p, formal_argument(p, id));
 			p->cur_arg = id;
+			p->max_numparam = -1;
 			$$ = $1;
 		    }
 		;

--- a/parse.y
+++ b/parse.y
@@ -4734,6 +4734,7 @@ f_norm_arg	: f_bad_arg
 		| tIDENTIFIER
 		    {
 			formal_argument(p, get_id($1));
+			p->max_numparam = -1;
 			$$ = $1;
 		    }
 		;

--- a/test/ruby/test_syntax.rb
+++ b/test/ruby/test_syntax.rb
@@ -1301,6 +1301,7 @@ eom
     assert_syntax_error('->(){@1}', /ordinary parameter is defined/)
     assert_syntax_error('->(x){@1}', /ordinary parameter is defined/)
     assert_syntax_error('->x{@1}', /ordinary parameter is defined/)
+    assert_syntax_error('->x:@2{}', /ordinary parameter is defined/)
     assert_syntax_error('proc {@1 = nil}', /Can't assign to numbered parameter @1/)
     assert_syntax_error('proc {@01}', /leading zero/)
     assert_syntax_error('proc {@1_}', /unexpected/)

--- a/test/ruby/test_syntax.rb
+++ b/test/ruby/test_syntax.rb
@@ -1302,6 +1302,7 @@ eom
     assert_syntax_error('->(x){@1}', /ordinary parameter is defined/)
     assert_syntax_error('->x{@1}', /ordinary parameter is defined/)
     assert_syntax_error('->x:@2{}', /ordinary parameter is defined/)
+    assert_syntax_error('->x=@1{}', /ordinary parameter is defined/)
     assert_syntax_error('proc {@1 = nil}', /Can't assign to numbered parameter @1/)
     assert_syntax_error('proc {@01}', /leading zero/)
     assert_syntax_error('proc {@1_}', /unexpected/)


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/15783

- Fix SEGV of `->x:@2{}`
- Disallow numbered parameter as the default value of optional argument