### PR TITLE
Handle Enumerable in Set#intersect?

### DIFF
--- a/lib/set.rb
+++ b/lib/set.rb
@@ -313,21 +313,27 @@ class Set
     end
   end
 
-  # Returns true if the set and the given set have at least one
+  # Returns true if the set and the given Enumerable have at least one
   # element in common.
   #
   #     Set[1, 2, 3].intersect? Set[4, 5]   #=> false
   #     Set[1, 2, 3].intersect? Set[3, 4]   #=> true
+  #     Set[1, 2, 3].intersect? [3, 4]      #=> true
   def intersect?(set)
-    set.is_a?(Set) or raise ArgumentError, "value must be a set"
-    if size < set.size
+    set.is_a?(Enumerable) or raise ArgumentError, "value must be an Enumerable"
+
+    if set.is_a?(Range) && set.infinite?
+      raise ArgumentError, "value cannot be an infinite sequence"
+    end
+
+    if set.is_a?(Set) && size < set.size
       any? { |o| set.include?(o) }
     else
       set.any? { |o| include?(o) }
     end
   end
 
-  # Returns true if the set and the given set have no element in
+  # Returns true if the set and the given Enumerable have no element in
   # common.  This method is the opposite of `intersect?`.
   #
   #     Set[1, 2, 3].disjoint? Set[3, 4]   #=> false

--- a/range.c
+++ b/range.c
@@ -1576,6 +1576,24 @@ range_include_internal(VALUE range, VALUE val, int string_use_cover)
     return Qundef;
 }
 
+/*
+ *  call-seq:
+ *     rng.infinite?    -> true or false
+ *
+ *  Returns <code>true</code> if the range is infinite.
+ *
+ *     (1..5).infinite?     #=> false
+ *     (1..).infinite?      #=> true
+ */
+
+static VALUE
+range_infinite_p(VALUE range)
+{
+    VALUE b = RANGE_BEG(range), e = RANGE_END(range);
+
+    return NIL_P(b) || NIL_P(e) ? Qtrue : Qfalse;
+}
+
 static int r_cover_range_p(VALUE range, VALUE beg, VALUE end, VALUE val);
 
 /*
@@ -1877,6 +1895,7 @@ Init_Range(void)
     rb_define_method(rb_cRange, "inspect", range_inspect, 0);
 
     rb_define_method(rb_cRange, "exclude_end?", range_exclude_end_p, 0);
+    rb_define_method(rb_cRange, "infinite?", range_infinite_p, 0);
 
     rb_define_method(rb_cRange, "member?", range_include, 1);
     rb_define_method(rb_cRange, "include?", range_include, 1);

--- a/test/ruby/test_range.rb
+++ b/test/ruby/test_range.rb
@@ -196,6 +196,11 @@ class TestRange < Test::Unit::TestCase
     assert_predicate(0..., :exclude_end?)
   end
 
+  def test_infinite
+    assert_not_predicate(0..10, :infinite?)
+    assert_predicate((0..), :infinite?)
+  end
+
   def test_eq
     r = (0..1)
     assert_equal(r, r)

--- a/test/test_set.rb
+++ b/test/test_set.rb
@@ -378,7 +378,7 @@ class TC_Set < Test::Unit::TestCase
     set = Set[3,4,5]
 
     assert_intersect(ArgumentError, set, 3)
-    assert_intersect(ArgumentError, set, [2,4,6])
+    assert_intersect(ArgumentError, set, 1..)
 
     assert_intersect(true, set, set)
     assert_intersect(true, set, Set[2,4])
@@ -389,6 +389,11 @@ class TC_Set < Test::Unit::TestCase
     assert_intersect(false, set, Set[0,2])
     assert_intersect(false, set, Set[0,2,6])
     assert_intersect(false, set, Set[0,2,6,8,10])
+
+    assert_send([set, :intersect?, [2,4,6]])
+    assert_not_send([set, :disjoint?, [2,4,6]])
+    assert_not_send([set, :intersect?, [0,2]])
+    assert_send([set, :disjoint?, [0,2]])
 
     # Make sure set hasn't changed
     assert_equal(Set[3,4,5], set)


### PR DESCRIPTION
Another feature in addition (or as an alternative) to https://github.com/ruby/ruby/pull/1972 as suggested in the discussion on https://bugs.ruby-lang.org/issues/15198

This adds support for all `Enumerable` types in `Set#intersect?` by always iterating through the other enumerable if it is not a set.

This does not support infinite ranges. It adds `Range#infinite?` as a helper method and raises and argument error if one is supplied. 