### PR TITLE
Let the current VM and main thread be static and not heap allocated

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -9723,16 +9723,6 @@ ruby_mimmalloc(size_t size)
     return mem;
 }
 
-void
-ruby_mimfree(void *ptr)
-{
-#if CALC_EXACT_MALLOC_SIZE
-    struct malloc_obj_info *info = (struct malloc_obj_info *)ptr - 1;
-    ptr = info;
-#endif
-    free(ptr);
-}
-
 void *
 rb_alloc_tmp_buffer_with_count(volatile VALUE *store, size_t size, size_t cnt)
 {

--- a/internal.h
+++ b/internal.h
@@ -1507,7 +1507,6 @@ extern VALUE *ruby_initial_gc_stress_ptr;
 extern int ruby_disable_gc;
 void Init_heap(void);
 void *ruby_mimmalloc(size_t size);
-void ruby_mimfree(void *ptr);
 void rb_objspace_set_event_hook(const rb_event_flag_t event);
 #if USE_RGENGC
 void rb_gc_writebarrier_remember(VALUE obj);


### PR DESCRIPTION
I was curious when I saw the memory access patterns of the `rb_vm_t` struct for the current VM instance:

```
==24182== -------------------- 764 of 1000 --------------------
==24182== max-live:    1,344 in 1 blocks
==24182== tot-alloc:   1,344 in 1 blocks (avg size 1344.00)
==24182== deaths:      1, at avg age 10,692,850,268 (99.98% of prog lifetime)
==24182== acc-ratios:  67844.80 rd, 3222.89 wr  (91,183,423 b-read, 4,331,567 b-written)
==24182==    at 0x4C2DECF: malloc (in /usr/lib/valgrind/vgpreload_exp-dhat-amd64-linux.so)
==24182==    by 0x300F2F: Init_BareVM (vm.c:3211)
==24182==    by 0x133DE6: ruby_setup (eval.c:67)
==24182==    by 0x133EB8: ruby_init (eval.c:91)
```

I looked at `ruby_mimmalloc` and `ruby_mimfree` and noticed allocs happen prior to objspace init for 3 concerns:

* Current VM
* The main thread
* The root fiber (which needs to be heap allocated and cannot be shared as pointed out by @mame in https://github.com/ruby/ruby/pull/2157#issuecomment-488532950, so I removed this one)

This PR moves the following 2 instances from the heap to the `bss` segment (cannot be `data` because uninitialized and then initialized incrementally in phases in `Init_BareVM`, also strong coupling via references between the 2):

```
.bss            0x00000000006280a0      0xa48
 *(.dynbss)
 *(.bss .bss.* .gnu.linkonce.b.*)
 .bss           0x00000000006280a0      0x2b0 vm.o
                0x00000000006280a0                ruby_current_execution_context_ptr
                0x00000000006280a8                ruby_current_vm_ptr
                0x00000000006280b0                ruby_vm_const_missing_count
 *(COMMON)
 *fill*         0x0000000000628350       0x10 
 COMMON         0x0000000000628360      0x788 vm.o
                0x0000000000628360                rb_cRubyVM
                0x0000000000628380                ruby_vm_storage_main_th <<<<<<<<<<
                0x0000000000628588                ruby_vm_event_enabled_global_flags
                0x000000000062858c                ruby_vm_event_local_num
                0x0000000000628590                ruby_vm_event_flags
                0x0000000000628598                rb_mRubyVMFrozenCore
                0x00000000006285a0                ruby_vm_storage_current_vm <<<<<<<<<<
                0x0000000000628ae0                rb_cThread
                0x0000000000628ae8                . = ALIGN ((. != 0x0)?0x8:0x1)
```

Memory is thus explicitly allocated for the `ruby_storage_current_vm` and `ruby_storage_main_th` variables when `ruby` starts. This removes having to handle error paths from `ruby_mimmalloc` explicitly (the OS loader can handle it) and also no need to zero out any of the memory as it's initialized to 0 / zero-filled on modern platforms (I may be wrong on this and we can restore the `MEMZERO` macro for the main thread as fallback).

A side effect of this change is that `ruby_mimfree` is no longer needed as it was only ever used on VM shutdown to free the current VM. The only remaining `ruby_mimmalloc` call on initializing the root fiber returns a pointer suitable for `xfree` anyways. cc @ioquatix 

I am also not sure about the `ruby_vm_storage_` API - ideas welcome. There are also paths in the timer thread implementation, specifically `rb_thread_wakeup_timer_thread` that can be simplified, but I'm still wrapping my head around `system_working` and out of scope for this changeset.