### PR TITLE
Fix timezone issue for logger period's tests

### DIFF
--- a/test/logger/test_logperiod.rb
+++ b/test/logger/test_logperiod.rb
@@ -6,18 +6,18 @@ require 'time'
 
 class TestLogPeriod < Test::Unit::TestCase
   def test_next_rotate_time
-    time = Time.parse("2019-07-18 13:52:02 +0100")
+    time = Time.parse("2019-07-18 13:52:02")
 
     daily_result = Logger::Period.next_rotate_time(time, 'daily')
-    next_day = Time.parse("2019-07-19 00:00:00 +0100")
+    next_day = Time.parse("2019-07-19 00:00:00")
     assert_equal(next_day, daily_result)
 
     weekly_result = Logger::Period.next_rotate_time(time, 'weekly')
-    next_week = Time.parse("2019-07-21 00:00:00 +0100")
+    next_week = Time.parse("2019-07-21 00:00:00")
     assert_equal(next_week, weekly_result)
 
     monthly_result = Logger::Period.next_rotate_time(time, 'monthly')
-    next_month = Time.parse("2019-08-1 00:00:00 +0100")
+    next_month = Time.parse("2019-08-1 00:00:00")
     assert_equal(next_month, monthly_result)
 
     result = Logger::Period.next_rotate_time(time, 'invalid')
@@ -26,18 +26,18 @@ class TestLogPeriod < Test::Unit::TestCase
 
   def test_next_rotate_time_extreme_cases
     # First day of Month and Saturday
-    time = Time.parse("2018-07-01 00:00:00 +0100")
+    time = Time.parse("2018-07-01 00:00:00")
 
     daily_result = Logger::Period.next_rotate_time(time, 'daily')
-    next_day = Time.parse("2018-07-02 00:00:00 +0100")
+    next_day = Time.parse("2018-07-02 00:00:00")
     assert_equal(next_day, daily_result)
 
     weekly_result = Logger::Period.next_rotate_time(time, 'weekly')
-    next_week = Time.parse("2018-07-08 00:00:00 +0100")
+    next_week = Time.parse("2018-07-08 00:00:00")
     assert_equal(next_week, weekly_result)
 
     monthly_result = Logger::Period.next_rotate_time(time, 'monthly')
-    next_month = Time.parse("2018-08-1 00:00:00 +0100")
+    next_month = Time.parse("2018-08-1 00:00:00")
     assert_equal(next_month, monthly_result)
 
     result = Logger::Period.next_rotate_time(time, 'invalid')
@@ -45,18 +45,18 @@ class TestLogPeriod < Test::Unit::TestCase
   end
 
   def test_previous_period_end
-    time = Time.parse("2019-07-18 13:52:02 +0100")
+    time = Time.parse("2019-07-18 13:52:02")
 
     daily_result = Logger::Period.previous_period_end(time, 'daily')
-    day_ago = Time.parse("2019-07-17 23:59:59 +0100")
+    day_ago = Time.parse("2019-07-17 23:59:59")
     assert_equal(day_ago, daily_result)
 
     weekly_result = Logger::Period.previous_period_end(time, 'weekly')
-    week_ago = Time.parse("2019-07-13 23:59:59 +0100")
+    week_ago = Time.parse("2019-07-13 23:59:59")
     assert_equal(week_ago, weekly_result)
 
     monthly_result = Logger::Period.previous_period_end(time, 'monthly')
-    month_ago = Time.parse("2019-06-30 23:59:59 +0100")
+    month_ago = Time.parse("2019-06-30 23:59:59")
     assert_equal(month_ago, monthly_result)
 
     result = Logger::Period.previous_period_end(time, 'invalid')
@@ -65,18 +65,18 @@ class TestLogPeriod < Test::Unit::TestCase
 
   def test_previous_period_end_extreme_cases
     # First day of Month and Saturday
-    time = Time.parse("2018-07-01 00:00:00 +0100")
+    time = Time.parse("2018-07-01 00:00:00")
 
     daily_result = Logger::Period.previous_period_end(time, 'daily')
-    day_ago = Time.parse("2018-06-30 23:59:59 +0100")
+    day_ago = Time.parse("2018-06-30 23:59:59")
     assert_equal(day_ago, daily_result)
 
     weekly_result = Logger::Period.previous_period_end(time, 'weekly')
-    week_ago = Time.parse("2018-06-30 23:59:59 +0100")
+    week_ago = Time.parse("2018-06-30 23:59:59")
     assert_equal(week_ago, weekly_result)
 
     monthly_result = Logger::Period.previous_period_end(time, 'monthly')
-    month_ago = Time.parse("2018-06-30 23:59:59 +0100")
+    month_ago = Time.parse("2018-06-30 23:59:59")
     assert_equal(month_ago, monthly_result)
 
     result = Logger::Period.previous_period_end(time, 'invalid')


### PR DESCRIPTION
In https://github.com/ruby/ruby/pull/2266 I setup specific timezone (+01, UK) and CI server has different (+00). In this case we break CI build.

This PR fix this problem. I tested it locally with Tokyo timezone and all was okay (@mame sow it too)