### PR TITLE
Allow Array#join to allocate smaller strings

### DIFF
--- a/array.c
+++ b/array.c
@@ -2369,7 +2369,9 @@ rb_ary_join(VALUE ary, VALUE sep)
 	len += RSTRING_LEN(tmp);
     }
 
-    result = rb_str_buf_new(len);
+    result = rb_str_new(0, len);
+    rb_str_set_len(result, 0);
+
     if (taint) OBJ_TAINT(result);
     ary_join_0(ary, sep, RARRAY_LEN(ary), result);
 


### PR DESCRIPTION
`rb_str_buf_new` always allocates at least 127 bytes of capacity, even when less is requested.

```
> ObjectSpace.dump(%w[a b c].join)
{
  "address":"0x7f935f06ebf0",
  "type":"STRING",
  "class":"0x7f935d8b7bb0",
  "bytesize":3,
  "capacity":127,
  "value":"abc",
  "encoding":"UTF-8",
  "memsize":168,
  "flags":{"wb_protected":true}
}
```

Instead, by using `rb_str_new` and then setting the length to 0, we can allocate the exact amount of memory needed, without extra capacity.

```
> ObjectSpace.dump(%w[a b c].join)
{
  "address":"0x7f903fcab530",
  "type":"STRING",
  "class":"0x7f903f8b7988",
  "embedded":true,
  "bytesize":3,
  "value":"abc",
  "encoding":"UTF-8",
  "memsize":40,
  "flags":{"wb_protected":true}
}
```