### PR TITLE
MinGW - rename OpenSSL dll's in system32 directory

### DIFF
--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -99,6 +99,9 @@ jobs:
       - name: make all
         timeout-minutes: 20
         run: |
+          # Hopefully, GitHub will remove these files
+          ren C:\Windows\System32\libcrypto-1_1-x64.dll libcrypto-1_1-x64.dll_
+          ren C:\Windows\System32\libssl-1_1-x64.dll libssl-1_1-x64.dll_
           $jobs = [int]$env:NUMBER_OF_PROCESSORS + 1
           make -C build -j $jobs V=1
 


### PR DESCRIPTION
This issue also existed on AppVeyor.  A popular OpenSSL msvc package adds its dll files to the System32 folder.

MinGW / RubyInstaller2 builds use a manifest for dll's, but CI here does not, and that only applies to the Ruby exe in the install folder.

Rename the dll's