### PR TITLE
using len variable in rb_ary_any_p

### DIFF
--- a/array.c
+++ b/array.c
@@ -6281,7 +6281,7 @@ rb_ary_any_p(int argc, VALUE *argv, VALUE ary)
         if (rb_block_given_p()) {
             rb_warn("given block not used");
         }
-	for (i = 0; i < RARRAY_LEN(ary); ++i) {
+	for (i = 0; i < len; ++i) {
 	    if (RTEST(rb_funcall(argv[0], idEqq, 1, RARRAY_AREF(ary, i)))) return Qtrue;
 	}
     }
@@ -6291,7 +6291,7 @@ rb_ary_any_p(int argc, VALUE *argv, VALUE ary)
         }
     }
     else {
-	for (i = 0; i < RARRAY_LEN(ary); ++i) {
+	for (i = 0; i < len; ++i) {
 	    if (RTEST(rb_yield(RARRAY_AREF(ary, i)))) return Qtrue;
 	}
     }

--- a/array.c
+++ b/array.c
@@ -6291,7 +6291,7 @@ rb_ary_any_p(int argc, VALUE *argv, VALUE ary)
         }
     }
     else {
-	for (i = 0; i < len; ++i) {
+	for (i = 0; i < RARRAY_LEN(ary); ++i) {
 	    if (RTEST(rb_yield(RARRAY_AREF(ary, i)))) return Qtrue;
 	}
     }


### PR DESCRIPTION
create local variable `len` is used by once, and using `RARRAY_LEN(ary)` in for loop in `master`.

```c
static VALUE
rb_ary_any_p(int argc, VALUE *argv, VALUE ary)
{
    long i, len = RARRAY_LEN(ary);

    rb_check_arity(argc, 0, 1);
    if (!len) return Qfalse;
    if (argc) {
        if (rb_block_given_p()) {
            rb_warn("given block not used");
        }
	for (i = 0; i < RARRAY_LEN(ary); ++i) {
	    if (RTEST(rb_funcall(argv[0], idEqq, 1, RARRAY_AREF(ary, i)))) return Qtrue;
	}
    }
    else if (!rb_block_given_p()) {
        for (i = 0; i < len; ++i) {
            if (RTEST(RARRAY_AREF(ary, i))) return Qtrue;
        }
    }
    else {
	for (i = 0; i < RARRAY_LEN(ary); ++i) {
	    if (RTEST(rb_yield(RARRAY_AREF(ary, i)))) return Qtrue;
	}
    }
    return Qfalse;
}
```

This PR, used local variable `len` to for loop.

```c
static VALUE
rb_ary_any_p(int argc, VALUE *argv, VALUE ary)
{
    long i, len = RARRAY_LEN(ary);

    rb_check_arity(argc, 0, 1);
    if (!len) return Qfalse;
    if (argc) {
        if (rb_block_given_p()) {
            rb_warn("given block not used");
        }
	for (i = 0; i < len; ++i) {
	    if (RTEST(rb_funcall(argv[0], idEqq, 1, RARRAY_AREF(ary, i)))) return Qtrue;
	}
    }
    else if (!rb_block_given_p()) {
        for (i = 0; i < len; ++i) {
            if (RTEST(RARRAY_AREF(ary, i))) return Qtrue;
        }
    }
    else {
	for (i = 0; i < len; ++i) {
	    if (RTEST(rb_yield(RARRAY_AREF(ary, i)))) return Qtrue;
	}
    }
    return Qfalse;
}
```

Peformance is no change, code is more simple.

`benchmark`
```yml
prelude: |
  ary = [1, 2, 3]
benchmark:
  arg: |
    ary.any?(3)
  block: |
    ary.any? {|a| a == 3}
loop_count: 10000

```

`result`
```bash
sh@MyComputer:/mnt/c/Users/sh/Desktop/rubydev/build$ make benchmark/benchmark.yml -e BASE_RUBY=../install/bin/ruby -e COMPARE_RUBY=~/.rbenv/shims/ruby
compiling ../ruby/array.c
generating known_errors.inc
known_errors.inc unchanged
../ruby/revision.h updated
compiling ../ruby/version.c
generating vm_call_iseq_optimized.inc
vm_call_iseq_optimized.inc unchanged
linking miniruby
Calculating -------------------------------------
                     compare-ruby  built-ruby
                 arg       2.982M      3.146M i/s -     10.000k times in 0.003353s 0.003178s
               block       2.044M      2.326M i/s -     10.000k times in 0.004893s 0.004300s

Comparison:
                              arg
          built-ruby:   3146138.1 i/s
        compare-ruby:   2982492.8 i/s - 1.05x  slower

                            block
          built-ruby:   2325581.4 i/s 
        compare-ruby:   2043861.3 i/s - 1.14x  slower
```

`COMPARE_RUBY` is `ruby 2.8.0dev (2020-05-14T10:58:44Z master d7d0d01401) [x86_64-linux]`. `BASE_RUBY` is a head of `ruby 2.8.0dev (2020-05-14T10:58:44Z master d7d0d01401) [x86_64-linux]`