### PR TITLE
`T_MOVED` should never be pushed on the mark stack

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -4590,6 +4590,7 @@ push_mark_stack(mark_stack_t *stack, VALUE data)
     switch (BUILTIN_TYPE(obj)) {
       case T_NIL:
       case T_FIXNUM:
+      case T_MOVED:
 	rb_bug("push_mark_stack() called for broken object");
 	break;
 


### PR DESCRIPTION
No objects should ever reference a `T_MOVED` slot.  If they do, it's
absolutely a bug.  If we kill the process when `T_MOVED` is pushed on
the mark stack it will make it easier to identify which object holds a
reference that hasn't been updated.