### PR TITLE
struct.c: use RB_PASS_CALLED_KEYWORDS for initialize

### DIFF
--- a/internal/object.h
+++ b/internal/object.h
@@ -22,6 +22,7 @@ int rb_bool_expected(VALUE, const char *);
 static inline void RBASIC_CLEAR_CLASS(VALUE obj);
 static inline void RBASIC_SET_CLASS_RAW(VALUE obj, VALUE klass);
 static inline void RBASIC_SET_CLASS(VALUE obj, VALUE klass);
+VALUE rb_class_new_instance_passedkw(int argc, const VALUE *argv, VALUE klass);
 
 RUBY_SYMBOL_EXPORT_BEGIN
 /* object.c (export) */

--- a/object.c
+++ b/object.c
@@ -2156,8 +2156,8 @@ rb_class_allocate_instance(VALUE klass)
  *
  */
 
-static VALUE
-rb_class_s_new(int argc, const VALUE *argv, VALUE klass)
+VALUE
+rb_class_new_instance_passedkw(int argc, const VALUE *argv, VALUE klass)
 {
     VALUE obj;
 
@@ -4699,7 +4699,7 @@ InitVM_Object(void)
     rb_define_method(rb_cModule, "singleton_class?", rb_mod_singleton_p, 0);
 
     rb_define_method(rb_cClass, "allocate", rb_class_alloc_m, 0);
-    rb_define_method(rb_cClass, "new", rb_class_s_new, -1);
+    rb_define_method(rb_cClass, "new", rb_class_new_instance_passedkw, -1);
     rb_define_method(rb_cClass, "initialize", rb_class_initialize, -1);
     rb_define_method(rb_cClass, "superclass", rb_class_superclass, 0);
     rb_define_alloc_func(rb_cClass, rb_class_s_alloc);

--- a/struct.c
+++ b/struct.c
@@ -326,7 +326,7 @@ static VALUE
 setup_struct(VALUE nstr, VALUE members, int keyword_init)
 {
     long i, len;
-    VALUE (*new_func)(int, const VALUE *, VALUE) = rb_class_new_instance;
+    VALUE (*new_func)(int, const VALUE *, VALUE) = rb_class_new_instance_passedkw;
 
     if (keyword_init) new_func = struct_new_kw;
 

--- a/test/ruby/test_struct.rb
+++ b/test/ruby/test_struct.rb
@@ -114,8 +114,8 @@ module TestStruct
     assert_equal "#{@Struct}::KeywordInitFalse", @Struct::KeywordInitFalse.inspect
     assert_equal "#{@Struct}::KeywordInitTrue(keyword_init: true)", @Struct::KeywordInitTrue.inspect
     # eval is needed to prevent the warning duplication filter
-    k = eval("Class.new(@Struct::KeywordInitFalse) {def initialize(**) end}")
-    assert_warn(/Using the last argument as keyword parameters is deprecated/) {k.new(a: 1, b: 2)}
+    k = eval("Class.new(@Struct::KeywordInitFalse) {def initialize(*) end}")
+    assert_warn('') {k.new(a: 1, b: 2)}
     k = Class.new(@Struct::KeywordInitTrue) {def initialize(**) end}
     assert_warn('') {k.new(a: 1, b: 2)}
 
@@ -442,6 +442,20 @@ module TestStruct
     assert_raise(TypeError) {
       o.deconstruct_keys(0)
     }
+  end
+
+  def test_normal_struct_with_keyword_arguments
+    klass = @Struct.new(:s1, :s2, :s3) do
+      def initialize(a1:, a2:)
+        super(a1, a2, a1 + a2)
+      end
+    end
+    assert_warn('', "[Bug #16465]") do
+      s = klass.new(a1: 1, a2: 2)
+      assert_equal(1, s.s1)
+      assert_equal(2, s.s2)
+      assert_equal(3, s.s3)
+    end
   end
 
   class TopStruct < Test::Unit::TestCase


### PR DESCRIPTION
It caused a false positive warning for innocent usage of
Struct#initialize.  [Bug #16465]

@jeremyevans Could you please review this?

I changed one existing assertion in `test_struct_new_with_keyword_init`.  It expected a warning displayed when `Struct#initialize` accepts keywords for `keyword_init: false`.  However, a user may override `Struct#initialize` to accept keywords, even if `keyword_init: false` is specified.  So the assertion was too aggressive, I think.