### PR TITLE
fix for multi-run test.

### DIFF
--- a/test/ruby/test_autoload.rb
+++ b/test/ruby/test_autoload.rb
@@ -428,15 +428,18 @@ p Foo::Bar
   end
 
   def test_source_location
-    klass = self.class
     bug = "Bug16764"
     Dir.mktmpdir('autoload') do |tmpdir|
       path = "#{tmpdir}/test-#{bug}.rb"
-      File.write(path, "#{klass}::#{bug} = __FILE__\n")
-      klass.autoload(:Bug16764, path)
-      assert_equal [__FILE__, __LINE__-1], klass.const_source_location(bug)
-      assert_equal path, klass.const_get(bug)
-      assert_equal [path, 1], klass.const_source_location(bug)
+      File.write(path, "C::#{bug} = __FILE__\n")
+      assert_separately(%W[-I #{tmpdir}], "#{<<-"begin;"}\n#{<<-"end;"}")
+      begin;
+        class C; end
+        C.autoload(:Bug16764, #{path.dump})
+        assert_equal [__FILE__, __LINE__-1], C.const_source_location(#{bug.dump})
+        assert_equal #{path.dump}, C.const_get(#{bug.dump})
+        assert_equal [#{path.dump}, 1], C.const_source_location(#{bug.dump})
+      end;
     end
   end
 


### PR DESCRIPTION
TestAutoload#test_source_location can't run multiple test-run so
that use assert_separately().

repro command:
make yes-test-all TESTS='--repeat-count=50 ruby/test_autoload -n test_source_location'