### PR TITLE
rb_reg_start_with_p: Properly check the match with \K is at the beginning

### DIFF
--- a/re.c
+++ b/re.c
@@ -1674,13 +1674,17 @@ rb_reg_start_with_p(VALUE re, VALUE str)
 	if (regs == &regi)
 	    onig_region_free(regs, 0);
 	if (result == ONIG_MISMATCH) {
-	    rb_backref_set(Qnil);
-	    return false;
+            goto mismatch;
 	}
 	else {
 	    onig_error_code_to_str((UChar*)err, (int)result);
 	    rb_reg_raise(RREGEXP_SRC_PTR(re), RREGEXP_SRC_LEN(re), err, re);
 	}
+    }
+
+    /* In case re contains \K */
+    if (BEG(0) != 0) {
+        goto mismatch;
     }
 
     if (NIL_P(match)) {
@@ -1697,6 +1701,10 @@ rb_reg_start_with_p(VALUE re, VALUE str)
     rb_backref_set(match);
 
     return true;
+
+  mismatch:
+    rb_backref_set(Qnil);
+    return false;
 }
 
 VALUE

--- a/test/ruby/test_string.rb
+++ b/test/ruby/test_string.rb
@@ -1884,6 +1884,9 @@ CODE
     assert_equal("hel", $&)
     assert_equal(false, "hello".start_with?(/el/))
     assert_nil($&)
+
+    assert_equal(false, "hello".start_with?(/h\Ke/))
+    assert_nil($&)
   end
 
   def test_strip


### PR DESCRIPTION
When the Regexp given to String#start_with? contains /\K/ (lookbehind) operator, the function reports a wrong result when the lookbehind portion of the pattern matches at the beginning of self.

```
"hello".start_with?(/h\Ke/)  # => true (unexpected)
```

This patch corrects this issue by checking that the matched substring actually starts at offset 0.

Fixes https://bugs.ruby-lang.org/issues/17120