### PR TITLE
Prohibit setter method names in endless method definition

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -2474,6 +2474,9 @@ arg		: lhs '=' arg_rhs
 		    }
 		| defn_head f_paren_args '=' arg
 		    {
+			if (is_attrset_id($<node>1->nd_mid)) {
+			    yyerror1(&@1, "setter method cannot be defined in an endless method definition");
+			}
 			token_info_drop(p, "def", @1.beg_pos);
 			restore_defun(p, $<node>1->nd_defn);
 		    /*%%%*/

--- a/test/ruby/test_syntax.rb
+++ b/test/ruby/test_syntax.rb
@@ -1429,6 +1429,7 @@ eom
     end
     assert_equal("class ok", k.rescued("ok"))
     assert_equal("instance ok", k.new.rescued("ok"))
+    assert_syntax_error('def foo=() = 42', /setter method cannot be defined in an endless method definition/)
   end
 
   def test_methoddef_in_cond


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/16746#note-26