### PR TITLE
Increase the frozen_strings table initial size

### DIFF
--- a/vm.c
+++ b/vm.c
@@ -3344,7 +3344,7 @@ Init_vm_objects(void)
     /* initialize mark object array, hash */
     vm->mark_object_ary = rb_ary_tmp_new(128);
     vm->loading_table = st_init_strtable();
-    vm->frozen_strings = st_init_table_with_size(&rb_fstring_hash_type, 1000);
+    vm->frozen_strings = st_init_table_with_size(&rb_fstring_hash_type, 10000);
 }
 
 /* top self */


### PR DESCRIPTION
I noticed this default size while working on something else, and it intrigued me.

It was set to 1000 in a4a2b9be7a55bb61d17cf9673ed0d2a93bb52d31.

However on ruby-2.7.0p0, there are much more than 1k frozen string right after boot:

```
$ ruby -robjspace -e 'p ObjectSpace.each_object(String).select { |s| s.frozen? && ObjectSpace.dump(s).include?(%{"fstring":true})}.uniq.count'
5948
```

The gain is likely very minor, but it's also a very simple change (which I suppose don't require a redmine ticket).

@mame what do you think ?