### PR TITLE
`Module#deprecate_constant` with message

### DIFF
--- a/constant.h
+++ b/constant.h
@@ -13,6 +13,7 @@
 
 typedef enum {
     CONST_DEPRECATED = 0x100,
+    CONST_DEPRECATED_MESG = CONST_DEPRECATED << 1,
 
     CONST_VISIBILITY_MASK = 0xff,
     CONST_PUBLIC    = 0x00,
@@ -34,6 +35,11 @@ typedef struct rb_const_entry_struct {
     VALUE value;            /* should be mark */
     VALUE file;             /* should be mark */
 } rb_const_entry_t;
+
+typedef struct rb_deprecated_const_entry_struct {
+    rb_const_entry_t base;
+    const VALUE message;          /* should be mark */
+} rb_deprecated_const_entry_t;
 
 VALUE rb_mod_private_constant(int argc, const VALUE *argv, VALUE obj);
 VALUE rb_mod_public_constant(int argc, const VALUE *argv, VALUE obj);

--- a/gc.c
+++ b/gc.c
@@ -4599,6 +4599,9 @@ mark_const_entry_i(VALUE value, void *data)
 
     gc_mark(objspace, ce->value);
     gc_mark(objspace, ce->file);
+    if (ce->flag & CONST_DEPRECATED_MESG) {
+	gc_mark(objspace, ((const rb_deprecated_const_entry_t *)ce)->message);
+    }
     return ID_TABLE_CONTINUE;
 }
 

--- a/test/ruby/test_module.rb
+++ b/test/ruby/test_module.rb
@@ -1519,6 +1519,8 @@ class TestModule < Test::Unit::TestCase
     assert_warn(/#{c}::FOO is deprecated/) {Class.new(c)::FOO}
     bug12382 = '[ruby-core:75505] [Bug #12382]'
     assert_warn(/deprecated/, bug12382) {c.class_eval "FOO"}
+    c.deprecate_constant(FOO: "by BAR")
+    assert_warn(/deprecated by BAR/) {c::FOO}
   end
 
   NIL = nil


### PR DESCRIPTION
Improve `Module#deprecate_constant` so that the appendix message
to the default message can be specified.

```ruby
module C
  class X
  end
  X = Y
  deprecate_constant X: ", use C::Y instead"
end

C::X #=> warning: C::X is deprecated, use C::Y instead
```