### PR TITLE
Speeds up fallback to Hash#default_proc in rb_hash_aref by removing a method call

### DIFF
--- a/benchmark/hash_defaults.yml
+++ b/benchmark/hash_defaults.yml
@@ -1,0 +1,6 @@
+prelude: |
+  h = Hash.new { :foo }
+benchmark:
+  default_aref: h[1]
+  default_method: h.default(1)
+loop_count: 1000000


### PR DESCRIPTION
```
lourens@CarbonX1:~/src/ruby/ruby$ make benchmark ITEM=hash_default COMPARE_RUBY=~/src/ruby/trunk/ruby OPTS="-v --repeat-count 24 --repeat-result median"
/usr/local/bin/ruby --disable=gems -rrubygems -I./benchmark/lib ./benchmark/benchmark-driver/exe/benchmark-driver \
            --executables="compare-ruby::/home/lourens/src/ruby/trunk/ruby -I.ext/common --disable-gem" \
            --executables="built-ruby::./miniruby -I./lib -I. -I.ext/common  ./tool/runruby.rb --extout=.ext  -- --disable-gems --disable-gem" \
            $(find ./benchmark -maxdepth 1 -name 'hash_default' -o -name '*hash_default*.yml' -o -name '*hash_default*.rb' | sort) -v --repeat-count 24 --repeat-result median
compare-ruby: ruby 2.8.0dev (2020-01-07T03:23:04Z master f132825ffa) [x86_64-linux]
built-ruby: ruby 2.8.0dev (2020-01-08T00:19:26Z faster-hash-defaul.. c762d98ea7) [x86_64-linux]
Calculating -------------------------------------
                     compare-ruby  built-ruby 
        default_aref      16.060M     19.724M i/s -      1.000M times in 0.063009s 0.050711s
      default_method      15.387M     18.336M i/s -      1.000M times in 0.067363s 0.055662s

Comparison:
                     default_aref
          built-ruby:  19724261.5 i/s 
        compare-ruby:  16059630.6 i/s - 1.23x  slower

                   default_method
          built-ruby:  18336024.8 i/s 
        compare-ruby:  15387028.8 i/s - 1.19x  slower
```

Pitty about the ability to override `Hash#default`, otherwise it would be possible to have instruction `opt_aref` as leaf.