### PR TITLE
Check that BASERUBY is at least Ruby 2.2 in configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -34,7 +34,7 @@ AC_ARG_WITH(baseruby,
 	[
 		AC_PATH_PROG([BASERUBY], [ruby], [false])
 	])
-AS_IF([test "$HAVE_BASERUBY" = yes -a "`RUBYOPT=- $BASERUBY --disable=gems -e 'print 42' 2>/dev/null`" = 42], [
+AS_IF([test "$HAVE_BASERUBY" != no -a "`RUBYOPT=- $BASERUBY --disable=gems -e 'print 42 if RUBY_VERSION > "2.2"' 2>/dev/null`" = 42], [
     BASERUBY="$BASERUBY --disable=gems"
     BASERUBY_VERSION=`$BASERUBY -v`
     $BASERUBY -C "$srcdir" tool/downloader.rb -d tool -e gnu config.guess config.sub >&AS_MESSAGE_FD


### PR DESCRIPTION
BASERUBY needs to be at least Ruby 2.2 since
46acd0075d80c2f886498f089fde1e9d795d50c4.

I think it's better to explicitly fail early as soon as BASERUBY
is used in this case, versus trying to debug later failures.

This modifies things to check both implicitly use of ruby in the
PATH as BASERUBY, and explicitly specified older versions of ruby
when using --with-baseruby.

Additionally, since all supported BASERUBY versions support
--disable=gems, always specify that instead of checking for
support.

Remove Ruby <2.2 support from tool/lib/vcs.rb

BASERUBY now requires at least Ruby 2.2, so there is no point
trying to support older ruby versions here.

This should address [Bug #16668]