### PR TITLE
Don't convert bundler man pages from mdoc to man

### DIFF
--- a/tool/rbinstall.rb
+++ b/tool/rbinstall.rb
@@ -632,8 +632,13 @@ install?(:local, :comm, :man) do
       class << (w = [])
         alias print push
       end
-      open(mdoc) {|r| Mdoc2Man.mdoc2man(r, w)}
-      w = w.join("")
+      if File.basename(mdoc).start_with?('bundle') ||
+         File.basename(mdoc).start_with?('gemfile')
+        w = File.read(mdoc)
+      else
+        open(mdoc) {|r| Mdoc2Man.mdoc2man(r, w)}
+        w = w.join("")
+      end
       if compress
         require 'tmpdir'
         Dir.mktmpdir("man") {|d|


### PR DESCRIPTION
These man pages are already in man format and assuming they are
mdoc format breaks things.

Fixes [Bug #16823]