### PR TITLE
Add version that FreeBSD supports `CLOCK_PROCESS_CPUTIME_ID` [ci skip]

### DIFF
--- a/process.c
+++ b/process.c
@@ -7660,7 +7660,7 @@ ruby_real_ms_time(void)
  *
  *  [CLOCK_REALTIME] SUSv2 to 4, Linux 2.5.63, FreeBSD 3.0, NetBSD 2.0, OpenBSD 2.1, macOS 10.12
  *  [CLOCK_MONOTONIC] SUSv3 to 4, Linux 2.5.63, FreeBSD 3.0, NetBSD 2.0, OpenBSD 3.4, macOS 10.12
- *  [CLOCK_PROCESS_CPUTIME_ID] SUSv3 to 4, Linux 2.5.63, OpenBSD 5.4, macOS 10.12
+ *  [CLOCK_PROCESS_CPUTIME_ID] SUSv3 to 4, Linux 2.5.63, FreeBSD 9.3, OpenBSD 5.4, macOS 10.12
  *  [CLOCK_THREAD_CPUTIME_ID] SUSv3 to 4, Linux 2.5.63, FreeBSD 7.1, OpenBSD 5.4, macOS 10.12
  *  [CLOCK_VIRTUAL] FreeBSD 3.0, OpenBSD 2.1
  *  [CLOCK_PROF] FreeBSD 3.0, OpenBSD 2.1


### PR DESCRIPTION
Seems FreeBSD already supported `CLOCK_PROCESS_CPUTIME_ID`.
That added by https://reviews.freebsd.org/rS239347 and the doc was updated by https://reviews.freebsd.org/rS315694.

I confirmed `CLOCK_PROCESS_CPUTIME_ID` constant exists in 9.3.0 branch.
https://github.com/freebsd/freebsd/blob/release/9.3.0/sys/sys/time.h#L269