### PR TITLE
reduce duplicate include.

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -3878,7 +3878,6 @@ dir.$(OBJEXT): {$(VPATH)}3/variable.h
 dir.$(OBJEXT): {$(VPATH)}3/warning_push.h
 dir.$(OBJEXT): {$(VPATH)}3/xmalloc.h
 dir.$(OBJEXT): {$(VPATH)}assert.h
-dir.$(OBJEXT): {$(VPATH)}builtin.h
 dir.$(OBJEXT): {$(VPATH)}backward/2/assume.h
 dir.$(OBJEXT): {$(VPATH)}backward/2/attributes.h
 dir.$(OBJEXT): {$(VPATH)}backward/2/bool.h
@@ -3891,6 +3890,7 @@ dir.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 dir.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 dir.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 dir.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
+dir.$(OBJEXT): {$(VPATH)}builtin.h
 dir.$(OBJEXT): {$(VPATH)}config.h
 dir.$(OBJEXT): {$(VPATH)}defines.h
 dir.$(OBJEXT): {$(VPATH)}dir.c
@@ -5416,6 +5416,10 @@ explicit_bzero.$(OBJEXT): {$(VPATH)}3/compiler_is/sunpro.h
 explicit_bzero.$(OBJEXT): {$(VPATH)}3/compiler_since.h
 explicit_bzero.$(OBJEXT): {$(VPATH)}3/config.h
 explicit_bzero.$(OBJEXT): {$(VPATH)}3/dllexport.h
+explicit_bzero.$(OBJEXT): {$(VPATH)}3/has/attribute.h
+explicit_bzero.$(OBJEXT): {$(VPATH)}3/has/warning.h
+explicit_bzero.$(OBJEXT): {$(VPATH)}3/token_paste.h
+explicit_bzero.$(OBJEXT): {$(VPATH)}3/warning_push.h
 explicit_bzero.$(OBJEXT): {$(VPATH)}config.h
 explicit_bzero.$(OBJEXT): {$(VPATH)}explicit_bzero.c
 explicit_bzero.$(OBJEXT): {$(VPATH)}missing.h
@@ -11778,6 +11782,10 @@ ruby-runner.$(OBJEXT): {$(VPATH)}3/compiler_is/msvc.h
 ruby-runner.$(OBJEXT): {$(VPATH)}3/compiler_is/sunpro.h
 ruby-runner.$(OBJEXT): {$(VPATH)}3/compiler_since.h
 ruby-runner.$(OBJEXT): {$(VPATH)}3/config.h
+ruby-runner.$(OBJEXT): {$(VPATH)}3/has/attribute.h
+ruby-runner.$(OBJEXT): {$(VPATH)}3/has/warning.h
+ruby-runner.$(OBJEXT): {$(VPATH)}3/token_paste.h
+ruby-runner.$(OBJEXT): {$(VPATH)}3/warning_push.h
 ruby-runner.$(OBJEXT): {$(VPATH)}config.h
 ruby-runner.$(OBJEXT): {$(VPATH)}ruby-runner.c
 ruby-runner.$(OBJEXT): {$(VPATH)}ruby-runner.h
@@ -13081,6 +13089,10 @@ strlcat.$(OBJEXT): {$(VPATH)}3/compiler_is/sunpro.h
 strlcat.$(OBJEXT): {$(VPATH)}3/compiler_since.h
 strlcat.$(OBJEXT): {$(VPATH)}3/config.h
 strlcat.$(OBJEXT): {$(VPATH)}3/dllexport.h
+strlcat.$(OBJEXT): {$(VPATH)}3/has/attribute.h
+strlcat.$(OBJEXT): {$(VPATH)}3/has/warning.h
+strlcat.$(OBJEXT): {$(VPATH)}3/token_paste.h
+strlcat.$(OBJEXT): {$(VPATH)}3/warning_push.h
 strlcat.$(OBJEXT): {$(VPATH)}config.h
 strlcat.$(OBJEXT): {$(VPATH)}missing.h
 strlcat.$(OBJEXT): {$(VPATH)}strlcat.c
@@ -13094,6 +13106,10 @@ strlcpy.$(OBJEXT): {$(VPATH)}3/compiler_is/sunpro.h
 strlcpy.$(OBJEXT): {$(VPATH)}3/compiler_since.h
 strlcpy.$(OBJEXT): {$(VPATH)}3/config.h
 strlcpy.$(OBJEXT): {$(VPATH)}3/dllexport.h
+strlcpy.$(OBJEXT): {$(VPATH)}3/has/attribute.h
+strlcpy.$(OBJEXT): {$(VPATH)}3/has/warning.h
+strlcpy.$(OBJEXT): {$(VPATH)}3/token_paste.h
+strlcpy.$(OBJEXT): {$(VPATH)}3/warning_push.h
 strlcpy.$(OBJEXT): {$(VPATH)}config.h
 strlcpy.$(OBJEXT): {$(VPATH)}missing.h
 strlcpy.$(OBJEXT): {$(VPATH)}strlcpy.c

--- a/include/ruby/3/anyargs.h
+++ b/include/ruby/3/anyargs.h
@@ -72,7 +72,6 @@
 #include "ruby/3/attr/weakref.h"
 #include "ruby/3/cast.h"
 #include "ruby/3/config.h"
-#include "ruby/3/has/attribute.h"
 #include "ruby/3/intern/class.h"
 #include "ruby/3/intern/vm.h"
 #include "ruby/3/method.h"

--- a/include/ruby/3/arithmetic/int.h
+++ b/include/ruby/3/arithmetic/int.h
@@ -31,7 +31,6 @@
 #include "ruby/3/dllexport.h"
 #include "ruby/3/special_consts.h"
 #include "ruby/3/value.h"
-#include "ruby/3/warning_push.h"
 #include "ruby/assert.h"
 
 #define RB_INT2NUM  rb_int2num_inline

--- a/include/ruby/3/assume.h
+++ b/include/ruby/3/assume.h
@@ -27,7 +27,6 @@
 #define  RUBY3_ASSUME_H
 #include "ruby/3/config.h"
 #include "ruby/3/cast.h"
-#include "ruby/3/compiler_since.h"
 #include "ruby/3/has/builtin.h"
 
 /** @cond INTERNAL_MACRO */

--- a/include/ruby/3/attr/alloc_size.h
+++ b/include/ruby/3/attr/alloc_size.h
@@ -18,7 +18,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines #RUBY3_ATTR_ALLOC_SIZE.
  */
-#include "ruby/3/has/attribute.h"
 
 /** Wraps (or simulates) `__attribute__((alloc_size))` */
 #if defined(RUBY3_ATTR_ALLOC_SIZE)

--- a/include/ruby/3/attr/artificial.h
+++ b/include/ruby/3/attr/artificial.h
@@ -32,7 +32,6 @@
  *      case it gets  vital to know where the inlining  happened in the callee.
  *      See also https://stackoverflow.com/a/21936099
  */
-#include "ruby/3/has/attribute.h"
 
 /** Wraps (or simulates) `__attribute__((artificial))` */
 #if defined(RUBY3_ATTR_ARTIFICIAL)

--- a/include/ruby/3/attr/cold.h
+++ b/include/ruby/3/attr/cold.h
@@ -19,7 +19,6 @@
  * @brief      Defines #RUBY3_ATTR_COLD.
  */
 #include "ruby/3/compiler_is.h"
-#include "ruby/3/has/attribute.h"
 
 /** Wraps (or simulates) `__attribute__((cold))` */
 #if defined(RUBY3_ATTR_COLD)

--- a/include/ruby/3/attr/const.h
+++ b/include/ruby/3/attr/const.h
@@ -18,8 +18,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines #RUBY3_ATTR_CONST.
  */
-#include "ruby/3/compiler_since.h"
-#include "ruby/3/has/attribute.h"
 #include "ruby/3/has/declspec_attribute.h"
 
 /** Wraps (or simulates) `__attribute__((const))` */

--- a/include/ruby/3/attr/constexpr.h
+++ b/include/ruby/3/attr/constexpr.h
@@ -20,7 +20,6 @@
  */
 #include "ruby/3/has/feature.h"
 #include "ruby/3/compiler_is.h"
-#include "ruby/3/token_paste.h"
 
 /** @cond INTERNAL_MACRO*/
 #if defined(RUBY3_ATTR_CONSTEXPR)

--- a/include/ruby/3/attr/deprecated.h
+++ b/include/ruby/3/attr/deprecated.h
@@ -18,8 +18,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines #RUBY3_ATTR_DEPRECATED.
  */
-#include "ruby/3/compiler_since.h"
-#include "ruby/3/has/attribute.h"
 #include "ruby/3/has/c_attribute.h"
 #include "ruby/3/has/cpp_attribute.h"
 #include "ruby/3/has/declspec_attribute.h"

--- a/include/ruby/3/attr/diagnose_if.h
+++ b/include/ruby/3/attr/diagnose_if.h
@@ -18,8 +18,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines #RUBY3_ATTR_DIAGNOSE_IF.
  */
-#include "ruby/3/has/attribute.h"
-#include "ruby/3/warning_push.h"
 
 /** Wraps (or simulates) `__attribute__((diagnose_if))` */
 #if defined(RUBY3_ATTR_DIAGNOSE_IF)

--- a/include/ruby/3/attr/enum_extensibility.h
+++ b/include/ruby/3/attr/enum_extensibility.h
@@ -18,7 +18,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      #RUBY3_ATTR_ENUM_EXTENSIBILITY.
  */
-#include "ruby/3/has/attribute.h"
 
 /** Wraps (or simulates) `__attribute__((enum_extensibility))` */
 #if defined(RUBY3_ATTR_ENUM_EXTENSIBILITY)

--- a/include/ruby/3/attr/error.h
+++ b/include/ruby/3/attr/error.h
@@ -18,7 +18,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines #RUBY3_ATTR_ERROR.
  */
-#include "ruby/3/has/attribute.h"
 
 /** Wraps (or simulates) `__attribute__((error))` */
 #if defined(RUBY3_ATTR_ERROR)

--- a/include/ruby/3/attr/flag_enum.h
+++ b/include/ruby/3/attr/flag_enum.h
@@ -19,7 +19,6 @@
  * @brief      Defines #RUBY3_ATTR_FLAG_ENUM.
  * @see        https://clang.llvm.org/docs/AttributeReference.html#flag_enum
  */
-#include "ruby/3/has/attribute.h"
 
 /** Wraps (or simulates) `__attribute__((flag_enum)` */
 #if defined(RUBY3_ATTR_FLAG_ENUM)

--- a/include/ruby/3/attr/forceinline.h
+++ b/include/ruby/3/attr/forceinline.h
@@ -18,8 +18,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines #RUBY3_ATTR_FORCEINLINE.
  */
-#include "ruby/3/compiler_since.h"
-#include "ruby/3/has/attribute.h"
 
 /**
  * Wraps (or  simulates) `__forceinline`.  MSVC complains  on declarations like

--- a/include/ruby/3/attr/format.h
+++ b/include/ruby/3/attr/format.h
@@ -18,7 +18,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines #RUBY3_ATTR_FORMAT.
  */
-#include "ruby/3/has/attribute.h"
 
 /** Wraps (or simulates) `__attribute__((format))` */
 #if defined(RUBY3_ATTR_FORMAT)

--- a/include/ruby/3/attr/maybe_unused.h
+++ b/include/ruby/3/attr/maybe_unused.h
@@ -18,7 +18,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines #RUBY3_ATTR_MAYBE_UNUSED.
  */
-#include "ruby/3/has/attribute.h"
 #include "ruby/3/has/c_attribute.h"
 #include "ruby/3/has/cpp_attribute.h"
 

--- a/include/ruby/3/attr/nodiscard.h
+++ b/include/ruby/3/attr/nodiscard.h
@@ -18,7 +18,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines #RUBY3_ATTR_NODISCARD.
  */
-#include "ruby/3/has/attribute.h"
 #include "ruby/3/has/c_attribute.h"
 #include "ruby/3/has/cpp_attribute.h"
 

--- a/include/ruby/3/attr/noexcept.h
+++ b/include/ruby/3/attr/noexcept.h
@@ -59,7 +59,6 @@
  *       Itanium C++ ABI has zero-cost  exception handling), but does impact on
  *       generated binary size.  This is bad.
  */
-#include "ruby/3/compiler_since.h"
 #include "ruby/3/has/feature.h"
 
 /** Wraps (or simulates) C++11 `noexcept` */

--- a/include/ruby/3/attr/noinline.h
+++ b/include/ruby/3/attr/noinline.h
@@ -18,7 +18,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines #RUBY3_ATTR_NOINLINE.
  */
-#include "ruby/3/has/attribute.h"
 #include "ruby/3/has/declspec_attribute.h"
 
 /** Wraps (or simulates) `__declspec(noinline)` */

--- a/include/ruby/3/attr/nonnull.h
+++ b/include/ruby/3/attr/nonnull.h
@@ -18,7 +18,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines #RUBY3_ATTR_NONNULL.
  */
-#include "ruby/3/has/attribute.h"
 
 /** Wraps (or simulates) `__attribute__((nonnull))` */
 #if defined(RUBY3_ATTR_NONNULL)

--- a/include/ruby/3/attr/noreturn.h
+++ b/include/ruby/3/attr/noreturn.h
@@ -18,8 +18,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines #RUBY3_ATTR_NORETURN.
  */
-#include "ruby/3/compiler_since.h"
-#include "ruby/3/has/attribute.h"
 #include "ruby/3/has/cpp_attribute.h"
 #include "ruby/3/has/declspec_attribute.h"
 

--- a/include/ruby/3/attr/pure.h
+++ b/include/ruby/3/attr/pure.h
@@ -18,8 +18,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines #RUBY3_ATTR_PURE.
  */
-#include "ruby/3/compiler_since.h"
-#include "ruby/3/has/attribute.h"
 #include "ruby/assert.h"
 
 /** Wraps (or simulates) `__attribute__((pure))` */

--- a/include/ruby/3/attr/restrict.h
+++ b/include/ruby/3/attr/restrict.h
@@ -18,9 +18,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines #RUBY3_ATTR_RESTRICT.
  */
-#include "ruby/3/compiler_since.h"
-#include "ruby/3/has/attribute.h"
-#include "ruby/3/token_paste.h"
 
 /* :FIXME:  config.h  includes conflicting  `#define  restrict`.   MSVC can  be
  * detected  using  `RUBY3_COMPILER_SINCE()`, but  Clang  &  family cannot  use

--- a/include/ruby/3/attr/returns_nonnull.h
+++ b/include/ruby/3/attr/returns_nonnull.h
@@ -18,7 +18,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines #RUBY3_ATTR_RETURNS_NONNULL.
  */
-#include "ruby/3/has/attribute.h"
 
 /** Wraps (or simulates) `__attribute__((returns_nonnull))` */
 #if defined(RUBY3_ATTR_RETURNS_NONNULL)

--- a/include/ruby/3/attr/warning.h
+++ b/include/ruby/3/attr/warning.h
@@ -18,7 +18,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines #RUBY3_ATTR_WARNING.
  */
-#include "ruby/3/has/attribute.h"
 
 /** Wraps (or simulates) `__attribute__((warning))` */
 #if defined(RUBY3_ATTR_WARNING)

--- a/include/ruby/3/attr/weakref.h
+++ b/include/ruby/3/attr/weakref.h
@@ -18,7 +18,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines #RUBY3_ATTR_WEAKREF.
  */
-#include "ruby/3/has/attribute.h"
 
 /** Wraps (or simulates) `__attribute__((weakref))` */
 #if defined(RUBY3_ATTR_WEAKREF)

--- a/include/ruby/3/cast.h
+++ b/include/ruby/3/cast.h
@@ -23,9 +23,6 @@
  * public headers.  They could be used  from C++, and C-style casts could issue
  * warnings.  Ruby internals are pure C so they should not bother.
  */
-#include "ruby/3/compiler_since.h"
-#include "ruby/3/has/warning.h"
-#include "ruby/3/warning_push.h"
 
 #if defined(RUBY3_CAST)
 # /* Take that. */

--- a/include/ruby/3/compiler_is.h
+++ b/include/ruby/3/compiler_is.h
@@ -25,6 +25,9 @@
  * @retval  true   It is.
  * @retval  false  It isn't.
  */
+#ifndef RUBY3_COMPILER_IS_INCLUDED
+#define RUBY3_COMPILER_IS_INCLUDED
+
 #ifndef RUBY3_COMPILER_IS
 # define RUBY3_COMPILER_IS(cc) RUBY3_COMPILER_IS_ ## cc
 #endif
@@ -41,3 +44,5 @@
  *   Apple's might be needed.
  *
  * - ARM's armclang: ditto, it can be clang-backended.  */
+
+#endif // RUBY3_COMPILER_IS_INCLUDED

--- a/include/ruby/3/config.h
+++ b/include/ruby/3/config.h
@@ -27,6 +27,10 @@
 #endif
 
 #include "ruby/3/compiler_since.h"
+#include "ruby/3/has/warning.h"
+#include "ruby/3/has/attribute.h"
+#include "ruby/3/warning_push.h"
+#include "ruby/3/token_paste.h"
 
 #if defined(__cplusplus)
 #/* __builtin_choose_expr and __builtin_types_compatible aren't available

--- a/include/ruby/3/core/rdata.h
+++ b/include/ruby/3/core/rdata.h
@@ -32,7 +32,6 @@
 #include "ruby/3/core/rbasic.h"
 #include "ruby/3/dllexport.h"
 #include "ruby/3/fl_type.h"
-#include "ruby/3/token_paste.h"
 #include "ruby/3/value.h"
 #include "ruby/3/value_type.h"
 #include "ruby/defines.h"

--- a/include/ruby/3/has/attribute.h
+++ b/include/ruby/3/has/attribute.h
@@ -19,8 +19,6 @@
  * @brief      Defines #RUBY3_HAS_ATTRIBUTE.
  */
 #include "ruby/3/config.h"
-#include "ruby/3/compiler_since.h"
-#include "ruby/3/token_paste.h"
 
 /** Wraps (or simulates) `__has_attribute`. */
 #if defined(RUBY3_HAS_ATTRIBUTE)

--- a/include/ruby/3/has/builtin.h
+++ b/include/ruby/3/has/builtin.h
@@ -19,8 +19,6 @@
  * @brief      Defines #RUBY3_HAS_BUILTIN.
  */
 #include "ruby/3/config.h"
-#include "ruby/3/compiler_since.h"
-#include "ruby/3/token_paste.h"
 
 /** Wraps (or simulates) `__has_builtin`. */
 #if defined(RUBY3_HAS_BUILTIN)

--- a/include/ruby/3/has/cpp_attribute.h
+++ b/include/ruby/3/has/cpp_attribute.h
@@ -19,8 +19,6 @@
  * @brief      Defines #RUBY3_HAS_CPP_ATTRIBUTE.
  */
 #include "ruby/3/compiler_is.h"
-#include "ruby/3/compiler_since.h"
-#include "ruby/3/token_paste.h"
 
 /** @cond INTERNAL_MACRO */
 #if defined(RUBY3_HAS_CPP_ATTRIBUTE0)

--- a/include/ruby/3/has/declspec_attribute.h
+++ b/include/ruby/3/has/declspec_attribute.h
@@ -18,8 +18,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines #RUBY3_HAS_DECLSPEC_ATTRIBUTE.
  */
-#include "ruby/3/compiler_since.h"
-#include "ruby/3/token_paste.h"
 
 /** Wraps (or simulates) `__has_declspec_attribute`. */
 #if defined(RUBY3_HAS_DECLSPEC_ATTRIBUTE)

--- a/include/ruby/3/static_assert.h
+++ b/include/ruby/3/static_assert.h
@@ -20,7 +20,6 @@
  */
 #include <assert.h>
 #include "ruby/3/has/extension.h"
-#include "ruby/3/compiler_since.h"
 
 /** @cond INTERNAL_MACRO */
 #if defined(RUBY3_STATIC_ASSERT0)

--- a/include/ruby/3/stdalign.h
+++ b/include/ruby/3/stdalign.h
@@ -25,10 +25,8 @@
 #endif
 
 #include "ruby/3/compiler_is.h"
-#include "ruby/3/compiler_since.h"
 #include "ruby/3/has/feature.h"
 #include "ruby/3/has/extension.h"
-#include "ruby/3/has/attribute.h"
 #include "ruby/3/has/declspec_attribute.h"
 
 /**

--- a/include/ruby/3/token_paste.h
+++ b/include/ruby/3/token_paste.h
@@ -19,9 +19,6 @@
  * @brief      Defines #RUBY3_TOKEN_PASTE.
  */
 #include "ruby/3/config.h"
-#include "ruby/3/compiler_since.h"
-#include "ruby/3/has/warning.h"
-#include "ruby/3/warning_push.h"
 
 /* :TODO: add your  compiler here.  There are many compilers  that can suppress
  * warnings via pragmas, but not all of them accept such things inside of `#if`

--- a/include/ruby/3/warning_push.h
+++ b/include/ruby/3/warning_push.h
@@ -42,7 +42,6 @@
  *    ```
  */
 #include "ruby/3/compiler_is.h"
-#include "ruby/3/compiler_since.h"
 
 #ifdef RUBY3_WARNING_PUSH
 # /* Take that. */

--- a/include/ruby/backward/2/gcc_version_since.h
+++ b/include/ruby/backward/2/gcc_version_since.h
@@ -18,7 +18,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines old #GCC_VERSION_SINCE
  */
-#include "ruby/3/compiler_since.h"
 
 #ifndef GCC_VERSION_SINCE
 #define GCC_VERSION_SINCE(x, y, z) RUBY3_COMPILER_SINCE(GCC, (x), (y), (z))

--- a/include/ruby/backward/2/long_long.h
+++ b/include/ruby/backward/2/long_long.h
@@ -24,8 +24,6 @@
  * compatibility only.
  */
 #include "ruby/3/config.h"
-#include "ruby/3/has/warning.h"
-#include "ruby/3/warning_push.h"
 
 #if defined(LONG_LONG)
 # /* Take that. */


### PR DESCRIPTION
Without this patch, 20k files are opened (openat syscall) because
of duplicate includes. This patch reduced it to 3k and build time
was reduced compile time of range.o from 15sec -> 3sec on my machine.
[Bug #16772]