### PR TITLE
Small core documentation fixes

### DIFF
--- a/doc/syntax/modules_and_classes.rdoc
+++ b/doc/syntax/modules_and_classes.rdoc
@@ -190,9 +190,41 @@ Here is an example:
   b.n b #=> 1 -- m called on defining class
   a.n b # raises NoMethodError A is not a subclass of B
 
-The third visibility is +private+.  A private method may not be called with a
-receiver, not even if it equals +self+.  If a private method is called with a
-receiver other than a literal +self+ a NoMethodError will be raised.
+The third visibility is +private+.  A private method may only be called from
+inside the owner class without a receiver, or with a literal +self+
+as a receiver.  If a private method is called with a
+receiver other than a literal +self+, a NoMethodError will be raised.
+
+  class A
+    def without
+      m
+    end
+
+    def with_self
+      self.m
+    end
+
+    def with_other
+      A.new.m
+    end
+
+    def with_renamed
+      copy = self
+      copy.m
+    end
+
+    def m
+      1
+    end
+
+    private :m
+  end
+
+  a = A.new
+  a.without      #=> 1
+  a.with_self    #=> 1
+  a.with_other   # NoMethodError (private method `m' called for #<A:0x0000559c287f27d0>)
+  a.with_renamed # NoMethodError (private method `m' called for #<A:0x0000559c285f8330>)
 
 === +alias+ and +undef+
 

--- a/error.c
+++ b/error.c
@@ -1457,7 +1457,7 @@ err_init_recv(VALUE exc, VALUE recv)
  * method.
  *
  *    a = [].freeze
- *    raise FrozenError.new("can't modify frozen array", a)
+ *    raise FrozenError.new("can't modify frozen array", receiver: a)
  */
 
 static VALUE
@@ -1475,6 +1475,7 @@ frozen_err_initialize(int argc, VALUE *argv, VALUE self)
 }
 
 /*
+ * Document-method: FrozenError#receiver
  * call-seq:
  *   frozen_error.receiver  -> object
  *

--- a/proc.c
+++ b/proc.c
@@ -2766,11 +2766,30 @@ rb_method_parameters(VALUE method)
  *
  *  Returns a human-readable description of the underlying method.
  *
- *    "cat".method(:count).inspect   #=> "#<Method: String#count>"
- *    (1..3).method(:map).inspect    #=> "#<Method: Range(Enumerable)#map>"
+ *    "cat".method(:count).inspect   #=> "#<Method: String#count(*)>"
+ *    (1..3).method(:map).inspect    #=> "#<Method: Range(Enumerable)#map()>"
  *
  *  In the latter case, the method description includes the "owner" of the
  *  original method (+Enumerable+ module, which is included into +Range+).
+ *
+ *  +inspect+ also provides, when possible, method argument names (call
+ *  sequence) and source location.
+ *
+ *    require 'net/http'
+ *    Net::HTTP.method(:get).inspect
+ *    #=> "#<Method: Net::HTTP.get(uri_or_host, path=..., port=...) <skip>/lib/ruby/2.7.0/net/http.rb:457>"
+ *
+ *  <code>...</code> in argument definition means argument is optional (has
+ *  some default value).
+ *
+ *  For methods defined in C (language core and extensions), location and
+ *  argument names can't be extracted, and only generic information is provided
+ *  in form of <code>*</code> (any number of arguments) or <code>_</code> (some
+ *  positional argument).
+ *
+ *    "cat".method(:count).inspect   #=> "#<Method: String#count(*)>"
+ *    "cat".method(:+).inspect       #=> "#<Method: String#+(_)>""
+
  */
 
 static VALUE

--- a/range.c
+++ b/range.c
@@ -1373,19 +1373,26 @@ static VALUE range_include_internal(VALUE range, VALUE val, int string_use_cover
  *  call-seq:
  *     rng === obj       ->  true or false
  *
- *  Returns <code>true</code> if +obj+ is an element of the range,
- *  <code>false</code> otherwise.  Conveniently, <code>===</code> is the
- *  comparison operator used by <code>case</code> statements.
+ *  Returns <code>true</code> if +obj+ is between begin and end of range,
+ *  <code>false</code> otherwise (same as #cover?). Conveniently,
+ *  <code>===</code> is the comparison operator used by <code>case</code>
+ *  statements.
  *
  *     case 79
- *     when 1..50   then   print "low\n"
- *     when 51..75  then   print "medium\n"
- *     when 76..100 then   print "high\n"
+ *     when 1..50   then   puts "low"
+ *     when 51..75  then   puts "medium"
+ *     when 76..100 then   puts "high"
  *     end
+ *     # Prints "high"
  *
- *  <em>produces:</em>
+ *     case "2.6.5"
+ *     when ..."2.4" then puts "EOL"
+ *     when "2.4"..."2.5" then puts "maintenance"
+ *     when "2.5"..."2.7" then puts "stable"
+ *     when "2.7".. then puts "upcoming"
+ *     end
+ *     # Prints "stable"
  *
- *     high
  */
 
 static VALUE
@@ -1403,12 +1410,19 @@ range_eqq(VALUE range, VALUE val)
  *     rng.include?(obj) ->  true or false
  *
  *  Returns <code>true</code> if +obj+ is an element of
- *  the range, <code>false</code> otherwise.  If begin and end are
- *  numeric, comparison is done according to the magnitude of the values.
+ *  the range, <code>false</code> otherwise.
  *
  *     ("a".."z").include?("g")   #=> true
  *     ("a".."z").include?("A")   #=> false
  *     ("a".."z").include?("cc")  #=> false
+ *
+ *  If you need to ensure +obj+ is between +begin+ and +end+, use #cover?
+ *
+ *     ("a".."z").cover?("cc")  #=> true
+ *
+ *  If begin and end are numeric, #include? behaves like #cover?
+ *
+ *     (1..3).include?(1.5) # => true
  */
 
 static VALUE

--- a/time.c
+++ b/time.c
@@ -4091,14 +4091,15 @@ time_to_s(VALUE time)
  *  call-seq:
  *     time.inspect -> string
  *
- *  Returns a detailed string representing _time_.
+ *  Returns a detailed string representing _time_. Inlike to_s, preserves
+ *  nanoseconds in representation for easier debugging.
  *
  *     t = Time.now
- *     t.to_s                              #=> "2012-11-10 18:16:12 +0100"
- *     t.strftime "%Y-%m-%d %H:%M:%S %z"   #=> "2012-11-10 18:16:12 +0100"
+ *     t.inspect                             #=> "2012-11-10 18:16:12.261257655 +0100"
+ *     t.strftime "%Y-%m-%d %H:%M:%S.%N %z"  #=> "2012-11-10 18:16:12.261257655 +0100"
  *
- *     t.utc.to_s                          #=> "2012-11-10 17:16:12 UTC"
- *     t.strftime "%Y-%m-%d %H:%M:%S UTC"  #=> "2012-11-10 17:16:12 UTC"
+ *     t.utc.inspect                          #=> "2012-11-10 17:16:12.261257655 UTC"
+ *     t.strftime "%Y-%m-%d %H:%M:%S.%N UTC"  #=> "2012-11-10 17:16:12.261257655 UTC"
  */
 
 static VALUE

--- a/variable.c
+++ b/variable.c
@@ -2992,7 +2992,19 @@ rb_mod_public_constant(int argc, const VALUE *argv, VALUE obj)
  *  call-seq:
  *     mod.deprecate_constant(symbol, ...)    => mod
  *
- *  Makes a list of existing constants deprecated.
+ *  Makes a list of existing constants deprecated. Attempt
+ *  to refer to them will produce a warning.
+ *
+ *     module HTTP
+ *       NotFound = Exception.new
+ *       NOT_FOUND = NotFound # previous version of the library used this name
+ *
+ *       deprecate_constant :NOT_FOUND
+ *     end
+ *
+ *     HTTP::NOT_FOUND
+ *     # warning: constant HTTP::NOT_FOUND is deprecated
+ *
  */
 
 VALUE


### PR DESCRIPTION
Sorry for several changes in the PR again, but as release is near, I assume it is easier to review than 6 1-line PRs. At least each change is in its own commit, and some commits could be discarded if they are not appropriate.

Change list:
* Update `private` visibility explanation to clearer explain `self` receiver rules
* Fix `FrozenError#receiver` (mentioned `NameError` instead of `FrozenError`) and `#initialize` (showed old positional syntax) docs
* Actualize `Method#inspect` docs according to changes in 2.7 (parameter list and location)
* Actualize `Time#inspect` docs according to changes in 2.7 (nanoseconds)
* Enhance `Range` docs to clarify distinction of `#include?` and `#cover?` and fix explanation of `#===` behavior
* Enhance docs for `Module#deprecate_constant` (explain what does deprecation mean)