### PR TITLE
Wrap "call data" with an IMEMO object

### DIFF
--- a/ext/objspace/objspace.c
+++ b/ext/objspace/objspace.c
@@ -634,6 +634,7 @@ count_imemo_objects(int argc, VALUE *argv, VALUE self)
 	imemo_type_ids[8] = rb_intern("imemo_tmpbuf");
         imemo_type_ids[9] = rb_intern("imemo_ast");
         imemo_type_ids[10] = rb_intern("imemo_parser_strterm");
+        imemo_type_ids[11] = rb_intern("imemo_call_data");
     }
 
     rb_objspace_each_objects(count_imemo_objects_i, (void *)hash);

--- a/ext/objspace/objspace_dump.c
+++ b/ext/objspace/objspace_dump.c
@@ -208,6 +208,7 @@ imemo_name(int imemo)
 	TYPE_STR(tmpbuf);
 	TYPE_STR(ast);
 	TYPE_STR(parser_strterm);
+	TYPE_STR(call_data);
       default:
 	return "unknown";
 #undef TYPE_STR

--- a/gc.c
+++ b/gc.c
@@ -2338,6 +2338,7 @@ imemo_memsize(VALUE obj)
       case imemo_ifunc:
       case imemo_memo:
       case imemo_parser_strterm:
+      case imemo_call_data:
         break;
       default:
         /* unreachable */
@@ -2825,6 +2826,9 @@ obj_free(rb_objspace_t *objspace, VALUE obj)
             break;
           case imemo_parser_strterm:
             RB_DEBUG_COUNTER_INC(obj_imemo_parser_strterm);
+            break;
+          case imemo_call_data:
+            RB_DEBUG_COUNTER_INC(obj_imemo_call_data);
             break;
 	  default:
             /* unreachable */
@@ -5226,6 +5230,8 @@ gc_mark_imemo(rb_objspace_t *objspace, VALUE obj)
 	return;
       case imemo_parser_strterm:
 	rb_strterm_mark(obj);
+	return;
+      case imemo_call_data:
 	return;
 #if VM_CHECK_MODE > 0
       default:
@@ -8095,6 +8101,7 @@ gc_ref_update_imemo(rb_objspace_t *objspace, VALUE obj)
         break;
       case imemo_parser_strterm:
       case imemo_tmpbuf:
+      case imemo_call_data:
         break;
       default:
         rb_bug("not reachable %d", imemo_type(obj));


### PR DESCRIPTION
Currently, compaction will invalidate all inline caches.  I would like
to update the compactor to fix references in inline caches.
Unfortunately this static variable is not reachable from the GC.  This
commit introduces a "call data" imemo type to wrap the call data.  This
way the GC can see the static call data variable and update its
references.