### PR TITLE
Unpin default value objects

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -10135,6 +10135,7 @@ wmap_compact(void *ptr)
     struct weakmap *w = ptr;
     if (w->wmap2obj) rb_gc_update_tbl_refs(w->wmap2obj);
     if (w->obj2wmap) rb_gc_update_tbl_refs(w->obj2wmap);
+    w->final = rb_gc_location(w->final);
 }
 
 static void
@@ -10144,7 +10145,7 @@ wmap_mark(void *ptr)
 #if WMAP_DELETE_DEAD_OBJECT_IN_MARK
     if (w->obj2wmap) st_foreach(w->obj2wmap, wmap_mark_map, (st_data_t)&rb_objspace);
 #endif
-    rb_gc_mark(w->final);
+    rb_gc_mark_no_pin(w->final);
 }
 
 static int

--- a/iseq.c
+++ b/iseq.c
@@ -305,7 +305,7 @@ rb_iseq_mark(const rb_iseq_t *iseq)
 	    for (j = 0; i < keyword->num; i++, j++) {
 		VALUE obj = keyword->default_values[j];
 		if (!SPECIAL_CONST_P(obj)) {
-		    rb_gc_mark(obj);
+		    rb_gc_mark_no_pin(obj);
 		}
 	    }
 	}


### PR DESCRIPTION
We're already updating the location of default values, so we may as well
unpin them.

Default values were already being updated [here](https://github.com/ruby/ruby/blob/e6dbade675ce27037d5bbf0e17f02da2600f011f/iseq.c#L249).

~~This change basically had no impact on our heap.  We went from 9235 pinned slots to 9039.~~  I still think it's good to unpin as much as possible!

I made a mistake measuring, this actually brought us down to 8462 pinned objects (out of 2665641)