### PR TITLE
Add Pathname#mkdir_p and alias #mkpath to it

### DIFF
--- a/ext/pathname/lib/pathname.rb
+++ b/ext/pathname/lib/pathname.rb
@@ -573,11 +573,12 @@ class Pathname    # * FileUtils *
   # exist.
   #
   # See FileUtils.mkpath and FileUtils.mkdir_p
-  def mkpath
+  def mkdir_p
     require 'fileutils'
-    FileUtils.mkpath(@path)
+    FileUtils.mkdir_p(@path)
     nil
   end
+  alias :mkpath :mkdir_p
 
   # Recursively deletes a directory, including all directories beneath it.
   #

--- a/ext/pathname/pathname.c
+++ b/ext/pathname/pathname.c
@@ -1487,6 +1487,7 @@ path_f_pathname(VALUE self, VALUE str)
  *
  * These methods are a mixture of Find, FileUtils, and others:
  * - #find(&block)
+ * - #mkdir_p
  * - #mkpath
  * - #rmtree
  * - #unlink / #delete


### PR DESCRIPTION
The method `FileUtils.mkdir_p` is more frequently used than `FileUtils.mkpath` here are some searches:

- `FileUtils.mkdir_p` has 1,000,000+ references on GitHub https://github.com/search?q=FileUtils.mkdir_p
- `FileUtils.mkpath` has 53,000+ references on GitHub https://github.com/search?q=FileUtils.mkpath

Based on this search it looks like people are 18x more likely to want to use `mkdir_p` than `mkpath`.

If you are trying to use Pathname without ready access to the documentation and falsely believe that it has a `mkdir_p` method you will get an error:

```ruby
Pathname.new("/tmp/blerg").mkdir_p
Traceback (most recent call last):
        4: from /Users/rschneeman/.rubies/ruby-2.6.5/bin/irb:23:in `<main>'
        3: from /Users/rschneeman/.rubies/ruby-2.6.5/bin/irb:23:in `load'
        2: from /Users/rschneeman/.rubies/ruby-2.6.5/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
        1: from (irb):3
NoMethodError (undefined method `mkdir_p' for #<Pathname:/tmp/blerg>)
Did you mean?  mkdir
```

That suggests to use `mkdir` rather than `mkpath`, this is confusing. We should add the `mkdir_p` method to `Pathname` to eliminate confusion and provide for a better development experience.

This commit adds `Pathname#mkdir_p` and aliases `Pathname#mkpath` to it. This is consistent with `FileUtils` as `FileUtils#mkpath` is aliased to `FileUtils#mkdir_p`.

On a personal note, this PR was prompted by me complaining to several developers (including a C-Ruby committer) that Pathname didn't have a `mkdir_p` method, none of them knew (and I had previously never seen) about `Pathname#mkpath`. 

My original purpose for this PR was to add `mkdir_p` functionality. Now that I see it already exists, I think we can make the behavior more discoverable by adding this alias.