### PR TITLE
Support XDG_*

### DIFF
--- a/lib/irb/init.rb
+++ b/lib/irb/init.rb
@@ -271,10 +271,19 @@ module IRB # :nodoc:
     if irbrc = ENV["IRBRC"]
       yield proc{|rc| rc == "rc" ? irbrc : irbrc+rc}
     end
+    if xdg_config_home = ENV["XDG_CONFIG_HOME"]
+      irb_home = File.join(xdg_config_home, "irb")
+      unless File.exist? irb_home
+        require 'fileutils'
+        FileUtils.mkdir_p irb_home
+      end
+      yield proc{|rc| irb_home + "/irb#{rc}"}
+    end
     if home = ENV["HOME"]
       yield proc{|rc| home+"/.irb#{rc}"}
     end
     current_dir = Dir.pwd
+    yield proc{|rc| current_dir+"/.config/irb/irb#{rc}"}
     yield proc{|rc| current_dir+"/.irb#{rc}"}
     yield proc{|rc| current_dir+"/irb#{rc.sub(/\A_?/, '.')}"}
     yield proc{|rc| current_dir+"/_irb#{rc}"}

--- a/lib/rdoc.rb
+++ b/lib/rdoc.rb
@@ -121,9 +121,19 @@ module RDoc
   end
 
   def self.home
-    begin
-      File.expand_path('~/.rdoc')
-    rescue ArgumentError
+    rdoc_dir = begin
+                File.expand_path('~/.rdoc')
+              rescue ArgumentError
+              end
+
+    if File.exists?(rdoc_dir)
+      rdoc_dir
+    else
+      xdg_data_home = ENV["XDG_DATA_HOME"] || File.join(Gem.user_home, '.local', 'share')
+      unless File.exists?(xdg_data_home)
+        FileUtils.mkdir_p xdg_data_home
+      end
+      File.join xdg_data_home, "rdoc"
     end
   end
 

--- a/lib/rdoc.rb
+++ b/lib/rdoc.rb
@@ -126,11 +126,11 @@ module RDoc
               rescue ArgumentError
               end
 
-    if File.exists?(rdoc_dir)
+    if File.exist?(rdoc_dir)
       rdoc_dir
     else
       xdg_data_home = ENV["XDG_DATA_HOME"] || File.join(Gem.user_home, '.local', 'share')
-      unless File.exists?(xdg_data_home)
+      unless File.exist?(xdg_data_home)
         FileUtils.mkdir_p xdg_data_home
       end
       File.join xdg_data_home, "rdoc"

--- a/lib/rdoc.rb
+++ b/lib/rdoc.rb
@@ -120,6 +120,13 @@ module RDoc
     end
   end
 
+  def self.home
+    begin
+      File.expand_path('~/.rdoc')
+    rescue ArgumentError
+    end
+  end
+
   autoload :RDoc,           'rdoc/rdoc'
 
   autoload :CrossReference, 'rdoc/cross_reference'

--- a/lib/rdoc.rb
+++ b/lib/rdoc.rb
@@ -129,7 +129,8 @@ module RDoc
     if File.exist?(rdoc_dir)
       rdoc_dir
     else
-      xdg_data_home = ENV["XDG_DATA_HOME"] || File.join(Gem.user_home, '.local', 'share')
+      # XDG
+      xdg_data_home = ENV["XDG_DATA_HOME"] || File.join(File.expand_path("~"), '.local', 'share')
       unless File.exist?(xdg_data_home)
         FileUtils.mkdir_p xdg_data_home
       end

--- a/lib/rdoc.rb
+++ b/lib/rdoc.rb
@@ -126,7 +126,7 @@ module RDoc
               rescue ArgumentError
               end
 
-    if File.exist?(rdoc_dir)
+    if File.directory?(rdoc_dir)
       rdoc_dir
     else
       # XDG

--- a/lib/rdoc/ri/paths.rb
+++ b/lib/rdoc/ri/paths.rb
@@ -14,10 +14,7 @@ module RDoc::RI::Paths
 
   BASE    = File.join RbConfig::CONFIG['ridir'], version
 
-  HOMEDIR = begin
-              File.expand_path('~/.rdoc')
-            rescue ArgumentError
-            end
+  HOMEDIR = RDoc.home
   #:startdoc:
 
   ##

--- a/lib/rdoc/store.rb
+++ b/lib/rdoc/store.rb
@@ -482,7 +482,7 @@ class RDoc::Store
     when :gem    then
       parent = File.expand_path '..', @path
       "gem #{File.basename parent}"
-    when :home   then '~/.rdoc'
+    when :home   then RDoc.home
     when :site   then 'ruby site'
     when :system then 'ruby core'
     else @path

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -338,39 +338,6 @@ module Gem
   end
 
   ##
-  # The path to standard location of the user's configuration directory.
-
-  def self.config_home
-    @config_home ||= (ENV["XDG_CONFIG_HOME"] || File.join(Gem.user_home, '.config'))
-  end
-
-  ##
-  # The path to standard location of the user's cache directory.
-
-  def self.cache_home
-    @cache_home ||= (ENV["XDG_CACHE_HOME"] || File.join(Gem.user_home, '.cache'))
-  end
-
-  ##
-  # The path to standard location of the user's data directory.
-
-  def self.data_home
-    @data_home ||= (ENV["XDG_DATA_HOME"] || File.join(Gem.user_home, '.local', 'share'))
-  end
-
-  ##
-  # The path to standard location of the user's .gemrc file.
-
-  def self.config_file
-    gemrc = File.join Gem.user_home, '.gemrc'
-    if File.exist? gemrc
-      @config_file ||= gemrc
-    else
-      @config_file ||= File.join Gem.config_home, "gem", "gemrc"
-    end
-  end
-
-  ##
   # The standard configuration object for gems.
 
   def self.configuration

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -345,6 +345,13 @@ module Gem
   end
 
   ##
+  # The path to standard location of the user's cache directory.
+
+  def self.cache_home
+    @cache_home ||= (ENV["XDG_CACHE_HOME"] || File.join(Gem.user_home, '.cache'))
+  end
+
+  ##
   # The path to standard location of the user's .gemrc file.
 
   def self.config_file

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -352,6 +352,13 @@ module Gem
   end
 
   ##
+  # The path to standard location of the user's data directory.
+
+  def self.data_home
+    @data_home ||= (ENV["XDG_DATA_HOME"] || File.join(Gem.user_home, '.local', 'share'))
+  end
+
+  ##
   # The path to standard location of the user's .gemrc file.
 
   def self.config_file

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -346,8 +346,8 @@ module Gem
       @config_file ||= gemrc
     else
       # XDG
-      ENV["XDG_CONFIG_HOME"] ||= File.join Gem.user_home, '.config'
-      @config_file ||= File.join ENV["XDG_CONFIG_HOME"], "gem"
+      xdg_config_home = ENV["XDG_CONFIG_HOME"] || File.join(Gem.user_home, '.config')
+      @config_file ||= File.join xdg_config_home, "gem"
     end
   end
 

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -338,6 +338,13 @@ module Gem
   end
 
   ##
+  # The path to standard location of the user's configuration directory.
+
+  def self.config_home
+    @config_home ||= (ENV["XDG_CONFIG_HOME"] || File.join(Gem.user_home, '.config'))
+  end
+
+  ##
   # The path to standard location of the user's .gemrc file.
 
   def self.config_file
@@ -345,9 +352,7 @@ module Gem
     if File.exist? gemrc
       @config_file ||= gemrc
     else
-      # XDG
-      xdg_config_home = ENV["XDG_CONFIG_HOME"] || File.join(Gem.user_home, '.config')
-      @config_file ||= File.join xdg_config_home, "gem"
+      @config_file ||= File.join Gem.config_home, "gem", "gemrc"
     end
   end
 

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -551,33 +551,6 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   end
 
   ##
-  # Finds the user's home directory.
-  #--
-  # Some comments from the ruby-talk list regarding finding the home
-  # directory:
-  #
-  #   I have HOME, USERPROFILE and HOMEDRIVE + HOMEPATH. Ruby seems
-  #   to be depending on HOME in those code samples. I propose that
-  #   it should fallback to USERPROFILE and HOMEDRIVE + HOMEPATH (at
-  #   least on Win32).
-  #++
-  #--
-  #
-  #++
-
-  def self.find_home
-    Dir.home.dup
-  rescue
-    if Gem.win_platform?
-      File.expand_path File.join(ENV['HOMEDRIVE'] || ENV['SystemDrive'], '/')
-    else
-      File.expand_path "/"
-    end
-  end
-
-  private_class_method :find_home
-
-  ##
   # Top level install helper method. Allows you to install gems interactively:
   #
   #   % irb

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -341,7 +341,14 @@ module Gem
   # The path to standard location of the user's .gemrc file.
 
   def self.config_file
-    @config_file ||= File.join Gem.user_home, '.gemrc'
+    gemrc = File.join Gem.user_home, '.gemrc'
+    if File.exist? gemrc
+      @config_file ||= gemrc
+    else
+      # XDG
+      ENV["XDG_CONFIG_HOME"] ||= File.join Gem.user_home, '.config'
+      @config_file ||= File.join ENV["XDG_CONFIG_HOME"], "gem"
+    end
   end
 
   ##

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -1023,13 +1023,6 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   end
 
   ##
-  # The home directory for the user.
-
-  def self.user_home
-    @user_home ||= find_home.tap(&Gem::UNTAINT)
-  end
-
-  ##
   # Is this a windows platform?
 
   def self.win_platform?

--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -261,7 +261,12 @@ if you believe they were disclosed to a third party.
   # Location of RubyGems.org credentials
 
   def credentials_path
-    File.join Gem.user_home, '.gem', 'credentials'
+    credentials = File.join Gem.user_home, '.gem', 'credentials'
+    if File.exist? credentials
+      credentials
+    else
+      File.join Gem.config_home, "gem", "credentials"
+    end
   end
 
   def load_api_keys

--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -265,7 +265,7 @@ if you believe they were disclosed to a third party.
     if File.exist? credentials
       credentials
     else
-      File.join Gem.config_home, "gem", "credentials"
+      File.join Gem.cache_home, "gem", "credentials"
     end
   end
 

--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -444,6 +444,10 @@ if you believe they were disclosed to a third party.
 
   # Writes out this config file, replacing its source.
   def write
+    unless File.exist?(File.dirname(config_file_name))
+      FileUtils.mkdir_p File.dirname(config_file_name)
+    end
+
     File.open config_file_name, 'w' do |io|
       io.write to_yaml
     end

--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -265,7 +265,7 @@ if you believe they were disclosed to a third party.
     if File.exist? credentials
       credentials
     else
-      File.join Gem.cache_home, "gem", "credentials"
+      File.join Gem.data_home, "gem", "credentials"
     end
   end
 

--- a/lib/rubygems/defaults.rb
+++ b/lib/rubygems/defaults.rb
@@ -107,7 +107,7 @@ module Gem
   # The home directory for the user.
 
   def self.user_home
-    @user_home ||= find_home.untaint
+    @user_home ||= find_home.tap(&Gem::UNTAINT)
   end
 
   ##

--- a/lib/rubygems/defaults.rb
+++ b/lib/rubygems/defaults.rb
@@ -144,7 +144,7 @@ module Gem
   # The path to standard location of the user's .gemrc file.
 
   def self.config_file
-    @config_file ||= find_config_file.untaint
+    @config_file ||= find_config_file.tap(&Gem::UNTAINT)
   end
 
   ##

--- a/lib/rubygems/defaults.rb
+++ b/lib/rubygems/defaults.rb
@@ -129,15 +129,22 @@ module Gem
   end
 
   ##
+  # Finds the user's config file
+
+  def self.find_config_file
+    gemrc = File.join Gem.user_home, '.gemrc'
+    if File.exist? gemrc
+      gemrc
+    else
+      File.join Gem.config_home, "gem", "gemrc"
+    end
+  end
+
+  ##
   # The path to standard location of the user's .gemrc file.
 
   def self.config_file
-    gemrc = File.join Gem.user_home, '.gemrc'
-    if File.exist? gemrc
-      @config_file ||= gemrc
-    else
-      @config_file ||= File.join Gem.config_home, "gem", "gemrc"
-    end
+    @config_file ||= find_config_file.untaint
   end
 
   ##

--- a/lib/rubygems/defaults.rb
+++ b/lib/rubygems/defaults.rb
@@ -74,7 +74,13 @@ module Gem
   # Path for gems in the user's home directory
 
   def self.user_dir
-    parts = [Gem.user_home, '.gem', ruby_engine]
+    gem_dir = File.join(Gem.user_home, ".gem")
+    unless File.exist?(gem_dir)
+      # XDG
+      ENV["XDG_DATA_HOME"] ||= File.join Gem.user_home, '.local', 'share'
+      gem_dir = File.join ENV["XDG_DATA_HOME"], "gem"
+    end
+    parts = [gem_dir, ruby_engine]
     parts << RbConfig::CONFIG['ruby_version'] unless RbConfig::CONFIG['ruby_version'].empty?
     File.join parts
   end

--- a/lib/rubygems/defaults.rb
+++ b/lib/rubygems/defaults.rb
@@ -20,7 +20,13 @@ module Gem
   # specified in the environment
 
   def self.default_spec_cache_dir
-    File.join Gem.user_home, '.gem', 'specs'
+    default_spec_cache_dir = File.join Gem.user_home, '.gem', 'specs'
+
+    unless File.exist?(default_spec_cache_dir)
+      default_spec_cache_dir = File.join Gem.data_home, 'gem', 'specs'
+    end
+
+    default_spec_cache_dir
   end
 
   ##

--- a/lib/rubygems/defaults.rb
+++ b/lib/rubygems/defaults.rb
@@ -75,11 +75,7 @@ module Gem
 
   def self.user_dir
     gem_dir = File.join(Gem.user_home, ".gem")
-    unless File.exist?(gem_dir)
-      # XDG
-      ENV["XDG_DATA_HOME"] ||= File.join Gem.user_home, '.local', 'share'
-      gem_dir = File.join ENV["XDG_DATA_HOME"], "gem"
-    end
+    gem_dir = File.join(Gem.data_home, "gem") unless File.exist?(gem_dir)
     parts = [gem_dir, ruby_engine]
     parts << RbConfig::CONFIG['ruby_version'] unless RbConfig::CONFIG['ruby_version'].empty?
     File.join parts

--- a/lib/rubygems/defaults.rb
+++ b/lib/rubygems/defaults.rb
@@ -199,14 +199,26 @@ module Gem
   # The default signing key path
 
   def self.default_key_path
-    File.join Gem.user_home, ".gem", "gem-private_key.pem"
+    default_key_path = File.join Gem.user_home, ".gem", "gem-private_key.pem"
+
+    unless File.exist?(default_key_path)
+      default_key_path = File.join Gem.data_home, "gem", "gem-private_key.pem"
+    end
+
+    default_key_path
   end
 
   ##
   # The default signing certificate chain path
 
   def self.default_cert_path
-    File.join Gem.user_home, ".gem", "gem-public_cert.pem"
+    default_cert_path = File.join Gem.user_home, ".gem", "gem-public_cert.pem"
+
+    unless File.exist?(default_cert_path)
+      default_cert_path = File.join Gem.data_home, "gem", "gem-public_cert.pem"
+    end
+
+    default_cert_path
   end
 
   ##

--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -19,7 +19,7 @@ module Gem::GemcutterUtilities
   def add_key_option
     add_option('-k', '--key KEYNAME', Symbol,
                'Use the given API key',
-               'from ~/.local/share/gem/credentials') do |value,options|
+               "from #{Gem.configuration.credentials_path}") do |value,options|
       options[:key] = value
     end
   end

--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -19,7 +19,7 @@ module Gem::GemcutterUtilities
   def add_key_option
     add_option('-k', '--key KEYNAME', Symbol,
                'Use the given API key',
-               'from ~/.config/gem/credentials') do |value,options|
+               'from ~/.cache/gem/credentials') do |value,options|
       options[:key] = value
     end
   end

--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -19,7 +19,7 @@ module Gem::GemcutterUtilities
   def add_key_option
     add_option('-k', '--key KEYNAME', Symbol,
                'Use the given API key',
-               'from ~/.cache/gem/credentials') do |value,options|
+               'from ~/.local/share/gem/credentials') do |value,options|
       options[:key] = value
     end
   end

--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -19,7 +19,7 @@ module Gem::GemcutterUtilities
   def add_key_option
     add_option('-k', '--key KEYNAME', Symbol,
                'Use the given API key',
-               'from ~/.gem/credentials') do |value,options|
+               'from ~/.config/gem/credentials') do |value,options|
       options[:key] = value
     end
   end

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -364,12 +364,11 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
 
     ENV['HOME'] = @userhome
     FileUtils.mkdir_p File.join(@userhome, ".gem")
-    File.open(File.join(@userhome, ".gemrc"), "w"){|f| f.puts "--- {}" }
+    File.write File.join(@userhome, ".gemrc"), "--- {}"
     temp_cred = File.join(@userhome, '.gem', 'credentials')
     FileUtils.mkdir_p File.dirname(temp_cred)
-    File.open temp_cred, 'w', 0600 do |fp|
-      fp.puts ':rubygems_api_key: 701229f217cdf23b1344c7b4b54ca97'
-    end
+    File.write temp_cred, ':rubygems_api_key: 701229f217cdf23b1344c7b4b54ca97'
+    File.chmod 0600, temp_cred
 
     Gem.instance_variable_set :@user_home, nil
     Gem.instance_variable_set :@gemdeps, nil

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -364,8 +364,12 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
 
     ENV['HOME'] = @userhome
     FileUtils.mkdir_p File.join(@userhome, ".gem")
-    FileUtils.touch File.join(@userhome, ".gemrc")
-    FileUtils.touch File.join(@userhome, ".gem" "credentials",)
+    File.open(File.join(@userhome, ".gemrc"), "w"){|f| f.puts "--- {}" }
+    temp_cred = File.join(@userhome, '.gem', 'credentials')
+    FileUtils.mkdir_p File.dirname(temp_cred)
+    File.open temp_cred, 'w', 0600 do |fp|
+      fp.puts ':rubygems_api_key: 701229f217cdf23b1344c7b4b54ca97'
+    end
     Gem.instance_variable_set :@user_home, nil
     Gem.instance_variable_set :@gemdeps, nil
     Gem.instance_variable_set :@env_requirements_by_name, nil

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -370,6 +370,7 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
     File.open temp_cred, 'w', 0600 do |fp|
       fp.puts ':rubygems_api_key: 701229f217cdf23b1344c7b4b54ca97'
     end
+    ENV['XDG_DATA_HOME'] = File.join @userhome, ".local", "share"
     Gem.instance_variable_set :@user_home, nil
     Gem.instance_variable_set :@gemdeps, nil
     Gem.instance_variable_set :@env_requirements_by_name, nil

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -363,6 +363,9 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
     Dir.chdir @tempdir
 
     ENV['HOME'] = @userhome
+    FileUtils.mkdir_p File.join(@userhome, ".gem")
+    FileUtils.touch File.join(@userhome, ".gemrc")
+    FileUtils.touch File.join(@userhome, ".gem" "credentials",)
     Gem.instance_variable_set :@user_home, nil
     Gem.instance_variable_set :@gemdeps, nil
     Gem.instance_variable_set :@env_requirements_by_name, nil

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -370,7 +370,7 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
     File.open temp_cred, 'w', 0600 do |fp|
       fp.puts ':rubygems_api_key: 701229f217cdf23b1344c7b4b54ca97'
     end
-    ENV['XDG_DATA_HOME'] = File.join @userhome, ".local", "share"
+
     Gem.instance_variable_set :@user_home, nil
     Gem.instance_variable_set :@gemdeps, nil
     Gem.instance_variable_set :@env_requirements_by_name, nil

--- a/spec/bundler/bundler/env_spec.rb
+++ b/spec/bundler/bundler/env_spec.rb
@@ -41,11 +41,13 @@ RSpec.describe Bundler::Env do
       end
 
       it "prints user path" do
-        with_clear_paths("HOME", "/a/b/c") do
+        if Gem::VERSION >= "3.1.0.pre.1"
+          allow(Gem).to receive(:data_home) { "/a/b/c/.local/share" }
           out = described_class.report
-          if Gem::VERSION >= "3.1.0.pre.1"
-            expect(out).to include("User Path   /a/b/c/.local/share/gem")
-          else
+          expect(out).to include("User Path   /a/b/c/.local/share/gem")
+        else
+          with_clear_paths("HOME", "/a/b/c") do
+            out = described_class.report
             expect(out).to include("User Path   /a/b/c/.gem")
           end
         end

--- a/spec/bundler/bundler/env_spec.rb
+++ b/spec/bundler/bundler/env_spec.rb
@@ -43,7 +43,11 @@ RSpec.describe Bundler::Env do
       it "prints user path" do
         with_clear_paths("HOME", "/a/b/c") do
           out = described_class.report
-          expect(out).to include("User Path   /a/b/c/.gem")
+          if Gem::VERSION >= "3.1.0.pre.1"
+            expect(out).to include("User Path   /a/b/c/.local/share/gem")
+          else
+            expect(out).to include("User Path   /a/b/c/.gem")
+          end
         end
       end
 

--- a/spec/bundler/bundler/env_spec.rb
+++ b/spec/bundler/bundler/env_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Bundler::Env do
       end
 
       it "prints user path" do
-        if Gem::VERSION >= "3.1.0.pre.1"
+        if Gem::VERSION >= "3.2.0.pre.1"
           allow(Gem).to receive(:data_home) { "/a/b/c/.local/share" }
           out = described_class.report
           expect(out).to include("User Path   /a/b/c/.local/share/gem")

--- a/spec/bundler/bundler/friendly_errors_spec.rb
+++ b/spec/bundler/bundler/friendly_errors_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Bundler, "friendly errors" do
 
       bundle :install, :env => { "DEBUG" => "true" }
 
-      if Gem::VERSION >= "3.1.0.pre.1"
+      if Gem::VERSION >= "3.2.0.pre.1"
         expect(err).to include("Failed to load #{File.join(config_home, "gemrc")}")
       else
         expect(err).to include("Failed to load #{home(".gemrc")}")

--- a/spec/bundler/bundler/friendly_errors_spec.rb
+++ b/spec/bundler/bundler/friendly_errors_spec.rb
@@ -6,7 +6,10 @@ require "cgi"
 
 RSpec.describe Bundler, "friendly errors" do
   context "with invalid YAML in .gemrc" do
+    let(:config_home) { File.dirname(Gem.configuration.config_file_name) }
+
     before do
+      FileUtils.mkdir_p config_home
       File.open(Gem.configuration.config_file_name, "w") do |f|
         f.write "invalid: yaml: hah"
       end
@@ -24,7 +27,11 @@ RSpec.describe Bundler, "friendly errors" do
 
       bundle :install, :env => { "DEBUG" => "true" }
 
-      expect(err).to include("Failed to load #{home(".gemrc")}")
+      if Gem::VERSION >= "3.1.0.pre.1"
+        expect(err).to include("Failed to load #{File.join(config_home, "gemrc")}")
+      else
+        expect(err).to include("Failed to load #{home(".gemrc")}")
+      end
       expect(exitstatus).to eq(0) if exitstatus
     end
   end

--- a/spec/bundler/spec_helper.rb
+++ b/spec/bundler/spec_helper.rb
@@ -86,7 +86,6 @@ RSpec.configure do |config|
     ENV["BUNDLE_SPEC_RUN"] = "true"
     ENV["BUNDLE_USER_CONFIG"] = ENV["BUNDLE_USER_CACHE"] = ENV["BUNDLE_USER_PLUGIN"] = nil
     ENV["GEMRC"] = nil
-    ENV["XDG_DATA_HOME"] = nil
 
     # Don't wrap output in tests
     ENV["THOR_COLUMNS"] = "10000"

--- a/spec/bundler/spec_helper.rb
+++ b/spec/bundler/spec_helper.rb
@@ -86,6 +86,7 @@ RSpec.configure do |config|
     ENV["BUNDLE_SPEC_RUN"] = "true"
     ENV["BUNDLE_USER_CONFIG"] = ENV["BUNDLE_USER_CACHE"] = ENV["BUNDLE_USER_PLUGIN"] = nil
     ENV["GEMRC"] = nil
+    ENV["XDG_DATA_HOME"] = nil
 
     # Don't wrap output in tests
     ENV["THOR_COLUMNS"] = "10000"

--- a/test/rdoc/test_rdoc_ri_driver.rb
+++ b/test/rdoc/test_rdoc_ri_driver.rb
@@ -15,6 +15,8 @@ class TestRDocRIDriver < RDoc::TestCase
     @orig_ri = ENV['RI']
     @orig_home = ENV['HOME']
     ENV['HOME'] = @tmpdir
+    @rdoc_home = File.join ENV["HOME"], ".rdoc"
+    FileUtils.mkdir_p @rdoc_home
     ENV.delete 'RI'
 
     @options = RDoc::RI::Driver.default_options
@@ -81,7 +83,7 @@ class TestRDocRIDriver < RDoc::TestCase
       @RM::Rule.new(1),
       @RM::Paragraph.new('Also found in:'),
       @RM::Verbatim.new("ruby core", "\n",
-                        "~/.rdoc", "\n"))
+                        @rdoc_home, "\n"))
 
     assert_equal expected, out
   end
@@ -231,7 +233,7 @@ class TestRDocRIDriver < RDoc::TestCase
       doc(
         head(1, 'Foo::Bar#blah'),
         blank_line,
-        para('(from ~/.rdoc)'),
+        para("(from #{@rdoc_home})"),
         head(3, 'Implementation from Bar'),
         rule(1),
         verb("blah(5) => 5\n",
@@ -254,7 +256,7 @@ class TestRDocRIDriver < RDoc::TestCase
       doc(
         head(1, 'Qux#aliased'),
         blank_line,
-        para('(from ~/.rdoc)'),
+        para("(from #{@rdoc_home})"),
         rule(1),
         blank_line,
         para('alias comment'),
@@ -280,7 +282,7 @@ class TestRDocRIDriver < RDoc::TestCase
       doc(
         head(1, 'Foo::Bar#attr'),
         blank_line,
-        para('(from ~/.rdoc)'),
+        para("(from #{@rdoc_home})"),
         rule(1),
         blank_line,
         blank_line)
@@ -299,7 +301,7 @@ class TestRDocRIDriver < RDoc::TestCase
       doc(
         head(1, 'Bar#inherit'),
         blank_line,
-        para('(from ~/.rdoc)'),
+        para("(from #{@rdoc_home})"),
         head(3, 'Implementation from Foo'),
         rule(1),
         blank_line,
@@ -343,13 +345,13 @@ class TestRDocRIDriver < RDoc::TestCase
       doc(
         head(1, 'Foo#inherit'),
         blank_line,
-        para('(from ~/.rdoc)'),
+        para("(from #{@rdoc_home})"),
         rule(1),
         blank_line,
         blank_line,
         head(1, 'Foo#override'),
         blank_line,
-        para('(from ~/.rdoc)'),
+        para("(from #{@rdoc_home})"),
         rule(1),
         blank_line,
         para('must not be displayed in Bar#override'),
@@ -802,7 +804,7 @@ Foo::Bar#bother
       @driver.display_page 'home:README'
     end
 
-    assert_match %r%= README pages in ~/\.rdoc%, out
+    assert_match %r%= README pages in #{@rdoc_home}%, out
     assert_match %r%README\.rdoc%,               out
     assert_match %r%README\.md%,                 out
   end
@@ -856,7 +858,7 @@ Foo::Bar#bother
       @driver.display_page_list @store1
     end
 
-    assert_match %r%= Pages in ~/\.rdoc%, out
+    assert_match %r%= Pages in #{@rdoc_home}%, out
     assert_match %r%README\.rdoc%,        out
   end
 
@@ -876,7 +878,7 @@ Foo::Bar#bother
       @driver.display_page_list @store1
     end
 
-    assert_match %r%= Pages in ~/\.rdoc%, out
+    assert_match %r%= Pages in #{@rdoc_home}%, out
     assert_match %r%README\.rdoc%,        out
     assert_match %r%OTHER\.rdoc%,         out
   end

--- a/test/rdoc/test_rdoc_store.rb
+++ b/test/rdoc/test_rdoc_store.rb
@@ -317,6 +317,9 @@ class TestRDocStore < XrefTestCase
   end
 
   def test_friendly_path
+    @orig_xdg_data_home = ENV['XDG_DATA_HOME']
+    ENV.delete('XDG_DATA_HOME')
+
     @s.path = @tmpdir
     @s.type = nil
     assert_equal @s.path, @s.friendly_path
@@ -336,6 +339,8 @@ class TestRDocStore < XrefTestCase
     @s.type = :gem
     @s.path = "#{@tmpdir}/gem_repository/doc/gem_name-1.0/ri"
     assert_equal "gem gem_name-1.0", @s.friendly_path
+  ensure
+    ENV['XDG_DATA_HOME'] = @orig_xdg_data_home
   end
 
   def test_dry_run

--- a/test/rdoc/test_rdoc_store.rb
+++ b/test/rdoc/test_rdoc_store.rb
@@ -331,7 +331,7 @@ class TestRDocStore < XrefTestCase
     assert_equal "ruby site", @s.friendly_path
 
     @s.type = :home
-    assert_equal "~/.rdoc", @s.friendly_path
+    assert_equal File.expand_path("~/.local/share/rdoc"), @s.friendly_path
 
     @s.type = :gem
     @s.path = "#{@tmpdir}/gem_repository/doc/gem_name-1.0/ri"

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1359,7 +1359,19 @@ class TestGem < Gem::TestCase
     parts = [@userhome, '.gem', Gem.ruby_engine]
     parts << RbConfig::CONFIG['ruby_version'] unless RbConfig::CONFIG['ruby_version'].empty?
 
+    FileUtils.mkdir_p File.join(parts)
+
     assert_equal File.join(parts), Gem.user_dir
+  end
+
+  def test_self_user_dir_xdg
+    parts = [@userhome, '.gem', Gem.ruby_engine]
+    parts << RbConfig::CONFIG['ruby_version'] unless RbConfig::CONFIG['ruby_version'].empty?
+
+    xdg_parts = [@userhome, ".local", "share", "gem", Gem.ruby_engine]
+    xdg_parts << RbConfig::CONFIG['ruby_version'] unless RbConfig::CONFIG['ruby_version'].empty?
+
+    assert_equal File.join(xdg_parts), Gem.user_dir
   end
 
   def test_self_user_home

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1365,10 +1365,10 @@ class TestGem < Gem::TestCase
   end
 
   def test_self_user_dir_xdg
-    parts = [@userhome, '.gem', Gem.ruby_engine]
-    parts << RbConfig::CONFIG['ruby_version'] unless RbConfig::CONFIG['ruby_version'].empty?
+    FileUtils.rm_rf File.join(@userhome, ".gem")
+    ENV['XDG_DATA_HOME'] = File.join @userhome, ".local", "share"
 
-    xdg_parts = [@userhome, ".local", "share", "gem", Gem.ruby_engine]
+    xdg_parts = [Gem.user_home, ".local", "share", "gem", Gem.ruby_engine]
     xdg_parts << RbConfig::CONFIG['ruby_version'] unless RbConfig::CONFIG['ruby_version'].empty?
 
     assert_equal File.join(xdg_parts), Gem.user_dir

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1366,12 +1366,14 @@ class TestGem < Gem::TestCase
 
   def test_self_user_dir_xdg
     FileUtils.rm_rf File.join(@userhome, ".gem")
+    orig_env = ENV['XDG_DATA_HOME']
     ENV['XDG_DATA_HOME'] = File.join @userhome, ".local", "share"
 
     xdg_parts = [Gem.user_home, ".local", "share", "gem", Gem.ruby_engine]
     xdg_parts << RbConfig::CONFIG['ruby_version'] unless RbConfig::CONFIG['ruby_version'].empty?
 
     assert_equal File.join(xdg_parts), Gem.user_dir
+    ENV['XDG_DATA_HOME'] = orig_env
   end
 
   def test_self_user_home

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1364,18 +1364,6 @@ class TestGem < Gem::TestCase
     assert_equal File.join(parts), Gem.user_dir
   end
 
-  def test_self_user_dir_xdg
-    FileUtils.rm_rf File.join(@userhome, ".gem")
-    orig_env = ENV['XDG_DATA_HOME']
-    ENV['XDG_DATA_HOME'] = File.join @userhome, ".local", "share"
-
-    xdg_parts = [Gem.user_home, ".local", "share", "gem", Gem.ruby_engine]
-    xdg_parts << RbConfig::CONFIG['ruby_version'] unless RbConfig::CONFIG['ruby_version'].empty?
-
-    assert_equal File.join(xdg_parts), Gem.user_dir
-    ENV['XDG_DATA_HOME'] = orig_env
-  end
-
   def test_self_user_home
     if ENV['HOME']
       assert_equal ENV['HOME'], Gem.user_home

--- a/test/rubygems/test_gem_commands_build_command.rb
+++ b/test/rubygems/test_gem_commands_build_command.rb
@@ -376,7 +376,7 @@ class TestGemCommandsBuildCommand < Gem::TestCase
     skip 'openssl is missing' unless defined?(OpenSSL::SSL) && !java_platform?
 
     gem_path = File.join Gem.user_home, ".gem"
-    Dir.mkdir gem_path
+    FileUtils.mkdir_p gem_path
 
     Gem::Security.trust_dir
 
@@ -420,7 +420,7 @@ class TestGemCommandsBuildCommand < Gem::TestCase
     skip 'openssl is missing' unless defined?(OpenSSL::SSL) && !java_platform?
 
     gem_path = File.join Gem.user_home, ".gem"
-    Dir.mkdir gem_path
+    FileUtils.mkdir_p gem_path
 
     Gem::Security.trust_dir
 

--- a/test/rubygems/test_gem_commands_build_command.rb
+++ b/test/rubygems/test_gem_commands_build_command.rb
@@ -376,7 +376,6 @@ class TestGemCommandsBuildCommand < Gem::TestCase
     skip 'openssl is missing' unless defined?(OpenSSL::SSL) && !java_platform?
 
     gem_path = File.join Gem.user_home, ".gem"
-    Dir.mkdir gem_path
 
     Gem::Security.trust_dir
 
@@ -420,7 +419,6 @@ class TestGemCommandsBuildCommand < Gem::TestCase
     skip 'openssl is missing' unless defined?(OpenSSL::SSL) && !java_platform?
 
     gem_path = File.join Gem.user_home, ".gem"
-    Dir.mkdir gem_path
 
     Gem::Security.trust_dir
 

--- a/test/rubygems/test_gem_commands_build_command.rb
+++ b/test/rubygems/test_gem_commands_build_command.rb
@@ -376,7 +376,7 @@ class TestGemCommandsBuildCommand < Gem::TestCase
     skip 'openssl is missing' unless defined?(OpenSSL::SSL) && !java_platform?
 
     gem_path = File.join Gem.user_home, ".gem"
-    FileUtils.mkdir_p gem_path
+    Dir.mkdir gem_path
 
     Gem::Security.trust_dir
 
@@ -420,7 +420,7 @@ class TestGemCommandsBuildCommand < Gem::TestCase
     skip 'openssl is missing' unless defined?(OpenSSL::SSL) && !java_platform?
 
     gem_path = File.join Gem.user_home, ".gem"
-    FileUtils.mkdir_p gem_path
+    Dir.mkdir gem_path
 
     Gem::Security.trust_dir
 

--- a/test/rubygems/test_gem_commands_cert_command.rb
+++ b/test/rubygems/test_gem_commands_cert_command.rb
@@ -597,7 +597,6 @@ ERROR:  --private-key not specified and ~/.gem/gem-private_key.pem does not exis
 
   def test_execute_re_sign
     gem_path = File.join Gem.user_home, ".gem"
-    Dir.mkdir gem_path
 
     path = File.join @tempdir, 'cert.pem'
     Gem::Security.write EXPIRED_PUBLIC_CERT, path, 0600
@@ -628,9 +627,6 @@ ERROR:  --private-key not specified and ~/.gem/gem-private_key.pem does not exis
   end
 
   def test_execute_re_sign_with_cert_expiration_length_days
-    gem_path = File.join Gem.user_home, ".gem"
-    Dir.mkdir gem_path
-
     path = File.join @tempdir, 'cert.pem'
     Gem::Security.write EXPIRED_PUBLIC_CERT, path, 0600
 

--- a/test/rubygems/test_gem_commands_cert_command.rb
+++ b/test/rubygems/test_gem_commands_cert_command.rb
@@ -597,7 +597,7 @@ ERROR:  --private-key not specified and ~/.gem/gem-private_key.pem does not exis
 
   def test_execute_re_sign
     gem_path = File.join Gem.user_home, ".gem"
-    Dir.mkdir gem_path
+    FileUtils.mkdir_p gem_path
 
     path = File.join @tempdir, 'cert.pem'
     Gem::Security.write EXPIRED_PUBLIC_CERT, path, 0600
@@ -629,7 +629,7 @@ ERROR:  --private-key not specified and ~/.gem/gem-private_key.pem does not exis
 
   def test_execute_re_sign_with_cert_expiration_length_days
     gem_path = File.join Gem.user_home, ".gem"
-    Dir.mkdir gem_path
+    FileUtils.mkdir_p gem_path
 
     path = File.join @tempdir, 'cert.pem'
     Gem::Security.write EXPIRED_PUBLIC_CERT, path, 0600

--- a/test/rubygems/test_gem_commands_cert_command.rb
+++ b/test/rubygems/test_gem_commands_cert_command.rb
@@ -597,7 +597,7 @@ ERROR:  --private-key not specified and ~/.gem/gem-private_key.pem does not exis
 
   def test_execute_re_sign
     gem_path = File.join Gem.user_home, ".gem"
-    FileUtils.mkdir_p gem_path
+    Dir.mkdir gem_path
 
     path = File.join @tempdir, 'cert.pem'
     Gem::Security.write EXPIRED_PUBLIC_CERT, path, 0600
@@ -629,7 +629,7 @@ ERROR:  --private-key not specified and ~/.gem/gem-private_key.pem does not exis
 
   def test_execute_re_sign_with_cert_expiration_length_days
     gem_path = File.join Gem.user_home, ".gem"
-    FileUtils.mkdir_p gem_path
+    Dir.mkdir gem_path
 
     path = File.join @tempdir, 'cert.pem'
     Gem::Security.write EXPIRED_PUBLIC_CERT, path, 0600

--- a/test/rubygems/test_gem_commands_signout_command.rb
+++ b/test/rubygems/test_gem_commands_signout_command.rb
@@ -8,6 +8,7 @@ class TestGemCommandsSignoutCommand < Gem::TestCase
 
   def setup
     super
+    File.delete Gem.configuration.credentials_path if File.exist?(Gem.configuration.credentials_path)
     @cmd = Gem::Commands::SignoutCommand.new
   end
 

--- a/test/rubygems/test_gem_config_file.rb
+++ b/test/rubygems/test_gem_config_file.rb
@@ -170,7 +170,7 @@ class TestGemConfigFile < Gem::TestCase
     assert_nil @cfg.instance_variable_get :@api_keys
 
     temp_cred = File.join Gem.user_home, '.gem', 'credentials'
-    FileUtils.mkdir File.dirname(temp_cred)
+    FileUtils.mkdir_p File.dirname(temp_cred)
     File.open temp_cred, 'w', 0600 do |fp|
       fp.puts ':rubygems_api_key: 701229f217cdf23b1344c7b4b54ca97'
     end
@@ -296,7 +296,7 @@ if you believe they were disclosed to a third party.
 
   def test_load_api_keys
     temp_cred = File.join Gem.user_home, '.gem', 'credentials'
-    FileUtils.mkdir File.dirname(temp_cred)
+    FileUtils.mkdir_p File.dirname(temp_cred)
     File.open temp_cred, 'w', 0600 do |fp|
       fp.puts ":rubygems_api_key: 701229f217cdf23b1344c7b4b54ca97"
       fp.puts ":other: a5fdbb6ba150cbb83aad2bb2fede64c"

--- a/test/rubygems/test_gem_source.rb
+++ b/test/rubygems/test_gem_source.rb
@@ -230,7 +230,7 @@ class TestGemSource < Gem::TestCase
   end
 
   def test_update_cache_eh_home_nonexistent
-    FileUtils.rmdir Gem.user_home
+    FileUtils.rm_rf Gem.user_home
 
     refute @source.update_cache?
   end

--- a/test/rubygems/test_gem_spec_fetcher.rb
+++ b/test/rubygems/test_gem_spec_fetcher.rb
@@ -33,7 +33,7 @@ class TestGemSpecFetcher < Gem::TestCase
   end
 
   def test_initialize_nonexistent_home_dir
-    FileUtils.rmdir Gem.user_home
+    FileUtils.rm_rf Gem.user_home
 
     assert Gem::SpecFetcher.new
   end


### PR DESCRIPTION
We should support [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) on the Ruby language.

I try to support the following environmental variables:

* XDG_CONFIG_HOME
* XDG_CACHE_HOME
* XDG_DATA_HOME