### PR TITLE
Support obj.clone(freeze: true) for freezing clone

### DIFF
--- a/kernel.rb
+++ b/kernel.rb
@@ -1,13 +1,13 @@
 module Kernel
   #
   #  call-seq:
-  #     obj.clone(freeze: true) -> an_object
+  #     obj.clone(freeze: nil) -> an_object
   #
   #  Produces a shallow copy of <i>obj</i>---the instance variables of
   #  <i>obj</i> are copied, but not the objects they reference.
-  #  #clone copies the frozen (unless +:freeze+ keyword argument is
-  #  given with a false value) state of <i>obj</i>.  See
-  #  also the discussion under Object#dup.
+  #  #clone copies the frozen value state of <i>obj</i>, unless the
+  #  +:freeze+ keyword argument is given with a false or true value.
+  #  See also the discussion under Object#dup.
   #
   #     class Klass
   #        attr_accessor :str
@@ -23,7 +23,7 @@ module Kernel
   #  behavior will be documented under the #+initialize_copy+ method of
   #  the class.
   #
-  def clone(freeze: true)
+  def clone(freeze: nil)
     __builtin_rb_obj_clone2(freeze)
   end
 end

--- a/lib/delegate.rb
+++ b/lib/delegate.rb
@@ -218,7 +218,7 @@ class Delegator < BasicObject
     end
   end
 
-  def initialize_clone(obj, freeze: true) # :nodoc:
+  def initialize_clone(obj, freeze: nil) # :nodoc:
     self.__setobj__(obj.__getobj__.clone(freeze: freeze))
   end
   def initialize_dup(obj) # :nodoc:

--- a/lib/set.rb
+++ b/lib/set.rb
@@ -137,7 +137,7 @@ class Set
   end
 
   # Clone internal hash.
-  def initialize_clone(orig, freeze: true)
+  def initialize_clone(orig, freeze: nil)
     super
     @hash = orig.instance_variable_get(:@hash).clone(freeze: freeze)
   end

--- a/spec/ruby/core/kernel/clone_spec.rb
+++ b/spec/ruby/core/kernel/clone_spec.rb
@@ -37,11 +37,17 @@ describe "Kernel#clone" do
     o3.frozen?.should == true
   end
 
-  it 'takes an option to copy freeze state or not' do
-    @obj.clone(freeze: true).frozen?.should == false
+  ruby_version_is '2.8' do
+    it 'takes an freeze: true option to frozen copy' do
+      @obj.clone(freeze: true).frozen?.should == true
+      @obj.freeze
+      @obj.clone(freeze: true).frozen?.should == true
+    end
+  end
+
+  it 'takes an freeze: false option to not return frozen copy' do
     @obj.clone(freeze: false).frozen?.should == false
     @obj.freeze
-    @obj.clone(freeze: true).frozen?.should == true
     @obj.clone(freeze: false).frozen?.should == false
   end
 

--- a/test/ruby/test_object.rb
+++ b/test/ruby/test_object.rb
@@ -47,15 +47,27 @@ class TestObject < Test::Unit::TestCase
     a = Object.new
     def a.b; 2 end
 
+    c = a.clone
+    assert_equal(false, c.frozen?)
+    assert_equal(false, a.frozen?)
+    assert_equal(2, c.b)
+
+    c = a.clone(freeze: true)
+    assert_equal(true, c.frozen?)
+    assert_equal(false, a.frozen?)
+    assert_equal(2, c.b)
+
     a.freeze
     c = a.clone
     assert_equal(true, c.frozen?)
+    assert_equal(true, a.frozen?)
     assert_equal(2, c.b)
 
     assert_raise(ArgumentError) {a.clone(freeze: [])}
     d = a.clone(freeze: false)
     def d.e; 3; end
     assert_equal(false, d.frozen?)
+    assert_equal(true, a.frozen?)
     assert_equal(2, d.b)
     assert_equal(3, d.e)
 


### PR DESCRIPTION
This freezes the clone even if the receiver is not frozen.  It
is only for consistency with freeze: false not freezing the clone
even if the receiver is frozen.

Because Object#clone is now partially implemented in Ruby and
not fully implemented in C, freeze: nil must be supported to
provide the default behavior of only freezing the clone if the
receiver is frozen.

This requires modifying delegate and set, to set freeze: nil
instead of freeze: true as the keyword parameter for
initialize_clone.  Those are the two libraries in stdlib that
override initialize_clone.

Implements [Feature #16175]