### PR TITLE
Fix modules that are use prepend and are refined

### DIFF
--- a/class.c
+++ b/class.c
@@ -896,12 +896,18 @@ add_refined_method_entry_i(ID key, VALUE value, void *data)
     return ID_TABLE_CONTINUE;
 }
 
+static void ensure_origin(VALUE klass);
+
 static int
 include_modules_at(const VALUE klass, VALUE c, VALUE module, int search_super)
 {
     VALUE p, iclass;
     int method_changed = 0, constant_changed = 0;
     struct rb_id_table *const klass_m_tbl = RCLASS_M_TBL(RCLASS_ORIGIN(klass));
+
+    if (FL_TEST(module, RCLASS_REFINED_BY_ANY)) {
+        ensure_origin(module);
+    }
 
     while (module) {
 	int superclass_seen = FALSE;
@@ -984,15 +990,10 @@ move_refined_method(ID key, VALUE value, void *data)
     }
 }
 
-void
-rb_prepend_module(VALUE klass, VALUE module)
+static void
+ensure_origin(VALUE klass)
 {
-    VALUE origin;
-    int changed = 0;
-
-    ensure_includable(klass, module);
-
-    origin = RCLASS_ORIGIN(klass);
+    VALUE origin = RCLASS_ORIGIN(klass);
     if (origin == klass) {
 	origin = class_alloc(T_ICLASS, klass);
 	OBJ_WB_UNPROTECT(origin); /* TODO: conservative shading. Need more survey. */
@@ -1003,6 +1004,16 @@ rb_prepend_module(VALUE klass, VALUE module)
 	RCLASS_M_TBL_INIT(klass);
 	rb_id_table_foreach(RCLASS_M_TBL(origin), move_refined_method, (void *)klass);
     }
+}
+
+void
+rb_prepend_module(VALUE klass, VALUE module)
+{
+    VALUE origin;
+    int changed = 0;
+
+    ensure_includable(klass, module);
+    ensure_origin(klass);
     changed = include_modules_at(klass, klass, module, FALSE);
     if (changed < 0)
 	rb_raise(rb_eArgError, "cyclic prepend detected");

--- a/class.c
+++ b/class.c
@@ -828,9 +828,19 @@ VALUE
 rb_include_class_new(VALUE module, VALUE super)
 {
     VALUE klass = class_alloc(T_ICLASS, rb_cClass);
+    RCLASS_SET_ORIGIN(klass, klass);
+
+    RCLASS_M_TBL(OBJ_WB_UNPROTECT(klass)) =
+      RCLASS_M_TBL(OBJ_WB_UNPROTECT(module)); /* TODO: unprotected? */
 
     if (BUILTIN_TYPE(module) == T_ICLASS) {
+        if (module != RCLASS_ORIGIN(module)) {
+            RCLASS_SET_ORIGIN(klass, RCLASS_ORIGIN(module));
+        }
 	module = RBASIC(module)->klass;
+    }
+    else if (module != RCLASS_ORIGIN(module)) {
+        RCLASS_SET_ORIGIN(klass, RCLASS_ORIGIN(module));
     }
     if (!RCLASS_IV_TBL(module)) {
 	RCLASS_IV_TBL(module) = st_init_numtable();
@@ -840,9 +850,6 @@ rb_include_class_new(VALUE module, VALUE super)
     }
     RCLASS_IV_TBL(klass) = RCLASS_IV_TBL(module);
     RCLASS_CONST_TBL(klass) = RCLASS_CONST_TBL(module);
-
-    RCLASS_M_TBL(OBJ_WB_UNPROTECT(klass)) =
-      RCLASS_M_TBL(OBJ_WB_UNPROTECT(RCLASS_ORIGIN(module))); /* TODO: unprotected? */
 
     RCLASS_SET_SUPER(klass, super);
     if (RB_TYPE_P(module, T_ICLASS)) {
@@ -900,8 +907,6 @@ include_modules_at(const VALUE klass, VALUE c, VALUE module, int search_super)
 	int superclass_seen = FALSE;
 	struct rb_id_table *tbl;
 
-	if (RCLASS_ORIGIN(module) != module)
-	    goto skip;
 	if (klass_m_tbl && klass_m_tbl == RCLASS_M_TBL(module))
 	    return -1;
 	/* ignore if the module included already in superclasses */
@@ -1097,10 +1102,11 @@ rb_mod_ancestors(VALUE mod)
     VALUE p, ary = rb_ary_new();
 
     for (p = mod; p; p = RCLASS_SUPER(p)) {
+        if (p != RCLASS_ORIGIN(p)) continue;
 	if (BUILTIN_TYPE(p) == T_ICLASS) {
 	    rb_ary_push(ary, RBASIC(p)->klass);
 	}
-	else if (p == RCLASS_ORIGIN(p)) {
+        else {
 	    rb_ary_push(ary, p);
 	}
     }

--- a/eval.c
+++ b/eval.c
@@ -1537,6 +1537,9 @@ rb_mod_refine(VALUE module, VALUE klass)
     }
 
     ensure_class_or_module(klass);
+    if (RB_TYPE_P(klass, T_MODULE)) {
+        FL_SET(klass, RCLASS_REFINED_BY_ANY);
+    }
     CONST_ID(id_refinements, "__refinements__");
     refinements = rb_attr_get(module, id_refinements);
     if (NIL_P(refinements)) {

--- a/internal.h
+++ b/internal.h
@@ -1059,6 +1059,7 @@ int rb_singleton_class_internal_p(VALUE sklass);
 
 #define RCLASS_CLONED     FL_USER6
 #define RICLASS_IS_ORIGIN FL_USER5
+#define RCLASS_REFINED_BY_ANY FL_USER7
 
 static inline void
 RCLASS_SET_ORIGIN(VALUE klass, VALUE origin)

--- a/test/ruby/test_refinement.rb
+++ b/test/ruby/test_refinement.rb
@@ -2351,6 +2351,38 @@ class TestRefinement < Test::Unit::TestCase
     assert_equal("refine_method", Bug16242::X.new.hoge)
   end
 
+  module Bug13446
+    module Enumerable
+      def sum(*args)
+        i = 0
+        args.each { |arg| i += a }
+        i
+      end
+    end
+
+    using Module.new {
+      refine Enumerable do
+        alias :orig_sum :sum
+      end
+    }
+
+    module Enumerable
+      def sum(*args)
+        orig_sum(*args)
+      end
+    end
+
+    class GenericEnumerable
+      include Enumerable
+    end
+
+    Enumerable.prepend(Module.new)
+  end
+
+  def test_prepend_refined_module
+    assert_equal(0, Bug13446::GenericEnumerable.new.sum)
+  end
+
   private
 
   def eval_using(mod, s)

--- a/test/ruby/test_refinement.rb
+++ b/test/ruby/test_refinement.rb
@@ -2323,6 +2323,34 @@ class TestRefinement < Test::Unit::TestCase
     assert_equal(:ok, RefineInUsing.test)
   end
 
+  class Bug16242
+    module OtherM
+    end
+
+    module M
+      prepend OtherM
+
+      refine M do
+        def refine_method
+          "refine_method"
+        end
+      end
+      using M
+
+      def hoge
+        refine_method
+      end
+    end
+
+    class X
+      include M
+    end
+  end
+
+  def test_refine_prepended_module
+    assert_equal("refine_method", Bug16242::X.new.hoge)
+  end
+
   private
 
   def eval_using(mod, s)


### PR DESCRIPTION
Honor refinements for modules that prepend other modules

This previously did not work, and the reason it did not work is
that:

1) Refining a module or class that prepends other modules places
   the refinements in the class itself and not the origin iclass.

2) Inclusion of a module that prepends other modules skips the
   module itself, including only iclasses for the prepended modules
   and the origin iclass.

Those two behaviors combined meant that the method table for the
refined methods for the included module never ends up in the
method lookup chain for the class including the module.

Fix this by not skipping the module itself when the module is
included.  This requires some code rearranging in
rb_include_class_new to make sure the correct method tables and
origin settings are used for the created iclass.

As origin iclasses shouldn't be exposed to Ruby, this also
requires skipping modules that have origin iclasses in
Module#ancestors (classes that have origin iclasses were already
skipped).

Make prepending a refined module after inclusion not break refinements

After the previous commit, this was still broken. The reason it
was broken is that a refined module that hasn't been prepended to
yet keeps the refined methods in the module's method table. When
prepending, the module's method table is moved to the origin
iclass, and then the refined methods are moved from the method
table to a new method table in the module itself.

Unfortunately, that means that if a class has included the module,
prepending breaks the refinements, because when the methods are
moved from the origin iclass method table to the module method
table, they are removed from the method table from the iclass
created when the module was included earlier.

Fix this by always creating an origin class when including a
module that has any refinements, even if the refinements are
not currently used.  I wasn't sure the best way to do that.
The approach I choose was to use an object flag. The flag is
set on the module when Module#refine is called, and if the
flag is present when the module is included in another module
or class, an origin iclass is created for the module.

Fixes Ruby bugs 16242 and 13446.