### PR TITLE
Optimize Array#rotate!(n) for n = 1 and n = -1

### DIFF
--- a/array.c
+++ b/array.c
@@ -2607,10 +2607,20 @@ rotate_count(long cnt, long len)
 static void
 ary_rotate_ptr(VALUE *ptr, long len, long cnt)
 {
-    --len;
-    if (cnt < len) ary_reverse(ptr + cnt, ptr + len);
-    if (--cnt > 0) ary_reverse(ptr, ptr + cnt);
-    if (len > 0) ary_reverse(ptr, ptr + len);
+    if (cnt == 1) {
+        VALUE tmp = *ptr;
+        memmove(ptr, ptr + 1, sizeof(VALUE)*(len - 1));
+        *(ptr + len - 1) = tmp;
+    } else if (cnt == len - 1) {
+        VALUE tmp = *(ptr + len - 1);
+        memmove(ptr + 1, ptr, sizeof(VALUE)*(len - 1));
+        *ptr = tmp;
+    } else {
+        --len;
+        if (cnt < len) ary_reverse(ptr + cnt, ptr + len);
+        if (--cnt > 0) ary_reverse(ptr, ptr + cnt);
+        if (len > 0) ary_reverse(ptr, ptr + len);
+    }
 }
 
 VALUE
@@ -2620,7 +2630,7 @@ rb_ary_rotate(VALUE ary, long cnt)
 
     if (cnt != 0) {
         long len = RARRAY_LEN(ary);
-        if (len > 0 && (cnt = rotate_count(cnt, len)) > 0) {
+        if (len > 1 && (cnt = rotate_count(cnt, len)) > 0) {
             RARRAY_PTR_USE_TRANSIENT(ary, ptr, ary_rotate_ptr(ptr, len, cnt));
             return ary;
         }


### PR DESCRIPTION
For the most common cases of `rotate!` one place to the right or to the left, instead of doing some reversals of the array we just keep a single value in a temporary value, use memmove and then put the temporary value where it should be.

I tried it with this code:

```ruby
a = (1..1_000).to_a

time = Time.now
1_000_000.times do
  a.rotate!
end
puts Time.now - time
```

Old time: 0.540512
New time: 0.122193

Similar results with `rotate!(-1)`.

Also notice I changed the condition from `len > 0` to `len > 1`: if the array has only one element rotating it will always keep it the same way so there's no need to do anything.

For reference, we are doing similar optimizations in Crystal: https://github.com/crystal-lang/crystal/pull/8516/files

There's actually another optimization one can do, if one is willing to sacrifice some stack space: we can use a stack-allocated array when `cnt` is small, for example 16 or less, then do three memmove which should be faster than rotating the array. But I left it out of this PR because `rotate!` might become too complex, and maybe `rotate!(1)` and `rotate!(-1)` are the most common cases.

I also tested this with smaller arrays: it seems when the length of the array is less than 15, the reverse method is actually slightly faster. But for len >= 15 this new method is always faster. So maybe we could add that check to avoid specialcasing for 1 and -1 (I didn't include it in this PR because I'd like to know whether you think this is good or not).