### PR TITLE
Add static modifier in object.c

### DIFF
--- a/object.c
+++ b/object.c
@@ -678,7 +678,7 @@ rb_obj_init_copy(VALUE obj, VALUE orig)
  * \param[in] orig    the object to be dup from.
  *++
  **/
-VALUE
+static VALUE
 rb_obj_init_dup_clone(VALUE obj, VALUE orig)
 {
     rb_funcall(obj, id_init_copy, 1, orig);

--- a/object.c
+++ b/object.c
@@ -974,7 +974,7 @@ rb_class_search_ancestor(VALUE cl, VALUE c)
  *++
  */
 
-VALUE
+static VALUE
 rb_obj_tap(VALUE obj)
 {
     rb_yield(obj);

--- a/object.c
+++ b/object.c
@@ -2392,7 +2392,7 @@ rb_mod_attr_reader(int argc, VALUE *argv, VALUE klass)
  * \todo can be static?
  *++
  */
-VALUE
+static VALUE
 rb_mod_attr(int argc, VALUE *argv, VALUE klass)
 {
     if (argc == 2 && (argv[1] == Qtrue || argv[1] == Qfalse)) {


### PR DESCRIPTION
These function seem's to not used by other source code.

- `rb_obj_init_dup_clone`
- `rb_obj_tap`
- `rb_mod_attr`

So, I think added static modifier is better.