### PR TITLE
Add VM insns counter like debug_counter

### DIFF
--- a/vm_exec.h
+++ b/vm_exec.h
@@ -41,6 +41,10 @@ typedef rb_iseq_t *ISEQ;
 #define throwdebug if(0)printf
 /* #define throwdebug printf */
 
+#ifndef USE_INSNS_COUNTER
+#define USE_INSNS_COUNTER 0
+#endif
+
 /************************************************/
 #if defined(DISPATCH_XXX)
 error !
@@ -75,7 +79,8 @@ error !
                  (reg_pc - reg_cfp->iseq->body->iseq_encoded), \
                  (reg_cfp->pc - reg_cfp->iseq->body->iseq_encoded), \
                  RSTRING_PTR(rb_iseq_path(reg_cfp->iseq)), \
-                 rb_iseq_line_no(reg_cfp->iseq, reg_pc - reg_cfp->iseq->body->iseq_encoded));
+                 rb_iseq_line_no(reg_cfp->iseq, reg_pc - reg_cfp->iseq->body->iseq_encoded)); \
+  if (USE_INSNS_COUNTER) vm_insns_counter_count_insn(BIN(insn));
 
 #define INSN_DISPATCH_SIG(insn)
 


### PR DESCRIPTION
Like debug_counter.c, I'd like to have a counter for VM insns. 

Since it'd be slow to run both existing counters and insn counters and I wanted to show percentages, this counter implementation is independent from debug_counter.

This is only for VM development purposes and enabled by manually modifying `USE_INSNS_COUNTER` macro.

## Example
```
$ ruby bin/optcarrot-bench
fps: 50.86144912423572
[RUBY_INSNS_COUNTER]     nop                                  7381364 ( 0.6%)
[RUBY_INSNS_COUNTER]     getlocal                             1573163 ( 0.1%)
[RUBY_INSNS_COUNTER]     setlocal                                   0 ( 0.0%)
[RUBY_INSNS_COUNTER]     getblockparam                              1 ( 0.0%)
[RUBY_INSNS_COUNTER]     setblockparam                              0 ( 0.0%)
[RUBY_INSNS_COUNTER]     getblockparamproxy                         1 ( 0.0%)
[RUBY_INSNS_COUNTER]     getspecial                              1011 ( 0.0%)
[RUBY_INSNS_COUNTER]     setspecial                                 0 ( 0.0%)
[RUBY_INSNS_COUNTER]     getinstancevariable                293840139 (24.0%)
[RUBY_INSNS_COUNTER]     setinstancevariable                 60781636 ( 5.0%)
[RUBY_INSNS_COUNTER]     getclassvariable                         277 ( 0.0%)
[RUBY_INSNS_COUNTER]     setclassvariable                          21 ( 0.0%)
[RUBY_INSNS_COUNTER]     getconstant                             1347 ( 0.0%)
[RUBY_INSNS_COUNTER]     setconstant                              169 ( 0.0%)
[RUBY_INSNS_COUNTER]     getglobal                                215 ( 0.0%)
[RUBY_INSNS_COUNTER]     setglobal                                  1 ( 0.0%)
[RUBY_INSNS_COUNTER]     putnil                              25782811 ( 2.1%)
[RUBY_INSNS_COUNTER]     putself                             71061002 ( 5.8%)
[RUBY_INSNS_COUNTER]     putobject                           72384750 ( 5.9%)
[RUBY_INSNS_COUNTER]     putspecialobject                         325 ( 0.0%)
[RUBY_INSNS_COUNTER]     putstring                               1293 ( 0.0%)
[RUBY_INSNS_COUNTER]     concatstrings                            406 ( 0.0%)
[RUBY_INSNS_COUNTER]     tostring                                  90 ( 0.0%)
[RUBY_INSNS_COUNTER]     freezestring                              83 ( 0.0%)
[RUBY_INSNS_COUNTER]     toregexp                                   6 ( 0.0%)
[RUBY_INSNS_COUNTER]     intern                                    20 ( 0.0%)
[RUBY_INSNS_COUNTER]     newarray                              103648 ( 0.0%)
[RUBY_INSNS_COUNTER]     newarraykwsplat                            0 ( 0.0%)
[RUBY_INSNS_COUNTER]     duparray                                3001 ( 0.0%)
[RUBY_INSNS_COUNTER]     duphash                                    4 ( 0.0%)
[RUBY_INSNS_COUNTER]     expandarray                          1768748 ( 0.1%)
[RUBY_INSNS_COUNTER]     concatarray                              223 ( 0.0%)
[RUBY_INSNS_COUNTER]     splatarray                           1773092 ( 0.1%)
[RUBY_INSNS_COUNTER]     newhash                                  165 ( 0.0%)
[RUBY_INSNS_COUNTER]     newrange                                   6 ( 0.0%)
[RUBY_INSNS_COUNTER]     pop                                 57089600 ( 4.7%)
[RUBY_INSNS_COUNTER]     dup                                 20700682 ( 1.7%)
[RUBY_INSNS_COUNTER]     dupn                                  327861 ( 0.0%)
[RUBY_INSNS_COUNTER]     swap                                       1 ( 0.0%)
[RUBY_INSNS_COUNTER]     reverse                                    0 ( 0.0%)
[RUBY_INSNS_COUNTER]     topn                                     180 ( 0.0%)
[RUBY_INSNS_COUNTER]     setn                                 1979244 ( 0.2%)
[RUBY_INSNS_COUNTER]     adjuststack                           322503 ( 0.0%)
[RUBY_INSNS_COUNTER]     defined                                 6742 ( 0.0%)
[RUBY_INSNS_COUNTER]     checkmatch                               553 ( 0.0%)
[RUBY_INSNS_COUNTER]     checkkeyword                               0 ( 0.0%)
[RUBY_INSNS_COUNTER]     checktype                                452 ( 0.0%)
[RUBY_INSNS_COUNTER]     defineclass                              169 ( 0.0%)
[RUBY_INSNS_COUNTER]     definemethod                             871 ( 0.0%)
[RUBY_INSNS_COUNTER]     definesmethod                            201 ( 0.0%)
[RUBY_INSNS_COUNTER]     send                                   91593 ( 0.0%)
[RUBY_INSNS_COUNTER]     opt_send_without_block              78249748 ( 6.4%)
[RUBY_INSNS_COUNTER]     opt_str_freeze                          1490 ( 0.0%)
[RUBY_INSNS_COUNTER]     opt_nil_p                                244 ( 0.0%)
[RUBY_INSNS_COUNTER]     opt_str_uminus                             0 ( 0.0%)
[RUBY_INSNS_COUNTER]     opt_newarray_max                           1 ( 0.0%)
[RUBY_INSNS_COUNTER]     opt_newarray_min                        1536 ( 0.0%)
[RUBY_INSNS_COUNTER]     invokesuper                             4288 ( 0.0%)
[RUBY_INSNS_COUNTER]     invokeblock                              145 ( 0.0%)
[RUBY_INSNS_COUNTER]     leave                               76645682 ( 6.3%)
[RUBY_INSNS_COUNTER]     throw                                     12 ( 0.0%)
[RUBY_INSNS_COUNTER]     jump                                12678635 ( 1.0%)
[RUBY_INSNS_COUNTER]     branchif                            28529093 ( 2.3%)
[RUBY_INSNS_COUNTER]     branchunless                       113266030 ( 9.3%)
[RUBY_INSNS_COUNTER]     branchnil                                  0 ( 0.0%)
[RUBY_INSNS_COUNTER]     opt_getinlinecache                   5006083 ( 0.4%)
[RUBY_INSNS_COUNTER]     opt_setinlinecache                      1044 ( 0.0%)
[RUBY_INSNS_COUNTER]     once                                       0 ( 0.0%)
[RUBY_INSNS_COUNTER]     opt_case_dispatch                         76 ( 0.0%)
[RUBY_INSNS_COUNTER]     opt_plus                            38709944 ( 3.2%)
[RUBY_INSNS_COUNTER]     opt_minus                            7775951 ( 0.6%)
[RUBY_INSNS_COUNTER]     opt_mult                             4570268 ( 0.4%)
[RUBY_INSNS_COUNTER]     opt_div                              1680993 ( 0.1%)
[RUBY_INSNS_COUNTER]     opt_mod                             10998302 ( 0.9%)
[RUBY_INSNS_COUNTER]     opt_eq                              12226076 ( 1.0%)
[RUBY_INSNS_COUNTER]     opt_neq                              3749322 ( 0.3%)
[RUBY_INSNS_COUNTER]     opt_lt                               6738246 ( 0.6%)
[RUBY_INSNS_COUNTER]     opt_le                              17084197 ( 1.4%)
[RUBY_INSNS_COUNTER]     opt_gt                                453499 ( 0.0%)
[RUBY_INSNS_COUNTER]     opt_ge                              12888777 ( 1.1%)
[RUBY_INSNS_COUNTER]     opt_ltlt                            11699010 ( 1.0%)
[RUBY_INSNS_COUNTER]     opt_and                              8037994 ( 0.7%)
[RUBY_INSNS_COUNTER]     opt_or                               6200817 ( 0.5%)
[RUBY_INSNS_COUNTER]     opt_aref                            51373935 ( 4.2%)
[RUBY_INSNS_COUNTER]     opt_aset                              772355 ( 0.1%)
[RUBY_INSNS_COUNTER]     opt_aset_with                            230 ( 0.0%)
[RUBY_INSNS_COUNTER]     opt_aref_with                              0 ( 0.0%)
[RUBY_INSNS_COUNTER]     opt_length                               219 ( 0.0%)
[RUBY_INSNS_COUNTER]     opt_size                              195258 ( 0.0%)
[RUBY_INSNS_COUNTER]     opt_empty_p                              286 ( 0.0%)
[RUBY_INSNS_COUNTER]     opt_succ                                   0 ( 0.0%)
[RUBY_INSNS_COUNTER]     opt_not                                 4894 ( 0.0%)
[RUBY_INSNS_COUNTER]     opt_regexpmatch2                         362 ( 0.0%)
[RUBY_INSNS_COUNTER]     opt_call_c_function                        0 ( 0.0%)
[RUBY_INSNS_COUNTER]     invokebuiltin                              0 ( 0.0%)
[RUBY_INSNS_COUNTER]     opt_invokebuiltin_delegate                 0 ( 0.0%)
[RUBY_INSNS_COUNTER]     opt_invokebuiltin_delegate_leave           0 ( 0.0%)
[RUBY_INSNS_COUNTER]     getlocal_WC_0                       44375452 ( 3.6%)
[RUBY_INSNS_COUNTER]     getlocal_WC_1                        4825714 ( 0.4%)
[RUBY_INSNS_COUNTER]     setlocal_WC_0                       17993389 ( 1.5%)
[RUBY_INSNS_COUNTER]     setlocal_WC_1                              0 ( 0.0%)
[RUBY_INSNS_COUNTER]     putobject_INT2FIX_0_                 5856633 ( 0.5%)
[RUBY_INSNS_COUNTER]     putobject_INT2FIX_1_                23399395 ( 1.9%)
```