### PR TITLE
Check Module#ruby2_keywords arity

### DIFF
--- a/test/ruby/test_keyword.rb
+++ b/test/ruby/test_keyword.rb
@@ -2724,6 +2724,12 @@ class TestKeywordArguments < Test::Unit::TestCase
   end
 
   def test_ruby2_keywords
+    assert_raise(ArgumentError) do
+      Class.new do
+        ruby2_keywords
+      end
+    end
+
     c = Class.new do
       ruby2_keywords def foo(meth, *args)
         send(meth, *args)

--- a/vm_method.c
+++ b/vm_method.c
@@ -1811,6 +1811,7 @@ rb_mod_ruby2_keywords(int argc, VALUE *argv, VALUE module)
     int i;
     VALUE origin_class = RCLASS_ORIGIN(module);
 
+    rb_check_arity(argc, 1, UNLIMITED_ARGUMENTS);
     rb_check_frozen(module);
 
     for (i = 0; i < argc; i++) {


### PR DESCRIPTION
It is considered a mistake, because calling this method with no arguments has no effect.
