### PR TITLE
Encode ' as &apos; when using encode(xml: :attr)

### DIFF
--- a/enc/trans/escape.trans
+++ b/enc/trans/escape.trans
@@ -18,9 +18,10 @@
   ], nil)
 
   transcode_tblgen("", "xml_attr_content_escape", [
-    ["{00-21,23-25,27-3B,3D,3F-FF}", :nomap],
+    ["{00-21,23-25,28-3B,3D,3F-FF}", :nomap],
     ["22", hexstr("&quot;")],
     ["26", hexstr("&amp;")],
+    ["27", hexstr("&apos;")],
     ["3C", hexstr("&lt;")],
     ["3E", hexstr("&gt;")]
   ], nil)

--- a/test/ruby/test_econv.rb
+++ b/test/ruby/test_econv.rb
@@ -803,7 +803,7 @@ class TestEncodingConverter < Test::Unit::TestCase
     assert_equal('', ec.finish)
 
     ec = Encoding::Converter.new("", "xml_attr_content_escape")
-    assert_equal('&amp;&lt;&gt;&quot;', ec.convert("&<>\""))
+    assert_equal('&amp;&lt;&gt;&quot;&apos;', ec.convert("&<>\"'"))
     assert_equal('', ec.finish)
   end
 
@@ -844,7 +844,7 @@ class TestEncodingConverter < Test::Unit::TestCase
   def test_xml_hasharg
     assert_equal("&amp;\e$B$&\e(B&#x2665;&amp;\"'".force_encoding("iso-2022-jp"),
         "&\u3046\u2665&\"'".encode("iso-2022-jp", xml: :text))
-    assert_equal("\"&amp;\e$B$&\e(B&#x2661;&amp;&quot;'\"".force_encoding("iso-2022-jp"),
+    assert_equal("\"&amp;\e$B$&\e(B&#x2661;&amp;&quot;&apos;\"".force_encoding("iso-2022-jp"),
       "&\u3046\u2661&\"'".encode("iso-2022-jp", xml: :attr))
 
     assert_equal("&amp;\u3046\u2661&amp;\"'".force_encoding("utf-8"),

--- a/test/ruby/test_io_m17n.rb
+++ b/test/ruby/test_io_m17n.rb
@@ -2047,19 +2047,19 @@ EOT
     with_tmpdir {
       open("raw.txt", "wb", xml: :attr) {|f| f.print '&<>"\''; f.puts "\u4E02\u3042" }
       content = File.read("raw.txt", :mode=>"rb:ascii-8bit")
-      assert_equal("\"&amp;&lt;&gt;&quot;'\u4E02\u3042\n\"".force_encoding("ascii-8bit"), content)
+      assert_equal("\"&amp;&lt;&gt;&quot;&apos;\u4E02\u3042\n\"".force_encoding("ascii-8bit"), content)
 
       open("ascii.txt", "wb:us-ascii", xml: :attr) {|f| f.print '&<>"\''; f.puts "\u4E02\u3042" }
       content = File.read("ascii.txt", :mode=>"rb:ascii-8bit")
-      assert_equal("\"&amp;&lt;&gt;&quot;'&#x4E02;&#x3042;\n\"".force_encoding("ascii-8bit"), content)
+      assert_equal("\"&amp;&lt;&gt;&quot;&apos;&#x4E02;&#x3042;\n\"".force_encoding("ascii-8bit"), content)
 
       open("iso-2022-jp.txt", "wb:iso-2022-jp", xml: :attr) {|f| f.print '&<>"\''; f.puts "\u4E02\u3042" }
       content = File.read("iso-2022-jp.txt", :mode=>"rb:ascii-8bit")
-      assert_equal("\"&amp;&lt;&gt;&quot;'&#x4E02;\e$B$\"\e(B\n\"".force_encoding("ascii-8bit"), content)
+      assert_equal("\"&amp;&lt;&gt;&quot;&apos;&#x4E02;\e$B$\"\e(B\n\"".force_encoding("ascii-8bit"), content)
 
       open("utf-16be.txt", "wb:utf-16be", xml: :attr) {|f| f.print '&<>"\''; f.puts "\u4E02\u3042" }
       content = File.read("utf-16be.txt", :mode=>"rb:ascii-8bit")
-      assert_equal("\0\"\0&\0a\0m\0p\0;\0&\0l\0t\0;\0&\0g\0t\0;\0&\0q\0u\0o\0t\0;\0'\x4E\x02\x30\x42\0\n\0\"".force_encoding("ascii-8bit"), content)
+      assert_equal("\0\"\0&\0a\0m\0p\0;\0&\0l\0t\0;\0&\0g\0t\0;\0&\0q\0u\0o\0t\0;\0&\0a\0p\0o\0s\0;\x4E\x02\x30\x42\0\n\0\"".force_encoding("ascii-8bit"), content)
 
       open("eucjp.txt", "w:euc-jp:utf-8", xml: :attr) {|f|
         f.print "\u4E02" # U+4E02 is 0x3021 in JIS X 0212


### PR DESCRIPTION
Fixes [Bug #16922]