### PR TITLE
support builtin for Kernel#Integer

### DIFF
--- a/benchmark/kernel_integer.yml
+++ b/benchmark/kernel_integer.yml
@@ -1,0 +1,8 @@
+benchmark:
+  str2int: "Integer('42')"
+  str2int_true: "Integer('42', exception: true)"
+  str2int_false: "Integer('42', exception: false)"
+  float2int: "Integer(4.2)"
+  float2int_true: "Integer(4.2, exception: true)"
+  float2int_false: "Integer(4.2, exception: false)"
+loop_count: 10000

--- a/kernel.rb
+++ b/kernel.rb
@@ -31,6 +31,41 @@ module Kernel
 
   #
   #  call-seq:
+  #     Integer(arg, base=0, exception: true)    -> integer or nil
+  #
+  #  Converts <i>arg</i> to an Integer.
+  #  Numeric types are converted directly (with floating point numbers
+  #  being truncated).  <i>base</i> (0, or between 2 and 36) is a base for
+  #  integer string representation.  If <i>arg</i> is a String,
+  #  when <i>base</i> is omitted or equals zero, radix indicators
+  #  (<code>0</code>, <code>0b</code>, and <code>0x</code>) are honored.
+  #  In any case, strings should be strictly conformed to numeric
+  #  representation. This behavior is different from that of
+  #  String#to_i.  Non string values will be converted by first
+  #  trying <code>to_int</code>, then <code>to_i</code>.
+  #
+  #  Passing <code>nil</code> raises a TypeError, while passing a String that
+  #  does not conform with numeric representation raises an ArgumentError.
+  #  This behavior can be altered by passing <code>exception: false</code>,
+  #  in this case a not convertible value will return <code>nil</code>.
+  #
+  #     Integer(123.999)    #=> 123
+  #     Integer("0x1a")     #=> 26
+  #     Integer(Time.new)   #=> 1204973019
+  #     Integer("0930", 10) #=> 930
+  #     Integer("111", 2)   #=> 7
+  #     Integer(nil)        #=> TypeError: can't convert nil into Integer
+  #     Integer("x")        #=> ArgumentError: invalid value for Integer(): "x"
+  #
+  #     Integer("x", exception: false)        #=> nil
+  #
+  #
+  def Integer(arg, base = 0, exception: true)
+    __builtin_rb_f_integer(arg, base, exception)
+  end
+
+  #
+  #  call-seq:
   #     Float(arg, exception: true)    -> float or nil
   #
   #  Returns <i>arg</i> converted to a float. Numeric types are

--- a/object.c
+++ b/object.c
@@ -3451,63 +3451,17 @@ rb_opts_exception_p(VALUE opts, int default_value)
 
 #define opts_exception_p(opts) rb_opts_exception_p((opts), TRUE)
 
-/*
- *  call-seq:
- *     Integer(arg, base=0, exception: true)    -> integer or nil
- *
- *  Converts <i>arg</i> to an Integer.
- *  Numeric types are converted directly (with floating point numbers
- *  being truncated).  <i>base</i> (0, or between 2 and 36) is a base for
- *  integer string representation.  If <i>arg</i> is a String,
- *  when <i>base</i> is omitted or equals zero, radix indicators
- *  (<code>0</code>, <code>0b</code>, and <code>0x</code>) are honored.
- *  In any case, strings should be strictly conformed to numeric
- *  representation. This behavior is different from that of
- *  String#to_i.  Non string values will be converted by first
- *  trying <code>to_int</code>, then <code>to_i</code>.
- *
- *  Passing <code>nil</code> raises a TypeError, while passing a String that
- *  does not conform with numeric representation raises an ArgumentError.
- *  This behavior can be altered by passing <code>exception: false</code>,
- *  in this case a not convertible value will return <code>nil</code>.
- *
- *     Integer(123.999)    #=> 123
- *     Integer("0x1a")     #=> 26
- *     Integer(Time.new)   #=> 1204973019
- *     Integer("0930", 10) #=> 930
- *     Integer("111", 2)   #=> 7
- *     Integer(nil)        #=> TypeError: can't convert nil into Integer
- *     Integer("x")        #=> ArgumentError: invalid value for Integer(): "x"
- *
- *     Integer("x", exception: false)        #=> nil
- *
- */
-
 static VALUE
-rb_f_integer(int argc, VALUE *argv, VALUE obj)
+rb_f_integer(rb_execution_context_t *ec, VALUE obj, VALUE arg, VALUE vbase, VALUE opts)
 {
-    VALUE arg = Qnil, opts = Qnil;
     int base = 0;
+    int exception = rb_bool_expected(opts, "exception");
 
-    if (argc > 1) {
-        int narg = 1;
-        VALUE vbase = rb_check_to_int(argv[1]);
-        if (!NIL_P(vbase)) {
-            base = NUM2INT(vbase);
-            narg = 2;
-        }
-        if (argc > narg) {
-            VALUE hash = rb_check_hash_type(argv[argc-1]);
-            if (!NIL_P(hash)) {
-                opts = rb_extract_keywords(&hash);
-                if (!hash) --argc;
-            }
-        }
+    if (!NIL_P(vbase) && FIXNUM_P(vbase)) {
+        base = NUM2INT(vbase);
     }
-    rb_check_arity(argc, 1, 2);
-    arg = argv[0];
 
-    return rb_convert_to_integer(arg, base, opts_exception_p(opts));
+    return rb_convert_to_integer(arg, base, exception);
 }
 
 static double
@@ -4645,8 +4599,6 @@ InitVM_Object(void)
 
     rb_define_global_function("sprintf", f_sprintf, -1);
     rb_define_global_function("format", f_sprintf, -1);
-
-    rb_define_global_function("Integer", rb_f_integer, -1);
 
     rb_define_global_function("String", rb_f_string, 1);
     rb_define_global_function("Array", rb_f_array, 1);


### PR DESCRIPTION
using builtin func for `Kernel#Integer`(Perfomance implovement is main purpose)

benchmark:

```yml
benchmark:
  str2int: "Integer('42')"
  str2int_true: "Integer('42', exception: true)"
  str2int_false: "Integer('42', exception: false)"
  float2int: "Integer(4.2)"
  float2int_true: "Integer(4.2, exception: true)"
  float2int_false: "Integer(4.2, exception: false)"
loop_count: 10000

```

result:

```bash
sh@MyComputer:/mnt/c/users/sh/desktop/rubydev/build$ make benchmark/kernel_integer.yml -e COMPARE_RUBY="~/.rbenv/shims/ruby"
generating known_errors.inc
known_errors.inc unchanged
Calculating -------------------------------------
                     compare-ruby  built-ruby
             str2int       4.966M      4.271M i/s -     10.000k times in 0.002014s 0.002341s
        str2int_true       1.571M      4.246M i/s -     10.000k times in 0.006367s 0.002355s
       str2int_false       1.006M      3.949M i/s -     10.000k times in 0.009945s 0.002532s
           float2int      42.123M     17.547M i/s -     10.000k times in 0.000237s 0.000570s
      float2int_true       1.081M     14.510M i/s -     10.000k times in 0.009254s 0.000689s
     float2int_false       1.189M     16.228M i/s -     10.000k times in 0.008413s 0.000616s

Comparison:
                          str2int
        compare-ruby:   4966229.7 i/s
          built-ruby:   4271496.3 i/s - 1.16x  slower

                     str2int_true
          built-ruby:   4245923.9 i/s
        compare-ruby:   1570549.1 i/s - 2.70x  slower

                    str2int_false
          built-ruby:   3949447.1 i/s
        compare-ruby:   1005510.2 i/s - 3.93x  slower

                        float2int
        compare-ruby:  42122999.9 i/s
          built-ruby:  17546938.0 i/s - 2.40x  slower

                   float2int_true
          built-ruby:  14509576.3 i/s
        compare-ruby:   1080613.8 i/s - 13.43x  slower

                  float2int_false
          built-ruby:  16228497.3 i/s
        compare-ruby:   1188679.0 i/s - 13.65x  slower
```

`COMPARE_RUBY` is `ruby 2.8.0dev (2020-04-23T01:44:27Z master d1f50b9872) [x86_64-linux]`. patch is ahead of `COMPARE_RUBY`.

Generally faster, but `float2int` very slow.