### PR TITLE
Make Enumerator::Lazy#with_index be lazy

### DIFF
--- a/spec/ruby/core/enumerator/lazy/shared/to_enum.rb
+++ b/spec/ruby/core/enumerator/lazy/shared/to_enum.rb
@@ -43,7 +43,6 @@ describe :enumerator_lazy_to_enum, shared: true do
       each_entry: [],
       each_cons: [2]
     }.each_pair do |method, args|
-      @infinite.method(method).owner.should_not equal(Enumerator::Lazy)
       @infinite.send(method, *args).should be_an_instance_of(Enumerator::Lazy)
     end
   end

--- a/test/ruby/test_lazy_enumerator.rb
+++ b/test/ruby/test_lazy_enumerator.rb
@@ -587,4 +587,26 @@ EOS
     assert_equal([4, 6, 6, 4, 0, 4], e.first(6))
     assert_equal([4, 6, 6, 4, 0, 4], e.first(6))
   end
+
+  def test_with_index
+    feature7877 = '[ruby-dev:47025] [Feature #7877]'
+    leibniz = ->(n) {
+      (0..Float::INFINITY).lazy.with_index {|i, j|
+        raise IndexError, "limit exceeded (#{n})" unless j < n
+        ((-1) ** j) / (2*i+1).to_f
+      }.take(n).reduce(:+)
+    }
+    assert_nothing_raised(IndexError, feature7877) {
+      assert_in_epsilon(Math::PI/4, leibniz[1000])
+    }
+
+    ary = (0..Float::INFINITY).lazy.with_index(2) {|i, j| [i-1, j] }.take(2).to_a
+    assert_equal([[-1, 2], [0, 3]], ary)
+
+    ary = (0..Float::INFINITY).lazy.with_index(2).take(2).to_a
+    assert_equal([[0, 2], [1, 3]], ary)
+
+    ary = (0..Float::INFINITY).lazy.with_index.take(2).to_a
+    assert_equal([[0, 0], [1, 1]], ary)
+  end
 end


### PR DESCRIPTION
Previously, Enumerator::Lazy#with_index was not defined, so it
picked up the default implementation from Enumerator, which was
not lazy.

Adding this support made rubyspec fail, and the underlying cause is that Enumerator#Lazy#{to_enum,enum_for} was actually broken if you passed
it a method that Enumerator#Lazy defined to operate lazily.  Previously,
Ruby would have the following behavior:

```ruby
      [1,2,3].to_enum(:map).to_a
      # => [1, 2, 3]
      [1,2,3].lazy.to_enum(:map).to_a
      # => []
```

This adds a poor work-around of implicitly calling the implementation in
Enumerable/Enumerator so that you get the correct results.  However,
a better fix for the problem should probably be implemented by someone
more familiar with how Enumerator::Lazy works.

The Enumerator::Lazy#with_index implementation is based on earlier
patch from @nobu .

Fixes Ruby Bug 7877.