### PR TITLE
Convert ip addresses to canonical form in Resolv::DNS::Requester::UnconnectedUDP#sender

### DIFF
--- a/lib/resolv.rb
+++ b/lib/resolv.rb
@@ -767,6 +767,7 @@ class Resolv
         end
 
         def sender(msg, data, host, port=Port)
+          host = Addrinfo.ip(host).ip_address
           lazy_initialize
           sock = @socks_hash[host.index(':') ? "::" : "0.0.0.0"]
           return nil if !sock


### PR DESCRIPTION
Otherwise, if the IP address given is not in canonical form, it
won't match, and Resolv will ignore it.

Fixes [Bug #16439]