### PR TITLE
Optimize Gem::Package::TarReader#each

### DIFF
--- a/lib/rubygems/package/tar_reader.rb
+++ b/lib/rubygems/package/tar_reader.rb
@@ -55,6 +55,8 @@ class Gem::Package::TarReader
   def each
     return enum_for __method__ unless block_given?
 
+    use_seek = @io.respond_to?(:seek)
+
     until @io.eof? do
       header = Gem::Package::TarHeader.from @io
       return if header.empty?
@@ -67,16 +69,20 @@ class Gem::Package::TarReader
       skip = (512 - (size % 512)) % 512
       pending = size - entry.bytes_read
 
-      begin
-        # avoid reading...
-        @io.seek pending, IO::SEEK_CUR
-        pending = 0
-      rescue Errno::EINVAL, NameError
-        while pending > 0 do
-          bytes_read = @io.read([pending, 4096].min).size
-          raise UnexpectedEOF if @io.eof?
-          pending -= bytes_read
+      if use_seek
+        begin
+          # avoid reading if the @io supports seeking
+          @io.seek pending, IO::SEEK_CUR
+          pending = 0
+        rescue Errno::EINVAL
         end
+      end
+
+      # if seeking didn't work
+      while pending > 0 do
+        bytes_read = @io.read([pending, 4096].min).size
+        raise UnexpectedEOF if @io.eof?
+        pending -= bytes_read
       end
 
       @io.read skip # discard trailing zeros


### PR DESCRIPTION
The current implementation always try to seek, and then rescue `NameError` (parent of `NoMethodError`) to fallback to seeking using `read`.

The main issue is that it never remembers that the IO don't support seeking, so it uselessly try again on each iteration. If you have 1k entries in a `tar.gz` it will raise `1k` exception with their backtraces etc.

A simple early check using `respond_to?(:seek)` can avoid all that.

I benched this patch against a `165M` linux tar.gz, and saw a `3.6%` improvement. [The benchmark code](https://gist.github.com/casperisfine/53171c14c135bf61979f328926d9ee34).

cc @rafaelfranca @chrisseaton @XrXr 