### PR TITLE
Remove s390x from allow_failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -442,7 +442,6 @@ matrix:
     - <<: *CALL_THREADED_CODE
     - <<: *NO_THREADED_CODE
   allow_failures:
-    - name: s390x-linux
     - name: -fsanitize=address
     - name: -fsanitize=memory
     - name: -fsanitize=undefined


### PR DESCRIPTION
I checked the latest Travis 20 jobs for master branch's Travis s390x-linux case, and all the job was succeeded now.
So, I think it's time to remove the s390-linux case from `allow_failures`.
