### PR TITLE
Add *_start and *_running  methods to VM_COLLECT_USAGE_DETAILS API

### DIFF
--- a/vm.c
+++ b/vm.c
@@ -2941,6 +2941,9 @@ static VALUE usage_analysis_register_stop(VALUE self);
 static VALUE usage_analysis_insn_running(VALUE self);
 static VALUE usage_analysis_operand_running(VALUE self);
 static VALUE usage_analysis_register_running(VALUE self);
+static VALUE usage_analysis_insn_clear(VALUE self);
+static VALUE usage_analysis_operand_clear(VALUE self);
+static VALUE usage_analysis_register_clear(VALUE self);
 #endif
 
 /*
@@ -3172,6 +3175,9 @@ Init_VM(void)
     rb_define_singleton_method(rb_cRubyVM, "USAGE_ANALYSIS_INSN_RUNNING", usage_analysis_insn_running, 0);
     rb_define_singleton_method(rb_cRubyVM, "USAGE_ANALYSIS_OPERAND_RUNNING", usage_analysis_operand_running, 0);
     rb_define_singleton_method(rb_cRubyVM, "USAGE_ANALYSIS_REGISTER_RUNNING", usage_analysis_register_running, 0);
+    rb_define_singleton_method(rb_cRubyVM, "USAGE_ANALYSIS_INSN_CLEAR", usage_analysis_insn_clear, 0);
+    rb_define_singleton_method(rb_cRubyVM, "USAGE_ANALYSIS_OPERAND_CLEAR", usage_analysis_operand_clear, 0);
+    rb_define_singleton_method(rb_cRubyVM, "USAGE_ANALYSIS_REGISTER_CLEAR", usage_analysis_register_clear, 0);
 #endif
 
     /* ::RubyVM::OPTS, which shows vm build options */
@@ -3586,6 +3592,53 @@ static VALUE
 usage_analysis_register_running(VALUE self)
 {
   if (ruby_vm_collect_usage_func_register == 0) return Qfalse;
+  return Qtrue;
+}
+
+/* :nodoc: */
+static VALUE
+usage_analysis_insn_clear(VALUE self)
+{
+  ID usage_hash;
+  ID bigram_hash;
+  VALUE uh;
+  VALUE bh;
+
+  CONST_ID(usage_hash, "USAGE_ANALYSIS_INSN");
+  CONST_ID(bigram_hash, "USAGE_ANALYSIS_INSN_BIGRAM");
+  uh = rb_const_get(rb_cRubyVM, usage_hash);
+  bh = rb_const_get(rb_cRubyVM, bigram_hash);
+  rb_hash_clear(uh);
+  rb_hash_clear(bh);
+
+  return Qtrue;
+}
+
+/* :nodoc: */
+static VALUE
+usage_analysis_operand_clear(VALUE self)
+{
+  ID usage_hash;
+  VALUE uh;
+
+  CONST_ID(usage_hash, "USAGE_ANALYSIS_INSN");
+  uh = rb_const_get(rb_cRubyVM, usage_hash);
+  rb_hash_clear(uh);
+
+  return Qtrue;
+}
+
+/* :nodoc: */
+static VALUE
+usage_analysis_register_clear(VALUE self)
+{
+  ID usage_hash;
+  VALUE uh;
+
+  CONST_ID(usage_hash, "USAGE_ANALYSIS_REGS");
+  uh = rb_const_get(rb_cRubyVM, usage_hash);
+  rb_hash_clear(uh);
+
   return Qtrue;
 }
 


### PR DESCRIPTION
I want to count how many VM instructions get executed for an arbitrary block of ruby code with `VM_COLLECT_USAGE_DETAILS` enabled. However, the current API enables VM usage detail collection immediately and only exposes methods to turn collection off.

This commit exposes additional methods to start usage detail collection and check if usage details are being collected. Subsequently, this changes behaviour to not collect VM usage details by default.

https://bugs.ruby-lang.org/issues/15963