### PR TITLE
Remove the deprecated override of Kernel#open in open-uri

### DIFF
--- a/lib/open-uri.rb
+++ b/lib/open-uri.rb
@@ -3,27 +3,6 @@ require 'uri'
 require 'stringio'
 require 'time'
 
-module Kernel
-  private
-  alias open_uri_original_open open # :nodoc:
-  class << self
-    alias open_uri_original_open open # :nodoc:
-  end
-
-  def open(name, *rest, **kw, &block) # :nodoc:
-    if (name.respond_to?(:open) && !name.respond_to?(:to_path)) ||
-       (name.respond_to?(:to_str) &&
-        %r{\A[A-Za-z][A-Za-z0-9+\-\.]*://} =~ name &&
-        (uri = URI.parse(name)).respond_to?(:open))
-      warn('calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open', uplevel: 1)
-      URI.open(name, *rest, **kw, &block)
-    else
-      open_uri_original_open(name, *rest, **kw, &block)
-    end
-  end
-  module_function :open
-end
-
 module URI
   # Allows the opening of various resources including URIs.
   #
@@ -49,9 +28,7 @@ module URI
           (uri = URI.parse(name)).respond_to?(:open)
       uri.open(*rest, &block)
     else
-      open_uri_original_open(name, *rest, &block)
-      # After Kernel#open override is removed:
-      #super
+      super
     end
   end
 end

--- a/test/open-uri/test_open-uri.rb
+++ b/test/open-uri/test_open-uri.rb
@@ -68,18 +68,6 @@ class TestOpenURI < Test::Unit::TestCase
     @proxies.each_with_index {|k, i| ENV[k] = @old_proxies[i] }
   end
 
-  def test_deprecated_kernel_open
-    with_http {|srv, dr, url|
-      srv.mount_proc("/foo200", lambda { |req, res| res.body = "foo200" } )
-      assert_warning(/calling URI.open via Kernel#open is deprecated, call URI.open directly/) {
-        open("#{url}/foo200") {|f|
-          assert_equal("200", f.status[0])
-          assert_equal("foo200", f.read)
-        }
-      }
-    }
-  end
-
   def test_200_uri_open
     with_http {|srv, dr, url|
       srv.mount_proc("/urifoo200", lambda { |req, res| res.body = "urifoo200" } )


### PR DESCRIPTION
This was deprecated in 2.7 to resolve [Misc #15893].