### PR TITLE
Fix Leaked file descriptor in test/did_you_mean

### DIFF
--- a/test/did_you_mean/core_ext/test_name_error_extension.rb
+++ b/test/did_you_mean/core_ext/test_name_error_extension.rb
@@ -35,14 +35,14 @@ class NameErrorExtensionTest < Test::Unit::TestCase
   def test_correctable_error_objects_are_dumpable
     error =
       begin
-        Dir.chdir(__dir__) { File.open('test_name_error_extension.rb').sizee }
+        Dir.chdir(__dir__) { File.open('test_name_error_extension.rb') { |f| f.sizee } }
       rescue NoMethodError => e
         e
       end
 
     error.to_s
 
-    assert_equal "undefined method `sizee' for #<File:test_name_error_extension.rb>",
+    assert_equal "undefined method `sizee' for #<File:test_name_error_extension.rb (closed)>",
                  Marshal.load(Marshal.dump(error)).original_message
   end
 end


### PR DESCRIPTION
https://github.com/ruby/ruby/commit/de74d2c3b0005048a2c4433bde68b9be10c86f01/checks?check_suite_id=336910877#step:19:131
```
Leaked file descriptor: NameErrorExtensionTest#test_correctable_error_objects_are_dumpable: 7 : #<File:test_name_error_extension.rb>
```