### PR TITLE
Fix builtin scirpt paths

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -985,11 +985,11 @@ $(srcs_vpath)mjit_compile.inc: $(srcdir)/tool/ruby_vm/views/mjit_compile.inc.erb
   $(srcdir)/tool/ruby_vm/views/_mjit_compile_insn_body.erb $(srcdir)/tool/ruby_vm/views/_mjit_compile_pc_and_sp.erb
 
 BUILTIN_RB_SRCS = \
-		$(srcs_vpath)ast.rb \
-		$(srcs_vpath)gc.rb \
-		$(srcs_vpath)io.rb \
-		$(srcs_vpath)pack.rb \
-		$(srcs_vpath)trace_point.rb \
+		$(srcdir)/ast.rb \
+		$(srcdir)/gc.rb \
+		$(srcdir)/io.rb \
+		$(srcdir)/pack.rb \
+		$(srcdir)/trace_point.rb \
 		$(empty)
 BUILTIN_RB_INCS = $(BUILTIN_RB_SRCS:.rb=.rbinc)
 
@@ -1104,7 +1104,7 @@ preludes: {$(VPATH)}prelude.c
 preludes: {$(VPATH)}miniprelude.c
 preludes: {$(srcdir)}golf_prelude.c
 
-.rb.rbinc:
+{$(srcdir)}.rb.rbinc:
 	$(ECHO) making $@
 	$(Q) $(BASERUBY) $(srcdir)/tool/mk_builtin_loader.rb $<
 

--- a/win32/Makefile.sub
+++ b/win32/Makefile.sub
@@ -1284,9 +1284,6 @@ $(ruby_pc): $(RBCONFIG)
 	$(ECHO) preprocessing $(<:\=/)
 	$(Q) $(CC) $(XCFLAGS) $(CPPFLAGS) -P $(CSRCFLAG)$(<:\=/)
 
-{$(srcdir)}.rb.rbinc:
-	$(Q) $(BASERUBY) $(srcdir)/tool/mk_builtin_loader.rb $<
-
 .rc.res:
 	$(ECHO) compiling $(<:\=/)
 	$(Q) $(RC) $(RCFLAGS) -I. -I$(<D) $(iconinc) -I$(srcdir)/win32 $(RFLAGS) -fo$@ $(<:\=/)


### PR DESCRIPTION
Do not search builtin scripts by using VPATH, to get rid of weird nmake VPATH.