### PR TITLE
Adding s390x support for Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -128,6 +128,11 @@ env:
     arch: arm64
     <<: *gcc-8
 
+  - &s390x-linux
+    name: s390x-linux
+    arch: s390x
+    <<: *gcc-8
+    
   - &jemalloc
     name: --with-jemalloc
     <<: *gcc-8
@@ -412,6 +417,7 @@ matrix:
     - <<: *arm64-linux
     - <<: *i686-linux
     - <<: *arm32-linux
+    - <<: *s390x-linux
     - <<: *pedanticism
     - <<: *assertions
     - <<: *baseruby


### PR DESCRIPTION
As Travis CI [officially supports](https://blog.travis-ci.com/2019-11-12-multi-cpu-architecture-ibm-power-ibm-z) s390x builds, adding support for same.