### PR TITLE
deprecate backward/2/rmodule.h

### DIFF
--- a/class.c
+++ b/class.c
@@ -1027,7 +1027,7 @@ include_modules_at(const VALUE klass, VALUE c, VALUE module, int search_super)
         VALUE super_class = RCLASS_SUPER(c);
 
         // invalidate inline method cache
-        tbl = RMODULE_M_TBL(module);
+        tbl = RCLASS_M_TBL(module);
         if (tbl && rb_id_table_size(tbl)) {
             if (search_super) { // include
                 if (super_class && !RB_TYPE_P(super_class, T_MODULE)) {
@@ -1070,11 +1070,11 @@ include_modules_at(const VALUE klass, VALUE c, VALUE module, int search_super)
 	    VALUE refined_class =
 		rb_refinement_module_get_refined_class(klass);
 
-            rb_id_table_foreach(RMODULE_M_TBL(module), add_refined_method_entry_i, (void *)refined_class);
+            rb_id_table_foreach(RCLASS_M_TBL(module), add_refined_method_entry_i, (void *)refined_class);
 	    FL_SET(c, RMODULE_INCLUDED_INTO_REFINEMENT);
 	}
 
-	tbl = RMODULE_CONST_TBL(module);
+        tbl = RCLASS_CONST_TBL(module);
 	if (tbl && rb_id_table_size(tbl)) constant_changed = 1;
       skip:
 	module = RCLASS_SUPER(module);

--- a/common.mk
+++ b/common.mk
@@ -1695,7 +1695,6 @@ array.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 array.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 array.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 array.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-array.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 array.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 array.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 array.$(OBJEXT): {$(VPATH)}builtin.h
@@ -1883,7 +1882,6 @@ ast.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 ast.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 ast.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 ast.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-ast.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 ast.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 ast.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 ast.$(OBJEXT): {$(VPATH)}builtin.h
@@ -2074,7 +2072,6 @@ bignum.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 bignum.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 bignum.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 bignum.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-bignum.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 bignum.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 bignum.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 bignum.$(OBJEXT): {$(VPATH)}bignum.c
@@ -2253,7 +2250,6 @@ builtin.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 builtin.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 builtin.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 builtin.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-builtin.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 builtin.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 builtin.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 builtin.$(OBJEXT): {$(VPATH)}builtin.c
@@ -2445,7 +2441,6 @@ class.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 class.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 class.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 class.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-class.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 class.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 class.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 class.$(OBJEXT): {$(VPATH)}class.c
@@ -2627,7 +2622,6 @@ compar.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 compar.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 compar.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 compar.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-compar.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 compar.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 compar.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 compar.$(OBJEXT): {$(VPATH)}compar.c
@@ -2820,7 +2814,6 @@ compile.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 compile.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 compile.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 compile.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-compile.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 compile.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 compile.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 compile.$(OBJEXT): {$(VPATH)}builtin.h
@@ -3030,7 +3023,6 @@ complex.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 complex.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 complex.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 complex.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-complex.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 complex.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 complex.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 complex.$(OBJEXT): {$(VPATH)}complex.c
@@ -3213,7 +3205,6 @@ cont.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 cont.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 cont.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 cont.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-cont.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 cont.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 cont.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 cont.$(OBJEXT): {$(VPATH)}config.h
@@ -3402,7 +3393,6 @@ debug.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 debug.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 debug.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 debug.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-debug.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 debug.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 debug.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 debug.$(OBJEXT): {$(VPATH)}config.h
@@ -3583,7 +3573,6 @@ debug_counter.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 debug_counter.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 debug_counter.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 debug_counter.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-debug_counter.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 debug_counter.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 debug_counter.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 debug_counter.$(OBJEXT): {$(VPATH)}config.h
@@ -3758,7 +3747,6 @@ dir.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 dir.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 dir.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 dir.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-dir.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 dir.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 dir.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 dir.$(OBJEXT): {$(VPATH)}builtin.h
@@ -3931,7 +3919,6 @@ dln.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 dln.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 dln.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 dln.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-dln.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 dln.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 dln.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 dln.$(OBJEXT): {$(VPATH)}config.h
@@ -4092,7 +4079,6 @@ dln_find.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 dln_find.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 dln_find.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 dln_find.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-dln_find.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 dln_find.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 dln_find.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 dln_find.$(OBJEXT): {$(VPATH)}config.h
@@ -4252,7 +4238,6 @@ dmydln.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 dmydln.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 dmydln.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 dmydln.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-dmydln.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 dmydln.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 dmydln.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 dmydln.$(OBJEXT): {$(VPATH)}config.h
@@ -4466,7 +4451,6 @@ encoding.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 encoding.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 encoding.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 encoding.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-encoding.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 encoding.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 encoding.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 encoding.$(OBJEXT): {$(VPATH)}config.h
@@ -4654,7 +4638,6 @@ enum.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 enum.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 enum.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 enum.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-enum.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 enum.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 enum.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 enum.$(OBJEXT): {$(VPATH)}config.h
@@ -4841,7 +4824,6 @@ enumerator.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 enumerator.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 enumerator.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 enumerator.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-enumerator.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 enumerator.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 enumerator.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 enumerator.$(OBJEXT): {$(VPATH)}config.h
@@ -5028,7 +5010,6 @@ error.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 error.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 error.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 error.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-error.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 error.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 error.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 error.$(OBJEXT): {$(VPATH)}builtin.h
@@ -5230,7 +5211,6 @@ eval.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 eval.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 eval.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 eval.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-eval.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 eval.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 eval.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 eval.$(OBJEXT): {$(VPATH)}config.h
@@ -5448,7 +5428,6 @@ file.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 file.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 file.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 file.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-file.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 file.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 file.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 file.$(OBJEXT): {$(VPATH)}config.h
@@ -5651,7 +5630,6 @@ gc.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 gc.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 gc.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 gc.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-gc.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 gc.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 gc.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 gc.$(OBJEXT): {$(VPATH)}builtin.h
@@ -5858,7 +5836,6 @@ golf_prelude.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 golf_prelude.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 golf_prelude.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 golf_prelude.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-golf_prelude.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 golf_prelude.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 golf_prelude.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 golf_prelude.$(OBJEXT): {$(VPATH)}config.h
@@ -6031,7 +6008,6 @@ goruby.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 goruby.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 goruby.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 goruby.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-goruby.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 goruby.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 goruby.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 goruby.$(OBJEXT): {$(VPATH)}config.h
@@ -6212,7 +6188,6 @@ hash.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 hash.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 hash.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 hash.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-hash.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 hash.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 hash.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 hash.$(OBJEXT): {$(VPATH)}config.h
@@ -6388,7 +6363,6 @@ inits.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 inits.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 inits.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 inits.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-inits.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 inits.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 inits.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 inits.$(OBJEXT): {$(VPATH)}builtin.h
@@ -6578,7 +6552,6 @@ io.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 io.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 io.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 io.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-io.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 io.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 io.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 io.$(OBJEXT): {$(VPATH)}builtin.h
@@ -6783,7 +6756,6 @@ iseq.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 iseq.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 iseq.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 iseq.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-iseq.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 iseq.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 iseq.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 iseq.$(OBJEXT): {$(VPATH)}builtin.h
@@ -6990,7 +6962,6 @@ load.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 load.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 load.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 load.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-load.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 load.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 load.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 load.$(OBJEXT): {$(VPATH)}config.h
@@ -7172,7 +7143,6 @@ loadpath.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 loadpath.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 loadpath.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 loadpath.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-loadpath.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 loadpath.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 loadpath.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 loadpath.$(OBJEXT): {$(VPATH)}config.h
@@ -7333,7 +7303,6 @@ localeinit.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 localeinit.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 localeinit.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 localeinit.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-localeinit.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 localeinit.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 localeinit.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 localeinit.$(OBJEXT): {$(VPATH)}config.h
@@ -7499,7 +7468,6 @@ main.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 main.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 main.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 main.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-main.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 main.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 main.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 main.$(OBJEXT): {$(VPATH)}config.h
@@ -7677,7 +7645,6 @@ marshal.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 marshal.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 marshal.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 marshal.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-marshal.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 marshal.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 marshal.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 marshal.$(OBJEXT): {$(VPATH)}config.h
@@ -7855,7 +7822,6 @@ math.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 math.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 math.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 math.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-math.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 math.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 math.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 math.$(OBJEXT): {$(VPATH)}config.h
@@ -8031,7 +7997,6 @@ miniinit.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 miniinit.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 miniinit.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 miniinit.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-miniinit.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 miniinit.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 miniinit.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 miniinit.$(OBJEXT): {$(VPATH)}builtin.h
@@ -8267,7 +8232,6 @@ mjit.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 mjit.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 mjit.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 mjit.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-mjit.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 mjit.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 mjit.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 mjit.$(OBJEXT): {$(VPATH)}config.h
@@ -8481,7 +8445,6 @@ mjit_compile.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 mjit_compile.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 mjit_compile.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 mjit_compile.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-mjit_compile.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 mjit_compile.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 mjit_compile.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 mjit_compile.$(OBJEXT): {$(VPATH)}builtin.h
@@ -8678,7 +8641,6 @@ node.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 node.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 node.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 node.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-node.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 node.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 node.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 node.$(OBJEXT): {$(VPATH)}config.h
@@ -8869,7 +8831,6 @@ numeric.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 numeric.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 numeric.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 numeric.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-numeric.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 numeric.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 numeric.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 numeric.$(OBJEXT): {$(VPATH)}builtin.h
@@ -9061,7 +9022,6 @@ object.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 object.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 object.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 object.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-object.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 object.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 object.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 object.$(OBJEXT): {$(VPATH)}builtin.h
@@ -9243,7 +9203,6 @@ pack.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 pack.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 pack.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 pack.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-pack.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 pack.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 pack.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 pack.$(OBJEXT): {$(VPATH)}builtin.h
@@ -9436,7 +9395,6 @@ parse.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 parse.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 parse.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 parse.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-parse.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 parse.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 parse.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 parse.$(OBJEXT): {$(VPATH)}config.h
@@ -9661,7 +9619,6 @@ proc.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 proc.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 proc.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 proc.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-proc.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 proc.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 proc.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 proc.$(OBJEXT): {$(VPATH)}config.h
@@ -9862,7 +9819,6 @@ process.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 process.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 process.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 process.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-process.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 process.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 process.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 process.$(OBJEXT): {$(VPATH)}config.h
@@ -10055,7 +10011,6 @@ random.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 random.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 random.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 random.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-random.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 random.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 random.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 random.$(OBJEXT): {$(VPATH)}config.h
@@ -10241,7 +10196,6 @@ range.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 range.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 range.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 range.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-range.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 range.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 range.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 range.$(OBJEXT): {$(VPATH)}config.h
@@ -10423,7 +10377,6 @@ rational.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 rational.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 rational.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 rational.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-rational.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 rational.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 rational.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 rational.$(OBJEXT): {$(VPATH)}config.h
@@ -10600,7 +10553,6 @@ re.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 re.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 re.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 re.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-re.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 re.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 re.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 re.$(OBJEXT): {$(VPATH)}config.h
@@ -10770,7 +10722,6 @@ regcomp.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 regcomp.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 regcomp.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 regcomp.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-regcomp.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 regcomp.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 regcomp.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 regcomp.$(OBJEXT): {$(VPATH)}config.h
@@ -10933,7 +10884,6 @@ regenc.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 regenc.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 regenc.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 regenc.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-regenc.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 regenc.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 regenc.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 regenc.$(OBJEXT): {$(VPATH)}config.h
@@ -11095,7 +11045,6 @@ regerror.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 regerror.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 regerror.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 regerror.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-regerror.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 regerror.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 regerror.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 regerror.$(OBJEXT): {$(VPATH)}config.h
@@ -11257,7 +11206,6 @@ regexec.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 regexec.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 regexec.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 regexec.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-regexec.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 regexec.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 regexec.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 regexec.$(OBJEXT): {$(VPATH)}config.h
@@ -11419,7 +11367,6 @@ regparse.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 regparse.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 regparse.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 regparse.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-regparse.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 regparse.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 regparse.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 regparse.$(OBJEXT): {$(VPATH)}config.h
@@ -11582,7 +11529,6 @@ regsyntax.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 regsyntax.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 regsyntax.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 regsyntax.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-regsyntax.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 regsyntax.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 regsyntax.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 regsyntax.$(OBJEXT): {$(VPATH)}config.h
@@ -11783,7 +11729,6 @@ ruby.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 ruby.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 ruby.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 ruby.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-ruby.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 ruby.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 ruby.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 ruby.$(OBJEXT): {$(VPATH)}config.h
@@ -11965,7 +11910,6 @@ setproctitle.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 setproctitle.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 setproctitle.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 setproctitle.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-setproctitle.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 setproctitle.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 setproctitle.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 setproctitle.$(OBJEXT): {$(VPATH)}config.h
@@ -12143,7 +12087,6 @@ signal.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 signal.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 signal.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 signal.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-signal.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 signal.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 signal.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 signal.$(OBJEXT): {$(VPATH)}config.h
@@ -12335,7 +12278,6 @@ sprintf.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 sprintf.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 sprintf.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 sprintf.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-sprintf.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 sprintf.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 sprintf.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 sprintf.$(OBJEXT): {$(VPATH)}config.h
@@ -12510,7 +12452,6 @@ st.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 st.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 st.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 st.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-st.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 st.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 st.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 st.$(OBJEXT): {$(VPATH)}config.h
@@ -12677,7 +12618,6 @@ strftime.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 strftime.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 strftime.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 strftime.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-strftime.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 strftime.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 strftime.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 strftime.$(OBJEXT): {$(VPATH)}config.h
@@ -12863,7 +12803,6 @@ string.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 string.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 string.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 string.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-string.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 string.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 string.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 string.$(OBJEXT): {$(VPATH)}config.h
@@ -13086,7 +13025,6 @@ struct.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 struct.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 struct.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 struct.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-struct.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 struct.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 struct.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 struct.$(OBJEXT): {$(VPATH)}builtin.h
@@ -13274,7 +13212,6 @@ symbol.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 symbol.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 symbol.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 symbol.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-symbol.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 symbol.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 symbol.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 symbol.$(OBJEXT): {$(VPATH)}config.h
@@ -13470,7 +13407,6 @@ thread.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 thread.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 thread.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 thread.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-thread.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 thread.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 thread.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 thread.$(OBJEXT): {$(VPATH)}config.h
@@ -13672,7 +13608,6 @@ time.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 time.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 time.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 time.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-time.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 time.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 time.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 time.$(OBJEXT): {$(VPATH)}config.h
@@ -13851,7 +13786,6 @@ transcode.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 transcode.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 transcode.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 transcode.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-transcode.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 transcode.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 transcode.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 transcode.$(OBJEXT): {$(VPATH)}config.h
@@ -14026,7 +13960,6 @@ transient_heap.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 transient_heap.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 transient_heap.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 transient_heap.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-transient_heap.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 transient_heap.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 transient_heap.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 transient_heap.$(OBJEXT): {$(VPATH)}config.h
@@ -14199,7 +14132,6 @@ util.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 util.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 util.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 util.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-util.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 util.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 util.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 util.$(OBJEXT): {$(VPATH)}config.h
@@ -14384,7 +14316,6 @@ variable.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 variable.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 variable.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 variable.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-variable.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 variable.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 variable.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 variable.$(OBJEXT): {$(VPATH)}config.h
@@ -14578,7 +14509,6 @@ version.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 version.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 version.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 version.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-version.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 version.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 version.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 version.$(OBJEXT): {$(VPATH)}config.h
@@ -14783,7 +14713,6 @@ vm.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 vm.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 vm.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 vm.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-vm.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 vm.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 vm.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 vm.$(OBJEXT): {$(VPATH)}builtin.h
@@ -14997,7 +14926,6 @@ vm_backtrace.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 vm_backtrace.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 vm_backtrace.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 vm_backtrace.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-vm_backtrace.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 vm_backtrace.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 vm_backtrace.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 vm_backtrace.$(OBJEXT): {$(VPATH)}config.h
@@ -15187,7 +15115,6 @@ vm_dump.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 vm_dump.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 vm_dump.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 vm_dump.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-vm_dump.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 vm_dump.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 vm_dump.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 vm_dump.$(OBJEXT): {$(VPATH)}config.h
@@ -15376,7 +15303,6 @@ vm_trace.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 vm_trace.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 vm_trace.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 vm_trace.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
-vm_trace.$(OBJEXT): {$(VPATH)}backward/2/rmodule.h
 vm_trace.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 vm_trace.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 vm_trace.$(OBJEXT): {$(VPATH)}builtin.h

--- a/enc/depend
+++ b/enc/depend
@@ -329,7 +329,6 @@ enc/ascii.$(OBJEXT): backward/2/gcc_version_since.h
 enc/ascii.$(OBJEXT): backward/2/inttypes.h
 enc/ascii.$(OBJEXT): backward/2/limits.h
 enc/ascii.$(OBJEXT): backward/2/long_long.h
-enc/ascii.$(OBJEXT): backward/2/rmodule.h
 enc/ascii.$(OBJEXT): backward/2/stdalign.h
 enc/ascii.$(OBJEXT): backward/2/stdarg.h
 enc/ascii.$(OBJEXT): config.h
@@ -551,7 +550,6 @@ enc/cesu_8.$(OBJEXT): backward/2/gcc_version_since.h
 enc/cesu_8.$(OBJEXT): backward/2/inttypes.h
 enc/cesu_8.$(OBJEXT): backward/2/limits.h
 enc/cesu_8.$(OBJEXT): backward/2/long_long.h
-enc/cesu_8.$(OBJEXT): backward/2/rmodule.h
 enc/cesu_8.$(OBJEXT): backward/2/stdalign.h
 enc/cesu_8.$(OBJEXT): backward/2/stdarg.h
 enc/cesu_8.$(OBJEXT): config.h
@@ -831,7 +829,6 @@ enc/encdb.$(OBJEXT): backward/2/gcc_version_since.h
 enc/encdb.$(OBJEXT): backward/2/inttypes.h
 enc/encdb.$(OBJEXT): backward/2/limits.h
 enc/encdb.$(OBJEXT): backward/2/long_long.h
-enc/encdb.$(OBJEXT): backward/2/rmodule.h
 enc/encdb.$(OBJEXT): backward/2/stdalign.h
 enc/encdb.$(OBJEXT): backward/2/stdarg.h
 enc/encdb.$(OBJEXT): config.h
@@ -2379,7 +2376,6 @@ enc/trans/big5.$(OBJEXT): backward/2/gcc_version_since.h
 enc/trans/big5.$(OBJEXT): backward/2/inttypes.h
 enc/trans/big5.$(OBJEXT): backward/2/limits.h
 enc/trans/big5.$(OBJEXT): backward/2/long_long.h
-enc/trans/big5.$(OBJEXT): backward/2/rmodule.h
 enc/trans/big5.$(OBJEXT): backward/2/stdalign.h
 enc/trans/big5.$(OBJEXT): backward/2/stdarg.h
 enc/trans/big5.$(OBJEXT): config.h
@@ -2540,7 +2536,6 @@ enc/trans/cesu_8.$(OBJEXT): backward/2/gcc_version_since.h
 enc/trans/cesu_8.$(OBJEXT): backward/2/inttypes.h
 enc/trans/cesu_8.$(OBJEXT): backward/2/limits.h
 enc/trans/cesu_8.$(OBJEXT): backward/2/long_long.h
-enc/trans/cesu_8.$(OBJEXT): backward/2/rmodule.h
 enc/trans/cesu_8.$(OBJEXT): backward/2/stdalign.h
 enc/trans/cesu_8.$(OBJEXT): backward/2/stdarg.h
 enc/trans/cesu_8.$(OBJEXT): config.h
@@ -2701,7 +2696,6 @@ enc/trans/chinese.$(OBJEXT): backward/2/gcc_version_since.h
 enc/trans/chinese.$(OBJEXT): backward/2/inttypes.h
 enc/trans/chinese.$(OBJEXT): backward/2/limits.h
 enc/trans/chinese.$(OBJEXT): backward/2/long_long.h
-enc/trans/chinese.$(OBJEXT): backward/2/rmodule.h
 enc/trans/chinese.$(OBJEXT): backward/2/stdalign.h
 enc/trans/chinese.$(OBJEXT): backward/2/stdarg.h
 enc/trans/chinese.$(OBJEXT): config.h
@@ -2862,7 +2856,6 @@ enc/trans/ebcdic.$(OBJEXT): backward/2/gcc_version_since.h
 enc/trans/ebcdic.$(OBJEXT): backward/2/inttypes.h
 enc/trans/ebcdic.$(OBJEXT): backward/2/limits.h
 enc/trans/ebcdic.$(OBJEXT): backward/2/long_long.h
-enc/trans/ebcdic.$(OBJEXT): backward/2/rmodule.h
 enc/trans/ebcdic.$(OBJEXT): backward/2/stdalign.h
 enc/trans/ebcdic.$(OBJEXT): backward/2/stdarg.h
 enc/trans/ebcdic.$(OBJEXT): config.h
@@ -3023,7 +3016,6 @@ enc/trans/emoji.$(OBJEXT): backward/2/gcc_version_since.h
 enc/trans/emoji.$(OBJEXT): backward/2/inttypes.h
 enc/trans/emoji.$(OBJEXT): backward/2/limits.h
 enc/trans/emoji.$(OBJEXT): backward/2/long_long.h
-enc/trans/emoji.$(OBJEXT): backward/2/rmodule.h
 enc/trans/emoji.$(OBJEXT): backward/2/stdalign.h
 enc/trans/emoji.$(OBJEXT): backward/2/stdarg.h
 enc/trans/emoji.$(OBJEXT): config.h
@@ -3184,7 +3176,6 @@ enc/trans/emoji_iso2022_kddi.$(OBJEXT): backward/2/gcc_version_since.h
 enc/trans/emoji_iso2022_kddi.$(OBJEXT): backward/2/inttypes.h
 enc/trans/emoji_iso2022_kddi.$(OBJEXT): backward/2/limits.h
 enc/trans/emoji_iso2022_kddi.$(OBJEXT): backward/2/long_long.h
-enc/trans/emoji_iso2022_kddi.$(OBJEXT): backward/2/rmodule.h
 enc/trans/emoji_iso2022_kddi.$(OBJEXT): backward/2/stdalign.h
 enc/trans/emoji_iso2022_kddi.$(OBJEXT): backward/2/stdarg.h
 enc/trans/emoji_iso2022_kddi.$(OBJEXT): config.h
@@ -3345,7 +3336,6 @@ enc/trans/emoji_sjis_docomo.$(OBJEXT): backward/2/gcc_version_since.h
 enc/trans/emoji_sjis_docomo.$(OBJEXT): backward/2/inttypes.h
 enc/trans/emoji_sjis_docomo.$(OBJEXT): backward/2/limits.h
 enc/trans/emoji_sjis_docomo.$(OBJEXT): backward/2/long_long.h
-enc/trans/emoji_sjis_docomo.$(OBJEXT): backward/2/rmodule.h
 enc/trans/emoji_sjis_docomo.$(OBJEXT): backward/2/stdalign.h
 enc/trans/emoji_sjis_docomo.$(OBJEXT): backward/2/stdarg.h
 enc/trans/emoji_sjis_docomo.$(OBJEXT): config.h
@@ -3506,7 +3496,6 @@ enc/trans/emoji_sjis_kddi.$(OBJEXT): backward/2/gcc_version_since.h
 enc/trans/emoji_sjis_kddi.$(OBJEXT): backward/2/inttypes.h
 enc/trans/emoji_sjis_kddi.$(OBJEXT): backward/2/limits.h
 enc/trans/emoji_sjis_kddi.$(OBJEXT): backward/2/long_long.h
-enc/trans/emoji_sjis_kddi.$(OBJEXT): backward/2/rmodule.h
 enc/trans/emoji_sjis_kddi.$(OBJEXT): backward/2/stdalign.h
 enc/trans/emoji_sjis_kddi.$(OBJEXT): backward/2/stdarg.h
 enc/trans/emoji_sjis_kddi.$(OBJEXT): config.h
@@ -3667,7 +3656,6 @@ enc/trans/emoji_sjis_softbank.$(OBJEXT): backward/2/gcc_version_since.h
 enc/trans/emoji_sjis_softbank.$(OBJEXT): backward/2/inttypes.h
 enc/trans/emoji_sjis_softbank.$(OBJEXT): backward/2/limits.h
 enc/trans/emoji_sjis_softbank.$(OBJEXT): backward/2/long_long.h
-enc/trans/emoji_sjis_softbank.$(OBJEXT): backward/2/rmodule.h
 enc/trans/emoji_sjis_softbank.$(OBJEXT): backward/2/stdalign.h
 enc/trans/emoji_sjis_softbank.$(OBJEXT): backward/2/stdarg.h
 enc/trans/emoji_sjis_softbank.$(OBJEXT): config.h
@@ -3828,7 +3816,6 @@ enc/trans/escape.$(OBJEXT): backward/2/gcc_version_since.h
 enc/trans/escape.$(OBJEXT): backward/2/inttypes.h
 enc/trans/escape.$(OBJEXT): backward/2/limits.h
 enc/trans/escape.$(OBJEXT): backward/2/long_long.h
-enc/trans/escape.$(OBJEXT): backward/2/rmodule.h
 enc/trans/escape.$(OBJEXT): backward/2/stdalign.h
 enc/trans/escape.$(OBJEXT): backward/2/stdarg.h
 enc/trans/escape.$(OBJEXT): config.h
@@ -3989,7 +3976,6 @@ enc/trans/gb18030.$(OBJEXT): backward/2/gcc_version_since.h
 enc/trans/gb18030.$(OBJEXT): backward/2/inttypes.h
 enc/trans/gb18030.$(OBJEXT): backward/2/limits.h
 enc/trans/gb18030.$(OBJEXT): backward/2/long_long.h
-enc/trans/gb18030.$(OBJEXT): backward/2/rmodule.h
 enc/trans/gb18030.$(OBJEXT): backward/2/stdalign.h
 enc/trans/gb18030.$(OBJEXT): backward/2/stdarg.h
 enc/trans/gb18030.$(OBJEXT): config.h
@@ -4150,7 +4136,6 @@ enc/trans/gbk.$(OBJEXT): backward/2/gcc_version_since.h
 enc/trans/gbk.$(OBJEXT): backward/2/inttypes.h
 enc/trans/gbk.$(OBJEXT): backward/2/limits.h
 enc/trans/gbk.$(OBJEXT): backward/2/long_long.h
-enc/trans/gbk.$(OBJEXT): backward/2/rmodule.h
 enc/trans/gbk.$(OBJEXT): backward/2/stdalign.h
 enc/trans/gbk.$(OBJEXT): backward/2/stdarg.h
 enc/trans/gbk.$(OBJEXT): config.h
@@ -4311,7 +4296,6 @@ enc/trans/iso2022.$(OBJEXT): backward/2/gcc_version_since.h
 enc/trans/iso2022.$(OBJEXT): backward/2/inttypes.h
 enc/trans/iso2022.$(OBJEXT): backward/2/limits.h
 enc/trans/iso2022.$(OBJEXT): backward/2/long_long.h
-enc/trans/iso2022.$(OBJEXT): backward/2/rmodule.h
 enc/trans/iso2022.$(OBJEXT): backward/2/stdalign.h
 enc/trans/iso2022.$(OBJEXT): backward/2/stdarg.h
 enc/trans/iso2022.$(OBJEXT): config.h
@@ -4472,7 +4456,6 @@ enc/trans/japanese.$(OBJEXT): backward/2/gcc_version_since.h
 enc/trans/japanese.$(OBJEXT): backward/2/inttypes.h
 enc/trans/japanese.$(OBJEXT): backward/2/limits.h
 enc/trans/japanese.$(OBJEXT): backward/2/long_long.h
-enc/trans/japanese.$(OBJEXT): backward/2/rmodule.h
 enc/trans/japanese.$(OBJEXT): backward/2/stdalign.h
 enc/trans/japanese.$(OBJEXT): backward/2/stdarg.h
 enc/trans/japanese.$(OBJEXT): config.h
@@ -4633,7 +4616,6 @@ enc/trans/japanese_euc.$(OBJEXT): backward/2/gcc_version_since.h
 enc/trans/japanese_euc.$(OBJEXT): backward/2/inttypes.h
 enc/trans/japanese_euc.$(OBJEXT): backward/2/limits.h
 enc/trans/japanese_euc.$(OBJEXT): backward/2/long_long.h
-enc/trans/japanese_euc.$(OBJEXT): backward/2/rmodule.h
 enc/trans/japanese_euc.$(OBJEXT): backward/2/stdalign.h
 enc/trans/japanese_euc.$(OBJEXT): backward/2/stdarg.h
 enc/trans/japanese_euc.$(OBJEXT): config.h
@@ -4794,7 +4776,6 @@ enc/trans/japanese_sjis.$(OBJEXT): backward/2/gcc_version_since.h
 enc/trans/japanese_sjis.$(OBJEXT): backward/2/inttypes.h
 enc/trans/japanese_sjis.$(OBJEXT): backward/2/limits.h
 enc/trans/japanese_sjis.$(OBJEXT): backward/2/long_long.h
-enc/trans/japanese_sjis.$(OBJEXT): backward/2/rmodule.h
 enc/trans/japanese_sjis.$(OBJEXT): backward/2/stdalign.h
 enc/trans/japanese_sjis.$(OBJEXT): backward/2/stdarg.h
 enc/trans/japanese_sjis.$(OBJEXT): config.h
@@ -4955,7 +4936,6 @@ enc/trans/korean.$(OBJEXT): backward/2/gcc_version_since.h
 enc/trans/korean.$(OBJEXT): backward/2/inttypes.h
 enc/trans/korean.$(OBJEXT): backward/2/limits.h
 enc/trans/korean.$(OBJEXT): backward/2/long_long.h
-enc/trans/korean.$(OBJEXT): backward/2/rmodule.h
 enc/trans/korean.$(OBJEXT): backward/2/stdalign.h
 enc/trans/korean.$(OBJEXT): backward/2/stdarg.h
 enc/trans/korean.$(OBJEXT): config.h
@@ -5115,7 +5095,6 @@ enc/trans/newline.$(OBJEXT): backward/2/gcc_version_since.h
 enc/trans/newline.$(OBJEXT): backward/2/inttypes.h
 enc/trans/newline.$(OBJEXT): backward/2/limits.h
 enc/trans/newline.$(OBJEXT): backward/2/long_long.h
-enc/trans/newline.$(OBJEXT): backward/2/rmodule.h
 enc/trans/newline.$(OBJEXT): backward/2/stdalign.h
 enc/trans/newline.$(OBJEXT): backward/2/stdarg.h
 enc/trans/newline.$(OBJEXT): config.h
@@ -5276,7 +5255,6 @@ enc/trans/single_byte.$(OBJEXT): backward/2/gcc_version_since.h
 enc/trans/single_byte.$(OBJEXT): backward/2/inttypes.h
 enc/trans/single_byte.$(OBJEXT): backward/2/limits.h
 enc/trans/single_byte.$(OBJEXT): backward/2/long_long.h
-enc/trans/single_byte.$(OBJEXT): backward/2/rmodule.h
 enc/trans/single_byte.$(OBJEXT): backward/2/stdalign.h
 enc/trans/single_byte.$(OBJEXT): backward/2/stdarg.h
 enc/trans/single_byte.$(OBJEXT): config.h
@@ -5439,7 +5417,6 @@ enc/trans/utf8_mac.$(OBJEXT): backward/2/gcc_version_since.h
 enc/trans/utf8_mac.$(OBJEXT): backward/2/inttypes.h
 enc/trans/utf8_mac.$(OBJEXT): backward/2/limits.h
 enc/trans/utf8_mac.$(OBJEXT): backward/2/long_long.h
-enc/trans/utf8_mac.$(OBJEXT): backward/2/rmodule.h
 enc/trans/utf8_mac.$(OBJEXT): backward/2/stdalign.h
 enc/trans/utf8_mac.$(OBJEXT): backward/2/stdarg.h
 enc/trans/utf8_mac.$(OBJEXT): config.h
@@ -5600,7 +5577,6 @@ enc/trans/utf_16_32.$(OBJEXT): backward/2/gcc_version_since.h
 enc/trans/utf_16_32.$(OBJEXT): backward/2/inttypes.h
 enc/trans/utf_16_32.$(OBJEXT): backward/2/limits.h
 enc/trans/utf_16_32.$(OBJEXT): backward/2/long_long.h
-enc/trans/utf_16_32.$(OBJEXT): backward/2/rmodule.h
 enc/trans/utf_16_32.$(OBJEXT): backward/2/stdalign.h
 enc/trans/utf_16_32.$(OBJEXT): backward/2/stdarg.h
 enc/trans/utf_16_32.$(OBJEXT): config.h
@@ -5763,7 +5739,6 @@ enc/unicode.$(OBJEXT): backward/2/gcc_version_since.h
 enc/unicode.$(OBJEXT): backward/2/inttypes.h
 enc/unicode.$(OBJEXT): backward/2/limits.h
 enc/unicode.$(OBJEXT): backward/2/long_long.h
-enc/unicode.$(OBJEXT): backward/2/rmodule.h
 enc/unicode.$(OBJEXT): backward/2/stdalign.h
 enc/unicode.$(OBJEXT): backward/2/stdarg.h
 enc/unicode.$(OBJEXT): config.h
@@ -5925,7 +5900,6 @@ enc/us_ascii.$(OBJEXT): backward/2/gcc_version_since.h
 enc/us_ascii.$(OBJEXT): backward/2/inttypes.h
 enc/us_ascii.$(OBJEXT): backward/2/limits.h
 enc/us_ascii.$(OBJEXT): backward/2/long_long.h
-enc/us_ascii.$(OBJEXT): backward/2/rmodule.h
 enc/us_ascii.$(OBJEXT): backward/2/stdalign.h
 enc/us_ascii.$(OBJEXT): backward/2/stdarg.h
 enc/us_ascii.$(OBJEXT): config.h
@@ -6321,7 +6295,6 @@ enc/utf_8.$(OBJEXT): backward/2/gcc_version_since.h
 enc/utf_8.$(OBJEXT): backward/2/inttypes.h
 enc/utf_8.$(OBJEXT): backward/2/limits.h
 enc/utf_8.$(OBJEXT): backward/2/long_long.h
-enc/utf_8.$(OBJEXT): backward/2/rmodule.h
 enc/utf_8.$(OBJEXT): backward/2/stdalign.h
 enc/utf_8.$(OBJEXT): backward/2/stdarg.h
 enc/utf_8.$(OBJEXT): config.h

--- a/ext/-test-/arith_seq/extract/depend
+++ b/ext/-test-/arith_seq/extract/depend
@@ -150,7 +150,6 @@ extract.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 extract.o: $(hdrdir)/ruby/backward/2/inttypes.h
 extract.o: $(hdrdir)/ruby/backward/2/limits.h
 extract.o: $(hdrdir)/ruby/backward/2/long_long.h
-extract.o: $(hdrdir)/ruby/backward/2/rmodule.h
 extract.o: $(hdrdir)/ruby/backward/2/stdalign.h
 extract.o: $(hdrdir)/ruby/backward/2/stdarg.h
 extract.o: $(hdrdir)/ruby/defines.h

--- a/ext/-test-/array/resize/depend
+++ b/ext/-test-/array/resize/depend
@@ -150,7 +150,6 @@ resize.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 resize.o: $(hdrdir)/ruby/backward/2/inttypes.h
 resize.o: $(hdrdir)/ruby/backward/2/limits.h
 resize.o: $(hdrdir)/ruby/backward/2/long_long.h
-resize.o: $(hdrdir)/ruby/backward/2/rmodule.h
 resize.o: $(hdrdir)/ruby/backward/2/stdalign.h
 resize.o: $(hdrdir)/ruby/backward/2/stdarg.h
 resize.o: $(hdrdir)/ruby/defines.h

--- a/ext/-test-/bignum/depend
+++ b/ext/-test-/bignum/depend
@@ -151,7 +151,6 @@ big2str.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 big2str.o: $(hdrdir)/ruby/backward/2/inttypes.h
 big2str.o: $(hdrdir)/ruby/backward/2/limits.h
 big2str.o: $(hdrdir)/ruby/backward/2/long_long.h
-big2str.o: $(hdrdir)/ruby/backward/2/rmodule.h
 big2str.o: $(hdrdir)/ruby/backward/2/stdalign.h
 big2str.o: $(hdrdir)/ruby/backward/2/stdarg.h
 big2str.o: $(hdrdir)/ruby/defines.h
@@ -315,7 +314,6 @@ bigzero.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 bigzero.o: $(hdrdir)/ruby/backward/2/inttypes.h
 bigzero.o: $(hdrdir)/ruby/backward/2/limits.h
 bigzero.o: $(hdrdir)/ruby/backward/2/long_long.h
-bigzero.o: $(hdrdir)/ruby/backward/2/rmodule.h
 bigzero.o: $(hdrdir)/ruby/backward/2/stdalign.h
 bigzero.o: $(hdrdir)/ruby/backward/2/stdarg.h
 bigzero.o: $(hdrdir)/ruby/defines.h
@@ -479,7 +477,6 @@ div.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 div.o: $(hdrdir)/ruby/backward/2/inttypes.h
 div.o: $(hdrdir)/ruby/backward/2/limits.h
 div.o: $(hdrdir)/ruby/backward/2/long_long.h
-div.o: $(hdrdir)/ruby/backward/2/rmodule.h
 div.o: $(hdrdir)/ruby/backward/2/stdalign.h
 div.o: $(hdrdir)/ruby/backward/2/stdarg.h
 div.o: $(hdrdir)/ruby/defines.h
@@ -643,7 +640,6 @@ init.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 init.o: $(hdrdir)/ruby/backward/2/inttypes.h
 init.o: $(hdrdir)/ruby/backward/2/limits.h
 init.o: $(hdrdir)/ruby/backward/2/long_long.h
-init.o: $(hdrdir)/ruby/backward/2/rmodule.h
 init.o: $(hdrdir)/ruby/backward/2/stdalign.h
 init.o: $(hdrdir)/ruby/backward/2/stdarg.h
 init.o: $(hdrdir)/ruby/defines.h
@@ -805,7 +801,6 @@ intpack.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 intpack.o: $(hdrdir)/ruby/backward/2/inttypes.h
 intpack.o: $(hdrdir)/ruby/backward/2/limits.h
 intpack.o: $(hdrdir)/ruby/backward/2/long_long.h
-intpack.o: $(hdrdir)/ruby/backward/2/rmodule.h
 intpack.o: $(hdrdir)/ruby/backward/2/stdalign.h
 intpack.o: $(hdrdir)/ruby/backward/2/stdarg.h
 intpack.o: $(hdrdir)/ruby/defines.h
@@ -969,7 +964,6 @@ mul.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 mul.o: $(hdrdir)/ruby/backward/2/inttypes.h
 mul.o: $(hdrdir)/ruby/backward/2/limits.h
 mul.o: $(hdrdir)/ruby/backward/2/long_long.h
-mul.o: $(hdrdir)/ruby/backward/2/rmodule.h
 mul.o: $(hdrdir)/ruby/backward/2/stdalign.h
 mul.o: $(hdrdir)/ruby/backward/2/stdarg.h
 mul.o: $(hdrdir)/ruby/defines.h
@@ -1133,7 +1127,6 @@ str2big.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 str2big.o: $(hdrdir)/ruby/backward/2/inttypes.h
 str2big.o: $(hdrdir)/ruby/backward/2/limits.h
 str2big.o: $(hdrdir)/ruby/backward/2/long_long.h
-str2big.o: $(hdrdir)/ruby/backward/2/rmodule.h
 str2big.o: $(hdrdir)/ruby/backward/2/stdalign.h
 str2big.o: $(hdrdir)/ruby/backward/2/stdarg.h
 str2big.o: $(hdrdir)/ruby/defines.h

--- a/ext/-test-/bug-14834/depend
+++ b/ext/-test-/bug-14834/depend
@@ -150,7 +150,6 @@ bug-14384.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 bug-14384.o: $(hdrdir)/ruby/backward/2/inttypes.h
 bug-14384.o: $(hdrdir)/ruby/backward/2/limits.h
 bug-14384.o: $(hdrdir)/ruby/backward/2/long_long.h
-bug-14384.o: $(hdrdir)/ruby/backward/2/rmodule.h
 bug-14384.o: $(hdrdir)/ruby/backward/2/stdalign.h
 bug-14384.o: $(hdrdir)/ruby/backward/2/stdarg.h
 bug-14384.o: $(hdrdir)/ruby/debug.h

--- a/ext/-test-/bug-3571/depend
+++ b/ext/-test-/bug-3571/depend
@@ -151,7 +151,6 @@ bug.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 bug.o: $(hdrdir)/ruby/backward/2/inttypes.h
 bug.o: $(hdrdir)/ruby/backward/2/limits.h
 bug.o: $(hdrdir)/ruby/backward/2/long_long.h
-bug.o: $(hdrdir)/ruby/backward/2/rmodule.h
 bug.o: $(hdrdir)/ruby/backward/2/stdalign.h
 bug.o: $(hdrdir)/ruby/backward/2/stdarg.h
 bug.o: $(hdrdir)/ruby/defines.h

--- a/ext/-test-/bug-5832/depend
+++ b/ext/-test-/bug-5832/depend
@@ -151,7 +151,6 @@ bug.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 bug.o: $(hdrdir)/ruby/backward/2/inttypes.h
 bug.o: $(hdrdir)/ruby/backward/2/limits.h
 bug.o: $(hdrdir)/ruby/backward/2/long_long.h
-bug.o: $(hdrdir)/ruby/backward/2/rmodule.h
 bug.o: $(hdrdir)/ruby/backward/2/stdalign.h
 bug.o: $(hdrdir)/ruby/backward/2/stdarg.h
 bug.o: $(hdrdir)/ruby/defines.h

--- a/ext/-test-/bug_reporter/depend
+++ b/ext/-test-/bug_reporter/depend
@@ -151,7 +151,6 @@ bug_reporter.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 bug_reporter.o: $(hdrdir)/ruby/backward/2/inttypes.h
 bug_reporter.o: $(hdrdir)/ruby/backward/2/limits.h
 bug_reporter.o: $(hdrdir)/ruby/backward/2/long_long.h
-bug_reporter.o: $(hdrdir)/ruby/backward/2/rmodule.h
 bug_reporter.o: $(hdrdir)/ruby/backward/2/stdalign.h
 bug_reporter.o: $(hdrdir)/ruby/backward/2/stdarg.h
 bug_reporter.o: $(hdrdir)/ruby/defines.h

--- a/ext/-test-/class/depend
+++ b/ext/-test-/class/depend
@@ -150,7 +150,6 @@ class2name.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 class2name.o: $(hdrdir)/ruby/backward/2/inttypes.h
 class2name.o: $(hdrdir)/ruby/backward/2/limits.h
 class2name.o: $(hdrdir)/ruby/backward/2/long_long.h
-class2name.o: $(hdrdir)/ruby/backward/2/rmodule.h
 class2name.o: $(hdrdir)/ruby/backward/2/stdalign.h
 class2name.o: $(hdrdir)/ruby/backward/2/stdarg.h
 class2name.o: $(hdrdir)/ruby/defines.h
@@ -312,7 +311,6 @@ init.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 init.o: $(hdrdir)/ruby/backward/2/inttypes.h
 init.o: $(hdrdir)/ruby/backward/2/limits.h
 init.o: $(hdrdir)/ruby/backward/2/long_long.h
-init.o: $(hdrdir)/ruby/backward/2/rmodule.h
 init.o: $(hdrdir)/ruby/backward/2/stdalign.h
 init.o: $(hdrdir)/ruby/backward/2/stdarg.h
 init.o: $(hdrdir)/ruby/defines.h

--- a/ext/-test-/debug/depend
+++ b/ext/-test-/debug/depend
@@ -151,7 +151,6 @@ init.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 init.o: $(hdrdir)/ruby/backward/2/inttypes.h
 init.o: $(hdrdir)/ruby/backward/2/limits.h
 init.o: $(hdrdir)/ruby/backward/2/long_long.h
-init.o: $(hdrdir)/ruby/backward/2/rmodule.h
 init.o: $(hdrdir)/ruby/backward/2/stdalign.h
 init.o: $(hdrdir)/ruby/backward/2/stdarg.h
 init.o: $(hdrdir)/ruby/defines.h
@@ -312,7 +311,6 @@ inspector.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 inspector.o: $(hdrdir)/ruby/backward/2/inttypes.h
 inspector.o: $(hdrdir)/ruby/backward/2/limits.h
 inspector.o: $(hdrdir)/ruby/backward/2/long_long.h
-inspector.o: $(hdrdir)/ruby/backward/2/rmodule.h
 inspector.o: $(hdrdir)/ruby/backward/2/stdalign.h
 inspector.o: $(hdrdir)/ruby/backward/2/stdarg.h
 inspector.o: $(hdrdir)/ruby/debug.h
@@ -474,7 +472,6 @@ profile_frames.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 profile_frames.o: $(hdrdir)/ruby/backward/2/inttypes.h
 profile_frames.o: $(hdrdir)/ruby/backward/2/limits.h
 profile_frames.o: $(hdrdir)/ruby/backward/2/long_long.h
-profile_frames.o: $(hdrdir)/ruby/backward/2/rmodule.h
 profile_frames.o: $(hdrdir)/ruby/backward/2/stdalign.h
 profile_frames.o: $(hdrdir)/ruby/backward/2/stdarg.h
 profile_frames.o: $(hdrdir)/ruby/debug.h

--- a/ext/-test-/enumerator_kw/depend
+++ b/ext/-test-/enumerator_kw/depend
@@ -151,7 +151,6 @@ enumerator_kw.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 enumerator_kw.o: $(hdrdir)/ruby/backward/2/inttypes.h
 enumerator_kw.o: $(hdrdir)/ruby/backward/2/limits.h
 enumerator_kw.o: $(hdrdir)/ruby/backward/2/long_long.h
-enumerator_kw.o: $(hdrdir)/ruby/backward/2/rmodule.h
 enumerator_kw.o: $(hdrdir)/ruby/backward/2/stdalign.h
 enumerator_kw.o: $(hdrdir)/ruby/backward/2/stdarg.h
 enumerator_kw.o: $(hdrdir)/ruby/defines.h

--- a/ext/-test-/exception/depend
+++ b/ext/-test-/exception/depend
@@ -150,7 +150,6 @@ dataerror.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 dataerror.o: $(hdrdir)/ruby/backward/2/inttypes.h
 dataerror.o: $(hdrdir)/ruby/backward/2/limits.h
 dataerror.o: $(hdrdir)/ruby/backward/2/long_long.h
-dataerror.o: $(hdrdir)/ruby/backward/2/rmodule.h
 dataerror.o: $(hdrdir)/ruby/backward/2/stdalign.h
 dataerror.o: $(hdrdir)/ruby/backward/2/stdarg.h
 dataerror.o: $(hdrdir)/ruby/defines.h
@@ -312,7 +311,6 @@ enc_raise.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 enc_raise.o: $(hdrdir)/ruby/backward/2/inttypes.h
 enc_raise.o: $(hdrdir)/ruby/backward/2/limits.h
 enc_raise.o: $(hdrdir)/ruby/backward/2/long_long.h
-enc_raise.o: $(hdrdir)/ruby/backward/2/rmodule.h
 enc_raise.o: $(hdrdir)/ruby/backward/2/stdalign.h
 enc_raise.o: $(hdrdir)/ruby/backward/2/stdarg.h
 enc_raise.o: $(hdrdir)/ruby/defines.h
@@ -477,7 +475,6 @@ ensured.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ensured.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ensured.o: $(hdrdir)/ruby/backward/2/limits.h
 ensured.o: $(hdrdir)/ruby/backward/2/long_long.h
-ensured.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ensured.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ensured.o: $(hdrdir)/ruby/backward/2/stdarg.h
 ensured.o: $(hdrdir)/ruby/defines.h
@@ -639,7 +636,6 @@ init.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 init.o: $(hdrdir)/ruby/backward/2/inttypes.h
 init.o: $(hdrdir)/ruby/backward/2/limits.h
 init.o: $(hdrdir)/ruby/backward/2/long_long.h
-init.o: $(hdrdir)/ruby/backward/2/rmodule.h
 init.o: $(hdrdir)/ruby/backward/2/stdalign.h
 init.o: $(hdrdir)/ruby/backward/2/stdarg.h
 init.o: $(hdrdir)/ruby/defines.h

--- a/ext/-test-/fatal/depend
+++ b/ext/-test-/fatal/depend
@@ -151,7 +151,6 @@ rb_fatal.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 rb_fatal.o: $(hdrdir)/ruby/backward/2/inttypes.h
 rb_fatal.o: $(hdrdir)/ruby/backward/2/limits.h
 rb_fatal.o: $(hdrdir)/ruby/backward/2/long_long.h
-rb_fatal.o: $(hdrdir)/ruby/backward/2/rmodule.h
 rb_fatal.o: $(hdrdir)/ruby/backward/2/stdalign.h
 rb_fatal.o: $(hdrdir)/ruby/backward/2/stdarg.h
 rb_fatal.o: $(hdrdir)/ruby/defines.h

--- a/ext/-test-/file/depend
+++ b/ext/-test-/file/depend
@@ -150,7 +150,6 @@ fs.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 fs.o: $(hdrdir)/ruby/backward/2/inttypes.h
 fs.o: $(hdrdir)/ruby/backward/2/limits.h
 fs.o: $(hdrdir)/ruby/backward/2/long_long.h
-fs.o: $(hdrdir)/ruby/backward/2/rmodule.h
 fs.o: $(hdrdir)/ruby/backward/2/stdalign.h
 fs.o: $(hdrdir)/ruby/backward/2/stdarg.h
 fs.o: $(hdrdir)/ruby/defines.h
@@ -316,7 +315,6 @@ init.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 init.o: $(hdrdir)/ruby/backward/2/inttypes.h
 init.o: $(hdrdir)/ruby/backward/2/limits.h
 init.o: $(hdrdir)/ruby/backward/2/long_long.h
-init.o: $(hdrdir)/ruby/backward/2/rmodule.h
 init.o: $(hdrdir)/ruby/backward/2/stdalign.h
 init.o: $(hdrdir)/ruby/backward/2/stdarg.h
 init.o: $(hdrdir)/ruby/defines.h
@@ -477,7 +475,6 @@ stat.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 stat.o: $(hdrdir)/ruby/backward/2/inttypes.h
 stat.o: $(hdrdir)/ruby/backward/2/limits.h
 stat.o: $(hdrdir)/ruby/backward/2/long_long.h
-stat.o: $(hdrdir)/ruby/backward/2/rmodule.h
 stat.o: $(hdrdir)/ruby/backward/2/stdalign.h
 stat.o: $(hdrdir)/ruby/backward/2/stdarg.h
 stat.o: $(hdrdir)/ruby/defines.h

--- a/ext/-test-/float/depend
+++ b/ext/-test-/float/depend
@@ -154,7 +154,6 @@ init.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 init.o: $(hdrdir)/ruby/backward/2/inttypes.h
 init.o: $(hdrdir)/ruby/backward/2/limits.h
 init.o: $(hdrdir)/ruby/backward/2/long_long.h
-init.o: $(hdrdir)/ruby/backward/2/rmodule.h
 init.o: $(hdrdir)/ruby/backward/2/stdalign.h
 init.o: $(hdrdir)/ruby/backward/2/stdarg.h
 init.o: $(hdrdir)/ruby/defines.h
@@ -316,7 +315,6 @@ nextafter.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 nextafter.o: $(hdrdir)/ruby/backward/2/inttypes.h
 nextafter.o: $(hdrdir)/ruby/backward/2/limits.h
 nextafter.o: $(hdrdir)/ruby/backward/2/long_long.h
-nextafter.o: $(hdrdir)/ruby/backward/2/rmodule.h
 nextafter.o: $(hdrdir)/ruby/backward/2/stdalign.h
 nextafter.o: $(hdrdir)/ruby/backward/2/stdarg.h
 nextafter.o: $(hdrdir)/ruby/defines.h

--- a/ext/-test-/funcall/depend
+++ b/ext/-test-/funcall/depend
@@ -151,7 +151,6 @@ funcall.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 funcall.o: $(hdrdir)/ruby/backward/2/inttypes.h
 funcall.o: $(hdrdir)/ruby/backward/2/limits.h
 funcall.o: $(hdrdir)/ruby/backward/2/long_long.h
-funcall.o: $(hdrdir)/ruby/backward/2/rmodule.h
 funcall.o: $(hdrdir)/ruby/backward/2/stdalign.h
 funcall.o: $(hdrdir)/ruby/backward/2/stdarg.h
 funcall.o: $(hdrdir)/ruby/defines.h

--- a/ext/-test-/gvl/call_without_gvl/depend
+++ b/ext/-test-/gvl/call_without_gvl/depend
@@ -150,7 +150,6 @@ call_without_gvl.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 call_without_gvl.o: $(hdrdir)/ruby/backward/2/inttypes.h
 call_without_gvl.o: $(hdrdir)/ruby/backward/2/limits.h
 call_without_gvl.o: $(hdrdir)/ruby/backward/2/long_long.h
-call_without_gvl.o: $(hdrdir)/ruby/backward/2/rmodule.h
 call_without_gvl.o: $(hdrdir)/ruby/backward/2/stdalign.h
 call_without_gvl.o: $(hdrdir)/ruby/backward/2/stdarg.h
 call_without_gvl.o: $(hdrdir)/ruby/defines.h

--- a/ext/-test-/hash/depend
+++ b/ext/-test-/hash/depend
@@ -151,7 +151,6 @@ delete.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 delete.o: $(hdrdir)/ruby/backward/2/inttypes.h
 delete.o: $(hdrdir)/ruby/backward/2/limits.h
 delete.o: $(hdrdir)/ruby/backward/2/long_long.h
-delete.o: $(hdrdir)/ruby/backward/2/rmodule.h
 delete.o: $(hdrdir)/ruby/backward/2/stdalign.h
 delete.o: $(hdrdir)/ruby/backward/2/stdarg.h
 delete.o: $(hdrdir)/ruby/defines.h
@@ -313,7 +312,6 @@ init.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 init.o: $(hdrdir)/ruby/backward/2/inttypes.h
 init.o: $(hdrdir)/ruby/backward/2/limits.h
 init.o: $(hdrdir)/ruby/backward/2/long_long.h
-init.o: $(hdrdir)/ruby/backward/2/rmodule.h
 init.o: $(hdrdir)/ruby/backward/2/stdalign.h
 init.o: $(hdrdir)/ruby/backward/2/stdarg.h
 init.o: $(hdrdir)/ruby/defines.h

--- a/ext/-test-/integer/depend
+++ b/ext/-test-/integer/depend
@@ -151,7 +151,6 @@ core_ext.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 core_ext.o: $(hdrdir)/ruby/backward/2/inttypes.h
 core_ext.o: $(hdrdir)/ruby/backward/2/limits.h
 core_ext.o: $(hdrdir)/ruby/backward/2/long_long.h
-core_ext.o: $(hdrdir)/ruby/backward/2/rmodule.h
 core_ext.o: $(hdrdir)/ruby/backward/2/stdalign.h
 core_ext.o: $(hdrdir)/ruby/backward/2/stdarg.h
 core_ext.o: $(hdrdir)/ruby/defines.h
@@ -322,7 +321,6 @@ init.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 init.o: $(hdrdir)/ruby/backward/2/inttypes.h
 init.o: $(hdrdir)/ruby/backward/2/limits.h
 init.o: $(hdrdir)/ruby/backward/2/long_long.h
-init.o: $(hdrdir)/ruby/backward/2/rmodule.h
 init.o: $(hdrdir)/ruby/backward/2/stdalign.h
 init.o: $(hdrdir)/ruby/backward/2/stdarg.h
 init.o: $(hdrdir)/ruby/defines.h
@@ -484,7 +482,6 @@ my_integer.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 my_integer.o: $(hdrdir)/ruby/backward/2/inttypes.h
 my_integer.o: $(hdrdir)/ruby/backward/2/limits.h
 my_integer.o: $(hdrdir)/ruby/backward/2/long_long.h
-my_integer.o: $(hdrdir)/ruby/backward/2/rmodule.h
 my_integer.o: $(hdrdir)/ruby/backward/2/stdalign.h
 my_integer.o: $(hdrdir)/ruby/backward/2/stdarg.h
 my_integer.o: $(hdrdir)/ruby/defines.h

--- a/ext/-test-/iseq_load/depend
+++ b/ext/-test-/iseq_load/depend
@@ -151,7 +151,6 @@ iseq_load.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 iseq_load.o: $(hdrdir)/ruby/backward/2/inttypes.h
 iseq_load.o: $(hdrdir)/ruby/backward/2/limits.h
 iseq_load.o: $(hdrdir)/ruby/backward/2/long_long.h
-iseq_load.o: $(hdrdir)/ruby/backward/2/rmodule.h
 iseq_load.o: $(hdrdir)/ruby/backward/2/stdalign.h
 iseq_load.o: $(hdrdir)/ruby/backward/2/stdarg.h
 iseq_load.o: $(hdrdir)/ruby/defines.h

--- a/ext/-test-/iter/depend
+++ b/ext/-test-/iter/depend
@@ -151,7 +151,6 @@ break.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 break.o: $(hdrdir)/ruby/backward/2/inttypes.h
 break.o: $(hdrdir)/ruby/backward/2/limits.h
 break.o: $(hdrdir)/ruby/backward/2/long_long.h
-break.o: $(hdrdir)/ruby/backward/2/rmodule.h
 break.o: $(hdrdir)/ruby/backward/2/stdalign.h
 break.o: $(hdrdir)/ruby/backward/2/stdarg.h
 break.o: $(hdrdir)/ruby/defines.h
@@ -313,7 +312,6 @@ init.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 init.o: $(hdrdir)/ruby/backward/2/inttypes.h
 init.o: $(hdrdir)/ruby/backward/2/limits.h
 init.o: $(hdrdir)/ruby/backward/2/long_long.h
-init.o: $(hdrdir)/ruby/backward/2/rmodule.h
 init.o: $(hdrdir)/ruby/backward/2/stdalign.h
 init.o: $(hdrdir)/ruby/backward/2/stdarg.h
 init.o: $(hdrdir)/ruby/defines.h
@@ -475,7 +473,6 @@ yield.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 yield.o: $(hdrdir)/ruby/backward/2/inttypes.h
 yield.o: $(hdrdir)/ruby/backward/2/limits.h
 yield.o: $(hdrdir)/ruby/backward/2/long_long.h
-yield.o: $(hdrdir)/ruby/backward/2/rmodule.h
 yield.o: $(hdrdir)/ruby/backward/2/stdalign.h
 yield.o: $(hdrdir)/ruby/backward/2/stdarg.h
 yield.o: $(hdrdir)/ruby/defines.h

--- a/ext/-test-/load/protect/depend
+++ b/ext/-test-/load/protect/depend
@@ -151,7 +151,6 @@ protect.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 protect.o: $(hdrdir)/ruby/backward/2/inttypes.h
 protect.o: $(hdrdir)/ruby/backward/2/limits.h
 protect.o: $(hdrdir)/ruby/backward/2/long_long.h
-protect.o: $(hdrdir)/ruby/backward/2/rmodule.h
 protect.o: $(hdrdir)/ruby/backward/2/stdalign.h
 protect.o: $(hdrdir)/ruby/backward/2/stdarg.h
 protect.o: $(hdrdir)/ruby/defines.h

--- a/ext/-test-/marshal/compat/depend
+++ b/ext/-test-/marshal/compat/depend
@@ -151,7 +151,6 @@ usrcompat.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 usrcompat.o: $(hdrdir)/ruby/backward/2/inttypes.h
 usrcompat.o: $(hdrdir)/ruby/backward/2/limits.h
 usrcompat.o: $(hdrdir)/ruby/backward/2/long_long.h
-usrcompat.o: $(hdrdir)/ruby/backward/2/rmodule.h
 usrcompat.o: $(hdrdir)/ruby/backward/2/stdalign.h
 usrcompat.o: $(hdrdir)/ruby/backward/2/stdarg.h
 usrcompat.o: $(hdrdir)/ruby/defines.h

--- a/ext/-test-/marshal/internal_ivar/depend
+++ b/ext/-test-/marshal/internal_ivar/depend
@@ -151,7 +151,6 @@ internal_ivar.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 internal_ivar.o: $(hdrdir)/ruby/backward/2/inttypes.h
 internal_ivar.o: $(hdrdir)/ruby/backward/2/limits.h
 internal_ivar.o: $(hdrdir)/ruby/backward/2/long_long.h
-internal_ivar.o: $(hdrdir)/ruby/backward/2/rmodule.h
 internal_ivar.o: $(hdrdir)/ruby/backward/2/stdalign.h
 internal_ivar.o: $(hdrdir)/ruby/backward/2/stdarg.h
 internal_ivar.o: $(hdrdir)/ruby/defines.h

--- a/ext/-test-/marshal/usr/depend
+++ b/ext/-test-/marshal/usr/depend
@@ -151,7 +151,6 @@ usrmarshal.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 usrmarshal.o: $(hdrdir)/ruby/backward/2/inttypes.h
 usrmarshal.o: $(hdrdir)/ruby/backward/2/limits.h
 usrmarshal.o: $(hdrdir)/ruby/backward/2/long_long.h
-usrmarshal.o: $(hdrdir)/ruby/backward/2/rmodule.h
 usrmarshal.o: $(hdrdir)/ruby/backward/2/stdalign.h
 usrmarshal.o: $(hdrdir)/ruby/backward/2/stdarg.h
 usrmarshal.o: $(hdrdir)/ruby/defines.h

--- a/ext/-test-/method/depend
+++ b/ext/-test-/method/depend
@@ -151,7 +151,6 @@ arity.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 arity.o: $(hdrdir)/ruby/backward/2/inttypes.h
 arity.o: $(hdrdir)/ruby/backward/2/limits.h
 arity.o: $(hdrdir)/ruby/backward/2/long_long.h
-arity.o: $(hdrdir)/ruby/backward/2/rmodule.h
 arity.o: $(hdrdir)/ruby/backward/2/stdalign.h
 arity.o: $(hdrdir)/ruby/backward/2/stdarg.h
 arity.o: $(hdrdir)/ruby/defines.h
@@ -313,7 +312,6 @@ init.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 init.o: $(hdrdir)/ruby/backward/2/inttypes.h
 init.o: $(hdrdir)/ruby/backward/2/limits.h
 init.o: $(hdrdir)/ruby/backward/2/long_long.h
-init.o: $(hdrdir)/ruby/backward/2/rmodule.h
 init.o: $(hdrdir)/ruby/backward/2/stdalign.h
 init.o: $(hdrdir)/ruby/backward/2/stdarg.h
 init.o: $(hdrdir)/ruby/defines.h

--- a/ext/-test-/notimplement/depend
+++ b/ext/-test-/notimplement/depend
@@ -151,7 +151,6 @@ bug.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 bug.o: $(hdrdir)/ruby/backward/2/inttypes.h
 bug.o: $(hdrdir)/ruby/backward/2/limits.h
 bug.o: $(hdrdir)/ruby/backward/2/long_long.h
-bug.o: $(hdrdir)/ruby/backward/2/rmodule.h
 bug.o: $(hdrdir)/ruby/backward/2/stdalign.h
 bug.o: $(hdrdir)/ruby/backward/2/stdarg.h
 bug.o: $(hdrdir)/ruby/defines.h

--- a/ext/-test-/num2int/depend
+++ b/ext/-test-/num2int/depend
@@ -151,7 +151,6 @@ num2int.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 num2int.o: $(hdrdir)/ruby/backward/2/inttypes.h
 num2int.o: $(hdrdir)/ruby/backward/2/limits.h
 num2int.o: $(hdrdir)/ruby/backward/2/long_long.h
-num2int.o: $(hdrdir)/ruby/backward/2/rmodule.h
 num2int.o: $(hdrdir)/ruby/backward/2/stdalign.h
 num2int.o: $(hdrdir)/ruby/backward/2/stdarg.h
 num2int.o: $(hdrdir)/ruby/defines.h

--- a/ext/-test-/path_to_class/depend
+++ b/ext/-test-/path_to_class/depend
@@ -151,7 +151,6 @@ path_to_class.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 path_to_class.o: $(hdrdir)/ruby/backward/2/inttypes.h
 path_to_class.o: $(hdrdir)/ruby/backward/2/limits.h
 path_to_class.o: $(hdrdir)/ruby/backward/2/long_long.h
-path_to_class.o: $(hdrdir)/ruby/backward/2/rmodule.h
 path_to_class.o: $(hdrdir)/ruby/backward/2/stdalign.h
 path_to_class.o: $(hdrdir)/ruby/backward/2/stdarg.h
 path_to_class.o: $(hdrdir)/ruby/defines.h

--- a/ext/-test-/popen_deadlock/depend
+++ b/ext/-test-/popen_deadlock/depend
@@ -150,7 +150,6 @@ infinite_loop_dlsym.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 infinite_loop_dlsym.o: $(hdrdir)/ruby/backward/2/inttypes.h
 infinite_loop_dlsym.o: $(hdrdir)/ruby/backward/2/limits.h
 infinite_loop_dlsym.o: $(hdrdir)/ruby/backward/2/long_long.h
-infinite_loop_dlsym.o: $(hdrdir)/ruby/backward/2/rmodule.h
 infinite_loop_dlsym.o: $(hdrdir)/ruby/backward/2/stdalign.h
 infinite_loop_dlsym.o: $(hdrdir)/ruby/backward/2/stdarg.h
 infinite_loop_dlsym.o: $(hdrdir)/ruby/defines.h

--- a/ext/-test-/postponed_job/depend
+++ b/ext/-test-/postponed_job/depend
@@ -151,7 +151,6 @@ postponed_job.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 postponed_job.o: $(hdrdir)/ruby/backward/2/inttypes.h
 postponed_job.o: $(hdrdir)/ruby/backward/2/limits.h
 postponed_job.o: $(hdrdir)/ruby/backward/2/long_long.h
-postponed_job.o: $(hdrdir)/ruby/backward/2/rmodule.h
 postponed_job.o: $(hdrdir)/ruby/backward/2/stdalign.h
 postponed_job.o: $(hdrdir)/ruby/backward/2/stdarg.h
 postponed_job.o: $(hdrdir)/ruby/debug.h

--- a/ext/-test-/printf/depend
+++ b/ext/-test-/printf/depend
@@ -151,7 +151,6 @@ printf.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 printf.o: $(hdrdir)/ruby/backward/2/inttypes.h
 printf.o: $(hdrdir)/ruby/backward/2/limits.h
 printf.o: $(hdrdir)/ruby/backward/2/long_long.h
-printf.o: $(hdrdir)/ruby/backward/2/rmodule.h
 printf.o: $(hdrdir)/ruby/backward/2/stdalign.h
 printf.o: $(hdrdir)/ruby/backward/2/stdarg.h
 printf.o: $(hdrdir)/ruby/defines.h

--- a/ext/-test-/proc/depend
+++ b/ext/-test-/proc/depend
@@ -151,7 +151,6 @@ init.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 init.o: $(hdrdir)/ruby/backward/2/inttypes.h
 init.o: $(hdrdir)/ruby/backward/2/limits.h
 init.o: $(hdrdir)/ruby/backward/2/long_long.h
-init.o: $(hdrdir)/ruby/backward/2/rmodule.h
 init.o: $(hdrdir)/ruby/backward/2/stdalign.h
 init.o: $(hdrdir)/ruby/backward/2/stdarg.h
 init.o: $(hdrdir)/ruby/defines.h
@@ -313,7 +312,6 @@ receiver.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 receiver.o: $(hdrdir)/ruby/backward/2/inttypes.h
 receiver.o: $(hdrdir)/ruby/backward/2/limits.h
 receiver.o: $(hdrdir)/ruby/backward/2/long_long.h
-receiver.o: $(hdrdir)/ruby/backward/2/rmodule.h
 receiver.o: $(hdrdir)/ruby/backward/2/stdalign.h
 receiver.o: $(hdrdir)/ruby/backward/2/stdarg.h
 receiver.o: $(hdrdir)/ruby/defines.h
@@ -475,7 +473,6 @@ super.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 super.o: $(hdrdir)/ruby/backward/2/inttypes.h
 super.o: $(hdrdir)/ruby/backward/2/limits.h
 super.o: $(hdrdir)/ruby/backward/2/long_long.h
-super.o: $(hdrdir)/ruby/backward/2/rmodule.h
 super.o: $(hdrdir)/ruby/backward/2/stdalign.h
 super.o: $(hdrdir)/ruby/backward/2/stdarg.h
 super.o: $(hdrdir)/ruby/defines.h

--- a/ext/-test-/rational/depend
+++ b/ext/-test-/rational/depend
@@ -155,7 +155,6 @@ rat.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 rat.o: $(hdrdir)/ruby/backward/2/inttypes.h
 rat.o: $(hdrdir)/ruby/backward/2/limits.h
 rat.o: $(hdrdir)/ruby/backward/2/long_long.h
-rat.o: $(hdrdir)/ruby/backward/2/rmodule.h
 rat.o: $(hdrdir)/ruby/backward/2/stdalign.h
 rat.o: $(hdrdir)/ruby/backward/2/stdarg.h
 rat.o: $(hdrdir)/ruby/defines.h

--- a/ext/-test-/rb_call_super_kw/depend
+++ b/ext/-test-/rb_call_super_kw/depend
@@ -151,7 +151,6 @@ rb_call_super_kw.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 rb_call_super_kw.o: $(hdrdir)/ruby/backward/2/inttypes.h
 rb_call_super_kw.o: $(hdrdir)/ruby/backward/2/limits.h
 rb_call_super_kw.o: $(hdrdir)/ruby/backward/2/long_long.h
-rb_call_super_kw.o: $(hdrdir)/ruby/backward/2/rmodule.h
 rb_call_super_kw.o: $(hdrdir)/ruby/backward/2/stdalign.h
 rb_call_super_kw.o: $(hdrdir)/ruby/backward/2/stdarg.h
 rb_call_super_kw.o: $(hdrdir)/ruby/defines.h

--- a/ext/-test-/recursion/depend
+++ b/ext/-test-/recursion/depend
@@ -151,7 +151,6 @@ recursion.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 recursion.o: $(hdrdir)/ruby/backward/2/inttypes.h
 recursion.o: $(hdrdir)/ruby/backward/2/limits.h
 recursion.o: $(hdrdir)/ruby/backward/2/long_long.h
-recursion.o: $(hdrdir)/ruby/backward/2/rmodule.h
 recursion.o: $(hdrdir)/ruby/backward/2/stdalign.h
 recursion.o: $(hdrdir)/ruby/backward/2/stdarg.h
 recursion.o: $(hdrdir)/ruby/defines.h

--- a/ext/-test-/regexp/depend
+++ b/ext/-test-/regexp/depend
@@ -151,7 +151,6 @@ init.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 init.o: $(hdrdir)/ruby/backward/2/inttypes.h
 init.o: $(hdrdir)/ruby/backward/2/limits.h
 init.o: $(hdrdir)/ruby/backward/2/long_long.h
-init.o: $(hdrdir)/ruby/backward/2/rmodule.h
 init.o: $(hdrdir)/ruby/backward/2/stdalign.h
 init.o: $(hdrdir)/ruby/backward/2/stdarg.h
 init.o: $(hdrdir)/ruby/defines.h
@@ -313,7 +312,6 @@ parse_depth_limit.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 parse_depth_limit.o: $(hdrdir)/ruby/backward/2/inttypes.h
 parse_depth_limit.o: $(hdrdir)/ruby/backward/2/limits.h
 parse_depth_limit.o: $(hdrdir)/ruby/backward/2/long_long.h
-parse_depth_limit.o: $(hdrdir)/ruby/backward/2/rmodule.h
 parse_depth_limit.o: $(hdrdir)/ruby/backward/2/stdalign.h
 parse_depth_limit.o: $(hdrdir)/ruby/backward/2/stdarg.h
 parse_depth_limit.o: $(hdrdir)/ruby/defines.h

--- a/ext/-test-/scan_args/depend
+++ b/ext/-test-/scan_args/depend
@@ -151,7 +151,6 @@ scan_args.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 scan_args.o: $(hdrdir)/ruby/backward/2/inttypes.h
 scan_args.o: $(hdrdir)/ruby/backward/2/limits.h
 scan_args.o: $(hdrdir)/ruby/backward/2/long_long.h
-scan_args.o: $(hdrdir)/ruby/backward/2/rmodule.h
 scan_args.o: $(hdrdir)/ruby/backward/2/stdalign.h
 scan_args.o: $(hdrdir)/ruby/backward/2/stdarg.h
 scan_args.o: $(hdrdir)/ruby/defines.h

--- a/ext/-test-/st/foreach/depend
+++ b/ext/-test-/st/foreach/depend
@@ -151,7 +151,6 @@ foreach.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 foreach.o: $(hdrdir)/ruby/backward/2/inttypes.h
 foreach.o: $(hdrdir)/ruby/backward/2/limits.h
 foreach.o: $(hdrdir)/ruby/backward/2/long_long.h
-foreach.o: $(hdrdir)/ruby/backward/2/rmodule.h
 foreach.o: $(hdrdir)/ruby/backward/2/stdalign.h
 foreach.o: $(hdrdir)/ruby/backward/2/stdarg.h
 foreach.o: $(hdrdir)/ruby/defines.h

--- a/ext/-test-/st/numhash/depend
+++ b/ext/-test-/st/numhash/depend
@@ -151,7 +151,6 @@ numhash.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 numhash.o: $(hdrdir)/ruby/backward/2/inttypes.h
 numhash.o: $(hdrdir)/ruby/backward/2/limits.h
 numhash.o: $(hdrdir)/ruby/backward/2/long_long.h
-numhash.o: $(hdrdir)/ruby/backward/2/rmodule.h
 numhash.o: $(hdrdir)/ruby/backward/2/stdalign.h
 numhash.o: $(hdrdir)/ruby/backward/2/stdarg.h
 numhash.o: $(hdrdir)/ruby/defines.h

--- a/ext/-test-/st/update/depend
+++ b/ext/-test-/st/update/depend
@@ -151,7 +151,6 @@ update.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 update.o: $(hdrdir)/ruby/backward/2/inttypes.h
 update.o: $(hdrdir)/ruby/backward/2/limits.h
 update.o: $(hdrdir)/ruby/backward/2/long_long.h
-update.o: $(hdrdir)/ruby/backward/2/rmodule.h
 update.o: $(hdrdir)/ruby/backward/2/stdalign.h
 update.o: $(hdrdir)/ruby/backward/2/stdarg.h
 update.o: $(hdrdir)/ruby/defines.h

--- a/ext/-test-/string/depend
+++ b/ext/-test-/string/depend
@@ -151,7 +151,6 @@ capacity.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 capacity.o: $(hdrdir)/ruby/backward/2/inttypes.h
 capacity.o: $(hdrdir)/ruby/backward/2/limits.h
 capacity.o: $(hdrdir)/ruby/backward/2/long_long.h
-capacity.o: $(hdrdir)/ruby/backward/2/rmodule.h
 capacity.o: $(hdrdir)/ruby/backward/2/stdalign.h
 capacity.o: $(hdrdir)/ruby/backward/2/stdarg.h
 capacity.o: $(hdrdir)/ruby/defines.h
@@ -318,7 +317,6 @@ coderange.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 coderange.o: $(hdrdir)/ruby/backward/2/inttypes.h
 coderange.o: $(hdrdir)/ruby/backward/2/limits.h
 coderange.o: $(hdrdir)/ruby/backward/2/long_long.h
-coderange.o: $(hdrdir)/ruby/backward/2/rmodule.h
 coderange.o: $(hdrdir)/ruby/backward/2/stdalign.h
 coderange.o: $(hdrdir)/ruby/backward/2/stdarg.h
 coderange.o: $(hdrdir)/ruby/defines.h
@@ -483,7 +481,6 @@ cstr.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 cstr.o: $(hdrdir)/ruby/backward/2/inttypes.h
 cstr.o: $(hdrdir)/ruby/backward/2/limits.h
 cstr.o: $(hdrdir)/ruby/backward/2/long_long.h
-cstr.o: $(hdrdir)/ruby/backward/2/rmodule.h
 cstr.o: $(hdrdir)/ruby/backward/2/stdalign.h
 cstr.o: $(hdrdir)/ruby/backward/2/stdarg.h
 cstr.o: $(hdrdir)/ruby/defines.h
@@ -652,7 +649,6 @@ ellipsize.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ellipsize.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ellipsize.o: $(hdrdir)/ruby/backward/2/limits.h
 ellipsize.o: $(hdrdir)/ruby/backward/2/long_long.h
-ellipsize.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ellipsize.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ellipsize.o: $(hdrdir)/ruby/backward/2/stdarg.h
 ellipsize.o: $(hdrdir)/ruby/defines.h
@@ -814,7 +810,6 @@ enc_associate.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 enc_associate.o: $(hdrdir)/ruby/backward/2/inttypes.h
 enc_associate.o: $(hdrdir)/ruby/backward/2/limits.h
 enc_associate.o: $(hdrdir)/ruby/backward/2/long_long.h
-enc_associate.o: $(hdrdir)/ruby/backward/2/rmodule.h
 enc_associate.o: $(hdrdir)/ruby/backward/2/stdalign.h
 enc_associate.o: $(hdrdir)/ruby/backward/2/stdarg.h
 enc_associate.o: $(hdrdir)/ruby/defines.h
@@ -978,7 +973,6 @@ enc_str_buf_cat.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 enc_str_buf_cat.o: $(hdrdir)/ruby/backward/2/inttypes.h
 enc_str_buf_cat.o: $(hdrdir)/ruby/backward/2/limits.h
 enc_str_buf_cat.o: $(hdrdir)/ruby/backward/2/long_long.h
-enc_str_buf_cat.o: $(hdrdir)/ruby/backward/2/rmodule.h
 enc_str_buf_cat.o: $(hdrdir)/ruby/backward/2/stdalign.h
 enc_str_buf_cat.o: $(hdrdir)/ruby/backward/2/stdarg.h
 enc_str_buf_cat.o: $(hdrdir)/ruby/defines.h
@@ -1143,7 +1137,6 @@ fstring.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 fstring.o: $(hdrdir)/ruby/backward/2/inttypes.h
 fstring.o: $(hdrdir)/ruby/backward/2/limits.h
 fstring.o: $(hdrdir)/ruby/backward/2/long_long.h
-fstring.o: $(hdrdir)/ruby/backward/2/rmodule.h
 fstring.o: $(hdrdir)/ruby/backward/2/stdalign.h
 fstring.o: $(hdrdir)/ruby/backward/2/stdarg.h
 fstring.o: $(hdrdir)/ruby/defines.h
@@ -1305,7 +1298,6 @@ init.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 init.o: $(hdrdir)/ruby/backward/2/inttypes.h
 init.o: $(hdrdir)/ruby/backward/2/limits.h
 init.o: $(hdrdir)/ruby/backward/2/long_long.h
-init.o: $(hdrdir)/ruby/backward/2/rmodule.h
 init.o: $(hdrdir)/ruby/backward/2/stdalign.h
 init.o: $(hdrdir)/ruby/backward/2/stdarg.h
 init.o: $(hdrdir)/ruby/defines.h
@@ -1467,7 +1459,6 @@ modify.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 modify.o: $(hdrdir)/ruby/backward/2/inttypes.h
 modify.o: $(hdrdir)/ruby/backward/2/limits.h
 modify.o: $(hdrdir)/ruby/backward/2/long_long.h
-modify.o: $(hdrdir)/ruby/backward/2/rmodule.h
 modify.o: $(hdrdir)/ruby/backward/2/stdalign.h
 modify.o: $(hdrdir)/ruby/backward/2/stdarg.h
 modify.o: $(hdrdir)/ruby/defines.h
@@ -1629,7 +1620,6 @@ new.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 new.o: $(hdrdir)/ruby/backward/2/inttypes.h
 new.o: $(hdrdir)/ruby/backward/2/limits.h
 new.o: $(hdrdir)/ruby/backward/2/long_long.h
-new.o: $(hdrdir)/ruby/backward/2/rmodule.h
 new.o: $(hdrdir)/ruby/backward/2/stdalign.h
 new.o: $(hdrdir)/ruby/backward/2/stdarg.h
 new.o: $(hdrdir)/ruby/defines.h
@@ -1794,7 +1784,6 @@ nofree.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 nofree.o: $(hdrdir)/ruby/backward/2/inttypes.h
 nofree.o: $(hdrdir)/ruby/backward/2/limits.h
 nofree.o: $(hdrdir)/ruby/backward/2/long_long.h
-nofree.o: $(hdrdir)/ruby/backward/2/rmodule.h
 nofree.o: $(hdrdir)/ruby/backward/2/stdalign.h
 nofree.o: $(hdrdir)/ruby/backward/2/stdarg.h
 nofree.o: $(hdrdir)/ruby/defines.h
@@ -1956,7 +1945,6 @@ normalize.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 normalize.o: $(hdrdir)/ruby/backward/2/inttypes.h
 normalize.o: $(hdrdir)/ruby/backward/2/limits.h
 normalize.o: $(hdrdir)/ruby/backward/2/long_long.h
-normalize.o: $(hdrdir)/ruby/backward/2/rmodule.h
 normalize.o: $(hdrdir)/ruby/backward/2/stdalign.h
 normalize.o: $(hdrdir)/ruby/backward/2/stdarg.h
 normalize.o: $(hdrdir)/ruby/defines.h
@@ -2123,7 +2111,6 @@ qsort.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 qsort.o: $(hdrdir)/ruby/backward/2/inttypes.h
 qsort.o: $(hdrdir)/ruby/backward/2/limits.h
 qsort.o: $(hdrdir)/ruby/backward/2/long_long.h
-qsort.o: $(hdrdir)/ruby/backward/2/rmodule.h
 qsort.o: $(hdrdir)/ruby/backward/2/stdalign.h
 qsort.o: $(hdrdir)/ruby/backward/2/stdarg.h
 qsort.o: $(hdrdir)/ruby/defines.h
@@ -2289,7 +2276,6 @@ rb_str_dup.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 rb_str_dup.o: $(hdrdir)/ruby/backward/2/inttypes.h
 rb_str_dup.o: $(hdrdir)/ruby/backward/2/limits.h
 rb_str_dup.o: $(hdrdir)/ruby/backward/2/long_long.h
-rb_str_dup.o: $(hdrdir)/ruby/backward/2/rmodule.h
 rb_str_dup.o: $(hdrdir)/ruby/backward/2/stdalign.h
 rb_str_dup.o: $(hdrdir)/ruby/backward/2/stdarg.h
 rb_str_dup.o: $(hdrdir)/ruby/defines.h
@@ -2451,7 +2437,6 @@ set_len.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 set_len.o: $(hdrdir)/ruby/backward/2/inttypes.h
 set_len.o: $(hdrdir)/ruby/backward/2/limits.h
 set_len.o: $(hdrdir)/ruby/backward/2/long_long.h
-set_len.o: $(hdrdir)/ruby/backward/2/rmodule.h
 set_len.o: $(hdrdir)/ruby/backward/2/stdalign.h
 set_len.o: $(hdrdir)/ruby/backward/2/stdarg.h
 set_len.o: $(hdrdir)/ruby/defines.h

--- a/ext/-test-/struct/depend
+++ b/ext/-test-/struct/depend
@@ -151,7 +151,6 @@ duplicate.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 duplicate.o: $(hdrdir)/ruby/backward/2/inttypes.h
 duplicate.o: $(hdrdir)/ruby/backward/2/limits.h
 duplicate.o: $(hdrdir)/ruby/backward/2/long_long.h
-duplicate.o: $(hdrdir)/ruby/backward/2/rmodule.h
 duplicate.o: $(hdrdir)/ruby/backward/2/stdalign.h
 duplicate.o: $(hdrdir)/ruby/backward/2/stdarg.h
 duplicate.o: $(hdrdir)/ruby/defines.h
@@ -313,7 +312,6 @@ init.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 init.o: $(hdrdir)/ruby/backward/2/inttypes.h
 init.o: $(hdrdir)/ruby/backward/2/limits.h
 init.o: $(hdrdir)/ruby/backward/2/long_long.h
-init.o: $(hdrdir)/ruby/backward/2/rmodule.h
 init.o: $(hdrdir)/ruby/backward/2/stdalign.h
 init.o: $(hdrdir)/ruby/backward/2/stdarg.h
 init.o: $(hdrdir)/ruby/defines.h
@@ -475,7 +473,6 @@ len.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 len.o: $(hdrdir)/ruby/backward/2/inttypes.h
 len.o: $(hdrdir)/ruby/backward/2/limits.h
 len.o: $(hdrdir)/ruby/backward/2/long_long.h
-len.o: $(hdrdir)/ruby/backward/2/rmodule.h
 len.o: $(hdrdir)/ruby/backward/2/stdalign.h
 len.o: $(hdrdir)/ruby/backward/2/stdarg.h
 len.o: $(hdrdir)/ruby/defines.h
@@ -637,7 +634,6 @@ member.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 member.o: $(hdrdir)/ruby/backward/2/inttypes.h
 member.o: $(hdrdir)/ruby/backward/2/limits.h
 member.o: $(hdrdir)/ruby/backward/2/long_long.h
-member.o: $(hdrdir)/ruby/backward/2/rmodule.h
 member.o: $(hdrdir)/ruby/backward/2/stdalign.h
 member.o: $(hdrdir)/ruby/backward/2/stdarg.h
 member.o: $(hdrdir)/ruby/defines.h

--- a/ext/-test-/symbol/depend
+++ b/ext/-test-/symbol/depend
@@ -151,7 +151,6 @@ init.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 init.o: $(hdrdir)/ruby/backward/2/inttypes.h
 init.o: $(hdrdir)/ruby/backward/2/limits.h
 init.o: $(hdrdir)/ruby/backward/2/long_long.h
-init.o: $(hdrdir)/ruby/backward/2/rmodule.h
 init.o: $(hdrdir)/ruby/backward/2/stdalign.h
 init.o: $(hdrdir)/ruby/backward/2/stdarg.h
 init.o: $(hdrdir)/ruby/defines.h
@@ -313,7 +312,6 @@ type.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 type.o: $(hdrdir)/ruby/backward/2/inttypes.h
 type.o: $(hdrdir)/ruby/backward/2/limits.h
 type.o: $(hdrdir)/ruby/backward/2/long_long.h
-type.o: $(hdrdir)/ruby/backward/2/rmodule.h
 type.o: $(hdrdir)/ruby/backward/2/stdalign.h
 type.o: $(hdrdir)/ruby/backward/2/stdarg.h
 type.o: $(hdrdir)/ruby/defines.h

--- a/ext/-test-/thread_fd_close/depend
+++ b/ext/-test-/thread_fd_close/depend
@@ -150,7 +150,6 @@ thread_fd_close.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 thread_fd_close.o: $(hdrdir)/ruby/backward/2/inttypes.h
 thread_fd_close.o: $(hdrdir)/ruby/backward/2/limits.h
 thread_fd_close.o: $(hdrdir)/ruby/backward/2/long_long.h
-thread_fd_close.o: $(hdrdir)/ruby/backward/2/rmodule.h
 thread_fd_close.o: $(hdrdir)/ruby/backward/2/stdalign.h
 thread_fd_close.o: $(hdrdir)/ruby/backward/2/stdarg.h
 thread_fd_close.o: $(hdrdir)/ruby/defines.h

--- a/ext/-test-/time/depend
+++ b/ext/-test-/time/depend
@@ -151,7 +151,6 @@ init.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 init.o: $(hdrdir)/ruby/backward/2/inttypes.h
 init.o: $(hdrdir)/ruby/backward/2/limits.h
 init.o: $(hdrdir)/ruby/backward/2/long_long.h
-init.o: $(hdrdir)/ruby/backward/2/rmodule.h
 init.o: $(hdrdir)/ruby/backward/2/stdalign.h
 init.o: $(hdrdir)/ruby/backward/2/stdarg.h
 init.o: $(hdrdir)/ruby/defines.h
@@ -313,7 +312,6 @@ leap_second.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 leap_second.o: $(hdrdir)/ruby/backward/2/inttypes.h
 leap_second.o: $(hdrdir)/ruby/backward/2/limits.h
 leap_second.o: $(hdrdir)/ruby/backward/2/long_long.h
-leap_second.o: $(hdrdir)/ruby/backward/2/rmodule.h
 leap_second.o: $(hdrdir)/ruby/backward/2/stdalign.h
 leap_second.o: $(hdrdir)/ruby/backward/2/stdarg.h
 leap_second.o: $(hdrdir)/ruby/defines.h
@@ -479,7 +477,6 @@ new.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 new.o: $(hdrdir)/ruby/backward/2/inttypes.h
 new.o: $(hdrdir)/ruby/backward/2/limits.h
 new.o: $(hdrdir)/ruby/backward/2/long_long.h
-new.o: $(hdrdir)/ruby/backward/2/rmodule.h
 new.o: $(hdrdir)/ruby/backward/2/stdalign.h
 new.o: $(hdrdir)/ruby/backward/2/stdarg.h
 new.o: $(hdrdir)/ruby/defines.h

--- a/ext/-test-/tracepoint/depend
+++ b/ext/-test-/tracepoint/depend
@@ -150,7 +150,6 @@ gc_hook.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 gc_hook.o: $(hdrdir)/ruby/backward/2/inttypes.h
 gc_hook.o: $(hdrdir)/ruby/backward/2/limits.h
 gc_hook.o: $(hdrdir)/ruby/backward/2/long_long.h
-gc_hook.o: $(hdrdir)/ruby/backward/2/rmodule.h
 gc_hook.o: $(hdrdir)/ruby/backward/2/stdalign.h
 gc_hook.o: $(hdrdir)/ruby/backward/2/stdarg.h
 gc_hook.o: $(hdrdir)/ruby/debug.h
@@ -312,7 +311,6 @@ tracepoint.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 tracepoint.o: $(hdrdir)/ruby/backward/2/inttypes.h
 tracepoint.o: $(hdrdir)/ruby/backward/2/limits.h
 tracepoint.o: $(hdrdir)/ruby/backward/2/long_long.h
-tracepoint.o: $(hdrdir)/ruby/backward/2/rmodule.h
 tracepoint.o: $(hdrdir)/ruby/backward/2/stdalign.h
 tracepoint.o: $(hdrdir)/ruby/backward/2/stdarg.h
 tracepoint.o: $(hdrdir)/ruby/debug.h

--- a/ext/-test-/typeddata/depend
+++ b/ext/-test-/typeddata/depend
@@ -151,7 +151,6 @@ typeddata.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 typeddata.o: $(hdrdir)/ruby/backward/2/inttypes.h
 typeddata.o: $(hdrdir)/ruby/backward/2/limits.h
 typeddata.o: $(hdrdir)/ruby/backward/2/long_long.h
-typeddata.o: $(hdrdir)/ruby/backward/2/rmodule.h
 typeddata.o: $(hdrdir)/ruby/backward/2/stdalign.h
 typeddata.o: $(hdrdir)/ruby/backward/2/stdarg.h
 typeddata.o: $(hdrdir)/ruby/defines.h

--- a/ext/-test-/vm/depend
+++ b/ext/-test-/vm/depend
@@ -150,7 +150,6 @@ at_exit.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 at_exit.o: $(hdrdir)/ruby/backward/2/inttypes.h
 at_exit.o: $(hdrdir)/ruby/backward/2/limits.h
 at_exit.o: $(hdrdir)/ruby/backward/2/long_long.h
-at_exit.o: $(hdrdir)/ruby/backward/2/rmodule.h
 at_exit.o: $(hdrdir)/ruby/backward/2/stdalign.h
 at_exit.o: $(hdrdir)/ruby/backward/2/stdarg.h
 at_exit.o: $(hdrdir)/ruby/defines.h

--- a/ext/-test-/wait_for_single_fd/depend
+++ b/ext/-test-/wait_for_single_fd/depend
@@ -150,7 +150,6 @@ wait_for_single_fd.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 wait_for_single_fd.o: $(hdrdir)/ruby/backward/2/inttypes.h
 wait_for_single_fd.o: $(hdrdir)/ruby/backward/2/limits.h
 wait_for_single_fd.o: $(hdrdir)/ruby/backward/2/long_long.h
-wait_for_single_fd.o: $(hdrdir)/ruby/backward/2/rmodule.h
 wait_for_single_fd.o: $(hdrdir)/ruby/backward/2/stdalign.h
 wait_for_single_fd.o: $(hdrdir)/ruby/backward/2/stdarg.h
 wait_for_single_fd.o: $(hdrdir)/ruby/defines.h

--- a/ext/bigdecimal/depend
+++ b/ext/bigdecimal/depend
@@ -152,7 +152,6 @@ bigdecimal.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 bigdecimal.o: $(hdrdir)/ruby/backward/2/inttypes.h
 bigdecimal.o: $(hdrdir)/ruby/backward/2/limits.h
 bigdecimal.o: $(hdrdir)/ruby/backward/2/long_long.h
-bigdecimal.o: $(hdrdir)/ruby/backward/2/rmodule.h
 bigdecimal.o: $(hdrdir)/ruby/backward/2/stdalign.h
 bigdecimal.o: $(hdrdir)/ruby/backward/2/stdarg.h
 bigdecimal.o: $(hdrdir)/ruby/defines.h

--- a/ext/cgi/escape/depend
+++ b/ext/cgi/escape/depend
@@ -151,7 +151,6 @@ escape.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 escape.o: $(hdrdir)/ruby/backward/2/inttypes.h
 escape.o: $(hdrdir)/ruby/backward/2/limits.h
 escape.o: $(hdrdir)/ruby/backward/2/long_long.h
-escape.o: $(hdrdir)/ruby/backward/2/rmodule.h
 escape.o: $(hdrdir)/ruby/backward/2/stdalign.h
 escape.o: $(hdrdir)/ruby/backward/2/stdarg.h
 escape.o: $(hdrdir)/ruby/defines.h

--- a/ext/continuation/depend
+++ b/ext/continuation/depend
@@ -150,7 +150,6 @@ continuation.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 continuation.o: $(hdrdir)/ruby/backward/2/inttypes.h
 continuation.o: $(hdrdir)/ruby/backward/2/limits.h
 continuation.o: $(hdrdir)/ruby/backward/2/long_long.h
-continuation.o: $(hdrdir)/ruby/backward/2/rmodule.h
 continuation.o: $(hdrdir)/ruby/backward/2/stdalign.h
 continuation.o: $(hdrdir)/ruby/backward/2/stdarg.h
 continuation.o: $(hdrdir)/ruby/defines.h

--- a/ext/coverage/depend
+++ b/ext/coverage/depend
@@ -151,7 +151,6 @@ coverage.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 coverage.o: $(hdrdir)/ruby/backward/2/inttypes.h
 coverage.o: $(hdrdir)/ruby/backward/2/limits.h
 coverage.o: $(hdrdir)/ruby/backward/2/long_long.h
-coverage.o: $(hdrdir)/ruby/backward/2/rmodule.h
 coverage.o: $(hdrdir)/ruby/backward/2/stdalign.h
 coverage.o: $(hdrdir)/ruby/backward/2/stdarg.h
 coverage.o: $(hdrdir)/ruby/defines.h

--- a/ext/date/depend
+++ b/ext/date/depend
@@ -151,7 +151,6 @@ date_core.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 date_core.o: $(hdrdir)/ruby/backward/2/inttypes.h
 date_core.o: $(hdrdir)/ruby/backward/2/limits.h
 date_core.o: $(hdrdir)/ruby/backward/2/long_long.h
-date_core.o: $(hdrdir)/ruby/backward/2/rmodule.h
 date_core.o: $(hdrdir)/ruby/backward/2/stdalign.h
 date_core.o: $(hdrdir)/ruby/backward/2/stdarg.h
 date_core.o: $(hdrdir)/ruby/defines.h
@@ -319,7 +318,6 @@ date_parse.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 date_parse.o: $(hdrdir)/ruby/backward/2/inttypes.h
 date_parse.o: $(hdrdir)/ruby/backward/2/limits.h
 date_parse.o: $(hdrdir)/ruby/backward/2/long_long.h
-date_parse.o: $(hdrdir)/ruby/backward/2/rmodule.h
 date_parse.o: $(hdrdir)/ruby/backward/2/stdalign.h
 date_parse.o: $(hdrdir)/ruby/backward/2/stdarg.h
 date_parse.o: $(hdrdir)/ruby/defines.h
@@ -487,7 +485,6 @@ date_strftime.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 date_strftime.o: $(hdrdir)/ruby/backward/2/inttypes.h
 date_strftime.o: $(hdrdir)/ruby/backward/2/limits.h
 date_strftime.o: $(hdrdir)/ruby/backward/2/long_long.h
-date_strftime.o: $(hdrdir)/ruby/backward/2/rmodule.h
 date_strftime.o: $(hdrdir)/ruby/backward/2/stdalign.h
 date_strftime.o: $(hdrdir)/ruby/backward/2/stdarg.h
 date_strftime.o: $(hdrdir)/ruby/defines.h
@@ -651,7 +648,6 @@ date_strptime.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 date_strptime.o: $(hdrdir)/ruby/backward/2/inttypes.h
 date_strptime.o: $(hdrdir)/ruby/backward/2/limits.h
 date_strptime.o: $(hdrdir)/ruby/backward/2/long_long.h
-date_strptime.o: $(hdrdir)/ruby/backward/2/rmodule.h
 date_strptime.o: $(hdrdir)/ruby/backward/2/stdalign.h
 date_strptime.o: $(hdrdir)/ruby/backward/2/stdarg.h
 date_strptime.o: $(hdrdir)/ruby/defines.h

--- a/ext/dbm/depend
+++ b/ext/dbm/depend
@@ -151,7 +151,6 @@ dbm.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 dbm.o: $(hdrdir)/ruby/backward/2/inttypes.h
 dbm.o: $(hdrdir)/ruby/backward/2/limits.h
 dbm.o: $(hdrdir)/ruby/backward/2/long_long.h
-dbm.o: $(hdrdir)/ruby/backward/2/rmodule.h
 dbm.o: $(hdrdir)/ruby/backward/2/stdalign.h
 dbm.o: $(hdrdir)/ruby/backward/2/stdarg.h
 dbm.o: $(hdrdir)/ruby/defines.h

--- a/ext/digest/bubblebabble/depend
+++ b/ext/digest/bubblebabble/depend
@@ -151,7 +151,6 @@ bubblebabble.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 bubblebabble.o: $(hdrdir)/ruby/backward/2/inttypes.h
 bubblebabble.o: $(hdrdir)/ruby/backward/2/limits.h
 bubblebabble.o: $(hdrdir)/ruby/backward/2/long_long.h
-bubblebabble.o: $(hdrdir)/ruby/backward/2/rmodule.h
 bubblebabble.o: $(hdrdir)/ruby/backward/2/stdalign.h
 bubblebabble.o: $(hdrdir)/ruby/backward/2/stdarg.h
 bubblebabble.o: $(hdrdir)/ruby/defines.h

--- a/ext/digest/depend
+++ b/ext/digest/depend
@@ -151,7 +151,6 @@ digest.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 digest.o: $(hdrdir)/ruby/backward/2/inttypes.h
 digest.o: $(hdrdir)/ruby/backward/2/limits.h
 digest.o: $(hdrdir)/ruby/backward/2/long_long.h
-digest.o: $(hdrdir)/ruby/backward/2/rmodule.h
 digest.o: $(hdrdir)/ruby/backward/2/stdalign.h
 digest.o: $(hdrdir)/ruby/backward/2/stdarg.h
 digest.o: $(hdrdir)/ruby/defines.h

--- a/ext/digest/md5/depend
+++ b/ext/digest/md5/depend
@@ -154,7 +154,6 @@ md5init.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 md5init.o: $(hdrdir)/ruby/backward/2/inttypes.h
 md5init.o: $(hdrdir)/ruby/backward/2/limits.h
 md5init.o: $(hdrdir)/ruby/backward/2/long_long.h
-md5init.o: $(hdrdir)/ruby/backward/2/rmodule.h
 md5init.o: $(hdrdir)/ruby/backward/2/stdalign.h
 md5init.o: $(hdrdir)/ruby/backward/2/stdarg.h
 md5init.o: $(hdrdir)/ruby/defines.h

--- a/ext/digest/rmd160/depend
+++ b/ext/digest/rmd160/depend
@@ -154,7 +154,6 @@ rmd160init.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 rmd160init.o: $(hdrdir)/ruby/backward/2/inttypes.h
 rmd160init.o: $(hdrdir)/ruby/backward/2/limits.h
 rmd160init.o: $(hdrdir)/ruby/backward/2/long_long.h
-rmd160init.o: $(hdrdir)/ruby/backward/2/rmodule.h
 rmd160init.o: $(hdrdir)/ruby/backward/2/stdalign.h
 rmd160init.o: $(hdrdir)/ruby/backward/2/stdarg.h
 rmd160init.o: $(hdrdir)/ruby/defines.h

--- a/ext/digest/sha1/depend
+++ b/ext/digest/sha1/depend
@@ -154,7 +154,6 @@ sha1init.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 sha1init.o: $(hdrdir)/ruby/backward/2/inttypes.h
 sha1init.o: $(hdrdir)/ruby/backward/2/limits.h
 sha1init.o: $(hdrdir)/ruby/backward/2/long_long.h
-sha1init.o: $(hdrdir)/ruby/backward/2/rmodule.h
 sha1init.o: $(hdrdir)/ruby/backward/2/stdalign.h
 sha1init.o: $(hdrdir)/ruby/backward/2/stdarg.h
 sha1init.o: $(hdrdir)/ruby/defines.h

--- a/ext/digest/sha2/depend
+++ b/ext/digest/sha2/depend
@@ -154,7 +154,6 @@ sha2init.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 sha2init.o: $(hdrdir)/ruby/backward/2/inttypes.h
 sha2init.o: $(hdrdir)/ruby/backward/2/limits.h
 sha2init.o: $(hdrdir)/ruby/backward/2/long_long.h
-sha2init.o: $(hdrdir)/ruby/backward/2/rmodule.h
 sha2init.o: $(hdrdir)/ruby/backward/2/stdalign.h
 sha2init.o: $(hdrdir)/ruby/backward/2/stdarg.h
 sha2init.o: $(hdrdir)/ruby/defines.h

--- a/ext/etc/depend
+++ b/ext/etc/depend
@@ -155,7 +155,6 @@ etc.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 etc.o: $(hdrdir)/ruby/backward/2/inttypes.h
 etc.o: $(hdrdir)/ruby/backward/2/limits.h
 etc.o: $(hdrdir)/ruby/backward/2/long_long.h
-etc.o: $(hdrdir)/ruby/backward/2/rmodule.h
 etc.o: $(hdrdir)/ruby/backward/2/stdalign.h
 etc.o: $(hdrdir)/ruby/backward/2/stdarg.h
 etc.o: $(hdrdir)/ruby/defines.h

--- a/ext/fcntl/depend
+++ b/ext/fcntl/depend
@@ -151,7 +151,6 @@ fcntl.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 fcntl.o: $(hdrdir)/ruby/backward/2/inttypes.h
 fcntl.o: $(hdrdir)/ruby/backward/2/limits.h
 fcntl.o: $(hdrdir)/ruby/backward/2/long_long.h
-fcntl.o: $(hdrdir)/ruby/backward/2/rmodule.h
 fcntl.o: $(hdrdir)/ruby/backward/2/stdalign.h
 fcntl.o: $(hdrdir)/ruby/backward/2/stdarg.h
 fcntl.o: $(hdrdir)/ruby/defines.h

--- a/ext/fiddle/depend
+++ b/ext/fiddle/depend
@@ -204,7 +204,6 @@ closure.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 closure.o: $(hdrdir)/ruby/backward/2/inttypes.h
 closure.o: $(hdrdir)/ruby/backward/2/limits.h
 closure.o: $(hdrdir)/ruby/backward/2/long_long.h
-closure.o: $(hdrdir)/ruby/backward/2/rmodule.h
 closure.o: $(hdrdir)/ruby/backward/2/stdalign.h
 closure.o: $(hdrdir)/ruby/backward/2/stdarg.h
 closure.o: $(hdrdir)/ruby/defines.h
@@ -371,7 +370,6 @@ conversions.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 conversions.o: $(hdrdir)/ruby/backward/2/inttypes.h
 conversions.o: $(hdrdir)/ruby/backward/2/limits.h
 conversions.o: $(hdrdir)/ruby/backward/2/long_long.h
-conversions.o: $(hdrdir)/ruby/backward/2/rmodule.h
 conversions.o: $(hdrdir)/ruby/backward/2/stdalign.h
 conversions.o: $(hdrdir)/ruby/backward/2/stdarg.h
 conversions.o: $(hdrdir)/ruby/defines.h
@@ -537,7 +535,6 @@ fiddle.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 fiddle.o: $(hdrdir)/ruby/backward/2/inttypes.h
 fiddle.o: $(hdrdir)/ruby/backward/2/limits.h
 fiddle.o: $(hdrdir)/ruby/backward/2/long_long.h
-fiddle.o: $(hdrdir)/ruby/backward/2/rmodule.h
 fiddle.o: $(hdrdir)/ruby/backward/2/stdalign.h
 fiddle.o: $(hdrdir)/ruby/backward/2/stdarg.h
 fiddle.o: $(hdrdir)/ruby/defines.h
@@ -703,7 +700,6 @@ function.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 function.o: $(hdrdir)/ruby/backward/2/inttypes.h
 function.o: $(hdrdir)/ruby/backward/2/limits.h
 function.o: $(hdrdir)/ruby/backward/2/long_long.h
-function.o: $(hdrdir)/ruby/backward/2/rmodule.h
 function.o: $(hdrdir)/ruby/backward/2/stdalign.h
 function.o: $(hdrdir)/ruby/backward/2/stdarg.h
 function.o: $(hdrdir)/ruby/defines.h
@@ -870,7 +866,6 @@ handle.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 handle.o: $(hdrdir)/ruby/backward/2/inttypes.h
 handle.o: $(hdrdir)/ruby/backward/2/limits.h
 handle.o: $(hdrdir)/ruby/backward/2/long_long.h
-handle.o: $(hdrdir)/ruby/backward/2/rmodule.h
 handle.o: $(hdrdir)/ruby/backward/2/stdalign.h
 handle.o: $(hdrdir)/ruby/backward/2/stdarg.h
 handle.o: $(hdrdir)/ruby/defines.h
@@ -1036,7 +1031,6 @@ pointer.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 pointer.o: $(hdrdir)/ruby/backward/2/inttypes.h
 pointer.o: $(hdrdir)/ruby/backward/2/limits.h
 pointer.o: $(hdrdir)/ruby/backward/2/long_long.h
-pointer.o: $(hdrdir)/ruby/backward/2/rmodule.h
 pointer.o: $(hdrdir)/ruby/backward/2/stdalign.h
 pointer.o: $(hdrdir)/ruby/backward/2/stdarg.h
 pointer.o: $(hdrdir)/ruby/defines.h

--- a/ext/gdbm/depend
+++ b/ext/gdbm/depend
@@ -151,7 +151,6 @@ gdbm.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 gdbm.o: $(hdrdir)/ruby/backward/2/inttypes.h
 gdbm.o: $(hdrdir)/ruby/backward/2/limits.h
 gdbm.o: $(hdrdir)/ruby/backward/2/long_long.h
-gdbm.o: $(hdrdir)/ruby/backward/2/rmodule.h
 gdbm.o: $(hdrdir)/ruby/backward/2/stdalign.h
 gdbm.o: $(hdrdir)/ruby/backward/2/stdarg.h
 gdbm.o: $(hdrdir)/ruby/defines.h

--- a/ext/io/console/depend
+++ b/ext/io/console/depend
@@ -151,7 +151,6 @@ console.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 console.o: $(hdrdir)/ruby/backward/2/inttypes.h
 console.o: $(hdrdir)/ruby/backward/2/limits.h
 console.o: $(hdrdir)/ruby/backward/2/long_long.h
-console.o: $(hdrdir)/ruby/backward/2/rmodule.h
 console.o: $(hdrdir)/ruby/backward/2/stdalign.h
 console.o: $(hdrdir)/ruby/backward/2/stdarg.h
 console.o: $(hdrdir)/ruby/defines.h

--- a/ext/io/nonblock/depend
+++ b/ext/io/nonblock/depend
@@ -151,7 +151,6 @@ nonblock.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 nonblock.o: $(hdrdir)/ruby/backward/2/inttypes.h
 nonblock.o: $(hdrdir)/ruby/backward/2/limits.h
 nonblock.o: $(hdrdir)/ruby/backward/2/long_long.h
-nonblock.o: $(hdrdir)/ruby/backward/2/rmodule.h
 nonblock.o: $(hdrdir)/ruby/backward/2/stdalign.h
 nonblock.o: $(hdrdir)/ruby/backward/2/stdarg.h
 nonblock.o: $(hdrdir)/ruby/defines.h

--- a/ext/io/wait/depend
+++ b/ext/io/wait/depend
@@ -151,7 +151,6 @@ wait.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 wait.o: $(hdrdir)/ruby/backward/2/inttypes.h
 wait.o: $(hdrdir)/ruby/backward/2/limits.h
 wait.o: $(hdrdir)/ruby/backward/2/long_long.h
-wait.o: $(hdrdir)/ruby/backward/2/rmodule.h
 wait.o: $(hdrdir)/ruby/backward/2/stdalign.h
 wait.o: $(hdrdir)/ruby/backward/2/stdarg.h
 wait.o: $(hdrdir)/ruby/defines.h

--- a/ext/json/generator/depend
+++ b/ext/json/generator/depend
@@ -155,7 +155,6 @@ generator.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 generator.o: $(hdrdir)/ruby/backward/2/inttypes.h
 generator.o: $(hdrdir)/ruby/backward/2/limits.h
 generator.o: $(hdrdir)/ruby/backward/2/long_long.h
-generator.o: $(hdrdir)/ruby/backward/2/rmodule.h
 generator.o: $(hdrdir)/ruby/backward/2/stdalign.h
 generator.o: $(hdrdir)/ruby/backward/2/stdarg.h
 generator.o: $(hdrdir)/ruby/defines.h

--- a/ext/json/parser/depend
+++ b/ext/json/parser/depend
@@ -154,7 +154,6 @@ parser.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 parser.o: $(hdrdir)/ruby/backward/2/inttypes.h
 parser.o: $(hdrdir)/ruby/backward/2/limits.h
 parser.o: $(hdrdir)/ruby/backward/2/long_long.h
-parser.o: $(hdrdir)/ruby/backward/2/rmodule.h
 parser.o: $(hdrdir)/ruby/backward/2/stdalign.h
 parser.o: $(hdrdir)/ruby/backward/2/stdarg.h
 parser.o: $(hdrdir)/ruby/defines.h

--- a/ext/monitor/depend
+++ b/ext/monitor/depend
@@ -150,7 +150,6 @@ monitor.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 monitor.o: $(hdrdir)/ruby/backward/2/inttypes.h
 monitor.o: $(hdrdir)/ruby/backward/2/limits.h
 monitor.o: $(hdrdir)/ruby/backward/2/long_long.h
-monitor.o: $(hdrdir)/ruby/backward/2/rmodule.h
 monitor.o: $(hdrdir)/ruby/backward/2/stdalign.h
 monitor.o: $(hdrdir)/ruby/backward/2/stdarg.h
 monitor.o: $(hdrdir)/ruby/defines.h

--- a/ext/nkf/depend
+++ b/ext/nkf/depend
@@ -154,7 +154,6 @@ nkf.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 nkf.o: $(hdrdir)/ruby/backward/2/inttypes.h
 nkf.o: $(hdrdir)/ruby/backward/2/limits.h
 nkf.o: $(hdrdir)/ruby/backward/2/long_long.h
-nkf.o: $(hdrdir)/ruby/backward/2/rmodule.h
 nkf.o: $(hdrdir)/ruby/backward/2/stdalign.h
 nkf.o: $(hdrdir)/ruby/backward/2/stdarg.h
 nkf.o: $(hdrdir)/ruby/defines.h

--- a/ext/objspace/depend
+++ b/ext/objspace/depend
@@ -151,7 +151,6 @@ object_tracing.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 object_tracing.o: $(hdrdir)/ruby/backward/2/inttypes.h
 object_tracing.o: $(hdrdir)/ruby/backward/2/limits.h
 object_tracing.o: $(hdrdir)/ruby/backward/2/long_long.h
-object_tracing.o: $(hdrdir)/ruby/backward/2/rmodule.h
 object_tracing.o: $(hdrdir)/ruby/backward/2/stdalign.h
 object_tracing.o: $(hdrdir)/ruby/backward/2/stdarg.h
 object_tracing.o: $(hdrdir)/ruby/debug.h
@@ -317,7 +316,6 @@ objspace.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 objspace.o: $(hdrdir)/ruby/backward/2/inttypes.h
 objspace.o: $(hdrdir)/ruby/backward/2/limits.h
 objspace.o: $(hdrdir)/ruby/backward/2/long_long.h
-objspace.o: $(hdrdir)/ruby/backward/2/rmodule.h
 objspace.o: $(hdrdir)/ruby/backward/2/stdalign.h
 objspace.o: $(hdrdir)/ruby/backward/2/stdarg.h
 objspace.o: $(hdrdir)/ruby/defines.h
@@ -500,7 +498,6 @@ objspace_dump.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 objspace_dump.o: $(hdrdir)/ruby/backward/2/inttypes.h
 objspace_dump.o: $(hdrdir)/ruby/backward/2/limits.h
 objspace_dump.o: $(hdrdir)/ruby/backward/2/long_long.h
-objspace_dump.o: $(hdrdir)/ruby/backward/2/rmodule.h
 objspace_dump.o: $(hdrdir)/ruby/backward/2/stdalign.h
 objspace_dump.o: $(hdrdir)/ruby/backward/2/stdarg.h
 objspace_dump.o: $(hdrdir)/ruby/debug.h

--- a/ext/openssl/depend
+++ b/ext/openssl/depend
@@ -155,7 +155,6 @@ ossl.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl.o: $(hdrdir)/ruby/backward/2/stdarg.h
 ossl.o: $(hdrdir)/ruby/defines.h
@@ -344,7 +343,6 @@ ossl_asn1.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_asn1.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_asn1.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_asn1.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_asn1.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_asn1.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_asn1.o: $(hdrdir)/ruby/backward/2/stdarg.h
 ossl_asn1.o: $(hdrdir)/ruby/defines.h
@@ -532,7 +530,6 @@ ossl_bio.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_bio.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_bio.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_bio.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_bio.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_bio.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_bio.o: $(hdrdir)/ruby/backward/2/stdarg.h
 ossl_bio.o: $(hdrdir)/ruby/defines.h
@@ -720,7 +717,6 @@ ossl_bn.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_bn.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_bn.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_bn.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_bn.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_bn.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_bn.o: $(hdrdir)/ruby/backward/2/stdarg.h
 ossl_bn.o: $(hdrdir)/ruby/defines.h
@@ -908,7 +904,6 @@ ossl_cipher.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_cipher.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_cipher.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_cipher.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_cipher.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_cipher.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_cipher.o: $(hdrdir)/ruby/backward/2/stdarg.h
 ossl_cipher.o: $(hdrdir)/ruby/defines.h
@@ -1096,7 +1091,6 @@ ossl_config.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_config.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_config.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_config.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_config.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_config.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_config.o: $(hdrdir)/ruby/backward/2/stdarg.h
 ossl_config.o: $(hdrdir)/ruby/defines.h
@@ -1284,7 +1278,6 @@ ossl_digest.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_digest.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_digest.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_digest.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_digest.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_digest.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_digest.o: $(hdrdir)/ruby/backward/2/stdarg.h
 ossl_digest.o: $(hdrdir)/ruby/defines.h
@@ -1472,7 +1465,6 @@ ossl_engine.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_engine.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_engine.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_engine.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_engine.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_engine.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_engine.o: $(hdrdir)/ruby/backward/2/stdarg.h
 ossl_engine.o: $(hdrdir)/ruby/defines.h
@@ -1660,7 +1652,6 @@ ossl_hmac.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_hmac.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_hmac.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_hmac.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_hmac.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_hmac.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_hmac.o: $(hdrdir)/ruby/backward/2/stdarg.h
 ossl_hmac.o: $(hdrdir)/ruby/defines.h
@@ -1848,7 +1839,6 @@ ossl_kdf.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_kdf.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_kdf.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_kdf.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_kdf.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_kdf.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_kdf.o: $(hdrdir)/ruby/backward/2/stdarg.h
 ossl_kdf.o: $(hdrdir)/ruby/defines.h
@@ -2036,7 +2026,6 @@ ossl_ns_spki.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_ns_spki.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_ns_spki.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_ns_spki.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_ns_spki.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_ns_spki.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_ns_spki.o: $(hdrdir)/ruby/backward/2/stdarg.h
 ossl_ns_spki.o: $(hdrdir)/ruby/defines.h
@@ -2224,7 +2213,6 @@ ossl_ocsp.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_ocsp.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_ocsp.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_ocsp.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_ocsp.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_ocsp.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_ocsp.o: $(hdrdir)/ruby/backward/2/stdarg.h
 ossl_ocsp.o: $(hdrdir)/ruby/defines.h
@@ -2412,7 +2400,6 @@ ossl_pkcs12.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_pkcs12.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_pkcs12.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_pkcs12.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_pkcs12.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_pkcs12.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_pkcs12.o: $(hdrdir)/ruby/backward/2/stdarg.h
 ossl_pkcs12.o: $(hdrdir)/ruby/defines.h
@@ -2600,7 +2587,6 @@ ossl_pkcs7.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_pkcs7.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_pkcs7.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_pkcs7.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_pkcs7.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_pkcs7.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_pkcs7.o: $(hdrdir)/ruby/backward/2/stdarg.h
 ossl_pkcs7.o: $(hdrdir)/ruby/defines.h
@@ -2788,7 +2774,6 @@ ossl_pkey.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_pkey.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_pkey.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_pkey.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_pkey.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_pkey.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_pkey.o: $(hdrdir)/ruby/backward/2/stdarg.h
 ossl_pkey.o: $(hdrdir)/ruby/defines.h
@@ -2976,7 +2961,6 @@ ossl_pkey_dh.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_pkey_dh.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_pkey_dh.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_pkey_dh.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_pkey_dh.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_pkey_dh.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_pkey_dh.o: $(hdrdir)/ruby/backward/2/stdarg.h
 ossl_pkey_dh.o: $(hdrdir)/ruby/defines.h
@@ -3164,7 +3148,6 @@ ossl_pkey_dsa.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_pkey_dsa.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_pkey_dsa.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_pkey_dsa.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_pkey_dsa.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_pkey_dsa.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_pkey_dsa.o: $(hdrdir)/ruby/backward/2/stdarg.h
 ossl_pkey_dsa.o: $(hdrdir)/ruby/defines.h
@@ -3352,7 +3335,6 @@ ossl_pkey_ec.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_pkey_ec.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_pkey_ec.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_pkey_ec.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_pkey_ec.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_pkey_ec.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_pkey_ec.o: $(hdrdir)/ruby/backward/2/stdarg.h
 ossl_pkey_ec.o: $(hdrdir)/ruby/defines.h
@@ -3540,7 +3522,6 @@ ossl_pkey_rsa.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_pkey_rsa.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_pkey_rsa.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_pkey_rsa.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_pkey_rsa.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_pkey_rsa.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_pkey_rsa.o: $(hdrdir)/ruby/backward/2/stdarg.h
 ossl_pkey_rsa.o: $(hdrdir)/ruby/defines.h
@@ -3728,7 +3709,6 @@ ossl_rand.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_rand.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_rand.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_rand.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_rand.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_rand.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_rand.o: $(hdrdir)/ruby/backward/2/stdarg.h
 ossl_rand.o: $(hdrdir)/ruby/defines.h
@@ -3916,7 +3896,6 @@ ossl_ssl.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_ssl.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_ssl.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_ssl.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_ssl.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_ssl.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_ssl.o: $(hdrdir)/ruby/backward/2/stdarg.h
 ossl_ssl.o: $(hdrdir)/ruby/defines.h
@@ -4104,7 +4083,6 @@ ossl_ssl_session.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_ssl_session.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_ssl_session.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_ssl_session.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_ssl_session.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_ssl_session.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_ssl_session.o: $(hdrdir)/ruby/backward/2/stdarg.h
 ossl_ssl_session.o: $(hdrdir)/ruby/defines.h
@@ -4292,7 +4270,6 @@ ossl_ts.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_ts.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_ts.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_ts.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_ts.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_ts.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_ts.o: $(hdrdir)/ruby/backward/2/stdarg.h
 ossl_ts.o: $(hdrdir)/ruby/defines.h
@@ -4480,7 +4457,6 @@ ossl_x509.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_x509.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_x509.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_x509.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_x509.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_x509.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_x509.o: $(hdrdir)/ruby/backward/2/stdarg.h
 ossl_x509.o: $(hdrdir)/ruby/defines.h
@@ -4668,7 +4644,6 @@ ossl_x509attr.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_x509attr.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_x509attr.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_x509attr.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_x509attr.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_x509attr.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_x509attr.o: $(hdrdir)/ruby/backward/2/stdarg.h
 ossl_x509attr.o: $(hdrdir)/ruby/defines.h
@@ -4856,7 +4831,6 @@ ossl_x509cert.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_x509cert.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_x509cert.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_x509cert.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_x509cert.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_x509cert.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_x509cert.o: $(hdrdir)/ruby/backward/2/stdarg.h
 ossl_x509cert.o: $(hdrdir)/ruby/defines.h
@@ -5044,7 +5018,6 @@ ossl_x509crl.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_x509crl.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_x509crl.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_x509crl.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_x509crl.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_x509crl.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_x509crl.o: $(hdrdir)/ruby/backward/2/stdarg.h
 ossl_x509crl.o: $(hdrdir)/ruby/defines.h
@@ -5232,7 +5205,6 @@ ossl_x509ext.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_x509ext.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_x509ext.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_x509ext.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_x509ext.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_x509ext.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_x509ext.o: $(hdrdir)/ruby/backward/2/stdarg.h
 ossl_x509ext.o: $(hdrdir)/ruby/defines.h
@@ -5420,7 +5392,6 @@ ossl_x509name.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_x509name.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_x509name.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_x509name.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_x509name.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_x509name.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_x509name.o: $(hdrdir)/ruby/backward/2/stdarg.h
 ossl_x509name.o: $(hdrdir)/ruby/defines.h
@@ -5608,7 +5579,6 @@ ossl_x509req.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_x509req.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_x509req.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_x509req.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_x509req.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_x509req.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_x509req.o: $(hdrdir)/ruby/backward/2/stdarg.h
 ossl_x509req.o: $(hdrdir)/ruby/defines.h
@@ -5796,7 +5766,6 @@ ossl_x509revoked.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_x509revoked.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_x509revoked.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_x509revoked.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_x509revoked.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_x509revoked.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_x509revoked.o: $(hdrdir)/ruby/backward/2/stdarg.h
 ossl_x509revoked.o: $(hdrdir)/ruby/defines.h
@@ -5984,7 +5953,6 @@ ossl_x509store.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ossl_x509store.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ossl_x509store.o: $(hdrdir)/ruby/backward/2/limits.h
 ossl_x509store.o: $(hdrdir)/ruby/backward/2/long_long.h
-ossl_x509store.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ossl_x509store.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ossl_x509store.o: $(hdrdir)/ruby/backward/2/stdarg.h
 ossl_x509store.o: $(hdrdir)/ruby/defines.h

--- a/ext/pathname/depend
+++ b/ext/pathname/depend
@@ -151,7 +151,6 @@ pathname.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 pathname.o: $(hdrdir)/ruby/backward/2/inttypes.h
 pathname.o: $(hdrdir)/ruby/backward/2/limits.h
 pathname.o: $(hdrdir)/ruby/backward/2/long_long.h
-pathname.o: $(hdrdir)/ruby/backward/2/rmodule.h
 pathname.o: $(hdrdir)/ruby/backward/2/stdalign.h
 pathname.o: $(hdrdir)/ruby/backward/2/stdarg.h
 pathname.o: $(hdrdir)/ruby/defines.h

--- a/ext/psych/depend
+++ b/ext/psych/depend
@@ -153,7 +153,6 @@ psych.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 psych.o: $(hdrdir)/ruby/backward/2/inttypes.h
 psych.o: $(hdrdir)/ruby/backward/2/limits.h
 psych.o: $(hdrdir)/ruby/backward/2/long_long.h
-psych.o: $(hdrdir)/ruby/backward/2/rmodule.h
 psych.o: $(hdrdir)/ruby/backward/2/stdalign.h
 psych.o: $(hdrdir)/ruby/backward/2/stdarg.h
 psych.o: $(hdrdir)/ruby/defines.h
@@ -323,7 +322,6 @@ psych_emitter.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 psych_emitter.o: $(hdrdir)/ruby/backward/2/inttypes.h
 psych_emitter.o: $(hdrdir)/ruby/backward/2/limits.h
 psych_emitter.o: $(hdrdir)/ruby/backward/2/long_long.h
-psych_emitter.o: $(hdrdir)/ruby/backward/2/rmodule.h
 psych_emitter.o: $(hdrdir)/ruby/backward/2/stdalign.h
 psych_emitter.o: $(hdrdir)/ruby/backward/2/stdarg.h
 psych_emitter.o: $(hdrdir)/ruby/defines.h
@@ -493,7 +491,6 @@ psych_parser.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 psych_parser.o: $(hdrdir)/ruby/backward/2/inttypes.h
 psych_parser.o: $(hdrdir)/ruby/backward/2/limits.h
 psych_parser.o: $(hdrdir)/ruby/backward/2/long_long.h
-psych_parser.o: $(hdrdir)/ruby/backward/2/rmodule.h
 psych_parser.o: $(hdrdir)/ruby/backward/2/stdalign.h
 psych_parser.o: $(hdrdir)/ruby/backward/2/stdarg.h
 psych_parser.o: $(hdrdir)/ruby/defines.h
@@ -663,7 +660,6 @@ psych_to_ruby.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 psych_to_ruby.o: $(hdrdir)/ruby/backward/2/inttypes.h
 psych_to_ruby.o: $(hdrdir)/ruby/backward/2/limits.h
 psych_to_ruby.o: $(hdrdir)/ruby/backward/2/long_long.h
-psych_to_ruby.o: $(hdrdir)/ruby/backward/2/rmodule.h
 psych_to_ruby.o: $(hdrdir)/ruby/backward/2/stdalign.h
 psych_to_ruby.o: $(hdrdir)/ruby/backward/2/stdarg.h
 psych_to_ruby.o: $(hdrdir)/ruby/defines.h
@@ -833,7 +829,6 @@ psych_yaml_tree.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 psych_yaml_tree.o: $(hdrdir)/ruby/backward/2/inttypes.h
 psych_yaml_tree.o: $(hdrdir)/ruby/backward/2/limits.h
 psych_yaml_tree.o: $(hdrdir)/ruby/backward/2/long_long.h
-psych_yaml_tree.o: $(hdrdir)/ruby/backward/2/rmodule.h
 psych_yaml_tree.o: $(hdrdir)/ruby/backward/2/stdalign.h
 psych_yaml_tree.o: $(hdrdir)/ruby/backward/2/stdarg.h
 psych_yaml_tree.o: $(hdrdir)/ruby/defines.h

--- a/ext/pty/depend
+++ b/ext/pty/depend
@@ -151,7 +151,6 @@ pty.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 pty.o: $(hdrdir)/ruby/backward/2/inttypes.h
 pty.o: $(hdrdir)/ruby/backward/2/limits.h
 pty.o: $(hdrdir)/ruby/backward/2/long_long.h
-pty.o: $(hdrdir)/ruby/backward/2/rmodule.h
 pty.o: $(hdrdir)/ruby/backward/2/stdalign.h
 pty.o: $(hdrdir)/ruby/backward/2/stdarg.h
 pty.o: $(hdrdir)/ruby/defines.h

--- a/ext/racc/cparse/depend
+++ b/ext/racc/cparse/depend
@@ -151,7 +151,6 @@ cparse.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 cparse.o: $(hdrdir)/ruby/backward/2/inttypes.h
 cparse.o: $(hdrdir)/ruby/backward/2/limits.h
 cparse.o: $(hdrdir)/ruby/backward/2/long_long.h
-cparse.o: $(hdrdir)/ruby/backward/2/rmodule.h
 cparse.o: $(hdrdir)/ruby/backward/2/stdalign.h
 cparse.o: $(hdrdir)/ruby/backward/2/stdarg.h
 cparse.o: $(hdrdir)/ruby/defines.h

--- a/ext/rbconfig/sizeof/depend
+++ b/ext/rbconfig/sizeof/depend
@@ -165,7 +165,6 @@ limits.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 limits.o: $(hdrdir)/ruby/backward/2/inttypes.h
 limits.o: $(hdrdir)/ruby/backward/2/limits.h
 limits.o: $(hdrdir)/ruby/backward/2/long_long.h
-limits.o: $(hdrdir)/ruby/backward/2/rmodule.h
 limits.o: $(hdrdir)/ruby/backward/2/stdalign.h
 limits.o: $(hdrdir)/ruby/backward/2/stdarg.h
 limits.o: $(hdrdir)/ruby/defines.h
@@ -326,7 +325,6 @@ sizes.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 sizes.o: $(hdrdir)/ruby/backward/2/inttypes.h
 sizes.o: $(hdrdir)/ruby/backward/2/limits.h
 sizes.o: $(hdrdir)/ruby/backward/2/long_long.h
-sizes.o: $(hdrdir)/ruby/backward/2/rmodule.h
 sizes.o: $(hdrdir)/ruby/backward/2/stdalign.h
 sizes.o: $(hdrdir)/ruby/backward/2/stdarg.h
 sizes.o: $(hdrdir)/ruby/defines.h

--- a/ext/readline/depend
+++ b/ext/readline/depend
@@ -150,7 +150,6 @@ readline.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 readline.o: $(hdrdir)/ruby/backward/2/inttypes.h
 readline.o: $(hdrdir)/ruby/backward/2/limits.h
 readline.o: $(hdrdir)/ruby/backward/2/long_long.h
-readline.o: $(hdrdir)/ruby/backward/2/rmodule.h
 readline.o: $(hdrdir)/ruby/backward/2/stdalign.h
 readline.o: $(hdrdir)/ruby/backward/2/stdarg.h
 readline.o: $(hdrdir)/ruby/defines.h

--- a/ext/ripper/depend
+++ b/ext/ripper/depend
@@ -201,7 +201,6 @@ ripper.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ripper.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ripper.o: $(hdrdir)/ruby/backward/2/limits.h
 ripper.o: $(hdrdir)/ruby/backward/2/long_long.h
-ripper.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ripper.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ripper.o: $(hdrdir)/ruby/backward/2/stdarg.h
 ripper.o: $(hdrdir)/ruby/defines.h

--- a/ext/socket/depend
+++ b/ext/socket/depend
@@ -162,7 +162,6 @@ ancdata.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ancdata.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ancdata.o: $(hdrdir)/ruby/backward/2/limits.h
 ancdata.o: $(hdrdir)/ruby/backward/2/long_long.h
-ancdata.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ancdata.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ancdata.o: $(hdrdir)/ruby/backward/2/stdarg.h
 ancdata.o: $(hdrdir)/ruby/defines.h
@@ -345,7 +344,6 @@ basicsocket.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 basicsocket.o: $(hdrdir)/ruby/backward/2/inttypes.h
 basicsocket.o: $(hdrdir)/ruby/backward/2/limits.h
 basicsocket.o: $(hdrdir)/ruby/backward/2/long_long.h
-basicsocket.o: $(hdrdir)/ruby/backward/2/rmodule.h
 basicsocket.o: $(hdrdir)/ruby/backward/2/stdalign.h
 basicsocket.o: $(hdrdir)/ruby/backward/2/stdarg.h
 basicsocket.o: $(hdrdir)/ruby/defines.h
@@ -528,7 +526,6 @@ constants.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 constants.o: $(hdrdir)/ruby/backward/2/inttypes.h
 constants.o: $(hdrdir)/ruby/backward/2/limits.h
 constants.o: $(hdrdir)/ruby/backward/2/long_long.h
-constants.o: $(hdrdir)/ruby/backward/2/rmodule.h
 constants.o: $(hdrdir)/ruby/backward/2/stdalign.h
 constants.o: $(hdrdir)/ruby/backward/2/stdarg.h
 constants.o: $(hdrdir)/ruby/defines.h
@@ -712,7 +709,6 @@ ifaddr.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ifaddr.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ifaddr.o: $(hdrdir)/ruby/backward/2/limits.h
 ifaddr.o: $(hdrdir)/ruby/backward/2/long_long.h
-ifaddr.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ifaddr.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ifaddr.o: $(hdrdir)/ruby/backward/2/stdarg.h
 ifaddr.o: $(hdrdir)/ruby/defines.h
@@ -895,7 +891,6 @@ init.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 init.o: $(hdrdir)/ruby/backward/2/inttypes.h
 init.o: $(hdrdir)/ruby/backward/2/limits.h
 init.o: $(hdrdir)/ruby/backward/2/long_long.h
-init.o: $(hdrdir)/ruby/backward/2/rmodule.h
 init.o: $(hdrdir)/ruby/backward/2/stdalign.h
 init.o: $(hdrdir)/ruby/backward/2/stdarg.h
 init.o: $(hdrdir)/ruby/defines.h
@@ -1078,7 +1073,6 @@ ipsocket.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 ipsocket.o: $(hdrdir)/ruby/backward/2/inttypes.h
 ipsocket.o: $(hdrdir)/ruby/backward/2/limits.h
 ipsocket.o: $(hdrdir)/ruby/backward/2/long_long.h
-ipsocket.o: $(hdrdir)/ruby/backward/2/rmodule.h
 ipsocket.o: $(hdrdir)/ruby/backward/2/stdalign.h
 ipsocket.o: $(hdrdir)/ruby/backward/2/stdarg.h
 ipsocket.o: $(hdrdir)/ruby/defines.h
@@ -1261,7 +1255,6 @@ option.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 option.o: $(hdrdir)/ruby/backward/2/inttypes.h
 option.o: $(hdrdir)/ruby/backward/2/limits.h
 option.o: $(hdrdir)/ruby/backward/2/long_long.h
-option.o: $(hdrdir)/ruby/backward/2/rmodule.h
 option.o: $(hdrdir)/ruby/backward/2/stdalign.h
 option.o: $(hdrdir)/ruby/backward/2/stdarg.h
 option.o: $(hdrdir)/ruby/defines.h
@@ -1444,7 +1437,6 @@ raddrinfo.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 raddrinfo.o: $(hdrdir)/ruby/backward/2/inttypes.h
 raddrinfo.o: $(hdrdir)/ruby/backward/2/limits.h
 raddrinfo.o: $(hdrdir)/ruby/backward/2/long_long.h
-raddrinfo.o: $(hdrdir)/ruby/backward/2/rmodule.h
 raddrinfo.o: $(hdrdir)/ruby/backward/2/stdalign.h
 raddrinfo.o: $(hdrdir)/ruby/backward/2/stdarg.h
 raddrinfo.o: $(hdrdir)/ruby/defines.h
@@ -1627,7 +1619,6 @@ socket.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 socket.o: $(hdrdir)/ruby/backward/2/inttypes.h
 socket.o: $(hdrdir)/ruby/backward/2/limits.h
 socket.o: $(hdrdir)/ruby/backward/2/long_long.h
-socket.o: $(hdrdir)/ruby/backward/2/rmodule.h
 socket.o: $(hdrdir)/ruby/backward/2/stdalign.h
 socket.o: $(hdrdir)/ruby/backward/2/stdarg.h
 socket.o: $(hdrdir)/ruby/defines.h
@@ -1810,7 +1801,6 @@ sockssocket.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 sockssocket.o: $(hdrdir)/ruby/backward/2/inttypes.h
 sockssocket.o: $(hdrdir)/ruby/backward/2/limits.h
 sockssocket.o: $(hdrdir)/ruby/backward/2/long_long.h
-sockssocket.o: $(hdrdir)/ruby/backward/2/rmodule.h
 sockssocket.o: $(hdrdir)/ruby/backward/2/stdalign.h
 sockssocket.o: $(hdrdir)/ruby/backward/2/stdarg.h
 sockssocket.o: $(hdrdir)/ruby/defines.h
@@ -1993,7 +1983,6 @@ tcpserver.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 tcpserver.o: $(hdrdir)/ruby/backward/2/inttypes.h
 tcpserver.o: $(hdrdir)/ruby/backward/2/limits.h
 tcpserver.o: $(hdrdir)/ruby/backward/2/long_long.h
-tcpserver.o: $(hdrdir)/ruby/backward/2/rmodule.h
 tcpserver.o: $(hdrdir)/ruby/backward/2/stdalign.h
 tcpserver.o: $(hdrdir)/ruby/backward/2/stdarg.h
 tcpserver.o: $(hdrdir)/ruby/defines.h
@@ -2176,7 +2165,6 @@ tcpsocket.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 tcpsocket.o: $(hdrdir)/ruby/backward/2/inttypes.h
 tcpsocket.o: $(hdrdir)/ruby/backward/2/limits.h
 tcpsocket.o: $(hdrdir)/ruby/backward/2/long_long.h
-tcpsocket.o: $(hdrdir)/ruby/backward/2/rmodule.h
 tcpsocket.o: $(hdrdir)/ruby/backward/2/stdalign.h
 tcpsocket.o: $(hdrdir)/ruby/backward/2/stdarg.h
 tcpsocket.o: $(hdrdir)/ruby/defines.h
@@ -2359,7 +2347,6 @@ udpsocket.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 udpsocket.o: $(hdrdir)/ruby/backward/2/inttypes.h
 udpsocket.o: $(hdrdir)/ruby/backward/2/limits.h
 udpsocket.o: $(hdrdir)/ruby/backward/2/long_long.h
-udpsocket.o: $(hdrdir)/ruby/backward/2/rmodule.h
 udpsocket.o: $(hdrdir)/ruby/backward/2/stdalign.h
 udpsocket.o: $(hdrdir)/ruby/backward/2/stdarg.h
 udpsocket.o: $(hdrdir)/ruby/defines.h
@@ -2542,7 +2529,6 @@ unixserver.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 unixserver.o: $(hdrdir)/ruby/backward/2/inttypes.h
 unixserver.o: $(hdrdir)/ruby/backward/2/limits.h
 unixserver.o: $(hdrdir)/ruby/backward/2/long_long.h
-unixserver.o: $(hdrdir)/ruby/backward/2/rmodule.h
 unixserver.o: $(hdrdir)/ruby/backward/2/stdalign.h
 unixserver.o: $(hdrdir)/ruby/backward/2/stdarg.h
 unixserver.o: $(hdrdir)/ruby/defines.h
@@ -2725,7 +2711,6 @@ unixsocket.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 unixsocket.o: $(hdrdir)/ruby/backward/2/inttypes.h
 unixsocket.o: $(hdrdir)/ruby/backward/2/limits.h
 unixsocket.o: $(hdrdir)/ruby/backward/2/long_long.h
-unixsocket.o: $(hdrdir)/ruby/backward/2/rmodule.h
 unixsocket.o: $(hdrdir)/ruby/backward/2/stdalign.h
 unixsocket.o: $(hdrdir)/ruby/backward/2/stdarg.h
 unixsocket.o: $(hdrdir)/ruby/defines.h

--- a/ext/stringio/depend
+++ b/ext/stringio/depend
@@ -151,7 +151,6 @@ stringio.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 stringio.o: $(hdrdir)/ruby/backward/2/inttypes.h
 stringio.o: $(hdrdir)/ruby/backward/2/limits.h
 stringio.o: $(hdrdir)/ruby/backward/2/long_long.h
-stringio.o: $(hdrdir)/ruby/backward/2/rmodule.h
 stringio.o: $(hdrdir)/ruby/backward/2/stdalign.h
 stringio.o: $(hdrdir)/ruby/backward/2/stdarg.h
 stringio.o: $(hdrdir)/ruby/defines.h

--- a/ext/strscan/depend
+++ b/ext/strscan/depend
@@ -151,7 +151,6 @@ strscan.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 strscan.o: $(hdrdir)/ruby/backward/2/inttypes.h
 strscan.o: $(hdrdir)/ruby/backward/2/limits.h
 strscan.o: $(hdrdir)/ruby/backward/2/long_long.h
-strscan.o: $(hdrdir)/ruby/backward/2/rmodule.h
 strscan.o: $(hdrdir)/ruby/backward/2/stdalign.h
 strscan.o: $(hdrdir)/ruby/backward/2/stdarg.h
 strscan.o: $(hdrdir)/ruby/defines.h

--- a/ext/syslog/depend
+++ b/ext/syslog/depend
@@ -150,7 +150,6 @@ syslog.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 syslog.o: $(hdrdir)/ruby/backward/2/inttypes.h
 syslog.o: $(hdrdir)/ruby/backward/2/limits.h
 syslog.o: $(hdrdir)/ruby/backward/2/long_long.h
-syslog.o: $(hdrdir)/ruby/backward/2/rmodule.h
 syslog.o: $(hdrdir)/ruby/backward/2/stdalign.h
 syslog.o: $(hdrdir)/ruby/backward/2/stdarg.h
 syslog.o: $(hdrdir)/ruby/defines.h

--- a/ext/zlib/depend
+++ b/ext/zlib/depend
@@ -151,7 +151,6 @@ zlib.o: $(hdrdir)/ruby/backward/2/gcc_version_since.h
 zlib.o: $(hdrdir)/ruby/backward/2/inttypes.h
 zlib.o: $(hdrdir)/ruby/backward/2/limits.h
 zlib.o: $(hdrdir)/ruby/backward/2/long_long.h
-zlib.o: $(hdrdir)/ruby/backward/2/rmodule.h
 zlib.o: $(hdrdir)/ruby/backward/2/stdalign.h
 zlib.o: $(hdrdir)/ruby/backward/2/stdarg.h
 zlib.o: $(hdrdir)/ruby/defines.h

--- a/include/ruby/backward/2/rmodule.h
+++ b/include/ruby/backward/2/rmodule.h
@@ -28,4 +28,10 @@
 #define RMODULE_CONST_TBL(m) RCLASS_CONST_TBL(m)
 #define RMODULE_M_TBL(m) RCLASS_M_TBL(m)
 #define RMODULE_SUPER(m) RCLASS_SUPER(m)
+
+#if defined(__GNUC__)
+# warning RMODULE_* macros are deprecated
+#elif defined(_MSC_VER)
+# pragma message("warning: RMODULE_* macros are deprecated")
+#endif
 #endif /* RUBY_BACKWARD2_RMODULE_H */

--- a/include/ruby/ruby.h
+++ b/include/ruby/ruby.h
@@ -51,7 +51,6 @@
 #include "ruby/backward/2/assume.h"
 #include "ruby/backward/2/inttypes.h"
 #include "ruby/backward/2/limits.h"
-#include "ruby/backward/2/rmodule.h"
 
 RBIMPL_SYMBOL_EXPORT_BEGIN()
 


### PR DESCRIPTION
Why do we have to maintain this public header, which is used from only one function in one file?