### PR TITLE
Revert nil error and adding deprecation message

### DIFF
--- a/re.c
+++ b/re.c
@@ -3323,7 +3323,9 @@ rb_reg_match_m(int argc, VALUE *argv, VALUE re)
 	pos = 0;
     }
 
-    str = SYMBOL_P(str) ? rb_sym2str(str) : StringValue(str);
+    if (NIL_P(str)) {
+        rb_warn("given argument is nil");
+    }
     pos = reg_match_pos(re, &str, pos);
     if (pos < 0) {
 	rb_backref_set(Qnil);
@@ -3369,6 +3371,10 @@ rb_reg_match_p(VALUE re, VALUE str, long pos)
     const UChar *start, *end;
     int tmpreg;
 
+    if (NIL_P(str)) {
+        rb_warn("given argument is nil");
+        return Qfalse;
+    }
     str = SYMBOL_P(str) ? rb_sym2str(str) : StringValue(str);
     if (pos) {
 	if (pos < 0) {

--- a/re.c
+++ b/re.c
@@ -3324,7 +3324,7 @@ rb_reg_match_m(int argc, VALUE *argv, VALUE re)
     }
 
     if (NIL_P(str)) {
-        rb_warn("given argument is nil");
+        rb_warn("given argument is nil; this will raise a TypeError in the next release");
     }
     pos = reg_match_pos(re, &str, pos);
     if (pos < 0) {
@@ -3372,7 +3372,7 @@ rb_reg_match_p(VALUE re, VALUE str, long pos)
     int tmpreg;
 
     if (NIL_P(str)) {
-        rb_warn("given argument is nil");
+        rb_warn("given argument is nil; this will raise a TypeError in the next release");
         return Qfalse;
     }
     str = SYMBOL_P(str) ? rb_sym2str(str) : StringValue(str);

--- a/spec/ruby/core/regexp/match_spec.rb
+++ b/spec/ruby/core/regexp/match_spec.rb
@@ -87,7 +87,7 @@ describe "Regexp#match" do
     end
   end
 
-  ruby_version_is ""..."2.7" do
+  ruby_version_is ""..."3.0" do
     it "resets $~ if passed nil" do
       # set $~
       /./.match("a")
@@ -98,7 +98,13 @@ describe "Regexp#match" do
     end
   end
 
-  ruby_version_is "2.7" do
+  ruby_version_is "2.7"..."3.0" do
+    it "warns the deprecation when the given argument is nil" do
+      -> { /foo/.match(nil) }.should complain(/given argument is nil/)
+    end
+  end
+
+  ruby_version_is "3.0" do
     it "raises TypeError when the given argument is nil" do
       -> { /foo/.match(nil) }.should raise_error(TypeError)
     end
@@ -137,13 +143,19 @@ describe "Regexp#match?" do
     /str/i.match?('string', 1).should be_false
   end
 
-  ruby_version_is ""..."2.7" do
+  ruby_version_is ""..."3.0" do
     it "returns false when given nil" do
       /./.match?(nil).should be_false
     end
   end
 
-  ruby_version_is "2.7" do
+  ruby_version_is "2.7"..."3.0" do
+    it "warns the deprecation" do
+      -> { /./.match?(nil) }.should complain(/given argument is nil/)
+    end
+  end
+
+  ruby_version_is "3.0" do
     it "raises TypeError when given nil" do
       -> { /./.match?(nil) }.should raise_error(TypeError)
     end

--- a/spec/ruby/core/regexp/match_spec.rb
+++ b/spec/ruby/core/regexp/match_spec.rb
@@ -100,7 +100,7 @@ describe "Regexp#match" do
 
   ruby_version_is "2.7"..."3.0" do
     it "warns the deprecation when the given argument is nil" do
-      -> { /foo/.match(nil) }.should complain(/given argument is nil/)
+      -> { /foo/.match(nil) }.should complain(/given argument is nil; this will raise a TypeError in the next release/)
     end
   end
 
@@ -151,7 +151,7 @@ describe "Regexp#match?" do
 
   ruby_version_is "2.7"..."3.0" do
     it "warns the deprecation" do
-      -> { /./.match?(nil) }.should complain(/given argument is nil/)
+      -> { /./.match?(nil) }.should complain(/given argument is nil; this will raise a TypeError in the next release/)
     end
   end
 

--- a/test/ruby/test_regexp.rb
+++ b/test/ruby/test_regexp.rb
@@ -539,7 +539,7 @@ class TestRegexp < Test::Unit::TestCase
   end
 
   def test_match
-    assert_raise(TypeError) { //.match(nil) }
+    assert_nil(//.match(nil))
     assert_equal("abc", /.../.match(:abc)[0])
     assert_raise(TypeError) { /.../.match(Object.new)[0] }
     assert_equal("bc", /../.match('abc', 1)[0])
@@ -561,10 +561,10 @@ class TestRegexp < Test::Unit::TestCase
     /backref/ =~ 'backref'
     # must match here, but not in a separate method, e.g., assert_send,
     # to check if $~ is affected or not.
+    assert_equal(false, //.match?(nil))
     assert_equal(true, //.match?(""))
     assert_equal(true, /.../.match?(:abc))
     assert_raise(TypeError) { /.../.match?(Object.new) }
-    assert_raise(TypeError) { //.match?(nil) }
     assert_equal(true, /b/.match?('abc'))
     assert_equal(true, /b/.match?('abc', 1))
     assert_equal(true, /../.match?('abc', 1))


### PR DESCRIPTION
ticket: https://bugs.ruby-lang.org/issues/13083

This revert https://github.com/ruby/ruby/pull/1506 and  warns for now.

@rafaelfranca How about this?