### PR TITLE
fix spelling

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -4767,8 +4767,8 @@ rb_f_getenv(VALUE obj, VALUE name)
  *
  * Retrieves the environment variable +name+.
  *
- * If the given name does not exist and neither +default+ nor a block a
- * provided an KeyError is raised.  If a block is given it is called with
+ * If the given name does not exist and neither +default+ nor a block is
+ * provided, a KeyError is raised.  If a block is given it is called with
  * the missing name to provide a value.  If a default value is given it will
  * be returned when no block is given.
  */


### PR DESCRIPTION
Just noticed these couple of minor spelling errors while reading some ruby docs & thought I'd fix them.

I also added the comma because my brain kept wanting to read "provided a KeyError is raised" as if it was an additional requirement (as in "X will occur, provided a KeyError is raised.").