### PR TITLE
Improve doc for Enumerable#include? and member?

### DIFF
--- a/enum.c
+++ b/enum.c
@@ -2301,10 +2301,10 @@ member_i(RB_BLOCK_CALL_FUNC_ARGLIST(iter, args))
  *  Returns <code>true</code> if any member of <i>enum</i> equals
  *  <i>obj</i>. Equality is tested using <code>==</code>.
  *
- *     IO.constants.include? :SEEK_SET          #=> true
- *     IO.constants.include? :SEEK_NO_FURTHER   #=> false
- *     IO.constants.member? :SEEK_SET          #=> true
- *     IO.constants.member? :SEEK_NO_FURTHER   #=> false
+ *     (1..10).include? 5  #=> true
+ *     (1..10).include? 15 #=> false
+ *     (1..10).member? 5   #=> true
+ *     (1..10).member? 15  #=> false
  *
  */
 


### PR DESCRIPTION
Existing doc for Enumerable#include? and member? has some problems.

* `IO.constants` is not commonly used, and only some know
    that `SEEK_SET` is actually included in constants.
* `IO.constants` is actually an Array, not the example is not
    appropriate for `Enumerable` module.

So in this commit, the old example is replaced with new one.
New example uses integer range, which is much simpler and easier to
understand.