### PR TITLE
Kernel#abort without arguments should print error info

### DIFF
--- a/eval.c
+++ b/eval.c
@@ -477,7 +477,7 @@ rb_class_modify_check(VALUE klass)
 
 NORETURN(static void rb_longjmp(rb_execution_context_t *, int, volatile VALUE, VALUE));
 static VALUE get_errinfo(void);
-static VALUE get_ec_errinfo(const rb_execution_context_t *ec);
+#define get_ec_errinfo(ec) rb_ec_get_errinfo(ec)
 
 static VALUE
 exc_setup_cause(VALUE exc, VALUE cause)
@@ -1847,8 +1847,8 @@ errinfo_place(const rb_execution_context_t *ec)
     return 0;
 }
 
-static VALUE
-get_ec_errinfo(const rb_execution_context_t *ec)
+VALUE
+rb_ec_get_errinfo(const rb_execution_context_t *ec)
 {
     const VALUE *ptr = errinfo_place(ec);
     if (ptr) {

--- a/process.c
+++ b/process.c
@@ -4279,7 +4279,7 @@ rb_f_abort(int argc, const VALUE *argv)
     rb_check_arity(argc, 0, 1);
     if (argc == 0) {
 	rb_execution_context_t *ec = GET_EC();
-	VALUE errinfo = ec->errinfo;
+        VALUE errinfo = rb_ec_get_errinfo(ec);
 	if (!NIL_P(errinfo)) {
 	    rb_ec_error_print(ec, errinfo);
 	}

--- a/test/ruby/test_process.rb
+++ b/test/ruby/test_process.rb
@@ -1509,7 +1509,17 @@ class TestProcess < Test::Unit::TestCase
   def test_abort
     with_tmpchdir do
       s = run_in_child("abort")
-      assert_not_equal(0, s.exitstatus)
+      assert_not_predicate(s, :success?)
+      write_file("test-script", "#{<<~"begin;"}\n#{<<~'end;'}")
+      begin;
+        STDERR.reopen(STDOUT)
+        begin
+          raise "[Bug #16424]"
+        rescue => e
+          abort
+        end
+      end;
+      assert_include(IO.popen([RUBY, "test-script"], &:read), "[Bug #16424]")
     end
   end
 

--- a/vm_core.h
+++ b/vm_core.h
@@ -1848,6 +1848,7 @@ void rb_threadptr_interrupt(rb_thread_t *th);
 void rb_threadptr_unlock_all_locking_mutexes(rb_thread_t *th);
 void rb_threadptr_pending_interrupt_clear(rb_thread_t *th);
 void rb_threadptr_pending_interrupt_enque(rb_thread_t *th, VALUE v);
+VALUE rb_ec_get_errinfo(const rb_execution_context_t *ec);
 void rb_ec_error_print(rb_execution_context_t * volatile ec, volatile VALUE errinfo);
 void rb_execution_context_update(const rb_execution_context_t *ec);
 void rb_execution_context_mark(const rb_execution_context_t *ec);


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/16424