### PR TITLE
Optimize String#split

### DIFF
--- a/benchmark/string_split.yml
+++ b/benchmark/string_split.yml
@@ -1,7 +1,18 @@
 prelude: |
-  str0 = [*0..9].join("")
+  str1 = [*0..5].join(" ") + " "
+  str10 = str1 * 10
+  str100 = str10 * 10
+  str1000 = str100 * 10
 benchmark:
-  to_chars-1: str0.split('')
-  to_chars-10: (str0 * 10).split('')
-  to_chars-100: (str0 * 100).split('')
-  to_chars-1000: (str0 * 1000).split('')
+  to_chars-1: str1.split('')
+  to_chars-10: str10.split('')
+  to_chars-100: str100.split('')
+  to_chars-1000: str1000.split('')
+  to_words-1: str1.split(' ')
+  to_words-10: str10.split(' ')
+  to_words-100: str100.split(' ')
+  to_words-1000: str1000.split(' ')
+  re_space-1: str1.split(/ /)
+  re_space-10: str10.split(/ /)
+  re_space-100: str100.split(/ /)
+  re_space-1000: str1000.split(/ /)


### PR DESCRIPTION
Optimized `String#split` with `/ /` (single space regexp) as simple string splitting.  [ruby-core:98272](https://bugs.ruby-lang.org/issues/15771#change-85511)

|               |compare-ruby|built-ruby|
|:--------------|-----------:|---------:|
|re_space-1     |    432.786k|    1.539M|
|               |           -|     3.56x|
|re_space-10    |     76.231k|  191.547k|
|               |           -|     2.51x|
|re_space-100   |      8.152k|   19.557k|
|               |           -|     2.40x|
|re_space-1000  |     837.405|    2.022k|
|               |           -|     2.41x|
