### PR TITLE
Mark bundler / bundled-gems as continue-on-failure

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -41,10 +41,19 @@ jobs:
       - name: configure
         run: ./configure -C --disable-install-doc --with-openssl-dir=$(brew --prefix openssl@1.1) --with-readline-dir=$(brew --prefix readline)
       - run: make $JOBS
-      - name: make check/test-bundler/test-bundled-gems
+      - name: make check
         run: make -s ${{ matrix.test_task }}
         env:
           TESTOPTS: "$JOBS -q --tty=no"
           MSPECOPT: "-ff" # not using `-j` because sometimes `mspec -j` silently dies
+        if: matrix.test_task == 'check'
+      # test-bundler/test-bundled-gems are separated because it randomly fails and ends up cancelling `make check`.
+      # TODO: Remove `continue-on-error` once they become stable and also we have a notification for their failure.
+      - name: make test-bundler/test-bundled-gems
+        run: make -s ${{ matrix.test_task }}
+        env:
+          TESTOPTS: "$JOBS -q --tty=no"
+        continue-on-error: true
+        if: matrix.test_task != 'check'
       - name: Leaked Globals
         run: make -s leaked-globals

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -44,7 +44,9 @@ jobs:
       - name: configure
         run: ./configure -C --disable-install-doc
       - run: make $JOBS
+      # TODO: Remove `continue-on-error` once they become stable and also we have a notification for their failure.
       - name: make test-bundler/test-bundled-gems
         run: make -s ${{ matrix.test_task }}
+        continue-on-error: true
       - name: Leaked Globals
         run: make -s leaked-globals


### PR DESCRIPTION
because these tests have failed too often and it's false-positive for
checking healthiness of the master branch.