### PR TITLE
Extract version number from the source

### DIFF
--- a/lib/cgi.rb
+++ b/lib/cgi.rb
@@ -288,6 +288,7 @@
 #
 
 class CGI
+  VERSION = "0.1.0"
 end
 
 require 'cgi/core'

--- a/lib/cgi/cgi.gemspec
+++ b/lib/cgi/cgi.gemspec
@@ -1,12 +1,15 @@
-begin
-  require_relative "lib/cgi/version"
-rescue LoadError # Fallback to load version file in ruby core repository
-  require_relative "version"
+# frozen_string_literal: true
+
+name = File.basename(__FILE__, ".gemspec")
+version = ["lib", Array.new(name.count("-")+1, "..").join("/")].find do |dir|
+  break File.foreach(File.join(__dir__, dir, "#{name.tr('-', '/')}.rb")) do |line|
+    /^\s*VERSION\s*=\s*"(.*)"/ =~ line and break $1
+  end rescue nil
 end
 
 Gem::Specification.new do |spec|
-  spec.name          = "cgi"
-  spec.version       = CGI::VERSION
+  spec.name          = name
+  spec.version       = version
   spec.authors       = ["Yukihiro Matsumoto"]
   spec.email         = ["matz@ruby-lang.org"]
 

--- a/lib/cgi/version.rb
+++ b/lib/cgi/version.rb
@@ -1,3 +1,0 @@
-class CGI
-  VERSION = "0.1.0"
-end

--- a/lib/delegate.rb
+++ b/lib/delegate.rb
@@ -39,6 +39,8 @@
 # Be advised, RDoc will not detect delegated methods.
 #
 class Delegator < BasicObject
+  VERSION = "0.1.0"
+
   kernel = ::Kernel.dup
   kernel.class_eval do
     alias __raise__ raise

--- a/lib/delegate/delegate.gemspec
+++ b/lib/delegate/delegate.gemspec
@@ -1,12 +1,15 @@
-begin
-  require_relative "lib/delegate/version"
-rescue LoadError # Fallback to load version file in ruby core repository
-  require_relative "version"
+# frozen_string_literal: true
+
+name = File.basename(__FILE__, ".gemspec")
+version = ["lib", Array.new(name.count("-")+1, "..").join("/")].find do |dir|
+  break File.foreach(File.join(__dir__, dir, "#{name.tr('-', '/')}.rb")) do |line|
+    /^\s*VERSION\s*=\s*"(.*)"/ =~ line and break $1
+  end rescue nil
 end
 
 Gem::Specification.new do |spec|
-  spec.name          = "delegate"
-  spec.version       = Delegator::VERSION
+  spec.name          = name
+  spec.version       = version
   spec.authors       = ["Yukihiro Matsumoto"]
   spec.email         = ["matz@ruby-lang.org"]
 

--- a/lib/delegate/version.rb
+++ b/lib/delegate/version.rb
@@ -1,3 +1,0 @@
-class Delegator < BasicObject
-  VERSION = "0.1.0"
-end

--- a/lib/forwardable.rb
+++ b/lib/forwardable.rb
@@ -110,7 +110,10 @@
 #
 module Forwardable
   require 'forwardable/impl'
-  require "forwardable/version"
+
+  # Version of +forwardable.rb+
+  VERSION = "1.3.1"
+  FORWARDABLE_VERSION = VERSION
 
   @debug = nil
   class << self

--- a/lib/forwardable/forwardable.gemspec
+++ b/lib/forwardable/forwardable.gemspec
@@ -1,13 +1,15 @@
-begin
-  require_relative "lib/forwardable/version"
-rescue LoadError
-  # for Ruby core repository
-  require_relative "version"
+# frozen_string_literal: true
+
+name = File.basename(__FILE__, ".gemspec")
+version = ["lib", Array.new(name.count("-")+1, "..").join("/")].find do |dir|
+  break File.foreach(File.join(__dir__, dir, "#{name.tr('-', '/')}.rb")) do |line|
+    /^\s*VERSION\s*=\s*"(.*)"/ =~ line and break $1
+  end rescue nil
 end
 
 Gem::Specification.new do |spec|
-  spec.name          = "forwardable"
-  spec.version       = Forwardable::VERSION
+  spec.name          = name
+  spec.version       = version
   spec.authors       = ["Keiju ISHITSUKA"]
   spec.email         = ["keiju@ruby-lang.org"]
 

--- a/lib/forwardable/version.rb
+++ b/lib/forwardable/version.rb
@@ -1,5 +1,0 @@
-module Forwardable
-  # Version of +forwardable.rb+
-  VERSION = "1.3.1"
-  FORWARDABLE_VERSION = VERSION
-end

--- a/lib/getoptlong.rb
+++ b/lib/getoptlong.rb
@@ -85,6 +85,9 @@
 #     hello -n 6 --name -- /tmp
 #
 class GetoptLong
+  # Version.
+  VERSION = "0.1.0"
+
   #
   # Orderings.
   #

--- a/lib/getoptlong/getoptlong.gemspec
+++ b/lib/getoptlong/getoptlong.gemspec
@@ -1,12 +1,15 @@
-begin
-  require_relative "lib/getoptlong/version"
-rescue LoadError # Fallback to load version file in ruby core repository
-  require_relative "version"
+# frozen_string_literal: true
+
+name = File.basename(__FILE__, ".gemspec")
+version = ["lib", Array.new(name.count("-")+1, "..").join("/")].find do |dir|
+  break File.foreach(File.join(__dir__, dir, "#{name.tr('-', '/')}.rb")) do |line|
+    /^\s*VERSION\s*=\s*"(.*)"/ =~ line and break $1
+  end rescue nil
 end
 
 Gem::Specification.new do |spec|
-  spec.name          = "getoptlong"
-  spec.version       = GetoptLong::VERSION
+  spec.name          = name
+  spec.version       = version
   spec.authors       = ["Yukihiro Matsumoto"]
   spec.email         = ["matz@ruby-lang.org"]
 

--- a/lib/getoptlong/version.rb
+++ b/lib/getoptlong/version.rb
@@ -1,3 +1,0 @@
-class GetoptLong
-  VERSION = "0.1.0"
-end

--- a/lib/net/ftp/net-ftp.gemspec
+++ b/lib/net/ftp/net-ftp.gemspec
@@ -1,13 +1,14 @@
+# frozen_string_literal: true
+
 name = File.basename(__FILE__, ".gemspec")
-version = nil
-["lib", "../.."].find do |dir|
-  version = File.foreach(File.join(__dir__, dir, "#{name.tr('-', '/')}.rb")) do |line|
+version = ["lib", Array.new(name.count("-")+1, "..").join("/")].find do |dir|
+  break File.foreach(File.join(__dir__, dir, "#{name.tr('-', '/')}.rb")) do |line|
     /^\s*VERSION\s*=\s*"(.*)"/ =~ line and break $1
   end rescue nil
 end
 
 Gem::Specification.new do |spec|
-  spec.name          = "net-ftp"
+  spec.name          = name
   spec.version       = version
   spec.authors       = ["Shugo Maeda"]
   spec.email         = ["shugo@ruby-lang.org"]

--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -388,6 +388,7 @@ module Net   #:nodoc:
   class HTTP < Protocol
 
     # :stopdoc:
+    VERSION = "0.1.0"
     Revision = %q$Revision$.split[1]
     HTTPVersion = '1.1'
     begin

--- a/lib/net/http/net-http.gemspec
+++ b/lib/net/http/net-http.gemspec
@@ -1,12 +1,15 @@
-begin
-  require_relative "lib/net/http/version"
-rescue LoadError # Fallback to load version file in ruby core repository
-  require_relative "version"
+# frozen_string_literal: true
+
+name = File.basename(__FILE__, ".gemspec")
+version = ["lib", Array.new(name.count("-")+1, "..").join("/")].find do |dir|
+  break File.foreach(File.join(__dir__, dir, "#{name.tr('-', '/')}.rb")) do |line|
+    /^\s*VERSION\s*=\s*"(.*)"/ =~ line and break $1
+  end rescue nil
 end
 
 Gem::Specification.new do |spec|
-  spec.name          = "net-http"
-  spec.version       = Net::Http::VERSION
+  spec.name          = name
+  spec.version       = version
   spec.authors       = ["NARUSE, Yui"]
   spec.email         = ["naruse@airemix.jp"]
 

--- a/lib/net/http/version.rb
+++ b/lib/net/http/version.rb
@@ -1,5 +1,0 @@
-module Net
-  module Http
-    VERSION = "0.1.0"
-  end
-end

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -201,6 +201,8 @@ module Net
   #    Unicode", RFC 2152, May 1997.
   #
   class IMAP < Protocol
+    VERSION = "0.1.0"
+
     include MonitorMixin
     if defined?(OpenSSL::SSL)
       include OpenSSL

--- a/lib/net/imap/net-imap.gemspec
+++ b/lib/net/imap/net-imap.gemspec
@@ -1,12 +1,15 @@
-begin
-  require_relative 'lib/net/imap/version'
-rescue LoadError # Fallback to load version file in ruby core repository
-  require_relative "version"
+# frozen_string_literal: true
+
+name = File.basename(__FILE__, ".gemspec")
+version = ["lib", Array.new(name.count("-")+1, "..").join("/")].find do |dir|
+  break File.foreach(File.join(__dir__, dir, "#{name.tr('-', '/')}.rb")) do |line|
+    /^\s*VERSION\s*=\s*"(.*)"/ =~ line and break $1
+  end rescue nil
 end
 
 Gem::Specification.new do |spec|
-  spec.name          = "net-imap"
-  spec.version       = Net::Imap::VERSION
+  spec.name          = name
+  spec.version       = version
   spec.authors       = ["Shugo Maeda"]
   spec.email         = ["shugo@ruby-lang.org"]
 

--- a/lib/net/imap/version.rb
+++ b/lib/net/imap/version.rb
@@ -1,5 +1,0 @@
-module Net
-  module Imap
-    VERSION = "0.1.0"
-  end
-end

--- a/lib/net/pop.rb
+++ b/lib/net/pop.rb
@@ -194,9 +194,8 @@ module Net
   # String. Normally the unique-id is a hash of the message.
   #
   class POP3 < Protocol
-
-    # svn revision of this library
-    Revision = %q$Revision$.split[1]
+    # version of this library
+    VERSION = "0.1.0"
 
     #
     # Class Parameters

--- a/lib/net/pop/net-pop.gemspec
+++ b/lib/net/pop/net-pop.gemspec
@@ -1,12 +1,15 @@
-begin
-  require_relative "lib/net/pop/version"
-rescue LoadError # Fallback to load version file in ruby core repository
-  require_relative "version"
+# frozen_string_literal: true
+
+name = File.basename(__FILE__, ".gemspec")
+version = ["lib", Array.new(name.count("-")+1, "..").join("/")].find do |dir|
+  break File.foreach(File.join(__dir__, dir, "#{name.tr('-', '/')}.rb")) do |line|
+    /^\s*VERSION\s*=\s*"(.*)"/ =~ line and break $1
+  end rescue nil
 end
 
 Gem::Specification.new do |spec|
-  spec.name          = "net-pop"
-  spec.version       = Net::POP3::VERSION
+  spec.name          = name
+  spec.version       = version
   spec.authors       = ["Yukihiro Matsumoto"]
   spec.email         = ["matz@ruby-lang.org"]
 

--- a/lib/net/pop/version.rb
+++ b/lib/net/pop/version.rb
@@ -1,6 +1,0 @@
-module Net
-  class Protocol; end
-  class POP3 < Protocol
-    VERSION = "0.1.0"
-  end
-end

--- a/lib/net/protocol.rb
+++ b/lib/net/protocol.rb
@@ -26,6 +26,8 @@ require 'io/wait'
 module Net # :nodoc:
 
   class Protocol   #:nodoc: internal use only
+    VERSION = "0.1.0"
+
     private
     def Protocol.protocol_param(name, val)
       module_eval(<<-End, __FILE__, __LINE__ + 1)

--- a/lib/net/protocol/net-protocol.gemspec
+++ b/lib/net/protocol/net-protocol.gemspec
@@ -1,12 +1,15 @@
-begin
-  require_relative "lib/net/protocol/version"
-rescue LoadError # Fallback to load version file in ruby core repository
-  require_relative "version"
+# frozen_string_literal: true
+
+name = File.basename(__FILE__, ".gemspec")
+version = ["lib", Array.new(name.count("-")+1, "..").join("/")].find do |dir|
+  break File.foreach(File.join(__dir__, dir, "#{name.tr('-', '/')}.rb")) do |line|
+    /^\s*VERSION\s*=\s*"(.*)"/ =~ line and break $1
+  end rescue nil
 end
 
 Gem::Specification.new do |spec|
-  spec.name          = "net-protocol"
-  spec.version       = Net::Protocol::VERSION
+  spec.name          = name
+  spec.version       = version
   spec.authors = ["Yukihiro Matsumoto"]
   spec.email = ["matz@ruby-lang.org"]
 

--- a/lib/net/protocol/version.rb
+++ b/lib/net/protocol/version.rb
@@ -1,5 +1,0 @@
-module Net
-  class Protocol
-    VERSION = "0.1.0"
-  end
-end

--- a/lib/net/smtp.rb
+++ b/lib/net/smtp.rb
@@ -168,6 +168,7 @@ module Net
   #                     'Your Account', 'Your Password', :cram_md5)
   #
   class SMTP < Protocol
+    VERSION = "0.1.0"
 
     Revision = %q$Revision$.split[1]
 

--- a/lib/net/smtp/net-smtp.gemspec
+++ b/lib/net/smtp/net-smtp.gemspec
@@ -1,12 +1,15 @@
-begin
-  require_relative "lib/net/smtp/version"
-rescue LoadError # Fallback to load version file in ruby core repository
-  require_relative "version"
+# frozen_string_literal: true
+
+name = File.basename(__FILE__, ".gemspec")
+version = ["lib", Array.new(name.count("-")+1, "..").join("/")].find do |dir|
+  break File.foreach(File.join(__dir__, dir, "#{name.tr('-', '/')}.rb")) do |line|
+    /^\s*VERSION\s*=\s*"(.*)"/ =~ line and break $1
+  end rescue nil
 end
 
 Gem::Specification.new do |spec|
-  spec.name          = "net-smtp"
-  spec.version       = Net::SMTP::VERSION
+  spec.name          = name
+  spec.version       = version
   spec.authors       = ["Yukihiro Matsumoto"]
   spec.email         = ["matz@ruby-lang.org"]
 

--- a/lib/net/smtp/version.rb
+++ b/lib/net/smtp/version.rb
@@ -1,6 +1,0 @@
-module Net
-  class Protocol; end
-  class SMTP < Protocol
-    VERSION = "0.1.0"
-  end
-end

--- a/lib/observer.rb
+++ b/lib/observer.rb
@@ -136,6 +136,7 @@
 #   ticker.add_observer(warner, :call)
 #   ticker.run
 module Observable
+  VERSION = "0.1.0"
 
   #
   # Add +observer+ as an observer on this object. So that it will receive

--- a/lib/observer/observer.gemspec
+++ b/lib/observer/observer.gemspec
@@ -1,12 +1,15 @@
-begin
-  require_relative "lib/observer/version"
-rescue LoadError # Fallback to load version file in ruby core repository
-  require_relative "version"
+# frozen_string_literal: true
+
+name = File.basename(__FILE__, ".gemspec")
+version = ["lib", Array.new(name.count("-")+1, "..").join("/")].find do |dir|
+  break File.foreach(File.join(__dir__, dir, "#{name.tr('-', '/')}.rb")) do |line|
+    /^\s*VERSION\s*=\s*"(.*)"/ =~ line and break $1
+  end rescue nil
 end
 
 Gem::Specification.new do |spec|
-  spec.name          = "observer"
-  spec.version       = Observer::VERSION
+  spec.name          = name
+  spec.version       = version
   spec.authors       = ["Yukihiro Matsumoto"]
   spec.email         = ["matz@ruby-lang.org"]
 

--- a/lib/observer/version.rb
+++ b/lib/observer/version.rb
@@ -1,3 +1,0 @@
-module Observer
-  VERSION = "0.1.0"
-end

--- a/lib/open3.rb
+++ b/lib/open3.rb
@@ -30,6 +30,7 @@
 #
 
 module Open3
+  VERSION = "0.1.0"
 
   # Open stdin, stdout, and stderr streams and start external executable.
   # In addition, a thread to wait for the started process is created.

--- a/lib/open3/open3.gemspec
+++ b/lib/open3/open3.gemspec
@@ -1,12 +1,15 @@
-begin
-  require_relative "lib/open3/version"
-rescue LoadError # Fallback to load version file in ruby core repository
-  require_relative "version"
+# frozen_string_literal: true
+
+name = File.basename(__FILE__, ".gemspec")
+version = ["lib", Array.new(name.count("-")+1, "..").join("/")].find do |dir|
+  break File.foreach(File.join(__dir__, dir, "#{name.tr('-', '/')}.rb")) do |line|
+    /^\s*VERSION\s*=\s*"(.*)"/ =~ line and break $1
+  end rescue nil
 end
 
 Gem::Specification.new do |spec|
-  spec.name          = "open3"
-  spec.version       = Open3::VERSION
+  spec.name          = name
+  spec.version       = version
   spec.authors       = ["Yukihiro Matsumoto"]
   spec.email         = ["matz@ruby-lang.org"]
 

--- a/lib/open3/version.rb
+++ b/lib/open3/version.rb
@@ -1,3 +1,0 @@
-module Open3
-  VERSION = "0.1.0"
-end

--- a/lib/optparse/optparse.gemspec
+++ b/lib/optparse/optparse.gemspec
@@ -1,7 +1,8 @@
+# frozen_string_literal: true
+
 name = File.basename(__FILE__, ".gemspec")
-version = nil
-["lib", ".."].find do |dir|
-  version = File.foreach(File.join(__dir__, dir, "#{name}.rb")) do |line|
+version = ["lib", Array.new(name.count("-")+1, "..").join("/")].find do |dir|
+  break File.foreach(File.join(__dir__, dir, "#{name.tr('-', '/')}.rb")) do |line|
     /^\s*OptionParser::Version\s*=\s*"(.*)"/ =~ line and break $1
   end rescue nil
 end

--- a/lib/ostruct.rb
+++ b/lib/ostruct.rb
@@ -9,8 +9,6 @@
 # See OpenStruct for an example.
 #
 
-require_relative 'ostruct/version'
-
 #
 # An OpenStruct is a data structure, similar to a Hash, that allows the
 # definition of arbitrary attributes with their accompanying values. This is
@@ -75,6 +73,7 @@ require_relative 'ostruct/version'
 # of these properties compared to using a Hash or a Struct.
 #
 class OpenStruct
+  VERSION = "0.2.0"
 
   #
   # Creates a new OpenStruct object.  By default, the resulting OpenStruct

--- a/lib/ostruct/ostruct.gemspec
+++ b/lib/ostruct/ostruct.gemspec
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
-begin
-  require_relative "lib/ostruct/version"
-rescue LoadError
-  # for Ruby core repository
-  require_relative "version"
+name = File.basename(__FILE__, ".gemspec")
+version = ["lib", Array.new(name.count("-")+1, "..").join("/")].find do |dir|
+  break File.foreach(File.join(__dir__, dir, "#{name.tr('-', '/')}.rb")) do |line|
+    /^\s*VERSION\s*=\s*"(.*)"/ =~ line and break $1
+  end rescue nil
 end
 
 Gem::Specification.new do |spec|
-  spec.name          = "ostruct"
-  spec.version       = OpenStruct::VERSION
+  spec.name          = name
+  spec.version       = version
   spec.authors       = ["Marc-Andre Lafortune"]
   spec.email         = ["ruby-core@marc-andre.ca"]
 

--- a/lib/ostruct/version.rb
+++ b/lib/ostruct/version.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-class OpenStruct
-  VERSION = "0.2.0"
-end

--- a/lib/pstore.rb
+++ b/lib/pstore.rb
@@ -92,6 +92,8 @@ require "digest"
 # Needless to say, if you're storing valuable data with PStore, then you should
 # backup the PStore files from time to time.
 class PStore
+  VERSION = "0.1.0"
+
   RDWR_ACCESS = {mode: IO::RDWR | IO::CREAT | IO::BINARY, encoding: Encoding::ASCII_8BIT}.freeze
   RD_ACCESS = {mode: IO::RDONLY | IO::BINARY, encoding: Encoding::ASCII_8BIT}.freeze
   WR_ACCESS = {mode: IO::WRONLY | IO::CREAT | IO::TRUNC | IO::BINARY, encoding: Encoding::ASCII_8BIT}.freeze

--- a/lib/pstore/pstore.gemspec
+++ b/lib/pstore/pstore.gemspec
@@ -1,12 +1,15 @@
-begin
-  require_relative "lib/pstore/version"
-rescue LoadError # Fallback to load version file in ruby core repository
-  require_relative "version"
+# frozen_string_literal: true
+
+name = File.basename(__FILE__, ".gemspec")
+version = ["lib", Array.new(name.count("-")+1, "..").join("/")].find do |dir|
+  break File.foreach(File.join(__dir__, dir, "#{name.tr('-', '/')}.rb")) do |line|
+    /^\s*VERSION\s*=\s*"(.*)"/ =~ line and break $1
+  end rescue nil
 end
 
 Gem::Specification.new do |spec|
-  spec.name          = "pstore"
-  spec.version       = PStore::VERSION
+  spec.name          = name
+  spec.version       = version
   spec.authors       = ["Yukihiro Matsumoto"]
   spec.email         = ["matz@ruby-lang.org"]
 

--- a/lib/pstore/version.rb
+++ b/lib/pstore/version.rb
@@ -1,3 +1,0 @@
-class PStore
-  VERSION = "0.1.0"
-end

--- a/lib/singleton.rb
+++ b/lib/singleton.rb
@@ -92,6 +92,8 @@
 #    p a.strip #  => nil
 #
 module Singleton
+  VERSION = "0.1.0"
+
   # Raises a TypeError to prevent cloning.
   def clone
     raise TypeError, "can't clone instance of singleton #{self.class}"

--- a/lib/singleton/singleton.gemspec
+++ b/lib/singleton/singleton.gemspec
@@ -1,12 +1,15 @@
-begin
-  require_relative "lib/singleton/version"
-rescue LoadError # Fallback to load version file in ruby core repository
-  require_relative "version"
+# frozen_string_literal: true
+
+name = File.basename(__FILE__, ".gemspec")
+version = ["lib", Array.new(name.count("-")+1, "..").join("/")].find do |dir|
+  break File.foreach(File.join(__dir__, dir, "#{name.tr('-', '/')}.rb")) do |line|
+    /^\s*VERSION\s*=\s*"(.*)"/ =~ line and break $1
+  end rescue nil
 end
 
 Gem::Specification.new do |spec|
-  spec.name          = "singleton"
-  spec.version       = Singleton::VERSION
+  spec.name          = name
+  spec.version       = version
   spec.authors       = ["Yukihiro Matsumoto"]
   spec.email         = ["matz@ruby-lang.org"]
 

--- a/lib/singleton/version.rb
+++ b/lib/singleton/version.rb
@@ -1,3 +1,0 @@
-module Singleton
-  VERSION = "0.1.0"
-end

--- a/lib/timeout.rb
+++ b/lib/timeout.rb
@@ -23,6 +23,8 @@
 # Copyright:: (C) 2000  Information-technology Promotion Agency, Japan
 
 module Timeout
+  VERSION = "0.1.0"
+
   # Raised by Timeout.timeout when the block times out.
   class Error < RuntimeError
     attr_reader :thread

--- a/lib/timeout/timeout.gemspec
+++ b/lib/timeout/timeout.gemspec
@@ -1,12 +1,15 @@
-begin
-  require_relative "lib/timeout/version"
-rescue LoadError # Fallback to load version file in ruby core repository
-  require_relative "version"
+# frozen_string_literal: true
+
+name = File.basename(__FILE__, ".gemspec")
+version = ["lib", Array.new(name.count("-")+1, "..").join("/")].find do |dir|
+  break File.foreach(File.join(__dir__, dir, "#{name.tr('-', '/')}.rb")) do |line|
+    /^\s*VERSION\s*=\s*"(.*)"/ =~ line and break $1
+  end rescue nil
 end
 
 Gem::Specification.new do |spec|
-  spec.name          = "timeout"
-  spec.version       = Timeout::VERSION
+  spec.name          = name
+  spec.version       = version
   spec.authors       = ["Yukihiro Matsumoto"]
   spec.email         = ["matz@ruby-lang.org"]
 

--- a/lib/timeout/version.rb
+++ b/lib/timeout/version.rb
@@ -1,3 +1,0 @@
-module Timeout
-  VERSION = "0.1.0"
-end

--- a/lib/tracer.rb
+++ b/lib/tracer.rb
@@ -60,6 +60,7 @@
 # by Keiju ISHITSUKA(keiju@ishitsuka.com)
 #
 class Tracer
+  VERSION = "0.1.0"
 
   class << self
     # display additional debug information (defaults to false)

--- a/lib/tracer/tracer.gemspec
+++ b/lib/tracer/tracer.gemspec
@@ -1,13 +1,15 @@
-begin
-  require_relative "lib/tracer/version"
-rescue LoadError
-  # for Ruby core repository
-  require_relative "version"
+# frozen_string_literal: true
+
+name = File.basename(__FILE__, ".gemspec")
+version = ["lib", Array.new(name.count("-")+1, "..").join("/")].find do |dir|
+  break File.foreach(File.join(__dir__, dir, "#{name.tr('-', '/')}.rb")) do |line|
+    /^\s*VERSION\s*=\s*"(.*)"/ =~ line and break $1
+  end rescue nil
 end
 
 Gem::Specification.new do |spec|
-  spec.name          = "tracer"
-  spec.version       = Tracer::VERSION
+  spec.name          = name
+  spec.version       = version
   spec.authors       = ["Keiju ISHITSUKA"]
   spec.email         = ["keiju@ruby-lang.org"]
 

--- a/lib/tracer/version.rb
+++ b/lib/tracer/version.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-class Tracer
-  VERSION = "0.1.0"
-end

--- a/lib/weakref.rb
+++ b/lib/weakref.rb
@@ -17,6 +17,7 @@ require "delegate"
 #
 
 class WeakRef < Delegator
+  VERSION = "0.1.0"
 
   ##
   # RefError is raised when a referenced object has been recycled by the

--- a/lib/weakref/version.rb
+++ b/lib/weakref/version.rb
@@ -1,3 +1,0 @@
-module Weakref
-  VERSION = "0.1.0"
-end

--- a/lib/weakref/weakref.gemspec
+++ b/lib/weakref/weakref.gemspec
@@ -1,10 +1,15 @@
-lib = File.expand_path("lib", __dir__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "weakref/version"
+# frozen_string_literal: true
+
+name = File.basename(__FILE__, ".gemspec")
+version = ["lib", Array.new(name.count("-")+1, "..").join("/")].find do |dir|
+  break File.foreach(File.join(__dir__, dir, "#{name.tr('-', '/')}.rb")) do |line|
+    /^\s*VERSION\s*=\s*"(.*)"/ =~ line and break $1
+  end rescue nil
+end
 
 Gem::Specification.new do |spec|
-  spec.name          = "weakref"
-  spec.version       = Weakref::VERSION
+  spec.name          = name
+  spec.version       = version
   spec.authors = ["Yukihiro Matsumoto"]
   spec.email = ["matz@ruby-lang.org"]
 


### PR DESCRIPTION
"requiring version.rb" strategy has some issues.

- cannot work when cross-compiling
- often introduces wrong namespace
- must know the superclasses
- costs at each runtime than at build-time

etc.