### PR TITLE
Fix syntax error in obj_free with hash size debug counter when USE_DEBUG_COUNTER is enabled

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -2653,7 +2653,7 @@ obj_free(rb_objspace_t *objspace, VALUE obj)
 	break;
       case T_HASH:
 #if USE_DEBUG_COUNTER
-        switch RHASH_SIZE(obj) {
+        switch (RHASH_SIZE(obj)) {
           case 0:
             RB_DEBUG_COUNTER_INC(obj_hash_empty);
             break;


### PR DESCRIPTION
Fixes:

```
gc.c: In function ‘obj_free’:
gc.c:2656:16: error: expected ‘(’ before ‘RHASH_SIZE’
 2656 |         switch RHASH_SIZE(obj) {
      |                ^~~~~~~~~~
      |                (
```