### PR TITLE
Right size the numtable in insn_make_insn_table to VM_INSTRUCTION_SIZE

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -8619,7 +8619,7 @@ insn_make_insn_table(void)
 {
     struct st_table *table;
     int i;
-    table = st_init_numtable();
+    table = st_init_numtable_with_size(VM_INSTRUCTION_SIZE);
 
     for (i=0; i<VM_INSTRUCTION_SIZE; i++) {
 	st_insert(table, ID2SYM(rb_intern(insn_name(i))), i);


### PR DESCRIPTION
For consistent use of other tables initialized with known size `VM_INSTRUCTION_SIZE`