### PR TITLE
Avoid deprecated OpenSSL::Digest constants

### DIFF
--- a/lib/drb/ssl.rb
+++ b/lib/drb/ssl.rb
@@ -196,7 +196,7 @@ module DRb
         if comment = self[:SSLCertComment]
           cert.add_extension(ef.create_extension("nsComment", comment))
         end
-        cert.sign(rsa, OpenSSL::Digest::SHA256.new)
+        cert.sign(rsa, "SHA256")
 
         @cert = cert
         @pkey = rsa

--- a/lib/webrick/ssl.rb
+++ b/lib/webrick/ssl.rb
@@ -130,7 +130,7 @@ module WEBrick
       aki = ef.create_extension("authorityKeyIdentifier",
                                 "keyid:always,issuer:always")
       cert.add_extension(aki)
-      cert.sign(rsa, OpenSSL::Digest::SHA256.new)
+      cert.sign(rsa, "SHA256")
 
       return [ cert, rsa ]
     end

--- a/spec/ruby/library/openssl/hmac/digest_spec.rb
+++ b/spec/ruby/library/openssl/hmac/digest_spec.rb
@@ -4,7 +4,7 @@ require 'openssl'
 
 describe "OpenSSL::HMAC.digest" do
   it "returns an SHA1 digest" do
-    cur_digest = OpenSSL::Digest::SHA1.new
+    cur_digest = OpenSSL::Digest.new("SHA1")
     cur_digest.digest.should == HMACConstants::BlankSHA1Digest
     digest = OpenSSL::HMAC.digest(cur_digest,
                                         HMACConstants::Key,

--- a/spec/ruby/library/openssl/hmac/hexdigest_spec.rb
+++ b/spec/ruby/library/openssl/hmac/hexdigest_spec.rb
@@ -4,7 +4,7 @@ require 'openssl'
 
 describe "OpenSSL::HMAC.hexdigest" do
   it "returns an SHA1 hex digest" do
-    cur_digest = OpenSSL::Digest::SHA1.new
+    cur_digest = OpenSSL::Digest.new("SHA1")
     cur_digest.hexdigest.should == HMACConstants::BlankSHA1HexDigest
     hexdigest = OpenSSL::HMAC.hexdigest(cur_digest,
                                         HMACConstants::Key,


### PR DESCRIPTION
See https://github.com/ruby/openssl/pull/366 for the upcoming deprecation. This fixes all occurrences outside OpenSSL and Bundler/Rubygems. The latter are being handled in https://github.com/rubygems/rubygems/pull/3763

cc @ioquatix @rhenium 