### PR TITLE
Write barrier should execute on target array when it is shared

### DIFF
--- a/include/ruby/ruby.h
+++ b/include/ruby/ruby.h
@@ -1100,6 +1100,9 @@ struct RArray {
     const VALUE _v = (v); \
     VALUE *ptr = (VALUE *)RARRAY_PTR_USE_START_TRANSIENT(_ary); \
     RB_OBJ_WRITE(_ary, &ptr[i], _v); \
+    if (FL_TEST((_ary),ELTS_SHARED)!=0) { \
+      RB_OBJ_WRITTEN(RARRAY(_ary)->as.heap.aux.shared, Qundef, _v); \
+    } \
     RARRAY_PTR_USE_END_TRANSIENT(_ary); \
 } while (0)
 


### PR DESCRIPTION
RARRAY_ASET will update the underlying array buffer.  However, if the
array is backed by a *shared* array, it will update the shared array's
buffer.  In the case that it updates a shared array buffer, it should
execute the write barrier for the shared array since it wrote to that
array's buffer.

Before this commit:

```
array1 --(shared)--> array2 -> ptr[ ... ]

RARRAY_ASET(array1, obj) // WB HIT for array1 -> obj, but MISS for array2 -> obj
```

After this commit:

```
array1 --(shared)--> array2 -> ptr[ ... ]

RARRAY_ASET(array1, obj) // WB HIT for array1 -> obj, WB HIT for array2 -> obj
```

Before this commit:

```
[aaron@TC-275 ~/g/ruby (trunk)]$ env RUBY_DEBUG=gc_stress ./ruby --disable-gems -e'1'
verify_internal_consistency_reachable_i: WB miss (O->Y) 0x00007fc10a00b978 [3LM   ] T_ARRAY [   ] len: 20, capa:2 ptr:0x00007fc10960cce0 -> 0x00007fc10a00b860 [2  P  ] T_STRING (String) /Users/aaron/.rbenv/versions/ruby-trunk/lib/ruby/site_ruby/2.7.0
./ruby: [BUG] gc_verify_internal_consistency: found internal inconsistency.
```

After this commit:

```
[aaron@TC-275 ~/g/ruby (trunk)]$ env RUBY_DEBUG=gc_stress ./ruby --disable-gems -e'1'
[aaron@TC-275 ~/g/ruby (trunk)]$
```

I think this might be why:

```
test-all : 21295 tests, 5653327 assertions, 1 failures, 0 errors, 83 skips
:   1)
: TestGc#test_gc_stress_at_startup [/tmp/ruby/v2/src/trunk-asserts/test/ruby/test_gc.rb:388]:
: [Bug #15784].
```