### PR TITLE
Fix gem testing, timeouts for Actions test

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -44,6 +44,7 @@ jobs:
       - run: make $JOBS
       - name: Tests
         run: make -s ${{ matrix.test_task }} TESTOPTS="$JOBS -q --tty=no"
+        timeout-minutes: 50
         env:
           MSPECOPT: "-ff" # not using `-j` because sometimes `mspec -j` silently dies
         if: matrix.test_task != 'test-bundled-gems'

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -72,6 +72,7 @@ jobs:
       - run: make $JOBS
       - name: Tests
         run: make -s ${{ matrix.test_task }} TESTOPTS="$JOBS -q --tty=no"
+        timeout-minutes: 50
         env:
           MSPECOPT: "-ff" # not using `-j` because sometimes `mspec -j` silently dies
         if: matrix.test_task != 'test-bundled-gems'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,16 +13,18 @@ environment:
     # to reduce time for finishing all jobs, run the slowest msys2 build first.
     - build: msys2
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      GEMS_FOR_TEST: "timezone tzinfo"
     - build: vs
       vs: 120
       ssl: OpenSSL
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+      GEMS_FOR_TEST: ""
     - build: vs
       vs: 140
       ssl: OpenSSL-v111
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      GEMS_FOR_TEST: ""
   RELINE_TEST_ENCODING: "Windows-31J"
-  GEMS_FOR_TEST: "timezone tzinfo"
   UPDATE_UNICODE: "UNICODE_FILES=. UNICODE_PROPERTY_FILES=. UNICODE_AUXILIARY_FILES=. UNICODE_EMOJI_FILES=."
 for:
 -

--- a/test/ruby/test_exception.rb
+++ b/test/ruby/test_exception.rb
@@ -995,7 +995,7 @@ end.join
     error = NoMethodError.new("Message", :foo)
     assert_raise(ArgumentError) {error.receiver}
 
-    msg = defined?(:DidYouMean.formatter) ?
+    msg = defined?(DidYouMean.formatter) ?
       "Message\nDid you mean?  for" : "Message"
 
     error = NoMethodError.new("Message", :foo, receiver: receiver)

--- a/test/runner.rb
+++ b/test/runner.rb
@@ -1,11 +1,20 @@
 # frozen_string_literal: true
 
+require 'rbconfig'
+
 # Should be done in rubygems test files?
 ENV["GEM_SKIP"] = ENV["GEM_HOME"] = ENV["GEM_PATH"] = "".freeze
 
-# Get bundled gems on load path
-Dir.glob("#{__dir__}/../gems/*/*.gemspec")
-  .reject {|f| f =~ /minitest|test-unit|power_assert/ }
-  .map {|f| $LOAD_PATH.unshift File.join(File.dirname(f), "lib") }
+# Get bundled gems on load path, try install dir first
+gem_dir = "#{RbConfig::CONFIG['rubylibdir'].sub('/ruby/', '/ruby/gems/')}/gems"
+unless Dir.exist? gem_dir
+  gem_dir = "#{__dir__}/../gems"
+end
+
+# we need to pick up gems without a gemspec, so pick folders with a lib sub-folder
+# the 'tz' gems for Windows do not have gemspec files
+Dir.glob("#{gem_dir}/*/lib")
+  .reject {|f| Dir.exist?(f) and f =~ /minitest|test-unit|power_assert/ }
+  .map {|f| $LOAD_PATH.unshift f }
 
 require_relative '../tool/test/runner'


### PR DESCRIPTION
Commits:

1. test/runner.rb - correct $LOAD_PATH additions for gems

2. appveyor.yml - remove timezone & tzinfo gems from MSVC buiilds, not compatible with concurrent-ruby dependency, see:
   https://ci.appveyor.com/project/ruby/ruby/builds/28246154/job/ba8vftbg7u8hh2v7#L20866
   https://ci.appveyor.com/project/ruby/ruby/builds/28246154/job/p7pv4wyu8jn0lrh0#L20852

3. test/ruby/test_exception typo fix

4. Actions Workflows - set test timeout for Ubuntu & macOS