### PR TITLE
Fix MinTTY detection and fix Reline tests on Windows

### DIFF
--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -415,8 +415,7 @@ end
 
 if RbConfig::CONFIG['host_os'] =~ /mswin|msys|mingw|cygwin|bccwin|wince|emc/
   require 'reline/windows'
-  if Reline::Windows.get_screen_size == [0, 0]
-    # Maybe Mintty on Cygwin
+  if Reline::Windows.msys_tty?
     require 'reline/ansi'
     Reline::IOGate = Reline::ANSI
   else

--- a/test/readline/test_readline.rb
+++ b/test/readline/test_readline.rb
@@ -238,7 +238,7 @@ module BasetestReadline
     append_character = Readline.completion_append_character
     Readline.completion_append_character = ""
     completion_case_fold = Readline.completion_case_fold
-    locale = Encoding.find("locale")
+    locale = get_default_internal_encoding
     if locale == Encoding::UTF_8
       enc1 = Encoding::EUC_JP
     else
@@ -545,7 +545,7 @@ module BasetestReadline
     saved_completer_quote_characters = Readline.completer_quote_characters
     saved_completer_word_break_characters = Readline.completer_word_break_characters
     return unless Readline.respond_to?(:quoting_detection_proc=)
-    unless Encoding.find("locale") == Encoding::UTF_8
+    unless Encoding.find("external") == Encoding::UTF_8
       return if assert_under_utf8
       skip 'this test needs UTF-8 locale'
     end
@@ -595,7 +595,7 @@ module BasetestReadline
         Readline.output = null
         Readline.completion_proc = ->(text) do
           ['abcde', 'abc12'].map { |i|
-            i.encode(Encoding.default_external)
+            i.encode(get_default_internal_encoding)
           }
         end
         w.write("a\t\n")
@@ -620,7 +620,7 @@ module BasetestReadline
         Readline.completion_append_character = '!'
         Readline.completion_proc = ->(text) do
           ['abcde'].map { |i|
-            i.encode(Encoding.default_external)
+            i.encode(get_default_internal_encoding)
           }
         end
         w.write("a\t\n")
@@ -789,5 +789,13 @@ class TestRelineAsReadline < Test::Unit::TestCase
   def setup
     use_lib_reline
     super
+  end
+
+  def get_default_internal_encoding
+    if RUBY_PLATFORM =~ /mswin|mingw/
+      Encoding.default_internal || Encoding::UTF_8
+    else
+      super
+    end
   end
 end

--- a/test/readline/test_readline_history.rb
+++ b/test/readline/test_readline_history.rb
@@ -275,4 +275,12 @@ class TestRelineAsReadlineHistory < Test::Unit::TestCase
     use_lib_reline
     super
   end
+
+  def get_default_internal_encoding
+    if RUBY_PLATFORM =~ /mswin|mingw/
+      Encoding.default_internal || Encoding::UTF_8
+    else
+      super
+    end
+  end
 end

--- a/test/reline/test_history.rb
+++ b/test/reline/test_history.rb
@@ -268,6 +268,10 @@ class Reline::History::Test < Reline::TestCase
   end
 
   def get_default_internal_encoding
-    return Encoding.default_internal || Encoding.find("locale")
+    if RUBY_PLATFORM =~ /mswin|mingw/
+      Encoding.default_internal || Encoding::UTF_8
+    else
+      Encoding.default_internal || Encoding.find("locale")
+    end
   end
 end

--- a/test/reline/test_reline.rb
+++ b/test/reline/test_reline.rb
@@ -21,15 +21,15 @@ class Reline::Test < Reline::TestCase
 
     Reline.completion_append_character = "a".encode(Encoding::ASCII)
     assert_equal("a", Reline.completion_append_character)
-    assert_equal(Encoding::default_external, Reline.completion_append_character.encoding)
+    assert_equal(get_reline_encoding, Reline.completion_append_character.encoding)
 
     Reline.completion_append_character = "ba".encode(Encoding::ASCII)
     assert_equal("b", Reline.completion_append_character)
-    assert_equal(Encoding::default_external, Reline.completion_append_character.encoding)
+    assert_equal(get_reline_encoding, Reline.completion_append_character.encoding)
 
     Reline.completion_append_character = "cba".encode(Encoding::ASCII)
     assert_equal("c", Reline.completion_append_character)
-    assert_equal(Encoding::default_external, Reline.completion_append_character.encoding)
+    assert_equal(get_reline_encoding, Reline.completion_append_character.encoding)
 
     Reline.completion_append_character = nil
     assert_equal(nil, Reline.completion_append_character)
@@ -40,7 +40,7 @@ class Reline::Test < Reline::TestCase
 
     Reline.basic_word_break_characters = "[".encode(Encoding::ASCII)
     assert_equal("[", Reline.basic_word_break_characters)
-    assert_equal(Encoding::default_external, Reline.basic_word_break_characters.encoding)
+    assert_equal(get_reline_encoding, Reline.basic_word_break_characters.encoding)
   end
 
   def test_completer_word_break_characters
@@ -48,7 +48,7 @@ class Reline::Test < Reline::TestCase
 
     Reline.completer_word_break_characters = "[".encode(Encoding::ASCII)
     assert_equal("[", Reline.completer_word_break_characters)
-    assert_equal(Encoding::default_external, Reline.completer_word_break_characters.encoding)
+    assert_equal(get_reline_encoding, Reline.completer_word_break_characters.encoding)
   end
 
   def test_basic_quote_characters
@@ -56,7 +56,7 @@ class Reline::Test < Reline::TestCase
 
     Reline.basic_quote_characters = "`".encode(Encoding::ASCII)
     assert_equal("`", Reline.basic_quote_characters)
-    assert_equal(Encoding::default_external, Reline.basic_quote_characters.encoding)
+    assert_equal(get_reline_encoding, Reline.basic_quote_characters.encoding)
   end
 
   def test_completer_quote_characters
@@ -64,7 +64,7 @@ class Reline::Test < Reline::TestCase
 
     Reline.completer_quote_characters = "`".encode(Encoding::ASCII)
     assert_equal("`", Reline.completer_quote_characters)
-    assert_equal(Encoding::default_external, Reline.completer_quote_characters.encoding)
+    assert_equal(get_reline_encoding, Reline.completer_quote_characters.encoding)
   end
 
   def test_filename_quote_characters
@@ -72,7 +72,7 @@ class Reline::Test < Reline::TestCase
 
     Reline.filename_quote_characters = "\'".encode(Encoding::ASCII)
     assert_equal("\'", Reline.filename_quote_characters)
-    assert_equal(Encoding::default_external, Reline.filename_quote_characters.encoding)
+    assert_equal(get_reline_encoding, Reline.filename_quote_characters.encoding)
   end
 
   def test_special_prefixes
@@ -80,7 +80,7 @@ class Reline::Test < Reline::TestCase
 
     Reline.special_prefixes = "\'".encode(Encoding::ASCII)
     assert_equal("\'", Reline.special_prefixes)
-    assert_equal(Encoding::default_external, Reline.special_prefixes.encoding)
+    assert_equal(get_reline_encoding, Reline.special_prefixes.encoding)
   end
 
   def test_completion_case_fold
@@ -266,5 +266,9 @@ class Reline::Test < Reline::TestCase
 
   def test_may_req_ambiguous_char_width
     # TODO in Reline::Core
+  end
+
+  def get_reline_encoding
+    RUBY_PLATFORM =~ /mswin|mingw/ ? Encoding::UTF_8 : Encoding::default_external
   end
 end


### PR DESCRIPTION
The story started when I inspected this reline commit https://github.com/ruby/ruby/commit/f8ea2860b0cac1aec79978e6c44168802958e8af . I wondered about so few changes in tests although there was a hard change to string encodings on the Windows backend. So I tried to run the tests alone and got encoding related failures as expected. After some back and forth I realized that the way how `make test-all` is running makes the difference. If it's running with `-j` it succeeds and without `-j` it fails. So `make test-all` was joking in CI!

The two attached commits first fix the MinTTY detection that caused the difference in test results and then it fixes the encoding related failures caused by commit f8ea2860b0cac1aec79978e6c44168802958e8af .
