### PR TITLE
Dump symbols reference to their fstr in ObjectSpace.dump() (Feature #15939)

### DIFF
--- a/test/objspace/test_objspace.rb
+++ b/test/objspace/test_objspace.rb
@@ -281,13 +281,22 @@ class TestObjSpace < Test::Unit::TestCase
     assert_equal('true', ObjectSpace.dump(true))
     assert_equal('false', ObjectSpace.dump(false))
     assert_equal('0', ObjectSpace.dump(0))
-    assert_equal('{"type":"SYMBOL", "value":"foo"}', ObjectSpace.dump(:foo))
+
+    dump = JSON.parse(ObjectSpace.dump(:foo))
+    assert_equal('SYMBOL', dump['type'])
+    assert_equal('foo', dump['value'])
+    assert_equal(false, dump['dynamic'])
+    assert_instance_of(Array, dump['references'])
+    assert_equal(1, dump['references'].size)
   end
 
   def test_dump_dynamic_symbol
-    dump = ObjectSpace.dump(("foobar%x" % rand(0x10000)).to_sym)
-    assert_match(/"type":"SYMBOL"/, dump)
-    assert_match(/"value":"foobar\h+"/, dump)
+    dump = JSON.parse(ObjectSpace.dump(("foobar%x" % rand(0x10000)).to_sym))
+    assert_equal('SYMBOL', dump['type'])
+    assert_match(/\Afoobar\h+\z/, dump['value'])
+    assert_equal(true, dump['dynamic'])
+    assert_instance_of(Array, dump['references'])
+    assert_equal(1, dump['references'].size)
   end
 
   def test_dump_includes_imemo_type


### PR DESCRIPTION
Ref: https://bugs.ruby-lang.org/issues/15939

Symbols wether they are dynamic or static do hold a reference
onto their respective string, so it's important to dump these
references so that it's possible to see that a String isn't
garbage collected because it has an associated Symbol.

Dumping a static Symbol:

```
>> puts ObjectSpace.dump(:foobar)
{"address":"0x7a210c", "type":"SYMBOL", "value":"foobar", "references":["0x7f8dd482c7d8"], "dynamic": false}
```

Dumping a dynamic Symbol:

```
>> puts ObjectSpace.dump("foobar".to_sym)
{"address":"0x7fcdf7042eb0", "type":"SYMBOL", "class":"0x7fcdf70c8628", "frozen":true, "bytesize":6, "value":"foobar", "dynamic":true, "references":["0x7fcdf7042ed8"], "memsize":40, "flags":{"wb_protected":true}}
```

Limitations:

`ObjectSpace.dump_all` rely on `rb_objspace_reachable_objects_from` to list an object's references.
Because of this static symbol "references" are not followed, and
as such are invisible in `ObjectSpace.dump_all`.

I'd like to correct it but it's quite more complicated.