### PR TITLE
Do not occupy `ARGV` by XRUBY command

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1295,7 +1295,7 @@ no-test-bundled-gems:
 # TEST_BUNDLED_GEMS_ALLOW_FAILURES =
 
 test-bundled-gems-run: $(PREPARE_BUNDLED_GEMS)
-	$(Q) $(XRUBY) $(srcdir)/tool/test-bundled-gems.rb $(XRUBY)
+	$(Q) $(XRUBY) $(srcdir)/tool/test-bundled-gems.rb
 
 test-bundler-precheck: $(arch)-fake.rb programs
 

--- a/tool/test-bundled-gems.rb
+++ b/tool/test-bundled-gems.rb
@@ -5,12 +5,13 @@ allowed_failures = allowed_failures.split(',').reject(&:empty?)
 
 gem_dir = File.expand_path('../../gems', __FILE__)
 exit_code = 0
+ruby = ENV['RUBY'] || RbConfig.ruby
 File.foreach("#{gem_dir}/bundled_gems") do |line|
   gem = line.split.first
   puts "\nTesting the #{gem} gem"
 
   gem_src_dir = File.expand_path("#{gem_dir}/src/#{gem}", __FILE__)
-  test_command = "#{ARGV.join(' ')} -C #{gem_src_dir} -Ilib ../../../.bundle/bin/rake"
+  test_command = "#{ruby} -C #{gem_src_dir} -Ilib ../../../.bundle/bin/rake"
   puts test_command
   system test_command
 


### PR DESCRIPTION
Instead run test-bundled-gems.rb by `ENV['RUBY']`, which should be set by runruby.rb.