### PR TITLE
fmod() is making things slower

### DIFF
--- a/numeric.c
+++ b/numeric.c
@@ -1175,14 +1175,10 @@ flodivmod(double x, double y, double *divp, double *modp)
     if ((x == 0.0) || (isinf(y) && !isinf(x)))
         mod = x;
     else {
-#ifdef HAVE_FMOD
-	mod = fmod(x, y);
-#else
 	double z;
 
 	modf(x/y, &z);
 	mod = x - z * y;
-#endif
     }
     if (isinf(x) && !isinf(y))
 	div = x;


### PR DESCRIPTION
On systems of gcc + glibc combinations (i.e. most Linux), gcc's `__builtin_fmod()` ultimately results in library routine version of `fmod()` inside of `libm.so`.  This function is a nontrivial simulation of IEEE754 remainder _not_ using the FPU.

On such setup `__builtin_modf()` is also a library routine `modf()` inside of libm, but it seems much more lightweight.

```
Calculating -------------------------------------
                           ours       trunk
            so_fasta      0.816       0.760 i/s -       1.000 times in 1.225553s 1.315507s

Comparison:
                         so_fasta
                ours:         0.8 i/s
               trunk:         0.8 i/s - 1.07x  slower
```