### PR TITLE
Warn on access/modify of $SAFE, and remove effects of modifying $SAFE

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -198,6 +198,15 @@ sufficient information, see the ChangeLog file or Redmine
   block arguments.
   Note that the parentheses are mandatory.  `bar ...` is parsed as an endless range.
 
+* Access and setting of <code>$SAFE</code> is now always warned. <code>$SAFE</code>
+  will become a normal global variable in Ruby 3.0. [Feature #16131]
+
+* <code>Object#{taint,untaint,trust,untrust}</code> and related functions in the C-API
+  no longer have an effect (all objects are always considered untainted), and are now
+  warned in verbose mode. This warning will be disabled even in non-verbose mode in
+  Ruby 3.0, and the methods and C functions will be removed in Ruby 3.2.
+  [Feature #16131] 
+
 === Core classes updates (outstanding ones only)
 
 Array::

--- a/array.c
+++ b/array.c
@@ -2285,7 +2285,6 @@ ary_join_0(VALUE ary, VALUE sep, long max, VALUE result)
 	if (i > 0 && !NIL_P(sep))
 	    rb_str_buf_append(result, sep);
 	rb_str_buf_append(result, val);
-	if (OBJ_TAINTED(val)) OBJ_TAINT(result);
     }
 }
 
@@ -2346,11 +2345,9 @@ VALUE
 rb_ary_join(VALUE ary, VALUE sep)
 {
     long len = 1, i;
-    int taint = FALSE;
     VALUE val, tmp, result;
 
     if (RARRAY_LEN(ary) == 0) return rb_usascii_str_new(0, 0);
-    if (OBJ_TAINTED(ary)) taint = TRUE;
 
     if (!NIL_P(sep)) {
 	StringValue(sep);
@@ -2364,7 +2361,6 @@ rb_ary_join(VALUE ary, VALUE sep)
 	    int first;
 	    result = rb_str_buf_new(len + (RARRAY_LEN(ary)-i)*10);
 	    rb_enc_associate(result, rb_usascii_encoding());
-	    if (taint) OBJ_TAINT(result);
 	    ary_join_0(ary, sep, i, result);
 	    first = i == 0;
 	    ary_join_1(ary, ary, sep, i, result, &first);
@@ -2377,7 +2373,6 @@ rb_ary_join(VALUE ary, VALUE sep)
     result = rb_str_new(0, len);
     rb_str_set_len(result, 0);
 
-    if (taint) OBJ_TAINT(result);
     ary_join_0(ary, sep, RARRAY_LEN(ary), result);
 
     return result;
@@ -2419,7 +2414,6 @@ rb_ary_join_m(int argc, VALUE *argv, VALUE ary)
 static VALUE
 inspect_ary(VALUE ary, VALUE dummy, int recur)
 {
-    int tainted = OBJ_TAINTED(ary);
     long i;
     VALUE s, str;
 
@@ -2427,13 +2421,11 @@ inspect_ary(VALUE ary, VALUE dummy, int recur)
     str = rb_str_buf_new2("[");
     for (i=0; i<RARRAY_LEN(ary); i++) {
 	s = rb_inspect(RARRAY_AREF(ary, i));
-	if (OBJ_TAINTED(s)) tainted = TRUE;
 	if (i > 0) rb_str_buf_cat2(str, ", ");
 	else rb_enc_copy(str, s);
 	rb_str_buf_append(str, s);
     }
     rb_str_buf_cat2(str, "]");
-    if (tainted) OBJ_TAINT(str);
     return str;
 }
 
@@ -4135,8 +4127,6 @@ rb_ary_times(VALUE ary, VALUE times)
         }
     }
   out:
-    OBJ_INFECT(ary2, ary);
-
     return ary2;
 }
 
@@ -5315,7 +5305,6 @@ rb_ary_flatten(int argc, VALUE *argv, VALUE ary)
     if (result == ary) {
         result = ary_make_shared_copy(ary);
     }
-    OBJ_INFECT(result, ary);
 
     return result;
 }

--- a/bin/erb
+++ b/bin/erb
@@ -128,10 +128,10 @@ EOU
       exit 2 unless src
       trim = trim_mode_opt(trim_mode, disable_percent)
       if safe_level.nil?
-        erb = factory.new(src.untaint, trim_mode: trim)
+        erb = factory.new(src, trim_mode: trim)
       else
         # [deprecated] This will be removed at Ruby 2.7.
-        erb = factory.new(src.untaint, safe_level, trim_mode: trim)
+        erb = factory.new(src, safe_level, trim_mode: trim)
       end
       erb.filename = filename
       if output
@@ -143,7 +143,7 @@ EOU
           puts erb.src
         end
       else
-        bind = TOPLEVEL_BINDING.taint
+        bind = TOPLEVEL_BINDING
         if variables
           enc = erb.encoding
           for var, val in variables do

--- a/class.c
+++ b/class.c
@@ -205,7 +205,6 @@ rb_class_boot(VALUE super)
     RCLASS_SET_SUPER(klass, super);
     RCLASS_M_TBL_INIT(klass);
 
-    OBJ_INFECT(klass, super);
     return (VALUE)klass;
 }
 
@@ -510,8 +509,6 @@ make_metaclass(VALUE klass)
     super = RCLASS_SUPER(klass);
     while (RB_TYPE_P(super, T_ICLASS)) super = RCLASS_SUPER(super);
     RCLASS_SET_SUPER(metaclass, super ? ENSURE_EIGENCLASS(super) : rb_cClass);
-
-    OBJ_INFECT(metaclass, RCLASS_SUPER(metaclass));
 
     return metaclass;
 }
@@ -851,8 +848,6 @@ rb_include_class_new(VALUE module, VALUE super)
     else {
 	RBASIC_SET_CLASS(klass, module);
     }
-    OBJ_INFECT(klass, module);
-    OBJ_INFECT(klass, super);
 
     return (VALUE)klass;
 }
@@ -867,7 +862,6 @@ ensure_includable(VALUE klass, VALUE module)
     if (!NIL_P(rb_refinement_module_get_refined_class(module))) {
 	rb_raise(rb_eArgError, "refinement module is not allowed");
     }
-    OBJ_INFECT(klass, module);
 }
 
 void
@@ -1660,12 +1654,6 @@ singleton_class_of(VALUE obj)
 	RCLASS_SERIAL(klass) = serial;
     }
 
-    if (OBJ_TAINTED(obj)) {
-	OBJ_TAINT(klass);
-    }
-    else {
-	FL_UNSET(klass, FL_TAINT);
-    }
     RB_FL_SET_RAW(klass, RB_OBJ_FROZEN_RAW(obj));
 
     return klass;

--- a/compile.c
+++ b/compile.c
@@ -11469,8 +11469,6 @@ ibf_load_setup_bytes(struct ibf_load *load, VALUE loader_obj, const char *bytes,
 static void
 ibf_load_setup(struct ibf_load *load, VALUE loader_obj, VALUE str)
 {
-    rb_check_safe_obj(str);
-
     if (RSTRING_LENINT(str) < (int)sizeof(struct ibf_header)) {
         rb_raise(rb_eRuntimeError, "broken binary format");
     }

--- a/dir.c
+++ b/dir.c
@@ -1129,9 +1129,8 @@ rb_dir_getwd_ospath(void)
     DATA_PTR(path_guard) = path;
 #ifdef __APPLE__
     cwd = rb_str_normalize_ospath(path, strlen(path));
-    OBJ_TAINT(cwd);
 #else
-    cwd = rb_tainted_str_new2(path);
+    cwd = rb_str_new2(path);
 #endif
     DATA_PTR(path_guard) = 0;
 
@@ -2564,7 +2563,6 @@ push_pattern(const char *path, VALUE ary, void *enc)
 #if defined _WIN32 || defined __APPLE__
     VALUE name = rb_utf8_str_new_cstr(path);
     rb_encoding *eenc = rb_default_internal_encoding();
-    OBJ_TAINT(name);
     name = rb_str_conv_enc(name, NULL, eenc ? eenc : enc);
 #else
     VALUE name = rb_external_str_new_with_enc(path, strlen(path), enc);

--- a/dir.c
+++ b/dir.c
@@ -2719,7 +2719,6 @@ rb_push_glob(VALUE str, VALUE base, int flags) /* '\0' is delimiter */
         rb_raise(rb_eArgError, "nul-separated glob pattern is deprecated");
     }
     else {
-	rb_check_safe_obj(str);
 	rb_enc_check(str, rb_enc_from_encoding(rb_usascii_encoding()));
     }
     ary = rb_ary_new();

--- a/doc/extension.ja.rdoc
+++ b/doc/extension.ja.rdoc
@@ -215,17 +215,6 @@ rb_str_new_literal(const char *ptr) ::
 
   Cのリテラル文字列からRubyの文字列を生成する．
 
-rb_tainted_str_new(const char *ptr, long len) ::
-
-  汚染マークが付加された新しいRubyの文字列を生成する．外部
-  からのデータに基づく文字列には汚染マークが付加されるべき
-  である．
-
-rb_tainted_str_new2(const char *ptr) ::
-rb_tainted_str_new_cstr(const char *ptr) ::
-
-  Cの文字列から汚染マークが付加されたRubyの文字列を生成する．
-
 rb_str_append(VALUE str1, VALUE str2) ::
 
   Rubyの文字列str1にRubyの文字列str2を追加する．
@@ -1251,7 +1240,6 @@ Data_Get_Struct(data, type, sval) ::
   RB_INTEGER_TYPE_P(value)
   RB_FLOAT_TYPE_P(value)
   void Check_Type(VALUE value, int type)
-  SafeStringValue(value)
 
 === 型変換
 

--- a/doc/extension.rdoc
+++ b/doc/extension.rdoc
@@ -190,16 +190,6 @@ rb_str_new_literal(const char *ptr) ::
 
   Creates a new Ruby string from a C string literal.
 
-rb_tainted_str_new(const char *ptr, long len) ::
-
-  Creates a new tainted Ruby string.  Strings from external data
-  sources should be tainted.
-
-rb_tainted_str_new2(const char *ptr) ::
-rb_tainted_str_new_cstr(const char *ptr) ::
-
-  Creates a new tainted Ruby string from a C string.
-
 rb_sprintf(const char *format, ...) ::
 rb_vsprintf(const char *format, va_list ap) ::
 
@@ -1209,10 +1199,6 @@ RB_FLOAT_TYPE_P(value) ::
 void Check_Type(VALUE value, int type) ::
 
   Ensures +value+ is of the given internal +type+ or raises a TypeError
-
-SafeStringValue(value) ::
-
-  Checks that +value+ is a String and is not tainted
 
 === Data Type Conversion
 

--- a/doc/security.rdoc
+++ b/doc/security.rdoc
@@ -15,19 +15,6 @@ mailto:security@ruby-lang.org ({the PGP public
 key}[https://www.ruby-lang.org/security.asc]), which is a private mailing list.
 Reported problems will be published after fixes.
 
-== <code>$SAFE</code>
-
-Ruby provides a mechanism to restrict what operations can be performed by Ruby
-code in the form of the <code>$SAFE</code> variable.
-
-However, <code>$SAFE</code> does not provide a secure environment for executing
-untrusted code.
-
-If you need to execute untrusted code, you should use an operating system level
-sandboxing mechanism. On Linux, ptrace or LXC can be used to sandbox
-potentially malicious code. Other similar mechanisms exist on every major
-operating system.
-
 == +Marshal.load+
 
 Ruby's +Marshal+ module provides methods for serializing and deserializing Ruby

--- a/encoding.c
+++ b/encoding.c
@@ -654,7 +654,7 @@ load_encoding(const char *name)
     ruby_verbose = Qfalse;
     ruby_debug = Qfalse;
     errinfo = rb_errinfo();
-    loaded = rb_require_internal(enclib, rb_safe_level());
+    loaded = rb_require_internal(enclib);
     ruby_verbose = verbose;
     ruby_debug = debug;
     rb_set_errinfo(errinfo);

--- a/encoding.c
+++ b/encoding.c
@@ -649,7 +649,6 @@ load_encoding(const char *name)
 	else if (ISUPPER(*s)) *s = (char)TOLOWER(*s);
 	++s;
     }
-    FL_UNSET(enclib, FL_TAINT);
     enclib = rb_fstring(enclib);
     ruby_verbose = Qfalse;
     ruby_debug = Qfalse;

--- a/enum.c
+++ b/enum.c
@@ -647,7 +647,6 @@ enum_to_a(int argc, VALUE *argv, VALUE obj)
     VALUE ary = rb_ary_new();
 
     rb_block_call(obj, id_each, argc, argv, collect_all, ary);
-    OBJ_INFECT(ary, obj);
 
     return ary;
 }
@@ -657,7 +656,6 @@ enum_hashify(VALUE obj, int argc, const VALUE *argv, rb_block_call_func *iter)
 {
     VALUE hash = rb_hash_new();
     rb_block_call(obj, id_each, argc, argv, iter, hash);
-    OBJ_INFECT(hash, obj);
     return hash;
 }
 
@@ -1245,7 +1243,6 @@ enum_sort_by(VALUE obj)
     buf = rb_ary_tmp_new(SORT_BY_BUFSIZE*2);
     rb_ary_store(buf, SORT_BY_BUFSIZE*2-1, Qnil);
     memo = MEMO_NEW(0, 0, 0);
-    OBJ_INFECT(memo, obj);
     data = (struct sort_by_data *)&memo->v1;
     RB_OBJ_WRITE(memo, &data->ary, ary);
     RB_OBJ_WRITE(memo, &data->buf, buf);
@@ -1270,7 +1267,6 @@ enum_sort_by(VALUE obj)
     }
     rb_ary_resize(ary, RARRAY_LEN(ary)/2);
     RBASIC_SET_CLASS_RAW(ary, rb_cArray);
-    OBJ_INFECT(ary, memo);
 
     return ary;
 }

--- a/enumerator.c
+++ b/enumerator.c
@@ -1077,7 +1077,6 @@ inspect_enumerator(VALUE obj, VALUE dummy, int recur)
 
     if (recur) {
 	str = rb_sprintf("#<%"PRIsVALUE": ...>", rb_class_path(cname));
-	OBJ_TAINT(str);
 	return str;
     }
 
@@ -1172,7 +1171,6 @@ append_method(VALUE obj, VALUE str, ID default_method, VALUE default_args)
 
 		rb_str_append(str, rb_inspect(arg));
 		rb_str_buf_cat2(str, ", ");
-		OBJ_INFECT(str, arg);
 	    }
 	    if (!NIL_P(kwds)) {
 		rb_hash_foreach(kwds, kwd_append, str);
@@ -3609,7 +3607,6 @@ arith_seq_inspect(VALUE self)
 
                 rb_str_append(str, rb_inspect(arg));
                 rb_str_buf_cat2(str, ", ");
-                OBJ_INFECT(str, arg);
             }
             if (!NIL_P(kwds)) {
                 rb_hash_foreach(kwds, kwd_append, str);

--- a/error.c
+++ b/error.c
@@ -2018,7 +2018,6 @@ syserr_initialize(int argc, VALUE *argv, VALUE self)
 
 	if (!NIL_P(func)) rb_str_catf(errmsg, " @ %"PRIsVALUE, func);
 	rb_str_catf(errmsg, " - %"PRIsVALUE, str);
-	OBJ_INFECT(errmsg, mesg);
     }
     mesg = errmsg;
 
@@ -2319,19 +2318,7 @@ syserr_eqq(VALUE self, VALUE exc)
 /*
  *  Document-class: SecurityError
  *
- *  Raised when attempting a potential unsafe operation, typically when
- *  the $SAFE level is raised above 0.
- *
- *     foo = "bar"
- *     proc = Proc.new do
- *       $SAFE = 3
- *       foo.untaint
- *     end
- *     proc.call
- *
- *  <em>raises the exception:</em>
- *
- *     SecurityError: Insecure: Insecure operation `untaint' at level 3
+ *  No longer used by internal code.
  */
 
 /*
@@ -2971,12 +2958,14 @@ rb_check_frozen(VALUE obj)
 void
 rb_error_untrusted(VALUE obj)
 {
+    rb_warning("rb_error_untrusted is deprecated and will be removed in Ruby 3.2.");
 }
 
 #undef rb_check_trusted
 void
 rb_check_trusted(VALUE obj)
 {
+    rb_warning("rb_check_trusted is deprecated and will be removed in Ruby 3.2.");
 }
 
 void

--- a/error.c
+++ b/error.c
@@ -2985,12 +2985,6 @@ rb_check_copyable(VALUE obj, VALUE orig)
     if (!FL_ABLE(obj)) return;
     rb_check_frozen_internal(obj);
     if (!FL_ABLE(orig)) return;
-    if ((~RBASIC(obj)->flags & RBASIC(orig)->flags) & FL_TAINT) {
-	if (rb_safe_level() > 0) {
-	    rb_raise(rb_eSecurityError, "Insecure: can't modify %"PRIsVALUE,
-		     RBASIC(obj)->klass);
-	}
-    }
 }
 
 void

--- a/eval.c
+++ b/eval.c
@@ -204,7 +204,6 @@ rb_ec_cleanup(rb_execution_context_t *ec, volatile int ex)
         th = th0;
         errs[1] = ec->errinfo;
         if (THROW_DATA_P(ec->errinfo)) ec->errinfo = Qnil;
-	rb_set_safe_level_force(0);
 	ruby_init_stack(&errs[STACK_UPPER(errs, 0, 1)]);
 
         SAVE_ROOT_JMPBUF(th, rb_ec_teardown(ec));

--- a/ext/cgi/escape/escape.c
+++ b/ext/cgi/escape/escape.c
@@ -30,8 +30,6 @@ static inline void
 preserve_original_state(VALUE orig, VALUE dest)
 {
     rb_enc_associate(dest, rb_enc_get(orig));
-
-    RB_OBJ_INFECT_RAW(dest, orig);
 }
 
 static VALUE

--- a/ext/etc/etc.c
+++ b/ext/etc/etc.c
@@ -219,6 +219,7 @@ etc_getpwnam(VALUE obj, VALUE nam)
     struct passwd *pwd;
     const char *p = StringValueCStr(nam);
 
+    rb_check_safe_obj(nam);
     pwd = getpwnam(p);
     if (pwd == 0) rb_raise(rb_eArgError, "can't find user for %"PRIsVALUE, nam);
     return setup_passwd(pwd);
@@ -462,6 +463,7 @@ etc_getgrnam(VALUE obj, VALUE nam)
     struct group *grp;
     const char *p = StringValueCStr(nam);
 
+    rb_check_safe_obj(nam);
     grp = getgrnam(p);
     if (grp == 0) rb_raise(rb_eArgError, "can't find group for %"PRIsVALUE, nam);
     return setup_group(grp);

--- a/ext/etc/etc.c
+++ b/ext/etc/etc.c
@@ -100,7 +100,7 @@ static VALUE
 safe_setup_str(const char *str)
 {
     if (str == 0) str = "";
-    return rb_tainted_str_new2(str);
+    return rb_str_new2(str);
 }
 
 static VALUE
@@ -219,7 +219,6 @@ etc_getpwnam(VALUE obj, VALUE nam)
     struct passwd *pwd;
     const char *p = StringValueCStr(nam);
 
-    rb_check_safe_obj(nam);
     pwd = getpwnam(p);
     if (pwd == 0) rb_raise(rb_eArgError, "can't find user for %"PRIsVALUE, nam);
     return setup_passwd(pwd);
@@ -463,7 +462,6 @@ etc_getgrnam(VALUE obj, VALUE nam)
     struct group *grp;
     const char *p = StringValueCStr(nam);
 
-    rb_check_safe_obj(nam);
     grp = getgrnam(p);
     if (grp == 0) rb_raise(rb_eArgError, "can't find group for %"PRIsVALUE, nam);
     return setup_group(grp);
@@ -679,7 +677,10 @@ etc_systmpdir(VALUE _)
     }
 # endif
 #endif
+#ifndef RB_PASS_KEYWORDS
+    /* untaint on Ruby < 2.7 */
     FL_UNSET(tmpdir, FL_TAINT);
+#endif
     return tmpdir;
 }
 

--- a/ext/etc/etc.c
+++ b/ext/etc/etc.c
@@ -219,7 +219,6 @@ etc_getpwnam(VALUE obj, VALUE nam)
     struct passwd *pwd;
     const char *p = StringValueCStr(nam);
 
-    rb_check_safe_obj(nam);
     pwd = getpwnam(p);
     if (pwd == 0) rb_raise(rb_eArgError, "can't find user for %"PRIsVALUE, nam);
     return setup_passwd(pwd);
@@ -463,7 +462,6 @@ etc_getgrnam(VALUE obj, VALUE nam)
     struct group *grp;
     const char *p = StringValueCStr(nam);
 
-    rb_check_safe_obj(nam);
     grp = getgrnam(p);
     if (grp == 0) rb_raise(rb_eArgError, "can't find group for %"PRIsVALUE, nam);
     return setup_group(grp);

--- a/ext/io/console/console.c
+++ b/ext/io/console/console.c
@@ -1483,6 +1483,7 @@ prompt(int argc, VALUE *argv, VALUE io)
     if (argc > 0 && !NIL_P(argv[0])) {
 	VALUE str = argv[0];
 	StringValueCStr(str);
+	rb_check_safe_obj(str);
 	rb_io_write(io, str);
     }
 }

--- a/ext/io/console/console.c
+++ b/ext/io/console/console.c
@@ -1483,7 +1483,6 @@ prompt(int argc, VALUE *argv, VALUE io)
     if (argc > 0 && !NIL_P(argv[0])) {
 	VALUE str = argv[0];
 	StringValueCStr(str);
-	rb_check_safe_obj(str);
 	rb_io_write(io, str);
     }
 }

--- a/ext/nkf/nkf.c
+++ b/ext/nkf/nkf.c
@@ -168,7 +168,6 @@ rb_nkf_convert(VALUE obj, VALUE opt, VALUE src)
     /* use _result_ end */
 
     rb_str_set_len(tmp, output_ctr);
-    OBJ_INFECT(tmp, src);
 
     if (mimeout_f)
 	rb_enc_associate(tmp, rb_usascii_encoding());

--- a/ext/openssl/ossl_rand.c
+++ b/ext/openssl/ossl_rand.c
@@ -67,8 +67,6 @@ ossl_rand_add(VALUE self, VALUE str, VALUE entropy)
 static VALUE
 ossl_rand_load_file(VALUE self, VALUE filename)
 {
-    rb_check_safe_obj(filename);
-
     if(!RAND_load_file(StringValueCStr(filename), -1)) {
 	ossl_raise(eRandomError, NULL);
     }
@@ -86,8 +84,6 @@ ossl_rand_load_file(VALUE self, VALUE filename)
 static VALUE
 ossl_rand_write_file(VALUE self, VALUE filename)
 {
-    rb_check_safe_obj(filename);
-
     if (RAND_write_file(StringValueCStr(filename)) == -1) {
 	ossl_raise(eRandomError, NULL);
     }
@@ -164,8 +160,6 @@ ossl_rand_pseudo_bytes(VALUE self, VALUE len)
 static VALUE
 ossl_rand_egd(VALUE self, VALUE filename)
 {
-    rb_check_safe_obj(filename);
-
     if (RAND_egd(StringValueCStr(filename)) == -1) {
 	ossl_raise(eRandomError, NULL);
     }
@@ -185,8 +179,6 @@ static VALUE
 ossl_rand_egd_bytes(VALUE self, VALUE filename, VALUE len)
 {
     int n = NUM2INT(len);
-
-    rb_check_safe_obj(filename);
 
     if (RAND_egd_bytes(StringValueCStr(filename), n) == -1) {
 	ossl_raise(eRandomError, NULL);

--- a/ext/openssl/ossl_rand.c
+++ b/ext/openssl/ossl_rand.c
@@ -67,6 +67,8 @@ ossl_rand_add(VALUE self, VALUE str, VALUE entropy)
 static VALUE
 ossl_rand_load_file(VALUE self, VALUE filename)
 {
+    rb_check_safe_obj(filename);
+
     if(!RAND_load_file(StringValueCStr(filename), -1)) {
 	ossl_raise(eRandomError, NULL);
     }
@@ -84,6 +86,8 @@ ossl_rand_load_file(VALUE self, VALUE filename)
 static VALUE
 ossl_rand_write_file(VALUE self, VALUE filename)
 {
+    rb_check_safe_obj(filename);
+
     if (RAND_write_file(StringValueCStr(filename)) == -1) {
 	ossl_raise(eRandomError, NULL);
     }
@@ -160,6 +164,8 @@ ossl_rand_pseudo_bytes(VALUE self, VALUE len)
 static VALUE
 ossl_rand_egd(VALUE self, VALUE filename)
 {
+    rb_check_safe_obj(filename);
+
     if (RAND_egd(StringValueCStr(filename)) == -1) {
 	ossl_raise(eRandomError, NULL);
     }
@@ -179,6 +185,8 @@ static VALUE
 ossl_rand_egd_bytes(VALUE self, VALUE filename, VALUE len)
 {
     int n = NUM2INT(len);
+
+    rb_check_safe_obj(filename);
 
     if (RAND_egd_bytes(StringValueCStr(filename), n) == -1) {
 	ossl_raise(eRandomError, NULL);

--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -1828,7 +1828,6 @@ ossl_ssl_read_internal(int argc, VALUE *argv, VALUE self, int nonblock)
 	else
 	    rb_str_modify_expand(str, ilen - RSTRING_LEN(str));
     }
-    OBJ_TAINT(str);
     rb_str_set_len(str, 0);
     if (ilen == 0)
 	return str;

--- a/ext/openssl/ossl_x509store.c
+++ b/ext/openssl/ossl_x509store.c
@@ -304,7 +304,6 @@ ossl_x509store_add_file(VALUE self, VALUE file)
     char *path = NULL;
 
     if(file != Qnil){
-	rb_check_safe_obj(file);
 	path = StringValueCStr(file);
     }
     GetX509Store(self, store);
@@ -340,7 +339,6 @@ ossl_x509store_add_path(VALUE self, VALUE dir)
     char *path = NULL;
 
     if(dir != Qnil){
-	rb_check_safe_obj(dir);
 	path = StringValueCStr(dir);
     }
     GetX509Store(self, store);

--- a/ext/openssl/ossl_x509store.c
+++ b/ext/openssl/ossl_x509store.c
@@ -304,6 +304,7 @@ ossl_x509store_add_file(VALUE self, VALUE file)
     char *path = NULL;
 
     if(file != Qnil){
+	rb_check_safe_obj(file);
 	path = StringValueCStr(file);
     }
     GetX509Store(self, store);
@@ -339,6 +340,7 @@ ossl_x509store_add_path(VALUE self, VALUE dir)
     char *path = NULL;
 
     if(dir != Qnil){
+	rb_check_safe_obj(dir);
 	path = StringValueCStr(dir);
     }
     GetX509Store(self, store);

--- a/ext/pathname/pathname.c
+++ b/ext/pathname/pathname.c
@@ -110,7 +110,6 @@ path_initialize(VALUE self, VALUE arg)
     str = rb_obj_dup(str);
 
     set_strpath(self, str);
-    OBJ_INFECT(self, str);
     return self;
 }
 
@@ -134,15 +133,12 @@ path_freeze(VALUE self)
  * call-seq:
  *   pathname.taint -> obj
  *
- * Taints this Pathname.
- *
- * See Object.taint.
+ * Returns pathname.  This method is deprecated and will be removed in Ruby 3.2.
  */
 static VALUE
 path_taint(VALUE self)
 {
-    rb_call_super(0, 0);
-    rb_obj_taint(get_strpath(self));
+    rb_warning("Pathname#taint is deprecated and will be removed in Ruby 3.2.");
     return self;
 }
 
@@ -150,15 +146,12 @@ path_taint(VALUE self)
  * call-seq:
  *   pathname.untaint -> obj
  *
- * Untaints this Pathname.
- *
- * See Object.untaint.
+ * Returns pathname.  This method is deprecated and will be removed in Ruby 3.2.
  */
 static VALUE
 path_untaint(VALUE self)
 {
-    rb_call_super(0, 0);
-    rb_obj_untaint(get_strpath(self));
+    rb_warning("Pathname#untaint is deprecated and will be removed in Ruby 3.2.");
     return self;
 }
 
@@ -308,7 +301,6 @@ path_sub_ext(VALUE self, VALUE repl)
     }
     str2 = rb_str_subseq(str, 0, ext-p);
     rb_str_append(str2, repl);
-    OBJ_INFECT(str2, str);
     return rb_class_new_instance(1, &str2, rb_obj_class(self));
 }
 

--- a/ext/readline/readline.c
+++ b/ext/readline/readline.c
@@ -95,7 +95,6 @@ static char **readline_attempted_completion_function(const char *text,
 
 #define OutputStringValue(str) do {\
     StringValueCStr(str);\
-    rb_check_safe_obj(str);\
     (str) = rb_str_conv_enc((str), rb_enc_get(str), rb_locale_encoding());\
 } while (0)\
 

--- a/ext/socket/ancdata.c
+++ b/ext/socket/ancdata.c
@@ -1631,10 +1631,9 @@ bsock_recvmsg_internal(VALUE sock,
     }
 
     if (NIL_P(dat_str))
-        dat_str = rb_tainted_str_new(datbuf, ss);
+        dat_str = rb_str_new(datbuf, ss);
     else {
         rb_str_resize(dat_str, ss);
-        OBJ_TAINT(dat_str);
 	rb_obj_reveal(dat_str, rb_cString);
     }
 
@@ -1660,7 +1659,7 @@ bsock_recvmsg_internal(VALUE sock,
             }
             ctl_end = (char*)cmh + cmh->cmsg_len;
 	    clen = (ctl_end <= msg_end ? ctl_end : msg_end) - (char*)CMSG_DATA(cmh);
-            ctl = ancdata_new(family, cmh->cmsg_level, cmh->cmsg_type, rb_tainted_str_new((char*)CMSG_DATA(cmh), clen));
+            ctl = ancdata_new(family, cmh->cmsg_level, cmh->cmsg_type, rb_str_new((char*)CMSG_DATA(cmh), clen));
             if (request_scm_rights)
                 make_io_for_unix_rights(ctl, cmh, msg_end);
             else

--- a/ext/socket/constants.c
+++ b/ext/socket/constants.c
@@ -28,7 +28,6 @@ constant_arg(VALUE arg, int (*str_to_int)(const char*, long, int*), const char *
     else if (!NIL_P(tmp = rb_check_string_type(arg))) {
 	arg = tmp;
       str:
-	rb_check_safe_obj(arg);
         ptr = RSTRING_PTR(arg);
         if (str_to_int(ptr, RSTRING_LEN(arg), &ret) == -1)
 	    rb_raise(rb_eSocket, "%s: %s", errmsg, ptr);

--- a/ext/socket/init.c
+++ b/ext/socket/init.c
@@ -143,7 +143,7 @@ rsock_strbuf(VALUE str, long buflen)
 {
     long len;
 
-    if (NIL_P(str)) return rb_tainted_str_new(0, buflen);
+    if (NIL_P(str)) return rb_str_new(0, buflen);
 
     StringValue(str);
     len = RSTRING_LEN(str);
@@ -201,7 +201,6 @@ rsock_s_recvfrom(VALUE sock, int argc, VALUE *argv, enum sock_recv_type from)
     if (slen != RSTRING_LEN(str)) {
 	rb_str_set_len(str, slen);
     }
-    rb_obj_taint(str);
     switch (from) {
       case RECV_RECV:
 	return str;
@@ -282,7 +281,6 @@ rsock_s_recvfrom_nonblock(VALUE sock, VALUE len, VALUE flg, VALUE str,
     if (slen != RSTRING_LEN(str)) {
 	rb_str_set_len(str, slen);
     }
-    rb_obj_taint(str);
     switch (from) {
       case RECV_RECV:
         return str;
@@ -329,7 +327,6 @@ rsock_read_nonblock(VALUE sock, VALUE length, VALUE buf, VALUE ex)
     VALUE str = rsock_strbuf(buf, len);
     char *ptr;
 
-    OBJ_TAINT(str);
     GetOpenFile(sock, fptr);
 
     if (len == 0) {

--- a/ext/socket/raddrinfo.c
+++ b/ext/socket/raddrinfo.c
@@ -969,7 +969,7 @@ init_addrinfo_getaddrinfo(rb_addrinfo_t *rai, VALUE node, VALUE service,
 
     canonname = Qnil;
     if (res->ai->ai_canonname) {
-        canonname = rb_tainted_str_new_cstr(res->ai->ai_canonname);
+        canonname = rb_str_new_cstr(res->ai->ai_canonname);
         OBJ_FREEZE(canonname);
     }
 
@@ -1019,8 +1019,6 @@ make_inspectname(VALUE node, VALUE service, struct addrinfo *res)
             rb_str_catf(inspectname, ":%d", FIX2INT(service));
     }
     if (!NIL_P(inspectname)) {
-        OBJ_INFECT(inspectname, node);
-        OBJ_INFECT(inspectname, service);
         OBJ_FREEZE(inspectname);
     }
     return inspectname;
@@ -1039,7 +1037,7 @@ addrinfo_firstonly_new(VALUE node, VALUE service, VALUE family, VALUE socktype, 
 
     canonname = Qnil;
     if (res->ai->ai_canonname) {
-        canonname = rb_tainted_str_new_cstr(res->ai->ai_canonname);
+        canonname = rb_str_new_cstr(res->ai->ai_canonname);
         OBJ_FREEZE(canonname);
     }
 
@@ -1069,7 +1067,7 @@ addrinfo_list_new(VALUE node, VALUE service, VALUE family, VALUE socktype, VALUE
         VALUE canonname = Qnil;
 
         if (r->ai_canonname) {
-            canonname = rb_tainted_str_new_cstr(r->ai_canonname);
+            canonname = rb_str_new_cstr(r->ai_canonname);
             OBJ_FREEZE(canonname);
         }
 
@@ -1908,7 +1906,6 @@ addrinfo_to_sockaddr(VALUE self)
     rb_addrinfo_t *rai = get_addrinfo(self);
     VALUE ret;
     ret = rb_str_new((char*)&rai->addr, rai->sockaddr_len);
-    OBJ_INFECT(ret, self);
     return ret;
 }
 
@@ -2591,7 +2588,6 @@ addrinfo_s_unix(int argc, VALUE *argv, VALUE self)
     addr = addrinfo_s_allocate(rb_cAddrinfo);
     DATA_PTR(addr) = rai = alloc_addrinfo();
     init_unix_addrinfo(rai, path, socktype);
-    OBJ_INFECT(addr, path);
     return addr;
 }
 

--- a/ext/socket/raddrinfo.c
+++ b/ext/socket/raddrinfo.c
@@ -503,10 +503,6 @@ str_is_number(const char *p)
 #define str_equal(ptr, len, name) \
     ((ptr)[0] == name[0] && \
      rb_strlen_lit(name) == (len) && memcmp(ptr, name, len) == 0)
-#define SafeStringValueCStr(v) do {\
-    StringValueCStr(v);\
-    rb_check_safe_obj(v);\
-} while(0)
 
 static char*
 host_str(VALUE host, char *hbuf, size_t hbuflen, int *flags_ptr)
@@ -525,7 +521,7 @@ host_str(VALUE host, char *hbuf, size_t hbuflen, int *flags_ptr)
         const char *name;
         size_t len;
 
-        SafeStringValueCStr(host);
+        StringValueCStr(host);
         RSTRING_GETMEM(host, name, len);
         if (!len || str_equal(name, len, "<any>")) {
             make_inetaddr(INADDR_ANY, hbuf, hbuflen);
@@ -564,7 +560,7 @@ port_str(VALUE port, char *pbuf, size_t pbuflen, int *flags_ptr)
         const char *serv;
         size_t len;
 
-        SafeStringValueCStr(port);
+        StringValueCStr(port);
         RSTRING_GETMEM(port, serv, len);
         if (len >= pbuflen) {
             rb_raise(rb_eArgError, "service name too long (%"PRIuSIZE")",

--- a/ext/socket/socket.c
+++ b/ext/socket/socket.c
@@ -1164,7 +1164,7 @@ sock_s_getservbyport(int argc, VALUE *argv, VALUE _)
     if (!sp) {
 	rb_raise(rb_eSocket, "no such service for port %d/%s", (int)portnum, protoname);
     }
-    return rb_tainted_str_new2(sp->s_name);
+    return rb_str_new2(sp->s_name);
 }
 
 /*
@@ -1414,8 +1414,6 @@ sock_s_pack_sockaddr_in(VALUE self, VALUE port, VALUE host)
     VALUE addr = rb_str_new((char*)res->ai->ai_addr, res->ai->ai_addrlen);
 
     rb_freeaddrinfo(res);
-    OBJ_INFECT(addr, port);
-    OBJ_INFECT(addr, host);
 
     return addr;
 }
@@ -1457,7 +1455,6 @@ sock_s_unpack_sockaddr_in(VALUE self, VALUE addr)
 #endif
     }
     host = rsock_make_ipaddr((struct sockaddr*)sockaddr, RSTRING_SOCKLEN(addr));
-    OBJ_INFECT(host, addr);
     return rb_assoc_new(INT2NUM(ntohs(sockaddr->sin_port)), host);
 }
 
@@ -1487,7 +1484,6 @@ sock_s_pack_sockaddr_un(VALUE self, VALUE path)
     }
     memcpy(sockaddr.sun_path, RSTRING_PTR(path), RSTRING_LEN(path));
     addr = rb_str_new((char*)&sockaddr, rsock_unix_sockaddr_len(path));
-    OBJ_INFECT(addr, path);
 
     return addr;
 }
@@ -1524,7 +1520,6 @@ sock_s_unpack_sockaddr_un(VALUE self, VALUE addr)
 		 RSTRING_LEN(addr), (int)sizeof(struct sockaddr_un));
     }
     path = rsock_unixpath_str(sockaddr, RSTRING_SOCKLEN(addr));
-    OBJ_INFECT(path, addr);
     return path;
 }
 #endif

--- a/ext/socket/unixsocket.c
+++ b/ext/socket/unixsocket.c
@@ -39,7 +39,6 @@ unixsock_path_value(VALUE path)
 #endif
     if (isstr) {
         if (RSTRING_LEN(name) == 0 || RSTRING_PTR(name)[0] == '\0') {
-            rb_check_safe_obj(name);
             return name;             /* ignore encoding */
         }
     }

--- a/ext/strscan/strscan.c
+++ b/ext/strscan/strscan.c
@@ -77,7 +77,6 @@ struct strscanner
    ======================================================================= */
 
 static inline long minl _((const long n, const long x));
-static VALUE infect _((VALUE str, struct strscanner *p));
 static VALUE extract_range _((struct strscanner *p, long beg_i, long end_i));
 static VALUE extract_beg_len _((struct strscanner *p, long beg_i, long len));
 
@@ -139,13 +138,6 @@ static VALUE inspect2 _((struct strscanner *p));
    ======================================================================= */
 
 static VALUE
-infect(VALUE str, struct strscanner *p)
-{
-    OBJ_INFECT(str, p->str);
-    return str;
-}
-
-static VALUE
 str_new(struct strscanner *p, const char *ptr, long len)
 {
     VALUE str = rb_str_new(ptr, len);
@@ -164,7 +156,7 @@ extract_range(struct strscanner *p, long beg_i, long end_i)
 {
     if (beg_i > S_LEN(p)) return Qnil;
     end_i = minl(end_i, S_LEN(p));
-    return infect(str_new(p, S_PBEG(p) + beg_i, end_i - beg_i), p);
+    return str_new(p, S_PBEG(p) + beg_i, end_i - beg_i);
 }
 
 static VALUE
@@ -172,7 +164,7 @@ extract_beg_len(struct strscanner *p, long beg_i, long len)
 {
     if (beg_i > S_LEN(p)) return Qnil;
     len = minl(len, S_LEN(p) - beg_i);
-    return infect(str_new(p, S_PBEG(p) + beg_i, len), p);
+    return str_new(p, S_PBEG(p) + beg_i, len);
 }
 
 /* =======================================================================
@@ -950,7 +942,7 @@ strscan_peek(VALUE self, VALUE vlen)
 
     len = NUM2LONG(vlen);
     if (EOS_P(p))
-        return infect(str_new(p, "", 0), p);
+        return str_new(p, "", 0);
 
     len = minl(len, S_RESTLEN(p));
     return extract_beg_len(p, p->curr, len);
@@ -1336,7 +1328,7 @@ strscan_rest(VALUE self)
 
     GET_SCANNER(self, p);
     if (EOS_P(p)) {
-        return infect(str_new(p, "", 0), p);
+        return str_new(p, "", 0);
     }
     return extract_range(p, p->curr, S_LEN(p));
 }
@@ -1391,11 +1383,11 @@ strscan_inspect(VALUE self)
     p = check_strscan(self);
     if (NIL_P(p->str)) {
 	a = rb_sprintf("#<%"PRIsVALUE" (uninitialized)>", rb_obj_class(self));
-	return infect(a, p);
+	return a;
     }
     if (EOS_P(p)) {
 	a = rb_sprintf("#<%"PRIsVALUE" fin>", rb_obj_class(self));
-	return infect(a, p);
+	return a;
     }
     if (p->curr == 0) {
 	b = inspect2(p);
@@ -1403,7 +1395,7 @@ strscan_inspect(VALUE self)
 		       rb_obj_class(self),
 		       p->curr, S_LEN(p),
 		       b);
-	return infect(a, p);
+	return a;
     }
     a = inspect1(p);
     b = inspect2(p);
@@ -1411,7 +1403,7 @@ strscan_inspect(VALUE self)
 		   rb_obj_class(self),
 		   p->curr, S_LEN(p),
 		   a, b);
-    return infect(a, p);
+    return a;
 }
 
 static VALUE

--- a/ext/syslog/syslog.c
+++ b/ext/syslog/syslog.c
@@ -162,7 +162,6 @@ static VALUE mSyslog_open(int argc, VALUE *argv, VALUE self)
         ident = rb_gv_get("$0");
     }
     ident_ptr = StringValueCStr(ident);
-    rb_check_safe_obj(ident);
     syslog_ident = strdup(ident_ptr);
 
     if (NIL_P(opt)) {

--- a/ext/win32ole/win32ole.c
+++ b/ext/win32ole/win32ole.c
@@ -1985,10 +1985,6 @@ fole_s_connect(int argc, VALUE *argv, VALUE self)
 
     rb_scan_args(argc, argv, "1*", &svr_name, &others);
     StringValue(svr_name);
-    if (rb_safe_level() > 0 && OBJ_TAINTED(svr_name)) {
-        rb_raise(rb_eSecurityError, "insecure connection - `%s'",
-		StringValuePtr(svr_name));
-    }
 
     /* get CLSID from OLE server name */
     pBuf = ole_vstr2wc(svr_name);
@@ -2478,16 +2474,8 @@ fole_initialize(int argc, VALUE *argv, VALUE self)
     rb_scan_args(argc, argv, "11*:", &svr_name, &host, &others, &opts);
 
     StringValue(svr_name);
-    if (rb_safe_level() > 0 && OBJ_TAINTED(svr_name)) {
-        rb_raise(rb_eSecurityError, "insecure object creation - `%s'",
-                 StringValuePtr(svr_name));
-    }
     if (!NIL_P(host)) {
         StringValue(host);
-        if (rb_safe_level() > 0 && OBJ_TAINTED(host)) {
-            rb_raise(rb_eSecurityError, "insecure object creation - `%s'",
-                     StringValuePtr(host));
-        }
         return ole_create_dcom(self, svr_name, host, others);
     }
 

--- a/ext/win32ole/win32ole_event.c
+++ b/ext/win32ole/win32ole_event.c
@@ -922,10 +922,6 @@ ev_advise(int argc, VALUE *argv, VALUE self)
 
     if(!RB_TYPE_P(itf, T_NIL)) {
         pitf = StringValuePtr(itf);
-        if (rb_safe_level() > 0 && OBJ_TAINTED(itf)) {
-            rb_raise(rb_eSecurityError, "insecure event creation - `%s'",
-                     StringValuePtr(itf));
-        }
         hr = find_iid(ole, pitf, &iid, &pTypeInfo);
     }
     else {

--- a/gc.c
+++ b/gc.c
@@ -3288,9 +3288,6 @@ static VALUE
 run_single_final(VALUE final, VALUE objid)
 {
     const VALUE cmd = RARRAY_AREF(final, 1);
-    const int level = OBJ_TAINTED(cmd) ?
-	RUBY_SAFE_LEVEL_MAX : FIX2INT(RARRAY_AREF(final, 0));
-
     return rb_check_funcall(cmd, idCall, 1, &objid);
 }
 
@@ -10486,8 +10483,6 @@ wmap_inspect_i(st_data_t key, st_data_t val, st_data_t arg)
     rb_str_cat2(str, " => ");
     v = SPECIAL_CONST_P(v) ? rb_inspect(v) : rb_any_to_s(v);
     rb_str_append(str, v);
-    OBJ_INFECT(str, k);
-    OBJ_INFECT(str, v);
 
     return ST_CONTINUE;
 }

--- a/hash.c
+++ b/hash.c
@@ -5719,7 +5719,6 @@ env_has_value(VALUE dmy, VALUE obj)
 
     obj = rb_check_string_type(obj);
     if (NIL_P(obj)) return Qnil;
-    rb_check_safe_obj(obj);
     env = GET_ENVIRON(environ);
     while (*env) {
 	char *s = strchr(*env, '=');
@@ -5750,7 +5749,6 @@ env_rassoc(VALUE dmy, VALUE obj)
 
     obj = rb_check_string_type(obj);
     if (NIL_P(obj)) return Qnil;
-    rb_check_safe_obj(obj);
     env = GET_ENVIRON(environ);
     while (*env) {
 	char *s = strchr(*env, '=');

--- a/include/ruby/intern.h
+++ b/include/ruby/intern.h
@@ -459,7 +459,8 @@ int rb_provided(const char*);
 int rb_feature_provided(const char *, const char **);
 void rb_provide(const char*);
 VALUE rb_f_require(VALUE, VALUE);
-VALUE rb_require_safe(VALUE, int);
+VALUE rb_require_safe(VALUE, int); /* Remove in 3.0 */
+VALUE rb_require_string(VALUE);
 void rb_obj_call_init(VALUE, int, const VALUE*);
 void rb_obj_call_init_kw(VALUE, int, const VALUE*, int);
 VALUE rb_class_new_instance(int, const VALUE*, VALUE);
@@ -519,8 +520,8 @@ VALUE rb_file_expand_path(VALUE, VALUE);
 VALUE rb_file_s_absolute_path(int, const VALUE *);
 VALUE rb_file_absolute_path(VALUE, VALUE);
 VALUE rb_file_dirname(VALUE fname);
-int rb_find_file_ext_safe(VALUE*, const char* const*, int);
-VALUE rb_find_file_safe(VALUE, int);
+int rb_find_file_ext_safe(VALUE*, const char* const*, int); /* Remove in 3.0 */
+VALUE rb_find_file_safe(VALUE, int); /* Remove in 3.0 */
 int rb_find_file_ext(VALUE*, const char* const*);
 VALUE rb_find_file(VALUE);
 VALUE rb_file_directory_p(VALUE,VALUE);

--- a/include/ruby/intern.h
+++ b/include/ruby/intern.h
@@ -308,10 +308,8 @@ void rb_check_trusted(VALUE);
 	    rb_error_frozen_object(frozen_obj); \
 	} \
     } while (0)
-#define rb_check_trusted_internal(obj) ((void) 0)
 #ifdef __GNUC__
 #define rb_check_frozen(obj) __extension__({rb_check_frozen_internal(obj);})
-#define rb_check_trusted(obj) __extension__({rb_check_trusted_internal(obj);})
 #else
 static inline void
 rb_check_frozen_inline(VALUE obj)
@@ -322,7 +320,7 @@ rb_check_frozen_inline(VALUE obj)
 static inline void
 rb_check_trusted_inline(VALUE obj)
 {
-    rb_check_trusted_internal(obj);
+    rb_check_trusted(obj);
 }
 #define rb_check_trusted(obj) rb_check_trusted_inline(obj)
 #endif

--- a/include/ruby/intern.h
+++ b/include/ruby/intern.h
@@ -435,6 +435,7 @@ void rb_attr(VALUE,ID,int,int,int);
 int rb_method_boundp(VALUE, ID, int);
 int rb_method_basic_definition_p(VALUE, ID);
 VALUE rb_eval_cmd(VALUE, VALUE, int);
+VALUE rb_eval_cmd_kw(VALUE, VALUE, int);
 int rb_obj_respond_to(VALUE, ID, int);
 int rb_respond_to(VALUE, ID);
 NORETURN(VALUE rb_f_notimplement(int argc, const VALUE *argv, VALUE obj, VALUE marker));

--- a/include/ruby/ruby.h
+++ b/include/ruby/ruby.h
@@ -604,21 +604,18 @@ char *rb_string_value_cstr(volatile VALUE*);
 #define StringValueCStr(v) rb_string_value_cstr(&(v))
 
 void rb_check_safe_obj(VALUE);
-#define SafeStringValue(v) do {\
-    StringValue(v);\
-    rb_check_safe_obj(v);\
-} while (0)
+#define SafeStringValue(v) StringValue(v)
 #if GCC_VERSION_SINCE(4,4,0)
-void rb_check_safe_str(VALUE) __attribute__((error("rb_check_safe_str() and Check_SafeStr() are obsolete; use SafeStringValue() instead")));
+void rb_check_safe_str(VALUE) __attribute__((error("rb_check_safe_str() and Check_SafeStr() are obsolete; use StringValue() instead")));
 # define Check_SafeStr(v) rb_check_safe_str((VALUE)(v))
 #else
-# define rb_check_safe_str(x) [<"rb_check_safe_str() is obsolete; use SafeStringValue() instead">]
-# define Check_SafeStr(v) [<"Check_SafeStr() is obsolete; use SafeStringValue() instead">]
+# define rb_check_safe_str(x) [<"rb_check_safe_str() is obsolete; use StringValue() instead">]
+# define Check_SafeStr(v) [<"Check_SafeStr() is obsolete; use StringValue() instead">]
 #endif
 
 VALUE rb_str_export(VALUE);
 #define ExportStringValue(v) do {\
-    SafeStringValue(v);\
+    StringValue(v);\
    (v) = rb_str_export(v);\
 } while (0)
 VALUE rb_str_export_locale(VALUE);
@@ -627,8 +624,9 @@ VALUE rb_get_path(VALUE);
 #define FilePathValue(v) (RB_GC_GUARD(v) = rb_get_path(v))
 
 VALUE rb_get_path_no_checksafe(VALUE);
-#define FilePathStringValue(v) ((v) = rb_get_path_no_checksafe(v))
+#define FilePathStringValue(v) ((v) = rb_get_path(v))
 
+/* Remove in 3.0 */
 #define RUBY_SAFE_LEVEL_MAX 1
 void rb_secure(int);
 int rb_safe_level(void);

--- a/internal.h
+++ b/internal.h
@@ -1570,9 +1570,8 @@ void rb_file_const(const char*, VALUE);
 int rb_file_load_ok(const char *);
 VALUE rb_file_expand_path_fast(VALUE, VALUE);
 VALUE rb_file_expand_path_internal(VALUE, VALUE, int, int, VALUE);
-VALUE rb_get_path_check_to_string(VALUE, int);
-VALUE rb_get_path_check_convert(VALUE, VALUE, int);
-VALUE rb_get_path_check(VALUE, int);
+VALUE rb_get_path_check_to_string(VALUE);
+VALUE rb_get_path_check_convert(VALUE);
 void Init_File(void);
 int ruby_is_fd_loadable(int fd);
 
@@ -1604,7 +1603,7 @@ void rb_gc_writebarrier_remember(VALUE obj);
 #else
 #define rb_gc_writebarrier_remember(obj) 0
 #endif
-void ruby_gc_set_params(int safe_level);
+void ruby_gc_set_params(void);
 void rb_copy_wb_protected_attribute(VALUE dest, VALUE obj);
 
 #if defined(HAVE_MALLOC_USABLE_SIZE) || defined(HAVE_MALLOC_SIZE) || defined(_WIN32)
@@ -1696,7 +1695,7 @@ void rb_io_fptr_finalize_internal(void *ptr);
 
 /* load.c */
 VALUE rb_get_expanded_load_path(void);
-int rb_require_internal(VALUE fname, int safe);
+int rb_require_internal(VALUE fname);
 NORETURN(void rb_load_fail(VALUE, const char*));
 
 /* loadpath.c */

--- a/io.c
+++ b/io.c
@@ -12839,9 +12839,6 @@ opt_i_get(ID id, VALUE *var)
 static VALUE
 argf_inplace_mode_set(VALUE argf, VALUE val)
 {
-    if (rb_safe_level() >= 1 && OBJ_TAINTED(val))
-	rb_insecure_operation();
-
     if (!RTEST(val)) {
 	ARGF.inplace = Qfalse;
     }

--- a/io.c
+++ b/io.c
@@ -2525,7 +2525,6 @@ remain_size(rb_io_t *fptr)
 static VALUE
 io_enc_str(VALUE str, rb_io_t *fptr)
 {
-    OBJ_TAINT(str);
     rb_enc_associate(str, io_read_encoding(fptr));
     return str;
 }
@@ -2655,7 +2654,6 @@ io_shift_cbuf(rb_io_t *fptr, int len, VALUE *strp)
 	else {
 	    rb_str_cat(str, fptr->cbuf.ptr+fptr->cbuf.off, len);
 	}
-	OBJ_TAINT(str);
 	rb_enc_associate(str, fptr->encs.enc);
     }
     fptr->cbuf.off += len;
@@ -2820,7 +2818,6 @@ io_getpartial(int argc, VALUE *argv, VALUE io, int no_exception, int nonblock)
     }
 
     shrinkable = io_setstrbuf(&str, len);
-    OBJ_TAINT(str);
 
     GetOpenFile(io, fptr);
     rb_io_check_byte_readable(fptr);
@@ -2963,7 +2960,6 @@ io_read_nonblock(rb_execution_context_t *ec, VALUE io, VALUE length, VALUE str, 
     }
 
     shrinkable = io_setstrbuf(&str, len);
-    OBJ_TAINT(str);
     rb_bool_expected(ex, "exception");
 
     GetOpenFile(io, fptr);
@@ -3150,7 +3146,6 @@ io_read(int argc, VALUE *argv, VALUE io)
     }
 #endif
     if (n == 0) return Qnil;
-    OBJ_TAINT(str);
 
     return str;
 }
@@ -5185,7 +5180,6 @@ rb_io_sysread(int argc, VALUE *argv, VALUE io)
     if (n == 0 && ilen > 0) {
 	rb_eof_error();
     }
-    OBJ_TAINT(str);
 
     return str;
 }
@@ -5269,7 +5263,6 @@ rb_io_pread(int argc, VALUE *argv, VALUE io)
     if (n == 0 && arg.count > 0) {
 	rb_eof_error();
     }
-    OBJ_TAINT(str);
 
     return str;
 }
@@ -7088,7 +7081,6 @@ check_pipe_command(VALUE filename_or_command)
 
     if (rb_enc_ascget(s, e, &chlen, rb_enc_get(filename_or_command)) == '|') {
         VALUE cmd = rb_str_new(s+chlen, l-chlen);
-        OBJ_INFECT(cmd, filename_or_command);
         return cmd;
     }
     return Qnil;

--- a/iseq.c
+++ b/iseq.c
@@ -1175,8 +1175,6 @@ iseqw_s_compile(int argc, VALUE *argv, VALUE self)
     VALUE src, file = Qnil, path = Qnil, line = INT2FIX(1), opt = Qnil;
     int i;
 
-    rb_secure(1);
-
     i = rb_scan_args(argc, argv, "1*:", &src, NULL, &opt);
     if (i > 4+NIL_P(opt)) rb_error_arity(argc, 1, 5);
     switch (i) {
@@ -1225,7 +1223,6 @@ iseqw_s_compile_file(int argc, VALUE *argv, VALUE self)
     rb_compile_option_t option;
     int i;
 
-    rb_secure(1);
     i = rb_scan_args(argc, argv, "1*:", &file, NULL, &opt);
     if (i > 1+NIL_P(opt)) rb_error_arity(argc, 1, 2);
     switch (i) {
@@ -1292,7 +1289,6 @@ static VALUE
 iseqw_s_compile_option_set(VALUE self, VALUE opt)
 {
     rb_compile_option_t option;
-    rb_secure(1);
     make_compile_option(&option, opt);
     COMPILE_OPTION_DEFAULT = option;
     return opt;
@@ -1344,7 +1340,6 @@ rb_iseqw_to_iseq(VALUE iseqw)
 static VALUE
 iseqw_eval(VALUE self)
 {
-    rb_secure(1);
     return rb_iseq_eval(iseqw_check(self));
 }
 
@@ -1579,7 +1574,6 @@ static VALUE
 iseqw_to_a(VALUE self)
 {
     const rb_iseq_t *iseq = iseqw_check(self);
-    rb_secure(1);
     return iseq_data_to_ary(iseq);
 }
 
@@ -2134,8 +2128,6 @@ rb_iseq_disasm_recursive(const rb_iseq_t *iseq, VALUE indent)
     const char *indent_str;
     long indent_len;
 
-    rb_secure(1);
-
     size = body->iseq_size;
 
     indent_len = RSTRING_LEN(indent);
@@ -2437,8 +2429,6 @@ static VALUE
 iseqw_s_of(VALUE klass, VALUE body)
 {
     const rb_iseq_t *iseq = NULL;
-
-    rb_secure(1);
 
     if (rb_obj_is_proc(body)) {
         iseq = vm_proc_iseq(body);

--- a/lib/cgi/core.rb
+++ b/lib/cgi/core.rb
@@ -544,11 +544,11 @@ class CGI
         /Content-Disposition:.* filename=(?:"(.*?)"|([^;\r\n]*))/i.match(head)
         filename = $1 || $2 || ''.dup
         filename = CGI.unescape(filename) if unescape_filename?()
-        body.instance_variable_set(:@original_filename, filename.taint)
+        body.instance_variable_set(:@original_filename, filename)
         ## content type
         /Content-Type: (.*)/i.match(head)
         (content_type = $1 || ''.dup).chomp!
-        body.instance_variable_set(:@content_type, content_type.taint)
+        body.instance_variable_set(:@content_type, content_type)
         ## query parameter name
         /Content-Disposition:.* name=(?:"(.*?)"|([^;\r\n]*))/i.match(head)
         name = $1 || $2 || ''

--- a/lib/cgi/session/pstore.rb
+++ b/lib/cgi/session/pstore.rb
@@ -50,7 +50,6 @@ class CGI
         require 'digest/md5'
         md5 = Digest::MD5.hexdigest(id)[0,16]
         path = dir+"/"+prefix+md5
-        path.untaint
         if File::exist?(path)
           @hash = nil
         else

--- a/lib/debug.rb
+++ b/lib/debug.rb
@@ -5,11 +5,6 @@
 
 require 'continuation'
 
-if $SAFE > 0
-  STDERR.print "-r debug.rb is not available in safe mode\n"
-  exit 1
-end
-
 require 'tracer'
 require 'pp'
 

--- a/lib/delegate.rb
+++ b/lib/delegate.rb
@@ -220,35 +220,12 @@ class Delegator < BasicObject
   private :initialize_clone, :initialize_dup
 
   ##
-  # :method: trust
-  # Trust both the object returned by \_\_getobj\_\_ and self.
-  #
-
-  ##
-  # :method: untrust
-  # Untrust both the object returned by \_\_getobj\_\_ and self.
-  #
-
-  ##
-  # :method: taint
-  # Taint both the object returned by \_\_getobj\_\_ and self.
-  #
-
-  ##
-  # :method: untaint
-  # Untaint both the object returned by \_\_getobj\_\_ and self.
-  #
-
-  ##
   # :method: freeze
   # Freeze both the object returned by \_\_getobj\_\_ and self.
   #
-
-  [:trust, :untrust, :taint, :untaint, :freeze].each do |method|
-    define_method method do
-      __getobj__.send(method)
-      super()
-    end
+  def freeze
+    __getobj__.freeze
+    super()
   end
 
   @delegator_api = self.public_instance_methods

--- a/lib/drb/ssl.rb
+++ b/lib/drb/ssl.rb
@@ -248,8 +248,6 @@ module DRb
     # configuration.  Either a Hash or DRb::DRbSSLSocket::SSLConfig
     def self.open(uri, config)
       host, port, = parse_uri(uri)
-      host.untaint
-      port.untaint
       soc = TCPSocket.open(host, port)
       ssl_conf = SSLConfig::new(config)
       ssl_conf.setup_ssl_context

--- a/lib/drb/unix.rb
+++ b/lib/drb/unix.rb
@@ -27,7 +27,6 @@ module DRb
 
     def self.open(uri, config)
       filename, = parse_uri(uri)
-      filename.untaint
       soc = UNIXSocket.open(filename)
       self.new(uri, soc, config)
     end

--- a/lib/erb.rb
+++ b/lib/erb.rb
@@ -57,7 +57,6 @@ require "cgi/util"
 #
 # There are several settings you can change when you use ERB:
 # * the nature of the tags that are recognized;
-# * the value of <tt>$SAFE</tt> under which the template is run;
 # * the binding used to resolve local variables in the template.
 #
 # See the ERB.new and ERB#result methods for more detail.
@@ -747,9 +746,7 @@ class ERB
   # Constructs a new ERB object with the template specified in _str_.
   #
   # An ERB object works by building a chunk of Ruby code that will output
-  # the completed template when run. If _safe_level_ is set to a non-nil value,
-  # ERB code will be run in a separate thread with <b>$SAFE</b> set to the
-  # provided level.
+  # the completed template when run.
   #
   # If _trim_mode_ is passed a String containing one or more of the following
   # modifiers, ERB will adjust its code generation as listed:
@@ -813,8 +810,6 @@ class ERB
     # Complex initializer for $SAFE deprecation at [Feature #14256]. Use keyword arguments to pass trim_mode or eoutvar.
     if safe_level != NOT_GIVEN
       warn 'Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.', uplevel: 1 if $VERBOSE || !ZERO_SAFE_LEVELS.include?(safe_level)
-    else
-      safe_level = nil
     end
     if legacy_trim_mode != NOT_GIVEN
       warn 'Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.', uplevel: 1 if $VERBOSE
@@ -825,7 +820,6 @@ class ERB
       eoutvar = legacy_eoutvar
     end
 
-    @safe_level = safe_level
     compiler = make_compiler(trim_mode)
     set_eoutvar(compiler, eoutvar)
     @src, @encoding, @frozen_string = *compiler.compile(str)
@@ -908,17 +902,7 @@ class ERB
     unless @_init.equal?(self.class.singleton_class)
       raise ArgumentError, "not initialized"
     end
-    if @safe_level
-      proc do
-        prev_safe_level = $SAFE
-        $SAFE = @safe_level
-        eval(@src, b, (@filename || '(erb)'), @lineno)
-      ensure
-        $SAFE = prev_safe_level
-      end.call
-    else
-      eval(@src, b, (@filename || '(erb)'), @lineno)
-    end
+    eval(@src, b, (@filename || '(erb)'), @lineno)
   end
 
   # Render a template on a new toplevel binding with local variables specified

--- a/lib/find.rb
+++ b/lib/find.rb
@@ -46,7 +46,7 @@ module Find
       ps = [path]
       while file = ps.shift
         catch(:prune) do
-          yield file.dup.taint
+          yield file.dup
           begin
             s = File.lstat(file)
           rescue Errno::ENOENT, Errno::EACCES, Errno::ENOTDIR, Errno::ELOOP, Errno::ENAMETOOLONG
@@ -63,7 +63,7 @@ module Find
             fs.sort!
             fs.reverse_each {|f|
               f = File.join(file, f)
-              ps.unshift f.untaint
+              ps.unshift f
             }
           end
         end

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -3238,7 +3238,7 @@ module Net
             if atom
               atom
             else
-              symbol = flag.capitalize.untaint.intern
+              symbol = flag.capitalize.intern
               @flag_symbols[symbol] = true
               if @flag_symbols.length > IMAP.max_flag_count
                 raise FlagCountError, "number of flag symbols exceeded"

--- a/lib/net/smtp.rb
+++ b/lib/net/smtp.rb
@@ -831,9 +831,6 @@ module Net
     end
 
     def mailfrom(from_addr)
-      if $SAFE > 0
-        raise SecurityError, 'tainted from_addr' if from_addr.tainted?
-      end
       getok("MAIL FROM:<#{from_addr}>")
     end
 
@@ -859,9 +856,6 @@ module Net
     end
 
     def rcptto(to_addr)
-      if $SAFE > 0
-        raise SecurityError, 'tainted to_addr' if to_addr.tainted?
-      end
       getok("RCPT TO:<#{to_addr}>")
     end
 

--- a/lib/pp.rb
+++ b/lib/pp.rb
@@ -106,17 +106,17 @@ class PP < PrettyPrint
     # and preserves the previous set of objects being printed.
     def guard_inspect_key
       if Thread.current[:__recursive_key__] == nil
-        Thread.current[:__recursive_key__] = {}.compare_by_identity.taint
+        Thread.current[:__recursive_key__] = {}.compare_by_identity
       end
 
       if Thread.current[:__recursive_key__][:inspect] == nil
-        Thread.current[:__recursive_key__][:inspect] = {}.compare_by_identity.taint
+        Thread.current[:__recursive_key__][:inspect] = {}.compare_by_identity
       end
 
       save = Thread.current[:__recursive_key__][:inspect]
 
       begin
-        Thread.current[:__recursive_key__][:inspect] = {}.compare_by_identity.taint
+        Thread.current[:__recursive_key__][:inspect] = {}.compare_by_identity
         yield
       ensure
         Thread.current[:__recursive_key__][:inspect] = save

--- a/lib/resolv.rb
+++ b/lib/resolv.rb
@@ -194,15 +194,12 @@ class Resolv
               line.sub!(/#.*/, '')
               addr, hostname, *aliases = line.split(/\s+/)
               next unless addr
-              addr.untaint
-              hostname.untaint
               @addr2name[addr] = [] unless @addr2name.include? addr
               @addr2name[addr] << hostname
               @addr2name[addr] += aliases
               @name2addr[hostname] = [] unless @name2addr.include? hostname
               @name2addr[hostname] << addr
               aliases.each {|n|
-                n.untaint
                 @name2addr[n] = [] unless @name2addr.include? n
                 @name2addr[n] << addr
               }
@@ -964,7 +961,6 @@ class Resolv
           f.each {|line|
             line.sub!(/[#;].*/, '')
             keyword, *args = line.split(/\s+/)
-            args.each(&:untaint)
             next unless keyword
             case keyword
             when 'nameserver'

--- a/lib/rexml/source.rb
+++ b/lib/rexml/source.rb
@@ -200,7 +200,7 @@ module REXML
         end
         rv = super
       end
-      rv.taint
+      rv.taint if RUBY_VERSION < '2.7'
       rv
     end
 
@@ -228,7 +228,7 @@ module REXML
           @source = nil
         end
       end
-      rv.taint
+      rv.taint if RUBY_VERSION < '2.7'
       rv
     end
 

--- a/lib/rss/parser.rb
+++ b/lib/rss/parser.rb
@@ -120,7 +120,7 @@ module RSS
 
       if uri.respond_to?(:read)
         uri.read
-      elsif !rss.tainted? and File.readable?(rss)
+      elsif (RUBY_VERSION >= '2.7' || !rss.tainted?) and File.readable?(rss)
         File.open(rss) {|f| f.read}
       else
         rss

--- a/lib/set.rb
+++ b/lib/set.rb
@@ -147,16 +147,6 @@ class Set
     super
   end
 
-  def taint     # :nodoc:
-    @hash.taint
-    super
-  end
-
-  def untaint   # :nodoc:
-    @hash.untaint
-    super
-  end
-
   # Returns the number of elements.
   def size
     @hash.size

--- a/lib/singleton.rb
+++ b/lib/singleton.rb
@@ -58,10 +58,9 @@
 # == Singleton and Marshal
 #
 # By default Singleton's #_dump(depth) returns the empty string. Marshalling by
-# default will strip state information, e.g. instance variables and taint
-# state, from the instance. Classes using Singleton can provide custom
-# _load(str) and _dump(depth) methods to retain some of the previous state of
-# the instance.
+# default will strip state information, e.g. instance variables from the instance.
+# Classes using Singleton can provide custom _load(str) and _dump(depth) methods
+# to retain some of the previous state of the instance.
 #
 #    require 'singleton'
 #
@@ -82,7 +81,6 @@
 #    a = Example.instance
 #    a.keep = "keep this"
 #    a.strip = "get rid of this"
-#    a.taint
 #
 #    stored_state = Marshal.dump(a)
 #

--- a/lib/tempfile.rb
+++ b/lib/tempfile.rb
@@ -98,10 +98,6 @@ class Tempfile < DelegateClass(File)
   #
   # The temporary file will be placed in the directory as specified
   # by the +tmpdir+ parameter. By default, this is +Dir.tmpdir+.
-  # When $SAFE > 0 and the given +tmpdir+ is tainted, it uses
-  # '/tmp' as the temporary directory. Please note that ENV values
-  # are tainted by default, and +Dir.tmpdir+'s return value might
-  # come from environment variables (e.g. <tt>$TMPDIR</tt>).
   #
   #   file = Tempfile.new('hello', '/home/aisaka')
   #   file.path  # => something like: "/home/aisaka/hello2843-8392-92849382--0"

--- a/lib/tmpdir.rb
+++ b/lib/tmpdir.rb
@@ -19,22 +19,18 @@ class Dir
   # Returns the operating system's temporary file path.
 
   def self.tmpdir
-    if $SAFE > 0
-      @@systmpdir.dup
-    else
-      tmp = nil
-      [ENV['TMPDIR'], ENV['TMP'], ENV['TEMP'], @@systmpdir, '/tmp', '.'].each do |dir|
-        next if !dir
-        dir = File.expand_path(dir)
-        if stat = File.stat(dir) and stat.directory? and stat.writable? and
-            (!stat.world_writable? or stat.sticky?)
-          tmp = dir
-          break
-        end rescue nil
-      end
-      raise ArgumentError, "could not find a temporary directory" unless tmp
-      tmp
+    tmp = nil
+    [ENV['TMPDIR'], ENV['TMP'], ENV['TEMP'], @@systmpdir, '/tmp', '.'].each do |dir|
+      next if !dir
+      dir = File.expand_path(dir)
+      if stat = File.stat(dir) and stat.directory? and stat.writable? and
+          (!stat.world_writable? or stat.sticky?)
+        tmp = dir
+        break
+      end rescue nil
     end
+    raise ArgumentError, "could not find a temporary directory" unless tmp
+    tmp
   end
 
   # Dir.mktmpdir creates a temporary directory.
@@ -115,12 +111,8 @@ class Dir
     UNUSABLE_CHARS = [File::SEPARATOR, File::ALT_SEPARATOR, File::PATH_SEPARATOR, ":"].uniq.join("").freeze
 
     def create(basename, tmpdir=nil, max_try: nil, **opts)
-      if $SAFE > 0 and tmpdir.tainted?
-        tmpdir = '/tmp'
-      else
-        origdir = tmpdir
-        tmpdir ||= tmpdir()
-      end
+      origdir = tmpdir
+      tmpdir ||= tmpdir()
       n = nil
       prefix, suffix = basename
       prefix = (String.try_convert(prefix) or

--- a/node.h
+++ b/node.h
@@ -175,7 +175,7 @@ typedef struct RNode {
 
 #define RNODE(obj)  (R_CAST(RNode)(obj))
 
-/* FL     : 0..4: T_TYPES, 5: KEEP_WB, 6: PROMOTED, 7: FINALIZE, 8: TAINT, 9: UNTRUSTED, 10: EXIVAR, 11: FREEZE */
+/* FL     : 0..4: T_TYPES, 5: KEEP_WB, 6: PROMOTED, 7: FINALIZE, 8: UNUSED, 9: UNUSED, 10: EXIVAR, 11: FREEZE */
 /* NODE_FL: 0..4: T_TYPES, 5: KEEP_WB, 6: PROMOTED, 7: NODE_FL_NEWLINE,
  *          8..14: nd_type,
  *          15..: nd_line

--- a/object.c
+++ b/object.c
@@ -346,7 +346,7 @@ init_copy(VALUE dest, VALUE obj)
         rb_raise(rb_eTypeError, "[bug] frozen object (%s) allocated", rb_obj_classname(dest));
     }
     RBASIC(dest)->flags &= ~(T_MASK|FL_EXIVAR);
-    RBASIC(dest)->flags |= RBASIC(obj)->flags & (T_MASK|FL_EXIVAR|FL_TAINT);
+    RBASIC(dest)->flags |= RBASIC(obj)->flags & (T_MASK|FL_EXIVAR);
     rb_copy_wb_protected_attribute(dest, obj);
     rb_copy_generic_ivar(dest, obj);
     rb_gc_copy_finalizer(dest, obj);
@@ -383,7 +383,7 @@ special_object_p(VALUE obj)
  *  Produces a shallow copy of <i>obj</i>---the instance variables of
  *  <i>obj</i> are copied, but not the objects they reference.
  *  #clone copies the frozen (unless +:freeze+ keyword argument is
- *  given with a false value) and tainted state of <i>obj</i>.  See
+ *  given with a false value) state of <i>obj</i>.  See
  *  also the discussion under Object#dup.
  *
  *     class Klass
@@ -491,7 +491,6 @@ rb_obj_clone(VALUE obj)
  *
  *  Produces a shallow copy of <i>obj</i>---the instance variables of
  *  <i>obj</i> are copied, but not the objects they reference.
- *  #dup copies the tainted state of <i>obj</i>.
  *
  *  This method may have class-specific behavior.  If so, that
  *  behavior will be documented under the #+initialize_copy+ method of
@@ -616,7 +615,6 @@ rb_obj_init_copy(VALUE obj, VALUE orig)
 {
     if (obj == orig) return obj;
     rb_check_frozen(obj);
-    rb_check_trusted(obj);
     if (TYPE(obj) != TYPE(orig) || rb_obj_class(obj) != rb_obj_class(orig)) {
 	rb_raise(rb_eTypeError, "initialize_copy should take same class object");
     }
@@ -659,7 +657,6 @@ rb_any_to_s(VALUE obj)
     VALUE cname = rb_class_name(CLASS_OF(obj));
 
     str = rb_sprintf("#<%"PRIsVALUE":%p>", cname, (void*)obj);
-    OBJ_INFECT(str, obj);
 
     return str;
 }
@@ -728,7 +725,6 @@ inspect_obj(VALUE obj, VALUE str, int recur)
     }
     rb_str_cat2(str, ">");
     RSTRING_PTR(str)[0] = '#';
-    OBJ_INFECT(str, obj);
 
     return str;
 }
@@ -1164,26 +1160,15 @@ rb_obj_dummy1(VALUE _x, VALUE _y)
 
 /**
  *  call-seq:
- *     obj.tainted?    -> true or false
+ *     obj.tainted?    -> false
  *
- *  Returns true if the object is tainted.
- *
- *  See #taint for more information.
- *--
- * Determines if \a obj is tainted. Equivalent to \c Object\#tainted? in Ruby.
- * \param[in] obj  the object to be determined
- * \retval Qtrue if the object is tainted
- * \retval Qfalse if the object is not tainted
- * \sa rb_obj_taint
- * \sa rb_obj_untaint
- *++
+ *  Returns false.  This method is deprecated and will be removed in Ruby 3.2.
  */
 
 VALUE
 rb_obj_tainted(VALUE obj)
 {
-    if (OBJ_TAINTED(obj))
-	return Qtrue;
+    rb_warning("Object#tainted? is deprecated and will be removed in Ruby 3.2.");
     return Qfalse;
 }
 
@@ -1191,33 +1176,13 @@ rb_obj_tainted(VALUE obj)
  *  call-seq:
  *     obj.taint -> obj
  *
- *  Mark the object as tainted.
- *
- *  Objects that are marked as tainted will be restricted from various built-in
- *  methods. This is to prevent insecure data, such as command-line arguments
- *  or strings read from Kernel#gets, from inadvertently compromising the user's
- *  system.
- *
- *  To check whether an object is tainted, use #tainted?.
- *
- *  You should only untaint a tainted object if your code has inspected it and
- *  determined that it is safe. To do so use #untaint.
- *--
- * Marks the object as tainted. Equivalent to \c Object\#taint in Ruby
- * \param[in] obj  the object to be tainted
- * \return the object itself
- * \sa rb_obj_untaint
- * \sa rb_obj_tainted
- *++
+ *  Returns object. This method is deprecated and will be removed in Ruby 3.2.
  */
 
 VALUE
 rb_obj_taint(VALUE obj)
 {
-    if (!OBJ_TAINTED(obj) && OBJ_TAINTABLE(obj)) {
-	rb_check_frozen(obj);
-	OBJ_TAINT(obj);
-    }
+    rb_warning("Object#taint is deprecated and will be removed in Ruby 3.2.");
     return obj;
 }
 
@@ -1226,74 +1191,42 @@ rb_obj_taint(VALUE obj)
  *  call-seq:
  *     obj.untaint    -> obj
  *
- *  Removes the tainted mark from the object.
- *
- *  See #taint for more information.
- *--
- * Removes the tainted mark from the object.
- * Equivalent to \c Object\#untaint in Ruby.
- *
- * \param[in] obj  the object to be tainted
- * \return the object itself
- * \sa rb_obj_taint
- * \sa rb_obj_tainted
- *++
+ *  Returns object. This method is deprecated and will be removed in Ruby 3.2.
  */
 
 VALUE
 rb_obj_untaint(VALUE obj)
 {
-    if (OBJ_TAINTED(obj)) {
-	rb_check_frozen(obj);
-	FL_UNSET(obj, FL_TAINT);
-    }
+    rb_warning("Object#untaint is deprecated and will be removed in Ruby 3.2.");
     return obj;
 }
 
 /**
  *  call-seq:
- *     obj.untrusted?    -> true or false
+ *     obj.untrusted?    -> false
  *
- *  Deprecated method that is equivalent to #tainted?.
- *--
- * \deprecated Use rb_obj_tainted.
- *
- * Trustiness used to have independent semantics from taintedness.
- * But now trustiness of objects is obsolete and this function behaves
- * the same as rb_obj_tainted.
- *
- * \sa rb_obj_tainted
- *++
+ *  Returns false.  This method is deprecated and will be removed in Ruby 3.2.
  */
 
 VALUE
 rb_obj_untrusted(VALUE obj)
 {
-    rb_warning("untrusted? is deprecated and its behavior is same as tainted?");
-    return rb_obj_tainted(obj);
+    rb_warning("Object#untrusted? is deprecated and will be removed in Ruby 3.2.");
+    return Qfalse;
 }
 
 /**
  *  call-seq:
  *     obj.untrust -> obj
  *
- *  Deprecated method that is equivalent to #taint.
- *--
- * \deprecated Use rb_obj_taint(obj)
- *
- * Trustiness used to have independent semantics from taintedness.
- * But now trustiness of objects is obsolete and this function behaves
- * the same as rb_obj_taint.
- *
- * \sa rb_obj_taint
- *++
+ *  Returns object. This method is deprecated and will be removed in Ruby 3.2.
  */
 
 VALUE
 rb_obj_untrust(VALUE obj)
 {
-    rb_warning("untrust is deprecated and its behavior is same as taint");
-    return rb_obj_taint(obj);
+    rb_warning("Object#untrust is deprecated and will be removed in Ruby 3.2.");
+    return obj;
 }
 
 
@@ -1301,37 +1234,24 @@ rb_obj_untrust(VALUE obj)
  *  call-seq:
  *     obj.trust    -> obj
  *
- *  Deprecated method that is equivalent to #untaint.
- *--
- * \deprecated Use rb_obj_untaint(obj)
- *
- * Trustiness used to have independent semantics from taintedness.
- * But now trustiness of objects is obsolete and this function behaves
- * the same as rb_obj_untaint.
- *
- * \sa rb_obj_untaint
- *++
+ *  Returns object. This method is deprecated and will be removed in Ruby 3.2.
  */
 
 VALUE
 rb_obj_trust(VALUE obj)
 {
-    rb_warning("trust is deprecated and its behavior is same as untaint");
-    return rb_obj_untaint(obj);
+    rb_warning("Object#trust is deprecated and will be removed in Ruby 3.2.");
+    return obj;
 }
 
 /**
- * Convenient function to infect \a victim with the taintedness of \a carrier.
- *
- * It just keeps the taintedness of \a victim if \a carrier is not tainted.
- * \param[in,out] victim the object being infected with the taintness of \a carrier
- * \param[in] carrier a possibly tainted object
+ * Does nothing. This method is deprecated and will be removed in Ruby 3.2.
  */
 
 void
 rb_obj_infect(VALUE victim, VALUE carrier)
 {
-    OBJ_INFECT(victim, carrier);
+    rb_warning("rb_obj_infect is deprecated and will be removed in Ruby 3.2.");
 }
 
 /**

--- a/parse.y
+++ b/parse.y
@@ -5902,7 +5902,7 @@ yycompile0(VALUE arg)
     struct parser_params *p = (struct parser_params *)arg;
     VALUE cov = Qfalse;
 
-    if (!compile_for_eval && rb_safe_level() == 0 && !NIL_P(p->ruby_sourcefile_string)) {
+    if (!compile_for_eval && !NIL_P(p->ruby_sourcefile_string)) {
 	p->debug_lines = debug_lines(p->ruby_sourcefile_string);
 	if (p->debug_lines && p->ruby_sourceline > 0) {
 	    VALUE str = STR_NEW0();

--- a/proc.c
+++ b/proc.c
@@ -1377,7 +1377,6 @@ rb_block_to_s(VALUE self, const struct rb_block *block, const char *additional_i
 
     if (additional_info) rb_str_cat_cstr(str, additional_info);
     rb_str_cat_cstr(str, ">");
-    OBJ_INFECT_RAW(str, self);
     return str;
 }
 
@@ -1490,8 +1489,6 @@ mnew_missing(VALUE klass, VALUE obj, ID id, VALUE mclass)
 
     RB_OBJ_WRITE(method, &data->me, me);
 
-    OBJ_INFECT(method, klass);
-
     return method;
 }
 
@@ -1548,7 +1545,6 @@ mnew_internal(const rb_method_entry_t *me, VALUE klass, VALUE iclass,
     RB_OBJ_WRITE(method, &data->iclass, iclass);
     RB_OBJ_WRITE(method, &data->me, me);
 
-    OBJ_INFECT(method, klass);
     return method;
 }
 
@@ -1691,7 +1687,6 @@ method_unbind(VALUE obj)
     RB_OBJ_WRITE(method, &data->recv, Qundef);
     RB_OBJ_WRITE(method, &data->klass, orig->klass);
     RB_OBJ_WRITE(method, &data->me, rb_method_entry_clone(orig->me));
-    OBJ_INFECT(method, obj);
 
     return method;
 }
@@ -2775,7 +2770,6 @@ method_inspect(VALUE method)
 
     TypedData_Get_Struct(method, struct METHOD, &method_data_type, data);
     str = rb_sprintf("#<% "PRIsVALUE": ", rb_obj_class(method));
-    OBJ_INFECT_RAW(str, method);
 
     mklass = data->klass;
 

--- a/process.c
+++ b/process.c
@@ -1574,16 +1574,6 @@ after_fork_ruby(void)
 
 #include "dln.h"
 
-static void
-security(const char *str)
-{
-    if (rb_env_path_tainted()) {
-	if (rb_safe_level() > 0) {
-	    rb_raise(rb_eSecurityError, "Insecure PATH - %s", str);
-	}
-    }
-}
-
 #if defined(HAVE_WORKING_FORK)
 
 /* try_with_sh and exec_with_sh should be async-signal-safe. Actually it is.*/
@@ -1759,7 +1749,6 @@ proc_spawn_cmd_internal(char **argv, char *prog)
 
     if (!prog)
 	prog = argv[0];
-    security(prog);
     prog = dln_find_exe_r(prog, 0, fbuf, sizeof(fbuf));
     if (!prog)
 	return -1;
@@ -2371,7 +2360,6 @@ rb_check_argv(int argc, VALUE *argv)
 	argv[i] = rb_str_new_frozen(argv[i]);
 	StringValueCStr(argv[i]);
     }
-    security(name ? name : RSTRING_PTR(argv[0]));
     return prog;
 }
 

--- a/range.c
+++ b/range.c
@@ -1325,7 +1325,6 @@ range_to_s(VALUE range)
     str = rb_str_dup(str);
     rb_str_cat(str, "...", EXCL(range) ? 3 : 2);
     rb_str_append(str, str2);
-    OBJ_INFECT(str, range);
 
     return str;
 }
@@ -1349,7 +1348,6 @@ inspect_range(VALUE range, VALUE dummy, int recur)
         str2 = rb_inspect(RANGE_END(range));
     }
     if (str2 != Qundef) rb_str_append(str, str2);
-    OBJ_INFECT(str, range);
 
     return str;
 }

--- a/rational.c
+++ b/rational.c
@@ -1853,7 +1853,6 @@ nurat_marshal_load(VALUE self, VALUE a)
     VALUE num, den;
 
     rb_check_frozen(self);
-    rb_check_trusted(self);
 
     Check_Type(a, T_ARRAY);
     if (RARRAY_LEN(a) != 2)

--- a/re.c
+++ b/re.c
@@ -462,7 +462,6 @@ rb_reg_desc(const char *s, long len, VALUE re)
 	if (RBASIC(re)->flags & REG_ENCODING_NONE)
 	    rb_str_buf_cat2(str, "n");
     }
-    OBJ_INFECT(str, re);
     return str;
 }
 
@@ -488,7 +487,6 @@ rb_reg_source(VALUE re)
 
     rb_reg_check(re);
     str = rb_str_dup(RREGEXP_SRC(re));
-    if (OBJ_TAINTED(re)) OBJ_TAINT(str);
     return str;
 }
 
@@ -647,7 +645,6 @@ rb_reg_str_with_term(VALUE re, int term)
     }
     rb_enc_copy(str, re);
 
-    OBJ_INFECT(str, re);
     return str;
 }
 
@@ -1337,7 +1334,6 @@ match_set_string(VALUE m, VALUE string, long pos, long len)
     if (err) rb_memerror();
     rmatch->regs.beg[0] = pos;
     rmatch->regs.end[0] = pos + len;
-    OBJ_INFECT(match, string);
 }
 
 void
@@ -1601,19 +1597,13 @@ rb_reg_search0(VALUE re, VALUE str, long pos, int reverse, int set_backref_str)
 	onig_region_free(regs, 0);
 	if (err) rb_memerror();
     }
-    else {
-	FL_UNSET(match, FL_TAINT);
-    }
 
     if (set_backref_str) {
 	RMATCH(match)->str = rb_str_new4(str);
-	OBJ_INFECT(match, str);
     }
 
     RMATCH(match)->regexp = re;
     rb_backref_set(match);
-
-    OBJ_INFECT(match, re);
 
     return result;
 }
@@ -1685,17 +1675,11 @@ rb_reg_start_with_p(VALUE re, VALUE str)
 	onig_region_free(regs, 0);
 	if (err) rb_memerror();
     }
-    else {
-	FL_UNSET(match, FL_TAINT);
-    }
 
     RMATCH(match)->str = rb_str_new4(str);
-    OBJ_INFECT(match, str);
 
     RMATCH(match)->regexp = re;
     rb_backref_set(match);
-
-    OBJ_INFECT(match, re);
 
     return true;
 }
@@ -1740,7 +1724,6 @@ rb_reg_nth_match(int nth, VALUE match)
     end = END(nth);
     len = end - start;
     str = rb_str_subseq(RMATCH(match)->str, start, len);
-    OBJ_INFECT(str, match);
     return str;
 }
 
@@ -1773,7 +1756,6 @@ rb_reg_match_pre(VALUE match)
     regs = RMATCH_REGS(match);
     if (BEG(0) == -1) return Qnil;
     str = rb_str_subseq(RMATCH(match)->str, 0, BEG(0));
-    if (OBJ_TAINTED(match)) OBJ_TAINT(str);
     return str;
 }
 
@@ -1803,7 +1785,6 @@ rb_reg_match_post(VALUE match)
     str = RMATCH(match)->str;
     pos = END(0);
     str = rb_str_subseq(str, pos, RSTRING_LEN(str) - pos);
-    if (OBJ_TAINTED(match)) OBJ_TAINT(str);
     return str;
 }
 
@@ -1855,7 +1836,6 @@ match_array(VALUE match, int start)
     VALUE ary;
     VALUE target;
     int i;
-    int taint = OBJ_TAINTED(match);
 
     match_check(match);
     regs = RMATCH_REGS(match);
@@ -1868,7 +1848,6 @@ match_array(VALUE match, int start)
 	}
 	else {
 	    VALUE str = rb_str_subseq(target, regs->beg[i], regs->end[i]-regs->beg[i]);
-	    if (taint) OBJ_TAINT(str);
 	    rb_ary_push(ary, str);
 	}
     }
@@ -2129,8 +2108,6 @@ match_to_s(VALUE match)
 
     match_check(match);
     if (NIL_P(str)) str = rb_str_new(0,0);
-    if (OBJ_TAINTED(match)) OBJ_TAINT(str);
-    if (OBJ_TAINTED(RMATCH(match)->str)) OBJ_TAINT(str);
     return str;
 }
 
@@ -2891,7 +2868,6 @@ rb_reg_initialize_str(VALUE obj, VALUE str, int options, onig_errmsg_buffer err,
     }
     ret = rb_reg_initialize(obj, RSTRING_PTR(str), RSTRING_LEN(str), enc,
 			    options, err, sourcefile, sourceline);
-    OBJ_INFECT(obj, str);
     if (ret == 0) reg_set_source(obj, str, str_enc);
     return ret;
 }
@@ -3580,7 +3556,6 @@ rb_reg_quote(VALUE str)
         t += rb_enc_mbcput(c, t, enc);
     }
     rb_str_resize(tmp, t - RSTRING_PTR(tmp));
-    OBJ_INFECT(tmp, str);
     return tmp;
 }
 

--- a/ruby.c
+++ b/ruby.c
@@ -2227,7 +2227,6 @@ external_str_new_cstr(const char *p)
 #if UTF8_PATH
     VALUE str = rb_utf8_str_new_cstr(p);
     str = str_conv_enc(str, NULL, rb_default_external_encoding());
-    OBJ_TAINT_RAW(str);
     return str;
 #else
     return rb_external_str_new_cstr(p);

--- a/safe.c
+++ b/safe.c
@@ -9,11 +9,6 @@
 
 **********************************************************************/
 
-/* safe-level:
-   0 - strings from streams/environment/ARGV are tainted (default)
-   1 - no dangerous operation by tainted value
-*/
-
 #define SAFE_LEVEL_MAX RUBY_SAFE_LEVEL_MAX
 
 #include "ruby/ruby.h"
@@ -141,9 +136,6 @@ void
 rb_check_safe_obj(VALUE x)
 {
     rb_warn("rb_check_safe_obj will be removed in Ruby 3.0");
-    if (rb_safe_level() > 0 && OBJ_TAINTED(x)) {
-	rb_insecure_operation();
-    }
 }
 
 void

--- a/safe.c
+++ b/safe.c
@@ -28,18 +28,21 @@
 int
 ruby_safe_level_2_warning(void)
 {
+    rb_warn("rb_safe_level_2_warning will be removed in Ruby 3.0");
     return 2;
 }
 
 int
 rb_safe_level(void)
 {
+    rb_warn("rb_safe_level will be removed in Ruby 3.0");
     return GET_VM()->safe_level_;
 }
 
 void
 rb_set_safe_level_force(int safe)
 {
+    rb_warn("rb_set_safe_level_force will be removed in Ruby 3.0");
     GET_VM()->safe_level_ = safe;
 }
 
@@ -48,6 +51,7 @@ rb_set_safe_level(int level)
 {
     rb_vm_t *vm = GET_VM();
 
+    rb_warn("rb_set_safe_level will be removed in Ruby 3.0");
     if (level > SAFE_LEVEL_MAX) {
 	rb_raise(rb_eArgError, "$SAFE=2 to 4 are obsolete");
     }
@@ -68,28 +72,47 @@ rb_set_safe_level(int level)
 static VALUE
 safe_getter(ID _x, VALUE *_y)
 {
-    return INT2NUM(rb_safe_level());
+    rb_warn("$SAFE will become a normal global variable in Ruby 3.0");
+    return INT2NUM(GET_VM()->safe_level_);
 }
 
 static void
 safe_setter(VALUE val, ID _x, VALUE *_y)
 {
     int level = NUM2INT(val);
-    rb_set_safe_level(level);
+    rb_vm_t *vm = GET_VM();
+
+    rb_warn("$SAFE will become a normal global variable in Ruby 3.0");
+    if (level > SAFE_LEVEL_MAX) {
+        rb_raise(rb_eArgError, "$SAFE=2 to 4 are obsolete");
+    }
+    else if (level < 0) {
+        rb_raise(rb_eArgError, "$SAFE should be >= 0");
+    }
+    else {
+        int line;
+        const char *path = rb_source_location_cstr(&line);
+
+        if (0) fprintf(stderr, "%s:%d $SAFE %d -> %d\n",
+                       path ? path : "-", line, vm->safe_level_, level);
+
+        vm->safe_level_ = level;
+    }
 }
 
 void
 rb_secure(int level)
 {
-    if (level <= rb_safe_level()) {
+    rb_warn("rb_secure will be removed in Ruby 3.0");
+    if (level <= GET_VM()->safe_level_) {
 	ID caller_name = rb_frame_callee();
 	if (caller_name) {
 	    rb_raise(rb_eSecurityError, "Insecure operation `%"PRIsVALUE"' at level %d",
-		     rb_id2str(caller_name), rb_safe_level());
+                     rb_id2str(caller_name), GET_VM()->safe_level_);
 	}
 	else {
 	    rb_raise(rb_eSecurityError, "Insecure operation at level %d",
-		     rb_safe_level());
+                     GET_VM()->safe_level_);
 	}
     }
 }
@@ -97,11 +120,13 @@ rb_secure(int level)
 void
 rb_secure_update(VALUE obj)
 {
+    rb_warn("rb_secure_update will be removed in Ruby 3.0");
 }
 
 void
 rb_insecure_operation(void)
 {
+    rb_warn("rb_insecure_operation will be removed in Ruby 3.0");
     ID caller_name = rb_frame_callee();
     if (caller_name) {
 	rb_raise(rb_eSecurityError, "Insecure operation - %"PRIsVALUE,
@@ -115,6 +140,7 @@ rb_insecure_operation(void)
 void
 rb_check_safe_obj(VALUE x)
 {
+    rb_warn("rb_check_safe_obj will be removed in Ruby 3.0");
     if (rb_safe_level() > 0 && OBJ_TAINTED(x)) {
 	rb_insecure_operation();
     }

--- a/signal.c
+++ b/signal.c
@@ -1195,7 +1195,7 @@ trap_handler(VALUE *cmd, int sig)
 	if (!NIL_P(command)) {
 	    const char *cptr;
 	    long len;
-	    SafeStringValue(command);	/* taint check */
+            StringValue(command);
 	    *cmd = command;
 	    RSTRING_GETMEM(command, cptr, len);
 	    switch (len) {
@@ -1391,10 +1391,6 @@ sig_trap(int argc, VALUE *argv, VALUE _)
     else {
 	cmd = argv[1];
 	func = trap_handler(&cmd, sig);
-    }
-
-    if (OBJ_TAINTED(cmd)) {
-	rb_raise(rb_eSecurityError, "Insecure: tainted signal trap");
     }
 
     return trap(sig, func, cmd);

--- a/signal.c
+++ b/signal.c
@@ -1043,7 +1043,7 @@ signal_exec(VALUE cmd, int sig)
     EC_PUSH_TAG(ec);
     if ((state = EC_EXEC_TAG()) == TAG_NONE) {
 	VALUE signum = INT2NUM(sig);
-        rb_eval_cmd(cmd, rb_ary_new3(1, signum), 0);
+        rb_eval_cmd_kw(cmd, rb_ary_new3(1, signum), RB_NO_KEYWORDS);
     }
     EC_POP_TAG();
     ec = GET_EC();

--- a/spec/ruby/core/array/clear_spec.rb
+++ b/spec/ruby/core/array/clear_spec.rb
@@ -20,24 +20,28 @@ describe "Array#clear" do
     a.size.should == 0
   end
 
-  it "keeps tainted status" do
-    a = [1]
-    a.taint
-    a.tainted?.should be_true
-    a.clear
-    a.tainted?.should be_true
+  ruby_version_is ''...'2.7' do
+    it "keeps tainted status" do
+      a = [1]
+      a.taint
+      a.tainted?.should be_true
+      a.clear
+      a.tainted?.should be_true
+    end
   end
 
   it "does not accept any arguments" do
     -> { [1].clear(true) }.should raise_error(ArgumentError)
   end
 
-  it "keeps untrusted status" do
-    a = [1]
-    a.untrust
-    a.untrusted?.should be_true
-    a.clear
-    a.untrusted?.should be_true
+  ruby_version_is ''...'2.7' do
+    it "keeps untrusted status" do
+      a = [1]
+      a.untrust
+      a.untrusted?.should be_true
+      a.clear
+      a.untrusted?.should be_true
+    end
   end
 
   it "raises a #{frozen_error_class} on a frozen array" do

--- a/spec/ruby/core/array/compact_spec.rb
+++ b/spec/ruby/core/array/compact_spec.rb
@@ -22,16 +22,18 @@ describe "Array#compact" do
     ArraySpecs::MyArray[1, 2, 3, nil].compact.should be_an_instance_of(Array)
   end
 
-  it "does not keep tainted status even if all elements are removed" do
-    a = [nil, nil]
-    a.taint
-    a.compact.tainted?.should be_false
-  end
+  ruby_version_is ''...'2.7' do
+    it "does not keep tainted status even if all elements are removed" do
+      a = [nil, nil]
+      a.taint
+      a.compact.tainted?.should be_false
+    end
 
-  it "does not keep untrusted status even if all elements are removed" do
-    a = [nil, nil]
-    a.untrust
-    a.compact.untrusted?.should be_false
+    it "does not keep untrusted status even if all elements are removed" do
+      a = [nil, nil]
+      a.untrust
+      a.compact.untrusted?.should be_false
+    end
   end
 end
 
@@ -57,18 +59,20 @@ describe "Array#compact!" do
     [1, 2, false, 3].compact!.should == nil
   end
 
-  it "keeps tainted status even if all elements are removed" do
-    a = [nil, nil]
-    a.taint
-    a.compact!
-    a.tainted?.should be_true
-  end
+  ruby_version_is ''...'2.7' do
+    it "keeps tainted status even if all elements are removed" do
+      a = [nil, nil]
+      a.taint
+      a.compact!
+      a.tainted?.should be_true
+    end
 
-  it "keeps untrusted status even if all elements are removed" do
-    a = [nil, nil]
-    a.untrust
-    a.compact!
-    a.untrusted?.should be_true
+    it "keeps untrusted status even if all elements are removed" do
+      a = [nil, nil]
+      a.untrust
+      a.compact!
+      a.untrusted?.should be_true
+    end
   end
 
   it "raises a #{frozen_error_class} on a frozen array" do

--- a/spec/ruby/core/array/concat_spec.rb
+++ b/spec/ruby/core/array/concat_spec.rb
@@ -41,60 +41,62 @@ describe "Array#concat" do
     -> { ArraySpecs.frozen_array.concat([]) }.should raise_error(frozen_error_class)
   end
 
-  it "keeps tainted status" do
-    ary = [1, 2]
-    ary.taint
-    ary.concat([3])
-    ary.tainted?.should be_true
-    ary.concat([])
-    ary.tainted?.should be_true
-  end
+  ruby_version_is ''...'2.7' do
+    it "keeps tainted status" do
+      ary = [1, 2]
+      ary.taint
+      ary.concat([3])
+      ary.tainted?.should be_true
+      ary.concat([])
+      ary.tainted?.should be_true
+    end
 
-  it "is not infected by the other" do
-    ary = [1,2]
-    other = [3]; other.taint
-    ary.tainted?.should be_false
-    ary.concat(other)
-    ary.tainted?.should be_false
-  end
+    it "is not infected by the other" do
+      ary = [1,2]
+      other = [3]; other.taint
+      ary.tainted?.should be_false
+      ary.concat(other)
+      ary.tainted?.should be_false
+    end
 
-  it "keeps the tainted status of elements" do
-    ary = [ Object.new, Object.new, Object.new ]
-    ary.each {|x| x.taint }
+    it "keeps the tainted status of elements" do
+      ary = [ Object.new, Object.new, Object.new ]
+      ary.each {|x| x.taint }
 
-    ary.concat([ Object.new ])
-    ary[0].tainted?.should be_true
-    ary[1].tainted?.should be_true
-    ary[2].tainted?.should be_true
-    ary[3].tainted?.should be_false
-  end
+      ary.concat([ Object.new ])
+      ary[0].tainted?.should be_true
+      ary[1].tainted?.should be_true
+      ary[2].tainted?.should be_true
+      ary[3].tainted?.should be_false
+    end
 
-  it "keeps untrusted status" do
-    ary = [1, 2]
-    ary.untrust
-    ary.concat([3])
-    ary.untrusted?.should be_true
-    ary.concat([])
-    ary.untrusted?.should be_true
-  end
+    it "keeps untrusted status" do
+      ary = [1, 2]
+      ary.untrust
+      ary.concat([3])
+      ary.untrusted?.should be_true
+      ary.concat([])
+      ary.untrusted?.should be_true
+    end
 
-  it "is not infected untrustedness by the other" do
-    ary = [1,2]
-    other = [3]; other.untrust
-    ary.untrusted?.should be_false
-    ary.concat(other)
-    ary.untrusted?.should be_false
-  end
+    it "is not infected untrustedness by the other" do
+      ary = [1,2]
+      other = [3]; other.untrust
+      ary.untrusted?.should be_false
+      ary.concat(other)
+      ary.untrusted?.should be_false
+    end
 
-  it "keeps the untrusted status of elements" do
-    ary = [ Object.new, Object.new, Object.new ]
-    ary.each {|x| x.untrust }
+    it "keeps the untrusted status of elements" do
+      ary = [ Object.new, Object.new, Object.new ]
+      ary.each {|x| x.untrust }
 
-    ary.concat([ Object.new ])
-    ary[0].untrusted?.should be_true
-    ary[1].untrusted?.should be_true
-    ary[2].untrusted?.should be_true
-    ary[3].untrusted?.should be_false
+      ary.concat([ Object.new ])
+      ary[0].untrusted?.should be_true
+      ary[1].untrusted?.should be_true
+      ary[2].untrusted?.should be_true
+      ary[3].untrusted?.should be_false
+    end
   end
 
   it "appends elements to an Array with enough capacity that has been shifted" do

--- a/spec/ruby/core/array/delete_at_spec.rb
+++ b/spec/ruby/core/array/delete_at_spec.rb
@@ -39,23 +39,25 @@ describe "Array#delete_at" do
     -> { [1,2,3].freeze.delete_at(0) }.should raise_error(frozen_error_class)
   end
 
-  it "keeps tainted status" do
-    ary = [1, 2]
-    ary.taint
-    ary.tainted?.should be_true
-    ary.delete_at(0)
-    ary.tainted?.should be_true
-    ary.delete_at(0) # now empty
-    ary.tainted?.should be_true
-  end
+  ruby_version_is ''...'2.7' do
+    it "keeps tainted status" do
+      ary = [1, 2]
+      ary.taint
+      ary.tainted?.should be_true
+      ary.delete_at(0)
+      ary.tainted?.should be_true
+      ary.delete_at(0) # now empty
+      ary.tainted?.should be_true
+    end
 
-  it "keeps untrusted status" do
-    ary = [1, 2]
-    ary.untrust
-    ary.untrusted?.should be_true
-    ary.delete_at(0)
-    ary.untrusted?.should be_true
-    ary.delete_at(0) # now empty
-    ary.untrusted?.should be_true
+    it "keeps untrusted status" do
+      ary = [1, 2]
+      ary.untrust
+      ary.untrusted?.should be_true
+      ary.delete_at(0)
+      ary.untrusted?.should be_true
+      ary.delete_at(0) # now empty
+      ary.untrusted?.should be_true
+    end
   end
 end

--- a/spec/ruby/core/array/delete_if_spec.rb
+++ b/spec/ruby/core/array/delete_if_spec.rb
@@ -47,18 +47,20 @@ describe "Array#delete_if" do
     -> { ArraySpecs.empty_frozen_array.delete_if {} }.should raise_error(frozen_error_class)
   end
 
-  it "keeps tainted status" do
-    @a.taint
-    @a.tainted?.should be_true
-    @a.delete_if{ true }
-    @a.tainted?.should be_true
-  end
+  ruby_version_is ''...'2.7' do
+    it "keeps tainted status" do
+      @a.taint
+      @a.tainted?.should be_true
+      @a.delete_if{ true }
+      @a.tainted?.should be_true
+    end
 
-  it "keeps untrusted status" do
-    @a.untrust
-    @a.untrusted?.should be_true
-    @a.delete_if{ true }
-    @a.untrusted?.should be_true
+    it "keeps untrusted status" do
+      @a.untrust
+      @a.untrusted?.should be_true
+      @a.delete_if{ true }
+      @a.untrusted?.should be_true
+    end
   end
 
   it_behaves_like :enumeratorized_with_origin_size, :delete_if, [1,2,3]

--- a/spec/ruby/core/array/delete_spec.rb
+++ b/spec/ruby/core/array/delete_spec.rb
@@ -44,23 +44,25 @@ describe "Array#delete" do
     -> { [1, 2, 3].freeze.delete(1) }.should raise_error(frozen_error_class)
   end
 
-  it "keeps tainted status" do
-    a = [1, 2]
-    a.taint
-    a.tainted?.should be_true
-    a.delete(2)
-    a.tainted?.should be_true
-    a.delete(1) # now empty
-    a.tainted?.should be_true
-  end
+  ruby_version_is ''...'2.7' do
+    it "keeps tainted status" do
+      a = [1, 2]
+      a.taint
+      a.tainted?.should be_true
+      a.delete(2)
+      a.tainted?.should be_true
+      a.delete(1) # now empty
+      a.tainted?.should be_true
+    end
 
-  it "keeps untrusted status" do
-    a = [1, 2]
-    a.untrust
-    a.untrusted?.should be_true
-    a.delete(2)
-    a.untrusted?.should be_true
-    a.delete(1) # now empty
-    a.untrusted?.should be_true
+    it "keeps untrusted status" do
+      a = [1, 2]
+      a.untrust
+      a.untrusted?.should be_true
+      a.delete(2)
+      a.untrusted?.should be_true
+      a.delete(1) # now empty
+      a.untrusted?.should be_true
+    end
   end
 end

--- a/spec/ruby/core/array/flatten_spec.rb
+++ b/spec/ruby/core/array/flatten_spec.rb
@@ -145,12 +145,14 @@ describe "Array#flatten" do
     end
   end
 
-  it "returns a tainted array if self is tainted" do
-    [].taint.flatten.tainted?.should be_true
-  end
+  ruby_version_is ''...'2.7' do
+    it "returns a tainted array if self is tainted" do
+      [].taint.flatten.tainted?.should be_true
+    end
 
-  it "returns an untrusted array if self is untrusted" do
-    [].untrust.flatten.untrusted?.should be_true
+    it "returns an untrusted array if self is untrusted" do
+      [].untrust.flatten.untrusted?.should be_true
+    end
   end
 
   it "performs respond_to? and method_missing-aware checks when coercing elements to array" do

--- a/spec/ruby/core/array/multiply_spec.rb
+++ b/spec/ruby/core/array/multiply_spec.rb
@@ -88,42 +88,44 @@ describe "Array#* with an integer" do
     end
   end
 
-  it "copies the taint status of the original array even if the passed count is 0" do
-    ary = [1, 2, 3]
-    ary.taint
-    (ary * 0).tainted?.should == true
-  end
+  ruby_version_is ''...'2.7' do
+    it "copies the taint status of the original array even if the passed count is 0" do
+      ary = [1, 2, 3]
+      ary.taint
+      (ary * 0).tainted?.should == true
+    end
 
-  it "copies the taint status of the original array even if the array is empty" do
-    ary = []
-    ary.taint
-    (ary * 3).tainted?.should == true
-  end
+    it "copies the taint status of the original array even if the array is empty" do
+      ary = []
+      ary.taint
+      (ary * 3).tainted?.should == true
+    end
 
-  it "copies the taint status of the original array if the passed count is not 0" do
-    ary = [1, 2, 3]
-    ary.taint
-    (ary * 1).tainted?.should == true
-    (ary * 2).tainted?.should == true
-  end
+    it "copies the taint status of the original array if the passed count is not 0" do
+      ary = [1, 2, 3]
+      ary.taint
+      (ary * 1).tainted?.should == true
+      (ary * 2).tainted?.should == true
+    end
 
-  it "copies the untrusted status of the original array even if the passed count is 0" do
-    ary = [1, 2, 3]
-    ary.untrust
-    (ary * 0).untrusted?.should == true
-  end
+    it "copies the untrusted status of the original array even if the passed count is 0" do
+      ary = [1, 2, 3]
+      ary.untrust
+      (ary * 0).untrusted?.should == true
+    end
 
-  it "copies the untrusted status of the original array even if the array is empty" do
-    ary = []
-    ary.untrust
-    (ary * 3).untrusted?.should == true
-  end
+    it "copies the untrusted status of the original array even if the array is empty" do
+      ary = []
+      ary.untrust
+      (ary * 3).untrusted?.should == true
+    end
 
-  it "copies the untrusted status of the original array if the passed count is not 0" do
-    ary = [1, 2, 3]
-    ary.untrust
-    (ary * 1).untrusted?.should == true
-    (ary * 2).untrusted?.should == true
+    it "copies the untrusted status of the original array if the passed count is not 0" do
+      ary = [1, 2, 3]
+      ary.untrust
+      (ary * 1).untrusted?.should == true
+      (ary * 2).untrusted?.should == true
+    end
   end
 end
 

--- a/spec/ruby/core/array/pack/p_spec.rb
+++ b/spec/ruby/core/array/pack/p_spec.rb
@@ -15,14 +15,16 @@ describe "Array#pack with format 'P'" do
     ["hello"].pack("P").unpack("P5").should == ["hello"]
   end
 
-  it "taints the input string" do
-    input_string = "hello"
-    [input_string].pack("P")
-    input_string.tainted?.should be_true
-  end
+  ruby_version_is ''...'2.7' do
+    it "taints the input string" do
+      input_string = "hello"
+      [input_string].pack("P")
+      input_string.tainted?.should be_true
+    end
 
-  it "does not taint the output string in normal cases" do
-    ["hello"].pack("P").tainted?.should be_false
+    it "does not taint the output string in normal cases" do
+      ["hello"].pack("P").tainted?.should be_false
+    end
   end
 
   it "with nil gives a null pointer" do
@@ -42,14 +44,16 @@ describe "Array#pack with format 'p'" do
     ["hello"].pack("p").unpack("p").should == ["hello"]
   end
 
-  it "taints the input string" do
-    input_string = "hello"
-    [input_string].pack("p")
-    input_string.tainted?.should be_true
-  end
+  ruby_version_is ''...'2.7' do
+    it "taints the input string" do
+      input_string = "hello"
+      [input_string].pack("p")
+      input_string.tainted?.should be_true
+    end
 
-  it "does not taint the output string in normal cases" do
-    ["hello"].pack("p").tainted?.should be_false
+    it "does not taint the output string in normal cases" do
+      ["hello"].pack("p").tainted?.should be_false
+    end
   end
 
   it "with nil gives a null pointer" do

--- a/spec/ruby/core/array/pack/shared/basic.rb
+++ b/spec/ruby/core/array/pack/shared/basic.rb
@@ -33,8 +33,10 @@ describe :array_pack_basic_non_float, shared: true do
     [@obj, @obj].pack(d).should be_an_instance_of(String)
   end
 
-  it "taints the output string if the format string is tainted" do
-    [@obj, @obj].pack("x"+pack_format.taint).tainted?.should be_true
+  ruby_version_is ''...'2.7' do
+    it "taints the output string if the format string is tainted" do
+      [@obj, @obj].pack("x"+pack_format.taint).tainted?.should be_true
+    end
   end
 end
 
@@ -49,8 +51,10 @@ describe :array_pack_basic_float, shared: true do
     [1.2, 4.7].pack(d).should be_an_instance_of(String)
   end
 
-  it "taints the output string if the format string is tainted" do
-    [3.2, 2.8].pack("x"+pack_format.taint).tainted?.should be_true
+  ruby_version_is ''...'2.7' do
+    it "taints the output string if the format string is tainted" do
+      [3.2, 2.8].pack("x"+pack_format.taint).tainted?.should be_true
+    end
   end
 end
 

--- a/spec/ruby/core/array/pack/shared/taint.rb
+++ b/spec/ruby/core/array/pack/shared/taint.rb
@@ -1,33 +1,35 @@
 describe :array_pack_taint, shared: true do
-  it "returns a tainted string when a pack argument is tainted" do
-    ["abcd".taint, 0x20].pack(pack_format("3C")).tainted?.should be_true
-  end
+  ruby_version_is ''...'2.7' do
+    it "returns a tainted string when a pack argument is tainted" do
+      ["abcd".taint, 0x20].pack(pack_format("3C")).tainted?.should be_true
+    end
 
-  it "does not return a tainted string when the array is tainted" do
-    ["abcd", 0x20].taint.pack(pack_format("3C")).tainted?.should be_false
-  end
+    it "does not return a tainted string when the array is tainted" do
+      ["abcd", 0x20].taint.pack(pack_format("3C")).tainted?.should be_false
+    end
 
-  it "returns a tainted string when the format is tainted" do
-    ["abcd", 0x20].pack(pack_format("3C").taint).tainted?.should be_true
-  end
+    it "returns a tainted string when the format is tainted" do
+      ["abcd", 0x20].pack(pack_format("3C").taint).tainted?.should be_true
+    end
 
-  it "returns a tainted string when an empty format is tainted" do
-    ["abcd", 0x20].pack("".taint).tainted?.should be_true
-  end
+    it "returns a tainted string when an empty format is tainted" do
+      ["abcd", 0x20].pack("".taint).tainted?.should be_true
+    end
 
-  it "returns a untrusted string when the format is untrusted" do
-    ["abcd", 0x20].pack(pack_format("3C").untrust).untrusted?.should be_true
-  end
+    it "returns a untrusted string when the format is untrusted" do
+      ["abcd", 0x20].pack(pack_format("3C").untrust).untrusted?.should be_true
+    end
 
-  it "returns a untrusted string when the empty format is untrusted" do
-    ["abcd", 0x20].pack("".untrust).untrusted?.should be_true
-  end
+    it "returns a untrusted string when the empty format is untrusted" do
+      ["abcd", 0x20].pack("".untrust).untrusted?.should be_true
+    end
 
-  it "returns a untrusted string when a pack argument is untrusted" do
-    ["abcd".untrust, 0x20].pack(pack_format("3C")).untrusted?.should be_true
-  end
+    it "returns a untrusted string when a pack argument is untrusted" do
+      ["abcd".untrust, 0x20].pack(pack_format("3C")).untrusted?.should be_true
+    end
 
-  it "returns a trusted string when the array is untrusted" do
-    ["abcd", 0x20].untrust.pack(pack_format("3C")).untrusted?.should be_false
+    it "returns a trusted string when the array is untrusted" do
+      ["abcd", 0x20].untrust.pack(pack_format("3C")).untrusted?.should be_false
+    end
   end
 end

--- a/spec/ruby/core/array/plus_spec.rb
+++ b/spec/ruby/core/array/plus_spec.rb
@@ -41,17 +41,19 @@ describe "Array#+" do
     ([5, 6] + ArraySpecs::ToAryArray[1, 2]).should == [5, 6, 1, 2]
   end
 
-  it "does not get infected even if an original array is tainted" do
-    ([1, 2] + [3, 4]).tainted?.should be_false
-    ([1, 2].taint + [3, 4]).tainted?.should be_false
-    ([1, 2] + [3, 4].taint).tainted?.should be_false
-    ([1, 2].taint + [3, 4].taint).tainted?.should be_false
-  end
+  ruby_version_is ''...'2.7' do
+    it "does not get infected even if an original array is tainted" do
+      ([1, 2] + [3, 4]).tainted?.should be_false
+      ([1, 2].taint + [3, 4]).tainted?.should be_false
+      ([1, 2] + [3, 4].taint).tainted?.should be_false
+      ([1, 2].taint + [3, 4].taint).tainted?.should be_false
+    end
 
-  it "does not infected even if an original array is untrusted" do
-    ([1, 2] + [3, 4]).untrusted?.should be_false
-    ([1, 2].untrust + [3, 4]).untrusted?.should be_false
-    ([1, 2] + [3, 4].untrust).untrusted?.should be_false
-    ([1, 2].untrust + [3, 4].untrust).untrusted?.should be_false
+    it "does not infected even if an original array is untrusted" do
+      ([1, 2] + [3, 4]).untrusted?.should be_false
+      ([1, 2].untrust + [3, 4]).untrusted?.should be_false
+      ([1, 2] + [3, 4].untrust).untrusted?.should be_false
+      ([1, 2].untrust + [3, 4].untrust).untrusted?.should be_false
+    end
   end
 end

--- a/spec/ruby/core/array/pop_spec.rb
+++ b/spec/ruby/core/array/pop_spec.rb
@@ -30,12 +30,14 @@ describe "Array#pop" do
     array.pop.should == [1, 'two', 3.0, array, array, array, array]
   end
 
-  it "keeps taint status" do
-    a = [1, 2].taint
-    a.pop
-    a.tainted?.should be_true
-    a.pop
-    a.tainted?.should be_true
+  ruby_version_is ''...'2.7' do
+    it "keeps taint status" do
+      a = [1, 2].taint
+      a.pop
+      a.tainted?.should be_true
+      a.pop
+      a.tainted?.should be_true
+    end
   end
 
   it "raises a #{frozen_error_class} on a frozen array" do
@@ -46,12 +48,14 @@ describe "Array#pop" do
     -> { ArraySpecs.empty_frozen_array.pop }.should raise_error(frozen_error_class)
   end
 
-  it "keeps untrusted status" do
-    a = [1, 2].untrust
-    a.pop
-    a.untrusted?.should be_true
-    a.pop
-    a.untrusted?.should be_true
+  ruby_version_is ''...'2.7' do
+    it "keeps untrusted status" do
+      a = [1, 2].untrust
+      a.pop
+      a.untrusted?.should be_true
+      a.pop
+      a.untrusted?.should be_true
+    end
   end
 
   describe "passed a number n as an argument" do
@@ -132,24 +136,26 @@ describe "Array#pop" do
       ArraySpecs::MyArray[1, 2, 3].pop(2).should be_an_instance_of(Array)
     end
 
-    it "returns an untainted array even if the array is tainted" do
-      ary = [1, 2].taint
-      ary.pop(2).tainted?.should be_false
-      ary.pop(0).tainted?.should be_false
-    end
+    ruby_version_is ''...'2.7' do
+      it "returns an untainted array even if the array is tainted" do
+        ary = [1, 2].taint
+        ary.pop(2).tainted?.should be_false
+        ary.pop(0).tainted?.should be_false
+      end
 
-    it "keeps taint status" do
-      a = [1, 2].taint
-      a.pop(2)
-      a.tainted?.should be_true
-      a.pop(2)
-      a.tainted?.should be_true
-    end
+      it "keeps taint status" do
+        a = [1, 2].taint
+        a.pop(2)
+        a.tainted?.should be_true
+        a.pop(2)
+        a.tainted?.should be_true
+      end
 
-    it "returns a trusted array even if the array is untrusted" do
-      ary = [1, 2].untrust
-      ary.pop(2).untrusted?.should be_false
-      ary.pop(0).untrusted?.should be_false
+      it "returns a trusted array even if the array is untrusted" do
+        ary = [1, 2].untrust
+        ary.pop(2).untrusted?.should be_false
+        ary.pop(0).untrusted?.should be_false
+      end
     end
 
     it "raises a #{frozen_error_class} on a frozen array" do
@@ -157,12 +163,14 @@ describe "Array#pop" do
       -> { ArraySpecs.frozen_array.pop(0) }.should raise_error(frozen_error_class)
     end
 
-    it "keeps untrusted status" do
-      a = [1, 2].untrust
-      a.pop(2)
-      a.untrusted?.should be_true
-      a.pop(2)
-      a.untrusted?.should be_true
+    ruby_version_is ''...'2.7' do
+      it "keeps untrusted status" do
+        a = [1, 2].untrust
+        a.pop(2)
+        a.untrusted?.should be_true
+        a.pop(2)
+        a.untrusted?.should be_true
+      end
     end
   end
 end

--- a/spec/ruby/core/array/shared/clone.rb
+++ b/spec/ruby/core/array/shared/clone.rb
@@ -18,25 +18,27 @@ describe :array_clone, shared: true do
     b.__id__.should_not == a.__id__
   end
 
-  it "copies taint status from the original" do
-    a = [1, 2, 3, 4]
-    b = [1, 2, 3, 4]
-    a.taint
-    aa = a.send @method
-    bb = b.send @method
+  ruby_version_is ''...'2.7' do
+    it "copies taint status from the original" do
+      a = [1, 2, 3, 4]
+      b = [1, 2, 3, 4]
+      a.taint
+      aa = a.send @method
+      bb = b.send @method
 
-    aa.tainted?.should == true
-    bb.tainted?.should == false
-  end
+      aa.tainted?.should == true
+      bb.tainted?.should == false
+    end
 
-  it "copies untrusted status from the original" do
-    a = [1, 2, 3, 4]
-    b = [1, 2, 3, 4]
-    a.untrust
-    aa = a.send @method
-    bb = b.send @method
+    it "copies untrusted status from the original" do
+      a = [1, 2, 3, 4]
+      b = [1, 2, 3, 4]
+      a.untrust
+      aa = a.send @method
+      bb = b.send @method
 
-    aa.untrusted?.should == true
-    bb.untrusted?.should == false
+      aa.untrusted?.should == true
+      bb.untrusted?.should == false
+    end
   end
 end

--- a/spec/ruby/core/array/shared/collect.rb
+++ b/spec/ruby/core/array/shared/collect.rb
@@ -42,16 +42,18 @@ describe :array_collect, shared: true do
     }.should raise_error(ArgumentError)
   end
 
-  it "does not copy tainted status" do
-    a = [1, 2, 3]
-    a.taint
-    a.send(@method){|x| x}.tainted?.should be_false
-  end
+  ruby_version_is ''...'2.7' do
+    it "does not copy tainted status" do
+      a = [1, 2, 3]
+      a.taint
+      a.send(@method){|x| x}.tainted?.should be_false
+    end
 
-  it "does not copy untrusted status" do
-    a = [1, 2, 3]
-    a.untrust
-    a.send(@method){|x| x}.untrusted?.should be_false
+    it "does not copy untrusted status" do
+      a = [1, 2, 3]
+      a.untrust
+      a.send(@method){|x| x}.untrusted?.should be_false
+    end
   end
 
   before :all do
@@ -94,19 +96,21 @@ describe :array_collect_b, shared: true do
     a.should == ["1!", "2!", "3!"]
   end
 
-  it "keeps tainted status" do
-    a = [1, 2, 3]
-    a.taint
-    a.tainted?.should be_true
-    a.send(@method){|x| x}
-    a.tainted?.should be_true
-  end
+  ruby_version_is ''...'2.7' do
+    it "keeps tainted status" do
+      a = [1, 2, 3]
+      a.taint
+      a.tainted?.should be_true
+      a.send(@method){|x| x}
+      a.tainted?.should be_true
+    end
 
-  it "keeps untrusted status" do
-    a = [1, 2, 3]
-    a.untrust
-    a.send(@method){|x| x}
-    a.untrusted?.should be_true
+    it "keeps untrusted status" do
+      a = [1, 2, 3]
+      a.untrust
+      a.send(@method){|x| x}
+      a.untrusted?.should be_true
+    end
   end
 
   describe "when frozen" do

--- a/spec/ruby/core/array/shared/inspect.rb
+++ b/spec/ruby/core/array/shared/inspect.rb
@@ -64,28 +64,30 @@ describe :array_inspect, shared: true do
     ArraySpecs.empty_recursive_array.send(@method).should == "[[...]]"
   end
 
-  it "taints the result if the Array is non-empty and tainted" do
-    [1, 2].taint.send(@method).tainted?.should be_true
-  end
+  ruby_version_is ''...'2.7' do
+    it "taints the result if the Array is non-empty and tainted" do
+      [1, 2].taint.send(@method).tainted?.should be_true
+    end
 
-  it "does not taint the result if the Array is tainted but empty" do
-    [].taint.send(@method).tainted?.should be_false
-  end
+    it "does not taint the result if the Array is tainted but empty" do
+      [].taint.send(@method).tainted?.should be_false
+    end
 
-  it "taints the result if an element is tainted" do
-    ["str".taint].send(@method).tainted?.should be_true
-  end
+    it "taints the result if an element is tainted" do
+      ["str".taint].send(@method).tainted?.should be_true
+    end
 
-  it "untrusts the result if the Array is untrusted" do
-    [1, 2].untrust.send(@method).untrusted?.should be_true
-  end
+    it "untrusts the result if the Array is untrusted" do
+      [1, 2].untrust.send(@method).untrusted?.should be_true
+    end
 
-  it "does not untrust the result if the Array is untrusted but empty" do
-    [].untrust.send(@method).untrusted?.should be_false
-  end
+    it "does not untrust the result if the Array is untrusted but empty" do
+      [].untrust.send(@method).untrusted?.should be_false
+    end
 
-  it "untrusts the result if an element is untrusted" do
-    ["str".untrust].send(@method).untrusted?.should be_true
+    it "untrusts the result if an element is untrusted" do
+      ["str".untrust].send(@method).untrusted?.should be_true
+    end
   end
 
   describe "with encoding" do

--- a/spec/ruby/core/array/shared/join.rb
+++ b/spec/ruby/core/array/shared/join.rb
@@ -58,32 +58,34 @@ describe :array_join_with_default_separator, shared: true do
     -> { ArraySpecs.empty_recursive_array.send(@method) }.should raise_error(ArgumentError)
   end
 
-  it "taints the result if the Array is tainted and non-empty" do
-    [1, 2].taint.send(@method).tainted?.should be_true
-  end
+  ruby_version_is ''...'2.7' do
+    it "taints the result if the Array is tainted and non-empty" do
+      [1, 2].taint.send(@method).tainted?.should be_true
+    end
 
-  it "does not taint the result if the Array is tainted but empty" do
-    [].taint.send(@method).tainted?.should be_false
-  end
+    it "does not taint the result if the Array is tainted but empty" do
+      [].taint.send(@method).tainted?.should be_false
+    end
 
-  it "taints the result if the result of coercing an element is tainted" do
-    s = mock("taint")
-    s.should_receive(:to_s).and_return("str".taint)
-    [s].send(@method).tainted?.should be_true
-  end
+    it "taints the result if the result of coercing an element is tainted" do
+      s = mock("taint")
+      s.should_receive(:to_s).and_return("str".taint)
+      [s].send(@method).tainted?.should be_true
+    end
 
-  it "untrusts the result if the Array is untrusted and non-empty" do
-    [1, 2].untrust.send(@method).untrusted?.should be_true
-  end
+    it "untrusts the result if the Array is untrusted and non-empty" do
+      [1, 2].untrust.send(@method).untrusted?.should be_true
+    end
 
-  it "does not untrust the result if the Array is untrusted but empty" do
-    [].untrust.send(@method).untrusted?.should be_false
-  end
+    it "does not untrust the result if the Array is untrusted but empty" do
+      [].untrust.send(@method).untrusted?.should be_false
+    end
 
-  it "untrusts the result if the result of coercing an element is untrusted" do
-    s = mock("untrust")
-    s.should_receive(:to_s).and_return("str".untrust)
-    [s].send(@method).untrusted?.should be_true
+    it "untrusts the result if the result of coercing an element is untrusted" do
+      s = mock("untrust")
+      s.should_receive(:to_s).and_return("str".untrust)
+      [s].send(@method).untrusted?.should be_true
+    end
   end
 
   it "uses the first encoding when other strings are compatible" do
@@ -125,39 +127,41 @@ describe :array_join_with_string_separator, shared: true do
     [1, [2, ArraySpecs::MyArray[3, 4], 5], 6].send(@method, ":").should == "1:2:3:4:5:6"
   end
 
-  describe "with a tainted separator" do
-    before :each do
-      @sep = ":".taint
+  ruby_version_is ''...'2.7' do
+    describe "with a tainted separator" do
+      before :each do
+        @sep = ":".taint
+      end
+
+      it "does not taint the result if the array is empty" do
+        [].send(@method, @sep).tainted?.should be_false
+      end
+
+      it "does not taint the result if the array has only one element" do
+        [1].send(@method, @sep).tainted?.should be_false
+      end
+
+      it "taints the result if the array has two or more elements" do
+        [1, 2].send(@method, @sep).tainted?.should be_true
+      end
     end
 
-    it "does not taint the result if the array is empty" do
-      [].send(@method, @sep).tainted?.should be_false
-    end
+    describe "with an untrusted separator" do
+      before :each do
+        @sep = ":".untrust
+      end
 
-    it "does not taint the result if the array has only one element" do
-      [1].send(@method, @sep).tainted?.should be_false
-    end
+      it "does not untrust the result if the array is empty" do
+        [].send(@method, @sep).untrusted?.should be_false
+      end
 
-    it "taints the result if the array has two or more elements" do
-      [1, 2].send(@method, @sep).tainted?.should be_true
-    end
-  end
+      it "does not untrust the result if the array has only one element" do
+        [1].send(@method, @sep).untrusted?.should be_false
+      end
 
-  describe "with an untrusted separator" do
-    before :each do
-      @sep = ":".untrust
-    end
-
-    it "does not untrust the result if the array is empty" do
-      [].send(@method, @sep).untrusted?.should be_false
-    end
-
-    it "does not untrust the result if the array has only one element" do
-      [1].send(@method, @sep).untrusted?.should be_false
-    end
-
-    it "untrusts the result if the array has two or more elements" do
-      [1, 2].send(@method, @sep).untrusted?.should be_true
+      it "untrusts the result if the array has two or more elements" do
+        [1, 2].send(@method, @sep).untrusted?.should be_true
+      end
     end
   end
 end

--- a/spec/ruby/core/array/shift_spec.rb
+++ b/spec/ruby/core/array/shift_spec.rb
@@ -117,18 +117,20 @@ describe "Array#shift" do
       ArraySpecs::MyArray[1, 2, 3].shift(2).should be_an_instance_of(Array)
     end
 
-    it "returns an untainted array even if the array is tainted" do
-      ary = [1, 2].taint
-      ary.shift(2).tainted?.should be_false
-      ary.shift(0).tainted?.should be_false
-    end
+    ruby_version_is ''...'2.7' do
+      it "returns an untainted array even if the array is tainted" do
+        ary = [1, 2].taint
+        ary.shift(2).tainted?.should be_false
+        ary.shift(0).tainted?.should be_false
+      end
 
-    it "keeps taint status" do
-      a = [1, 2].taint
-      a.shift(2)
-      a.tainted?.should be_true
-      a.shift(2)
-      a.tainted?.should be_true
+      it "keeps taint status" do
+        a = [1, 2].taint
+        a.shift(2)
+        a.tainted?.should be_true
+        a.shift(2)
+        a.tainted?.should be_true
+      end
     end
   end
 end

--- a/spec/ruby/core/enumerable/group_by_spec.rb
+++ b/spec/ruby/core/enumerable/group_by_spec.rb
@@ -33,12 +33,14 @@ describe "Enumerable#group_by" do
                   [3, 4, 5] => [[3, 4, 5]] }
   end
 
-  it "returns a tainted hash if self is tainted" do
-    EnumerableSpecs::Empty.new.taint.group_by {}.tainted?.should be_true
-  end
+  ruby_version_is ''...'2.7' do
+    it "returns a tainted hash if self is tainted" do
+      EnumerableSpecs::Empty.new.taint.group_by {}.tainted?.should be_true
+    end
 
-  it "returns an untrusted hash if self is untrusted" do
-    EnumerableSpecs::Empty.new.untrust.group_by {}.untrusted?.should be_true
+    it "returns an untrusted hash if self is untrusted" do
+      EnumerableSpecs::Empty.new.untrust.group_by {}.untrusted?.should be_true
+    end
   end
 
   it_behaves_like :enumerable_enumeratorized_with_origin_size, :group_by

--- a/spec/ruby/core/enumerable/shared/entries.rb
+++ b/spec/ruby/core/enumerable/shared/entries.rb
@@ -14,11 +14,13 @@ describe :enumerable_entries, shared: true do
     count.arguments_passed.should == [:hello, "world"]
   end
 
-  it "returns a tainted array if self is tainted" do
-    EnumerableSpecs::Empty.new.taint.send(@method).tainted?.should be_true
-  end
+  ruby_version_is ''...'2.7' do
+    it "returns a tainted array if self is tainted" do
+      EnumerableSpecs::Empty.new.taint.send(@method).tainted?.should be_true
+    end
 
-  it "returns an untrusted array if self is untrusted" do
-    EnumerableSpecs::Empty.new.untrust.send(@method).untrusted?.should be_true
+    it "returns an untrusted array if self is untrusted" do
+      EnumerableSpecs::Empty.new.untrust.send(@method).untrusted?.should be_true
+    end
   end
 end

--- a/spec/ruby/core/enumerable/uniq_spec.rb
+++ b/spec/ruby/core/enumerable/uniq_spec.rb
@@ -31,44 +31,76 @@ describe 'Enumerable#uniq' do
     [x, y].to_enum.uniq.should == [x, y]
   end
 
-  it "compares elements with matching hash codes with #eql?" do
-    a = Array.new(2) do
-      obj = mock('0')
-      obj.should_receive(:hash).at_least(1).and_return(0)
+  ruby_version_is '2.7' do
+    it "compares elements with matching hash codes with #eql?" do
+      a = Array.new(2) do
+        obj = mock('0')
+        obj.should_receive(:hash).at_least(1).and_return(0)
 
-      def obj.eql?(o)
-        # It's undefined whether the impl does a[0].eql?(a[1]) or
-        # a[1].eql?(a[0]) so we taint both.
-        taint
-        o.taint
-        false
+        def obj.eql?(o)
+          false
+        end
+
+        obj
       end
 
-      obj
-    end
+      a.uniq.should == a
 
-    a.uniq.should == a
-    a[0].tainted?.should == true
-    a[1].tainted?.should == true
+      a = Array.new(2) do
+        obj = mock('0')
+        obj.should_receive(:hash).at_least(1).and_return(0)
 
-    a = Array.new(2) do
-      obj = mock('0')
-      obj.should_receive(:hash).at_least(1).and_return(0)
+        def obj.eql?(o)
+          true
+        end
 
-      def obj.eql?(o)
-        # It's undefined whether the impl does a[0].eql?(a[1]) or
-        # a[1].eql?(a[0]) so we taint both.
-        taint
-        o.taint
-        true
+        obj
       end
 
-      obj
+      a.to_enum.uniq.size.should == 1
     end
+  end
 
-    a.to_enum.uniq.size.should == 1
-    a[0].tainted?.should == true
-    a[1].tainted?.should == true
+  ruby_version_is ''...'2.7' do
+    it "compares elements with matching hash codes with #eql?" do
+      a = Array.new(2) do
+        obj = mock('0')
+        obj.should_receive(:hash).at_least(1).and_return(0)
+
+        def obj.eql?(o)
+          # It's undefined whether the impl does a[0].eql?(a[1]) or
+          # a[1].eql?(a[0]) so we taint both.
+          taint
+          o.taint
+          false
+        end
+
+        obj
+      end
+
+      a.uniq.should == a
+      a[0].tainted?.should == true
+      a[1].tainted?.should == true
+
+      a = Array.new(2) do
+        obj = mock('0')
+        obj.should_receive(:hash).at_least(1).and_return(0)
+
+        def obj.eql?(o)
+          # It's undefined whether the impl does a[0].eql?(a[1]) or
+          # a[1].eql?(a[0]) so we taint both.
+          taint
+          o.taint
+          true
+        end
+
+        obj
+      end
+
+      a.to_enum.uniq.size.should == 1
+      a[0].tainted?.should == true
+      a[1].tainted?.should == true
+    end
   end
 
   context 'when yielded with multiple arguments' do

--- a/spec/ruby/core/hash/reject_spec.rb
+++ b/spec/ruby/core/hash/reject_spec.rb
@@ -32,9 +32,11 @@ describe "Hash#reject" do
       HashSpecs::MyHash[1 => 2, 3 => 4].reject { true }.should be_kind_of(Hash)
     end
 
-    it "does not taint the resulting hash" do
-      h = { a: 1 }.taint
-      h.reject {false}.tainted?.should == false
+    ruby_version_is ''...'2.7' do
+      it "does not taint the resulting hash" do
+        h = { a: 1 }.taint
+        h.reject {false}.tainted?.should == false
+      end
     end
   end
 

--- a/spec/ruby/core/hash/shared/to_s.rb
+++ b/spec/ruby/core/hash/shared/to_s.rb
@@ -77,14 +77,16 @@ describe :hash_to_s, shared: true do
     y.send(@method).should == "{1=>{0=>{...}}}"
   end
 
-  it "returns a tainted string if self is tainted and not empty" do
-    {}.taint.send(@method).tainted?.should be_false
-    { nil => nil }.taint.send(@method).tainted?.should be_true
-  end
+  ruby_version_is ''...'2.7' do
+    it "returns a tainted string if self is tainted and not empty" do
+      {}.taint.send(@method).tainted?.should be_false
+      { nil => nil }.taint.send(@method).tainted?.should be_true
+    end
 
-  it "returns an untrusted string if self is untrusted and not empty" do
-    {}.untrust.send(@method).untrusted?.should be_false
-    { nil => nil }.untrust.send(@method).untrusted?.should be_true
+    it "returns an untrusted string if self is untrusted and not empty" do
+      {}.untrust.send(@method).untrusted?.should be_false
+      { nil => nil }.untrust.send(@method).untrusted?.should be_true
+    end
   end
 
   it "does not raise if inspected result is not default external encoding" do

--- a/spec/ruby/core/hash/to_a_spec.rb
+++ b/spec/ruby/core/hash/to_a_spec.rb
@@ -27,11 +27,13 @@ describe "Hash#to_a" do
     ent.should == pairs
   end
 
-  it "returns a tainted array if self is tainted" do
-    {}.taint.to_a.tainted?.should be_true
-  end
+  ruby_version_is ''...'2.7' do
+    it "returns a tainted array if self is tainted" do
+      {}.taint.to_a.tainted?.should be_true
+    end
 
-  it "returns an untrusted array if self is untrusted" do
-    {}.untrust.to_a.untrusted?.should be_true
+    it "returns an untrusted array if self is untrusted" do
+      {}.untrust.to_a.untrusted?.should be_true
+    end
   end
 end

--- a/spec/ruby/core/io/gets_spec.rb
+++ b/spec/ruby/core/io/gets_spec.rb
@@ -38,9 +38,11 @@ describe "IO#gets" do
       IOSpecs.lines.each { |line| line.should == @io.gets }
     end
 
-    it "returns tainted strings" do
-      while line = @io.gets
-        line.tainted?.should == true
+    ruby_version_is ''...'2.7' do
+      it "returns tainted strings" do
+        while line = @io.gets
+          line.tainted?.should == true
+        end
       end
     end
 
@@ -62,9 +64,11 @@ describe "IO#gets" do
       @io.gets(nil).should == IOSpecs.lines.join("")
     end
 
-    it "returns tainted strings" do
-      while line = @io.gets(nil)
-        line.tainted?.should == true
+    ruby_version_is ''...'2.7' do
+      it "returns tainted strings" do
+        while line = @io.gets(nil)
+          line.tainted?.should == true
+        end
       end
     end
 
@@ -96,9 +100,11 @@ describe "IO#gets" do
       @io.gets.should == IOSpecs.lines[4]
     end
 
-    it "returns tainted strings" do
-      while line = @io.gets("")
-        line.tainted?.should == true
+    ruby_version_is ''...'2.7' do
+      it "returns tainted strings" do
+        while line = @io.gets("")
+          line.tainted?.should == true
+        end
       end
     end
 
@@ -120,9 +126,11 @@ describe "IO#gets" do
       @io.gets("la linea").should == "Voici la ligne une.\nQui \303\250 la linea"
     end
 
-    it "returns tainted strings" do
-      while line = @io.gets("la")
-        line.tainted?.should == true
+    ruby_version_is ''...'2.7' do
+      it "returns tainted strings" do
+        while line = @io.gets("la")
+          line.tainted?.should == true
+        end
       end
     end
 

--- a/spec/ruby/core/kernel/clone_spec.rb
+++ b/spec/ruby/core/kernel/clone_spec.rb
@@ -108,9 +108,15 @@ describe "Kernel#clone" do
     cloned.bar.should == ['a']
   end
 
-  it 'copies frozen? and tainted?' do
-    o = ''.taint.freeze.clone
+  it 'copies frozen?' do
+    o = ''.freeze.clone
     o.frozen?.should be_true
-    o.tainted?.should be_true
+  end
+
+  ruby_version_is ''...'2.7' do
+    it 'copies tainted?' do
+      o = ''.taint.clone
+      o.tainted?.should be_true
+    end
   end
 end

--- a/spec/ruby/core/kernel/inspect_spec.rb
+++ b/spec/ruby/core/kernel/inspect_spec.rb
@@ -6,12 +6,14 @@ describe "Kernel#inspect" do
     Object.new.inspect.should be_an_instance_of(String)
   end
 
-  it "returns a tainted string if self is tainted" do
-    Object.new.taint.inspect.tainted?.should be_true
-  end
+  ruby_version_is ''...'2.7' do
+    it "returns a tainted string if self is tainted" do
+      Object.new.taint.inspect.tainted?.should be_true
+    end
 
-  it "returns an untrusted string if self is untrusted" do
-    Object.new.untrust.inspect.untrusted?.should be_true
+    it "returns an untrusted string if self is untrusted" do
+      Object.new.untrust.inspect.untrusted?.should be_true
+    end
   end
 
   it "does not call #to_s if it is defined" do

--- a/spec/ruby/core/kernel/shared/dup_clone.rb
+++ b/spec/ruby/core/kernel/shared/dup_clone.rb
@@ -52,14 +52,16 @@ describe :kernel_dup_clone, shared: true do
     o2.original.should equal(o)
   end
 
-  it "preserves tainted state from the original" do
-    o = ObjectSpecDupInitCopy.new
-    o2 = o.send(@method)
-    o.taint
-    o3 = o.send(@method)
+  ruby_version_is ''...'2.7' do
+    it "preserves tainted state from the original" do
+      o = ObjectSpecDupInitCopy.new
+      o2 = o.send(@method)
+      o.taint
+      o3 = o.send(@method)
 
-    o2.tainted?.should == false
-    o3.tainted?.should == true
+      o2.tainted?.should == false
+      o3.tainted?.should == true
+    end
   end
 
   it "does not preserve the object_id" do
@@ -69,14 +71,16 @@ describe :kernel_dup_clone, shared: true do
     o2.object_id.should_not == old_object_id
   end
 
-  it "preserves untrusted state from the original" do
-    o = ObjectSpecDupInitCopy.new
-    o2 = o.send(@method)
-    o.untrust
-    o3 = o.send(@method)
+  ruby_version_is ''...'2.7' do
+    it "preserves untrusted state from the original" do
+      o = ObjectSpecDupInitCopy.new
+      o2 = o.send(@method)
+      o.untrust
+      o3 = o.send(@method)
 
-    o2.untrusted?.should == false
-    o3.untrusted?.should == true
+      o2.untrusted?.should == false
+      o3.untrusted?.should == true
+    end
   end
 
   it "returns nil for NilClass" do

--- a/spec/ruby/core/kernel/taint_spec.rb
+++ b/spec/ruby/core/kernel/taint_spec.rb
@@ -2,44 +2,46 @@ require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
 describe "Kernel#taint" do
-  it "returns self" do
-    o = Object.new
-    o.taint.should equal(o)
-  end
-
-  it "sets the tainted bit" do
-    o = Object.new
-    o.taint
-    o.tainted?.should == true
-  end
-
-  it "raises #{frozen_error_class} on an untainted, frozen object" do
-    o = Object.new.freeze
-    -> { o.taint }.should raise_error(frozen_error_class)
-  end
-
-  it "does not raise an error on a tainted, frozen object" do
-    o = Object.new.taint.freeze
-    o.taint.should equal(o)
-  end
-
-  it "has no effect on immediate values" do
-    [nil, true, false].each do |v|
-      v.taint
-      v.tainted?.should == false
+  ruby_version_is ''...'2.7' do
+    it "returns self" do
+      o = Object.new
+      o.taint.should equal(o)
     end
-  end
 
-  it "no raises a RuntimeError on symbols" do
-    v = :sym
-    -> { v.taint }.should_not raise_error(RuntimeError)
-    v.tainted?.should == false
-  end
+    it "sets the tainted bit" do
+      o = Object.new
+      o.taint
+      o.tainted?.should == true
+    end
 
-  it "no raises error on fixnum values" do
-    [1].each do |v|
+    it "raises #{frozen_error_class} on an untainted, frozen object" do
+      o = Object.new.freeze
+      -> { o.taint }.should raise_error(frozen_error_class)
+    end
+
+    it "does not raise an error on a tainted, frozen object" do
+      o = Object.new.taint.freeze
+      o.taint.should equal(o)
+    end
+
+    it "has no effect on immediate values" do
+      [nil, true, false].each do |v|
+        v.taint
+        v.tainted?.should == false
+      end
+    end
+
+    it "no raises a RuntimeError on symbols" do
+      v = :sym
       -> { v.taint }.should_not raise_error(RuntimeError)
       v.tainted?.should == false
+    end
+
+    it "no raises error on fixnum values" do
+      [1].each do |v|
+        -> { v.taint }.should_not raise_error(RuntimeError)
+        v.tainted?.should == false
+      end
     end
   end
 end

--- a/spec/ruby/core/kernel/tainted_spec.rb
+++ b/spec/ruby/core/kernel/tainted_spec.rb
@@ -2,11 +2,13 @@ require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
 describe "Kernel#tainted?" do
-  it "returns true if Object is tainted" do
-    o = mock('o')
-    p = mock('p')
-    p.taint
-    o.tainted?.should == false
-    p.tainted?.should == true
+  ruby_version_is ''...'2.7' do
+    it "returns true if Object is tainted" do
+      o = mock('o')
+      p = mock('p')
+      p.taint
+      o.tainted?.should == false
+      p.tainted?.should == true
+    end
   end
 end

--- a/spec/ruby/core/kernel/to_s_spec.rb
+++ b/spec/ruby/core/kernel/to_s_spec.rb
@@ -6,11 +6,13 @@ describe "Kernel#to_s" do
     Object.new.to_s.should =~ /Object/
   end
 
-  it "returns a tainted result if self is tainted" do
-    Object.new.taint.to_s.tainted?.should be_true
-  end
+  ruby_version_is ''...'2.7' do
+    it "returns a tainted result if self is tainted" do
+      Object.new.taint.to_s.tainted?.should be_true
+    end
 
-  it "returns an untrusted result if self is untrusted" do
-    Object.new.untrust.to_s.untrusted?.should be_true
+    it "returns an untrusted result if self is untrusted" do
+      Object.new.untrust.to_s.untrusted?.should be_true
+    end
   end
 end

--- a/spec/ruby/core/kernel/trust_spec.rb
+++ b/spec/ruby/core/kernel/trust_spec.rb
@@ -2,24 +2,26 @@ require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
 describe "Kernel#trust" do
-  it "returns self" do
-    o = Object.new
-    o.trust.should equal(o)
-  end
+  ruby_version_is ''...'2.7' do
+    it "returns self" do
+      o = Object.new
+      o.trust.should equal(o)
+    end
 
-  it "clears the untrusted bit" do
-    o = Object.new.untrust
-    o.trust
-    o.untrusted?.should == false
-  end
+    it "clears the untrusted bit" do
+      o = Object.new.untrust
+      o.trust
+      o.untrusted?.should == false
+    end
 
-  it "raises #{frozen_error_class} on an untrusted, frozen object" do
-    o = Object.new.untrust.freeze
-    -> { o.trust }.should raise_error(frozen_error_class)
-  end
+    it "raises #{frozen_error_class} on an untrusted, frozen object" do
+      o = Object.new.untrust.freeze
+      -> { o.trust }.should raise_error(frozen_error_class)
+    end
 
-  it "does not raise an error on a trusted, frozen object" do
-    o = Object.new.freeze
-    o.trust.should equal(o)
+    it "does not raise an error on a trusted, frozen object" do
+      o = Object.new.freeze
+      o.trust.should equal(o)
+    end
   end
 end

--- a/spec/ruby/core/kernel/untaint_spec.rb
+++ b/spec/ruby/core/kernel/untaint_spec.rb
@@ -2,24 +2,26 @@ require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
 describe "Kernel#untaint" do
-  it "returns self" do
-    o = Object.new
-    o.untaint.should equal(o)
-  end
+  ruby_version_is ''...'2.7' do
+    it "returns self" do
+      o = Object.new
+      o.untaint.should equal(o)
+    end
 
-  it "clears the tainted bit" do
-    o = Object.new.taint
-    o.untaint
-    o.tainted?.should == false
-  end
+    it "clears the tainted bit" do
+      o = Object.new.taint
+      o.untaint
+      o.tainted?.should == false
+    end
 
-  it "raises #{frozen_error_class} on a tainted, frozen object" do
-    o = Object.new.taint.freeze
-    -> { o.untaint }.should raise_error(frozen_error_class)
-  end
+    it "raises #{frozen_error_class} on a tainted, frozen object" do
+      o = Object.new.taint.freeze
+      -> { o.untaint }.should raise_error(frozen_error_class)
+    end
 
-  it "does not raise an error on an untainted, frozen object" do
-    o = Object.new.freeze
-    o.untaint.should equal(o)
+    it "does not raise an error on an untainted, frozen object" do
+      o = Object.new.freeze
+      o.untaint.should equal(o)
+    end
   end
 end

--- a/spec/ruby/core/kernel/untrust_spec.rb
+++ b/spec/ruby/core/kernel/untrust_spec.rb
@@ -2,24 +2,26 @@ require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
 describe "Kernel#untrust" do
-  it "returns self" do
-    o = Object.new
-    o.untrust.should equal(o)
-  end
+  ruby_version_is ''...'2.7' do
+    it "returns self" do
+      o = Object.new
+      o.untrust.should equal(o)
+    end
 
-  it "sets the untrusted bit" do
-    o = Object.new
-    o.untrust
-    o.untrusted?.should == true
-  end
+    it "sets the untrusted bit" do
+      o = Object.new
+      o.untrust
+      o.untrusted?.should == true
+    end
 
-  it "raises #{frozen_error_class} on a trusted, frozen object" do
-    o = Object.new.freeze
-    -> { o.untrust }.should raise_error(frozen_error_class)
-  end
+    it "raises #{frozen_error_class} on a trusted, frozen object" do
+      o = Object.new.freeze
+      -> { o.untrust }.should raise_error(frozen_error_class)
+    end
 
-  it "does not raise an error on an untrusted, frozen object" do
-    o = Object.new.untrust.freeze
-    o.untrust.should equal(o)
+    it "does not raise an error on an untrusted, frozen object" do
+      o = Object.new.untrust.freeze
+      o.untrust.should equal(o)
+    end
   end
 end

--- a/spec/ruby/core/kernel/untrusted_spec.rb
+++ b/spec/ruby/core/kernel/untrusted_spec.rb
@@ -2,27 +2,29 @@ require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
 describe "Kernel#untrusted?" do
-  it "returns the untrusted status of an object" do
-    o = mock('o')
-    o.untrusted?.should == false
-    o.untrust
-    o.untrusted?.should == true
-  end
+  ruby_version_is ''...'2.7' do
+    it "returns the untrusted status of an object" do
+      o = mock('o')
+      o.untrusted?.should == false
+      o.untrust
+      o.untrusted?.should == true
+    end
 
-  it "has no effect on immediate values" do
-    a = nil
-    b = true
-    c = false
-    a.untrust
-    b.untrust
-    c.untrust
-    a.untrusted?.should == false
-    b.untrusted?.should == false
-    c.untrusted?.should == false
-  end
+    it "has no effect on immediate values" do
+      a = nil
+      b = true
+      c = false
+      a.untrust
+      b.untrust
+      c.untrust
+      a.untrusted?.should == false
+      b.untrusted?.should == false
+      c.untrusted?.should == false
+    end
 
-  it "has effect on immediate values" do
-    d = 1
-    -> { d.untrust }.should_not raise_error(RuntimeError)
+    it "has effect on immediate values" do
+      d = 1
+      -> { d.untrust }.should_not raise_error(RuntimeError)
+    end
   end
 end

--- a/spec/ruby/core/marshal/dump_spec.rb
+++ b/spec/ruby/core/marshal/dump_spec.rb
@@ -581,27 +581,29 @@ describe "Marshal.dump" do
     -> { Marshal.dump(m) }.should raise_error(TypeError)
   end
 
-  it "returns an untainted string if object is untainted" do
-    Marshal.dump(Object.new).tainted?.should be_false
-  end
+  ruby_version_is ''...'2.7' do
+    it "returns an untainted string if object is untainted" do
+      Marshal.dump(Object.new).tainted?.should be_false
+    end
 
-  it "returns a tainted string if object is tainted" do
-    Marshal.dump(Object.new.taint).tainted?.should be_true
-  end
+    it "returns a tainted string if object is tainted" do
+      Marshal.dump(Object.new.taint).tainted?.should be_true
+    end
 
-  it "returns a tainted string if nested object is tainted" do
-    Marshal.dump([[Object.new.taint]]).tainted?.should be_true
-  end
+    it "returns a tainted string if nested object is tainted" do
+      Marshal.dump([[Object.new.taint]]).tainted?.should be_true
+    end
 
-  it "returns a trusted string if object is trusted" do
-    Marshal.dump(Object.new).untrusted?.should be_false
-  end
+    it "returns a trusted string if object is trusted" do
+      Marshal.dump(Object.new).untrusted?.should be_false
+    end
 
-  it "returns an untrusted string if object is untrusted" do
-    Marshal.dump(Object.new.untrust).untrusted?.should be_true
-  end
+    it "returns an untrusted string if object is untrusted" do
+      Marshal.dump(Object.new.untrust).untrusted?.should be_true
+    end
 
-  it "returns an untrusted string if nested object is untrusted" do
-    Marshal.dump([[Object.new.untrust]]).untrusted?.should be_true
+    it "returns an untrusted string if nested object is untrusted" do
+      Marshal.dump([[Object.new.untrust]]).untrusted?.should be_true
+    end
   end
 end

--- a/spec/ruby/core/marshal/shared/load.rb
+++ b/spec/ruby/core/marshal/shared/load.rb
@@ -182,85 +182,87 @@ describe :marshal_load, shared: true do
     end
   end
 
-  it "returns an untainted object if source is untainted" do
-    x = Object.new
-    y = Marshal.send(@method, Marshal.dump(x))
-    y.tainted?.should be_false
-  end
-
-  describe "when source is tainted" do
-    it "returns a tainted object" do
+  ruby_version_is ''...'2.7' do
+    it "returns an untainted object if source is untainted" do
       x = Object.new
-      x.taint
-      s = Marshal.dump(x)
-      y = Marshal.send(@method, s)
-      y.tainted?.should be_true
+      y = Marshal.send(@method, Marshal.dump(x))
+      y.tainted?.should be_false
+    end
 
-      # note that round-trip via Marshal does not preserve
-      # the taintedness at each level of the nested structure
-      y = Marshal.send(@method, Marshal.dump([[x]]))
+    describe "when source is tainted" do
+      it "returns a tainted object" do
+        x = Object.new
+        x.taint
+        s = Marshal.dump(x)
+        y = Marshal.send(@method, s)
+        y.tainted?.should be_true
+
+        # note that round-trip via Marshal does not preserve
+        # the taintedness at each level of the nested structure
+        y = Marshal.send(@method, Marshal.dump([[x]]))
+        y.tainted?.should be_true
+        y.first.tainted?.should be_true
+        y.first.first.tainted?.should be_true
+      end
+
+      it "does not taint Symbols" do
+        x = [:x]
+        y = Marshal.send(@method, Marshal.dump(x).taint)
+        y.tainted?.should be_true
+        y.first.tainted?.should be_false
+      end
+
+      it "does not taint Fixnums" do
+        x = [1]
+        y = Marshal.send(@method, Marshal.dump(x).taint)
+        y.tainted?.should be_true
+        y.first.tainted?.should be_false
+      end
+
+      it "does not taint Bignums" do
+        x = [bignum_value]
+        y = Marshal.send(@method, Marshal.dump(x).taint)
+        y.tainted?.should be_true
+        y.first.tainted?.should be_false
+      end
+
+      it "does not taint Floats" do
+        x = [1.2]
+        y = Marshal.send(@method, Marshal.dump(x).taint)
+        y.tainted?.should be_true
+        y.first.tainted?.should be_false
+      end
+    end
+
+    it "preserves taintedness of nested structure" do
+      x = Object.new
+      a = [[x]]
+      x.taint
+      y = Marshal.send(@method, Marshal.dump(a))
       y.tainted?.should be_true
       y.first.tainted?.should be_true
       y.first.first.tainted?.should be_true
     end
 
-    it "does not taint Symbols" do
-      x = [:x]
-      y = Marshal.send(@method, Marshal.dump(x).taint)
-      y.tainted?.should be_true
-      y.first.tainted?.should be_false
+    it "returns a trusted object if source is trusted" do
+      x = Object.new
+      y = Marshal.send(@method, Marshal.dump(x))
+      y.untrusted?.should be_false
     end
 
-    it "does not taint Fixnums" do
-      x = [1]
-      y = Marshal.send(@method, Marshal.dump(x).taint)
-      y.tainted?.should be_true
-      y.first.tainted?.should be_false
+    it "returns an untrusted object if source is untrusted" do
+      x = Object.new
+      x.untrust
+      y = Marshal.send(@method, Marshal.dump(x))
+      y.untrusted?.should be_true
+
+      # note that round-trip via Marshal does not preserve
+      # the untrustedness at each level of the nested structure
+      y = Marshal.send(@method, Marshal.dump([[x]]))
+      y.untrusted?.should be_true
+      y.first.untrusted?.should be_true
+      y.first.first.untrusted?.should be_true
     end
-
-    it "does not taint Bignums" do
-      x = [bignum_value]
-      y = Marshal.send(@method, Marshal.dump(x).taint)
-      y.tainted?.should be_true
-      y.first.tainted?.should be_false
-    end
-
-    it "does not taint Floats" do
-      x = [1.2]
-      y = Marshal.send(@method, Marshal.dump(x).taint)
-      y.tainted?.should be_true
-      y.first.tainted?.should be_false
-    end
-  end
-
-  it "preserves taintedness of nested structure" do
-    x = Object.new
-    a = [[x]]
-    x.taint
-    y = Marshal.send(@method, Marshal.dump(a))
-    y.tainted?.should be_true
-    y.first.tainted?.should be_true
-    y.first.first.tainted?.should be_true
-  end
-
-  it "returns a trusted object if source is trusted" do
-    x = Object.new
-    y = Marshal.send(@method, Marshal.dump(x))
-    y.untrusted?.should be_false
-  end
-
-  it "returns an untrusted object if source is untrusted" do
-    x = Object.new
-    x.untrust
-    y = Marshal.send(@method, Marshal.dump(x))
-    y.untrusted?.should be_true
-
-    # note that round-trip via Marshal does not preserve
-    # the untrustedness at each level of the nested structure
-    y = Marshal.send(@method, Marshal.dump([[x]]))
-    y.untrusted?.should be_true
-    y.first.untrusted?.should be_true
-    y.first.first.untrusted?.should be_true
   end
 
   # Note: Ruby 1.9 should be compatible with older marshal format

--- a/spec/ruby/core/matchdata/post_match_spec.rb
+++ b/spec/ruby/core/matchdata/post_match_spec.rb
@@ -6,20 +6,22 @@ describe "MatchData#post_match" do
     $'.should == ': The Movie'
   end
 
-  it "keeps taint status from the source string" do
-    str = "THX1138: The Movie"
-    str.taint
-    res = /(.)(.)(\d+)(\d)/.match(str).post_match
-    res.tainted?.should be_true
-    $'.tainted?.should be_true
-  end
+  ruby_version_is ''...'2.7' do
+    it "keeps taint status from the source string" do
+      str = "THX1138: The Movie"
+      str.taint
+      res = /(.)(.)(\d+)(\d)/.match(str).post_match
+      res.tainted?.should be_true
+      $'.tainted?.should be_true
+    end
 
-  it "keeps untrusted status from the source string" do
-    str = "THX1138: The Movie"
-    str.untrust
-    res = /(.)(.)(\d+)(\d)/.match(str).post_match
-    res.untrusted?.should be_true
-    $'.untrusted?.should be_true
+    it "keeps untrusted status from the source string" do
+      str = "THX1138: The Movie"
+      str.untrust
+      res = /(.)(.)(\d+)(\d)/.match(str).post_match
+      res.untrusted?.should be_true
+      $'.untrusted?.should be_true
+    end
   end
 
   it "sets the encoding to the encoding of the source String" do

--- a/spec/ruby/core/matchdata/pre_match_spec.rb
+++ b/spec/ruby/core/matchdata/pre_match_spec.rb
@@ -6,20 +6,22 @@ describe "MatchData#pre_match" do
     $`.should == 'T'
   end
 
-  it "keeps taint status from the source string" do
-    str = "THX1138: The Movie"
-    str.taint
-    res = /(.)(.)(\d+)(\d)/.match(str).pre_match
-    res.tainted?.should be_true
-    $`.tainted?.should be_true
-  end
+  ruby_version_is ''...'2.7' do
+    it "keeps taint status from the source string" do
+      str = "THX1138: The Movie"
+      str.taint
+      res = /(.)(.)(\d+)(\d)/.match(str).pre_match
+      res.tainted?.should be_true
+      $`.tainted?.should be_true
+    end
 
-  it "keeps untrusted status from the source string" do
-    str = "THX1138: The Movie"
-    str.untrust
-    res = /(.)(.)(\d+)(\d)/.match(str).pre_match
-    res.untrusted?.should be_true
-    $`.untrusted?.should be_true
+    it "keeps untrusted status from the source string" do
+      str = "THX1138: The Movie"
+      str.untrust
+      res = /(.)(.)(\d+)(\d)/.match(str).pre_match
+      res.untrusted?.should be_true
+      $`.untrusted?.should be_true
+    end
   end
 
   it "sets the encoding to the encoding of the source String" do

--- a/spec/ruby/core/module/append_features_spec.rb
+++ b/spec/ruby/core/module/append_features_spec.rb
@@ -47,16 +47,18 @@ describe "Module#append_features" do
 
   end
 
-  it "copies own tainted status to the given module" do
-    other = Module.new
-    Module.new.taint.send :append_features, other
-    other.tainted?.should be_true
-  end
+  ruby_version_is ''...'2.7' do
+    it "copies own tainted status to the given module" do
+      other = Module.new
+      Module.new.taint.send :append_features, other
+      other.tainted?.should be_true
+    end
 
-  it "copies own untrusted status to the given module" do
-    other = Module.new
-    Module.new.untrust.send :append_features, other
-    other.untrusted?.should be_true
+    it "copies own untrusted status to the given module" do
+      other = Module.new
+      Module.new.untrust.send :append_features, other
+      other.untrusted?.should be_true
+    end
   end
 
   describe "when other is frozen" do

--- a/spec/ruby/core/module/extend_object_spec.rb
+++ b/spec/ruby/core/module/extend_object_spec.rb
@@ -42,16 +42,18 @@ describe "Module#extend_object" do
     ScratchPad.recorded.should == :extended
   end
 
-  it "does not copy own tainted status to the given object" do
-    other = Object.new
-    Module.new.taint.send :extend_object, other
-    other.tainted?.should be_false
-  end
+  ruby_version_is ''...'2.7' do
+    it "does not copy own tainted status to the given object" do
+      other = Object.new
+      Module.new.taint.send :extend_object, other
+      other.tainted?.should be_false
+    end
 
-  it "does not copy own untrusted status to the given object" do
-    other = Object.new
-    Module.new.untrust.send :extend_object, other
-    other.untrusted?.should be_false
+    it "does not copy own untrusted status to the given object" do
+      other = Object.new
+      Module.new.untrust.send :extend_object, other
+      other.untrusted?.should be_false
+    end
   end
 
   describe "when given a frozen object" do

--- a/spec/ruby/core/module/prepend_features_spec.rb
+++ b/spec/ruby/core/module/prepend_features_spec.rb
@@ -28,16 +28,18 @@ describe "Module#prepend_features" do
     }.should raise_error(ArgumentError)
   end
 
-  it "copies own tainted status to the given module" do
-    other = Module.new
-    Module.new.taint.send :prepend_features, other
-    other.tainted?.should be_true
-  end
+  ruby_version_is ''...'2.7' do
+    it "copies own tainted status to the given module" do
+      other = Module.new
+      Module.new.taint.send :prepend_features, other
+      other.tainted?.should be_true
+    end
 
-  it "copies own untrusted status to the given module" do
-    other = Module.new
-    Module.new.untrust.send :prepend_features, other
-    other.untrusted?.should be_true
+    it "copies own untrusted status to the given module" do
+      other = Module.new
+      Module.new.untrust.send :prepend_features, other
+      other.untrusted?.should be_true
+    end
   end
 
   it "clears caches of the given module" do

--- a/spec/ruby/core/range/inspect_spec.rb
+++ b/spec/ruby/core/range/inspect_spec.rb
@@ -12,15 +12,17 @@ describe "Range#inspect" do
     (0.5..2.4).inspect.should == "0.5..2.4"
   end
 
-  it "returns a tainted string if either end is tainted" do
-    (("a".taint)..."c").inspect.tainted?.should be_true
-    ("a"...("c".taint)).inspect.tainted?.should be_true
-    ("a"..."c").taint.inspect.tainted?.should be_true
-  end
+  ruby_version_is ''...'2.7' do
+    it "returns a tainted string if either end is tainted" do
+      (("a".taint)..."c").inspect.tainted?.should be_true
+      ("a"...("c".taint)).inspect.tainted?.should be_true
+      ("a"..."c").taint.inspect.tainted?.should be_true
+    end
 
-  it "returns a untrusted string if either end is untrusted" do
-    (("a".untrust)..."c").inspect.untrusted?.should be_true
-    ("a"...("c".untrust)).inspect.untrusted?.should be_true
-    ("a"..."c").untrust.inspect.untrusted?.should be_true
+    it "returns a untrusted string if either end is untrusted" do
+      (("a".untrust)..."c").inspect.untrusted?.should be_true
+      ("a"...("c".untrust)).inspect.untrusted?.should be_true
+      ("a"..."c").untrust.inspect.untrusted?.should be_true
+    end
   end
 end

--- a/spec/ruby/core/range/to_s_spec.rb
+++ b/spec/ruby/core/range/to_s_spec.rb
@@ -11,15 +11,17 @@ describe "Range#to_s" do
     (0.5..2.4).to_s.should == "0.5..2.4"
   end
 
-  it "returns a tainted string if either end is tainted" do
-    (("a".taint)..."c").to_s.tainted?.should be_true
-    ("a"...("c".taint)).to_s.tainted?.should be_true
-    ("a"..."c").taint.to_s.tainted?.should be_true
-  end
+  ruby_version_is ''...'2.7' do
+    it "returns a tainted string if either end is tainted" do
+      (("a".taint)..."c").to_s.tainted?.should be_true
+      ("a"...("c".taint)).to_s.tainted?.should be_true
+      ("a"..."c").taint.to_s.tainted?.should be_true
+    end
 
-  it "returns a untrusted string if either end is untrusted" do
-    (("a".untrust)..."c").to_s.untrusted?.should be_true
-    ("a"...("c".untrust)).to_s.untrusted?.should be_true
-    ("a"..."c").untrust.to_s.untrusted?.should be_true
+    it "returns a untrusted string if either end is untrusted" do
+      (("a".untrust)..."c").to_s.untrusted?.should be_true
+      ("a"...("c".untrust)).to_s.untrusted?.should be_true
+      ("a"..."c").untrust.to_s.untrusted?.should be_true
+    end
   end
 end

--- a/spec/ruby/core/string/b_spec.rb
+++ b/spec/ruby/core/string/b_spec.rb
@@ -13,10 +13,12 @@ describe "String#b" do
     str.should == "こんちには"
   end
 
-  it "copies own tainted/untrusted status to the returning value" do
-    utf_8 = "こんちには".taint.untrust
-    ret = utf_8.b
-    ret.tainted?.should be_true
-    ret.untrusted?.should be_true
+  ruby_version_is ''...'2.7' do
+    it "copies own tainted/untrusted status to the returning value" do
+      utf_8 = "こんちには".taint.untrust
+      ret = utf_8.b
+      ret.tainted?.should be_true
+      ret.untrusted?.should be_true
+    end
   end
 end

--- a/spec/ruby/core/string/capitalize_spec.rb
+++ b/spec/ruby/core/string/capitalize_spec.rb
@@ -12,9 +12,11 @@ describe "String#capitalize" do
     "123ABC".capitalize.should == "123abc"
   end
 
-  it "taints resulting string when self is tainted" do
-    "".taint.capitalize.tainted?.should == true
-    "hello".taint.capitalize.tainted?.should == true
+  ruby_version_is ''...'2.7' do
+    it "taints resulting string when self is tainted" do
+      "".taint.capitalize.tainted?.should == true
+      "hello".taint.capitalize.tainted?.should == true
+    end
   end
 
   describe "full Unicode case mapping" do

--- a/spec/ruby/core/string/center_spec.rb
+++ b/spec/ruby/core/string/center_spec.rb
@@ -47,12 +47,14 @@ describe "String#center with length, padding" do
     "radiology".center(8, '-').should == "radiology"
   end
 
-  it "taints result when self or padstr is tainted" do
-    "x".taint.center(4).tainted?.should == true
-    "x".taint.center(0).tainted?.should == true
-    "".taint.center(0).tainted?.should == true
-    "x".taint.center(4, "*").tainted?.should == true
-    "x".center(4, "*".taint).tainted?.should == true
+  ruby_version_is ''...'2.7' do
+    it "taints result when self or padstr is tainted" do
+      "x".taint.center(4).tainted?.should == true
+      "x".taint.center(0).tainted?.should == true
+      "".taint.center(0).tainted?.should == true
+      "x".taint.center(4, "*").tainted?.should == true
+      "x".center(4, "*".taint).tainted?.should == true
+    end
   end
 
   it "calls #to_int to convert length to an integer" do
@@ -98,10 +100,12 @@ describe "String#center with length, padding" do
     "foo".center(10, StringSpecs::MyString.new("x")).should be_an_instance_of(String)
   end
 
-  it "when padding is tainted and self is untainted returns a tainted string if and only if length is longer than self" do
-    "hello".center(4, 'X'.taint).tainted?.should be_false
-    "hello".center(5, 'X'.taint).tainted?.should be_false
-    "hello".center(6, 'X'.taint).tainted?.should be_true
+  ruby_version_is ''...'2.7' do
+    it "when padding is tainted and self is untainted returns a tainted string if and only if length is longer than self" do
+      "hello".center(4, 'X'.taint).tainted?.should be_false
+      "hello".center(5, 'X'.taint).tainted?.should be_false
+      "hello".center(6, 'X'.taint).tainted?.should be_true
+    end
   end
 
   describe "with width" do

--- a/spec/ruby/core/string/chomp_spec.rb
+++ b/spec/ruby/core/string/chomp_spec.rb
@@ -38,8 +38,10 @@ describe "String#chomp" do
       "".chomp.should == ""
     end
 
-    it "taints the result if self is tainted" do
-      "abc".taint.chomp.tainted?.should be_true
+    ruby_version_is ''...'2.7' do
+      it "taints the result if self is tainted" do
+        "abc".taint.chomp.tainted?.should be_true
+      end
     end
 
     it "returns subclass instances when called on a subclass" do
@@ -63,8 +65,10 @@ describe "String#chomp" do
       str.chomp(nil).should_not equal(str)
     end
 
-    it "taints the result if self is tainted" do
-      "abc".taint.chomp(nil).tainted?.should be_true
+    ruby_version_is ''...'2.7' do
+      it "taints the result if self is tainted" do
+        "abc".taint.chomp(nil).tainted?.should be_true
+      end
     end
 
     it "returns an empty String when self is empty" do
@@ -93,8 +97,10 @@ describe "String#chomp" do
       "abc\r\n\r\n\r\n".chomp("").should == "abc"
     end
 
-    it "taints the result if self is tainted" do
-      "abc".taint.chomp("").tainted?.should be_true
+    ruby_version_is ''...'2.7' do
+      it "taints the result if self is tainted" do
+        "abc".taint.chomp("").tainted?.should be_true
+      end
     end
 
     it "returns an empty String when self is empty" do
@@ -115,8 +121,10 @@ describe "String#chomp" do
       "abc\r\n\r\n".chomp("\n").should == "abc\r\n"
     end
 
-    it "taints the result if self is tainted" do
-      "abc".taint.chomp("\n").tainted?.should be_true
+    ruby_version_is ''...'2.7' do
+      it "taints the result if self is tainted" do
+        "abc".taint.chomp("\n").tainted?.should be_true
+      end
     end
 
     it "returns an empty String when self is empty" do
@@ -151,12 +159,14 @@ describe "String#chomp" do
       "".chomp("abc").should == ""
     end
 
-    it "taints the result if self is tainted" do
-      "abc".taint.chomp("abc").tainted?.should be_true
-    end
+    ruby_version_is ''...'2.7' do
+      it "taints the result if self is tainted" do
+        "abc".taint.chomp("abc").tainted?.should be_true
+      end
 
-    it "does not taint the result when the argument is tainted" do
-      "abc".chomp("abc".taint).tainted?.should be_false
+      it "does not taint the result when the argument is tainted" do
+        "abc".chomp("abc".taint).tainted?.should be_false
+      end
     end
 
     it "returns an empty String when the argument equals self" do
@@ -201,8 +211,10 @@ describe "String#chomp!" do
       "".chomp!.should be_nil
     end
 
-    it "taints the result if self is tainted" do
-      "abc\n".taint.chomp!.tainted?.should be_true
+    ruby_version_is ''...'2.7' do
+      it "taints the result if self is tainted" do
+        "abc\n".taint.chomp!.tainted?.should be_true
+      end
     end
 
     it "returns subclass instances when called on a subclass" do
@@ -247,8 +259,10 @@ describe "String#chomp!" do
       "abc\r\n\r\n\r\n".chomp!("").should == "abc"
     end
 
-    it "taints the result if self is tainted" do
-      "abc\n".taint.chomp!("").tainted?.should be_true
+    ruby_version_is ''...'2.7' do
+      it "taints the result if self is tainted" do
+        "abc\n".taint.chomp!("").tainted?.should be_true
+      end
     end
 
     it "returns nil when self is empty" do
@@ -269,8 +283,10 @@ describe "String#chomp!" do
       "abc\r\n\r\n".chomp!("\n").should == "abc\r\n"
     end
 
-    it "taints the result if self is tainted" do
-      "abc\n".taint.chomp!("\n").tainted?.should be_true
+    ruby_version_is ''...'2.7' do
+      it "taints the result if self is tainted" do
+        "abc\n".taint.chomp!("\n").tainted?.should be_true
+      end
     end
 
     it "returns nil when self is empty" do
@@ -305,12 +321,14 @@ describe "String#chomp!" do
       "".chomp!("abc").should be_nil
     end
 
-    it "taints the result if self is tainted" do
-      "abc".taint.chomp!("abc").tainted?.should be_true
-    end
+    ruby_version_is ''...'2.7' do
+      it "taints the result if self is tainted" do
+        "abc".taint.chomp!("abc").tainted?.should be_true
+      end
 
-    it "does not taint the result when the argument is tainted" do
-      "abc".chomp!("abc".taint).tainted?.should be_false
+      it "does not taint the result when the argument is tainted" do
+        "abc".chomp!("abc".taint).tainted?.should be_false
+      end
     end
   end
 

--- a/spec/ruby/core/string/chop_spec.rb
+++ b/spec/ruby/core/string/chop_spec.rb
@@ -49,14 +49,16 @@ describe "String#chop" do
     s.chop.should_not equal(s)
   end
 
-  it "taints result when self is tainted" do
-    "hello".taint.chop.tainted?.should == true
-    "".taint.chop.tainted?.should == true
-  end
+  ruby_version_is ''...'2.7' do
+    it "taints result when self is tainted" do
+      "hello".taint.chop.tainted?.should == true
+      "".taint.chop.tainted?.should == true
+    end
 
-  it "untrusts result when self is untrusted" do
-    "hello".untrust.chop.untrusted?.should == true
-    "".untrust.chop.untrusted?.should == true
+    it "untrusts result when self is untrusted" do
+      "hello".untrust.chop.untrusted?.should == true
+      "".untrust.chop.untrusted?.should == true
+    end
   end
 
   it "returns subclass instances when called on a subclass" do

--- a/spec/ruby/core/string/crypt_spec.rb
+++ b/spec/ruby/core/string/crypt_spec.rb
@@ -25,17 +25,19 @@ describe "String#crypt" do
       "mypassword".crypt(obj).should == "$2a$04$0WVaz0pV3jzfZ5G5tpmHWuBQGbkjzgtSc3gJbmdy0GAGMa45MFM2."
     end
 
-    it "taints the result if either salt or self is tainted" do
-      tainted_salt = "$2a$04$0WVaz0pV3jzfZ5G5tpmHWu"
-      tainted_str = "mypassword"
+    ruby_version_is ''...'2.7' do
+      it "taints the result if either salt or self is tainted" do
+        tainted_salt = "$2a$04$0WVaz0pV3jzfZ5G5tpmHWu"
+        tainted_str = "mypassword"
 
-      tainted_salt.taint
-      tainted_str.taint
+        tainted_salt.taint
+        tainted_str.taint
 
-      "mypassword".crypt("$2a$04$0WVaz0pV3jzfZ5G5tpmHWu").tainted?.should == false
-      tainted_str.crypt("$2a$04$0WVaz0pV3jzfZ5G5tpmHWu").tainted?.should == true
-      "mypassword".crypt(tainted_salt).tainted?.should == true
-      tainted_str.crypt(tainted_salt).tainted?.should == true
+        "mypassword".crypt("$2a$04$0WVaz0pV3jzfZ5G5tpmHWu").tainted?.should == false
+        tainted_str.crypt("$2a$04$0WVaz0pV3jzfZ5G5tpmHWu").tainted?.should == true
+        "mypassword".crypt(tainted_salt).tainted?.should == true
+        tainted_str.crypt(tainted_salt).tainted?.should == true
+      end
     end
 
     it "doesn't return subclass instances" do
@@ -83,17 +85,19 @@ describe "String#crypt" do
       "".crypt(obj).should == "aaQSqAReePlq6"
     end
 
-    it "taints the result if either salt or self is tainted" do
-      tainted_salt = "aa"
-      tainted_str = "hello"
+    ruby_version_is ''...'2.7' do
+      it "taints the result if either salt or self is tainted" do
+        tainted_salt = "aa"
+        tainted_str = "hello"
 
-      tainted_salt.taint
-      tainted_str.taint
+        tainted_salt.taint
+        tainted_str.taint
 
-      "hello".crypt("aa").tainted?.should == false
-      tainted_str.crypt("aa").tainted?.should == true
-      "hello".crypt(tainted_salt).tainted?.should == true
-      tainted_str.crypt(tainted_salt).tainted?.should == true
+        "hello".crypt("aa").tainted?.should == false
+        tainted_str.crypt("aa").tainted?.should == true
+        "hello".crypt(tainted_salt).tainted?.should == true
+        tainted_str.crypt(tainted_salt).tainted?.should == true
+      end
     end
 
     it "doesn't return subclass instances" do

--- a/spec/ruby/core/string/delete_prefix_spec.rb
+++ b/spec/ruby/core/string/delete_prefix_spec.rb
@@ -22,9 +22,11 @@ ruby_version_is '2.5' do
       r.should == s
     end
 
-    it "taints resulting strings when other is tainted" do
-      'hello'.taint.delete_prefix('hell').tainted?.should == true
-      'hello'.taint.delete_prefix('').tainted?.should == true
+    ruby_version_is ''...'2.7' do
+      it "taints resulting strings when other is tainted" do
+        'hello'.taint.delete_prefix('hell').tainted?.should == true
+        'hello'.taint.delete_prefix('').tainted?.should == true
+      end
     end
 
     it "doesn't set $~" do

--- a/spec/ruby/core/string/delete_spec.rb
+++ b/spec/ruby/core/string/delete_spec.rb
@@ -68,11 +68,13 @@ describe "String#delete" do
     -> { "hello".delete("^h-e") }.should raise_error(ArgumentError)
   end
 
-  it "taints result when self is tainted" do
-    "hello".taint.delete("e").tainted?.should == true
-    "hello".taint.delete("a-z").tainted?.should == true
+  ruby_version_is ''...'2.7' do
+    it "taints result when self is tainted" do
+      "hello".taint.delete("e").tainted?.should == true
+      "hello".taint.delete("a-z").tainted?.should == true
 
-    "hello".delete("e".taint).tainted?.should == false
+      "hello".delete("e".taint).tainted?.should == false
+    end
   end
 
   it "tries to convert each set arg to a string using to_str" do

--- a/spec/ruby/core/string/delete_suffix_spec.rb
+++ b/spec/ruby/core/string/delete_suffix_spec.rb
@@ -22,9 +22,11 @@ ruby_version_is '2.5' do
       r.should == s
     end
 
-    it "taints resulting strings when other is tainted" do
-      'hello'.taint.delete_suffix('ello').tainted?.should == true
-      'hello'.taint.delete_suffix('').tainted?.should == true
+    ruby_version_is ''...'2.7' do
+      it "taints resulting strings when other is tainted" do
+        'hello'.taint.delete_suffix('ello').tainted?.should == true
+        'hello'.taint.delete_suffix('').tainted?.should == true
+      end
     end
 
     it "doesn't set $~" do

--- a/spec/ruby/core/string/downcase_spec.rb
+++ b/spec/ruby/core/string/downcase_spec.rb
@@ -68,10 +68,12 @@ describe "String#downcase" do
     -> { "ABC".downcase(:invalid_option) }.should raise_error(ArgumentError)
   end
 
-  it "taints result when self is tainted" do
-    "".taint.downcase.tainted?.should == true
-    "x".taint.downcase.tainted?.should == true
-    "X".taint.downcase.tainted?.should == true
+  ruby_version_is ''...'2.7' do
+    it "taints result when self is tainted" do
+      "".taint.downcase.tainted?.should == true
+      "x".taint.downcase.tainted?.should == true
+      "X".taint.downcase.tainted?.should == true
+    end
   end
 
   it "returns a subclass instance for subclasses" do

--- a/spec/ruby/core/string/dump_spec.rb
+++ b/spec/ruby/core/string/dump_spec.rb
@@ -3,14 +3,16 @@ require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
 describe "String#dump" do
-  it "taints the result if self is tainted" do
-    "foo".taint.dump.tainted?.should == true
-    "foo\n".taint.dump.tainted?.should == true
-  end
+  ruby_version_is ''...'2.7' do
+    it "taints the result if self is tainted" do
+      "foo".taint.dump.tainted?.should == true
+      "foo\n".taint.dump.tainted?.should == true
+    end
 
-  it "untrusts the result if self is untrusted" do
-    "foo".untrust.dump.untrusted?.should == true
-    "foo\n".untrust.dump.untrusted?.should == true
+    it "untrusts the result if self is untrusted" do
+      "foo".untrust.dump.untrusted?.should == true
+      "foo\n".untrust.dump.untrusted?.should == true
+    end
   end
 
   it "does not take into account if a string is frozen" do

--- a/spec/ruby/core/string/element_set_spec.rb
+++ b/spec/ruby/core/string/element_set_spec.rb
@@ -14,14 +14,16 @@ describe "String#[]= with Fixnum index" do
     a.should == "bamelo"
   end
 
-  it "taints self if other_str is tainted" do
-    a = "hello"
-    a[0] = "".taint
-    a.tainted?.should == true
+  ruby_version_is ''...'2.7' do
+    it "taints self if other_str is tainted" do
+      a = "hello"
+      a[0] = "".taint
+      a.tainted?.should == true
 
-    a = "hello"
-    a[0] = "x".taint
-    a.tainted?.should == true
+      a = "hello"
+      a[0] = "x".taint
+      a.tainted?.should == true
+    end
   end
 
   it "raises an IndexError without changing self if idx is outside of self" do
@@ -485,14 +487,16 @@ describe "String#[]= with Fixnum index, count" do
     a.should == "hellobob"
   end
 
-  it "taints self if other_str is tainted" do
-    a = "hello"
-    a[0, 0] = "".taint
-    a.tainted?.should == true
+  ruby_version_is ''...'2.7' do
+    it "taints self if other_str is tainted" do
+      a = "hello"
+      a[0, 0] = "".taint
+      a.tainted?.should == true
 
-    a = "hello"
-    a[1, 4] = "x".taint
-    a.tainted?.should == true
+      a = "hello"
+      a[1, 4] = "x".taint
+      a.tainted?.should == true
+    end
   end
 
   it "calls #to_int to convert the index and count objects" do

--- a/spec/ruby/core/string/gsub_spec.rb
+++ b/spec/ruby/core/string/gsub_spec.rb
@@ -160,24 +160,26 @@ describe "String#gsub with pattern and replacement" do
 
   it_behaves_like :string_gsub_named_capture, :gsub
 
-  it "taints the result if the original string or replacement is tainted" do
-    hello = "hello"
-    hello_t = "hello"
-    a = "a"
-    a_t = "a"
-    empty = ""
-    empty_t = ""
+  ruby_version_is ''...'2.7' do
+    it "taints the result if the original string or replacement is tainted" do
+      hello = "hello"
+      hello_t = "hello"
+      a = "a"
+      a_t = "a"
+      empty = ""
+      empty_t = ""
 
-    hello_t.taint; a_t.taint; empty_t.taint
+      hello_t.taint; a_t.taint; empty_t.taint
 
-    hello_t.gsub(/./, a).tainted?.should == true
-    hello_t.gsub(/./, empty).tainted?.should == true
+      hello_t.gsub(/./, a).tainted?.should == true
+      hello_t.gsub(/./, empty).tainted?.should == true
 
-    hello.gsub(/./, a_t).tainted?.should == true
-    hello.gsub(/./, empty_t).tainted?.should == true
-    hello.gsub(//, empty_t).tainted?.should == true
+      hello.gsub(/./, a_t).tainted?.should == true
+      hello.gsub(/./, empty_t).tainted?.should == true
+      hello.gsub(//, empty_t).tainted?.should == true
 
-    hello.gsub(//.taint, "foo").tainted?.should == false
+      hello.gsub(//.taint, "foo").tainted?.should == false
+    end
   end
 
   it "handles pattern collapse" do
@@ -186,24 +188,26 @@ describe "String#gsub with pattern and replacement" do
     str.gsub(reg, ".").should == ".こ.に.ち.わ."
   end
 
-  it "untrusts the result if the original string or replacement is untrusted" do
-    hello = "hello"
-    hello_t = "hello"
-    a = "a"
-    a_t = "a"
-    empty = ""
-    empty_t = ""
+  ruby_version_is ''...'2.7' do
+    it "untrusts the result if the original string or replacement is untrusted" do
+      hello = "hello"
+      hello_t = "hello"
+      a = "a"
+      a_t = "a"
+      empty = ""
+      empty_t = ""
 
-    hello_t.untrust; a_t.untrust; empty_t.untrust
+      hello_t.untrust; a_t.untrust; empty_t.untrust
 
-    hello_t.gsub(/./, a).untrusted?.should == true
-    hello_t.gsub(/./, empty).untrusted?.should == true
+      hello_t.gsub(/./, a).untrusted?.should == true
+      hello_t.gsub(/./, empty).untrusted?.should == true
 
-    hello.gsub(/./, a_t).untrusted?.should == true
-    hello.gsub(/./, empty_t).untrusted?.should == true
-    hello.gsub(//, empty_t).untrusted?.should == true
+      hello.gsub(/./, a_t).untrusted?.should == true
+      hello.gsub(/./, empty_t).untrusted?.should == true
+      hello.gsub(//, empty_t).untrusted?.should == true
 
-    hello.gsub(//.untrust, "foo").untrusted?.should == false
+      hello.gsub(//.untrust, "foo").untrusted?.should == false
+    end
   end
 
   it "tries to convert pattern to a string using to_str" do
@@ -322,26 +326,27 @@ describe "String#gsub with pattern and Hash" do
     "hello".gsub(/(.+)/, 'hello' => repl ).should == repl
   end
 
-  it "untrusts the result if the original string is untrusted" do
-    str = "Ghana".untrust
-    str.gsub(/[Aa]na/, 'ana' => '').untrusted?.should be_true
-  end
+  ruby_version_is ''...'2.7' do
+    it "untrusts the result if the original string is untrusted" do
+      str = "Ghana".untrust
+      str.gsub(/[Aa]na/, 'ana' => '').untrusted?.should be_true
+    end
 
-  it "untrusts the result if a hash value is untrusted" do
-    str = "Ghana"
-    str.gsub(/a$/, 'a' => 'di'.untrust).untrusted?.should be_true
-  end
+    it "untrusts the result if a hash value is untrusted" do
+      str = "Ghana"
+      str.gsub(/a$/, 'a' => 'di'.untrust).untrusted?.should be_true
+    end
 
-  it "taints the result if the original string is tainted" do
-    str = "Ghana".taint
-    str.gsub(/[Aa]na/, 'ana' => '').tainted?.should be_true
-  end
+    it "taints the result if the original string is tainted" do
+      str = "Ghana".taint
+      str.gsub(/[Aa]na/, 'ana' => '').tainted?.should be_true
+    end
 
-  it "taints the result if a hash value is tainted" do
-    str = "Ghana"
-    str.gsub(/a$/, 'a' => 'di'.taint).tainted?.should be_true
+    it "taints the result if a hash value is tainted" do
+      str = "Ghana"
+      str.gsub(/a$/, 'a' => 'di'.taint).tainted?.should be_true
+    end
   end
-
 end
 
 describe "String#gsub! with pattern and Hash" do
@@ -411,26 +416,27 @@ describe "String#gsub! with pattern and Hash" do
     "hello".gsub!(/(.+)/, 'hello' => repl ).should == repl
   end
 
-  it "keeps untrusted state" do
-    str = "Ghana".untrust
-    str.gsub!(/[Aa]na/, 'ana' => '').untrusted?.should be_true
-  end
+  ruby_version_is ''...'2.7' do
+    it "keeps untrusted state" do
+      str = "Ghana".untrust
+      str.gsub!(/[Aa]na/, 'ana' => '').untrusted?.should be_true
+    end
 
-  it "untrusts self if a hash value is untrusted" do
-    str = "Ghana"
-    str.gsub!(/a$/, 'a' => 'di'.untrust).untrusted?.should be_true
-  end
+    it "untrusts self if a hash value is untrusted" do
+      str = "Ghana"
+      str.gsub!(/a$/, 'a' => 'di'.untrust).untrusted?.should be_true
+    end
 
-  it "keeps tainted state" do
-    str = "Ghana".taint
-    str.gsub!(/[Aa]na/, 'ana' => '').tainted?.should be_true
-  end
+    it "keeps tainted state" do
+      str = "Ghana".taint
+      str.gsub!(/[Aa]na/, 'ana' => '').tainted?.should be_true
+    end
 
-  it "taints self if a hash value is tainted" do
-    str = "Ghana"
-    str.gsub!(/a$/, 'a' => 'di'.taint).tainted?.should be_true
+    it "taints self if a hash value is tainted" do
+      str = "Ghana"
+      str.gsub!(/a$/, 'a' => 'di'.taint).tainted?.should be_true
+    end
   end
-
 end
 
 describe "String#gsub with pattern and block" do
@@ -504,24 +510,26 @@ describe "String#gsub with pattern and block" do
     "hello".gsub(/.+/) { obj }.should == "ok"
   end
 
-  it "untrusts the result if the original string or replacement is untrusted" do
-    hello = "hello"
-    hello_t = "hello"
-    a = "a"
-    a_t = "a"
-    empty = ""
-    empty_t = ""
+  ruby_version_is ''...'2.7' do
+    it "untrusts the result if the original string or replacement is untrusted" do
+      hello = "hello"
+      hello_t = "hello"
+      a = "a"
+      a_t = "a"
+      empty = ""
+      empty_t = ""
 
-    hello_t.untrust; a_t.untrust; empty_t.untrust
+      hello_t.untrust; a_t.untrust; empty_t.untrust
 
-    hello_t.gsub(/./) { a }.untrusted?.should == true
-    hello_t.gsub(/./) { empty }.untrusted?.should == true
+      hello_t.gsub(/./) { a }.untrusted?.should == true
+      hello_t.gsub(/./) { empty }.untrusted?.should == true
 
-    hello.gsub(/./) { a_t }.untrusted?.should == true
-    hello.gsub(/./) { empty_t }.untrusted?.should == true
-    hello.gsub(//) { empty_t }.untrusted?.should == true
+      hello.gsub(/./) { a_t }.untrusted?.should == true
+      hello.gsub(/./) { empty_t }.untrusted?.should == true
+      hello.gsub(//) { empty_t }.untrusted?.should == true
 
-    hello.gsub(//.untrust) { "foo" }.untrusted?.should == false
+      hello.gsub(//.untrust) { "foo" }.untrusted?.should == false
+    end
   end
 
   it "uses the compatible encoding if they are compatible" do
@@ -583,16 +591,18 @@ describe "String#gsub! with pattern and replacement" do
     a.should == "*¿** **é*?*"
   end
 
-  it "taints self if replacement is tainted" do
-    a = "hello"
-    a.gsub!(/./.taint, "foo").tainted?.should == false
-    a.gsub!(/./, "foo".taint).tainted?.should == true
-  end
+  ruby_version_is ''...'2.7' do
+    it "taints self if replacement is tainted" do
+      a = "hello"
+      a.gsub!(/./.taint, "foo").tainted?.should == false
+      a.gsub!(/./, "foo".taint).tainted?.should == true
+    end
 
-  it "untrusts self if replacement is untrusted" do
-    a = "hello"
-    a.gsub!(/./.untrust, "foo").untrusted?.should == false
-    a.gsub!(/./, "foo".untrust).untrusted?.should == true
+    it "untrusts self if replacement is untrusted" do
+      a = "hello"
+      a.gsub!(/./.untrust, "foo").untrusted?.should == false
+      a.gsub!(/./, "foo".untrust).untrusted?.should == true
+    end
   end
 
   it "returns nil if no modifications were made" do
@@ -620,16 +630,18 @@ describe "String#gsub! with pattern and block" do
     a.should == "h*ll*"
   end
 
-  it "taints self if block's result is tainted" do
-    a = "hello"
-    a.gsub!(/./.taint) { "foo" }.tainted?.should == false
-    a.gsub!(/./) { "foo".taint }.tainted?.should == true
-  end
+  ruby_version_is ''...'2.7' do
+    it "taints self if block's result is tainted" do
+      a = "hello"
+      a.gsub!(/./.taint) { "foo" }.tainted?.should == false
+      a.gsub!(/./) { "foo".taint }.tainted?.should == true
+    end
 
-  it "untrusts self if block's result is untrusted" do
-    a = "hello"
-    a.gsub!(/./.untrust) { "foo" }.untrusted?.should == false
-    a.gsub!(/./) { "foo".untrust }.untrusted?.should == true
+    it "untrusts self if block's result is untrusted" do
+      a = "hello"
+      a.gsub!(/./.untrust) { "foo" }.untrusted?.should == false
+      a.gsub!(/./) { "foo".untrust }.untrusted?.should == true
+    end
   end
 
   it "returns nil if no modifications were made" do

--- a/spec/ruby/core/string/insert_spec.rb
+++ b/spec/ruby/core/string/insert_spec.rb
@@ -41,14 +41,16 @@ describe "String#insert with index, other" do
     "abcd".insert(-3, other).should == "abXYZcd"
   end
 
-  it "taints self if string to insert is tainted" do
-    str = "abcd"
-    str.insert(0, "T".taint).tainted?.should == true
+  ruby_version_is ''...'2.7' do
+    it "taints self if string to insert is tainted" do
+      str = "abcd"
+      str.insert(0, "T".taint).tainted?.should == true
 
-    str = "abcd"
-    other = mock('T')
-    def other.to_str() "T".taint end
-    str.insert(0, other).tainted?.should == true
+      str = "abcd"
+      other = mock('T')
+      def other.to_str() "T".taint end
+      str.insert(0, other).tainted?.should == true
+    end
   end
 
   it "raises a TypeError if other can't be converted to string" do

--- a/spec/ruby/core/string/inspect_spec.rb
+++ b/spec/ruby/core/string/inspect_spec.rb
@@ -3,14 +3,16 @@ require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
 describe "String#inspect" do
-  it "taints the result if self is tainted" do
-    "foo".taint.inspect.tainted?.should == true
-    "foo\n".taint.inspect.tainted?.should == true
-  end
+  ruby_version_is ''...'2.7' do
+    it "taints the result if self is tainted" do
+      "foo".taint.inspect.tainted?.should == true
+      "foo\n".taint.inspect.tainted?.should == true
+    end
 
-  it "untrusts the result if self is untrusted" do
-    "foo".untrust.inspect.untrusted?.should == true
-    "foo\n".untrust.inspect.untrusted?.should == true
+    it "untrusts the result if self is untrusted" do
+      "foo".untrust.inspect.untrusted?.should == true
+      "foo\n".untrust.inspect.untrusted?.should == true
+    end
   end
 
   it "does not return a subclass instance" do

--- a/spec/ruby/core/string/ljust_spec.rb
+++ b/spec/ruby/core/string/ljust_spec.rb
@@ -31,12 +31,14 @@ describe "String#ljust with length, padding" do
     "radiology".ljust(8, '-').should == "radiology"
   end
 
-  it "taints result when self or padstr is tainted" do
-    "x".taint.ljust(4).tainted?.should == true
-    "x".taint.ljust(0).tainted?.should == true
-    "".taint.ljust(0).tainted?.should == true
-    "x".taint.ljust(4, "*").tainted?.should == true
-    "x".ljust(4, "*".taint).tainted?.should == true
+  ruby_version_is ''...'2.7' do
+    it "taints result when self or padstr is tainted" do
+      "x".taint.ljust(4).tainted?.should == true
+      "x".taint.ljust(0).tainted?.should == true
+      "".taint.ljust(0).tainted?.should == true
+      "x".taint.ljust(4, "*").tainted?.should == true
+      "x".ljust(4, "*".taint).tainted?.should == true
+    end
   end
 
   it "tries to convert length to an integer using to_int" do
@@ -81,10 +83,12 @@ describe "String#ljust with length, padding" do
     "foo".ljust(10, StringSpecs::MyString.new("x")).should be_an_instance_of(String)
   end
 
-  it "when padding is tainted and self is untainted returns a tainted string if and only if length is longer than self" do
-    "hello".ljust(4, 'X'.taint).tainted?.should be_false
-    "hello".ljust(5, 'X'.taint).tainted?.should be_false
-    "hello".ljust(6, 'X'.taint).tainted?.should be_true
+  ruby_version_is ''...'2.7' do
+    it "when padding is tainted and self is untainted returns a tainted string if and only if length is longer than self" do
+      "hello".ljust(4, 'X'.taint).tainted?.should be_false
+      "hello".ljust(5, 'X'.taint).tainted?.should be_false
+      "hello".ljust(6, 'X'.taint).tainted?.should be_true
+    end
   end
 
   describe "with width" do

--- a/spec/ruby/core/string/lstrip_spec.rb
+++ b/spec/ruby/core/string/lstrip_spec.rb
@@ -14,10 +14,12 @@ describe "String#lstrip" do
    "\x00hello".lstrip.should == "\x00hello"
   end
 
-  it "taints the result when self is tainted" do
-    "".taint.lstrip.tainted?.should == true
-    "ok".taint.lstrip.tainted?.should == true
-    "   ok".taint.lstrip.tainted?.should == true
+  ruby_version_is ''...'2.7' do
+    it "taints the result when self is tainted" do
+      "".taint.lstrip.tainted?.should == true
+      "ok".taint.lstrip.tainted?.should == true
+      "   ok".taint.lstrip.tainted?.should == true
+    end
   end
 end
 

--- a/spec/ruby/core/string/modulo_spec.rb
+++ b/spec/ruby/core/string/modulo_spec.rb
@@ -297,24 +297,26 @@ describe "String#%" do
     end
   end
 
-  it "always taints the result when the format string is tainted" do
-    universal = mock('0')
-    def universal.to_int() 0 end
-    def universal.to_str() "0" end
-    def universal.to_f() 0.0 end
+  ruby_version_is ''...'2.7' do
+    it "always taints the result when the format string is tainted" do
+      universal = mock('0')
+      def universal.to_int() 0 end
+      def universal.to_str() "0" end
+      def universal.to_f() 0.0 end
 
-    [
-      "", "foo",
-      "%b", "%B", "%c", "%d", "%e", "%E",
-      "%f", "%g", "%G", "%i", "%o", "%p",
-      "%s", "%u", "%x", "%X"
-    ].each do |format|
-      subcls_format = StringSpecs::MyString.new(format)
-      subcls_format.taint
-      format.taint
+      [
+        "", "foo",
+        "%b", "%B", "%c", "%d", "%e", "%E",
+        "%f", "%g", "%G", "%i", "%o", "%p",
+        "%s", "%u", "%x", "%X"
+      ].each do |format|
+        subcls_format = StringSpecs::MyString.new(format)
+        subcls_format.taint
+        format.taint
 
-      (format % universal).tainted?.should == true
-      (subcls_format % universal).tainted?.should == true
+        (format % universal).tainted?.should == true
+        (subcls_format % universal).tainted?.should == true
+      end
     end
   end
 
@@ -571,16 +573,18 @@ describe "String#%" do
     # ("%p" % obj).should == "obj"
   end
 
-  it "taints result for %p when argument.inspect is tainted" do
-    obj = mock('x')
-    def obj.inspect() "x".taint end
+  ruby_version_is ''...'2.7' do
+    it "taints result for %p when argument.inspect is tainted" do
+      obj = mock('x')
+      def obj.inspect() "x".taint end
 
-    ("%p" % obj).tainted?.should == true
+      ("%p" % obj).tainted?.should == true
 
-    obj = mock('x'); obj.taint
-    def obj.inspect() "x" end
+      obj = mock('x'); obj.taint
+      def obj.inspect() "x" end
 
-    ("%p" % obj).tainted?.should == false
+      ("%p" % obj).tainted?.should == false
+    end
   end
 
   it "supports string formats using %s" do
@@ -611,9 +615,11 @@ describe "String#%" do
     # ("%s" % obj).should == "obj"
   end
 
-  it "taints result for %s when argument is tainted" do
-    ("%s" % "x".taint).tainted?.should == true
-    ("%s" % mock('x').taint).tainted?.should == true
+  ruby_version_is ''...'2.7' do
+    it "taints result for %s when argument is tainted" do
+      ("%s" % "x".taint).tainted?.should == true
+      ("%s" % mock('x').taint).tainted?.should == true
+    end
   end
 
   # MRI crashes on this one.
@@ -776,8 +782,10 @@ describe "String#%" do
       (format % "0xA").should == (format % 0xA)
     end
 
-    it "doesn't taint the result for #{format} when argument is tainted" do
-      (format % "5".taint).tainted?.should == false
+    ruby_version_is ''...'2.7' do
+      it "doesn't taint the result for #{format} when argument is tainted" do
+        (format % "5".taint).tainted?.should == false
+      end
     end
   end
 

--- a/spec/ruby/core/string/plus_spec.rb
+++ b/spec/ruby/core/string/plus_spec.rb
@@ -32,13 +32,15 @@ describe "String#+" do
     ("hello" + StringSpecs::MyString.new("")).should be_an_instance_of(String)
   end
 
-  it "taints the result when self or other is tainted" do
-    strs = ["", "OK", StringSpecs::MyString.new(""), StringSpecs::MyString.new("OK")]
-    strs += strs.map { |s| s.dup.taint }
+  ruby_version_is ''...'2.7' do
+    it "taints the result when self or other is tainted" do
+      strs = ["", "OK", StringSpecs::MyString.new(""), StringSpecs::MyString.new("OK")]
+      strs += strs.map { |s| s.dup.taint }
 
-    strs.each do |str|
-      strs.each do |other|
-        (str + other).tainted?.should == (str.tainted? | other.tainted?)
+      strs.each do |str|
+        strs.each do |other|
+          (str + other).tainted?.should == (str.tainted? | other.tainted?)
+        end
       end
     end
   end

--- a/spec/ruby/core/string/prepend_spec.rb
+++ b/spec/ruby/core/string/prepend_spec.rb
@@ -34,12 +34,14 @@ describe "String#prepend" do
     a.should == "hello world"
   end
 
-  it "taints self if other is tainted" do
-    x = "x"
-    x.prepend("".taint).tainted?.should be_true
+  ruby_version_is ''...'2.7' do
+    it "taints self if other is tainted" do
+      x = "x"
+      x.prepend("".taint).tainted?.should be_true
 
-    x = "x"
-    x.prepend("y".taint).tainted?.should be_true
+      x = "x"
+      x.prepend("y".taint).tainted?.should be_true
+    end
   end
 
   it "takes multiple arguments" do

--- a/spec/ruby/core/string/reverse_spec.rb
+++ b/spec/ruby/core/string/reverse_spec.rb
@@ -10,9 +10,11 @@ describe "String#reverse" do
     "".reverse.should == ""
   end
 
-  it "taints the result if self is tainted" do
-    "".taint.reverse.tainted?.should == true
-    "m".taint.reverse.tainted?.should == true
+  ruby_version_is ''...'2.7' do
+    it "taints the result if self is tainted" do
+      "".taint.reverse.tainted?.should == true
+      "m".taint.reverse.tainted?.should == true
+    end
   end
 
   it "reverses a string with multi byte characters" do

--- a/spec/ruby/core/string/rjust_spec.rb
+++ b/spec/ruby/core/string/rjust_spec.rb
@@ -31,12 +31,14 @@ describe "String#rjust with length, padding" do
     "radiology".rjust(8, '-').should == "radiology"
   end
 
-  it "taints result when self or padstr is tainted" do
-    "x".taint.rjust(4).tainted?.should == true
-    "x".taint.rjust(0).tainted?.should == true
-    "".taint.rjust(0).tainted?.should == true
-    "x".taint.rjust(4, "*").tainted?.should == true
-    "x".rjust(4, "*".taint).tainted?.should == true
+  ruby_version_is ''...'2.7' do
+    it "taints result when self or padstr is tainted" do
+      "x".taint.rjust(4).tainted?.should == true
+      "x".taint.rjust(0).tainted?.should == true
+      "".taint.rjust(0).tainted?.should == true
+      "x".taint.rjust(4, "*").tainted?.should == true
+      "x".rjust(4, "*".taint).tainted?.should == true
+    end
   end
 
   it "tries to convert length to an integer using to_int" do
@@ -81,10 +83,12 @@ describe "String#rjust with length, padding" do
     "foo".rjust(10, StringSpecs::MyString.new("x")).should be_an_instance_of(String)
   end
 
-  it "when padding is tainted and self is untainted returns a tainted string if and only if length is longer than self" do
-    "hello".rjust(4, 'X'.taint).tainted?.should be_false
-    "hello".rjust(5, 'X'.taint).tainted?.should be_false
-    "hello".rjust(6, 'X'.taint).tainted?.should be_true
+  ruby_version_is ''...'2.7' do
+    it "when padding is tainted and self is untainted returns a tainted string if and only if length is longer than self" do
+      "hello".rjust(4, 'X'.taint).tainted?.should be_false
+      "hello".rjust(5, 'X'.taint).tainted?.should be_false
+      "hello".rjust(6, 'X'.taint).tainted?.should be_true
+    end
   end
 
   describe "with width" do

--- a/spec/ruby/core/string/rstrip_spec.rb
+++ b/spec/ruby/core/string/rstrip_spec.rb
@@ -14,10 +14,12 @@ describe "String#rstrip" do
     "\x00 \x00hello\x00 \x00".rstrip.should == "\x00 \x00hello"
   end
 
-  it "taints the result when self is tainted" do
-    "".taint.rstrip.tainted?.should == true
-    "ok".taint.rstrip.tainted?.should == true
-    "ok    ".taint.rstrip.tainted?.should == true
+  ruby_version_is ''...'2.7' do
+    it "taints the result when self is tainted" do
+      "".taint.rstrip.tainted?.should == true
+      "ok".taint.rstrip.tainted?.should == true
+      "ok    ".taint.rstrip.tainted?.should == true
+    end
   end
 end
 

--- a/spec/ruby/core/string/scan_spec.rb
+++ b/spec/ruby/core/string/scan_spec.rb
@@ -65,24 +65,26 @@ describe "String#scan" do
     -> { "cruel world".scan(mock('x')) }.should raise_error(TypeError)
   end
 
-  it "taints the results if the String argument is tainted" do
-    a = "hello hello hello".scan("hello".taint)
-    a.each { |m| m.tainted?.should be_true }
-  end
+  ruby_version_is ''...'2.7' do
+    it "taints the results if the String argument is tainted" do
+      a = "hello hello hello".scan("hello".taint)
+      a.each { |m| m.tainted?.should be_true }
+    end
 
-  it "taints the results when passed a String argument if self is tainted" do
-    a = "hello hello hello".taint.scan("hello")
-    a.each { |m| m.tainted?.should be_true }
-  end
+    it "taints the results when passed a String argument if self is tainted" do
+      a = "hello hello hello".taint.scan("hello")
+      a.each { |m| m.tainted?.should be_true }
+    end
 
-  it "taints the results if the Regexp argument is tainted" do
-    a = "hello".scan(/./.taint)
-    a.each { |m| m.tainted?.should be_true }
-  end
+    it "taints the results if the Regexp argument is tainted" do
+      a = "hello".scan(/./.taint)
+      a.each { |m| m.tainted?.should be_true }
+    end
 
-  it "taints the results when passed a Regexp argument if self is tainted" do
-    a = "hello".taint.scan(/./)
-    a.each { |m| m.tainted?.should be_true }
+    it "taints the results when passed a Regexp argument if self is tainted" do
+      a = "hello".taint.scan(/./)
+      a.each { |m| m.tainted?.should be_true }
+    end
   end
 
   # jruby/jruby#5513
@@ -171,20 +173,22 @@ describe "String#scan with pattern and block" do
     $~.should == nil
   end
 
-  it "taints the results if the String argument is tainted" do
-    "hello hello hello".scan("hello".taint).each { |m| m.tainted?.should be_true }
-  end
+  ruby_version_is ''...'2.7' do
+    it "taints the results if the String argument is tainted" do
+      "hello hello hello".scan("hello".taint).each { |m| m.tainted?.should be_true }
+    end
 
-  it "taints the results when passed a String argument if self is tainted" do
-    "hello hello hello".taint.scan("hello").each { |m| m.tainted?.should be_true }
-  end
+    it "taints the results when passed a String argument if self is tainted" do
+      "hello hello hello".taint.scan("hello").each { |m| m.tainted?.should be_true }
+    end
 
-  it "taints the results if the Regexp argument is tainted" do
-    "hello".scan(/./.taint).each { |m| m.tainted?.should be_true }
-  end
+    it "taints the results if the Regexp argument is tainted" do
+      "hello".scan(/./.taint).each { |m| m.tainted?.should be_true }
+    end
 
-  it "taints the results when passed a Regexp argument if self is tainted" do
-    "hello".taint.scan(/./).each { |m| m.tainted?.should be_true }
+    it "taints the results when passed a Regexp argument if self is tainted" do
+      "hello".taint.scan(/./).each { |m| m.tainted?.should be_true }
+    end
   end
 
   it "passes block arguments as individual arguments when blocks are provided" do

--- a/spec/ruby/core/string/shared/chars.rb
+++ b/spec/ruby/core/string/shared/chars.rb
@@ -64,15 +64,17 @@ describe :string_chars, shared: true do
     ]
   end
 
-  it "taints resulting strings when self is tainted" do
-    str = "hello"
+  ruby_version_is ''...'2.7' do
+    it "taints resulting strings when self is tainted" do
+      str = "hello"
 
-    str.send(@method) do |x|
-      x.tainted?.should == false
-    end
+      str.send(@method) do |x|
+        x.tainted?.should == false
+      end
 
-    str.dup.taint.send(@method) do |x|
-      x.tainted?.should == true
+      str.dup.taint.send(@method) do |x|
+        x.tainted?.should == true
+      end
     end
   end
 end

--- a/spec/ruby/core/string/shared/concat.rb
+++ b/spec/ruby/core/string/shared/concat.rb
@@ -39,14 +39,16 @@ describe :string_concat, shared: true do
     str.should be_an_instance_of(StringSpecs::MyString)
   end
 
-  it "taints self if other is tainted" do
-    "x".send(@method, "".taint).tainted?.should == true
-    "x".send(@method, "y".taint).tainted?.should == true
-  end
+  ruby_version_is ''...'2.7' do
+    it "taints self if other is tainted" do
+      "x".send(@method, "".taint).tainted?.should == true
+      "x".send(@method, "y".taint).tainted?.should == true
+    end
 
-  it "untrusts self if other is untrusted" do
-    "x".send(@method, "".untrust).untrusted?.should == true
-    "x".send(@method, "y".untrust).untrusted?.should == true
+    it "untrusts self if other is untrusted" do
+      "x".send(@method, "".untrust).untrusted?.should == true
+      "x".send(@method, "y".untrust).untrusted?.should == true
+    end
   end
 
   describe "with Integer" do

--- a/spec/ruby/core/string/shared/each_line.rb
+++ b/spec/ruby/core/string/shared/each_line.rb
@@ -40,10 +40,12 @@ describe :string_each_line, shared: true do
     b.should == ["foo\n", "🤡🤡🤡🤡🤡🤡🤡\n", "bar\n", "baz\n"]
   end
 
-  it "taints substrings that are passed to the block if self is tainted" do
-    "one\ntwo\r\nthree".taint.send(@method) { |s| s.tainted?.should == true }
+  ruby_version_is ''...'2.7' do
+    it "taints substrings that are passed to the block if self is tainted" do
+      "one\ntwo\r\nthree".taint.send(@method) { |s| s.tainted?.should == true }
 
-    "x.y.".send(@method, ".".taint) { |s| s.tainted?.should == false }
+      "x.y.".send(@method, ".".taint) { |s| s.tainted?.should == false }
+    end
   end
 
   it "passes self as a whole to the block if the separator is nil" do

--- a/spec/ruby/core/string/shared/replace.rb
+++ b/spec/ruby/core/string/shared/replace.rb
@@ -10,32 +10,34 @@ describe :string_replace, shared: true do
     a.should == "another string"
   end
 
-  it "taints self if other is tainted" do
-    a = ""
-    b = "".taint
-    a.send(@method, b)
-    a.tainted?.should == true
-  end
+  ruby_version_is ''...'2.7' do
+    it "taints self if other is tainted" do
+      a = ""
+      b = "".taint
+      a.send(@method, b)
+      a.tainted?.should == true
+    end
 
-  it "does not untaint self if other is untainted" do
-    a = "".taint
-    b = ""
-    a.send(@method, b)
-    a.tainted?.should == true
-  end
+    it "does not untaint self if other is untainted" do
+      a = "".taint
+      b = ""
+      a.send(@method, b)
+      a.tainted?.should == true
+    end
 
-  it "untrusts self if other is untrusted" do
-    a = ""
-    b = "".untrust
-    a.send(@method, b)
-    a.untrusted?.should == true
-  end
+    it "untrusts self if other is untrusted" do
+      a = ""
+      b = "".untrust
+      a.send(@method, b)
+      a.untrusted?.should == true
+    end
 
-  it "does not trust self if other is trusted" do
-    a = "".untrust
-    b = ""
-    a.send(@method, b)
-    a.untrusted?.should == true
+    it "does not trust self if other is trusted" do
+      a = "".untrust
+      b = ""
+      a.send(@method, b)
+      a.untrusted?.should == true
+    end
   end
 
   it "replaces the encoding of self with that of other" do

--- a/spec/ruby/core/string/shared/slice.rb
+++ b/spec/ruby/core/string/shared/slice.rb
@@ -80,13 +80,15 @@ describe :string_slice_index_length, shared: true do
     "hello there".send(@method, -3,2).should == "er"
   end
 
-  it "always taints resulting strings when self is tainted" do
-    str = "hello world"
-    str.taint
+  ruby_version_is ''...'2.7' do
+    it "always taints resulting strings when self is tainted" do
+      str = "hello world"
+      str.taint
 
-    str.send(@method, 0,0).tainted?.should == true
-    str.send(@method, 0,1).tainted?.should == true
-    str.send(@method, 2,1).tainted?.should == true
+      str.send(@method, 0,0).tainted?.should == true
+      str.send(@method, 0,1).tainted?.should == true
+      str.send(@method, 2,1).tainted?.should == true
+    end
   end
 
   it "returns a string with the same encoding" do
@@ -234,16 +236,18 @@ describe :string_slice_range, shared: true do
     "x".send(@method, 1...-1).should == ""
   end
 
-  it "always taints resulting strings when self is tainted" do
-    str = "hello world"
-    str.taint
+  ruby_version_is ''...'2.7' do
+    it "always taints resulting strings when self is tainted" do
+      str = "hello world"
+      str.taint
 
-    str.send(@method, 0..0).tainted?.should == true
-    str.send(@method, 0...0).tainted?.should == true
-    str.send(@method, 0..1).tainted?.should == true
-    str.send(@method, 0...1).tainted?.should == true
-    str.send(@method, 2..3).tainted?.should == true
-    str.send(@method, 2..0).tainted?.should == true
+      str.send(@method, 0..0).tainted?.should == true
+      str.send(@method, 0...0).tainted?.should == true
+      str.send(@method, 0..1).tainted?.should == true
+      str.send(@method, 0...1).tainted?.should == true
+      str.send(@method, 2..3).tainted?.should == true
+      str.send(@method, 2..0).tainted?.should == true
+    end
   end
 
   it "returns subclass instances" do
@@ -302,23 +306,25 @@ describe :string_slice_regexp, shared: true do
   end
 
   not_supported_on :opal do
-    it "always taints resulting strings when self or regexp is tainted" do
-      strs = ["hello world"]
-      strs += strs.map { |s| s.dup.taint }
+    ruby_version_is ''...'2.7' do
+      it "always taints resulting strings when self or regexp is tainted" do
+        strs = ["hello world"]
+        strs += strs.map { |s| s.dup.taint }
 
-      strs.each do |str|
-        str.send(@method, //).tainted?.should == str.tainted?
-        str.send(@method, /hello/).tainted?.should == str.tainted?
+        strs.each do |str|
+          str.send(@method, //).tainted?.should == str.tainted?
+          str.send(@method, /hello/).tainted?.should == str.tainted?
 
-        tainted_re = /./
-        tainted_re.taint
+          tainted_re = /./
+          tainted_re.taint
 
-        str.send(@method, tainted_re).tainted?.should == true
+          str.send(@method, tainted_re).tainted?.should == true
+        end
       end
-    end
 
-    it "returns an untrusted string if the regexp is untrusted" do
-      "hello".send(@method, /./.untrust).untrusted?.should be_true
+      it "returns an untrusted string if the regexp is untrusted" do
+        "hello".send(@method, /./.untrust).untrusted?.should be_true
+      end
     end
   end
 
@@ -352,31 +358,33 @@ describe :string_slice_regexp_index, shared: true do
     "har".send(@method, /(.)(.)(.)/, -3).should == "h"
   end
 
-  it "always taints resulting strings when self or regexp is tainted" do
-    strs = ["hello world"]
-    strs += strs.map { |s| s.dup.taint }
+  ruby_version_is ''...'2.7' do
+    it "always taints resulting strings when self or regexp is tainted" do
+      strs = ["hello world"]
+      strs += strs.map { |s| s.dup.taint }
 
-    strs.each do |str|
-      str.send(@method, //, 0).tainted?.should == str.tainted?
-      str.send(@method, /hello/, 0).tainted?.should == str.tainted?
+      strs.each do |str|
+        str.send(@method, //, 0).tainted?.should == str.tainted?
+        str.send(@method, /hello/, 0).tainted?.should == str.tainted?
 
-      str.send(@method, /(.)(.)(.)/, 0).tainted?.should == str.tainted?
-      str.send(@method, /(.)(.)(.)/, 1).tainted?.should == str.tainted?
-      str.send(@method, /(.)(.)(.)/, -1).tainted?.should == str.tainted?
-      str.send(@method, /(.)(.)(.)/, -2).tainted?.should == str.tainted?
+        str.send(@method, /(.)(.)(.)/, 0).tainted?.should == str.tainted?
+        str.send(@method, /(.)(.)(.)/, 1).tainted?.should == str.tainted?
+        str.send(@method, /(.)(.)(.)/, -1).tainted?.should == str.tainted?
+        str.send(@method, /(.)(.)(.)/, -2).tainted?.should == str.tainted?
 
-      tainted_re = /(.)(.)(.)/
-      tainted_re.taint
+        tainted_re = /(.)(.)(.)/
+        tainted_re.taint
 
-      str.send(@method, tainted_re, 0).tainted?.should == true
-      str.send(@method, tainted_re, 1).tainted?.should == true
-      str.send(@method, tainted_re, -1).tainted?.should == true
+        str.send(@method, tainted_re, 0).tainted?.should == true
+        str.send(@method, tainted_re, 1).tainted?.should == true
+        str.send(@method, tainted_re, -1).tainted?.should == true
+      end
     end
-  end
 
-  not_supported_on :opal do
-    it "returns an untrusted string if the regexp is untrusted" do
-      "hello".send(@method, /(.)/.untrust, 1).untrusted?.should be_true
+    not_supported_on :opal do
+      it "returns an untrusted string if the regexp is untrusted" do
+        "hello".send(@method, /(.)/.untrust, 1).untrusted?.should be_true
+      end
     end
   end
 
@@ -432,15 +440,17 @@ describe :string_slice_string, shared: true do
     "hello there".send(@method, s).should == s
   end
 
-  it "taints resulting strings when other is tainted" do
-    strs = ["", "hello world", "hello"]
-    strs += strs.map { |s| s.dup.taint }
+  ruby_version_is ''...'2.7' do
+    it "taints resulting strings when other is tainted" do
+      strs = ["", "hello world", "hello"]
+      strs += strs.map { |s| s.dup.taint }
 
-    strs.each do |str|
-      strs.each do |other|
-        r = str.send(@method, other)
+      strs.each do |str|
+        strs.each do |other|
+          r = str.send(@method, other)
 
-        r.tainted?.should == !r.nil? & other.tainted?
+          r.tainted?.should == !r.nil? & other.tainted?
+        end
       end
     end
   end
@@ -493,25 +503,27 @@ describe :string_slice_regexp_group, shared: true do
       "hello there".send(@method, /(?<g>h(?<g>.))/, 'g').should == "e"
     end
 
-    it "always taints resulting strings when self or regexp is tainted" do
-      strs = ["hello world"]
-      strs += strs.map { |s| s.dup.taint }
+    ruby_version_is ''...'2.7' do
+      it "always taints resulting strings when self or regexp is tainted" do
+        strs = ["hello world"]
+        strs += strs.map { |s| s.dup.taint }
 
-      strs.each do |str|
-        str.send(@method, /(?<hi>hello)/, 'hi').tainted?.should == str.tainted?
+        strs.each do |str|
+          str.send(@method, /(?<hi>hello)/, 'hi').tainted?.should == str.tainted?
 
-        str.send(@method, /(?<g>(.)(.)(.))/, 'g').tainted?.should == str.tainted?
-        str.send(@method, /(?<h>.)(.)(.)/, 'h').tainted?.should == str.tainted?
-        str.send(@method, /(.)(?<a>.)(.)/, 'a').tainted?.should == str.tainted?
-        str.send(@method, /(.)(.)(?<r>.)/, 'r').tainted?.should == str.tainted?
-        str.send(@method, /(?<h>.)(?<a>.)(?<r>.)/, 'r').tainted?.should == str.tainted?
+          str.send(@method, /(?<g>(.)(.)(.))/, 'g').tainted?.should == str.tainted?
+          str.send(@method, /(?<h>.)(.)(.)/, 'h').tainted?.should == str.tainted?
+          str.send(@method, /(.)(?<a>.)(.)/, 'a').tainted?.should == str.tainted?
+          str.send(@method, /(.)(.)(?<r>.)/, 'r').tainted?.should == str.tainted?
+          str.send(@method, /(?<h>.)(?<a>.)(?<r>.)/, 'r').tainted?.should == str.tainted?
 
-        tainted_re = /(?<a>.)(?<b>.)(?<c>.)/
-        tainted_re.taint
+          tainted_re = /(?<a>.)(?<b>.)(?<c>.)/
+          tainted_re.taint
 
-        str.send(@method, tainted_re, 'a').tainted?.should be_true
-        str.send(@method, tainted_re, 'b').tainted?.should be_true
-        str.send(@method, tainted_re, 'c').tainted?.should be_true
+          str.send(@method, tainted_re, 'a').tainted?.should be_true
+          str.send(@method, tainted_re, 'b').tainted?.should be_true
+          str.send(@method, tainted_re, 'c').tainted?.should be_true
+        end
       end
     end
 

--- a/spec/ruby/core/string/shared/succ.rb
+++ b/spec/ruby/core/string/shared/succ.rb
@@ -65,9 +65,11 @@ describe :string_succ, shared: true do
     StringSpecs::MyString.new("z").send(@method).should be_an_instance_of(StringSpecs::MyString)
   end
 
-  it "taints the result if self is tainted" do
-    ["", "a", "z", "Z", "9", "\xFF", "\xFF\xFF"].each do |s|
-      s.taint.send(@method).tainted?.should == true
+  ruby_version_is ''...'2.7' do
+    it "taints the result if self is tainted" do
+      ["", "a", "z", "Z", "9", "\xFF", "\xFF\xFF"].each do |s|
+        s.taint.send(@method).tainted?.should == true
+      end
     end
   end
 end

--- a/spec/ruby/core/string/shared/to_s.rb
+++ b/spec/ruby/core/string/shared/to_s.rb
@@ -11,8 +11,10 @@ describe :string_to_s, shared: true do
     s.should be_an_instance_of(String)
   end
 
-  it "taints the result when self is tainted" do
-    "x".taint.send(@method).tainted?.should == true
-    StringSpecs::MyString.new("x").taint.send(@method).tainted?.should == true
+  ruby_version_is ''...'2.7' do
+    it "taints the result when self is tainted" do
+      "x".taint.send(@method).tainted?.should == true
+      StringSpecs::MyString.new("x").taint.send(@method).tainted?.should == true
+    end
   end
 end

--- a/spec/ruby/core/string/slice_spec.rb
+++ b/spec/ruby/core/string/slice_spec.rb
@@ -94,12 +94,14 @@ describe "String#slice! with index, length" do
     a.should == "h"
   end
 
-  it "always taints resulting strings when self is tainted" do
-    str = "hello world"
-    str.taint
+  ruby_version_is ''...'2.7' do
+    it "always taints resulting strings when self is tainted" do
+      str = "hello world"
+      str.taint
 
-    str.slice!(0, 0).tainted?.should == true
-    str.slice!(2, 1).tainted?.should == true
+      str.slice!(0, 0).tainted?.should == true
+      str.slice!(2, 1).tainted?.should == true
+    end
   end
 
   it "returns nil if the given position is out of self" do
@@ -184,12 +186,14 @@ describe "String#slice! Range" do
     b.should == "hello"
   end
 
-  it "always taints resulting strings when self is tainted" do
-    str = "hello world"
-    str.taint
+  ruby_version_is ''...'2.7' do
+    it "always taints resulting strings when self is tainted" do
+      str = "hello world"
+      str.taint
 
-    str.slice!(0..0).tainted?.should == true
-    str.slice!(2..3).tainted?.should == true
+      str.slice!(0..0).tainted?.should == true
+      str.slice!(2..3).tainted?.should == true
+    end
   end
 
   it "returns subclass instances" do
@@ -271,26 +275,28 @@ describe "String#slice! with Regexp" do
     s.should == "this is a string"
   end
 
-  it "always taints resulting strings when self or regexp is tainted" do
-    strs = ["hello world"]
-    strs += strs.map { |s| s.dup.taint }
+  ruby_version_is ''...'2.7' do
+    it "always taints resulting strings when self or regexp is tainted" do
+      strs = ["hello world"]
+      strs += strs.map { |s| s.dup.taint }
 
-    strs.each do |str|
-      str = str.dup
-      str.slice!(//).tainted?.should == str.tainted?
-      str.slice!(/hello/).tainted?.should == str.tainted?
+      strs.each do |str|
+        str = str.dup
+        str.slice!(//).tainted?.should == str.tainted?
+        str.slice!(/hello/).tainted?.should == str.tainted?
 
-      tainted_re = /./
-      tainted_re.taint
+        tainted_re = /./
+        tainted_re.taint
 
-      str.slice!(tainted_re).tainted?.should == true
+        str.slice!(tainted_re).tainted?.should == true
+      end
     end
-  end
 
-  it "doesn't taint self when regexp is tainted" do
-    s = "hello"
-    s.slice!(/./.taint)
-    s.tainted?.should == false
+    it "doesn't taint self when regexp is tainted" do
+      s = "hello"
+      s.slice!(/./.taint)
+      s.tainted?.should == false
+    end
   end
 
   it "returns subclass instances" do
@@ -330,26 +336,28 @@ describe "String#slice! with Regexp, index" do
     str.should == "ho here"
   end
 
-  it "always taints resulting strings when self or regexp is tainted" do
-    strs = ["hello world"]
-    strs += strs.map { |s| s.dup.taint }
+  ruby_version_is ''...'2.7' do
+    it "always taints resulting strings when self or regexp is tainted" do
+      strs = ["hello world"]
+      strs += strs.map { |s| s.dup.taint }
 
-    strs.each do |str|
-      str = str.dup
-      str.slice!(//, 0).tainted?.should == str.tainted?
-      str.slice!(/hello/, 0).tainted?.should == str.tainted?
+      strs.each do |str|
+        str = str.dup
+        str.slice!(//, 0).tainted?.should == str.tainted?
+        str.slice!(/hello/, 0).tainted?.should == str.tainted?
 
-      tainted_re = /(.)(.)(.)/
-      tainted_re.taint
+        tainted_re = /(.)(.)(.)/
+        tainted_re.taint
 
-      str.slice!(tainted_re, 1).tainted?.should == true
+        str.slice!(tainted_re, 1).tainted?.should == true
+      end
     end
-  end
 
-  it "doesn't taint self when regexp is tainted" do
-    s = "hello"
-    s.slice!(/(.)(.)/.taint, 1)
-    s.tainted?.should == false
+    it "doesn't taint self when regexp is tainted" do
+      s = "hello"
+      s.slice!(/(.)(.)/.taint, 1)
+      s.tainted?.should == false
+    end
   end
 
   it "returns nil if there was no match" do
@@ -416,17 +424,19 @@ describe "String#slice! with String" do
     c.should == "he hello"
   end
 
-  it "taints resulting strings when other is tainted" do
-    strs = ["", "hello world", "hello"]
-    strs += strs.map { |s| s.dup.taint }
+  ruby_version_is ''...'2.7' do
+    it "taints resulting strings when other is tainted" do
+      strs = ["", "hello world", "hello"]
+      strs += strs.map { |s| s.dup.taint }
 
-    strs.each do |str|
-      str = str.dup
-      strs.each do |other|
-        other = other.dup
-        r = str.slice!(other)
+      strs.each do |str|
+        str = str.dup
+        strs.each do |other|
+          other = other.dup
+          r = str.slice!(other)
 
-        r.tainted?.should == !r.nil? & other.tainted?
+          r.tainted?.should == !r.nil? & other.tainted?
+        end
       end
     end
   end

--- a/spec/ruby/core/string/split_spec.rb
+++ b/spec/ruby/core/string/split_spec.rb
@@ -165,16 +165,18 @@ describe "String#split with String" do
     s.split(':').first.should == 'silly'
   end
 
-  it "taints the resulting strings if self is tainted" do
-    ["", "x.y.z.", "  x  y  "].each do |str|
-      ["", ".", " "].each do |pat|
-        [-1, 0, 1, 2].each do |limit|
-          str.dup.taint.split(pat).each do |x|
-            x.tainted?.should == true
-          end
+  ruby_version_is ''...'2.7' do
+    it "taints the resulting strings if self is tainted" do
+      ["", "x.y.z.", "  x  y  "].each do |str|
+        ["", ".", " "].each do |pat|
+          [-1, 0, 1, 2].each do |limit|
+            str.dup.taint.split(pat).each do |x|
+              x.tainted?.should == true
+            end
 
-          str.split(pat.dup.taint).each do |x|
-            x.tainted?.should == false
+            str.split(pat.dup.taint).each do |x|
+              x.tainted?.should == false
+            end
           end
         end
       end
@@ -355,29 +357,31 @@ describe "String#split with Regexp" do
     s.split(/:/).first.should == 'silly'
   end
 
-  it "taints the resulting strings if self is tainted" do
-    ["", "x:y:z:", "  x  y  "].each do |str|
-      [//, /:/, /\s+/].each do |pat|
-        [-1, 0, 1, 2].each do |limit|
-          str.dup.taint.split(pat, limit).each do |x|
-            # See the spec below for why the conditional is here
-            x.tainted?.should be_true unless x.empty?
+  ruby_version_is ''...'2.7' do
+    it "taints the resulting strings if self is tainted" do
+      ["", "x:y:z:", "  x  y  "].each do |str|
+        [//, /:/, /\s+/].each do |pat|
+          [-1, 0, 1, 2].each do |limit|
+            str.dup.taint.split(pat, limit).each do |x|
+              # See the spec below for why the conditional is here
+              x.tainted?.should be_true unless x.empty?
+            end
           end
         end
       end
     end
-  end
 
-  it "taints an empty string if self is tainted" do
-    ":".taint.split(//, -1).last.tainted?.should be_true
-  end
+    it "taints an empty string if self is tainted" do
+      ":".taint.split(//, -1).last.tainted?.should be_true
+    end
 
-  it "doesn't taints the resulting strings if the Regexp is tainted" do
-    ["", "x:y:z:", "  x  y  "].each do |str|
-      [//, /:/, /\s+/].each do |pat|
-        [-1, 0, 1, 2].each do |limit|
-          str.split(pat.dup.taint, limit).each do |x|
-            x.tainted?.should be_false
+    it "doesn't taints the resulting strings if the Regexp is tainted" do
+      ["", "x:y:z:", "  x  y  "].each do |str|
+        [//, /:/, /\s+/].each do |pat|
+          [-1, 0, 1, 2].each do |limit|
+            str.split(pat.dup.taint, limit).each do |x|
+              x.tainted?.should be_false
+            end
           end
         end
       end

--- a/spec/ruby/core/string/squeeze_spec.rb
+++ b/spec/ruby/core/string/squeeze_spec.rb
@@ -54,12 +54,14 @@ describe "String#squeeze" do
     -> { s.squeeze("^e-b") }.should raise_error(ArgumentError)
   end
 
-  it "taints the result when self is tainted" do
-    "hello".taint.squeeze("e").tainted?.should == true
-    "hello".taint.squeeze("a-z").tainted?.should == true
+  ruby_version_is ''...'2.7' do
+    it "taints the result when self is tainted" do
+      "hello".taint.squeeze("e").tainted?.should == true
+      "hello".taint.squeeze("a-z").tainted?.should == true
 
-    "hello".squeeze("e".taint).tainted?.should == false
-    "hello".squeeze("l".taint).tainted?.should == false
+      "hello".squeeze("e".taint).tainted?.should == false
+      "hello".squeeze("l".taint).tainted?.should == false
+    end
   end
 
   it "tries to convert each set arg to a string using to_str" do

--- a/spec/ruby/core/string/strip_spec.rb
+++ b/spec/ruby/core/string/strip_spec.rb
@@ -13,10 +13,12 @@ describe "String#strip" do
     " \x00 goodbye \x00 ".strip.should == "\x00 goodbye"
   end
 
-  it "taints the result when self is tainted" do
-    "".taint.strip.tainted?.should == true
-    "ok".taint.strip.tainted?.should == true
-    "  ok  ".taint.strip.tainted?.should == true
+  ruby_version_is ''...'2.7' do
+    it "taints the result when self is tainted" do
+      "".taint.strip.tainted?.should == true
+      "ok".taint.strip.tainted?.should == true
+      "  ok  ".taint.strip.tainted?.should == true
+    end
   end
 end
 

--- a/spec/ruby/core/string/sub_spec.rb
+++ b/spec/ruby/core/string/sub_spec.rb
@@ -137,24 +137,26 @@ describe "String#sub with pattern, replacement" do
     "hello".sub(/./, 'hah\\').should == 'hah\\ello'
   end
 
-  it "taints the result if the original string or replacement is tainted" do
-    hello = "hello"
-    hello_t = "hello"
-    a = "a"
-    a_t = "a"
-    empty = ""
-    empty_t = ""
+  ruby_version_is ''...'2.7' do
+    it "taints the result if the original string or replacement is tainted" do
+      hello = "hello"
+      hello_t = "hello"
+      a = "a"
+      a_t = "a"
+      empty = ""
+      empty_t = ""
 
-    hello_t.taint; a_t.taint; empty_t.taint
+      hello_t.taint; a_t.taint; empty_t.taint
 
-    hello_t.sub(/./, a).tainted?.should == true
-    hello_t.sub(/./, empty).tainted?.should == true
+      hello_t.sub(/./, a).tainted?.should == true
+      hello_t.sub(/./, empty).tainted?.should == true
 
-    hello.sub(/./, a_t).tainted?.should == true
-    hello.sub(/./, empty_t).tainted?.should == true
-    hello.sub(//, empty_t).tainted?.should == true
+      hello.sub(/./, a_t).tainted?.should == true
+      hello.sub(/./, empty_t).tainted?.should == true
+      hello.sub(//, empty_t).tainted?.should == true
 
-    hello.sub(//.taint, "foo").tainted?.should == false
+      hello.sub(//.taint, "foo").tainted?.should == false
+    end
   end
 
   it "tries to convert pattern to a string using to_str" do
@@ -285,24 +287,26 @@ describe "String#sub with pattern and block" do
     "hello".sub(/.+/) { obj }.should == "ok"
   end
 
-  it "taints the result if the original string or replacement is tainted" do
-    hello = "hello"
-    hello_t = "hello"
-    a = "a"
-    a_t = "a"
-    empty = ""
-    empty_t = ""
+  ruby_version_is ''...'2.7' do
+    it "taints the result if the original string or replacement is tainted" do
+      hello = "hello"
+      hello_t = "hello"
+      a = "a"
+      a_t = "a"
+      empty = ""
+      empty_t = ""
 
-    hello_t.taint; a_t.taint; empty_t.taint
+      hello_t.taint; a_t.taint; empty_t.taint
 
-    hello_t.sub(/./) { a }.tainted?.should == true
-    hello_t.sub(/./) { empty }.tainted?.should == true
+      hello_t.sub(/./) { a }.tainted?.should == true
+      hello_t.sub(/./) { empty }.tainted?.should == true
 
-    hello.sub(/./) { a_t }.tainted?.should == true
-    hello.sub(/./) { empty_t }.tainted?.should == true
-    hello.sub(//) { empty_t }.tainted?.should == true
+      hello.sub(/./) { a_t }.tainted?.should == true
+      hello.sub(/./) { empty_t }.tainted?.should == true
+      hello.sub(//) { empty_t }.tainted?.should == true
 
-    hello.sub(//.taint) { "foo" }.tainted?.should == false
+      hello.sub(//.taint) { "foo" }.tainted?.should == false
+    end
   end
 end
 
@@ -313,10 +317,12 @@ describe "String#sub! with pattern, replacement" do
     a.should == "h*llo"
   end
 
-  it "taints self if replacement is tainted" do
-    a = "hello"
-    a.sub!(/./.taint, "foo").tainted?.should == false
-    a.sub!(/./, "foo".taint).tainted?.should == true
+  ruby_version_is ''...'2.7' do
+    it "taints self if replacement is tainted" do
+      a = "hello"
+      a.sub!(/./.taint, "foo").tainted?.should == false
+      a.sub!(/./, "foo".taint).tainted?.should == true
+    end
   end
 
   it "returns nil if no modifications were made" do
@@ -361,10 +367,12 @@ describe "String#sub! with pattern and block" do
     offsets.should == [[1, 2]]
   end
 
-  it "taints self if block's result is tainted" do
-    a = "hello"
-    a.sub!(/./.taint) { "foo" }.tainted?.should == false
-    a.sub!(/./) { "foo".taint }.tainted?.should == true
+  ruby_version_is ''...'2.7' do
+    it "taints self if block's result is tainted" do
+      a = "hello"
+      a.sub!(/./.taint) { "foo" }.tainted?.should == false
+      a.sub!(/./) { "foo".taint }.tainted?.should == true
+    end
   end
 
   it "returns nil if no modifications were made" do
@@ -452,24 +460,26 @@ describe "String#sub with pattern and Hash" do
     "hello".sub(/(.+)/, 'hello' => repl ).should == repl
   end
 
-  it "untrusts the result if the original string is untrusted" do
-    str = "Ghana".untrust
-    str.sub(/[Aa]na/, 'ana' => '').untrusted?.should be_true
-  end
+  ruby_version_is ''...'2.7' do
+    it "untrusts the result if the original string is untrusted" do
+      str = "Ghana".untrust
+      str.sub(/[Aa]na/, 'ana' => '').untrusted?.should be_true
+    end
 
-  it "untrusts the result if a hash value is untrusted" do
-    str = "Ghana"
-    str.sub(/a$/, 'a' => 'di'.untrust).untrusted?.should be_true
-  end
+    it "untrusts the result if a hash value is untrusted" do
+      str = "Ghana"
+      str.sub(/a$/, 'a' => 'di'.untrust).untrusted?.should be_true
+    end
 
-  it "taints the result if the original string is tainted" do
-    str = "Ghana".taint
-    str.sub(/[Aa]na/, 'ana' => '').tainted?.should be_true
-  end
+    it "taints the result if the original string is tainted" do
+      str = "Ghana".taint
+      str.sub(/[Aa]na/, 'ana' => '').tainted?.should be_true
+    end
 
-  it "taints the result if a hash value is tainted" do
-    str = "Ghana"
-    str.sub(/a$/, 'a' => 'di'.taint).tainted?.should be_true
+    it "taints the result if a hash value is tainted" do
+      str = "Ghana"
+      str.sub(/a$/, 'a' => 'di'.taint).tainted?.should be_true
+    end
   end
 
 end
@@ -537,24 +547,26 @@ describe "String#sub! with pattern and Hash" do
     "hello".sub!(/(.+)/, 'hello' => repl ).should == repl
   end
 
-  it "keeps untrusted state" do
-    str = "Ghana".untrust
-    str.sub!(/[Aa]na/, 'ana' => '').untrusted?.should be_true
-  end
+  ruby_version_is ''...'2.7' do
+    it "keeps untrusted state" do
+      str = "Ghana".untrust
+      str.sub!(/[Aa]na/, 'ana' => '').untrusted?.should be_true
+    end
 
-  it "untrusts self if a hash value is untrusted" do
-    str = "Ghana"
-    str.sub!(/a$/, 'a' => 'di'.untrust).untrusted?.should be_true
-  end
+    it "untrusts self if a hash value is untrusted" do
+      str = "Ghana"
+      str.sub!(/a$/, 'a' => 'di'.untrust).untrusted?.should be_true
+    end
 
-  it "keeps tainted state" do
-    str = "Ghana".taint
-    str.sub!(/[Aa]na/, 'ana' => '').tainted?.should be_true
-  end
+    it "keeps tainted state" do
+      str = "Ghana".taint
+      str.sub!(/[Aa]na/, 'ana' => '').tainted?.should be_true
+    end
 
-  it "taints self if a hash value is tainted" do
-    str = "Ghana"
-    str.sub!(/a$/, 'a' => 'di'.taint).tainted?.should be_true
+    it "taints self if a hash value is tainted" do
+      str = "Ghana"
+      str.sub!(/a$/, 'a' => 'di'.taint).tainted?.should be_true
+    end
   end
 end
 

--- a/spec/ruby/core/string/swapcase_spec.rb
+++ b/spec/ruby/core/string/swapcase_spec.rb
@@ -9,9 +9,11 @@ describe "String#swapcase" do
    "+++---111222???".swapcase.should == "+++---111222???"
   end
 
-  it "taints resulting string when self is tainted" do
-    "".taint.swapcase.tainted?.should == true
-    "hello".taint.swapcase.tainted?.should == true
+  ruby_version_is ''...'2.7' do
+    it "taints resulting string when self is tainted" do
+      "".taint.swapcase.tainted?.should == true
+      "hello".taint.swapcase.tainted?.should == true
+    end
   end
 
   describe "full Unicode case mapping" do

--- a/spec/ruby/core/string/tr_s_spec.rb
+++ b/spec/ruby/core/string/tr_s_spec.rb
@@ -49,14 +49,16 @@ describe "String#tr_s" do
     StringSpecs::MyString.new("hello").tr_s("e", "a").should be_an_instance_of(StringSpecs::MyString)
   end
 
-  it "taints the result when self is tainted" do
-    ["h", "hello"].each do |str|
-      tainted_str = str.dup.taint
+  ruby_version_is ''...'2.7' do
+    it "taints the result when self is tainted" do
+      ["h", "hello"].each do |str|
+        tainted_str = str.dup.taint
 
-      tainted_str.tr_s("e", "a").tainted?.should == true
+        tainted_str.tr_s("e", "a").tainted?.should == true
 
-      str.tr_s("e".taint, "a").tainted?.should == false
-      str.tr_s("e", "a".taint).tainted?.should == false
+        str.tr_s("e".taint, "a").tainted?.should == false
+        str.tr_s("e", "a".taint).tainted?.should == false
+      end
     end
   end
 

--- a/spec/ruby/core/string/tr_spec.rb
+++ b/spec/ruby/core/string/tr_spec.rb
@@ -61,14 +61,16 @@ describe "String#tr" do
     StringSpecs::MyString.new("hello").tr("e", "a").should be_an_instance_of(StringSpecs::MyString)
   end
 
-  it "taints the result when self is tainted" do
-    ["h", "hello"].each do |str|
-      tainted_str = str.dup.taint
+  ruby_version_is ''...'2.7' do
+    it "taints the result when self is tainted" do
+      ["h", "hello"].each do |str|
+        tainted_str = str.dup.taint
 
-      tainted_str.tr("e", "a").tainted?.should == true
+        tainted_str.tr("e", "a").tainted?.should == true
 
-      str.tr("e".taint, "a").tainted?.should == false
-      str.tr("e", "a".taint).tainted?.should == false
+        str.tr("e".taint, "a").tainted?.should == false
+        str.tr("e", "a".taint).tainted?.should == false
+      end
     end
   end
 

--- a/spec/ruby/core/string/undump_spec.rb
+++ b/spec/ruby/core/string/undump_spec.rb
@@ -4,12 +4,14 @@ require_relative 'fixtures/classes'
 
 ruby_version_is '2.5' do
   describe "String#undump" do
-    it "taints the result if self is tainted" do
-      '"foo"'.taint.undump.tainted?.should == true
-    end
+    ruby_version_is ''...'2.7' do
+      it "taints the result if self is tainted" do
+        '"foo"'.taint.undump.tainted?.should == true
+      end
 
-    it "untrusts the result if self is untrusted" do
-      '"foo"'.untrust.undump.untrusted?.should == true
+      it "untrusts the result if self is untrusted" do
+        '"foo"'.untrust.undump.untrusted?.should == true
+      end
     end
 
     it "does not take into account if a string is frozen" do

--- a/spec/ruby/core/string/unpack/p_spec.rb
+++ b/spec/ruby/core/string/unpack/p_spec.rb
@@ -18,8 +18,10 @@ describe "String#unpack with format 'P'" do
     -> { packed.to_sym.to_s.unpack("P5") }.should raise_error(ArgumentError, /no associated pointer/)
   end
 
-  it "taints the unpacked string" do
-    ["hello"].pack("P").unpack("P5").first.tainted?.should be_true
+  ruby_version_is ''...'2.7' do
+    it "taints the unpacked string" do
+      ["hello"].pack("P").unpack("P5").first.tainted?.should be_true
+    end
   end
 
   it "reads as many characters as specified" do
@@ -46,7 +48,9 @@ describe "String#unpack with format 'p'" do
     -> { packed.to_sym.to_s.unpack("p") }.should raise_error(ArgumentError, /no associated pointer/)
   end
 
-  it "taints the unpacked string" do
-    ["hello"].pack("p").unpack("p").first.tainted?.should be_true
+  ruby_version_is ''...'2.7' do
+    it "taints the unpacked string" do
+      ["hello"].pack("p").unpack("p").first.tainted?.should be_true
+    end
   end
 end

--- a/spec/ruby/core/string/unpack/shared/taint.rb
+++ b/spec/ruby/core/string/unpack/shared/taint.rb
@@ -1,81 +1,83 @@
 describe :string_unpack_taint, shared: true do
-  it "does not taint returned arrays if given an untainted format string" do
-    "".unpack(unpack_format(2)).tainted?.should be_false
-  end
+  ruby_version_is ''...'2.7' do
+    it "does not taint returned arrays if given an untainted format string" do
+      "".unpack(unpack_format(2)).tainted?.should be_false
+    end
 
-  it "does not taint returned arrays if given a tainted format string" do
-    format_string = unpack_format(2).dup
-    format_string.taint
-    "".unpack(format_string).tainted?.should be_false
-  end
+    it "does not taint returned arrays if given a tainted format string" do
+      format_string = unpack_format(2).dup
+      format_string.taint
+      "".unpack(format_string).tainted?.should be_false
+    end
 
-  it "does not taint returned strings if given an untainted format string" do
-    "".unpack(unpack_format(2)).any?(&:tainted?).should be_false
-  end
+    it "does not taint returned strings if given an untainted format string" do
+      "".unpack(unpack_format(2)).any?(&:tainted?).should be_false
+    end
 
-  it "does not taint returned strings if given a tainted format string" do
-    format_string = unpack_format(2).dup
-    format_string.taint
-    "".unpack(format_string).any?(&:tainted?).should be_false
-  end
+    it "does not taint returned strings if given a tainted format string" do
+      format_string = unpack_format(2).dup
+      format_string.taint
+      "".unpack(format_string).any?(&:tainted?).should be_false
+    end
 
-  it "does not taint returned arrays if given an untainted packed string" do
-    "".unpack(unpack_format(2)).tainted?.should be_false
-  end
+    it "does not taint returned arrays if given an untainted packed string" do
+      "".unpack(unpack_format(2)).tainted?.should be_false
+    end
 
-  it "does not taint returned arrays if given a tainted packed string" do
-    packed_string = ""
-    packed_string.taint
-    packed_string.unpack(unpack_format(2)).tainted?.should be_false
-  end
+    it "does not taint returned arrays if given a tainted packed string" do
+      packed_string = ""
+      packed_string.taint
+      packed_string.unpack(unpack_format(2)).tainted?.should be_false
+    end
 
-  it "does not taint returned strings if given an untainted packed string" do
-    "".unpack(unpack_format(2)).any?(&:tainted?).should be_false
-  end
+    it "does not taint returned strings if given an untainted packed string" do
+      "".unpack(unpack_format(2)).any?(&:tainted?).should be_false
+    end
 
-  it "taints returned strings if given a tainted packed string" do
-    packed_string = ""
-    packed_string.taint
-    packed_string.unpack(unpack_format(2)).all?(&:tainted?).should be_true
-  end
+    it "taints returned strings if given a tainted packed string" do
+      packed_string = ""
+      packed_string.taint
+      packed_string.unpack(unpack_format(2)).all?(&:tainted?).should be_true
+    end
 
-  it "does not untrust returned arrays if given an untrusted format string" do
-    "".unpack(unpack_format(2)).untrusted?.should be_false
-  end
+    it "does not untrust returned arrays if given an untrusted format string" do
+      "".unpack(unpack_format(2)).untrusted?.should be_false
+    end
 
-  it "does not untrust returned arrays if given a untrusted format string" do
-    format_string = unpack_format(2).dup
-    format_string.untrust
-    "".unpack(format_string).untrusted?.should be_false
-  end
+    it "does not untrust returned arrays if given a untrusted format string" do
+      format_string = unpack_format(2).dup
+      format_string.untrust
+      "".unpack(format_string).untrusted?.should be_false
+    end
 
-  it "does not untrust returned strings if given an untainted format string" do
-    "".unpack(unpack_format(2)).any?(&:untrusted?).should be_false
-  end
+    it "does not untrust returned strings if given an untainted format string" do
+      "".unpack(unpack_format(2)).any?(&:untrusted?).should be_false
+    end
 
-  it "does not untrust returned strings if given a untrusted format string" do
-    format_string = unpack_format(2).dup
-    format_string.untrust
-    "".unpack(format_string).any?(&:untrusted?).should be_false
-  end
+    it "does not untrust returned strings if given a untrusted format string" do
+      format_string = unpack_format(2).dup
+      format_string.untrust
+      "".unpack(format_string).any?(&:untrusted?).should be_false
+    end
 
-  it "does not untrust returned arrays if given an trusted packed string" do
-    "".unpack(unpack_format(2)).untrusted?.should be_false
-  end
+    it "does not untrust returned arrays if given an trusted packed string" do
+      "".unpack(unpack_format(2)).untrusted?.should be_false
+    end
 
-  it "does not untrust returned arrays if given a untrusted packed string" do
-    packed_string = ""
-    packed_string.untrust
-    packed_string.unpack(unpack_format(2)).untrusted?.should be_false
-  end
+    it "does not untrust returned arrays if given a untrusted packed string" do
+      packed_string = ""
+      packed_string.untrust
+      packed_string.unpack(unpack_format(2)).untrusted?.should be_false
+    end
 
-  it "does not untrust returned strings if given an trusted packed string" do
-    "".unpack(unpack_format(2)).any?(&:untrusted?).should be_false
-  end
+    it "does not untrust returned strings if given an trusted packed string" do
+      "".unpack(unpack_format(2)).any?(&:untrusted?).should be_false
+    end
 
-  it "untrusts returned strings if given a untrusted packed string" do
-    packed_string = ""
-    packed_string.untrust
-    packed_string.unpack(unpack_format(2)).all?(&:untrusted?).should be_true
+    it "untrusts returned strings if given a untrusted packed string" do
+      packed_string = ""
+      packed_string.untrust
+      packed_string.unpack(unpack_format(2)).all?(&:untrusted?).should be_true
+    end
   end
 end

--- a/spec/ruby/core/string/upcase_spec.rb
+++ b/spec/ruby/core/string/upcase_spec.rb
@@ -65,10 +65,12 @@ describe "String#upcase" do
     -> { "abc".upcase(:invalid_option) }.should raise_error(ArgumentError)
   end
 
-  it "taints result when self is tainted" do
-    "".taint.upcase.tainted?.should == true
-    "X".taint.upcase.tainted?.should == true
-    "x".taint.upcase.tainted?.should == true
+  ruby_version_is ''...'2.7' do
+    it "taints result when self is tainted" do
+      "".taint.upcase.tainted?.should == true
+      "X".taint.upcase.tainted?.should == true
+      "x".taint.upcase.tainted?.should == true
+    end
   end
 
   it "returns a subclass instance for subclasses" do

--- a/spec/ruby/core/symbol/shared/slice.rb
+++ b/spec/ruby/core/symbol/shared/slice.rb
@@ -191,12 +191,14 @@ describe :symbol_slice, shared: true do
         $~.should be_nil
       end
 
-      it "returns a tainted string if the regexp is tainted" do
-        :symbol.send(@method, /./.taint).tainted?.should be_true
-      end
+      ruby_version_is ''...'2.7' do
+        it "returns a tainted string if the regexp is tainted" do
+          :symbol.send(@method, /./.taint).tainted?.should be_true
+        end
 
-      it "returns an untrusted string if the regexp is untrusted" do
-        :symbol.send(@method, /./.untrust).untrusted?.should be_true
+        it "returns an untrusted string if the regexp is untrusted" do
+          :symbol.send(@method, /./.untrust).untrusted?.should be_true
+        end
       end
     end
 
@@ -219,12 +221,14 @@ describe :symbol_slice, shared: true do
         :symbol.send(@method, /(sy)(mb)(ol)/, 1.5).should == "sy"
       end
 
-      it "returns a tainted string if the regexp is tainted" do
-        :symbol.send(@method, /(.)/.taint, 1).tainted?.should be_true
-      end
+      ruby_version_is ''...'2.7' do
+        it "returns a tainted string if the regexp is tainted" do
+          :symbol.send(@method, /(.)/.taint, 1).tainted?.should be_true
+        end
 
-      it "returns an untrusted string if the regexp is untrusted" do
-        :symbol.send(@method, /(.)/.untrust, 1).untrusted?.should be_true
+        it "returns an untrusted string if the regexp is untrusted" do
+          :symbol.send(@method, /(.)/.untrust, 1).untrusted?.should be_true
+        end
       end
 
       describe "and an index that cannot be converted to an Integer" do

--- a/spec/ruby/language/predefined_spec.rb
+++ b/spec/ruby/language/predefined_spec.rb
@@ -771,8 +771,6 @@ __LINE__         String          The current line number in the source file. [r/
 $LOAD_PATH       Array           A synonym for $:. [r/o]
 $-p              Object          Set to true if the -p option (which puts an implicit while gets . . . end
                                  loop around your program) is present on the command line. [r/o]
-$SAFE            Fixnum          The current safe level. This variable’s value may never be
-                                 reduced by assignment. [thread] (Not implemented in Rubinius)
 $VERBOSE         Object          Set to true if the -v, --version, -W, or -w option is specified on the com-
                                  mand line. Set to false if no option, or -W1 is given. Set to nil if -W0
                                  was specified. Setting this option to true causes the interpreter and some

--- a/spec/ruby/language/safe_spec.rb
+++ b/spec/ruby/language/safe_spec.rb
@@ -1,137 +1,138 @@
 require_relative '../spec_helper'
 
 describe "The $SAFE variable" do
-
-  ruby_version_is "2.6" do
-    after :each do
-      $SAFE = 0
+  ruby_version_is ""..."2.7" do
+    ruby_version_is "2.6" do
+      after :each do
+        $SAFE = 0
+      end
     end
-  end
 
-  it "is 0 by default" do
-    $SAFE.should == 0
-    proc {
+    it "is 0 by default" do
       $SAFE.should == 0
-    }.call
-  end
+      proc {
+        $SAFE.should == 0
+      }.call
+    end
 
-  it "can be set to 0" do
-    proc {
-      $SAFE = 0
-      $SAFE.should == 0
-    }.call
-  end
+    it "can be set to 0" do
+      proc {
+        $SAFE = 0
+        $SAFE.should == 0
+      }.call
+    end
 
-  it "can be set to 1" do
-    proc {
-      $SAFE = 1
-      $SAFE.should == 1
-    }.call
-  end
+    it "can be set to 1" do
+      proc {
+        $SAFE = 1
+        $SAFE.should == 1
+      }.call
+    end
 
-  [2, 3, 4].each do |n|
-    it "cannot be set to #{n}" do
+    [2, 3, 4].each do |n|
+      it "cannot be set to #{n}" do
+        -> {
+          proc {
+            $SAFE = n
+          }.call
+        }.should raise_error(ArgumentError, /\$SAFE=2 to 4 are obsolete/)
+      end
+    end
+
+    ruby_version_is ""..."2.6" do
+      it "cannot be set to values below 0" do
+        -> {
+          proc {
+            $SAFE = -100
+          }.call
+        }.should raise_error(SecurityError, /tried to downgrade safe level from 0 to -100/)
+      end
+    end
+
+    ruby_version_is "2.6" do
+      it "raises ArgumentError when set to values below 0" do
+        -> {
+          proc {
+            $SAFE = -100
+          }.call
+        }.should raise_error(ArgumentError, "$SAFE should be >= 0")
+      end
+    end
+
+    it "cannot be set to values above 4" do
       -> {
         proc {
-          $SAFE = n
+          $SAFE = 100
         }.call
       }.should raise_error(ArgumentError, /\$SAFE=2 to 4 are obsolete/)
     end
-  end
 
-  ruby_version_is ""..."2.6" do
-    it "cannot be set to values below 0" do
-      -> {
+    ruby_version_is ""..."2.6" do
+      it "cannot be manually lowered" do
         proc {
-          $SAFE = -100
+          $SAFE = 1
+          -> {
+            $SAFE = 0
+          }.should raise_error(SecurityError, /tried to downgrade safe level from 1 to 0/)
         }.call
-      }.should raise_error(SecurityError, /tried to downgrade safe level from 0 to -100/)
-    end
-  end
+      end
 
-  ruby_version_is "2.6" do
-    it "raises ArgumentError when set to values below 0" do
-      -> {
+      it "is automatically lowered when leaving a proc" do
+        $SAFE.should == 0
         proc {
-          $SAFE = -100
+          $SAFE = 1
         }.call
-      }.should raise_error(ArgumentError, "$SAFE should be >= 0")
-    end
-  end
+        $SAFE.should == 0
+      end
 
-  it "cannot be set to values above 4" do
-    -> {
-      proc {
-        $SAFE = 100
-      }.call
-    }.should raise_error(ArgumentError, /\$SAFE=2 to 4 are obsolete/)
-  end
-
-  ruby_version_is ""..."2.6" do
-    it "cannot be manually lowered" do
-      proc {
-        $SAFE = 1
+      it "is automatically lowered when leaving a lambda" do
+        $SAFE.should == 0
         -> {
-          $SAFE = 0
-        }.should raise_error(SecurityError, /tried to downgrade safe level from 1 to 0/)
-      }.call
+          $SAFE = 1
+        }.call
+        $SAFE.should == 0
+      end
     end
 
-    it "is automatically lowered when leaving a proc" do
-      $SAFE.should == 0
+    ruby_version_is "2.6" do
+      it "can be manually lowered" do
+        $SAFE = 1
+        $SAFE = 0
+        $SAFE.should == 0
+      end
+
+      it "is not Proc local" do
+        $SAFE.should == 0
+        proc {
+          $SAFE = 1
+        }.call
+        $SAFE.should == 1
+      end
+
+      it "is not lambda local" do
+        $SAFE.should == 0
+        -> {
+          $SAFE = 1
+        }.call
+        $SAFE.should == 1
+      end
+
+      it "is global like regular global variables" do
+        Thread.new { $SAFE }.value.should == 0
+        $SAFE = 1
+        Thread.new { $SAFE }.value.should == 1
+      end
+    end
+
+    it "can be read when default from Thread#safe_level" do
+      Thread.current.safe_level.should == 0
+    end
+
+    it "can be read when modified from Thread#safe_level" do
       proc {
         $SAFE = 1
+        Thread.current.safe_level.should == 1
       }.call
-      $SAFE.should == 0
     end
-
-    it "is automatically lowered when leaving a lambda" do
-      $SAFE.should == 0
-      -> {
-        $SAFE = 1
-      }.call
-      $SAFE.should == 0
-    end
-  end
-
-  ruby_version_is "2.6" do
-    it "can be manually lowered" do
-      $SAFE = 1
-      $SAFE = 0
-      $SAFE.should == 0
-    end
-
-    it "is not Proc local" do
-      $SAFE.should == 0
-      proc {
-        $SAFE = 1
-      }.call
-      $SAFE.should == 1
-    end
-
-    it "is not lambda local" do
-      $SAFE.should == 0
-      -> {
-        $SAFE = 1
-      }.call
-      $SAFE.should == 1
-    end
-
-    it "is global like regular global variables" do
-      Thread.new { $SAFE }.value.should == 0
-      $SAFE = 1
-      Thread.new { $SAFE }.value.should == 1
-    end
-  end
-
-  it "can be read when default from Thread#safe_level" do
-    Thread.current.safe_level.should == 0
-  end
-
-  it "can be read when modified from Thread#safe_level" do
-    proc {
-      $SAFE = 1
-      Thread.current.safe_level.should == 1
-    }.call
   end
 end

--- a/spec/ruby/language/string_spec.rb
+++ b/spec/ruby/language/string_spec.rb
@@ -51,24 +51,26 @@ describe "Ruby character strings" do
     "#\$".should == '#$'
   end
 
-  it "taints the result of interpolation when an interpolated value is tainted" do
-    "#{"".taint}".tainted?.should be_true
+  ruby_version_is ''...'2.7' do
+    it "taints the result of interpolation when an interpolated value is tainted" do
+      "#{"".taint}".tainted?.should be_true
 
-    @ip.taint
-    "#@ip".tainted?.should be_true
+      @ip.taint
+      "#@ip".tainted?.should be_true
 
-    $ip.taint
-    "#$ip".tainted?.should be_true
-  end
+      $ip.taint
+      "#$ip".tainted?.should be_true
+    end
 
-  it "untrusts the result of interpolation when an interpolated value is untrusted" do
-    "#{"".untrust}".untrusted?.should be_true
+    it "untrusts the result of interpolation when an interpolated value is untrusted" do
+      "#{"".untrust}".untrusted?.should be_true
 
-    @ip.untrust
-    "#@ip".untrusted?.should be_true
+      @ip.untrust
+      "#@ip".untrusted?.should be_true
 
-    $ip.untrust
-    "#$ip".untrusted?.should be_true
+      $ip.untrust
+      "#$ip".untrusted?.should be_true
+    end
   end
 
   it "allows using non-alnum characters as string delimiters" do

--- a/spec/ruby/library/delegate/delegator/taint_spec.rb
+++ b/spec/ruby/library/delegate/delegator/taint_spec.rb
@@ -6,18 +6,20 @@ describe "Delegator#taint" do
     @delegate = DelegateSpecs::Delegator.new("")
   end
 
-  it "returns self" do
-    @delegate.taint.equal?(@delegate).should be_true
-  end
+  ruby_version_is ''...'2.7' do
+    it "returns self" do
+      @delegate.taint.equal?(@delegate).should be_true
+    end
 
-  it "taints the delegator" do
-    @delegate.__setobj__(nil)
-    @delegate.taint
-    @delegate.tainted?.should be_true
-  end
+    it "taints the delegator" do
+      @delegate.__setobj__(nil)
+      @delegate.taint
+      @delegate.tainted?.should be_true
+    end
 
-  it "taints the delegated object" do
-    @delegate.taint
-    @delegate.__getobj__.tainted?.should be_true
+    it "taints the delegated object" do
+      @delegate.taint
+      @delegate.__getobj__.tainted?.should be_true
+    end
   end
 end

--- a/spec/ruby/library/delegate/delegator/trust_spec.rb
+++ b/spec/ruby/library/delegate/delegator/trust_spec.rb
@@ -6,17 +6,19 @@ describe "Delegator#trust" do
     @delegate = DelegateSpecs::Delegator.new([])
   end
 
-  it "returns self" do
-    @delegate.trust.equal?(@delegate).should be_true
-  end
+  ruby_version_is ''...'2.7' do
+    it "returns self" do
+      @delegate.trust.equal?(@delegate).should be_true
+    end
 
-  it "trusts the delegator" do
-    @delegate.trust
-    @delegate.untrusted?.should be_false
-  end
+    it "trusts the delegator" do
+      @delegate.trust
+      @delegate.untrusted?.should be_false
+    end
 
-  it "trusts the delegated object" do
-    @delegate.trust
-    @delegate.__getobj__.untrusted?.should be_false
+    it "trusts the delegated object" do
+      @delegate.trust
+      @delegate.__getobj__.untrusted?.should be_false
+    end
   end
 end

--- a/spec/ruby/library/delegate/delegator/untaint_spec.rb
+++ b/spec/ruby/library/delegate/delegator/untaint_spec.rb
@@ -6,19 +6,21 @@ describe "Delegator#untaint" do
     @delegate = -> { DelegateSpecs::Delegator.new("") }.call
   end
 
-  it "returns self" do
-    @delegate.untaint.equal?(@delegate).should be_true
-  end
+  ruby_version_is ''...'2.7' do
+    it "returns self" do
+      @delegate.untaint.equal?(@delegate).should be_true
+    end
 
-  it "untaints the delegator" do
-    @delegate.untaint
-    @delegate.tainted?.should be_false
-    # No additional meaningful test; that it does or not taint
-    # "for real" the delegator has no consequence
-  end
+    it "untaints the delegator" do
+      @delegate.untaint
+      @delegate.tainted?.should be_false
+      # No additional meaningful test; that it does or not taint
+      # "for real" the delegator has no consequence
+    end
 
-  it "untaints the delegated object" do
-    @delegate.untaint
-    @delegate.__getobj__.tainted?.should be_false
+    it "untaints the delegated object" do
+      @delegate.untaint
+      @delegate.__getobj__.tainted?.should be_false
+    end
   end
 end

--- a/spec/ruby/library/delegate/delegator/untrust_spec.rb
+++ b/spec/ruby/library/delegate/delegator/untrust_spec.rb
@@ -6,18 +6,20 @@ describe "Delegator#untrust" do
     @delegate = DelegateSpecs::Delegator.new("")
   end
 
-  it "returns self" do
-    @delegate.untrust.equal?(@delegate).should be_true
-  end
+  ruby_version_is ''...'2.7' do
+    it "returns self" do
+      @delegate.untrust.equal?(@delegate).should be_true
+    end
 
-  it "untrusts the delegator" do
-    @delegate.__setobj__(nil)
-    @delegate.untrust
-    @delegate.untrusted?.should be_true
-  end
+    it "untrusts the delegator" do
+      @delegate.__setobj__(nil)
+      @delegate.untrust
+      @delegate.untrusted?.should be_true
+    end
 
-  it "untrusts the delegated object" do
-    @delegate.untrust
-    @delegate.__getobj__.untrusted?.should be_true
+    it "untrusts the delegated object" do
+      @delegate.untrust
+      @delegate.__getobj__.untrusted?.should be_true
+    end
   end
 end

--- a/spec/ruby/library/pathname/new_spec.rb
+++ b/spec/ruby/library/pathname/new_spec.rb
@@ -10,9 +10,11 @@ describe "Pathname.new" do
     -> { Pathname.new("\0")}.should raise_error(ArgumentError)
   end
 
-  it "is tainted if path is tainted" do
-    path = '/usr/local/bin'.taint
-    Pathname.new(path).tainted?.should == true
+  ruby_version_is ''...'2.7' do
+    it "is tainted if path is tainted" do
+      path = '/usr/local/bin'.taint
+      Pathname.new(path).tainted?.should == true
+    end
   end
 
   it "raises a TypeError if not passed a String type" do

--- a/spec/ruby/library/readline/history/delete_at_spec.rb
+++ b/spec/ruby/library/readline/history/delete_at_spec.rb
@@ -35,11 +35,13 @@ with_feature :readline do
       -> { Readline::HISTORY.delete_at(-10) }.should raise_error(IndexError)
     end
 
-    it "taints the returned strings" do
-      Readline::HISTORY.push("1", "2", "3")
-      Readline::HISTORY.delete_at(0).tainted?.should be_true
-      Readline::HISTORY.delete_at(0).tainted?.should be_true
-      Readline::HISTORY.delete_at(0).tainted?.should be_true
+  ruby_version_is ''...'2.7' do
+      it "taints the returned strings" do
+        Readline::HISTORY.push("1", "2", "3")
+        Readline::HISTORY.delete_at(0).tainted?.should be_true
+        Readline::HISTORY.delete_at(0).tainted?.should be_true
+        Readline::HISTORY.delete_at(0).tainted?.should be_true
+      end
     end
   end
 end

--- a/spec/ruby/library/readline/history/each_spec.rb
+++ b/spec/ruby/library/readline/history/each_spec.rb
@@ -20,9 +20,11 @@ with_feature :readline do
       result.should == ["1", "2", "3"]
     end
 
-    it "yields tainted Objects" do
-      Readline::HISTORY.each do |x|
-        x.tainted?.should be_true
+    ruby_version_is ''...'2.7' do
+      it "yields tainted Objects" do
+        Readline::HISTORY.each do |x|
+          x.tainted?.should be_true
+        end
       end
     end
   end

--- a/spec/ruby/library/readline/history/element_reference_spec.rb
+++ b/spec/ruby/library/readline/history/element_reference_spec.rb
@@ -12,9 +12,11 @@ with_feature :readline do
       Readline::HISTORY.pop
     end
 
-    it "returns tainted objects" do
-      Readline::HISTORY[0].tainted?.should be_true
-      Readline::HISTORY[1].tainted?.should be_true
+    ruby_version_is ''...'2.7' do
+      it "returns tainted objects" do
+        Readline::HISTORY[0].tainted?.should be_true
+        Readline::HISTORY[1].tainted?.should be_true
+      end
     end
 
     it "returns the history item at the passed index" do

--- a/spec/ruby/library/readline/history/pop_spec.rb
+++ b/spec/ruby/library/readline/history/pop_spec.rb
@@ -20,11 +20,13 @@ with_feature :readline do
       Readline::HISTORY.size.should == 0
     end
 
-    it "taints the returned strings" do
-      Readline::HISTORY.push("1", "2", "3")
-      Readline::HISTORY.pop.tainted?.should be_true
-      Readline::HISTORY.pop.tainted?.should be_true
-      Readline::HISTORY.pop.tainted?.should be_true
+    ruby_version_is ''...'2.7' do
+      it "taints the returned strings" do
+        Readline::HISTORY.push("1", "2", "3")
+        Readline::HISTORY.pop.tainted?.should be_true
+        Readline::HISTORY.pop.tainted?.should be_true
+        Readline::HISTORY.pop.tainted?.should be_true
+      end
     end
   end
 end

--- a/spec/ruby/library/readline/history/shift_spec.rb
+++ b/spec/ruby/library/readline/history/shift_spec.rb
@@ -20,11 +20,13 @@ with_feature :readline do
       Readline::HISTORY.size.should == 0
     end
 
-    it "taints the returned strings" do
-      Readline::HISTORY.push("1", "2", "3")
-      Readline::HISTORY.shift.tainted?.should be_true
-      Readline::HISTORY.shift.tainted?.should be_true
-      Readline::HISTORY.shift.tainted?.should be_true
+    ruby_version_is ''...'2.7' do
+      it "taints the returned strings" do
+        Readline::HISTORY.push("1", "2", "3")
+        Readline::HISTORY.shift.tainted?.should be_true
+        Readline::HISTORY.shift.tainted?.should be_true
+        Readline::HISTORY.shift.tainted?.should be_true
+      end
     end
   end
 end

--- a/spec/ruby/library/readline/readline_spec.rb
+++ b/spec/ruby/library/readline/readline_spec.rb
@@ -22,9 +22,11 @@ with_feature :readline do
         File.read(@out).should == "test"
       end
 
-      it "taints the returned strings" do
-        ruby_exe('File.write ARGV[0], Readline.readline.tainted?', @options)
-        File.read(@out).should == "true"
+      ruby_version_is ''...'2.7' do
+        it "taints the returned strings" do
+          ruby_exe('File.write ARGV[0], Readline.readline.tainted?', @options)
+          File.read(@out).should == "true"
+        end
       end
     end
   end

--- a/spec/ruby/library/stringscanner/initialize_spec.rb
+++ b/spec/ruby/library/stringscanner/initialize_spec.rb
@@ -12,7 +12,6 @@ describe "StringScanner#initialize" do
 
   it "returns an instance of StringScanner" do
     @s.should be_kind_of(StringScanner)
-    @s.tainted?.should be_false
     @s.eos?.should be_false
   end
 

--- a/spec/ruby/library/stringscanner/shared/extract_range.rb
+++ b/spec/ruby/library/stringscanner/shared/extract_range.rb
@@ -9,14 +9,16 @@ describe :extract_range, shared: true do
     ch.should be_an_instance_of(String)
   end
 
-  it "taints the returned String if the input was tainted" do
-    str = 'abc'
-    str.taint
+  ruby_version_is ''...'2.7' do
+    it "taints the returned String if the input was tainted" do
+      str = 'abc'
+      str.taint
 
-    s = StringScanner.new(str)
+      s = StringScanner.new(str)
 
-    s.send(@method).tainted?.should be_true
-    s.send(@method).tainted?.should be_true
-    s.send(@method).tainted?.should be_true
+      s.send(@method).tainted?.should be_true
+      s.send(@method).tainted?.should be_true
+      s.send(@method).tainted?.should be_true
+    end
   end
 end

--- a/spec/ruby/library/stringscanner/shared/extract_range_matched.rb
+++ b/spec/ruby/library/stringscanner/shared/extract_range_matched.rb
@@ -11,12 +11,14 @@ describe :extract_range_matched, shared: true do
     ch.should be_an_instance_of(String)
   end
 
-  it "taints the returned String if the input was tainted" do
-    str = 'abc'
-    str.taint
+  ruby_version_is ''...'2.7' do
+    it "taints the returned String if the input was tainted" do
+      str = 'abc'
+      str.taint
 
-    s = StringScanner.new(str)
-    s.scan(/\w{1}/)
-    s.send(@method).tainted?.should be_true
+      s = StringScanner.new(str)
+      s.scan(/\w{1}/)
+      s.send(@method).tainted?.should be_true
+    end
   end
 end

--- a/spec/ruby/library/stringscanner/shared/peek.rb
+++ b/spec/ruby/library/stringscanner/shared/peek.rb
@@ -37,11 +37,13 @@ describe :strscan_peek, shared: true do
     ch.should be_an_instance_of(String)
   end
 
-  it "taints the returned String if the input was tainted" do
-    str = 'abc'
-    str.taint
+  ruby_version_is ''...'2.7' do
+    it "taints the returned String if the input was tainted" do
+      str = 'abc'
+      str.taint
 
-    s = StringScanner.new(str)
-    s.send(@method, 1).tainted?.should be_true
+      s = StringScanner.new(str)
+      s.send(@method, 1).tainted?.should be_true
+    end
   end
 end

--- a/spec/ruby/optional/capi/object_spec.rb
+++ b/spec/ruby/optional/capi/object_spec.rb
@@ -414,11 +414,13 @@ describe "CApiObject" do
   end
 
   describe "FL_TEST" do
-    it "returns correct status for FL_TAINT" do
-      obj = Object.new
-      @o.FL_TEST(obj, "FL_TAINT").should == 0
-      obj.taint
-      @o.FL_TEST(obj, "FL_TAINT").should_not == 0
+    ruby_version_is ''...'2.7' do
+      it "returns correct status for FL_TAINT" do
+        obj = Object.new
+        @o.FL_TEST(obj, "FL_TAINT").should == 0
+        obj.taint
+        @o.FL_TEST(obj, "FL_TAINT").should_not == 0
+      end
     end
 
     it "returns correct status for FL_FREEZE" do
@@ -570,61 +572,67 @@ describe "CApiObject" do
   end
 
   describe "OBJ_TAINT" do
-    it "taints the object" do
-      obj = mock("tainted")
-      @o.OBJ_TAINT(obj)
-      obj.tainted?.should be_true
+    ruby_version_is ''...'2.7' do
+      it "taints the object" do
+        obj = mock("tainted")
+        @o.OBJ_TAINT(obj)
+        obj.tainted?.should be_true
+      end
     end
   end
 
   describe "OBJ_TAINTED" do
-    it "returns C true if the object is tainted" do
-      obj = mock("tainted")
-      obj.taint
-      @o.OBJ_TAINTED(obj).should be_true
-    end
+    ruby_version_is ''...'2.7' do
+      it "returns C true if the object is tainted" do
+        obj = mock("tainted")
+        obj.taint
+        @o.OBJ_TAINTED(obj).should be_true
+      end
 
-    it "returns C false if the object is not tainted" do
-      obj = mock("untainted")
-      @o.OBJ_TAINTED(obj).should be_false
+      it "returns C false if the object is not tainted" do
+        obj = mock("untainted")
+        @o.OBJ_TAINTED(obj).should be_false
+      end
     end
   end
 
   describe "OBJ_INFECT" do
-    it "does not taint the first argument if the second argument is not tainted" do
-      host   = mock("host")
-      source = mock("source")
-      @o.OBJ_INFECT(host, source)
-      host.tainted?.should be_false
-    end
+    ruby_version_is ''...'2.7' do
+      it "does not taint the first argument if the second argument is not tainted" do
+        host   = mock("host")
+        source = mock("source")
+        @o.OBJ_INFECT(host, source)
+        host.tainted?.should be_false
+      end
 
-    it "taints the first argument if the second argument is tainted" do
-      host   = mock("host")
-      source = mock("source").taint
-      @o.OBJ_INFECT(host, source)
-      host.tainted?.should be_true
-    end
+      it "taints the first argument if the second argument is tainted" do
+        host   = mock("host")
+        source = mock("source").taint
+        @o.OBJ_INFECT(host, source)
+        host.tainted?.should be_true
+      end
 
-    it "does not untrust the first argument if the second argument is trusted" do
-      host   = mock("host")
-      source = mock("source")
-      @o.OBJ_INFECT(host, source)
-      host.untrusted?.should be_false
-    end
+      it "does not untrust the first argument if the second argument is trusted" do
+        host   = mock("host")
+        source = mock("source")
+        @o.OBJ_INFECT(host, source)
+        host.untrusted?.should be_false
+      end
 
-    it "untrusts the first argument if the second argument is untrusted" do
-      host   = mock("host")
-      source = mock("source").untrust
-      @o.OBJ_INFECT(host, source)
-      host.untrusted?.should be_true
-    end
+      it "untrusts the first argument if the second argument is untrusted" do
+        host   = mock("host")
+        source = mock("source").untrust
+        @o.OBJ_INFECT(host, source)
+        host.untrusted?.should be_true
+      end
 
-    it "propagates both taint and distrust" do
-      host   = mock("host")
-      source = mock("source").taint.untrust
-      @o.OBJ_INFECT(host, source)
-      host.tainted?.should be_true
-      host.untrusted?.should be_true
+      it "propagates both taint and distrust" do
+        host   = mock("host")
+        source = mock("source").taint.untrust
+        @o.OBJ_INFECT(host, source)
+        host.tainted?.should be_true
+        host.untrusted?.should be_true
+      end
     end
   end
 
@@ -659,15 +667,17 @@ describe "CApiObject" do
   end
 
   describe "rb_obj_taint" do
-    it "marks the object passed as tainted" do
-      obj = ""
-      obj.tainted?.should == false
-      @o.rb_obj_taint(obj)
-      obj.tainted?.should == true
-    end
+    ruby_version_is ''...'2.7' do
+      it "marks the object passed as tainted" do
+        obj = ""
+        obj.tainted?.should == false
+        @o.rb_obj_taint(obj)
+        obj.tainted?.should == true
+      end
 
-    it "raises a #{frozen_error_class} if the object passed is frozen" do
-      -> { @o.rb_obj_taint("".freeze) }.should raise_error(frozen_error_class)
+      it "raises a #{frozen_error_class} if the object passed is frozen" do
+        -> { @o.rb_obj_taint("".freeze) }.should raise_error(frozen_error_class)
+      end
     end
   end
 

--- a/spec/ruby/optional/capi/string_spec.rb
+++ b/spec/ruby/optional/capi/string_spec.rb
@@ -167,8 +167,10 @@ describe "C-API String function" do
       @s.rb_str_new("hello", 3).should == "hel"
     end
 
-    it "returns a non-tainted string" do
-      @s.rb_str_new("hello", 5).tainted?.should == false
+    ruby_version_is ''...'2.7' do
+      it "returns a non-tainted string" do
+        @s.rb_str_new("hello", 5).tainted?.should == false
+      end
     end
 
     it "returns an empty string if len is 0" do
@@ -305,19 +307,21 @@ describe "C-API String function" do
     end
   end
 
-  describe "rb_tainted_str_new" do
-    it "creates a new tainted String" do
-      newstring = @s.rb_tainted_str_new("test", 4)
-      newstring.should == "test"
-      newstring.tainted?.should be_true
+  ruby_version_is ''...'2.7' do
+    describe "rb_tainted_str_new" do
+      it "creates a new tainted String" do
+        newstring = @s.rb_tainted_str_new("test", 4)
+        newstring.should == "test"
+        newstring.tainted?.should be_true
+      end
     end
-  end
 
-  describe "rb_tainted_str_new2" do
-    it "creates a new tainted String" do
-      newstring = @s.rb_tainted_str_new2("test")
-      newstring.should == "test"
-      newstring.tainted?.should be_true
+    describe "rb_tainted_str_new2" do
+      it "creates a new tainted String" do
+        newstring = @s.rb_tainted_str_new2("test")
+        newstring.should == "test"
+        newstring.tainted?.should be_true
+      end
     end
   end
 
@@ -684,8 +688,10 @@ describe :rb_external_str_new, shared: true do
     @s.send(@method, "#{x80}abc").encoding.should == Encoding::BINARY
   end
 
-  it "returns a tainted String" do
-    @s.send(@method, "abc").tainted?.should be_true
+  ruby_version_is ''...'2.7' do
+    it "returns a tainted String" do
+      @s.send(@method, "abc").tainted?.should be_true
+    end
   end
 end
 
@@ -767,9 +773,11 @@ describe "C-API String function" do
       s.encoding.should equal(Encoding::EUC_JP)
     end
 
-    it "returns a tainted String" do
-      s = @s.rb_external_str_new_with_enc("abc", 3, Encoding::US_ASCII)
-      s.tainted?.should be_true
+    ruby_version_is ''...'2.7' do
+      it "returns a tainted String" do
+        s = @s.rb_external_str_new_with_enc("abc", 3, Encoding::US_ASCII)
+        s.tainted?.should be_true
+      end
     end
   end
 

--- a/spec/ruby/optional/capi/string_spec.rb
+++ b/spec/ruby/optional/capi/string_spec.rb
@@ -558,20 +558,22 @@ describe "C-API String function" do
   end
 
   describe "SafeStringValue" do
-    it "raises for tained string when $SAFE is 1" do
-      begin
-        Thread.new {
-          $SAFE = 1
-          -> {
-            @s.SafeStringValue("str".taint)
-          }.should raise_error(SecurityError)
-        }.join
-      ensure
-        $SAFE = 0
+    ruby_version_is ''...'2.7' do
+      it "raises for tained string when $SAFE is 1" do
+        begin
+          Thread.new {
+            $SAFE = 1
+            -> {
+              @s.SafeStringValue("str".taint)
+            }.should raise_error(SecurityError)
+          }.join
+        ensure
+          $SAFE = 0
+        end
       end
-    end
 
-    it_behaves_like :string_value_macro, :SafeStringValue
+      it_behaves_like :string_value_macro, :SafeStringValue
+    end
   end
 
   describe "rb_str_modify_expand" do

--- a/spec/ruby/security/cve_2018_16396_spec.rb
+++ b/spec/ruby/security/cve_2018_16396_spec.rb
@@ -2,9 +2,11 @@ require_relative '../spec_helper'
 
 describe "Array#pack" do
 
-  it "resists CVE-2018-16396 by tainting output based on input" do
-    "aAZBbHhuMmPp".each_char do |f|
-      ["123456".taint].pack(f).tainted?.should be_true
+  ruby_version_is ''...'2.7' do
+    it "resists CVE-2018-16396 by tainting output based on input" do
+      "aAZBbHhuMmPp".each_char do |f|
+        ["123456".taint].pack(f).tainted?.should be_true
+      end
     end
   end
 
@@ -12,9 +14,11 @@ end
 
 describe "String#unpack" do
 
-  it "resists CVE-2018-16396 by tainting output based on input" do
-    "aAZBbHhuMm".each_char do |f|
-      "123456".taint.unpack(f).first.tainted?.should be_true
+  ruby_version_is ''...'2.7' do
+    it "resists CVE-2018-16396 by tainting output based on input" do
+      "aAZBbHhuMm".each_char do |f|
+        "123456".taint.unpack(f).first.tainted?.should be_true
+      end
     end
   end
 

--- a/spec/ruby/shared/string/times.rb
+++ b/spec/ruby/shared/string/times.rb
@@ -32,12 +32,14 @@ describe :string_times, shared: true do
     @object.call(MyString.new("cool"), 2).should be_an_instance_of(MyString)
   end
 
-  it "always taints the result when self is tainted" do
-    ["", "OK", MyString.new(""), MyString.new("OK")].each do |str|
-      str.taint
+  ruby_version_is ''...'2.7' do
+    it "always taints the result when self is tainted" do
+      ["", "OK", MyString.new(""), MyString.new("OK")].each do |str|
+        str.taint
 
-      [0, 1, 2].each do |arg|
-        @object.call(str, arg).tainted?.should == true
+        [0, 1, 2].each do |arg|
+          @object.call(str, arg).tainted?.should == true
+        end
       end
     end
   end

--- a/sprintf.c
+++ b/sprintf.c
@@ -215,7 +215,6 @@ rb_str_format(int argc, const VALUE *argv, VALUE fmt)
     int width, prec, flags = FNONE;
     int nextarg = 1;
     int posarg = 0;
-    int tainted = 0;
     VALUE nextvalue;
     VALUE tmp;
     VALUE orig;
@@ -239,7 +238,6 @@ rb_str_format(int argc, const VALUE *argv, VALUE fmt)
 
     ++argc;
     --argv;
-    if (OBJ_TAINTED(fmt)) tainted = 1;
     StringValue(fmt);
     enc = rb_enc_get(fmt);
     orig = fmt;
@@ -479,7 +477,6 @@ rb_str_format(int argc, const VALUE *argv, VALUE fmt)
 		else {
 		    str = rb_obj_as_string(arg);
 		}
-		if (OBJ_TAINTED(str)) tainted = 1;
 		len = RSTRING_LEN(str);
 		rb_str_set_len(result, blen);
 		if (coderange != ENC_CODERANGE_BROKEN && scanned < blen) {
@@ -931,7 +928,6 @@ rb_str_format(int argc, const VALUE *argv, VALUE fmt)
     }
     rb_str_resize(result, blen);
 
-    if (tainted) OBJ_TAINT(result);
     return result;
 }
 
@@ -1142,7 +1138,6 @@ ruby__sfvextra(rb_printf_buffer *fp, size_t valsize, void *valp, long *sz, int s
     StringValueCStr(value);
     RSTRING_GETMEM(value, cp, *sz);
     ((rb_printf_buffer_extra *)fp)->value = value;
-    OBJ_INFECT(result, value);
     return cp;
 }
 

--- a/struct.c
+++ b/struct.c
@@ -250,7 +250,6 @@ static void
 rb_struct_modify(VALUE s)
 {
     rb_check_frozen(s);
-    rb_check_trusted(s);
 }
 
 static VALUE
@@ -872,7 +871,6 @@ inspect_struct(VALUE s, VALUE dummy, int recur)
 	rb_str_append(str, rb_inspect(RSTRUCT_GET(s, i)));
     }
     rb_str_cat2(str, ">");
-    OBJ_INFECT(str, s);
 
     return str;
 }

--- a/test/-ext-/string/test_fstring.rb
+++ b/test/-ext-/string/test_fstring.rb
@@ -12,36 +12,6 @@ class Test_String_Fstring < Test::Unit::TestCase
     yield fstr
   end
 
-  def test_taint_shared_string
-    str = __method__.to_s.dup
-    str.taint
-    assert_fstring(str) {|s| assert_predicate(s, :tainted?)}
-  end
-
-  def test_taint_normal_string
-    str = __method__.to_s * 3
-    str.taint
-    assert_fstring(str) {|s| assert_predicate(s, :tainted?)}
-  end
-
-  def test_taint_registered_tainted
-    str = __method__.to_s * 3
-    str.taint
-    assert_fstring(str) {|s| assert_predicate(s, :tainted?)}
-
-    str = __method__.to_s * 3
-    assert_fstring(str) {|s| assert_not_predicate(s, :tainted?)}
-  end
-
-  def test_taint_registered_untainted
-    str = __method__.to_s * 3
-    assert_fstring(str) {|s| assert_not_predicate(s, :tainted?)}
-
-    str = __method__.to_s * 3
-    str.taint
-    assert_fstring(str) {|s| assert_predicate(s, :tainted?)}
-  end
-
   def test_instance_variable
     str = __method__.to_s * 3
     str.instance_variable_set(:@test, 42)

--- a/test/-ext-/test_printf.rb
+++ b/test/-ext-/test_printf.rb
@@ -35,15 +35,6 @@ class Test_SPrintf < Test::Unit::TestCase
     assert_equal("<\u{3042 3044 3046 3048 304a}>", Bug::Printf.s(self))
   end
 
-  def test_taint
-    obj = Object.new.taint
-    assert_equal({to_s: true, inspect: true},
-                 {
-                   to_s: Bug::Printf.s(obj).tainted?,
-                   inspect: Bug::Printf.v(obj).tainted?,
-                 })
-  end
-
   VS = [
     #-0x1000000000000000000000000000000000000000000000002,
     #-0x1000000000000000000000000000000000000000000000001,

--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -155,13 +155,15 @@ class TestBigDecimal < Test::Unit::TestCase
     end
   end
 
-  def test_BigDecimal_with_tainted_string
-    Thread.new {
-      $SAFE = 1
-      BigDecimal('1'.taint)
-    }.join
-  ensure
-    $SAFE = 0
+  if RUBY_VERSION < '2.7'
+    def test_BigDecimal_with_tainted_string
+      Thread.new {
+        $SAFE = 1
+        BigDecimal('1'.taint)
+      }.join
+    ensure
+      $SAFE = 0
+    end
   end
 
   def test_BigDecimal_with_exception_keyword

--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -155,6 +155,15 @@ class TestBigDecimal < Test::Unit::TestCase
     end
   end
 
+  def test_BigDecimal_with_tainted_string
+    Thread.new {
+      $SAFE = 1
+      BigDecimal('1'.taint)
+    }.join
+  ensure
+    $SAFE = 0
+  end
+
   def test_BigDecimal_with_exception_keyword
     assert_raise(ArgumentError) {
       BigDecimal('.', exception: true)

--- a/test/cgi/test_cgi_util.rb
+++ b/test/cgi/test_cgi_util.rb
@@ -99,13 +99,6 @@ class CGIUtilTest < Test::Unit::TestCase
     end
   end
 
-  def test_cgi_escape_html_preserve_tainted
-    assert_not_predicate CGI.escapeHTML("'&\"><"),           :tainted?
-    assert_predicate     CGI.escapeHTML("'&\"><".dup.taint), :tainted?
-    assert_not_predicate CGI.escapeHTML("Ruby"),             :tainted?
-    assert_predicate     CGI.escapeHTML("Ruby".dup.taint),   :tainted?
-  end
-
   def test_cgi_escape_html_dont_freeze
     assert_not_predicate CGI.escapeHTML("'&\"><".dup),    :frozen?
     assert_not_predicate CGI.escapeHTML("'&\"><".freeze), :frozen?

--- a/test/drb/test_drb.rb
+++ b/test/drb/test_drb.rb
@@ -103,15 +103,6 @@ module DRbYield
     @there.xarray_each {|x| assert_kind_of(XArray, x)}
     @there.xarray_each {|*x| assert_kind_of(XArray, x[0])}
   end
-
-  def test_06_taint
-    x = proc {}
-    assert_not_predicate(x, :tainted?)
-    @there.echo_yield(x) {|o|
-      assert_equal(x, o)
-      assert_not_predicate(x, :tainted?)
-    }
-  end
 end
 
 class TestDRbYield < Test::Unit::TestCase

--- a/test/fiddle/test_func.rb
+++ b/test/fiddle/test_func.rb
@@ -11,18 +11,6 @@ module Fiddle
       assert_nil f.call(10)
     end
 
-    def test_syscall_with_tainted_string
-      f = Function.new(@libc['system'], [TYPE_VOIDP], TYPE_INT)
-      Thread.new {
-        $SAFE = 1
-        assert_raise(SecurityError) do
-          f.call("uname -rs".dup.taint)
-        end
-      }.join
-    ensure
-      $SAFE = 0
-    end
-
     def test_sinf
       begin
         f = Function.new(@libm['sinf'], [TYPE_FLOAT], TYPE_FLOAT)

--- a/test/fiddle/test_func.rb
+++ b/test/fiddle/test_func.rb
@@ -11,6 +11,18 @@ module Fiddle
       assert_nil f.call(10)
     end
 
+    def test_syscall_with_tainted_string
+      f = Function.new(@libc['system'], [TYPE_VOIDP], TYPE_INT)
+      Thread.new {
+        $SAFE = 1
+        assert_raise(SecurityError) do
+          f.call("uname -rs".dup.taint)
+        end
+      }.join
+    ensure
+      $SAFE = 0
+    end
+
     def test_sinf
       begin
         f = Function.new(@libm['sinf'], [TYPE_FLOAT], TYPE_FLOAT)

--- a/test/fiddle/test_handle.rb
+++ b/test/fiddle/test_handle.rb
@@ -8,29 +8,6 @@ module Fiddle
   class TestHandle < TestCase
     include Fiddle
 
-    def test_safe_handle_open
-      Thread.new do
-        $SAFE = 1
-        assert_raise(SecurityError) {
-          Fiddle::Handle.new(LIBC_SO.dup.taint)
-        }
-      end.join
-    ensure
-      $SAFE = 0
-    end
-
-    def test_safe_function_lookup
-      Thread.new do
-        h = Fiddle::Handle.new(LIBC_SO)
-        $SAFE = 1
-        assert_raise(SecurityError) {
-          h["qsort".dup.taint]
-        }
-      end.join
-    ensure
-      $SAFE = 0
-    end
-
     def test_to_i
       handle = Fiddle::Handle.new(LIBC_SO)
       assert_kind_of Integer, handle.to_i

--- a/test/fiddle/test_handle.rb
+++ b/test/fiddle/test_handle.rb
@@ -8,6 +8,29 @@ module Fiddle
   class TestHandle < TestCase
     include Fiddle
 
+    def test_safe_handle_open
+      Thread.new do
+        $SAFE = 1
+        assert_raise(SecurityError) {
+          Fiddle::Handle.new(LIBC_SO.dup.taint)
+        }
+      end.join
+    ensure
+      $SAFE = 0
+    end
+
+    def test_safe_function_lookup
+      Thread.new do
+        h = Fiddle::Handle.new(LIBC_SO)
+        $SAFE = 1
+        assert_raise(SecurityError) {
+          h["qsort".dup.taint]
+        }
+      end.join
+    ensure
+      $SAFE = 0
+    end
+
     def test_to_i
       handle = Fiddle::Handle.new(LIBC_SO)
       assert_kind_of Integer, handle.to_i

--- a/test/net/imap/test_imap_response_parser.rb
+++ b/test/net/imap/test_imap_response_parser.rb
@@ -20,19 +20,6 @@ class IMAPResponseParserTest < Test::Unit::TestCase
     end
   end
 
-  def test_flag_list_safe
-    parser = Net::IMAP::ResponseParser.new
-    response = lambda {
-      $SAFE = 1
-      parser.parse(<<EOF.gsub(/\n/, "\r\n").taint)
-* LIST (\\HasChildren) "." "INBOX"
-EOF
-    }.call
-    assert_equal [:Haschildren], response.data.attr
-  ensure
-    $SAFE = 0
-  end
-
   def test_flag_list_too_many_flags
     parser = Net::IMAP::ResponseParser.new
     assert_nothing_raised do

--- a/test/net/imap/test_imap_response_parser.rb
+++ b/test/net/imap/test_imap_response_parser.rb
@@ -24,13 +24,13 @@ class IMAPResponseParserTest < Test::Unit::TestCase
     parser = Net::IMAP::ResponseParser.new
     assert_nothing_raised do
       3.times do |i|
-      parser.parse(<<EOF.gsub(/\n/, "\r\n").taint)
+      parser.parse(<<EOF.gsub(/\n/, "\r\n"))
 * LIST (\\Foo#{i}) "." "INBOX"
 EOF
       end
     end
     assert_raise(Net::IMAP::FlagCountError) do
-      parser.parse(<<EOF.gsub(/\n/, "\r\n").taint)
+      parser.parse(<<EOF.gsub(/\n/, "\r\n"))
 * LIST (\\Foo3) "." "INBOX"
 EOF
     end
@@ -40,7 +40,7 @@ EOF
     parser = Net::IMAP::ResponseParser.new
     assert_nothing_raised do
       100.times do
-      parser.parse(<<EOF.gsub(/\n/, "\r\n").taint)
+      parser.parse(<<EOF.gsub(/\n/, "\r\n"))
 * LIST (\\Foo) "." "INBOX"
 EOF
       end
@@ -49,7 +49,7 @@ EOF
 
   def test_flag_xlist_inbox
     parser = Net::IMAP::ResponseParser.new
-    response = parser.parse(<<EOF.gsub(/\n/, "\r\n").taint)
+    response = parser.parse(<<EOF.gsub(/\n/, "\r\n"))
 * XLIST (\\Inbox) "." "INBOX"
 EOF
     assert_equal [:Inbox], response.data.attr
@@ -57,7 +57,7 @@ EOF
 
   def test_resp_text_code
     parser = Net::IMAP::ResponseParser.new
-    response = parser.parse(<<EOF.gsub(/\n/, "\r\n").taint)
+    response = parser.parse(<<EOF.gsub(/\n/, "\r\n"))
 * OK [CLOSED] Previous mailbox closed.
 EOF
     assert_equal "CLOSED", response.data.code.name
@@ -65,15 +65,15 @@ EOF
 
   def test_search_response
     parser = Net::IMAP::ResponseParser.new
-    response = parser.parse(<<EOF.gsub(/\n/, "\r\n").taint)
+    response = parser.parse(<<EOF.gsub(/\n/, "\r\n"))
 * SEARCH
 EOF
     assert_equal [], response.data
-    response = parser.parse(<<EOF.gsub(/\n/, "\r\n").taint)
+    response = parser.parse(<<EOF.gsub(/\n/, "\r\n"))
 * SEARCH 1
 EOF
     assert_equal [1], response.data
-    response = parser.parse(<<EOF.gsub(/\n/, "\r\n").taint)
+    response = parser.parse(<<EOF.gsub(/\n/, "\r\n"))
 * SEARCH 1 2 3
 EOF
     assert_equal [1, 2, 3], response.data
@@ -81,11 +81,11 @@ EOF
 
   def test_search_response_of_yahoo
     parser = Net::IMAP::ResponseParser.new
-    response = parser.parse(<<EOF.gsub(/\n/, "\r\n").taint)
+    response = parser.parse(<<EOF.gsub(/\n/, "\r\n"))
 * SEARCH 1\s
 EOF
     assert_equal [1], response.data
-    response = parser.parse(<<EOF.gsub(/\n/, "\r\n").taint)
+    response = parser.parse(<<EOF.gsub(/\n/, "\r\n"))
 * SEARCH 1 2 3\s
 EOF
     assert_equal [1, 2, 3], response.data
@@ -93,12 +93,12 @@ EOF
 
   def test_msg_att_extra_space
     parser = Net::IMAP::ResponseParser.new
-    response = parser.parse(<<EOF.gsub(/\n/, "\r\n").taint)
+    response = parser.parse(<<EOF.gsub(/\n/, "\r\n"))
 * 1 FETCH (UID 92285)
 EOF
     assert_equal 92285, response.data.attr["UID"]
 
-    response = parser.parse(<<EOF.gsub(/\n/, "\r\n").taint)
+    response = parser.parse(<<EOF.gsub(/\n/, "\r\n"))
 * 1 FETCH (UID 92285 )
 EOF
     assert_equal 92285, response.data.attr["UID"]
@@ -107,7 +107,7 @@ EOF
   def test_msg_att_parse_error
     parser = Net::IMAP::ResponseParser.new
     e = assert_raise(Net::IMAP::ResponseParseError) {
-      parser.parse(<<EOF.gsub(/\n/, "\r\n").taint)
+      parser.parse(<<EOF.gsub(/\n/, "\r\n"))
 * 123 FETCH (UNKNOWN 92285)
 EOF
     }
@@ -116,13 +116,13 @@ EOF
 
   def test_msg_att_rfc822_text
     parser = Net::IMAP::ResponseParser.new
-    response = parser.parse(<<EOF.gsub(/\n/, "\r\n").taint)
+    response = parser.parse(<<EOF.gsub(/\n/, "\r\n"))
 * 123 FETCH (RFC822 {5}
 foo
 )
 EOF
     assert_equal("foo\r\n", response.data.attr["RFC822"])
-    response = parser.parse(<<EOF.gsub(/\n/, "\r\n").taint)
+    response = parser.parse(<<EOF.gsub(/\n/, "\r\n"))
 * 123 FETCH (RFC822[] {5}
 foo
 )
@@ -133,7 +133,7 @@ EOF
   # [Bug #6397] [ruby-core:44849]
   def test_body_type_attachment
     parser = Net::IMAP::ResponseParser.new
-    response = parser.parse(<<EOF.gsub(/\n/, "\r\n").taint)
+    response = parser.parse(<<EOF.gsub(/\n/, "\r\n"))
 * 980 FETCH (UID 2862 BODYSTRUCTURE ((("TEXT" "PLAIN" ("CHARSET" "iso-8859-1") NIL NIL "7BIT" 416 21 NIL NIL NIL)("TEXT" "HTML" ("CHARSET" "iso-8859-1") NIL NIL "7BIT" 1493 32 NIL NIL NIL) "ALTERNATIVE" ("BOUNDARY" "Boundary_(ID_IaecgfnXwG5bn3x8lIeGIQ)") NIL NIL)("MESSAGE" "RFC822" ("NAME" "Fw_ ____ _____ ____.eml") NIL NIL "7BIT" 1980088 NIL ("ATTACHMENT" ("FILENAME" "Fw_ ____ _____ ____.eml")) NIL) "MIXED" ("BOUNDARY" "Boundary_(ID_eDdLc/j0mBIzIlR191pHjA)") NIL NIL))
 EOF
     assert_equal("Fw_ ____ _____ ____.eml",
@@ -142,7 +142,7 @@ EOF
 
   def assert_parseable(s)
     parser = Net::IMAP::ResponseParser.new
-    parser.parse(s.gsub(/\n/, "\r\n").taint)
+    parser.parse(s.gsub(/\n/, "\r\n"))
   end
 
   # [Bug #7146]
@@ -171,7 +171,7 @@ EOF
   # [Bug #8167]
   def test_msg_delivery_status_with_extra_data
     parser = Net::IMAP::ResponseParser.new
-    response = parser.parse(<<EOF.gsub(/\n/, "\r\n").taint)
+    response = parser.parse(<<EOF.gsub(/\n/, "\r\n"))
 * 29021 FETCH (RFC822.SIZE 3162 UID 113622 RFC822.HEADER {1155}
 Return-path: <>
 Envelope-to: info@xxxxxxxx.si
@@ -214,7 +214,7 @@ EOF
   # [Bug #8281]
   def test_acl
     parser = Net::IMAP::ResponseParser.new
-    response = parser.parse(<<EOF.gsub(/\n/, "\r\n").taint)
+    response = parser.parse(<<EOF.gsub(/\n/, "\r\n"))
 * ACL "INBOX/share" "imshare2copy1366146467@xxxxxxxxxxxxxxxxxx.com" lrswickxteda
 EOF
     assert_equal("ACL", response.name)

--- a/test/pathname/test_pathname.rb
+++ b/test/pathname/test_pathname.rb
@@ -592,39 +592,6 @@ class TestPathname < Test::Unit::TestCase
     assert_raise(ArgumentError) { Pathname.new("\0") }
   end
 
-  def test_taint
-    obj = Pathname.new("a"); assert_same(obj, obj.taint)
-    obj = Pathname.new("a"); assert_same(obj, obj.untaint)
-
-    assert_equal(false, Pathname.new("a"          )           .tainted?)
-    assert_equal(false, Pathname.new("a"          )      .to_s.tainted?)
-    assert_equal(true,  Pathname.new("a"          ).taint     .tainted?)
-    assert_equal(true,  Pathname.new("a"          ).taint.to_s.tainted?)
-    assert_equal(true,  Pathname.new("a".dup.taint)           .tainted?)
-    assert_equal(true,  Pathname.new("a".dup.taint)      .to_s.tainted?)
-    assert_equal(true,  Pathname.new("a".dup.taint).taint     .tainted?)
-    assert_equal(true,  Pathname.new("a".dup.taint).taint.to_s.tainted?)
-
-    str = "a".dup
-    path = Pathname.new(str)
-    str.taint
-    assert_equal(false, path     .tainted?)
-    assert_equal(false, path.to_s.tainted?)
-  end
-
-  def test_untaint
-    obj = Pathname.new("a"); assert_same(obj, obj.untaint)
-
-    assert_equal(false, Pathname.new("a").taint.untaint     .tainted?)
-    assert_equal(false, Pathname.new("a").taint.untaint.to_s.tainted?)
-
-    str = "a".dup.taint
-    path = Pathname.new(str)
-    str.untaint
-    assert_equal(true, path     .tainted?)
-    assert_equal(true, path.to_s.tainted?)
-  end
-
   def test_freeze
     obj = Pathname.new("a"); assert_same(obj, obj.freeze)
 
@@ -636,20 +603,6 @@ class TestPathname < Test::Unit::TestCase
     assert_equal(false, Pathname.new("a".freeze)       .to_s.frozen?)
     assert_equal(false, Pathname.new("a"       ).freeze.to_s.frozen?)
     assert_equal(false, Pathname.new("a".freeze).freeze.to_s.frozen?)
-  end
-
-  def test_freeze_and_taint
-    obj = Pathname.new("a")
-    obj.freeze
-    assert_equal(false, obj.tainted?)
-    assert_raise(FrozenError) { obj.taint }
-
-    obj = Pathname.new("a")
-    obj.taint
-    assert_equal(true, obj.tainted?)
-    obj.freeze
-    assert_equal(true, obj.tainted?)
-    assert_nothing_raised { obj.taint }
   end
 
   def test_to_s

--- a/test/pathname/test_pathname.rb
+++ b/test/pathname/test_pathname.rb
@@ -1467,16 +1467,6 @@ class TestPathname < Test::Unit::TestCase
     assert(File.fnmatch("*.*", Pathname.new("bar.baz")))
   end
 
-  def test_file_join
-    assert_equal("foo/bar", File.join(Pathname.new("foo"), Pathname.new("bar")))
-    lambda {
-      $SAFE = 1
-      assert_equal("foo/bar", File.join(Pathname.new("foo"), Pathname.new("bar").taint))
-    }.call
-  ensure
-    $SAFE = 0
-  end
-
   def test_relative_path_from_casefold
     assert_separately([], <<-'end;') #    do
       module File::Constants

--- a/test/readline/test_readline.rb
+++ b/test/readline/test_readline.rb
@@ -41,21 +41,6 @@ module BasetestReadline
       assert_equal("> ", stdout.read(2))
       assert_equal(1, Readline::HISTORY.length)
       assert_equal("hello", Readline::HISTORY[0])
-
-      # Work around lack of SecurityError in Reline
-      # test mode with tainted prompt
-      return if kind_of?(TestRelineAsReadline)
-
-      Thread.start {
-        $SAFE = 1
-        assert_raise(SecurityError) do
-          replace_stdio(stdin.path, stdout.path) do
-            Readline.readline("> ".taint)
-          end
-        end
-      }.join
-    ensure
-      $SAFE = 0
     end
   end
 

--- a/test/readline/test_readline.rb
+++ b/test/readline/test_readline.rb
@@ -41,6 +41,21 @@ module BasetestReadline
       assert_equal("> ", stdout.read(2))
       assert_equal(1, Readline::HISTORY.length)
       assert_equal("hello", Readline::HISTORY[0])
+
+      # Work around lack of SecurityError in Reline
+      # test mode with tainted prompt
+      return if kind_of?(TestRelineAsReadline)
+
+      Thread.start {
+        $SAFE = 1
+        assert_raise(SecurityError) do
+          replace_stdio(stdin.path, stdout.path) do
+            Readline.readline("> ".taint)
+          end
+        end
+      }.join
+    ensure
+      $SAFE = 0
     end
   end
 

--- a/test/rss/test_parser.rb
+++ b/test/rss/test_parser.rb
@@ -19,7 +19,7 @@ EOR
       @rss_tmp = Tempfile.new(%w"rss10- .rdf")
       @rss_tmp.print(@rss10)
       @rss_tmp.close
-      @rss_file = @rss_tmp.path.untaint
+      @rss_file = @rss_tmp.path
     end
 
     def teardown

--- a/test/ruby/test_alias.rb
+++ b/test/ruby/test_alias.rb
@@ -47,12 +47,6 @@ class TestAlias < Test::Unit::TestCase
     assert_raise(NoMethodError) { x.quux }
   end
 
-  class C
-    def m
-      $SAFE
-    end
-  end
-
   def test_nonexistmethod
     assert_raise(NameError){
       Class.new{

--- a/test/ruby/test_array.rb
+++ b/test/ruby/test_array.rb
@@ -556,18 +556,14 @@ class TestArray < Test::Unit::TestCase
   end
 
   def test_clone
-    for taint in [ false, true ]
-      for frozen in [ false, true ]
-        a = @cls[*(0..99).to_a]
-        a.taint  if taint
-        a.freeze if frozen
-        b = a.clone
+    for frozen in [ false, true ]
+      a = @cls[*(0..99).to_a]
+      a.freeze if frozen
+      b = a.clone
 
-        assert_equal(a, b)
-        assert_not_equal(a.__id__, b.__id__)
-        assert_equal(a.frozen?, b.frozen?)
-        assert_equal(a.tainted?, b.tainted?)
-      end
+      assert_equal(a, b)
+      assert_not_equal(a.__id__, b.__id__)
+      assert_equal(a.frozen?, b.frozen?)
     end
   end
 
@@ -754,18 +750,14 @@ class TestArray < Test::Unit::TestCase
   end
 
   def test_dup
-    for taint in [ false, true ]
-      for frozen in [ false, true ]
-        a = @cls[*(0..99).to_a]
-        a.taint  if taint
-        a.freeze if frozen
-        b = a.dup
+    for frozen in [ false, true ]
+      a = @cls[*(0..99).to_a]
+      a.freeze if frozen
+      b = a.dup
 
-        assert_equal(a, b)
-        assert_not_equal(a.__id__, b.__id__)
-        assert_equal(false, b.frozen?)
-        assert_equal(a.tainted?, b.tainted?)
-      end
+      assert_equal(a, b)
+      assert_not_equal(a.__id__, b.__id__)
+      assert_equal(false, b.frozen?)
     end
   end
 
@@ -863,13 +855,6 @@ class TestArray < Test::Unit::TestCase
 
   def test_flatten_wrong_argument
     assert_raise(TypeError, "[ruby-dev:31197]") { [[]].flatten("") }
-  end
-
-  def test_flatten_taint
-    a6 = @cls[[1, 2], 3]
-    a6.taint
-    a7 = a6.flatten
-    assert_equal(true, a7.tainted?)
   end
 
   def test_flatten_level0
@@ -1132,20 +1117,6 @@ class TestArray < Test::Unit::TestCase
     assert_equal("1,2,3", a.join(','))
 
     $, = ""
-    a = @cls[1, 2, 3]
-    a.taint
-    s = a.join
-    assert_equal(true, s.tainted?)
-
-    bug5902 = '[ruby-core:42161]'
-    sep = ":".taint
-
-    s = @cls[].join(sep)
-    assert_equal(false, s.tainted?, bug5902)
-    s = @cls[1].join(sep)
-    assert_equal(false, s.tainted?, bug5902)
-    s = @cls[1, 2].join(sep)
-    assert_equal(true, s.tainted?, bug5902)
 
     e = ''.force_encoding('EUC-JP')
     u = ''.force_encoding('UTF-8')
@@ -2897,13 +2868,6 @@ class TestArray < Test::Unit::TestCase
     assert_equal(Array2, Array2[1,2,3].uniq.class, "[ruby-dev:34581]")
     assert_equal(Array2, Array2[1,2][0,1].class) # embedded
     assert_equal(Array2, Array2[*(1..100)][1..99].class) #not embedded
-  end
-
-  def test_inspect
-    a = @cls[1, 2, 3]
-    a.taint
-    s = a.inspect
-    assert_equal(true, s.tainted?)
   end
 
   def test_initialize2

--- a/test/ruby/test_econv.rb
+++ b/test/ruby/test_econv.rb
@@ -685,7 +685,6 @@ class TestEncodingConverter < Test::Unit::TestCase
     ec = Encoding::Converter.new("utf-8", "euc-jp")
     assert_raise(Encoding::InvalidByteSequenceError) { ec.convert("a\x80") }
     assert_raise(Encoding::UndefinedConversionError) { ec.convert("\ufffd") }
-    assert_predicate(ec.convert("abc".taint), :tainted?)
     ret = ec.primitive_convert(nil, "", nil, nil)
     assert_equal(:finished, ret)
     assert_raise(ArgumentError) { ec.convert("a") }

--- a/test/ruby/test_encoding.rb
+++ b/test/ruby/test_encoding.rb
@@ -34,9 +34,6 @@ class TestEncoding < Test::Unit::TestCase
       assert_raise(TypeError) { e.dup }
       assert_raise(TypeError) { e.clone }
       assert_equal(e.object_id, Marshal.load(Marshal.dump(e)).object_id)
-      assert_not_predicate(e, :tainted?)
-      Marshal.load(Marshal.dump(e).taint)
-      assert_not_predicate(e, :tainted?, '[ruby-core:71793] [Bug #11760]')
     end
   end
 

--- a/test/ruby/test_env.rb
+++ b/test/ruby/test_env.rb
@@ -46,7 +46,6 @@ class TestEnv < Test::Unit::TestCase
     end
     ENV['TEST'] = 'bar'
     assert_equal('bar', ENV['TEST'])
-    assert_predicate(ENV['TEST'], :tainted?)
     if IGNORE_CASE
       assert_equal('bar', ENV['test'])
     else
@@ -113,7 +112,6 @@ class TestEnv < Test::Unit::TestCase
     assert_invalid_env {|v| ENV[v]}
     ENV[PATH_ENV] = ""
     assert_equal("", ENV[PATH_ENV])
-    assert_predicate(ENV[PATH_ENV], :tainted?)
     assert_nil(ENV[""])
   end
 
@@ -136,7 +134,6 @@ class TestEnv < Test::Unit::TestCase
     assert_nothing_raised { ENV.fetch(PATH_ENV, "foo") }
     ENV[PATH_ENV] = ""
     assert_equal("", ENV.fetch(PATH_ENV))
-    assert_predicate(ENV.fetch(PATH_ENV), :tainted?)
   end
 
   def test_aset
@@ -154,9 +151,6 @@ class TestEnv < Test::Unit::TestCase
       assert_equal("test", ENV["foo"])
     rescue Errno::EINVAL
     end
-
-    ENV[PATH_ENV] = "/tmp/".taint
-    assert_equal("/tmp/", ENV[PATH_ENV])
   end
 
   def test_keys
@@ -364,7 +358,6 @@ class TestEnv < Test::Unit::TestCase
       assert_equal("foo", v)
     end
     assert_invalid_env {|var| ENV.assoc(var)}
-    assert_predicate(v, :tainted?)
     assert_equal(Encoding.find("locale"), v.encoding)
   end
 

--- a/test/ruby/test_exception.rb
+++ b/test/ruby/test_exception.rb
@@ -550,28 +550,6 @@ end.join
     end
   end
 
-  def test_to_s_taintness_propagation
-    for exc in [Exception, NameError]
-      m = "abcdefg"
-      e = exc.new(m)
-      e.taint
-      s = e.to_s
-      assert_equal(false, m.tainted?,
-                   "#{exc}#to_s should not propagate taintness")
-      assert_equal(false, s.tainted?,
-                   "#{exc}#to_s should not propagate taintness")
-    end
-
-    o = Object.new
-    def o.to_str
-      "foo"
-    end
-    o.taint
-    e = NameError.new(o)
-    s = e.to_s
-    assert_equal(false, s.tainted?)
-  end
-
   def m
     m(&->{return 0})
     42

--- a/test/ruby/test_file.rb
+++ b/test/ruby/test_file.rb
@@ -287,26 +287,6 @@ class TestFile < Test::Unit::TestCase
     }
   end
 
-  def test_realpath_taintedness
-    Dir.mktmpdir('rubytest-realpath') {|tmpdir|
-      dir = File.realpath(tmpdir).untaint
-      File.write(File.join(dir, base = "test.file"), '')
-      base.taint
-      dir.taint
-      assert_predicate(File.realpath(base, dir), :tainted?)
-      base.untaint
-      dir.taint
-      assert_predicate(File.realpath(base, dir), :tainted?)
-      base.taint
-      dir.untaint
-      assert_predicate(File.realpath(base, dir), :tainted?)
-      base.untaint
-      dir.untaint
-      assert_predicate(File.realpath(base, dir), :tainted?)
-      assert_predicate(Dir.chdir(dir) {File.realpath(base)}, :tainted?)
-    }
-  end
-
   def test_realpath_special_symlink
     IO.pipe do |r, w|
       if File.pipe?(path = "/dev/fd/#{r.fileno}")

--- a/test/ruby/test_file.rb
+++ b/test/ruby/test_file.rb
@@ -471,18 +471,6 @@ class TestFile < Test::Unit::TestCase
     end
   end
 
-  def test_untainted_path
-    bug5374 = '[ruby-core:39745]'
-    cwd = ("./"*40+".".taint).dup.untaint
-    in_safe = proc {|safe| $SAFE = safe; File.stat(cwd)}
-    assert_not_send([cwd, :tainted?])
-    (0..1).each do |level|
-      assert_nothing_raised(SecurityError, bug5374) {in_safe[level]}
-    end
-  ensure
-    $SAFE = 0
-  end
-
   if /(bcc|ms|cyg)win|mingw|emx/ =~ RUBY_PLATFORM
     def test_long_unc
       feature3399 = '[ruby-core:30623]'

--- a/test/ruby/test_hash.rb
+++ b/test/ruby/test_hash.rb
@@ -320,17 +320,6 @@ class TestHash < Test::Unit::TestCase
     assert_same "ABC".freeze, c.keys[0]
   end
 
-  def test_tainted_string_key
-    str = 'str'.taint
-    h = {}
-    h[str] = nil
-    key = h.keys.first
-    assert_predicate str, :tainted?
-    assert_not_predicate str, :frozen?
-    assert_predicate key, :tainted?
-    assert_predicate key, :frozen?
-  end
-
   def test_EQUAL # '=='
     h1 = @cls[ "a" => 1, "c" => 2 ]
     h2 = @cls[ "a" => 1, "c" => 2, 7 => 35 ]
@@ -353,18 +342,14 @@ class TestHash < Test::Unit::TestCase
   end
 
   def test_clone
-    for taint in [ false, true ]
-      for frozen in [ false, true ]
-        a = @h.clone
-        a.taint  if taint
-        a.freeze if frozen
-        b = a.clone
+    for frozen in [ false, true ]
+      a = @h.clone
+      a.freeze if frozen
+      b = a.clone
 
-        assert_equal(a, b)
-        assert_not_same(a, b)
-        assert_equal(a.frozen?, b.frozen?)
-        assert_equal(a.tainted?, b.tainted?)
-      end
+      assert_equal(a, b)
+      assert_not_same(a, b)
+      assert_equal(a.frozen?, b.frozen?)
     end
   end
 
@@ -451,18 +436,14 @@ class TestHash < Test::Unit::TestCase
   end
 
   def test_dup
-    for taint in [ false, true ]
-      for frozen in [ false, true ]
-        a = @h.dup
-        a.taint  if taint
-        a.freeze if frozen
-        b = a.dup
+    for frozen in [ false, true ]
+      a = @h.dup
+      a.freeze if frozen
+      b = a.dup
 
-        assert_equal(a, b)
-        assert_not_same(a, b)
-        assert_equal(false, b.frozen?)
-        assert_equal(a.tainted?, b.tainted?)
-      end
+      assert_equal(a, b)
+      assert_not_same(a, b)
+      assert_equal(false, b.frozen?)
     end
   end
 
@@ -712,10 +693,8 @@ class TestHash < Test::Unit::TestCase
 
     h.instance_variable_set(:@foo, :foo)
     h.default = 42
-    h.taint
     h = EnvUtil.suppress_warning {h.reject {false}}
     assert_instance_of(Hash, h)
-    assert_not_predicate(h, :tainted?)
     assert_nil(h.default)
     assert_not_send([h, :instance_variable_defined?, :@foo])
   end
@@ -840,11 +819,6 @@ class TestHash < Test::Unit::TestCase
     assert_equal([3,4], a.delete([3,4]))
     assert_equal([5,6], a.delete([5,6]))
     assert_equal(0, a.length)
-
-    h = @cls[ 1=>2, 3=>4, 5=>6 ]
-    h.taint
-    a = h.to_a
-    assert_equal(true, a.tainted?)
   end
 
   def test_to_hash
@@ -1037,10 +1011,8 @@ class TestHash < Test::Unit::TestCase
 
     h.instance_variable_set(:@foo, :foo)
     h.default = 42
-    h.taint
     h = h.select {true}
     assert_instance_of(Hash, h)
-    assert_not_predicate(h, :tainted?)
     assert_nil(h.default)
     assert_not_send([h, :instance_variable_defined?, :@foo])
   end
@@ -1083,10 +1055,8 @@ class TestHash < Test::Unit::TestCase
 
     h.instance_variable_set(:@foo, :foo)
     h.default = 42
-    h.taint
     h = h.filter {true}
     assert_instance_of(Hash, h)
-    assert_not_predicate(h, :tainted?)
     assert_nil(h.default)
     assert_not_send([h, :instance_variable_defined?, :@foo])
   end

--- a/test/ruby/test_io.rb
+++ b/test/ruby/test_io.rb
@@ -2768,13 +2768,6 @@ class TestIO < Test::Unit::TestCase
     }
   end if /freebsd|linux/ =~ RUBY_PLATFORM and defined? File::NOFOLLOW
 
-  def test_tainted
-    make_tempfile {|t|
-      assert_predicate(File.read(t.path, 4), :tainted?, '[ruby-dev:38826]')
-      assert_predicate(File.open(t.path) {|f| f.read(4)}, :tainted?, '[ruby-dev:38826]')
-    }
-  end
-
   def test_binmode_after_closed
     make_tempfile {|t|
       assert_raise(IOError) {t.binmode}

--- a/test/ruby/test_m17n.rb
+++ b/test/ruby/test_m17n.rb
@@ -1582,8 +1582,6 @@ class TestM17N < Test::Unit::TestCase
     s = "\u3042"
     assert_equal(a("\xE3\x81\x82"), s.b)
     assert_equal(Encoding::ASCII_8BIT, s.b.encoding)
-    s.taint
-    assert_predicate(s.b, :tainted?)
     s = "abc".b
     assert_predicate(s.b, :ascii_only?)
   end
@@ -1592,16 +1590,13 @@ class TestM17N < Test::Unit::TestCase
     str = "foo"
     assert_equal(str, str.scrub)
     assert_not_same(str, str.scrub)
-    assert_predicate(str.dup.taint.scrub, :tainted?)
     str = "\u3042\u3044"
     assert_equal(str, str.scrub)
     assert_not_same(str, str.scrub)
-    assert_predicate(str.dup.taint.scrub, :tainted?)
     str.force_encoding(Encoding::ISO_2022_JP) # dummy encoding
     assert_equal(str, str.scrub)
     assert_not_same(str, str.scrub)
     assert_nothing_raised(ArgumentError) {str.scrub(nil)}
-    assert_predicate(str.dup.taint.scrub, :tainted?)
   end
 
   def test_scrub_modification_inside_block
@@ -1620,8 +1615,6 @@ class TestM17N < Test::Unit::TestCase
   def test_scrub_replace_default
     assert_equal("\uFFFD\uFFFD\uFFFD", u("\x80\x80\x80").scrub)
     assert_equal("\uFFFDA", u("\xF4\x80\x80A").scrub)
-    assert_predicate(u("\x80\x80\x80").taint.scrub, :tainted?)
-    assert_predicate(u("\xF4\x80\x80A").taint.scrub, :tainted?)
 
     # examples in Unicode 6.1.0 D93b
     assert_equal("\x41\uFFFD\uFFFD\x41\uFFFD\x41",
@@ -1636,14 +1629,8 @@ class TestM17N < Test::Unit::TestCase
 
   def test_scrub_replace_argument
     assert_equal("foo", u("foo").scrub("\u3013"))
-    assert_predicate(u("foo").taint.scrub("\u3013"), :tainted?)
-    assert_not_predicate(u("foo").scrub("\u3013".taint), :tainted?)
     assert_equal("\u3042\u3044", u("\xE3\x81\x82\xE3\x81\x84").scrub("\u3013"))
-    assert_predicate(u("\xE3\x81\x82\xE3\x81\x84").taint.scrub("\u3013"), :tainted?)
-    assert_not_predicate(u("\xE3\x81\x82\xE3\x81\x84").scrub("\u3013".taint), :tainted?)
     assert_equal("\u3042\u3013", u("\xE3\x81\x82\xE3\x81").scrub("\u3013"))
-    assert_predicate(u("\xE3\x81\x82\xE3\x81").taint.scrub("\u3013"), :tainted?)
-    assert_predicate(u("\xE3\x81\x82\xE3\x81").scrub("\u3013".taint), :tainted?)
     assert_raise(Encoding::CompatibilityError){ u("\xE3\x81\x82\xE3\x81").scrub(e("\xA4\xA2")) }
     assert_raise(TypeError){ u("\xE3\x81\x82\xE3\x81").scrub(1) }
     assert_raise(ArgumentError){ u("\xE3\x81\x82\xE3\x81\x82\xE3\x81").scrub(u("\x81")) }
@@ -1652,8 +1639,6 @@ class TestM17N < Test::Unit::TestCase
 
   def test_scrub_replace_block
     assert_equal("\u3042<e381>", u("\xE3\x81\x82\xE3\x81").scrub{|x|'<'+x.unpack('H*')[0]+'>'})
-    assert_predicate(u("\xE3\x81\x82\xE3\x81").taint.scrub{|x|'<'+x.unpack('H*')[0]+'>'}, :tainted?)
-    assert_predicate(u("\xE3\x81\x82\xE3\x81").scrub{|x|('<'+x.unpack('H*')[0]+'>').taint}, :tainted?)
     assert_raise(Encoding::CompatibilityError){ u("\xE3\x81\x82\xE3\x81").scrub{e("\xA4\xA2")} }
     assert_raise(TypeError){ u("\xE3\x81\x82\xE3\x81").scrub{1} }
     assert_raise(ArgumentError){ u("\xE3\x81\x82\xE3\x81\x82\xE3\x81").scrub{u("\x81")} }

--- a/test/ruby/test_method.rb
+++ b/test/ruby/test_method.rb
@@ -456,9 +456,6 @@ class TestMethod < Test::Unit::TestCase
     c3.class_eval { alias bar foo }
     m3 = c3.new.method(:bar)
     assert_equal("#<Method: #{c3.inspect}(#{c.inspect})#bar(foo) #{__FILE__}:#{line_no}>", m3.inspect, bug7806)
-
-    m.taint
-    assert_predicate(m.inspect, :tainted?, "inspect result should be infected")
   end
 
   def test_callee_top_level

--- a/test/ruby/test_optimization.rb
+++ b/test/ruby/test_optimization.rb
@@ -714,17 +714,6 @@ class TestRubyOptimization < Test::Unit::TestCase
     END
   end
 
-  def test_block_parameter_should_restore_safe_level
-    assert_separately [], <<-END
-      #
-      def foo &b
-        $SAFE = 1
-        b.call
-      end
-      assert_equal 1, foo{$SAFE}
-    END
-  end
-
   def test_peephole_optimization_without_trace
     assert_separately [], <<-END
       RubyVM::InstructionSequence.compile_option = {trace_instruction: false}

--- a/test/ruby/test_pack.rb
+++ b/test/ruby/test_pack.rb
@@ -869,20 +869,4 @@ EXPECTED
     assert_equal "hogefuga", "aG9nZWZ1Z2E=".unpack1("m")
     assert_equal "01000001", "A".unpack1("B*")
   end
-
-  def test_pack_infection
-    tainted_array_string = ["123456"]
-    tainted_array_string.first.taint
-    ['a', 'A', 'Z', 'B', 'b', 'H', 'h', 'u', 'M', 'm', 'P', 'p'].each do |f|
-      assert_predicate(tainted_array_string.pack(f), :tainted?)
-    end
-  end
-
-  def test_unpack_infection
-    tainted_string = "123456"
-    tainted_string.taint
-    ['a', 'A', 'Z', 'B', 'b', 'H', 'h', 'u', 'M', 'm'].each do |f|
-      assert_predicate(tainted_string.unpack(f).first, :tainted?)
-    end
-  end
 end

--- a/test/ruby/test_proc.rb
+++ b/test/ruby/test_proc.rb
@@ -1158,9 +1158,6 @@ class TestProc < Test::Unit::TestCase
     assert_match(/^#<Proc:0x\h+ #{ Regexp.quote(__FILE__) }:\d+>$/, proc {}.to_s)
     assert_match(/^#<Proc:0x\h+ #{ Regexp.quote(__FILE__) }:\d+ \(lambda\)>$/, lambda {}.to_s)
     assert_match(/^#<Proc:0x\h+ \(lambda\)>$/, method(:p).to_proc.to_s)
-    x = proc {}
-    x.taint
-    assert_predicate(x.to_s, :tainted?)
     name = "Proc\u{1f37b}"
     assert_include(EnvUtil.labeled_class(name, Proc).new {}.to_s, name)
   end

--- a/test/ruby/test_proc.rb
+++ b/test/ruby/test_proc.rb
@@ -157,45 +157,6 @@ class TestProc < Test::Unit::TestCase
     assert_equal(12, Proc.new{|a,&b| b.call(a)}.call(12) {|x| x})
   end
 
-  def test_safe
-    safe = $SAFE
-    c = Class.new
-    x = c.new
-
-    p = proc {
-      $SAFE += 1
-      proc {$SAFE}
-    }.call
-
-    assert_equal(safe + 1, $SAFE)
-    assert_equal(safe + 1, p.call)
-    assert_equal(safe + 1, $SAFE)
-
-    $SAFE = 0
-    c.class_eval {define_method(:safe, p)}
-    assert_equal(safe, x.safe)
-
-    $SAFE = 0
-    p = proc {$SAFE += 1}
-    assert_equal(safe + 1, p.call)
-    assert_equal(safe + 1, $SAFE)
-
-    $SAFE = 0
-    c.class_eval {define_method(:inc, p)}
-    assert_equal(safe + 1, proc {x.inc; $SAFE}.call)
-    assert_equal(safe + 1, $SAFE)
-
-    $SAFE = 0
-    assert_equal(safe + 1, proc {x.method(:inc).call; $SAFE}.call)
-    assert_equal(safe + 1, $SAFE)
-
-    $SAFE = 0
-    assert_equal(safe + 1, proc {x.method(:inc).to_proc.call; $SAFE}.call)
-    assert_equal(safe + 1, $SAFE)
-  ensure
-    $SAFE = 0
-  end
-
   def m2
     "OK"
   end

--- a/test/ruby/test_range.rb
+++ b/test/ruby/test_range.rb
@@ -499,11 +499,6 @@ class TestRange < Test::Unit::TestCase
     assert_equal("0...1", (0...1).to_s)
     assert_equal("0..", (0..nil).to_s)
     assert_equal("0...", (0...nil).to_s)
-
-    bug11767 = '[ruby-core:71811] [Bug #11767]'
-    assert_predicate(("0".taint.."1").to_s, :tainted?, bug11767)
-    assert_predicate(("0".."1".taint).to_s, :tainted?, bug11767)
-    assert_predicate(("0".."1").taint.to_s, :tainted?, bug11767)
   end
 
   def test_inspect
@@ -515,11 +510,6 @@ class TestRange < Test::Unit::TestCase
     assert_equal("...1", (nil...1).inspect)
     assert_equal("nil..nil", (nil..nil).inspect)
     assert_equal("nil...nil", (nil...nil).inspect)
-
-    bug11767 = '[ruby-core:71811] [Bug #11767]'
-    assert_predicate(("0".taint.."1").inspect, :tainted?, bug11767)
-    assert_predicate(("0".."1".taint).inspect, :tainted?, bug11767)
-    assert_predicate(("0".."1").taint.inspect, :tainted?, bug11767)
   end
 
   def test_eqq

--- a/test/ruby/test_refinement.rb
+++ b/test/ruby/test_refinement.rb
@@ -2064,7 +2064,6 @@ class TestRefinement < Test::Unit::TestCase
 
   def test_tostring
     assert_equal("ok", ToString.new.string)
-    assert_predicate(ToString.new.taint.string, :tainted?)
   end
 
   class ToSymbol

--- a/test/ruby/test_require.rb
+++ b/test/ruby/test_require.rb
@@ -398,13 +398,6 @@ class TestRequire < Test::Unit::TestCase
 
       assert_separately([], <<-INPUT)
         abs_dir = "#{ abs_dir }"
-        $: << abs_dir.taint
-        $SAFE = 1
-        assert_raise(SecurityError) {require "#{ file }"}
-      INPUT
-
-      assert_separately([], <<-INPUT)
-        abs_dir = "#{ abs_dir }"
         $: << abs_dir << 'elsewhere'.taint
         assert_nothing_raised {require "#{ file }"}
       INPUT

--- a/test/ruby/test_require.rb
+++ b/test/ruby/test_require.rb
@@ -379,31 +379,6 @@ class TestRequire < Test::Unit::TestCase
     end
   end
 
-  def test_tainted_loadpath
-    Tempfile.create(["test_ruby_test_require", ".rb"]) {|t|
-      abs_dir, file = File.split(t.path)
-      abs_dir = File.expand_path(abs_dir).untaint
-
-      assert_separately([], <<-INPUT)
-        abs_dir = "#{ abs_dir }"
-        $: << abs_dir
-        assert_nothing_raised {require "#{ file }"}
-      INPUT
-
-      assert_separately([], <<-INPUT)
-        abs_dir = "#{ abs_dir }"
-        $: << abs_dir.taint
-        assert_nothing_raised {require "#{ file }"}
-      INPUT
-
-      assert_separately([], <<-INPUT)
-        abs_dir = "#{ abs_dir }"
-        $: << abs_dir << 'elsewhere'.taint
-        assert_nothing_raised {require "#{ file }"}
-      INPUT
-    }
-  end
-
   def test_relative
     load_path = $:.dup
     $:.delete(".")

--- a/test/ruby/test_rubyoptions.rb
+++ b/test/ruby/test_rubyoptions.rb
@@ -1043,13 +1043,6 @@ class TestRubyOptions < Test::Unit::TestCase
     assert_in_out_err([IO::NULL], success: true)
   end
 
-  def test_argv_tainted
-    assert_separately(%w[- arg], "#{<<~"begin;"}\n#{<<~'end;'}")
-    begin;
-      assert_predicate(ARGV[0], :tainted?, '[ruby-dev:50596] [Bug #14941]')
-    end;
-  end
-
   private
 
   def mjit_force_enabled?

--- a/test/ruby/test_rubyoptions.rb
+++ b/test/ruby/test_rubyoptions.rb
@@ -79,14 +79,6 @@ class TestRubyOptions < Test::Unit::TestCase
     ENV['RUBYOPT'] = save_rubyopt
   end
 
-  def test_safe_level
-    assert_in_out_err(%w(-T -e) + [""], "", [],
-                      /no -e allowed in tainted mode \(SecurityError\)/)
-
-    assert_in_out_err(%w(-T4 -S foo.rb), "", [],
-                      /no -S allowed in tainted mode \(SecurityError\)/)
-  end
-
   def test_debug
     assert_in_out_err(["--disable-gems", "-de", "p $DEBUG"], "", %w(true), [])
 
@@ -325,12 +317,6 @@ class TestRubyOptions < Test::Unit::TestCase
 
     ENV['RUBYOPT'] = '-e "p 1"'
     assert_in_out_err([], "", [], /invalid switch in RUBYOPT: -e \(RuntimeError\)/)
-
-    ENV['RUBYOPT'] = '-T1'
-    assert_in_out_err(["--disable-gems"], "", [], /no program input from stdin allowed in tainted mode \(SecurityError\)/)
-
-    ENV['RUBYOPT'] = '-T4'
-    assert_in_out_err(["--disable-gems"], "", [], /no program input from stdin allowed in tainted mode \(SecurityError\)/)
 
     ENV['RUBYOPT'] = '-Eus-ascii -KN'
     assert_in_out_err(%w(-Eutf-8 -KU), "p '\u3042'") do |r, e|

--- a/test/ruby/test_signal.rb
+++ b/test/ruby/test_signal.rb
@@ -137,11 +137,6 @@ class TestSignal < Test::Unit::TestCase
 
       assert_raise(ArgumentError) { Signal.trap }
 
-      assert_raise(SecurityError) do
-        s = proc {}.taint
-        Signal.trap(:INT, s)
-      end
-
       # FIXME!
       Signal.trap(:INT, nil)
       Signal.trap(:INT, "")

--- a/test/ruby/test_symbol.rb
+++ b/test/ruby/test_symbol.rb
@@ -538,14 +538,6 @@ class TestSymbol < Test::Unit::TestCase
     end;
   end
 
-  def test_not_freeze
-    bug11721 = '[ruby-core:71611] [Bug #11721]'
-    str = "\u{1f363}".taint
-    assert_not_predicate(str, :frozen?)
-    assert_equal str, str.to_sym.to_s
-    assert_not_predicate(str, :frozen?, bug11721)
-  end
-
   def test_hash_nondeterministic
     ruby = EnvUtil.rubybin
     assert_not_equal :foo.hash, `#{ruby} -e 'puts :foo.hash'`.to_i,

--- a/test/ruby/test_thread.rb
+++ b/test/ruby/test_thread.rb
@@ -533,23 +533,6 @@ class TestThread < Test::Unit::TestCase
     waiter&.kill&.join
   end
 
-  def test_safe_level
-    ok = false
-    t = Thread.new do
-      EnvUtil.suppress_warning do
-        $SAFE = 1
-      end
-      ok = true
-      sleep
-    end
-    Thread.pass until ok
-    assert_equal($SAFE, Thread.current.safe_level)
-    assert_equal($SAFE, t.safe_level)
-  ensure
-    $SAFE = 0
-    t&.kill&.join
-  end
-
   def test_thread_local
     t = Thread.new { sleep }
 

--- a/test/ruby/test_trace.rb
+++ b/test/ruby/test_trace.rb
@@ -20,17 +20,6 @@ class TestTrace < Test::Unit::TestCase
     untrace_var :$x
   end
 
-  def test_trace_tainted_proc
-    $x = 1234
-    s = proc { $y = :foo }
-    trace_var :$x, s
-    s.taint
-    $x = 42
-    assert_equal(:foo, $y)
-  ensure
-    untrace_var :$x
-  end
-
   def test_trace_proc_that_raises_exception
     $x = 1234
     trace_var :$x, proc { raise }

--- a/test/strscan/test_stringscanner.rb
+++ b/test/strscan/test_stringscanner.rb
@@ -16,20 +16,12 @@ class TestStringScanner < Test::Unit::TestCase
     s = create_string_scanner('test string')
     assert_instance_of StringScanner, s
     assert_equal false, s.eos?
-    assert_equal false, s.tainted?
 
     str = 'test string'.dup
-    str.taint
     s = create_string_scanner(str, false)
     assert_instance_of StringScanner, s
     assert_equal false, s.eos?
     assert_same str, s.string
-    assert_equal true, s.string.tainted?
-
-    str = 'test string'.dup
-    str.taint
-    s = create_string_scanner(str)
-    assert_equal true, s.string.tainted?
   end
 
   UNINIT_ERROR = ArgumentError
@@ -101,14 +93,12 @@ class TestStringScanner < Test::Unit::TestCase
 
   def test_inspect
     str = 'test string'.dup
-    str.taint
     s = create_string_scanner(str, false)
     assert_instance_of String, s.inspect
     assert_equal s.inspect, s.inspect
     assert_equal '#<StringScanner 0/11 @ "test ...">', s.inspect.sub(/StringScanner_C/, 'StringScanner')
     s.get_byte
     assert_equal '#<StringScanner 1/11 "t" @ "est s...">', s.inspect.sub(/StringScanner_C/, 'StringScanner')
-    assert_equal true, s.inspect.tainted?
 
     s = create_string_scanner("\n")
     assert_equal '#<StringScanner 0/1 @ "\n">', s.inspect
@@ -233,40 +223,33 @@ class TestStringScanner < Test::Unit::TestCase
     s = create_string_scanner('stra strb strc', true)
     tmp = s.scan(/\w+/)
     assert_equal 'stra', tmp
-    assert_equal false, tmp.tainted?
 
     tmp = s.scan(/\s+/)
     assert_equal ' ', tmp
-    assert_equal false, tmp.tainted?
 
     assert_equal 'strb', s.scan(/\w+/)
     assert_equal ' ',    s.scan(/\s+/)
 
     tmp = s.scan(/\w+/)
     assert_equal 'strc', tmp
-    assert_equal false, tmp.tainted?
 
     assert_nil           s.scan(/\w+/)
     assert_nil           s.scan(/\w+/)
 
 
     str = 'stra strb strc'.dup
-    str.taint
     s = create_string_scanner(str, false)
     tmp = s.scan(/\w+/)
     assert_equal 'stra', tmp
-    assert_equal true, tmp.tainted?
 
     tmp = s.scan(/\s+/)
     assert_equal ' ', tmp
-    assert_equal true, tmp.tainted?
 
     assert_equal 'strb', s.scan(/\w+/)
     assert_equal ' ',    s.scan(/\s+/)
 
     tmp = s.scan(/\w+/)
     assert_equal 'strc', tmp
-    assert_equal true, tmp.tainted?
 
     assert_nil           s.scan(/\w+/)
     assert_nil           s.scan(/\w+/)
@@ -291,15 +274,12 @@ class TestStringScanner < Test::Unit::TestCase
     assert_equal 'str', s.scan('str')
     assert_equal 'str', s[0]
     assert_equal 3, s.pos
-    assert_equal false, s.tainted?
     assert_equal 'a ', s.scan('a ')
 
     str = 'stra strb strc'.dup
-    str.taint
     s = create_string_scanner(str, false)
     matched = s.scan('str')
     assert_equal 'str', matched
-    assert_equal true, matched.tainted?
   end
 
   def test_skip
@@ -346,14 +326,6 @@ class TestStringScanner < Test::Unit::TestCase
     assert_equal 'e', s.getch
     assert_nil        s.getch
 
-    str = 'abc'.dup
-    str.taint
-    s = create_string_scanner(str)
-    assert_equal true, s.getch.tainted?
-    assert_equal true, s.getch.tainted?
-    assert_equal true, s.getch.tainted?
-    assert_nil s.getch
-
     s = create_string_scanner("\244\242".dup.force_encoding("euc-jp"))
     assert_equal "\244\242".dup.force_encoding("euc-jp"), s.getch
     assert_nil s.getch
@@ -374,14 +346,6 @@ class TestStringScanner < Test::Unit::TestCase
     assert_nil        s.get_byte
     assert_nil        s.get_byte
 
-    str = 'abc'.dup
-    str.taint
-    s = create_string_scanner(str)
-    assert_equal true, s.get_byte.tainted?
-    assert_equal true, s.get_byte.tainted?
-    assert_equal true, s.get_byte.tainted?
-    assert_nil s.get_byte
-
     s = create_string_scanner("\244\242".dup.force_encoding("euc-jp"))
     assert_equal "\244".dup.force_encoding("euc-jp"), s.get_byte
     assert_equal "\242".dup.force_encoding("euc-jp"), s.get_byte
@@ -397,7 +361,6 @@ class TestStringScanner < Test::Unit::TestCase
     s = create_string_scanner('stra strb strc')
     s.scan(/\w+/)
     assert_equal 'stra', s.matched
-    assert_equal false, s.matched.tainted?
     s.scan(/\s+/)
     assert_equal ' ', s.matched
     s.scan('st')
@@ -416,18 +379,9 @@ class TestStringScanner < Test::Unit::TestCase
     s = create_string_scanner('stra strb strc')
     s.getch
     assert_equal 's', s.matched
-    assert_equal false, s.matched.tainted?
     s.get_byte
     assert_equal 't', s.matched
     assert_equal 't', s.matched
-    assert_equal false, s.matched.tainted?
-
-    str = 'test'.dup
-    str.taint
-    s = create_string_scanner(str)
-    s.scan(/\w+/)
-    assert_equal true, s.matched.tainted?
-    assert_equal true, s.matched.tainted?
   end
 
   def test_AREF
@@ -440,9 +394,6 @@ class TestStringScanner < Test::Unit::TestCase
     assert_nil           s[1]
     assert_raise(IndexError) { s[:c] }
     assert_raise(IndexError) { s['c'] }
-
-    assert_equal false,  s[-1].tainted?
-    assert_equal false,  s[0].tainted?
 
     s.skip(/\s+/)
     assert_nil           s[-2]
@@ -486,16 +437,6 @@ class TestStringScanner < Test::Unit::TestCase
     s.getch
     assert_equal "\244\242".dup.force_encoding("euc-jp"), s[0]
 
-    str = 'test'.dup
-    str.taint
-    s = create_string_scanner(str)
-    s.scan(/(t)(e)(s)(t)/)
-    assert_equal true, s[0].tainted?
-    assert_equal true, s[1].tainted?
-    assert_equal true, s[2].tainted?
-    assert_equal true, s[3].tainted?
-    assert_equal true, s[4].tainted?
-
     s = create_string_scanner("foo bar baz")
     s.scan(/(?<a>\w+) (?<b>\w+) (\w+)/)
     assert_equal 'foo', s[1]
@@ -514,10 +455,8 @@ class TestStringScanner < Test::Unit::TestCase
     s = create_string_scanner('a b c d e')
     s.scan(/\w/)
     assert_equal '', s.pre_match
-    assert_equal false, s.pre_match.tainted?
     s.skip(/\s/)
     assert_equal 'a', s.pre_match
-    assert_equal false, s.pre_match.tainted?
     s.scan('b')
     assert_equal 'a ', s.pre_match
     s.scan_until(/c/)
@@ -530,16 +469,6 @@ class TestStringScanner < Test::Unit::TestCase
     assert_equal 'a b c d', s.pre_match
     s.scan(/never match/)
     assert_nil s.pre_match
-
-    str = 'test string'.dup
-    str.taint
-    s = create_string_scanner(str)
-    s.scan(/\w+/)
-    assert_equal true, s.pre_match.tainted?
-    s.scan(/\s+/)
-    assert_equal true, s.pre_match.tainted?
-    s.scan(/\w+/)
-    assert_equal true, s.pre_match.tainted?
   end
 
   def test_post_match
@@ -564,16 +493,6 @@ class TestStringScanner < Test::Unit::TestCase
     assert_equal '', s.post_match
     s.scan(/./)
     assert_nil s.post_match
-
-    str = 'test string'.dup
-    str.taint
-    s = create_string_scanner(str)
-    s.scan(/\w+/)
-    assert_equal true, s.post_match.tainted?
-    s.scan(/\s+/)
-    assert_equal true, s.post_match.tainted?
-    s.scan(/\w+/)
-    assert_equal true, s.post_match.tainted?
   end
 
   def test_terminate

--- a/test/test_set.rb
+++ b/test/test_set.rb
@@ -696,15 +696,6 @@ class TC_Set < Test::Unit::TestCase
     assert_equal(set, ret.flatten)
   end
 
-  def test_taintness
-    orig = set = Set[1,2,3]
-    assert_equal false, set.tainted?
-    assert_same orig, set.taint
-    assert_equal true, set.tainted?
-    assert_same orig, set.untaint
-    assert_equal false, set.tainted?
-  end
-
   def test_freeze
     orig = set = Set[1,2,3]
     assert_equal false, set.frozen?

--- a/test/test_tempfile.rb
+++ b/test/test_tempfile.rb
@@ -31,17 +31,6 @@ class TestTempfile < Test::Unit::TestCase
     assert_equal "hello world", File.read(path)
   end
 
-  def test_saves_in_dir_tmpdir_by_default
-    t = tempfile("foo")
-    assert_equal Dir.tmpdir, File.dirname(t.path)
-    bug3733 = '[ruby-dev:42089]'
-    assert_nothing_raised(SecurityError, bug3733) {
-      proc {$SAFE = 1; File.expand_path(Dir.tmpdir)}.call
-    }
-  ensure
-    $SAFE = 0
-  end
-
   def test_saves_in_given_directory
     subdir = File.join(Dir.tmpdir, "tempfile-test-#{rand}")
     Dir.mkdir(subdir)

--- a/test/test_tmpdir.rb
+++ b/test/test_tmpdir.rb
@@ -11,19 +11,6 @@ class TestTmpdir < Test::Unit::TestCase
     assert_equal(tmpdir_org, Dir.tmpdir)
   end
 
-  def test_tmpdir_modifiable_safe
-    Thread.new {
-      $SAFE = 1
-      tmpdir = Dir.tmpdir
-      assert_equal(false, tmpdir.frozen?)
-      tmpdir_org = tmpdir.dup
-      tmpdir << "foo"
-      assert_equal(tmpdir_org, Dir.tmpdir)
-    }.join
-  ensure
-    $SAFE = 0
-  end
-
   def test_world_writable
     skip "no meaning on this platform" if /mswin|mingw/ =~ RUBY_PLATFORM
     Dir.mktmpdir do |tmpdir|

--- a/test/win32ole/test_win32ole.rb
+++ b/test/win32ole/test_win32ole.rb
@@ -176,39 +176,6 @@ if defined?(WIN32OLE)
       }
     end
 
-    def test_s_new_exc_svr_tainted
-      th = Thread.start {
-        $SAFE = 1
-        svr = "Scripting.Dictionary"
-        svr.taint
-        Thread.current.report_on_exception = false
-        WIN32OLE.new(svr)
-      }
-      exc = assert_raise(SecurityError) {
-        th.join
-      }
-      assert_match(/insecure object creation - `Scripting.Dictionary'/, exc.message)
-    ensure
-      $SAFE = 0
-    end
-
-    def test_s_new_exc_host_tainted
-      th = Thread.start {
-        $SAFE = 1
-        svr = "Scripting.Dictionary"
-        host = "localhost"
-        host.taint
-        Thread.current.report_on_exception = false
-        WIN32OLE.new(svr, host)
-      }
-      exc = assert_raise(SecurityError) {
-        th.join
-      }
-      assert_match(/insecure object creation - `localhost'/, exc.message)
-    ensure
-      $SAFE = 0
-    end
-
     def test_s_new_DCOM
       rshell = WIN32OLE.new("Shell.Application")
       assert_instance_of(WIN32OLE, rshell)
@@ -232,22 +199,6 @@ if defined?(WIN32OLE)
       assert_raise(TypeError) {
         WIN32OLE.connect(1)
       }
-    end
-
-    def test_s_coonect_exc_tainted
-      th = Thread.start {
-        $SAFE = 1
-        svr = "winmgmts:"
-        svr.taint
-        Thread.current.report_on_exception = false
-        WIN32OLE.connect(svr)
-      }
-      exc = assert_raise(SecurityError) {
-        th.join
-      }
-      assert_match(/insecure connection - `winmgmts:'/, exc.message)
-    ensure
-      $SAFE = 0
     end
 
     def test_invoke_accept_symbol_hash_key

--- a/test/win32ole/test_win32ole_event.rb
+++ b/test/win32ole/test_win32ole_event.rb
@@ -401,21 +401,6 @@ if defined?(WIN32OLE_EVENT)
         message_loop
         assert(h2.ev != "")
       end
-
-      def test_s_new_exc_tainted
-        th = Thread.new {
-          $SAFE=1
-          str = 'ConnectionEvents'
-          str.taint
-          WIN32OLE_EVENT.new(@db, str)
-        }
-        exc = assert_raise(SecurityError) {
-          th.join
-        }
-        assert_match(/insecure event creation - `ConnectionEvents'/, exc.message)
-      ensure
-        $SAFE = 0
-      end
     end
   end
 end

--- a/thread.c
+++ b/thread.c
@@ -3112,7 +3112,8 @@ rb_thread_stop_p(VALUE thread)
 static VALUE
 rb_thread_safe_level(VALUE thread)
 {
-    return UINT2NUM(rb_safe_level());
+    rb_warn("Thread#safe_level will be removed in Ruby 3.0");
+    return UINT2NUM(GET_VM()->safe_level_);
 }
 
 /*

--- a/thread.c
+++ b/thread.c
@@ -3185,7 +3185,6 @@ rb_thread_to_s(VALUE thread)
         rb_gc_force_recycle(loc);
     }
     rb_str_catf(str, " %s>", status);
-    OBJ_INFECT(str, thread);
 
     return str;
 }

--- a/time.c
+++ b/time.c
@@ -1818,7 +1818,6 @@ static void
 time_modify(VALUE time)
 {
     rb_check_frozen(time);
-    rb_check_trusted(time);
 }
 
 static wideval_t

--- a/tool/lib/leakchecker.rb
+++ b/tool/lib/leakchecker.rb
@@ -16,14 +16,9 @@ class LeakChecker
       check_tempfile_leak(test_name),
       check_env(test_name),
       check_encodings(test_name),
-      check_safe(test_name),
       check_verbose(test_name),
     ]
     GC.start if leaks.any?
-  end
-
-  def check_safe test_name
-    puts "#{test_name}: $SAFE == #{$SAFE}" unless $SAFE == 0
   end
 
   def check_verbose test_name

--- a/transcode.c
+++ b/transcode.c
@@ -375,7 +375,7 @@ load_transcoder_entry(transcoder_entry_t *entry)
         rb_str_set_len(fn, total_len);
         FL_UNSET(fn, FL_TAINT);
         OBJ_FREEZE(fn);
-        rb_require_safe(fn, rb_safe_level());
+        rb_require_string(fn);
     }
 
     if (entry->transcoder)

--- a/transcode.c
+++ b/transcode.c
@@ -373,7 +373,6 @@ load_transcoder_entry(transcoder_entry_t *entry)
         memcpy(path, transcoder_lib_prefix, sizeof(transcoder_lib_prefix) - 1);
         memcpy(path + sizeof(transcoder_lib_prefix) - 1, lib, len);
         rb_str_set_len(fn, total_len);
-        FL_UNSET(fn, FL_TAINT);
         OBJ_FREEZE(fn);
         rb_require_string(fn);
     }
@@ -1841,7 +1840,6 @@ rb_econv_substr_append(rb_econv_t *ec, VALUE src, long off, long len, VALUE dst,
     src = rb_str_new_frozen(src);
     dst = rb_econv_append(ec, RSTRING_PTR(src) + off, len, dst, flags);
     RB_GC_GUARD(src);
-    OBJ_INFECT_RAW(dst, src);
     return dst;
 }
 
@@ -3780,7 +3778,6 @@ econv_primitive_convert(int argc, VALUE *argv, VALUE self)
     res = rb_econv_convert(ec, &ip, is, &op, os, flags);
     rb_str_set_len(output, op-(unsigned char *)RSTRING_PTR(output));
     if (!NIL_P(input)) {
-        OBJ_INFECT_RAW(output, input);
         rb_str_drop_bytes(input, ip - (unsigned char *)RSTRING_PTR(input));
     }
 

--- a/variable.c
+++ b/variable.c
@@ -526,7 +526,7 @@ rb_define_virtual_variable(
 static void
 rb_trace_eval(VALUE cmd, VALUE val)
 {
-    rb_eval_cmd(cmd, rb_ary_new3(1, val), 0);
+    rb_eval_cmd_kw(cmd, rb_ary_new3(1, val), RB_NO_KEYWORDS);
 }
 
 VALUE

--- a/variable.c
+++ b/variable.c
@@ -543,9 +543,6 @@ rb_f_trace_var(int argc, const VALUE *argv)
 	return rb_f_untrace_var(argc, argv);
     }
     entry = rb_global_entry(rb_to_id(var));
-    if (OBJ_TAINTED(cmd)) {
-	rb_raise(rb_eSecurityError, "Insecure: tainted variable trace");
-    }
     trace = ALLOC(struct trace_var);
     trace->next = entry->var->trace;
     trace->func = rb_trace_eval;
@@ -1968,10 +1965,6 @@ rb_autoload_str(VALUE mod, ID id, VALUE file)
 	DATA_PTR(av) = tbl = st_init_numtable();
     }
 
-    if (OBJ_TAINTED(file)) {
-	file = rb_str_dup(file);
-	FL_UNSET(file, FL_TAINT);
-    }
     file = rb_fstring(file);
     if (!autoload_featuremap) {
         autoload_featuremap = rb_ident_hash_new();

--- a/vm.c
+++ b/vm.c
@@ -2290,7 +2290,6 @@ rb_vm_register_special_exception_str(enum ruby_special_exceptions sp, VALUE cls,
 {
     rb_vm_t *vm = GET_VM();
     VALUE exc = rb_exc_new3(cls, rb_obj_freeze(mesg));
-    OBJ_TAINT(exc);
     OBJ_FREEZE(exc);
     ((VALUE *)vm->special_exceptions)[sp] = exc;
     rb_gc_register_mark_object(exc);

--- a/vm_core.h
+++ b/vm_core.h
@@ -619,7 +619,6 @@ typedef struct rb_vm_struct {
     /* signal */
     struct {
 	VALUE cmd[RUBY_NSIG];
-	unsigned char safe[RUBY_NSIG];
     } trap_list;
 
     /* hook */

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -1777,7 +1777,7 @@ rb_eval_string_wrap(const char *str, int *pstate)
 }
 
 VALUE
-rb_eval_cmd(VALUE cmd, VALUE arg, int _level)
+rb_eval_cmd_kw(VALUE cmd, VALUE arg, int kw_splat)
 {
     enum ruby_tag_type state;
     volatile VALUE val = Qnil;		/* OK */
@@ -1786,8 +1786,8 @@ rb_eval_cmd(VALUE cmd, VALUE arg, int _level)
     EC_PUSH_TAG(ec);
     if ((state = EC_EXEC_TAG()) == TAG_NONE) {
 	if (!RB_TYPE_P(cmd, T_STRING)) {
-	    val = rb_funcallv(cmd, idCall, RARRAY_LENINT(arg),
-			      RARRAY_CONST_PTR(arg));
+            val = rb_funcallv_kw(cmd, idCall, RARRAY_LENINT(arg),
+                              RARRAY_CONST_PTR(arg), kw_splat);
 	}
 	else {
 	    val = eval_string_with_cref(rb_vm_top_self(), cmd, NULL, 0, 0);
@@ -1797,6 +1797,13 @@ rb_eval_cmd(VALUE cmd, VALUE arg, int _level)
 
     if (state) EC_JUMP_TAG(ec, state);
     return val;
+}
+
+VALUE
+rb_eval_cmd(VALUE cmd, VALUE arg, int _level)
+{
+    rb_warn("rb_eval_cmd will be removed in Ruby 3.0");
+    return rb_eval_cmd_kw(cmd, arg, RB_NO_KEYWORDS);
 }
 
 /* block eval under the class/module context */

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -1777,19 +1777,13 @@ rb_eval_string_wrap(const char *str, int *pstate)
 }
 
 VALUE
-rb_eval_cmd(VALUE cmd, VALUE arg, int level)
+rb_eval_cmd(VALUE cmd, VALUE arg, int _level)
 {
     enum ruby_tag_type state;
     volatile VALUE val = Qnil;		/* OK */
-    const int VAR_NOCLOBBERED(current_safe_level) = rb_safe_level();
     rb_execution_context_t * volatile ec = GET_EC();
 
-    if (OBJ_TAINTED(cmd)) {
-	level = RUBY_SAFE_LEVEL_MAX;
-    }
-
     EC_PUSH_TAG(ec);
-    rb_set_safe_level_force(level);
     if ((state = EC_EXEC_TAG()) == TAG_NONE) {
 	if (!RB_TYPE_P(cmd, T_STRING)) {
 	    val = rb_funcallv(cmd, idCall, RARRAY_LENINT(arg),
@@ -1801,7 +1795,6 @@ rb_eval_cmd(VALUE cmd, VALUE arg, int level)
     }
     EC_POP_TAG();
 
-    rb_set_safe_level_force(current_safe_level);
     if (state) EC_JUMP_TAG(ec, state);
     return val;
 }


### PR DESCRIPTION
This removes the security features added by $SAFE = 1, and warns for access
or modification of $SAFE from Ruby-level, as well as warning when calling
all public C functions related to $SAFE.

This modifies some internal functions that took a safe level argument
to no longer take the argument.

rb_require_safe now warns, rb_require_string has been added as a
version that takes a VALUE and does not warn.

One public C function that still takes a safe level argument and that
this doesn't warn for is rb_eval_cmd.  We may want to consider
adding an alternative method that does not take a safe level argument,
and warn for rb_eval_cmd.