### PR TITLE
Output compaction stats in one loop / eliminate 0 counts

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -8509,11 +8509,13 @@ gc_compact_stats(rb_objspace_t *objspace)
     VALUE moved = rb_hash_new();
 
     for (i=0; i<T_MASK; i++) {
-        rb_hash_aset(considered, type_sym(i), SIZET2NUM(objspace->rcompactor.considered_count_table[i]));
-    }
+        if(objspace->rcompactor.considered_count_table[i]) {
+            rb_hash_aset(considered, type_sym(i), SIZET2NUM(objspace->rcompactor.considered_count_table[i]));
+        }
 
-    for (i=0; i<T_MASK; i++) {
-        rb_hash_aset(moved, type_sym(i), SIZET2NUM(objspace->rcompactor.moved_count_table[i]));
+        if(objspace->rcompactor.moved_count_table[i]) {
+            rb_hash_aset(moved, type_sym(i), SIZET2NUM(objspace->rcompactor.moved_count_table[i]));
+        }
     }
 
     rb_hash_aset(h, ID2SYM(rb_intern("considered")), considered);


### PR DESCRIPTION
We only need to loop `T_MASK` times once.  Also, not every value between
0 and `T_MASK` is an actual Ruby type.  Before this change, some
integers were being added to the result hash even though they aren't
actual types.  This patch omits considered / moved entries that total 0,
cleaning up the result hash and eliminating these "fake types".