### PR TITLE
Implement Array#minmax

### DIFF
--- a/array.c
+++ b/array.c
@@ -4850,6 +4850,36 @@ rb_ary_min(int argc, VALUE *argv, VALUE ary)
     return result;
 }
 
+/*
+ *  call-seq:
+ *     range.minmax                  -> [min, max]
+ *     range.minmax { |a, b| block } -> [min, max]
+ *
+ *  Returns a two element array which contains the minimum and the
+ *  maximum value of the array. The first form assumes all
+ *  objects implement Comparable; the second uses the
+ *  block to return <em>a <=> b</em>.
+ *
+ *  ary = %w[albatross dog horse]
+ *  ary.minmax                                  #=> ["albatross", "horse"]
+ *  ary.minmax {|a, b| a.length <=> b.length }  #=> ["dog", "albatross"]
+ */
+static VALUE
+rb_ary_minmax(int argc, VALUE *argv, VALUE ary)
+{
+    if (rb_block_given_p()) {
+        return rb_call_super(0, 0);
+    }
+
+    VALUE min, max, result;
+    result = rb_ary_new2(2);
+    min = rb_ary_min(argc, argv, ary);
+    rb_ary_push(result, min);
+    max = rb_ary_max(argc, argv, ary);
+    rb_ary_push(result, max);
+    return result;
+}
+
 static int
 push_value(st_data_t key, st_data_t val, st_data_t ary)
 {
@@ -6902,6 +6932,7 @@ Init_Array(void)
 
     rb_define_method(rb_cArray, "max", rb_ary_max, -1);
     rb_define_method(rb_cArray, "min", rb_ary_min, -1);
+    rb_define_method(rb_cArray, "minmax", rb_ary_minmax, -1);
 
     rb_define_method(rb_cArray, "uniq", rb_ary_uniq, 0);
     rb_define_method(rb_cArray, "uniq!", rb_ary_uniq_bang, 0);

--- a/test/ruby/test_array.rb
+++ b/test/ruby/test_array.rb
@@ -1792,6 +1792,23 @@ class TestArray < Test::Unit::TestCase
     assert_same(obj, [obj, 1.0].max)
   end
 
+  def test_minmax
+    assert_equal([1, 3], [1, 2, 3, 1, 2].minmax)
+    assert_equal([3, 1], [1, 2, 3, 1, 2].minmax {|a,b| b <=> a })
+    cond = ->((a, ia), (b, ib)) { (b <=> a).nonzero? or ia <=> ib }
+    assert_equal([[3, 2], [1, 3]], [1, 2, 3, 1, 2].each_with_index.minmax(&cond))
+    ary = %w(albatross dog horse)
+    assert_equal(["albatross", "horse"], ary.minmax)
+    assert_equal(["dog", "albatross"], ary.minmax {|a,b| a.length <=> b.length })
+    assert_equal([3, 1], [3,2,1].minmax{|a,b| b <=> a })
+    class << (obj = Object.new)
+      def <=>(x) 1 <=> x end
+      def coerce(x) [x, 1] end
+    end
+    assert_same(obj, [obj, 1.0].minmax.first)
+    assert_same(obj, [obj, 1.0].minmax.last)
+  end
+
   def test_uniq
     a = []
     b = a.uniq


### PR DESCRIPTION
Fix https://bugs.ruby-lang.org/issues/15929.

## Before:
```
min, max     66.999k (± 0.5%) i/s -    336.752k in   5.026395s
  minmax     39.816k (± 2.1%) i/s -    200.750k in   5.044432s
```

## After:
```
min, max     67.348k (± 0.6%) i/s -    337.636k in   5.013497s
  minmax     67.066k (± 2.0%) i/s -    338.895k in   5.055384s
```