### PR TITLE
Delete or warn deprecated (rev.3)

### DIFF
--- a/dir.c
+++ b/dir.c
@@ -3345,7 +3345,7 @@ rb_file_directory_p(void)
 static VALUE
 rb_dir_exists_p(VALUE obj, VALUE fname)
 {
-    rb_warn_deprecated("Dir.exists?", "Dir.exist?");
+    rb_warn_deprecated_to_remove_use_this_one_instead("Dir.exists?", "3.2", "Dir.exist?");
     return rb_file_directory_p(obj, fname);
 }
 

--- a/error.c
+++ b/error.c
@@ -2652,7 +2652,7 @@ Init_Exception(void)
     rb_define_method(rb_eNameError, "name", name_err_name, 0);
     rb_define_method(rb_eNameError, "receiver", name_err_receiver, 0);
     rb_define_method(rb_eNameError, "local_variables", name_err_local_variables, 0);
-    rb_cNameErrorMesg = rb_define_class_under(rb_eNameError, "message", rb_cData);
+    rb_cNameErrorMesg = rb_define_class_under(rb_eNameError, "message", rb_cObject);
     rb_define_method(rb_cNameErrorMesg, "==", name_err_mesg_equal, 1);
     rb_define_method(rb_cNameErrorMesg, "to_str", name_err_mesg_to_str, 0);
     rb_define_method(rb_cNameErrorMesg, "_dump", name_err_mesg_dump, 1);

--- a/error.c
+++ b/error.c
@@ -392,7 +392,7 @@ warn_deprecated_i(
     rb_str_set_len(mesg, RSTRING_LEN(mesg) - 1);
     rb_str_cat_cstr(mesg, " is deprecated");
     if (removal) {
-        rb_str_catf(mesg, ", and will be removed in Ruby %s", removal);
+        rb_str_cat_cstr(mesg, ", and is planned for removal");
     }
     if (suggest) {
         rb_str_catf(mesg, "; use %s instead", suggest);

--- a/ext/stringio/stringio.c
+++ b/ext/stringio/stringio.c
@@ -833,18 +833,6 @@ strio_each_byte(VALUE self)
 }
 
 /*
- *  This is a deprecated alias for #each_byte.
- */
-static VALUE
-strio_bytes(VALUE self)
-{
-    rb_warn("StringIO#bytes is deprecated; use #each_byte instead");
-    if (!rb_block_given_p())
-	return rb_enumeratorize(self, ID2SYM(rb_intern("each_byte")), 0, 0);
-    return strio_each_byte(self);
-}
-
-/*
  * call-seq:
  *   strio.getc   -> string or nil
  *
@@ -1058,18 +1046,6 @@ strio_each_char(VALUE self)
 }
 
 /*
- *  This is a deprecated alias for #each_char.
- */
-static VALUE
-strio_chars(VALUE self)
-{
-    rb_warn("StringIO#chars is deprecated; use #each_char instead");
-    if (!rb_block_given_p())
-	return rb_enumeratorize(self, ID2SYM(rb_intern("each_char")), 0, 0);
-    return strio_each_char(self);
-}
-
-/*
  * call-seq:
  *   strio.each_codepoint {|c| block }  -> strio
  *   strio.each_codepoint               -> anEnumerator
@@ -1099,18 +1075,6 @@ strio_each_codepoint(VALUE self)
 	ptr->pos += n;
     }
     return self;
-}
-
-/*
- *  This is a deprecated alias for #each_codepoint.
- */
-static VALUE
-strio_codepoints(VALUE self)
-{
-    rb_warn("StringIO#codepoints is deprecated; use #each_codepoint instead");
-    if (!rb_block_given_p())
-	return rb_enumeratorize(self, ID2SYM(rb_intern("each_codepoint")), 0, 0);
-    return strio_each_codepoint(self);
 }
 
 /* Boyer-Moore search: copied from regex.c */
@@ -1361,18 +1325,6 @@ strio_each(int argc, VALUE *argv, VALUE self)
 	rb_yield(line);
     }
     return self;
-}
-
-/*
- *  This is a deprecated alias for #each_line.
- */
-static VALUE
-strio_lines(int argc, VALUE *argv, VALUE self)
-{
-    rb_warn("StringIO#lines is deprecated; use #each_line instead");
-    if (!rb_block_given_p())
-	return rb_enumeratorize(self, ID2SYM(rb_intern("each_line")), argc, argv);
-    return strio_each(argc, argv, self);
 }
 
 /*
@@ -1843,13 +1795,9 @@ Init_stringio(void)
 
     rb_define_method(StringIO, "each", strio_each, -1);
     rb_define_method(StringIO, "each_line", strio_each, -1);
-    rb_define_method(StringIO, "lines", strio_lines, -1);
     rb_define_method(StringIO, "each_byte", strio_each_byte, 0);
-    rb_define_method(StringIO, "bytes", strio_bytes, 0);
     rb_define_method(StringIO, "each_char", strio_each_char, 0);
-    rb_define_method(StringIO, "chars", strio_chars, 0);
     rb_define_method(StringIO, "each_codepoint", strio_each_codepoint, 0);
-    rb_define_method(StringIO, "codepoints", strio_codepoints, 0);
     rb_define_method(StringIO, "getc", strio_getc, 0);
     rb_define_method(StringIO, "ungetc", strio_ungetc, 1);
     rb_define_method(StringIO, "ungetbyte", strio_ungetbyte, 1);

--- a/ext/zlib/zlib.c
+++ b/ext/zlib/zlib.c
@@ -3950,20 +3950,6 @@ rb_gzreader_each_byte(VALUE obj)
 }
 
 /*
- * Document-method: Zlib::GzipReader#bytes
- *
- *  This is a deprecated alias for <code>each_byte</code>.
- */
-static VALUE
-rb_gzreader_bytes(VALUE obj)
-{
-    rb_warn("Zlib::GzipReader#bytes is deprecated; use #each_byte instead");
-    if (!rb_block_given_p())
-	return rb_enumeratorize(obj, ID2SYM(rb_intern("each_byte")), 0, 0);
-    return rb_gzreader_each_byte(obj);
-}
-
-/*
  * Document-method: Zlib::GzipReader#ungetc
  *
  * See Zlib::GzipReader documentation for a description.
@@ -4233,20 +4219,6 @@ rb_gzreader_each(int argc, VALUE *argv, VALUE obj)
 	rb_yield(str);
     }
     return obj;
-}
-
-/*
- * Document-method: Zlib::GzipReader#lines
- *
- *  This is a deprecated alias for <code>each_line</code>.
- */
-static VALUE
-rb_gzreader_lines(int argc, VALUE *argv, VALUE obj)
-{
-    rb_warn("Zlib::GzipReader#lines is deprecated; use #each_line instead");
-    if (!rb_block_given_p())
-	return rb_enumeratorize(obj, ID2SYM(rb_intern("each_line")), argc, argv);
-    return rb_gzreader_each(argc, argv, obj);
 }
 
 /*
@@ -4708,14 +4680,12 @@ Init_zlib(void)
     rb_define_method(cGzipReader, "readbyte", rb_gzreader_readbyte, 0);
     rb_define_method(cGzipReader, "each_byte", rb_gzreader_each_byte, 0);
     rb_define_method(cGzipReader, "each_char", rb_gzreader_each_char, 0);
-    rb_define_method(cGzipReader, "bytes", rb_gzreader_bytes, 0);
     rb_define_method(cGzipReader, "ungetc", rb_gzreader_ungetc, 1);
     rb_define_method(cGzipReader, "ungetbyte", rb_gzreader_ungetbyte, 1);
     rb_define_method(cGzipReader, "gets", rb_gzreader_gets, -1);
     rb_define_method(cGzipReader, "readline", rb_gzreader_readline, -1);
     rb_define_method(cGzipReader, "each", rb_gzreader_each, -1);
     rb_define_method(cGzipReader, "each_line", rb_gzreader_each, -1);
-    rb_define_method(cGzipReader, "lines", rb_gzreader_lines, -1);
     rb_define_method(cGzipReader, "readlines", rb_gzreader_readlines, -1);
     rb_define_method(cGzipReader, "external_encoding", rb_gzreader_external_encoding, 0);
 

--- a/file.c
+++ b/file.c
@@ -1800,7 +1800,7 @@ rb_file_exists_p(VALUE obj, VALUE fname)
 	      RTEST(rb_class_inherited_p(obj, rb_cFile)))) {
 	s = "File.exist?";
     }
-    rb_warn_deprecated("%.*ss?", s, (int)(strlen(s)-1), s);
+    rb_warn_deprecated_to_remove_use_this_one_instead("%.*ss?", "3.2", s, (int)(strlen(s)-1), s);
     return rb_file_exist_p(obj, fname);
 }
 

--- a/hash.c
+++ b/hash.c
@@ -6784,19 +6784,6 @@ env_key(VALUE dmy, VALUE value)
     return Qnil;
 }
 
-/*
- * call-seq:
- *   ENV.index(value) -> name
- *
- * Deprecated method that is equivalent to ENV.key.
- */
-static VALUE
-env_index(VALUE dmy, VALUE value)
-{
-    rb_warn_deprecated("ENV.index", "ENV.key");
-    return env_key(dmy, value);
-}
-
 static VALUE
 env_to_hash(void)
 {
@@ -7703,7 +7690,6 @@ Init_Hash(void)
     rb_define_singleton_method(envtbl, "to_a", env_to_a, 0);
     rb_define_singleton_method(envtbl, "to_s", env_to_s, 0);
     rb_define_singleton_method(envtbl, "key", env_key, 1);
-    rb_define_singleton_method(envtbl, "index", env_index, 1);
     rb_define_singleton_method(envtbl, "size", env_size, 0);
     rb_define_singleton_method(envtbl, "length", env_size, 0);
     rb_define_singleton_method(envtbl, "empty?", env_empty_p, 0);

--- a/hash.c
+++ b/hash.c
@@ -2446,14 +2446,6 @@ rb_hash_key(VALUE hash, VALUE value)
     return args[1];
 }
 
-/* :nodoc: */
-static VALUE
-rb_hash_index(VALUE hash, VALUE value)
-{
-    rb_warn_deprecated("Hash#index", "Hash#key");
-    return rb_hash_key(hash, value);
-}
-
 int
 rb_hash_stlike_delete(VALUE hash, st_data_t *pkey, st_data_t *pval)
 {
@@ -7526,7 +7518,6 @@ Init_Hash(void)
     rb_define_method(rb_cHash, "default_proc", rb_hash_default_proc, 0);
     rb_define_method(rb_cHash, "default_proc=", rb_hash_set_default_proc, 1);
     rb_define_method(rb_cHash, "key", rb_hash_key, 1);
-    rb_define_method(rb_cHash, "index", rb_hash_index, 1);
     rb_define_method(rb_cHash, "size", rb_hash_size, 0);
     rb_define_method(rb_cHash, "length", rb_hash_size, 0);
     rb_define_method(rb_cHash, "empty?", rb_hash_empty_p, 0);

--- a/include/ruby/internal/globals.h
+++ b/include/ruby/internal/globals.h
@@ -20,6 +20,7 @@
  *             extension libraries. They could be written in C++98.
  * @brief      Ruby-level global variables / constants, visible from C.
  */
+#include "ruby/internal/attr/deprecated.h"
 #include "ruby/internal/attr/pure.h"
 #include "ruby/internal/dllexport.h"
 #include "ruby/internal/fl_type.h"
@@ -48,6 +49,7 @@ RUBY_EXTERN VALUE rb_cArray;
 RUBY_EXTERN VALUE rb_cBinding;
 RUBY_EXTERN VALUE rb_cClass;
 RUBY_EXTERN VALUE rb_cCont;
+RBIMPL_ATTR_DEPRECATED(("by: rb_cObject.  Will be removed in 3.1."))
 RUBY_EXTERN VALUE rb_cData;
 RUBY_EXTERN VALUE rb_cDir;
 RUBY_EXTERN VALUE rb_cEncoding;

--- a/internal/error.h
+++ b/internal/error.h
@@ -56,6 +56,7 @@ const char *rb_builtin_type_name(int t);
 const char *rb_builtin_class_name(VALUE x);
 PRINTF_ARGS(void rb_warn_deprecated(const char *fmt, const char *suggest, ...), 1, 3);
 PRINTF_ARGS(void rb_warn_deprecated_to_remove(const char *fmt, const char *removal, ...), 1, 3);
+PRINTF_ARGS(void rb_warn_deprecated_to_remove_use_this_one_instead(const char *deprecated, const char *to_remove, const char *use_this_one_instead, ...), 1, 4);
 VALUE rb_syntax_error_append(VALUE, VALUE, int, int, rb_encoding*, const char*, va_list);
 PRINTF_ARGS(void rb_enc_warn(rb_encoding *enc, const char *fmt, ...), 2, 3);
 PRINTF_ARGS(void rb_sys_enc_warning(rb_encoding *enc, const char *fmt, ...), 2, 3);

--- a/io.c
+++ b/io.c
@@ -3872,19 +3872,6 @@ rb_io_each_line(int argc, VALUE *argv, VALUE io)
 }
 
 /*
- *  This is a deprecated alias for #each_line.
- */
-
-static VALUE
-rb_io_lines(int argc, VALUE *argv, VALUE io)
-{
-    rb_warn_deprecated("IO#lines", "#each_line");
-    if (!rb_block_given_p())
-	return rb_enumeratorize(io, ID2SYM(rb_intern("each_line")), argc, argv);
-    return rb_io_each_line(argc, argv, io);
-}
-
-/*
  *  call-seq:
  *     ios.each_byte {|byte| block }  -> ios
  *     ios.each_byte                  -> an_enumerator
@@ -3920,19 +3907,6 @@ rb_io_each_byte(VALUE io)
 	READ_CHECK(fptr);
     } while (io_fillbuf(fptr) >= 0);
     return io;
-}
-
-/*
- *  This is a deprecated alias for #each_byte.
- */
-
-static VALUE
-rb_io_bytes(VALUE io)
-{
-    rb_warn_deprecated("IO#bytes", "#each_byte");
-    if (!rb_block_given_p())
-	return rb_enumeratorize(io, ID2SYM(rb_intern("each_byte")), 0, 0);
-    return rb_io_each_byte(io);
 }
 
 static VALUE
@@ -4077,20 +4051,6 @@ rb_io_each_char(VALUE io)
 }
 
 /*
- *  This is a deprecated alias for #each_char.
- */
-
-static VALUE
-rb_io_chars(VALUE io)
-{
-    rb_warn_deprecated("IO#chars", "#each_char");
-    if (!rb_block_given_p())
-	return rb_enumeratorize(io, ID2SYM(rb_intern("each_char")), 0, 0);
-    return rb_io_each_char(io);
-}
-
-
-/*
  *  call-seq:
  *     ios.each_codepoint {|c| block }  -> ios
  *     ios.codepoints     {|c| block }  -> ios
@@ -4206,20 +4166,6 @@ rb_io_each_codepoint(VALUE io)
     rb_raise(rb_eArgError, "invalid byte sequence in %s", rb_enc_name(enc));
     UNREACHABLE_RETURN(Qundef);
 }
-
-/*
- *  This is a deprecated alias for #each_codepoint.
- */
-
-static VALUE
-rb_io_codepoints(VALUE io)
-{
-    rb_warn_deprecated("IO#codepoints", "#each_codepoint");
-    if (!rb_block_given_p())
-	return rb_enumeratorize(io, ID2SYM(rb_intern("each_codepoint")), 0, 0);
-    return rb_io_each_codepoint(io);
-}
-
 
 /*
  *  call-seq:
@@ -12605,23 +12551,7 @@ argf_each_line(int argc, VALUE *argv, VALUE argf)
 }
 
 /*
- *  This is a deprecated alias for #each_line.
- */
-
-static VALUE
-argf_lines(int argc, VALUE *argv, VALUE argf)
-{
-    rb_warn_deprecated("ARGF#lines", "#each_line");
-    if (!rb_block_given_p())
-	return rb_enumeratorize(argf, ID2SYM(rb_intern("each_line")), argc, argv);
-    return argf_each_line(argc, argv, argf);
-}
-
-/*
  *  call-seq:
- *     ARGF.bytes     {|byte| block }  -> ARGF
- *     ARGF.bytes                      -> an_enumerator
- *
  *     ARGF.each_byte {|byte| block }  -> ARGF
  *     ARGF.each_byte                  -> an_enumerator
  *
@@ -12652,19 +12582,6 @@ argf_each_byte(VALUE argf)
 }
 
 /*
- *  This is a deprecated alias for #each_byte.
- */
-
-static VALUE
-argf_bytes(VALUE argf)
-{
-    rb_warn_deprecated("ARGF#bytes", "#each_byte");
-    if (!rb_block_given_p())
-	return rb_enumeratorize(argf, ID2SYM(rb_intern("each_byte")), 0, 0);
-    return argf_each_byte(argf);
-}
-
-/*
  *  call-seq:
  *     ARGF.each_char {|char| block }  -> ARGF
  *     ARGF.each_char                  -> an_enumerator
@@ -12691,19 +12608,6 @@ argf_each_char(VALUE argf)
 }
 
 /*
- *  This is a deprecated alias for #each_char.
- */
-
-static VALUE
-argf_chars(VALUE argf)
-{
-    rb_warn_deprecated("ARGF#chars", "#each_char");
-    if (!rb_block_given_p())
-	return rb_enumeratorize(argf, ID2SYM(rb_intern("each_char")), 0, 0);
-    return argf_each_char(argf);
-}
-
-/*
  *  call-seq:
  *     ARGF.each_codepoint {|codepoint| block }  -> ARGF
  *     ARGF.each_codepoint                       -> an_enumerator
@@ -12727,19 +12631,6 @@ argf_each_codepoint(VALUE argf)
 	argf_block_call(rb_intern("each_codepoint"), 0, 0, argf);
     }
     return argf;
-}
-
-/*
- *  This is a deprecated alias for #each_codepoint.
- */
-
-static VALUE
-argf_codepoints(VALUE argf)
-{
-    rb_warn_deprecated("ARGF#codepoints", "#each_codepoint");
-    if (!rb_block_given_p())
-	return rb_enumeratorize(argf, ID2SYM(rb_intern("each_codepoint")), 0, 0);
-    return argf_each_codepoint(argf);
 }
 
 /*
@@ -13407,10 +13298,6 @@ Init_IO(void)
     rb_define_method(rb_cIO, "each_byte",  rb_io_each_byte, 0);
     rb_define_method(rb_cIO, "each_char",  rb_io_each_char, 0);
     rb_define_method(rb_cIO, "each_codepoint",  rb_io_each_codepoint, 0);
-    rb_define_method(rb_cIO, "lines",  rb_io_lines, -1);
-    rb_define_method(rb_cIO, "bytes",  rb_io_bytes, 0);
-    rb_define_method(rb_cIO, "chars",  rb_io_chars, 0);
-    rb_define_method(rb_cIO, "codepoints",  rb_io_codepoints, 0);
 
     rb_define_method(rb_cIO, "syswrite", rb_io_syswrite, 1);
     rb_define_method(rb_cIO, "sysread",  rb_io_sysread, -1);
@@ -13538,10 +13425,6 @@ Init_IO(void)
     rb_define_method(rb_cARGF, "each_byte",  argf_each_byte, 0);
     rb_define_method(rb_cARGF, "each_char",  argf_each_char, 0);
     rb_define_method(rb_cARGF, "each_codepoint",  argf_each_codepoint, 0);
-    rb_define_method(rb_cARGF, "lines", argf_lines, -1);
-    rb_define_method(rb_cARGF, "bytes", argf_bytes, 0);
-    rb_define_method(rb_cARGF, "chars", argf_chars, 0);
-    rb_define_method(rb_cARGF, "codepoints", argf_codepoints, 0);
 
     rb_define_method(rb_cARGF, "read",  argf_read, -1);
     rb_define_method(rb_cARGF, "readpartial",  argf_readpartial, -1);

--- a/io.c
+++ b/io.c
@@ -7587,7 +7587,7 @@ deprecated_str_setter(VALUE val, ID id, VALUE *var)
 {
     rb_str_setter(val, id, &val);
     if (!NIL_P(val)) {
-        rb_warn_deprecated("`%s'", NULL, rb_id2name(id));
+        rb_warn_deprecated_to_remove("`%s'", "3.1", rb_id2name(id));
     }
     *var = val;
 }

--- a/lib/delegate.rb
+++ b/lib/delegate.rb
@@ -44,7 +44,7 @@ class Delegator < BasicObject
   kernel = ::Kernel.dup
   kernel.class_eval do
     alias __raise__ raise
-    [:to_s, :inspect, :=~, :!~, :===, :<=>, :hash].each do |m|
+    [:to_s, :inspect, :!~, :===, :<=>, :hash].each do |m|
       undef_method m
     end
     private_instance_methods.each do |m|

--- a/object.c
+++ b/object.c
@@ -1399,6 +1399,8 @@ nil_inspect(VALUE obj)
  *     nil =~ other  -> nil
  *
  *  Dummy pattern matching -- always returns nil.
+ *
+ *  This method makes it possible to `while gets =~ /re/ do`.
  */
 
 static VALUE
@@ -1576,27 +1578,6 @@ MJIT_FUNC_EXPORTED VALUE
 rb_false(VALUE obj)
 {
     return Qfalse;
-}
-
-
-/*
- *  call-seq:
- *     obj =~ other  -> nil
- *
- * This method is deprecated.
- *
- * This is not only useless but also troublesome because it may hide a
- * type error.
- */
-
-static VALUE
-rb_obj_match(VALUE obj1, VALUE obj2)
-{
-    if (rb_warning_category_enabled_p(RB_WARN_CATEGORY_DEPRECATED)) {
-        rb_warn("deprecated Object#=~ is called on %"PRIsVALUE
-                "; it always returns nil", rb_obj_class(obj1));
-    }
-    return Qnil;
 }
 
 /*
@@ -4524,7 +4505,6 @@ InitVM_Object(void)
 
     rb_define_method(rb_mKernel, "nil?", rb_false, 0);
     rb_define_method(rb_mKernel, "===", case_equal, 1);
-    rb_define_method(rb_mKernel, "=~", rb_obj_match, 1);
     rb_define_method(rb_mKernel, "!~", rb_obj_not_match, 1);
     rb_define_method(rb_mKernel, "eql?", rb_obj_equal, 1);
     rb_define_method(rb_mKernel, "hash", rb_obj_hash, 0); /* in hash.c */

--- a/object.c
+++ b/object.c
@@ -32,6 +32,7 @@
 #include "internal/struct.h"
 #include "internal/symbol.h"
 #include "internal/variable.h"
+#include "internal/warnings.h"
 #include "probes.h"
 #include "ruby/encoding.h"
 #include "ruby/st.h"
@@ -4299,6 +4300,25 @@ f_sprintf(int c, const VALUE *v, VALUE _)
     return rb_f_sprintf(c, v);
 }
 
+COMPILER_WARNING_PUSH
+#if defined(_MSC_VER)
+COMPILER_WARNING_IGNORED(4996)
+#elif defined(__INTEL_COMPILER)
+COMPILER_WARNING_IGNORED(1786)
+#elif __has_warning("-Wdeprecated-declarations")
+COMPILER_WARNING_IGNORED(-Wdeprecated-declarations)
+#elif defined(__GNUC__)
+COMPILER_WARNING_IGNORED(-Wdeprecated-declarations)
+#endif
+
+static inline void
+Init_rb_cData(void)
+{
+    rb_cData = rb_cObject;
+}
+
+COMPILER_WARNING_POP
+
 /*
  *  Document-class: Class
  *
@@ -4633,15 +4653,7 @@ InitVM_Object(void)
     rb_undef_method(rb_cClass, "append_features");
     rb_undef_method(rb_cClass, "prepend_features");
 
-    /*
-     * Document-class: Data
-     *
-     * This is a deprecated class, base class for C extensions using
-     * Data_Make_Struct or Data_Wrap_Struct.
-     */
-    rb_cData = rb_define_class("Data", rb_cObject);
-    rb_undef_alloc_func(rb_cData);
-    rb_deprecate_constant(rb_cObject, "Data");
+    Init_rb_cData();
 
     rb_cTrueClass = rb_define_class("TrueClass", rb_cObject);
     rb_cTrueClass_to_s = rb_fstring_enc_lit("true", rb_usascii_encoding());

--- a/prelude.rb
+++ b/prelude.rb
@@ -1,18 +1,3 @@
-class << Thread
-  # call-seq:
-  #    Thread.exclusive { block }   -> obj
-  #
-  # Wraps the block in a single, VM-global Mutex.synchronize, returning the
-  # value of the block. A thread executing inside the exclusive section will
-  # only block other threads which also use the Thread.exclusive mechanism.
-  def exclusive(&block) end if false
-  mutex = Mutex.new # :nodoc:
-  define_method(:exclusive) do |&block|
-    warn "Thread.exclusive is deprecated, use Thread::Mutex", uplevel: 1
-    mutex.synchronize(&block)
-  end
-end
-
 class Binding
   # :nodoc:
   def irb

--- a/proc.c
+++ b/proc.c
@@ -863,7 +863,7 @@ f_lambda(VALUE _)
           case block_handler_type_proc:
           case block_handler_type_symbol:
           case block_handler_type_ifunc:
-            rb_warn_deprecated("lambda without a literal block", "the proc without lambda");
+            rb_warn_deprecated_to_remove_use_this_one_instead("lambda without a literal block", "3.1", "the proc without lambda");
           default:
             break;
         }

--- a/process.c
+++ b/process.c
@@ -8796,9 +8796,6 @@ InitVM_process(void)
 #if defined(HAVE_TIMES) || defined(_WIN32)
     /* Placeholder for rusage */
     rb_cProcessTms = rb_struct_define_under(rb_mProcess, "Tms", "utime", "stime", "cutime", "cstime", NULL);
-    /* An obsolete name of Process::Tms for backward compatibility */
-    rb_define_const(rb_cStruct, "Tms", rb_cProcessTms);
-    rb_deprecate_constant(rb_cStruct, "Tms");
 #endif
 
     SAVED_USER_ID = geteuid();

--- a/spec/ruby/core/argf/bytes_spec.rb
+++ b/spec/ruby/core/argf/bytes_spec.rb
@@ -1,6 +1,8 @@
 require_relative '../../spec_helper'
 require_relative 'shared/each_byte'
 
-describe "ARGF.bytes" do
-  it_behaves_like :argf_each_byte, :bytes
+ruby_version_is ''...'2.8' do
+  describe "ARGF.bytes" do
+    it_behaves_like :argf_each_byte, :bytes
+  end
 end

--- a/spec/ruby/core/argf/chars_spec.rb
+++ b/spec/ruby/core/argf/chars_spec.rb
@@ -1,6 +1,8 @@
 require_relative '../../spec_helper'
 require_relative 'shared/each_char'
 
-describe "ARGF.chars" do
-  it_behaves_like :argf_each_char, :chars
+ruby_version_is ''...'2.8' do
+  describe "ARGF.chars" do
+    it_behaves_like :argf_each_char, :chars
+  end
 end

--- a/spec/ruby/core/argf/codepoints_spec.rb
+++ b/spec/ruby/core/argf/codepoints_spec.rb
@@ -1,6 +1,8 @@
 require_relative '../../spec_helper'
 require_relative 'shared/each_codepoint'
 
-describe "ARGF.codepoints" do
-  it_behaves_like :argf_each_codepoint, :codepoints
+ruby_version_is ''...'2.8' do
+  describe "ARGF.codepoints" do
+    it_behaves_like :argf_each_codepoint, :codepoints
+  end
 end

--- a/spec/ruby/core/argf/lines_spec.rb
+++ b/spec/ruby/core/argf/lines_spec.rb
@@ -1,6 +1,8 @@
 require_relative '../../spec_helper'
 require_relative 'shared/each_line'
 
-describe "ARGF.lines" do
-  it_behaves_like :argf_each_line, :lines
+ruby_version_is ''...'2.8' do
+  describe "ARGF.lines" do
+    it_behaves_like :argf_each_line, :lines
+  end
 end

--- a/spec/ruby/core/data/constants_spec.rb
+++ b/spec/ruby/core/data/constants_spec.rb
@@ -1,13 +1,15 @@
 require_relative '../../spec_helper'
 
-describe "Data" do
-  it "is a subclass of Object" do
-    suppress_warning do
-      Data.superclass.should == Object
+ruby_version_is ''...'2.8' do
+  describe "Data" do
+    it "is a subclass of Object" do
+      suppress_warning do
+        Data.superclass.should == Object
+      end
     end
-  end
 
-  it "is deprecated" do
-    -> { Data }.should complain(/constant ::Data is deprecated/)
+    it "is deprecated" do
+      -> { Data }.should complain(/constant ::Data is deprecated/)
+    end
   end
 end

--- a/spec/ruby/core/enumerator/initialize_spec.rb
+++ b/spec/ruby/core/enumerator/initialize_spec.rb
@@ -11,8 +11,10 @@ describe "Enumerator#initialize" do
     Enumerator.should have_private_instance_method(:initialize, false)
   end
 
-  it "returns self when given an object" do
-    @uninitialized.send(:initialize, Object.new).should equal(@uninitialized)
+  ruby_version_is ''...'2.8' do
+    it "returns self when given an object" do
+      @uninitialized.send(:initialize, Object.new).should equal(@uninitialized)
+    end
   end
 
   it "returns self when given a block" do

--- a/spec/ruby/core/enumerator/new_spec.rb
+++ b/spec/ruby/core/enumerator/new_spec.rb
@@ -1,42 +1,52 @@
 require_relative '../../spec_helper'
 
 describe "Enumerator.new" do
-  it "creates a new custom enumerator with the given object, iterator and arguments" do
-    enum = Enumerator.new(1, :upto, 3)
-    enum.should be_an_instance_of(Enumerator)
-  end
-
-  it "creates a new custom enumerator that responds to #each" do
-    enum = Enumerator.new(1, :upto, 3)
-    enum.respond_to?(:each).should == true
-  end
-
-  it "creates a new custom enumerator that runs correctly" do
-    Enumerator.new(1, :upto, 3).map{|x|x}.should == [1,2,3]
-  end
-
-  it "aliases the second argument to :each" do
-    Enumerator.new(1..2).to_a.should == Enumerator.new(1..2, :each).to_a
-  end
-
-  it "doesn't check for the presence of the iterator method" do
-    Enumerator.new(nil).should be_an_instance_of(Enumerator)
-  end
-
-  it "uses the latest define iterator method" do
-    class StrangeEach
-      def each
-        yield :foo
+  context "no block given" do
+    ruby_version_is '2.8' do
+      it "raises" do
+        -> { Enumerator.new(1, :upto, 3) }.should raise_error(ArgumentError)
       end
     end
-    enum = Enumerator.new(StrangeEach.new)
-    enum.to_a.should == [:foo]
-    class StrangeEach
-      def each
-        yield :bar
+
+    ruby_version_is ''...'2.8' do
+      it "creates a new custom enumerator with the given object, iterator and arguments" do
+        enum = Enumerator.new(1, :upto, 3)
+        enum.should be_an_instance_of(Enumerator)
+      end
+
+      it "creates a new custom enumerator that responds to #each" do
+        enum = Enumerator.new(1, :upto, 3)
+        enum.respond_to?(:each).should == true
+      end
+
+      it "creates a new custom enumerator that runs correctly" do
+        Enumerator.new(1, :upto, 3).map{|x|x}.should == [1,2,3]
+      end
+
+      it "aliases the second argument to :each" do
+        Enumerator.new(1..2).to_a.should == Enumerator.new(1..2, :each).to_a
+      end
+
+      it "doesn't check for the presence of the iterator method" do
+        Enumerator.new(nil).should be_an_instance_of(Enumerator)
+      end
+
+      it "uses the latest define iterator method" do
+        class StrangeEach
+          def each
+            yield :foo
+          end
+        end
+        enum = Enumerator.new(StrangeEach.new)
+        enum.to_a.should == [:foo]
+        class StrangeEach
+          def each
+            yield :bar
+          end
+        end
+        enum.to_a.should == [:bar]
       end
     end
-    enum.to_a.should == [:bar]
   end
 
   context "when passed a block" do

--- a/spec/ruby/core/env/index_spec.rb
+++ b/spec/ruby/core/env/index_spec.rb
@@ -1,12 +1,14 @@
 require_relative '../../spec_helper'
 require_relative 'shared/key'
 
-describe "ENV.index" do
-  it_behaves_like :env_key, :index
+ruby_version_is ''...'2.8' do
+  describe "ENV.index" do
+    it_behaves_like :env_key, :index
 
-  it "warns about deprecation" do
-    -> do
-      ENV.index("foo")
-    end.should complain(/warning: ENV.index is deprecated; use ENV.key/)
+    it "warns about deprecation" do
+      -> do
+        ENV.index("foo")
+      end.should complain(/warning: ENV.index is deprecated; use ENV.key/)
+    end
   end
 end

--- a/spec/ruby/core/hash/index_spec.rb
+++ b/spec/ruby/core/hash/index_spec.rb
@@ -2,6 +2,8 @@ require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 require_relative 'shared/index'
 
-describe "Hash#index" do
-  it_behaves_like :hash_index, :index
+ruby_version_is ''...'2.8' do
+  describe "Hash#index" do
+    it_behaves_like :hash_index, :index
+  end
 end

--- a/spec/ruby/core/io/bytes_spec.rb
+++ b/spec/ruby/core/io/bytes_spec.rb
@@ -2,42 +2,44 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
-describe "IO#bytes" do
-  before :each do
-    @io = IOSpecs.io_fixture "lines.txt"
-  end
-
-  after :each do
-    @io.close unless @io.closed?
-  end
-
-  it "returns an enumerator of the next bytes from the stream" do
-    enum = @io.bytes
-    enum.should be_an_instance_of(Enumerator)
-    @io.readline.should == "Voici la ligne une.\n"
-    enum.first(5).should == [81, 117, 105, 32, 195]
-  end
-
-  it "yields each byte" do
-    count = 0
-    ScratchPad.record []
-    @io.each_byte do |byte|
-      ScratchPad << byte
-      break if 4 < count += 1
+ruby_version_is ''...'2.8' do
+  describe "IO#bytes" do
+    before :each do
+      @io = IOSpecs.io_fixture "lines.txt"
     end
 
-    ScratchPad.recorded.should == [86, 111, 105, 99, 105]
-  end
+    after :each do
+      @io.close unless @io.closed?
+    end
 
-  it "raises an IOError on closed stream" do
-    enum = IOSpecs.closed_io.bytes
-    -> { enum.first }.should raise_error(IOError)
-  end
+    it "returns an enumerator of the next bytes from the stream" do
+      enum = @io.bytes
+      enum.should be_an_instance_of(Enumerator)
+      @io.readline.should == "Voici la ligne une.\n"
+      enum.first(5).should == [81, 117, 105, 32, 195]
+    end
 
-  it "raises an IOError on an enumerator for a stream that has been closed" do
-    enum = @io.bytes
-    enum.first.should == 86
-    @io.close
-    -> { enum.first }.should raise_error(IOError)
+    it "yields each byte" do
+      count = 0
+      ScratchPad.record []
+      @io.each_byte do |byte|
+        ScratchPad << byte
+        break if 4 < count += 1
+      end
+
+      ScratchPad.recorded.should == [86, 111, 105, 99, 105]
+    end
+
+    it "raises an IOError on closed stream" do
+      enum = IOSpecs.closed_io.bytes
+      -> { enum.first }.should raise_error(IOError)
+    end
+
+    it "raises an IOError on an enumerator for a stream that has been closed" do
+      enum = @io.bytes
+      enum.first.should == 86
+      @io.close
+      -> { enum.first }.should raise_error(IOError)
+    end
   end
 end

--- a/spec/ruby/core/io/chars_spec.rb
+++ b/spec/ruby/core/io/chars_spec.rb
@@ -3,10 +3,12 @@ require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 require_relative 'shared/chars'
 
-describe "IO#chars" do
-  it_behaves_like :io_chars, :chars
-end
+ruby_version_is ''...'2.8' do
+  describe "IO#chars" do
+    it_behaves_like :io_chars, :chars
+  end
 
-describe "IO#chars" do
-  it_behaves_like :io_chars_empty, :chars
+  describe "IO#chars" do
+    it_behaves_like :io_chars_empty, :chars
+  end
 end

--- a/spec/ruby/core/io/codepoints_spec.rb
+++ b/spec/ruby/core/io/codepoints_spec.rb
@@ -2,24 +2,27 @@ require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 require_relative 'shared/codepoints'
 
-# See redmine #1667
-describe "IO#codepoints" do
-  it_behaves_like :io_codepoints, :codepoints
-end
+ruby_version_is ''...'2.8' do
 
-describe "IO#codepoints" do
-  before :each do
-    @io = IOSpecs.io_fixture "lines.txt"
+  # See redmine #1667
+  describe "IO#codepoints" do
+    it_behaves_like :io_codepoints, :codepoints
   end
 
-  after :each do
-    @io.close unless @io.closed?
-  end
+  describe "IO#codepoints" do
+    before :each do
+      @io = IOSpecs.io_fixture "lines.txt"
+    end
 
-  it "calls the given block" do
-    r = []
-    @io.codepoints { |c| r << c }
-    r[24].should == 232
-    r.last.should == 10
+    after :each do
+      @io.close unless @io.closed?
+    end
+
+    it "calls the given block" do
+      r = []
+      @io.codepoints { |c| r << c }
+      r[24].should == 232
+      r.last.should == 10
+    end
   end
 end

--- a/spec/ruby/core/io/each_codepoint_spec.rb
+++ b/spec/ruby/core/io/each_codepoint_spec.rb
@@ -4,7 +4,7 @@ require_relative 'shared/codepoints'
 
 # See redmine #1667
 describe "IO#each_codepoint" do
-  it_behaves_like :io_codepoints, :codepoints
+  it_behaves_like :io_codepoints, :each_codepoint
 end
 
 describe "IO#each_codepoint" do

--- a/spec/ruby/core/io/lines_spec.rb
+++ b/spec/ruby/core/io/lines_spec.rb
@@ -2,41 +2,43 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
-describe "IO#lines" do
-  before :each do
-    @io = IOSpecs.io_fixture "lines.txt"
-  end
+ruby_version_is ''...'2.8' do
+  describe "IO#lines" do
+    before :each do
+      @io = IOSpecs.io_fixture "lines.txt"
+    end
 
-  after :each do
-    @io.close if @io
-  end
+    after :each do
+      @io.close if @io
+    end
 
-  it "returns an Enumerator" do
-    @io.lines.should be_an_instance_of(Enumerator)
-  end
-
-  describe "when no block is given" do
     it "returns an Enumerator" do
       @io.lines.should be_an_instance_of(Enumerator)
     end
 
-    describe "returned Enumerator" do
-      describe "size" do
-        it "should return nil" do
-          @io.lines.size.should == nil
+    describe "when no block is given" do
+      it "returns an Enumerator" do
+        @io.lines.should be_an_instance_of(Enumerator)
+      end
+
+      describe "returned Enumerator" do
+        describe "size" do
+          it "should return nil" do
+            @io.lines.size.should == nil
+          end
         end
       end
     end
-  end
 
-  it "returns a line when accessed" do
-    enum = @io.lines
-    enum.first.should == IOSpecs.lines[0]
-  end
+    it "returns a line when accessed" do
+      enum = @io.lines
+      enum.first.should == IOSpecs.lines[0]
+    end
 
-  it "yields each line to the passed block" do
-    ScratchPad.record []
-    @io.lines { |s| ScratchPad << s }
-    ScratchPad.recorded.should == IOSpecs.lines
+    it "yields each line to the passed block" do
+      ScratchPad.record []
+      @io.lines { |s| ScratchPad << s }
+      ScratchPad.recorded.should == IOSpecs.lines
+    end
   end
 end

--- a/spec/ruby/core/kernel/match_spec.rb
+++ b/spec/ruby/core/kernel/match_spec.rb
@@ -1,24 +1,26 @@
 require_relative '../../spec_helper'
 
-describe "Kernel#=~" do
-  it "returns nil matching any object" do
-    o = Object.new
+ruby_version_is ''...'2.8' do
+  describe "Kernel#=~" do
+    it "returns nil matching any object" do
+      o = Object.new
 
-    suppress_warning do
-      (o =~ /Object/).should   be_nil
-      (o =~ 'Object').should   be_nil
-      (o =~ Object).should     be_nil
-      (o =~ Object.new).should be_nil
-      (o =~ nil).should        be_nil
-      (o =~ true).should       be_nil
+      suppress_warning do
+        (o =~ /Object/).should   be_nil
+        (o =~ 'Object').should   be_nil
+        (o =~ Object).should     be_nil
+        (o =~ Object.new).should be_nil
+        (o =~ nil).should        be_nil
+        (o =~ true).should       be_nil
+      end
     end
-  end
 
-  ruby_version_is "2.6" do
-    it "is deprecated" do
-      -> do
-        Object.new =~ /regexp/
-      end.should complain(/deprecated Object#=~ is called on Object/, verbose: true)
+    ruby_version_is "2.6" do
+      it "is deprecated" do
+        -> do
+          Object.new =~ /regexp/
+        end.should complain(/deprecated Object#=~ is called on Object/, verbose: true)
+      end
     end
   end
 end

--- a/spec/ruby/core/nil/match_spec.rb
+++ b/spec/ruby/core/nil/match_spec.rb
@@ -3,7 +3,7 @@ require_relative '../../spec_helper'
 ruby_version_is "2.6" do
   describe "NilClass#=~" do
     it "returns nil matching any object" do
-      o = Object.new
+      o = nil
 
       suppress_warning do
         (o =~ /Object/).should   be_nil

--- a/spec/ruby/core/thread/exclusive_spec.rb
+++ b/spec/ruby/core/thread/exclusive_spec.rb
@@ -1,47 +1,49 @@
 require_relative '../../spec_helper'
 
-describe "Thread.exclusive" do
-  before :each do
-    ScratchPad.clear
-    $VERBOSE, @verbose = nil, $VERBOSE
-  end
+ruby_version_is ''...'2.8' do
+  describe "Thread.exclusive" do
+    before :each do
+      ScratchPad.clear
+      $VERBOSE, @verbose = nil, $VERBOSE
+    end
 
-  after :each do
-    $VERBOSE = @verbose
-  end
+    after :each do
+      $VERBOSE = @verbose
+    end
 
-  it "yields to the block" do
-    Thread.exclusive { ScratchPad.record true }
-    ScratchPad.recorded.should == true
-  end
+    it "yields to the block" do
+      Thread.exclusive { ScratchPad.record true }
+      ScratchPad.recorded.should == true
+    end
 
-  it "returns the result of yielding" do
-    Thread.exclusive { :result }.should == :result
-  end
+    it "returns the result of yielding" do
+      Thread.exclusive { :result }.should == :result
+    end
 
-  it "blocks the caller if another thread is also in an exclusive block" do
-    m = Mutex.new
-    q1 = Queue.new
-    q2 = Queue.new
+    it "blocks the caller if another thread is also in an exclusive block" do
+      m = Mutex.new
+      q1 = Queue.new
+      q2 = Queue.new
 
-    t = Thread.new {
-      Thread.exclusive {
-        q1.push :ready
-        q2.pop
+      t = Thread.new {
+        Thread.exclusive {
+          q1.push :ready
+          q2.pop
+        }
       }
-    }
 
-    q1.pop.should == :ready
+      q1.pop.should == :ready
 
-    -> { Thread.exclusive { } }.should block_caller
+      -> { Thread.exclusive { } }.should block_caller
 
-    q2.push :done
-    t.join
-  end
+      q2.push :done
+      t.join
+    end
 
-  it "is not recursive" do
-    Thread.exclusive do
-      -> { Thread.exclusive { } }.should raise_error(ThreadError)
+    it "is not recursive" do
+      Thread.exclusive do
+        -> { Thread.exclusive { } }.should raise_error(ThreadError)
+      end
     end
   end
 end

--- a/spec/ruby/library/stringio/bytes_spec.rb
+++ b/spec/ruby/library/stringio/bytes_spec.rb
@@ -2,10 +2,12 @@ require_relative '../../spec_helper'
 require 'stringio'
 require_relative 'shared/each_byte'
 
-describe "StringIO#bytes" do
-  it_behaves_like :stringio_each_byte, :bytes
-end
+ruby_version_is ''...'2.8' do
+  describe "StringIO#bytes" do
+    it_behaves_like :stringio_each_byte, :bytes
+  end
 
-describe "StringIO#bytes when self is not readable" do
-  it_behaves_like :stringio_each_byte_not_readable, :bytes
+  describe "StringIO#bytes when self is not readable" do
+    it_behaves_like :stringio_each_byte_not_readable, :bytes
+  end
 end

--- a/spec/ruby/library/stringio/chars_spec.rb
+++ b/spec/ruby/library/stringio/chars_spec.rb
@@ -2,10 +2,12 @@ require_relative '../../spec_helper'
 require 'stringio'
 require_relative 'shared/each_char'
 
-describe "StringIO#chars" do
-  it_behaves_like :stringio_each_char, :chars
-end
+ruby_version_is ''...'2.8' do
+  describe "StringIO#chars" do
+    it_behaves_like :stringio_each_char, :chars
+  end
 
-describe "StringIO#chars when self is not readable" do
-  it_behaves_like :stringio_each_char_not_readable, :chars
+  describe "StringIO#chars when self is not readable" do
+    it_behaves_like :stringio_each_char_not_readable, :chars
+  end
 end

--- a/spec/ruby/library/stringio/codepoints_spec.rb
+++ b/spec/ruby/library/stringio/codepoints_spec.rb
@@ -3,7 +3,10 @@ require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 require_relative 'shared/codepoints'
 
-# See redmine #1667
-describe "StringIO#codepoints" do
-  it_behaves_like :stringio_codepoints, :codepoints
+ruby_version_is ''...'2.8' do
+
+  # See redmine #1667
+  describe "StringIO#codepoints" do
+    it_behaves_like :stringio_codepoints, :codepoints
+  end
 end

--- a/spec/ruby/library/stringio/each_char_spec.rb
+++ b/spec/ruby/library/stringio/each_char_spec.rb
@@ -7,5 +7,5 @@ describe "StringIO#each_char" do
 end
 
 describe "StringIO#each_char when self is not readable" do
-  it_behaves_like :stringio_each_char_not_readable, :chars
+  it_behaves_like :stringio_each_char_not_readable, :each_char
 end

--- a/spec/ruby/library/stringio/each_codepoint_spec.rb
+++ b/spec/ruby/library/stringio/each_codepoint_spec.rb
@@ -5,5 +5,5 @@ require_relative 'shared/codepoints'
 
 # See redmine #1667
 describe "StringIO#each_codepoint" do
-  it_behaves_like :stringio_codepoints, :codepoints
+  it_behaves_like :stringio_codepoints, :each_codepoint
 end

--- a/spec/ruby/library/stringio/lines_spec.rb
+++ b/spec/ruby/library/stringio/lines_spec.rb
@@ -2,18 +2,20 @@ require_relative '../../spec_helper'
 require 'stringio'
 require_relative 'shared/each'
 
-describe "StringIO#lines when passed a separator" do
-  it_behaves_like :stringio_each_separator, :lines
-end
+ruby_version_is ''...'2.8' do
+  describe "StringIO#lines when passed a separator" do
+    it_behaves_like :stringio_each_separator, :lines
+  end
 
-describe "StringIO#lines when passed no arguments" do
-  it_behaves_like :stringio_each_no_arguments, :lines
-end
+  describe "StringIO#lines when passed no arguments" do
+    it_behaves_like :stringio_each_no_arguments, :lines
+  end
 
-describe "StringIO#lines when self is not readable" do
-  it_behaves_like :stringio_each_not_readable, :lines
-end
+  describe "StringIO#lines when self is not readable" do
+    it_behaves_like :stringio_each_not_readable, :lines
+  end
 
-describe "StringIO#lines when passed chomp" do
-  it_behaves_like :stringio_each_chomp, :lines
+  describe "StringIO#lines when passed chomp" do
+    it_behaves_like :stringio_each_chomp, :lines
+  end
 end

--- a/string.c
+++ b/string.c
@@ -10271,7 +10271,7 @@ rb_fs_setter(VALUE val, ID id, VALUE *var)
 		 rb_id2str(id));
     }
     if (!NIL_P(val)) {
-        rb_warn_deprecated("`$;'", NULL);
+        rb_warn_deprecated_to_remove("`$;'", "3.1");
     }
     *var = val;
 }

--- a/string.c
+++ b/string.c
@@ -3856,7 +3856,6 @@ rb_str_rindex_m(int argc, VALUE *argv, VALUE str)
  *  against the receiver, and returns the position the match starts,
  *  or +nil+ if there is no match. Otherwise, invokes <i>obj.=~</i>,
  *  passing the string as an argument.
- *  The default Object#=~ (deprecated) returns +nil+.
  *
  *     "cat o' 9 tails" =~ /\d/   #=> 7
  *     "cat o' 9 tails" =~ 9      #=> nil

--- a/test/ruby/test_argf.rb
+++ b/test/ruby/test_argf.rb
@@ -998,48 +998,11 @@ class TestArgf < Test::Unit::TestCase
     assert_ruby_status(["-e", "2.times {STDIN.tty?; readlines}"], "", bug5952)
   end
 
-  def test_lines
+  def test_each_codepoint
     ruby('-W1', '-e', "#{<<~"{#"}\n#{<<~'};'}", @t1.path, @t2.path, @t3.path) do |f|
       {#
-        $stderr = $stdout
-        s = []
-        ARGF.lines {|l| s << l }
-        p s
+        print Marshal.dump(ARGF.each_codepoint.to_a)
       };
-      assert_match(/deprecated/, f.gets)
-      assert_equal("[\"1\\n\", \"2\\n\", \"3\\n\", \"4\\n\", \"5\\n\", \"6\\n\"]\n", f.read)
-    end
-  end
-
-  def test_bytes
-    ruby('-W1', '-e', "#{<<~"{#"}\n#{<<~'};'}", @t1.path, @t2.path, @t3.path) do |f|
-      {#
-        $stderr = $stdout
-        print Marshal.dump(ARGF.bytes.to_a)
-      };
-      assert_match(/deprecated/, f.gets)
-      assert_equal([49, 10, 50, 10, 51, 10, 52, 10, 53, 10, 54, 10], Marshal.load(f.read))
-    end
-  end
-
-  def test_chars
-    ruby('-W1', '-e', "#{<<~"{#"}\n#{<<~'};'}", @t1.path, @t2.path, @t3.path) do |f|
-      {#
-        $stderr = $stdout
-        print [Marshal.dump(ARGF.chars.to_a)].pack('m')
-      };
-      assert_match(/deprecated/, f.gets)
-      assert_equal(["1", "\n", "2", "\n", "3", "\n", "4", "\n", "5", "\n", "6", "\n"], Marshal.load(f.read.unpack('m').first))
-    end
-  end
-
-  def test_codepoints
-    ruby('-W1', '-e', "#{<<~"{#"}\n#{<<~'};'}", @t1.path, @t2.path, @t3.path) do |f|
-      {#
-        $stderr = $stdout
-        print Marshal.dump(ARGF.codepoints.to_a)
-      };
-      assert_match(/deprecated/, f.gets)
       assert_equal([49, 10, 50, 10, 51, 10, 52, 10, 53, 10, 54, 10], Marshal.load(f.read))
     end
   end

--- a/test/ruby/test_enumerator.rb
+++ b/test/ruby/test_enumerator.rb
@@ -69,17 +69,16 @@ class TestEnumerator < Test::Unit::TestCase
 
   def test_initialize
     assert_equal([1, 2, 3], @obj.to_enum(:foo, 1, 2, 3).to_a)
-    _, err = capture_io do
-      assert_equal([1, 2, 3], Enumerator.new(@obj, :foo, 1, 2, 3).to_a)
-    end
-    assert_match 'Enumerator.new without a block is deprecated', err
+    assert_raise(ArgumentError) {
+      Enumerator.new(@obj, :foo, 1, 2, 3)
+    }
     assert_equal([1, 2, 3], Enumerator.new { |y| i = 0; loop { y << (i += 1) } }.take(3))
     assert_raise(ArgumentError) { Enumerator.new }
 
     enum = @obj.to_enum
     assert_raise(NoMethodError) { enum.each {} }
     enum.freeze
-    assert_raise(FrozenError) {
+    assert_raise(ArgumentError) {
       capture_io do
         # warning: Enumerator.new without a block is deprecated; use Object#to_enum
         enum.__send__(:initialize, @obj, :foo)

--- a/test/ruby/test_env.rb
+++ b/test/ruby/test_env.rb
@@ -84,7 +84,6 @@ class TestEnv < Test::Unit::TestCase
     ENV['test'] = val[0...-1]
 
     assert_nil(ENV.key(val))
-    assert_nil(ENV.index(val))
     assert_nil(ENV.key(val.upcase))
     ENV['test'] = val
     if IGNORE_CASE

--- a/test/ruby/test_io.rb
+++ b/test/ruby/test_io.rb
@@ -405,19 +405,6 @@ class TestIO < Test::Unit::TestCase
     }
   end
 
-  def test_codepoints
-    make_tempfile {|t|
-      bug2959 = '[ruby-core:28650]'
-      a = ""
-      File.open(t, 'rt') {|f|
-        assert_warn(/deprecated/) {
-          f.codepoints {|c| a << c}
-        }
-      }
-      assert_equal("foo\nbar\nbaz\n", a, bug2959)
-    }
-  end
-
   def test_rubydev33072
     t = make_tempfile
     path = t.path
@@ -1822,8 +1809,7 @@ class TestIO < Test::Unit::TestCase
     end)
   end
 
-  def test_lines
-    verbose, $VERBOSE = $VERBOSE, nil
+  def test_each_line
     pipe(proc do |w|
       w.puts "foo"
       w.puts "bar"
@@ -1831,20 +1817,17 @@ class TestIO < Test::Unit::TestCase
       w.close
     end, proc do |r|
       e = nil
-      assert_warn(/deprecated/) {
-        e = r.lines
+      assert_warn('') {
+        e = r.each_line
       }
       assert_equal("foo\n", e.next)
       assert_equal("bar\n", e.next)
       assert_equal("baz\n", e.next)
       assert_raise(StopIteration) { e.next }
     end)
-  ensure
-    $VERBOSE = verbose
   end
 
-  def test_bytes
-    verbose, $VERBOSE = $VERBOSE, nil
+  def test_each_byte
     pipe(proc do |w|
       w.binmode
       w.puts "foo"
@@ -1853,20 +1836,17 @@ class TestIO < Test::Unit::TestCase
       w.close
     end, proc do |r|
       e = nil
-      assert_warn(/deprecated/) {
-        e = r.bytes
+      assert_warn('') {
+        e = r.each_byte
       }
       (%w(f o o) + ["\n"] + %w(b a r) + ["\n"] + %w(b a z) + ["\n"]).each do |c|
         assert_equal(c.ord, e.next)
       end
       assert_raise(StopIteration) { e.next }
     end)
-  ensure
-    $VERBOSE = verbose
   end
 
-  def test_chars
-    verbose, $VERBOSE = $VERBOSE, nil
+  def test_each_char
     pipe(proc do |w|
       w.puts "foo"
       w.puts "bar"
@@ -1874,16 +1854,14 @@ class TestIO < Test::Unit::TestCase
       w.close
     end, proc do |r|
       e = nil
-      assert_warn(/deprecated/) {
-        e = r.chars
+      assert_warn('') {
+        e = r.each_char
       }
       (%w(f o o) + ["\n"] + %w(b a r) + ["\n"] + %w(b a z) + ["\n"]).each do |c|
         assert_equal(c, e.next)
       end
       assert_raise(StopIteration) { e.next }
     end)
-  ensure
-    $VERBOSE = verbose
   end
 
   def test_readbyte

--- a/test/ruby/test_object.rb
+++ b/test/ruby/test_object.rb
@@ -990,13 +990,4 @@ class TestObject < Test::Unit::TestCase
       end
     EOS
   end
-
-  def test_matcher
-    assert_warning(/deprecated Object#=~ is called on Object/) do
-      assert_equal(Object.new =~ 42, nil)
-    end
-    assert_warning(/deprecated Object#=~ is called on Array/) do
-      assert_equal([] =~ 42, nil)
-    end
-  end
 end

--- a/transcode.c
+++ b/transcode.c
@@ -4462,7 +4462,7 @@ InitVM_transcode(void)
     rb_define_method(rb_cString, "encode", str_encode, -1);
     rb_define_method(rb_cString, "encode!", str_encode_bang, -1);
 
-    rb_cEncodingConverter = rb_define_class_under(rb_cEncoding, "Converter", rb_cData);
+    rb_cEncodingConverter = rb_define_class_under(rb_cEncoding, "Converter", rb_cObject);
     rb_define_alloc_func(rb_cEncodingConverter, econv_s_allocate);
     rb_define_singleton_method(rb_cEncodingConverter, "asciicompat_encoding", econv_s_asciicompat_encoding, 1);
     rb_define_singleton_method(rb_cEncodingConverter, "search_convpath", econv_s_search_convpath, -1);


### PR DESCRIPTION
Revised #3412 

|Feature|Warned (without `-w`) since|This pull request|
|:-|-:|:-|
|`Hash#index`|1.9.0|Deletes it|
|`IO#bytes`|2.0.0|Deletes it|
|`Enumerator.new` without a block|2.0.0|Deletes it|
|`Thread.exclusive`|2.3.0|Deletes it|
|`Data`|2.5.0|Deletes it|
|`Struct::Tms`|2.6.0|Deletes it|
|`Object#=~`|2.7.0|Deletes it|
|`Dir.exists?`|2.8.0|Knells for 3.1|
|`FileTest.exists?`|2.8.0|Knells for 3.1|
|`$,`,`$/`,`$\`,`$;`|2.8.0|Knells for 3.1|
|`lambda(&variable)`|2.8.0|Knells for 3.1|