### PR TITLE
Workaround for bison provided by scoop on mswin environment

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -865,6 +865,7 @@ PHONY:
 	$(ECHO) generating $@
 	$(Q)$(BASERUBY) $(srcdir)/tool/id2token.rb --path-separator=.$(PATH_SEPARATOR)./ --vpath=$(VPATH) id.h $(SRC_FILE) > parse.tmp.y
 	$(Q)$(BASERUBY) $(srcdir)/tool/pure_parser.rb parse.tmp.y $(YACC)
+	$(Q)$(RM) parse.tmp.y.bak
 	$(Q)$(YACC) -d $(YFLAGS) -o y.tab.c parse.tmp.y
 	$(Q)$(RM) parse.tmp.y
 	$(Q)sed -f $(srcdir)/tool/ytab.sed -e "/^#/s|parse\.tmp\.[iy]|$(SRC_FILE)|" -e "/^#/s!y\.tab\.c!$@!" y.tab.c > $@.new

--- a/ext/ripper/depend
+++ b/ext/ripper/depend
@@ -22,6 +22,7 @@ ripper.y: $(srcdir)/tools/preproc.rb $(srcdir)/tools/dsl.rb $(top_srcdir)/parse.
 	$(Q) $(RUBY) $(top_srcdir)/tool/id2token.rb --path-separator=.$(PATH_SEPARATOR)./ \
 		--vpath=$(VPATH)$(PATH_SEPARATOR)$(top_srcdir) id.h $(top_srcdir)/parse.y > ripper.tmp.y
 	$(Q) $(RUBY) $(top_srcdir)/tool/pure_parser.rb ripper.tmp.y $(BISON)
+	$(Q) $(RM) ripper.tmp.y.bak
 	$(Q) $(RUBY) $(srcdir)/tools/preproc.rb ripper.tmp.y --output=$@
 	$(Q) $(RM) ripper.tmp.y
 

--- a/tool/pure_parser.rb
+++ b/tool/pure_parser.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby -pi
+#!/usr/bin/ruby -pi.bak
 BEGIN {
   require_relative 'lib/colorize'
 


### PR DESCRIPTION
I got the error the following error with ruby and bison provided by scoop.

```
generating parse.c
Traceback (most recent call last):
        2: from ../ruby/tool/pure_parser.rb:1:in `<main>'
        1: from ../ruby/tool/pure_parser.rb:1:in `gets'
../ruby/tool/pure_parser.rb:1:in `gets': Can't do inplace edit without backup (fatal)
NMAKE : fatal error U1077: 'C:\opt\scoop\apps\ruby\current\bin\ruby.exe' : リターン コード '0x1'
Stop.
```