### PR TITLE
Add Enumerable#one method to return a single element from the collection

### DIFF
--- a/enum.c
+++ b/enum.c
@@ -1658,7 +1658,7 @@ rb_nmin_run(VALUE obj, VALUE num, int by, int rev, int ary)
  *
  */
 static VALUE
-enum_one(int argc, VALUE *argv, VALUE obj)
+enum_one_p(int argc, VALUE *argv, VALUE obj)
 {
     struct MEMO *memo = MEMO_ENUM_NEW(Qundef);
     VALUE result;
@@ -1668,6 +1668,53 @@ enum_one(int argc, VALUE *argv, VALUE obj)
     result = memo->v1;
     if (result == Qundef) return Qfalse;
     return result;
+}
+
+/*
+ *  call-seq:
+ *     enum.one                           -> object
+ *     enum.one(default_value)            -> object
+ *     enum.one { ... }                   -> object
+ *
+ *  Returns one and only one item. Raises an error if there are none or more than one.
+ *     [99].one             #=> 99
+ *     [].one               #=> RuntimeError: collection is empty
+ *     [99, 100].one        #=> RuntimeError: collection contains more than one item
+ *
+ *  If collection is empty and no block was given, returns +default_value+:
+ *     [].one(99)           #=> 99
+ *
+ * If collection is empty and a block was given, returns the block's return value:
+ *     [].one { 99 }        #=> 99
+ */
+static VALUE
+enum_one(int argc, VALUE* argv, VALUE obj)
+{
+    VALUE default_val, result;
+    struct MEMO *memo = MEMO_ENUM_NEW(Qundef);
+
+    rb_scan_args(argc, argv, "01", &default_val);
+    if (rb_block_given_p() && argc == 1) {
+        rb_warn("block supersedes default value argument");
+    }
+
+    rb_block_call(obj, id_each, 0, 0, one_i, (VALUE)memo);
+    result = memo->v1;
+
+    if (result == Qundef) {
+        if (rb_block_given_p()) {
+            return rb_yield(Qundef);
+        }
+        else if (!NIL_P(default_val)) {
+            return default_val;
+        }
+        rb_raise(rb_eRuntimeError, "collection is empty");
+    }
+    else if (result == Qfalse) {
+        rb_raise(rb_eRuntimeError, "collection contains more than one item");
+    }
+
+    return enum_first(0, 0, obj);
 }
 
 DEFINE_ENUMFUNCS(none)
@@ -4206,7 +4253,8 @@ Init_Enumerable(void)
     rb_define_method(rb_mEnumerable, "first", enum_first, -1);
     rb_define_method(rb_mEnumerable, "all?", enum_all, -1);
     rb_define_method(rb_mEnumerable, "any?", enum_any, -1);
-    rb_define_method(rb_mEnumerable, "one?", enum_one, -1);
+    rb_define_method(rb_mEnumerable, "one?", enum_one_p, -1);
+    rb_define_method(rb_mEnumerable, "one", enum_one, -1);
     rb_define_method(rb_mEnumerable, "none?", enum_none, -1);
     rb_define_method(rb_mEnumerable, "min", enum_min, -1);
     rb_define_method(rb_mEnumerable, "max", enum_max, -1);

--- a/test/ruby/test_enum.rb
+++ b/test/ruby/test_enum.rb
@@ -465,7 +465,7 @@ class TestEnumerable < Test::Unit::TestCase
     EOS
   end
 
-  def test_one
+  def test_one_p
     assert(@obj.one? {|x| x == 3 })
     assert(!(@obj.one? {|x| x == 1 }))
     assert(!(@obj.one? {|x| x == 4 }))
@@ -484,7 +484,7 @@ class TestEnumerable < Test::Unit::TestCase
     assert([ nil, true, 99 ].one?(Integer))
   end
 
-  def test_one_with_unused_block
+  def test_one_p_with_unused_block
     assert_in_out_err [], <<-EOS, [], ["-:1: warning: given block not used"]
       [1, 2].one?(1) {|x| x == 3 }
     EOS
@@ -497,6 +497,24 @@ class TestEnumerable < Test::Unit::TestCase
     assert_in_out_err [], <<-EOS, [], ["-:1: warning: given block not used"]
       {a: 1, b: 2}.one?([:b, 2]) {|x| x == 4 }
     EOS
+  end
+
+  def test_one
+    assert_equal(42, [42].one)
+    assert_raise_with_message(RuntimeError, "collection is empty") do
+      [].one
+    end
+    assert_raise_with_message(RuntimeError, "collection contains more than one item") do
+      [42, 43].one
+    end
+  end
+
+  def test_one_default
+    assert_in_out_err [], <<-EOS, [], ["-:1: warning: block supersedes default value argument"]
+      [].one(42) { 42 }
+    EOS
+    assert_equal(42, [].one(42))
+    assert_equal(42, [].one { 42 })
   end
 
   def test_none


### PR DESCRIPTION
Relevant issue - https://bugs.ruby-lang.org/issues/13683

```ruby
# Returns one and only one item. Raises an error if there are none or more than one.
[99].one            #=> 99
[].one              #=> RuntimeError: collection is empty
[99, 100].one       #=> RuntimeError: collection contains more than one item

# If collection is empty and no block was given, returns default value:
[].one(99)          #=> 99

# If collection is empty and a block was given, returns the block's return value:
[].one { 99 }       #=> 99
```