### PR TITLE
Remove rb_eval_cmd

### DIFF
--- a/include/ruby/intern.h
+++ b/include/ruby/intern.h
@@ -434,7 +434,6 @@ void rb_alias(VALUE, ID, ID);
 void rb_attr(VALUE,ID,int,int,int);
 int rb_method_boundp(VALUE, ID, int);
 int rb_method_basic_definition_p(VALUE, ID);
-VALUE rb_eval_cmd(VALUE, VALUE, int);
 VALUE rb_eval_cmd_kw(VALUE, VALUE, int);
 int rb_obj_respond_to(VALUE, ID, int);
 int rb_respond_to(VALUE, ID);

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -1748,13 +1748,6 @@ rb_eval_cmd_kw(VALUE cmd, VALUE arg, int kw_splat)
     return val;
 }
 
-VALUE
-rb_eval_cmd(VALUE cmd, VALUE arg, int _level)
-{
-    rb_warn("rb_eval_cmd will be removed in Ruby 3.0");
-    return rb_eval_cmd_kw(cmd, arg, RB_NO_KEYWORDS);
-}
-
 /* block eval under the class/module context */
 
 static VALUE


### PR DESCRIPTION
This was related to $SAFE, and was deprecated in 2.7.  I missed it
earlier when removing the other $SAFE-related code.