### PR TITLE
Get rid of infinite recursion at loading transcoder

### DIFF
--- a/file.c
+++ b/file.c
@@ -237,7 +237,7 @@ rb_str_encode_ospath(VALUE path)
 {
 #if USE_OSPATH
     int encidx = ENCODING_GET(path);
-#ifdef _WIN32
+#if 0 && defined _WIN32
     if (encidx == ENCINDEX_ASCII) {
 	encidx = rb_filesystem_encindex();
     }


### PR DESCRIPTION
Disable encoding US-ASCII path to filesystem encoding on Windows too.

https://bugs.ruby-lang.org/issues/16392