### PR TITLE
Unpin proc references and imemo env references

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -4542,12 +4542,7 @@ mark_keyvalue(st_data_t key, st_data_t value, st_data_t data)
 {
     rb_objspace_t *objspace = (rb_objspace_t *)data;
 
-    if (SPECIAL_CONST_P((VALUE)key) || BUILTIN_TYPE((VALUE)key) == T_STRING) {
-        gc_mark(objspace, (VALUE)key);
-    }
-    else {
-        gc_mark_and_pin(objspace, (VALUE)key);
-    }
+    gc_mark(objspace, (VALUE)key);
     gc_mark(objspace, (VALUE)value);
     return ST_CONTINUE;
 }


### PR DESCRIPTION
This PR unpins proc references and imemo env references.  To test this, I ran against GitHub's Rails application.  These patches dropped our pinned objects from 8% of the heap to about 3% of the heap:

```
$ jq -c 'select(.flags.pinned)' master.json | wc -l
  286476
$ wc -l master.json
 3352791 master.json
$ jq -c 'select(.flags.pinned)' branch.json | wc -l
  101604
$ wc -l branch.json
 3343140 branch.json
$ irb
irb(main):001:0> 286476 / 3352791.0
=> 0.08544403751978576
irb(main):002:0> 101604 / 3343140.0
=> 0.030391787361582226
irb(main):003:0>
```

`master.json` is the heap against the master branch, and `branch.json` is against this branch.  This branch seemed to drop the number of pages by about 120, but I don't know if that's just random.  I think "percentage of heap pinned" is a better metric.

Here are graphs of the heaps:

### Master

![master](https://user-images.githubusercontent.com/3124/58671728-8b2d1a80-82f8-11e9-85cb-49df6f91c53e.png)

### This Branch

![branch](https://user-images.githubusercontent.com/3124/58671735-9122fb80-82f8-11e9-96c5-dda75fe10ef0.png)
