### PR TITLE
[PoC] Mark objects as frozen in the next ruby version

### DIFF
--- a/class.c
+++ b/class.c
@@ -1696,6 +1696,19 @@ rb_freeze_singleton_class(VALUE x)
     }
 }
 
+void
+rb_will_freeze_singleton_class(VALUE x)
+{
+    /* should not propagate to meta-meta-class, and so on */
+    if (!(RBASIC(x)->flags & FL_SINGLETON)) {
+        VALUE klass = RBASIC_CLASS(x);
+        if (klass && (klass = RCLASS_ORIGIN(klass)) != 0 &&
+            FL_TEST(klass, (FL_SINGLETON|FL_WILL_FREEZE)) == FL_SINGLETON) {
+            RB_OBJ_WILL_FREEZE_RAW(klass);
+        }
+    }
+}
+
 /*!
  * Returns the singleton class of \a obj, or nil if obj is not a
  * singleton object.

--- a/include/ruby/intern.h
+++ b/include/ruby/intern.h
@@ -299,15 +299,15 @@ PRINTF_ARGS(NORETURN(void rb_frozen_error_raise(VALUE, const char*, ...)), 2, 3)
 NORETURN(void rb_invalid_str(const char*, const char*));
 NORETURN(void rb_error_frozen(const char*));
 NORETURN(void rb_error_frozen_object(VALUE));
+void rb_warning_future_frozen_object(VALUE);
 void rb_error_untrusted(VALUE);
 void rb_check_frozen(VALUE);
 void rb_check_trusted(VALUE);
 #define rb_check_frozen_internal(obj) do { \
-	VALUE frozen_obj = (obj); \
-	if (RB_UNLIKELY(RB_OBJ_FROZEN(frozen_obj))) { \
-	    rb_error_frozen_object(frozen_obj); \
-	} \
-    } while (0)
+    VALUE frozen_obj = (obj); \
+    if (RB_UNLIKELY(RB_OBJ_CHILLED(frozen_obj))) \
+        RB_OBJ_FROZEN(frozen_obj) ? rb_error_frozen_object(frozen_obj) : rb_warning_future_frozen_object(frozen_obj); \
+} while (0)
 #ifdef __GNUC__
 #define rb_check_frozen(obj) __extension__({rb_check_frozen_internal(obj);})
 #else

--- a/object.c
+++ b/object.c
@@ -1363,7 +1363,7 @@ rb_obj_freeze(VALUE obj)
 VALUE
 rb_obj_frozen_p(VALUE obj)
 {
-    return OBJ_FROZEN(obj) ? Qtrue : Qfalse;
+    return RB_OBJ_CHILLED(obj) ? Qtrue : Qfalse;
 }
 
 

--- a/string.c
+++ b/string.c
@@ -2647,12 +2647,11 @@ rb_str_freeze(VALUE str)
 static VALUE
 str_uplus(VALUE str)
 {
-    if (OBJ_FROZEN(str)) {
-	return rb_str_dup(str);
+    if (RB_OBJ_CHILLED(str)) {
+        return rb_str_dup(str);
     }
-    else {
-	return str;
-    }
+
+    return str;
 }
 
 /*
@@ -10870,7 +10869,9 @@ sym_inspect(VALUE sym)
 VALUE
 rb_sym_to_s(VALUE sym)
 {
-    return str_new_shared(rb_cString, rb_sym2str(sym));
+    VALUE str = str_new_shared(rb_cString, rb_sym2str(sym));
+    RB_OBJ_WILL_FREEZE(str);
+    return str;
 }
 
 


### PR DESCRIPTION
Seeing https://bugs.ruby-lang.org/issues/16601 I think being able to mark objects as "frozen in the future" is necessary to deprecate mutating some return values.

This would also ease re-experimenting with freezing the return value of `Symbol#to_s` (https://bugs.ruby-lang.org/issues/16150).

This is in good part what is suggested here: https://bugs.ruby-lang.org/issues/16153

Implementation notes:
  - This is mostly a proof of concept, I'm sure there is a bunch of defects.
  - `Symbol#to_s` is modified only to test that new code.
  - I'm recycling the `RUBY_FL_TAINT` flag because from what I gathered there is no free flags available, and `RUBY_FL_TAINT` can no longer be set.
  - When a warning is issued, the `FL_WILL_FREEZE` flag is removed so that it reduced the warning noise.

@eregon since you showed interest that subject, I wonder if you have some early feedback.