### PR TITLE
Correctly set ENV['BUNDLE_BIN_PATH']

### DIFF
--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -289,7 +289,9 @@ module Bundler
     def set_bundle_variables
       exe_file = File.expand_path("../../../exe/bundle", __FILE__)
       # for Ruby core repository
-      exe_file = File.expand_path("../../../../bin/bundle", __FILE__) unless File.exist?(exe_file)
+      unless File.exist?(exe_file)
+        exe_file = File.join(Gem.dir, "gems", "bundler-#{Bundler::VERSION}", "exe", "bundle")
+      end
       Bundler::SharedHelpers.set_env "BUNDLE_BIN_PATH", exe_file
       Bundler::SharedHelpers.set_env "BUNDLE_GEMFILE", find_gemfile(:order_matters).to_s
       Bundler::SharedHelpers.set_env "BUNDLER_VERSION", Bundler::VERSION


### PR DESCRIPTION
Below is only when using ruby 2.7.

This fixes CI failures that occur with nested `bundle exec` commands, as often testing is started with `bundle exec <test>`...

Once activated, bundler redefines `Gem.activate_bin_path`, and the value of `ENV['BUNDLE_BIN_PATH']` is used for subsequent bundle commands.

In master/trunk/2.7.0, bundler is installed as a default gem, and at some point in time I assume the bundle exe folder was within the lib/bundler folder.  Now, it is in the gems folder.  Patch updates the location so that that `ENV['BUNDLE_BIN_PATH']` is correct.

ping @hsbt