### PR TITLE
Make Symbol#to_s return a frozen String, the same String for a given Symbol

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -197,6 +197,14 @@ RubyVM::
     * RubyVM.resolve_feature_path moved to
       $LOAD_PATH.resolve_feature_path.  [Feature #15903] [Feature #15230]
 
+Symbol::
+
+  Modified method::
+
+    * Symbol#to_s now always returns a frozen String. The returned String is
+      always the same for a given Symbol. This change is experimental.
+      [Feature #16150]
+
 Time::
 
   New methods::

--- a/spec/ruby/core/symbol/shared/id2name.rb
+++ b/spec/ruby/core/symbol/shared/id2name.rb
@@ -6,4 +6,21 @@ describe :symbol_id2name, shared: true do
     :@ruby.send(@method).should == "@ruby"
     :@@ruby.send(@method).should == "@@ruby"
   end
+
+  ruby_version_is "2.7" do
+    it "returns a frozen String" do
+      :my_symbol.to_s.frozen?.should == true
+      :"dynamic symbol #{6 * 7}".to_s.frozen?.should == true
+    end
+
+    it "always returns the same String for a given Symbol" do
+      s1 = :my_symbol.to_s
+      s2 = :my_symbol.to_s
+      s1.should equal(s2)
+
+      s1 = :"dynamic symbol #{6 * 7}".to_s
+      s2 = :"dynamic symbol #{2 * 3 * 7}".to_s
+      s1.should equal(s2)
+    end
+  end
 end

--- a/string.c
+++ b/string.c
@@ -10856,7 +10856,8 @@ sym_inspect(VALUE sym)
  *     sym.id2name   -> string
  *     sym.to_s      -> string
  *
- *  Returns the name or string corresponding to <i>sym</i>.
+ *  Returns a frozen string corresponding to <i>sym</i>.
+ *  The returned String is always the same String instance for a given Symbol.
  *
  *     :fred.id2name   #=> "fred"
  *     :ginger.to_s    #=> "ginger"
@@ -10866,7 +10867,7 @@ sym_inspect(VALUE sym)
 VALUE
 rb_sym_to_s(VALUE sym)
 {
-    return str_new_shared(rb_cString, rb_sym2str(sym));
+    return rb_sym2str(sym);
 }
 
 

--- a/test/-ext-/string/test_capacity.rb
+++ b/test/-ext-/string/test_capacity.rb
@@ -14,7 +14,9 @@ class Test_StringCapacity < Test::Unit::TestCase
   end
 
   def test_capacity_shared
-    assert_equal 0, capa(:abcdefghijklmnopqrstuvwxyz.to_s)
+    str = :abcdefghijklmnopqrstuvwxyz.to_s.dup
+    assert Bug::String.shared_string? str
+    assert_equal 0, capa(str)
   end
 
   def test_capacity_normal


### PR DESCRIPTION
* Avoids extra allocations whenever calling Symbol#to_s.
* See https://bugs.ruby-lang.org/issues/16150
* `make test-spec` and `make test-all` both pass, with only one change in `test-all`.