### PR TITLE
move rb_flo_is_finite_p func definition to numeric.h

### DIFF
--- a/complex.c
+++ b/complex.c
@@ -341,7 +341,6 @@ f_zero_p(VALUE x)
 
 #define f_nonzero_p(x) (!f_zero_p(x))
 
-VALUE rb_flo_is_finite_p(VALUE num);
 inline static int
 f_finite_p(VALUE x)
 {

--- a/internal/numeric.h
+++ b/internal/numeric.h
@@ -82,6 +82,7 @@ int rb_int_negative_p(VALUE num);
 VALUE rb_num_pow(VALUE x, VALUE y);
 VALUE rb_float_ceil(VALUE num, int ndigits);
 VALUE rb_float_abs(VALUE flt);
+VALUE rb_flo_is_finite_p(VALUE num);
 static inline VALUE rb_num_compare_with_zero(VALUE num, ID mid);
 static inline int rb_num_positive_int_p(VALUE num);
 static inline int rb_num_negative_int_p(VALUE num);


### PR DESCRIPTION
## Summary

Move definition `rb_flo_is_finite_p` to `numeric.h`

## Why?

`rb_flo_is_finite_p` function is defined in `numeric.c`, but prototype  id defined in `complex.c`.

I thought that better to move prototype  definition in `numeric.h` when consider using this function in another source code in the future.

So, I proposal to move it

