### PR TITLE
Correctly show defined class for aliases of aliases

### DIFF
--- a/proc.c
+++ b/proc.c
@@ -1657,8 +1657,8 @@ method_entry_defined_class(const rb_method_entry_t *me)
  *   meth == other_meth  -> true or false
  *
  * Two method objects are equal if they are bound to the same
- * object and refer to the same method definition and their owners are the
- * same class or module.
+ * object and refer to the same method definition and the classes
+ * defining the methods are the same class or module.
  */
 
 static VALUE

--- a/test/ruby/test_alias.rb
+++ b/test/ruby/test_alias.rb
@@ -35,6 +35,18 @@ class TestAlias < Test::Unit::TestCase
     end
   end
 
+  class Alias4 < Alias0
+    alias foo1 foo
+    alias foo2 foo1
+    alias foo3 foo2
+  end
+
+  class Alias5 < Alias4
+    alias foo1 foo
+    alias foo3 foo2
+    alias foo2 foo1
+  end
+
   def test_alias
     x = Alias2.new
     assert_equal "foo", x.bar
@@ -45,6 +57,20 @@ class TestAlias < Test::Unit::TestCase
     assert_raise(NoMethodError) { x.foo }
     assert_equal "foo", x.bar
     assert_raise(NoMethodError) { x.quux }
+  end
+
+  def test_alias_inspect
+    o = Alias4.new
+    assert_equal("TestAlias::Alias4(TestAlias::Alias0)#foo()", o.method(:foo).inspect.split[1])
+    assert_equal("TestAlias::Alias4(TestAlias::Alias0)#foo1(foo)()", o.method(:foo1).inspect.split[1])
+    assert_equal("TestAlias::Alias4(TestAlias::Alias0)#foo2(foo)()", o.method(:foo2).inspect.split[1])
+    assert_equal("TestAlias::Alias4(TestAlias::Alias0)#foo3(foo)()", o.method(:foo3).inspect.split[1])
+
+    o = Alias5.new
+    assert_equal("TestAlias::Alias5(TestAlias::Alias0)#foo()", o.method(:foo).inspect.split[1])
+    assert_equal("TestAlias::Alias5(TestAlias::Alias0)#foo1(foo)()", o.method(:foo1).inspect.split[1])
+    assert_equal("TestAlias::Alias5(TestAlias::Alias0)#foo2(foo)()", o.method(:foo2).inspect.split[1])
+    assert_equal("TestAlias::Alias5(TestAlias::Alias0)#foo3(foo)()", o.method(:foo3).inspect.split[1])
   end
 
   def test_nonexistmethod

--- a/test/ruby/test_method.rb
+++ b/test/ruby/test_method.rb
@@ -828,7 +828,7 @@ class TestMethod < Test::Unit::TestCase
     assert_equal(c, c.instance_method(:foo).owner)
     assert_equal(c, x.method(:foo).owner)
     assert_equal(x.singleton_class, x.method(:bar).owner)
-    assert_not_equal(x.method(:foo), x.method(:bar), bug7613)
+    assert_equal(x.method(:foo), x.method(:bar), bug7613)
     assert_equal(c, x.method(:zot).owner, bug7993)
     assert_equal(c, c.instance_method(:zot).owner, bug7993)
   end

--- a/vm_method.c
+++ b/vm_method.c
@@ -1807,7 +1807,7 @@ rb_alias(VALUE klass, ID alias_name, ID original_name)
 
 	alias_me = method_entry_set(target_klass, alias_name, orig_me, visi, orig_me->owner);
 	RB_OBJ_WRITE(alias_me, &alias_me->owner, target_klass);
-	RB_OBJ_WRITE(alias_me, &alias_me->defined_class, defined_class);
+        RB_OBJ_WRITE(alias_me, &alias_me->defined_class, orig_me->defined_class);
     }
 }
 


### PR DESCRIPTION
Previously, aliasing a method defined in an ancestor class would
show the ancestor class as the defined_class for the method, but
aliasing that alias method would result in the current class
showing as the defined_class for the method.

Fix this by copying the defined_class from the main alias
method to the chained alias method if we detect such an alias
chain.

Fixes [Bug #11888]