### PR TITLE
Only marked objects should be considered movable

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -7599,7 +7599,7 @@ gc_is_moveable_obj(rb_objspace_t *objspace, VALUE obj)
                 return FALSE;
             }
         }
-        return !RVALUE_PINNED(obj);
+        return RVALUE_MARKED(obj) && !RVALUE_PINNED(obj);
 
       default:
         rb_bug("gc_is_moveable_obj: unreachable (%d)", (int)BUILTIN_TYPE(obj));


### PR DESCRIPTION
Ruby's GC is incremental, meaning that during the mark phase (and also
the sweep phase) programs are allowed to run.  This means that programs
can allocate objects before the mark or sweep phase have actually
completed.  Those objects may not have had a chance to be marked, so we
can't know if they are movable or not as something that references that
target object might have called the pinning function during the mark
phase, but since the mark phase hasn't run since the object was
allocated, we can't know.

So to be conservative, we must only allow objects that are not pinned
but also marked to move.