### PR TITLE
Make proc/Proc.new without block an error instead of warning

### DIFF
--- a/bootstraptest/test_flow.rb
+++ b/bootstraptest/test_flow.rb
@@ -534,11 +534,11 @@ assert_equal %Q{ENSURE\n}, %q{
  ['[ruby-core:39125]', %q{
   class Bug5234
     include Enumerable
-    def each
+    def each(&block)
       begin
         yield :foo
       ensure
-        proc
+        proc(&block)
       end
     end
   end
@@ -547,11 +547,11 @@ assert_equal %Q{ENSURE\n}, %q{
  ['[ruby-dev:45656]', %q{
   class Bug6460
     include Enumerable
-    def each
+    def each(&block)
       begin
         yield :foo
       ensure
-        1.times { Proc.new }
+        1.times { Proc.new(&block) }
       end
     end
   end

--- a/bootstraptest/test_proc.rb
+++ b/bootstraptest/test_proc.rb
@@ -367,8 +367,8 @@ assert_equal 'ok', %q{
 
 assert_equal 'ok', %q{
   class Foo
-    def call_it
-      p = Proc.new
+    def call_it(&block)
+      p = Proc.new(&block)
       p.call
     end
   end

--- a/spec/ruby/core/kernel/proc_spec.rb
+++ b/spec/ruby/core/kernel/proc_spec.rb
@@ -48,7 +48,7 @@ describe "Kernel#proc" do
     end
   end
 
-  ruby_version_is "2.7" do
+  ruby_version_is "2.7" ... "2.8" do
     it "can be created when called with no block" do
       def some_method
         proc

--- a/spec/ruby/core/proc/new_spec.rb
+++ b/spec/ruby/core/proc/new_spec.rb
@@ -203,7 +203,7 @@ describe "Proc.new without a block" do
     end
   end
 
-  ruby_version_is "2.7" do
+  ruby_version_is "2.7" ... "2.8" do
     it "can be created if invoked from within a method with a block" do
       -> { ProcSpecs.new_proc_in_method { "hello" } }.should complain(/Capturing the given block using Proc.new is deprecated/)
     end

--- a/test/ruby/test_proc.rb
+++ b/test/ruby/test_proc.rb
@@ -53,11 +53,9 @@ class TestProc < Test::Unit::TestCase
     assert_equal(5, x)
   end
 
-  def assert_arity(n)
+  def assert_arity(n, &block)
     meta = class << self; self; end
-    b = assert_warn(/Capturing the given block using Proc\.new is deprecated/) do
-      Proc.new
-    end
+    b = Proc.new(&block)
     meta.class_eval {
       remove_method(:foo_arity) if method_defined?(:foo_arity)
       define_method(:foo_arity, b)
@@ -1431,16 +1429,6 @@ class TestProc < Test::Unit::TestCase
       def m(&blk) blk.call; end
       m {}
     end;
-  end
-
-  def method_for_test_proc_without_block_for_symbol
-    assert_warn(/Capturing the given block using Kernel#proc is deprecated/) do
-      binding.eval('proc')
-    end
-  end
-
-  def test_proc_without_block_for_symbol
-    assert_equal('1', method_for_test_proc_without_block_for_symbol(&:to_s).call(1), '[Bug #14782]')
   end
 
   def test_compose


### PR DESCRIPTION
The warning for these was added in 2.7.