### PR TITLE
mswin build - install src zlib files, remove vcpkg zlib

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -22,7 +22,12 @@ jobs:
             ${{ runner.os }}-vcpkg-download-
       - name: Install libraries with vcpkg
         run: |
-          vcpkg --triplet x64-windows install readline zlib
+          vcpkg --triplet x64-windows install readline
+      - name: zlib
+        run: |
+          $zlib = 'zlib1211.zip'
+          curl -fsSL -o $zlib --retry 10 https://zlib.net/$zlib
+          &'C:\Program Files\7-Zip\7z.exe' x -osrc/ext/zlib $zlib
       - uses: actions/cache@v2
         with:
           path: C:\Users\runneradmin\AppData\Local\Temp\chocolatey


### PR DESCRIPTION
I've been doing this for quite a while with the ruby-loco mswin build, and it's fully tested and also used in CI elsewhere.