### PR TITLE
[Feature #14240] warn special variables

### DIFF
--- a/io.c
+++ b/io.c
@@ -13288,8 +13288,8 @@ Init_IO(void)
     rb_gc_register_mark_object(rb_default_rs);
     rb_rs = rb_default_rs;
     rb_output_rs = Qnil;
-    rb_define_hooked_variable("$/", &rb_rs, 0, rb_str_setter);
-    rb_define_hooked_variable("$-0", &rb_rs, 0, rb_str_setter);
+    rb_define_hooked_variable("$/", &rb_rs, 0, deprecated_str_setter);
+    rb_define_hooked_variable("$-0", &rb_rs, 0, deprecated_str_setter);
     rb_define_hooked_variable("$\\", &rb_output_rs, 0, deprecated_str_setter);
 
     rb_define_virtual_variable("$_", get_LAST_READ_LINE, set_LAST_READ_LINE);

--- a/io.c
+++ b/io.c
@@ -7570,11 +7570,11 @@ rb_f_printf(int argc, VALUE *argv, VALUE _)
 }
 
 static void
-rb_output_fs_setter(VALUE val, ID id, VALUE *var)
+deprecated_str_setter(VALUE val, ID id, VALUE *var)
 {
     rb_str_setter(val, id, &val);
     if (!NIL_P(val)) {
-        rb_warn_deprecated("`$,'", NULL);
+        rb_warn_deprecated("`%s'", NULL, rb_id2name(id));
     }
     *var = val;
 }
@@ -13282,7 +13282,7 @@ Init_IO(void)
     rb_define_method(rb_cIO, "initialize", rb_io_initialize, -1);
 
     rb_output_fs = Qnil;
-    rb_define_hooked_variable("$,", &rb_output_fs, 0, rb_output_fs_setter);
+    rb_define_hooked_variable("$,", &rb_output_fs, 0, deprecated_str_setter);
 
     rb_default_rs = rb_fstring_lit("\n"); /* avoid modifying RS_default */
     rb_gc_register_mark_object(rb_default_rs);
@@ -13290,7 +13290,7 @@ Init_IO(void)
     rb_output_rs = Qnil;
     rb_define_hooked_variable("$/", &rb_rs, 0, rb_str_setter);
     rb_define_hooked_variable("$-0", &rb_rs, 0, rb_str_setter);
-    rb_define_hooked_variable("$\\", &rb_output_rs, 0, rb_str_setter);
+    rb_define_hooked_variable("$\\", &rb_output_rs, 0, deprecated_str_setter);
 
     rb_define_virtual_variable("$_", get_LAST_READ_LINE, set_LAST_READ_LINE);
 

--- a/io.c
+++ b/io.c
@@ -7615,6 +7615,9 @@ rb_io_print(int argc, const VALUE *argv, VALUE out)
 	line = rb_lastline_get();
 	argv = &line;
     }
+    if (argc > 1 && !NIL_P(rb_output_fs)) {
+        rb_warn("$, is set to non-nil value");
+    }
     for (i=0; i<argc; i++) {
 	if (!NIL_P(rb_output_fs) && i>0) {
 	    rb_io_write(out, rb_output_fs);

--- a/spec/ruby/core/io/print_spec.rb
+++ b/spec/ruby/core/io/print_spec.rb
@@ -4,12 +4,12 @@ require_relative 'fixtures/classes'
 describe IO, "#print" do
   before :each do
     @old_separator = $\
-    $\ = '->'
+    suppress_warning {$\ = '->'}
     @name = tmp("io_print")
   end
 
   after :each do
-    $\ = @old_separator
+    suppress_warning {$\ = @old_separator}
     rm_r @name
   end
 

--- a/spec/ruby/core/io/puts_spec.rb
+++ b/spec/ruby/core/io/puts_spec.rb
@@ -16,7 +16,7 @@ describe "IO#puts" do
     ScratchPad.clear
     @io.close if @io
     rm_r @name
-    $/ = @before_separator
+    suppress_warning {$/ = @before_separator}
   end
 
   it "writes just a newline when given no args" do
@@ -105,7 +105,7 @@ describe "IO#puts" do
   end
 
   it "ignores the $/ separator global" do
-    $/ = ":"
+    suppress_warning {$/ = ":"}
     @io.puts(5).should == nil
     ScratchPad.recorded.should == "5\n"
   end

--- a/spec/ruby/core/io/readlines_spec.rb
+++ b/spec/ruby/core/io/readlines_spec.rb
@@ -22,11 +22,11 @@ describe "IO#readlines" do
 
   describe "when passed no arguments" do
     before :each do
-      @sep, $/ = $/, " "
+      suppress_warning {@sep, $/ = $/, " "}
     end
 
     after :each do
-      $/ = @sep
+      suppress_warning {$/ = @sep}
     end
 
     it "returns an Array containing lines based on $/" do
@@ -184,7 +184,7 @@ describe "IO.readlines" do
   after :each do
     Encoding.default_external = @external
     Encoding.default_internal = @internal
-    $/ = @dollar_slash
+    suppress_warning {$/ = @dollar_slash}
   end
 
   it "encodes lines using the default external encoding" do
@@ -196,7 +196,7 @@ describe "IO.readlines" do
   it "encodes lines using the default internal encoding, when set" do
     Encoding.default_external = Encoding::UTF_8
     Encoding.default_internal = Encoding::UTF_16
-    $/ = $/.encode Encoding::UTF_16
+    suppress_warning {$/ = $/.encode Encoding::UTF_16}
     lines = IO.readlines(@name)
     lines.all? { |s| s.encoding == Encoding::UTF_16 }.should be_true
   end

--- a/spec/ruby/core/io/shared/each.rb
+++ b/spec/ruby/core/io/shared/each.rb
@@ -168,12 +168,12 @@ describe :io_each_default_separator, shared: true do
   before :each do
     @io = IOSpecs.io_fixture "lines.txt"
     ScratchPad.record []
-    @sep, $/ = $/, " "
+    suppress_warning {@sep, $/ = $/, " "}
   end
 
   after :each do
     @io.close if @io
-    $/ = @sep
+    suppress_warning {$/ = @sep}
   end
 
   it "uses $/ as the default line separator" do

--- a/spec/ruby/core/io/shared/readlines.rb
+++ b/spec/ruby/core/io/shared/readlines.rb
@@ -60,11 +60,11 @@ describe :io_readlines_options_19, shared: true do
       end
 
       after :each do
-        $/ = @sep
+        suppress_warning {$/ = @sep}
       end
 
       it "defaults to $/ as the separator" do
-        $/ = " "
+        suppress_warning {$/ = " "}
         result = IO.send(@method, @name, 10, &@object)
         (result ? result : ScratchPad.recorded).should == IOSpecs.lines_space_separator_limit
       end

--- a/spec/ruby/core/kernel/fixtures/classes.rb
+++ b/spec/ruby/core/kernel/fixtures/classes.rb
@@ -49,7 +49,7 @@ module KernelSpecs
 
   def self.chomp(str, method, sep="\n")
     code = "$_ = #{str.inspect}; $/ = #{sep.inspect}; #{method}; print $_"
-    IO.popen([*ruby_exe, "-n", "-e", code], "r+") do |io|
+    IO.popen([*ruby_exe, "-W0", "-n", "-e", code], "r+") do |io|
       io.puts
       io.close_write
       io.read

--- a/spec/ruby/core/kernel/p_spec.rb
+++ b/spec/ruby/core/kernel/p_spec.rb
@@ -57,10 +57,14 @@ describe "Kernel#p" do
     }
     -> { p(o) }.should output_to_fd("Next time, Gadget, NEXT TIME!\n")
 
-    $\ = " *helicopter sound*\n"
+    suppress_warning {
+      $\ = " *helicopter sound*\n"
+    }
     -> { p(o) }.should output_to_fd("Next time, Gadget, NEXT TIME!\n")
 
-    $/ = " *helicopter sound*\n"
+    suppress_warning {
+      $/ = " *helicopter sound*\n"
+    }
     -> { p(o) }.should output_to_fd("Next time, Gadget, NEXT TIME!\n")
   end
 

--- a/spec/ruby/core/kernel/warn_spec.rb
+++ b/spec/ruby/core/kernel/warn_spec.rb
@@ -8,8 +8,9 @@ describe "Kernel#warn" do
   end
 
   after :each do
-    $VERBOSE = @before_verbose
+    $VERBOSE = nil
     $/ = @before_separator
+    $VERBOSE = @before_verbose
   end
 
   it "is a private method" do

--- a/spec/ruby/core/string/chomp_spec.rb
+++ b/spec/ruby/core/string/chomp_spec.rb
@@ -6,11 +6,13 @@ describe "String#chomp" do
   describe "when passed no argument" do
     before do
       # Ensure that $/ is set to the default value
+      @verbose, $VERBOSE = $VERBOSE, nil
       @dollar_slash, $/ = $/, "\n"
     end
 
     after do
       $/ = @dollar_slash
+      $VERBOSE = @verbose
     end
 
     it "does not modify a String with no trailing carriage return or newline" do
@@ -179,11 +181,13 @@ describe "String#chomp!" do
   describe "when passed no argument" do
     before do
       # Ensure that $/ is set to the default value
+      @verbose, $VERBOSE = $VERBOSE, nil
       @dollar_slash, $/ = $/, "\n"
     end
 
     after do
       $/ = @dollar_slash
+      $VERBOSE = @verbose
     end
 
     it "modifies self" do
@@ -350,11 +354,13 @@ end
 
 describe "String#chomp" do
   before :each do
+    @verbose, $VERBOSE = $VERBOSE, nil
     @before_separator = $/
   end
 
   after :each do
     $/ = @before_separator
+    $VERBOSE = @verbose
   end
 
   it "does not modify a multi-byte character" do
@@ -379,11 +385,13 @@ end
 
 describe "String#chomp!" do
   before :each do
+    @verbose, $VERBOSE = $VERBOSE, nil
     @before_separator = $/
   end
 
   after :each do
     $/ = @before_separator
+    $VERBOSE = @verbose
   end
 
   it "returns nil when the String is not modified" do

--- a/spec/ruby/core/string/shared/each_line.rb
+++ b/spec/ruby/core/string/shared/each_line.rb
@@ -84,7 +84,7 @@ describe :string_each_line, shared: true do
     end
 
     after :each do
-      $/ = @before_separator
+      suppress_warning {$/ = @before_separator}
     end
 
     it "as the separator when none is given" do
@@ -96,10 +96,10 @@ describe :string_each_line, shared: true do
           expected = []
           str.send(@method, sep) { |x| expected << x }
 
-          $/ = sep
+          suppress_warning {$/ = sep}
 
           actual = []
-          str.send(@method) { |x| actual << x }
+          suppress_warning {str.send(@method) { |x| actual << x }}
 
           actual.should == expected
         end

--- a/spec/ruby/language/predefined_spec.rb
+++ b/spec/ruby/language/predefined_spec.rb
@@ -541,6 +541,7 @@ $stdout          IO              The current standard output. Assignment to $std
 
 describe "Predefined global $/" do
   before :each do
+    @verbose, $VERBOSE = $VERBOSE, nil
     @dollar_slash = $/
     @dollar_dash_zero = $-0
   end
@@ -548,6 +549,7 @@ describe "Predefined global $/" do
   after :each do
     $/ = @dollar_slash
     $-0 = @dollar_dash_zero
+    $VERBOSE = @verbose
   end
 
   it "can be assigned a String" do
@@ -589,6 +591,7 @@ end
 
 describe "Predefined global $-0" do
   before :each do
+    @verbose, $VERBOSE = $VERBOSE, nil
     @dollar_slash = $/
     @dollar_dash_zero = $-0
   end
@@ -596,6 +599,7 @@ describe "Predefined global $-0" do
   after :each do
     $/ = @dollar_slash
     $-0 = @dollar_dash_zero
+    $VERBOSE = @verbose
   end
 
   it "can be assigned a String" do

--- a/spec/ruby/library/English/English_spec.rb
+++ b/spec/ruby/library/English/English_spec.rb
@@ -67,18 +67,18 @@ describe "English" do
 
   it "aliases $ORS to $\\" do
     original = $\
-    $\ = "\t"
+    suppress_warning {$\ = "\t"}
     $ORS.should_not be_nil
     $ORS.should == $\
-    $\ = original
+    suppress_warning {$\ = original}
   end
 
   it "aliases $OUTPUT_RECORD_SEPARATOR to $\\" do
     original = $\
-    $\ = "\t"
+    suppress_warning {$\ = "\t"}
     $OUTPUT_RECORD_SEPARATOR.should_not be_nil
     $OUTPUT_RECORD_SEPARATOR.should == $\
-    $\ = original
+    suppress_warning {$\ = original}
   end
 
   it "aliases $INPUT_LINE_NUMBER to $." do

--- a/spec/ruby/library/stringio/gets_spec.rb
+++ b/spec/ruby/library/stringio/gets_spec.rb
@@ -76,12 +76,13 @@ describe "StringIO#gets when passed no argument" do
     @io.gets.should == "this is\n"
 
     begin
-      old_sep, $/ = $/, " "
+      old_sep = $/
+      suppress_warning {$/ = " "}
       @io.gets.should == "an "
       @io.gets.should == "example\nfor "
       @io.gets.should == "StringIO#gets"
     ensure
-      $/ = old_sep
+      suppress_warning {$/ = old_sep}
     end
   end
 

--- a/spec/ruby/library/stringio/print_spec.rb
+++ b/spec/ruby/library/stringio/print_spec.rb
@@ -39,13 +39,14 @@ describe "StringIO#print" do
   end
 
   it "honors the output record separator global" do
-    old_rs, $\ = $\, 'x'
+    old_rs = $\
+    suppress_warning {$\ = 'x'}
 
     begin
       @io.print(5, 6, 7, 8)
       @io.string.should == '5678xle'
     ensure
-      $\ = old_rs
+      suppress_warning {$\ = old_rs}
     end
   end
 
@@ -58,13 +59,14 @@ describe "StringIO#print" do
   end
 
   it "correctly updates the current position when honoring the output record separator global" do
-    old_rs, $\ = $\, 'x'
+    old_rs = $\
+    suppress_warning {$\ = 'x'}
 
     begin
       @io.print(5, 6, 7, 8)
       @io.pos.should eql(5)
     ensure
-      $\ = old_rs
+      suppress_warning {$\ = old_rs}
     end
   end
 end

--- a/spec/ruby/library/stringio/puts_spec.rb
+++ b/spec/ruby/library/stringio/puts_spec.rb
@@ -30,11 +30,12 @@ describe "StringIO#puts when passed an Array" do
 
   it "does not honor the global output record separator $\\" do
     begin
-      old_rs, $\ = $\, "test"
+      old_rs = $\
+      suppress_warning {$\ = "test"}
       @io.puts([1, 2, 3, 4])
       @io.string.should == "1\n2\n3\n4\n"
     ensure
-      $\ = old_rs
+      suppress_warning {$\ = old_rs}
     end
   end
 
@@ -68,11 +69,12 @@ describe "StringIO#puts when passed 1 or more objects" do
 
   it "does not honor the global output record separator $\\" do
     begin
-      old_rs, $\ = $\, "test"
+      old_rs = $\
+      suppress_warning {$\ = "test"}
       @io.puts(1, 2, 3, 4)
       @io.string.should == "1\n2\n3\n4\n"
     ensure
-      $\ = old_rs
+      suppress_warning {$\ = old_rs}
     end
   end
 
@@ -117,11 +119,12 @@ describe "StringIO#puts when passed no arguments" do
 
   it "does not honor the global output record separator $\\" do
     begin
-      old_rs, $\ = $\, "test"
+      old_rs = $\
+      suppress_warning {$\ = "test"}
       @io.puts
       @io.string.should == "\n"
     ensure
-      $\ = old_rs
+      suppress_warning {$\ = old_rs}
     end
   end
 end

--- a/spec/ruby/library/stringio/readline_spec.rb
+++ b/spec/ruby/library/stringio/readline_spec.rb
@@ -64,12 +64,13 @@ describe "StringIO#readline when passed no argument" do
     @io.readline.should == "this is\n"
 
     begin
-      old_sep, $/ = $/, " "
+      old_sep = $/
+      suppress_warning {$/ = " "}
       @io.readline.should == "an "
       @io.readline.should == "example\nfor "
       @io.readline.should == "StringIO#readline"
     ensure
-      $/ = old_sep
+      suppress_warning {$/ = old_sep}
     end
   end
 

--- a/spec/ruby/library/stringio/readlines_spec.rb
+++ b/spec/ruby/library/stringio/readlines_spec.rb
@@ -51,10 +51,11 @@ describe "StringIO#readlines when passed no argument" do
 
   it "returns an Array containing lines based on $/" do
     begin
-      old_sep, $/ = $/, " "
+      old_sep = $/;
+      suppress_warning {$/ = " "}
       @io.readlines.should == ["this ", "is\nan ", "example\nfor ", "StringIO#readlines"]
     ensure
-      $/ = old_sep
+      suppress_warning {$/ = old_sep}
     end
   end
 

--- a/spec/ruby/library/stringio/shared/each.rb
+++ b/spec/ruby/library/stringio/shared/each.rb
@@ -71,11 +71,12 @@ describe :stringio_each_no_arguments, shared: true do
   it "uses $/ as the default line separator" do
     seen = []
     begin
-      old_rs, $/ = $/, " "
+      old_rs = $/
+      suppress_warning {$/ = " "}
       @io.send(@method) {|s| seen << s }
       seen.should eql(["a ", "b ", "c ", "d ", "e\n1 ", "2 ", "3 ", "4 ", "5"])
     ensure
-      $/ = old_rs
+      suppress_warning {$/ = old_rs}
     end
   end
 

--- a/spec/ruby/optional/capi/globals_spec.rb
+++ b/spec/ruby/optional/capi/globals_spec.rb
@@ -59,7 +59,7 @@ describe "CApiGlobalSpecs" do
     end
 
     after :each do
-      $/ = @dollar_slash
+      suppress_warning {$/ = @dollar_slash}
     end
 
     it "returns \\n by default" do
@@ -67,7 +67,7 @@ describe "CApiGlobalSpecs" do
     end
 
     it "returns the value of $/" do
-      $/ = "foo"
+      suppress_warning {$/ = "foo"}
       @f.rb_rs.should == "foo"
     end
   end

--- a/spec/ruby/optional/capi/globals_spec.rb
+++ b/spec/ruby/optional/capi/globals_spec.rb
@@ -140,7 +140,7 @@ describe "CApiGlobalSpecs" do
     end
 
     after :each do
-      $\ = @dollar_backslash
+      suppress_warning {$\ = @dollar_backslash}
     end
 
     it "returns nil by default" do
@@ -148,7 +148,7 @@ describe "CApiGlobalSpecs" do
     end
 
     it "returns the value of $\\" do
-      $\ = "foo"
+      suppress_warning {$\ = "foo"}
       @f.rb_output_rs.should == "foo"
     end
   end

--- a/string.c
+++ b/string.c
@@ -8246,6 +8246,21 @@ chomp_newline(const char *p, const char *e, rb_encoding *enc)
 }
 
 static VALUE
+get_rs(void)
+{
+    VALUE rs = rb_rs;
+    if (!NIL_P(rs) &&
+	(!RB_TYPE_P(rs, T_STRING) ||
+	 RSTRING_LEN(rs) != 1 ||
+	 RSTRING_PTR(rs)[0] != '\n')) {
+        rb_warn("$/ is set to non-default value");
+    }
+    return rs;
+}
+
+#define rb_rs get_rs()
+
+static VALUE
 rb_str_enumerate_lines(int argc, VALUE *argv, VALUE str, VALUE ary)
 {
     rb_encoding *enc;

--- a/test/openssl/test_pair.rb
+++ b/test/openssl/test_pair.rb
@@ -160,10 +160,10 @@ module OpenSSL::TestPairM
     ssl_pair {|s1, s2|
       begin
         old = $/
-        $/ = '*'
+        EnvUtil.suppress_warning {$/ = '*'}
         s1.puts 'a'
       ensure
-        $/ = old
+        EnvUtil.suppress_warning {$/ = old}
       end
       s1.close
       assert_equal("a\n", s2.read)

--- a/test/ruby/test_io.rb
+++ b/test/ruby/test_io.rb
@@ -2572,7 +2572,7 @@ class TestIO < Test::Unit::TestCase
     $\ = "\n"
     pipe(proc do |w|
       w.print('a')
-      w.print('a','b','c')
+      EnvUtil.suppress_warning {w.print('a','b','c')}
       w.close
     end, proc do |r|
       assert_equal("a\n", r.gets)

--- a/test/ruby/test_io.rb
+++ b/test/ruby/test_io.rb
@@ -2568,8 +2568,10 @@ class TestIO < Test::Unit::TestCase
   end
 
   def test_print_separators
-    EnvUtil.suppress_warning {$, = ':'}
-    $\ = "\n"
+    EnvUtil.suppress_warning {
+      $, = ':'
+      $\ = "\n"
+    }
     pipe(proc do |w|
       w.print('a')
       EnvUtil.suppress_warning {w.print('a','b','c')}

--- a/test/ruby/test_string.rb
+++ b/test/ruby/test_string.rb
@@ -387,6 +387,8 @@ CODE
   end
 
   def test_chomp
+    verbose, $VERBOSE = $VERBOSE, nil
+
     assert_equal(S("hello"), S("hello").chomp("\n"))
     assert_equal(S("hello"), S("hello\n").chomp("\n"))
     save = $/
@@ -452,9 +454,12 @@ CODE
     assert_equal("foo", s.chomp("\n"))
   ensure
     $/ = save
+    $VERBOSE = verbose
   end
 
   def test_chomp!
+    verbose, $VERBOSE = $VERBOSE, nil
+
     a = S("hello")
     a.chomp!(S("\n"))
 
@@ -511,6 +516,7 @@ CODE
 
     s = S("").freeze
     assert_raise_with_message(FrozenError, /frozen/) {s.chomp!}
+    $VERBOSE = nil # EnvUtil.suppress_warning resets $VERBOSE to the original state
 
     s = S("ax")
     o = Struct.new(:s).new(s)
@@ -519,6 +525,7 @@ CODE
       "x"
     end
     assert_raise_with_message(FrozenError, /frozen/) {s.chomp!(o)}
+    $VERBOSE = nil # EnvUtil.suppress_warning resets $VERBOSE to the original state
 
     s = S("hello")
     assert_equal("hel", s.chomp!('lo'))
@@ -569,6 +576,7 @@ CODE
     assert_equal("foo", s.chomp!("\n"))
   ensure
     $/ = save
+    $VERBOSE = verbose
   end
 
   def test_chop
@@ -859,6 +867,8 @@ CODE
   end
 
   def test_each
+    verbose, $VERBOSE = $VERBOSE, nil
+
     save = $/
     $/ = "\n"
     res=[]
@@ -878,6 +888,7 @@ CODE
     assert_equal(S("world"),  res[1])
   ensure
     $/ = save
+    $VERBOSE = verbose
   end
 
   def test_each_byte
@@ -1055,6 +1066,8 @@ CODE
   end
 
   def test_each_line
+    verbose, $VERBOSE = $VERBOSE, nil
+
     save = $/
     $/ = "\n"
     res=[]
@@ -1101,6 +1114,7 @@ CODE
     end
   ensure
     $/ = save
+    $VERBOSE = verbose
   end
 
   def test_each_line_chomp


### PR DESCRIPTION
[[Feature #14240]](https://bugs.ruby-lang.org/issues/14240): warn four special variables: `$;` `$,` `$/` `$\`