### PR TITLE
Avoid allocating a string when dumping an anonymous module or class

### DIFF
--- a/ext/objspace/objspace_dump.c
+++ b/ext/objspace/objspace_dump.c
@@ -268,8 +268,11 @@ dump_object(VALUE obj, struct dump_config *dc)
 
       case T_CLASS:
       case T_MODULE:
-	if (dc->cur_obj_klass)
-	    dump_append(dc, ", \"name\":\"%s\"", rb_class2name(obj));
+	if (dc->cur_obj_klass) {
+	    VALUE mod_name = rb_mod_name(obj);
+	    if (!NIL_P(mod_name))
+		dump_append(dc, ", \"name\":\"%s\"", RSTRING_PTR(mod_name));
+	}
 	break;
 
       case T_DATA:

--- a/test/objspace/test_objspace.rb
+++ b/test/objspace/test_objspace.rb
@@ -503,4 +503,31 @@ class TestObjSpace < Test::Unit::TestCase
     assert_equal h[:immortal_symbol], h[:immortal_dynamic_symbol] + h[:immortal_static_symbol], m
     ;;;
   end
+
+  def test_dump_allocations
+    object = Object.new
+    assert_allocations_count(3) { ObjectSpace.dump(object) }
+  end
+
+  def test_anonymous_class_name
+    klass = Class.new
+    assert_allocations_count(4) { ObjectSpace.dump(klass) }
+    assert_allocations_count(3) { ObjectSpace.dump(klass) }
+
+    mod = Module.new
+    assert_allocations_count(3) { ObjectSpace.dump(mod) }
+
+    assert_not_include ObjectSpace.dump(Class.new), '"name"'
+    assert_not_include ObjectSpace.dump(Module.new), '"name"'
+  end
+
+  private
+
+  def assert_allocations_count(count)
+    ObjectSpace.dump(Object.new) # warming up
+
+    before = GC.stat(:total_allocated_objects)
+    yield
+    assert_equal count, GC.stat(:total_allocated_objects) - before
+  end
 end


### PR DESCRIPTION
`rb_class2name` will allocate a string for anonymous classes and modules. So when taking a heap dump with `ObjectSpace.dump_all` a string will be allocated for each anonymous module and class on the heap.

I'm working on a heap dump diffing tool, so I expect `ObjectSpace.dump_all` to do as little allocations as possible so that it isn't polluting the observation.

Ideally two subsequent calls to `dump_all` should produce identical files (not necessarily in the same order).
