### PR TITLE
Provide a way for methods to omit their return value (rev.2)

### DIFF
--- a/bignum.c
+++ b/bignum.c
@@ -2914,30 +2914,6 @@ bary_divmod(BDIGIT *qds, size_t qn, BDIGIT *rds, size_t rn, const BDIGIT *xds, s
 # define BIGNUM_DEBUG (0+RUBY_DEBUG)
 #endif
 
-#if BIGNUM_DEBUG
-#define ON_DEBUG(x) do { x; } while (0)
-static void
-dump_bignum(VALUE x)
-{
-    long i;
-    printf("%c0x0", BIGNUM_SIGN(x) ? '+' : '-');
-    for (i = BIGNUM_LEN(x); i--; ) {
-        printf("_%0*"PRIxBDIGIT, SIZEOF_BDIGIT*2, BDIGITS(x)[i]);
-    }
-    printf(", len=%"PRIuSIZE, BIGNUM_LEN(x));
-    puts("");
-}
-
-static VALUE
-rb_big_dump(VALUE x)
-{
-    dump_bignum(x);
-    return x;
-}
-#else
-#define ON_DEBUG(x)
-#endif
-
 static int
 bigzero_p(VALUE x)
 {

--- a/bootstraptest/test_insns.rb
+++ b/bootstraptest/test_insns.rb
@@ -412,6 +412,31 @@ tests = [
     class String; def =~ other; true; end; end
     'true' =~ /true/
   },
+
+  [ 'opt_RubyVM_return_value_is_used_', <<~'},', ],       # {
+    def used
+      used = yield
+      return used == true
+    end
+
+    used do
+      next RubyVM.return_value_is_used? # <- HERE
+    end
+  },
+
+  [ 'opt_RubyVM_return_value_is_used_', <<~'},', ],       # {
+    def notused
+      yield
+    rescue
+      return true
+    else
+      return false
+    end
+
+    notused do
+      raise unless RubyVM.return_value_is_used? # <- HERE
+    end
+  },
 ]
 
 # normal path

--- a/compile.c
+++ b/compile.c
@@ -3472,6 +3472,10 @@ iseq_specialized_instruction(rb_iseq_t *iseq, INSN *iobj)
                   case idNilP:   SP_INSN(nil_p);  return COMPILE_OK;
 		  case idSucc:	 SP_INSN(succ);	  return COMPILE_OK;
 		  case idNot:	 SP_INSN(not);	  return COMPILE_OK;
+                  default:
+                    if (vm_ci_mid(ci) == rb_intern("return_value_is_used?")) {
+                        return SP_INSN(RubyVM_return_value_is_used_);
+                    }
 		}
 		break;
 	      case 1:

--- a/ext/strscan/strscan.c
+++ b/ext/strscan/strscan.c
@@ -652,7 +652,8 @@ strscan_do_scan(VALUE self, VALUE pattern, int succptr, int getstr, int headonly
 static VALUE
 strscan_scan(VALUE self, VALUE re)
 {
-    return strscan_do_scan(self, re, 1, 1, 1);
+    bool needstr = rb_whether_the_return_value_is_used_p();
+    return strscan_do_scan(self, re, 1, needstr, 1);
 }
 
 /*
@@ -715,7 +716,8 @@ strscan_skip(VALUE self, VALUE re)
 static VALUE
 strscan_check(VALUE self, VALUE re)
 {
-    return strscan_do_scan(self, re, 0, 1, 1);
+    bool needstr = rb_whether_the_return_value_is_used_p();
+    return strscan_do_scan(self, re, 0, needstr, 1);
 }
 
 /*
@@ -749,7 +751,8 @@ strscan_scan_full(VALUE self, VALUE re, VALUE s, VALUE f)
 static VALUE
 strscan_scan_until(VALUE self, VALUE re)
 {
-    return strscan_do_scan(self, re, 1, 1, 0);
+    bool needstr = rb_whether_the_return_value_is_used_p();
+    return strscan_do_scan(self, re, 1, needstr, 0);
 }
 
 /*
@@ -809,7 +812,8 @@ strscan_skip_until(VALUE self, VALUE re)
 static VALUE
 strscan_check_until(VALUE self, VALUE re)
 {
-    return strscan_do_scan(self, re, 0, 1, 0);
+    bool needstr = rb_whether_the_return_value_is_used_p();
+    return strscan_do_scan(self, re, 0, needstr, 0);
 }
 
 /*

--- a/include/ruby/internal/intern/vm.h
+++ b/include/ruby/internal/intern/vm.h
@@ -31,6 +31,21 @@ int rb_sourceline(void);
 const char *rb_sourcefile(void);
 int rb_frame_method_id_and_class(ID *idp, VALUE *klassp);
 
+/**
+ * Checks if the innermost block/method that the calling function represents is
+ * expected to return meaningful return value(s) or not.
+ *
+ * @retval false It isn't.
+ * @retval true  Not sure.
+ *
+ * When this function returns `false`, the  VM detects that the return value of
+ * the  current  block/method  is  discarded.   Such  block/method  can  return
+ * anything.  Care  should be taken  if this function returns  otherwise.  That
+ * merely indicates that the VM cannot detect the usage of the return values of
+ * the current block/method.  They might or might not be actually used.
+ */
+bool rb_whether_the_return_value_is_used_p(void);
+
 /* vm_eval.c */
 VALUE rb_check_funcall(VALUE, ID, int, const VALUE*);
 VALUE rb_check_funcall_kw(VALUE, ID, int, const VALUE*, int);

--- a/insns.def
+++ b/insns.def
@@ -738,8 +738,11 @@ defineclass
 
     rb_iseq_check(class_iseq);
 
+    /* if next instruction is pop (likely), we can skip a part of the execution. */
+    VALUE flag = CURRENT_INSN_IS(pop) * VM_FRAME_FLAG_DISCARDED;
+
     /* enter scope */
-    vm_push_frame(ec, class_iseq, VM_FRAME_MAGIC_CLASS | VM_ENV_FLAG_LOCAL, klass,
+    vm_push_frame(ec, class_iseq, flag | VM_FRAME_MAGIC_CLASS | VM_ENV_FLAG_LOCAL, klass,
 		  GET_BLOCK_HANDLER(),
 		  (VALUE)vm_cref_push(ec, klass, NULL, FALSE),
 		  class_iseq->body->iseq_encoded, GET_SP(),

--- a/insns.def
+++ b/insns.def
@@ -1459,6 +1459,30 @@ opt_regexpmatch2
     }
 }
 
+/* optimized RubyVM.return_value_is_used?
+ *
+ * This method involves the caller's CFP.  Specialised instruction is
+ * much lightweight than lifting up a new frame to run a C function
+ * then look underneath from there.
+ */
+DEFINE_INSN
+opt_RubyVM_return_value_is_used_
+(CALL_DATA cd)
+(VALUE recv)
+(VALUE val)
+{
+    if (! vm_method_cfunc_is(GET_ISEQ(), cd, recv,
+            rb_whether_the_return_value_is_used_p_m)) {
+        CALL_SIMPLE_METHOD();
+    }
+    else if (VM_ENV_FLAGS(GET_EP(), VM_FRAME_FLAG_DISCARDED)) {
+        val = Qfalse;
+    }
+    else {
+        val = Qtrue;
+    }
+}
+
 /* call native compiled method */
 DEFINE_INSN_IF(SUPPORT_CALL_C_FUNCTION)
 opt_call_c_function

--- a/insns.def
+++ b/insns.def
@@ -183,12 +183,12 @@ getblockparamproxy
 }
 
 /* Get value of special local variable ($~, $_, ..). */
+/* This is not a leaf because `$~ = MatchData.allocate; $&` can raise. */
 DEFINE_INSN
 getspecial
 (rb_num_t key, rb_num_t type)
 ()
 (VALUE val)
-/* `$~ = MatchData.allocate; $&` can raise. */
 // attr bool leaf = (type == 0) ? true : false;
 {
     val = vm_getspecial(ec, GET_LEP(), key, type);
@@ -205,12 +205,13 @@ setspecial
 }
 
 /* Get value of instance variable id of self. */
+/* This is not a leaf because "instance variable not initialized" warning can
+ * be hooked. */
 DEFINE_INSN
 getinstancevariable
 (ID id, IVC ic)
 ()
 (VALUE val)
-/* "instance variable not initialized" warning can be hooked. */
 // attr bool leaf = false; /* has rb_warning() */
 {
     val = vm_getinstancevariable(GET_SELF(), id, ic);
@@ -228,24 +229,25 @@ setinstancevariable
 }
 
 /* Get value of class variable id of klass as val. */
+/* This is no a leaf because "class variable access from toplevel" warning can
+ * be hooked. */
 DEFINE_INSN
 getclassvariable
 (ID id)
 ()
 (VALUE val)
-/* "class variable access from toplevel" warning can be hooked. */
 // attr bool leaf = false; /* has rb_warning() */
 {
     val = rb_cvar_get(vm_get_cvar_base(vm_get_cref(GET_EP()), GET_CFP(), 1), id);
 }
 
 /* Set value of class variable id of klass as val. */
+/* This is not a leaf (ditto for getcalassvariable). */
 DEFINE_INSN
 setclassvariable
 (ID id)
 (VALUE val)
 ()
-/* "class variable access from toplevel" warning can be hooked. */
 // attr bool leaf = false; /* has rb_warning() */
 {
     vm_ensure_not_refinement_module(GET_SELF());
@@ -256,28 +258,27 @@ setclassvariable
    are searched in the current scope. Otherwise, get constant under klass
    class or module.
  */
+/* This is no a leaf because it can kick autoload. */
 DEFINE_INSN
 getconstant
 (ID id)
 (VALUE klass, VALUE allow_nil)
 (VALUE val)
-/* getconstant can kick autoload */
 // attr bool leaf = false; /* has rb_autoload_load() */
 {
     val = vm_get_ev_const(ec, klass, id, allow_nil == Qtrue, 0);
 }
 
-/* Set constant variable id under cbase class or module.
- */
+/* Set constant variable id under cbase class or module. */
+/* Assigning an object to a constant is basically a leaf operation.
+ * The problem is, assigning a Module instance to a constant _names_
+ * that module.  Naming involves string manipulations, which are
+ * method calls.  Hence it is not a leaf in general. */
 DEFINE_INSN
 setconstant
 (ID id)
 (VALUE val, VALUE cbase)
 ()
-/* Assigning an object to a constant is basically a leaf operation.
- * The problem is, assigning a Module instance to a constant _names_
- * that module.  Naming involves string manipulations, which are
- * method calls. */
 // attr bool leaf = false; /* has StringValue() */
 {
     vm_check_if_namespace(cbase);
@@ -369,13 +370,13 @@ putstring
 }
 
 /* put concatenate strings */
+/* This instruction can concat UTF-8 and binary strings, resulting in
+ * Encoding::CompatibilityError. */
 DEFINE_INSN
 concatstrings
 (rb_num_t num)
 (...)
 (VALUE val)
-/* This instruction can concat UTF-8 and binary strings, resulting in
- * Encoding::CompatibilityError. */
 // attr bool leaf = false; /* has rb_enc_cr_str_buf_cat() */
 // attr rb_snum_t sp_inc = 1 - (rb_snum_t)num;
 {
@@ -405,13 +406,13 @@ freezestring
 /* compile str to Regexp and push it.
      opt is the option for the Regexp.
  */
+/* This instruction can raise RegexpError, thus can call
+ * RegexpError#initialize */
 DEFINE_INSN
 toregexp
 (rb_num_t opt, rb_num_t cnt)
 (...)
 (VALUE val)
-/* This instruction can raise RegexpError, thus can call
- * RegexpError#initialize */
 // attr bool leaf = false;
 // attr rb_snum_t sp_inc = 1 - (rb_snum_t)cnt;
 {
@@ -544,12 +545,13 @@ newhash
 }
 
 /* put new Range object.(Range.new(low, high, flag)) */
+/* This is not a leaf because rb_range_new() exercises "bad value for range"
+ * check. */
 DEFINE_INSN
 newrange
 (rb_num_t flag)
 (VALUE low, VALUE high)
 (VALUE val)
-/* rb_range_new() exercises "bad value for range" check. */
 // attr bool leaf = false; /* see also: range.c:range_init() */
 {
     val = rb_range_new(low, high, (int)flag);
@@ -848,27 +850,27 @@ opt_str_uminus
     }
 }
 
+/* This instruction typically has no funcalls.  But it compares array
+ * contents each other by nature.  That part could call methods when
+ * necessary.  No way to detect such method calls beforehand.  We
+ * cannot but mark it being not leaf. */
 DEFINE_INSN
 opt_newarray_max
 (rb_num_t num)
 (...)
 (VALUE val)
-/* This instruction typically has no funcalls.  But it compares array
- * contents each other by nature.  That part could call methods when
- * necessary.  No way to detect such method calls beforehand.  We
- * cannot but mark it being not leaf. */
 // attr bool leaf = false; /* has rb_funcall() */
 // attr rb_snum_t sp_inc = 1 - (rb_snum_t)num;
 {
     val = vm_opt_newarray_max(num, STACK_ADDR_FROM_TOP(num));
 }
 
+/* Same discussion as opt_newarray_max. */
 DEFINE_INSN
 opt_newarray_min
 (rb_num_t num)
 (...)
 (VALUE val)
-/* Same discussion as opt_newarray_max. */
 // attr bool leaf = false; /* has rb_funcall() */
 // attr rb_snum_t sp_inc = 1 - (rb_snum_t)num;
 {
@@ -918,14 +920,14 @@ invokeblock
 }
 
 /* return from this scope. */
+/* This is super surprising but when leaving from a frame, we check
+ * for interrupts.  If any, that should be executed on top of the
+ * current execution context.  This is a method call. */
 DEFINE_INSN
 leave
 ()
 (VALUE val)
 (VALUE val)
-/* This is super surprising but when leaving from a frame, we check
- * for interrupts.  If any, that should be executed on top of the
- * current execution context.  This is a method call. */
 // attr bool leaf = false; /* has rb_threadptr_execute_interrupts() */
 // attr bool handles_sp = true;
 {
@@ -954,12 +956,12 @@ leave
 /**********************************************************/
 
 /* longjump */
+/* This is not a leaf (ditto for leave). */
 DEFINE_INSN
 throw
 (rb_num_t throw_state)
 (VALUE throwobj)
 (VALUE val)
-/* Same discussion as leave. */
 // attr bool leaf = false; /* has rb_threadptr_execute_interrupts() */
 {
     val = vm_throw(ec, GET_CFP(), throw_state, throwobj);
@@ -972,12 +974,12 @@ throw
 /**********************************************************/
 
 /* set PC to (PC + dst). */
+/* This is not a leaf (ditto for leave). */
 DEFINE_INSN
 jump
 (OFFSET dst)
 ()
 ()
-/* Same discussion as leave. */
 // attr bool leaf = false; /* has rb_threadptr_execute_interrupts() */
 {
     RUBY_VM_CHECK_INTS(ec);
@@ -985,12 +987,12 @@ jump
 }
 
 /* if val is not false or nil, set PC to (PC + dst). */
+/* This is not a leaf (ditto for jump). */
 DEFINE_INSN
 branchif
 (OFFSET dst)
 (VALUE val)
 ()
-/* Same discussion as jump. */
 // attr bool leaf = false; /* has rb_threadptr_execute_interrupts() */
 {
     if (RTEST(val)) {
@@ -1000,12 +1002,12 @@ branchif
 }
 
 /* if val is false or nil, set PC to (PC + dst). */
+/* This is not a leaf (ditto for jump). */
 DEFINE_INSN
 branchunless
 (OFFSET dst)
 (VALUE val)
 ()
-/* Same discussion as jump. */
 // attr bool leaf = false; /* has rb_threadptr_execute_interrupts() */
 {
     if (!RTEST(val)) {
@@ -1015,12 +1017,12 @@ branchunless
 }
 
 /* if val is nil, set PC to (PC + dst). */
+/* This is not a leaf (ditto for jump). */
 DEFINE_INSN
 branchnil
 (OFFSET dst)
 (VALUE val)
 ()
-/* Same discussion as jump. */
 // attr bool leaf = false; /* has rb_threadptr_execute_interrupts() */
 {
     if (NIL_P(val)) {
@@ -1129,13 +1131,13 @@ opt_mult
 }
 
 /* optimized X/Y. */
+/* In case of division by zero, it raises. Thus
+ * ZeroDivisionError#initialize is called.  */
 DEFINE_INSN
 opt_div
 (CALL_DATA cd)
 (VALUE recv, VALUE obj)
 (VALUE val)
-/* In case of division by zero, it raises. Thus
- * ZeroDivisionError#initialize is called.  */
 // attr bool leaf = false;
 {
     val = vm_opt_div(recv, obj);
@@ -1146,12 +1148,12 @@ opt_div
 }
 
 /* optimized X%Y. */
+/* This is not a leaf (ditto for opt_div). */
 DEFINE_INSN
 opt_mod
 (CALL_DATA cd)
 (VALUE recv, VALUE obj)
 (VALUE val)
-/* Same discussion as opt_mod. */
 // attr bool leaf = false;
 {
     val = vm_opt_mod(recv, obj);
@@ -1246,14 +1248,14 @@ opt_ge
 }
 
 /* << */
+/* This instruction can append an integer, as a codepoint, into a
+ * string.  Then what happens if that codepoint does not exist in the
+ * string's encoding?  Of course an exception.  That's not a leaf. */
 DEFINE_INSN
 opt_ltlt
 (CALL_DATA cd)
 (VALUE recv, VALUE obj)
 (VALUE val)
-/* This instruction can append an integer, as a codepoint, into a
- * string.  Then what happens if that codepoint does not exist in the
- * string's encoding?  Of course an exception.  That's not a leaf. */
 // attr bool leaf = false; /* has "invalid codepoint" exception */
 {
     val = vm_opt_ltlt(recv, obj);
@@ -1292,15 +1294,15 @@ opt_or
 }
 
 /* [] */
+/* This is complicated.  In case of hash, vm_opt_aref() resorts to
+ * rb_hash_aref().  If `recv` has no `obj`, this function then yields
+ * default_proc.  This is a method call.  So opt_aref is
+ * (surprisingly) not leaf. */
 DEFINE_INSN
 opt_aref
 (CALL_DATA cd)
 (VALUE recv, VALUE obj)
 (VALUE val)
-/* This is complicated.  In case of hash, vm_opt_aref() resorts to
- * rb_hash_aref().  If `recv` has no `obj`, this function then yields
- * default_proc.  This is a method call.  So opt_aref is
- * (surprisingly) not leaf. */
 // attr bool leaf = false; /* has rb_funcall() */ /* calls #yield */
 {
     val = vm_opt_aref(recv, obj);
@@ -1311,13 +1313,13 @@ opt_aref
 }
 
 /* recv[obj] = set */
+/* This is another story than opt_aref.  When vm_opt_aset() resorts
+ * to rb_hash_aset(), which should call #hash for `obj`. */
 DEFINE_INSN
 opt_aset
 (CALL_DATA cd)
 (VALUE recv, VALUE obj, VALUE set)
 (VALUE val)
-/* This is another story than opt_aref.  When vm_opt_aset() resorts
- * to rb_hash_aset(), which should call #hash for `obj`. */
 // attr bool leaf = false; /* has rb_funcall() */ /* calls #hash */
 {
     val = vm_opt_aset(recv, obj, set);
@@ -1328,12 +1330,12 @@ opt_aset
 }
 
 /* recv[str] = set */
+/* This is not a leaf (ditto for opt_aset). */
 DEFINE_INSN
 opt_aset_with
 (VALUE key, CALL_DATA cd)
 (VALUE recv, VALUE val)
 (VALUE val)
-/* Same discussion as opt_aset. */
 // attr bool leaf = false; /* has rb_funcall() */ /* calls #hash */
 {
     VALUE tmp = vm_opt_aset_with(recv, key, val);
@@ -1351,12 +1353,12 @@ opt_aset_with
 }
 
 /* recv[str] */
+/* This is not a leaf (ditto for opt_aref). */
 DEFINE_INSN
 opt_aref_with
 (VALUE key, CALL_DATA cd)
 (VALUE recv)
 (VALUE val)
-/* Same discussion as opt_aref. */
 // attr bool leaf = false; /* has rb_funcall() */ /* calls #yield */
 {
     val = vm_opt_aref_with(recv, key);

--- a/iseq.c
+++ b/iseq.c
@@ -1993,6 +1993,7 @@ rb_insn_operand_intern(const rb_iseq_t *iseq,
 		CALL_FLAG(KWARG);
 		CALL_FLAG(KW_SPLAT);
                 CALL_FLAG(KW_SPLAT_MUT);
+                CALL_FLAG(DISCARDED);
 		CALL_FLAG(OPT_SEND); /* maybe not reachable */
 		rb_ary_push(ary, rb_ary_join(flags, rb_str_new2("|")));
 	    }

--- a/string.c
+++ b/string.c
@@ -4961,7 +4961,9 @@ rb_str_slice_bang(int argc, VALUE *argv, VALUE str)
 	beg = rb_str_index(str, indx, 0);
 	if (beg == -1) return Qnil;
 	len = RSTRING_LEN(indx);
-	result = rb_str_dup(indx);
+        if (rb_whether_the_return_value_is_used_p()) {
+            result = rb_str_dup(indx);
+        }
         goto squash;
     }
     else {
@@ -4981,8 +4983,10 @@ rb_str_slice_bang(int argc, VALUE *argv, VALUE str)
     beg = p - RSTRING_PTR(str);
 
   subseq:
-    result = rb_str_new_with_class(str, RSTRING_PTR(str)+beg, len);
-    rb_enc_cr_str_copy_for_substr(result, str);
+    if (rb_whether_the_return_value_is_used_p()) {
+        result = rb_str_new_with_class(str, RSTRING_PTR(str)+beg, len);
+        rb_enc_cr_str_copy_for_substr(result, str);
+    }
 
   squash:
     if (len > 0) {

--- a/test/ruby/test_gc.rb
+++ b/test/ruby/test_gc.rb
@@ -93,18 +93,24 @@ class TestGc < Test::Unit::TestCase
 
     stat, count = {}, {}
     GC.start
-    GC.stat(stat)
-    ObjectSpace.count_objects(count)
     # repeat same methods invocation for cache object creation.
-    GC.stat(stat)
-    ObjectSpace.count_objects(count)
+    i, j, k = true, true, false
+    while i do
+      i, j, k = j, k, i
+      GC.stat(stat)
+      ObjectSpace.count_objects(count)
+    end
     assert_equal(count[:TOTAL]-count[:FREE], stat[:heap_live_slots])
     assert_equal(count[:FREE], stat[:heap_free_slots])
 
     # measure again without GC.start
     1000.times{ "a" + "b" }
-    GC.stat(stat)
-    ObjectSpace.count_objects(count)
+    i, j, k = true, true, false
+    while i do
+      i, j, k = j, k, i
+      GC.stat(stat)
+      ObjectSpace.count_objects(count)
+    end
     assert_equal(count[:FREE], stat[:heap_free_slots])
   end
 

--- a/tool/ruby_vm/views/_mjit_compile_send.erb
+++ b/tool/ruby_vm/views/_mjit_compile_send.erb
@@ -64,6 +64,7 @@
             fprintf(f, "    {\n");
             fprintf(f, "        VALUE val;\n");
             fprintf(f, "        struct rb_calling_info calling;\n");
+            fprintf(f, "        calling.flags = %d;\n", VM_FRAME_FLAG_DISCARDED * !!(vm_ci_flag(ci) & VM_CALL_DISCARDED));
 % if insn.name == 'send'
             fprintf(f, "        calling.block_handler = vm_caller_setup_arg_block(ec, reg_cfp, (const struct rb_callinfo *)0x%"PRIxVALUE", (rb_iseq_t *)0x%"PRIxVALUE", FALSE);\n", (VALUE)ci, (VALUE)blockiseq);
 % else

--- a/vm.c
+++ b/vm.c
@@ -346,7 +346,7 @@ extern VALUE rb_vm_invoke_bmethod(rb_execution_context_t *ec, rb_proc_t *proc, V
                                   int argc, const VALUE *argv, int kw_splat, VALUE block_handler,
                                   const rb_callable_method_entry_t *me);
 static VALUE vm_invoke_proc(rb_execution_context_t *ec, rb_proc_t *proc, VALUE self, int argc, const VALUE *argv, int kw_splat, VALUE block_handler);
-
+static VALUE rb_whether_the_return_value_is_used_p_m(VALUE self);
 #include "vm_insnhelper.c"
 
 #ifndef MJIT_HEADER
@@ -3064,6 +3064,7 @@ Init_VM(void)
     rb_define_singleton_method(rb_cRubyVM, "reset_debug_counters", rb_debug_counter_reset, 0);
     rb_define_singleton_method(rb_cRubyVM, "show_debug_counters", rb_debug_counter_show, 0);
 #endif
+    rb_define_singleton_method(rb_cRubyVM, "return_value_is_used?", rb_whether_the_return_value_is_used_p_m, 0);
 
     /* FrozenCore (hidden) */
     fcore = rb_class_new(rb_cBasicObject);
@@ -3805,6 +3806,25 @@ rb_vm_empty_cc(void)
 }
 
 #endif /* #ifndef MJIT_HEADER */
+
+/*
+ *  call-seq:
+ *    RubyVM.return_value_is_used? -> true or false
+ *
+ *  Checks if the innermost block/method is expected to return meaningful
+ *  return value(s) or not.  When this method returns +false+, the VM detects
+ *  that the return value of the calling block/method is discarded.  Such
+ *  block/method can return anything.  Care should be taken if this method
+ *  returns otherwise.  That merely indicates that the VM cannot detect the
+ *  usage of the return values of the current block/method.  They might or
+ *  might not be actually used.
+ *
+ */
+static VALUE
+rb_whether_the_return_value_is_used_p_m(MAYBE_UNUSED(VALUE self))
+{
+    return rb_whether_the_return_value_is_used_p() ? Qtrue : Qfalse;
+}
 
 bool
 rb_whether_the_return_value_is_used_p(void)

--- a/vm.c
+++ b/vm.c
@@ -3806,4 +3806,14 @@ rb_vm_empty_cc(void)
 
 #endif /* #ifndef MJIT_HEADER */
 
+bool
+rb_whether_the_return_value_is_used_p(void)
+{
+    const struct rb_execution_context_struct *ec = GET_EC();
+    const struct rb_control_frame_struct *reg_cfp = ec->cfp;
+    const VALUE *ep = GET_EP();
+
+    return ! VM_ENV_FLAGS(ep, VM_FRAME_FLAG_DISCARDED);
+}
+
 #include "vm_call_iseq_optimized.inc" /* required from vm_insnhelper.c */

--- a/vm_callinfo.h
+++ b/vm_callinfo.h
@@ -25,6 +25,7 @@ enum vm_call_flag_bits {
     VM_CALL_ZSUPER_bit,         /* zsuper */
     VM_CALL_OPT_SEND_bit,       /* internal flag */
     VM_CALL_KW_SPLAT_MUT_bit,   /* kw splat hash can be modified (to avoid allocating a new one) */
+    VM_CALL_DISCARDED_bit,      /* ;m(...); */
     VM_CALL__END
 };
 
@@ -41,6 +42,7 @@ enum vm_call_flag_bits {
 #define VM_CALL_ZSUPER          (0x01 << VM_CALL_ZSUPER_bit)
 #define VM_CALL_OPT_SEND        (0x01 << VM_CALL_OPT_SEND_bit)
 #define VM_CALL_KW_SPLAT_MUT    (0x01 << VM_CALL_KW_SPLAT_MUT_bit)
+#define VM_CALL_DISCARDED       (0x01 << VM_CALL_DISCARDED_bit)
 
 struct rb_callinfo_kwarg {
     int keyword_len;

--- a/vm_core.h
+++ b/vm_core.h
@@ -1113,11 +1113,11 @@ typedef rb_control_frame_t *
 
 enum {
     /* Frame/Environment flag bits:
-     *   MMMM MMMM MMMM MMMM ____ _FFF FFFF EEEX (LSB)
+     *   MMMM MMMM MMMM MMMM ____ FFFF FFFF EEEX (LSB)
      *
      * X   : tag for GC marking (It seems as Fixnum)
      * EEE : 3 bits Env flags
-     * FF..: 7 bits Frame flags
+     * FF..: 8 bits Frame flags
      * MM..: 15 bits frame magic (to check frame corruption)
      */
 
@@ -1142,6 +1142,7 @@ enum {
     VM_FRAME_FLAG_LAMBDA    = 0x0100,
     VM_FRAME_FLAG_MODIFIED_BLOCK_PARAM = 0x0200,
     VM_FRAME_FLAG_CFRAME_KW = 0x0400,
+    VM_FRAME_FLAG_DISCARDED = 0x0800,
 
     /* env flag */
     VM_ENV_FLAG_LOCAL       = 0x0002,

--- a/vm_core.h
+++ b/vm_core.h
@@ -239,6 +239,7 @@ union iseq_inline_storage_entry {
 };
 
 struct rb_calling_info {
+    VALUE flags;
     VALUE block_handler;
     VALUE recv;
     int argc;

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -46,6 +46,7 @@ MJIT_FUNC_EXPORTED VALUE
 rb_vm_call0(rb_execution_context_t *ec, VALUE recv, ID id, int argc, const VALUE *argv, const rb_callable_method_entry_t *me, int kw_splat)
 {
     struct rb_calling_info calling = {
+        .flags = RBIMPL_VALUE_NULL, /* or ... ? */
         .block_handler = VM_BLOCK_HANDLER_NONE,
         .recv = recv,
         .argc = argc,

--- a/vm_exec.h
+++ b/vm_exec.h
@@ -64,6 +64,7 @@ error !
 
 #define START_OF_ORIGINAL_INSN(x) /* ignore */
 #define DISPATCH_ORIGINAL_INSN(x) return LABEL(x)(ec, reg_cfp);
+#define CURRENT_INSN_IS(pop) ((rb_insn_func_t)GET_CURRENT_INSN() == LABEL(pop))
 
 /************************************************/
 #elif OPT_TOKEN_THREADED_CODE || OPT_DIRECT_THREADED_CODE
@@ -132,6 +133,7 @@ error !
 
 #define START_OF_ORIGINAL_INSN(x) start_of_##x:
 #define DISPATCH_ORIGINAL_INSN(x) goto  start_of_##x;
+#define CURRENT_INSN_IS(pop) (GET_CURRENT_INSN() == (VALUE)LABEL_PTR(pop))
 
 /************************************************/
 #else /* no threaded code */
@@ -159,12 +161,16 @@ default:                        \
 
 #define START_OF_ORIGINAL_INSN(x) start_of_##x:
 #define DISPATCH_ORIGINAL_INSN(x) goto  start_of_##x;
+#define CURRENT_INSN_IS(pop) (GET_CURRENT_INSN() == BIN(pop))
 
 #endif
 
 #define VM_SP_CNT(ec, sp) ((sp) - (ec)->vm_stack)
 
 #ifdef MJIT_HEADER
+/* MJIT_HEADER lacks LABEL_PTR */
+#undef CURRENT_INSN_IS
+#define CURRENT_INSN_IS(pop) false
 #define THROW_EXCEPTION(exc) do { \
     ec->errinfo = (VALUE)(exc); \
     EC_JUMP_TAG(ec, ec->tag->state); \

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -2334,7 +2334,7 @@ vm_call_iseq_setup_normal(rb_execution_context_t *ec, rb_control_frame_t *cfp, s
     VALUE *sp = argv + param_size;
     cfp->sp = argv - 1 /* recv */;
 
-    vm_push_frame(ec, iseq, VM_FRAME_MAGIC_METHOD | VM_ENV_FLAG_LOCAL, calling->recv,
+    vm_push_frame(ec, iseq, calling->flags | VM_FRAME_MAGIC_METHOD | VM_ENV_FLAG_LOCAL, calling->recv,
                   calling->block_handler, (VALUE)me,
                   iseq->body->iseq_encoded + opt_pc, sp,
                   local_size - param_size,
@@ -2381,7 +2381,7 @@ vm_call_iseq_setup_tailcall(rb_execution_context_t *ec, rb_control_frame_t *cfp,
 	*sp++ = src_argv[i];
     }
 
-    vm_push_frame(ec, iseq, VM_FRAME_MAGIC_METHOD | VM_ENV_FLAG_LOCAL | finish_flag,
+    vm_push_frame(ec, iseq, calling->flags | VM_FRAME_MAGIC_METHOD | VM_ENV_FLAG_LOCAL | finish_flag,
 		  calling->recv, calling->block_handler, (VALUE)me,
 		  iseq->body->iseq_encoded + opt_pc, sp,
 		  iseq->body->local_table_size - iseq->body->param.size,
@@ -4157,7 +4157,9 @@ vm_sendish(
     int argc = vm_ci_argc(ci);
     VALUE recv = TOPN(argc);
     struct rb_calling_info calling;
+    VALUE flags = vm_ci_flag(ci);
 
+    calling.flags = VM_FRAME_FLAG_DISCARDED * !!(flags & VM_CALL_DISCARDED);
     calling.block_handler = block_handler;
     calling.kw_splat = IS_ARGS_KW_SPLAT(ci) > 0;
     calling.recv = recv;

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -2569,7 +2569,7 @@ vm_call_cfunc_with_frame(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp
     RUBY_DTRACE_CMETHOD_ENTRY_HOOK(ec, me->owner, me->def->original_id);
     EXEC_EVENT_HOOK(ec, RUBY_EVENT_C_CALL, recv, me->def->original_id, vm_ci_mid(ci), me->owner, Qundef);
 
-    vm_push_frame(ec, NULL, frame_type, recv,
+    vm_push_frame(ec, NULL, calling->flags | frame_type, recv,
 		  block_handler, (VALUE)me,
 		  0, ec->cfp->sp, 0, 0);
 

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -3499,7 +3499,7 @@ vm_invoke_iseq_block(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp,
     SET_SP(rsp);
 
     vm_push_frame(ec, iseq,
-		  VM_FRAME_MAGIC_BLOCK | (is_lambda ? VM_FRAME_FLAG_LAMBDA : 0),
+                  calling->flags | VM_FRAME_MAGIC_BLOCK | (is_lambda ? VM_FRAME_FLAG_LAMBDA : 0),
 		  captured->self,
 		  VM_GUARDED_PREV_EP(captured->ep), 0,
 		  iseq->body->iseq_encoded + opt_pc,


### PR DESCRIPTION
### Abstract

This pull request implements `RubyVM.return_value_is_used?` (and its CAPI counterpart `rb_whether_the_return_value_is_used_p()`), which could be used by 3rd party applications/libraries to optimise their code.

### Revision history

- #3271 Revision 2 (current).
    - Removed dependency to #1943 (which was a show-stopper).  This means we gave up automatic abortion of an instruction sequence.
    - Reconsidered names of internal flags.
    - Split commits into smaller ones.
- #2100 Initial revision.

### Introduction

Ruby do not force you a style of writing.  In Ruby, one thing tends to be doable in more than one ways.  This is considered to be a good thing.  To make it possible, a return value of a method is not forced to be used: every method can (and does) return possibly multiple values, while its callers are free to ignore them.  Even when a method does not expect its callers to take any return values, it tends to return something meaningful "just in case" the expectation breaks.

However, these "just in case" return values rarely gets used in practice.  Most of the time they are just silently ignored.  They become instant garbage unless referenced elsewhere; which is of course a waste of both time and space.  There is a room of improvements around this area.

How often does this happen?  We can observe it in the following scheme.  The interpreter implements its instructions and runs them in series.  This series can be seen as a conceptual language, and its 2-gram can be thought of.  By taking such 2-grams of the entire execution of a Ruby program, we can see the ratio of the operation we are talking about.

<details>
<summary>
Following is the top 10 list of 2 grams of the entire execution of <a href="https://github.com/mame/optcarrot">mame/optcarrot</a> benchmark:
</summary>

```
zsh % LANG=C wc -l 2gram.txt
1143155369
zsh % LANG=C sort 2gram.txt | uniq -c | sort -nr | head -n 10
69065813 getinstancevariable -> getinstancevariable
65600442 putself -> getinstancevariable
59624140 getinstancevariable -> branchunless
59116388 branchunless -> getinstancevariable
52828407 leave -> pop
50434175 getinstancevariable -> putobject
30368815 pop -> putself
27717161 setinstancevariable -> getinstancevariable
25661090 branchunless -> putself
25165032 getinstancevariable -> branchif
```

Here, the `leave` instruction (almost) resembles ruby's `return` statement, and the `pop` instruction (almost) resembles ruby's ';' delimiter.  So the "leave -> pop" output indicates that a method returns a value, and that value is not used.  It seems such situation is # 5 most frequent operation in the entire execution of a program, which is about 4.6% of the whole.

</details>

### Telling methods that their return values are not used

To remedy, we introduce a new method calling convention that _allows_ methods to return arbitrary return values when not used.  We do not force them to eliminate unused return values.  This is because at the beginning every method in the wild -- especially those written in C -- already returns something.  In order not to break existing codes, methods must be allowed to return values even if they are discarded.  However, for new ones, let us make room for optimisations.

This is done by setting a 1-bit flag in a method stack frame.  Every time a method is called, several flags are set in the VM's stack.  We add a flag called `VM_FRAME_FLAG_DISCARDED` which denotes that the return value is not used.

```
zsh % ./miniruby --dump=i -e 'discarded_method(used_method);nil'
== disasm: #<ISeq:<main>@-e:1 (1,0)-(1,33)> (catch: FALSE)
0000 putself                                                          (   1)[Li]
0001 putself
0002 opt_send_without_block                 <calldata!mid:used_method, argc:0, FCALL|VCALL|ARGS_SIMPLE>
0004 opt_send_without_block                 <calldata!mid:discarded_method, argc:1, FCALL|ARGS_SIMPLE|DISCARDED>
0006 pop
0007 putnil
0008 leave
```

Here in the example above, the return value of `discarded_method` is not used; thus it is marked as "DISCARDED".  OTOH that of `used_method` is used.

### APIs for the flag

We provide Ruby level API `RubyVM.return_value_is_used?` and its CAPI counterpart `rb_whether_the_return_value_is_used_p()`.  These two API simply look at the frame flag and return whether `VM_FRAME_FLAG_DISCARDED` is set or not.  Because looking at the current frame's flag by calling another method is kind of suboptimal, we also provide a new VM instruction `opt_RubyVM_return_value_is_used_` which transparently does the same thing without modifying the execution context at all.

A typical application area for those flags is `String#slice!` method.  This is a method which destructively slices its receiver, and returns what was sliced.  However it often is the case that its users are not interested in the return values; this method tends to be used only to mutate the receiver.  By skipping allocation of those unused return values, not only does the method runs faster but GC pressures can also be reduced.

### Benchmarks

We are only providing APIs in this pull request.  Neither positive nor negative effects can be observed.

```
Calculating -------------------------------------
                             master        ours
Optcarrot Lan_Master.nes     25.222      25.311 fps

Comparison:
             Optcarrot Lan_Master.nes
                    ours:        25.3 fps
                  master:        25.2 fps - 1.00x  slower

Calculating -------------------------------------
                         master        ours
             sinatra    12.967k     12.938k i/s -    100.000k times in 7.711948s 7.729280s

Comparison:
                          sinatra
              master:     12966.9 i/s
                ours:     12937.8 i/s - 1.00x  slower

```

However when you take a closer look, for instance `String#slice!` does improve considerably.

```
Warming up --------------------------------------
        regexp-short     2.190M i/s -      2.277M times in 1.039406s (456.55ns/i)
         regexp-long   159.324k i/s -    161.392k times in 1.012980s (6.28μs/i)
        string-short     4.393M i/s -      4.444M times in 1.011546s (227.62ns/i)
         string-long     1.529M i/s -      1.560M times in 1.020005s (653.81ns/i)
Calculating -------------------------------------
                         master        ours
        regexp-short     2.335M      2.892M i/s -      6.571M times in 2.814090s 2.272405s
         regexp-long   159.398k    162.607k i/s -    477.971k times in 2.998608s 2.939417s
        string-short     5.139M      6.318M i/s -     13.180M times in 2.564713s 2.086098s
         string-long     1.598M      1.656M i/s -      4.588M times in 2.871445s 2.770246s

Comparison:
                     regexp-short
                ours:   2891685.4 i/s
              master:   2335064.6 i/s - 1.24x  slower

                      regexp-long
                ours:    162607.4 i/s
              master:    159397.7 i/s - 1.02x  slower

                     string-short
                ours:   6317880.0 i/s
              master:   5138864.6 i/s - 1.23x  slower

                      string-long
                ours:   1656349.9 i/s
              master:   1597974.5 i/s - 1.04x  slower
```


### Conclusions

We propose Ruby/C APIs for 3rd party programmers to know if a return value is used.  They do not speed things up by themselves.  However programmers can use them to optimise their own programs.

### Future work

<details>
<summary>
A well-known waste of memory is when a block ends with an assignment.  "Just in case" the value of that block is used, an array is created to store the assigned values, like this:
</summary>

```
% ruby --dump=i -ve '1.times {|i| x, y = self, i }'
ruby 2.8.0dev (2020-06-29T02:06:18Z master 1020e120e0) [aarch64-linux]
== disasm: #<ISeq:<main>@-e:1 (1,0)-(1,29)> (catch: FALSE)
== catch table
| catch type: break  st: 0000 ed: 0004 sp: 0000 cont: 0004
| == disasm: #<ISeq:block in <main>@-e:1 (1,8)-(1,29)> (catch: FALSE)
| == catch table
| | catch type: redo   st: 0001 ed: 0014 sp: 0000 cont: 0001
| | catch type: next   st: 0001 ed: 0014 sp: 0000 cont: 0014
| |------------------------------------------------------------------------
| local table (size: 3, argc: 1 [opts: 0, rest: -1, post: 0, block: -1, kw: -1@-1, kwrest: -1])
| [ 3] i@0<Arg>   | [ 2] x@1        | [ 1] y@2
| 0000 nop                                                              (   1)[Bc]
| 0001 putself                                [Li]
| 0002 getlocal_WC_0                          i@0
| 0004 newarray                               2
| 0006 dup
| 0007 expandarray                            2, 0
| 0010 setlocal_WC_0                          x@1
| 0012 setlocal_WC_0                          y@2
| 0014 nop
| 0015 leave                                                            (   1)[Br]
|------------------------------------------------------------------------
0000 putobject_INT2FIX_1_                                             (   1)[Li]
0001 send                                   <calldata!mid:times, argc:0>, block in <main>
0004 nop
0005 leave                                                            (   1)

```

Note the unnecessarily complex output of `block in <main>`'s disasm.  The proposed changeset is not capable of eliminating this `newarray`-`dup`-`expandarray` combo.  Because assignments can never be function calls, there is no way for the proposed API to save such situations.
</details>

Optimisation of this situation is beyond this proposal.   We could think of some automatic detection of such sequences.  However assignments are complex.  The amount of reconstructing compiler infrastructure is too much.