### PR TITLE
Add a way to print debug counters without exiting

### DIFF
--- a/debug_counter.c
+++ b/debug_counter.c
@@ -44,6 +44,13 @@ rb_debug_counter_show_results(const char *msg)
 }
 
 VALUE
+rb_debug_counter_show(void)
+{
+    rb_debug_counter_show_results("method call");
+    return Qnil;
+}
+
+VALUE
 rb_debug_counter_reset(void)
 {
     for (int i = 0; i < RB_DEBUG_COUNTER_MAX; i++) {

--- a/debug_counter.h
+++ b/debug_counter.h
@@ -350,6 +350,7 @@ rb_debug_counter_add(enum rb_debug_counter_type type, int add, int cond)
 }
 
 VALUE rb_debug_counter_reset(void);
+VALUE rb_debug_counter_show(void);
 
 #define RB_DEBUG_COUNTER_INC(type)                rb_debug_counter_add(RB_DEBUG_COUNTER_##type, 1, 1)
 #define RB_DEBUG_COUNTER_INC_UNLESS(type, cond) (!rb_debug_counter_add(RB_DEBUG_COUNTER_##type, 1, !(cond)))

--- a/vm.c
+++ b/vm.c
@@ -2916,6 +2916,7 @@ Init_VM(void)
     rb_define_singleton_method(rb_cRubyVM, "stat", vm_stat, -1);
 #if USE_DEBUG_COUNTER
     rb_define_singleton_method(rb_cRubyVM, "reset_debug_counters", rb_debug_counter_reset, 0);
+    rb_define_singleton_method(rb_cRubyVM, "show_debug_counters", rb_debug_counter_show, 0);
 #endif
 
     /* FrozenCore (hidden) */


### PR DESCRIPTION
I am trying to study debug counters inside a Rails application.
Accessing debug counters by killing the process is hard because child
processes don't get the same TRAP as the parent, and Rails seems to
intercept calls to `exit`.  Adding this method lets me print the debug
counters when I want (at the end of requests for example)