### PR TITLE
Check frozen state of ENV

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -1426,6 +1426,12 @@ rb_hash_modify_check(VALUE hash)
     rb_check_frozen(hash);
 }
 
+static void
+rb_env_modify_check()
+{
+    rb_check_frozen(envtbl);
+}
+
 MJIT_FUNC_EXPORTED struct st_table *
 #if RHASH_CONVERT_TABLE_DEBUG
 rb_hash_tbl_raw(VALUE hash, const char *file, int line)
@@ -4626,6 +4632,7 @@ env_delete_m(VALUE obj, VALUE name)
 {
     VALUE val;
 
+    rb_env_modify_check();
     val = env_delete(name);
     if (NIL_P(val) && rb_block_given_p()) rb_yield(name);
     return val;
@@ -4959,6 +4966,7 @@ ruby_unsetenv(const char *name)
 static VALUE
 env_aset_m(VALUE obj, VALUE nm, VALUE val)
 {
+    rb_env_modify_check();
     return env_aset(nm, val);
 }
 
@@ -5170,6 +5178,7 @@ env_reject_bang(VALUE ehash)
     int del = 0;
 
     RETURN_SIZED_ENUMERATOR(ehash, 0, 0, rb_env_size);
+    rb_env_modify_check();
     keys = env_keys();
     RBASIC_CLEAR_CLASS(keys);
     for (i=0; i<RARRAY_LEN(keys); i++) {
@@ -5200,6 +5209,7 @@ static VALUE
 env_delete_if(VALUE ehash)
 {
     RETURN_SIZED_ENUMERATOR(ehash, 0, 0, rb_env_size);
+    rb_env_modify_check();
     env_reject_bang(ehash);
     return envtbl;
 }
@@ -5280,6 +5290,7 @@ env_select_bang(VALUE ehash)
     int del = 0;
 
     RETURN_SIZED_ENUMERATOR(ehash, 0, 0, rb_env_size);
+    rb_env_modify_check();
     keys = env_keys();
     RBASIC_CLEAR_CLASS(keys);
     for (i=0; i<RARRAY_LEN(keys); i++) {
@@ -5310,6 +5321,7 @@ static VALUE
 env_keep_if(VALUE ehash)
 {
     RETURN_SIZED_ENUMERATOR(ehash, 0, 0, rb_env_size);
+    rb_env_modify_check();
     env_select_bang(ehash);
     return envtbl;
 }
@@ -5355,6 +5367,7 @@ rb_env_clear(void)
     VALUE keys;
     long i;
 
+    rb_env_modify_check();
     keys = env_keys();
     for (i=0; i<RARRAY_LEN(keys); i++) {
 	VALUE val = rb_f_getenv(Qnil, RARRAY_AREF(keys, i));
@@ -5453,6 +5466,7 @@ env_to_a(void)
 static VALUE
 env_none(void)
 {
+    rb_env_modify_check();
     return Qnil;
 }
 
@@ -5712,6 +5726,7 @@ env_shift(void)
     char **env;
     VALUE result = Qnil;
 
+    rb_env_modify_check();
     env = GET_ENVIRON(environ);
     if (*env) {
 	char *s = strchr(*env, '=');
@@ -5762,6 +5777,7 @@ env_replace(VALUE env, VALUE hash)
     VALUE keys;
     long i;
 
+    rb_env_modify_check();
     keys = env_keys();
     if (env == hash) return env;
     hash = to_hash(hash);
@@ -5797,6 +5813,7 @@ env_update_i(VALUE key, VALUE val)
 static VALUE
 env_update(VALUE env, VALUE hash)
 {
+    rb_env_modify_check();
     if (env == hash) return env;
     hash = to_hash(hash);
     rb_hash_foreach(hash, env_update_i, 0);

--- a/test/ruby/test_env.rb
+++ b/test/ruby/test_env.rb
@@ -107,6 +107,8 @@ class TestEnv < Test::Unit::TestCase
     assert_invalid_env {|v| ENV.delete(v)}
     assert_nil(ENV.delete("TEST"))
     assert_nothing_raised { ENV.delete(PATH_ENV) }
+
+    assert_in_out_err([], 'ENV.freeze; ENV.delete("TEST")', [], [/.*FrozenError.*\n/, /.*main.*\n/])
   end
 
   def test_getenv
@@ -157,6 +159,8 @@ class TestEnv < Test::Unit::TestCase
 
     ENV[PATH_ENV] = "/tmp/".taint
     assert_equal("/tmp/", ENV[PATH_ENV])
+
+    assert_in_out_err([], 'ENV.freeze; ENV["TEST"] = nil', [], [/.*FrozenError.*\n/, /.*main.*\n/])
   end
 
   def test_keys
@@ -196,6 +200,8 @@ class TestEnv < Test::Unit::TestCase
     assert_equal(h1, h2)
 
     assert_nil(ENV.reject! {|k, v| IGNORE_CASE ? k.upcase == "TEST" : k == "test" })
+
+    assert_in_out_err([], 'ENV.freeze; ENV.reject! {}', [], [/.*FrozenError.*\n/, /.*main.*\n/])
   end
 
   def test_delete_if
@@ -208,6 +214,8 @@ class TestEnv < Test::Unit::TestCase
     assert_equal(h1, h2)
 
     assert_equal(ENV, ENV.delete_if {|k, v| IGNORE_CASE ? k.upcase == "TEST" : k == "test" })
+
+    assert_in_out_err([], 'ENV.freeze; ENV.delete_if {}', [], [/.*FrozenError.*\n/, /.*main.*\n/])
   end
 
   def test_select_bang
@@ -220,6 +228,8 @@ class TestEnv < Test::Unit::TestCase
     assert_equal(h1, h2)
 
     assert_nil(ENV.select! {|k, v| IGNORE_CASE ? k.upcase != "TEST" : k != "test" })
+
+    assert_in_out_err([], 'ENV.freeze; ENV.select! {}', [], [/.*FrozenError.*\n/, /.*main.*\n/])
   end
 
   def test_filter_bang
@@ -232,6 +242,8 @@ class TestEnv < Test::Unit::TestCase
     assert_equal(h1, h2)
 
     assert_nil(ENV.filter! {|k, v| IGNORE_CASE ? k.upcase != "TEST" : k != "test" })
+
+    assert_in_out_err([], 'ENV.freeze; ENV.filter! {}', [], [/.*FrozenError.*\n/, /.*main.*\n/])
   end
 
   def test_keep_if
@@ -244,6 +256,8 @@ class TestEnv < Test::Unit::TestCase
     assert_equal(h1, h2)
 
     assert_equal(ENV, ENV.keep_if {|k, v| IGNORE_CASE ? k.upcase != "TEST" : k != "test" })
+
+    assert_in_out_err([], 'ENV.freeze; ENV.keep_if {}', [], [/.*FrozenError.*\n/, /.*main.*\n/])
   end
 
   def test_values_at
@@ -295,6 +309,8 @@ class TestEnv < Test::Unit::TestCase
   def test_clear
     ENV.clear
     assert_equal(0, ENV.size)
+
+    assert_in_out_err([], 'ENV.freeze; ENV.clear', [], [/.*FrozenError.*\n/, /.*main.*\n/])
   end
 
   def test_to_s
@@ -330,6 +346,8 @@ class TestEnv < Test::Unit::TestCase
 
   def test_rehash
     assert_nil(ENV.rehash)
+
+    assert_in_out_err([], 'ENV.freeze; ENV.rehash', [], [/.*FrozenError.*\n/, /.*main.*\n/])
   end
 
   def test_size
@@ -427,6 +445,8 @@ class TestEnv < Test::Unit::TestCase
     b = ENV.shift
     check([a, b], [%w(foo bar), %w(baz qux)])
     assert_nil(ENV.shift)
+
+    assert_in_out_err([], 'ENV.freeze; ENV.shift', [], [/.*FrozenError.*\n/, /.*main.*\n/])
   end
 
   def test_invert
@@ -440,6 +460,8 @@ class TestEnv < Test::Unit::TestCase
     ENV["foo"] = "xxx"
     ENV.replace({"foo"=>"bar", "baz"=>"qux"})
     check(ENV.to_hash.to_a, [%w(foo bar), %w(baz qux)])
+
+    assert_in_out_err([], 'ENV.freeze; ENV.replace({})', [], [/.*FrozenError.*\n/, /.*main.*\n/])
   end
 
   def test_update
@@ -454,6 +476,8 @@ class TestEnv < Test::Unit::TestCase
     ENV["baz"] = "qux"
     ENV.update({"baz"=>"quux","a"=>"b"}) {|k, v1, v2| v1 ? k + "_" + v1 + "_" + v2 : v2 }
     check(ENV.to_hash.to_a, [%w(foo bar), %w(baz baz_qux_quux), %w(a b)])
+
+    assert_in_out_err([], 'ENV.freeze; ENV.update({})', [], [/.*FrozenError.*\n/, /.*main.*\n/])
   end
 
   def test_huge_value


### PR DESCRIPTION
ref: https://bugs.ruby-lang.org/issues/15920

Is this an intentional behavior?

```ruby
ENV.freeze
ENV.clear #=> No exception happen
```

raising FrozenError sounds reasonable to me