### PR TITLE
Make CSV::Row#dup return a usable Row

### DIFF
--- a/lib/csv/row.rb
+++ b/lib/csv/row.rb
@@ -241,6 +241,14 @@ class CSV
     end
 
     #
+    # Returns a copy of the object with headers and fields that are copied from
+    # the source object. This allows the copy to receive changes without
+    # affecting the source.
+    def dup
+      self.class.new(headers, fields, header_row?)
+    end
+
+    #
     # This method accepts any number of arguments which can be headers, indices,
     # Ranges of either, or two-element Arrays containing a header and offset.
     # Each argument will be replaced with a field lookup as described in

--- a/test/csv/test_row.rb
+++ b/test/csv/test_row.rb
@@ -425,6 +425,9 @@ class TestCSVRow < Test::Unit::TestCase
   def test_dup
     row = CSV::Row.new(["A"], ["foo"])
     dupped_row = row.dup
+    dupped_row["A"] = "bar"
+    assert_equal(["foo", "bar"],
+                 [row["A"], dupped_row["A"]])
     dupped_row.delete("A")
     assert_equal(["foo", nil],
                  [row["A"], dupped_row["A"]])


### PR DESCRIPTION
Previously, calling `dup` on a `CSV::Row` object yielded an object whose
copy was too shallow. Changing the clone's fields would also change the
fields on the source. This change makes the clone more distinct from the
source, so that changes can be made to its fields without affecting the
source.