### PR TITLE
Add arm64 case on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,7 @@ env:
       - |-
         ${BEFORE_INSTALL}
         tool/travis_retry.sh sudo -E apt-get $travis_apt_get_options install \
+          ccache \
           gcc-8 \
           g++-8 \
           libffi-dev \
@@ -123,6 +124,13 @@ env:
     <<: *gcc-8
     env:
       - TEST_MJIT_SYMBOLS=1 # detect exports missing for MJIT
+
+  - &arm64-linux
+    name: arm64-linux
+    arch: arm64
+    <<: *gcc-8
+    env:
+      - TEST_MJIT_SYMBOLS=1
 
   - &jemalloc
     name: --with-jemalloc
@@ -366,6 +374,7 @@ matrix:
   include:
     # Build every commit:
     - <<: *x86_64-linux
+    - <<: *arm64-linux
     - <<: *i686-linux
     - <<: *pedanticism
     - <<: *assertions
@@ -386,6 +395,7 @@ matrix:
     - <<: *CALL_THREADED_CODE
     - <<: *NO_THREADED_CODE
   allow_failures:
+    - name: arm64-linux
     - name: -fsanitize=address
     - name: -fsanitize=memory
     - name: -fsanitize=undefined


### PR DESCRIPTION
This PR is pointed out from https://bugs.ruby-lang.org/issues/16234

I added arch64 (arm64) case with `arch: arm64` syntax as `allow_failures`.
Because the 1 test was failed on my forked repository's test like this.

https://travis-ci.org/junaruga/ruby/jobs/598309782#L2635

```
1)
Process.spawn joins the specified process group if pgroup: pgid FAILED
Expected (STDOUT): "0"
          but got: "34127"
Backtrace
/home/travis/build/junaruga/ruby/spec/ruby/core/process/spawn_spec.rb:334:in `block (3 levels) in <top (required)>'
/home/travis/build/junaruga/ruby/spec/ruby/core/process/spawn_spec.rb:32:in `<top (required)>'
Finished in 139.480640 seconds
3775 files, 30931 examples, 126138 expectations, 1 failure, 0 errors, 0 tagged
```

`ccache` deb package needed to be installed on `arch: arm64` environment.