### PR TITLE
Fix document of `GC.start`

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -7279,7 +7279,7 @@ garbage_collect_with_gvl(rb_objspace_t *objspace, int reason)
  *     ObjectSpace.garbage_collect(full_mark: true, immediate_sweep: true) -> nil
  *     include GC; garbage_collect(full_mark: true, immediate_sweep: true) -> nil
  *
- *  Initiates garbage collection, unless manually disabled.
+ *  Initiates garbage collection, even if manually disabled.
  *
  *  This method is defined with keyword arguments that default to true:
  *


### PR DESCRIPTION
The documentation of `GC.start` says "Initiates garbage collection, unless manually disabled.".
But actually, it starts garbage collection even if it is manually disabled, since 121b6e064a1b167dddbdc271d503ff96e7deb83b.

https://github.com/ruby/ruby/blob/800d205799175734c937693e2a85fceddfce2ffc/test/ruby/test_gc.rb#L392-L401



So this change updates the documentation.
