### PR TITLE
Fix URI empty queries

### DIFF
--- a/lib/uri/generic.rb
+++ b/lib/uri/generic.rb
@@ -1355,7 +1355,7 @@ module URI
           str << @port.to_s
         end
         str << @path
-        if @query
+        if @query && !@query.empty?
           str << '?'
           str << @query
         end

--- a/test/uri/test_generic.rb
+++ b/test/uri/test_generic.rb
@@ -728,6 +728,8 @@ class URI::TestGeneric < Test::Unit::TestCase
     assert_equal('http://foo:bar@zab:8080', uri.to_s)
     assert_equal('/', uri.path = '/')
     assert_equal('http://foo:bar@zab:8080/', uri.to_s)
+    assert_equal('', uri.query = '')
+    assert_equal('http://foo:bar@zab:8080/', uri.to_s)
     assert_equal('a=1', uri.query = 'a=1')
     assert_equal('http://foo:bar@zab:8080/?a=1', uri.to_s)
     assert_equal('b123', uri.fragment = 'b123')


### PR DESCRIPTION
# Problem
The `URI::Generic` class permits build a URI with an empty query, generating an empty query string that could generate weird behaviors in some browsers: `https://www.ruby-lang.org?`.

## Example
```ruby
irb(main):001:0> URI::Generic.build(scheme:'https', host: 'ruby-lang.org', query: '').to_s
=> "https://ruby-lang.org?"
```

# Solution
Just build the query section given a non-empty query.

## Example
```ruby
irb(main):001:0> URI::Generic.build(scheme:'https', host: 'ruby-lang.org', query: '').to_s
=> "https://ruby-lang.org"
```