### PR TITLE
Make mutating the result of SortedSet#to_a not affect the set

### DIFF
--- a/lib/set.rb
+++ b/lib/set.rb
@@ -778,7 +778,7 @@ class SortedSet < Set
 
             def to_a
               (@keys = @hash.keys).sort! unless @keys
-              @keys
+              @keys.dup
             end
 
             def freeze

--- a/test/test_set.rb
+++ b/test/test_set.rb
@@ -800,6 +800,9 @@ class TC_SortedSet < Test::Unit::TestCase
   def test_sortedset
     s = SortedSet[4,5,3,1,2]
 
+    a = s.to_a
+    assert_equal([1,2,3,4,5], a)
+    a << -1
     assert_equal([1,2,3,4,5], s.to_a)
 
     prev = nil


### PR DESCRIPTION
Fixes [Bug #15834]