### PR TITLE
Add and use Reline::Unicode.escape_for_print

### DIFF
--- a/lib/irb/color.rb
+++ b/lib/irb/color.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'reline'
 require 'ripper'
 
 module IRB # :nodoc:
@@ -80,11 +81,11 @@ module IRB # :nodoc:
         length = 0
         Ripper.lex(code).each do |(_line, _col), token, str, expr|
           if seq = dispatch_seq(token, expr, str)
-            str.each_line do |line|
+            Reline::Unicode.escape_for_print(str).each_line do |line|
               colored << "#{seq.map { |s| "\e[#{s}m" }.join('')}#{line}#{clear}"
             end
           else
-            colored << str
+            colored << Reline::Unicode.escape_for_print(str)
           end
           length += str.length
         end

--- a/lib/irb/input-method.rb
+++ b/lib/irb/input-method.rb
@@ -222,12 +222,17 @@ module IRB
       end
       Reline.completion_append_character = nil
       Reline.completion_proc = IRB::InputCompletor::CompletionProc
-      if IRB.conf[:USE_COLORIZE]
-        Reline.output_modifier_proc = proc do |output|
-          next unless IRB::Color.colorable?
-          IRB::Color.colorize_code(output)
+      Reline.output_modifier_proc =
+        if IRB.conf[:USE_COLORIZE]
+          proc do |output|
+            next unless IRB::Color.colorable?
+            IRB::Color.colorize_code(output)
+          end
+        else
+          proc do |output|
+            Reline::Unicode.escape_for_print(output)
+          end
         end
-      end
       Reline.dig_perfect_match_proc = IRB::InputCompletor::PerfectMatchedProc
     end
 

--- a/lib/reline/unicode.rb
+++ b/lib/reline/unicode.rb
@@ -55,6 +55,17 @@ class Reline::Unicode
     end
   end
 
+  def self.escape_for_print(str)
+    str.chars.map! { |gr|
+      escaped = EscapedPairs[gr.ord]
+      if escaped && gr != "\n"
+        escaped
+      else
+        gr
+      end
+    }.join
+  end
+
   def self.get_mbchar_width(mbchar)
     case mbchar.encode(Encoding::UTF_8)
     when *EscapedChars # ^ + char, such as ^M, ^H, ^[, ...

--- a/test/irb/test_color.rb
+++ b/test/irb/test_color.rb
@@ -35,6 +35,7 @@ module TestIRB
         "'a\nb'" => "#{RED}'#{CLEAR}#{RED}a\n#{CLEAR}#{RED}b#{CLEAR}#{RED}'#{CLEAR}",
         "4.5.6" => "4.5.6",
         "[1]]]" => "[1]]]",
+        "\e[0m\n" => "^[[#{BLUE}#{BOLD}0#{CLEAR}m\n",
       }.each do |code, result|
         assert_equal(result, with_term { IRB::Color.colorize_code(code) }, "Case: colorize_code(#{code.dump})")
       end


### PR DESCRIPTION
Define `Reline::Unicode.escape_for_print` and use it for escaping source input. 

The method's original implementation is old `Reline::LineEditor.escaped_print`. So it would behave like before https://github.com/ruby/ruby/pull/2202.