### PR TITLE
Fix MonitorMixin and Mutex_m when the super's initialize method has kwargs

### DIFF
--- a/ext/monitor/lib/monitor.rb
+++ b/ext/monitor/lib/monitor.rb
@@ -220,7 +220,7 @@ module MonitorMixin
   # Use <tt>extend MonitorMixin</tt> or <tt>include MonitorMixin</tt> instead
   # of this constructor.  Have look at the examples above to understand how to
   # use this module.
-  def initialize(*args)
+  def initialize(...)
     super
     mon_initialize
   end

--- a/test/monitor/test_monitor.rb
+++ b/test/monitor/test_monitor.rb
@@ -236,6 +236,22 @@ class TestMonitor < Test::Unit::TestCase
     assert NewCondTest.new.cond.instance_variable_get(:@monitor) != nil
   end
 
+  class KeywordInitializeParent
+    def initialize(x:)
+    end
+  end
+
+  class KeywordInitializeChild < KeywordInitializeParent
+    include MonitorMixin
+    def initialize
+      super(x: 1)
+    end
+  end
+
+  def test_initialize_with_keyword_arg
+    assert KeywordInitializeChild.new
+  end
+
   def test_timedwait
     cond = @monitor.new_cond
     b = "foo"


### PR DESCRIPTION
# Problem


MonitorMixin and Mutex_m have the same kwargs problem.
When the super class's `initialize` method has kwargs, it raises an error on Ruby 2.8.

For example:


```ruby
class P
  def initialize(x:)
    p x
  end
end

class C < P
  include MonitorMixin

  def initialize
    super(x: 1)
  end
end

C.new
```

```ruby
# Ruby 2.8
$ ruby -v test.rb
ruby 2.8.0dev (2020-07-10T22:31:51Z master 021cec938a) [x86_64-linux]
test.rb:2:in `initialize': wrong number of arguments (given 1, expected 0; required keyword: x) (ArgumentError)
	from /home/pocke/.rbenv/versions/trunk/lib/ruby/2.8.0/monitor.rb:224:in `initialize'
	from test.rb:11:in `initialize'
	from test.rb:15:in `new'
	from test.rb:15:in `<main>'

# Ruby 2.7.1
$ ruby -v test.rb
ruby 2.7.1p83 (2020-03-31 revision a0c7c23c9c) [x86_64-linux]
1
/home/pocke/.rbenv/versions/2.7.1/lib/ruby/2.7.0/monitor.rb:224: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
test.rb:2: warning: The called method `initialize' is defined here
```


# Solution


Use `...` instead of `*args`.

I'm not familiar with the kwargs problem, so I'm not sure this solution is the best.
If you know the best way, please tell me it :pray: 