### PR TITLE
Honor Syslog::Logger#level overrides

### DIFF
--- a/ext/syslog/lib/syslog/logger.rb
+++ b/ext/syslog/lib/syslog/logger.rb
@@ -112,7 +112,7 @@ class Syslog::Logger
       end
 
       def #{meth}?
-        @level <= #{level}
+        level <= #{level}
       end
     EOM
   end
@@ -202,7 +202,7 @@ class Syslog::Logger
 
   def add severity, message = nil, progname = nil, &block
     severity ||= ::Logger::UNKNOWN
-    @level <= severity and
+    level <= severity and
       @@syslog.log( (LEVEL_MAP[severity] | @facility), '%s', formatter.call(severity, Time.now, progname, (message || block.call)) )
     true
   end

--- a/test/syslog/test_syslog_logger.rb
+++ b/test/syslog/test_syslog_logger.rb
@@ -551,6 +551,21 @@ class TestSyslogLogger < TestSyslogRootLogger
     assert_equal facility|Syslog::LOG_DEBUG,   msg.priority
   end
 
+  class CustomSyslogLogger < Syslog::Logger
+    def level
+      Logger::INFO
+    end
+  end
+
+  def test_overriding_level
+    @logger = CustomSyslogLogger.new
+    log = log_add Logger::INFO, 'msg'
+    assert_equal 'msg', log.msg
+
+    log = log_add Logger::DEBUG, 'msg'
+    assert_nil log.msg
+  end
+
 end if defined?(Syslog)
 
 


### PR DESCRIPTION
Allow subclasses to customize how the current level is determined without reimplementing `#add` or juggling multiple underlying `Syslog::Logger` instances. Maintain parity with `Logger` (ruby/logger#41).