### PR TITLE
Correctly remove temporary directory if path yielded is mutated

### DIFF
--- a/lib/tmpdir.rb
+++ b/lib/tmpdir.rb
@@ -86,7 +86,7 @@ class Dir
     }
     if block_given?
       begin
-        yield path
+        yield path.dup
       ensure
         unless base
           stat = File.stat(File.dirname(path))

--- a/test/test_tmpdir.rb
+++ b/test/test_tmpdir.rb
@@ -52,6 +52,17 @@ class TestTmpdir < Test::Unit::TestCase
     }
   end
 
+  def test_mktmpdir_mutate
+    bug16918 = '[ruby-core:98563]'
+    assert_nothing_raised(bug16918) do
+      assert_mktmpdir_traversal do |traversal_path|
+        Dir.mktmpdir(traversal_path + 'foo') do |actual|
+          actual << "foo"
+        end
+      end
+    end
+  end
+
   def test_mktmpdir_traversal
     assert_mktmpdir_traversal do |traversal_path|
       Dir.mktmpdir(traversal_path + 'foo') do |actual|


### PR DESCRIPTION
Another approach would be to freeze the string, but that could
cause backwards compatibility issues.

Fixes [Bug #16918]