### PR TITLE
st.c: Use rb_st_* prefix instead of st_*

### DIFF
--- a/include/ruby/intern.h
+++ b/include/ruby/intern.h
@@ -534,7 +534,8 @@ size_t rb_gc_stat(VALUE);
 VALUE rb_gc_latest_gc_info(VALUE);
 void rb_gc_adjust_memory_usage(ssize_t);
 /* hash.c */
-void st_foreach_safe(struct st_table *, int (*)(st_data_t, st_data_t, st_data_t), st_data_t);
+void rb_st_foreach_safe(struct st_table *, int (*)(st_data_t, st_data_t, st_data_t), st_data_t);
+#define st_foreach_safe rb_st_foreach_safe
 VALUE rb_check_hash_type(VALUE);
 void rb_hash_foreach(VALUE, int (*)(VALUE, VALUE, VALUE), VALUE);
 VALUE rb_hash(VALUE);

--- a/include/ruby/st.h
+++ b/include/ruby/st.h
@@ -98,52 +98,89 @@ struct st_table {
 
 enum st_retval {ST_CONTINUE, ST_STOP, ST_DELETE, ST_CHECK, ST_REPLACE};
 
-st_table *st_init_table(const struct st_hash_type *);
-st_table *st_init_table_with_size(const struct st_hash_type *, st_index_t);
-st_table *st_init_numtable(void);
-st_table *st_init_numtable_with_size(st_index_t);
-st_table *st_init_strtable(void);
-st_table *st_init_strtable_with_size(st_index_t);
-st_table *st_init_strcasetable(void);
-st_table *st_init_strcasetable_with_size(st_index_t);
-int st_delete(st_table *, st_data_t *, st_data_t *); /* returns 0:notfound 1:deleted */
-int st_delete_safe(st_table *, st_data_t *, st_data_t *, st_data_t);
-int st_shift(st_table *, st_data_t *, st_data_t *); /* returns 0:notfound 1:deleted */
-int st_insert(st_table *, st_data_t, st_data_t);
-int st_insert2(st_table *, st_data_t, st_data_t, st_data_t (*)(st_data_t));
-int st_lookup(st_table *, st_data_t, st_data_t *);
-int st_get_key(st_table *, st_data_t, st_data_t *);
+st_table *rb_st_init_table(const struct st_hash_type *);
+#define st_init_table rb_st_init_table
+st_table *rb_st_init_table_with_size(const struct st_hash_type *, st_index_t);
+#define st_init_table_with_size rb_st_init_table_with_size
+st_table *rb_st_init_numtable(void);
+#define st_init_numtable rb_st_init_numtable
+st_table *rb_st_init_numtable_with_size(st_index_t);
+#define st_init_numtable_with_size rb_st_init_numtable_with_size
+st_table *rb_st_init_strtable(void);
+#define st_init_strtable rb_st_init_strtable
+st_table *rb_st_init_strtable_with_size(st_index_t);
+#define st_init_strtable_with_size rb_st_init_strtable_with_size
+st_table *rb_st_init_strcasetable(void);
+#define st_init_strcasetable rb_st_init_strcasetable
+st_table *rb_st_init_strcasetable_with_size(st_index_t);
+#define st_init_strcasetable_with_size rb_st_init_strcasetable_with_size
+int rb_st_delete(st_table *, st_data_t *, st_data_t *); /* returns 0:notfound 1:deleted */
+#define st_delete rb_st_delete
+int rb_st_delete_safe(st_table *, st_data_t *, st_data_t *, st_data_t);
+#define st_delete_safe rb_st_delete_safe
+int rb_st_shift(st_table *, st_data_t *, st_data_t *); /* returns 0:notfound 1:deleted */
+#define st_shift rb_st_shift
+int rb_st_insert(st_table *, st_data_t, st_data_t);
+#define st_insert rb_st_insert
+int rb_st_insert2(st_table *, st_data_t, st_data_t, st_data_t (*)(st_data_t));
+#define st_insert2 rb_st_insert2
+int rb_st_lookup(st_table *, st_data_t, st_data_t *);
+#define st_lookup rb_st_lookup
+int rb_st_get_key(st_table *, st_data_t, st_data_t *);
+#define st_get_key rb_st_get_key
 typedef int st_update_callback_func(st_data_t *key, st_data_t *value, st_data_t arg, int existing);
 /* *key may be altered, but must equal to the old key, i.e., the
  * results of hash() are same and compare() returns 0, otherwise the
  * behavior is undefined */
-int st_update(st_table *table, st_data_t key, st_update_callback_func *func, st_data_t arg);
+int rb_st_update(st_table *table, st_data_t key, st_update_callback_func *func, st_data_t arg);
+#define st_update rb_st_update
 typedef int st_foreach_callback_func(st_data_t, st_data_t, st_data_t);
 typedef int st_foreach_check_callback_func(st_data_t, st_data_t, st_data_t, int);
-int st_foreach_with_replace(st_table *tab, st_foreach_check_callback_func *func, st_update_callback_func *replace, st_data_t arg);
-int st_foreach(st_table *, st_foreach_callback_func *, st_data_t);
-int st_foreach_check(st_table *, st_foreach_check_callback_func *, st_data_t, st_data_t);
-st_index_t st_keys(st_table *table, st_data_t *keys, st_index_t size);
-st_index_t st_keys_check(st_table *table, st_data_t *keys, st_index_t size, st_data_t never);
-st_index_t st_values(st_table *table, st_data_t *values, st_index_t size);
-st_index_t st_values_check(st_table *table, st_data_t *values, st_index_t size, st_data_t never);
-void st_add_direct(st_table *, st_data_t, st_data_t);
-void st_free_table(st_table *);
-void st_cleanup_safe(st_table *, st_data_t);
-void st_clear(st_table *);
-st_table *st_copy(st_table *);
-CONSTFUNC(int st_numcmp(st_data_t, st_data_t));
-CONSTFUNC(st_index_t st_numhash(st_data_t));
-PUREFUNC(int st_locale_insensitive_strcasecmp(const char *s1, const char *s2));
-PUREFUNC(int st_locale_insensitive_strncasecmp(const char *s1, const char *s2, size_t n));
-#define st_strcasecmp st_locale_insensitive_strcasecmp
-#define st_strncasecmp st_locale_insensitive_strncasecmp
-PUREFUNC(size_t st_memsize(const st_table *));
-PUREFUNC(st_index_t st_hash(const void *ptr, size_t len, st_index_t h));
-CONSTFUNC(st_index_t st_hash_uint32(st_index_t h, uint32_t i));
-CONSTFUNC(st_index_t st_hash_uint(st_index_t h, st_index_t i));
-CONSTFUNC(st_index_t st_hash_end(st_index_t h));
-CONSTFUNC(st_index_t st_hash_start(st_index_t h));
+int rb_st_foreach_with_replace(st_table *tab, st_foreach_check_callback_func *func, st_update_callback_func *replace, st_data_t arg);
+#define st_foreach_with_replace rb_st_foreach_with_replace
+int rb_st_foreach(st_table *, st_foreach_callback_func *, st_data_t);
+#define st_foreach rb_st_foreach
+int rb_st_foreach_check(st_table *, st_foreach_check_callback_func *, st_data_t, st_data_t);
+#define st_foreach_check rb_st_foreach_check
+st_index_t rb_st_keys(st_table *table, st_data_t *keys, st_index_t size);
+#define st_keys rb_st_keys
+st_index_t rb_st_keys_check(st_table *table, st_data_t *keys, st_index_t size, st_data_t never);
+#define st_keys_check rb_st_keys_check
+st_index_t rb_st_values(st_table *table, st_data_t *values, st_index_t size);
+#define st_values rb_st_values
+st_index_t rb_st_values_check(st_table *table, st_data_t *values, st_index_t size, st_data_t never);
+#define st_values_check rb_st_values_check
+void rb_st_add_direct(st_table *, st_data_t, st_data_t);
+#define st_add_direct rb_st_add_direct
+void rb_st_free_table(st_table *);
+#define st_free_table rb_st_free_table
+void rb_st_cleanup_safe(st_table *, st_data_t);
+#define st_cleanup_safe rb_st_cleanup_safe
+void rb_st_clear(st_table *);
+#define st_clear rb_st_clear
+st_table *rb_st_copy(st_table *);
+#define st_copy rb_st_copy
+CONSTFUNC(int rb_st_numcmp(st_data_t, st_data_t));
+#define st_numcmp rb_st_numcmp
+CONSTFUNC(st_index_t rb_st_numhash(st_data_t));
+#define st_numhash rb_st_numhash
+PUREFUNC(int rb_st_locale_insensitive_strcasecmp(const char *s1, const char *s2));
+#define st_locale_insensitive_strcasecmp rb_st_locale_insensitive_strcasecmp
+PUREFUNC(int rb_st_locale_insensitive_strncasecmp(const char *s1, const char *s2, size_t n));
+#define st_locale_insensitive_strncasecmp rb_st_locale_insensitive_strncasecmp
+#define st_strcasecmp rb_st_locale_insensitive_strcasecmp
+#define st_strncasecmp rb_st_locale_insensitive_strncasecmp
+PUREFUNC(size_t rb_st_memsize(const st_table *));
+#define st_memsize rb_st_memsize
+PUREFUNC(st_index_t rb_st_hash(const void *ptr, size_t len, st_index_t h));
+#define st_hash rb_st_hash
+CONSTFUNC(st_index_t rb_st_hash_uint32(st_index_t h, uint32_t i));
+#define st_hash_uint32 rb_st_hash_uint32
+CONSTFUNC(st_index_t rb_st_hash_uint(st_index_t h, st_index_t i));
+#define st_hash_uint rb_st_hash_uint
+CONSTFUNC(st_index_t rb_st_hash_end(st_index_t h));
+#define st_hash_end rb_st_hash_end
+CONSTFUNC(st_index_t rb_st_hash_start(st_index_t h));
 #define st_hash_start(h) ((st_index_t)(h))
 
 void rb_hash_bulk_insert_into_st_table(long, const VALUE *, VALUE);

--- a/st.c
+++ b/st.c
@@ -2027,7 +2027,7 @@ st_hash_end(st_index_t h)
 
 #undef st_hash_start
 st_index_t
-st_hash_start(st_index_t h)
+rb_st_hash_start(st_index_t h)
 {
     return h;
 }

--- a/tool/leaked-globals
+++ b/tool/leaked-globals
@@ -24,7 +24,7 @@ IO.foreach("|#{NM} -Pgp #{ARGV.join(' ')}") do |line|
   next unless /[BDT]/ =~ t
   next unless n.sub!(/^#{SYMBOL_PREFIX}/o, "")
   next if n.include?(".")
-  next if /\A(?:Init_|InitVM_|ruby_|rb_|[Oo]nig|st_|dln_|mjit_|coroutine_|nu(?:comp|rat)_)/ =~ n
+  next if /\A(?:Init_|InitVM_|ruby_|rb_|[Oo]nig|dln_|mjit_|coroutine_|nu(?:comp|rat)_)/ =~ n
   next if REPLACE.include?(n)
   puts col.fail("leaked") if count.zero?
   count += 1


### PR DESCRIPTION
The original st.c was public domain hash table implementation, but
Ruby's st.c is highly modified, and its data structure is not
compatiblie with the original one.

Therefore, when creating an extension library to wrap C code that uses
the original st.c, the symbols conflict, which leads to segfault.

This changes the prefix `st_*` of st.c functions to `rb_st_*` for
reflecting that they are specific to Ruby's, and avoid symbol conflicts.