### PR TITLE
Add ubuntu-20.04 and rename to ubuntu-18.04 from ubuntu-latest

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       matrix:
         test_task: [ "check", "test-bundler-parallel", "test-bundled-gems", "test-all TESTS=--repeat-count=2", "leaked-globals" ]
-        os: [ubuntu-latest, ubuntu-16.04]
+        os: [ubuntu-20.04, ubuntu-18.04, ubuntu-16.04]
         debug: ["", "-DRUBY_DEBUG"]
         exclude:
           - test_task: test-bundler-parallel


### PR DESCRIPTION
https://github.com/actions/virtual-environments/blob/d1fc6628feab4f809520367065199344535defde/README.md
Ubuntu 20.04 is `ubuntu-20.04`.
Ubuntu 18.04 is `ubuntu-latest` or `ubuntu-18.04`.