### PR TITLE
do not test --version

### DIFF
--- a/spec/ruby/library/rbconfig/rbconfig_spec.rb
+++ b/spec/ruby/library/rbconfig/rbconfig_spec.rb
@@ -59,11 +59,17 @@ describe 'RbConfig::CONFIG' do
       out.should_not be_empty
     end
 
+    require 'tempfile'
     it "['STRIP'] exists and can be executed" do
       strip = RbConfig::CONFIG.fetch('STRIP')
-      out = `#{strip} --version`
-      $?.should.success?
-      out.should_not be_empty
+      Tempfile.open('sh') do |dst|
+        File.open('/bin/sh', 'rb') do |src|
+          IO.copy_stream(src, dst)
+          dst.flush
+          out =`#{strip} #{dst.to_path}`
+          $?.should.success?
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
`llvm-strip-7` is a sane valid strip command that LLVM 7 ships, albeit it does not understand `--version`.  It is a bad idea to check that option.  Instead just see if the command actually strips something.  A copy of `/bin/sh` should suffice.  That file must be ubiquitous.