### PR TITLE
Performance improvement for Array#intersection

### DIFF
--- a/lib/ruby_test.rb
+++ b/lib/ruby_test.rb
@@ -1,0 +1,10 @@
+puts 'doing &'
+puts 'small'
+puts Benchmark.measure { [1, 2, 3] & [1, 2, 3, 4, 5] & [2, 3, 4, 5] & [2] }
+puts 'big'
+puts Benchmark.measure { (@cls[1, 2, 3, 4] * 64) & (@cls[1, 2, 3] * 64) & (@cls[1, 2] * 64) }
+puts 'doing intersection'
+puts 'small'
+puts Benchmark.measure { [1, 2, 3].intersection([1, 2, 3, 4, 5], [2, 3, 4, 5], [2]) }
+puts 'big'
+puts Benchmark.measure { (@cls[1, 2, 3, 4] * 64).intersection(@cls[1, 2, 3] * 64, @cls[1, 2] * 64) }

--- a/spec/ruby/core/array/intersection_spec.rb
+++ b/spec/ruby/core/array/intersection_spec.rb
@@ -1,51 +1,51 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
-describe "Array#&" do
+describe "Array#intersect" do
   it "creates an array with elements common to both arrays (intersection)" do
-    ([] & []).should == []
-    ([1, 2] & []).should == []
-    ([] & [1, 2]).should == []
-    ([ 1, 3, 5 ] & [ 1, 2, 3 ]).should == [1, 3]
+    [].intersection([]).should == []
+    [1, 2].intersection([]).should == []
+    [].intersection([1, 2]).should == []
+    [ 1, 3, 5 ].intersection([ 1, 2, 3 ]).should == [1, 3]
   end
 
   it "creates an array with no duplicates" do
-    ([ 1, 1, 3, 5 ] & [ 1, 2, 3 ]).uniq!.should == nil
+    [ 1, 1, 3, 5 ].intersection([ 1, 2, 3 ]).uniq!.should == nil
   end
 
   it "creates an array with elements in order they are first encountered" do
-    ([ 1, 2, 3, 2, 5 ] & [ 5, 2, 3, 4 ]).should == [2, 3, 5]
+    [ 1, 2, 3, 2, 5 ].intersection([ 5, 2, 3, 4 ]).should == [2, 3, 5]
   end
 
   it "does not modify the original Array" do
     a = [1, 1, 3, 5]
-    (a & [1, 2, 3]).should == [1, 3]
+    a.intersection([1, 2, 3]).should == [1, 3]
     a.should == [1, 1, 3, 5]
   end
 
   it "properly handles recursive arrays" do
     empty = ArraySpecs.empty_recursive_array
-    (empty & empty).should == empty
+    empty.intersection(empty).should == empty
 
-    (ArraySpecs.recursive_array & []).should == []
-    ([] & ArraySpecs.recursive_array).should == []
+    ArraySpecs.recursive_array.intersection([]).should == []
+    [].intersection(ArraySpecs.recursive_array).should == []
 
-    (ArraySpecs.recursive_array & ArraySpecs.recursive_array).should == [1, 'two', 3.0, ArraySpecs.recursive_array]
+    ArraySpecs.recursive_array.intersection(ArraySpecs.recursive_array).should == [1, 'two', 3.0, ArraySpecs.recursive_array]
   end
 
   it "tries to convert the passed argument to an Array using #to_ary" do
     obj = mock('[1,2,3]')
     obj.should_receive(:to_ary).and_return([1, 2, 3])
-    ([1, 2] & obj).should == ([1, 2])
+    [1, 2].intersection(obj).should == ([1, 2])
   end
 
   it "determines equivalence between elements in the sense of eql?" do
     not_supported_on :opal do
-      ([5.0, 4.0] & [5, 4]).should == []
+      [5.0, 4.0].intersection([5, 4]).should == []
     end
 
     str = "x"
-    ([str] & [str.dup]).should == [str]
+    [str].intersection([str.dup]).should == [str]
 
     obj1 = mock('1')
     obj2 = mock('2')
@@ -54,8 +54,8 @@ describe "Array#&" do
     obj1.should_receive(:eql?).at_least(1).and_return(true)
     obj2.stub!(:eql?).and_return(true)
 
-    ([obj1] & [obj2]).should == [obj1]
-    ([obj1, obj1, obj2, obj2] & [obj2]).should == [obj1]
+    [obj1].intersection([obj2]).should == [obj1]
+    [obj1, obj1, obj2, obj2].intersection([obj2]).should == [obj1]
 
     obj1 = mock('3')
     obj2 = mock('4')
@@ -63,18 +63,18 @@ describe "Array#&" do
     obj2.stub!(:hash).and_return(0)
     obj1.should_receive(:eql?).at_least(1).and_return(false)
 
-    ([obj1] & [obj2]).should == []
-    ([obj1, obj1, obj2, obj2] & [obj2]).should == [obj2]
+    [obj1].intersection([obj2]).should == []
+    [obj1, obj1, obj2, obj2].intersection([obj2]).should == [obj2]
   end
 
   it "does return subclass instances for Array subclasses" do
-    (ArraySpecs::MyArray[1, 2, 3] & []).should be_an_instance_of(Array)
-    (ArraySpecs::MyArray[1, 2, 3] & ArraySpecs::MyArray[1, 2, 3]).should be_an_instance_of(Array)
-    ([] & ArraySpecs::MyArray[1, 2, 3]).should be_an_instance_of(Array)
+    ArraySpecs::MyArray[1, 2, 3].intersection([]).should be_an_instance_of(Array)
+    ArraySpecs::MyArray[1, 2, 3].intersection(ArraySpecs::MyArray[1, 2, 3]).should be_an_instance_of(Array)
+    [].intersection(ArraySpecs::MyArray[1, 2, 3]).should be_an_instance_of(Array)
   end
 
   it "does not call to_ary on array subclasses" do
-    ([5, 6] & ArraySpecs::ToAryArray[1, 2, 5, 6]).should == [5, 6]
+    [5, 6].intersection(ArraySpecs::ToAryArray[1, 2, 5, 6]).should == [5, 6]
   end
 
   it "properly handles an identical item even when its #eql? isn't reflexive" do
@@ -82,6 +82,6 @@ describe "Array#&" do
     x.stub!(:hash).and_return(42)
     x.stub!(:eql?).and_return(false) # Stubbed for clarity and latitude in implementation; not actually sent by MRI.
 
-    ([x] & [x]).should == [x]
+    [x].intersection([x]).should == [x]
   end
 end

--- a/test/ruby/test_array.rb
+++ b/test/ruby/test_array.rb
@@ -248,6 +248,7 @@ class TestArray < Test::Unit::TestCase
     assert_equal(@cls[1], @cls[1, 2, 3].intersection(@cls[1, 2], @cls[1]))
     assert_equal(@cls[ ], @cls[1, 2, 3].intersection(@cls[1, 2], @cls[3]))
     assert_equal(@cls[ ], @cls[1, 2, 3].intersection(@cls[4, 5, 6]))
+    assert_equal(@cls[1], @cls[1, 1].intersection)
   end
 
   def test_intersection_big_array


### PR DESCRIPTION
Performance improvement mentioned here: https://github.com/ruby/ruby/pull/2533

Instead of creating N intermediate arrays, this repurposes the current implementation for `&` as the new implementation for `intersection` and holds onto a single result array.

The logic is to loop through the arrays, and perform the `&` implementation, i.e.
- if both arrays are relatively small, try to find each element of one array in the other, otherwise
- hash the array and check each element in the result set against the hash