### PR TITLE
Expression with modifier `in`

### DIFF
--- a/test/ruby/test_iseq.rb
+++ b/test/ruby/test_iseq.rb
@@ -434,7 +434,7 @@ class TestISeq < Test::Unit::TestCase
   end
 
   def test_to_binary_pattern_matching
-    code = "case foo in []; end"
+    code = "case foo; in []; end"
     iseq = compile(code)
     assert_include(iseq.disasm, "TypeError")
     assert_include(iseq.disasm, "NoMatchingPatternError")

--- a/test/ruby/test_pattern_matching.rb
+++ b/test/ruby/test_pattern_matching.rb
@@ -1180,6 +1180,13 @@ END
       end
     end
   end
+
+  ################################################################
+
+  def test_modifier_in
+    assert_equal true, (1 in a)
+    assert_equal 1, a
+  end
 end
 END_of_GUARD
 $VERBOSE = verbose


### PR DESCRIPTION
[Feature #15865]