### PR TITLE
Add missing write barrier for Hash#transform_values{,!}

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -3257,7 +3257,8 @@ static int
 transform_values_foreach_replace(st_data_t *key, st_data_t *value, st_data_t argp, int existing)
 {
     VALUE new_value = rb_yield((VALUE)*value);
-    *value = new_value;
+    VALUE hash = (VALUE)argp;
+    RB_OBJ_WRITE(hash, value, new_value);
     return ST_CONTINUE;
 }
 
@@ -3287,7 +3288,7 @@ rb_hash_transform_values(VALUE hash)
     result = hash_copy(hash_alloc(rb_cHash), hash);
 
     if (!RHASH_EMPTY_P(hash)) {
-        rb_hash_stlike_foreach_with_replace(result, transform_values_foreach_func, transform_values_foreach_replace, 0);
+        rb_hash_stlike_foreach_with_replace(result, transform_values_foreach_func, transform_values_foreach_replace, result);
     }
 
     return result;
@@ -3317,7 +3318,7 @@ rb_hash_transform_values_bang(VALUE hash)
     rb_hash_modify_check(hash);
 
     if (!RHASH_TABLE_EMPTY_P(hash)) {
-        rb_hash_stlike_foreach_with_replace(hash, transform_values_foreach_func, transform_values_foreach_replace, 0);
+        rb_hash_stlike_foreach_with_replace(hash, transform_values_foreach_func, transform_values_foreach_replace, hash);
     }
 
     return hash;


### PR DESCRIPTION
21994b7fd686f263544fcac1616ecf3189fb78b3 removed the write barrier that
was present in rb_hash_aset(). Re-insert it to not crash during GC.

------
See https://bugs.ruby-lang.org/issues/16689