### PR TITLE
Allow 'day' argument while using `deprecation`

### DIFF
--- a/lib/rubygems/deprecate.rb
+++ b/lib/rubygems/deprecate.rb
@@ -47,7 +47,7 @@ module Gem::Deprecate
   # telling the user of +repl+ (unless +repl+ is :none) and the
   # year/month that it is planned to go away.
 
-  def deprecate(name, repl, year, month)
+  def deprecate(name, repl, year, month, day=1)
     class_eval do
       old = "_deprecated_#{name}"
       alias_method old, name
@@ -56,7 +56,7 @@ module Gem::Deprecate
         target = klass ? "#{self}." : "#{self.class}#"
         msg = [ "NOTE: #{target}#{name} is deprecated",
                 repl == :none ? " with no replacement" : "; use #{repl} instead",
-                ". It will be removed on or after %4d-%02d-01." % [year, month],
+                ". It will be removed on or after %4d-%02d-%02d." % [year, month, day],
                 "\n#{target}#{name} called from #{Gem.location_of_caller.join(":")}",
         ]
         warn "#{msg.join}." unless Gem::Deprecate.skip


### PR DESCRIPTION
Currently `deprecate` only supports four arguments, allowing for deprecation year and month. Attempting to supply a 'day' fails. 

```
class MyClass
  extend Gem::Deprecate
  
  def the_dying_method
  end
  deprecate :the_dying_method, :the_new_method, 2020, 5, 10
  
  def the_new_method
  end
end

#=> ArgumentError (wrong number of arguments (given 5, expected 4))
```

This supports prior implementation (day is optional) but can support more specific deprecation dates:

`NOTE: MyClass#the_dying_method is deprecated; use the_new_method instead. It will be removed on or after 2020-05-10.`