### PR TITLE
Optimize Array#max

### DIFF
--- a/benchmark/array_max_float.yml
+++ b/benchmark/array_max_float.yml
@@ -1,0 +1,30 @@
+prelude: |
+  ary2 = 2.times.map(&:to_f).shuffle
+  ary10 = 10.times.map(&:to_f).shuffle
+  ary100 = 100.times.map(&:to_f).shuffle
+  ary500 = 500.times.map(&:to_f).shuffle
+  ary1000 = 1000.times.map(&:to_f).shuffle
+  ary2000 = 2500.times.map(&:to_f).shuffle
+  ary3000 = 2500.times.map(&:to_f).shuffle
+  ary5000 = 5000.times.map(&:to_f).shuffle
+  ary10000 = 10000.times.map(&:to_f).shuffle
+  ary20000 = 20000.times.map(&:to_f).shuffle
+  ary50000 = 50000.times.map(&:to_f).shuffle
+  ary100000 = 100000.times.map(&:to_f).shuffle
+
+benchmark:
+  ary2.max: ary2.max
+  ary10.max: ary10.max
+  ary100.max: ary100.max
+  ary500.max: ary500.max
+  ary1000.max: ary1000.max
+  ary2000.max: ary2000.max
+  ary3000.max: ary3000.max
+  ary5000.max: ary5000.max
+  ary10000.max: ary10000.max
+  ary20000.max: ary20000.max
+  ary50000.max: ary50000.max
+  ary100000.max: ary100000.max
+
+loop_count: 10000
+

--- a/benchmark/array_max_int.yml
+++ b/benchmark/array_max_int.yml
@@ -1,0 +1,31 @@
+prelude: |
+  ary2 = 2.times.to_a.shuffle
+  ary10 = 10.times.to_a.shuffle
+  ary100 = 100.times.to_a.shuffle
+  ary500 = 500.times.to_a.shuffle
+  ary1000 = 1000.times.to_a.shuffle
+  ary2000 = 2500.times.to_a.shuffle
+  ary3000 = 2500.times.to_a.shuffle
+  ary5000 = 5000.times.to_a.shuffle
+  ary10000 = 10000.times.to_a.shuffle
+  ary20000 = 20000.times.to_a.shuffle
+  ary50000 = 50000.times.to_a.shuffle
+  ary100000 = 100000.times.to_a.shuffle
+  ary1000000 = 1000000.times.to_a.shuffle
+
+benchmark:
+  ary2.max: ary2.max
+  ary10.max: ary10.max
+  ary100.max: ary100.max
+  ary500.max: ary500.max
+  ary1000.max: ary1000.max
+  ary2000.max: ary2000.max
+  ary3000.max: ary3000.max
+  ary5000.max: ary5000.max
+  ary10000.max: ary10000.max
+  ary20000.max: ary20000.max
+  ary50000.max: ary50000.max
+  ary100000.max: ary100000.max
+  ary1000000.max: ary1000000.max
+
+loop_count: 10000

--- a/benchmark/array_max_str.yml
+++ b/benchmark/array_max_str.yml
@@ -1,0 +1,30 @@
+prelude: |
+  ary2 = 2.times.map(&:to_s).shuffle
+  ary10 = 10.times.map(&:to_s).shuffle
+  ary100 = 100.times.map(&:to_s).shuffle
+  ary500 = 500.times.map(&:to_s).shuffle
+  ary1000 = 1000.times.map(&:to_s).shuffle
+  ary2000 = 2500.times.map(&:to_s).shuffle
+  ary3000 = 2500.times.map(&:to_s).shuffle
+  ary5000 = 5000.times.map(&:to_s).shuffle
+  ary10000 = 10000.times.map(&:to_s).shuffle
+  ary20000 = 20000.times.map(&:to_s).shuffle
+  ary50000 = 50000.times.map(&:to_s).shuffle
+  ary100000 = 100000.times.map(&:to_s).shuffle
+
+benchmark:
+  ary2.max: ary2.max
+  ary10.max: ary10.max
+  ary100.max: ary100.max
+  ary500.max: ary500.max
+  ary1000.max: ary1000.max
+  ary2000.max: ary2000.max
+  ary3000.max: ary3000.max
+  ary5000.max: ary5000.max
+  ary10000.max: ary10000.max
+  ary20000.max: ary20000.max
+  ary50000.max: ary50000.max
+  ary100000.max: ary100000.max
+
+loop_count: 10000
+

--- a/test/ruby/test_array.rb
+++ b/test/ruby/test_array.rb
@@ -1756,10 +1756,12 @@ class TestArray < Test::Unit::TestCase
   end
 
   def test_max
+    assert_equal(1, [1].max)
     assert_equal(3, [1, 2, 3, 1, 2].max)
     assert_equal(1, [1, 2, 3, 1, 2].max {|a,b| b <=> a })
     cond = ->((a, ia), (b, ib)) { (b <=> a).nonzero? or ia <=> ib }
     assert_equal([1, 3], [1, 2, 3, 1, 2].each_with_index.max(&cond))
+    assert_equal(3.0, [1.0, 3.0, 2.0].max)
     ary = %w(albatross dog horse)
     assert_equal("horse", ary.max)
     assert_equal("albatross", ary.max {|a,b| a.length <=> b.length })
@@ -1777,6 +1779,7 @@ class TestArray < Test::Unit::TestCase
   end
 
   def test_minmax
+    assert_equal([3, 3], [3].minmax)
     assert_equal([1, 3], [1, 2, 3, 1, 2].minmax)
     assert_equal([3, 1], [1, 2, 3, 1, 2].minmax {|a,b| b <=> a })
     cond = ->((a, ia), (b, ib)) { (b <=> a).nonzero? or ia <=> ib }


### PR DESCRIPTION
The optimization of `Array#min`, a part of #3246, can be merged because it is constantly over about 2.0x faster than the original for a large array.

The benchmark result is below:

|                |compare-ruby|built-ruby|
|:---------------|-----------:|---------:|
|ary2.max        |     38.837M|   40.830M|
|                |           -|     1.05x|
|ary10.max       |     23.035M|   32.626M|
|                |           -|     1.42x|
|ary100.max      |      5.490M|   11.020M|
|                |           -|     2.01x|
|ary500.max      |      1.324M|    2.679M|
|                |           -|     2.02x|
|ary1000.max     |    699.167k|    1.403M|
|                |           -|     2.01x|
|ary2000.max     |    284.321k|  570.446k|
|                |           -|     2.01x|
|ary3000.max     |    282.613k|  571.683k|
|                |           -|     2.02x|
|ary5000.max     |    145.120k|  285.546k|
|                |           -|     1.97x|
|ary10000.max    |     72.102k|  142.831k|
|                |           -|     1.98x|
|ary20000.max    |     36.065k|   72.077k|
|                |           -|     2.00x|
|ary50000.max    |     14.343k|   29.139k|
|                |           -|     2.03x|
|ary100000.max   |      7.586k|   14.472k|
|                |           -|     1.91x|
|ary1000000.max  |     726.915|    1.495k|
|                |           -|     2.06x|