### PR TITLE
Add more timeouts to macos, mjit and ubuntu workflows.

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -46,6 +46,7 @@ jobs:
         working-directory: build
         if: matrix.test_task == 'check'
       - run: make $JOBS -s ${{ matrix.test_task }}
+        timeout-minutes: 30
         working-directory: build
         env:
           RUBY_TESTOPTS: "-q --tty=no"

--- a/.github/workflows/mjit.yml
+++ b/.github/workflows/mjit.yml
@@ -48,10 +48,13 @@ jobs:
       - run: sudo make $JOBS -s install
         working-directory: build
       - run: make $JOBS -s test RUN_OPTS="$RUN_OPTS"
+        timeout-minutes: 10
         working-directory: build
       - run: make $JOBS -s test-all RUN_OPTS="$RUN_OPTS"
+        timeout-minutes: 10
         working-directory: build
       - run: make $JOBS -s test-spec RUN_OPTS="$RUN_OPTS"
+        timeout-minutes: 5
         working-directory: build
       - uses: k0kubun/action-slack@v2.0.0
         with:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -68,6 +68,7 @@ jobs:
         working-directory: build
         if: matrix.test_task == 'check'
       - run: make $JOBS -s ${{ matrix.test_task }}
+        timeout-minutes: 30
         working-directory: build
         env:
           RUBY_TESTOPTS: "-q --tty=no"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -61,6 +61,7 @@ jobs:
         working-directory: build
         shell: cmd
       - name: nmake test
+        timeout-minutes: 30
         run: |
           call "C:\Program Files (x86)\Microsoft Visual Studio\${{ matrix.vs }}\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           nmake ${{ matrix.test_task }}


### PR DESCRIPTION
GitHub Actions default timeout is 6 hours: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes

We should avoid waiting 6 hours for a hung test to fail. This PR introduces additional timeouts on the main pain points. However we should consider introducing more timeouts across all the tests. e.g. bundle install may hang and that would block the test for 6 hours.