### PR TITLE
Warn if calculated sp != LABEL sp on compile time

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -8965,7 +8965,11 @@ insn_data_to_s_detail(INSN *iobj)
 	      case TS_VALUE:	/* VALUE */
 		{
 		    VALUE v = OPERAND_AT(iobj, j);
-		    rb_str_concat(str, opobj_inspect(v));
+                    if (!CLASS_OF(v))
+                        rb_str_cat2(str, "<hidden>");
+                    else {
+                        rb_str_concat(str, opobj_inspect(v));
+                    }
 		    break;
 		}
 	      case TS_ID:	/* ID */
@@ -9001,7 +9005,7 @@ insn_data_to_s_detail(INSN *iobj)
 		}
 		break;
               case TS_BUILTIN:
-                rb_bug("unsupported: TS_BUILTIN");
+                rb_str_cat2(str, "<TS_BUILTIN>");
                 break;
 	      default:{
 		rb_raise(rb_eSyntaxError, "unknown operand type: %c", type);

--- a/compile.c
+++ b/compile.c
@@ -2058,7 +2058,11 @@ fix_sp_depth(rb_iseq_t *iseq, LINK_ANCHOR *const anchor)
 			}
 			if (lobj->sp == -1) {
 			    lobj->sp = sp;
-			}
+                        } else if (lobj->sp != sp) {
+                            debugs("%s:%d: sp inconsistency found but ignored (" LABEL_FORMAT " sp: %d, calculated sp: %d)\n",
+                                   RSTRING_PTR(rb_iseq_path(iseq)), line,
+                                   lobj->label_no, lobj->sp, sp);
+                        }
 		    }
 		}
 		break;
@@ -2070,6 +2074,11 @@ fix_sp_depth(rb_iseq_t *iseq, LINK_ANCHOR *const anchor)
 		    lobj->sp = sp;
 		}
 		else {
+                    if (lobj->sp != sp) {
+                        debugs("%s:%d: sp inconsistency found but ignored (" LABEL_FORMAT " sp: %d, calculated sp: %d)\n",
+                                RSTRING_PTR(rb_iseq_path(iseq)), line,
+                                lobj->label_no, lobj->sp, sp);
+                    }
 		    sp = lobj->sp;
 		}
 		break;
@@ -2187,6 +2196,11 @@ iseq_set_sequence(rb_iseq_t *iseq, LINK_ANCHOR *const anchor)
 	    {
 		LABEL *lobj = (LABEL *)list;
 		lobj->position = code_index;
+                if (lobj->sp != sp) {
+                    debugs("%s: sp inconsistency found but ignored (" LABEL_FORMAT " sp: %d, calculated sp: %d)\n",
+                           RSTRING_PTR(rb_iseq_path(iseq)),
+                           lobj->label_no, lobj->sp, sp);
+                }
 		sp = lobj->sp;
 		break;
 	    }
@@ -2337,6 +2351,11 @@ iseq_set_sequence(rb_iseq_t *iseq, LINK_ANCHOR *const anchor)
 	  case ISEQ_ELEMENT_LABEL:
 	    {
 		LABEL *lobj = (LABEL *)list;
+                if (lobj->sp != sp) {
+                    debugs("%s: sp inconsistency found but ignored (" LABEL_FORMAT " sp: %d, calculated sp: %d)\n",
+                           RSTRING_PTR(rb_iseq_path(iseq)),
+                           lobj->label_no, lobj->sp, sp);
+                }
 		sp = lobj->sp;
 		break;
 	    }


### PR DESCRIPTION
`compile.c` seems to expect that sp will be determined when reading the ISeq from the beginning.
(see `fix_sp_depth()` or `iseq_set_sequence()`)

So I would guess that Ruby should warn if the inconsistency is found between the LABEL sp and the calculated one.
https://github.com/ruby/ruby/commit/6bd88686b39a1d81413ff1fa7a720372a5f261b3 will add this warning when `CPDEBUG > 1`.
https://github.com/ruby/ruby/commit/89a581c160cab9c4a903fe4b1b30080962e2ecbf will fix `CPDEBUG > 1` output.
