### PR TITLE
Fix description of Encoding.default_(in|ex)ternal

### DIFF
--- a/encoding.c
+++ b/encoding.c
@@ -1475,7 +1475,7 @@ rb_enc_default_external(void)
  * encoding may not be valid.  Be sure to check String#valid_encoding?.
  *
  * File data written to disk will be transcoded to the default external
- * encoding when written.
+ * encoding when written, if default_internal is not nil.
  *
  * The default external encoding is initialized by the locale or -E option.
  */
@@ -1560,8 +1560,7 @@ rb_enc_default_internal(void)
  * The script encoding (__ENCODING__), not default_internal, is used as the
  * encoding of created strings.
  *
- * Encoding::default_internal is initialized by the source file's
- * internal_encoding or -E option.
+ * Encoding::default_internal is initialized with -E option or nil otherwise.
  */
 static VALUE
 get_default_internal(VALUE klass)


### PR DESCRIPTION
Data written to files is not transcoded per default, but only when `default_internal` is set.

The default for `default_internal` is `nil` and doesn't depend on the source file encoding.