### PR TITLE
Stop making a redundant hash copy in Hash#dup

### DIFF
--- a/benchmark/hash_dup.yml
+++ b/benchmark/hash_dup.yml
@@ -1,0 +1,8 @@
+prelude: |
+  small_hash = { a: 1 }
+  larger_hash = 20.times.map { |i| [('a'.ord + i).chr.to_sym, i] }.to_h
+
+benchmark:
+  dup_small: small_hash.dup
+  dup_larger: larger_hash.dup
+loop_count: 10000

--- a/hash.c
+++ b/hash.c
@@ -2824,14 +2824,20 @@ rb_hash_initialize_copy(VALUE hash, VALUE hash2)
 
     if (hash == hash2) return hash;
 
+    if (RHASH_ST_TABLE_P(hash)) {
+        st_free_table(RHASH_ST_TABLE(hash));
+        RHASH_ST_CLEAR(hash);
+    }
+    else {
+        ar_free_and_clear_table(hash);
+    }
+
     if (RHASH_AR_TABLE_P(hash2)) {
-        if (RHASH_AR_TABLE_P(hash)) ar_free_and_clear_table(hash);
         ar_copy(hash, hash2);
         if (RHASH_AR_TABLE_SIZE(hash))
 	    rb_hash_rehash(hash);
     }
     else if (RHASH_ST_TABLE_P(hash2)) {
-        if (RHASH_ST_TABLE_P(hash)) st_free_table(RHASH_ST_TABLE(hash));
         RHASH_ST_TABLE_SET(hash, st_copy(RHASH_ST_TABLE(hash2)));
         if (RHASH_ST_TABLE(hash)->num_entries)
             rb_hash_rehash(hash);

--- a/hash.c
+++ b/hash.c
@@ -2837,16 +2837,10 @@ rb_hash_initialize_copy(VALUE hash, VALUE hash2)
         if (RHASH_AR_TABLE_SIZE(hash))
 	    rb_hash_rehash(hash);
     }
-    else if (RHASH_ST_TABLE_P(hash2)) {
+    else {
         RHASH_ST_TABLE_SET(hash, st_copy(RHASH_ST_TABLE(hash2)));
         if (RHASH_ST_TABLE(hash)->num_entries)
             rb_hash_rehash(hash);
-    }
-    else if (RHASH_AR_TABLE_P(hash)) {
-        ar_clear(hash);
-    }
-    else if (RHASH_ST_TABLE_P(hash)) {
-        st_clear(RHASH_ST_TABLE(hash));
     }
 
     COPY_DEFAULT(hash, hash2);

--- a/hash.c
+++ b/hash.c
@@ -2807,46 +2807,6 @@ rb_hash_aset(VALUE hash, VALUE key, VALUE val)
     return val;
 }
 
-static int
-replace_i(VALUE key, VALUE val, VALUE hash)
-{
-    rb_hash_aset(hash, key, val);
-
-    return ST_CONTINUE;
-}
-
-/* :nodoc: */
-static VALUE
-rb_hash_initialize_copy(VALUE hash, VALUE hash2)
-{
-    rb_hash_modify_check(hash);
-    hash2 = to_hash(hash2);
-
-    if (hash == hash2) return hash;
-
-    if (RHASH_ITER_LEV(hash) > 0) {
-        rb_raise(rb_eRuntimeError, "can't replace hash during iteration");
-    }
-
-    if (RHASH_ST_TABLE_P(hash)) {
-        st_free_table(RHASH_ST_TABLE(hash));
-        RHASH_ST_CLEAR(hash);
-    }
-    else {
-        ar_free_and_clear_table(hash);
-    }
-
-    if (RHASH_ST_TABLE_P(hash2)) {
-        RHASH_ST_TABLE_SET(hash, st_init_table_with_size(RHASH_ST_TABLE(hash2)->type, RHASH_ST_SIZE(hash2)));
-    }
-
-    rb_hash_foreach(hash2, rb_hash_rehash_i, (VALUE)hash);
-    COPY_DEFAULT(hash, hash2);
-    rb_gc_writebarrier_remember(hash);
-
-    return hash;
-}
-
 /*
  *  call-seq:
  *     hsh.replace(other_hash) -> hsh
@@ -2864,26 +2824,35 @@ rb_hash_replace(VALUE hash, VALUE hash2)
 {
     rb_hash_modify_check(hash);
     if (hash == hash2) return hash;
+    if (RHASH_ITER_LEV(hash) > 0) {
+        rb_raise(rb_eRuntimeError, "can't replace hash during iteration");
+    }
     hash2 = to_hash(hash2);
 
     COPY_DEFAULT(hash, hash2);
 
-    rb_hash_clear(hash);
-
     if (RHASH_AR_TABLE_P(hash)) {
-        if (RHASH_AR_TABLE_P(hash2)) {
-            ar_copy(hash, hash2);
-        }
-        else {
-            goto st_to_st;
-        }
+      if (RHASH_AR_TABLE_P(hash2)) {
+        ar_clear(hash);
+      }
+      else {
+        ar_free_and_clear_table(hash);
+        RHASH_ST_TABLE_SET(hash, st_init_table_with_size(RHASH_TYPE(hash2), RHASH_SIZE(hash2)));
+      }
     }
     else {
-        if (RHASH_AR_TABLE_P(hash2)) ar_force_convert_table(hash2, __FILE__, __LINE__);
-      st_to_st:
+      if (RHASH_AR_TABLE_P(hash2)) {
+        st_free_table(RHASH_ST_TABLE(hash));
+        RHASH_ST_CLEAR(hash);
+      }
+      else {
+        st_clear(RHASH_ST_TABLE(hash));
         RHASH_TBL_RAW(hash)->type = RHASH_ST_TABLE(hash2)->type;
-        rb_hash_foreach(hash2, replace_i, hash);
+      }
     }
+    rb_hash_foreach(hash2, rb_hash_rehash_i, (VALUE)hash);
+
+    rb_gc_writebarrier_remember(hash);
 
     return hash;
 }
@@ -6127,7 +6096,7 @@ Init_Hash(void)
     rb_define_singleton_method(rb_cHash, "[]", rb_hash_s_create, -1);
     rb_define_singleton_method(rb_cHash, "try_convert", rb_hash_s_try_convert, 1);
     rb_define_method(rb_cHash, "initialize", rb_hash_initialize, -1);
-    rb_define_method(rb_cHash, "initialize_copy", rb_hash_initialize_copy, 1);
+    rb_define_method(rb_cHash, "initialize_copy", rb_hash_replace, 1);
     rb_define_method(rb_cHash, "rehash", rb_hash_rehash, 0);
 
     rb_define_method(rb_cHash, "to_hash", rb_hash_to_hash, 0);

--- a/hash.c
+++ b/hash.c
@@ -2822,8 +2822,6 @@ rb_hash_initialize_copy(VALUE hash, VALUE hash2)
     rb_hash_modify_check(hash);
     hash2 = to_hash(hash2);
 
-    Check_Type(hash2, T_HASH);
-
     if (hash == hash2) return hash;
 
     if (RHASH_AR_TABLE_P(hash2)) {


### PR DESCRIPTION
@ko1 here is a PR for [Bug #16121](https://bugs.ruby-lang.org/issues/16121) as requested.
Edit: also addresses [Bug #16187](https://bugs.ruby-lang.org/issues/16187)

I've updated the benchmark to work with benchmark driver like other benchmarks in the repo.

```yaml
prelude: |
  small_hash = { a: 1 }
  larger_hash = 20.times.map { |i| [('a'.ord + i).chr.to_sym, i] }.to_h

benchmark:
  dup_small: small_hash.dup
  dup_larger: larger_hash.dup
loop_count: 100000
```

and benchmarked against the ruby master commit this branch is based on (compare-ruby) and got

```
Comparison:
                        dup_small
          built-ruby:   3405182.6 i/s
        compare-ruby:   2900652.6 i/s - 1.17x  slower

                       dup_larger
          built-ruby:    623192.7 i/s
        compare-ruby:    458236.3 i/s - 1.36x  slower
```

ko1 (Koichi Sasada) wrote:
> I found that
> 
> > `    rb_define_method(rb_cArray, "initialize_copy", rb_ary_replace, 1);`
> 
> `Array#initialize_copy` == `Array#replace`. Can we use same technique?

We will have to make sure they are actually functionally equivalent before merging implementations to avoid breaking backwards compatibility.

It is definitely worth looking into though, since it looks like `rb_hash_replace` could be optimized for larger hashes.  To show that, I tried that benchmark again with this change

```
diff --git a/hash.c b/hash.c
index 7efea12e8a..64e9ee3ca7 100644
--- a/hash.c
+++ b/hash.c
@@ -6124,7 +6124,7 @@ Init_Hash(void)
     rb_define_singleton_method(rb_cHash, "[]", rb_hash_s_create, -1);
     rb_define_singleton_method(rb_cHash, "try_convert", rb_hash_s_try_convert, 1);
     rb_define_method(rb_cHash, "initialize", rb_hash_initialize, -1);
-    rb_define_method(rb_cHash, "initialize_copy", rb_hash_initialize_copy, 1);
+    rb_define_method(rb_cHash, "initialize_copy", rb_hash_replace, 1);
     rb_define_method(rb_cHash, "rehash", rb_hash_rehash, 0);
 
     rb_define_method(rb_cHash, "to_hash", rb_hash_to_hash, 0);
```

and got

```
Comparison:
                        dup_small
          built-ruby:   4701457.6 i/s
        compare-ruby:   3093293.7 i/s - 1.52x  slower

                       dup_larger
        compare-ruby:    471051.5 i/s
          built-ruby:    294461.5 i/s - 1.60x  slower
```

so it looks like avoiding the hash allocation makes it faster than Hash#dup on trunk for small arrays, but its hash iteration function (`replace_i` in hash.c) seems to be slower than `rb_hash_rehash_i`.