### PR TITLE
raise ArgumentError in Enumerator#new in no given blocks [Feature #17116]

### DIFF
--- a/enumerator.c
+++ b/enumerator.c
@@ -422,12 +422,11 @@ enumerator_init(VALUE enum_obj, VALUE obj, VALUE meth, int argc, const VALUE *ar
 /*
  * call-seq:
  *   Enumerator.new(size = nil) { |yielder| ... }
- *   Enumerator.new(obj, method = :each, *args)
  *
  * Creates a new Enumerator object, which can be used as an
  * Enumerable.
  *
- * In the first form, iteration is defined by the given block, in
+ * Iteration is defined by the given block, in
  * which a "yielder" object, given as block parameter, can be used to
  * yield a value by calling the +yield+ method (aliased as <code><<</code>):
  *
@@ -444,12 +443,6 @@ enumerator_init(VALUE enum_obj, VALUE obj, VALUE meth, int argc, const VALUE *ar
  * The optional parameter can be used to specify how to calculate the size
  * in a lazy fashion (see Enumerator#size). It can either be a value or
  * a callable object.
- *
- * In the deprecated second form, a generated Enumerator iterates over the
- * given object using the given method with the given arguments passed.
- *
- * Use of this form is discouraged.  Use Object#enum_for or Object#to_enum
- * instead.
  *
  *   e = Enumerator.new(ObjectSpace, :each_object)
  *       #-> ObjectSpace.enum_for(:each_object)
@@ -479,14 +472,7 @@ enumerator_initialize(int argc, VALUE *argv, VALUE obj)
         }
     }
     else {
-	rb_check_arity(argc, 1, UNLIMITED_ARGUMENTS);
-	rb_warn_deprecated("Enumerator.new without a block", "Object#to_enum");
-	recv = *argv++;
-	if (--argc) {
-	    meth = *argv++;
-	    --argc;
-	}
-        kw_splat = rb_keyword_given_p();
+        rb_raise(rb_eArgError, "not given block argument");
     }
 
     return enumerator_init(obj, recv, meth, argc, argv, 0, size, kw_splat);

--- a/spec/ruby/core/enumerator/initialize_spec.rb
+++ b/spec/ruby/core/enumerator/initialize_spec.rb
@@ -11,10 +11,6 @@ describe "Enumerator#initialize" do
     Enumerator.should have_private_instance_method(:initialize, false)
   end
 
-  it "returns self when given an object" do
-    @uninitialized.send(:initialize, Object.new).should equal(@uninitialized)
-  end
-
   it "returns self when given a block" do
     @uninitialized.send(:initialize) {}.should equal(@uninitialized)
   end

--- a/spec/ruby/core/enumerator/new_spec.rb
+++ b/spec/ruby/core/enumerator/new_spec.rb
@@ -1,44 +1,6 @@
 require_relative '../../spec_helper'
 
 describe "Enumerator.new" do
-  it "creates a new custom enumerator with the given object, iterator and arguments" do
-    enum = Enumerator.new(1, :upto, 3)
-    enum.should be_an_instance_of(Enumerator)
-  end
-
-  it "creates a new custom enumerator that responds to #each" do
-    enum = Enumerator.new(1, :upto, 3)
-    enum.respond_to?(:each).should == true
-  end
-
-  it "creates a new custom enumerator that runs correctly" do
-    Enumerator.new(1, :upto, 3).map{|x|x}.should == [1,2,3]
-  end
-
-  it "aliases the second argument to :each" do
-    Enumerator.new(1..2).to_a.should == Enumerator.new(1..2, :each).to_a
-  end
-
-  it "doesn't check for the presence of the iterator method" do
-    Enumerator.new(nil).should be_an_instance_of(Enumerator)
-  end
-
-  it "uses the latest define iterator method" do
-    class StrangeEach
-      def each
-        yield :foo
-      end
-    end
-    enum = Enumerator.new(StrangeEach.new)
-    enum.to_a.should == [:foo]
-    class StrangeEach
-      def each
-        yield :bar
-      end
-    end
-    enum.to_a.should == [:bar]
-  end
-
   context "when passed a block" do
     it "defines iteration with block, yielder argument and calling << method" do
       enum = Enumerator.new do |yielder|

--- a/test/ruby/test_enumerator.rb
+++ b/test/ruby/test_enumerator.rb
@@ -69,22 +69,12 @@ class TestEnumerator < Test::Unit::TestCase
 
   def test_initialize
     assert_equal([1, 2, 3], @obj.to_enum(:foo, 1, 2, 3).to_a)
-    _, err = capture_io do
-      assert_equal([1, 2, 3], Enumerator.new(@obj, :foo, 1, 2, 3).to_a)
-    end
-    assert_match 'Enumerator.new without a block is deprecated', err
     assert_equal([1, 2, 3], Enumerator.new { |y| i = 0; loop { y << (i += 1) } }.take(3))
     assert_raise(ArgumentError) { Enumerator.new }
+    assert_raise(ArgumentError) { Enumerator.new(@obj) }
 
     enum = @obj.to_enum
     assert_raise(NoMethodError) { enum.each {} }
-    enum.freeze
-    assert_raise(FrozenError) {
-      capture_io do
-        # warning: Enumerator.new without a block is deprecated; use Object#to_enum
-        enum.__send__(:initialize, @obj, :foo)
-      end
-    }
   end
 
   def test_initialize_copy


### PR DESCRIPTION
Not allow this code, and raise `ArgumentError`.

```ruby
obj = Object.new
Enumerator.new(obj)
```

ref: [Feature #17116 raise ArgumentError in Enumerator#new in no given blocks](https://bugs.ruby-lang.org/issues/17116)