### PR TITLE
Lazy init thread local storage

### DIFF
--- a/defs/id.def
+++ b/defs/id.def
@@ -46,6 +46,7 @@ firstline, predefined = __LINE__+1, %[\
   call
   mesg
   exception
+  locals
   not                                                   NOT
   and                                                   AND
   or                                                    OR

--- a/vm.c
+++ b/vm.c
@@ -2727,7 +2727,6 @@ ruby_thread_init(VALUE self)
 
     th->vm = vm;
     th_init(th, self);
-    rb_ivar_set(self, rb_intern("locals"), rb_hash_new());
 
     th->top_wrapper = 0;
     th->top_self = rb_vm_top_self();
@@ -3235,7 +3234,6 @@ Init_VM(void)
 
 	/* create main thread */
 	th_self = th->self = TypedData_Wrap_Struct(rb_cThread, &thread_data_type, th);
-	rb_iv_set(th_self, "locals", rb_hash_new());
 	vm->main_thread = th;
 	vm->running_thread = th;
 	th->vm = vm;


### PR DESCRIPTION
### Why?

The `local_storage` member of execution context is lazy initialized and drives the `Thread#[]` and `Thread#[]=` APIs, which are Fiber local and not Thread local storage. I think the same lazy init pattern should be applied to the APIs below as well - reduces one `Hash` alloc per thread created that does not use thread locals.

### Lazy allocates thread local storage for the following APIs

*  `Thread#thread_variable_get` - early returns `nil` on locals Hash not initialised
*  `Thread#thread_variable_set` - forces allocation of the locals Hash if not initilalised
*  `Thread#thread_variables` - early returns the empty array AND saves on Hash iteration if locals Hash not initialised
*  `Thread#thread_variable?` - early returns `false` on locals Hash not initialised

### Other notes

* Moved initial implementation from `internal.h` to `thread.c` local to call sites.
* Preferred `defs/id.def` for the `locals` ID (seeing this pattern used more often, but not sure if that is preferred to inline `rb_intern` yet. Either way there's quite a few different conventions around IDs in the codebase at the moment and happy to help converging to a standard instead.
* Maybe a flag is overkill and `NIL_P` on `locals` ivar could also work ...

Thoughts?