### PR TITLE
Optimize defining methods on deeply included modules

### DIFF
--- a/internal.h
+++ b/internal.h
@@ -2282,6 +2282,7 @@ const char *rb_source_location_cstr(int *pline);
 MJIT_STATIC void rb_vm_pop_cfunc_frame(void);
 int rb_vm_add_root_module(ID id, VALUE module);
 void rb_vm_check_redefinition_by_prepend(VALUE klass);
+int rb_vm_check_optimizable_mid(VALUE mid);
 VALUE rb_yield_refine_block(VALUE refinement, VALUE refinements);
 MJIT_STATIC VALUE ruby_vm_special_exception_copy(VALUE);
 PUREFUNC(st_table *rb_vm_fstring_table(void));

--- a/vm_insnhelper.h
+++ b/vm_insnhelper.h
@@ -173,6 +173,7 @@ enum vm_regan_acttype {
 } while (0)
 #endif
 
+#define PREV_CLASS_SERIAL() (ruby_vm_class_serial)
 #define NEXT_CLASS_SERIAL() (++ruby_vm_class_serial)
 #define GET_GLOBAL_METHOD_STATE() (ruby_vm_global_method_state)
 #define INC_GLOBAL_METHOD_STATE() (++ruby_vm_global_method_state)

--- a/vm_method.c
+++ b/vm_method.c
@@ -500,7 +500,7 @@ rb_add_refined_method_entry(VALUE refined_class, ID mid)
 }
 
 static void
-check_override_opt_method(VALUE klass, VALUE arg)
+check_override_opt_method_i(VALUE klass, VALUE arg)
 {
     ID mid = (ID)arg;
     const rb_method_entry_t *me, *newme;
@@ -512,7 +512,15 @@ check_override_opt_method(VALUE klass, VALUE arg)
 	    if (newme != me) rb_vm_check_redefinition_opt_method(me, me->owner);
 	}
     }
-    rb_class_foreach_subclass(klass, check_override_opt_method, (VALUE)mid);
+    rb_class_foreach_subclass(klass, check_override_opt_method_i, (VALUE)mid);
+}
+
+static void
+check_override_opt_method(VALUE klass, VALUE mid)
+{
+    if (rb_vm_check_optimizable_mid(mid)) {
+        check_override_opt_method_i(klass, mid);
+    }
 }
 
 /*

--- a/vm_method.c
+++ b/vm_method.c
@@ -62,6 +62,11 @@ static struct {
 static void
 rb_class_clear_method_cache(VALUE klass, VALUE arg)
 {
+    VALUE old_serial = *(rb_serial_t *)arg;
+    if (RCLASS_SERIAL(klass) > old_serial) {
+        return;
+    }
+
     mjit_remove_class_serial(RCLASS_SERIAL(klass));
     RCLASS_SERIAL(klass) = rb_next_class_serial();
 
@@ -99,7 +104,8 @@ rb_clear_method_cache_by_class(VALUE klass)
 	    INC_GLOBAL_METHOD_STATE();
 	}
 	else {
-	    rb_class_clear_method_cache(klass, Qnil);
+	    rb_serial_t old_serial = rb_next_class_serial();
+	    rb_class_clear_method_cache(klass, (VALUE)&old_serial);
 	}
     }
 

--- a/vm_method.c
+++ b/vm_method.c
@@ -104,7 +104,7 @@ rb_clear_method_cache_by_class(VALUE klass)
 	    INC_GLOBAL_METHOD_STATE();
 	}
 	else {
-	    rb_serial_t old_serial = rb_next_class_serial();
+	    rb_serial_t old_serial = PREV_CLASS_SERIAL();
 	    rb_class_clear_method_cache(klass, (VALUE)&old_serial);
 	}
     }

--- a/vm_method.c
+++ b/vm_method.c
@@ -77,10 +77,7 @@ rb_class_clear_method_cache(VALUE klass, VALUE arg)
 	}
     }
     else {
-	if (RCLASS_CALLABLE_M_TBL(klass) != 0) {
-	    rb_obj_info_dump(klass);
-	    rb_bug("RCLASS_CALLABLE_M_TBL(klass) != 0");
-	}
+	VM_ASSERT(RCLASS_CALLABLE_M_TBL(klass) == 0);
     }
 
     rb_class_foreach_subclass(klass, rb_class_clear_method_cache, arg);

--- a/vm_method.c
+++ b/vm_method.c
@@ -70,7 +70,7 @@ rb_class_clear_method_cache(VALUE klass, VALUE arg)
     mjit_remove_class_serial(RCLASS_SERIAL(klass));
     RCLASS_SERIAL(klass) = rb_next_class_serial();
 
-    if (RB_TYPE_P(klass, T_ICLASS)) {
+    if (BUILTIN_TYPE(klass) == T_ICLASS) {
 	struct rb_id_table *table = RCLASS_CALLABLE_M_TBL(klass);
 	if (table) {
 	    rb_id_table_clear(table);


### PR DESCRIPTION
In Rails we discovered that a significant amount of time was spent defining named routes, methods on a module included by a lot of other classes. Checking profiling this time was mostly spent in `rb_class_foreach_subclass` and `rb_class_clear_method_cache`. @tenderlove helped me investigate what was happening inside Ruby and we found that it was revisiting classes and clearing their caches multiple times since there could be multiple paths to them down the subclass tree. This could also be measured by a large increase in `RubyVM.stat(:class_serial)`.

This added several seconds to the bootup time of large applications like GitHub's and Shopify's.

Though we've [improved this in Rails by avoiding some duplicate modules](https://github.com/rails/rails/pull/37927), defining these methods is still a little slow and Ruby should avoid doing duplicate work clearing caches.

This PR improves the speed of defining methods on modules which have already been included in other classes.

## `rb_clear_method_cache_by_class`

`rb_clear_method_cache_by_class` calls `rb_class_clear_method_cache` recursively on subclasses, where it will bump the class serial and clear some other data (`callable_m_tbl`, and some mjit data).

Previously this could end up taking a long time to clear all the classes if the module was included a few levels deep and especially if there were multiple paths to it in the dependency tree (ie. a class includes two modules which both include the same other module) as we end up revisiting class/iclass/module objects multiple times.

This commit avoids revisiting the same object, by short circuiting when revisit the same object. We can check this efficiently by comparing the class serial of each object we visit with the next class serial at the start. We know that any objects with a higher class serial have already been visited.

(This would probably have even more of an improvement if mjit was enabled, since it will avoid clearing that cache when possible, but I didn't test that)

## `check_override_opt_method`

This was another place we were calling `rb_class_foreach_subclass` recursively.

Previously every time a method was defined on a module, we would recursively walk all subclasses to see if the module was included in a class which the VM optimizes for (such as `Integer#+`).

For most method definitions we can tell immediately that this won't be the case based on the method's name. To do this we just keep a hash with method IDs of optimized methods and if our new method isn't in that list we don't need to check subclasses at all.

## Benchmarks

### Synthetic

This is probably an unrealistic scenario but best measures that we are avoiding duplicate work revisiting the same trees.

``` ruby
mod = initial = Module.new
10.times do
  mod = Module.new{ include initial; include mod }
end

classes = 100.times.map { Class.new { include mod } }

before = RubyVM.stat(:class_serial)
1000.times do
  initial.define_method(:foo) {  }
end
after = RubyVM.stat(:class_serial)
puts "class_serial changed by #{after - before}"
```

**Before:**

```
$ time ./ruby --disable-gems test_method_cache.rb
class_serial changed by 310160000
./ruby --disable-gems test_method_cache2.rb  3.52s user 0.00s system 99% cpu 3.522 total
```

**After:**

```
$ time ./ruby --disable-gems test_method_cache.rb
class_serial changed by 1266000
./ruby --disable-gems test_method_cache2.rb  0.03s user 0.00s system 99% cpu 0.028 total
```

### Rails without duplicate module fix

This is test is a good approximation of this part of a very large real Rails 6.0 application's boot.

<details>
<summary>Benchmark script</summary>

``` ruby
require "action_controller/railtie"
require "rails"

class MyApp < Rails::Application
  config.eager_load = true
  config.secret_key_base = SecureRandom.hex
  initialize!
end

class ApplicationController < ActionController::Base
end

N = (ENV["N"] || 500).to_i
M = (ENV["M"] || 2000).to_i
N.times do |n|
  Object.const_set("Foo#{n}Controller", Class.new(ApplicationController))
end
puts "For #{N} controller:"

MyApp.routes.draw do
  before = RubyVM.stat(:class_serial)
  get "/foo", to: "home#index"
  after = RubyVM.stat(:class_serial)
  puts "  Class serial changed by #{after - before} per route"

  ms = Benchmark.ms {
    M.times do |n|
      get "/foo#{n}", to: "home#index"
    end
  }
  puts "  Defining #{M} routes took #{ms}ms"
end
```

</details>

**Before:**

```
$ N=1000 M=5000 ruby -S bundle exec ruby test_url_definitons.rb
For 1000 controller:
  Class serial changed by 27043 per route
  Defining 5000 routes took 5195.625874213874ms
```

**After:**

```
$ N=1000 M=5000 ruby -S bundle exec ruby test_url_definitons.rb
For 1000 controller:
  Class serial changed by 19039 per route
  Defining 5000 routes took 2421.337984967977ms
```


### Rails with duplicate module fix

This is test is a good approximation of this part of a very large real Rails master application's boot. There's less impact because it's been patched to avoid the worst of the cache clearing (most of the runtime is now outside of that) but the improvement is still significant.

**Before:**

```
$ N=1000 M=5000 ruby -S bundle exec ruby test_url_definitons.rb
For 1000 controller:
  Class serial changed by 4028 per route
  Defining 5000 routes took 1043.2057077996433ms
```

**After:**

```
$ N=1000 M=5000 ruby -S bundle exec ruby test_url_definitons.rb
For 1000 controller:
  Class serial changed by 2024 per route
  Defining 5000 routes took 786.4317209459841ms
```

