### PR TITLE
Symbol#to_proc reports -1 for arity

### DIFF
--- a/proc.c
+++ b/proc.c
@@ -1090,6 +1090,10 @@ rb_vm_block_min_max_arity(const struct rb_block *block, int *max)
 	    return ifunc->argc.min;
 	}
       case block_type_symbol:
+	{
+	    *max = 1;
+	    return 1;
+	}
 	break;
     }
     *max = UNLIMITED_ARGUMENTS;

--- a/spec/ruby/core/symbol/to_proc_spec.rb
+++ b/spec/ruby/core/symbol/to_proc_spec.rb
@@ -12,18 +12,18 @@ describe "Symbol#to_proc" do
     :to_s.to_proc.call(obj).should == "Received #to_s"
   end
 
-  it "produces a proc with arity -1" do
+  it "produces a proc with arity 1" do
     pr = :to_s.to_proc
-    pr.arity.should == -1
+    pr.arity.should == 1
   end
 
   it "raises an ArgumentError when calling #call on the Proc without receiver" do
     -> { :object_id.to_proc.call }.should raise_error(ArgumentError, "no receiver given")
   end
 
-  it "produces a proc that always returns [[:rest]] for #parameters" do
+  it "produces a proc that always returns [[:req]] for #parameters" do
     pr = :to_s.to_proc
-    pr.parameters.should == [[:rest]]
+    pr.parameters.should == [[:req]]
   end
 
   it "passes along the block passed to Proc#call" do

--- a/test/ruby/test_proc.rb
+++ b/test/ruby/test_proc.rb
@@ -121,9 +121,13 @@ class TestProc < Test::Unit::TestCase
     assert_equal(-3, lambda{|x, y=0, z, **o|}.arity)
     assert_equal(-3, lambda{|x, y=0, *z, w, **o|}.arity)
 
+    assert_equal(1, proc(&:hash).arity)
+    assert_equal(1, lambda(&:hash).arity)
+
     assert_arity(0) {}
     assert_arity(0) {||}
     assert_arity(1) {|x|}
+    assert_arity(1, &:hash)
     assert_arity(2) {|x, y|}
     assert_arity(-2) {|x, *y|}
     assert_arity(-3) {|x, *y, z|}

--- a/test/ruby/test_symbol.rb
+++ b/test/ruby/test_symbol.rb
@@ -219,11 +219,11 @@ class TestSymbol < Test::Unit::TestCase
     begin;
       bug11845 = '[ruby-core:72381] [Bug #11845]'
       assert_nil(:class.to_proc.source_location, bug11845)
-      assert_equal([[:rest]], :class.to_proc.parameters, bug11845)
+      assert_equal([[:req]], :class.to_proc.parameters, bug11845)
       c = Class.new {define_method(:klass, :class.to_proc)}
       m = c.instance_method(:klass)
       assert_nil(m.source_location, bug11845)
-      assert_equal([[:rest]], m.parameters, bug11845)
+      assert_equal([[:req]], m.parameters, bug11845)
     end;
   end
 


### PR DESCRIPTION
When you create a proc using Symbol#to_proc syntax, it reports the arity as -1, even though the required number of arguments is actually 1. This can happen based on `lambda(&:hash)`, `proc(&:hash)`, or `some_method(&:hash)`.