### PR TITLE
support multi-run test for test/did_you_mean/test_verbose_formatter.rb

### DIFF
--- a/test/did_you_mean/test_verbose_formatter.rb
+++ b/test/did_you_mean/test_verbose_formatter.rb
@@ -3,6 +3,7 @@ require_relative './helper'
 class VerboseFormatterTest < Test::Unit::TestCase
   def setup
     require_relative File.join(DidYouMean::TestHelper.root, 'verbose')
+    DidYouMean.formatter = DidYouMean::VerboseFormatter.new
   end
 
   def teardown


### PR DESCRIPTION
Support multi-run test for test/did_you_mean/test_verbose_formatter.rb.

Secondly test is fail to this line, because usng formatter `DidYouMean::PlainFormatter` in other test.

```ruby
assert_match <<~MESSAGE.strip, @error.message
```

So, using `DidYouMean::VerboseFormatter` in `setup` method.