### PR TITLE
Mention correct class name in uninitialized error

### DIFF
--- a/re.c
+++ b/re.c
@@ -1044,7 +1044,7 @@ static void
 match_check(VALUE match)
 {
     if (!RMATCH(match)->regexp) {
-	rb_raise(rb_eTypeError, "uninitialized Match");
+	rb_raise(rb_eTypeError, "uninitialized MatchData");
     }
 }
 


### PR DESCRIPTION
I think this meant to mention `MatchData`? This is a breaking change, but
should be a minor one.