### PR TITLE
Avoid UB with flexible array member

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -3951,7 +3951,7 @@ compile_keyword_arg(rb_iseq_t *iseq, LINK_ANCHOR *const ret,
 	{
 	    int len = (int)node->nd_alen / 2;
             struct rb_callinfo_kwarg *kw_arg =
-                rb_xmalloc_mul_add(len - 1, sizeof(VALUE), sizeof(struct rb_callinfo_kwarg));
+                rb_xmalloc_mul_add(len, sizeof(VALUE), sizeof(struct rb_callinfo_kwarg));
 	    VALUE *keywords = kw_arg->keywords;
 	    int i = 0;
 	    kw_arg->keyword_len = len;
@@ -10394,7 +10394,7 @@ ibf_load_ci_entries(const struct ibf_load *load,
             struct rb_callinfo_kwarg *kwarg = NULL;
             int kwlen = (int)ibf_load_small_value(load, &reading_pos);
             if (kwlen > 0) {
-                kwarg = rb_xmalloc_mul_add(kwlen - 1, sizeof(VALUE), sizeof(struct rb_callinfo_kwarg));;
+                kwarg = rb_xmalloc_mul_add(kwlen, sizeof(VALUE), sizeof(struct rb_callinfo_kwarg));
                 kwarg->keyword_len = kwlen;
                 for (int j=0; j<kwlen; j++) {
                     VALUE keyword = ibf_load_small_value(load, &reading_pos);

--- a/vm_callinfo.h
+++ b/vm_callinfo.h
@@ -33,14 +33,14 @@ enum vm_call_flag_bits {
 
 struct rb_callinfo_kwarg {
     int keyword_len;
-    VALUE keywords[1];
+    VALUE keywords[];
 };
 
 static inline size_t
 rb_callinfo_kwarg_bytes(int keyword_len)
 {
     return rb_size_mul_add_or_raise(
-        keyword_len - 1,
+        keyword_len,
         sizeof(VALUE),
         sizeof(struct rb_callinfo_kwarg),
         rb_eRuntimeError);


### PR DESCRIPTION
Accessing past the end of an array is technically UB. Use C99 flexible
array member instead to avoid the UB and simplify allocation size
calculation.

See also: DCL38-C in the SEI CERT C Coding Standard