### PR TITLE
Allow suppressing uninitialized instance variable and method redefined verbose mode warnings

### DIFF
--- a/internal/variable.h
+++ b/internal/variable.h
@@ -32,6 +32,7 @@ NORETURN(VALUE rb_mod_const_missing(VALUE,VALUE));
 rb_gvar_getter_t *rb_gvar_getter_function_of(ID);
 rb_gvar_setter_t *rb_gvar_setter_function_of(ID);
 void rb_gvar_readonly_setter(VALUE v, ID id, VALUE *_);
+
 static inline bool ROBJ_TRANSIENT_P(VALUE obj);
 static inline void ROBJ_TRANSIENT_SET(VALUE obj);
 static inline void ROBJ_TRANSIENT_UNSET(VALUE obj);
@@ -51,6 +52,7 @@ VALUE rb_gvar_get(ID);
 VALUE rb_gvar_set(ID, VALUE);
 VALUE rb_gvar_defined(ID);
 void rb_const_warn_if_deprecated(const rb_const_entry_t *, VALUE, ID);
+void rb_uninitialized_ivar_access_verbose(VALUE obj, VALUE var);
 MJIT_SYMBOL_EXPORT_END
 
 static inline bool

--- a/object.c
+++ b/object.c
@@ -2864,6 +2864,8 @@ rb_obj_ivar_get(VALUE obj, VALUE iv)
     ID id = id_for_var(obj, iv, instance);
 
     if (!id) {
+        if (RTEST(ruby_verbose))
+            rb_uninitialized_ivar_access_verbose(obj, iv);
 	return Qnil;
     }
     return rb_ivar_get(obj, id);

--- a/test/ruby/test_module.rb
+++ b/test/ruby/test_module.rb
@@ -1573,6 +1573,27 @@ class TestModule < Test::Unit::TestCase
     assert_match(/: warning: previous definition of foo/, stderr)
   end
 
+  def test_method_redefinition_expected
+    m = nil
+    stderr = EnvUtil.verbose_warning do
+      m = Module.new do
+        def self.expected_redefined_method?(m) m == :foo end
+        def foo; end
+        def foo; end
+      end
+    end
+    assert_equal('', stderr)
+
+    stderr = EnvUtil.verbose_warning do
+      m.class_eval do
+        def bar; end
+        def bar; end
+      end
+    end
+    assert_match(/: warning: method redefined; discarding old bar/, stderr)
+    assert_match(/: warning: previous definition of bar/, stderr)
+  end
+
   def test_module_function_inside_method
     assert_warn(/calling module_function without arguments inside a method may not have the intended effect/, '[ruby-core:79751]') do
       Module.new do

--- a/test/ruby/test_module.rb
+++ b/test/ruby/test_module.rb
@@ -2423,6 +2423,17 @@ class TestModule < Test::Unit::TestCase
     end
   end
 
+  def test_expected_uninitialized_instance_variable_without_id
+    a = Object.new
+    a.define_singleton_method(:expected_uninitialized_instance_variable?){|v| v == "@ivar2_adfasdfjo14390"}
+    assert_warning(/instance variable @ivar2_adfasdfjo14391 not initialized/) do
+      assert_nil(a.instance_variable_get("@ivar2_adfasdfjo14391"))
+    end
+    assert_warning('') do
+      assert_nil(a.instance_variable_get("@ivar2_adfasdfjo14390"))
+    end
+  end
+
   def test_uninitialized_attr
     a = AttrTest.new
     assert_warning '' do

--- a/test/ruby/test_module.rb
+++ b/test/ruby/test_module.rb
@@ -2379,6 +2379,9 @@ class TestModule < Test::Unit::TestCase
     def ivar
       @ivar
     end
+    def ivar2
+      @ivar2
+    end
   end
 
   def test_uninitialized_instance_variable
@@ -2394,6 +2397,29 @@ class TestModule < Test::Unit::TestCase
     name = "@\u{5909 6570}"
     assert_warning(/instance variable #{name} not initialized/) do
       assert_nil(a.instance_eval(name))
+    end
+  end
+
+  def test_expected_uninitialized_instance_variable
+    a = AttrTest.new
+    a.define_singleton_method(:expected_uninitialized_instance_variable?){|v| v == :@ivar2}
+    assert_warning(/instance variable @ivar not initialized/) do
+      assert_nil(a.ivar)
+    end
+    assert_warning(/instance variable @ivar not initialized/) do
+      assert_nil(a.instance_variable_get(:@ivar))
+    end
+    assert_warning(/instance variable @ivar not initialized/) do
+      assert_nil(a.instance_variable_get("@ivar"))
+    end
+    assert_warning('') do
+      assert_nil(a.ivar2)
+    end
+    assert_warning('') do
+      assert_nil(a.instance_variable_get(:@ivar2))
+    end
+    assert_warning('') do
+      assert_nil(a.instance_variable_get("@ivar2"))
     end
   end
 

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1145,7 +1145,7 @@ vm_getivar(VALUE obj, ID id, IVC ic, const struct rb_callcache *cc, int is_attr)
         }
         else {
             if (!is_attr && RTEST(ruby_verbose)) {
-                rb_warning("instance variable %"PRIsVALUE" not initialized", QUOTE_ID(id));
+                rb_uninitialized_ivar_access_verbose(obj, ID2SYM(id));
             }
             return Qnil;
         }


### PR DESCRIPTION
These two verbose mode warnings are both fairly common and have good reasons why you would not want to warn about them in specific cases.  Not initializing instance variables to nil can be much better for performance, and redefining methods without removing the method first is the only safe approach in multi-threaded code.

There are reasons that you may want to issue verbose warnings by default in these cases.  For uninitialized instance variables, it helps catch typos. For method redefinition, it could alert you that a method already exists when you didn't expect it to, such as when a file is loaded multiple times when it should only be loaded once.

I propose we keep the default behavior the same, but offer the ability to opt-out of these warnings by defining methods.  For uninitialized instance variables in verbose mode, I propose we call `expected_uninitialized_instance_variable?(iv)` on the object.  If this method doesn't exist or returns false/nil, we issue the warning.  If the method exists and returns true, we suppress the warning.  Similarly, for redefined methods, we call `expected_redefined_method?(method_name)` on the class or module.  If the method doesn't exist or returns false/nil, we issue the warning.  If the method exists and returns true, we suppress the warning.

This approach allows high performance code (uninitialized instance variables) and safe code (redefining methods without removing) to work without verbose mode warnings.