### PR TITLE
Check type of empty keyword

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -4253,7 +4253,7 @@ compile_hash(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, int popp
                 FLUSH_CHUNK();
 
                 const NODE *kw = node->nd_next->nd_head;
-                int empty_kw = nd_type(kw) == NODE_LIT;       /* foo(  ..., **{}, ...) */
+                int empty_kw = nd_type(kw) == NODE_LIT && RB_TYPE_P(kw->nd_lit, T_HASH); /* foo(  ..., **{}, ...) */
                 int first_kw = first_chunk && stack_len == 0; /* foo(1,2,3, **kw, ...) */
                 int last_kw = !node->nd_next->nd_next;        /* foo(  ..., **kw) */
                 int only_kw = last_kw && first_kw;            /* foo(1,2,3, **kw) */

--- a/test/ruby/test_keyword.rb
+++ b/test/ruby/test_keyword.rb
@@ -4076,4 +4076,10 @@ class TestKeywordArgumentsSymProcRefinements < Test::Unit::TestCase
       mock.new.foo
     end
   end
+
+  def test_splat_fixnum
+    bug16603 = '[ruby-core:97047] [Bug #16603]'
+    assert_raise(TypeError, bug16603) { p(**42) }
+    assert_raise(TypeError, bug16603) { p(k:1, **42) }
+  end
 end


### PR DESCRIPTION
Co-authored-by: Yusuke Endoh <mame@ruby-lang.org>

Fix https://bugs.ruby-lang.org/issues/16603