### PR TITLE
Fix keyword argument separation issues in forwardable

### DIFF
--- a/lib/forwardable.rb
+++ b/lib/forwardable.rb
@@ -204,7 +204,7 @@ module Forwardable
       accessor = "#{accessor}()"
     end
 
-    method_call = ".__send__(:#{method}, *args, &block)"
+    method_call = ".__send__(:#{method}, *args, **kw, &block)"
     if _valid_method?(method)
       loc, = caller_locations(2,1)
       pre = "_ ="
@@ -215,7 +215,7 @@ module Forwardable
             ::Kernel.warn #{mesg.dump}"\#{_.class}"'##{method}', uplevel: 1
             _#{method_call}
           else
-            _.#{method}(*args, &block)
+            _.#{method}(*args, **kw, &block)
           end
         end;
     end
@@ -223,7 +223,7 @@ module Forwardable
     _compile_method("#{<<-"begin;"}\n#{<<-"end;"}", __FILE__, __LINE__+1)
     begin;
       proc do
-        def #{ali}(*args, &block)
+        def #{ali}(*args, **kw, &block)
           #{pre}
           begin
             #{accessor}

--- a/test/test_forwardable.rb
+++ b/test/test_forwardable.rb
@@ -16,6 +16,10 @@ class TestForwardable < Test::Unit::TestCase
     def delegated2
       RETURNED2
     end
+
+    def delegated1_kw(**kw)
+      [RETURNED1, kw]
+    end
   end
 
   def test_def_instance_delegator
@@ -25,6 +29,18 @@ class TestForwardable < Test::Unit::TestCase
       end
 
       assert_same RETURNED1, cls.new.delegated1
+    end
+  end
+
+  def test_def_instance_delegator_kw
+    %i[def_delegator def_instance_delegator].each do |m|
+      cls = forwardable_class do
+        __send__ m, :@receiver, :delegated1_kw
+      end
+
+      ary = cls.new.delegated1_kw b: 1
+      assert_same RETURNED1, ary[0]
+      assert_equal({b: 1}, ary[1])
     end
   end
 


### PR DESCRIPTION
Found when working on fixing keyword argument separation issues in
capybara.