### PR TITLE
introduce RUBY_ON_BUG envval.

### DIFF
--- a/error.c
+++ b/error.c
@@ -429,8 +429,9 @@ bug_report_file(const char *file, int line)
 
     if ((ssize_t)fwrite(buf, 1, len, out) == (ssize_t)len ||
 	(ssize_t)fwrite(buf, 1, len, (out = stdout)) == (ssize_t)len) {
-	return out;
+        return out;
     }
+
     return NULL;
 }
 
@@ -519,6 +520,17 @@ bug_report_begin_valist(FILE *out, const char *fmt, va_list args)
     snprintf(buf, sizeof(buf), "\n%s\n\n", ruby_description);
     fputs(buf, out);
     preface_dump(out);
+
+#if RUBY_DEVEL
+    const char *cmd = getenv("RUBY_ON_BUG");
+    if (cmd) {
+        snprintf(buf, sizeof(buf), "%s %d", cmd, getpid());
+        int r = system(buf);
+        if (r == -1) {
+            snprintf(buf, sizeof(buf), "Launching RUBY_ON_BUG command failed.");
+        }
+    }
+#endif
 }
 
 #define bug_report_begin(out, fmt) do { \


### PR DESCRIPTION
`rb_bug()` is called at critical bug, MRI can't run anymore.
To make debug easy, this patch introduces RUBY_ON_BUG environment
variable to specify the process which is called with pid.

  RUBY_ON_BUG='gdb -p' ruby xxx.rb

In this case, if ruby interpreter causes critical bug, and call
rb_bug(), then "gdb -p [PID]' is called by system(3). You can
debug on invoked gdb.

Ticket: https://bugs.ruby-lang.org/issues/16090