### PR TITLE
Reintroduce reverted commits from rubygems

### DIFF
--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -357,6 +357,7 @@ class Gem::TestCase < Minitest::Test
 
     ENV['HOME'] = @userhome
     Gem.instance_variable_set :@user_home, nil
+    Gem.instance_variable_set :@data_home, nil
     Gem.instance_variable_set :@gemdeps, nil
     Gem.instance_variable_set :@env_requirements_by_name, nil
     Gem.send :remove_instance_variable, :@ruby_version if

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -356,12 +356,7 @@ class Gem::TestCase < Minitest::Test
     Dir.chdir @tempdir
 
     ENV['HOME'] = @userhome
-    FileUtils.mkdir_p File.join(@userhome, ".gem")
-    File.write File.join(@userhome, ".gemrc"), "--- {}"
-
     Gem.instance_variable_set :@user_home, nil
-    Gem.instance_variable_set :@cache_home, nil
-    Gem.instance_variable_set :@data_home, nil
     Gem.instance_variable_set :@gemdeps, nil
     Gem.instance_variable_set :@env_requirements_by_name, nil
     Gem.send :remove_instance_variable, :@ruby_version if
@@ -480,6 +475,10 @@ class Gem::TestCase < Minitest::Test
     FileUtils.mkdir_p File.dirname(@temp_cred)
     File.write @temp_cred, ':rubygems_api_key: 701229f217cdf23b1344c7b4b54ca97'
     File.chmod 0600, @temp_cred
+  end
+
+  def credential_teardown
+    FileUtils.rm_rf @temp_cred
   end
 
   def common_installer_setup

--- a/test/rubygems/test_gem_commands_build_command.rb
+++ b/test/rubygems/test_gem_commands_build_command.rb
@@ -398,6 +398,7 @@ class TestGemCommandsBuildCommand < Gem::TestCase
     skip 'openssl is missing' unless defined?(OpenSSL::SSL) && !java_platform?
 
     gem_path = File.join Gem.user_home, ".gem"
+    Dir.mkdir gem_path
 
     Gem::Security.trust_dir
 
@@ -441,6 +442,7 @@ class TestGemCommandsBuildCommand < Gem::TestCase
     skip 'openssl is missing' unless defined?(OpenSSL::SSL) && !java_platform?
 
     gem_path = File.join Gem.user_home, ".gem"
+    Dir.mkdir gem_path
 
     Gem::Security.trust_dir
 

--- a/test/rubygems/test_gem_commands_cert_command.rb
+++ b/test/rubygems/test_gem_commands_cert_command.rb
@@ -597,6 +597,7 @@ ERROR:  --private-key not specified and ~/.gem/gem-private_key.pem does not exis
 
   def test_execute_re_sign
     gem_path = File.join Gem.user_home, ".gem"
+    Dir.mkdir gem_path
 
     path = File.join @tempdir, 'cert.pem'
     Gem::Security.write EXPIRED_PUBLIC_CERT, path, 0600
@@ -627,6 +628,9 @@ ERROR:  --private-key not specified and ~/.gem/gem-private_key.pem does not exis
   end
 
   def test_execute_re_sign_with_cert_expiration_length_days
+    gem_path = File.join Gem.user_home, ".gem"
+    Dir.mkdir gem_path
+
     path = File.join @tempdir, 'cert.pem'
     Gem::Security.write EXPIRED_PUBLIC_CERT, path, 0600
 

--- a/test/rubygems/test_gem_commands_owner_command.rb
+++ b/test/rubygems/test_gem_commands_owner_command.rb
@@ -19,6 +19,12 @@ class TestGemCommandsOwnerCommand < Gem::TestCase
     @cmd = Gem::Commands::OwnerCommand.new
   end
 
+  def teardown
+    credential_teardown
+
+    super
+  end
+
   def test_show_owners
     response = <<EOF
 ---

--- a/test/rubygems/test_gem_commands_push_command.rb
+++ b/test/rubygems/test_gem_commands_push_command.rb
@@ -40,6 +40,8 @@ class TestGemCommandsPushCommand < Gem::TestCase
   end
 
   def teardown
+    credential_teardown
+
     super
 
     singleton_gem_class.class_eval do

--- a/test/rubygems/test_gem_commands_signin_command.rb
+++ b/test/rubygems/test_gem_commands_signin_command.rb
@@ -17,8 +17,8 @@ class TestGemCommandsSigninCommand < Gem::TestCase
   end
 
   def teardown
-    credentials_path = Gem.configuration.credentials_path
-    File.delete(credentials_path) if File.exist?(credentials_path)
+    credential_teardown
+
     super
   end
 

--- a/test/rubygems/test_gem_commands_signout_command.rb
+++ b/test/rubygems/test_gem_commands_signout_command.rb
@@ -8,13 +8,7 @@ class TestGemCommandsSignoutCommand < Gem::TestCase
 
   def setup
     super
-
     @cmd = Gem::Commands::SignoutCommand.new
-  end
-
-  def teardown
-    super
-    File.delete Gem.configuration.credentials_path if File.exist?(Gem.configuration.credentials_path)
   end
 
   def test_execute_when_user_is_signed_in

--- a/test/rubygems/test_gem_commands_yank_command.rb
+++ b/test/rubygems/test_gem_commands_yank_command.rb
@@ -18,6 +18,12 @@ class TestGemCommandsYankCommand < Gem::TestCase
     Gem.configuration.api_keys[:KEY] = 'other'
   end
 
+  def teardown
+    credential_teardown
+
+    super
+  end
+
   def test_handle_options
     @cmd.handle_options %w[a --version 1.0 --platform x86-darwin -k KEY --host HOST]
 

--- a/test/rubygems/test_gem_config_file.rb
+++ b/test/rubygems/test_gem_config_file.rb
@@ -28,6 +28,8 @@ class TestGemConfigFile < Gem::TestCase
 
     ENV['GEMRC'] = @env_gemrc
 
+    credential_teardown
+
     super
   end
 

--- a/test/rubygems/test_gem_gemcutter_utilities.rb
+++ b/test/rubygems/test_gem_gemcutter_utilities.rb
@@ -25,6 +25,8 @@ class TestGemGemcutterUtilities < Gem::TestCase
     ENV['RUBYGEMS_HOST'] = nil
     Gem.configuration.rubygems_api_key = nil
 
+    credential_teardown
+
     super
   end
 

--- a/test/rubygems/test_gem_source.rb
+++ b/test/rubygems/test_gem_source.rb
@@ -228,7 +228,7 @@ class TestGemSource < Gem::TestCase
   end
 
   def test_update_cache_eh_home_nonexistent
-    FileUtils.rm_rf Gem.user_home
+    FileUtils.rmdir Gem.user_home
 
     refute @source.update_cache?
   end

--- a/test/rubygems/test_gem_spec_fetcher.rb
+++ b/test/rubygems/test_gem_spec_fetcher.rb
@@ -33,7 +33,7 @@ class TestGemSpecFetcher < Gem::TestCase
   end
 
   def test_initialize_nonexistent_home_dir
-    FileUtils.rm_rf Gem.user_home
+    FileUtils.rmdir Gem.user_home
 
     assert Gem::SpecFetcher.new
   end


### PR DESCRIPTION
In recent rubygems syncronizations, some upstream commits were reverted due to failing tests.

This PR reintroduces these commits, and backports [the fix for the original issues](https://github.com/rubygems/rubygems/pull/3694) from rubygems upstream.

I believe this should pass CI.

Closes rubygems/rubygems#3618.