### PR TITLE
Fix method name escaping in ObjectSpace.dump

### DIFF
--- a/ext/objspace/objspace_dump.c
+++ b/ext/objspace/objspace_dump.c
@@ -310,7 +310,8 @@ dump_object(VALUE obj, struct dump_config *dc)
 	dump_append(dc, ", \"file\":\"%s\", \"line\":%lu", ainfo->path, ainfo->line);
 	if (RTEST(ainfo->mid)) {
 	    VALUE m = rb_sym2str(ainfo->mid);
-	    dump_append(dc, ", \"method\":\"%s\"", RSTRING_PTR(m));
+	    dump_append(dc, ", \"method\":");
+	    dump_append_string_value(dc, m);
 	}
 	dump_append(dc, ", \"generation\":%"PRIuSIZE, ainfo->generation);
     }

--- a/test/objspace/test_objspace.rb
+++ b/test/objspace/test_objspace.rb
@@ -357,6 +357,24 @@ class TestObjSpace < Test::Unit::TestCase
     end
   end
 
+  def test_dump_escapes_method_name
+    method_name = "foo\"bar"
+    klass = Class.new do
+      define_method(method_name) { "TEST STRING" }
+    end
+    ObjectSpace.trace_object_allocations_start
+
+    obj = klass.new.send(method_name)
+
+    dump = ObjectSpace.dump(obj)
+    assert_includes dump, '"method":"foo\"bar"'
+
+    parsed = JSON.parse(dump)
+    assert_equal "foo\"bar", parsed["method"]
+  ensure
+    ObjectSpace.trace_object_allocations_stop
+  end
+
   def test_dump_reference_addresses_match_dump_all_addresses
     assert_in_out_err(%w[-robjspace], "#{<<-"begin;"}\n#{<<-'end;'}") do |output, error|
       begin;


### PR DESCRIPTION
It's possible to define methods with any name, even if the parser doesn't support it even if it can only be used with ex. `send`.

This PR fixes an issue where invalid JSON was output from ObjectSpace.dump when a method name needed escaping.

Example invalid JSON (NB. `"method":"foo"bar"`):
```
{"address":"0x55ce37dc9c40", "type":"STRING", "class":"0x55ce378a1fd0", "embedded":true, "bytesize":11, "value":"TEST STRING", "encoding":"UTF-8", "file":"/home/jhawthorn/src/ruby/test/objspace/test_objspace.rb", "line":363, "method":"foo"bar", "generation":27, "memsize":48, "flags":{"wb_protected":true}}
```