### PR TITLE
fix memory leak of ccs

### DIFF
--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1573,8 +1573,14 @@ vm_search_cc(VALUE klass, const struct rb_callinfo *ci)
 
         if (ccs == NULL) {
             VM_ASSERT(cc_tbl != NULL);
-            ccs = vm_ccs_create(klass, cme);
-            rb_id_table_insert(cc_tbl, mid, (VALUE)ccs);
+            if (LIKELY(rb_id_table_lookup(cc_tbl, mid, (VALUE*)&ccs))) {
+                // rb_callable_method_entry() prepares ccs.
+            }
+            else {
+                // TODO: required?
+                ccs = vm_ccs_create(klass, cme);
+                rb_id_table_insert(cc_tbl, mid, (VALUE)ccs);
+            }
         }
         vm_ccs_push(klass, ccs, ci, cc);
 


### PR DESCRIPTION
rb_callable_method_entry() creates ccs entry in cc_tbl, but this
code overwrite by insert newly created ccs and overwrote ccs never
freed.
[Bug #16900]