### PR TITLE
Perform full MSYS2/MinGW update for build, -fstack-protector-strong - spec freeze

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -100,9 +100,8 @@ for:
     - SET PATH=%ruby_path%\bin;C:\msys64\%MSYSTEM%\bin;C:\msys64\usr\bin;%PATH%
     - ruby --version
   build_script:
-    - pacman -Syd --noconfirm --noprogressbar --needed mingw-w64-x86_64-binutils mingw-w64-x86_64-isl mingw-w64-x86_64-libiconv mingw-w64-x86_64-mpc mingw-w64-x86_64-gcc-libs mingw-w64-x86_64-windows-default-manifest mingw-w64-x86_64-winpthreads mingw-w64-x86_64-gcc
-    # when fixed in MSYS2 / Mingw-w64, remove above and use normal code below
-    #- pacman -Sy --noconfirm --noprogressbar --needed mingw-w64-x86_64-toolchain
+    # below is all packages needed for Ruby from mingw-w64-x86_64-toolchain
+    - pacman -Syd --noconfirm --noprogressbar --needed mingw-w64-x86_64-binutils mingw-w64-x86_64-crt mingw-w64-x86_64-headers mingw-w64-x86_64-isl mingw-w64-x86_64-libiconv mingw-w64-x86_64-mpc mingw-w64-x86_64-windows-default-manifest mingw-w64-x86_64-libwinpthread mingw-w64-x86_64-winpthreads  mingw-w64-x86_64-gcc-libs mingw-w64-x86_64-gcc
     - pacman -S  --noconfirm --noprogressbar --needed mingw-w64-x86_64-gdbm mingw-w64-x86_64-gmp mingw-w64-x86_64-libffi mingw-w64-x86_64-libyaml mingw-w64-x86_64-openssl mingw-w64-x86_64-ragel mingw-w64-x86_64-readline mingw-w64-x86_64-zlib
     - cd %APPVEYOR_BUILD_FOLDER%
     - set CFLAGS=-march=%MSYS2_ARCH:_=-% -mtune=generic -O3 -pipe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -104,10 +104,10 @@ for:
     - pacman -Syd --noconfirm --noprogressbar --needed mingw-w64-x86_64-binutils mingw-w64-x86_64-crt mingw-w64-x86_64-headers mingw-w64-x86_64-isl mingw-w64-x86_64-libiconv mingw-w64-x86_64-mpc mingw-w64-x86_64-windows-default-manifest mingw-w64-x86_64-libwinpthread mingw-w64-x86_64-winpthreads  mingw-w64-x86_64-gcc-libs mingw-w64-x86_64-gcc
     - pacman -S  --noconfirm --noprogressbar --needed mingw-w64-x86_64-gdbm mingw-w64-x86_64-gmp mingw-w64-x86_64-libffi mingw-w64-x86_64-libyaml mingw-w64-x86_64-openssl mingw-w64-x86_64-ragel mingw-w64-x86_64-readline mingw-w64-x86_64-zlib
     - cd %APPVEYOR_BUILD_FOLDER%
-    - set CFLAGS=-march=%MSYS2_ARCH:_=-% -mtune=generic -O3 -pipe
+    - set CFLAGS=-march=%MSYS2_ARCH:_=-% -mtune=generic -O3  -fstack-protector-strong -pipe
     - set CXXFLAGS=%CFLAGS%
     - set CPPFLAGS=-D_FORTIFY_SOURCE=2 -D__USE_MINGW_ANSI_STDIO=1 -DFD_SETSIZE=2048
-    - set LDFLAGS=-pipe
+    - set LDFLAGS=-fstack-protector-strong -pipe
     - sh -c "autoreconf -fi"
     - cd ..\build
     - sh ../ruby/configure --disable-install-doc --prefix=/. --build=%MINGW_CHOST% --host=%MINGW_CHOST% --target=%MINGW_CHOST%


### PR DESCRIPTION
The current MSYS2/minGW gcc update in is not updating all gcc related packages.

https://github.com/ruby/ruby/blob/7f2cd2ae6fea76ff3a2b95b69e6e2f749e8a249f/appveyor.yml#L103

This PR updates all packages needed for gcc use in Ruby, similar to a new (or updated) MSYS2 install.

Doing so requires libssp use, otherwise build errors like `undefined references to __*_chk` will occur.  See:
https://ci.appveyor.com/project/MSP-Greg/ruby/builds/29269011/job/krgmoi642srl63d2#L1054

Second commit adds `-fstack-protector-strong` to CFLAGS and LDFLAGS, which fixes the build errors. 

But, that then causes a spec to freeze
```
C-API Thread function rb_thread_call_without_gvl
- runs a C function with the global lock unlocked
- runs a C function with the global lock unlocked and unlocks IO with the generic RUBY_UBF_IO
```

as noted in:
https://bugs.ruby-lang.org/issues/16265