### PR TITLE
Use a monotonically increasing number for object_id

### DIFF
--- a/bootstraptest/test_objectspace.rb
+++ b/bootstraptest/test_objectspace.rb
@@ -44,3 +44,12 @@ assert_normal_exit %q{
     Thread.new {}
   end
 }, '[ruby-core:37858]'
+
+assert_equal 'ok', %q{
+  objects_and_ids = 1000.times.map { o = Object.new; [o, o.object_id] }
+  objects_and_ids.each { |expected, id|
+    actual = ObjectSpace._id2ref(id)
+    raise "expected #{expected.inspect}, got #{actual.inspect}" unless actual.equal?(expected)
+  }
+  'ok'
+}

--- a/hash.c
+++ b/hash.c
@@ -273,10 +273,14 @@ rb_objid_hash(st_index_t index)
 static st_index_t
 objid_hash(VALUE obj)
 {
+    VALUE object_id = rb_obj_id(obj);
+    if (!FIXNUM_P(object_id))
+        object_id = rb_big_hash(object_id);
+
 #if SIZEOF_LONG == SIZEOF_VOIDP
-    return (st_index_t)st_index_hash((st_index_t)NUM2LONG(rb_obj_id(obj)));
+    return (st_index_t)st_index_hash((st_index_t)NUM2LONG(object_id));
 #elif SIZEOF_LONG_LONG == SIZEOF_VOIDP
-    return (st_index_t)st_index_hash((st_index_t)NUM2LL(rb_obj_id(obj)));
+    return (st_index_t)st_index_hash((st_index_t)NUM2LL(object_id));
 #endif
 }
 

--- a/test/ruby/test_gc.rb
+++ b/test/ruby/test_gc.rb
@@ -461,4 +461,12 @@ class TestGc < Test::Unit::TestCase
     skip "finalizers did not get run" if @result.empty?
     assert_equal([:c1, :c2], @result)
   end
+
+  def test_object_ids_never_repeat
+    GC.start
+    a = 1000.times.map { Object.new.object_id }
+    GC.start
+    b = 1000.times.map { Object.new.object_id }
+    assert_empty(a & b)
+  end
 end

--- a/test/ruby/test_gc_compact.rb
+++ b/test/ruby/test_gc_compact.rb
@@ -7,13 +7,6 @@ class TestGCCompact < Test::Unit::TestCase
     (Fiddle.dlwrap(obj) >> 1)
   end
 
-  def assert_object_ids(list)
-    same_count = list.find_all { |obj|
-      memory_location(obj) == obj.object_id
-    }.count
-    list.count - same_count
-  end
-
   def big_list(level = 10)
     if level > 0
       big_list(level - 1)
@@ -39,89 +32,6 @@ class TestGCCompact < Test::Unit::TestCase
     end
 
     new_object
-  end
-
-  def try_to_move_objects
-    10.times do
-      list_of_objects = big_list
-
-      ids       = list_of_objects.map(&:object_id) # store id in map
-      addresses = list_of_objects.map(&self.:memory_location)
-
-      assert_equal ids, addresses
-
-      # All object ids should be equal
-      assert_equal 0, assert_object_ids(list_of_objects) # should be 0
-
-      GC.verify_compaction_references(toward: :empty)
-
-      # Some should have moved
-      id_count = assert_object_ids(list_of_objects)
-      skip "couldn't get objects to move" if id_count == 0
-      assert_operator id_count, :>, 0
-
-      new_ids = list_of_objects.map(&:object_id)
-
-      # Object ids should not change after compaction
-      assert_equal ids, new_ids
-
-      new_tenant = find_object_in_recycled_slot(addresses)
-      return [list_of_objects, addresses, new_tenant] if new_tenant
-    end
-
-    flunk "Couldn't get objects to move"
-  end
-
-  def test_find_collided_object
-    skip "figure out how to guarantee move"
-
-    list_of_objects, addresses, new_tenant = try_to_move_objects
-
-    # This is the object that used to be in new_object's position
-    loc = memory_location(new_tenant)
-    assert loc, "should have a memory location"
-
-    if (ENV['TRAVIS'] && RUBY_PLATFORM =~ /darwin/)
-      skip "tests are failing on Travis osx / Wercker from here"
-    end
-
-    address_idx = addresses.index(loc)
-    assert address_idx, "should have an address index"
-
-    previous_tenant = list_of_objects[address_idx]
-    assert previous_tenant, "should have a previous tenant"
-
-    assert_not_equal previous_tenant.object_id, new_tenant.object_id
-
-    # Should be able to look up object by object_id
-    assert_equal new_tenant, ObjectSpace._id2ref(new_tenant.object_id)
-
-    # Should be able to look up object by object_id
-    assert_equal previous_tenant, ObjectSpace._id2ref(previous_tenant.object_id)
-
-    int = (new_tenant.object_id >> 1)
-    # These two should be the same! but they are not :(
-    assert_equal int, ObjectSpace._id2ref(int.object_id)
-  end
-
-  def test_many_collisions
-    list_of_objects = big_list
-    ids       = list_of_objects.map(&:object_id)
-    addresses = list_of_objects.map(&self.:memory_location)
-
-    GC.verify_compaction_references(toward: :empty)
-
-    skip "time consuming"
-
-    new_tenants = 10.times.map {
-      find_object_in_recycled_slot(addresses)
-    }
-
-    collisions = GC.stat(:object_id_collisions)
-    skip "couldn't get objects to collide" if collisions == 0
-    assert_operator collisions, :>, 0
-    ids.clear
-    new_tenants.clear
   end
 
   def test_complex_hash_keys


### PR DESCRIPTION
This changes object_id from being based on the objects location in
memory (or a nearby memory location in the case of a conflict) to be
based on an always increasing number.

This number is a Ruby Integer which allows it to overflow the size of a
pointer without issue (very unlikely to happen in real programs
especially on 64-bit, but a nice guarantee).

This changes obj_to_id_tbl and id_to_obj_tbl to both be maps of Ruby
objects to Ruby objects (previously they were Ruby object to C integer)
which simplifies updating them after compaction as we can run them
through gc_update_table_refs.