### PR TITLE
Use inline cache for super() calls

### DIFF
--- a/test/ruby/test_super.rb
+++ b/test/ruby/test_super.rb
@@ -583,4 +583,17 @@ class TestSuper < Test::Unit::TestCase
   def test_super_with_modified_rest_parameter
     assert_equal [13], TestFor_super_with_modified_rest_parameter.new.foo
   end
+
+  def test_super_with_define_method
+    superklass = Class.new do
+      def foo; :foo; end
+      def bar; :bar; end
+    end
+    subklass = Class.new(superklass)
+    [:foo, :bar].each do |sym|
+      subklass.define_method(sym){ super() }
+    end
+    assert_equal :foo, subklass.new.foo
+    assert_equal :bar, subklass.new.bar
+  end
 end

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -3151,9 +3151,25 @@ vm_search_super_method(const rb_control_frame_t *reg_cfp, struct rb_call_data *c
         CC_SET_FASTPATH(cc, vm_call_method_missing, TRUE);
     }
     else {
-        /* TODO: use inline cache */
+#if OPT_INLINE_METHOD_CACHE
+	/* Unlike normal method search, we only consider the first class
+	 * serial. Since we're testing defined_class rather than receiver,
+	 * there's only one valid "warm" value. */
+	if (LIKELY(RB_DEBUG_COUNTER_INC_UNLESS(mc_global_state_miss,
+			GET_GLOBAL_METHOD_STATE() == cc->method_state) &&
+			cc->class_serial[0] == RCLASS_SERIAL(klass)) &&
+			cc->me && ci->mid == cc->me->def->original_id) {
+	    VM_ASSERT(cc->call != NULL);
+	    RB_DEBUG_COUNTER_INC(mc_inline_hit);
+	    return;
+	}
+#endif
+
         CC_SET_ME(cc, rb_callable_method_entry(klass, ci->mid));
         CC_SET_FASTPATH(cc, vm_call_super_method, TRUE);
+
+	cc->method_state = GET_GLOBAL_METHOD_STATE();
+	cc->class_serial[0] = RCLASS_SERIAL(klass);
     }
 }
 


### PR DESCRIPTION
This introduces inline caching for `super()` calls. This is able to skip the method lookup on the superclass but is still slower than a standard method call as some checks (ie. `rb_obj_is_kind_of`) are still required.

## Benchmarks

```
require "benchmark/ips"

class A;     def foo; end; def bar; end; end
class B < A; def foo; super; end; end

Benchmark.ips do |x|
  obj = B.new
  x.report("foo") { obj.foo }
  x.report("bar") { obj.bar }
end
```

**Before**

```
                 foo     12.558M (± 1.6%) i/s -     63.187M in   5.033012s
                 bar     25.596M (± 1.0%) i/s -    128.195M in   5.008823s
```

**After**

```
                 foo     17.329M (± 0.5%) i/s -     86.647M in   5.000196s
                 bar     25.564M (± 0.4%) i/s -    128.370M in   5.021504s
```

## Rails benchmark

This makes `ActionDispatch::Request.new` faster, as it calls `super()` a few times.

```
$ cat benchmark_build_request.rb
# frozen_string_literal: true

require "action_dispatch"
require "benchmark/ips"

REQUEST_ENV = Rack::MockRequest.env_for("http://example.org/hello_world/json")
REQUEST_ENV.freeze

Benchmark.ips do |x|
  x.report "ActionDispatch::Request.new", <<~RUBY
    ActionDispatch::Request.new(REQUEST_ENV)
  RUBY
end
```

**Before**
```
ActionDispatch::Request.new
                          2.500M (± 2.2%) i/s -     12.609M in   5.045582s

```

**After**
```
ActionDispatch::Request.new
                          3.371M (± 0.4%) i/s -     16.898M in   5.012308s
```