### PR TITLE
Revert "Add NEWS entry about Module#name performance (#2779)"

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -434,9 +434,6 @@ Module::
     * Module#autoload? now takes an +inherit+ optional argument, like
       Module#const_defined?.  [Feature #15777]
 
-    * Module#name and Module#inspect no longer search through all defined
-      constants when the receiver is anonymous.  [Feature #15765]
-
     * Module#name now always returns a frozen String. The returned String is
       always the same for a given Module. This change is
       experimental. [Feature #16150]


### PR DESCRIPTION
Revert ruby/ruby#2779 Since it's not newsworthy enough that the majority of Ruby users should know about it