### PR TITLE
configure.ac: Bump the size of sigaltstack

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2948,12 +2948,12 @@ main(void)
     stack_t ss;
     struct sigaction sa;
 
-    ss.ss_sp = malloc(SIGSTKSZ);
+    ss.ss_sp = malloc(16*1024);
     if (ss.ss_sp == NULL) {
 	fprintf(stderr, "cannot allocate memory for sigaltstack\n");
 	return EXIT_FAILURE;
     }
-    ss.ss_size = SIGSTKSZ;
+    ss.ss_size = 16*1024;
     ss.ss_flags = 0;
     if (sigaltstack(&ss, NULL) == -1) {
 	fprintf(stderr, "sigaltstack failed\n");


### PR DESCRIPTION
The RubyVM uses C macro defines to feature detect whether
`backtrace(3)` support is available, and if so it includes C level backtraces
when the RubyVM itself crashes.

But on my machine, C level backtraces from `vm_dump.c` didn't work when
using a version of Ruby built on the machine, but worked fine when using a
version of Ruby built on another machine and copied to my machine.

The default autoconf test for backtraces uses a sigaltstack size that is
too small, so the SIGSEGV signal handler itself causes a SIGSEGV).
I noticed that signal.c uses a larger sigaltstack size:

https://github.com/ruby/ruby/blob/v2_6_5/signal.c#L568

The specific variables it looks at:

- `HAVE_BACKTRACE`

  this is a macro defined by autoconf because there is a line in the
  configure script like `AC_CHECK_FUNCS(backtrace)` (see the autoconf
  docs for more).

- `BROKEN_BACKTRACE`

  this comes from a custom program that Ruby's configure script runs to
  attempt to figure out whether actually using backtrace(3) in a real
  program works. You can see the autoconf program here.

  <https://github.com/ruby/ruby/blob/v2_6_5/configure.ac#L2817-L2863>

It uses sigaltstack and SA_ONSTACK to create a seperate stack for
handling signals.

The problem was: SIGSTKSZ (which comes from a system header!) was not
suggesting a large enough stack size. When checking on an Ubuntu 16.04
box, we found that SIGSTKSZ was 8192 and MINSIGSTKSZ was 2048.