### PR TITLE
Restore `tmp` dir change in rubygems specs

### DIFF
--- a/lib/rubygems/package_task.rb
+++ b/lib/rubygems/package_task.rb
@@ -22,11 +22,6 @@
 
 require 'rubygems'
 require 'rubygems/package'
-begin
-  gem 'rake'
-rescue Gem::LoadError
-end
-
 require 'rake/packagetask'
 
 ##

--- a/lib/rubygems/rdoc.rb
+++ b/lib/rubygems/rdoc.rb
@@ -2,18 +2,6 @@
 require 'rubygems'
 
 begin
-  gem 'rdoc'
-rescue Gem::LoadError
-  # swallow
-else
-  # This will force any deps that 'rdoc' might have
-  # (such as json) that are ambiguous to be activated, which
-  # is important because we end up using Specification.reset
-  # and we don't want the warning it pops out.
-  Gem.finish_resolve
-end
-
-begin
   require 'rdoc/rubygems_hook'
   module Gem
     RDoc = ::RDoc::RubygemsHook

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -298,11 +298,14 @@ class Gem::TestCase < Minitest::Test
     super
 
     @orig_env = ENV.to_hash
+    @tmp = File.expand_path("tmp")
+
+    Dir.mkdir @tmp
 
     ENV['GEM_VENDOR'] = nil
     ENV['GEMRC'] = nil
     ENV['SOURCE_DATE_EPOCH'] = nil
-    ENV["TMPDIR"] = File.expand_path("tmp")
+    ENV["TMPDIR"] = @tmp
 
     @current_dir = Dir.pwd
     @fetcher     = nil
@@ -319,7 +322,7 @@ class Gem::TestCase < Minitest::Test
     @tempdir = File.join(tmpdir, "test_rubygems_#{$$}")
     @tempdir.tap(&Gem::UNTAINT)
 
-    FileUtils.mkdir_p @tempdir
+    FileUtils.mkdir @tempdir
 
     @orig_SYSTEM_WIDE_CONFIG_FILE = Gem::ConfigFile::SYSTEM_WIDE_CONFIG_FILE
     Gem::ConfigFile.send :remove_const, :SYSTEM_WIDE_CONFIG_FILE
@@ -445,7 +448,7 @@ class Gem::TestCase < Minitest::Test
 
     Dir.chdir @current_dir
 
-    FileUtils.rm_rf @tempdir
+    FileUtils.rm_rf @tmp
 
     ENV.replace(@orig_env)
 

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -429,11 +429,8 @@ class Gem::TestCase < Minitest::Test
     $LOAD_PATH.replace @orig_LOAD_PATH if @orig_LOAD_PATH
     if @orig_LOADED_FEATURES
       if @orig_LOAD_PATH
-        paths = @orig_LOAD_PATH.map {|path| File.join(File.expand_path(path), "/") }
         ($LOADED_FEATURES - @orig_LOADED_FEATURES).each do |feat|
-          unless paths.any? {|path| feat.start_with?(path) }
-            $LOADED_FEATURES.delete(feat)
-          end
+          $LOADED_FEATURES.delete(feat) if feat.start_with?(@tmp)
         end
       else
         $LOADED_FEATURES.replace @orig_LOADED_FEATURES

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -300,7 +300,7 @@ class Gem::TestCase < Minitest::Test
     @orig_env = ENV.to_hash
     @tmp = File.expand_path("tmp")
 
-    Dir.mkdir @tmp
+    FileUtils.mkdir_p @tmp
 
     ENV['GEM_VENDOR'] = nil
     ENV['GEMRC'] = nil
@@ -322,7 +322,7 @@ class Gem::TestCase < Minitest::Test
     @tempdir = File.join(tmpdir, "test_rubygems_#{$$}")
     @tempdir.tap(&Gem::UNTAINT)
 
-    FileUtils.mkdir @tempdir
+    FileUtils.mkdir_p @tempdir
 
     @orig_SYSTEM_WIDE_CONFIG_FILE = Gem::ConfigFile::SYSTEM_WIDE_CONFIG_FILE
     Gem::ConfigFile.send :remove_const, :SYSTEM_WIDE_CONFIG_FILE
@@ -445,7 +445,7 @@ class Gem::TestCase < Minitest::Test
 
     Dir.chdir @current_dir
 
-    FileUtils.rm_rf @tmp
+    FileUtils.rm_rf @tempdir
 
     ENV.replace(@orig_env)
 

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -1531,24 +1531,4 @@ Also, a list:
 
 end
 
-# require dependencies that are not discoverable once GEM_HOME and GEM_PATH
-# are wiped
-begin
-  gem 'rake'
-rescue Gem::LoadError
-end
-
-begin
-  require 'rake/packagetask'
-rescue LoadError
-end
-
-begin
-  gem 'rdoc'
-  require 'rdoc'
-
-  require 'rubygems/rdoc'
-rescue LoadError, Gem::LoadError
-end
-
 require 'rubygems/test_utilities'

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -302,6 +302,7 @@ class Gem::TestCase < Minitest::Test
     ENV['GEM_VENDOR'] = nil
     ENV['GEMRC'] = nil
     ENV['SOURCE_DATE_EPOCH'] = nil
+    ENV["TMPDIR"] = File.expand_path("tmp")
 
     @current_dir = Dir.pwd
     @fetcher     = nil

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -125,6 +125,8 @@ class TestGemCommandsSetupCommand < Gem::TestCase
   end
 
   def test_execute_informs_about_installed_executables
+    @cmd.options[:document] = []
+
     use_ui @ui do
       @cmd.execute
     end

--- a/test/rubygems/test_gem_package_task.rb
+++ b/test/rubygems/test_gem_package_task.rb
@@ -1,7 +1,16 @@
 # frozen_string_literal: true
 require 'rubygems/test_case'
 require 'rubygems'
-require 'rubygems/package_task'
+
+begin
+  require 'rubygems/package_task'
+rescue LoadError => e
+  raise unless e.path == 'rake/packagetask'
+end
+
+unless defined?(Rake::PackageTask)
+  warn 'Skipping Gem::PackageTask tests.  rake not found.'
+end
 
 class TestGemPackageTask < Gem::TestCase
 
@@ -107,4 +116,4 @@ class TestGemPackageTask < Gem::TestCase
     assert_equal 'pkg/nokogiri-1.5.0-java', pkg.package_dir_path
   end
 
-end
+end if defined?(Rake::PackageTask)

--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -5,8 +5,7 @@ require 'webrick'
 begin
   require 'webrick/https'
 rescue LoadError => e
-  raise unless (e.respond_to?(:path) && e.path == 'openssl') ||
-               e.message =~ / -- openssl$/
+  raise unless e.path == 'openssl'
 end
 
 unless defined?(OpenSSL::SSL)


### PR DESCRIPTION
This PR is complementary to #3211 and restores another commit that was reverted when syncronizing with rubygems upstream due to test failures.