### PR TITLE
Patch to work in a musl-libc environment on ARMv7

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2353,8 +2353,8 @@ AS_CASE([$rb_cv_coroutine], [yes|''], [
         [*86-mingw32], [
             rb_cv_coroutine=win32
         ],
-        [armv7*-linux*], [
-            rb_cv_coroutine=ucontext
+        [arm*-linux*], [
+            rb_cv_coroutine=arm32
         ],
         [aarch64-linux*], [
             rb_cv_coroutine=arm64

--- a/coroutine/arm32/Context.S
+++ b/coroutine/arm32/Context.S
@@ -5,9 +5,13 @@
 ##  Copyright, 2018, by Samuel Williams.
 ##
 
+.file "Context.S"
 .text
-
 .globl coroutine_transfer
+.align 2
+.type coroutine_transfer,%function
+.syntax unified
+
 coroutine_transfer:
 	# Save caller state (8 registers + return address)
 	push {r4-r11,lr}

--- a/test/fiddle/helper.rb
+++ b/test/fiddle/helper.rb
@@ -32,7 +32,11 @@ when /linux/
       # libc.so and libm.so are installed to /lib/arm-linux-gnu*.
       # It's not installed to /lib32.
       dirs = Dir.glob('/lib/arm-linux-gnu*')
-      libdir = dirs[0] if dirs && File.directory?(dirs[0])
+      if dirs.length > 0
+        libdir = dirs[0] if dirs && File.directory?(dirs[0])
+      else # handle alpine environment
+        libdir = '/lib' if File.directory? '/lib'
+      end
     else
       libdir = '/lib32' if File.directory? '/lib32'
     end
@@ -40,8 +44,17 @@ when /linux/
     # 64-bit ruby
     libdir = '/lib64' if File.directory? '/lib64'
   end
-  libc_so = File.join(libdir, "libc.so.6")
-  libm_so = File.join(libdir, "libm.so.6")
+
+  # Handle musl libc
+  libc = Dir.glob(File.join(libdir, "libc.musl*.so*"))
+  if libc && libc.length > 0
+    libc_so = libc[0]
+    libm_so = libc[0]
+  else
+    # glibc
+    libc_so = File.join(libdir, "libc.so.6")
+    libm_so = File.join(libdir, "libm.so.6")
+  end
 when /mingw/, /mswin/
   require "rbconfig"
   crtname = RbConfig::CONFIG["RUBY_SO_NAME"][/msvc\w+/] || 'ucrtbase'


### PR DESCRIPTION
Makes fewer assumptions about which libc is used, and adds support for musl libc in an ARM environment.

See full discussion [here](https://github.com/ruby/ruby/commit/acb67472c7da459812aa9008cf8cfbedcdddea67)