### PR TITLE
Do not turn on keyword_init for Struct subclass if keyword hash is empty

### DIFF
--- a/struct.c
+++ b/struct.c
@@ -538,7 +538,7 @@ rb_struct_s_def(int argc, VALUE *argv, VALUE klass)
 	    keyword_ids[0] = rb_intern("keyword_init");
 	}
         rb_get_kwargs(argv[argc-1], keyword_ids, 0, 1, &keyword_init);
-        if(keyword_init == Qundef) {
+        if (keyword_init == Qundef) {
             keyword_init = Qfalse;
         }
 	--argc;

--- a/struct.c
+++ b/struct.c
@@ -516,7 +516,7 @@ rb_struct_define_under(VALUE outer, const char *name, ...)
 static VALUE
 rb_struct_s_def(int argc, VALUE *argv, VALUE klass)
 {
-    VALUE name, rest, keyword_init;
+    VALUE name, rest, keyword_init = Qfalse;
     long i;
     VALUE st;
     st_table *tbl;
@@ -532,18 +532,16 @@ rb_struct_s_def(int argc, VALUE *argv, VALUE klass)
     }
 
     if (RB_TYPE_P(argv[argc-1], T_HASH)) {
-	VALUE kwargs[1];
 	static ID keyword_ids[1];
 
 	if (!keyword_ids[0]) {
 	    keyword_ids[0] = rb_intern("keyword_init");
 	}
-	rb_get_kwargs(argv[argc-1], keyword_ids, 0, 1, kwargs);
+        rb_get_kwargs(argv[argc-1], keyword_ids, 0, 1, &keyword_init);
+        if(keyword_init == Qundef) {
+            keyword_init = Qfalse;
+        }
 	--argc;
-	keyword_init = kwargs[0];
-    }
-    else {
-	keyword_init = Qfalse;
     }
 
     rest = rb_ident_hash_new();

--- a/test/ruby/test_struct.rb
+++ b/test/ruby/test_struct.rb
@@ -96,6 +96,10 @@ module TestStruct
     assert_equal([:utime, :stime, :cutime, :cstime], Process.times.members)
   end
 
+  def test_struct_new_with_empty_hash
+    assert_equal({:a=>1}, Struct.new(:a, {}).new({:a=>1}).a)
+  end
+
   def test_struct_new_with_keyword_init
     @Struct.new("KeywordInitTrue", :a, :b, keyword_init: true)
     @Struct.new("KeywordInitFalse", :a, :b, keyword_init: false)


### PR DESCRIPTION
This was accidentally turned on because there was no checking for
Qundef.

Also, since only a single keyword is currently supported, simplify
the rb_get_kwargs call.