### PR TITLE
Fix RUBY_BIT_ROTL/RUBY_BIT_ROTR's undefined behaviours

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1104,6 +1104,7 @@ AC_CHECK_HEADERS(syscall.h)
 AC_CHECK_HEADERS(time.h)
 AC_CHECK_HEADERS(ucontext.h)
 AC_CHECK_HEADERS(utime.h)
+AC_CHECK_HEADERS(x86intrin.h)
 
 AC_ARG_WITH([gmp],
   [AS_HELP_STRING([--without-gmp],

--- a/internal/bits.h
+++ b/internal/bits.h
@@ -213,7 +213,7 @@ nlz_int32(uint32_t x)
 #elif defined(__x86_64__) && defined(__LZCNT__) && ! defined(MJIT_HEADER)
     return (unsigned int)_lzcnt_u32(x);
 
-#elif defined(_MSC_VER) && defined(_Win64) /* &&! defined(__AVX2__) */
+#elif defined(_MSC_VER) && defined(_WIN64) /* &&! defined(__AVX2__) */
     unsigned long r;
     return _BitScanReverse(&r, x) ? (int)r : 32;
 
@@ -242,7 +242,7 @@ nlz_int64(uint64_t x)
 #elif defined(__x86_64__) && defined(__LZCNT__) && ! defined(MJIT_HEADER)
     return (unsigned int)_lzcnt_u64(x);
 
-#elif defined(_MSC_VER) && defined(_Win64) /* &&! defined(__AVX2__) */
+#elif defined(_MSC_VER) && defined(_WIN64) /* &&! defined(__AVX2__) */
     unsigned long r;
     return _BitScanReverse64(&r, x) ? (unsigned int)r : 64;
 
@@ -285,7 +285,7 @@ nlz_int128(uint128_t x)
         return 128;
     }
     else if (y == 0) {
-        return (unsigned int)nlz_int64(y) + 64;
+        return (unsigned int)nlz_int64(x) + 64;
     }
     else {
         return (unsigned int)nlz_int64(y);

--- a/internal/bits.h
+++ b/internal/bits.h
@@ -215,7 +215,7 @@ nlz_int32(uint32_t x)
 
 #elif defined(_MSC_VER) && defined(_WIN64) /* &&! defined(__AVX2__) */
     unsigned long r;
-    return _BitScanReverse(&r, x) ? (int)r : 32;
+    return _BitScanReverse(&r, x) ? (31 - (int)r) : 32;
 
 #elif __has_builtin(__builtin_clz)
     STATIC_ASSERT(sizeof_int, sizeof(int) * CHAR_BIT == 32);
@@ -244,7 +244,7 @@ nlz_int64(uint64_t x)
 
 #elif defined(_MSC_VER) && defined(_WIN64) /* &&! defined(__AVX2__) */
     unsigned long r;
-    return _BitScanReverse64(&r, x) ? (unsigned int)r : 64;
+    return _BitScanReverse64(&r, x) ? (63u - (unsigned int)r) : 64;
 
 #elif __has_builtin(__builtin_clzl)
     if (x == 0) {

--- a/internal/compilers.h
+++ b/internal/compilers.h
@@ -210,6 +210,7 @@ __extension__({ \
         RB_BUILTIN_TYPE(arg_obj); \
     })
 #else
+# include "ruby/ruby.h"
 static inline int
 rb_obj_builtin_type(VALUE obj)
 {


### PR DESCRIPTION
ISO/IEC 9899:1999 section 6.5.7 states:

> If the value of the right operand is negative or is greater than or equal to the width of the promoted left operand, the behavior is undefined.

So we have to take care of such situations.

This has not been a problem because contemporary C compilers are extraordinary smart to compile the series of shifts into a single `ROTLQ`/`ROTRQ` machine instruction.  In contrast to what C says those instructions have fully defined behaviour for all possible inputs. Hence it has been quite difficult to observe the undefined-ness of such situations.  But undefined is undefined.  We should not rely on such target-specific assumptions.

We are fixing the situation by carefully avoiding shifts with out-of-range values.  At least GCC since 4.6.3 and Clang since 8.0 can issue the exact same instructions like before the changeset.

Also in case of Intel processors, there supposedly be intrinsics named `_lrotl`/`_lrotr` that does exactly what we need.  They, in practice, are absent on Clang before 9.x so we cannot blindly use.  But we can at least save MSVC.