### PR TITLE
Refactor to reduce "swap" instruction of pattern matching

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -6333,6 +6333,7 @@ compile_case3(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const orig_no
     INIT_ANCHOR(body_seq);
     INIT_ANCHOR(cond_seq);
 
+    ADD_INSN(head, nd_line(node), putnil); /* allocate stack for cached #deconstruct value */
     CHECK(COMPILE(head, "case base", node->nd_head));
 
     branches = decl_branch_base(iseq, node, "case");
@@ -6345,8 +6346,6 @@ compile_case3(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const orig_no
     endlabel = NEW_LABEL(line);
     elselabel = NEW_LABEL(line);
 
-    ADD_INSN(head, line, putnil); /* allocate stack for cached #deconstruct value */
-    ADD_INSN(head, line, swap);
     ADD_SEQ(ret, head);	/* case VAL */
 
     while (type == NODE_IN) {


### PR DESCRIPTION
This is a retry of 3a4be429b50062122d1616256de38649464d3146.

I think the line of stack allocation should be `case` line, so I change it.
ref: https://github.com/ruby/ruby/commit/3a4be429b50062122d1616256de38649464d3146#commitcomment-41512195

example:
```
case \  # 1: nd_line(node)
  0     # 2: nd_line(node->nd_head) 
in \    # 3: nd_line(node->nd_body) == line == original place
  0
  foo
end
```

@k-tsj san, How do you think?