### PR TITLE
Remove the 65 size limit for name_err_mesg_to_str

### DIFF
--- a/error.c
+++ b/error.c
@@ -1791,7 +1791,7 @@ name_err_mesg_to_str(VALUE obj)
 	    d = rb_protect(rb_inspect, obj, &state);
 	    if (state)
 		rb_set_errinfo(Qnil);
-	    if (NIL_P(d) || RSTRING_LEN(d) > 65) {
+	    if (NIL_P(d)) {
 		d = rb_any_to_s(obj);
 	    }
 	    singleton = (RSTRING_LEN(d) > 0 && RSTRING_PTR(d)[0] == '#');

--- a/test/ruby/test_name_error.rb
+++ b/test/ruby/test_name_error.rb
@@ -127,4 +127,17 @@ class TestNameError < Test::Unit::TestCase
       -> {require ARGV[0]}.call
     end;
   end
+
+  def test_large_receiver_inspect
+    receiver = Class.new do
+      def self.inspect
+        'A' * 120
+      end
+    end
+
+    error = assert_raise(NameError) do
+      receiver::FOO
+    end
+    assert_equal "uninitialized constant #{'A' * 120}::FOO", error.message
+  end
 end


### PR DESCRIPTION
This limit was introduced on Nov 20 1996
in 554b989ba1623b9f6a0b76f00824c83a23fbcbc1

Apparently to protect from a buffer overflow:

  * eval.c (f_missing): オブジェクトの文字列表現が長すぎる時バッファ
	  を書き潰していた

However I tested that path with very large strings
and it works fine.

See https://bugs.ruby-lang.org/issues/16832 for more context