### PR TITLE
Warn for calling public/protected/private/module_function without arguments inside method

### DIFF
--- a/test/ruby/test_class.rb
+++ b/test/ruby/test_class.rb
@@ -131,6 +131,48 @@ class TestClass < Test::Unit::TestCase
       [:module_function, :extend_object, :append_features, :prepend_features])
   end
 
+  def test_visibility_inside_method
+    assert_warn(/calling private without arguments inside a method may not have the intended effect/, '[ruby-core:79751]') do
+      Class.new do
+        def self.foo
+          private
+        end
+        foo
+      end
+    end
+
+    assert_warn(/calling protected without arguments inside a method may not have the intended effect/, '[ruby-core:79751]') do
+      Class.new do
+        def self.foo
+          protected
+        end
+        foo
+      end
+    end
+
+    assert_warn(/calling public without arguments inside a method may not have the intended effect/, '[ruby-core:79751]') do
+      Class.new do
+        def self.foo
+          public
+        end
+        foo
+      end
+    end
+
+    assert_warn(/calling private without arguments inside a method may not have the intended effect/, '[ruby-core:79751]') do
+      Class.new do
+        class << self
+          alias priv private
+        end
+
+        def self.foo
+          priv
+        end
+        foo
+      end
+    end
+  end
+
   def test_method_redefinition
     feature2155 = '[ruby-dev:39400]'
 

--- a/test/ruby/test_module.rb
+++ b/test/ruby/test_module.rb
@@ -1394,6 +1394,17 @@ class TestModule < Test::Unit::TestCase
     assert_match(/: warning: previous definition of foo/, stderr)
   end
 
+  def test_module_function_inside_method
+    assert_warn(/calling module_function without arguments inside a method may not have the intended effect/, '[ruby-core:79751]') do
+      Module.new do
+        def self.foo
+          module_function
+        end
+        foo
+      end
+    end
+  end
+
   def test_protected_singleton_method
     klass = Class.new
     x = klass.new


### PR DESCRIPTION
Calling these methods without an argument does not have the desired effect inside a method.

Fixes Ruby Bug 13249