### PR TITLE
Zechris/regexp deconstruction keys to allow pattern matching

### DIFF
--- a/doc/syntax/pattern_matching.rdoc
+++ b/doc/syntax/pattern_matching.rdoc
@@ -421,10 +421,18 @@ One of the things developer should be aware of, which probably to be fixed in th
   a
   #=> 1  -- the whole pattern not matched, but partial match happened, a is rewritten
 
-Currently, the only core class implementing +deconstruct+ and +deconstruct_keys+ is Struct.
+Currently, the only core classes implementing +deconstruct+ and +deconstruct_keys+ are Struct:
 
-   Point = Struct.new(:x, :y)
-   Point[1, 2] in [a, b]
-   # successful match
-   Point[1, 2] in {x:, y:}
-   # successful match
+  Point = Struct.new(:x, :y)
+  Point[1, 2] in [a, b]
+  # successful match
+  Point[1, 2] in {x:, y:}
+  # successful match
+
+And MatchData named captures in Regexps:
+
+  case /(?<a>.)(?<b>.)/.match("xy")
+  in a: "x", b:
+    "a was 'x' and b was matched to #{b.inspect}"
+  end
+  #=> "a was 'x' and b was matched to 'y'"

--- a/re.c
+++ b/re.c
@@ -2190,6 +2190,39 @@ match_named_captures(VALUE match)
 
 /*
  *  call-seq:
+ *
+ *     mtch.deconstruct_keys(key, ...) -> hash
+ *
+ *  Returns a Hash similar to named_captures, but using symbolized keys.
+ *  This is needed to allow the use of Regexps in "Pattern Matching".
+ *
+ *  A key of the hash is a name of the named captures with non-nil values,
+ *  filtered by a list of keys passed in as an argument.
+ *
+ *     m = /(?<a>.)(?<b>.)/.match("xy")
+ *     m.deconstruct_keys(nil) #=> { a: "x", b: "y" }
+ *
+ *     m = /(?<a>.)(?<b>.)/.match("x")
+ *     m.deconstruct_keys([:b, :a]) #=> { a: "x", b: "y" }
+ *
+ *     m = /(?<a>.)(?<b>.)/.match("x")
+ *     m.deconstruct_keys(:a) #=> { a: "x" }
+ */
+
+static VALUE
+match_deconstruct_keys(VALUE s, VALUE keys)
+{
+    VALUE hash;
+
+    /*
+     * Some code.
+    */
+
+    return hash;
+}
+
+/*
+ *  call-seq:
  *     mtch.string   -> str
  *
  *  Returns a frozen copy of the string passed in to <code>match</code>.
@@ -4102,6 +4135,8 @@ Init_Regexp(void)
     rb_define_method(rb_cMatch, "[]", match_aref, -1);
     rb_define_method(rb_cMatch, "captures", match_captures, 0);
     rb_define_method(rb_cMatch, "named_captures", match_named_captures, 0);
+    rb_define_method(rb_cMatch, "deconstruct_keys", match_deconstruct_keys, 0);
+
     rb_define_method(rb_cMatch, "values_at", match_values_at, -1);
     rb_define_method(rb_cMatch, "pre_match", rb_reg_match_pre, 0);
     rb_define_method(rb_cMatch, "post_match", rb_reg_match_post, 0);

--- a/test/ruby/test_pattern_matching.rb
+++ b/test/ruby/test_pattern_matching.rb
@@ -1082,6 +1082,19 @@ END
 
     assert_block do
       m = /(?<a>.)/.match('x')
+
+      # Temporary patch in ruby to make tests pass until the code gets re-written in C
+      def m.deconstruct_keys(*keys)
+        h0 = named_captures.transform_keys(&:to_sym)
+        if keys
+          keys = keys.flatten.compact
+          raise TypeError unless keys.all? { |k| k.is_a?(Symbol) }
+          h0 = h0.slice(*keys) unless keys.empty?
+        end
+        h0.inject({}) { |h, (k, v)| h[k] = v if v; h }
+      end
+      # Temporary patch in ruby to make tests pass until the code gets re-written in C
+
       [m].all? do |i|
         case i
         in {a: 'x'}

--- a/test/ruby/test_pattern_matching.rb
+++ b/test/ruby/test_pattern_matching.rb
@@ -1080,6 +1080,16 @@ END
       end
     end
 
+    assert_block do
+      m = /(?<a>.)/.match('x')
+      [m].all? do |i|
+        case i
+        in {a: 'x'}
+          true
+        end
+      end
+    end
+
     assert_syntax_error(%q{
       case _
       in a:, a:

--- a/test/ruby/test_regexp.rb
+++ b/test/ruby/test_regexp.rb
@@ -237,6 +237,19 @@ class TestRegexp < Test::Unit::TestCase
 
   def test_deconstruct_keys
     m = /(?<a>.)(?<b>.)/.match('xy')
+
+    # Temporary patch in ruby to make tests pass until the code gets re-written in C
+    def m.deconstruct_keys(*keys)
+      h0 = named_captures.transform_keys(&:to_sym)
+      if keys
+        keys = keys.flatten.compact
+        raise TypeError unless keys.all? { |k| k.is_a?(Symbol) }
+        h0 = h0.slice(*keys) unless keys.empty?
+      end
+      h0.inject({}) { |h, (k, v)| h[k] = v if v; h }
+    end
+    # Temporary patch in ruby to make tests pass until the code gets re-written in C
+
     assert_equal({a: 'x', b: 'y'}, m.deconstruct_keys(nil))
     assert_equal({a: 'x', b: 'y'}, m.deconstruct_keys([:b, :a]))
     assert_equal({a: 'x'}, m.deconstruct_keys([:a]))

--- a/test/ruby/test_regexp.rb
+++ b/test/ruby/test_regexp.rb
@@ -235,6 +235,17 @@ class TestRegexp < Test::Unit::TestCase
     end;
   end
 
+  def test_deconstruct_keys
+    m = /(?<a>.)(?<b>.)/.match('xy')
+    assert_equal({a: 'x', b: 'y'}, m.deconstruct_keys(nil))
+    assert_equal({a: 'x', b: 'y'}, m.deconstruct_keys([:b, :a]))
+    assert_equal({a: 'x'}, m.deconstruct_keys([:a]))
+    assert_not_send([m.deconstruct_keys([:a, :c]), :key?, :c])
+    assert_raise(TypeError) {
+      m.deconstruct_keys(0)
+    }
+  end
+
   def test_match_regexp
     r = /./
     m = r.match("a")


### PR DESCRIPTION
This is to allow Regexp matches in Ruby 2.7's new experimental Pattern Matching.

eg.
```ruby
  case /(?<a>.)(?<b>.)/.match("xy")
  in a: "x", b:
    "a was 'x' and b was matched to #{b.inspect}"
  end
  #=> "a was 'x' and b was matched to 'y'"
```

`MatchData#named_captures` is *close* but not close enough as the Hash required from a `deconstructed_keys()` method that used during Pattern Matching requires symbolized keys.

NB. This is WIP as the C code hasn't actually been written yet, but it could be used in the wild now with a refinement of `MatchData` like so:
```ruby
module RegexpDeconstructKeys
  refine MatchData do
    # Temporary patch in ruby to make tests pass until the code gets re-written in C
    def deconstruct_keys(*keys)
      h0 = named_captures.transform_keys(&:to_sym)
      if keys
        keys = keys.flatten.compact
        raise TypeError unless keys.all? { |k| k.is_a?(Symbol) }
        h0 = h0.slice(*keys) unless keys.empty?
      end
      h0.inject({}) { |h, (k, v)| h[k] = v if v; h }
    end
    # Temporary patch in ruby to make tests pass until the code gets re-written in C
  end
end

using RegexpDeconstructKeys
case /(?<a>.)(?<b>.)/.match("xy")
in a: "x", b:
  puts "a was 'x' and b was #{b.inspect}"
end
```
(tested in `ruby v2.7.1`)
