### PR TITLE
Allow String#-@ to deduplicate tainted string, but return an untainted one

### DIFF
--- a/spec/ruby/core/string/uminus_spec.rb
+++ b/spec/ruby/core/string/uminus_spec.rb
@@ -71,4 +71,14 @@ describe 'String#-@' do
       (-dynamic).should equal(-"this string is frozen".freeze)
     end
   end
+
+  ruby_version_is "2.7" do
+    it "does deduplicate tainted strings" do
+      dynamic = %w(this string is frozen).join(' ')
+      dynamic.taint
+      (-dynamic).should equal("this string is frozen".freeze)
+      (-dynamic).should equal(-"this string is frozen".freeze)
+      (-dynamic).should == "this string is frozen"
+    end
+  end
 end

--- a/string.c
+++ b/string.c
@@ -258,7 +258,7 @@ const struct st_hash_type rb_fstring_hash_type = {
     rb_str_hash,
 };
 
-#define BARE_STRING_P(str) (!FL_ANY_RAW(str, FL_TAINT|FL_EXIVAR) && RBASIC_CLASS(str) == rb_cString)
+#define BARE_STRING_P(str) (!FL_ANY_RAW(str, FL_EXIVAR) && RBASIC_CLASS(str) == rb_cString)
 
 static int
 fstr_update_callback(st_data_t *key, st_data_t *value, st_data_t arg, int existing)
@@ -319,6 +319,11 @@ rb_fstring(VALUE str)
     if (STR_EMBED_P(str) && !bare) {
 	OBJ_FREEZE_RAW(str);
 	return str;
+    }
+
+    if (FL_ANY_RAW(str, FL_TAINT)) {
+	str = rb_str_dup(str);
+	FL_UNSET(str, FL_TAINT);
     }
 
     if (!OBJ_FROZEN(str))
@@ -2683,7 +2688,7 @@ str_uplus(VALUE str)
  *
  * Returns a frozen, possibly pre-existing copy of the string.
  *
- * The string will be deduplicated as long as it is not tainted,
+ * The string will be deduplicated as long as it is not a sublass
  * or has any instance variables set on it.
  */
 static VALUE

--- a/test/-ext-/string/test_fstring.rb
+++ b/test/-ext-/string/test_fstring.rb
@@ -14,32 +14,36 @@ class Test_String_Fstring < Test::Unit::TestCase
 
   def test_taint_shared_string
     str = __method__.to_s.dup
-    str.taint
-    assert_fstring(str) {|s| assert_predicate(s, :tainted?)}
+    assert_predicate(str.taint, :tainted?)
+    assert_not_predicate(Bug::String.fstring(str), :tainted?)
   end
 
   def test_taint_normal_string
     str = __method__.to_s * 3
-    str.taint
-    assert_fstring(str) {|s| assert_predicate(s, :tainted?)}
+    assert_predicate(str.taint, :tainted?)
+    assert_not_predicate(Bug::String.fstring(str), :tainted?)
   end
 
   def test_taint_registered_tainted
     str = __method__.to_s * 3
     str.taint
-    assert_fstring(str) {|s| assert_predicate(s, :tainted?)}
+    assert_predicate(str.taint, :tainted?)
+    assert_not_predicate(Bug::String.fstring(str), :tainted?)
 
     str = __method__.to_s * 3
-    assert_fstring(str) {|s| assert_not_predicate(s, :tainted?)}
+    assert_predicate(str.taint, :tainted?)
+    assert_not_predicate(Bug::String.fstring(str), :tainted?)
   end
 
   def test_taint_registered_untainted
     str = __method__.to_s * 3
-    assert_fstring(str) {|s| assert_not_predicate(s, :tainted?)}
+    assert_predicate(str.taint, :tainted?)
+    assert_not_predicate(Bug::String.fstring(str), :tainted?)
 
     str = __method__.to_s * 3
     str.taint
-    assert_fstring(str) {|s| assert_predicate(s, :tainted?)}
+    assert_predicate(str.taint, :tainted?)
+    assert_not_predicate(Bug::String.fstring(str), :tainted?)
   end
 
   def test_instance_variable


### PR DESCRIPTION
Redmine issue: https://bugs.ruby-lang.org/issues/15998

There was a previous attempt by Eric Wong to allow deduplication of tainted strings, but it was reverted because of unknown CI issues: https://github.com/ruby/ruby/commit/0493b1ce3a4

The previous approach was trying to segregate tainted fstrings from untainted ones. This patch is different.

Instead it returns an untainted fstring.

The rationale is that `String#-@` purpose is to deduplicate string we know will stay in memory for long if not until exit, hence I'd argue that by doing so we're implicitly trusting them. A typical usage for instance is:

```ruby
CONFIG = YAML.load_file('path/to/config.yml').transform_keys { |k| -k }.freeze
```

Except the above currently doesn't work because YAML returns tainted instances when it reads from a file, so instead you have to do:

```ruby
CONFIG = YAML.load_file('path/to/config.yml').transform_keys { |k| -(+k).untaint }.freeze
```

Which is fairly inefficient and unexpected. Several time I wondered why `-@` wouldn't deduplicate strings until I noticed they were tainted.