### PR TITLE
Remove arm64 from allow_failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -378,6 +378,7 @@ matrix:
   include:
     # Build every commit:
     - <<: *x86_64-linux
+    - <<: *arm64-linux
     - <<: *i686-linux
     - <<: *pedanticism
     - <<: *assertions
@@ -385,7 +386,6 @@ matrix:
     - <<: *rubyspec
     - <<: *dependency
     # Build every commit (Allowed Failures):
-    - <<: *arm64-linux
     - <<: *ASAN
     - <<: *MSAN
     - <<: *UBSAN
@@ -400,7 +400,6 @@ matrix:
     - <<: *CALL_THREADED_CODE
     - <<: *NO_THREADED_CODE
   allow_failures:
-    - name: arm64-linux
     - name: -fsanitize=address
     - name: -fsanitize=memory
     - name: -fsanitize=undefined


### PR DESCRIPTION
This PR is just a cherry-pick from https://github.com/ruby/ruby/commit/212f4d49bac844b3c0fa52f2185b3df30aa62e75 .

It comes from https://github.com/ruby/ruby/pull/2669#issuecomment-552813155 .
Now the arm64 case is 100% success on master branch.
I think that it's time to remove the arm64 from allow_failures.

