### PR TITLE
Add instance_methods to class generated by DelegateClass

### DIFF
--- a/lib/delegate.rb
+++ b/lib/delegate.rb
@@ -421,6 +421,18 @@ def DelegateClass(superclass, &block)
   klass.define_singleton_method :instance_methods do |all=true|
     super(all) | superclass.instance_methods
   end
+  klass.define_singleton_method :public_instance_method do |name|
+    super(name)
+  rescue NameError
+    raise unless self.public_instance_methods.include?(name)
+    superclass.public_instance_method(name)
+  end
+  klass.define_singleton_method :instance_method do |name|
+    super(name)
+  rescue NameError
+    raise unless self.instance_methods.include?(name)
+    superclass.instance_method(name)
+  end
   klass.module_eval(&block) if block
   return klass
 end

--- a/lib/delegate.rb
+++ b/lib/delegate.rb
@@ -418,6 +418,9 @@ def DelegateClass(superclass, &block)
   klass.define_singleton_method :protected_instance_methods do |all=true|
     super(all) | superclass.protected_instance_methods
   end
+  klass.define_singleton_method :instance_methods do |all=true|
+    super(all) | superclass.instance_methods
+  end
   klass.module_eval(&block) if block
   return klass
 end

--- a/test/test_delegate.rb
+++ b/test/test_delegate.rb
@@ -131,6 +131,12 @@ class TestDelegateClass < Test::Unit::TestCase
     assert_equal([:parent_protected, :parent_protected_added], (Child.new(Parent.new).protected_methods - ignores).sort)
   end
 
+  def test_instance_methods
+    ignores = Object.instance_methods | Delegator.instance_methods
+    assert_equal([:parent_protected, :parent_protected_added, :parent_public, :parent_public_added], (Child.instance_methods - ignores).sort)
+    assert_equal([:parent_protected, :parent_protected_added, :parent_public, :parent_public_added], (Child.new(Parent.new).methods - ignores).sort)
+  end
+
   class IV < DelegateClass(Integer)
     attr_accessor :var
 

--- a/test/test_delegate.rb
+++ b/test/test_delegate.rb
@@ -106,6 +106,10 @@ class TestDelegateClass < Test::Unit::TestCase
     protected
 
     def parent_protected; end
+
+    private
+
+    def parent_private; end
   end
 
   class Child < DelegateClass(Parent)
@@ -117,6 +121,10 @@ class TestDelegateClass < Test::Unit::TestCase
     protected
 
     def parent_protected_added; end
+
+    private
+
+    def parent_private_added; end
   end
 
   def test_public_instance_methods
@@ -135,6 +143,26 @@ class TestDelegateClass < Test::Unit::TestCase
     ignores = Object.instance_methods | Delegator.instance_methods
     assert_equal([:parent_protected, :parent_protected_added, :parent_public, :parent_public_added], (Child.instance_methods - ignores).sort)
     assert_equal([:parent_protected, :parent_protected_added, :parent_public, :parent_public_added], (Child.new(Parent.new).methods - ignores).sort)
+  end
+
+  def test_DelegateClass_instance_method
+    assert_instance_of UnboundMethod, Child.instance_method(:parent_public)
+    assert_instance_of UnboundMethod, Child.instance_method(:parent_public_added)
+    assert_instance_of UnboundMethod, Child.instance_method(:parent_protected)
+    assert_instance_of UnboundMethod, Child.instance_method(:parent_protected_added)
+    assert_raise(NameError) { Child.instance_method(:parent_private) }
+    assert_raise(NameError) { Child.instance_method(:parent_private_added) }
+    assert_instance_of UnboundMethod, Child.instance_method(:to_s)
+  end
+
+  def test_DelegateClass_public_instance_method
+    assert_instance_of UnboundMethod, Child.public_instance_method(:parent_public)
+    assert_instance_of UnboundMethod, Child.public_instance_method(:parent_public_added)
+    assert_raise(NameError) { Child.public_instance_method(:parent_protected) }
+    assert_raise(NameError) { Child.public_instance_method(:parent_protected_added) }
+    assert_raise(NameError) { Child.instance_method(:parent_private) }
+    assert_raise(NameError) { Child.instance_method(:parent_private_added) }
+    assert_instance_of UnboundMethod, Child.public_instance_method(:to_s)
   end
 
   class IV < DelegateClass(Integer)


### PR DESCRIPTION
This pull request adds `instance_methods` method to class generated by `DelegateClass` method.
It makes the `instance_methods` contains method names added after the class is defined.


Currently `instance_methods` doesn't contain method names added after the class is defined.


```ruby
require 'delegate'

class Parent
  def parent_public; end

  protected

  def parent_protected; end
end

class Child < DelegateClass(Parent)
end

class Parent
  def parent_public_added; end

  protected

  def parent_protected_added; end
end

p Child.instance_methods.include? :parent_public    # => true
p Child.instance_methods.include? :parent_protected # => true

p Child.instance_methods.include? :parent_public_added    # => false
p Child.instance_methods.include? :parent_protected_added # => false`
```

But actually these methods are available, and `public_instance_methods` and `protected_instance_methods` treats added methods. So I think it would be better if `instance_methods` also treat added methods.



---


updated 2020-06-14 18:00


Adding `instance_methods` broke `test/ruby/test_method.rb`.
https://github.com/ruby/ruby/blob/d1fb446b62b1e114252606dcf040dd9392f25170/test/ruby/test_method.rb#L1300
Because `instance_method` method is also broken.

```ruby
require 'delegate'

class Parent
  def parent() end
end

class Child < DelegateClass(Parent)
end

class Parent
  def parent_added() end
end

p Child.instance_method(:parent) # ok
p Child.instance_method(:parent_added) # undefined method `parent_added' for class `Child' (NameError)
```


So I also added `instance_method` and `public_instance_method` methods to fix the bug.