### PR TITLE
fix rdoc formatting

### DIFF
--- a/doc/NEWS-2.7.0
+++ b/doc/NEWS-2.7.0
@@ -135,8 +135,7 @@ sufficient information, see the ChangeLog file or Redmine
 
 ==== Numbered parameters
 
-* Numbered parameters as default block parameters are introduced.
-  [Feature #4475]
+* Numbered parameters as default block parameters are introduced. [Feature #4475]
 
     [1, 2, 10].map { _1.to_s(16) }    #=> ["1", "2", "a"]
     [[1, 2], [3, 4]].map { _1 + _2 }  #=> [3, 7]


### PR DESCRIPTION
This PR fixes formatting issue in NEWS-2.7.0 rdoc. NEWS-2.7.0 rdoc looks like following currently.
___

![Alt text](https://monosnap.com/image/n8ypsaddI88lYO2D0PuswDPuFKpuXc)