### PR TITLE
Update standard library docs [ci skip]

### DIFF
--- a/ext/stringio/stringio.c
+++ b/ext/stringio/stringio.c
@@ -429,7 +429,7 @@ strio_nil(VALUE self)
 }
 
 /*
- * Returns *strio* itself.  Just for compatibility to IO.
+ * Returns an object itself.  Just for compatibility to IO.
  */
 static VALUE
 strio_self(VALUE self)
@@ -505,7 +505,7 @@ strio_set_string(VALUE self, VALUE string)
  * call-seq:
  *   strio.close  -> nil
  *
- * Closes strio.  The *strio* is unavailable for any further data
+ * Closes a StringIO. The stream is unavailable for any further data
  * operations; an +IOError+ is raised if such an attempt is made.
  */
 static VALUE
@@ -521,7 +521,7 @@ strio_close(VALUE self)
  *   strio.close_read    -> nil
  *
  * Closes the read end of a StringIO.  Will raise an +IOError+ if the
- * *strio* is not readable.
+ * receiver is not readable.
  */
 static VALUE
 strio_close_read(VALUE self)
@@ -539,7 +539,7 @@ strio_close_read(VALUE self)
  *   strio.close_write    -> nil
  *
  * Closes the write end of a StringIO.  Will raise an  +IOError+ if the
- * *strio* is not writeable.
+ * receiver is not writeable.
  */
 static VALUE
 strio_close_write(VALUE self)
@@ -556,7 +556,7 @@ strio_close_write(VALUE self)
  * call-seq:
  *   strio.closed?    -> true or false
  *
- * Returns +true+ if *strio* is completely closed, +false+ otherwise.
+ * Returns +true+ if the stream is completely closed, +false+ otherwise.
  */
 static VALUE
 strio_closed(VALUE self)
@@ -570,7 +570,7 @@ strio_closed(VALUE self)
  * call-seq:
  *   strio.closed_read?    -> true or false
  *
- * Returns +true+ if *strio* is not readable, +false+ otherwise.
+ * Returns +true+ if the stream is not readable, +false+ otherwise.
  */
 static VALUE
 strio_closed_read(VALUE self)
@@ -584,7 +584,7 @@ strio_closed_read(VALUE self)
  * call-seq:
  *   strio.closed_write?    -> true or false
  *
- * Returns +true+ if *strio* is not writable, +false+ otherwise.
+ * Returns +true+ if the stream is not writable, +false+ otherwise.
  */
 static VALUE
 strio_closed_write(VALUE self)
@@ -599,8 +599,8 @@ strio_closed_write(VALUE self)
  *   strio.eof     -> true or false
  *   strio.eof?    -> true or false
  *
- * Returns true if *strio* is at end of file. The stringio must be
- * opened for reading or an +IOError+ will be raised.
+ * Returns true if the stream is at the end of the data (underlying string).
+ * The stream must be opened for reading or an +IOError+ will be raised.
  */
 static VALUE
 strio_eof(VALUE self)
@@ -634,7 +634,7 @@ strio_copy(VALUE copy, VALUE orig)
  * call-seq:
  *   strio.lineno    -> integer
  *
- * Returns the current line number in *strio*. The stringio must be
+ * Returns the current line number. The stream must be
  * opened for reading. +lineno+ counts the number of times  +gets+ is
  * called, rather than the number of newlines  encountered. The two
  * values will differ if +gets+ is  called with a separator other than
@@ -660,6 +660,13 @@ strio_set_lineno(VALUE self, VALUE lineno)
     return lineno;
 }
 
+/*
+ * call-seq:
+ *   strio.binmode    -> stringio
+ *
+ * Puts stream into binary mode. See IO#binmode.
+ *
+ */
 static VALUE
 strio_binmode(VALUE self)
 {
@@ -684,7 +691,7 @@ strio_binmode(VALUE self)
  *   strio.reopen(other_StrIO)     -> strio
  *   strio.reopen(string, mode)    -> strio
  *
- * Reinitializes *strio* with the given <i>other_StrIO</i> or _string_
+ * Reinitializes the stream with the given <i>other_StrIO</i> or _string_
  * and _mode_ (see StringIO#new).
  */
 static VALUE
@@ -702,7 +709,7 @@ strio_reopen(int argc, VALUE *argv, VALUE self)
  *   strio.pos     -> integer
  *   strio.tell    -> integer
  *
- * Returns the current offset (in bytes) of *strio*.
+ * Returns the current offset (in bytes).
  */
 static VALUE
 strio_get_pos(VALUE self)
@@ -714,7 +721,7 @@ strio_get_pos(VALUE self)
  * call-seq:
  *   strio.pos = integer    -> integer
  *
- * Seeks to the given position (in bytes) in *strio*.
+ * Seeks to the given position (in bytes).
  */
 static VALUE
 strio_set_pos(VALUE self, VALUE pos)
@@ -732,7 +739,7 @@ strio_set_pos(VALUE self, VALUE pos)
  * call-seq:
  *   strio.rewind    -> 0
  *
- * Positions *strio* to the beginning of input, resetting
+ * Positions the stream to the beginning of input, resetting
  * +lineno+ to zero.
  */
 static VALUE
@@ -900,7 +907,7 @@ strio_extend(struct StringIO *ptr, long pos, long len)
  * call-seq:
  *   strio.ungetc(string)   -> nil
  *
- * Pushes back one character (passed as a parameter) onto *strio*
+ * Pushes back one character (passed as a parameter)
  * such that a subsequent buffered read will return it.  There is no
  * limitation for multiple pushbacks including pushing back behind the
  * beginning of the buffer string.
@@ -1047,7 +1054,7 @@ strio_each_char(VALUE self)
 }
 
 /*
- *  This is a deprecated alias for <code>each_char</code>.
+ *  This is a deprecated alias for #each_char.
  */
 static VALUE
 strio_chars(VALUE self)
@@ -1091,7 +1098,7 @@ strio_each_codepoint(VALUE self)
 }
 
 /*
- *  This is a deprecated alias for <code>each_codepoint</code>.
+ *  This is a deprecated alias for #each_codepoint.
  */
 static VALUE
 strio_codepoints(VALUE self)
@@ -1281,9 +1288,9 @@ strio_getline(struct getline_arg *arg, struct StringIO *ptr)
 
 /*
  * call-seq:
- *   strio.gets(sep=$/)     -> string or nil
- *   strio.gets(limit)      -> string or nil
- *   strio.gets(sep, limit) -> string or nil
+ *   strio.gets(sep=$/, chomp: false)     -> string or nil
+ *   strio.gets(limit, chomp: false)      -> string or nil
+ *   strio.gets(sep, limit, chomp: false) -> string or nil
  *
  * See IO#gets.
  */
@@ -1305,9 +1312,9 @@ strio_gets(int argc, VALUE *argv, VALUE self)
 
 /*
  * call-seq:
- *   strio.readline(sep=$/)     -> string
- *   strio.readline(limit)      -> string or nil
- *   strio.readline(sep, limit) -> string or nil
+ *   strio.readline(sep=$/, chomp: false)     -> string
+ *   strio.readline(limit, chomp: false)      -> string or nil
+ *   strio.readline(sep, limit, chomp: false) -> string or nil
  *
  * See IO#readline.
  */
@@ -1321,15 +1328,15 @@ strio_readline(int argc, VALUE *argv, VALUE self)
 
 /*
  * call-seq:
- *   strio.each(sep=$/) {|line| block }         -> strio
- *   strio.each(limit) {|line| block }          -> strio
- *   strio.each(sep, limit) {|line| block }     -> strio
- *   strio.each(...)                            -> anEnumerator
+ *   strio.each(sep=$/, chomp: false) {|line| block }         -> strio
+ *   strio.each(limit, chomp: false) {|line| block }          -> strio
+ *   strio.each(sep, limit, chomp: false) {|line| block }     -> strio
+ *   strio.each(...)                                          -> anEnumerator
  *
- *   strio.each_line(sep=$/) {|line| block }    -> strio
- *   strio.each_line(limit) {|line| block }     -> strio
- *   strio.each_line(sep,limit) {|line| block } -> strio
- *   strio.each_line(...)                       -> anEnumerator
+ *   strio.each_line(sep=$/, chomp: false) {|line| block }     -> strio
+ *   strio.each_line(limit, chomp: false) {|line| block }      -> strio
+ *   strio.each_line(sep, limit, chomp: false) {|line| block } -> strio
+ *   strio.each_line(...)                                      -> anEnumerator
  *
  * See IO#each.
  */
@@ -1353,7 +1360,7 @@ strio_each(int argc, VALUE *argv, VALUE self)
 }
 
 /*
- *  This is a deprecated alias for <code>each_line</code>.
+ *  This is a deprecated alias for #each_line.
  */
 static VALUE
 strio_lines(int argc, VALUE *argv, VALUE self)
@@ -1366,9 +1373,9 @@ strio_lines(int argc, VALUE *argv, VALUE self)
 
 /*
  * call-seq:
- *   strio.readlines(sep=$/)    ->   array
- *   strio.readlines(limit)     ->   array
- *   strio.readlines(sep,limit) ->   array
+ *   strio.readlines(sep=$/, chomp: false)     ->   array
+ *   strio.readlines(limit, chomp: false)      ->   array
+ *   strio.readlines(sep, limit, chomp: false) ->   array
  *
  * See IO#readlines.
  */
@@ -1395,7 +1402,7 @@ strio_readlines(int argc, VALUE *argv, VALUE self)
  *   strio.write(string, ...) -> integer
  *   strio.syswrite(string)   -> integer
  *
- * Appends the given string to the underlying buffer string of *strio*.
+ * Appends the given string to the underlying buffer string.
  * The stream must be opened for writing.  If the argument is not a
  * string, it will be converted to a string using <code>to_s</code>.
  * Returns the number of bytes written.  See IO#write.
@@ -1669,7 +1676,7 @@ strio_size(VALUE self)
  * call-seq:
  *   strio.truncate(integer)    -> 0
  *
- * Truncates the buffer string to at most _integer_ bytes. The *strio*
+ * Truncates the buffer string to at most _integer_ bytes. The stream
  * must be opened for writing.
  */
 static VALUE
@@ -1693,7 +1700,8 @@ strio_truncate(VALUE self, VALUE len)
  *     strio.external_encoding   => encoding
  *
  *  Returns the Encoding object that represents the encoding of the file.
- *  If strio is write mode and no encoding is specified, returns <code>nil</code>.
+ *  If the stream is write mode and no encoding is specified, returns
+ *  +nil+.
  */
 
 static VALUE
@@ -1708,7 +1716,7 @@ strio_external_encoding(VALUE self)
  *     strio.internal_encoding   => encoding
  *
  *  Returns the Encoding of the internal string if conversion is
- *  specified.  Otherwise returns nil.
+ *  specified.  Otherwise returns +nil+.
  */
 
 static VALUE
@@ -1763,17 +1771,24 @@ strio_set_encoding_by_bom(VALUE self)
 }
 
 /*
- * Pseudo I/O on String object.
+ * Pseudo I/O on String object, with interface corresponding to IO.
  *
- * Commonly used to simulate `$stdio` or `$stderr`
+ * Commonly used to simulate <code>$stdio</code> or <code>$stderr</code>
  *
  * === Examples
  *
  *   require 'stringio'
  *
+ *   # Writing stream emulation
  *   io = StringIO.new
  *   io.puts "Hello World"
  *   io.string #=> "Hello World\n"
+ *
+ *   # Reading stream emulation
+ *   io = StringIO.new "first\nsecond\nlast\n"
+ *   io.getc #=> "f"
+ *   io.gets #=> "irst\n"
+ *   io.read #=> "second\nlast\n"
  */
 void
 Init_stringio(void)

--- a/lib/erb.rb
+++ b/lib/erb.rb
@@ -248,15 +248,13 @@ require "cgi/util"
 #
 # == Notes
 #
-# There are a variety of templating solutions available in various Ruby projects:
-# * ERB's big brother, eRuby, works the same but is written in C for speed;
-# * Amrita (smart at producing HTML/XML);
-# * cs/Template (written in C for speed);
-# * RDoc, distributed with Ruby, uses its own template engine, which can be reused elsewhere;
-# * and others; search {RubyGems.org}[https://rubygems.org/] or
-#   {The Ruby Toolbox}[https://www.ruby-toolbox.com/].
+# There are a variety of templating solutions available in various Ruby projects.
+# For example, RDoc, distributed with Ruby, uses its own template engine, which
+# can be reused elsewhere.
 #
-# Rails, the web application framework, uses ERB to create views.
+# Other popular engines could be found in the corresponding
+# {Category}[https://www.ruby-toolbox.com/categories/template_engines] of
+# The Ruby Toolbox.
 #
 class ERB
   Revision = '$Date::                           $' # :nodoc: #'
@@ -861,6 +859,21 @@ class ERB
   # is run
   attr_accessor :lineno
 
+  #
+  # Sets optional filename and line number that will be used in ERB code
+  # evaluation and error reporting. See also #filename= and #lineno=
+  #
+  #   erb = ERB.new('<%= some_x %>')
+  #   erb.render
+  #   # undefined local variable or method `some_x'
+  #   #   from (erb):1
+  #
+  #   erb.location = ['file.erb', 3]
+  #   # All subsequent error reporting would use new location
+  #   erb.render
+  #   # undefined local variable or method `some_x'
+  #   #   from file.erb:4
+  #
   def location=((filename, lineno))
     @filename = filename
     @lineno = lineno if lineno

--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -124,13 +124,21 @@ require "irb/version"
 # === History
 #
 # By default, irb will store the last 1000 commands you used in
-# <code>~/.irb_history</code>.
+# <code>IRB.conf[:HISTORY_FILE]</code> (<code>~/.irb_history</code> by default).
 #
 # If you want to disable history, add the following to your +.irbrc+:
 #
 #     IRB.conf[:SAVE_HISTORY] = nil
 #
 # See IRB::Context#save_history= for more information.
+#
+# The history of _resuls_ of commands evaluated is not stored by default,
+# but can be turned on to be stored with this +.irbrc+ setting:
+#
+#     IRB.conf[:EVAL_HISTORY] = <number>
+#
+# See IRB::Context#eval_history= and History class. The history of command
+# results is not permanently saved in any file.
 #
 # == Customizing the IRB Prompt
 #
@@ -274,7 +282,9 @@ require "irb/version"
 # <code>_</code>::
 #   The value command executed, as a local variable
 # <code>__</code>::
-#   The history of evaluated commands
+#   The history of evaluated commands. Available only if
+#   <code>IRB.conf[:EVAL_HISTORY]</code> is not +nil+ (which is the default).
+#   See also IRB::Context#eval_history= and IRB::History.
 # <code>__[line_no]</code>::
 #   Returns the evaluation value at the given line number, +line_no+.
 #   If +line_no+ is a negative, the return value +line_no+ many lines before

--- a/lib/irb/ext/history.rb
+++ b/lib/irb/ext/history.rb
@@ -31,9 +31,12 @@ module IRB # :nodoc:
     end
 
     remove_method :eval_history= if method_defined?(:eval_history=)
-    # The command result history limit.
+    # The command result history limit. This method is not available until
+    # #eval_history= was called with non-nil value (directly or via
+    # setting <code>IRB.conf[:EVAL_HISTORY]</code> in <code>.irbrc</code>).
     attr_reader :eval_history
-    # Sets command result history limit.
+    # Sets command result history limit. Default value is set from
+    # <code>IRB.conf[:EVAL_HISTORY]</code>.
     #
     # +no+ is an Integer or +nil+.
     #
@@ -42,6 +45,9 @@ module IRB # :nodoc:
     # If +no+ is 0, the number of history items is unlimited.
     #
     # If +no+ is +nil+, execution result history isn't used (default).
+    #
+    # History values are available via <code>__</code> variable, see
+    # IRB::History.
     def eval_history=(no)
       if no
         if defined?(@eval_history) && @eval_history
@@ -59,20 +65,51 @@ module IRB # :nodoc:
     end
   end
 
-  class History # :nodoc:
+  # Represents history of results of previously evaluated commands.
+  #
+  # Available via <code>__</code> variable, only if <code>IRB.conf[:EVAL_HISTORY]</code>
+  # or <code>IRB::CurrentContext().eval_history</code> is non-nil integer value
+  # (by default it is +nil+).
+  #
+  # Example (in `irb`):
+  #
+  #    # Initialize history
+  #    IRB::CurrentContext().eval_history = 10
+  #    # => 10
+  #
+  #    # Perform some commands...
+  #    1 + 2
+  #    # => 3
+  #    puts 'x'
+  #    # x
+  #    # => nil
+  #    raise RuntimeError
+  #    # ...error raised
+  #
+  #    # Inspect history (format is "<item number> <evaluated value>":
+  #    __
+  #    # => 1 10
+  #    # 2 3
+  #    # 3 nil
+  #
+  #    __[1]
+  #    # => 10
+  #
+  class History
 
-    def initialize(size = 16)
+    def initialize(size = 16)  # :nodoc:
       @size = size
       @contents = []
     end
 
-    def size(size)
+    def size(size) # :nodoc:
       if size != 0 && size < @size
         @contents = @contents[@size - size .. @size]
       end
       @size = size
     end
 
+    # Get one item of the content (both positive and negative indexes work).
     def [](idx)
       begin
         if idx >= 0
@@ -85,14 +122,14 @@ module IRB # :nodoc:
       end
     end
 
-    def push(no, val)
+    def push(no, val)  # :nodoc:
       @contents.push [no, val]
       @contents.shift if @size != 0 && @contents.size > @size
     end
 
     alias real_inspect inspect
 
-    def inspect
+    def inspect  # :nodoc:
       if @contents.empty?
         return real_inspect
       end

--- a/lib/net/ftp.rb
+++ b/lib/net/ftp.rb
@@ -1236,7 +1236,8 @@ module Net
 
     #
     # Returns the status (STAT command).
-    # pathname - when stat is invoked with pathname as a parameter it acts like
+    #
+    # pathname:: when stat is invoked with pathname as a parameter it acts like
     #            list but alot faster and over the same tcp session.
     #
     def status(pathname = nil)

--- a/lib/net/http/generic_request.rb
+++ b/lib/net/http/generic_request.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: false
-# HTTPGenericRequest is the parent of the HTTPRequest class.
-# Do not use this directly; use a subclass of HTTPRequest.
+# HTTPGenericRequest is the parent of the Net::HTTPRequest class.
+# Do not use this directly; use a subclass of Net::HTTPRequest.
 #
-# Mixes in the HTTPHeader module to provide easier access to HTTP headers.
+# Mixes in the Net::HTTPHeader module to provide easier access to HTTP headers.
 #
 class Net::HTTPGenericRequest
 

--- a/lib/net/http/response.rb
+++ b/lib/net/http/response.rb
@@ -8,11 +8,13 @@
 # header values both via hash-like methods and via individual readers.
 #
 # Note that each possible HTTP response code defines its own
-# HTTPResponse subclass.  These are listed below.
+# HTTPResponse subclass. All classes are defined under the Net module.
+# Indentation indicates inheritance.  For a list of the classes see Net::HTTP.
 #
-# All classes are defined under the Net module. Indentation indicates
-# inheritance.  For a list of the classes see Net::HTTP.
+# Correspondense <code>HTTP code => class</code> is stored in CODE_TO_OBJ
+# constant:
 #
+#    Net::HTTPResponse::CODE_TO_OBJ['404'] #=> Net::HTTPNotFound
 #
 class Net::HTTPResponse
   class << self
@@ -173,6 +175,10 @@ class Net::HTTPResponse
   #
   # If a block is given, the body is passed to the block, and
   # the body is provided in fragments, as it is read in from the socket.
+  #
+  # If +dest+ argument is given, response is read into that variable,
+  # with <code>dest#<<</code> method (it could be String or IO, or any
+  # other object responding to <code><<</code>).
   #
   # Calling this method a second or subsequent time for the same
   # HTTPResponse object will return the value already read.

--- a/lib/open-uri.rb
+++ b/lib/open-uri.rb
@@ -30,11 +30,11 @@ module URI
   # If the first argument responds to the 'open' method, 'open' is called on
   # it with the rest of the arguments.
   #
-  # If the first argument is a string that begins with xxx://, it is parsed by
+  # If the first argument is a string that begins with <code>(protocol)://<code>, it is parsed by
   # URI.parse.  If the parsed object responds to the 'open' method,
   # 'open' is called on it with the rest of the arguments.
   #
-  # Otherwise, the original Kernel#open is called.
+  # Otherwise, Kernel#open is called.
   #
   # OpenURI::OpenRead#open provides URI::HTTP#open, URI::HTTPS#open and
   # URI::FTP#open, Kernel#open.
@@ -62,14 +62,14 @@ end
 #
 # It is possible to open an http, https or ftp URL as though it were a file:
 #
-#   open("http://www.ruby-lang.org/") {|f|
+#   URI.open("http://www.ruby-lang.org/") {|f|
 #     f.each_line {|line| p line}
 #   }
 #
 # The opened file has several getter methods for its meta-information, as
 # follows, since it is extended by OpenURI::Meta.
 #
-#   open("http://www.ruby-lang.org/en") {|f|
+#   URI.open("http://www.ruby-lang.org/en") {|f|
 #     f.each_line {|line| p line}
 #     p f.base_uri         # <URI::HTTP:0x40e6ef2 URL:http://www.ruby-lang.org/en/>
 #     p f.content_type     # "text/html"
@@ -80,7 +80,7 @@ end
 #
 # Additional header fields can be specified by an optional hash argument.
 #
-#   open("http://www.ruby-lang.org/en/",
+#   URI.open("http://www.ruby-lang.org/en/",
 #     "User-Agent" => "Ruby/#{RUBY_VERSION}",
 #     "From" => "foo@bar.invalid",
 #     "Referer" => "http://www.ruby-lang.org/") {|f|
@@ -90,11 +90,11 @@ end
 # The environment variables such as http_proxy, https_proxy and ftp_proxy
 # are in effect by default. Here we disable proxy:
 #
-#   open("http://www.ruby-lang.org/en/", :proxy => nil) {|f|
+#   URI.open("http://www.ruby-lang.org/en/", :proxy => nil) {|f|
 #     # ...
 #   }
 #
-# See OpenURI::OpenRead.open and Kernel#open for more on available options.
+# See OpenURI::OpenRead.open and URI.open for more on available options.
 #
 # URI objects can be opened in a similar way.
 #

--- a/lib/optparse.rb
+++ b/lib/optparse.rb
@@ -169,7 +169,7 @@
 # - Array -- Strings separated by ',' (e.g. 1,2,3)
 # - Regexp -- Regular expressions. Also includes options.
 #
-# We can also add our own coercions, which we will cover soon.
+# We can also add our own coercions, which we will cover below.
 #
 # ==== Using Built-in Conversions
 #
@@ -1548,7 +1548,10 @@ XXX
 
   #
   # Parses command line arguments +argv+ in order. When a block is given,
-  # each non-option argument is yielded.
+  # each non-option argument is yielded. When optional +into+ keyword
+  # argument is provided, the parsed option values are stored there via
+  # <code>[]=</code> method (so it can be Hash, or OpenStruct, or other
+  # similar object).
   #
   # Returns the rest of +argv+ left unparsed.
   #
@@ -1644,7 +1647,10 @@ XXX
 
   #
   # Parses command line arguments +argv+ in permutation mode and returns
-  # list of non-option arguments.
+  # list of non-option arguments. When optional +into+ keyword
+  # argument is provided, the parsed option values are stored there via
+  # <code>[]=</code> method (so it can be Hash, or OpenStruct, or other
+  # similar object).
   #
   def permute(*argv, into: nil)
     argv = argv[0].dup if argv.size == 1 and Array === argv[0]
@@ -1665,6 +1671,9 @@ XXX
   #
   # Parses command line arguments +argv+ in order when environment variable
   # POSIXLY_CORRECT is set, and in permutation mode otherwise.
+  # When optional +into+ keyword argument is provided, the parsed option
+  # values are stored there via <code>[]=</code> method (so it can be Hash,
+  # or OpenStruct, or other similar object).
   #
   def parse(*argv, into: nil)
     argv = argv[0].dup if argv.size == 1 and Array === argv[0]


### PR DESCRIPTION
* Update ERB docs
  * Actualize Notes about other templating engines;
  * Document #location= method.
* Update StringIO docs:
  * More explanations/examples in class docs;
  * Fix links to other methods (remove `<code>` tag);
  * Fix wording of method docs (remove *stringio* receiver name, as it is not rendered by modern     RDoc);
  * Add `chomp:` option mention to linereading methods (added in 2.4);
  * Several other small fixes.
* IRB: Document command evaluation history.
* Net::FTP: fix formatting problems for #status method
* open-uri: change global docs to reflect that URI.open syntax is preferred
* OptionParser: document `into:` argument
* Improve Net::HTTP docs:
  * Make links from Net::GenericHTTPRequest work;
  * Document `dest` param of HTTPResponse#read_body;
  * Slightly improve reference to particular response classes from HTTPResponse class docs.