### PR TITLE
Correct documented return values for certain ENV methods

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -5830,7 +5830,7 @@ env_to_hash(void)
 
 /*
  * call-seq:
- *   ENV.to_hash -> Hash
+ *   ENV.to_hash -> hash
  *
  * Creates a hash with a copy of the environment variables.
  *
@@ -5844,8 +5844,8 @@ env_f_to_hash(VALUE _)
 
 /*
  * call-seq:
- *   ENV.to_h                        -> Hash
- *   ENV.to_h {|name, value| block } -> Hash
+ *   ENV.to_h                        -> hash
+ *   ENV.to_h {|name, value| block } -> hash
  *
  * Creates a hash with a copy of the environment variables.
  *

--- a/hash.c
+++ b/hash.c
@@ -5194,7 +5194,7 @@ rb_env_size(VALUE ehash, VALUE args, VALUE eobj)
 
 /*
  * call-seq:
- *   ENV.each_key { |name| block } -> Hash
+ *   ENV.each_key { |name| block } -> ENV
  *   ENV.each_key                  -> Enumerator
  *
  * Yields each environment variable name.
@@ -5249,7 +5249,7 @@ env_f_values(VALUE _)
 
 /*
  * call-seq:
- *   ENV.each_value { |value| block } -> Hash
+ *   ENV.each_value { |value| block } -> ENV
  *   ENV.each_value                   -> Enumerator
  *
  * Yields each environment variable +value+.
@@ -5351,7 +5351,7 @@ env_reject_bang(VALUE ehash)
 
 /*
  * call-seq:
- *   ENV.delete_if { |name, value| block } -> Hash
+ *   ENV.delete_if { |name, value| block } -> ENV
  *   ENV.delete_if                         -> Enumerator
  *
  * Deletes every environment variable for which the block evaluates to +true+.
@@ -5461,7 +5461,7 @@ env_select_bang(VALUE ehash)
 
 /*
  * call-seq:
- *   ENV.keep_if { |name, value| block } -> Hash
+ *   ENV.keep_if { |name, value| block } -> ENV
  *   ENV.keep_if                         -> Enumerator
  *
  * Deletes every environment variable where the block evaluates to +false+.
@@ -5830,7 +5830,7 @@ env_to_hash(void)
 
 /*
  * call-seq:
- *   ENV.to_hash -> hash
+ *   ENV.to_hash -> Hash
  *
  * Creates a hash with a copy of the environment variables.
  *
@@ -5844,8 +5844,8 @@ env_f_to_hash(VALUE _)
 
 /*
  * call-seq:
- *   ENV.to_h                        -> hash
- *   ENV.to_h {|name, value| block } -> hash
+ *   ENV.to_h                        -> Hash
+ *   ENV.to_h {|name, value| block } -> Hash
  *
  * Creates a hash with a copy of the environment variables.
  *
@@ -5975,10 +5975,10 @@ env_update_i(VALUE key, VALUE val, VALUE _)
 
 /*
  * call-seq:
- *   ENV.update(hash)                                        -> Hash
- *   ENV.update(hash) { |name, old_value, new_value| block } -> Hash
- *   ENV.merge!(hash)                                        -> Hash
- *   ENV.merge!(hash) { |name, old_value, new_value| block } -> Hash
+ *   ENV.update(hash)                                        -> ENV
+ *   ENV.update(hash) { |name, old_value, new_value| block } -> ENV
+ *   ENV.merge!(hash)                                        -> ENV
+ *   ENV.merge!(hash) { |name, old_value, new_value| block } -> ENV
  *
  * Adds the contents of +hash+ to the environment variables.  If no block is
  * specified entries with duplicate keys are overwritten, otherwise the value


### PR DESCRIPTION
To verify, paste this into irb:

ENV.each_key { |k| } == ENV
ENV.each_value { |v| } == ENV
ENV.delete_if { |k, v| false } == ENV
ENV.keep_if { |k, v| true } == ENV
ENV.update({}) == ENV
ENV.update({}) { |name, old, new | new } == ENV
ENV.merge!({}) == ENV
ENV.merge!({}) { |name, old, new | new } == ENV