### PR TITLE
Fix keyword argument separation issues with instance_exec and similar methods

### DIFF
--- a/cont.c
+++ b/cont.c
@@ -1775,6 +1775,12 @@ rb_fiber_new(rb_block_call_func_t func, VALUE obj)
     return fiber_initialize(fiber_alloc(rb_cFiber), rb_proc_new(func, obj), &shared_fiber_pool);
 }
 
+VALUE
+rb_fiber_new_kw(rb_block_call_kw_func_t func, VALUE obj)
+{
+    return fiber_initialize(fiber_alloc(rb_cFiber), rb_proc_new_kw(func, obj), &shared_fiber_pool);
+}
+
 static void rb_fiber_terminate(rb_fiber_t *fiber, int need_interrupt);
 
 void

--- a/debug_counter.h
+++ b/debug_counter.h
@@ -260,6 +260,7 @@ RB_DEBUG_COUNTER(obj_imemo_cref)
 RB_DEBUG_COUNTER(obj_imemo_svar)
 RB_DEBUG_COUNTER(obj_imemo_throw_data)
 RB_DEBUG_COUNTER(obj_imemo_ifunc)
+RB_DEBUG_COUNTER(obj_imemo_ifunc_kw)
 RB_DEBUG_COUNTER(obj_imemo_memo)
 RB_DEBUG_COUNTER(obj_imemo_parser_strterm)
 

--- a/enum.c
+++ b/enum.c
@@ -1535,7 +1535,7 @@ nmin_filter(struct nmin_data *data)
 }
 
 static VALUE
-nmin_i(RB_BLOCK_CALL_FUNC_ARGLIST(i, _data))
+nmin_i(RB_BLOCK_CALL_KW_FUNC_ARGLIST(i, _data))
 {
     struct nmin_data *data = (struct nmin_data *)_data;
     VALUE cmpv;
@@ -1595,11 +1595,11 @@ rb_nmin_run(VALUE obj, VALUE num, int by, int rev, int ary)
 	for (i = 0; i < RARRAY_LEN(obj); i++) {
 	    VALUE args[1];
 	    args[0] = RARRAY_AREF(obj, i);
-            nmin_i(obj, (VALUE)&data, 1, args, Qundef);
+            nmin_i(obj, (VALUE)&data, 1, args, Qundef, RB_NO_KEYWORDS);
 	}
     }
     else {
-	rb_block_call(obj, id_each, 0, 0, nmin_i, (VALUE)&data);
+        rb_block_call_kw(obj, id_each, 0, 0, nmin_i, (VALUE)&data, RB_NO_KEYWORDS);
     }
     nmin_filter(&data);
     result = data.buf;

--- a/enumerator.c
+++ b/enumerator.c
@@ -528,7 +528,7 @@ rb_enumeratorize_with_size(VALUE obj, VALUE meth, int argc, const VALUE *argv, r
 }
 
 static VALUE
-enumerator_block_call(VALUE obj, rb_block_call_func *func, VALUE arg)
+enumerator_block_call(VALUE obj, rb_block_call_kw_func *func, VALUE arg)
 {
     int argc = 0;
     const VALUE *argv = 0;
@@ -604,7 +604,7 @@ enumerator_each(int argc, VALUE *argv, VALUE obj)
 }
 
 static VALUE
-enumerator_with_index_i(RB_BLOCK_CALL_FUNC_ARGLIST(val, m))
+enumerator_with_index_i(RB_BLOCK_CALL_KW_FUNC_ARGLIST(val, m))
 {
     struct MEMO *memo = (struct MEMO *)m;
     VALUE idx = memo->v1;
@@ -665,7 +665,7 @@ enumerator_each_with_index(VALUE obj)
 }
 
 static VALUE
-enumerator_with_object_i(RB_BLOCK_CALL_FUNC_ARGLIST(val, memo))
+enumerator_with_object_i(RB_BLOCK_CALL_KW_FUNC_ARGLIST(val, memo))
 {
     if (argc <= 1)
 	return rb_yield_values(2, val, memo);

--- a/ext/-test-/iter/yield.c
+++ b/ext/-test-/iter/yield.c
@@ -4,7 +4,7 @@ static VALUE
 yield_block(int argc, VALUE *argv, VALUE self)
 {
     rb_check_arity(argc, 1, UNLIMITED_ARGUMENTS);
-    return rb_block_call(self, rb_to_id(argv[0]), argc-1, argv+1, rb_yield_block, 0);
+    return rb_block_call_kw(self, rb_to_id(argv[0]), argc-1, argv+1, rb_yield_block_kw, 0, RB_PASS_CALLED_KEYWORDS);
 }
 
 void

--- a/ext/objspace/objspace.c
+++ b/ext/objspace/objspace.c
@@ -634,6 +634,7 @@ count_imemo_objects(int argc, VALUE *argv, VALUE self)
 	imemo_type_ids[8] = rb_intern("imemo_tmpbuf");
         imemo_type_ids[9] = rb_intern("imemo_ast");
         imemo_type_ids[10] = rb_intern("imemo_parser_strterm");
+        imemo_type_ids[11] = rb_intern("imemo_ifunc_kw");
     }
 
     rb_objspace_each_objects(count_imemo_objects_i, (void *)hash);

--- a/ext/pathname/pathname.c
+++ b/ext/pathname/pathname.c
@@ -1076,7 +1076,7 @@ path_empty_p(VALUE self)
 }
 
 static VALUE
-s_glob_i(RB_BLOCK_CALL_FUNC_ARGLIST(elt, klass))
+s_glob_i(RB_BLOCK_CALL_KW_FUNC_ARGLIST(elt, klass))
 {
     return rb_yield(rb_class_new_instance(1, &elt, klass));
 }
@@ -1114,7 +1114,7 @@ path_s_glob(int argc, VALUE *argv, VALUE klass)
 }
 
 static VALUE
-glob_i(RB_BLOCK_CALL_FUNC_ARGLIST(elt, self))
+glob_i(RB_BLOCK_CALL_KW_FUNC_ARGLIST(elt, self))
 {
     elt = rb_funcall(self, '+', 1, elt);
     return rb_yield(elt);

--- a/gc.c
+++ b/gc.c
@@ -2174,6 +2174,7 @@ imemo_memsize(VALUE obj)
       case imemo_svar:
       case imemo_throw_data:
       case imemo_ifunc:
+      case imemo_ifunc_kw:
       case imemo_memo:
       case imemo_parser_strterm:
         break;
@@ -2657,6 +2658,9 @@ obj_free(rb_objspace_t *objspace, VALUE obj)
             break;
           case imemo_ifunc:
             RB_DEBUG_COUNTER_INC(obj_imemo_ifunc);
+            break;
+          case imemo_ifunc_kw:
+            RB_DEBUG_COUNTER_INC(obj_imemo_ifunc_kw);
             break;
           case imemo_memo:
             RB_DEBUG_COUNTER_INC(obj_imemo_memo);
@@ -5028,6 +5032,7 @@ gc_mark_imemo(rb_objspace_t *objspace, VALUE obj)
 	gc_mark(objspace, RANY(obj)->as.imemo.throw_data.throw_obj);
 	return;
       case imemo_ifunc:
+      case imemo_ifunc_kw:
 	gc_mark_maybe(objspace, (VALUE)RANY(obj)->as.imemo.ifunc.data);
 	return;
       case imemo_memo:
@@ -7906,6 +7911,7 @@ gc_ref_update_imemo(rb_objspace_t *objspace, VALUE obj)
         UPDATE_IF_MOVED(objspace, RANY(obj)->as.imemo.throw_data.throw_obj);
         break;
       case imemo_ifunc:
+      case imemo_ifunc_kw:
         break;
       case imemo_memo:
         UPDATE_IF_MOVED(objspace, RANY(obj)->as.imemo.memo.v1);

--- a/hash.c
+++ b/hash.c
@@ -4471,7 +4471,7 @@ rb_hash_gt(VALUE hash, VALUE other)
 }
 
 static VALUE
-hash_proc_call(VALUE key, VALUE hash, int argc, const VALUE *argv, VALUE passed_proc)
+hash_proc_call(RB_BLOCK_CALL_FUNC_ARGLIST(key, hash))
 {
     rb_check_arity(argc, 1, 1);
     return rb_hash_aref(hash, *argv);

--- a/include/ruby/intern.h
+++ b/include/ruby/intern.h
@@ -239,6 +239,7 @@ int rb_cmpint(VALUE, VALUE, VALUE);
 NORETURN(void rb_cmperr(VALUE, VALUE));
 /* cont.c */
 VALUE rb_fiber_new(rb_block_call_func_t, VALUE);
+VALUE rb_fiber_new_kw(rb_block_call_kw_func_t, VALUE);
 VALUE rb_fiber_resume(VALUE fib, int argc, const VALUE *argv);
 VALUE rb_fiber_yield(int argc, const VALUE *argv);
 VALUE rb_fiber_current(void);
@@ -450,6 +451,7 @@ VALUE rb_class_new_instance_kw(int, const VALUE*, VALUE, int);
 VALUE rb_block_proc(void);
 VALUE rb_block_lambda(void);
 VALUE rb_proc_new(rb_block_call_func_t, VALUE);
+VALUE rb_proc_new_kw(rb_block_call_kw_func_t, VALUE);
 VALUE rb_obj_is_proc(VALUE);
 VALUE rb_proc_call(VALUE, VALUE);
 VALUE rb_proc_call_with_block(VALUE, int argc, const VALUE *argv, VALUE);

--- a/include/ruby/ruby.h
+++ b/include/ruby/ruby.h
@@ -1965,13 +1965,18 @@ PRINTF_ARGS(void rb_compile_warn(const char *, int, const char*, ...), 3, 4);
     VALUE yielded_arg, VALUE callback_arg, int argc, const VALUE *argv, VALUE blockarg
 typedef VALUE rb_block_call_func(RB_BLOCK_CALL_FUNC_ARGLIST(yielded_arg, callback_arg));
 typedef rb_block_call_func *rb_block_call_func_t;
+#define RB_BLOCK_CALL_KW_FUNC_ARGLIST(yielded_arg, callback_arg) \
+    VALUE yielded_arg, VALUE callback_arg, int argc, const VALUE *argv, VALUE blockarg, int kw_splat
+typedef VALUE rb_block_call_kw_func(RB_BLOCK_CALL_KW_FUNC_ARGLIST(yielded_arg, callback_arg));
+typedef rb_block_call_kw_func *rb_block_call_kw_func_t;
 
 VALUE rb_each(VALUE);
 VALUE rb_yield(VALUE);
 VALUE rb_yield_values(int n, ...);
 VALUE rb_yield_values2(int n, const VALUE *argv);
 VALUE rb_yield_splat(VALUE);
-VALUE rb_yield_block(VALUE, VALUE, int, const VALUE *, VALUE); /* rb_block_call_func */
+VALUE rb_yield_block(RB_BLOCK_CALL_FUNC_ARGLIST(yielded_arg, callback_arg)); /* rb_block_call_func */
+VALUE rb_yield_block_kw(RB_BLOCK_CALL_KW_FUNC_ARGLIST(yielded_arg, callback_arg)); /* rb_block_call_kw_func */
 #define RB_NO_KEYWORDS 0
 #define RB_PASS_KEYWORDS 1
 #define RB_PASS_EMPTY_KEYWORDS 2
@@ -1980,8 +1985,9 @@ int rb_keyword_given_p(void);
 int rb_block_given_p(void);
 void rb_need_block(void);
 VALUE rb_iterate(VALUE(*)(VALUE),VALUE,rb_block_call_func_t,VALUE);
+VALUE rb_iterate_kw(VALUE(*)(VALUE),VALUE,rb_block_call_kw_func_t,VALUE);
 VALUE rb_block_call(VALUE,ID,int,const VALUE*,rb_block_call_func_t,VALUE);
-VALUE rb_block_call_kw(VALUE,ID,int,const VALUE*,rb_block_call_func_t,VALUE,int);
+VALUE rb_block_call_kw(VALUE,ID,int,const VALUE*,rb_block_call_kw_func_t,VALUE,int);
 VALUE rb_rescue(VALUE(*)(VALUE),VALUE,VALUE(*)(VALUE,VALUE),VALUE);
 VALUE rb_rescue2(VALUE(*)(VALUE),VALUE,VALUE(*)(VALUE,VALUE),VALUE,...);
 VALUE rb_vrescue2(VALUE(*)(VALUE),VALUE,VALUE(*)(VALUE,VALUE),VALUE,va_list);

--- a/test/ruby/test_keyword.rb
+++ b/test/ruby/test_keyword.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: false
 require 'test/unit'
 require '-test-/rb_call_super_kw'
+require '-test-/iter'
 
 class TestKeywordArguments < Test::Unit::TestCase
   def f1(str: "foo", num: 424242)
@@ -2894,6 +2895,576 @@ class TestKeywordArguments < Test::Unit::TestCase
     assert_equal([h2, kw], c.to_enum(:each, h2, &m).size)
     assert_warn(/The last argument is split into positional and keyword parameters/m) do
       assert_equal([h2, h], c.to_enum(:each, h3, &m).size)
+    end
+  end
+
+  def test_instance_exec_kwsplat
+    kw = {}
+    h = {:a=>1}
+    h2 = {'a'=>1}
+    h3 = {'a'=>1, :a=>1}
+
+    c = Object.new
+    m = ->(*args) { args }
+    assert_equal([], c.instance_exec(**{}, &m))
+    assert_equal([], c.instance_exec(**kw, &m))
+    assert_equal([h], c.instance_exec(**h, &m))
+    assert_equal([h], c.instance_exec(a: 1, &m))
+    assert_equal([h2], c.instance_exec(**h2, &m))
+    assert_equal([h3], c.instance_exec(**h3, &m))
+    assert_equal([h3], c.instance_exec(a: 1, **h2, &m))
+
+    m = ->() { nil }
+    assert_nil(c.instance_exec(**{}, &m))
+    assert_nil(c.instance_exec(**kw, &m))
+    assert_raise(ArgumentError) { c.instance_exec(**h, &m) }
+    assert_raise(ArgumentError) { c.instance_exec(a: 1, &m) }
+    assert_raise(ArgumentError) { c.instance_exec(**h2, &m) }
+    assert_raise(ArgumentError) { c.instance_exec(**h3, &m) }
+    assert_raise(ArgumentError) { c.instance_exec(a: 1, **h2, &m) }
+
+    m = ->(args) { args }
+    assert_warn(/The keyword argument is passed as the last hash parameter/) do
+      assert_equal(kw, c.instance_exec(**{}, &m))
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/) do
+      assert_equal(kw, c.instance_exec(**kw, &m))
+    end
+    assert_equal(kw, c.instance_exec(kw, **kw, &m))
+    assert_equal(h, c.instance_exec(**h, &m))
+    assert_equal(h, c.instance_exec(a: 1, &m))
+    assert_equal(h2, c.instance_exec(**h2, &m))
+    assert_equal(h3, c.instance_exec(**h3, &m))
+    assert_equal(h3, c.instance_exec(a: 1, **h2, &m))
+
+    m = ->(**args) { args }
+    assert_equal(kw, c.instance_exec(**{}, &m))
+    assert_equal(kw, c.instance_exec(**kw, &m))
+    assert_equal(h, c.instance_exec(**h, &m))
+    assert_equal(h, c.instance_exec(a: 1, &m))
+    assert_equal(h2, c.instance_exec(**h2, &m))
+    assert_equal(h3, c.instance_exec(**h3, &m))
+    assert_equal(h3, c.instance_exec(a: 1, **h2, &m))
+    assert_warn(/The last argument is used as the keyword parameter/) do
+      assert_equal(h, c.instance_exec(h, &m))
+    end
+    assert_raise(ArgumentError) { c.instance_exec(h2, &m) }
+    assert_warn(/The last argument is split into positional and keyword parameters/) do
+      assert_raise(ArgumentError) { c.instance_exec(h3, &m) }
+    end
+
+    m = ->(arg, **args) { [arg, args] }
+    assert_warn(/The keyword argument is passed as the last hash parameter/) do
+      c.instance_exec(**{}, &m)
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/) do
+      c.instance_exec(**kw, &m)
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/) do
+      assert_equal([h, kw], c.instance_exec(**h, &m))
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/) do
+      assert_equal([h, kw], c.instance_exec(a: 1, &m))
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/) do
+      assert_equal([h2, kw], c.instance_exec(**h2, &m))
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/) do
+      assert_equal([h3, kw], c.instance_exec(**h3, &m))
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/) do
+      assert_equal([h3, kw], c.instance_exec(a: 1, **h2, &m))
+    end
+    assert_equal([h, kw], c.instance_exec(h, &m))
+    assert_equal([h2, kw], c.instance_exec(h2, &m))
+    assert_equal([h3, kw], c.instance_exec(h3, &m))
+
+    m = ->(arg=1, **args) { [arg, args] }
+    assert_equal([1, kw], c.instance_exec(**{}, &m))
+    assert_equal([1, kw], c.instance_exec(**kw, &m))
+    assert_equal([1, h], c.instance_exec(**h, &m))
+    assert_equal([1, h], c.instance_exec(a: 1, &m))
+    assert_equal([1, h2], c.instance_exec(**h2, &m))
+    assert_equal([1, h3], c.instance_exec(**h3, &m))
+    assert_equal([1, h3], c.instance_exec(a: 1, **h2, &m))
+    assert_warn(/The last argument is used as the keyword parameter/m) do
+      assert_equal([1, h], c.instance_exec(h, &m))
+    end
+    assert_equal([h2, kw], c.instance_exec(h2, &m))
+    assert_warn(/The last argument is split into positional and keyword parameters/m) do
+      assert_equal([h2, h], c.instance_exec(h3, &m))
+    end
+  end
+
+  def test_instance_exec_method_kwsplat
+    kw = {}
+    h = {:a=>1}
+    h2 = {'a'=>1}
+    h3 = {'a'=>1, :a=>1}
+
+    c = Object.new
+    def c.m(*args)
+      args
+    end
+    m  = c.method(:m)
+    assert_equal([], c.instance_exec(**{}, &m))
+    assert_equal([], c.instance_exec(**kw, &m))
+    assert_equal([h], c.instance_exec(**h, &m))
+    assert_equal([h], c.instance_exec(a: 1, &m))
+    assert_equal([h2], c.instance_exec(**h2, &m))
+    assert_equal([h3], c.instance_exec(**h3, &m))
+    assert_equal([h3], c.instance_exec(a: 1, **h2, &m))
+
+    c.singleton_class.remove_method(:m)
+    def c.m
+    end
+    m  = c.method(:m)
+    assert_nil(c.instance_exec(**{}, &m))
+    assert_nil(c.instance_exec(**kw, &m))
+    assert_raise(ArgumentError) { c.instance_exec(**h, &m) }
+    assert_raise(ArgumentError) { c.instance_exec(a: 1, &m) }
+    assert_raise(ArgumentError) { c.instance_exec(**h2, &m) }
+    assert_raise(ArgumentError) { c.instance_exec(**h3, &m) }
+    assert_raise(ArgumentError) { c.instance_exec(a: 1, **h2, &m) }
+
+    c.singleton_class.remove_method(:m)
+    def c.m(args)
+      args
+    end
+    m  = c.method(:m)
+    assert_warn(/The keyword argument is passed as the last hash parameter/) do
+      assert_equal(kw, c.instance_exec(**{}, &m))
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/) do
+      assert_equal(kw, c.instance_exec(**kw, &m))
+    end
+    assert_equal(kw, c.instance_exec(kw, **kw, &m))
+    assert_equal(h, c.instance_exec(**h, &m))
+    assert_equal(h, c.instance_exec(a: 1, &m))
+    assert_equal(h2, c.instance_exec(**h2, &m))
+    assert_equal(h3, c.instance_exec(**h3, &m))
+    assert_equal(h3, c.instance_exec(a: 1, **h2, &m))
+
+    c.singleton_class.remove_method(:m)
+    def c.m(**args)
+      args
+    end
+    m  = c.method(:m)
+    assert_equal(kw, c.instance_exec(**{}, &m))
+    assert_equal(kw, c.instance_exec(**kw, &m))
+    assert_equal(h, c.instance_exec(**h, &m))
+    assert_equal(h, c.instance_exec(a: 1, &m))
+    assert_equal(h2, c.instance_exec(**h2, &m))
+    assert_equal(h3, c.instance_exec(**h3, &m))
+    assert_equal(h3, c.instance_exec(a: 1, **h2, &m))
+    assert_warn(/The last argument is used as the keyword parameter/) do
+      assert_equal(h, c.instance_exec(h, &m))
+    end
+    assert_raise(ArgumentError) { c.instance_exec(h2, &m) }
+    assert_warn(/The last argument is split into positional and keyword parameters/) do
+      assert_raise(ArgumentError) { c.instance_exec(h3, &m) }
+    end
+
+    c.singleton_class.remove_method(:m)
+    def c.m(arg, **args)
+      [arg, args]
+    end
+    m  = c.method(:m)
+    assert_warn(/The keyword argument is passed as the last hash parameter/) do
+      c.instance_exec(**{}, &m)
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/) do
+      c.instance_exec(**kw, &m)
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/) do
+      assert_equal([h, kw], c.instance_exec(**h, &m))
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/) do
+      assert_equal([h, kw], c.instance_exec(a: 1, &m))
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/) do
+      assert_equal([h2, kw], c.instance_exec(**h2, &m))
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/) do
+      assert_equal([h3, kw], c.instance_exec(**h3, &m))
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/) do
+      assert_equal([h3, kw], c.instance_exec(a: 1, **h2, &m))
+    end
+    assert_equal([h, kw], c.instance_exec(h, &m))
+    assert_equal([h2, kw], c.instance_exec(h2, &m))
+    assert_equal([h3, kw], c.instance_exec(h3, &m))
+
+    c.singleton_class.remove_method(:m)
+    def c.m(arg=1, **args)
+      [arg, args]
+    end
+    m  = c.method(:m)
+    assert_equal([1, kw], c.instance_exec(**{}, &m))
+    assert_equal([1, kw], c.instance_exec(**kw, &m))
+    assert_equal([1, h], c.instance_exec(**h, &m))
+    assert_equal([1, h], c.instance_exec(a: 1, &m))
+    assert_equal([1, h2], c.instance_exec(**h2, &m))
+    assert_equal([1, h3], c.instance_exec(**h3, &m))
+    assert_equal([1, h3], c.instance_exec(a: 1, **h2, &m))
+    assert_warn(/The last argument is used as the keyword parameter/m) do
+      assert_equal([1, h], c.instance_exec(h, &m))
+    end
+    assert_equal([h2, kw], c.instance_exec(h2, &m))
+    assert_warn(/The last argument is split into positional and keyword parameters/) do
+      assert_equal([h2, h], c.instance_exec(h3, &m))
+    end
+  end
+
+  def test_instance_exec_define_method_kwsplat
+    kw = {}
+    h = {:a=>1}
+    h2 = {'a'=>1}
+    h3 = {'a'=>1, :a=>1}
+
+    c = Object.new
+    c.define_singleton_method(:m) do |*args|
+      args
+    end
+    m  = c.method(:m)
+    assert_equal([], c.instance_exec(**{}, &m))
+    assert_equal([], c.instance_exec(**kw, &m))
+    assert_equal([h], c.instance_exec(**h, &m))
+    assert_equal([h], c.instance_exec(a: 1, &m))
+    assert_equal([h2], c.instance_exec(**h2, &m))
+    assert_equal([h3], c.instance_exec(**h3, &m))
+    assert_equal([h3], c.instance_exec(a: 1, **h2, &m))
+
+    c.singleton_class.remove_method(:m)
+    c.define_singleton_method(:m) do
+    end
+    m  = c.method(:m)
+    assert_nil(c.instance_exec(**{}, &m))
+    assert_nil(c.instance_exec(**kw, &m))
+    assert_raise(ArgumentError) { c.instance_exec(**h, &m) }
+    assert_raise(ArgumentError) { c.instance_exec(a: 1, &m) }
+    assert_raise(ArgumentError) { c.instance_exec(**h2, &m) }
+    assert_raise(ArgumentError) { c.instance_exec(**h3, &m) }
+    assert_raise(ArgumentError) { c.instance_exec(a: 1, **h2, &m) }
+
+    c.singleton_class.remove_method(:m)
+    c.define_singleton_method(:m) do |args|
+      args
+    end
+    m  = c.method(:m)
+    assert_warn(/The keyword argument is passed as the last hash parameter/) do
+      assert_equal(kw, c.instance_exec(**{}, &m))
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/) do
+      assert_equal(kw, c.instance_exec(**kw, &m))
+    end
+    assert_equal(kw, c.instance_exec(kw, **kw, &m))
+    assert_equal(h, c.instance_exec(**h, &m))
+    assert_equal(h, c.instance_exec(a: 1, &m))
+    assert_equal(h2, c.instance_exec(**h2, &m))
+    assert_equal(h3, c.instance_exec(**h3, &m))
+    assert_equal(h3, c.instance_exec(a: 1, **h2, &m))
+
+    c.singleton_class.remove_method(:m)
+    c.define_singleton_method(:m) do |**args|
+      args
+    end
+    m  = c.method(:m)
+    assert_equal(kw, c.instance_exec(**{}, &m))
+    assert_equal(kw, c.instance_exec(**kw, &m))
+    assert_equal(h, c.instance_exec(**h, &m))
+    assert_equal(h, c.instance_exec(a: 1, &m))
+    assert_equal(h2, c.instance_exec(**h2, &m))
+    assert_equal(h3, c.instance_exec(**h3, &m))
+    assert_equal(h3, c.instance_exec(a: 1, **h2, &m))
+    assert_warn(/The last argument is used as the keyword parameter/) do
+      assert_equal(h, c.instance_exec(h, &m))
+    end
+    assert_raise(ArgumentError) { c.instance_exec(h2, &m) }
+    assert_warn(/The last argument is split into positional and keyword parameters/) do
+      assert_raise(ArgumentError) { c.instance_exec(h3, &m) }
+    end
+
+    c.singleton_class.remove_method(:m)
+    c.define_singleton_method(:m) do |arg, **args|
+      [arg, args]
+    end
+    m  = c.method(:m)
+    assert_warn(/The keyword argument is passed as the last hash parameter/) do
+      c.instance_exec(**{}, &m)
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/) do
+      c.instance_exec(**kw, &m)
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/) do
+      assert_equal([h, kw], c.instance_exec(**h, &m))
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/) do
+      assert_equal([h, kw], c.instance_exec(a: 1, &m))
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/) do
+      assert_equal([h2, kw], c.instance_exec(**h2, &m))
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/) do
+      assert_equal([h3, kw], c.instance_exec(**h3, &m))
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/) do
+      assert_equal([h3, kw], c.instance_exec(a: 1, **h2, &m))
+    end
+    assert_equal([h, kw], c.instance_exec(h, &m))
+    assert_equal([h2, kw], c.instance_exec(h2, &m))
+    assert_equal([h3, kw], c.instance_exec(h3, &m))
+
+    c.singleton_class.remove_method(:m)
+    c.define_singleton_method(:m) do |arg=1, **args|
+      [arg, args]
+    end
+    m  = c.method(:m)
+    assert_equal([1, kw], c.instance_exec(**{}, &m))
+    assert_equal([1, kw], c.instance_exec(**kw, &m))
+    assert_equal([1, h], c.instance_exec(**h, &m))
+    assert_equal([1, h], c.instance_exec(a: 1, &m))
+    assert_equal([1, h2], c.instance_exec(**h2, &m))
+    assert_equal([1, h3], c.instance_exec(**h3, &m))
+    assert_equal([1, h3], c.instance_exec(a: 1, **h2, &m))
+    assert_warn(/The last argument is used as the keyword parameter/m) do
+      assert_equal([1, h], c.instance_exec(h, &m))
+    end
+    assert_equal([h2, kw], c.instance_exec(h2, &m))
+    assert_warn(/The last argument is split into positional and keyword parameters/) do
+      assert_equal([h2, h], c.instance_exec(h3, &m))
+    end
+  end
+
+  def test_instance_exec_sym_proc_kwsplat
+    kw = {}
+    h = {:a=>1}
+    h2 = {'a'=>1}
+    h3 = {'a'=>1, :a=>1}
+
+    c = Object.new
+    def c.m(*args)
+      args
+    end
+    assert_equal([], c.instance_exec(c, **{}, &:m))
+    assert_equal([], c.instance_exec(c, **kw, &:m))
+    assert_equal([h], c.instance_exec(c, **h, &:m))
+    assert_equal([h], c.instance_exec(c, a: 1, &:m))
+    assert_equal([h2], c.instance_exec(c, **h2, &:m))
+    assert_equal([h3], c.instance_exec(c, **h3, &:m))
+    assert_equal([h3], c.instance_exec(c, a: 1, **h2, &:m))
+
+    c.singleton_class.remove_method(:m)
+    def c.m
+    end
+    assert_nil(c.instance_exec(c, **{}, &:m))
+    assert_nil(c.instance_exec(c, **kw, &:m))
+    assert_raise(ArgumentError) { c.instance_exec(c, **h, &:m) }
+    assert_raise(ArgumentError) { c.instance_exec(c, a: 1, &:m) }
+    assert_raise(ArgumentError) { c.instance_exec(c, **h2, &:m) }
+    assert_raise(ArgumentError) { c.instance_exec(c, **h3, &:m) }
+    assert_raise(ArgumentError) { c.instance_exec(c, a: 1, **h2, &:m) }
+
+    c.singleton_class.remove_method(:m)
+    def c.m(args)
+      args
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/) do
+      assert_equal(kw, c.instance_exec(c, **{}, &:m))
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/) do
+      assert_equal(kw, c.instance_exec(c, **kw, &:m))
+    end
+    assert_equal(kw, c.instance_exec(c, kw, **kw, &:m))
+    assert_equal(h, c.instance_exec(c, **h, &:m))
+    assert_equal(h, c.instance_exec(c, a: 1, &:m))
+    assert_equal(h2, c.instance_exec(c, **h2, &:m))
+    assert_equal(h3, c.instance_exec(c, **h3, &:m))
+    assert_equal(h3, c.instance_exec(c, a: 1, **h2, &:m))
+
+    c.singleton_class.remove_method(:m)
+    def c.m(**args)
+      args
+    end
+    assert_equal(kw, c.instance_exec(c, **{}, &:m))
+    assert_equal(kw, c.instance_exec(c, **kw, &:m))
+    assert_equal(h, c.instance_exec(c, **h, &:m))
+    assert_equal(h, c.instance_exec(c, a: 1, &:m))
+    assert_equal(h2, c.instance_exec(c, **h2, &:m))
+    assert_equal(h3, c.instance_exec(c, **h3, &:m))
+    assert_equal(h3, c.instance_exec(c, a: 1, **h2, &:m))
+    assert_warn(/The last argument is used as the keyword parameter/) do
+      assert_equal(h, c.instance_exec(c, h, &:m))
+    end
+    assert_raise(ArgumentError) { c.instance_exec(c, h2, &:m) }
+    assert_warn(/The last argument is split into positional and keyword parameters/) do
+      assert_raise(ArgumentError) { c.instance_exec(c, h3, &:m) }
+    end
+
+    c.singleton_class.remove_method(:m)
+    def c.m(arg, **args)
+      [arg, args]
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/) do
+      c.instance_exec(c, **{}, &:m)
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/) do
+      c.instance_exec(c, **kw, &:m)
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/) do
+      assert_equal([h, kw], c.instance_exec(c, **h, &:m))
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/) do
+      assert_equal([h, kw], c.instance_exec(c, a: 1, &:m))
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/) do
+      assert_equal([h2, kw], c.instance_exec(c, **h2, &:m))
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/) do
+      assert_equal([h3, kw], c.instance_exec(c, **h3, &:m))
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter/) do
+      assert_equal([h3, kw], c.instance_exec(c, a: 1, **h2, &:m))
+    end
+    assert_equal([h, kw], c.instance_exec(c, h, &:m))
+    assert_equal([h2, kw], c.instance_exec(c, h2, &:m))
+    assert_equal([h3, kw], c.instance_exec(c, h3, &:m))
+
+    c.singleton_class.remove_method(:m)
+    def c.m(arg=1, **args)
+      [arg, args]
+    end
+    assert_equal([1, kw], c.instance_exec(c, **{}, &:m))
+    assert_equal([1, kw], c.instance_exec(c, **kw, &:m))
+    assert_equal([1, h], c.instance_exec(c, **h, &:m))
+    assert_equal([1, h], c.instance_exec(c, a: 1, &:m))
+    assert_equal([1, h2], c.instance_exec(c, **h2, &:m))
+    assert_equal([1, h3], c.instance_exec(c, **h3, &:m))
+    assert_equal([1, h3], c.instance_exec(c, a: 1, **h2, &:m))
+    assert_warn(/The last argument is used as the keyword parameter/m) do
+      assert_equal([1, h], c.instance_exec(c, h, &:m))
+    end
+    assert_equal([h2, kw], c.instance_exec(c, h2, &:m))
+    assert_warn(/The last argument is split into positional and keyword parameters/) do
+      assert_equal([h2, h], c.instance_exec(c, h3, &:m))
+    end
+  end
+
+  def test_rb_yield_block_kwsplat
+    kw = {}
+    h = {:a=>1}
+    h2 = {'a'=>1}
+    h3 = {'a'=>1, :a=>1}
+
+    c = Object.new
+    c.extend Bug::Iter::Yield
+    class << c
+      alias m yield_block
+    end
+    def c.c(*args)
+      args
+    end
+    assert_equal([], c.m(:c, **{}))
+    assert_equal([], c.m(:c, **kw))
+    assert_equal([h], c.m(:c, **h))
+    assert_equal([h], c.m(:c, a: 1))
+    assert_equal([h2], c.m(:c, **h2))
+    assert_equal([h3], c.m(:c, **h3))
+    assert_equal([h3], c.m(:c, a: 1, **h2))
+
+    c.singleton_class.remove_method(:c)
+    def c.c; end
+    assert_nil(c.m(:c, **{}))
+    assert_nil(c.m(:c, **kw))
+    assert_raise(ArgumentError) { c.m(:c, **h) }
+    assert_raise(ArgumentError) { c.m(:c, a: 1) }
+    assert_raise(ArgumentError) { c.m(:c, **h2) }
+    assert_raise(ArgumentError) { c.m(:c, **h3) }
+    assert_raise(ArgumentError) { c.m(:c, a: 1, **h2) }
+
+    c.singleton_class.remove_method(:c)
+    def c.c(args)
+      args
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter.* for `c'/m) do
+      assert_equal(kw, c.m(:c, **{}))
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter.* for `c'/m) do
+      assert_equal(kw, c.m(:c, **kw))
+    end
+    assert_equal(kw, c.m(:c, kw, **kw))
+    assert_equal(h, c.m(:c, **h))
+    assert_equal(h, c.m(:c, a: 1))
+    assert_equal(h2, c.m(:c, **h2))
+    assert_equal(h3, c.m(:c, **h3))
+    assert_equal(h3, c.m(:c, a: 1, **h2))
+
+    c.singleton_class.remove_method(:c)
+    def c.c(**args)
+      [args, yield(**args)]
+    end
+    m = ->(**args){ args }
+    assert_equal([kw, kw], c.m(:c, **{}, &m))
+    assert_equal([kw, kw], c.m(:c, **kw, &m))
+    assert_equal([h, h], c.m(:c, **h, &m))
+    assert_equal([h, h], c.m(:c, a: 1, &m))
+    assert_equal([h2, h2], c.m(:c, **h2, &m))
+    assert_equal([h3, h3], c.m(:c, **h3, &m))
+    assert_equal([h3, h3], c.m(:c, a: 1, **h2, &m))
+    assert_warn(/The last argument is used as the keyword parameter.*for `c'/m) do
+      assert_equal([h, h], c.m(:c, h, &m))
+    end
+    assert_raise(ArgumentError) { c.m(:c, h2, &m) }
+    assert_warn(/The last argument is split into positional and keyword parameters.*for `c'/m) do
+      assert_raise(ArgumentError) { c.m(:c, h3, &m) }
+    end
+
+    c.singleton_class.remove_method(:c)
+    def c.c(arg, **args)
+      [arg, args]
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter.* for `c'/m) do
+      assert_equal([kw, kw], c.m(:c, **{}))
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter.* for `c'/m) do
+      assert_equal([kw, kw], c.m(:c, **kw))
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter.* for `c'/m) do
+      assert_equal([h, kw], c.m(:c, **h))
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter.* for `c'/m) do
+      assert_equal([h, kw], c.m(:c, a: 1))
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter.* for `c'/m) do
+      assert_equal([h2, kw], c.m(:c, **h2))
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter.* for `c'/m) do
+      assert_equal([h3, kw], c.m(:c, **h3))
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter.* for `c'/m) do
+      assert_equal([h3, kw], c.m(:c, a: 1, **h2))
+    end
+    assert_equal([h, kw], c.m(:c, h))
+    assert_equal([h2, kw], c.m(:c, h2))
+    assert_equal([h3, kw], c.m(:c, h3))
+
+    c.singleton_class.remove_method(:c)
+    def c.c(arg=1, **args)
+      [arg, args]
+    end
+    assert_equal([1, kw], c.m(:c, **{}))
+    assert_equal([1, kw], c.m(:c, **kw))
+    assert_equal([1, h], c.m(:c, **h))
+    assert_equal([1, h], c.m(:c, a: 1))
+    assert_equal([1, h2], c.m(:c, **h2))
+    assert_equal([1, h3], c.m(:c, **h3))
+    assert_equal([1, h3], c.m(:c, a: 1, **h2))
+    assert_warn(/The last argument is used as the keyword parameter.*for `c'/m) do
+      assert_equal([1, h], c.m(:c, h))
+    end
+    assert_equal([h2, kw], c.m(:c, h2))
+    assert_warn(/The last argument is split into positional and keyword parameters.*for `c'/m) do
+      assert_equal([h2, h], c.m(:c, h3))
     end
   end
 

--- a/vm.c
+++ b/vm.c
@@ -938,7 +938,8 @@ rb_vm_make_proc_lambda(const rb_execution_context_t *ec, const struct rb_capture
     }
     VM_ASSERT(VM_EP_IN_HEAP_P(ec, captured->ep));
     VM_ASSERT(imemo_type_p(captured->code.val, imemo_iseq) ||
-	      imemo_type_p(captured->code.val, imemo_ifunc));
+              imemo_type_p(captured->code.val, imemo_ifunc) ||
+              imemo_type_p(captured->code.val, imemo_ifunc_kw));
 
     procval = vm_proc_create_from_captured(klass, captured,
 					   imemo_type(captured->code.val) == imemo_iseq ? block_type_iseq : block_type_ifunc, FALSE, is_lambda);
@@ -1164,10 +1165,10 @@ check_block_handler(rb_execution_context_t *ec)
 }
 
 static VALUE
-vm_yield_with_cref(rb_execution_context_t *ec, int argc, const VALUE *argv, const rb_cref_t *cref, int is_lambda)
+vm_yield_with_cref(rb_execution_context_t *ec, int argc, const VALUE *argv, int kw_splat, const rb_cref_t *cref, int is_lambda)
 {
     return invoke_block_from_c_bh(ec, check_block_handler(ec),
-                                  argc, argv, VM_NO_KEYWORDS, VM_BLOCK_HANDLER_NONE,
+                                  argc, argv, kw_splat, VM_BLOCK_HANDLER_NONE,
 				  cref, is_lambda, FALSE);
 }
 
@@ -1180,10 +1181,10 @@ vm_yield(rb_execution_context_t *ec, int argc, const VALUE *argv)
 }
 
 static VALUE
-vm_yield_with_block(rb_execution_context_t *ec, int argc, const VALUE *argv, VALUE block_handler)
+vm_yield_with_block(rb_execution_context_t *ec, int argc, const VALUE *argv, VALUE block_handler, int kw_splat)
 {
     return invoke_block_from_c_bh(ec, check_block_handler(ec),
-                                  argc, argv, VM_NO_KEYWORDS, block_handler,
+                                  argc, argv, kw_splat, block_handler,
 				  NULL, FALSE, FALSE);
 }
 

--- a/vm_args.c
+++ b/vm_args.c
@@ -1084,7 +1084,7 @@ vm_to_proc(VALUE proc)
 }
 
 static VALUE
-refine_sym_proc_call(RB_BLOCK_CALL_FUNC_ARGLIST(yielded_arg, callback_arg))
+refine_sym_proc_call(RB_BLOCK_CALL_KW_FUNC_ARGLIST(yielded_arg, callback_arg))
 {
     VALUE obj;
     ID mid;
@@ -1092,7 +1092,7 @@ refine_sym_proc_call(RB_BLOCK_CALL_FUNC_ARGLIST(yielded_arg, callback_arg))
     rb_execution_context_t *ec;
     const VALUE symbol = RARRAY_AREF(callback_arg, 0);
     const VALUE refinements = RARRAY_AREF(callback_arg, 1);
-    int kw_splat = RB_PASS_CALLED_KEYWORDS;
+    int kwsplat = RB_PASS_CALLED_KEYWORDS;
     VALUE v;
     VALUE ret;
     VALUE klass;
@@ -1115,12 +1115,12 @@ refine_sym_proc_call(RB_BLOCK_CALL_FUNC_ARGLIST(yielded_arg, callback_arg))
     if (!NIL_P(blockarg)) {
 	vm_passed_block_handler_set(ec, blockarg);
     }
-    v = rb_adjust_argv_kw_splat(&argc, &argv, &kw_splat);
+    v = rb_adjust_argv_kw_splat(&argc, &argv, &kwsplat);
     if (!me) {
-        ret = method_missing(obj, mid, argc, argv, MISSING_NOENTRY, kw_splat);
+        ret = method_missing(obj, mid, argc, argv, MISSING_NOENTRY, kwsplat);
     }
     else {
-        ret = rb_vm_call0(ec, obj, mid, argc, argv, me, kw_splat);
+        ret = rb_vm_call0(ec, obj, mid, argc, argv, me, kwsplat);
     }
     rb_free_tmp_buffer(&v);
     return ret;
@@ -1150,7 +1150,7 @@ vm_caller_setup_arg_block(const rb_execution_context_t *ec, rb_control_frame_t *
                     rb_ary_push(callback_arg, block_code);
                     rb_ary_push(callback_arg, ref);
                     OBJ_FREEZE_RAW(callback_arg);
-                    func = rb_func_proc_new(refine_sym_proc_call, callback_arg);
+                    func = rb_func_kw_proc_new(refine_sym_proc_call, callback_arg);
 		    rb_hash_aset(ref, block_code, func);
 		}
 		block_code = func;

--- a/vm_core.h
+++ b/vm_core.h
@@ -1428,7 +1428,8 @@ VM_BH_IFUNC_P(VALUE block_handler)
     if ((block_handler & 0x03) == 0x03) {
 #if VM_CHECK_MODE > 0
 	struct rb_captured_block *captured = (void *)(block_handler & ~0x03);
-	VM_ASSERT(imemo_type_p(captured->code.val, imemo_ifunc));
+        VM_ASSERT(imemo_type_p(captured->code.val, imemo_ifunc) ||
+                  imemo_type_p(captured->code.val, imemo_ifunc_kw));
 #endif
 	return 1;
     }
@@ -1495,7 +1496,8 @@ vm_block_type(const struct rb_block *block)
 	VM_ASSERT(imemo_type_p(block->as.captured.code.val, imemo_iseq));
 	break;
       case block_type_ifunc:
-	VM_ASSERT(imemo_type_p(block->as.captured.code.val, imemo_ifunc));
+        VM_ASSERT(imemo_type_p(block->as.captured.code.val, imemo_ifunc) ||
+                  imemo_type_p(block->as.captured.code.val, imemo_ifunc_kw));
 	break;
       case block_type_symbol:
 	VM_ASSERT(SYMBOL_P(block->as.symbol));

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -2960,7 +2960,12 @@ vm_yield_with_cfunc(rb_execution_context_t *ec,
 		  VM_GUARDED_PREV_EP(captured->ep),
                   (VALUE)me,
 		  0, ec->cfp->sp, 0, 0);
-    val = (*ifunc->func)(arg, (VALUE)ifunc->data, argc, argv, blockarg);
+    if (imemo_type((VALUE)ifunc) == imemo_ifunc_kw) {
+        val = (*ifunc->func.kw)(arg, (VALUE)ifunc->data, argc, argv, blockarg, kw_splat > 0);
+    }
+    else {
+        val = (*ifunc->func.nokw)(arg, (VALUE)ifunc->data, argc, argv, blockarg);
+    }
     rb_vm_pop_frame(ec);
 
     return val;


### PR DESCRIPTION
This was challenging to do and keep backwards compatibility, because handling
the case when instance_exec was called with a proc produced using
Method#to_proc involves rb_block_call_func.  rb_block_call_func is a public
API type, and changing it would require breaking backwards compatibility.

To avoid changing the rb_block_call_func type, add rb_block_call_kw_func type,
and a bunch of methods that use it that are identical to those that accept
rb_block_call_func other than the function type.  Eventually, both of these
call paths converge on creating a struct vm_ifunc.  struct vm_ifunc is an
internal type, so we can modify it without changing backwards compatibility.
Modify struct vm_infunc to use a union of rb_block_call_func and
rb_block_call_kw_func.  struct vm_ifunc is also a IMEMO object, and use a
separate IMEMO type (imemo_ifunc_kw instead of imemo_ifunc) to differentiate
rb_block_call_func and rb_block_call_kw_func, so that the code can know
whether to call the function with the keyword argument flag.

Switch some methods using rb_block_call_func to use the rb_block_call_kw_func
instead.  Modify rb_block_call_kw to use rb_block_call_kw_func.  That
function was added after 2.6 was released, so it is safe to change.

With that plumbing work done, handle keyword argument separation for
instance_exec and similar methods.  This involves adding a kw_splat
argument to vm_yield_with_cref and vm_yield_with_block.

I originally tried to tackle this issue in a couple commits which broke backwards
compatibility:

* https://github.com/ruby/ruby/pull/2470/commits/68d42d6272c0a9022394ac981d0c7d2143027092
* https://github.com/ruby/ruby/pull/2470/commits/dc65786db70849d3e2c880247d5d5eb89456f933

That approach is significantly simpler than the approach used in this pull request,
but I don't think we can break backwards compatibility for users for the
rb_block_call_func type, which is why I developed this backwards compatible
approach.