### PR TITLE
[ci skip] Enhanced rdoc for JSON

### DIFF
--- a/doc/implicit_conversion.rdoc
+++ b/doc/implicit_conversion.rdoc
@@ -28,7 +28,7 @@ This class is Array-convertible:
 
     class ArrayConvertible
       def to_ary
-        [:foo, 'bar', baz = 2]
+        [:foo, 'bar', 2]
       end
     end
     a = []
@@ -45,7 +45,7 @@ This class is not Array-convertible (method +to_ary+ takes arguments):
 
     class NotArrayConvertible
       def to_ary(x)
-        [:foo, 'bar', baz = 2]
+        [:foo, 'bar', 2]
       end
     end
     a = []

--- a/doc/implicit_conversion.rdoc
+++ b/doc/implicit_conversion.rdoc
@@ -28,7 +28,7 @@ This class is Array-convertible:
 
     class ArrayConvertible
       def to_ary
-        [:foo, 'bar', 2]
+        [:foo, 'bar', baz = 2]
       end
     end
     a = []
@@ -45,7 +45,7 @@ This class is not Array-convertible (method +to_ary+ takes arguments):
 
     class NotArrayConvertible
       def to_ary(x)
-        [:foo, 'bar', 2]
+        [:foo, 'bar', baz = 2]
       end
     end
     a = []

--- a/ext/json/lib/json.rb
+++ b/ext/json/lib/json.rb
@@ -111,109 +111,6 @@ require 'json/common'
 #   n # => nil
 #   n.class # => NilClass
 #
-# ==== Parsing Options
-#
-# Argument +opts+ is a \Hash object containing options for parsing.
-#
-# ---
-#
-# Option +:max_nesting+ specifies the maximum nesting depth allowed;
-# defaults to +100+; specify +false+ to disable depth checking.
-#
-# With the default:
-#   source = '[0, [1, [2, [3]]]]'
-#   a = JSON.parse(source)
-#   a # => [0, [1, [2, [3]]]]
-# Too deep:
-#   # Raises JSON::NestingError (nesting of 2 is too deep):
-#   a = JSON.parse(source, {max_nesting: 1})
-# Bad value:
-#   # Raises TypeError (wrong argument type Symbol (expected Fixnum)):
-#   JSON.parse(source, {max_nesting: :foo})
-#
-# ---
-#
-# Option +allow_nan+ specifies whether to allow
-# +NaN+, +Infinity+, and +-Infinity+ in +source+;
-# defaults to +false+.
-#
-# With the default:
-#   source = '[NaN]'
-#   # Raises JSON::ParserError (232: unexpected token at '[NaN]'):
-#   a = JSON.parse(source)
-#   source = '[Infinity]'
-#   # Raises JSON::ParserError (232: unexpected token at '[Infinity]'):
-#   a = JSON.parse(source)
-#   source = '[-Infinity]'
-#   # Raises JSON::ParserError (232: unexpected token at '[-Infinity]'):
-#   a = JSON.parse(source)
-# Allow:
-#   source = '[NaN, Infinity, -Infinity]'
-#   a = JSON.parse(source, {allow_nan: true})
-#   a # => [NaN, Infinity, -Infinity]
-# With a truthy value:
-#   a = JSON.parse(source, {allow_nan: :foo})
-#   a # => [NaN, Infinity, -Infinity]
-#
-# ---
-#
-# Option +symbolize_names+ specifies whether to use Symbols or Strings
-# as keys in returned Hashes;
-# defaults to +false+ (use Strings).
-#
-# With the default:
-#   source = '{"a": "foo", "b": 1.0, "c": true, "d": false, "e": null}'
-#   h = JSON.parse(source)
-#   h # => {"a"=>"foo", "b"=>1.0, "c"=>true, "d"=>false, "e"=>nil}
-# Use Symbols:
-#   h = JSON.parse(source, {symbolize_names: true})
-#   h # => {:a=>"foo", :b=>1.0, :c=>true, :d=>false, :e=>nil}
-#
-# ---
-#
-# Option +object_class+ specifies the Ruby class to be used
-# for each \JSON object;
-# defaults to \Hash.
-#
-# With the default:
-#   source = '{"a": "foo", "b": 1.0, "c": true, "d": false, "e": null}'
-#   h = JSON.parse(source)
-#   h.class # => Hash
-# Use class \OpenStruct:
-#   o = JSON.parse(source, {object_class: OpenStruct})
-#   o # => #<OpenStruct a="foo", b=1.0, c=true, d=false, e=nil>
-# Try class \Object:
-#   # Raises NoMethodError (undefined method `[]=' for #<Object:>):
-#   JSON.parse(source, {object_class: Object})
-# Bad value:
-#   # Raises TypeError (wrong argument type Symbol (expected Class)):
-#   JSON.parse(source, {object_class: :foo})
-#
-# ---
-#
-# Option +array_class+ specifies the Ruby class to be used
-# for each \JSON array;
-# defaults to \Array.
-#
-# With the default:
-#   source = '["foo", 1.0, true, false, null]'
-#   a = JSON.parse(source)
-#   a.class # => Array
-# Use class \Set:
-#   s = JSON.parse(source, {array_class: Set})
-#   s # => #<Set: {"foo", 1.0, true, false, nil}>
-# Try class \Object:
-#   # Raises NoMethodError (undefined method `<<' for #<Object:>):
-#   JSON.parse(source, {array_class: Object})
-# Bad value:
-#   # Raises TypeError (wrong argument type Symbol (expected Class)):
-#   JSON.parse(source, {array_class: :foo})
-#
-# ---
-#
-# Option +create_additions+ specifies whether to
-# XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-#
 # === Generating \JSON
 #
 # To generate a Ruby \String containing \JSON data,
@@ -327,8 +224,6 @@ require 'json/common'
 # You can also craft custom additions.  See {Custom \JSON Additions}[#module-label-Custom+JSON+Additions]
 #
 # === Built-in Additions
-#
-# <table><tr><td>Foo</td></tr></table>
 #
 # The \JSON module includes additions for these classes:
 # - BigDecimal: <tt>require 'json/add/bigdecimal'</tt>
@@ -449,8 +344,8 @@ require 'json/common'
 # === Custom \JSON Additions
 #
 # In addition to the \JSON additions provided,
-# you can craft addition of your own,
-# either for Ruby built-in classes or for classes of your own.
+# you can craft \JSON additions of your own,
+# either for Ruby built-in classes or for user-defined classes.
 #
 # Here's a user-defined class +Foo+:
 #

--- a/ext/json/lib/json.rb
+++ b/ext/json/lib/json.rb
@@ -168,9 +168,9 @@ require 'json/common'
 #
 # When +source+ is none of the above, JSON.generate returns
 # a \String containing a string representation of +source+:
-#   JSON.generate(:foo)
-#   JSON.generate(Complex(0, 0))
-#   JSON.generate(Dir.new('.'))
+#   JSON.generate(:foo) # => "\"foo\""
+#   JSON.generate(Complex(0, 0)) # => "\"0+0i\""
+#   JSON.generate(Dir.new('.')) # => "\"#<Dir:0x0000000006bb30b8>\""
 #
 # == \JSON Additions
 #

--- a/ext/json/lib/json.rb
+++ b/ext/json/lib/json.rb
@@ -11,14 +11,13 @@ require 'json/common'
 # - Number:  +1+, +1.0+, +2.0e2+.
 # - Boolean:  +true+, +false+.
 # - Null: +null+.
-# - \Array: an ordered list of values, enclosed by square brackets; example:
+# - \Array: an ordered list of values, enclosed by square brackets:
 #
 #     ["foo", 1, 1.0, 2.0e2, true, false, null]
 #
 # - \Object: a collection of name/value pairs, enclosed by curly braces;
 #   each name is double-quoted text;
-#   the values may be any \JSON values;
-#   example:
+#   the values may be any \JSON values:
 #
 #     {"a": "foo", "b": 1, "c": 1.0, "d": 2.0e2, "e": true, "f": false, "g": null}
 #
@@ -73,29 +72,35 @@ require 'json/common'
 #
 # ==== Parsing \JSON Scalars
 #
-# When the \JSON source is a scalar, JSON.parse returns a scalar:
+# When the \JSON source is a bare scalar (not an array or object),
+# JSON.parse returns a scalar.
+#
+# \String:
 #   s = JSON.parse('"foo"')
 #   s # => "foo"
 #   s.class # => String
+# \Integer:
 #   n = JSON.parse('1')
 #   n # => 1
 #   n.class # => Integer
+# \Float:
 #   f = JSON.parse('1.0')
 #   f # => 1.0
 #   f.class # => Float
 #   f = JSON.parse('2.0e2')
 #   f # => 200
-#   f.class # => Flaot
+#   f.class # => Float
+# Boolean:
 #   b = JSON.parse('true')
 #   b # => true
 #   b.class # => TrueClass
 #   b = JSON.parse('false')
 #   b # => false
 #   b.class # => FalseClass
+# Null:
 #   n = JSON.parse('null')
 #   n # => nil
 #   n.class # => NilClass
-#
 #
 # ==== Parsing Options
 #
@@ -112,10 +117,10 @@ require 'json/common'
 #   a # => [0, [1, [2, [3]]]]
 # Too deep:
 #   # Raises JSON::NestingError (nesting of 2 is too deep):
-#   a = JSON.parse(source, {:max_nesting: 1})
+#   a = JSON.parse(source, {max_nesting: 1})
 # Bad value:
 #   # Raises TypeError (wrong argument type Symbol (expected Fixnum)):
-#   JSON.parse(source, {:max_nesting => :foo})
+#   JSON.parse(source, {max_nesting: :foo})
 #
 # ---
 #
@@ -135,15 +140,15 @@ require 'json/common'
 #   a = JSON.parse(source)
 # Allow:
 #   source = '[NaN, Infinity, -Infinity]'
-#   a = JSON.parse(source, {:allow_nan: true})
+#   a = JSON.parse(source, {allow_nan: true})
 #   a # => [NaN, Infinity, -Infinity]
 # With a truthy value:
-#   a = JSON.parse(source, {:allow_nan => :foo})
+#   a = JSON.parse(source, {allow_nan: :foo})
 #   a # => [NaN, Infinity, -Infinity]
 #
 # ---
 #
-# Option +symbolize_names* specifies whether to use Symbols or Strings
+# Option +symbolize_names+ specifies whether to use Symbols or Strings
 # as keys in returned Hashes;
 # defaults to +false+ (use Strings).
 #
@@ -152,7 +157,7 @@ require 'json/common'
 #   h = JSON.parse(source)
 #   h # => {"a"=>"foo", "b"=>1.0, "c"=>true, "d"=>false, "e"=>nil}
 # Use Symbols:
-#   h = JSON.parse(source, {:symbolize_names: true})
+#   h = JSON.parse(source, {symbolize_names: true})
 #   h # => {:a=>"foo", :b=>1.0, :c=>true, :d=>false, :e=>nil}
 #
 # ---
@@ -166,14 +171,14 @@ require 'json/common'
 #   h = JSON.parse(source)
 #   h.class # => Hash
 # Use class \OpenStruct:
-#   o = JSON.parse(source, {:object_class: OpenStruct})
+#   o = JSON.parse(source, {object_class: OpenStruct})
 #   o # => #<OpenStruct a="foo", b=1.0, c=true, d=false, e=nil>
 # Try class \Object:
 #   # Raises NoMethodError (undefined method `[]=' for #<Object:>):
-#   JSON.parse(source, {:object_class: Object})
+#   JSON.parse(source, {object_class: Object})
 # Bad value:
 #   # Raises TypeError (wrong argument type Symbol (expected Class)):
-#   JSON.parse(source, {:object_class: :foo})
+#   JSON.parse(source, {object_class: :foo})
 #
 # ---
 #
@@ -186,14 +191,14 @@ require 'json/common'
 #   a = JSON.parse(source)
 #   a.class # => Array
 # Use class \Set:
-#   s = JSON.parse(source, {:array_class: Set})
+#   s = JSON.parse(source, {array_class: Set})
 #   s # => #<Set: {"foo", 1.0, true, false, nil}>
 # Try class \Object:
 #   # Raises NoMethodError (undefined method `<<' for #<Object:>):
-#   JSON.parse(source, {:array_class: Object})
+#   JSON.parse(source, {array_class: Object})
 # Bad value:
 #   # Raises TypeError (wrong argument type Symbol (expected Class)):
-#   JSON.parse(source, {:array_class: :foo})
+#   JSON.parse(source, {array_class: :foo})
 #
 # ---
 #
@@ -221,40 +226,150 @@ require 'json/common'
 #
 # Option +indent+ specifies the string to be used for indentation.
 # The default is the empty string <tt>''</tt>:
-#   source = '{"foo": {"bar": 1, "baz": 2}, "bat": [0, 1, 2]}'
+  #   source = '{"foo": {"bar": 1, "baz": 2}, "bat": [0, 1, 2]}'
 #   h = JSON.parse(source)
 #   h # => {"foo"=>{"bar"=>1, "baz"=>2}, "bat"=>[0, 1, 2]}
 # With two spaces:
-#   h = JSON.parse(source, {:indent => ''})
+#   h = JSON.parse(source, {indent: '  '})
 #   h # => {"foo"=>{"bar"=>1, "baz"=>2}, "bat"=>[0, 1, 2]}
 #
 # ---
 #
 # Option +create_additions+ specifies whether to
 #
-# == Extended rendering and loading of Ruby objects
+# == Generating \JSON with Additions
 #
-# JSON library provides optional _additions_ allowing to serialize and
-# deserialize Ruby classes without loosing their type.
+# === Built-in Additions
 #
-#   # without additions
-#   require "json"
-#   json = JSON.generate({range: 1..3, regex: /test/})
-#   # => '{"range":"1..3","regex":"(?-mix:test)"}'
-#   JSON.parse(json)
-#   # => {"range"=>"1..3", "regex"=>"(?-mix:test)"}
+# For certain classes, module \JSON offers optional _additions_.
+# Each addition provides enrichments for \JSON for a class.
 #
-#   # with additions
-#   require "json/add/range"
-#   require "json/add/regexp"
-#   json = JSON.generate({range: 1..3, regex: /test/})
-#   # => '{"range":{"json_class":"Range","a":[1,3,false]},"regex":{"json_class":"Regexp","o":0,"s":"test"}}'
-#   JSON.parse(json)
-#   # => {"range"=>{"json_class"=>"Range", "a"=>[1, 3, false]}, "regex"=>{"json_class"=>"Regexp", "o"=>0, "s"=>"test"}}
-#   JSON.load(json)
-#   # => {"range"=>1..3, "regex"=>/test/}
+# To reduce punctuation clutter, the examples below
+# show the generated \JSON via +puts+, rather than the usual +inspect+,
 #
-# See JSON.load for details.
+# ---
+#
+# \BigDecimal:
+#   value = BigDecimal(0) # 0.0
+# Without addition:
+#   JSON.generate(value) # "0.0"
+# With addition:
+#   require 'json/add/bigdecimal'
+#   JSON.generate(value) # {"json_class":"BigDecimal","b":"27:0.0"}
+#
+# ---
+#
+# \Complex:
+#   value = Complex(1+0i) # (1+0i)
+# Without addition:
+#   JSON.generate(value) # "0.0"
+# With addition:
+#   require 'json/add/complex'
+#   JSON.generate(value) # {"json_class":"Date","y":2020,"m":5,"d":1,"sg":2299161.0}
+#
+# ---
+#
+# \Date:
+#   value = Date.today # #<Date: 2020-05-01 ((2458971j,0s,0n),+0s,2299161j)>
+# Without addition:
+#   JSON.generate(value) # "2020-05-01"
+# With addition:
+#   require 'json/add/date'
+#   JSON.generate(value) # {"json_class":"Date","y":2020,"m":5,"d":1,"sg":2299161.0}
+#
+# ---
+#
+# \DateTime:
+#   value = DateTime.now # 2020-05-01T11:00:47-05:00
+# Without addition:
+#   JSON.generate(value) # "2020-05-01T11:00:47-05:00"
+# With addition:
+#   require 'json/add/date_time'
+#   JSON.generate(value) # {"json_class":"DateTime","y":2020,"m":5,"d":1,"H":11,"M":0,"S":47,"of":"-5/24","sg":2299161.0}
+#
+# ---
+#
+# \Exception (and its subclasses, including \RuntimeError):
+#   value0 = Exception.new('A message') # #<Exception: A message>
+#   value1 = RuntimeError.new('Another message') # #<RuntimeError: Another message>
+# Without addition:
+#   JSON.generate(value0) # "A message"
+#   JSON.generate(value1) # "Another message"
+# With addition:
+#   require 'json/add/exception'
+#   JSON.generate(value0) # {"json_class":"Exception","m":"A message","b":null}
+#   JSON.generate(value1) # {"json_class":"RuntimeError","m":"Another message","b":null}
+#
+# ---
+#
+# \OpenStruct:
+#   value = OpenStruct.new(name: 'Matz', language: 'Ruby') # #<OpenStruct name="Matz", language="Ruby">
+# Without addition:
+#   JSON.generate(value) # "#<OpenStruct name=\"Matz\", language=\"Ruby\">"
+# With addition:
+#   require 'json/add/ostruct'
+#   JSON.generate(value) # {"json_class":"OpenStruct","t":{"name":"Matz","language":"Ruby"}}
+#
+# ---
+#
+# \Range:
+#   value = Range.new(1, 3) # 1..3
+# Without addition:
+#   JSON.generate(value) # "1..3"
+# With addition:
+#   require 'json/add/range'
+#   JSON.generate(value) # {"json_class":"Range","a":[1,3,false]}
+#
+# ---
+#
+# \Rational:
+#   value = Rational.new(1, 3) # (1/3)
+# Without addition:
+#   JSON.generate(value) # "1/3"
+# With addition:
+#   require 'json/add/rational'
+#   JSON.generate(value) # {"json_class":"Rational","n":1,"d":3}
+#
+# ---
+#
+# \Regexp:
+#   value = Regexp.new('foo') # /foo/
+# Without addition:
+#   JSON.generate(value) # "(?-mix:foo)"
+# With addition:
+#   require 'json/add/regexp'
+#   JSON.generate(value) # {"json_class":"Regexp","o":0,"s":"foo"}
+#
+# ---
+#
+# \Set:
+#   value = Set.new([0, 1, 2]) # #<Set: {0, 1, 2}>
+# Without addition:
+#   JSON.generate(value) # "#<Set: {0, 1, 2}>"
+# With addition:
+#   require 'json/add/set'
+#   JSON.generate(value) # {"json_class":"Set","a":[0,1,2]}
+#
+# ---
+#
+# \Struct:
+#   value = Struct.new("Customer", :name, :address) # Struct::Customer
+# Without addition:
+#   JSON.generate(value) # "Struct::Customer"
+# With addition:
+#   require 'json/add/struct'
+#   JSON.generate(value) # "Struct::Customer"
+#
+# ---
+#
+# \Symbol:
+#   value = :foo # :foo
+# Without addition:
+#   JSON.generate(value) # :foo
+# With addition:
+#   require 'json/add/symbol'
+#   JSON.generate(value) # {"json_class":"Symbol","s":"foo"}
+#
 module JSON
   require 'json/version'
 

--- a/ext/json/lib/json.rb
+++ b/ext/json/lib/json.rb
@@ -40,16 +40,16 @@ require 'json/common'
 #
 # You can parse a \String containing \JSON data using
 # either of two methods:
-# - JSON.parse(source, opts)
-# - JSON.parse!(source, opts)
+# - <tt>JSON.parse(source, opts)</tt>
+# - <tt>JSON.parse!(source, opts)</tt>
 #
 # where
-# - +source+ is a Ruby data structure.
+# - +source+ is a Ruby object.
 # - +opts+ is a \Hash object containing options data.
 #
 # The difference between the two methods
-# is that JSON.parse! takes some shortcuts
-# that may not be safe in all cases;
+# is that JSON.parse! omits some checks
+# and may not be safe for some +source+ data;
 # use it only for data from trusted sources.
 # Use the safer method JSON.parse for less trusted sources.
 #

--- a/ext/json/lib/json.rb
+++ b/ext/json/lib/json.rb
@@ -12,22 +12,17 @@ require 'json/common'
 # - Boolean:  +true+, +false+.
 # - Null: +null+.
 # - \Array: an ordered list of values, enclosed by square brackets:
-#
 #     ["foo", 1, 1.0, 2.0e2, true, false, null]
 #
 # - \Object: a collection of name/value pairs, enclosed by curly braces;
 #   each name is double-quoted text;
 #   the values may be any \JSON values:
-#
 #     {"a": "foo", "b": 1, "c": 1.0, "d": 2.0e2, "e": true, "f": false, "g": null}
-#
 #
 # A \JSON array or object may contain nested arrays, objects, and scalars
 # to any depth:
 #   {"foo": {"bar": 1, "baz": 2}, "bat": [0, 1, 2]}
 #   [{"foo": 0, "bar": 1}, ["baz", 2]]
-#
-# To read more about \JSON visit: http://json.org
 #
 # == Using \Module \JSON
 #
@@ -56,118 +51,118 @@ require 'json/common'
 # ==== Parsing \JSON Arrays
 #
 # When +source+ is a \JSON array, JSON.parse by default returns a Ruby \Array:
-#   source = '["foo", 1, 1.0, 2.0e2, true, false, null]'
-#   a = JSON.parse(source)
-#   a # => ["foo", 1, 1.0, 200.0, true, false, nil]
-#   a.class # => Array
+#   json = '["foo", 1, 1.0, 2.0e2, true, false, null]'
+#   ruby = JSON.parse(json)
+#   ruby # => ["foo", 1, 1.0, 200.0, true, false, nil]
+#   ruby.class # => Array
 #
 # The \JSON array may contain nested arrays, objects, and scalars
 # to any depth:
-#   source = '[{"foo": 0, "bar": 1}, ["baz", 2]]'
-#   JSON.parse(source) # => [{"foo"=>0, "bar"=>1}, ["baz", 2]]
+#   json = '[{"foo": 0, "bar": 1}, ["baz", 2]]'
+#   JSON.parse(json) # => [{"foo"=>0, "bar"=>1}, ["baz", 2]]
 #
 # ==== Parsing \JSON \Objects
 #
-# When +source+ is a \JSON object, JSON.parse by default returns a Ruby \Hash:
-#   source = '{"a": "foo", "b": 1, "c": 1.0, "d": 2.0e2, "e": true, "f": false, "g": null}'
-#   h = JSON.parse(source)
-#   h # => {"a"=>"foo", "b"=>1, "c"=>1.0, "d"=>200.0, "e"=>true, "f"=>false, "g"=>nil}
-#   h.class # => Hash
+# When the source is a \JSON object, JSON.parse by default returns a Ruby \Hash:
+#   json = '{"a": "foo", "b": 1, "c": 1.0, "d": 2.0e2, "e": true, "f": false, "g": null}'
+#   ruby = JSON.parse(json)
+#   ruby # => {"a"=>"foo", "b"=>1, "c"=>1.0, "d"=>200.0, "e"=>true, "f"=>false, "g"=>nil}
+#   ruby.class # => Hash
 #
 # The \JSON object may contain nested arrays, objects, and scalars
 # to any depth:
-#   source = '{"foo": {"bar": 1, "baz": 2}, "bat": [0, 1, 2]}'
-#   JSON.parse(source) # => {"foo"=>{"bar"=>1, "baz"=>2}, "bat"=>[0, 1, 2]}
+#   json = '{"foo": {"bar": 1, "baz": 2}, "bat": [0, 1, 2]}'
+#   JSON.parse(json) # => {"foo"=>{"bar"=>1, "baz"=>2}, "bat"=>[0, 1, 2]}
 #
 # ==== Parsing \JSON Scalars
 #
-# When +source+ is a \JSON scalar (not an array or object),
+# When the source is a \JSON scalar (not an array or object),
 # JSON.parse returns a Ruby scalar.
 #
 # \String:
-#   s = JSON.parse('"foo"')
-#   s # => "foo"
-#   s.class # => String
+#   ruby = JSON.parse('"foo"')
+#   ruby # => "foo"
+#   ruby.class # => String
 # \Integer:
-#   n = JSON.parse('1')
-#   n # => 1
-#   n.class # => Integer
+#   ruby = JSON.parse('1')
+#   ruby # => 1
+#   ruby.class # => Integer
 # \Float:
-#   f = JSON.parse('1.0')
-#   f # => 1.0
-#   f.class # => Float
-#   f = JSON.parse('2.0e2')
-#   f # => 200
-#   f.class # => Float
+#   ruby = JSON.parse('1.0')
+#   ruby # => 1.0
+#   ruby.class # => Float
+#   ruby = JSON.parse('2.0e2')
+#   ruby # => 200
+#   ruby.class # => Float
 # Boolean:
-#   b = JSON.parse('true')
-#   b # => true
-#   b.class # => TrueClass
-#   b = JSON.parse('false')
-#   b # => false
-#   b.class # => FalseClass
+#   ruby = JSON.parse('true')
+#   ruby # => true
+#   ruby.class # => TrueClass
+#   ruby = JSON.parse('false')
+#   ruby # => false
+#   ruby.class # => FalseClass
 # Null:
-#   n = JSON.parse('null')
-#   n # => nil
-#   n.class # => NilClass
+#   ruby = JSON.parse('null')
+#   ruby # => nil
+#   ruby.class # => NilClass
 #
 # === Generating \JSON
 #
 # To generate a Ruby \String containing \JSON data,
-# use method JSON.generate(source, opts), where
+# use method <tt>JSON.generate(source, opts)</tt>, where
 # - +source+ is a Ruby object.
 # - +opts+ is a \Hash object containing options data.
 #
 # ==== Generating \JSON from Arrays
 #
-# When +source+ is a Ruby \Array, JSON.generate returns
+# When the source is a Ruby \Array, JSON.generate returns
 # a \String containing a \JSON array:
-#   source = [0, 's', :foo]
-#   json = JSON.generate(source)
+#   ruby = [0, 's', :foo]
+#   json = JSON.generate(ruby)
 #   json # => "[0,\"s\",\"foo\"]"
 #
 # The Ruby \Array array may contain nested arrays, hashes, and scalars
 # to any depth:
-#   source = [0, [1, 2], {foo: 3, bar: 4}]
-#   json = JSON.generate(source)
+#   ruby = [0, [1, 2], {foo: 3, bar: 4}]
+#   json = JSON.generate(ruby)
 #   json # => "[0,[1,2],{\"foo\":3,\"bar\":4}]"
 #
 # ==== Generating \JSON from Hashes
 #
-# When +source+ is a Ruby \Hash, JSON.generate returns
+# When the source is a Ruby \Hash, JSON.generate returns
 # a \String containing a \JSON object:
-#   source = {foo: 0, bar: 's', baz: :bat}
-#   json = JSON.generate(source)
+#   ruby = {foo: 0, bar: 's', baz: :bat}
+#   json = JSON.generate(ruby)
 #   json # => "{\"foo\":0,\"bar\":\"s\",\"baz\":\"bat\"}"
 #
 # The Ruby \Hash array may contain nested arrays, hashes, and scalars
 # to any depth:
-#   source = {foo: [0, 1], bar: {baz: 2, bat: 3}, bam: :bad}
-#   json = JSON.generate(source)
+#   ruby = {foo: [0, 1], bar: {baz: 2, bat: 3}, bam: :bad}
+#   json = JSON.generate(ruby)
 #   json # => "{\"foo\":[0,1],\"bar\":{\"baz\":2,\"bat\":3},\"bam\":\"bad\"}"
 #
 # ==== Generating \JSON from Other Objects
 #
-# When +source+ is neither an \Array nor a \Hash,
-# the generated \JSON data depends on the class of +source+.
+# When the source is neither an \Array nor a \Hash,
+# the generated \JSON data depends on the class of the source.
 #
-# When +source+ is a Ruby \Integer or \Float, JSON.generate returns
+# When the source is a Ruby \Integer or \Float, JSON.generate returns
 # a \String containing a \JSON number:
 #   JSON.generate(Integer(0)) # => "0""
 #   JSON.generate(Float(1.0)) # => "1.0"
 #
-# When +source+ is a Ruby \String, JSON.generate returns
+# When the source is a Ruby \String, JSON.generate returns
 # a \String containing a \JSON string (with double-quotes):
 #   JSON.generate('A string') # => "\"A string\""
 #
-# When +source+ is +true+, +false+ or +nil+, JSON.generate returns
+# When the source is +true+, +false+ or +nil+, JSON.generate returns
 # a \String containing the corresponding \JSON token:
 #   JSON.generate(true) # => "true"
 #   JSON.generate(false) # => "false"
 #   JSON.generate(nil) # => "null"
 #
-# When +source+ is none of the above, JSON.generate returns
-# a \String containing a string representation of +source+:
+# When the source is none of the above, JSON.generate returns
+# a \String containing a \JSON string representation of the source:
 #   JSON.generate(:foo) # => "\"foo\""
 #   JSON.generate(Complex(0, 0)) # => "\"0+0i\""
 #   JSON.generate(Dir.new('.')) # => "\"#<Dir:0x0000000006bb30b8>\""
@@ -176,30 +171,29 @@ require 'json/common'
 #
 # When you "round trip" a non-\String object from Ruby to \JSON and back,
 # you have a new \String, instead of the object you began with:
-#
-#   range = Range.new(0, 2)
-#   json = JSON.generate(range)
+#   ruby0 = Range.new(0, 2)
+#   json = JSON.generate(ruby0)
 #   json # => "\"0..2\""
-#   object = JSON.parse(json)
-#   object # => "0..2"
-#   object.class # => String
+#   ruby1 = JSON.parse(json)
+#   ruby1 # => "0..2"
+#   ruby1.class # => String
 #
-# You can use \JSON _additions_ to restore the original object.
+# You can use \JSON _additions_ to preserve the original object.
 # The addition is an extension of a ruby class, so that:
 # - \JSON.generate stores more information in the \JSON string.
-# - \JSON.parse, called with option +create_additions,
+# - \JSON.parse, called with option +create_additions+,
 #   uses that information to create a proper Ruby object.
 #
 # This example shows a \Range being generated into \JSON
 # and parsed back into Ruby, both without and with
 # the addition for \Range:
-#   range = Range.new(0, 2)
+#   ruby = Range.new(0, 2)
 #   # This passage does not use the addition for Range.
-#   json0 = JSON.generate(range)
+#   json0 = JSON.generate(ruby)
 #   ruby0 = JSON.parse(json0)
 #   # This passage uses the addition for Range.
 #   require 'json/add/range'
-#   json1 = JSON.generate(range)
+#   json1 = JSON.generate(ruby)
 #   ruby1 = JSON.parse(json1, create_additions: true)
 #   # Make a nice display.
 #   display = <<EOT
@@ -221,11 +215,13 @@ require 'json/common'
 #     With addition:     0..2 (Range)
 #
 # The \JSON module includes additions for certain classes.
-# You can also craft custom additions.  See {Custom \JSON Additions}[#module-label-Custom+JSON+Additions]
+# You can also craft custom additions.
+# See {Custom \JSON Additions}[#module-JSON-label-Custom+JSON+Additions].
 #
 # === Built-in Additions
 #
-# The \JSON module includes additions for these classes:
+# The \JSON module includes additions for certain classes.
+# To use an addition, +require+ its source:
 # - BigDecimal: <tt>require 'json/add/bigdecimal'</tt>
 # - Complex: <tt>require 'json/add/complex'</tt>
 # - Date: <tt>require 'json/add/date'</tt>
@@ -245,100 +241,99 @@ require 'json/common'
 #
 # \BigDecimal:
 #   require 'json/add/bigdecimal'
-#   value = BigDecimal(0) # 0.0
-#   json = JSON.generate(value) # {"json_class":"BigDecimal","b":"27:0.0"}
-#   ruby = JSON.parse(json, create_additions: true) # 0.0
+#   ruby0 = BigDecimal(0) # 0.0
+#   json = JSON.generate(ruby0) # {"json_class":"BigDecimal","b":"27:0.0"}
+#   ruby1 = JSON.parse(json, create_additions: true) # 0.0
+#   ruby1.class # => BigDecimal
 #
 # \Complex:
 #   require 'json/add/complex'
-#   value = Complex(1+0i) # 1+0i
-#   json = JSON.generate(value) # {"json_class":"Complex","r":1,"i":0}
-#   ruby = JSON.parse(json, create_additions: true) # 1+0i
-#   ruby.class # Complex
+#   ruby0 = Complex(1+0i) # 1+0i
+#   json = JSON.generate(ruby0) # {"json_class":"Complex","r":1,"i":0}
+#   ruby1 = JSON.parse(json, create_additions: true) # 1+0i
+#   ruby1.class # Complex
 #
 # \Date:
 #   require 'json/add/date'
-#   value = Date.today # 2020-05-02
-#   json = JSON.generate(value) # {"json_class":"Date","y":2020,"m":5,"d":2,"sg":2299161.0}
-#   ruby = JSON.parse(json, create_additions: true) # 2020-05-02
-#   ruby.class # Date
+#   ruby0 = Date.today # 2020-05-02
+#   json = JSON.generate(ruby0) # {"json_class":"Date","y":2020,"m":5,"d":2,"sg":2299161.0}
+#   ruby1 = JSON.parse(json, create_additions: true) # 2020-05-02
+#   ruby1.class # Date
 #
 # \DateTime:
 #   require 'json/add/date_time'
-#   value = DateTime.now # 2020-05-02T10:38:13-05:00
-#   json = JSON.generate(value) # {"json_class":"DateTime","y":2020,"m":5,"d":2,"H":10,"M":38,"S":13,"of":"-5/24","sg":2299161.0}
-#   ruby = JSON.parse(json, create_additions: true) # 2020-05-02T10:38:13-05:00
-#   ruby.class # DateTime
+#   ruby0 = DateTime.now # 2020-05-02T10:38:13-05:00
+#   json = JSON.generate(ruby0) # {"json_class":"DateTime","y":2020,"m":5,"d":2,"H":10,"M":38,"S":13,"of":"-5/24","sg":2299161.0}
+#   ruby1 = JSON.parse(json, create_additions: true) # 2020-05-02T10:38:13-05:00
+#   ruby1.class # DateTime
 #
 # \Exception (and its subclasses including \RuntimeError):
 #   require 'json/add/exception'
-#   value = Exception.new('A message') # A message
-#   json = JSON.generate(value) # {"json_class":"Exception","m":"A message","b":null}
-#   ruby = JSON.parse(json, create_additions: true) # A message
-#   ruby.class # Exception
-#   value = RuntimeError.new('Another message') # Another message
-#   json = JSON.generate(value) # {"json_class":"RuntimeError","m":"Another message","b":null}
-#   ruby = JSON.parse(json, create_additions: true) # Another message
-#   ruby.class # RuntimeError
+#   ruby0 = Exception.new('A message') # A message
+#   json = JSON.generate(ruby0) # {"json_class":"Exception","m":"A message","b":null}
+#   ruby1 = JSON.parse(json, create_additions: true) # A message
+#   ruby1.class # Exception
+#   ruby0 = RuntimeError.new('Another message') # Another message
+#   json = JSON.generate(ruby0) # {"json_class":"RuntimeError","m":"Another message","b":null}
+#   ruby1 = JSON.parse(json, create_additions: true) # Another message
+#   ruby1.class # RuntimeError
 #
 # \OpenStruct:
 #   require 'json/add/ostruct'
-#   value = OpenStruct.new(name: 'Matz', language: 'Ruby') # #<OpenStruct name="Matz", language="Ruby">
-#   json = JSON.generate(value) # {"json_class":"OpenStruct","t":{"name":"Matz","language":"Ruby"}}
-#   ruby = JSON.parse(json, create_additions: true) # #<OpenStruct name="Matz", language="Ruby">
-#   ruby.class # OpenStruct
+#   ruby0 = OpenStruct.new(name: 'Matz', language: 'Ruby') # #<OpenStruct name="Matz", language="Ruby">
+#   json = JSON.generate(ruby0) # {"json_class":"OpenStruct","t":{"name":"Matz","language":"Ruby"}}
+#   ruby1 = JSON.parse(json, create_additions: true) # #<OpenStruct name="Matz", language="Ruby">
+#   ruby1.class # OpenStruct
 #
 # \Range:
 #   require 'json/add/range'
-#   value = Range.new(0, 2) # 0..2
-#   json = JSON.generate(value) # {"json_class":"Range","a":[0,2,false]}
-#   ruby = JSON.parse(json, create_additions: true) # 0..2
-#   ruby.class # Range
+#   ruby0 = Range.new(0, 2) # 0..2
+#   json = JSON.generate(ruby0) # {"json_class":"Range","a":[0,2,false]}
+#   ruby1 = JSON.parse(json, create_additions: true) # 0..2
+#   ruby1.class # Range
 #
 # \Rational:
 #   require 'json/add/rational'
-#   value = Rational(1, 3) # 1/3
-#   json = JSON.generate(value) # {"json_class":"Rational","n":1,"d":3}
-#   ruby = JSON.parse(json, create_additions: true) # 1/3
-#   ruby.class # Rational
+#   ruby0 = Rational(1, 3) # 1/3
+#   json = JSON.generate(ruby0) # {"json_class":"Rational","n":1,"d":3}
+#   ruby1 = JSON.parse(json, create_additions: true) # 1/3
+#   ruby1.class # Rational
 #
 # \Regexp:
 #   require 'json/add/regexp'
-#   value = Regexp.new('foo') # (?-mix:foo)
-#   json = JSON.generate(value) # {"json_class":"Regexp","o":0,"s":"foo"}
-#   ruby = JSON.parse(json, create_additions: true) # (?-mix:foo)
-#   ruby.class # Regexp
+#   ruby0 = Regexp.new('foo') # (?-mix:foo)
+#   json = JSON.generate(ruby0) # {"json_class":"Regexp","o":0,"s":"foo"}
+#   ruby1 = JSON.parse(json, create_additions: true) # (?-mix:foo)
+#   ruby1.class # Regexp
 #
 # \Set:
 #   require 'json/add/set'
-#   value = Set.new([0, 1, 2]) # #<Set: {0, 1, 2}>
-#   json = JSON.generate(value) # {"json_class":"Set","a":[0,1,2]}
-#   ruby = JSON.parse(json, create_additions: true) # #<Set: {0, 1, 2}>
-#   ruby.class # Set
-#
-# ---
+#   ruby0 = Set.new([0, 1, 2]) # #<Set: {0, 1, 2}>
+#   json = JSON.generate(ruby0) # {"json_class":"Set","a":[0,1,2]}
+#   ruby1 = JSON.parse(json, create_additions: true) # #<Set: {0, 1, 2}>
+#   ruby1.class # Set
 #
 # \Struct:
 #   require 'json/add/struct'
 #   Customer = Struct.new(:name, :address) # Customer
-#   value = Customer.new("Dave", "123 Main") # #<struct Customer name="Dave", address="123 Main">
-#   json = JSON.generate(value) # {"json_class":"Customer","v":["Dave","123 Main"]}
-#   ruby = JSON.parse(json, create_additions: true) # #<struct Customer name="Dave", address="123 Main">
-#   ruby.class # Customer
-#
+#   ruby0 = Customer.new("Dave", "123 Main") # #<struct Customer name="Dave", address="123 Main">
+#   json = JSON.generate(ruby0) # {"json_class":"Customer","v":["Dave","123 Main"]}
+#   ruby1 = JSON.parse(json, create_additions: true) # #<struct Customer name="Dave", address="123 Main">
+#   ruby1.class # Customer
+  #
 # \Symbol:
 #   require 'json/add/symbol'
-#   value = :foo # foo
-#   json = JSON.generate(value) # {"json_class":"Symbol","s":"foo"}
-#   ruby = JSON.parse(json, create_additions: true) # foo
-#   ruby.class # Symbol
+#   ruby0 = :foo # foo
+#   json = JSON.generate(ruby0) # {"json_class":"Symbol","s":"foo"}
+#   ruby1 = JSON.parse(json, create_additions: true) # foo
+#   ruby1.class # Symbol
 #
 # \Time:
 #   require 'json/add/time'
-#   value = Time.now # 2020-05-02 11:28:26 -0500
-#   json = JSON.generate(value) # {"json_class":"Time","s":1588436906,"n":840560000}
-#   ruby = JSON.parse(json, create_additions: true) # 2020-05-02 11:28:26 -0500
-#   ruby.class # Time
+#   ruby0 = Time.now # 2020-05-02 11:28:26 -0500
+#   json = JSON.generate(ruby0) # {"json_class":"Time","s":1588436906,"n":840560000}
+#   ruby1 = JSON.parse(json, create_additions: true) # 2020-05-02 11:28:26 -0500
+#   ruby1.class # Time
 #
 #
 # === Custom \JSON Additions
@@ -348,7 +343,6 @@ require 'json/common'
 # either for Ruby built-in classes or for user-defined classes.
 #
 # Here's a user-defined class +Foo+:
-#
 #   class Foo
 #     attr_accessor :bar, :baz
 #     def initialize(bar, baz)
@@ -358,7 +352,6 @@ require 'json/common'
 #   end
 #
 # Here's the \JSON addition for it:
-#
 #   # Extend class Foo with JSON addition.
 #   class Foo
 #     # Serialize Foo object with its class name and arguments

--- a/ext/json/lib/json.rb
+++ b/ext/json/lib/json.rb
@@ -40,7 +40,8 @@ require 'json/common'
 #
 # where
 # - +source+ is a Ruby object.
-# - +opts+ is a \Hash object containing options data.
+# - +opts+ is a \Hash object containing options
+#   that control both input allowed and output formatting.
 #
 # The difference between the two methods
 # is that JSON.parse! omits some checks
@@ -111,7 +112,8 @@ require 'json/common'
 # To generate a Ruby \String containing \JSON data,
 # use method <tt>JSON.generate(source, opts)</tt>, where
 # - +source+ is a Ruby object.
-# - +opts+ is a \Hash object containing options data.
+# - +opts+ is a \Hash object containing options
+#   that control both input allowed and output formatting.
 #
 # ==== Generating \JSON from Arrays
 #

--- a/ext/json/lib/json.rb
+++ b/ext/json/lib/json.rb
@@ -22,7 +22,8 @@ require 'json/common'
 #     {"a": "foo", "b": 1, "c": 1.0, "d": 2.0e2, "e": true, "f": false, "g": null}
 #
 #
-# \JSON arrays and objects may be nested (to any depth):
+# A \JSON array or object may contain nested arrays, objects, and scalars
+# to any depth:
 #   {"foo": {"bar": 1, "baz": 2}, "bat": [0, 1, 2]}
 #   [{"foo": 0, "bar": 1}, ["baz", 2]]
 #
@@ -38,42 +39,50 @@ require 'json/common'
 # === Parsing \JSON
 #
 # You can parse a \String containing \JSON data using
-# either method JSON.parse or JSON.parse!.
+# either of two methods:
+# - JSON.parse(source, opts)
+# - JSON.parse!(source, opts)
+#
+# where
+# - +source+ is a Ruby data structure.
+# - +opts+ is a \Hash object containing options data.
 #
 # The difference between the two methods
-# is that JSON.parse! takes some performance shortcuts
+# is that JSON.parse! takes some shortcuts
 # that may not be safe in all cases;
 # use it only for data from trusted sources.
 # Use the safer method JSON.parse for less trusted sources.
 #
-# ==== Parsing a \JSON \Array
+# ==== Parsing \JSON Arrays
 #
-# When the \JSON source is an array, JSON.parse by default returns a new Ruby \Array:
+# When +source+ is a \JSON array, JSON.parse by default returns a Ruby \Array:
 #   source = '["foo", 1, 1.0, 2.0e2, true, false, null]'
 #   a = JSON.parse(source)
 #   a # => ["foo", 1, 1.0, 200.0, true, false, nil]
 #   a.class # => Array
 #
-# The \JSON array may contain nested arrays and objects:
+# The \JSON array may contain nested arrays, objects, and scalars
+# to any depth:
 #   source = '[{"foo": 0, "bar": 1}, ["baz", 2]]'
 #   JSON.parse(source) # => [{"foo"=>0, "bar"=>1}, ["baz", 2]]
 #
-# ==== Parsing a \JSON \Object
+# ==== Parsing \JSON \Objects
 #
-# When the \JSON source is an object, JSON.parse by default returns a new Ruby \Hash:
+# When +source+ is a \JSON object, JSON.parse by default returns a Ruby \Hash:
 #   source = '{"a": "foo", "b": 1, "c": 1.0, "d": 2.0e2, "e": true, "f": false, "g": null}'
 #   h = JSON.parse(source)
 #   h # => {"a"=>"foo", "b"=>1, "c"=>1.0, "d"=>200.0, "e"=>true, "f"=>false, "g"=>nil}
 #   h.class # => Hash
 #
-# The \JSON object may contain nested arrays and objects:
+# The \JSON object may contain nested arrays, objects, and scalars
+# to any depth:
 #   source = '{"foo": {"bar": 1, "baz": 2}, "bat": [0, 1, 2]}'
 #   JSON.parse(source) # => {"foo"=>{"bar"=>1, "baz"=>2}, "bat"=>[0, 1, 2]}
 #
 # ==== Parsing \JSON Scalars
 #
-# When the \JSON source is a bare scalar (not an array or object),
-# JSON.parse returns a scalar.
+# When +source+ is a \JSON scalar (not an array or object),
+# JSON.parse returns a Ruby scalar.
 #
 # \String:
 #   s = JSON.parse('"foo"')
@@ -202,41 +211,69 @@ require 'json/common'
 #
 # ---
 #
-# Option +create_additions+
+# Option +create_additions+ specifies whether to
+# XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 #
 # === Generating \JSON
 #
-# You can parse a \String containing \JSON data using method
-# - <tt>JSON.generate(source, opts)
-# where
-# - +source+ is a Ruby data structure.
+# To generate a Ruby \String containing \JSON data,
+# use method JSON.generate(source, opts), where
+# - +source+ is a Ruby object.
 # - +opts+ is a \Hash object containing options data.
 #
-# ---
+# ==== Generating \JSON from Arrays
 #
-# ==== Generating \JSON from a Ruby \Array:
+# When +source+ is a Ruby \Array, JSON.generate returns
+# a \String containing a \JSON array:
+#   source = [0, 's', :foo]
+#   json = JSON.generate(source)
+#   json # => "[0,\"s\",\"foo\"]"
 #
-# When +source+ is a Ruby \Array, JSON.generate returns a \JSON array:
-#   source = ['foo', 1, 1.0, true, false, nil]
+# The Ruby \Array array may contain nested arrays, hashes, and scalars
+# to any depth:
+#   source = [0, [1, 2], {foo: 3, bar: 4}]
+#   json = JSON.generate(source)
+#   json # => "[0,[1,2],{\"foo\":3,\"bar\":4}]"
 #
+# ==== Generating \JSON from Hashes
 #
+# When +source+ is a Ruby \Hash, JSON.generate returns
+# a \String containing a \JSON object:
+#   source = {foo: 0, bar: 's', baz: :bat}
+#   json = JSON.generate(source)
+#   json # => "{\"foo\":0,\"bar\":\"s\",\"baz\":\"bat\"}"
 #
-# Creating a JSON string for communication or serialization is
-# just as simple.
+# The Ruby \Hash array may contain nested arrays, hashes, and scalars
+# to any depth:
+#   source = {foo: [0, 1], bar: {baz: 2, bat: 3}, bam: :bad}
+#   json = JSON.generate(source)
+#   json # => "{\"foo\":[0,1],\"bar\":{\"baz\":2,\"bat\":3},\"bam\":\"bad\"}"
 #
-# Option +indent+ specifies the string to be used for indentation.
-# The default is the empty string <tt>''</tt>:
-  #   source = '{"foo": {"bar": 1, "baz": 2}, "bat": [0, 1, 2]}'
-#   h = JSON.parse(source)
-#   h # => {"foo"=>{"bar"=>1, "baz"=>2}, "bat"=>[0, 1, 2]}
-# With two spaces:
-#   h = JSON.parse(source, {indent: '  '})
-#   h # => {"foo"=>{"bar"=>1, "baz"=>2}, "bat"=>[0, 1, 2]}
+# ==== Generating \JSON from Other Objects
 #
-# ---
+# When +source+ is neither an \Array nor a \Hash,
+# the generated \JSON data depends on the class of +source+.
 #
-# Option +create_additions+ specifies whether to
-# XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+# When +source+ is a Ruby \Integer or \Float, JSON.generate returns
+# a \String containing a \JSON number:
+#   JSON.generate(Integer(0)) # => "0""
+#   JSON.generate(Float(1.0)) # => "1.0"
+#
+# When +source+ is a Ruby \String, JSON.generate returns
+# a \String containing a \JSON string (with double-quotes):
+#   JSON.generate('A string') # => "\"A string\""
+#
+# When +source+ is +true+, +false+ or +nil+, JSON.generate returns
+# a \String containing the corresponding \JSON token:
+#   JSON.generate(true) # => "true"
+#   JSON.generate(false) # => "false"
+#   JSON.generate(nil) # => "null"
+#
+# When +source+ is none of the above, JSON.generate returns
+# a \String containing a string representation of +source+:
+#   JSON.generate(:foo)
+#   JSON.generate(Complex(0, 0))
+#   JSON.generate(Dir.new('.'))
 #
 # == \JSON Additions
 #

--- a/ext/json/lib/json.rb
+++ b/ext/json/lib/json.rb
@@ -287,7 +287,7 @@ require 'json/common'
 #     With addition:     0..2 (Range)
 #
 # The \JSON module includes additions for certain classes.
-# You can also craft custom additions.  See {Custom Additions}[#module-JSON-label-Custom+Additions]
+# You can also craft custom additions.  See {Custom \JSON Additions}[#module-label-Custom+JSON+Additions]
 #
 # === Built-in Additions
 #
@@ -409,7 +409,70 @@ require 'json/common'
 #   ruby.class # Time
 #
 #
-# === Custom Additions
+# === Custom \JSON Additions
+#
+# In addition to the \JSON additions provided,
+# you can craft addition of your own,
+# either for Ruby built-in classes or for classes of your own.
+#
+# Here's a user-defined class +Foo+:
+#
+#   class Foo
+#     attr_accessor :bar, :baz
+#     def initialize(bar, baz)
+#       self.bar = bar
+#       self.baz = baz
+#     end
+#   end
+#
+# Here's the \JSON addition for it:
+#
+#   # Extend class Foo with JSON addition.
+#   class Foo
+#     # Serialize Foo object with its class name and arguments
+#     def to_json(*args)
+#       {
+#         JSON.create_id  => self.class.name,
+#         'a'             => [ bar, baz ]
+#       }.to_json(*args)
+#     end
+#     # Deserialize JSON string by constructing new Foo object with arguments.
+#     def self.json_create(object)
+#       new(*object['a'])
+#     end
+#   end
+#
+# Demonstration:
+#   require 'json'
+#   # This Foo object has no custom addition.
+#   foo0 = Foo.new(0, 1)
+#   json0 = JSON.generate(foo0)
+#   obj0 = JSON.parse(json0)
+#   # Lood the custom addition.
+#   require_relative 'foo_addition'
+#   # This foo has the custom addition.
+#   foo1 = Foo.new(0, 1)
+#   json1 = JSON.generate(foo1)
+#   obj1 = JSON.parse(json1, create_additions: true)
+#   #   Make a nice display.
+#   display = <<EOT
+#   Generated JSON:
+#     Without custom addition:  #{json0} (#{json0.class})
+#     With custom addition:     #{json1} (#{json1.class})
+#   Parsed JSON:
+#     Without custom addition:  #{obj0.inspect} (#{obj0.class})
+#     With custom addition:     #{obj1.inspect} (#{obj1.class})
+#   EOT
+#   puts display
+#
+# Output:
+#
+#   Generated JSON:
+#     Without custom addition:  "#<Foo:0x0000000006534e80>" (String)
+#     With custom addition:     {"json_class":"Foo","a":[0,1]} (String)
+#   Parsed JSON:
+#     Without custom addition:  "#<Foo:0x0000000006534e80>" (String)
+#     With custom addition:     #<Foo:0x0000000006473bb8 @bar=0, @baz=1> (Foo)
 #
 module JSON
   require 'json/version'

--- a/ext/json/lib/json.rb
+++ b/ext/json/lib/json.rb
@@ -236,13 +236,55 @@ require 'json/common'
 # ---
 #
 # Option +create_additions+ specifies whether to
+# XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 #
-# == Generating \JSON with Additions
+# == \JSON Additions
+#
+# When you "round trip" a non-\String object from Ruby to \JSON and back,
+# you have a new \String, instead of the object you began with:
+#
+#   range = Range.new(0, 2)
+#   json = JSON.generate(range)
+#   json # => "\"0..2\""
+#   object = JSON.parse(json)
+#   object # => "0..2"
+#   object.class # => String
+#
+# You can use \JSON _additions_ to restore the original object.
+# The addition is an extension of a ruby class, so that:
+# - \JSON.generate stores more information in the \JSON string.
+# - \JSON.parse, called with option +create_additions,
+#   uses that information to create a proper Ruby object.
+#
+# This example generates \JSON from a \Range object,
+# then parses that \JSON to form a (new) \Range object:
+#   range = Range.new(0, 2)
+#   require 'json/add/range'
+#   json = JSON.generate(range)
+#   json # => "{\"json_class\":\"Range\",\"a\":[0,2,false]}"
+#   object = JSON.parse(json, create_additions: true)
+#   object # => 0..2
+#   object.class # => Range
+#
+# The \JSON module includes additions for certain classes.
+# You can also craft custom additions (see below).
 #
 # === Built-in Additions
 #
-# For certain classes, module \JSON offers optional _additions_.
-# Each addition provides enrichments for \JSON for a class.
+# The |JSON module includes additions for these classes:
+# - BigDecimal
+# - Complex
+# - Date
+# - DateTime
+# - Exception
+# - OpenStruct
+# - Range
+# - Rational
+# - Regexp
+# - Set
+# - Struct
+# - Symbol
+# - Time
 #
 # To reduce punctuation clutter, the examples below
 # show the generated \JSON via +puts+, rather than the usual +inspect+,
@@ -369,6 +411,8 @@ require 'json/common'
 # With addition:
 #   require 'json/add/symbol'
 #   JSON.generate(value) # {"json_class":"Symbol","s":"foo"}
+#
+# Custom Additions
 #
 module JSON
   require 'json/version'

--- a/ext/json/lib/json.rb
+++ b/ext/json/lib/json.rb
@@ -256,163 +256,160 @@ require 'json/common'
 # - \JSON.parse, called with option +create_additions,
 #   uses that information to create a proper Ruby object.
 #
-# This example generates \JSON from a \Range object,
-# then parses that \JSON to form a (new) \Range object:
+# This example shows a \Range being generated into \JSON
+# and parsed back into Ruby, both without and with
+# the addition for \Range:
 #   range = Range.new(0, 2)
+#   # This passage does not use the addition for Range.
+#   json0 = JSON.generate(range)
+#   ruby0 = JSON.parse(json0)
+#   # This passage uses the addition for Range.
 #   require 'json/add/range'
-#   json = JSON.generate(range)
-#   json # => "{\"json_class\":\"Range\",\"a\":[0,2,false]}"
-#   object = JSON.parse(json, create_additions: true)
-#   object # => 0..2
-#   object.class # => Range
+#   json1 = JSON.generate(range)
+#   ruby1 = JSON.parse(json1, create_additions: true)
+#   # Make a nice display.
+#   display = <<EOT
+#   Generated JSON:
+#     Without addition:  #{json0} (#{json0.class})
+#     With addition:     #{json1} (#{json1.class})
+#   Parsed JSON:
+#     Without addition:  #{ruby0.inspect} (#{ruby0.class})
+#     With addition:     #{ruby1.inspect} (#{ruby1.class})
+#   EOT
+#   puts display
+#
+# This output shows the different results:
+#   Generated JSON:
+#     Without addition:  "0..2" (String)
+#     With addition:     {"json_class":"Range","a":[0,2,false]} (String)
+#   Parsed JSON:
+#     Without addition:  "0..2" (String)
+#     With addition:     0..2 (Range)
 #
 # The \JSON module includes additions for certain classes.
-# You can also craft custom additions (see below).
+# You can also craft custom additions.  See {Custom Additions}[#module-JSON-label-Custom+Additions]
 #
 # === Built-in Additions
 #
-# The |JSON module includes additions for these classes:
-# - BigDecimal
-# - Complex
-# - Date
-# - DateTime
-# - Exception
-# - OpenStruct
-# - Range
-# - Rational
-# - Regexp
-# - Set
-# - Struct
-# - Symbol
-# - Time
+# <table><tr><td>Foo</td></tr></table>
+#
+# The \JSON module includes additions for these classes:
+# - BigDecimal: <tt>require 'json/add/bigdecimal'</tt>
+# - Complex: <tt>require 'json/add/complex'</tt>
+# - Date: <tt>require 'json/add/date'</tt>
+# - DateTime: <tt>require 'json/add/date_time'</tt>
+# - Exception: <tt>require 'json/add/exception'</tt>
+# - OpenStruct: <tt>require 'json/add/ostruct'</tt>
+# - Range: <tt>require 'json/add/range'</tt>
+# - Rational: <tt>require 'json/add/rational'</tt>
+# - Regexp: <tt>require 'json/add/regexp'</tt>
+# - Set: <tt>require 'json/add/set'</tt>
+# - Struct: <tt>require 'json/add/struct'</tt>
+# - Symbol: <tt>require 'json/add/symbol'</tt>
+# - Time: <tt>require 'json/add/time'</tt>
 #
 # To reduce punctuation clutter, the examples below
 # show the generated \JSON via +puts+, rather than the usual +inspect+,
 #
-# ---
-#
 # \BigDecimal:
-#   value = BigDecimal(0) # 0.0
-# Without addition:
-#   JSON.generate(value) # "0.0"
-# With addition:
 #   require 'json/add/bigdecimal'
-#   JSON.generate(value) # {"json_class":"BigDecimal","b":"27:0.0"}
-#
-# ---
+#   value = BigDecimal(0) # 0.0
+#   json = JSON.generate(value) # {"json_class":"BigDecimal","b":"27:0.0"}
+#   ruby = JSON.parse(json, create_additions: true) # 0.0
 #
 # \Complex:
-#   value = Complex(1+0i) # (1+0i)
-# Without addition:
-#   JSON.generate(value) # "0.0"
-# With addition:
 #   require 'json/add/complex'
-#   JSON.generate(value) # {"json_class":"Date","y":2020,"m":5,"d":1,"sg":2299161.0}
-#
-# ---
+#   value = Complex(1+0i) # 1+0i
+#   json = JSON.generate(value) # {"json_class":"Complex","r":1,"i":0}
+#   ruby = JSON.parse(json, create_additions: true) # 1+0i
+#   ruby.class # Complex
 #
 # \Date:
-#   value = Date.today # #<Date: 2020-05-01 ((2458971j,0s,0n),+0s,2299161j)>
-# Without addition:
-#   JSON.generate(value) # "2020-05-01"
-# With addition:
 #   require 'json/add/date'
-#   JSON.generate(value) # {"json_class":"Date","y":2020,"m":5,"d":1,"sg":2299161.0}
-#
-# ---
+#   value = Date.today # 2020-05-02
+#   json = JSON.generate(value) # {"json_class":"Date","y":2020,"m":5,"d":2,"sg":2299161.0}
+#   ruby = JSON.parse(json, create_additions: true) # 2020-05-02
+#   ruby.class # Date
 #
 # \DateTime:
-#   value = DateTime.now # 2020-05-01T11:00:47-05:00
-# Without addition:
-#   JSON.generate(value) # "2020-05-01T11:00:47-05:00"
-# With addition:
 #   require 'json/add/date_time'
-#   JSON.generate(value) # {"json_class":"DateTime","y":2020,"m":5,"d":1,"H":11,"M":0,"S":47,"of":"-5/24","sg":2299161.0}
+#   value = DateTime.now # 2020-05-02T10:38:13-05:00
+#   json = JSON.generate(value) # {"json_class":"DateTime","y":2020,"m":5,"d":2,"H":10,"M":38,"S":13,"of":"-5/24","sg":2299161.0}
+#   ruby = JSON.parse(json, create_additions: true) # 2020-05-02T10:38:13-05:00
+#   ruby.class # DateTime
 #
-# ---
-#
-# \Exception (and its subclasses, including \RuntimeError):
-#   value0 = Exception.new('A message') # #<Exception: A message>
-#   value1 = RuntimeError.new('Another message') # #<RuntimeError: Another message>
-# Without addition:
-#   JSON.generate(value0) # "A message"
-#   JSON.generate(value1) # "Another message"
-# With addition:
+# \Exception (and its subclasses including \RuntimeError):
 #   require 'json/add/exception'
-#   JSON.generate(value0) # {"json_class":"Exception","m":"A message","b":null}
-#   JSON.generate(value1) # {"json_class":"RuntimeError","m":"Another message","b":null}
-#
-# ---
+#   value = Exception.new('A message') # A message
+#   json = JSON.generate(value) # {"json_class":"Exception","m":"A message","b":null}
+#   ruby = JSON.parse(json, create_additions: true) # A message
+#   ruby.class # Exception
+#   value = RuntimeError.new('Another message') # Another message
+#   json = JSON.generate(value) # {"json_class":"RuntimeError","m":"Another message","b":null}
+#   ruby = JSON.parse(json, create_additions: true) # Another message
+#   ruby.class # RuntimeError
 #
 # \OpenStruct:
-#   value = OpenStruct.new(name: 'Matz', language: 'Ruby') # #<OpenStruct name="Matz", language="Ruby">
-# Without addition:
-#   JSON.generate(value) # "#<OpenStruct name=\"Matz\", language=\"Ruby\">"
-# With addition:
 #   require 'json/add/ostruct'
-#   JSON.generate(value) # {"json_class":"OpenStruct","t":{"name":"Matz","language":"Ruby"}}
-#
-# ---
+#   value = OpenStruct.new(name: 'Matz', language: 'Ruby') # #<OpenStruct name="Matz", language="Ruby">
+#   json = JSON.generate(value) # {"json_class":"OpenStruct","t":{"name":"Matz","language":"Ruby"}}
+#   ruby = JSON.parse(json, create_additions: true) # #<OpenStruct name="Matz", language="Ruby">
+#   ruby.class # OpenStruct
 #
 # \Range:
-#   value = Range.new(1, 3) # 1..3
-# Without addition:
-#   JSON.generate(value) # "1..3"
-# With addition:
 #   require 'json/add/range'
-#   JSON.generate(value) # {"json_class":"Range","a":[1,3,false]}
-#
-# ---
+#   value = Range.new(0, 2) # 0..2
+#   json = JSON.generate(value) # {"json_class":"Range","a":[0,2,false]}
+#   ruby = JSON.parse(json, create_additions: true) # 0..2
+#   ruby.class # Range
 #
 # \Rational:
-#   value = Rational.new(1, 3) # (1/3)
-# Without addition:
-#   JSON.generate(value) # "1/3"
-# With addition:
 #   require 'json/add/rational'
-#   JSON.generate(value) # {"json_class":"Rational","n":1,"d":3}
-#
-# ---
+#   value = Rational(1, 3) # 1/3
+#   json = JSON.generate(value) # {"json_class":"Rational","n":1,"d":3}
+#   ruby = JSON.parse(json, create_additions: true) # 1/3
+#   ruby.class # Rational
 #
 # \Regexp:
-#   value = Regexp.new('foo') # /foo/
-# Without addition:
-#   JSON.generate(value) # "(?-mix:foo)"
-# With addition:
 #   require 'json/add/regexp'
-#   JSON.generate(value) # {"json_class":"Regexp","o":0,"s":"foo"}
-#
-# ---
+#   value = Regexp.new('foo') # (?-mix:foo)
+#   json = JSON.generate(value) # {"json_class":"Regexp","o":0,"s":"foo"}
+#   ruby = JSON.parse(json, create_additions: true) # (?-mix:foo)
+#   ruby.class # Regexp
 #
 # \Set:
-#   value = Set.new([0, 1, 2]) # #<Set: {0, 1, 2}>
-# Without addition:
-#   JSON.generate(value) # "#<Set: {0, 1, 2}>"
-# With addition:
 #   require 'json/add/set'
-#   JSON.generate(value) # {"json_class":"Set","a":[0,1,2]}
+#   value = Set.new([0, 1, 2]) # #<Set: {0, 1, 2}>
+#   json = JSON.generate(value) # {"json_class":"Set","a":[0,1,2]}
+#   ruby = JSON.parse(json, create_additions: true) # #<Set: {0, 1, 2}>
+#   ruby.class # Set
 #
 # ---
 #
 # \Struct:
-#   value = Struct.new("Customer", :name, :address) # Struct::Customer
-# Without addition:
-#   JSON.generate(value) # "Struct::Customer"
-# With addition:
 #   require 'json/add/struct'
-#   JSON.generate(value) # "Struct::Customer"
-#
-# ---
+#   Customer = Struct.new(:name, :address) # Customer
+#   value = Customer.new("Dave", "123 Main") # #<struct Customer name="Dave", address="123 Main">
+#   json = JSON.generate(value) # {"json_class":"Customer","v":["Dave","123 Main"]}
+#   ruby = JSON.parse(json, create_additions: true) # #<struct Customer name="Dave", address="123 Main">
+#   ruby.class # Customer
 #
 # \Symbol:
-#   value = :foo # :foo
-# Without addition:
-#   JSON.generate(value) # :foo
-# With addition:
 #   require 'json/add/symbol'
-#   JSON.generate(value) # {"json_class":"Symbol","s":"foo"}
+#   value = :foo # foo
+#   json = JSON.generate(value) # {"json_class":"Symbol","s":"foo"}
+#   ruby = JSON.parse(json, create_additions: true) # foo
+#   ruby.class # Symbol
 #
-# Custom Additions
+# \Time:
+#   require 'json/add/time'
+#   value = Time.now # 2020-05-02 11:28:26 -0500
+#   json = JSON.generate(value) # {"json_class":"Time","s":1588436906,"n":840560000}
+#   ruby = JSON.parse(json, create_additions: true) # 2020-05-02 11:28:26 -0500
+#   ruby.class # Time
+#
+#
+# === Custom Additions
 #
 module JSON
   require 'json/version'

--- a/ext/json/lib/json/common.rb
+++ b/ext/json/lib/json/common.rb
@@ -6,13 +6,13 @@ module JSON
   class << self
     # If +object+ is a
     # {String-convertible object}[doc/implicit_conversion_rdoc.html#label-String-Convertible+Objects]
-    # (implementing +to_str+), calls #parse with +object+ and +opts+:
-    #   json = '[0, 1, null]' # => [0, 1, nil]
-    #   JSON[json]
+    # (implementing +to_str+), calls JSON.parse with +object+ and +opts+:
+    #   json = '[0, 1, null]'
+    #   JSON[json]# => [0, 1, nil]
     #
-    # Otherwise, calls #generate with +object+ and +opts+:
-    #   ruby = [0, 1, nil] # => "[0,1,null]"
-    #   JSON[ruby]
+    # Otherwise, calls JSON.generate with +object+ and +opts+:
+    #   ruby = [0, 1, nil]
+    #   JSON[ruby] # => "[0,1,null]"
     def [](object, opts = {})
       if object.respond_to? :to_str
         JSON.parse(object.to_str, opts)
@@ -166,7 +166,7 @@ module JSON
   #
   # ====== Options
   #
-  # Option +:max_nesting+ (\Integer) specifies the maximum nesting depth allowed;
+  # Option +max_nesting+ (\Integer) specifies the maximum nesting depth allowed;
   # defaults to +100+; specify +false+ to disable depth checking.
   #
   # With the default, +false+:
@@ -308,6 +308,8 @@ module JSON
   #
   # Returns a \String containing the generated \JSON data.
   #
+  # See also JSON.fast_generate, JSON.pretty_generate.
+  #
   # ---
   #
   # When +source+ is an
@@ -387,33 +389,41 @@ module JSON
   #     }
   #   }
   #
-  # * *allow_nan*: true if NaN, Infinity, and -Infinity should be
-  #   generated, otherwise an exception is thrown if these values are
-  #   encountered. This options defaults to false.
-  # * *max_nesting*: The maximum depth of nesting allowed in the data
-  #   structures from which JSON is to be generated. Disable depth checking
-  #   with <tt>max_nesting: false</tt>, it defaults to 100.
+  # ====== Other Options
   #
-  # The default options are set to create the shortest possible JSON text
-  # in one line, check for circular data structures and do not allow NaN,
-  # Infinity, and -Infinity.
+  # Option +allow_nan+ (boolean) specifies whether
+  # +NaN+, +Infinity+, and <tt>-Infinity</tt> may be generated;
+  # defaults to +false+.
   #
-  # An _opts_ hash can have the following keys:
-  # * *indent*: a string used to indent levels (default: <tt>''</tt>),
-  # * *space*: a string that is put after a <tt>:</tt> pair delimiter (default: <tt>''</tt>),
-  # * *space_before*: a string that is put before a <tt>:</tt> pair delimiter (default: <tt>''</tt>),
-  # * *object_nl*: a string that is put at the end of a JSON object (default: <tt>''</tt>),
-  # * *array_nl*: a string that is put at the end of a JSON array (default: <tt>''</tt>),
-  # * *allow_nan*: true if NaN, Infinity, and -Infinity should be
-  #   generated, otherwise an exception is thrown if these values are
-  #   encountered. This options defaults to false.
-  # * *max_nesting*: The maximum depth of nesting allowed in the data
-  #   structures from which JSON is to be generated. Disable depth checking
-  #   with <tt>max_nesting: false</tt>, it defaults to 100.
+  # With the default, +false+:
+  #   # Raises JSON::GeneratorError (920: NaN not allowed in JSON):
+  #   JSON.generate(0.0/0)
+  #   # Raises JSON::GeneratorError (917: Infinity not allowed in JSON):
+  #   JSON.generate(1.0/0)
+  #   # Raises JSON::GeneratorError (917: -Infinity not allowed in JSON):
+  #   JSON.generate(-1.0/0)
   #
-  # See also the fast_generate for the fastest creation method with the least
-  # amount of sanity checks, and the pretty_generate method for some
-  # defaults for pretty output.
+  # Allow:
+  #   ruby = [0.0/0, 1.0/0, -1.0/0]
+  #   JSON.generate(ruby, allow_nan: true) # => "[NaN,Infinity,-Infinity]"
+  #
+  # ---
+  #
+  # Option +max_nesting+ (\Integer) specifies the maximum nesting depth
+  # in +source+; defaults to +100+.
+  #
+  # With the default, +100+:
+  #   source = [[[[[[0]]]]]]
+  #   JSON.generate(source) # => "[[[[[[0]]]]]]"
+  #
+  # Too deep:
+  #   # Raises JSON::NestingError (nesting of 2 is too deep):
+  #   JSON.generate(source, max_nesting: 2)
+  #
+  # Bad Value:
+  #   # Raises TypeError (can't convert Symbol into Hash):
+  #   JSON.generate(source, :foo)
+  #
   def generate(obj, opts = nil)
     if State === opts
       state, opts = opts, nil

--- a/ext/json/lib/json/common.rb
+++ b/ext/json/lib/json/common.rb
@@ -133,7 +133,7 @@ module JSON
   # This exception is raised if a generator or unparser error occurs.
   class GeneratorError < JSONError; end
   # For backwards compatibility
-  UnparserError = GeneratorError
+  UnparserError = GeneratorError # :nodoc:
 
   # This exception is raised if the required unicode support is missing on the
   # system. Usually this means that the iconv library is not installed.

--- a/ext/json/lib/json/common.rb
+++ b/ext/json/lib/json/common.rb
@@ -168,7 +168,7 @@ module JSON
   # For examples of parsing for all \JSON data types, see
   # {Parsing \JSON}[#module-JSON-label-Parsing+JSON].
   #
-  # ====== Options
+  # ====== Input Options
   #
   # Option +max_nesting+ (\Integer) specifies the maximum nesting depth allowed;
   # defaults to +100+; specify +false+ to disable depth checking.
@@ -205,7 +205,7 @@ module JSON
   #   ruby = JSON.parse(source, {allow_nan: :foo})
   #   ruby # => [NaN, Infinity, -Infinity]
   #
-  # ---
+  # ====== Output Options
   #
   # Option +symbolize_names+ (boolean) specifies whether returned \Hash keys
   # should be Symbols;
@@ -331,7 +331,42 @@ module JSON
   # For examples of generating from other Ruby objects, see
   # {Generating \JSON from Other Objects}[#module-JSON-label-Generating+JSON+from+Other+Objects].
   #
-  # ====== \JSON Format Options
+  # ====== Input Options
+  #
+  # Option +allow_nan+ (boolean) specifies whether
+  # +NaN+, +Infinity+, and <tt>-Infinity</tt> may be generated;
+  # defaults to +false+.
+  #
+  # With the default, +false+:
+  #   # Raises JSON::GeneratorError (920: NaN not allowed in JSON):
+  #   JSON.generate(JSON::NaN)
+  #   # Raises JSON::GeneratorError (917: Infinity not allowed in JSON):
+  #   JSON.generate(JSON::Infinity)
+  #   # Raises JSON::GeneratorError (917: -Infinity not allowed in JSON):
+  #   JSON.generate(JSON::MinusInfinity)
+  #
+  # Allow:
+  #   ruby = [JSON::NaN, JSON::Infinity, JSON::MinusInfinity]
+  #   JSON.generate(ruby, allow_nan: true) # => "[NaN,Infinity,-Infinity]"
+  #
+  # ---
+  #
+  # Option +max_nesting+ (\Integer) specifies the maximum nesting depth
+  # in +obj+; defaults to +100+.
+  #
+  # With the default, +100+:
+  #   obj = [[[[[[0]]]]]]
+  #   JSON.generate(obj) # => "[[[[[[0]]]]]]"
+  #
+  # Too deep:
+  #   # Raises JSON::NestingError (nesting of 2 is too deep):
+  #   JSON.generate(obj, max_nesting: 2)
+  #
+  # Bad Value:
+  #   # Raises TypeError (can't convert Symbol into Hash):
+  #   JSON.generate(obj, :foo)
+  #
+  # ====== Output Options
   #
   # The default formatting options generate the most compact
   # \JSON data, all on one line and with no whitespace.
@@ -388,44 +423,9 @@ module JSON
   #
   # ---
   #
-  # Raises an exception if any format option is not a \String.
+  # Raises an exception if any formatting option is not a \String.
   #
-  # ====== Other Options
-  #
-  # Option +allow_nan+ (boolean) specifies whether
-  # +NaN+, +Infinity+, and <tt>-Infinity</tt> may be generated;
-  # defaults to +false+.
-  #
-  # With the default, +false+:
-  #   # Raises JSON::GeneratorError (920: NaN not allowed in JSON):
-  #   JSON.generate(JSON::NaN)
-  #   # Raises JSON::GeneratorError (917: Infinity not allowed in JSON):
-  #   JSON.generate(JSON::Infinity)
-  #   # Raises JSON::GeneratorError (917: -Infinity not allowed in JSON):
-  #   JSON.generate(JSON::MinusInfinity)
-  #
-  # Allow:
-  #   ruby = [JSON::NaN, JSON::Infinity, JSON::MinusInfinity]
-  #   JSON.generate(ruby, allow_nan: true) # => "[NaN,Infinity,-Infinity]"
-  #
-  # ---
-  #
-  # Option +max_nesting+ (\Integer) specifies the maximum nesting depth
-  # in +obj+; defaults to +100+.
-  #
-  # With the default, +100+:
-  #   obj = [[[[[[0]]]]]]
-  #   JSON.generate(obj) # => "[[[[[[0]]]]]]"
-  #
-  # Too deep:
-  #   # Raises JSON::NestingError (nesting of 2 is too deep):
-  #   JSON.generate(obj, max_nesting: 2)
-  #
-  # Bad Value:
-  #   # Raises TypeError (can't convert Symbol into Hash):
-  #   JSON.generate(obj, :foo)
-  #
-  # ---
+  # ====== Exceptions
   #
   # Raises an exception if +obj+ is not a valid Ruby object:
   #   # Raises NameError (uninitialized constant Foo):

--- a/ext/json/lib/json/common.rb
+++ b/ext/json/lib/json/common.rb
@@ -134,31 +134,139 @@ module JSON
 
   module_function
 
-  # Parse the JSON document _source_ into a Ruby data structure and return it.
+  # Argument +source+ must be a
+  # {String-convertible object}[doc/implicit_conversion_rdoc.html#label-String-Convertible+Objects]
+  # (implementing +to_str+).
   #
-  # _opts_ can have the following
-  # keys:
+  # Argument +opts+, if given, must be a
+  # {Hash-convertible object}[doc/implicit_conversion_rdoc.html#label-Hash-Convertible+Objects]
+  # (implementing +to_hash+), or must be a JSON::State object.
+  #
+  # ---
+  #
+  # Returns the Ruby data structure created by parsing the given +source+.
+  #
+  # ---
+  #
+  # When +source+ is a JSON array, returns a new \Array:
+  #   source = '["foo", 1.0, true, false, null]'
+  #   a = JSON.parse(source)
+  #   a # => ["foo", 1.0, true, false, nil]
+  #   a.class # => Array
+  #
+  # The JSON array may contain nested arrays and objects:
+  #   source = '[{"foo": 0, "bar": 1}, ["baz", 2]]'
+  #   a = JSON.parse(source)
+  #   a # => [{"foo"=>0, "bar"=>1}, ["baz", 2]]
+  #
+  # ---
+  #
+  # When +source+ is a JSON object, returns a new \Hash:
+  #   source = '{"a": "foo", "b": 1.0, "c": true, "d": false, "e": null}'
+  #   h = JSON.parse(source)
+  #   h # => {"a"=>"foo", "b"=>1.0, "c"=>true, "d"=>false, "e"=>nil}
+  #   h.class # => Hash
+  #
+  # The JSON object may contain nested arrays and objects:
+  #   source = '{"foo": {"bar": 1, "baz": 2}, "bat": [0, 1, 2]}'
+  #   h = JSON.parse(source)
+  #   h # => {"foo"=>{"bar"=>1, "baz"=>2}, "bat"=>[0, 1, 2]}
+  #
+  # ---
+  #
+  # * *array_class*: Defaults to Array
   # * *max_nesting*: The maximum depth of nesting allowed in the parsed data
   #   structures. Disable depth checking with :max_nesting => false. It
   #   defaults to 100.
-  # * *allow_nan*: If set to true, allow NaN, Infinity and -Infinity in
-  #   defiance of RFC 7159 to be parsed by the Parser. This option defaults
-  #   to false.
+  # * *object_class*: Defaults to Hash
   # * *symbolize_names*: If set to true, returns symbols for the names
   #   (keys) in a JSON object. Otherwise strings are returned. Strings are
   #   the default.
-  # * *create_additions*: If set to false, the Parser doesn't create
-  #   additions even if a matching class and create_id was found. This option
-  #   defaults to false.
-  # * *object_class*: Defaults to Hash
-  # * *array_class*: Defaults to Array
+  # * *max_nesting*: The maximum depth of nesting allowed in the parsed data
+  #   structures. Disable depth checking with :max_nesting => false. It
+  #   defaults to 100.
+  #
+  # ---
+  #
+  # Raises an exception if +source+ is not \String-convertible:
+  #
+  #   Raises TypeError (no implicit conversion of Symbol into String):
+  #   JSON.parse(:foo)
+  #
+  # Raises an exception if +opts+ is not \Hash-convertible:
+  #
+  #   Raises TypeError (no implicit conversion of Symbol into Hash):
+  #   JSON.parse(['foo'], :foo)
+  #
+  # Raises an exception if +source+ is not valid JSON:
+  #
+  #   Raises JSON::ParserError (783: unexpected token at ''):
+  #   JSON.parse('')
+  #
   def parse(source, opts = {})
     Parser.new(source, **(opts||{})).parse
   end
 
+  # Argument +source+ must be a
+  # {String-convertible object}[doc/implicit_conversion_rdoc.html#label-String-Convertible+Objects]
+  # (implementing +to_str+).
+  #
+  # Argument +opts+, if given, must be a
+  # {Hash-convertible object}[doc/implicit_conversion_rdoc.html#label-Hash-Convertible+Objects]
+  # (implementing +to_hash+), or must be a JSON::State object.
+  #
+  # ---
+  #
+  # Returns the Ruby data structure created by parsing the given +source+.
+  #
+  # Method +parse!+ has defaults that are more dangerous
+  # than those for method +parse+;
+  # it should be used only for trusted +source+ documents.
+  #
+  # ---
+  #
+  # When +source+ is a JSON array, returns a new \Array:
+  #   source = '["foo", 1.0, true, false, null]'
+  #   a = JSON.parse!(source)
+  #   a # => ["foo", 1.0, true, false, nil]
+  #   a.class # => Array
+  #
+  # The JSON array may contain nested arrays and objects:
+  #   source = '[{"foo": 0, "bar": 1}, ["baz", 2]]'
+  #   a = JSON.parse!(source)
+  #   a # => [{"foo"=>0, "bar"=>1}, ["baz", 2]]
+  #
+  # ---
+  #
+  # When +source+ is a JSON object, returns a new \Hash:
+  #   source = '{"a": "foo", "b": 1.0, "c": true, "d": false, "e": null}'
+  #   h = JSON.parse!(source)
+  #   h # => {"a"=>"foo", "b"=>1.0, "c"=>true, "d"=>false, "e"=>nil}
+  #   h.class # => Hash
+  #
+  # The JSON object may contain nested arrays and objects:
+  #   source = '{"foo": {"bar": 1, "baz": 2}, "bat": [0, 1, 2]}'
+  #   h = JSON.parse!(source)
+  #   h # => {"foo"=>{"bar"=>1, "baz"=>2}, "bat"=>[0, 1, 2]}
+  #
+  # ---
+  #
+  # Raises an exception if +source+ is not \String-convertible:
+  #
+  #   Raises TypeError (no implicit conversion of Symbol into String):
+  #   JSON.parse!(:foo)
+  #
+  # Raises an exception if +opts+ is not \Hash-convertible:
+  #
+  #   Raises TypeError (no implicit conversion of Symbol into Hash):
+  #   JSON.parse!(['foo'], :foo)
+  #
+  # Raises an exception if +source+ is not valid JSON:
+  #
+  #   Raises JSON::ParserError (783: unexpected token at ''):
+  #   JSON.parse!('')
+  #
   # Parse the JSON document _source_ into a Ruby data structure and return it.
-  # The bang version of the parse method defaults to the more dangerous values
-  # for the _opts_ hash, so be sure only to parse trusted _source_ documents.
   #
   # _opts_ can have the following keys:
   # * *max_nesting*: The maximum depth of nesting allowed in the parsed data

--- a/ext/json/lib/json/common.rb
+++ b/ext/json/lib/json/common.rb
@@ -22,7 +22,8 @@ module JSON
     end
 
     # Returns the JSON parser class that is used by JSON. This is either
-    # JSON::Ext::Parser or JSON::Pure::Parser.
+    # JSON::Ext::Parser or JSON::Pure::Parser:
+    #   JSON.parser # => JSON::Ext::Parser
     attr_reader :parser
 
     # Set the JSON parser class _parser_ to be used by JSON.
@@ -87,15 +88,18 @@ module JSON
     end
 
     # Returns the JSON generator module that is used by JSON. This is
-    # either JSON::Ext::Generator or JSON::Pure::Generator.
+    # either JSON::Ext::Generator or JSON::Pure::Generator:
+    #   JSON.generator # => JSON::Ext::Generator
     attr_reader :generator
 
     # Returns the JSON generator state class that is used by JSON. This is
-    # either JSON::Ext::Generator::State or JSON::Pure::Generator::State.
+    # either JSON::Ext::Generator::State or JSON::Pure::Generator::State:
+    #   JSON.state # => JSON::Ext::Generator::State
     attr_accessor :state
 
     # This is create identifier, which is used to decide if the _json_create_
-    # hook of a class should be called. It defaults to 'json_class'.
+    # hook of a class should be called; initial value is +json_class+:
+    #   JSON.create_id # => "json_class"
     attr_accessor :create_id
   end
   self.create_id = 'json_class'
@@ -183,19 +187,16 @@ module JSON
   # ---
   #
   # Option +allow_nan+ (boolean) specifies whether to allow
-  # +NaN+, +Infinity+, and +-Infinity+ in +source+;
+  # NaN, Infinity, and MinusInfinity in +source+;
   # defaults to +false+.
   #
   # With the default, +false+:
-  #   source = '[NaN]'
-  #   # Raises JSON::ParserError (232: unexpected token at '[NaN]'):
-  #   a = JSON.parse(source)
-  #   source = '[Infinity]'
+  #   # Raises JSON::ParserError (225: unexpected token at '[NaN]'):
+  #   a = JSON.parse('[NaN]')
   #   # Raises JSON::ParserError (232: unexpected token at '[Infinity]'):
-  #   a = JSON.parse(source)
-  #   source = '[-Infinity]'
-  #   # Raises JSON::ParserError (232: unexpected token at '[-Infinity]'):
-  #   a = JSON.parse(source)
+  #   a = JSON.parse('[Infinity]')
+  #   # Raises JSON::ParserError (248: unexpected token at '[-Infinity]'):
+  #   a = JSON.parse('[-Infinity]')
   # Allow:
   #   source = '[NaN, Infinity, -Infinity]'
   #   a = JSON.parse(source, {allow_nan: true})
@@ -328,9 +329,9 @@ module JSON
   #   json # => "{\"foo\":0,\"bar\":\"s\",\"baz\":\"bat\"}"
   #
   # For examples of generating from other Ruby objects, see
-  # {Generating \JSON}[#module-JSON-label-Generating+JSON].
+  # {Generating \JSON from Other Objects}[#module-JSON-label-Generating+JSON+from+Other+Objects].
   #
-  # ====== Formatting Options
+  # ====== \JSON Format Options
   #
   # The default formatting options generate the most compact
   # \JSON data, all on one line and with no whitespace.
@@ -364,7 +365,7 @@ module JSON
   #   opts = {
   #     array_nl: "\n",
   #     object_nl: "\n",
-  #     indent: '  ',
+  #     indent+: '  ',
   #     space_before: ' ',
   #     space: ' '
   #   }
@@ -376,18 +377,18 @@ module JSON
   #   Open:
   #   {
   #     "foo" : [
-  #     "bar",
-  #     "baz"
+  #       "bar",
+  #       "baz"
   #   ],
   #     "bat" : {
-  #     "bam" : 0,
-  #     "bad" : 1
+  #       "bam" : 0,
+  #       "bad" : 1
   #     }
   #   }
   #
   # ---
   #
-  # Raises an exception if any formatting is not a \String.
+  # Raises an exception if any format option is not a \String.
   #
   # ====== Other Options
   #
@@ -397,14 +398,14 @@ module JSON
   #
   # With the default, +false+:
   #   # Raises JSON::GeneratorError (920: NaN not allowed in JSON):
-  #   JSON.generate(0.0/0)
+  #   JSON.generate(JSON::NaN)
   #   # Raises JSON::GeneratorError (917: Infinity not allowed in JSON):
-  #   JSON.generate(1.0/0)
+  #   JSON.generate(JSON::Infinity)
   #   # Raises JSON::GeneratorError (917: -Infinity not allowed in JSON):
-  #   JSON.generate(-1.0/0)
+  #   JSON.generate(JSON::MinusInfinity)
   #
   # Allow:
-  #   ruby = [0.0/0, 1.0/0, -1.0/0]
+  #   ruby = [JSON::NaN, JSON::Infinity, JSON::MinusInfinity]
   #   JSON.generate(ruby, allow_nan: true) # => "[NaN,Infinity,-Infinity]"
   #
   # ---
@@ -507,10 +508,12 @@ module JSON
   # arguments +source+ and +opts+ in JSON.generate.
   #
   # Default options are:
-  # - +indent+: '  ' (two spaces)
-  # - +space+: ' ' (one space)
-  # - +array_no+: "\n" (newline)
-  # - +object_nl+: "\n" (newline)
+  #   {
+  #     indent: '  ',   # Two spaces
+  #     space: ' ',     # One space
+  #     array_nl: "\n", # Newline
+  #     object_nl: "\n" # Newline
+  #   }
   #
   # Example:
   #   source = {foo: [:bar, :baz], bat: {bam: 0, bad: 1}}
@@ -558,6 +561,7 @@ module JSON
     #  :max_nesting: false
     #  :allow_nan:   true
     #  :allow_blank:  true
+    #  :create_additions: true
     attr_accessor :load_default_options
   end
   self.load_default_options = {
@@ -619,7 +623,6 @@ module JSON
     # The global default options for the JSON.dump method:
     #  :max_nesting: false
     #  :allow_nan:   true
-    #  :allow_blank: true
     attr_accessor :dump_default_options
   end
   self.dump_default_options = {

--- a/ext/json/lib/json/common.rb
+++ b/ext/json/lib/json/common.rb
@@ -92,12 +92,12 @@ module JSON
     #   JSON.generator # => JSON::Ext::Generator
     attr_reader :generator
 
-    # Returns the JSON generator state class that is used by JSON. This is
+    # Sets or Returns the JSON generator state class that is used by JSON. This is
     # either JSON::Ext::Generator::State or JSON::Pure::Generator::State:
     #   JSON.state # => JSON::Ext::Generator::State
     attr_accessor :state
 
-    # This is create identifier, which is used to decide if the _json_create_
+    # Sets or returns create identifier, which is used to decide if the _json_create_
     # hook of a class should be called; initial value is +json_class+:
     #   JSON.create_id # => "json_class"
     attr_accessor :create_id
@@ -155,15 +155,15 @@ module JSON
   #
   # When +source+ is a \JSON array, returns a Ruby \Array:
   #   source = '["foo", 1.0, true, false, null]'
-  #   a = JSON.parse(source)
-  #   a # => ["foo", 1.0, true, false, nil]
-  #   a.class # => Array
+  #   ruby = JSON.parse(source)
+  #   ruby # => ["foo", 1.0, true, false, nil]
+  #   ruby.class # => Array
   #
   # When +source+ is a \JSON object, returns a Ruby \Hash:
   #   source = '{"a": "foo", "b": 1.0, "c": true, "d": false, "e": null}'
-  #   h = JSON.parse(source)
-  #   h # => {"a"=>"foo", "b"=>1.0, "c"=>true, "d"=>false, "e"=>nil}
-  #   h.class # => Hash
+  #   ruby = JSON.parse(source)
+  #   ruby # => {"a"=>"foo", "b"=>1.0, "c"=>true, "d"=>false, "e"=>nil}
+  #   ruby.class # => Hash
   #
   # For examples of parsing for all \JSON data types, see
   # {Parsing \JSON}[#module-JSON-label-Parsing+JSON].
@@ -175,11 +175,11 @@ module JSON
   #
   # With the default, +false+:
   #   source = '[0, [1, [2, [3]]]]'
-  #   a = JSON.parse(source)
-  #   a # => [0, [1, [2, [3]]]]
+  #   ruby = JSON.parse(source)
+  #   ruby # => [0, [1, [2, [3]]]]
   # Too deep:
   #   # Raises JSON::NestingError (nesting of 2 is too deep):
-  #   a = JSON.parse(source, {max_nesting: 1})
+  #   JSON.parse(source, {max_nesting: 1})
   # Bad value:
   #   # Raises TypeError (wrong argument type Symbol (expected Fixnum)):
   #   JSON.parse(source, {max_nesting: :foo})
@@ -192,18 +192,18 @@ module JSON
   #
   # With the default, +false+:
   #   # Raises JSON::ParserError (225: unexpected token at '[NaN]'):
-  #   a = JSON.parse('[NaN]')
+  #   JSON.parse('[NaN]')
   #   # Raises JSON::ParserError (232: unexpected token at '[Infinity]'):
-  #   a = JSON.parse('[Infinity]')
+  #   JSON.parse('[Infinity]')
   #   # Raises JSON::ParserError (248: unexpected token at '[-Infinity]'):
-  #   a = JSON.parse('[-Infinity]')
+  #   JSON.parse('[-Infinity]')
   # Allow:
   #   source = '[NaN, Infinity, -Infinity]'
-  #   a = JSON.parse(source, {allow_nan: true})
-  #   a # => [NaN, Infinity, -Infinity]
+  #   ruby = JSON.parse(source, {allow_nan: true})
+  #   ruby # => [NaN, Infinity, -Infinity]
   # With a truthy value:
-  #   a = JSON.parse(source, {allow_nan: :foo})
-  #   a # => [NaN, Infinity, -Infinity]
+  #   ruby = JSON.parse(source, {allow_nan: :foo})
+  #   ruby # => [NaN, Infinity, -Infinity]
   #
   # ---
   #
@@ -213,11 +213,11 @@ module JSON
   #
   # With the default, +false+:
   #   source = '{"a": "foo", "b": 1.0, "c": true, "d": false, "e": null}'
-  #   h = JSON.parse(source)
-  #   h # => {"a"=>"foo", "b"=>1.0, "c"=>true, "d"=>false, "e"=>nil}
+  #   ruby = JSON.parse(source)
+  #   ruby # => {"a"=>"foo", "b"=>1.0, "c"=>true, "d"=>false, "e"=>nil}
   # Use Symbols:
-  #   h = JSON.parse(source, {symbolize_names: true})
-  #   h # => {:a=>"foo", :b=>1.0, :c=>true, :d=>false, :e=>nil}
+  #   ruby = JSON.parse(source, {symbolize_names: true})
+  #   ruby # => {:a=>"foo", :b=>1.0, :c=>true, :d=>false, :e=>nil}
   #
   # ---
   #
@@ -227,11 +227,11 @@ module JSON
   #
   # With the default, \Hash:
   #   source = '{"a": "foo", "b": 1.0, "c": true, "d": false, "e": null}'
-  #   h = JSON.parse(source)
-  #   h.class # => Hash
+  #   ruby = JSON.parse(source)
+  #   ruby.class # => Hash
   # Use class \OpenStruct:
-  #   o = JSON.parse(source, {object_class: OpenStruct})
-  #   o # => #<OpenStruct a="foo", b=1.0, c=true, d=false, e=nil>
+  #   ruby = JSON.parse(source, {object_class: OpenStruct})
+  #   ruby # => #<OpenStruct a="foo", b=1.0, c=true, d=false, e=nil>
   # Try class \Object:
   #   # Raises NoMethodError (undefined method `[]=' for #<Object:>):
   #   JSON.parse(source, {object_class: Object})
@@ -247,11 +247,11 @@ module JSON
   #
   # With the default, \Array:
   #   source = '["foo", 1.0, true, false, null]'
-  #   a = JSON.parse(source)
-  #   a.class # => Array
+  #   ruby = JSON.parse(source)
+  #   ruby.class # => Array
   # Use class \Set:
-  #   s = JSON.parse(source, {array_class: Set})
-  #   s # => #<Set: {"foo", 1.0, true, false, nil}>
+  #   ruby = JSON.parse(source, {array_class: Set})
+  #   ruby # => #<Set: {"foo", 1.0, true, false, nil}>
   # Try class \Object:
   #   # Raises NoMethodError (undefined method `<<' for #<Object:>):
   #   JSON.parse(source, {array_class: Object})
@@ -301,7 +301,7 @@ module JSON
     Parser.new(source, **(opts||{})).parse
   end
 
-  # Argument +source+ is the Ruby object to be converted to \JSON.
+  # Argument +obj+ is the Ruby object to be converted to \JSON.
   #
   # Argument +opts+, if given, contains options for the generation, and must be a
   # {Hash-convertible object}[doc/implicit_conversion_rdoc.html#label-Hash-Convertible+Objects]
@@ -313,19 +313,19 @@ module JSON
   #
   # ---
   #
-  # When +source+ is an
+  # When +obj+ is an
   # {Array-convertible object}[doc/implicit_conversion_rdoc.html#label-Array-Convertible+Objects]
   # (implementing +to_ary+), returns a \String containing a \JSON array:
-  #   source = ["foo", 1.0, true, false, nil]
-  #   json = JSON.generate(source)
+  #   obj = ["foo", 1.0, true, false, nil]
+  #   json = JSON.generate(obj)
   #   json # => "[\"foo\",1.0,true,false,null]"
   #   json.class # => String
   #
-  # When +source+ is a
+  # When +obj+ is a
   # {Hash-convertible object}[doc/implicit_conversion_rdoc.html#label-Hash-Convertible+Objects],
   # return a \String containing a \JSON object:
-  #   source = {foo: 0, bar: 's', baz: :bat}
-  #   json = JSON.generate(source)
+  #   obj = {foo: 0, bar: 's', baz: :bat}
+  #   json = JSON.generate(obj)
   #   json # => "{\"foo\":0,\"bar\":\"s\",\"baz\":\"bat\"}"
   #
   # For examples of generating from other Ruby objects, see
@@ -355,12 +355,12 @@ module JSON
   #   inserted before the colon in each \JSON object's pair;
   #   defaults to the empty \String, <tt>''</tt>.
   #
-  # In this example, +source+ is used first to generate the shortest
+  # In this example, +obj+ is used first to generate the shortest
   # \JSON data (no whitespace), then again with all formatting options
   # specified:
   #
-  #   source = {foo: [:bar, :baz], bat: {bam: 0, bad: 1}}
-  #   json = JSON.generate(source)
+  #   obj = {foo: [:bar, :baz], bat: {bam: 0, bad: 1}}
+  #   json = JSON.generate(obj)
   #   puts 'Compact:', json
   #   opts = {
   #     array_nl: "\n",
@@ -369,7 +369,7 @@ module JSON
   #     space_before: ' ',
   #     space: ' '
   #   }
-  #   puts 'Open:', JSON.generate(source, opts)
+  #   puts 'Open:', JSON.generate(obj, opts)
   #
   # Output:
   #   Compact:
@@ -411,29 +411,29 @@ module JSON
   # ---
   #
   # Option +max_nesting+ (\Integer) specifies the maximum nesting depth
-  # in +source+; defaults to +100+.
+  # in +obj+; defaults to +100+.
   #
   # With the default, +100+:
-  #   source = [[[[[[0]]]]]]
-  #   JSON.generate(source) # => "[[[[[[0]]]]]]"
+  #   obj = [[[[[[0]]]]]]
+  #   JSON.generate(obj) # => "[[[[[[0]]]]]]"
   #
   # Too deep:
   #   # Raises JSON::NestingError (nesting of 2 is too deep):
-  #   JSON.generate(source, max_nesting: 2)
+  #   JSON.generate(obj, max_nesting: 2)
   #
   # Bad Value:
   #   # Raises TypeError (can't convert Symbol into Hash):
-  #   JSON.generate(source, :foo)
+  #   JSON.generate(obj, :foo)
   #
   # ---
   #
-  # Raises an exception if +source+ is not a valid Ruby object:
+  # Raises an exception if +obj+ is not a valid Ruby object:
   #   # Raises NameError (uninitialized constant Foo):
   #   JSON.generate(Foo)
   #   # Raises NameError (undefined local variable or method `foo' for main:Object):
   #   JSON.generate(foo)
   #
-  # Raises an exception if +source+ contains circular references:
+  # Raises an exception if +obj+ contains circular references:
   #   a = []; b = []; a.push(b); b.push(a)
   #   # Raises JSON::NestingError (nesting of 100 is too deep):
   #   JSON.generate(a)
@@ -470,12 +470,12 @@ module JSON
   # :startdoc:
 
   # Arguments +obj+ and +opts+ here are the same as
-  # arguments +source+ and +opts+ in JSON.generate.
+  # arguments +obj+ and +opts+ in JSON.generate.
   #
   # By default, generates \JSON data without checking
   # for circular references in +obj+ (option +max_nesting+ set to +false+, disabled).
   #
-  # Raises an exception if +source+ contains circular references:
+  # Raises an exception if +obj+ contains circular references:
   #   a = []; b = []; a.push(b); b.push(a)
   #   # Raises SystemStackError (stack level too deep):
   #   JSON.fast_generate(a)
@@ -505,7 +505,7 @@ module JSON
   # :startdoc:
 
   # Arguments +obj+ and +opts+ here are the same as
-  # arguments +source+ and +opts+ in JSON.generate.
+  # arguments +obj+ and +opts+ in JSON.generate.
   #
   # Default options are:
   #   {
@@ -516,8 +516,8 @@ module JSON
   #   }
   #
   # Example:
-  #   source = {foo: [:bar, :baz], bat: {bam: 0, bad: 1}}
-  #   json = JSON.pretty_generate(source)
+  #   obj = {foo: [:bar, :baz], bat: {bam: 0, bad: 1}}
+  #   json = JSON.pretty_generate(obj)
   #   puts json
   # Output:
   #   {
@@ -557,11 +557,10 @@ module JSON
   # :startdoc:
 
   class << self
-    # The global default options for the JSON.load method:
-    #  :max_nesting: false
-    #  :allow_nan:   true
-    #  :allow_blank:  true
-    #  :create_additions: true
+    # Sets or returns default options for the JSON.load method.
+    # Initially:
+    #   opts = JSON.load_default_options
+    #   opts # => {:max_nesting=>false, :allow_nan=>true, :allow_blank=>true, :create_additions=>true}
     attr_accessor :load_default_options
   end
   self.load_default_options = {
@@ -620,9 +619,10 @@ module JSON
   module_function :restore
 
   class << self
-    # The global default options for the JSON.dump method:
-    #  :max_nesting: false
-    #  :allow_nan:   true
+    # Sets or returns the default options for the JSON.dump method.
+    # Initially:
+    #   opts = JSON.dump_default_options
+    #   opts # => {:max_nesting=>false, :allow_nan=>true}
     attr_accessor :dump_default_options
   end
   self.dump_default_options = {

--- a/ext/json/lib/json/common.rb
+++ b/ext/json/lib/json/common.rb
@@ -337,7 +337,7 @@ module JSON
   #
   # You can use these formatting options to generate
   # \JSON data in a more open format, using whitespace.
-  # See also #pretty_generate.
+  # See also JSON.pretty_generate.
   #
   # - Option +array_nl+ (\String) specifies a string (usually a newline)
   #   to be inserted after each \JSON array; defaults to the empty \String, <tt>''</tt>.
@@ -663,7 +663,7 @@ module JSON
     raise ArgumentError, "exceed depth limit"
   end
 
-  # Encodes string using Ruby's _String.encode_
+  # Encodes string using String.encode.
   def self.iconv(to, from, string)
     string.encode(to, from)
   end

--- a/ext/json/lib/json/common.rb
+++ b/ext/json/lib/json/common.rb
@@ -174,35 +174,37 @@ module JSON
   #
   # ---
   #
-  # * *array_class*: Defaults to Array
-  # * *max_nesting*: The maximum depth of nesting allowed in the parsed data
-  #   structures. Disable depth checking with :max_nesting => false. It
-  #   defaults to 100.
-  # * *object_class*: Defaults to Hash
-  # * *symbolize_names*: If set to true, returns symbols for the names
-  #   (keys) in a JSON object. Otherwise strings are returned. Strings are
-  #   the default.
-  # * *max_nesting*: The maximum depth of nesting allowed in the parsed data
-  #   structures. Disable depth checking with :max_nesting => false. It
-  #   defaults to 100.
-  #
-  # ---
-  #
   # Raises an exception if +source+ is not \String-convertible:
   #
-  #   Raises TypeError (no implicit conversion of Symbol into String):
+  #   # Raises TypeError (no implicit conversion of Symbol into String):
   #   JSON.parse(:foo)
   #
   # Raises an exception if +opts+ is not \Hash-convertible:
   #
-  #   Raises TypeError (no implicit conversion of Symbol into Hash):
+  #   # Raises TypeError (no implicit conversion of Symbol into Hash):
   #   JSON.parse(['foo'], :foo)
   #
   # Raises an exception if +source+ is not valid JSON:
   #
-  #   Raises JSON::ParserError (783: unexpected token at ''):
+  #   # Raises JSON::ParserError (783: unexpected token at ''):
   #   JSON.parse('')
   #
+  # _opts_ can have the following
+  # keys:
+  # * *max_nesting*: The maximum depth of nesting allowed in the parsed data
+  #   structures. Disable depth checking with :max_nesting => false. It
+  #   defaults to 100.
+  # * *allow_nan*: If set to true, allow NaN, Infinity and -Infinity in
+  #   defiance of RFC 7159 to be parsed by the Parser. This option defaults
+  #   to false.
+  # * *symbolize_names*: If set to true, returns symbols for the names
+  #   (keys) in a JSON object. Otherwise strings are returned. Strings are
+  #   the default.
+  # * *create_additions*: If set to false, the Parser doesn't create
+  #   additions even if a matching class and create_id was found. This option
+  #   defaults to false.
+  # * *object_class*: Defaults to Hash
+  # * *array_class*: Defaults to Array
   def parse(source, opts = {})
     Parser.new(source, **(opts||{})).parse
   end
@@ -253,17 +255,17 @@ module JSON
   #
   # Raises an exception if +source+ is not \String-convertible:
   #
-  #   Raises TypeError (no implicit conversion of Symbol into String):
+  #   # Raises TypeError (no implicit conversion of Symbol into String):
   #   JSON.parse!(:foo)
   #
   # Raises an exception if +opts+ is not \Hash-convertible:
   #
-  #   Raises TypeError (no implicit conversion of Symbol into Hash):
+  #   # Raises TypeError (no implicit conversion of Symbol into Hash):
   #   JSON.parse!(['foo'], :foo)
   #
   # Raises an exception if +source+ is not valid JSON:
   #
-  #   Raises JSON::ParserError (783: unexpected token at ''):
+  #   # Raises JSON::ParserError (783: unexpected token at ''):
   #   JSON.parse!('')
   #
   # Parse the JSON document _source_ into a Ruby data structure and return it.

--- a/ext/json/lib/json/common.rb
+++ b/ext/json/lib/json/common.rb
@@ -4,12 +4,15 @@ require 'json/generic_object'
 
 module JSON
   class << self
-    # If _object_ is string-like, parse the string and return the parsed
-    # result as a Ruby data structure. Otherwise generate a JSON text from the
-    # Ruby data structure object and return it.
+    # If +object+ is a
+    # {String-convertible object}[doc/implicit_conversion_rdoc.html#label-String-Convertible+Objects]
+    # (implementing +to_str+), calls #parse with +object+ and +opts+:
+    #   json = '[0, 1, null]' # => [0, 1, nil]
+    #   JSON[json]
     #
-    # The _opts_ argument is passed through to generate/parse respectively.
-    # See generate and parse for their documentation.
+    # Otherwise, calls #generate with +object+ and +opts+:
+    #   ruby = [0, 1, nil] # => "[0,1,null]"
+    #   JSON[ruby]
     def [](object, opts = {})
       if object.respond_to? :to_str
         JSON.parse(object.to_str, opts)
@@ -163,8 +166,7 @@ module JSON
   #
   # ====== Options
   #
-  #
-  # Option +:max_nesting+ specifies the maximum nesting depth allowed;
+  # Option +:max_nesting+ (\Integer) specifies the maximum nesting depth allowed;
   # defaults to +100+; specify +false+ to disable depth checking.
   #
   # With the default, +false+:
@@ -180,7 +182,7 @@ module JSON
   #
   # ---
   #
-  # Option +allow_nan+ specifies whether to allow
+  # Option +allow_nan+ (boolean) specifies whether to allow
   # +NaN+, +Infinity+, and +-Infinity+ in +source+;
   # defaults to +false+.
   #
@@ -204,7 +206,7 @@ module JSON
   #
   # ---
   #
-  # Option +symbolize_names+ specifies whether returned \Hash keys
+  # Option +symbolize_names+ (boolean) specifies whether returned \Hash keys
   # should be Symbols;
   # defaults to +false+ (use Strings).
   #
@@ -218,7 +220,7 @@ module JSON
   #
   # ---
   #
-  # Option +object_class+ specifies the Ruby class to be used
+  # Option +object_class+ (\Class) specifies the Ruby class to be used
   # for each \JSON object;
   # defaults to \Hash.
   #
@@ -238,7 +240,7 @@ module JSON
   #
   # ---
   #
-  # Option +array_class+ specifies the Ruby class to be used
+  # Option +array_class+ (\Class) specifies the Ruby class to be used
   # for each \JSON array;
   # defaults to \Array.
   #
@@ -258,7 +260,7 @@ module JSON
   #
   # ---
   #
-  # Option +create_additions+ specifies whether to use \JSON additions in parsing.
+  # Option +create_additions+ (boolean) specifies whether to use \JSON additions in parsing.
   # See {\JSON Additions}[#module-JSON-label-JSON+Additions].
   #
   # ====== Exceptions
@@ -326,7 +328,71 @@ module JSON
   # For examples of generating from other Ruby objects, see
   # {Generating \JSON}[#module-JSON-label-Generating+JSON].
   #
-  # ====== Options
+  # ====== Formatting Options
+  #
+  # The default formatting options generate the most compact
+  # \JSON data, all on one line and with no whitespace.
+  #
+  # You can use these formatting options to generate
+  # \JSON data in a more open format, using whitespace.
+  # See also #pretty_generate.
+  #
+  # Option +array_nl+ (\String) specifies a string (usually a newline)
+  # to be inserted after each \JSON array; defaults to the empty \String, <tt>''</tt>.
+  #
+  # Option +object_nl+ (\String) specifies a string (usually a newline)
+  # to be inserted after each \JSON object; defaults to the empty \String, <tt>''</tt>.
+  #
+  # Option +indent+ (\String) specifies the string (usually spaces) to be
+  # used for indentation; defaults to the empty \String, <tt>''</tt>;
+  # defaults to the empty \String, <tt>''</tt>;
+  # has no effect unless options +array_nl+ or +object_nl+ specify newlines.
+  #
+  # Option +space+ (\String) specifies a string (usually a space) to be
+  # inserted after the colon in each \JSON object's pair;
+  # defaults to the empty \String, <tt>''</tt>.
+  #
+  # Option +space_before+ (\String) specifies a string (usually a space) to be
+  # inserted before the colon in each \JSON object's pair;
+  # defaults to the empty \String, <tt>''</tt>.
+  #
+  # In this example, +source+ is used first to generate the shortest
+  # \JSON data (no whitespace), then again with all formatting options
+  # specified:
+  #
+  #   source = {foo: [:bar, :baz], bat: {bam: 0, bad: 1}}
+  #   json = JSON.generate(source)
+  #   puts 'Compact:', json
+  #   opts = {
+  #     array_nl: "\n",
+  #     object_nl: "\n",
+  #     indent: '  ',
+  #     space_before: ' ',
+  #     space: ' '
+  #   }
+  #   puts 'Open:', JSON.generate(source, opts)
+  #
+  # Output:
+  #   Compact:
+  #   {"foo":["bar","baz"],"bat":{"bam":0,"bad":1}}
+  #   Open:
+  #   {
+  #     "foo" : [
+  #     "bar",
+  #     "baz"
+  #   ],
+  #     "bat" : {
+  #     "bam" : 0,
+  #     "bad" : 1
+  #     }
+  #   }
+  #
+  # * *allow_nan*: true if NaN, Infinity, and -Infinity should be
+  #   generated, otherwise an exception is thrown if these values are
+  #   encountered. This options defaults to false.
+  # * *max_nesting*: The maximum depth of nesting allowed in the data
+  #   structures from which JSON is to be generated. Disable depth checking
+  #   with <tt>max_nesting: false</tt>, it defaults to 100.
   #
   # The default options are set to create the shortest possible JSON text
   # in one line, check for circular data structures and do not allow NaN,


### PR DESCRIPTION
Enhancements in json.rb:
* Added JSON types.
* More examples for JSON.parse and JSON.generate.
* Examples for all JSON additions.
* Example custom JSON addition.

Enhancements in common.rb:
* More examples for JSON.generate, its options, and its exceptions.
* More examples for JSON.parse, its options, and its exceptions.
* Example for JSON.pretty_generate.

Not enhanced:  JSON.restore, JSON.dump, JSON.load, JSON.recurse_proc.

If preferred, I can put up a PR with just json.rb.
Also if preferred, I can put up piecemeal PRs for common.rb.
