### PR TITLE
Fix segfault at RubyVM::InstructionSequence.compile with debug_level: > 1

### DIFF
--- a/bootstraptest/test_insns.rb
+++ b/bootstraptest/test_insns.rb
@@ -438,3 +438,8 @@ tests.compact.each {|(insn, expr, *a)|
     assert_equal 'true', progn, 'trace_' + insn, *a
   end
 }
+
+assert_normal_exit("#{<<-"begin;"}\n#{<<-'end;'}")
+begin;
+  RubyVM::InstructionSequence.compile("", debug_level: 5)
+end;

--- a/compile.c
+++ b/compile.c
@@ -1423,6 +1423,13 @@ iseq_setup(rb_iseq_t *iseq, LINK_ANCHOR *const anchor)
     debugs("[compile step 6 (update_catch_except_flags)] \n");
     update_catch_except_flags(iseq->body);
 
+#if VM_INSN_INFO_TABLE_IMPL == 2
+    if (iseq->body->insns_info.succ_index_table == NULL) {
+        debugs("[compile step 7 (rb_iseq_insns_info_encode_positions)] \n");
+        rb_iseq_insns_info_encode_positions(iseq);
+    }
+#endif
+
     if (compile_debug > 1) {
 	VALUE str = rb_iseq_disasm(iseq);
 	printf("%s\n", StringValueCStr(str));

--- a/iseq.c
+++ b/iseq.c
@@ -615,6 +615,7 @@ void
 rb_iseq_insns_info_encode_positions(const rb_iseq_t *iseq)
 {
 #if VM_INSN_INFO_TABLE_IMPL == 2
+    /* create succ_index_table */
     struct rb_iseq_constant_body *const body = iseq->body;
     int size = body->insns_info.size;
     int max_pos = body->iseq_size;
@@ -656,13 +657,6 @@ finish_iseq_build(rb_iseq_t *iseq)
     VALUE err = data->err_info;
     ISEQ_COMPILE_DATA_CLEAR(iseq);
     compile_data_free(data);
-
-#if VM_INSN_INFO_TABLE_IMPL == 2 /* succinct bitvector */
-    /* create succ_index_table */
-    if (body->insns_info.succ_index_table == NULL) {
-	rb_iseq_insns_info_encode_positions(iseq);
-    }
-#endif
 
 #if VM_CHECK_MODE > 0 && VM_INSN_INFO_TABLE_IMPL > 0
     validate_get_insn_info(iseq);

--- a/test/ruby/test_iseq.rb
+++ b/test/ruby/test_iseq.rb
@@ -571,4 +571,12 @@ class TestISeq < Test::Unit::TestCase
     assert_not_nil(invokebuiltin)
     assert_equal([:func_ptr, :argc, :index, :name], invokebuiltin[1].keys)
   end
+
+  def test_iseq_option_debug_level
+    assert_raise(TypeError) {ISeq.compile("", debug_level: "")}
+    assert_ruby_status([], "#{<<~"begin;"}\n#{<<~'end;'}")
+    begin;
+      RubyVM::InstructionSequence.compile("", debug_level: 5)
+    end;
+  end
 end


### PR DESCRIPTION
With compiling `CPDEBUG >= 2`, `rb_iseq_disasm` segfaults if this table has not been created.  Also `ibf_load_iseq_each` calls `rb_iseq_insns_info_encode_positions`.