### PR TITLE
Always use struct_new_kw as Struct constructor

### DIFF
--- a/struct.c
+++ b/struct.c
@@ -326,15 +326,11 @@ static VALUE
 setup_struct(VALUE nstr, VALUE members, int keyword_init)
 {
     long i, len;
-    VALUE (*new_func)(int, const VALUE *, VALUE) = rb_class_new_instance;
-
-    if (keyword_init) new_func = struct_new_kw;
-
     members = struct_set_members(nstr, members);
 
     rb_define_alloc_func(nstr, struct_alloc);
-    rb_define_singleton_method(nstr, "new", new_func, -1);
-    rb_define_singleton_method(nstr, "[]", new_func, -1);
+    rb_define_singleton_method(nstr, "new", struct_new_kw, -1);
+    rb_define_singleton_method(nstr, "[]", struct_new_kw, -1);
     rb_define_singleton_method(nstr, "members", rb_struct_s_members_m, 0);
     rb_define_singleton_method(nstr, "inspect", rb_struct_s_inspect, 0);
     len = RARRAY_LEN(members);

--- a/test/ruby/test_struct.rb
+++ b/test/ruby/test_struct.rb
@@ -119,7 +119,7 @@ module TestStruct
     assert_equal "#{@Struct}::KeywordInitTrue(keyword_init: true)", @Struct::KeywordInitTrue.inspect
     # eval is needed to prevent the warning duplication filter
     k = eval("Class.new(@Struct::KeywordInitFalse) {def initialize(**) end}")
-    assert_raise(ArgumentError) { k.new(a: 1, b: 2) }
+    assert_warn('') {k.new(a: 1, b: 2)}
     k = Class.new(@Struct::KeywordInitTrue) {def initialize(**) end}
     assert_warn('') {k.new(a: 1, b: 2)}
 


### PR DESCRIPTION
Ruby-core Issue: https://bugs.ruby-lang.org/issues/16801
Ref: https://github.com/ruby/ruby/pull/2582

Otherwise if the `initialize` is redefined to also accept keyword
arguments, rb_class_new_instance improperly handle them:

```
Field = Struct.new(:value) do
  def initialize(value, keyword: false)
    super(value)
    @keyword = keyword
  end
end

Field.new(1, keyword: true)
```

```
/tmp/kw.rb:8: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/tmp/kw.rb:2: warning: The called method `initialize' is defined here
```