### PR TITLE
Allow global variables to move

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -8491,6 +8491,7 @@ gc_update_references(rb_objspace_t * objspace)
     objspace_each_objects_without_setup(objspace, gc_ref_update, objspace);
     rb_vm_update_references(vm);
     rb_transient_heap_update_references();
+    rb_gc_update_global_tbl();
     global_symbols.ids = rb_gc_location(global_symbols.ids);
     global_symbols.dsymbol_fstr_hash = rb_gc_location(global_symbols.dsymbol_fstr_hash);
     gc_update_tbl_refs(objspace, objspace->obj_to_id_tbl);

--- a/internal/variable.h
+++ b/internal/variable.h
@@ -28,6 +28,7 @@ struct rb_global_entry {
 
 /* variable.c */
 void rb_gc_mark_global_tbl(void);
+void rb_gc_update_global_tbl(void);
 size_t rb_generic_ivar_memsize(VALUE);
 VALUE rb_search_class_path(VALUE);
 VALUE rb_attr_delete(VALUE, ID);


### PR DESCRIPTION
This patch allows global variables that have been assigned in Ruby to
move.  I added a new function for the GC to call that will update
global references and introduced a new callback in the global variable
struct for updating references.

Only pure Ruby global variables are supported right now, other
references will be pinned.