### PR TITLE
Optimize array pattern checktype

### DIFF
--- a/benchmark/pm_array.yml
+++ b/benchmark/pm_array.yml
@@ -1,0 +1,19 @@
+prelude: |
+  def call(*val)
+    case val
+      in [String => body]
+        [200, {}, [body]]
+      in [Integer => status]
+        [status, {}, [""]]
+      in [Integer, String] => response
+        [response[0], {}, [response[1]]]
+      in [Integer, Hash, String] => response
+        [response[0], response[1], [response[2]]]
+    end
+  end
+
+benchmark:
+  first_match: call("ok")
+  second_match: call(401)
+  third_match: call(200, "ok")
+  fourth_match: call(201, {}, "created")


### PR DESCRIPTION
## Changes

We can only check for `#deconstruct` result type once, since in case of mismatch we raise an exception.

For the following example:

```ruby
case val
in [200]
  :ok
in [401]
  :not_ok
end
```

The iseq difference is the following:

```diff 
== disasm: #<ISeq:<main>@-e:1 (1,0)-(7,3)> (catch: FALSE)
0000 putself                                                          (   2)[Li]
0001 opt_send_without_block                 <calldata!mid:val, argc:0, FCALL|VCALL|ARGS_SIMPLE>
0003 dup                                                              (   3)
0004 dup
0005 putobject                              :deconstruct
0007 opt_send_without_block                 <calldata!mid:respond_to?, argc:1, ARGS_SIMPLE>
0009 branchunless                           49
0011 opt_send_without_block                 <calldata!mid:deconstruct, argc:0, ARGS_SIMPLE>
0013 dup
0014 checktype                              T_ARRAY
0016 branchunless                           41
0018 dup
0019 opt_length                             <calldata!mid:length, argc:0, ARGS_SIMPLE>
0021 putobject_INT2FIX_1_
0022 opt_eq                                 <calldata!mid:==, argc:1, ARGS_SIMPLE>
0024 branchunless                           49
0026 dup
0027 putobject_INT2FIX_0_
0028 opt_aref                               <calldata!mid:[], argc:1, ARGS_SIMPLE>
0030 putobject                              200
0032 checkmatch                             2
0034 branchunless                           49
0036 pop
0037 putobject                              true
0039 jump                                   52
0041 putspecialobject                       1
0043 putobject                              TypeError
0045 putobject                              "deconstruct must return Array"
0047 opt_send_without_block                 <calldata!mid:core#raise, argc:2, ARGS_SIMPLE>
0049 pop
0050 putobject                              false
0052 branchif                               117
0054 dup                                                              (   5)
0055 dup
0056 putobject                              :deconstruct
0058 opt_send_without_block                 <calldata!mid:respond_to?, argc:1, ARGS_SIMPLE>
0060 branchunless                           100
0062 opt_send_without_block                 <calldata!mid:deconstruct, argc:0, ARGS_SIMPLE>
-0064 dup
-0065 checktype                              T_ARRAY
-0067 branchunless                           92
0069 dup
0070 opt_length                             <calldata!mid:length, argc:0, ARGS_SIMPLE>
0072 putobject_INT2FIX_1_
0073 opt_eq                                 <calldata!mid:==, argc:1, ARGS_SIMPLE>
0075 branchunless                           100
0077 dup
0078 putobject_INT2FIX_0_
0079 opt_aref                               <calldata!mid:[], argc:1, ARGS_SIMPLE>
0081 putobject                              401
0083 checkmatch                             2
0085 branchunless                           100
0087 pop
0088 putobject                              true
0090 jump                                   103
-0092 putspecialobject                       1
-0094 putobject                              TypeError
-0096 putobject                              "deconstruct must return Array"
-0098 opt_send_without_block                 <calldata!mid:core#raise, argc:2, ARGS_SIMPLE>
0100 pop
0101 putobject                              false
0103 branchif                               121
0105 putspecialobject                       1                         (   2)
0107 putobject                              NoMatchingPatternError
0109 topn                                   2
0111 opt_send_without_block                 <calldata!mid:core#raise, argc:2, ARGS_SIMPLE>
0113 pop
0114 pop
0115 putnil
0116 leave                                                            (   6)
0117 pop                                                              (   3)
0118 putobject                              :ok                       (   4)[Li]
0120 leave                                                            (   6)
0121 pop                                                              (   5)
0122 putobject                              :not_ok                   (   6)[Li]
0124 leave
```

## Performance

I've added a pattern matching [benchmark](https://github.com/ruby/ruby/pull/2948/commits/0b409a2efeaad4369628e9a8b3f8e56190d6c554) (based on the [real-life example](https://github.com/hanami/api/blob/b1823e3bf6bb832d60818b533666c0c9788b52cf/lib/hanami/api/block/context.rb#L129-L141)):

```
$  /usr/local/bin/ruby -v
ruby 2.7.0p0 (2019-12-25 revision 647ee6f091) [x86_64-linux]

$ benchmark-driver -e ./ruby -e /usr/local/bin/ruby benchmark/pm_array.yml 
...
Comparison:
                      first_match
              ./ruby:   2243417.1 i/s 
 /usr/local/bin/ruby:   1947863.2 i/s - 1.15x  slower

                     second_match
              ./ruby:   1625937.7 i/s 
 /usr/local/bin/ruby:   1359534.4 i/s - 1.20x  slower

                      third_match
              ./ruby:   1175999.5 i/s 
 /usr/local/bin/ruby:   1058739.1 i/s - 1.11x  slower

                     fourth_match
              ./ruby:   1014063.8 i/s 
 /usr/local/bin/ruby:    934814.2 i/s - 1.08x  slower
```

### Why no hash pattern optimization?

Unfortunately, we cannot do the same trick for hash patterns: `#deconstruct_keys(keys)` return value depends on the keys set (and it's more likely to have distinct sets within the same `case ... in
` statement). So, `#deconstruct_keys` could return pretty much anything. And that makes it really hard to optimize 😞.

----

This small improvement is backported from the [Ruby Next project](https://github.com/ruby-next/ruby-next) (which allows transpiling pattern matching syntax for older Ruby versions).

I was able to achieve a 2x better performance of the transpiled code on 2.7 for array patterns ([the same benchmark](https://github.com/ruby-next/ruby-next/pull/22)) using a few other tricks.

Reducing the number `respond_to?` calls (to at most 2—for `#deconstruct` and `#deconstruct_keys`) also has a great effect. I tried to port to MRI [here](https://github.com/palkan/ruby/commit/ed51ffa9ef91b877acd09d57c3660c79cfd2abb1). It works find but I'm not sure it's the right way to do that, would like to discuss first. Or, maybe, there is an already work in progress regarding PM performance (/cc @k-tsj) and these ad-hoc optimizations don't make sense at all 🙂

Anyway, I would be glad to work on further PM improvements.