### PR TITLE
Introduce Integer::MIN,MAX

### DIFF
--- a/numeric.c
+++ b/numeric.c
@@ -5599,6 +5599,20 @@ Init_Numeric(void)
     rb_define_method(rb_cNumeric, "negative?", num_negative_p, 0);
 
     rb_cInteger = rb_define_class("Integer", rb_cNumeric);
+
+    /*
+     *  The smallest number possible integer
+     *
+     *  Usually defaults to -4611686018427387903.
+     */
+    rb_define_const(rb_cInteger, "MIN", LONG2FIX(FIXNUM_MIN));
+    /*
+     *  The largest possible integer.
+     *
+     *  Usually defaults to 4611686018427387903.
+     */
+    rb_define_const(rb_cInteger, "MAX", LONG2FIX(FIXNUM_MAX));
+
     rb_undef_alloc_func(rb_cInteger);
     rb_undef_method(CLASS_OF(rb_cInteger), "new");
     rb_define_singleton_method(rb_cInteger, "sqrt", rb_int_s_isqrt, 1);

--- a/test/ruby/test_integer.rb
+++ b/test/ruby/test_integer.rb
@@ -650,4 +650,18 @@ class TestInteger < Test::Unit::TestCase
     def o.fdiv(x); 1; end
     assert_equal(1.0, 1.fdiv(o))
   end
+
+  def test_min
+    assert_kind_of(Fixnum, Fixnum::MIN)
+    if RUBY_ENGINE == 'ruby'
+      assert_equal(-2 ** (1.size * 8 - 2), Fixnum::MIN)
+    end
+  end
+
+  def test_max
+    assert_kind_of(Fixnum, Fixnum::MAX)
+    if RUBY_ENGINE == 'ruby'
+      assert_equal(2 ** (1.size * 8 - 2), Fixnum::MAX)
+    end
+  end
 end


### PR DESCRIPTION
Implements Matz suggestion https://bugs.ruby-lang.org/issues/7517 as part of https://github.com/ko1/rubyhackchallenge

Maximum (or minimum) number of fixnum can not be get in portable fashion, so I propose Integer::MAX and Integer::MIN just like Float::MAX and Float::MIN.

Co-Authored-By: Sebastian Sogamoso <sebasoga@gmail.com>
  