### PR TITLE
Fix warning of generated parser for nested module

### DIFF
--- a/lib/racc/parserfilegenerator.rb
+++ b/lib/racc/parserfilegenerator.rb
@@ -157,8 +157,8 @@ module Racc
       cref_pop
       indent; line "end   \# class #{classid}"
       mods.reverse_each do |mod|
-        indent; line "end   \# module #{mod}"
         cref_pop
+        indent; line "end   \# module #{mod}"
       end
     end
 


### PR DESCRIPTION
ruby-signature use this style.

> ```
> class Ruby::Signature::Parser
> ```
> https://github.com/ruby/ruby-signature/blob/e92f6b0e57d3bafbdcfc1c3d4babe8685d60582f/lib/ruby/signature/parser.y#L1

## Before this pull request

```
% cat foobar.y
class Foo::Bar

rule
  foobar:
% racc -o foobar.rb foobar.y
% cat foobar.rb | tail -2
  end   # class Bar
  end   # module Foo
% ruby -vw foobar.rb
ruby 2.7.0dev (2019-10-17T15:46:02Z master fdfb5100b9) [x86_64-linux]
foobar.rb:87: warning: mismatched indentations at 'end' with 'module' at 8
```

## After this pull request

```
% cat foobar.y
class Foo::Bar

rule
  foobar:
% racc -o foobar.rb foobar.y
% cat foobar.rb | tail -2
  end   # class Bar
end   # module Foo
% ruby -vw foobar.rb
ruby 2.7.0dev (2019-10-17T16:35:58Z fix_racc_warning bb7e46ef61) [x86_64-linux]
last_commit=Fix warning of racc generated parser for nested module
```
