### PR TITLE
Fix pp when passed a empty ruby2_keywords-flagged hash as array element

### DIFF
--- a/lib/pp.rb
+++ b/lib/pp.rb
@@ -223,7 +223,7 @@ class PP < PrettyPrint
         else
           sep.call
         end
-        yield(*v)
+        yield(*v, **{})
       }
     end
 

--- a/test/test_pp.rb
+++ b/test/test_pp.rb
@@ -176,6 +176,10 @@ class PPSingleLineTest < Test::Unit::TestCase
     assert_equal("{1=>1}", PP.singleline_pp({ 1 => 1}, ''.dup)) # [ruby-core:02699]
     assert_equal("[1#{', 1'*99}]", PP.singleline_pp([1]*100, ''.dup))
   end
+
+  def test_hash_in_array
+    assert_equal("[{}]", PP.singleline_pp([->(*a){a.last}.ruby2_keywords.call(**{})], ''.dup))
+  end
 end
 
 class PPDelegateTest < Test::Unit::TestCase


### PR DESCRIPTION
This causes problems because the hash is passed to a block not
accepting keywords.  Because the hash is empty and keyword flagged,
it is removed before calling the block.  This doesn't cause an
ArgumentError because it is a block and not a lambda.  Just like
any other block not passed required arguments, arguments not
passed are set to nil.

Issues like this are a strong reason not to have ruby2_keywords
by default.

Fixes [Bug #16519]