### PR TITLE
Fix origin iclass pointer for modules

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -2815,9 +2815,11 @@ obj_free(rb_objspace_t *objspace, VALUE obj)
 	break;
       case T_ICLASS:
 	/* Basically , T_ICLASS shares table with the module */
-	if (FL_TEST(obj, RICLASS_IS_ORIGIN)) {
-	    rb_id_table_free(RCLASS_M_TBL(obj));
-	}
+        if (FL_TEST(obj, RICLASS_IS_ORIGIN) &&
+                !FL_TEST(obj, RICLASS_ORIGIN_SHARED_MTBL)) {
+            /* Method table is not shared for origin iclasses of classes */
+            rb_id_table_free(RCLASS_M_TBL(obj));
+        }
 	if (RCLASS_CALLABLE_M_TBL(obj) != NULL) {
 	    rb_id_table_free(RCLASS_CALLABLE_M_TBL(obj));
 	}
@@ -3911,7 +3913,8 @@ obj_memsize_of(VALUE obj, int use_all_types)
 	}
 	break;
       case T_ICLASS:
-	if (FL_TEST(obj, RICLASS_IS_ORIGIN)) {
+        if (FL_TEST(obj, RICLASS_IS_ORIGIN) &&
+                !FL_TEST(obj, RICLASS_ORIGIN_SHARED_MTBL)) {
 	    if (RCLASS_M_TBL(obj)) {
 		size += rb_id_table_memsize(RCLASS_M_TBL(obj));
 	    }
@@ -5432,7 +5435,8 @@ gc_mark_children(rb_objspace_t *objspace, VALUE obj)
 	break;
 
       case T_ICLASS:
-	if (FL_TEST(obj, RICLASS_IS_ORIGIN)) {
+        if (FL_TEST(obj, RICLASS_IS_ORIGIN) &&
+                !FL_TEST(obj, RICLASS_ORIGIN_SHARED_MTBL)) {
 	    mark_m_tbl(objspace, RCLASS_M_TBL(obj));
 	}
         if (RCLASS_SUPER(obj)) {
@@ -8296,7 +8300,8 @@ gc_update_object_references(rb_objspace_t *objspace, VALUE obj)
         break;
 
       case T_ICLASS:
-        if (FL_TEST(obj, RICLASS_IS_ORIGIN)) {
+        if (FL_TEST(obj, RICLASS_IS_ORIGIN) &&
+                !FL_TEST(obj, RICLASS_ORIGIN_SHARED_MTBL)) {
             update_m_tbl(objspace, RCLASS_M_TBL(obj));
         }
         if (RCLASS_SUPER((VALUE)obj)) {

--- a/internal/class.h
+++ b/internal/class.h
@@ -95,9 +95,10 @@ typedef struct rb_classext_struct rb_classext_t;
 #endif
 #define RCLASS_INCLUDER(c) (RCLASS_EXT(c)->includer)
 
-#define RCLASS_CLONED     FL_USER6
 #define RICLASS_IS_ORIGIN FL_USER5
+#define RCLASS_CLONED     FL_USER6
 #define RCLASS_REFINED_BY_ANY FL_USER7
+#define RICLASS_ORIGIN_SHARED_MTBL FL_USER8
 
 /* class.c */
 void rb_class_subclass_add(VALUE super, VALUE klass);
@@ -120,6 +121,7 @@ VALUE rb_singleton_class_get(VALUE obj);
 int rb_class_has_methods(VALUE c);
 void rb_undef_methods_from(VALUE klass, VALUE super);
 static inline void RCLASS_SET_ORIGIN(VALUE klass, VALUE origin);
+static inline void RICLASS_SET_ORIGIN_SHARED_MTBL(VALUE iclass);
 static inline VALUE RCLASS_SUPER(VALUE klass);
 static inline VALUE RCLASS_SET_SUPER(VALUE klass, VALUE super);
 static inline void RCLASS_SET_INCLUDER(VALUE iclass, VALUE klass);
@@ -134,6 +136,12 @@ RCLASS_SET_ORIGIN(VALUE klass, VALUE origin)
 {
     RB_OBJ_WRITE(klass, &RCLASS_ORIGIN(klass), origin);
     if (klass != origin) FL_SET(origin, RICLASS_IS_ORIGIN);
+}
+
+static inline void
+RICLASS_SET_ORIGIN_SHARED_MTBL(VALUE iclass)
+{
+    FL_SET(iclass, RICLASS_ORIGIN_SHARED_MTBL);
 }
 
 static inline void

--- a/test/ruby/test_module.rb
+++ b/test/ruby/test_module.rb
@@ -479,6 +479,28 @@ class TestModule < Test::Unit::TestCase
     assert_raise(ArgumentError) { Module.new { include } }
   end
 
+  def test_gc_prepend_chain
+    assert_separately([], <<-EOS)
+      10000.times { |i|
+        m1 = Module.new do
+          def foo; end
+        end
+        m2 = Module.new do
+          prepend m1
+          def bar; end
+        end
+        m3 = Module.new do
+          def baz; end
+          prepend m2
+        end
+        Class.new do
+          prepend m3
+        end
+      }
+      GC.start
+    EOS
+  end
+
   def test_include_into_module_already_included
     c = Class.new{def foo; [:c] end}
     modules = lambda do ||
@@ -538,6 +560,16 @@ class TestModule < Test::Unit::TestCase
     mixins << JSON::Ext::Generator::GeneratorMethods::String if defined?(JSON::Ext::Generator::GeneratorMethods::String)
     assert_equal([Kernel], Object.included_modules - mixins)
     assert_equal([Comparable, Kernel], String.included_modules - mixins)
+  end
+
+  def test_included_modules_with_prepend
+    m1 = Module.new
+    m2 = Module.new
+    m3 = Module.new
+
+    m2.prepend m1
+    m3.include m2
+    assert_equal([m1, m2], m3.included_modules)
   end
 
   def test_instance_methods
@@ -2041,6 +2073,33 @@ class TestModule < Test::Unit::TestCase
     assert_not_include(im, c1, bug8025)
     assert_not_include(im, c2, bug8025)
     assert_include(im, mixin, bug8025)
+  end
+
+  def test_prepended_module_with_super_and_alias
+    bug16736 = '[Bug #16736]'
+
+    a = labeled_class("A") do
+      def m; "A"; end
+    end
+    m = labeled_module("M") do
+      prepend Module.new
+
+      def self.included(base)
+        base.alias_method :base_m, :m
+      end
+
+      def m
+        super + "M"
+      end
+
+      def m2
+        base_m
+      end
+    end
+    b = labeled_class("B", a) do
+      include m
+    end
+    assert_equal("AM", b.new.m2, bug16736)
   end
 
   def test_prepend_super_in_alias

--- a/vm.c
+++ b/vm.c
@@ -1618,7 +1618,8 @@ static void
 rb_vm_check_redefinition_opt_method(const rb_method_entry_t *me, VALUE klass)
 {
     st_data_t bop;
-    if (RB_TYPE_P(klass, T_ICLASS) && FL_TEST(klass, RICLASS_IS_ORIGIN)) {
+    if (RB_TYPE_P(klass, T_ICLASS) && FL_TEST(klass, RICLASS_IS_ORIGIN) &&
+            RB_TYPE_P(RBASIC_CLASS(klass), T_CLASS)) {
        klass = RBASIC_CLASS(klass);
     }
     if (vm_redefinition_check_method_type(me->def)) {

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -2632,7 +2632,10 @@ find_defined_class_by_owner(VALUE current_class, VALUE target_owner)
     VALUE klass = current_class;
 
     /* for prepended Module, then start from cover class */
-    if (RB_TYPE_P(klass, T_ICLASS) && FL_TEST(klass, RICLASS_IS_ORIGIN)) klass = RBASIC_CLASS(klass);
+    if (RB_TYPE_P(klass, T_ICLASS) && FL_TEST(klass, RICLASS_IS_ORIGIN) &&
+            RB_TYPE_P(RBASIC_CLASS(klass), T_CLASS)) {
+        klass = RBASIC_CLASS(klass);
+    }
 
     while (RTEST(klass)) {
 	VALUE owner = RB_TYPE_P(klass, T_ICLASS) ? RBASIC_CLASS(klass) : klass;


### PR DESCRIPTION
If a module has an origin, and that module is included in another
module or class, previously the iclass created for the module had
an origin pointer to the module's origin instead of the iclass's
origin.

Setting the origin pointer correctly requires using a stack, since
the origin iclass is not created until after the iclass itself.
Use a hidden ruby array to implement that stack.

Correctly assigning the origin pointers in the iclass caused a
use-after-free in GC.  If a module with an origin is included
in a class, the iclass shares a method table with the module
and the iclass origin shares a method table with module origin.

Mark iclass origin with a flag that notes that even though the
iclass is an origin, it shares a method table, so the method table
should not be garbage collected.  The shared method table will be
garbage collected when the module origin is garbage collected.
I've tested that this does not introduce a memory leak.

This change caused a VM assertion failure, which was traced to callable
method entries using the incorrect defined_class.  Update
rb_vm_check_redefinition_opt_method and find_defined_class_by_owner
to treat iclass origins different than class origins to avoid this
issue.

This also includes a fix for Module#included_modules to skip
iclasses with origins.

Fixes [Bug #16736]