### PR TITLE
Remove continue-on-error for test-bundled-gems

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -47,8 +47,9 @@ jobs:
           MSPECOPT: "-ff" # not using `-j` because sometimes `mspec -j` silently dies
         if: matrix.test_task != 'test-bundled-gems' && !contains(github.event.head_commit.message, '[ci skip]')
       - name: Tests (test-bundled-gems)
-        # Remove TEST_BUNDLED_GEMS_ALLOW_FAILURES=minitest if https://github.com/seattlerb/minitest/pull/798 resolved
-        run: make -s ${{ matrix.test_task }} TEST_BUNDLED_GEMS_ALLOW_FAILURES=minitest
+        # Remove minitest from TEST_BUNDLED_GEMS_ALLOW_FAILURES if https://github.com/seattlerb/minitest/pull/798 is resolved
+        # Remove test-unit from TEST_BUNDLED_GEMS_ALLOW_FAILURES if https://github.com/test-unit/test-unit/issues/165 is resolved
+        run: make -s ${{ matrix.test_task }} TEST_BUNDLED_GEMS_ALLOW_FAILURES=minitest,test-unit
         env:
           RUBY_TESTOPTS: "-q --tty=no"
         if: matrix.test_task == 'test-bundled-gems' && !contains(github.event.head_commit.message, '[ci skip]')

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -46,13 +46,11 @@ jobs:
         env:
           MSPECOPT: "-ff" # not using `-j` because sometimes `mspec -j` silently dies
         if: matrix.test_task != 'test-bundled-gems' && !contains(github.event.head_commit.message, '[ci skip]')
-      # test-bundled-gems is separated for marking `continue-on-error` because it randomly fails.
       - name: Tests (test-bundled-gems)
         # Remove TEST_BUNDLED_GEMS_ALLOW_FAILURES=minitest if https://github.com/seattlerb/minitest/pull/798 resolved
         run: make -s ${{ matrix.test_task }} TEST_BUNDLED_GEMS_ALLOW_FAILURES=minitest
         env:
           RUBY_TESTOPTS: "-q --tty=no"
-        continue-on-error: true
         if: matrix.test_task == 'test-bundled-gems' && !contains(github.event.head_commit.message, '[ci skip]')
       - name: Leaked Globals
         run: make -s leaked-globals

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -74,13 +74,11 @@ jobs:
         env:
           MSPECOPT: "-ff" # not using `-j` because sometimes `mspec -j` silently dies
         if: matrix.test_task != 'test-bundled-gems' && !contains(github.event.head_commit.message, '[ci skip]')
-      # test-bundled-gems is separated for marking `continue-on-error` because it randomly fails.
       - name: Tests (test-bundled-gems)
         # Remove TEST_BUNDLED_GEMS_ALLOW_FAILURES=minitest if https://github.com/seattlerb/minitest/pull/798 resolved
         run: make -s ${{ matrix.test_task }} TEST_BUNDLED_GEMS_ALLOW_FAILURES=minitest
         env:
           RUBY_TESTOPTS: "-q --tty=no"
-        continue-on-error: true
         if: matrix.test_task == 'test-bundled-gems' && !contains(github.event.head_commit.message, '[ci skip]')
       - name: Leaked Globals
         run: make -s leaked-globals

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -75,8 +75,9 @@ jobs:
           MSPECOPT: "-ff" # not using `-j` because sometimes `mspec -j` silently dies
         if: matrix.test_task != 'test-bundled-gems' && !contains(github.event.head_commit.message, '[ci skip]')
       - name: Tests (test-bundled-gems)
-        # Remove TEST_BUNDLED_GEMS_ALLOW_FAILURES=minitest if https://github.com/seattlerb/minitest/pull/798 resolved
-        run: make -s ${{ matrix.test_task }} TEST_BUNDLED_GEMS_ALLOW_FAILURES=minitest
+        # Remove minitest from TEST_BUNDLED_GEMS_ALLOW_FAILURES if https://github.com/seattlerb/minitest/pull/798 is resolved
+        # Remove test-unit from TEST_BUNDLED_GEMS_ALLOW_FAILURES if https://github.com/test-unit/test-unit/issues/165 is resolved
+        run: make -s ${{ matrix.test_task }} TEST_BUNDLED_GEMS_ALLOW_FAILURES=minitest,test-unit
         env:
           RUBY_TESTOPTS: "-q --tty=no"
         if: matrix.test_task == 'test-bundled-gems' && !contains(github.event.head_commit.message, '[ci skip]')

--- a/template/Makefile.in
+++ b/template/Makefile.in
@@ -536,15 +536,7 @@ cont.$(OBJEXT): $(COROUTINE_H)
 TEST_BUNDLED_GEMS_ALLOW_FAILURES =
 
 test-bundled-gems-run:
-	$(Q) fail=0 keep=; case "$(MFLAGS)" in *k*) keep=1;; esac; \
-	while read gem _; do \
-	  echo testing $$gem gem; \
-	  [ $$keep ] || echo $(TEST_BUNDLED_GEMS_ALLOW_FAILURES) | grep -q $$gem || set -e; \
-	  $(XRUBY) -C $(srcdir)/gems/src/$$gem -Ilib ../../../.bundle/bin/rake; \
-	  [ $$? = 0 ] || fail=1; \
-	  set +e; \
-	done < $(srcdir)/gems/bundled_gems; \
-	exit $$fail
+	$(Q) $(XRUBY) $(srcdir)/tool/test-bundled-gems.rb
 
 update-src::
 	@$(CHDIR) "$(srcdir)" && LC_TIME=C exec $(VCSUP)

--- a/template/Makefile.in
+++ b/template/Makefile.in
@@ -536,7 +536,7 @@ cont.$(OBJEXT): $(COROUTINE_H)
 TEST_BUNDLED_GEMS_ALLOW_FAILURES =
 
 test-bundled-gems-run:
-	$(Q) $(XRUBY) $(srcdir)/tool/test-bundled-gems.rb
+	$(Q) $(XRUBY) $(srcdir)/tool/test-bundled-gems.rb $(XRUBY)
 
 update-src::
 	@$(CHDIR) "$(srcdir)" && LC_TIME=C exec $(VCSUP)

--- a/tool/test-bundled-gems.rb
+++ b/tool/test-bundled-gems.rb
@@ -9,7 +9,7 @@ File.foreach('gems/bundled_gems') do |line|
   puts "\nTesting the #{gem} gem"
 
   gem_src_dir = File.expand_path("../../gems/src/#{gem}", __FILE__ )
-  test_command = "#{RbConfig.ruby} -C #{gem_src_dir} -Ilib ../../../.bundle/bin/rake"
+  test_command = "#{ARGV.join(' ')} -C #{gem_src_dir} -Ilib ../../../.bundle/bin/rake"
   puts test_command
   system test_command
 

--- a/tool/test-bundled-gems.rb
+++ b/tool/test-bundled-gems.rb
@@ -1,0 +1,26 @@
+require 'rbconfig'
+
+allowed_failures = ENV['TEST_BUNDLED_GEMS_ALLOW_FAILURES'] || ''
+allowed_failures = allowed_failures.split(',').reject(&:empty?)
+
+exit_code = 0
+File.foreach('gems/bundled_gems') do |line|
+  gem = line.split.first
+  puts "\nTesting the #{gem} gem"
+
+  gem_src_dir = File.expand_path("../../gems/src/#{gem}", __FILE__ )
+  test_command = "#{RbConfig.ruby} -C #{gem_src_dir} -Ilib ../../../.bundle/bin/rake"
+  puts test_command
+  system test_command
+
+  unless $?.success?
+    puts "Tests failed with exit code #{$?.exitstatus}"
+    if allowed_failures.include?(gem)
+      puts "Ignoring test failures for #{gem} due to \$TEST_BUNDLED_GEMS_ALLOW_FAILURES"
+    else
+      exit_code = $?.exitstatus
+    end
+  end
+end
+
+exit exit_code


### PR DESCRIPTION
* Otherwise, it takes a very long time to notice those tests broke.
* Needs a release of `did_you_mean` to fix those tests.