### PR TITLE
Not to rewrite node while compiling

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -3963,9 +3963,7 @@ compile_branch_condition(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *co
     return COMPILE_OK;
 }
 
-#define HASH_NO_BRACE 0
 #define HASH_BRACE 1
-#define METHOD_CALL_KEYWORDS 2
 
 static int
 keyword_node_p(const NODE *const node)


### PR DESCRIPTION
Moved this hack mark to an argument to `compile_hash`.
> Bad Hack: temporarily mark hash node with flag so
> compile_hash can compile call differently.