### PR TITLE
Net::Support parameters for MAIL FROM and RCPT TO

### DIFF
--- a/lib/net/smtp.rb
+++ b/lib/net/smtp.rb
@@ -249,7 +249,6 @@ module Net
       return nil unless @capabilities
       @capabilities[key] ? true : false
     end
-    private :capable?
 
     # true if server advertises AUTH PLAIN.
     # You cannot get valid value before opening SMTP session.
@@ -942,11 +941,13 @@ module Net
     end
 
     def getok(reqline)
+      puts reqline
       validate_line reqline
       res = critical {
         @socket.writeline reqline
         recv_response()
       }
+      puts res.string
       check_response res
       res
     end

--- a/lib/net/smtp.rb
+++ b/lib/net/smtp.rb
@@ -637,6 +637,8 @@ module Net
     # pair, where +addr+ is a String representing the source mail address and
     # +params+ is an Array or Hash of parameters.
     #
+    # Parameters may be a Hash or an Array of Strings.
+    #
     # === Example
     #
     #     Net::SMTP.start('smtp.example.com') do |smtp|
@@ -691,6 +693,8 @@ module Net
     # An address is a String representing the source mail address, or an [addr, params]
     # pair, where +addr+ is a String representing the source mail address and
     # +params+ is an Array or Hash of parameters.
+    #
+    # Parameters may be a Hash or an Array of Strings.
     #
     # === Example
     #

--- a/lib/net/smtp.rb
+++ b/lib/net/smtp.rb
@@ -945,13 +945,11 @@ module Net
     end
 
     def getok(reqline)
-      puts reqline
       validate_line reqline
       res = critical {
         @socket.writeline reqline
         recv_response()
       }
-      puts res.string
       check_response res
       res
     end


### PR DESCRIPTION
In `Net::SMTP`, add support for parameters for `MAIL FROM` and `RCPT TO`, such as [SMTPUTF8](https://tools.ietf.org/html/rfc6531) and [REQUIRETLS](https://tools.ietf.org/html/rfc8689).

I suggest extending `Net::SMTP#mailfrom` and `Net::SMTP#rcpto` so they accept an additional optional Array or Hash of parameters.

For `Net::SMTP#send_message` and `Net::SMTP#open_message_stream`, I suggest that in addition to a String email address (or arrays of Strings), these methods should accept a pair (or arrays of pairs) of `[addr, params]`, where `addr` is the String email address, and `params` is an Array or Hash of parameters.

In order for the parameters to be useful, we should expose the capabilities reported by `EHLO`, so `capable?` should be made public.
