### PR TITLE
Use `alloca` to improve performance of thread creation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ lcov*.info
 /*.pc
 /*.rc
 /*_prelude.c
+/build*
 /COPYING.LIB
 /ChangeLog
 /Doxyfile

--- a/benchmark/vm_thread_alive_check.yml
+++ b/benchmark/vm_thread_alive_check.yml
@@ -1,0 +1,8 @@
+benchmark:
+  vm_thread_alive_check: |
+    t = Thread.new{}
+    while t.alive?
+      Thread.pass
+    end
+loop_count: 50_000
+

--- a/benchmark/vm_thread_alive_check1.rb
+++ b/benchmark/vm_thread_alive_check1.rb
@@ -1,6 +1,0 @@
-5_000.times{
-  t = Thread.new{}
-  while t.alive?
-    Thread.pass
-  end
-}

--- a/benchmark/vm_thread_pass.rb
+++ b/benchmark/vm_thread_pass.rb
@@ -1,8 +1,8 @@
 # Plenty Thtread.pass
 # A performance may depend on GVL implementation.
 
-tmax = (ARGV.shift || 2).to_i
-lmax = 200_000 / tmax
+tmax = (ARGV.shift || 8).to_i
+lmax = 400_000 / tmax
 
 (1..tmax).map{
   Thread.new{

--- a/benchmark/vm_thread_pass_flood.rb
+++ b/benchmark/vm_thread_pass_flood.rb
@@ -1,10 +1,10 @@
 # n.b. this is a good test for GVL when pinned to a single CPU
 
-1000.times{
+5_000.times{
   Thread.new{loop{Thread.pass}}
 }
 
 i = 0
-while i<10000
+while i<10_000
   i += 1
 end

--- a/benchmark/vm_thread_queue.rb
+++ b/benchmark/vm_thread_queue.rb
@@ -1,6 +1,6 @@
 require 'thread'
 
-n = 1_000_000
+n = 10_000_000
 q = Thread::Queue.new
 consumer = Thread.new{
   while q.pop

--- a/benchmark/vm_thread_sleep.yml
+++ b/benchmark/vm_thread_sleep.yml
@@ -1,0 +1,4 @@
+benchmark:
+  vm_thread_sleep: |
+    Thread.new { sleep }
+loop_count: 10_000

--- a/bootstraptest/runner.rb
+++ b/bootstraptest/runner.rb
@@ -208,6 +208,9 @@ def exec_test(pathes)
     $stderr.puts unless @quiet and @tty and @error == error
   end
   $stderr.print(erase) if @quiet
+  @errbuf.each do |msg|
+    $stderr.puts msg
+  end
   if @error == 0
     if @count == 0
       $stderr.puts "No tests, no problem"
@@ -216,9 +219,6 @@ def exec_test(pathes)
     end
     exit true
   else
-    @errbuf.each do |msg|
-      $stderr.puts msg
-    end
     $stderr.puts "#{@failed}FAIL#{@reset} #{@error}/#{@count} tests failed"
     exit false
   end
@@ -244,7 +244,7 @@ def show_progress(message = '')
   else
     $stderr.print "#{@failed}F"
     $stderr.printf(" %.3f", t) if @verbose
-    $stderr.print "#{@reset}"
+    $stderr.print @reset
     $stderr.puts if @verbose
     error faildesc, message
     unless errout.empty?
@@ -261,6 +261,19 @@ rescue Exception => err
   $stderr.print 'E'
   $stderr.puts if @verbose
   error err.message, message
+end
+
+def show_limit(testsrc, opt = '', **argh)
+  result = get_result_string(testsrc, opt, **argh)
+  $stderr.print '.'
+  $stderr.print @reset
+  $stderr.puts if @verbose
+  
+  if @tty
+    $stderr.puts "#{erase}#{result}"
+  else
+    @errbuf.push result
+  end
 end
 
 def assert_check(testsrc, message = '', opt = '', **argh)

--- a/bootstraptest/test_thread.rb
+++ b/bootstraptest/test_thread.rb
@@ -1,5 +1,27 @@
-# Thread and Fiber
-
+show_limit %q{
+  threads = []
+  begin
+    threads << Thread.new{sleep}
+    
+    raise Exception, "skipping" if threads.count >= 10_000
+  rescue Exception => error
+    puts "Thread count: #{threads.count} (#{error})"
+    break
+  end while true
+}
+show_limit %q{
+  fibers = []
+  begin
+    fiber = Fiber.new{Fiber.yield}
+    fiber.resume
+    fibers << fiber
+    
+    raise Exception, "skipping" if fibers.count >= 10_000
+  rescue Exception => error
+    puts "Fiber count: #{fibers.count} (#{error})"
+    break
+  end while true
+}
 assert_equal %q{ok}, %q{
   Thread.new{
   }.join

--- a/bootstraptest/test_thread.rb
+++ b/bootstraptest/test_thread.rb
@@ -11,6 +11,9 @@ assert_equal %q{ok}, %q{
   }.value
 }
 assert_equal %q{ok}, %q{
+  :ok if Thread.new{sleep}.backtrace == []
+}
+assert_equal %q{ok}, %q{
 begin
   v = 0
   (1..200).map{|i|

--- a/cont.c
+++ b/cont.c
@@ -1530,19 +1530,7 @@ fiber_init(VALUE fibval, VALUE proc)
         vm_stack = ruby_xmalloc(fib_stack_bytes);
     }
     cont->free_vm_stack = 1;
-    rb_ec_set_vm_stack(sec, vm_stack, fib_stack_bytes / sizeof(VALUE));
-    sec->cfp = (void *)(sec->vm_stack + sec->vm_stack_size);
-
-    rb_vm_push_frame(sec,
-		     NULL,
-		     VM_FRAME_MAGIC_DUMMY | VM_ENV_FLAG_LOCAL | VM_FRAME_FLAG_FINISH | VM_FRAME_FLAG_CFRAME,
-		     Qnil, /* self */
-		     VM_BLOCK_HANDLER_NONE,
-		     0, /* specval */
-		     NULL, /* pc */
-		     sec->vm_stack, /* sp */
-		     0, /* local_size */
-		     0);
+    rb_ec_initialize_vm_stack(sec, vm_stack, fib_stack_bytes / sizeof(VALUE));
 
     sec->tag = NULL;
     sec->local_storage = NULL;

--- a/cont.c
+++ b/cont.c
@@ -420,10 +420,7 @@ cont_free(void *ptr)
 	rb_fiber_t *fib = (rb_fiber_t*)cont;
 #if defined(FIBER_USE_COROUTINE)
 	coroutine_destroy(&fib->context);
-	if (fib->ss_sp != NULL) {
-	    if (fiber_is_root_p(fib)) {
-		rb_bug("Illegal root fiber parameter");
-	    }
+	if (fib->ss_sp != NULL && !fiber_is_root_p(fib)) {
 #ifdef _WIN32
             VirtualFree((void*)fib->ss_sp, 0, MEM_RELEASE);
 #else
@@ -1660,6 +1657,8 @@ rb_threadptr_root_fiber_setup(rb_thread_t *th)
     fib->cont.saved_ec.thread_ptr = th;
     fiber_status_set(fib, FIBER_RESUMED); /* skip CREATED */
     th->ec = &fib->cont.saved_ec;
+
+    th->root_fiber = fib;
 
     /* NOTE: On WIN32, fib_handle is not allocated yet. */
 }

--- a/gc.c
+++ b/gc.c
@@ -9398,6 +9398,10 @@ rb_memerror(void)
     rb_objspace_t *objspace = rb_objspace_of(rb_ec_vm_ptr(ec));
     VALUE exc;
 
+    // Print out pid, sleep, so you can attach debugger to see what went wrong:
+    // fprintf(stderr, "rb_memerror pid=%d\n", getpid());
+    // sleep(60);
+
     if (during_gc) gc_exit(objspace, "rb_memerror");
 
     exc = nomem_error;

--- a/gc.c
+++ b/gc.c
@@ -9398,9 +9398,11 @@ rb_memerror(void)
     rb_objspace_t *objspace = rb_objspace_of(rb_ec_vm_ptr(ec));
     VALUE exc;
 
-    // Print out pid, sleep, so you can attach debugger to see what went wrong:
-    // fprintf(stderr, "rb_memerror pid=%d\n", getpid());
-    // sleep(60);
+    if (0) {
+      // Print out pid, sleep, so you can attach debugger to see what went wrong:
+      fprintf(stderr, "rb_memerror pid=%d\n", getpid());
+      sleep(60);
+    }
 
     if (during_gc) gc_exit(objspace, "rb_memerror");
 

--- a/thread.c
+++ b/thread.c
@@ -821,7 +821,7 @@ thread_start_func_2(rb_thread_t *th, VALUE *stack_start, VALUE *register_stack_s
 	rb_threadptr_unlock_all_locking_mutexes(th);
 	rb_check_deadlock(th->vm);
 
-        rb_ec_set_vm_stack(th->ec, NULL, 0);
+	rb_fiber_close(th->ec->fiber_ptr);
     }
     thread_cleanup_func(th, FALSE);
     gvl_release(th->vm);

--- a/thread.c
+++ b/thread.c
@@ -821,7 +821,7 @@ thread_start_func_2(rb_thread_t *th, VALUE *stack_start, VALUE *register_stack_s
 	rb_threadptr_unlock_all_locking_mutexes(th);
 	rb_check_deadlock(th->vm);
 
-	// rb_fiber_close(th->ec->fiber_ptr);
+        rb_ec_set_vm_stack(th->ec, NULL, 0);
     }
     thread_cleanup_func(th, FALSE);
     gvl_release(th->vm);

--- a/thread.c
+++ b/thread.c
@@ -77,6 +77,11 @@
 #include "mjit.h"
 #include "hrtime.h"
 
+#ifdef __linux__
+// Normally,  gcc(1)  translates  calls to alloca() with inlined code.  This is not done when either the -ansi, -std=c89, -std=c99, or the -std=c11 option is given and the header <alloca.h> is not included.
+#include <alloca.h>
+#endif
+
 #ifndef USE_NATIVE_THREAD_PRIORITY
 #define USE_NATIVE_THREAD_PRIORITY 0
 #define RUBY_THREAD_PRIORITY_MAX 3
@@ -714,8 +719,8 @@ thread_start_func_2(rb_thread_t *th, VALUE *stack_start, VALUE *register_stack_s
     rb_thread_list_t *join_list;
     rb_thread_t *main_th;
     VALUE errinfo = Qnil;
-    VALUE * vm_stack = NULL;
     size_t size = th->vm->default_params.thread_vm_stack_size / sizeof(VALUE);
+    VALUE * vm_stack = NULL;
 
     if (th == th->vm->main_thread) {
         rb_bug("thread_start_func_2 must not be used for main thread");
@@ -723,7 +728,6 @@ thread_start_func_2(rb_thread_t *th, VALUE *stack_start, VALUE *register_stack_s
 
     vm_stack = alloca(size * sizeof(VALUE));
     rb_ec_set_vm_stack(th->ec, vm_stack, size);
-
     th->ec->cfp = (void *)(th->ec->vm_stack + th->ec->vm_stack_size);
 
     rb_vm_push_frame(th->ec,

--- a/thread.c
+++ b/thread.c
@@ -715,6 +715,7 @@ rb_vm_push_frame(rb_execution_context_t *sec,
 static int
 thread_start_func_2(rb_thread_t *th, VALUE *stack_start, VALUE *register_stack_start)
 {
+    STACK_GROW_DIR_DETECTION;
     enum ruby_tag_type state;
     rb_thread_list_t *join_list;
     rb_thread_t *main_th;
@@ -740,8 +741,8 @@ thread_start_func_2(rb_thread_t *th, VALUE *stack_start, VALUE *register_stack_s
 
     ruby_thread_set_native(th);
 
-    th->ec->machine.stack_start = vm_stack;
-    th->ec->machine.stack_maxsize = th->ec->machine.stack_end - th->ec->machine.stack_start;
+    th->ec->machine.stack_start = STACK_DIR_UPPER(vm_stack + size, vm_stack);
+    th->ec->machine.stack_maxsize -= size * sizeof(VALUE);
 #ifdef __ia64
     th->ec->machine.register_stack_start = register_stack_start;
 #endif

--- a/thread.c
+++ b/thread.c
@@ -728,16 +728,7 @@ thread_start_func_2(rb_thread_t *th, VALUE *stack_start, VALUE *register_stack_s
     }
 
     vm_stack = alloca(size * sizeof(VALUE));
-    rb_ec_set_vm_stack(th->ec, vm_stack, size);
-    th->ec->cfp = (void *)(th->ec->vm_stack + th->ec->vm_stack_size);
-
-    rb_vm_push_frame(th->ec,
-        0 /* dummy iseq */,
-        VM_FRAME_MAGIC_DUMMY | VM_ENV_FLAG_LOCAL | VM_FRAME_FLAG_FINISH | VM_FRAME_FLAG_CFRAME /* dummy frame */,
-        Qnil /* dummy self */, VM_BLOCK_HANDLER_NONE /* dummy block ptr */,
-        0 /* dummy cref/me */,
-        0 /* dummy pc */, th->ec->vm_stack, 0, 0
-    );
+    rb_ec_initialize_vm_stack(th->ec, vm_stack, size);
 
     ruby_thread_set_native(th);
 

--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -1157,7 +1157,7 @@ native_thread_create(rb_thread_t *th)
     }
     else {
 	pthread_attr_t attr;
-	const size_t stack_size = th->vm->default_params.thread_machine_stack_size;
+	const size_t stack_size = th->vm->default_params.thread_machine_stack_size + th->vm->default_params.thread_vm_stack_size;
 	const size_t space = space_size(stack_size);
 
         th->ec->machine.stack_maxsize = stack_size - space;

--- a/thread_win32.c
+++ b/thread_win32.c
@@ -592,7 +592,7 @@ thread_start_func_1(void *th_ptr)
 static int
 native_thread_create(rb_thread_t *th)
 {
-    size_t stack_size = 4 * 1024; /* 4KB is the minimum commit size */
+    const size_t stack_size = th->vm->default_params.thread_machine_stack_size + th->vm->default_params.thread_vm_stack_size;
     th->thread_id = w32_create_thread(stack_size, thread_start_func_1, th);
 
     if ((th->thread_id) == 0) {
@@ -831,7 +831,7 @@ mjit_worker(void *arg)
 int
 rb_thread_create_mjit_thread(void (*worker_func)(void))
 {
-    size_t stack_size = 4 * 1024; /* 4KB is the minimum commit size */
+    const size_t stack_size = th->vm->default_params.thread_machine_stack_size;
     HANDLE thread_id = w32_create_thread(stack_size, mjit_worker, worker_func);
     if (thread_id == 0) {
         return FALSE;

--- a/thread_win32.c
+++ b/thread_win32.c
@@ -256,7 +256,7 @@ typedef LPTHREAD_START_ROUTINE w32_thread_start_func;
 static HANDLE
 w32_create_thread(DWORD stack_size, w32_thread_start_func func, void *val)
 {
-    return start_thread(0, stack_size, func, val, CREATE_SUSPENDED, 0);
+    return start_thread(0, stack_size, func, val, CREATE_SUSPENDED | STACK_SIZE_PARAM_IS_A_RESERVATION, 0);
 }
 
 int

--- a/thread_win32.c
+++ b/thread_win32.c
@@ -831,7 +831,7 @@ mjit_worker(void *arg)
 int
 rb_thread_create_mjit_thread(void (*worker_func)(void))
 {
-    const size_t stack_size = th->vm->default_params.thread_machine_stack_size;
+    size_t stack_size = 4 * 1024; /* 4KB is the minimum commit size */
     HANDLE thread_id = w32_create_thread(stack_size, mjit_worker, worker_func);
     if (thread_id == 0) {
         return FALSE;

--- a/vm.c
+++ b/vm.c
@@ -2704,9 +2704,6 @@ th_init(rb_thread_t *th, VALUE self)
             0 /* dummy cref/me */,
             0 /* dummy pc */, th->ec->vm_stack, 0, 0
         );
-    } else {
-        th->ec->cfp = NULL;
-        rb_ec_set_vm_stack(th->ec, NULL, 0);
     }
 
     th->status = THREAD_RUNNABLE;

--- a/vm.c
+++ b/vm.c
@@ -2625,7 +2625,7 @@ thread_free(void *ptr)
 	rb_bug("thread_free: keeping_mutexes must be NULL (%p:%p)", (void *)th, (void *)th->keeping_mutexes);
     }
 
-    //rb_threadptr_root_fiber_release(th);
+    rb_threadptr_root_fiber_release(th);
 
     if (th->vm && th->vm->main_thread == th) {
 	RUBY_GC_INFO("main thread\n");

--- a/vm.c
+++ b/vm.c
@@ -2704,6 +2704,10 @@ th_init(rb_thread_t *th, VALUE self)
             0 /* dummy cref/me */,
             0 /* dummy pc */, th->ec->vm_stack, 0, 0
         );
+    } else {
+      VM_ASSERT(th->ec->cfp == NULL);
+      VM_ASSERT(th->ec->vm_stack == NULL);
+      VM_ASSERT(th->ec->vm_stack_size == 0);
     }
 
     th->status = THREAD_RUNNABLE;

--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -451,6 +451,12 @@ backtrace_each(const rb_execution_context_t *ec,
     const rb_control_frame_t *cfp;
     ptrdiff_t size, i;
 
+    // In the case the thread vm_stack or cfp is not initialized, there is no backtrace.
+    if (start_cfp == NULL) {
+        init(arg, 0);
+        return;
+    }
+
     /*                <- start_cfp (end control frame)
      *  top frame (dummy)
      *  top frame (dummy)

--- a/vm_core.h
+++ b/vm_core.h
@@ -903,7 +903,14 @@ typedef struct rb_execution_context_struct {
     } machine;
 } rb_execution_context_t;
 
+// Set the vm_stack pointer in the execution context.
 void rb_ec_set_vm_stack(rb_execution_context_t *ec, VALUE *stack, size_t size);
+
+// Initialize the vm_stack pointer in the execution context and push the initial stack frame.
+// @param ec the execution context to update.
+// @param stack a pointer to the stack to use.
+// @param size the size of the stack, as in `VALUE stack[size]`.
+void rb_ec_initialize_vm_stack(rb_execution_context_t *ec, VALUE *stack, size_t size);
 
 typedef struct rb_thread_struct {
     struct list_node vmlt_node;


### PR DESCRIPTION
This avoids the need for `vm_stack` allocation per thread, which improves performance and can lead to code simplification (removal of stack recycling code).