### PR TITLE
Use __bultin_assume() from clang-7

### DIFF
--- a/include/ruby/assert.h
+++ b/include/ruby/assert.h
@@ -90,7 +90,7 @@ RBIMPL_SYMBOL_EXPORT_END()
 # define RBIMPL_ASSERT_OR_ASSUME(_) RUBY_ASSERT(_)
 #elif defined(RBIMPL_HAVE___ASSUME)
 # define RBIMPL_ASSERT_OR_ASSUME(_) RBIMPL_ASSUME(_)
-#elif RBIMPL_HAS_BUILTIN(__builtin_assume)
+#elif RBIMPL_HAS_BUILTIN(__builtin_assume) && RBIMPL_COMPILER_SINCE(Clang, 7, 0, 0)
 # define RBIMPL_ASSERT_OR_ASSUME(_) RBIMPL_ASSUME(_)
 #else
 # define RBIMPL_ASSERT_OR_ASSUME(_) /* void */


### PR DESCRIPTION
We observed combination of multiple __builtin_assume() can cause
strange compile results on clang-6 (-DNDEBUG exposed this issue).
To avoid this problem, __builtin_assume() is from clang-7.
https://github.com/ruby/ruby/pull/3120#issuecomment-630821333