### PR TITLE
Remove read_timeout changes to Net::FTP storlines and storbinary

### DIFF
--- a/lib/net/ftp.rb
+++ b/lib/net/ftp.rb
@@ -689,8 +689,6 @@ module Net
               yield(buf) if block_given?
             end
             conn.shutdown(Socket::SHUT_WR)
-            conn.read_timeout = 1
-            conn.read
           ensure
             conn.close if conn
           end
@@ -725,8 +723,6 @@ module Net
               yield(buf) if block_given?
             end
             conn.shutdown(Socket::SHUT_WR)
-            conn.read_timeout = 1
-            conn.read
           ensure
             conn.close if conn
           end


### PR DESCRIPTION
Issue written up here: https://bugs.ruby-lang.org/issues/16780

These changes were introduced in Ruby 2.7.0 due to [this issue](https://bugs.ruby-lang.org/issues/16413), and [this commit](https://github.com/ruby/ruby/commit/5be34d6a3310065850c0c530db6936415124b5d9).

We immediately started seeing `Net::ReadTimeout` exceptions from `Net::FTP#put` being throw in our application after upgrading from ruby 2.6.5 to 2.7.1. I believe this will fix it. It's not clear why the `read_timeout` change was introduced, other than the same logic is seen in `#retrbinary` and `#retrlines`.