### PR TITLE
Use receiver #name rather than #inspect to build NameError message

### DIFF
--- a/error.c
+++ b/error.c
@@ -1762,6 +1762,17 @@ name_err_mesg_equal(VALUE obj1, VALUE obj2)
 
 /* :nodoc: */
 static VALUE
+name_err_mesg_receiver_name(VALUE obj)
+{
+    if (RB_SPECIAL_CONST_P(obj)) return Qundef;
+    if (RB_BUILTIN_TYPE(obj) == T_MODULE || RB_BUILTIN_TYPE(obj) == T_CLASS) {
+        return rb_check_funcall(obj, rb_intern("name"), 0, 0);
+    }
+    return Qundef;
+}
+
+/* :nodoc: */
+static VALUE
 name_err_mesg_to_str(VALUE obj)
 {
     VALUE *ptr, mesg;
@@ -1788,7 +1799,9 @@ name_err_mesg_to_str(VALUE obj)
 	    d = FAKE_CSTR(&d_str, "false");
 	    break;
 	  default:
-	    d = rb_protect(rb_inspect, obj, &state);
+	    d = rb_protect(name_err_mesg_receiver_name, obj, &state);
+	    if (state || d == Qundef || d == Qnil)
+		d = rb_protect(rb_inspect, obj, &state);
 	    if (state)
 		rb_set_errinfo(Qnil);
 	    if (NIL_P(d) || RSTRING_LEN(d) > 65) {

--- a/spec/ruby/language/constants_spec.rb
+++ b/spec/ruby/language/constants_spec.rb
@@ -154,6 +154,36 @@ describe "Literal (A::X) constant resolution" do
     -> { ConstantSpecs::ParentA::CS_CONSTX }.should raise_error(NameError)
   end
 
+  ruby_version_is "2.8" do
+    it "uses the module or class #name to craft the error message" do
+      mod = Module.new do
+        def self.name
+          "ModuleName"
+        end
+
+        def self.inspect
+          "<unusable info>"
+        end
+      end
+
+      -> { mod::DOES_NOT_EXIST }.should raise_error(NameError, /uninitialized constant ModuleName::DOES_NOT_EXIST/)
+    end
+
+    it "uses the module or class #inspect to craft the error message if they are anonymous" do
+      mod = Module.new do
+        def self.name
+          nil
+        end
+
+        def self.inspect
+          "<unusable info>"
+        end
+      end
+
+      -> { mod::DOES_NOT_EXIST }.should raise_error(NameError, /uninitialized constant <unusable info>::DOES_NOT_EXIST/)
+    end
+  end
+
   it "sends #const_missing to the original class or module scope" do
     ConstantSpecs::ClassA::CS_CONSTX.should == :CS_CONSTX
   end


### PR DESCRIPTION
While debugging a bug in Rails (https://github.com/rails/rails/pull/37632#issuecomment-623387954) I noticed `NameError` calls `inspect` on the `const_get` receiver to build its error message.

The problem is that some libraries such as Active Record have been redefining `inspect` for years to provide human readable information, e.g.: 

```
>> Shipit::Stack.inspect
=> "Shipit::Stack (call 'Shipit::Stack.connection' to establish a connection)"
>> Shipit::Stack.connection; nil
>> Shipit::Stack.inspect
=> "Shipit::Stack(id: integer, environment: string, ...)"
```

Which makes for fairly unhelpful error messages:

```
>> Shipit::Stack.const_get(:Foo)
Traceback (most recent call last):
        2: from (irb):4
        1: from (irb):4:in `const_get'
NameError (uninitialized constant #<Class:0x00007fc8cadf2dd0>::Foo)
```

So perhaps it's Active Record that is at fault here, but from my understanding since the goal is to display the constant path that was requested, `name` is much more likely to return a relevant constant name.

cc @fxn