### PR TITLE
Fix coroutine support on win32

### DIFF
--- a/coroutine/win32/Context.h
+++ b/coroutine/win32/Context.h
@@ -42,7 +42,7 @@ static inline void coroutine_initialize(
     *--context->stack_pointer = (void*)start;
 
     /* Windows Thread Information Block */
-    *--context->stack_pointer = 0; /* fs:[0] */
+    *--context->stack_pointer = (void*)0xFFFFFFFF; /* fs:[0] */
     *--context->stack_pointer = (void*)top; /* fs:[4] */
     *--context->stack_pointer = (void*)stack;  /* fs:[8] */
 


### PR DESCRIPTION
Ruby master branch currently fails on Windows MINGW 32 bit at this spec: https://github.com/ruby/spec/blob/master/core/thread/element_set_spec.rb

It took me several hours to find the root cause: `__builtin_setjmp()` on MINGW makes use of `setjmp3()` implemented in `MSVCRT.DLL`. This function traverses the SEH list up to a terminating pointer 0xFFFFFFFF. It therefore currently segfaults on NULL. The SEH linked list must be terminated by 0xFFFFFFFF instead of NULL.

Possibly 32 bit MSVC is also affected. At least there are [posts that describe this SEH mechanism](https://blog.osom.info/2012/04/simple-structured-exception-handling.html) as a generic Windows mechanism (not MINGW specific).

This fixes the issue mentioned here: https://github.com/ruby/ruby/pull/2279#issuecomment-509508810