### PR TITLE
Implemented some NilClass method in Ruby code is faster [Feature #17054]

### DIFF
--- a/benchmark/nilclass.yml
+++ b/benchmark/nilclass.yml
@@ -1,0 +1,6 @@
+benchmark:
+  to_i: |
+    nil.to_i
+  to_f: |
+    nil.to_f
+loop_count: 100000

--- a/common.mk
+++ b/common.mk
@@ -1031,6 +1031,7 @@ BUILTIN_RB_SRCS = \
 		$(srcdir)/kernel.rb \
 		$(srcdir)/ractor.rb \
 		$(srcdir)/timev.rb \
+		$(srcdir)/nilclass.rb \
 		$(srcdir)/prelude.rb \
 		$(srcdir)/gem_prelude.rb \
 		$(empty)
@@ -8350,6 +8351,7 @@ miniinit.$(OBJEXT): {$(VPATH)}miniinit.c
 miniinit.$(OBJEXT): {$(VPATH)}miniprelude.c
 miniinit.$(OBJEXT): {$(VPATH)}missing.h
 miniinit.$(OBJEXT): {$(VPATH)}node.h
+miniinit.$(OBJEXT): {$(VPATH)}nilclass.rb
 miniinit.$(OBJEXT): {$(VPATH)}numeric.rb
 miniinit.$(OBJEXT): {$(VPATH)}onigmo.h
 miniinit.$(OBJEXT): {$(VPATH)}oniguruma.h
@@ -9374,6 +9376,8 @@ object.$(OBJEXT): {$(VPATH)}internal/xmalloc.h
 object.$(OBJEXT): {$(VPATH)}kernel.rb
 object.$(OBJEXT): {$(VPATH)}kernel.rbinc
 object.$(OBJEXT): {$(VPATH)}missing.h
+object.$(OBJEXT): {$(VPATH)}nilclass.rb
+object.$(OBJEXT): {$(VPATH)}nilclass.rbinc
 object.$(OBJEXT): {$(VPATH)}object.c
 object.$(OBJEXT): {$(VPATH)}onigmo.h
 object.$(OBJEXT): {$(VPATH)}oniguruma.h

--- a/inits.c
+++ b/inits.c
@@ -97,6 +97,7 @@ rb_call_builtin_inits(void)
     BUILTIN(array);
     BUILTIN(kernel);
     BUILTIN(timev);
+    BUILTIN(nilclass);
     Init_builtin_prelude();
 }
 #undef CALL

--- a/nilclass.rb
+++ b/nilclass.rb
@@ -1,0 +1,25 @@
+class NilClass
+  #
+  #  call-seq:
+  #     nil.to_i -> 0
+  #
+  #  Always returns zero.
+  #
+  #     nil.to_i   #=> 0
+  #
+  def to_i
+    return 0
+  end
+
+  #
+  #  call-seq:
+  #     nil.to_f    -> 0.0
+  #
+  #  Always returns zero.
+  #
+  #     nil.to_f   #=> 0.0
+  #
+  def to_f
+    return 0.0
+  end
+end

--- a/object.c
+++ b/object.c
@@ -1347,37 +1347,6 @@ rb_obj_frozen_p(VALUE obj)
 
 /*
  *  call-seq:
- *     nil.to_i -> 0
- *
- *  Always returns zero.
- *
- *     nil.to_i   #=> 0
- */
-
-
-static VALUE
-nil_to_i(VALUE obj)
-{
-    return INT2FIX(0);
-}
-
-/*
- *  call-seq:
- *     nil.to_f    -> 0.0
- *
- *  Always returns zero.
- *
- *     nil.to_f   #=> 0.0
- */
-
-static VALUE
-nil_to_f(VALUE obj)
-{
-    return DBL2NUM(0.0);
-}
-
-/*
- *  call-seq:
  *     nil.to_s    -> ""
  *
  *  Always returns the empty string.
@@ -4871,8 +4840,6 @@ InitVM_Object(void)
     rb_cNilClass = rb_define_class("NilClass", rb_cObject);
     rb_cNilClass_to_s = rb_fstring_enc_lit("", rb_usascii_encoding());
     rb_gc_register_mark_object(rb_cNilClass_to_s);
-    rb_define_method(rb_cNilClass, "to_i", nil_to_i, 0);
-    rb_define_method(rb_cNilClass, "to_f", nil_to_f, 0);
     rb_define_method(rb_cNilClass, "to_s", nil_to_s, 0);
     rb_define_method(rb_cNilClass, "to_a", nil_to_a, 0);
     rb_define_method(rb_cNilClass, "to_h", nil_to_h, 0);
@@ -4975,6 +4942,7 @@ InitVM_Object(void)
 }
 
 #include "kernel.rbinc"
+#include "nilclass.rbinc"
 
 void
 Init_Object(void)


### PR DESCRIPTION
This patch is some NilClass method impleted by Ruby code.
ref: [Feature #17054 Implemented some NilClass method in Ruby code is faster](https://bugs.ruby-lang.org/issues/17054)