### PR TITLE
Allow Struct subclass to take kwargs in initialize

### DIFF
--- a/struct.c
+++ b/struct.c
@@ -326,9 +326,7 @@ static VALUE
 setup_struct(VALUE nstr, VALUE members, int keyword_init)
 {
     long i, len;
-    VALUE (*new_func)(int, const VALUE *, VALUE) = rb_class_new_instance;
-
-    if (keyword_init) new_func = struct_new_kw;
+    VALUE (*new_func)(int, const VALUE *, VALUE) = struct_new_kw;
 
     members = struct_set_members(nstr, members);
 

--- a/test/ruby/test_struct.rb
+++ b/test/ruby/test_struct.rb
@@ -117,9 +117,6 @@ module TestStruct
     assert_equal @Struct::KeywordInitTrue.new(a: 1, b: 2).values, @Struct::KeywordInitFalse.new(1, 2).values
     assert_equal "#{@Struct}::KeywordInitFalse", @Struct::KeywordInitFalse.inspect
     assert_equal "#{@Struct}::KeywordInitTrue(keyword_init: true)", @Struct::KeywordInitTrue.inspect
-    # eval is needed to prevent the warning duplication filter
-    k = eval("Class.new(@Struct::KeywordInitFalse) {def initialize(**) end}")
-    assert_raise(ArgumentError) { k.new(a: 1, b: 2) }
     k = Class.new(@Struct::KeywordInitTrue) {def initialize(**) end}
     assert_warn('') {k.new(a: 1, b: 2)}
 
@@ -137,6 +134,17 @@ module TestStruct
     end
 
     assert_equal(3, struct.new(a: 1, b: 2).c)
+  end
+
+  def test_struct_subclass_with_keywords
+    struct = @Struct.new(:args, :foo)
+    klass = Class.new(struct) do
+      def initialize(*args, foo:)
+        super(args, foo)
+      end
+    end
+
+    assert_equal("#<struct args=[1], foo=2>", klass.new(1, foo: 2).inspect)
   end
 
   def test_initialize


### PR DESCRIPTION
We were investigating some strange behaviour with keyword arguments and subclasses of Struct.

``` ruby
class Foo < Struct.new(:a)
  def initialize(*args, bar: nil)
    print "Foo: "
    p(args: args, bar: bar)
  end
end

class Bar
  def initialize(*args, bar: nil)
    print "Bar: "
    p(args: args, bar: bar)
  end
end

Foo.new("a", bar: :bar)
Bar.new("a", bar: :bar)
```

```
$ ruby struct_warning.rb
Foo: {:args=>["a", {:bar=>:bar}], :bar=>nil}
Bar: {:args=>["a"], :bar=>:bar}
```

It's surprising to see such different behaviour between an identical `initialize` in a normal class and a subclass of a Struct.

This difference turned out to be that [`Struct`s define their own `new` method](https://github.com/ruby/ruby/blob/431132f037aecc8c9bc783fea257db653c4f8cb0/struct.c#L323-L331). I believe this is to work around `Struct.new` also being custom (because it creates a subclass, not an instance).

To solve this, I believe we can set new to be `rb_class_new_instance_kw` instead of `rb_class_new_instance` and always pass the keyword arguments through to initialize. There was a conditional before, to already do this if the struct was `keyword_init: true`, but I don't think it's necessary and we can always pass the keywords.

There's also a similar problem on Ruby 2.7, where this will emit a kwarg deprecation, so we might want to backport it as well.

This was investigated and written pairing with @hparker and @jacortinas ❤️