### PR TITLE
StringIO#initialize default to the source string encoding

### DIFF
--- a/ext/stringio/stringio.c
+++ b/ext/stringio/stringio.c
@@ -363,7 +363,11 @@ strio_init(int argc, VALUE *argv, struct StringIO *ptr, VALUE self)
 	rb_str_resize(string, 0);
     }
     ptr->string = string;
-    ptr->enc = convconfig.enc;
+    if (argc == 1) {
+        ptr->enc = rb_enc_get(string);
+    } else {
+        ptr->enc = convconfig.enc;
+    }
     ptr->pos = 0;
     ptr->lineno = 0;
     if (ptr->flags & FMODE_SETENC_BY_BOM) set_encoding_by_bom(ptr);
@@ -1758,10 +1762,6 @@ static VALUE
 strio_set_encoding_by_bom(VALUE self)
 {
     struct StringIO *ptr = StringIO(self);
-
-    if (ptr->enc) {
-	rb_raise(rb_eArgError, "encoding conversion is set");
-    }
     if (!set_encoding_by_bom(ptr)) return Qnil;
     return rb_enc_from_encoding(ptr->enc);
 }

--- a/spec/ruby/library/stringio/initialize_spec.rb
+++ b/spec/ruby/library/stringio/initialize_spec.rb
@@ -187,11 +187,14 @@ end
 describe "StringIO#initialize sets the encoding to" do
   before :each do
     @external = Encoding.default_external
+    @internal = Encoding.default_internal
     Encoding.default_external = Encoding::ISO_8859_2
+    Encoding.default_internal = Encoding::ISO_8859_2
   end
 
   after :each do
     Encoding.default_external = @external
+    Encoding.default_internal = @internal
   end
 
   it "Encoding.default_external when passed no arguments" do

--- a/test/stringio/test_stringio.rb
+++ b/test/stringio/test_stringio.rb
@@ -797,6 +797,14 @@ class TestStringIO < Test::Unit::TestCase
     end
   end
 
+  def test_binary_encoding_read_and_default_internal
+    default_internal = Encoding.default_internal
+    Encoding.default_internal = Encoding::UTF_8
+    assert_equal Encoding::BINARY, StringIO.new("Hello".b).read.encoding
+  ensure
+    Encoding.default_internal = default_internal
+  end
+
   def assert_string(content, encoding, str, mesg = nil)
     assert_equal([content, encoding], [str, str.encoding], mesg)
   end


### PR DESCRIPTION
Bug report: https://bugs.ruby-lang.org/issues/16497

I think this went un-noticed because it doesn't happen if `Encoding.default_internal = nil`.

I'm very unsure about my change in `strio_set_encoding_by_bom`, but the method is undocumented, so I don't know what the intended behavior was exactly. 