### PR TITLE
[WIP] Adding a special arena for `INSN *`

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -889,7 +889,8 @@ compile_data_alloc(rb_iseq_t *iseq, size_t size)
 static INSN *
 compile_data_alloc_insn(rb_iseq_t *iseq)
 {
-    return (INSN *)compile_data_alloc(iseq, sizeof(INSN));
+    struct iseq_compile_data_storage ** arena = &ISEQ_COMPILE_DATA(iseq)->insn.storage_current;
+    return (INSN *)compile_data_alloc_with_arena(arena, sizeof(INSN));
 }
 
 static LABEL *

--- a/compile.c
+++ b/compile.c
@@ -579,7 +579,7 @@ static int
 iseq_add_mark_object_compile_time(const rb_iseq_t *iseq, VALUE v)
 {
     if (!SPECIAL_CONST_P(v)) {
-	rb_ary_push(ISEQ_COMPILE_DATA(iseq)->mark_ary, v);
+        RB_OBJ_WRITTEN(iseq, Qundef, v);
     }
     return COMPILE_OK;
 }

--- a/compile.c
+++ b/compile.c
@@ -882,7 +882,7 @@ compile_data_alloc_with_arena(struct iseq_compile_data_storage **arena, size_t s
 static void *
 compile_data_alloc(rb_iseq_t *iseq, size_t size)
 {
-    struct iseq_compile_data_storage ** arena = &ISEQ_COMPILE_DATA(iseq)->storage_current;
+    struct iseq_compile_data_storage ** arena = &ISEQ_COMPILE_DATA(iseq)->node.storage_current;
     return compile_data_alloc_with_arena(arena, size);
 }
 

--- a/compile.c
+++ b/compile.c
@@ -575,12 +575,6 @@ APPEND_ELEM(ISEQ_ARG_DECLARE LINK_ANCHOR *const anchor, LINK_ELEMENT *before, LI
 
 #define ISEQ_LAST_LINE(iseq) (ISEQ_COMPILE_DATA(iseq)->last_line)
 
-static inline VALUE
-freeze_literal(rb_iseq_t *iseq, VALUE lit)
-{
-    return rb_fstring(lit);
-}
-
 static int
 validate_label(st_data_t name, st_data_t label, st_data_t arg)
 {
@@ -3644,7 +3638,7 @@ compile_dstr_fragments(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *cons
 			  rb_builtin_type_name(TYPE(lit)));
 	    return COMPILE_NG;
 	}
-	lit = freeze_literal(iseq, lit);
+	lit = rb_fstring(lit);
 	ADD_INSN1(ret, nd_line(node), putobject, lit);
         RB_OBJ_WRITTEN(iseq, Qundef, lit);
 	if (RSTRING_LEN(lit) == 0) first_lit = LAST_ELEMENT(ret);
@@ -3653,7 +3647,7 @@ compile_dstr_fragments(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *cons
     while (list) {
 	const NODE *const head = list->nd_head;
 	if (nd_type(head) == NODE_STR) {
-	    lit = freeze_literal(iseq, head->nd_lit);
+	    lit = rb_fstring(head->nd_lit);
 	    ADD_INSN1(ret, nd_line(head), putobject, lit);
             RB_OBJ_WRITTEN(iseq, Qundef, lit);
 	    lit = Qnil;
@@ -4272,7 +4266,7 @@ when_vals(rb_iseq_t *iseq, LINK_ANCHOR *const cond_seq, const NODE *vals,
 
 	if (nd_type(val) == NODE_STR) {
 	    debugp_param("nd_lit", val->nd_lit);
-	    lit = freeze_literal(iseq, val->nd_lit);
+	    lit = rb_fstring(val->nd_lit);
 	    ADD_INSN1(cond_seq, nd_line(val), putobject, lit);
             RB_OBJ_WRITTEN(iseq, Qundef, lit);
 	}
@@ -6646,7 +6640,7 @@ compile_call_precheck_freeze(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE
         node->nd_args == NULL &&
         ISEQ_COMPILE_DATA(iseq)->current_block == NULL &&
         ISEQ_COMPILE_DATA(iseq)->option->specialized_instruction) {
-        VALUE str = freeze_literal(iseq, node->nd_recv->nd_lit);
+        VALUE str = rb_fstring(node->nd_recv->nd_lit);
         if (node->nd_mid == idUMinus) {
             ADD_INSN3(ret, line, opt_str_uminus, str,
                       new_callinfo(iseq, idUMinus, 0, 0, NULL, FALSE),
@@ -6672,7 +6666,7 @@ compile_call_precheck_freeze(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE
         ISEQ_COMPILE_DATA(iseq)->current_block == NULL &&
         !ISEQ_COMPILE_DATA(iseq)->option->frozen_string_literal &&
         ISEQ_COMPILE_DATA(iseq)->option->specialized_instruction) {
-        VALUE str = freeze_literal(iseq, node->nd_args->nd_head->nd_lit);
+        VALUE str = rb_fstring(node->nd_args->nd_head->nd_lit);
         CHECK(COMPILE(ret, "recv", node->nd_recv));
         ADD_INSN3(ret, line, opt_aref_with, str,
                   new_callinfo(iseq, idAREF, 1, 0, NULL, FALSE),
@@ -7752,7 +7746,7 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
 	if (!popped) {
 	    VALUE lit = node->nd_lit;
 	    if (!ISEQ_COMPILE_DATA(iseq)->option->frozen_string_literal) {
-		lit = freeze_literal(iseq, lit);
+		lit = rb_fstring(lit);
 		ADD_INSN1(ret, line, putstring, lit);
                 RB_OBJ_WRITTEN(iseq, Qundef, lit);
 	    }
@@ -7794,7 +7788,7 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
       }
       case NODE_XSTR:{
 	ADD_CALL_RECEIVER(ret, line);
-        VALUE str = freeze_literal(iseq, node->nd_lit);
+        VALUE str = rb_fstring(node->nd_lit);
 	ADD_INSN1(ret, line, putobject, str);
         RB_OBJ_WRITTEN(iseq, Qundef, str);
 	ADD_CALL(ret, line, idBackquote, INT2FIX(1));
@@ -8236,7 +8230,7 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
             !ISEQ_COMPILE_DATA(iseq)->option->frozen_string_literal &&
 	    ISEQ_COMPILE_DATA(iseq)->option->specialized_instruction)
 	{
-	    VALUE str = freeze_literal(iseq, node->nd_args->nd_head->nd_lit);
+	    VALUE str = rb_fstring(node->nd_args->nd_head->nd_lit);
 	    CHECK(COMPILE(ret, "recv", node->nd_recv));
 	    CHECK(COMPILE(ret, "value", node->nd_args->nd_next->nd_head));
 	    if (!popped) {

--- a/iseq.c
+++ b/iseq.c
@@ -339,9 +339,6 @@ rb_iseq_mark(const rb_iseq_t *iseq)
 
         rb_iseq_mark_insn_storage(compile_data->insn.storage_head);
 
-        if (RTEST(compile_data->mark_ary)) {
-            rb_gc_mark(compile_data->mark_ary);
-        }
         RUBY_MARK_UNLESS_NULL(compile_data->err_info);
         if (RTEST(compile_data->catch_table_ary)) {
             rb_gc_mark(compile_data->catch_table_ary);
@@ -559,7 +556,6 @@ prepare_iseq_build(rb_iseq_t *iseq,
 
     ISEQ_COMPILE_DATA_ALLOC(iseq);
     RB_OBJ_WRITE(iseq, &ISEQ_COMPILE_DATA(iseq)->err_info, err_info);
-    RB_OBJ_WRITE(iseq, &ISEQ_COMPILE_DATA(iseq)->mark_ary, rb_ary_tmp_new(3));
     RB_OBJ_WRITE(iseq, &ISEQ_COMPILE_DATA(iseq)->catch_table_ary, Qnil);
 
     ISEQ_COMPILE_DATA(iseq)->node.storage_head = ISEQ_COMPILE_DATA(iseq)->node.storage_current = new_arena();

--- a/iseq.c
+++ b/iseq.c
@@ -75,7 +75,8 @@ static void
 compile_data_free(struct iseq_compile_data *compile_data)
 {
     if (compile_data) {
-	free_arena(compile_data->storage_head);
+	free_arena(compile_data->node.storage_head);
+	free_arena(compile_data->insn.storage_head);
 	if (compile_data->ivar_cache_table) {
 	    rb_id_table_free(compile_data->ivar_cache_table);
 	}
@@ -420,7 +421,7 @@ rb_iseq_memsize(const rb_iseq_t *iseq)
 
 	size += sizeof(struct iseq_compile_data);
 
-	cur = compile_data->storage_head;
+	cur = compile_data->node.storage_head;
 	while (cur) {
 	    size += cur->size + offsetof(struct iseq_compile_data_storage, buff);
 	    cur = cur->next;
@@ -558,7 +559,8 @@ prepare_iseq_build(rb_iseq_t *iseq,
     RB_OBJ_WRITE(iseq, &ISEQ_COMPILE_DATA(iseq)->mark_ary, rb_ary_tmp_new(3));
     RB_OBJ_WRITE(iseq, &ISEQ_COMPILE_DATA(iseq)->catch_table_ary, Qnil);
 
-    ISEQ_COMPILE_DATA(iseq)->storage_head = ISEQ_COMPILE_DATA(iseq)->storage_current = new_arena();
+    ISEQ_COMPILE_DATA(iseq)->node.storage_head = ISEQ_COMPILE_DATA(iseq)->node.storage_current = new_arena();
+    ISEQ_COMPILE_DATA(iseq)->insn.storage_head = ISEQ_COMPILE_DATA(iseq)->insn.storage_current = new_arena();
     ISEQ_COMPILE_DATA(iseq)->option = option;
 
     ISEQ_COMPILE_DATA(iseq)->ivar_cache_table = NULL;

--- a/iseq.c
+++ b/iseq.c
@@ -336,6 +336,9 @@ rb_iseq_mark(const rb_iseq_t *iseq)
     }
     else if (FL_TEST_RAW(iseq, ISEQ_USE_COMPILE_DATA)) {
 	const struct iseq_compile_data *const compile_data = ISEQ_COMPILE_DATA(iseq);
+
+        rb_iseq_mark_insn_storage(compile_data->insn.storage_head);
+
         if (RTEST(compile_data->mark_ary)) {
             rb_gc_mark(compile_data->mark_ary);
         }

--- a/iseq.h
+++ b/iseq.h
@@ -99,8 +99,14 @@ struct iseq_compile_data {
     struct iseq_label_data *redo_label;
     const rb_iseq_t *current_block;
     struct iseq_compile_data_ensure_node_stack *ensure_node_stack;
-    struct iseq_compile_data_storage *storage_head;
-    struct iseq_compile_data_storage *storage_current;
+    struct {
+      struct iseq_compile_data_storage *storage_head;
+      struct iseq_compile_data_storage *storage_current;
+    } node;
+    struct {
+      struct iseq_compile_data_storage *storage_head;
+      struct iseq_compile_data_storage *storage_current;
+    } insn;
     int loopval_popped;	/* used by NODE_BREAK */
     int last_line;
     int label_no;

--- a/iseq.h
+++ b/iseq.h
@@ -90,7 +90,6 @@ ISEQ_ORIGINAL_ISEQ_ALLOC(const rb_iseq_t *iseq, long size)
 struct iseq_compile_data {
     /* GC is needed */
     const VALUE err_info;
-    VALUE mark_ary;
     const VALUE catch_table_ary;	/* Array */
 
     /* GC is not needed */

--- a/iseq.h
+++ b/iseq.h
@@ -174,6 +174,7 @@ VALUE *rb_iseq_original_iseq(const rb_iseq_t *iseq);
 void rb_iseq_build_from_ary(rb_iseq_t *iseq, VALUE misc,
 			    VALUE locals, VALUE args,
 			    VALUE exception, VALUE body);
+void rb_iseq_mark_insn_storage(struct iseq_compile_data_storage *arena);
 
 /* iseq.c */
 VALUE rb_iseq_load(VALUE data, VALUE parent, VALUE opt);


### PR DESCRIPTION
`INSN *` objects point to `VALUE` objects.  Currently the compile time mark array guarantees liveness.  But if the compactor runs during compilation, the mark array references will be updated but the `INSN *` references will not be updated.

I want to ensure that `INSN *` references are pinned during compaction.  I've implemented a secondary arena that is specialized just for `INSN *` objects.  Since it only contains `INSN *`, we can scan it for `VALUE` references and pin them.

~~Right now this just scans for references, I haven't called `rb_gc_mark` on any of them.~~