### PR TITLE
Return seconds slept after Thread.scheduler wait_sleep

### DIFF
--- a/process.c
+++ b/process.c
@@ -4920,20 +4920,20 @@ rb_f_spawn(int argc, VALUE *argv, VALUE _)
 static VALUE
 rb_f_sleep(int argc, VALUE *argv, VALUE _)
 {
+    time_t beg = time(0);
     VALUE scheduler = rb_current_thread_scheduler();
 
     if (scheduler != Qnil) {
-        VALUE result = rb_funcallv(scheduler, rb_intern("wait_sleep"), argc, argv);
-        return RTEST(result);
-    }
-
-    time_t beg = time(0);
-    if (argc == 0) {
-	rb_thread_sleep_forever();
+        rb_funcallv(scheduler, rb_intern("wait_sleep"), argc, argv);
     }
     else {
-	rb_check_arity(argc, 0, 1);
-	rb_thread_wait_for(rb_time_interval(argv[0]));
+        if (argc == 0) {
+            rb_thread_sleep_forever();
+        }
+        else {
+            rb_check_arity(argc, 0, 1);
+            rb_thread_wait_for(rb_time_interval(argv[0]));
+        }
     }
 
     time_t end = time(0) - beg;

--- a/test/fiber/test_sleep.rb
+++ b/test/fiber/test_sleep.rb
@@ -14,7 +14,7 @@ class TestFiberSleep < Test::Unit::TestCase
 
       5.times do |i|
         Fiber do
-          sleep(i/100.0)
+          assert(sleep(i/100.0) >= 0)
           items << i
         end
       end
@@ -27,4 +27,21 @@ class TestFiberSleep < Test::Unit::TestCase
 
     assert_equal ITEMS, items
   end
+
+  def test_sleep_returns_seconds_slept
+    seconds = nil
+
+    thread = Thread.new do
+      scheduler = Scheduler.new
+      Thread.current.scheduler = scheduler
+      Fiber do
+        seconds = sleep(2)
+      end
+    end
+
+    thread.join
+
+    assert(seconds >= 2, "actual: %p" % seconds)
+  end
+
 end


### PR DESCRIPTION
Kernel#sleep should still return seconds slept, even when using a
Thread.scheduler. The return value of Scheduler#wait_sleep can be
ignored.