### PR TITLE
Fix linkage of popen_deadlock test

### DIFF
--- a/ext/-test-/popen_deadlock/extconf.rb
+++ b/ext/-test-/popen_deadlock/extconf.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: false
 case RUBY_PLATFORM
 when /solaris/i, /linux/i
+  $LDFLAGS << " -ldl"
   create_makefile("-test-/popen_deadlock/infinite_loop_dlsym")
 end


### PR DESCRIPTION
```
DEBUG: BUILDSTDERR: /usr/bin/ld: infinite_loop_dlsym.o: in function `native_loop_dlsym':
DEBUG: BUILDSTDERR: /builddir/build/BUILD/ruby-2.7.0/ext/-test-/popen_deadlock/infinite_loop_dlsym.c:16: undefined reference to `dlsym'
DEBUG: BUILDSTDERR: collect2: error: ld returned 1 exit status
```

Ruby was built with LibreSSL.