### PR TITLE
Make Kernel#lambda always return a lambda

### DIFF
--- a/proc.c
+++ b/proc.c
@@ -771,14 +771,20 @@ proc_new(VALUE klass, int8_t is_lambda)
       case block_handler_type_proc:
 	procval = VM_BH_TO_PROC(block_handler);
 
-	if (RBASIC_CLASS(procval) == klass) {
-	    return procval;
-	}
-	else {
+	if (RBASIC_CLASS(procval) != klass) {
 	    VALUE newprocval = rb_proc_dup(procval);
             RBASIC_SET_CLASS(newprocval, klass);
-	    return newprocval;
+	    procval = newprocval;
 	}
+
+        rb_proc_t *proc = RTYPEDDATA_DATA(procval);
+        if (is_lambda && !proc->is_lambda) {
+            procval = rb_proc_dup(procval);
+            proc = RTYPEDDATA_DATA(procval);
+            proc->is_lambda = true;
+        }
+
+        return procval;
 	break;
 
       case block_handler_type_symbol:

--- a/spec/ruby/core/proc/lambda_spec.rb
+++ b/spec/ruby/core/proc/lambda_spec.rb
@@ -16,7 +16,9 @@ describe "Proc#lambda?" do
 
   it "is preserved when passing a Proc with & to the lambda keyword" do
     lambda(&lambda{}).lambda?.should be_true
-    lambda(&proc{}).lambda?.should be_false
+    ruby_version_is ""..."2.7" do
+      lambda(&proc{}).lambda?.should be_false
+    end
   end
 
   it "is preserved when passing a Proc with & to the proc keyword" do

--- a/test/ruby/test_proc.rb
+++ b/test/ruby/test_proc.rb
@@ -306,7 +306,7 @@ class TestProc < Test::Unit::TestCase
     assert_equal(false, l.lambda?)
     assert_equal(false, l.curry.lambda?, '[ruby-core:24127]')
     assert_equal(false, proc(&l).lambda?)
-    assert_equal(false, lambda(&l).lambda?)
+    assert_equal(true, lambda(&l).lambda?)
     assert_equal(false, Proc.new(&l).lambda?)
     l = lambda {}
     assert_equal(true, l.lambda?)


### PR DESCRIPTION
Before this commit, when Kernel#lambda receives a Proc that is not a lambda,
it retuned it without modification. This commit makes it so that in all
cases, Kernel#lambda returns a Proc that is a lambda.

Calling a method called lambda and having it effectively do nothing was
not very intuitive.

[Feature #15973](https://bugs.ruby-lang.org/issues/15973)
[Bug #15620](https://bugs.ruby-lang.org/issues/15620)