### PR TITLE
Make direct calls to rb_{obj_instance,mod_module}_{eval,exec} not pass keyword

### DIFF
--- a/struct.c
+++ b/struct.c
@@ -569,7 +569,7 @@ rb_struct_s_def(int argc, VALUE *argv, VALUE klass)
     setup_struct(st, rest);
     rb_ivar_set(st, id_keyword_init, keyword_init);
     if (rb_block_given_p()) {
-        rb_funcall_passing_block(st, rb_intern("module_eval"), 0, 0);
+        rb_mod_module_eval(0, 0, st);
     }
 
     return st;


### PR DESCRIPTION
In general RB_PASS_CALLED_KEYWORDS should only be set if we are
sure the arguments passed come directly from Ruby.  For direct calls
to these C functions, we should not assume that keywords are passed.
Add static *_internal versions of these functions that
Kernel#instance_{eval,exec} and Module#{class,module}_{eval,exec}
call that set RB_PASS_CALLED_KEYWORDS.

Also, change struct.c back to calling rb_mod_module_eval, now that
the call is safe.