### PR TITLE
delegate.rb: fixed keyword arguments in DelegateClass

### DIFF
--- a/lib/delegate.rb
+++ b/lib/delegate.rb
@@ -334,7 +334,7 @@ def Delegator.delegating_block(mid) # :nodoc:
   lambda do |*args, &block|
     target = self.__getobj__
     target.__send__(mid, *args, &block)
-  end
+  end.ruby2_keywords
 end
 
 #

--- a/test/test_delegate.rb
+++ b/test/test_delegate.rb
@@ -343,4 +343,12 @@ class TestDelegateClass < Test::Unit::TestCase
     assert_equal(1, delegate.bar)
     assert_raise(NoMethodError, /undefined method `foo' for/) { delegate.foo }
   end
+
+  def test_keyword_argument
+    k = EnvUtil.labeled_class("Target") do
+      def test(a, k:) [a, k]; end
+    end
+    a = DelegateClass(k).new(k.new)
+    assert_equal([1, 0], a.test(1, k: 0))
+  end
 end


### PR DESCRIPTION
`Delegator.delegating_block` should delegate keyword arguments separately.  [ruby-core:96949]