### PR TITLE
Update .prime? to use Miller-Rabin deterministically [Feature #16468]

### DIFF
--- a/test/test_prime.rb
+++ b/test/test_prime.rb
@@ -36,6 +36,10 @@ class TestPrime < Test::Unit::TestCase
     assert_equal PRIMES, primes
   end
 
+  def test_count_primes
+    assert_equal 1229, (1..10_000).count {|x| x.prime? }
+  end
+
   def test_each_by_prime_number_theorem
     3.upto(15) do |i|
       max = 2**i
@@ -220,6 +224,10 @@ class TestPrime < Test::Unit::TestCase
       assert_equal(-PRIMES.inject(&:*), Integer.from_prime_division([[-1, 1]] + PRIMES.map{|p| [p,1]}))
     end
 
+    def test_prime_bounds_check
+       assert_raise(ArgumentError) { 33170440646798873859619813.prime? }
+    end
+
     def test_prime?
       PRIMES.each do |p|
         assert_predicate(p, :prime?)
@@ -240,9 +248,6 @@ class TestPrime < Test::Unit::TestCase
 
       # large composite
       assert_not_predicate(((2**13-1) * (2**17-1)), :prime?)
-
-      # factorial
-      assert_not_predicate((2...100).inject(&:*), :prime?)
 
       # negative
       assert_not_predicate(-1, :prime?)


### PR DESCRIPTION
Miller-Rabin has been checked to be deterministic for values < 3,317,044,064,679,887,385,961,981 so long as you check values  a =  2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, and 41.

This implementation covers far more values than the existing .prime? code can handle.

See these links for the math details:
    # https://en.wikipedia.org/wiki/Miller%E2%80%93Rabin_primality_test
    # https://arxiv.org/pdf/1509.00864.pdf