### PR TITLE
string.c(rb_str_split_m): Handle /\K/ correctly

### DIFF
--- a/string.c
+++ b/string.c
@@ -8216,11 +8216,12 @@ rb_str_split_m(int argc, VALUE *argv, VALUE str)
 	struct re_registers *regs;
         VALUE match = 0;
 
-        for (; (end = rb_reg_search(spat, str, start, 0)) >= 0;
+        for (; rb_reg_search(spat, str, start, 0) >= 0;
              (match ? (rb_match_unbusy(match), rb_backref_set(match)) : (void)0)) {
             match = rb_backref_get();
             if (!result) rb_match_busy(match);
             regs = RMATCH_REGS(match);
+            end = BEG(0);
 	    if (start == end && BEG(0) == END(0)) {
 		if (!ptr) {
 		    SPLIT_STR(0, 0);

--- a/test/ruby/test_string.rb
+++ b/test/ruby/test_string.rb
@@ -1838,6 +1838,11 @@ CODE
     assert_equal("abc", s)
   end
 
+  def test_split_lookbehind
+    assert_equal([S("ab"), S("d")], S("abcd").split(/(?<=b)c/))
+    assert_equal([S("ab"), S("d")], S("abcd").split(/b\Kc/))
+  end
+
   def test_squeeze
     assert_equal(S("abc"), S("aaabbbbccc").squeeze)
     assert_equal(S("aa bb cc"), S("aa   bb      cc").squeeze(S(" ")))


### PR DESCRIPTION
Fixes https://bugs.ruby-lang.org/issues/17113

Use BEG(0) instead of the result of rb_reg_search to handle the cases when the separator Regexp contains /\K/ (lookbehind) operator.