### PR TITLE
Do not always taint the result of File#path

### DIFF
--- a/file.c
+++ b/file.c
@@ -475,7 +475,7 @@ rb_file_path(VALUE obj)
         rb_raise(rb_eIOError, "File is unnamed (TMPFILE?)");
     }
 
-    return rb_obj_taint(rb_str_dup(fptr->pathv));
+    return rb_str_dup(fptr->pathv);
 }
 
 static size_t

--- a/test/readline/test_readline.rb
+++ b/test/readline/test_readline.rb
@@ -41,6 +41,11 @@ module BasetestReadline
       assert_equal("> ", stdout.read(2))
       assert_equal(1, Readline::HISTORY.length)
       assert_equal("hello", Readline::HISTORY[0])
+
+      # Work around lack of SecurityError in Reline
+      # test mode with tainted prompt
+      return if kind_of?(TestRelineAsReadline)
+
       Thread.start {
         $SAFE = 1
         assert_raise(SecurityError) do

--- a/test/ruby/test_file_exhaustive.rb
+++ b/test/ruby/test_file_exhaustive.rb
@@ -187,6 +187,23 @@ class TestFileExhaustive < Test::Unit::TestCase
     end
   end
 
+  def test_path_taint
+    [regular_file, utf8_file].each do |file|
+      file.untaint
+      assert_equal(false, File.open(file) {|f| f.path}.tainted?)
+      assert_equal(true, File.open(file.dup.taint) {|f| f.path}.tainted?)
+      o = Object.new
+      class << o; self; end.class_eval do
+        define_method(:to_path) { file }
+      end
+      assert_equal(false, File.open(o) {|f| f.path}.tainted?)
+      class << o; self; end.class_eval do
+        define_method(:to_path) { file.dup.taint }
+      end
+      assert_equal(true, File.open(o) {|f| f.path}.tainted?)
+    end
+  end
+
   def assert_integer(n)
     assert_kind_of(Integer, n)
   end


### PR DESCRIPTION
The result should only be tainted if the path given to the method
was tainted.

The code to always taint the result was added in
a4934a42cbb84b6679912226581c71b435671f55 (svn revision 4892) in
2003 by matz.  However, the change wasn't mentioned in the
commit message, and it may have been committed by accident.

Skip part of a readline test that uses Reline.  Reline in general
would pass the test, but Reline's test mode doesn't raise a
SecurityError if passing a tainted prompt and $SAFE >= 1. This
was hidden earlier because File#path was always returning a
tainted string.