### PR TITLE
Update String#crypt tests to work on OpenBSD

### DIFF
--- a/test/webrick/test_httpauth.rb
+++ b/test/webrick/test_httpauth.rb
@@ -58,6 +58,9 @@ class TestWEBrickHTTPAuth < Test::Unit::TestCase
   end
 
   [nil, :crypt, :bcrypt].each do |hash_algo|
+    # OpenBSD does not support insecure DES-crypt
+    next if /openbsd/ =~ RUBY_PLATFORM && hash_algo != :bcrypt
+
     begin
       case hash_algo
       when :crypt


### PR DESCRIPTION
Skip the webrick httpauth tests that use crypt when testing on
OpenBSD.

Fixes [Bug #11363]