### PR TITLE
Fix Time#ceil when result should be the same as the receiver

### DIFF
--- a/test/ruby/test_time.rb
+++ b/test/ruby/test_time.rb
@@ -1069,6 +1069,11 @@ class TestTime < Test::Unit::TestCase
     t2 = (t+0.123456789).ceil(4)
     assert_equal([59,59,23, 31,12,1999, 5,365,false,"UTC"], t2.to_a)
     assert_equal(Rational(1235,10000), t2.subsec)
+
+    time = Time.utc(2016, 4, 23, 0, 0, 0.123456789r)
+    assert_equal(time, time.ceil(9))
+    assert_equal(time, time.ceil(10))
+    assert_equal(time, time.ceil(11))
   end
 
   def test_getlocal_dont_share_eigenclass

--- a/time.c
+++ b/time.c
@@ -4446,7 +4446,10 @@ time_ceil(int argc, VALUE *argv, VALUE time)
     v = w2v(rb_time_unmagnify(tobj->timew));
 
     v = modv(v, den);
-    return time_add(tobj, time, subv(den, v), 1);
+    if (!rb_equal(v, INT2FIX(0))) {
+        v = subv(den, v);
+    }
+    return time_add(tobj, time, v, 1);
 }
 
 /*


### PR DESCRIPTION
Fixes [Bug #17025]