### PR TITLE
Let File::NULL ("/dev/null", "NUL" etc.) be considered a nil log device

### DIFF
--- a/lib/logger.rb
+++ b/lib/logger.rb
@@ -385,7 +385,7 @@ class Logger
     self.datetime_format = datetime_format
     self.formatter = formatter
     @logdev = nil
-    if logdev
+    if logdev && logdev != File::NULL
       @logdev = LogDevice.new(logdev, shift_age: shift_age,
         shift_size: shift_size,
         shift_period_suffix: shift_period_suffix,

--- a/lib/logger.rb
+++ b/lib/logger.rb
@@ -410,7 +410,7 @@ class Logger
   # Reopen a log device.
   #
   def reopen(logdev = nil)
-    @logdev.reopen(logdev)
+    @logdev&.reopen(logdev)
     self
   end
 

--- a/spec/ruby/library/logger/logger/new_spec.rb
+++ b/spec/ruby/library/logger/logger/new_spec.rb
@@ -115,4 +115,9 @@ describe "Logger#new" do
     rm_r path, shifted_path
   end
 
+  it "does not instantiate a log device for File::NULL" do
+    l = Logger.new(File::NULL)
+    l.instance_variable_get(:@logdev).should == nil
+    l.close
+  end
 end


### PR DESCRIPTION
I noticed on a `Logger` instance with `File::NULL` or `/dev/null` as log device arguments a lot of formatting and other overhead still occurs, with the expected result essentially still being "I want to blackhole these logs":

```
GC: 130 (7.40%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
       348  (19.8%)         348  (19.8%)     Logger::Formatter#format_datetime
       614  (35.0%)         169   (9.6%)     Logger::Formatter#call
       395  (22.5%)         152   (8.7%)     Logger::LogDevice#write
```

The logger was configured as `Logger.new(File::NULL)`.