### PR TITLE
test/runner.rb - allow to load gems from install or build

### DIFF
--- a/test/runner.rb
+++ b/test/runner.rb
@@ -1,11 +1,22 @@
 # frozen_string_literal: true
 
+require 'rbconfig'
+
 # Should be done in rubygems test files?
 ENV["GEM_SKIP"] = ENV["GEM_HOME"] = ENV["GEM_PATH"] = "".freeze
 
-# Get bundled gems on load path
-Dir.glob("#{__dir__}/../gems/*/*.gemspec")
-  .reject {|f| f =~ /minitest|test-unit|power_assert/ }
-  .map {|f| $LOAD_PATH.unshift File.join(File.dirname(f), "lib") }
+# Get bundled gems on load path, try install dir first
+gem_dir = "#{RbConfig::CONFIG['rubylibdir'].sub('/ruby/', '/ruby/gems/')}/gems"
+unless Dir.exist? gem_dir
+  gem_dir = "#{__dir__}/../gems"
+end
+
+# we need to pick up gems without a gemspec, so pick folders with a lib sub-folder
+# the 'tz' gems for Windows do not have gemspec files
+Dir.glob("#{gem_dir}/*/lib")
+  .reject {|f| Dir.exist?(f) and f =~ /minitest|test-unit|power_assert/ }
+  .map {|f| $LOAD_PATH.unshift f }
+
+puts '', $LOAD_PATH, ''        # debugging
 
 require_relative '../tool/test/runner'


### PR DESCRIPTION
**This is a draft** for debugging

It outputs $LOAD_PATH after changes to it by test/runner.rb.  Also, adds logic for running tests from the install folder.