### PR TITLE
Add Array#uniq?

### DIFF
--- a/array.c
+++ b/array.c
@@ -5042,6 +5042,60 @@ rb_ary_uniq(VALUE ary)
 
 /*
  *  call-seq:
+ *     ary.uniq?                -> true or false
+ *     ary.uniq? {|item| ...}   -> true or false
+ *
+ *  Returns +true+ if no duplicates are found in +self+, otherwise returns +false+.
+ *
+ *  If +self+ is empty, returns +true+.
+ *
+ *  If a block is given, it will use the return value of the block for comparison.
+ *
+ *  It compares values using their #hash and #eql? methods for efficiency.
+ *
+ *     a = [ "a", "b", "c" ]
+ *     a.uniq?   # => true
+ *
+ *     b = [ "a", "b", "a" ]
+ *     b.uniq?   # => false
+ *
+ *     c = [ "a", "b", "A" ]
+ *     c.uniq? {|s| s.upcase}   # => false
+ *
+ */
+
+static VALUE
+rb_ary_uniq_p(VALUE ary)
+{
+    VALUE hash;
+    long i;
+    int block_given_p;
+
+    if (RARRAY_LEN(ary) <= 1) {
+	return Qtrue;
+    }
+
+    hash = ary_tmp_hash_new(ary);
+    block_given_p = rb_block_given_p();
+
+    for (i=0; i<RARRAY_LEN(ary); i++) {
+	VALUE elt = rb_ary_elt(ary, i);
+	if (block_given_p) {
+	    elt = rb_yield(elt);
+	}
+	if (rb_hash_add_new_element(hash, elt, elt)) {
+	    ary_recycle_hash(hash);
+	    return Qfalse;
+	}
+    }
+
+    ary_recycle_hash(hash);
+
+    return Qtrue;
+}
+
+/*
+ *  call-seq:
  *     ary.compact!    -> ary  or  nil
  *
  *  Removes +nil+ elements from the array.
@@ -7017,6 +7071,7 @@ Init_Array(void)
 
     rb_define_method(rb_cArray, "uniq", rb_ary_uniq, 0);
     rb_define_method(rb_cArray, "uniq!", rb_ary_uniq_bang, 0);
+    rb_define_method(rb_cArray, "uniq?", rb_ary_uniq_p, 0);
     rb_define_method(rb_cArray, "compact", rb_ary_compact, 0);
     rb_define_method(rb_cArray, "compact!", rb_ary_compact_bang, 0);
     rb_define_method(rb_cArray, "flatten", rb_ary_flatten, -1);

--- a/test/ruby/test_array.rb
+++ b/test/ruby/test_array.rb
@@ -1986,6 +1986,23 @@ class TestArray < Test::Unit::TestCase
     assert_equal(orig, ary, "must not be modified once frozen")
   end
 
+  def test_uniq?
+    assert_equal(true, [].uniq?)
+    assert_equal(true, [1].uniq?)
+    assert_equal(true, [1, 2].uniq?)
+    assert_equal(false, [1, 2, 1].uniq?)
+    assert_equal(true, [{a: 'a'}, {a: 'A'}].uniq?)
+    assert_equal(false, [{a: 'A'}, {a: 'A'}].uniq?)
+    assert_equal(true, @cls[1, 2, 3].uniq?)
+  end
+
+  def test_uniq_p_with_block
+    assert_equal(true, [].uniq? {|v| v % 3 })
+    assert_equal(true, [1].uniq? {|v| v % 3 })
+    assert_equal(true, [1, 2, 3].uniq? {|v| v % 3 })
+    assert_equal(false, [1, 2, 4].uniq? {|v| v % 3 })
+  end
+
   def test_unshift
     a = @cls[]
     assert_equal(@cls['cat'], a.unshift('cat'))


### PR DESCRIPTION
I often need to check if an array have duplicate elements.

This method returns true if no duplicates are found in self, otherwise returns false.
If a block is given, it will use the return value of the block for comparison.

This is equivalent to `array.uniq.size == array.size`, but faster.

```
% ~/tmp/r/bin/ruby -rbenchmark/ips -e 'a = Array.new(100) { rand(1000) }; Benchmark.ips { |x| x.report("uniq") { a.uniq.size == a.size }; x.report("uniq?") { a.uniq? } }'
Warming up --------------------------------------
                uniq    25.765k i/100ms
               uniq?    76.544k i/100ms
Calculating -------------------------------------
                uniq    278.144k (± 4.1%) i/s -      1.391M in   5.010858s
               uniq?    981.868k (± 5.1%) i/s -      4.975M in   5.081611s
```

I think the name `uniq?` is natural because Array already has `uniq`.
