### PR TITLE
Fix leading dot method chain bug

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -91,6 +91,7 @@ enum lex_state_bits {
     EXPR_LABEL_bit,		/* flag bit, label is allowed. */
     EXPR_LABELED_bit,		/* flag bit, just after a label. */
     EXPR_FITEM_bit,		/* symbol literal as FNAME. */
+    EXPR_EMPTYLN_bit,		/* line contains only whitespace and comments */
     EXPR_MAX_STATE
 };
 /* examine combinations */
@@ -109,6 +110,7 @@ enum lex_state_e {
     DEF_EXPR(LABEL),
     DEF_EXPR(LABELED),
     DEF_EXPR(FITEM),
+    DEF_EXPR(EMPTYLN),
     EXPR_VALUE = EXPR_BEG,
     EXPR_BEG_ANY  =  (EXPR_BEG | EXPR_MID | EXPR_CLASS),
     EXPR_ARG_ANY  =  (EXPR_ARG | EXPR_CMDARG),
@@ -8678,6 +8680,11 @@ parser_yylex(struct parser_params *p)
 	      case '\13': /* '\v' */
 		space_seen = 1;
 		break;
+	      case '\n':
+	      case '#':
+		SET_LEX_STATE(EXPR_EMPTYLN);
+		pushback(p, c);
+		goto retry;
 	      case '|':
 	      case '&':
 	      case '.': {
@@ -10016,7 +10023,7 @@ new_regexp(struct parser_params *p, VALUE re, VALUE opt, const YYLTYPE *loc)
 static const char rb_parser_lex_state_names[][13] = {
     "EXPR_BEG",    "EXPR_END",    "EXPR_ENDARG", "EXPR_ENDFN",  "EXPR_ARG",
     "EXPR_CMDARG", "EXPR_MID",    "EXPR_FNAME",  "EXPR_DOT",    "EXPR_CLASS",
-    "EXPR_LABEL",  "EXPR_LABELED","EXPR_FITEM",
+    "EXPR_LABEL",  "EXPR_LABELED","EXPR_FITEM",  "EXPR_EMPTYLN",
 };
 
 static VALUE

--- a/test/ruby/test_syntax.rb
+++ b/test/ruby/test_syntax.rb
@@ -981,6 +981,34 @@ eom
     assert_syntax_error("a&.x,=0", /multiple assignment destination/)
   end
 
+  def test_fluent_dot_with_empty_lines_between
+    assert_valid_syntax("a #\n #\n.foo")
+    assert_valid_syntax("a #\n #\n&.foo")
+    assert_valid_syntax("a\n\n.foo")
+    assert_valid_syntax("a \n \n &.foo")
+
+    src = <<~RUBY
+      def m
+        # c
+
+        x
+      end
+    RUBY
+    tokens = [
+      [:on_kw,      "def",     ], # EXPR_FNAME],
+      [:on_sp,      " ",       ], # EXPR_FNAME],
+      [:on_ident,   "m",       ], # EXPR_ENDFN],
+      [:on_nl,      "\n\n",    ], # EXPR_BEG],
+      [:on_comment, "  # c\n", ], # EXPR_EMPTYLN],
+      [:on_sp,      "  ",      ], # EXPR_BEG],
+      [:on_ident,   "x",       ], # EXPR_CMDARG],
+      [:on_nl,      "\n",      ], # EXPR_BEG],
+      [:on_kw,      "end",     ], # EXPR_END],
+      [:on_nl,      "\n",      ], # EXPR_BEG],
+    ]
+    assert_tokens tokens, src
+  end
+
   def test_no_warning_logop_literal
     assert_warning("") do
       eval("true||raise;nil")
@@ -1403,6 +1431,12 @@ eom
     @result = nil
     assert_nothing_raised(SyntaxError, message) {eval(src)}
     assert_equal(expected, @result, message)
+  end
+
+  def assert_tokens(expected, src, message = nil)
+    require 'ripper'
+    actual = Ripper.lex(src).map { |_position, type, value, _state| [type, value] }
+    assert_equal(expected, actual, message)
   end
 
   def make_tmpsrc(f, src)


### PR DESCRIPTION
Description
------------

When you split method invocations across multiple lines, you can put the dot at the end of the previous line or at the beginning of the current line. However, when you comment one of the lines out, it then breaks. This fixes that issue. However, it's failing on the RDoc tests. I figured I'd submit it anyway, to get the ball rolling again.

On my local machine, I apparently also have a change that allows it to work across empty lines. I can include that, too, if desired.

Context
--------

> Aesthetically, and for all the other reasons listed, I agree with @JoshCheek . However, there is one single reason against `leading` and, IMO, it trumps all the others: single-line comments mid-chain:
> 
> ```ruby
> foo.
>   bar.
>   # baz.
>   boo
> ```
> 
> No problems. 😎
> 
> ```ruby
> foo
>   .bar
>   # .baz
>   .boo
> ```
> 
> syntax error, unexpected '.', expecting end-of-input. 😢
> 
> It might just be a personal thing, but it seems I'm _frequently_ commenting out sections in a chain when debugging; but the leading dot prevents that capability.

-- @jasonkarns ([source](https://github.com/testdouble/standard/issues/75#issuecomment-460661597))

Example
--------

![](https://user-images.githubusercontent.com/77495/52332865-6e737c80-29c1-11e9-9bf1-f48d488ab259.gif)