### PR TITLE
Expose ec -> backtrace (internal) and use it to implement fiber backtrace

### DIFF
--- a/cont.c
+++ b/cont.c
@@ -2281,6 +2281,18 @@ rb_fiber_raise(int argc, VALUE *argv, VALUE fiber)
     return rb_fiber_resume_kw(fiber, -1, &exc, RB_NO_KEYWORDS);
 }
 
+static VALUE
+rb_fiber_backtrace(int argc, VALUE *argv, VALUE fiber)
+{
+    return rb_vm_backtrace(argc, argv, &fiber_ptr(fiber)->cont.saved_ec);
+}
+
+static VALUE
+rb_fiber_backtrace_locations(int argc, VALUE *argv, VALUE fiber)
+{
+    return rb_vm_backtrace_locations(argc, argv, &fiber_ptr(fiber)->cont.saved_ec);
+}
+
 /*
  *  call-seq:
  *     fiber.transfer(args, ...) -> obj
@@ -2533,6 +2545,8 @@ Init_Cont(void)
     rb_define_method(rb_cFiber, "blocking?", rb_fiber_blocking_p, 0);
     rb_define_method(rb_cFiber, "resume", rb_fiber_m_resume, -1);
     rb_define_method(rb_cFiber, "raise", rb_fiber_raise, -1);
+    rb_define_method(rb_cFiber, "backtrace", rb_fiber_backtrace, -1);
+    rb_define_method(rb_cFiber, "backtrace_locations", rb_fiber_backtrace_locations, -1);
     rb_define_method(rb_cFiber, "to_s", fiber_to_s, 0);
     rb_define_alias(rb_cFiber, "inspect", "to_s");
 

--- a/internal/vm.h
+++ b/internal/vm.h
@@ -107,6 +107,8 @@ void rb_print_backtrace(void);
 /* vm_backtrace.c */
 VALUE rb_vm_thread_backtrace(int argc, const VALUE *argv, VALUE thval);
 VALUE rb_vm_thread_backtrace_locations(int argc, const VALUE *argv, VALUE thval);
+VALUE rb_vm_backtrace(int argc, const VALUE * argv, struct rb_execution_context_struct * ec);
+VALUE rb_vm_backtrace_locations(int argc, const VALUE * argv, struct rb_execution_context_struct * ec);
 VALUE rb_make_backtrace(void);
 void rb_backtrace_print_as_bugreport(void);
 int rb_backtrace_p(VALUE obj);

--- a/test/fiber/test_backtrace.rb
+++ b/test/fiber/test_backtrace.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require 'test/unit'
+require 'fiber'
+
+class TestFiberBacktrace < Test::Unit::TestCase
+  def test_backtrace
+    backtrace = Fiber.current.backtrace
+    assert_kind_of Array, backtrace
+    assert_match /test_backtrace/, backtrace[0]
+  end
+
+  def test_backtrace_locations
+    backtrace = Fiber.current.backtrace_locations
+    assert_kind_of Array, backtrace
+    assert_match /test_backtrace_locations/, backtrace[1].label
+  end
+
+  def test_local_backtrace
+    backtrace = Fiber.current.backtrace(2)
+    assert_equal backtrace, caller
+  end
+end

--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -996,6 +996,16 @@ rb_vm_thread_backtrace_locations(int argc, const VALUE *argv, VALUE thval)
     return thread_backtrace_to_ary(argc, argv, thval, 0);
 }
 
+VALUE rb_vm_backtrace(int argc, const VALUE * argv, struct rb_execution_context_struct * ec)
+{
+    return ec_backtrace_to_ary(ec, argc, argv, 0, 0, 1);
+}
+
+VALUE rb_vm_backtrace_locations(int argc, const VALUE * argv, struct rb_execution_context_struct * ec)
+{
+    return ec_backtrace_to_ary(ec, argc, argv, 0, 0, 0);
+}
+
 /*
  *  call-seq:
  *     caller(start=1, length=nil)  -> array or nil


### PR DESCRIPTION
See <https://bugs.ruby-lang.org/issues/16815> for more details.