### PR TITLE
Use the official actions/checkout again

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,8 +21,10 @@ jobs:
         run: |
           brew update
           brew install gdbm gmp libffi openssl@1.1 zlib autoconf automake libtool readline
-      - name: Checkout # not using actions/checkout because it's unstable.
-        run: git clone --depth=50 https://github.com/ruby/ruby .
+      - name: Checkout
+        uses: actions/checkout@master
+        with:
+          fetch-depth: 50
       - name: Set ENV
         run: |
           echo '##[set-env name=JOBS]'-j$((1 + $(sysctl -n hw.activecpu)))

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -20,8 +20,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install ruby2.5
           sudo apt-get build-dep ruby2.5
-      - name: Checkout # not using actions/checkout because it's unstable.
-        run: git clone --depth=50 https://github.com/ruby/ruby .
+      - name: Checkout
+        uses: actions/checkout@master
+        with:
+          fetch-depth: 50
       - name: Set ENV
         run: |
           export JOBS=-j$((1 + $(nproc --all)))

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -31,8 +31,10 @@ jobs:
           dependencies: openssl readline zlib
       - name: Install libraries with chocolatey
         run: choco install winflexbison3
-      - name: Checkout # not using actions/checkout because it's unstable.
-        run: git clone --depth=50 https://github.com/ruby/ruby .
+      - name: Checkout
+        uses: actions/checkout@master
+        with:
+          fetch-depth: 50
       - name: configure
         run: |
           call "C:\Program Files (x86)\Microsoft Visual Studio\${{ matrix.vs }}\Enterprise\VC\Auxiliary\Build\vcvars64.bat"


### PR DESCRIPTION
because clone does not checkout exact commit sha, and also we'd need to handle
pull_request on fork, so I tentatively stopped to do this.