### PR TITLE
remove warning & support multi-run test for test/psych/visitors/test_…

### DIFF
--- a/test/psych/visitors/test_to_ruby.rb
+++ b/test/psych/visitors/test_to_ruby.rb
@@ -24,6 +24,7 @@ module Psych
       end
 
       def test_legacy_struct
+        Struct.send(:remove_const, AWESOME) if Struct.const_defined?(:AWESOME)
         foo = Struct.new('AWESOME', :bar)
         assert_equal foo.new('baz'), Psych.load(<<-eoyml)
 !ruby/struct:AWESOME


### PR DESCRIPTION
Remove warning for test for `test/psych/visitors/test_to_ruby.rb`(in multi-run tests).