### PR TITLE
Add compaction support for threads / fibers / continuations / autoload

### DIFF
--- a/proc.c
+++ b/proc.c
@@ -64,7 +64,7 @@ block_mark(const struct rb_block *block)
 	    RUBY_MARK_NO_PIN_UNLESS_NULL(captured->self);
 	    RUBY_MARK_NO_PIN_UNLESS_NULL((VALUE)captured->code.val);
 	    if (captured->ep && captured->ep[VM_ENV_DATA_INDEX_ENV] != Qundef /* cfunc_proc_t */) {
-		RUBY_MARK_UNLESS_NULL(VM_ENV_ENVVAL(captured->ep));
+		RUBY_MARK_NO_PIN_UNLESS_NULL(VM_ENV_ENVVAL(captured->ep));
 	    }
 	}
 	break;
@@ -87,6 +87,9 @@ block_compact(struct rb_block *block)
 	    struct rb_captured_block *captured = &block->as.captured;
             captured->self = rb_gc_location(captured->self);
             captured->code.val = rb_gc_location(captured->code.val);
+	    if (captured->ep && captured->ep[VM_ENV_DATA_INDEX_ENV] != Qundef /* cfunc_proc_t */) {
+                UPDATE_REFERENCE(captured->ep[VM_ENV_DATA_INDEX_ENV]);
+	    }
 	}
 	break;
       case block_type_symbol:

--- a/variable.c
+++ b/variable.c
@@ -1913,13 +1913,23 @@ static const rb_data_type_t autoload_data_i_type = {
 };
 
 static void
+autoload_c_compact(void *ptr)
+{
+    struct autoload_const *ac = ptr;
+
+    ac->mod = rb_gc_location(ac->mod);
+    ac->ad = rb_gc_location(ac->ad);
+    ac->value = rb_gc_location(ac->value);
+}
+
+static void
 autoload_c_mark(void *ptr)
 {
     struct autoload_const *ac = ptr;
 
-    rb_gc_mark(ac->mod);
-    rb_gc_mark(ac->ad);
-    rb_gc_mark(ac->value);
+    rb_gc_mark_no_pin(ac->mod);
+    rb_gc_mark_no_pin(ac->ad);
+    rb_gc_mark_no_pin(ac->value);
 }
 
 static void
@@ -1938,7 +1948,7 @@ autoload_c_memsize(const void *ptr)
 
 static const rb_data_type_t autoload_const_type = {
     "autoload_const",
-    {autoload_c_mark, autoload_c_free, autoload_c_memsize,},
+    {autoload_c_mark, autoload_c_free, autoload_c_memsize, autoload_c_compact,},
     0, 0, RUBY_TYPED_FREE_IMMEDIATELY
 };
 

--- a/vm_core.h
+++ b/vm_core.h
@@ -1815,6 +1815,7 @@ void rb_threadptr_unlock_all_locking_mutexes(rb_thread_t *th);
 void rb_threadptr_pending_interrupt_clear(rb_thread_t *th);
 void rb_threadptr_pending_interrupt_enque(rb_thread_t *th, VALUE v);
 void rb_ec_error_print(rb_execution_context_t * volatile ec, volatile VALUE errinfo);
+void rb_execution_context_update(const rb_execution_context_t *ec);
 void rb_execution_context_mark(const rb_execution_context_t *ec);
 void rb_fiber_close(rb_fiber_t *fib);
 void Init_native_thread(rb_thread_t *th);


### PR DESCRIPTION
Like #2212, this is tested against GitHub's Rails app.  This reduces the pinned heap in GitHub's app from ~3.2% to ~1.3%:

```
$ wc -l master.json
 3245847 master.json
$ jq -c 'select(.flags.pinned)' master.json | wc -l
  105928
$ wc -l branch.json
 3239696 branch.json
$ jq -c 'select(.flags.pinned)' branch.json | wc -l
   42137
$ irb
irb(main):001:0> 105928 / 3245847.0
=> 0.03263493319309259
irb(main):002:0> 42137 / 3239696.0
=> 0.013006467273472573
irb(main):003:0> 
```

Here are graphs of the heaps:

### Ruby Master (c9b74f9fd95113df903fc34cc1d6ec3fb3160c85)

![master](https://user-images.githubusercontent.com/3124/58841968-1e2fc280-8621-11e9-9ea5-838627ad419d.png)

### This branch

![branch](https://user-images.githubusercontent.com/3124/58842013-3273bf80-8621-11e9-9ec4-b534f8173ed6.png)

Pinned object statistics:

### Master

```
$ jq 'select(.flags.pinned) | (if .type == "IMEMO" then .imemo_type else .type end)' master.json | sort | uniq -c | sort -n
   1 "COMPLEX"
   1 "MATCH"
   1 "RATIONAL"
   1 "STRUCT"
   1 "svar"
   1 "tmpbuf"
   2 "ast"
   2 "throw_data"
   3 "cref"
   4 "FILE"
   4 "ICLASS"
   6 "FLOAT"
  10 "REGEXP"
  11 "BIGNUM"
  36 "ment"
  44 "iseq"
 122 "HASH"
 151 "ARRAY"
 374 "MODULE"
1118 "OBJECT"
1241 "CLASS"
1394 "DATA"
4859 "STRING"
96541 "env"
```

### This branch

```
$ jq 'select(.flags.pinned) | (if .type == "IMEMO" then .imemo_type else .type end)' branch.json | sort | uniq -c | sort -n
   1 "COMPLEX"
   1 "RATIONAL"
   1 "STRUCT"
   1 "svar"
   1 "tmpbuf"
   2 "ast"
   2 "throw_data"
   3 "cref"
   4 "FILE"
   5 "ICLASS"
   6 "FLOAT"
  10 "REGEXP"
  11 "BIGNUM"
  25 "iseq"
  42 "ment"
 119 "HASH"
 150 "ARRAY"
 309 "MODULE"
 875 "DATA"
1121 "OBJECT"
1227 "CLASS"
4865 "STRING"
33356 "env"
```

This PR seems to mostly unpin IMEMO `env` objects.
