### PR TITLE
test/readline - allow ENV control of test class creation

### DIFF
--- a/test/readline/test_readline.rb
+++ b/test/readline/test_readline.rb
@@ -784,7 +784,7 @@ class TestReadline < Test::Unit::TestCase
     use_ext_readline
     super
   end
-end if defined?(ReadlineSo)
+end if defined?(ReadlineSo) && ENV["TEST_READLINE_OR_RELINE"] != "Reline"
 
 class TestRelineAsReadline < Test::Unit::TestCase
   include BasetestReadline
@@ -801,4 +801,4 @@ class TestRelineAsReadline < Test::Unit::TestCase
       super
     end
   end
-end if defined?(Reline)
+end if defined?(Reline) && ENV["TEST_READLINE_OR_RELINE"] != "Readline"

--- a/test/readline/test_readline_history.rb
+++ b/test/readline/test_readline_history.rb
@@ -260,6 +260,7 @@ class TestReadlineHistory < Test::Unit::TestCase
     super
   end
 end if defined?(::ReadlineSo) && defined?(::ReadlineSo::HISTORY) &&
+  ENV["TEST_READLINE_OR_RELINE"] != "Reline" &&
   (
    begin
      ReadlineSo::HISTORY.clear
@@ -283,4 +284,4 @@ class TestRelineAsReadlineHistory < Test::Unit::TestCase
       super
     end
   end
-end if defined?(Reline)
+end if defined?(Reline) && ENV["TEST_READLINE_OR_RELINE"] != "Readline"


### PR DESCRIPTION
In ruby/ruby, the tests run on both readline & reline by creating four test classes:
```
TestReadline
TestReadlineHistory

TestRelineAsReadline
TestRelineAsReadlineHistory
```

Reline inports the test files and uses them in its CI.  Adding the ENV control allows it to only run the two `TestRelineAsReadline` classes.

Note that when `ENV["TestReadlineOrReline"]` is undefined, the behavior is unchanged, and hence, it has no effect on CI here.