### PR TITLE
Partial compliance with doc/method_documentation.rdoc in hash.c

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -1837,10 +1837,7 @@ rb_hash_initialize(int argc, VALUE *argv, VALUE hash)
  *    Hash[:foo, 0, :bar, 1] # => {:foo=>0, :bar=>1}
  *
  *  When argument <tt>hash_convertible_object</tt> is given,
- *  the argument must be a
- *  {Hash-convertible object}[doc/implicit_conversion_rdoc.html#label-Hash-Convertible+Objects];
- *  converts the object and returns the resulting \Hash object:
- *
+ *  the argument must be a \Hash:
  *    class Foo
  *      def to_hash
  *        {foo: 0, bar: 1}
@@ -1851,9 +1848,7 @@ rb_hash_initialize(int argc, VALUE *argv, VALUE hash)
  *  ---
  *
  *  Raises an exception if the argument count is 1,
- *  but the argument is not an array of 2-element arrays or a
- *  {Hash-convertible object}[doc/implicit_conversion_rdoc.html#label-Hash-Convertible+Objects]:
- *
+ *  but the argument is not an array of 2-element arrays or a \Hash:
  *    # Raises ArgumentError (odd number of arguments for Hash):
  *    Hash[:foo]
  *    # Raises ArgumentError (invalid number of elements (3 for 1..2)):
@@ -3201,13 +3196,6 @@ rb_hash_aset(VALUE hash, VALUE key, VALUE val)
  *    h1 = h.replace({bat: 3, bam: 4})
  *    h1 # => {:bat=>3, :bam=>4}
  *    h1.equal?(h) # => true # Identity check
- *
- *  ---
- *
- *  Raises an exception if other_hash is not a Hash-convertible object:
- *    h = {}
- *    # Raises TypeError (no implicit conversion of Symbol into Hash):
- *    h.replace(:not_a_hash)
  */
 
 static VALUE
@@ -4360,8 +4348,7 @@ rb_hash_update_block_i(VALUE key, VALUE value, VALUE hash)
  *
  *  Merges each of +other_hashes+ into +self+; returns +self+.
  *
- *  Each argument in +other_hashes+ must be
- *  a {Hash-convertible object}[doc/implicit_conversion_rdoc.html#label-Hash-Convertible+Objects].
+ *  Each argument in +other_hashes+ must be a \Hash.
  *
  *  \Method #update is an alias for \#merge!.
  *
@@ -4418,13 +4405,6 @@ rb_hash_update_block_i(VALUE key, VALUE value, VALUE hash)
  *    h1 = h.merge! { |key, old_value, new_value| raise 'Cannot happen' }
  *    h1 # => {:foo=>0, :bar=>1, :baz=>2}
  *    h1.equal?(h) # => true # Identity check
- *
- *  ---
- *
- *  Raises an exception if any given argument is not a Hash-convertible object:
- *    h = {}
- *    # Raises TypeError (no implicit conversion of Integer into Hash):
- *    h.merge!(1)
  */
 
 static VALUE
@@ -4509,8 +4489,7 @@ rb_hash_update_by(VALUE hash1, VALUE hash2, rb_hash_update_func *func)
  *  Returns the new \Hash formed by merging each of +other_hashes+
  *  into a copy of +self+.
  *
- *  Each argument in +other_hashes+ must be
- *  a {Hash-convertible object}[doc/implicit_conversion_rdoc.html#label-Hash-Convertible+Objects].
+ *  Each argument in +other_hashes+ must be a \Hash.
  *
  *  ---
  *
@@ -4568,13 +4547,6 @@ rb_hash_update_by(VALUE hash1, VALUE hash2, rb_hash_update_func *func)
  *    h2 = h.merge { |key, old_value, new_value| raise 'Cannot happen' }
  *    h2 # => {:foo=>0, :bar=>1, :baz=>2}
  *    h2.equal?(h) # => false # Identity check
- *
- *  ---
- *
- *  Raises an exception if any given argument is not a Hash-convertible object:
- *    h = {}
- *    # Raises TypeError (no implicit conversion of Integer into Hash):
- *    h.merge(1)
  */
 
 static VALUE
@@ -4734,8 +4706,7 @@ flatten_i(VALUE key, VALUE val, VALUE ary)
  *     hash.flatten -> new_array
  *     hash.flatten(level) -> new_array
  *
- *  Argument +level+, if given, must be an
- *  {Integer-convertible object}[doc/implicit_conversion_rdoc.html#label-Integer-Convertible+Objects].
+ *  Argument +level+, if given, must be an \Integer.
  *
  *  Returns a new \Array object that is a 1-dimensional flattening of +self+.
  *
@@ -4761,13 +4732,6 @@ flatten_i(VALUE key, VALUE val, VALUE ary)
  *    h = {foo: 0, bar: [:bat, 3], baz: 2}
  *    h.flatten(0) # => [[:foo, 0], [:bar, [:bat, 3]], [:baz, 2]]
  *    h.flatten(0) == h.to_a # => true
- *
- *  ---
- *
- *  Raises an exception if +level+ is not an \Integer-convertible object:
- *    h = {foo: 0, bar: [:bat, 3], baz: 2}
- *    # Raises TypeError (no implicit conversion of Symbol into Integer):
- *    h.flatten(:nosuch)
  */
 
 static VALUE
@@ -5128,13 +5092,6 @@ hash_le(VALUE hash1, VALUE hash2)
  *    h1 <= h2 # => true
  *    h2 <= h1 # => false
  *    h1 <= h1 # => true
- *
- *  ---
- *
- *  Raises an exception if +other_hash+ is not a
- *  {Hash-convertible object}[doc/implicit_conversion_rdoc.html#label-Hash-Convertible+Objects]:
- *    h = {}
- *    h <= 1 # Raises TypeError (no implicit conversion of Integer into Hash)
  */
 static VALUE
 rb_hash_le(VALUE hash, VALUE other)
@@ -5154,13 +5111,6 @@ rb_hash_le(VALUE hash, VALUE other)
  *    h1 < h2 # => true
  *    h2 < h1 # => false
  *    h1 < h1 # => false
- *
- *  ---
- *
- *  Raises an exception if +other_hash+ is not a
- *  {Hash-convertible object}[doc/implicit_conversion_rdoc.html#label-Hash-Convertible+Objects]:
- *    h = {}
- *    h < 1 # Raises TypeError (no implicit conversion of Integer into Hash)
  */
 static VALUE
 rb_hash_lt(VALUE hash, VALUE other)
@@ -5180,13 +5130,6 @@ rb_hash_lt(VALUE hash, VALUE other)
  *    h1 >= h2 # => true
  *    h2 >= h1 # => false
  *    h1 >= h1 # => true
- *
- *  ---
- *
- *  Raises an exception if +other_hash+ is not a
- *  {Hash-convertible object}[doc/implicit_conversion_rdoc.html#label-Hash-Convertible+Objects]:
- *    h = {}
- *    h >= 1 # Raises TypeError (no implicit conversion of Integer into Hash)
  */
 static VALUE
 rb_hash_ge(VALUE hash, VALUE other)
@@ -5206,13 +5149,6 @@ rb_hash_ge(VALUE hash, VALUE other)
  *    h1 > h2 # => true
  *    h2 > h1 # => false
  *    h1 > h1 # => false
- *
- *  ---
- *
- *  Raises an exception if +other_hash+ is not a
- *  {Hash-convertible object}[doc/implicit_conversion_rdoc.html#label-Hash-Convertible+Objects]:
- *    h = {}
- *    h > 1 # Raises TypeError (no implicit conversion of Integer into Hash)
  */
 static VALUE
 rb_hash_gt(VALUE hash, VALUE other)

--- a/hash.c
+++ b/hash.c
@@ -1810,7 +1810,7 @@ rb_hash_initialize(int argc, VALUE *argv, VALUE hash)
  *    Hash[] -> new_empty_hash
  *    Hash[ [*2_element_arrays] ] -> new_hash
  *    Hash[*objects] -> new_hash
- *    Hash[hash_convertible_object] -> new_hash
+ *    Hash[hash] -> new_hash
  *
  *  Returns a new \Hash object populated with the given objects, if any.
  *
@@ -1836,7 +1836,7 @@ rb_hash_initialize(int argc, VALUE *argv, VALUE hash)
  *    Hash[] # => {}
  *    Hash[:foo, 0, :bar, 1] # => {:foo=>0, :bar=>1}
  *
- *  When argument <tt>hash_convertible_object</tt> is given,
+ *  When argument <tt>hash</tt> is given,
  *  the argument must be a \Hash:
  *    class Foo
  *      def to_hash


### PR DESCRIPTION
Removes references to *-convertible thingies.