### PR TITLE
Fix cross build with base ruby version < 2.7

### DIFF
--- a/template/fake.rb.in
+++ b/template/fake.rb.in
@@ -27,6 +27,10 @@ case "$0" in /*) r=-r"$0";; *) r=-r"./$0";; esac
 exec $ruby "$r" "$@"
 =end
 =baseruby
+<% if RUBY_VERSION < "2.7" %>
+def ruby2_keywords(*)
+end
+<% end %>
 class Object
   remove_const :CROSS_COMPILING if defined?(CROSS_COMPILING)
   CROSS_COMPILING = RUBY_PLATFORM


### PR DESCRIPTION
Otherwise build fails when requiring "delegate" library.

I noticed this issue while preparation of ruby-2.7 in rake-compiler-dock. So I use the attached patch there: https://github.com/rake-compiler/rake-compiler-dock/blob/master/build/patches/ruby-2.7.0-rc2/ruby2_keywords.patch