### PR TITLE
Use Regexp#match? to avoid extra allocations

### DIFF
--- a/lib/uri/common.rb
+++ b/lib/uri/common.rb
@@ -397,7 +397,7 @@ module URI
   #
   # See URI.encode_www_form_component, URI.decode_www_form.
   def self.decode_www_form_component(str, enc=Encoding::UTF_8)
-    raise ArgumentError, "invalid %-encoding (#{str})" if /%(?!\h\h)/ =~ str
+    raise ArgumentError, "invalid %-encoding (#{str})" if /%(?!\h\h)/.match?(str)
     str.b.gsub(/\+|%\h\h/, TBLDECWWWCOMP_).force_encoding(enc)
   end
 


### PR DESCRIPTION
`#=~` builds `MatchData`, requiring extra allocations as compared to `#match?`, which returns a boolean without having to build the `MatchData`. We discovered this particular instance while investigating some hotspots in our application code.

Thank you.