### PR TITLE
Remove empty keyword splats when calling even when using ruby2_keywords

### DIFF
--- a/test/ruby/test_keyword.rb
+++ b/test/ruby/test_keyword.rb
@@ -2339,10 +2339,10 @@ class TestKeywordArguments < Test::Unit::TestCase
     assert_equal([[1, h1, 1], {}], o.foo_bar_mod(1, **h1))
     assert_equal([1, h1, 1], o.foo_baz_mod(1, **h1))
 
-    assert_equal([[h1, {}, 1], {}], o.foo_mod(:bar, h1, **{}))
-    assert_equal([h1, {}, 1], o.foo_mod(:baz, h1, **{}))
-    assert_equal([[h1, {}, 1], {}], o.foo_bar_mod(h1, **{}))
-    assert_equal([h1, {}, 1], o.foo_baz_mod(h1, **{}))
+    assert_equal([[h1, 1], {}], o.foo_mod(:bar, h1, **{}))
+    assert_equal([h1, 1], o.foo_mod(:baz, h1, **{}))
+    assert_equal([[h1, 1], {}], o.foo_bar_mod(h1, **{}))
+    assert_equal([h1, 1], o.foo_baz_mod(h1, **{}))
 
     assert_equal([[1, h1, 1], {}], o.foo_mod(:bar, 1, h1))
     assert_equal([1, h1, 1], o.foo_mod(:baz, 1, h1))

--- a/test/test_pp.rb
+++ b/test/test_pp.rb
@@ -178,7 +178,7 @@ class PPSingleLineTest < Test::Unit::TestCase
   end
 
   def test_hash_in_array
-    assert_equal("[{}]", PP.singleline_pp([->(*a){a.last}.ruby2_keywords.call(**{})], ''.dup))
+    assert_equal("[{}]", PP.singleline_pp([->(*a){a.last.clear}.ruby2_keywords.call(a: 1)], ''.dup))
     assert_equal("[{}]", PP.singleline_pp([Hash.ruby2_keywords_hash({})], ''.dup))
   end
 end


### PR DESCRIPTION
Keeping empty keyword splats for ruby2_keywords methods was
necessary in 2.7 to prevent the final positional hash being
treated as keywords when the target method is called.

Now that keyword argument separation has been committed, the
final positional hash is never treated as keywords, so there is no
need to keep empty keyword splats when using ruby2_keywords.