### PR TITLE
Update moved objects in original_iseq

### DIFF
--- a/iseq.c
+++ b/iseq.c
@@ -236,6 +236,14 @@ rb_iseq_update_references(rb_iseq_t *iseq)
         }
         if (FL_TEST(iseq, ISEQ_MARKABLE_ISEQ)) {
             rb_iseq_each_value(iseq, update_each_insn_value, NULL);
+            VALUE *original_iseq = ISEQ_ORIGINAL_ISEQ(iseq);
+            if (original_iseq) {
+                size_t n = 0;
+                const unsigned int size = body->iseq_size;
+                while (n < size) {
+                    n += iseq_extract_values(original_iseq, n, update_each_insn_value, NULL, rb_vm_insn_null_translator);
+                }
+            }
         }
 
         if (body->param.flags.has_kw && ISEQ_COMPILE_DATA(iseq) == NULL) {


### PR DESCRIPTION
Without doing this, enabling a TracePoint on a method could lead to use
of moved objects. This was found by running
`env RUBY_ISEQ_DUMP_DEBUG=to_binary make test-all`, which sets
orignal_iseq then runs the compaction tests and the tracepoint tests.

Please excuse the lack of tests. I was not able to figure out how to
reliably trigger a move on a specific iseq imemo to make a good
regression test.

To manually confirm the problem and this fix, you can run:
```
env RUBY_ISEQ_DUMP_DEBUG=to_binary make test-all \
  TESTOPTS="test/ruby/test_gc_compact.rb \
            test/gdbm/test_gdbm.rb \
            test/ruby/test_settracefunc.rb"
```

Or the following script:

```ruby
tp = TracePoint.new(:line) {}
1.times do # put it in a block to not keep these objects alive
  objects = 10_000.times.map { Object.new }
  objects.hash
end

1.times do
  # this allocation pattern can realistically happen in an app
  # at load time
  beek = 10_000.times.map do
    eval(<<-RUBY)
      def foo
        a + b
        1.times {
          4 + 234234
        }
        nil + 234
      end
    RUBY
    Object.new
    Object.new
  end
  beek.hash
end

tp.enable(target: self.:foo) { 234 } # allocate original iseq

GC.verify_compaction_references(toward: :empty)
GC.compact

tp.enable(target: self.:foo) { 234234 } # crash
```

@tenderlove 
[Bug #16098](https://bugs.ruby-lang.org/issues/16098)