### PR TITLE
typedef rb_jmpbuf_t to void *[5] if __builtin_setjmp is used

### DIFF
--- a/tool/m4/ruby_setjmp_type.m4
+++ b/tool/m4/ruby_setjmp_type.m4
@@ -47,6 +47,6 @@ AS_IF([test x$setjmp_prefix:$setjmp_sigmask = xsig:], [
 AC_MSG_RESULT(${setjmp_prefix}setjmp${setjmp_suffix}${setjmp_cast:+\($setjmp_cast\)}${setjmp_sigmask})
 AC_DEFINE_UNQUOTED([RUBY_SETJMP(env)], [${setjmp_prefix}setjmp${setjmp_suffix}($setjmp_cast(env)${setjmp_sigmask})])
 AC_DEFINE_UNQUOTED([RUBY_LONGJMP(env,val)], [${setjmp_prefix}longjmp($setjmp_cast(env),val)])
-AC_DEFINE_UNQUOTED(RUBY_JMP_BUF, ${setjmp_sigmask+${setjmp_prefix}}jmp_buf)
+AS_IF([test x$setjmp_prefix != x__builtin_], AC_DEFINE_UNQUOTED(RUBY_JMP_BUF, ${setjmp_sigmask+${setjmp_prefix}}jmp_buf))
 AS_IF([test x$setjmp_suffix = xex], [AC_DEFINE_UNQUOTED(RUBY_USE_SETJMPEX, 1)])
 ])dnl

--- a/vm_core.h
+++ b/vm_core.h
@@ -775,7 +775,11 @@ enum rb_thread_status {
     THREAD_KILLED
 };
 
+#ifdef RUBY_JMP_BUF
 typedef RUBY_JMP_BUF rb_jmpbuf_t;
+#else
+typedef void *rb_jmpbuf_t[5];
+#endif
 
 /*
   the members which are written in EC_PUSH_TAG() should be placed at


### PR DESCRIPTION
The built-in version operates on a buffer of 5 words, much smaller than
the size of jmp_buf defined in libc.
Note, powerpc requires 5 words, while arm and x86_64 just require 3.

---------------------

```zsh
autoreconf
mkdir Debug
../configure --prefix=/tmp/opt
make -j
make test-all
```

For some reason, master has some failed tests on my machine. `20988 tests, 5475721 assertions, 13 failures, 1 errors, 35 skips`. Anyhow, this patch does not cause new failures.

GCC doc: https://gcc.gnu.org/onlinedocs/gcc/Nonlocal-Gotos.html#Nonlocal-Gotos

I choose `typedef void *rb_jmpbuf_t[5];` because `void *[5]` (in contrast to current `jmp_buf` or `long [5]`) can suppress a clang warning:

```
warning: incompatible pointer types passing 'foo' (aka 'long [5]') to parameter of type 'void **' [-Wincompatible-pointer-types]
```