### PR TITLE
Prevent Dynamic -> Static symbols from moving

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -7256,6 +7256,10 @@ gc_is_moveable_obj(rb_objspace_t *objspace, VALUE obj)
         case T_ZOMBIE:
             return FALSE;
             break;
+        case T_SYMBOL:
+            if (DYNAMIC_SYM_P(obj) && (RSYMBOL(obj)->id & ~ID_SCOPE_MASK)) {
+                return FALSE;
+            }
         case T_STRING:
         case T_OBJECT:
         case T_FLOAT:
@@ -7266,7 +7270,6 @@ gc_is_moveable_obj(rb_objspace_t *objspace, VALUE obj)
         case T_MODULE:
         case T_REGEXP:
         case T_DATA:
-        case T_SYMBOL:
         case T_MATCH:
         case T_STRUCT:
         case T_HASH:

--- a/test/ruby/test_gc_compact.rb
+++ b/test/ruby/test_gc_compact.rb
@@ -2,8 +2,6 @@
 require 'test/unit'
 require 'fiddle'
 
-return
-
 class TestGCCompact < Test::Unit::TestCase
   def memory_location(obj)
     (Fiddle.dlwrap(obj) >> 1)


### PR DESCRIPTION
If a dynamic symbol has been converted to a static symbol, it gets added
to the global ID list and should no longer move.  C extensions can pass
symbols to rb_sym2id and those symbols should no longer be movable.
When the symbol is passed to rb_sym2id, the `id` member is set, so we
can use its existence to prevent movement.