### PR TITLE
Move rb_obj_hash define to internal/hash.h

### DIFF
--- a/internal/hash.h
+++ b/internal/hash.h
@@ -74,6 +74,7 @@ VALUE rb_to_hash_type(VALUE obj);
 VALUE rb_hash_key_str(VALUE);
 VALUE rb_hash_values(VALUE hash);
 VALUE rb_hash_rehash(VALUE hash);
+VALUE rb_obj_hash(VALUE obj);
 int rb_hash_add_new_element(VALUE hash, VALUE key, VALUE val);
 VALUE rb_hash_set_pair(VALUE hash, VALUE pair);
 int rb_hash_stlike_delete(VALUE hash, st_data_t *pkey, st_data_t *pval);

--- a/object.c
+++ b/object.c
@@ -26,6 +26,7 @@
 #include "internal/class.h"
 #include "internal/error.h"
 #include "internal/eval.h"
+#include "internal/hash.h"
 #include "internal/inits.h"
 #include "internal/numeric.h"
 #include "internal/object.h"
@@ -226,8 +227,6 @@ rb_obj_equal(VALUE obj1, VALUE obj2)
     if (obj1 == obj2) return Qtrue;
     return Qfalse;
 }
-
-VALUE rb_obj_hash(VALUE obj);
 
 /**
  *  call-seq:


### PR DESCRIPTION
Move `rb_obj_hash` define in `object.c` to `internal/hash.h`.

I thought it's easier to read defination in `object.c` than  `internal/hash.h`