### PR TITLE
Stop using official actions/checkout

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,10 +21,19 @@ jobs:
         run: |
           brew update
           brew install gdbm gmp libffi openssl@1.1 zlib autoconf automake libtool readline
-      - name: Checkout
-        uses: actions/checkout@master
-        with:
-          fetch-depth: 50
+      # Not using official actions/checkout because it's unstable and sometimes doesn't work for a fork.
+      - name: Checkout ruby/ruby
+        run: git clone --depth=50 https://github.com/ruby/ruby . && git reset --hard "$GITHUB_SHA"
+        env:
+          GITHUB_SHA: ${{ github.sha }}
+        if: github.event_name == 'push'
+      - name: Checkout a pull request
+        run: git clone --depth=50 "--branch=$GITHUB_BRANCH" "https://github.com/${GITHUB_REPO}" . && git reset --hard "$GITHUB_REV"
+        env:
+          GITHUB_REV: ${{ github.event.pull_request.head.sha }}
+          GITHUB_BRANCH: ${{ github.event.pull_request.head.ref }}
+          GITHUB_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+        if: github.event_name == 'pull_request'
       - name: Set ENV
         run: |
           echo '##[set-env name=JOBS]'-j$((1 + $(sysctl -n hw.activecpu)))

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -20,10 +20,19 @@ jobs:
           sudo apt-get update
           sudo apt-get install ruby2.5
           sudo apt-get build-dep ruby2.5
-      - name: Checkout
-        uses: actions/checkout@master
-        with:
-          fetch-depth: 50
+      # Not using official actions/checkout because it's unstable and sometimes doesn't work for a fork.
+      - name: Checkout ruby/ruby
+        run: git clone --depth=50 https://github.com/ruby/ruby . && git reset --hard "$GITHUB_SHA"
+        env:
+          GITHUB_SHA: ${{ github.sha }}
+        if: github.event_name == 'push'
+      - name: Checkout a pull request
+        run: git clone --depth=50 "--branch=$GITHUB_BRANCH" "https://github.com/${GITHUB_REPO}" . && git reset --hard "$GITHUB_REV"
+        env:
+          GITHUB_REV: ${{ github.event.pull_request.head.sha }}
+          GITHUB_BRANCH: ${{ github.event.pull_request.head.ref }}
+          GITHUB_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+        if: github.event_name == 'pull_request'
       - name: Set ENV
         run: |
           export JOBS=-j$((1 + $(nproc --all)))

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -31,10 +31,19 @@ jobs:
           dependencies: openssl readline zlib
       - name: Install libraries with chocolatey
         run: choco install winflexbison3
-      - name: Checkout
-        uses: actions/checkout@master
-        with:
-          fetch-depth: 50
+      # Not using official actions/checkout because it's unstable and sometimes doesn't work for a fork.
+      - name: Checkout ruby/ruby
+        run: git clone --depth=50 https://github.com/ruby/ruby . && git reset --hard "$GITHUB_SHA"
+        env:
+          GITHUB_SHA: ${{ github.sha }}
+        if: github.event_name == 'push'
+      - name: Checkout a pull request
+        run: git clone --depth=50 "--branch=$GITHUB_BRANCH" "https://github.com/${GITHUB_REPO}" . && git reset --hard "$GITHUB_REV"
+        env:
+          GITHUB_REV: ${{ github.event.pull_request.head.sha }}
+          GITHUB_BRANCH: ${{ github.event.pull_request.head.ref }}
+          GITHUB_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+        if: github.event_name == 'pull_request'
       - name: configure
         run: |
           call "C:\Program Files (x86)\Microsoft Visual Studio\${{ matrix.vs }}\Enterprise\VC\Auxiliary\Build\vcvars64.bat"


### PR DESCRIPTION
because it has been unstable, and also it sometimes does not work for a pull request like:
https://github.com/ruby/ruby/pull/2358/checks?check_run_id=192685048#step:4:17