### PR TITLE
Enable fastpath on invokesuper

### DIFF
--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -3032,7 +3032,7 @@ vm_call_method_each_type(rb_execution_context_t *ec, rb_control_frame_t *cfp, st
 
       case VM_METHOD_TYPE_REFINED:
         // CC_SET_FASTPATH(cc, vm_call_refined, TRUE);
-        // should not set FASTPATH because vm_call_refined check cc->call.
+        // should not set FASTPATH since vm_call_refined assumes cc->call is vm_call_super_method on invokesuper.
         return vm_call_refined(ec, cfp, calling, cd);
     }
 
@@ -3223,7 +3223,7 @@ vm_search_super_method(const rb_control_frame_t *reg_cfp, struct rb_call_data *c
             RB_OBJ_WRITE(reg_cfp->iseq, &cd->cc, cc);
         }
         else if (cached_cme->def->type == VM_METHOD_TYPE_REFINED) {
-            // vm_call_refined checks cc->call
+            // vm_call_refined (search_refined_method) assumes cc->call is vm_call_super_method on invokesuper.
             vm_cc_call_set(cd->cc, vm_call_super_method);
         }
     }

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -3222,7 +3222,8 @@ vm_search_super_method(const rb_control_frame_t *reg_cfp, struct rb_call_data *c
             const struct rb_callcache *cc = vm_cc_new(klass, cme, vm_call_super_method);
             RB_OBJ_WRITE(reg_cfp->iseq, &cd->cc, cc);
         }
-        else {
+        else if (cached_cme->def->type == VM_METHOD_TYPE_REFINED) {
+            // vm_call_refined checks cc->call
             vm_cc_call_set(cd->cc, vm_call_super_method);
         }
     }


### PR DESCRIPTION
```
$ benchmark-driver -v --rbenv 'before;after' benchmark/vm2_super.yml --repeat-count=4
before: ruby 2.8.0dev (2020-04-11T15:19:58Z master a01bda5949) [x86_64-linux]
after: ruby 2.8.0dev (2020-04-12T02:00:08Z invokesuper-fastpath c171984ee3) [x86_64-linux]
Calculating -------------------------------------
                         before       after
           vm2_super    20.031M     32.860M i/s -      6.000M times in 0.299534s 0.182593s

Comparison:
                        vm2_super
               after:  32859885.2 i/s
              before:  20031097.3 i/s - 1.64x  slower
```