### PR TITLE
[stringio] fix stringio codepoint enumerator off by one error

### DIFF
--- a/ext/stringio/stringio.c
+++ b/ext/stringio/stringio.c
@@ -1095,8 +1095,8 @@ strio_each_codepoint(VALUE self)
 
 	c = rb_enc_codepoint_len(RSTRING_PTR(ptr->string)+ptr->pos,
 				 RSTRING_END(ptr->string), &n, enc);
-	rb_yield(UINT2NUM(c));
 	ptr->pos += n;
+	rb_yield(UINT2NUM(c));
     }
     return self;
 }

--- a/test/ruby/test_io.rb
+++ b/test/ruby/test_io.rb
@@ -405,6 +405,19 @@ class TestIO < Test::Unit::TestCase
     }
   end
 
+  def test_each_codepoint_enumerator
+    make_tempfile {|t|
+      a = ""
+      b = ""
+      File.open(t, 'rt') {|f|
+        a = f.each_codepoint.take(4).pack('U*')
+        b = f.read(8)
+      }
+      assert_equal("foo\n", a)
+      assert_equal("bar\nbaz\n", b)
+    }
+  end
+
   def test_codepoints
     make_tempfile {|t|
       bug2959 = '[ruby-core:28650]'

--- a/test/stringio/test_stringio.rb
+++ b/test/stringio/test_stringio.rb
@@ -525,6 +525,16 @@ class TestStringIO < Test::Unit::TestCase
     assert_equal([49, 50, 51, 52], f.each_codepoint.to_a)
   end
 
+  def test_each_codepoint_enumerator
+    io = StringIO.new('你好построить')
+
+    chinese_part = io.each_codepoint.take(2).pack('U*')
+    russian_part = io.read(40).force_encoding('UTF-8')
+
+    assert_equal("你好", chinese_part)
+    assert_equal("построить", russian_part)
+  end
+
   def test_gets2
     f = StringIO.new("foo\nbar\nbaz\n")
     assert_equal("fo", f.gets(2))


### PR DESCRIPTION
**Context**

When working with a `StringIO` I wanted to read the first n codepoints in one variable and read the end of the buffer in another variable

**Example**

```ruby
require 'stringio'

io = StringIO.new('你好построить')

io.rewind

puts io.each_codepoint.take(2).pack('U*')
puts io.read(40).force_encoding('UTF-8')

io.rewind

puts io.each_codepoint.take(3).pack('U*')
puts io.read(40).force_encoding('UTF-8')
```

**Expected result**

I expect the result to be

```
你好
построить
你好п
остроить
```

**Actual results**

```
ylecuyer@inwin:~$ ruby --version
ruby 2.5.3p105 (2018-10-18 revision 65156) [x86_64-linux]
ylecuyer@inwin:~$ ruby ruby_utf8.rb 
你好
好построить
你好п
построить
```

```
ylecuyer@inwin:~$ ruby --version
ruby 2.7.1p83 (2020-03-31 revision a0c7c23c9c) [x86_64-linux]
ylecuyer@inwin:~$ ruby ruby_utf8.rb 
你好
好построить
你好п
построить
```

```
ylecuyer@inwin:~$ ruby --version
ruby 2.8.0dev (2020-08-26T12:36:22Z master 445e5548c9) [x86_64-linux]
ylecuyer@inwin:~$ ruby ruby_utf8.rb 
你好
好построить
你好п
построить
```

**With fix**

```
ylecuyer@inwin:~/Projects/ruby$ ./ruby --version
ruby 2.8.0dev (2020-08-26T20:46:58Z fix-codepoint-off-.. 94c1bd786a) [x86_64-linux]
ylecuyer@inwin:~/Projects/ruby$ make runruby
./miniruby -I./lib -I. -I.ext/common  ./tool/runruby.rb --extout=.ext  -- --disable-gems ./test.rb
你好
построить
你好п
остроить
```