### PR TITLE
[fix] added docs about :decimal_class option (was undocumented)

### DIFF
--- a/ext/json/parser/parser.c
+++ b/ext/json/parser/parser.c
@@ -1740,6 +1740,7 @@ static VALUE convert_encoding(VALUE source)
  *   defaults to false.
  * * *object_class*: Defaults to Hash
  * * *array_class*: Defaults to Array
+ * * *decimal_class*: Defaults to Float, also supports BigDecimal as value
  */
 static VALUE cParser_initialize(int argc, VALUE *argv, VALUE self)
 {

--- a/ext/json/parser/parser.rl
+++ b/ext/json/parser/parser.rl
@@ -635,6 +635,7 @@ static VALUE convert_encoding(VALUE source)
  *   defaults to false.
  * * *object_class*: Defaults to Hash
  * * *array_class*: Defaults to Array
+ * * *decimal_class*: Defaults to Float, also supports BigDecimal as value
  */
 static VALUE cParser_initialize(int argc, VALUE *argv, VALUE self)
 {


### PR DESCRIPTION
As I had trouble finding information about numerals handling when parsing json, just added the docs for a undocumented option called `decimal_class`.