### PR TITLE
support multi-run test for test/webrick/test_filehandler.rb

### DIFF
--- a/test/webrick/test_filehandler.rb
+++ b/test/webrick/test_filehandler.rb
@@ -103,6 +103,7 @@ class WEBrick::TestFileHandler < Test::Unit::TestCase
     bug2593 = '[ruby-dev:40030]'
 
     TestWEBrick.start_httpserver(config) do |server, addr, port, log|
+      server[:DocumentRootOptions][:NondisclosureName] = []
       http = Net::HTTP.new(addr, port)
       req = Net::HTTP::Get.new("/")
       http.request(req){|res|


### PR DESCRIPTION
Support multi-run test for test/webrick/test_filehandler.rb.

Secondly test fail in this line.

```ruby
assert_match(/HREF="#{this_file}"/, res.body, log.call)
```

Other test set `NondisclosureName=>[".ht*", "*~", "TEST_*"]` in first test, and cannot access to `/test_filehandler.rb`.

Init to `:NondisclosureName` for multi-run.

```ruby
server[:DocumentRootOptions][:NondisclosureName] = []
```

