### PR TITLE
Let prev EP move again

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -5028,7 +5028,7 @@ gc_mark_imemo(rb_objspace_t *objspace, VALUE obj)
 	    GC_ASSERT(VM_ENV_ESCAPED_P(env->ep));
             gc_mark_values(objspace, (long)env->env_size, env->env);
 	    VM_ENV_FLAGS_SET(env->ep, VM_ENV_FLAG_WB_REQUIRED);
-            gc_mark_and_pin(objspace, (VALUE)rb_vm_env_prev_env(env));
+            gc_mark(objspace, (VALUE)rb_vm_env_prev_env(env));
 	    gc_mark(objspace, (VALUE)env->iseq);
 	}
 	return;
@@ -7867,9 +7867,9 @@ gc_ref_update_imemo(rb_objspace_t *objspace, VALUE obj)
         {
             rb_env_t *env = (rb_env_t *)obj;
             TYPED_UPDATE_IF_MOVED(objspace, rb_iseq_t *, env->iseq);
+            UPDATE_IF_MOVED(objspace, env->ep[VM_ENV_DATA_INDEX_ENV]);
             gc_update_values(objspace, (long)env->env_size, (VALUE *)env->env);
         }
-        break;
         break;
       case imemo_cref:
         UPDATE_IF_MOVED(objspace, RANY(obj)->as.imemo.cref.klass);


### PR DESCRIPTION
The last time we committed this, we were asking the VM to write to the
ep.  But VM assertions check if the ENV data is the correct type, which
if it's a T_MOVED pointer it's not the correct type.  So the vm
assertions would fail.  This time we just directly write to it from the
GC and that bypasses the vm assertion checks.