### PR TITLE
[ci skip] Enumerator doc cleanup

### DIFF
--- a/enumerator.c
+++ b/enumerator.c
@@ -722,9 +722,9 @@ enumerator_with_object_i(RB_BLOCK_CALL_FUNC_ARGLIST(val, memo))
  *     puts "#{string}: #{x}"
  *   end
  *
- *   # => foo:0
- *   # => foo:1
- *   # => foo:2
+ *   # => foo: 0
+ *   # => foo: 1
+ *   # => foo: 2
  */
 static VALUE
 enumerator_with_object(VALUE obj, VALUE memo)


### PR DESCRIPTION
This is my first attempt at a pull request. I was reading the ruby docs
the other day and noticed that the output didn't match the code sample
on the with_object documentation.

Inserted spaces to make the output match the code example.