### PR TITLE
Raise timeout for test_queue_with_trap

### DIFF
--- a/test/ruby/test_thread_queue.rb
+++ b/test/ruby/test_thread_queue.rb
@@ -564,7 +564,7 @@ class TestThreadQueue < Test::Unit::TestCase
       skip 'This test fails too often on MinGW'
     end
 
-    assert_in_out_err([], <<-INPUT, %w(INT INT exit), [])
+    assert_in_out_err([], <<-INPUT, %w(INT INT exit), [], **{:timeout => 60})
       q = Queue.new
       trap(:INT){
         q.push 'INT'


### PR DESCRIPTION
as it fails to finish in 10s in various CIs.