### PR TITLE
opt_invokebuiltin_delegate_leave: no copy&paste

### DIFF
--- a/insns.def
+++ b/insns.def
@@ -1505,20 +1505,8 @@ opt_invokebuiltin_delegate_leave
 // attr bool leaf = false; /* anything can happen inside */
 {
     val = vm_invoke_builtin_delegate(ec, reg_cfp, bf, (unsigned int)index);
-
-    /* leave fastpath */
-    /* TracePoint/return fallbacks this insn to opt_invokebuiltin_delegate */
-    if (vm_pop_frame(ec, GET_CFP(), GET_EP())) {
-#if OPT_CALL_THREADED_CODE
-        rb_ec_thread_ptr(ec)->retval = val;
-        return 0;
-#else
-        return val;
-#endif
-    }
-    else {
-        RESTORE_REGS();
-    }
+    PUSH(val);
+    DISPATCH_ORIGINAL_INSN(leave);
 }
 
 /* BLT */

--- a/tool/ruby_vm/views/mjit_compile.inc.erb
+++ b/tool/ruby_vm/views/mjit_compile.inc.erb
@@ -70,11 +70,17 @@ switch (insn) {
       RB_BUILTIN bf = (RB_BUILTIN)operands[0];
       rb_num_t index = (rb_num_t)operands[0];
       fprintf(f, "{\n");
-      fprintf(f, "    VALUE val;\n");
-      fprintf(f, "    RB_BUILTIN bf = (RB_BUILTIN)0x%"PRIxVALUE";\n", operands[0]);
-      fprintf(f, "    rb_num_t index = (rb_num_t)0x%"PRIxVALUE";\n", operands[1]);
-      fprintf(f, <%= rstring2cstr(insn.expr.expr.lines.find { |l| l =~ / vm_invoke_builtin_delegate\(/ }).gsub("\n", '\n') %>);
-      fprintf(f, "    stack[0] = val;\n");
+      if (bf->argc == 0) {
+          fprintf(f, "    rb_insn_func_t f = (rb_insn_func_t)%p;\n", bf->func_ptr);
+          fprintf(f, "    stack[0] = builtin_invoker0(ec, GET_SELF(), NULL, f);\n");
+      }
+      else {
+          fprintf(f, "    RB_BUILTIN bf = (RB_BUILTIN)0x%"PRIxVALUE";\n", operands[0]);
+          fprintf(f, "    rb_num_t index = (rb_num_t)0x%"PRIxVALUE";\n", operands[1]);
+          fprintf(f, "    const unsigned int lnum = GET_ISEQ()->body->local_table_size;\n");
+          fprintf(f, "    const VALUE *argv = GET_EP() - lnum - VM_ENV_DATA_SIZE + 1 + index;\n");
+          fprintf(f, "    stack[0] = invoke_bf(ec, GET_CFP(), bf, argv);\n");
+      }
       fprintf(f, "}\n");
 %     else
       if (b->stack_size != 1) {

--- a/tool/ruby_vm/views/mjit_compile.inc.erb
+++ b/tool/ruby_vm/views/mjit_compile.inc.erb
@@ -68,7 +68,7 @@ switch (insn) {
 %     # opt_invokebuiltin_delegate_leave also implements leave insn. We need to handle it here for inlining.
 %     if insn.name == 'opt_invokebuiltin_delegate_leave'
       RB_BUILTIN bf = (RB_BUILTIN)operands[0];
-      rb_num_t index = (rb_num_t)operands[0];
+      rb_num_t index = (rb_num_t)operands[1];
       fprintf(f, "{\n");
       if (bf->argc == 0) {
           fprintf(f, "    rb_insn_func_t f = (rb_insn_func_t)%p;\n", bf->func_ptr);


### PR DESCRIPTION
This changeset reduces generated binary size of `vm_exec_core` from 37,112 bytes to 36,119 bytes on my machine, according to `nm(1)`.