### PR TITLE
[ci skip]Fix return type on RbConfig.fire_update!

### DIFF
--- a/tool/mkconfig.rb
+++ b/tool/mkconfig.rb
@@ -333,8 +333,8 @@ print <<EOS
   # :nodoc:
   # call-seq:
   #
-  #   RbConfig.fire_update!(key, val)               -> string
-  #   RbConfig.fire_update!(key, val, mkconf, conf) -> string
+  #   RbConfig.fire_update!(key, val)               -> array
+  #   RbConfig.fire_update!(key, val, mkconf, conf) -> array
   #
   # updates +key+ in +mkconf+ with +val+, and all values depending on
   # the +key+ in +mkconf+.


### PR DESCRIPTION
I fix return type on `RbConfig.fire_update!`. `RbConfig.fire_update! ` returns strings of array.

```ruby
irb(main):001:0> RbConfig.fire_update!("CC", "gcc-8")  
=> ["CC", "DLDSHARED", "LDSHARED", "CC_VERSION", "CPP"]
```