### PR TITLE
Make Time initialization faster

### DIFF
--- a/test/ruby/test_time.rb
+++ b/test/ruby/test_time.rb
@@ -431,6 +431,10 @@ class TestTime < Test::Unit::TestCase
 
     assert_equal(-4427700000, Time.utc(-4427700000,12,1).year)
     assert_equal(-2**30+10, Time.utc(-2**30+10,1,1).year)
+
+    assert_raise(ArgumentError) { Time.gm(2000, 1, -1) }
+    assert_raise(ArgumentError) { Time.gm(2000, 1, 2**30 + 1) }
+    assert_raise(ArgumentError) { Time.gm(2000, 1, -2**30 + 1) }
   end
 
   def test_time_interval

--- a/time.c
+++ b/time.c
@@ -656,7 +656,7 @@ VALUE rb_cTime;
 static VALUE rb_cTimeTM;
 
 static int obj2int(VALUE obj);
-static uint32_t obj2ubits(VALUE obj, size_t bits);
+static uint32_t obj2ubits(VALUE obj, unsigned int bits);
 static VALUE obj2vint(VALUE obj);
 static uint32_t month_arg(VALUE arg);
 static VALUE validate_utc_offset(VALUE utc_offset);
@@ -2863,20 +2863,16 @@ obj2int(VALUE obj)
     return NUM2INT(obj);
 }
 
+/* bits should be 0 <= x <= 31 */
 static uint32_t
-obj2ubits(VALUE obj, size_t bits)
+obj2ubits(VALUE obj, unsigned int bits)
 {
-    static const uint32_t u32max = (uint32_t)-1;
-    const uint32_t usable_mask = ~(u32max << bits);
-    uint32_t rv;
-    int tmp = obj2int(obj);
+    const unsigned int usable_mask = (1U << bits) - 1;
+    unsigned int rv = (unsigned int)obj2int(obj);
 
-    if (tmp < 0)
-	rb_raise(rb_eArgError, "argument out of range");
-    rv = tmp;
     if ((rv & usable_mask) != rv)
 	rb_raise(rb_eArgError, "argument out of range");
-    return rv;
+    return (uint32_t)rv;
 }
 
 static VALUE

--- a/time.c
+++ b/time.c
@@ -47,6 +47,8 @@ static ID id_submicro, id_nano_num, id_nano_den, id_offset, id_zone;
 static ID id_nanosecond, id_microsecond, id_millisecond, id_nsec, id_usec;
 static ID id_local_to_utc, id_utc_to_local, id_find_timezone;
 static ID id_year, id_mon, id_mday, id_hour, id_min, id_sec, id_isdst;
+static VALUE str_utc, str_empty;
+
 #define id_quo idQuo
 #define id_div idDiv
 #define id_divmod idDivmod
@@ -1023,7 +1025,7 @@ gmtimew_noleapsecond(wideval_t timew, struct vtm *vtm)
     }
 
     vtm->utc_offset = INT2FIX(0);
-    vtm->zone = rb_fstring_lit("UTC");
+    vtm->zone = str_utc;
 }
 
 static struct tm *
@@ -1455,7 +1457,7 @@ guess_local_offset(struct vtm *vtm_utc, int *isdst_ret, VALUE *zone_ret)
 
     timev = w2v(rb_time_unmagnify(timegmw(&vtm2)));
     t = NUM2TIMET(timev);
-    zone = rb_fstring_lit("UTC");
+    zone = str_utc;
     if (localtime_with_gmtoff_zone(&t, &tm, &gmtoff, &zone)) {
         if (isdst_ret)
             *isdst_ret = tm.tm_isdst;
@@ -2299,7 +2301,7 @@ time_init_1(int argc, VALUE *argv, VALUE time)
 
     vtm.wday = VTM_WDAY_INITVAL;
     vtm.yday = 0;
-    vtm.zone = rb_fstring_lit("");
+    vtm.zone = str_empty;
 
     /*                             year  mon   mday  hour  min   sec   off */
     rb_scan_args(argc, argv, "16", &v[0],&v[1],&v[2],&v[3],&v[4],&v[5],&v[6]);
@@ -2994,7 +2996,7 @@ time_arg(int argc, const VALUE *argv, struct vtm *vtm)
     vtm->wday = 0;
     vtm->yday = 0;
     vtm->isdst = 0;
-    vtm->zone = rb_fstring_lit("");
+    vtm->zone = str_empty;
 
     if (argc == 10) {
 	v[0] = argv[5];
@@ -3918,7 +3920,7 @@ time_gmtime(VALUE time)
 	time_modify(time);
     }
 
-    vtm.zone = rb_fstring_lit("UTC");
+    vtm.zone = str_utc;
     GMTIMEW(tobj->timew, &vtm);
     tobj->vtm = vtm;
 
@@ -5367,7 +5369,7 @@ time_mload(VALUE time, VALUE str)
         vtm.utc_offset = INT2FIX(0);
 	vtm.yday = vtm.wday = 0;
 	vtm.isdst = 0;
-	vtm.zone = rb_fstring_lit("");
+	vtm.zone = str_empty;
 
 	usec = (long)(s & 0xfffff);
         nsec = usec * 1000;
@@ -5840,6 +5842,11 @@ Init_Time(void)
     id_sec = rb_intern("sec");
     id_isdst = rb_intern("isdst");
     id_find_timezone = rb_intern("find_timezone");
+
+    str_utc = rb_fstring_lit("UTC");
+    rb_gc_register_mark_object(str_utc);
+    str_empty = rb_fstring_lit("");
+    rb_gc_register_mark_object(str_empty);
 
     rb_cTime = rb_define_class("Time", rb_cObject);
     rb_include_module(rb_cTime, rb_mComparable);

--- a/time.c
+++ b/time.c
@@ -2923,6 +2923,10 @@ month_arg(VALUE arg)
 {
     int i, mon;
 
+    if (FIXNUM_P(arg)) {
+        return obj2ubits(arg, 4);
+    }
+
     VALUE s = rb_check_string_type(arg);
     if (!NIL_P(s) && RSTRING_LEN(s) > 0) {
         mon = 0;


### PR DESCRIPTION
This makes most `Time` initialization calls a bit faster, and `Time.utc` **much** faster.

The main improvement here is storing the two most commonly used fstrings used by this file, `"UTC"` and `""`, in a static global. This way we don't need to fetch them from the fstring table each time we construct a new time. This makes `Time.utc` nearly twice as fast, and most other methods slightly faster.

## Benchmark

```
require "benchmark/ips"

Benchmark.ips do |x|
  x.report "Time.utc" do
    Time.utc(2020, 1, 1, 0, 0, 0, 0)
  end

  x.report "Time.at" do
    Time.at(1577836800)
  end
end
```

**Before:**
 
```
            Time.utc      2.273M (± 0.6%) i/s -     11.436M in   5.031174s
          Time.local      1.112M (± 0.2%) i/s -      5.650M in   5.079622s
            Time.new      2.196M (± 0.6%) i/s -     11.094M in   5.051065s
            Time.now      5.724M (± 0.8%) i/s -     28.643M in   5.004617s
             Time.at      9.394M (± 0.6%) i/s -     47.296M in   5.034809s
```

**After**

```
            Time.utc      4.362M (± 0.2%) i/s -     22.064M in   5.058701s
          Time.local      1.326M (± 0.4%) i/s -      6.679M in   5.035385s
            Time.new      3.028M (± 0.4%) i/s -     15.140M in   5.000674s
            Time.now      5.785M (± 0.2%) i/s -     29.271M in   5.059968s
             Time.at      8.902M (± 0.1%) i/s -     44.589M in   5.009060s
```