### PR TITLE
Update rubygems with latest upstream changes

### DIFF
--- a/lib/rubygems/command_manager.rb
+++ b/lib/rubygems/command_manager.rb
@@ -169,12 +169,6 @@ class Gem::CommandManager
     when '-v', '--version' then
       say Gem::VERSION
       terminate_interaction 0
-    when '--no-ri', '--no-rdoc' then
-      # This was added to compensate for a deprecation warning not being shown
-      # in Rubygems 2.x.x.
-      # TODO: Remove when Rubygems 3.1 is released.
-      alert_error "Invalid option: #{args.first}. Use --no-document instead."
-      terminate_interaction 1
     when /^-/ then
       alert_error clean_text("Invalid option: #{args.first}. See 'gem --help'.")
       terminate_interaction 1

--- a/lib/rubygems/commands/dependency_command.rb
+++ b/lib/rubygems/commands/dependency_command.rb
@@ -208,7 +208,7 @@ use with other commands.
   def name_pattern(args)
     args << '' if args.empty?
 
-    if args.length == 1 and args.first =~ /\A\/(.*)\/(i)?\z/m
+    if args.length == 1 and args.first =~ /\A(.*)(i)?\z/m
       flags = $2 ? Regexp::IGNORECASE : nil
       Regexp.new $1, flags
     else

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -319,7 +319,7 @@ By default, this RubyGems will install gem as:
 
   def install_lib(lib_dir)
     libs = { 'RubyGems' => 'lib' }
-    libs['Bundler'] = 'bundler/lib' if Gem::USE_BUNDLER_FOR_GEMDEPS
+    libs['Bundler'] = 'bundler/lib'
     libs.each do |tool, path|
       say "Installing #{tool}" if @verbose
 
@@ -382,8 +382,6 @@ By default, this RubyGems will install gem as:
   end
 
   def install_default_bundler_gem(bin_dir)
-    return unless Gem::USE_BUNDLER_FOR_GEMDEPS
-
     specs_dir = Gem::Specification.default_specifications_dir
     specs_dir = File.join(options[:destdir], specs_dir) unless Gem.win_platform?
     mkdir_p specs_dir, :mode => 0755
@@ -430,8 +428,12 @@ By default, this RubyGems will install gem as:
 
     Dir.chdir("bundler") do
       built_gem = Gem::Package.build(bundler_spec)
-      installer = Gem::Installer.at(built_gem, env_shebang: options[:env_shebang], install_as_default: true, bin_dir: bin_dir, wrappers: true)
-      installer.install
+      begin
+        installer = Gem::Installer.at(built_gem, env_shebang: options[:env_shebang], install_as_default: true, bin_dir: bin_dir, wrappers: true)
+        installer.install
+      ensure
+        FileUtils.rm_f built_gem
+      end
     end
 
     say "Bundler #{bundler_spec.version} installed"
@@ -544,7 +546,7 @@ abort "#{deprecation_message}"
 
   def remove_old_lib_files(lib_dir)
     lib_dirs = { File.join(lib_dir, 'rubygems') => 'lib/rubygems' }
-    lib_dirs[File.join(lib_dir, 'bundler')] = 'bundler/lib/bundler' if Gem::USE_BUNDLER_FOR_GEMDEPS
+    lib_dirs[File.join(lib_dir, 'bundler')] = 'bundler/lib/bundler'
     lib_dirs.each do |old_lib_dir, new_lib_dir|
       lib_files = rb_files_in(new_lib_dir)
       lib_files.concat(template_files_in(new_lib_dir)) if new_lib_dir =~ /bundler/

--- a/lib/rubygems/commands/unpack_command.rb
+++ b/lib/rubygems/commands/unpack_command.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'rubygems/command'
-require 'rubygems/installer'
 require 'rubygems/version_option'
 require 'rubygems/security_option'
 require 'rubygems/remote_fetcher'

--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -197,9 +197,10 @@ class Gem::ConfigFile
     platform_config = Marshal.load Marshal.dump(PLATFORM_DEFAULTS)
     system_config = load_file SYSTEM_WIDE_CONFIG_FILE
     user_config = load_file config_file_name.dup.untaint
-    environment_config = (ENV['GEMRC'] || '').split(/[:;]/).inject({}) do |result, file|
-      result.merge load_file file
-    end
+    environment_config = (ENV['GEMRC'] || '')
+      .split(File::PATH_SEPARATOR).inject({}) do |result, file|
+        result.merge load_file file
+      end
 
     @hash = operating_system_config.merge platform_config
     unless arg_list.index '--norc'

--- a/lib/rubygems/core_ext/kernel_require.rb
+++ b/lib/rubygems/core_ext/kernel_require.rb
@@ -39,7 +39,7 @@ module Kernel
     if spec = Gem.find_unresolved_default_spec(path)
       Gem.remove_unresolved_default_spec(spec)
       begin
-        Kernel.send(:gem, spec.name)
+        Kernel.send(:gem, spec.name, "#{Gem::Requirement.default}.a")
       rescue Exception
         RUBYGEMS_ACTIVATION_MONITOR.exit
         raise

--- a/lib/rubygems/dependency_installer.rb
+++ b/lib/rubygems/dependency_installer.rb
@@ -107,62 +107,6 @@ class Gem::DependencyInstaller
   end
 
   ##
-  #--
-  # TODO remove at RubyGems 4, no longer used
-
-  def add_found_dependencies(to_do, dependency_list) # :nodoc:
-    seen = {}
-    dependencies = Hash.new { |h, name| h[name] = Gem::Dependency.new name }
-
-    until to_do.empty? do
-      spec = to_do.shift
-
-      # HACK why is spec nil?
-      next if spec.nil? or seen[spec.name]
-      seen[spec.name] = true
-
-      deps = spec.runtime_dependencies
-
-      if @development
-        if @dev_shallow
-          if @toplevel_specs.include? spec.full_name
-            deps |= spec.development_dependencies
-          end
-        else
-          deps |= spec.development_dependencies
-        end
-      end
-
-      deps.each do |dep|
-        dependencies[dep.name] = dependencies[dep.name].merge dep
-
-        if @minimal_deps
-          next if Gem::Specification.any? do |installed_spec|
-                    dep.name == installed_spec.name and
-                      dep.requirement.satisfied_by? installed_spec.version
-                  end
-        end
-
-        results = Gem::Deprecate.skip_during do
-          find_gems_with_sources(dep)
-        end
-
-        results.sorted.each do |t|
-          to_do.push t.spec
-        end
-
-        results.remove_installed! dep
-
-        @available << results
-        results.inject_into_list dependency_list
-      end
-    end
-
-    dependency_list.remove_specs_unsatisfied_by dependencies
-  end
-  deprecate :add_found_dependencies, :none, 2018, 12
-
-  ##
   # Creates an AvailableSet to install from based on +dep_or_name+ and
   # +version+
 
@@ -324,48 +268,6 @@ class Gem::DependencyInstaller
     @available = set
   end
   deprecate :find_spec_by_name_and_version, :none, 2019, 12
-
-  ##
-  # Gathers all dependencies necessary for the installation from local and
-  # remote sources unless the ignore_dependencies was given.
-  #--
-  # TODO remove at RubyGems 4
-
-  def gather_dependencies # :nodoc:
-    specs = @available.all_specs
-
-    # these gems were listed by the user, always install them
-    keep_names = specs.map { |spec| spec.full_name }
-
-    if @dev_shallow
-      @toplevel_specs = keep_names
-    end
-
-    dependency_list = Gem::DependencyList.new @development
-    dependency_list.add(*specs)
-    to_do = specs.dup
-
-    Gem::Deprecate.skip_during do
-      add_found_dependencies to_do, dependency_list unless @ignore_dependencies
-    end
-
-    # REFACTOR maybe abstract away using Gem::Specification.include? so
-    # that this isn't dependent only on the currently installed gems
-    dependency_list.specs.reject! do |spec|
-      not keep_names.include?(spec.full_name) and
-      Gem::Specification.include?(spec)
-    end
-
-    unless dependency_list.ok? or @ignore_dependencies or @force
-      reason = dependency_list.why_not_ok?.map do |k,v|
-        "#{k} requires #{v.join(", ")}"
-      end.join("; ")
-      raise Gem::DependencyError, "Unable to resolve dependencies: #{reason}"
-    end
-
-    @gems_to_install = dependency_list.dependency_order.reverse
-  end
-  deprecate :gather_dependencies, :none, 2018, 12
 
   def in_background(what) # :nodoc:
     fork_happened = false

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -193,7 +193,7 @@ class Gem::Installer
 
     @bin_dir = options[:bin_dir] if options[:bin_dir]
 
-    if options[:user_install] and not options[:unpack]
+    if options[:user_install]
       @gem_home = Gem.user_dir
       @bin_dir = Gem.bindir gem_home unless options[:bin_dir]
       check_that_user_bin_dir_is_in_path
@@ -428,6 +428,7 @@ class Gem::Installer
     @gem_dir = directory
     extract_files
   end
+  deprecate :unpack, :none, 2020, 04
 
   ##
   # The location of the spec file that is installed.
@@ -726,10 +727,9 @@ class Gem::Installer
     end
   end
 
-  def verify_gem_home(unpack = false) # :nodoc:
+  def verify_gem_home # :nodoc:
     FileUtils.mkdir_p gem_home, :mode => options[:dir_mode] && 0755
-    raise Gem::FilePermissionError, gem_home unless
-      unpack or File.writable?(gem_home)
+    raise Gem::FilePermissionError, gem_home unless File.writable?(gem_home)
   end
 
   def verify_spec
@@ -898,7 +898,7 @@ TEXT
   # The dependent check will be skipped if the install is ignoring dependencies.
 
   def pre_install_checks
-    verify_gem_home options[:unpack]
+    verify_gem_home
 
     # The name and require_paths must be verified first, since it could contain
     # ruby code that would be eval'ed in #ensure_loadable_spec

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -265,7 +265,6 @@ class Gem::Package
     raise ArgumentError, "skip_validation = true and strict_validation = true are incompatible" if skip_validation && strict_validation
 
     Gem.load_yaml
-    require 'rubygems/security'
 
     @spec.mark_version
     @spec.validate true, strict_validation unless skip_validation

--- a/lib/rubygems/security/signer.rb
+++ b/lib/rubygems/security/signer.rb
@@ -85,7 +85,6 @@ class Gem::Security::Signer
     @digest_name      = Gem::Security::DIGEST_NAME
 
     if @key && !@key.is_a?(OpenSSL::PKey::RSA)
-      @passphrase ||= ask_for_password("Enter PEM pass phrase:")
       @key = OpenSSL::PKey::RSA.new(File.read(@key), @passphrase)
     end
 
@@ -144,6 +143,8 @@ class Gem::Security::Signer
     raise Gem::Security::Exception, 'no certs provided' if @cert_chain.empty?
 
     if @cert_chain.length == 1 and @cert_chain.last.not_after < Time.now
+      alert("Your certificate has expired, trying to re-sign it...")
+
       re_sign_key(
         expiration_length: (Gem::Security::ONE_DAY * options[:expiration_length_days])
       )

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -654,8 +654,8 @@ class Gem::Specification < Gem::BasicSpecification
   #  # This gem will work with 1.8.6 or greater...
   #  spec.required_ruby_version = '>= 1.8.6'
   #
-  #  # Only with ruby 2.0.x
-  #  spec.required_ruby_version = '~> 2.0'
+  #  # Only with final releases of major version 2 where minor version is at least 3
+  #  spec.required_ruby_version = '~> 2.3'
   #
   #  # Only prereleases or final releases after 2.6.0.preview2
   #  spec.required_ruby_version = '> 2.6.0.preview2'
@@ -812,7 +812,7 @@ class Gem::Specification < Gem::BasicSpecification
   def self.stubs
     @@stubs ||= begin
       pattern = "*.gemspec"
-      stubs = Gem.loaded_specs.values + default_stubs(pattern) + installed_stubs(dirs, pattern)
+      stubs = Gem.loaded_specs.values + installed_stubs(dirs, pattern) + default_stubs(pattern)
       stubs = uniq_by(stubs) { |stub| stub.full_name }
 
       _resort!(stubs)
@@ -843,8 +843,9 @@ class Gem::Specification < Gem::BasicSpecification
       @@stubs_by_name[name] || []
     else
       pattern = "#{name}-*.gemspec"
-      stubs = Gem.loaded_specs.values + default_stubs(pattern) +
-        installed_stubs(dirs, pattern).select { |s| Gem::Platform.match s.platform }
+      stubs = Gem.loaded_specs.values +
+        installed_stubs(dirs, pattern).select { |s| Gem::Platform.match s.platform } +
+        default_stubs(pattern)
       stubs = uniq_by(stubs) { |stub| stub.full_name }.group_by(&:name)
       stubs.each_value { |v| _resort!(v) }
 
@@ -2594,8 +2595,6 @@ class Gem::Specification < Gem::BasicSpecification
   # checks..
 
   def validate(packaging = true, strict = false)
-    require 'rubygems/user_interaction'
-    extend Gem::UserInteraction
     normalize
 
     validation_policy = Gem::SpecificationPolicy.new(self)

--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -1,7 +1,10 @@
 require 'delegate'
 require 'uri'
+require 'rubygems/user_interaction'
 
 class Gem::SpecificationPolicy < SimpleDelegator
+
+  include Gem::UserInteraction
 
   VALID_NAME_PATTERN = /\A[a-zA-Z0-9\.\-\_]+\z/.freeze # :nodoc:
 

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 # TODO: $SAFE = 1
 
-if defined? Gem::QuickLoader
-  Gem::QuickLoader.load_full_rubygems_library
-else
-  require 'rubygems'
-end
+require 'rubygems'
 
 # If bundler gemspec exists, add to stubs
 bundler_gemspec = File.expand_path("../../../bundler/bundler.gemspec", __FILE__)
@@ -38,9 +34,8 @@ unless Gem::Dependency.new('rdoc', '>= 3.10').matching_specs.empty?
   gem 'json'
 end
 
-if Gem::USE_BUNDLER_FOR_GEMDEPS
-  require 'bundler'
-end
+require 'bundler'
+
 require 'minitest/autorun'
 
 require 'rubygems/deprecate'
@@ -261,9 +256,8 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
     @current_dir = Dir.pwd
     @fetcher     = nil
 
-    if Gem::USE_BUNDLER_FOR_GEMDEPS
-      Bundler.ui = Bundler::UI::Silent.new
-    end
+    Bundler.ui = Bundler::UI::Silent.new
+
     @back_ui                       = Gem::DefaultUserInteraction.ui
     @ui                            = Gem::MockGemUi.new
     # This needs to be a new instance since we call use_ui(@ui) when we want to
@@ -368,9 +362,7 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
     Gem.loaded_specs.clear
     Gem.clear_default_specs
     Gem::Specification.unresolved_deps.clear
-    if Gem::USE_BUNDLER_FOR_GEMDEPS
-      Bundler.reset!
-    end
+    Bundler.reset!
 
     Gem.configuration.verbose = true
     Gem.configuration.update_sources = true

--- a/lib/rubygems/uninstaller.rb
+++ b/lib/rubygems/uninstaller.rb
@@ -46,7 +46,7 @@ class Gem::Uninstaller
     # TODO document the valid options
     @gem                = gem
     @version            = options[:version] || Gem::Requirement.default
-    @gem_home           = File.expand_path(options[:install_dir] || Gem.dir)
+    @gem_home           = File.realpath(options[:install_dir] || Gem.dir)
     @force_executables  = options[:executables]
     @force_all          = options[:all]
     @force_ignore       = options[:ignore]

--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -344,8 +344,8 @@ class Gem::Version
     return unless Gem::Version === other
     return 0 if @version == other._version || canonical_segments == other.canonical_segments
 
-    lhsegments = _segments
-    rhsegments = other._segments
+    lhsegments = canonical_segments
+    rhsegments = other.canonical_segments
 
     lhsize = lhsegments.size
     rhsize = rhsegments.size

--- a/test/rubygems/test_gem_command_manager.rb
+++ b/test/rubygems/test_gem_command_manager.rb
@@ -103,16 +103,6 @@ class TestGemCommandManager < Gem::TestCase
     assert_match(/invalid option: --bad-arg/i, @ui.error)
   end
 
-  def test_process_args_bad_no_ri
-    use_ui @ui do
-      assert_raises Gem::MockGemUi::TermError do
-        @command_manager.process_args %w[--no-ri]
-      end
-    end
-
-    assert_match(/invalid option: --no-ri. Use --no-document instead./i, @ui.error)
-  end
-
   # HACK move to install command test
   def test_process_args_install
     #capture all install options

--- a/test/rubygems/test_gem_commands_dependency_command.rb
+++ b/test/rubygems/test_gem_commands_dependency_command.rb
@@ -101,7 +101,7 @@ Gem x-2
       fetcher.spec 'b',      2
     end
 
-    @cmd.options[:args] = %w[/[ab]/]
+    @cmd.options[:args] = %w[[ab]]
 
     use_ui @stub_ui do
       @cmd.execute

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -135,24 +135,17 @@ class TestGemCommandsSetupCommand < Gem::TestCase
 
     gem_exec = sprintf Gem.default_exec_format, 'gem'
     default_gem_bin_path = File.join @install_dir, 'bin', gem_exec
-    if Gem::USE_BUNDLER_FOR_GEMDEPS
-      bundle_exec = sprintf Gem.default_exec_format, 'bundle'
-      default_bundle_bin_path = File.join @install_dir, 'bin', bundle_exec
-    end
-
+    bundle_exec = sprintf Gem.default_exec_format, 'bundle'
+    default_bundle_bin_path = File.join @install_dir, 'bin', bundle_exec
     ruby_exec = sprintf Gem.default_exec_format, 'ruby'
 
     if Gem.win_platform?
       assert_match %r%\A#!\s*#{ruby_exec}%, File.read(default_gem_bin_path)
-      if Gem::USE_BUNDLER_FOR_GEMDEPS
-        assert_match %r%\A#!\s*#{ruby_exec}%, File.read(default_bundle_bin_path)
-      end
+      assert_match %r%\A#!\s*#{ruby_exec}%, File.read(default_bundle_bin_path)
       assert_match %r%\A#!\s*#{ruby_exec}%, File.read(gem_bin_path)
     else
       assert_match %r%\A#!/usr/bin/env #{ruby_exec}%, File.read(default_gem_bin_path)
-      if Gem::USE_BUNDLER_FOR_GEMDEPS
-        assert_match %r%\A#!/usr/bin/env #{ruby_exec}%, File.read(default_bundle_bin_path)
-      end
+      assert_match %r%\A#!/usr/bin/env #{ruby_exec}%, File.read(default_bundle_bin_path)
       assert_match %r%\A#!/usr/bin/env #{ruby_exec}%, File.read(gem_bin_path)
     end
   end
@@ -176,10 +169,8 @@ class TestGemCommandsSetupCommand < Gem::TestCase
       assert_path_exists File.join(dir, 'rubygems.rb')
       assert_path_exists File.join(dir, 'rubygems/ssl_certs/rubygems.org/foo.pem')
 
-      if Gem::USE_BUNDLER_FOR_GEMDEPS
-        assert_path_exists File.join(dir, 'bundler.rb')
-        assert_path_exists File.join(dir, 'bundler/b.rb')
-      end
+      assert_path_exists File.join(dir, 'bundler.rb')
+      assert_path_exists File.join(dir, 'bundler/b.rb')
     end
   end
 
@@ -223,7 +214,7 @@ class TestGemCommandsSetupCommand < Gem::TestCase
 
     # expect to not remove bundler-* direcotyr.
     assert_path_exists 'default/gems/bundler-audit-1.0.0'
-  end if Gem::USE_BUNDLER_FOR_GEMDEPS
+  end
 
   def test_remove_old_lib_files
     lib                   = File.join @install_dir, 'lib'
@@ -271,7 +262,7 @@ class TestGemCommandsSetupCommand < Gem::TestCase
 
     refute_path_exists old_builder_rb
     refute_path_exists old_format_rb
-    refute_path_exists old_bundler_c_rb if Gem::USE_BUNDLER_FOR_GEMDEPS
+    refute_path_exists old_bundler_c_rb
 
     assert_path_exists securerandom_rb
     assert_path_exists engine_defaults_rb

--- a/test/rubygems/test_gem_config_file.rb
+++ b/test/rubygems/test_gem_config_file.rb
@@ -157,8 +157,8 @@ class TestGemConfigFile < Gem::TestCase
     File.open conf3, 'w' do |fp|
       fp.puts ':verbose: :loud'
     end
-
-    ENV['GEMRC'] = conf1 + ':' + conf2 + ';' + conf3
+    ps = File::PATH_SEPARATOR
+    ENV['GEMRC'] = conf1 + ps + conf2 + ps + conf3
 
     util_config_file
 

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -901,6 +901,36 @@ gem 'other', version
     assert_includes(e.message, "can't find gem a (= 3.0)")
   end
 
+  def test_install_creates_binstub_that_prefers_user_installed_gem_to_default
+    Dir.mkdir util_inst_bindir
+
+    install_default_gems new_default_spec('default', '2')
+
+    util_setup_gem do |spec|
+      spec.name = 'default'
+      spec.version = '2'
+    end
+
+    util_clear_gems
+
+    @installer.wrappers = true
+
+    @newspec = nil
+    build_rake_in do
+      use_ui @ui do
+        @newspec = @installer.install
+      end
+    end
+
+    exe = File.join @gemhome, 'bin', 'executable'
+
+    e = assert_raises RuntimeError do
+      instance_eval File.read(exe)
+    end
+
+    assert_equal(e.message, "ran executable")
+  end
+
   def test_install_creates_binstub_that_dont_trust_encoding
     Dir.mkdir util_inst_bindir
     util_setup_gem
@@ -1724,7 +1754,9 @@ gem 'other', version
 
     dest = File.join @gemhome, 'gems', @spec.full_name
 
-    @installer.unpack dest
+    Gem::Deprecate.skip_during do
+      @installer.unpack dest
+    end
 
     assert_path_exists File.join dest, 'lib', 'code.rb'
     assert_path_exists File.join dest, 'bin', 'executable'

--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -53,7 +53,6 @@ gems:
     homepage: http://rake.rubyforge.org
     description: Rake is a Make-like program implemented in Ruby. Tasks and dependencies are specified in standard Ruby syntax.
     autorequire:
-    default_executable: rake
     bindir: bin
     has_rdoc: true
     required_ruby_version: !ruby/object:Gem::Version::Requirement

--- a/test/rubygems/test_gem_requirement.rb
+++ b/test/rubygems/test_gem_requirement.rb
@@ -265,6 +265,12 @@ class TestGemRequirement < Gem::TestCase
     assert_satisfied_by "3.0.rc2",     "< 3.0.1"
 
     assert_satisfied_by "3.0.rc2",     "> 0"
+
+    assert_satisfied_by "5.0.0.rc2",   "~> 5.a"
+    refute_satisfied_by "5.0.0.rc2",   "~> 5.x"
+
+    assert_satisfied_by "5.0.0",       "~> 5.a"
+    assert_satisfied_by "5.0.0",       "~> 5.x"
   end
 
   def test_illformed_requirements

--- a/test/rubygems/test_gem_uninstaller.rb
+++ b/test/rubygems/test_gem_uninstaller.rb
@@ -22,9 +22,10 @@ class TestGemUninstaller < Gem::InstallerTestCase
   end
 
   def test_initialize_expand_path
-    uninstaller = Gem::Uninstaller.new nil, :install_dir => '/foo//bar'
+    FileUtils.mkdir_p 'foo/bar'
+    uninstaller = Gem::Uninstaller.new nil, :install_dir => 'foo//bar'
 
-    assert_match %r|/foo/bar$|, uninstaller.instance_variable_get(:@gem_home)
+    assert_match %r|foo/bar$|, uninstaller.instance_variable_get(:@gem_home)
   end
 
   def test_ask_if_ok
@@ -133,6 +134,7 @@ class TestGemUninstaller < Gem::InstallerTestCase
   end
 
   def test_remove_not_in_home
+    Dir.mkdir "#{@gemhome}2"
     uninstaller = Gem::Uninstaller.new nil, :install_dir => "#{@gemhome}2"
 
     e = assert_raises Gem::GemNotInHomeException do
@@ -147,6 +149,22 @@ class TestGemUninstaller < Gem::InstallerTestCase
     assert_equal expected, e.message
 
     assert_path_exists @spec.gem_dir
+  end
+
+  def test_remove_symlinked_gem_home
+    Dir.mktmpdir("gem_home") do |dir|
+      symlinked_gem_home = "#{dir}/#{File.basename(@gemhome)}"
+
+      FileUtils.ln_s(@gemhome, dir)
+
+      uninstaller = Gem::Uninstaller.new nil, :install_dir => symlinked_gem_home
+
+      use_ui ui do
+        uninstaller.remove @spec
+      end
+
+      refute_path_exists @spec.gem_dir
+    end
   end
 
   def test_path_ok_eh
@@ -313,6 +331,7 @@ create_makefile '#{@spec.name}'
   end
 
   def test_uninstall_wrong_repo
+    Dir.mkdir "#{@gemhome}2"
     Gem.use_paths "#{@gemhome}2", [@gemhome]
 
     uninstaller = Gem::Uninstaller.new @spec.name, :executables => true

--- a/test/rubygems/test_gem_version.rb
+++ b/test/rubygems/test_gem_version.rb
@@ -157,6 +157,13 @@ class TestGemVersion < Gem::TestCase
     assert_equal(1, v("1.8.2.a10") <=> v("1.8.2.a9"))
     assert_equal(0, v("")          <=> v("0"))
 
+    assert_equal(0, v("0.beta.1")  <=> v("0.0.beta.1"))
+    assert_equal(-1, v("0.0.beta")  <=> v("0.0.beta.1"))
+    assert_equal(-1, v("0.0.beta")  <=> v("0.beta.1"))
+
+    assert_equal(-1, v("5.a") <=> v("5.0.0.rc2"))
+    assert_equal(1, v("5.x") <=> v("5.0.0.rc2"))
+
     assert_nil v("1.0") <=> "whatever"
   end
 

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -323,6 +323,19 @@ class TestGemRequire < Gem::TestCase
     assert_equal %w(default-3.0), loaded_spec_names
   end
 
+  def test_default_gem_prerelease
+    default_gem_spec = new_default_spec("default", "2.0.0",
+                                        nil, "default/gem.rb")
+    install_default_specs(default_gem_spec)
+
+    normal_gem_higher_prerelease_spec = util_spec("default", "3.0.0.rc2", nil,
+                                                  "lib/default/gem.rb")
+    install_default_specs(normal_gem_higher_prerelease_spec)
+
+    assert_require "default/gem"
+    assert_equal %w(default-3.0.0.rc2), loaded_spec_names
+  end
+
   def loaded_spec_names
     Gem.loaded_specs.values.map(&:full_name).sort
   end


### PR DESCRIPTION
Hi @hsbt!

Today I run bundler specs from ruby-core, and got a bunch of failures in specs like:

https://github.com/bundler/bundler/blob/6b88a62f72e3dce6ef7f45117f457799113a1536/spec/commands/binstubs_spec.rb#L95-L133

I investigated and the failures happen because:

* `bundler-2.0.1.pre.1` is a default gem in ruby-core.
* The offending specs install a custom version of `bundler-2.0.1.pre.1`.
* Due to a bug in rubygems, the default version is preferred to the custom version, so the specs fail.

This is fixed in https://github.com/rubygems/rubygems/pull/2112, so I would like to start using that fix so that the specs go green :smiley: 