### PR TITLE
Add word "Euler's number" to Math::E docs

### DIFF
--- a/math.c
+++ b/math.c
@@ -982,7 +982,7 @@ InitVM_Math(void)
     rb_define_const(rb_mMath, "PI", DBL2NUM(M_PI));
 
 #ifdef M_E
-    /*  Definition of the mathematical constant E (e) as a Float number. */
+    /*  Definition of the mathematical constant for Euler's number E (e) as a Float number. */
     rb_define_const(rb_mMath, "E", DBL2NUM(M_E));
 #else
     rb_define_const(rb_mMath, "E", DBL2NUM(exp(1.0)));


### PR DESCRIPTION
When searching for this constant, I landed on the correct page https://ruby-doc.org/core-2.6.4/Math.html however I was using CMD+f to search for "Euler" and did not find it. If we add the full name for this constant then it will be easier to search for and find.