### PR TITLE
Add a spec for the new NoMethodError display of the receiver

### DIFF
--- a/spec/ruby/core/exception/no_method_error_spec.rb
+++ b/spec/ruby/core/exception/no_method_error_spec.rb
@@ -103,6 +103,24 @@ describe "NoMethodError#message" do
       message.should include test_class.inspect
     end
   end
+
+  ruby_version_is "2.8" do
+    it "uses #name to display the receiver if it is a class or a module" do
+      klass = Class.new { def self.name; "MyClass"; end }
+      begin
+        klass.foo
+      rescue NoMethodError => error
+        error.message.lines.first.should == "undefined method `foo' for MyClass:Class\n"
+      end
+
+      mod = Module.new { def self.name; "MyModule"; end }
+      begin
+        mod.foo
+      rescue NoMethodError => error
+        error.message.lines.first.should == "undefined method `foo' for MyModule:Module\n"
+      end
+    end
+  end
 end
 
 describe "NoMethodError#dup" do


### PR DESCRIPTION
Ref: 7d5da30c9e9c572f6ef0aaccc1ca0e724966e2ee
Ref: https://github.com/ruby/ruby/pull/3080

As discussed in https://bugs.ruby-lang.org/issues/16832#note-19

cc @eregon 