### PR TITLE
More DRb Fixes

### DIFF
--- a/lib/drb/drb.rb
+++ b/lib/drb/drb.rb
@@ -1024,6 +1024,8 @@ module DRb
 
     def set_sockopt(soc) # :nodoc:
       soc.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1)
+    rescue IOError, Errno::ECONNRESET, Errno::EINVAL
+      # closed/shutdown socket, ignore error
     end
   end
 

--- a/lib/drb/drb.rb
+++ b/lib/drb/drb.rb
@@ -1606,15 +1606,9 @@ module DRb
     # Coerce an object to a string, providing our own representation if
     # to_s is not defined for the object.
     def any_to_s(obj)
-      obj.to_s + ":#{obj.class}"
+      "#{obj}:#{obj.class}"
     rescue
-      case obj
-      when Object
-        klass = obj.class
-      else
-        klass = Kernel.instance_method(:class).bind(obj).call
-      end
-      sprintf("#<%s:0x%dx>", klass, obj.__id__)
+      Kernel.instance_method(:to_s).bind_call(obj)
     end
 
     # Check that a method is callable via dRuby.

--- a/lib/drb/drb.rb
+++ b/lib/drb/drb.rb
@@ -1701,7 +1701,9 @@ module DRb
           end
         end
         return @succ, @result
-      rescue StandardError, ScriptError, Interrupt
+      rescue NoMemoryError, SystemExit, SystemStackError, SecurityError
+        raise
+      rescue Exception
         @result = $!
         return @succ, @result
       end

--- a/test/drb/test_drb.rb
+++ b/test/drb/test_drb.rb
@@ -327,4 +327,19 @@ class TestBug4409 < Test::Unit::TestCase
   end
 end
 
+class TestDRbTCP < Test::Unit::TestCase
+  def test_immediate_close
+    server = DRb::DRbServer.new('druby://:0')
+    host, port, = DRb::DRbTCPSocket.send(:parse_uri, server.uri)
+    socket = TCPSocket.open host, port
+    socket.shutdown
+    socket.close
+    client = DRb::DRbTCPSocket.new(server.uri, socket)
+    assert client
+    client.close
+    server.stop_service
+    server.thread.join
+  end
+end
+
 end

--- a/test/drb/test_drb.rb
+++ b/test/drb/test_drb.rb
@@ -327,6 +327,20 @@ class TestBug4409 < Test::Unit::TestCase
   end
 end
 
+class TestDRbAnyToS < Test::Unit::TestCase
+  class BO < BasicObject
+  end
+
+  def test_any_to_s
+    server = DRb::DRbServer.new('druby://:0')
+    server.singleton_class.send(:public, :any_to_s)
+    assert_equal("foo:String", server.any_to_s("foo"))
+    assert_match(/\A#<DRbTests::TestDRbAnyToS::BO:0x[0-9a-f]+>\z/, server.any_to_s(BO.new))
+    server.stop_service
+    server.thread.join
+  end
+end
+
 class TestDRbTCP < Test::Unit::TestCase
   def test_immediate_close
     server = DRb::DRbServer.new('druby://:0')


### PR DESCRIPTION
Fixes Ruby bugs 5618 and 8039, and also includes better handling of `BasicObject`s in `DRbServer#any_to_s`.