### PR TITLE
Expose fstring related APIs to C-extensions

### DIFF
--- a/include/ruby/encoding.h
+++ b/include/ruby/encoding.h
@@ -139,6 +139,8 @@ VALUE rb_enc_str_new(const char*, long, rb_encoding*);
 VALUE rb_enc_str_new_cstr(const char*, rb_encoding*);
 VALUE rb_enc_str_new_static(const char*, long, rb_encoding*);
 VALUE rb_enc_reg_new(const char*, long, rb_encoding*, int);
+VALUE rb_fstring_enc_new(const char *ptr, long len, rb_encoding *enc);
+VALUE rb_fstring_enc_cstr(const char *ptr, rb_encoding *enc);
 PRINTF_ARGS(VALUE rb_enc_sprintf(rb_encoding *, const char*, ...), 2, 3);
 VALUE rb_enc_vsprintf(rb_encoding *, const char*, va_list);
 long rb_enc_strlen(const char*, const char*, rb_encoding*);
@@ -162,6 +164,11 @@ VALUE rb_str_conv_enc_opts(VALUE str, rb_encoding *from, rb_encoding *to, int ec
     (__builtin_constant_p(str)) ?	       \
 	rb_enc_str_new_static((str), (long)strlen(str), (enc)) : \
 	rb_enc_str_new_cstr((str), (enc)) \
+)
+#define rb_fstring_enc_cstr(str, enc) RB_GNUC_EXTENSION_BLOCK( \
+    (__builtin_constant_p(str)) ?		\
+	rb_fstring_enc_new((str), (long)strlen(str), (enc)) : \
+	rb_fstring_enc_cstr(str, enc) \
 )
 #endif
 

--- a/include/ruby/intern.h
+++ b/include/ruby/intern.h
@@ -810,6 +810,10 @@ long rb_str_offset(VALUE, long);
 PUREFUNC(size_t rb_str_capacity(VALUE));
 VALUE rb_str_ellipsize(VALUE, long);
 VALUE rb_str_scrub(VALUE, VALUE);
+VALUE rb_fstring(VALUE);
+VALUE rb_fstring_new(const char *ptr, long len);
+VALUE rb_fstring_cstr(const char *str);
+
 /* symbol.c */
 VALUE rb_sym_all_symbols(void);
 
@@ -875,6 +879,11 @@ VALUE rb_sym_all_symbols(void);
 	rb_exc_new((klass), (ptr), (long)strlen(ptr)) : \
 	rb_exc_new_cstr((klass), (ptr))		\
 )
+# define rb_fstring_cstr(str) RB_GNUC_EXTENSION_BLOCK(	\
+    (__builtin_constant_p(str)) ?		\
+	rb_fstring_new((str), (long)strlen(str)) : \
+	rb_fstring_cstr(str) \
+)
 #endif
 #define rb_str_new2 rb_str_new_cstr
 #define rb_str_new3 rb_str_new_shared
@@ -895,6 +904,10 @@ VALUE rb_sym_all_symbols(void);
 #define rb_usascii_str_new_literal(str) rb_usascii_str_new_lit(str)
 #define rb_utf8_str_new_literal(str) rb_utf8_str_new_lit(str)
 #define rb_enc_str_new_literal(str, enc) rb_enc_str_new_lit(str, enc)
+#define rb_fstring_lit(str) rb_fstring_new((str), rb_strlen_lit(str))
+#define rb_fstring_literal(str) rb_fstring_lit(str)
+#define rb_fstring_enc_lit(str, enc) rb_fstring_enc_new((str), rb_strlen_lit(str), (enc))
+#define rb_fstring_enc_literal(str, enc) rb_fstring_enc_lit(str, enc)
 
 /* struct.c */
 VALUE rb_struct_new(VALUE, ...);

--- a/internal.h
+++ b/internal.h
@@ -2089,31 +2089,6 @@ extern int ruby_enable_coredump;
 int rb_get_next_signal(void);
 
 /* string.c */
-VALUE rb_fstring(VALUE);
-VALUE rb_fstring_new(const char *ptr, long len);
-#define rb_fstring_lit(str) rb_fstring_new((str), rb_strlen_lit(str))
-#define rb_fstring_literal(str) rb_fstring_lit(str)
-VALUE rb_fstring_cstr(const char *str);
-#ifdef HAVE_BUILTIN___BUILTIN_CONSTANT_P
-# define rb_fstring_cstr(str) RB_GNUC_EXTENSION_BLOCK(	\
-    (__builtin_constant_p(str)) ?		\
-	rb_fstring_new((str), (long)strlen(str)) : \
-	rb_fstring_cstr(str) \
-)
-#endif
-#ifdef RUBY_ENCODING_H
-VALUE rb_fstring_enc_new(const char *ptr, long len, rb_encoding *enc);
-#define rb_fstring_enc_lit(str, enc) rb_fstring_enc_new((str), rb_strlen_lit(str), (enc))
-#define rb_fstring_enc_literal(str, enc) rb_fstring_enc_lit(str, enc)
-VALUE rb_fstring_enc_cstr(const char *ptr, rb_encoding *enc);
-# ifdef HAVE_BUILTIN___BUILTIN_CONSTANT_P
-#  define rb_fstring_enc_cstr(str, enc) RB_GNUC_EXTENSION_BLOCK( \
-    (__builtin_constant_p(str)) ?		\
-	rb_fstring_enc_new((str), (long)strlen(str), (enc)) : \
-	rb_fstring_enc_cstr(str, enc) \
-)
-# endif
-#endif
 int rb_str_buf_cat_escaped_char(VALUE result, unsigned int c, int unicode_p);
 int rb_str_symname_p(VALUE);
 VALUE rb_str_quote_unprintable(VALUE);


### PR DESCRIPTION
As discussed with @tenderlove here: https://github.com/ruby/ruby/pull/2287#issuecomment-513865160

We'd like to update various data format parsers (JSON, MessagePack, etc) to add the possibility to deduplicate strings while parsing.

But unfortunately the `rb_fstring_*` family of functions isn't available to C-extensions, so the only available fallback is `rb_funcall(str, rb_intern("-@"))` which most parsers will likely consider too slow.

cc @tenderlove @rafaelfranca @Edouard-Chin