### PR TITLE
Use shallow-since instead of depth

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -22,12 +22,12 @@ jobs:
       # Not using official actions/checkout because it's unstable and sometimes doesn't work for a fork.
       - name: Checkout ruby/ruby
         run: |
-          git clone --depth=50 https://github.com/ruby/ruby src
+          git clone --single-branch --shallow-since=yesterday https://github.com/ruby/ruby src
           git -C src reset --hard "$GITHUB_SHA"
         if: github.event_name == 'push'
       - name: Checkout a pull request
         run: |
-          git clone --depth=50 "--branch=$GITHUB_BRANCH" "https://github.com/${GITHUB_REPO}" src
+          git clone --single-branch --shallow-since=yesterday "--branch=$GITHUB_BRANCH" "https://github.com/${GITHUB_REPO}" src
           git -C src reset --hard "$GITHUB_REV"
         env:
           GITHUB_REV: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/mjit.yml
+++ b/.github/workflows/mjit.yml
@@ -23,12 +23,12 @@ jobs:
       # Not using official actions/checkout because it's unstable and sometimes doesn't work for a fork.
       - name: Checkout ruby/ruby
         run: |
-          git clone --depth=50 https://github.com/ruby/ruby src
+          git clone --single-branch --shallow-since=yesterday https://github.com/ruby/ruby src
           git -C src reset --hard "$GITHUB_SHA"
         if: github.event_name == 'push'
       - name: Checkout a pull request
         run: |
-          git clone --depth=50 "--branch=$GITHUB_BRANCH" "https://github.com/${GITHUB_REPO}" src
+          git clone --single-branch --shallow-since=yesterday "--branch=$GITHUB_BRANCH" "https://github.com/${GITHUB_REPO}" src
           git -C src reset --hard "$GITHUB_REV"
         env:
           GITHUB_REV: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -55,12 +55,12 @@ jobs:
       # Not using official actions/checkout because it's unstable and sometimes doesn't work for a fork.
       - name: Checkout ruby/ruby
         run: |
-          git clone --depth=50 https://github.com/ruby/ruby src
+          git clone --single-branch --shallow-since=yesterday https://github.com/ruby/ruby src
           git -C src reset --hard "$GITHUB_SHA"
         if: github.event_name == 'push'
       - name: Checkout a pull request
         run: |
-          git clone --depth=50 "--branch=$GITHUB_BRANCH" "https://github.com/${GITHUB_REPO}" src
+          git clone --single-branch --shallow-since=yesterday "--branch=$GITHUB_BRANCH" "https://github.com/${GITHUB_REPO}" src
           git -C src reset --hard "$GITHUB_REV"
         env:
           GITHUB_REV: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -46,12 +46,12 @@ jobs:
       # Not using official actions/checkout because it's unstable and sometimes doesn't work for a fork.
       - name: Checkout ruby/ruby
         run: |
-          git clone --depth=50 https://github.com/ruby/ruby src
+          git clone --single-branch --shallow-since=yesterday https://github.com/ruby/ruby src
           git -C src reset --hard ${{ github.sha }}
         if: github.event_name == 'push'
       - name: Checkout a pull request
         run: |
-          git clone --depth=50 --branch=${{ github.event.pull_request.head.ref }} https://github.com/${{ github.event.pull_request.head.repo.full_name }} src
+          git clone --single-branch --shallow-since=yesterday --branch=${{ github.event.pull_request.head.ref }} https://github.com/${{ github.event.pull_request.head.repo.full_name }} src
           git -C src reset --hard ${{ github.event.pull_request.head.sha }}
         if: github.event_name == 'pull_request'
       - run: ./src/tool/actions-commit-info.sh


### PR DESCRIPTION
commit number of today requires log since 0:00 UTC.
So commits of 24 hours are enough.

https://www.git-scm.com/docs/git-clone#Documentation/git-clone.txt---depthltdepthgt
> Implies --single-branch unless --no-single-branch is given to fetch the histories near the tips of all branches.

So I add `--single-branch` too.