### PR TITLE
Make Kernel#lambda return non-lambda when block is not literal

### DIFF
--- a/proc.c
+++ b/proc.c
@@ -789,6 +789,9 @@ proc_new(VALUE klass, int8_t is_lambda)
 
       case block_handler_type_ifunc:
       case block_handler_type_iseq:
+        if (VM_BH_FORWARDED_ISEQ_BLOCK_P(block_handler)) {
+            is_lambda = 0;
+        }
 	return rb_vm_make_proc_lambda(ec, VM_BH_TO_CAPT_BLOCK(block_handler), klass, is_lambda);
     }
     VM_UNREACHABLE(proc_new);

--- a/test/ruby/test_lambda.rb
+++ b/test/ruby/test_lambda.rb
@@ -74,6 +74,22 @@ class TestLambdaParameters < Test::Unit::TestCase
     assert_raise(ArgumentError, bug9605) {proc(&plus).call [1,2]}
   end
 
+  def pass_along(&block)
+    lambda(&block)
+  end
+
+  def pass_along2(&block)
+    pass_along(&block)
+  end
+
+  def test_create_non_lambda_for_non_literal_block
+    bug15620 = '[Bug #15620]'
+    f = pass_along {}
+    assert_nothing_raised(ArgumentError, bug15620) { f.call(:extra_arg) }
+    f = pass_along2 {}
+    assert_nothing_raised(ArgumentError, bug15620) { f.call(:extra_arg) }
+  end
+
   def test_instance_exec
     bug12568 = '[ruby-core:76300] [Bug #12568]'
     assert_nothing_raised(ArgumentError, bug12568) do

--- a/vm_args.c
+++ b/vm_args.c
@@ -892,7 +892,11 @@ vm_caller_setup_arg_block(const rb_execution_context_t *ec, rb_control_frame_t *
             return VM_BLOCK_HANDLER_NONE;
         }
 	else if (block_code == rb_block_param_proxy) {
-            return VM_CF_BLOCK_HANDLER(reg_cfp);
+            VALUE block_handler = VM_CF_BLOCK_HANDLER(reg_cfp);
+            if (VM_BH_ISEQ_BLOCK_P(block_handler)) {
+                block_handler = VM_FORWARDED_BH_FROM_ISEQ_BLOCK_BH(block_handler);
+            }
+            return block_handler;
         }
 	else if (SYMBOL_P(block_code) && rb_method_basic_definition_p(rb_cSymbol, idTo_proc)) {
 	    const rb_cref_t *cref = vm_env_cref(reg_cfp->ep);


### PR DESCRIPTION
This restores the behavior of Kernel#lambda from Ruby 2.4.x
when it receives a non literal block.

Semantically speaking, once a literal block is passed into a method
which takes an ampersand argument, the block becomes a non-lambda
Proc object. When Kernel#lambda recieves a non-lambda proc,
it is supposed to simply return it.

Because of lazy proc allocation, Kernel#lambda wasn't able to tell
the difference between a literal block and a block that has passed
through an ampersand argument and is semantically supposed to be
a Proc object.

This commit uses a new pointer tag, `0x2`, to indicate that a block
has passed through an ampersand argument. In all other regards,
this block handler tag is the same as `block_handler_type_iseq`.
I then use this new tag in Kernel#lambda to implement the
2.4.x spec.

[Bug #15620](https://bugs.ruby-lang.org/issues/15620)