### PR TITLE
net/imap: Parsing CAPABILITY data for ResponseCode

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -3173,6 +3173,7 @@ module Net
           end
         end
         match(T_RBRA)
+        @pos += 1 if @str[@pos] == " "
         @lex_state = EXPR_RTEXT
         return result
       end

--- a/test/net/imap/test_imap_response_parser.rb
+++ b/test/net/imap/test_imap_response_parser.rb
@@ -236,7 +236,7 @@ EOF
     assert_equal("AUTH=PLAIN", response.data.last)
     response = parser.parse("* OK [CAPABILITY IMAP4rev1 SASL-IR 1234 NIL THIS+THAT + AUTH=PLAIN ID] IMAP4rev1 Hello\r\n")
     assert_equal("OK", response.name)
-    assert_equal(" IMAP4rev1 Hello", response.data.text)
+    assert_equal("IMAP4rev1 Hello", response.data.text)
     code = response.data.code
     assert_equal("CAPABILITY", code.name)
     assert_equal(

--- a/test/net/imap/test_imap_response_parser.rb
+++ b/test/net/imap/test_imap_response_parser.rb
@@ -234,6 +234,15 @@ EOF
     response = parser.parse("* CAPABILITY st11p00mm-iscream009 1Q49 XAPPLEPUSHSERVICE IMAP4 IMAP4rev1 SASL-IR AUTH=ATOKEN AUTH=PLAIN \r\n")
     assert_equal("CAPABILITY", response.name)
     assert_equal("AUTH=PLAIN", response.data.last)
+    response = parser.parse("* OK [CAPABILITY IMAP4rev1 SASL-IR 1234 NIL THIS+THAT + AUTH=PLAIN ID] IMAP4rev1 Hello\r\n")
+    assert_equal("OK", response.name)
+    assert_equal(" IMAP4rev1 Hello", response.data.text)
+    code = response.data.code
+    assert_equal("CAPABILITY", code.name)
+    assert_equal(
+      ["IMAP4REV1", "SASL-IR", "1234", "NIL", "THIS+THAT", "+", "AUTH=PLAIN", "ID"],
+      code.data
+    )
   end
 
   def test_mixed_boundary


### PR DESCRIPTION
In RFC3501, "capability-data" is found both in "response-data" and in
"resp-text-code".  Many IMAP servers return CAPABILITY codes in the
server greeting or in the tagged OK for STARTTLS, LOGIN, or
AUTHENTICATE.

This adds parsing for CAPABILITY data in a ResponseCode, the same as
already existed for CAPABILITY data in an UntaggedResponse.

See also the ruby ticket: https://bugs.ruby-lang.org/issues/16626