### PR TITLE
Let the arrays for the singleton and instance method reflection helpers be initialized to the methods count

### DIFF
--- a/class.c
+++ b/class.c
@@ -1229,7 +1229,7 @@ class_instance_method_list(int argc, const VALUE *argv, VALUE mod, int obj, int 
 	if (BUILTIN_TYPE(mod) == T_ICLASS && !prepended) continue;
 	if (!recur) break;
     }
-    ary = rb_ary_new();
+    ary = rb_ary_new2(me_arg.list->num_entries);
     st_foreach(me_arg.list, func, ary);
     st_free_table(me_arg.list);
 
@@ -1466,7 +1466,7 @@ rb_obj_singleton_methods(int argc, const VALUE *argv, VALUE obj)
 	    klass = RCLASS_SUPER(klass);
 	}
     }
-    ary = rb_ary_new();
+    ary = rb_ary_new2(me_arg.list->num_entries);
     st_foreach(me_arg.list, ins_methods_i, ary);
     st_free_table(me_arg.list);
 


### PR DESCRIPTION
Affects the instance and single methods reflection API through entry points `class_instance_method_list` and `rb_obj_singleton_methods` respectively.

The gist of the optimization is being able to grab the size of the transient method entries table that drives the `st_foreach` iteration before being discarded and initialize the resulting array to a capacity equal to the methods being reflected on.