### PR TITLE
Fix keyword argument warnings for define_method and symbol procs

### DIFF
--- a/cont.c
+++ b/cont.c
@@ -1802,7 +1802,7 @@ rb_fiber_start(void)
         th->ec->root_svar = Qfalse;
 
         EXEC_EVENT_HOOK(th->ec, RUBY_EVENT_FIBER_SWITCH, th->self, 0, 0, 0, Qnil);
-        cont->value = rb_vm_invoke_proc(th->ec, proc, argc, argv, 0 /* kw_splat */, VM_BLOCK_HANDLER_NONE);
+        cont->value = rb_vm_invoke_proc(th->ec, proc, argc, argv, VM_NO_KEYWORDS, VM_BLOCK_HANDLER_NONE);
     }
     EC_POP_TAG();
 

--- a/cont.c
+++ b/cont.c
@@ -1802,7 +1802,7 @@ rb_fiber_start(void)
         th->ec->root_svar = Qfalse;
 
         EXEC_EVENT_HOOK(th->ec, RUBY_EVENT_FIBER_SWITCH, th->self, 0, 0, 0, Qnil);
-        cont->value = rb_vm_invoke_proc(th->ec, proc, argc, argv, VM_BLOCK_HANDLER_NONE);
+        cont->value = rb_vm_invoke_proc(th->ec, proc, argc, argv, 0 /* kw_splat */, VM_BLOCK_HANDLER_NONE);
     }
     EC_POP_TAG();
 

--- a/include/ruby/ruby.h
+++ b/include/ruby/ruby.h
@@ -1892,6 +1892,7 @@ VALUE rb_funcallv_public(VALUE, ID, int, const VALUE*);
 #define rb_funcall3 rb_funcallv_public
 VALUE rb_funcall_passing_block(VALUE, ID, int, const VALUE*);
 VALUE rb_funcall_with_block(VALUE, ID, int, const VALUE*, VALUE);
+VALUE rb_funcall_with_block_kw(VALUE, ID, int, const VALUE*, VALUE, int);
 int rb_scan_args(int, const VALUE*, const char*, ...);
 VALUE rb_call_super(int, const VALUE*);
 VALUE rb_current_receiver(void);

--- a/internal.h
+++ b/internal.h
@@ -2140,7 +2140,7 @@ VALUE rb_str_initialize(VALUE str, const char *ptr, long len, rb_encoding *enc);
 #define is_ascii_string(str) (rb_enc_str_coderange(str) == ENC_CODERANGE_7BIT)
 #define is_broken_string(str) (rb_enc_str_coderange(str) == ENC_CODERANGE_BROKEN)
 size_t rb_str_memsize(VALUE);
-VALUE rb_sym_proc_call(ID mid, int argc, const VALUE *argv, VALUE passed_proc);
+VALUE rb_sym_proc_call(ID mid, int argc, const VALUE *argv, int kw_splat, VALUE passed_proc);
 VALUE rb_sym_to_proc(VALUE sym);
 char *rb_str_to_cstr(VALUE str);
 VALUE rb_str_eql(VALUE str1, VALUE str2);

--- a/proc.c
+++ b/proc.c
@@ -942,7 +942,7 @@ rb_proc_call(VALUE self, VALUE args)
     GetProcPtr(self, proc);
     vret = rb_vm_invoke_proc(GET_EC(), proc,
 			     check_argc(RARRAY_LEN(args)), RARRAY_CONST_PTR(args),
-			     0 /* kw_splat */, VM_BLOCK_HANDLER_NONE);
+                             VM_NO_KEYWORDS, VM_BLOCK_HANDLER_NONE);
     RB_GC_GUARD(self);
     RB_GC_GUARD(args);
     return vret;
@@ -961,7 +961,7 @@ rb_proc_call_with_block(VALUE self, int argc, const VALUE *argv, VALUE passed_pr
     VALUE vret;
     rb_proc_t *proc;
     GetProcPtr(self, proc);
-    vret = rb_vm_invoke_proc(ec, proc, argc, argv, 0 /* kw_splat */, proc_to_block_handler(passed_procval));
+    vret = rb_vm_invoke_proc(ec, proc, argc, argv, VM_NO_KEYWORDS, proc_to_block_handler(passed_procval));
     RB_GC_GUARD(self);
     return vret;
 }

--- a/proc.c
+++ b/proc.c
@@ -942,7 +942,7 @@ rb_proc_call(VALUE self, VALUE args)
     GetProcPtr(self, proc);
     vret = rb_vm_invoke_proc(GET_EC(), proc,
 			     check_argc(RARRAY_LEN(args)), RARRAY_CONST_PTR(args),
-			     VM_BLOCK_HANDLER_NONE);
+			     0 /* kw_splat */, VM_BLOCK_HANDLER_NONE);
     RB_GC_GUARD(self);
     RB_GC_GUARD(args);
     return vret;
@@ -961,7 +961,7 @@ rb_proc_call_with_block(VALUE self, int argc, const VALUE *argv, VALUE passed_pr
     VALUE vret;
     rb_proc_t *proc;
     GetProcPtr(self, proc);
-    vret = rb_vm_invoke_proc(ec, proc, argc, argv, proc_to_block_handler(passed_procval));
+    vret = rb_vm_invoke_proc(ec, proc, argc, argv, 0 /* kw_splat */, proc_to_block_handler(passed_procval));
     RB_GC_GUARD(self);
     return vret;
 }

--- a/string.c
+++ b/string.c
@@ -10887,7 +10887,7 @@ sym_to_sym(VALUE sym)
 }
 
 MJIT_FUNC_EXPORTED VALUE
-rb_sym_proc_call(ID mid, int argc, const VALUE *argv, VALUE passed_proc)
+rb_sym_proc_call(ID mid, int argc, const VALUE *argv, int kw_splat, VALUE passed_proc)
 {
     VALUE obj;
 
@@ -10895,7 +10895,7 @@ rb_sym_proc_call(ID mid, int argc, const VALUE *argv, VALUE passed_proc)
 	rb_raise(rb_eArgError, "no receiver given");
     }
     obj = argv[0];
-    return rb_funcall_with_block(obj, mid, argc - 1, argv + 1, passed_proc);
+    return rb_funcall_with_block_kw(obj, mid, argc - 1, argv + 1, passed_proc, kw_splat);
 }
 
 #if 0

--- a/test/ruby/test_keyword.rb
+++ b/test/ruby/test_keyword.rb
@@ -464,12 +464,8 @@ class TestKeywordArguments < Test::Unit::TestCase
     def c.m(arg, **args)
       [arg, args]
     end
-    assert_warn(/The keyword argument is passed as the last hash parameter.* for `m'/m) do
-      assert_equal([kw, kw], c.send(:m, **{}))
-    end
-    assert_warn(/The keyword argument is passed as the last hash parameter.* for `m'/m) do
-      assert_equal([kw, kw], c.send(:m, **kw))
-    end
+    assert_raise(ArgumentError) { c.send(:m, **{}) }
+    assert_raise(ArgumentError) { c.send(:m, **kw) }
     assert_warn(/The keyword argument is passed as the last hash parameter.* for `m'/m) do
       assert_equal([h, kw], c.send(:m, **h))
     end
@@ -643,12 +639,8 @@ class TestKeywordArguments < Test::Unit::TestCase
     def c.method_missing(_, arg, **args)
       [arg, args]
     end
-    assert_warn(/The keyword argument is passed as the last hash parameter.* for `method_missing'/m) do
-      assert_equal([kw, kw], c.send(:m, **{}))
-    end
-    assert_warn(/The keyword argument is passed as the last hash parameter.* for `method_missing'/m) do
-      assert_equal([kw, kw], c.send(:m, **kw))
-    end
+    assert_raise(ArgumentError) { c.send(:m, **{}) }
+    assert_raise(ArgumentError) { c.send(:m, **kw) }
     assert_warn(/The keyword argument is passed as the last hash parameter.* for `method_missing'/m) do
       assert_equal([h, kw], c.send(:m, **h))
     end
@@ -737,9 +729,7 @@ class TestKeywordArguments < Test::Unit::TestCase
       define_method(:m) {|arg, **opt| [arg, opt] }
     end
     assert_raise(ArgumentError) { c.m(**{}) }
-    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
-      assert_equal([kw, kw], c.m(**kw))
-    end
+    assert_raise(ArgumentError) { c.m(**kw) }
     assert_warn(/The keyword argument is passed as the last hash parameter/m) do
       assert_equal([h, kw], c.m(**h))
     end

--- a/test/ruby/test_keyword.rb
+++ b/test/ruby/test_keyword.rb
@@ -185,9 +185,7 @@ class TestKeywordArguments < Test::Unit::TestCase
 
     f = -> { true }
     assert_equal(true, f[**{}])
-    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
-      assert_raise(ArgumentError) { f[**kw] }
-    end
+    assert_equal(true, f[**kw])
     assert_warn(/The keyword argument is passed as the last hash parameter/m) do
       assert_raise(ArgumentError) { f[**h] }
     end
@@ -203,9 +201,7 @@ class TestKeywordArguments < Test::Unit::TestCase
 
     f = ->(a) { a }
     assert_raise(ArgumentError) { f[**{}] }
-    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
-      assert_equal(kw, f[**kw])
-    end
+    assert_raise(ArgumentError) { f[**kw] }
     assert_warn(/The keyword argument is passed as the last hash parameter/m) do
       assert_equal(h, f[**h])
     end
@@ -283,7 +279,7 @@ class TestKeywordArguments < Test::Unit::TestCase
       end
     end
     assert_equal([], c[**{}].args)
-    assert_equal([{}], c[**kw].args)
+    assert_equal([], c[**kw].args)
     assert_equal([h], c[**h].args)
     assert_equal([h], c[a: 1].args)
     assert_equal([h2], c[**h2].args)
@@ -294,7 +290,7 @@ class TestKeywordArguments < Test::Unit::TestCase
       def initialize; end
     end
     assert_nil(c[**{}].args)
-    assert_raise(ArgumentError) { c[**kw] }
+    assert_nil(c[**kw].args)
     assert_raise(ArgumentError) { c[**h] }
     assert_raise(ArgumentError) { c[a: 1] }
     assert_raise(ArgumentError) { c[**h2] }
@@ -307,7 +303,7 @@ class TestKeywordArguments < Test::Unit::TestCase
       end
     end
     assert_raise(ArgumentError) { c[**{}] }
-    assert_equal(kw, c[**kw].args)
+    assert_raise(ArgumentError) { c[**kw] }
     assert_equal(h, c[**h].args)
     assert_equal(h, c[a: 1].args)
     assert_equal(h2, c[**h2].args)
@@ -333,7 +329,7 @@ class TestKeywordArguments < Test::Unit::TestCase
       end
     end
     assert_raise(ArgumentError) { c[**{}] }
-    assert_equal([kw, kw], c[**kw].args)
+    assert_raise(ArgumentError) { c[**kw] }
     assert_equal([h, kw], c[**h].args)
     assert_equal([h, kw], c[a: 1].args)
     assert_equal([h2, kw], c[**h2].args)
@@ -365,7 +361,7 @@ class TestKeywordArguments < Test::Unit::TestCase
       args
     end
     assert_equal([], c.method(:m)[**{}])
-    assert_equal([{}], c.method(:m)[**kw])
+    assert_equal([], c.method(:m)[**kw])
     assert_equal([h], c.method(:m)[**h])
     assert_equal([h], c.method(:m)[a: 1])
     assert_equal([h2], c.method(:m)[**h2])
@@ -375,7 +371,7 @@ class TestKeywordArguments < Test::Unit::TestCase
     c.singleton_class.remove_method(:m)
     def c.m; end
     assert_nil(c.method(:m)[**{}])
-    assert_raise(ArgumentError) { c.method(:m)[**kw] }
+    assert_nil(c.method(:m)[**kw])
     assert_raise(ArgumentError) { c.method(:m)[**h] }
     assert_raise(ArgumentError) { c.method(:m)[a: 1] }
     assert_raise(ArgumentError) { c.method(:m)[**h2] }
@@ -387,7 +383,7 @@ class TestKeywordArguments < Test::Unit::TestCase
       args
     end
     assert_raise(ArgumentError) { c.method(:m)[**{}] }
-    assert_equal(kw, c.method(:m)[**kw])
+    assert_raise(ArgumentError) { c.method(:m)[**kw] }
     assert_equal(h, c.method(:m)[**h])
     assert_equal(h, c.method(:m)[a: 1])
     assert_equal(h2, c.method(:m)[**h2])
@@ -411,7 +407,7 @@ class TestKeywordArguments < Test::Unit::TestCase
       [arg, args]
     end
     assert_raise(ArgumentError) { c.method(:m)[**{}] }
-    assert_equal([kw, kw], c.method(:m)[**kw])
+    assert_raise(ArgumentError) { c.method(:m)[**kw] }
     assert_equal([h, kw], c.method(:m)[**h])
     assert_equal([h, kw], c.method(:m)[a: 1])
     assert_equal([h2, kw], c.method(:m)[**h2])
@@ -487,9 +483,7 @@ class TestKeywordArguments < Test::Unit::TestCase
       [arg, args]
     end
     assert_raise(ArgumentError) { c.send(:m, **{}) }
-    assert_warn(/The keyword argument is passed as the last hash parameter.* for `m'/m) do
-      assert_equal([kw, kw], c.send(:m, **kw))
-    end
+    assert_raise(ArgumentError) { c.send(:m, **kw) }
     assert_warn(/The keyword argument is passed as the last hash parameter.* for `m'/m) do
       assert_equal([h, kw], c.send(:m, **h))
     end
@@ -576,9 +570,7 @@ class TestKeywordArguments < Test::Unit::TestCase
       [arg, args]
     end
     assert_raise(ArgumentError) { :m.to_proc.call(c, **{}) }
-    assert_warn(/The keyword argument is passed as the last hash parameter.* for `m'/m) do
-      assert_equal([kw, kw], :m.to_proc.call(c, **kw))
-    end
+    assert_raise(ArgumentError) { :m.to_proc.call(c, **kw) }
     assert_warn(/The keyword argument is passed as the last hash parameter.* for `m'/m) do
       assert_equal([h, kw], :m.to_proc.call(c, **h))
     end
@@ -664,9 +656,7 @@ class TestKeywordArguments < Test::Unit::TestCase
       [arg, args]
     end
     assert_raise(ArgumentError) { c.m(**{}) }
-    assert_warn(/The keyword argument is passed as the last hash parameter.* for `method_missing'/m) do
-      assert_equal([kw, kw], c.m(**kw))
-    end
+    assert_raise(ArgumentError) { c.m(**kw) }
     assert_warn(/The keyword argument is passed as the last hash parameter.* for `method_missing'/m) do
       assert_equal([h, kw], c.m(**h))
     end
@@ -707,9 +697,7 @@ class TestKeywordArguments < Test::Unit::TestCase
       define_method(:m) { }
     end
     assert_nil(c.m(**{}))
-    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
-      assert_raise(ArgumentError) { c.m(**kw) }
-    end
+    assert_nil(c.m(**kw))
     assert_warn(/The keyword argument is passed as the last hash parameter/m) do
       assert_raise(ArgumentError) { c.m(**h) }
     end
@@ -731,9 +719,7 @@ class TestKeywordArguments < Test::Unit::TestCase
       define_method(:m) {|arg| arg }
     end
     assert_raise(ArgumentError) { c.m(**{}) }
-    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
-      assert_equal(kw, c.m(**kw))
-    end
+    assert_raise(ArgumentError) { c.m(**kw) }
     assert_warn(/The keyword argument is passed as the last hash parameter/m) do
       assert_equal(h, c.m(**h))
     end
@@ -779,9 +765,7 @@ class TestKeywordArguments < Test::Unit::TestCase
       define_method(:m) {|arg, **opt| [arg, opt] }
     end
     assert_raise(ArgumentError) { c.m(**{}) }
-    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
-      assert_equal([kw, kw], c.m(**kw))
-    end
+    assert_raise(ArgumentError) { c.m(**kw) }
     assert_warn(/The keyword argument is passed as the last hash parameter/m) do
       assert_equal([h, kw], c.m(**h))
     end

--- a/test/ruby/test_keyword.rb
+++ b/test/ruby/test_keyword.rb
@@ -465,7 +465,9 @@ class TestKeywordArguments < Test::Unit::TestCase
       [arg, args]
     end
     assert_raise(ArgumentError) { c.send(:m, **{}) }
-    assert_raise(ArgumentError) { c.send(:m, **kw) }
+    assert_warn(/The keyword argument is passed as the last hash parameter.* for `m'/m) do
+      assert_equal([kw, kw], c.send(:m, **kw))
+    end
     assert_warn(/The keyword argument is passed as the last hash parameter.* for `m'/m) do
       assert_equal([h, kw], c.send(:m, **h))
     end
@@ -640,7 +642,6 @@ class TestKeywordArguments < Test::Unit::TestCase
       [arg, args]
     end
     assert_raise(ArgumentError) { c.m(**{}) }
-    assert_raise(ArgumentError) { c.send(:m, **kw) } # XXX: fix it after the commit
     assert_warn(/The keyword argument is passed as the last hash parameter.* for `method_missing'/m) do
       assert_equal([kw, kw], c.m(**kw))
     end

--- a/test/ruby/test_keyword.rb
+++ b/test/ruby/test_keyword.rb
@@ -733,7 +733,9 @@ class TestKeywordArguments < Test::Unit::TestCase
       define_method(:m) {|arg, **opt| [arg, opt] }
     end
     assert_raise(ArgumentError) { c.m(**{}) }
-    assert_raise(ArgumentError) { c.m(**kw) }
+    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
+      assert_equal([kw, kw], c.m(**kw))
+    end
     assert_warn(/The keyword argument is passed as the last hash parameter/m) do
       assert_equal([h, kw], c.m(**h))
     end

--- a/test/ruby/test_keyword.rb
+++ b/test/ruby/test_keyword.rb
@@ -633,8 +633,12 @@ class TestKeywordArguments < Test::Unit::TestCase
     def c.m(args)
       args
     end
-    assert_raise(ArgumentError) { :m.to_proc.call(c, **{}) }
-    assert_raise(ArgumentError) { :m.to_proc.call(c, **kw) }
+    assert_warn(/The keyword argument is passed as the last hash parameter.* for `m'/m) do
+      assert_equal(kw, :m.to_proc.call(c, **{}))
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter.* for `m'/m) do
+      assert_equal(kw, :m.to_proc.call(c, **kw))
+    end
     assert_equal(h, :m.to_proc.call(c, **h))
     assert_equal(h, :m.to_proc.call(c, a: 1))
     assert_equal(h2, :m.to_proc.call(c, **h2))
@@ -657,8 +661,12 @@ class TestKeywordArguments < Test::Unit::TestCase
     def c.m(arg, **args)
       [arg, args]
     end
-    assert_raise(ArgumentError) { :m.to_proc.call(c, **{}) }
-    assert_raise(ArgumentError) { :m.to_proc.call(c, **kw) }
+    assert_warn(/The keyword argument is passed as the last hash parameter.* for `m'/m) do
+      assert_equal([kw, kw], :m.to_proc.call(c, **{}))
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter.* for `m'/m) do
+      assert_equal([kw, kw], :m.to_proc.call(c, **kw))
+    end
     assert_warn(/The keyword argument is passed as the last hash parameter.* for `m'/m) do
       assert_equal([h, kw], :m.to_proc.call(c, **h))
     end

--- a/test/ruby/test_keyword.rb
+++ b/test/ruby/test_keyword.rb
@@ -728,8 +728,12 @@ class TestKeywordArguments < Test::Unit::TestCase
     def c.method_missing(_, args)
       args
     end
-    assert_raise(ArgumentError) { c.m(**{}) }
-    assert_raise(ArgumentError) { c.m(**kw) }
+    assert_warn(/The keyword argument is passed as the last hash parameter.* for `method_missing'/m) do
+      assert_equal(kw, c.m(**{}))
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter.* for `method_missing'/m) do
+      assert_equal(kw, c.m(**kw))
+    end
     assert_equal(h, c.m(**h))
     assert_equal(h, c.m(a: 1))
     assert_equal(h2, c.m(**h2))
@@ -751,8 +755,12 @@ class TestKeywordArguments < Test::Unit::TestCase
     def c.method_missing(_, arg, **args)
       [arg, args]
     end
-    assert_raise(ArgumentError) { c.m(**{}) }
-    assert_raise(ArgumentError) { c.m(**kw) }
+    assert_warn(/The keyword argument is passed as the last hash parameter.* for `method_missing'/m) do
+      assert_equal([kw, kw], c.m(**{}))
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter.* for `method_missing'/m) do
+      assert_equal([kw, kw], c.m(**kw))
+    end
     assert_warn(/The keyword argument is passed as the last hash parameter.* for `method_missing'/m) do
       assert_equal([h, kw], c.m(**h))
     end

--- a/test/ruby/test_keyword.rb
+++ b/test/ruby/test_keyword.rb
@@ -179,7 +179,7 @@ class TestKeywordArguments < Test::Unit::TestCase
 
   def test_lambda_kwsplat_call
     kw = {}
-    h = {'a'=>1}
+    h = {:a=>1}
     h2 = {'a'=>1}
     h3 = {'a'=>1, :a=>1}
 
@@ -187,6 +187,7 @@ class TestKeywordArguments < Test::Unit::TestCase
     assert_equal(true, f[**{}])
     assert_equal(true, f[**kw])
     assert_raise(ArgumentError) { f[**h] }
+    assert_raise(ArgumentError) { f[a: 1] }
     assert_raise(ArgumentError) { f[**h2] }
     assert_raise(ArgumentError) { f[**h3] }
 
@@ -194,15 +195,19 @@ class TestKeywordArguments < Test::Unit::TestCase
     assert_raise(ArgumentError) { f[**{}] }
     assert_raise(ArgumentError) { f[**kw] }
     assert_equal(h, f[**h])
+    assert_equal(h, f[a: 1])
     assert_equal(h2, f[**h2])
     assert_equal(h3, f[**h3])
+    assert_equal(h3, f[a: 1, **h2])
 
     f = ->(**x) { x }
     assert_equal(kw, f[**{}])
     assert_equal(kw, f[**kw])
     assert_equal(h, f[**h])
+    assert_equal(h, f[a: 1])
     assert_equal(h2, f[**h2])
     assert_equal(h3, f[**h3])
+    assert_equal(h3, f[a: 1, **h2])
 
     f = ->(a, **x) { [a,x] }
     assert_warn(/The keyword argument is passed as the last hash parameter.* for `\[\]'/m) do
@@ -215,23 +220,31 @@ class TestKeywordArguments < Test::Unit::TestCase
       assert_equal([h, {}], f[**h])
     end
     assert_warn(/The keyword argument is passed as the last hash parameter.* for `\[\]'/m) do
+      assert_equal([h, {}], f[a: 1])
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter.* for `\[\]'/m) do
       assert_equal([h2, {}], f[**h2])
     end
     assert_warn(/The keyword argument is passed as the last hash parameter.* for `\[\]'/m) do
       assert_equal([h3, {}], f[**h3])
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter.* for `\[\]'/m) do
+      assert_equal([h3, {}], f[a: 1, **h2])
     end
 
     f = ->(a=1, **x) { [a, x] }
     assert_equal([1, kw], f[**{}])
     assert_equal([1, kw], f[**kw])
     assert_equal([1, h], f[**h])
+    assert_equal([1, h], f[a: 1])
     assert_equal([1, h2], f[**h2])
     assert_equal([1, h3], f[**h3])
+    assert_equal([1, h3], f[a: 1, **h2])
   end
 
   def test_cfunc_kwsplat_call
     kw = {}
-    h = {'a'=>1}
+    h = {:a=>1}
     h2 = {'a'=>1}
     h3 = {'a'=>1, :a=>1}
 
@@ -250,8 +263,10 @@ class TestKeywordArguments < Test::Unit::TestCase
     assert_equal([], c[**{}].args)
     assert_equal([], c[**kw].args)
     assert_equal([h], c[**h].args)
+    assert_equal([h], c[a: 1].args)
     assert_equal([h2], c[**h2].args)
     assert_equal([h3], c[**h3].args)
+    assert_equal([h3], c[a: 1, **h2].args)
 
     c = Class.new(sc) do
       def initialize; end
@@ -259,8 +274,10 @@ class TestKeywordArguments < Test::Unit::TestCase
     assert_nil(c[**{}].args)
     assert_nil(c[**kw].args)
     assert_raise(ArgumentError) { c[**h] }
+    assert_raise(ArgumentError) { c[a: 1] }
     assert_raise(ArgumentError) { c[**h2] }
     assert_raise(ArgumentError) { c[**h3] }
+    assert_raise(ArgumentError) { c[a: 1, **h2] }
 
     c = Class.new(sc) do
       def initialize(args)
@@ -270,8 +287,10 @@ class TestKeywordArguments < Test::Unit::TestCase
     assert_raise(ArgumentError) { c[**{}] }
     assert_raise(ArgumentError) { c[**kw] }
     assert_equal(h, c[**h].args)
+    assert_equal(h, c[a: 1].args)
     assert_equal(h2, c[**h2].args)
     assert_equal(h3, c[**h3].args)
+    assert_equal(h3, c[a: 1, **h2].args)
 
     c = Class.new(sc) do
       def initialize(**args)
@@ -281,8 +300,10 @@ class TestKeywordArguments < Test::Unit::TestCase
     assert_equal(kw, c[**{}].args)
     assert_equal(kw, c[**kw].args)
     assert_equal(h, c[**h].args)
+    assert_equal(h, c[a: 1].args)
     assert_equal(h2, c[**h2].args)
     assert_equal(h3, c[**h3].args)
+    assert_equal(h3, c[a: 1, **h2].args)
 
     c = Class.new(sc) do
       def initialize(arg, **args)
@@ -292,8 +313,10 @@ class TestKeywordArguments < Test::Unit::TestCase
     assert_raise(ArgumentError) { c[**{}] }
     assert_raise(ArgumentError) { c[**kw] }
     assert_equal([h, kw], c[**h].args)
+    assert_equal([h, kw], c[a: 1].args)
     assert_equal([h2, kw], c[**h2].args)
     assert_equal([h3, kw], c[**h3].args)
+    assert_equal([h3, kw], c[a: 1, **h2].args)
 
     c = Class.new(sc) do
       def initialize(arg=1, **args)
@@ -303,13 +326,15 @@ class TestKeywordArguments < Test::Unit::TestCase
     assert_equal([1, kw], c[**{}].args)
     assert_equal([1, kw], c[**kw].args)
     assert_equal([1, h], c[**h].args)
+    assert_equal([1, h], c[a: 1].args)
     assert_equal([1, h2], c[**h2].args)
     assert_equal([1, h3], c[**h3].args)
+    assert_equal([1, h3], c[a: 1, **h2].args)
   end
 
   def test_method_kwsplat_call
     kw = {}
-    h = {'a'=>1}
+    h = {:a=>1}
     h2 = {'a'=>1}
     h3 = {'a'=>1, :a=>1}
 
@@ -320,16 +345,20 @@ class TestKeywordArguments < Test::Unit::TestCase
     assert_equal([], c.method(:m)[**{}])
     assert_equal([], c.method(:m)[**kw])
     assert_equal([h], c.method(:m)[**h])
+    assert_equal([h], c.method(:m)[a: 1])
     assert_equal([h2], c.method(:m)[**h2])
     assert_equal([h3], c.method(:m)[**h3])
+    assert_equal([h3], c.method(:m)[a: 1, **h2])
 
     c.singleton_class.remove_method(:m)
     def c.m; end
     assert_nil(c.method(:m)[**{}])
     assert_nil(c.method(:m)[**kw])
     assert_raise(ArgumentError) { c.method(:m)[**h] }
+    assert_raise(ArgumentError) { c.method(:m)[a: 1] }
     assert_raise(ArgumentError) { c.method(:m)[**h2] }
     assert_raise(ArgumentError) { c.method(:m)[**h3] }
+    assert_raise(ArgumentError) { c.method(:m)[a: 1, **h2] }
 
     c.singleton_class.remove_method(:m)
     def c.m(args)
@@ -338,8 +367,10 @@ class TestKeywordArguments < Test::Unit::TestCase
     assert_raise(ArgumentError) { c.method(:m)[**{}] }
     assert_raise(ArgumentError) { c.method(:m)[**kw] }
     assert_equal(h, c.method(:m)[**h])
+    assert_equal(h, c.method(:m)[a: 1])
     assert_equal(h2, c.method(:m)[**h2])
     assert_equal(h3, c.method(:m)[**h3])
+    assert_equal(h3, c.method(:m)[a: 1, **h2])
 
     c.singleton_class.remove_method(:m)
     def c.m(**args)
@@ -348,8 +379,10 @@ class TestKeywordArguments < Test::Unit::TestCase
     assert_equal(kw, c.method(:m)[**{}])
     assert_equal(kw, c.method(:m)[**kw])
     assert_equal(h, c.method(:m)[**h])
+    assert_equal(h, c.method(:m)[a: 1])
     assert_equal(h2, c.method(:m)[**h2])
     assert_equal(h3, c.method(:m)[**h3])
+    assert_equal(h3, c.method(:m)[a: 1, **h2])
 
     c.singleton_class.remove_method(:m)
     def c.m(arg, **args)
@@ -358,8 +391,10 @@ class TestKeywordArguments < Test::Unit::TestCase
     assert_raise(ArgumentError) { c.method(:m)[**{}] }
     assert_raise(ArgumentError) { c.method(:m)[**kw] }
     assert_equal([h, kw], c.method(:m)[**h])
+    assert_equal([h, kw], c.method(:m)[a: 1])
     assert_equal([h2, kw], c.method(:m)[**h2])
     assert_equal([h3, kw], c.method(:m)[**h3])
+    assert_equal([h3, kw], c.method(:m)[a: 1, **h2])
 
     c.singleton_class.remove_method(:m)
     def c.m(arg=1, **args)
@@ -368,13 +403,15 @@ class TestKeywordArguments < Test::Unit::TestCase
     assert_equal([1, kw], c.method(:m)[**{}])
     assert_equal([1, kw], c.method(:m)[**kw])
     assert_equal([1, h], c.method(:m)[**h])
+    assert_equal([1, h], c.method(:m)[a: 1])
     assert_equal([1, h2], c.method(:m)[**h2])
     assert_equal([1, h3], c.method(:m)[**h3])
+    assert_equal([1, h3], c.method(:m)[a: 1, **h2])
   end
 
   def test_send_kwsplat
     kw = {}
-    h = {'a'=>1}
+    h = {:a=>1}
     h2 = {'a'=>1}
     h3 = {'a'=>1, :a=>1}
 
@@ -385,16 +422,20 @@ class TestKeywordArguments < Test::Unit::TestCase
     assert_equal([], c.send(:m, **{}))
     assert_equal([], c.send(:m, **kw))
     assert_equal([h], c.send(:m, **h))
+    assert_equal([h], c.send(:m, a: 1))
     assert_equal([h2], c.send(:m, **h2))
     assert_equal([h3], c.send(:m, **h3))
+    assert_equal([h3], c.send(:m, a: 1, **h2))
 
     c.singleton_class.remove_method(:m)
     def c.m; end
     assert_nil(c.send(:m, **{}))
     assert_nil(c.send(:m, **kw))
     assert_raise(ArgumentError) { c.send(:m, **h) }
+    assert_raise(ArgumentError) { c.send(:m, a: 1) }
     assert_raise(ArgumentError) { c.send(:m, **h2) }
     assert_raise(ArgumentError) { c.send(:m, **h3) }
+    assert_raise(ArgumentError) { c.send(:m, a: 1, **h2) }
 
     c.singleton_class.remove_method(:m)
     def c.m(args)
@@ -403,8 +444,10 @@ class TestKeywordArguments < Test::Unit::TestCase
     assert_raise(ArgumentError) { c.send(:m, **{}) }
     assert_raise(ArgumentError) { c.send(:m, **kw) }
     assert_equal(h, c.send(:m, **h))
+    assert_equal(h, c.send(:m, a: 1))
     assert_equal(h2, c.send(:m, **h2))
     assert_equal(h3, c.send(:m, **h3))
+    assert_equal(h3, c.send(:m, a: 1, **h2))
 
     c.singleton_class.remove_method(:m)
     def c.m(**args)
@@ -413,8 +456,9 @@ class TestKeywordArguments < Test::Unit::TestCase
     assert_equal(kw, c.send(:m, **{}))
     assert_equal(kw, c.send(:m, **kw))
     assert_equal(h, c.send(:m, **h))
+    assert_equal(h, c.send(:m, a: 1))
     assert_equal(h2, c.send(:m, **h2))
-    assert_equal(h3, c.send(:m, **h3))
+    assert_equal(h3, c.send(:m, a: 1, **h2))
 
     c.singleton_class.remove_method(:m)
     def c.m(arg, **args)
@@ -430,10 +474,16 @@ class TestKeywordArguments < Test::Unit::TestCase
       assert_equal([h, kw], c.send(:m, **h))
     end
     assert_warn(/The keyword argument is passed as the last hash parameter.* for `m'/m) do
+      assert_equal([h, kw], c.send(:m, a: 1))
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter.* for `m'/m) do
       assert_equal([h2, kw], c.send(:m, **h2))
     end
     assert_warn(/The keyword argument is passed as the last hash parameter.* for `m'/m) do
       assert_equal([h3, kw], c.send(:m, **h3))
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter.* for `m'/m) do
+      assert_equal([h3, kw], c.send(:m, a: 1, **h2))
     end
 
     c.singleton_class.remove_method(:m)
@@ -443,13 +493,15 @@ class TestKeywordArguments < Test::Unit::TestCase
     assert_equal([1, kw], c.send(:m, **{}))
     assert_equal([1, kw], c.send(:m, **kw))
     assert_equal([1, h], c.send(:m, **h))
+    assert_equal([1, h], c.send(:m, a: 1))
     assert_equal([1, h2], c.send(:m, **h2))
     assert_equal([1, h3], c.send(:m, **h3))
+    assert_equal([1, h3], c.send(:m, a: 1, **h2))
   end
 
   def test_sym_proc_kwsplat
     kw = {}
-    h = {'a'=>1}
+    h = {:a=>1}
     h2 = {'a'=>1}
     h3 = {'a'=>1, :a=>1}
 
@@ -460,16 +512,20 @@ class TestKeywordArguments < Test::Unit::TestCase
     assert_equal([], :m.to_proc.call(c, **{}))
     assert_equal([], :m.to_proc.call(c, **kw))
     assert_equal([h], :m.to_proc.call(c, **h))
+    assert_equal([h], :m.to_proc.call(c, a: 1))
     assert_equal([h2], :m.to_proc.call(c, **h2))
     assert_equal([h3], :m.to_proc.call(c, **h3))
+    assert_equal([h3], :m.to_proc.call(c, a: 1, **h2))
 
     c.singleton_class.remove_method(:m)
     def c.m; end
     assert_nil(:m.to_proc.call(c, **{}))
     assert_nil(:m.to_proc.call(c, **kw))
     assert_raise(ArgumentError) { :m.to_proc.call(c, **h) }
+    assert_raise(ArgumentError) { :m.to_proc.call(c, a: 1) }
     assert_raise(ArgumentError) { :m.to_proc.call(c, **h2) }
     assert_raise(ArgumentError) { :m.to_proc.call(c, **h3) }
+    assert_raise(ArgumentError) { :m.to_proc.call(c, a: 1, **h2) }
 
     c.singleton_class.remove_method(:m)
     def c.m(args)
@@ -478,8 +534,10 @@ class TestKeywordArguments < Test::Unit::TestCase
     assert_raise(ArgumentError) { :m.to_proc.call(c, **{}) }
     assert_raise(ArgumentError) { :m.to_proc.call(c, **kw) }
     assert_equal(h, :m.to_proc.call(c, **h))
+    assert_equal(h, :m.to_proc.call(c, a: 1))
     assert_equal(h2, :m.to_proc.call(c, **h2))
     assert_equal(h3, :m.to_proc.call(c, **h3))
+    assert_equal(h3, :m.to_proc.call(c, a: 1, **h2))
 
     c.singleton_class.remove_method(:m)
     def c.m(**args)
@@ -488,8 +546,10 @@ class TestKeywordArguments < Test::Unit::TestCase
     assert_equal(kw, :m.to_proc.call(c, **{}))
     assert_equal(kw, :m.to_proc.call(c, **kw))
     assert_equal(h, :m.to_proc.call(c, **h))
+    assert_equal(h, :m.to_proc.call(c, a: 1))
     assert_equal(h2, :m.to_proc.call(c, **h2))
     assert_equal(h3, :m.to_proc.call(c, **h3))
+    assert_equal(h3, :m.to_proc.call(c, a: 1, **h2))
 
     c.singleton_class.remove_method(:m)
     def c.m(arg, **args)
@@ -503,10 +563,16 @@ class TestKeywordArguments < Test::Unit::TestCase
       assert_equal([h, kw], :m.to_proc.call(c, **h))
     end
     assert_warn(/The keyword argument is passed as the last hash parameter.* for `m'/m) do
+      assert_equal([h, kw], :m.to_proc.call(c, a: 1))
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter.* for `m'/m) do
       assert_equal([h2, kw], :m.to_proc.call(c, **h2))
     end
     assert_warn(/The keyword argument is passed as the last hash parameter.* for `m'/m) do
       assert_equal([h3, kw], :m.to_proc.call(c, **h3))
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter.* for `m'/m) do
+      assert_equal([h3, kw], :m.to_proc.call(c, a: 1, **h2))
     end
 
     c.singleton_class.remove_method(:m)
@@ -516,13 +582,15 @@ class TestKeywordArguments < Test::Unit::TestCase
     assert_equal([1, kw], :m.to_proc.call(c, **{}))
     assert_equal([1, kw], :m.to_proc.call(c, **kw))
     assert_equal([1, h], :m.to_proc.call(c, **h))
+    assert_equal([1, h], :m.to_proc.call(c, a: 1))
     assert_equal([1, h2], :m.to_proc.call(c, **h2))
     assert_equal([1, h3], :m.to_proc.call(c, **h3))
+    assert_equal([1, h3], :m.to_proc.call(c, a: 1, **h2))
   end
 
   def test_method_missing_kwsplat
     kw = {}
-    h = {'a'=>1}
+    h = {:a=>1}
     h2 = {'a'=>1}
     h3 = {'a'=>1, :a=>1}
 
@@ -533,16 +601,20 @@ class TestKeywordArguments < Test::Unit::TestCase
     assert_equal([], c.send(:m, **{}))
     assert_equal([], c.send(:m, **kw))
     assert_equal([h], c.send(:m, **h))
+    assert_equal([h], c.send(:m, a: 1))
     assert_equal([h2], c.send(:m, **h2))
     assert_equal([h3], c.send(:m, **h3))
+    assert_equal([h3], c.send(:m, a: 1, **h2))
 
     c.singleton_class.remove_method(:method_missing)
     def c.method_missing(_); end
     assert_nil(c.send(:m, **{}))
     assert_nil(c.send(:m, **kw))
     assert_raise(ArgumentError) { c.send(:m, **h) }
+    assert_raise(ArgumentError) { c.send(:m, a: 1) }
     assert_raise(ArgumentError) { c.send(:m, **h2) }
     assert_raise(ArgumentError) { c.send(:m, **h3) }
+    assert_raise(ArgumentError) { c.send(:m, a: 1, **h2) }
 
     c.singleton_class.remove_method(:method_missing)
     def c.method_missing(_, args)
@@ -551,8 +623,10 @@ class TestKeywordArguments < Test::Unit::TestCase
     assert_raise(ArgumentError) { c.send(:m, **{}) }
     assert_raise(ArgumentError) { c.send(:m, **kw) }
     assert_equal(h, c.send(:m, **h))
+    assert_equal(h, c.send(:m, a: 1))
     assert_equal(h2, c.send(:m, **h2))
     assert_equal(h3, c.send(:m, **h3))
+    assert_equal(h3, c.send(:m, a: 1, **h2))
 
     c.singleton_class.remove_method(:method_missing)
     def c.method_missing(_, **args)
@@ -561,8 +635,9 @@ class TestKeywordArguments < Test::Unit::TestCase
     assert_equal(kw, c.send(:m, **{}))
     assert_equal(kw, c.send(:m, **kw))
     assert_equal(h, c.send(:m, **h))
+    assert_equal(h, c.send(:m, a: 1))
     assert_equal(h2, c.send(:m, **h2))
-    assert_equal(h3, c.send(:m, **h3))
+    assert_equal(h3, c.send(:m, a: 1, **h2))
 
     c.singleton_class.remove_method(:method_missing)
     def c.method_missing(_, arg, **args)
@@ -578,10 +653,16 @@ class TestKeywordArguments < Test::Unit::TestCase
       assert_equal([h, kw], c.send(:m, **h))
     end
     assert_warn(/The keyword argument is passed as the last hash parameter.* for `method_missing'/m) do
+      assert_equal([h, kw], c.send(:m, a: 1))
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter.* for `method_missing'/m) do
       assert_equal([h2, kw], c.send(:m, **h2))
     end
     assert_warn(/The keyword argument is passed as the last hash parameter.* for `method_missing'/m) do
       assert_equal([h3, kw], c.send(:m, **h3))
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter.* for `method_missing'/m) do
+      assert_equal([h3, kw], c.send(:m, a: 1, **h2))
     end
 
     c.singleton_class.remove_method(:method_missing)
@@ -591,13 +672,15 @@ class TestKeywordArguments < Test::Unit::TestCase
     assert_equal([1, kw], c.send(:m, **{}))
     assert_equal([1, kw], c.send(:m, **kw))
     assert_equal([1, h], c.send(:m, **h))
+    assert_equal([1, h], c.send(:m, a: 1))
     assert_equal([1, h2], c.send(:m, **h2))
     assert_equal([1, h3], c.send(:m, **h3))
+    assert_equal([1, h3], c.send(:m, a: 1, **h2))
   end
 
   def test_define_method_kwsplat
     kw = {}
-    h = {'a'=>1}
+    h = {:a=>1}
     h2 = {'a'=>1}
     h3 = {'a'=>1, :a=>1}
 
@@ -608,38 +691,46 @@ class TestKeywordArguments < Test::Unit::TestCase
     assert_nil(c.m(**{}))
     assert_nil(c.m(**kw))
     assert_raise(ArgumentError) { c.m(**h) }
+    assert_raise(ArgumentError) { c.m(a: 1) }
     assert_raise(ArgumentError) { c.m(**h2) }
     assert_raise(ArgumentError) { c.m(**h3) }
+    assert_raise(ArgumentError) { c.m(a: 1, **h2) }
 
     c = Object.new
     class << c
-      define_method(:m) {|arg| }
+      define_method(:m) {|arg| arg }
     end
     assert_raise(ArgumentError) { c.m(**{}) }
     assert_raise(ArgumentError) { c.m(**kw) }
-    assert_nil(c.m(**h))
-    assert_nil(c.m(**h2))
-    assert_nil(c.m(**h3))
+    assert_equal(h, c.m(**h))
+    assert_equal(h, c.m(a: 1))
+    assert_equal(h2, c.m(**h2))
+    assert_equal(h3, c.m(**h3))
+    assert_equal(h3, c.m(a: 1, **h2))
 
     c = Object.new
     class << c
-      define_method(:m) {|*args| }
+      define_method(:m) {|*args| args }
     end
-    assert_nil(c.m(**{}))
-    assert_nil(c.m(**kw))
-    assert_nil(c.m(**h))
-    assert_nil(c.m(**h2))
-    assert_nil(c.m(**h3))
+    assert_equal([], c.m(**{}))
+    assert_equal([], c.m(**kw))
+    assert_equal([h], c.m(**h))
+    assert_equal([h], c.m(a: 1))
+    assert_equal([h2], c.m(**h2))
+    assert_equal([h3], c.m(**h3))
+    assert_equal([h3], c.m(a: 1, **h2))
 
     c = Object.new
     class << c
-      define_method(:m) {|**opt| }
+      define_method(:m) {|**opt| opt}
     end
-    assert_nil(c.m(**{}))
-    assert_nil(c.m(**kw))
-    assert_nil(c.m(**h))
-    assert_nil(c.m(**h2))
-    assert_nil(c.m(**h3))
+    assert_equal(kw, c.m(**{}))
+    assert_equal(kw, c.m(**kw))
+    assert_equal(h, c.m(**h))
+    assert_equal(h, c.m(a: 1))
+    assert_equal(h2, c.m(**h2))
+    assert_equal(h3, c.m(**h3))
+    assert_equal(h3, c.m(a: 1, **h2))
 
     c = Object.new
     class << c
@@ -653,21 +744,29 @@ class TestKeywordArguments < Test::Unit::TestCase
       assert_equal([h, kw], c.m(**h))
     end
     assert_warn(/The keyword argument is passed as the last hash parameter/m) do
+      assert_equal([h, kw], c.m(a: 1))
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
       assert_equal([h2, kw], c.m(**h2))
     end
     assert_warn(/The keyword argument is passed as the last hash parameter/m) do
       assert_equal([h3, kw], c.m(**h3))
     end
+    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
+      assert_equal([h3, kw], c.m(a: 1, **h2))
+    end
 
     c = Object.new
     class << c
-      define_method(:m) {|arg=1, **opt| }
+      define_method(:m) {|arg=1, **opt| [arg, opt] }
     end
-    assert_nil(c.m(**{}))
-    assert_nil(c.m(**kw))
-    assert_nil(c.m(**h))
-    assert_nil(c.m(**h2))
-    assert_nil(c.m(**h3))
+    assert_equal([1, kw], c.m(**{}))
+    assert_equal([1, kw], c.m(**kw))
+    assert_equal([1, h], c.m(**h))
+    assert_equal([1, h], c.m(a: 1))
+    assert_equal([1, h2], c.m(**h2))
+    assert_equal([1, h3], c.m(**h3))
+    assert_equal([1, h3], c.m(a: 1, **h2))
   end
 
   def p1

--- a/test/ruby/test_keyword.rb
+++ b/test/ruby/test_keyword.rb
@@ -759,6 +759,52 @@ class TestKeywordArguments < Test::Unit::TestCase
     assert_equal([1, h3], c.m(a: 1, **h2))
   end
 
+  def test_attr_reader_kwsplat
+    kw = {}
+    h = {:a=>1}
+    h2 = {'a'=>1}
+    h3 = {'a'=>1, :a=>1}
+
+    c = Object.new
+    class << c
+      attr_reader :m
+    end
+    assert_nil(c.m(**{}))
+    assert_nil(c.m(**kw))
+    assert_raise(ArgumentError) { c.m(**h) }
+    assert_raise(ArgumentError) { c.m(a: 1) }
+    assert_raise(ArgumentError) { c.m(**h2) }
+    assert_raise(ArgumentError) { c.m(**h3) }
+    assert_raise(ArgumentError) { c.m(a: 1, **h2) }
+  end
+
+  def test_attr_writer_kwsplat
+    kw = {}
+    h = {:a=>1}
+    h2 = {'a'=>1}
+    h3 = {'a'=>1, :a=>1}
+
+    c = Object.new
+    class << c
+      attr_writer :m
+    end
+    assert_raise(ArgumentError) { c.send(:m=, **{}) }
+    assert_raise(ArgumentError) { c.send(:m=, **kw) }
+    assert_equal(h, c.send(:m=, **h))
+    assert_equal(h, c.send(:m=, a: 1))
+    assert_equal(h2, c.send(:m=, **h2))
+    assert_equal(h3, c.send(:m=, **h3))
+    assert_equal(h3, c.send(:m=, a: 1, **h2))
+
+    assert_equal(42, c.send(:m=, 42, **{}))
+    assert_equal(42, c.send(:m=, 42, **kw))
+    assert_raise(ArgumentError) { c.send(:m=, 42, **h) }
+    assert_raise(ArgumentError) { c.send(:m=, 42, a: 1) }
+    assert_raise(ArgumentError) { c.send(:m=, 42, **h2) }
+    assert_raise(ArgumentError) { c.send(:m=, 42, **h3) }
+    assert_raise(ArgumentError) { c.send(:m=, 42, a: 1, **h2) }
+  end
+
   def p1
     Proc.new do |str: "foo", num: 424242|
       [str, num]

--- a/test/ruby/test_keyword.rb
+++ b/test/ruby/test_keyword.rb
@@ -280,37 +280,23 @@ class TestKeywordArguments < Test::Unit::TestCase
     f = -> { true }
     assert_equal(true, f[**{}])
     assert_equal(true, f[**kw])
-    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
-      assert_raise(ArgumentError) { f[**h] }
-    end
-    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
-      assert_raise(ArgumentError) { f[a: 1] }
-    end
-    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
-      assert_raise(ArgumentError) { f[**h2] }
-    end
-    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
-      assert_raise(ArgumentError) { f[**h3] }
-    end
+    assert_raise(ArgumentError) { f[**h] }
+    assert_raise(ArgumentError) { f[a: 1] }
+    assert_raise(ArgumentError) { f[**h2] }
+    assert_raise(ArgumentError) { f[**h3] }
 
     f = ->(a) { a }
-    assert_raise(ArgumentError) { f[**{}] }
-    assert_raise(ArgumentError) { f[**kw] }
     assert_warn(/The keyword argument is passed as the last hash parameter/m) do
-      assert_equal(h, f[**h])
+      assert_equal(kw, f[**{}])
     end
     assert_warn(/The keyword argument is passed as the last hash parameter/m) do
-      assert_equal(h, f[a: 1])
+      assert_equal(kw, f[**kw])
     end
-    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
-      assert_equal(h2, f[**h2])
-    end
-    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
-      assert_equal(h3, f[**h3])
-    end
-    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
-      assert_equal(h3, f[a: 1, **h2])
-    end
+    assert_equal(h, f[**h])
+    assert_equal(h, f[a: 1])
+    assert_equal(h2, f[**h2])
+    assert_equal(h3, f[**h3])
+    assert_equal(h3, f[a: 1, **h2])
 
     f = ->(**x) { x }
     assert_equal(kw, f[**{}])
@@ -800,43 +786,27 @@ class TestKeywordArguments < Test::Unit::TestCase
     end
     assert_nil(c.m(**{}))
     assert_nil(c.m(**kw))
-    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
-      assert_raise(ArgumentError) { c.m(**h) }
-    end
-    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
-      assert_raise(ArgumentError) { c.m(a: 1) }
-    end
-    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
-      assert_raise(ArgumentError) { c.m(**h2) }
-    end
-    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
-      assert_raise(ArgumentError) { c.m(**h3) }
-    end
-    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
-      assert_raise(ArgumentError) { c.m(a: 1, **h2) }
-    end
+    assert_raise(ArgumentError) { c.m(**h) }
+    assert_raise(ArgumentError) { c.m(a: 1) }
+    assert_raise(ArgumentError) { c.m(**h2) }
+    assert_raise(ArgumentError) { c.m(**h3) }
+    assert_raise(ArgumentError) { c.m(a: 1, **h2) }
 
     c = Object.new
     class << c
       define_method(:m) {|arg| arg }
     end
-    assert_raise(ArgumentError) { c.m(**{}) }
-    assert_raise(ArgumentError) { c.m(**kw) }
     assert_warn(/The keyword argument is passed as the last hash parameter/m) do
-      assert_equal(h, c.m(**h))
+      assert_equal(kw, c.m(**{}))
     end
     assert_warn(/The keyword argument is passed as the last hash parameter/m) do
-      assert_equal(h, c.m(a: 1))
+      assert_equal(kw, c.m(**kw))
     end
-    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
-      assert_equal(h2, c.m(**h2))
-    end
-    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
-      assert_equal(h3, c.m(**h3))
-    end
-    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
-      assert_equal(h3, c.m(a: 1, **h2))
-    end
+    assert_equal(h, c.m(**h))
+    assert_equal(h, c.m(a: 1))
+    assert_equal(h2, c.m(**h2))
+    assert_equal(h3, c.m(**h3))
+    assert_equal(h3, c.m(a: 1, **h2))
 
     c = Object.new
     class << c
@@ -866,8 +836,12 @@ class TestKeywordArguments < Test::Unit::TestCase
     class << c
       define_method(:m) {|arg, **opt| [arg, opt] }
     end
-    assert_raise(ArgumentError) { c.m(**{}) }
-    assert_raise(ArgumentError) { c.m(**kw) }
+    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
+      assert_equal([kw, kw], c.m(**{}))
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
+      assert_equal([kw, kw], c.m(**kw))
+    end
     assert_warn(/The keyword argument is passed as the last hash parameter/m) do
       assert_equal([h, kw], c.m(**h))
     end
@@ -1347,14 +1321,10 @@ class TestKeywordArguments < Test::Unit::TestCase
 
     o = Object.new
     def o.to_hash() { a: 1 } end
-    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
-      assert_equal({a: 1}, m1(**o) {|x| break x}, bug9898)
-    end
+    assert_equal({a: 1}, m1(**o) {|x| break x}, bug9898)
     o2 = Object.new
     def o2.to_hash() { b: 2 } end
-    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
-      assert_equal({a: 1, b: 2}, m1(**o, **o2) {|x| break x}, bug9898)
-    end
+    assert_equal({a: 1, b: 2}, m1(**o, **o2) {|x| break x}, bug9898)
   end
 
   def test_implicit_hash_conversion

--- a/test/ruby/test_keyword.rb
+++ b/test/ruby/test_keyword.rb
@@ -522,6 +522,81 @@ class TestKeywordArguments < Test::Unit::TestCase
     assert_equal([1, h3], c.send(:m, **h3))
   end
 
+  def test_define_method_kwsplat
+    kw = {}
+    h = {'a'=>1}
+    h2 = {'a'=>1}
+    h3 = {'a'=>1, :a=>1}
+
+    c = Object.new
+    class << c
+      define_method(:m) { }
+    end
+    assert_nil(c.m(**{}))
+    assert_nil(c.m(**kw))
+    assert_raise(ArgumentError) { c.m(**h) }
+    assert_raise(ArgumentError) { c.m(**h2) }
+    assert_raise(ArgumentError) { c.m(**h3) }
+
+    c = Object.new
+    class << c
+      define_method(:m) {|arg| }
+    end
+    assert_raise(ArgumentError) { c.m(**{}) }
+    assert_raise(ArgumentError) { c.m(**kw) }
+    assert_nil(c.m(**h))
+    assert_nil(c.m(**h2))
+    assert_nil(c.m(**h3))
+
+    c = Object.new
+    class << c
+      define_method(:m) {|*args| }
+    end
+    assert_nil(c.m(**{}))
+    assert_nil(c.m(**kw))
+    assert_nil(c.m(**h))
+    assert_nil(c.m(**h2))
+    assert_nil(c.m(**h3))
+
+    c = Object.new
+    class << c
+      define_method(:m) {|**opt| }
+    end
+    assert_nil(c.m(**{}))
+    assert_nil(c.m(**kw))
+    assert_nil(c.m(**h))
+    assert_nil(c.m(**h2))
+    assert_nil(c.m(**h3))
+
+    c = Object.new
+    class << c
+      define_method(:m) {|arg, **opt| [arg, opt] }
+    end
+    assert_raise(ArgumentError) { c.m(**{}) }
+    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
+      assert_equal([kw, kw], c.m(**kw))
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
+      assert_equal([h, kw], c.m(**h))
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
+      assert_equal([h2, kw], c.m(**h2))
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
+      assert_equal([h3, kw], c.m(**h3))
+    end
+
+    c = Object.new
+    class << c
+      define_method(:m) {|arg=1, **opt| }
+    end
+    assert_nil(c.m(**{}))
+    assert_nil(c.m(**kw))
+    assert_nil(c.m(**h))
+    assert_nil(c.m(**h2))
+    assert_nil(c.m(**h3))
+  end
+
   def p1
     Proc.new do |str: "foo", num: 424242|
       [str, num]

--- a/test/ruby/test_keyword.rb
+++ b/test/ruby/test_keyword.rb
@@ -185,7 +185,7 @@ class TestKeywordArguments < Test::Unit::TestCase
 
     f = -> { true }
     assert_equal(true, f[**{}])
-    assert_equal(true, f[**kw])
+    assert_raise(ArgumentError) { f[**kw] }
     assert_raise(ArgumentError) { f[**h] }
     assert_raise(ArgumentError) { f[a: 1] }
     assert_raise(ArgumentError) { f[**h2] }
@@ -193,7 +193,7 @@ class TestKeywordArguments < Test::Unit::TestCase
 
     f = ->(a) { a }
     assert_raise(ArgumentError) { f[**{}] }
-    assert_raise(ArgumentError) { f[**kw] }
+    assert_equal(kw, f[**kw])
     assert_equal(h, f[**h])
     assert_equal(h, f[a: 1])
     assert_equal(h2, f[**h2])
@@ -685,7 +685,7 @@ class TestKeywordArguments < Test::Unit::TestCase
       define_method(:m) { }
     end
     assert_nil(c.m(**{}))
-    assert_nil(c.m(**kw))
+    assert_raise(ArgumentError) { c.m(**kw) }
     assert_raise(ArgumentError) { c.m(**h) }
     assert_raise(ArgumentError) { c.m(a: 1) }
     assert_raise(ArgumentError) { c.m(**h2) }
@@ -697,7 +697,7 @@ class TestKeywordArguments < Test::Unit::TestCase
       define_method(:m) {|arg| arg }
     end
     assert_raise(ArgumentError) { c.m(**{}) }
-    assert_raise(ArgumentError) { c.m(**kw) }
+    assert_equal(kw, c.m(**kw))
     assert_equal(h, c.m(**h))
     assert_equal(h, c.m(a: 1))
     assert_equal(h2, c.m(**h2))

--- a/test/ruby/test_keyword.rb
+++ b/test/ruby/test_keyword.rb
@@ -261,7 +261,7 @@ class TestKeywordArguments < Test::Unit::TestCase
       end
     end
     assert_equal([], c[**{}].args)
-    assert_equal([], c[**kw].args)
+    assert_equal([{}], c[**kw].args)
     assert_equal([h], c[**h].args)
     assert_equal([h], c[a: 1].args)
     assert_equal([h2], c[**h2].args)
@@ -272,7 +272,7 @@ class TestKeywordArguments < Test::Unit::TestCase
       def initialize; end
     end
     assert_nil(c[**{}].args)
-    assert_nil(c[**kw].args)
+    assert_raise(ArgumentError) { c[**kw] }
     assert_raise(ArgumentError) { c[**h] }
     assert_raise(ArgumentError) { c[a: 1] }
     assert_raise(ArgumentError) { c[**h2] }
@@ -285,7 +285,7 @@ class TestKeywordArguments < Test::Unit::TestCase
       end
     end
     assert_raise(ArgumentError) { c[**{}] }
-    assert_raise(ArgumentError) { c[**kw] }
+    assert_equal(kw, c[**kw].args)
     assert_equal(h, c[**h].args)
     assert_equal(h, c[a: 1].args)
     assert_equal(h2, c[**h2].args)
@@ -311,7 +311,7 @@ class TestKeywordArguments < Test::Unit::TestCase
       end
     end
     assert_raise(ArgumentError) { c[**{}] }
-    assert_raise(ArgumentError) { c[**kw] }
+    assert_equal([kw, kw], c[**kw].args)
     assert_equal([h, kw], c[**h].args)
     assert_equal([h, kw], c[a: 1].args)
     assert_equal([h2, kw], c[**h2].args)
@@ -343,7 +343,7 @@ class TestKeywordArguments < Test::Unit::TestCase
       args
     end
     assert_equal([], c.method(:m)[**{}])
-    assert_equal([], c.method(:m)[**kw])
+    assert_equal([{}], c.method(:m)[**kw])
     assert_equal([h], c.method(:m)[**h])
     assert_equal([h], c.method(:m)[a: 1])
     assert_equal([h2], c.method(:m)[**h2])
@@ -353,7 +353,7 @@ class TestKeywordArguments < Test::Unit::TestCase
     c.singleton_class.remove_method(:m)
     def c.m; end
     assert_nil(c.method(:m)[**{}])
-    assert_nil(c.method(:m)[**kw])
+    assert_raise(ArgumentError) { c.method(:m)[**kw] }
     assert_raise(ArgumentError) { c.method(:m)[**h] }
     assert_raise(ArgumentError) { c.method(:m)[a: 1] }
     assert_raise(ArgumentError) { c.method(:m)[**h2] }
@@ -365,7 +365,7 @@ class TestKeywordArguments < Test::Unit::TestCase
       args
     end
     assert_raise(ArgumentError) { c.method(:m)[**{}] }
-    assert_raise(ArgumentError) { c.method(:m)[**kw] }
+    assert_equal(kw, c.method(:m)[**kw])
     assert_equal(h, c.method(:m)[**h])
     assert_equal(h, c.method(:m)[a: 1])
     assert_equal(h2, c.method(:m)[**h2])
@@ -389,7 +389,7 @@ class TestKeywordArguments < Test::Unit::TestCase
       [arg, args]
     end
     assert_raise(ArgumentError) { c.method(:m)[**{}] }
-    assert_raise(ArgumentError) { c.method(:m)[**kw] }
+    assert_equal([kw, kw], c.method(:m)[**kw])
     assert_equal([h, kw], c.method(:m)[**h])
     assert_equal([h, kw], c.method(:m)[a: 1])
     assert_equal([h2, kw], c.method(:m)[**h2])

--- a/test/ruby/test_keyword.rb
+++ b/test/ruby/test_keyword.rb
@@ -185,20 +185,42 @@ class TestKeywordArguments < Test::Unit::TestCase
 
     f = -> { true }
     assert_equal(true, f[**{}])
-    assert_raise(ArgumentError) { f[**kw] }
-    assert_raise(ArgumentError) { f[**h] }
-    assert_raise(ArgumentError) { f[a: 1] }
-    assert_raise(ArgumentError) { f[**h2] }
-    assert_raise(ArgumentError) { f[**h3] }
+    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
+      assert_raise(ArgumentError) { f[**kw] }
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
+      assert_raise(ArgumentError) { f[**h] }
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
+      assert_raise(ArgumentError) { f[a: 1] }
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
+      assert_raise(ArgumentError) { f[**h2] }
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
+      assert_raise(ArgumentError) { f[**h3] }
+    end
 
     f = ->(a) { a }
     assert_raise(ArgumentError) { f[**{}] }
-    assert_equal(kw, f[**kw])
-    assert_equal(h, f[**h])
-    assert_equal(h, f[a: 1])
-    assert_equal(h2, f[**h2])
-    assert_equal(h3, f[**h3])
-    assert_equal(h3, f[a: 1, **h2])
+    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
+      assert_equal(kw, f[**kw])
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
+      assert_equal(h, f[**h])
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
+      assert_equal(h, f[a: 1])
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
+      assert_equal(h2, f[**h2])
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
+      assert_equal(h3, f[**h3])
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
+      assert_equal(h3, f[a: 1, **h2])
+    end
 
     f = ->(**x) { x }
     assert_equal(kw, f[**{}])
@@ -685,24 +707,48 @@ class TestKeywordArguments < Test::Unit::TestCase
       define_method(:m) { }
     end
     assert_nil(c.m(**{}))
-    assert_raise(ArgumentError) { c.m(**kw) }
-    assert_raise(ArgumentError) { c.m(**h) }
-    assert_raise(ArgumentError) { c.m(a: 1) }
-    assert_raise(ArgumentError) { c.m(**h2) }
-    assert_raise(ArgumentError) { c.m(**h3) }
-    assert_raise(ArgumentError) { c.m(a: 1, **h2) }
+    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
+      assert_raise(ArgumentError) { c.m(**kw) }
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
+      assert_raise(ArgumentError) { c.m(**h) }
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
+      assert_raise(ArgumentError) { c.m(a: 1) }
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
+      assert_raise(ArgumentError) { c.m(**h2) }
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
+      assert_raise(ArgumentError) { c.m(**h3) }
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
+      assert_raise(ArgumentError) { c.m(a: 1, **h2) }
+    end
 
     c = Object.new
     class << c
       define_method(:m) {|arg| arg }
     end
     assert_raise(ArgumentError) { c.m(**{}) }
-    assert_equal(kw, c.m(**kw))
-    assert_equal(h, c.m(**h))
-    assert_equal(h, c.m(a: 1))
-    assert_equal(h2, c.m(**h2))
-    assert_equal(h3, c.m(**h3))
-    assert_equal(h3, c.m(a: 1, **h2))
+    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
+      assert_equal(kw, c.m(**kw))
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
+      assert_equal(h, c.m(**h))
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
+      assert_equal(h, c.m(a: 1))
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
+      assert_equal(h2, c.m(**h2))
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
+      assert_equal(h3, c.m(**h3))
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
+      assert_equal(h3, c.m(a: 1, **h2))
+    end
 
     c = Object.new
     class << c
@@ -1211,10 +1257,14 @@ class TestKeywordArguments < Test::Unit::TestCase
 
     o = Object.new
     def o.to_hash() { a: 1 } end
-    assert_equal({a: 1}, m1(**o) {|x| break x}, bug9898)
+    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
+      assert_equal({a: 1}, m1(**o) {|x| break x}, bug9898)
+    end
     o2 = Object.new
     def o2.to_hash() { b: 2 } end
-    assert_equal({a: 1, b: 2}, m1(**o, **o2) {|x| break x}, bug9898)
+    assert_warn(/The keyword argument is passed as the last hash parameter/m) do
+      assert_equal({a: 1, b: 2}, m1(**o, **o2) {|x| break x}, bug9898)
+    end
   end
 
   def test_implicit_hash_conversion

--- a/test/ruby/test_keyword.rb
+++ b/test/ruby/test_keyword.rb
@@ -594,80 +594,83 @@ class TestKeywordArguments < Test::Unit::TestCase
     def c.method_missing(_, *args)
       args
     end
-    assert_equal([], c.send(:m, **{}))
-    assert_equal([], c.send(:m, **kw))
-    assert_equal([h], c.send(:m, **h))
-    assert_equal([h], c.send(:m, a: 1))
-    assert_equal([h2], c.send(:m, **h2))
-    assert_equal([h3], c.send(:m, **h3))
-    assert_equal([h3], c.send(:m, a: 1, **h2))
+    assert_equal([], c.m(**{}))
+    assert_equal([], c.m(**kw))
+    assert_equal([h], c.m(**h))
+    assert_equal([h], c.m(a: 1))
+    assert_equal([h2], c.m(**h2))
+    assert_equal([h3], c.m(**h3))
+    assert_equal([h3], c.m(a: 1, **h2))
 
     c.singleton_class.remove_method(:method_missing)
     def c.method_missing(_); end
-    assert_nil(c.send(:m, **{}))
-    assert_nil(c.send(:m, **kw))
-    assert_raise(ArgumentError) { c.send(:m, **h) }
-    assert_raise(ArgumentError) { c.send(:m, a: 1) }
-    assert_raise(ArgumentError) { c.send(:m, **h2) }
-    assert_raise(ArgumentError) { c.send(:m, **h3) }
-    assert_raise(ArgumentError) { c.send(:m, a: 1, **h2) }
+    assert_nil(c.m(**{}))
+    assert_nil(c.m(**kw))
+    assert_raise(ArgumentError) { c.m(**h) }
+    assert_raise(ArgumentError) { c.m(a: 1) }
+    assert_raise(ArgumentError) { c.m(**h2) }
+    assert_raise(ArgumentError) { c.m(**h3) }
+    assert_raise(ArgumentError) { c.m(a: 1, **h2) }
 
     c.singleton_class.remove_method(:method_missing)
     def c.method_missing(_, args)
       args
     end
-    assert_raise(ArgumentError) { c.send(:m, **{}) }
-    assert_raise(ArgumentError) { c.send(:m, **kw) }
-    assert_equal(h, c.send(:m, **h))
-    assert_equal(h, c.send(:m, a: 1))
-    assert_equal(h2, c.send(:m, **h2))
-    assert_equal(h3, c.send(:m, **h3))
-    assert_equal(h3, c.send(:m, a: 1, **h2))
+    assert_raise(ArgumentError) { c.m(**{}) }
+    assert_raise(ArgumentError) { c.m(**kw) }
+    assert_equal(h, c.m(**h))
+    assert_equal(h, c.m(a: 1))
+    assert_equal(h2, c.m(**h2))
+    assert_equal(h3, c.m(**h3))
+    assert_equal(h3, c.m(a: 1, **h2))
 
     c.singleton_class.remove_method(:method_missing)
     def c.method_missing(_, **args)
       args
     end
-    assert_equal(kw, c.send(:m, **{}))
-    assert_equal(kw, c.send(:m, **kw))
-    assert_equal(h, c.send(:m, **h))
-    assert_equal(h, c.send(:m, a: 1))
-    assert_equal(h2, c.send(:m, **h2))
-    assert_equal(h3, c.send(:m, a: 1, **h2))
+    assert_equal(kw, c.m(**{}))
+    assert_equal(kw, c.m(**kw))
+    assert_equal(h, c.m(**h))
+    assert_equal(h, c.m(a: 1))
+    assert_equal(h2, c.m(**h2))
+    assert_equal(h3, c.m(a: 1, **h2))
 
     c.singleton_class.remove_method(:method_missing)
     def c.method_missing(_, arg, **args)
       [arg, args]
     end
-    assert_raise(ArgumentError) { c.send(:m, **{}) }
-    assert_raise(ArgumentError) { c.send(:m, **kw) }
+    assert_raise(ArgumentError) { c.m(**{}) }
+    assert_raise(ArgumentError) { c.send(:m, **kw) } # XXX: fix it after the commit
     assert_warn(/The keyword argument is passed as the last hash parameter.* for `method_missing'/m) do
-      assert_equal([h, kw], c.send(:m, **h))
+      assert_equal([kw, kw], c.m(**kw))
     end
     assert_warn(/The keyword argument is passed as the last hash parameter.* for `method_missing'/m) do
-      assert_equal([h, kw], c.send(:m, a: 1))
+      assert_equal([h, kw], c.m(**h))
     end
     assert_warn(/The keyword argument is passed as the last hash parameter.* for `method_missing'/m) do
-      assert_equal([h2, kw], c.send(:m, **h2))
+      assert_equal([h, kw], c.m(a: 1))
     end
     assert_warn(/The keyword argument is passed as the last hash parameter.* for `method_missing'/m) do
-      assert_equal([h3, kw], c.send(:m, **h3))
+      assert_equal([h2, kw], c.m(**h2))
     end
     assert_warn(/The keyword argument is passed as the last hash parameter.* for `method_missing'/m) do
-      assert_equal([h3, kw], c.send(:m, a: 1, **h2))
+      assert_equal([h3, kw], c.m(**h3))
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter.* for `method_missing'/m) do
+      assert_equal([h3, kw], c.m(a: 1, **h2))
     end
 
     c.singleton_class.remove_method(:method_missing)
     def c.method_missing(_, arg=1, **args)
       [arg=1, args]
     end
-    assert_equal([1, kw], c.send(:m, **{}))
-    assert_equal([1, kw], c.send(:m, **kw))
-    assert_equal([1, h], c.send(:m, **h))
-    assert_equal([1, h], c.send(:m, a: 1))
-    assert_equal([1, h2], c.send(:m, **h2))
-    assert_equal([1, h3], c.send(:m, **h3))
-    assert_equal([1, h3], c.send(:m, a: 1, **h2))
+    assert_equal([1, kw], c.m(**{}))
+    assert_equal([1, kw], c.m(**kw))
+    assert_equal([1, h], c.m(**h))
+    assert_equal([1, h], c.m(a: 1))
+    assert_equal([1, h2], c.m(**h2))
+    assert_equal([1, h3], c.m(**h3))
+    assert_equal([1, h3], c.m(a: 1, **h2))
   end
 
   def test_define_method_kwsplat

--- a/thread.c
+++ b/thread.c
@@ -681,7 +681,7 @@ thread_do_start(rb_thread_t *th)
 
         th->value = rb_vm_invoke_proc(th->ec, proc,
                                       (int)args_len, args_ptr,
-                                      VM_BLOCK_HANDLER_NONE);
+                                      0 /* kw_splat */, VM_BLOCK_HANDLER_NONE);
 
         EXEC_EVENT_HOOK(th->ec, RUBY_EVENT_THREAD_END, th->self, 0, 0, 0, Qundef);
     }

--- a/thread.c
+++ b/thread.c
@@ -681,7 +681,7 @@ thread_do_start(rb_thread_t *th)
 
         th->value = rb_vm_invoke_proc(th->ec, proc,
                                       (int)args_len, args_ptr,
-                                      0 /* kw_splat */, VM_BLOCK_HANDLER_NONE);
+                                      VM_NO_KEYWORDS, VM_BLOCK_HANDLER_NONE);
 
         EXEC_EVENT_HOOK(th->ec, RUBY_EVENT_THREAD_END, th->self, 0, 0, 0, Qundef);
     }

--- a/vm.c
+++ b/vm.c
@@ -1160,7 +1160,7 @@ static VALUE
 vm_yield_with_cref(rb_execution_context_t *ec, int argc, const VALUE *argv, const rb_cref_t *cref, int is_lambda)
 {
     return invoke_block_from_c_bh(ec, check_block_handler(ec),
-				  argc, argv, 0 /* kw_splat */, VM_BLOCK_HANDLER_NONE,
+                                  argc, argv, VM_NO_KEYWORDS, VM_BLOCK_HANDLER_NONE,
 				  cref, is_lambda, FALSE);
 }
 
@@ -1168,7 +1168,7 @@ static VALUE
 vm_yield(rb_execution_context_t *ec, int argc, const VALUE *argv)
 {
     return invoke_block_from_c_bh(ec, check_block_handler(ec),
-				  argc, argv, 0 /* kw_splat */, VM_BLOCK_HANDLER_NONE,
+                                  argc, argv, VM_NO_KEYWORDS, VM_BLOCK_HANDLER_NONE,
 				  NULL, FALSE, FALSE);
 }
 
@@ -1176,7 +1176,7 @@ static VALUE
 vm_yield_with_block(rb_execution_context_t *ec, int argc, const VALUE *argv, VALUE block_handler)
 {
     return invoke_block_from_c_bh(ec, check_block_handler(ec),
-				  argc, argv, 0 /* kw_splat */, block_handler,
+                                  argc, argv, VM_NO_KEYWORDS, block_handler,
 				  NULL, FALSE, FALSE);
 }
 
@@ -1184,7 +1184,7 @@ static VALUE
 vm_yield_force_blockarg(rb_execution_context_t *ec, VALUE args)
 {
     return invoke_block_from_c_bh(ec, check_block_handler(ec), 1, &args,
-				  0 /* kw_splat */, VM_BLOCK_HANDLER_NONE, NULL, FALSE, TRUE);
+                                  VM_NO_KEYWORDS, VM_BLOCK_HANDLER_NONE, NULL, FALSE, TRUE);
 }
 
 ALWAYS_INLINE(static VALUE

--- a/vm_args.c
+++ b/vm_args.c
@@ -581,7 +581,7 @@ ignore_keyword_hash_p(VALUE keyword_hash, const rb_iseq_t * const iseq) {
 
 VALUE rb_iseq_location(const rb_iseq_t *iseq);
 
-void
+MJIT_FUNC_EXPORTED void
 rb_warn_keyword_to_last_hash(struct rb_calling_info *calling, const struct rb_call_info *ci, const rb_iseq_t * const iseq)
 {
     VALUE name, loc;

--- a/vm_args.c
+++ b/vm_args.c
@@ -996,7 +996,7 @@ vm_to_proc(VALUE proc)
 	    rb_callable_method_entry_with_refinements(CLASS_OF(proc), idTo_proc, NULL);
 
 	if (me) {
-            b = rb_vm_call0(GET_EC(), proc, idTo_proc, 0, NULL, me);
+            b = rb_vm_call0(GET_EC(), proc, idTo_proc, 0, NULL, me, VM_NO_KEYWORDS);
 	}
 	else {
 	    /* NOTE: calling method_missing */
@@ -1047,7 +1047,7 @@ refine_sym_proc_call(RB_BLOCK_CALL_FUNC_ARGLIST(yielded_arg, callback_arg))
     if (!me) {
 	return method_missing(obj, mid, argc, argv, MISSING_NOENTRY);
     }
-    return rb_vm_call0(ec, obj, mid, argc, argv, me);
+    return rb_vm_call0(ec, obj, mid, argc, argv, me, VM_NO_KEYWORDS);
 }
 
 static VALUE

--- a/vm_args.c
+++ b/vm_args.c
@@ -969,7 +969,7 @@ vm_caller_setup_arg_splat(rb_control_frame_t *cfp, struct rb_calling_info *calli
 }
 
 static inline void
-vm_caller_setup_arg_kw(rb_control_frame_t *cfp, struct rb_calling_info *calling, const struct rb_call_info *ci, int cfunc)
+vm_caller_setup_arg_kw(rb_control_frame_t *cfp, struct rb_calling_info *calling, const struct rb_call_info *ci)
 {
     struct rb_call_info_with_kwarg *ci_kw = (struct rb_call_info_with_kwarg *)ci;
     const VALUE *const passed_keywords = ci_kw->kw_arg->keywords;

--- a/vm_args.c
+++ b/vm_args.c
@@ -581,7 +581,7 @@ ignore_keyword_hash_p(VALUE keyword_hash, const rb_iseq_t * const iseq) {
 
 VALUE rb_iseq_location(const rb_iseq_t *iseq);
 
-MJIT_FUNC_EXPORTED void
+static inline void
 rb_warn_keyword_to_last_hash(struct rb_calling_info *calling, const struct rb_call_info *ci, const rb_iseq_t * const iseq)
 {
     VALUE name, loc;

--- a/vm_args.c
+++ b/vm_args.c
@@ -985,6 +985,7 @@ vm_caller_setup_arg_kw(rb_control_frame_t *cfp, struct rb_calling_info *calling,
 
     cfp->sp -= kw_len - 1;
     calling->argc -= kw_len - 1;
+    calling->kw_splat = 1;
 }
 
 static VALUE

--- a/vm_args.c
+++ b/vm_args.c
@@ -584,7 +584,10 @@ VALUE rb_iseq_location(const rb_iseq_t *iseq);
 static inline void
 rb_warn_keyword_to_last_hash(struct rb_calling_info *calling, const struct rb_call_info *ci, const rb_iseq_t * const iseq)
 {
-    if (calling->recv == Qundef) return;
+    if (calling->recv == Qundef) {
+        rb_warn("The keyword argument is passed as the last hash parameter");
+        return;
+    }
     VALUE name = rb_id2str(ci->mid);
     VALUE loc = rb_iseq_location(iseq);
     if (NIL_P(loc)) {

--- a/vm_core.h
+++ b/vm_core.h
@@ -255,6 +255,7 @@ struct rb_calling_info {
     VALUE block_handler;
     VALUE recv;
     int argc;
+    int kw_splat;
 };
 
 struct rb_execution_context_struct;
@@ -1627,7 +1628,7 @@ void rb_iseq_pathobj_set(const rb_iseq_t *iseq, VALUE path, VALUE realpath);
 int rb_ec_frame_method_id_and_class(const rb_execution_context_t *ec, ID *idp, ID *called_idp, VALUE *klassp);
 void rb_ec_setup_exception(const rb_execution_context_t *ec, VALUE mesg, VALUE cause);
 
-VALUE rb_vm_invoke_proc(rb_execution_context_t *ec, rb_proc_t *proc, int argc, const VALUE *argv, VALUE block_handler);
+VALUE rb_vm_invoke_proc(rb_execution_context_t *ec, rb_proc_t *proc, int argc, const VALUE *argv, int kw_splat, VALUE block_handler);
 
 VALUE rb_vm_make_proc_lambda(const rb_execution_context_t *ec, const struct rb_captured_block *captured, VALUE klass, int8_t is_lambda);
 static inline VALUE

--- a/vm_core.h
+++ b/vm_core.h
@@ -1268,6 +1268,7 @@ VM_FRAME_RUBYFRAME_P(const rb_control_frame_t *cfp)
 
 #define VM_GUARDED_PREV_EP(ep)         GC_GUARDED_PTR(ep)
 #define VM_BLOCK_HANDLER_NONE 0
+#define VM_NO_KEYWORDS 0
 
 static inline int
 VM_ENV_LOCAL_P(const VALUE *ep)

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -56,6 +56,7 @@ rb_vm_call0(rb_execution_context_t *ec, VALUE recv, ID id, int argc, const VALUE
 
     calling->recv = recv;
     calling->argc = argc;
+    calling->kw_splat = 0;
 
     return vm_call0_body(ec, calling, &ci_entry, &cc_entry, argv);
 }
@@ -184,7 +185,7 @@ vm_call0_body(rb_execution_context_t *ec, struct rb_calling_info *calling, const
 	    {
 		rb_proc_t *proc;
 		GetProcPtr(calling->recv, proc);
-		ret = rb_vm_invoke_proc(ec, proc, calling->argc, argv, calling->block_handler);
+		ret = rb_vm_invoke_proc(ec, proc, calling->argc, argv, calling->kw_splat, calling->block_handler);
 		goto success;
 	    }
 	  default:

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -2255,7 +2255,7 @@ vm_call_bmethod_body(rb_execution_context_t *ec, struct rb_calling_info *calling
 
     /* control block frame */
     GetProcPtr(cc->me->def->body.bmethod.proc, proc);
-    val = rb_vm_invoke_bmethod(ec, proc, calling->recv, calling->argc, argv, calling->kw_splat, calling->block_handler, cc->me);
+    val = rb_vm_invoke_bmethod(ec, proc, calling->recv, calling->argc, argv, calling->kw_splat || (ci->flag & (VM_CALL_KWARG | VM_CALL_KW_SPLAT)), calling->block_handler, cc->me);
 
     return val;
 }
@@ -2412,7 +2412,8 @@ vm_call_method_missing(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, 
     CALLER_SETUP_ARG(reg_cfp, calling, orig_ci, 0);
     argc = calling->argc+1;
 
-    ci_entry.flag = VM_CALL_FCALL | VM_CALL_OPT_SEND | (orig_ci->flag & VM_CALL_KW_SPLAT);
+    ci_entry.flag = VM_CALL_FCALL | VM_CALL_OPT_SEND |
+                    (orig_ci->flag & (VM_CALL_KW_SPLAT |VM_CALL_KWARG) ? VM_CALL_KW_SPLAT : 0);
     ci_entry.mid = idMethodMissing;
     ci_entry.orig_argc = argc;
     ci = &ci_entry;
@@ -3015,7 +3016,7 @@ vm_invoke_symbol_block(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp,
     int argc;
     CALLER_SETUP_ARG(ec->cfp, calling, ci, 0);
     argc = calling->argc;
-    val = vm_yield_with_symbol(ec, symbol, argc, STACK_ADDR_FROM_TOP(argc), calling->kw_splat, calling->block_handler);
+    val = vm_yield_with_symbol(ec, symbol, argc, STACK_ADDR_FROM_TOP(argc), calling->kw_splat || (ci->flag & (VM_CALL_KWARG | VM_CALL_KW_SPLAT)), calling->block_handler);
     POPN(argc);
     return val;
 }

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1746,7 +1746,7 @@ CALLER_SETUP_ARG(struct rb_control_frame_struct *restrict cfp,
         vm_caller_setup_arg_splat(cfp, calling);
     }
     if (UNLIKELY(IS_ARGS_KEYWORD(ci))) {
-        vm_caller_setup_arg_kw(cfp, calling, ci, cfunc);
+        vm_caller_setup_arg_kw(cfp, calling, ci);
     }
 }
 

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -2192,6 +2192,7 @@ vm_call_cfunc_with_frame(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp
     if (UNLIKELY(calling->kw_splat)) {
         if (RHASH_EMPTY_P(*(GET_SP()-1))) {
             argc--;
+            calling->kw_splat = 0;
         }
     }
     if (UNLIKELY(IS_ARGS_KW_OR_KW_SPLAT(ci))) {
@@ -2927,6 +2928,7 @@ vm_callee_setup_block_arg(rb_execution_context_t *ec, struct rb_calling_info *ca
         if (UNLIKELY(calling->kw_splat)) {
             if (RHASH_EMPTY_P(argv[calling->argc-1])) {
                 calling->argc--;
+                calling->kw_splat = 0;
             }
         }
 

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -2279,7 +2279,7 @@ vm_call_bmethod(rb_execution_context_t *ec, rb_control_frame_t *cfp, struct rb_c
     VALUE *argv;
     int argc;
 
-    CALLER_SETUP_ARG(cfp, calling, ci, 1);
+    CALLER_SETUP_ARG(cfp, calling, ci, 0);
     argc = calling->argc;
     argv = ALLOCA_N(VALUE, argc);
     MEMCPY(argv, cfp->sp - argc, VALUE, argc);

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -2309,7 +2309,7 @@ vm_call_opt_send(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, struct
     struct rb_call_info_with_kwarg ci_entry;
     struct rb_call_cache cc_entry, *cc;
 
-    CALLER_SETUP_ARG(reg_cfp, calling, orig_ci, 1);
+    CALLER_SETUP_ARG(reg_cfp, calling, orig_ci, 0);
 
     i = calling->argc - 1;
 

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -2227,7 +2227,7 @@ vm_call_cfunc(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, struct rb
 {
     RB_DEBUG_COUNTER_INC(ccf_cfunc);
 
-    CALLER_SETUP_ARG(reg_cfp, calling, ci, 1);
+    CALLER_SETUP_ARG(reg_cfp, calling, ci, 0);
     return vm_call_cfunc_with_frame(ec, reg_cfp, calling, ci, cc);
 }
 

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -2866,11 +2866,10 @@ vm_yield_with_cfunc(rb_execution_context_t *ec,
     }
 
     blockarg = rb_vm_bh_to_procval(ec, block_handler);
-    /* XXX: Set VM_FRAME_FLAG_CFRAME_KW https://github.com/ruby/ruby/pull/2422 */
 
     vm_push_frame(ec, (const rb_iseq_t *)captured->code.ifunc,
                   VM_FRAME_MAGIC_IFUNC | VM_FRAME_FLAG_CFRAME |
-                  (me ? VM_FRAME_FLAG_BMETHOD : 0),
+                  (me ? VM_FRAME_FLAG_BMETHOD : 0) | (kw_splat ? VM_FRAME_FLAG_CFRAME_KW : 0),
 		  self,
 		  VM_GUARDED_PREV_EP(captured->ep),
                   (VALUE)me,

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -2255,7 +2255,7 @@ vm_call_bmethod_body(rb_execution_context_t *ec, struct rb_calling_info *calling
 
     /* control block frame */
     GetProcPtr(cc->me->def->body.bmethod.proc, proc);
-    val = rb_vm_invoke_bmethod(ec, proc, calling->recv, calling->argc, argv, calling->kw_splat || (ci->flag & (VM_CALL_KWARG | VM_CALL_KW_SPLAT)), calling->block_handler, cc->me);
+    val = rb_vm_invoke_bmethod(ec, proc, calling->recv, calling->argc, argv, calling->kw_splat, calling->block_handler, cc->me);
 
     return val;
 }
@@ -2412,8 +2412,7 @@ vm_call_method_missing(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, 
     CALLER_SETUP_ARG(reg_cfp, calling, orig_ci, 0);
     argc = calling->argc+1;
 
-    ci_entry.flag = VM_CALL_FCALL | VM_CALL_OPT_SEND |
-                    (orig_ci->flag & (VM_CALL_KW_SPLAT |VM_CALL_KWARG) ? VM_CALL_KW_SPLAT : 0);
+    ci_entry.flag = VM_CALL_FCALL | VM_CALL_OPT_SEND | (orig_ci->flag & VM_CALL_KW_SPLAT);
     ci_entry.mid = idMethodMissing;
     ci_entry.orig_argc = argc;
     ci = &ci_entry;
@@ -3016,7 +3015,7 @@ vm_invoke_symbol_block(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp,
     int argc;
     CALLER_SETUP_ARG(ec->cfp, calling, ci, 0);
     argc = calling->argc;
-    val = vm_yield_with_symbol(ec, symbol, argc, STACK_ADDR_FROM_TOP(argc), calling->kw_splat || (ci->flag & (VM_CALL_KWARG | VM_CALL_KW_SPLAT)), calling->block_handler);
+    val = vm_yield_with_symbol(ec, symbol, argc, STACK_ADDR_FROM_TOP(argc), calling->kw_splat, calling->block_handler);
     POPN(argc);
     return val;
 }

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -24,7 +24,6 @@ extern void rb_method_definition_set(const rb_method_entry_t *me, rb_method_defi
 extern int rb_method_definition_eq(const rb_method_definition_t *d1, const rb_method_definition_t *d2);
 extern VALUE rb_make_no_method_exception(VALUE exc, VALUE format, VALUE obj,
                                          int argc, const VALUE *argv, int priv);
-extern void rb_warn_keyword_to_last_hash(struct rb_calling_info *calling, const struct rb_call_info *ci, const rb_iseq_t * const iseq);
 
 /* control stack frame */
 

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -2884,8 +2884,7 @@ vm_yield_with_cfunc(rb_execution_context_t *ec,
 static VALUE
 vm_yield_with_symbol(rb_execution_context_t *ec,  VALUE symbol, int argc, const VALUE *argv, int kw_splat, VALUE block_handler)
 {
-    /* XXX: need to pass kw_splat? */
-    return rb_sym_proc_call(SYM2ID(symbol), argc, argv, rb_vm_bh_to_procval(ec, block_handler));
+    return rb_sym_proc_call(SYM2ID(symbol), argc, argv, kw_splat, rb_vm_bh_to_procval(ec, block_handler));
 }
 
 static inline int

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -2927,7 +2927,7 @@ vm_callee_setup_block_arg(rb_execution_context_t *ec, struct rb_calling_info *ca
 	rb_control_frame_t *cfp = ec->cfp;
 	VALUE arg0;
 
-	CALLER_SETUP_ARG(cfp, calling, ci, 1); /* splat arg */
+	CALLER_SETUP_ARG(cfp, calling, ci, 0); /* splat arg */
 
 	if (arg_setup_type == arg_setup_block &&
 	    calling->argc == 1 &&

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -2429,7 +2429,7 @@ vm_call_method_missing(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, 
     struct rb_call_cache cc_entry, *cc;
     unsigned int argc;
 
-    CALLER_SETUP_ARG(reg_cfp, calling, orig_ci);
+    CALLER_SETUP_ARG_WITHOUT_KW_SPLAT(reg_cfp, calling, orig_ci);
     argc = calling->argc+1;
 
     ci_entry.flag = VM_CALL_FCALL | VM_CALL_OPT_SEND | (calling->kw_splat ? VM_CALL_KW_SPLAT : 0);

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -2206,7 +2206,7 @@ vm_call_cfunc_with_frame(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp
     int argc = calling->argc;
     int orig_argc = argc;
 
-    if (UNLIKELY(IS_ARGS_KW_OR_KW_SPLAT(ci))) {
+    if (UNLIKELY(calling->kw_splat)) {
         frame_type |= VM_FRAME_FLAG_CFRAME_KW;
     }
 
@@ -2417,7 +2417,7 @@ vm_call_method_missing(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, 
     CALLER_SETUP_ARG(reg_cfp, calling, orig_ci, 0);
     argc = calling->argc+1;
 
-    ci_entry.flag = VM_CALL_FCALL | VM_CALL_OPT_SEND | (orig_ci->flag & VM_CALL_KW_SPLAT);
+    ci_entry.flag = VM_CALL_FCALL | VM_CALL_OPT_SEND | (calling->kw_splat ? VM_CALL_KW_SPLAT : 0);
     ci_entry.mid = idMethodMissing;
     ci_entry.orig_argc = argc;
     ci = &ci_entry;

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -2929,6 +2929,10 @@ vm_callee_setup_block_arg(rb_execution_context_t *ec, struct rb_calling_info *ca
 
 	CALLER_SETUP_ARG(cfp, calling, ci, 0); /* splat arg */
 
+        if (calling->kw_splat) {
+            rb_warn_keyword_to_last_hash(calling, ci, iseq);
+        }
+
 	if (arg_setup_type == arg_setup_block &&
 	    calling->argc == 1 &&
 	    iseq->body->param.flags.has_lead &&

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -2609,14 +2609,14 @@ vm_call_method_each_type(rb_execution_context_t *ec, rb_control_frame_t *cfp, st
 	return vm_call_cfunc(ec, cfp, calling, ci, cc);
 
       case VM_METHOD_TYPE_ATTRSET:
-	CALLER_SETUP_ARG(cfp, calling, ci, 0);
+	CALLER_SETUP_ARG(cfp, calling, ci, 1);
 	rb_check_arity(calling->argc, 1, 1);
 	cc->aux.index = 0;
         CC_SET_FASTPATH(cc, vm_call_attrset, !((ci->flag & VM_CALL_ARGS_SPLAT) || (ci->flag & VM_CALL_KWARG)));
 	return vm_call_attrset(ec, cfp, calling, ci, cc);
 
       case VM_METHOD_TYPE_IVAR:
-	CALLER_SETUP_ARG(cfp, calling, ci, 0);
+	CALLER_SETUP_ARG(cfp, calling, ci, 1);
 	rb_check_arity(calling->argc, 0, 0);
 	cc->aux.index = 0;
         CC_SET_FASTPATH(cc, vm_call_ivar, !(ci->flag & VM_CALL_ARGS_SPLAT));

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1743,12 +1743,22 @@ CALLER_SETUP_ARG(struct rb_control_frame_struct *restrict cfp,
                  const struct rb_call_info *restrict ci, int remove_empty_keyword_hash)
 {
     if (UNLIKELY(IS_ARGS_SPLAT(ci))) {
+        /* This expands the rest argument to the stack.
+         * So, ci->flag & VM_CALL_ARGS_SPLAT is now inconsistent.
+         */
         vm_caller_setup_arg_splat(cfp, calling);
     }
     if (UNLIKELY(IS_ARGS_KEYWORD(ci))) {
+        /* This converts VM_CALL_KWARG style to VM_CALL_KW_SPLAT style
+         * by creating a keyword hash.
+         * So, ci->flag & VM_CALL_KWARG is now inconsistent.
+         */
         vm_caller_setup_arg_kw(cfp, calling, ci);
     }
     if (UNLIKELY(calling->kw_splat && remove_empty_keyword_hash)) {
+        /* This removes the last Hash object if it is empty.
+         * So, ci->flag & VM_CALL_KW_SPLAT is now inconsistent.
+         */
         if (RHASH_EMPTY_P(cfp->sp[-1])) {
             cfp->sp--;
             calling->argc--;

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -3039,7 +3039,7 @@ vm_invoke_symbol_block(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp,
 {
     VALUE val;
     int argc;
-    CALLER_SETUP_ARG(ec->cfp, calling, ci);
+    CALLER_SETUP_ARG_WITHOUT_KW_SPLAT(ec->cfp, calling, ci);
     argc = calling->argc;
     val = vm_yield_with_symbol(ec, symbol, argc, STACK_ADDR_FROM_TOP(argc), calling->kw_splat, calling->block_handler);
     POPN(argc);

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -2294,7 +2294,7 @@ vm_call_bmethod(rb_execution_context_t *ec, rb_control_frame_t *cfp, struct rb_c
     VALUE *argv;
     int argc;
 
-    CALLER_SETUP_ARG(cfp, calling, ci);
+    CALLER_SETUP_ARG_WITHOUT_KW_SPLAT(cfp, calling, ci);
     argc = calling->argc;
     argv = ALLOCA_N(VALUE, argc);
     MEMCPY(argv, cfp->sp - argc, VALUE, argc);
@@ -2949,10 +2949,12 @@ vm_callee_setup_block_arg(rb_execution_context_t *ec, struct rb_calling_info *ca
 	rb_control_frame_t *cfp = ec->cfp;
 	VALUE arg0;
 
-        CALLER_SETUP_ARG(cfp, calling, ci);
-
-        if (calling->kw_splat) {
+        if (calling->kw_splat && calling->argc == iseq->body->param.lead_num + iseq->body->param.post_num && RHASH_EMPTY_P(cfp->sp[-1])) {
+            CALLER_SETUP_ARG_WITHOUT_KW_SPLAT(cfp, calling, ci);
             rb_warn_keyword_to_last_hash(calling, ci, iseq);
+        }
+        else {
+            CALLER_SETUP_ARG(cfp, calling, ci);
         }
 
 	if (arg_setup_type == arg_setup_block &&

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1576,7 +1576,7 @@ rb_eql_opt(VALUE obj1, VALUE obj2)
     return opt_eql_func(obj1, obj2, &ci, &cc);
 }
 
-extern VALUE rb_vm_call0(rb_execution_context_t *ec, VALUE, ID, int, const VALUE*, const rb_callable_method_entry_t *);
+extern VALUE rb_vm_call0(rb_execution_context_t *ec, VALUE, ID, int, const VALUE*, const rb_callable_method_entry_t *, int kw_splat);
 
 static VALUE
 check_match(rb_execution_context_t *ec, VALUE pattern, VALUE target, enum vm_check_match_type type)
@@ -1593,7 +1593,7 @@ check_match(rb_execution_context_t *ec, VALUE pattern, VALUE target, enum vm_che
 	const rb_callable_method_entry_t *me =
 	    rb_callable_method_entry_with_refinements(CLASS_OF(pattern), idEqq, NULL);
 	if (me) {
-            return rb_vm_call0(ec, pattern, idEqq, 1, &target, me);
+            return rb_vm_call0(ec, pattern, idEqq, 1, &target, me, VM_NO_KEYWORDS);
 	}
 	else {
 	    /* fallback to funcall (e.g. method_missing) */

--- a/vm_method.c
+++ b/vm_method.c
@@ -1921,7 +1921,7 @@ call_method_entry(rb_execution_context_t *ec, VALUE defined_class, VALUE obj, ID
     const rb_callable_method_entry_t *cme =
 	prepare_callable_method_entry(defined_class, id, me);
     VALUE passed_block_handler = vm_passed_block_handler(ec);
-    VALUE result = rb_vm_call0(ec, obj, id, argc, argv, cme);
+    VALUE result = rb_vm_call0(ec, obj, id, argc, argv, cme, VM_NO_KEYWORDS);
     vm_passed_block_handler_set(ec, passed_block_handler);
     return result;
 }


### PR DESCRIPTION
This rebases #2425 (which fixes keyword argument warnings for define_method) after 39c3252cd175074581855e5f9681cc723c15ff72 so it can pick up the `VM_FRAME_FLAG_CFRAME_KW` flag.  It also adds a `VM_NO_KEYWORDS` constant to avoid the need to use comments for documentation.

To fix keyword argument warnings for symbol procs, this adds `rb_funcall_with_block_kw`, which allows C functions to call Ruby methods treating the last argument as keywords.

This also fixes empty keyword hash removal to unset the keyword hash flag.  That hadn't caused any problems yet, but probably would cause problems in the future.