### PR TITLE
remove warning & support multi-run test for test/psych_test_yaml.rb

### DIFF
--- a/test/psych/test_yaml.rb
+++ b/test/psych/test_yaml.rb
@@ -1034,6 +1034,7 @@ EOY
     end
 
 	def test_ruby_struct
+		Struct.send(:remove_const, :MyBookStruct) if Struct.const_defined?(:MyBookStruct)
 		# Ruby structures
 		book_struct = Struct::new( "MyBookStruct", :author, :title, :year, :isbn )
 		assert_to_yaml(


### PR DESCRIPTION
Remove warning for test for`test/psych_test_yaml.rb`(in multi-run tests).