### PR TITLE
Clang can also use C call cache

### DIFF
--- a/internal.h
+++ b/internal.h
@@ -2388,7 +2388,7 @@ struct rb_call_data {
     struct rb_call_info ci;
 };
 VALUE rb_funcallv_with_cc(struct rb_call_data*, VALUE, ID, int, const VALUE*)
-#if GCC_VERSION_SINCE(3, 3, 0) && defined(__OPTIMIZE__)
+#if (defined(__clang__) || GCC_VERSION_SINCE(3, 3, 0)) && defined(__OPTIMIZE__)
 __attribute__((__visibility__("default"), __nonnull__(1)))
 # define rb_funcallv(recv, mid, argc, argv) \
     __extension__({ \


### PR DESCRIPTION
Previously this was restricted to only gcc because of the GCC_VERSION_SINCE check (which explicitly excludes clang).

GCC 3.3.0 is quite old so I feel relatively safe assuming that all reasonable versions of clang support this.

EDIT: it seems to be compatible at least as far back as clang 3.0.0 (the oldest version on godbolt)

I get similar numbers to https://github.com/ruby/ruby/pull/2627#issuecomment-547196541, with the same benchmark

```
Warming up --------------------------------------
                grep    51.002k i/100ms
Calculating -------------------------------------
                grep    591.171k (± 4.9%) i/s -      2.958M in   5.017473s
```

```
Warming up --------------------------------------
                grep    70.983k i/100ms
Calculating -------------------------------------
                grep    856.779k (± 1.5%) i/s -      4.330M in   5.054946s
```

cc @tenderlove I don't know if you want to fold this into #2627 ❤️