### PR TITLE
Remove unnecessary double bangs from Pathname#root?

### DIFF
--- a/ext/pathname/lib/pathname.rb
+++ b/ext/pathname/lib/pathname.rb
@@ -207,7 +207,7 @@ class Pathname
   # pathnames which points to roots such as <tt>/usr/..</tt>.
   #
   def root?
-    !!(chop_basename(@path) == nil && /#{SEPARATOR_PAT}/o.match?(@path))
+    chop_basename(@path) == nil && /#{SEPARATOR_PAT}/o.match?(@path)
   end
 
   # Predicate method for testing whether a path is absolute.


### PR DESCRIPTION
This pull request removes `!!` from `Pathname#root?` because it is unnecessary.


```ruby
def root?
  chop_basename(@path) == nil && /#{SEPARATOR_PAT}/o.match?(@path)
end
```

In this case, both of `chop_basename(@path) == nil` and `/.../.match?(@path)` return a boolean always.

Previously the `Regexp#=~` is used instead of `Regexp#match?`. So the double bangs are necessary. But it is no longer needed.
https://github.com/ruby/ruby/pull/1836