### PR TITLE
Allow non-finalizable objects in ObjectSpace::WeakMap

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -2986,18 +2986,12 @@ should_be_callable(VALUE block)
 }
 
 static void
-should_be_finalizable_internal(VALUE obj)
+should_be_finalizable(VALUE obj)
 {
     if (!FL_ABLE(obj)) {
 	rb_raise(rb_eArgError, "cannot define finalizer for %s",
 		 rb_obj_classname(obj));
     }
-}
-
-static void
-should_be_finalizable(VALUE obj)
-{
-    should_be_finalizable_internal(obj);
     rb_check_frozen(obj);
 }
 
@@ -10204,6 +10198,7 @@ wmap_allocate(VALUE klass)
 static int
 wmap_live_p(rb_objspace_t *objspace, VALUE obj)
 {
+    if (!FL_ABLE(obj)) return TRUE;
     if (!is_id_value(objspace, obj)) return FALSE;
     if (!is_live_object(objspace, obj)) return FALSE;
     return TRUE;
@@ -10461,10 +10456,13 @@ wmap_aset(VALUE self, VALUE wmap, VALUE orig)
     struct weakmap *w;
 
     TypedData_Get_Struct(self, struct weakmap, &weakmap_type, w);
-    should_be_finalizable_internal(orig);
-    should_be_finalizable_internal(wmap);
-    define_final0(orig, w->final);
-    define_final0(wmap, w->final);
+    if (FL_ABLE(orig)) {
+        define_final0(orig, w->final);
+    }
+    if (FL_ABLE(wmap)) {
+        define_final0(wmap, w->final);
+    }
+
     st_update(w->obj2wmap, (st_data_t)orig, wmap_aset_update, wmap);
     st_insert(w->wmap2obj, (st_data_t)wmap, (st_data_t)orig);
     return nonspecial_obj_id(orig);

--- a/test/ruby/test_weakmap.rb
+++ b/test/ruby/test_weakmap.rb
@@ -16,16 +16,27 @@ class TestWeakMap < Test::Unit::TestCase
 
   def test_aset_const
     x = Object.new
-    assert_raise(ArgumentError) {@wm[true] = x}
-    assert_raise(ArgumentError) {@wm[false] = x}
-    assert_raise(ArgumentError) {@wm[nil] = x}
-    assert_raise(ArgumentError) {@wm[42] = x}
-    assert_raise(ArgumentError) {@wm[:foo] = x}
-    assert_raise(ArgumentError) {@wm[x] = true}
-    assert_raise(ArgumentError) {@wm[x] = false}
-    assert_raise(ArgumentError) {@wm[x] = nil}
-    assert_raise(ArgumentError) {@wm[x] = 42}
-    assert_raise(ArgumentError) {@wm[x] = :foo}
+    @wm[true] = x
+    assert_same(x, @wm[true])
+    @wm[false] = x
+    assert_same(x, @wm[false])
+    @wm[nil] = x
+    assert_same(x, @wm[nil])
+    @wm[42] = x
+    assert_same(x, @wm[42])
+    @wm[:foo] = x
+    assert_same(x, @wm[:foo])
+
+    @wm[x] = true
+    assert_same(true, @wm[x])
+    @wm[x] = false
+    assert_same(false, @wm[x])
+    @wm[x] = nil
+    assert_same(nil, @wm[x])
+    @wm[x] = 42
+    assert_same(42, @wm[x])
+    @wm[x] = :foo
+    assert_same(:foo, @wm[x])
   end
 
   def assert_weak_include(m, k, n = 100)


### PR DESCRIPTION
This goes one step farther than what @nobu did in https://bugs.ruby-lang.org/issues/13498

With this patch, special objects such as static symbols, integers, etc can be used as either key or values inside WeakMap. They simply don't have a finalizer defined on them.

This is useful if you need to deduplicate value objects, e.g. some minimal use case:

```ruby
class Money
  REGISTRY = ObjectSpace::WeakMap.new
  private_constant :REGISTRY

  def self.new(amount)
    REGISTRY[amount] ||= super.freeze
  end

  def initialize(amount)
    @amount = amount
  end
end

if Money.new(42).eql?(Money.new(42))
  puts "Same instance"
else
  puts "Different instances"
end
```

This is a very simple example, but more complex examples can create use a dynamically created symbol as deduplication key, etc.

It also removes one weirdness introduced in the mentioned patch:

```ruby
wmap = ObjectSpace::WeakMap.new
wmap["foo".to_sym] = Object.new # works fine with dynamic symbols
wmap[:bar] = Object.new # cannot define finalizer for Symbol (ArgumentError)
```