### PR TITLE
Fix wrong documentation for return value of Pathname#fnmatch

### DIFF
--- a/ext/pathname/pathname.c
+++ b/ext/pathname/pathname.c
@@ -610,8 +610,8 @@ path_lchown(VALUE self, VALUE owner, VALUE group)
 
 /*
  * call-seq:
- *    pathname.fnmatch(pattern, [flags])        -> string
- *    pathname.fnmatch?(pattern, [flags])       -> string
+ *    pathname.fnmatch(pattern, [flags])        -> true or false
+ *    pathname.fnmatch?(pattern, [flags])       -> true or false
  *
  * Return +true+ if the receiver matches the given pattern.
  *


### PR DESCRIPTION
The document says it returns a string, but actually it returns true or false.

```bash
$ ruby -rpathname -e 'p Pathname("foo.rb").fnmatch("*.rb")'
true
```