### PR TITLE
compile.c: dup rest arguments if block arg expr may have side effect

### DIFF
--- a/bootstraptest/test_method.rb
+++ b/bootstraptest/test_method.rb
@@ -1190,3 +1190,19 @@ assert_equal 'DC', %q{
   test2 o1, [], block
   $result.join
 }
+
+assert_equal 'ok', %q{
+  def foo(*args, &blk)
+    blk.call(args)
+  end
+  args = [1, 2, -> (args) { args.size == 3 ? "ok" : "NG" }]
+  foo(*args, &args.pop)
+}, "Bug #16504"
+
+assert_equal 'ok', %q{
+  def foo(*args, &blk)
+    blk.call(args)
+  end
+  args = [1, 2, -> (args) { args.size == 4 ? "ok" : "NG" }]
+  foo(0, *args, &args.pop)
+}, "Bug #16504"

--- a/spec/ruby/language/send_spec.rb
+++ b/spec/ruby/language/send_spec.rb
@@ -421,18 +421,36 @@ describe "Invoking a method" do
     specs.rest_len(0,*a,4,*5,6,7,*c,-1).should == 11
   end
 
-  it "expands the Array elements from the splat after executing the arguments and block if no other arguments follow the splat" do
-    def self.m(*args, &block)
-      [args, block]
+  ruby_version_is ""..."2.8" do
+    it "expands the Array elements from the splat after executing the arguments and block if no other arguments follow the splat" do
+      def self.m(*args, &block)
+        [args, block]
+      end
+
+      args = [1, nil]
+      m(*args, &args.pop).should == [[1], nil]
+
+      args = [1, nil]
+      order = []
+      m(*(order << :args; args), &(order << :block; args.pop)).should == [[1], nil]
+      order.should == [:args, :block]
     end
+  end
 
-    args = [1, nil]
-    m(*args, &args.pop).should == [[1], nil]
+  ruby_version_is "2.8" do
+    it "evaluates the splatted arguments before the block" do
+      def self.m(*args, &block)
+        [args, block]
+      end
 
-    args = [1, nil]
-    order = []
-    m(*(order << :args; args), &(order << :block; args.pop)).should == [[1], nil]
-    order.should == [:args, :block]
+      args = [1, nil]
+      m(*args, &args.pop).should == [[1, nil], nil]
+
+      args = [1, nil]
+      order = []
+      m(*(order << :args; args), &(order << :block; args.pop)).should == [[1, nil], nil]
+      order.should == [:args, :block]
+    end
   end
 
   it "evaluates the splatted arguments before the block if there are other arguments after the splat" do


### PR DESCRIPTION
The following code should pass one positional argument and one block
one.

```
args = [->{}]
foo(*args, &args.pop)
```

However, the old implementation passes no argument because the
expression of the block argument (`args.pop`) is executed before the
rest argument is passed.

By this change, the passed rest argument is duplicated before
`args.pop` is executed.
(This duplication is omitted when the expression of the block
argument is "getblockparamproxy" because it has no side effect.)

[Bug #16504]