### PR TITLE
More keyword argument separation fixes

### DIFF
--- a/cont.c
+++ b/cont.c
@@ -179,6 +179,7 @@ struct fiber_pool {
 typedef struct rb_context_struct {
     enum context_type type;
     int argc;
+    int kw_splat;
     VALUE self;
     VALUE value;
 
@@ -1777,6 +1778,9 @@ rb_fiber_new(rb_block_call_func_t func, VALUE obj)
 
 static void rb_fiber_terminate(rb_fiber_t *fiber, int need_interrupt);
 
+#define PASS_KW_SPLAT (rb_empty_keyword_given_p() ? RB_PASS_EMPTY_KEYWORDS : rb_keyword_given_p())
+extern VALUE rb_adjust_argv_kw_splat(int *argc, const VALUE **argv, int *kw_splat);
+
 void
 rb_fiber_start(void)
 {
@@ -1794,6 +1798,7 @@ rb_fiber_start(void)
         rb_context_t *cont = &VAR_FROM_MEMORY(fiber)->cont;
         int argc;
         const VALUE *argv, args = cont->value;
+        int kw_splat = cont->kw_splat;
         GetProcPtr(fiber->first_proc, proc);
         argv = (argc = cont->argc) > 1 ? RARRAY_CONST_PTR(args) : &args;
         cont->value = Qnil;
@@ -1802,7 +1807,8 @@ rb_fiber_start(void)
         th->ec->root_svar = Qfalse;
 
         EXEC_EVENT_HOOK(th->ec, RUBY_EVENT_FIBER_SWITCH, th->self, 0, 0, 0, Qnil);
-        cont->value = rb_vm_invoke_proc(th->ec, proc, argc, argv, VM_NO_KEYWORDS, VM_BLOCK_HANDLER_NONE);
+        rb_adjust_argv_kw_splat(&argc, &argv, &kw_splat);
+        cont->value = rb_vm_invoke_proc(th->ec, proc, argc, argv, kw_splat, VM_BLOCK_HANDLER_NONE);
     }
     EC_POP_TAG();
 
@@ -1965,7 +1971,7 @@ fiber_store(rb_fiber_t *next_fiber, rb_thread_t *th)
 }
 
 static inline VALUE
-fiber_switch(rb_fiber_t *fiber, int argc, const VALUE *argv, int is_resume)
+fiber_switch(rb_fiber_t *fiber, int argc, const VALUE *argv, int is_resume, int kw_splat)
 {
     VALUE value;
     rb_context_t *cont = &fiber->cont;
@@ -2017,6 +2023,7 @@ fiber_switch(rb_fiber_t *fiber, int argc, const VALUE *argv, int is_resume)
     VM_ASSERT(FIBER_RUNNABLE_P(fiber));
 
     cont->argc = argc;
+    cont->kw_splat = kw_splat;
     cont->value = make_passing_arg(argc, argv);
 
     value = fiber_store(fiber, th);
@@ -2035,7 +2042,7 @@ fiber_switch(rb_fiber_t *fiber, int argc, const VALUE *argv, int is_resume)
 VALUE
 rb_fiber_transfer(VALUE fiber_value, int argc, const VALUE *argv)
 {
-    return fiber_switch(fiber_ptr(fiber_value), argc, argv, 0);
+    return fiber_switch(fiber_ptr(fiber_value), argc, argv, 0, RB_NO_KEYWORDS);
 }
 
 void
@@ -2060,11 +2067,11 @@ rb_fiber_terminate(rb_fiber_t *fiber, int need_interrupt)
 
     next_fiber = return_fiber();
     if (need_interrupt) RUBY_VM_SET_INTERRUPT(&next_fiber->cont.saved_ec);
-    fiber_switch(next_fiber, 1, &value, 0);
+    fiber_switch(next_fiber, 1, &value, 0, RB_NO_KEYWORDS);
 }
 
 VALUE
-rb_fiber_resume(VALUE fiber_value, int argc, const VALUE *argv)
+rb_fiber_resume_kw(VALUE fiber_value, int argc, const VALUE *argv, int kw_splat)
 {
     rb_fiber_t *fiber = fiber_ptr(fiber_value);
 
@@ -2080,13 +2087,25 @@ rb_fiber_resume(VALUE fiber_value, int argc, const VALUE *argv)
         rb_raise(rb_eFiberError, "cannot resume transferred Fiber");
     }
 
-    return fiber_switch(fiber, argc, argv, 1);
+    return fiber_switch(fiber, argc, argv, 1, kw_splat);
+}
+
+VALUE
+rb_fiber_resume(VALUE fiber_value, int argc, const VALUE *argv)
+{
+    return rb_fiber_resume_kw(fiber_value, argc, argv, RB_NO_KEYWORDS);
+}
+
+VALUE
+rb_fiber_yield_kw(int argc, const VALUE *argv, int kw_splat)
+{
+    return fiber_switch(return_fiber(), argc, argv, 0, kw_splat);
 }
 
 VALUE
 rb_fiber_yield(int argc, const VALUE *argv)
 {
-    return fiber_switch(return_fiber(), argc, argv, 0);
+    return fiber_switch(return_fiber(), argc, argv, 0, RB_NO_KEYWORDS);
 }
 
 void
@@ -2130,7 +2149,7 @@ rb_fiber_alive_p(VALUE fiber_value)
 static VALUE
 rb_fiber_m_resume(int argc, VALUE *argv, VALUE fiber)
 {
-    return rb_fiber_resume(fiber, argc, argv);
+    return rb_fiber_resume_kw(fiber, argc, argv, PASS_KW_SPLAT);
 }
 
 /*
@@ -2156,7 +2175,7 @@ static VALUE
 rb_fiber_raise(int argc, VALUE *argv, VALUE fiber)
 {
     VALUE exc = rb_make_exception(argc, argv);
-    return rb_fiber_resume(fiber, -1, &exc);
+    return rb_fiber_resume_kw(fiber, -1, &exc, RB_NO_KEYWORDS);
 }
 
 /*
@@ -2209,7 +2228,7 @@ rb_fiber_m_transfer(int argc, VALUE *argv, VALUE fiber_value)
 {
     rb_fiber_t *fiber = fiber_ptr(fiber_value);
     fiber->transferred = 1;
-    return fiber_switch(fiber, argc, argv, 0);
+    return fiber_switch(fiber, argc, argv, 0, PASS_KW_SPLAT);
 }
 
 /*
@@ -2225,7 +2244,7 @@ rb_fiber_m_transfer(int argc, VALUE *argv, VALUE fiber_value)
 static VALUE
 rb_fiber_s_yield(int argc, VALUE *argv, VALUE klass)
 {
-    return rb_fiber_yield(argc, argv);
+    return rb_fiber_yield_kw(argc, argv, PASS_KW_SPLAT);
 }
 
 /*

--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -1881,8 +1881,13 @@ ossl_ssl_read_internal(int argc, VALUE *argv, VALUE self, int nonblock)
 	ID meth = nonblock ? rb_intern("read_nonblock") : rb_intern("sysread");
 
 	rb_warning("SSL session is not started yet.");
-	if (nonblock)
-	    return rb_funcall(io, meth, 3, len, str, opts);
+	if (nonblock) {
+            VALUE argv[3];
+            argv[0] = len;
+            argv[1] = str;
+            argv[2] = opts;
+            return rb_funcallv_kw(io, meth, 3, argv, RB_PASS_KEYWORDS);
+        }
 	else
 	    return rb_funcall(io, meth, 2, len, str);
     }
@@ -1972,8 +1977,12 @@ ossl_ssl_write_internal(VALUE self, VALUE str, VALUE opts)
 	    rb_intern("write_nonblock") : rb_intern("syswrite");
 
 	rb_warning("SSL session is not started yet.");
-	if (nonblock)
-	    return rb_funcall(io, meth, 2, str, opts);
+	if (nonblock) {
+            VALUE argv[2];
+            argv[0] = str;
+            argv[1] = opts;
+            return rb_funcallv_kw(io, meth, 2, argv, RB_PASS_KEYWORDS);
+        }
 	else
 	    return rb_funcall(io, meth, 1, str);
     }

--- a/ext/pathname/pathname.c
+++ b/ext/pathname/pathname.c
@@ -434,7 +434,7 @@ path_write(int argc, VALUE *argv, VALUE self)
 
     args[0] = get_strpath(self);
     n = rb_scan_args(argc, argv, "03", &args[1], &args[2], &args[3]);
-    return rb_funcallv(rb_cFile, id_write, 1+n, args);
+    return rb_funcallv_kw(rb_cFile, id_write, 1+n, args, RB_PASS_CALLED_KEYWORDS);
 }
 
 /*
@@ -455,7 +455,7 @@ path_binwrite(int argc, VALUE *argv, VALUE self)
 
     args[0] = get_strpath(self);
     n = rb_scan_args(argc, argv, "03", &args[1], &args[2], &args[3]);
-    return rb_funcallv(rb_cFile, id_binwrite, 1+n, args);
+    return rb_funcallv_kw(rb_cFile, id_binwrite, 1+n, args, RB_PASS_CALLED_KEYWORDS);
 }
 
 /*
@@ -477,7 +477,7 @@ path_readlines(int argc, VALUE *argv, VALUE self)
 
     args[0] = get_strpath(self);
     n = rb_scan_args(argc, argv, "03", &args[1], &args[2], &args[3]);
-    return rb_funcallv(rb_cFile, id_readlines, 1+n, args);
+    return rb_funcallv_kw(rb_cFile, id_readlines, 1+n, args, RB_PASS_CALLED_KEYWORDS);
 }
 
 /*
@@ -678,10 +678,10 @@ path_open(int argc, VALUE *argv, VALUE self)
     args[0] = get_strpath(self);
     n = rb_scan_args(argc, argv, "03", &args[1], &args[2], &args[3]);
     if (rb_block_given_p()) {
-        return rb_block_call(rb_cFile, id_open, 1+n, args, 0, 0);
+        return rb_block_call_kw(rb_cFile, id_open, 1+n, args, 0, 0, RB_PASS_CALLED_KEYWORDS);
     }
     else {
-        return rb_funcallv(rb_cFile, id_open, 1+n, args);
+        return rb_funcallv_kw(rb_cFile, id_open, 1+n, args, RB_PASS_CALLED_KEYWORDS);
     }
 }
 

--- a/include/ruby/intern.h
+++ b/include/ruby/intern.h
@@ -453,6 +453,7 @@ VALUE rb_proc_new(rb_block_call_func_t, VALUE);
 VALUE rb_obj_is_proc(VALUE);
 VALUE rb_proc_call(VALUE, VALUE);
 VALUE rb_proc_call_with_block(VALUE, int argc, const VALUE *argv, VALUE);
+VALUE rb_proc_call_with_block_kw(VALUE, int argc, const VALUE *argv, VALUE, int);
 int rb_proc_arity(VALUE);
 VALUE rb_proc_lambda_p(VALUE);
 VALUE rb_binding_new(void);

--- a/include/ruby/intern.h
+++ b/include/ruby/intern.h
@@ -240,7 +240,9 @@ NORETURN(void rb_cmperr(VALUE, VALUE));
 /* cont.c */
 VALUE rb_fiber_new(rb_block_call_func_t, VALUE);
 VALUE rb_fiber_resume(VALUE fib, int argc, const VALUE *argv);
+VALUE rb_fiber_resume_kw(VALUE fib, int argc, const VALUE *argv, int kw_splat);
 VALUE rb_fiber_yield(int argc, const VALUE *argv);
+VALUE rb_fiber_yield_kw(int argc, const VALUE *argv, int kw_splat);
 VALUE rb_fiber_current(void);
 VALUE rb_fiber_alive_p(VALUE);
 /* enum.c */

--- a/test/openssl/test_ssl.rb
+++ b/test/openssl/test_ssl.rb
@@ -155,6 +155,21 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
     }
   end
 
+  def test_sysread_nonblock_and_syswrite_nonblock_keywords
+    start_server(ignore_listener_error: true) do |port|
+      sock = TCPSocket.new("127.0.0.1", port)
+      ssl = OpenSSL::SSL::SSLSocket.new(sock)
+
+      assert_warn ("") do
+        ssl.send(:syswrite_nonblock, "1", exception: false)
+        ssl.send(:sysread_nonblock, 1, exception: false) rescue nil
+        ssl.send(:sysread_nonblock, 1, String.new, exception: false) rescue nil
+      end
+    ensure
+      sock&.close
+    end
+  end
+
   def test_sync_close
     start_server { |port|
       begin

--- a/test/pathname/test_pathname.rb
+++ b/test/pathname/test_pathname.rb
@@ -745,6 +745,14 @@ class TestPathname < Test::Unit::TestCase
     }
   end
 
+  def test_readlines_opts
+    with_tmpchdir('rubytest-pathname') {|dir|
+      open("a", "w") {|f| f.puts 1, 2 }
+      a = Pathname("a").readlines 1, chomp: true
+      assert_equal(["1", "", "2", ""], a)
+    }
+  end
+
   def test_read
     with_tmpchdir('rubytest-pathname') {|dir|
       open("a", "w") {|f| f.puts 1, 2 }
@@ -769,10 +777,26 @@ class TestPathname < Test::Unit::TestCase
     }
   end
 
+  def test_write_opts
+    with_tmpchdir('rubytest-pathname') {|dir|
+      path = Pathname("a")
+      path.write "abc", mode: "w"
+      assert_equal("abc", path.read)
+    }
+  end
+
   def test_binwrite
     with_tmpchdir('rubytest-pathname') {|dir|
       path = Pathname("a")
       path.binwrite "abc\x80"
+      assert_equal("abc\x80".b, path.binread)
+    }
+  end
+
+  def test_binwrite_opts
+    with_tmpchdir('rubytest-pathname') {|dir|
+      path = Pathname("a")
+      path.binwrite "abc\x80", mode: 'w'
       assert_equal("abc\x80".b, path.binread)
     }
   end
@@ -929,6 +953,10 @@ class TestPathname < Test::Unit::TestCase
         assert_equal("abc", f.read)
       }
 
+      path.open(mode: "r") {|f|
+        assert_equal("abc", f.read)
+      }
+
       Pathname("b").open("w", 0444) {|f| f.write "def" }
       assert_equal(0444 & ~File.umask, File.stat("b").mode & 0777)
       assert_equal("def", File.read("b"))
@@ -938,6 +966,10 @@ class TestPathname < Test::Unit::TestCase
       assert_equal("ghi", File.read("c"))
 
       g = path.open
+      assert_equal("abc", g.read)
+      g.close
+
+      g = path.open(mode: "r")
       assert_equal("abc", g.read)
       g.close
     }

--- a/test/ruby/test_io.rb
+++ b/test/ruby/test_io.rb
@@ -2279,6 +2279,19 @@ class TestIO < Test::Unit::TestCase
     assert_equal(o, o2)
   end
 
+  def test_open_redirect_keyword
+    o = Object.new
+    def o.to_open(**kw); kw; end
+    assert_equal({:a=>1}, open(o, a: 1))
+    assert_warn(/The last argument is used as the keyword parameter.*for `to_open'/m) do
+      assert_equal({:a=>1}, open(o, {a: 1}))
+    end
+
+    def o.to_open(kw); kw; end
+    assert_equal({:a=>1}, open(o, a: 1))
+    assert_equal({:a=>1}, open(o, {a: 1}))
+  end
+
   def test_open_pipe
     open("|" + EnvUtil.rubybin, "r+") do |f|
       f.puts "puts 'foo'"

--- a/test/ruby/test_proc.rb
+++ b/test/ruby/test_proc.rb
@@ -1512,3 +1512,139 @@ class TestProc < Test::Unit::TestCase
       def m1(&b) b end; def m2(); m1 { next 42 } end }.m2.call)
   end
 end
+
+class TestProcKeywords < Test::Unit::TestCase
+  def test_compose_keywords
+    f = ->(**kw) { kw.merge(:a=>1) }
+    g = ->(kw) { kw.merge(:a=>2) }
+
+    assert_equal(2, (f >> g).call(a: 3)[:a])
+    assert_warn(/The last argument is used as the keyword parameter.*for method/m) do
+      assert_equal(1, (f << g).call(a: 3)[:a])
+    end
+    assert_equal(2, (f >> g).call(a: 3)[:a])
+    assert_warn(/The last argument is used as the keyword parameter.*for method/m) do
+      assert_equal(1, (f << g).call({a: 3})[:a])
+    end
+    assert_warn(/The last argument is used as the keyword parameter.*for method/m) do
+      assert_equal(2, (f >> g).call({a: 3})[:a])
+    end
+    assert_equal(2, (g << f).call(a: 3)[:a])
+    assert_warn(/The last argument is used as the keyword parameter.*for method/m) do
+      assert_equal(1, (g >> f).call(a: 3)[:a])
+    end
+    assert_warn(/The last argument is used as the keyword parameter.*for method/m) do
+      assert_equal(2, (g << f).call({a: 3})[:a])
+    end
+    assert_warn(/The last argument is used as the keyword parameter.*for method/m) do
+      assert_equal(1, (g >> f).call({a: 3})[:a])
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter.*The last argument is used as the keyword parameter.*for method/m) do
+      assert_equal(1, (f << g).call(**{})[:a])
+    end
+    assert_equal(2, (f >> g).call(**{})[:a])
+  end
+
+  def test_compose_keywords_method
+    f = ->(**kw) { kw.merge(:a=>1) }.method(:call)
+    g = ->(kw) { kw.merge(:a=>2) }.method(:call)
+
+    assert_warn(/The last argument is used as the keyword parameter.*for method/m) do
+      assert_equal(1, (f << g).call(a: 3)[:a])
+    end
+    assert_warn(/The last argument is used as the keyword parameter.*for method/m) do
+      assert_equal(2, (f >> g).call(a: 3)[:a])
+    end
+    assert_warn(/The last argument is used as the keyword parameter.*for method/m) do
+      assert_equal(1, (f << g).call({a: 3})[:a])
+    end
+    assert_warn(/The last argument is used as the keyword parameter.*for method/m) do
+      assert_equal(2, (f >> g).call({a: 3})[:a])
+    end
+    assert_equal(2, (g << f).call(a: 3)[:a])
+    assert_warn(/The last argument is used as the keyword parameter.*for method/m) do
+      assert_equal(1, (g >> f).call(a: 3)[:a])
+    end
+    assert_warn(/The last argument is used as the keyword parameter.*for method/m) do
+      assert_equal(2, (g << f).call({a: 3})[:a])
+    end
+    assert_warn(/The last argument is used as the keyword parameter.*for method/m) do
+      assert_equal(1, (g >> f).call({a: 3})[:a])
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter.*The last argument is used as the keyword parameter.*for method/m) do
+      assert_equal(1, (f << g).call(**{})[:a])
+    end
+    assert_warn(/The last argument is used as the keyword parameter.*for method/m) do
+      assert_equal(2, (f >> g).call(**{})[:a])
+    end
+  end
+
+  def test_compose_keywords_non_proc
+    f = ->(**kw) { kw.merge(:a=>1) }
+    g = Object.new
+    def g.call(kw) kw.merge(:a=>2) end
+    def g.to_proc; method(:call).to_proc; end
+    def g.<<(f) to_proc << f end
+    def g.>>(f) to_proc >> f end
+
+    assert_warn(/The last argument is used as the keyword parameter.*for method/m) do
+      assert_equal(1, (f << g).call(a: 3)[:a])
+    end
+    assert_equal(2, (f >> g).call(a: 3)[:a])
+    assert_warn(/The last argument is used as the keyword parameter.*for method/m) do
+      assert_equal(1, (f << g).call({a: 3})[:a])
+    end
+    assert_warn(/The last argument is used as the keyword parameter.*for method/m) do
+      assert_equal(2, (f >> g).call({a: 3})[:a])
+    end
+    assert_equal(2, (g << f).call(a: 3)[:a])
+    assert_warn(/The last argument is used as the keyword parameter.*for method/m) do
+      assert_equal(1, (g >> f).call(a: 3)[:a])
+    end
+    assert_warn(/The last argument is used as the keyword parameter.*for method/m) do
+      assert_equal(2, (g << f).call({a: 3})[:a])
+    end
+    assert_warn(/The last argument is used as the keyword parameter.*for method/m) do
+      assert_equal(1, (g >> f).call({a: 3})[:a])
+    end
+    assert_warn(/The keyword argument is passed as the last hash parameter.*for `call'/m) do
+      assert_equal(1, (f << g).call(**{})[:a])
+    end
+    assert_equal(2, (f >> g).call(**{})[:a])
+
+    f = ->(kw) { kw.merge(:a=>1) }
+    g = Object.new
+    def g.call(**kw) kw.merge(:a=>2) end
+    def g.to_proc; method(:call).to_proc; end
+    def g.<<(f) to_proc << f end
+    def g.>>(f) to_proc >> f end
+
+    assert_equal(1, (f << g).call(a: 3)[:a])
+    assert_warn(/The last argument is used as the keyword parameter.*for `call'/m) do
+      assert_equal(2, (f >> g).call(a: 3)[:a])
+    end
+    assert_warn(/The last argument is used as the keyword parameter.*for `call'/m) do
+      assert_equal(1, (f << g).call({a: 3})[:a])
+    end
+    assert_warn(/The last argument is used as the keyword parameter.*for `call'/m) do
+      assert_equal(2, (f >> g).call({a: 3})[:a])
+    end
+    assert_warn(/The last argument is used as the keyword parameter.*for `call'/m) do
+      assert_equal(2, (g << f).call(a: 3)[:a])
+    end
+    assert_warn(/The last argument is used as the keyword parameter.*for `call'/m) do
+      assert_equal(1, (g >> f).call(a: 3)[:a])
+    end
+    assert_warn(/The last argument is used as the keyword parameter.*for `call'/m) do
+      assert_equal(2, (g << f).call({a: 3})[:a])
+    end
+    assert_warn(/The last argument is used as the keyword parameter.*for `call'/m) do
+      assert_equal(1, (g >> f).call({a: 3})[:a])
+    end
+    assert_equal(1, (f << g).call(**{})[:a])
+    assert_warn(/The keyword argument is passed as the last hash parameter.*The last argument is used as the keyword parameter.*for `call'/m) do
+      assert_equal(2, (f >> g).call(**{})[:a])
+    end
+  end
+end
+

--- a/thread.c
+++ b/thread.c
@@ -671,7 +671,7 @@ thread_do_start(rb_thread_t *th)
 
     if (th->invoke_type == thread_invoke_type_proc) {
         VALUE args = th->invoke_arg.proc.args;
-        int args_len = RARRAY_LEN(args);
+        int args_len = (int)RARRAY_LEN(args);
         int kw_splat = th->invoke_arg.proc.kw_splat;
         const VALUE *args_ptr;
         VALUE procval = th->invoke_arg.proc.proc;

--- a/vm_core.h
+++ b/vm_core.h
@@ -951,6 +951,7 @@ typedef struct rb_thread_struct {
         struct {
             VALUE proc;
             VALUE args;
+            int kw_splat;
         } proc;
         struct {
             VALUE (*func)(void *);


### PR DESCRIPTION
Fixes for:

* IO#open calling #to_open 
* Proc#{<<,>>}
* OpenSSL::SSL::SSLSocket#sys{read,write}_nonblock
* Pathname#{write,binwrite,readlines,open}