### PR TITLE
Actions MinGW - fix test-all

### DIFF
--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           git config --system core.autocrlf false
           git config --system core.eol lf
-      # Not using official actions/checkout because it's unstable and sometimes doesn't work for a fork.
+      # Not using official actions/checkout@v2 because it's unstable and sometimes doesn't work for a fork.
       - name: Checkout ruby/ruby
         run: |
           git clone --single-branch --shallow-since=yesterday https://github.com/ruby/ruby src
@@ -143,7 +143,7 @@ jobs:
           [Console]::OutputEncoding = [System.Text.Encoding]::GetEncoding("IBM437")
           [Console]::InputEncoding  = [System.Text.Encoding]::GetEncoding("IBM437")
           $jobs = [int]$env:NUMBER_OF_PROCESSORS
-          make -C build test-all TESTOPTS="--retry --job-status=normal --show-skip --timeout-scale=1.5 --excludes=../src/test/excludes -n !/memory_leak/ -j $jobs"
+          make -C build test-all TESTOPTS="-j $jobs --retry --job-status=normal --show-skip --timeout-scale=1.5"
 
       - uses: k0kubun/action-slack@v2.0.0
         with:


### PR DESCRIPTION
While working on mswin, pushed an incorrect change to test-all in MinGW.  The step passes, but no tests are run.  This reverts.

Also, PR used the 'updated' actions/checkout@v2, which is still broken.  Update comment to make clear that v2 is broken (just like v1)