### PR TITLE
compile.c: Initialize label->position field [Bug #16184]

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -1079,6 +1079,7 @@ new_label_body(rb_iseq_t *iseq, long line)
     labelobj->link.next = 0;
 
     labelobj->label_no = ISEQ_COMPILE_DATA(iseq)->label_no++;
+    labelobj->position = 0;
     labelobj->sc_state = 0;
     labelobj->sp = -1;
     labelobj->refcnt = 0;


### PR DESCRIPTION
The initial value of the label position may still be used
(see bug #16184 for an example), so let's play it safe
and initialize it.

Signed-off-by: Ivan A. Melnikov <iv@altlinux.org>