### PR TITLE
Add compaction support to `rb_ast_t`

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -7918,6 +7918,8 @@ gc_ref_update_imemo(rb_objspace_t *objspace, VALUE obj)
         rb_iseq_update_references((rb_iseq_t *)obj);
         break;
       case imemo_ast:
+        rb_ast_update_references((rb_ast_t *)obj);
+        break;
       case imemo_parser_strterm:
       case imemo_tmpbuf:
         break;

--- a/node.h
+++ b/node.h
@@ -405,6 +405,7 @@ typedef struct rb_ast_struct {
 } rb_ast_t;
 rb_ast_t *rb_ast_new(void);
 void rb_ast_mark(rb_ast_t*);
+void rb_ast_update_references(rb_ast_t*);
 void rb_ast_dispose(rb_ast_t*);
 void rb_ast_free(rb_ast_t*);
 size_t rb_ast_memsize(const rb_ast_t*);

--- a/test/ruby/test_gc_compact.rb
+++ b/test/ruby/test_gc_compact.rb
@@ -130,4 +130,18 @@ class TestGCCompact < Test::Unit::TestCase
     GC.verify_compaction_references(toward: :empty)
     assert_equal hash, list_of_objects.hash
   end
+
+  def walk_ast ast
+    children = ast.children.grep(RubyVM::AbstractSyntaxTree::Node)
+    children.each do |child|
+      assert child.type
+      walk_ast child
+    end
+  end
+
+  def test_ast_compacts
+    ast = RubyVM::AbstractSyntaxTree.parse_file __FILE__
+    assert GC.compact
+    walk_ast ast
+  end
 end


### PR DESCRIPTION
This commit adds compaction support to `rb_ast_t`.

I tested this with the following benchmark:

```ruby
require "objspace"

file_contents = File.binread ARGV[0]

GC.compact
ast = RubyVM::AbstractSyntaxTree.parse file_contents
GC.compact
File.open("heap.json", "wb") { |f| ObjectSpace.dump_all output: f }
```

Then:

```
$ ./ruby --disable-gems ast_bench.rb enc/trans/gb18030-tbl.rb
```

When I graph the heap, before this patch the heap looks like:

![heap](https://user-images.githubusercontent.com/3124/64571730-9d681d00-d319-11e9-8e2a-224cebf20e52.png)

Red dots are unmovable objects, black dots are movable, clear is empty.  After this patch is applied:

![heap2](https://user-images.githubusercontent.com/3124/64571748-af49c000-d319-11e9-86eb-09518a199045.png)

Now most objects are movable.
