### PR TITLE
Optionally load did_you_mean and RubyGems

### DIFF
--- a/gem_prelude.rb
+++ b/gem_prelude.rb
@@ -1,2 +1,6 @@
 require 'rubygems.rb' if defined?(Gem)
-require 'did_you_mean' if defined?(DidYouMean)
+
+begin
+  require 'did_you_mean'
+rescue LoadError
+end if defined?(DidYouMean)

--- a/gem_prelude.rb
+++ b/gem_prelude.rb
@@ -1,6 +1,7 @@
 begin
   require 'rubygems.rb'
 rescue LoadError
+  warn "`RubyGems' were not loaded."
 end if defined?(Gem)
 
 begin

--- a/gem_prelude.rb
+++ b/gem_prelude.rb
@@ -6,4 +6,5 @@ end if defined?(Gem)
 begin
   require 'did_you_mean'
 rescue LoadError
+  warn "`did_you_mean' was not loaded."
 end if defined?(DidYouMean)

--- a/gem_prelude.rb
+++ b/gem_prelude.rb
@@ -1,4 +1,7 @@
-require 'rubygems.rb' if defined?(Gem)
+begin
+  require 'rubygems.rb'
+rescue LoadError
+end if defined?(Gem)
 
 begin
   require 'did_you_mean'


### PR DESCRIPTION
After aa5f7045cf3e3835519b91a0b2705eaaf5e56394 which was part of #2689, it is not possible to execute Ruby, when did_you_mean is not available on the system.

This was previously possible on platforms such as Fedora, where Ruby is distributed via its packaging systems. The ability to not install did_you_mean is useful when speed, memory, disk or network bandwidth is a concern. This is typically the case for production environment, where 'did_you_mean' is of limited usage.

The PR is split into 4 commits, where I really care about the 86fd631 and I prepared the rest since I was already there. So these are just nice to have.