### PR TITLE
fix typo in Hash#delete docs

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -2506,7 +2506,7 @@ rb_hash_delete(VALUE hash, VALUE key)
 /*
  *  call-seq:
  *    hash.delete(key) -> value or nil
- *    hash.delete(key) { |key| ... } -<value
+ *    hash.delete(key) { |key| ... } -> value
  *
  *  Deletes the entry for the given +key+
  *  and returns its associated value.


### PR DESCRIPTION
It's seems like typo?

```c
 *  call-seq:
 *    hash.delete(key) -> value or nil
 *    hash.delete(key) { |key| ... } -<value
```
