### PR TITLE
Add null terminating character to prelude strings

### DIFF
--- a/template/prelude.c.tmpl
+++ b/template/prelude.c.tmpl
@@ -64,6 +64,7 @@ class Prelude
       end
       lines << [line, comment]
     end
+    lines[-1][0] += "\x0"
     result
   end
 end


### PR DESCRIPTION
The current prelude code structs do not have space for a null terminating character. This means that the Ruby string generated in `PRELUDE_CODE` points to a string that potentially does not have a null terminator (even if it does, it's out of bounds). This string is used to build the ast using `PRELUDE_AST` and `rb_builtin_ast`.

For example:

Before:
```c
static const char prelude_name0[] = "<internal:ast>";
static const struct {
    char L0[507]; /* 1..106 */
    char L106[361]; /* 107..147 */
} prelude_code0 = {
#line 1 "ast.rb"
"class RubyVM\n"
...
"end\n"
#line 607 "miniprelude.c"
};
```

After:
```c
static const char prelude_name0[] = "<internal:ast>";
static const struct {
    char L0[507]; /* 1..106 */
    char L106[362]; /* 107..147 */
} prelude_code0 = {
#line 1 "ast.rb"
"class RubyVM\n"
...
"end\n\0"
#line 607 "miniprelude.c"
};
```

The new `prelude_code0` struct is larger by a byte to store the null terminator.