### PR TITLE
support multi-run test for test/did_you_mean/spell_checking/test_class_name_check.rb

### DIFF
--- a/test/did_you_mean/fixtures/book.rb
+++ b/test/did_you_mean/fixtures/book.rb
@@ -1,4 +1,4 @@
 class Book
-  class Cover
+  class Spine
   end
 end

--- a/test/did_you_mean/spell_checking/test_class_name_check.rb
+++ b/test/did_you_mean/spell_checking/test_class_name_check.rb
@@ -66,7 +66,9 @@ class ClassNameCheckTest < Test::Unit::TestCase
   end
 
   def test_does_not_suggest_user_input
-    error = assert_raise(NameError) { ::Book::Cover }
+    Book.send(:remove_const, :Spine) if Book.constants.include?(:Spine)
+
+    error = assert_raise(NameError) { ::Book::Spine }
 
     # This is a weird require, but in a multi-threaded condition, a constant may
     # be loaded between when a NameError occurred and when the spell checker


### PR DESCRIPTION
Support multi-run test.

Secondly test fails in this line, because already define `Book::Cover`.

```ruby
error = assert_raise(NameError) { ::Book::Cover }
```

Tried remove `Book::Cover`, but test was fail this line.

```ruby
assert_empty error.corrections
```

```bash
ClassNameCheckTest#test_does_not_suggest_user_input [/home/ubuntu/environment/workdir/ruby/test/did_you_mean/spell_checking/test_class_name_check.rb:81]:
Expected ["Coverage"] to be empty.
```

So, rename to `Book::Spine` and remove `Book::Spine` for secondly test.
