### PR TITLE
Create `RUBYCOMMONDIR` directory and `.RUBYCOMMONDIR.time` file in advance.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -378,6 +378,7 @@ matrix:
   include:
     # Build every commit:
     - <<: *x86_64-linux
+    - <<: *arm64-linux
     - <<: *i686-linux
     - <<: *pedanticism
     - <<: *assertions
@@ -385,7 +386,6 @@ matrix:
     - <<: *rubyspec
     - <<: *dependency
     # Build every commit (Allowed Failures):
-    - <<: *arm64-linux
     - <<: *ASAN
     - <<: *MSAN
     - <<: *UBSAN
@@ -400,7 +400,6 @@ matrix:
     - <<: *CALL_THREADED_CODE
     - <<: *NO_THREADED_CODE
   allow_failures:
-    - name: arm64-linux
     - name: -fsanitize=address
     - name: -fsanitize=memory
     - name: -fsanitize=undefined

--- a/common.mk
+++ b/common.mk
@@ -58,6 +58,7 @@ DOCLIE_GIT_REF = v1.3.2
 STATIC_RUBY   = static-ruby
 
 TIMESTAMPDIR  = $(EXTOUT)/.timestamp
+RUBYCOMMONDIR = $(EXTOUT)/common
 EXTCONF       = extconf.rb
 LIBRUBY_EXTS  = ./.libruby-with-ext.time
 REVISION_H    = ./.revision.time
@@ -289,7 +290,14 @@ ext/configure-ext.mk: $(PREP) all-incs $(MKFILES) $(RBCONFIG) $(LIBRUBY) \
 
 configure-ext: $(EXTS_MK)
 
-build-ext: $(EXTS_MK)
+$(TIMESTAMPDIR)/.RUBYCOMMONDIR.time:
+	$(Q) $(MAKEDIRS) $(RUBYCOMMONDIR)
+	$(Q) $(TOUCH) $@
+
+# Create `.RUBYCOMMONDIR.time` file here before it is created by building
+# extensions. The file can be touched more than 2 times by each extension's
+# `Makefile` `.RUBYCOMMONDIR.time` task in case of `make -jN`.
+build-ext: $(EXTS_MK) $(TIMESTAMPDIR)/.RUBYCOMMONDIR.time
 	$(Q)$(MAKE) -f $(EXTS_MK) $(mflags) libdir="$(libdir)" LIBRUBY_EXTS=$(LIBRUBY_EXTS) \
 	    EXTENCS="$(ENCOBJS)" UPDATE_LIBRARIES=no $(EXTSTATIC)
 	$(Q)$(MAKE) $(EXTS_NOTE)

--- a/template/Makefile.in
+++ b/template/Makefile.in
@@ -200,6 +200,7 @@ SET_LC_MESSAGES = env LC_MESSAGES=C
 
 MAKEDIRS      = @MKDIR_P@
 CP            = cp
+TOUCH         = exit >
 MV            = mv
 RM            = rm -f
 RMDIR         = @RMDIR@


### PR DESCRIPTION
It's to fix the failure in Travis arm64.
This PR is pointed out from https://bugs.ruby-lang.org/issues/16234 .
I tested it 3 times on my forked repository's Travis. And it was okay.


Create `RUBYCOMMONDIR` (`.ext/common`) `.ext/.timestamp/.RUBYCOMMONDIR.time`
file in `common.mk` before building extensions.
This prevents following error in `make install`.
    
Because `$(TIMESTAMP_DIR)/.RUBYCOMMONDIR.time` file can be touched more than
2 times by each `ext/**/Makefile` `$(TIMESTAMP_DIR)/.RUBYCOMMONDIR.time` task
in case of `make -jN`.
    
```
$ make -jN
```
    
`ext/**/Makefile`
    
```
$(TIMESTAMP_DIR)/.RUBYCOMMONDIR.time:
    $(Q) $(MAKEDIRS) $(@D) $(RUBYLIBDIR)
    $(Q) $(TOUCH) $@
```
    
This causes "Permission defined" error like https://travis-ci.org/ruby/ruby/jobs/606916890#L2412 .
    
```
$ make install
...
Prerequisite '../../.ext/.timestamp/.RUBYCOMMONDIR.time' is newer than target '../../.ext/common/json.rb'.
...
cp ../../../ext/json/lib/json.rb ../../.ext/common
cp: cannot create regular file '../../.ext/common/json.rb': Permission denied
  => ../../.ext/common/json.rb already exists as permission 444 (-r--r--r--).
...
```
    
The `template/Makefile.in` `TOUCH` definition comes from `lib/mkmf.rb` `TOUCH`.
