### PR TITLE
Let memory sizes of the various IMEMO object types be reflected correctly

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -843,6 +843,7 @@ int ruby_disable_gc = 0;
 void rb_iseq_mark(const rb_iseq_t *iseq);
 void rb_iseq_update_references(rb_iseq_t *iseq);
 void rb_iseq_free(const rb_iseq_t *iseq);
+size_t rb_iseq_memsize(const rb_iseq_t *iseq);
 void rb_vm_update_references(void *ptr);
 
 void rb_gcdebug_print_obj_condition(VALUE obj);
@@ -2104,6 +2105,40 @@ rb_imemo_tmpbuf_t *
 rb_imemo_tmpbuf_parser_heap(void *buf, rb_imemo_tmpbuf_t *old_heap, size_t cnt)
 {
     return (rb_imemo_tmpbuf_t *)rb_imemo_tmpbuf_new((VALUE)buf, (VALUE)old_heap, (VALUE)cnt, 0);
+}
+
+static size_t
+imemo_memsize(VALUE obj)
+{
+    size_t size = 0;
+    switch (imemo_type(obj)) {
+      case imemo_ment:
+        size += sizeof(RANY(obj)->as.imemo.ment.def);
+        break;
+      case imemo_iseq:
+        size += rb_iseq_memsize((rb_iseq_t *)obj);
+        break;
+      case imemo_env:
+        size += RANY(obj)->as.imemo.env.env_size * sizeof(VALUE);
+        break;
+      case imemo_tmpbuf:
+        size += RANY(obj)->as.imemo.alloc.cnt * sizeof(VALUE);
+        break;
+      case imemo_ast:
+        size += rb_ast_memsize(&RANY(obj)->as.imemo.ast);
+        break;
+          case imemo_cref:
+          case imemo_svar:
+          case imemo_throw_data:
+          case imemo_ifunc:
+          case imemo_memo:
+          case imemo_parser_strterm:
+          break;
+      default:
+        /* unreachable */
+        break;
+    }
+    return size;
 }
 
 #if IMEMO_DEBUG
@@ -3543,9 +3578,7 @@ obj_memsize_of(VALUE obj, int use_all_types)
       case T_COMPLEX:
         break;
       case T_IMEMO:
-	if (imemo_type_p(obj, imemo_tmpbuf)) {
-	    size += RANY(obj)->as.imemo.alloc.cnt * sizeof(VALUE);
-	}
+	    size += imemo_memsize(obj);
 	break;
 
       case T_FLOAT:

--- a/iseq.c
+++ b/iseq.c
@@ -361,8 +361,8 @@ param_keyword_size(const struct rb_iseq_param_keyword *pkw)
     return size;
 }
 
-static size_t
-iseq_memsize(const rb_iseq_t *iseq)
+size_t
+rb_iseq_memsize(const rb_iseq_t *iseq)
 {
     size_t size = 0; /* struct already counted as RVALUE size */
     const struct rb_iseq_constant_body *body = iseq->body;
@@ -1111,7 +1111,7 @@ iseqw_mark(void *ptr)
 static size_t
 iseqw_memsize(const void *ptr)
 {
-    return iseq_memsize((const rb_iseq_t *)ptr);
+    return rb_iseq_memsize((const rb_iseq_t *)ptr);
 }
 
 static const rb_data_type_t iseqw_data_type = {

--- a/node.h
+++ b/node.h
@@ -402,6 +402,7 @@ rb_ast_t *rb_ast_new(void);
 void rb_ast_mark(rb_ast_t*);
 void rb_ast_dispose(rb_ast_t*);
 void rb_ast_free(rb_ast_t*);
+size_t rb_ast_memsize(const rb_ast_t*);
 void rb_ast_add_mark_object(rb_ast_t*, VALUE);
 NODE *rb_ast_newnode(rb_ast_t*);
 void rb_ast_delete_node(rb_ast_t*, NODE *n);


### PR DESCRIPTION
Supersedes https://github.com/ruby/ruby/pull/2112. In current trunk only the `imemo_tmpbuf` type's auxiliary malloc heap buffer is factored into `obj_memsize_of`. The following IMEMO types also allocate on the malloc heap:

* `imemo_env` (similar pattern as `imemo_tmpbuf`, an array of `VALUE`s)
* `imemo_ment` (single struct allocated)
* `imemo_iseq` (massaged the `iseq_memsize` API a little)
* `imemo_ast` (more difficult to get right, need to walk buffer elements too)

The `imemo_memsize` function introduced attempts to be the entry point for object size calculation of the IMEMO types.