### PR TITLE
Fix keyword argument separation issues in Enumerator::Generator#each

### DIFF
--- a/cont.c
+++ b/cont.c
@@ -1779,7 +1779,6 @@ rb_fiber_new(rb_block_call_func_t func, VALUE obj)
 static void rb_fiber_terminate(rb_fiber_t *fiber, int need_interrupt);
 
 #define PASS_KW_SPLAT (rb_empty_keyword_given_p() ? RB_PASS_EMPTY_KEYWORDS : rb_keyword_given_p())
-extern VALUE rb_adjust_argv_kw_splat(int *argc, const VALUE **argv, int *kw_splat);
 
 void
 rb_fiber_start(void)

--- a/enumerator.c
+++ b/enumerator.c
@@ -1506,7 +1506,7 @@ generator_each(int argc, VALUE *argv, VALUE obj)
 	rb_ary_cat(args, argv, argc);
     }
 
-    return rb_proc_call(ptr->proc, args);
+    return rb_proc_call_kw(ptr->proc, args, RB_PASS_CALLED_KEYWORDS);
 }
 
 /* Lazy Enumerator methods */

--- a/include/ruby/intern.h
+++ b/include/ruby/intern.h
@@ -454,6 +454,7 @@ VALUE rb_block_lambda(void);
 VALUE rb_proc_new(rb_block_call_func_t, VALUE);
 VALUE rb_obj_is_proc(VALUE);
 VALUE rb_proc_call(VALUE, VALUE);
+VALUE rb_proc_call_kw(VALUE, VALUE, int);
 VALUE rb_proc_call_with_block(VALUE, int argc, const VALUE *argv, VALUE);
 VALUE rb_proc_call_with_block_kw(VALUE, int argc, const VALUE *argv, VALUE, int);
 int rb_proc_arity(VALUE);

--- a/internal.h
+++ b/internal.h
@@ -2294,6 +2294,7 @@ void rb_print_backtrace(void);
 
 /* vm_eval.c */
 void Init_vm_eval(void);
+VALUE rb_adjust_argv_kw_splat(int *, const VALUE **, int *);
 VALUE rb_current_realfilepath(void);
 VALUE rb_check_block_call(VALUE, ID, int, const VALUE *, rb_block_call_func_t, VALUE);
 typedef void rb_check_funcall_hook(int, VALUE, ID, int, const VALUE *, VALUE);

--- a/proc.c
+++ b/proc.c
@@ -935,6 +935,24 @@ check_argc(long argc)
 #endif
 
 VALUE
+rb_proc_call_kw(VALUE self, VALUE args, int kw_splat)
+{
+    VALUE vret;
+    rb_proc_t *proc;
+    VALUE v;
+    int argc = check_argc(RARRAY_LEN(args));
+    const VALUE *argv = RARRAY_CONST_PTR(args);
+    GetProcPtr(self, proc);
+    v = rb_adjust_argv_kw_splat(&argc, &argv, &kw_splat);
+    vret = rb_vm_invoke_proc(GET_EC(), proc, argc, argv,
+                             kw_splat, VM_BLOCK_HANDLER_NONE);
+    rb_free_tmp_buffer(&v);
+    RB_GC_GUARD(self);
+    RB_GC_GUARD(args);
+    return vret;
+}
+
+VALUE
 rb_proc_call(VALUE self, VALUE args)
 {
     VALUE vret;

--- a/proc.c
+++ b/proc.c
@@ -954,8 +954,6 @@ proc_to_block_handler(VALUE procval)
     return NIL_P(procval) ? VM_BLOCK_HANDLER_NONE : procval;
 }
 
-extern VALUE rb_adjust_argv_kw_splat(int *argc, const VALUE **argv, int *kw_splat);
-
 VALUE
 rb_proc_call_with_block_kw(VALUE self, int argc, const VALUE *argv, VALUE passed_procval, int kw_splat)
 {

--- a/thread.c
+++ b/thread.c
@@ -662,8 +662,6 @@ rb_vm_proc_local_ep(VALUE proc)
     }
 }
 
-extern VALUE rb_adjust_argv_kw_splat(int *argc, const VALUE **argv, int *kw_splat);
-
 static void
 thread_do_start(rb_thread_t *th)
 {

--- a/vm_args.c
+++ b/vm_args.c
@@ -14,7 +14,6 @@ NORETURN(static void argument_kw_error(rb_execution_context_t *ec, const rb_iseq
 VALUE rb_keyword_error_new(const char *error, VALUE keys); /* class.c */
 static VALUE method_missing(VALUE obj, ID id, int argc, const VALUE *argv,
                             enum method_missing_reason call_status, int kw_splat);
-extern VALUE rb_adjust_argv_kw_splat(int *argc, const VALUE **argv, int *kw_splat);
 
 struct args_info {
     /* basic args info */


### PR DESCRIPTION
This requires adding `rb_proc_call_kw` to pass the keyword flag.

Add `rb_adjust_argv_kw_splat` to internal.h, instead of adding a prototype to a other files that use it.
