### PR TITLE
case_option_single_p: check rb_enc_asciicompat

### DIFF
--- a/string.c
+++ b/string.c
@@ -6459,7 +6459,7 @@ check_case_options(int argc, VALUE *argv, OnigCaseFoldType flags)
 static inline bool
 case_option_single_p(OnigCaseFoldType flags, rb_encoding *enc, VALUE str)
 {
-    if ((flags & ONIGENC_CASE_ASCII_ONLY) && (enc==rb_utf8_encoding() || rb_enc_mbmaxlen(enc) == 1))
+    if ((flags & ONIGENC_CASE_ASCII_ONLY) && rb_enc_asciicompat(enc))
         return true;
     return !(flags & ONIGENC_CASE_FOLD_TURKISH_AZERI) && ENC_CODERANGE(str) == ENC_CODERANGE_7BIT;
 }


### PR DESCRIPTION
Motivation:

1. Communicates the intent better.
2. No need to special-case UTF8.
3. Just because `mbmaxlen` is 1 byte does not necessarily mean that the bytes correspond to ASCII. E.g. EBCDIC is single-byte but isn't ASCII-compatible. Ruby does not currently support this encoding but the current code will break if Ruby supports such encodings in the future.

@nobu