### PR TITLE
lib/optparse.rb: Show a did_you_mean hint for unknown option

### DIFF
--- a/test/optparse/test_did_you_mean.rb
+++ b/test/optparse/test_did_you_mean.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: false
+require_relative 'test_optparse'
+require "did_you_mean" rescue return
+
+class TestOptionParser::DidYouMean < TestOptionParser
+  def setup
+    super
+    @opt.def_option("--foo", Integer) { |v| @foo = v }
+    @opt.def_option("--bar", Integer) { |v| @bar = v }
+    @opt.def_option("--baz", Integer) { |v| @baz = v }
+  end
+
+  def test_did_you_mean
+    assert_raise(OptionParser::InvalidOption) do
+      begin
+        @opt.permute!(%w"--baa")
+      ensure
+        assert_equal("invalid option: --baa\nDid you mean?  baz\n               bar", $!.message)
+      end
+    end
+  end
+end


### PR DESCRIPTION
```
require 'optparse'

OptionParser.new do |opts|
  opts.on("-f", "--foo", "foo") {|v| }
  opts.on("-b", "--bar", "bar") {|v| }
  opts.on("-c", "--baz", "baz") {|v| }
end.parse!
```

```
$ ruby test.rb --baa
Traceback (most recent call last):
test.rb:7:in `<main>': invalid option: --baa (OptionParser::InvalidOption)
Did you mean?  baz
               bar
```