### PR TITLE
openssl/ossl_ssl.c - fix for eol with OpenSSL 1.1.1e

### DIFF
--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -1896,7 +1896,17 @@ ossl_ssl_read_internal(int argc, VALUE *argv, VALUE self, int nonblock)
 			rb_eof_error();
 		    }
 		}
-                /* fall through */
+		/* fall through */
+#ifdef SSL_R_UNEXPECTED_EOF_WHILE_READING
+	    case SSL_ERROR_SSL:
+		/* defined for OpenSSL versions 1.1.1e and later */
+		if (OpenSSL_version_num() >= 0x1010105fL &&
+		    ERR_GET_REASON(ERR_peek_last_error()) == SSL_R_UNEXPECTED_EOF_WHILE_READING) {
+		    rb_eof_error();
+		    continue;
+		}
+		/* fall through */
+#endif
 	    default:
 		ossl_raise(eSSLError, "SSL_read");
 	    }


### PR DESCRIPTION
See https://bugs.ruby-lang.org/issues/16696 and https://github.com/ruby/openssl/pull/356 (passed).

Fix a somewhat breaking change in OpenSSL 1.1.1e that changes how eol is handled in reads.

**EDIT:** At present, the only builds using 1.1.1e are the MinGW build here and the OpenSSL PR CI at https://github.com/ruby/openssl/runs/520814976.