### PR TITLE
Use __func__ as rb_cv_function_name_string on OpenBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1525,15 +1525,18 @@ AC_SUBST(MATHN, $mathn)
 
 AC_CACHE_CHECK(for function name string predefined identifier,
     rb_cv_function_name_string,
-    [rb_cv_function_name_string=no
-    RUBY_WERROR_FLAG([
-	for func in __func__ __FUNCTION__; do
-	    AC_TRY_LINK([@%:@include <stdio.h>],
-			[puts($func);],
-			[rb_cv_function_name_string=$func
-			break])
-	done
-    ])]
+    [AS_CASE(["$target_os"],[openbsd*],[
+      rb_cv_function_name_string=__func__
+     ],[
+     rb_cv_function_name_string=no
+      RUBY_WERROR_FLAG([
+        for func in __func__ __FUNCTION__; do
+            AC_TRY_LINK([@%:@include <stdio.h>],
+            [puts($func);],
+            [rb_cv_function_name_string=$func
+            break])
+        done
+      ])])]
 )
 AS_IF([test "$rb_cv_function_name_string" != no], [
     AC_DEFINE_UNQUOTED(RUBY_FUNCTION_NAME_STRING, [$rb_cv_function_name_string])


### PR DESCRIPTION
The use of RUBY_WERROR_FLAG causes this test to fail on OpenBSD
platforms that use the binutils linker (ld.bfd) instead of the
llvm linker (ld.lld), due to warnings added to the binutils linker
in OpenBSD.

Removing the RUBY_WERROR_FLAG would probably also fix it, but that
would affect other platforms.

This should also be backported to Ruby 2.7.

Analysis and similar fix recommended by George Koehler.