### PR TITLE
Prevent rb_define_(class|module) classes from moving

### DIFF
--- a/class.c
+++ b/class.c
@@ -659,6 +659,9 @@ rb_define_class(const char *name, VALUE super)
 	if (rb_class_real(RCLASS_SUPER(klass)) != super) {
 	    rb_raise(rb_eTypeError, "superclass mismatch for class %s", name);
 	}
+
+        /* Class may have been defined in Ruby and not pin-rooted */
+        rb_vm_add_root_module(id, klass);
 	return klass;
     }
     if (!super) {

--- a/gc.c
+++ b/gc.c
@@ -8159,7 +8159,7 @@ gc_verify_compaction_references(VALUE mod)
     heap_eden->using_page = NULL;
 
     gc_verify_internal_consistency(mod);
-    rb_gc_enable();
+
     /* GC after compaction to eliminate T_MOVED */
     rb_gc();
 

--- a/vm_core.h
+++ b/vm_core.h
@@ -660,7 +660,7 @@ typedef struct rb_vm_struct {
     VALUE coverages;
     int coverage_mode;
 
-    VALUE defined_module_hash;
+    st_table * defined_module_hash;
 
     struct rb_objspace *objspace;
 


### PR DESCRIPTION
Before this commit, classes and modules would be registered with the
VM's `defined_module_hash`.  The key was the ID of the class, but that
meant that it was possible for hash collisions to occur.  The compactor
doesn't allow classes in the `defined_module_hash` to move, but if there
is a conflict, then it's possible a class would be removed from the hash
and not get pined.

This commit changes the key / value of the hash just to be the class
itself, thus preventing movement.