### PR TITLE
Make Delegate delegate keyword arguments

### DIFF
--- a/lib/delegate.rb
+++ b/lib/delegate.rb
@@ -75,16 +75,16 @@ class Delegator < BasicObject
   #
   # Handles the magic of delegation through \_\_getobj\_\_.
   #
-  def method_missing(m, *args, &block)
+  def method_missing(m, *args, **kw, &block)
     r = true
     target = self.__getobj__ {r = false}
 
     if r && target.respond_to?(m)
-      target.__send__(m, *args, &block)
+      target.__send__(m, *args, **kw, &block)
     elsif ::Kernel.method_defined?(m) || ::Kernel.private_method_defined?(m)
       ::Kernel.instance_method(m).bind(self).(*args, &block)
     else
-      super(m, *args, &block)
+      super
     end
   end
 

--- a/lib/delegate.rb
+++ b/lib/delegate.rb
@@ -75,7 +75,7 @@ class Delegator < BasicObject
   #
   # Handles the magic of delegation through \_\_getobj\_\_.
   #
-  def method_missing(m, *args, **kw, &block)
+  pass_positional_hash def method_missing(m, *args, **kw, &block)
     r = true
     target = self.__getobj__ {r = false}
 

--- a/mjit_compile.c
+++ b/mjit_compile.c
@@ -217,7 +217,7 @@ compile_inlined_cancel_handler(FILE *f, const struct rb_iseq_constant_body *body
     fprintf(f, "    calling.argc = %d;\n", inline_context->orig_argc);
     fprintf(f, "    calling.recv = reg_cfp->self;\n");
     fprintf(f, "    reg_cfp->self = orig_self;\n");
-    fprintf(f, "    vm_call_iseq_setup_normal(ec, reg_cfp, &calling, (const rb_callable_method_entry_t *)0x%"PRIxVALUE", 0, %d, %d);\n\n",
+    fprintf(f, "    vm_call_iseq_setup_normal(ec, reg_cfp, &calling, (const rb_callable_method_entry_t *)0x%"PRIxVALUE", 0, %d, %d, 0);\n\n",
             inline_context->me, inline_context->param_size, inline_context->local_size); // fastpath_applied_iseq_p checks rb_simple_iseq_p, which ensures has_opt == FALSE
 
     // Start usual cancel from here.

--- a/test/test_delegate.rb
+++ b/test/test_delegate.rb
@@ -197,12 +197,10 @@ class TestDelegateClass < Test::Unit::TestCase
     assert_equal([], d.bar)
     assert_equal([[], {:a=>1}], d.foo(:a=>1))
     assert_equal([{:a=>1}], d.bar(:a=>1))
-    assert_warn(/The last argument is used as the keyword parameter.* for `method_missing'/m) do
+    assert_warn(/The last argument is used as the keyword parameter.* for `foo'/m) do
       assert_equal([[], {:a=>1}], d.foo({:a=>1}))
     end
-    assert_warn(/The last argument is used as the keyword parameter.* for `method_missing'/m) do
-      assert_equal([{:a=>1}], d.bar({:a=>1}))
-    end
+    assert_equal([{:a=>1}], d.bar({:a=>1}))
   end
 
   def test_private_method

--- a/test/test_delegate.rb
+++ b/test/test_delegate.rb
@@ -184,6 +184,27 @@ class TestDelegateClass < Test::Unit::TestCase
     end
   end
 
+  def test_keyword_and_hash
+    foo = Object.new
+    def foo.bar(*args)
+      args
+    end
+    def foo.foo(*args, **kw)
+      [args, kw]
+    end
+    d = SimpleDelegator.new(foo)
+    assert_equal([[], {}], d.foo)
+    assert_equal([], d.bar)
+    assert_equal([[], {:a=>1}], d.foo(:a=>1))
+    assert_equal([{:a=>1}], d.bar(:a=>1))
+    assert_warn(/The last argument is used as the keyword parameter.* for `method_missing'/m) do
+      assert_equal([[], {:a=>1}], d.foo({:a=>1}))
+    end
+    assert_warn(/The last argument is used as the keyword parameter.* for `method_missing'/m) do
+      assert_equal([{:a=>1}], d.bar({:a=>1}))
+    end
+  end
+
   def test_private_method
     foo = Foo.new
     d = SimpleDelegator.new(foo)

--- a/tool/mk_call_iseq_optimized.rb
+++ b/tool/mk_call_iseq_optimized.rb
@@ -24,7 +24,7 @@ static VALUE
 #{fname(param, local)}(rb_execution_context_t *ec, rb_control_frame_t *cfp, struct rb_calling_info *calling, const struct rb_call_info *ci, struct rb_call_cache *cc)
 {
     RB_DEBUG_COUNTER_INC(ccf_iseq_fix);
-    return vm_call_iseq_setup_normal(ec, cfp, calling, cc->me, 0, #{param}, #{local});
+    return vm_call_iseq_setup_normal(ec, cfp, calling, cc->me, 0, #{param}, #{local}, 0);
 }
 
 EOS

--- a/tool/ruby_vm/views/_mjit_compile_send.erb
+++ b/tool/ruby_vm/views/_mjit_compile_send.erb
@@ -68,7 +68,7 @@
 % # JIT: Special CALL_METHOD. Bypass cc_copy->call and inline vm_call_iseq_setup_normal for vm_call_iseq_setup_func FASTPATH.
                 fprintf(f, "        {\n");
                 fprintf(f, "            VALUE v;\n");
-                fprintf(f, "            vm_call_iseq_setup_normal(ec, reg_cfp, &calling, (const rb_callable_method_entry_t *)0x%"PRIxVALUE", 0, %d, %d);\n",
+                fprintf(f, "            vm_call_iseq_setup_normal(ec, reg_cfp, &calling, (const rb_callable_method_entry_t *)0x%"PRIxVALUE", 0, %d, %d, 0);\n",
                         (VALUE)cc_copy->me, param_size, iseq->body->local_table_size); // fastpath_applied_iseq_p checks rb_simple_iseq_p, which ensures has_opt == FALSE
                 if (iseq->body->catch_except_p) {
                     fprintf(f, "            VM_ENV_FLAGS_SET(ec->cfp->ep, VM_FRAME_FLAG_FINISH);\n");

--- a/vm_core.h
+++ b/vm_core.h
@@ -358,6 +358,7 @@ struct rb_iseq_constant_body {
 
 	    unsigned int ambiguous_param0 : 1; /* {|a|} */
 	    unsigned int accepts_no_kwarg : 1;
+            unsigned int pass_positional_hash: 1; /* -- Remove In 3.0 -- */
 	} flags;
 
 	unsigned int size;
@@ -1138,11 +1139,11 @@ typedef rb_control_frame_t *
 
 enum {
     /* Frame/Environment flag bits:
-     *   MMMM MMMM MMMM MMMM ____ FFFF FFFF EEEX (LSB)
+     *   MMMM MMMM MMMM MMMM ___F FFFF FFFF EEEX (LSB)
      *
      * X   : tag for GC marking (It seems as Fixnum)
      * EEE : 3 bits Env flags
-     * FF..: 8 bits Frame flags
+     * FF..: 9 bits Frame flags
      * MM..: 15 bits frame magic (to check frame corruption)
      */
 
@@ -1168,6 +1169,7 @@ enum {
     VM_FRAME_FLAG_MODIFIED_BLOCK_PARAM = 0x0200,
     VM_FRAME_FLAG_CFRAME_KW = 0x0400,
     VM_FRAME_FLAG_CFRAME_EMPTY_KW = 0x0800, /* -- Remove In 3.0 -- */
+    VM_FRAME_FLAG_PASS_POSITIONAL_HASH = 0x1000, /* -- Remove In 3.0 -- */
 
     /* env flag */
     VM_ENV_FLAG_LOCAL       = 0x0002,
@@ -1233,6 +1235,11 @@ static inline int
 VM_FRAME_CFRAME_EMPTY_KW_P(const rb_control_frame_t *cfp)
 {
     return VM_ENV_FLAGS(cfp->ep, VM_FRAME_FLAG_CFRAME_EMPTY_KW) != 0;
+}
+static inline int
+VM_FRAME_PASS_POSITIONAL_HASH_P(const rb_control_frame_t *cfp)
+{
+    return VM_ENV_FLAGS(cfp->ep, VM_FRAME_FLAG_PASS_POSITIONAL_HASH) != 0;
 }
 
 static inline int

--- a/vm_method.c
+++ b/vm_method.c
@@ -1757,10 +1757,15 @@ rb_mod_private(int argc, VALUE *argv, VALUE module)
  *
  *  This should only be used for methods that delegate keywords to another
  *  method, suppressing a warning when the target method does not accept
- *  keyword arguments the final argument is a hash.
+ *  keyword arguments and the final positional argument is a hash.
  *
- *  Will only be present in 2.7, will be removed in 3.0, so always check that
- *  the module responds to this method before calling it.
+ *  +pass_positional_hash+ should only called with a method if keyword arguments are
+ *  not modified inside the method before splatting, and additional arguments are
+ *  not appended to the array of positional arguments.  Otherwise the behavior may
+ *  differ in Ruby 3 and will not be warned about.
+ *
+ *  +pass_positional_hash+ is only be present in 2.7, it will be removed in 3.0. You
+ *  should always check that the module responds to this method before calling it.
  *
  *    module Mod
  *      def foo(meth, *args, **kw, &block)


### PR DESCRIPTION
In order to implement this without warning in case where the final
argument is a hash and the target method does not accept keyword
arguments, add `Module#pass_positional_hash` for fixing keyword
argument separation warnings in delegating methods.

In Ruby <=2.6, delegation was often done using:

```ruby
def foo(*args, &block)
  bar(*args, &block)
end
```

With the keyword argument separation changes recently added, this now
causes a warning if bar accepts keyword arguments, as that will break
in Ruby 3.  You need to switch to delegating keyword arguments:

```ruby
def foo(*args, **kw, &block)
  bar(*args, **kw, &block)
end
```

This works and fixes the delegation.  However, if the final positional
argument is a hash, you will get a keyword argument separation
warning.  That is fine if bar accepts keyword arguments, as the
warning is to alert you to a change in behavior.  However, if bar does
not accept keyword arguments, then you get a warning even though the
behavior will not change in Ruby 3, because the keywords will be
converted back to a positional hash.

To avoid this unhelpful warning, but still keep helpful warnings, we
need a way to flag a method such that if the method is called with a
positional hash that is converted to a keyword argument, keyword
splats inside that method will be implicitly converted to positional
hashes.

This implements such support using a VM frame flag.  This flag is only
for use in 2.7, and will be going away in Ruby 3.0.  If we would
normally warn for positional hash to keyword conversion, suppress
the warning, and set a flag in the next VM frame to implicitly
convert keyword splats to positional hashes.

Use this in the delegate library to avoid warning in the case where
warning is not necessary.