### PR TITLE
Update heap_pages_himem after freeing pages

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -1752,6 +1752,12 @@ heap_pages_free_unused_pages(rb_objspace_t *objspace)
 		j++;
 	    }
 	}
+
+        struct heap_page *hipage = heap_pages_sorted[heap_allocated_pages - 1];
+        RVALUE *himem = hipage->start + hipage->total_slots;
+        GC_ASSERT(himem <= heap_pages_himem);
+        heap_pages_himem = himem;
+
 	GC_ASSERT(j == heap_allocated_pages);
     }
 }


### PR DESCRIPTION
Currently, `heap_pages_himem` is only updated when allocating a new page, but not when we free a page. This PR updates `heap_pages_himem` to the high address in the heap after freeing unused pages. This can also potentially improve the performance of `is_pointer_to_heap`, since if a pointer is outside of the addresses between `heap_pages_lomem` and `heap_pages_himem` then it could return without doing binary search.

NOTE: `heap_pages_lomem` does not need to be updated because the lowest page is not freed.