### PR TITLE
Prohibit nul-separated glob pattern [Feature #14643]

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -79,6 +79,13 @@ Complex::
 
     * Added Complex#<=>. So 0 <=> 0i will not raise NoMethodError. [Bug #15857]
 
+Dir::
+
+  Modified method::
+
+    * Dir#glob and Dir#[] no longer allow NUL-separated glob pattern.
+      Use Array instead.  [Feature #14643]
+
 Encoding::
 
   * Added new encoding CESU-8 [Feature #15931]

--- a/spec/ruby/core/dir/shared/glob.rb
+++ b/spec/ruby/core/dir/shared/glob.rb
@@ -30,12 +30,18 @@ describe :dir_glob, shared: true do
     end
   end
 
-  ruby_version_is "2.6" do
+  ruby_version_is "2.6"..."2.7" do
     it "splits the string on \\0 if there is only one string given and warns" do
       -> {
         Dir.send(@method, "file_o*\0file_t*").should ==
           %w!file_one.ext file_two.ext!
       }.should complain(/warning: use glob patterns list instead of nul-separated patterns/)
+    end
+  end
+
+  ruby_version_is "2.7" do
+    it "raises an ArgumentError if the string contains \\0" do
+      -> {Dir.send(@method, "file_o*\0file_t*")}.should raise_error ArgumentError, /nul-separated/
     end
   end
 

--- a/test/ruby/test_dir.rb
+++ b/test/ruby/test_dir.rb
@@ -138,9 +138,8 @@ class TestDir < Test::Unit::TestCase
                  Dir.glob(File.join(@root, "*"), File::FNM_DOTMATCH).sort)
     assert_equal([@root] + ("a".."z").map {|f| File.join(@root, f) }.sort,
                  Dir.glob([@root, File.join(@root, "*")]).sort)
-    assert_warning(/nul-separated patterns/) do
-      assert_equal([@root] + ("a".."z").map {|f| File.join(@root, f) }.sort,
-                   Dir.glob(@root + "\0\0\0" + File.join(@root, "*")).sort)
+    assert_raise_with_message(ArgumentError, /nul-separated/) do
+      Dir.glob(@root + "\0\0\0" + File.join(@root, "*"))
     end
 
     assert_equal(("a".."z").step(2).map {|f| File.join(File.join(@root, f), "") }.sort,


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/14643#change-81318