### PR TITLE
vm_backtrace.c: let rb_profile_frames show cfunc frames

### DIFF
--- a/test/-ext-/debug/test_profile_frames.rb
+++ b/test/-ext-/debug/test_profile_frames.rb
@@ -44,6 +44,7 @@ class TestProfileFrames < Test::Unit::TestCase
     }.resume
 
     labels = [
+      nil,
       "test_profile_frames",
       "zab",
       "baz",
@@ -54,6 +55,7 @@ class TestProfileFrames < Test::Unit::TestCase
       "test_profile_frames",
     ]
     base_labels = [
+      nil,
       "test_profile_frames",
       "zab",
       "baz",
@@ -64,6 +66,7 @@ class TestProfileFrames < Test::Unit::TestCase
       "test_profile_frames",
     ]
     full_labels = [
+      "Bug::Debug.profile_frames",
       "TestProfileFrames#test_profile_frames",
       "#{obj.inspect}.zab",
       "SampleClassForTestProfileFrames::Sample2#baz",
@@ -74,6 +77,7 @@ class TestProfileFrames < Test::Unit::TestCase
       "TestProfileFrames#test_profile_frames",
     ]
     classes = [
+      Bug::Debug,
       TestProfileFrames,
       obj,
       SampleClassForTestProfileFrames::Sample2,
@@ -84,9 +88,10 @@ class TestProfileFrames < Test::Unit::TestCase
       TestProfileFrames,
     ]
     singleton_method_p = [
-      false, true, false, true, true, true, false, false, false,
+      true, false, true, false, true, true, true, false, false, false,
     ]
     method_names = [
+      "profile_frames",
       "test_profile_frames",
       "zab",
       "baz",
@@ -97,6 +102,7 @@ class TestProfileFrames < Test::Unit::TestCase
       "test_profile_frames",
     ]
     qualified_method_names = [
+      "Bug::Debug.profile_frames",
       "TestProfileFrames#test_profile_frames",
       "#{obj.inspect}.zab",
       "SampleClassForTestProfileFrames::Sample2#baz",
@@ -106,8 +112,8 @@ class TestProfileFrames < Test::Unit::TestCase
       "SampleClassForTestProfileFrames#foo",
       "TestProfileFrames#test_profile_frames",
     ]
-    paths = [ file=__FILE__, "(eval)", file, file, file, file, file, file ]
-    absolute_paths = [ file, nil, file, file, file, file, file, file ]
+    paths = [ nil, file=__FILE__, "(eval)", file, file, file, file, file, file, nil ]
+    absolute_paths = [ "<cfunc>", file, nil, file, file, file, file, file, file, nil ]
 
     assert_equal(labels.size, frames.size)
 
@@ -120,8 +126,8 @@ class TestProfileFrames < Test::Unit::TestCase
       assert_equal(base_labels[i], base_label, err_msg)
       assert_equal(singleton_method_p[i], singleton_p, err_msg)
       assert_equal(method_names[i], method_name, err_msg)
-      assert_match(qualified_method_names[i], qualified_method_name, err_msg)
-      assert_match(full_labels[i], full_label, err_msg)
+      assert_equal(qualified_method_names[i], qualified_method_name, err_msg)
+      assert_equal(full_labels[i], full_label, err_msg)
       assert_match(classes[i].inspect, classpath, err_msg)
       if label == method_name
         c = classes[i]


### PR DESCRIPTION
... in addition to normal iseq frames.
It is sometimes useful to point the bottleneck more precisely.

An example code:
```
N = 100_000
M = 100_000
def foo
  open("/dev/zero") do |inp|
    open("/dev/null", "w") do |out|
      N.times do
        data = inp.read(N)
        out.write(data)
      end
    end
  end
end
```

`stackprof --d3-flamegraph` before the patch:
![image](https://user-images.githubusercontent.com/21557/86896892-aa27ee00-c141-11ea-998c-03a47bd14d0e.png)

`stackprof --d3-flamegraph` after the patch:
![image](https://user-images.githubusercontent.com/21557/86896910-b0b66580-c141-11ea-8f96-5740ea75c513.png)
