### PR TITLE
optimize CLASS_OF

### DIFF
--- a/include/ruby/ruby.h
+++ b/include/ruby/ruby.h
@@ -2094,17 +2094,27 @@ RUBY_EXTERN VALUE rb_stdin, rb_stdout, rb_stderr;
 static inline VALUE
 rb_class_of(VALUE obj)
 {
-    if (RB_IMMEDIATE_P(obj)) {
-	if (RB_FIXNUM_P(obj)) return rb_cInteger;
-	if (RB_FLONUM_P(obj)) return rb_cFloat;
-	if (obj == RUBY_Qtrue)  return rb_cTrueClass;
-	if (RB_STATIC_SYM_P(obj)) return rb_cSymbol;
+    if (!RB_SPECIAL_CONST_P(obj)) {
+        return RBASIC_CLASS(obj);
     }
-    else if (!RB_TEST(obj)) {
-	if (obj == RUBY_Qnil)   return rb_cNilClass;
-	if (obj == RUBY_Qfalse) return rb_cFalseClass;
+    else if (obj == RUBY_Qfalse) {
+        return rb_cFalseClass;
     }
-    return RBASIC(obj)->klass;
+    else if (obj == RUBY_Qnil) {
+        return rb_cNilClass;
+    }
+    else if (obj == RUBY_Qtrue) {
+        return rb_cTrueClass;
+    }
+    else if (RB_FIXNUM_P(obj)) {
+        return rb_cInteger;
+    }
+    else if (RB_STATIC_SYM_P(obj)) {
+        return rb_cSymbol;
+    }
+    else {
+        return rb_cFloat;
+    }
 }
 
 static inline int

--- a/include/ruby/ruby.h
+++ b/include/ruby/ruby.h
@@ -2120,18 +2120,27 @@ rb_class_of(VALUE obj)
 static inline int
 rb_type(VALUE obj)
 {
-    if (RB_IMMEDIATE_P(obj)) {
-	if (RB_FIXNUM_P(obj)) return RUBY_T_FIXNUM;
-        if (RB_FLONUM_P(obj)) return RUBY_T_FLOAT;
-        if (obj == RUBY_Qtrue)  return RUBY_T_TRUE;
-	if (RB_STATIC_SYM_P(obj)) return RUBY_T_SYMBOL;
-	if (obj == RUBY_Qundef) return RUBY_T_UNDEF;
+    if (!RB_SPECIAL_CONST_P(obj)) {
+        return RB_BUILTIN_TYPE(obj);
     }
-    else if (!RB_TEST(obj)) {
-	if (obj == RUBY_Qnil)   return RUBY_T_NIL;
-	if (obj == RUBY_Qfalse) return RUBY_T_FALSE;
+    else if (obj == RUBY_Qfalse) {
+        return RUBY_T_FALSE;
     }
-    return RB_BUILTIN_TYPE(obj);
+    else if (obj == RUBY_Qnil) {
+        return RUBY_T_NIL;
+    }
+    else if (obj == RUBY_Qtrue) {
+        return RUBY_T_TRUE;
+    }
+    else if (RB_FIXNUM_P(obj)) {
+        return RUBY_T_FIXNUM;
+    }
+    else if (RB_STATIC_SYM_P(obj)) {
+        return RUBY_T_SYMBOL;
+    }
+    else {
+        return RUBY_T_FLOAT;
+    }
 }
 
 #ifdef __GNUC__


### PR DESCRIPTION
`CLASS_OF` is literally everywhere.  When you call a method, the class has to be inferred from its receiver, which is done by this.

So even a small fraction of it has a very huge impact on runtime performance.  Looking at the implementation the `RBASIC(obj)` part was at the very end of the function body.  This, however, is
expected to be the most frequently-entering branch because most method calls for Fixnums etc. are special-cased in `insns.def`.

Moving what is likely to happen right in front of the function makes it easier for compilers to emit optimal codes.  This rearrangement does not speed things up at all if you use gcc 9, but for clang 10, the impact is considerable.

```
Calculating -------------------------------------
                         ours@clang-10  ours@gcc-9  master@clang-10 master@gcc-9
Optcarrot Lan_Master.nes        45.471      47.408           38.084       44.744 fps

Comparison:
             Optcarrot Lan_Master.nes
              ours@gcc-9:        47.4 fps
           ours@clang-10:        45.5 fps - 1.04x  slower
            master@gcc-9:        44.7 fps - 1.06x  slower
         master@clang-10:        38.1 fps - 1.24x  slower
```