### PR TITLE
Clear all trace events during teardown

### DIFF
--- a/eval.c
+++ b/eval.c
@@ -38,6 +38,7 @@
 
 NORETURN(void rb_raise_jump(VALUE, VALUE));
 void rb_ec_clear_current_thread_trace_func(const rb_execution_context_t *ec);
+void rb_ec_clear_all_trace_func(const rb_execution_context_t *ec);
 
 static int rb_ec_cleanup(rb_execution_context_t *ec, volatile int ex);
 static int rb_ec_exec_node(rb_execution_context_t *ec, void *n);
@@ -152,7 +153,7 @@ rb_ec_teardown(rb_execution_context_t *ec)
     }
     EC_POP_TAG();
     rb_ec_exec_end_proc(ec);
-    rb_ec_clear_current_thread_trace_func(ec);
+    rb_ec_clear_all_trace_func(ec);
 }
 
 static void

--- a/ext/-test-/tracepoint/gc_hook.c
+++ b/ext/-test-/tracepoint/gc_hook.c
@@ -73,8 +73,16 @@ set_after_gc_start(VALUE module, VALUE proc)
 		       "__set_after_gc_start_tpval__", "__set_after_gc_start_proc__");
 }
 
+static VALUE
+start_after_gc_exit(VALUE module, VALUE proc)
+{
+    return set_gc_hook(module, proc, RUBY_INTERNAL_EVENT_GC_EXIT,
+                       "__set_after_gc_exit_tpval__", "__set_after_gc_exit_proc__");
+}
+
 void
 Init_gc_hook(VALUE module)
 {
     rb_define_module_function(module, "after_gc_start_hook=", set_after_gc_start, 1);
+    rb_define_module_function(module, "after_gc_exit_hook=", start_after_gc_exit, 1);
 }

--- a/test/-ext-/tracepoint/test_tracepoint.rb
+++ b/test/-ext-/tracepoint/test_tracepoint.rb
@@ -77,4 +77,8 @@ class TestTracepointObj < Test::Unit::TestCase
     end
   end
 
+  def test_teardown_with_active_GC_end_hook
+    assert_separately([], 'require("-test-/tracepoint"); Bug.after_gc_exit_hook = proc {}')
+  end
+
 end

--- a/vm_trace.c
+++ b/vm_trace.c
@@ -278,6 +278,12 @@ rb_ec_clear_current_thread_trace_func(const rb_execution_context_t *ec)
     rb_threadptr_remove_event_hook(ec, rb_ec_thread_ptr(ec), 0, Qundef);
 }
 
+void
+rb_ec_clear_all_trace_func(const rb_execution_context_t *ec)
+{
+    rb_threadptr_remove_event_hook(ec, MATCH_ANY_FILTER_TH, 0, Qundef);
+}
+
 /* invoke hooks */
 
 static void


### PR DESCRIPTION
Since 0c2d81dada, not all trace events are cleared during VM teardown.
This causes a crash when there is a tracepoint for
`RUBY_INTERNAL_EVENT_GC_EXIT` active during teardown.

The commit looks like a refactoring commit so I think this change was
unintentional.

[[Bug #16682]](https://bugs.ruby-lang.org/issues/16682)

---

On older versions the GC_EXIT event does not fire during shutdown.
The commit removed the usage of `MATCH_ANY_FILTER_TH` in the cleanup process which means GC events that used to not fire now do.
During filtering (see `remove_event_hook()`), it now only looks for hooks targeting the main thread while hooks made from `alloc_event_hook()` have their target thread set to null.
The commit message says it's a rename so I think this change was unintentional.
@nobu, could you take a look?