### PR TITLE
Refactor parser handling of outer scope

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -9123,11 +9123,9 @@ rb_iseq_build_from_ary(rb_iseq_t *iseq, VALUE misc, VALUE locals, VALUE params,
 /* for parser */
 
 int
-rb_dvar_defined(ID id, const struct rb_block *base_block)
+rb_dvar_defined(ID id, const rb_iseq_t *iseq)
 {
-    const rb_iseq_t *iseq;
-
-    if (base_block && (iseq = vm_block_iseq(base_block)) != NULL) {
+    if (iseq) {
 	const struct rb_iseq_constant_body *body = iseq->body;
 	while (body->type == ISEQ_TYPE_BLOCK ||
 	       body->type == ISEQ_TYPE_RESCUE ||
@@ -9150,11 +9148,9 @@ rb_dvar_defined(ID id, const struct rb_block *base_block)
 }
 
 int
-rb_local_defined(ID id, const struct rb_block *base_block)
+rb_local_defined(ID id, const rb_iseq_t *iseq)
 {
-    const rb_iseq_t *iseq;
-
-    if (base_block && (iseq = vm_block_iseq(base_block)) != NULL) {
+    if (iseq) {
 	unsigned int i;
 	const struct rb_iseq_constant_body *const body = iseq->body->local_iseq->body;
 

--- a/internal.h
+++ b/internal.h
@@ -1457,8 +1457,9 @@ VALUE rb_invcmp(VALUE, VALUE);
 
 /* compile.c */
 struct rb_block;
-int rb_dvar_defined(ID, const struct rb_block *);
-int rb_local_defined(ID, const struct rb_block *);
+struct rb_iseq_struct;
+int rb_dvar_defined(ID, const struct rb_iseq_struct *);
+int rb_local_defined(ID, const struct rb_iseq_struct *);
 const char * rb_insns_name(int i);
 VALUE rb_insns_name_array(void);
 int rb_vm_insn_addr2insn(const void *);
@@ -1954,7 +1955,7 @@ struct RBasicRaw {
 VALUE rb_parser_get_yydebug(VALUE);
 VALUE rb_parser_set_yydebug(VALUE, VALUE);
 RUBY_SYMBOL_EXPORT_BEGIN
-VALUE rb_parser_set_context(VALUE, const struct rb_block *, int);
+VALUE rb_parser_set_context(VALUE, const struct rb_iseq_struct *, int);
 RUBY_SYMBOL_EXPORT_END
 void *rb_parser_load_file(VALUE parser, VALUE name);
 int rb_is_const_name(VALUE name);

--- a/iseq.c
+++ b/iseq.c
@@ -994,7 +994,7 @@ rb_iseq_compile_with_option(VALUE src, VALUE file, VALUE realpath, VALUE line, c
     }
     {
 	const VALUE parser = rb_parser_new();
-	rb_parser_set_context(parser, base_block, FALSE);
+	rb_parser_set_context(parser, parent, FALSE);
 	ast = (*parse)(parser, file, src, ln);
     }
 

--- a/parse.y
+++ b/parse.y
@@ -294,7 +294,7 @@ struct parser_params {
     NODE *eval_tree;
     VALUE error_buffer;
     VALUE debug_lines;
-    const struct rb_block *base_block;
+    const rb_iseq_t *parent_iseq;
 
     struct {
 	NODE *outer, *inner, *current;
@@ -329,7 +329,7 @@ static int parser_yyerror(struct parser_params*, const YYLTYPE *yylloc, const ch
 #ifdef RIPPER
 #define compile_for_eval	(0)
 #else
-#define compile_for_eval	(p->base_block != 0)
+#define compile_for_eval	(p->parent_iseq != 0)
 #endif
 
 #define token_column		((int)(p->lex.ptok - p->lex.pbeg))
@@ -11777,7 +11777,7 @@ local_id_ref(struct parser_params *p, ID id, ID **vidrefp)
     }
 
     if (vars && vars->prev == DVARS_INHERIT) {
-	return rb_local_defined(id, p->base_block);
+	return rb_local_defined(id, p->parent_iseq);
     }
     else if (vtable_included(args, id)) {
 	return 1;
@@ -11920,7 +11920,7 @@ dvar_defined_ref(struct parser_params *p, ID id, ID **vidrefp)
     }
 
     if (vars == DVARS_INHERIT) {
-        return rb_dvar_defined(id, p->base_block);
+        return rb_dvar_defined(id, p->parent_iseq);
     }
 
     return 0;
@@ -12301,13 +12301,13 @@ rb_parser_new(void)
 }
 
 VALUE
-rb_parser_set_context(VALUE vparser, const struct rb_block *base, int main)
+rb_parser_set_context(VALUE vparser, const rb_iseq_t *base, int main)
 {
     struct parser_params *p;
 
     TypedData_Get_Struct(vparser, struct parser_params, &parser_data_type, p);
     p->error_buffer = main ? Qfalse : Qnil;
-    p->base_block = base;
+    p->parent_iseq = base;
     return vparser;
 }
 #endif

--- a/parse.y
+++ b/parse.y
@@ -270,7 +270,6 @@ struct parser_params {
     unsigned int debug: 1;
     unsigned int has_shebang: 1;
     unsigned int in_defined: 1;
-    unsigned int in_main: 1;
     unsigned int in_kwarg: 1;
     unsigned int in_def: 1;
     unsigned int in_class: 1;
@@ -330,7 +329,7 @@ static int parser_yyerror(struct parser_params*, const YYLTYPE *yylloc, const ch
 #ifdef RIPPER
 #define compile_for_eval	(0)
 #else
-#define compile_for_eval	(p->base_block != 0 && !p->in_main)
+#define compile_for_eval	(p->base_block != 0)
 #endif
 
 #define token_column		((int)(p->lex.ptok - p->lex.pbeg))
@@ -11649,7 +11648,7 @@ static void
 local_push(struct parser_params *p, int toplevel_scope)
 {
     struct local_vars *local;
-    int inherits_dvars = toplevel_scope && (compile_for_eval || p->in_main /* is p->in_main really needed? */);
+    int inherits_dvars = toplevel_scope && compile_for_eval;
     int warn_unused_vars = RTEST(ruby_verbose);
 
     local = ALLOC(struct local_vars);
@@ -12309,7 +12308,6 @@ rb_parser_set_context(VALUE vparser, const struct rb_block *base, int main)
     TypedData_Get_Struct(vparser, struct parser_params, &parser_data_type, p);
     p->error_buffer = main ? Qfalse : Qnil;
     p->base_block = base;
-    p->in_main = main;
     return vparser;
 }
 #endif

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -1579,7 +1579,7 @@ eval_make_iseq(VALUE src, VALUE fname, int line, const rb_binding_t *bind,
         fname = rb_fstring_lit("(eval)");
     }
 
-    rb_parser_set_context(parser, base_block, FALSE);
+    rb_parser_set_context(parser, parent, FALSE);
     ast = rb_parser_compile_string_path(parser, fname, src, line);
     if (ast->body.root) {
 	iseq = rb_iseq_new_with_opt(&ast->body,


### PR DESCRIPTION
This PR refactors parser_params a bit.

* Removes redundant field `in_main`
* Instead of referring the block of outer scope (in `base_block`), refers the iseq of the block.