### PR TITLE
Bump benchmark-driver to v0.15.7

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -47,7 +47,7 @@ GEM_PATH =
 GEM_VENDOR =
 
 BENCHMARK_DRIVER_GIT_URL = https://github.com/benchmark-driver/benchmark-driver
-BENCHMARK_DRIVER_GIT_REF = v0.15.6
+BENCHMARK_DRIVER_GIT_REF = v0.15.7
 SIMPLECOV_GIT_URL = https://github.com/colszowka/simplecov.git
 SIMPLECOV_GIT_REF = v0.17.0
 SIMPLECOV_HTML_GIT_URL = https://github.com/colszowka/simplecov-html.git


### PR DESCRIPTION
Enables the use of the `median` result type.

@k0kubun 