### PR TITLE
Fix non-existent method reference in Enumerator.produce document

### DIFF
--- a/enumerator.c
+++ b/enumerator.c
@@ -2996,7 +2996,7 @@ producer_size(VALUE obj, VALUE args, VALUE eobj)
  *   enclosing_section = ancestors.find { |n| n.type == :section }
  *
  * Using ::produce together with Enumerable methods like Enumerable#detect,
- * Enumerable#slice, Enumerable#take_while can provide Enumerator-based alternatives
+ * Enumerable#slice_after, Enumerable#take_while can provide Enumerator-based alternatives
  * for +while+ and +until+ cycles:
  *
  *   # Find next Tuesday


### PR DESCRIPTION
Enumerator.produce document has a reference to Enumerable#slice, but Enumerable#slice does not exist.

This pull request replaces it with Enumerable#slice_after. It exists, and used in the sample code.
