### PR TITLE
Avoid defining unused instructions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -154,7 +154,7 @@ env:
     <<: *cron-only
     <<: *make-test-only
     env:
-      - BEFORE_INSTALL="sed vm_opts.h -e 's/SUPPORT_JOKE *0/SUPPORT_JOKE 1/' -i"
+      - BEFORE_INSTALL="sed vm_opts.h -e 's/OPT_SUPPORT_JOKE *0/OPT_SUPPORT_JOKE 1/' -i"
 
   - &WITH_COROUTINE_UCONTEXT
     name: COROUTINE=ucontext

--- a/insns.def
+++ b/insns.def
@@ -624,7 +624,7 @@ reverse
 }
 
 /* for stack caching. */
-DEFINE_INSN
+DEFINE_INSN_IF(STACK_CACHING)
 reput
 ()
 (..., VALUE val)
@@ -1485,7 +1485,7 @@ opt_call_c_function
 }
 
 /* BLT */
-DEFINE_INSN
+DEFINE_INSN_IF(SUPPORT_JOKE)
 bitblt
 ()
 ()
@@ -1495,7 +1495,7 @@ bitblt
 }
 
 /* The Answer to Life, the Universe, and Everything */
-DEFINE_INSN
+DEFINE_INSN_IF(SUPPORT_JOKE)
 answer
 ()
 ()

--- a/tool/ruby_vm/loaders/insns_def.rb
+++ b/tool/ruby_vm/loaders/insns_def.rb
@@ -11,6 +11,7 @@
 # details.
 
 require_relative '../helpers/scanner'
+require_relative './vm_opts_h'
 
 json    = []
 scanner = RubyVM::Scanner.new '../../../insns.def'
@@ -33,7 +34,7 @@ grammar = %r'
                  (?<pragma:name> \g<ident>  )              \g<ws>*
                  =                                         \g<ws>*
                  (?<pragma:expr> .+?;       )              \g<ws>* ){0}
-    (?<insn>     DEFINE_INSN                               \g<ws>+
+    (?<insn>     DEFINE_INSN(_IF\((?<insn:if>\w+)\))?      \g<ws>+
                  (?<insn:name>   \g<ident>  )              \g<ws>*
      [(] \g<ws>* (?<insn:opes>   \g<argv>   ) \g<ws>* [)]  \g<ws>*
      [(] \g<ws>* (?<insn:pops>   \g<argv>   ) \g<ws>* [)]  \g<ws>*
@@ -52,6 +53,7 @@ until scanner.eos? do
 
   l1   = scanner.scan!(/\G#{grammar}\g<insn>/o)
   name = scanner["insn:name"]
+  opt  = scanner["insn:if"]
   ope  = split.(scanner["insn:opes"])
   pop  = split.(scanner["insn:pops"])
   ret  = split.(scanner["insn:rets"])
@@ -67,21 +69,23 @@ until scanner.eos? do
   end
 
   l3 = scanner.scan!(/\G#{grammar}\g<block>/o)
-  json << {
-    name: name,
-    location: [path, l1],
-    signature: {
+  if opt.nil? || RubyVM::VmOptsH[opt]
+    json << {
       name: name,
-      ope: ope,
-      pop: pop,
-      ret: ret,
-    },
-    attributes: attrs,
-    expr: {
-      location: [path, l3],
-      expr: scanner["block"],
-    },
-  }
+      location: [path, l1],
+      signature: {
+        name: name,
+        ope: ope,
+        pop: pop,
+        ret: ret,
+      },
+      attributes: attrs,
+      expr: {
+        location: [path, l3],
+        expr: scanner["block"],
+      },
+    }
+  end
 end
 
 RubyVM::InsnsDef = json

--- a/vm_opts.h
+++ b/vm_opts.h
@@ -61,7 +61,8 @@
 #define OPT_STACK_CACHING            0
 
 /* misc */
-#define SUPPORT_JOKE                 0
+#define OPT_SUPPORT_JOKE             0
+#define SUPPORT_JOKE OPT_SUPPORT_JOKE
 
 #ifndef VM_COLLECT_USAGE_DETAILS
 #define VM_COLLECT_USAGE_DETAILS     0


### PR DESCRIPTION
Defining unused instructions increases the code size and might be cache-inefficient.

I also think it would be less confusing if `RubyVM::INSTRUCTION_NAMES` were not including never-used instruction names.