### PR TITLE
Work around infinite loop when overriding method visibility in prepended module

### DIFF
--- a/proc.c
+++ b/proc.c
@@ -1554,7 +1554,6 @@ mnew_internal(const rb_method_entry_t *me, VALUE klass, VALUE iclass,
     struct METHOD *data;
     VALUE method;
     rb_method_visibility_t visi = METHOD_VISI_UNDEF;
-    VALUE orig_klass = klass;
 
   again:
     if (UNDEFINED_METHOD_ENTRY_P(me)) {
@@ -1573,22 +1572,12 @@ mnew_internal(const rb_method_entry_t *me, VALUE klass, VALUE iclass,
     }
     if (me->def->type == VM_METHOD_TYPE_ZSUPER) {
 	if (me->defined_class) {
-            klass = RCLASS_SUPER(RCLASS_ORIGIN(me->defined_class));
+            VALUE klass = RCLASS_SUPER(RCLASS_ORIGIN(me->defined_class));
 	    id = me->def->original_id;
             me = (rb_method_entry_t *)rb_callable_method_entry_with_refinements(klass, id, &iclass);
 	}
 	else {
-            VALUE tmp_klass, owner_super;
-            int seen = 0;
-            owner_super = RCLASS_SUPER(me->owner);
-
-            for(tmp_klass = owner_super; tmp_klass; tmp_klass = RCLASS_SUPER(tmp_klass)) {
-                if (tmp_klass == klass) {
-                    seen = 1;
-                    break;
-                }
-            }
-            klass = seen ? RCLASS_SUPER(klass) : owner_super;
+            VALUE klass = RCLASS_SUPER(RCLASS_ORIGIN(me->owner));
 	    id = me->def->original_id;
 	    me = rb_method_entry_without_refinements(klass, id, &iclass);
 	}
@@ -1598,7 +1587,7 @@ mnew_internal(const rb_method_entry_t *me, VALUE klass, VALUE iclass,
     method = TypedData_Make_Struct(mclass, struct METHOD, &method_data_type, data);
 
     RB_OBJ_WRITE(method, &data->recv, obj);
-    RB_OBJ_WRITE(method, &data->klass, orig_klass);
+    RB_OBJ_WRITE(method, &data->klass, klass);
     RB_OBJ_WRITE(method, &data->iclass, iclass);
     RB_OBJ_WRITE(method, &data->me, me);
 

--- a/proc.c
+++ b/proc.c
@@ -1554,6 +1554,7 @@ mnew_internal(const rb_method_entry_t *me, VALUE klass, VALUE iclass,
     struct METHOD *data;
     VALUE method;
     rb_method_visibility_t visi = METHOD_VISI_UNDEF;
+    VALUE orig_klass = klass;
 
   again:
     if (UNDEFINED_METHOD_ENTRY_P(me)) {
@@ -1572,12 +1573,22 @@ mnew_internal(const rb_method_entry_t *me, VALUE klass, VALUE iclass,
     }
     if (me->def->type == VM_METHOD_TYPE_ZSUPER) {
 	if (me->defined_class) {
-	    VALUE klass = RCLASS_SUPER(RCLASS_ORIGIN(me->defined_class));
+            klass = RCLASS_SUPER(RCLASS_ORIGIN(me->defined_class));
 	    id = me->def->original_id;
             me = (rb_method_entry_t *)rb_callable_method_entry_with_refinements(klass, id, &iclass);
 	}
 	else {
-	    VALUE klass = RCLASS_SUPER(me->owner);
+            VALUE tmp_klass, owner_super;
+            int seen = 0;
+            owner_super = RCLASS_SUPER(me->owner);
+
+            for(tmp_klass = owner_super; tmp_klass; tmp_klass = RCLASS_SUPER(tmp_klass)) {
+                if (tmp_klass == klass) {
+                    seen = 1;
+                    break;
+                }
+            }
+            klass = seen ? RCLASS_SUPER(klass) : owner_super;
 	    id = me->def->original_id;
 	    me = rb_method_entry_without_refinements(klass, id, &iclass);
 	}
@@ -1587,7 +1598,7 @@ mnew_internal(const rb_method_entry_t *me, VALUE klass, VALUE iclass,
     method = TypedData_Make_Struct(mclass, struct METHOD, &method_data_type, data);
 
     RB_OBJ_WRITE(method, &data->recv, obj);
-    RB_OBJ_WRITE(method, &data->klass, klass);
+    RB_OBJ_WRITE(method, &data->klass, orig_klass);
     RB_OBJ_WRITE(method, &data->iclass, iclass);
     RB_OBJ_WRITE(method, &data->me, me);
 

--- a/test/ruby/test_method.rb
+++ b/test/ruby/test_method.rb
@@ -1197,8 +1197,8 @@ class TestMethod < Test::Unit::TestCase
 
       ::Object.prepend(M2)
 
-       m = Object.instance_method(:x)
-       assert_equal M, m.owner
+      m = Object.instance_method(:x)
+      assert_equal M, m.owner
     end;
   end
 

--- a/test/ruby/test_method.rb
+++ b/test/ruby/test_method.rb
@@ -1181,6 +1181,27 @@ class TestMethod < Test::Unit::TestCase
     assert_separately [], "RubyVM::InstructionSequence.compile_option = {trace_instruction: false}\n" + body
   end
 
+  def test_zsuper_private_override_instance_method
+    assert_separately(%w(--disable-gems), <<-'end;', timeout: 30)
+      # Bug #16942 [ruby-core:98691]
+      module M
+        def x
+        end
+      end
+
+      module M2
+        prepend Module.new
+        include M
+        private :x
+      end
+
+      ::Object.prepend(M2)
+
+       m = Object.instance_method(:x)
+       assert_equal M, m.owner
+    end;
+  end
+
   def test_eqq
     assert_operator(0.method(:<), :===, 5)
     assert_not_operator(0.method(:<), :===, -5)


### PR DESCRIPTION
This makes sure that during method entry lookup, we don't go backwards
in the super chain.  This approach is relatively inefficient, being
O(m*n) where m is the number of ZSUPER method entries in and n is
the average length of the super chain for the method entry.

Fixes [Bug #16942]