### PR TITLE
add support for hash literal shorthand

### DIFF
--- a/doc/syntax/literals.rdoc
+++ b/doc/syntax/literals.rdoc
@@ -327,6 +327,14 @@ is equal to
 
   { :"a 1" => 1, :"b 2" => 2 }
 
+You may also use the shorthand syntax for creating hash with symbol keys:
+
+  { a:, b: }
+
+which equals to
+
+  { :a => a, :b => b }
+
 See Hash for the methods you may use with a hash.
 
 == Ranges

--- a/parse.y
+++ b/parse.y
@@ -5141,6 +5141,16 @@ assoc		: arg_value tASSOC arg_value
 		    /*% %*/
 		    /*% ripper: assoc_new!($1, $2) %*/
 		    }
+		| tLABEL
+			{
+			/*%%%*/
+			NODE *key, *val;
+			key = NEW_LIT(ID2SYM($1), &@1);
+			if (!(val = gettable(p, $1, &@$))) val = NEW_BEGIN(0, &@$);
+			$$ = list_append(p, NEW_LIST(key, &@1), val);
+			/*% %*/
+			/*% ripper: assoc_new!($1, get_value($1)) %*/
+			}
 		| tSTRING_BEG string_contents tLABEL_END arg_value
 		    {
 		    /*%%%*/

--- a/spec/ruby/language/hash_spec.rb
+++ b/spec/ruby/language/hash_spec.rb
@@ -78,14 +78,53 @@ describe "Hash literal" do
     {rbx: :cool, specs: 'fail_sometimes',}.should == h
   end
 
+  ruby_version_is "2.7" do
+    it "accepts short notation 'key' for 'key: value' syntax" do
+      a, b, c = 1, 2, 3
+      h = eval('{a:}')
+      {a: 1}.should == h
+      h = eval('{a:, b:, c:}')
+      {a: 1, b: 2, c: 3}.should == h
+    end
+
+    it "accepts short notation on method call" do
+      def foo(param1:, param2:)
+        param1 + param2
+      end
+
+      param1 = 1
+      param2 = 2
+
+      h = eval('foo(param1:, param2:)')
+
+      3.should == h
+    end
+
+    it "ignores hanging comma on short notation" do
+      a, b, c = 1, 2, 3
+      h = eval('{a:, b:, c:,}')
+      {a: 1, b: 2, c: 3}.should == h
+    end
+  end
+
   it "accepts mixed 'key: value' and 'key => value' syntax" do
     h = {:a => 1, :b => 2, "c" => 3}
     {a: 1, b: 2, "c" => 3}.should == h
   end
 
-  it "accepts mixed 'key: value', 'key => value' and '\"key\"': value' syntax" do
-    h = {:a => 1, :b => 2, "c" => 3, :d => 4}
-    eval('{a: 1, :b => 2, "c" => 3, "d": 4}').should == h
+  ruby_version_is "2.7" do
+    it "accepts mixed 'key', 'key: value', 'key => value' and '\"key\"': value' syntax" do
+      a, e = 1, 5
+      h = eval('{a:, :b => 2, "c" => 3, :d => 4, e:}')
+      eval('{a: 1, :b => 2, "c" => 3, "d": 4, e: 5}').should == h
+    end
+  end
+
+  ruby_version_is ""..."2.6" do
+    it "accepts mixed 'key: value', 'key => value' and '\"key\"': value' syntax" do
+      h = {:a => 1, :b => 2, "c" => 3, :d => 4}
+      eval('{a: 1, :b => 2, "c" => 3, "d": 4}').should == h
+    end
   end
 
   it "expands an '**{}' element into the containing Hash literal initialization" do


### PR DESCRIPTION
- redmine ticket: https://bugs.ruby-lang.org/issues/15236
- alternative syntax of #1990 

inspired by javascript support for object literal shorthand `{ a }`, which will be expanded into `{ a: a }`..

to avoid ambiguity with the mathematical notation for Set, the shorthand are followed by `:`

Example:

```ruby
def foo(param1:, param2:)
  param1 + param2
end

param1 = 7
param2 = 42

foo(param1:, param2:)

def respond_with(resource, options)
  meta = extract_meta(resource, options)
  etc = extract_etc(resource, options)

  { resource:, meta:, etc: }
end
```