### PR TITLE
Set default for Encoding.default_external to UTF-8 on Windows

### DIFF
--- a/encoding.c
+++ b/encoding.c
@@ -1685,7 +1685,9 @@ rb_enc_default_external(void)
  * File data written to disk will be transcoded to the default external
  * encoding when written, if default_internal is not nil.
  *
- * The default external encoding is initialized by the locale or -E option.
+ * The default external encoding is initialized by the -E option.
+ * If -E isn't set, it is initialized to UTF-8 on Windows and the locale on
+ * other operating systems.
  */
 static VALUE
 get_default_external(VALUE klass)

--- a/ruby.c
+++ b/ruby.c
@@ -1818,6 +1818,9 @@ process_options(int argc, char **argv, ruby_cmdline_options_t *opt)
     Init_ruby_description();
     Init_enc();
     lenc = rb_locale_encoding();
+#if UTF8_PATH
+    uenc = rb_utf8_encoding();
+#endif
     rb_enc_associate(rb_progname, lenc);
     rb_obj_freeze(rb_progname);
     parser = rb_parser_new();
@@ -1838,7 +1841,7 @@ process_options(int argc, char **argv, ruby_cmdline_options_t *opt)
 	enc = rb_enc_from_index(opt->ext.enc.index);
     }
     else {
-	enc = lenc;
+	enc = IF_UTF8_PATH(uenc, lenc);
     }
     rb_enc_set_default_external(rb_enc_from_encoding(enc));
     if (opt->intern.enc.index >= 0) {
@@ -1850,8 +1853,7 @@ process_options(int argc, char **argv, ruby_cmdline_options_t *opt)
 #endif
     }
     script_name = opt->script_name;
-    rb_enc_associate(opt->script_name,
-		     IF_UTF8_PATH(uenc = rb_utf8_encoding(), lenc));
+    rb_enc_associate(opt->script_name, IF_UTF8_PATH(uenc, lenc));
 #if UTF8_PATH
     if (uenc != lenc) {
 	opt->script_name = str_conv_enc(opt->script_name, uenc, lenc);
@@ -1944,7 +1946,7 @@ process_options(int argc, char **argv, ruby_cmdline_options_t *opt)
 	enc = rb_enc_from_index(opt->ext.enc.index);
     }
     else {
-	enc = lenc;
+	enc = IF_UTF8_PATH(uenc, lenc);
     }
     rb_enc_set_default_external(rb_enc_from_encoding(enc));
     if (opt->intern.enc.index >= 0) {

--- a/spec/ruby/command_line/dash_upper_k_spec.rb
+++ b/spec/ruby/command_line/dash_upper_k_spec.rb
@@ -58,8 +58,8 @@ describe 'The -K command line option' do
   end
 
   it "ignores unknown codes" do
-    locale = Encoding.find('locale')
+    external = Encoding.find('external')
     ruby_exe(@test_string, options: '-KZ').should ==
-      [Encoding::UTF_8.name, locale.name, nil].inspect
+      [Encoding::UTF_8.name, external.name, nil].inspect
   end
 end

--- a/spec/ruby/library/stringio/binmode_spec.rb
+++ b/spec/ruby/library/stringio/binmode_spec.rb
@@ -9,7 +9,7 @@ describe "StringIO#binmode" do
 
   it "changes external encoding to BINARY" do
     io = StringIO.new
-    io.external_encoding.should == Encoding.find('locale')
+    io.external_encoding.should == Encoding.find('external')
     io.binmode
     io.external_encoding.should == Encoding::BINARY
   end


### PR DESCRIPTION
See discussion on https://bugs.ruby-lang.org/issues/16604 .