### PR TITLE
hash.c: Add a feature to manipulate ruby2_keywords flag

### DIFF
--- a/test/ruby/test_hash.rb
+++ b/test/ruby/test_hash.rb
@@ -1756,4 +1756,28 @@ class TestHash < Test::Unit::TestCase
       super
     end
   end
+
+  ruby2_keywords def get_flagged_hash(*args)
+    args.last
+  end
+
+  def check_flagged_hash(k: :NG)
+    k
+  end
+
+  def test_ruby2_keywords_hash?
+    flagged_hash = get_flagged_hash(k: 1)
+    assert_equal(true, Hash.ruby2_keywords_hash?(flagged_hash))
+    assert_equal(false, Hash.ruby2_keywords_hash?({}))
+    assert_raise(TypeError) { Hash.ruby2_keywords_hash?(1) }
+  end
+
+  def test_ruby2_keywords_hash!
+    hash = {k: 1}
+    assert_equal(false, Hash.ruby2_keywords_hash?(hash))
+    hash = Hash.ruby2_keywords_hash(hash)
+    assert_equal(true, Hash.ruby2_keywords_hash?(hash))
+    assert_equal(1, check_flagged_hash(*[hash]))
+    assert_raise(TypeError) { Hash.ruby2_keywords_hash(1) }
+  end
 end


### PR DESCRIPTION
It was found that a feature to check and add ruby2_keywords flag to an
existing Hash is needed when arguments are serialized and deserialized.
It is possible to do the same without explicit APIs, but it would be
good to provide them as a core feature.

https://github.com/rails/rails/pull/38105#discussion_r361863767

Hash.ruby2_keywords?(hash) checks if hash is flagged or not.
Hash.ruby2_keywords!(hash) flags a given hash.