### PR TITLE
Prefer class_serial over m_tbl

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -3794,10 +3794,10 @@ obj_memsize_of(VALUE obj, int use_all_types)
 	break;
       case T_MODULE:
       case T_CLASS:
-	if (RCLASS_M_TBL(obj)) {
-	    size += rb_id_table_memsize(RCLASS_M_TBL(obj));
-	}
 	if (RCLASS_EXT(obj)) {
+            if (RCLASS_M_TBL(obj)) {
+                size += rb_id_table_memsize(RCLASS_M_TBL(obj));
+            }
 	    if (RCLASS_IV_TBL(obj)) {
 		size += st_memsize(RCLASS_IV_TBL(obj));
 	    }
@@ -5306,11 +5306,11 @@ gc_mark_children(rb_objspace_t *objspace, VALUE obj)
     switch (BUILTIN_TYPE(obj)) {
       case T_CLASS:
       case T_MODULE:
-	mark_m_tbl(objspace, RCLASS_M_TBL(obj));
         if (RCLASS_SUPER(obj)) {
             gc_mark(objspace, RCLASS_SUPER(obj));
         }
 	if (!RCLASS_EXT(obj)) break;
+        mark_m_tbl(objspace, RCLASS_M_TBL(obj));
         mark_tbl_no_pin(objspace, RCLASS_IV_TBL(obj));
 	mark_const_tbl(objspace, RCLASS_CONST_TBL(obj));
 	break;


### PR DESCRIPTION
Decades ago, among all the data that a class has, its method table was no doubt the most frequently accessed data.  Previous data structures were based on that assumption.

Today that is no longer true.  The most frequently accessed field moved to class_serial.  That field is not always as wide as VALUE but if it is, let us swap m_tbl and class_serial.

```
Calculating -------------------------------------
                               ours       trunk
Optcarrot Lan_Master.nes     47.363      46.630 fps

Comparison:
             Optcarrot Lan_Master.nes
                    ours:        47.4 fps
                   trunk:        46.6 fps - 1.02x  slower
```