### PR TITLE
Fix more keyword separation issues

### DIFF
--- a/enumerator.c
+++ b/enumerator.c
@@ -1320,7 +1320,7 @@ yielder_yield(VALUE obj, VALUE args)
 {
     struct yielder *ptr = yielder_ptr(obj);
 
-    return rb_proc_call(ptr->proc, args);
+    return rb_proc_call_kw(ptr->proc, args, RB_PASS_CALLED_KEYWORDS);
 }
 
 /* :nodoc: */
@@ -1357,7 +1357,7 @@ yielder_to_proc(VALUE obj)
 static VALUE
 yielder_yield_i(RB_BLOCK_CALL_FUNC_ARGLIST(obj, memo))
 {
-    return rb_yield_values2(argc, argv);
+    return rb_yield_values_kw(argc, argv, RB_PASS_CALLED_KEYWORDS);
 }
 
 static VALUE

--- a/ext/-test-/iter/yield.c
+++ b/ext/-test-/iter/yield.c
@@ -4,7 +4,7 @@ static VALUE
 yield_block(int argc, VALUE *argv, VALUE self)
 {
     rb_check_arity(argc, 1, UNLIMITED_ARGUMENTS);
-    return rb_block_call(self, rb_to_id(argv[0]), argc-1, argv+1, rb_yield_block, 0);
+    return rb_block_call_kw(self, rb_to_id(argv[0]), argc-1, argv+1, rb_yield_block, 0, RB_PASS_CALLED_KEYWORDS);
 }
 
 void

--- a/hash.c
+++ b/hash.c
@@ -4471,7 +4471,7 @@ rb_hash_gt(VALUE hash, VALUE other)
 }
 
 static VALUE
-hash_proc_call(VALUE key, VALUE hash, int argc, const VALUE *argv, VALUE passed_proc)
+hash_proc_call(RB_BLOCK_CALL_FUNC_ARGLIST(key, hash))
 {
     rb_check_arity(argc, 1, 1);
     return rb_hash_aref(hash, *argv);

--- a/include/ruby/ruby.h
+++ b/include/ruby/ruby.h
@@ -1970,8 +1970,9 @@ VALUE rb_each(VALUE);
 VALUE rb_yield(VALUE);
 VALUE rb_yield_values(int n, ...);
 VALUE rb_yield_values2(int n, const VALUE *argv);
+VALUE rb_yield_values_kw(int n, const VALUE *argv, int kw_splat);
 VALUE rb_yield_splat(VALUE);
-VALUE rb_yield_block(VALUE, VALUE, int, const VALUE *, VALUE); /* rb_block_call_func */
+VALUE rb_yield_block(RB_BLOCK_CALL_FUNC_ARGLIST(yielded_arg, callback_arg)); /* rb_block_call_func */
 #define RB_NO_KEYWORDS 0
 #define RB_PASS_KEYWORDS 1
 #define RB_PASS_EMPTY_KEYWORDS 2

--- a/proc.c
+++ b/proc.c
@@ -2895,7 +2895,7 @@ mlambda(VALUE method)
 static VALUE
 bmcall(RB_BLOCK_CALL_FUNC_ARGLIST(args, method))
 {
-    return rb_method_call_with_block(argc, argv, method, blockarg);
+    return rb_method_call_with_block_kw(argc, argv, method, blockarg, RB_PASS_CALLED_KEYWORDS);
 }
 
 VALUE

--- a/test/ruby/test_proc.rb
+++ b/test/ruby/test_proc.rb
@@ -1552,9 +1552,7 @@ class TestProcKeywords < Test::Unit::TestCase
     assert_warn(/The last argument is used as the keyword parameter.*for method/m) do
       assert_equal(1, (f << g).call(a: 3)[:a])
     end
-    assert_warn(/The last argument is used as the keyword parameter.*for method/m) do
-      assert_equal(2, (f >> g).call(a: 3)[:a])
-    end
+    assert_equal(2, (f >> g).call(a: 3)[:a])
     assert_warn(/The last argument is used as the keyword parameter.*for method/m) do
       assert_equal(1, (f << g).call({a: 3})[:a])
     end
@@ -1574,9 +1572,7 @@ class TestProcKeywords < Test::Unit::TestCase
     assert_warn(/The keyword argument is passed as the last hash parameter.*The last argument is used as the keyword parameter.*for method/m) do
       assert_equal(1, (f << g).call(**{})[:a])
     end
-    assert_warn(/The last argument is used as the keyword parameter.*for method/m) do
-      assert_equal(2, (f >> g).call(**{})[:a])
-    end
+    assert_equal(2, (f >> g).call(**{})[:a])
   end
 
   def test_compose_keywords_non_proc
@@ -1632,9 +1628,7 @@ class TestProcKeywords < Test::Unit::TestCase
     assert_warn(/The last argument is used as the keyword parameter.*for `call'/m) do
       assert_equal(2, (g << f).call(a: 3)[:a])
     end
-    assert_warn(/The last argument is used as the keyword parameter.*for `call'/m) do
-      assert_equal(1, (g >> f).call(a: 3)[:a])
-    end
+    assert_equal(1, (g >> f).call(a: 3)[:a])
     assert_warn(/The last argument is used as the keyword parameter.*for `call'/m) do
       assert_equal(2, (g << f).call({a: 3})[:a])
     end

--- a/vm.c
+++ b/vm.c
@@ -1164,26 +1164,26 @@ check_block_handler(rb_execution_context_t *ec)
 }
 
 static VALUE
-vm_yield_with_cref(rb_execution_context_t *ec, int argc, const VALUE *argv, const rb_cref_t *cref, int is_lambda)
+vm_yield_with_cref(rb_execution_context_t *ec, int argc, const VALUE *argv, int kw_splat, const rb_cref_t *cref, int is_lambda)
 {
     return invoke_block_from_c_bh(ec, check_block_handler(ec),
-                                  argc, argv, VM_NO_KEYWORDS, VM_BLOCK_HANDLER_NONE,
+                                  argc, argv, kw_splat, VM_BLOCK_HANDLER_NONE,
 				  cref, is_lambda, FALSE);
 }
 
 static VALUE
-vm_yield(rb_execution_context_t *ec, int argc, const VALUE *argv)
+vm_yield(rb_execution_context_t *ec, int argc, const VALUE *argv, int kw_splat)
 {
     return invoke_block_from_c_bh(ec, check_block_handler(ec),
-                                  argc, argv, VM_NO_KEYWORDS, VM_BLOCK_HANDLER_NONE,
+                                  argc, argv, kw_splat, VM_BLOCK_HANDLER_NONE,
 				  NULL, FALSE, FALSE);
 }
 
 static VALUE
-vm_yield_with_block(rb_execution_context_t *ec, int argc, const VALUE *argv, VALUE block_handler)
+vm_yield_with_block(rb_execution_context_t *ec, int argc, const VALUE *argv, VALUE block_handler, int kw_splat)
 {
     return invoke_block_from_c_bh(ec, check_block_handler(ec),
-                                  argc, argv, VM_NO_KEYWORDS, block_handler,
+                                  argc, argv, kw_splat, block_handler,
 				  NULL, FALSE, FALSE);
 }
 
@@ -1213,6 +1213,10 @@ invoke_block_from_c_proc(rb_execution_context_t *ec, const rb_proc_t *proc,
       case block_type_iseq:
         return invoke_iseq_block_from_c(ec, &block->as.captured, self, argc, argv, kw_splat, passed_block_handler, NULL, is_lambda, me);
       case block_type_ifunc:
+        if (kw_splat == 1 && RHASH_EMPTY_P(argv[argc-1])) {
+            argc--;
+            kw_splat = 2;
+        }
         return vm_yield_with_cfunc(ec, &block->as.captured, self, argc, argv, kw_splat, passed_block_handler, me);
       case block_type_symbol:
 	return vm_yield_with_symbol(ec, block->as.symbol, argc, argv, kw_splat, passed_block_handler);


### PR DESCRIPTION
This fixes instance_exec and similar methods. It also fixes
Enumerator::Yielder#yield, rb_yield_block, and a couple of cases
with Proc#{<<,>>}.

This support requires the addition of rb_yield_values_kw, similar to
rb_yield_values2, for passing the keyword flag.

Unlike earlier attempts at this, this does not modify the rb_block_call_func
type or add a separate function type.  The functions of type
rb_block_call_func are called by Ruby with a separate VM frame, and we can
get the keyword flag information from the VM frame flags, so it doesn't need
to be passed as a function argument.

These changes require the following VM functions accept a keyword flag:

* vm_yield_with_cref
* vm_yield
* vm_yield_with_block