### PR TITLE
Annotate Kernel#class as inline

### DIFF
--- a/benchmark/mjit_class.yml
+++ b/benchmark/mjit_class.yml
@@ -1,0 +1,11 @@
+type: lib/benchmark_driver/runner/mjit
+prelude: |
+  def mjit_class(obj)
+    obj.class
+  end
+
+benchmark:
+  - mjit_class(self)
+  - mjit_class(1)
+
+loop_count: 40000000

--- a/benchmark/mjit_send_cfunc.yml
+++ b/benchmark/mjit_send_cfunc.yml
@@ -1,7 +1,0 @@
-type: lib/benchmark_driver/runner/mjit
-prelude: |
-  def mjit_send_cfunc
-    self.class
-  end
-benchmark: mjit_send_cfunc
-loop_count: 100000000

--- a/common.mk
+++ b/common.mk
@@ -8514,6 +8514,7 @@ mjit_compile.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 mjit_compile.$(OBJEXT): $(top_srcdir)/internal/gc.h
 mjit_compile.$(OBJEXT): $(top_srcdir)/internal/hash.h
 mjit_compile.$(OBJEXT): $(top_srcdir)/internal/imemo.h
+mjit_compile.$(OBJEXT): $(top_srcdir)/internal/object.h
 mjit_compile.$(OBJEXT): $(top_srcdir)/internal/serial.h
 mjit_compile.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 mjit_compile.$(OBJEXT): $(top_srcdir)/internal/variable.h
@@ -9266,6 +9267,7 @@ object.$(OBJEXT): {$(VPATH)}internal/value_type.h
 object.$(OBJEXT): {$(VPATH)}internal/variable.h
 object.$(OBJEXT): {$(VPATH)}internal/warning_push.h
 object.$(OBJEXT): {$(VPATH)}internal/xmalloc.h
+object.$(OBJEXT): {$(VPATH)}kernel.rb
 object.$(OBJEXT): {$(VPATH)}kernel.rbinc
 object.$(OBJEXT): {$(VPATH)}missing.h
 object.$(OBJEXT): {$(VPATH)}object.c

--- a/kernel.rb
+++ b/kernel.rb
@@ -1,6 +1,27 @@
 module Kernel
   #
   #  call-seq:
+  #     obj.class    -> class
+  #
+  #  Returns the class of <i>obj</i>. This method must always be called
+  #  with an explicit receiver, as #class is also a reserved word in
+  #  Ruby.
+  #
+  #     1.class      #=> Integer
+  #     self.class   #=> Object
+  #--
+  # Equivalent to \c Object\#class in Ruby.
+  #
+  # Returns the class of \c obj, skipping singleton classes or module inclusions.
+  #++
+  #
+  def class
+    Primitive.attr! 'inline'
+    Primitive.cexpr! 'rb_obj_class(self)'
+  end
+
+  #
+  #  call-seq:
   #     obj.clone(freeze: nil) -> an_object
   #
   #  Produces a shallow copy of <i>obj</i>---the instance variables of

--- a/object.c
+++ b/object.c
@@ -291,22 +291,6 @@ rb_class_real(VALUE cl)
     return cl;
 }
 
-/**
- *  call-seq:
- *     obj.class    -> class
- *
- *  Returns the class of <i>obj</i>. This method must always be called
- *  with an explicit receiver, as #class is also a reserved word in
- *  Ruby.
- *
- *     1.class      #=> Integer
- *     self.class   #=> Object
- *--
- * Equivalent to \c Object\#class in Ruby.
- *
- * Returns the class of \c obj, skipping singleton classes or module inclusions.
- *++
- */
 VALUE
 rb_obj_class(VALUE obj)
 {
@@ -4606,7 +4590,6 @@ InitVM_Object(void)
     rb_define_method(rb_mKernel, "hash", rb_obj_hash, 0); /* in hash.c */
     rb_define_method(rb_mKernel, "<=>", rb_obj_cmp, 1);
 
-    rb_define_method(rb_mKernel, "class", rb_obj_class, 0);
     rb_define_method(rb_mKernel, "singleton_class", rb_obj_singleton_class, 0);
     rb_define_method(rb_mKernel, "dup", rb_obj_dup, 0);
     rb_define_method(rb_mKernel, "itself", rb_obj_itself, 0);


### PR DESCRIPTION
```
$ benchmark-driver -v --rbenv 'before;after;before --jit;after --jit' benchmark/mjit_class.yml --repeat-count=4
before: ruby 2.8.0dev (2020-06-23T07:09:54Z master 37a2e48d76) [x86_64-linux]
after: ruby 2.8.0dev (2020-06-23T17:29:56Z inline-class 0ff147c007) [x86_64-linux]
before --jit: ruby 2.8.0dev (2020-06-23T07:09:54Z master 37a2e48d76) +JIT [x86_64-linux]
after --jit: ruby 2.8.0dev (2020-06-23T17:29:56Z inline-class 0ff147c007) +JIT [x86_64-linux]
Calculating -------------------------------------
                         before       after  before --jit  after --jit
    mjit_class(self)    39.219M     40.060M       53.502M      69.202M i/s -     40.000M times in 1.019915s 0.998495s 0.747631s 0.578021s
       mjit_class(1)    39.567M     41.242M       52.100M      68.895M i/s -     40.000M times in 1.010935s 0.969885s 0.767749s 0.580591s

Comparison:
                 mjit_class(self)
         after --jit:  69201690.7 i/s
        before --jit:  53502336.4 i/s - 1.29x  slower
               after:  40060289.1 i/s - 1.73x  slower
              before:  39218939.2 i/s - 1.76x  slower

                    mjit_class(1)
         after --jit:  68895358.6 i/s
        before --jit:  52100353.0 i/s - 1.32x  slower
               after:  41241993.6 i/s - 1.67x  slower
              before:  39567314.0 i/s - 1.74x  slower
```