### PR TITLE
Remove write barrier exemption for T_ICLASS, take 2

### DIFF
--- a/class.c
+++ b/class.c
@@ -911,8 +911,7 @@ rb_include_class_new(VALUE module, VALUE super)
 {
     VALUE klass = class_alloc(T_ICLASS, rb_cClass);
 
-    RCLASS_M_TBL(OBJ_WB_UNPROTECT(klass)) =
-      RCLASS_M_TBL(OBJ_WB_UNPROTECT(module)); /* TODO: unprotected? */
+    RCLASS_M_TBL(klass) = RCLASS_M_TBL(module);
 
     RCLASS_SET_ORIGIN(klass, klass);
     if (BUILTIN_TYPE(module) == T_ICLASS) {
@@ -1098,13 +1097,12 @@ move_refined_method(ID key, VALUE value, void *data)
 	    const rb_method_entry_t *orig_me = me->def->body.refined.orig_me, *new_me;
 	    RB_OBJ_WRITE(me, &me->def->body.refined.orig_me, NULL);
 	    new_me = rb_method_entry_clone(me);
-	    rb_id_table_insert(tbl, key, (VALUE)new_me);
-	    RB_OBJ_WRITTEN(klass, Qundef, new_me);
+            rb_method_table_insert(klass, tbl, key, new_me);
 	    rb_method_entry_copy(me, orig_me);
 	    return ID_TABLE_CONTINUE;
 	}
 	else {
-	    rb_id_table_insert(tbl, key, (VALUE)me);
+            rb_method_table_insert(klass, tbl, key, me);
 	    return ID_TABLE_DELETE;
 	}
     }
@@ -1119,7 +1117,6 @@ ensure_origin(VALUE klass)
     VALUE origin = RCLASS_ORIGIN(klass);
     if (origin == klass) {
 	origin = class_alloc(T_ICLASS, klass);
-	OBJ_WB_UNPROTECT(origin); /* TODO: conservative shading. Need more survey. */
 	RCLASS_SET_SUPER(origin, RCLASS_SUPER(klass));
 	RCLASS_SET_SUPER(klass, origin);
 	RCLASS_SET_ORIGIN(klass, origin);

--- a/eval.c
+++ b/eval.c
@@ -1420,8 +1420,7 @@ rb_using_refinement(rb_cref_t *cref, VALUE klass, VALUE module)
     c = iclass = rb_include_class_new(module, superclass);
     RB_OBJ_WRITE(c, &RCLASS_REFINED_CLASS(c), klass);
 
-    RCLASS_M_TBL(OBJ_WB_UNPROTECT(c)) =
-      RCLASS_M_TBL(OBJ_WB_UNPROTECT(module)); /* TODO: check unprotecting */
+    RCLASS_M_TBL(c) = RCLASS_M_TBL(module);
 
     module = RCLASS_SUPER(module);
     while (module && module != klass) {

--- a/gc.c
+++ b/gc.c
@@ -2854,8 +2854,7 @@ obj_free(rb_objspace_t *objspace, VALUE obj)
 	break;
       case T_ICLASS:
 	/* Basically , T_ICLASS shares table with the module */
-        if (FL_TEST(obj, RICLASS_IS_ORIGIN) &&
-                !FL_TEST(obj, RICLASS_ORIGIN_SHARED_MTBL)) {
+        if (RICLASS_OWNS_M_TBL_P(obj)) {
             /* Method table is not shared for origin iclasses of classes */
             rb_id_table_free(RCLASS_M_TBL(obj));
         }
@@ -3974,8 +3973,7 @@ obj_memsize_of(VALUE obj, int use_all_types)
 	}
 	break;
       case T_ICLASS:
-        if (FL_TEST(obj, RICLASS_IS_ORIGIN) &&
-                !FL_TEST(obj, RICLASS_ORIGIN_SHARED_MTBL)) {
+        if (RICLASS_OWNS_M_TBL_P(obj)) {
 	    if (RCLASS_M_TBL(obj)) {
 		size += rb_id_table_memsize(RCLASS_M_TBL(obj));
 	    }
@@ -5504,8 +5502,7 @@ gc_mark_children(rb_objspace_t *objspace, VALUE obj)
 	break;
 
       case T_ICLASS:
-        if (FL_TEST(obj, RICLASS_IS_ORIGIN) &&
-                !FL_TEST(obj, RICLASS_ORIGIN_SHARED_MTBL)) {
+        if (RICLASS_OWNS_M_TBL_P(obj)) {
 	    mark_m_tbl(objspace, RCLASS_M_TBL(obj));
 	}
         if (RCLASS_SUPER(obj)) {

--- a/internal/class.h
+++ b/internal/class.h
@@ -144,6 +144,12 @@ RICLASS_SET_ORIGIN_SHARED_MTBL(VALUE iclass)
     FL_SET(iclass, RICLASS_ORIGIN_SHARED_MTBL);
 }
 
+static inline bool
+RICLASS_OWNS_M_TBL_P(VALUE iclass)
+{
+    return FL_TEST_RAW(iclass, RICLASS_IS_ORIGIN | RICLASS_ORIGIN_SHARED_MTBL) == RICLASS_IS_ORIGIN;
+}
+
 static inline void
 RCLASS_SET_INCLUDER(VALUE iclass, VALUE klass)
 {

--- a/method.h
+++ b/method.h
@@ -188,6 +188,8 @@ struct rb_method_definition_struct {
     uintptr_t method_serial;
 };
 
+struct rb_id_table;
+
 typedef struct rb_method_definition_struct rb_method_definition_t;
 STATIC_ASSERT(sizeof_method_def, offsetof(rb_method_definition_t, body)==8);
 
@@ -229,6 +231,8 @@ void rb_free_method_entry(const rb_method_entry_t *me);
 const rb_method_entry_t *rb_method_entry_clone(const rb_method_entry_t *me);
 const rb_callable_method_entry_t *rb_method_entry_complement_defined_class(const rb_method_entry_t *src_me, ID called_id, VALUE defined_class);
 void rb_method_entry_copy(rb_method_entry_t *dst, const rb_method_entry_t *src);
+
+void rb_method_table_insert(VALUE klass, struct rb_id_table *table, ID method_id, const rb_method_entry_t *me);
 
 void rb_scope_visibility_set(rb_method_visibility_t);
 


### PR DESCRIPTION
Before this commit, iclasses were "shady", or not protected by write
barriers. Because of that, the GC needs to spend more time marking these
objects than otherwise.

Applications that make heavy use of modules should see reduction in GC
time as they have a significant number of live iclasses on the heap.

 - Put logic for iclass method table ownership into a function
 - Remove calls to WB_UNPROTECT and insert write barriers for iclasses

This commit relies on the following invariant: for any non origin iclass `I`,
`RCLASS_M_TBL(I) == RCLASS_M_TBL(RBasic(I)->klass)`. This invariant
did not hold prior to 98286e9 for classes and modules that have prepended
modules.

[[Feature #16984]](https://bugs.ruby-lang.org/issues/16984)

---

This is a redo of #3238. It's much simpler and it
doesn't introduce new garbage collected objects. I realized that despite
saving a pointer to some other object's method table, iclasses don't
mark the method tables. So, for each method table, there is an unique
object that's responsible for marking it. Since write barriers are only
needed for the object that is marking the newly written value (correct me
if I'm wrong here), having an unique object that marks the tables
makes things straight forward.

The numbers from v1 of this patch was a bit inflated because we were
[allocating an excessive amount of iclasses](https://github.com/ruby/ruby/commit/37e6c83609ac9d4c30ca4660ee16701e53cf82a3).
I measured again and an app that has an approximately 250MiB heap
saw a 22% reduction in minor GC time.
 
Credits to @tenderlove for motivating this change.