### PR TITLE
Fix links to Dig Methods document

### DIFF
--- a/array.c
+++ b/array.c
@@ -8645,7 +8645,7 @@ rb_ary_one_p(int argc, VALUE *argv, VALUE ary)
  *  Finds and returns the object in nested objects
  *  that is specified by +index+ and +identifiers+.
  *  The nested objects may be instances of various classes.
- *  See {Dig Methods}[dig_methods_rdoc.html].
+ *  See {Dig Methods}[rdoc-ref:doc/dig_methods.rdoc].
  *
  *  Examples:
  *    a = [:foo, [:bar, :baz, [:bat, :bam]]]

--- a/array.c
+++ b/array.c
@@ -8645,7 +8645,7 @@ rb_ary_one_p(int argc, VALUE *argv, VALUE ary)
  *  Finds and returns the object in nested objects
  *  that is specified by +index+ and +identifiers+.
  *  The nested objects may be instances of various classes.
- *  See {Dig Methods}[doc/dig_methods_rdoc.html].
+ *  See {Dig Methods}[dig_methods_rdoc.html].
  *
  *  Examples:
  *    a = [:foo, [:bar, :baz, [:bat, :bam]]]

--- a/hash.c
+++ b/hash.c
@@ -5085,7 +5085,7 @@ rb_hash_any_p(int argc, VALUE *argv, VALUE hash)
  *  Finds and returns the object in nested objects
  *  that is specified by +key+ and +identifiers+.
  *  The nested objects may be instances of various classes.
- *  See {Dig Methods}[dig_methods_rdoc.html].
+ *  See {Dig Methods}[rdoc-ref:doc/dig_methods.rdoc].
  *
  *  Examples:
  *    h = {foo: {bar: {baz: 2}}}

--- a/hash.c
+++ b/hash.c
@@ -5085,7 +5085,7 @@ rb_hash_any_p(int argc, VALUE *argv, VALUE hash)
  *  Finds and returns the object in nested objects
  *  that is specified by +key+ and +identifiers+.
  *  The nested objects may be instances of various classes.
- *  See {Dig Methods}[doc/dig_methods_rdoc.html].
+ *  See {Dig Methods}[dig_methods_rdoc.html].
  *
  *  Examples:
  *    h = {foo: {bar: {baz: 2}}}

--- a/lib/ostruct.rb
+++ b/lib/ostruct.rb
@@ -261,7 +261,7 @@ class OpenStruct
   # Finds and returns the object in nested objects
   # that is specified by +name+ and +identifiers+.
   # The nested objects may be instances of various classes.
-  # See {Dig Methods}[doc/dig_methods_rdoc.html].
+  # See {Dig Methods}[dig_methods_rdoc.html].
   #
   # Examples:
   #   require "ostruct"

--- a/lib/ostruct.rb
+++ b/lib/ostruct.rb
@@ -261,7 +261,7 @@ class OpenStruct
   # Finds and returns the object in nested objects
   # that is specified by +name+ and +identifiers+.
   # The nested objects may be instances of various classes.
-  # See {Dig Methods}[dig_methods_rdoc.html].
+  # See {Dig Methods}[rdoc-ref:doc/dig_methods.rdoc].
   #
   # Examples:
   #   require "ostruct"

--- a/struct.c
+++ b/struct.c
@@ -1333,7 +1333,7 @@ rb_struct_size(VALUE s)
  * Finds and returns the object in nested objects
  * that is specified by +key+ and +identifiers+.
  * The nested objects may be instances of various classes.
- * See {Dig Methods}[dig_methods_rdoc.html].
+ * See {Dig Methods}[rdoc-ref:doc/dig_methods.rdoc].
  *
  * Examples:
  *   Foo = Struct.new(:a)

--- a/struct.c
+++ b/struct.c
@@ -1333,7 +1333,7 @@ rb_struct_size(VALUE s)
  * Finds and returns the object in nested objects
  * that is specified by +key+ and +identifiers+.
  * The nested objects may be instances of various classes.
- * See {Dig Methods}[doc/dig_methods_rdoc.html].
+ * See {Dig Methods}[dig_methods_rdoc.html].
  *
  * Examples:
  *   Foo = Struct.new(:a)


### PR DESCRIPTION
The .rdoc files in ruby/doc, when processed into .html files, do not  appear in a doc/ subdirectory as I had expected.

I had expected this:
- https://docs.ruby-lang.org/en/master/doc/dig_methods_rdoc.html

But got this:
- https://docs.ruby-lang.org/en/master/dig_methods_rdoc.html

So this PR fixes that.

A question:  When I run 'rdoc --op rdoc', there's a doc/ output directory that has all the output from doc/*.rdoc.  That's why I didn't know the links were broken.  Is there a way to run rdoc so that the output is the same as on docs.ruby-lang.org?

And, btw:  Yes, this also means that all the *-convertible links are broken.  About which more later.
