### PR TITLE
Add SNI support to net/smtp

### DIFF
--- a/lib/net/smtp.rb
+++ b/lib/net/smtp.rb
@@ -581,6 +581,7 @@ module Net
       s = ssl_socket(s, @ssl_context)
       logging "TLS connection started"
       s.sync_close = true
+      s.hostname = @address if s.respond_to? :hostname=
       ssl_socket_connect(s, @open_timeout)
       if @ssl_context.verify_mode != OpenSSL::SSL::VERIFY_NONE
         s.post_connection_check(@address)


### PR DESCRIPTION
It looks like it's already been added to FTP, HTTP, IMAP, and POP. I think that SMTP was the only one remaining.

Since it's used by all of the `Net::Protocol` classes, does it make more sense to move this into `Net::Protocol#ssl_socket_connect(socket, open_timeout, hostname)` similar to the suggestion here: https://bugs.ruby-lang.org/issues/15594#change-77564 ?

See the ruby ticket here: https://bugs.ruby-lang.org/issues/16611