### PR TITLE
array.c: eql? optimization (8x speedup, benchmark build provided)

### DIFF
--- a/array.c
+++ b/array.c
@@ -4275,12 +4275,22 @@ rb_ary_equal(VALUE ary1, VALUE ary2)
 static VALUE
 recursive_eql(VALUE ary1, VALUE ary2, int recur)
 {
-    long i;
+    long i, len;
+    const VALUE *p1, *p2;
 
     if (recur) return Qtrue; /* Subtle! */
-    for (i=0; i<RARRAY_LEN(ary1); i++) {
-	if (!rb_eql(rb_ary_elt(ary1, i), rb_ary_elt(ary2, i)))
-	    return Qfalse;
+
+    len = RARRAY_LEN(ary1);
+
+    p1 = RARRAY_CONST_PTR(ary1);
+    p2 = RARRAY_CONST_PTR(ary2);
+    for (i=0; i<len; i++) {
+	if ((!IMMEDIATE_P(*p1)) || (*p1 != *p2)) {
+	    if (!rb_eql(*p1, *p2))
+		return Qfalse;
+	}
+	p1++;
+	p2++;
     }
     return Qtrue;
 }


### PR DESCRIPTION
Reopening this PR now rebased with master: https://github.com/ruby/ruby/pull/1206

*If I need to make a redmine ticket for this, please let me know, will gladly do so*. This is an optimization PR and provides no functional changes however.

Historically this provided a 49x speedup (see benchmark in previous PR), but running this now on my laptop against a 2.7dev build provides an 8x speedup when the objects are equal. 

Link to build with both methods and benchmark code: https://github.com/ruby/ruby/compare/master...dwfait:array-eql-bench?expand=1

Benchmarks run on my local machine: https://gist.github.com/dwfait/db7f7e077353b9cce0d70ae1f6bb638b

In the previous PR there was a concern that my patch made `[Float::NAN].eql? [Float::NAN]` equal true, but it appears that this has been introduced anyway in another modification to rb_eql.

Irb for ruby 2.6.2: 
```
irb(main):001:0> [Float::NAN].eql? [Float::NAN]                                                                                                                                                                                  
=> true   
```
