### PR TITLE
Fix load error

### DIFF
--- a/io.c
+++ b/io.c
@@ -308,23 +308,29 @@ rb_fix_detect_o_cloexec(int fd)
 
 int
 get_rb_cloexec_open_retry_interval() {
-    const char *interval = getenv("RB_CLOEXEC_OPEN_RETRY_INTERVAL");
+    const char *env_str = getenv("RB_CLOEXEC_OPEN_RETRY_INTERVAL");
 
-    if (interval) {
-        return atof(interval);
+    if (env_str) {
+        int ret = atoi(env_str);
+        free(env_str);
+        return ret;
     }
 
+    // RB_CLOEXEC_OPEN_RETRY_INTERVAL: default value is 0
     return 0;
 }
 
 int
 get_rb_cloexec_open_retry_max_count() {
-    const char *count = getenv("RB_CLOEXEC_OPEN_RETRY_MAX_COUNT");
+    const char *env_str = getenv("RB_CLOEXEC_OPEN_RETRY_MAX_COUNT");
 
-    if (count) {
-        return atoi(count);
+    if (env_str) {
+        int ret = atoi(env_str);
+        free(env_str);
+        return ret;
     }
 
+    // RB_CLOEXEC_OPEN_RETRY_MAX_COUNT: default value is 10000
     return 10000;
 }
 
@@ -355,13 +361,13 @@ rb_cloexec_open(const char *pathname, int flags, mode_t mode)
     flags |= O_NOINHERIT;
 #endif
 
-    while (true) {
+    while (1) {
         ret = open(pathname, flags, mode);
         e = errno;
 
         if (ret != -1 || e != EAGAIN || retry_count >= retry_max_count) {
             if (retry_count > 0) {
-                fprintf(stderr, "%s:%d %s - pathname = %s, ret = %d, errno = %d, retry_count = %d\n", __FILE__, __LINE__, __func__, pathname, ret, errno, retry_count);
+                // fprintf(stderr, "%s:%d %s - pathname = %s, ret = %d, errno = %d, retry_count = %d\n", __FILE__, __LINE__, __func__, pathname, ret, errno, retry_count);
             }
 
             break;

--- a/io.c
+++ b/io.c
@@ -307,10 +307,46 @@ rb_fix_detect_o_cloexec(int fd)
 }
 
 int
+get_rb_cloexec_open_retry_interval() {
+    const char *interval = getenv("RB_CLOEXEC_OPEN_RETRY_INTERVAL");
+
+    if (interval) {
+        return atof(interval);
+    }
+
+    return 0;
+}
+
+int
+get_rb_cloexec_open_retry_max_count() {
+    const char *count = getenv("RB_CLOEXEC_OPEN_RETRY_MAX_COUNT");
+
+    if (count) {
+        return atoi(count);
+    }
+
+    return 10000;
+}
+
+int
 rb_cloexec_open(const char *pathname, int flags, mode_t mode)
 {
     int ret;
     static int o_cloexec_state = -1; /* <0: unknown, 0: ignored, >0: working */
+
+    static int retry_init = 0;
+    static double retry_interval = 0;
+    static int retry_max_count = 0;
+
+    int retry_count = 0;
+    int e;
+
+    if (!retry_init) {
+        retry_init = 1;
+
+        retry_interval = get_rb_cloexec_open_retry_interval();
+        retry_max_count = get_rb_cloexec_open_retry_max_count();
+    }
 
 #ifdef O_CLOEXEC
     /* O_CLOEXEC is available since Linux 2.6.23.  Linux 2.6.18 silently ignore it. */
@@ -318,7 +354,23 @@ rb_cloexec_open(const char *pathname, int flags, mode_t mode)
 #elif defined O_NOINHERIT
     flags |= O_NOINHERIT;
 #endif
-    ret = open(pathname, flags, mode);
+
+    while (true) {
+        ret = open(pathname, flags, mode);
+        e = errno;
+
+        if (ret != -1 || e != EAGAIN || retry_count >= retry_max_count) {
+            if (retry_count > 0) {
+                fprintf(stderr, "%s:%d %s - pathname = %s, ret = %d, errno = %d, retry_count = %d\n", __FILE__, __LINE__, __func__, pathname, ret, errno, retry_count);
+            }
+
+            break;
+        }
+
+        retry_count++;
+        sleep(retry_interval);
+    }
+
     if (ret < 0) return ret;
     if (ret <= 2 || o_cloexec_state == 0) {
 	rb_maygvl_fd_fix_cloexec(ret);

--- a/io.c
+++ b/io.c
@@ -307,52 +307,16 @@ rb_fix_detect_o_cloexec(int fd)
 }
 
 int
-get_rb_cloexec_open_retry_interval() {
-    const char *env_str = getenv("RB_CLOEXEC_OPEN_RETRY_INTERVAL");
-
-    if (env_str) {
-        int ret = atoi(env_str);
-        free(env_str);
-        return ret;
-    }
-
-    // RB_CLOEXEC_OPEN_RETRY_INTERVAL: default value is 0
-    return 0;
-}
-
-int
-get_rb_cloexec_open_retry_max_count() {
-    const char *env_str = getenv("RB_CLOEXEC_OPEN_RETRY_MAX_COUNT");
-
-    if (env_str) {
-        int ret = atoi(env_str);
-        free(env_str);
-        return ret;
-    }
-
-    // RB_CLOEXEC_OPEN_RETRY_MAX_COUNT: default value is 10000
-    return 10000;
-}
-
-int
 rb_cloexec_open(const char *pathname, int flags, mode_t mode)
 {
     int ret;
     static int o_cloexec_state = -1; /* <0: unknown, 0: ignored, >0: working */
 
-    static int retry_init = 0;
-    static double retry_interval = 0;
-    static int retry_max_count = 0;
+    static const int retry_interval = 0;
+    static const int retry_max_count = 10000;
 
     int retry_count = 0;
     int e;
-
-    if (!retry_init) {
-        retry_init = 1;
-
-        retry_interval = get_rb_cloexec_open_retry_interval();
-        retry_max_count = get_rb_cloexec_open_retry_max_count();
-    }
 
 #ifdef O_CLOEXEC
     /* O_CLOEXEC is available since Linux 2.6.23.  Linux 2.6.18 silently ignore it. */
@@ -366,10 +330,6 @@ rb_cloexec_open(const char *pathname, int flags, mode_t mode)
         e = errno;
 
         if (ret != -1 || e != EAGAIN || retry_count >= retry_max_count) {
-            if (retry_count > 0) {
-                // fprintf(stderr, "%s:%d %s - pathname = %s, ret = %d, errno = %d, retry_count = %d\n", __FILE__, __LINE__, __func__, pathname, ret, errno, retry_count);
-            }
-
             break;
         }
 


### PR DESCRIPTION
This is a fix related to the following issue.
https://github.com/rails/rails/issues/33464

Not only in rails apps, some little ruby app with only 2 or 3 ruby files reproduce the problem during many years. 

When I edit linux ruby files by vs code via samba on windows, and then I execute the ruby files on linux, "require_relative" will sometimes not work properly.

My solution is to wait a monument if the required relative file is busy.