### PR TITLE
Ensure origins of included, prepended, and refined modules

### DIFF
--- a/complex.c
+++ b/complex.c
@@ -2356,7 +2356,7 @@ Init_Complex(void)
 
     rb_define_global_function("Complex", nucomp_f_complex, -1);
 
-    rb_undef_methods_from(rb_cComplex, rb_mComparable);
+    rb_undef_methods_from(rb_cComplex, RCLASS_ORIGIN(rb_mComparable));
     rb_undef_method(rb_cComplex, "%");
     rb_undef_method(rb_cComplex, "div");
     rb_undef_method(rb_cComplex, "divmod");

--- a/eval.c
+++ b/eval.c
@@ -1382,7 +1382,7 @@ refinement_superclass(VALUE superclass)
 {
     if (RB_TYPE_P(superclass, T_MODULE)) {
 	/* FIXME: Should ancestors of superclass be used here? */
-	return rb_include_class_new(superclass, rb_cBasicObject);
+        return rb_include_class_new(RCLASS_ORIGIN(superclass), rb_cBasicObject);
     }
     else {
 	return superclass;
@@ -1556,7 +1556,7 @@ rb_mod_refine(VALUE module, VALUE klass)
 
     ensure_class_or_module(klass);
     if (RB_TYPE_P(klass, T_MODULE)) {
-        FL_SET(klass, RCLASS_REFINED_BY_ANY);
+        rb_ensure_origin(klass);
     }
     CONST_ID(id_refinements, "__refinements__");
     refinements = rb_attr_get(module, id_refinements);

--- a/internal/class.h
+++ b/internal/class.h
@@ -97,7 +97,6 @@ typedef struct rb_classext_struct rb_classext_t;
 
 #define RICLASS_IS_ORIGIN FL_USER5
 #define RCLASS_CLONED     FL_USER6
-#define RCLASS_REFINED_BY_ANY FL_USER7
 #define RICLASS_ORIGIN_SHARED_MTBL FL_USER8
 
 /* class.c */
@@ -120,6 +119,8 @@ VALUE rb_singleton_class_clone_and_attach(VALUE obj, VALUE attach);
 VALUE rb_singleton_class_get(VALUE obj);
 int rb_class_has_methods(VALUE c);
 void rb_undef_methods_from(VALUE klass, VALUE super);
+void rb_ensure_origin(VALUE klass);
+
 static inline void RCLASS_SET_ORIGIN(VALUE klass, VALUE origin);
 static inline void RICLASS_SET_ORIGIN_SHARED_MTBL(VALUE iclass);
 static inline VALUE RCLASS_SUPER(VALUE klass);

--- a/marshal.c
+++ b/marshal.c
@@ -531,10 +531,13 @@ w_extended(VALUE klass, struct dump_arg *arg, int check)
 	klass = RCLASS_SUPER(klass);
     }
     while (BUILTIN_TYPE(klass) == T_ICLASS) {
-	VALUE path = rb_class_name(RBASIC(klass)->klass);
-	w_byte(TYPE_EXTENDED, arg);
-	w_unique(path, arg);
-	klass = RCLASS_SUPER(klass);
+        if (!FL_TEST(klass, RICLASS_IS_ORIGIN) ||
+                BUILTIN_TYPE(RBASIC(klass)->klass) != T_MODULE) {
+            VALUE path = rb_class_name(RBASIC(klass)->klass);
+            w_byte(TYPE_EXTENDED, arg);
+            w_unique(path, arg);
+        }
+        klass = RCLASS_SUPER(klass);
     }
 }
 

--- a/spec/ruby/core/module/prepend_spec.rb
+++ b/spec/ruby/core/module/prepend_spec.rb
@@ -128,17 +128,34 @@ describe "Module#prepend" do
     c.dup.new.should be_kind_of(m)
   end
 
-  it "keeps the module in the chain when dupping an intermediate module" do
-    m1 = Module.new { def calc(x) x end }
-    m2 = Module.new { prepend(m1) }
-    c1 = Class.new { prepend(m2) }
-    m2dup = m2.dup
-    m2dup.ancestors.should == [m2dup,m1,m2]
-    c2 = Class.new { prepend(m2dup) }
-    c1.ancestors[0,3].should == [m1,m2,c1]
-    c1.new.should be_kind_of(m1)
-    c2.ancestors[0,4].should == [m2dup,m1,m2,c2]
-    c2.new.should be_kind_of(m1)
+  ruby_version_is '0'...'2.8' do
+    it "keeps the module in the chain when dupping an intermediate module" do
+      m1 = Module.new { def calc(x) x end }
+      m2 = Module.new { prepend(m1) }
+      c1 = Class.new { prepend(m2) }
+      m2dup = m2.dup
+      m2dup.ancestors.should == [m2dup,m1,m2]
+      c2 = Class.new { prepend(m2dup) }
+      c1.ancestors[0,3].should == [m1,m2,c1]
+      c1.new.should be_kind_of(m1)
+      c2.ancestors[0,4].should == [m2dup,m1,m2,c2]
+      c2.new.should be_kind_of(m1)
+    end
+  end
+
+  ruby_version_is '2.8' do
+    it "uses only new module when dupping the module" do
+      m1 = Module.new { def calc(x) x end }
+      m2 = Module.new { prepend(m1) }
+      c1 = Class.new { prepend(m2) }
+      m2dup = m2.dup
+      m2dup.ancestors.should == [m1,m2dup]
+      c2 = Class.new { prepend(m2dup) }
+      c1.ancestors[0,3].should == [m1,m2,c1]
+      c1.new.should be_kind_of(m1)
+      c2.ancestors[0,3].should == [m1,m2dup,c2]
+      c2.new.should be_kind_of(m1)
+    end
   end
 
   it "depends on prepend_features to add the module" do

--- a/test/ruby/test_enum.rb
+++ b/test/ruby/test_enum.rb
@@ -279,6 +279,25 @@ class TestEnumerable < Test::Unit::TestCase
     end;
   end
 
+  def test_refine_Enumerable_then_include
+    assert_separately([], "#{<<~"end;"}\n")
+      module RefinementBug
+        refine Enumerable do
+          def refined_method
+            :rm
+          end
+        end
+      end
+      using RefinementBug
+
+      class A
+        include Enumerable
+      end
+
+      assert_equal(:rm, [].refined_method)
+    end;
+  end
+
   def test_partition
     assert_equal([[1, 3, 1], [2, 2]], @obj.partition {|x| x % 2 == 1 })
     cond = ->(x, i) { x % 2 == 1 }


### PR DESCRIPTION
This fixes cases where the modules are refined and included into
other modules or classes.

Implement by renaming ensure_origin to rb_ensure_origin, making it
non-static, and calling it directly after Enumerable, Comparable,
and Kernel are created.

This requires a couple of other changes:

* rb_undef_methods_from doesn't automatically handle classes with
  origins, so pass it the origin for Comparable when undefing
  methods in Complex. This fixed a failure in the Complex tests.

* When adding a method, the method cache was not be cleared
  correctly if klass has an origin.  Clear the method cache for
  the klass before switching to the origin of klass.  This fixed
  failures in the autoload tests related to overridding require,
  without breaking the optimization tests.

Potentially, this approach could work for other modules (possibly
all modules), but this commit focuses on modules that are included
by default in core classes and are reasonably likely targets for
refinement.

Fixes [Bug #16852]