### PR TITLE
make functions static

### DIFF
--- a/array.c
+++ b/array.c
@@ -1532,6 +1532,8 @@ rb_ary_subseq(VALUE ary, long beg, long len)
     return ary_make_partial(ary, klass, beg, len);
 }
 
+static VALUE rb_ary_aref2(VALUE ary, VALUE b, VALUE e);
+
 /*
  *  call-seq:
  *     ary[index]                -> obj     or nil

--- a/bignum.c
+++ b/bignum.c
@@ -3990,6 +3990,8 @@ str2big_gmp(
 }
 #endif
 
+static VALUE rb_cstr_parse_inum(const char *str, ssize_t len, char **endp, int base);
+
 /*
  * Parse +str+ as Ruby Integer, i.e., underscores, 0d and 0b prefixes.
  *
@@ -4233,7 +4235,7 @@ rb_int_parse_cstr(const char *str, ssize_t len, char **endp, size_t *ndigits,
     return bignorm(z);
 }
 
-VALUE
+static VALUE
 rb_cstr_parse_inum(const char *str, ssize_t len, char **endp, int base)
 {
     return rb_int_parse_cstr(str, len, endp, NULL, base,

--- a/compile.c
+++ b/compile.c
@@ -755,7 +755,7 @@ rb_iseq_compile_node(rb_iseq_t *iseq, const NODE *node)
     return iseq_setup(iseq, ret);
 }
 
-int
+static int
 rb_iseq_translate_threaded_code(rb_iseq_t *iseq)
 {
 #if OPT_DIRECT_THREADED_CODE || OPT_CALL_THREADED_CODE

--- a/error.c
+++ b/error.c
@@ -159,7 +159,7 @@ rb_warning_s_warn(VALUE mod, VALUE str)
  *  printing the warning to $stderr.
  */
 
-VALUE
+static VALUE
 rb_warning_warn(VALUE mod, VALUE str)
 {
     return rb_funcallv(mod, id_warn, 1, &str);
@@ -1169,6 +1169,8 @@ exc_backtrace(VALUE exc)
     return obj;
 }
 
+static VALUE rb_check_backtrace(VALUE);
+
 VALUE
 rb_get_backtrace(VALUE exc)
 {
@@ -1212,7 +1214,7 @@ exc_backtrace_locations(VALUE exc)
     return obj;
 }
 
-VALUE
+static VALUE
 rb_check_backtrace(VALUE bt)
 {
     long i;
@@ -1506,6 +1508,8 @@ name_err_initialize(int argc, VALUE *argv, VALUE self)
     return self;
 }
 
+static VALUE rb_name_err_mesg_new(VALUE mesg, VALUE recv, VALUE method);
+
 static VALUE
 name_err_init(VALUE exc, VALUE mesg, VALUE recv, VALUE method)
 {
@@ -1636,7 +1640,7 @@ static const rb_data_type_t name_err_mesg_data_type = {
 };
 
 /* :nodoc: */
-VALUE
+static VALUE
 rb_name_err_mesg_new(VALUE mesg, VALUE recv, VALUE method)
 {
     VALUE result = TypedData_Wrap_Struct(rb_cNameErrorMesg, &name_err_mesg_data_type, 0);

--- a/gc.c
+++ b/gc.c
@@ -1747,6 +1747,8 @@ heap_unlink_page(rb_objspace_t *objspace, rb_heap_t *heap, struct heap_page *pag
     heap->total_slots -= page->total_slots;
 }
 
+static void rb_aligned_free(void *ptr);
+
 static void
 heap_page_free(rb_objspace_t *objspace, struct heap_page *page)
 {
@@ -2302,7 +2304,7 @@ rb_imemo_tmpbuf_new(VALUE v1, VALUE v2, VALUE v3, VALUE v0)
     return newobj_of(v0, flags, v1, v2, v3, FALSE);
 }
 
-VALUE
+static VALUE
 rb_imemo_tmpbuf_auto_free_maybe_mark_buffer(void *buf, size_t cnt)
 {
     return rb_imemo_tmpbuf_new((VALUE)buf, 0, (VALUE)cnt, 0);
@@ -9624,7 +9626,7 @@ rb_aligned_malloc(size_t alignment, size_t size)
     return res;
 }
 
-void
+static void
 rb_aligned_free(void *ptr)
 {
 #if defined __MINGW32__

--- a/hash.c
+++ b/hash.c
@@ -146,7 +146,7 @@ rb_hash(VALUE obj)
     return hval;
 }
 
-long rb_objid_hash(st_index_t index);
+static long rb_objid_hash(st_index_t index);
 
 static st_index_t
 dbl_to_index(double d)
@@ -264,7 +264,7 @@ key64_hash(uint64_t key, uint32_t seed)
 /* Should cast down the result for each purpose */
 #define st_index_hash(index) key64_hash(rb_hash_start(index), prime2)
 
-long
+static long
 rb_objid_hash(st_index_t index)
 {
     return (long)st_index_hash(index);
@@ -4153,6 +4153,8 @@ rb_hash_compact_bang(VALUE hash)
     return Qnil;
 }
 
+static st_table *rb_init_identtable_with_size(st_index_t size);
+
 /*
  *  call-seq:
  *     hsh.compare_by_identity -> hsh
@@ -4227,7 +4229,7 @@ rb_init_identtable(void)
     return st_init_table(&identhash);
 }
 
-st_table *
+static st_table *
 rb_init_identtable_with_size(st_index_t size)
 {
     return st_init_table_with_size(&identhash, size);

--- a/internal.h
+++ b/internal.h
@@ -1206,7 +1206,6 @@ typedef struct rb_imemo_tmpbuf_struct {
 } rb_imemo_tmpbuf_t;
 
 #define rb_imemo_tmpbuf_auto_free_pointer() rb_imemo_new(imemo_tmpbuf, 0, 0, 0, 0)
-VALUE rb_imemo_tmpbuf_auto_free_maybe_mark_buffer(void *buf, size_t cnt);
 rb_imemo_tmpbuf_t *rb_imemo_tmpbuf_parser_heap(void *buf, rb_imemo_tmpbuf_t *old_heap, size_t cnt);
 
 #define RB_IMEMO_TMPBUF_PTR(v) \
@@ -1364,7 +1363,6 @@ void rb_ary_delete_same(VALUE, VALUE);
 VALUE rb_ary_tmp_new_fill(long capa);
 VALUE rb_ary_at(VALUE, VALUE);
 VALUE rb_ary_aref1(VALUE ary, VALUE i);
-VALUE rb_ary_aref2(VALUE ary, VALUE b, VALUE e);
 size_t rb_ary_memsize(VALUE);
 VALUE rb_to_array_type(VALUE obj);
 VALUE rb_check_to_array(VALUE ary);
@@ -1425,7 +1423,6 @@ VALUE rb_big_even_p(VALUE);
 size_t rb_big_size(VALUE);
 VALUE rb_integer_float_cmp(VALUE x, VALUE y);
 VALUE rb_integer_float_eq(VALUE x, VALUE y);
-VALUE rb_cstr_parse_inum(const char *str, ssize_t len, char **endp, int base);
 VALUE rb_str_convert_to_inum(VALUE str, int base, int badcheck, int raise_exception);
 VALUE rb_big_comp(VALUE x);
 VALUE rb_big_aref(VALUE x, VALUE y);
@@ -1516,7 +1513,6 @@ extern VALUE rb_eEAGAIN;
 extern VALUE rb_eEWOULDBLOCK;
 extern VALUE rb_eEINPROGRESS;
 void rb_report_bug_valist(VALUE file, int line, const char *fmt, va_list args);
-VALUE rb_check_backtrace(VALUE);
 NORETURN(void rb_async_bug_errno(const char *,int));
 const char *rb_builtin_type_name(int t);
 const char *rb_builtin_class_name(VALUE x);
@@ -1541,7 +1537,6 @@ VALUE rb_nomethod_err_new(VALUE mesg, VALUE recv, VALUE method, VALUE args, int 
 VALUE rb_key_err_new(VALUE mesg, VALUE recv, VALUE name);
 #define rb_key_err_raise(mesg, recv, name) \
     rb_exc_raise(rb_key_err_new(mesg, recv, name))
-VALUE rb_warning_warn(VALUE mod, VALUE str);
 PRINTF_ARGS(VALUE rb_warning_string(const char *fmt, ...), 1, 2);
 NORETURN(void rb_vraise(VALUE, const char *, va_list));
 
@@ -1635,7 +1630,6 @@ __attribute__((__alloc_align__(1)))
 #endif
 #endif
 void *rb_aligned_malloc(size_t, size_t) RUBY_ATTR_MALLOC RUBY_ATTR_ALLOC_SIZE((2));
-void rb_aligned_free(void *);
 
 size_t rb_size_mul_or_raise(size_t, size_t, VALUE); /* used in compile.c */
 size_t rb_size_mul_add_or_raise(size_t, size_t, size_t, VALUE); /* used in iseq.h */
@@ -1657,10 +1651,8 @@ VALUE rb_hash_new_with_size(st_index_t size);
 VALUE rb_hash_has_key(VALUE hash, VALUE key);
 VALUE rb_hash_default_value(VALUE hash, VALUE key);
 VALUE rb_hash_set_default_proc(VALUE hash, VALUE proc);
-long rb_objid_hash(st_index_t index);
 long rb_dbl_long_hash(double d);
 st_table *rb_init_identtable(void);
-st_table *rb_init_identtable_with_size(st_index_t size);
 VALUE rb_hash_compare_by_id_p(VALUE hash);
 VALUE rb_to_hash_type(VALUE obj);
 VALUE rb_hash_key_str(VALUE);
@@ -1714,7 +1706,6 @@ VALUE rb_math_hypot(VALUE, VALUE);
 VALUE rb_math_log(int argc, const VALUE *argv);
 VALUE rb_math_sin(VALUE);
 VALUE rb_math_sinh(VALUE);
-VALUE rb_math_sqrt(VALUE);
 
 /* mjit.c */
 
@@ -1768,7 +1759,6 @@ int ruby_float_step(VALUE from, VALUE to, VALUE step, int excl, int allow_endles
 double ruby_float_mod(double x, double y);
 int rb_num_negative_p(VALUE);
 VALUE rb_int_succ(VALUE num);
-VALUE rb_int_pred(VALUE num);
 VALUE rb_int_uminus(VALUE num);
 VALUE rb_float_uminus(VALUE num);
 VALUE rb_int_plus(VALUE x, VALUE y);
@@ -1779,9 +1769,7 @@ VALUE rb_float_mul(VALUE x, VALUE y);
 VALUE rb_float_div(VALUE x, VALUE y);
 VALUE rb_int_idiv(VALUE x, VALUE y);
 VALUE rb_int_modulo(VALUE x, VALUE y);
-VALUE rb_int_round(VALUE num, int ndigits, enum ruby_num_rounding_mode mode);
 VALUE rb_int2str(VALUE num, int base);
-VALUE rb_dbl_hash(double d);
 VALUE rb_fix_plus(VALUE x, VALUE y);
 VALUE rb_fix_aref(VALUE fix, VALUE idx);
 VALUE rb_int_gt(VALUE x, VALUE y);
@@ -2280,7 +2268,6 @@ VALUE rb_check_funcall_with_hook_kw(VALUE recv, ID mid, int argc, const VALUE *a
                                  rb_check_funcall_hook *hook, VALUE arg, int kw_splat);
 const char *rb_type_str(enum ruby_value_type type);
 VALUE rb_check_funcall_default(VALUE, ID, int, const VALUE *, VALUE);
-VALUE rb_check_funcall_default_kw(VALUE, ID, int, const VALUE *, VALUE, int);
 VALUE rb_yield_1(VALUE val);
 VALUE rb_yield_force_blockarg(VALUE values);
 VALUE rb_lambda_call(VALUE obj, ID mid, int argc, const VALUE *argv,
@@ -2402,11 +2389,6 @@ const char *rb_objspace_data_type_name(VALUE obj);
 
 /* Temporary.  This API will be removed (renamed). */
 VALUE rb_thread_io_blocking_region(rb_blocking_function_t *func, void *data1, int fd);
-
-/* array.c (export) */
-void rb_ary_detransient(VALUE a);
-VALUE *rb_ary_ptr_use_start(VALUE ary);
-void rb_ary_ptr_use_end(VALUE ary);
 
 /* bignum.c (export) */
 VALUE rb_big_mul_normal(VALUE x, VALUE y);

--- a/iseq.c
+++ b/iseq.c
@@ -690,7 +690,7 @@ set_compile_option_from_hash(rb_compile_option_t *option, VALUE opt)
 #undef SET_COMPILE_OPTION_NUM
 }
 
-void
+static void
 rb_iseq_make_compile_option(rb_compile_option_t *option, VALUE opt)
 {
     Check_Type(opt, T_HASH);
@@ -963,7 +963,7 @@ rb_iseq_load(VALUE data, VALUE parent, VALUE opt)
     return iseq_load(data, RTEST(parent) ? (rb_iseq_t *)parent : NULL, opt);
 }
 
-rb_iseq_t *
+static rb_iseq_t *
 rb_iseq_compile_with_option(VALUE src, VALUE file, VALUE realpath, VALUE line, VALUE opt)
 {
     rb_iseq_t *iseq = NULL;

--- a/iseq.h
+++ b/iseq.h
@@ -172,7 +172,6 @@ RUBY_SYMBOL_EXPORT_BEGIN
 /* compile.c */
 VALUE rb_iseq_compile_node(rb_iseq_t *iseq, const NODE *node);
 VALUE rb_iseq_compile_callback(rb_iseq_t *iseq, const struct rb_iseq_new_with_callback_callback_func * ifunc);
-int rb_iseq_translate_threaded_code(rb_iseq_t *iseq);
 VALUE *rb_iseq_original_iseq(const rb_iseq_t *iseq);
 void rb_iseq_build_from_ary(rb_iseq_t *iseq, VALUE misc,
 			    VALUE locals, VALUE args,
@@ -303,7 +302,6 @@ enum defined_type {
 };
 
 VALUE rb_iseq_defined_string(enum defined_type type);
-void rb_iseq_make_compile_option(struct rb_compile_option_struct *option, VALUE opt);
 
 /* vm.c */
 VALUE rb_iseq_local_variables(const rb_iseq_t *iseq);

--- a/math.c
+++ b/math.c
@@ -573,6 +573,8 @@ math_log10(VALUE unused_obj, VALUE x)
     return DBL2NUM(log10(d) + numbits * log10(2)); /* log10(d * 2 ** numbits) */
 }
 
+static VALUE rb_math_sqrt(VALUE x);
+
 /*
  *  call-seq:
  *     Math.sqrt(x)    -> Float
@@ -630,7 +632,7 @@ f_signbit(VALUE x)
     return f_negative_p(x);
 }
 
-VALUE
+static VALUE
 rb_math_sqrt(VALUE x)
 {
     double d;

--- a/method.h
+++ b/method.h
@@ -202,7 +202,6 @@ const rb_method_entry_t *rb_method_entry_with_refinements(VALUE klass, ID id, VA
 const rb_method_entry_t *rb_method_entry_without_refinements(VALUE klass, ID id, VALUE *defined_class);
 const rb_method_entry_t *rb_resolve_refined_method(VALUE refinements, const rb_method_entry_t *me);
 RUBY_SYMBOL_EXPORT_BEGIN
-const rb_callable_method_entry_t *rb_resolve_refined_method_callable(VALUE refinements, const rb_callable_method_entry_t *me);
 const rb_method_entry_t *rb_resolve_me_location(const rb_method_entry_t *, VALUE[5]);
 RUBY_SYMBOL_EXPORT_END
 

--- a/numeric.c
+++ b/numeric.c
@@ -1404,6 +1404,7 @@ rb_float_equal(VALUE x, VALUE y)
 }
 
 #define flo_eq rb_float_equal
+static VALUE rb_dbl_hash(double d);
 
 /*
  * call-seq:
@@ -1420,7 +1421,7 @@ flo_hash(VALUE num)
     return rb_dbl_hash(RFLOAT_VALUE(num));
 }
 
-VALUE
+static VALUE
 rb_dbl_hash(double d)
 {
     return LONG2FIX(rb_dbl_long_hash(d));
@@ -2099,7 +2100,7 @@ int_half_p_half_down(VALUE num, VALUE n, VALUE f)
 /*
  * Assumes num is an Integer, ndigits <= 0
  */
-VALUE
+static VALUE
 rb_int_round(VALUE num, int ndigits, enum ruby_num_rounding_mode mode)
 {
     VALUE n, f, h, r;
@@ -3342,7 +3343,7 @@ rb_int_succ(VALUE num)
  *     (-1).pred   #=> -2
  */
 
-VALUE
+static VALUE
 rb_int_pred(VALUE num)
 {
     if (FIXNUM_P(num)) {

--- a/vm_args.c
+++ b/vm_args.c
@@ -14,6 +14,9 @@ NORETURN(static void argument_kw_error(rb_execution_context_t *ec, const rb_iseq
 VALUE rb_keyword_error_new(const char *error, VALUE keys); /* class.c */
 static VALUE method_missing(VALUE obj, ID id, int argc, const VALUE *argv,
                             enum method_missing_reason call_status, int kw_splat);
+#if !defined(_MSC_VER) || !defined(MJIT_HEADER)
+MJIT_FUNC_EXPORTED const rb_callable_method_entry_t *rb_resolve_refined_method_callable(VALUE refinements, const rb_callable_method_entry_t *me);
+#endif
 
 struct args_info {
     /* basic args info */

--- a/vm_core.h
+++ b/vm_core.h
@@ -1027,9 +1027,6 @@ rb_iseq_t *rb_iseq_new_with_callback(const struct rb_iseq_new_with_callback_call
     VALUE name, VALUE path, VALUE realpath, VALUE first_lineno,
     const rb_iseq_t *parent, enum iseq_type, const rb_compile_option_t*);
 
-/* src -> iseq */
-rb_iseq_t *rb_iseq_compile_with_option(VALUE src, VALUE file, VALUE realpath, VALUE line, VALUE opt);
-
 VALUE rb_iseq_disasm(const rb_iseq_t *iseq);
 int rb_iseq_disasm_insn(VALUE str, const VALUE *iseqval, size_t pos, const rb_iseq_t *iseq, VALUE child);
 
@@ -1708,7 +1705,6 @@ typedef int rb_backtrace_iter_func(void *, VALUE, int, VALUE);
 rb_control_frame_t *rb_vm_get_ruby_level_next_cfp(const rb_execution_context_t *ec, const rb_control_frame_t *cfp);
 rb_control_frame_t *rb_vm_get_binding_creatable_next_cfp(const rb_execution_context_t *ec, const rb_control_frame_t *cfp);
 int rb_vm_get_sourceline(const rb_control_frame_t *);
-VALUE rb_name_err_mesg_new(VALUE mesg, VALUE recv, VALUE method);
 void rb_vm_stack_to_heap(rb_execution_context_t *ec);
 void ruby_thread_init_stack(rb_thread_t *th);
 int rb_vm_control_frame_id_and_class(const rb_control_frame_t *cfp, ID *idp, ID *called_idp, VALUE *klassp);

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -496,6 +496,8 @@ check_funcall_missing(rb_execution_context_t *ec, VALUE klass, VALUE recv, ID mi
     return ret;
 }
 
+static VALUE rb_check_funcall_default_kw(VALUE recv, ID mid, int argc, const VALUE *argv, VALUE def, int kw_splat);
+
 VALUE
 rb_check_funcall_kw(VALUE recv, ID mid, int argc, const VALUE *argv, int kw_splat)
 {
@@ -508,7 +510,7 @@ rb_check_funcall(VALUE recv, ID mid, int argc, const VALUE *argv)
     return rb_check_funcall_default_kw(recv, mid, argc, argv, Qundef, RB_NO_KEYWORDS);
 }
 
-VALUE
+static VALUE
 rb_check_funcall_default_kw(VALUE recv, ID mid, int argc, const VALUE *argv, VALUE def, int kw_splat)
 {
     VALUE klass = CLASS_OF(recv);

--- a/vm_method.c
+++ b/vm_method.c
@@ -961,6 +961,7 @@ rb_resolve_refined_method(VALUE refinements, const rb_method_entry_t *me)
     return resolve_refined_method(refinements, me, NULL);
 }
 
+MJIT_FUNC_EXPORTED
 const rb_callable_method_entry_t *
 rb_resolve_refined_method_callable(VALUE refinements, const rb_callable_method_entry_t *me)
 {


### PR DESCRIPTION
These functions are used from within a compilation unit so we can make them static, for better binary size.  This changeset reduces the size of generated ruby binary from 26,590,128 bytes to 26,584,472 bytes on my macihne.