### PR TITLE
Move pread + pwrite tests out of RUBY_ENGINE block

### DIFF
--- a/test/ruby/test_io.rb
+++ b/test/ruby/test_io.rb
@@ -3813,28 +3813,28 @@ __END__
         end
       end
     end
-
-    def test_pread
-      make_tempfile { |t|
-        open(t.path) do |f|
-          assert_equal("bar", f.pread(3, 4))
-          buf = "asdf"
-          assert_equal("bar", f.pread(3, 4, buf))
-          assert_equal("bar", buf)
-          assert_raise(EOFError) { f.pread(1, f.size) }
-        end
-      }
-    end if IO.method_defined?(:pread)
-
-    def test_pwrite
-      make_tempfile { |t|
-        open(t.path, IO::RDWR) do |f|
-          assert_equal(3, f.pwrite("ooo", 4))
-          assert_equal("ooo", f.pread(3, 4))
-        end
-      }
-    end if IO.method_defined?(:pread) and IO.method_defined?(:pwrite)
   end
+
+  def test_pread
+    make_tempfile { |t|
+      open(t.path) do |f|
+        assert_equal("bar", f.pread(3, 4))
+        buf = "asdf"
+        assert_equal("bar", f.pread(3, 4, buf))
+        assert_equal("bar", buf)
+        assert_raise(EOFError) { f.pread(1, f.size) }
+      end
+    }
+  end if IO.method_defined?(:pread)
+
+  def test_pwrite
+    make_tempfile { |t|
+      open(t.path, IO::RDWR) do |f|
+        assert_equal(3, f.pwrite("ooo", 4))
+        assert_equal("ooo", f.pread(3, 4))
+      end
+    }
+  end if IO.method_defined?(:pread) and IO.method_defined?(:pwrite)
 
   def test_select_exceptfds
     if Etc.uname[:sysname] == 'SunOS' && Etc.uname[:release] == '5.11'


### PR DESCRIPTION
These tests were guarded by a RUBY_ENGINE of "ruby" even though they test an official Ruby feature (pread/pwrite added in Ruby 2.5). This commit moves them to the top level of the test case so they will run on other implementations.

This should be backported to Ruby 2.6 and 2.5 for implementations testing against those versions.