### PR TITLE
Make Socket.getaddrinfo interruptible

### DIFF
--- a/ext/socket/rubysocket.h
+++ b/ext/socket/rubysocket.h
@@ -317,6 +317,10 @@ int rb_getnameinfo(const struct sockaddr *sa, socklen_t salen, char *host, size_
 int rsock_fd_family(int fd);
 struct rb_addrinfo *rsock_addrinfo(VALUE host, VALUE port, int family, int socktype, int flags);
 struct rb_addrinfo *rsock_getaddrinfo(VALUE host, VALUE port, struct addrinfo *hints, int socktype_hack);
+#ifdef HAVE_GETADDRINFO_A
+struct rb_addrinfo *rsock_getaddrinfo_a(VALUE host, VALUE port, struct addrinfo *hints, int socktype_hack, VALUE timeout);
+#endif
+
 VALUE rsock_fd_socket_addrinfo(int fd, struct sockaddr *addr, socklen_t len);
 VALUE rsock_io_socket_addrinfo(VALUE io, struct sockaddr *addr, socklen_t len);
 

--- a/ext/socket/socket.c
+++ b/ext/socket/socket.c
@@ -1227,7 +1227,12 @@ sock_s_getaddrinfo(int argc, VALUE *argv, VALUE _)
     if (NIL_P(revlookup) || !rsock_revlookup_flag(revlookup, &norevlookup)) {
 	norevlookup = rsock_do_not_reverse_lookup;
     }
-    res = rsock_getaddrinfo(host, port, &hints, 0);
+
+    #ifdef HAVE_GETADDRINFO_A
+        res = rsock_getaddrinfo_a(host, port, &hints, 0, Qnil);
+    #else
+        res = rsock_getaddrinfo(host, port, &hints, 0);
+    #endif
 
     ret = make_addrinfo(res, norevlookup);
     rb_freeaddrinfo(res);

--- a/test/socket/test_addrinfo.rb
+++ b/test/socket/test_addrinfo.rb
@@ -103,7 +103,7 @@ class TestSocketAddrinfo < Test::Unit::TestCase
   end
 
   def test_error_message
-    e = assert_raise_with_message(SocketError, /getaddrinfo:/) do
+    e = assert_raise_with_message(SocketError, /getaddrinfo/) do
       Addrinfo.ip("...")
     end
     m = e.message


### PR DESCRIPTION
This attempts to solve https://bugs.ruby-lang.org/issues/16476 and https://bugs.ruby-lang.org/issues/16381.

Before, Socket.getaddrinfo was using the blocking `getaddrinfo(3)` call.
That didn't allow to wrap it into Timeout.timeout or interrupt the thread.

Since we already have support for `getaddrinfo_a(3)` - the async version
of `getaddrinfo(3)`, we should be able to make `Socket.getaddrinfo` leverage that
when async version is available in the system.