### PR TITLE
remove 2 redundant calls to rb_str_dup

### DIFF
--- a/error.c
+++ b/error.c
@@ -1098,7 +1098,7 @@ exc_inspect(VALUE exc)
     klass = CLASS_OF(exc);
     exc = rb_obj_as_string(exc);
     if (RSTRING_LEN(exc) == 0) {
-	return rb_str_dup(rb_class_name(klass));
+	return rb_class_name(klass);
     }
 
     str = rb_str_buf_new2("#<");

--- a/object.c
+++ b/object.c
@@ -1800,7 +1800,7 @@ rb_mod_to_s(VALUE klass)
 	rb_str_cat2(s, ">");
 	return s;
     }
-    return rb_str_dup(rb_class_name(klass));
+    return rb_class_name(klass);
 }
 
 /*


### PR DESCRIPTION
rb_class_path() already duplicates the string, so no need to do it again :)