### PR TITLE
Pathname#mountpoint? to support bind mount

### DIFF
--- a/ext/pathname/lib/pathname.rb
+++ b/ext/pathname/lib/pathname.rb
@@ -200,9 +200,15 @@ class Pathname
   # Returns +true+ if +self+ points to a mountpoint.
   def mountpoint?
     begin
-      stat1 = self.lstat
-      stat2 = self.parent.lstat
-      stat1.dev != stat2.dev || stat1.ino == stat2.ino
+      if File.exist? "/proc/self/mountinfo"
+        File.foreach("/proc/self/mountinfo"){ |line|
+          break true if line.split(" ")[4] == File.expand_path(self)
+        } or false
+      else
+        stat1 = self.lstat
+        stat2 = self.parent.lstat
+        stat1.dev != stat2.dev || stat1.ino == stat2.ino
+      end
     rescue Errno::ENOENT
       false
     end


### PR DESCRIPTION
The current Pathname#mountpoint? method is based on stat (lstat, actually), so bind mount cannot be detected.

```
[root@linux /]# mkdir /tmp1 /tmp2
[root@linux /]# mount --bind /tmp1 /tmp2

[root@linux /]# mountpoint /tmp2
/tmp2 is a mountpoint

[root@linux /]# ruby -r pathname -e "p Pathname.new('/tmp2').mountpoint?"
false
```

This PR updates the method to read /proc/self/mountinfo so that the method can detect bind mount.

```
[root@linux /]# cat /proc/self/mountinfo | grep tmp1
276 27 8:2 /tmp1 /tmp2 rw,relatime shared:1 - ext4 /dev/sda2 rw

[root@linux /]# ruby -r pathname -e "p Pathname.new('/tmp2').mountpoint?"
true
```

In case /proc/self/mountinfo is not available, the method uses the previous way, which is lstat.