### PR TITLE
Make Module#name and Symbol#to_s return their internal fstrings

### DIFF
--- a/string.c
+++ b/string.c
@@ -10750,7 +10750,7 @@ sym_inspect(VALUE sym)
 VALUE
 rb_sym_to_s(VALUE sym)
 {
-    return str_new_shared(rb_cString, rb_sym2str(sym));
+    return rb_sym2str(sym);
 }
 
 

--- a/variable.c
+++ b/variable.c
@@ -243,10 +243,7 @@ VALUE
 rb_mod_name(VALUE mod)
 {
     int permanent;
-    VALUE path = classname(mod, &permanent);
-
-    if (!NIL_P(path)) return rb_str_dup(path);
-    return path;
+    return classname(mod, &permanent);
 }
 
 static VALUE


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/15836

### Why?

In many codebases, especially Rails apps, these two methods are the source of quite a lot of object allocations.

`Module#name` is often accessed for various introspection features, autoloading etc.

`Symbol#to_s` is access a lot by HashWithIndifferentAccess other various APIs accepting both symbols and strings. 

Returning fstrings for both of these methods could significantly reduce allocations, as well as sligthly reduce retention as it would reduce some duplications.

Also, more and more Ruby APIs are now returning fstrings. `frozen_string_literal`AFAIK should become the default some day, string used as hash keys are now automatically interned as well.

### Backward compatibilty 

Of course this is not fully backward compatible, it's inevitable that some code in the wild is mutating the strings returned by these methods, but I do believe it's a rare occurence, and easy to fix. 