### PR TITLE
Make Kernel#then, #yield_self, #frozen? builtin

### DIFF
--- a/benchmark/kernel_then.yml
+++ b/benchmark/kernel_then.yml
@@ -1,0 +1,6 @@
+benchmark:
+  kernel_then: 1.then { |i| i + 1 }
+  kernel_then_enum: 1.then
+  kernel_yield_self: 1.yield_self { |i| i + 1 }
+  kernel_yield_self_enum: 1.yield_self
+loop_count: 20000000

--- a/benchmark/mjit_kernel.yml
+++ b/benchmark/mjit_kernel.yml
@@ -4,8 +4,17 @@ prelude: |
     obj.class
   end
 
+  def mjit_frozen?(obj)
+    obj.frozen?
+  end
+
+  str = ""
+  fstr = "".freeze
+
 benchmark:
   - mjit_class(self)
   - mjit_class(1)
+  - mjit_frozen?(str)
+  - mjit_frozen?(fstr)
 
 loop_count: 40000000

--- a/object.c
+++ b/object.c
@@ -597,41 +597,10 @@ rb_obj_size(VALUE self, VALUE args, VALUE obj)
     return LONG2FIX(1);
 }
 
-/*
- *  call-seq:
- *     obj.then {|x| block }          -> an_object
- *     obj.yield_self {|x| block }    -> an_object
- *
- *  Yields self to the block and returns the result of the block.
- *
- *     3.next.then {|x| x**x }.to_s             #=> "256"
- *     "my string".yield_self {|s| s.upcase }   #=> "MY STRING"
- *
- *  Good usage for +then+ is value piping in method chains:
- *
- *     require 'open-uri'
- *     require 'json'
- *
- *     construct_url(arguments).
- *       then {|url| open(url).read }.
- *       then {|response| JSON.parse(response) }
- *
- *  When called without block, the method returns +Enumerator+,
- *  which can be used, for example, for conditional
- *  circuit-breaking:
- *
- *     # meets condition, no-op
- *     1.then.detect(&:odd?)            # => 1
- *     # does not meet condition, drop value
- *     2.then.detect(&:odd?)            # => nil
- *
- */
-
 static VALUE
-rb_obj_yield_self(VALUE obj)
+block_given_p(rb_execution_context_t *ec, VALUE self)
 {
-    RETURN_SIZED_ENUMERATOR(obj, 0, 0, rb_obj_size);
-    return rb_yield_values2(1, &obj);
+    return rb_block_given_p() ? Qtrue : Qfalse;
 }
 
 /**
@@ -1320,23 +1289,6 @@ rb_obj_freeze(VALUE obj)
     }
     return obj;
 }
-
-/**
- *  call-seq:
- *     obj.frozen?    -> true or false
- *
- *  Returns the freeze status of <i>obj</i>.
- *
- *     a = [ "a", "b", "c" ]
- *     a.freeze    #=> ["a", "b", "c"]
- *     a.frozen?   #=> true
- *--
- * Determines if the object is frozen. Equivalent to \c Object\#frozen? in Ruby.
- * \param[in] obj  the object to be determines
- * \retval Qtrue if frozen
- * \retval Qfalse if not frozen
- *++
- */
 
 VALUE
 rb_obj_frozen_p(VALUE obj)
@@ -4581,8 +4533,6 @@ InitVM_Object(void)
     rb_define_method(rb_mKernel, "singleton_class", rb_obj_singleton_class, 0);
     rb_define_method(rb_mKernel, "dup", rb_obj_dup, 0);
     rb_define_method(rb_mKernel, "itself", rb_obj_itself, 0);
-    rb_define_method(rb_mKernel, "yield_self", rb_obj_yield_self, 0);
-    rb_define_method(rb_mKernel, "then", rb_obj_yield_self, 0);
     rb_define_method(rb_mKernel, "initialize_copy", rb_obj_init_copy, 1);
     rb_define_method(rb_mKernel, "initialize_dup", rb_obj_init_dup_clone, 1);
     rb_define_method(rb_mKernel, "initialize_clone", rb_obj_init_clone, -1);
@@ -4594,7 +4544,6 @@ InitVM_Object(void)
     rb_define_method(rb_mKernel, "untrusted?", rb_obj_untrusted, 0);
     rb_define_method(rb_mKernel, "trust", rb_obj_trust, 0);
     rb_define_method(rb_mKernel, "freeze", rb_obj_freeze, 0);
-    rb_define_method(rb_mKernel, "frozen?", rb_obj_frozen_p, 0);
 
     rb_define_method(rb_mKernel, "to_s", rb_any_to_s, 0);
     rb_define_method(rb_mKernel, "inspect", rb_obj_inspect, 0);

--- a/test/ruby/test_jit.rb
+++ b/test/ruby/test_jit.rb
@@ -372,7 +372,7 @@ class TestJIT < Test::Unit::TestCase
   end
 
   def test_compile_insn_send
-    assert_eval_with_jit("#{<<~"begin;"}\n#{<<~"end;"}", stdout: '1', success_count: 2, insns: %i[send])
+    assert_eval_with_jit("#{<<~"begin;"}\n#{<<~"end;"}", stdout: '1', success_count: 3, insns: %i[send])
     begin;
       print proc { yield_self { 1 } }.call
     end;


### PR DESCRIPTION
## Kernel#then, #yield_self
https://github.com/ruby/ruby/pull/3281#issuecomment-653438097

To keep Enumerator creation reasonably fast, I used builtin functions. Still it became a bit slower, but calling a block became faster, which I believe is the dominant usage of `#then` / `#yield_self`.

```
$ benchmark-driver -v --rbenv 'before;after' benchmark/kernel_then.yml --repeat-count=4
before: ruby 2.8.0dev (2020-07-03T16:52:54Z master ccb2e6eaa5) [x86_64-linux]
after: ruby 2.8.0dev (2020-07-03T18:36:08Z builtin-kernel 5fa06daca8) [x86_64-linux]
Calculating -------------------------------------
                           before       after
           kernel_then    21.343M     28.113M i/s -     20.000M times in 0.937094s 0.711421s
      kernel_then_enum    11.122M     10.756M i/s -     20.000M times in 1.798222s 1.859484s
     kernel_yield_self    21.379M     28.061M i/s -     20.000M times in 0.935492s 0.712737s
kernel_yield_self_enum    11.051M     10.781M i/s -     20.000M times in 1.809825s 1.855115s

Comparison:
                        kernel_then
                 after:  28112752.9 i/s
                before:  21342580.3 i/s - 1.32x  slower

                   kernel_then_enum
                before:  11122095.6 i/s
                 after:  10755671.9 i/s - 1.03x  slower

                  kernel_yield_self
                 after:  28060852.6 i/s
                before:  21379125.2 i/s - 1.31x  slower

             kernel_yield_self_enum
                before:  11050794.7 i/s
                 after:  10781002.7 i/s - 1.03x  slower
```

## Kernel#frozen?
```
$ benchmark-driver -v --rbenv 'before;after;before --jit;after --jit' benchmark/mjit_kernel.yml --filter=frozen --repeat-count=4
before: ruby 2.8.0dev (2020-07-03T16:52:54Z master ccb2e6eaa5) [x86_64-linux]
after: ruby 2.8.0dev (2020-07-03T18:36:08Z builtin-kernel 5fa06daca8) [x86_64-linux]
before --jit: ruby 2.8.0dev (2020-07-03T16:52:54Z master ccb2e6eaa5) +JIT [x86_64-linux]
after --jit: ruby 2.8.0dev (2020-07-03T18:36:08Z builtin-kernel 5fa06daca8) +JIT [x86_64-linux]
Calculating -------------------------------------
                         before       after  before --jit  after --jit
   mjit_frozen?(str)    39.360M     40.199M       52.619M      72.695M i/s -     40.000M times in 1.016256s 0.995045s 0.760185s 0.550247s
  mjit_frozen?(fstr)    39.881M     40.331M       52.570M      72.192M i/s -     40.000M times in 1.002995s 0.991791s 0.760887s 0.554076s

Comparison:
                mjit_frozen?(str)
         after --jit:  72694647.8 i/s
        before --jit:  52618772.3 i/s - 1.38x  slower
               after:  40199206.6 i/s - 1.81x  slower
              before:  39360167.5 i/s - 1.85x  slower

               mjit_frozen?(fstr)
         after --jit:  72192223.1 i/s
        before --jit:  52570212.1 i/s - 1.37x  slower
               after:  40331080.7 i/s - 1.79x  slower
              before:  39880547.1 i/s - 1.81x  slower
```