### PR TITLE
Avoid top-level search for nested constant reference from nil in defined?

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -4728,13 +4728,13 @@ defined_expr0(rb_iseq_t *iseq, LINK_ANCHOR *const ret,
 
         ADD_INSN3(ret, line, defined,
 		  (rb_is_const_id(node->nd_mid) ?
-		   INT2FIX(DEFINED_CONST) : INT2FIX(DEFINED_METHOD)),
+		   INT2FIX(DEFINED_CONST_FROM) : INT2FIX(DEFINED_METHOD)),
 		  ID2SYM(node->nd_mid), needstr);
         return;
       case NODE_COLON3:
         ADD_INSN1(ret, line, putobject, rb_cObject);
         ADD_INSN3(ret, line, defined,
-		  INT2FIX(DEFINED_CONST), ID2SYM(node->nd_mid), needstr);
+		  INT2FIX(DEFINED_CONST_FROM), ID2SYM(node->nd_mid), needstr);
         return;
 
 	/* method dispatch */
@@ -7495,7 +7495,7 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
 	if (node->nd_aid == idOROP) {
 	    lassign = NEW_LABEL(line);
 	    ADD_INSN(ret, line, dup); /* cref cref */
-	    ADD_INSN3(ret, line, defined, INT2FIX(DEFINED_CONST),
+	    ADD_INSN3(ret, line, defined, INT2FIX(DEFINED_CONST_FROM),
 		      ID2SYM(mid), Qfalse); /* cref bool */
 	    ADD_INSNL(ret, line, branchunless, lassign); /* cref */
 	}

--- a/iseq.c
+++ b/iseq.c
@@ -1830,13 +1830,20 @@ rb_insn_operand_intern(const rb_iseq_t *iseq,
       case TS_NUM:		/* ULONG */
 	if (insn == BIN(defined) && op_no == 0) {
 	    enum defined_type deftype = (enum defined_type)op;
-	    if (deftype == DEFINED_FUNC) {
-		ret = rb_fstring_lit("func"); break;
+	    switch (deftype) {
+	      case DEFINED_FUNC:
+		ret = rb_fstring_lit("func");
+		break;
+	      case DEFINED_REF:
+		ret = rb_fstring_lit("ref");
+		break;
+	      case DEFINED_CONST_FROM:
+		ret = rb_fstring_lit("constant-from");
+		break;
+	      default:
+		ret = rb_iseq_defined_string(deftype);
+		break;
 	    }
-	    if (deftype == DEFINED_REF) {
-		ret = rb_fstring_lit("ref"); break;
-	    }
-	    ret = rb_iseq_defined_string(deftype);
 	    if (ret) break;
 	}
 	else if (insn == BIN(checktype) && op_no == 0) {

--- a/iseq.h
+++ b/iseq.h
@@ -300,7 +300,8 @@ enum defined_type {
     DEFINED_EXPR,
     DEFINED_IVAR2,
     DEFINED_REF,
-    DEFINED_FUNC
+    DEFINED_FUNC,
+    DEFINED_CONST_FROM
 };
 
 VALUE rb_iseq_defined_string(enum defined_type type);

--- a/template/Makefile.in
+++ b/template/Makefile.in
@@ -581,7 +581,52 @@ INSNS	= opt_sc.inc optinsn.inc optunifs.inc insns.inc insns_info.inc \
 
 $(INSNS): $(srcdir)/insns.def vm_opts.h \
 	  $(srcdir)/defs/opt_operand.def $(srcdir)/defs/opt_insn_unif.def \
-	  $(srcdir)/tool/insns2vm.rb
+	  $(srcdir)/tool/insns2vm.rb \
+	  $(srcdir)/tool/ruby_vm/controllers/application_controller.rb \
+	  $(srcdir)/tool/ruby_vm/helpers/c_escape.rb \
+	  $(srcdir)/tool/ruby_vm/helpers/dumper.rb \
+	  $(srcdir)/tool/ruby_vm/helpers/scanner.rb \
+	  $(srcdir)/tool/ruby_vm/loaders/insns_def.rb \
+	  $(srcdir)/tool/ruby_vm/loaders/opt_insn_unif_def.rb \
+	  $(srcdir)/tool/ruby_vm/loaders/opt_operand_def.rb \
+	  $(srcdir)/tool/ruby_vm/loaders/vm_opts_h.rb \
+	  $(srcdir)/tool/ruby_vm/models/attribute.rb \
+	  $(srcdir)/tool/ruby_vm/models/bare_instructions.rb \
+	  $(srcdir)/tool/ruby_vm/models/c_expr.rb \
+	  $(srcdir)/tool/ruby_vm/models/instructions.rb \
+	  $(srcdir)/tool/ruby_vm/models/instructions_unifications.rb \
+	  $(srcdir)/tool/ruby_vm/models/operands_unifications.rb \
+	  $(srcdir)/tool/ruby_vm/models/trace_instructions.rb \
+	  $(srcdir)/tool/ruby_vm/models/typemap.rb \
+	  $(srcdir)/tool/ruby_vm/scripts/converter.rb \
+	  $(srcdir)/tool/ruby_vm/scripts/insns2vm.rb \
+	  $(srcdir)/tool/ruby_vm/views/_attributes.erb \
+	  $(srcdir)/tool/ruby_vm/views/_c_expr.erb \
+	  $(srcdir)/tool/ruby_vm/views/_comptime_insn_stack_increase.erb \
+	  $(srcdir)/tool/ruby_vm/views/_copyright.erb \
+	  $(srcdir)/tool/ruby_vm/views/_insn_entry.erb \
+	  $(srcdir)/tool/ruby_vm/views/_insn_len_info.erb \
+	  $(srcdir)/tool/ruby_vm/views/_insn_name_info.erb \
+	  $(srcdir)/tool/ruby_vm/views/_insn_operand_info.erb \
+	  $(srcdir)/tool/ruby_vm/views/_insn_sp_pc_dependency.erb \
+	  $(srcdir)/tool/ruby_vm/views/_insn_type_chars.erb \
+	  $(srcdir)/tool/ruby_vm/views/_leaf_helpers.erb \
+	  $(srcdir)/tool/ruby_vm/views/_mjit_compile_insn.erb \
+	  $(srcdir)/tool/ruby_vm/views/_mjit_compile_insn_body.erb \
+	  $(srcdir)/tool/ruby_vm/views/_mjit_compile_ivar.erb \
+	  $(srcdir)/tool/ruby_vm/views/_mjit_compile_pc_and_sp.erb \
+	  $(srcdir)/tool/ruby_vm/views/_mjit_compile_send.erb \
+	  $(srcdir)/tool/ruby_vm/views/_notice.erb \
+	  $(srcdir)/tool/ruby_vm/views/_sp_inc_helpers.erb \
+	  $(srcdir)/tool/ruby_vm/views/_trace_instruction.erb \
+	  $(srcdir)/tool/ruby_vm/views/insns.inc.erb \
+	  $(srcdir)/tool/ruby_vm/views/insns_info.inc.erb \
+	  $(srcdir)/tool/ruby_vm/views/mjit_compile.inc.erb \
+	  $(srcdir)/tool/ruby_vm/views/opt_sc.inc.erb \
+	  $(srcdir)/tool/ruby_vm/views/optinsn.inc.erb \
+	  $(srcdir)/tool/ruby_vm/views/optunifs.inc.erb \
+	  $(srcdir)/tool/ruby_vm/views/vm.inc.erb \
+	  $(srcdir)/tool/ruby_vm/views/vmtc.inc.erb
 	$(ECHO) generating $@
 	$(Q) $(BASERUBY) -Ku $(srcdir)/tool/insns2vm.rb $(INSNS2VMOPT) $@
 

--- a/test/ruby/test_const.rb
+++ b/test/ruby/test_const.rb
@@ -50,8 +50,13 @@ class TestConst < Test::Unit::TestCase
 
   def test_const_access_from_nil
     assert_raise(TypeError) { eval("nil::Object") }
+    assert_nil eval("defined?(nil::Object)")
+
     assert_raise(TypeError) { eval("c = nil; c::Object") }
+    assert_nil eval("c = nil; defined?(c::Object)")
+
     assert_raise(TypeError) { eval("sc = Class.new; sc::C = nil; sc::C::Object") }
+    assert_nil eval("sc = Class.new; sc::C = nil; defined?(sc::C::Object)")
   end
 
   def test_redefinition

--- a/tool/ruby_vm/views/_leaf_helpers.erb
+++ b/tool/ruby_vm/views/_leaf_helpers.erb
@@ -81,6 +81,7 @@ leafness_of_defined(rb_num_t op_type)
       case DEFINED_ZSUPER:
         return false;
       case DEFINED_CONST:
+      case DEFINED_CONST_FROM:
         /* has rb_autoload_load(); */
         return false;
       case DEFINED_FUNC:

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -3477,11 +3477,14 @@ vm_defined(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, rb_num_t op_
 	break;
       }
       case DEFINED_CONST:
+      case DEFINED_CONST_FROM: {
+	bool allow_nil = type == DEFINED_CONST;
 	klass = v;
-        if (vm_get_ev_const(ec, klass, SYM2ID(obj), 1, 1)) {
+        if (vm_get_ev_const(ec, klass, SYM2ID(obj), allow_nil, true)) {
 	    expr_type = DEFINED_CONST;
 	}
 	break;
+      }
       case DEFINED_FUNC:
 	klass = CLASS_OF(v);
 	if (rb_method_boundp(klass, SYM2ID(obj), 0)) {


### PR DESCRIPTION
This is a fix for https://bugs.ruby-lang.org/issues/16332 which describes the problem

> The fix for https://bugs.ruby-lang.org/issues/11718 to disallow constant access through `nil` (e.g. `nil::CONSTANT`) didn't make a corresponding change for `defined?`.
>
> This inconsistency can be seen with the example `nil::Object`, which will raise `TypeError`, even though `defined?(nil::Object)` returns `"constant"`. I believe that `defined?(nil::Object)` should behave the same way as checking if a constant is defined on any other non-namespace object (e.g. `defined?(1::Object)`), which currently returns `nil`.

The first commit in this PR fixes this behaviour so that `defined?(nil::Object)` returns `nil`.

An additional parameter was added to the `getconstant` instruction to change its behaviour, which didn't seem appropriate for the `defined` instruction, so I instead added another defined type to distinguish between a constant referenced from the current lexical scope and one referenced from another namespace.

I found that `make` wasn't picking up my change to `tool/ruby_vm/views/_leaf_helpers.erb`, so I added the missing dependencies of `tool/insns2vm.rb ` in Makefile.in in the second commit in this PR