### PR TITLE
Add operator info to `OP_ASGN2` of `RubyVM::AbstractSyntaxTree`

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -398,9 +398,10 @@ node_children(rb_ast_t *ast, NODE *node)
                                     NEW_CHILD(ast, node->nd_args->nd_head),
                                     NEW_CHILD(ast, node->nd_args->nd_body));
       case NODE_OP_ASGN2:
-        return rb_ary_new_from_args(4, NEW_CHILD(ast, node->nd_recv),
+        return rb_ary_new_from_args(5, NEW_CHILD(ast, node->nd_recv),
                                     node->nd_next->nd_aid ? Qtrue : Qfalse,
                                     ID2SYM(node->nd_next->nd_vid),
+                                    ID2SYM(node->nd_next->nd_mid),
                                     NEW_CHILD(ast, node->nd_value));
       case NODE_OP_ASGN_AND:
         return rb_ary_new_from_args(3, NEW_CHILD(ast, node->nd_head), ID2SYM(idANDOP),

--- a/test/ruby/test_ast.rb
+++ b/test/ruby/test_ast.rb
@@ -319,4 +319,15 @@ class TestAst < Test::Unit::TestCase
     helper.validate_range
     assert_equal([], helper.errors)
   end
+
+  def test_op_asgn2
+    node = RubyVM::AbstractSyntaxTree.parse("struct.field += foo")
+    _, _, body = *node.children
+    assert_equal(:OP_ASGN2, body.type)
+    recv, _, mid, op, value = body.children
+    assert_equal(:VCALL, recv.type)
+    assert_equal(:field, mid)
+    assert_equal(:+, op)
+    assert_equal(:VCALL, value.type)
+  end
 end


### PR DESCRIPTION
[#17013](https://bugs.ruby-lang.org/issues/17013)