### PR TITLE
Check for invalid hex escapes in URI#query=

### DIFF
--- a/lib/uri/generic.rb
+++ b/lib/uri/generic.rb
@@ -836,6 +836,7 @@ module URI
       v.encode!(Encoding::UTF_8) rescue nil
       v.delete!("\t\r\n")
       v.force_encoding(Encoding::ASCII_8BIT)
+      raise InvalidURIError, "invalid percent escape: #{$1}" if /(%\H\H)/n.match(v)
       v.gsub!(/(?!%\h\h|[!$-&(-;=?-_a-~])./n.freeze){'%%%02X' % $&.ord}
       v.force_encoding(Encoding::US_ASCII)
       @query = v

--- a/test/uri/test_parser.rb
+++ b/test/uri/test_parser.rb
@@ -40,6 +40,11 @@ class URI::TestParser < Test::Unit::TestCase
 		 uri_to_ary(u1))
   end
 
+  def test_parse_query_pct_encoded
+    assert_equal('q=%32!$&-/?.09;=:@AZ_az~', URI.parse('https://www.example.com/search?q=%32!$&-/?.09;=:@AZ_az~').query)
+    assert_raise(URI::InvalidURIError) { URI.parse('https://www.example.com/search?q=%XX') }
+  end
+
   def test_raise_bad_uri_for_integer
     assert_raise(URI::InvalidURIError) do
       URI.parse(1)


### PR DESCRIPTION
Fixes Ruby Bug 11275