### PR TITLE
[DO NOT MERGE] Create dummy files on builddir

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -43,7 +43,7 @@ jobs:
       - run: make $JOBS
       - name: 'create dummy files'
         run: |
-          ./ruby -e '%w[a b foo bar test zzz].each{|basename|File.write("#{basename}.rb", "raise %(do not load #{basename}.rb)")}'
+          ./miniruby -e '%w[a b foo bar test zzz].each{|basename|File.write("#{basename}.rb", "raise %(do not load #{basename}.rb)")}'
       - name: Tests
         run: make -s ${{ matrix.test_task }} TESTOPTS="$JOBS -q --tty=no"
         env:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -41,6 +41,9 @@ jobs:
       - name: configure
         run: ./configure -C --disable-install-doc --with-openssl-dir=$(brew --prefix openssl@1.1) --with-readline-dir=$(brew --prefix readline)
       - run: make $JOBS
+      - name: 'create dummy files'
+        run: |
+          ./ruby -e '%w[a b foo bar test zzz].each{|basename|File.write("#{basename}.rb", "raise %(do not load #{basename}.rb)")}'
       - name: Tests
         run: make -s ${{ matrix.test_task }} TESTOPTS="$JOBS -q --tty=no"
         env:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -71,7 +71,7 @@ jobs:
       - run: make $JOBS
       - name: 'create dummy files'
         run: |
-          ./ruby -e '%w[a b foo bar test zzz].each{|basename|File.write("#{basename}.rb", "raise %(do not load #{basename}.rb)")}'
+          ./miniruby -e '%w[a b foo bar test zzz].each{|basename|File.write("#{basename}.rb", "raise %(do not load #{basename}.rb)")}'
       - name: Tests
         run: make -s ${{ matrix.test_task }} TESTOPTS="$JOBS -q --tty=no"
         env:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -69,6 +69,9 @@ jobs:
       - name: configure
         run: ./configure -C --disable-install-doc
       - run: make $JOBS
+      - name: 'create dummy files'
+        run: |
+          ./ruby -e '%w[a b foo bar test zzz].each{|basename|File.write("#{basename}.rb", "raise %(do not load #{basename}.rb)")}'
       - name: Tests
         run: make -s ${{ matrix.test_task }} TESTOPTS="$JOBS -q --tty=no"
         env:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -56,7 +56,7 @@ jobs:
           nmake
       - name: 'create dummy files'
         run: |
-          .\ruby -e "%w[a b foo bar test zzz].each{|basename|File.write(%(#{basename}.rb), %[raise %(do not load #{basename}.rb)])}"
+          miniruby -e "%w[a b foo bar test zzz].each{|basename|File.write(%(#{basename}.rb), %[raise %(do not load #{basename}.rb)])}"
       - name: nmake test
         run: |
           call "C:\Program Files (x86)\Microsoft Visual Studio\${{ matrix.vs }}\Enterprise\VC\Auxiliary\Build\vcvars64.bat"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -54,6 +54,9 @@ jobs:
           set YACC=win_bison
           nmake up
           nmake
+      - name: 'create dummy files'
+        run: |
+          .\ruby -e "%w[a b foo bar test zzz].each{|basename|File.write(%(#{basename}.rb), %[raise %(do not load #{basename}.rb)])}"
       - name: nmake test
         run: |
           call "C:\Program Files (x86)\Microsoft Visual Studio\${{ matrix.vs }}\Enterprise\VC\Auxiliary\Build\vcvars64.bat"


### PR DESCRIPTION
Some `*.rb` files on builddir cause test failures.
This pull request runs tests with such files on GitHub Actions.