### PR TITLE
Add static modifier for rb_str_ord func

### DIFF
--- a/string.c
+++ b/string.c
@@ -9727,7 +9727,7 @@ rb_str_crypt(VALUE str, VALUE salt)
  *     "a".ord         #=> 97
  */
 
-VALUE
+static VALUE
 rb_str_ord(VALUE s)
 {
     unsigned int c;


### PR DESCRIPTION
`rb_str_ord` don't seems to be used by C Extension API. So, I propasal add static modifier for `rb_str_ord` function.