### PR TITLE
Coerce symbols internal fstrings in UTF8 rather than ASCII

### DIFF
--- a/spec/ruby/core/string/shared/to_sym.rb
+++ b/spec/ruby/core/string/shared/to_sym.rb
@@ -21,16 +21,32 @@ describe :string_to_sym, shared: true do
     "-(unary)".send(@method).should equal :"-(unary)"
   end
 
-  it "returns a US-ASCII Symbol for a UTF-8 String containing only US-ASCII characters" do
-    sym = "foobar".send(@method)
-    sym.encoding.should == Encoding::US_ASCII
-    sym.should equal :"foobar"
+  ruby_version_is "".."2.6" do
+    it "returns a US-ASCII Symbol for a UTF-8 String containing only US-ASCII characters" do
+      sym = "foobar".send(@method)
+      sym.encoding.should == Encoding::US_ASCII
+      sym.should equal :"foobar"
+    end
+
+    it "returns a US-ASCII Symbol for a binary String containing only US-ASCII characters" do
+      sym = "foobar".b.send(@method)
+      sym.encoding.should == Encoding::US_ASCII
+      sym.should equal :"foobar"
+    end
   end
 
-  it "returns a US-ASCII Symbol for a binary String containing only US-ASCII characters" do
-    sym = "foobar".b.send(@method)
-    sym.encoding.should == Encoding::US_ASCII
-    sym.should equal :"foobar"
+  ruby_version_is "2.7" do
+    it "returns a UTF-8 Symbol for a UTF-8 String containing only US-ASCII characters" do
+      sym = "foobar".send(@method)
+      sym.encoding.should == Encoding::UTF_8
+      sym.should equal :"foobar"
+    end
+
+    it "returns a UTF-8 Symbol for a binary String containing only US-ASCII characters" do
+      sym = "foobar".b.send(@method)
+      sym.encoding.should == Encoding::UTF_8
+      sym.should equal :"foobar"
+    end
   end
 
   it "returns a UTF-8 Symbol for a UTF-8 String containing non US-ASCII characters" do

--- a/spec/ruby/core/symbol/encoding_spec.rb
+++ b/spec/ruby/core/symbol/encoding_spec.rb
@@ -3,12 +3,24 @@
 require_relative '../../spec_helper'
 
 describe "Symbol#encoding for ASCII symbols" do
-  it "is US-ASCII" do
-    :foo.encoding.name.should == "US-ASCII"
+  ruby_version_is "".."2.6" do
+    it "is US-ASCII" do
+      :foo.encoding.name.should == "US-ASCII"
+    end
+
+    it "is US-ASCII after converting to string" do
+      :foo.to_s.encoding.name.should == "US-ASCII"
+    end
   end
 
-  it "is US-ASCII after converting to string" do
-    :foo.to_s.encoding.name.should == "US-ASCII"
+  ruby_version_is "2.7" do
+    it "is UTF-8" do
+      :foo.encoding.name.should == "UTF-8"
+    end
+
+    it "is UTF-8 after converting to string" do
+      :foo.to_s.encoding.name.should == "UTF-8"
+    end
   end
 end
 

--- a/spec/ruby/language/symbol_spec.rb
+++ b/spec/ruby/language/symbol_spec.rb
@@ -73,7 +73,7 @@ describe "A Symbol literal" do
   end
 
   it "can contain null in the string" do
-    eval(':"\0" ').inspect.should == ':"\\x00"'
+    eval(':"\0" ')[0].bytes.should == [0]
   end
 
   it "can be an empty string" do

--- a/spec/ruby/optional/capi/symbol_spec.rb
+++ b/spec/ruby/optional/capi/symbol_spec.rb
@@ -30,10 +30,20 @@ describe "C-API Symbol function" do
       @s.rb_intern3_c_compare("Ω", 2, Encoding::UTF_8, :Ω).should == true
     end
 
-    it "converts an ascii compatible symbol with the ascii encoding" do
-      sym = @s.rb_intern3("foo", 3, Encoding::UTF_8)
-      sym.encoding.should == Encoding::US_ASCII
-      sym.should == :foo
+    ruby_version_is "".."2.6" do
+      it "converts an ascii compatible symbol with the ascii encoding" do
+        sym = @s.rb_intern3("foo", 3, Encoding::UTF_8)
+        sym.encoding.should == Encoding::US_ASCII
+        sym.should == :foo
+      end
+    end
+
+    ruby_version_is "2.7" do
+      it "converts an ascii compatible symbol with the utf-8 encoding" do
+        sym = @s.rb_intern3("foo", 3, Encoding::US_ASCII)
+        sym.encoding.should == Encoding::UTF_8
+        sym.should == :foo
+      end
     end
 
     it "should respect the symbol encoding via rb_intern3" do

--- a/test/ruby/test_m17n.rb
+++ b/test/ruby/test_m17n.rb
@@ -1294,7 +1294,7 @@ class TestM17N < Test::Unit::TestCase
       === != =~ !~ ~ ! [] []= << >> :: `
     "
     ops.each do |op|
-      assert_equal(Encoding::US_ASCII, op.intern.encoding, "[ruby-dev:33449]")
+      assert_equal(Encoding::UTF_8, op.intern.encoding, "[ruby-dev:33449]")
     end
   end
 


### PR DESCRIPTION
Ref: https://bugs.ruby-lang.org/issues/15940

It's not uncommon for symbols to have literal string counterparts, e.g.

```ruby
class User
  attr_accessor :name

  def as_json
    { 'name' => name }
  end
end
```

Since the default source encoding is UTF-8, and that symbols coerce their
internal fstring to ASCII when possible, the above snippet will actually keep
two instances of `"name"` in the fstring registry. One in ASCII, the other
in UTF-8.

Considering that UTF-8 is a strict superset of ASCII, storing the symbols
fstrings as UTF-8 instead makes no real difference, but allows in most cases
to reuse the equivalent string literals.

The only notable behavioral change is `Symbol#to_s`.

Previously `:name.to_s.encoding` would be `#<Encoding:US-ASCII>`.
After this patch it's `#<Encoding:UTF-8>`. I can't foresee any significant
compatibility impact of this change on existing code.

There are several ruby specs asserting this behavior. If this specification is impossible to change, then we could consider changing the encoding of the String returned by `Symbol#to_s`, e.g )ruby pseudo code:

```ruby
def to_s
  str = fstr.dup
  str.force_encoding(Encoding::ASCII) if str.ascii_only?
  str
end
```