### PR TITLE
Verify builtin inline annotation with VM_CHECK_MODE

### DIFF
--- a/tool/ruby_vm/views/_insn_entry.erb
+++ b/tool/ruby_vm/views/_insn_entry.erb
@@ -39,7 +39,7 @@ INSN_ENTRY(<%= insn.name %>)
 % if insn.handles_sp?
     POPN(INSN_ATTR(popn));
 % end
-<%= insn.handle_canary "SETUP_CANARY()" -%>
+<%= insn.handle_canary "SETUP_CANARY(leaf)" -%>
     COLLECT_USAGE_INSN(INSN_ATTR(bin));
 % insn.opes.each_with_index do |ope, i|
     COLLECT_USAGE_OPERAND(INSN_ATTR(bin), <%= i %>, <%= ope[:name] %>);
@@ -55,7 +55,7 @@ INSN_ENTRY(<%= insn.name %>)
 
     /* ### Instruction trailers. ### */
     CHECK_VM_STACK_OVERFLOW_FOR_INSN(VM_REG_CFP, INSN_ATTR(retn));
-<%= insn.handle_canary "CHECK_CANARY()" -%>
+<%= insn.handle_canary "CHECK_CANARY(leaf, INSN_ATTR(bin))" -%>
 % if insn.handles_sp?
 %   insn.rets.reverse_each do |ret|
     PUSH(<%= insn.cast_to_VALUE ret %>);

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -4969,7 +4969,7 @@ vm_trace(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, const VALUE *p
 }
 
 #if VM_CHECK_MODE > 0
-static NORETURN( NOINLINE( COLDFUNC
+NORETURN( NOINLINE( COLDFUNC
 void vm_canary_is_found_dead(enum ruby_vminsn_type i, VALUE c)));
 
 void

--- a/vm_insnhelper.h
+++ b/vm_insnhelper.h
@@ -139,27 +139,27 @@ CC_SET_FASTPATH(const struct rb_callcache *cc, vm_call_handler func, bool enable
 /**********************************************************/
 
 #if VM_CHECK_MODE > 0
-#define SETUP_CANARY() \
+#define SETUP_CANARY(cond) \
     VALUE *canary = 0; \
-    if (leaf) { \
+    if (cond) { \
         canary = GET_SP(); \
         SET_SV(vm_stack_canary); \
     } \
     else {\
         SET_SV(Qfalse); /* cleanup */ \
     }
-#define CHECK_CANARY() \
-    if (leaf) { \
+#define CHECK_CANARY(cond, insn) \
+    if (cond) { \
         if (*canary == vm_stack_canary) { \
             *canary = Qfalse; /* cleanup */ \
         } \
         else { \
-            vm_canary_is_found_dead(INSN_ATTR(bin), *canary); \
+            vm_canary_is_found_dead(insn, *canary); \
         } \
     }
 #else
-#define SETUP_CANARY()          /* void */
-#define CHECK_CANARY()          /* void */
+#define SETUP_CANARY(cond)       /* void */
+#define CHECK_CANARY(cond, insn) /* void */
 #endif
 
 /**********************************************************/


### PR DESCRIPTION
## What's this?
In https://github.com/ruby/ruby/pull/3242, I introduced an internal annotation for a method using builtin: `inline` (see https://bugs.ruby-lang.org/issues/16956 for details). When `inline` is specified, we assume (1) rb_funcall doesn't happen and (2) `cfp->pc` isn't read inside a builtin function.

While ideally we should verify both, checking (1) is more important than (2) and this PR intends to verify (1) with VM_CHECK_MODE first.

## Example
If we insert `rb_funcall` to `int_zero_p` which is used by `Integer#zero?` with `Primitive.attr! 'inline'`, the output will be like the following one.

We can know `Integer#zero?` is wrong from `ISeq:zero?@<internal:integer>` and find the line `numeric.c:782` which I inserted `rb_funcall` to.

```
We are killing the stack canary set by leave, at <RubyVM::InstructionSequence:zero?@<internal:integer>:6>@pc=3
watch out the C stack trace.
== disasm: #<ISeq:zero?@<internal:integer>:6 (6,2)-(9,5)> (catch: FALSE)
0000 opt_invokebuiltin_delegate_leave       <builtin!_bi0/0>, 0       (   8)[LiCa]
0003 leave                                                            (   9)[Re]
<internal:integer>:8: [BUG] see above.
ruby 2.8.0dev (2020-06-21T08:16:45Z builtin-canary 8110788f92) [x86_64-linux]

-- Control frame information -----------------------------------------------
c:0022 p:0003 s:0139 e:000138 METHOD <internal:integer>:8 [FINISH]
c:0021 p:---- s:0135 e:000134 CFUNC  :nonzero?
c:0020 p:0017 s:0131 e:000130 BLOCK  /home/k0kubun/src/github.com/ruby/ruby/lib/rubygems/specification.rb:847 [FINISH]
c:0019 p:---- s:0125 e:000124 CFUNC  :sort!
c:0018 p:0005 s:0121 e:000120 METHOD /home/k0kubun/src/github.com/ruby/ruby/lib/rubygems/specification.rb:845
c:0017 p:0047 s:0116 e:000115 METHOD /home/k0kubun/src/github.com/ruby/ruby/lib/rubygems/specification.rb:807
c:0016 p:0014 s:0110 e:000109 METHOD /home/k0kubun/src/github.com/ruby/ruby/lib/rubygems/specification.rb:745
c:0015 p:0020 s:0105 e:000103 METHOD /home/k0kubun/src/github.com/ruby/ruby/lib/rubygems/specification.rb:1073
c:0014 p:0005 s:0099 e:000098 METHOD /home/k0kubun/src/github.com/ruby/ruby/lib/rubygems/specification.rb:1080
c:0013 p:0021 s:0094 e:000093 BLOCK  /home/k0kubun/src/github.com/ruby/ruby/lib/rubygems/installer.rb:512 [FINISH]
c:0012 p:---- s:0091 e:000090 CFUNC  :synchronize
c:0011 p:0018 s:0087 e:000086 METHOD /home/k0kubun/src/github.com/ruby/ruby/lib/rubygems/installer.rb:512
c:0010 p:0176 s:0082 e:000081 METHOD /home/k0kubun/src/github.com/ruby/ruby/lib/rubygems/installer.rb:323 [FINISH]
c:0009 p:---- s:0077 e:000076 CFUNC  :call
c:0008 p:0030 s:0073 e:000072 BLOCK  ../tool/rbinstall.rb:825 [FINISH]
c:0007 p:0344 s:0069 e:000068 BLOCK  ../tool/rbinstall.rb:940 [FINISH]
c:0006 p:---- s:0059 e:000058 CFUNC  :foreach
c:0005 p:0189 s:0054 e:000053 BLOCK  ../tool/rbinstall.rb:925
c:0004 p:0018 s:0043 e:000042 BLOCK  ../tool/rbinstall.rb:997 [FINISH]
c:0003 p:---- s:0038 e:000037 CFUNC  :each
c:0002 p:1406 s:0034 E:000fc0 EVAL   ../tool/rbinstall.rb:994 [FINISH]
c:0001 p:0000 s:0003 E:0020e0 (none) [FINISH]

-- Ruby level backtrace information ----------------------------------------
../tool/rbinstall.rb:994:in `<main>'
../tool/rbinstall.rb:994:in `each'
../tool/rbinstall.rb:997:in `block in <main>'
../tool/rbinstall.rb:925:in `block in <main>'
../tool/rbinstall.rb:925:in `foreach'
../tool/rbinstall.rb:940:in `block (2 levels) in <main>'
../tool/rbinstall.rb:825:in `block in <class:Installer>'
../tool/rbinstall.rb:825:in `call'
/home/k0kubun/src/github.com/ruby/ruby/lib/rubygems/installer.rb:323:in `install'
/home/k0kubun/src/github.com/ruby/ruby/lib/rubygems/installer.rb:512:in `generate_plugins'
/home/k0kubun/src/github.com/ruby/ruby/lib/rubygems/installer.rb:512:in `synchronize'
/home/k0kubun/src/github.com/ruby/ruby/lib/rubygems/installer.rb:512:in `block in generate_plugins'
/home/k0kubun/src/github.com/ruby/ruby/lib/rubygems/specification.rb:1080:in `latest_spec_for'
/home/k0kubun/src/github.com/ruby/ruby/lib/rubygems/specification.rb:1073:in `latest_specs'
/home/k0kubun/src/github.com/ruby/ruby/lib/rubygems/specification.rb:745:in `_all'
/home/k0kubun/src/github.com/ruby/ruby/lib/rubygems/specification.rb:807:in `stubs'
/home/k0kubun/src/github.com/ruby/ruby/lib/rubygems/specification.rb:845:in `_resort!'
/home/k0kubun/src/github.com/ruby/ruby/lib/rubygems/specification.rb:845:in `sort!'
/home/k0kubun/src/github.com/ruby/ruby/lib/rubygems/specification.rb:847:in `block in _resort!'
/home/k0kubun/src/github.com/ruby/ruby/lib/rubygems/specification.rb:847:in `nonzero?'
<internal:integer>:8:in `zero?'

-- C level backtrace information -------------------------------------------
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(rb_vm_bugreport+0xcb1) [0x55cb273c0741] ../vm_dump.c:757
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(rb_bug+0xe1) [0x55cb271cadac] ../error.c:660
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(vm_check_canary+0xe8) [0x55cb27392a38] ../vm_insnhelper.c:281
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(vm_push_frame+0x76) [0x55cb27392e46] ../vm_insnhelper.c:309
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(rb_vm_call0+0x514) [0x55cb273a4304] ../vm_eval.c:91
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(rb_vm_call_kw+0x1e) [0x55cb273a5d78] ../vm_eval.c:239
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(rb_call0) ../vm_eval.c:361
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(builtin_inline_class_8+0x15) [0x55cb272720d5] ../numeric.c:782
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(vm_invoke_builtin_delegate+0x9a) [0x55cb2738f58a] ../vm_insnhelper.c:5172
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(vm_exec_core+0x3c89) [0x55cb273ad199] ../insns.def:1509
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(rb_vm_exec+0x92) [0x55cb273a0872] ../vm.c:1953
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(rb_vm_call0+0x2f4) [0x55cb273a40e4] ../vm_eval.c:142
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(rb_vm_call_kw+0x1e) [0x55cb273a5d78] ../vm_eval.c:239
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(rb_call0) ../vm_eval.c:361
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(exec_recursive+0x35d) [0x55cb2735768d] ../thread.c:5161
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(num_funcall0+0x12) [0x55cb2727209b] ../numeric.c:353
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(num_nonzero_p) ../numeric.c:814
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(vm_call_cfunc_with_frame+0xe1) [0x55cb27395be1] ../vm_insnhelper.c:2575
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(vm_call_method_each_type+0x118) [0x55cb273b3008] ../vm_insnhelper.c:3071
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(vm_call_method+0xf3) [0x55cb273b3743] ../vm_insnhelper.c:3175
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(vm_sendish+0x133) [0x55cb2739a893] ../vm_insnhelper.c:4165
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(vm_exec_core+0x10b) [0x55cb273a961b] ../insns.def:801
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(rb_vm_exec+0x92) [0x55cb273a0872] ../vm.c:1953
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(rb_yield_values2+0x79) [0x55cb273a2129] ../vm.c:1195
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(sort_1+0x54) [0x55cb273cc344] ../array.c:3399
/lib/x86_64-linux-gnu/libc.so.6(msort_with_tmp+0x3f2) [0x7f17b69031f2] msort.c:83
/lib/x86_64-linux-gnu/libc.so.6(msort_with_tmp+0x35e) [0x7f17b690315e] msort.c:117
/lib/x86_64-linux-gnu/libc.so.6(msort_with_tmp+0x370) [0x7f17b6903170] msort.c:117
/lib/x86_64-linux-gnu/libc.so.6(msort_with_tmp+0x370) [0x7f17b6903170] msort.c:117
/lib/x86_64-linux-gnu/libc.so.6(msort_with_tmp+0x370) [0x7f17b6903170] msort.c:117
/lib/x86_64-linux-gnu/libc.so.6(msort_with_tmp+0x370) [0x7f17b6903170] msort.c:117
/lib/x86_64-linux-gnu/libc.so.6(msort_with_tmp+0x17) [0x7f17b6903596] msort.c:45
/lib/x86_64-linux-gnu/libc.so.6(__qsort_r) msort.c:297
/lib/x86_64-linux-gnu/libc.so.6(qsort_r) (null):0
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(rb_ary_sort_bang+0x103) [0x55cb273d4c93] ../array.c:3469
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(vm_call_cfunc_with_frame+0xe1) [0x55cb27395be1] ../vm_insnhelper.c:2575
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(vm_call_method_each_type+0x118) [0x55cb273b3008] ../vm_insnhelper.c:3071
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(vm_call_method+0xf3) [0x55cb273b3743] ../vm_insnhelper.c:3175
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(vm_sendish+0x133) [0x55cb2739a893] ../vm_insnhelper.c:4165
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(vm_exec_core+0x31c1) [0x55cb273ac6d1] ../insns.def:782
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(rb_vm_exec+0x92) [0x55cb273a0872] ../vm.c:1953
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(rb_yield+0x2b3) [0x55cb273a3233] ../vm.c:1132
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(rb_ensure+0xd1) [0x55cb271d1811] ../eval.c:1141
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(vm_call_cfunc_with_frame+0xe1) [0x55cb27395be1] ../vm_insnhelper.c:2575
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(vm_sendish+0x133) [0x55cb2739a893] ../vm_insnhelper.c:4165
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(vm_exec_core+0x31c1) [0x55cb273ac6d1] ../insns.def:782
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(rb_vm_exec+0x92) [0x55cb273a0872] ../vm.c:1953
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(rb_vm_call0+0x2f4) [0x55cb273a40e4] ../vm_eval.c:142
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(rb_method_call_pass_called_kw+0x7e) [0x55cb272b923e] ../proc.c:2361
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(vm_call_cfunc_with_frame+0xe1) [0x55cb27395be1] ../vm_insnhelper.c:2575
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(vm_call_method_each_type+0x118) [0x55cb273b3008] ../vm_insnhelper.c:3071
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(vm_call_method+0xf3) [0x55cb273b3743] ../vm_insnhelper.c:3175
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(vm_sendish+0x133) [0x55cb2739a893] ../vm_insnhelper.c:4165
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(vm_exec_core+0x10b) [0x55cb273a961b] ../insns.def:801
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(rb_vm_exec+0x92) [0x55cb273a0872] ../vm.c:1953
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(rb_ec_vm_ptr+0x0) [0x55cb273a3671] ../vm.c:1090
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(rb_vm_invoke_bmethod) ../vm_core.h:1886
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(vm_call_bmethod+0xa7) [0x55cb273b2e97] ../vm_insnhelper.c:2627
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(vm_call_method_each_type+0x230) [0x55cb273b3120] ../vm_insnhelper.c:3097
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(vm_call_method+0xf3) [0x55cb273b3743] ../vm_insnhelper.c:3175
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(vm_sendish+0x133) [0x55cb2739a893] ../vm_insnhelper.c:4165
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(vm_exec_core+0x10b) [0x55cb273a961b] ../insns.def:801
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(rb_vm_exec+0x92) [0x55cb273a0872] ../vm.c:1953
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(invoke_block_from_c_bh+0x23c) [0x55cb273a2c6c] ../vm.c:1132
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(rb_yield+0x92) [0x55cb273a3012] ../vm.c:1195
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(io_s_foreach+0xb4) [0x55cb27212c04] ../io.c:10481
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(rb_ensure+0xd1) [0x55cb271d1811] ../eval.c:1141
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(rb_io_s_foreach+0x1cf) [0x55cb2721ab0f] ../io.c:10529
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(vm_call_cfunc_with_frame+0xe1) [0x55cb27395be1] ../vm_insnhelper.c:2575
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(vm_call_method_each_type+0x118) [0x55cb273b3008] ../vm_insnhelper.c:3071
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(vm_call_method+0xf3) [0x55cb273b3743] ../vm_insnhelper.c:3175
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(vm_sendish+0x133) [0x55cb2739a893] ../vm_insnhelper.c:4165
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(vm_exec_core+0x31c1) [0x55cb273ac6d1] ../insns.def:782
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(rb_vm_exec+0x92) [0x55cb273a0872] ../vm.c:1953
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(invoke_block_from_c_bh+0x23c) [0x55cb273a2c6c] ../vm.c:1132
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(rb_yield+0x92) [0x55cb273a3012] ../vm.c:1195
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(RB_FL_TEST_RAW+0x0) [0x55cb273d0fcc] ../array.c:2687
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(RB_FL_ANY_RAW) ../include/ruby/internal/fl_type.h:256
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(rb_ary_each) ../include/ruby/internal/core/rarray.h:135
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(vm_call_cfunc_with_frame+0xe1) [0x55cb27395be1] ../vm_insnhelper.c:2575
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(vm_sendish+0x133) [0x55cb2739a893] ../vm_insnhelper.c:4165
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(vm_exec_core+0x31c1) [0x55cb273ac6d1] ../insns.def:782
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(rb_vm_exec+0x92) [0x55cb273a0872] ../vm.c:1953
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(rb_ec_exec_node+0xaa) [0x55cb271cb83a] ../eval.c:296
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(ruby_run_node+0x46) [0x55cb271d08b6] ../eval.c:354
/home/k0kubun/src/github.com/ruby/ruby/.ruby-vm-check/ruby(main+0x6f) [0x55cb271caeef] ../main.c:50
```

From 