### PR TITLE
Support libsocksd socks library for SOCKSSocket

### DIFF
--- a/ext/socket/extconf.rb
+++ b/ext/socket/extconf.rb
@@ -648,7 +648,7 @@ EOS
   if enable_config("socks", ENV["SOCKS_SERVER"])
     if have_library("socks5", "SOCKSinit")
       $defs << "-DSOCKS5" << "-DSOCKS"
-    elsif have_library("socks", "Rconnect")
+    elsif have_library("socks", "Rconnect") || have_library("socksd", "Rconnect")
       $defs << "-DSOCKS"
     end
   end

--- a/ext/socket/extconf.rb
+++ b/ext/socket/extconf.rb
@@ -648,7 +648,7 @@ EOS
   if enable_config("socks", ENV["SOCKS_SERVER"])
     if have_library("socks5", "SOCKSinit")
       $defs << "-DSOCKS5" << "-DSOCKS"
-    elsif have_library("socks", "Rconnect") || have_library("socksd", "Rconnect")
+    elsif have_library("socksd", "Rconnect") || have_library("socks", "Rconnect")
       $defs << "-DSOCKS"
     end
   end


### PR DESCRIPTION
Date's libsocks implementation renamed to libsocksd and is compatible as a socks library for SOCKSSocket.

https://github.com/notpeter/dante/blob/master/debian/changelog#L428

This allows the library to link with -lsocksd.

The work around was to copy libsocksd.so to libsocks.so but this allows the ruby build to find it as is.