### PR TITLE
Fix or suppress keyword argument separation warnings in util_spec

### DIFF
--- a/spec/ruby/optional/capi/ext/util_spec.c
+++ b/spec/ruby/optional/capi/ext/util_spec.c
@@ -16,7 +16,14 @@ VALUE util_spec_rb_scan_args(VALUE self, VALUE argv, VALUE fmt, VALUE expected, 
     args[i] = rb_ary_entry(argv, i);
   }
 
-  result = rb_scan_args(argc, args, RSTRING_PTR(fmt), &a1, &a2, &a3, &a4, &a5, &a6);
+  if (*RSTRING_PTR(fmt) == 'k') {
+#ifdef RB_SCAN_ARGS_KEYWORDS
+    result = rb_scan_args_kw(RB_SCAN_ARGS_KEYWORDS, argc, args, RSTRING_PTR(fmt)+1, &a1, &a2, &a3, &a4, &a5, &a6);
+#endif
+  }
+  else {
+    result = rb_scan_args(argc, args, RSTRING_PTR(fmt), &a1, &a2, &a3, &a4, &a5, &a6);
+  }
 
   switch(NUM2INT(expected)) {
   case 6:


### PR DESCRIPTION
Some warnings are because the @o.rb_scan_args call doesn't
include keyword arguments, but the first argument is passed to
rb_scan_args may have a last hash treated as keywords.  Those
should be handled using rb_scan_args_kw on Ruby 2.7.

Other warnings are for the deprecated rb_scan_args behavior to
split option hashes or treat a nil argument as an option hash.
Those warnings should just be suppressed.