### PR TITLE
Add leading arguments support to arguments forwarding

### DIFF
--- a/test/ripper/test_parser_events.rb
+++ b/test/ripper/test_parser_events.rb
@@ -132,9 +132,17 @@ class TestRipper::ParserEvents < Test::Unit::TestCase
   end
 
   def test_args_forward
-    thru_args_forward = false
-    parse('def m(...) n(...) end', :on_args_forward) {thru_args_forward = true}
-    assert_equal true, thru_args_forward
+    [
+      'def m(...) n(...) end',
+      'def m(...) end',
+      'def m(a, ...) n(1, ...) end',
+      'def m(...) n(1, ...) end',
+      'def m(a, ...) n(...) end'
+    ].each do |code|
+      thru_args_forward = false
+      parse(code, :on_args_forward) {thru_args_forward = true}
+      assert_equal true, thru_args_forward, "no args_forward for: #{code}"
+    end
   end
 
   def test_arg_paren

--- a/test/ruby/test_syntax.rb
+++ b/test/ruby/test_syntax.rb
@@ -1581,6 +1581,119 @@ eom
     end
   end
 
+  def test_argument_forwarding_with_leading_arguments
+    obj = Object.new
+    def obj.bar(*args, **kws, &block)
+      if block
+        block.call(args, kws)
+      else
+        [args, kws]
+      end
+    end
+    obj.instance_eval('def foo(_a, ...) bar(...) end', __FILE__, __LINE__)
+    assert_equal [[], {}], obj.foo(1)
+    assert_equal [[2], {}], obj.foo(1, 2)
+    assert_equal [[2, 3], {}], obj.foo(1, 2, 3)
+    assert_equal [[], {a: 1}], obj.foo(1, a: 1)
+    assert_equal [[2], {a: 1}], obj.foo(1, 2, a: 1)
+    assert_equal [[2, 3], {a: 1}], obj.foo(1, 2, 3, a: 1)
+    assert_equal [[2, 3], {a: 1}], obj.foo(1, 2, 3, a: 1){|args, kws| [args, kws]}
+
+    obj.singleton_class.send(:remove_method, :foo)
+    obj.instance_eval('def foo(...) bar(1, ...) end', __FILE__, __LINE__)
+    assert_equal [[1], {}], obj.foo
+    assert_equal [[1, 1], {}], obj.foo(1)
+    assert_equal [[1, 1, 2], {}], obj.foo(1, 2)
+    assert_equal [[1, 1, 2, 3], {}], obj.foo(1, 2, 3)
+    assert_equal [[1], {a: 1}], obj.foo(a: 1)
+    assert_equal [[1, 1], {a: 1}], obj.foo(1, a: 1)
+    assert_equal [[1, 1, 2], {a: 1}], obj.foo(1, 2, a: 1)
+    assert_equal [[1, 1, 2, 3], {a: 1}], obj.foo(1, 2, 3, a: 1)
+    assert_equal [[1, 1, 2, 3], {a: 1}], obj.foo(1, 2, 3, a: 1){|args, kws| [args, kws]}
+
+    obj.singleton_class.send(:remove_method, :foo)
+    obj.instance_eval('def foo(a, ...) bar(a, ...) end', __FILE__, __LINE__)
+    assert_equal [[4], {}], obj.foo(4)
+    assert_equal [[4, 2], {}], obj.foo(4, 2)
+    assert_equal [[4, 2, 3], {}], obj.foo(4, 2, 3)
+    assert_equal [[4], {a: 1}], obj.foo(4, a: 1)
+    assert_equal [[4, 2], {a: 1}], obj.foo(4, 2, a: 1)
+    assert_equal [[4, 2, 3], {a: 1}], obj.foo(4, 2, 3, a: 1)
+    assert_equal [[4, 2, 3], {a: 1}], obj.foo(4, 2, 3, a: 1){|args, kws| [args, kws]}
+
+    obj.singleton_class.send(:remove_method, :foo)
+    obj.instance_eval('def foo(_a, ...) bar(1, ...) end', __FILE__, __LINE__)
+    assert_equal [[1], {}], obj.foo(4)
+    assert_equal [[1, 2], {}], obj.foo(4, 2)
+    assert_equal [[1, 2, 3], {}], obj.foo(4, 2, 3)
+    assert_equal [[1], {a: 1}], obj.foo(4, a: 1)
+    assert_equal [[1, 2], {a: 1}], obj.foo(4, 2, a: 1)
+    assert_equal [[1, 2, 3], {a: 1}], obj.foo(4, 2, 3, a: 1)
+    assert_equal [[1, 2, 3], {a: 1}], obj.foo(4, 2, 3, a: 1){|args, kws| [args, kws]}
+
+    obj.singleton_class.send(:remove_method, :foo)
+    obj.instance_eval('def foo(_a, _b, ...) bar(...) end', __FILE__, __LINE__)
+    assert_equal [[], {}], obj.foo(4, 5)
+    assert_equal [[2], {}], obj.foo(4, 5, 2)
+    assert_equal [[2, 3], {}], obj.foo(4, 5, 2, 3)
+    assert_equal [[], {a: 1}], obj.foo(4, 5, a: 1)
+    assert_equal [[2], {a: 1}], obj.foo(4, 5, 2, a: 1)
+    assert_equal [[2, 3], {a: 1}], obj.foo(4, 5, 2, 3, a: 1)
+    assert_equal [[2, 3], {a: 1}], obj.foo(4, 5, 2, 3, a: 1){|args, kws| [args, kws]}
+
+    obj.singleton_class.send(:remove_method, :foo)
+    obj.instance_eval('def foo(_a, _b, ...) bar(1, ...) end', __FILE__, __LINE__)
+    assert_equal [[1], {}], obj.foo(4, 5)
+    assert_equal [[1, 2], {}], obj.foo(4, 5, 2)
+    assert_equal [[1, 2, 3], {}], obj.foo(4, 5, 2, 3)
+    assert_equal [[1], {a: 1}], obj.foo(4, 5, a: 1)
+    assert_equal [[1, 2], {a: 1}], obj.foo(4, 5, 2, a: 1)
+    assert_equal [[1, 2, 3], {a: 1}], obj.foo(4, 5, 2, 3, a: 1)
+    assert_equal [[1, 2, 3], {a: 1}], obj.foo(4, 5, 2, 3, a: 1){|args, kws| [args, kws]}
+
+    obj.singleton_class.send(:remove_method, :foo)
+    obj.instance_eval('def foo(_a, ...) bar(1, 2, ...) end', __FILE__, __LINE__)
+    assert_equal [[1, 2], {}], obj.foo(5)
+    assert_equal [[1, 2, 5], {}], obj.foo(4, 5)
+    assert_equal [[1, 2, 5, 2], {}], obj.foo(4, 5, 2)
+    assert_equal [[1, 2, 5, 2, 3], {}], obj.foo(4, 5, 2, 3)
+    assert_equal [[1, 2, 5], {a: 1}], obj.foo(4, 5, a: 1)
+    assert_equal [[1, 2, 5, 2], {a: 1}], obj.foo(4, 5, 2, a: 1)
+    assert_equal [[1, 2, 5, 2, 3], {a: 1}], obj.foo(4, 5, 2, 3, a: 1)
+    assert_equal [[1, 2, 5, 2, 3], {a: 1}], obj.foo(4, 5, 2, 3, a: 1){|args, kws| [args, kws]}
+
+    obj.singleton_class.send(:remove_method, :foo)
+    obj.instance_eval('def foo(a, b, ...) bar(b, a, ...) end', __FILE__, __LINE__)
+    assert_equal [[5, 4], {}], obj.foo(4, 5)
+    assert_equal [[5, 4, 2], {}], obj.foo(4, 5, 2)
+    assert_equal [[5, 4, 2, 3], {}], obj.foo(4, 5, 2, 3)
+    assert_equal [[5, 4], {a: 1}], obj.foo(4, 5, a: 1)
+    assert_equal [[5, 4, 2], {a: 1}], obj.foo(4, 5, 2, a: 1)
+    assert_equal [[5, 4, 2, 3], {a: 1}], obj.foo(4, 5, 2, 3, a: 1)
+    assert_equal [[5, 4, 2, 3], {a: 1}], obj.foo(4, 5, 2, 3, a: 1){|args, kws| [args, kws]}
+
+    obj.singleton_class.send(:remove_method, :foo)
+    obj.instance_eval('def foo(a, _b, ...) bar(a, ...) end', __FILE__, __LINE__)
+    assert_equal [[4], {}], obj.foo(4, 5)
+    assert_equal [[4, 2], {}], obj.foo(4, 5, 2)
+    assert_equal [[4, 2, 3], {}], obj.foo(4, 5, 2, 3)
+    assert_equal [[4], {a: 1}], obj.foo(4, 5, a: 1)
+    assert_equal [[4, 2], {a: 1}], obj.foo(4, 5, 2, a: 1)
+    assert_equal [[4, 2, 3], {a: 1}], obj.foo(4, 5, 2, 3, a: 1)
+    assert_equal [[4, 2, 3], {a: 1}], obj.foo(4, 5, 2, 3, a: 1){|args, kws| [args, kws]}
+
+    obj.singleton_class.send(:remove_method, :foo)
+    obj.instance_eval('def foo(a, ...) bar(a, 1, ...) end', __FILE__, __LINE__)
+    assert_equal [[4, 1], {}], obj.foo(4)
+    assert_equal [[4, 1, 5], {}], obj.foo(4, 5)
+    assert_equal [[4, 1, 5, 2], {}], obj.foo(4, 5, 2)
+    assert_equal [[4, 1, 5, 2, 3], {}], obj.foo(4, 5, 2, 3)
+    assert_equal [[4, 1, 5], {a: 1}], obj.foo(4, 5, a: 1)
+    assert_equal [[4, 1, 5, 2], {a: 1}], obj.foo(4, 5, 2, a: 1)
+    assert_equal [[4, 1, 5, 2, 3], {a: 1}], obj.foo(4, 5, 2, 3, a: 1)
+    assert_equal [[4, 1, 5, 2, 3], {a: 1}], obj.foo(4, 5, 2, 3, a: 1){|args, kws| [args, kws]}
+  end
+
   def test_rightward_assign
     assert_equal(1, eval("1 => a"))
     assert_equal([2,3], eval("13.divmod(5) => a,b; [a, b]"))


### PR DESCRIPTION
The idFWD_KWREST sections may be wrong. However, the existing
idFWD_KWREST sections for ... without leading arguments are already
broken.

Implements [Feature #16378]