### PR TITLE
Remove github_action_linux tag from bundler examples.

### DIFF
--- a/spec/bundler/commands/exec_spec.rb
+++ b/spec/bundler/commands/exec_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "bundle exec" do
     expect(out).to eq("hi")
   end
 
-  it "respects custom process title when loading through ruby", :github_action_linux do
+  it "respects custom process title when loading through ruby" do
     script_that_changes_its_own_title_and_checks_if_picked_up_by_ps_unix_utility = <<~'RUBY'
       Process.setproctitle("1-2-3-4-5-6-7-8-9-10-11-12-13-14-15")
       puts `ps -ocommand= -p#{$$}`

--- a/spec/bundler/spec_helper.rb
+++ b/spec/bundler/spec_helper.rb
@@ -71,7 +71,6 @@ RSpec.configure do |config|
   config.filter_run_excluding :bundler => RequirementChecker.against(Bundler::VERSION.split(".")[0])
   config.filter_run_excluding :ruby_repo => !ENV["GEM_COMMAND"].nil?
   config.filter_run_excluding :no_color_tty => Gem.win_platform? || !ENV["GITHUB_ACTION"].nil?
-  config.filter_run_excluding :github_action_linux => !ENV["GITHUB_ACTION"].nil? && (ENV["RUNNER_OS"] == "Linux")
 
   config.filter_run_when_matching :focus unless ENV["CI"]
 


### PR DESCRIPTION
  Maybe it has fixed at 5a384e2c08704dc7af9d8d3bdfc475eb8c0723aa