### PR TITLE
Fix max, min, minmax documentation

### DIFF
--- a/array.c
+++ b/array.c
@@ -4932,7 +4932,7 @@ rb_ary_union_multi(int argc, VALUE *argv, VALUE ary)
  *     ary.max(n) {|a, b| block}   -> array
  *
  *  Returns the object in _ary_ with the maximum value. The
- *  first form assumes all objects implement Comparable;
+ *  first form assumes all objects implement <code><=></code>;
  *  the second uses the block to return <em>a <=> b</em>.
  *
  *     ary = %w(albatross dog horse)
@@ -4985,7 +4985,7 @@ rb_ary_max(int argc, VALUE *argv, VALUE ary)
  *     ary.min(n) {| a,b | block } -> array
  *
  *  Returns the object in _ary_ with the minimum value. The
- *  first form assumes all objects implement Comparable;
+ *  first form assumes all objects implement <code><=></code>;
  *  the second uses the block to return <em>a <=> b</em>.
  *
  *     ary = %w(albatross dog horse)

--- a/enum.c
+++ b/enum.c
@@ -1763,7 +1763,7 @@ min_ii(RB_BLOCK_CALL_FUNC_ARGLIST(i, args))
  *     enum.min(n) { |a, b| block } -> array
  *
  *  Returns the object in _enum_ with the minimum value. The
- *  first form assumes all objects implement Comparable;
+ *  first form assumes all objects implement <code><=></code>;
  *  the second uses the block to return <em>a <=> b</em>.
  *
  *     a = %w(albatross dog horse)
@@ -1855,7 +1855,7 @@ max_ii(RB_BLOCK_CALL_FUNC_ARGLIST(i, args))
  *     enum.max(n) { |a, b| block } -> array
  *
  *  Returns the object in _enum_ with the maximum value. The
- *  first form assumes all objects implement Comparable;
+ *  first form assumes all objects implement <code><=></code>;
  *  the second uses the block to return <em>a <=> b</em>.
  *
  *     a = %w(albatross dog horse)
@@ -2014,7 +2014,7 @@ minmax_ii(RB_BLOCK_CALL_FUNC_ARGLIST(i, _memo))
  *
  *  Returns a two element array which contains the minimum and the
  *  maximum value in the enumerable.  The first form assumes all
- *  objects implement Comparable; the second uses the
+ *  objects implement <code><=></code>; the second uses the
  *  block to return <em>a <=> b</em>.
  *
  *     a = %w(albatross dog horse)


### PR DESCRIPTION
Such as Enumerable#minmax only need that all objects implement <=>, but the documentation said it needs Comparable.


So this pull request updates the documentation of the following methods. 


* Enumerable#minmax
* Enumerable#max
* Enumerable#min
* Array#max
* Array#min


Note that Array#minmax document doesn't mention Comparable, so I didn't make any changes to the method documentation.
https://github.com/ruby/ruby/blob/f4f157fc81b940c0f76a01ee266a08e6bba69b6b/array.c#L5034-L5042



I've confirmed commits that are the first commits of the documents, and current implementation.
They look not to have any dependency on Comparable, so I think we should update the documentation.



There are the first commits of documents.

*  Enumerable#min, Enumerable#max ruby/ruby@84f0b05
* Enumerable#minmax ruby/ruby@3f2fe37
* Array#min, Array#max ruby/ruby@68a6f2e