### PR TITLE
Apply timeout-scale to test_nogvl_poll.

### DIFF
--- a/test/fiddle/test_function.rb
+++ b/test/fiddle/test_function.rb
@@ -111,7 +111,8 @@ module Fiddle
       n1 = f.call(nil, 0, msec)
       n2 = th.value
       t1 = Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond)
-      assert_in_delta(msec, t1 - t0, 180, 'slept amount of time')
+      delta = EnvUtil.apply_timeout_scale(180)
+      assert_in_delta(msec, t1 - t0, delta, 'slept amount of time')
       assert_equal(0, n1, perror("poll(2) in main-thread"))
       assert_equal(0, n2, perror("poll(2) in sub-thread"))
     end


### PR DESCRIPTION

This PR is related to https://bugs.ruby-lang.org/issues/16921 and to apply timeout scale (environment variable `RUBY_TEST_TIMEOUT_SCALE=<number>` or `make test-all TESTOPTS="--timeout-scale=<number>"`.

Other tests showing the ticket are applying the time scale already.
