### PR TITLE
updating guard for MAX_INT to support strings of exactly the limit

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -8490,7 +8490,7 @@ parse_numvar(struct parser_params *p)
     int overflow;
     unsigned long n = ruby_scan_digits(tok(p)+1, toklen(p)-1, 10, &len, &overflow);
     const unsigned long nth_ref_max =
-	((FIXNUM_MAX < INT_MAX) ? FIXNUM_MAX : INT_MAX) >> 1;
+	((FIXNUM_MAX <= INT_MAX) ? FIXNUM_MAX : INT_MAX) >> 1;
     /* NTH_REF is left-shifted to be ORed with back-ref flag and
      * turned into a Fixnum, in compile.c */
 


### PR DESCRIPTION
When using a string or file at exactly `2147483648` bytes for example  this guard will fail despite 2 gigabytes being a legit size. 
I am not an expert in Ruby and I have not tested this PR in any practical sense, I ran into this uploading 2 Gigabyte file assets to Github using Travis CI which uses ruby to handle the deployment and got an INT too big error. 
Modifying files to  `2147483647` bytes resolves this, but seems like this comparison operator should have an equal to. 

Let me know if you need anymore information. 