### PR TITLE
Ensure we don't have dangling cfp.

### DIFF
--- a/cont.c
+++ b/cont.c
@@ -709,6 +709,7 @@ fiber_stack_release(rb_fiber_t * fiber)
 
     // The stack is no longer associated with this execution context:
     rb_ec_clear_vm_stack(ec);
+    ec->cfp = NULL;
 }
 
 static const char *


### PR DESCRIPTION
We are having some failures and it looks like during enumeration of `cfp` in `rb_execution_context_mark`. By that time, it's entirely possible `cfp` is invalid, so ensure it's `NULL`.

```
-- C level backtrace information -------------------------------------------
/tmp/ruby/v2/build/trunk-gc-asserts/libruby.so.2.7.0(rb_vm_bugreport+0x769) [0x7ffa94ba4c49] /tmp/ruby/v2/src/trunk-gc-asserts/vm_dump.c:707
/tmp/ruby/v2/build/trunk-gc-asserts/libruby.so.2.7.0(rb_bug_context+0xe7) [0x7ffa949cf697] /tmp/ruby/v2/src/trunk-gc-asserts/error.c:599
/tmp/ruby/v2/build/trunk-gc-asserts/libruby.so.2.7.0(sigsegv+0x42) [0x7ffa94b0b392] /tmp/ruby/v2/src/trunk-gc-asserts/signal.c:997
/lib/x86_64-linux-gnu/libc.so.6(0x7ffa94555f20) [0x7ffa94555f20]
/tmp/ruby/v2/build/trunk-gc-asserts/libruby.so.2.7.0(VM_ENV_PREV_EP+0x8) [0x7ffa94b8aeca] /tmp/ruby/v2/src/trunk-gc-asserts/vm_core.h:1285
/tmp/ruby/v2/build/trunk-gc-asserts/libruby.so.2.7.0(rb_execution_context_mark) /tmp/ruby/v2/src/trunk-gc-asserts/vm.c:2496
/tmp/ruby/v2/build/trunk-gc-asserts/libruby.so.2.7.0(cont_thread_value+0x0) [0x7ffa949a59d0] /tmp/ruby/v2/src/trunk-gc-asserts/cont.c:836
/tmp/ruby/v2/build/trunk-gc-asserts/libruby.so.2.7.0(fiber_mark) /tmp/ruby/v2/src/trunk-gc-asserts/cont.c:837
/tmp/ruby/v2/build/trunk-gc-asserts/libruby.so.2.7.0(rb_objspace_reachable_objects_from+0x9c) [0x7ffa949f594c] /tmp/ruby/v2/src/trunk-gc-asserts/gc.c:9291
/tmp/ruby/v2/build/trunk-gc-asserts/libruby.so.2.7.0(verify_internal_consistency_i+0x17a) [0x7ffa949f5ada] /tmp/ruby/v2/src/trunk-gc-asserts/gc.c:5690
/tmp/ruby/v2/build/trunk-gc-asserts/libruby.so.2.7.0(objspace_each_objects+0xe0) [0x7ffa949e8f50] /tmp/ruby/v2/src/trunk-gc-asserts/gc.c:2697
/tmp/ruby/v2/build/trunk-gc-asserts/libruby.so.2.7.0(gc_verify_internal_consistency+0x5b) [0x7ffa949f65ab] /tmp/ruby/v2/src/trunk-gc-asserts/gc.c:5855
/tmp/ruby/v2/build/trunk-gc-asserts/libruby.so.2.7.0(gc_sweep_step+0xa5b) [0x7ffa949f95fb] /tmp/ruby/v2/src/trunk-gc-asserts/gc.c:4035
/tmp/ruby/v2/build/trunk-gc-asserts/libruby.so.2.7.0(heap_get_freeobj_from_next_freepage+0x8f) [0x7ffa949fbf8f] /tmp/ruby/v2/src/trunk-gc-asserts/gc.c:4125
/tmp/ruby/v2/build/trunk-gc-asserts/libruby.so.2.7.0(newobj_slowpath_wb_protected+0x8a) [0x7ffa949fcb9a] /tmp/ruby/v2/src/trunk-gc-asserts/gc.c:1911
```