### PR TITLE
fix: warnflags bug

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -1,6 +1,6 @@
-# generated automatically by aclocal 1.16.2 -*- Autoconf -*-
+# generated automatically by aclocal 1.15.1 -*- Autoconf -*-
 
-# Copyright (C) 1996-2020 Free Software Foundation, Inc.
+# Copyright (C) 1996-2017 Free Software Foundation, Inc.
 
 # This file is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,

--- a/configure.ac
+++ b/configure.ac
@@ -3664,7 +3664,7 @@ AS_IF([test "${ARCH_FLAG}"], [
     LDFLAGS=`echo "$LDFLAGS" | sed "s| *$archflagpat"'||'`
 ])
 rb_cv_warnflags=`echo "$rb_cv_warnflags" | sed 's/^ *//;s/ *$//'`
-warnflags="$rb_cv_warnflags"
+warnflags="$warnflags $rb_cv_warnflags"
 AC_SUBST(cppflags)dnl
 AC_SUBST(cflags, ["${orig_cflags:+$orig_cflags }"'${optflags} ${debugflags} ${warnflags}'])dnl
 AC_SUBST(cxxflags)dnl

--- a/template/Makefile.in
+++ b/template/Makefile.in
@@ -82,7 +82,7 @@ CFLAGS = $(CFLAGS_NO_ARCH) $(ARCH_FLAG)
 cflags = @cflags@
 optflags = @optflags@
 debugflags = @debugflags@
-warnflags = @warnflags@ @strict_warnflags@
+warnflags = @warnflags@
 cppflags = @cppflags@
 MATHN = @MATHN@
 XCFLAGS = @XCFLAGS@ $(MATHN:yes=-DCANONICALIZATION_FOR_MATHN) $(INCFLAGS)


### PR DESCRIPTION
I have build ruby in alpine linux. And I got following error.

---
compiling ../../../../../ruby/ext/-test-/arith_seq/extract/extract.c                      
In file included from ../../../../../ruby/include/ruby/defines.h:157,                             
                 from ../../../../../ruby/include/ruby/ruby.h:29,                                               
                 from ../../../../../ruby/ext/-test-/arith_seq/extract/extract.c:1:                            
../../../../.ext/include/x86_64-linux-musl/ruby/config.h:135:25: error: expected '{' before '_Alignas'
 #define RUBY_ALIGNAS(x) alignas(x)                                            
                         ^~~~~~~      
...

---

I checked this failure cause, and I found the following.
1. In the configuring, '-std=gnu99' is included in CFLAGS.
2. In the building, '-std=gnu99' is not included in CFLAGS.

I changed the configure.ac. '-std=gnu99' is now included in CFLAGS in building.