### PR TITLE
support multi-run test for test_readline.rb

### DIFF
--- a/test/readline/test_readline.rb
+++ b/test/readline/test_readline.rb
@@ -21,6 +21,8 @@ module BasetestReadline
       Readline.point = 0
     rescue NotImplementedError
     end
+    Readline.special_prefixes = ""
+    Readline.completion_append_character = nil
     Readline.input = nil
     Readline.output = nil
     SAVED_ENV.each_with_index {|k, i| ENV[k] = @saved_env[i] }


### PR DESCRIPTION
Somtimes `make test-all TESTS="--repeat-count="50""` is Fail.

```bash
TestReadline#test_line_buffer__point [/home/ubuntu/environment/workdir/ruby/test/readline/test_readline.rb:101]:
<"second"> expected but was
<" second">.
[15857/19977] TestReadline#test_using_quoting_detection_proc_with_multibyte_input = 0.00 s
  2) Failure:
TestReadline#test_using_quoting_detection_proc_with_multibyte_input [/home/ubuntu/environment/workdir/ruby/test/readline/test_readline.rb:586]:
<"あん completion"> expected but was
<"あん completion ">.
```

`TestReadline#test_line_buffer__point` is failed by  `TestReadline#test_some_characters_methods`(throw Exception). And `Readline.special_prefixes` is ` `.

```bash
TestReadline#test_line_buffer__point [/home/ubuntu/environment/workdir/ruby/test/readline/test_readline.rb:101]:
<"second"> expected but was
<" second">.
```  

`TestReadline#test_using_quoting_detection_proc_with_multibyte_input` is  failed to `ReadlineReadline.completion_append_character` is ` `. 

So, there's re-init in `teardown`.