### PR TITLE
Add static modifier to C function in hash.c

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -2762,7 +2762,7 @@ reject_i(VALUE key, VALUE value, VALUE result)
  *    h1 # => {:foo=>0}
  */
 
-VALUE
+static VALUE
 rb_hash_reject(VALUE hash)
 {
     VALUE result;

--- a/hash.c
+++ b/hash.c
@@ -4348,7 +4348,7 @@ rassoc_i(VALUE key, VALUE val, VALUE arg)
  *     a.rassoc("four")   #=> nil
  */
 
-VALUE
+static VALUE
 rb_hash_rassoc(VALUE hash, VALUE obj)
 {
     VALUE args[2];

--- a/hash.c
+++ b/hash.c
@@ -2721,7 +2721,7 @@ rb_hash_delete_if(VALUE hash)
  *    h.reject! { |key, value| h[:new_Key] = 3 }
  */
 
-VALUE
+static VALUE
 rb_hash_reject_bang(VALUE hash)
 {
     st_index_t n;

--- a/hash.c
+++ b/hash.c
@@ -4287,7 +4287,7 @@ assoc_i(VALUE key, VALUE val, VALUE arg)
  *     h.assoc("foo")      #=> nil
  */
 
-VALUE
+static VALUE
 rb_hash_assoc(VALUE hash, VALUE key)
 {
     st_table *table;

--- a/hash.c
+++ b/hash.c
@@ -2824,7 +2824,7 @@ rb_hash_slice(int argc, VALUE *argv, VALUE hash)
  *   h.values_at("cow", "cat")  #=> ["bovine", "feline"]
  */
 
-VALUE
+static VALUE
 rb_hash_values_at(int argc, VALUE *argv, VALUE hash)
 {
     VALUE result = rb_ary_new2(argc);


### PR DESCRIPTION
I found it again so I created a Pull Request.
Some C function don't seems to be used by C Extension API. So, these function add static modifier.

These C func add static modifier.

- `rb_hash_reject_bang`
- `rb_hash_reject`
- `rb_hash_values_at`
- `rb_hash_assoc`
- `rb_hash_rassoc`