### PR TITLE
Let execution context local storage be an ID table

### DIFF
--- a/benchmark/fiber_locals.yml
+++ b/benchmark/fiber_locals.yml
@@ -1,0 +1,8 @@
+prelude: |
+  th = Thread.current
+  th[:key] = :val
+benchmark:
+  key?: th.key?(:key)
+  []: th[:key]
+  keys: th.keys
+loop_count: 1_000_000

--- a/common.mk
+++ b/common.mk
@@ -1919,6 +1919,7 @@ cont.$(OBJEXT): {$(VPATH)}defines.h
 cont.$(OBJEXT): {$(VPATH)}eval_intern.h
 cont.$(OBJEXT): {$(VPATH)}gc.h
 cont.$(OBJEXT): {$(VPATH)}id.h
+cont.$(OBJEXT): {$(VPATH)}id_table.h
 cont.$(OBJEXT): {$(VPATH)}intern.h
 cont.$(OBJEXT): {$(VPATH)}internal.h
 cont.$(OBJEXT): {$(VPATH)}method.h

--- a/cont.c
+++ b/cont.c
@@ -27,6 +27,7 @@
 #include "internal/warnings.h"
 #include "mjit.h"
 #include "vm_core.h"
+#include "id_table.h"
 
 static const int DEBUG = 0;
 
@@ -1018,7 +1019,7 @@ fiber_free(void *ptr)
     //if (DEBUG) fprintf(stderr, "fiber_free: %p[%p]\n", fiber, fiber->stack.base);
 
     if (fiber->cont.saved_ec.local_storage) {
-        st_free_table(fiber->cont.saved_ec.local_storage);
+        rb_id_table_free(fiber->cont.saved_ec.local_storage);
     }
 
     cont_free(&fiber->cont);
@@ -1037,7 +1038,7 @@ fiber_memsize(const void *ptr)
      * vm.c::thread_memsize already counts th->ec->local_storage
      */
     if (saved_ec->local_storage && fiber != th->root_fiber) {
-        size += st_memsize(saved_ec->local_storage);
+        size += rb_id_table_memsize(saved_ec->local_storage);
     }
     size += cont_memsize(&fiber->cont);
     return size;

--- a/vm_core.h
+++ b/vm_core.h
@@ -865,7 +865,7 @@ typedef struct rb_execution_context_struct {
     struct rb_thread_struct *thread_ptr;
 
     /* storage (ec (fiber) local) */
-    st_table *local_storage;
+    struct rb_id_table *local_storage;
     VALUE local_storage_recursive_hash;
     VALUE local_storage_recursive_hash_for_trace;
 


### PR DESCRIPTION
Back fiber local variables with an ID table instead of `st_table`

```
lourens@CarbonX1:~/src/ruby/ruby$ make benchmark ITEM=fiber_locals COMPARE_RUBY="~/src/ruby/trunk/ruby" OPTS="--repeat-count 12 -v --repeat-result median"
/usr/local/bin/ruby --disable=gems -rrubygems -I./benchmark/lib ./benchmark/benchmark-driver/exe/benchmark-driver \
            --executables="compare-ruby::~/src/ruby/trunk/ruby -I.ext/common --disable-gem" \
            --executables="built-ruby::./miniruby -I./lib -I. -I.ext/common  ./tool/runruby.rb --extout=.ext  -- --disable-gems --disable-gem" \
            $(find ./benchmark -maxdepth 1 -name 'fiber_locals' -o -name '*fiber_locals*.yml' -o -name '*fiber_locals*.rb' | sort) --repeat-count 12 -v --repeat-result median
compare-ruby: ruby 2.8.0dev (2020-01-03T05:53:25Z master 170f4dbb9b) [x86_64-linux]
built-ruby: ruby 2.8.0dev (2020-01-04T00:45:58Z ec-local-storage-i.. 333a5e8c7c) [x86_64-linux]
Calculating -------------------------------------
                     compare-ruby  built-ruby 
                key?      41.002M     46.144M i/s -      1.000M times in 0.024458s 0.021954s
                  []      37.590M     41.950M i/s -      1.000M times in 0.027206s 0.024386s
                keys      20.494M     19.289M i/s -      1.000M times in 0.049985s 0.057330s

Comparison:
                             key?
          built-ruby:  46144102.0 i/s 
        compare-ruby:  41001504.5 i/s - 1.13x  slower

                               []
          built-ruby:  41949873.8 i/s 
        compare-ruby:  37590350.2 i/s - 1.12x  slower

                             keys
        compare-ruby:  20494100.9 i/s 
          built-ruby:  19288690.6 i/s - 1.06x  slower
```

A regression on `Thread#keys`, however I think it's not the dominant use case, compared to key lookups.

Memory looks stable, and the difference within margin of error:

```
lourens@CarbonX1:~/src/ruby/ruby$ make benchmark ITEM=fiber_locals COMPARE_RUBY="~/src/ruby/trunk/ruby" OPTS="--repeat-count 12 -v -r memory"
/usr/local/bin/ruby --disable=gems -rrubygems -I./benchmark/lib ./benchmark/benchmark-driver/exe/benchmark-driver \
            --executables="compare-ruby::~/src/ruby/trunk/ruby -I.ext/common --disable-gem" \
            --executables="built-ruby::./miniruby -I./lib -I. -I.ext/common  ./tool/runruby.rb --extout=.ext  -- --disable-gems --disable-gem" \
            $(find ./benchmark -maxdepth 1 -name 'fiber_locals' -o -name '*fiber_locals*.yml' -o -name '*fiber_locals*.rb' | sort) --repeat-count 12 -v -r memory
compare-ruby: ruby 2.8.0dev (2020-01-03T05:53:25Z master 170f4dbb9b) [x86_64-linux]
built-ruby: ruby 2.8.0dev (2020-01-04T00:45:58Z ec-local-storage-i.. 333a5e8c7c) [x86_64-linux]
Calculating -------------------------------------
                     compare-ruby  built-ruby 
                key?      19.768M     20.108M bytes -      1.000M times
                  []      19.888M     20.124M bytes -      1.000M times
                keys      19.852M     20.184M bytes -      1.000M times

Comparison:
                             key?
        compare-ruby:  19768000.0 bytes 
          built-ruby:  20108000.0 bytes - 1.02x  larger

                               []
        compare-ruby:  19888000.0 bytes 
          built-ruby:  20124000.0 bytes - 1.01x  larger

                             keys
        compare-ruby:  19852000.0 bytes 
          built-ruby:  20184000.0 bytes - 1.02x  larger
```

cc @ioquatix 