### PR TITLE
Fix ObjectSpace.trace_object_allocations_stop to not raise if the tracepoint were not initialized

### DIFF
--- a/ext/objspace/object_tracing.c
+++ b/ext/objspace/object_tracing.c
@@ -216,8 +216,12 @@ trace_object_allocations_stop(VALUE self)
     }
 
     if (arg->running == 0) {
-	rb_tracepoint_disable(arg->newobj_trace);
-	rb_tracepoint_disable(arg->freeobj_trace);
+        if (arg->newobj_trace != 0) {
+            rb_tracepoint_disable(arg->newobj_trace);
+        }
+        if (arg->freeobj_trace != 0) {
+            rb_tracepoint_disable(arg->freeobj_trace);
+        }
     }
 
     return Qnil;

--- a/test/objspace/test_objspace.rb
+++ b/test/objspace/test_objspace.rb
@@ -164,6 +164,15 @@ class TestObjSpace < Test::Unit::TestCase
     end;
   end
 
+  def test_trace_object_allocations_stop_first
+    assert_separately([], "#{<<~"begin;"}\n#{<<~'end;'}")
+    begin;
+      require "objspace"
+      # Make sure stoping before the tracepoints are initialized doesn't raise. See [Bug #17020]
+      ObjectSpace.trace_object_allocations_stop
+    end;
+  end
+
   def test_trace_object_allocations
     Class.name
     o0 = Object.new


### PR DESCRIPTION
Ruby issue: https://bugs.ruby-lang.org/issues/17020

The error is easy to reproduce:

e.g. on Ruby 2.3:

```
$ ruby -robjspace -e 'ObjectSpace.trace_object_allocations_stop'
-e:1:in `trace_object_allocations_stop': wrong argument type false (expected tracepoint) (TypeError)
	from -e:1:in `<main>'
```

Up to ruby 2.7.1:

```
$ ruby -robjspace -e 'ObjectSpace.trace_object_allocations_stop'
Traceback (most recent call last):
	1: from -e:1:in `<main>'
-e:1:in `trace_object_allocations_stop': wrong argument type false (expected tracepoint) (TypeError)
```

However I have no idea how to write a regression test, because as long as `ObjectSpace.trace_object_allocations_start` was called at least once in the program, it no longer fails. So in the test suite ensuring that `ObjectSpace.trace_object_allocations_start` wasn't called seems impossible.

cc @XrXr 
