### PR TITLE
fix return event and opt_invokebuiltin_delegate_leave

### DIFF
--- a/iseq.c
+++ b/iseq.c
@@ -3125,17 +3125,20 @@ rb_vm_encoded_insn_data_table_init(void)
     encoded_insn_data = st_init_numtable_with_size(VM_INSTRUCTION_SIZE / 2);
 
     for (insn = 0; insn < VM_INSTRUCTION_SIZE/2; insn++) {
-        int traced_insn = (int)insn;
-        if (traced_insn == BIN(opt_invokebuiltin_delegate_leave)) {
-            traced_insn = BIN(opt_invokebuiltin_delegate); // to dispatch :return from leave
-        }
         st_data_t key1 = (st_data_t)INSN_CODE(insn);
-        st_data_t key2 = (st_data_t)INSN_CODE((st_data_t)traced_insn + VM_INSTRUCTION_SIZE/2);
+        st_data_t key2 = (st_data_t)INSN_CODE(insn + VM_INSTRUCTION_SIZE/2);
 
         insn_data[insn].insn = (int)insn;
         insn_data[insn].insn_len = insn_len(insn);
-        insn_data[insn].notrace_encoded_insn = (void *) key1;
-        insn_data[insn].trace_encoded_insn = (void *) key2;
+
+        if (insn != BIN(opt_invokebuiltin_delegate_leave)) {
+            insn_data[insn].notrace_encoded_insn = (void *) key1;
+            insn_data[insn].trace_encoded_insn = (void *) key2;
+        }
+        else {
+            insn_data[insn].notrace_encoded_insn = (void *) INSN_CODE(BIN(opt_invokebuiltin_delegate));
+            insn_data[insn].trace_encoded_insn = (void *) INSN_CODE(BIN(opt_invokebuiltin_delegate) + VM_INSTRUCTION_SIZE/2);
+        }
 
         st_add_direct(encoded_insn_data, key1, (st_data_t)&insn_data[insn]);
         st_add_direct(encoded_insn_data, key2, (st_data_t)&insn_data[insn]);

--- a/test/ruby/test_settracefunc.rb
+++ b/test/ruby/test_settracefunc.rb
@@ -2299,7 +2299,6 @@ class TestSetTraceFunc < Test::Unit::TestCase
     assert_match /^0000 opt_invokebuiltin_delegate_leave /, out
 
     event = eval(EnvUtil.invoke_ruby(['-e', <<~'EOS'], '', true).first)
-      set_trace_func(proc {}); set_trace_func(nil) # Is it okay that this is required?
       TracePoint.new(:return) do |tp|
         p [tp.event, tp.method_id]
       end.enable do


### PR DESCRIPTION
If :return event is specified for a opt_invokebuiltin_delegate_leave
and leave combination, the instructions should be
  opt_invokebuiltin_delegate
  trace_return
instructions. To make it, opt_invokebuiltin_delegate_leave
instruction will be changed to opt_invokebuiltin_delegate even if
it is not an event target instruction.