### PR TITLE
Fix rb_profile_frame_classpath to handle module singletons

### DIFF
--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -1425,7 +1425,7 @@ rb_profile_frame_classpath(VALUE frame)
 	}
 	else if (FL_TEST(klass, FL_SINGLETON)) {
 	    klass = rb_ivar_get(klass, id__attached__);
-	    if (!RB_TYPE_P(klass, T_CLASS))
+	    if (!RB_TYPE_P(klass, T_CLASS) && !RB_TYPE_P(klass, T_MODULE))
 		return rb_sprintf("#<%s:%p>", rb_class2name(rb_obj_class(klass)), (void*)klass);
 	}
 	return rb_class_path(klass);


### PR DESCRIPTION
Ruby issue: https://bugs.ruby-lang.org/issues/16834

Right now `SomeClass.method` is properly named, but `SomeModule.method`
is displayed as `#<Module:0x000055eb5d95adc8>.method` which makes
profiling annoying.

This particularly impact StackProf.

cc @tenderlove @XrXr 