### PR TITLE
Enable arm64 optimizations that exist for power/x86

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -1115,6 +1115,19 @@ tick(void)
     return val;
 }
 
+#elif defined(__aarch64__) &&  defined(__GNUC__)
+typedef unsigned long tick_t;
+#define PRItick "lu"
+
+static __inline__ tick_t
+tick(void)
+{
+    unsigned long val;
+    __asm__ __volatile__ ("mrs %0, cntvct_el0", : "=r" (val));
+    return val;
+}
+
+
 #elif defined(_WIN32) && defined(_MSC_VER)
 #include <intrin.h>
 typedef unsigned __int64 tick_t;

--- a/gc.h
+++ b/gc.h
@@ -8,6 +8,8 @@
 #define SET_MACHINE_STACK_END(p) __asm__ __volatile__ ("movl\t%%esp, %0" : "=r" (*(p)))
 #elif defined(__powerpc64__) && defined(__GNUC__)
 #define SET_MACHINE_STACK_END(p) __asm__ __volatile__ ("mr\t%0, %%r1" : "=r" (*(p)))
+#elif defined(__aarch64__) && defined(__GNUC__)
+#define SET_MACHINE_STACK_END(p) __asm__ __volatile__ ("mov\t%0, sp" : "=r" (*(p)))
 #else
 NOINLINE(void rb_gc_set_stack_end(VALUE **stack_end_p));
 #define SET_MACHINE_STACK_END(p) rb_gc_set_stack_end(p)

--- a/include/ruby/internal/config.h
+++ b/include/ruby/internal/config.h
@@ -103,6 +103,8 @@
 # define UNALIGNED_WORD_ACCESS 1
 #elif defined(__powerpc64__)
 # define UNALIGNED_WORD_ACCESS 1
+#elif defined(__aarch64__)
+# define UNALIGNED_WORD_ACCESS 1
 #elif defined(__mc68020__)
 # define UNALIGNED_WORD_ACCESS 1
 #else

--- a/regint.h
+++ b/regint.h
@@ -52,7 +52,7 @@
 #ifndef UNALIGNED_WORD_ACCESS
 # if defined(__i386) || defined(__i386__) || defined(_M_IX86) || \
      defined(__x86_64) || defined(__x86_64__) || defined(_M_AMD64) || \
-     defined(__powerpc64__) || \
+     defined(__powerpc64__) || defined(__aarch64__) || \
      defined(__mc68020__)
 #  define UNALIGNED_WORD_ACCESS 1
 # else

--- a/siphash.c
+++ b/siphash.c
@@ -30,7 +30,7 @@
 #ifndef UNALIGNED_WORD_ACCESS
 # if defined(__i386) || defined(__i386__) || defined(_M_IX86) || \
      defined(__x86_64) || defined(__x86_64__) || defined(_M_AMD64) || \
-     defined(__powerpc64__) || \
+     defined(__powerpc64__) || defined(__aarch64__) || \
      defined(__mc68020__)
 #   define UNALIGNED_WORD_ACCESS 1
 # endif

--- a/st.c
+++ b/st.c
@@ -1662,7 +1662,7 @@ st_values_check(st_table *tab, st_data_t *values, st_index_t size,
 #ifndef UNALIGNED_WORD_ACCESS
 # if defined(__i386) || defined(__i386__) || defined(_M_IX86) || \
      defined(__x86_64) || defined(__x86_64__) || defined(_M_AMD64) || \
-     defined(__powerpc64__) || \
+     defined(__powerpc64__) || defined(__aarch64__) || \
      defined(__mc68020__)
 #   define UNALIGNED_WORD_ACCESS 1
 # endif

--- a/vm_exec.c
+++ b/vm_exec.c
@@ -57,6 +57,9 @@ static void vm_insns_counter_count_insn(int insn) {}
 #elif defined(__GNUC__) && defined(__powerpc64__)
 #define DECL_SC_REG(type, r, reg) register type reg_##r __asm__("r" reg)
 
+#elif defined(__GNUC__) && defined(__aarch64__)
+#define DECL_SC_REG(type, r, reg) register type reg_##r __asm__("x" reg)
+
 #else
 #define DECL_SC_REG(type, r, reg) register type reg_##r
 #endif
@@ -91,6 +94,11 @@ vm_exec_core(rb_execution_context_t *ec, VALUE initial)
 #elif defined(__GNUC__) && defined(__powerpc64__)
     DECL_SC_REG(const VALUE *, pc, "14");
     DECL_SC_REG(rb_control_frame_t *, cfp, "15");
+#define USE_MACHINE_REGS 1
+
+#elif defined(__GNUC__) && defined(__aarch64__)
+    DECL_SC_REG(const VALUE *, pc, "19");
+    DECL_SC_REG(rb_control_frame_t *, cfp, "20");
 #define USE_MACHINE_REGS 1
 
 #else


### PR DESCRIPTION
Enable a set of optimizations that exist already for power and x86 for aarch64/arm64 systems.

Passes make check after these changes.

Running the string benchmarks the unaligned access change improves performance
by an average of 1.04x, min .96x, max 1.21x, median 1.01x

The gc optimization improves benchmark/gc/hash1 by 5%

The vm_exec changes make a massive difference on some benchmarks (e.g. 1.38x).

