### PR TITLE
Apply timeout-scale to test_thr_kill.

### DIFF
--- a/test/ruby/test_thread_queue.rb
+++ b/test/ruby/test_thread_queue.rb
@@ -131,7 +131,7 @@ class TestThreadQueue < Test::Unit::TestCase
   def test_thr_kill
     bug5343 = '[ruby-core:39634]'
     Dir.mktmpdir {|d|
-      timeout = 60
+      timeout = EnvUtil.apply_timeout_scale(60)
       total_count = 250
       begin
         assert_normal_exit(<<-"_eom", bug5343, **{:timeout => timeout, :chdir=>d})


### PR DESCRIPTION
This PR is similar with https://github.com/ruby/ruby/pull/3354 .
As I faced the failures 3 times continuously on Fedora aarch64 build environment..

```
  1) Failure:
TestThreadQueue#test_thr_kill [/builddir/build/BUILD/ruby-2.7.1/test/ruby/test_thread_queue.rb:153]:
only 122/250 done in 60 seconds.
Finished tests in 880.126869s, 23.8818 tests/s, 3093.1041 assertions/s.
21019 tests, 2722324 assertions, 1 failures, 0 errors, 65 skips
ruby -v: ruby 2.7.1p83 (2020-03-31 revision a0c7c23c9c) [aarch64-linux]
make: *** [uncommon.mk:783: yes-test-all] Error 1
```

```
  1) Failure:
TestThreadQueue#test_thr_kill [/builddir/build/BUILD/ruby-2.7.1/test/ruby/test_thread_queue.rb:153]:
only 128/250 done in 60 seconds.
Finished tests in 872.795406s, 24.0778 tests/s, 3115.2983 assertions/s.
21015 tests, 2719018 assertions, 1 failures, 0 errors, 65 skips
ruby -v: ruby 2.7.1p83 (2020-03-31 revision a0c7c23c9c) [aarch64-linux]
```

```
  1) Failure:
TestThreadQueue#test_thr_kill [/builddir/build/BUILD/ruby-2.7.1/test/ruby/test_thread_queue.rb:153]:
only 240/250 done in 60 seconds.
Finished tests in 1086.912709s, 19.3281 tests/s, 2504.1514 assertions/s.
21008 tests, 2721794 assertions, 1 failures, 0 errors, 66 skips
ruby -v: ruby 2.7.1p83 (2020-03-31 revision a0c7c23c9c) [aarch64-linux]
```

