### PR TITLE
Use filesystem encoding in do_GET of filehandler

### DIFF
--- a/lib/webrick/httpservlet/filehandler.rb
+++ b/lib/webrick/httpservlet/filehandler.rb
@@ -42,6 +42,11 @@ module WEBrick
       # :stopdoc:
 
       def do_GET(req, res)
+        case enc = Encoding.find('filesystem')
+        when Encoding::US_ASCII, Encoding::ASCII_8BIT
+        else
+          @local_path = @local_path.dup.force_encoding(enc)
+        end
         st = File::stat(@local_path)
         mtime = st.mtime
         res['etag'] = sprintf("%x-%x-%x", st.ino, st.size, st.mtime.to_i)


### PR DESCRIPTION
Try to fix 404 error on mswinci.

https://rubyci.org/logs/mswinci.japaneast.cloudapp.azure.com/vc12-x64/ruby-master/log/20200614T225859Z.fail.html.gz
```
  1) Failure:
WEBrick::TestFileHandler#test_cjk_in_path [D:/tmp/mswin-build20200615-24932-11ykstf/ruby/test/webrick/utils.rb:72]:
exceptions on 2 threads:
webrick log start:
  [2020-06-15 09:48:29] ERROR `/あ.txt' not found.

webrick log end.
<"200"> expected but was
<"404">.
---
<[]> expected but was
<["[2020-06-15 09:48:29] ERROR `/\xE3\x81\x82.txt' not found.\n"]>.
```