### PR TITLE
Rename RUBY_MARK_NO_PIN_UNLESS_NULL to RUBY_MARK_MOVABLE_UNLESS_NULL

### DIFF
--- a/gc.h
+++ b/gc.h
@@ -59,7 +59,7 @@ rb_gc_debug_body(const char *mode, const char *msg, int st, void *ptr)
 #define RUBY_GC_INFO if(0)printf
 #endif
 
-#define RUBY_MARK_NO_PIN_UNLESS_NULL(ptr) do { \
+#define RUBY_MARK_MOVABLE_UNLESS_NULL(ptr) do { \
     VALUE markobj = (ptr); \
     if (RTEST(markobj)) {rb_gc_mark_movable(markobj);} \
 } while (0)

--- a/iseq.c
+++ b/iseq.c
@@ -314,7 +314,7 @@ rb_iseq_mark(const rb_iseq_t *iseq)
         rb_gc_mark_movable(body->location.label);
         rb_gc_mark_movable(body->location.base_label);
         rb_gc_mark_movable(body->location.pathobj);
-        RUBY_MARK_NO_PIN_UNLESS_NULL((VALUE)body->parent_iseq);
+        RUBY_MARK_MOVABLE_UNLESS_NULL((VALUE)body->parent_iseq);
 
 	if (body->param.flags.has_kw && ISEQ_COMPILE_DATA(iseq) == NULL) {
 	    const struct rb_iseq_param_keyword *const keyword = body->param.keyword;

--- a/proc.c
+++ b/proc.c
@@ -66,18 +66,18 @@ block_mark(const struct rb_block *block)
       case block_type_ifunc:
 	{
 	    const struct rb_captured_block *captured = &block->as.captured;
-	    RUBY_MARK_NO_PIN_UNLESS_NULL(captured->self);
-	    RUBY_MARK_NO_PIN_UNLESS_NULL((VALUE)captured->code.val);
+	    RUBY_MARK_MOVABLE_UNLESS_NULL(captured->self);
+	    RUBY_MARK_MOVABLE_UNLESS_NULL((VALUE)captured->code.val);
 	    if (captured->ep && captured->ep[VM_ENV_DATA_INDEX_ENV] != Qundef /* cfunc_proc_t */) {
-                RUBY_MARK_NO_PIN_UNLESS_NULL(VM_ENV_ENVVAL(captured->ep));
+                RUBY_MARK_MOVABLE_UNLESS_NULL(VM_ENV_ENVVAL(captured->ep));
 	    }
 	}
 	break;
       case block_type_symbol:
-	RUBY_MARK_NO_PIN_UNLESS_NULL(block->as.symbol);
+	RUBY_MARK_MOVABLE_UNLESS_NULL(block->as.symbol);
 	break;
       case block_type_proc:
-	RUBY_MARK_NO_PIN_UNLESS_NULL(block->as.proc);
+	RUBY_MARK_MOVABLE_UNLESS_NULL(block->as.proc);
 	break;
     }
 }


### PR DESCRIPTION
Function `rb_gc_mark_no_pin` is renamed to `rb_gc_mark_movable` in the commit aac4d9d6c7e6b6b0742f3941b574f6006ccb5672, but the macro `RUBY_MARK_NO_PIN_UNLESS_NULL` was not renamed at that time (though it calls `rb_gc_mark_movable` now).
So, I renamed `RUBY_MARK_NO_PIN_UNLESS_NULL` to `RUBY_MARK_MOVABLE_UNLESS_NULL`

This PR fixes Misc 16346