### PR TITLE
Pack structs push_glob0_args (40 to 32 bytes) and push_glob_args (64 to 56 bytes)

### DIFF
--- a/dir.c
+++ b/dir.c
@@ -2022,12 +2022,12 @@ dirent_match(const char *pat, rb_encoding *enc, const char *name, const struct d
 
 struct push_glob_args {
     int fd;
+    int flags;
     const char *path;
     size_t baselen;
     size_t namelen;
     int dirsep; /* '/' should be placed before appending child entry's name to 'path'. */
     rb_pathtype_t pathtype; /* type of 'path' */
-    int flags;
     const ruby_glob_funcs_t *funcs;
     VALUE arg;
 };

--- a/dir.c
+++ b/dir.c
@@ -2448,8 +2448,8 @@ static int ruby_glob0(const char *path, int fd, const char *base, int flags,
 
 struct push_glob0_args {
     int fd;
-    const char *base;
     int flags;
+    const char *base;
     const ruby_glob_funcs_t *funcs;
     VALUE arg;
 };


### PR DESCRIPTION
Before:

```
lourens@CarbonX1:~/src/ruby/ruby$ pahole -C push_glob0_args ./miniruby
struct push_glob0_args {
	int                        fd;                   /*     0     4 */

	/* XXX 4 bytes hole, try to pack */

	const char  *              base;                 /*     8     8 */
	int                        flags;                /*    16     4 */

	/* XXX 4 bytes hole, try to pack */

	const ruby_glob_funcs_t  * funcs;                /*    24     8 */
	VALUE                      arg;                  /*    32     8 */

	/* size: 40, cachelines: 1, members: 5 */
	/* sum members: 32, holes: 2, sum holes: 8 */
	/* last cacheline: 40 bytes */
};
lourens@CarbonX1:~/src/ruby/ruby$ pahole -C push_glob_args ./miniruby
struct push_glob_args {
	int                        fd;                   /*     0     4 */

	/* XXX 4 bytes hole, try to pack */

	const char  *              path;                 /*     8     8 */
	size_t                     baselen;              /*    16     8 */
	size_t                     namelen;              /*    24     8 */
	int                        dirsep;               /*    32     4 */
	rb_pathtype_t              pathtype;             /*    36     4 */
	int                        flags;                /*    40     4 */

	/* XXX 4 bytes hole, try to pack */

	const ruby_glob_funcs_t  * funcs;                /*    48     8 */
	VALUE                      arg;                  /*    56     8 */

	/* size: 64, cachelines: 1, members: 9 */
	/* sum members: 56, holes: 2, sum holes: 8 */
};
```

After:

```
lourens@CarbonX1:~/src/ruby/ruby$ pahole -C push_glob_args ./miniruby
struct push_glob_args {
	int                        fd;                   /*     0     4 */
	int                        flags;                /*     4     4 */
	const char  *              path;                 /*     8     8 */
	size_t                     baselen;              /*    16     8 */
	size_t                     namelen;              /*    24     8 */
	int                        dirsep;               /*    32     4 */
	rb_pathtype_t              pathtype;             /*    36     4 */
	const ruby_glob_funcs_t  * funcs;                /*    40     8 */
	VALUE                      arg;                  /*    48     8 */

	/* size: 56, cachelines: 1, members: 9 */
	/* last cacheline: 56 bytes */
};
lourens@CarbonX1:~/src/ruby/ruby$ pahole -C push_glob0_args ./miniruby
struct push_glob0_args {
	int                        fd;                   /*     0     4 */
	int                        flags;                /*     4     4 */
	const char  *              base;                 /*     8     8 */
	const ruby_glob_funcs_t  * funcs;                /*    16     8 */
	VALUE                      arg;                  /*    24     8 */

	/* size: 32, cachelines: 1, members: 5 */
	/* last cacheline: 32 bytes */
};
```
