### PR TITLE
Fix typo s/test_ruby2_keywords_hash!/test_ruby2_keywords_hash/

### DIFF
--- a/test/ruby/test_hash.rb
+++ b/test/ruby/test_hash.rb
@@ -1772,7 +1772,7 @@ class TestHash < Test::Unit::TestCase
     assert_raise(TypeError) { Hash.ruby2_keywords_hash?(1) }
   end
 
-  def test_ruby2_keywords_hash!
+  def test_ruby2_keywords_hash
     hash = {k: 1}
     assert_equal(false, Hash.ruby2_keywords_hash?(hash))
     hash = Hash.ruby2_keywords_hash(hash)


### PR DESCRIPTION
In #2818, `Hash.ruby2_keywords!` has renamed to `Hash.ruby2_keywords_hash`.