### PR TITLE
Update 2.7 news

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -159,10 +159,19 @@ sufficient information, see the ChangeLog file or Redmine
 
 ==== Other miscellaneous changes
 
-* A beginless range is experimentally introduced.  It might not be as useful
-  as an endless range, but would be good for DSL purposes.  [Feature #14799]
+* A beginless range is experimentally introduced.  It might be useful
+  in +case+, new call-sequence of the <code>Comparable#clamp</code>,
+  constants and DSLs.  [Feature #14799]
 
      ary[..3]  # identical to ary[0..3]
+
+     case RUBY_VERSION
+     when ..."2.4" then puts "EOL"
+     # ...
+     end
+
+     age.clamp(..100)
+
      where(sales: ..100)
 
 * Setting <code>$;</code> to non-nil value is warned now.  Use of it in
@@ -242,6 +251,10 @@ Comparable::
         -1.clamp(0..2) #=> 0
          1.clamp(0..2) #=> 1
          3.clamp(0..2) #=> 2
+        # With beginless and endless ranges:
+        -1.clamp(0..)  #=> 0
+         3.clamp(..2)  #=> 2
+
 
 Complex::
 
@@ -408,6 +421,12 @@ Range::
 
     * Added Range#minmax, with a faster implementation than Enumerable#minmax.
       It returns a maximum that now corresponds to Range#max. [Bug #15807]
+
+  Modified method::
+
+    * Range#=== now uses #cover? for String arguments, too (in Ruby 2.6, it was
+      changed from #include? for all types except strings). [Bug #15449]
+
 
 RubyVM::
 


### PR DESCRIPTION
* Change wording for beginless ranges. It included unfortunate "It might not be as useful as endless range...", which was already mindlessly repeated or rephrased in several "What's new in Ruby 2.7?" reviews, while in fact, slicing arrays is not only, and probably not even the main usage of ranges. I believe introducing feature with explicit mentioning of its "less usefulness" is what should be generally avoided;
* Update `Comparable#clamp` example with beginless and endless ranges;
* Mention behavior change for `Range#===` with strings, I believe it is important enough.

_**Possible conflict of interest:** I am the original proposer for all three features, but I believe that I am guided by attempt to make them better explained and therefore more useful for the community, not myself "better recognized"._