### PR TITLE
Added NODE_SPECIAL_EXCESSIVE_COMMA info to ARGS of RubyVM::AbstractSyntaxTree

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -547,7 +547,9 @@ node_children(rb_ast_t *ast, NODE *node)
                                         var_name(ainfo->first_post_arg),
                                         INT2NUM(ainfo->post_args_num),
                                         NEW_CHILD(ast, ainfo->post_init),
-                                        var_name(ainfo->rest_arg),
+                                        (ainfo->rest_arg == NODE_SPECIAL_EXCESSIVE_COMMA
+                                            ? ID2SYM(rb_intern("NODE_SPECIAL_EXCESSIVE_COMMA"))
+                                            : var_name(ainfo->rest_arg)),
                                         (ainfo->no_kwarg ? Qfalse : NEW_CHILD(ast, ainfo->kw_args)),
                                         (ainfo->no_kwarg ? Qfalse : NEW_CHILD(ast, ainfo->kw_rest_arg)),
                                         var_name(ainfo->block_arg));

--- a/test/ruby/test_ast.rb
+++ b/test/ruby/test_ast.rb
@@ -330,4 +330,19 @@ class TestAst < Test::Unit::TestCase
     assert_equal(:+, op)
     assert_equal(:VCALL, value.type)
   end
+
+  def test_args
+    rest = 6
+    node = RubyVM::AbstractSyntaxTree.parse("proc { |a| }")
+    _, args = *node.children.last.children[1].children
+    assert_equal(nil, args.children[rest])
+
+    node = RubyVM::AbstractSyntaxTree.parse("proc { |a,| }")
+    _, args = *node.children.last.children[1].children
+    assert_equal(:NODE_SPECIAL_EXCESSIVE_COMMA, args.children[rest])
+
+    node = RubyVM::AbstractSyntaxTree.parse("proc { |*a| }")
+    _, args = *node.children.last.children[1].children
+    assert_equal(:a, args.children[rest])
+  end
 end


### PR DESCRIPTION
[Bug #17015](https://bugs.ruby-lang.org/issues/17015)