### PR TITLE
Initialize new T_OBJECT as ROBJECT_EMBED to improve ivar performance

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -2368,6 +2368,13 @@ rb_imemo_new_debug(enum imemo_type type, VALUE v1, VALUE v2, VALUE v3, VALUE v0,
 #endif
 
 VALUE
+rb_class_allocate_instance(VALUE klass)
+{
+    VALUE flags = T_OBJECT | ROBJECT_EMBED;
+    return newobj_of(klass, flags, Qundef, Qundef, Qundef, RGENGC_WB_PROTECTED_OBJECT);
+}
+
+VALUE
 rb_data_object_wrap(VALUE klass, void *datap, RUBY_DATA_FUNC dmark, RUBY_DATA_FUNC dfree)
 {
     RUBY_ASSERT_ALWAYS(dfree != (RUBY_DATA_FUNC)1);

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -78,6 +78,7 @@ RUBY_ATTR_MALLOC void *rb_xcalloc_mul_add_mul(size_t, size_t, size_t, size_t);
 static inline void *ruby_sized_xrealloc_inlined(void *ptr, size_t new_size, size_t old_size) RUBY_ATTR_RETURNS_NONNULL RUBY_ATTR_ALLOC_SIZE((2));
 static inline void *ruby_sized_xrealloc2_inlined(void *ptr, size_t new_count, size_t elemsiz, size_t old_count) RUBY_ATTR_RETURNS_NONNULL RUBY_ATTR_ALLOC_SIZE((2, 3));
 static inline void ruby_sized_xfree_inlined(void *ptr, size_t size);
+VALUE rb_class_allocate_instance(VALUE klass);
 
 RUBY_SYMBOL_EXPORT_BEGIN
 /* gc.c (export) */

--- a/object.c
+++ b/object.c
@@ -2102,13 +2102,6 @@ rb_obj_alloc(VALUE klass)
     return rb_class_alloc(klass);
 }
 
-static VALUE
-rb_class_allocate_instance(VALUE klass)
-{
-    NEWOBJ_OF(obj, struct RObject, klass, T_OBJECT | (RGENGC_WB_PROTECTED_OBJECT ? FL_WB_PROTECTED : 0));
-    return (VALUE)obj;
-}
-
 /*
  *  call-seq:
  *     class.new(args, ...)    ->  obj


### PR DESCRIPTION
@tenderlove discovered that that the first ivar set on an object never used the inline cache. What was happening was that when an object was first initialized, the ROBJECT_EMBED flag isn't set. This means that for brand new objects, `ROBJECT_NUMIV(obj)` is `0` and `ROBJECT_IV_INDEX_TBL(obj)` is `NULL`.

This combination meant that the inline cache would never be initialized when setting an ivar on an object for the first time since `iv_index_tbl` was `NULL`, and if it were it would never be used because `ROBJECT_NUMIV` was `0`. Both cases always fell through to the generic `rb_ivar_set` which would then set the `ROBJECT_EMBED` flag and initialize the ivar array.

This commit changes `rb_class_allocate_instance` to set the `ROBJECT_EMBED` flag on the object initially and to initialize all members of the embedded array to `Qundef`. This allows the inline cache to be set correctly on first use and to be used on future uses. This also emits the faster version of the ivar code when using MJIT.

This moves `rb_class_allocate_instance` to gc.c, so that it has access to `newobj_of`. This seems appropriate given that there are other allocating methods in this file (ex. `rb_data_object_wrap`, `rb_imemo_new`).

**Benchmark**

```
require "benchmark/ips"

class InitIV
  def initialize
    @a = nil
  end
end

Benchmark.ips do |x|
  x.report "InitIV.new", "InitIV.new"
end
```

**Before**

```
Warming up --------------------------------------
          InitIV.new   799.029k i/100ms
Calculating -------------------------------------
          InitIV.new      8.001M (± 0.1%) i/s -     40.750M in   5.093022s
```

**After**

```
Warming up --------------------------------------
          InitIV.new   960.870k i/100ms
Calculating -------------------------------------
          InitIV.new      9.585M (± 0.2%) i/s -     48.044M in   5.012177s
```