### PR TITLE
vm_insnhelper.c: merge opt_eq_func / opt_eql_func

### DIFF
--- a/insns.def
+++ b/insns.def
@@ -1168,7 +1168,7 @@ opt_eq
 (VALUE recv, VALUE obj)
 (VALUE val)
 {
-    val = opt_eq_func(GET_ISEQ(), recv, obj, cd);
+    val = opt_equality(GET_ISEQ(), recv, obj, cd);
 
     if (val == Qundef) {
         CALL_SIMPLE_METHOD();


### PR DESCRIPTION
These two function were almost identical, except in case of T_STRING. Why not merge them into one, and let the difference be handled in normal method calls (slowpath).  This does not improve runtime performance for me, but at least reduces for instance rb_eql_opt from 653 bytes to 86 bytes on my machine, according to `nm(1)`.