### PR TITLE
Implement String#before and String#after

### DIFF
--- a/test/ruby/test_string.rb
+++ b/test/ruby/test_string.rb
@@ -2627,6 +2627,34 @@ CODE
     assert_equal("hello", hello, bug)
   end
 
+  def test_before
+    assert_equal("hello", "hello world".before(" "))
+    assert_equal(nil, "onetwothree".before("four"))
+    assert_equal("he", "hello world".before("l"))
+    assert_equal("cat", "cats and dogs".before("s"))
+
+    assert_equal("foo", "foobarbaz".before(/bar/))
+    assert_equal(nil, "cats and dogs".before(/pigs/))
+    assert_equal("he", "hello".before(/ll/))
+    assert_equal("", "hello".before(//))
+
+    assert_equal(nil, "".before(""))
+  end
+
+  def test_after
+    assert_equal("world", "hello world".after(" "))
+    assert_equal(nil, "onetwothree".after("four"))
+    assert_equal("lo world", "hello world".after("l"))
+    assert_equal(" and dogs", "cats and dogs".after("s"))
+
+    assert_equal("baz", "foobarbaz".after(/bar/))
+    assert_equal(nil, "cats and dogs".after(/pigs/))
+    assert_equal("o", "hello".after(/ll/))
+    assert_equal("hello", "hello".after(//))
+
+    assert_equal(nil, "".after(""))
+  end
+
   def test_setter
     assert_raise(TypeError) { $/ = 1 }
     name = "\u{5206 884c}"


### PR DESCRIPTION
Came across [this Redmine ticket (15899)](https://bugs.ruby-lang.org/issues/15899) that mirrors a behaviour I would also find useful: the ability to get the head or tail of a string, pivoting around a given string (or regex)

This is possible using `String#partition`, but when you want _only_ the head or tail, the partitioning approach unnecessarily allocates a new string holding the partition you don't want, and additionally returns the match itself. In this common use case, both of these other returned values are often discarded:

````ruby
# before
head, _sep, _tail = "matz is nice".partition("is")

# after
head = "matz is nice".before("is")
````

(There is some talk on the issue regarding the names of these methods. IMO `before` and `after` sounds fine, but any recommendations for better names would be good)