### PR TITLE
respect --test-order=random

### DIFF
--- a/tool/lib/minitest/unit.rb
+++ b/tool/lib/minitest/unit.rb
@@ -1387,11 +1387,16 @@ module MiniTest
       end
 
       def self.test_order # :nodoc:
-        :random
+        :sorted
       end
 
       def self.test_suites # :nodoc:
-        @@test_suites.keys.sort_by { |ts| ts.name.to_s }
+        case self.test_order
+        when :random
+          @@test_suites.keys.shuffle
+        else
+          @@test_suites.keys.sort_by { |ts| ts.name.to_s }
+        end
       end
 
       def self.test_methods # :nodoc:

--- a/tool/lib/test/unit.rb
+++ b/tool/lib/test/unit.rb
@@ -474,6 +474,14 @@ module Test
         # Require needed thing for parallel running
         require 'timeout'
         @tasks = @files.dup # Array of filenames.
+
+        case MiniTest::Unit::TestCase.test_order
+        when :random
+          @tasks.shuffle!
+        else
+          # sorted
+        end
+
         @need_quit = false
         @dead_workers = []  # Array of dead workers.
         @warnings = []

--- a/tool/lib/test/unit/testcase.rb
+++ b/tool/lib/test/unit/testcase.rb
@@ -18,10 +18,6 @@ module Test
         super runner
       end
 
-      def self.test_order
-        :sorted
-      end
-
       def self.method_added(name)
         super
         return unless name.to_s.start_with?("test_")


### PR DESCRIPTION
Now --test-order=random is simply ignored. This patch respect
this option.