### PR TITLE
Move rb_big_isqrt defination to internal/bignum.h

### DIFF
--- a/internal/bignum.h
+++ b/internal/bignum.h
@@ -116,6 +116,7 @@ VALUE rb_big_uminus(VALUE x);
 VALUE rb_big_hash(VALUE);
 VALUE rb_big_odd_p(VALUE);
 VALUE rb_big_even_p(VALUE);
+VALUE rb_big_isqrt(VALUE);
 size_t rb_big_size(VALUE);
 VALUE rb_integer_float_cmp(VALUE x, VALUE y);
 VALUE rb_integer_float_eq(VALUE x, VALUE y);

--- a/numeric.c
+++ b/numeric.c
@@ -5418,8 +5418,6 @@ DEFINE_INT_SQRT(BDIGIT, rb_bdigit_dbl, BDIGIT_DBL)
 #define domain_error(msg) \
     rb_raise(rb_eMathDomainError, "Numerical argument is out of domain - " #msg)
 
-VALUE rb_big_isqrt(VALUE);
-
 /*
  *  Document-method: Integer::sqrt
  *  call-seq:


### PR DESCRIPTION
Move `rb_big_isqrt` defination in `numeric.c` to `internal/bignum.h`