### PR TITLE
Try to improve Travis apt stability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,25 +69,42 @@ env:
 
   - &linux
     os: linux
+    # Sorry for showing "No command 'gcc-8' found", but there's no better way to
+    # set CC=gcc-8 without using `env`, which is already used by jobs sharing this.
     compiler: gcc-8
     before_install:
-      - sudo -E apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
-      - travis_apt_get_update
       - |-
-        sudo -E apt-get -yq --no-install-suggests --no-install-recommends $(travis_apt_get_options) install \
-          gcc-8 \
-          libffi-dev \
-          libgdbm-dev \
-          libgmp-dev \
-          libjemalloc-dev \
-          libncurses5-dev \
-          libncursesw5-dev \
-          libreadline6-dev \
-          libssl-dev \
-          libyaml-dev \
-          openssl \
-          valgrind \
-          zlib1g-dev
+        travis_retry bash -xc '
+          sudo -E apt-add-repository -y "ppa:ubuntu-toolchain-r/test" || (sleep 60; exit 1)
+        '
+      - |-
+        for seconds in 1 25 100 0; do
+          travis_apt_get_update
+          cat "${TRAVIS_HOME}/apt-get-update.log"; rm "${TRAVIS_HOME}/apt-get-update.log"
+
+          sudo -E apt-get -yq --no-install-suggests --no-install-recommends $(travis_apt_get_options) install \
+            gcc-8 \
+            libffi-dev \
+            libgdbm-dev \
+            libgmp-dev \
+            libjemalloc-dev \
+            libncurses5-dev \
+            libncursesw5-dev \
+            libreadline6-dev \
+            libssl-dev \
+            libyaml-dev \
+            openssl \
+            valgrind \
+            zlib1g-dev
+
+          if [[ $? = 0 ]]; then
+            break
+          elif [[ $seconds = 0 ]]; then
+            exit 1
+          else
+            sleep "$seconds"
+          fi
+        done
 
   - &osx
     os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,30 +24,15 @@ dist: xenial
 git:
   quiet: true
 
-addons:
-  apt:
-    config:
-      retries: true
-    update: true
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - gcc-8
-      - libffi-dev
-      - libgdbm-dev
-      - libgmp-dev
-      - libjemalloc-dev
-      - libncurses5-dev
-      - libncursesw5-dev
-      - libreadline6-dev
-      - libssl-dev
-      - libyaml-dev
-      - openssl
-      - valgrind
-      - zlib1g-dev
-  # # Travis homebrew addon is unstable for now. Use `before_install` instead.
-  # # https://travis-ci.community/t/osx-homebrew-addons-module-not-as-reliable-as-claimed/4054
-  # homebrew:
+# # Not using addons for stability. See `before_install` of `&linux` and `&osx`.
+# addons:
+#   # Travis apt addon is unstable even with `config.retries: true`.
+#   # https://github.com/travis-ci/travis-build/pull/1712
+#   apt:
+#
+#   # Travis homebrew addon is unstable for now. Use `before_install` instead.
+#   # https://travis-ci.community/t/osx-homebrew-addons-module-not-as-reliable-as-claimed/4054
+#   homebrew:
 
 cache:
   ccache: true
@@ -85,6 +70,24 @@ env:
   - &linux
     os: linux
     compiler: gcc-8
+    before_install:
+      - sudo -E apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
+      - travis_apt_get_update
+      - |-
+        sudo -E apt-get -yq --no-install-suggests --no-install-recommends $(travis_apt_get_options) install \
+          gcc-8 \
+          libffi-dev \
+          libgdbm-dev \
+          libgmp-dev \
+          libjemalloc-dev \
+          libncurses5-dev \
+          libncursesw5-dev \
+          libreadline6-dev \
+          libssl-dev \
+          libyaml-dev \
+          openssl \
+          valgrind \
+          zlib1g-dev
 
   - &osx
     os: osx


### PR DESCRIPTION
We've had too many Travis failures due to random `apt` failures these days. Even just today, we got 4 failures:
https://travis-ci.org/ruby/ruby/jobs/567802384
https://travis-ci.org/ruby/ruby/jobs/567802388
https://travis-ci.org/ruby/ruby/jobs/567695879
https://travis-ci.org/ruby/ruby/jobs/567666931

This clearly spoils our productivity, but Travis team stopped to retry these commands. Let me stop using the apt addon and implement retry logic on our own.