### PR TITLE
Avoid allocating a temporary empty string in String#slice!

### DIFF
--- a/string.c
+++ b/string.c
@@ -215,6 +215,8 @@ str_make_independent(VALUE str)
 /* symbols for [up|down|swap]case/capitalize options */
 static VALUE sym_ascii, sym_turkic, sym_lithuanian, sym_fold;
 
+static VALUE empty_string;
+
 static rb_encoding *
 get_actual_encoding(const int encidx, VALUE str)
 {
@@ -4887,13 +4889,13 @@ rb_str_slice_bang(int argc, VALUE *argv, VALUE str)
 
     rb_check_arity(argc, 1, 2);
     for (i=0; i<argc; i++) {
-	buf[i] = argv[i];
+        buf[i] = argv[i];
     }
     str_modify_keep_cr(str);
     result = rb_str_aref_m(argc, buf, str);
     if (!NIL_P(result)) {
-	buf[i] = rb_str_new(0,0);
-	rb_str_aset_m(argc+1, buf, str);
+        buf[i] = empty_string;
+        rb_str_aset_m(argc+1, buf, str);
     }
     return result;
 }
@@ -11379,6 +11381,9 @@ Init_String(void)
     rb_define_method(rb_cString, "unicode_normalize", rb_str_unicode_normalize, -1);
     rb_define_method(rb_cString, "unicode_normalize!", rb_str_unicode_normalize_bang, -1);
     rb_define_method(rb_cString, "unicode_normalized?", rb_str_unicode_normalized_p, -1);
+
+    empty_string = rb_fstring_enc_lit("", rb_usascii_encoding());
+    rb_gc_register_mark_object(empty_string);
 
     rb_fs = Qnil;
     rb_define_hooked_variable("$;", &rb_fs, 0, rb_fs_setter);


### PR DESCRIPTION
I was surprised to see an empty string allocation being reported for `"foo.rb".slice!(-3, 3)` (https://github.com/fxn/zeitwerk/pull/105)

Ultimately it doesn't matter much, but I suspect many people use the string "bang methods" to save allocations, so it's surprising to see that `slice!` actually allocates more than `slice`.