### PR TITLE
support multi-run for test/net/http/test_http.rb

### DIFF
--- a/test/net/http/test_http.rb
+++ b/test/net/http/test_http.rb
@@ -1170,7 +1170,7 @@ end
 
 class TestNetHTTPLocalBind < Test::Unit::TestCase
   CONFIG = {
-    'host' => 'localhost',
+    'host' => '127.0.0.1',
     'proxy_host' => nil,
     'proxy_port' => nil,
   }


### PR DESCRIPTION
Fail `TestNetHTTPLocalBind` class test in `test/net/http/test_http.rb`.

Replace `host` in `CONFIG` is `127.0.0.1`, and fix it.

