### PR TITLE
(failed?) Attempt to inline Primitive.cexpr!

### DIFF
--- a/builtin.h
+++ b/builtin.h
@@ -80,20 +80,4 @@ struct builtin_binary {
     size_t bin_size;
 };
 
-// mjit
-
-RBIMPL_ATTR_MAYBE_UNUSED()
-static void
-mjit_invokebuiltin_default_compiler(FILE *f, const struct rb_builtin_function *bf, long index)
-{
-    if (index >= 0) {
-        fprintf(f, "val = vm_invoke_builtin(ec, GET_CFP(), %p, STACK_ADDR_FROM_TOP(%d));\n",
-                (const void *)bf, bf->argc);
-    }
-    else {
-        fprintf(f, "val = vm_invoke_builtin_delegate(ec, GET_CFP(), %p, %ld);\n",
-                (const void *)bf, index);
-    }
-}
-
 #endif // BUILTIN_H_INCLUDED

--- a/insns.def
+++ b/insns.def
@@ -1478,11 +1478,11 @@ DEFINE_INSN
 invokebuiltin
 (RB_BUILTIN bf)
 (...)
-(VALUE ret)
+(VALUE val)
 // attr bool leaf = false; /* anything can happen inside */
 // attr rb_snum_t sp_inc = 1 - bf->argc;
 {
-    ret = vm_invoke_builtin(ec, reg_cfp, bf, STACK_ADDR_FROM_TOP(bf->argc));
+    val = vm_invoke_builtin(ec, reg_cfp, bf, STACK_ADDR_FROM_TOP(bf->argc));
 }
 
 /* call specific function with args (same parameters) */
@@ -1490,10 +1490,10 @@ DEFINE_INSN
 opt_invokebuiltin_delegate
 (RB_BUILTIN bf, rb_num_t index)
 ()
-(VALUE ret)
+(VALUE val)
 // attr bool leaf = false; /* anything can happen inside */
 {
-    ret = vm_invoke_builtin_delegate(ec, reg_cfp, bf, (unsigned int)index);
+    val = vm_invoke_builtin_delegate(ec, reg_cfp, bf, (unsigned int)index);
 }
 
 /* call specific function with args (same parameters) and leave */

--- a/integer.rb
+++ b/integer.rb
@@ -15,7 +15,7 @@ class Integer
   #  Returns +true+ if +int+ is an even number.
   def even?
     Primitive.attr! 'inline'
-    Primitive.cexpr! 'int_even_p(self)'
+    Primitive.cexpr! 'rb_int_even_p(self)'
   end
 
   #  call-seq:
@@ -79,6 +79,6 @@ class Integer
   # Returns +true+ if +int+ has a zero value.
   def zero?
     Primitive.attr! 'inline'
-    Primitive.cexpr! 'int_zero_p(self)'
+    Primitive.cexpr! 'rb_int_zero_p(self)'
   end
 end

--- a/internal/numeric.h
+++ b/internal/numeric.h
@@ -75,7 +75,6 @@ VALUE rb_int_divmod(VALUE x, VALUE y);
 VALUE rb_int_and(VALUE x, VALUE y);
 VALUE rb_int_lshift(VALUE x, VALUE y);
 VALUE rb_int_div(VALUE x, VALUE y);
-VALUE rb_int_abs(VALUE num);
 VALUE rb_int_odd_p(VALUE num);
 int rb_int_positive_p(VALUE num);
 int rb_int_negative_p(VALUE num);
@@ -107,6 +106,9 @@ VALUE rb_float_equal(VALUE x, VALUE y);
 int rb_float_cmp(VALUE x, VALUE y);
 VALUE rb_float_eql(VALUE x, VALUE y);
 VALUE rb_fix_aref(VALUE fix, VALUE idx);
+VALUE rb_int_zero_p(VALUE num);
+VALUE rb_int_even_p(VALUE num);
+VALUE rb_int_abs(VALUE num);
 MJIT_SYMBOL_EXPORT_END
 
 static inline bool

--- a/internal/numeric.h
+++ b/internal/numeric.h
@@ -75,7 +75,6 @@ VALUE rb_int_divmod(VALUE x, VALUE y);
 VALUE rb_int_and(VALUE x, VALUE y);
 VALUE rb_int_lshift(VALUE x, VALUE y);
 VALUE rb_int_div(VALUE x, VALUE y);
-VALUE rb_int_odd_p(VALUE num);
 int rb_int_positive_p(VALUE num);
 int rb_int_negative_p(VALUE num);
 VALUE rb_num_pow(VALUE x, VALUE y);
@@ -108,7 +107,9 @@ VALUE rb_float_eql(VALUE x, VALUE y);
 VALUE rb_fix_aref(VALUE fix, VALUE idx);
 VALUE rb_int_zero_p(VALUE num);
 VALUE rb_int_even_p(VALUE num);
+VALUE rb_int_odd_p(VALUE num);
 VALUE rb_int_abs(VALUE num);
+VALUE rb_int_bit_length(VALUE num);
 MJIT_SYMBOL_EXPORT_END
 
 static inline bool

--- a/internal/object.h
+++ b/internal/object.h
@@ -35,6 +35,7 @@ VALUE rb_obj_not_equal(VALUE obj1, VALUE obj2);
 void rb_obj_copy_ivar(VALUE dest, VALUE obj);
 VALUE rb_false(VALUE obj);
 VALUE rb_convert_type_with_id(VALUE v, int t, const char* nam, ID mid);
+VALUE rb_obj_size(VALUE self, VALUE args, VALUE obj);
 MJIT_SYMBOL_EXPORT_END
 
 static inline void

--- a/numeric.c
+++ b/numeric.c
@@ -4931,7 +4931,7 @@ rb_fix_bit_length(VALUE fix)
     return LONG2FIX(bit_length(v));
 }
 
-static VALUE
+VALUE
 rb_int_bit_length(VALUE num)
 {
     if (FIXNUM_P(num)) {

--- a/numeric.c
+++ b/numeric.c
@@ -794,6 +794,12 @@ int_zero_p(VALUE num)
     return Qfalse;
 }
 
+VALUE
+rb_int_zero_p(VALUE num)
+{
+    return int_zero_p(num);
+}
+
 /*
  *  call-seq:
  *     num.nonzero?  ->  self or nil
@@ -3248,6 +3254,12 @@ int_even_p(VALUE num)
         assert(RB_TYPE_P(num, T_BIGNUM));
 	return rb_big_even_p(num);
     }
+}
+
+VALUE
+rb_int_even_p(VALUE num)
+{
+    return int_even_p(num);
 }
 
 /*

--- a/object.c
+++ b/object.c
@@ -591,7 +591,7 @@ rb_obj_itself(VALUE obj)
     return obj;
 }
 
-static VALUE
+VALUE
 rb_obj_size(VALUE self, VALUE args, VALUE obj)
 {
     return LONG2FIX(1);

--- a/struct.c
+++ b/struct.c
@@ -316,9 +316,9 @@ opt_struct_aset(rb_execution_context_t *ec, VALUE self, VALUE val, VALUE idx)
 }
 
 static const struct rb_builtin_function struct_aref_builtin =
-    RB_BUILTIN_FUNCTION(0, struct_aref, opt_struct_aref, 1);
+    RB_BUILTIN_FUNCTION(0, struct_aref, opt_struct_aref, 1, 0);
 static const struct rb_builtin_function struct_aset_builtin =
-    RB_BUILTIN_FUNCTION(1, struct_aref, opt_struct_aset, 2);
+    RB_BUILTIN_FUNCTION(1, struct_aref, opt_struct_aset, 2, 0);
 
 static void
 define_aref_method(VALUE nstr, VALUE name, VALUE off)

--- a/tool/mk_builtin_loader.rb
+++ b/tool/mk_builtin_loader.rb
@@ -311,7 +311,7 @@ def mk_builtin_header file
           f.puts %'        fprintf(f, "    const VALUE *argv = GET_EP() - lnum - VM_ENV_DATA_SIZE + 1 + %ld;\\n", index);'
           f.puts %'    }'
         end
-        f.puts %'    fprintf(f, "    func f = (func)%p\\n;", (const void *)#{cfunc_name});'
+        f.puts %'    fprintf(f, "    func f = (func)%p;\\n", (const void *)#{cfunc_name});'
         f.puts %'    fprintf(f, "    val = f(ec, GET_SELF()#{argv});\\n");'
       end
       f.puts %'}'

--- a/tool/mk_builtin_loader.rb
+++ b/tool/mk_builtin_loader.rb
@@ -311,7 +311,7 @@ def mk_builtin_header file
           f.puts %'        fprintf(f, "    const VALUE *argv = GET_EP() - lnum - VM_ENV_DATA_SIZE + 1 + %ld;\\n", index);'
           f.puts %'    }'
         end
-        f.puts %'    fprintf(f, "    func f = (func)/* #{cfunc_name} */%p;\\n", (const void *)#{cfunc_name});'
+        f.puts %'    fprintf(f, "    func f = (func)%"PRIdPTR"; /* == #{cfunc_name} */\\n", (intptr_t)#{cfunc_name});'
         f.puts %'    fprintf(f, "    val = f(ec, GET_SELF()#{argv});\\n");'
       end
       f.puts %'}'

--- a/tool/mk_builtin_loader.rb
+++ b/tool/mk_builtin_loader.rb
@@ -311,7 +311,7 @@ def mk_builtin_header file
           f.puts %'        fprintf(f, "    const VALUE *argv = GET_EP() - lnum - VM_ENV_DATA_SIZE + 1 + %ld;\\n", index);'
           f.puts %'    }'
         end
-        f.puts %'    fprintf(f, "    func f = (func)%p;\\n", (const void *)#{cfunc_name});'
+        f.puts %'    fprintf(f, "    func f = (func)/* #{cfunc_name} */%p;\\n", (const void *)#{cfunc_name});'
         f.puts %'    fprintf(f, "    val = f(ec, GET_SELF()#{argv});\\n");'
       end
       f.puts %'}'

--- a/tool/ruby_vm/helpers/c_escape.rb
+++ b/tool/ruby_vm/helpers/c_escape.rb
@@ -46,7 +46,7 @@ module RubyVM::CEscape
     # I believe this is the fastest implementation done in pure-ruby.
     # Constants cached, gsub skips block evaluation, string literal optimized.
     buf = str.b
-    buf.gsub! %r/./n, RString2CStr
+    buf.gsub! %r/./nm, RString2CStr
     return %'"#{buf}"'
   end
 

--- a/tool/ruby_vm/views/_mjit_compile_insn_body.erb
+++ b/tool/ruby_vm/views/_mjit_compile_insn_body.erb
@@ -63,10 +63,6 @@
             fprintf(f, "        goto label_%lu;\n", arg.base_pos + else_offset);
             fprintf(f, "    }\n");
         }
-%     elsif insn.name == 'invokebuiltin' || insn.name == 'opt_invokebuiltin_delegate'
-        {
-<%=   render 'mjit_compile_invokebuiltin', locals: { insn: insn } -%>
-        }
 %     else
 %       # Before we `goto` next insn, we need to set return values, especially for getinlinecache
 %       insn.rets.reverse_each.with_index do |ret, i|

--- a/tool/ruby_vm/views/_mjit_compile_insn_body.erb
+++ b/tool/ruby_vm/views/_mjit_compile_insn_body.erb
@@ -63,6 +63,10 @@
             fprintf(f, "        goto label_%lu;\n", arg.base_pos + else_offset);
             fprintf(f, "    }\n");
         }
+%     elsif insn.name == 'invokebuiltin' || insn.name == 'opt_invokebuiltin_delegate'
+        {
+<%=   render 'mjit_compile_invokebuiltin', locals: { insn: insn } -%>
+        }
 %     else
 %       # Before we `goto` next insn, we need to set return values, especially for getinlinecache
 %       insn.rets.reverse_each.with_index do |ret, i|

--- a/tool/ruby_vm/views/_mjit_compile_invokebuiltin.erb
+++ b/tool/ruby_vm/views/_mjit_compile_invokebuiltin.erb
@@ -1,0 +1,23 @@
+% # -*- C -*-
+% # Copyright (c) 2020 Urabe, Shyouhei.  All rights reserved.
+% #
+% # This file is a part of  the programming language Ruby.  Permission is hereby
+% # granted, to either  redistribute and/or modify this file,  provided that the
+% # conditions mentioned  in the  file COPYING  are met.   Consult the  file for
+% # details.
+%
+    /* <%= insn.name %> */
+    const struct rb_builtin_function *bf = (const void *)operands[0];
+%
+% if insn.name == 'invokebuiltin' then
+    const rb_num_t index = -1;
+% else
+    const rb_num_t index = (rb_num_t)operands[1];
+% end
+%
+    if (bf->compiler) {
+        bf->compiler(f, index);
+    }
+    else {
+        mjit_invokebuiltin_default_compiler(f, bf, index);
+    }

--- a/tool/ruby_vm/views/_mjit_compile_invokebuiltin.erb
+++ b/tool/ruby_vm/views/_mjit_compile_invokebuiltin.erb
@@ -6,18 +6,24 @@
 % # conditions mentioned  in the  file COPYING  are met.   Consult the  file for
 % # details.
 %
-    /* <%= insn.name %> */
-    const struct rb_builtin_function *bf = (const void *)operands[0];
-%
-% if insn.name == 'invokebuiltin' then
-    const rb_num_t index = -1;
-% else
-    const rb_num_t index = (rb_num_t)operands[1];
+% insn.opes.each_with_index do |ope, i|
+        <%= ope.fetch(:decl) %> = (<%= ope.fetch(:type) %>)operands[<%= i %>];
 % end
-%
-    if (bf->compiler) {
-        bf->compiler(f, index);
-    }
-    else {
-        mjit_invokebuiltin_default_compiler(f, bf, index);
-    }
+        rb_snum_t sp_inc = <%= insn.call_attribute('sp_inc') %>;
+        unsigned sp = b->stack_size + (unsigned)sp_inc;
+        VM_ASSERT(sp_inc >= 0);
+        VM_ASSERT(sp_inc < UINT_MAX - b->stack_size);
+
+        if (bf->compiler) {
+            fprintf(f, "{\n");
+            fprintf(f, "    VALUE val;\n");
+            bf->compiler(f, <%=
+                insn.name == 'invokebuiltin' ? '-1' : '(rb_num_t)operands[1]'
+            %>);
+            fprintf(f, "    stack[%u] = val;\n", sp - 1);
+            fprintf(f, "}\n");
+% if insn.name != 'opt_invokebuiltin_delegate_leave'
+            b->stack_size = sp;
+            break;
+% end
+        }

--- a/tool/ruby_vm/views/mjit_compile.inc.erb
+++ b/tool/ruby_vm/views/mjit_compile.inc.erb
@@ -63,15 +63,15 @@ switch (insn) {
       }
 %   when 'getinstancevariable', 'setinstancevariable'
 <%=   render 'mjit_compile_ivar', locals: { insn: insn } -%>
+%   when 'invokebuiltin', 'opt_invokebuiltin_delegate'
+    {
+<%=   render 'mjit_compile_invokebuiltin', locals: { insn: insn } -%>
+    }
 %   when 'leave', 'opt_invokebuiltin_delegate_leave'
     {
 %     # opt_invokebuiltin_delegate_leave also implements leave insn. We need to handle it here for inlining.
 %     if insn.name == 'opt_invokebuiltin_delegate_leave'
-      fprintf(f, "{\n");
-      fprintf(f, "    VALUE val;\n");
 <%=   render 'mjit_compile_invokebuiltin', locals: { insn: insn } -%>
-      fprintf(f, "    stack[0] = val;\n");
-      fprintf(f, "}\n");
 %     else
       if (b->stack_size != 1) {
           if (mjit_opts.warnings || mjit_opts.verbose)

--- a/tool/ruby_vm/views/mjit_compile.inc.erb
+++ b/tool/ruby_vm/views/mjit_compile.inc.erb
@@ -67,13 +67,9 @@ switch (insn) {
     {
 %     # opt_invokebuiltin_delegate_leave also implements leave insn. We need to handle it here for inlining.
 %     if insn.name == 'opt_invokebuiltin_delegate_leave'
-      RB_BUILTIN bf = (RB_BUILTIN)operands[0];
-      rb_num_t index = (rb_num_t)operands[0];
       fprintf(f, "{\n");
       fprintf(f, "    VALUE val;\n");
-      fprintf(f, "    RB_BUILTIN bf = (RB_BUILTIN)0x%"PRIxVALUE";\n", operands[0]);
-      fprintf(f, "    rb_num_t index = (rb_num_t)0x%"PRIxVALUE";\n", operands[1]);
-      fprintf(f, <%= rstring2cstr(insn.expr.expr.lines.find { |l| l =~ / vm_invoke_builtin_delegate\(/ }).gsub("\n", '\n') %>);
+<%=   render 'mjit_compile_invokebuiltin', locals: { insn: insn } -%>
       fprintf(f, "    stack[0] = val;\n");
       fprintf(f, "}\n");
 %     else


### PR DESCRIPTION
Noticed that because `Primitive.cexpr!` is a purely compile-time construct, we can eliminate runtime `lookup_builtin_invoker()` circus and directly embed the expressions themselves into JITed codes.

<details><summary>This works, and for instance generated inline C for `Integer#abs` would become:</summary>

```C
static inline VALUE
_mjit0_inlined_2(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, const VALUE orig_self, const rb_iseq_t *original_iseq)
{
    const VALUE *orig_pc = reg_cfp->pc;
    VALUE *orig_sp = reg_cfp->sp;
    VALUE stack[1];
    static const VALUE *const original_body_iseq = (VALUE *)0x559e523c18e0;

label_0: /* opt_invokebuiltin_delegate_leave */
{
    VALUE val;
    MAYBE_UNUSED(VALUE) self = GET_SELF();
{
    val = rb_int_abs(self);
}
    stack[0] = val;
}
    return stack[0];

(... snip ...)
```

</details>

<details><summary>However IT SLOWS DOWN on AWS EC2 c6g.2xlarge:</summary>

```
$ benchmark-driver -v --repeat-count=11 --output=all --rbenv 'master::master@git;ours::tmp;master --jit::master@git --jit;ours --jit::tmp --jit' --filter=abs ~/data/src/github.com/shy
ouhei/ruby/benchmark/mjit_integer.yml
master: ruby 2.8.0dev (2020-07-09T22:01:10Z master ba81bc24e6) [aarch64-linux]
ours: ruby 2.8.0dev (2020-07-10T02:49:50Z origin/compile-bui.. 2d5c59e21e) [aarch64-linux]
master --jit: ruby 2.8.0dev (2020-07-09T22:01:10Z master ba81bc24e6) +JIT [aarch64-linux]
ours --jit: ruby 2.8.0dev (2020-07-10T02:49:50Z origin/compile-bui.. 2d5c59e21e) +JIT [aarch64-linux]
Calculating -------------------------------------
                                   master                  ours          master --jit            ours --jit
        mjit_abs(-1)   18489311.253129158    18982457.009280208    30128929.258191332    29354327.567977905 i/s
                       19080117.484867666    19237473.860359915    30399283.531448383    29402037.452557422
                       19202604.364737410    19295726.280229516    30715431.769021541    29460415.679664187
                       19429883.302648768    19403658.373607460    30748517.479827501    29532670.372629836
                       19569566.973248113    19439899.586268935    30812276.965962008    29593321.386331223
                       19601113.757824801    19593888.245184083    30873217.203203499    29998978.497288637
                       19656988.673114762    19606039.929396592    30879054.025119048    30158585.142605729
                       19706913.073762778    19715792.173321426    30923353.643916830    30385699.086196225
                       19912591.172063068    19847260.327253465    31360081.653118704    30825604.444944806
                       19965823.561417315    20097527.836062040    31516313.017349727    31053188.264961582
                       20079694.389420200    20233826.909296039    31837865.136915416    31475418.785401657
```

</details>