### PR TITLE
Correctly issue ArgumentError when calling method that accepts no keywords

### DIFF
--- a/test/ruby/test_keyword.rb
+++ b/test/ruby/test_keyword.rb
@@ -158,6 +158,19 @@ class TestKeywordArguments < Test::Unit::TestCase
     assert_equal([b, [:b]], f12(**h, &b))
   end
 
+  def f13(a, **nil)
+    a
+  end
+
+  def test_f13
+    assert_equal(1, f13(1))
+    assert_equal(1, f13(1, **{}))
+    assert_raise(ArgumentError) { f13(a: 1) }
+    assert_raise(ArgumentError) { f13(1, a: 1) }
+    assert_raise(ArgumentError) { f13(**{a: 1}) }
+    assert_raise(ArgumentError) { f13(1, **{a: 1}) }
+  end
+
   def test_method_parameters
     assert_equal([[:key, :str], [:key, :num]], method(:f1).parameters);
     assert_equal([[:req, :x], [:key, :str], [:key, :num]], method(:f2).parameters);

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1743,6 +1743,7 @@ rb_simple_iseq_p(const rb_iseq_t *iseq)
 	   iseq->body->param.flags.has_post == FALSE &&
 	   iseq->body->param.flags.has_kw == FALSE &&
 	   iseq->body->param.flags.has_kwrest == FALSE &&
+           iseq->body->param.flags.accepts_no_kwarg == FALSE &&
 	   iseq->body->param.flags.has_block == FALSE;
 }
 
@@ -1754,6 +1755,7 @@ rb_iseq_only_optparam_p(const rb_iseq_t *iseq)
            iseq->body->param.flags.has_post == FALSE &&
            iseq->body->param.flags.has_kw == FALSE &&
            iseq->body->param.flags.has_kwrest == FALSE &&
+           iseq->body->param.flags.accepts_no_kwarg == FALSE &&
            iseq->body->param.flags.has_block == FALSE;
 }
 


### PR DESCRIPTION
If a method accepts no keywords and was called with a keyword, an
ArgumentError was not always issued previously.  Force methods that
accept no keywords to go through setup_parameters_complex so that
an ArgumentError is raised if keywords are provided.