### PR TITLE
Bug/16173 env.delete block

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -4766,12 +4766,26 @@ env_delete(VALUE name)
 
 /*
  * call-seq:
- *   ENV.delete(name)                  -> value
- *   ENV.delete(name) { |name| block } -> value
+ *   ENV.delete(name)                          -> value
+ *   ENV.delete(name) { |name| block }         -> value
+ *   ENV.delete(missing_name)                  -> nil
+ *   ENV.delete(missing_name) { |name| block } -> nil
  *
- * Deletes the environment variable with +name+ and returns the value of the
- * variable.  If a block is given it will be called when the named environment
- * does not exist.
+ * Deletes the environment variable for +name+ if it exists (ignoring
+ * the block, if given); returns the old value:
+ *   ENV.delete('LINES') # => '300'
+ *   ENV.delete('COLUMNS') { |name| fail 'boo' } # => '120'
+ *
+ * Returns +nil+ if the environment variable does not exist and block
+ * not given:
+ *   ENV.delete('NOSUCH') # => nil
+ *
+ * Calls the block and returns +nil+ if the environment variable does
+ * not exist and block given:
+ *   ENV.delete('NOSUCH') { |name| } # => nil
+ *
+ * Raises TypeError if +name+ is not a +String+:
+ *   ENV.delete(1) # => TypeError raised
  */
 static VALUE
 env_delete_m(VALUE obj, VALUE name)

--- a/hash.c
+++ b/hash.c
@@ -4779,7 +4779,7 @@ env_delete_m(VALUE obj, VALUE name)
     VALUE val;
 
     val = env_delete(name);
-    if (NIL_P(val) && rb_block_given_p()) rb_yield(name);
+    if (NIL_P(val) && rb_block_given_p()) val = rb_yield(name);
     return val;
 }
 

--- a/spec/ruby/core/env/delete_spec.rb
+++ b/spec/ruby/core/env/delete_spec.rb
@@ -16,9 +16,25 @@ describe "ENV.delete" do
     ENV.delete("foo").should == "bar"
   end
 
+  it "ignores the block if the environment variable exists" do
+    ENV["foo"] = "bar"
+    begin
+      -> { ENV.delete("foo") { |name| fail name } }.should_not raise_error(RuntimeError)
+    end
+  end
+
   it "yields the name to the given block if the named environment variable does not exist" do
     ENV.delete("foo")
     ENV.delete("foo") { |name| ScratchPad.record name }
     ScratchPad.recorded.should == "foo"
+  end
+
+  it "returns nil if the named environment variable does not exist and block given" do
+    ENV.delete("foo")
+    ENV.delete("foo") { |name| name }.should == nil
+  end
+
+  it "raises TypeError if name is not a String" do
+    -> { ENV.delete(1) }.should raise_error(TypeError)
   end
 end

--- a/test/ruby/test_env.rb
+++ b/test/ruby/test_env.rb
@@ -107,6 +107,7 @@ class TestEnv < Test::Unit::TestCase
     assert_invalid_env {|v| ENV.delete(v)}
     assert_nil(ENV.delete("TEST"))
     assert_nothing_raised { ENV.delete(PATH_ENV) }
+    assert_equal("NO TEST", ENV.delete("TEST") {|name| "NO "+name})
   end
 
   def test_getenv


### PR DESCRIPTION
`ENV.delete` should return the result of block on non-existing key.
[Bug #16173]