### PR TITLE
Removed old names of internal methods

### DIFF
--- a/lib/ostruct.rb
+++ b/lib/ostruct.rb
@@ -206,7 +206,7 @@ class OpenStruct
 
   def respond_to_missing?(mid, include_private = false) # :nodoc:
     mname = mid.to_s.chomp("=").to_sym
-    @table&.key?(mname) || super
+    defined?(@table) && @table.key?(mname) || super
   end
 
   def method_missing(mid, *args) # :nodoc:

--- a/lib/ostruct.rb
+++ b/lib/ostruct.rb
@@ -176,10 +176,6 @@ class OpenStruct
   end
   private :modifiable?
 
-  # ::Kernel.warn("do not use OpenStruct#modifiable", uplevel: 1)
-  alias modifiable modifiable? # :nodoc:
-  protected :modifiable
-
   #
   # Used internally to defined properties on the
   # OpenStruct. It does this by using the metaprogramming function
@@ -194,10 +190,6 @@ class OpenStruct
     name
   end
   private :new_ostruct_member!
-
-  # ::Kernel.warn("do not use OpenStruct#new_ostruct_member", uplevel: 1)
-  alias new_ostruct_member new_ostruct_member! # :nodoc:
-  protected :new_ostruct_member
 
   def freeze
     @table.each_key {|key| new_ostruct_member!(key)}


### PR DESCRIPTION
They have been protected for 3 years.