### PR TITLE
support builtin for global function Complex

### DIFF
--- a/.document
+++ b/.document
@@ -12,6 +12,7 @@ prelude.rb
 rbconfig.rb
 array.rb
 ast.rb
+complex.rb
 dir.rb
 gc.rb
 io.rb

--- a/benchmark/complex.yml
+++ b/benchmark/complex.yml
@@ -1,0 +1,8 @@
+benchmark:
+  complex: "Complex(1, 2)"
+  complex_exception_true: "Complex(1, 2, exception: true)"
+  complex_exception_false: "Complex(1, 2, exception: false)"
+  str_complex: "Complex('1+2i')"
+  str_complex_exception_true: "Complex('1+2i', exception: true)"
+  str_complex_exception_false: "Complex('1+2i', exception: false)"
+loop_count: 100000 

--- a/common.mk
+++ b/common.mk
@@ -1007,6 +1007,7 @@ BUILTIN_RB_SRCS = \
 		$(srcdir)/trace_point.rb \
 		$(srcdir)/warning.rb \
 		$(srcdir)/array.rb \
+		$(srcdir)/complex.rb \
 		$(srcdir)/kernel.rb \
 		$(srcdir)/prelude.rb \
 		$(srcdir)/gem_prelude.rb \
@@ -3157,7 +3158,9 @@ complex.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 complex.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 complex.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 complex.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
+complex.$(OBJEXT): {$(VPATH)}builtin.h
 complex.$(OBJEXT): {$(VPATH)}complex.c
+complex.$(OBJEXT): {$(VPATH)}complex.rbinc
 complex.$(OBJEXT): {$(VPATH)}config.h
 complex.$(OBJEXT): {$(VPATH)}defines.h
 complex.$(OBJEXT): {$(VPATH)}encoding.h
@@ -8199,6 +8202,7 @@ miniinit.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 miniinit.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 miniinit.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 miniinit.$(OBJEXT): {$(VPATH)}builtin.h
+miniinit.$(OBJEXT): {$(VPATH)}complex.rb
 miniinit.$(OBJEXT): {$(VPATH)}config.h
 miniinit.$(OBJEXT): {$(VPATH)}defines.h
 miniinit.$(OBJEXT): {$(VPATH)}dir.rb

--- a/complex.rb
+++ b/complex.rb
@@ -1,0 +1,42 @@
+module Kernel
+  module_function
+  #
+  # call-seq:
+  #    Complex(x[, y], exception: true)  ->  numeric or nil
+  #
+  # Returns x+i*y;
+  #
+  #    Complex(1, 2)    #=> (1+2i)
+  #    Complex('1+2i')  #=> (1+2i)
+  #    Complex(nil)     #=> TypeError
+  #    Complex(1, nil)  #=> TypeError
+  #
+  #    Complex(1, nil, exception: false)  #=> nil
+  #    Complex('1+2', exception: false)   #=> nil
+  #
+  # Syntax of string form:
+  #
+  #   string form = extra spaces , complex , extra spaces ;
+  #   complex = real part | [ sign ] , imaginary part
+  #           | real part , sign , imaginary part
+  #           | rational , "@" , rational ;
+  #   real part = rational ;
+  #   imaginary part = imaginary unit | unsigned rational , imaginary unit ;
+  #   rational = [ sign ] , unsigned rational ;
+  #   unsigned rational = numerator | numerator , "/" , denominator ;
+  #   numerator = integer part | fractional part | integer part , fractional part ;
+  #   denominator = digits ;
+  #   integer part = digits ;
+  #   fractional part = "." , digits , [ ( "e" | "E" ) , [ sign ] , digits ] ;
+  #   imaginary unit = "i" | "I" | "j" | "J" ;
+  #   sign = "-" | "+" ;
+  #   digits = digit , { digit | "_" , digit };
+  #   digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
+  #   extra spaces = ? \s* ? ;
+  #
+  # See String#to_c.
+  #
+  def Complex(*args, exception: true)
+    __builtin_nucomp_f_complex(args, exception)
+  end
+end

--- a/inits.c
+++ b/inits.c
@@ -89,8 +89,8 @@ rb_call_inits(void)
 #ifndef complex
 #undef complex
     BUILTIN(complex);
-#endif
 #define complex _complex
+#endif
     Init_builtin_prelude();
 }
 #undef CALL

--- a/inits.c
+++ b/inits.c
@@ -86,6 +86,11 @@ rb_call_inits(void)
     BUILTIN(warning);
     BUILTIN(array);
     BUILTIN(kernel);
+#ifndef complex
+#undef complex
+    BUILTIN(complex);
+#endif
+#define complex _complex
     Init_builtin_prelude();
 }
 #undef CALL

--- a/inits.c
+++ b/inits.c
@@ -17,7 +17,7 @@ static void Init_builtin_prelude(void);
 
 #define CALL(n) {void Init_##n(void); Init_##n();}
 
-#ifndef complex
+#ifdef complex
 #undef complex
 #endif
 
@@ -95,4 +95,6 @@ rb_call_inits(void)
 }
 #undef CALL
 
-#define complex _complex
+#ifndef complex
+#undef complex
+#endif

--- a/inits.c
+++ b/inits.c
@@ -17,6 +17,10 @@ static void Init_builtin_prelude(void);
 
 #define CALL(n) {void Init_##n(void); Init_##n();}
 
+#ifndef complex
+#undef complex
+#endif
+
 void
 rb_call_inits(void)
 {
@@ -86,11 +90,9 @@ rb_call_inits(void)
     BUILTIN(warning);
     BUILTIN(array);
     BUILTIN(kernel);
-#ifndef complex
-#undef complex
     BUILTIN(complex);
-#define complex _complex
-#endif
     Init_builtin_prelude();
 }
 #undef CALL
+
+#define complex _complex


### PR DESCRIPTION
Support builtin for `Complex()`.

This patch is a bit faster(given execption keyword args cases).

benchmark:
```yml
benchmark:
  complex: "Complex(1, 2)"
  complex_exception_true: "Complex(1, 2, exception: true)"
  complex_exception_false: "Complex(1, 2, exception: false)"
  str_complex: "Complex('1+2i')"
  str_complex_exception_true: "Complex('1+2i', exception: true)"
  str_complex_exception_false: "Complex('1+2i', exception: false)"
loop_count: 100000 

```

result:
```bash
sh@MyComputer:/mnt/c/users/shunh/desktop/rubydev/build$ make benchmark/complex.yml -e BASE_RUBY=../install/bin/ruby -e COMPARE_RUBY=~/.rbenv/shims/ruby
generating known_errors.inc
known_errors.inc unchanged
../ruby/revision.h updated
compiling ../ruby/version.c
linking miniruby
Calculating -------------------------------------
                            compare-ruby  built-ruby
                    complex      11.829M      3.041M i/s -    100.000k times in 0.008454s 0.032881s
     complex_exception_true       2.717M      3.802M i/s -    100.000k times in 0.036802s 0.026305s
    complex_exception_false       3.003M      3.799M i/s -    100.000k times in 0.033296s 0.026320s
                str_complex       3.896M      2.360M i/s -    100.000k times in 0.025666s 0.042367s
 str_complex_exception_true       1.661M      2.301M i/s -    100.000k times in 0.060204s 0.043454s
str_complex_exception_false       1.643M      2.032M i/s -    100.000k times in 0.060868s 0.049209s

Comparison:
                                 complex
               compare-ruby:  11828720.1 i/s
                 built-ruby:   3041251.5 i/s - 3.89x  slower

                  complex_exception_true
                 built-ruby:   3801515.3 i/s
               compare-ruby:   2717273.2 i/s - 1.40x  slower

                 complex_exception_false
                 built-ruby:   3799406.5 i/s
               compare-ruby:   3003327.7 i/s - 1.27x  slower

                             str_complex
               compare-ruby:   3896159.6 i/s
                 built-ruby:   2360327.6 i/s - 1.65x  slower

              str_complex_exception_true
                 built-ruby:   2301273.5 i/s
               compare-ruby:   1661016.4 i/s - 1.39x  slower

             str_complex_exception_false
                 built-ruby:   2032152.7 i/s
               compare-ruby:   1642891.3 i/s - 1.24x  slower
```
`BASE_RUBY` is ahead of `e88bb6a2f7`(`COMPAE_RUBY` is `ruby 2.8.0dev (2020-05-08T16:43:53Z master e88bb6a2f7) [x86_64-linux]`)