### PR TITLE
Make Time#inspect format fractional usec same as integer usec

### DIFF
--- a/spec/ruby/core/time/inspect_spec.rb
+++ b/spec/ruby/core/time/inspect_spec.rb
@@ -9,13 +9,25 @@ describe "Time#inspect" do
       t = Time.utc(2007, 11, 1, 15, 25, 0, 123456)
       t.inspect.should == "2007-11-01 15:25:00.123456 UTC"
     end
+  end
 
-    it "formats nanoseconds as a Rational" do
+  ruby_version_is "2.7"..."2.8" do
+    it "formats fractional microseconds as a Rational" do
       t = Time.utc(2007, 11, 1, 15, 25, 0, 123456.789)
       t.nsec.should == 123456789
       t.strftime("%N").should == "123456789"
 
       t.inspect.should == "2007-11-01 15:25:00 8483885939586761/68719476736000000 UTC"
+    end
+  end
+
+  ruby_version_is "2.8" do
+    it "formats fractional microseconds same as integer microseconds" do
+      t = Time.utc(2007, 11, 1, 15, 25, 0, 123456.789)
+      t.nsec.should == 123456789
+      t.strftime("%N").should == "123456789"
+
+      t.inspect.should == "2007-11-01 15:25:00.123456789 UTC"
     end
   end
 end

--- a/test/ruby/test_time.rb
+++ b/test/ruby/test_time.rb
@@ -573,9 +573,9 @@ class TestTime < Test::Unit::TestCase
     t2000 = get_t2000 + 1/1000000000r
     assert_equal("2000-01-01 00:00:00.000000001 UTC", t2000.inspect)
     t2000 = get_t2000 + 1/10000000000r
-    assert_equal("2000-01-01 00:00:00 1/10000000000 UTC", t2000.inspect)
+    assert_equal("2000-01-01 00:00:00 UTC", t2000.inspect)
     t2000 = get_t2000 + 0.1
-    assert_equal("2000-01-01 00:00:00 3602879701896397/36028797018963968 UTC", t2000.inspect)
+    assert_equal("2000-01-01 00:00:00.1 UTC", t2000.inspect)
 
     t2000 = get_t2000
     t2000 = t2000.localtime(9*3600)

--- a/time.c
+++ b/time.c
@@ -4140,7 +4140,7 @@ time_inspect(VALUE time)
 
     GetTimeval(time, tobj);
     str = strftimev("%Y-%m-%d %H:%M:%S", time, rb_usascii_encoding());
-    subsec = w2v(wmod(tobj->timew, WINT2FIXWV(TIME_SCALE)));
+    subsec = rb_to_int(w2v(wmod(tobj->timew, WINT2FIXWV(TIME_SCALE))));
     if (FIXNUM_P(subsec) && FIX2LONG(subsec) == 0) {
     }
     else if (FIXNUM_P(subsec) && FIX2LONG(subsec) < TIME_SCALE) {


### PR DESCRIPTION
I think almost all Ruby programmers find the rational formatting
less useful, and most would consider it a bug.

Implements [Feature #16470]