### PR TITLE
Remove unused field in rb_iseq_constant_body

### DIFF
--- a/iseq.c
+++ b/iseq.c
@@ -451,14 +451,11 @@ rb_iseq_memsize(const rb_iseq_t *iseq)
     return size;
 }
 
-static uintptr_t fresh_iseq_unique_id = 0; /* -- Remove In 3.0 -- */
-
 struct rb_iseq_constant_body *
 rb_iseq_constant_body_alloc(void)
 {
     struct rb_iseq_constant_body *iseq_body;
     iseq_body = ZALLOC(struct rb_iseq_constant_body);
-    iseq_body->iseq_unique_id = fresh_iseq_unique_id++; /* -- Remove In 3.0 -- */
     return iseq_body;
 }
 

--- a/vm_core.h
+++ b/vm_core.h
@@ -427,8 +427,6 @@ struct rb_iseq_constant_body {
     long unsigned total_calls; /* number of total calls with `mjit_exec()` */
     struct rb_mjit_unit *jit_unit;
 #endif
-
-    uintptr_t iseq_unique_id; /* -- Remove In 3.0 -- */
 };
 
 /* T_IMEMO/iseq */


### PR DESCRIPTION
This was introduced in 191ce5344ec42c91571f8f47c85be9138262b1c7
and has been unused since beae6cbf0fd8b6619e5212552de98022d4c4d4d4