### PR TITLE
reuse cc->call

### DIFF
--- a/benchmark/vm2_poly_same_method.yml
+++ b/benchmark/vm2_poly_same_method.yml
@@ -1,0 +1,25 @@
+prelude: |
+  module AR; end
+  class AR::Base
+    def create_or_update
+      nil
+    end
+    def save
+      create_or_update
+    end
+  end
+  class Foo < AR::Base; end
+  class Bar < AR::Base; end
+  o1 = Foo.new
+  o2 = Bar.new
+benchmark:
+  vm2_poly_same_method: |
+    o1.save; o2.save;
+    o1.save; o2.save;
+    o1.save; o2.save;
+    o1.save; o2.save;
+    o1.save; o2.save;
+    o1.save; o2.save;
+    o1.save; o2.save;
+    o1.save; o2.save;
+loop_count: 6000000

--- a/insns.def
+++ b/insns.def
@@ -911,7 +911,7 @@ invokeblock
 // attr rb_snum_t sp_inc = sp_inc_of_invokeblock(ci);
 {
     static struct rb_call_cache cc = {
-        0, 0, NULL, vm_invokeblock_i,
+        0, 0, NULL, NULL, vm_invokeblock_i,
     };
 
     VALUE bh = VM_BLOCK_HANDLER_NONE;

--- a/internal.h
+++ b/internal.h
@@ -2328,6 +2328,7 @@ enum method_missing_reason {
     MISSING_NONE      = 0x40
 };
 struct rb_callable_method_entry_struct;
+struct rb_method_definition_struct;
 struct rb_execution_context_struct;
 struct rb_control_frame_struct;
 struct rb_calling_info;
@@ -2339,6 +2340,7 @@ struct rb_call_cache {
 
     /* inline cache: values */
     const struct rb_callable_method_entry_struct *me;
+    const struct rb_method_definition_struct *def;
 
     VALUE (*call)(struct rb_execution_context_struct *ec,
                   struct rb_control_frame_struct *cfp,


### PR DESCRIPTION
I noticed that in case of cache misshit, re-calculated `cc->me` can be the same method entry than the pevious one.  That is an okay situation but can't we partially reuse the cache, because `cc->call`
should still be valid then?

One thing that has to be special-cased is when the method entry gets amended by some refinements.  That happens behind-the-scene of call cache mechanism.  We have to check if `cc->me->def` points to the previously saved one.

```
Calculating -------------------------------------
                          trunk        ours
vm2_poly_same_method     1.534M      2.025M i/s -      6.000M times in 3.910203s 2.962752s

Comparison:
             vm2_poly_same_method
                ours:   2025143.9 i/s
               trunk:   1534447.2 i/s - 1.32x  slower
```