### PR TITLE
Fix a class of fstring related use-after-free

### DIFF
--- a/string.c
+++ b/string.c
@@ -307,16 +307,12 @@ RUBY_FUNC_EXPORTED
 VALUE
 rb_fstring(VALUE str)
 {
-    VALUE fstr;
-    int bare;
-
     Check_Type(str, T_STRING);
 
     if (FL_TEST(str, RSTRING_FSTR))
 	return str;
 
-    bare = BARE_STRING_P(str);
-    if (STR_EMBED_P(str) && !bare) {
+    if (!BARE_STRING_P(str)) {
 	OBJ_FREEZE_RAW(str);
 	return str;
     }
@@ -324,14 +320,7 @@ rb_fstring(VALUE str)
     if (!OBJ_FROZEN(str))
         rb_str_resize(str, RSTRING_LEN(str));
 
-    fstr = register_fstring(str);
-
-    if (!bare) {
-	str_replace_shared_without_enc(str, fstr);
-	OBJ_FREEZE_RAW(str);
-	return str;
-    }
-    return fstr;
+    return register_fstring(str);
 }
 
 static VALUE

--- a/test/-ext-/string/test_fstring.rb
+++ b/test/-ext-/string/test_fstring.rb
@@ -71,4 +71,13 @@ class Test_String_Fstring < Test::Unit::TestCase
     str.freeze
     assert_fstring(str) {|s| assert_instance_of(S, s)}
   end
+
+  def test_shared_string_safety
+    -('a' * 30).force_encoding(Encoding::ASCII)
+    str = ('a' * 30).force_encoding(Encoding::ASCII).taint
+    frozen_str = Bug::String.rb_str_new_frozen(str)
+    assert_fstring(frozen_str) {|s| assert_equal(str, s)}
+    GC.start
+    assert_equal('a' * 30, str, "[Bug #16151]")
+  end
 end


### PR DESCRIPTION
rb_fstring used to replace/free the buffer of the input string when it
is not bare and not embedable. This mechanism causes use-after-free when
rb_fstring is given a string that other strings depend on.

Remove this mechanism since we cannot easily tell whether a string is
a shared root to provide the mechanism safely.

For more details, see [Bug #16151](https://bugs.ruby-lang.org/issues/16151)

---
EDIT:
I added a `GC.start` in the test per nobu's suggestion at http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/94838 in case my approach is acceptable. On my Linux box GC.start isn't necessary to trigger the bug, but I guess it is necessary to scrub the freed memory for other systems.
