### PR TITLE
Iseq#to_binary: dump flag for **nil

### DIFF
--- a/test/ruby/test_iseq.rb
+++ b/test/ruby/test_iseq.rb
@@ -443,6 +443,17 @@ class TestISeq < Test::Unit::TestCase
     end
   end
 
+  def test_to_binary_dumps_nokey
+    iseq = assert_iseq_to_binary(<<-RUBY)
+      o = Object.new
+      class << o
+        def foo(**nil); end
+      end
+      o
+    RUBY
+    assert_equal([[:nokey]], iseq.eval.singleton_method(:foo).parameters)
+  end
+
   def test_to_binary_line_info
     assert_iseq_to_binary("#{<<~"begin;"}\n#{<<~'end;'}", '[Bug #14660]').eval
     begin;


### PR DESCRIPTION
RUBY_ISEQ_DUMP_DEBUG=to_binary and the attached test case was failing.
Dump the flag to make sure `**nil` can round-trip properly.

---

It seems like RUBY_ISEQ_DUMP_DEBUG=to_binary is failing a lot. I've fixed [two](https://bugs.ruby-lang.org/issues/16098) [other](https://bugs.ruby-lang.org/issues/16088) bugs related to to_binary recently. What do you think about putting it on CI? Rails app all rely on this functionality through Bootsnap so it's probably important.