### PR TITLE
Remove obsoleted opt_call_c_function insn

### DIFF
--- a/bootstraptest/test_insns.rb
+++ b/bootstraptest/test_insns.rb
@@ -412,8 +412,6 @@ tests = [
     class String; def =~ other; true; end; end
     'true' =~ /true/
   },
-
-  [ 'opt_call_c_function', 'Struct.new(:x).new.x = true', ],
 ]
 
 # normal path

--- a/insns.def
+++ b/insns.def
@@ -1454,27 +1454,6 @@ opt_regexpmatch2
     }
 }
 
-/* call native compiled method */
-DEFINE_INSN
-opt_call_c_function
-(rb_insn_func_t funcptr)
-()
-()
-// attr bool leaf = false; /* anything can happen inside */
-// attr bool handles_sp = true;
-{
-    reg_cfp = (funcptr)(ec, reg_cfp);
-
-    if (reg_cfp == 0) {
-	VALUE err = ec->errinfo;
-	ec->errinfo = Qnil;
-	THROW_EXCEPTION(err);
-    }
-
-    RESTORE_REGS();
-    NEXT_INSN();
-}
-
 /* call specific function with args */
 DEFINE_INSN
 invokebuiltin

--- a/insns.def
+++ b/insns.def
@@ -1454,6 +1454,27 @@ opt_regexpmatch2
     }
 }
 
+/* call native compiled method */
+DEFINE_INSN_IF(SUPPORT_CALL_C_FUNCTION)
+opt_call_c_function
+(rb_insn_func_t funcptr)
+()
+()
+// attr bool leaf = false; /* anything can happen inside */
+// attr bool handles_sp = true;
+{
+    reg_cfp = (funcptr)(ec, reg_cfp);
+
+    if (reg_cfp == 0) {
+	VALUE err = ec->errinfo;
+	ec->errinfo = Qnil;
+	THROW_EXCEPTION(err);
+    }
+
+    RESTORE_REGS();
+    NEXT_INSN();
+}
+
 /* call specific function with args */
 DEFINE_INSN
 invokebuiltin

--- a/test/ruby/test_jit.rb
+++ b/test/ruby/test_jit.rb
@@ -22,7 +22,6 @@ class TestJIT < Test::Unit::TestCase
   TEST_PENDING_INSNS = RubyVM::INSTRUCTION_NAMES.select { |n| n.start_with?('trace_') }.map(&:to_sym) + [
     # not supported yet
     :defineclass,
-    :opt_call_c_function,
 
     # to be tested
     :invokebuiltin,
@@ -611,10 +610,6 @@ class TestJIT < Test::Unit::TestCase
   def test_compile_insn_opt_regexpmatch2
     assert_compile_once("/true/ =~ 'true'", result_inspect: '0', insns: %i[opt_regexpmatch2])
     assert_compile_once("'true' =~ /true/", result_inspect: '0', insns: %i[opt_regexpmatch2])
-  end
-
-  def test_compile_insn_opt_call_c_function
-    skip "support this in opt_call_c_function (low priority)"
   end
 
   def test_compile_insn_opt_invokebuiltin_delegate_leave

--- a/tool/ruby_vm/views/mjit_compile.inc.erb
+++ b/tool/ruby_vm/views/mjit_compile.inc.erb
@@ -16,8 +16,7 @@
 } -%>
 %
 % unsupported_insns = [
-%   'defineclass',         # low priority
-%   'opt_call_c_function', # low priority
+%   'defineclass', # low priority
 % ]
 %
 % opt_send_without_block = RubyVM::Instructions.find { |i| i.name == 'opt_send_without_block' }

--- a/vm_opts.h
+++ b/vm_opts.h
@@ -62,6 +62,10 @@
 #define OPT_SUPPORT_JOKE             0
 #endif
 
+#ifndef OPT_SUPPORT_CALL_C_FUNCTION
+#define OPT_SUPPORT_CALL_C_FUNCTION  0
+#endif
+
 #ifndef VM_COLLECT_USAGE_DETAILS
 #define VM_COLLECT_USAGE_DETAILS     0
 #endif


### PR DESCRIPTION
Since https://github.com/ruby/ruby/commit/ccb7a4b9f22c6ef8d51517322f82031fadf68769, there's no use of this insn anymore. Is there any reason to keep it?