### PR TITLE
deprecate backward/2/r_cast.h

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1695,7 +1695,6 @@ array.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 array.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 array.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 array.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-array.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 array.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 array.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 array.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -1884,7 +1883,6 @@ ast.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 ast.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 ast.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 ast.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-ast.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 ast.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 ast.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 ast.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -2076,7 +2074,6 @@ bignum.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 bignum.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 bignum.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 bignum.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-bignum.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 bignum.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 bignum.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 bignum.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -2257,7 +2254,6 @@ builtin.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 builtin.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 builtin.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 builtin.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-builtin.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 builtin.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 builtin.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 builtin.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -2451,7 +2447,6 @@ class.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 class.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 class.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 class.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-class.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 class.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 class.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 class.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -2635,7 +2630,6 @@ compar.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 compar.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 compar.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 compar.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-compar.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 compar.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 compar.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 compar.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -2829,7 +2823,6 @@ compile.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 compile.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 compile.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 compile.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-compile.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 compile.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 compile.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 compile.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -3040,7 +3033,6 @@ complex.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 complex.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 complex.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 complex.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-complex.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 complex.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 complex.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 complex.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -3225,7 +3217,6 @@ cont.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 cont.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 cont.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 cont.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-cont.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 cont.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 cont.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 cont.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -3416,7 +3407,6 @@ debug.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 debug.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 debug.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 debug.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-debug.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 debug.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 debug.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 debug.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -3599,7 +3589,6 @@ debug_counter.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 debug_counter.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 debug_counter.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 debug_counter.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-debug_counter.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 debug_counter.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 debug_counter.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 debug_counter.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -3775,7 +3764,6 @@ dir.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 dir.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 dir.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 dir.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-dir.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 dir.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 dir.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 dir.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -3950,7 +3938,6 @@ dln.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 dln.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 dln.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 dln.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-dln.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 dln.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 dln.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 dln.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -4113,7 +4100,6 @@ dln_find.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 dln_find.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 dln_find.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 dln_find.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-dln_find.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 dln_find.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 dln_find.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 dln_find.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -4275,7 +4261,6 @@ dmydln.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 dmydln.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 dmydln.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 dmydln.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-dmydln.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 dmydln.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 dmydln.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 dmydln.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -4489,7 +4474,6 @@ encoding.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 encoding.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 encoding.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 encoding.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-encoding.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 encoding.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 encoding.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 encoding.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -4677,7 +4661,6 @@ enum.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 enum.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 enum.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 enum.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-enum.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 enum.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 enum.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 enum.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -4865,7 +4848,6 @@ enumerator.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 enumerator.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 enumerator.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 enumerator.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-enumerator.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 enumerator.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 enumerator.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 enumerator.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -5053,7 +5035,6 @@ error.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 error.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 error.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 error.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-error.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 error.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 error.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 error.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -5257,7 +5238,6 @@ eval.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 eval.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 eval.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 eval.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-eval.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 eval.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 eval.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 eval.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -5476,7 +5456,6 @@ file.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 file.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 file.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 file.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-file.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 file.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 file.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 file.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -5680,7 +5659,6 @@ gc.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 gc.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 gc.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 gc.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-gc.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 gc.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 gc.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 gc.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -5889,7 +5867,6 @@ golf_prelude.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 golf_prelude.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 golf_prelude.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 golf_prelude.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-golf_prelude.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 golf_prelude.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 golf_prelude.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 golf_prelude.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -6064,7 +6041,6 @@ goruby.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 goruby.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 goruby.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 goruby.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-goruby.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 goruby.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 goruby.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 goruby.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -6247,7 +6223,6 @@ hash.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 hash.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 hash.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 hash.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-hash.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 hash.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 hash.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 hash.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -6425,7 +6400,6 @@ inits.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 inits.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 inits.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 inits.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-inits.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 inits.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 inits.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 inits.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -6616,7 +6590,6 @@ io.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 io.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 io.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 io.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-io.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 io.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 io.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 io.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -6823,7 +6796,6 @@ iseq.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 iseq.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 iseq.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 iseq.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-iseq.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 iseq.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 iseq.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 iseq.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -7032,7 +7004,6 @@ load.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 load.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 load.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 load.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-load.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 load.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 load.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 load.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -7216,7 +7187,6 @@ loadpath.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 loadpath.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 loadpath.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 loadpath.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-loadpath.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 loadpath.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 loadpath.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 loadpath.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -7379,7 +7349,6 @@ localeinit.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 localeinit.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 localeinit.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 localeinit.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-localeinit.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 localeinit.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 localeinit.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 localeinit.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -7547,7 +7516,6 @@ main.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 main.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 main.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 main.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-main.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 main.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 main.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 main.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -7726,7 +7694,6 @@ marshal.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 marshal.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 marshal.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 marshal.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-marshal.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 marshal.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 marshal.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 marshal.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -7904,7 +7871,6 @@ math.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 math.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 math.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 math.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-math.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 math.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 math.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 math.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -8081,7 +8047,6 @@ miniinit.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 miniinit.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 miniinit.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 miniinit.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-miniinit.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 miniinit.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 miniinit.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 miniinit.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -8319,7 +8284,6 @@ mjit.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 mjit.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 mjit.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 mjit.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-mjit.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 mjit.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 mjit.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 mjit.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -8534,7 +8498,6 @@ mjit_compile.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 mjit_compile.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 mjit_compile.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 mjit_compile.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-mjit_compile.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 mjit_compile.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 mjit_compile.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 mjit_compile.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -8733,7 +8696,6 @@ node.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 node.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 node.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 node.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-node.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 node.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 node.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 node.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -8925,7 +8887,6 @@ numeric.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 numeric.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 numeric.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 numeric.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-numeric.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 numeric.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 numeric.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 numeric.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -9119,7 +9080,6 @@ object.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 object.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 object.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 object.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-object.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 object.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 object.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 object.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -9302,7 +9262,6 @@ pack.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 pack.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 pack.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 pack.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-pack.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 pack.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 pack.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 pack.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -9497,7 +9456,6 @@ parse.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 parse.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 parse.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 parse.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-parse.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 parse.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 parse.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 parse.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -9724,7 +9682,6 @@ proc.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 proc.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 proc.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 proc.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-proc.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 proc.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 proc.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 proc.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -9926,7 +9883,6 @@ process.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 process.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 process.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 process.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-process.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 process.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 process.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 process.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -10120,7 +10076,6 @@ random.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 random.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 random.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 random.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-random.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 random.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 random.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 random.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -10308,7 +10263,6 @@ range.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 range.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 range.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 range.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-range.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 range.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 range.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 range.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -10490,7 +10444,6 @@ rational.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 rational.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 rational.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 rational.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-rational.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 rational.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 rational.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 rational.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -10668,7 +10621,6 @@ re.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 re.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 re.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 re.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-re.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 re.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 re.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 re.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -10840,7 +10792,6 @@ regcomp.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 regcomp.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 regcomp.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 regcomp.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-regcomp.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 regcomp.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 regcomp.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 regcomp.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -11005,7 +10956,6 @@ regenc.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 regenc.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 regenc.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 regenc.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-regenc.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 regenc.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 regenc.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 regenc.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -11169,7 +11119,6 @@ regerror.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 regerror.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 regerror.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 regerror.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-regerror.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 regerror.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 regerror.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 regerror.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -11333,7 +11282,6 @@ regexec.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 regexec.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 regexec.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 regexec.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-regexec.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 regexec.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 regexec.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 regexec.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -11497,7 +11445,6 @@ regparse.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 regparse.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 regparse.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 regparse.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-regparse.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 regparse.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 regparse.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 regparse.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -11662,7 +11609,6 @@ regsyntax.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 regsyntax.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 regsyntax.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 regsyntax.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-regsyntax.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 regsyntax.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 regsyntax.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 regsyntax.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -11864,7 +11810,6 @@ ruby.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 ruby.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 ruby.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 ruby.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-ruby.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 ruby.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 ruby.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 ruby.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -12048,7 +11993,6 @@ setproctitle.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 setproctitle.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 setproctitle.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 setproctitle.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-setproctitle.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 setproctitle.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 setproctitle.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 setproctitle.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -12228,7 +12172,6 @@ signal.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 signal.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 signal.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 signal.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-signal.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 signal.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 signal.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 signal.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -12420,7 +12363,6 @@ sprintf.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 sprintf.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 sprintf.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 sprintf.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-sprintf.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 sprintf.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 sprintf.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 sprintf.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -12596,7 +12538,6 @@ st.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 st.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 st.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 st.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-st.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 st.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 st.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 st.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -12765,7 +12706,6 @@ strftime.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 strftime.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 strftime.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 strftime.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-strftime.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 strftime.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 strftime.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 strftime.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -12952,7 +12892,6 @@ string.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 string.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 string.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 string.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-string.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 string.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 string.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 string.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -13176,7 +13115,6 @@ struct.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 struct.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 struct.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 struct.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-struct.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 struct.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 struct.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 struct.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -13365,7 +13303,6 @@ symbol.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 symbol.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 symbol.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 symbol.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-symbol.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 symbol.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 symbol.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 symbol.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -13563,7 +13500,6 @@ thread.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 thread.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 thread.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 thread.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-thread.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 thread.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 thread.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 thread.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -13767,7 +13703,6 @@ time.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 time.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 time.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 time.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-time.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 time.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 time.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 time.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -13943,7 +13878,6 @@ transcode.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 transcode.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 transcode.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 transcode.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-transcode.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 transcode.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 transcode.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 transcode.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -14119,7 +14053,6 @@ transient_heap.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 transient_heap.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 transient_heap.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 transient_heap.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-transient_heap.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 transient_heap.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 transient_heap.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 transient_heap.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -14294,7 +14227,6 @@ util.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 util.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 util.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 util.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-util.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 util.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 util.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 util.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -14480,7 +14412,6 @@ variable.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 variable.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 variable.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 variable.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-variable.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 variable.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 variable.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 variable.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -14676,7 +14607,6 @@ version.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 version.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 version.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 version.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-version.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 version.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 version.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 version.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -14883,7 +14813,6 @@ vm.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 vm.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 vm.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 vm.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-vm.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 vm.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 vm.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 vm.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -15099,7 +15028,6 @@ vm_backtrace.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 vm_backtrace.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 vm_backtrace.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 vm_backtrace.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-vm_backtrace.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 vm_backtrace.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 vm_backtrace.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 vm_backtrace.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -15291,7 +15219,6 @@ vm_dump.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 vm_dump.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 vm_dump.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 vm_dump.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-vm_dump.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 vm_dump.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 vm_dump.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 vm_dump.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
@@ -15482,7 +15409,6 @@ vm_trace.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 vm_trace.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 vm_trace.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 vm_trace.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-vm_trace.$(OBJEXT): {$(VPATH)}backward/2/r_cast.h
 vm_trace.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 vm_trace.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 vm_trace.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h

--- a/enc/depend
+++ b/enc/depend
@@ -330,7 +330,6 @@ enc/ascii.$(OBJEXT): backward/2/gcc_version_since.h
 enc/ascii.$(OBJEXT): backward/2/inttypes.h
 enc/ascii.$(OBJEXT): backward/2/limits.h
 enc/ascii.$(OBJEXT): backward/2/long_long.h
-enc/ascii.$(OBJEXT): backward/2/r_cast.h
 enc/ascii.$(OBJEXT): backward/2/rmodule.h
 enc/ascii.$(OBJEXT): backward/2/stdalign.h
 enc/ascii.$(OBJEXT): backward/2/stdarg.h
@@ -555,7 +554,6 @@ enc/cesu_8.$(OBJEXT): backward/2/gcc_version_since.h
 enc/cesu_8.$(OBJEXT): backward/2/inttypes.h
 enc/cesu_8.$(OBJEXT): backward/2/limits.h
 enc/cesu_8.$(OBJEXT): backward/2/long_long.h
-enc/cesu_8.$(OBJEXT): backward/2/r_cast.h
 enc/cesu_8.$(OBJEXT): backward/2/rmodule.h
 enc/cesu_8.$(OBJEXT): backward/2/stdalign.h
 enc/cesu_8.$(OBJEXT): backward/2/stdarg.h
@@ -839,7 +837,6 @@ enc/encdb.$(OBJEXT): backward/2/gcc_version_since.h
 enc/encdb.$(OBJEXT): backward/2/inttypes.h
 enc/encdb.$(OBJEXT): backward/2/limits.h
 enc/encdb.$(OBJEXT): backward/2/long_long.h
-enc/encdb.$(OBJEXT): backward/2/r_cast.h
 enc/encdb.$(OBJEXT): backward/2/rmodule.h
 enc/encdb.$(OBJEXT): backward/2/stdalign.h
 enc/encdb.$(OBJEXT): backward/2/stdarg.h
@@ -2413,7 +2410,6 @@ enc/trans/big5.$(OBJEXT): backward/2/gcc_version_since.h
 enc/trans/big5.$(OBJEXT): backward/2/inttypes.h
 enc/trans/big5.$(OBJEXT): backward/2/limits.h
 enc/trans/big5.$(OBJEXT): backward/2/long_long.h
-enc/trans/big5.$(OBJEXT): backward/2/r_cast.h
 enc/trans/big5.$(OBJEXT): backward/2/rmodule.h
 enc/trans/big5.$(OBJEXT): backward/2/stdalign.h
 enc/trans/big5.$(OBJEXT): backward/2/stdarg.h
@@ -2576,7 +2572,6 @@ enc/trans/cesu_8.$(OBJEXT): backward/2/gcc_version_since.h
 enc/trans/cesu_8.$(OBJEXT): backward/2/inttypes.h
 enc/trans/cesu_8.$(OBJEXT): backward/2/limits.h
 enc/trans/cesu_8.$(OBJEXT): backward/2/long_long.h
-enc/trans/cesu_8.$(OBJEXT): backward/2/r_cast.h
 enc/trans/cesu_8.$(OBJEXT): backward/2/rmodule.h
 enc/trans/cesu_8.$(OBJEXT): backward/2/stdalign.h
 enc/trans/cesu_8.$(OBJEXT): backward/2/stdarg.h
@@ -2739,7 +2734,6 @@ enc/trans/chinese.$(OBJEXT): backward/2/gcc_version_since.h
 enc/trans/chinese.$(OBJEXT): backward/2/inttypes.h
 enc/trans/chinese.$(OBJEXT): backward/2/limits.h
 enc/trans/chinese.$(OBJEXT): backward/2/long_long.h
-enc/trans/chinese.$(OBJEXT): backward/2/r_cast.h
 enc/trans/chinese.$(OBJEXT): backward/2/rmodule.h
 enc/trans/chinese.$(OBJEXT): backward/2/stdalign.h
 enc/trans/chinese.$(OBJEXT): backward/2/stdarg.h
@@ -2902,7 +2896,6 @@ enc/trans/ebcdic.$(OBJEXT): backward/2/gcc_version_since.h
 enc/trans/ebcdic.$(OBJEXT): backward/2/inttypes.h
 enc/trans/ebcdic.$(OBJEXT): backward/2/limits.h
 enc/trans/ebcdic.$(OBJEXT): backward/2/long_long.h
-enc/trans/ebcdic.$(OBJEXT): backward/2/r_cast.h
 enc/trans/ebcdic.$(OBJEXT): backward/2/rmodule.h
 enc/trans/ebcdic.$(OBJEXT): backward/2/stdalign.h
 enc/trans/ebcdic.$(OBJEXT): backward/2/stdarg.h
@@ -3065,7 +3058,6 @@ enc/trans/emoji.$(OBJEXT): backward/2/gcc_version_since.h
 enc/trans/emoji.$(OBJEXT): backward/2/inttypes.h
 enc/trans/emoji.$(OBJEXT): backward/2/limits.h
 enc/trans/emoji.$(OBJEXT): backward/2/long_long.h
-enc/trans/emoji.$(OBJEXT): backward/2/r_cast.h
 enc/trans/emoji.$(OBJEXT): backward/2/rmodule.h
 enc/trans/emoji.$(OBJEXT): backward/2/stdalign.h
 enc/trans/emoji.$(OBJEXT): backward/2/stdarg.h
@@ -3228,7 +3220,6 @@ enc/trans/emoji_iso2022_kddi.$(OBJEXT): backward/2/gcc_version_since.h
 enc/trans/emoji_iso2022_kddi.$(OBJEXT): backward/2/inttypes.h
 enc/trans/emoji_iso2022_kddi.$(OBJEXT): backward/2/limits.h
 enc/trans/emoji_iso2022_kddi.$(OBJEXT): backward/2/long_long.h
-enc/trans/emoji_iso2022_kddi.$(OBJEXT): backward/2/r_cast.h
 enc/trans/emoji_iso2022_kddi.$(OBJEXT): backward/2/rmodule.h
 enc/trans/emoji_iso2022_kddi.$(OBJEXT): backward/2/stdalign.h
 enc/trans/emoji_iso2022_kddi.$(OBJEXT): backward/2/stdarg.h
@@ -3391,7 +3382,6 @@ enc/trans/emoji_sjis_docomo.$(OBJEXT): backward/2/gcc_version_since.h
 enc/trans/emoji_sjis_docomo.$(OBJEXT): backward/2/inttypes.h
 enc/trans/emoji_sjis_docomo.$(OBJEXT): backward/2/limits.h
 enc/trans/emoji_sjis_docomo.$(OBJEXT): backward/2/long_long.h
-enc/trans/emoji_sjis_docomo.$(OBJEXT): backward/2/r_cast.h
 enc/trans/emoji_sjis_docomo.$(OBJEXT): backward/2/rmodule.h
 enc/trans/emoji_sjis_docomo.$(OBJEXT): backward/2/stdalign.h
 enc/trans/emoji_sjis_docomo.$(OBJEXT): backward/2/stdarg.h
@@ -3554,7 +3544,6 @@ enc/trans/emoji_sjis_kddi.$(OBJEXT): backward/2/gcc_version_since.h
 enc/trans/emoji_sjis_kddi.$(OBJEXT): backward/2/inttypes.h
 enc/trans/emoji_sjis_kddi.$(OBJEXT): backward/2/limits.h
 enc/trans/emoji_sjis_kddi.$(OBJEXT): backward/2/long_long.h
-enc/trans/emoji_sjis_kddi.$(OBJEXT): backward/2/r_cast.h
 enc/trans/emoji_sjis_kddi.$(OBJEXT): backward/2/rmodule.h
 enc/trans/emoji_sjis_kddi.$(OBJEXT): backward/2/stdalign.h
 enc/trans/emoji_sjis_kddi.$(OBJEXT): backward/2/stdarg.h
@@ -3717,7 +3706,6 @@ enc/trans/emoji_sjis_softbank.$(OBJEXT): backward/2/gcc_version_since.h
 enc/trans/emoji_sjis_softbank.$(OBJEXT): backward/2/inttypes.h
 enc/trans/emoji_sjis_softbank.$(OBJEXT): backward/2/limits.h
 enc/trans/emoji_sjis_softbank.$(OBJEXT): backward/2/long_long.h
-enc/trans/emoji_sjis_softbank.$(OBJEXT): backward/2/r_cast.h
 enc/trans/emoji_sjis_softbank.$(OBJEXT): backward/2/rmodule.h
 enc/trans/emoji_sjis_softbank.$(OBJEXT): backward/2/stdalign.h
 enc/trans/emoji_sjis_softbank.$(OBJEXT): backward/2/stdarg.h
@@ -3880,7 +3868,6 @@ enc/trans/escape.$(OBJEXT): backward/2/gcc_version_since.h
 enc/trans/escape.$(OBJEXT): backward/2/inttypes.h
 enc/trans/escape.$(OBJEXT): backward/2/limits.h
 enc/trans/escape.$(OBJEXT): backward/2/long_long.h
-enc/trans/escape.$(OBJEXT): backward/2/r_cast.h
 enc/trans/escape.$(OBJEXT): backward/2/rmodule.h
 enc/trans/escape.$(OBJEXT): backward/2/stdalign.h
 enc/trans/escape.$(OBJEXT): backward/2/stdarg.h
@@ -4043,7 +4030,6 @@ enc/trans/gb18030.$(OBJEXT): backward/2/gcc_version_since.h
 enc/trans/gb18030.$(OBJEXT): backward/2/inttypes.h
 enc/trans/gb18030.$(OBJEXT): backward/2/limits.h
 enc/trans/gb18030.$(OBJEXT): backward/2/long_long.h
-enc/trans/gb18030.$(OBJEXT): backward/2/r_cast.h
 enc/trans/gb18030.$(OBJEXT): backward/2/rmodule.h
 enc/trans/gb18030.$(OBJEXT): backward/2/stdalign.h
 enc/trans/gb18030.$(OBJEXT): backward/2/stdarg.h
@@ -4206,7 +4192,6 @@ enc/trans/gbk.$(OBJEXT): backward/2/gcc_version_since.h
 enc/trans/gbk.$(OBJEXT): backward/2/inttypes.h
 enc/trans/gbk.$(OBJEXT): backward/2/limits.h
 enc/trans/gbk.$(OBJEXT): backward/2/long_long.h
-enc/trans/gbk.$(OBJEXT): backward/2/r_cast.h
 enc/trans/gbk.$(OBJEXT): backward/2/rmodule.h
 enc/trans/gbk.$(OBJEXT): backward/2/stdalign.h
 enc/trans/gbk.$(OBJEXT): backward/2/stdarg.h
@@ -4369,7 +4354,6 @@ enc/trans/iso2022.$(OBJEXT): backward/2/gcc_version_since.h
 enc/trans/iso2022.$(OBJEXT): backward/2/inttypes.h
 enc/trans/iso2022.$(OBJEXT): backward/2/limits.h
 enc/trans/iso2022.$(OBJEXT): backward/2/long_long.h
-enc/trans/iso2022.$(OBJEXT): backward/2/r_cast.h
 enc/trans/iso2022.$(OBJEXT): backward/2/rmodule.h
 enc/trans/iso2022.$(OBJEXT): backward/2/stdalign.h
 enc/trans/iso2022.$(OBJEXT): backward/2/stdarg.h
@@ -4532,7 +4516,6 @@ enc/trans/japanese.$(OBJEXT): backward/2/gcc_version_since.h
 enc/trans/japanese.$(OBJEXT): backward/2/inttypes.h
 enc/trans/japanese.$(OBJEXT): backward/2/limits.h
 enc/trans/japanese.$(OBJEXT): backward/2/long_long.h
-enc/trans/japanese.$(OBJEXT): backward/2/r_cast.h
 enc/trans/japanese.$(OBJEXT): backward/2/rmodule.h
 enc/trans/japanese.$(OBJEXT): backward/2/stdalign.h
 enc/trans/japanese.$(OBJEXT): backward/2/stdarg.h
@@ -4695,7 +4678,6 @@ enc/trans/japanese_euc.$(OBJEXT): backward/2/gcc_version_since.h
 enc/trans/japanese_euc.$(OBJEXT): backward/2/inttypes.h
 enc/trans/japanese_euc.$(OBJEXT): backward/2/limits.h
 enc/trans/japanese_euc.$(OBJEXT): backward/2/long_long.h
-enc/trans/japanese_euc.$(OBJEXT): backward/2/r_cast.h
 enc/trans/japanese_euc.$(OBJEXT): backward/2/rmodule.h
 enc/trans/japanese_euc.$(OBJEXT): backward/2/stdalign.h
 enc/trans/japanese_euc.$(OBJEXT): backward/2/stdarg.h
@@ -4858,7 +4840,6 @@ enc/trans/japanese_sjis.$(OBJEXT): backward/2/gcc_version_since.h
 enc/trans/japanese_sjis.$(OBJEXT): backward/2/inttypes.h
 enc/trans/japanese_sjis.$(OBJEXT): backward/2/limits.h
 enc/trans/japanese_sjis.$(OBJEXT): backward/2/long_long.h
-enc/trans/japanese_sjis.$(OBJEXT): backward/2/r_cast.h
 enc/trans/japanese_sjis.$(OBJEXT): backward/2/rmodule.h
 enc/trans/japanese_sjis.$(OBJEXT): backward/2/stdalign.h
 enc/trans/japanese_sjis.$(OBJEXT): backward/2/stdarg.h
@@ -5021,7 +5002,6 @@ enc/trans/korean.$(OBJEXT): backward/2/gcc_version_since.h
 enc/trans/korean.$(OBJEXT): backward/2/inttypes.h
 enc/trans/korean.$(OBJEXT): backward/2/limits.h
 enc/trans/korean.$(OBJEXT): backward/2/long_long.h
-enc/trans/korean.$(OBJEXT): backward/2/r_cast.h
 enc/trans/korean.$(OBJEXT): backward/2/rmodule.h
 enc/trans/korean.$(OBJEXT): backward/2/stdalign.h
 enc/trans/korean.$(OBJEXT): backward/2/stdarg.h
@@ -5183,7 +5163,6 @@ enc/trans/newline.$(OBJEXT): backward/2/gcc_version_since.h
 enc/trans/newline.$(OBJEXT): backward/2/inttypes.h
 enc/trans/newline.$(OBJEXT): backward/2/limits.h
 enc/trans/newline.$(OBJEXT): backward/2/long_long.h
-enc/trans/newline.$(OBJEXT): backward/2/r_cast.h
 enc/trans/newline.$(OBJEXT): backward/2/rmodule.h
 enc/trans/newline.$(OBJEXT): backward/2/stdalign.h
 enc/trans/newline.$(OBJEXT): backward/2/stdarg.h
@@ -5346,7 +5325,6 @@ enc/trans/single_byte.$(OBJEXT): backward/2/gcc_version_since.h
 enc/trans/single_byte.$(OBJEXT): backward/2/inttypes.h
 enc/trans/single_byte.$(OBJEXT): backward/2/limits.h
 enc/trans/single_byte.$(OBJEXT): backward/2/long_long.h
-enc/trans/single_byte.$(OBJEXT): backward/2/r_cast.h
 enc/trans/single_byte.$(OBJEXT): backward/2/rmodule.h
 enc/trans/single_byte.$(OBJEXT): backward/2/stdalign.h
 enc/trans/single_byte.$(OBJEXT): backward/2/stdarg.h
@@ -5511,7 +5489,6 @@ enc/trans/utf8_mac.$(OBJEXT): backward/2/gcc_version_since.h
 enc/trans/utf8_mac.$(OBJEXT): backward/2/inttypes.h
 enc/trans/utf8_mac.$(OBJEXT): backward/2/limits.h
 enc/trans/utf8_mac.$(OBJEXT): backward/2/long_long.h
-enc/trans/utf8_mac.$(OBJEXT): backward/2/r_cast.h
 enc/trans/utf8_mac.$(OBJEXT): backward/2/rmodule.h
 enc/trans/utf8_mac.$(OBJEXT): backward/2/stdalign.h
 enc/trans/utf8_mac.$(OBJEXT): backward/2/stdarg.h
@@ -5674,7 +5651,6 @@ enc/trans/utf_16_32.$(OBJEXT): backward/2/gcc_version_since.h
 enc/trans/utf_16_32.$(OBJEXT): backward/2/inttypes.h
 enc/trans/utf_16_32.$(OBJEXT): backward/2/limits.h
 enc/trans/utf_16_32.$(OBJEXT): backward/2/long_long.h
-enc/trans/utf_16_32.$(OBJEXT): backward/2/r_cast.h
 enc/trans/utf_16_32.$(OBJEXT): backward/2/rmodule.h
 enc/trans/utf_16_32.$(OBJEXT): backward/2/stdalign.h
 enc/trans/utf_16_32.$(OBJEXT): backward/2/stdarg.h
@@ -5839,7 +5815,6 @@ enc/unicode.$(OBJEXT): backward/2/gcc_version_since.h
 enc/unicode.$(OBJEXT): backward/2/inttypes.h
 enc/unicode.$(OBJEXT): backward/2/limits.h
 enc/unicode.$(OBJEXT): backward/2/long_long.h
-enc/unicode.$(OBJEXT): backward/2/r_cast.h
 enc/unicode.$(OBJEXT): backward/2/rmodule.h
 enc/unicode.$(OBJEXT): backward/2/stdalign.h
 enc/unicode.$(OBJEXT): backward/2/stdarg.h
@@ -6003,7 +5978,6 @@ enc/us_ascii.$(OBJEXT): backward/2/gcc_version_since.h
 enc/us_ascii.$(OBJEXT): backward/2/inttypes.h
 enc/us_ascii.$(OBJEXT): backward/2/limits.h
 enc/us_ascii.$(OBJEXT): backward/2/long_long.h
-enc/us_ascii.$(OBJEXT): backward/2/r_cast.h
 enc/us_ascii.$(OBJEXT): backward/2/rmodule.h
 enc/us_ascii.$(OBJEXT): backward/2/stdalign.h
 enc/us_ascii.$(OBJEXT): backward/2/stdarg.h
@@ -6405,7 +6379,6 @@ enc/utf_8.$(OBJEXT): backward/2/gcc_version_since.h
 enc/utf_8.$(OBJEXT): backward/2/inttypes.h
 enc/utf_8.$(OBJEXT): backward/2/limits.h
 enc/utf_8.$(OBJEXT): backward/2/long_long.h
-enc/utf_8.$(OBJEXT): backward/2/r_cast.h
 enc/utf_8.$(OBJEXT): backward/2/rmodule.h
 enc/utf_8.$(OBJEXT): backward/2/stdalign.h
 enc/utf_8.$(OBJEXT): backward/2/stdarg.h

--- a/ext/-test-/arith_seq/extract/depend
+++ b/ext/-test-/arith_seq/extract/depend
@@ -151,7 +151,6 @@ extract.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 extract.o: $(hdrdir)/ruby/backward/2/inttypes.h
 extract.o: $(hdrdir)/ruby/backward/2/limits.h
 extract.o: $(hdrdir)/ruby/backward/2/long_long.h
-extract.o: $(hdrdir)/ruby/backward/2/r_cast.h
 extract.o: $(hdrdir)/ruby/backward/2/rmodule.h
 extract.o: $(hdrdir)/ruby/backward/2/stdalign.h
 extract.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/-test-/array/resize/depend
+++ b/ext/-test-/array/resize/depend
@@ -151,7 +151,6 @@ resize.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 resize.o: $(hdrdir)/ruby/backward/2/inttypes.h
 resize.o: $(hdrdir)/ruby/backward/2/limits.h
 resize.o: $(hdrdir)/ruby/backward/2/long_long.h
-resize.o: $(hdrdir)/ruby/backward/2/r_cast.h
 resize.o: $(hdrdir)/ruby/backward/2/rmodule.h
 resize.o: $(hdrdir)/ruby/backward/2/stdalign.h
 resize.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/-test-/bignum/depend
+++ b/ext/-test-/bignum/depend
@@ -152,7 +152,6 @@ big2str.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 big2str.o: $(hdrdir)/ruby/backward/2/inttypes.h
 big2str.o: $(hdrdir)/ruby/backward/2/limits.h
 big2str.o: $(hdrdir)/ruby/backward/2/long_long.h
-big2str.o: $(hdrdir)/ruby/backward/2/r_cast.h
 big2str.o: $(hdrdir)/ruby/backward/2/rmodule.h
 big2str.o: $(hdrdir)/ruby/backward/2/stdalign.h
 big2str.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -318,7 +317,6 @@ bigzero.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 bigzero.o: $(hdrdir)/ruby/backward/2/inttypes.h
 bigzero.o: $(hdrdir)/ruby/backward/2/limits.h
 bigzero.o: $(hdrdir)/ruby/backward/2/long_long.h
-bigzero.o: $(hdrdir)/ruby/backward/2/r_cast.h
 bigzero.o: $(hdrdir)/ruby/backward/2/rmodule.h
 bigzero.o: $(hdrdir)/ruby/backward/2/stdalign.h
 bigzero.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -484,7 +482,6 @@ div.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 div.o: $(hdrdir)/ruby/backward/2/inttypes.h
 div.o: $(hdrdir)/ruby/backward/2/limits.h
 div.o: $(hdrdir)/ruby/backward/2/long_long.h
-div.o: $(hdrdir)/ruby/backward/2/r_cast.h
 div.o: $(hdrdir)/ruby/backward/2/rmodule.h
 div.o: $(hdrdir)/ruby/backward/2/stdalign.h
 div.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -650,7 +647,6 @@ init.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 init.o: $(hdrdir)/ruby/backward/2/inttypes.h
 init.o: $(hdrdir)/ruby/backward/2/limits.h
 init.o: $(hdrdir)/ruby/backward/2/long_long.h
-init.o: $(hdrdir)/ruby/backward/2/r_cast.h
 init.o: $(hdrdir)/ruby/backward/2/rmodule.h
 init.o: $(hdrdir)/ruby/backward/2/stdalign.h
 init.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -814,7 +810,6 @@ intpack.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 intpack.o: $(hdrdir)/ruby/backward/2/inttypes.h
 intpack.o: $(hdrdir)/ruby/backward/2/limits.h
 intpack.o: $(hdrdir)/ruby/backward/2/long_long.h
-intpack.o: $(hdrdir)/ruby/backward/2/r_cast.h
 intpack.o: $(hdrdir)/ruby/backward/2/rmodule.h
 intpack.o: $(hdrdir)/ruby/backward/2/stdalign.h
 intpack.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -980,7 +975,6 @@ mul.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 mul.o: $(hdrdir)/ruby/backward/2/inttypes.h
 mul.o: $(hdrdir)/ruby/backward/2/limits.h
 mul.o: $(hdrdir)/ruby/backward/2/long_long.h
-mul.o: $(hdrdir)/ruby/backward/2/r_cast.h
 mul.o: $(hdrdir)/ruby/backward/2/rmodule.h
 mul.o: $(hdrdir)/ruby/backward/2/stdalign.h
 mul.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -1146,7 +1140,6 @@ str2big.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 str2big.o: $(hdrdir)/ruby/backward/2/inttypes.h
 str2big.o: $(hdrdir)/ruby/backward/2/limits.h
 str2big.o: $(hdrdir)/ruby/backward/2/long_long.h
-str2big.o: $(hdrdir)/ruby/backward/2/r_cast.h
 str2big.o: $(hdrdir)/ruby/backward/2/rmodule.h
 str2big.o: $(hdrdir)/ruby/backward/2/stdalign.h
 str2big.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/-test-/bug-14834/depend
+++ b/ext/-test-/bug-14834/depend
@@ -151,7 +151,6 @@ bug-14384.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 bug-14384.o: $(hdrdir)/ruby/backward/2/inttypes.h
 bug-14384.o: $(hdrdir)/ruby/backward/2/limits.h
 bug-14384.o: $(hdrdir)/ruby/backward/2/long_long.h
-bug-14384.o: $(hdrdir)/ruby/backward/2/r_cast.h
 bug-14384.o: $(hdrdir)/ruby/backward/2/rmodule.h
 bug-14384.o: $(hdrdir)/ruby/backward/2/stdalign.h
 bug-14384.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/-test-/bug-3571/depend
+++ b/ext/-test-/bug-3571/depend
@@ -152,7 +152,6 @@ bug.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 bug.o: $(hdrdir)/ruby/backward/2/inttypes.h
 bug.o: $(hdrdir)/ruby/backward/2/limits.h
 bug.o: $(hdrdir)/ruby/backward/2/long_long.h
-bug.o: $(hdrdir)/ruby/backward/2/r_cast.h
 bug.o: $(hdrdir)/ruby/backward/2/rmodule.h
 bug.o: $(hdrdir)/ruby/backward/2/stdalign.h
 bug.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/-test-/bug-5832/depend
+++ b/ext/-test-/bug-5832/depend
@@ -152,7 +152,6 @@ bug.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 bug.o: $(hdrdir)/ruby/backward/2/inttypes.h
 bug.o: $(hdrdir)/ruby/backward/2/limits.h
 bug.o: $(hdrdir)/ruby/backward/2/long_long.h
-bug.o: $(hdrdir)/ruby/backward/2/r_cast.h
 bug.o: $(hdrdir)/ruby/backward/2/rmodule.h
 bug.o: $(hdrdir)/ruby/backward/2/stdalign.h
 bug.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/-test-/bug_reporter/depend
+++ b/ext/-test-/bug_reporter/depend
@@ -152,7 +152,6 @@ bug_reporter.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 bug_reporter.o: $(hdrdir)/ruby/backward/2/inttypes.h
 bug_reporter.o: $(hdrdir)/ruby/backward/2/limits.h
 bug_reporter.o: $(hdrdir)/ruby/backward/2/long_long.h
-bug_reporter.o: $(hdrdir)/ruby/backward/2/r_cast.h
 bug_reporter.o: $(hdrdir)/ruby/backward/2/rmodule.h
 bug_reporter.o: $(hdrdir)/ruby/backward/2/stdalign.h
 bug_reporter.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/-test-/class/depend
+++ b/ext/-test-/class/depend
@@ -151,7 +151,6 @@ class2name.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 class2name.o: $(hdrdir)/ruby/backward/2/inttypes.h
 class2name.o: $(hdrdir)/ruby/backward/2/limits.h
 class2name.o: $(hdrdir)/ruby/backward/2/long_long.h
-class2name.o: $(hdrdir)/ruby/backward/2/r_cast.h
 class2name.o: $(hdrdir)/ruby/backward/2/rmodule.h
 class2name.o: $(hdrdir)/ruby/backward/2/stdalign.h
 class2name.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -315,7 +314,6 @@ init.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 init.o: $(hdrdir)/ruby/backward/2/inttypes.h
 init.o: $(hdrdir)/ruby/backward/2/limits.h
 init.o: $(hdrdir)/ruby/backward/2/long_long.h
-init.o: $(hdrdir)/ruby/backward/2/r_cast.h
 init.o: $(hdrdir)/ruby/backward/2/rmodule.h
 init.o: $(hdrdir)/ruby/backward/2/stdalign.h
 init.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/-test-/debug/depend
+++ b/ext/-test-/debug/depend
@@ -152,7 +152,6 @@ init.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 init.o: $(hdrdir)/ruby/backward/2/inttypes.h
 init.o: $(hdrdir)/ruby/backward/2/limits.h
 init.o: $(hdrdir)/ruby/backward/2/long_long.h
-init.o: $(hdrdir)/ruby/backward/2/r_cast.h
 init.o: $(hdrdir)/ruby/backward/2/rmodule.h
 init.o: $(hdrdir)/ruby/backward/2/stdalign.h
 init.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -315,7 +314,6 @@ inspector.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 inspector.o: $(hdrdir)/ruby/backward/2/inttypes.h
 inspector.o: $(hdrdir)/ruby/backward/2/limits.h
 inspector.o: $(hdrdir)/ruby/backward/2/long_long.h
-inspector.o: $(hdrdir)/ruby/backward/2/r_cast.h
 inspector.o: $(hdrdir)/ruby/backward/2/rmodule.h
 inspector.o: $(hdrdir)/ruby/backward/2/stdalign.h
 inspector.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -479,7 +477,6 @@ profile_frames.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 profile_frames.o: $(hdrdir)/ruby/backward/2/inttypes.h
 profile_frames.o: $(hdrdir)/ruby/backward/2/limits.h
 profile_frames.o: $(hdrdir)/ruby/backward/2/long_long.h
-profile_frames.o: $(hdrdir)/ruby/backward/2/r_cast.h
 profile_frames.o: $(hdrdir)/ruby/backward/2/rmodule.h
 profile_frames.o: $(hdrdir)/ruby/backward/2/stdalign.h
 profile_frames.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/-test-/enumerator_kw/depend
+++ b/ext/-test-/enumerator_kw/depend
@@ -152,7 +152,6 @@ enumerator_kw.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 enumerator_kw.o: $(hdrdir)/ruby/backward/2/inttypes.h
 enumerator_kw.o: $(hdrdir)/ruby/backward/2/limits.h
 enumerator_kw.o: $(hdrdir)/ruby/backward/2/long_long.h
-enumerator_kw.o: $(hdrdir)/ruby/backward/2/r_cast.h
 enumerator_kw.o: $(hdrdir)/ruby/backward/2/rmodule.h
 enumerator_kw.o: $(hdrdir)/ruby/backward/2/stdalign.h
 enumerator_kw.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/-test-/exception/depend
+++ b/ext/-test-/exception/depend
@@ -151,7 +151,6 @@ dataerror.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 dataerror.o: $(hdrdir)/ruby/backward/2/inttypes.h
 dataerror.o: $(hdrdir)/ruby/backward/2/limits.h
 dataerror.o: $(hdrdir)/ruby/backward/2/long_long.h
-dataerror.o: $(hdrdir)/ruby/backward/2/r_cast.h
 dataerror.o: $(hdrdir)/ruby/backward/2/rmodule.h
 dataerror.o: $(hdrdir)/ruby/backward/2/stdalign.h
 dataerror.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -315,7 +314,6 @@ enc_raise.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 enc_raise.o: $(hdrdir)/ruby/backward/2/inttypes.h
 enc_raise.o: $(hdrdir)/ruby/backward/2/limits.h
 enc_raise.o: $(hdrdir)/ruby/backward/2/long_long.h
-enc_raise.o: $(hdrdir)/ruby/backward/2/r_cast.h
 enc_raise.o: $(hdrdir)/ruby/backward/2/rmodule.h
 enc_raise.o: $(hdrdir)/ruby/backward/2/stdalign.h
 enc_raise.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -482,7 +480,6 @@ ensured.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ensured.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ensured.o: $(hdrdir)/ruby/backward/2/limits.h
 ensured.o: $(hdrdir)/ruby/backward/2/long_long.h
-ensured.o: $(hdrdir)/ruby/backward/2/r_cast.h
 ensured.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ensured.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ensured.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -646,7 +643,6 @@ init.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 init.o: $(hdrdir)/ruby/backward/2/inttypes.h
 init.o: $(hdrdir)/ruby/backward/2/limits.h
 init.o: $(hdrdir)/ruby/backward/2/long_long.h
-init.o: $(hdrdir)/ruby/backward/2/r_cast.h
 init.o: $(hdrdir)/ruby/backward/2/rmodule.h
 init.o: $(hdrdir)/ruby/backward/2/stdalign.h
 init.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/-test-/fatal/depend
+++ b/ext/-test-/fatal/depend
@@ -152,7 +152,6 @@ rb_fatal.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 rb_fatal.o: $(hdrdir)/ruby/backward/2/inttypes.h
 rb_fatal.o: $(hdrdir)/ruby/backward/2/limits.h
 rb_fatal.o: $(hdrdir)/ruby/backward/2/long_long.h
-rb_fatal.o: $(hdrdir)/ruby/backward/2/r_cast.h
 rb_fatal.o: $(hdrdir)/ruby/backward/2/rmodule.h
 rb_fatal.o: $(hdrdir)/ruby/backward/2/stdalign.h
 rb_fatal.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/-test-/file/depend
+++ b/ext/-test-/file/depend
@@ -151,7 +151,6 @@ fs.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 fs.o: $(hdrdir)/ruby/backward/2/inttypes.h
 fs.o: $(hdrdir)/ruby/backward/2/limits.h
 fs.o: $(hdrdir)/ruby/backward/2/long_long.h
-fs.o: $(hdrdir)/ruby/backward/2/r_cast.h
 fs.o: $(hdrdir)/ruby/backward/2/rmodule.h
 fs.o: $(hdrdir)/ruby/backward/2/stdalign.h
 fs.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -319,7 +318,6 @@ init.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 init.o: $(hdrdir)/ruby/backward/2/inttypes.h
 init.o: $(hdrdir)/ruby/backward/2/limits.h
 init.o: $(hdrdir)/ruby/backward/2/long_long.h
-init.o: $(hdrdir)/ruby/backward/2/r_cast.h
 init.o: $(hdrdir)/ruby/backward/2/rmodule.h
 init.o: $(hdrdir)/ruby/backward/2/stdalign.h
 init.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -482,7 +480,6 @@ stat.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 stat.o: $(hdrdir)/ruby/backward/2/inttypes.h
 stat.o: $(hdrdir)/ruby/backward/2/limits.h
 stat.o: $(hdrdir)/ruby/backward/2/long_long.h
-stat.o: $(hdrdir)/ruby/backward/2/r_cast.h
 stat.o: $(hdrdir)/ruby/backward/2/rmodule.h
 stat.o: $(hdrdir)/ruby/backward/2/stdalign.h
 stat.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/-test-/float/depend
+++ b/ext/-test-/float/depend
@@ -155,7 +155,6 @@ init.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 init.o: $(hdrdir)/ruby/backward/2/inttypes.h
 init.o: $(hdrdir)/ruby/backward/2/limits.h
 init.o: $(hdrdir)/ruby/backward/2/long_long.h
-init.o: $(hdrdir)/ruby/backward/2/r_cast.h
 init.o: $(hdrdir)/ruby/backward/2/rmodule.h
 init.o: $(hdrdir)/ruby/backward/2/stdalign.h
 init.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -319,7 +318,6 @@ nextafter.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 nextafter.o: $(hdrdir)/ruby/backward/2/inttypes.h
 nextafter.o: $(hdrdir)/ruby/backward/2/limits.h
 nextafter.o: $(hdrdir)/ruby/backward/2/long_long.h
-nextafter.o: $(hdrdir)/ruby/backward/2/r_cast.h
 nextafter.o: $(hdrdir)/ruby/backward/2/rmodule.h
 nextafter.o: $(hdrdir)/ruby/backward/2/stdalign.h
 nextafter.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/-test-/funcall/depend
+++ b/ext/-test-/funcall/depend
@@ -152,7 +152,6 @@ funcall.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 funcall.o: $(hdrdir)/ruby/backward/2/inttypes.h
 funcall.o: $(hdrdir)/ruby/backward/2/limits.h
 funcall.o: $(hdrdir)/ruby/backward/2/long_long.h
-funcall.o: $(hdrdir)/ruby/backward/2/r_cast.h
 funcall.o: $(hdrdir)/ruby/backward/2/rmodule.h
 funcall.o: $(hdrdir)/ruby/backward/2/stdalign.h
 funcall.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/-test-/gvl/call_without_gvl/depend
+++ b/ext/-test-/gvl/call_without_gvl/depend
@@ -151,7 +151,6 @@ call_without_gvl.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 call_without_gvl.o: $(hdrdir)/ruby/backward/2/inttypes.h
 call_without_gvl.o: $(hdrdir)/ruby/backward/2/limits.h
 call_without_gvl.o: $(hdrdir)/ruby/backward/2/long_long.h
-call_without_gvl.o: $(hdrdir)/ruby/backward/2/r_cast.h
 call_without_gvl.o: $(hdrdir)/ruby/backward/2/rmodule.h
 call_without_gvl.o: $(hdrdir)/ruby/backward/2/stdalign.h
 call_without_gvl.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/-test-/hash/depend
+++ b/ext/-test-/hash/depend
@@ -152,7 +152,6 @@ delete.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 delete.o: $(hdrdir)/ruby/backward/2/inttypes.h
 delete.o: $(hdrdir)/ruby/backward/2/limits.h
 delete.o: $(hdrdir)/ruby/backward/2/long_long.h
-delete.o: $(hdrdir)/ruby/backward/2/r_cast.h
 delete.o: $(hdrdir)/ruby/backward/2/rmodule.h
 delete.o: $(hdrdir)/ruby/backward/2/stdalign.h
 delete.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -316,7 +315,6 @@ init.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 init.o: $(hdrdir)/ruby/backward/2/inttypes.h
 init.o: $(hdrdir)/ruby/backward/2/limits.h
 init.o: $(hdrdir)/ruby/backward/2/long_long.h
-init.o: $(hdrdir)/ruby/backward/2/r_cast.h
 init.o: $(hdrdir)/ruby/backward/2/rmodule.h
 init.o: $(hdrdir)/ruby/backward/2/stdalign.h
 init.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/-test-/integer/depend
+++ b/ext/-test-/integer/depend
@@ -152,7 +152,6 @@ core_ext.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 core_ext.o: $(hdrdir)/ruby/backward/2/inttypes.h
 core_ext.o: $(hdrdir)/ruby/backward/2/limits.h
 core_ext.o: $(hdrdir)/ruby/backward/2/long_long.h
-core_ext.o: $(hdrdir)/ruby/backward/2/r_cast.h
 core_ext.o: $(hdrdir)/ruby/backward/2/rmodule.h
 core_ext.o: $(hdrdir)/ruby/backward/2/stdalign.h
 core_ext.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -325,7 +324,6 @@ init.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 init.o: $(hdrdir)/ruby/backward/2/inttypes.h
 init.o: $(hdrdir)/ruby/backward/2/limits.h
 init.o: $(hdrdir)/ruby/backward/2/long_long.h
-init.o: $(hdrdir)/ruby/backward/2/r_cast.h
 init.o: $(hdrdir)/ruby/backward/2/rmodule.h
 init.o: $(hdrdir)/ruby/backward/2/stdalign.h
 init.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -489,7 +487,6 @@ my_integer.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 my_integer.o: $(hdrdir)/ruby/backward/2/inttypes.h
 my_integer.o: $(hdrdir)/ruby/backward/2/limits.h
 my_integer.o: $(hdrdir)/ruby/backward/2/long_long.h
-my_integer.o: $(hdrdir)/ruby/backward/2/r_cast.h
 my_integer.o: $(hdrdir)/ruby/backward/2/rmodule.h
 my_integer.o: $(hdrdir)/ruby/backward/2/stdalign.h
 my_integer.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/-test-/iseq_load/depend
+++ b/ext/-test-/iseq_load/depend
@@ -152,7 +152,6 @@ iseq_load.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 iseq_load.o: $(hdrdir)/ruby/backward/2/inttypes.h
 iseq_load.o: $(hdrdir)/ruby/backward/2/limits.h
 iseq_load.o: $(hdrdir)/ruby/backward/2/long_long.h
-iseq_load.o: $(hdrdir)/ruby/backward/2/r_cast.h
 iseq_load.o: $(hdrdir)/ruby/backward/2/rmodule.h
 iseq_load.o: $(hdrdir)/ruby/backward/2/stdalign.h
 iseq_load.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/-test-/iter/depend
+++ b/ext/-test-/iter/depend
@@ -152,7 +152,6 @@ break.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 break.o: $(hdrdir)/ruby/backward/2/inttypes.h
 break.o: $(hdrdir)/ruby/backward/2/limits.h
 break.o: $(hdrdir)/ruby/backward/2/long_long.h
-break.o: $(hdrdir)/ruby/backward/2/r_cast.h
 break.o: $(hdrdir)/ruby/backward/2/rmodule.h
 break.o: $(hdrdir)/ruby/backward/2/stdalign.h
 break.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -316,7 +315,6 @@ init.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 init.o: $(hdrdir)/ruby/backward/2/inttypes.h
 init.o: $(hdrdir)/ruby/backward/2/limits.h
 init.o: $(hdrdir)/ruby/backward/2/long_long.h
-init.o: $(hdrdir)/ruby/backward/2/r_cast.h
 init.o: $(hdrdir)/ruby/backward/2/rmodule.h
 init.o: $(hdrdir)/ruby/backward/2/stdalign.h
 init.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -480,7 +478,6 @@ yield.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 yield.o: $(hdrdir)/ruby/backward/2/inttypes.h
 yield.o: $(hdrdir)/ruby/backward/2/limits.h
 yield.o: $(hdrdir)/ruby/backward/2/long_long.h
-yield.o: $(hdrdir)/ruby/backward/2/r_cast.h
 yield.o: $(hdrdir)/ruby/backward/2/rmodule.h
 yield.o: $(hdrdir)/ruby/backward/2/stdalign.h
 yield.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/-test-/load/protect/depend
+++ b/ext/-test-/load/protect/depend
@@ -152,7 +152,6 @@ protect.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 protect.o: $(hdrdir)/ruby/backward/2/inttypes.h
 protect.o: $(hdrdir)/ruby/backward/2/limits.h
 protect.o: $(hdrdir)/ruby/backward/2/long_long.h
-protect.o: $(hdrdir)/ruby/backward/2/r_cast.h
 protect.o: $(hdrdir)/ruby/backward/2/rmodule.h
 protect.o: $(hdrdir)/ruby/backward/2/stdalign.h
 protect.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/-test-/marshal/compat/depend
+++ b/ext/-test-/marshal/compat/depend
@@ -152,7 +152,6 @@ usrcompat.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 usrcompat.o: $(hdrdir)/ruby/backward/2/inttypes.h
 usrcompat.o: $(hdrdir)/ruby/backward/2/limits.h
 usrcompat.o: $(hdrdir)/ruby/backward/2/long_long.h
-usrcompat.o: $(hdrdir)/ruby/backward/2/r_cast.h
 usrcompat.o: $(hdrdir)/ruby/backward/2/rmodule.h
 usrcompat.o: $(hdrdir)/ruby/backward/2/stdalign.h
 usrcompat.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/-test-/marshal/internal_ivar/depend
+++ b/ext/-test-/marshal/internal_ivar/depend
@@ -152,7 +152,6 @@ internal_ivar.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 internal_ivar.o: $(hdrdir)/ruby/backward/2/inttypes.h
 internal_ivar.o: $(hdrdir)/ruby/backward/2/limits.h
 internal_ivar.o: $(hdrdir)/ruby/backward/2/long_long.h
-internal_ivar.o: $(hdrdir)/ruby/backward/2/r_cast.h
 internal_ivar.o: $(hdrdir)/ruby/backward/2/rmodule.h
 internal_ivar.o: $(hdrdir)/ruby/backward/2/stdalign.h
 internal_ivar.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/-test-/marshal/usr/depend
+++ b/ext/-test-/marshal/usr/depend
@@ -152,7 +152,6 @@ usrmarshal.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 usrmarshal.o: $(hdrdir)/ruby/backward/2/inttypes.h
 usrmarshal.o: $(hdrdir)/ruby/backward/2/limits.h
 usrmarshal.o: $(hdrdir)/ruby/backward/2/long_long.h
-usrmarshal.o: $(hdrdir)/ruby/backward/2/r_cast.h
 usrmarshal.o: $(hdrdir)/ruby/backward/2/rmodule.h
 usrmarshal.o: $(hdrdir)/ruby/backward/2/stdalign.h
 usrmarshal.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/-test-/method/depend
+++ b/ext/-test-/method/depend
@@ -152,7 +152,6 @@ arity.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 arity.o: $(hdrdir)/ruby/backward/2/inttypes.h
 arity.o: $(hdrdir)/ruby/backward/2/limits.h
 arity.o: $(hdrdir)/ruby/backward/2/long_long.h
-arity.o: $(hdrdir)/ruby/backward/2/r_cast.h
 arity.o: $(hdrdir)/ruby/backward/2/rmodule.h
 arity.o: $(hdrdir)/ruby/backward/2/stdalign.h
 arity.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -316,7 +315,6 @@ init.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 init.o: $(hdrdir)/ruby/backward/2/inttypes.h
 init.o: $(hdrdir)/ruby/backward/2/limits.h
 init.o: $(hdrdir)/ruby/backward/2/long_long.h
-init.o: $(hdrdir)/ruby/backward/2/r_cast.h
 init.o: $(hdrdir)/ruby/backward/2/rmodule.h
 init.o: $(hdrdir)/ruby/backward/2/stdalign.h
 init.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/-test-/notimplement/depend
+++ b/ext/-test-/notimplement/depend
@@ -152,7 +152,6 @@ bug.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 bug.o: $(hdrdir)/ruby/backward/2/inttypes.h
 bug.o: $(hdrdir)/ruby/backward/2/limits.h
 bug.o: $(hdrdir)/ruby/backward/2/long_long.h
-bug.o: $(hdrdir)/ruby/backward/2/r_cast.h
 bug.o: $(hdrdir)/ruby/backward/2/rmodule.h
 bug.o: $(hdrdir)/ruby/backward/2/stdalign.h
 bug.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/-test-/num2int/depend
+++ b/ext/-test-/num2int/depend
@@ -152,7 +152,6 @@ num2int.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 num2int.o: $(hdrdir)/ruby/backward/2/inttypes.h
 num2int.o: $(hdrdir)/ruby/backward/2/limits.h
 num2int.o: $(hdrdir)/ruby/backward/2/long_long.h
-num2int.o: $(hdrdir)/ruby/backward/2/r_cast.h
 num2int.o: $(hdrdir)/ruby/backward/2/rmodule.h
 num2int.o: $(hdrdir)/ruby/backward/2/stdalign.h
 num2int.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/-test-/path_to_class/depend
+++ b/ext/-test-/path_to_class/depend
@@ -152,7 +152,6 @@ path_to_class.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 path_to_class.o: $(hdrdir)/ruby/backward/2/inttypes.h
 path_to_class.o: $(hdrdir)/ruby/backward/2/limits.h
 path_to_class.o: $(hdrdir)/ruby/backward/2/long_long.h
-path_to_class.o: $(hdrdir)/ruby/backward/2/r_cast.h
 path_to_class.o: $(hdrdir)/ruby/backward/2/rmodule.h
 path_to_class.o: $(hdrdir)/ruby/backward/2/stdalign.h
 path_to_class.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/-test-/popen_deadlock/depend
+++ b/ext/-test-/popen_deadlock/depend
@@ -151,7 +151,6 @@ infinite_loop_dlsym.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 infinite_loop_dlsym.o: $(hdrdir)/ruby/backward/2/inttypes.h
 infinite_loop_dlsym.o: $(hdrdir)/ruby/backward/2/limits.h
 infinite_loop_dlsym.o: $(hdrdir)/ruby/backward/2/long_long.h
-infinite_loop_dlsym.o: $(hdrdir)/ruby/backward/2/r_cast.h
 infinite_loop_dlsym.o: $(hdrdir)/ruby/backward/2/rmodule.h
 infinite_loop_dlsym.o: $(hdrdir)/ruby/backward/2/stdalign.h
 infinite_loop_dlsym.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/-test-/postponed_job/depend
+++ b/ext/-test-/postponed_job/depend
@@ -152,7 +152,6 @@ postponed_job.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 postponed_job.o: $(hdrdir)/ruby/backward/2/inttypes.h
 postponed_job.o: $(hdrdir)/ruby/backward/2/limits.h
 postponed_job.o: $(hdrdir)/ruby/backward/2/long_long.h
-postponed_job.o: $(hdrdir)/ruby/backward/2/r_cast.h
 postponed_job.o: $(hdrdir)/ruby/backward/2/rmodule.h
 postponed_job.o: $(hdrdir)/ruby/backward/2/stdalign.h
 postponed_job.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/-test-/printf/depend
+++ b/ext/-test-/printf/depend
@@ -152,7 +152,6 @@ printf.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 printf.o: $(hdrdir)/ruby/backward/2/inttypes.h
 printf.o: $(hdrdir)/ruby/backward/2/limits.h
 printf.o: $(hdrdir)/ruby/backward/2/long_long.h
-printf.o: $(hdrdir)/ruby/backward/2/r_cast.h
 printf.o: $(hdrdir)/ruby/backward/2/rmodule.h
 printf.o: $(hdrdir)/ruby/backward/2/stdalign.h
 printf.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/-test-/proc/depend
+++ b/ext/-test-/proc/depend
@@ -152,7 +152,6 @@ init.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 init.o: $(hdrdir)/ruby/backward/2/inttypes.h
 init.o: $(hdrdir)/ruby/backward/2/limits.h
 init.o: $(hdrdir)/ruby/backward/2/long_long.h
-init.o: $(hdrdir)/ruby/backward/2/r_cast.h
 init.o: $(hdrdir)/ruby/backward/2/rmodule.h
 init.o: $(hdrdir)/ruby/backward/2/stdalign.h
 init.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -316,7 +315,6 @@ receiver.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 receiver.o: $(hdrdir)/ruby/backward/2/inttypes.h
 receiver.o: $(hdrdir)/ruby/backward/2/limits.h
 receiver.o: $(hdrdir)/ruby/backward/2/long_long.h
-receiver.o: $(hdrdir)/ruby/backward/2/r_cast.h
 receiver.o: $(hdrdir)/ruby/backward/2/rmodule.h
 receiver.o: $(hdrdir)/ruby/backward/2/stdalign.h
 receiver.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -480,7 +478,6 @@ super.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 super.o: $(hdrdir)/ruby/backward/2/inttypes.h
 super.o: $(hdrdir)/ruby/backward/2/limits.h
 super.o: $(hdrdir)/ruby/backward/2/long_long.h
-super.o: $(hdrdir)/ruby/backward/2/r_cast.h
 super.o: $(hdrdir)/ruby/backward/2/rmodule.h
 super.o: $(hdrdir)/ruby/backward/2/stdalign.h
 super.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/-test-/rational/depend
+++ b/ext/-test-/rational/depend
@@ -156,7 +156,6 @@ rat.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 rat.o: $(hdrdir)/ruby/backward/2/inttypes.h
 rat.o: $(hdrdir)/ruby/backward/2/limits.h
 rat.o: $(hdrdir)/ruby/backward/2/long_long.h
-rat.o: $(hdrdir)/ruby/backward/2/r_cast.h
 rat.o: $(hdrdir)/ruby/backward/2/rmodule.h
 rat.o: $(hdrdir)/ruby/backward/2/stdalign.h
 rat.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/-test-/rb_call_super_kw/depend
+++ b/ext/-test-/rb_call_super_kw/depend
@@ -152,7 +152,6 @@ rb_call_super_kw.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 rb_call_super_kw.o: $(hdrdir)/ruby/backward/2/inttypes.h
 rb_call_super_kw.o: $(hdrdir)/ruby/backward/2/limits.h
 rb_call_super_kw.o: $(hdrdir)/ruby/backward/2/long_long.h
-rb_call_super_kw.o: $(hdrdir)/ruby/backward/2/r_cast.h
 rb_call_super_kw.o: $(hdrdir)/ruby/backward/2/rmodule.h
 rb_call_super_kw.o: $(hdrdir)/ruby/backward/2/stdalign.h
 rb_call_super_kw.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/-test-/recursion/depend
+++ b/ext/-test-/recursion/depend
@@ -152,7 +152,6 @@ recursion.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 recursion.o: $(hdrdir)/ruby/backward/2/inttypes.h
 recursion.o: $(hdrdir)/ruby/backward/2/limits.h
 recursion.o: $(hdrdir)/ruby/backward/2/long_long.h
-recursion.o: $(hdrdir)/ruby/backward/2/r_cast.h
 recursion.o: $(hdrdir)/ruby/backward/2/rmodule.h
 recursion.o: $(hdrdir)/ruby/backward/2/stdalign.h
 recursion.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/-test-/regexp/depend
+++ b/ext/-test-/regexp/depend
@@ -152,7 +152,6 @@ init.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 init.o: $(hdrdir)/ruby/backward/2/inttypes.h
 init.o: $(hdrdir)/ruby/backward/2/limits.h
 init.o: $(hdrdir)/ruby/backward/2/long_long.h
-init.o: $(hdrdir)/ruby/backward/2/r_cast.h
 init.o: $(hdrdir)/ruby/backward/2/rmodule.h
 init.o: $(hdrdir)/ruby/backward/2/stdalign.h
 init.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -316,7 +315,6 @@ parse_depth_limit.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 parse_depth_limit.o: $(hdrdir)/ruby/backward/2/inttypes.h
 parse_depth_limit.o: $(hdrdir)/ruby/backward/2/limits.h
 parse_depth_limit.o: $(hdrdir)/ruby/backward/2/long_long.h
-parse_depth_limit.o: $(hdrdir)/ruby/backward/2/r_cast.h
 parse_depth_limit.o: $(hdrdir)/ruby/backward/2/rmodule.h
 parse_depth_limit.o: $(hdrdir)/ruby/backward/2/stdalign.h
 parse_depth_limit.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/-test-/scan_args/depend
+++ b/ext/-test-/scan_args/depend
@@ -152,7 +152,6 @@ scan_args.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 scan_args.o: $(hdrdir)/ruby/backward/2/inttypes.h
 scan_args.o: $(hdrdir)/ruby/backward/2/limits.h
 scan_args.o: $(hdrdir)/ruby/backward/2/long_long.h
-scan_args.o: $(hdrdir)/ruby/backward/2/r_cast.h
 scan_args.o: $(hdrdir)/ruby/backward/2/rmodule.h
 scan_args.o: $(hdrdir)/ruby/backward/2/stdalign.h
 scan_args.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/-test-/st/foreach/depend
+++ b/ext/-test-/st/foreach/depend
@@ -152,7 +152,6 @@ foreach.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 foreach.o: $(hdrdir)/ruby/backward/2/inttypes.h
 foreach.o: $(hdrdir)/ruby/backward/2/limits.h
 foreach.o: $(hdrdir)/ruby/backward/2/long_long.h
-foreach.o: $(hdrdir)/ruby/backward/2/r_cast.h
 foreach.o: $(hdrdir)/ruby/backward/2/rmodule.h
 foreach.o: $(hdrdir)/ruby/backward/2/stdalign.h
 foreach.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/-test-/st/numhash/depend
+++ b/ext/-test-/st/numhash/depend
@@ -152,7 +152,6 @@ numhash.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 numhash.o: $(hdrdir)/ruby/backward/2/inttypes.h
 numhash.o: $(hdrdir)/ruby/backward/2/limits.h
 numhash.o: $(hdrdir)/ruby/backward/2/long_long.h
-numhash.o: $(hdrdir)/ruby/backward/2/r_cast.h
 numhash.o: $(hdrdir)/ruby/backward/2/rmodule.h
 numhash.o: $(hdrdir)/ruby/backward/2/stdalign.h
 numhash.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/-test-/st/update/depend
+++ b/ext/-test-/st/update/depend
@@ -152,7 +152,6 @@ update.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 update.o: $(hdrdir)/ruby/backward/2/inttypes.h
 update.o: $(hdrdir)/ruby/backward/2/limits.h
 update.o: $(hdrdir)/ruby/backward/2/long_long.h
-update.o: $(hdrdir)/ruby/backward/2/r_cast.h
 update.o: $(hdrdir)/ruby/backward/2/rmodule.h
 update.o: $(hdrdir)/ruby/backward/2/stdalign.h
 update.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/-test-/string/depend
+++ b/ext/-test-/string/depend
@@ -152,7 +152,6 @@ capacity.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 capacity.o: $(hdrdir)/ruby/backward/2/inttypes.h
 capacity.o: $(hdrdir)/ruby/backward/2/limits.h
 capacity.o: $(hdrdir)/ruby/backward/2/long_long.h
-capacity.o: $(hdrdir)/ruby/backward/2/r_cast.h
 capacity.o: $(hdrdir)/ruby/backward/2/rmodule.h
 capacity.o: $(hdrdir)/ruby/backward/2/stdalign.h
 capacity.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -321,7 +320,6 @@ coderange.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 coderange.o: $(hdrdir)/ruby/backward/2/inttypes.h
 coderange.o: $(hdrdir)/ruby/backward/2/limits.h
 coderange.o: $(hdrdir)/ruby/backward/2/long_long.h
-coderange.o: $(hdrdir)/ruby/backward/2/r_cast.h
 coderange.o: $(hdrdir)/ruby/backward/2/rmodule.h
 coderange.o: $(hdrdir)/ruby/backward/2/stdalign.h
 coderange.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -488,7 +486,6 @@ cstr.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 cstr.o: $(hdrdir)/ruby/backward/2/inttypes.h
 cstr.o: $(hdrdir)/ruby/backward/2/limits.h
 cstr.o: $(hdrdir)/ruby/backward/2/long_long.h
-cstr.o: $(hdrdir)/ruby/backward/2/r_cast.h
 cstr.o: $(hdrdir)/ruby/backward/2/rmodule.h
 cstr.o: $(hdrdir)/ruby/backward/2/stdalign.h
 cstr.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -659,7 +656,6 @@ ellipsize.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ellipsize.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ellipsize.o: $(hdrdir)/ruby/backward/2/limits.h
 ellipsize.o: $(hdrdir)/ruby/backward/2/long_long.h
-ellipsize.o: $(hdrdir)/ruby/backward/2/r_cast.h
 ellipsize.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ellipsize.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ellipsize.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -823,7 +819,6 @@ enc_associate.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 enc_associate.o: $(hdrdir)/ruby/backward/2/inttypes.h
 enc_associate.o: $(hdrdir)/ruby/backward/2/limits.h
 enc_associate.o: $(hdrdir)/ruby/backward/2/long_long.h
-enc_associate.o: $(hdrdir)/ruby/backward/2/r_cast.h
 enc_associate.o: $(hdrdir)/ruby/backward/2/rmodule.h
 enc_associate.o: $(hdrdir)/ruby/backward/2/stdalign.h
 enc_associate.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -989,7 +984,6 @@ enc_str_buf_cat.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 enc_str_buf_cat.o: $(hdrdir)/ruby/backward/2/inttypes.h
 enc_str_buf_cat.o: $(hdrdir)/ruby/backward/2/limits.h
 enc_str_buf_cat.o: $(hdrdir)/ruby/backward/2/long_long.h
-enc_str_buf_cat.o: $(hdrdir)/ruby/backward/2/r_cast.h
 enc_str_buf_cat.o: $(hdrdir)/ruby/backward/2/rmodule.h
 enc_str_buf_cat.o: $(hdrdir)/ruby/backward/2/stdalign.h
 enc_str_buf_cat.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -1156,7 +1150,6 @@ fstring.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 fstring.o: $(hdrdir)/ruby/backward/2/inttypes.h
 fstring.o: $(hdrdir)/ruby/backward/2/limits.h
 fstring.o: $(hdrdir)/ruby/backward/2/long_long.h
-fstring.o: $(hdrdir)/ruby/backward/2/r_cast.h
 fstring.o: $(hdrdir)/ruby/backward/2/rmodule.h
 fstring.o: $(hdrdir)/ruby/backward/2/stdalign.h
 fstring.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -1320,7 +1313,6 @@ init.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 init.o: $(hdrdir)/ruby/backward/2/inttypes.h
 init.o: $(hdrdir)/ruby/backward/2/limits.h
 init.o: $(hdrdir)/ruby/backward/2/long_long.h
-init.o: $(hdrdir)/ruby/backward/2/r_cast.h
 init.o: $(hdrdir)/ruby/backward/2/rmodule.h
 init.o: $(hdrdir)/ruby/backward/2/stdalign.h
 init.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -1484,7 +1476,6 @@ modify.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 modify.o: $(hdrdir)/ruby/backward/2/inttypes.h
 modify.o: $(hdrdir)/ruby/backward/2/limits.h
 modify.o: $(hdrdir)/ruby/backward/2/long_long.h
-modify.o: $(hdrdir)/ruby/backward/2/r_cast.h
 modify.o: $(hdrdir)/ruby/backward/2/rmodule.h
 modify.o: $(hdrdir)/ruby/backward/2/stdalign.h
 modify.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -1648,7 +1639,6 @@ new.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 new.o: $(hdrdir)/ruby/backward/2/inttypes.h
 new.o: $(hdrdir)/ruby/backward/2/limits.h
 new.o: $(hdrdir)/ruby/backward/2/long_long.h
-new.o: $(hdrdir)/ruby/backward/2/r_cast.h
 new.o: $(hdrdir)/ruby/backward/2/rmodule.h
 new.o: $(hdrdir)/ruby/backward/2/stdalign.h
 new.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -1815,7 +1805,6 @@ nofree.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 nofree.o: $(hdrdir)/ruby/backward/2/inttypes.h
 nofree.o: $(hdrdir)/ruby/backward/2/limits.h
 nofree.o: $(hdrdir)/ruby/backward/2/long_long.h
-nofree.o: $(hdrdir)/ruby/backward/2/r_cast.h
 nofree.o: $(hdrdir)/ruby/backward/2/rmodule.h
 nofree.o: $(hdrdir)/ruby/backward/2/stdalign.h
 nofree.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -1979,7 +1968,6 @@ normalize.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 normalize.o: $(hdrdir)/ruby/backward/2/inttypes.h
 normalize.o: $(hdrdir)/ruby/backward/2/limits.h
 normalize.o: $(hdrdir)/ruby/backward/2/long_long.h
-normalize.o: $(hdrdir)/ruby/backward/2/r_cast.h
 normalize.o: $(hdrdir)/ruby/backward/2/rmodule.h
 normalize.o: $(hdrdir)/ruby/backward/2/stdalign.h
 normalize.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -2148,7 +2136,6 @@ qsort.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 qsort.o: $(hdrdir)/ruby/backward/2/inttypes.h
 qsort.o: $(hdrdir)/ruby/backward/2/limits.h
 qsort.o: $(hdrdir)/ruby/backward/2/long_long.h
-qsort.o: $(hdrdir)/ruby/backward/2/r_cast.h
 qsort.o: $(hdrdir)/ruby/backward/2/rmodule.h
 qsort.o: $(hdrdir)/ruby/backward/2/stdalign.h
 qsort.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -2316,7 +2303,6 @@ rb_str_dup.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 rb_str_dup.o: $(hdrdir)/ruby/backward/2/inttypes.h
 rb_str_dup.o: $(hdrdir)/ruby/backward/2/limits.h
 rb_str_dup.o: $(hdrdir)/ruby/backward/2/long_long.h
-rb_str_dup.o: $(hdrdir)/ruby/backward/2/r_cast.h
 rb_str_dup.o: $(hdrdir)/ruby/backward/2/rmodule.h
 rb_str_dup.o: $(hdrdir)/ruby/backward/2/stdalign.h
 rb_str_dup.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -2480,7 +2466,6 @@ set_len.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 set_len.o: $(hdrdir)/ruby/backward/2/inttypes.h
 set_len.o: $(hdrdir)/ruby/backward/2/limits.h
 set_len.o: $(hdrdir)/ruby/backward/2/long_long.h
-set_len.o: $(hdrdir)/ruby/backward/2/r_cast.h
 set_len.o: $(hdrdir)/ruby/backward/2/rmodule.h
 set_len.o: $(hdrdir)/ruby/backward/2/stdalign.h
 set_len.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/-test-/struct/depend
+++ b/ext/-test-/struct/depend
@@ -152,7 +152,6 @@ duplicate.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 duplicate.o: $(hdrdir)/ruby/backward/2/inttypes.h
 duplicate.o: $(hdrdir)/ruby/backward/2/limits.h
 duplicate.o: $(hdrdir)/ruby/backward/2/long_long.h
-duplicate.o: $(hdrdir)/ruby/backward/2/r_cast.h
 duplicate.o: $(hdrdir)/ruby/backward/2/rmodule.h
 duplicate.o: $(hdrdir)/ruby/backward/2/stdalign.h
 duplicate.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -316,7 +315,6 @@ init.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 init.o: $(hdrdir)/ruby/backward/2/inttypes.h
 init.o: $(hdrdir)/ruby/backward/2/limits.h
 init.o: $(hdrdir)/ruby/backward/2/long_long.h
-init.o: $(hdrdir)/ruby/backward/2/r_cast.h
 init.o: $(hdrdir)/ruby/backward/2/rmodule.h
 init.o: $(hdrdir)/ruby/backward/2/stdalign.h
 init.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -480,7 +478,6 @@ len.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 len.o: $(hdrdir)/ruby/backward/2/inttypes.h
 len.o: $(hdrdir)/ruby/backward/2/limits.h
 len.o: $(hdrdir)/ruby/backward/2/long_long.h
-len.o: $(hdrdir)/ruby/backward/2/r_cast.h
 len.o: $(hdrdir)/ruby/backward/2/rmodule.h
 len.o: $(hdrdir)/ruby/backward/2/stdalign.h
 len.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -644,7 +641,6 @@ member.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 member.o: $(hdrdir)/ruby/backward/2/inttypes.h
 member.o: $(hdrdir)/ruby/backward/2/limits.h
 member.o: $(hdrdir)/ruby/backward/2/long_long.h
-member.o: $(hdrdir)/ruby/backward/2/r_cast.h
 member.o: $(hdrdir)/ruby/backward/2/rmodule.h
 member.o: $(hdrdir)/ruby/backward/2/stdalign.h
 member.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/-test-/symbol/depend
+++ b/ext/-test-/symbol/depend
@@ -152,7 +152,6 @@ init.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 init.o: $(hdrdir)/ruby/backward/2/inttypes.h
 init.o: $(hdrdir)/ruby/backward/2/limits.h
 init.o: $(hdrdir)/ruby/backward/2/long_long.h
-init.o: $(hdrdir)/ruby/backward/2/r_cast.h
 init.o: $(hdrdir)/ruby/backward/2/rmodule.h
 init.o: $(hdrdir)/ruby/backward/2/stdalign.h
 init.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -316,7 +315,6 @@ type.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 type.o: $(hdrdir)/ruby/backward/2/inttypes.h
 type.o: $(hdrdir)/ruby/backward/2/limits.h
 type.o: $(hdrdir)/ruby/backward/2/long_long.h
-type.o: $(hdrdir)/ruby/backward/2/r_cast.h
 type.o: $(hdrdir)/ruby/backward/2/rmodule.h
 type.o: $(hdrdir)/ruby/backward/2/stdalign.h
 type.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/-test-/thread_fd_close/depend
+++ b/ext/-test-/thread_fd_close/depend
@@ -151,7 +151,6 @@ thread_fd_close.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 thread_fd_close.o: $(hdrdir)/ruby/backward/2/inttypes.h
 thread_fd_close.o: $(hdrdir)/ruby/backward/2/limits.h
 thread_fd_close.o: $(hdrdir)/ruby/backward/2/long_long.h
-thread_fd_close.o: $(hdrdir)/ruby/backward/2/r_cast.h
 thread_fd_close.o: $(hdrdir)/ruby/backward/2/rmodule.h
 thread_fd_close.o: $(hdrdir)/ruby/backward/2/stdalign.h
 thread_fd_close.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/-test-/time/depend
+++ b/ext/-test-/time/depend
@@ -152,7 +152,6 @@ init.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 init.o: $(hdrdir)/ruby/backward/2/inttypes.h
 init.o: $(hdrdir)/ruby/backward/2/limits.h
 init.o: $(hdrdir)/ruby/backward/2/long_long.h
-init.o: $(hdrdir)/ruby/backward/2/r_cast.h
 init.o: $(hdrdir)/ruby/backward/2/rmodule.h
 init.o: $(hdrdir)/ruby/backward/2/stdalign.h
 init.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -316,7 +315,6 @@ leap_second.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 leap_second.o: $(hdrdir)/ruby/backward/2/inttypes.h
 leap_second.o: $(hdrdir)/ruby/backward/2/limits.h
 leap_second.o: $(hdrdir)/ruby/backward/2/long_long.h
-leap_second.o: $(hdrdir)/ruby/backward/2/r_cast.h
 leap_second.o: $(hdrdir)/ruby/backward/2/rmodule.h
 leap_second.o: $(hdrdir)/ruby/backward/2/stdalign.h
 leap_second.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -484,7 +482,6 @@ new.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 new.o: $(hdrdir)/ruby/backward/2/inttypes.h
 new.o: $(hdrdir)/ruby/backward/2/limits.h
 new.o: $(hdrdir)/ruby/backward/2/long_long.h
-new.o: $(hdrdir)/ruby/backward/2/r_cast.h
 new.o: $(hdrdir)/ruby/backward/2/rmodule.h
 new.o: $(hdrdir)/ruby/backward/2/stdalign.h
 new.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/-test-/tracepoint/depend
+++ b/ext/-test-/tracepoint/depend
@@ -151,7 +151,6 @@ gc_hook.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 gc_hook.o: $(hdrdir)/ruby/backward/2/inttypes.h
 gc_hook.o: $(hdrdir)/ruby/backward/2/limits.h
 gc_hook.o: $(hdrdir)/ruby/backward/2/long_long.h
-gc_hook.o: $(hdrdir)/ruby/backward/2/r_cast.h
 gc_hook.o: $(hdrdir)/ruby/backward/2/rmodule.h
 gc_hook.o: $(hdrdir)/ruby/backward/2/stdalign.h
 gc_hook.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -315,7 +314,6 @@ tracepoint.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 tracepoint.o: $(hdrdir)/ruby/backward/2/inttypes.h
 tracepoint.o: $(hdrdir)/ruby/backward/2/limits.h
 tracepoint.o: $(hdrdir)/ruby/backward/2/long_long.h
-tracepoint.o: $(hdrdir)/ruby/backward/2/r_cast.h
 tracepoint.o: $(hdrdir)/ruby/backward/2/rmodule.h
 tracepoint.o: $(hdrdir)/ruby/backward/2/stdalign.h
 tracepoint.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/-test-/typeddata/depend
+++ b/ext/-test-/typeddata/depend
@@ -152,7 +152,6 @@ typeddata.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 typeddata.o: $(hdrdir)/ruby/backward/2/inttypes.h
 typeddata.o: $(hdrdir)/ruby/backward/2/limits.h
 typeddata.o: $(hdrdir)/ruby/backward/2/long_long.h
-typeddata.o: $(hdrdir)/ruby/backward/2/r_cast.h
 typeddata.o: $(hdrdir)/ruby/backward/2/rmodule.h
 typeddata.o: $(hdrdir)/ruby/backward/2/stdalign.h
 typeddata.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/-test-/vm/depend
+++ b/ext/-test-/vm/depend
@@ -151,7 +151,6 @@ at_exit.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 at_exit.o: $(hdrdir)/ruby/backward/2/inttypes.h
 at_exit.o: $(hdrdir)/ruby/backward/2/limits.h
 at_exit.o: $(hdrdir)/ruby/backward/2/long_long.h
-at_exit.o: $(hdrdir)/ruby/backward/2/r_cast.h
 at_exit.o: $(hdrdir)/ruby/backward/2/rmodule.h
 at_exit.o: $(hdrdir)/ruby/backward/2/stdalign.h
 at_exit.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/-test-/wait_for_single_fd/depend
+++ b/ext/-test-/wait_for_single_fd/depend
@@ -151,7 +151,6 @@ wait_for_single_fd.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 wait_for_single_fd.o: $(hdrdir)/ruby/backward/2/inttypes.h
 wait_for_single_fd.o: $(hdrdir)/ruby/backward/2/limits.h
 wait_for_single_fd.o: $(hdrdir)/ruby/backward/2/long_long.h
-wait_for_single_fd.o: $(hdrdir)/ruby/backward/2/r_cast.h
 wait_for_single_fd.o: $(hdrdir)/ruby/backward/2/rmodule.h
 wait_for_single_fd.o: $(hdrdir)/ruby/backward/2/stdalign.h
 wait_for_single_fd.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/bigdecimal/depend
+++ b/ext/bigdecimal/depend
@@ -153,7 +153,6 @@ bigdecimal.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 bigdecimal.o: $(hdrdir)/ruby/backward/2/inttypes.h
 bigdecimal.o: $(hdrdir)/ruby/backward/2/limits.h
 bigdecimal.o: $(hdrdir)/ruby/backward/2/long_long.h
-bigdecimal.o: $(hdrdir)/ruby/backward/2/r_cast.h
 bigdecimal.o: $(hdrdir)/ruby/backward/2/rmodule.h
 bigdecimal.o: $(hdrdir)/ruby/backward/2/stdalign.h
 bigdecimal.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/cgi/escape/depend
+++ b/ext/cgi/escape/depend
@@ -152,7 +152,6 @@ escape.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 escape.o: $(hdrdir)/ruby/backward/2/inttypes.h
 escape.o: $(hdrdir)/ruby/backward/2/limits.h
 escape.o: $(hdrdir)/ruby/backward/2/long_long.h
-escape.o: $(hdrdir)/ruby/backward/2/r_cast.h
 escape.o: $(hdrdir)/ruby/backward/2/rmodule.h
 escape.o: $(hdrdir)/ruby/backward/2/stdalign.h
 escape.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/continuation/depend
+++ b/ext/continuation/depend
@@ -151,7 +151,6 @@ continuation.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 continuation.o: $(hdrdir)/ruby/backward/2/inttypes.h
 continuation.o: $(hdrdir)/ruby/backward/2/limits.h
 continuation.o: $(hdrdir)/ruby/backward/2/long_long.h
-continuation.o: $(hdrdir)/ruby/backward/2/r_cast.h
 continuation.o: $(hdrdir)/ruby/backward/2/rmodule.h
 continuation.o: $(hdrdir)/ruby/backward/2/stdalign.h
 continuation.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/coverage/depend
+++ b/ext/coverage/depend
@@ -152,7 +152,6 @@ coverage.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 coverage.o: $(hdrdir)/ruby/backward/2/inttypes.h
 coverage.o: $(hdrdir)/ruby/backward/2/limits.h
 coverage.o: $(hdrdir)/ruby/backward/2/long_long.h
-coverage.o: $(hdrdir)/ruby/backward/2/r_cast.h
 coverage.o: $(hdrdir)/ruby/backward/2/rmodule.h
 coverage.o: $(hdrdir)/ruby/backward/2/stdalign.h
 coverage.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/date/depend
+++ b/ext/date/depend
@@ -152,7 +152,6 @@ date_core.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 date_core.o: $(hdrdir)/ruby/backward/2/inttypes.h
 date_core.o: $(hdrdir)/ruby/backward/2/limits.h
 date_core.o: $(hdrdir)/ruby/backward/2/long_long.h
-date_core.o: $(hdrdir)/ruby/backward/2/r_cast.h
 date_core.o: $(hdrdir)/ruby/backward/2/rmodule.h
 date_core.o: $(hdrdir)/ruby/backward/2/stdalign.h
 date_core.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -322,7 +321,6 @@ date_parse.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 date_parse.o: $(hdrdir)/ruby/backward/2/inttypes.h
 date_parse.o: $(hdrdir)/ruby/backward/2/limits.h
 date_parse.o: $(hdrdir)/ruby/backward/2/long_long.h
-date_parse.o: $(hdrdir)/ruby/backward/2/r_cast.h
 date_parse.o: $(hdrdir)/ruby/backward/2/rmodule.h
 date_parse.o: $(hdrdir)/ruby/backward/2/stdalign.h
 date_parse.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -492,7 +490,6 @@ date_strftime.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 date_strftime.o: $(hdrdir)/ruby/backward/2/inttypes.h
 date_strftime.o: $(hdrdir)/ruby/backward/2/limits.h
 date_strftime.o: $(hdrdir)/ruby/backward/2/long_long.h
-date_strftime.o: $(hdrdir)/ruby/backward/2/r_cast.h
 date_strftime.o: $(hdrdir)/ruby/backward/2/rmodule.h
 date_strftime.o: $(hdrdir)/ruby/backward/2/stdalign.h
 date_strftime.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -658,7 +655,6 @@ date_strptime.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 date_strptime.o: $(hdrdir)/ruby/backward/2/inttypes.h
 date_strptime.o: $(hdrdir)/ruby/backward/2/limits.h
 date_strptime.o: $(hdrdir)/ruby/backward/2/long_long.h
-date_strptime.o: $(hdrdir)/ruby/backward/2/r_cast.h
 date_strptime.o: $(hdrdir)/ruby/backward/2/rmodule.h
 date_strptime.o: $(hdrdir)/ruby/backward/2/stdalign.h
 date_strptime.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/dbm/depend
+++ b/ext/dbm/depend
@@ -152,7 +152,6 @@ dbm.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 dbm.o: $(hdrdir)/ruby/backward/2/inttypes.h
 dbm.o: $(hdrdir)/ruby/backward/2/limits.h
 dbm.o: $(hdrdir)/ruby/backward/2/long_long.h
-dbm.o: $(hdrdir)/ruby/backward/2/r_cast.h
 dbm.o: $(hdrdir)/ruby/backward/2/rmodule.h
 dbm.o: $(hdrdir)/ruby/backward/2/stdalign.h
 dbm.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/digest/bubblebabble/depend
+++ b/ext/digest/bubblebabble/depend
@@ -152,7 +152,6 @@ bubblebabble.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 bubblebabble.o: $(hdrdir)/ruby/backward/2/inttypes.h
 bubblebabble.o: $(hdrdir)/ruby/backward/2/limits.h
 bubblebabble.o: $(hdrdir)/ruby/backward/2/long_long.h
-bubblebabble.o: $(hdrdir)/ruby/backward/2/r_cast.h
 bubblebabble.o: $(hdrdir)/ruby/backward/2/rmodule.h
 bubblebabble.o: $(hdrdir)/ruby/backward/2/stdalign.h
 bubblebabble.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/digest/depend
+++ b/ext/digest/depend
@@ -152,7 +152,6 @@ digest.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 digest.o: $(hdrdir)/ruby/backward/2/inttypes.h
 digest.o: $(hdrdir)/ruby/backward/2/limits.h
 digest.o: $(hdrdir)/ruby/backward/2/long_long.h
-digest.o: $(hdrdir)/ruby/backward/2/r_cast.h
 digest.o: $(hdrdir)/ruby/backward/2/rmodule.h
 digest.o: $(hdrdir)/ruby/backward/2/stdalign.h
 digest.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/digest/md5/depend
+++ b/ext/digest/md5/depend
@@ -155,7 +155,6 @@ md5init.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 md5init.o: $(hdrdir)/ruby/backward/2/inttypes.h
 md5init.o: $(hdrdir)/ruby/backward/2/limits.h
 md5init.o: $(hdrdir)/ruby/backward/2/long_long.h
-md5init.o: $(hdrdir)/ruby/backward/2/r_cast.h
 md5init.o: $(hdrdir)/ruby/backward/2/rmodule.h
 md5init.o: $(hdrdir)/ruby/backward/2/stdalign.h
 md5init.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/digest/rmd160/depend
+++ b/ext/digest/rmd160/depend
@@ -155,7 +155,6 @@ rmd160init.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 rmd160init.o: $(hdrdir)/ruby/backward/2/inttypes.h
 rmd160init.o: $(hdrdir)/ruby/backward/2/limits.h
 rmd160init.o: $(hdrdir)/ruby/backward/2/long_long.h
-rmd160init.o: $(hdrdir)/ruby/backward/2/r_cast.h
 rmd160init.o: $(hdrdir)/ruby/backward/2/rmodule.h
 rmd160init.o: $(hdrdir)/ruby/backward/2/stdalign.h
 rmd160init.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/digest/sha1/depend
+++ b/ext/digest/sha1/depend
@@ -155,7 +155,6 @@ sha1init.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 sha1init.o: $(hdrdir)/ruby/backward/2/inttypes.h
 sha1init.o: $(hdrdir)/ruby/backward/2/limits.h
 sha1init.o: $(hdrdir)/ruby/backward/2/long_long.h
-sha1init.o: $(hdrdir)/ruby/backward/2/r_cast.h
 sha1init.o: $(hdrdir)/ruby/backward/2/rmodule.h
 sha1init.o: $(hdrdir)/ruby/backward/2/stdalign.h
 sha1init.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/digest/sha2/depend
+++ b/ext/digest/sha2/depend
@@ -155,7 +155,6 @@ sha2init.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 sha2init.o: $(hdrdir)/ruby/backward/2/inttypes.h
 sha2init.o: $(hdrdir)/ruby/backward/2/limits.h
 sha2init.o: $(hdrdir)/ruby/backward/2/long_long.h
-sha2init.o: $(hdrdir)/ruby/backward/2/r_cast.h
 sha2init.o: $(hdrdir)/ruby/backward/2/rmodule.h
 sha2init.o: $(hdrdir)/ruby/backward/2/stdalign.h
 sha2init.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/etc/depend
+++ b/ext/etc/depend
@@ -156,7 +156,6 @@ etc.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 etc.o: $(hdrdir)/ruby/backward/2/inttypes.h
 etc.o: $(hdrdir)/ruby/backward/2/limits.h
 etc.o: $(hdrdir)/ruby/backward/2/long_long.h
-etc.o: $(hdrdir)/ruby/backward/2/r_cast.h
 etc.o: $(hdrdir)/ruby/backward/2/rmodule.h
 etc.o: $(hdrdir)/ruby/backward/2/stdalign.h
 etc.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/fcntl/depend
+++ b/ext/fcntl/depend
@@ -152,7 +152,6 @@ fcntl.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 fcntl.o: $(hdrdir)/ruby/backward/2/inttypes.h
 fcntl.o: $(hdrdir)/ruby/backward/2/limits.h
 fcntl.o: $(hdrdir)/ruby/backward/2/long_long.h
-fcntl.o: $(hdrdir)/ruby/backward/2/r_cast.h
 fcntl.o: $(hdrdir)/ruby/backward/2/rmodule.h
 fcntl.o: $(hdrdir)/ruby/backward/2/stdalign.h
 fcntl.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/fiddle/depend
+++ b/ext/fiddle/depend
@@ -205,7 +205,6 @@ closure.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 closure.o: $(hdrdir)/ruby/backward/2/inttypes.h
 closure.o: $(hdrdir)/ruby/backward/2/limits.h
 closure.o: $(hdrdir)/ruby/backward/2/long_long.h
-closure.o: $(hdrdir)/ruby/backward/2/r_cast.h
 closure.o: $(hdrdir)/ruby/backward/2/rmodule.h
 closure.o: $(hdrdir)/ruby/backward/2/stdalign.h
 closure.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -374,7 +373,6 @@ conversions.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 conversions.o: $(hdrdir)/ruby/backward/2/inttypes.h
 conversions.o: $(hdrdir)/ruby/backward/2/limits.h
 conversions.o: $(hdrdir)/ruby/backward/2/long_long.h
-conversions.o: $(hdrdir)/ruby/backward/2/r_cast.h
 conversions.o: $(hdrdir)/ruby/backward/2/rmodule.h
 conversions.o: $(hdrdir)/ruby/backward/2/stdalign.h
 conversions.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -542,7 +540,6 @@ fiddle.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 fiddle.o: $(hdrdir)/ruby/backward/2/inttypes.h
 fiddle.o: $(hdrdir)/ruby/backward/2/limits.h
 fiddle.o: $(hdrdir)/ruby/backward/2/long_long.h
-fiddle.o: $(hdrdir)/ruby/backward/2/r_cast.h
 fiddle.o: $(hdrdir)/ruby/backward/2/rmodule.h
 fiddle.o: $(hdrdir)/ruby/backward/2/stdalign.h
 fiddle.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -710,7 +707,6 @@ function.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 function.o: $(hdrdir)/ruby/backward/2/inttypes.h
 function.o: $(hdrdir)/ruby/backward/2/limits.h
 function.o: $(hdrdir)/ruby/backward/2/long_long.h
-function.o: $(hdrdir)/ruby/backward/2/r_cast.h
 function.o: $(hdrdir)/ruby/backward/2/rmodule.h
 function.o: $(hdrdir)/ruby/backward/2/stdalign.h
 function.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -879,7 +875,6 @@ handle.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 handle.o: $(hdrdir)/ruby/backward/2/inttypes.h
 handle.o: $(hdrdir)/ruby/backward/2/limits.h
 handle.o: $(hdrdir)/ruby/backward/2/long_long.h
-handle.o: $(hdrdir)/ruby/backward/2/r_cast.h
 handle.o: $(hdrdir)/ruby/backward/2/rmodule.h
 handle.o: $(hdrdir)/ruby/backward/2/stdalign.h
 handle.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -1047,7 +1042,6 @@ pointer.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 pointer.o: $(hdrdir)/ruby/backward/2/inttypes.h
 pointer.o: $(hdrdir)/ruby/backward/2/limits.h
 pointer.o: $(hdrdir)/ruby/backward/2/long_long.h
-pointer.o: $(hdrdir)/ruby/backward/2/r_cast.h
 pointer.o: $(hdrdir)/ruby/backward/2/rmodule.h
 pointer.o: $(hdrdir)/ruby/backward/2/stdalign.h
 pointer.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/gdbm/depend
+++ b/ext/gdbm/depend
@@ -152,7 +152,6 @@ gdbm.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 gdbm.o: $(hdrdir)/ruby/backward/2/inttypes.h
 gdbm.o: $(hdrdir)/ruby/backward/2/limits.h
 gdbm.o: $(hdrdir)/ruby/backward/2/long_long.h
-gdbm.o: $(hdrdir)/ruby/backward/2/r_cast.h
 gdbm.o: $(hdrdir)/ruby/backward/2/rmodule.h
 gdbm.o: $(hdrdir)/ruby/backward/2/stdalign.h
 gdbm.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/io/console/depend
+++ b/ext/io/console/depend
@@ -152,7 +152,6 @@ console.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 console.o: $(hdrdir)/ruby/backward/2/inttypes.h
 console.o: $(hdrdir)/ruby/backward/2/limits.h
 console.o: $(hdrdir)/ruby/backward/2/long_long.h
-console.o: $(hdrdir)/ruby/backward/2/r_cast.h
 console.o: $(hdrdir)/ruby/backward/2/rmodule.h
 console.o: $(hdrdir)/ruby/backward/2/stdalign.h
 console.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/io/nonblock/depend
+++ b/ext/io/nonblock/depend
@@ -152,7 +152,6 @@ nonblock.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 nonblock.o: $(hdrdir)/ruby/backward/2/inttypes.h
 nonblock.o: $(hdrdir)/ruby/backward/2/limits.h
 nonblock.o: $(hdrdir)/ruby/backward/2/long_long.h
-nonblock.o: $(hdrdir)/ruby/backward/2/r_cast.h
 nonblock.o: $(hdrdir)/ruby/backward/2/rmodule.h
 nonblock.o: $(hdrdir)/ruby/backward/2/stdalign.h
 nonblock.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/io/wait/depend
+++ b/ext/io/wait/depend
@@ -152,7 +152,6 @@ wait.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 wait.o: $(hdrdir)/ruby/backward/2/inttypes.h
 wait.o: $(hdrdir)/ruby/backward/2/limits.h
 wait.o: $(hdrdir)/ruby/backward/2/long_long.h
-wait.o: $(hdrdir)/ruby/backward/2/r_cast.h
 wait.o: $(hdrdir)/ruby/backward/2/rmodule.h
 wait.o: $(hdrdir)/ruby/backward/2/stdalign.h
 wait.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/json/generator/depend
+++ b/ext/json/generator/depend
@@ -156,7 +156,6 @@ generator.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 generator.o: $(hdrdir)/ruby/backward/2/inttypes.h
 generator.o: $(hdrdir)/ruby/backward/2/limits.h
 generator.o: $(hdrdir)/ruby/backward/2/long_long.h
-generator.o: $(hdrdir)/ruby/backward/2/r_cast.h
 generator.o: $(hdrdir)/ruby/backward/2/rmodule.h
 generator.o: $(hdrdir)/ruby/backward/2/stdalign.h
 generator.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/json/parser/depend
+++ b/ext/json/parser/depend
@@ -155,7 +155,6 @@ parser.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 parser.o: $(hdrdir)/ruby/backward/2/inttypes.h
 parser.o: $(hdrdir)/ruby/backward/2/limits.h
 parser.o: $(hdrdir)/ruby/backward/2/long_long.h
-parser.o: $(hdrdir)/ruby/backward/2/r_cast.h
 parser.o: $(hdrdir)/ruby/backward/2/rmodule.h
 parser.o: $(hdrdir)/ruby/backward/2/stdalign.h
 parser.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/monitor/depend
+++ b/ext/monitor/depend
@@ -151,7 +151,6 @@ monitor.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 monitor.o: $(hdrdir)/ruby/backward/2/inttypes.h
 monitor.o: $(hdrdir)/ruby/backward/2/limits.h
 monitor.o: $(hdrdir)/ruby/backward/2/long_long.h
-monitor.o: $(hdrdir)/ruby/backward/2/r_cast.h
 monitor.o: $(hdrdir)/ruby/backward/2/rmodule.h
 monitor.o: $(hdrdir)/ruby/backward/2/stdalign.h
 monitor.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/nkf/depend
+++ b/ext/nkf/depend
@@ -155,7 +155,6 @@ nkf.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 nkf.o: $(hdrdir)/ruby/backward/2/inttypes.h
 nkf.o: $(hdrdir)/ruby/backward/2/limits.h
 nkf.o: $(hdrdir)/ruby/backward/2/long_long.h
-nkf.o: $(hdrdir)/ruby/backward/2/r_cast.h
 nkf.o: $(hdrdir)/ruby/backward/2/rmodule.h
 nkf.o: $(hdrdir)/ruby/backward/2/stdalign.h
 nkf.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/objspace/depend
+++ b/ext/objspace/depend
@@ -152,7 +152,6 @@ object_tracing.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 object_tracing.o: $(hdrdir)/ruby/backward/2/inttypes.h
 object_tracing.o: $(hdrdir)/ruby/backward/2/limits.h
 object_tracing.o: $(hdrdir)/ruby/backward/2/long_long.h
-object_tracing.o: $(hdrdir)/ruby/backward/2/r_cast.h
 object_tracing.o: $(hdrdir)/ruby/backward/2/rmodule.h
 object_tracing.o: $(hdrdir)/ruby/backward/2/stdalign.h
 object_tracing.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -320,7 +319,6 @@ objspace.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 objspace.o: $(hdrdir)/ruby/backward/2/inttypes.h
 objspace.o: $(hdrdir)/ruby/backward/2/limits.h
 objspace.o: $(hdrdir)/ruby/backward/2/long_long.h
-objspace.o: $(hdrdir)/ruby/backward/2/r_cast.h
 objspace.o: $(hdrdir)/ruby/backward/2/rmodule.h
 objspace.o: $(hdrdir)/ruby/backward/2/stdalign.h
 objspace.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -505,7 +503,6 @@ objspace_dump.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 objspace_dump.o: $(hdrdir)/ruby/backward/2/inttypes.h
 objspace_dump.o: $(hdrdir)/ruby/backward/2/limits.h
 objspace_dump.o: $(hdrdir)/ruby/backward/2/long_long.h
-objspace_dump.o: $(hdrdir)/ruby/backward/2/r_cast.h
 objspace_dump.o: $(hdrdir)/ruby/backward/2/rmodule.h
 objspace_dump.o: $(hdrdir)/ruby/backward/2/stdalign.h
 objspace_dump.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/openssl/depend
+++ b/ext/openssl/depend
@@ -156,7 +156,6 @@ ossl.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl.o: $(hdrdir)/ruby/backward/2/r_cast.h
 ossl.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -347,7 +346,6 @@ ossl_asn1.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_asn1.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_asn1.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_asn1.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_asn1.o: $(hdrdir)/ruby/backward/2/r_cast.h
 ossl_asn1.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_asn1.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_asn1.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -537,7 +535,6 @@ ossl_bio.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_bio.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_bio.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_bio.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_bio.o: $(hdrdir)/ruby/backward/2/r_cast.h
 ossl_bio.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_bio.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_bio.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -727,7 +724,6 @@ ossl_bn.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_bn.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_bn.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_bn.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_bn.o: $(hdrdir)/ruby/backward/2/r_cast.h
 ossl_bn.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_bn.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_bn.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -917,7 +913,6 @@ ossl_cipher.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_cipher.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_cipher.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_cipher.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_cipher.o: $(hdrdir)/ruby/backward/2/r_cast.h
 ossl_cipher.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_cipher.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_cipher.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -1107,7 +1102,6 @@ ossl_config.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_config.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_config.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_config.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_config.o: $(hdrdir)/ruby/backward/2/r_cast.h
 ossl_config.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_config.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_config.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -1297,7 +1291,6 @@ ossl_digest.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_digest.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_digest.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_digest.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_digest.o: $(hdrdir)/ruby/backward/2/r_cast.h
 ossl_digest.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_digest.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_digest.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -1487,7 +1480,6 @@ ossl_engine.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_engine.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_engine.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_engine.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_engine.o: $(hdrdir)/ruby/backward/2/r_cast.h
 ossl_engine.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_engine.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_engine.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -1677,7 +1669,6 @@ ossl_hmac.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_hmac.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_hmac.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_hmac.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_hmac.o: $(hdrdir)/ruby/backward/2/r_cast.h
 ossl_hmac.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_hmac.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_hmac.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -1867,7 +1858,6 @@ ossl_kdf.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_kdf.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_kdf.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_kdf.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_kdf.o: $(hdrdir)/ruby/backward/2/r_cast.h
 ossl_kdf.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_kdf.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_kdf.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -2057,7 +2047,6 @@ ossl_ns_spki.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_ns_spki.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_ns_spki.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_ns_spki.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_ns_spki.o: $(hdrdir)/ruby/backward/2/r_cast.h
 ossl_ns_spki.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_ns_spki.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_ns_spki.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -2247,7 +2236,6 @@ ossl_ocsp.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_ocsp.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_ocsp.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_ocsp.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_ocsp.o: $(hdrdir)/ruby/backward/2/r_cast.h
 ossl_ocsp.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_ocsp.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_ocsp.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -2437,7 +2425,6 @@ ossl_pkcs12.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_pkcs12.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_pkcs12.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_pkcs12.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_pkcs12.o: $(hdrdir)/ruby/backward/2/r_cast.h
 ossl_pkcs12.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_pkcs12.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_pkcs12.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -2627,7 +2614,6 @@ ossl_pkcs7.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_pkcs7.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_pkcs7.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_pkcs7.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_pkcs7.o: $(hdrdir)/ruby/backward/2/r_cast.h
 ossl_pkcs7.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_pkcs7.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_pkcs7.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -2817,7 +2803,6 @@ ossl_pkey.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_pkey.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_pkey.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_pkey.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_pkey.o: $(hdrdir)/ruby/backward/2/r_cast.h
 ossl_pkey.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_pkey.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_pkey.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -3007,7 +2992,6 @@ ossl_pkey_dh.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_pkey_dh.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_pkey_dh.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_pkey_dh.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_pkey_dh.o: $(hdrdir)/ruby/backward/2/r_cast.h
 ossl_pkey_dh.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_pkey_dh.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_pkey_dh.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -3197,7 +3181,6 @@ ossl_pkey_dsa.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_pkey_dsa.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_pkey_dsa.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_pkey_dsa.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_pkey_dsa.o: $(hdrdir)/ruby/backward/2/r_cast.h
 ossl_pkey_dsa.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_pkey_dsa.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_pkey_dsa.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -3387,7 +3370,6 @@ ossl_pkey_ec.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_pkey_ec.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_pkey_ec.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_pkey_ec.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_pkey_ec.o: $(hdrdir)/ruby/backward/2/r_cast.h
 ossl_pkey_ec.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_pkey_ec.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_pkey_ec.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -3577,7 +3559,6 @@ ossl_pkey_rsa.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_pkey_rsa.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_pkey_rsa.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_pkey_rsa.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_pkey_rsa.o: $(hdrdir)/ruby/backward/2/r_cast.h
 ossl_pkey_rsa.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_pkey_rsa.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_pkey_rsa.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -3767,7 +3748,6 @@ ossl_rand.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_rand.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_rand.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_rand.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_rand.o: $(hdrdir)/ruby/backward/2/r_cast.h
 ossl_rand.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_rand.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_rand.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -3957,7 +3937,6 @@ ossl_ssl.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_ssl.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_ssl.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_ssl.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_ssl.o: $(hdrdir)/ruby/backward/2/r_cast.h
 ossl_ssl.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_ssl.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_ssl.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -4147,7 +4126,6 @@ ossl_ssl_session.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_ssl_session.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_ssl_session.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_ssl_session.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_ssl_session.o: $(hdrdir)/ruby/backward/2/r_cast.h
 ossl_ssl_session.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_ssl_session.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_ssl_session.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -4337,7 +4315,6 @@ ossl_ts.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_ts.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_ts.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_ts.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_ts.o: $(hdrdir)/ruby/backward/2/r_cast.h
 ossl_ts.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_ts.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_ts.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -4527,7 +4504,6 @@ ossl_x509.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_x509.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_x509.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_x509.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_x509.o: $(hdrdir)/ruby/backward/2/r_cast.h
 ossl_x509.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_x509.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_x509.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -4717,7 +4693,6 @@ ossl_x509attr.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_x509attr.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_x509attr.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_x509attr.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_x509attr.o: $(hdrdir)/ruby/backward/2/r_cast.h
 ossl_x509attr.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_x509attr.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_x509attr.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -4907,7 +4882,6 @@ ossl_x509cert.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_x509cert.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_x509cert.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_x509cert.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_x509cert.o: $(hdrdir)/ruby/backward/2/r_cast.h
 ossl_x509cert.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_x509cert.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_x509cert.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -5097,7 +5071,6 @@ ossl_x509crl.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_x509crl.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_x509crl.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_x509crl.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_x509crl.o: $(hdrdir)/ruby/backward/2/r_cast.h
 ossl_x509crl.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_x509crl.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_x509crl.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -5287,7 +5260,6 @@ ossl_x509ext.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_x509ext.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_x509ext.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_x509ext.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_x509ext.o: $(hdrdir)/ruby/backward/2/r_cast.h
 ossl_x509ext.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_x509ext.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_x509ext.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -5477,7 +5449,6 @@ ossl_x509name.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_x509name.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_x509name.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_x509name.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_x509name.o: $(hdrdir)/ruby/backward/2/r_cast.h
 ossl_x509name.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_x509name.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_x509name.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -5667,7 +5638,6 @@ ossl_x509req.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_x509req.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_x509req.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_x509req.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_x509req.o: $(hdrdir)/ruby/backward/2/r_cast.h
 ossl_x509req.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_x509req.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_x509req.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -5857,7 +5827,6 @@ ossl_x509revoked.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_x509revoked.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_x509revoked.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_x509revoked.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_x509revoked.o: $(hdrdir)/ruby/backward/2/r_cast.h
 ossl_x509revoked.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_x509revoked.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_x509revoked.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -6047,7 +6016,6 @@ ossl_x509store.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_x509store.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_x509store.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_x509store.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_x509store.o: $(hdrdir)/ruby/backward/2/r_cast.h
 ossl_x509store.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_x509store.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_x509store.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/pathname/depend
+++ b/ext/pathname/depend
@@ -152,7 +152,6 @@ pathname.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 pathname.o: $(hdrdir)/ruby/backward/2/inttypes.h
 pathname.o: $(hdrdir)/ruby/backward/2/limits.h
 pathname.o: $(hdrdir)/ruby/backward/2/long_long.h
-pathname.o: $(hdrdir)/ruby/backward/2/r_cast.h
 pathname.o: $(hdrdir)/ruby/backward/2/rmodule.h
 pathname.o: $(hdrdir)/ruby/backward/2/stdalign.h
 pathname.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/psych/depend
+++ b/ext/psych/depend
@@ -154,7 +154,6 @@ psych.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 psych.o: $(hdrdir)/ruby/backward/2/inttypes.h
 psych.o: $(hdrdir)/ruby/backward/2/limits.h
 psych.o: $(hdrdir)/ruby/backward/2/long_long.h
-psych.o: $(hdrdir)/ruby/backward/2/r_cast.h
 psych.o: $(hdrdir)/ruby/backward/2/rmodule.h
 psych.o: $(hdrdir)/ruby/backward/2/stdalign.h
 psych.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -326,7 +325,6 @@ psych_emitter.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 psych_emitter.o: $(hdrdir)/ruby/backward/2/inttypes.h
 psych_emitter.o: $(hdrdir)/ruby/backward/2/limits.h
 psych_emitter.o: $(hdrdir)/ruby/backward/2/long_long.h
-psych_emitter.o: $(hdrdir)/ruby/backward/2/r_cast.h
 psych_emitter.o: $(hdrdir)/ruby/backward/2/rmodule.h
 psych_emitter.o: $(hdrdir)/ruby/backward/2/stdalign.h
 psych_emitter.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -498,7 +496,6 @@ psych_parser.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 psych_parser.o: $(hdrdir)/ruby/backward/2/inttypes.h
 psych_parser.o: $(hdrdir)/ruby/backward/2/limits.h
 psych_parser.o: $(hdrdir)/ruby/backward/2/long_long.h
-psych_parser.o: $(hdrdir)/ruby/backward/2/r_cast.h
 psych_parser.o: $(hdrdir)/ruby/backward/2/rmodule.h
 psych_parser.o: $(hdrdir)/ruby/backward/2/stdalign.h
 psych_parser.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -670,7 +667,6 @@ psych_to_ruby.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 psych_to_ruby.o: $(hdrdir)/ruby/backward/2/inttypes.h
 psych_to_ruby.o: $(hdrdir)/ruby/backward/2/limits.h
 psych_to_ruby.o: $(hdrdir)/ruby/backward/2/long_long.h
-psych_to_ruby.o: $(hdrdir)/ruby/backward/2/r_cast.h
 psych_to_ruby.o: $(hdrdir)/ruby/backward/2/rmodule.h
 psych_to_ruby.o: $(hdrdir)/ruby/backward/2/stdalign.h
 psych_to_ruby.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -842,7 +838,6 @@ psych_yaml_tree.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 psych_yaml_tree.o: $(hdrdir)/ruby/backward/2/inttypes.h
 psych_yaml_tree.o: $(hdrdir)/ruby/backward/2/limits.h
 psych_yaml_tree.o: $(hdrdir)/ruby/backward/2/long_long.h
-psych_yaml_tree.o: $(hdrdir)/ruby/backward/2/r_cast.h
 psych_yaml_tree.o: $(hdrdir)/ruby/backward/2/rmodule.h
 psych_yaml_tree.o: $(hdrdir)/ruby/backward/2/stdalign.h
 psych_yaml_tree.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/pty/depend
+++ b/ext/pty/depend
@@ -152,7 +152,6 @@ pty.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 pty.o: $(hdrdir)/ruby/backward/2/inttypes.h
 pty.o: $(hdrdir)/ruby/backward/2/limits.h
 pty.o: $(hdrdir)/ruby/backward/2/long_long.h
-pty.o: $(hdrdir)/ruby/backward/2/r_cast.h
 pty.o: $(hdrdir)/ruby/backward/2/rmodule.h
 pty.o: $(hdrdir)/ruby/backward/2/stdalign.h
 pty.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/racc/cparse/depend
+++ b/ext/racc/cparse/depend
@@ -152,7 +152,6 @@ cparse.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 cparse.o: $(hdrdir)/ruby/backward/2/inttypes.h
 cparse.o: $(hdrdir)/ruby/backward/2/limits.h
 cparse.o: $(hdrdir)/ruby/backward/2/long_long.h
-cparse.o: $(hdrdir)/ruby/backward/2/r_cast.h
 cparse.o: $(hdrdir)/ruby/backward/2/rmodule.h
 cparse.o: $(hdrdir)/ruby/backward/2/stdalign.h
 cparse.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/rbconfig/sizeof/depend
+++ b/ext/rbconfig/sizeof/depend
@@ -166,7 +166,6 @@ limits.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 limits.o: $(hdrdir)/ruby/backward/2/inttypes.h
 limits.o: $(hdrdir)/ruby/backward/2/limits.h
 limits.o: $(hdrdir)/ruby/backward/2/long_long.h
-limits.o: $(hdrdir)/ruby/backward/2/r_cast.h
 limits.o: $(hdrdir)/ruby/backward/2/rmodule.h
 limits.o: $(hdrdir)/ruby/backward/2/stdalign.h
 limits.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -329,7 +328,6 @@ sizes.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 sizes.o: $(hdrdir)/ruby/backward/2/inttypes.h
 sizes.o: $(hdrdir)/ruby/backward/2/limits.h
 sizes.o: $(hdrdir)/ruby/backward/2/long_long.h
-sizes.o: $(hdrdir)/ruby/backward/2/r_cast.h
 sizes.o: $(hdrdir)/ruby/backward/2/rmodule.h
 sizes.o: $(hdrdir)/ruby/backward/2/stdalign.h
 sizes.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/readline/depend
+++ b/ext/readline/depend
@@ -151,7 +151,6 @@ readline.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 readline.o: $(hdrdir)/ruby/backward/2/inttypes.h
 readline.o: $(hdrdir)/ruby/backward/2/limits.h
 readline.o: $(hdrdir)/ruby/backward/2/long_long.h
-readline.o: $(hdrdir)/ruby/backward/2/r_cast.h
 readline.o: $(hdrdir)/ruby/backward/2/rmodule.h
 readline.o: $(hdrdir)/ruby/backward/2/stdalign.h
 readline.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/ripper/depend
+++ b/ext/ripper/depend
@@ -202,7 +202,6 @@ ripper.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ripper.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ripper.o: $(hdrdir)/ruby/backward/2/limits.h
 ripper.o: $(hdrdir)/ruby/backward/2/long_long.h
-ripper.o: $(hdrdir)/ruby/backward/2/r_cast.h
 ripper.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ripper.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ripper.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/socket/depend
+++ b/ext/socket/depend
@@ -163,7 +163,6 @@ ancdata.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ancdata.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ancdata.o: $(hdrdir)/ruby/backward/2/limits.h
 ancdata.o: $(hdrdir)/ruby/backward/2/long_long.h
-ancdata.o: $(hdrdir)/ruby/backward/2/r_cast.h
 ancdata.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ancdata.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ancdata.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -348,7 +347,6 @@ basicsocket.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 basicsocket.o: $(hdrdir)/ruby/backward/2/inttypes.h
 basicsocket.o: $(hdrdir)/ruby/backward/2/limits.h
 basicsocket.o: $(hdrdir)/ruby/backward/2/long_long.h
-basicsocket.o: $(hdrdir)/ruby/backward/2/r_cast.h
 basicsocket.o: $(hdrdir)/ruby/backward/2/rmodule.h
 basicsocket.o: $(hdrdir)/ruby/backward/2/stdalign.h
 basicsocket.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -533,7 +531,6 @@ constants.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 constants.o: $(hdrdir)/ruby/backward/2/inttypes.h
 constants.o: $(hdrdir)/ruby/backward/2/limits.h
 constants.o: $(hdrdir)/ruby/backward/2/long_long.h
-constants.o: $(hdrdir)/ruby/backward/2/r_cast.h
 constants.o: $(hdrdir)/ruby/backward/2/rmodule.h
 constants.o: $(hdrdir)/ruby/backward/2/stdalign.h
 constants.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -719,7 +716,6 @@ ifaddr.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ifaddr.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ifaddr.o: $(hdrdir)/ruby/backward/2/limits.h
 ifaddr.o: $(hdrdir)/ruby/backward/2/long_long.h
-ifaddr.o: $(hdrdir)/ruby/backward/2/r_cast.h
 ifaddr.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ifaddr.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ifaddr.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -904,7 +900,6 @@ init.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 init.o: $(hdrdir)/ruby/backward/2/inttypes.h
 init.o: $(hdrdir)/ruby/backward/2/limits.h
 init.o: $(hdrdir)/ruby/backward/2/long_long.h
-init.o: $(hdrdir)/ruby/backward/2/r_cast.h
 init.o: $(hdrdir)/ruby/backward/2/rmodule.h
 init.o: $(hdrdir)/ruby/backward/2/stdalign.h
 init.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -1089,7 +1084,6 @@ ipsocket.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ipsocket.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ipsocket.o: $(hdrdir)/ruby/backward/2/limits.h
 ipsocket.o: $(hdrdir)/ruby/backward/2/long_long.h
-ipsocket.o: $(hdrdir)/ruby/backward/2/r_cast.h
 ipsocket.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ipsocket.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ipsocket.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -1274,7 +1268,6 @@ option.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 option.o: $(hdrdir)/ruby/backward/2/inttypes.h
 option.o: $(hdrdir)/ruby/backward/2/limits.h
 option.o: $(hdrdir)/ruby/backward/2/long_long.h
-option.o: $(hdrdir)/ruby/backward/2/r_cast.h
 option.o: $(hdrdir)/ruby/backward/2/rmodule.h
 option.o: $(hdrdir)/ruby/backward/2/stdalign.h
 option.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -1459,7 +1452,6 @@ raddrinfo.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 raddrinfo.o: $(hdrdir)/ruby/backward/2/inttypes.h
 raddrinfo.o: $(hdrdir)/ruby/backward/2/limits.h
 raddrinfo.o: $(hdrdir)/ruby/backward/2/long_long.h
-raddrinfo.o: $(hdrdir)/ruby/backward/2/r_cast.h
 raddrinfo.o: $(hdrdir)/ruby/backward/2/rmodule.h
 raddrinfo.o: $(hdrdir)/ruby/backward/2/stdalign.h
 raddrinfo.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -1644,7 +1636,6 @@ socket.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 socket.o: $(hdrdir)/ruby/backward/2/inttypes.h
 socket.o: $(hdrdir)/ruby/backward/2/limits.h
 socket.o: $(hdrdir)/ruby/backward/2/long_long.h
-socket.o: $(hdrdir)/ruby/backward/2/r_cast.h
 socket.o: $(hdrdir)/ruby/backward/2/rmodule.h
 socket.o: $(hdrdir)/ruby/backward/2/stdalign.h
 socket.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -1829,7 +1820,6 @@ sockssocket.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 sockssocket.o: $(hdrdir)/ruby/backward/2/inttypes.h
 sockssocket.o: $(hdrdir)/ruby/backward/2/limits.h
 sockssocket.o: $(hdrdir)/ruby/backward/2/long_long.h
-sockssocket.o: $(hdrdir)/ruby/backward/2/r_cast.h
 sockssocket.o: $(hdrdir)/ruby/backward/2/rmodule.h
 sockssocket.o: $(hdrdir)/ruby/backward/2/stdalign.h
 sockssocket.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -2014,7 +2004,6 @@ tcpserver.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 tcpserver.o: $(hdrdir)/ruby/backward/2/inttypes.h
 tcpserver.o: $(hdrdir)/ruby/backward/2/limits.h
 tcpserver.o: $(hdrdir)/ruby/backward/2/long_long.h
-tcpserver.o: $(hdrdir)/ruby/backward/2/r_cast.h
 tcpserver.o: $(hdrdir)/ruby/backward/2/rmodule.h
 tcpserver.o: $(hdrdir)/ruby/backward/2/stdalign.h
 tcpserver.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -2199,7 +2188,6 @@ tcpsocket.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 tcpsocket.o: $(hdrdir)/ruby/backward/2/inttypes.h
 tcpsocket.o: $(hdrdir)/ruby/backward/2/limits.h
 tcpsocket.o: $(hdrdir)/ruby/backward/2/long_long.h
-tcpsocket.o: $(hdrdir)/ruby/backward/2/r_cast.h
 tcpsocket.o: $(hdrdir)/ruby/backward/2/rmodule.h
 tcpsocket.o: $(hdrdir)/ruby/backward/2/stdalign.h
 tcpsocket.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -2384,7 +2372,6 @@ udpsocket.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 udpsocket.o: $(hdrdir)/ruby/backward/2/inttypes.h
 udpsocket.o: $(hdrdir)/ruby/backward/2/limits.h
 udpsocket.o: $(hdrdir)/ruby/backward/2/long_long.h
-udpsocket.o: $(hdrdir)/ruby/backward/2/r_cast.h
 udpsocket.o: $(hdrdir)/ruby/backward/2/rmodule.h
 udpsocket.o: $(hdrdir)/ruby/backward/2/stdalign.h
 udpsocket.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -2569,7 +2556,6 @@ unixserver.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 unixserver.o: $(hdrdir)/ruby/backward/2/inttypes.h
 unixserver.o: $(hdrdir)/ruby/backward/2/limits.h
 unixserver.o: $(hdrdir)/ruby/backward/2/long_long.h
-unixserver.o: $(hdrdir)/ruby/backward/2/r_cast.h
 unixserver.o: $(hdrdir)/ruby/backward/2/rmodule.h
 unixserver.o: $(hdrdir)/ruby/backward/2/stdalign.h
 unixserver.o: $(hdrdir)/ruby/backward/2/stdarg.h
@@ -2754,7 +2740,6 @@ unixsocket.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 unixsocket.o: $(hdrdir)/ruby/backward/2/inttypes.h
 unixsocket.o: $(hdrdir)/ruby/backward/2/limits.h
 unixsocket.o: $(hdrdir)/ruby/backward/2/long_long.h
-unixsocket.o: $(hdrdir)/ruby/backward/2/r_cast.h
 unixsocket.o: $(hdrdir)/ruby/backward/2/rmodule.h
 unixsocket.o: $(hdrdir)/ruby/backward/2/stdalign.h
 unixsocket.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/stringio/depend
+++ b/ext/stringio/depend
@@ -152,7 +152,6 @@ stringio.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 stringio.o: $(hdrdir)/ruby/backward/2/inttypes.h
 stringio.o: $(hdrdir)/ruby/backward/2/limits.h
 stringio.o: $(hdrdir)/ruby/backward/2/long_long.h
-stringio.o: $(hdrdir)/ruby/backward/2/r_cast.h
 stringio.o: $(hdrdir)/ruby/backward/2/rmodule.h
 stringio.o: $(hdrdir)/ruby/backward/2/stdalign.h
 stringio.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/strscan/depend
+++ b/ext/strscan/depend
@@ -152,7 +152,6 @@ strscan.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 strscan.o: $(hdrdir)/ruby/backward/2/inttypes.h
 strscan.o: $(hdrdir)/ruby/backward/2/limits.h
 strscan.o: $(hdrdir)/ruby/backward/2/long_long.h
-strscan.o: $(hdrdir)/ruby/backward/2/r_cast.h
 strscan.o: $(hdrdir)/ruby/backward/2/rmodule.h
 strscan.o: $(hdrdir)/ruby/backward/2/stdalign.h
 strscan.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/syslog/depend
+++ b/ext/syslog/depend
@@ -151,7 +151,6 @@ syslog.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 syslog.o: $(hdrdir)/ruby/backward/2/inttypes.h
 syslog.o: $(hdrdir)/ruby/backward/2/limits.h
 syslog.o: $(hdrdir)/ruby/backward/2/long_long.h
-syslog.o: $(hdrdir)/ruby/backward/2/r_cast.h
 syslog.o: $(hdrdir)/ruby/backward/2/rmodule.h
 syslog.o: $(hdrdir)/ruby/backward/2/stdalign.h
 syslog.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/ext/zlib/depend
+++ b/ext/zlib/depend
@@ -152,7 +152,6 @@ zlib.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 zlib.o: $(hdrdir)/ruby/backward/2/inttypes.h
 zlib.o: $(hdrdir)/ruby/backward/2/limits.h
 zlib.o: $(hdrdir)/ruby/backward/2/long_long.h
-zlib.o: $(hdrdir)/ruby/backward/2/r_cast.h
 zlib.o: $(hdrdir)/ruby/backward/2/rmodule.h
 zlib.o: $(hdrdir)/ruby/backward/2/stdalign.h
 zlib.o: $(hdrdir)/ruby/backward/2/stdarg.h

--- a/gc.c
+++ b/gc.c
@@ -536,6 +536,8 @@ struct RMoved {
     } as;
 };
 
+#define RMOVED(obj) ((struct RMoved *)(obj))
+
 #if defined(_MSC_VER) || defined(__CYGWIN__)
 #pragma pack(push, 1) /* magic for reducing sizeof(RVALUE): 24 -> 20 */
 #endif

--- a/include/ruby/backward/2/r_cast.h
+++ b/include/ruby/backward/2/r_cast.h
@@ -24,4 +24,10 @@
  */
 #define R_CAST(st)   (struct st*)
 #define RMOVED(obj)  (R_CAST(RMoved)(obj))
+
+#if defined(__GNUC__)
+# warning R_CAST and RMOVED are deprecated
+#elif defined(_MSC_VER)
+# pragma message("warning: R_CAST and RMOVED are deprecated")
+#endif
 #endif /* RUBY_BACKWARD2_R_CAST_H */

--- a/include/ruby/ruby.h
+++ b/include/ruby/ruby.h
@@ -52,7 +52,6 @@
 #include "ruby/backward/2/inttypes.h"
 #include "ruby/backward/2/limits.h"
 #include "ruby/backward/2/rmodule.h"
-#include "ruby/backward/2/r_cast.h"
 
 RBIMPL_SYMBOL_EXPORT_BEGIN()
 

--- a/internal/bignum.h
+++ b/internal/bignum.h
@@ -74,7 +74,7 @@
 # define PRIXBDIGIT_DBL PRI_BDIGIT_DBL_PREFIX"X"
 #endif
 
-#define RBIGNUM(obj) (R_CAST(RBignum)(obj))
+#define RBIGNUM(obj) ((struct RBignum *)(obj))
 #define BIGNUM_SIGN_BIT FL_USER1
 #define BIGNUM_EMBED_FLAG ((VALUE)FL_USER2)
 #define BIGNUM_EMBED_LEN_NUMBITS 3

--- a/internal/complex.h
+++ b/internal/complex.h
@@ -17,7 +17,7 @@ struct RComplex {
     VALUE imag;
 };
 
-#define RCOMPLEX(obj) (R_CAST(RComplex)(obj))
+#define RCOMPLEX(obj) ((struct RComplex *)(obj))
 
 /* shortcut macro for internal only */
 #define RCOMPLEX_SET_REAL(cmp, r) RB_OBJ_WRITE((cmp), &RCOMPLEX(cmp)->real, (r))

--- a/internal/hash.h
+++ b/internal/hash.h
@@ -54,7 +54,7 @@ struct RHash {
     } ar_hint;
 };
 
-#define RHASH(obj) (R_CAST(RHash)(obj))
+#define RHASH(obj) ((struct RHash *)(obj))
 
 #ifdef RHASH_IFNONE
 # undef RHASH_IFNONE

--- a/internal/imemo.h
+++ b/internal/imemo.h
@@ -117,7 +117,7 @@ struct MEMO {
 /* ment is in method.h */
 
 #define THROW_DATA_P(err) imemo_throw_data_p((VALUE)err)
-#define MEMO_CAST(m) (R_CAST(MEMO)(m))
+#define MEMO_CAST(m) ((struct MEMO *)(m))
 #define MEMO_NEW(a, b, c) ((struct MEMO *)rb_imemo_new(imemo_memo, (VALUE)(a), (VALUE)(b), (VALUE)(c), 0))
 #define MEMO_FOR(type, value) ((type *)RARRAY_PTR(value))
 #define NEW_MEMO_FOR(type, value) \

--- a/internal/numeric.h
+++ b/internal/numeric.h
@@ -41,7 +41,7 @@ struct RFloat {
     double float_value;
 };
 
-#define RFLOAT(obj)  (R_CAST(RFloat)(obj))
+#define RFLOAT(obj)  ((struct RFloat *)(obj))
 
 /* numeric.c */
 int rb_num_to_uint(VALUE val, unsigned int *ret);

--- a/internal/rational.h
+++ b/internal/rational.h
@@ -21,7 +21,7 @@ struct RRational {
     VALUE den;
 };
 
-#define RRATIONAL(obj) (R_CAST(RRational)(obj))
+#define RRATIONAL(obj) ((struct RRational *)(obj))
 
 /* rational.c */
 VALUE rb_rational_canonicalize(VALUE x);

--- a/internal/struct.h
+++ b/internal/struct.h
@@ -31,7 +31,7 @@ struct RStruct {
     } as;
 };
 
-#define RSTRUCT(obj) (R_CAST(RStruct)(obj))
+#define RSTRUCT(obj) ((struct RStruct *)(obj))
 
 #ifdef RSTRUCT_LEN
 # undef RSTRUCT_LEN

--- a/node.h
+++ b/node.h
@@ -173,7 +173,7 @@ typedef struct RNode {
     int node_id;
 } NODE;
 
-#define RNODE(obj)  (R_CAST(RNode)(obj))
+#define RNODE(obj)  ((struct RNode *)(obj))
 
 /* FL     : 0..4: T_TYPES, 5: KEEP_WB, 6: PROMOTED, 7: FINALIZE, 8: UNUSED, 9: UNUSED, 10: EXIVAR, 11: FREEZE */
 /* NODE_FL: 0..4: T_TYPES, 5: KEEP_WB, 6: PROMOTED, 7: NODE_FL_NEWLINE,

--- a/symbol.h
+++ b/symbol.h
@@ -30,7 +30,7 @@ struct RSymbol {
     ID id;
 };
 
-#define RSYMBOL(obj) (R_CAST(RSymbol)(obj))
+#define RSYMBOL(obj) ((struct RSymbol *)(obj))
 
 #define is_notop_id(id) ((id)>tLAST_OP_ID)
 #define is_local_id(id) (id_type(id)==ID_LOCAL)


### PR DESCRIPTION
These contents have never been marked as deprecated.  We cannot delete them today.  But why not start telling users they are deprecated.