### PR TITLE
Let the VM postponed job buffer not be heap allocated

### DIFF
--- a/vm_trace.c
+++ b/vm_trace.c
@@ -1817,11 +1817,13 @@ struct rb_workqueue_job {
     rb_postponed_job_t job;
 };
 
+rb_postponed_job_t ruby_vm_storage_postponed_job[MAX_POSTPONED_JOB];
+
 void
 Init_vm_postponed_job(void)
 {
     rb_vm_t *vm = GET_VM();
-    vm->postponed_job_buffer = ALLOC_N(rb_postponed_job_t, MAX_POSTPONED_JOB);
+    vm->postponed_job_buffer = ruby_vm_storage_postponed_job;
     vm->postponed_job_index = 0;
     /* workqueue is initialized when VM locks are initialized */
 }


### PR DESCRIPTION
Builds on https://github.com/ruby/ruby/pull/2157 (no dependency, just the `ruby_vm_storage_` pattern) and references postponed job buffer utilization observed during a few requests of Redmine:

```
==7335== -------------------- 310 of 2000 --------------------
==7335== max-live:    16,000 in 1 blocks
==7335== tot-alloc:   16,000 in 1 blocks (avg size 16000.00)
==7335== deaths:      none (none of these blocks were freed)
==7335== acc-ratios:  7.76 rd, 0.12 wr  (124,216 b-read, 2,016 b-written)
==7335==    at 0x4C2DECF: malloc (in /usr/lib/valgrind/vgpreload_exp-dhat-amd64-linux.so)
==7335==    by 0x1521F3: objspace_xmalloc0 (gc.c:9416)
==7335==    by 0x30ABD6: Init_vm_postponed_job (vm_trace.c:1824)
==7335==    by 0x164BCD: rb_call_inits (inits.c:22)
```

Currently not freed on VM shutdown, thus semantically no different than a global variable
