### PR TITLE
Enable ruby2_keywords semantics by default

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -11301,7 +11301,8 @@ new_args(struct parser_params *p, NODE *pre_args, NODE *opt_args, ID rest_arg, N
 
     args->opt_args       = opt_args;
 
-    args->ruby2_keywords = rest_arg == idFWD_REST;
+    args->ruby2_keywords = (rest_arg == idFWD_REST) ||
+        (rest_arg && !args->kw_args && !args->kw_rest_arg && !args->no_kwarg);
 
     p->ruby_sourceline = saved_line;
     nd_set_loc(tail, loc);

--- a/test/ruby/test_keyword.rb
+++ b/test/ruby/test_keyword.rb
@@ -2429,8 +2429,8 @@ class TestKeywordArguments < Test::Unit::TestCase
     assert_equal([1, h1], o.baz(1, h1))
     assert_equal([h1], o.baz(h1, **{}))
 
-    assert_equal([[1, h1], {}], o.foo(:pass_bar, 1, :a=>1))
-    assert_equal([[1, h1], {}], o.foo(:pass_cfunc, 1, :a=>1))
+    assert_equal([[1], h1], o.foo(:pass_bar, 1, :a=>1))
+    assert_equal([[1], h1], o.foo(:pass_cfunc, 1, :a=>1))
 
     assert_warn(/Skipping set of ruby2_keywords flag for bar \(method accepts keywords or method does not accept argument splat\)/) do
       assert_nil(c.send(:ruby2_keywords, :bar))


### PR DESCRIPTION
See https://bugs.ruby-lang.org/issues/16463
Slides: https://docs.google.com/presentation/d/1J6voqHFQ46-MsEm_vUJsBJiktNvoA6niz3fea9awmco/edit?usp=sharing