### PR TITLE
.github: use actions/checkout@v2 again

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -13,17 +13,10 @@ jobs:
         run: |
           sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate off
           sudo /usr/libexec/ApplicationFirewall/socketfilterfw --getglobalstate
-      # Not using official actions/checkout because it's unstable and sometimes doesn't work for a fork.
-      - name: Checkout ruby
-        run: |
-          git clone --single-branch --shallow-since=yesterday --branch=${GITHUB_REF#refs/heads/} https://github.com/${{ github.repository }} src
-          git -C src reset --hard "$GITHUB_SHA"
-        if: github.event_name == 'push'
-      - name: Checkout a pull request
-        run: |
-          git clone --single-branch --depth=50 --branch=${{ github.event.pull_request.head.ref }} https://github.com/${{ github.event.pull_request.head.repo.full_name }} src
-          git -C src reset --hard ${{ github.event.pull_request.head.sha }}
-        if: github.event_name == 'pull_request'
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 128
+          path: src
       - run: ./src/tool/actions-commit-info.sh
         id: commit_info
       - name: Install libraries

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -27,19 +27,10 @@ jobs:
         run: |
           git config --system core.autocrlf false
           git config --system core.eol lf
-      # Not using official actions/checkout@v2 because it's unstable.
-      - name: Checkout ruby
-        run: |
-          git clone --single-branch --shallow-since=yesterday --branch=${GITHUB_REF#refs/heads/} https://github.com/${{ github.repository }} src
-          git -C src reset --hard "$GITHUB_SHA"
-        if: github.event_name == 'push'
-        shell: bash
-      - name: Checkout a pull request
-        run: |
-          git clone --single-branch --depth=50 --branch=${{ github.event.pull_request.head.ref }} https://github.com/${{ github.event.pull_request.head.repo.full_name }} src
-          git -C src reset --hard ${{ github.event.pull_request.head.sha }}
-        if: github.event_name == 'pull_request'
-        shell: bash
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 128
+          path: src
       - run: ./src/tool/actions-commit-info.sh
         shell: bash
         id: commit_info

--- a/.github/workflows/mjit.yml
+++ b/.github/workflows/mjit.yml
@@ -18,17 +18,10 @@ jobs:
           set -x
           sudo apt-get update -q || :
           sudo apt-get install --no-install-recommends -q -y build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm-dev bison autoconf ruby
-      # Not using official actions/checkout because it's unstable and sometimes doesn't work for a fork.
-      - name: Checkout ruby
-        run: |
-          git clone --single-branch --shallow-since=yesterday --branch=${GITHUB_REF#refs/heads/} https://github.com/${{ github.repository }} src
-          git -C src reset --hard "$GITHUB_SHA"
-        if: github.event_name == 'push'
-      - name: Checkout a pull request
-        run: |
-          git clone --single-branch --depth=50 --branch=${{ github.event.pull_request.head.ref }} https://github.com/${{ github.event.pull_request.head.repo.full_name }} src
-          git -C src reset --hard ${{ github.event.pull_request.head.sha }}
-        if: github.event_name == 'pull_request'
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 128
+          path: src
       - run: ./src/tool/actions-commit-info.sh
         id: commit_info
       - name: Fixed world writable dirs

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -24,17 +24,10 @@ jobs:
           set -x
           sudo apt-get update -q || :
           sudo apt-get install --no-install-recommends -q -y build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm-dev bison autoconf ruby
-      # Not using official actions/checkout because it's unstable and sometimes doesn't work for a fork.
-      - name: Checkout ruby
-        run: |
-          git clone --single-branch --shallow-since=yesterday --branch=${GITHUB_REF#refs/heads/} https://github.com/${{ github.repository }} src
-          git -C src reset --hard "$GITHUB_SHA"
-        if: github.event_name == 'push'
-      - name: Checkout a pull request
-        run: |
-          git clone --single-branch --depth=50 --branch=${{ github.event.pull_request.head.ref }} https://github.com/${{ github.event.pull_request.head.repo.full_name }} src
-          git -C src reset --hard ${{ github.event.pull_request.head.sha }}
-        if: github.event_name == 'pull_request'
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 128
+          path: src
       - run: ./src/tool/actions-commit-info.sh
         id: commit_info
       - name: Fixed world writable dirs

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -31,18 +31,10 @@ jobs:
       - name: Install libraries with chocolatey
         run: |
           choco install --no-progress openssl winflexbison3
-      # Not using official actions/checkout because it's unstable and sometimes doesn't work for a fork.
-      - name: Checkout ruby
-        run: |
-          git clone --single-branch --shallow-since=yesterday --branch=${GITHUB_REF#refs/heads/} https://github.com/${{ github.repository }} src
-          git -C src reset --hard ${{ github.sha }}
-        if: github.event_name == 'push'
-        shell: bash
-      - name: Checkout a pull request
-        run: |
-          git clone --single-branch --depth=50 --branch=${{ github.event.pull_request.head.ref }} https://github.com/${{ github.event.pull_request.head.repo.full_name }} src
-          git -C src reset --hard ${{ github.event.pull_request.head.sha }}
-        if: github.event_name == 'pull_request'
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 128
+          path: src
       - run: ./src/tool/actions-commit-info.sh
         shell: bash
         id: commit_info


### PR DESCRIPTION
Have you noticed that [I silently resurrected actions/checkout@v2](https://github.com/ruby/ruby/blob/15e977349e31389515bccf7a9684005a0c36e02d/.github/workflows/compilers.yml#L152-L155) more than a month ago?  It seems working.  I see [failures](https://github.com/ruby/ruby/actions?query=workflow%3ACompilations+is%3Afailure) are not related to this at all.

Maybe time to reconsider?