### PR TITLE
RUBY_SHOW_COPYRIGHT_TO_DIE: flip the default

### DIFF
--- a/include/ruby/backward.h
+++ b/include/ruby/backward.h
@@ -72,12 +72,9 @@ DECLARE_DEPRECATED_INTERNAL_FEATURE(rb_generic_ivar_table);
 NORETURN(ERRORFUNC(("internal function"), VALUE rb_mod_const_missing(VALUE, VALUE)));
 
 /* from version.c */
-#ifndef RUBY_SHOW_COPYRIGHT_TO_DIE
-# define RUBY_SHOW_COPYRIGHT_TO_DIE 1
-#endif
-#if RUBY_SHOW_COPYRIGHT_TO_DIE
+#if defined(RUBY_SHOW_COPYRIGHT_TO_DIE) && !!(RUBY_SHOW_COPYRIGHT_TO_DIE+0)
 /* for source code backward compatibility */
-DEPRECATED(static inline int ruby_show_copyright_to_die(int));
+RBIMPL_ATTR_DEPRECATED(("since 2.4"))
 static inline int
 ruby_show_copyright_to_die(int exitcode)
 {


### PR DESCRIPTION
Commit 7aab062ef3772c7e8e50fc872a1647918c76dbba says:

> ruby_show_version() will no longer exits the process, if
> RUBY_SHOW_COPYRIGHT_TO_DIE is set to 0.  This will be the default in
> the future.

3.0 is a good timing for that "future".