### PR TITLE
Fix remove warning & support multi-run test for test/psych/visitors/test_to_ruby.rb

### DIFF
--- a/test/psych/visitors/test_to_ruby.rb
+++ b/test/psych/visitors/test_to_ruby.rb
@@ -24,7 +24,7 @@ module Psych
       end
 
       def test_legacy_struct
-        Struct.send(:remove_const, AWESOME) if Struct.const_defined?(:AWESOME)
+        Struct.send(:remove_const, :AWESOME) if Struct.const_defined?(:AWESOME)
         foo = Struct.new('AWESOME', :bar)
         assert_equal foo.new('baz'), Psych.load(<<-eoyml)
 !ruby/struct:AWESOME


### PR DESCRIPTION
Sorry,  Re:fix Remove warning for test for test/psych/visitors/test_to_ruby.rb(in multi-run tests).

running multi-test fail this code

```ruby
Struct.send(:remove_const, AWESOME) if Struct.const_defined?(:AWESOME)
```

So, fix that