### PR TITLE
Fix rbinstall bugs

### DIFF
--- a/tool/rbinstall.rb
+++ b/tool/rbinstall.rb
@@ -819,7 +819,8 @@ end
 
 def install_default_gem(dir, srcdir)
   gem_dir = Gem.default_dir
-  directories = Gem.ensure_gem_subdirectories(gem_dir, $dir_mode)
+  install_dir = with_destdir(gem_dir)
+  directories = Gem.ensure_gem_subdirectories(install_dir, $dir_mode)
   prepare "default gems from #{dir}", gem_dir, directories
 
   spec_dir = File.join(gem_dir, directories.grep(/^spec/)[0])
@@ -866,9 +867,9 @@ end
 
 install?(:ext, :comm, :gem, :'bundled-gems') do
   gem_dir = Gem.default_dir
-  directories = Gem.ensure_gem_subdirectories(gem_dir, $dir_mode)
-  prepare "bundled gems", gem_dir, directories
   install_dir = with_destdir(gem_dir)
+  directories = Gem.ensure_gem_subdirectories(install_dir, $dir_mode)
+  prepare "bundled gems", gem_dir, directories
   installed_gems = {}
   options = {
     :install_dir => install_dir,

--- a/tool/rbinstall.rb
+++ b/tool/rbinstall.rb
@@ -821,10 +821,9 @@ def install_default_gem(dir, srcdir)
   gem_dir = Gem.default_dir
   install_dir = with_destdir(gem_dir)
   directories = Gem.ensure_default_gem_subdirectories(install_dir, $dir_mode)
-  prepare "default gems from #{dir}", gem_dir, directories
+  prepare "default gems from #{dir}", gem_dir
 
   default_spec_dir = File.join(gem_dir, directories.grep(/^spec/)[0])
-  makedirs(default_spec_dir)
 
   gems = Dir.glob("#{srcdir}/#{dir}/**/*.gemspec").map {|src|
     spec = load_gemspec(src)
@@ -867,8 +866,8 @@ end
 install?(:ext, :comm, :gem, :'bundled-gems') do
   gem_dir = Gem.default_dir
   install_dir = with_destdir(gem_dir)
-  directories = Gem.ensure_gem_subdirectories(install_dir, $dir_mode)
-  prepare "bundled gems", gem_dir, directories
+  Gem.ensure_gem_subdirectories(install_dir, $dir_mode)
+  prepare "bundled gems", gem_dir
   installed_gems = {}
   options = {
     :install_dir => install_dir,

--- a/tool/rbinstall.rb
+++ b/tool/rbinstall.rb
@@ -820,11 +820,10 @@ end
 def install_default_gem(dir, srcdir)
   gem_dir = Gem.default_dir
   install_dir = with_destdir(gem_dir)
-  directories = Gem.ensure_gem_subdirectories(install_dir, $dir_mode)
+  directories = Gem.ensure_default_gem_subdirectories(install_dir, $dir_mode)
   prepare "default gems from #{dir}", gem_dir, directories
 
-  spec_dir = File.join(gem_dir, directories.grep(/^spec/)[0])
-  default_spec_dir = "#{spec_dir}/default"
+  default_spec_dir = File.join(gem_dir, directories.grep(/^spec/)[0])
   makedirs(default_spec_dir)
 
   gems = Dir.glob("#{srcdir}/#{dir}/**/*.gemspec").map {|src|

--- a/tool/rbinstall.rb
+++ b/tool/rbinstall.rb
@@ -819,7 +819,7 @@ end
 
 def install_default_gem(dir, srcdir)
   gem_dir = Gem.default_dir
-  directories = Gem.ensure_gem_subdirectories(gem_dir, :mode => $dir_mode)
+  directories = Gem.ensure_gem_subdirectories(gem_dir, $dir_mode)
   prepare "default gems from #{dir}", gem_dir, directories
 
   spec_dir = File.join(gem_dir, directories.grep(/^spec/)[0])
@@ -866,7 +866,7 @@ end
 
 install?(:ext, :comm, :gem, :'bundled-gems') do
   gem_dir = Gem.default_dir
-  directories = Gem.ensure_gem_subdirectories(gem_dir, :mode => $dir_mode)
+  directories = Gem.ensure_gem_subdirectories(gem_dir, $dir_mode)
   prepare "bundled gems", gem_dir, directories
   install_dir = with_destdir(gem_dir)
   installed_gems = {}

--- a/tool/rbinstall.rb
+++ b/tool/rbinstall.rb
@@ -820,10 +820,10 @@ end
 def install_default_gem(dir, srcdir)
   gem_dir = Gem.default_dir
   install_dir = with_destdir(gem_dir)
-  directories = Gem.ensure_default_gem_subdirectories(install_dir, $dir_mode)
+  Gem.ensure_default_gem_subdirectories(install_dir, $dir_mode)
   prepare "default gems from #{dir}", gem_dir
 
-  default_spec_dir = File.join(gem_dir, directories.grep(/^spec/)[0])
+  default_spec_dir = Gem.default_specifications_dir
 
   gems = Dir.glob("#{srcdir}/#{dir}/**/*.gemspec").map {|src|
     spec = load_gemspec(src)


### PR DESCRIPTION
I noticed a couple of bugs in `rbinstall.rb`, so I fixed them:

* [ ] `Gem.ensure_gem_subdirectories` does not take keyword args. The error was being swallowed, but [I'm fixing that in rubygems](https://github.com/rubygems/rubygems/pull/3156). This bugfix allows to simplify some code.

* [x] One regexp was missing a `\` escape character. Merged through #2933. 
