### PR TITLE
Remove dependency on `openssl/conf_api.h`

### DIFF
--- a/ext/openssl/ossl.h
+++ b/ext/openssl/ossl.h
@@ -27,7 +27,6 @@
 #include <openssl/hmac.h>
 #include <openssl/rand.h>
 #include <openssl/conf.h>
-#include <openssl/conf_api.h>
 #include <openssl/crypto.h>
 #if !defined(OPENSSL_NO_ENGINE)
 #  include <openssl/engine.h>


### PR DESCRIPTION
None of the [functions](https://github.com/openssl/openssl/blob/master/include/openssl/conf_api.h) defined in this header are actually used in Ruby.
Fixes build against boringssl that does not have this file.