### PR TITLE
Remove call-seq for method that doesn't exist

### DIFF
--- a/process.c
+++ b/process.c
@@ -547,7 +547,6 @@ rb_last_status_clear(void)
 /*
  *  call-seq:
  *     stat.to_i     -> integer
- *     stat.to_int   -> integer
  *
  *  Returns the bits in _stat_ as a Integer. Poking
  *  around in these bits is platform dependent.


### PR DESCRIPTION
```
$ ruby -ve 'IO.popen("ls"){}; $?.to_int'
ruby 2.6.4p104 (2019-08-28 revision 67798) [x86_64-darwin18]
Traceback (most recent call last):
-e:1:in `<main>': undefined method `to_int' for #<Process::Status: pid 33989 SIGPIPE (signal 13)> (NoMethodError)
Did you mean?  to_i
               taint
```