### PR TITLE
add static modifer for rb_hash_fetch_values func

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -2763,7 +2763,7 @@ rb_hash_values_at(int argc, VALUE *argv, VALUE hash)
  *   h.fetch_values("cow", "bird") { |k| k.upcase } #=> ["bovine", "BIRD"]
  */
 
-VALUE
+static VALUE
 rb_hash_fetch_values(int argc, VALUE *argv, VALUE hash)
 {
     VALUE result = rb_ary_new2(argc);


### PR DESCRIPTION
## summary:

Propasal, add static modifer to `rb_rb_hash_fetch_values`.

## whiy?

I read `Hash#fetch_values` implementation in Ruby code.

```c
/*
 * call-seq:
 *   hsh.fetch_values(key, ...)                 -> array
 *   hsh.fetch_values(key, ...) { |key| block } -> array
 *
 * Returns an array containing the values associated with the given keys
 * but also raises KeyError when one of keys can't be found.
 * Also see Hash#values_at and Hash#fetch.
 *
 *   h = { "cat" => "feline", "dog" => "canine", "cow" => "bovine" }
 *
 *   h.fetch_values("cow", "cat")                   #=> ["bovine", "feline"]
 *   h.fetch_values("cow", "bird")                  # raises KeyError
 *   h.fetch_values("cow", "bird") { |k| k.upcase } #=> ["bovine", "BIRD"]
 */

VALUE
rb_hash_fetch_values(int argc, VALUE *argv, VALUE hash)
{
    VALUE result = rb_ary_new2(argc);
    long i;

    for (i=0; i<argc; i++) {
	rb_ary_push(result, rb_hash_fetch(hash, argv[i]));
    }
    return result;
}
```

`rb_hash_fetch_values` func is not used by other source code.
And, it seems that it is not published for C extension API

So, I think it better add static modifer.

But, some reason has rb_hash_fetch_values func not add static modifer. 
I'll respect these reason.