### PR TITLE
Fix Range#max for beginless Integer ranges

### DIFF
--- a/range.c
+++ b/range.c
@@ -1220,16 +1220,17 @@ range_max(int argc, VALUE *argv, VALUE range)
 	rb_raise(rb_eRangeError, "cannot get the maximum of endless range");
     }
 
+    VALUE b = RANGE_BEG(range);
+
     if (rb_block_given_p() || (EXCL(range) && !nm) || argc) {
-        if (NIL_P(RANGE_BEG(range))) {
+        if (NIL_P(b)) {
             rb_raise(rb_eRangeError, "cannot get the maximum of beginless range with custom comparison method");
         }
         return rb_call_super(argc, argv);
     }
     else {
         struct cmp_opt_data cmp_opt = { 0, 0 };
-        VALUE b = RANGE_BEG(range);
-        int c = OPTIMIZED_CMP(b, e, cmp_opt);
+        int c = NIL_P(b) ? -1 : OPTIMIZED_CMP(b, e, cmp_opt);
 
         if (c > 0)
             return Qnil;

--- a/test/ruby/test_range.rb
+++ b/test/ruby/test_range.rb
@@ -129,8 +129,8 @@ class TestRange < Test::Unit::TestCase
     assert_raise(RangeError) { (..0).min {|a, b| a <=> b } }
 
     assert_equal(2, (..2).max)
-    assert_raise(TypeError, (...2).max)
-    assert_raise(TypeError, (...2.0).max)
+    assert_raise(TypeError) {(...2).max}
+    assert_raise(TypeError) {(...2.0).max}
   end
 
   def test_minmax

--- a/test/ruby/test_range.rb
+++ b/test/ruby/test_range.rb
@@ -127,6 +127,10 @@ class TestRange < Test::Unit::TestCase
     assert_raise(RangeError) { (1...).max(3) }
 
     assert_raise(RangeError) { (..0).min {|a, b| a <=> b } }
+
+    assert_equal(2, (..2).max)
+    assert_raise(TypeError, (...2).max)
+    assert_raise(TypeError, (...2.0).max)
   end
 
   def test_minmax

--- a/test/ruby/test_range.rb
+++ b/test/ruby/test_range.rb
@@ -129,8 +129,8 @@ class TestRange < Test::Unit::TestCase
     assert_raise(RangeError) { (..0).min {|a, b| a <=> b } }
 
     assert_equal(2, (..2).max)
-    assert_raise(TypeError) {(...2).max}
-    assert_raise(TypeError) {(...2.0).max}
+    assert_raise(TypeError) { (...2).max }
+    assert_raise(TypeError) { (...2.0).max }
   end
 
   def test_minmax


### PR DESCRIPTION
Proposed solution for [Bug #17034](https://bugs.ruby-lang.org/issues/17034)

**Summary**

Getting the maximum of a beginless range leads to an unintuitive error:

```ruby
(..2).max
# ArgumentError: comparison of NilClass with 2 failed
```

This PR fixes that without changing any other behavior:

```ruby
(..2).max
#=> 2
(...2).max 
# TypeError (cannot exclude end value with non Integer begin value)
(...2.0).max'
# TypeError (cannot exclude non Integer end value)
```