### PR TITLE
Ensure that the head of the vacancy list is correctly inserted into t…

### DIFF
--- a/cont.c
+++ b/cont.c
@@ -336,6 +336,7 @@ fiber_pool_vacancy_push(struct fiber_pool_vacancy * vacancy, struct fiber_pool_v
 #ifdef FIBER_POOL_ALLOCATION_FREE
     if (head) {
         head->previous = vacancy;
+        vacancy->previous = NULL;
     }
 #endif
 


### PR DESCRIPTION
…he linked list.

See <https://bugs.ruby-lang.org/issues/16814> for more details.