### PR TITLE
Finalizer capture warning

### DIFF
--- a/include/ruby/internal/intern/proc.h
+++ b/include/ruby/internal/intern/proc.h
@@ -46,6 +46,7 @@ VALUE rb_method_call_with_block(int, const VALUE *, VALUE, VALUE);
 VALUE rb_method_call_with_block_kw(int, const VALUE *, VALUE, VALUE, int);
 int rb_mod_method_arity(VALUE, ID);
 int rb_obj_method_arity(VALUE, ID);
+VALUE rb_callable_receiver(VALUE);
 VALUE rb_protect(VALUE (*)(VALUE), VALUE, int*);
 
 RBIMPL_SYMBOL_EXPORT_END()

--- a/proc.c
+++ b/proc.c
@@ -2739,6 +2739,18 @@ rb_obj_method_arity(VALUE obj, ID id)
     return rb_mod_method_arity(CLASS_OF(obj), id);
 }
 
+VALUE
+rb_callable_receiver(VALUE callable) {
+    if (rb_obj_is_proc(callable)) {
+        VALUE binding = rb_funcall(callable, rb_intern("binding"), 0);
+        return rb_funcall(binding, rb_intern("receiver"), 0);
+    } else if (rb_obj_is_method(callable)) {
+        return method_receiver(callable);
+    } else {
+        return Qundef;
+    }
+}
+
 const rb_method_definition_t *
 rb_method_def(VALUE method)
 {

--- a/spec/ruby/core/objectspace/define_finalizer_spec.rb
+++ b/spec/ruby/core/objectspace/define_finalizer_spec.rb
@@ -1,24 +1,42 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
-# NOTE: A call to define_finalizer does not guarantee that the
-# passed proc or callable will be called at any particular time.
+# Why do we not test that finalizers are run by the GC? The documentation
+# says that finalizers are never guaranteed to be run, so we can't
+# spec that they are. On some implementations of Ruby the finalizers may
+# run asyncronously, meaning that we can't predict when they'll run,
+# even if they were guaranteed to do so. Even on MRI finalizers can be
+# very unpredictable, due to conservative stack scanning and references
+# left in unused memory.
+
 describe "ObjectSpace.define_finalizer" do
   it "raises an ArgumentError if the action does not respond to call" do
     -> {
-      ObjectSpace.define_finalizer("", mock("ObjectSpace.define_finalizer no #call"))
+      ObjectSpace.define_finalizer(Object.new, mock("ObjectSpace.define_finalizer no #call"))
     }.should raise_error(ArgumentError)
   end
 
   it "accepts an object and a proc" do
-    handler = -> obj { obj }
-    ObjectSpace.define_finalizer("garbage", handler).should == [0, handler]
+    handler = -> id { id }
+    ObjectSpace.define_finalizer(Object.new, handler).should == [0, handler]
+  end
+
+  it "accepts an object and a bound method" do
+    handler = mock("callable")
+    def handler.finalize(id) end
+    finalize = handler.method(:finalize)
+    ObjectSpace.define_finalizer(Object.new, finalize).should == [0, finalize]
   end
 
   it "accepts an object and a callable" do
     handler = mock("callable")
-    def handler.call(obj) end
-    ObjectSpace.define_finalizer("garbage", handler).should == [0, handler]
+    def handler.call(id) end
+    ObjectSpace.define_finalizer(Object.new, handler).should == [0, handler]
+  end
+
+  it "accepts an object and a block" do
+    handler = -> id { id }
+    ObjectSpace.define_finalizer(Object.new, &handler).should == [0, handler]
   end
 
   it "raises ArgumentError trying to define a finalizer on a non-reference" do
@@ -31,7 +49,7 @@ describe "ObjectSpace.define_finalizer" do
   it "calls finalizer on process termination" do
     code = <<-RUBY
       def scoped
-        Proc.new { puts "finalized" }
+        Proc.new { puts "finalizer run" }
       end
       handler = scoped
       obj = "Test"
@@ -39,18 +57,104 @@ describe "ObjectSpace.define_finalizer" do
       exit 0
     RUBY
 
-    ruby_exe(code).should == "finalized\n"
+    ruby_exe(code, :args => "2>&1").should include("finalizer run\n")
   end
 
-  it "calls finalizer at exit even if it is self-referencing" do
+  ruby_version_is "2.8" do
+    it "warns if the finalizer has the object as the receiver" do
+      code = <<-RUBY
+        class CapturesSelf
+          def initialize
+            ObjectSpace.define_finalizer(self, proc {
+              puts "finalizer run"
+            })
+          end
+        end
+        CapturesSelf.new
+        exit 0
+      RUBY
+
+      ruby_exe(code, :args => "2>&1").should include("warning: finalizer references object to be finalized\n")
+    end
+
+    it "warns if the finalizer is a method bound to the receiver" do
+      code = <<-RUBY
+        class CapturesSelf
+          def initialize
+            ObjectSpace.define_finalizer(self, method(:finalize))
+          end
+          def finalize(id)
+            puts "finalizer run"
+          end
+        end
+        CapturesSelf.new
+        exit 0
+      RUBY
+
+      ruby_exe(code, :args => "2>&1").should include("warning: finalizer references object to be finalized\n")
+    end
+
+    it "warns if the finalizer was a block in the reciever" do
+      code = <<-RUBY
+        class CapturesSelf
+          def initialize
+            ObjectSpace.define_finalizer(self) do
+              puts "finalizer run"
+            end
+          end
+        end
+        CapturesSelf.new
+        exit 0
+      RUBY
+
+      ruby_exe(code, :args => "2>&1").should include("warning: finalizer references object to be finalized\n")
+    end
+  end
+
+  it "calls a finalizer at exit even if it is self-referencing" do
     code = <<-RUBY
       obj = "Test"
-      handler = Proc.new { puts "finalized" }
+      handler = Proc.new { puts "finalizer run" }
       ObjectSpace.define_finalizer(obj, handler)
       exit 0
     RUBY
 
-    ruby_exe(code).should == "finalized\n"
+    ruby_exe(code).should include("finalizer run\n")
+  end
+
+  it "calls a finalizer at exit even if it is indirectly self-referencing" do
+    code = <<-RUBY
+      class CapturesSelf
+        def initialize
+          ObjectSpace.define_finalizer(self, finalizer(self))
+        end
+        def finalizer(zelf)
+          proc do
+            puts "finalizer run"
+          end
+        end
+      end
+      CapturesSelf.new
+      exit 0
+    RUBY
+
+    ruby_exe(code, :args => "2>&1").should include("finalizer run\n")
+  end
+
+  it "calls a finalizer defined in a finalizer running at exit" do
+    code = <<-RUBY
+      obj = "Test"
+      handler = Proc.new do
+        obj2 = "Test"
+        handler2 = Proc.new { puts "finalizer 2 run" }
+        ObjectSpace.define_finalizer(obj2, handler2)
+        exit 0
+      end
+      ObjectSpace.define_finalizer(obj, handler)
+      exit 0
+    RUBY
+
+    ruby_exe(code, :args => "2>&1").should include("finalizer 2 run\n")
   end
 
   it "allows multiple finalizers with different 'callables' to be defined" do


### PR DESCRIPTION
Feature https://bugs.ruby-lang.org/issues/15974.

The idea of this feature is to warn when a finalizer captures the object to be finalized, because this prevents the finalizer being run until the process exits, which is likely not what is intended. This PR covers the most simple and common case, where the receiver of the finalizer is the object to be finalized.

It's easy to do this https://www.mikeperham.com/2010/02/24/the-trouble-with-ruby-finalizers/ and I've done it myself before.

I originally implemented this feature in #2264, but there I tired to solve the general case of warning if the finalizer transitively captured the object to be finalized, by using the GC's mechanism to walk the object graph. That's useful, but impactical. This PR is simple, easy, can always be on, and will capture what I would guess is the most common case. The original implementation was also part of a hack-day, so was very rough, which is why it got reverted in 23c92b6f820f670994026423d4c7b5abcf51eafa, which was understandable.

I've also improved the specification and documentation of `ObjectSpace.define_finalizer`.

Overall, this is the idea:

```ruby
class CapturesSelf
  def initialize(name)
    ObjectSpace.define_finalizer(self, proc {
      # this finalizer will only be run on exit because it has captured self
      puts "finalizing #{name}"
    })
  end
end

CapturesSelf.new('foo')
```

```
./test.rb:3: warning: finalizer references object to be finalized
```