### PR TITLE
Update VMDEBUG reference doc

### DIFF
--- a/vm_dump.c
+++ b/vm_dump.c
@@ -37,7 +37,7 @@
 #include "vm_core.h"
 
 
-/* see vm_insnhelper.h for the values */
+/* see vm_core.h for the values */
 #ifndef VMDEBUG
 #define VMDEBUG 0
 #endif


### PR DESCRIPTION
Since this commit (https://github.com/ruby/ruby/commit/9e1b06e17d27fb4ddf51e9244f205417e9c4dd5c), the VM Debug Level constant is moved from `vm_insnhelper.h` to `vm_core.h`. This PR is a super tiny update to reflect that change so that people won't waste time on searching in a wrong file.