### PR TITLE
Let the backtrace array constructed in backtrace_collect be initialized with the size already given

### DIFF
--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -578,7 +578,7 @@ backtrace_collect(rb_backtrace_t *bt, long lev, long n, VALUE (*func)(rb_backtra
 	rb_bug("backtrace_collect: unreachable");
     }
 
-    btary = rb_ary_new();
+    btary = rb_ary_new2(n);
 
     for (i=0; i+lev<bt->backtrace_size && i<n; i++) {
 	rb_backtrace_location_t *loc = &bt->backtrace[bt->backtrace_size - 1 - (lev+i)];


### PR DESCRIPTION
`backtrace_collect` has 2 callsites:

* `backtrace_to_location_ary`
* `backtrace_to_str_ary`

Both of which has extensive validation of the requested backtrace size and thus provide an already known size to the backtrace array on init.