### PR TITLE
Speed up GC.compact

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -8444,7 +8444,7 @@ gc_compact(rb_objspace_t *objspace, int use_toward_empty, int use_double_pages, 
         /* pin objects referenced by maybe pointers */
         garbage_collect(objspace, GPR_DEFAULT_REASON);
         /* compact */
-        gc_compact_after_gc(objspace, use_toward_empty, use_double_pages, TRUE);
+        gc_compact_after_gc(objspace, use_toward_empty, use_double_pages, use_verifier);
     }
     objspace->flags.during_compacting = FALSE;
 }


### PR DESCRIPTION
This speeds up `GC.compact` by:
* Fixing a bug where `use_verifier` was always `TRUE`, doing unnecessary verification work
* Only counting pinned slots once per page instead of once per comparison (probably about `2 * N log N)`
* Make pinned slot counting faster by relying only on the bitmap (accessing much less memory) and making use of popcount (much fewer instructions).

## Benchmark

```
OBJECT_COUNT = 1_000_000
COMPACT_COUNT = 100

GC.start

objects = Array.new(OBJECT_COUNT) { Object.new }

if ENV["GC_ONLY"]
  COMPACT_COUNT.times { GC.start }
else
  COMPACT_COUNT.times { GC.compact }
end
```

**Before**

```
$ time GC_ONLY=1 ./ruby --disable-gems benchmark_gc_compact.rb
GC_ONLY=1 ./ruby --disable-gems benchmark_gc_compact.rb  2.12s user 0.02s system 99% cpu 2.138 total
$ time ./ruby --disable-gems benchmark_gc_compact.rb
./ruby --disable-gems benchmark_gc_compact.rb  17.83s user 0.02s system 99% cpu 17.871 total
```

**After**

```
$ time GC_ONLY=1 ./ruby --disable-gems benchmark_gc_compact.rb
GC_ONLY=1 ./ruby --disable-gems benchmark_gc_compact.rb  2.20s user 0.02s system 99% cpu 2.215 total
$ time ./ruby --disable-gems benchmark_gc_compact.rb
./ruby --disable-gems benchmark_gc_compact.rb  2.95s user 0.03s system 99% cpu 2.980 total
```
