### PR TITLE
[Feature #16513] TracePoint#inspect returns "... file:line"

### DIFF
--- a/lib/debug.rb
+++ b/lib/debug.rb
@@ -1012,8 +1012,8 @@ EOHELP
     #
     #   (rdb:1) DEBUGGER__.thread_list_all
     #   +1 #<Thread:0x007fb2320c03f0 run> debug_me.rb.rb:3
-    #    2 #<Thread:0x007fb23218a538@debug_me.rb.rb:3 sleep>
-    #    3 #<Thread:0x007fb23218b0f0@debug_me.rb.rb:3 sleep>
+    #    2 #<Thread:0x007fb23218a538 debug_me.rb.rb:3 sleep>
+    #    3 #<Thread:0x007fb23218b0f0 debug_me.rb.rb:3 sleep>
     #   [1, 2, 3]
     #
     # Your current thread is indicated by a <b>+</b>
@@ -1022,8 +1022,8 @@ EOHELP
     #
     #   (rdb:1) th l
     #    +1 #<Thread:0x007f99328c0410 run>  debug_me.rb:3
-    #     2 #<Thread:0x007f9932938230@debug_me.rb:3 sleep> debug_me.rb:3
-    #     3 #<Thread:0x007f9932938e10@debug_me.rb:3 sleep> debug_me.rb:3
+    #     2 #<Thread:0x007f9932938230 debug_me.rb:3 sleep> debug_me.rb:3
+    #     3 #<Thread:0x007f9932938e10 debug_me.rb:3 sleep> debug_me.rb:3
     #
     # See DEBUGGER__ for more usage.
 

--- a/spec/ruby/core/tracepoint/enable_spec.rb
+++ b/spec/ruby/core/tracepoint/enable_spec.rb
@@ -123,6 +123,18 @@ describe 'TracePoint#enable' do
   end
 
   describe "when nested" do
+    before do
+      ruby_version_is ""..."2.8" do
+        # Old behavior for Ruby < 2.8
+        @path_prefix = '@'
+      end
+
+      ruby_version_is "2.8" do
+        # New behavior for Ruby >= 2.8
+        @path_prefix = ' '
+      end
+    end
+
     it "enables both TracePoints but only calls the respective callbacks" do
       called = false
       first = TracePoint.new(:line) do |tp|
@@ -146,7 +158,7 @@ describe 'TracePoint#enable' do
       end
 
       all.uniq.should == [second]
-      inspects.uniq.should == ["#<TracePoint:line #{__FILE__}:#{line}>"]
+      inspects.uniq.should == ["#<TracePoint:line#{@path_prefix}#{__FILE__}:#{line}>"]
       called.should == true
     end
   end

--- a/spec/ruby/core/tracepoint/enable_spec.rb
+++ b/spec/ruby/core/tracepoint/enable_spec.rb
@@ -146,7 +146,7 @@ describe 'TracePoint#enable' do
       end
 
       all.uniq.should == [second]
-      inspects.uniq.should == ["#<TracePoint:line@#{__FILE__}:#{line}>"]
+      inspects.uniq.should == ["#<TracePoint:line #{__FILE__}:#{line}>"]
       called.should == true
     end
   end

--- a/spec/ruby/core/tracepoint/inspect_spec.rb
+++ b/spec/ruby/core/tracepoint/inspect_spec.rb
@@ -95,8 +95,10 @@ describe 'TracePoint#inspect' do
 
   it 'returns a String showing the event and thread for :thread_begin event' do
     inspect = nil
+    thread = nil
     thread_inspection = nil
     TracePoint.new(:thread_begin) { |tp|
+      next unless Thread.current == thread
       inspect ||= tp.inspect
     }.enable do
       thread = Thread.new {}
@@ -109,8 +111,10 @@ describe 'TracePoint#inspect' do
 
   it 'returns a String showing the event and thread for :thread_end event' do
     inspect = nil
+    thread = nil
     thread_inspection = nil
     TracePoint.new(:thread_end) { |tp|
+      next unless Thread.current == thread
       inspect ||= tp.inspect
     }.enable do
       thread = Thread.new {}

--- a/spec/ruby/core/tracepoint/inspect_spec.rb
+++ b/spec/ruby/core/tracepoint/inspect_spec.rb
@@ -2,6 +2,18 @@ require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
 describe 'TracePoint#inspect' do
+  before do
+    ruby_version_is ""..."2.8" do
+      # Old behavior for Ruby < 2.8
+      @path_prefix = '@'
+    end
+
+    ruby_version_is "2.8" do
+      # New behavior for Ruby >= 2.8
+      @path_prefix = ' '
+    end
+  end
+
   it 'returns a string containing a human-readable TracePoint status' do
     TracePoint.new(:line) {}.inspect.should == '#<TracePoint:disabled>'
   end
@@ -16,7 +28,7 @@ describe 'TracePoint#inspect' do
       line = __LINE__
     end
 
-    inspect.should == "#<TracePoint:line #{__FILE__}:#{line}>"
+    inspect.should == "#<TracePoint:line#{@path_prefix}#{__FILE__}:#{line}>"
   end
 
   it 'returns a String showing the event, method, path and line for a :call event' do
@@ -31,7 +43,7 @@ describe 'TracePoint#inspect' do
       trace_point_spec_test_call
     end
 
-    inspect.should == "#<TracePoint:call `trace_point_spec_test_call' #{__FILE__}:#{line}>"
+    inspect.should == "#<TracePoint:call `trace_point_spec_test_call'#{@path_prefix}#{__FILE__}:#{line}>"
   end
 
   it 'returns a String showing the event, method, path and line for a :return event' do
@@ -49,7 +61,7 @@ describe 'TracePoint#inspect' do
       trace_point_spec_test_return
     end
 
-    inspect.should == "#<TracePoint:return `trace_point_spec_test_return' #{__FILE__}:#{line}>"
+    inspect.should == "#<TracePoint:return `trace_point_spec_test_return'#{@path_prefix}#{__FILE__}:#{line}>"
   end
 
   it 'returns a String showing the event, method, path and line for a :c_call event' do
@@ -63,7 +75,7 @@ describe 'TracePoint#inspect' do
       [0, 1].max
     end
 
-    inspect.should == "#<TracePoint:c_call `max' #{__FILE__}:#{line}>"
+    inspect.should == "#<TracePoint:c_call `max'#{@path_prefix}#{__FILE__}:#{line}>"
   end
 
   it 'returns a String showing the event, path and line for a :class event' do
@@ -78,7 +90,7 @@ describe 'TracePoint#inspect' do
       end
     end
 
-    inspect.should == "#<TracePoint:class #{__FILE__}:#{line}>"
+    inspect.should == "#<TracePoint:class#{@path_prefix}#{__FILE__}:#{line}>"
   end
 
   it 'returns a String showing the event and thread for :thread_begin event' do

--- a/spec/ruby/core/tracepoint/inspect_spec.rb
+++ b/spec/ruby/core/tracepoint/inspect_spec.rb
@@ -16,7 +16,54 @@ describe 'TracePoint#inspect' do
       line = __LINE__
     end
 
-    inspect.should == "#<TracePoint:line@#{__FILE__}:#{line}>"
+    inspect.should == "#<TracePoint:line #{__FILE__}:#{line}>"
+  end
+
+  it 'returns a String showing the event, method, path and line for a :call event' do
+    inspect = nil
+    line = nil
+    TracePoint.new(:call) { |tp|
+      next unless TracePointSpec.target_thread?
+      inspect ||= tp.inspect
+    }.enable do
+      line = __LINE__ + 1
+      def trace_point_spec_test_call; end
+      trace_point_spec_test_call
+    end
+
+    inspect.should == "#<TracePoint:call `trace_point_spec_test_call' #{__FILE__}:#{line}>"
+  end
+
+  it 'returns a String showing the event, method, path and line for a :return event' do
+    inspect = nil
+    line = nil
+    TracePoint.new(:return) { |tp|
+      next unless TracePointSpec.target_thread?
+      inspect ||= tp.inspect
+    }.enable do
+      line = __LINE__ + 4
+      def trace_point_spec_test_return
+        a = 1
+        return a
+      end
+      trace_point_spec_test_return
+    end
+
+    inspect.should == "#<TracePoint:return `trace_point_spec_test_return' #{__FILE__}:#{line}>"
+  end
+
+  it 'returns a String showing the event, method, path and line for a :c_call event' do
+    inspect = nil
+    line = nil
+    TracePoint.new(:c_call) { |tp|
+      next unless TracePointSpec.target_thread?
+      inspect ||= tp.inspect
+    }.enable do
+      line = __LINE__ + 1
+      [0, 1].max
+    end
+
+    inspect.should == "#<TracePoint:c_call `max' #{__FILE__}:#{line}>"
   end
 
   it 'returns a String showing the event, path and line for a :class event' do
@@ -31,6 +78,34 @@ describe 'TracePoint#inspect' do
       end
     end
 
-    inspect.should == "#<TracePoint:class@#{__FILE__}:#{line}>"
+    inspect.should == "#<TracePoint:class #{__FILE__}:#{line}>"
+  end
+
+  it 'returns a String showing the event and thread for :thread_begin event' do
+    inspect = nil
+    thread_inspection = nil
+    TracePoint.new(:thread_begin) { |tp|
+      inspect ||= tp.inspect
+    }.enable do
+      thread = Thread.new {}
+      thread_inspection = thread.inspect
+      thread.join
+    end
+
+    inspect.should == "#<TracePoint:thread_begin #{thread_inspection}>"
+  end
+
+  it 'returns a String showing the event and thread for :thread_end event' do
+    inspect = nil
+    thread_inspection = nil
+    TracePoint.new(:thread_end) { |tp|
+      inspect ||= tp.inspect
+    }.enable do
+      thread = Thread.new {}
+      thread_inspection = thread.inspect
+      thread.join
+    end
+
+    inspect.should == "#<TracePoint:thread_end #{thread_inspection}>"
   end
 end

--- a/test/ruby/test_settracefunc.rb
+++ b/test/ruby/test_settracefunc.rb
@@ -937,9 +937,9 @@ class TestSetTraceFunc < Test::Unit::TestCase
       when :line
         assert_match(/ in /, str)
       when :call, :c_call
-        assert_match(/call \`/, str) # #<TracePoint:c_call `inherited'@../trunk/test.rb:11>
+        assert_match(/call \`/, str) # #<TracePoint:c_call `inherited' ../trunk/test.rb:11>
       when :return, :c_return
-        assert_match(/return \`/, str) # #<TracePoint:return `m'@../trunk/test.rb:3>
+        assert_match(/return \`/, str) # #<TracePoint:return `m' ../trunk/test.rb:3>
       when /thread/
         assert_match(/\#<Thread:/, str) # #<TracePoint:thread_end of #<Thread:0x87076c0>>
       else

--- a/trace_point.rb
+++ b/trace_point.rb
@@ -183,7 +183,7 @@ class TracePoint
   #    t.enable(target: method(:m1))
   #
   #    m1
-  #    # prints #<TracePoint:line@test.rb:4 in `m1'>
+  #    # prints #<TracePoint:line test.rb:4 in `m1'>
   #    m2
   #    # prints nothing
   #

--- a/vm_trace.c
+++ b/vm_trace.c
@@ -1456,7 +1456,7 @@ tracepoint_inspect(rb_execution_context_t *ec, VALUE self)
 		VALUE sym = rb_tracearg_method_id(trace_arg);
 		if (NIL_P(sym))
                     break;
-		return rb_sprintf("#<TracePoint:%"PRIsVALUE"@%"PRIsVALUE":%d in `%"PRIsVALUE"'>",
+		return rb_sprintf("#<TracePoint:%"PRIsVALUE" %"PRIsVALUE":%d in `%"PRIsVALUE"'>",
 				  rb_tracearg_event(trace_arg),
 				  rb_tracearg_path(trace_arg),
 				  FIX2INT(rb_tracearg_lineno(trace_arg)),
@@ -1466,7 +1466,7 @@ tracepoint_inspect(rb_execution_context_t *ec, VALUE self)
 	  case RUBY_EVENT_C_CALL:
 	  case RUBY_EVENT_RETURN:
 	  case RUBY_EVENT_C_RETURN:
-	    return rb_sprintf("#<TracePoint:%"PRIsVALUE" `%"PRIsVALUE"'@%"PRIsVALUE":%d>",
+	    return rb_sprintf("#<TracePoint:%"PRIsVALUE" `%"PRIsVALUE"' %"PRIsVALUE":%d>",
 			      rb_tracearg_event(trace_arg),
 			      rb_tracearg_method_id(trace_arg),
 			      rb_tracearg_path(trace_arg),
@@ -1479,7 +1479,7 @@ tracepoint_inspect(rb_execution_context_t *ec, VALUE self)
 	  default:
             break;
 	}
-        return rb_sprintf("#<TracePoint:%"PRIsVALUE"@%"PRIsVALUE":%d>",
+        return rb_sprintf("#<TracePoint:%"PRIsVALUE" %"PRIsVALUE":%d>",
                           rb_tracearg_event(trace_arg),
                           rb_tracearg_path(trace_arg),
                           FIX2INT(rb_tracearg_lineno(trace_arg)));


### PR DESCRIPTION
This PR is to resolve ticket https://bugs.ruby-lang.org/issues/16513, so that `TracePoint#inspect` returns `path:line` without `@` prefix. This change ensures the consistency with previous changes in https://bugs.ruby-lang.org/issues/16412 and https://bugs.ruby-lang.org/issues/16412.

Before

```
#<TracePoint:line@test1.rb:12>
#<TracePoint:call `random_method'@test1.rb:12>
```

After

```
#<TracePoint:line test1.rb:12>
#<TracePoint:call `random_method' test1.rb:12>
```