### PR TITLE
Don't manipulate GC flags directly

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -8217,9 +8217,9 @@ gc_compact(rb_objspace_t *objspace, int use_toward_empty, int use_double_pages, 
         /* pin objects referenced by maybe pointers */
         rb_gc();
         /* compact */
-        during_gc = TRUE;
+        rb_gc_disable();
         gc_compact_after_gc(objspace, use_toward_empty, use_double_pages, TRUE);
-        during_gc = FALSE;
+        rb_gc_enable();
     }
     objspace->flags.during_compacting = FALSE;
     return gc_compact_stats(objspace);


### PR DESCRIPTION
We need to disable the GC around compaction (for now) because object id
book keeping can cause malloc to happen and that can trigger GC.