### PR TITLE
Fix bundled gems installation on a fresh clone

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -43,7 +43,7 @@ jobs:
         working-directory: build
       - run: make $JOBS
         working-directory: build
-      - run: make update-gems extract-gems
+      - run: make prepare-gems
         working-directory: build
         if: matrix.test_task == 'check'
       - run: make $JOBS -s ${{ matrix.test_task }}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -52,7 +52,7 @@ jobs:
         working-directory: build
       - run: make $JOBS
         working-directory: build
-      - run: make update-gems extract-gems
+      - run: make prepare-gems
         working-directory: build
         if: matrix.test_task == 'check'
       - name: Create dummy files in build dir

--- a/README.md
+++ b/README.md
@@ -108,12 +108,7 @@ in the mail body (not subject) to the address
     interpreter works well. If you see the message "`check succeeded`", your
     Ruby works as it should (hopefully).
 
-8.  Optionally, run `make update-gems` and `make extract-gems`.
-
-    If you want to install bundled gems, run `make update-gems` and
-    `make extract-gems` before running `make install`.
-
-9.  Run '`make install`'.
+8.  Run '`make install`'.
 
     This command will create the following directories and install files into
     them.

--- a/common.mk
+++ b/common.mk
@@ -367,17 +367,17 @@ pkgconfig-data: $(ruby_pc)
 $(ruby_pc): $(srcdir)/template/ruby.pc.in config.status
 
 install-all: docs pre-install-all do-install-all post-install-all
-pre-install-all:: all pre-install-local pre-install-ext pre-install-doc
+pre-install-all:: all pre-install-local pre-install-ext pre-install-gem pre-install-doc
 do-install-all: pre-install-all
 	$(INSTRUBY) --make="$(MAKE)" $(INSTRUBY_ARGS) $(INSTALL_DOC_OPTS)
-post-install-all:: post-install-local post-install-ext post-install-doc
+post-install-all:: post-install-local post-install-ext post-install-gem post-install-doc
 	@$(NULLCMD)
 
 install-nodoc: pre-install-nodoc do-install-nodoc post-install-nodoc
-pre-install-nodoc:: pre-install-local pre-install-ext
+pre-install-nodoc:: pre-install-local pre-install-ext pre-install-gem
 do-install-nodoc: main pre-install-nodoc
 	$(INSTRUBY) --make="$(MAKE)" $(INSTRUBY_ARGS) --exclude=doc
-post-install-nodoc:: post-install-local post-install-ext
+post-install-nodoc:: post-install-local post-install-ext post-install-gem
 
 install-local: pre-install-local do-install-local post-install-local
 pre-install-local:: pre-install-bin pre-install-lib pre-install-man
@@ -543,7 +543,7 @@ post-install-doc::
 	@$(NULLCMD)
 
 install-gem: pre-install-gem do-install-gem post-install-gem
-pre-install-gem:: pre-install-bin pre-install-lib pre-install-man
+pre-install-gem:: prepare-gems pre-install-bin pre-install-lib pre-install-man
 do-install-gem: $(PROGRAM) pre-install-gem
 	$(INSTRUBY) --make="$(MAKE)" $(INSTRUBY_ARGS) --install=gem
 post-install-gem::


### PR DESCRIPTION
Currently, if you run `configure`, `make` and `make install` on a fresh ruby clone, `make install` _tries_ to install bundled gems, but fails to install anything.

See the `make install` output, where it succeeds to install default gems  with and without extensions, and then tries to install bundled gems but fails to install anything.

```
./miniruby -I../src/lib -I. -I.ext/common  ../src/tool/runruby.rb --extout=.ext  -- --disable-gems -r./x86_64-linux-fake ../src/tool/rbinstall.rb --make="make" --dest-dir="" --extout=".ext" --mflags="-w" --make-flags="w" --data-mode=0644 --prog-mode=0755 --installed-list .installed.list --mantype="doc" --exclude=doc
installing binary commands:         /home/deivid/.rbenv/versions/ruby-head/bin
installing base libraries:          /home/deivid/.rbenv/versions/ruby-head/lib
installing arch files:              /home/deivid/.rbenv/versions/ruby-head/lib/ruby/2.8.0/x86_64-linux
installing pkgconfig data:          /home/deivid/.rbenv/versions/ruby-head/lib/pkgconfig
installing extension objects:       /home/deivid/.rbenv/versions/ruby-head/lib/ruby/2.8.0/x86_64-linux
installing extension objects:       /home/deivid/.rbenv/versions/ruby-head/lib/ruby/site_ruby/2.8.0/x86_64-linux
installing extension objects:       /home/deivid/.rbenv/versions/ruby-head/lib/ruby/vendor_ruby/2.8.0/x86_64-linux
installing extension headers:       /home/deivid/.rbenv/versions/ruby-head/include/ruby-2.8.0/x86_64-linux
installing extension scripts:       /home/deivid/.rbenv/versions/ruby-head/lib/ruby/2.8.0
installing extension scripts:       /home/deivid/.rbenv/versions/ruby-head/lib/ruby/site_ruby/2.8.0
installing extension scripts:       /home/deivid/.rbenv/versions/ruby-head/lib/ruby/vendor_ruby/2.8.0
installing extension headers:       /home/deivid/.rbenv/versions/ruby-head/include/ruby-2.8.0/ruby
installing command scripts:         /home/deivid/.rbenv/versions/ruby-head/bin
installing library scripts:         /home/deivid/.rbenv/versions/ruby-head/lib/ruby/2.8.0
installing common headers:          /home/deivid/.rbenv/versions/ruby-head/include/ruby-2.8.0
installing manpages:                /home/deivid/.rbenv/versions/ruby-head/share/man (man1, man5)
installing default gems from lib:   /home/deivid/.rbenv/versions/ruby-head/lib/ruby/gems/2.8.0
                                    English 0.1.0
                                    benchmark 0.1.0
                                    bundler 2.1.4
                                    cgi 0.1.0
                                    csv 3.1.2
                                    delegate 0.1.0
                                    did_you_mean 1.4.0
                                    fileutils 1.4.1
                                    forwardable 1.3.1
                                    getoptlong 0.1.0
                                    ipaddr 1.2.2
                                    irb 1.2.3
                                    logger 1.4.2
                                    matrix 0.2.0
                                    mutex_m 0.1.0
                                    net-ftp 0.1.0
                                    net-http 0.1.0
                                    net-imap 0.1.0
                                    net-pop 0.1.0
                                    net-protocol 0.1.0
                                    net-smtp 0.1.0
                                    observer 0.1.0
                                    open3 0.1.0
                                    ostruct 0.2.0
                                    prime 0.1.1
                                    pstore 0.1.0
                                    racc 1.4.16
                                    rdoc 6.2.1
                                    readline 0.0.2
                                    reline 0.1.3
                                    singleton 0.1.0
                                    tempfile 0.1.0
                                    timeout 0.1.0
                                    tmpdir 0.1.0
                                    tracer 0.1.0
                                    uri 0.10.0
                                    weakref 0.1.0
                                    webrick 1.6.0
                                    yaml 0.1.0
installing default gems from ext:   /home/deivid/.rbenv/versions/ruby-head/lib/ruby/gems/2.8.0
                                    bigdecimal 2.0.0
                                    date 3.0.0
                                    dbm 1.1.0
                                    etc 1.1.0
                                    fcntl 1.0.0
                                    fiddle 1.0.0
                                    gdbm 2.1.0
                                    io-console 0.5.6
                                    json 2.3.0
                                    openssl 2.2.0
                                    psych 3.1.0
                                    readline-ext 0.1.0
                                    sdbm 1.0.0
                                    stringio 0.1.0
                                    strscan 1.0.3
                                    zlib 1.1.0
installing bundled gems:            /home/deivid/.rbenv/versions/ruby-head/lib/ruby/gems/2.8.0
make: Leaving directory '/home/deivid/Code/ruby/ruby/build'
```

If at some point you happen to run `make update-gems` and `make extract-gems`, then the proper `.gem` files and extracted gem contents are placed at the right place so that `rbinstall.rb` can see then, and `make install` starts doing the right thing.

To me, this is clearly unintended, because if it was intentional, `make install` wouldn't even _try_ to install bundled gems by default.

With this changes, `make install` does the right thing by default:

```
./miniruby -I../src/lib -I. -I.ext/common  ../src/tool/runruby.rb --extout=.ext  -- --disable-gems -r./x86_64-linux-fake ../src/tool/rbinstall.rb --make="make" --dest-dir="" --extout=".ext" --mflags="-w" --make-flags="w" --data-mode=0644 --prog-mode=0755 --installed-list .installed.list --mantype="doc" --exclude=doc
installing binary commands:         /home/deivid/.rbenv/versions/ruby-head/bin
installing base libraries:          /home/deivid/.rbenv/versions/ruby-head/lib
installing arch files:              /home/deivid/.rbenv/versions/ruby-head/lib/ruby/2.8.0/x86_64-linux
installing pkgconfig data:          /home/deivid/.rbenv/versions/ruby-head/lib/pkgconfig
installing extension objects:       /home/deivid/.rbenv/versions/ruby-head/lib/ruby/2.8.0/x86_64-linux
installing extension objects:       /home/deivid/.rbenv/versions/ruby-head/lib/ruby/site_ruby/2.8.0/x86_64-linux
installing extension objects:       /home/deivid/.rbenv/versions/ruby-head/lib/ruby/vendor_ruby/2.8.0/x86_64-linux
installing extension headers:       /home/deivid/.rbenv/versions/ruby-head/include/ruby-2.8.0/x86_64-linux
installing extension scripts:       /home/deivid/.rbenv/versions/ruby-head/lib/ruby/2.8.0
installing extension scripts:       /home/deivid/.rbenv/versions/ruby-head/lib/ruby/site_ruby/2.8.0
installing extension scripts:       /home/deivid/.rbenv/versions/ruby-head/lib/ruby/vendor_ruby/2.8.0
installing extension headers:       /home/deivid/.rbenv/versions/ruby-head/include/ruby-2.8.0/ruby
installing command scripts:         /home/deivid/.rbenv/versions/ruby-head/bin
installing library scripts:         /home/deivid/.rbenv/versions/ruby-head/lib/ruby/2.8.0
installing common headers:          /home/deivid/.rbenv/versions/ruby-head/include/ruby-2.8.0
installing manpages:                /home/deivid/.rbenv/versions/ruby-head/share/man (man1, man5)
installing default gems from lib:   /home/deivid/.rbenv/versions/ruby-head/lib/ruby/gems/2.8.0
                                    English 0.1.0
                                    benchmark 0.1.0
                                    bundler 2.1.4
                                    cgi 0.1.0
                                    csv 3.1.2
                                    delegate 0.1.0
                                    did_you_mean 1.4.0
                                    fileutils 1.4.1
                                    forwardable 1.3.1
                                    getoptlong 0.1.0
                                    ipaddr 1.2.2
                                    irb 1.2.3
                                    logger 1.4.2
                                    matrix 0.2.0
                                    mutex_m 0.1.0
                                    net-ftp 0.1.0
                                    net-http 0.1.0
                                    net-imap 0.1.0
                                    net-pop 0.1.0
                                    net-protocol 0.1.0
                                    net-smtp 0.1.0
                                    observer 0.1.0
                                    open3 0.1.0
                                    ostruct 0.2.0
                                    prime 0.1.1
                                    pstore 0.1.0
                                    racc 1.4.16
                                    rdoc 6.2.1
                                    readline 0.0.2
                                    reline 0.1.3
                                    singleton 0.1.0
                                    tempfile 0.1.0
                                    timeout 0.1.0
                                    tmpdir 0.1.0
                                    tracer 0.1.0
                                    uri 0.10.0
                                    weakref 0.1.0
                                    webrick 1.6.0
                                    yaml 0.1.0
installing default gems from ext:   /home/deivid/.rbenv/versions/ruby-head/lib/ruby/gems/2.8.0
                                    bigdecimal 2.0.0
                                    date 3.0.0
                                    dbm 1.1.0
                                    etc 1.1.0
                                    fcntl 1.0.0
                                    fiddle 1.0.0
                                    gdbm 2.1.0
                                    io-console 0.5.6
                                    json 2.3.0
                                    openssl 2.2.0
                                    psych 3.1.0
                                    readline-ext 0.1.0
                                    sdbm 1.0.0
                                    stringio 0.1.0
                                    strscan 1.0.3
                                    zlib 1.1.0
installing bundled gems:            /home/deivid/.rbenv/versions/ruby-head/lib/ruby/gems/2.8.0
                                    minitest 5.14.0
                                    power_assert 1.1.6
                                    rake 13.0.1
                                    test-unit 3.3.5
                                    rexml 3.2.4
                                    rss 0.2.9
make: Leaving directory '/home/deivid/Code/ruby/ruby/build'
```

This PR fixes ruby bug https://bugs.ruby-lang.org/issues/13724.