### PR TITLE
Allow callinfo live on-stack

### DIFF
--- a/iseq.c
+++ b/iseq.c
@@ -325,9 +325,13 @@ rb_iseq_mark(const rb_iseq_t *iseq)
         if (body->call_data) {
             struct rb_call_data *cds = (struct rb_call_data *)body->call_data;
             for (unsigned int i=0; i<body->ci_size; i++) {
-                rb_gc_mark_movable((VALUE)cds[i].ci);
+                const struct rb_callinfo *ci = cds[i].ci;
                 const struct rb_callcache *cc = cds[i].cc;
-                if (cc && vm_cc_markable(cds[i].cc)) {
+
+                if (vm_ci_markable(ci)) {
+                    rb_gc_mark_movable((VALUE)ci);
+                }
+                if (cc && vm_cc_markable(cc)) {
                     rb_gc_mark_movable((VALUE)cc);
                     // TODO: check enable
                 }

--- a/vm.c
+++ b/vm.c
@@ -386,7 +386,15 @@ rb_serial_t ruby_vm_global_method_state = 1;
 rb_serial_t ruby_vm_global_constant_state = 1;
 rb_serial_t ruby_vm_class_serial = 1;
 
-static const struct rb_callcache vm_empty_cc = VM_CC_ON_STACK(0, vm_call_general, { 0 }, 0);
+static const struct rb_callcache vm_empty_cc = {
+    .flags = T_IMEMO | (imemo_callcache << FL_USHIFT) | VM_CALLCACHE_UNMARKABLE,
+    .klass = Qfalse,
+    .cme_  = NULL,
+    .call_ = vm_call_general,
+    .aux_  = {
+        .v = Qfalse,
+    }
+};
 
 static void thread_free(void *ptr);
 

--- a/vm.c
+++ b/vm.c
@@ -386,7 +386,13 @@ rb_serial_t ruby_vm_global_method_state = 1;
 rb_serial_t ruby_vm_global_constant_state = 1;
 rb_serial_t ruby_vm_class_serial = 1;
 
-static const struct rb_callcache *vm_empty_cc;
+static const struct rb_callcache vm_empty_cc = {
+    .flags = (T_IMEMO | (imemo_callcache << FL_USHIFT) | VM_CALLCACHE_UNMARKABLE),
+    .klass = Qfalse,
+    .cme_ = NULL,
+    .call_ = vm_call_general,
+    .aux_.v = 0,
+};
 
 static void thread_free(void *ptr);
 
@@ -3424,10 +3430,6 @@ Init_vm_objects(void)
     vm->frozen_strings = st_init_table_with_size(&rb_fstring_hash_type, 10000);
 
     rb_objspace_gc_enable(vm->objspace);
-
-    vm_empty_cc = vm_cc_new(0, NULL, vm_call_general);
-    FL_SET_RAW((VALUE)vm_empty_cc, VM_CALLCACHE_UNMARKABLE);
-    rb_gc_register_mark_object((VALUE)vm_empty_cc);
 }
 
 /* top self */
@@ -3799,7 +3801,7 @@ vm_collect_usage_register(int reg, int isset)
 MJIT_FUNC_EXPORTED const struct rb_callcache *
 rb_vm_empty_cc(void)
 {
-    return vm_empty_cc;
+    return &vm_empty_cc;
 }
 
 #endif /* #ifndef MJIT_HEADER */

--- a/vm.c
+++ b/vm.c
@@ -386,13 +386,7 @@ rb_serial_t ruby_vm_global_method_state = 1;
 rb_serial_t ruby_vm_global_constant_state = 1;
 rb_serial_t ruby_vm_class_serial = 1;
 
-static const struct rb_callcache vm_empty_cc = {
-    .flags = (T_IMEMO | (imemo_callcache << FL_USHIFT) | VM_CALLCACHE_UNMARKABLE),
-    .klass = Qfalse,
-    .cme_ = NULL,
-    .call_ = vm_call_general,
-    .aux_.v = 0,
-};
+static const struct rb_callcache vm_empty_cc = VM_CC_ON_STACK(0, vm_call_general, { 0 }, 0);
 
 static void thread_free(void *ptr);
 

--- a/vm_callinfo.h
+++ b/vm_callinfo.h
@@ -187,18 +187,20 @@ vm_ci_dump(const struct rb_callinfo *ci)
      ((argc) & ~CI_EMBED_ARGC_MASK) ? false :      \
       (kwarg)                       ? false : true)
 
+#define vm_ci_new_id(mid, flag, argc, must_zero) \
+    ((const struct rb_callinfo *)                \
+     ((((VALUE)(mid )) << CI_EMBED_ID_SHFT)   |  \
+      (((VALUE)(flag)) << CI_EMBED_FLAG_SHFT) |  \
+      (((VALUE)(argc)) << CI_EMBED_ARGC_SHFT) |  \
+      RUBY_FIXNUM_FLAG))
+
 static inline const struct rb_callinfo *
 vm_ci_new_(ID mid, unsigned int flag, unsigned int argc, const struct rb_callinfo_kwarg *kwarg, const char *file, int line)
 {
 #if USE_EMBED_CI
     if (VM_CI_EMBEDDABLE_P(mid, flag, argc, kwarg)) {
-        VALUE embed_ci =
-          RUBY_FIXNUM_FLAG                    |
-          ((VALUE)argc << CI_EMBED_ARGC_SHFT) |
-          ((VALUE)flag << CI_EMBED_FLAG_SHFT) |
-          ((VALUE)mid  << CI_EMBED_ID_SHFT);
         RB_DEBUG_COUNTER_INC(ci_packed);
-        return (const struct rb_callinfo *)embed_ci;
+        return vm_ci_new_id(mid, flag, argc, kwarg);
     }
 #endif
 

--- a/vm_callinfo.h
+++ b/vm_callinfo.h
@@ -229,6 +229,23 @@ vm_ci_new_runtime_(ID mid, unsigned int flag, unsigned int argc, const struct rb
     return vm_ci_new_(mid, flag, argc, kwarg, file, line);
 }
 
+#define VM_CALLINFO_NOT_UNDER_GC IMEMO_FL_USER0
+
+static inline bool
+vm_ci_markable(const struct rb_callinfo *ci)
+{
+    if (! ci) {
+        return false; /* or true? This is Qfalse... */
+    }
+    else if (vm_ci_packed_p(ci)) {
+        return true;
+    }
+    else {
+        VM_ASSERT(IMEMO_TYPE_P(ci, imemo_callinfo));
+        return ! FL_ANY_RAW((VALUE)ci, VM_CALLINFO_NOT_UNDER_GC);
+    }
+}
+
 typedef VALUE (*vm_call_handler)(
     struct rb_execution_context_struct *ec,
     struct rb_control_frame_struct *cfp,

--- a/vm_callinfo.h
+++ b/vm_callinfo.h
@@ -251,6 +251,17 @@ vm_ci_markable(const struct rb_callinfo *ci)
     }
 }
 
+#define VM_CI_ON_STACK(mid_, flags_, argc_, kwarg_) \
+    (struct rb_callinfo) {                          \
+        .flags = T_IMEMO |                          \
+            (imemo_callinfo << FL_USHIFT) |         \
+            VM_CALLINFO_NOT_UNDER_GC,               \
+        .mid   = mid_,                              \
+        .flag  = flags_,                            \
+        .argc  = argc_,                             \
+        .kwarg = kwarg_,                            \
+    }
+
 typedef VALUE (*vm_call_handler)(
     struct rb_execution_context_struct *ec,
     struct rb_control_frame_struct *cfp,
@@ -290,22 +301,16 @@ vm_cc_new(VALUE klass,
     return cc;
 }
 
-static inline const struct rb_callcache *
-vm_cc_fill(struct rb_callcache *cc,
-           VALUE klass,
-           const struct rb_callable_method_entry_struct *cme,
-           vm_call_handler call)
-{
-    struct rb_callcache cc_body = {
-        .flags = T_IMEMO | (imemo_callcache << FL_USHIFT) | VM_CALLCACHE_UNMARKABLE,
-        .klass = klass,
-        .cme_ = cme,
-        .call_ = call,
-        .aux_.v = 0,
-    };
-    MEMCPY(cc, &cc_body, struct rb_callcache, 1);
-    return cc;
-}
+#define VM_CC_ON_STACK(clazz, call, aux, cme) \
+    (struct rb_callcache) {                   \
+        .flags = T_IMEMO |                    \
+            (imemo_callcache << FL_USHIFT) |  \
+            VM_CALLCACHE_UNMARKABLE,          \
+        .klass = clazz,                       \
+        .cme_  = cme,                         \
+        .call_ = call,                        \
+        .aux_  = aux,                         \
+    }
 
 static inline bool
 vm_cc_class_check(const struct rb_callcache *cc, VALUE klass)

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -45,20 +45,18 @@ static VALUE vm_call0_body(rb_execution_context_t* ec, struct rb_calling_info *c
 MJIT_FUNC_EXPORTED VALUE
 rb_vm_call0(rb_execution_context_t *ec, VALUE recv, ID id, int argc, const VALUE *argv, const rb_callable_method_entry_t *me, int kw_splat)
 {
-    return vm_call0_body(
-        ec,
-        &(struct rb_calling_info) {
-            .block_handler = VM_BLOCK_HANDLER_NONE,
-            .recv = recv,
-            .argc = argc,
-            .kw_splat = kw_splat,
-        },
-        &(struct rb_call_data) {
-            .ci = &VM_CI_ON_STACK(id, kw_splat ? VM_CALL_KW_SPLAT : 0, argc, NULL),
-            .cc = &VM_CC_ON_STACK(Qfalse, vm_call_general, { 0 }, me),
-        },
-        argv
-    );
+    struct rb_calling_info calling = {
+        .block_handler = VM_BLOCK_HANDLER_NONE,
+        .recv = recv,
+        .argc = argc,
+        .kw_splat = kw_splat,
+    };
+    struct rb_call_data cd = {
+        .ci = &VM_CI_ON_STACK(id, kw_splat ? VM_CALL_KW_SPLAT : 0, argc, NULL),
+        .cc = &VM_CC_ON_STACK(Qfalse, vm_call_general, { 0 }, me),
+    };
+
+    return vm_call0_body(ec, &calling, &cd, argv);
 }
 
 static VALUE

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -45,12 +45,20 @@ static VALUE vm_call0_body(rb_execution_context_t* ec, struct rb_calling_info *c
 MJIT_FUNC_EXPORTED VALUE
 rb_vm_call0(rb_execution_context_t *ec, VALUE recv, ID id, int argc, const VALUE *argv, const rb_callable_method_entry_t *me, int kw_splat)
 {
-    struct rb_calling_info calling = { Qundef, recv, argc, kw_splat, };
-    const struct rb_callinfo *ci = vm_ci_new_runtime(id, kw_splat ? VM_CALL_KW_SPLAT : 0, argc, NULL);
-    struct rb_callcache cc_body;
-    const struct rb_callcache *cc = vm_cc_fill(&cc_body, 0, me, vm_call_general);
-    struct rb_call_data cd = { ci, cc, };
-    return vm_call0_body(ec, &calling, &cd, argv);
+    return vm_call0_body(
+        ec,
+        &(struct rb_calling_info) {
+            .block_handler = VM_BLOCK_HANDLER_NONE,
+            .recv = recv,
+            .argc = argc,
+            .kw_splat = kw_splat,
+        },
+        &(struct rb_call_data) {
+            .ci = &VM_CI_ON_STACK(id, kw_splat ? VM_CALL_KW_SPLAT : 0, argc, NULL),
+            .cc = &VM_CC_ON_STACK(Qfalse, vm_call_general, { 0 }, me),
+        },
+        argv
+    );
 }
 
 static VALUE

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1473,6 +1473,13 @@ vm_ccs_create(VALUE klass, const rb_callable_method_entry_t *cme)
 static void
 vm_ccs_push(VALUE klass, struct rb_class_cc_entries *ccs, const struct rb_callinfo *ci, const struct rb_callcache *cc)
 {
+    if (! vm_cc_markable(cc)) {
+        return;
+    }
+    else if (! vm_ci_markable(ci)) {
+        return;
+    }
+
     if (UNLIKELY(ccs->len == ccs->capa)) {
         const int nsize = ccs->capa * 2;
         struct rb_class_cc_entries_entry *nents = ALLOC_N(struct rb_class_cc_entries_entry, nsize);

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1784,19 +1784,22 @@ opt_equality(const rb_iseq_t *cd_owner, VALUE recv, VALUE obj, CALL_DATA cd)
 #undef EQ_UNREDEFINED_P
 
 #ifndef MJIT_HEADER
-#define VM_CI_NEW_ID(mid) \
-    ((const struct rb_callinfo *)\
-     ((((VALUE)(mid)) << CI_EMBED_ID_SHFT) | RUBY_FIXNUM_FLAG))
-
 VALUE
 rb_equal_opt(VALUE obj1, VALUE obj2)
 {
     STATIC_ASSERT(idEq_is_embeddable, VM_CI_EMBEDDABLE_P(idEq, 0, 1, 0));
 
+#if USE_EMBED_CI
     static struct rb_call_data cd = {
-        .ci = VM_CI_NEW_ID(idEq),
+        .ci = vm_ci_new_id(idEq, 0, 1, 0),
         .cc = &vm_empty_cc,
     };
+#else
+    struct rb_call_data cd = {
+        .ci = &VM_CI_ON_STACK(idEq, 0, 1, 0),
+        .cc = &vm_empty_cc,
+    };
+#endif
 
     return opt_equality(NULL, obj1, obj2, &cd);
 }
@@ -1806,10 +1809,17 @@ rb_eql_opt(VALUE obj1, VALUE obj2)
 {
     STATIC_ASSERT(idEqlP_is_embeddable, VM_CI_EMBEDDABLE_P(idEqlP, 0, 1, 0));
 
+#if USE_EMBED_CI
     static struct rb_call_data cd = {
-        .ci = VM_CI_NEW_ID(idEqlP),
+        .ci = vm_ci_new_id(idEqlP, 0, 1, 0),
         .cc = &vm_empty_cc,
     };
+#else
+    struct rb_call_data cd = {
+        .ci = &VM_CI_ON_STACK(idEqlP, 0, 1, 0),
+        .cc = &vm_empty_cc,
+    };
+#endif
 
     return opt_equality(NULL, obj1, obj2, &cd);
 }

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1653,12 +1653,19 @@ vm_search_method(VALUE cd_owner, struct rb_call_data *cd, VALUE recv)
 static inline int
 check_cfunc(const rb_callable_method_entry_t *me, VALUE (*func)())
 {
-    if (me && me->def->type == VM_METHOD_TYPE_CFUNC &&
-	me->def->body.cfunc.func == func) {
-	return 1;
+    if (! me) {
+        return false;
     }
     else {
-	return 0;
+        VM_ASSERT(IMEMO_TYPE_P(me, imemo_ment));
+        VM_ASSERT(callable_method_entry_p(me));
+        VM_ASSERT(me->def);
+        if (me->def->type != VM_METHOD_TYPE_CFUNC) {
+            return false;
+        }
+        else {
+            return me->def->body.cfunc.func == func;
+        }
     }
 }
 

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -3159,9 +3159,10 @@ vm_call_method(rb_execution_context_t *ec, rb_control_frame_t *cfp, struct rb_ca
 		else {
 		    /* caching method info to dummy cc */
 		    VM_ASSERT(vm_cc_cme(cc) != NULL);
+                    const struct rb_callcache cc_on_stack = *cc;
                     return vm_call_method_each_type(ec, cfp, calling, &(struct rb_call_data) {
                         .ci = ci,
-                        .cc = &VM_CC_ON_STACK(cc->klass, vm_cc_call(cc), { 0 }, vm_cc_cme(cc)),
+                        .cc = &cc_on_stack,
                     });
 		}
 	    }

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1603,11 +1603,18 @@ rb_vm_search_method_slowpath(VALUE cd_owner, struct rb_call_data *cd, VALUE klas
 {
     const struct rb_callcache *cc = vm_search_cc(klass, cd->ci);
 
-    if (cd_owner) {
-        RB_OBJ_WRITE(cd_owner, &cd->cc, cc);
+    VM_ASSERT(cc);
+    VM_ASSERT(IMEMO_TYPE_P(cc, imemo_callcache));
+
+    if (! cd_owner) {
+        cd->cc = cc;
+    }
+    else if (cc == &vm_empty_cc) {
+        cd->cc = cc;
     }
     else {
-        cd->cc = cc;
+        VM_ASSERT(vm_cc_markable(cc));
+        RB_OBJ_WRITE(cd_owner, &cd->cc, cc);
     }
 
     VM_ASSERT(cc == vm_cc_empty() || cc->klass == klass);

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -2931,13 +2931,10 @@ vm_call_zsuper(rb_execution_context_t *ec, rb_control_frame_t *cfp, struct rb_ca
         cme = refined_method_callable_without_refinement(cme);
     }
 
-    struct rb_callcache cc_body;
-    struct rb_call_data cd_body = {
+    return vm_call_method_each_type(ec, cfp, calling, &(struct rb_call_data) {
         .ci = cd->ci,
-        .cc = vm_cc_fill(&cc_body, Qundef, cme, 0),
-    };
-    return vm_call_method_each_type(ec, cfp, calling, &cd_body);
-
+        .cc = &VM_CC_ON_STACK(Qundef, vm_call_general, { 0 }, cme),
+    });
 }
 
 static inline VALUE

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1799,15 +1799,14 @@ rb_equal_opt(VALUE obj1, VALUE obj2)
 #if USE_EMBED_CI
     static struct rb_call_data cd = {
         .ci = vm_ci_new_id(idEq, 0, 1, 0),
-        .cc = &vm_empty_cc,
     };
 #else
     struct rb_call_data cd = {
         .ci = &VM_CI_ON_STACK(idEq, 0, 1, 0),
-        .cc = &vm_empty_cc,
     };
 #endif
 
+    cd.cc = &vm_empty_cc;
     return opt_equality(NULL, obj1, obj2, &cd);
 }
 
@@ -1819,15 +1818,14 @@ rb_eql_opt(VALUE obj1, VALUE obj2)
 #if USE_EMBED_CI
     static struct rb_call_data cd = {
         .ci = vm_ci_new_id(idEqlP, 0, 1, 0),
-        .cc = &vm_empty_cc,
     };
 #else
     struct rb_call_data cd = {
         .ci = &VM_CI_ON_STACK(idEqlP, 0, 1, 0),
-        .cc = &vm_empty_cc,
     };
 #endif
 
+    cd.cc = &vm_empty_cc;
     return opt_equality(NULL, obj1, obj2, &cd);
 }
 #endif

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -2682,16 +2682,25 @@ aliased_callable_method_entry(const rb_callable_method_entry_t *me)
     return cme;
 }
 
+#define VM_CC_ON_STACK(clazz, call, aux, cme) \
+    (struct rb_callcache) {                   \
+        .flags = T_IMEMO |                    \
+            (imemo_callcache << FL_USHIFT) |  \
+            VM_CALLCACHE_UNMARKABLE,          \
+        .klass = clazz,                       \
+        .cme_  = cme,                         \
+        .call_ = call,                        \
+        .aux_  = aux,                         \
+    }
+
 static VALUE
 vm_call_alias(rb_execution_context_t *ec, rb_control_frame_t *cfp, struct rb_calling_info *calling, struct rb_call_data *cd)
 {
-    const rb_callable_method_entry_t *cme = aliased_callable_method_entry(vm_cc_cme(cd->cc));
-    struct rb_callcache cc_body;
-    struct rb_call_data cd_body = {
+    return vm_call_method_each_type(ec, cfp, calling, &(struct rb_call_data) {
         .ci = cd->ci,
-        .cc = vm_cc_fill(&cc_body, Qundef, cme, 0),
-    };
-    return vm_call_method_each_type(ec, cfp, calling, &cd_body);
+        .cc = &VM_CC_ON_STACK(Qundef, vm_call_general, { 0 },
+            aliased_callable_method_entry(vm_cc_cme(cd->cc))),
+    });
 }
 
 static enum method_missing_reason

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -2682,28 +2682,6 @@ aliased_callable_method_entry(const rb_callable_method_entry_t *me)
     return cme;
 }
 
-#define VM_CI_ON_STACK(mid_, flags_, argc_, kwarg_) \
-    (struct rb_callinfo) {                          \
-        .flags = T_IMEMO |                          \
-            (imemo_callinfo << FL_USHIFT) |         \
-            VM_CALLINFO_NOT_UNDER_GC,               \
-        .mid   = mid_,                              \
-        .flag  = flags_,                            \
-        .argc  = argc_,                             \
-        .kwarg = kwarg_,                            \
-    }
-
-#define VM_CC_ON_STACK(clazz, call, aux, cme) \
-    (struct rb_callcache) {                   \
-        .flags = T_IMEMO |                    \
-            (imemo_callcache << FL_USHIFT) |  \
-            VM_CALLCACHE_UNMARKABLE,          \
-        .klass = clazz,                       \
-        .cme_  = cme,                         \
-        .call_ = call,                        \
-        .aux_  = aux,                         \
-    }
-
 static VALUE
 vm_call_alias(rb_execution_context_t *ec, rb_control_frame_t *cfp, struct rb_calling_info *calling, struct rb_call_data *cd)
 {

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -3468,10 +3468,7 @@ vm_yield_setup_args(rb_execution_context_t *ec, const rb_iseq_t *iseq, const int
     calling->block_handler = block_handler;
     calling->kw_splat = kw_splat;
     calling->recv = Qundef;
-    struct rb_callinfo dummy_ci = {
-        .flags = T_IMEMO | (imemo_callinfo << FL_USHIFT),
-        .flag = (VALUE)(kw_splat ? VM_CALL_KW_SPLAT : 0),
-    };
+    struct rb_callinfo dummy_ci = VM_CI_ON_STACK(0, (kw_splat ? VM_CALL_KW_SPLAT : 0), 0, 0);
 
     return vm_callee_setup_block_arg(ec, calling, &dummy_ci, iseq, argv, arg_setup_type);
 }

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -3181,12 +3181,10 @@ vm_call_method(rb_execution_context_t *ec, rb_control_frame_t *cfp, struct rb_ca
 		else {
 		    /* caching method info to dummy cc */
 		    VM_ASSERT(vm_cc_cme(cc) != NULL);
-                    struct rb_callcache cc_body;
-                    struct rb_call_data cd_body = {
+                    return vm_call_method_each_type(ec, cfp, calling, &(struct rb_call_data) {
                         .ci = ci,
-                        .cc = vm_cc_fill(&cc_body, cc->klass, vm_cc_cme(cc), vm_cc_call(cc)),
-                    };
-                    return vm_call_method_each_type(ec, cfp, calling, &cd_body);
+                        .cc = &VM_CC_ON_STACK(cc->klass, vm_cc_call(cc), { 0 }, vm_cc_cme(cc)),
+                    });
 		}
 	    }
             return vm_call_method_each_type(ec, cfp, calling, cd);

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -3042,12 +3042,10 @@ vm_call_refined(rb_execution_context_t *ec, rb_control_frame_t *cfp, struct rb_c
     const rb_callable_method_entry_t *cme = search_refined_method(ec, cfp, cd);
 
     if (cme != NULL) {
-        struct rb_callcache cc_body;
-        struct rb_call_data cd_body = {
+        return vm_call_method(ec, cfp, calling, &(struct rb_call_data) {
             .ci = cd->ci,
-            .cc = vm_cc_fill(&cc_body, Qundef, cme, 0),
-        };
-        return vm_call_method(ec, cfp, calling, &cd_body);
+            .cc = &VM_CC_ON_STACK(Qundef, vm_call_general, { 0 }, cme),
+        });
     }
     else {
         return vm_call_method_nome(ec, cfp, calling, cd);

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1784,8 +1784,6 @@ opt_equality(const rb_iseq_t *cd_owner, VALUE recv, VALUE obj, CALL_DATA cd)
 #undef EQ_UNREDEFINED_P
 
 #ifndef MJIT_HEADER
-
-#define vm_ci_new_id(mid) vm_ci_new_runtime(mid, 0, 0, NULL)
 #define VM_CI_NEW_ID(mid) \
     ((const struct rb_callinfo *)\
      ((((VALUE)(mid)) << CI_EMBED_ID_SHFT) | RUBY_FIXNUM_FLAG))
@@ -1802,14 +1800,20 @@ rb_equal_opt(VALUE obj1, VALUE obj2)
 
     return opt_equality(NULL, obj1, obj2, &cd);
 }
-#endif
 
 VALUE
 rb_eql_opt(VALUE obj1, VALUE obj2)
 {
-    struct rb_call_data cd = { .ci = vm_ci_new_id(idEqlP), .cc = vm_cc_empty() };
+    STATIC_ASSERT(idEqlP_is_embeddable, VM_CI_EMBEDDABLE_P(idEqlP, 0, 1, 0));
+
+    static struct rb_call_data cd = {
+        .ci = VM_CI_NEW_ID(idEqlP),
+        .cc = &vm_empty_cc,
+    };
+
     return opt_equality(NULL, obj1, obj2, &cd);
 }
+#endif
 
 extern VALUE rb_vm_call0(rb_execution_context_t *ec, VALUE, ID, int, const VALUE*, const rb_callable_method_entry_t *, int kw_splat);
 


### PR DESCRIPTION
`struct rb_callinfo`s are created on-the-fly, which results in increasing GC pressure.  However they include no references to other objects, and those on-the-fly CIs tend to be short lived.  Why not skip allocation of them.  By allowing CI/CC to be on stack, some functions could be reduced in generated binary.

Main purpose of this pull request is the binary size.  No speedup is observed for optcarrot.  However because it modifies `rb_vm_call0`, some micro benchmarks cerebrate very small improvements.

```
Calculating -------------------------------------
                         master        ours
 enum_lazy_grep_v_20      6.481       6.600 i/s -       1.000 times in 0.154301s 0.151505s
 enum_lazy_grep_v_50      4.846       4.953 i/s -       1.000 times in 0.206348s 0.201884s
enum_lazy_grep_v_100      3.430       3.733 i/s -       1.000 times in 0.291519s 0.267860s
   enum_lazy_uniq_20      5.589       5.818 i/s -       1.000 times in 0.178924s 0.171895s
   enum_lazy_uniq_50      4.042       4.152 i/s -       1.000 times in 0.247420s 0.240838s
  enum_lazy_uniq_100      2.772       2.862 i/s -       1.000 times in 0.360692s 0.349366s

Comparison:
              enum_lazy_grep_v_20
                ours:         6.6 i/s
              master:         6.5 i/s - 1.02x  slower

              enum_lazy_grep_v_50
                ours:         5.0 i/s
              master:         4.8 i/s - 1.02x  slower

             enum_lazy_grep_v_100
                ours:         3.7 i/s
              master:         3.4 i/s - 1.09x  slower

                enum_lazy_uniq_20
                ours:         5.8 i/s
              master:         5.6 i/s - 1.04x  slower

                enum_lazy_uniq_50
                ours:         4.2 i/s
              master:         4.0 i/s - 1.03x  slower

               enum_lazy_uniq_100
                ours:         2.9 i/s
              master:         2.8 i/s - 1.03x  slower

```
