### PR TITLE
Fix error message for wb unprotected objects count

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -6328,7 +6328,7 @@ gc_verify_internal_consistency(rb_objspace_t *objspace)
                    objspace->rgengc.old_objects, data.old_object_count);
 	}
 	if (objspace->rgengc.uncollectible_wb_unprotected_objects != data.remembered_shady_count) {
-	    rb_bug("inconsistent old slot number: expect %"PRIuSIZE", but %"PRIuSIZE".",
+            rb_bug("inconsistent number of wb unprotected objects: expect %"PRIuSIZE", but %"PRIuSIZE".",
                    objspace->rgengc.uncollectible_wb_unprotected_objects, data.remembered_shady_count);
 	}
     }


### PR DESCRIPTION
This error message seems to be about wb unprotected count rather than the number of old slots. The error message is the same as the one above it, so it's difficult to determine which line it crashed on.