### PR TITLE
Fix AppVeyor pull request CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,8 @@
 ---
 version: '{build}'
+init:
+  - git config --global user.name git
+  - git config --global user.email svn-admin@ruby-lang.org
 clone_depth: 10
 platform:
   - x64


### PR DESCRIPTION
#2979 is Fix AppVeyor CI fail.

But, not cover Pull Request CI. So Fail CI like this.

```bash
Build started
git clone -q --depth=10 https://github.com/ruby/ruby.git C:\projects\ruby
git fetch -q origin +refs/pull/1870/merge:
git checkout -qf FETCH_HEAD
Running Install scripts
ver
Microsoft Windows [Version 6.3.9600]
chcp
Active code page: 437
SET BITS=%Platform:x86=32%
SET BITS=%BITS:x=%
SET OPENSSL_DIR=C:\%ssl%-Win%BITS%
CALL SET vcvars=%%^VS%VS%COMNTOOLS^%%..\..\VC\vcvarsall.bat
SET vcvars
vcvars=C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\Tools\..\..\VC\vcvarsall.bat
"%vcvars%" %Platform:x64=amd64%
SET ruby_path=C:\Ruby%ruby_version:-x86=%
SET PATH=\usr\local\bin;%ruby_path%\bin;%PATH%;C:\msys64\mingw64\bin;C:\msys64\usr\bin
ruby --version
ruby 2.4.6p354 (2019-04-01 revision 67394) [x64-mingw32]
cl
Microsoft (R) C/C++ Optimizing Compiler Version 19.00.24241.7 for x64
Copyright (C) Microsoft Corporation.  All rights reserved.
usage: cl [ option... ] filename... [ /link linkoption... ]
echo> Makefile srcdir=.
echo>> Makefile MSC_VER=0
echo>> Makefile RT=none
echo>> Makefile RT_VER=0
echo>> Makefile BUILTIN_ENCOBJS=nul
type win32\Makefile.sub >> Makefile
nmake %mflags% touch-unicode-files
Microsoft (R) Program Maintenance Utility Version 14.00.24210.0
Copyright (C) Microsoft Corporation.  All rights reserved.
	C:\windows\system32\cmd.exe /E:ON /C .\win32\makedirs.bat ./enc/unicode/data/12.1.0/ucd
	touch ./enc/unicode/data/12.1.0/ucd/.unicode-tables.time ./enc/unicode/12.1.0/casefold.h  ./enc/unicode/12.1.0/name2ctype.h  
nmake %mflags% %UPDATE_UNICODE% up incs
Microsoft (R) Program Maintenance Utility Version 14.00.24210.0
Copyright (C) Microsoft Corporation.  All rights reserved.
From https://github.com/ruby/ruby
 * [new tag]               v1_0_r2         -> v1_0_r2
 * [new tag]               v2_7_0_preview1 -> v2_7_0_preview1
 * [new tag]               v2_7_0_preview2 -> v2_7_0_preview2
 * [new tag]               v2_7_0_preview3 -> v2_7_0_preview3
 * [new tag]               v2_7_0_rc1      -> v2_7_0_rc1
 * [new tag]               v2_7_0_rc2      -> v2_7_0_rc2
First, rewinding head to replay your work on top of it...
*** Please tell me who you are.
Run
  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"
to set your account's default identity.
Omit --global to set the identity only in this repository.
fatal: unable to auto-detect email address (got 'appveyor@APPVYR-WIN.(none)')
NMAKE : fatal error U1077: 'cd' : return code '0x1'
Stop.

```

ref: [Prefer UNIXSocket which could be supported on Windows. 19032](https://ci.appveyor.com/project/ruby/ruby/builds/31735117)

Add `init` setting for Fix fail.

```yaml
init:
  - git config --global user.name git
  - git config --global user.email svn-admin@ruby-lang.org
```