### PR TITLE
Improve the doc example of `method_missing`

### DIFF
--- a/vm_eval.c
+++ b/vm_eval.c
@@ -634,9 +634,14 @@ NORETURN(static void raise_method_missing(rb_execution_context_t *ec, int argc, 
  *       def roman_to_int(str)
  *         # ...
  *       end
- *       def method_missing(methId)
- *         str = methId.id2name
- *         roman_to_int(str)
+ *
+ *       def method_missing(symbol, *args)
+ *         str = symbol.id2name
+ *         begin
+ *           roman_to_int(str)
+ *         rescue
+ *           super(symbol, *args)
+ *         end
  *       end
  *     end
  *
@@ -644,6 +649,7 @@ NORETURN(static void raise_method_missing(rb_execution_context_t *ec, int argc, 
  *     r.iv      #=> 4
  *     r.xxiii   #=> 23
  *     r.mm      #=> 2000
+ *     r.foo     #=> NoMethodError
  */
 
 static VALUE


### PR DESCRIPTION
Improvements are:
* Use `symbol` instead of `methId`, described in doc
* Add `*args` following method signature
* Rescue error in `roman_to_int` and calls `super`, recommended in doc
* Call invalid `foo` method to Roman object to raise NoMethodError