### PR TITLE
Make vm_call_cfunc_with_frame a fastpath

### DIFF
--- a/benchmark/vm_send_cfunc.yml
+++ b/benchmark/vm_send_cfunc.yml
@@ -1,0 +1,3 @@
+benchmark:
+  vm_send_cfunc: self.class
+loop_count: 100000000

--- a/debug_counter.h
+++ b/debug_counter.h
@@ -66,6 +66,7 @@ RB_DEBUG_COUNTER(ccf_iseq_opt) /* has_opt == TRUE (has optional parameters), but
 RB_DEBUG_COUNTER(ccf_iseq_kw1) /* vm_call_iseq_setup_kwparm_kwarg() */
 RB_DEBUG_COUNTER(ccf_iseq_kw2) /* vm_call_iseq_setup_kwparm_nokwarg() */
 RB_DEBUG_COUNTER(ccf_cfunc)
+RB_DEBUG_COUNTER(ccf_cfunc_with_frame)
 RB_DEBUG_COUNTER(ccf_ivar) /* attr_reader */
 RB_DEBUG_COUNTER(ccf_attrset) /* attr_writer */
 RB_DEBUG_COUNTER(ccf_method_missing)

--- a/tool/ruby_vm/views/_mjit_compile_send.erb
+++ b/tool/ruby_vm/views/_mjit_compile_send.erb
@@ -18,9 +18,12 @@
 % # compiler: Inline send insn where some supported fastpath is used.
     const rb_iseq_t *iseq = NULL;
     const CALL_INFO ci = cd->ci;
+    int kw_splat = IS_ARGS_KW_SPLAT(ci) > 0;
+    extern bool rb_splat_or_kwargs_p(const struct rb_callinfo *restrict ci);
     if (!status->compile_info->disable_send_cache && has_valid_method_type(captured_cc) && (
-%       # `CC_SET_FASTPATH(cc, vm_call_cfunc, TRUE)` in `vm_call_method_each_type`
-        vm_cc_cme(captured_cc)->def->type == VM_METHOD_TYPE_CFUNC
+%       # `CC_SET_FASTPATH(cd->cc, vm_call_cfunc_with_frame, ...)` in `vm_call_cfunc`
+        (vm_cc_cme(captured_cc)->def->type == VM_METHOD_TYPE_CFUNC
+         && !rb_splat_or_kwargs_p(ci) && !kw_splat)
 %       # `CC_SET_FASTPATH(cc, vm_call_iseq_setup_func(...), vm_call_iseq_optimizable_p(...))` in `vm_callee_setup_arg`,
 %       # and support only non-VM_CALL_TAILCALL path inside it
         || (vm_cc_cme(captured_cc)->def->type == VM_METHOD_TYPE_ISEQ
@@ -61,14 +64,14 @@
 % else
             fprintf(f, "        calling.block_handler = VM_BLOCK_HANDLER_NONE;\n");
 % end
-            fprintf(f, "        calling.kw_splat = %d;\n", IS_ARGS_KW_SPLAT(ci) > 0);
+            fprintf(f, "        calling.kw_splat = %d;\n", kw_splat);
             fprintf(f, "        calling.recv = stack[%d];\n", b->stack_size + sp_inc - 1);
             fprintf(f, "        calling.argc = %d;\n", vm_ci_argc(ci));
 
             if (vm_cc_cme(captured_cc)->def->type == VM_METHOD_TYPE_CFUNC) {
 %               # TODO: optimize this more
                 fprintf(f, "        CALL_DATA cd = (CALL_DATA)0x%"PRIxVALUE";\n", operands[0]);
-                fprintf(f, "        val = vm_call_cfunc(ec, reg_cfp, &calling, cd);\n");
+                fprintf(f, "        val = vm_call_cfunc_with_frame(ec, reg_cfp, &calling, cd);\n");
             }
             else { // VM_METHOD_TYPE_ISEQ
 %               # fastpath_applied_iseq_p checks rb_simple_iseq_p, which ensures has_opt == FALSE


### PR DESCRIPTION
when there's no need to call CALLER_SETUP_ARG and CALLER_REMOVE_EMPTY_KW_SPLAT
(i.e. `!rb_splat_or_kwargs_p(ci) && !calling->kw_splat`).

Micro benchmark:
```
$ benchmark-driver -v --rbenv 'before;after' benchmark/vm_send_cfunc.yml --repeat-count=4
before: ruby 2.8.0dev (2020-04-13T23:45:05Z master b9d3ceee8f) [x86_64-linux]
after: ruby 2.8.0dev (2020-04-14T00:48:52Z no-splat-fastpath 418d363722) [x86_64-linux]
Calculating -------------------------------------
                         before       after
       vm_send_cfunc    69.585M     88.724M i/s -    100.000M times in 1.437097s 1.127096s

Comparison:
                    vm_send_cfunc
               after:  88723605.2 i/s
              before:  69584737.1 i/s - 1.28x  slower
```

Optcarrot:
```
$ benchmark-driver -v --rbenv 'before;after' benchmark.yml --repeat-count=12 --output=all
before: ruby 2.8.0dev (2020-04-13T23:45:05Z master b9d3ceee8f) [x86_64-linux]
after: ruby 2.8.0dev (2020-04-14T00:48:52Z no-splat-fastpath 418d363722) [x86_64-linux]
Calculating -------------------------------------
                                       before                 after
Optcarrot Lan_Master.nes    50.76119601545175     42.73858236484051 fps
                            50.76388649761503     51.04211379912850
                            50.80930672252514     51.39455790755538
                            50.90236000778749     51.75656936556145
                            51.01744746340430     51.86875277356489
                            51.06495279015112     51.88692482485558
                            51.07785337168974     51.93429603190578
                            51.20163525187862     51.95768145071314
                            51.34671771913112     52.45577266040274
                            51.35918340835583     52.53163888762858
                            51.46641337418146     52.62172484121034
                            51.50835463462257     52.85064021113239
```

```
$ benchmark-driver -v --rbenv 'before --jit;after --jit' benchmark.yml --repeat-count=12 --output=all
before --jit: ruby 2.8.0dev (2020-04-13T23:45:05Z master b9d3ceee8f) +JIT [x86_64-linux]
after --jit: ruby 2.8.0dev (2020-04-14T00:48:52Z no-splat-fastpath 418d363722) +JIT [x86_64-linux]
Calculating -------------------------------------
                                 before --jit           after --jit
Optcarrot Lan_Master.nes    60.52861537565374     67.08980202264379 fps
                            67.05028666947801     77.38689228405163
                            69.88002452370954     77.50596684745499
                            70.26134426118010     77.94041584350319
                            71.66299817222229     77.98394114736431
                            73.18773148379002     78.15891498662722
                            73.42268672752398     79.33680706371175
                            74.31435163481852     79.90004611877974
                            74.69955776785898     80.80041972223560
                            75.68628285203798     81.15191864435850
                            76.11380955643959     81.30957930892660
                            79.78410350903283     81.50037555555708
```