### PR TITLE
Don't allocate objects in `gc_compact`

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -8285,7 +8285,7 @@ gc_compact_stats(rb_objspace_t *objspace)
 
 static void gc_compact_after_gc(rb_objspace_t *objspace, int use_toward_empty, int use_double_pages, int use_verifier);
 
-static VALUE
+static void
 gc_compact(rb_objspace_t *objspace, int use_toward_empty, int use_double_pages, int use_verifier)
 {
 
@@ -8297,7 +8297,6 @@ gc_compact(rb_objspace_t *objspace, int use_toward_empty, int use_double_pages, 
         gc_compact_after_gc(objspace, use_toward_empty, use_double_pages, TRUE);
     }
     objspace->flags.during_compacting = FALSE;
-    return gc_compact_stats(objspace);
 }
 
 static VALUE
@@ -8306,7 +8305,8 @@ rb_gc_compact(VALUE mod)
     rb_objspace_t *objspace = &rb_objspace;
     if (dont_gc) return Qnil;
 
-    return gc_compact(objspace, FALSE, FALSE, FALSE);
+    gc_compact(objspace, FALSE, FALSE, FALSE);
+    return gc_compact_stats(objspace);
 }
 
 static void
@@ -8471,7 +8471,8 @@ gc_verify_compaction_references(int argc, VALUE *argv, VALUE mod)
         }
     }
 
-    return gc_compact(objspace, use_toward_empty, use_double_pages, TRUE);
+    gc_compact(objspace, use_toward_empty, use_double_pages, TRUE);
+    return gc_compact_stats(objspace);
 }
 
 VALUE


### PR DESCRIPTION
I'd like to call `gc_compact` after major GC, but before the GC
finishes.  This means we can't allocate any objects inside `gc_compact`.
So in this commit I'm just pulling the compaction statistics allocation
outside the `gc_compact` function so we can safely call it.