### PR TITLE
add deprecated warning in Kernel#iterator? method [Feature #17133]

### DIFF
--- a/vm_eval.c
+++ b/vm_eval.c
@@ -2346,6 +2346,13 @@ rb_f_block_given_p(VALUE _)
     }
 }
 
+static VALUE
+rb_f_iterator_p(VALUE _)
+{
+    rb_warn_deprecated("iterator?", "block_given?");
+    return rb_f_block_given_p(_);
+}
+
 VALUE
 rb_current_realfilepath(void)
 {
@@ -2361,7 +2368,7 @@ Init_vm_eval(void)
 {
     rb_define_global_function("eval", rb_f_eval, -1);
     rb_define_global_function("local_variables", rb_f_local_variables, 0);
-    rb_define_global_function("iterator?", rb_f_block_given_p, 0);
+    rb_define_global_function("iterator?", rb_f_iterator_p, 0);
     rb_define_global_function("block_given?", rb_f_block_given_p, 0);
 
     rb_define_global_function("catch", rb_f_catch, -1);


### PR DESCRIPTION
ref: [Feature #17133 Add deprecate warning Kernel#iterator?](https://bugs.ruby-lang.org/issues/17133)