### PR TITLE
Disable IPv6 on Travis s390x case.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ env:
     - RUBY_PREFIX=/tmp/ruby-prefix
     - GEMS_FOR_TEST='timezone tzinfo'
     - UPDATE_UNICODE="UNICODE_FILES=. UNICODE_PROPERTY_FILES=. UNICODE_AUXILIARY_FILES=. UNICODE_EMOJI_FILES=."
+    - BEFORE_INSTALL=true
     # https://github.com/travis-ci/travis-build/blob/e411371dda21430a60f61b8f3f57943d2fe4d344/lib/travis/build/bash/travis_apt_get_options.bash#L7
     - travis_apt_get_options='--allow-downgrades --allow-remove-essential --allow-change-held-packages'
     - travis_apt_get_options="-yq --no-install-suggests --no-install-recommends $travis_apt_get_options"
@@ -68,10 +69,10 @@ env:
     #     sources:
     #       - ubuntu-toolchain-r-test
     before_install:
+      - bash -cx "${BEFORE_INSTALL}"
       - tool/travis_retry.sh sudo -E apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
       - tool/travis_retry.sh sudo bash -c "rm -rf '${TRAVIS_ROOT}/var/lib/apt/lists/'* && exec apt-get update -yq"
       - |-
-        ${BEFORE_INSTALL}
         tool/travis_retry.sh sudo -E apt-get $travis_apt_get_options install \
           ccache \
           gcc-8 \
@@ -132,7 +133,9 @@ env:
     name: s390x-linux
     arch: s390x
     <<: *gcc-8
-    
+    env:
+      - BEFORE_INSTALL="tool/travis_disable_ipv6.sh"
+
   - &jemalloc
     name: --with-jemalloc
     <<: *gcc-8
@@ -453,6 +456,8 @@ before_script:
   - echo JOBS=${JOBS} SETARCH=${SETARCH}
   - $SETARCH uname -a
   - $SETARCH uname -r
+  - ip a
+  - cat /etc/hosts
   - rm -fr .ext autom4te.cache
   - echo $TERM
   - |-

--- a/tool/travis_disable_ipv6.sh
+++ b/tool/travis_disable_ipv6.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -ex
+ip a
+sudo sysctl -w net.ipv6.conf.all.disable_ipv6=1
+sudo sysctl -w net.ipv6.conf.default.disable_ipv6=1
+sudo sysctl -w net.ipv6.conf.lo.disable_ipv6=1
+ip a
+
+cat /etc/hosts
+sudo ruby -e "hosts = File.read('/etc/hosts').sub(/^::1\s*localhost.*$/, ''); File.write('/etc/hosts', hosts)"
+cat /etc/hosts


### PR DESCRIPTION
This PR is pointed out from https://bugs.ruby-lang.org/issues/16360#note-16 .

This fixes following error that sometimes happens once in a few times
on Travis s390x environment.

```
$ tool/travis_retry.sh sudo -E apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
+ sudo -E apt-add-repository -y ppa:ubuntu-toolchain-r/test
Error: retrieving gpg key timed out.
```

```
+      - bash -cx "${BEFORE_INSTALL}"
```

For above line, I put `bash -cx` because when run `${BEFORE_INSTALL}` without `bash -cx`, the `sed` command outputs the following error. https://travis-ci.org/junaruga/ruby/jobs/633341625#L210

```
$ ${BEFORE_INSTALL}
sed: -e expression #1, char 1: unknown command: `''
```

It's useful to see the actual executed command in the Travis log like this.

```
$ bash -cx "${BEFORE_INSTALL}"
+sed vm_opts.h -e 's/OPT_SUPPORT_JOKE *0/OPT_SUPPORT_JOKE 1/' -i
```

I added the script `tool/travis_disable_ipv6.sh`, as I had no idea about how to add the multiple commands to `${BEFORE_INSTALL}`.

The ruby code

```
+sudo ruby -e "hosts = File.read('/etc/hosts').sub(/^::1\s*localhost.*$/, ''); File.write('/etc/hosts', hosts)"
```

was used in `wercker.yml` in the past.

I tested `s390x-linux` case, and I executed the case 5 times continuously, and all the jobs is succeeded. And I want to watch the case keeping it as allow_failures, on master branch for now, until we can see it will be stable.
I tested `SUPPORT_JOKE` case too that is using `${BEFORE_INSTALL}`.
