### PR TITLE
Unskip some bundler specs

### DIFF
--- a/spec/bundler/commands/exec_spec.rb
+++ b/spec/bundler/commands/exec_spec.rb
@@ -67,17 +67,17 @@ RSpec.describe "bundle exec" do
     expect(out).to eq(Gem::VERSION)
   end
 
-  it "respects custom process title when loading through ruby", :ruby_repo do
+  it "respects custom process title when loading through ruby" do
     skip "https://github.com/rubygems/bundler/issues/6898" if Gem.win_platform?
 
     script_that_changes_its_own_title_and_checks_if_picked_up_by_ps_unix_utility = <<~'RUBY'
-      Process.setproctitle("1-2-3-4-5-6-7-8-9-10-11-12-13-14-15")
+      Process.setproctitle("1-2-3-4-5-6-7")
       puts `ps -ocommand= -p#{$$}`
     RUBY
     create_file "Gemfile"
     create_file "a.rb", script_that_changes_its_own_title_and_checks_if_picked_up_by_ps_unix_utility
     bundle "exec ruby a.rb"
-    expect(out).to eq("1-2-3-4-5-6-7-8-9-10-11-12-13-14-15")
+    expect(out).to eq("1-2-3-4-5-6-7")
   end
 
   it "accepts --verbose" do

--- a/spec/bundler/commands/exec_spec.rb
+++ b/spec/bundler/commands/exec_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "bundle exec" do
     system_gems(system_gems_to_install, :path => default_bundle_path)
   end
 
-  it "works with --gemfile flag", :ruby_repo do
+  it "works with --gemfile flag" do
     create_file "CustomGemfile", <<-G
       gem "rack", "1.0.0"
     G
@@ -15,7 +15,7 @@ RSpec.describe "bundle exec" do
     expect(out).to eq("1.0.0")
   end
 
-  it "activates the correct gem", :ruby_repo do
+  it "activates the correct gem" do
     gemfile <<-G
       gem "rack", "0.9.1"
     G
@@ -24,7 +24,7 @@ RSpec.describe "bundle exec" do
     expect(out).to eq("0.9.1")
   end
 
-  it "works when the bins are in ~/.bundle", :ruby_repo do
+  it "works when the bins are in ~/.bundle" do
     install_gemfile <<-G
       gem "rack"
     G
@@ -33,7 +33,7 @@ RSpec.describe "bundle exec" do
     expect(out).to eq("1.0.0")
   end
 
-  it "works when running from a random directory", :ruby_repo do
+  it "works when running from a random directory" do
     install_gemfile <<-G
       gem "rack"
     G
@@ -67,7 +67,7 @@ RSpec.describe "bundle exec" do
     expect(out).to eq(Gem::VERSION)
   end
 
-  it "respects custom process title when loading through ruby" do
+  it "respects custom process title when loading through ruby", :ruby_repo do
     skip "https://github.com/rubygems/bundler/issues/6898" if Gem.win_platform?
 
     script_that_changes_its_own_title_and_checks_if_picked_up_by_ps_unix_utility = <<~'RUBY'
@@ -269,7 +269,7 @@ RSpec.describe "bundle exec" do
     )
   end
 
-  it "handles gems installed with --without", :ruby_repo do
+  it "handles gems installed with --without" do
     bundle "config --local without middleware"
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
@@ -354,7 +354,7 @@ RSpec.describe "bundle exec" do
     expect(err).to include("bundler: exec needs a command to run")
   end
 
-  it "raises a helpful error when exec'ing to something outside of the bundle", :ruby_repo do
+  it "raises a helpful error when exec'ing to something outside of the bundle" do
     bundle! "config set clean false" # want to keep the rackup binstub
     install_gemfile! <<-G
       source "#{file_uri_for(gem_repo1)}"
@@ -458,7 +458,7 @@ RSpec.describe "bundle exec" do
   end
 
   describe "with gem executables" do
-    describe "run from a random directory", :ruby_repo do
+    describe "run from a random directory" do
       before(:each) do
         install_gemfile <<-G
           gem "rack"
@@ -588,7 +588,7 @@ RSpec.describe "bundle exec" do
   end
 
   describe "with gems bundled for deployment" do
-    it "works when calling bundler from another script", :ruby_repo do
+    it "works when calling bundler from another script" do
       skip "https://github.com/rubygems/bundler/issues/6898" if Gem.win_platform?
 
       gemfile <<-G
@@ -874,7 +874,7 @@ __FILE__: #{path.to_s.inspect}
         bundle! :install
       end
 
-      it "correctly shells out", :ruby_repo do
+      it "correctly shells out" do
         skip "https://github.com/rubygems/bundler/issues/6898" if Gem.win_platform?
 
         file = bundled_app("file_that_bundle_execs.rb")

--- a/spec/bundler/install/deploy_spec.rb
+++ b/spec/bundler/install/deploy_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe "install with --deployment or --frozen" do
     bundle! :install
   end
 
-  it "works when you bundle exec bundle", :ruby_repo do
+  it "works when you bundle exec bundle" do
     skip "doesn't find bundle" if Gem.win_platform?
 
     bundle! :install

--- a/spec/bundler/other/platform_spec.rb
+++ b/spec/bundler/other/platform_spec.rb
@@ -829,7 +829,7 @@ G
       system_gems "rack-1.0.0", "rack-0.9.1", :path => default_bundle_path
     end
 
-    it "activates the correct gem when ruby version matches", :ruby_repo do
+    it "activates the correct gem when ruby version matches" do
       gemfile <<-G
         gem "rack", "0.9.1"
 
@@ -852,7 +852,7 @@ G
       expect(out).to include("0.9.1")
     end
 
-    it "fails when the ruby version doesn't match", :ruby_repo do
+    it "fails when the ruby version doesn't match" do
       gemfile <<-G
         gem "rack", "0.9.1"
 
@@ -863,7 +863,7 @@ G
       should_be_ruby_version_incorrect
     end
 
-    it "fails when the engine doesn't match", :ruby_repo do
+    it "fails when the engine doesn't match" do
       gemfile <<-G
         gem "rack", "0.9.1"
 
@@ -885,7 +885,7 @@ G
     #   should_be_engine_version_incorrect
     # end
 
-    it "fails when patchlevel doesn't match", :ruby_repo do
+    it "fails when patchlevel doesn't match" do
       gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "rack"

--- a/spec/bundler/support/helpers.rb
+++ b/spec/bundler/support/helpers.rb
@@ -171,6 +171,9 @@ module Spec
     end
 
     def gem_command(command, options = {})
+      env = options[:env] || {}
+      env["RUBYOPT"] = opt_add("-r#{spec_dir}/support/hax.rb", env["RUBYOPT"] || ENV["RUBYOPT"])
+      options[:env] = env
       sys_exec("#{Path.gem_bin} #{command}", options)
     end
     bang :gem_command


### PR DESCRIPTION
In a [recent bundler upstream syncronization](https://github.com/ruby/ruby/pull/3114), some bundler specs were skipped because they started failing. This PR should fix them.