### PR TITLE
Disable branchif/branchnil/branchunless optimization

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -2907,6 +2907,14 @@ iseq_peephole_optimize(rb_iseq_t *iseq, LINK_ELEMENT *list, const int do_tailcal
 	remove_unreachable_chunk(iseq, iobj->link.next);
     }
 
+#if 0
+    /* Disabling this optimization due to misoptimization of:
+     * 
+     *   def f;x = false; y = (return until x unless x);end;f
+     * 
+     * which leads to a stack consistency error or crash.
+     * See [Bug #16695]
+     */
     if (IS_INSN_ID(iobj, branchif) ||
 	IS_INSN_ID(iobj, branchnil) ||
 	IS_INSN_ID(iobj, branchunless)) {
@@ -3049,6 +3057,7 @@ iseq_peephole_optimize(rb_iseq_t *iseq, LINK_ELEMENT *list, const int do_tailcal
             }
         }
     }
+#endif
 
     if (IS_INSN_ID(iobj, pop)) {
 	/*

--- a/test/ruby/test_iseq.rb
+++ b/test/ruby/test_iseq.rb
@@ -198,7 +198,9 @@ class TestISeq < Test::Unit::TestCase
     body = compile(src, __LINE__, {peephole_optimization: true}).to_a[13]
     labels = body.select {|op, arg| op == :branchnil}.map {|op, arg| arg}
     assert_equal(1, labels.uniq.size)
-  end if (!defined?(Coverage) || !Coverage.running?)
+  # Disable this test until the branchif/branchnil/branchunless
+  # optimization is debugged and reenabled.
+  end if (!defined?(Coverage) || !Coverage.running?) && false
 
   def test_parent_iseq_mark
     assert_separately([], <<-'end;', timeout: 20)

--- a/test/ruby/test_whileuntil.rb
+++ b/test/ruby/test_whileuntil.rb
@@ -80,4 +80,15 @@ class TestWhileuntil < Test::Unit::TestCase
     end
     assert_operator(i, :>, 4)
   end
+
+  def test_return_until_unless
+    assert_separately([], <<-EOS)
+      def self.f
+        x = false
+        y = (return 1 until x unless x)
+        y
+      end
+      assert_equal 1, f
+    EOS
+  end
 end


### PR DESCRIPTION
The comment for this block says:

  This is super nasty hack!!!

In addition to apparently being a nasty hack, it's not
always correct, as it misoptimizes the following code
leading to a stack consistency error or crash:

  def f;x = false; y = (return until x unless x);end;f

Someone with more experience with the optimizer and iseqs
should review the code and determine how it can be
changed to not break in the above code, and determine if
it is worth keeping the optimization.  For now, the safe
solution is to just disable the optimization.

Fixes [Bug #16695]