### PR TITLE
 [CI skip] Enhance rdoc intro for Hash 

### DIFF
--- a/doc/implicit_conversion.rdoc
+++ b/doc/implicit_conversion.rdoc
@@ -28,7 +28,7 @@ This class is Array-convertible:
 
     class ArrayConvertible
       def to_ary
-        [:foo, 'bar', baz = 2]
+        [:foo, 'bar', 2]
       end
     end
     a = []
@@ -45,7 +45,7 @@ This class is not Array-convertible (method +to_ary+ takes arguments):
 
     class NotArrayConvertible
       def to_ary(x)
-        [:foo, 'bar', baz = 2]
+        [:foo, 'bar', 2]
       end
     end
     a = []

--- a/hash.c
+++ b/hash.c
@@ -1748,7 +1748,7 @@ set_proc_default(VALUE hash, VALUE proc)
  *  call-seq:
  *     Hash.new                          -> new_hash
  *     Hash.new(default_value)           -> new_hash
- *     Hash.new {|hash, key| block }     -> new_hash
+ *     Hash.new {|hash, key| ... }       -> new_hash
  *
  *  Returns a new empty Hash object.
  *

--- a/hash.c
+++ b/hash.c
@@ -1787,7 +1787,7 @@ set_proc_default(VALUE hash, VALUE proc)
  *
  *  Raises an exception if both argument <tt>default_value</tt> and a block are given:
  *
- *    # Raises ArgumentError (wrong number of arguments (given 1, expected 0)) *
+ *    # Raises ArgumentError (wrong number of arguments (given 1, expected 0)):
  *    Hash.new(0) { }
  */
 
@@ -1860,34 +1860,34 @@ rb_hash_initialize(int argc, VALUE *argv, VALUE hash)
  *  but the argument is not an array of 2-element arrays or a
  *  {Hash-convertible object}[doc/implicit_conversion_rdoc.html#label-Hash-Convertible+Objects]:
  *
- *    # Raises ArgumentError (odd number of arguments for Hash)
+ *    # Raises ArgumentError (odd number of arguments for Hash):
  *    Hash[:foo]
- *    # Raises ArgumentError (invalid number of elements (3 for 1..2))
+ *    # Raises ArgumentError (invalid number of elements (3 for 1..2)):
  *    Hash[ [ [:foo, 0, 1] ] ]
  *
  *  Raises an exception if the argument count is odd and greater than 1:
  *
- *    # Raises ArgumentError (odd number of arguments for Hash)
+ *    # Raises ArgumentError (odd number of arguments for Hash):
  *    Hash[0, 1, 2]
  *
  *  Raises an exception if the argument is an array containing an element
  *  that is not a 2-element array:
  *
- *    # Raises ArgumentError (wrong element type Symbol at 0 (expected array))
+ *    # Raises ArgumentError (wrong element type Symbol at 0 (expected array)):
  *    Hash[ [ :foo ] ]
  *
  *  Raises an exception if the argument is an array containing an element
  *  that is an array of size different from 2:
  *
- *    # Raises ArgumentError (invalid number of elements (3 for 1..2))
+ *    # Raises ArgumentError (invalid number of elements (3 for 1..2)):
  *    Hash[ [ [0, 1, 2] ] ]
  *
  *  Raises an exception if any proposed key is not a valid key
  *  (see {Invalid Hash Keys}[#class-Hash-label-Invalid+Hash+Keys]):
  *
- *    # Raises NoMethodError (undefined method `hash' for #<BasicObject:>)
+ *    # Raises NoMethodError (undefined method `hash' for #<BasicObject:>):
  *    Hash[:foo, 0, BasicObject.new, 1]
- *    # Raises NoMethodError (undefined method `hash' for #<BasicObject:0x00000000064b1328>)
+ *    # Raises NoMethodError (undefined method `hash' for #<BasicObject:>):
  *    Hash[ [ [:foo, 0], [BasicObject.new, 1] ] ]
  */
 
@@ -2069,7 +2069,7 @@ rb_hash_rehash_i(VALUE key, VALUE value, VALUE arg)
  *  Raises an exception if called while an iterator is traversing the hash:
  *
  *    h = {foo: 0, bar: 1, baz: 2}
- *    # Raises RuntimeError (rehash during iteration)
+ *    # Raises RuntimeError (rehash during iteration):
  *    h.each { |x| h.rehash }
  */
 
@@ -6572,7 +6572,7 @@ env_update(VALUE env, VALUE hash)
  *  But it's an error to try the JSON-style syntax
  *  for a key that's not a bareword or a String:
  *
- *    # Raises SyntaxError (syntax error, unexpected ':', expecting =>)
+ *    # Raises SyntaxError (syntax error, unexpected ':', expecting =>):
  *    h = {0: 'zero'}
  *
  *  === Common Uses
@@ -6714,7 +6714,7 @@ env_update(VALUE env, VALUE hash)
  *
  *  An object that lacks method #hash cannot be a \Hash key:
  *
- *    # Raises NoMethodError (undefined method `hash' for #<BasicObject>)
+ *    # Raises NoMethodError (undefined method `hash' for #<BasicObject>):
  *    {BasicObject.new => 0}
  *
  *  ==== Modifying an Active \Hash Key

--- a/hash.c
+++ b/hash.c
@@ -6910,41 +6910,6 @@ env_update(VALUE env, VALUE hash)
  *    h.default_proc = nil
  *    h.default = false
  *    h[:nosuch] # => false
- *
- *  === Chaining \Method Calls
- *
- *  For a method that returns a \Hash, you can "chain" method calls
- *  by following one method call with another.
- *
- *  This example chains methods #merge and #compact:
- *
- *    h = {foo: 0, bar: nil, baz: 2}
- *    h1 = {bat: 3, bam: nil}
- *    h2 = h.merge(h1).compact
- *    h2 # => {:foo=>0, :baz=>2, :bat=>3}
- *
- *  Details:
- *
- *  - First method <tt>merge</tt> creates a copy of <tt>h</tt>,
- *    merges <tt>h1</tt> into the copy, and returns
- *      {foo=>0, bar=>nil, baz=>2, bat=>3, bam=>nil}
- *  - Chained method <tt>compact</tt> creates a copy of that return value,
- *    removes its <tt>nil</tt>-valued entries, and returns
- *      {:foo=>0, :baz=>2, :bat=>3}
- *
- *  A series of chained methods need not begin with a method in \Hash.
- *  This example chains methods Array#to_h and Hash#invert:
- *
- *    a = [[:foo, :bar], [1, 2]].to_h
- *    a.to_h.invert # => {:bar=>:foo, 2=>1}
- *
- *  Details:
- *
- *  - First method Array#to_h converts <tt>a</tt> to a \Hash, and returns
- *      {:foo=>:bar, 1=>2}
- *  - Chained method Hash#invert creates copy of that return value,
- *    inverts it, and  returns
- *      {:bar=>:foo, 2=>1}
  */
 
 void

--- a/hash.c
+++ b/hash.c
@@ -1748,7 +1748,7 @@ set_proc_default(VALUE hash, VALUE proc)
  *  call-seq:
  *     Hash.new                          -> new_hash
  *     Hash.new(default_value)           -> new_hash
- *     Hash.new { |hash, key| ... }      -> new_hash
+ *     Hash.new {|hash, key| ... }      -> new_hash
  *
  *  Returns a new empty Hash object.
  *
@@ -1860,7 +1860,7 @@ rb_hash_initialize(int argc, VALUE *argv, VALUE hash)
  *  but the argument is not an array of 2-element arrays or a
  *  {Hash-convertible object}[doc/implicit_conversion_rdoc.html#label-Hash-Convertible+Objects]:
  *
- *    # Raises ArgumentError (odd number of arguments
+ *    # Raises ArgumentError (odd number of arguments)
  *    Hash[:foo]
  *    # Raises ArgumentError (invalid number of elements (3 for 1..2))
  *    Hash[ [ [:foo, 0, 1] ] ]

--- a/hash.c
+++ b/hash.c
@@ -1748,7 +1748,7 @@ set_proc_default(VALUE hash, VALUE proc)
  *  call-seq:
  *     Hash.new                          -> new_hash
  *     Hash.new(default_value)           -> new_hash
- *     Hash.new {|hash, key| ... }      -> new_hash
+ *     Hash.new {|hash, key| block }      -> new_hash
  *
  *  Returns a new empty Hash object.
  *
@@ -1860,7 +1860,7 @@ rb_hash_initialize(int argc, VALUE *argv, VALUE hash)
  *  but the argument is not an array of 2-element arrays or a
  *  {Hash-convertible object}[doc/implicit_conversion_rdoc.html#label-Hash-Convertible+Objects]:
  *
- *    # Raises ArgumentError (odd number of arguments)
+ *    # Raises ArgumentError (odd number of arguments for Hash)
  *    Hash[:foo]
  *    # Raises ArgumentError (invalid number of elements (3 for 1..2))
  *    Hash[ [ [:foo, 0, 1] ] ]
@@ -2057,10 +2057,10 @@ rb_hash_rehash_i(VALUE key, VALUE value, VALUE arg)
  *  call-seq:
  *     hsh.rehash -> self
  *
- *  Rebuilds the hash index based on the current hash value for each key;
+ *  Rebuilds the hash table based on the current hash value for each key;
  *  returns <tt>self</tt>.
  *
- *  The index will have become invalid if the hash value of a key
+ *  The hash table will have become invalid if the hash value of a key
  *  has changed since the entry was created.
  *  See {Modifying an Active Hash Key}[#class-Hash-label-Modifying+an+Active+Hash+Key].
  *
@@ -6539,8 +6539,7 @@ env_update(VALUE env, VALUE hash)
 }
 
 /*
- *  A \Hash is a dictionary-like collection of key-value pairs
- *  whose keys are unique. (The values need not be unique.)
+ *  A \Hash maps each of its unique keys to a specific value.
  *
  *  A \Hash has certain similarities to an \Array, but:
  *  - An \Array index is always an \Integer.
@@ -6548,13 +6547,10 @@ env_update(VALUE env, VALUE hash)
  *
  *  === \Hash \Data Syntax
  *
- *  The older syntax for \Hash data uses the "hash rocket," <tt>=></tt>
- *  (known in some languages as the <i>fat comma.</i>):
+ *  The older syntax for \Hash data uses the "hash rocket," <tt>=></tt>:
  *
  *    h = {:foo => 0, :bar => 1, :baz => 2}
  *    h # => {:foo=>0, :bar=>1, :baz=>2}
- *
- *
  *
  *  Alternatively, but only for a \Hash key that's a \Symbol,
  *  you can use a newer JSON-style syntax,
@@ -6583,8 +6579,8 @@ env_update(VALUE env, VALUE hash)
  *
  *  You can use a \Hash to give names to objects:
  *
- *    matz = {name: 'Matz', language: 'Ruby'}
- *    matz # => {:name=>"Matz", :language=>"Ruby"}
+ *    person = {name: 'Matz', language: 'Ruby'}
+ *    person # => {:name=>"Matz", :language=>"Ruby"}
  *
  *  You can use a \Hash to give names to method arguments:
  *
@@ -6603,10 +6599,8 @@ env_update(VALUE env, VALUE hash)
  *    class Dev
  *      attr_accessor :name, :language
  *      def initialize(hash)
- *        hash.each_pair do |key, value|
- *          setter_method = "#{key}=".to_sym
- *          send(setter_method, value)
- *        end
+ *        self.name = hash[:name]
+ *        self.language = hash[:language]
  *      end
  *    end
  *    matz = Dev.new(name: 'Matz', language: 'Ruby')
@@ -6925,11 +6919,12 @@ env_update(VALUE env, VALUE hash)
  *
  *  This example chains methods #merge! and #compact!:
  *
- *  - <tt>merge!</tt> merges another Hash into <tt>h</tt>.
- *  - <tt>compact!</tt> removes <tt>nil</tt>valued entries from <tt>h</tt>.
+ *  - <tt>merge</tt> merges another \Hash into a copy of <tt>h</tt>.
+ *  - <tt>compact!</tt> removes <tt>nil</tt>valued entries from that copy.
  *
  *    h = {foo: 0, bar: 1, baz: 2}
- *    h.merge!({bat: 3, bam: nil}).compact! # => {:foo=>0, :bar=>1, :baz=>2, :bat=>3}
+ *    h1 = h.merge!({bat: 3, bam: nil}).compact!
+ *    h1 # => {:foo=>0, :bar=>1, :baz=>2, :bat=>3}
  */
 
 void

--- a/hash.c
+++ b/hash.c
@@ -6679,6 +6679,7 @@ env_update(VALUE env, VALUE hash)
  *    h = {foo: 0, bar: 1, baz: 2}
  *    h.delete(:bar) # => 1
  *    h # => {:foo=>0, :baz=>2}
+ *
  *  === Entry Order
  *
  *  A Hash object presents its entries in the order of their creation. This is seen in:
@@ -6717,7 +6718,7 @@ env_update(VALUE env, VALUE hash)
  *
  *  ==== Invalid \Hash Keys
  *
- *  An object that lacks method +hash+ cannot be a Hash key:
+ *  An object that lacks method #hash cannot be a \Hash key:
  *
  *    # Raises NoMethodError (undefined method `hash' for #<BasicObject>)
  *    {BasicObject.new => 0}
@@ -6735,7 +6736,7 @@ env_update(VALUE env, VALUE hash)
  *    h[a0] # => 0
  *    a0.hash # => 110002110
  *
- *  Modifying array element +a0[0]+ changes its hash value:
+ *  Modifying array element <tt>a0[0]</tt> changes its hash value:
  *
  *    a0[0] = :bam
  *    a0.hash # => 1069447059
@@ -6911,6 +6912,7 @@ env_update(VALUE env, VALUE hash)
  *
  *  You can set the default proc to +nil+, which restores control to the default value:
  *
+ *    h.delete(:nosuch)
  *    h.default_proc = nil
  *    h.default = false
  *    h[:nosuch] # => false

--- a/hash.c
+++ b/hash.c
@@ -1746,9 +1746,9 @@ set_proc_default(VALUE hash, VALUE proc)
 
 /*
  *  call-seq:
- *     Hash.new                          -> new_hash
- *     Hash.new(default_value)           -> new_hash
- *     Hash.new {|hash, key| block }      -> new_hash
+ *     Hash.new                                        -> new_hash
+ *     Hash.new(default_value)                         -> new_hash
+ *     Hash.new{|hash, key| hash[key] = default_value} -> new_hash
  *
  *  Returns a new empty Hash object.
  *
@@ -2057,7 +2057,7 @@ rb_hash_rehash_i(VALUE key, VALUE value, VALUE arg)
  *  call-seq:
  *     hsh.rehash -> self
  *
- *  Rebuilds the hash table based on the current hash value for each key;
+ *  Rebuilds the hash table by recomputing the hash index for each key;
  *  returns <tt>self</tt>.
  *
  *  The hash table will have become invalid if the hash value of a key
@@ -6913,18 +6913,38 @@ env_update(VALUE env, VALUE hash)
  *
  *  === Chaining \Method Calls
  *
- *  Some \Hash instance methods return <tt>self</tt>.
- *  For those methods, you can "chain" method calls
+ *  For a method that returns a \Hash, you can "chain" method calls
  *  by following one method call with another.
  *
- *  This example chains methods #merge! and #compact!:
+ *  This example chains methods #merge and #compact:
  *
- *  - <tt>merge</tt> merges another \Hash into a copy of <tt>h</tt>.
- *  - <tt>compact!</tt> removes <tt>nil</tt>valued entries from that copy.
+ *    h = {foo: 0, bar: nil, baz: 2}
+ *    h1 = {bat: 3, bam: nil}
+ *    h1 = h.merge(h1).compact
+ *    h1 # => {:foo=>0, :baz=>2, :bat=>3}
  *
- *    h = {foo: 0, bar: 1, baz: 2}
- *    h1 = h.merge!({bat: 3, bam: nil}).compact!
- *    h1 # => {:foo=>0, :bar=>1, :baz=>2, :bat=>3}
+ *  Details:
+ *
+ *  - First method <tt>merge</tt> creates a copy of <tt>h</tt>,
+ *    merges <tt>h1</tt> into the copy, and returns
+ *      {foo=>0, bar=>nil, baz=>2, bat=>3, bam=>nil}
+ *  - Chained method <tt>compact</tt> creates a copy of that return value,
+ *    removes its <tt>nil</tt>-valued entries, and returns
+ *      {:foo=>0, :baz=>2, :bat=>3}
+ *
+ *  A series of chained methods need not begin with a method in \Hash.
+ *  This example chains methods Array#to_h and Hash#invert:
+ *
+ *    a = [[:foo, :bar], [1, 2]].to_h
+ *    a.to_h.invert # => {:bar=>:foo, 2=>1}
+ *
+ *  Details:
+ *
+ *  - First method Array#to_h converts <tt>a</tt> to a \Hash, and returns
+ *      {:foo=>:bar, 1=>2}
+ *  - Chained method Hash#invert creates copy of that return value,
+ *    inverts it, and  returns
+ *      {:bar=>:foo, 2=>1}
  */
 
 void

--- a/hash.c
+++ b/hash.c
@@ -1783,9 +1783,12 @@ set_proc_default(VALUE hash, VALUE proc)
  *    h.default_proc.class # => Proc
  *    h[:nosuch] # => "Default value for nosuch"
  *
+ *  ---
+ *
  *  Raises an exception if both argument <tt>default_value</tt> and a block are given:
  *
- *    Hash.new(0) { } # Raises ArgumentError (wrong number of arguments (given 1, expected 0)) *
+ *    # Raises ArgumentError (wrong number of arguments (given 1, expected 0)) *
+ *    Hash.new(0) { }
  */
 
 static VALUE
@@ -1857,27 +1860,35 @@ rb_hash_initialize(int argc, VALUE *argv, VALUE hash)
  *  but the argument is not an array of 2-element arrays or a
  *  {Hash-convertible object}[doc/implicit_conversion_rdoc.html#label-Hash-Convertible+Objects]:
  *
- *    Hash[:foo] # Raises ArgumentError (odd number of arguments
- *    Hash[ [ [:foo, 0, 1] ] ] # Raises ArgumentError (invalid number of elements (3 for 1..2))
+ *    # Raises ArgumentError (odd number of arguments
+ *    Hash[:foo]
+ *    # Raises ArgumentError (invalid number of elements (3 for 1..2))
+ *    Hash[ [ [:foo, 0, 1] ] ]
  *
  *  Raises an exception if the argument count is odd and greater than 1:
  *
- *    Hash[0, 1, 2] # Raises ArgumentError (odd number of arguments for Hash)
+ *    # Raises ArgumentError (odd number of arguments for Hash)
+ *    Hash[0, 1, 2]
  *
  *  Raises an exception if the argument is an array containing an element
  *  that is not a 2-element array:
  *
- *    Hash[ [ :foo ] ] # Raises ArgumentError (wrong element type Symbol at 0 (expected array))
+ *    # Raises ArgumentError (wrong element type Symbol at 0 (expected array))
+ *    Hash[ [ :foo ] ]
  *
  *  Raises an exception if the argument is an array containing an element
  *  that is an array of size different from 2:
  *
- *    Hash[ [ [0, 1, 2] ] ] # Raises ArgumentError (invalid number of elements (3 for 1..2))
+ *    # Raises ArgumentError (invalid number of elements (3 for 1..2))
+ *    Hash[ [ [0, 1, 2] ] ]
  *
- *  Raises an exception if any proposed key is not a valid key:
+ *  Raises an exception if any proposed key is not a valid key
+ *  (see {Invalid Hash Keys}[#class-Hash-label-Invalid+Hash+Keys]):
  *
- *    Hash[:foo, 0, BasicObject.new, 1] # Raises NoMethodError (undefined method `hash' for #<BasicObject:>)
- *    Hash[ [ [:foo, 0], [BasicObject.new, 1] ] ] # Raises NoMethodError (undefined method `hash' for #<BasicObject:0x00000000064b1328>)
+ *    # Raises NoMethodError (undefined method `hash' for #<BasicObject:>)
+ *    Hash[:foo, 0, BasicObject.new, 1]
+ *    # Raises NoMethodError (undefined method `hash' for #<BasicObject:0x00000000064b1328>)
+ *    Hash[ [ [:foo, 0], [BasicObject.new, 1] ] ]
  */
 
 static VALUE
@@ -2044,22 +2055,22 @@ rb_hash_rehash_i(VALUE key, VALUE value, VALUE arg)
 
 /*
  *  call-seq:
- *     hsh.rehash -> hsh
+ *     hsh.rehash -> self
  *
- *  Rebuilds the hash based on the current hash values for each key. If
- *  values of key objects have changed since they were inserted, this
- *  method will reindex <i>hsh</i>. If Hash#rehash is
- *  called while an iterator is traversing the hash, a
- *  RuntimeError will be raised in the iterator.
+ *  Rebuilds the hash index based on the current hash value for each key;
+ *  returns <tt>self</tt>.
  *
- *     a = [ "a", "b" ]
- *     c = [ "c", "d" ]
- *     h = { a => 100, c => 300 }
- *     h[a]       #=> 100
- *     a[0] = "z"
- *     h[a]       #=> nil
- *     h.rehash   #=> {["z", "b"]=>100, ["c", "d"]=>300}
- *     h[a]       #=> 100
+ *  The index will have become invalid if the hash value of a key
+ *  has changed since the entry was created.
+ *  See {Modifying an Active Hash Key}[#class-Hash-label-Modifying+an+Active+Hash+Key].
+ *
+ *  ---
+ *
+ *  Raises an exception if called while an iterator is traversing the hash:
+ *
+ *    h = {foo: 0, bar: 1, baz: 2}
+ *    # Raises RuntimeError (rehash during iteration)
+ *    h.each { |x| h.rehash }
  */
 
 VALUE
@@ -6528,68 +6539,234 @@ env_update(VALUE env, VALUE hash)
 }
 
 /*
- *  A Hash is a dictionary-like collection of unique keys and their values.
- *  Also called associative arrays, they are similar to Arrays, but where an
- *  Array uses integers as its index, a Hash allows you to use any object
- *  type.
+ *  A \Hash is a dictionary-like collection of key-value pairs
+ *  whose keys are unique. (The values need not be unique.)
  *
- *  Hashes enumerate their values in the order that the corresponding keys
- *  were inserted.
+ *  A \Hash has certain similarities to an \Array, but:
+ *  - An \Array index is always an \Integer.
+ *  - A \Hash key can be (almost) any object.
  *
- *  A Hash can be easily created by using its implicit form:
+ *  === \Hash \Data Syntax
  *
- *    grades = { "Jane Doe" => 10, "Jim Doe" => 6 }
+ *  The older syntax for \Hash data uses the "hash rocket," <tt>=></tt>
+ *  (known in some languages as the <i>fat comma.</i>):
  *
- *  Hashes allow an alternate syntax for keys that are symbols.
- *  Instead of
+ *    h = {:foo => 0, :bar => 1, :baz => 2}
+ *    h # => {:foo=>0, :bar=>1, :baz=>2}
  *
- *    options = { :font_size => 10, :font_family => "Arial" }
  *
- *  You could write it as:
  *
- *    options = { font_size: 10, font_family: "Arial" }
+ *  Alternatively, but only for a \Hash key that's a \Symbol,
+ *  you can use a newer JSON-style syntax,
+ *  where each bareword becomes a \Symbol:
  *
- *  Each named key is a symbol you can access in hash:
+ *    h = {foo: 0, bar: 1, baz: 2}
+ *    h # => {:foo=>0, :bar=>1, :baz=>2}
  *
- *    options[:font_size]  # => 10
+ *  You can also use a \String in place of a bareword:
  *
- *  A Hash can also be created through its ::new method:
+ *    h = {'foo': 0, 'bar': 1, 'baz': 2}
+ *    h # => {:foo=>0, :bar=>1, :baz=>2}
  *
- *    grades = Hash.new
- *    grades["Dorothy Doe"] = 9
+ *  And you can mix the styles:
  *
- *  Accessing a value in a Hash requires using its key:
+ *    h = {foo: 0, :bar => 1, 'baz': 2}
+ *    h # => {:foo=>0, :bar=>1, :baz=>2}
  *
- *    puts grades["Jane Doe"] # => 0
+ *  But it's an error to try the JSON-style syntax
+ *  for a key that's not a bareword or a String:
+ *
+ *    # Raises SyntaxError (syntax error, unexpected ':', expecting =>)
+ *    h = {0: 'zero'}
  *
  *  === Common Uses
  *
- *  Hashes are an easy way to represent data structures, such as
+ *  You can use a \Hash to give names to objects:
  *
- *    books         = {}
- *    books[:matz]  = "The Ruby Programming Language"
- *    books[:black] = "The Well-Grounded Rubyist"
+ *    matz = {name: 'Matz', language: 'Ruby'}
+ *    matz # => {:name=>"Matz", :language=>"Ruby"}
  *
- *  Hashes are also commonly used as a way to have named parameters in
- *  functions. Note that no brackets are used below. If a hash is the last
- *  argument on a method call, no braces are needed, thus creating a really
- *  clean interface:
+ *  You can use a \Hash to give names to method arguments:
  *
- *    Person.create(name: "John Doe", age: 27)
- *
- *    def self.create(params)
- *      @name = params[:name]
- *      @age  = params[:age]
+ *    def some_method(hash)
+ *      p hash
  *    end
+ *    some_method({foo: 0, bar: 1, baz: 2}) # => {:foo=>0, :bar=>1, :baz=>2}
  *
- *  === Hash Keys
+ *  Note: when the last argument in a method call is a \Hash,
+ *  the curly braces may be omitted:
  *
- *  Two objects refer to the same hash key when their <code>hash</code> value
+ *    some_method(foo: 0, bar: 1, baz: 2) # => {:foo=>0, :bar=>1, :baz=>2}
+ *
+ *  You can use a Hash to initialize an object:
+ *
+ *    class Dev
+ *      attr_accessor :name, :language
+ *      def initialize(hash)
+ *        hash.each_pair do |key, value|
+ *          setter_method = "#{key}=".to_sym
+ *          send(setter_method, value)
+ *        end
+ *      end
+ *    end
+ *    matz = Dev.new(name: 'Matz', language: 'Ruby')
+ *    matz # => #<Dev: @name="Matz", @language="Ruby">
+ *
+ *  === Creating a \Hash
+ *
+ *  Here are three ways to create a \Hash:
+ *
+ *  - \Method <tt>Hash.new</tt>
+ *  - \Method <tt>Hash[]</tt>
+ *  - Literal form: <tt>{}</tt>.
+ *
+ *  ---
+ *
+ *  You can create a \Hash by calling method Hash.new.
+ *
+ *  Create an empty Hash:
+ *
+ *    h = Hash.new
+ *    h # => {}
+ *    h.class # => Hash
+ *
+ *  ---
+ *
+ *  You can create a \Hash by calling method Hash.[].
+ *
+ *  Create an empty Hash:
+ *
+ *    h = Hash[]
+ *    h # => {}
+ *
+ *  Create a \Hash with initial entries:
+ *
+ *    h = Hash[foo: 0, bar: 1, baz: 2]
+ *    h # => {:foo=>0, :bar=>1, :baz=>2}
+ *
+ *  ---
+ *
+ *  You can create a \Hash by using its literal form (curly braces).
+ *
+ *  Create an empty \Hash:
+ *
+ *    h = {}
+ *    h # => {}
+ *
+ *  Create a \Hash with initial entries:
+ *
+ *    h = {foo: 0, bar: 1, baz: 2}
+ *    h # => {:foo=>0, :bar=>1, :baz=>2}
+ *
+ *
+ *  === \Hash Value Basics
+ *
+ *  The simplest way to retrieve a \Hash value (instance method #[]):
+ *
+ *    h = {foo: 0, bar: 1, baz: 2}
+ *    h[:foo] # => 0
+ *
+ *  The simplest way to create or update a \Hash value (instance method #[]=):
+ *
+ *    h = {foo: 0, bar: 1, baz: 2}
+ *    h[:bat] = 3 # => 3
+ *    h # => {:foo=>0, :bar=>1, :baz=>2, :bat=>3}
+ *    h[:foo] = 4 # => 4
+ *    h # => {:foo=>4, :bar=>1, :baz=>2, :bat=>3}
+ *
+ *  The simplest way to delete a Hash entry (instance method #delete):
+ *
+ *    h = {foo: 0, bar: 1, baz: 2}
+ *    h.delete(:bar) # => 1
+ *    h # => {:foo=>0, :baz=>2}
+ *  === Entry Order
+ *
+ *  A Hash object presents its entries in the order of their creation. This is seen in:
+ *
+ *  - Iterative methods such as <tt>each</tt>, <tt>each_key</tt>, <tt>each_pair</tt>, <tt>each_value</tt>.
+ *  - Other order-sensitive methods such as <tt>shift</tt>, <tt>keys</tt>, <tt>values</tt>.
+ *  - The String returned by method <tt>inspect</tt>.
+ *
+ *  A new Hash has its initial ordering per the given entries:
+ *
+ *    h = Hash[foo: 0, bar: 1]
+ *    h # => {:foo=>0, :bar=>1}
+ *
+ *  New entries are added at the end:
+ *
+ *    h[:baz] = 2
+ *    h # => {:foo=>0, :bar=>1, :baz=>2}
+ *
+ *  Updating a value does not affect the order:
+ *
+ *    h[:baz] = 3
+ *    h # => {:foo=>0, :bar=>1, :baz=>3}
+ *
+ *  But re-creating a deleted entry can affect the order:
+ *
+ *    h.delete(:foo)
+ *    h[:foo] = 5
+ *    h # => {:bar=>1, :baz=>3, :foo=>5}
+ *
+ *  === \Hash Keys
+ *
+ *  ==== \Hash Key Equivalence
+ *
+ *  Two objects are treated as the same hash key when their <code>hash</code> value
  *  is identical and the two objects are <code>eql?</code> to each other.
  *
- *  A user-defined class may be used as a hash key if the <code>hash</code>
+ *  ==== Invalid \Hash Keys
+ *
+ *  An object that lacks method +hash+ cannot be a Hash key:
+ *
+ *    # Raises NoMethodError (undefined method `hash' for #<BasicObject>)
+ *    {BasicObject.new => 0}
+ *
+ *  ==== Modifying an Active \Hash Key
+ *
+ *  Modifying a \Hash key while it is in use damages the hash's index.
+ *
+ *  This \Hash has keys that are Arrays:
+ *
+ *    a0 = [ :foo, :bar ]
+ *    a1 = [ :baz, :bat ]
+ *    h = {a0 => 0, a1 => 1}
+ *    h.include?(a0) # => true
+ *    h[a0] # => 0
+ *    a0.hash # => 110002110
+ *
+ *  Modifying array element +a0[0]+ changes its hash value:
+ *
+ *    a0[0] = :bam
+ *    a0.hash # => 1069447059
+ *
+ *  And damages the \Hash index:
+ *
+ *    h.include?(a0) # => false
+ *    h[a0] # => nil
+ *
+ *  You can repair the hash index using method +rehash+:
+ *
+ *    h.rehash # => {[:bam, :bar]=>0, [:baz, :bat]=>1}
+ *    h.include?(a0) # => true
+ *    h[a0] # => 0
+ *
+ *  A \String key is always safe.
+ *  That's because an unfrozen String
+ *  passed as a key will be replaced by a duplicated and frozen \String:
+ *
+ *    s = 'foo'
+ *    s.frozen? # => false
+ *    h = {s => 0}
+ *    first_key = h.keys.first
+ *    first_key.frozen? # => true
+ *    first_key.equal?(s) # => false
+ *
+ *  ==== User-Defined \Hash Keys
+ *
+ *  A user-defined class may be used as a \Hash key if the <code>hash</code>
  *  and <code>eql?</code> methods are overridden to provide meaningful
- *  behavior.  By default, separate instances refer to separate hash keys.
+ *  behavior.  By default, separate instances refer to separate \Hash keys.
  *
  *  A typical implementation of <code>hash</code> is based on the
  *  object's data while <code>eql?</code> is usually aliased to the overridden
@@ -6625,8 +6802,6 @@ env_update(VALUE env, VALUE hash)
  *    reviews[book2] = 'Nice and compact!'
  *
  *    reviews.length #=> 1
- *
- *  See also Object#hash and Object#eql?
  *
  *  === Default Values
  *
@@ -6739,6 +6914,20 @@ env_update(VALUE env, VALUE hash)
  *    h.default_proc = nil
  *    h.default = false
  *    h[:nosuch] # => false
+ *
+ *  === Chaining \Method Calls
+ *
+ *  Some \Hash instance methods return <tt>self</tt>.
+ *  For those methods, you can "chain" method calls
+ *  by following one method call with another.
+ *
+ *  This example chains methods #merge! and #compact!:
+ *
+ *  - <tt>merge!</tt> merges another Hash into <tt>h</tt>.
+ *  - <tt>compact!</tt> removes <tt>nil</tt>valued entries from <tt>h</tt>.
+ *
+ *    h = {foo: 0, bar: 1, baz: 2}
+ *    h.merge!({bat: 3, bam: nil}).compact! # => {:foo=>0, :bar=>1, :baz=>2, :bat=>3}
  */
 
 void

--- a/hash.c
+++ b/hash.c
@@ -6920,8 +6920,8 @@ env_update(VALUE env, VALUE hash)
  *
  *    h = {foo: 0, bar: nil, baz: 2}
  *    h1 = {bat: 3, bam: nil}
- *    h1 = h.merge(h1).compact
- *    h1 # => {:foo=>0, :baz=>2, :bat=>3}
+ *    h2 = h.merge(h1).compact
+ *    h2 # => {:foo=>0, :baz=>2, :bat=>3}
  *
  *  Details:
  *

--- a/hash.c
+++ b/hash.c
@@ -1748,7 +1748,7 @@ set_proc_default(VALUE hash, VALUE proc)
  *  call-seq:
  *     Hash.new                          -> new_hash
  *     Hash.new(default_value)           -> new_hash
- *     Hash.new {|hash, key| ... }       -> new_hash
+ *     Hash.new { |hash, key| ... }      -> new_hash
  *
  *  Returns a new empty Hash object.
  *


### PR DESCRIPTION
This enhances the introductory material for Hash rdoc.

@ioquatix, I've crafted a big PR b/c doing this piecemeal would create various inconsistency and incoherence until the last part merged.  If too big, I'll figure something.

Some places I've avoided lower-level headers by using horizontal rules instead.