### PR TITLE
Delete unused functions

### DIFF
--- a/constant.h
+++ b/constant.h
@@ -39,16 +39,12 @@ VALUE rb_mod_private_constant(int argc, const VALUE *argv, VALUE obj);
 VALUE rb_mod_public_constant(int argc, const VALUE *argv, VALUE obj);
 VALUE rb_mod_deprecate_constant(int argc, const VALUE *argv, VALUE obj);
 void rb_free_const_table(struct rb_id_table *tbl);
-VALUE rb_public_const_get(VALUE klass, ID id);
 VALUE rb_public_const_get_at(VALUE klass, ID id);
 VALUE rb_public_const_get_from(VALUE klass, ID id);
-int rb_public_const_defined(VALUE klass, ID id);
-int rb_public_const_defined_at(VALUE klass, ID id);
 int rb_public_const_defined_from(VALUE klass, ID id);
 rb_const_entry_t *rb_const_lookup(VALUE klass, ID id);
 int rb_autoloading_value(VALUE mod, ID id, VALUE *value, rb_const_flag_t *flag);
 VALUE rb_const_source_location(VALUE, ID);
-VALUE rb_const_source_location_from(VALUE, ID);
 VALUE rb_const_source_location_at(VALUE, ID);
 
 #endif /* CONSTANT_H */

--- a/error.c
+++ b/error.c
@@ -127,13 +127,6 @@ rb_syntax_error_append(VALUE exc, VALUE file, int line, int column,
     return exc;
 }
 
-void
-ruby_deprecated_internal_feature(const char *func)
-{
-    rb_print_backtrace();
-    rb_fatal("%s is only for internal use and deprecated; do not use", func);
-}
-
 /*
  * call-seq:
  *    warn(msg)  -> nil

--- a/eval_intern.h
+++ b/eval_intern.h
@@ -250,9 +250,6 @@ CREF_OMOD_SHARED_UNSET(rb_cref_t *cref)
     cref->flags &= ~CREF_FL_OMOD_SHARED;
 }
 
-void rb_thread_cleanup(void);
-void rb_thread_wait_other_threads(void);
-
 enum {
     RAISED_EXCEPTION = 1,
     RAISED_STACKOVERFLOW = 2,

--- a/hash.c
+++ b/hash.c
@@ -544,7 +544,7 @@ RHASH_TABLE_EMPTY_P(VALUE hash)
     return RHASH_SIZE(hash) == 0;
 }
 
-MJIT_FUNC_EXPORTED int
+int
 rb_hash_ar_table_p(VALUE hash)
 {
     if (FL_TEST_RAW((hash), RHASH_ST_TABLE_FLAG)) {
@@ -563,7 +563,7 @@ rb_hash_ar_table(VALUE hash)
     return RHASH(hash)->as.ar;
 }
 
-MJIT_FUNC_EXPORTED st_table *
+st_table *
 rb_hash_st_table(VALUE hash)
 {
     HASH_ASSERT(!RHASH_AR_TABLE_P(hash));

--- a/internal.h
+++ b/internal.h
@@ -841,12 +841,12 @@ enum ruby_rhash_flags {
 #define RHASH_AR_TABLE_SIZE_RAW(h) \
   ((unsigned int)((RBASIC(h)->flags & RHASH_AR_TABLE_SIZE_MASK) >> RHASH_AR_TABLE_SIZE_SHIFT))
 
-int rb_hash_ar_table_p(VALUE hash);
-struct ar_table_struct *rb_hash_ar_table(VALUE hash);
-st_table *rb_hash_st_table(VALUE hash);
 void rb_hash_st_table_set(VALUE hash, st_table *st);
 
 #if 0 /* for debug */
+int rb_hash_ar_table_p(VALUE hash);
+struct ar_table_struct *rb_hash_ar_table(VALUE hash);
+st_table *rb_hash_st_table(VALUE hash);
 #define RHASH_AR_TABLE_P(hash)       rb_hash_ar_table_p(hash)
 #define RHASH_AR_TABLE(h)            rb_hash_ar_table(h)
 #define RHASH_ST_TABLE(h)            rb_hash_st_table(h)
@@ -1520,16 +1520,9 @@ VALUE rb_check_backtrace(VALUE);
 NORETURN(void rb_async_bug_errno(const char *,int));
 const char *rb_builtin_type_name(int t);
 const char *rb_builtin_class_name(VALUE x);
-PRINTF_ARGS(void rb_sys_warn(const char *fmt, ...), 1, 2);
-PRINTF_ARGS(void rb_syserr_warn(int err, const char *fmt, ...), 2, 3);
-PRINTF_ARGS(void rb_sys_warning(const char *fmt, ...), 1, 2);
-PRINTF_ARGS(void rb_syserr_warning(int err, const char *fmt, ...), 2, 3);
 #ifdef RUBY_ENCODING_H
 VALUE rb_syntax_error_append(VALUE, VALUE, int, int, rb_encoding*, const char*, va_list);
 PRINTF_ARGS(void rb_enc_warn(rb_encoding *enc, const char *fmt, ...), 2, 3);
-PRINTF_ARGS(void rb_sys_enc_warn(rb_encoding *enc, const char *fmt, ...), 2, 3);
-PRINTF_ARGS(void rb_syserr_enc_warn(int err, rb_encoding *enc, const char *fmt, ...), 3, 4);
-PRINTF_ARGS(void rb_enc_warning(rb_encoding *enc, const char *fmt, ...), 2, 3);
 PRINTF_ARGS(void rb_sys_enc_warning(rb_encoding *enc, const char *fmt, ...), 2, 3);
 PRINTF_ARGS(void rb_syserr_enc_warning(int err, rb_encoding *enc, const char *fmt, ...), 3, 4);
 #endif
@@ -1548,9 +1541,6 @@ VALUE rb_nomethod_err_new(VALUE mesg, VALUE recv, VALUE method, VALUE args, int 
 VALUE rb_key_err_new(VALUE mesg, VALUE recv, VALUE name);
 #define rb_key_err_raise(mesg, recv, name) \
     rb_exc_raise(rb_key_err_new(mesg, recv, name))
-NORETURN(void ruby_deprecated_internal_feature(const char *));
-#define DEPRECATED_INTERNAL_FEATURE(func) \
-    (ruby_deprecated_internal_feature(func), UNREACHABLE)
 VALUE rb_warning_warn(VALUE mod, VALUE str);
 PRINTF_ARGS(VALUE rb_warning_string(const char *fmt, ...), 1, 2);
 NORETURN(void rb_vraise(VALUE, const char *, va_list));
@@ -1694,9 +1684,7 @@ int rb_hash_stlike_update(VALUE hash, st_data_t key, st_update_callback_func fun
 void rb_call_inits(void);
 
 /* io.c */
-const char *ruby_get_inplace_mode(void);
 void ruby_set_inplace_mode(const char *);
-ssize_t rb_io_bufread(VALUE io, void *buf, size_t size);
 void rb_stdio_set_default_encoding(void);
 VALUE rb_io_flush_raw(VALUE, int);
 #ifdef RUBY_IO_H
@@ -1707,7 +1695,6 @@ void rb_io_fptr_finalize_internal(void *ptr);
 #define rb_io_fptr_finalize rb_io_fptr_finalize_internal
 
 /* load.c */
-VALUE rb_get_load_path(void);
 VALUE rb_get_expanded_load_path(void);
 int rb_require_internal(VALUE fname, int safe);
 NORETURN(void rb_load_fail(VALUE, const char*));
@@ -1973,7 +1960,6 @@ struct RBasicRaw {
 #ifndef USE_SYMBOL_GC
 #define USE_SYMBOL_GC 1
 #endif
-VALUE rb_parser_get_yydebug(VALUE);
 VALUE rb_parser_set_yydebug(VALUE, VALUE);
 RUBY_SYMBOL_EXPORT_BEGIN
 VALUE rb_parser_set_context(VALUE, const struct rb_iseq_struct *, int);
@@ -1981,23 +1967,12 @@ RUBY_SYMBOL_EXPORT_END
 void *rb_parser_load_file(VALUE parser, VALUE name);
 int rb_is_const_name(VALUE name);
 int rb_is_class_name(VALUE name);
-int rb_is_global_name(VALUE name);
 int rb_is_instance_name(VALUE name);
-int rb_is_attrset_name(VALUE name);
 int rb_is_local_name(VALUE name);
-int rb_is_method_name(VALUE name);
-int rb_is_junk_name(VALUE name);
 PUREFUNC(int rb_is_const_sym(VALUE sym));
-PUREFUNC(int rb_is_class_sym(VALUE sym));
-PUREFUNC(int rb_is_global_sym(VALUE sym));
-PUREFUNC(int rb_is_instance_sym(VALUE sym));
 PUREFUNC(int rb_is_attrset_sym(VALUE sym));
-PUREFUNC(int rb_is_local_sym(VALUE sym));
-PUREFUNC(int rb_is_method_sym(VALUE sym));
-PUREFUNC(int rb_is_junk_sym(VALUE sym));
 ID rb_make_internal_id(void);
 void rb_gc_free_dsymbol(VALUE);
-ID rb_id_attrget(ID id);
 
 /* proc.c */
 VALUE rb_proc_location(VALUE self);
@@ -2130,14 +2105,6 @@ VALUE rb_fstring_cstr(const char *str);
 VALUE rb_fstring_enc_new(const char *ptr, long len, rb_encoding *enc);
 #define rb_fstring_enc_lit(str, enc) rb_fstring_enc_new((str), rb_strlen_lit(str), (enc))
 #define rb_fstring_enc_literal(str, enc) rb_fstring_enc_lit(str, enc)
-VALUE rb_fstring_enc_cstr(const char *ptr, rb_encoding *enc);
-# ifdef HAVE_BUILTIN___BUILTIN_CONSTANT_P
-#  define rb_fstring_enc_cstr(str, enc) RB_GNUC_EXTENSION_BLOCK( \
-    (__builtin_constant_p(str)) ?		\
-	rb_fstring_enc_new((str), (long)strlen(str), (enc)) : \
-	rb_fstring_enc_cstr(str, enc) \
-)
-# endif
 #endif
 int rb_str_buf_cat_escaped_char(VALUE result, unsigned int c, int unicode_p);
 int rb_str_symname_p(VALUE);
@@ -2190,15 +2157,6 @@ rb_str_eql_internal(const VALUE str1, const VALUE str2)
 /* symbol.c */
 #ifdef RUBY_ENCODING_H
 VALUE rb_sym_intern(const char *ptr, long len, rb_encoding *enc);
-VALUE rb_sym_intern_cstr(const char *ptr, rb_encoding *enc);
-#ifdef __GNUC__
-#define rb_sym_intern_cstr(ptr, enc) __extension__ ( \
-{						\
-    (__builtin_constant_p(ptr)) ?		\
-	rb_sym_intern((ptr), (long)strlen(ptr), (enc)) : \
-	rb_sym_intern_cstr((ptr), (enc)); \
-})
-#endif
 #endif
 VALUE rb_sym_intern_ascii(const char *ptr, long len);
 VALUE rb_sym_intern_ascii_cstr(const char *ptr);
@@ -2296,9 +2254,6 @@ void rb_vm_mark(void *ptr);
 void Init_BareVM(void);
 void Init_vm_objects(void);
 PUREFUNC(VALUE rb_vm_top_self(void));
-void rb_thread_recycle_stack_release(VALUE *);
-VALUE *rb_thread_recycle_stack(size_t);
-void rb_vm_change_state(void);
 void rb_vm_inc_const_missing_count(void);
 const void **rb_vm_get_insns_address_table(void);
 VALUE rb_source_location(int *pline);

--- a/io.c
+++ b/io.c
@@ -2493,16 +2493,6 @@ io_fread(VALUE str, long offset, long size, rb_io_t *fptr)
     return len;
 }
 
-ssize_t
-rb_io_bufread(VALUE io, void *buf, size_t size)
-{
-    rb_io_t *fptr;
-
-    GetOpenFile(io, fptr);
-    rb_io_check_readable(fptr);
-    return (ssize_t)io_bufread(buf, (long)size, fptr);
-}
-
 static long
 remain_size(rb_io_t *fptr)
 {
@@ -12868,12 +12858,6 @@ static void
 opt_i_set(VALUE val, ID id, VALUE *var)
 {
     argf_inplace_mode_set(*var, val);
-}
-
-const char *
-ruby_get_inplace_mode(void)
-{
-    return RSTRING_PTR(ARGF.inplace);
 }
 
 void

--- a/iseq.c
+++ b/iseq.c
@@ -1012,12 +1012,6 @@ rb_iseq_compile_with_option(VALUE src, VALUE file, VALUE realpath, VALUE line, V
     return iseq;
 }
 
-rb_iseq_t *
-rb_iseq_compile(VALUE src, VALUE file, VALUE line)
-{
-    return rb_iseq_compile_with_option(src, file, Qnil, line, Qnil);
-}
-
 VALUE
 rb_iseq_path(const rb_iseq_t *iseq)
 {
@@ -3306,14 +3300,6 @@ void
 rb_iseq_trace_set_all(rb_event_flag_t turnon_events)
 {
     rb_objspace_each_objects(trace_set_i, &turnon_events);
-}
-
-/* This is exported since Ruby 2.5 but not internally used for now. If you're going to use this, please
-   update `ruby_vm_event_enabled_global_flags` and set `mjit_call_p = FALSE` as well to cancel MJIT code. */
-void
-rb_iseq_trace_on_all(void)
-{
-    rb_iseq_trace_set_all(RUBY_EVENT_TRACEPOINT_ALL);
 }
 
 VALUE

--- a/iseq.h
+++ b/iseq.h
@@ -182,11 +182,9 @@ void rb_iseq_mark_insn_storage(struct iseq_compile_data_storage *arena);
 /* iseq.c */
 VALUE rb_iseq_load(VALUE data, VALUE parent, VALUE opt);
 VALUE rb_iseq_parameters(const rb_iseq_t *iseq, int is_proc);
-struct st_table *ruby_insn_make_insn_table(void);
 unsigned int rb_iseq_line_no(const rb_iseq_t *iseq, size_t pos);
 void rb_iseq_trace_set(const rb_iseq_t *iseq, rb_event_flag_t turnon_events);
 void rb_iseq_trace_set_all(rb_event_flag_t turnon_events);
-void rb_iseq_trace_on_all(void);
 void rb_iseq_insns_info_encode_positions(const rb_iseq_t *iseq);
 
 VALUE rb_iseqw_new(const rb_iseq_t *iseq);

--- a/load.c
+++ b/load.c
@@ -28,13 +28,6 @@ static const char *const loadable_ext[] = {
     0
 };
 
-VALUE
-rb_get_load_path(void)
-{
-    VALUE load_path = GET_VM()->load_path;
-    return load_path;
-}
-
 enum expand_type {
     EXPAND_ALL,
     EXPAND_RELATIVE,

--- a/method.h
+++ b/method.h
@@ -215,11 +215,8 @@ int rb_method_entry_eq(const rb_method_entry_t *m1, const rb_method_entry_t *m2)
 st_index_t rb_hash_method_entry(st_index_t hash, const rb_method_entry_t *me);
 
 VALUE rb_method_entry_location(const rb_method_entry_t *me);
-VALUE rb_mod_method_location(VALUE mod, ID id);
-VALUE rb_obj_method_location(VALUE obj, ID id);
 
 void rb_free_method_entry(const rb_method_entry_t *me);
-void rb_sweep_method_entry(void *vm);
 
 const rb_method_entry_t *rb_method_entry_clone(const rb_method_entry_t *me);
 const rb_callable_method_entry_t *rb_method_entry_complement_defined_class(const rb_method_entry_t *src_me, ID called_id, VALUE defined_class);

--- a/mjit.h
+++ b/mjit.h
@@ -79,8 +79,6 @@ RUBY_SYMBOL_EXPORT_END
 
 extern bool mjit_compile(FILE *f, const rb_iseq_t *iseq, const char *funcname);
 extern void mjit_init(struct mjit_options *opts);
-extern void mjit_postponed_job_register_start_hook(void);
-extern void mjit_postponed_job_register_finish_hook(void);
 extern void mjit_gc_start_hook(void);
 extern void mjit_gc_exit_hook(void);
 extern void mjit_free_iseq(const rb_iseq_t *iseq);
@@ -164,8 +162,6 @@ void mjit_child_after_fork(void);
 #else // USE_MJIT
 static inline struct mjit_cont *mjit_cont_new(rb_execution_context_t *ec){return NULL;}
 static inline void mjit_cont_free(struct mjit_cont *cont){}
-static inline void mjit_postponed_job_register_start_hook(void){}
-static inline void mjit_postponed_job_register_finish_hook(void){}
 static inline void mjit_gc_start_hook(void){}
 static inline void mjit_gc_exit_hook(void){}
 static inline void mjit_free_iseq(const rb_iseq_t *iseq){}

--- a/node.h
+++ b/node.h
@@ -414,21 +414,14 @@ void rb_ast_delete_node(rb_ast_t*, NODE *n);
 VALUE rb_parser_new(void);
 VALUE rb_parser_end_seen_p(VALUE);
 VALUE rb_parser_encoding(VALUE);
-VALUE rb_parser_get_yydebug(VALUE);
 VALUE rb_parser_set_yydebug(VALUE, VALUE);
 VALUE rb_parser_dump_tree(const NODE *node, int comment);
 void rb_parser_set_options(VALUE, int, int, int, int);
 
-rb_ast_t *rb_parser_compile_cstr(VALUE, const char*, const char*, int, int);
 rb_ast_t *rb_parser_compile_string(VALUE, const char*, VALUE, int);
-rb_ast_t *rb_parser_compile_file(VALUE, const char*, VALUE, int);
 rb_ast_t *rb_parser_compile_string_path(VALUE vparser, VALUE fname, VALUE src, int line);
 rb_ast_t *rb_parser_compile_file_path(VALUE vparser, VALUE fname, VALUE input, int line);
 rb_ast_t *rb_parser_compile_generic(VALUE vparser, VALUE (*lex_gets)(VALUE, int), VALUE fname, VALUE input, int line);
-
-rb_ast_t *rb_compile_cstr(const char*, const char*, int, int);
-rb_ast_t *rb_compile_string(const char*, VALUE, int);
-rb_ast_t *rb_compile_file(const char*, VALUE, int);
 
 void rb_node_init(NODE *n, enum node_type type, VALUE a0, VALUE a1, VALUE a2);
 const char *ruby_node_name(int node);

--- a/parse.y
+++ b/parse.y
@@ -6045,13 +6045,6 @@ parser_compile_string(VALUE vparser, VALUE fname, VALUE s, int line)
 }
 
 rb_ast_t*
-rb_compile_string(const char *f, VALUE s, int line)
-{
-    must_be_ascii_compatible(s);
-    return parser_compile_string(rb_parser_new(), rb_filesystem_str_new_cstr(f), s, line);
-}
-
-rb_ast_t*
 rb_parser_compile_string(VALUE vparser, const char *f, VALUE s, int line)
 {
     return rb_parser_compile_string_path(vparser, rb_filesystem_str_new_cstr(f), s, line);
@@ -6064,40 +6057,12 @@ rb_parser_compile_string_path(VALUE vparser, VALUE f, VALUE s, int line)
     return parser_compile_string(vparser, f, s, line);
 }
 
-rb_ast_t*
-rb_compile_cstr(const char *f, const char *s, int len, int line)
-{
-    VALUE str = rb_str_new(s, len);
-    return parser_compile_string(rb_parser_new(), rb_filesystem_str_new_cstr(f), str, line);
-}
-
-rb_ast_t*
-rb_parser_compile_cstr(VALUE vparser, const char *f, const char *s, int len, int line)
-{
-    VALUE str = rb_str_new(s, len);
-    return parser_compile_string(vparser, rb_filesystem_str_new_cstr(f), str, line);
-}
-
 VALUE rb_io_gets_internal(VALUE io);
 
 static VALUE
 lex_io_gets(struct parser_params *p, VALUE io)
 {
     return rb_io_gets_internal(io);
-}
-
-rb_ast_t*
-rb_compile_file(const char *f, VALUE file, int start)
-{
-    VALUE vparser = rb_parser_new();
-
-    return rb_parser_compile_file(vparser, f, file, start);
-}
-
-rb_ast_t*
-rb_parser_compile_file(VALUE vparser, const char *f, VALUE file, int start)
-{
-    return rb_parser_compile_file_path(vparser, rb_filesystem_str_new_cstr(f), file, start);
 }
 
 rb_ast_t*
@@ -12475,6 +12440,7 @@ rb_parser_encoding(VALUE vparser)
     return rb_enc_from_encoding(p->enc);
 }
 
+#ifdef RIPPER
 /*
  *  call-seq:
  *    ripper.yydebug   -> true or false
@@ -12489,6 +12455,7 @@ rb_parser_get_yydebug(VALUE self)
     TypedData_Get_Struct(self, struct parser_params, &parser_data_type, p);
     return p->debug ? Qtrue : Qfalse;
 }
+#endif
 
 /*
  *  call-seq:

--- a/proc.c
+++ b/proc.c
@@ -2736,19 +2736,6 @@ rb_method_entry_location(const rb_method_entry_t *me)
     return method_def_location(me->def);
 }
 
-VALUE
-rb_mod_method_location(VALUE mod, ID id)
-{
-    const rb_method_entry_t *me = original_method_entry(mod, id);
-    return rb_method_entry_location(me);
-}
-
-MJIT_FUNC_EXPORTED VALUE
-rb_obj_method_location(VALUE obj, ID id)
-{
-    return rb_mod_method_location(CLASS_OF(obj), id);
-}
-
 /*
  * call-seq:
  *    meth.source_location  -> [String, Integer]

--- a/string.c
+++ b/string.c
@@ -60,7 +60,6 @@
 #undef rb_str_cat2
 #undef rb_str_cat_cstr
 #undef rb_fstring_cstr
-#undef rb_fstring_enc_cstr
 
 static VALUE rb_str_clear(VALUE str);
 
@@ -412,12 +411,6 @@ VALUE
 rb_fstring_cstr(const char *ptr)
 {
     return rb_fstring_new(ptr, strlen(ptr));
-}
-
-VALUE
-rb_fstring_enc_cstr(const char *ptr, rb_encoding *enc)
-{
-    return rb_fstring_enc_new(ptr, strlen(ptr), enc);
 }
 
 static int

--- a/variable.c
+++ b/variable.c
@@ -2418,12 +2418,6 @@ rb_public_const_get_from(VALUE klass, ID id)
     return rb_const_get_0(klass, id, TRUE, TRUE, TRUE);
 }
 
-VALUE
-rb_public_const_get(VALUE klass, ID id)
-{
-    return rb_const_get_0(klass, id, FALSE, TRUE, TRUE);
-}
-
 MJIT_FUNC_EXPORTED VALUE
 rb_public_const_get_at(VALUE klass, ID id)
 {
@@ -2474,12 +2468,6 @@ rb_const_location(VALUE klass, ID id, int exclude, int recurse, int visibility)
     if (BUILTIN_TYPE(klass) != T_MODULE) return loc;
     /* search global const too, if klass is a module */
     return rb_const_location_from(rb_cObject, id, FALSE, recurse, visibility);
-}
-
-VALUE
-rb_const_source_location_from(VALUE klass, ID id)
-{
-    return rb_const_location(klass, id, TRUE, TRUE, FALSE);
 }
 
 VALUE
@@ -2723,18 +2711,6 @@ MJIT_FUNC_EXPORTED int
 rb_public_const_defined_from(VALUE klass, ID id)
 {
     return rb_const_defined_0(klass, id, TRUE, TRUE, TRUE);
-}
-
-int
-rb_public_const_defined(VALUE klass, ID id)
-{
-    return rb_const_defined_0(klass, id, FALSE, TRUE, TRUE);
-}
-
-int
-rb_public_const_defined_at(VALUE klass, ID id)
-{
-    return rb_const_defined_0(klass, id, TRUE, FALSE, TRUE);
 }
 
 static void

--- a/vm_core.h
+++ b/vm_core.h
@@ -1029,7 +1029,6 @@ rb_iseq_t *rb_iseq_new_with_callback(const struct rb_iseq_new_with_callback_call
     const rb_iseq_t *parent, enum iseq_type, const rb_compile_option_t*);
 
 /* src -> iseq */
-rb_iseq_t *rb_iseq_compile(VALUE src, VALUE file, VALUE line);
 rb_iseq_t *rb_iseq_compile_with_option(VALUE src, VALUE file, VALUE realpath, VALUE line, VALUE opt);
 
 VALUE rb_iseq_disasm(const rb_iseq_t *iseq);
@@ -1131,8 +1130,6 @@ typedef union iseq_inline_storage_entry *ISE;
 typedef struct rb_call_info *CALL_INFO;
 typedef struct rb_call_cache *CALL_CACHE;
 typedef struct rb_call_data *CALL_DATA;
-
-void rb_vm_change_state(void);
 
 typedef VALUE CDHASH;
 


### PR DESCRIPTION
Looking at the list of symbols inside of libruby-static.a, I found hundreds of functions that are defined, but used from nowhere.

There can be reasons for each of them (e.g. some functions are specific to some platform, some are useful when debugging, etc). However it seems the functions deleted here exist for no reason.

This changeset reduces the size of ruby binary from 26,671,456 bytes to 26,592,864 bytes on my machine.