### PR TITLE
Fix AppVeyor CI sometimes fail

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 ---
 version: '{build}'
-shallow_clone: true
+clone_depth: 10
 platform:
   - x64
 environment:


### PR DESCRIPTION
Past few days, fail AppVeyor CI.

```bash
Build started
Fetching repository commit (f6b6a7a)...Cannot download GitHub repository contents: Forbidden
```

replace `clone_depth: 10`, may be fix it.
