### PR TITLE
Fix read_status_line to work with HTTP/2 Header

### DIFF
--- a/lib/net/http/response.rb
+++ b/lib/net/http/response.rb
@@ -40,7 +40,7 @@ class Net::HTTPResponse
 
     def read_status_line(sock)
       str = sock.readline
-      m = /\AHTTP(?:\/(\d+(\.\d+)?))?\s+(\d\d\d)(?:\s+(.*))?\z/in.match(str) or
+      m = /\AHTTP(?:\/(\d+\.\d+|\d+))?\s+(\d\d\d)(?:\s+(.*))?\z/in.match(str) or
         raise Net::HTTPBadResponse, "wrong status line: #{str.dump}"
       m.captures
     end

--- a/lib/net/http/response.rb
+++ b/lib/net/http/response.rb
@@ -40,7 +40,7 @@ class Net::HTTPResponse
 
     def read_status_line(sock)
       str = sock.readline
-      m = /\AHTTP(?:\/(\d+\.\d+))?\s+(\d\d\d)(?:\s+(.*))?\z/in.match(str) or
+      m = /\AHTTP(?:\/(\d+\.?\d*))?\s+(\d\d\d)(?:\s+(.*))?\z/in.match(str) or
         raise Net::HTTPBadResponse, "wrong status line: #{str.dump}"
       m.captures
     end

--- a/lib/net/http/response.rb
+++ b/lib/net/http/response.rb
@@ -40,7 +40,7 @@ class Net::HTTPResponse
 
     def read_status_line(sock)
       str = sock.readline
-      m = /\AHTTP(?:\/(\d+\.?\d*))?\s+(\d\d\d)(?:\s+(.*))?\z/in.match(str) or
+      m = /\AHTTP(?:\/(\d+(\.\d+)?))?\s+(\d\d\d)(?:\s+(.*))?\z/in.match(str) or
         raise Net::HTTPBadResponse, "wrong status line: #{str.dump}"
       m.captures
     end

--- a/test/net/http/test_httpresponse.rb
+++ b/test/net/http/test_httpresponse.rb
@@ -411,6 +411,21 @@ EOS
     assert_equal(nil, res.message)
   end
 
+  def test_http2_status_line
+    io = dummy_io(<<EOS)
+HTTP/2 200
+Content-Length: 5
+Connection: close
+
+hello
+EOS
+
+    res = Net::HTTPResponse.read_new(io)
+    assert_equal('2', res.http_version)
+    assert_equal('200', res.code)
+    assert_equal(nil, res.message)
+  end
+
   def test_raises_exception_with_missing_reason
     io = dummy_io(<<EOS)
 HTTP/1.1 404


### PR DESCRIPTION
Hey Folks 👋 

I sent this PR because I think there is a possible bug in response.rb in #read_status_line. 

I'm trying to execute the following code:

```
raw_response = "HTTP/2 202 \r\nserver: nginx\r\ndate: Mon, 18 May 2020 14:02:58 GMT\r\ncontent-type: application/json; charset=utf-8\r\nx-ratelimit-limit: 2400\r\nx-ratelimit-remaining: 2393\r\nx-ratelimit-reset: 1589813834\r\ncache-control: no-cache\r\nx-request-id: 98a59035-27c8-421e-b357-127f4c8da4e0\r\nx-runtime: 1.144313\r\nx-frame-options: DENY\r\nx-content-type-options: nosniff\r\nx-xss-protection: 1; mode=block\r\nx-download-options: noopen\r\nx-permitted-cross-domain-policies: none\r\n\r\n{\"data\":{}}"

socket = Net::BufferedIO.new(StringIO.new(raw_response))

response = Net::HTTPResponse.read_new(socket)
```

and it explodes with:

```
Net::HTTPBadResponse (wrong status line: "HTTP/2 202 ")
```

it explodes because it doesn't match the expected status http version, that needs a format of `HTTP DIGIT.DIGIT....`

This PR changes read_status_line to allow reading status header from
HTTP/2 response as well. Currently it explodes if it is not in it
format.

Thanks
🍻 