### PR TITLE
Update Enumerable::Yielder#to_proc document

### DIFF
--- a/enumerator.c
+++ b/enumerator.c
@@ -1365,7 +1365,7 @@ yielder_yield_push(VALUE obj, VALUE arg)
 }
 
 /*
- * Returns a Proc object that takes an argument and yields it.
+ * Returns a Proc object that takes arguments and yields them.
  *
  * This method is implemented so that a Yielder object can be directly
  * passed to another method as a block argument.


### PR DESCRIPTION
The documentation is:

> Returns a Proc object that takes an argument and yields it.

But actually the proc that is returned from Enumerable::Yielder#to_proc receives multiple arguments and yields them. So this pull request updates the document.


```ruby
Enumerator.new do |y|
  y.to_proc.call 1, 2, 3 
end.each do |*v|
  p v # => [1, 2, 3]
end
```