### PR TITLE
Avoid creating Hash objects per each `mon_synchronize` call

### DIFF
--- a/lib/monitor.rb
+++ b/lib/monitor.rb
@@ -87,6 +87,9 @@
 # MonitorMixin module.
 #
 module MonitorMixin
+  EXCEPTION_NEVER = {Exception => :never}.freeze
+  EXCEPTION_IMMEDIATE = {Exception => :immediate}.freeze
+
   #
   # FIXME: This isn't documented in Nutshell.
   #
@@ -103,11 +106,11 @@ module MonitorMixin
     # even if no other thread doesn't signal.
     #
     def wait(timeout = nil)
-      Thread.handle_interrupt(Exception => :never) do
+      Thread.handle_interrupt(EXCEPTION_NEVER) do
         @monitor.__send__(:mon_check_owner)
         count = @monitor.__send__(:mon_exit_for_cond)
         begin
-          Thread.handle_interrupt(Exception => :immediate) do
+          Thread.handle_interrupt(EXCEPTION_IMMEDIATE) do
             @cond.wait(@monitor.instance_variable_get(:@mon_mutex), timeout)
           end
           return true
@@ -227,11 +230,11 @@ module MonitorMixin
   def mon_synchronize
     # Prevent interrupt on handling interrupts; for example timeout errors
     # it may break locking state.
-    Thread.handle_interrupt(Exception => :never){ mon_enter }
+    Thread.handle_interrupt(EXCEPTION_NEVER){ mon_enter }
     begin
       yield
     ensure
-      Thread.handle_interrupt(Exception => :never){ mon_exit }
+      Thread.handle_interrupt(EXCEPTION_NEVER){ mon_exit }
     end
   end
   alias synchronize mon_synchronize


### PR DESCRIPTION
since f91879a7b548284c93743168acfd11e3d2aeefac, Rails apps became significantly more memory consuming.

For instance, here's the number of allocated objects and allocated memory size in monitor.rb that I measured on a vanilla Rails 6.1 app's scaffolded `show` action.

```
allocated objects by location
-----------------------------------
        59  ruby/lib/monitor.rb:231
        58  ruby/lib/monitor.rb:235

allocated memory by location
-----------------------------------
     10608  ruby/lib/monitor.rb:231
     10440  ruby/lib/monitor.rb:235
```

This is because Rails (especially Active Record) heavily abuses Monitor, and so total amount of Hash creations from `mon_synchronize` becomes unignorable.
(You'll see what I mean by searching "synchronize do" within this file https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb )

So, here's a patch that simply stores `{Exception => :never}` and like.

After this patch, Hash allocations obviously reduces (9KB per `show` request).

```
allocated objects by location
-----------------------------------
        29  ruby/lib/monitor.rb:233
        29  ruby/lib/monitor.rb:237

allocated memory by location
-----------------------------------
      5568  ruby/lib/monitor.rb:231
      5568  ruby/lib/monitor.rb:235
```