### PR TITLE
Fix typos of previous docs PR

### DIFF
--- a/doc/syntax/exceptions.rdoc
+++ b/doc/syntax/exceptions.rdoc
@@ -17,7 +17,7 @@ wish to limit the scope of rescued exceptions:
     # ...
   end
 
-The same is true for, +class+, +module+, and +block+:
+The same is true for a +class+, +module+, and +block+:
 
   [0, 1, 2].map do |i|
     10 / i

--- a/enumerator.c
+++ b/enumerator.c
@@ -316,7 +316,7 @@ proc_entry_ptr(VALUE proc_entry)
  *   some_method(a.to_enum)
  *
  *   # String#split in block form is more memory-effective:
- *   very_large_string.to_enum(:split, "|") { |chunk| return chunk if chunk.include?('DATE') }
+ *   very_large_string.split("|") { |chunk| return chunk if chunk.include?('DATE') }
  *   # This could be rewritten more idiomatically with to_enum:
  *   very_large_string.to_enum(:split, "|").lazy.grep(/DATE/).first
  *


### PR DESCRIPTION
In #2612 I made two typos (extra `,`, and copy-pasted same line of code instead of showing two different ones), fixing them.