### PR TITLE
Fix complex hash keys to work with compaction

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -272,7 +272,11 @@ rb_objid_hash(st_index_t index)
 static st_index_t
 objid_hash(VALUE obj)
 {
-    return (st_index_t)st_index_hash((st_index_t)obj);
+#if SIZEOF_LONG == SIZEOF_VOIDP
+    return (st_index_t)st_index_hash((st_index_t)NUM2LONG(rb_obj_id(obj)));
+#elif SIZEOF_LONG_LONG == SIZEOF_VOIDP
+    return (st_index_t)st_index_hash((st_index_t)NUM2LL(rb_obj_id(obj)));
+#endif
 }
 
 VALUE

--- a/test/ruby/test_gc_compact.rb
+++ b/test/ruby/test_gc_compact.rb
@@ -121,4 +121,11 @@ class TestGCCompact < Test::Unit::TestCase
     skip "couldn't get objects to collide" if collisions == 0
     assert_operator collisions, :>, 0
   end
+
+  def test_complex_hash_keys
+    list_of_objects = big_list
+    hash = list_of_objects.hash
+    GC.verify_compaction_references
+    assert_equal hash, list_of_objects.hash
+  end
 end


### PR DESCRIPTION
For example when an array containing objects is a hash key, the contents
of the array may move which can cause the hash value for the array to
change.   This commit makes the default `hash` value based off the
object id, so the hash value will remain stable.

Fixes test/shell/test_command_processor.rb