### PR TITLE
Add static modifier to c function in hash.c

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -2881,7 +2881,7 @@ rb_hash_select_bang(VALUE hash)
  *  See also Hash#select!.
  */
 
-VALUE
+static VALUE
 rb_hash_keep_if(VALUE hash)
 {
     RETURN_SIZED_ENUMERATOR(hash, 0, 0, hash_enum_size);

--- a/hash.c
+++ b/hash.c
@@ -2819,7 +2819,7 @@ select_i(VALUE key, VALUE value, VALUE result)
  *  Hash#filter is an alias for Hash#select.
  */
 
-VALUE
+static VALUE
 rb_hash_select(VALUE hash)
 {
     VALUE result;

--- a/hash.c
+++ b/hash.c
@@ -2854,7 +2854,7 @@ keep_if_i(VALUE key, VALUE value, VALUE hash)
  *  Hash#filter! is an alias for Hash#select!.
  */
 
-VALUE
+static VALUE
 rb_hash_select_bang(VALUE hash)
 {
     st_index_t n;


### PR DESCRIPTION
Some C function don't seems to be used by C Extension API. So, these function add static modifier.

These C func add static modifier.

- `rb_hash_select`
- `rb_hash_select_bang`
- `rb_hash_keep_if`