### PR TITLE
Merge ivar guards on JIT when an ISeq has multiple ivar accesses

### DIFF
--- a/tool/ruby_vm/views/_mjit_compile_ivar.erb
+++ b/tool/ruby_vm/views/_mjit_compile_ivar.erb
@@ -16,28 +16,57 @@
 % # compiler: Use copied IVC to avoid race condition
     IVC ic_copy = &(status->is_entries + ((union iseq_inline_storage_entry *)ic - body->is_entries))->iv_cache;
 %
-    if (!status->compile_info->disable_ivar_cache && ic_copy->ic_serial) {
+    if (!status->compile_info->disable_ivar_cache && ic_copy->ic_serial) { // Only initialized (ic_serial > 0) IVCs are optimized
 % # JIT: optimize away motion of sp and pc. This path does not call rb_warning() and so it's always leaf and not `handles_sp`.
 % # <%= render 'mjit_compile_pc_and_sp', locals: { insn: insn } -%>
 %
 % # JIT: prepare vm_getivar/vm_setivar arguments and variables
         fprintf(f, "{\n");
         fprintf(f, "    VALUE obj = GET_SELF();\n");
-        fprintf(f, "    const rb_serial_t ic_serial = (rb_serial_t)%"PRI_SERIALT_PREFIX"u;\n", ic_copy->ic_serial);
         fprintf(f, "    const st_index_t index = %"PRIuSIZE";\n", ic_copy->index);
+        fprintf(f, "    VALUE val;\n");
+        if (status->merge_ivar_guards_p) {
+% # JIT: Access ivar without checking these VM_ASSERTed prerequisites as we checked them in the beginning of `mjit_compile_body`
+            fprintf(f, "    VM_ASSERT(RB_TYPE_P(obj, T_OBJECT));\n");
+            fprintf(f, "    VM_ASSERT((rb_serial_t)%"PRI_SERIALT_PREFIX"u == RCLASS_SERIAL(RBASIC(obj)->klass));\n", ic_copy->ic_serial);
+            fprintf(f, "    VM_ASSERT(index < ROBJECT_NUMIV(obj));\n");
+% if insn.name == 'setinstancevariable'
+            fprintf(f, "    if (LIKELY(!RB_OBJ_FROZEN(obj))) {\n");
+            fprintf(f, "        val = stack[%d];\n", b->stack_size - 1);
+            if (status->max_ivar_index >= ROBJECT_EMBED_LEN_MAX) {
+                fprintf(f, "        RB_OBJ_WRITE(obj, &ROBJECT(obj)->as.heap.ivptr[index], val);\n");
+            }
+            else {
+                fprintf(f, "        RB_OBJ_WRITE(obj, &ROBJECT(obj)->as.ary[index], val);\n");
+            }
+            fprintf(f, "    }\n");
+% else
+            if (status->max_ivar_index >= ROBJECT_EMBED_LEN_MAX) {
+                fprintf(f, "    val = ROBJECT(obj)->as.heap.ivptr[index];\n");
+            }
+            else {
+                fprintf(f, "    val = ROBJECT(obj)->as.ary[index];\n");
+            }
+            fprintf(f, "    if (LIKELY(val != Qundef)) {\n");
+            fprintf(f, "        stack[%d] = val;\n", b->stack_size);
+            fprintf(f, "    }\n");
+%end
+        }
+        else {
+            fprintf(f, "    const rb_serial_t ic_serial = (rb_serial_t)%"PRI_SERIALT_PREFIX"u;\n", ic_copy->ic_serial);
 % # JIT: cache hit path of vm_getivar/vm_setivar, or cancel JIT (recompile it with exivar)
 % if insn.name == 'setinstancevariable'
-        fprintf(f, "    VALUE val = stack[%d];\n", b->stack_size - 1);
-        fprintf(f, "    if (LIKELY(RB_TYPE_P(obj, T_OBJECT) && ic_serial == RCLASS_SERIAL(RBASIC(obj)->klass) && index < ROBJECT_NUMIV(obj) && !RB_OBJ_FROZEN(obj))) {\n");
-        fprintf(f, "        VALUE *ptr = ROBJECT_IVPTR(obj);\n");
-        fprintf(f, "        RB_OBJ_WRITE(obj, &ptr[index], val);\n");
-        fprintf(f, "    }\n");
+            fprintf(f, "    val = stack[%d];\n", b->stack_size - 1);
+            fprintf(f, "    if (LIKELY(RB_TYPE_P(obj, T_OBJECT) && ic_serial == RCLASS_SERIAL(RBASIC(obj)->klass) && index < ROBJECT_NUMIV(obj) && !RB_OBJ_FROZEN(obj))) {\n");
+            fprintf(f, "        VALUE *ptr = ROBJECT_IVPTR(obj);\n");
+            fprintf(f, "        RB_OBJ_WRITE(obj, &ptr[index], val);\n");
+            fprintf(f, "    }\n");
 % else
-        fprintf(f, "    VALUE val;\n");
-        fprintf(f, "    if (LIKELY(RB_TYPE_P(obj, T_OBJECT) && ic_serial == RCLASS_SERIAL(RBASIC(obj)->klass) && index < ROBJECT_NUMIV(obj) && (val = ROBJECT_IVPTR(obj)[index]) != Qundef)) {\n");
-        fprintf(f, "        stack[%d] = val;\n", b->stack_size);
-        fprintf(f, "    }\n");
+            fprintf(f, "    if (LIKELY(RB_TYPE_P(obj, T_OBJECT) && ic_serial == RCLASS_SERIAL(RBASIC(obj)->klass) && index < ROBJECT_NUMIV(obj) && (val = ROBJECT_IVPTR(obj)[index]) != Qundef)) {\n");
+            fprintf(f, "        stack[%d] = val;\n", b->stack_size);
+            fprintf(f, "    }\n");
 % end
+        }
         fprintf(f, "    else {\n");
         fprintf(f, "        reg_cfp->pc = original_body_iseq + %d;\n", pos);
         fprintf(f, "        reg_cfp->sp = vm_base_ptr(reg_cfp) + %d;\n", b->stack_size);


### PR DESCRIPTION
```
$ benchmark-driver -v --rbenv 'before --jit;after --jit' benchmark.yml --repeat-count=24 --output=all
before --jit: ruby 2.8.0dev (2020-07-03T16:52:54Z master ccb2e6eaa5) +JIT [x86_64-linux]
after --jit: ruby 2.8.0dev (2020-07-03T23:58:06Z ivar-guard f3d3691c74) +JIT [x86_64-linux]
Calculating -------------------------------------
                                 before --jit           after --jit
Optcarrot Lan_Master.nes     71.3624688269922      70.9239548083316 fps
                             72.6359580311016      77.1039753707283
                             74.1993512788708      80.0204069821405
                             75.3320353557776      81.7604440781847
                             75.8100844520402      82.6924317730600
                             78.3256414692381      83.1069968129562
                             79.0091501069809      84.1156234337417
                             79.1959373760543      84.5740177219342
                             79.3106606484137      85.9564085474114
                             79.5170038163073      86.4532950598815
                             79.8300039575979      86.6334184285854
                             80.1353874907729      87.8352304838773
                             80.1378791759272      88.3262571688172
                             80.7475478759448      88.8220596131538
                             81.1574370642460      89.1693182394324
                             81.4321261692806      89.4351081801636
                             81.6494191482392      89.8590686370407
                             81.9902704472289      89.8956141186323
                             82.5367512828839      90.3904587601945
                             82.5612412463655      90.6481734159511
                             82.8173726568623      91.0229514349186
                             83.0947368065651      91.4468334000509
                             83.1425803843619      91.5750654820674
                             83.2655243563682      93.0285740785746
```

The technique has been implemented in other implementations like RTL-MJIT and TruffleRuby. Credit goes to the precedents.