### PR TITLE
Fix sp calculation

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -2270,16 +2270,14 @@ iseq_set_sequence(rb_iseq_t *iseq, LINK_ANCHOR *const anchor)
 	    }
 	  case ISEQ_ELEMENT_ADJUST:
 	    {
-		ADJUST *adjust = (ADJUST *)list;
-		if (adjust->line_no != -1) {
-		    int orig_sp = sp;
-		    sp = adjust->label ? adjust->label->sp : 0;
-		    if (orig_sp - sp > 0) {
-			if (orig_sp - sp > 1) code_index++; /* 1 operand */
-			code_index++; /* insn */
-			insn_num++;
-		    }
-		}
+                ADJUST *adjust = (ADJUST *)list;
+                int orig_sp = sp;
+                sp = adjust->label ? adjust->label->sp : 0;
+                if (adjust->line_no != -1 && orig_sp - sp > 0) {
+                    if (orig_sp - sp > 1) code_index++; /* 1 operand */
+                    code_index++; /* insn */
+                    insn_num++;
+                }
 		break;
 	    }
 	  default: break;


### PR DESCRIPTION
WARNING: It causes stack underflow on pattern matching without https://github.com/ruby/ruby/pull/3403. https://github.com/ruby/ruby/pull/3403 is needed before the PR.

In Ruby compile flow, `iseq_peephole_optimize()` is called before `iseq_set_sequence()`.
It can causes "removing dead code", but dead code may use for sp adjusting. (see https://github.com/ruby/ruby/pull/3402 https://github.com/ruby/ruby/pull/3403)
So I guess that some peephole optimizing should be placed after `iseq_set_sequence()`.