### PR TITLE
Don't read past the end of the Ruby string in rb_raw_obj_info

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -11667,7 +11667,7 @@ rb_raw_obj_info(char *buff, const int buff_size, VALUE obj)
             }
 	    break;
 	  case T_STRING: {
-            APPENDF((BUFF_ARGS, "%s", RSTRING_PTR(obj)));
+            APPENDF((BUFF_ARGS, "%.*s", (int)RSTRING_LEN(obj), RSTRING_PTR(obj)));
 	    break;
 	  }
           case T_MOVED: {


### PR DESCRIPTION
Ruby strings don't always have a null terminator, so we can't use it as a regular C string. By reading only the first `len` bytes of the Ruby string, we won't read past the end of the Ruby string.