### PR TITLE
Make Mutex per-Fiber instead of per-Thread

### DIFF
--- a/cont.c
+++ b/cont.c
@@ -850,7 +850,7 @@ NOINLINE(static VALUE cont_capture(volatile int *volatile stat));
     } while (0)
 
 rb_thread_t*
-fiber_thread_ptr(const rb_fiber_t *fiber)
+rb_fiber_threadptr(const rb_fiber_t *fiber)
 {
     return fiber->cont.saved_ec.thread_ptr;
 }

--- a/cont.c
+++ b/cont.c
@@ -849,6 +849,12 @@ NOINLINE(static VALUE cont_capture(volatile int *volatile stat));
         if (!(th)->ec->tag) rb_raise(rb_eThreadError, "not running thread"); \
     } while (0)
 
+rb_thread_t*
+fiber_thread_ptr(const rb_fiber_t *fiber)
+{
+    return fiber->cont.saved_ec.thread_ptr;
+}
+
 static VALUE
 cont_thread_value(const rb_context_t *cont)
 {

--- a/spec/ruby/core/mutex/owned_spec.rb
+++ b/spec/ruby/core/mutex/owned_spec.rb
@@ -40,4 +40,16 @@ describe "Mutex#owned?" do
       m.owned?.should be_false
     end
   end
+
+  ruby_version_is "2.8" do
+    it "is held per Fiber" do
+      m = Mutex.new
+      m.lock
+
+      Fiber.new do
+        m.locked?.should == true
+        m.owned?.should == false
+      end.resume
+    end
+  end
 end

--- a/thread_sync.c
+++ b/thread_sync.c
@@ -93,7 +93,7 @@ rb_mutex_num_waiting(rb_mutex_t *mutex)
     return n;
 }
 
-rb_thread_t* fiber_thread_ptr(const rb_fiber_t *fiber);
+rb_thread_t* rb_fiber_threadptr(const rb_fiber_t *fiber);
 
 static void
 mutex_free(void *ptr)
@@ -101,7 +101,7 @@ mutex_free(void *ptr)
     rb_mutex_t *mutex = ptr;
     if (mutex->fiber) {
 	/* rb_warn("free locked mutex"); */
-	const char *err = rb_mutex_unlock_th(mutex, fiber_thread_ptr(mutex->fiber), mutex->fiber);
+	const char *err = rb_mutex_unlock_th(mutex, rb_fiber_threadptr(mutex->fiber), mutex->fiber);
 	if (err) rb_bug("%s", err);
     }
     ruby_xfree(ptr);


### PR DESCRIPTION
* Enables Mutex to be used as synchronization between multiple Fibers of the same Thread.
* With a Fiber scheduler we can yield to another Fiber on contended Mutex#lock instead of blocking the entire thread.
* This also makes the behavior of Mutex consistent across CRuby, JRuby and TruffleRuby.
* https://bugs.ruby-lang.org/issues/16792

@ioquatix This is the first step for https://bugs.ruby-lang.org/issues/16792
IMHO we could already merge this on its own as it already has the advantage to make the behavior of Mutex consistent across CRuby, JRuby and TruffleRuby, which I think is valuable on its own.
But we can also wait until we have the integration with the Fiber scheduler.