### PR TITLE
`rp(obj)` shows func, file and line.

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -11449,6 +11449,13 @@ rb_obj_info_dump(VALUE obj)
     fprintf(stderr, "rb_obj_info_dump: %s\n", rb_raw_obj_info(buff, 0x100, obj));
 }
 
+void
+rb_obj_info_dump_loc(VALUE obj, const char *file, int line, const char *func)
+{
+    char buff[0x100];
+    fprintf(stderr, "<OBJ_INFO:%s@%s:%d> %s\n", func, file, line, rb_raw_obj_info(buff, 0x100, obj));
+}
+
 #if GC_DEBUG
 
 void

--- a/internal.h
+++ b/internal.h
@@ -1390,10 +1390,12 @@ rb_ary_entry_internal(VALUE ary, long offset)
 
 /* MRI debug support */
 void rb_obj_info_dump(VALUE obj);
-void  ruby_debug_breakpoint(void);
+void rb_obj_info_dump_loc(VALUE obj, const char *file, int line, const char *func);
+void ruby_debug_breakpoint(void);
 
 // show obj data structure without any side-effect
-#define rp(obj) rb_obj_info_dump((VALUE)obj);
+#define rp(obj) rb_obj_info_dump_loc((VALUE)(obj), __FILE__, __LINE__, __func__)
+
 // same as rp, but add message header
 #define rp_m(msg, obj) do { \
     fprintf(stderr, "%s", (msg)); \


### PR DESCRIPTION
rp() macro for debug also shows file location and function name
such as:

  [OBJ_INFO:rb_call_inits@inits.c:73] 0x000056147741b248 ...