### PR TITLE
Assume pch is stabler than pdb

### DIFF
--- a/win32/Makefile.sub
+++ b/win32/Makefile.sub
@@ -1341,11 +1341,17 @@ clean-local::
 #
 # TODO: Fix the above issue by including VC version in header name, and create another header
 # for --jit-debug as well.
+#
+# Using .pdb for ifchange target as a workaround since using .pch randomly results in:
+# > rb_mjit_header-2.8.0.pdb is not the pdb file that was used when this precompiled header
+# > was created, recreate the precompiled header.
+# with AppVeyor Visual Studio 2013 for some reason. TODO: Support updating multiple files
+# (.pdb and .pch) in win32/ifchange.bat
 $(TIMESTAMPDIR)/$(MJIT_PRECOMPILED_HEADER_NAME:.pch=).time: probes.h vm.$(OBJEXT)
 	$(ECHO) building $(@F:.time=.pch)
 	$(Q) $(CC) -DMJIT_HEADER $(CFLAGS) $(XCFLAGS:-DRUBY_EXPORT =) -URUBY_EXPORT $(CPPFLAGS) $(srcdir)/vm.c -c -Yc \
-	  $(COUTFLAG)$(@F:.time=.)$(OBJEXT) -Fd$(@F:.time=.pdb) -Fp$(@F:.time=.pch).new
-	$(Q) $(IFCHANGE) "--timestamp=$@" $(@F:.time=.pch) $(@F:.time=.pch).new
+	  $(COUTFLAG)$(@F:.time=.)$(OBJEXT) -Fd$(@F:.time=.pdb).new -Fp$(@F:.time=.pch)
+	$(Q) $(IFCHANGE) "--timestamp=$@" $(@F:.time=.pdb) $(@F:.time=.pdb).new
 
 $(MJIT_PRECOMPILED_HEADER_NAME): $(TIMESTAMPDIR)/$(MJIT_PRECOMPILED_HEADER_NAME:.pch=).time
 


### PR DESCRIPTION
to fix random AppVeyor failures like:
https://ci.appveyor.com/project/ruby/ruby/builds/32159878/job/l2p38snw8yxxpp8h

C:\Users\appveyor\AppData\Local\Temp\1/_ruby_mjit_p27500u0.c(1) : error C2859:
c:\projects\ruby\x64-mswin_120\include\ruby-2.8.0\x64-mswin64_120\rb_mjit_header-2.8.0.pdb
is not the pdb file that was used when this precompiled header was created, recreate the precompiled header.

Currently ifchange skips updating .time and .pch when there's no change
in .pch, but it does not skip updating .pdb. I suspect it causes
mismatch between .pdb and .pch. Assuming .pch is stabler (i.e. When .pdb
has no change, .pch never has any change either), I hope this will work
as a workaround until we support updating multiple files in ifchange.bat.

There's a possibility that .pdb is completely unstable (it never
produces the same binary). In that case please feel free to revert this
commit.