### PR TITLE
Allow only one argument for keyword_init struct

### DIFF
--- a/struct.c
+++ b/struct.c
@@ -633,7 +633,7 @@ rb_struct_initialize_m(int argc, const VALUE *argv, VALUE self)
     n = num_members(klass);
     if (argc > 0 && RTEST(rb_struct_s_keyword_init(klass))) {
 	struct struct_hash_set_arg arg;
-	if (argc > 2 || !RB_TYPE_P(argv[0], T_HASH)) {
+	if (argc > 1 || !RB_TYPE_P(argv[0], T_HASH)) {
 	    rb_raise(rb_eArgError, "wrong number of arguments (given %d, expected 0)", argc);
 	}
 	rb_mem_clear((VALUE *)RSTRUCT_CONST_PTR(self), n);

--- a/test/ruby/test_struct.rb
+++ b/test/ruby/test_struct.rb
@@ -105,6 +105,7 @@ module TestStruct
     @Struct.new("KeywordInitFalse", :a, :b, keyword_init: false)
 
     assert_raise(ArgumentError) { @Struct::KeywordInitTrue.new(1, 2) }
+    assert_raise(ArgumentError) { @Struct::KeywordInitTrue.new({a: 100}, 2) }
     assert_nothing_raised { @Struct::KeywordInitFalse.new(1, 2) }
     assert_nothing_raised { @Struct::KeywordInitTrue.new(a: 1, b: 2) }
     assert_raise(ArgumentError) { @Struct::KeywordInitTrue.new(1, b: 2) }


### PR DESCRIPTION
```
irb(main):001:0> RUBY_VERSION
=> "2.6.5"
irb(main):002:0> S = Struct.new(:foo, keyword_init: true)
=> S(keyword_init: true)
irb(main):003:0> S.new({foo: 23424}, 234) # I don't think this is intentional
=> #<struct S foo=23424>
irb(main):004:0>
```

Tightening this up should inform users when they are confused about
whether a struct is `keyword_init`.