### PR TITLE
Fix typo in test name

### DIFF
--- a/test/ruby/test_defined.rb
+++ b/test/ruby/test_defined.rb
@@ -23,7 +23,7 @@ class TestDefined < Test::Unit::TestCase
     return !defined?(yield)
   end
 
-  def test_defined_gloval_variable
+  def test_defined_global_variable
     $x = nil
 
     assert(defined?($x))		# global variable


### PR DESCRIPTION
Fix typo in test from `test_defined_gloval_variable` to `test_defined_global_variable`.