### PR TITLE
Fix Time#to_a behavior with timezone [Bug #17046]

### DIFF
--- a/test/ruby/test_time_tz.rb
+++ b/test/ruby/test_time_tz.rb
@@ -661,6 +661,12 @@ module TestTimeTZ::WithTZ
     assert_equal(utc, t.to_i)
   end
 
+  def subtest_to_a(time_class, tz, tzarg, tzname, abbr, utc_offset)
+    t = time_class.new(2018, 9, 1, 12, 0, 0, tzarg)
+    ary = t.to_a
+    assert_equal(ary, [t.sec, t.min, t.hour, t.mday, t.mon, t.year, t.wday, t.yday, t.isdst, t.zone])
+  end
+
   def subtest_marshal(time_class, tz, tzarg, tzname, abbr, utc_offset)
     t = time_class.new(2018, 9, 1, 12, 0, 0, tzarg)
     t2 = Marshal.load(Marshal.dump(t))

--- a/time.c
+++ b/time.c
@@ -4867,7 +4867,7 @@ time_to_a(VALUE time)
     struct time_object *tobj;
 
     GetTimeval(time, tobj);
-    MAKE_TM(time, tobj);
+    MAKE_TM_ENSURE(time, tobj, tobj->vtm.yday != 0);
     return rb_ary_new3(10,
 		    INT2FIX(tobj->vtm.sec),
 		    INT2FIX(tobj->vtm.min),


### PR DESCRIPTION
Fix `Time#to_a` behavior(given timezone info)

ref: [Bug #17046 Time#to_a yday is 0(given timezone info)](https://bugs.ruby-lang.org/issues/17046)