### PR TITLE
Fix "cannot find the function: strcpy()" error on arm32 on Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -304,6 +304,7 @@ env:
         tool/travis_retry.sh sudo -E apt-get $travis_apt_get_options install \
           ccache \
           crossbuild-essential-armhf \
+          libc6:armhf \
           libstdc++-5-dev:armhf \
           libffi-dev:armhf \
           libffi6:armhf \
@@ -432,7 +433,6 @@ matrix:
     - <<: *CALL_THREADED_CODE
     - <<: *NO_THREADED_CODE
   allow_failures:
-    - name: arm32-linux
     - name: -fsanitize=address
     - name: -fsanitize=memory
     - name: -fsanitize=undefined


### PR DESCRIPTION
This PR is pointed out from https://bugs.ruby-lang.org/issues/16234#note-25 .

This PR fixes the failure in Travis CI arm32.
So, I remove arm32 case from allow_failures.

Here is the example of the issue.
https://travis-ci.org/ruby/ruby/jobs/611483288#L3018

```
/home/travis/build/ruby/ruby/build/.ext/common/fiddle/import.rb:299:in `import_function': cannot find the function: strcpy() (Fiddle::DLError)
```

This issue happened when `libc.so` and `libm.so` path were not found
and `ldd ruby` command also failed to print the shared dependencies
in `test/fiddle/helper.rb`.

I set `libc6:armhf` as a installing dependency explicitly.

The Travis is succeeded at my forked repository.
https://travis-ci.org/junaruga/ruby/builds/615088201
