### PR TITLE
Test out fix for OpenSSL test flakiness

### DIFF
--- a/test/openssl/test_x509store.rb
+++ b/test/openssl/test_x509store.rb
@@ -66,7 +66,7 @@ class OpenSSL::TestX509Store < OpenSSL::TestCase
     ee1_cert = issue_cert(@ee1, @dsa256, 10, ee_exts, ca2_cert, @rsa1024)
     ee2_cert = issue_cert(@ee2, @dsa512, 20, ee_exts, ca2_cert, @rsa1024)
     ee3_cert = issue_cert(@ee2, @dsa512, 30,  ee_exts, ca2_cert, @rsa1024,
-                          not_before: now-100, not_after: now-1)
+                          not_before: now-100, not_after: now-50)
     ee4_cert = issue_cert(@ee2, @dsa512, 40, ee_exts, ca2_cert, @rsa1024,
                           not_before: now+1000, not_after: now+2000,)
 


### PR DESCRIPTION
`OpenSSL::TestX509Store#test_verify` has been failing intermittently on
CI about once a day:
  - http://ci.rvm.jp/results/trunk-random2@phosphorus-docker/3121244
  - http://ci.rvm.jp/results/trunk-random1@phosphorus-docker/3117661
  - http://ci.rvm.jp/results/trunk-random1@phosphorus-docker/3111684

According to the test:
 > OpenSSL uses time(2) while Time.now uses clock_gettime(CLOCK_REALTIME),
 > and there may be difference.

This difference is could be the cause for the flaky failures. Let's see
if giving the certificate more room solves the problem.

In any case, I will revert this in a week. I think changes to these
should go to https://github.com/ruby/openssl/?