### PR TITLE
Introduce skip_header in Logger.new

### DIFF
--- a/lib/logger.rb
+++ b/lib/logger.rb
@@ -368,6 +368,8 @@ class Logger
   #   Date and time format. Default value is '%Y-%m-%d %H:%M:%S'.
   # +binmode+::
   #   Use binary mode on the log device. Default value is false.
+  # +skip_header+::
+  #   Skip header line in logfile created by the log device. Default value is false.
   # +shift_period_suffix+::
   #   The log file suffix format for +daily+, +weekly+ or +monthly+ rotation.
   #   Default is '%Y%m%d'.
@@ -378,7 +380,7 @@ class Logger
   #
   def initialize(logdev, shift_age = 0, shift_size = 1048576, level: DEBUG,
                  progname: nil, formatter: nil, datetime_format: nil,
-                 binmode: false, shift_period_suffix: '%Y%m%d')
+                 binmode: false, shift_period_suffix: '%Y%m%d', skip_header: false)
     self.level = level
     self.progname = progname
     @default_formatter = Formatter.new
@@ -389,7 +391,7 @@ class Logger
       @logdev = LogDevice.new(logdev, shift_age: shift_age,
         shift_size: shift_size,
         shift_period_suffix: shift_period_suffix,
-        binmode: binmode)
+        binmode: binmode, skip_header: skip_header)
     end
   end
 

--- a/lib/logger/log_device.rb
+++ b/lib/logger/log_device.rb
@@ -11,9 +11,10 @@ class Logger
     attr_reader :filename
     include MonitorMixin
 
-    def initialize(log = nil, shift_age: nil, shift_size: nil, shift_period_suffix: nil, binmode: false)
+    def initialize(log = nil, shift_age: nil, shift_size: nil, shift_period_suffix: nil, binmode: false, skip_header: false)
       @dev = @filename = @shift_age = @shift_size = @shift_period_suffix = nil
       @binmode = binmode
+      @skip_header = skip_header
       mon_initialize
       set_dev(log)
       if @filename
@@ -117,7 +118,7 @@ class Logger
     def add_log_header(file)
       file.write(
         "# Logfile created on %s by %s\n" % [Time.now.to_s, Logger::ProgName]
-      ) if file.size == 0
+      ) if file.size == 0 && !@skip_header
     end
 
     def check_shift_log


### PR DESCRIPTION
When `Logger.new('foo.log')` creates the file, the header line has added by Logger like below.

```
# Logfile created on 2020-02-27 01:24:03 +0000 by logger.rb/v1.4.2
```

When I don't want to add header, the only way is to override the inner method of LogDevice.
This solution is from [stackoverflow](https://stackoverflow.com/questions/4096336/can-i-disable-the-log-header-for-ruby-logger) in 10 years ago.

```ruby
class Logger::LogDevice
  def add_log_header(file)
  end
end

log1 = Logger.new('info1.log')
```

I introduce `skip_header` param in `Logger.new`. Default value is `false`.

```ruby
logger = Logger.new('foo.log', skip_header: true)
```