### PR TITLE
ia64: Don't clear register_stack_start

### DIFF
--- a/cont.c
+++ b/cont.c
@@ -621,7 +621,6 @@ cont_save_thread(rb_context_t *cont, rb_thread_t *th)
     sec->machine.stack_end = NULL;
 
 #ifdef __ia64
-    sec->machine.register_stack_start = NULL;
     sec->machine.register_stack_end = NULL;
 #endif
 }


### PR DESCRIPTION
r59829 stopped clearing stack_start and enabled the code for !FIBER_USE_NATIVE, but we need to do the same for register_stack_start on ia64, otherwise we end up with NULL in cont_save_machine_stack.

This regression first shows up on the 2.1 branch, though 2.5 is the earliest branch still subject to normal maintenance, so I suppose this is only really a candidate for the 2.5 and 2.6 branches.