### PR TITLE
Special case Range#max for integer beginning and Float::Infinity end

### DIFF
--- a/range.c
+++ b/range.c
@@ -1254,6 +1254,15 @@ range_max(int argc, VALUE *argv, VALUE range)
             return rb_funcall(e, '-', 1, INT2FIX(1));
         }
         if (RB_INTEGER_TYPE_P(b) && !RB_INTEGER_TYPE_P(e)) {
+            if (RB_TYPE_P(e, T_FLOAT)) {
+                VALUE inf = rb_funcall(e, rb_intern("infinite?"), 0);
+                if (inf != Qnil) {
+                  /* For backwards compatibility, return end if the end
+                   * is Float::Infinity and the beginning is integer.
+                     If end is -Float::Infinity, return nil. */
+                  return(inf == INT2FIX(1) ? e : Qnil);
+                }
+            }
             e = rb_funcall(e, rb_intern("floor"), 0);
         }
         return e;

--- a/test/ruby/test_range.rb
+++ b/test/ruby/test_range.rb
@@ -127,6 +127,9 @@ class TestRange < Test::Unit::TestCase
     assert_raise(RangeError) { (1...).max(3) }
 
     assert_raise(RangeError) { (..0).min {|a, b| a <=> b } }
+
+    assert_equal(Float::INFINITY, (1..Float::INFINITY).max)
+    assert_nil((1..-Float::INFINITY).max)
   end
 
   def test_minmax
@@ -153,6 +156,9 @@ class TestRange < Test::Unit::TestCase
 
     assert_equal(['a', 'c'], ('a'..'c').minmax)
     assert_equal(['a', 'b'], ('a'...'c').minmax)
+
+    assert_equal([1, Float::INFINITY], (1..Float::INFINITY).minmax)
+    assert_equal([nil, nil], (1..-Float::INFINITY).minmax)
   end
 
   def test_initialize_twice


### PR DESCRIPTION
Popular Ruby libraries such as Rails and Rubocop relying on the
previous behavior, even though it is technically a bug.  The
correct behavior is probably raising RangeError, since that is what
an endless range raises.

Related to [Bug #17017]