### PR TITLE
Make Module#include affect the iclasses of the module

### DIFF
--- a/test/ruby/test_module.rb
+++ b/test/ruby/test_module.rb
@@ -473,6 +473,57 @@ class TestModule < Test::Unit::TestCase
     assert_raise(ArgumentError) { Module.new { include } }
   end
 
+  def test_include_into_module_already_included
+    c = Class.new{def foo; [:c] end}
+    modules = lambda do ||
+      sub = Class.new(c){def foo; [:sc] + super end}
+      [
+        Module.new{def foo; [:m1] + super end},
+        Module.new{def foo; [:m2] + super end},
+        Module.new{def foo; [:m3] + super end},
+        sub,
+        sub.new
+      ]
+    end
+
+    m1, m2, m3, sc, o = modules.call
+    assert_equal([:sc, :c], o.foo)
+    sc.include m1
+    assert_equal([:sc, :m1, :c], o.foo)
+    m1.include m2
+    assert_equal([:sc, :m1, :m2, :c], o.foo)
+    m2.include m3
+    assert_equal([:sc, :m1, :m2, :m3, :c], o.foo)
+
+    m1, m2, m3, sc, o = modules.call
+    sc.prepend m1
+    assert_equal([:m1, :sc, :c], o.foo)
+    m1.include m2
+    assert_equal([:m1, :m2, :sc, :c], o.foo)
+    m2.include m3
+    assert_equal([:m1, :m2, :m3, :sc, :c], o.foo)
+
+    m1, m2, m3, sc, o = modules.call
+    sc.include m2
+    assert_equal([:sc, :m2, :c], o.foo)
+    sc.prepend m1
+    assert_equal([:m1, :sc, :m2, :c], o.foo)
+    m1.include m2
+    assert_equal([:m1, :sc, :m2, :c], o.foo)
+    m1.include m3
+    assert_equal([:m1, :m3, :sc, :m2, :c], o.foo)
+
+    m1, m2, m3, sc, o = modules.call
+    sc.include m3
+    sc.include m2
+    assert_equal([:sc, :m2, :m3, :c], o.foo)
+    sc.prepend m1
+    assert_equal([:m1, :sc, :m2, :m3, :c], o.foo)
+    m1.include m2
+    m1.include m3
+    assert_equal([:m1, :sc, :m2, :m3, :c], o.foo)
+  end
+
   def test_included_modules
     assert_equal([], Mixin.included_modules)
     assert_equal([Mixin], User.included_modules)


### PR DESCRIPTION
When calling Module#include, if the receiver is a module,
walk the subclasses list and include the argument module in each
iclass.

This does not affect Module#prepend, as fixing that is significantly
more involved.

Fixes [Bug #9573]