### PR TITLE
reduce cache mishits

### DIFF
--- a/mjit_compile.c
+++ b/mjit_compile.c
@@ -87,7 +87,7 @@ has_valid_method_type(CALL_CACHE cc)
 {
     extern bool mjit_valid_class_serial_p(rb_serial_t class_serial);
     return GET_GLOBAL_METHOD_STATE() == cc->method_state
-        && mjit_valid_class_serial_p(cc->class_serial) && cc->me;
+        && mjit_valid_class_serial_p(cc->class_serial[0]) && cc->me;
 }
 
 // Returns true if iseq can use fastpath for setup, otherwise NULL. This becomes true in the same condition

--- a/tool/ruby_vm/loaders/insns_def.rb
+++ b/tool/ruby_vm/loaders/insns_def.rb
@@ -21,7 +21,7 @@ grammar = %r'
     (?<keyword>  typedef | extern | static | auto | register |
                  struct  | union  | enum                           ){0}
     (?<C>        (?: \g<block> | [^{}]+ )*                         ){0}
-    (?<block>    \{ \g<ws>* ^ \g<C> $ \g<ws>* \}                   ){0}
+    (?<block>    \{ \g<ws>*   \g<C>   \g<ws>* \}                   ){0}
     (?<ws>       \g<comment> | \s                                  ){0}
     (?<ident>    [_a-zA-Z] [0-9_a-zA-Z]*                           ){0}
     (?<type>     (?: \g<keyword> \g<ws>+ )* \g<ident>              ){0}

--- a/tool/ruby_vm/views/_mjit_compile_send.erb
+++ b/tool/ruby_vm/views/_mjit_compile_send.erb
@@ -36,7 +36,7 @@
 
 % # JIT: Invalidate call cache if it requires vm_search_method. This allows to inline some of following things.
             fprintf(f, "    if (UNLIKELY(GET_GLOBAL_METHOD_STATE() != %"PRI_SERIALT_PREFIX"u ||\n", cc_copy->method_state);
-            fprintf(f, "        RCLASS_SERIAL(CLASS_OF(stack[%d])) != %"PRI_SERIALT_PREFIX"u)) {\n", b->stack_size - 1 - argc, cc_copy->class_serial);
+            fprintf(f, "        RCLASS_SERIAL(CLASS_OF(stack[%d])) != %"PRI_SERIALT_PREFIX"u)) {\n", b->stack_size - 1 - argc, cc_copy->class_serial[0]);
             fprintf(f, "        reg_cfp->pc = original_body_iseq + %d;\n", pos);
             fprintf(f, "        reg_cfp->sp = vm_base_ptr(reg_cfp) + %d;\n", b->stack_size);
             fprintf(f, "        goto send_cancel;\n");

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -47,7 +47,7 @@ rb_vm_call0(rb_execution_context_t *ec, VALUE recv, ID id, int argc, const VALUE
 {
     struct rb_calling_info calling = { Qundef, recv, argc, kw_splat, };
     struct rb_call_info ci = { id, (kw_splat ? VM_CALL_KW_SPLAT : 0), argc, };
-    struct rb_call_cache cc = { 0, 0, me, me->def, vm_call_general, { 0, }, };
+    struct rb_call_cache cc = { 0, { 0, }, me, me->def, vm_call_general, { 0, }, };
     struct rb_call_data cd = { cc, ci, };
     return vm_call0_body(ec, &calling, &cd, argv);
 }


### PR DESCRIPTION
While running discourse benchmark under [linux perf](https://github.com/torvalds/linux/tree/master/tools/perf), I  noticed one of the most frequent operations that ruby does is the method lookup.

That was kind of known, but something didn't smell right.  I pushed 3ffd98c5cd040a4081617b3bc6f9062237937b9b and ran the benchmark again, to get this output:

[![](https://pbs.twimg.com/media/EGBPO2HVAAEbqFV?format=png&name=small)](https://twitter.com/shyouhei/status/1180030229227569152)

So 65,039,079 out of 94,613,117 inline cache mishits are spurious; they resulted in method lookups that end up exactly the same method entry the cache already stored.  This is not a buggy behaviour and your program works as expected (apart from unnecessarily consuming our precious environmental resources to generate electricity for the computation).  However there definitely is a room of improvements.

Let's use the cache more efficiently.  We are facing the fact that several classes share the identical method entry for a method name; possibly due to inheritance, inclusions, and so on.  We can use this.  A call cache is valid for multiple classes.  So in order to express the info, this changeset expands `struct rb_call_cache` from 44-ish bytes to cache line width.  The space we add is used for second and later class serials.

By this changeset the debug counter output for the same benchmark is now like this:

![Screenshot from 2019-10-21 17-56-48](https://user-images.githubusercontent.com/15377/67191593-d7eeca80-f42c-11e9-97e4-c85be2d7628f.png)

The `mc_miss_spurious` counter dropped down to 23,344,738.