### PR TITLE
Add support for IPv6 link local addresses to resolv

### DIFF
--- a/lib/resolv.rb
+++ b/lib/resolv.rb
@@ -2460,13 +2460,38 @@ class Resolv
       \z/x
 
     ##
+    # IPv6 link local address format fe80:b:c:d:e:f:g:h%em1
+    Regex_8HexLinkLocal = /\A
+      fe80
+      (?::[0-9A-Fa-f]{1,4}){7}
+      %[0-9A-Za-z]+
+      \z/x
+
+    ##
+    # Compressed IPv6 link local address format fe80::b%em1
+
+    Regex_CompressedHexLinkLocal = /\A
+      fe80:
+      (?:
+        ((?:[0-9A-Fa-f]{1,4}(?::[0-9A-Fa-f]{1,4})*)?) ::
+        ((?:[0-9A-Fa-f]{1,4}(?::[0-9A-Fa-f]{1,4})*)?)
+        |
+        :((?:[0-9A-Fa-f]{1,4}(?::[0-9A-Fa-f]{1,4})*)?)
+      )?
+      :[0-9A-Fa-f]{1,4}%[0-9A-Za-z]+
+      \z/x
+
+    ##
     # A composite IPv6 address Regexp.
 
     Regex = /
       (?:#{Regex_8Hex}) |
       (?:#{Regex_CompressedHex}) |
       (?:#{Regex_6Hex4Dec}) |
-      (?:#{Regex_CompressedHex4Dec})/x
+      (?:#{Regex_CompressedHex4Dec}) |
+      (?:#{Regex_8HexLinkLocal}) |
+      (?:#{Regex_CompressedHexLinkLocal})
+      /x
 
     ##
     # Creates a new IPv6 address from +arg+ which may be:

--- a/test/resolv/test_addr.rb
+++ b/test/resolv/test_addr.rb
@@ -16,6 +16,25 @@ class TestResolvAddr < Test::Unit::TestCase
     }
   end
 
+  def test_valid_ipv6_link_local_address
+    bug17112 = "[ruby-core:99539]"
+    assert_not_match(Resolv::IPv6::Regex, "fe80::1%", bug17112)
+    assert_not_match(Resolv::IPv6::Regex, "fe80:2:3:4:5:6:7:8%", bug17112)
+    assert_not_match(Resolv::IPv6::Regex, "fe90::1%em1", bug17112)
+    assert_not_match(Resolv::IPv6::Regex, "1:2:3:4:5:6:7:8%em1", bug17112)
+    assert_match(Resolv::IPv6::Regex, "fe80:2:3:4:5:6:7:8%em1", bug17112)
+    assert_match(Resolv::IPv6::Regex, "fe80::20d:3aff:fe7d:9760%eth0", bug17112)
+    assert_match(Resolv::IPv6::Regex, "fe80::1%em1", bug17112)
+  end
+
+  def test_valid_socket_ip_address_list
+    Socket.ip_address_list.each do |addr|
+      ip = addr.ip_address
+      assert_match(Resolv::AddressRegex, ip)
+      assert_equal(ip, Resolv.getaddress(ip))
+    end
+  end
+
   def test_invalid_byte_comment
     bug9273 = '[ruby-core:59239] [Bug #9273]'
     Tempfile.create('resolv_test_addr_') do |tmpfile|


### PR DESCRIPTION
Now that it should work correctly, test that every address returned
by Socket.ip_address_list is resolvable.

Socket works with IPv6 link local addresses, and ipaddr now does
as well, so I think resolv should support them.

Fixes [Bug #17112]