### PR TITLE
integer.rbinc: do not generate C functions

### DIFF
--- a/integer.rb
+++ b/integer.rb
@@ -23,8 +23,7 @@ class Integer
   #
   #  Since +int+ is already an Integer, this always returns +true+.
   def integer?
-    Primitive.attr! 'inline'
-    Primitive.cexpr! 'Qtrue'
+    return true
   end
 
   def magnitude
@@ -53,8 +52,7 @@ class Integer
   #
   #  For example, <code>?a.ord</code> returns 97 both in 1.8 and 1.9.
   def ord
-    Primitive.attr! 'inline'
-    Primitive.cexpr! 'self'
+    return self
   end
 
   #  call-seq:
@@ -64,8 +62,7 @@ class Integer
   #
   #  #to_int is an alias for #to_i.
   def to_i
-    Primitive.attr! 'inline'
-    Primitive.cexpr! 'self'
+    return self
   end
 
   #  call-seq:
@@ -73,8 +70,7 @@ class Integer
   #
   #  Since +int+ is already an Integer, returns +self+.
   def to_int
-    Primitive.attr! 'inline'
-    Primitive.cexpr! 'self'
+    return self
   end
 
   # call-seq:


### PR DESCRIPTION
This changeset changes for instance `Integer#to_i?` from:

    == disasm: #<ISeq:to_i@<internal:integer>:66 (66,2)-(69,5)> (catch: FALSE)
    0000 opt_invokebuiltin_delegate_leave       <builtin!_bi7/0>, 0       (68)[LiCa]
    0003 leave                                                            (69)[Re]

to:

    == disasm: #<ISeq:to_i@<internal:integer>:66 (66,2)-(69,5)> (catch: FALSE)
    0000 putself                                                          (68)[LiCa]
    0001 leave                                                            (69)[Re]

which is of course faster.