### PR TITLE
add static modifier to rb_ary_aref2 func

### DIFF
--- a/array.c
+++ b/array.c
@@ -1685,7 +1685,7 @@ rb_ary_aref(int argc, const VALUE *argv, VALUE ary)
     return rb_ary_aref1(ary, argv[0]);
 }
 
-VALUE
+static VALUE
 rb_ary_aref2(VALUE ary, VALUE b, VALUE e)
 {
     long beg = NUM2LONG(b);


### PR DESCRIPTION
## summary:
add static modifier to `rb_ary_aref2` func.

## why?
I saw `Array#[]` implementation, And Think it 
>Why prototype declaration is add static modifier, but implementation is no add static modifier?

```c:array.c
static VALUE rb_ary_aref2(VALUE ary, VALUE b, VALUE e);

/*
 *  call-seq:
 *     ary[index]                -> obj     or nil
 *     ary[start, length]        -> new_ary or nil
 *     ary[range]                -> new_ary or nil
 *     ary.slice(index)          -> obj     or nil
 *     ary.slice(start, length)  -> new_ary or nil
 *     ary.slice(range)          -> new_ary or nil
 *
 *  Element Reference --- Returns the element at +index+, or returns a
 *  subarray starting at the +start+ index and continuing for +length+
 *  elements, or returns a subarray specified by +range+ of indices.
 *
 *  Negative indices count backward from the end of the array (-1 is the last
 *  element).  For +start+ and +range+ cases the starting index is just before
 *  an element.  Additionally, an empty array is returned when the starting
 *  index for an element range is at the end of the array.
 *
 *  Returns +nil+ if the index (or starting index) are out of range.
 *
 *     a = [ "a", "b", "c", "d", "e" ]
 *     a[2] +  a[0] + a[1]    #=> "cab"
 *     a[6]                   #=> nil
 *     a[1, 2]                #=> [ "b", "c" ]
 *     a[1..3]                #=> [ "b", "c", "d" ]
 *     a[4..7]                #=> [ "e" ]
 *     a[6..10]               #=> nil
 *     a[-3, 3]               #=> [ "c", "d", "e" ]
 *     # special cases
 *     a[5]                   #=> nil
 *     a[6, 1]                #=> nil
 *     a[5, 1]                #=> []
 *     a[5..10]               #=> []
 *
 */

VALUE
rb_ary_aref(int argc, const VALUE *argv, VALUE ary)
{
    rb_check_arity(argc, 1, 2);
    if (argc == 2) {
	return rb_ary_aref2(ary, argv[0], argv[1]);
    }
    return rb_ary_aref1(ary, argv[0]);
}

static VALUE
rb_ary_aref2(VALUE ary, VALUE b, VALUE e)
{
    long beg = NUM2LONG(b);
    long len = NUM2LONG(e);
    if (beg < 0) {
	beg += RARRAY_LEN(ary);
    }
    return rb_ary_subseq(ary, beg, len);
}
```

When I read the source code of Ruby, it seems that `rb_ary_aref2` is not used in another source code.

Also, looking at the past changes, it seems that static is qualified in the declaration of `rb_ary_aref2` to improve the binary size.

ref: [Subject: [ruby-changes:58836] 0e8219f591 (master): make functions static](http://mla.n-z.jp/~w3ml/w3ml.cgi/ruby-changes/msg/58836)
ref: [make functions static](https://git.ruby-lang.org/ruby.git/commit/?id=0e8219f591)

`rb_ary_aref2` is not used in other source code.

Also, it seems that it is not published for C extension API 

So it is better to add the static modifier.