### PR TITLE
net/imap: support NAMESPACE extension (RFC2342)

### DIFF
--- a/test/net/imap/test_imap_response_parser.rb
+++ b/test/net/imap/test_imap_response_parser.rb
@@ -308,4 +308,37 @@ EOF
     assert_equal(nil, response.data.code)
     assert_equal("", response.data.text)
   end
+
+  def test_namespace
+    parser = Net::IMAP::ResponseParser.new
+    # RFC2342 Example 5.1
+    response = parser.parse(%Q{* NAMESPACE (("" "/")) NIL NIL\r\n})
+    assert_equal("NAMESPACE", response.name)
+    assert_equal([Net::IMAP::Namespace.new("", "/", {})], response.data.personal)
+    assert_equal([], response.data.other)
+    assert_equal([], response.data.shared)
+    # RFC2342 Example 5.4
+    response = parser.parse(%Q{* NAMESPACE (("" "/")) (("~" "/")) (("#shared/" "/")} +
+                            %Q{ ("#public/" "/") ("#ftp/" "/") ("#news." "."))\r\n})
+    assert_equal("NAMESPACE", response.name)
+    assert_equal([Net::IMAP::Namespace.new("", "/", {})], response.data.personal)
+    assert_equal([Net::IMAP::Namespace.new("~", "/", {})], response.data.other)
+    assert_equal(
+      [
+        Net::IMAP::Namespace.new("#shared/", "/", {}),
+        Net::IMAP::Namespace.new("#public/", "/", {}),
+        Net::IMAP::Namespace.new("#ftp/", "/", {}),
+        Net::IMAP::Namespace.new("#news.", ".", {}),
+      ],
+      response.data.shared
+    )
+    # RFC2342 Example 5.6
+    response = parser.parse(%Q{* NAMESPACE (("" "/") ("#mh/" "/" "X-PARAM" ("FLAG1" "FLAG2"))) NIL NIL\r\n})
+    assert_equal("NAMESPACE", response.name)
+    namespace = response.data.personal.last
+    assert_equal("#mh/", namespace.prefix)
+    assert_equal("/", namespace.delim)
+    assert_equal({"X-PARAM" => ["FLAG1", "FLAG2"]}, namespace.extensions)
+  end
+
 end


### PR DESCRIPTION
This extension predates IMAP4rev1 (RFC3501), so most IMAP servers
support it. Many popular IMAP servers are configured with the default
personal namespaces as `("" "/")`: no prefix and "/" hierarchy
delimiter. In that common case, the naive client may not have any
trouble naming mailboxes.

But many servers are configured e.g. with the default personal namespace
as `("INBOX." ".")`, placing all personal folders under INBOX with "."
as the hierarchy delimiter. If the client does not check for this, but
naively assumes it can use the same folder names for all servers, then
folder creation (and listing, moving, etc) can lead to errors.