### PR TITLE
Removed no longer used variable `last_hash`

### DIFF
--- a/class.c
+++ b/class.c
@@ -1964,7 +1964,6 @@ struct rb_scan_args_t {
     int n_mand;
     int argi;
     VALUE hash;
-    VALUE last_hash;
 };
 
 static void
@@ -2065,11 +2064,7 @@ rb_scan_args_assign(struct rb_scan_args_t *arg, va_list vargs)
 
 	var = va_arg(vargs, VALUE *);
 	if (0 < n_var) {
-	    if (var) {
-                int f_last = (arg->argc == arg->n_trail);
-                *var = rb_ary_new4(n_var - f_last, &arg->argv[argi]);
-                if (f_last) rb_ary_push(*var, arg->last_hash);
-	    }
+	    if (var) *var = rb_ary_new4(n_var, &arg->argv[argi]);
 	    argi += n_var;
 	}
 	else {

--- a/include/ruby/ruby.h
+++ b/include/ruby/ruby.h
@@ -2482,7 +2482,7 @@ rb_scan_args_set(int argc, const VALUE *argv,
 # endif
 {
     int i, argi = 0, vari = 0;
-    VALUE *var, hash = Qnil, last_hash = 0;
+    VALUE *var, hash = Qnil;
     const int n_mand = n_lead + n_trail;
 
     if (f_hash && argc > 0 && rb_keyword_given_p()) {
@@ -2517,11 +2517,7 @@ rb_scan_args_set(int argc, const VALUE *argv,
 
 	var = vars[vari++];
 	if (0 < n_var) {
-	    if (var) {
-		int f_last = (argc == n_trail);
-		*var = rb_ary_new4(n_var-f_last, &argv[argi]);
-		if (f_last) rb_ary_push(*var, last_hash);
-	    }
+	    if (var) *var = rb_ary_new4(n_var, &argv[argi]);
 	    argi += n_var;
 	}
 	else {


### PR DESCRIPTION
1. By substituting `n_var` with its initializer, `0 < n_var` is equivalent to `argc > argi + n_trail`.
2. As `argi` is non-negative, so `argi + n_trail >= n_trail`, and the above expression is equivalent to `argc > n_trail`.
3. Therefore, `f_last` is always false, and `last_hash` is no longer used.
