### PR TITLE
Support cross-compilation

### DIFF
--- a/builtin.c
+++ b/builtin.c
@@ -3,6 +3,13 @@
 #include "iseq.h"
 #include "builtin.h"
 
+#if CROSS_COMPILING
+
+#define INCLUDED_BY_BUILTIN_C 1
+#include "mini_builtin.c"
+
+#else
+
 #include "builtin_binary.inc"
 
 static const unsigned char*
@@ -35,6 +42,8 @@ rb_load_with_builtin_functions(const char *feature_name, const struct rb_builtin
     // exec
     rb_iseq_eval(iseq);
 }
+
+#endif
 
 void
 Init_builtin(void)

--- a/builtin.c
+++ b/builtin.c
@@ -39,5 +39,11 @@ rb_load_with_builtin_functions(const char *feature_name, const struct rb_builtin
 void
 Init_builtin(void)
 {
-    //
+    // nothing
+}
+
+void
+Init_builtin_features(void)
+{
+    rb_load_with_builtin_functions("gem_prelude", NULL);
 }

--- a/builtin.h
+++ b/builtin.h
@@ -1,3 +1,6 @@
+#ifndef BUILTIN_H_INCLUDED
+#define BUILTIN_H_INCLUDED
+
 // invoke
 
 struct rb_builtin_function {
@@ -66,3 +69,5 @@ struct builtin_binary {
     const unsigned char *bin;     // binary by ISeq#to_binary
     size_t bin_size;
 };
+
+#endif // BUILTIN_H_INCLUDED

--- a/common.mk
+++ b/common.mk
@@ -1115,7 +1115,7 @@ preludes: {$(srcdir)}golf_prelude.c
 	$(Q) $(BASERUBY) $(srcdir)/tool/mk_builtin_loader.rb $<
 
 builtin_binary.inc: $(PREP) $(BUILTIN_RB_SRCS) $(srcdir)/tool/mk_builtin_binary.rb
-	$(Q) $(MINIRUBY) $(srcdir)/tool/mk_builtin_binary.rb
+	$(Q) $(MINIRUBY) $(srcdir)/tool/mk_builtin_binary.rb --cross=$(CROSS_COMPILING)
 
 $(BUILTIN_RB_INCS): $(top_srcdir)/tool/mk_builtin_loader.rb
 

--- a/common.mk
+++ b/common.mk
@@ -76,7 +76,7 @@ NORMALMAINOBJ = main.$(OBJEXT)
 MAINOBJ       = $(NORMALMAINOBJ)
 DLDOBJS	      = $(INITOBJS)
 EXTSOLIBS     =
-MINIOBJS      = $(ARCHMINIOBJS) miniinit.$(OBJEXT) dmyext.$(OBJEXT) miniprelude.$(OBJEXT)
+MINIOBJS      = $(ARCHMINIOBJS) miniinit.$(OBJEXT) dmyext.$(OBJEXT)
 ENC_MK        = enc.mk
 MAKE_ENC      = -f $(ENC_MK) V="$(V)" UNICODE_HDR_DIR="$(UNICODE_HDR_DIR)" \
 		RUBY="$(MINIRUBY)" MINIRUBY="$(MINIRUBY)" $(mflags)
@@ -157,7 +157,7 @@ EXPORTOBJS    = $(DLNOBJ) \
 		loadpath.$(OBJEXT) \
 		$(COMMONOBJS)
 
-OBJS          = $(EXPORTOBJS) prelude.$(OBJEXT) builtin.$(OBJEXT)
+OBJS          = $(EXPORTOBJS) builtin.$(OBJEXT)
 ALLOBJS       = $(NORMALMAINOBJ) $(MINIOBJS) $(COMMONOBJS) $(INITOBJS)
 
 GOLFOBJS      = goruby.$(OBJEXT) golf_prelude.$(OBJEXT)
@@ -165,7 +165,7 @@ GOLFOBJS      = goruby.$(OBJEXT) golf_prelude.$(OBJEXT)
 DEFAULT_PRELUDES = $(GEM_PRELUDE)
 PRELUDE_SCRIPTS = $(DEFAULT_PRELUDES)
 GEM_PRELUDE   = 
-PRELUDES      = {$(srcdir)}prelude.c {$(srcdir)}miniprelude.c
+PRELUDES      = {$(srcdir)}miniprelude.c
 GOLFPRELUDES  = {$(srcdir)}golf_prelude.c
 
 SCRIPT_ARGS   =	--dest-dir="$(DESTDIR)" \
@@ -949,7 +949,6 @@ $(COROUTINE_H:/Context.h=/.time):
 # dependencies for generated C sources.
 parse.$(OBJEXT): {$(VPATH)}parse.c
 miniprelude.$(OBJEXT): {$(VPATH)}miniprelude.c
-prelude.$(OBJEXT): {$(VPATH)}prelude.c
 
 # dependencies for optional sources.
 compile.$(OBJEXT): {$(VPATH)}opt_sc.inc {$(VPATH)}optunifs.inc
@@ -1088,12 +1087,6 @@ $(MINIPRELUDE_C): $(COMPILE_PRELUDE) $(BUILTIN_RB_SRCS)
 	$(Q) $(BASERUBY) $(srcdir)/tool/generic_erb.rb -I$(srcdir) -o $@ \
 		$(srcdir)/template/prelude.c.tmpl $(BUILTIN_RB_SRCS)
 
-$(PRELUDE_C): $(COMPILE_PRELUDE) \
-	   $(PRELUDE_SCRIPTS)
-	$(ECHO) generating $@
-	$(Q) $(BASERUBY) $(srcdir)/tool/generic_erb.rb -I$(srcdir) -c -o $@ \
-		$(srcdir)/template/prelude.c.tmpl $(PRELUDE_SCRIPTS)
-
 $(GOLF_PRELUDE_C): $(COMPILE_PRELUDE) {$(srcdir)}golf_prelude.rb
 	$(ECHO) generating $@
 	$(Q) $(BASERUBY) $(srcdir)/tool/generic_erb.rb -I$(srcdir) -c -o $@ \
@@ -1114,7 +1107,6 @@ probes.h: {$(VPATH)}probes.$(DTRACE_EXT)
 
 prereq: incs srcs preludes PHONY
 
-preludes: {$(VPATH)}prelude.c
 preludes: {$(VPATH)}miniprelude.c
 preludes: {$(srcdir)}golf_prelude.c
 
@@ -2373,6 +2365,7 @@ miniinit.$(OBJEXT): {$(VPATH)}iseq.h
 miniinit.$(OBJEXT): {$(VPATH)}method.h
 miniinit.$(OBJEXT): {$(VPATH)}mini_builtin.c
 miniinit.$(OBJEXT): {$(VPATH)}miniinit.c
+miniinit.$(OBJEXT): {$(VPATH)}miniprelude.c
 miniinit.$(OBJEXT): {$(VPATH)}missing.h
 miniinit.$(OBJEXT): {$(VPATH)}node.h
 miniinit.$(OBJEXT): {$(VPATH)}onigmo.h
@@ -2385,37 +2378,6 @@ miniinit.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).h
 miniinit.$(OBJEXT): {$(VPATH)}thread_native.h
 miniinit.$(OBJEXT): {$(VPATH)}vm_core.h
 miniinit.$(OBJEXT): {$(VPATH)}vm_opts.h
-miniprelude.$(OBJEXT): $(CCAN_DIR)/check_type/check_type.h
-miniprelude.$(OBJEXT): $(CCAN_DIR)/container_of/container_of.h
-miniprelude.$(OBJEXT): $(CCAN_DIR)/list/list.h
-miniprelude.$(OBJEXT): $(CCAN_DIR)/str/str.h
-miniprelude.$(OBJEXT): $(hdrdir)/ruby.h
-miniprelude.$(OBJEXT): $(hdrdir)/ruby/ruby.h
-miniprelude.$(OBJEXT): {$(VPATH)}assert.h
-miniprelude.$(OBJEXT): {$(VPATH)}ast.rb
-miniprelude.$(OBJEXT): {$(VPATH)}config.h
-miniprelude.$(OBJEXT): {$(VPATH)}defines.h
-miniprelude.$(OBJEXT): {$(VPATH)}gc.rb
-miniprelude.$(OBJEXT): {$(VPATH)}id.h
-miniprelude.$(OBJEXT): {$(VPATH)}intern.h
-miniprelude.$(OBJEXT): {$(VPATH)}internal.h
-miniprelude.$(OBJEXT): {$(VPATH)}io.rb
-miniprelude.$(OBJEXT): {$(VPATH)}iseq.h
-miniprelude.$(OBJEXT): {$(VPATH)}method.h
-miniprelude.$(OBJEXT): {$(VPATH)}miniprelude.c
-miniprelude.$(OBJEXT): {$(VPATH)}missing.h
-miniprelude.$(OBJEXT): {$(VPATH)}node.h
-miniprelude.$(OBJEXT): {$(VPATH)}pack.rb
-miniprelude.$(OBJEXT): {$(VPATH)}prelude.rb
-miniprelude.$(OBJEXT): {$(VPATH)}ruby_assert.h
-miniprelude.$(OBJEXT): {$(VPATH)}ruby_atomic.h
-miniprelude.$(OBJEXT): {$(VPATH)}st.h
-miniprelude.$(OBJEXT): {$(VPATH)}subst.h
-miniprelude.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).h
-miniprelude.$(OBJEXT): {$(VPATH)}thread_native.h
-miniprelude.$(OBJEXT): {$(VPATH)}trace_point.rb
-miniprelude.$(OBJEXT): {$(VPATH)}vm_core.h
-miniprelude.$(OBJEXT): {$(VPATH)}vm_opts.h
 mjit.$(OBJEXT): $(CCAN_DIR)/check_type/check_type.h
 mjit.$(OBJEXT): $(CCAN_DIR)/container_of/container_of.h
 mjit.$(OBJEXT): $(CCAN_DIR)/list/list.h
@@ -2586,32 +2548,6 @@ parse.$(OBJEXT): {$(VPATH)}st.h
 parse.$(OBJEXT): {$(VPATH)}subst.h
 parse.$(OBJEXT): {$(VPATH)}symbol.h
 parse.$(OBJEXT): {$(VPATH)}util.h
-prelude.$(OBJEXT): $(CCAN_DIR)/check_type/check_type.h
-prelude.$(OBJEXT): $(CCAN_DIR)/container_of/container_of.h
-prelude.$(OBJEXT): $(CCAN_DIR)/list/list.h
-prelude.$(OBJEXT): $(CCAN_DIR)/str/str.h
-prelude.$(OBJEXT): $(hdrdir)/ruby.h
-prelude.$(OBJEXT): $(hdrdir)/ruby/ruby.h
-prelude.$(OBJEXT): {$(VPATH)}assert.h
-prelude.$(OBJEXT): {$(VPATH)}config.h
-prelude.$(OBJEXT): {$(VPATH)}defines.h
-prelude.$(OBJEXT): {$(VPATH)}gem_prelude.rb
-prelude.$(OBJEXT): {$(VPATH)}id.h
-prelude.$(OBJEXT): {$(VPATH)}intern.h
-prelude.$(OBJEXT): {$(VPATH)}internal.h
-prelude.$(OBJEXT): {$(VPATH)}iseq.h
-prelude.$(OBJEXT): {$(VPATH)}method.h
-prelude.$(OBJEXT): {$(VPATH)}missing.h
-prelude.$(OBJEXT): {$(VPATH)}node.h
-prelude.$(OBJEXT): {$(VPATH)}prelude.c
-prelude.$(OBJEXT): {$(VPATH)}ruby_assert.h
-prelude.$(OBJEXT): {$(VPATH)}ruby_atomic.h
-prelude.$(OBJEXT): {$(VPATH)}st.h
-prelude.$(OBJEXT): {$(VPATH)}subst.h
-prelude.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).h
-prelude.$(OBJEXT): {$(VPATH)}thread_native.h
-prelude.$(OBJEXT): {$(VPATH)}vm_core.h
-prelude.$(OBJEXT): {$(VPATH)}vm_opts.h
 proc.$(OBJEXT): $(CCAN_DIR)/check_type/check_type.h
 proc.$(OBJEXT): $(CCAN_DIR)/container_of/container_of.h
 proc.$(OBJEXT): $(CCAN_DIR)/list/list.h

--- a/common.mk
+++ b/common.mk
@@ -164,7 +164,7 @@ GOLFOBJS      = goruby.$(OBJEXT) golf_prelude.$(OBJEXT)
 
 DEFAULT_PRELUDES = $(GEM_PRELUDE)
 PRELUDE_SCRIPTS = $(DEFAULT_PRELUDES)
-GEM_PRELUDE   = $(srcdir)/gem_prelude.rb
+GEM_PRELUDE   = 
 PRELUDES      = {$(srcdir)}prelude.c {$(srcdir)}miniprelude.c
 GOLFPRELUDES  = {$(srcdir)}golf_prelude.c
 
@@ -1003,6 +1003,7 @@ BUILTIN_RB_SRCS = \
 		$(srcdir)/pack.rb \
 		$(srcdir)/trace_point.rb \
 		$(srcdir)/prelude.rb \
+		$(srcdir)/gem_prelude.rb \
 		$(empty)
 BUILTIN_RB_INCS = $(BUILTIN_RB_SRCS:.rb=.rbinc)
 

--- a/configure.ac
+++ b/configure.ac
@@ -3053,6 +3053,7 @@ AS_IF([test x"$cross_compiling" = xyes], [
   XRUBY='$(MINIRUBY)'
   TEST_RUNNABLE=no
   CROSS_COMPILING=yes
+  AC_DEFINE(CROSS_COMPILING, 1)
 ], [
   MINIRUBY='./miniruby$(EXEEXT) -I$(srcdir)/lib -I.'
   MINIRUBY="$MINIRUBY"' -I$(EXTOUT)/common'

--- a/internal.h
+++ b/internal.h
@@ -2395,9 +2395,6 @@ RUBY_FUNC_NONNULL(1, bool rb_method_basic_definition_p_with_cc(struct rb_call_da
     })
 #endif
 
-/* miniprelude.c, prelude.c */
-void Init_prelude(void);
-
 /* vm_backtrace.c */
 void Init_vm_backtrace(void);
 VALUE rb_vm_thread_backtrace(int argc, const VALUE *argv, VALUE thval);

--- a/mini_builtin.c
+++ b/mini_builtin.c
@@ -2,11 +2,15 @@
 #include "vm_core.h"
 #include "iseq.h"
 #include "builtin.h"
+
 #include "miniprelude.c"
 
 // included from miniinit.c
 
+#ifndef INCLUDED_BY_BUILTIN_C
 static struct st_table *loaded_builtin_table;
+#endif
+
 rb_ast_t *rb_builtin_ast(const char *feature_name, VALUE *name_str);
 
 static const rb_iseq_t *
@@ -26,8 +30,10 @@ builtin_iseq_load(const char *feature_name, const struct rb_builtin_function *ta
         rb_io_write(rb_stdout, rb_iseq_disasm((const rb_iseq_t *)iseq));
     }
 
+#ifndef INCLUDED_BY_BUILTIN_C
     st_insert(loaded_builtin_table, (st_data_t)feature_name, (st_data_t)iseq);
     rb_gc_register_mark_object((VALUE)iseq);
+#endif
 
     return iseq;
 }
@@ -38,6 +44,8 @@ rb_load_with_builtin_functions(const char *feature_name, const struct rb_builtin
     const rb_iseq_t *iseq = builtin_iseq_load(feature_name, table);
     rb_iseq_eval(iseq);
 }
+
+#ifndef INCLUDED_BY_BUILTIN_C
 
 static int
 each_builtin_i(st_data_t key, st_data_t val, st_data_t dmy)
@@ -70,3 +78,4 @@ Init_builtin_features(void)
     // register for ruby
     builtin_iseq_load("gem_prelude", NULL);
 }
+#endif

--- a/mini_builtin.c
+++ b/mini_builtin.c
@@ -2,6 +2,7 @@
 #include "vm_core.h"
 #include "iseq.h"
 #include "builtin.h"
+#include "miniprelude.c"
 
 // included from miniinit.c
 

--- a/ruby.c
+++ b/ruby.c
@@ -1408,10 +1408,12 @@ proc_options(long argc, char **argv, ruby_cmdline_options_t *opt, int envopt)
     return argc0 - argc;
 }
 
+void Init_builtin_features(void);
+
 static void
 ruby_init_prelude(void)
 {
-    Init_prelude();
+    Init_builtin_features();
     rb_const_remove(rb_cObject, rb_intern_const("TMP_RUBY_PREFIX"));
 }
 

--- a/template/Makefile.in
+++ b/template/Makefile.in
@@ -235,7 +235,6 @@ INSTALLED_LIST= .installed.list
 
 NEWLINE_C     = enc/trans/newline.c
 MINIPRELUDE_C = miniprelude.c
-PRELUDE_C     = prelude.c
 GOLF_PRELUDE_C= golf_prelude.c
 RBCONFIG      = .rbconfig.time
 

--- a/template/prelude.c.tmpl
+++ b/template/prelude.c.tmpl
@@ -38,7 +38,7 @@ class Prelude
     @builtin_count = 0
     @preludes = {}
     @mains = preludes.map do |filename|
-      if prelude = filename.end_with?("_prelude.rb")
+      if prelude = filename.end_with?("golf_prelude.rb")
         @prelude_count += 1
       else
         @builtin_count += 1

--- a/tool/mk_builtin_binary.rb
+++ b/tool/mk_builtin_binary.rb
@@ -20,7 +20,7 @@ puts <<H
 
 H
 
-if !ARGV.grep('--cross=yes').empty?
+if ARGV.include?('--cross=yes')
   # do nothing
 else
   ary = []

--- a/tool/update-deps
+++ b/tool/update-deps
@@ -128,7 +128,6 @@ FILES_NEED_VPATH = %w[
   optunifs.inc
   parse.c
   parse.h
-  prelude.c
   probes.dmyh
   vm.inc
   vmtc.inc

--- a/win32/Makefile.sub
+++ b/win32/Makefile.sub
@@ -527,11 +527,6 @@ MINIPRELUDE_C = $(srcdir)/miniprelude.c
 !else
 MINIPRELUDE_C = miniprelude.c
 !endif
-!if !exist(prelude.c) && exist($(srcdir)/prelude.c)
-PRELUDE_C = $(srcdir)/prelude.c
-!else
-PRELUDE_C = prelude.c
-!endif
 !if !exist(golf_prelude.c) && exist($(srcdir)/golf_prelude.c)
 GOLF_PRELUDE_C = $(srcdir)/golf_prelude.c
 !else


### PR DESCRIPTION
    On cross-compilation, compiled binary can no be created because
    compiled binary should be created by same interpreter (on cross-
    compilation, host ruby is used to build ruby (BASERUBY)).

    So that cross-compilation system loads required scripts in text.
    It is same as miniruby.