### PR TITLE
Fix crashes in the peephole optimizer on OpenBSD/sparc64

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -2776,7 +2776,8 @@ iseq_peephole_optimize(rb_iseq_t *iseq, LINK_ELEMENT *list, const int do_tailcal
 	    ELEM_REMOVE(&iobj->link);
 	    return COMPILE_OK;
 	}
-	else if (iobj != diobj && IS_INSN_ID(diobj, jump) &&
+        else if (iobj != diobj && IS_INSN(&diobj->link) &&
+                 IS_INSN_ID(diobj, jump) &&
 		 OPERAND_AT(iobj, 0) != OPERAND_AT(diobj, 0)) {
 	    /*
 	     *  useless jump elimination:
@@ -2954,7 +2955,7 @@ iseq_peephole_optimize(rb_iseq_t *iseq, LINK_ELEMENT *list, const int do_tailcal
             }
 
             for (;;) {
-                if (IS_INSN_ID(nobj, jump)) {
+                if (IS_INSN(&nobj->link) && IS_INSN_ID(nobj, jump)) {
                     replace_destination(iobj, nobj);
                 }
                 else if (prev_dup && IS_INSN_ID(nobj, dup) &&


### PR DESCRIPTION
These crashes are due to alignment issues, casting ADJUST to INSN
and then accessing after the end of the ADJUST.  These patches
come from Stefan Sperling <stsp@apache.org>, who reported the
issue.