### PR TITLE
Kernel#lambda: return forwarded block as non-lambda proc

### DIFF
--- a/spec/ruby/core/kernel/fixtures/classes.rb
+++ b/spec/ruby/core/kernel/fixtures/classes.rb
@@ -337,6 +337,28 @@ module KernelSpecs
     end
   end
 
+  module LambdaSpecs
+    module ZSuper
+      def lambda
+        super
+      end
+    end
+
+    class ForwardBlockWithZSuper
+      prepend(ZSuper)
+    end
+
+    module Ampersand
+      def lambda(&block)
+        super(&block)
+      end
+    end
+
+    class SuperAmpersand
+      prepend(Ampersand)
+    end
+  end
+
   class RespondViaMissing
     def respond_to_missing?(method, priv=false)
       case method

--- a/spec/ruby/core/kernel/lambda_spec.rb
+++ b/spec/ruby/core/kernel/lambda_spec.rb
@@ -53,6 +53,13 @@ describe "Kernel.lambda" do
     l.lambda?.should be_false
   end
 
+  it "does not create lambda-style Procs when captured with #method" do
+    kernel_lambda = method(:lambda)
+    l = kernel_lambda.call { 42 }
+    l.lambda?.should be_false
+    l.call(:extra).should == 42
+  end
+
   it "checks the arity of the call when no args are specified" do
     l = lambda { :called }
     l.call.should == :called

--- a/spec/ruby/core/kernel/lambda_spec.rb
+++ b/spec/ruby/core/kernel/lambda_spec.rb
@@ -31,9 +31,24 @@ describe "Kernel.lambda" do
     l.lambda?.should be_true
   end
 
-  it "returned the passed Proc if given an existing Proc" do
+  it "returns the passed Proc if given an existing Proc" do
     some_proc = proc {}
     l = lambda(&some_proc)
+    l.should equal(some_proc)
+    l.lambda?.should be_false
+  end
+
+  it "creates a lambda-style Proc when called with zsuper" do
+    l = KernelSpecs::LambdaSpecs::ForwardBlockWithZSuper.new.lambda { 42 }
+    l.lambda?.should be_true
+    l.call.should == 42
+
+    lambda { l.call(:extra) }.should raise_error(ArgumentError)
+  end
+
+  it "returns the passed Proc if given an existing Proc through super" do
+    some_proc = proc { }
+    l = KernelSpecs::LambdaSpecs::SuperAmpersand.new.lambda(&some_proc)
     l.should equal(some_proc)
     l.lambda?.should be_false
   end

--- a/test/ruby/test_lambda.rb
+++ b/test/ruby/test_lambda.rb
@@ -74,6 +74,26 @@ class TestLambdaParameters < Test::Unit::TestCase
     assert_raise(ArgumentError, bug9605) {proc(&plus).call [1,2]}
   end
 
+  def pass_along(&block)
+    lambda(&block)
+  end
+
+  def pass_along2(&block)
+    pass_along(&block)
+  end
+
+  def test_create_non_lambda_for_proc_one_level
+    f = pass_along {}
+    refute_predicate(f, :lambda?, '[Bug #15620]')
+    assert_nothing_raised(ArgumentError) { f.call(:extra_arg) }
+  end
+
+  def test_create_non_lambda_for_proc_two_levels
+    f = pass_along2 {}
+    refute_predicate(f, :lambda?, '[Bug #15620]')
+    assert_nothing_raised(ArgumentError) { f.call(:extra_arg) }
+  end
+
   def test_instance_exec
     bug12568 = '[ruby-core:76300] [Bug #12568]'
     assert_nothing_raised(ArgumentError, bug12568) do

--- a/vm_args.c
+++ b/vm_args.c
@@ -1204,7 +1204,10 @@ vm_caller_setup_arg_block(const rb_execution_context_t *ec, rb_control_frame_t *
             return VM_BLOCK_HANDLER_NONE;
         }
 	else if (block_code == rb_block_param_proxy) {
-            return VM_CF_BLOCK_HANDLER(reg_cfp);
+            VM_ASSERT(!VM_CFP_IN_HEAP_P(GET_EC(), reg_cfp));
+            VALUE handler = VM_CF_BLOCK_HANDLER(reg_cfp);
+            reg_cfp->block_code = (const void *) handler;
+            return handler;
         }
 	else if (SYMBOL_P(block_code) && rb_method_basic_definition_p(rb_cSymbol, idTo_proc)) {
 	    const rb_cref_t *cref = vm_env_cref(reg_cfp->ep);

--- a/vm_core.h
+++ b/vm_core.h
@@ -763,7 +763,7 @@ typedef struct rb_control_frame_struct {
     const rb_iseq_t *iseq;	/* cfp[2] */
     VALUE self;			/* cfp[3] / block[0] */
     const VALUE *ep;		/* cfp[4] / block[1] */
-    const void *block_code;     /* cfp[5] / block[2] */ /* iseq or ifunc */
+    const void *block_code;     /* cfp[5] / block[2] */ /* iseq or ifunc or forwarded block handler */
     VALUE *__bp__;              /* cfp[6] */ /* outside vm_push_frame, use vm_base_ptr instead. */
 
 #if VM_DEBUG_BP_CHECK
@@ -1492,6 +1492,12 @@ vm_block_handler_verify(MAYBE_UNUSED(VALUE block_handler))
 {
     VM_ASSERT(block_handler == VM_BLOCK_HANDLER_NONE ||
 	      (vm_block_handler_type(block_handler), 1));
+}
+
+static inline int
+vm_cfp_forwarded_bh_p(const rb_control_frame_t *cfp, VALUE block_handler)
+{
+    return ((VALUE) cfp->block_code) == block_handler;
 }
 
 static inline enum rb_block_type


### PR DESCRIPTION
Before this commit, Kernel#lambda can't tell the difference between a
directly passed literal block and one passed with an ampersand.

A block passed with an ampersand is semantically speaking already a
non-lambda proc. When Kernel#lambda receives a non-lambda proc, it
should simply return it.

Implementation wise, when the VM calls a method with a literal block, it
places the code for the block on the calling control frame and passes a
pointer (block handler) to the callee. Before this commit, the VM
forwards block arguments by simply forwarding the block handler, which
leaves the slot for block code unused when a control frame forwards its
block argument. I use the vacant space to indicate that a frame has
forwarded its block argument and look for this in Kernel#lambda to
detect forwarded blocks.

This is a very ad-hoc solution and relies *heavily* on the way block
passing works in the VM. However, it's the most self-contained solution
I have.

[Bug #15620](https://bugs.ruby-lang.org/issues/15620)