### PR TITLE
array.c add back shared array optimization to ary_ensure_room_for_unshift

### DIFF
--- a/array.c
+++ b/array.c
@@ -1373,18 +1373,18 @@ ary_ensure_room_for_unshift(VALUE ary, int argc)
 	rb_raise(rb_eIndexError, "index %ld too big", new_len);
     }
 
-    rb_ary_modify(ary);
-
     if (ARY_SHARED_P(ary)) {
 	VALUE shared = ARY_SHARED(ary);
 	capa = RARRAY_LEN(shared);
 	if (ARY_SHARED_OCCUPIED(shared) && capa > new_len) {
+            rb_ary_modify_check(ary);
             head = RARRAY_CONST_PTR_TRANSIENT(ary);
             sharedp = RARRAY_CONST_PTR_TRANSIENT(shared);
 	    goto makeroom_if_need;
 	}
     }
 
+    rb_ary_modify(ary);
     capa = ARY_CAPA(ary);
     if (capa - (capa >> 6) <= new_len) {
 	ary_double_capa(ary, new_len);


### PR DESCRIPTION
Bug fix in commit ec8e5f5aa64e2a [Bug #15952] disabled an
optimization in this function.