### PR TITLE
Add #verify_hostname= and #verify_hostname to skip hostname verification

### DIFF
--- a/test/net/http/test_https.rb
+++ b/test/net/http/test_https.rb
@@ -204,6 +204,29 @@ class TestNetHTTPS < Test::Unit::TestCase
     skip $!
   end
 
+  def test_skip_hostname_verfiction
+    TestNetHTTPUtils.clean_http_proxy_env do
+      http = Net::HTTP.new('invalid_servername', config('port'))
+      http.ipaddr = config('host')
+      http.use_ssl = true
+      http.cert_store = TEST_STORE
+      http.verify_hostname = false
+      assert_nothing_raised { http.start }
+    end
+  end
+
+  def test_fail_if_verify_hostname_is_true
+    TestNetHTTPUtils.clean_http_proxy_env do
+      http = Net::HTTP.new('invalid_servername', config('port'))
+      http.ipaddr = config('host')
+      http.use_ssl = true
+      http.cert_store = TEST_STORE
+      http.verify_hostname = true
+      @log_tester = lambda { |_| }
+      assert_raise(OpenSSL::SSL::SSLError) { http.start }
+    end
+  end
+
   def test_certificate_verify_failure
     http = Net::HTTP.new("localhost", config("port"))
     http.use_ssl = true


### PR DESCRIPTION
According to https://github.com/ruby/openssl/pull/60,

> Currently an user who wants to do the hostname verification needs to
call SSLSocket#post_connection_check explicitly after the TLS connection
is established.

if an user who wants to skip the hostname verification,
SSLSocket#post_connection_check doesn't need to be called

ref: https://bugs.ruby-lang.org/issues/16555