### PR TITLE
Improve performance of partial backtraces

### DIFF
--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -405,7 +405,6 @@ location_inspect_m(VALUE self)
 
 typedef struct rb_backtrace_struct {
     rb_backtrace_location_t *backtrace;
-    rb_backtrace_location_t *backtrace_base;
     int backtrace_size;
     VALUE strary;
     VALUE locary;
@@ -428,7 +427,7 @@ static void
 backtrace_free(void *ptr)
 {
    rb_backtrace_t *bt = (rb_backtrace_t *)ptr;
-   if (bt->backtrace) ruby_xfree(bt->backtrace_base);
+   if (bt->backtrace) ruby_xfree(bt->backtrace);
    ruby_xfree(bt);
 }
 
@@ -613,10 +612,10 @@ bt_init(void *ptr, size_t size)
     struct bt_iter_arg *arg = (struct bt_iter_arg *)ptr;
     arg->btobj = backtrace_alloc(rb_cBacktrace);
     GetCoreDataFromValue(arg->btobj, rb_backtrace_t, arg->bt);
-    arg->bt->backtrace_base = arg->bt->backtrace = ALLOC_N(rb_backtrace_location_t, size+1);
+    arg->bt->backtrace = ALLOC_N(rb_backtrace_location_t, size+1);
     arg->bt->backtrace_size = 1;
     arg->prev_cfp = NULL;
-    arg->init_loc = &arg->bt->backtrace_base[size];
+    arg->init_loc = &arg->bt->backtrace[size];
     arg->init_loc->type = 0;
 }
 

--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -612,11 +612,10 @@ bt_init(void *ptr, size_t size)
     struct bt_iter_arg *arg = (struct bt_iter_arg *)ptr;
     arg->btobj = backtrace_alloc(rb_cBacktrace);
     GetCoreDataFromValue(arg->btobj, rb_backtrace_t, arg->bt);
-    arg->bt->backtrace = ALLOC_N(rb_backtrace_location_t, size+1);
+    arg->bt->backtrace = ZALLOC_N(rb_backtrace_location_t, size+1);
     arg->bt->backtrace_size = 1;
     arg->prev_cfp = NULL;
     arg->init_loc = &arg->bt->backtrace[size];
-    arg->init_loc->type = 0;
 }
 
 static void

--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -90,7 +90,6 @@ typedef struct rb_backtrace_location_struct {
 	LOCATION_TYPE_ISEQ = 1,
 	LOCATION_TYPE_ISEQ_CALCED,
 	LOCATION_TYPE_CFUNC,
-	LOCATION_TYPE_IFUNC
     } type;
 
     union {
@@ -129,7 +128,6 @@ location_mark_entry(rb_backtrace_location_t *fi)
 	rb_gc_mark_movable((VALUE)fi->body.iseq.iseq);
 	break;
       case LOCATION_TYPE_CFUNC:
-      case LOCATION_TYPE_IFUNC:
       default:
 	break;
     }
@@ -199,7 +197,6 @@ location_label(rb_backtrace_location_t *loc)
 	return loc->body.iseq.iseq->body->location.label;
       case LOCATION_TYPE_CFUNC:
 	return rb_id2str(loc->body.cfunc.mid);
-      case LOCATION_TYPE_IFUNC:
       default:
 	rb_bug("location_label: unreachable");
 	UNREACHABLE;
@@ -248,7 +245,6 @@ location_base_label(rb_backtrace_location_t *loc)
 	return loc->body.iseq.iseq->body->location.base_label;
       case LOCATION_TYPE_CFUNC:
 	return rb_id2str(loc->body.cfunc.mid);
-      case LOCATION_TYPE_IFUNC:
       default:
 	rb_bug("location_base_label: unreachable");
 	UNREACHABLE;
@@ -278,7 +274,6 @@ location_path(rb_backtrace_location_t *loc)
 	    return location_path(loc->body.cfunc.prev_loc);
 	}
 	return Qnil;
-      case LOCATION_TYPE_IFUNC:
       default:
 	rb_bug("location_path: unreachable");
 	UNREACHABLE;
@@ -311,7 +306,6 @@ location_realpath(rb_backtrace_location_t *loc)
 	    return location_realpath(loc->body.cfunc.prev_loc);
 	}
 	return Qnil;
-      case LOCATION_TYPE_IFUNC:
       default:
 	rb_bug("location_realpath: unreachable");
 	UNREACHABLE;
@@ -376,7 +370,6 @@ location_to_str(rb_backtrace_location_t *loc)
 	}
 	name = rb_id2str(loc->body.cfunc.mid);
 	break;
-      case LOCATION_TYPE_IFUNC:
       default:
 	rb_bug("location_to_str: unreachable");
     }
@@ -440,7 +433,6 @@ location_update_entry(rb_backtrace_location_t *fi)
 	fi->body.iseq.iseq = (rb_iseq_t*)rb_gc_location((VALUE)fi->body.iseq.iseq);
 	break;
       case LOCATION_TYPE_CFUNC:
-      case LOCATION_TYPE_IFUNC:
       default:
 	break;
     }

--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -129,10 +129,6 @@ location_mark_entry(rb_backtrace_location_t *fi)
 	rb_gc_mark_movable((VALUE)fi->body.iseq.iseq);
 	break;
       case LOCATION_TYPE_CFUNC:
-        if (fi->body.cfunc.prev_loc) {
-            location_mark_entry(fi->body.cfunc.prev_loc);
-        }
-        break;
       case LOCATION_TYPE_IFUNC:
       default:
 	break;


### PR DESCRIPTION
Revised attempt of #3357 after it was reverted at 4fc6cfbeae3c86e8f3675c70b417356ecd3d4a56.  This removes a change in `location_mark_entry` (called by `backtrace_mark`, which was in all of the CI failure backtraces).