### PR TITLE
Drop windows-2016 on GitHub Actions

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -11,13 +11,8 @@ jobs:
     strategy:
       matrix:
         test_task: [test]
-        os: [windows-2016, windows-2019]
-        vs: [2017, 2019]
-        exclude:
-          - os: windows-2016
-            vs: 2019
-          - os: windows-2019
-            vs: 2017
+        os: [windows-2019]
+        vs: [2019]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     if: "!contains(github.event.head_commit.message, '[ci skip]')"


### PR DESCRIPTION
https://help.github.com/en/actions/automating-your-workflow-with-github-actions/software-installed-on-github-hosted-runners#windows-server-2016
> Note: The Windows Server 2016 virtual environment will be removed on December 3, 2019.