### PR TITLE
README: Add smart URL for joining mailing list

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ send the following phrase:
     subscribe
 
 in the mail body (not subject) to the address
-<ruby-talk-request@ruby-lang.org>.
+[ruby-talk-request@ruby-lang.org](mailto:ruby-talk-request@ruby-lang.org?subject=Join%20Ruby%20Mailing%20List&body=subscribe).
 
 ## How to compile and install
 


### PR DESCRIPTION
This adds a couple of parameters to the mailing list link in the README
so that the subject line and body are automatically populated. The body
is populated with the `subscribe` string so that all an individual has
to do is perform the send action in their mail client.