### PR TITLE
Env

### DIFF
--- a/spec/ruby/core/env/assoc_spec.rb
+++ b/spec/ruby/core/env/assoc_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../../spec_helper'
+require_relative 'env_spec_helper'
 
 describe "ENV.assoc" do
   before :each do

--- a/spec/ruby/core/env/assoc_spec.rb
+++ b/spec/ruby/core/env/assoc_spec.rb
@@ -1,23 +1,30 @@
 require_relative '../../spec_helper'
 
 describe "ENV.assoc" do
-  after :each do
-    ENV.delete("foo")
+  before :each do
+    reserve_names("foo")
   end
 
-  it "returns an array of the key and value of the environment variable with the given key" do
+  after :each do
+    release_names
+  end
+
+  it "returns an array of the name and value of the environment variable with the given name" do
     ENV["foo"] = "bar"
     ENV.assoc("foo").should == ["foo", "bar"]
   end
 
-  it "returns nil if no environment variable with the given key exists" do
+  it "returns nil if no environment variable with the given name exists" do
     ENV.assoc("foo").should == nil
   end
 
-  it "returns the key element coerced with #to_str" do
+  it "coerces a non-String name by calling :to_str" do
     ENV["foo"] = "bar"
-    k = mock('key')
-    k.should_receive(:to_str).and_return("foo")
-    ENV.assoc(k).should == ["foo", "bar"]
+    mock_object = mock_to_str(:foo)
+    ENV.assoc(mock_object).should == ["foo", "bar"]
+  end
+
+  it "raises TypeError if the argument is not a String and does not respond to :to_str" do
+    -> { ENV.assoc(Object.new) }.should raise_error(TypeError)
   end
 end

--- a/spec/ruby/core/env/env_spec_helper.rb
+++ b/spec/ruby/core/env/env_spec_helper.rb
@@ -1,0 +1,23 @@
+# Reserve names.
+def reserve_names(*names)
+  names.each  do |name|
+    fail "Name #{name} is already in use" if ENV.include?(name)
+  end
+  @reserved_names = names
+end
+
+# Release reserved names.
+def release_names
+  @reserved_names.each do |name|
+    ENV.delete(name)
+  end
+end
+
+# Mock object for calling to_str.
+def mock_to_str(s)
+  mock_object = mock('name')
+  mock_object.should_receive(:to_str).and_return(s.to_s)
+  mock_object
+end
+
+require '../../spec_helper'

--- a/spec/ruby/spec_helper.rb
+++ b/spec/ruby/spec_helper.rb
@@ -3,6 +3,28 @@ root = File.dirname(__FILE__)
 dir = "fixtures/code"
 CODE_LOADING_DIR = use_realpath ? File.realpath(dir, root) : File.expand_path(dir, root)
 
+# Reserve names.
+def reserve_names(*names)
+  names.each  do |name|
+    fail "Name #{name} is already in use" if ENV.include?(name)
+  end
+  @reserved_names = names
+end
+
+# Release reserved names.
+def release_names
+  @reserved_names.each do |name|
+    ENV.delete(name)
+  end
+end
+
+# Mock object for calling to_str.
+def mock_to_str(s)
+  mock_object = mock('name')
+  mock_object.should_receive(:to_str).and_return(s.to_s)
+  mock_object
+end
+
 # Enable Thread.report_on_exception by default to catch thread errors earlier
 if Thread.respond_to? :report_on_exception=
   Thread.report_on_exception = true

--- a/spec/ruby/spec_helper.rb
+++ b/spec/ruby/spec_helper.rb
@@ -3,28 +3,6 @@ root = File.dirname(__FILE__)
 dir = "fixtures/code"
 CODE_LOADING_DIR = use_realpath ? File.realpath(dir, root) : File.expand_path(dir, root)
 
-# Reserve names.
-def reserve_names(*names)
-  names.each  do |name|
-    fail "Name #{name} is already in use" if ENV.include?(name)
-  end
-  @reserved_names = names
-end
-
-# Release reserved names.
-def release_names
-  @reserved_names.each do |name|
-    ENV.delete(name)
-  end
-end
-
-# Mock object for calling to_str.
-def mock_to_str(s)
-  mock_object = mock('name')
-  mock_object.should_receive(:to_str).and_return(s.to_s)
-  mock_object
-end
-
 # Enable Thread.report_on_exception by default to catch thread errors earlier
 if Thread.respond_to? :report_on_exception=
   Thread.report_on_exception = true


### PR DESCRIPTION
The most important thing here is an added test for an invalid name argument to ENV.assoc, which should raise TypeError.

I've also added env_spec_helper.rb, which has:

- Methods :reserve_names and :release_names, to reserve and release names used in the ENV tests.
- Method :mock_to_str, to return a mock object that responds to :to_str.

The updated assoc_spec.rb uses all of these, as will many other spec tests for ENV, as I get to them.

It's known that some of the ENV spec tests do not test a method's return value, and that some do not test error conditions (as above), so more to come. All in good time.