### PR TITLE
Improve `String#slice!` performance

### DIFF
--- a/benchmark/string_slice.yml
+++ b/benchmark/string_slice.yml
@@ -1,0 +1,11 @@
+prelude: |
+  long_string = "x"*1000+"-hår"
+benchmark:
+  regexp-short: |
+    "x-hår".slice!(/-(.)(.)(.)/, 3)
+  regexp-long: |
+    long_string.dup.slice!(/-(.)(.)(.)/, 3)
+  string-short: |
+    "x-hår".slice!("r")
+  string-long: |
+    long_string.dup.slice!("r")


### PR DESCRIPTION
Instead of searching twice to extract and to delete, extract and delete the found position at the first search.

This makes faster nearly twice, for regexps and strings.

|              |compare-ruby|built-ruby|
|:-------------|-----------:|---------:|
|regexp-short  |      2.143M|    3.918M|
|regexp-long   |    105.162k|  205.410k|
|string-short  |      3.789M|    7.964M|
|string-long   |      1.301M|    2.457M|