### PR TITLE
frozen string issue in lib/reline/ansi.rb

### DIFF
--- a/lib/reline/ansi.rb
+++ b/lib/reline/ansi.rb
@@ -100,7 +100,7 @@ class Reline::ANSI
 
   def self.cursor_pos
     begin
-      res = ''.dup
+      res = +''
       m = nil
       @@input.raw do |stdin|
         @@output << "\e[6n"

--- a/lib/reline/ansi.rb
+++ b/lib/reline/ansi.rb
@@ -100,7 +100,7 @@ class Reline::ANSI
 
   def self.cursor_pos
     begin
-      res = ''
+      res = ''.dup
       m = nil
       @@input.raw do |stdin|
         @@output << "\e[6n"


### PR DESCRIPTION
Getting cannot modify frozen string error in lib/reline/ansi.rb when running a rails command with `RUBYOPT=--enable-frozen-string-literal`.

```ruby
/Users/user/.rvm/rubies/ruby-2.7.1/lib/ruby/2.7.0/reline/ansi.rb:109:in `block in cursor_pos': can't modify frozen String: "" (FrozenError)

ruby version - 2.7.1
rails version - 6.0.3.2
```