### PR TITLE
Let struct dump_config in objspace fit in a single cache line

### DIFF
--- a/ext/objspace/objspace_dump.c
+++ b/ext/objspace/objspace_dump.c
@@ -28,11 +28,11 @@ struct dump_config {
     FILE *stream;
     VALUE string;
     int roots;
+    int full_heap;
     const char *root_category;
     VALUE cur_obj;
     VALUE cur_obj_klass;
     size_t cur_obj_references;
-    int full_heap;
 };
 
 PRINTF_ARGS(static void dump_append(struct dump_config *, const char *, ...), 2, 3);


### PR DESCRIPTION
Another small packed struct change - gets passed around quite a bit in the `dump_append*` helper methods

Before:

```
lourens@CarbonX1:~/src/ruby/trunk$ pahole -C dump_config -P ./.ext/x86_64-linux/objspace.so
struct dump_config {
	VALUE                      type;                 /*     0     8 */
	FILE *                     stream;               /*     8     8 */
	VALUE                      string;               /*    16     8 */
	int                        roots;                /*    24     4 */

	/* XXX 4 bytes hole, try to pack */

	const char  *              root_category;        /*    32     8 */
	VALUE                      cur_obj;              /*    40     8 */
	VALUE                      cur_obj_klass;        /*    48     8 */
	size_t                     cur_obj_references;   /*    56     8 */
	/* --- cacheline 1 boundary (64 bytes) --- */
	int                        full_heap;            /*    64     4 */

	/* size: 72, cachelines: 2, members: 9 */
	/* sum members: 64, holes: 1, sum holes: 4 */
	/* padding: 4 */
	/* last cacheline: 8 bytes */
};
```

After:

```
lourens@CarbonX1:~/src/ruby/ruby$ pahole -C dump_config -P ./.ext/x86_64-linux/objspace.so
struct dump_config {
	VALUE                      type;                 /*     0     8 */
	FILE *                     stream;               /*     8     8 */
	VALUE                      string;               /*    16     8 */
	int                        roots;                /*    24     4 */
	int                        full_heap;            /*    28     4 */
	const char  *              root_category;        /*    32     8 */
	VALUE                      cur_obj;              /*    40     8 */
	VALUE                      cur_obj_klass;        /*    48     8 */
	size_t                     cur_obj_references;   /*    56     8 */

	/* size: 64, cachelines: 1, members: 9 */
};

```