### PR TITLE
Passing `binmode: true` to `IO.pipe` should behave like `binmode`

### DIFF
--- a/io.c
+++ b/io.c
@@ -10313,7 +10313,7 @@ rb_io_s_pipe(int argc, VALUE *argv, VALUE klass)
 
     extract_binmode(opt, &fmode);
 
-    if (fmode & FMODE_BINMODE) {
+    if ((fmode & FMODE_BINMODE) && v1 == Qnil) {
 	rb_io_ascii8bit_binmode(r);
 	rb_io_ascii8bit_binmode(w);
     }

--- a/io.c
+++ b/io.c
@@ -10312,6 +10312,12 @@ rb_io_s_pipe(int argc, VALUE *argv, VALUE klass)
     rb_io_synchronized(fptr2);
 
     extract_binmode(opt, &fmode);
+
+    if (fmode & FMODE_BINMODE) {
+	rb_io_ascii8bit_binmode(r);
+	rb_io_ascii8bit_binmode(w);
+    }
+
 #if DEFAULT_TEXTMODE
     if ((fptr->mode & FMODE_TEXTMODE) && (fmode & FMODE_BINMODE)) {
 	fptr->mode &= ~FMODE_TEXTMODE;

--- a/test/ruby/test_io.rb
+++ b/test/ruby/test_io.rb
@@ -113,6 +113,38 @@ class TestIO < Test::Unit::TestCase
     ].each{|thr| thr.join}
   end
 
+  def test_binmode_writer
+    EnvUtil.with_default_internal(Encoding::UTF_8) do
+      reader, writer = IO.pipe
+      reader.binmode
+      writer.binmode
+
+      reader2, writer2 = IO.pipe(binmode: true)
+
+      assert writer.binmode?
+      assert writer2.binmode?
+      assert_equal writer.binmode?, writer2.binmode?
+      assert_equal writer.external_encoding, writer2.external_encoding
+      assert_equal writer.internal_encoding, writer2.internal_encoding
+    end
+  end
+
+  def test_binmode_reader
+    EnvUtil.with_default_internal(Encoding::UTF_8) do
+      reader, writer = IO.pipe
+      reader.binmode
+      writer.binmode
+
+      reader2, writer2 = IO.pipe(binmode: true)
+
+      assert reader.binmode?
+      assert reader2.binmode?
+      assert_equal reader.binmode?, reader2.binmode?
+      assert_equal reader.external_encoding, reader2.external_encoding
+      assert_equal reader.internal_encoding, reader2.internal_encoding
+    end
+  end
+
   def test_pipe_block
     x = nil
     ret = IO.pipe {|r, w|

--- a/test/ruby/test_io.rb
+++ b/test/ruby/test_io.rb
@@ -113,35 +113,51 @@ class TestIO < Test::Unit::TestCase
     ].each{|thr| thr.join}
   end
 
-  def test_binmode_writer
+  def test_binmode_pipe
     EnvUtil.with_default_internal(Encoding::UTF_8) do
-      reader, writer = IO.pipe
-      reader.binmode
-      writer.binmode
+      EnvUtil.with_default_external(Encoding::UTF_8) do
+        reader, writer = IO.pipe
+        reader.binmode
+        writer.binmode
 
-      reader2, writer2 = IO.pipe(binmode: true)
+        reader1, writer1 = IO.pipe
 
-      assert writer.binmode?
-      assert writer2.binmode?
-      assert_equal writer.binmode?, writer2.binmode?
-      assert_equal writer.external_encoding, writer2.external_encoding
-      assert_equal writer.internal_encoding, writer2.internal_encoding
-    end
-  end
+        reader2, writer2 = IO.pipe(binmode: true)
+        assert_predicate writer, :binmode?
+        assert_predicate writer2, :binmode?
+        assert_equal writer.binmode?, writer2.binmode?
+        assert_equal writer.external_encoding, writer2.external_encoding
+        assert_equal writer.internal_encoding, writer2.internal_encoding
+        assert_predicate reader, :binmode?
+        assert_predicate reader2, :binmode?
+        assert_equal reader.binmode?, reader2.binmode?
+        assert_equal reader.external_encoding, reader2.external_encoding
+        assert_equal reader.internal_encoding, reader2.internal_encoding
 
-  def test_binmode_reader
-    EnvUtil.with_default_internal(Encoding::UTF_8) do
-      reader, writer = IO.pipe
-      reader.binmode
-      writer.binmode
+        reader3, writer3 = IO.pipe("UTF-8:UTF-8", binmode: true)
+        assert_predicate writer3, :binmode?
+        assert_equal writer1.external_encoding, writer3.external_encoding
+        assert_equal writer1.internal_encoding, writer3.internal_encoding
+        assert_predicate reader3, :binmode?
+        assert_equal reader1.external_encoding, reader3.external_encoding
+        assert_equal reader1.internal_encoding, reader3.internal_encoding
 
-      reader2, writer2 = IO.pipe(binmode: true)
+        reader4, writer4 = IO.pipe("UTF-8:UTF-8", binmode: true)
+        assert_predicate writer4, :binmode?
+        assert_equal writer1.external_encoding, writer4.external_encoding
+        assert_equal writer1.internal_encoding, writer4.internal_encoding
+        assert_predicate reader4, :binmode?
+        assert_equal reader1.external_encoding, reader4.external_encoding
+        assert_equal reader1.internal_encoding, reader4.internal_encoding
 
-      assert reader.binmode?
-      assert reader2.binmode?
-      assert_equal reader.binmode?, reader2.binmode?
-      assert_equal reader.external_encoding, reader2.external_encoding
-      assert_equal reader.internal_encoding, reader2.internal_encoding
+        reader5, writer5 = IO.pipe("UTF-8", "UTF-8", binmode: true)
+        assert_predicate writer5, :binmode?
+        assert_equal writer1.external_encoding, writer5.external_encoding
+        assert_equal writer1.internal_encoding, writer5.internal_encoding
+        assert_predicate reader5, :binmode?
+        assert_equal reader1.external_encoding, reader5.external_encoding
+        assert_equal reader1.internal_encoding, reader5.internal_encoding
+      end
     end
   end
 


### PR DESCRIPTION
When passing `binmode: true` to `IO.pipe`, it should behave the same way
as calling `binmode` on each of the file handles.  It should set the
file to binmode *and* set the encoding to binary on the file.

Before this commit, passing `binmode: true` to `IO.pipe` would make
`binmode?` return `true`, but the file's encoding would remain the same
as the default encoding.  Passing `binmode: true` should make `binmode?`
return `true` *and* set the encoding to binary (unless another encoding
was explicitly specified).