### PR TITLE
Fixed File.extname at a name ending with a dot

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -191,6 +191,14 @@ Fiber::
     * Added Fiber#raise that behaves like Fiber#resume but raises an
       exception on the resumed fiber.  [Feature #10344]
 
+File::
+  Modified method::
+
+    * File.extname now returns a dot string at a name ending with a
+      dot.  [Bug #15267]
+
+          File.extname("foo.") #=> "."
+
 FrozenError::
 
   New method::

--- a/file.c
+++ b/file.c
@@ -4792,7 +4792,7 @@ ruby_enc_find_extname(const char *name, long *len, rb_encoding *enc)
  *     File.extname("test.rb")         #=> ".rb"
  *     File.extname("a/b/d/test.rb")   #=> ".rb"
  *     File.extname(".a/b/d/test.rb")  #=> ".rb"
- *     File.extname("foo.")            #=> ""
+ *     File.extname("foo.")            #=> "."
  *     File.extname("test")            #=> ""
  *     File.extname(".profile")        #=> ""
  *     File.extname(".profile.sh")     #=> ".sh"
@@ -4810,7 +4810,7 @@ rb_file_s_extname(VALUE klass, VALUE fname)
     name = StringValueCStr(fname);
     len = RSTRING_LEN(fname);
     e = ruby_enc_find_extname(name, &len, rb_enc_get(fname));
-    if (len <= 1)
+    if (len < 1)
 	return rb_str_new(0, 0);
     extname = rb_str_subseq(fname, e - name, len); /* keep the dot, too! */
     OBJ_INFECT(extname, fname);

--- a/spec/ruby/core/file/extname_spec.rb
+++ b/spec/ruby/core/file/extname_spec.rb
@@ -20,8 +20,14 @@ describe "File.extname" do
     File.extname("..").should ==  ""
     File.extname("...").should ==  ""
     File.extname("....").should ==  ""
-    File.extname(".foo.").should ==  ""
-    File.extname("foo.").should ==  ""
+    guard -> { platform_is :windows or ruby_version_is ""..."2.7" } do
+      File.extname(".foo.").should == ""
+      File.extname("foo.").should == ""
+    end
+    guard -> { platform_is_not :windows and ruby_version_is "2.7" } do
+      File.extname(".foo.").should == "."
+      File.extname("foo.").should == "."
+    end
   end
 
   it "returns only the last extension of a file with several dots" do

--- a/test/ruby/test_file_exhaustive.rb
+++ b/test/ruby/test_file_exhaustive.rb
@@ -1308,21 +1308,23 @@ class TestFileExhaustive < Test::Unit::TestCase
     assert_equal(".test", File.extname(regular_file))
     assert_equal(".test", File.extname(utf8_file))
     prefixes = ["", "/", ".", "/.", "bar/.", "/bar/."]
-    infixes = ["", " ", "."]
+    infixes = ["", " "]
     infixes2 = infixes + [".ext "]
     appendixes = [""]
     if NTFS
       appendixes << " " << "." << "::$DATA" << "::$DATA.bar"
+    else
+      appendixes << [".", "."]
     end
     prefixes.each do |prefix|
-      appendixes.each do |appendix|
+      appendixes.each do |appendix, ext = ""|
         infixes.each do |infix|
           path = "#{prefix}foo#{infix}#{appendix}"
-          assert_equal("", File.extname(path), "File.extname(#{path.inspect})")
+          assert_equal(ext, File.extname(path), "File.extname(#{path.inspect})")
         end
         infixes2.each do |infix|
           path = "#{prefix}foo#{infix}.ext#{appendix}"
-          assert_equal(".ext", File.extname(path), "File.extname(#{path.inspect})")
+          assert_equal(ext.empty? ? ".ext" : appendix, File.extname(path), "File.extname(#{path.inspect})")
         end
       end
     end

--- a/test/ruby/test_path.rb
+++ b/test/ruby/test_path.rb
@@ -236,10 +236,14 @@ class TestPath < Test::Unit::TestCase
     assert_equal(ext, File.extname('.a/b/d/test.rb'))
     unless /mswin|bccwin|mingw/ =~ RUBY_PLATFORM
       # trailing spaces and dots are ignored on NTFS.
-      ext = ''
+      ext = '.'
     end
     assert_equal(ext, File.extname('a.rb.'))
-    assert_equal('', File.extname('a.'))
+    if /mswin|bccwin|mingw/ =~ RUBY_PLATFORM
+      # trailing spaces and dots are ignored on NTFS.
+      ext = ''
+    end
+    assert_equal(ext, File.extname('a.'))
     assert_equal('', File.extname('.x'))
     assert_equal('', File.extname('..x'))
   end


### PR DESCRIPTION
File.extname now returns a dot string at a name ending with a dot.
bugs-15267