### PR TITLE
test/reline/test_reline.rb - #get_reline_encoding Windows fix

### DIFF
--- a/test/reline/test_reline.rb
+++ b/test/reline/test_reline.rb
@@ -269,6 +269,7 @@ class Reline::Test < Reline::TestCase
   end
 
   def get_reline_encoding
-    RUBY_PLATFORM =~ /mswin|mingw/ ? Encoding::UTF_8 : Encoding::default_external
+    (RUBY_PLATFORM.match? /mswin|mingw/ and !STDOUT.tty?) ?
+      Encoding::UTF_8 : Encoding::default_external
   end
 end


### PR DESCRIPTION
On mingw/mswin, tests are failing with parallel testing, but pass on retry.

Fix so tests pass either parallel or serial.

Due to pipe encoding (parallel) being different from console encoding (serial).  Tested locally on both mingw and mswin