### PR TITLE
Remove unused struct member

### DIFF
--- a/node.h
+++ b/node.h
@@ -401,7 +401,6 @@ typedef struct rb_ast_body_struct {
 typedef struct rb_ast_struct {
     VALUE flags;
     node_buffer_t *node_buffer;
-    ID *local_lists;
     rb_ast_body_t body;
 } rb_ast_t;
 rb_ast_t *rb_ast_new(void);


### PR DESCRIPTION
I accidentally added this, and it's making the size of RVALUE be too
big. I'm sorry! orz