### PR TITLE
avoid CVE-2019-11932 -like situations

### DIFF
--- a/dir.c
+++ b/dir.c
@@ -1343,8 +1343,20 @@ sys_enc_warning_in(const char *func, const char *mesg, rb_encoding *enc)
 #define sys_warning(val, enc) \
     ((flags & GLOB_VERBOSE) ? sys_enc_warning_in(RUBY_FUNCTION_NAME_STRING, (val), (enc)) :(void)0)
 
+static inline void *
+glob_alloc_n(size_t x, size_t y)
+{
+    size_t z;
+    if (rb_mul_size_overflow(x, y, SSIZE_MAX, &z)) {
+        rb_memerror();          /* or...? */
+    }
+    else {
+        return malloc(z);
+    }
+}
+
 #define GLOB_ALLOC(type) ((type *)malloc(sizeof(type)))
-#define GLOB_ALLOC_N(type, n) ((type *)malloc(sizeof(type) * (n)))
+#define GLOB_ALLOC_N(type, n) ((type *)glob_alloc_n(sizeof(type), n))
 #define GLOB_REALLOC(ptr, size) realloc((ptr), (size))
 #define GLOB_FREE(ptr) free(ptr)
 #define GLOB_JUMP_TAG(status) (((status) == -1) ? rb_memerror() : rb_jump_tag(status))

--- a/encoding.c
+++ b/encoding.c
@@ -266,7 +266,7 @@ enc_table_expand(int newsize)
 
     if (enc_table.size >= newsize) return newsize;
     newsize = (newsize + 7) / 8 * 8;
-    ent = xrealloc(enc_table.list, sizeof(*enc_table.list) * newsize);
+    ent = REALLOC_N(enc_table.list, struct rb_encoding_entry, newsize);
     memset(ent + enc_table.size, 0, sizeof(*ent)*(newsize - enc_table.size));
     enc_table.list = ent;
     enc_table.size = newsize;

--- a/include/ruby/defines.h
+++ b/include/ruby/defines.h
@@ -221,9 +221,18 @@ RUBY_SYMBOL_EXPORT_BEGIN
 # define RUBY_ATTR_ALLOC_SIZE(params)
 #endif
 
-void *ruby_xmalloc(size_t) RUBY_ATTR_ALLOC_SIZE((1));
-void *ruby_xmalloc2(size_t,size_t) RUBY_ATTR_ALLOC_SIZE((1,2));
-void *ruby_xcalloc(size_t,size_t) RUBY_ATTR_ALLOC_SIZE((1,2));
+#ifdef __has_attribute
+# if __has_attribute(malloc)
+#  define RUBY_ATTR_MALLOC __attribute__((__malloc__))
+# endif
+#endif
+#ifndef RUBY_ATTR_MALLOC
+# define RUBY_ATTR_MALLOC
+#endif
+
+void *ruby_xmalloc(size_t) RUBY_ATTR_MALLOC RUBY_ATTR_ALLOC_SIZE((1));
+void *ruby_xmalloc2(size_t,size_t) RUBY_ATTR_MALLOC RUBY_ATTR_ALLOC_SIZE((1,2));
+void *ruby_xcalloc(size_t,size_t) RUBY_ATTR_MALLOC RUBY_ATTR_ALLOC_SIZE((1,2));
 void *ruby_xrealloc(void*,size_t) RUBY_ATTR_ALLOC_SIZE((2));
 void *ruby_xrealloc2(void*,size_t,size_t) RUBY_ATTR_ALLOC_SIZE((2,3));
 void ruby_xfree(void*);

--- a/internal.h
+++ b/internal.h
@@ -1627,7 +1627,7 @@ void *ruby_sized_xrealloc(void *ptr, size_t new_size, size_t old_size) RUBY_ATTR
 void *ruby_sized_xrealloc2(void *ptr, size_t new_count, size_t element_size, size_t old_count) RUBY_ATTR_ALLOC_SIZE((2, 3));
 void ruby_sized_xfree(void *x, size_t size);
 RUBY_SYMBOL_EXPORT_END
-#define SIZED_REALLOC_N(var,type,n,old_n) ((var)=(type*)ruby_sized_xrealloc((char*)(var), (n) * sizeof(type), (old_n) * sizeof(type)))
+#define SIZED_REALLOC_N(var,type,n,old_n) ((var)=(type*)ruby_sized_xrealloc2((void*)(var), (n), sizeof(type), (old_n)))
 #endif
 
 /* optimized version of NEWOBJ() */
@@ -1646,6 +1646,13 @@ __attribute__((__alloc_align__(1)))
 #endif
 void *rb_aligned_malloc(size_t, size_t) RUBY_ATTR_MALLOC RUBY_ATTR_ALLOC_SIZE((2));
 void rb_aligned_free(void *);
+
+size_t rb_size_mul_or_raise(size_t, size_t, VALUE); /* used in compile.c */
+size_t rb_size_mul_add_or_raise(size_t, size_t, size_t, VALUE); /* used in iseq.h */
+void *rb_xmalloc_mul_add(size_t, size_t, size_t) RUBY_ATTR_MALLOC;
+void *rb_xrealloc_mul_add(const void *, size_t, size_t, size_t);
+void *rb_xmalloc_mul_add_mul(size_t, size_t, size_t, size_t) RUBY_ATTR_MALLOC;
+void *rb_xcalloc_mul_add_mul(size_t, size_t, size_t, size_t) RUBY_ATTR_MALLOC;
 
 /* hash.c */
 #if RHASH_CONVERT_TABLE_DEBUG

--- a/internal.h
+++ b/internal.h
@@ -1618,7 +1618,7 @@ void rb_copy_wb_protected_attribute(VALUE dest, VALUE obj);
 
 #if defined(HAVE_MALLOC_USABLE_SIZE) || defined(HAVE_MALLOC_SIZE) || defined(_WIN32)
 #define ruby_sized_xrealloc(ptr, new_size, old_size) ruby_xrealloc(ptr, new_size)
-#define ruby_sized_xrealloc2(ptr, new_count, element_size, old_count) ruby_xrealloc(ptr, new_count, element_size)
+#define ruby_sized_xrealloc2(ptr, new_count, element_size, old_count) ruby_xrealloc2(ptr, new_count, element_size)
 #define ruby_sized_xfree(ptr, size) ruby_xfree(ptr)
 #define SIZED_REALLOC_N(var,type,n,old_n) REALLOC_N(var, type, n)
 #else

--- a/internal.h
+++ b/internal.h
@@ -1639,7 +1639,12 @@ RUBY_SYMBOL_EXPORT_END
 			rb_wb_unprotected_newobj_of(klass, flags))
 #define NEWOBJ_OF(obj,type,klass,flags) RB_NEWOBJ_OF(obj,type,klass,flags)
 
-void *rb_aligned_malloc(size_t, size_t);
+#ifdef __has_attribute
+#if __has_attribute(alloc_align)
+__attribute__((__alloc_align__(1)))
+#endif
+#endif
+void *rb_aligned_malloc(size_t, size_t) RUBY_ATTR_MALLOC RUBY_ATTR_ALLOC_SIZE((2));
 void rb_aligned_free(void *);
 
 /* hash.c */

--- a/iseq.c
+++ b/iseq.c
@@ -3391,7 +3391,10 @@ succ_index_table_create(int max_pos, int *data, int size)
 {
     const int imm_size = (max_pos < IMMEDIATE_TABLE_SIZE ? max_pos + 8 : IMMEDIATE_TABLE_SIZE) / 9;
     const int succ_size = (max_pos < IMMEDIATE_TABLE_SIZE ? 0 : (max_pos - IMMEDIATE_TABLE_SIZE + 511)) / 512;
-    struct succ_index_table *sd = ruby_xcalloc(imm_size * sizeof(uint64_t) + succ_size * sizeof(struct succ_dict_block), 1); /* zero cleared */
+    struct succ_index_table *sd =
+        rb_xcalloc_mul_add_mul(
+            imm_size, sizeof(uint64_t),
+            succ_size, sizeof(struct succ_dict_block));
     int i, j, k, r;
 
     r = 0;
@@ -3426,7 +3429,7 @@ succ_index_table_invert(int max_pos, struct succ_index_table *sd, int size)
 {
     const int imm_size = (max_pos < IMMEDIATE_TABLE_SIZE ? max_pos + 8 : IMMEDIATE_TABLE_SIZE) / 9;
     const int succ_size = (max_pos < IMMEDIATE_TABLE_SIZE ? 0 : (max_pos - IMMEDIATE_TABLE_SIZE + 511)) / 512;
-    unsigned int *positions = ruby_xmalloc(sizeof(unsigned int) * size), *p;
+    unsigned int *positions = ALLOC_N(unsigned int, size), *p;
     int i, j, k, r = -1;
     p = positions;
     for (j = 0; j < imm_size; j++) {

--- a/iseq.h
+++ b/iseq.h
@@ -26,7 +26,9 @@ extern const ID rb_iseq_shared_exc_local_tbl[];
 static inline size_t
 rb_call_info_kw_arg_bytes(int keyword_len)
 {
-    return sizeof(struct rb_call_info_kw_arg) + sizeof(VALUE) * (keyword_len - 1);
+    return rb_size_mul_add_or_raise(
+        keyword_len - 1, sizeof(VALUE), sizeof(struct rb_call_info_kw_arg),
+        rb_eRuntimeError);
 }
 
 #define ISEQ_COVERAGE(iseq)           iseq->body->variable.coverage
@@ -67,7 +69,7 @@ static inline VALUE *
 ISEQ_ORIGINAL_ISEQ_ALLOC(const rb_iseq_t *iseq, long size)
 {
     return iseq->body->variable.original_iseq =
-        ruby_xmalloc2(size, sizeof(VALUE));
+        ALLOC_N(VALUE, size);
 }
 
 #define ISEQ_TRACE_EVENTS (RUBY_EVENT_LINE  | \

--- a/string.c
+++ b/string.c
@@ -2175,7 +2175,7 @@ rb_str_modify_expand(VALUE str, long expand)
     if (expand < 0) {
 	rb_raise(rb_eArgError, "negative expanding string size");
     }
-    if (expand > LONG_MAX - len) {
+    if (expand >= LONG_MAX - len) {
 	rb_raise(rb_eArgError, "string size too big");
     }
 

--- a/thread.c
+++ b/thread.c
@@ -3867,7 +3867,9 @@ rb_fd_set(int fd, rb_fdset_t *set)
     }
     if (set->fdset->fd_count >= (unsigned)set->capa) {
 	set->capa = (set->fdset->fd_count / FD_SETSIZE + 1) * FD_SETSIZE;
-	set->fdset = xrealloc(set->fdset, sizeof(unsigned int) + sizeof(SOCKET) * set->capa);
+        set->fdset =
+            rb_xrealloc_mul_add(
+                set->fdset, set->capa, sizeof(SOCKET), sizeof(unsigned int));
     }
     set->fdset->fd_array[set->fdset->fd_count++] = s;
 }

--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -526,7 +526,7 @@ bt_init(void *ptr, size_t size)
     struct bt_iter_arg *arg = (struct bt_iter_arg *)ptr;
     arg->btobj = backtrace_alloc(rb_cBacktrace);
     GetCoreDataFromValue(arg->btobj, rb_backtrace_t, arg->bt);
-    arg->bt->backtrace_base = arg->bt->backtrace = ruby_xmalloc(sizeof(rb_backtrace_location_t) * size);
+    arg->bt->backtrace_base = arg->bt->backtrace = ALLOC_N(rb_backtrace_location_t, size);
     arg->bt->backtrace_size = 0;
 }
 


### PR DESCRIPTION
On current master `ruby_xrealloc()` sometimes raises NoMemoryError, and sometimes returns `NULL`.  This is very much confusing.  Let's not return `NULL`.