### PR TITLE
Don't pin objects if we're just walking the heap

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -5313,7 +5313,9 @@ gc_pin(rb_objspace_t *objspace, VALUE obj)
 {
     GC_ASSERT(is_markable_object(objspace, obj));
     if (UNLIKELY(objspace->flags.during_compacting)) {
-        MARK_IN_BITMAP(GET_HEAP_PINNED_BITS(obj), obj);
+        if (LIKELY(objspace->mark_func_data == NULL)) {
+            MARK_IN_BITMAP(GET_HEAP_PINNED_BITS(obj), obj);
+        }
     }
 }
 


### PR DESCRIPTION
Walking the heap can inadvertently pin objects.  Only mark the object's
pin bit if the mark_func_data pointer is NULL (similar to the mark bits)