### PR TITLE
appveyor.yml again!

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -99,9 +99,9 @@ for:
   build_script:
     # always update database
     - pacman -Sy
-    - pacman -S --noconfirm --needed --noprogressbar --nodeps mingw-w64-x86_64-toolchain
-    # 2019-May-29 delete below after next Appveyor msys2 update, above line remove '--nodeps'
+    # 2019-May-31 delete below after next Appveyor msys2 update, also next line's "--nodeps"
     - pacman -S --noconfirm --needed --noprogressbar mingw-w64-x86_64-python3 mingw-w64-x86_64-readline mingw-w64-x86_64-sqlite3
+    - pacman -S --noconfirm --needed --noprogressbar --nodeps mingw-w64-x86_64-toolchain
     - pacman -S --noconfirm --needed --noprogressbar mingw-w64-x86_64-gdbm mingw-w64-x86_64-gmp mingw-w64-x86_64-libffi mingw-w64-x86_64-openssl mingw-w64-x86_64-pdcurses mingw-w64-x86_64-readline mingw-w64-x86_64-zlib
     - cd %APPVEYOR_BUILD_FOLDER%
     - set CFLAGS=-march=%MSYS2_ARCH:_=-% -mtune=generic -O3 -pipe


### PR DESCRIPTION
This issuse is caused by MSYS2 changing from using ncurses to pdcurses.

Appveyor's MSYS2 is so out-of-date that partial updates are 'troublesome'.

ruby-loco is building now, as it also broke...