### PR TITLE
Directly mark node objects instead of using a mark array

### DIFF
--- a/node.c
+++ b/node.c
@@ -1225,6 +1225,9 @@ mark_ast_value(void *ctx, NODE * node)
         case NODE_DXSTR:
         case NODE_DREGX:
         case NODE_DSYM:
+        case NODE_ARGS:
+        case NODE_FOR:
+        case NODE_ARYPTN:
             rb_gc_mark(node->nd_lit);
             break;
     }

--- a/node.c
+++ b/node.c
@@ -1276,6 +1276,8 @@ mark_ast_value(void *ctx, NODE * node)
         case NODE_ARYPTN:
             rb_gc_mark(node->nd_lit);
             break;
+        default:
+            rb_bug("unreachable");
     }
 }
 

--- a/node.c
+++ b/node.c
@@ -1149,7 +1149,7 @@ rb_node_buffer_new(void)
     node_buffer_t *nb = xmalloc(sizeof(node_buffer_t) + (bucket_size * 2));
     init_node_buffer_list(&nb->unmarkable, (node_buffer_elem_t*)&nb[1]);
     init_node_buffer_list(&nb->markable, (node_buffer_elem_t*)((size_t)nb->unmarkable.head + bucket_size));
-    nb->mark_ary = rb_ary_tmp_new(0);
+    nb->mark_ary = Qnil;
     return nb;
 }
 
@@ -1222,9 +1222,7 @@ rb_ast_t *
 rb_ast_new(void)
 {
     node_buffer_t *nb = rb_node_buffer_new();
-    VALUE mark_ary = nb->mark_ary;
     rb_ast_t *ast = (rb_ast_t *)rb_imemo_new(imemo_ast, 0, 0, 0, (VALUE)nb);
-    RB_OBJ_WRITTEN(ast, Qnil, mark_ary);
     return ast;
 }
 
@@ -1337,5 +1335,8 @@ rb_ast_dispose(rb_ast_t *ast)
 void
 rb_ast_add_mark_object(rb_ast_t *ast, VALUE obj)
 {
+    if (NIL_P(ast->node_buffer->mark_ary)) {
+        RB_OBJ_WRITE(ast, &ast->node_buffer->mark_ary, rb_ary_tmp_new(0));
+    }
     rb_ary_push(ast->node_buffer->mark_ary, obj);
 }

--- a/node.c
+++ b/node.c
@@ -1218,6 +1218,15 @@ static void
 mark_ast_value(void *ctx, NODE * node)
 {
     switch (nd_type(node)) {
+        case NODE_SCOPE:
+        {
+            ID *buf = node->nd_tbl;
+            if (buf) {
+                unsigned int size = (unsigned int)*buf;
+                rb_gc_mark((VALUE)buf[size + 1]);
+            }
+            break;
+        }
         case NODE_LIT:
         case NODE_STR:
         case NODE_XSTR:
@@ -1226,7 +1235,6 @@ mark_ast_value(void *ctx, NODE * node)
         case NODE_DREGX:
         case NODE_DSYM:
         case NODE_ARGS:
-        case NODE_FOR:
         case NODE_ARYPTN:
             rb_gc_mark(node->nd_lit);
             break;

--- a/node.h
+++ b/node.h
@@ -409,7 +409,7 @@ void rb_ast_dispose(rb_ast_t*);
 void rb_ast_free(rb_ast_t*);
 size_t rb_ast_memsize(const rb_ast_t*);
 void rb_ast_add_mark_object(rb_ast_t*, VALUE);
-NODE *rb_ast_newnode(rb_ast_t*);
+NODE *rb_ast_newnode(rb_ast_t*, enum node_type type);
 void rb_ast_delete_node(rb_ast_t*, NODE *n);
 
 VALUE rb_parser_new(void);

--- a/parse.y
+++ b/parse.y
@@ -299,7 +299,7 @@ struct parser_params {
 };
 
 #define new_tmpbuf() \
-    (rb_imemo_tmpbuf_t *)add_mark_object(p, rb_imemo_tmpbuf_auto_free_pointer(NULL))
+    (rb_imemo_tmpbuf_t *)add_tmpbuf_mark_object(p, rb_imemo_tmpbuf_auto_free_pointer(NULL))
 
 #define intern_cstr(n,l,en) rb_intern3(n,l,en)
 
@@ -337,6 +337,13 @@ rb_discard_node(struct parser_params *p, NODE *n)
 {
     rb_ast_delete_node(p->ast, n);
 }
+
+static inline VALUE
+add_tmpbuf_mark_object(struct parser_params *p, VALUE obj)
+{
+    rb_ast_add_mark_object(p->ast, obj);
+    return obj;
+}
 #endif
 
 static inline VALUE
@@ -347,7 +354,11 @@ add_mark_object(struct parser_params *p, VALUE obj)
 	&& !RB_TYPE_P(obj, T_NODE) /* Ripper jumbles NODE objects and other objects... */
 #endif
     ) {
+#ifdef RIPPER
 	rb_ast_add_mark_object(p->ast, obj);
+#else
+        RB_OBJ_WRITTEN(p->ast, Qundef, obj);
+#endif
     }
     return obj;
 }

--- a/parse.y
+++ b/parse.y
@@ -9605,9 +9605,7 @@ literal_concat(struct parser_params *p, NODE *head, NODE *tail, const YYLTYPE *l
 	    goto append;
 	}
 	else {
-	    nd_set_type(tail, NODE_ARRAY);
-	    tail->nd_head = NEW_STR(tail->nd_lit, loc);
-	    list_concat(head, tail);
+	    list_concat(head, NEW_NODE(NODE_ARRAY, NEW_STR(tail->nd_lit, loc), tail->nd_alen, tail->nd_next, loc));
 	}
 	break;
 

--- a/parse.y
+++ b/parse.y
@@ -9351,7 +9351,7 @@ yylex(YYSTYPE *lval, YYLTYPE *yylloc, struct parser_params *p)
 static NODE*
 node_newnode(struct parser_params *p, enum node_type type, VALUE a0, VALUE a1, VALUE a2, const rb_code_location_t *loc)
 {
-    NODE *n = rb_ast_newnode(p->ast);
+    NODE *n = rb_ast_newnode(p->ast, type);
 
     rb_node_init(n, type, a0, a1, a2);
 

--- a/parse.y
+++ b/parse.y
@@ -2797,10 +2797,10 @@ primary		: literal
 			ID id = internal_id(p);
 			NODE *m = NEW_ARGS_AUX(0, 0, &NULL_LOC);
 			NODE *args, *scope, *internal_var = NEW_DVAR(id, &@2);
-			rb_imemo_tmpbuf_t *tmpbuf = new_tmpbuf();
 			ID *tbl = ALLOC_N(ID, 2);
+			VALUE tmpbuf = rb_imemo_tmpbuf_auto_free_pointer(tbl);
+                        RB_OBJ_WRITTEN(p->ast, Qnil, tmpbuf);
 			tbl[0] = 1 /* length of local var table */; tbl[1] = id /* internal id */;
-			tmpbuf->ptr = (VALUE *)tbl;
 
 			switch (nd_type($2)) {
 			  case NODE_LASGN:
@@ -2821,6 +2821,7 @@ primary		: literal
 			args = new_args(p, m, 0, id, 0, new_args_tail(p, 0, 0, 0, &@2), &@2);
 			scope = NEW_NODE(NODE_SCOPE, tbl, $5, args, &@$);
 			$$ = NEW_FOR($4, scope, &@$);
+                        $$->nd_lit = tmpbuf;
 			fixpos($$, $2);
 		    /*% %*/
 		    /*% ripper: for!($2, $4, $5) %*/
@@ -11130,11 +11131,11 @@ new_args_tail(struct parser_params *p, NODE *kw_args, ID kw_rest_arg, ID block, 
     int saved_line = p->ruby_sourceline;
     struct rb_args_info *args;
     NODE *node;
-    rb_imemo_tmpbuf_t *tmpbuf = new_tmpbuf();
 
     args = ZALLOC(struct rb_args_info);
-    tmpbuf->ptr = (VALUE *)args;
-    node = NEW_NODE(NODE_ARGS, 0, 0, args, &NULL_LOC);
+    VALUE tmpbuf = rb_imemo_tmpbuf_auto_free_pointer(args);
+    RB_OBJ_WRITTEN(p->ast, Qnil, tmpbuf);
+    node = NEW_NODE(NODE_ARGS, tmpbuf, 0, args, &NULL_LOC);
     if (p->error_p) return node;
 
     args->block_arg      = block;
@@ -11239,11 +11240,11 @@ new_array_pattern_tail(struct parser_params *p, NODE *pre_args, int has_rest, ID
     int saved_line = p->ruby_sourceline;
     struct rb_ary_pattern_info *apinfo;
     NODE *node;
-    rb_imemo_tmpbuf_t *tmpbuf = new_tmpbuf();
 
     apinfo = ZALLOC(struct rb_ary_pattern_info);
-    tmpbuf->ptr = (VALUE *)apinfo;
-    node = NEW_NODE(NODE_ARYPTN, 0, 0, apinfo, loc);
+    VALUE tmpbuf = rb_imemo_tmpbuf_auto_free_pointer(apinfo);
+    node = NEW_NODE(NODE_ARYPTN, tmpbuf, 0, apinfo, loc);
+    RB_OBJ_WRITTEN(p->ast, Qnil, tmpbuf);
 
     apinfo->pre_args = pre_args;
 

--- a/parse.y
+++ b/parse.y
@@ -298,9 +298,6 @@ struct parser_params {
 #endif
 };
 
-#define new_tmpbuf() \
-    (rb_imemo_tmpbuf_t *)add_tmpbuf_mark_object(p, rb_imemo_tmpbuf_auto_free_pointer(NULL))
-
 #define intern_cstr(n,l,en) rb_intern3(n,l,en)
 
 #define STR_NEW(ptr,len) rb_enc_str_new((ptr),(len),p->enc)
@@ -336,13 +333,6 @@ static inline void
 rb_discard_node(struct parser_params *p, NODE *n)
 {
     rb_ast_delete_node(p->ast, n);
-}
-
-static inline VALUE
-add_tmpbuf_mark_object(struct parser_params *p, VALUE obj)
-{
-    rb_ast_add_mark_object(p->ast, obj);
-    return obj;
 }
 #endif
 
@@ -2797,10 +2787,11 @@ primary		: literal
 			ID id = internal_id(p);
 			NODE *m = NEW_ARGS_AUX(0, 0, &NULL_LOC);
 			NODE *args, *scope, *internal_var = NEW_DVAR(id, &@2);
-			ID *tbl = ALLOC_N(ID, 2);
+			ID *tbl = ALLOC_N(ID, 3);
 			VALUE tmpbuf = rb_imemo_tmpbuf_auto_free_pointer(tbl);
                         RB_OBJ_WRITTEN(p->ast, Qnil, tmpbuf);
 			tbl[0] = 1 /* length of local var table */; tbl[1] = id /* internal id */;
+                        tbl[2] = tmpbuf;
 
 			switch (nd_type($2)) {
 			  case NODE_LASGN:
@@ -2821,7 +2812,6 @@ primary		: literal
 			args = new_args(p, m, 0, id, 0, new_args_tail(p, 0, 0, 0, &@2), &@2);
 			scope = NEW_NODE(NODE_SCOPE, tbl, $5, args, &@$);
 			$$ = NEW_FOR($4, scope, &@$);
-                        $$->nd_lit = tmpbuf;
 			fixpos($$, $2);
 		    /*% %*/
 		    /*% ripper: for!($2, $4, $5) %*/
@@ -11627,11 +11617,9 @@ local_tbl(struct parser_params *p)
     int cnt = cnt_args + cnt_vars;
     int i, j;
     ID *buf;
-    rb_imemo_tmpbuf_t *tmpbuf = new_tmpbuf();
 
     if (cnt <= 0) return 0;
-    buf = ALLOC_N(ID, cnt + 1);
-    tmpbuf->ptr = (void *)buf;
+    buf = ALLOC_N(ID, cnt + 2);
     MEMCPY(buf+1, p->lvtbl->args->tbl, ID, cnt_args);
     /* remove IDs duplicated to warn shadowing */
     for (i = 0, j = cnt_args+1; i < cnt_vars; ++i) {
@@ -11640,8 +11628,12 @@ local_tbl(struct parser_params *p)
 	    buf[j++] = id;
 	}
     }
-    if (--j < cnt) tmpbuf->ptr = (void *)REALLOC_N(buf, ID, (cnt = j) + 1);
+    if (--j < cnt) REALLOC_N(buf, ID, (cnt = j) + 2);
     buf[0] = cnt;
+
+    VALUE tmpbuf = rb_imemo_tmpbuf_auto_free_pointer(buf);
+    buf[cnt + 1] = (ID)tmpbuf;
+    RB_OBJ_WRITTEN(p->ast, Qnil, tmpbuf);
 
     return buf;
 }


### PR DESCRIPTION
This patch changes the AST mark function so that it will walk through
nodes in the NODE buffer marking Ruby objects rather than using a mark
array to guarantee liveness.  The reason I want to do this is so that
when compaction happens on major GCs, node objects will have their
references pinned (or possibly we can update them correctly).