### PR TITLE
add #include guard hack

### DIFF
--- a/addr2line.h
+++ b/addr2line.h
@@ -1,3 +1,5 @@
+#ifndef RUBY_ADDR2LINE_H
+#define RUBY_ADDR2LINE_H
 /**********************************************************************
 
   addr2line.h -
@@ -7,9 +9,6 @@
   Copyright (C) 2010 Shinichiro Hamaji
 
 **********************************************************************/
-
-#ifndef RUBY_ADDR2LINE_H
-#define RUBY_ADDR2LINE_H
 
 #if (defined(USE_ELF) || defined(HAVE_MACH_O_LOADER_H))
 

--- a/common.mk
+++ b/common.mk
@@ -3878,6 +3878,7 @@ dir.$(OBJEXT): {$(VPATH)}3/variable.h
 dir.$(OBJEXT): {$(VPATH)}3/warning_push.h
 dir.$(OBJEXT): {$(VPATH)}3/xmalloc.h
 dir.$(OBJEXT): {$(VPATH)}assert.h
+dir.$(OBJEXT): {$(VPATH)}builtin.h
 dir.$(OBJEXT): {$(VPATH)}backward/2/assume.h
 dir.$(OBJEXT): {$(VPATH)}backward/2/attributes.h
 dir.$(OBJEXT): {$(VPATH)}backward/2/bool.h
@@ -3890,7 +3891,6 @@ dir.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 dir.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 dir.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 dir.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
-dir.$(OBJEXT): {$(VPATH)}builtin.h
 dir.$(OBJEXT): {$(VPATH)}config.h
 dir.$(OBJEXT): {$(VPATH)}defines.h
 dir.$(OBJEXT): {$(VPATH)}dir.c
@@ -5416,10 +5416,6 @@ explicit_bzero.$(OBJEXT): {$(VPATH)}3/compiler_is/sunpro.h
 explicit_bzero.$(OBJEXT): {$(VPATH)}3/compiler_since.h
 explicit_bzero.$(OBJEXT): {$(VPATH)}3/config.h
 explicit_bzero.$(OBJEXT): {$(VPATH)}3/dllexport.h
-explicit_bzero.$(OBJEXT): {$(VPATH)}3/has/attribute.h
-explicit_bzero.$(OBJEXT): {$(VPATH)}3/has/warning.h
-explicit_bzero.$(OBJEXT): {$(VPATH)}3/token_paste.h
-explicit_bzero.$(OBJEXT): {$(VPATH)}3/warning_push.h
 explicit_bzero.$(OBJEXT): {$(VPATH)}config.h
 explicit_bzero.$(OBJEXT): {$(VPATH)}explicit_bzero.c
 explicit_bzero.$(OBJEXT): {$(VPATH)}missing.h
@@ -11782,10 +11778,6 @@ ruby-runner.$(OBJEXT): {$(VPATH)}3/compiler_is/msvc.h
 ruby-runner.$(OBJEXT): {$(VPATH)}3/compiler_is/sunpro.h
 ruby-runner.$(OBJEXT): {$(VPATH)}3/compiler_since.h
 ruby-runner.$(OBJEXT): {$(VPATH)}3/config.h
-ruby-runner.$(OBJEXT): {$(VPATH)}3/has/attribute.h
-ruby-runner.$(OBJEXT): {$(VPATH)}3/has/warning.h
-ruby-runner.$(OBJEXT): {$(VPATH)}3/token_paste.h
-ruby-runner.$(OBJEXT): {$(VPATH)}3/warning_push.h
 ruby-runner.$(OBJEXT): {$(VPATH)}config.h
 ruby-runner.$(OBJEXT): {$(VPATH)}ruby-runner.c
 ruby-runner.$(OBJEXT): {$(VPATH)}ruby-runner.h
@@ -13089,10 +13081,6 @@ strlcat.$(OBJEXT): {$(VPATH)}3/compiler_is/sunpro.h
 strlcat.$(OBJEXT): {$(VPATH)}3/compiler_since.h
 strlcat.$(OBJEXT): {$(VPATH)}3/config.h
 strlcat.$(OBJEXT): {$(VPATH)}3/dllexport.h
-strlcat.$(OBJEXT): {$(VPATH)}3/has/attribute.h
-strlcat.$(OBJEXT): {$(VPATH)}3/has/warning.h
-strlcat.$(OBJEXT): {$(VPATH)}3/token_paste.h
-strlcat.$(OBJEXT): {$(VPATH)}3/warning_push.h
 strlcat.$(OBJEXT): {$(VPATH)}config.h
 strlcat.$(OBJEXT): {$(VPATH)}missing.h
 strlcat.$(OBJEXT): {$(VPATH)}strlcat.c
@@ -13106,10 +13094,6 @@ strlcpy.$(OBJEXT): {$(VPATH)}3/compiler_is/sunpro.h
 strlcpy.$(OBJEXT): {$(VPATH)}3/compiler_since.h
 strlcpy.$(OBJEXT): {$(VPATH)}3/config.h
 strlcpy.$(OBJEXT): {$(VPATH)}3/dllexport.h
-strlcpy.$(OBJEXT): {$(VPATH)}3/has/attribute.h
-strlcpy.$(OBJEXT): {$(VPATH)}3/has/warning.h
-strlcpy.$(OBJEXT): {$(VPATH)}3/token_paste.h
-strlcpy.$(OBJEXT): {$(VPATH)}3/warning_push.h
 strlcpy.$(OBJEXT): {$(VPATH)}config.h
 strlcpy.$(OBJEXT): {$(VPATH)}missing.h
 strlcpy.$(OBJEXT): {$(VPATH)}strlcpy.c

--- a/constant.h
+++ b/constant.h
@@ -1,3 +1,5 @@
+#ifndef CONSTANT_H
+#define CONSTANT_H
 /**********************************************************************
 
   constant.h -
@@ -8,8 +10,6 @@
   Copyright (C) 2009 Yusuke Endoh
 
 **********************************************************************/
-#ifndef CONSTANT_H
-#define CONSTANT_H
 #include "ruby/ruby.h"
 #include "id_table.h"
 

--- a/dln.h
+++ b/dln.h
@@ -1,3 +1,5 @@
+#ifndef DLN_H
+#define DLN_H
 /**********************************************************************
 
   dln.h -
@@ -9,8 +11,6 @@
 
 **********************************************************************/
 
-#ifndef DLN_H
-#define DLN_H
 #include "ruby/defines.h"       /* for RUBY_SYMBOL_EXPORT_BEGIN */
 
 #ifdef __cplusplus

--- a/encindex.h
+++ b/encindex.h
@@ -1,3 +1,5 @@
+#ifndef RUBY_ENCINDEX_H
+#define RUBY_ENCINDEX_H 1
 /**********************************************************************
 
   encindex.h -
@@ -9,8 +11,6 @@
 
 **********************************************************************/
 
-#ifndef RUBY_ENCINDEX_H
-#define RUBY_ENCINDEX_H 1
 #include "ruby/encoding.h"      /* rb_ascii8bit_encindex etc. */
 #if defined(__cplusplus)
 extern "C" {

--- a/include/ruby.h
+++ b/include/ruby.h
@@ -1,17 +1,15 @@
-/**********************************************************************
-
-  ruby.h -
-
-  $Author$
-  created at: Sun 10 12:06:15 Jun JST 2007
-
-  Copyright (C) 2007-2008 Yukihiro Matsumoto
-
-**********************************************************************/
-
-#ifndef RUBY_H
+#ifndef RUBY_H                                       /*-*-C++-*-vi:se ft=cpp:*/
 #define RUBY_H 1
-
+/**
+ * @file
+ * @author     $Author$
+ * @date       Sun 10 12:06:15 Jun JST 2007
+ * @copyright  2007-2008 Yukihiro Matsumoto
+ * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
+ *             Permission  is hereby  granted,  to  either redistribute  and/or
+ *             modify this file, provided that  the conditions mentioned in the
+ *             file COPYING are met.  Consult the file for details.
+ */
 #define HAVE_RUBY_DEFINES_H     1
 #define HAVE_RUBY_ENCODING_H    1
 #define HAVE_RUBY_INTERN_H      1

--- a/include/ruby/3/anyargs.h
+++ b/include/ruby/3/anyargs.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_ANYARGS_H                              /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_ANYARGS_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -65,8 +67,6 @@
  *      `__builtin_types_compatible_p`, and in doing  so we need to distinguish
  *      ::rb_f_notimplement from others, by type.
  */
-#ifndef  RUBY3_ANYARGS_H
-#define  RUBY3_ANYARGS_H
 #include "ruby/3/attr/maybe_unused.h"
 #include "ruby/3/attr/nonnull.h"
 #include "ruby/3/attr/weakref.h"
@@ -371,4 +371,4 @@ RUBY3_ANYARGS_DECL(rb_define_method, VALUE, const char *)
 
 #endif
 
-#endif  /* RUBY3_ANYARGS_H */
+#endif /* RUBY3_ANYARGS_H */

--- a/include/ruby/3/anyargs.h
+++ b/include/ruby/3/anyargs.h
@@ -72,6 +72,7 @@
 #include "ruby/3/attr/weakref.h"
 #include "ruby/3/cast.h"
 #include "ruby/3/config.h"
+#include "ruby/3/has/attribute.h"
 #include "ruby/3/intern/class.h"
 #include "ruby/3/intern/vm.h"
 #include "ruby/3/method.h"

--- a/include/ruby/3/arithmetic.h
+++ b/include/ruby/3/arithmetic.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_ARITHMETIC_H                           /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_ARITHMETIC_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -33,3 +35,4 @@
 #include "ruby/3/arithmetic/size_t.h"
 #include "ruby/3/arithmetic/st_data_t.h"
 #include "ruby/3/arithmetic/uid_t.h"
+#endif /* RUBY3_ARITHMETIC_H */

--- a/include/ruby/3/arithmetic/char.h
+++ b/include/ruby/3/arithmetic/char.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_ARITHMETIC_CHAR_H                      /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_ARITHMETIC_CHAR_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Arithmetic conversion between C's `char` and Ruby's.
  */
-#ifndef  RUBY3_ARITHMETIC_CHAR_H
-#define  RUBY3_ARITHMETIC_CHAR_H
 #include "ruby/3/arithmetic/int.h"  /* NUM2INT is here, but */
 #include "ruby/3/arithmetic/long.h" /* INT2FIX is here.*/
 #include "ruby/3/attr/artificial.h"

--- a/include/ruby/3/arithmetic/double.h
+++ b/include/ruby/3/arithmetic/double.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_ARITHMETIC_DOUBLE_H                    /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_ARITHMETIC_DOUBLE_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Arithmetic conversion between C's `double` and Ruby's.
  */
-#ifndef  RUBY3_ARITHMETIC_DOUBLE_H
-#define  RUBY3_ARITHMETIC_DOUBLE_H
 #include "ruby/3/attr/pure.h"
 #include "ruby/3/dllexport.h"
 #include "ruby/3/value.h"

--- a/include/ruby/3/arithmetic/fixnum.h
+++ b/include/ruby/3/arithmetic/fixnum.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_ARITHMETIC_FIXNUM_H                    /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_ARITHMETIC_FIXNUM_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Handling of integers formerly known as Fixnums.
  */
-#ifndef  RUBY3_ARITHMETIC_FIXNUM_H
-#define  RUBY3_ARITHMETIC_FIXNUM_H
 #include "ruby/backward/2/limits.h"
 
 #define FIXABLE    RB_FIXABLE

--- a/include/ruby/3/arithmetic/gid_t.h
+++ b/include/ruby/3/arithmetic/gid_t.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_ARITHMETIC_GID_T_H                     /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_ARITHMETIC_GID_T_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -28,3 +30,5 @@
 #ifndef NUM2GIDT
 # define NUM2GIDT RB_NUM2LONG
 #endif
+
+#endif /* RUBY3_ARITHMETIC_GID_T_H */

--- a/include/ruby/3/arithmetic/int.h
+++ b/include/ruby/3/arithmetic/int.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_ARITHMETIC_INT_H                       /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_ARITHMETIC_INT_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Arithmetic conversion between C's `int` and Ruby's.
  */
-#ifndef  RUBY3_ARITHMETIC_INT_H
-#define  RUBY3_ARITHMETIC_INT_H
 #include "ruby/3/config.h"
 #include "ruby/3/arithmetic/fixnum.h"
 #include "ruby/3/arithmetic/intptr_t.h"

--- a/include/ruby/3/arithmetic/int.h
+++ b/include/ruby/3/arithmetic/int.h
@@ -31,6 +31,7 @@
 #include "ruby/3/dllexport.h"
 #include "ruby/3/special_consts.h"
 #include "ruby/3/value.h"
+#include "ruby/3/warning_push.h"
 #include "ruby/assert.h"
 
 #define RB_INT2NUM  rb_int2num_inline

--- a/include/ruby/3/arithmetic/intptr_t.h
+++ b/include/ruby/3/arithmetic/intptr_t.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_ARITHMETIC_INTPTR_T_H                  /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_ARITHMETIC_INTPTR_T_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Arithmetic conversion between C's `intptr_t` and Ruby's.
  */
-#ifndef  RUBY3_ARITHMETIC_INTPTR_T_H
-#define  RUBY3_ARITHMETIC_INTPTR_T_H
 #include "ruby/3/config.h"
 
 #ifdef HAVE_STDINT_H

--- a/include/ruby/3/arithmetic/long.h
+++ b/include/ruby/3/arithmetic/long.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_ARITHMETIC_LONG_H                      /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_ARITHMETIC_LONG_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -26,8 +28,6 @@
  *      understand the difference of `int`  and `long` when they designed those
  *      macros.
  */
-#ifndef  RUBY3_ARITHMETIC_LONG_H
-#define  RUBY3_ARITHMETIC_LONG_H
 #include "ruby/3/config.h"
 #include "ruby/3/arithmetic/fixnum.h"   /* FIXABLE */
 #include "ruby/3/arithmetic/intptr_t.h" /* rb_int2big etc.*/

--- a/include/ruby/3/arithmetic/long_long.h
+++ b/include/ruby/3/arithmetic/long_long.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_ARITHMETIC_LONG_LONG_H                 /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_ARITHMETIC_LONG_LONG_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Arithmetic conversion between C's `long long` and Ruby's.
  */
-#ifndef  RUBY3_ARITHMETIC_LONG_LONG_H
-#define  RUBY3_ARITHMETIC_LONG_LONG_H
 #include "ruby/3/value.h"
 #include "ruby/3/dllexport.h"
 #include "ruby/3/special_consts.h"

--- a/include/ruby/3/arithmetic/mode_t.h
+++ b/include/ruby/3/arithmetic/mode_t.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_ARITHMETIC_MODE_T_H                    /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_ARITHMETIC_MODE_T_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -28,3 +30,5 @@
 #ifndef MODET2NUM
 # define MODET2NUM RB_INT2NUM
 #endif
+
+#endif /* RUBY3_ARITHMETIC_MODE_T_H */

--- a/include/ruby/3/arithmetic/off_t.h
+++ b/include/ruby/3/arithmetic/off_t.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_ARITHMETIC_OFF_T_H                     /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_ARITHMETIC_OFF_T_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -43,3 +45,5 @@
 #else
 # define NUM2OFFT RB_NUM2INT
 #endif
+
+#endif /* RUBY3_ARITHMETIC_OFF_T_H */

--- a/include/ruby/3/arithmetic/pid_t.h
+++ b/include/ruby/3/arithmetic/pid_t.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_ARITHMETIC_PID_T_H                     /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_ARITHMETIC_PID_T_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -28,3 +30,5 @@
 #ifndef NUM2PIDT
 # define NUM2PIDT RB_NUM2LONG
 #endif
+
+#endif /* RUBY3_ARITHMETIC_PID_T_H */

--- a/include/ruby/3/arithmetic/short.h
+++ b/include/ruby/3/arithmetic/short.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_ARITHMETIC_SHORT_H                     /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_ARITHMETIC_SHORT_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -21,8 +23,6 @@
  * Shyouhei  wonders:  why  there  is   no  SHORT2NUM,  given  there  are  both
  * #USHORT2NUM and #CHR2FIX?
  */
-#ifndef  RUBY3_ARITHMETIC_SHORT_H
-#define  RUBY3_ARITHMETIC_SHORT_H
 #include "ruby/3/value.h"
 #include "ruby/3/dllexport.h"
 #include "ruby/3/special_consts.h"

--- a/include/ruby/3/arithmetic/size_t.h
+++ b/include/ruby/3/arithmetic/size_t.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_ARITHMETIC_SIZE_T_H                    /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_ARITHMETIC_SIZE_T_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -45,3 +47,5 @@
 # define NUM2SIZET  RB_NUM2UINT
 # define NUM2SSIZET RB_NUM2INT
 #endif
+
+#endif /* RUBY3_ARITHMETIC_SIZE_T_H */

--- a/include/ruby/3/arithmetic/st_data_t.h
+++ b/include/ruby/3/arithmetic/st_data_t.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_ARITHMERIC_ST_DATA_T_H                 /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_ARITHMERIC_ST_DATA_T_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Arithmetic conversion between C's `st_data_t` and Ruby's.
  */
-#ifndef  RUBY3_ARITHMERIC_ST_DATA_T_H
-#define  RUBY3_ARITHMERIC_ST_DATA_T_H
 #include "ruby/3/arithmetic/fixnum.h"
 #include "ruby/3/arithmetic/long.h"
 #include "ruby/3/attr/artificial.h"

--- a/include/ruby/3/arithmetic/uid_t.h
+++ b/include/ruby/3/arithmetic/uid_t.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_ARITHMETIC_UID_T_H                     /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_ARITHMETIC_UID_T_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -28,3 +30,5 @@
 #ifndef NUM2UIDT
 # define NUM2UIDT RB_NUM2LONG
 #endif
+
+#endif /* RUBY3_ARITHMETIC_UID_T_H */

--- a/include/ruby/3/assume.h
+++ b/include/ruby/3/assume.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_ASSUME_H                               /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_ASSUME_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -23,8 +25,6 @@
  * - #RUBY3_ASSUME could fallback to #RUBY3_UNREACHABLE.
  * - #RUBY3_UNREACHABLE could fallback to #RUBY3_ASSUME.
  */
-#ifndef  RUBY3_ASSUME_H
-#define  RUBY3_ASSUME_H
 #include "ruby/3/config.h"
 #include "ruby/3/cast.h"
 #include "ruby/3/has/builtin.h"

--- a/include/ruby/3/assume.h
+++ b/include/ruby/3/assume.h
@@ -27,6 +27,7 @@
  */
 #include "ruby/3/config.h"
 #include "ruby/3/cast.h"
+#include "ruby/3/compiler_since.h"
 #include "ruby/3/has/builtin.h"
 #include "ruby/3/warning_push.h"
 

--- a/include/ruby/3/attr/alloc_size.h
+++ b/include/ruby/3/attr/alloc_size.h
@@ -20,6 +20,7 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines #RUBY3_ATTR_ALLOC_SIZE.
  */
+#include "ruby/3/has/attribute.h"
 
 /** Wraps (or simulates) `__attribute__((alloc_size))` */
 #if RUBY3_HAS_ATTRIBUTE(alloc_size)

--- a/include/ruby/3/attr/alloc_size.h
+++ b/include/ruby/3/attr/alloc_size.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_ATTR_ALLOC_SIZE_H                      /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_ATTR_ALLOC_SIZE_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -20,12 +22,10 @@
  */
 
 /** Wraps (or simulates) `__attribute__((alloc_size))` */
-#if defined(RUBY3_ATTR_ALLOC_SIZE)
-# /* Take that. */
-
-#elif RUBY3_HAS_ATTRIBUTE(alloc_size)
+#if RUBY3_HAS_ATTRIBUTE(alloc_size)
 # define RUBY3_ATTR_ALLOC_SIZE(tuple) __attribute__((__alloc_size__ tuple))
-
 #else
 # define RUBY3_ATTR_ALLOC_SIZE(tuple) /* void */
 #endif
+
+#endif /* RUBY3_ATTR_ALLOC_SIZE_H */

--- a/include/ruby/3/attr/artificial.h
+++ b/include/ruby/3/attr/artificial.h
@@ -34,6 +34,7 @@
  *      case it gets  vital to know where the inlining  happened in the callee.
  *      See also https://stackoverflow.com/a/21936099
  */
+#include "ruby/3/has/attribute.h"
 
 /** Wraps (or simulates) `__attribute__((artificial))` */
 #if RUBY3_HAS_ATTRIBUTE(artificial)

--- a/include/ruby/3/attr/artificial.h
+++ b/include/ruby/3/attr/artificial.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_ATTR_ARTIFICIAL_H                      /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_ATTR_ARTIFICIAL_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -34,12 +36,10 @@
  */
 
 /** Wraps (or simulates) `__attribute__((artificial))` */
-#if defined(RUBY3_ATTR_ARTIFICIAL)
-# /* Take that. */
-
-#elif RUBY3_HAS_ATTRIBUTE(artificial)
+#if RUBY3_HAS_ATTRIBUTE(artificial)
 # define RUBY3_ATTR_ARTIFICIAL() __attribute__((__artificial__))
-
 #else
 # define RUBY3_ATTR_ARTIFICIAL() /* void */
 #endif
+
+#endif /* RUBY3_ATTR_ARTIFICIAL_H */

--- a/include/ruby/3/attr/cold.h
+++ b/include/ruby/3/attr/cold.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_ATTR_COLD_H                            /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_ATTR_COLD_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -21,17 +23,14 @@
 #include "ruby/3/compiler_is.h"
 
 /** Wraps (or simulates) `__attribute__((cold))` */
-#if defined(RUBY3_ATTR_COLD)
-# /* Take that. */
-
-#elif RUBY3_COMPILER_IS(SunPro)
+#if RUBY3_COMPILER_IS(SunPro)
 # /* Recent SunPro has __has_attribute, and is borken. */
 # /* It reports it has attribute cold, reality isn't (warnings issued). */
 # define RUBY3_ATTR_COLD() /* void */
-
 #elif RUBY3_HAS_ATTRIBUTE(cold)
 # define RUBY3_ATTR_COLD() __attribute__((__cold__))
-
 #else
 # define RUBY3_ATTR_COLD() /* void */
 #endif
+
+#endif /* RUBY3_ATTR_COLD_H */

--- a/include/ruby/3/attr/cold.h
+++ b/include/ruby/3/attr/cold.h
@@ -21,6 +21,7 @@
  * @brief      Defines #RUBY3_ATTR_COLD.
  */
 #include "ruby/3/compiler_is.h"
+#include "ruby/3/has/attribute.h"
 
 /** Wraps (or simulates) `__attribute__((cold))` */
 #if RUBY3_COMPILER_IS(SunPro)

--- a/include/ruby/3/attr/const.h
+++ b/include/ruby/3/attr/const.h
@@ -20,6 +20,8 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines #RUBY3_ATTR_CONST.
  */
+#include "ruby/3/compiler_since.h"
+#include "ruby/3/has/attribute.h"
 #include "ruby/3/has/declspec_attribute.h"
 
 /** Wraps (or simulates) `__attribute__((const))` */

--- a/include/ruby/3/attr/const.h
+++ b/include/ruby/3/attr/const.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_ATTR_CONST_H                           /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_ATTR_CONST_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -21,30 +23,22 @@
 #include "ruby/3/has/declspec_attribute.h"
 
 /** Wraps (or simulates) `__attribute__((const))` */
-#if defined(RUBY3_ATTR_CONST)
-# /* Take that. */
-
-#elif RUBY3_HAS_ATTRIBUTE(const)
+#if RUBY3_HAS_ATTRIBUTE(const)
 # define RUBY3_ATTR_CONST() __attribute__((__const__))
-
 #elif RUBY3_HAS_DECLSPEC_ATTRIBUTE(noalias)
 # /* If a function can be a const, that is also a noalias. */
 # define RUBY3_ATTR_CONST() __declspec(noalias)
-
 #elif RUBY3_COMPILER_SINCE(SunPro, 5, 10, 0)
 # define RUBY3_ATTR_CONST() _Pragma("no_side_effect")
-
 #else
 # define RUBY3_ATTR_CONST() /* void */
 #endif
 
 /** Enables #RUBY3_ATTR_CONST iff. #RUBY_NDEBUG. */
-#if defined(RUBY3_ATTR_CONST_ON_NDEBUG)
-# /* Take that. */
-
-#elif RUBY_NDEBUG
+#if RUBY_NDEBUG
 # define RUBY3_ATTR_CONST_ON_NDEBUG() RUBY3_ATTR_CONST()
-
 #else
 # define RUBY3_ATTR_CONST_ON_NDEBUG() /* void */
 #endif
+
+#endif /* RUBY3_ATTR_CONST_H */

--- a/include/ruby/3/attr/constexpr.h
+++ b/include/ruby/3/attr/constexpr.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_ATTR_CONSTEXPR_H                       /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_ATTR_CONSTEXPR_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -21,11 +23,8 @@
 #include "ruby/3/has/feature.h"
 #include "ruby/3/compiler_is.h"
 
-/** @cond INTERNAL_MACRO*/
-#if defined(RUBY3_ATTR_CONSTEXPR)
-# /* Take that. */
-
-#elif ! defined(__cplusplus)
+/** @cond INTERNAL_MACRO */
+#if ! defined(__cplusplus)
 # /* Makes no sense. */
 # define RUBY3_HAS_ATTR_CONSTEXPR_CXX11 0
 # define RUBY3_HAS_ATTR_CONSTEXPR_CXX14 0
@@ -63,10 +62,7 @@
 /** @endcond */
 
 /** Wraps (or simulates) C++11 `constexpr`.  */
-#if defined(RUBY3_ATTR_CONSTEXPR)
-# /* Take that. */
-
-#elif RUBY3_HAS_ATTR_CONSTEXPR_CXX14
+#if RUBY3_HAS_ATTR_CONSTEXPR_CXX14
 # define RUBY3_ATTR_CONSTEXPR(_) constexpr
 
 #elif RUBY3_HAS_ATTR_CONSTEXPR_CXX11
@@ -79,12 +75,10 @@
 #endif
 
 /** Enables #RUBY3_ATTR_CONSTEXPR iff. #RUBY_NDEBUG. */
-#if defined(RUBY3_ATTR_CONSTEXPR_ON_NDEBUG)
-# /* Take that. */
-
-#elif RUBY_NDEBUG
+#if RUBY_NDEBUG
 # define RUBY3_ATTR_CONSTEXPR_ON_NDEBUG(_) RUBY3_ATTR_CONSTEXPR(_)
-
 #else
 # define RUBY3_ATTR_CONSTEXPR_ON_NDEBUG(_) /* void */
 #endif
+
+#endif /* RUBY3_ATTR_CONSTEXPR_H */

--- a/include/ruby/3/attr/constexpr.h
+++ b/include/ruby/3/attr/constexpr.h
@@ -22,6 +22,7 @@
  */
 #include "ruby/3/has/feature.h"
 #include "ruby/3/compiler_is.h"
+#include "ruby/3/token_paste.h"
 
 /** @cond INTERNAL_MACRO */
 #if ! defined(__cplusplus)

--- a/include/ruby/3/attr/deprecated.h
+++ b/include/ruby/3/attr/deprecated.h
@@ -20,6 +20,8 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines #RUBY3_ATTR_DEPRECATED.
  */
+#include "ruby/3/compiler_since.h"
+#include "ruby/3/has/attribute.h"
 #include "ruby/3/has/c_attribute.h"
 #include "ruby/3/has/cpp_attribute.h"
 #include "ruby/3/has/declspec_attribute.h"

--- a/include/ruby/3/attr/deprecated.h
+++ b/include/ruby/3/attr/deprecated.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_ATTR_DEPRECATED_H                      /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_ATTR_DEPRECATED_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -24,10 +26,7 @@
 #include "ruby/3/has/extension.h"
 
 /** Wraps (or simulates) `[[deprecated]]` */
-#if defined(RUBY3_ATTR_DEPRECATED)
-# /* Take that. */
-
-#elif RUBY3_HAS_EXTENSION(attribute_deprecated_with_message)
+#if RUBY3_HAS_EXTENSION(attribute_deprecated_with_message)
 # define RUBY3_ATTR_DEPRECATED(msg) __attribute__((__deprecated__ msg))
 
 #elif RUBY3_COMPILER_SINCE(GCC, 4, 5, 0)
@@ -54,3 +53,5 @@
 #else
 # define RUBY3_ATTR_DEPRECATED(msg) /* void */
 #endif
+
+#endif /* RUBY3_ATTR_DEPRECATED_H */

--- a/include/ruby/3/attr/diagnose_if.h
+++ b/include/ruby/3/attr/diagnose_if.h
@@ -20,6 +20,8 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines #RUBY3_ATTR_DIAGNOSE_IF.
  */
+#include "ruby/3/has/attribute.h"
+#include "ruby/3/warning_push.h"
 
 /** Wraps (or simulates) `__attribute__((diagnose_if))` */
 #if RUBY3_COMPILER_BEFORE(Clang, 5, 0, 0)

--- a/include/ruby/3/attr/diagnose_if.h
+++ b/include/ruby/3/attr/diagnose_if.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_ATTR_DIAGNOSE_IF_H                     /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_ATTR_DIAGNOSE_IF_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -20,10 +22,7 @@
  */
 
 /** Wraps (or simulates) `__attribute__((diagnose_if))` */
-#if defined(RUBY3_ATTR_DIAGNOSE_IF)
-# /* Take that. */
-
-#elif RUBY3_COMPILER_BEFORE(Clang, 5, 0, 0)
+#if RUBY3_COMPILER_BEFORE(Clang, 5, 0, 0)
 # /* https://bugs.llvm.org/show_bug.cgi?id=34319 */
 # define RUBY3_ATTR_DIAGNOSE_IF(_, __, ___) /* void */
 
@@ -37,3 +36,5 @@
 #else
 # define RUBY3_ATTR_DIAGNOSE_IF(_, __, ___) /* void */
 #endif
+
+#endif /* RUBY3_ATTR_DIAGNOSE_IF_H */

--- a/include/ruby/3/attr/enum_extensibility.h
+++ b/include/ruby/3/attr/enum_extensibility.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_ATTR_ENUM_EXTENSIBILITY_H              /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_ATTR_ENUM_EXTENSIBILITY_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -20,12 +22,10 @@
  */
 
 /** Wraps (or simulates) `__attribute__((enum_extensibility))` */
-#if defined(RUBY3_ATTR_ENUM_EXTENSIBILITY)
-# /* Take that. */
-
-#elif RUBY3_HAS_ATTRIBUTE(enum_extensibility)
+#if RUBY3_HAS_ATTRIBUTE(enum_extensibility)
 # define RUBY3_ATTR_ENUM_EXTENSIBILITY(_) __attribute__((__enum_extensibility__(_)))
-
 #else
 # define RUBY3_ATTR_ENUM_EXTENSIBILITY(_) /* void */
 #endif
+
+#endif /* RUBY3_ATTR_ENUM_EXTENSIBILITY_H */

--- a/include/ruby/3/attr/enum_extensibility.h
+++ b/include/ruby/3/attr/enum_extensibility.h
@@ -20,6 +20,7 @@
  *             extension libraries. They could be written in C++98.
  * @brief      #RUBY3_ATTR_ENUM_EXTENSIBILITY.
  */
+#include "ruby/3/has/attribute.h"
 
 /** Wraps (or simulates) `__attribute__((enum_extensibility))` */
 #if RUBY3_HAS_ATTRIBUTE(enum_extensibility)

--- a/include/ruby/3/attr/error.h
+++ b/include/ruby/3/attr/error.h
@@ -20,6 +20,7 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines #RUBY3_ATTR_ERROR.
  */
+#include "ruby/3/has/attribute.h"
 
 /** Wraps (or simulates) `__attribute__((error))` */
 #if RUBY3_HAS_ATTRIBUTE(error)

--- a/include/ruby/3/attr/error.h
+++ b/include/ruby/3/attr/error.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_ATTR_ERROR_H                           /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_ATTR_ERROR_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -20,12 +22,10 @@
  */
 
 /** Wraps (or simulates) `__attribute__((error))` */
-#if defined(RUBY3_ATTR_ERROR)
-# /* Take that. */
-
-#elif RUBY3_HAS_ATTRIBUTE(error)
+#if RUBY3_HAS_ATTRIBUTE(error)
 # define RUBY3_ATTR_ERROR(msg) __attribute__((__error__ msg))
-
 #else
 # define RUBY3_ATTR_ERROR(msg) /* void */
 #endif
+
+#endif /* RUBY3_ATTR_ERROR_H */

--- a/include/ruby/3/attr/flag_enum.h
+++ b/include/ruby/3/attr/flag_enum.h
@@ -21,6 +21,7 @@
  * @brief      Defines #RUBY3_ATTR_FLAG_ENUM.
  * @see        https://clang.llvm.org/docs/AttributeReference.html#flag_enum
  */
+#include "ruby/3/has/attribute.h"
 
 /** Wraps (or simulates) `__attribute__((flag_enum)` */
 #if RUBY3_HAS_ATTRIBUTE(flag_enum)

--- a/include/ruby/3/attr/flag_enum.h
+++ b/include/ruby/3/attr/flag_enum.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_ATTR_FLAG_ENUM_H                       /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_ATTR_FLAG_ENUM_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -21,12 +23,10 @@
  */
 
 /** Wraps (or simulates) `__attribute__((flag_enum)` */
-#if defined(RUBY3_ATTR_FLAG_ENUM)
-# /* Take that. */
-
-#elif RUBY3_HAS_ATTRIBUTE(flag_enum)
+#if RUBY3_HAS_ATTRIBUTE(flag_enum)
 # define RUBY3_ATTR_FLAG_ENUM() __attribute__((__flag_enum__))
-
 #else
 # define RUBY3_ATTR_FLAG_ENUM() /* void */
 #endif
+
+#endif /* RUBY3ATTR_FLAG_ENUM_H */

--- a/include/ruby/3/attr/forceinline.h
+++ b/include/ruby/3/attr/forceinline.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_ATTR_FORCEINLINE_H                     /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_ATTR_FORCEINLINE_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -25,15 +27,12 @@
  * `__forceinline` are mutually exclusive.  We have to mimic that behaviour for
  * non-MSVC compilers.
  */
-#if defined(RUBY3_ATTR_FORCEINLINE)
-# /* Take that. */
-
-#elif RUBY3_COMPILER_SINCE(MSVC, 12, 0, 0)
+#if RUBY3_COMPILER_SINCE(MSVC, 12, 0, 0)
 # define RUBY3_ATTR_FORCEINLINE() __forceinline
-
 #elif RUBY3_HAS_ATTRIBUTE(always_inline)
 # define RUBY3_ATTR_FORCEINLINE() __attribute__((__always_inline__)) inline
-
 #else
 # define RUBY3_ATTR_FORCEINLINE() inline
 #endif
+
+#endif /* RUBY3_ATTR_FORCEINLINE_H */

--- a/include/ruby/3/attr/forceinline.h
+++ b/include/ruby/3/attr/forceinline.h
@@ -20,6 +20,8 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines #RUBY3_ATTR_FORCEINLINE.
  */
+#include "ruby/3/compiler_since.h"
+#include "ruby/3/has/attribute.h"
 
 /**
  * Wraps (or  simulates) `__forceinline`.  MSVC complains  on declarations like

--- a/include/ruby/3/attr/format.h
+++ b/include/ruby/3/attr/format.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_ATTR_FORMAT_H                          /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_ATTR_FORMAT_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -20,22 +22,16 @@
  */
 
 /** Wraps (or simulates) `__attribute__((format))` */
-#if defined(RUBY3_ATTR_FORMAT)
-# /* Take that. */
-
-#elif RUBY3_HAS_ATTRIBUTE(format)
+#if RUBY3_HAS_ATTRIBUTE(format)
 # define RUBY3_ATTR_FORMAT(x, y, z) __attribute__((__format__(x, y, z)))
-
 #else
 # define RUBY3_ATTR_FORMAT(x, y, z) /* void */
 #endif
 
-#if defined(RUBY3_PRINTF_FORMAT)
-# /* Take that. */
-
-#elif defined(__MINGW_PRINTF_FORMAT)
+#if defined(__MINGW_PRINTF_FORMAT)
 # define RUBY3_PRINTF_FORMAT __MINGW_PRINTF_FORMAT
-
 #else
 # define RUBY3_PRINTF_FORMAT __printf__
 #endif
+
+#endif /* RUBY3_ATTR_FORMAT_H */

--- a/include/ruby/3/attr/format.h
+++ b/include/ruby/3/attr/format.h
@@ -20,6 +20,7 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines #RUBY3_ATTR_FORMAT.
  */
+#include "ruby/3/has/attribute.h"
 
 /** Wraps (or simulates) `__attribute__((format))` */
 #if RUBY3_HAS_ATTRIBUTE(format)

--- a/include/ruby/3/attr/maybe_unused.h
+++ b/include/ruby/3/attr/maybe_unused.h
@@ -20,6 +20,7 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines #RUBY3_ATTR_MAYBE_UNUSED.
  */
+#include "ruby/3/has/attribute.h"
 #include "ruby/3/has/c_attribute.h"
 #include "ruby/3/has/cpp_attribute.h"
 

--- a/include/ruby/3/attr/maybe_unused.h
+++ b/include/ruby/3/attr/maybe_unused.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_ATTR_MAYBE_UNUSED_H                    /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_ATTR_MAYBE_UNUSED_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -22,18 +24,14 @@
 #include "ruby/3/has/cpp_attribute.h"
 
 /** Wraps  (or simulates)  `[[maybe_unused]]` */
-#if defined(RUBY3_ATTR_MAYBE_UNUSED)
-# /* Take that. */
-
-#elif RUBY3_HAS_CPP_ATTRIBUTE(maybe_unused)
+#if RUBY3_HAS_CPP_ATTRIBUTE(maybe_unused)
 # define RUBY3_ATTR_MAYBE_UNUSED() [[maybe_unused]]
-
 #elif RUBY3_HAS_C_ATTRIBUTE(maybe_unused)
 # define RUBY3_ATTR_MAYBE_UNUSED() [[maybe_unused]]
-
 #elif RUBY3_HAS_ATTRIBUTE(unused)
 # define RUBY3_ATTR_MAYBE_UNUSED() __attribute__((__unused__))
-
 #else
 # define RUBY3_ATTR_MAYBE_UNUSED() /* void */
 #endif
+
+#endif /* RUBY3_ATTR_MAYBE_UNUSED */

--- a/include/ruby/3/attr/noalias.h
+++ b/include/ruby/3/attr/noalias.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_ATTR_NOALIAS_H                         /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_ATTR_NOALIAS_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -47,12 +49,10 @@
 #include "ruby/3/has/declspec_attribute.h"
 
 /** Wraps (or simulates) `__declspec((noalias))` */
-#if defined(RUBY3_ATTR_NOALIAS)
-# /* Take that. */
-
-#elif RUBY3_HAS_DECLSPEC_ATTRIBUTE(noalias)
+#if RUBY3_HAS_DECLSPEC_ATTRIBUTE(noalias)
 # define RUBY3_ATTR_NOALIAS() __declspec(noalias)
-
 #else
 # define RUBY3_ATTR_NOALIAS() /* void */
 #endif
+
+#endif /* RUBY3_ATTR_NOALIAS_H */

--- a/include/ruby/3/attr/nodiscard.h
+++ b/include/ruby/3/attr/nodiscard.h
@@ -20,6 +20,7 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines #RUBY3_ATTR_NODISCARD.
  */
+#include "ruby/3/has/attribute.h"
 #include "ruby/3/has/c_attribute.h"
 #include "ruby/3/has/cpp_attribute.h"
 

--- a/include/ruby/3/attr/nodiscard.h
+++ b/include/ruby/3/attr/nodiscard.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_ATTR_NODISCARD_H                       /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_ATTR_NODISCARD_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -26,22 +28,17 @@
  * nodiscard attribute can  have a message why the result  shall not be ignoed.
  * However GCC attribute and SAL annotation cannot take them.
  */
-#if defined(RUBY3_ATTR_NODISCARD)
-# /* Take that. */
-
-#elif RUBY3_HAS_CPP_ATTRIBUTE(nodiscard)
+#if RUBY3_HAS_CPP_ATTRIBUTE(nodiscard)
 # define RUBY3_ATTR_NODISCARD() [[nodiscard]]
-
 #elif RUBY3_HAS_C_ATTRIBUTE(nodiscard)
 # define RUBY3_ATTR_NODISCARD() [[nodiscard]]
-
 #elif RUBY3_HAS_ATTRIBUTE(warn_unused_result)
 # define RUBY3_ATTR_NODISCARD() __attribute__((__warn_unused_result__))
-
 #elif defined(_Check_return_)
 # /* Take SAL definition. */
 # define RUBY3_ATTR_NODISCARD() _Check_return_
-
 #else
 # define RUBY3_ATTR_NODISCARD() /* void */
 #endif
+
+#endif /* RUBY3_ATTR_NODISCARD_H */

--- a/include/ruby/3/attr/noexcept.h
+++ b/include/ruby/3/attr/noexcept.h
@@ -61,6 +61,7 @@
  *       Itanium C++ ABI has zero-cost  exception handling), but does impact on
  *       generated binary size.  This is bad.
  */
+#include "ruby/3/compiler_since.h"
 #include "ruby/3/has/feature.h"
 
 /** Wraps (or simulates) C++11 `noexcept` */

--- a/include/ruby/3/attr/noexcept.h
+++ b/include/ruby/3/attr/noexcept.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_ATTR_NOEXCEPT_H                       /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_ATTR_NOEXCEPT_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -62,10 +64,7 @@
 #include "ruby/3/has/feature.h"
 
 /** Wraps (or simulates) C++11 `noexcept` */
-#if defined(RUBY3_ATTR_NOEXCEPT)
-# /* Take that. */
-
-#elif ! defined(__cplusplus)
+#if ! defined(__cplusplus)
 # /* Doesn't make sense. */
 # define RUBY3_ATTR_NOEXCEPT(_) /* void */
 
@@ -87,3 +86,5 @@
 #else
 # define RUBY3_ATTR_NOEXCEPT(_) /* void */
 #endif
+
+#endif /* RUBY3_ATTR_NOEXCEPT_H */

--- a/include/ruby/3/attr/noinline.h
+++ b/include/ruby/3/attr/noinline.h
@@ -20,6 +20,7 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines #RUBY3_ATTR_NOINLINE.
  */
+#include "ruby/3/has/attribute.h"
 #include "ruby/3/has/declspec_attribute.h"
 
 /** Wraps (or simulates) `__declspec(noinline)` */

--- a/include/ruby/3/attr/noinline.h
+++ b/include/ruby/3/attr/noinline.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_ATTR_NOINLINE_H                        /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_ATTR_NOINLINE_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -21,15 +23,12 @@
 #include "ruby/3/has/declspec_attribute.h"
 
 /** Wraps (or simulates) `__declspec(noinline)` */
-#if defined(RUBY3_ATTR_NOINLINE)
-# /* Take that. */
-
-#elif RUBY3_HAS_DECLSPEC_ATTRIBUTE(noinline)
+#if RUBY3_HAS_DECLSPEC_ATTRIBUTE(noinline)
 # define RUBY3_ATTR_NOINLINE() __declspec(noinline)
-
 #elif RUBY3_HAS_ATTRIBUTE(noinline)
 # define RUBY3_ATTR_NOINLINE() __attribute__((__noinline__))
-
 #else
 # define RUBY3_ATTR_NOINLINE() /* void */
 #endif
+
+#endif /* RUBY3_ATTR_NOINLINE_H */

--- a/include/ruby/3/attr/nonnull.h
+++ b/include/ruby/3/attr/nonnull.h
@@ -20,6 +20,7 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines #RUBY3_ATTR_NONNULL.
  */
+#include "ruby/3/has/attribute.h"
 
 /** Wraps (or simulates) `__attribute__((nonnull))` */
 #if RUBY3_HAS_ATTRIBUTE(nonnull)

--- a/include/ruby/3/attr/nonnull.h
+++ b/include/ruby/3/attr/nonnull.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_ATTR_NONNULL_H                         /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_ATTR_NONNULL_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -20,12 +22,10 @@
  */
 
 /** Wraps (or simulates) `__attribute__((nonnull))` */
-#if defined(RUBY3_ATTR_NONNULL)
-# /* Take that. */
-
-#elif RUBY3_HAS_ATTRIBUTE(nonnull)
+#if RUBY3_HAS_ATTRIBUTE(nonnull)
 # define RUBY3_ATTR_NONNULL(list) __attribute__((__nonnull__ list))
-
 #else
 # define RUBY3_ATTR_NONNULL(list) /* void */
 #endif
+
+#endif /* RUBY3_ATTR_NONNULL_H */

--- a/include/ruby/3/attr/noreturn.h
+++ b/include/ruby/3/attr/noreturn.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_ATTR_NORETURN_H                        /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_ATTR_NORETURN_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -22,10 +24,7 @@
 #include "ruby/3/has/declspec_attribute.h"
 
 /** Wraps (or simulates) `[[noreturn]]` */
-#if defined(RUBY3_ATTR_NORETURN)
-# /* Take that. */
-
-#elif RUBY3_COMPILER_SINCE(SunPro, 5, 10, 0)
+#if RUBY3_COMPILER_SINCE(SunPro, 5, 10, 0)
 # define RUBY3_ATTR_NORETURN() _Pragma("does_not_return")
 
 #elif RUBY3_HAS_DECLSPEC_ATTRIBUTE(noreturn)
@@ -47,3 +46,5 @@
 #else
 # define RUBY3_ATTR_NORETURN() /* void */
 #endif
+
+#endif /* RUBY3_ATTR_NORETURN_H */

--- a/include/ruby/3/attr/noreturn.h
+++ b/include/ruby/3/attr/noreturn.h
@@ -20,6 +20,8 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines #RUBY3_ATTR_NORETURN.
  */
+#include "ruby/3/compiler_since.h"
+#include "ruby/3/has/attribute.h"
 #include "ruby/3/has/cpp_attribute.h"
 #include "ruby/3/has/declspec_attribute.h"
 

--- a/include/ruby/3/attr/pure.h
+++ b/include/ruby/3/attr/pure.h
@@ -20,6 +20,8 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines #RUBY3_ATTR_PURE.
  */
+#include "ruby/3/compiler_since.h"
+#include "ruby/3/has/attribute.h"
 #include "ruby/assert.h"
 
 /** Wraps (or simulates) `__attribute__((pure))` */

--- a/include/ruby/3/attr/pure.h
+++ b/include/ruby/3/attr/pure.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_ATTR_PURE_H                            /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_ATTR_PURE_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -21,26 +23,19 @@
 #include "ruby/assert.h"
 
 /** Wraps (or simulates) `__attribute__((pure))` */
-#if defined(RUBY3_ATTR_PURE)
-# /* Take that. */
-
-#elif RUBY3_HAS_ATTRIBUTE(pure)
+#if RUBY3_HAS_ATTRIBUTE(pure)
 # define RUBY3_ATTR_PURE() __attribute__((__pure__))
-
 #elif RUBY3_COMPILER_SINCE(SunPro, 5, 10, 0)
 # define RUBY3_ATTR_PURE() _Pragma("does_not_write_global_data")
-
 #else
 # define RUBY3_ATTR_PURE() /* void */
 #endif
 
 /** Enables #RUBY3_ATTR_PURE iff. #RUBY_NDEBUG. */
-#if defined(RUBY3_ATTR_PURE_ON_NDEBUG)
-# /* Take that. */
-
-#elif RUBY_NDEBUG
+#if RUBY_NDEBUG
 # define RUBY3_ATTR_PURE_ON_NDEBUG() RUBY3_ATTR_PURE()
-
 #else
 # define RUBY3_ATTR_PURE_ON_NDEBUG() /* void */
 #endif
+
+#endif /* RUBY3_ATTR_PURE_H */

--- a/include/ruby/3/attr/restrict.h
+++ b/include/ruby/3/attr/restrict.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_ATTR_RESTRICT_H                        /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_ATTR_RESTRICT_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -24,10 +26,7 @@
  * `__has_declspec_attribute()` which involves macro substitution. */
 
 /** Wraps (or simulates) `__declspec(restrict)` */
-#if defined(RUBY3_ATTR_RESTRICT)
-# /* Take that. */
-
-#elif RUBY3_COMPILER_SINCE(MSVC, 14, 0, 0)
+#if RUBY3_COMPILER_SINCE(MSVC, 14, 0, 0)
 # define RUBY3_ATTR_RESTRICT() __declspec(RUBY3_TOKEN_PASTE(re, strict))
 
 #elif RUBY3_HAS_ATTRIBUTE(malloc)
@@ -39,3 +38,5 @@
 #else
 # define RUBY3_ATTR_RESTRICT() /* void */
 #endif
+
+#endif /* RUBY3_ATTR_RESTRICT_H */

--- a/include/ruby/3/attr/restrict.h
+++ b/include/ruby/3/attr/restrict.h
@@ -20,6 +20,9 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines #RUBY3_ATTR_RESTRICT.
  */
+#include "ruby/3/compiler_since.h"
+#include "ruby/3/has/attribute.h"
+#include "ruby/3/token_paste.h"
 
 /* :FIXME:  config.h  includes conflicting  `#define  restrict`.   MSVC can  be
  * detected  using  `RUBY3_COMPILER_SINCE()`, but  Clang  &  family cannot  use

--- a/include/ruby/3/attr/returns_nonnull.h
+++ b/include/ruby/3/attr/returns_nonnull.h
@@ -20,6 +20,7 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines #RUBY3_ATTR_RETURNS_NONNULL.
  */
+#include "ruby/3/has/attribute.h"
 
 /** Wraps (or simulates) `__attribute__((returns_nonnull))` */
 #if defined(_Ret_nonnull_)

--- a/include/ruby/3/attr/returns_nonnull.h
+++ b/include/ruby/3/attr/returns_nonnull.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_ATTR_RETURNS_NONNULL_H                 /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_ATTR_RETURNS_NONNULL_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -20,10 +22,7 @@
  */
 
 /** Wraps (or simulates) `__attribute__((returns_nonnull))` */
-#if defined(RUBY3_ATTR_RETURNS_NONNULL)
-# /* Take that. */
-
-#elif defined(_Ret_nonnull_)
+#if defined(_Ret_nonnull_)
 # /* Take SAL definition. */
 # define RUBY3_ATTR_RETURNS_NONNULL() _Ret_nonnull_
 
@@ -33,3 +32,5 @@
 #else
 # define RUBY3_ATTR_RETURNS_NONNULL() /* void */
 #endif
+
+#endif /* RUBY3_ATTR_RETURNS_NONNULL_H */

--- a/include/ruby/3/attr/warning.h
+++ b/include/ruby/3/attr/warning.h
@@ -20,6 +20,7 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines #RUBY3_ATTR_WARNING.
  */
+#include "ruby/3/has/attribute.h"
 
 /** Wraps (or simulates) `__attribute__((warning))` */
 #if RUBY3_HAS_ATTRIBUTE(warning)

--- a/include/ruby/3/attr/warning.h
+++ b/include/ruby/3/attr/warning.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_ATTR_WARNING_H                         /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_ATTR_WARNING_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -20,12 +22,10 @@
  */
 
 /** Wraps (or simulates) `__attribute__((warning))` */
-#if defined(RUBY3_ATTR_WARNING)
-# /* Take that. */
-
-#elif RUBY3_HAS_ATTRIBUTE(warning)
+#if RUBY3_HAS_ATTRIBUTE(warning)
 # define RUBY3_ATTR_WARNING(msg) __attribute__((__warning__ msg))
-
 #else
 # define RUBY3_ATTR_WARNING(msg) /* void */
 #endif
+
+#endif /* RUBY3_ATTR_WARNING_H */

--- a/include/ruby/3/attr/weakref.h
+++ b/include/ruby/3/attr/weakref.h
@@ -20,6 +20,7 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines #RUBY3_ATTR_WEAKREF.
  */
+#include "ruby/3/has/attribute.h"
 
 /** Wraps (or simulates) `__attribute__((weakref))` */
 #if RUBY3_HAS_ATTRIBUTE(weakref)

--- a/include/ruby/3/attr/weakref.h
+++ b/include/ruby/3/attr/weakref.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_ATTR_WEAKREF_H                         /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_ATTR_WEAKREF_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -20,12 +22,10 @@
  */
 
 /** Wraps (or simulates) `__attribute__((weakref))` */
-#if defined(RUBY3_ATTR_WEAKREF)
-# /* Take that. */
-
-#elif RUBY3_HAS_ATTRIBUTE(weakref)
+#if RUBY3_HAS_ATTRIBUTE(weakref)
 # define RUBY3_ATTR_WEAKREF(sym) __attribute__((__weakref__(# sym)))
-
 #else
 # define RUBY3_ATTR_WEAKREF(sym) /* void */
 #endif
+
+#endif /* RUBY3_ATTR_WEAKREF_H */

--- a/include/ruby/3/cast.h
+++ b/include/ruby/3/cast.h
@@ -25,6 +25,9 @@
  * public headers.  They could be used  from C++, and C-style casts could issue
  * warnings.  Ruby internals are pure C so they should not bother.
  */
+#include "ruby/3/compiler_since.h"
+#include "ruby/3/has/warning.h"
+#include "ruby/3/warning_push.h"
 
 #if ! defined(__cplusplus)
 # define RUBY3_CAST(expr) (expr)

--- a/include/ruby/3/cast.h
+++ b/include/ruby/3/cast.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_CAST_H                                 /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_CAST_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -24,10 +26,7 @@
  * warnings.  Ruby internals are pure C so they should not bother.
  */
 
-#if defined(RUBY3_CAST)
-# /* Take that. */
-
-#elif ! defined(__cplusplus)
+#if ! defined(__cplusplus)
 # define RUBY3_CAST(expr) (expr)
 
 #elif RUBY3_COMPILER_SINCE(GCC, 4, 6, 0)
@@ -47,3 +46,5 @@
 # define RUBY3_CAST(expr) (expr)
 #endif
 /** @endcond */
+
+#endif /* RUBY3_CAST_H */

--- a/include/ruby/3/compiler_is.h
+++ b/include/ruby/3/compiler_is.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_COMPILER_IS_H                          /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_COMPILER_IS_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -25,12 +27,7 @@
  * @retval  true   It is.
  * @retval  false  It isn't.
  */
-#ifndef RUBY3_COMPILER_IS_INCLUDED
-#define RUBY3_COMPILER_IS_INCLUDED
-
-#ifndef RUBY3_COMPILER_IS
-# define RUBY3_COMPILER_IS(cc) RUBY3_COMPILER_IS_ ## cc
-#endif
+#define RUBY3_COMPILER_IS(cc) RUBY3_COMPILER_IS_ ## cc
 
 #include "ruby/3/compiler_is/apple.h"
 #include "ruby/3/compiler_is/clang.h"
@@ -45,4 +42,4 @@
  *
  * - ARM's armclang: ditto, it can be clang-backended.  */
 
-#endif // RUBY3_COMPILER_IS_INCLUDED
+#endif /* RUBY3_COMPILER_IS_H */

--- a/include/ruby/3/compiler_is/apple.h
+++ b/include/ruby/3/compiler_is/apple.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_COMPILER_IS_APPLE_H                    /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_COMPILER_IS_APPLE_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -23,10 +25,7 @@
  * from LLVM's,  when it comes  to compiler  detection business in  this header
  * file.
  */
-#if defined(RUBY3_COMPILER_IS_Apple)
-# /* Take that. */
-
-#elif ! defined(__clang__)
+#if ! defined(__clang__)
 # define RUBY3_COMPILER_IS_Apple 0
 
 #elif ! defined(__apple_build_version__)
@@ -38,3 +37,5 @@
 # define RUBY3_COMPILER_VERSION_MINOR __clang_minor__
 # define RUBY3_COMPILER_VERSION_PATCH __clang_patchlevel__
 #endif
+
+#endif /* RUBY3_COMPILER_IS_APPLE_H */

--- a/include/ruby/3/compiler_is/clang.h
+++ b/include/ruby/3/compiler_is/clang.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_COMPILER_IS_CLANG_H                    /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_COMPILER_IS_CLANG_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -20,10 +22,7 @@
  */
 #include "ruby/3/compiler_is/apple.h"
 
-#if defined(RUBY3_COMPILER_IS_Clang)
-# /* Take that. */
-
-#elif ! defined(__clang__)
+#if ! defined(__clang__)
 # define RUBY3_COMPILER_IS_Clang 0
 
 #elif RUBY3_COMPILER_IS(Apple)
@@ -35,3 +34,5 @@
 # define RUBY3_COMPILER_VERSION_MINOR __clang_minor__
 # define RUBY3_COMPILER_VERSION_PATCH __clang_patchlevel__
 #endif
+
+#endif /* RUBY3_COMPILER_IS_CLANG_H */

--- a/include/ruby/3/compiler_is/gcc.h
+++ b/include/ruby/3/compiler_is/gcc.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_COMPILER_IS_GCC_H                      /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_COMPILER_IS_GCC_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -22,10 +24,7 @@
 #include "ruby/3/compiler_is/clang.h"
 #include "ruby/3/compiler_is/intel.h"
 
-#if defined(RUBY3_COMPILER_IS_GCC)
-# /* Take that. */
-
-#elif ! defined(__GNUC__)
+#if ! defined(__GNUC__)
 # define RUBY3_COMPILER_IS_GCC 0
 
 #elif RUBY3_COMPILER_IS(Apple)
@@ -43,3 +42,5 @@
 # define RUBY3_COMPILER_VERSION_MINOR __GNUC_MINOR__
 # define RUBY3_COMPILER_VERSION_PATCH __GNUC_PATCHLEVEL__
 #endif
+
+#endif /* RUBY3_COMPILER_IS_GCC_H */

--- a/include/ruby/3/compiler_is/intel.h
+++ b/include/ruby/3/compiler_is/intel.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_COMPILER_IS_INTEL_H                    /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_COMPILER_IS_INTEL_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,10 +20,7 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines #RUBY3_COMPILER_IS_Intel.
  */
-#if defined(RUBY3_COMPILER_IS_Intel)
-# /* Take that. */
-
-#elif ! defined(__INTEL_COMPILER)
+#if ! defined(__INTEL_COMPILER)
 # define RUBY3_COMPILER_IS_Intel 0
 
 #elif ! defined(__INTEL_COMPILER_UPDATE)
@@ -38,3 +37,5 @@
 # define RUBY3_COMPILER_VERSION_MINOR (__INTEL_COMPILER % 100 / 10)
 # define RUBY3_COMPILER_VERSION_PATCH __INTEL_COMPILER_UPDATE
 #endif
+
+#endif /* RUBY3_COMPILER_IS_INTEL_H */

--- a/include/ruby/3/compiler_is/msvc.h
+++ b/include/ruby/3/compiler_is/msvc.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_COMPILER_IS_MSVC_H                     /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_COMPILER_IS_MSVC_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -21,10 +23,7 @@
 #include "ruby/3/compiler_is/clang.h"
 #include "ruby/3/compiler_is/intel.h"
 
-#if defined(RUBY3_COMPILER_IS_MSVC)
-# /* Take that. */
-
-#elif ! defined(_MSC_VER)
+#if ! defined(_MSC_VER)
 # define RUBY3_COMPILER_IS_MSVC 0
 
 #elif RUBY3_COMPILER_IS(Clang)
@@ -54,3 +53,5 @@
 # define RUBY3_COMPILER_VERSION_MINOR (_MSC_VER % 100)
 # define RUBY3_COMPILER_VERSION_PATCH 0
 #endif
+
+#endif /* RUBY3_COMPILER_IS_MSVC_H */

--- a/include/ruby/3/compiler_is/sunpro.h
+++ b/include/ruby/3/compiler_is/sunpro.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_COMPILER_IS_SUNPRO_H                   /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_COMPILER_IS_SUNPRO_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,10 +20,7 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines #RUBY3_COMPILER_IS_SunPro.
  */
-#if defined(RUBY3_COMPILER_IS_SunPro)
-# /* Take that. */
-
-#elif ! (defined(__SUNPRO_C) || defined(__SUNPRO_CC))
+#if ! (defined(__SUNPRO_C) || defined(__SUNPRO_CC))
 # define RUBY3_COMPILER_IS_SunPro 0
 
 #elif defined(__SUNPRO_C) && __SUNPRO_C >= 0x5100
@@ -52,3 +51,5 @@
 # define TERSE_COMPILER_VERSION_MINOR (__SUNPRO_CC >> 4 & 0xF)
 # define TERSE_COMPILER_VERSION_PATCH (__SUNPRO_CC      & 0xF)
 #endif
+
+#endif /* RUBY3_COMPILER_IS_SUNPRO_H */

--- a/include/ruby/3/compiler_since.h
+++ b/include/ruby/3/compiler_since.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_COMPILER_SINCE_H                       /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_COMPILER_SINCE_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -19,7 +21,6 @@
  * @brief      Defines #RUBY3_COMPILER_SINCE.
  */
 #include "ruby/3/compiler_is.h"
-#ifndef RUBY3_COMPILER_SINCE
 
 /**
  * @brief   Checks if the compiler is of given brand and is newer than or equal
@@ -57,4 +58,4 @@
     ((RUBY3_COMPILER_VERSION_MINOR == (y)) && \
      (RUBY3_COMPILER_VERSION_PATCH <  (z)))))))
 
-#endif /* RUBY3_COMPILER_SINCE */
+#endif /* RUBY3_COMPILER_SINCE_H */

--- a/include/ruby/3/config.h
+++ b/include/ruby/3/config.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_CONFIG_H                               /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_CONFIG_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Thin wrapper to ruby/config.h
  */
-#ifndef  RUBY3_CONFIG_H
-#define  RUBY3_CONFIG_H
 #include "ruby/config.h"
 
 #ifdef RUBY_EXTCONF_H

--- a/include/ruby/3/config.h
+++ b/include/ruby/3/config.h
@@ -27,10 +27,6 @@
 #endif
 
 #include "ruby/3/compiler_since.h"
-#include "ruby/3/has/warning.h"
-#include "ruby/3/has/attribute.h"
-#include "ruby/3/warning_push.h"
-#include "ruby/3/token_paste.h"
 
 #if defined(__cplusplus)
 #/* __builtin_choose_expr and __builtin_types_compatible aren't available

--- a/include/ruby/3/constant_p.h
+++ b/include/ruby/3/constant_p.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_CONSTANT_P_H                           /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_CONSTANT_P_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -26,12 +28,10 @@
  */
 #include "ruby/3/has/builtin.h"
 
-#if defined(RUBY3_CONSTANT_P)
-# /* Take that. */
-
-#elif RUBY3_HAS_BUILTIN(__builtin_constant_p)
+#if RUBY3_HAS_BUILTIN(__builtin_constant_p)
 # define RUBY3_CONSTANT_P(expr) __builtin_constant_p(expr)
-
 #else
 # define RUBY3_CONSTANT_P(expr) 0
 #endif
+
+#endif /* RUBY3_CONSTANT_P_H */

--- a/include/ruby/3/core.h
+++ b/include/ruby/3/core.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_CORE_H                                 /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_CORE_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -30,3 +32,4 @@
 #include "ruby/3/core/rstring.h"
 #include "ruby/3/core/rstruct.h"
 #include "ruby/3/core/rtypeddata.h"
+#endif /* RUBY3_CORE_H */

--- a/include/ruby/3/core/rarray.h
+++ b/include/ruby/3/core/rarray.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_RARRAY_H                               /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_RARRAY_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines struct ::RArray.
  */
-#ifndef  RUBY3_RARRAY_H
-#define  RUBY3_RARRAY_H
 #include "ruby/3/arithmetic/long.h"
 #include "ruby/3/attr/artificial.h"
 #include "ruby/3/attr/constexpr.h"

--- a/include/ruby/3/core/rbasic.h
+++ b/include/ruby/3/core/rbasic.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_RBASIC_H                               /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_RBASIC_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines struct ::RBasic.
  */
-#ifndef  RUBY3_RBASIC_H
-#define  RUBY3_RBASIC_H
 #include "ruby/3/attr/artificial.h"
 #include "ruby/3/attr/constexpr.h"
 #include "ruby/3/attr/forceinline.h"

--- a/include/ruby/3/core/rbignum.h
+++ b/include/ruby/3/core/rbignum.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_RBIGNUM_H                              /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_RBIGNUM_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Routines to manipulate struct ::RBignum.
  */
-#ifndef  RUBY3_RBIGNUM_H
-#define  RUBY3_RBIGNUM_H
 #include "ruby/3/dllexport.h"
 #include "ruby/3/value.h"
 #include "ruby/3/value_type.h"

--- a/include/ruby/3/core/rclass.h
+++ b/include/ruby/3/core/rclass.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_RCLASS_H                               /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_RCLASS_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Routines to manipulate struct ::RClass.
  */
-#ifndef  RUBY3_RCLASS_H
-#define  RUBY3_RCLASS_H
 #include "ruby/3/dllexport.h"
 #include "ruby/3/value.h"
 #include "ruby/3/cast.h"

--- a/include/ruby/3/core/rdata.h
+++ b/include/ruby/3/core/rdata.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_RDATA_H                                /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_RDATA_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines struct ::RData.
  */
-#ifndef  RUBY3_RDATA_H
-#define  RUBY3_RDATA_H
 #include "ruby/3/config.h"
 
 #ifdef STDC_HEADERS

--- a/include/ruby/3/core/rdata.h
+++ b/include/ruby/3/core/rdata.h
@@ -32,6 +32,7 @@
 #include "ruby/3/core/rbasic.h"
 #include "ruby/3/dllexport.h"
 #include "ruby/3/fl_type.h"
+#include "ruby/3/token_paste.h"
 #include "ruby/3/value.h"
 #include "ruby/3/value_type.h"
 #include "ruby/defines.h"

--- a/include/ruby/3/core/rfile.h
+++ b/include/ruby/3/core/rfile.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_RFILE_H                                /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_RFILE_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines struct ::RFile.
  */
-#ifndef  RUBY3_RFILE_H
-#define  RUBY3_RFILE_H
 #include "ruby/3/core/rbasic.h"
 #include "ruby/3/cast.h"
 

--- a/include/ruby/3/core/rhash.h
+++ b/include/ruby/3/core/rhash.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_RHASH_H                                /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_RHASH_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -30,8 +32,6 @@
  *
  * Shyouhei stopped thinking.  Let them be as is.
  */
-#ifndef  RUBY3_RHASH_H
-#define  RUBY3_RHASH_H
 #include "ruby/3/config.h"
 
 #ifdef STDC_HEADERS

--- a/include/ruby/3/core/rmatch.h
+++ b/include/ruby/3/core/rmatch.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_RMATCH_H                               /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_RMATCH_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines struct ::RMatch.
  */
-#ifndef  RUBY3_RMATCH_H
-#define  RUBY3_RMATCH_H
 #include "ruby/3/attr/artificial.h"
 #include "ruby/3/attr/pure.h"
 #include "ruby/3/attr/returns_nonnull.h"

--- a/include/ruby/3/core/robject.h
+++ b/include/ruby/3/core/robject.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_ROBJECT_H                              /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_ROBJECT_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines struct ::RObject.
  */
-#ifndef  RUBY3_ROBJECT_H
-#define  RUBY3_ROBJECT_H
 #include "ruby/3/config.h"
 
 #ifdef HAVE_STDINT_H

--- a/include/ruby/3/core/rregexp.h
+++ b/include/ruby/3/core/rregexp.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_RREGEXP_H                              /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_RREGEXP_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines struct ::RRegexp.
  */
-#ifndef  RUBY3_RREGEXP_H
-#define  RUBY3_RREGEXP_H
 #include "ruby/3/attr/artificial.h"
 #include "ruby/3/attr/pure.h"
 #include "ruby/3/cast.h"

--- a/include/ruby/3/core/rstring.h
+++ b/include/ruby/3/core/rstring.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_RSTRING_H                              /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_RSTRING_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines struct ::RString.
  */
-#ifndef  RUBY3_RSTRING_H
-#define  RUBY3_RSTRING_H
 #include "ruby/3/config.h"
 #include "ruby/3/arithmetic/long.h"
 #include "ruby/3/attr/artificial.h"

--- a/include/ruby/3/core/rstruct.h
+++ b/include/ruby/3/core/rstruct.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_RSTRUCT_H                              /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_RSTRUCT_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Routines to manipulate struct ::RStruct.
  */
-#ifndef  RUBY3_RSTRUCT_H
-#define  RUBY3_RSTRUCT_H
 #include "ruby/3/attr/artificial.h"
 #include "ruby/3/dllexport.h"
 #include "ruby/3/value.h"

--- a/include/ruby/3/core/rtypeddata.h
+++ b/include/ruby/3/core/rtypeddata.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_RTYPEDDATA_H                           /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_RTYPEDDATA_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines struct ::RTypedData.
  */
-#ifndef  RUBY3_RTYPEDDATA_H
-#define  RUBY3_RTYPEDDATA_H
 #include "ruby/3/config.h"
 
 #ifdef STDC_HEADERS

--- a/include/ruby/3/ctype.h
+++ b/include/ruby/3/ctype.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_CTYPE_H                                /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_CTYPE_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Our own, locale independent, character handling routines.
  */
-#ifndef  RUBY3_CTYPE_H
-#define  RUBY3_CTYPE_H
 #include "ruby/3/config.h"
 
 #ifdef STDC_HEADERS

--- a/include/ruby/3/dllexport.h
+++ b/include/ruby/3/dllexport.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_DLLEXPORT_H                            /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_DLLEXPORT_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Tewaking visibility of C variables/functions.
  */
-#ifndef  RUBY3_DLLEXPORT_H
-#define  RUBY3_DLLEXPORT_H
 #include "ruby/3/config.h"
 #include "ruby/3/compiler_is.h"
 

--- a/include/ruby/3/dosish.h
+++ b/include/ruby/3/dosish.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_DOSISH_H                               /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_DOSISH_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Support for so-called dosish systems.
  */
-#ifndef RUBY3_DOSISH_H
-#define RUBY3_DOSISH_H
 #ifdef __CYGWIN__
 #undef _WIN32
 #endif

--- a/include/ruby/3/error.h
+++ b/include/ruby/3/error.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_ERROR_H                                /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_ERROR_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Declares ::rb_raise().
  */
-#ifndef  RUBY3_ERROR_H
-#define  RUBY3_ERROR_H
 #include "ruby/3/dllexport.h"
 #include "ruby/3/value.h"
 #include "ruby/backward/2/attributes.h"

--- a/include/ruby/3/eval.h
+++ b/include/ruby/3/eval.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_EVAL_H                                 /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_EVAL_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Declares ::rb_eval_string().
  */
-#ifndef  RUBY3_EVAL_H
-#define  RUBY3_EVAL_H
 #include "ruby/3/dllexport.h"
 #include "ruby/3/value.h"
 

--- a/include/ruby/3/event.h
+++ b/include/ruby/3/event.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_EVENT_H                                /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_EVENT_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Debugging and tracing APIs.
  */
-#ifndef  RUBY3_EVENT_H
-#define  RUBY3_EVENT_H
 #include "ruby/3/dllexport.h"
 #include "ruby/3/value.h"
 

--- a/include/ruby/3/fl_type.h
+++ b/include/ruby/3/fl_type.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_FL_TYPE_H                              /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_FL_TYPE_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines enum ::ruby_fl_type.
  */
-#ifndef  RUBY3_FL_TYPE_H
-#define  RUBY3_FL_TYPE_H
 #include "ruby/3/config.h"      /* for ENUM_OVER_INT */
 #include "ruby/3/attr/artificial.h"
 #include "ruby/3/attr/flag_enum.h"

--- a/include/ruby/3/gc.h
+++ b/include/ruby/3/gc.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_GC_H                                   /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_GC_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Registering values to the GC.
  */
-#ifndef  RUBY3_GC_H
-#define  RUBY3_GC_H
 #include "ruby/3/dllexport.h"
 #include "ruby/3/value.h"
 

--- a/include/ruby/3/glob.h
+++ b/include/ruby/3/glob.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_GLOB_H                                 /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_GLOB_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Declares ::rb_glob().
  */
-#ifndef  RUBY3_GLOB_H
-#define  RUBY3_GLOB_H
 #include "ruby/3/dllexport.h"
 #include "ruby/3/value.h"
 

--- a/include/ruby/3/globals.h
+++ b/include/ruby/3/globals.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_GLOBALS_H                              /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_GLOBALS_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Ruby-level global variables / constants, visible from C.
  */
-#ifndef  RUBY3_GLOBALS_H
-#define  RUBY3_GLOBALS_H
 #include "ruby/3/attr/pure.h"
 #include "ruby/3/dllexport.h"
 #include "ruby/3/fl_type.h"

--- a/include/ruby/3/has/attribute.h
+++ b/include/ruby/3/has/attribute.h
@@ -21,6 +21,8 @@
  * @brief      Defines #RUBY3_HAS_ATTRIBUTE.
  */
 #include "ruby/3/config.h"
+#include "ruby/3/compiler_since.h"
+#include "ruby/3/token_paste.h"
 
 /** Wraps (or simulates) `__has_attribute`. */
 #if defined(__has_attribute)

--- a/include/ruby/3/has/attribute.h
+++ b/include/ruby/3/has/attribute.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_HAS_ATTRIBUTE_H                        /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_HAS_ATTRIBUTE_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -21,10 +23,7 @@
 #include "ruby/3/config.h"
 
 /** Wraps (or simulates) `__has_attribute`. */
-#if defined(RUBY3_HAS_ATTRIBUTE)
-# /* Take that. */
-
-#elif defined(__has_attribute)
+#if defined(__has_attribute)
 # define RUBY3_HAS_ATTRIBUTE(_) __has_attribute(_)
 
 #elif RUBY3_COMPILER_IS(GCC)
@@ -150,3 +149,5 @@
 #  define RUBY3_HAS_ATTRIBUTE_weak 1
 # endif
 #endif
+
+#endif /* RUBY3_HAS_ATTRIBUTE_H */

--- a/include/ruby/3/has/builtin.h
+++ b/include/ruby/3/has/builtin.h
@@ -21,6 +21,8 @@
  * @brief      Defines #RUBY3_HAS_BUILTIN.
  */
 #include "ruby/3/config.h"
+#include "ruby/3/compiler_since.h"
+#include "ruby/3/token_paste.h"
 
 /** Wraps (or simulates) `__has_builtin`. */
 #if defined(__has_builtin) && ! RUBY3_COMPILER_IS(Intel)

--- a/include/ruby/3/has/builtin.h
+++ b/include/ruby/3/has/builtin.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_HAS_BUILTIN_H                          /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_HAS_BUILTIN_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -21,10 +23,7 @@
 #include "ruby/3/config.h"
 
 /** Wraps (or simulates) `__has_builtin`. */
-#if defined(RUBY3_HAS_BUILTIN)
-# /* Take that. */
-
-#elif defined(__has_builtin) && ! RUBY3_COMPILER_IS(Intel)
+#if defined(__has_builtin) && ! RUBY3_COMPILER_IS(Intel)
 # /* :TODO:  Intel C  Compiler has  __has_builtin (since  19.1 maybe?),  and is
 #  * reportedly  broken.  We  have to  skip  them.  However  the situation  can
 #  * change.  They might improve someday.  We need to revisit here later. */
@@ -89,3 +88,5 @@
 #  define RUBY3_HAS_BUILTIN___builtin_unreachable 1
 # endif
 #endif
+
+#endif /* RUBY3_HAS_BUILTIN_H */

--- a/include/ruby/3/has/c_attribute.h
+++ b/include/ruby/3/has/c_attribute.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_HAS_C_ATTRIBUTE_H                      /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_HAS_C_ATTRIBUTE_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -20,10 +22,7 @@
  */
 
 /** Wraps (or simulates) `__has_c_attribute`. */
-#if defined(RUBY3_HAS_C_ATTRIBUTE)
-# /* Take that. */
-
-#elif defined(__cplusplus)
+#if defined(__cplusplus)
 # /* Makes no sense. */
 # define RUBY3_HAS_C_ATTRIBUTE(_) 0
 
@@ -35,3 +34,5 @@
 #  * lacks C2x attributes as well.  Might change in future? */
 # define RUBY3_HAS_C_ATTRIBUTE(_) 0
 #endif
+
+#endif /* RUBY3_HAS_C_ATTRIBUTE_H */

--- a/include/ruby/3/has/cpp_attribute.h
+++ b/include/ruby/3/has/cpp_attribute.h
@@ -21,6 +21,8 @@
  * @brief      Defines #RUBY3_HAS_CPP_ATTRIBUTE.
  */
 #include "ruby/3/compiler_is.h"
+#include "ruby/3/compiler_since.h"
+#include "ruby/3/token_paste.h"
 
 /** @cond INTERNAL_MACRO */
 #if defined(__has_cpp_attribute)

--- a/include/ruby/3/has/cpp_attribute.h
+++ b/include/ruby/3/has/cpp_attribute.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_HAS_CPP_ATTRIBUTE_H                    /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_HAS_CPP_ATTRIBUTE_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -21,10 +23,7 @@
 #include "ruby/3/compiler_is.h"
 
 /** @cond INTERNAL_MACRO */
-#if defined(RUBY3_HAS_CPP_ATTRIBUTE0)
-# /* Take that. */
-
-#elif defined(__has_cpp_attribute)
+#if defined(__has_cpp_attribute)
 # define RUBY3_HAS_CPP_ATTRIBUTE0(_) __has_cpp_attribute(_)
 
 #elif RUBY3_COMPILER_IS(MSVC)
@@ -66,15 +65,13 @@
 /** @endcond */
 
 /** Wraps (or simulates) `__has_cpp_attribute`. */
-#ifdef RUBY3_HAS_CPP_ATTRIBUTE
-# /* Take that. */
-
-#elif ! defined(__cplusplus)
+#if ! defined(__cplusplus)
 # /* Makes no sense. */
 # define RUBY3_HAS_CPP_ATTRIBUTE(_) 0
-
 #else
 # /* GCC needs workarounds.  See https://gcc.godbolt.org/z/jdz3pa */
 # define RUBY3_HAS_CPP_ATTRIBUTE(_) \
     ((RUBY3_HAS_CPP_ATTRIBUTE0(_) <= __cplusplus) ? RUBY3_HAS_CPP_ATTRIBUTE0(_) : 0)
 #endif
+
+#endif /* RUBY3_HAS_CPP_ATTRIBUTE_H */

--- a/include/ruby/3/has/declspec_attribute.h
+++ b/include/ruby/3/has/declspec_attribute.h
@@ -20,6 +20,8 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines #RUBY3_HAS_DECLSPEC_ATTRIBUTE.
  */
+#include "ruby/3/compiler_since.h"
+#include "ruby/3/token_paste.h"
 
 /** Wraps (or simulates) `__has_declspec_attribute`. */
 #if defined(__has_declspec_attribute)

--- a/include/ruby/3/has/declspec_attribute.h
+++ b/include/ruby/3/has/declspec_attribute.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_HAS_DECLSPEC_ATTRIBUTE_H               /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_HAS_DECLSPEC_ATTRIBUTE_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -20,12 +22,8 @@
  */
 
 /** Wraps (or simulates) `__has_declspec_attribute`. */
-#if defined(RUBY3_HAS_DECLSPEC_ATTRIBUTE)
-# /* Take that. */
-
-#elif defined(__has_declspec_attribute)
+#if defined(__has_declspec_attribute)
 # define RUBY3_HAS_DECLSPEC_ATTRIBUTE(_) __has_declspec_attribute(_)
-
 #else
 # define RUBY3_HAS_DECLSPEC_ATTRIBUTE(_) RUBY3_TOKEN_PASTE(RUBY3_HAS_DECLSPEC_ATTRIBUTE_, _)
 # define RUBY3_HAS_DECLSPEC_ATTRIBUTE_align       RUBY3_COMPILER_SINCE(MSVC, 8, 0, 0)
@@ -44,3 +42,5 @@
 #  undef RUBY3_HAS_DECLSPEC_ATTRIBUTE_nothrow
 # endif
 #endif
+
+#endif /* RUBY3_HAS_DECLSPEC_ATTRIBUTE_H */

--- a/include/ruby/3/has/extension.h
+++ b/include/ruby/3/has/extension.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_HAS_EXTENSION_H                        /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_HAS_EXTENSION_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -21,13 +23,11 @@
 #include "ruby/3/has/feature.h"
 
 /** Wraps (or simulates) `__has_extension`. */
-#if defined(RUBY3_HAS_EXTENSION)
-# /* Take that. */
-
-#elif defined(__has_extension)
+#if defined(__has_extension)
 # define RUBY3_HAS_EXTENSION(_) __has_extension(_)
-
 #else
 # /* Pre-3.0 clang had __has_feature but not __has_extension. */
 # define RUBY3_HAS_EXTENSION(_) RUBY3_HAS_FEATURE(_)
 #endif
+
+#endif /* RUBY3_HAS_EXTENSION_H */

--- a/include/ruby/3/has/feature.h
+++ b/include/ruby/3/has/feature.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_HAS_FEATURE_H                          /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_HAS_FEATURE_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -20,12 +22,10 @@
  */
 
 /** Wraps (or simulates) `__has_feature`. */
-#if defined(RUBY3_HAS_FEATURE)
-# /* Take that. */
-
-#elif defined(__has_feature)
+#if defined(__has_feature)
 # define RUBY3_HAS_FEATURE(_) __has_feature(_)
-
 #else
 # define RUBY3_HAS_FEATURE(_) 0
 #endif
+
+#endif /* RUBY3_HAS_FEATURE_H */

--- a/include/ruby/3/has/warning.h
+++ b/include/ruby/3/has/warning.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_HAS_WARNING_H                          /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_HAS_WARNING_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -20,12 +22,10 @@
  */
 
 /** Wraps (or simulates) `__has_warning`. */
-#if defined(RUBY3_HAS_WARNING)
-# /* Take that. */
-
-#elif defined(__has_warning)
+#if defined(__has_warning)
 # define RUBY3_HAS_WARNING(_) __has_warning(_)
-
 #else
 # define RUBY3_HAS_WARNING(_) 0
 #endif
+
+#endif /* RUBY3_HAS_WARNING_H */

--- a/include/ruby/3/intern/array.h
+++ b/include/ruby/3/intern/array.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_INTERN_ARRAY_H                         /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_INTERN_ARRAY_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Public APIs related to ::rb_cArray.
  */
-#ifndef  RUBY3_INTERN_ARRAY_H
-#define  RUBY3_INTERN_ARRAY_H
 #include "ruby/3/dllexport.h"
 #include "ruby/3/value.h"
 

--- a/include/ruby/3/intern/bignum.h
+++ b/include/ruby/3/intern/bignum.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_INTERN_BIGNUM_H                        /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_INTERN_BIGNUM_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Public APIs related to so-called rb_cBignum.
  */
-#ifndef  RUBY3_INTERN_BIGNUM_H
-#define  RUBY3_INTERN_BIGNUM_H
 #include "ruby/3/config.h"
 
 #ifdef STDC_HEADERS

--- a/include/ruby/3/intern/class.h
+++ b/include/ruby/3/intern/class.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_INTERN_CLASS_H                         /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_INTERN_CLASS_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Public APIs related to ::rb_cClass/::rb_cModule.
  */
-#ifndef  RUBY3_INTERN_CLASS_H
-#define  RUBY3_INTERN_CLASS_H
 #include "ruby/3/dllexport.h"
 #include "ruby/3/value.h"
 #include "ruby/backward/2/stdarg.h"

--- a/include/ruby/3/intern/compar.h
+++ b/include/ruby/3/intern/compar.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef  RUBY3_INTERN_COMPAR_H                       /*-*-C++-*-vi:se ft=cpp:*/
+#define  RUBY3_INTERN_COMPAR_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Public APIs related to ::rb_mComparable.
  */
-#ifndef  RUBY3_INTERN_COMPAR_H
-#define  RUBY3_INTERN_COMPAR_H
 #include "ruby/3/dllexport.h"
 #include "ruby/3/value.h"
 

--- a/include/ruby/3/intern/complex.h
+++ b/include/ruby/3/intern/complex.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_INTERN_COMPLEX_H                       /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_INTERN_COMPLEX_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Public APIs related to ::rb_cComplex.
  */
-#ifndef  RUBY3_INTERN_COMPLEX_H
-#define  RUBY3_INTERN_COMPLEX_H
 #include "ruby/3/dllexport.h"
 #include "ruby/3/value.h"
 #include "ruby/3/arithmetic/long.h" /* INT2FIX is here. */

--- a/include/ruby/3/intern/cont.h
+++ b/include/ruby/3/intern/cont.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef  RUBY3_INTERN_CONT_H                         /*-*-C++-*-vi:se ft=cpp:*/
+#define  RUBY3_INTERN_CONT_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Public APIs related to rb_cFiber.
  */
-#ifndef  RUBY3_INTERN_CONT_H
-#define  RUBY3_INTERN_CONT_H
 #include "ruby/3/dllexport.h"
 #include "ruby/3/value.h"
 #include "ruby/3/iterator.h"

--- a/include/ruby/3/intern/dir.h
+++ b/include/ruby/3/intern/dir.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_INTERN_DIR_H                           /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_INTERN_DIR_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Public APIs related to ::rb_cDir.
  */
-#ifndef  RUBY3_INTERN_DIR_H
-#define  RUBY3_INTERN_DIR_H
 #include "ruby/3/dllexport.h"
 #include "ruby/3/value.h"
 

--- a/include/ruby/3/intern/enum.h
+++ b/include/ruby/3/intern/enum.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_INTERN_ENUM_H                          /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_INTERN_ENUM_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Public APIs related to ::rb_mEnumerable.
  */
-#ifndef  RUBY3_INTERN_ENUM_H
-#define  RUBY3_INTERN_ENUM_H
 #include "ruby/3/dllexport.h"
 #include "ruby/3/value.h"
 

--- a/include/ruby/3/intern/enumerator.h
+++ b/include/ruby/3/intern/enumerator.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_INTERN_ENUMERATOR_H                    /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_INTERN_ENUMERATOR_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Public APIs related to ::rb_cEnumerator.
  */
-#ifndef  RUBY3_INTERN_ENUMERATOR_H
-#define  RUBY3_INTERN_ENUMERATOR_H
 #include "ruby/3/dllexport.h"
 #include "ruby/3/intern/eval.h" /* rb_frame_this_func */
 #include "ruby/3/iterator.h"    /* rb_block_given_p */

--- a/include/ruby/3/intern/error.h
+++ b/include/ruby/3/intern/error.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_INTERN_ERROR_H                         /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_INTERN_ERROR_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Public APIs related to ::rb_eException.
  */
-#ifndef  RUBY3_INTERN_ERROR_H
-#define  RUBY3_INTERN_ERROR_H
 #include "ruby/3/dllexport.h"
 #include "ruby/3/value.h"
 #include "ruby/3/fl_type.h"

--- a/include/ruby/3/intern/eval.h
+++ b/include/ruby/3/intern/eval.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef  RUBY3_INTERN_EVAL_H                         /*-*-C++-*-vi:se ft=cpp:*/
+#define  RUBY3_INTERN_EVAL_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Pre-1.9 era evaluator APIs (now considered miscellaneous).
  */
-#ifndef  RUBY3_INTERN_EVAL_H
-#define  RUBY3_INTERN_EVAL_H
 #include "ruby/3/attr/noreturn.h"
 #include "ruby/3/dllexport.h"
 #include "ruby/3/value.h"

--- a/include/ruby/3/intern/file.h
+++ b/include/ruby/3/intern/file.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_INTERN_FILE_H                          /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_INTERN_FILE_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Public APIs related to ::rb_cFile.
  */
-#ifndef  RUBY3_INTERN_FILE_H
-#define  RUBY3_INTERN_FILE_H
 #include "ruby/3/dllexport.h"
 #include "ruby/3/value.h"
 

--- a/include/ruby/3/intern/gc.h
+++ b/include/ruby/3/intern/gc.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_INTERN_GC_H                            /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_INTERN_GC_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Public APIs related to ::rb_mGC.
  */
-#ifndef  RUBY3_INTERN_GC_H
-#define  RUBY3_INTERN_GC_H
 #include "ruby/3/dllexport.h"
 #include "ruby/3/value.h"
 #include "ruby/backward/2/attributes.h"

--- a/include/ruby/3/intern/hash.h
+++ b/include/ruby/3/intern/hash.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_INTERN_HASH_H                          /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_INTERN_HASH_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Public APIs related to ::rb_cHash.
  */
-#ifndef  RUBY3_INTERN_HASH_H
-#define  RUBY3_INTERN_HASH_H
 #include "ruby/3/dllexport.h"
 #include "ruby/3/value.h"
 #include "ruby/st.h"

--- a/include/ruby/3/intern/io.h
+++ b/include/ruby/3/intern/io.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_INTERN_IO_H                            /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_INTERN_IO_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Public APIs related to ::rb_cIO.
  */
-#ifndef  RUBY3_INTERN_IO_H
-#define  RUBY3_INTERN_IO_H
 #include "ruby/3/dllexport.h"
 #include "ruby/3/value.h"
 

--- a/include/ruby/3/intern/load.h
+++ b/include/ruby/3/intern/load.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef  RUBY3_INTERN_LOAD_H                         /*-*-C++-*-vi:se ft=cpp:*/
+#define  RUBY3_INTERN_LOAD_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Public APIs related to ::rb_f_require().
  */
-#ifndef  RUBY3_INTERN_LOAD_H
-#define  RUBY3_INTERN_LOAD_H
 #include "ruby/3/dllexport.h"
 #include "ruby/3/value.h"
 

--- a/include/ruby/3/intern/marshal.h
+++ b/include/ruby/3/intern/marshal.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_INTERN_MARSHAL_H                       /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_INTERN_MARSHAL_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Public APIs related to rb_mMarshal.
  */
-#ifndef  RUBY3_INTERN_MARSHAL_H
-#define  RUBY3_INTERN_MARSHAL_H
 #include "ruby/3/dllexport.h"
 #include "ruby/3/value.h"
 

--- a/include/ruby/3/intern/numeric.h
+++ b/include/ruby/3/intern/numeric.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_INTERN_NUMERIC_H                       /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_INTERN_NUMERIC_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Public APIs related to ::rb_cNumeric.
  */
-#ifndef  RUBY3_INTERN_NUMERIC_H
-#define  RUBY3_INTERN_NUMERIC_H
 #include "ruby/3/dllexport.h"
 #include "ruby/3/value.h"
 #include "ruby/backward/2/attributes.h"

--- a/include/ruby/3/intern/object.h
+++ b/include/ruby/3/intern/object.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_INTERN_OBJECT_H                        /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_INTERN_OBJECT_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Public APIs related to ::rb_cObject.
  */
-#ifndef  RUBY3_INTERN_OBJECT_H
-#define  RUBY3_INTERN_OBJECT_H
 #include "ruby/3/attr/pure.h"
 #include "ruby/3/dllexport.h"
 #include "ruby/3/value.h"

--- a/include/ruby/3/intern/parse.h
+++ b/include/ruby/3/intern/parse.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_INTERN_PARSE_H                         /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_INTERN_PARSE_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Public APIs related to ::rb_cSymbol.
  */
-#ifndef  RUBY3_INTERN_PARSE_H
-#define  RUBY3_INTERN_PARSE_H
 #include "ruby/3/attr/const.h"
 #include "ruby/3/dllexport.h"
 #include "ruby/3/value.h"

--- a/include/ruby/3/intern/proc.h
+++ b/include/ruby/3/intern/proc.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_INTERN_PROC_H                          /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_INTERN_PROC_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Public APIs related to ::rb_cProc.
  */
-#ifndef  RUBY3_INTERN_PROC_H
-#define  RUBY3_INTERN_PROC_H
 #include "ruby/3/dllexport.h"
 #include "ruby/3/iterator.h"
 #include "ruby/3/value.h"

--- a/include/ruby/3/intern/process.h
+++ b/include/ruby/3/intern/process.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_INTERN_PROCESS_H                       /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_INTERN_PROCESS_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Public APIs related to ::rb_mProcess.
  */
-#ifndef  RUBY3_INTERN_PROCESS_H
-#define  RUBY3_INTERN_PROCESS_H
 #include "ruby/3/attr/noreturn.h"
 #include "ruby/3/config.h"      /* rb_pid_t is defined here. */
 #include "ruby/3/dllexport.h"

--- a/include/ruby/3/intern/random.h
+++ b/include/ruby/3/intern/random.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_INTERN_RANDOM_H                        /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_INTERN_RANDOM_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -22,8 +24,6 @@
  *             generator", ACM  Trans. on  Modeling and Computer  Simulation, 8
  *             (1): pp 3-30, 1998.  https://doi.org/10.1145/272991.272995
  */
-#ifndef  RUBY3_INTERN_RANDOM_H
-#define  RUBY3_INTERN_RANDOM_H
 #include "ruby/3/dllexport.h"
 #include "ruby/3/value.h"
 

--- a/include/ruby/3/intern/range.h
+++ b/include/ruby/3/intern/range.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_INTERN_RANGE_H                         /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_INTERN_RANGE_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Public APIs related to ::rb_cRange.
  */
-#ifndef  RUBY3_INTERN_RANGE_H
-#define  RUBY3_INTERN_RANGE_H
 #include "ruby/3/dllexport.h"
 #include "ruby/3/value.h"
 

--- a/include/ruby/3/intern/rational.h
+++ b/include/ruby/3/intern/rational.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_INTERN_RATIONAL_H                      /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_INTERN_RATIONAL_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Public APIs related to ::rb_cRational.
  */
-#ifndef  RUBY3_INTERN_RATIONAL_H
-#define  RUBY3_INTERN_RATIONAL_H
 #include "ruby/3/dllexport.h"
 #include "ruby/3/value.h"
 #include "ruby/3/arithmetic/long.h" /* INT2FIX is here. */

--- a/include/ruby/3/intern/re.h
+++ b/include/ruby/3/intern/re.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_INTERN_RE_H                            /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_INTERN_RE_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Public APIs related to ::rb_cRegexp.
  */
-#ifndef  RUBY3_INTERN_RE_H
-#define  RUBY3_INTERN_RE_H
 #include "ruby/3/dllexport.h"
 #include "ruby/3/value.h"
 

--- a/include/ruby/3/intern/ruby.h
+++ b/include/ruby/3/intern/ruby.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_INTERN_RUBY_H                          /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_INTERN_RUBY_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Process-global APIs.
  */
-#ifndef  RUBY3_INTERN_RUBY_H
-#define  RUBY3_INTERN_RUBY_H
 #include "ruby/3/dllexport.h"
 #include "ruby/3/value.h"
 

--- a/include/ruby/3/intern/select.h
+++ b/include/ruby/3/intern/select.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_INTERN_SELECT_H                        /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_INTERN_SELECT_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -20,8 +22,6 @@
  * @note       Functions  and  structs defined  in  this  header file  are  not
  *             necessarily ruby-specific.  They don't need ::VALUE etc.
  */
-#ifndef  RUBY3_INTERN_SELECT_H
-#define  RUBY3_INTERN_SELECT_H
 #include "ruby/3/config.h"
 
 #ifdef HAVE_SYS_TYPES_H

--- a/include/ruby/3/intern/select/largesize.h
+++ b/include/ruby/3/intern/select/largesize.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_INTERN_SELECT_LARGESIZE_H              /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_INTERN_SELECT_LARGESIZE_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -53,8 +55,6 @@
  *
  * So `rb_fd_set` doesn't reject file descriptors bigger than `FD_SETSIZE`.
  */
-#ifndef  RUBY3_INTERN_SELECT_LARGESIZE_H
-#define  RUBY3_INTERN_SELECT_LARGESIZE_H
 #include "ruby/3/attr/nonnull.h"
 #include "ruby/3/attr/pure.h"
 #include "ruby/3/dllexport.h"

--- a/include/ruby/3/intern/select/posix.h
+++ b/include/ruby/3/intern/select/posix.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_INTERN_SELECT_POSIX_H                  /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_INTERN_SELECT_POSIX_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Public APIs to provide ::rb_fd_select().
  */
-#ifndef  RUBY3_INTERN_SELECT_POSIX_H
-#define  RUBY3_INTERN_SELECT_POSIX_H
 #include "ruby/3/config.h"
 
 #ifdef HAVE_SYS_SELECT_H

--- a/include/ruby/3/intern/select/win32.h
+++ b/include/ruby/3/intern/select/win32.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_INTERN_SELECT_WIN32_H                  /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_INTERN_SELECT_WIN32_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Public APIs to provide ::rb_fd_select().
  */
-#ifndef  RUBY3_INTERN_SELECT_WIN32_H
-#define  RUBY3_INTERN_SELECT_WIN32_H
 #include "ruby/3/dosish.h"      /* for rb_w32_select */
 #include "ruby/3/attr/nonnull.h"
 #include "ruby/3/attr/pure.h"

--- a/include/ruby/3/intern/signal.h
+++ b/include/ruby/3/intern/signal.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_INTERN_SIGNAL_H                        /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_INTERN_SIGNAL_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Signal handling APIs.
  */
-#ifndef  RUBY3_INTERN_SIGNAL_H
-#define  RUBY3_INTERN_SIGNAL_H
 #include "ruby/3/config.h"      /* POSIX_SIGNAL / RETSIGTYPE */
 #include "ruby/3/dllexport.h"
 #include "ruby/3/value.h"

--- a/include/ruby/3/intern/sprintf.h
+++ b/include/ruby/3/intern/sprintf.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_INTERN_SPRINTF_H                       /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_INTERN_SPRINTF_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Our own private printf(3).
  */
-#ifndef  RUBY3_INTERN_SPRINTF_H
-#define  RUBY3_INTERN_SPRINTF_H
 #include "ruby/3/attr/format.h"
 #include "ruby/3/dllexport.h"
 #include "ruby/3/value.h"

--- a/include/ruby/3/intern/string.h
+++ b/include/ruby/3/intern/string.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_INTERN_STRING_H                        /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_INTERN_STRING_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Public APIs related to ::rb_cString.
  */
-#ifndef  RUBY3_INTERN_STRING_H
-#define  RUBY3_INTERN_STRING_H
 #include "ruby/3/config.h"
 
 #ifdef STDC_HEADERS

--- a/include/ruby/3/intern/struct.h
+++ b/include/ruby/3/intern/struct.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_INTERN_STRUCT_H                        /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_INTERN_STRUCT_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Public APIs related to ::rb_cStruct.
  */
-#ifndef  RUBY3_INTERN_STRUCT_H
-#define  RUBY3_INTERN_STRUCT_H
 #include "ruby/3/dllexport.h"
 #include "ruby/3/intern/vm.h" /* rb_alloc_func_t */
 #include "ruby/3/value.h"

--- a/include/ruby/3/intern/thread.h
+++ b/include/ruby/3/intern/thread.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_INTERN_THREAD_H                        /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_INTERN_THREAD_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,10 +20,7 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Public APIs related to ::rb_cThread.
  */
-#ifndef  RUBY3_INTERN_THREAD_H
-#define  RUBY3_INTERN_THREAD_H
 #include "ruby/3/config.h"
-
 #include "ruby/3/cast.h"
 #include "ruby/3/dllexport.h"
 #include "ruby/3/value.h"

--- a/include/ruby/3/intern/time.h
+++ b/include/ruby/3/intern/time.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_INTERN_TIME_H                         /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_INTERN_TIME_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -16,10 +18,8 @@
  *             Do not  expect for  instance `__VA_ARGS__` is  always available.
  *             We assume C99  for ruby itself but we don't  assume languages of
  *             extension libraries. They could be written in C++98.
- * @brief      Public APIs related to ::rb_cStruct.
+ * @brief      Public APIs related to ::rb_cTime.
  */
-#ifndef  RUBY3_INTERN_TIME_H
-#define  RUBY3_INTERN_TIME_H
 #include "ruby/3/config.h"
 
 #ifdef HAVE_TIME_H

--- a/include/ruby/3/intern/variable.h
+++ b/include/ruby/3/intern/variable.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_INTERN_VARIABLE_H                      /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_INTERN_VARIABLE_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Public APIs related to names inside of a Ruby program.
  */
-#ifndef  RUBY3_INTERN_VARIABLE_H
-#define  RUBY3_INTERN_VARIABLE_H
 #include "ruby/3/attr/noreturn.h"
 #include "ruby/3/dllexport.h"
 #include "ruby/3/value.h"

--- a/include/ruby/3/intern/vm.h
+++ b/include/ruby/3/intern/vm.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_INTERN_VM_H                            /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_INTERN_VM_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Public APIs related to ::rb_cRubyVM.
  */
-#ifndef  RUBY3_INTERN_VM_H
-#define  RUBY3_INTERN_VM_H
 #include "ruby/3/attr/noreturn.h"
 #include "ruby/3/dllexport.h"
 #include "ruby/3/value.h"

--- a/include/ruby/3/interpreter.h
+++ b/include/ruby/3/interpreter.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_INTERPRETER_H                          /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_INTERPRETER_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Interpreter embedding APIs.
  */
-#ifndef  RUBY3_INTERPRETER_H
-#define  RUBY3_INTERPRETER_H
 #include "ruby/3/attr/noreturn.h"
 #include "ruby/3/dllexport.h"
 #include "ruby/3/value.h"
@@ -53,7 +53,6 @@ void ruby_show_version(void);
 #ifndef ruby_show_copyright
 void ruby_show_copyright(void);
 #endif
-
 
 /*! A convenience macro to call ruby_init_stack(). Must be placed just after
  *  variable declarations */

--- a/include/ruby/3/iterator.h
+++ b/include/ruby/3/iterator.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_ITERATOR_H                             /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_ITERATOR_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Block related APIs.
  */
-#ifndef  RUBY3_ITERATOR_H
-#define  RUBY3_ITERATOR_H
 #include "ruby/3/attr/noreturn.h"
 #include "ruby/3/dllexport.h"
 #include "ruby/3/value.h"

--- a/include/ruby/3/memory.h
+++ b/include/ruby/3/memory.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_MEMORY_H                               /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_MEMORY_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Memory management stuff.
  */
-#ifndef  RUBY3_MEMORY_H
-#define  RUBY3_MEMORY_H
 #include "ruby/3/config.h"
 
 #ifdef STDC_HEADERS

--- a/include/ruby/3/method.h
+++ b/include/ruby/3/method.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_METHOD_H                               /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_METHOD_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Creation and modification of Ruby methods.
  */
-#ifndef  RUBY3_METHOD_H
-#define  RUBY3_METHOD_H
 #include "ruby/3/dllexport.h"
 #include "ruby/3/value.h"
 #include "ruby/backward/2/stdarg.h"

--- a/include/ruby/3/module.h
+++ b/include/ruby/3/module.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_MODULE_H                               /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_MODULE_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Creation and modification of Ruby modules.
  */
-#ifndef  RUBY3_MODULE_H
-#define  RUBY3_MODULE_H
 #include "ruby/3/dllexport.h"
 #include "ruby/3/value.h"
 

--- a/include/ruby/3/newobj.h
+++ b/include/ruby/3/newobj.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_NEWOBJ_H                               /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_NEWOBJ_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines #NEWOBJ.
  */
-#ifndef  RUBY3_NEWOBJ_H
-#define  RUBY3_NEWOBJ_H
 #include "ruby/3/cast.h"
 #include "ruby/3/core/rbasic.h"
 #include "ruby/3/dllexport.h"

--- a/include/ruby/3/rgengc.h
+++ b/include/ruby/3/rgengc.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_RGENGC_H                               /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_RGENGC_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -22,8 +24,6 @@
  *             International  Symposium on  Memory Management  (ISMM 2019),  pp
  *             115-121, 2019. https://doi.org/10.1145/3315573.3329986
  */
-#ifndef  RUBY3_RGENGC_H
-#define  RUBY3_RGENGC_H
 #include "ruby/3/attr/artificial.h"
 #include "ruby/3/attr/pure.h"
 #include "ruby/3/dllexport.h"

--- a/include/ruby/3/scan_args.h
+++ b/include/ruby/3/scan_args.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_SCAN_ARGS_H                            /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_SCAN_ARGS_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -21,8 +23,6 @@
  * This  is a  beast.  It  statically analyses  the argument  spec string,  and
  * expands the assignment of variables into dedicated codes.
  */
-#ifndef  RUBY3_SCAN_ARGS_H
-#define  RUBY3_SCAN_ARGS_H
 #include "ruby/3/attr/diagnose_if.h"
 #include "ruby/3/attr/error.h"
 #include "ruby/3/attr/forceinline.h"

--- a/include/ruby/3/special_consts.h
+++ b/include/ruby/3/special_consts.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_SPECIAL_CONSTS_H                       /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_SPECIAL_CONSTS_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -22,8 +24,6 @@
  *             SIGPPL  Workshop   on  Programming  and   Programming  Languages
  *             (PPL2008), pp. 9-16, 2008.
  */
-#ifndef  RUBY3_SPECIAL_CONSTS_H
-#define  RUBY3_SPECIAL_CONSTS_H
 #include "ruby/3/attr/artificial.h"
 #include "ruby/3/attr/const.h"
 #include "ruby/3/attr/constexpr.h"
@@ -163,7 +163,6 @@ RB_FLONUM_P(VALUE obj)
     return false;
 #endif
 }
-
 
 RUBY3_ATTR_CONST()
 RUBY3_ATTR_CONSTEXPR(CXX11)

--- a/include/ruby/3/static_assert.h
+++ b/include/ruby/3/static_assert.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_STATIC_ASSERT_H                        /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_STATIC_ASSERT_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -22,10 +24,7 @@
 #include "ruby/3/has/extension.h"
 
 /** @cond INTERNAL_MACRO */
-#if defined(RUBY3_STATIC_ASSERT0)
-# /* Take that. */
-
-#elif defined(__cplusplus) && defined(__cpp_static_assert)
+#if defined(__cplusplus) && defined(__cpp_static_assert)
 # /* https://isocpp.org/std/standing-documents/sd-6-sg10-feature-test-recommendations */
 # define RUBY3_STATIC_ASSERT0 static_assert
 
@@ -62,10 +61,7 @@
  * @param  expr  Expression to assert.
  * @note   `name` shall not be a string literal.
  */
-#if defined(RUBY3_STATIC_ASSERT)
-# /* Take that. */
-
-#elif defined(__DOXYGEN__)
+#if defined(__DOXYGEN__)
 # define RUBY3_STATIC_ASSERT static_assert
 
 #elif defined(RUBY3_STATIC_ASSERT0)
@@ -76,3 +72,5 @@
 # define RUBY3_STATIC_ASSERT(name, expr) \
     typedef int static_assert_ ## name ## _check[1 - 2 * !(expr)]
 #endif
+
+#endif /* RUBY3_STATIC_ASSERT_H */

--- a/include/ruby/3/static_assert.h
+++ b/include/ruby/3/static_assert.h
@@ -22,6 +22,7 @@
  */
 #include <assert.h>
 #include "ruby/3/has/extension.h"
+#include "ruby/3/compiler_since.h"
 
 /** @cond INTERNAL_MACRO */
 #if defined(__cplusplus) && defined(__cpp_static_assert)

--- a/include/ruby/3/stdalign.h
+++ b/include/ruby/3/stdalign.h
@@ -27,8 +27,10 @@
 #endif
 
 #include "ruby/3/compiler_is.h"
+#include "ruby/3/compiler_since.h"
 #include "ruby/3/has/feature.h"
 #include "ruby/3/has/extension.h"
+#include "ruby/3/has/attribute.h"
 #include "ruby/3/has/declspec_attribute.h"
 
 /**

--- a/include/ruby/3/stdalign.h
+++ b/include/ruby/3/stdalign.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_STDALIGN_H                             /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_STDALIGN_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -48,10 +50,7 @@
  * - You cannot `struct _Alignas`.
  * - A `typedef` cannot have alignments.
  */
-#if defined(RUBY3_ALIGNAS)
-# /* OK, take that. */
-
-#elif defined(__cplusplus) && RUBY3_HAS_FEATURE(cxx_alignas)
+#if defined(__cplusplus) && RUBY3_HAS_FEATURE(cxx_alignas)
 # define RUBY3_ALIGNAS alignas
 
 #elif defined(__cplusplus) && (__cplusplus >= 201103L)
@@ -77,10 +76,7 @@
  * Wraps (or  simulates) `alignof`.   Unlike #RUBY3_ALIGNAS,  we can  safely say
  * both C/C++ definitions are effective.
  */
-#ifdef RUBY3_ALIGNOF
-# /* OK, take that. */
-
-#elif defined(__cplusplus) && RUBY3_HAS_EXTENSION(cxx_alignof)
+#if defined(__cplusplus) && RUBY3_HAS_EXTENSION(cxx_alignof)
 # define RUBY3_ALIGNOF __extension__ alignof
 
 #elif defined(__cplusplus) && (__cplusplus >= 201103L)
@@ -122,3 +118,5 @@
 #else
 # error :FIXME: add your compiler here to obtain an alignment.
 #endif
+
+#endif /* RUBY3_STDALIGN_H */

--- a/include/ruby/3/stdbool.h
+++ b/include/ruby/3/stdbool.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_STDBOOL_H                              /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_STDBOOL_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -45,3 +47,5 @@ typedef unsigned char _Bool;
 # define false ((_Bool)+0)
 # define __bool_true_false_are_defined
 #endif
+
+#endif /* RUBY3_STDBOOL_H */

--- a/include/ruby/3/symbol.h
+++ b/include/ruby/3/symbol.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_SYMBOL_H                               /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_SYMBOL_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines #rb_intern
  */
-#ifndef  RUBY3_SYMBOL_H
-#define  RUBY3_SYMBOL_H
 #include "ruby/3/config.h"
 
 #ifdef HAVE_STDDEF_H

--- a/include/ruby/3/token_paste.h
+++ b/include/ruby/3/token_paste.h
@@ -21,6 +21,9 @@
  * @brief      Defines #RUBY3_TOKEN_PASTE.
  */
 #include "ruby/3/config.h"
+#include "ruby/3/compiler_since.h"
+#include "ruby/3/has/warning.h"
+#include "ruby/3/warning_push.h"
 
 /* :TODO: add your  compiler here.  There are many compilers  that can suppress
  * warnings via pragmas, but not all of them accept such things inside of `#if`

--- a/include/ruby/3/token_paste.h
+++ b/include/ruby/3/token_paste.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_TOKEN_PASTE_H                          /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_TOKEN_PASTE_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -26,10 +28,7 @@
  * documented.  Please  improve this file when  you are really sure  about your
  * compiler's behaviour. */
 
-#if defined(RUBY3_TOKEN_PASTE)
-# /* Take that. */
-
-#elif RUBY3_COMPILER_SINCE(GCC, 4, 2, 0)
+#if RUBY3_COMPILER_SINCE(GCC, 4, 2, 0)
 # /* GCC is one of such compiler who  cannot write `_Pragma` inside of a `#if`.
 #  * Cannot but globally kill everything.  This  is of course a very bad thing.
 #  * If you know how to reroute this please tell us. */
@@ -69,3 +68,5 @@
 # /* No way. */
 # define RUBY3_TOKEN_PASTE(x, y) TOKEN_PASTE(x, y)
 #endif
+
+#endif /* RUBY3_TOKEN_PASTE_H */

--- a/include/ruby/3/value.h
+++ b/include/ruby/3/value.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_VALUE_H                                /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_VALUE_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines ::VALUE and ::ID.
  */
-#ifndef  RUBY3_VALUE_H
-#define  RUBY3_VALUE_H
 #include "ruby/3/static_assert.h"
 #include "ruby/backward/2/long_long.h"
 #include "ruby/backward/2/limits.h"

--- a/include/ruby/3/value_type.h
+++ b/include/ruby/3/value_type.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_VALUE_TYPE_H                           /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_VALUE_TYPE_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines enum ::ruby_value_type.
  */
-#ifndef  RUBY3_VALUE_TYPE_H
-#define  RUBY3_VALUE_TYPE_H
 #include "ruby/3/assume.h"
 #include "ruby/3/attr/artificial.h"
 #include "ruby/3/attr/cold.h"

--- a/include/ruby/3/variable.h
+++ b/include/ruby/3/variable.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_VARIABLE_H                             /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_VARIABLE_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      C-function backended Ruby-global variables.
  */
-#ifndef  RUBY3_VARIABLE_H
-#define  RUBY3_VARIABLE_H
 #include "ruby/3/dllexport.h"
 #include "ruby/3/value.h"
 #include "ruby/3/attr/noreturn.h"
@@ -59,4 +59,4 @@ VALUE rb_iv_set(VALUE, const char*, VALUE);
 
 RUBY3_SYMBOL_EXPORT_END()
 
-#endif /* RUBY3_RHASH_H */
+#endif /* RUBY3_VARIABLE_H */

--- a/include/ruby/3/warning_push.h
+++ b/include/ruby/3/warning_push.h
@@ -44,6 +44,7 @@
  *    ```
  */
 #include "ruby/3/compiler_is.h"
+#include "ruby/3/compiler_since.h"
 
 #if RUBY3_COMPILER_SINCE(MSVC, 12, 0, 0)
 # /* Not sure exactly when but it seems VC++ 6.0 is a version with it.*/

--- a/include/ruby/3/warning_push.h
+++ b/include/ruby/3/warning_push.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_WARNING_PUSH_H                         /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_WARNING_PUSH_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -43,10 +45,7 @@
  */
 #include "ruby/3/compiler_is.h"
 
-#ifdef RUBY3_WARNING_PUSH
-# /* Take that. */
-
-#elif RUBY3_COMPILER_SINCE(MSVC, 12, 0, 0)
+#if RUBY3_COMPILER_SINCE(MSVC, 12, 0, 0)
 # /* Not sure exactly when but it seems VC++ 6.0 is a version with it.*/
 # define RUBY3_WARNING_PUSH()        __pragma(warning(push))
 # define RUBY3_WARNING_POP()         __pragma(warning(pop))
@@ -87,3 +86,5 @@
 # define RUBY3_WARNING_IGNORED(flag) /* void */
 #endif /* _MSC_VER */
 /** @endcond */
+
+#endif /* RUBY3_WARNING_PUSH_H */

--- a/include/ruby/3/xmalloc.h
+++ b/include/ruby/3/xmalloc.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY3_XMALLOC_H                              /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY3_XMALLOC_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -18,8 +20,6 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Declares ::ruby_xmalloc().
  */
-#ifndef  RUBY3_XMALLOC_H
-#define  RUBY3_XMALLOC_H
 #include "ruby/3/config.h"
 
 #ifdef STDC_HEADERS

--- a/include/ruby/assert.h
+++ b/include/ruby/assert.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY_ASSERT_H                                /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY_ASSERT_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @date       Wed May 18 00:21:44 JST 1994
@@ -18,8 +20,6 @@
  *             We assume C99  for ruby itself but we don't  assume languages of
  *             extension libraries. They could be written in C++98.
  */
-#ifndef  RUBY_ASSERT_H
-#define  RUBY_ASSERT_H
 #include "ruby/3/assume.h"
 #include "ruby/3/attr/cold.h"
 #include "ruby/3/attr/noreturn.h"

--- a/include/ruby/backward.h
+++ b/include/ruby/backward.h
@@ -1,5 +1,13 @@
-#ifndef RUBY_RUBY_BACKWARD_H
+#ifndef RUBY_RUBY_BACKWARD_H                         /*-*-C++-*-vi:se ft=cpp:*/
 #define RUBY_RUBY_BACKWARD_H 1
+/**
+ * @file
+ * @author     Ruby developers <ruby-core@ruby-lang.org>
+ * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
+ *             Permission  is hereby  granted,  to  either redistribute  and/or
+ *             modify this file, provided that  the conditions mentioned in the
+ *             file COPYING are met.  Consult the file for details.
+ */
 #include "ruby/3/core/rbasic.h"
 #include "ruby/3/value.h"
 #include "ruby/3/interpreter.h"

--- a/include/ruby/backward/2/assume.h
+++ b/include/ruby/backward/2/assume.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY_BACKWARD2_ASSUME_H                      /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY_BACKWARD2_ASSUME_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -37,3 +39,5 @@
 # define RB_LIKELY(x)   (x)
 # define RB_UNLIKELY(x) (x)
 #endif
+
+#endif /* RUBY_BACKWARD2_ASSUME_H */

--- a/include/ruby/backward/2/attributes.h
+++ b/include/ruby/backward/2/attributes.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY_BACKWARD2_ATTRIBUTES_H                  /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY_BACKWARD2_ATTRIBUTES_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -26,8 +28,6 @@
  * - A: Don't know.   Don't blame me.  Backward compatibility is  the key here.
  *      I'm just preserving what they have been.
  */
-#ifndef  RUBY_BACKWARD2_ATTRIBUTES_H
-#define  RUBY_BACKWARD2_ATTRIBUTES_H
 #include "ruby/3/config.h"
 #include "ruby/3/attr/alloc_size.h"
 #include "ruby/3/attr/cold.h"

--- a/include/ruby/backward/2/bool.h
+++ b/include/ruby/backward/2/bool.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY_BACKWARD2_BOOL_H                        /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY_BACKWARD2_BOOL_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -31,3 +33,5 @@
 #elif ! TRUE
 # error TRUE must be true
 #endif
+
+#endif /* RUBY_BACKWARD2_BOOL_H */

--- a/include/ruby/backward/2/extern.h
+++ b/include/ruby/backward/2/extern.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY_BACKWARD2_EXTERN_H                      /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY_BACKWARD2_EXTERN_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -24,10 +26,7 @@
  * @brief      Synonym of #RUBY_EXTERN.
  * @deprecated #EXTERN is deprecated, use #RUBY_EXTERN instead.
  */
-#ifdef EXTERN
-# /* Stop bothering then. */
-
-#elif defined __GNUC__
+#if defined __GNUC__
 # define EXTERN \
     _Pragma("message \"EXTERN is deprecated, use RUBY_EXTERN instead\""); \
     RUBY_EXTERN
@@ -43,3 +42,5 @@
 # define EXTERN <-<-"EXTERN is deprecated, use RUBY_EXTERN instead"->->
 
 #endif
+
+#endif /* RUBY_BACKWARD2_EXTERN_H */

--- a/include/ruby/backward/2/gcc_version_since.h
+++ b/include/ruby/backward/2/gcc_version_since.h
@@ -20,6 +20,7 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Defines old #GCC_VERSION_SINCE
  */
+#include "ruby/3/compiler_since.h"
 
 #ifndef GCC_VERSION_SINCE
 #define GCC_VERSION_SINCE(x, y, z) RUBY3_COMPILER_SINCE(GCC, (x), (y), (z))

--- a/include/ruby/backward/2/gcc_version_since.h
+++ b/include/ruby/backward/2/gcc_version_since.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY_BACKWARD2_GCC_VERSION_SINCE_H           /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY_BACKWARD2_GCC_VERSION_SINCE_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -31,3 +33,5 @@
     ((RUBY3_COMPILER_VERSION_MINOR == (y))      && \
      (RUBY3_COMPILER_VERSION_PATCH == (z))))))
 #endif
+
+#endif /* RUBY_BACKWARD2_GCC_VERSION_SINCE_H */

--- a/include/ruby/backward/2/inttypes.h
+++ b/include/ruby/backward/2/inttypes.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY_BACKWARD2_INTTYPES_H                    /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY_BACKWARD2_INTTYPES_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -126,3 +128,5 @@
 # define PRIxSIZE PRI_SIZE_PREFIX"x"
 # define PRIXSIZE PRI_SIZE_PREFIX"X"
 #endif
+
+#endif /* RUBY_BACKWARD2_INTTYPES_H */

--- a/include/ruby/backward/2/limits.h
+++ b/include/ruby/backward/2/limits.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY_BACKWARD2_LIMITS_H                      /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY_BACKWARD2_LIMITS_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -94,3 +96,5 @@
 # define SSIZE_MAX SHRT_MAX
 # define SSIZE_MIN SHRT_MIN
 #endif
+
+#endif /* RUBY_BACKWARD2_LIMITS_H */

--- a/include/ruby/backward/2/long_long.h
+++ b/include/ruby/backward/2/long_long.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY_BACKWARD2_LONG_LONG_H                   /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY_BACKWARD2_LONG_LONG_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -25,10 +27,7 @@
  */
 #include "ruby/3/config.h"
 
-#if defined(LONG_LONG)
-# /* Take that. */
-
-#elif RUBY3_HAS_WARNING("-Wc++11-long-long")
+#if RUBY3_HAS_WARNING("-Wc++11-long-long")
 # define HAVE_TRUE_LONG_LONG 1
 # define LONG_LONG                           \
     RUBY3_WARNING_PUSH()                     \
@@ -60,3 +59,5 @@
 # error Remember to attach a detailed description of your environment.
 # error Thank you!
 #endif
+
+#endif /* RUBY3_BACKWARD2_LONG_LONG_H */

--- a/include/ruby/backward/2/long_long.h
+++ b/include/ruby/backward/2/long_long.h
@@ -26,6 +26,8 @@
  * compatibility only.
  */
 #include "ruby/3/config.h"
+#include "ruby/3/has/warning.h"
+#include "ruby/3/warning_push.h"
 
 #if RUBY3_HAS_WARNING("-Wc++11-long-long")
 # define HAVE_TRUE_LONG_LONG 1

--- a/include/ruby/backward/2/r_cast.h
+++ b/include/ruby/backward/2/r_cast.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY_BACKWARD2_R_CAST_H                      /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY_BACKWARD2_R_CAST_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -20,8 +22,6 @@
  *
  * Nobody is actively using this macro.
  */
-#ifndef RUBY_BACKWARD2_R_CAST_H
-#define RUBY_BACKWARD2_R_CAST_H
 #define R_CAST(st)   (struct st*)
 #define RMOVED(obj)  (R_CAST(RMoved)(obj))
 #endif /* RUBY_BACKWARD2_R_CAST_H */

--- a/include/ruby/backward/2/rmodule.h
+++ b/include/ruby/backward/2/rmodule.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY_BACKWARD2_RMODULE_H                     /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY_BACKWARD2_RMODULE_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -22,9 +24,8 @@
  * who is implementing the internals) could have used those macros for a while.
  * Kept public as-is here to keep some theoretical backwards compatibility.
  */
-#ifndef RMODULE_IV_TBL
 #define RMODULE_IV_TBL(m) RCLASS_IV_TBL(m)
 #define RMODULE_CONST_TBL(m) RCLASS_CONST_TBL(m)
 #define RMODULE_M_TBL(m) RCLASS_M_TBL(m)
 #define RMODULE_SUPER(m) RCLASS_SUPER(m)
-#endif
+#endif /* RUBY_BACKWARD2_RMODULE_H */

--- a/include/ruby/backward/2/stdalign.h
+++ b/include/ruby/backward/2/stdalign.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY_BACKWARD2_STDALIGN_H                    /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY_BACKWARD2_STDALIGN_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -24,3 +26,5 @@
 #undef RUBY_ALIGNOF
 #define RUBY_ALIGNAS RUBY3_ALIGNAS
 #define RUBY_ALIGNOF RUBY3_ALIGNOF
+
+#endif /* RUBY_BACKWARD2_STDALIGN_H */

--- a/include/ruby/backward/2/stdarg.h
+++ b/include/ruby/backward/2/stdarg.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY_BACKWARD2_STDARG_H                      /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY_BACKWARD2_STDARG_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -41,3 +43,5 @@
 #else
 #define ANYARGS
 #endif
+
+#endif /* RUBY_BACKWARD2_STDARG_H */

--- a/include/ruby/backward/classext.h
+++ b/include/ruby/backward/classext.h
@@ -1,11 +1,18 @@
+#ifndef RUBY_BACKWARD_CLASSEXT_H                     /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY_BACKWARD_CLASSEXT_H
+/**
+ * @file
+ * @author     Ruby developers <ruby-core@ruby-lang.org>
+ * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
+ *             Permission  is hereby  granted,  to  either redistribute  and/or
+ *             modify this file, provided that  the conditions mentioned in the
+ *             file COPYING are met.  Consult the file for details.
+ */
 #if   defined __GNUC__
 #warning use of RClass internals is deprecated
 #elif defined _MSC_VER
 #pragma message("warning: use of RClass internals is deprecated")
 #endif
-
-#ifndef RUBY_BACKWARD_CLASSEXT_H
-#define RUBY_BACKWARD_CLASSEXT_H 1
 
 typedef struct rb_deprecated_classext_struct {
     VALUE super;
@@ -15,4 +22,4 @@ typedef struct rb_deprecated_classext_struct {
 #define RCLASS_EXT(c) ((rb_deprecated_classext_t *)RCLASS(c)->ptr)
 #define RCLASS_SUPER(c) (RCLASS(c)->super)
 
-#endif	/* RUBY_BACKWARD_CLASSEXT_H */
+#endif /* RUBY_BACKWARD_CLASSEXT_H */

--- a/include/ruby/backward/cxxanyargs.hpp
+++ b/include/ruby/backward/cxxanyargs.hpp
@@ -1,4 +1,5 @@
-///                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY_BACKWARD_CXXANYARGS_HPP                       //-*-C++-*-vi:ft=cpp
+#define RUBY_BACKWARD_CXXANYARGS_HPP
 /// @file
 /// @author     \@shyouhei
 /// @copyright  This  file  is  a  part   of  the  programming  language  Ruby.
@@ -9,8 +10,6 @@
 ///             meant to  be a backwards  compatibility shim.  Please  stick to
 ///             C++ 98 and never use newer features, like `constexpr`.
 /// @brief      Provides old prototypes for C++ programs.
-#ifndef RUBY_BACKWARD_CXXANYARGS_HPP
-#define RUBY_BACKWARD_CXXANYARGS_HPP
 #include "ruby/3/config.h"
 #include "ruby/3/intern/class.h"
 #include "ruby/3/intern/cont.h"

--- a/include/ruby/backward/rubyio.h
+++ b/include/ruby/backward/rubyio.h
@@ -1,6 +1,18 @@
+#ifndef RUBY_BACKWARD_RUBYIO_H                       /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY_BACKWARD_RUBYIO_H
+/**
+ * @file
+ * @author     Ruby developers <ruby-core@ruby-lang.org>
+ * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
+ *             Permission  is hereby  granted,  to  either redistribute  and/or
+ *             modify this file, provided that  the conditions mentioned in the
+ *             file COPYING are met.  Consult the file for details.
+ */
 #if   defined __GNUC__
 #warning use "ruby/io.h" instead of "rubyio.h"
 #elif defined _MSC_VER
 #pragma message("warning: use \"ruby/io.h\" instead of \"rubyio.h\"")
 #endif
 #include "ruby/io.h"
+
+#endif /* RUBY_BACKWARD_RUBYIO_H */

--- a/include/ruby/backward/rubysig.h
+++ b/include/ruby/backward/rubysig.h
@@ -1,23 +1,20 @@
-/**********************************************************************
-
-  rubysig.h -
-
-  $Author$
-  $Date$
-  created at: Wed Aug 16 01:15:38 JST 1995
-
-  Copyright (C) 1993-2008 Yukihiro Matsumoto
-
-**********************************************************************/
-
+#ifndef RUBYSIG_H                                    /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBYSIG_H
+/**
+ * @file
+ * @author     $Author$
+ * @date       Wed Aug 16 01:15:38 JST 1995
+ * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
+ *             Permission  is hereby  granted,  to  either redistribute  and/or
+ *             modify this file, provided that  the conditions mentioned in the
+ *             file COPYING are met.  Consult the file for details.
+ */
 #if   defined __GNUC__
 #warning rubysig.h is obsolete
 #elif defined _MSC_VER
 #pragma message("warning: rubysig.h is obsolete")
 #endif
 
-#ifndef RUBYSIG_H
-#define RUBYSIG_H
 #include "ruby/ruby.h"
 
 #define RUBY_CRITICAL(statements) do {statements;} while (0)
@@ -26,4 +23,4 @@
 #define ALLOW_INTS do {CHECK_INTS;} while (0)
 #define CHECK_INTS rb_thread_check_ints()
 
-#endif
+#endif /* RUBYSIG_H */

--- a/include/ruby/backward/st.h
+++ b/include/ruby/backward/st.h
@@ -1,6 +1,18 @@
+#ifndef RUBY_BACKWARD_ST_H                           /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY_BACKWARD_ST_H
+/**
+ * @file
+ * @author     Ruby developers <ruby-core@ruby-lang.org>
+ * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
+ *             Permission  is hereby  granted,  to  either redistribute  and/or
+ *             modify this file, provided that  the conditions mentioned in the
+ *             file COPYING are met.  Consult the file for details.
+ */
 #if   defined __GNUC__
 #warning use "ruby/st.h" instead of bare "st.h"
 #elif defined _MSC_VER
 #pragma message("warning: use \"ruby/st.h\" instead of bare \"st.h\"")
 #endif
 #include "ruby/st.h"
+
+#endif /* RUBY_BACKWARD_ST_H */

--- a/include/ruby/backward/util.h
+++ b/include/ruby/backward/util.h
@@ -1,6 +1,18 @@
+#ifndef RUBY_BACKWARD_UTIL_H                         /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY_BACKWARD_UTIL_H
+/**
+ * @file
+ * @author     Ruby developers <ruby-core@ruby-lang.org>
+ * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
+ *             Permission  is hereby  granted,  to  either redistribute  and/or
+ *             modify this file, provided that  the conditions mentioned in the
+ *             file COPYING are met.  Consult the file for details.
+ */
 #if   defined __GNUC__
 #warning use "ruby/util.h" instead of bare "util.h"
 #elif defined _MSC_VER
 #pragma message("warning: use \"ruby/util.h\" instead of bare \"util.h\"")
 #endif
 #include "ruby/util.h"
+
+#endif /* RUBY_BACKWARD_UTIL_H */

--- a/include/ruby/debug.h
+++ b/include/ruby/debug.h
@@ -1,19 +1,18 @@
-/**********************************************************************
-
-  ruby/debug.h -
-
-  $Author: ko1 $
-  created at: Tue Nov 20 20:35:08 2012
-
-  Copyright (C) 2012 Yukihiro Matsumoto
-
-**********************************************************************/
-
-#ifndef RB_DEBUG_H
+#ifndef RB_DEBUG_H                                   /*-*-C++-*-vi:se ft=cpp:*/
 #define RB_DEBUG_H 1
-
+/**
+ * @file
+ * @author     $Author: ko1 $
+ * @date       Tue Nov 20 20:35:08 2012
+ * @copyright  Copyright (C) 2012 Yukihiro Matsumoto
+ * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
+ *             Permission  is hereby  granted,  to  either redistribute  and/or
+ *             modify this file, provided that  the conditions mentioned in the
+ *             file COPYING are met.  Consult the file for details.
+ */
 #include "ruby/3/dllexport.h"
 #include "ruby/3/event.h"
+#include "ruby/3/value.h"
 
 RUBY3_SYMBOL_EXPORT_BEGIN()
 

--- a/include/ruby/defines.h
+++ b/include/ruby/defines.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY_DEFINES_H                               /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY_DEFINES_H 1
+/**
  * @file
  * @author     $Author$
  * @date       Wed May 18 00:21:44 JST 1994
@@ -7,8 +9,6 @@
  *             modify this file, provided that  the conditions mentioned in the
  *             file COPYING are met.  Consult the file for details.
  */
-#ifndef RUBY_DEFINES_H
-#define RUBY_DEFINES_H 1
 
 #include "ruby/3/config.h"
 

--- a/include/ruby/encoding.h
+++ b/include/ruby/encoding.h
@@ -1,17 +1,15 @@
-/**********************************************************************
-
-  encoding.h -
-
-  $Author: matz $
-  created at: Thu May 24 11:49:41 JST 2007
-
-  Copyright (C) 2007 Yukihiro Matsumoto
-
-**********************************************************************/
-
-#ifndef RUBY_ENCODING_H
+#ifndef RUBY_ENCODING_H                              /*-*-C++-*-vi:se ft=cpp:*/
 #define RUBY_ENCODING_H 1
-
+/**
+ * @file
+ * @author     $Author: matz $
+ * @date       Thu May 24 11:49:41 JST 2007
+ * @copyright  Copyright (C) 2007 Yukihiro Matsumoto
+ * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
+ *             Permission  is hereby  granted,  to  either redistribute  and/or
+ *             modify this file, provided that  the conditions mentioned in the
+ *             file COPYING are met.  Consult the file for details.
+ */
 #include "ruby/3/config.h"
 #include <stdarg.h>
 #include "ruby/ruby.h"

--- a/include/ruby/intern.h
+++ b/include/ruby/intern.h
@@ -1,19 +1,17 @@
-/**********************************************************************
-
-  intern.h -
-
-  $Author$
-  created at: Thu Jun 10 14:22:17 JST 1993
-
-  Copyright (C) 1993-2007 Yukihiro Matsumoto
-  Copyright (C) 2000  Network Applied Communication Laboratory, Inc.
-  Copyright (C) 2000  Information-technology Promotion Agency, Japan
-
-**********************************************************************/
-
-#ifndef RUBY_INTERN_H
+#ifndef RUBY_INTERN_H                                /*-*-C++-*-vi:se ft=cpp:*/
 #define RUBY_INTERN_H 1
-
+/**
+ * @file
+ * @author     $Author$
+ * @date       Thu Jun 10 14:22:17 JST 1993
+ * @copyright  Copyright (C) 1993-2007 Yukihiro Matsumoto
+ * @copyright  Copyright (C) 2000  Network Applied Communication Laboratory, Inc.
+ * @copyright  Copyright (C) 2000  Information-technology Promotion Agency, Japan
+ * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
+ *             Permission  is hereby  granted,  to  either redistribute  and/or
+ *             modify this file, provided that  the conditions mentioned in the
+ *             file COPYING are met.  Consult the file for details.
+ */
 #include "ruby/3/config.h"
 #include "ruby/defines.h"
 

--- a/include/ruby/io.h
+++ b/include/ruby/io.h
@@ -1,17 +1,15 @@
-/**********************************************************************
-
-  rubyio.h -
-
-  $Author$
-  created at: Fri Nov 12 16:47:09 JST 1993
-
-  Copyright (C) 1993-2007 Yukihiro Matsumoto
-
-**********************************************************************/
-
-#ifndef RUBY_IO_H
+#ifndef RUBY_IO_H                                    /*-*-C++-*-vi:se ft=cpp:*/
 #define RUBY_IO_H 1
-
+/**
+ * @file
+ * @author     $Author$
+ * @date       Fri Nov 12 16:47:09 JST 1993
+ * @copyright  Copyright (C) 1993-2007 Yukihiro Matsumoto
+ * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
+ *             Permission  is hereby  granted,  to  either redistribute  and/or
+ *             modify this file, provided that  the conditions mentioned in the
+ *             file COPYING are met.  Consult the file for details.
+ */
 #include "ruby/3/config.h"
 
 #include <stdio.h>

--- a/include/ruby/missing.h
+++ b/include/ruby/missing.h
@@ -1,4 +1,6 @@
-/**                                                     \noop-*-C++-*-vi:ft=cpp
+#ifndef RUBY_MISSING_H                               /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY_MISSING_H 1
+/**
  * @file
  * @author     $Author$
  * @date       Sat May 11 23:46:03 JST 2002
@@ -8,9 +10,6 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      Prototype for *.c in ./missing, and for missing timeval struct.
  */
-#ifndef RUBY_MISSING_H
-#define RUBY_MISSING_H 1
-
 #include "ruby/3/config.h"
 
 #ifdef STDC_HEADERS

--- a/include/ruby/re.h
+++ b/include/ruby/re.h
@@ -1,17 +1,15 @@
-/**********************************************************************
-
-  re.h -
-
-  $Author$
-  created at: Thu Sep 30 14:18:32 JST 1993
-
-  Copyright (C) 1993-2007 Yukihiro Matsumoto
-
-**********************************************************************/
-
-#ifndef RUBY_RE_H
+#ifndef RUBY_RE_H                                    /*-*-C++-*-vi:se ft=cpp:*/
 #define RUBY_RE_H 1
-
+/**
+ * @file
+ * @author     $Author$
+ * @date       Thu Sep 30 14:18:32 JST 1993
+ * @copyright  Copyright (C) 1993-2007 Yukihiro Matsumoto
+ * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
+ *             Permission  is hereby  granted,  to  either redistribute  and/or
+ *             modify this file, provided that  the conditions mentioned in the
+ *             file COPYING are met.  Consult the file for details.
+ */
 #include "ruby/3/config.h"
 #include <sys/types.h>
 #include <stdio.h>

--- a/include/ruby/regex.h
+++ b/include/ruby/regex.h
@@ -1,16 +1,14 @@
-/**********************************************************************
-
-  regex.h -
-
-  $Author$
-
-  Copyright (C) 1993-2007 Yukihiro Matsumoto
-
-**********************************************************************/
-
-#ifndef ONIGURUMA_REGEX_H
+#ifndef ONIGURUMA_REGEX_H                            /*-*-C++-*-vi:se ft=cpp:*/
 #define ONIGURUMA_REGEX_H 1
-
+/**
+ * @file
+ * @author     $Author$
+ * @copyright  Copyright (C) 1993-2007 Yukihiro Matsumoto
+ * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
+ *             Permission  is hereby  granted,  to  either redistribute  and/or
+ *             modify this file, provided that  the conditions mentioned in the
+ *             file COPYING are met.  Consult the file for details.
+ */
 #if defined(__cplusplus)
 extern "C" {
 #if 0

--- a/include/ruby/ruby.h
+++ b/include/ruby/ruby.h
@@ -1,19 +1,17 @@
-/**********************************************************************
-
-  ruby/ruby.h -
-
-  $Author$
-  created at: Thu Jun 10 14:26:32 JST 1993
-
-  Copyright (C) 1993-2008 Yukihiro Matsumoto
-  Copyright (C) 2000  Network Applied Communication Laboratory, Inc.
-  Copyright (C) 2000  Information-technology Promotion Agency, Japan
-
-**********************************************************************/
-
-#ifndef RUBY_RUBY_H
+#ifndef RUBY_RUBY_H                                  /*-*-C++-*-vi:se ft=cpp:*/
 #define RUBY_RUBY_H 1
-
+/**
+ * @file
+ * @author     $Author$
+ * @date       Thu Jun 10 14:26:32 JST 1993
+ * @copyright  Copyright (C) 1993-2008 Yukihiro Matsumoto
+ * @copyright  Copyright (C) 2000  Network Applied Communication Laboratory, Inc.
+ * @copyright  Copyright (C) 2000  Information-technology Promotion Agency, Japan
+ * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
+ *             Permission  is hereby  granted,  to  either redistribute  and/or
+ *             modify this file, provided that  the conditions mentioned in the
+ *             file COPYING are met.  Consult the file for details.
+ */
 #include "ruby/3/config.h"
 
 #ifdef HAVE_INTRINSICS_H

--- a/include/ruby/subst.h
+++ b/include/ruby/subst.h
@@ -1,5 +1,13 @@
-#ifndef RUBY_SUBST_H
+#ifndef RUBY_SUBST_H                                 /*-*-C++-*-vi:se ft=cpp:*/
 #define RUBY_SUBST_H 1
+/**
+ * @file
+ * @author     Ruby developers <ruby-core@ruby-lang.org>
+ * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
+ *             Permission  is hereby  granted,  to  either redistribute  and/or
+ *             modify this file, provided that  the conditions mentioned in the
+ *             file COPYING are met.  Consult the file for details.
+ */
 
 #undef snprintf
 #undef vsnprintf

--- a/include/ruby/thread.h
+++ b/include/ruby/thread.h
@@ -1,17 +1,15 @@
-/**********************************************************************
-
-  thread.h -
-
-  $Author: matz $
-  created at: Tue Jul 10 17:35:43 JST 2012
-
-  Copyright (C) 2007 Yukihiro Matsumoto
-
-**********************************************************************/
-
-#ifndef RUBY_THREAD_H
+#ifndef RUBY_THREAD_H                                /*-*-C++-*-vi:se ft=cpp:*/
 #define RUBY_THREAD_H 1
-
+/**
+ * @file
+ * @author     $Author: matz $
+ * @date       Tue Jul 10 17:35:43 JST 2012
+ * @copyright  Copyright (C) 2007 Yukihiro Matsumoto
+ * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
+ *             Permission  is hereby  granted,  to  either redistribute  and/or
+ *             modify this file, provided that  the conditions mentioned in the
+ *             file COPYING are met.  Consult the file for details.
+ */
 #include "ruby/intern.h"
 #include "ruby/3/dllexport.h"
 

--- a/include/ruby/thread_native.h
+++ b/include/ruby/thread_native.h
@@ -1,16 +1,15 @@
-/**********************************************************************
-
-  thread_native.h -
-
-  $Author: ko1 $
-  created at: Wed May 14 19:37:31 2014
-
-  Copyright (C) 2014 Yukihiro Matsumoto
-
-**********************************************************************/
-
-#ifndef RUBY_THREAD_NATIVE_H
+#ifndef RUBY_THREAD_NATIVE_H                         /*-*-C++-*-vi:se ft=cpp:*/
 #define RUBY_THREAD_NATIVE_H 1
+/**
+ * @file
+ * @author     $Author: ko1 $
+ * @date       Wed May 14 19:37:31 2014
+ * @copyright  Copyright (C) 2014 Yukihiro Matsumoto
+ * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
+ *             Permission  is hereby  granted,  to  either redistribute  and/or
+ *             modify this file, provided that  the conditions mentioned in the
+ *             file COPYING are met.  Consult the file for details.
+ */
 
 /*
  * This file contains wrapper APIs for native thread primitives

--- a/include/ruby/util.h
+++ b/include/ruby/util.h
@@ -1,17 +1,15 @@
-/**********************************************************************
-
-  util.h -
-
-  $Author$
-  created at: Thu Mar  9 11:55:53 JST 1995
-
-  Copyright (C) 1993-2007 Yukihiro Matsumoto
-
-**********************************************************************/
-
-#ifndef RUBY_UTIL_H
+#ifndef RUBY_UTIL_H                                  /*-*-C++-*-vi:se ft=cpp:*/
 #define RUBY_UTIL_H 1
-
+/**
+ * @file
+ * @author     $Author$
+ * @date       Thu Mar  9 11:55:53 JST 1995
+ * @copyright  Copyright (C) 1993-2007 Yukihiro Matsumoto
+ * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
+ *             Permission  is hereby  granted,  to  either redistribute  and/or
+ *             modify this file, provided that  the conditions mentioned in the
+ *             file COPYING are met.  Consult the file for details.
+ */
 #include "ruby/3/config.h"
 #include "ruby/3/dllexport.h"
 #include "ruby/defines.h"

--- a/include/ruby/version.h
+++ b/include/ruby/version.h
@@ -1,17 +1,17 @@
-/**********************************************************************
-
-  ruby/version.h -
-
-  $Author$
-  created at: Wed May 13 12:56:56 JST 2009
-
-  Copyright (C) 1993-2009 Yukihiro Matsumoto
-  Copyright (C) 2000  Network Applied Communication Laboratory, Inc.
-  Copyright (C) 2000  Information-technology Promotion Agency, Japan
-
-**********************************************************************/
-
-/*
+#ifndef RUBY_VERSION_H                               /*-*-C++-*-vi:se ft=cpp:*/
+#define RUBY_VERSION_H 1
+/**
+ * @file
+ * @author     $Author$
+ * @date       Wed May 13 12:56:56 JST 2009
+ * @copyright  Copyright (C) 1993-2009 Yukihiro Matsumoto
+ * @copyright  Copyright (C) 2000  Network Applied Communication Laboratory, Inc.
+ * @copyright  Copyright (C) 2000  Information-technology Promotion Agency, Japan
+ * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
+ *             Permission  is hereby  granted,  to  either redistribute  and/or
+ *             modify this file, provided that  the conditions mentioned in the
+ *             file COPYING are met.  Consult the file for details.
+ *
  * This file contains only
  * - never-changeable information, and
  * - interfaces accessible from extension libraries.
@@ -19,9 +19,6 @@
  * Never try to check RUBY_VERSION_CODE etc in extension libraries,
  * check the features with mkmf.rb instead.
  */
-
-#ifndef RUBY_VERSION_H
-#define RUBY_VERSION_H 1
 
 /* The origin. */
 #define RUBY_AUTHOR "Yukihiro Matsumoto"

--- a/include/ruby/vm.h
+++ b/include/ruby/vm.h
@@ -1,17 +1,15 @@
-/**********************************************************************
-
-  ruby/vm.h -
-
-  $Author$
-  created at: Sat May 31 15:17:36 2008
-
-  Copyright (C) 2008 Yukihiro Matsumoto
-
-**********************************************************************/
-
-#ifndef RUBY_VM_H
+#ifndef RUBY_VM_H                                    /*-*-C++-*-vi:se ft=cpp:*/
 #define RUBY_VM_H 1
-
+/**
+ * @file
+ * @author     $Author$
+ * @date       Sat May 31 15:17:36 2008
+ * @copyright  Copyright (C) 2008 Yukihiro Matsumoto
+ * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
+ *             Permission  is hereby  granted,  to  either redistribute  and/or
+ *             modify this file, provided that  the conditions mentioned in the
+ *             file COPYING are met.  Consult the file for details.
+ */
 #include "ruby/3/dllexport.h"
 
 RUBY3_SYMBOL_EXPORT_BEGIN()

--- a/internal.h
+++ b/internal.h
@@ -1,17 +1,15 @@
-/**********************************************************************
-
-  internal.h -
-
-  $Author$
-  created at: Tue May 17 11:42:20 JST 2011
-
-  Copyright (C) 2011 Yukihiro Matsumoto
-
-**********************************************************************/
-
-#ifndef RUBY_INTERNAL_H
+#ifndef RUBY_INTERNAL_H                                  /*-*-C-*-vi:se ft=c:*/
 #define RUBY_INTERNAL_H 1
-
+/**
+ * @file
+ * @author     $Author$
+ * @date       Tue May 17 11:42:20 JST 2011
+ * @copyright  Copyright (C) 2011 Yukihiro Matsumoto
+ * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
+ *             Permission  is hereby  granted,  to  either redistribute  and/or
+ *             modify this file, provided that  the conditions mentioned in the
+ *             file COPYING are met.  Consult the file for details.
+ */
 #include "ruby/3/config.h"
 
 #ifdef __cplusplus

--- a/internal/array.h
+++ b/internal/array.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_ARRAY_H                                 /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_ARRAY_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -7,8 +9,6 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      Internal header for Array.
  */
-#ifndef INTERNAL_ARRAY_H
-#define INTERNAL_ARRAY_H
 #include "ruby/3/config.h"
 #include <stddef.h>                 /* for size_t */
 #include "internal/static_assert.h" /* for STATIC_ASSERT */

--- a/internal/bignum.h
+++ b/internal/bignum.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_BIGNUM_H                                /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_BIGNUM_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -7,8 +9,6 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      Internal header for Bignums.
  */
-#ifndef INTERNAL_BIGNUM_H
-#define INTERNAL_BIGNUM_H
 #include "ruby/3/config.h"      /* for HAVE_LIBGMP */
 #include <stddef.h>             /* for size_t */
 

--- a/internal/bits.h
+++ b/internal/bits.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_BITS_H                                  /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_BITS_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -24,8 +26,6 @@
  * @see        https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_rotr64
  * @see        https://stackoverflow.com/a/776523
  */
-#ifndef INTERNAL_BITS_H
-#define INTERNAL_BITS_H
 #include "ruby/3/config.h"
 #include <limits.h>             /* for CHAR_BITS */
 #include <stdint.h>             /* for uintptr_t */

--- a/internal/class.h
+++ b/internal/class.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_CLASS_H                                 /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_CLASS_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -7,8 +9,6 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      Internal header for Class.
  */
-#ifndef INTERNAL_CLASS_H
-#define INTERNAL_CLASS_H
 #include "id_table.h"           /* for struct rb_id_table */
 #include "internal/gc.h"        /* for RB_OBJ_WRITE */
 #include "internal/serial.h"    /* for rb_serial_t */

--- a/internal/compar.h
+++ b/internal/compar.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_COMPAR_H                                /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_COMPAR_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -7,8 +9,6 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      Internal header for Comparable.
  */
-#ifndef INTERNAL_COMPAR_H
-#define INTERNAL_COMPAR_H
 #include "internal/vm.h"        /* for rb_method_basic_definition_p */
 
 #define STRING_P(s) (RB_TYPE_P((s), T_STRING) && CLASS_OF(s) == rb_cString)

--- a/internal/compile.h
+++ b/internal/compile.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_COMPILE_H                               /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_COMPILE_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -7,8 +9,6 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      Internal header for the compiler.
  */
-#ifndef INTERNAL_COMPILE_H
-#define INTERNAL_COMPILE_H
 #include "ruby/3/config.h"
 #include <stddef.h>             /* for size_t */
 #include "ruby/ruby.h"          /* for rb_event_flag_t */

--- a/internal/compilers.h
+++ b/internal/compilers.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_COMPILERS_H                             /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_COMPILERS_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -7,8 +9,6 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      Internal header absorbing C compipler differences.
  */
-#ifndef INTERNAL_COMPILERS_H
-#define INTERNAL_COMPILERS_H
 #include "ruby/3/compiler_since.h"
 #include "ruby/3/has/attribute.h"
 #include "ruby/3/has/builtin.h"

--- a/internal/complex.h
+++ b/internal/complex.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_COMPLEX_H                               /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_COMPLEX_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -7,9 +9,7 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      Internal header for Complex.
  */
-#ifndef INTERNAL_COMPLEX_H
-#define INTERNAL_COMPLEX_H
-#include "ruby/ruby.h"          /* for struct RBasic */
+#include "ruby/3/value.h"          /* for struct RBasic */
 
 struct RComplex {
     struct RBasic basic;

--- a/internal/cont.h
+++ b/internal/cont.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_CONT_H                                  /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_CONT_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -7,8 +9,6 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      Internal header for Fiber.
  */
-#ifndef INTERNAL_CONT_H
-#define INTERNAL_CONT_H
 #include "ruby/ruby.h"          /* for VALUE */
 
 struct rb_thread_struct;        /* in vm_core.h */

--- a/internal/dir.h
+++ b/internal/dir.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_DIR_H                                   /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_DIR_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -7,8 +9,6 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      Internal header for Dir.
  */
-#ifndef INTERNAL_DIR_H
-#define INTERNAL_DIR_H
 #include "ruby/ruby.h"          /* for VALUE */
 
 /* dir.c */

--- a/internal/enc.h
+++ b/internal/enc.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_ENC_H                                   /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_ENC_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -7,8 +9,6 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      Internal header for Encoding.
  */
-#ifndef INTERNAL_ENC_H
-#define INTERNAL_ENC_H
 #include "ruby/encoding.h"      /* for rb_encoding */
 
 /* us_ascii.c */

--- a/internal/encoding.h
+++ b/internal/encoding.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_ENCODING_H                              /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_ENCODING_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -7,8 +9,6 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      Internal header for Encoding.
  */
-#ifndef INTERNAL_ENCODING_H
-#define INTERNAL_ENCODING_H
 #include "ruby/ruby.h"          /* for ID */
 #include "ruby/encoding.h"      /* for rb_encoding */
 

--- a/internal/enum.h
+++ b/internal/enum.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_ENUM_H                                  /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_ENUM_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -7,8 +9,6 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      Internal header for Enumerable.
  */
-#ifndef INTERNAL_ENUM_H
-#define INTERNAL_ENUM_H
 #include "ruby/ruby.h"          /* for VALUE */
 
 /* enum.c */

--- a/internal/enumerator.h
+++ b/internal/enumerator.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_ENUMERATOR_H                            /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_ENUMERATOR_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -7,8 +9,6 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      Internal header for Enumerator.
  */
-#ifndef INTERNAL_ENUMERATOR_H
-#define INTERNAL_ENUMERATOR_H
 #include "ruby/ruby.h"          /* for VALUE */
 #include "ruby/intern.h"        /* for rb_enumerator_size_func */
 

--- a/internal/error.h
+++ b/internal/error.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_ERROR_H                                 /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_ERROR_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -7,8 +9,6 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      Internal header for Exception.
  */
-#ifndef INTERNAL_ERROR_H
-#define INTERNAL_ERROR_H
 #include "ruby/3/config.h"
 #include <stdarg.h>             /* for va_list */
 #include "internal/string.h"    /* for rb_fstring_cstr */

--- a/internal/eval.h
+++ b/internal/eval.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_EVAL_H                                  /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_EVAL_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -9,8 +11,6 @@
  * @note       There  also  is  eval_intern.h, which  is  evaluator's  internal
  *             header (related to this file, but not the same role).
  */
-#ifndef INTERNAL_EVAL_H
-#define INTERNAL_EVAL_H
 #include "ruby/ruby.h"          /* for ID */
 
 #define id_signo ruby_static_id_signo

--- a/internal/file.h
+++ b/internal/file.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_FILE_H                                  /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_FILE_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -7,8 +9,6 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      Internal header for File.
  */
-#ifndef INTERNAL_FILE_H
-#define INTERNAL_FILE_H
 #include "ruby/ruby.h"          /* for VALUE */
 #include "ruby/encoding.h"      /* for rb_encodinng */
 

--- a/internal/fixnum.h
+++ b/internal/fixnum.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_FIXNUM_H                                /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_FIXNUM_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -7,8 +9,6 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      Internal header for Fixnums.
  */
-#ifndef INTERNAL_FIXNUM_H
-#define INTERNAL_FIXNUM_H
 #include "ruby/3/config.h"      /* for HAVE_LONG_LONG */
 #include <limits.h>             /* for CHAR_BIT */
 #include "internal/compilers.h" /* for __has_builtin */

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_GC_H                                    /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_GC_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -7,8 +9,6 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      Internal header for GC.
  */
-#ifndef INTERNAL_GC_H
-#define INTERNAL_GC_H
 #include "ruby/3/config.h"
 
 #include <stddef.h>             /* for size_t */

--- a/internal/hash.h
+++ b/internal/hash.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_HASH_H                                  /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_HASH_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -7,8 +9,6 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      Internal header for Hash.
  */
-#ifndef INTERNAL_HASH_H
-#define INTERNAL_HASH_H
 #include "ruby/3/config.h"
 #include <stddef.h>             /* for size_t */
 #include "ruby/3/stdbool.h"     /* for bool */

--- a/internal/imemo.h
+++ b/internal/imemo.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_IMEMO_H                                 /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_IMEMO_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -7,8 +9,6 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      IMEMO: Internal memo object.
  */
-#ifndef INTERNAL_IMEMO_H
-#define INTERNAL_IMEMO_H
 #include "ruby/3/config.h"
 #include <stddef.h>             /* for size_t */
 #include "internal/array.h"     /* for rb_ary_tmp_new_fill */

--- a/internal/inits.h
+++ b/internal/inits.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_INITS_H                                 /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_INITS_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -7,8 +9,6 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      Internal header aggregating init functions.
  */
-#ifndef INTERNAL_INITS_H
-#define INTERNAL_INITS_H
 
 /* class.c */
 void Init_class_hierarchy(void);

--- a/internal/io.h
+++ b/internal/io.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_IO_H                                    /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_IO_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -7,8 +9,6 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      Internal header for IO.
  */
-#ifndef INTERNAL_IO_H
-#define INTERNAL_IO_H
 #include "ruby/ruby.h"          /* for VALUE */
 #include "ruby/io.h"            /* for rb_io_t */
 

--- a/internal/load.h
+++ b/internal/load.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_LOAD_H                                  /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_LOAD_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -7,8 +9,6 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      Internal header for require.
  */
-#ifndef INTERNAL_LOAD_H
-#define INTERNAL_LOAD_H
 #include "ruby/ruby.h"          /* for VALUE */
 
 /* load.c */

--- a/internal/loadpath.h
+++ b/internal/loadpath.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_LOADPATH_H                              /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_LOADPATH_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -7,8 +9,6 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      Internal header for $LOAD_PATH.
  */
-#ifndef INTERNAL_LOADPATH_H
-#define INTERNAL_LOADPATH_H
 
 /* loadpath.c */
 extern const char ruby_exec_prefix[];

--- a/internal/math.h
+++ b/internal/math.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_MATH_H                                  /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_MATH_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -7,8 +9,6 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      Internal header for Math.
  */
-#ifndef INTERNAL_MATH_H
-#define INTERNAL_MATH_H
 #include "ruby/ruby.h"          /* for VALUE */
 
 /* math.c */

--- a/internal/missing.h
+++ b/internal/missing.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_MISSING_H                               /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_MISSING_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -7,8 +9,6 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      Internal header corresponding missing.
  */
-#ifndef INTERNAL_MISSING_H
-#define INTERNAL_MISSING_H
 #include "ruby/3/config.h"      /* for HAVE_SETPROCTITLE */
 
 /* missing/setproctitle.c */

--- a/internal/mjit.h
+++ b/internal/mjit.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_MJIT_H                                  /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_MJIT_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -7,8 +9,6 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      Internal header for MJIT.
  */
-#ifndef INTERNAL_MJIT_H
-#define INTERNAL_MJIT_H
 #include "ruby/3/stdbool.h"     /* for bool */
 #include "ruby/ruby.h"          /* for VALUE */
 

--- a/internal/numeric.h
+++ b/internal/numeric.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_NUMERIC_H                               /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_NUMERIC_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -7,8 +9,6 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      Internal header for Numeric.
  */
-#ifndef INTERNAL_NUMERIC_H
-#define INTERNAL_NUMERIC_H
 #include "internal/bignum.h"    /* for BIGNUM_POSITIVE_P */
 #include "internal/bits.h"      /* for RUBY_BIT_ROTL */
 #include "internal/fixnum.h"    /* for FIXNUM_POSITIVE_P */

--- a/internal/object.h
+++ b/internal/object.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_OBJECT_H                                /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_OBJECT_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -7,8 +9,6 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      Internal header for Object.
  */
-#ifndef INTERNAL_OBJECT_H
-#define INTERNAL_OBJECT_H
 #include "ruby/ruby.h"          /* for VALUE */
 
 /* object.c */

--- a/internal/parse.h
+++ b/internal/parse.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_PARSE_H                                 /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_PARSE_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -7,8 +9,6 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      Internal header for the parser.
  */
-#ifndef INTERNAL_PARSE_H
-#define INTERNAL_PARSE_H
 #include "ruby/ruby.h"          /* for VALUE */
 struct rb_iseq_struct;          /* in vm_core.h */
 

--- a/internal/proc.h
+++ b/internal/proc.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_PROC_H                                  /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_PROC_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -7,8 +9,6 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      Internal header for Proc.
  */
-#ifndef INTERNAL_PROC_H
-#define INTERNAL_PROC_H
 #include "ruby/ruby.h"          /* for rb_block_call_func_t */
 #include "ruby/st.h"            /* for st_index_t */
 struct rb_block;                /* in vm_core.h */

--- a/internal/process.h
+++ b/internal/process.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_PROCESS_H                               /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_PROCESS_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -7,8 +9,6 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      Internal header for Process.
  */
-#ifndef INTERNAL_PROCESS_H
-#define INTERNAL_PROCESS_H
 #include "ruby/3/config.h"      /* for rb_pid_t */
 #include <stddef.h>             /* for size_t */
 

--- a/internal/random.h
+++ b/internal/random.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_RANDOM_H                                /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_RANDOM_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -7,8 +9,6 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      Internal header for Random.
  */
-#ifndef INTERNAL_RANDOM_H
-#define INTERNAL_RANDOM_H
 #include <stddef.h>             /* for size_t */
 
 /* random.c */

--- a/internal/range.h
+++ b/internal/range.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_RANGE_H                                  /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_RANGE_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -7,8 +9,6 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      Internal header for Range.
  */
-#ifndef INTERNAL_RANGE_H
-#define INTERNAL_RANGE_H
 #include "internal/struct.h"    /* for RSTRUCT */
 
 /* range.c */

--- a/internal/rational.h
+++ b/internal/rational.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_RATIONAL_H                              /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_RATIONAL_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -7,8 +9,6 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      Internal header for Rational.
  */
-#ifndef INTERNAL_RATIONAL_H
-#define INTERNAL_RATIONAL_H
 #include "ruby/3/config.h"      /* for HAVE_LIBGMP */
 #include "ruby/ruby.h"          /* for struct RBasic */
 #include "internal/gc.h"        /* for RB_OBJ_WRITE */

--- a/internal/re.h
+++ b/internal/re.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_RE_H                                    /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_RE_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -7,8 +9,6 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      Internal header for Regexp.
  */
-#ifndef INTERNAL_RE_H
-#define INTERNAL_RE_H
 #include "ruby/3/stdbool.h"     /* for bool */
 #include "ruby/ruby.h"          /* for VALUE */
 

--- a/internal/sanitizers.h
+++ b/internal/sanitizers.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_SANITIZERS_H                            /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_SANITIZERS_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -7,8 +9,6 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      Internal header for ASAN / MSAN / etc.
  */
-#ifndef INTERNAL_SANITIZERS_H
-#define INTERNAL_SANITIZERS_H
 #include "ruby/3/config.h"
 #include "internal/compilers.h" /* for __has_feature */
 

--- a/internal/serial.h
+++ b/internal/serial.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_SERIAL_H                                /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_SERIAL_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -7,8 +9,6 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      Internal header for rb_serial_t.
  */
-#ifndef INTERNAL_SERIAL_H
-#define INTERNAL_SERIAL_H
 #include "ruby/3/config.h"      /* for HAVE_LONG_LONG */
 #include "ruby/defines.h"       /* for LONG_LONG */
 

--- a/internal/signal.h
+++ b/internal/signal.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_SIGNAL_H                                /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_SIGNAL_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -7,8 +9,6 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      Internal header for SignalException.
  */
-#ifndef INTERNAL_SIGNAL_H
-#define INTERNAL_SIGNAL_H
 
 /* signal.c */
 extern int ruby_enable_coredump;

--- a/internal/static_assert.h
+++ b/internal/static_assert.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_STATIC_ASSERT_H                         /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_STATIC_ASSERT_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -11,3 +13,5 @@
 #ifndef STATIC_ASSERT
 # define STATIC_ASSERT RUBY3_STATIC_ASSERT
 #endif
+
+#endif /* INTERNAL_STATIC_ASSERT_H */

--- a/internal/string.h
+++ b/internal/string.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_STRING_H                                /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_STRING_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -7,8 +9,6 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      Internal header for String.
  */
-#ifndef INTERNAL_STRING_H
-#define INTERNAL_STRING_H
 #include "ruby/3/config.h"
 #include <stddef.h>             /* for size_t */
 #include "internal/compilers.h" /* for __has_builtin */

--- a/internal/struct.h
+++ b/internal/struct.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_STRUCT_H                                /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_STRUCT_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -7,8 +9,6 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      Internal header for Struct.
  */
-#ifndef INTERNAL_STRUCT_H
-#define INTERNAL_STRUCT_H
 #include "ruby/3/stdbool.h"     /* for bool */
 #include "internal/gc.h"        /* for RB_OBJ_WRITE */
 #include "ruby/ruby.h"          /* for struct RBasic */

--- a/internal/symbol.h
+++ b/internal/symbol.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_SYMBOL_H                                /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_SYMBOL_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -7,8 +9,6 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      Internal header for Symbol.
  */
-#ifndef INTERNAL_SYMBOL_H
-#define INTERNAL_SYMBOL_H
 #include "ruby/ruby.h"          /* for VALUE */
 #include "ruby/encoding.h"      /* for rb_encoding */
 #include "internal/compilers.h" /* for __has_builtin */

--- a/internal/thread.h
+++ b/internal/thread.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_THREAD_H                                /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_THREAD_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -7,8 +9,6 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      Internal header for Thread.
  */
-#ifndef INTERNAL_THREAD_H
-#define INTERNAL_THREAD_H
 #include "ruby/ruby.h"          /* for VALUE */
 #include "ruby/intern.h"        /* for rb_blocking_function_t */
 

--- a/internal/time.h
+++ b/internal/time.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_TIME_H                                  /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_TIME_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -7,8 +9,6 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      Internal header for Time.
  */
-#ifndef INTERNAL_TIME_H
-#define INTERNAL_TIME_H
 #include "ruby/3/config.h"      /* for SIGNEDNESS_OF_TIME_T */
 #include "internal/bits.h"      /* for SIGNED_INTEGER_MAX */
 #include "ruby/ruby.h"          /* for VALUE */

--- a/internal/transcode.h
+++ b/internal/transcode.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_TRANSCODE_H                             /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_TRANSCODE_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -7,8 +9,6 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      Internal header for Encoding::Converter.
  */
-#ifndef INTERNAL_TRANSCODE_H
-#define INTERNAL_TRANSCODE_H
 #include "ruby/3/config.h"
 #include <stddef.h>             /* for size_t */
 #include "ruby/ruby.h"          /* for VALUE */

--- a/internal/util.h
+++ b/internal/util.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_UTIL_H                                  /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_UTIL_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -8,8 +10,6 @@
  * @brief      Internal header corresponding util.c.
  * @warning    DO NOT ADD RANDOM GARBAGE HERE THIS FILE IS FOR util.c
  */
-#ifndef INTERNAL_UTIL_H /* -*- C -*- */
-#define INTERNAL_UTIL_H
 #include "ruby/3/config.h"
 #include <stddef.h>             /* for size_t */
 

--- a/internal/variable.h
+++ b/internal/variable.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_VARIABLE_H                              /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_VARIABLE_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -7,8 +9,6 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      Internal header for variables.
  */
-#ifndef INTERNAL_VARIABLE_H
-#define INTERNAL_VARIABLE_H
 #include "ruby/3/config.h"
 #include <stddef.h>             /* for size_t */
 #include "constant.h"           /* for rb_const_entry_t */

--- a/internal/vm.h
+++ b/internal/vm.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_VM_H                                    /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_VM_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -7,8 +9,6 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      Internal header for RubyVM.
  */
-#ifndef INTERNAL_VM_H
-#define INTERNAL_VM_H
 #include "ruby/3/stdbool.h"         /* for bool */
 #include "internal/serial.h"        /* for rb_serial_t */
 #include "internal/static_assert.h" /* for STATIC_ASSERT */

--- a/internal/warnings.h
+++ b/internal/warnings.h
@@ -1,4 +1,6 @@
-/**                                                         \noop-*-C-*-vi:ft=c
+#ifndef INTERNAL_WARNINGS_H                              /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_WARNINGS_H
+/**
  * @file
  * @author     Ruby developers <ruby-core@ruby-lang.org>
  * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
@@ -7,8 +9,6 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      Internal header to suppres / mandate warnings.
  */
-#ifndef INTERNAL_WARNINGS_H
-#define INTERNAL_WARNINGS_H
 #include "ruby/3/warning_push.h"
 #define COMPILER_WARNING_PUSH          RUBY3_WARNING_PUSH()
 #define COMPILER_WARNING_POP           RUBY3_WARNING_POP()

--- a/iseq.h
+++ b/iseq.h
@@ -1,3 +1,5 @@
+#ifndef RUBY_ISEQ_H
+#define RUBY_ISEQ_H 1
 /**********************************************************************
 
   iseq.h -
@@ -8,9 +10,6 @@
   Copyright (C) 2004-2008 Koichi Sasada
 
 **********************************************************************/
-
-#ifndef RUBY_ISEQ_H
-#define RUBY_ISEQ_H 1
 #include "internal/gc.h"
 #include "vm_core.h"
 

--- a/method.h
+++ b/method.h
@@ -1,3 +1,5 @@
+#ifndef RUBY_METHOD_H
+#define RUBY_METHOD_H 1
 /**********************************************************************
 
   method.h -
@@ -8,8 +10,6 @@
   Copyright (C) 2009 Koichi Sasada
 
 **********************************************************************/
-#ifndef RUBY_METHOD_H
-#define RUBY_METHOD_H 1
 
 #include "internal.h"
 #include "internal/imemo.h"

--- a/missing/crypt.h
+++ b/missing/crypt.h
@@ -1,3 +1,5 @@
+#ifndef CRYPT_H
+#define CRYPT_H 1
 /*
  * Copyright (c) 1989, 1993
  *	The Regents of the University of California.  All rights reserved.
@@ -29,9 +31,6 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  */
-
-#ifndef CRYPT_H
-#define CRYPT_H 1
 
 /* =====  Configuration ==================== */
 

--- a/missing/file.h
+++ b/missing/file.h
@@ -1,7 +1,6 @@
-/* This is file FILE.H */
-
 #ifndef _FILE_H_
 #define _FILE_H_
+/* This is file FILE.H */
 
 #include <fcntl.h>
 

--- a/mjit.h
+++ b/mjit.h
@@ -1,3 +1,5 @@
+#ifndef RUBY_MJIT_H
+#define RUBY_MJIT_H 1
 /**********************************************************************
 
   mjit.h - Interface to MRI method JIT compiler for Ruby's main thread
@@ -5,9 +7,6 @@
   Copyright (C) 2017 Vladimir Makarov <vmakarov@redhat.com>.
 
 **********************************************************************/
-
-#ifndef RUBY_MJIT_H
-#define RUBY_MJIT_H 1
 
 #include "ruby/3/config.h"
 

--- a/node.h
+++ b/node.h
@@ -1,3 +1,5 @@
+#ifndef RUBY_NODE_H
+#define RUBY_NODE_H 1
 /**********************************************************************
 
   node.h -
@@ -8,9 +10,6 @@
   Copyright (C) 1993-2007 Yukihiro Matsumoto
 
 **********************************************************************/
-
-#ifndef RUBY_NODE_H
-#define RUBY_NODE_H 1
 
 #if defined(__cplusplus)
 extern "C" {

--- a/ruby_assert.h
+++ b/ruby_assert.h
@@ -1,3 +1,13 @@
+#ifndef RUBY_TOPLEVEL_ASSERT_H                           /*-*-C-*-vi:se ft=c:*/
+#define RUBY_TOPLEVEL_ASSERT_H
+/**
+ * @file
+ * @author     Ruby developers <ruby-core@ruby-lang.org>
+ * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
+ *             Permission  is hereby  granted,  to  either redistribute  and/or
+ *             modify this file, provided that  the conditions mentioned in the
+ *             file COPYING are met.  Consult the file for details.
+ */
 #include "ruby/assert.h"
 
 #if !defined(__STDC_VERSION__) || (__STDC_VERSION__ < 199901L)
@@ -8,3 +18,4 @@
 #undef assert
 #define assert RUBY_ASSERT
 #endif
+#endif /* RUBY_TOPLEVEL_ASSERT_H */

--- a/symbol.h
+++ b/symbol.h
@@ -1,3 +1,5 @@
+#ifndef RUBY_SYMBOL_H
+#define RUBY_SYMBOL_H 1
 /**********************************************************************
 
   symbol.h -
@@ -8,9 +10,6 @@
   Copyright (C) 2014 Yukihiro Matsumoto
 
 **********************************************************************/
-
-#ifndef RUBY_SYMBOL_H
-#define RUBY_SYMBOL_H 1
 
 #include "id.h"
 #include "ruby/encoding.h"

--- a/thread_pthread.h
+++ b/thread_pthread.h
@@ -1,3 +1,5 @@
+#ifndef RUBY_THREAD_PTHREAD_H
+#define RUBY_THREAD_PTHREAD_H
 /**********************************************************************
 
   thread_pthread.h -
@@ -7,9 +9,6 @@
   Copyright (C) 2004-2007 Koichi Sasada
 
 **********************************************************************/
-
-#ifndef RUBY_THREAD_PTHREAD_H
-#define RUBY_THREAD_PTHREAD_H
 
 #ifdef HAVE_PTHREAD_NP_H
 #include <pthread_np.h>

--- a/thread_win32.h
+++ b/thread_win32.h
@@ -1,3 +1,5 @@
+#ifndef RUBY_THREAD_WIN32_H
+#define RUBY_THREAD_WIN32_H
 /**********************************************************************
 
   thread_win32.h -
@@ -9,8 +11,6 @@
 **********************************************************************/
 
 /* interface */
-#ifndef RUBY_THREAD_WIN32_H
-#define RUBY_THREAD_WIN32_H
 
 # ifdef __CYGWIN__
 # undef _WIN32
@@ -33,4 +33,3 @@ typedef struct rb_global_vm_lock_struct {
 } rb_global_vm_lock_t;
 
 #endif /* RUBY_THREAD_WIN32_H */
-

--- a/transcode_data.h
+++ b/transcode_data.h
@@ -1,3 +1,5 @@
+#ifndef RUBY_TRANSCODE_DATA_H
+#define RUBY_TRANSCODE_DATA_H 1
 /**********************************************************************
 
   transcode_data.h -
@@ -10,9 +12,6 @@
 **********************************************************************/
 
 #include "ruby/ruby.h"
-
-#ifndef RUBY_TRANSCODE_DATA_H
-#define RUBY_TRANSCODE_DATA_H 1
 
 RUBY_SYMBOL_EXPORT_BEGIN
 

--- a/transient_heap.h
+++ b/transient_heap.h
@@ -1,3 +1,5 @@
+#ifndef RUBY_TRANSIENT_HEAP_H
+#define RUBY_TRANSIENT_HEAP_H
 /**********************************************************************
 
   transient_heap.h - declarations of transient_heap related APIs.
@@ -5,9 +7,6 @@
   Copyright (C) 2018 Koichi Sasada
 
 **********************************************************************/
-
-#ifndef RUBY_TRANSIENT_HEAP_H
-#define RUBY_TRANSIENT_HEAP_H
 
 #include "internal.h"
 

--- a/variable.h
+++ b/variable.h
@@ -1,3 +1,13 @@
+#ifndef RUBY_TOPLEVEL_VARIABLE_H                         /*-*-C-*-vi:se ft=c:*/
+#define RUBY_TOPLEVEL_VARIABLE_H
+/**
+ * @file
+ * @author     Ruby developers <ruby-core@ruby-lang.org>
+ * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
+ *             Permission  is hereby  granted,  to  either redistribute  and/or
+ *             modify this file, provided that  the conditions mentioned in the
+ *             file COPYING are met.  Consult the file for details.
+ */
 
 /* per-object */
 
@@ -7,3 +17,5 @@ struct gen_ivtbl {
 };
 
 struct st_table *rb_ivar_generic_ivtbl(void);
+
+#endif /* RUBY_TOPLEVEL_VARIABLE_H */

--- a/version.h
+++ b/version.h
@@ -1,3 +1,13 @@
+#ifndef RUBY_TOPLEVEL_VERSION_H                          /*-*-C-*-vi:se ft=c:*/
+#define RUBY_TOPLEVEL_VERSION_H
+/**
+ * @file
+ * @author     Ruby developers <ruby-core@ruby-lang.org>
+ * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
+ *             Permission  is hereby  granted,  to  either redistribute  and/or
+ *             modify this file, provided that  the conditions mentioned in the
+ *             file COPYING are met.  Consult the file for details.
+ */
 # define RUBY_VERSION_MAJOR RUBY_API_VERSION_MAJOR
 # define RUBY_VERSION_MINOR RUBY_API_VERSION_MINOR
 #define RUBY_VERSION_TEENY 0
@@ -75,3 +85,5 @@
     RUBY_BIRTH_YEAR_STR"-"   \
     RUBY_RELEASE_YEAR_STR" " \
     RUBY_AUTHOR
+
+#endif /* RUBY_TOPLEVEL_VERSION_H */

--- a/vm_callinfo.h
+++ b/vm_callinfo.h
@@ -1,3 +1,14 @@
+#ifndef RUBY_VM_CALLINFO_H                               /*-*-C-*-vi:se ft=c:*/
+#define RUBY_VM_CALLINFO_H
+/**
+ * @file
+ * @author     Ruby developers <ruby-core@ruby-lang.org>
+ * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
+ *             Permission  is hereby  granted,  to  either redistribute  and/or
+ *             modify this file, provided that  the conditions mentioned in the
+ *             file COPYING are met.  Consult the file for details.
+ */
+
 #include "debug_counter.h"
 
 enum vm_call_flag_bits {
@@ -426,3 +437,5 @@ vm_ccs_p(const struct rb_class_cc_entries *ccs)
 
 // gc.c
 void rb_vm_ccs_free(struct rb_class_cc_entries *ccs);
+
+#endif /* RUBY_VM_CALLINFO_H */

--- a/vm_core.h
+++ b/vm_core.h
@@ -1,3 +1,5 @@
+#ifndef RUBY_VM_CORE_H
+#define RUBY_VM_CORE_H
 /**********************************************************************
 
   vm_core.h -
@@ -8,9 +10,6 @@
   Copyright (C) 2004-2007 Koichi Sasada
 
 **********************************************************************/
-
-#ifndef RUBY_VM_CORE_H
-#define RUBY_VM_CORE_H
 
 /*
  * Enable check mode.

--- a/vm_debug.h
+++ b/vm_debug.h
@@ -1,3 +1,5 @@
+#ifndef RUBY_DEBUG_H
+#define RUBY_DEBUG_H
 /**********************************************************************
 
   vm_debug.h - YARV Debug function interface
@@ -8,9 +10,6 @@
   Copyright (C) 2004-2007 Koichi Sasada
 
 **********************************************************************/
-
-#ifndef RUBY_DEBUG_H
-#define RUBY_DEBUG_H
 
 #include "ruby/ruby.h"
 #include "node.h"

--- a/vm_exec.h
+++ b/vm_exec.h
@@ -1,3 +1,5 @@
+#ifndef RUBY_VM_EXEC_H
+#define RUBY_VM_EXEC_H
 /**********************************************************************
 
   vm.h -
@@ -8,9 +10,6 @@
   Copyright (C) 2004-2007 Koichi Sasada
 
 **********************************************************************/
-
-#ifndef RUBY_VM_EXEC_H
-#define RUBY_VM_EXEC_H
 
 typedef long OFFSET;
 typedef unsigned long lindex_t;

--- a/vm_insnhelper.h
+++ b/vm_insnhelper.h
@@ -1,3 +1,5 @@
+#ifndef RUBY_INSNHELPER_H
+#define RUBY_INSNHELPER_H
 /**********************************************************************
 
   insnhelper.h - helper macros to implement each instructions
@@ -8,9 +10,6 @@
   Copyright (C) 2004-2007 Koichi Sasada
 
 **********************************************************************/
-
-#ifndef RUBY_INSNHELPER_H
-#define RUBY_INSNHELPER_H
 
 RUBY_SYMBOL_EXPORT_BEGIN
 

--- a/vm_opts.h
+++ b/vm_opts.h
@@ -1,4 +1,5 @@
-/*-*-c-*-*/
+#ifndef RUBY_VM_OPTS_H/*-*-c-*-*/
+#define RUBY_VM_OPTS_H
 /**********************************************************************
 
   vm_opts.h - VM optimize option
@@ -8,10 +9,6 @@
   Copyright (C) 2004-2007 Koichi Sasada
 
 **********************************************************************/
-
-
-#ifndef RUBY_VM_OPTS_H
-#define RUBY_VM_OPTS_H
 
 /* Compile options.
  * You can change these options at runtime by VM::CompileOption.


### PR DESCRIPTION
According to [MSVC manual](https://docs.microsoft.com/en-us/cpp/preprocessor/once), `cl.exe` can skip including a header file when that:

- contains `#pragma once`, or
- starts with `#ifndef`, or
- starts with `#if ! defined`.

GCC has [a similar trick](https://gcc.gnu.org/onlinedocs/cppinternals/Guard-Macros.html), but it acts more stricter (e. g. there must be _no tokens_ outside of `#ifndef`...`#endif`).

Sun C lacked `#pragma once` for a looong time.  Oracle Developer Studio 12.5 finally implemented it, but we cannot assume such recent version.

This changeset modifies header files so that each of them include strictly one `#ifndef`...`#endif`.  I believe this is the most portable way to trigger compiler optimizations.