### PR TITLE
Fix ASan crash with debugging output

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -11514,6 +11514,8 @@ const char *
 rb_raw_obj_info(char *buff, const int buff_size, VALUE obj)
 {
     int pos = 0;
+    void *poisoned = asan_poisoned_object_p(obj);
+    asan_unpoison_object(obj, false);
 
 #define BUFF_ARGS buff + pos, buff_size - pos
 #define APPENDF(f) if ((pos += snprintf f) >= buff_size) goto end
@@ -11744,6 +11746,10 @@ rb_raw_obj_info(char *buff, const int buff_size, VALUE obj)
 #undef C
     }
   end:
+    if (poisoned) {
+        asan_poison_object(obj);
+    }
+
     return buff;
 #undef APPENDF
 #undef BUFF_ARGS


### PR DESCRIPTION
If you turn on ASan (`-fsanitize=address`) with `RGENGC_DEBUG` set to 3 and trigger a page sweep, ASan will cause a crash because `heap_page_add_freeobj` poisons the slot while `obj_info` reads the memory that was poisoned. Here's a Ruby script that can reproduce the crash:

```ruby
hash = {}
("aaaa".."matz").each_with_index do |s, i|
  hash[s] = i
end
```

There shouldn't be anything interesting to describe about the object since `heap_page_add_freeobj` turns it into a `T_NONE`, so we can just print the memory address.