### PR TITLE
Keep vm->orig_progname alive

### DIFF
--- a/test/ruby/test_process.rb
+++ b/test/ruby/test_process.rb
@@ -1400,6 +1400,14 @@ class TestProcess < Test::Unit::TestCase
     }
   end
 
+  def test_argv0_keep_alive
+    assert_in_out_err([], <<~REPRO, ['-'], [], "[Bug #15887]")
+      $0 = "diverge"
+      4.times { GC.start }
+      puts Process.argv0
+    REPRO
+  end
+
   def test_status
     with_tmpchdir do
       s = run_in_child("exit 1")

--- a/vm.c
+++ b/vm.c
@@ -2248,6 +2248,7 @@ rb_vm_mark(void *ptr)
 	rb_gc_mark(vm->loaded_features);
 	rb_gc_mark(vm->loaded_features_snapshot);
 	rb_gc_mark(vm->top_self);
+        rb_gc_mark(vm->orig_progname);
 	RUBY_MARK_UNLESS_NULL(vm->coverages);
         /* Prevent classes from moving */
         rb_mark_tbl(vm->defined_module_hash);


### PR DESCRIPTION
`vm->orig_progname` can be different from `vm->progname` when user
code assigns to `$0`. While `vm->progname` is kept alive by the
global table, nothing marked `vm->orig_progname`.

[Bug #15887](https://bugs.ruby-lang.org/issues/15887)

One liner that crashes 2.5.5 and 2.6.3: `ruby -e '$0 = "hi"; 4.times { GC.start }; Process.argv0.class'`