### PR TITLE
Add aligned_xmalloc()/aligned_xfree to retrieve aligned memory area in C-extension

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -10080,16 +10080,9 @@ rb_malloc_info_show_results(void)
 }
 #endif
 
-static void
-objspace_xfree(rb_objspace_t *objspace, void *ptr, size_t old_size)
+static size_t
+objspace_calc_exact_malloc_size(void *ptr, size_t old_size)
 {
-    if (!ptr) {
-        /*
-         * ISO/IEC 9899 says "If ptr is a null pointer, no action occurs" since
-         * its first version.  We would better follow.
-         */
-        return;
-    }
 #if CALC_EXACT_MALLOC_SIZE
     struct malloc_obj_info *info = (struct malloc_obj_info *)ptr - 1;
     ptr = info;
@@ -10146,6 +10139,21 @@ objspace_xfree(rb_objspace_t *objspace, void *ptr, size_t old_size)
     }
 #endif
 #endif
+    return old_size;
+}
+
+static void
+objspace_xfree(rb_objspace_t *objspace, void *ptr, size_t old_size)
+{
+    if (!ptr) {
+        /*
+         * ISO/IEC 9899 says "If ptr is a null pointer, no action occurs" since
+         * its first version.  We would better follow.
+         */
+        return;
+    }
+    old_size = objspace_calc_exact_malloc_size(ptr, old_size);
+
     old_size = objspace_malloc_size(objspace, ptr, old_size);
 
     free(ptr);

--- a/gc.c
+++ b/gc.c
@@ -10172,6 +10172,8 @@ objspace_aligned_xfree(rb_objspace_t *objspace, void *ptr, size_t old_size)
          */
         return;
     }
+    old_size = objspace_calc_exact_malloc_size(ptr, old_size);
+
     old_size = objspace_malloc_size(objspace, ptr, old_size);
 
     rb_aligned_free(ptr);

--- a/include/ruby/defines.h
+++ b/include/ruby/defines.h
@@ -213,12 +213,20 @@ RUBY_SYMBOL_EXPORT_BEGIN
 #define xcalloc ruby_xcalloc
 #define xrealloc ruby_xrealloc
 #define xrealloc2 ruby_xrealloc2
+#define aligned_xmalloc ruby_aligned_xmalloc
 #define xfree ruby_xfree
+#define aligned_xfree ruby_aligned_xfree
 
 #if GCC_VERSION_SINCE(4,3,0)
 # define RUBY_ATTR_ALLOC_SIZE(params) __attribute__ ((alloc_size params))
 #else
 # define RUBY_ATTR_ALLOC_SIZE(params)
+#endif
+
+#if GCC_VERSION_SINCE(4,9,0)
+# define RUBY_ATTR_ALLOC_ALIGN(params) __attribute__ ((alloc_align params))
+#else
+# define RUBY_ATTR_ALLOC_ALIGN(params)
 #endif
 
 #ifdef __has_attribute
@@ -235,7 +243,9 @@ void *ruby_xmalloc2(size_t,size_t) RUBY_ATTR_MALLOC RUBY_ATTR_ALLOC_SIZE((1,2));
 void *ruby_xcalloc(size_t,size_t) RUBY_ATTR_MALLOC RUBY_ATTR_ALLOC_SIZE((1,2));
 void *ruby_xrealloc(void*,size_t) RUBY_ATTR_ALLOC_SIZE((2));
 void *ruby_xrealloc2(void*,size_t,size_t) RUBY_ATTR_ALLOC_SIZE((2,3));
+void *ruby_aligned_xmalloc(size_t, size_t) RUBY_ATTR_ALLOC_ALIGN((1));
 void ruby_xfree(void*);
+void ruby_aligned_xfree(void*);
 
 #ifndef USE_GC_MALLOC_OBJ_INFO_DETAILS
 #define USE_GC_MALLOC_OBJ_INFO_DETAILS 0


### PR DESCRIPTION
We need to allocate aligned memory which works Ruby GC properly in Ruby C-extension.

Related to https://github.com/rmagick/rmagick/pull/832

https://bugs.ruby-lang.org/issues/16290