### PR TITLE
Add Module#ruby2_keywords for passing keyword arguments through regular splats

### DIFF
--- a/lib/delegate.rb
+++ b/lib/delegate.rb
@@ -75,7 +75,7 @@ class Delegator < BasicObject
   #
   # Handles the magic of delegation through \_\_getobj\_\_.
   #
-  pass_keywords def method_missing(m, *args, &block)
+  ruby2_keywords def method_missing(m, *args, &block)
     r = true
     target = self.__getobj__ {r = false}
 

--- a/lib/delegate.rb
+++ b/lib/delegate.rb
@@ -75,7 +75,7 @@ class Delegator < BasicObject
   #
   # Handles the magic of delegation through \_\_getobj\_\_.
   #
-  def method_missing(m, *args, &block)
+  pass_keywords def method_missing(m, *args, &block)
     r = true
     target = self.__getobj__ {r = false}
 

--- a/mjit_compile.c
+++ b/mjit_compile.c
@@ -217,7 +217,7 @@ compile_inlined_cancel_handler(FILE *f, const struct rb_iseq_constant_body *body
     fprintf(f, "    calling.argc = %d;\n", inline_context->orig_argc);
     fprintf(f, "    calling.recv = reg_cfp->self;\n");
     fprintf(f, "    reg_cfp->self = orig_self;\n");
-    fprintf(f, "    vm_call_iseq_setup_normal(ec, reg_cfp, &calling, (const rb_callable_method_entry_t *)0x%"PRIxVALUE", 0, %d, %d);\n\n",
+    fprintf(f, "    vm_call_iseq_setup_normal(ec, reg_cfp, &calling, (const rb_callable_method_entry_t *)0x%"PRIxVALUE", 0, %d, %d, 0);\n\n",
             inline_context->me, inline_context->param_size, inline_context->local_size); // fastpath_applied_iseq_p checks rb_simple_iseq_p, which ensures has_opt == FALSE
 
     // Start usual cancel from here.

--- a/test/ruby/test_keyword.rb
+++ b/test/ruby/test_keyword.rb
@@ -178,31 +178,31 @@ class TestKeywordArguments < Test::Unit::TestCase
     assert_equal(["bar", 111111], f[str: "bar", num: 111111])
   end
 
-  def test_pass_keywords
+  def test_ruby2_keywords
     c = Class.new do
-      pass_keywords def foo(meth, *args)
+      ruby2_keywords def foo(meth, *args)
         send(meth, *args)
       end
 
-      pass_keywords def foo_bar(*args)
+      ruby2_keywords def foo_bar(*args)
         bar(*args)
       end
 
-      pass_keywords def foo_baz(*args)
+      ruby2_keywords def foo_baz(*args)
         baz(*args)
       end
 
-      pass_keywords def foo_mod(meth, *args)
+      ruby2_keywords def foo_mod(meth, *args)
         args << 1
         send(meth, *args)
       end
 
-      pass_keywords def foo_bar_mod(*args)
+      ruby2_keywords def foo_bar_mod(*args)
         args << 1
         bar(*args)
       end
 
-      pass_keywords def foo_baz_mod(*args)
+      ruby2_keywords def foo_baz_mod(*args)
         args << 1
         baz(*args)
       end
@@ -215,11 +215,11 @@ class TestKeywordArguments < Test::Unit::TestCase
         args
       end
 
-      pass_keywords def foo_dbar(*args)
+      ruby2_keywords def foo_dbar(*args)
         dbar(*args)
       end
 
-      pass_keywords def foo_dbaz(*args)
+      ruby2_keywords def foo_dbaz(*args)
         dbaz(*args)
       end
 
@@ -231,11 +231,11 @@ class TestKeywordArguments < Test::Unit::TestCase
         args
       end
 
-      pass_keywords def block(*args)
+      ruby2_keywords def block(*args)
         ->(*args, **kw){[args, kw]}.(*args)
       end
 
-      pass_keywords def cfunc(*args)
+      ruby2_keywords def cfunc(*args)
         self.class.new(*args).init_args
       end
 
@@ -258,21 +258,21 @@ class TestKeywordArguments < Test::Unit::TestCase
     end
 
     implicit_super = Class.new(c) do
-      pass_keywords def bar(*args)
+      ruby2_keywords def bar(*args)
         super
       end
 
-      pass_keywords def baz(*args)
+      ruby2_keywords def baz(*args)
         super
       end
     end
 
     explicit_super = Class.new(c) do
-      pass_keywords def bar(*args)
+      ruby2_keywords def bar(*args)
         super(*args)
       end
 
-      pass_keywords def baz(*args)
+      ruby2_keywords def baz(*args)
         super(*args)
       end
     end
@@ -402,24 +402,24 @@ class TestKeywordArguments < Test::Unit::TestCase
     assert_equal([1, h1], o.baz(1, h1))
     assert_equal([h1], o.baz(h1, **{}))
 
-    assert_warn(/Skipping set of pass_keywords flag for bar \(method not defined in Ruby, method accepts keywords, or method does not accept argument splat\)/) do
-      assert_nil(c.send(:pass_keywords, :bar))
+    assert_warn(/Skipping set of ruby2_keywords flag for bar \(method not defined in Ruby, method accepts keywords, or method does not accept argument splat\)/) do
+      assert_nil(c.send(:ruby2_keywords, :bar))
     end
 
     sc = Class.new(c)
-    assert_warn(/Skipping set of pass_keywords flag for bar \(can only set in method defining module\)/) do
-      sc.send(:pass_keywords, :bar)
+    assert_warn(/Skipping set of ruby2_keywords flag for bar \(can only set in method defining module\)/) do
+      sc.send(:ruby2_keywords, :bar)
     end
     m = Module.new
-    assert_warn(/Skipping set of pass_keywords flag for system \(can only set in method defining module\)/) do
-      m.send(:pass_keywords, :system)
+    assert_warn(/Skipping set of ruby2_keywords flag for system \(can only set in method defining module\)/) do
+      m.send(:ruby2_keywords, :system)
     end
 
-    assert_raise(NameError) { c.send(:pass_keywords, "a5e36ccec4f5080a1d5e63f8") }
-    assert_raise(NameError) { c.send(:pass_keywords, :quux) }
+    assert_raise(NameError) { c.send(:ruby2_keywords, "a5e36ccec4f5080a1d5e63f8") }
+    assert_raise(NameError) { c.send(:ruby2_keywords, :quux) }
 
     c.freeze
-    assert_raise(FrozenError) { c.send(:pass_keywords, :baz) }
+    assert_raise(FrozenError) { c.send(:ruby2_keywords, :baz) }
   end
 
   def test_regular_kwsplat

--- a/test/test_delegate.rb
+++ b/test/test_delegate.rb
@@ -184,6 +184,25 @@ class TestDelegateClass < Test::Unit::TestCase
     end
   end
 
+  def test_keyword_and_hash
+    foo = Object.new
+    def foo.bar(*args)
+      args
+    end
+    def foo.foo(*args, **kw)
+      [args, kw]
+    end
+    d = SimpleDelegator.new(foo)
+    assert_equal([[], {}], d.foo)
+    assert_equal([], d.bar)
+    assert_equal([[], {:a=>1}], d.foo(:a=>1))
+    assert_equal([{:a=>1}], d.bar(:a=>1))
+    assert_warn(/The last argument is used as the keyword parameter.* for `foo'/m) do
+      assert_equal([[], {:a=>1}], d.foo({:a=>1}))
+    end
+    assert_equal([{:a=>1}], d.bar({:a=>1}))
+  end
+
   def test_private_method
     foo = Foo.new
     d = SimpleDelegator.new(foo)

--- a/tool/mk_call_iseq_optimized.rb
+++ b/tool/mk_call_iseq_optimized.rb
@@ -24,7 +24,7 @@ static VALUE
 #{fname(param, local)}(rb_execution_context_t *ec, rb_control_frame_t *cfp, struct rb_calling_info *calling, const struct rb_call_info *ci, struct rb_call_cache *cc)
 {
     RB_DEBUG_COUNTER_INC(ccf_iseq_fix);
-    return vm_call_iseq_setup_normal(ec, cfp, calling, cc->me, 0, #{param}, #{local});
+    return vm_call_iseq_setup_normal(ec, cfp, calling, cc->me, 0, #{param}, #{local}, 0);
 }
 
 EOS

--- a/tool/ruby_vm/views/_mjit_compile_send.erb
+++ b/tool/ruby_vm/views/_mjit_compile_send.erb
@@ -68,7 +68,7 @@
 % # JIT: Special CALL_METHOD. Bypass cc_copy->call and inline vm_call_iseq_setup_normal for vm_call_iseq_setup_func FASTPATH.
                 fprintf(f, "        {\n");
                 fprintf(f, "            VALUE v;\n");
-                fprintf(f, "            vm_call_iseq_setup_normal(ec, reg_cfp, &calling, (const rb_callable_method_entry_t *)0x%"PRIxVALUE", 0, %d, %d);\n",
+                fprintf(f, "            vm_call_iseq_setup_normal(ec, reg_cfp, &calling, (const rb_callable_method_entry_t *)0x%"PRIxVALUE", 0, %d, %d, 0);\n",
                         (VALUE)cc_copy->me, param_size, iseq->body->local_table_size); // fastpath_applied_iseq_p checks rb_simple_iseq_p, which ensures has_opt == FALSE
                 if (iseq->body->catch_except_p) {
                     fprintf(f, "            VM_ENV_FLAGS_SET(ec->cfp->ep, VM_FRAME_FLAG_FINISH);\n");

--- a/vm_args.c
+++ b/vm_args.c
@@ -722,7 +722,7 @@ setup_parameters_complex(rb_execution_context_t * const ec, const rb_iseq_t * co
 	args->kw_argv = NULL;
     }
 
-    if (iseq->body->param.flags.pass_keywords && kw_flag && frame_flag) {
+    if (iseq->body->param.flags.ruby2_keywords && kw_flag && frame_flag) {
         remove_empty_keyword_hash = 0;
         *frame_flag = VM_FRAME_FLAG_PASS_KEYWORDS;
     }

--- a/vm_core.h
+++ b/vm_core.h
@@ -358,6 +358,7 @@ struct rb_iseq_constant_body {
 
 	    unsigned int ambiguous_param0 : 1; /* {|a|} */
 	    unsigned int accepts_no_kwarg : 1;
+            unsigned int pass_keywords: 1;
 	} flags;
 
 	unsigned int size;
@@ -1137,11 +1138,11 @@ typedef rb_control_frame_t *
 
 enum {
     /* Frame/Environment flag bits:
-     *   MMMM MMMM MMMM MMMM ____ FFFF FFFF EEEX (LSB)
+     *   MMMM MMMM MMMM MMMM ___F FFFF FFFF EEEX (LSB)
      *
      * X   : tag for GC marking (It seems as Fixnum)
      * EEE : 3 bits Env flags
-     * FF..: 8 bits Frame flags
+     * FF..: 9 bits Frame flags
      * MM..: 15 bits frame magic (to check frame corruption)
      */
 
@@ -1166,7 +1167,8 @@ enum {
     VM_FRAME_FLAG_LAMBDA    = 0x0100,
     VM_FRAME_FLAG_MODIFIED_BLOCK_PARAM = 0x0200,
     VM_FRAME_FLAG_CFRAME_KW = 0x0400,
-    VM_FRAME_FLAG_CFRAME_EMPTY_KW = 0x0800, /* -- Remove In 3.0 -- */
+    VM_FRAME_FLAG_PASS_KEYWORDS = 0x0800,
+    VM_FRAME_FLAG_CFRAME_EMPTY_KW = 0x1000, /* -- Remove In 3.0 -- */
 
     /* env flag */
     VM_ENV_FLAG_LOCAL       = 0x0002,
@@ -1225,6 +1227,12 @@ static inline int
 VM_FRAME_CFRAME_KW_P(const rb_control_frame_t *cfp)
 {
     return VM_ENV_FLAGS(cfp->ep, VM_FRAME_FLAG_CFRAME_KW) != 0;
+}
+
+static inline int
+VM_FRAME_PASS_KEYWORDS_P(const rb_control_frame_t *cfp)
+{
+    return VM_ENV_FLAGS(cfp->ep, VM_FRAME_FLAG_PASS_KEYWORDS) != 0;
 }
 
 /* -- Remove In 3.0 -- */

--- a/vm_core.h
+++ b/vm_core.h
@@ -358,7 +358,7 @@ struct rb_iseq_constant_body {
 
 	    unsigned int ambiguous_param0 : 1; /* {|a|} */
 	    unsigned int accepts_no_kwarg : 1;
-            unsigned int pass_keywords: 1;
+            unsigned int ruby2_keywords: 1;
 	} flags;
 
 	unsigned int size;

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1707,8 +1707,8 @@ vm_base_ptr(const rb_control_frame_t *cfp)
 
 #include "vm_args.c"
 
-static inline VALUE vm_call_iseq_setup_2(rb_execution_context_t *ec, rb_control_frame_t *cfp, struct rb_calling_info *calling, const struct rb_call_info *ci, struct rb_call_cache *cc, int opt_pc, int param_size, int local_size);
-ALWAYS_INLINE(static VALUE vm_call_iseq_setup_normal(rb_execution_context_t *ec, rb_control_frame_t *cfp, struct rb_calling_info *calling, const rb_callable_method_entry_t *me, int opt_pc, int param_size, int local_size));
+static inline VALUE vm_call_iseq_setup_2(rb_execution_context_t *ec, rb_control_frame_t *cfp, struct rb_calling_info *calling, const struct rb_call_info *ci, struct rb_call_cache *cc, int opt_pc, int param_size, int local_size, int frame_flag);
+ALWAYS_INLINE(static VALUE vm_call_iseq_setup_normal(rb_execution_context_t *ec, rb_control_frame_t *cfp, struct rb_calling_info *calling, const rb_callable_method_entry_t *me, int opt_pc, int param_size, int local_size, int frame_flag));
 static inline VALUE vm_call_iseq_setup_tailcall(rb_execution_context_t *ec, rb_control_frame_t *cfp, struct rb_calling_info *calling, const struct rb_call_info *ci, struct rb_call_cache *cc, int opt_pc);
 static VALUE vm_call_super_method(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, struct rb_calling_info *calling, const struct rb_call_info *ci, struct rb_call_cache *cc);
 static VALUE vm_call_method_nome(rb_execution_context_t *ec, rb_control_frame_t *cfp, struct rb_calling_info *calling, const struct rb_call_info *ci, struct rb_call_cache *cc);
@@ -1733,7 +1733,7 @@ vm_call_iseq_setup_normal_0start(rb_execution_context_t *ec, rb_control_frame_t 
     const rb_iseq_t *iseq = def_iseq_ptr(cc->me->def);
     int param = iseq->body->param.size;
     int local = iseq->body->local_table_size;
-    return vm_call_iseq_setup_normal(ec, cfp, calling, cc->me, 0, param, local);
+    return vm_call_iseq_setup_normal(ec, cfp, calling, cc->me, 0, param, local, 0);
 }
 
 MJIT_STATIC bool
@@ -1788,6 +1788,14 @@ CALLER_SETUP_ARG_WITHOUT_KW_SPLAT(struct rb_control_frame_struct *restrict cfp,
          */
         vm_caller_setup_arg_kw(cfp, calling, ci);
     }
+    if ((ci->flag & VM_CALL_ARGS_SPLAT) &&
+            !(ci->flag & (VM_CALL_KWARG | VM_CALL_KW_SPLAT)) && 
+            VM_FRAME_PASS_KEYWORDS_P(cfp) &&
+            calling->argc > 0 &&
+            RB_TYPE_P(*(cfp->sp - 1), T_HASH)) {
+        calling->kw_splat = 1;
+    }
+
 }
 
 static inline void
@@ -1855,7 +1863,7 @@ vm_call_iseq_setup_normal_opt_start(rb_execution_context_t *ec, rb_control_frame
     }
 #endif
 
-    return vm_call_iseq_setup_normal(ec, cfp, calling, cc->me, opt_pc, param - delta, local);
+    return vm_call_iseq_setup_normal(ec, cfp, calling, cc->me, opt_pc, param - delta, local, 0);
 }
 
 static void
@@ -1885,7 +1893,7 @@ vm_call_iseq_setup_kwparm_kwarg(rb_execution_context_t *ec, rb_control_frame_t *
 
     int param = iseq->body->param.size;
     int local = iseq->body->local_table_size;
-    return vm_call_iseq_setup_normal(ec, cfp, calling, cc->me, 0, param, local);
+    return vm_call_iseq_setup_normal(ec, cfp, calling, cc->me, 0, param, local, 0);
 }
 
 static VALUE
@@ -1910,12 +1918,12 @@ vm_call_iseq_setup_kwparm_nokwarg(rb_execution_context_t *ec, rb_control_frame_t
 
     int param = iseq->body->param.size;
     int local = iseq->body->local_table_size;
-    return vm_call_iseq_setup_normal(ec, cfp, calling, cc->me, 0, param, local);
+    return vm_call_iseq_setup_normal(ec, cfp, calling, cc->me, 0, param, local, 0);
 }
 
 static inline int
 vm_callee_setup_arg(rb_execution_context_t *ec, struct rb_calling_info *calling, const struct rb_call_info *ci, struct rb_call_cache *cc,
-		    const rb_iseq_t *iseq, VALUE *argv, int param_size, int local_size)
+                    const rb_iseq_t *iseq, VALUE *argv, int param_size, int local_size, int *frame_flag)
 {
     if (LIKELY(!(ci->flag & VM_CALL_KW_SPLAT))) {
         if (LIKELY(rb_simple_iseq_p(iseq))) {
@@ -1992,7 +2000,7 @@ vm_callee_setup_arg(rb_execution_context_t *ec, struct rb_calling_info *calling,
         }
     }
 
-    return setup_parameters_complex(ec, iseq, calling, ci, argv, arg_setup_method);
+    return setup_parameters_complex(ec, iseq, calling, ci, argv, arg_setup_method, frame_flag);
 }
 
 static VALUE
@@ -2003,16 +2011,17 @@ vm_call_iseq_setup(rb_execution_context_t *ec, rb_control_frame_t *cfp, struct r
     const rb_iseq_t *iseq = def_iseq_ptr(cc->me->def);
     const int param_size = iseq->body->param.size;
     const int local_size = iseq->body->local_table_size;
-    const int opt_pc = vm_callee_setup_arg(ec, calling, ci, cc, def_iseq_ptr(cc->me->def), cfp->sp - calling->argc, param_size, local_size);
-    return vm_call_iseq_setup_2(ec, cfp, calling, ci, cc, opt_pc, param_size, local_size);
+    int frame_flag = 0;
+    const int opt_pc = vm_callee_setup_arg(ec, calling, ci, cc, def_iseq_ptr(cc->me->def), cfp->sp - calling->argc, param_size, local_size, &frame_flag);
+    return vm_call_iseq_setup_2(ec, cfp, calling, ci, cc, opt_pc, param_size, local_size, frame_flag);
 }
 
 static inline VALUE
 vm_call_iseq_setup_2(rb_execution_context_t *ec, rb_control_frame_t *cfp, struct rb_calling_info *calling, const struct rb_call_info *ci, struct rb_call_cache *cc,
-		     int opt_pc, int param_size, int local_size)
+                     int opt_pc, int param_size, int local_size, int frame_flag)
 {
     if (LIKELY(!(ci->flag & VM_CALL_TAILCALL))) {
-        return vm_call_iseq_setup_normal(ec, cfp, calling, cc->me, opt_pc, param_size, local_size);
+        return vm_call_iseq_setup_normal(ec, cfp, calling, cc->me, opt_pc, param_size, local_size, frame_flag);
     }
     else {
 	return vm_call_iseq_setup_tailcall(ec, cfp, calling, ci, cc, opt_pc);
@@ -2021,14 +2030,14 @@ vm_call_iseq_setup_2(rb_execution_context_t *ec, rb_control_frame_t *cfp, struct
 
 static inline VALUE
 vm_call_iseq_setup_normal(rb_execution_context_t *ec, rb_control_frame_t *cfp, struct rb_calling_info *calling, const rb_callable_method_entry_t *me,
-                          int opt_pc, int param_size, int local_size)
+                          int opt_pc, int param_size, int local_size, int frame_flag)
 {
     const rb_iseq_t *iseq = def_iseq_ptr(me->def);
     VALUE *argv = cfp->sp - calling->argc;
     VALUE *sp = argv + param_size;
     cfp->sp = argv - 1 /* recv */;
 
-    vm_push_frame(ec, iseq, VM_FRAME_MAGIC_METHOD | VM_ENV_FLAG_LOCAL, calling->recv,
+    vm_push_frame(ec, iseq, frame_flag | VM_FRAME_MAGIC_METHOD | VM_ENV_FLAG_LOCAL, calling->recv,
                   calling->block_handler, (VALUE)me,
                   iseq->body->iseq_encoded + opt_pc, sp,
                   local_size - param_size,
@@ -3035,7 +3044,7 @@ vm_callee_setup_block_arg(rb_execution_context_t *ec, struct rb_calling_info *ca
 	return 0;
     }
     else {
-	return setup_parameters_complex(ec, iseq, calling, ci, argv, arg_setup_type);
+        return setup_parameters_complex(ec, iseq, calling, ci, argv, arg_setup_type, 0);
     }
 }
 

--- a/vm_method.c
+++ b/vm_method.c
@@ -1747,6 +1747,82 @@ rb_mod_private(int argc, VALUE *argv, VALUE module)
 
 /*
  *  call-seq:
+ *     pass_keywords(method_name, ...)    -> self
+ *
+ *  For the given method names, marks the method as passing keywords through
+ *  a normal argument splat.  This should only be called on methods that
+ *  accept an argument splat (<tt>*args</tt>) but not explicit keywords or
+ *  a keyword splat.  It marks the method such that if the method is called
+ *  with keyword arguments, method calls directly inside the method with
+ *  argument splats where the last argument is a hash will convert the last
+ *  argument to a keyword splat.  In other words, keywords will be passed
+ *  through the method to other methods.
+ *
+ *  This should only be used for methods that delegate keywords to another
+ *  method, and only for backwards compatibility with Ruby versions before
+ *  2.7.
+ *
+ *  This method will probably be removed at some point, as it exists only
+ *  for backwards compatibility, so always check that the module responds
+ *  to this method before calling it.
+ *
+ *    module Mod
+ *      def foo(meth, *args, &block)
+ *        send(:"do_#{meth}", *args, &block)
+ *      end
+ *      pass_keywords(:foo) if respond_to?(:pass_keywords, true)
+ *    end
+ */
+
+static VALUE
+rb_mod_pass_keywords(int argc, VALUE *argv, VALUE module)
+{
+    int i;
+    VALUE origin_class = RCLASS_ORIGIN(module);
+
+    rb_check_frozen(module);
+
+    for (i = 0; i < argc; i++) {
+        VALUE v = argv[i];
+        ID name = rb_check_id(&v);
+        rb_method_entry_t *me;
+        VALUE defined_class;
+
+        if (!name) {
+            rb_print_undef_str(module, v);
+        }
+
+        me = search_method(origin_class, name, &defined_class);
+        if (!me && RB_TYPE_P(module, T_MODULE)) {
+            me = search_method(rb_cObject, name, &defined_class);
+        }
+
+        if (UNDEFINED_METHOD_ENTRY_P(me) ||
+            UNDEFINED_REFINED_METHOD_P(me->def)) {
+            rb_print_undef(module, name, METHOD_VISI_UNDEF);
+        }
+
+        if (module == defined_class || origin_class == defined_class) {
+            if (me->def->type == VM_METHOD_TYPE_ISEQ &&
+                    me->def->body.iseq.iseqptr->body->param.flags.has_rest &&
+                    !me->def->body.iseq.iseqptr->body->param.flags.has_kw &&
+                    !me->def->body.iseq.iseqptr->body->param.flags.has_kwrest) {
+                me->def->body.iseq.iseqptr->body->param.flags.pass_keywords = 1;
+                rb_clear_method_cache_by_class(module);
+            }
+            else {
+                rb_warn("Skipping set of pass_keywords flag for %s (method not defined in Ruby, method accepts keywords, or method does not accept argument splat)", rb_id2name(name));
+            }
+        }
+        else {
+            rb_warn("Skipping set of pass_keywords flag for %s (can only set in method defining module)", rb_id2name(name));
+        }
+    }
+    return Qnil;
+}
+
+/*
+ *  call-seq:
  *     mod.public_class_method(symbol, ...)    -> mod
  *     mod.public_class_method(string, ...)    -> mod
  *
@@ -2127,6 +2203,7 @@ Init_eval_method(void)
     rb_define_private_method(rb_cModule, "protected", rb_mod_protected, -1);
     rb_define_private_method(rb_cModule, "private", rb_mod_private, -1);
     rb_define_private_method(rb_cModule, "module_function", rb_mod_modfunc, -1);
+    rb_define_private_method(rb_cModule, "pass_keywords", rb_mod_pass_keywords, -1);
 
     rb_define_method(rb_cModule, "method_defined?", rb_mod_method_defined, -1);
     rb_define_method(rb_cModule, "public_method_defined?", rb_mod_public_method_defined, -1);

--- a/vm_method.c
+++ b/vm_method.c
@@ -1747,7 +1747,7 @@ rb_mod_private(int argc, VALUE *argv, VALUE module)
 
 /*
  *  call-seq:
- *     pass_keywords(method_name, ...)    -> self
+ *     ruby2_keywords(method_name, ...)    -> self
  *
  *  For the given method names, marks the method as passing keywords through
  *  a normal argument splat.  This should only be called on methods that
@@ -1770,12 +1770,12 @@ rb_mod_private(int argc, VALUE *argv, VALUE module)
  *      def foo(meth, *args, &block)
  *        send(:"do_#{meth}", *args, &block)
  *      end
- *      pass_keywords(:foo) if respond_to?(:pass_keywords, true)
+ *      ruby2_keywords(:foo) if respond_to?(:ruby2_keywords, true)
  *    end
  */
 
 static VALUE
-rb_mod_pass_keywords(int argc, VALUE *argv, VALUE module)
+rb_mod_ruby2_keywords(int argc, VALUE *argv, VALUE module)
 {
     int i;
     VALUE origin_class = RCLASS_ORIGIN(module);
@@ -1807,15 +1807,15 @@ rb_mod_pass_keywords(int argc, VALUE *argv, VALUE module)
                     me->def->body.iseq.iseqptr->body->param.flags.has_rest &&
                     !me->def->body.iseq.iseqptr->body->param.flags.has_kw &&
                     !me->def->body.iseq.iseqptr->body->param.flags.has_kwrest) {
-                me->def->body.iseq.iseqptr->body->param.flags.pass_keywords = 1;
+                me->def->body.iseq.iseqptr->body->param.flags.ruby2_keywords = 1;
                 rb_clear_method_cache_by_class(module);
             }
             else {
-                rb_warn("Skipping set of pass_keywords flag for %s (method not defined in Ruby, method accepts keywords, or method does not accept argument splat)", rb_id2name(name));
+                rb_warn("Skipping set of ruby2_keywords flag for %s (method not defined in Ruby, method accepts keywords, or method does not accept argument splat)", rb_id2name(name));
             }
         }
         else {
-            rb_warn("Skipping set of pass_keywords flag for %s (can only set in method defining module)", rb_id2name(name));
+            rb_warn("Skipping set of ruby2_keywords flag for %s (can only set in method defining module)", rb_id2name(name));
         }
     }
     return Qnil;
@@ -2203,7 +2203,7 @@ Init_eval_method(void)
     rb_define_private_method(rb_cModule, "protected", rb_mod_protected, -1);
     rb_define_private_method(rb_cModule, "private", rb_mod_private, -1);
     rb_define_private_method(rb_cModule, "module_function", rb_mod_modfunc, -1);
-    rb_define_private_method(rb_cModule, "pass_keywords", rb_mod_pass_keywords, -1);
+    rb_define_private_method(rb_cModule, "ruby2_keywords", rb_mod_ruby2_keywords, -1);
 
     rb_define_method(rb_cModule, "method_defined?", rb_mod_method_defined, -1);
     rb_define_method(rb_cModule, "public_method_defined?", rb_mod_public_method_defined, -1);


### PR DESCRIPTION
In Ruby <=2.6, delegation was often done using:

```ruby
def foo(*args, &block)
  bar(*args, &block)
end
```

With the keyword argument separation changes recently added, this now
causes a warning if bar accepts keyword arguments, as that will break
in Ruby 3.  You need to switch to delegating keyword arguments:

```ruby
def foo(*args, **kw, &block)
  bar(*args, **kw, &block)
end
```

This works and fixes the delegation. However, it is not backwards
compatible with older versions of Ruby, as if bar does not accept
keyword arguments, it will be passed an empty positional hash if
no keywords are passed to foo.  Also, there will be a hash to
keyword warning if no keywords are passed to foo, and the final
positional argument is a hash, even though behavior in terms of
arguments passed to bar will not change in Ruby 3, as the keyword
will be converted back to a hash.

For backwards compatibility with older versions of Ruby, this
allows you do to:

```ruby
class Module
  private
  def pass_keywords(*) end unless respond_to?(:pass_keywords, true)
end

class Foo
  def foo(*args, &block)
    bar(*args, &block)
  end
  pass_keywords :foo
end
```

Then if you call foo with keyword arguments, bar will be called with
keywords arguments, but if you call foo with a positional hash
argument, bar will be called with a positional hash argument. If bar
accepts keyword arguments, the hash will be converted to keywords
in bar, and a warning will be emitted, as behavior will change in
Ruby 3 to pass the hash as a positional argument.

This implements such support using a VM frame flag.  If a method has
been flagged as passing keywords (only allowed for methods that
accept an argument splat and do not accept keywords), and it is
called with keywords, it sets the flag on the next VM frame.  If that
frame flag is currently set, calls with an argument splat and no
keywords where the last argument is a hash are converted into
passing the hash as keywords.

The second commit uses pass_keywords in lib/delegate to fix keyword
argument separation warnings when the target method accepts keywords
and keywords are passed to the delegate method.