### PR TITLE
register_fstring: avoid duping the passed string when possible

### DIFF
--- a/string.c
+++ b/string.c
@@ -305,7 +305,8 @@ fstr_update_callback(st_data_t *key, st_data_t *value, st_data_t arg, int existi
 	    OBJ_FREEZE_RAW(str);
 	}
 	else {
-	    str = str_new_frozen(rb_cString, str);
+	    if (!OBJ_FROZEN(str))
+		str = str_new_frozen(rb_cString, str);
 	    if (STR_SHARED_P(str)) { /* str should not be shared */
 		/* shared substring  */
 		str_make_independent(str);

--- a/test/ruby/test_string.rb
+++ b/test/ruby/test_string.rb
@@ -3187,6 +3187,22 @@ CODE
     assert_same(str, -bar, "uminus deduplicates [Feature #13077]")
   end
 
+  def test_uminus_frozen
+    # embedded
+    str1 = ("foobar" * 3).freeze
+    str2 = ("foobar" * 3).freeze
+    assert_not_same str1, str2
+    assert_same str1, -str1
+    assert_same str1, -str2
+
+    # regular
+    str1 = ("foobar" * 4).freeze
+    str2 = ("foobar" * 4).freeze
+    assert_not_same str1, str2
+    assert_same str1, -str1
+    assert_same str1, -str2
+  end
+
   def test_uminus_no_freeze_not_bare
     str = @cls.new("foo")
     assert_instance_of(@cls, -str)


### PR DESCRIPTION
If the passed string is frozen, bare and not shared, then there is no need to duplicate it.

Ref: 4ab69ebbd7cef8539f687e1f948845d076461dc6
Ref: https://bugs.ruby-lang.org/issues/11386