### PR TITLE
[EXPERIMENTAL] Make Module#name return a frozen String

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -174,6 +174,10 @@ Module::
 
     * Module#autoload? now takes an +inherit+ optional argument, like as
       Module#const_defined?.  [Feature #15777]
+    
+    * Module#name now always return a frozen String. The returned String is
+      always the same for a given Module. This change is experimental
+      [Feature #16150]
 
 ObjectSpace::WeakMap::
 

--- a/spec/ruby/core/module/name_spec.rb
+++ b/spec/ruby/core/module/name_spec.rb
@@ -102,13 +102,27 @@ describe "Module#name" do
     m::N.name.should == "ModuleSpecs::Anonymous::E::N"
   end
 
-  it "returns a mutable string" do
-    ModuleSpecs.name.frozen?.should be_false
+  ruby_version_is ""..."2.7" do
+    it "returns a mutable string" do
+      ModuleSpecs.name.frozen?.should be_false
+    end
+
+    it "returns a mutable string that when mutated does not modify the original module name" do
+      ModuleSpecs.name << "foo"
+
+      ModuleSpecs.name.should == "ModuleSpecs"
+    end
   end
 
-  it "returns a mutable string that when mutated does not modify the original module name" do
-    ModuleSpecs.name << "foo"
+  ruby_version_is "2.7" do
+    it "returns a frozen String" do
+      ModuleSpecs.name.frozen?.should == true
+    end
 
-    ModuleSpecs.name.should == "ModuleSpecs"
+    it "always returns the same String for a given Module" do
+      s1 = ModuleSpecs.name
+      s2 = ModuleSpecs.name
+      s1.should equal(s2)
+    end
   end
 end

--- a/variable.c
+++ b/variable.c
@@ -107,10 +107,7 @@ VALUE
 rb_mod_name(VALUE mod)
 {
     int permanent;
-    VALUE path = classname(mod, &permanent);
-
-    if (!NIL_P(path)) return rb_str_dup(path);
-    return path;
+    return classname(mod, &permanent);
 }
 
 static VALUE


### PR DESCRIPTION
Ref: https://github.com/ruby/ruby/pull/2437

    * Always the same frozen String for a given Module or Class.
    * Avoids extra allocations whenever calling Module#name.
    * See [Feature #16150]

Matz agreed to experiment with this change: https://bugs.ruby-lang.org/issues/16150#note-21

cc @eregon 

I'll see for `NilClass/FalseClass/TrueClass` in a followup PR.