### PR TITLE
compile.c: Improve branch coverage instrumentation [Bug #16967]

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -595,12 +595,17 @@ APPEND_ELEM(ISEQ_ARG_DECLARE LINK_ANCHOR *const anchor, LINK_ELEMENT *before, LI
 #define APPEND_ELEM(anchor, before, elem) APPEND_ELEM(iseq, (anchor), (before), (elem))
 #endif
 
+static int branch_coverage_valid_p(rb_iseq_t *iseq, int first_line)
+{
+    if (!ISEQ_COVERAGE(iseq)) return 0;
+    if (!ISEQ_BRANCH_COVERAGE(iseq)) return 0;
+    if (first_line <= 0) return 0;
+    return 1;
+}
+
 static VALUE decl_branch_base(rb_iseq_t *iseq, int first_line, int first_column, int last_line, int last_column, const char *type)
 {
-    // check if branch coverage is enabled
-    if (!ISEQ_COVERAGE(iseq)) return Qundef;
-    if (!ISEQ_BRANCH_COVERAGE(iseq)) return Qundef;
-    if (first_line <= 0) return Qundef;
+    if (!branch_coverage_valid_p(iseq, first_line)) return Qundef;
 
     VALUE structure = RARRAY_AREF(ISEQ_BRANCH_COVERAGE(iseq), 0);
     VALUE branches = rb_ary_tmp_new(5);
@@ -616,10 +621,7 @@ static VALUE decl_branch_base(rb_iseq_t *iseq, int first_line, int first_column,
 
 static void add_trace_branch_coverage(rb_iseq_t *iseq, LINK_ANCHOR *const seq, int first_line, int first_column, int last_line, int last_column, const char *type, VALUE branches)
 {
-    // check if branch coverage is enabled
-    if (!ISEQ_COVERAGE(iseq)) return;
-    if (!ISEQ_BRANCH_COVERAGE(iseq)) return;
-    if (first_line <= 0) return;
+    if (!branch_coverage_valid_p(iseq, first_line)) return;
 
     VALUE counters = RARRAY_AREF(ISEQ_BRANCH_COVERAGE(iseq), 1);
     long counter_idx = RARRAY_LEN(counters);

--- a/test/coverage/test_coverage.rb
+++ b/test/coverage/test_coverage.rb
@@ -740,4 +740,24 @@ class TestCoverage < Test::Unit::TestCase
       end
     end;
   end
+
+  def test_branch_coverage_in_ensure_clause
+    result = {
+      :branches => {
+        [:if, 0, 4, 2, 4, 11] => {
+          [:then, 1, 4, 2, 4, 5] => 1,
+          [:else, 2, 4, 2, 4, 11] => 1,
+        }
+      }
+    }
+    assert_coverage(<<~"end;", { branches: true }, result) # Bug #16967
+      def foo
+        yield
+      ensure
+        :ok if $!
+      end
+      foo {}
+      foo { raise } rescue nil
+    end;
+  end
 end

--- a/thread.c
+++ b/thread.c
@@ -5644,20 +5644,31 @@ rb_default_coverage(int n)
     RARRAY_ASET(coverage, COVERAGE_INDEX_LINES, lines);
 
     if (mode & COVERAGE_TARGET_BRANCHES) {
-	branches = rb_ary_tmp_new_fill(2);
-	/* internal data structures for branch coverage:
-	 *
-	 * [[base_type, base_first_lineno, base_first_column, base_last_lineno, base_last_column,
-	 *   target_type_1, target_first_lineno_1, target_first_column_1, target_last_lineno_1, target_last_column_1, target_counter_index_1,
-	 *   target_type_2, target_first_lineno_2, target_first_column_2, target_last_lineno_2, target_last_column_2, target_counter_index_2, ...],
-	 *  ...]
-	 *
-	 * Example: [[:case, 1, 0, 4, 3,
-	 *            :when, 2, 8, 2, 9, 0,
-	 *            :when, 3, 8, 3, 9, 1, ...],
-	 *           ...]
-	 */
-	RARRAY_ASET(branches, 0, rb_ary_tmp_new(0));
+        branches = rb_ary_tmp_new_fill(2);
+        /* internal data structures for branch coverage:
+         *
+         * { branch base node =>
+         *     [base_type, base_first_lineno, base_first_column, base_last_lineno, base_last_column, {
+         *       branch target id =>
+         *         [target_type, target_first_lineno, target_first_column, target_last_lineno, target_last_column, target_counter_index],
+         *       ...
+         *     }],
+         *   ...
+         * }
+         *
+         * Example:
+         * { NODE_CASE =>
+         *     [1, 0, 4, 3, {
+         *       NODE_WHEN => [2, 8, 2, 9, 0],
+         *       NODE_WHEN => [3, 8, 3, 9, 1],
+         *       ...
+         *     }],
+         *   ...
+         * }
+         */
+        VALUE structure = rb_hash_new();
+        rb_obj_hide(structure);
+	RARRAY_ASET(branches, 0, structure);
 	/* branch execution counters */
 	RARRAY_ASET(branches, 1, rb_ary_tmp_new(0));
     }


### PR DESCRIPTION
Formerly, branch coverage measurement counters are generated for each
compilation traverse of the AST.  However, ensure clause node is
traversed twice; one is for normal-exit case (the resulted bytecode is
embedded in its outer scope), and the other is for exceptional case (the
resulted bytecode is used in catch table).  Two branch coverage counters
are generated for the two cases, but it is not desired.

This changeset revamps the internal representation of branch coverage
measurement.  Branch coverage counters are generated only at the first
visit of a branch node.  Visiting the same node reuses the
already-generated counter, so double counting is avoided.