### PR TITLE
Supress class variable overtaken warning when original modules are the same

### DIFF
--- a/test/ruby/test_variable.rb
+++ b/test/ruby/test_variable.rb
@@ -63,6 +63,29 @@ class TestVariable < Test::Unit::TestCase
     assert_equal(1, o.singleton_class.class_variable_get(:@@foo))
   end
 
+  class IncludeRefinedModuleClassVariableNoWarning
+    module Mod
+      @@_test_include_refined_module_class_variable = true
+    end
+
+    module Mod2
+      refine Mod do
+      end
+    end
+
+    include Mod
+
+    def t
+      @@_test_include_refined_module_class_variable
+    end
+  end
+
+  def test_include_refined_module_class_variable
+    assert_warning('') do
+      IncludeRefinedModuleClassVariableNoWarning.new.t
+    end
+  end
+
   def test_variable
     assert_instance_of(Integer, $$)
 

--- a/variable.c
+++ b/variable.c
@@ -3025,7 +3025,7 @@ cvar_overtaken(VALUE front, VALUE target, ID id)
     if (front && target != front) {
 	st_data_t did = (st_data_t)id;
 
-	if (RTEST(ruby_verbose)) {
+        if (RTEST(ruby_verbose) && original_module(front) != original_module(target)) {
 	    rb_warning("class variable % "PRIsVALUE" of %"PRIsVALUE" is overtaken by %"PRIsVALUE"",
 		       ID2SYM(id), rb_class_name(original_module(front)),
 		       rb_class_name(original_module(target)));


### PR DESCRIPTION
This issue was exposed by recent commits to better support including
refined modules.