### PR TITLE
Don't accidentally name anonymous module/class

### DIFF
--- a/test/ruby/test_module.rb
+++ b/test/ruby/test_module.rb
@@ -565,6 +565,24 @@ class TestModule < Test::Unit::TestCase
     assert_equal("TestModule::User",   User.name)
   end
 
+  def test_accidental_singleton_naming_with_module
+    o = Object.new
+    assert_nil(o.singleton_class.name)
+    class << o
+      module Hi; end
+    end
+    assert_nil(o.singleton_class.name)
+  end
+
+  def test_accidental_singleton_naming_with_class
+    o = Object.new
+    assert_nil(o.singleton_class.name)
+    class << o
+      class Hi; end
+    end
+    assert_nil(o.singleton_class.name)
+  end
+
   def test_classpath
     m = Module.new
     n = Module.new

--- a/variable.c
+++ b/variable.c
@@ -187,12 +187,6 @@ rb_search_class_path(VALUE klass)
 }
 
 static VALUE
-save_temporary_path(VALUE obj, VALUE name)
-{
-    return rb_ivar_set(obj, tmp_classpath, make_temporary_path(obj, name));
-}
-
-static VALUE
 build_const_pathname(VALUE head, VALUE tail)
 {
     VALUE path = rb_str_dup(head);
@@ -219,7 +213,7 @@ rb_set_class_path_string(VALUE klass, VALUE under, VALUE name)
     }
     else {
 	int permanent;
-        str = rb_tmp_class_path(under, &permanent, save_temporary_path);
+        str = rb_tmp_class_path(under, &permanent, make_temporary_path);
         str = build_const_pathname(str, name);
 	if (!permanent) {
 	    pathid = tmp_classpath;
@@ -231,23 +225,9 @@ rb_set_class_path_string(VALUE klass, VALUE under, VALUE name)
 void
 rb_set_class_path(VALUE klass, VALUE under, const char *name)
 {
-    VALUE str;
-    ID pathid = classpath;
-
-    if (under == rb_cObject) {
-	str = rb_str_new2(name);
-    }
-    else {
-	int permanent;
-	str = rb_str_dup(rb_tmp_class_path(under, &permanent, save_temporary_path));
-	rb_str_cat2(str, "::");
-	rb_str_cat2(str, name);
-	if (!permanent) {
-	    pathid = tmp_classpath;
-	}
-    }
+    VALUE str = rb_str_new2(name);
     OBJ_FREEZE(str);
-    rb_ivar_set(klass, pathid, str);
+    rb_set_class_path_string(klass, under, str);
 }
 
 VALUE


### PR DESCRIPTION
b00f280d4b9569e7153365d7e1c522b3d6b3c6cf introduced
an accidental behavior change in that defining a module/class under
`m` gives `m` a name when `m` is anonymous.

`ruby -ve 'Module.new { class self::A; end; p name }'` outputs a name
similar to `Module#inspect` when it should output `nil` like in Ruby
2.6.x.

 * variable.c: Use `make_temporary_path` instead of `save_temporary_path`
   when getting the name of the parent module.

 * variable.c (rb_set_class_path): Delegate to `rb_set_class_path_string`
   instead of duplicating the logic.


[Bug #16097](https://bugs.ruby-lang.org/issues/16097)