### PR TITLE
Fix erb executable

### DIFF
--- a/libexec/erb
+++ b/libexec/erb
@@ -171,6 +171,4 @@ EOU
   end
 end
 
-if __FILE__ == $0
-  ERB::Main.run
-end
+ERB::Main.run


### PR DESCRIPTION
This adds erb exectuable to erb's gemspec. It wasn't copied in "make install" since commit 8c97883b738ad9749848d9a10fce87df0f9b1bf3 .

Also run ERb processing unconditionally since `__FILE__` and `$0` doesn't match in a gem context.

I noticed it in RubyInstaller-CI [here](https://ci.appveyor.com/project/larskanis/rubyinstaller2-hbuor/builds/34808124/job/a331hmwi8ffp7frw#L26058). The [patched](https://github.com/oneclick/rubyinstaller2-packages/commit/7a35a9c85c30496797a5c7202367da4c6e1b4a11) version succeeds.

Error is:
```
$ erb
C:/Ruby28-x64/lib/ruby/2.8.0/rubygems.rb:277:in `find_spec_for_exe': can't find gem erb (>= 0.a) with executable erb (Gem::GemNotFoundException)
        from C:/Ruby28-x64/lib/ruby/2.8.0/rubygems.rb:296:in `activate_bin_path'
        from C:/Ruby28-x64/bin/erb.cmd:31:in `<main>'
```
