### PR TITLE
Fix Action mingw build

### DIFF
--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -110,14 +110,14 @@ jobs:
         timeout-minutes: 5
         working-directory: build
         run: |
-          $env:TMPDIR = "$pwd/../temp"
+          $env:TMPDIR = "$env:GITHUB_WORKSPACE/temp"
           make test
 
       - name: test-all
         timeout-minutes: 25
         working-directory: build
         run: |
-          $env:TMPDIR = "$pwd/../temp"
+          $env:TMPDIR = "$env:GITHUB_WORKSPACE/temp"
           # Actions uses UTF8, causes test failures, similar to normal OS setup
           $PSDefaultParameterValues['*:Encoding'] = 'utf8'
           [Console]::OutputEncoding = [System.Text.Encoding]::GetEncoding("IBM437")
@@ -129,8 +129,8 @@ jobs:
         timeout-minutes: 10
         working-directory: src/spec/ruby
         run: |
-          $env:TMPDIR = "$pwd/../temp"
-          $env:PATH = "$pwd/../install/bin;$env:PATH"
+          $env:TMPDIR = "$env:GITHUB_WORKSPACE/temp"
+          $env:PATH = "$env:GITHUB_WORKSPACE/install/bin;$env:PATH"
           # Actions uses UTF8, causes test failures, similar to normal OS setup
           $PSDefaultParameterValues['*:Encoding'] = 'utf8'
           [Console]::OutputEncoding = [System.Text.Encoding]::GetEncoding("IBM437")


### PR DESCRIPTION
Commit 888e736524 used 'working-directory:' to set the step's directory, but step scripts were setting relative paths based on a different folder.

This caused test-spec to run on the system's Ruby, not the install Ruby.

See:
https://github.com/ruby/ruby/runs/505758270?check_suite_focus=true#step:15:24