### PR TITLE
speeding up for Array#none? matching case

### DIFF
--- a/array.c
+++ b/array.c
@@ -6354,7 +6354,7 @@ rb_ary_none_p(int argc, VALUE *argv, VALUE ary)
             rb_warn("given block not used");
         }
         for (i = 0; i < RARRAY_LEN(ary); ++i) {
-            if (RTEST(rb_funcall(argv[0], idEqq, 1, RARRAY_AREF(ary, i)))) return Qfalse;
+            if (RTEST(rb_equal(argv[0], RARRAY_AREF(ary, i)))) return Qfalse;
         }
     }
     else if (!rb_block_given_p()) {

--- a/benchmark/array_none_match.yml
+++ b/benchmark/array_none_match.yml
@@ -1,0 +1,6 @@
+prelude: |
+  ary = [1, 2, 3]
+benchmark:
+  none_match: |
+    ary.none? 3
+loop_count: 10000


### PR DESCRIPTION
Using `rb_equal` instead of `rb_funcall` with `idEqq`, that speeding up for Array#none? in matching cases.

`benchmark`:

```yml
prelude: |
  ary = [1, 2, 3]
benchmark:
  none_match: |
    ary.none? 3
loop_count: 10000
```

`result`:
```bash
sh@MyComputer:/mnt/c/Users/sh/Desktop/rubydev/build$ make benchmark/array_none_match.yml -e BASE_RUBY=../install/bin/ruby -e COMPARE_RUBY=~/.rbenv/shims/ruby
generating known_errors.inc
known_errors.inc unchanged
generating vm_call_iseq_optimized.inc
vm_call_iseq_optimized.inc unchanged
Calculating -------------------------------------
                     compare-ruby  built-ruby
          none_match       3.778M     11.045M i/s -     10.000k times in 0.002647s 0.000905s

Comparison:
                       none_match
          built-ruby:  11044842.1 i/s
        compare-ruby:   3778147.2 i/s - 2.92x  slower

```

`COMPARE_RUBY` is `ruby 2.8.0dev (2020-05-13T01:57:14Z master b68dab8667) [x86_64-linux]`. This patch is ahead of `ruby 2.8.0dev (2020-05-13T01:57:14Z master b68dab8667) [x86_64-linux]`.