### PR TITLE
rbinstall - Use `Gem::Package` like object instead of monkey patching

### DIFF
--- a/tool/rbinstall.rb
+++ b/tool/rbinstall.rb
@@ -877,7 +877,7 @@ install?(:ext, :comm, :gem, :'bundled-gems') do
     :ignore_dependencies => true,
     :dir_mode => $dir_mode,
     :data_mode => $data_mode,
-    :prog_mode => $prog_mode,
+    :prog_mode => $script_mode,
     :wrappers => true,
     :format_executable => true,
   }

--- a/tool/rbinstall.rb
+++ b/tool/rbinstall.rb
@@ -721,7 +721,7 @@ module RbInstall
     def extract_files(destination_dir, pattern = "*")
       return if @src_dir == destination_dir
       File.chmod(0700, destination_dir)
-      mode = pattern == "bin/*" ? prog_mode : data_mode
+      mode = pattern == File.join(spec.bindir, '*') ? prog_mode : data_mode
       spec.files.each do |f|
         src = File.join(@src_dir, f)
         dest = File.join(without_destdir(destination_dir), f)

--- a/tool/rbinstall.rb
+++ b/tool/rbinstall.rb
@@ -719,12 +719,11 @@ module RbInstall
     end
 
     def extract_files(destination_dir, pattern = "*")
-      path = @src_dir
-      return if path == destination_dir
+      return if @src_dir == destination_dir
       File.chmod(0700, destination_dir)
       mode = pattern == "bin/*" ? prog_mode : data_mode
       spec.files.each do |f|
-        src = File.join(path, f)
+        src = File.join(@src_dir, f)
         dest = File.join(without_destdir(destination_dir), f)
         makedirs(dest[/.*(?=\/)/m])
         install src, dest, :mode => mode

--- a/tool/rbinstall.rb
+++ b/tool/rbinstall.rb
@@ -722,9 +722,10 @@ module RbInstall
       return if @src_dir == destination_dir
       File.chmod(0700, destination_dir)
       mode = pattern == File.join(spec.bindir, '*') ? prog_mode : data_mode
+      destdir = without_destdir(destination_dir)
       spec.files.each do |f|
         src = File.join(@src_dir, f)
-        dest = File.join(without_destdir(destination_dir), f)
+        dest = File.join(destdir, f)
         makedirs(dest[/.*(?=\/)/m])
         install src, dest, :mode => mode
       end

--- a/tool/rbinstall.rb
+++ b/tool/rbinstall.rb
@@ -722,14 +722,14 @@ module RbInstall
       path = @src_dir
       return if path == destination_dir
       File.chmod(0700, destination_dir)
-      mode = pattern == "bin/*" ? $script_mode : $data_mode
+      mode = pattern == "bin/*" ? prog_mode : data_mode
       spec.files.each do |f|
         src = File.join(path, f)
         dest = File.join(without_destdir(destination_dir), f)
         makedirs(dest[/.*(?=\/)/m])
         install src, dest, :mode => mode
       end
-      File.chmod($dir_mode, destination_dir)
+      File.chmod(dir_mode, destination_dir)
     end
   end
 

--- a/tool/rbinstall.rb
+++ b/tool/rbinstall.rb
@@ -706,29 +706,34 @@ module RbInstall
     end
   end
 
-  class UnpackedInstaller < Gem::Installer
-    module DirPackage
-      def extract_files(destination_dir, pattern = "*")
-        path = File.dirname(@gem.path)
-        return if path == destination_dir
-        File.chmod(0700, destination_dir)
-        mode = pattern == "bin/*" ? $script_mode : $data_mode
-        spec.files.each do |f|
-          src = File.join(path, f)
-          dest = File.join(without_destdir(destination_dir), f)
-          makedirs(dest[/.*(?=\/)/m])
-          install src, dest, :mode => mode
-        end
-        File.chmod($dir_mode, destination_dir)
+  class DirPackage
+    attr_reader :spec
+
+    attr_accessor :dir_mode
+    attr_accessor :prog_mode
+    attr_accessor :data_mode
+
+    def initialize(spec)
+      @spec = spec
+      @src_dir = File.dirname(@spec.loaded_from)
+    end
+
+    def extract_files(destination_dir, pattern = "*")
+      path = @src_dir
+      return if path == destination_dir
+      File.chmod(0700, destination_dir)
+      mode = pattern == "bin/*" ? $script_mode : $data_mode
+      spec.files.each do |f|
+        src = File.join(path, f)
+        dest = File.join(without_destdir(destination_dir), f)
+        makedirs(dest[/.*(?=\/)/m])
+        install src, dest, :mode => mode
       end
+      File.chmod($dir_mode, destination_dir)
     end
+  end
 
-    def initialize(spec, *options)
-      package = Gem::Package.new(spec.loaded_from)
-      super(package, *options)
-      @package.extend(DirPackage).spec = spec
-    end
-
+  class UnpackedInstaller < Gem::Installer
     def write_cache_file
     end
 
@@ -887,7 +892,8 @@ install?(:ext, :comm, :gem, :'bundled-gems') do
     if File.directory?(ext = "#{gem_ext_dir}/#{spec.full_name}")
       spec.extensions[0] ||= "-"
     end
-    ins = RbInstall::UnpackedInstaller.new(spec, options)
+    package = RbInstall::DirPackage.new spec
+    ins = RbInstall::UnpackedInstaller.new(package, options)
     puts "#{INDENT}#{spec.name} #{spec.version}"
     ins.install
     File.chmod($data_mode, File.join(install_dir, "specifications", "#{spec.full_name}.gemspec"))


### PR DESCRIPTION
Use `Gem::Package` like object instead of monkey patching.

1. This is similar to what RubyGems does and it is less magic [[1]].
2. It avoids deprecated code paths in RubyGems [[2]].

I'll try to follow up with modifications, that will allow to use more of standard RubyGems infrastructure to install the StdLib gems. My concern are mainly the default gems, which is related to this ticket [[3]].

[1]: https://github.com/rubygems/rubygems/blob/92892bbc3adba86a90756c385433835f6761b8da/lib/rubygems/installer.rb#L151
[2]: https://github.com/rubygems/rubygems/blob/92892bbc3adba86a90756c385433835f6761b8da/lib/rubygems/installer.rb#L187
[3]: https://bugs.ruby-lang.org/issues/14737