### PR TITLE
Remove unused variable to suppress warning

### DIFF
--- a/sample/observ.rb
+++ b/sample/observ.rb
@@ -27,5 +27,5 @@ class Clock
   end
 end
 
-clock = Clock.new(Tick.new)
+Clock.new(Tick.new)
 sleep


### PR DESCRIPTION
```shell
ruby -w sample/observ.rb
```

```
sample/observ.rb:30: warning: assigned but unused variable - clock
```