### PR TITLE
Resolve unused local variable reported by LGTM

### DIFF
--- a/misc/lldb_cruby.py
+++ b/misc/lldb_cruby.py
@@ -151,7 +151,7 @@ def lldb_inspect(debugger, target, result, val):
                 result.write(" (embed)")
             elif flags & RUBY_FL_USER2:
                 shared = val.GetValueForExpressionPath("->as.heap.aux.shared").GetValueAsUnsigned()
-                result.write(" (shared) shared=%016x")
+                result.write(" (shared) shared=%016x" % shared)
             else:
                 capa = val.GetValueForExpressionPath("->as.heap.aux.capa").GetValueAsSigned()
                 result.write(" (ownership) capa=%d" % capa)


### PR DESCRIPTION
LGTM reports that the value assigned to local variable 'shared' is never used:
https://lgtm.com/projects/g/ruby/ruby/snapshot/f319a5d064627c6641817ec2ed16b97b4d215148/files/misc/lldb_cruby.py#x6512c0281581a470:1

This problem was introduced in by the refactoring that took place in 7c496b6624f720d539e3c0b40f122a9422a13b99.