### PR TITLE
Fix OpenStructDocumentation

### DIFF
--- a/lib/ostruct.rb
+++ b/lib/ostruct.rb
@@ -9,6 +9,8 @@
 # See OpenStruct for an example.
 #
 
+require_relative 'ostruct/version'
+
 #
 # An OpenStruct is a data structure, similar to a Hash, that allows the
 # definition of arbitrary attributes with their accompanying values. This is
@@ -72,9 +74,6 @@
 # the objects that are created, as there is much more overhead in the setting
 # of these properties compared to using a Hash or a Struct.
 #
-
-require_relative 'ostruct/version'
-
 class OpenStruct
 
   #


### PR DESCRIPTION
In https://github.com/ruby/ruby/commit/9be3295d53b6fd9f8a3ad8157aa0655b1976d8ac,
OpenStruct's documentation stopped to be rendered by RDoc
(there should be no additional code between documentation
comment and documented class). Fixing this.

Before the fix: https://docs.ruby-lang.org/en/master/OpenStruct.html
![image](https://user-images.githubusercontent.com/129656/71695982-70ee7a00-2dbc-11ea-878e-d1ebab26d051.png)
After the fix:
![image](https://user-images.githubusercontent.com/129656/71696006-7f3c9600-2dbc-11ea-8dea-9f212a64a374.png)
