### PR TITLE
Optimize Array#flatten and flatten! for already flattened arrays

### DIFF
--- a/benchmark/array_flatten.yml
+++ b/benchmark/array_flatten.yml
@@ -1,0 +1,19 @@
+prelude: |
+  small_flat_ary = 5.times.to_a
+  large_flat_ary = 100.times.to_a
+  small_pairs_ary = [[1, 2]] * 5
+  large_pairs_ary = [[1, 2]] * 100
+  mostly_flat_ary = 100.times.to_a.push([101, 102])
+
+benchmark:
+  small_flat_ary.flatten: small_flat_ary.flatten
+  small_flat_ary.flatten!: small_flat_ary.flatten!
+  large_flat_ary.flatten: large_flat_ary.flatten
+  large_flat_ary.flatten!: large_flat_ary.flatten!
+  small_pairs_ary.flatten: small_pairs_ary.flatten
+  small_pairs_ary.flatten!: small_pairs_ary.dup.flatten!
+  large_pairs_ary.flatten: large_pairs_ary.flatten
+  large_pairs_ary.flatten!: large_pairs_ary.dup.flatten!
+  mostly_flat_ary.flatten: mostly_flat_ary.flatten
+  mostly_flat_ary.flatten!: mostly_flat_ary.dup.flatten!
+loop_count: 10000


### PR DESCRIPTION
cc @nobu

This is a rebase of my patch for [Bug #16121](https://bugs.ruby-lang.org/issues/16119) which had a merge conflict.

Here is an updated benchmark that avoids mutating arrays from the prelude, which affected my initial benchmark results.  I've also used the benchmark driver yaml format.

```yaml
prelude: |
  empty_ary = []
  small_flat_ary = 5.times.to_a
  large_flat_ary = 100.times.to_a
  small_pairs_ary = [[1, 2]] * 5
  large_pairs_ary = [[1, 2]] * 100
  mostly_flat_ary = 100.times.to_a.push([101, 102])

benchmark:
  empty_ary.flatten: empty_ary.flatten
  empty_ary.flatten!: empty_ary.flatten!
  small_flat_ary.flatten: small_flat_ary.flatten
  small_flat_ary.flatten!: small_flat_ary.flatten!
  large_flat_ary.flatten: large_flat_ary.flatten
  large_flat_ary.flatten!: large_flat_ary.flatten!
  small_pairs_ary.flatten: small_pairs_ary.flatten
  small_pairs_ary.flatten!: small_pairs_ary.dup.flatten!
  large_pairs_ary.flatten: large_pairs_ary.flatten
  large_pairs_ary.flatten!: large_pairs_ary.dup.flatten!
  mostly_flat_ary.flatten: mostly_flat_ary.flatten
  mostly_flat_ary.flatten!: mostly_flat_ary.dup.flatten!
loop_count: 100000
```

and here are the results I get against the latest ruby master commit that this branch is based on

```
Comparison:
                    empty_ary.flatten
              built-ruby:  16196955.0 i/s
            compare-ruby:   2013977.0 i/s - 8.04x  slower

                   empty_ary.flatten!
              built-ruby:  34698131.2 i/s
            compare-ruby:   2000080.0 i/s - 17.35x  slower

               small_flat_ary.flatten
              built-ruby:   3461525.2 i/s
            compare-ruby:   1331983.6 i/s - 2.60x  slower

              small_flat_ary.flatten!
              built-ruby:   3981367.3 i/s
            compare-ruby:   1298094.4 i/s - 3.07x  slower

               large_flat_ary.flatten
              built-ruby:    239017.2 i/s
            compare-ruby:    189051.3 i/s - 1.26x  slower

              large_flat_ary.flatten!
              built-ruby:    243342.2 i/s
            compare-ruby:    189334.8 i/s - 1.29x  slower

              small_pairs_ary.flatten
              built-ruby:    690913.1 i/s
            compare-ruby:    665916.4 i/s - 1.04x  slower

             small_pairs_ary.flatten!
              built-ruby:    482274.0 i/s
            compare-ruby:    455035.7 i/s - 1.06x  slower

              large_pairs_ary.flatten
            compare-ruby:     53500.6 i/s
              built-ruby:     52040.2 i/s - 1.03x  slower

             large_pairs_ary.flatten!
            compare-ruby:     52132.2 i/s
              built-ruby:     51463.7 i/s - 1.01x  slower

              mostly_flat_ary.flatten
              built-ruby:    208538.0 i/s
            compare-ruby:    184157.7 i/s - 1.13x  slower

             mostly_flat_ary.flatten!
              built-ruby:    183007.4 i/s
            compare-ruby:    161869.4 i/s - 1.13x  slower
```

So this helps for flat arrays or arrays with a flat prefix, but have an insignificant affect on arrays starting with a nested array.