### PR TITLE
Silence incorrect assigned but unused variable warnings in ripper

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -11723,11 +11723,13 @@ warn_unused_var(struct parser_params *p, struct local_vars *local)
     if (cnt != local->vars->pos) {
 	rb_parser_fatal(p, "local->used->pos != local->vars->pos");
     }
+#ifndef RIPPER
     for (i = 0; i < cnt; ++i) {
 	if (!v[i] || (u[i] & LVAR_USED)) continue;
 	if (is_private_local_id(v[i])) continue;
 	rb_warn1L((int)u[i], "assigned but unused variable - %"PRIsWARN, rb_id2str(v[i]));
     }
+#endif
 }
 
 static void


### PR DESCRIPTION
To only emit the warnings in correct cases would require tracking
local variable usage in ripper, which ripper currently does not do.

Fixes [Bug #15188]