### PR TITLE
Add the loaded feature after no exception raised

### DIFF
--- a/load.c
+++ b/load.c
@@ -1014,7 +1014,6 @@ require_internal(rb_execution_context_t *ec, VALUE fname, int exception)
 		result = 0;
 	    }
 	    else if (!*ftptr) {
-		rb_provide_feature(path);
 		result = TAG_RETURN;
 	    }
 	    else {
@@ -1029,7 +1028,6 @@ require_internal(rb_execution_context_t *ec, VALUE fname, int exception)
 		    rb_ary_push(ruby_dln_librefs, LONG2NUM(handle));
 		    break;
 		}
-                rb_provide_feature(path);
                 result = TAG_RETURN;
 	    }
 	}
@@ -1063,6 +1061,7 @@ require_internal(rb_execution_context_t *ec, VALUE fname, int exception)
         rb_exc_raise(ec->errinfo);
     }
 
+    if (result == TAG_RETURN) rb_provide_feature(path);
     ec->errinfo = errinfo;
 
     RUBY_DTRACE_HOOK(REQUIRE_RETURN, RSTRING_PTR(fname));

--- a/test/ruby/test_require.rb
+++ b/test/ruby/test_require.rb
@@ -216,6 +216,13 @@ class TestRequire < Test::Unit::TestCase
     assert_syntax_error_backtrace {|req| require req}
   end
 
+  def test_require_syntax_error_rescued
+    assert_syntax_error_backtrace do |req|
+      assert_raise_with_message(SyntaxError, /unexpected/) {require req}
+      require req
+    end
+  end
+
   def test_load_syntax_error
     assert_syntax_error_backtrace {|req| load req}
   end


### PR DESCRIPTION
Retrying after rescued `require` should try to load the same library again.  [Bug #16607]