### PR TITLE
Anonymous Struct literal `${a:1, b:2}`

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -449,6 +449,8 @@ node_children(rb_ast_t *ast, NODE *node)
         return rb_ary_new_from_node_args(ast, 0);
       case NODE_HASH:
         return rb_ary_new_from_node_args(ast, 1, node->nd_head);
+      case NODE_STRUCT:
+        return rb_ary_new_from_node_args(ast, 1, node->nd_head);
       case NODE_YIELD:
         return rb_ary_new_from_node_args(ast, 1, node->nd_head);
       case NODE_LVAR:

--- a/compile.c
+++ b/compile.c
@@ -4457,7 +4457,7 @@ compile_struct(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, int po
         n++;
         list = list->nd_next->nd_next;
     }
-    syms = ALLOC_N(VALUE, n);
+    syms = ALLOCA_N(VALUE, n);
     list = node->nd_head;
     while (list) {
         NODE *key = list->nd_head;

--- a/compile.c
+++ b/compile.c
@@ -4449,7 +4449,7 @@ compile_struct(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, int po
 
     if (!popped) {
         ADD_INSN1(ret, line, putobject, Qnil);
-        iobj = LAST_ELEMENT(ret);
+        iobj = (INSN *)LAST_ELEMENT(ret);
     }
 
     // check length

--- a/node.c
+++ b/node.c
@@ -600,6 +600,13 @@ dump_node(VALUE buf, VALUE indent, int comment, const NODE * node)
 	F_NODE(nd_head, "contents");
 	return;
 
+      case NODE_STRUCT:
+        ANN("Anonymous Struct constructor");
+        ANN("format: { [nd_head] }");
+        ANN("example: ${ a: 1, b: 2 }");
+        F_NODE(nd_head, "contents");
+        return;
+
       case NODE_YIELD:
 	ANN("yield invocation");
 	ANN("format: yield [nd_head]");

--- a/node.h
+++ b/node.h
@@ -67,6 +67,7 @@ enum node_type {
     NODE_ZLIST,
     NODE_VALUES,
     NODE_HASH,
+    NODE_STRUCT,
     NODE_RETURN,
     NODE_YIELD,
     NODE_LVAR,
@@ -315,6 +316,7 @@ typedef struct RNode {
 #define NEW_LIST(a,loc) NEW_NODE(NODE_LIST,a,1,0,loc)
 #define NEW_ZLIST(loc) NEW_NODE(NODE_ZLIST,0,0,0,loc)
 #define NEW_HASH(a,loc)  NEW_NODE(NODE_HASH,a,0,0,loc)
+#define NEW_STRUCT(a,loc)  NEW_NODE(NODE_STRUCT,a,0,0,loc)
 #define NEW_MASGN(l,r,loc)   NEW_NODE(NODE_MASGN,l,0,r,loc)
 #define NEW_GASGN(v,val,loc) NEW_NODE(NODE_GASGN,v,val,rb_global_entry(v),loc)
 #define NEW_LASGN(v,val,loc) NEW_NODE(NODE_LASGN,v,val,0,loc)

--- a/struct.c
+++ b/struct.c
@@ -139,7 +139,6 @@ struct_set_members(VALUE klass, VALUE /* frozen hidden array */ members)
     }
     rb_ivar_set(klass, id_members, members);
     rb_ivar_set(klass, id_back_members, back);
-
     return members;
 }
 
@@ -470,6 +469,14 @@ rb_struct_define(const char *name, ...)
 
     if (!name) st = anonymous_struct(rb_cStruct);
     else st = new_struct(rb_str_new2(name), rb_cStruct);
+    return setup_struct(st, ary);
+}
+
+VALUE
+rb_struct_define_syms(long num, VALUE *names)
+{
+    VALUE ary = rb_ary_new_from_values(num, names);
+    VALUE st = anonymous_struct(rb_cStruct);
     return setup_struct(st, ary);
 }
 

--- a/test/ripper/test_parser_events.rb
+++ b/test/ripper/test_parser_events.rb
@@ -762,6 +762,12 @@ class TestRipper::ParserEvents < Test::Unit::TestCase
     assert_equal true, thru_hash
   end
 
+  def test_struct
+    thru_struct = false
+    parse('${a: 1, b: 2}', :on_struct){thru_struct = true}
+    assert_equal true, thru_struct
+  end
+
   def test_if
     thru_if = false
     parse('if false; end', :on_if) {thru_if = true}

--- a/test/ruby/test_struct.rb
+++ b/test/ruby/test_struct.rb
@@ -472,6 +472,16 @@ module TestStruct
     assert_equal(2, s.b)
     assert_equal(3, s.c)
 
+    s1 = ${a: 1, b: 2, c: 3}
+    s2 = ${a: 1, b: 2, c: 3}
+    assert s1 == s2
+
+    s3 = ${a: 1, c: 3, b: 2}
+    s4 = ${d: 4}
+
+    assert_equal false, s1 == s3
+    assert_equal false, s1 == s4
+
     h = {}
     # only allows "key: expr" form
     assert_raise(SyntaxError){ eval '${a: 1, **h}'    }

--- a/test/ruby/test_struct.rb
+++ b/test/ruby/test_struct.rb
@@ -471,6 +471,12 @@ module TestStruct
     assert_equal(1, s.a)
     assert_equal(2, s.b)
     assert_equal(3, s.c)
+
+    h = {}
+    # only allows "key: expr" form
+    assert_raise(SyntaxError){ eval '${a: 1, **h}'    }
+    assert_raise(SyntaxError){ eval '${:a => 2}'      }
+    assert_raise(SyntaxError){ eval "${'foo-bar': 2}" }
   end
 
   class TopStruct < Test::Unit::TestCase

--- a/test/ruby/test_struct.rb
+++ b/test/ruby/test_struct.rb
@@ -466,6 +466,13 @@ module TestStruct
     }
   end
 
+  def test_struct_literal
+    s = ${a: 1, b: 2, c: 3}
+    assert_equal(1, s.a)
+    assert_equal(2, s.b)
+    assert_equal(3, s.c)
+  end
+
   class TopStruct < Test::Unit::TestCase
     include TestStruct
 

--- a/vm_core.h
+++ b/vm_core.h
@@ -600,6 +600,7 @@ typedef struct rb_vm_struct {
     VALUE loaded_features_snapshot;
     struct st_table *loaded_features_index;
     struct st_table *loading_table;
+    VALUE anonymous_struct_literal_cache;
 
     /* signal */
     struct {


### PR DESCRIPTION
Try to introduce anonymous Struct literal.
https://bugs.ruby-lang.org/issues/16986

`${a:1, b:2}` is almost equal to `Struct.new(kw.keys).new(kw.values)` where `kw` is `{a:1, b:2}`.
Anonymous class is prepared at compile time.