### PR TITLE
Use `rb_gc_mark` when marking globals

### DIFF
--- a/variable.c
+++ b/variable.c
@@ -397,7 +397,7 @@ void
 rb_gvar_val_marker(VALUE *var)
 {
     VALUE data = (VALUE)var;
-    if (data) rb_gc_mark_maybe(data);
+    if (data) rb_gc_mark(data);
 }
 
 VALUE


### PR DESCRIPTION
I think global references should either be 0 or valid heap pointers.
`rb_gc_mark_maybe` checks to see if the pointer is a valid heap pointer,
but I believe we already know they are valid addresses