### PR TITLE
debug.rb: expand filenames in breakpoints

### DIFF
--- a/lib/debug.rb
+++ b/lib/debug.rb
@@ -427,7 +427,7 @@ class DEBUGGER__
             pos = $2
             if $1
               klass = debug_silent_eval($1, binding)
-              file = $1
+              file = File.expand_path($1)
             end
             if pos =~ /^\d+$/
               pname = pos


### PR DESCRIPTION
When debugging some local code, specifying a breakpoint to a local
filename does not work, i.e.

    break lib/foo.rb:10

Expanding the filename makes it work. FWIW byebug has the same behavior.