### PR TITLE
Add class ref to `UnboundMethod#owner` doc

### DIFF
--- a/proc.c
+++ b/proc.c
@@ -1647,7 +1647,7 @@ method_original_name(VALUE obj)
  *     meth.owner    -> class_or_module
  *
  *  Returns the class or module that defines the method.
- *  See also receiver.
+ *  See also Method#receiver.
  *
  *    (1..3).method(:map).owner #=> Enumerable
  */


### PR DESCRIPTION
It refers to `Method#receiver` in the doc, but there's no class reference in current doc.
Some tools automatically make it a link so it's useful.