### PR TITLE
Exit if cd fails for some reason.

### DIFF
--- a/tool/bisect.sh
+++ b/tool/bisect.sh
@@ -16,7 +16,7 @@ case $1 in
     path="$builddir/_bisect.sh"
     echo "path: $path"
     cp "$0" "$path"
-    cd "$srcdir"
+    cd "$srcdir" || exit 125
     set -x
     exec git bisect run "$path" "run-$1"
     ;;


### PR DESCRIPTION
If cd fails for some reason (e.g. didn't exist file), exit without further execution.