### PR TITLE
Fix build error on Apple silicon macOS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2390,6 +2390,9 @@ AS_CASE([$rb_cv_coroutine], [yes|''], [
         [x*64-darwin*], [
             rb_cv_coroutine=amd64
         ],
+        [arm64-darwin*], [
+            rb_cv_coroutine=arm64
+        ],
         [x*64-linux*], [
             AS_CASE(["$ac_cv_sizeof_voidp"],
                 [8], [ rb_cv_coroutine=amd64 ],

--- a/coroutine/arm64/Context.S
+++ b/coroutine/arm64/Context.S
@@ -5,11 +5,14 @@
 ##  Copyright, 2018, by Samuel Williams.
 ##
 
+#define TOKEN_PASTE(x,y) x##y
+#define PREFIXED_SYMBOL(prefix,name) TOKEN_PASTE(prefix,name)
+
 .text
 .align 2
 
-.global coroutine_transfer
-coroutine_transfer:
+.global PREFIXED_SYMBOL(SYMBOL_PREFIX,coroutine_transfer)
+PREFIXED_SYMBOL(SYMBOL_PREFIX,coroutine_transfer):
 
 	# Make space on the stack for caller registers
 	sub sp, sp, 0xb0


### PR DESCRIPTION
This patch will fix following build error on macOS 11.0 + Xcode 12 beta.

```
$ ./configure
$ make V=1
	BASERUBY = /Users/watson/.rbenv/shims/ruby --disable=gems
	CC = clang -fdeclspec
	LD = ld
	LDSHARED = clang -fdeclspec -dynamiclib
	CFLAGS = -O3 -ggdb3 -Wall -Wextra -Werror=deprecated-declarations -Werror=division-by-zero -Werror=implicit-function-declaration -Werror=implicit-int -Werror=misleading-indentation -Werror=pointer-arith -Werror=shorten-64-to-32 -Werror=write-strings -Wmissing-noreturn -Wno-constant-logical-operand -Wno-long-long -Wno-missing-field-initializers -Wno-overlength-strings -Wno-parentheses-equality -Wno-self-assign -Wno-tautological-compare -Wno-unused-parameter -Wno-unused-value -Wunused-variable -Werror=extra-tokens -std=gnu99  -pipe
	XCFLAGS = -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fno-strict-overflow -DRUBY_DEVEL=1 -fvisibility=hidden -DRUBY_EXPORT -fPIE -DCANONICALIZATION_FOR_MATHN -I. -I.ext/include/arm64-darwin20 -I./include -I. -I./enc/unicode/12.1.0
	CPPFLAGS = -D_XOPEN_SOURCE -D_DARWIN_C_SOURCE -D_DARWIN_UNLIMITED_SELECT -D_REENTRANT
	DLDFLAGS = -Wl,-undefined,dynamic_lookup -Wl,-multiply_defined,suppress -fstack-protector-strong -Wl,-pie -framework Security -framework Foundation
	SOLIBS = -lpthread -ldl -lobjc
	LANG = ja_JP.UTF-8
	LC_ALL =
	LC_CTYPE =
	MFLAGS =
Apple clang version 12.0.0 (clang-1200.0.22.19)
Target: arm64-apple-darwin20.0.0
Thread model: posix
InstalledDir: /Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
clang -fdeclspec -O3 -ggdb3 -Wall -Wextra -Werror=deprecated-declarations -Werror=division-by-zero -Werror=implicit-function-declaration -Werror=implicit-int -Werror=misleading-indentation -Werror=pointer-arith -Werror=shorten-64-to-32 -Werror=write-strings -Wmissing-noreturn -Wno-constant-logical-operand -Wno-long-long -Wno-missing-field-initializers -Wno-overlength-strings -Wno-parentheses-equality -Wno-self-assign -Wno-tautological-compare -Wno-unused-parameter -Wno-unused-value -Wunused-variable -Werror=extra-tokens -std=gnu99  -pipe  -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fno-strict-overflow -DRUBY_DEVEL=1 -fvisibility=hidden -DRUBY_EXPORT -fPIE -DCANONICALIZATION_FOR_MATHN -I. -I.ext/include/arm64-darwin20 -I./include -I. -I./enc/unicode/12.1.0 -D_XOPEN_SOURCE -D_DARWIN_C_SOURCE -D_DARWIN_UNLIMITED_SELECT -D_REENTRANT    -o cont.o -c cont.c
In file included from cont.c:19:
./coroutine/ucontext/Context.h:32:5: error: 'getcontext' is deprecated: first deprecated in macOS 10.6 [-Werror,-Wdeprecated-declarations]
    getcontext(&context->state);
    ^
/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/ucontext.h:37:6: note: 'getcontext' has been
      explicitly marked deprecated here
int  getcontext(ucontext_t *) __OSX_AVAILABLE_BUT_DEPRECATED(__MAC_10_5, __MAC_10_6, __IPHONE_2_0, __IPHONE_2_0) __WATCHOS_PROHIBITED __TVOS_PROHIBITED;
     ^
In file included from cont.c:19:
./coroutine/ucontext/Context.h:51:5: error: 'makecontext' is deprecated: first deprecated in macOS 10.6 [-Werror,-Wdeprecated-declarations]
    makecontext(&context->state, (void(*)(void))coroutine_trampoline, 2, (void*)start, (void*)context);
    ^
/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/ucontext.h:38:6: note: 'makecontext' has been
      explicitly marked deprecated here
void makecontext(ucontext_t *, void (*)(), int, ...) __OSX_AVAILABLE_BUT_DEPRECATED(__MAC_10_5, __MAC_10_6, __IPHONE_2_0, __IPHONE_2_0) __WATCHOS_PROHI...
     ^
In file included from cont.c:19:
./coroutine/ucontext/Context.h:59:5: error: 'swapcontext' is deprecated: first deprecated in macOS 10.6 [-Werror,-Wdeprecated-declarations]
    swapcontext(&current->state, &target->state);
    ^
/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/ucontext.h:40:6: note: 'swapcontext' has been
      explicitly marked deprecated here
int  swapcontext(ucontext_t * __restrict, const ucontext_t * __restrict) __OSX_AVAILABLE_BUT_DEPRECATED(__MAC_10_5, __MAC_10_6, __IPHONE_2_0, __IPHONE_...
     ^
3 errors generated.
make: *** [cont.o] Error 1
```