### PR TITLE
Indicate that non-blocking isn't supported on Windows

### DIFF
--- a/prelude.rb
+++ b/prelude.rb
@@ -39,6 +39,10 @@ class IO
   #
   # read_nonblock causes EOFError on EOF.
   #
+  # On some platforms such as Windows, non-blocking mode is not supported
+  # on IO objects other than sockets. In such cases, Errno::EBADF will
+  # be raised.
+  #
   # If the read byte buffer is not empty,
   # read_nonblock reads from the buffer like readpartial.
   # In this case, the read(2) system call is not called.


### PR DESCRIPTION
The fact that non-blocking mode wasn't supported on Windows got me confused for a good while until I found this: https://bugs.ruby-lang.org/issues/5954

Hopefully this'll help others figuring this out.