### PR TITLE
Fix missing imemo cases in objspace_dump by refactoring

### DIFF
--- a/ext/objspace/objspace_dump.c
+++ b/ext/objspace/objspace_dump.c
@@ -195,28 +195,6 @@ dump_append_string_content(struct dump_config *dc, VALUE obj)
     }
 }
 
-static const char *
-imemo_name(int imemo)
-{
-    switch(imemo) {
-#define TYPE_STR(t) case(imemo_##t): return #t
-	TYPE_STR(env);
-	TYPE_STR(cref);
-	TYPE_STR(svar);
-	TYPE_STR(throw_data);
-	TYPE_STR(ifunc);
-	TYPE_STR(memo);
-	TYPE_STR(ment);
-	TYPE_STR(iseq);
-	TYPE_STR(tmpbuf);
-	TYPE_STR(ast);
-	TYPE_STR(parser_strterm);
-      default:
-	return "unknown";
-#undef TYPE_STR
-    }
-}
-
 static void
 dump_object(VALUE obj, struct dump_config *dc)
 {
@@ -251,7 +229,7 @@ dump_object(VALUE obj, struct dump_config *dc)
 	return;
 
       case T_IMEMO:
-	dump_append(dc, ", \"imemo_type\":\"%s\"", imemo_name(imemo_type(obj)));
+	dump_append(dc, ", \"imemo_type\":\"%s\"", rb_imemo_name(imemo_type(obj)));
 	break;
 
       case T_SYMBOL:

--- a/gc.c
+++ b/gc.c
@@ -2256,6 +2256,30 @@ rb_newobj_of(VALUE klass, VALUE flags)
     rb_bug(#func"(): GC does not handle T_NODE 0x%x(%p) 0x%"PRIxVALUE, \
 	   BUILTIN_TYPE(obj), (void*)(obj), RBASIC(obj)->flags)
 
+const char *
+rb_imemo_name(enum imemo_type type)
+{
+    // put no default case to get a warning if an imemo type is missing
+    switch (type) {
+#define IMEMO_NAME(x) case imemo_##x: return #x;
+        IMEMO_NAME(env);
+        IMEMO_NAME(cref);
+        IMEMO_NAME(svar);
+        IMEMO_NAME(throw_data);
+        IMEMO_NAME(ifunc);
+        IMEMO_NAME(memo);
+        IMEMO_NAME(ment);
+        IMEMO_NAME(iseq);
+        IMEMO_NAME(tmpbuf);
+        IMEMO_NAME(ast);
+        IMEMO_NAME(parser_strterm);
+        IMEMO_NAME(callinfo);
+        IMEMO_NAME(callcache);
+#undef IMEMO_NAME
+    }
+    return "unknown";
+}
+
 #undef rb_imemo_new
 
 VALUE
@@ -11662,26 +11686,7 @@ rb_raw_obj_info(char *buff, const int buff_size, VALUE obj)
 	    break;
 	  }
 	  case T_IMEMO: {
-	    const char *imemo_name = "\0";
-	    switch (imemo_type(obj)) {
-#define IMEMO_NAME(x) case imemo_##x: imemo_name = #x; break;
-		IMEMO_NAME(env);
-		IMEMO_NAME(cref);
-		IMEMO_NAME(svar);
-		IMEMO_NAME(throw_data);
-		IMEMO_NAME(ifunc);
-		IMEMO_NAME(memo);
-		IMEMO_NAME(ment);
-		IMEMO_NAME(iseq);
-		IMEMO_NAME(tmpbuf);
-                IMEMO_NAME(ast);
-                IMEMO_NAME(parser_strterm);
-                IMEMO_NAME(callinfo);
-                IMEMO_NAME(callcache);
-#undef IMEMO_NAME
-	      default: UNREACHABLE;
-	    }
-            APPENDF((BUFF_ARGS, "<%s> ", imemo_name));
+            APPENDF((BUFF_ARGS, "<%s> ", rb_imemo_name(imemo_type(obj))));
 
 	    switch (imemo_type(obj)) {
 	      case imemo_ment: {

--- a/internal/imemo.h
+++ b/internal/imemo.h
@@ -150,6 +150,7 @@ VALUE rb_imemo_new_debug(enum imemo_type type, VALUE v1, VALUE v2, VALUE v3, VAL
 #else
 VALUE rb_imemo_new(enum imemo_type type, VALUE v1, VALUE v2, VALUE v3, VALUE v0);
 #endif
+const char *rb_imemo_name(enum imemo_type type);
 RUBY_SYMBOL_EXPORT_END
 
 static inline enum imemo_type


### PR DESCRIPTION
imemo_callcache and imemo_callinfo were not handled by the `objspace`
module and were showing up as "unknown" in the dump. Extract the code for
naming imemos and use that in both the GC and the `objspace` module.