### PR TITLE
change Proc#to_s format ('@...' -> ' ...')

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -370,7 +370,7 @@ class Gem::Installer
       if hook.call(self) == false
         FileUtils.rm_rf gem_dir
 
-        location = " at #{$1}" if hook.inspect =~ /@(.*:\d+)/
+        location = " at #{$1}" if hook.inspect =~ / (.*:\d+)/
 
         message = "post-build hook#{location} failed for #{spec.full_name}"
         raise Gem::InstallError, message

--- a/proc.c
+++ b/proc.c
@@ -1310,7 +1310,7 @@ rb_block_to_s(VALUE self, const struct rb_block *block, const char *additional_i
       case block_type_iseq:
 	{
 	    const rb_iseq_t *iseq = rb_iseq_check(block->as.captured.code.iseq);
-	    rb_str_catf(str, "%p@%"PRIsVALUE":%d", (void *)self,
+	    rb_str_catf(str, "%p %"PRIsVALUE":%d", (void *)self,
 			rb_iseq_path(iseq),
 			FIX2INT(iseq->body->location.first_lineno));
 	}

--- a/spec/ruby/core/proc/shared/to_s.rb
+++ b/spec/ruby/core/proc/shared/to_s.rb
@@ -1,7 +1,7 @@
 describe :proc_to_s, shared: true do
   describe "for a proc created with Proc.new" do
     it "returns a description optionally including file and line number" do
-      Proc.new { "hello" }.send(@method).should =~ /^#<Proc:([^ ]*?)(@([^ ]*)\/to_s\.rb:4)?>$/
+      Proc.new { "hello" }.send(@method).should =~ /^#<Proc:([^ ]*?)( ([^ ]*)\/to_s\.rb:4)?>$/
     end
 
     it "has a binary encoding" do
@@ -11,7 +11,7 @@ describe :proc_to_s, shared: true do
 
   describe "for a proc created with lambda" do
     it "returns a description including '(lambda)' and optionally including file and line number" do
-      -> { "hello" }.send(@method).should =~ /^#<Proc:([^ ]*?)(@([^ ]*)\/to_s\.rb:10)? \(lambda\)>$/
+      -> { "hello" }.send(@method).should =~ /^#<Proc:([^ ]*?)( ([^ ]*)\/to_s\.rb:14)? \(lambda\)>$/
     end
 
     it "has a binary encoding" do
@@ -21,7 +21,7 @@ describe :proc_to_s, shared: true do
 
   describe "for a proc created with proc" do
     it "returns a description optionally including file and line number" do
-      proc { "hello" }.send(@method).should =~ /^#<Proc:([^ ]*?)(@([^ ]*)\/to_s\.rb:16)?>$/
+      proc { "hello" }.send(@method).should =~ /^#<Proc:([^ ]*?)( ([^ ]*)\/to_s\.rb:24)?>$/
     end
 
     it "has a binary encoding" do
@@ -32,7 +32,7 @@ describe :proc_to_s, shared: true do
   describe "for a proc created with UnboundMethod#to_proc" do
     it "returns a description including '(lambda)' and optionally including file and line number" do
       def hello; end
-      method("hello").to_proc.send(@method).should =~ /^#<Proc:([^ ]*?)(@([^ ]*)\/to_s\.rb:22)? \(lambda\)>$/
+      method("hello").to_proc.send(@method).should =~ /^#<Proc:([^ ]*?)( ([^ ]*)\/to_s\.rb:22)? \(lambda\)>$/
     end
 
     it "has a binary encoding" do

--- a/test/ruby/test_proc.rb
+++ b/test/ruby/test_proc.rb
@@ -1188,8 +1188,8 @@ class TestProc < Test::Unit::TestCase
   end
 
   def test_to_s
-    assert_match(/^#<Proc:0x\h+@#{ Regexp.quote(__FILE__) }:\d+>$/, proc {}.to_s)
-    assert_match(/^#<Proc:0x\h+@#{ Regexp.quote(__FILE__) }:\d+ \(lambda\)>$/, lambda {}.to_s)
+    assert_match(/^#<Proc:0x\h+ #{ Regexp.quote(__FILE__) }:\d+>$/, proc {}.to_s)
+    assert_match(/^#<Proc:0x\h+ #{ Regexp.quote(__FILE__) }:\d+ \(lambda\)>$/, lambda {}.to_s)
     assert_match(/^#<Proc:0x\h+ \(lambda\)>$/, method(:p).to_proc.to_s)
     x = proc {}
     x.taint


### PR DESCRIPTION
Now Proc#to_s returns
"#<Proc:0x00000237a0f5f170@t.rb:1>".
However, it is convenient to select a file name by (double-)clicking
on some terminals by separating ' ' instead of '@' like
"#<Proc:0x00000237a0f5f170 t.rb:1>"
[Feature #16101]