### PR TITLE
Tidy up vm_push_frame

### DIFF
--- a/vm_core.h
+++ b/vm_core.h
@@ -1688,17 +1688,17 @@ MJIT_STATIC const rb_callable_method_entry_t *rb_vm_frame_method_entry(const rb_
 
 #define sysstack_error GET_VM()->special_exceptions[ruby_error_sysstack]
 
-#define RUBY_CONST_ASSERT(expr) (1/!!(expr)) /* expr must be a compile-time constant */
-#define VM_STACK_OVERFLOWED_P(cfp, sp, margin) \
-    (!RUBY_CONST_ASSERT(sizeof(*(sp)) == sizeof(VALUE)) || \
-     !RUBY_CONST_ASSERT(sizeof(*(cfp)) == sizeof(rb_control_frame_t)) || \
-     ((rb_control_frame_t *)((sp) + (margin)) + 1) >= (cfp))
-#define WHEN_VM_STACK_OVERFLOWED(cfp, sp, margin) \
-    if (LIKELY(!VM_STACK_OVERFLOWED_P(cfp, sp, margin))) {(void)0;} else /* overflowed */
-#define CHECK_VM_STACK_OVERFLOW0(cfp, sp, margin) \
-    WHEN_VM_STACK_OVERFLOWED(cfp, sp, margin) vm_stackoverflow()
+#define CHECK_VM_STACK_OVERFLOW0(cfp, sp, margin) do {                       \
+    STATIC_ASSERT(sizeof_sp,  sizeof(*(sp))  == sizeof(VALUE));              \
+    STATIC_ASSERT(sizeof_cfp, sizeof(*(cfp)) == sizeof(rb_control_frame_t)); \
+    const struct rb_control_frame_struct *bound = (void *)&(sp)[(margin)];   \
+    if (UNLIKELY((cfp) <= &bound[1])) {                                      \
+        vm_stackoverflow();                                                  \
+    }                                                                        \
+} while (0)
+
 #define CHECK_VM_STACK_OVERFLOW(cfp, margin) \
-    WHEN_VM_STACK_OVERFLOWED(cfp, (cfp)->sp, margin) vm_stackoverflow()
+    CHECK_VM_STACK_OVERFLOW0((cfp), (cfp)->sp, (margin))
 
 VALUE rb_catch_protect(VALUE t, rb_block_call_func *func, VALUE data, enum ruby_tag_type *stateptr);
 

--- a/vm_exec.c
+++ b/vm_exec.c
@@ -62,17 +62,6 @@ static void vm_insns_counter_count_insn(int insn) {}
 #endif
 /* #define DECL_SC_REG(r, reg) VALUE reg_##r */
 
-#if VM_DEBUG_STACKOVERFLOW
-NORETURN(static void vm_stack_overflow_for_insn(void));
-static void
-vm_stack_overflow_for_insn(void)
-{
-    rb_bug("CHECK_VM_STACK_OVERFLOW_FOR_INSN: should not overflow here. "
-	   "Please contact ruby-core/dev with your (a part of) script. "
-	   "This check will be removed soon.");
-}
-#endif
-
 #if !OPT_CALL_THREADED_CODE
 static VALUE
 vm_exec_core(rb_execution_context_t *ec, VALUE initial)

--- a/vm_exec.h
+++ b/vm_exec.h
@@ -185,8 +185,7 @@ default:                        \
 #define VM_DEBUG_STACKOVERFLOW 0
 
 #if VM_DEBUG_STACKOVERFLOW
-#define CHECK_VM_STACK_OVERFLOW_FOR_INSN(cfp, margin) \
-    WHEN_VM_STACK_OVERFLOWED(cfp, (cfp)->sp, margin) vm_stack_overflow_for_insn()
+#define CHECK_VM_STACK_OVERFLOW_FOR_INSN CHECK_VM_STACK_OVERFLOW
 #else
 #define CHECK_VM_STACK_OVERFLOW_FOR_INSN(cfp, margin)
 #endif

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -301,12 +301,22 @@ vm_push_frame_debug_counter_inc(
     if (RUBY_VM_END_CONTROL_FRAME(ec) != prev_cfp) {
         const bool curr = VM_FRAME_RUBYFRAME_P(reg_cfp);
         const bool prev = VM_FRAME_RUBYFRAME_P(prev_cfp);
-        const enum rb_debug_counter_type pat[2][2] = {
-            { RB_DEBUG_COUNTER_frame_R2R, RB_DEBUG_COUNTER_frame_R2C, },
-            { RB_DEBUG_COUNTER_frame_C2R, RB_DEBUG_COUNTER_frame_C2C, },
-        };
-        const enum rb_debug_counter_type i = pat[prev][curr];
-        rb_debug_counter[i]++;
+        if (prev) {
+            if (crr) {
+                RB_DEBUG_COUNTER_INC(frame_R2R);
+            }
+            else {
+                RB_DEBUG_COUNTER_INC(frame_R2C);
+            }
+        }
+        else {
+            if (crr) {
+                RB_DEBUG_COUNTER_INC(frame_C2R);
+            }
+            else {
+                RB_DEBUG_COUNTER_INC(frame_C2C);
+            }
+        }
     }
 
     switch (type & VM_FRAME_MAGIC_MASK) {

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -287,7 +287,7 @@ vm_check_canary(const rb_execution_context_t *ec, VALUE *sp)
 #define vm_check_frame(a, b, c, d)
 #endif /* VM_CHECK_MODE > 0 */
 
-static inline rb_control_frame_t *
+static void
 vm_push_frame(rb_execution_context_t *ec,
 	      const rb_iseq_t *iseq,
 	      VALUE type,
@@ -370,8 +370,6 @@ vm_push_frame(rb_execution_context_t *ec,
         }
     }
 #endif
-
-    return cfp;
 }
 
 /* return TRUE if the frame is finished */

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -327,6 +327,10 @@ vm_push_frame_debug_counter_inc(
 #define vm_push_frame_debug_counter_inc(ec, cfp, t) /* void */
 #endif
 
+STATIC_ASSERT(VM_ENV_DATA_INDEX_ME_CREF, VM_ENV_DATA_INDEX_ME_CREF == -2);
+STATIC_ASSERT(VM_ENV_DATA_INDEX_SPECVAL, VM_ENV_DATA_INDEX_SPECVAL == -1);
+STATIC_ASSERT(VM_ENV_DATA_INDEX_FLAGS,   VM_ENV_DATA_INDEX_FLAGS   == -0);
+
 static void
 vm_push_frame(rb_execution_context_t *ec,
 	      const rb_iseq_t *iseq,
@@ -364,9 +368,6 @@ vm_push_frame(rb_execution_context_t *ec,
     }
 
     /* setup ep with managing data */
-    VM_ASSERT(VM_ENV_DATA_INDEX_ME_CREF == -2);
-    VM_ASSERT(VM_ENV_DATA_INDEX_SPECVAL == -1);
-    VM_ASSERT(VM_ENV_DATA_INDEX_FLAGS   == -0);
     *sp++ = cref_or_me; /* ep[-2] / Qnil or T_IMEMO(cref) or T_IMEMO(ment) */
     *sp++ = specval     /* ep[-1] / block handler or prev env ptr */;
     *sp   = type;       /* ep[-0] / ENV_FLAGS */


### PR DESCRIPTION
For instance its return value is used from nowhere so why not return `void`.

It seems compilers are smarter than me.  Neither speedup nor slowdown can be observed.  Must harm no one, though.

```
master: ruby 2.8.0dev (2020-07-01T13:41:16Z master 49029811d9) [aarch64-linux]
ours: ruby 2.8.0dev (2020-07-06T06:41:57Z origin/vm_push_frame 37bac56b10) [aarch64-linux]
Calculating -------------------------------------
                                       master                  ours
Optcarrot Lan_Master.nes   24.991672635908220    24.674321099849632 fps
                           25.049511891086389    24.751949030361153
                           25.107730926780810    24.832866393560870
                           25.193115588149983    25.084869359715185
                           25.227626632615966    25.130355271340051
                           25.247251028021367    25.223713670923104
                           25.323752498520427    25.294004296822507
```