### PR TITLE
Let the transient heap belong to objspace

### DIFF
--- a/internal.h
+++ b/internal.h
@@ -1597,6 +1597,9 @@ extern int ruby_disable_gc;
 void Init_heap(void);
 void *ruby_mimmalloc(size_t size);
 void ruby_mimfree(void *ptr);
+#if USE_TRANSIENT_HEAP
+struct transient_heap *rb_objspace_get_theap(void);
+#endif
 void rb_objspace_set_event_hook(const rb_event_flag_t event);
 #if USE_RGENGC
 void rb_gc_writebarrier_remember(VALUE obj);

--- a/transient_heap.h
+++ b/transient_heap.h
@@ -13,6 +13,94 @@
 
 #if USE_TRANSIENT_HEAP
 
+/*
+ * 1: enable assertions
+ * 2: enable verify all transient heaps
+ */
+#ifndef TRANSIENT_HEAP_CHECK_MODE
+#define TRANSIENT_HEAP_CHECK_MODE 0
+#endif
+#define TH_ASSERT(expr) RUBY_ASSERT_MESG_WHEN(TRANSIENT_HEAP_CHECK_MODE > 0, expr, #expr)
+
+/*
+ * 1: show events
+ * 2: show dump at events
+ * 3: show all operations
+ */
+#define TRANSIENT_HEAP_DEBUG 0
+
+/* For Debug: Provide blocks infinitely.
+ * This mode generates blocks unlimitedly
+ * and prohibit access free'ed blocks to check invalid access.
+ */
+#define TRANSIENT_HEAP_DEBUG_INFINITE_BLOCK 0
+
+#if TRANSIENT_HEAP_DEBUG_INFINITE_BLOCK
+#include <sys/mman.h>
+#include <errno.h>
+#endif
+
+/* For Debug: Prohibit promoting to malloc space.
+ */
+#define TRANSIENT_HEAP_DEBUG_DONT_PROMOTE 0
+
+/* size configuration */
+#define TRANSIENT_HEAP_PROMOTED_DEFAULT_SIZE 1024
+
+                                          /*  K      M */
+#define TRANSIENT_HEAP_BLOCK_SIZE  (1024 *   32       ) /* 32KB int16_t */
+#define TRANSIENT_HEAP_TOTAL_SIZE  (1024 * 1024 *   32) /* 32 MB */
+#define TRANSIENT_HEAP_ALLOC_MAX   (1024 *    2       ) /* 2 KB */
+#define TRANSIENT_HEAP_BLOCK_NUM   (TRANSIENT_HEAP_TOTAL_SIZE / TRANSIENT_HEAP_BLOCK_SIZE)
+
+#define TRANSIENT_HEAP_ALLOC_MAGIC 0xfeab
+#define TRANSIENT_HEAP_ALLOC_ALIGN RUBY_ALIGNOF(void *)
+
+#define TRANSIENT_HEAP_ALLOC_MARKING_LAST -1
+#define TRANSIENT_HEAP_ALLOC_MARKING_FREE -2
+
+enum transient_heap_status {
+    transient_heap_none,
+    transient_heap_marking,
+    transient_heap_escaping
+};
+
+struct transient_heap_block {
+    struct transient_heap_block_header {
+        int16_t size; /* sizeof(block) = TRANSIENT_HEAP_BLOCK_SIZE - sizeof(struct transient_heap_block_header) */
+        int16_t index;
+        int16_t last_marked_index;
+        int16_t objects;
+        struct transient_heap_block *next_block;
+    } info;
+    char buff[TRANSIENT_HEAP_BLOCK_SIZE - sizeof(struct transient_heap_block_header)];
+};
+
+struct transient_heap {
+    struct transient_heap_block *using_blocks;
+    struct transient_heap_block *marked_blocks;
+    struct transient_heap_block *free_blocks;
+    int total_objects;
+    int total_marked_objects;
+    int total_blocks;
+    enum transient_heap_status status;
+
+    VALUE *promoted_objects;
+    int promoted_objects_size;
+    int promoted_objects_index;
+
+    struct transient_heap_block *arena;
+    int arena_index; /* increment only */
+};
+
+struct transient_alloc_header {
+    uint16_t magic;
+    uint16_t size;
+    int16_t next_marked_index;
+    int16_t dummy;
+    VALUE obj;
+};
+
 /* public API */
 
 /* Allocate req_size bytes from transient_heap.


### PR DESCRIPTION
As per comment from @nobu in https://github.com/ruby/ruby/pull/2303#issuecomment-523248875 , I took an initial stab @ a tighter integration between objspace and the transient heap.

### Benefits

* Multi-VM (MVM) friendly - ( vm -> objspace -> theap )
* The 32MB (current size) arena lazy allocated on ruby init is now properly freed on shutdown as well
* It feels strange that the evacuation from the current global theap is to objspace, whereas the space evacuated from is a global arena.

### Not so great

* A fast reference to a global variable `global_transient_heap` becomes a function call to `rb_objspace_get_theap()` and related pointer chasing from vm -> objspace -> theap
* Some internal transient heap structs moved to the header file now leaks into all other reference sites where this source file (`transient_heap.c`) as previously just used for API
* I'm not sure exactly of the boundary Koichi had in mind for the GC compile module and how tightly it should (or shouldn't) be coupled to the transient heap. `struct rb_objspace*` declarations elsewhere for example reveals nothing about the structure members for example, whereas with this PR a lot of transient heap internals are exposed via the header file now
* Also possible to move `transient_heap.c` into `gc.c` - I feel theap is not an experimental feature anymore and has been stable for quite some time with plausible performance benefits. The downside of that is `gc.c` is quite dense already, but then all ruby heap management concerns belong to one compile unit.

Thoughts?