### PR TITLE
Optimize CGI.escapeHTML by reducing buffer extension and branches

### DIFF
--- a/benchmark/cgi_escape_html.yml
+++ b/benchmark/cgi_escape_html.yml
@@ -1,0 +1,40 @@
+prelude: require 'cgi/escape'
+benchmark:
+  - name: escape_html_blank
+    prelude: str = ""
+    script: CGI.escapeHTML(str)
+    loop_count: 20000000
+  - name: escape_html_short_none
+    prelude: str = "abcde"
+    script: CGI.escapeHTML(str)
+    loop_count: 20000000
+  - name: escape_html_short_one
+    prelude: str = "abcd<"
+    script: CGI.escapeHTML(str)
+    loop_count: 20000000
+  - name: escape_html_short_all
+    prelude: str = "'&\"<>"
+    script: CGI.escapeHTML(str)
+    loop_count: 5000000
+  - name: escape_html_long_none
+    prelude: str = "abcde" * 300
+    script: CGI.escapeHTML(str)
+    loop_count: 1000000
+  - name: escape_html_long_all
+    prelude: str = "'&\"<>" * 10
+    script: CGI.escapeHTML(str)
+    loop_count: 1000000
+  - name: escape_html_real
+    prelude: | # http://example.com/
+      str = <<~HTML
+        <body>
+        <div>
+            <h1>Example Domain</h1>
+            <p>This domain is established to be used for illustrative examples in documents. You may use this
+            domain in examples without prior coordination or asking for permission.</p>
+            <p><a href="http://www.iana.org/domains/example">More information...</a></p>
+        </div>
+        </body>
+      HTML
+    script: CGI.escapeHTML(str)
+    loop_count: 1000000

--- a/ext/cgi/escape/escape.c
+++ b/ext/cgi/escape/escape.c
@@ -19,11 +19,12 @@ static void
 init_html_escape_tables(void)
 {
 #define HTML_ESCAPE(c, str) do { \
-    html_escape_table[c] = str; \
-    html_escape_len[c] = strlen(str); \
-    if (html_escape_max_len < strlen(str)) { \
-        html_escape_max_len = strlen(str); \
+    size_t len = strlen(str); \
+    html_escape_len[c] = len; \
+    if (html_escape_max_len < len) { \
+        html_escape_max_len = len; \
     } \
+    html_escape_table[c] = str; \
 } while (0)
     HTML_ESCAPE('\'', "&#39;");
     HTML_ESCAPE('&', "&amp;");

--- a/ext/cgi/escape/escape.c
+++ b/ext/cgi/escape/escape.c
@@ -11,11 +11,11 @@ RUBY_EXTERN const signed char ruby_digit36_to_number_table[];
 static VALUE rb_cCGI, rb_mUtil, rb_mEscape;
 static ID id_accept_charset;
 
-static const size_t html_escape_max_len = 6; // "&quot;" is longest
+#define HTML_ESCAPE_MAX_LEN 6
 
 static const struct {
     uint8_t len;
-    char str[html_escape_max_len+1];
+    char str[HTML_ESCAPE_MAX_LEN+1];
 } html_escape_table[UCHAR_MAX+1] = {
 #define HTML_ESCAPE(c, str) [c] = {rb_strlen_lit(str), str}
     HTML_ESCAPE('\'', "&#39;"),
@@ -39,7 +39,7 @@ optimized_escape_html(VALUE str)
 {
     const char *cstr = RSTRING_PTR(str);
     const char *end = cstr + RSTRING_LEN(str);
-    char *buf = ALLOCA_N(char, RSTRING_LEN(str) * html_escape_max_len);
+    char *buf = ALLOCA_N(char, RSTRING_LEN(str) * HTML_ESCAPE_MAX_LEN);
 
     char *dest = buf;
     while (cstr < end) {

--- a/ext/cgi/escape/escape.c
+++ b/ext/cgi/escape/escape.c
@@ -11,26 +11,26 @@ RUBY_EXTERN const signed char ruby_digit36_to_number_table[];
 static VALUE rb_cCGI, rb_mUtil, rb_mEscape;
 static ID id_accept_charset;
 
+static const char* html_escape_table[UCHAR_MAX+1] = { NULL };
+static size_t html_escape_len[UCHAR_MAX+1] = { 0 };
+static size_t html_escape_max_len = 0;
+
 static void
-html_escaped_cat(VALUE str, char c)
+init_html_escape_tables(void)
 {
-    switch (c) {
-      case '\'':
-	rb_str_cat_cstr(str, "&#39;");
-	break;
-      case '&':
-	rb_str_cat_cstr(str, "&amp;");
-	break;
-      case '"':
-	rb_str_cat_cstr(str, "&quot;");
-	break;
-      case '<':
-	rb_str_cat_cstr(str, "&lt;");
-	break;
-      case '>':
-	rb_str_cat_cstr(str, "&gt;");
-	break;
-    }
+#define HTML_ESCAPE(c, str) do { \
+    html_escape_table[c] = str; \
+    html_escape_len[c] = strlen(str); \
+    if (html_escape_max_len < strlen(str)) { \
+        html_escape_max_len = strlen(str); \
+    } \
+} while (0)
+    HTML_ESCAPE('\'', "&#39;");
+    HTML_ESCAPE('&', "&amp;");
+    HTML_ESCAPE('"', "&quot;");
+    HTML_ESCAPE('<', "&lt;");
+    HTML_ESCAPE('>', "&gt;");
+#undef HTML_ESCAPE
 }
 
 static inline void
@@ -44,36 +44,28 @@ preserve_original_state(VALUE orig, VALUE dest)
 static VALUE
 optimized_escape_html(VALUE str)
 {
-    long i, len, beg = 0;
-    VALUE dest = 0;
-    const char *cstr;
+    const char *cstr = RSTRING_PTR(str);
+    const char *end = cstr + RSTRING_LEN(str);
+    char *buf = ALLOCA_N(char, RSTRING_LEN(str) * html_escape_max_len + 1);
 
-    len  = RSTRING_LEN(str);
-    cstr = RSTRING_PTR(str);
-
-    for (i = 0; i < len; i++) {
-	switch (cstr[i]) {
-	  case '\'':
-	  case '&':
-	  case '"':
-	  case '<':
-	  case '>':
-	    if (!dest) {
-		dest = rb_str_buf_new(len);
-	    }
-
-	    rb_str_cat(dest, cstr + beg, i - beg);
-	    beg = i + 1;
-
-	    html_escaped_cat(dest, cstr[i]);
-	    break;
-	}
+    char *dest = buf;
+    while (cstr < end) {
+        const unsigned char c = *cstr++;
+        const char *escaped = html_escape_table[c];
+        if (escaped) {
+            memcpy(dest, escaped, html_escape_len[c]);
+            dest += html_escape_len[c];
+        }
+        else {
+            *dest++ = c;
+        }
     }
 
-    if (dest) {
-	rb_str_cat(dest, cstr + beg, len - beg);
-	preserve_original_state(str, dest);
-	return dest;
+    if (RSTRING_LEN(str) < (dest - buf)) {
+        *dest = '\0';
+        VALUE escaped = rb_str_new_cstr(buf);
+        preserve_original_state(str, escaped);
+        return escaped;
     }
     else {
 	return rb_str_dup(str);
@@ -404,6 +396,7 @@ void
 Init_escape(void)
 {
     id_accept_charset = rb_intern_const("@@accept_charset");
+    init_html_escape_tables();
     InitVM(escape);
 }
 

--- a/ext/cgi/escape/escape.c
+++ b/ext/cgi/escape/escape.c
@@ -46,7 +46,7 @@ optimized_escape_html(VALUE str)
 {
     const char *cstr = RSTRING_PTR(str);
     const char *end = cstr + RSTRING_LEN(str);
-    char *buf = ALLOCA_N(char, RSTRING_LEN(str) * html_escape_max_len + 1);
+    char *buf = ALLOCA_N(char, RSTRING_LEN(str) * html_escape_max_len);
 
     char *dest = buf;
     while (cstr < end) {
@@ -62,8 +62,7 @@ optimized_escape_html(VALUE str)
     }
 
     if (RSTRING_LEN(str) < (dest - buf)) {
-        *dest = '\0';
-        VALUE escaped = rb_str_new_cstr(buf);
+        VALUE escaped = rb_str_new(buf, dest - buf);
         preserve_original_state(str, escaped);
         return escaped;
     }


### PR DESCRIPTION
Just a random experiment.

```
$ benchmark-driver benchmark/cgi_escape_html.yml -v --rbenv 'before;after' --repeat-count=8
before: ruby 2.7.0dev (2019-06-04 master c8b001858e) [x86_64-linux]
after: ruby 2.7.0dev (2019-06-04 no-switch-html-esc.. 0bc4478d27) [x86_64-linux]
Calculating -------------------------------------
                           before       after
     escape_html_blank    26.876M     25.126M i/s -     20.000M times in 0.744154s 0.795981s
escape_html_short_none    25.866M     24.011M i/s -     20.000M times in 0.773219s 0.832962s
 escape_html_short_one     7.995M     18.386M i/s -     20.000M times in 2.501553s 1.087774s
 escape_html_short_all     5.628M     10.109M i/s -      5.000M times in 0.888401s 0.494600s
 escape_html_long_none     1.372M      1.545M i/s -      1.000M times in 0.728884s 0.647043s
  escape_html_long_all     1.118M      3.954M i/s -      1.000M times in 0.894344s 0.252930s
      escape_html_real     1.138M      3.035M i/s -      1.000M times in 0.878760s 0.329461s

Comparison:
                  escape_html_blank
                before:  26876153.8 i/s
                 after:  25126220.5 i/s - 1.07x  slower

             escape_html_short_none
                before:  25865877.2 i/s
                 after:  24010709.4 i/s - 1.08x  slower

              escape_html_short_one
                 after:  18386168.7 i/s
                before:   7995033.6 i/s - 2.30x  slower

              escape_html_short_all
                 after:  10109188.1 i/s
                before:   5628088.3 i/s - 1.80x  slower

              escape_html_long_none
                 after:   1545492.1 i/s
                before:   1371961.3 i/s - 1.13x  slower

               escape_html_long_all
                 after:   3953662.4 i/s
                before:   1118137.6 i/s - 3.54x  slower

                   escape_html_real
                 after:   3035259.8 i/s
                before:   1137966.7 i/s - 2.67x  slower
```