### PR TITLE
Endless method definition [Feature #16746]

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -45,6 +45,13 @@ sufficient information, see the ChangeLog file or Redmine
     fib(10) => x
     ```
 
+* Endless method definition is added.  [EXPERIMENTAL]
+  [[Feature #16746]]
+
+    ```ruby
+    def square(x) = x * x
+    ```
+
 ## Command line options
 
 ## Core classes updates

--- a/spec/ruby/language/method_spec.rb
+++ b/spec/ruby/language/method_spec.rb
@@ -1766,3 +1766,16 @@ describe "An array-dereference method ([])" do
     end
   end
 end
+
+ruby_version_is '2.8' do
+  describe "An endless method definition" do
+    evaluate <<-ruby do
+      def m(a) = a
+    ruby
+
+      a = b = m 1
+      a.should == 1
+      b.should == 1
+    end
+  end
+end

--- a/test/ruby/test_syntax.rb
+++ b/test/ruby/test_syntax.rb
@@ -1414,6 +1414,13 @@ eom
     assert_equal(line, e.backtrace_locations[0].lineno)
   end
 
+  def test_methoddef_endless
+    assert_valid_syntax('private def foo = 42')
+    assert_valid_syntax('private def inc(x) = x + 1')
+    assert_valid_syntax('private def obj.foo = 42')
+    assert_valid_syntax('private def obj.inc(x) = x + 1')
+  end
+
   def test_methoddef_in_cond
     assert_valid_syntax('while def foo; tap do end; end; break; end')
     assert_valid_syntax('while def foo a = tap do end; end; break; end')


### PR DESCRIPTION
## Synopsis
The new method definition syntax proposed by @mame at [Feature #16746], then [noted by @matz].

```ruby
def value(args) = expression
```
As you see, there is no "`end`".

## Examples

```ruby
def hello(name) =
  puts("Hello, #{ name }")

hello("endless Ruby") #=> Hello, endless Ruby
```
```ruby
def inc(x) = x + 1

p inc(42) #=> 43
```
```ruby
x = Object.new

def x.foo = "FOO"

p x.foo #=> "FOO"
```
```ruby
def fib(x) =
  x < 2 ? x : fib(x-1) + fib(x-2)

p fib(10) #=> 55
```

[Feature #16746]: https://bugs.ruby-lang.org/issues/16746
[noted by @matz]: https://bugs.ruby-lang.org/issues/16746#change-84859