### PR TITLE
Delete calccall()

### DIFF
--- a/debug_counter.h
+++ b/debug_counter.h
@@ -26,11 +26,6 @@
  * * mc_cme_complement: callable_method_entry complement counts.
  * * mc_cme_complement_hit: callable_method_entry cache hit counts.
  * * mc_search_super: search_method() call counts.
- * * mc_miss_by_nome: inline mc miss by no ment.
- * * mc_miss_by_distinct:        ... by distinct ment.
- * * mc_miss_by_refine:          ... by ment being refined.
- * * mc_miss_by_visi:            ... by visibility change.
- * * mc_miss_spurious: spurious inline mc misshit.
  */
 RB_DEBUG_COUNTER(mc_inline_hit)
 RB_DEBUG_COUNTER(mc_inline_miss)
@@ -41,12 +36,6 @@ RB_DEBUG_COUNTER(mc_class_serial_miss)
 RB_DEBUG_COUNTER(mc_cme_complement)
 RB_DEBUG_COUNTER(mc_cme_complement_hit)
 RB_DEBUG_COUNTER(mc_search_super)
-RB_DEBUG_COUNTER(mc_miss_by_nome)
-RB_DEBUG_COUNTER(mc_miss_by_distinct)
-RB_DEBUG_COUNTER(mc_miss_by_refine)
-RB_DEBUG_COUNTER(mc_miss_by_visi)
-RB_DEBUG_COUNTER(mc_miss_spurious)
-RB_DEBUG_COUNTER(mc_miss_reuse_call)
 
 /*
  * call cache fastpath usage


### PR DESCRIPTION
Now that d45a013a1a3bcc860e6f7f303220b3297e2abdbc is merged, reuse of `cc->call` is less important than previous.  Let's write less code.