### PR TITLE
Remove unused else if statements in int_even_p func

### DIFF
--- a/numeric.c
+++ b/numeric.c
@@ -3280,9 +3280,6 @@ int_even_p(VALUE num)
     else if (RB_TYPE_P(num, T_BIGNUM)) {
 	return rb_big_even_p(num);
     }
-    else if (rb_funcall(num, '%', 1, INT2FIX(2)) == INT2FIX(0)) {
-	return Qtrue;
-    }
     return Qfalse;
 }
 

--- a/numeric.c
+++ b/numeric.c
@@ -3252,14 +3252,12 @@ rb_int_odd_p(VALUE num)
 	if (num & 2) {
 	    return Qtrue;
 	}
+        return Qfalse;
     }
-    else if (RB_TYPE_P(num, T_BIGNUM)) {
+    else {
+        assert(RB_TYPE_P(num, T_BIGNUM));
 	return rb_big_odd_p(num);
     }
-    else if (rb_funcall(num, '%', 1, INT2FIX(2)) != INT2FIX(0)) {
-	return Qtrue;
-    }
-    return Qfalse;
 }
 
 /*

--- a/numeric.c
+++ b/numeric.c
@@ -3276,11 +3276,12 @@ int_even_p(VALUE num)
 	if ((num & 2) == 0) {
 	    return Qtrue;
 	}
+        return Qfalse;
     }
-    else if (RB_TYPE_P(num, T_BIGNUM)) {
+    else {
+        assert(RB_TYPE_P(num, T_BIGNUM));
 	return rb_big_even_p(num);
     }
-    return Qfalse;
 }
 
 /*


### PR DESCRIPTION
## Summary

Remove unused else if statements in `int_even_p` func(`int_even_p` func is defined in `numeric.c`).

## Why?

First impl of `int_even_p` is this commit. This commit using  `%` operator with `rb_funcall`.

https://github.com/ruby/ruby/commit/255702be8ca169429867294d4a1fd818b53af928

After a while, `int_even_p` is changed implementation to treat Fixnum and Bignum values directly.

https://github.com/ruby/ruby/commit/0a607bc8f8101190e0684df2e4cea08cc562a5b0

I saw this commit, and think that `else if statements seems not use in int_even_p function?`.

```
static VALUE
int_even_p(VALUE num)
{
    if (FIXNUM_P(num)) {
	if ((num & 2) == 0) {
	    return Qtrue;
	}
    }
    else if (RB_TYPE_P(num, T_BIGNUM)) {
	return rb_big_even_p(num);
    }
    else if (rb_funcall(num, '%', 1, INT2FIX(2)) == INT2FIX(0)) {
	return Qtrue;
    }
    return Qfalse;
}
```
So, I propasal remove `else if statements` in `int_even_p`.

Remarks:
Tryed remove `else if statements` in `int_even_p` function, and run to test. result is success.

