### PR TITLE
Allow references stored in the VM stack to move

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -4800,14 +4800,13 @@ rb_gc_mark_values(long n, const VALUE *values)
 }
 
 static void
-gc_mark_and_pin_stack_values(rb_objspace_t *objspace, long n, const VALUE *values)
+gc_mark_stack_values(rb_objspace_t *objspace, long n, const VALUE *values)
 {
     long i;
 
     for (i=0; i<n; i++) {
-        /* skip MOVED objects that are on the stack */
-        if (is_markable_object(objspace, values[i]) && T_MOVED != BUILTIN_TYPE(values[i])) {
-            gc_mark_and_pin(objspace, values[i]);
+        if (is_markable_object(objspace, values[i])) {
+            gc_mark(objspace, values[i]);
         }
     }
 }
@@ -4816,7 +4815,7 @@ void
 rb_gc_mark_vm_stack_values(long n, const VALUE *values)
 {
     rb_objspace_t *objspace = &rb_objspace;
-    gc_mark_and_pin_stack_values(objspace, n, values);
+    gc_mark_stack_values(objspace, n, values);
 }
 
 static int

--- a/vm.c
+++ b/vm.c
@@ -2488,10 +2488,20 @@ rb_execution_context_update(const rb_execution_context_t *ec)
 {
     /* update VM stack */
     if (ec->vm_stack) {
+        long i;
         VM_ASSERT(ec->cfp);
-
+        VALUE *p = ec->vm_stack;
+        VALUE *sp = ec->cfp->sp;
         rb_control_frame_t *cfp = ec->cfp;
         rb_control_frame_t *limit_cfp = (void *)(ec->vm_stack + ec->vm_stack_size);
+
+        for (i = 0; i < (long)(sp - p); i++) {
+            VALUE ref = p[i];
+            VALUE update = rb_gc_location(ref);
+            if (ref != update) {
+                p[i] = update;
+            }
+        }
 
         while (cfp != limit_cfp) {
             const VALUE *ep = cfp->ep;


### PR DESCRIPTION
We can update these references too, so lets allow them to move.