### PR TITLE
`$LOAD_PATH.resolve_feature_path` should not raise

### DIFF
--- a/load.c
+++ b/load.c
@@ -991,7 +991,7 @@ rb_resolve_feature_path(VALUE klass, VALUE fname)
         sym = ID2SYM(rb_intern("so"));
         break;
       default:
-        load_failed(fname);
+        return Qnil;
     }
 
     return rb_ary_new_from_args(2, sym, path);

--- a/test/ruby/test_require.rb
+++ b/test/ruby/test_require.rb
@@ -857,5 +857,9 @@ class TestRequire < Test::Unit::TestCase
       $:.replace(paths)
       $".replace(loaded)
     end
+
+    def test_resolve_feature_path_with_missing_feature
+      assert_nil($LOAD_PATH.resolve_feature_path("superkalifragilisticoespialidoso"))
+    end
   end
 end


### PR DESCRIPTION
I think it's more friendly and easier to work with to return `nil` when the feature is not found in the $LOAD_PATH.