### PR TITLE
support builtin for Kernel#Float

### DIFF
--- a/benchmark/kernel_float.yml
+++ b/benchmark/kernel_float.yml
@@ -1,0 +1,5 @@
+benchmark:
+  float: "Float(42)"
+  float_true: "Float(42, exception: true)"
+  float_false: "Float(42, exception: false)"
+loop_count: 10000

--- a/kernel.rb
+++ b/kernel.rb
@@ -27,8 +27,8 @@ module Kernel
     __builtin_rb_obj_clone2(freeze)
   end
 
-  private
-  
+  module_function
+
   #
   #  call-seq:
   #     Float(arg, exception: true)    -> float or nil

--- a/kernel.rb
+++ b/kernel.rb
@@ -26,4 +26,28 @@ module Kernel
   def clone(freeze: nil)
     __builtin_rb_obj_clone2(freeze)
   end
+
+  private
+  
+  #
+  #  call-seq:
+  #     Float(arg, exception: true)    -> float or nil
+  #
+  #  Returns <i>arg</i> converted to a float. Numeric types are
+  #  converted directly, and with exception to String and
+  #  <code>nil</code> the rest are converted using
+  #  <i>arg</i><code>.to_f</code>.  Converting a String with invalid
+  #  characters will result in a ArgumentError.  Converting
+  #  <code>nil</code> generates a TypeError.  Exceptions can be
+  #  suppressed by passing <code>exception: false</code>.
+  #
+  #     Float(1)                 #=> 1.0
+  #     Float("123.456")         #=> 123.456
+  #     Float("123.0_badstring") #=> ArgumentError: invalid value for Float(): "123.0_badstring"
+  #     Float(nil)               #=> TypeError: can't convert nil into Float
+  #     Float("123.0_badstring", exception: false)  #=> nil
+  #
+  def Float(arg, exception: true)
+    __builtin_rb_f_float(arg, exception)
+  end
 end

--- a/object.c
+++ b/object.c
@@ -3813,32 +3813,11 @@ rb_Float(VALUE val)
     return rb_convert_to_float(val, TRUE);
 }
 
-/*
- *  call-seq:
- *     Float(arg, exception: true)    -> float or nil
- *
- *  Returns <i>arg</i> converted to a float. Numeric types are
- *  converted directly, and with exception to String and
- *  <code>nil</code> the rest are converted using
- *  <i>arg</i><code>.to_f</code>.  Converting a String with invalid
- *  characters will result in a ArgumentError.  Converting
- *  <code>nil</code> generates a TypeError.  Exceptions can be
- *  suppressed by passing <code>exception: false</code>.
- *
- *     Float(1)                 #=> 1.0
- *     Float("123.456")         #=> 123.456
- *     Float("123.0_badstring") #=> ArgumentError: invalid value for Float(): "123.0_badstring"
- *     Float(nil)               #=> TypeError: can't convert nil into Float
- *     Float("123.0_badstring", exception: false)  #=> nil
- */
-
 static VALUE
-rb_f_float(int argc, VALUE *argv, VALUE obj)
+rb_f_float(rb_execution_context_t *ec, VALUE obj, VALUE arg, VALUE opts)
 {
-    VALUE arg = Qnil, opts = Qnil;
-
-    rb_scan_args(argc, argv, "1:", &arg, &opts);
-    return rb_convert_to_float(arg, opts_exception_p(opts));
+    int exception = rb_bool_expected(opts, "exception");
+    return rb_convert_to_float(arg, exception);
 }
 
 static VALUE
@@ -4668,7 +4647,6 @@ InitVM_Object(void)
     rb_define_global_function("format", f_sprintf, -1);
 
     rb_define_global_function("Integer", rb_f_integer, -1);
-    rb_define_global_function("Float", rb_f_float, -1);
 
     rb_define_global_function("String", rb_f_string, 1);
     rb_define_global_function("Array", rb_f_array, 1);


### PR DESCRIPTION
using builtin for `Kernel#Float` func(Perfomance implovement is main purpose)

benchmark:

```yaml
benchmark:
  float: "Float(42)"
  float_true: "Float(42, exception: true)"
  float_false: "Float(42, exception: false)"
loop_count: 10000
```

result:

```bash
sh@MyComputer:/mnt/c/Users/sh/Desktop/rubydev/build$ make benchmark/kernel_float.yml -e COMPARE_RUBY=~/.rbenv/shims/ruby
generating known_errors.inc
known_errors.inc unchanged
Calculating -------------------------------------
                     compare-ruby  built-ruby
               float      26.028M     24.882M i/s -     10.000k times in 0.000384s 0.000402s
          float_true       1.274M      9.840M i/s -     10.000k times in 0.007851s 0.001016s
         float_false       1.136M     11.365M i/s -     10.000k times in 0.008801s 0.000880s

Comparison:
                            float
        compare-ruby:  26028110.4 i/s
          built-ruby:  24881811.4 i/s - 1.05x  slower

                       float_true
          built-ruby:   9839614.3 i/s
        compare-ruby:   1273658.2 i/s - 7.73x  slower

                      float_false
          built-ruby:  11364927.8 i/s
        compare-ruby:   1136247.4 i/s - 10.00x  slower
```

`COMPARE_RUBY` is `ruby 2.8.0dev (2020-04-21T12:12:00Z master 6b04c48048) [x86_64-linux]`. This patch is ahead of `ruby 2.8.0dev (2020-04-21T12:12:00Z master 6b04c48048) [x86_64-linux]`