### PR TITLE
Lazily insert origins on prepend to save memory

### DIFF
--- a/eval.c
+++ b/eval.c
@@ -1551,9 +1551,6 @@ rb_mod_refine(VALUE module, VALUE klass)
     }
 
     ensure_class_or_module(klass);
-    if (RB_TYPE_P(klass, T_MODULE)) {
-        rb_ensure_origin(klass);
-    }
     CONST_ID(id_refinements, "__refinements__");
     refinements = rb_attr_get(module, id_refinements);
     if (NIL_P(refinements)) {

--- a/internal/class.h
+++ b/internal/class.h
@@ -119,7 +119,6 @@ VALUE rb_singleton_class_clone_and_attach(VALUE obj, VALUE attach);
 VALUE rb_singleton_class_get(VALUE obj);
 int rb_class_has_methods(VALUE c);
 void rb_undef_methods_from(VALUE klass, VALUE super);
-void rb_ensure_origin(VALUE klass);
 
 static inline void RCLASS_SET_ORIGIN(VALUE klass, VALUE origin);
 static inline void RICLASS_SET_ORIGIN_SHARED_MTBL(VALUE iclass);


### PR DESCRIPTION
98286e9850936e27e8ae5e4f20858cc9c13d2dde made it so that
`Module#include` allocates an origin iclass on each use. Since `include`
is widely used, the extra allocation can contribute significantly to
memory usage.

Instead of always allocating in anticipation of prepend, this change
takes a different approach. The new setup inserts a origin iclass into
the super chains of all the children of the module when prepend happens
for the first time.

rb_ensure_origin is made static again since now that adding an origin
now means walking over all usages, we want to limit the number of places
where we do it.

---

I found this memory usage problem while testing an app on Ruby master. The
app was spending 50MiB more on iclasses. Also I think it slows down GC to have
all these extra iclasses. Iclasses are not WB protected and the GC needs
to do extra work for them.

This change brings memory usage back down to 2.7 levels when prepend is not used:
```ruby
a = Module.new
b = Module.new
c = Module.new
before = ObjectSpace.count_objects[:T_ICLASS]
a.include(c)
b.include(c)
after = ObjectSpace.count_objects[:T_ICLASS]
puts after - before
```
This prints `2` after the patch and on 2.7, while master(2eaa53e9a38b46442508878ac1795d91688701e3) prints 5


Tests pass but I'm not sure if I not sure if I got everything right. This area seems tricky to work in without introducing some refinement related bugs.