### PR TITLE
Clarified documentation in rb_integer_unpack

### DIFF
--- a/bignum.c
+++ b/bignum.c
@@ -3611,7 +3611,7 @@ rb_integer_pack(VALUE val, void *words, size_t numwords, size_t wordsize, size_t
 }
 
 /*
- * Import an integer into a buffer.
+ * Import an integer from a buffer.
  *
  * [words] buffer to import.
  * [numwords] the size of given buffer as number of words.


### PR DESCRIPTION
I struggled figuring out which of the pack/unpack functions goes into which direction and the two first sentences were of the documentation were:
* Import an integer into a buffer.
* Export an integer into a buffer.

It sounds like both of them go from a ruby integer to a buffer because both use "into". So I fixed it and went to "Import an integer from a buffer". I find this much more clear.