### PR TITLE
Fix documentation of Dir#each_child

### DIFF
--- a/dir.c
+++ b/dir.c
@@ -3023,7 +3023,7 @@ dir_s_each_child(int argc, VALUE *argv, VALUE io)
 
 /*
  *  call-seq:
- *     dir.each_child {| filename | block }  -> nil
+ *     dir.each_child {| filename | block }  -> dir
  *     dir.each_child                        -> an_enumerator
  *
  *  Calls the block once for each entry except for "." and ".." in


### PR DESCRIPTION
```
% ruby -ve 'p Dir.new(".").each_child { }'
ruby 2.7.0dev (2019-12-25T09:47:47Z master e1e1d92277) [x86_64-linux]
#<Dir:.>
```