### PR TITLE
Raise RuntimeError for class variable overtaken in nonverbose mode

### DIFF
--- a/basictest/test.rb
+++ b/basictest/test.rb
@@ -2140,7 +2140,7 @@ $_ = foobar
 test_ok($_ == foobar)
 
 class Gods
-  @@rule = "Uranus"		# private to Gods
+  @@rule = "Uranus"
   def ruler0
     @@rule
   end
@@ -2163,7 +2163,7 @@ module Olympians
 end
 
 class Titans < Gods
-  @@rule = "Cronus"		# do not affect @@rule in Gods
+  @@rule = "Cronus"		# modifies @@rule in Gods
   include Olympians
   def ruler4
     @@rule
@@ -2178,7 +2178,14 @@ test_ok(Titans.ruler2 == "Cronus")
 atlas = Titans.new
 test_ok(atlas.ruler0 == "Cronus")
 test_ok(atlas.ruler3 == "Zeus")
-test_ok(atlas.ruler4 == "Cronus")
+begin
+  atlas.ruler4
+rescue RuntimeError => e
+  test_ok(e.message.include?("class variable @@rule of Olympians is overtaken by Gods"))
+else
+  test_ok(false)
+end
+test_ok(atlas.ruler3 == "Zeus")
 
 test_check "trace"
 $x = 1234

--- a/test/ruby/test_variable.rb
+++ b/test/ruby/test_variable.rb
@@ -29,9 +29,7 @@ class TestVariable < Test::Unit::TestCase
     @@rule = "Cronus"			# modifies @@rule in Gods
     include Olympians
     def ruler4
-      EnvUtil.suppress_warning {
-        @@rule
-      }
+      @@rule
     end
   end
 
@@ -107,7 +105,7 @@ class TestVariable < Test::Unit::TestCase
     atlas = Titans.new
     assert_equal("Cronus", atlas.ruler0)
     assert_equal("Zeus", atlas.ruler3)
-    assert_equal("Cronus", atlas.ruler4)
+    assert_raise(RuntimeError) { atlas.ruler4 }
     assert_nothing_raised do
       class << Gods
         defined?(@@rule) && @@rule

--- a/variable.c
+++ b/variable.c
@@ -3105,7 +3105,7 @@ cvar_overtaken(VALUE front, VALUE target, ID id)
     if (front && target != front) {
 	st_data_t did = (st_data_t)id;
 
-        if (RTEST(ruby_verbose) && original_module(front) != original_module(target)) {
+        if (original_module(front) != original_module(target)) {
             rb_raise(rb_eRuntimeError,
                      "class variable % "PRIsVALUE" of %"PRIsVALUE" is overtaken by %"PRIsVALUE"",
 		       ID2SYM(id), rb_class_name(original_module(front)),


### PR DESCRIPTION
900e83b50115afda3f79712310e4cb95e4508972 changed from a warning
to an error in this case, but the warning was only issued in
verbose mode, and therefore the error was only raised in verbose
mode.  That was not intentional, verbose mode should only change
whether warnings are emitted, not other behavior.  This issues
the RuntimeError in all cases.

This change broke a couple tests, as the tests actually issued
the warning and therefore now raise an error.  This wasn't caught
earlier as test_variable suppressed the warning in this case,
effectively setting $VERBOSE = false around the code that warned.
basictest isn't run in verbose mode and therefore didn't expose
the issue previously. Fix these tests.

Fixes [Bug #14541]