### PR TITLE
Test BASERUBY: Ruby 1.9.3 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -314,6 +314,14 @@ env:
     # -j randomly hangs.
     script: ruby -C spec/ruby ../mspec/bin/mspec .
 
+  - &baseruby
+    name: "BASERUBY: Ruby 1.9.3"
+    <<: *linux
+    <<: *make-test-only
+    dist: trusty # xenial no longer has ruby-1.9.3
+    language: ruby
+    rvm: 1.9.3
+
   - &x86_64-darwin17
     name: x86_64-darwin17
     <<: *osx
@@ -342,6 +350,7 @@ matrix:
     - <<: *CALL_THREADED_CODE
     - <<: *NO_THREADED_CODE
     - <<: *rubyspec
+    - <<: *baseruby
   allow_failures:
     - name: -fsanitize=address
     - name: -fsanitize=memory


### PR DESCRIPTION
We have no clear assertion or check of BASERUBY requirement. I want to make the current situation more explicit.

I'm NOT saying we should support Ruby 1.9.3 here, but I'm just checking the situation as per https://github.com/ruby/ruby/commit/05bc14d81a1d7f6af826a92371aeff0c3fb2a67e.