### PR TITLE
Turn RHASH_EMPTY_P into an inline function (internal only)

### DIFF
--- a/ext/coverage/coverage.c
+++ b/ext/coverage/coverage.c
@@ -252,7 +252,8 @@ rb_coverage_peek_result(VALUE klass)
     if (!RTEST(coverages)) {
 	rb_raise(rb_eRuntimeError, "coverage measurement is not enabled");
     }
-    st_foreach(RHASH_TBL(coverages), coverage_peek_result_i, ncoverages);
+    OBJ_WB_UNPROTECT(coverages);
+    st_foreach(RHASH_TBL_RAW(coverages), coverage_peek_result_i, ncoverages);
 
     if (current_mode & COVERAGE_TARGET_METHODS) {
 	rb_objspace_each_objects(method_coverage_i, &ncoverages);

--- a/ext/objspace/objspace.c
+++ b/ext/objspace/objspace.c
@@ -141,7 +141,8 @@ setup_hash(int argc, VALUE *argv)
         hash = rb_hash_new();
     }
     else if (!RHASH_EMPTY_P(hash)) {
-        st_foreach(RHASH_TBL(hash), set_zero_i, hash);
+        /* WB: no new reference */
+        st_foreach(RHASH_TBL_RAW(hash), set_zero_i, hash);
     }
 
     return hash;

--- a/hash.c
+++ b/hash.c
@@ -1620,23 +1620,16 @@ rb_hash_modify_check(VALUE hash)
 }
 
 MJIT_FUNC_EXPORTED struct st_table *
-#if RHASH_CONVERT_TABLE_DEBUG
 rb_hash_tbl_raw(VALUE hash, const char *file, int line)
 {
     return ar_force_convert_table(hash, file, line);
 }
-#else
-rb_hash_tbl_raw(VALUE hash)
-{
-    return ar_force_convert_table(hash, NULL, 0);
-}
-#endif
 
 struct st_table *
 rb_hash_tbl(VALUE hash, const char *file, int line)
 {
     OBJ_WB_UNPROTECT(hash);
-    return RHASH_TBL_RAW(hash);
+    return rb_hash_tbl_raw(hash, file, line);
 }
 
 static void

--- a/internal.h
+++ b/internal.h
@@ -47,6 +47,7 @@
 #undef RHASH_IFNONE
 #undef RHASH_SIZE
 #undef RHASH_TBL
+#undef RHASH_EMPTY_P
 
 /* internal/struct.h */
 #undef RSTRUCT_LEN

--- a/internal.h
+++ b/internal.h
@@ -46,6 +46,7 @@
 /* internal/hash.h */
 #undef RHASH_IFNONE
 #undef RHASH_SIZE
+#undef RHASH_TBL
 
 /* internal/struct.h */
 #undef RSTRUCT_LEN

--- a/internal/hash.h
+++ b/internal/hash.h
@@ -107,13 +107,8 @@ VALUE rb_hash_keys(VALUE hash);
 VALUE rb_hash_has_key(VALUE hash, VALUE key);
 VALUE rb_hash_compare_by_id_p(VALUE hash);
 
-#if RHASH_CONVERT_TABLE_DEBUG
 st_table *rb_hash_tbl_raw(VALUE hash, const char *file, int line);
 #define RHASH_TBL_RAW(h) rb_hash_tbl_raw(h, __FILE__, __LINE__)
-#else
-st_table *rb_hash_tbl_raw(VALUE hash);
-#define RHASH_TBL_RAW(h) rb_hash_tbl_raw(h)
-#endif
 MJIT_SYMBOL_EXPORT_END
 
 #if 0 /* for debug */

--- a/internal/hash.h
+++ b/internal/hash.h
@@ -64,6 +64,10 @@ struct RHash {
 # undef RHASH_SIZE
 #endif
 
+#ifdef RHASH_EMPTY_P
+# undef RHASH_EMPTY_P
+#endif
+
 /* hash.c */
 void rb_hash_st_table_set(VALUE hash, st_table *st);
 VALUE rb_hash_default_value(VALUE hash, VALUE key);
@@ -82,6 +86,7 @@ int rb_hash_stlike_update(VALUE hash, st_data_t key, st_update_callback_func *fu
 static inline unsigned RHASH_AR_TABLE_SIZE_RAW(VALUE h);
 static inline VALUE RHASH_IFNONE(VALUE h);
 static inline size_t RHASH_SIZE(VALUE h);
+static inline bool RHASH_EMPTY_P(VALUE h);
 static inline bool RHASH_AR_TABLE_P(VALUE h);
 static inline bool RHASH_ST_TABLE_P(VALUE h);
 static inline struct ar_table_struct *RHASH_AR_TABLE(VALUE h);
@@ -171,6 +176,12 @@ RHASH_SIZE(VALUE h)
     else {
         return RHASH_ST_SIZE(h);
     }
+}
+
+static inline bool
+RHASH_EMPTY_P(VALUE h)
+{
+    return RHASH_SIZE(h) == 0;
 }
 
 static inline bool

--- a/struct.c
+++ b/struct.c
@@ -388,9 +388,10 @@ struct_make_members_list(va_list ar)
 {
     char *mem;
     VALUE ary, list = rb_ident_hash_new();
-    st_table *tbl = RHASH_TBL(list);
+    st_table *tbl = RHASH_TBL_RAW(list);
 
     RBASIC_CLEAR_CLASS(list);
+    OBJ_WB_UNPROTECT(list);
     while ((mem = va_arg(ar, char*)) != 0) {
 	VALUE sym = rb_sym_intern_ascii_cstr(mem);
 	if (st_insert(tbl, sym, Qtrue)) {
@@ -583,7 +584,8 @@ rb_struct_s_def(int argc, VALUE *argv, VALUE klass)
 
     rest = rb_ident_hash_new();
     RBASIC_CLEAR_CLASS(rest);
-    tbl = RHASH_TBL(rest);
+    OBJ_WB_UNPROTECT(rest);
+    tbl = RHASH_TBL_RAW(rest);
     for (i=0; i<argc; i++) {
 	VALUE mem = rb_to_symbol(argv[i]);
         if (rb_is_attrset_sym(mem)) {


### PR DESCRIPTION
The same as #3419, but for `RHASH_EMPTY_P` this time.  Must not impact public CAPI.