### PR TITLE
support builtin for Exception#full_message

### DIFF
--- a/.document
+++ b/.document
@@ -12,6 +12,7 @@ prelude.rb
 rbconfig.rb
 array.rb
 ast.rb
+exception.rb
 dir.rb
 gc.rb
 io.rb

--- a/benchmark/exception_full_message.yml
+++ b/benchmark/exception_full_message.yml
@@ -1,0 +1,26 @@
+benchmark:
+  kwargs: |
+    begin
+      raise "benchmark"
+    rescue => e
+      e.full_message(highlight: true, order: :bottom)
+    end
+  nokwargs: |
+    begin
+      raise "benchmark"
+    rescue => e
+      e.full_message
+    end
+  highlight: |
+    begin
+      raise "benchmark"
+    rescue => e
+      e.full_message(highlight: true)
+    end
+  order: |
+    begin
+      raise "benchmark"
+    rescue => e
+      e.full_message(order: :bottom)
+    end
+loop_count: 10000

--- a/common.mk
+++ b/common.mk
@@ -998,6 +998,7 @@ $(srcs_vpath)mjit_compile.inc: $(tooldir)/ruby_vm/views/mjit_compile.inc.erb $(i
 
 BUILTIN_RB_SRCS = \
 		$(srcdir)/ast.rb \
+		$(srcdir)/exception.rb \
 		$(srcdir)/gc.rb \
 		$(srcdir)/io.rb \
 		$(srcdir)/dir.rb \
@@ -5175,6 +5176,7 @@ error.$(OBJEXT): {$(VPATH)}defines.h
 error.$(OBJEXT): {$(VPATH)}encoding.h
 error.$(OBJEXT): {$(VPATH)}error.c
 error.$(OBJEXT): {$(VPATH)}eval_intern.h
+error.$(OBJEXT): {$(VPATH)}exception.rbinc
 error.$(OBJEXT): {$(VPATH)}id.h
 error.$(OBJEXT): {$(VPATH)}id_table.h
 error.$(OBJEXT): {$(VPATH)}intern.h
@@ -8201,6 +8203,7 @@ miniinit.$(OBJEXT): {$(VPATH)}config.h
 miniinit.$(OBJEXT): {$(VPATH)}defines.h
 miniinit.$(OBJEXT): {$(VPATH)}dir.rb
 miniinit.$(OBJEXT): {$(VPATH)}encoding.h
+miniinit.$(OBJEXT): {$(VPATH)}exception.rb
 miniinit.$(OBJEXT): {$(VPATH)}gc.rb
 miniinit.$(OBJEXT): {$(VPATH)}gem_prelude.rb
 miniinit.$(OBJEXT): {$(VPATH)}id.h

--- a/error.c
+++ b/error.c
@@ -1084,66 +1084,32 @@ exc_s_to_tty_p(VALUE self)
     return rb_stderr_tty_p() ? Qtrue : Qfalse;
 }
 
-/*
- * call-seq:
- *   exception.full_message(highlight: bool, order: [:top or :bottom]) ->  string
- *
- * Returns formatted string of _exception_.
- * The returned string is formatted using the same format that Ruby uses
- * when printing an uncaught exceptions to stderr.
- *
- * If _highlight_ is +true+ the default error handler will send the
- * messages to a tty.
- *
- * _order_ must be either of +:top+ or +:bottom+, and places the error
- * message and the innermost backtrace come at the top or the bottom.
- *
- * The default values of these options depend on <code>$stderr</code>
- * and its +tty?+ at the timing of a call.
- */
-
 static VALUE
-exc_full_message(int argc, VALUE *argv, VALUE exc)
+exc_full_message(rb_execution_context_t *ec, VALUE exc, VALUE highlight, VALUE order)
 {
-    VALUE opt, str, emesg, errat;
-    enum {kw_highlight, kw_order, kw_max_};
-    static ID kw[kw_max_];
-    VALUE args[kw_max_] = {Qnil, Qnil};
+    VALUE str, emesg, errat;
 
-    rb_scan_args(argc, argv, "0:", &opt);
-    if (!NIL_P(opt)) {
-	if (!kw[0]) {
-#define INIT_KW(n) kw[kw_##n] = rb_intern_const(#n)
-	    INIT_KW(highlight);
-	    INIT_KW(order);
-#undef INIT_KW
-	}
-	rb_get_kwargs(opt, kw, 0, kw_max_, args);
-	switch (args[kw_highlight]) {
+	switch (highlight) {
 	  default:
 	    rb_raise(rb_eArgError, "expected true or false as "
-		     "highlight: %+"PRIsVALUE, args[kw_highlight]);
-	  case Qundef: args[kw_highlight] = Qnil; break;
+		     "highlight: %+"PRIsVALUE, highlight);
+      case Qundef: highlight = Qnil; break;
 	  case Qtrue: case Qfalse: case Qnil: break;
 	}
-	if (args[kw_order] == Qundef) {
-	    args[kw_order] = Qnil;
-	}
-	else {
-	    ID id = rb_check_id(&args[kw_order]);
-	    if (id == id_bottom) args[kw_order] = Qtrue;
-	    else if (id == id_top) args[kw_order] = Qfalse;
+	if (!NIL_P(order)) {
+        ID id = rb_check_id(&order);
+        if (id == id_bottom) order = Qtrue;
+	    else if (id == id_top) order = Qfalse;
 	    else {
 		rb_raise(rb_eArgError, "expected :top or :bottom as "
-			 "order: %+"PRIsVALUE, args[kw_order]);
+			 "order: %+"PRIsVALUE, order);
 	    }
 	}
-    }
     str = rb_str_new2("");
     errat = rb_get_backtrace(exc);
     emesg = rb_get_message(exc);
 
-    rb_error_write(exc, emesg, errat, str, args[kw_highlight], args[kw_order]);
+    rb_error_write(exc, emesg, errat, str, highlight, order);
     return str;
 }
 
@@ -2565,7 +2531,6 @@ Init_Exception(void)
     rb_define_method(rb_eException, "==", exc_equal, 1);
     rb_define_method(rb_eException, "to_s", exc_to_s, 0);
     rb_define_method(rb_eException, "message", exc_message, 0);
-    rb_define_method(rb_eException, "full_message", exc_full_message, -1);
     rb_define_method(rb_eException, "inspect", exc_inspect, 0);
     rb_define_method(rb_eException, "backtrace", exc_backtrace, 0);
     rb_define_method(rb_eException, "backtrace_locations", exc_backtrace_locations, 0);
@@ -3085,6 +3050,7 @@ Init_syserr(void)
 }
 
 #include "warning.rbinc"
+#include "exception.rbinc"
 
 /*!
  * \}

--- a/exception.rb
+++ b/exception.rb
@@ -1,0 +1,22 @@
+class Exception
+  #
+  # call-seq:
+  #   exception.full_message(highlight: bool, order: [:top or :bottom]) ->  string
+  #
+  # Returns formatted string of _exception_.
+  # The returned string is formatted using the same format that Ruby uses
+  # when printing an uncaught exceptions to stderr.
+  #
+  # If _highlight_ is +true+ the default error handler will send the
+  # messages to a tty.
+  #
+  # _order_ must be either of +:top+ or +:bottom+, and places the error
+  # message and the innermost backtrace come at the top or the bottom.
+  #
+  # The default values of these options depend on <code>$stderr</code>
+  # and its +tty?+ at the timing of a call.
+  #
+  def full_message(highlight: nil, order: nil)
+    __builtin_exc_full_message(highlight, order)
+  end
+end

--- a/inits.c
+++ b/inits.c
@@ -86,6 +86,7 @@ rb_call_inits(void)
     BUILTIN(warning);
     BUILTIN(array);
     BUILTIN(kernel);
+    BUILTIN(exception);
     Init_builtin_prelude();
 }
 #undef CALL

--- a/spec/ruby/core/exception/full_message_spec.rb
+++ b/spec/ruby/core/exception/full_message_spec.rb
@@ -37,7 +37,11 @@ describe "Exception#full_message" do
       e = RuntimeError.new("Some runtime error")
       e.backtrace.should == nil
       full_message = e.full_message(highlight: false, order: :top)
-      full_message.should include("<internal:exception>:20:in `")
+      if ruby_version_is "2.8.0-dev"
+        full_message.should include("<internal:exception>:20:in ")
+      else
+        full_message.should include("#{__FILE__}:#{__LINE__-4}:in `")
+      end
       full_message.should include("': Some runtime error (RuntimeError)\n")
     end
 

--- a/spec/ruby/core/exception/full_message_spec.rb
+++ b/spec/ruby/core/exception/full_message_spec.rb
@@ -37,7 +37,7 @@ describe "Exception#full_message" do
       e = RuntimeError.new("Some runtime error")
       e.backtrace.should == nil
       full_message = e.full_message(highlight: false, order: :top)
-      full_message.should include("#{__FILE__}:#{__LINE__-1}:in `")
+      full_message.should include("<internal:exception>:20:in `")
       full_message.should include("': Some runtime error (RuntimeError)\n")
     end
 


### PR DESCRIPTION
support builtin for `Exception#full_message`, and better performance.

Benchmark:

```yml
benchmark:
  kwargs: |
    begin
      raise "benchmark"
    rescue => e
      e.full_message(highlight: true, order: :bottom)
    end
  nokwargs: |
    begin
      raise "benchmark"
    rescue => e
      e.full_message
    end
  highlight: |
    begin
      raise "benchmark"
    rescue => e
      e.full_message(highlight: true)
    end
  order: |
    begin
      raise "benchmark"
    rescue => e
      e.full_message(order: :bottom)
    end
loop_count: 10000
```

Result:

```bash
sh@MyComputer:/mnt/c/users/sh/desktop/rubydev/build$ make benchmark/exception_full_message.yml -e COMPARE_RUBY=/home/sh/.rbenv/shims/ruby
generating known_errors.inc
known_errors.inc unchanged
Calculating -------------------------------------
                     compare-ruby  built-ruby
              kwargs     155.549k    190.542k i/s -     10.000k times in 0.064289s 0.052482s
            nokwargs     189.043k    197.136k i/s -     10.000k times in 0.052898s 0.050726s
           highlight     182.715k    186.678k i/s -     10.000k times in 0.054730s 0.053568s
               order     170.794k    191.124k i/s -     10.000k times in 0.058550s 0.052322s

Comparison:
                           kwargs
          built-ruby:    190542.2 i/s
        compare-ruby:    155548.8 i/s - 1.22x  slower

                         nokwargs
          built-ruby:    197136.4 i/s
        compare-ruby:    189043.1 i/s - 1.04x  slower

                        highlight
          built-ruby:    186677.6 i/s
        compare-ruby:    182715.1 i/s - 1.02x  slower

                            order
          built-ruby:    191124.2 i/s
        compare-ruby:    170793.6 i/s - 1.12x  slower

```

`COMPARE_RUBY=/home/sh/.rbenv/shims/ruby` is `ruby 2.8.0dev (2020-04-16T09:02:11Z master 693378f105) [x86_64-linux]`