### PR TITLE
Rename rb_gc_mark_no_pin -> rb_gc_mark_movable

### DIFF
--- a/cont.c
+++ b/cont.c
@@ -858,7 +858,7 @@ cont_mark(void *ptr)
     rb_context_t *cont = ptr;
 
     RUBY_MARK_ENTER("cont");
-    rb_gc_mark_no_pin(cont->value);
+    rb_gc_mark_movable(cont->value);
 
     rb_execution_context_mark(&cont->saved_ec);
     rb_gc_mark(cont_thread_value(cont));
@@ -967,7 +967,7 @@ void
 rb_fiber_mark_self(const rb_fiber_t *fiber)
 {
     if (fiber->cont.self) {
-        rb_gc_mark_no_pin(fiber->cont.self);
+        rb_gc_mark_movable(fiber->cont.self);
     }
     else {
         rb_execution_context_mark(&fiber->cont.saved_ec);
@@ -992,7 +992,7 @@ fiber_mark(void *ptr)
     rb_fiber_t *fiber = ptr;
     RUBY_MARK_ENTER("cont");
     fiber_verify(fiber);
-    rb_gc_mark_no_pin(fiber->first_proc);
+    rb_gc_mark_movable(fiber->first_proc);
     if (fiber->prev) rb_fiber_mark_self(fiber->prev);
     cont_mark(&fiber->cont);
     RUBY_MARK_LEAVE("cont");

--- a/gc.c
+++ b/gc.c
@@ -4984,7 +4984,7 @@ gc_mark(rb_objspace_t *objspace, VALUE obj)
 }
 
 void
-rb_gc_mark_no_pin(VALUE ptr)
+rb_gc_mark_movable(VALUE ptr)
 {
     gc_mark(&rb_objspace, ptr);
 }
@@ -10145,7 +10145,7 @@ wmap_mark(void *ptr)
 #if WMAP_DELETE_DEAD_OBJECT_IN_MARK
     if (w->obj2wmap) st_foreach(w->obj2wmap, wmap_mark_map, (st_data_t)&rb_objspace);
 #endif
-    rb_gc_mark_no_pin(w->final);
+    rb_gc_mark_movable(w->final);
 }
 
 static int

--- a/gc.h
+++ b/gc.h
@@ -59,7 +59,7 @@ rb_gc_debug_body(const char *mode, const char *msg, int st, void *ptr)
 
 #define RUBY_MARK_NO_PIN_UNLESS_NULL(ptr) do { \
     VALUE markobj = (ptr); \
-    if (RTEST(markobj)) {rb_gc_mark_no_pin(markobj);} \
+    if (RTEST(markobj)) {rb_gc_mark_movable(markobj);} \
 } while (0)
 #define RUBY_MARK_UNLESS_NULL(ptr) do { \
     VALUE markobj = (ptr); \

--- a/include/ruby/intern.h
+++ b/include/ruby/intern.h
@@ -515,7 +515,7 @@ void rb_mark_hash(struct st_table*);
 void rb_update_st_references(struct st_table *ht);
 void rb_gc_mark_maybe(VALUE);
 void rb_gc_mark(VALUE);
-void rb_gc_mark_no_pin(VALUE);
+void rb_gc_mark_movable(VALUE);
 VALUE rb_gc_location(VALUE);
 void rb_gc_force_recycle(VALUE);
 void rb_gc(void);

--- a/iseq.c
+++ b/iseq.c
@@ -271,7 +271,7 @@ rb_iseq_update_references(rb_iseq_t *iseq)
 static VALUE
 each_insn_value(void *ctx, VALUE obj)
 {
-    rb_gc_mark_no_pin(obj);
+    rb_gc_mark_movable(obj);
     return obj;
 }
 
@@ -289,11 +289,11 @@ rb_iseq_mark(const rb_iseq_t *iseq)
 	    rb_iseq_each_value(iseq, each_insn_value, NULL);
 	}
 
-        rb_gc_mark_no_pin(body->variable.coverage);
-        rb_gc_mark_no_pin(body->variable.pc2branchindex);
-        rb_gc_mark_no_pin(body->location.label);
-        rb_gc_mark_no_pin(body->location.base_label);
-        rb_gc_mark_no_pin(body->location.pathobj);
+        rb_gc_mark_movable(body->variable.coverage);
+        rb_gc_mark_movable(body->variable.pc2branchindex);
+        rb_gc_mark_movable(body->location.label);
+        rb_gc_mark_movable(body->location.base_label);
+        rb_gc_mark_movable(body->location.pathobj);
         RUBY_MARK_NO_PIN_UNLESS_NULL((VALUE)body->parent_iseq);
 
 	if (body->param.flags.has_kw && ISEQ_COMPILE_DATA(iseq) == NULL) {
@@ -305,7 +305,7 @@ rb_iseq_mark(const rb_iseq_t *iseq)
 	    for (j = 0; i < keyword->num; i++, j++) {
 		VALUE obj = keyword->default_values[j];
 		if (!SPECIAL_CONST_P(obj)) {
-                    rb_gc_mark_no_pin(obj);
+                    rb_gc_mark_movable(obj);
 		}
 	    }
 	}
@@ -317,7 +317,7 @@ rb_iseq_mark(const rb_iseq_t *iseq)
 		const struct iseq_catch_table_entry *entry;
 		entry = UNALIGNED_MEMBER_PTR(table, entries[i]);
 		if (entry->iseq) {
-                    rb_gc_mark_no_pin((VALUE)entry->iseq);
+                    rb_gc_mark_movable((VALUE)entry->iseq);
 		}
 	    }
 	}

--- a/proc.c
+++ b/proc.c
@@ -297,7 +297,7 @@ binding_mark(void *ptr)
 
     RUBY_MARK_ENTER("binding");
     block_mark(&bind->block);
-    rb_gc_mark_no_pin(bind->pathobj);
+    rb_gc_mark_movable(bind->pathobj);
     RUBY_MARK_LEAVE("binding");
 }
 
@@ -1363,10 +1363,10 @@ static void
 bm_mark(void *ptr)
 {
     struct METHOD *data = ptr;
-    rb_gc_mark_no_pin(data->recv);
-    rb_gc_mark_no_pin(data->klass);
-    rb_gc_mark_no_pin(data->iclass);
-    rb_gc_mark_no_pin((VALUE)data->me);
+    rb_gc_mark_movable(data->recv);
+    rb_gc_mark_movable(data->klass);
+    rb_gc_mark_movable(data->iclass);
+    rb_gc_mark_movable((VALUE)data->me);
 }
 
 static void

--- a/variable.c
+++ b/variable.c
@@ -1896,7 +1896,7 @@ autoload_i_mark(void *ptr)
 {
     struct autoload_data_i *p = ptr;
 
-    rb_gc_mark_no_pin(p->feature);
+    rb_gc_mark_movable(p->feature);
 
     /* allow GC to free us if no modules refer to this via autoload_const.ad */
     if (list_empty(&p->constants)) {
@@ -1942,9 +1942,9 @@ autoload_c_mark(void *ptr)
 {
     struct autoload_const *ac = ptr;
 
-    rb_gc_mark_no_pin(ac->mod);
-    rb_gc_mark_no_pin(ac->ad);
-    rb_gc_mark_no_pin(ac->value);
+    rb_gc_mark_movable(ac->mod);
+    rb_gc_mark_movable(ac->ad);
+    rb_gc_mark_movable(ac->value);
 }
 
 static void

--- a/vm.c
+++ b/vm.c
@@ -2481,14 +2481,14 @@ rb_execution_context_mark(const rb_execution_context_t *ec)
 	while (cfp != limit_cfp) {
 	    const VALUE *ep = cfp->ep;
 	    VM_ASSERT(!!VM_ENV_FLAGS(ep, VM_ENV_FLAG_ESCAPED) == vm_ep_in_heap_p_(ec, ep));
-            rb_gc_mark_no_pin(cfp->self);
-            rb_gc_mark_no_pin((VALUE)cfp->iseq);
-            rb_gc_mark_no_pin((VALUE)cfp->block_code);
+            rb_gc_mark_movable(cfp->self);
+            rb_gc_mark_movable((VALUE)cfp->iseq);
+            rb_gc_mark_movable((VALUE)cfp->block_code);
 
 	    if (!VM_ENV_LOCAL_P(ep)) {
 		const VALUE *prev_ep = VM_ENV_PREV_EP(ep);
 		if (VM_ENV_FLAGS(prev_ep, VM_ENV_FLAG_ESCAPED)) {
-                    rb_gc_mark_no_pin(prev_ep[VM_ENV_DATA_INDEX_ENV]);
+                    rb_gc_mark_movable(prev_ep[VM_ENV_DATA_INDEX_ENV]);
 		}
 	    }
 


### PR DESCRIPTION
Renaming this function.  "No pin" leaks some implementation details.  We
just want users to know that if they mark this object, the reference may
move and they'll need to update the reference accordingly.