### PR TITLE
Right size the iseq coverage branches tmp array - initializes with 5 elements

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -273,7 +273,7 @@ const ID rb_iseq_shared_exc_local_tbl[] = {idERROR_INFO};
 	  ISEQ_BRANCH_COVERAGE(iseq) && \
 	  (first_line) > 0) { \
 	  VALUE structure = RARRAY_AREF(ISEQ_BRANCH_COVERAGE(iseq), 0); \
-	  branches = rb_ary_tmp_new(0); \
+	  branches = rb_ary_tmp_new(5); \
 	  rb_ary_push(structure, branches); \
 	  rb_ary_push(branches, ID2SYM(rb_intern(type))); \
 	  rb_ary_push(branches, INT2FIX(first_line)); \


### PR DESCRIPTION
Minor change the initializes the tmp array for branches to the correct size of 5 elements.

```c
#define DECL_BRANCH_BASE(branches, first_line, first_column, last_line, last_column, type) \
  do { \
      if (ISEQ_COVERAGE(iseq) && \
	  ISEQ_BRANCH_COVERAGE(iseq) && \
	  (first_line) > 0) { \
	  VALUE structure = RARRAY_AREF(ISEQ_BRANCH_COVERAGE(iseq), 0); \
	  branches = rb_ary_tmp_new(5); \
	  rb_ary_push(structure, branches); \
	  rb_ary_push(branches, ID2SYM(rb_intern(type))); \ <<<<<<<<<<<<<<<<
	  rb_ary_push(branches, INT2FIX(first_line)); \ <<<<<<<<<<<<<<<<
	  rb_ary_push(branches, INT2FIX(first_column)); \ <<<<<<<<<<<<<<<<
	  rb_ary_push(branches, INT2FIX(last_line)); \ <<<<<<<<<<<<<<<<
	  rb_ary_push(branches, INT2FIX(last_column)); \ <<<<<<<<<<<<<<<<
      } \
  } while (0)
```