### PR TITLE
Transition root fiber into state FIBER_TERMINATED.

### DIFF
--- a/cont.c
+++ b/cont.c
@@ -1581,6 +1581,17 @@ rb_threadptr_root_fiber_release(rb_thread_t *th)
     }
 }
 
+void
+rb_threadptr_root_fiber_terminate(rb_thread_t *th)
+{
+    rb_fiber_t *fiber = th->ec->fiber_ptr;
+
+    fiber->status = FIBER_TERMINATED;
+
+    // The vm_stack is `alloca`ed on the thread stack, so it's gone too:
+    rb_ec_clear_vm_stack(th->ec);
+}
+
 static inline rb_fiber_t*
 fiber_current(void)
 {

--- a/thread.c
+++ b/thread.c
@@ -591,6 +591,8 @@ rb_thread_terminate_all(void)
     EC_POP_TAG();
 }
 
+void rb_threadptr_root_fiber_terminate(rb_thread_t *th);
+
 static void
 thread_cleanup_func_before_exec(void *th_ptr)
 {
@@ -599,8 +601,7 @@ thread_cleanup_func_before_exec(void *th_ptr)
     // The thread stack doesn't exist in the forked process:
     th->ec->machine.stack_start = th->ec->machine.stack_end = NULL;
 
-    // The vm_stack is `alloca`ed on the thread stack, so it's gone too:
-    rb_ec_clear_vm_stack(th->ec);
+    rb_threadptr_root_fiber_terminate(th);
 }
 
 static void


### PR DESCRIPTION
During fork, it's possible that threads with root fibers are terminated,
but fiber state is not updated. `fiber_verify` will subsequently fail. We
forcefully enter the FIBER_TERMINATED state when terminating the root
fiber.