### PR TITLE
Fix documentation of `MonitorMixin#new_cond` [ci skip]

### DIFF
--- a/ext/monitor/lib/monitor.rb
+++ b/ext/monitor/lib/monitor.rb
@@ -205,7 +205,7 @@ module MonitorMixin
 
   #
   # Creates a new MonitorMixin::ConditionVariable associated with the
-  # receiver.
+  # Monitor object.
   #
   def new_cond
     return ConditionVariable.new(@mon_data)


### PR DESCRIPTION
Since https://github.com/ruby/ruby/pull/2576, `new_cond` uses the Monitor object, not the receiver.