### PR TITLE
Interpolated strings are no longer frozen with frozen-string-literal: true

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -80,6 +80,9 @@ sufficient information, see the ChangeLog file or Redmine
     def square(x) = x * x
     ```
 
+* Interpolated String literals are no longer frozen when
+  `# frozen-string-literal: true` is used. [[Feature #17104]]
+
 ## Command line options
 
 ### `--help` option
@@ -373,6 +376,7 @@ Excluding feature bug fixes.
 [Feature #16746]: https://bugs.ruby-lang.org/issues/16746
 [Feature #16754]: https://bugs.ruby-lang.org/issues/16754
 [Feature #16828]: https://bugs.ruby-lang.org/issues/16828
+[Feature #17104]: https://bugs.ruby-lang.org/issues/17104
 [Misc #16961]:    https://bugs.ruby-lang.org/issues/16961
 [Feature #17122]: https://bugs.ruby-lang.org/issues/17122
 [GH-2991]:        https://github.com/ruby/ruby/pull/2991

--- a/bootstraptest/test_insns.rb
+++ b/bootstraptest/test_insns.rb
@@ -89,8 +89,6 @@ tests = [
   [ 'putiseq',                  %q{ -> { true }.() }, ],
   [ 'putstring',                %q{ "true" }, ],
   [ 'tostring / concatstrings', %q{ "#{true}" }, ],
-  [ 'freezestring',             %q{ "#{true}" }, fsl, ],
-  [ 'freezestring',             %q{ "#{true}" }, '-d', fsl, ],
   [ 'toregexp',                 %q{ /#{true}/ =~ "true" && $~ }, ],
   [ 'intern',                   %q{ :"#{true}" }, ],
 

--- a/insns.def
+++ b/insns.def
@@ -390,16 +390,6 @@ tostring
     val = rb_obj_as_string_result(str, val);
 }
 
-/* Freeze (dynamically) created strings. if debug_info is given, set it. */
-DEFINE_INSN
-freezestring
-(VALUE debug_info)
-(VALUE str)
-(VALUE str)
-{
-    vm_freezestring(str, debug_info);
-}
-
 /* compile str to Regexp and push it.
      opt is the option for the Regexp.
  */

--- a/spec/ruby/language/string_spec.rb
+++ b/spec/ruby/language/string_spec.rb
@@ -291,4 +291,21 @@ describe "Ruby String interpolation" do
 
     -> { "#{a} #{b}" }.should raise_error(Encoding::CompatibilityError)
   end
+
+  it "creates a non-frozen String" do
+    code = <<~'RUBY'
+    "a#{6*7}c"
+    RUBY
+    eval(code).should_not.frozen?
+  end
+
+  ruby_version_is "3.0" do
+    it "creates a non-frozen String when # frozen-string-literal: true is used" do
+      code = <<~'RUBY'
+      # frozen-string-literal: true
+      "a#{6*7}c"
+      RUBY
+      eval(code).should_not.frozen?
+    end
+  end
 end

--- a/test/ruby/test_iseq.rb
+++ b/test/ruby/test_iseq.rb
@@ -187,8 +187,8 @@ class TestISeq < Test::Unit::TestCase
     s1, s2, s3, s4 = compile(code, line, {frozen_string_literal: true}).eval
     assert_predicate(s1, :frozen?)
     assert_predicate(s2, :frozen?)
-    assert_predicate(s3, :frozen?)
-    assert_predicate(s4, :frozen?)
+    assert_not_predicate(s3, :frozen?)
+    assert_predicate(s4, :frozen?) # should probably not be frozen, but unrealistic code
   end
 
   # Safe call chain is not optimized when Coverage is running.

--- a/test/ruby/test_jit.rb
+++ b/test/ruby/test_jit.rb
@@ -247,14 +247,6 @@ class TestJIT < Test::Unit::TestCase
     assert_compile_once('"a#{}b" + "c"', result_inspect: '"abc"', insns: %i[putstring concatstrings tostring])
   end
 
-  def test_compile_insn_freezestring
-    assert_eval_with_jit("#{<<~"begin;"}\n#{<<~'end;'}", stdout: 'true', success_count: 1, insns: %i[freezestring])
-    begin;
-      # frozen_string_literal: true
-      print proc { "#{true}".frozen? }.call
-    end;
-  end
-
   def test_compile_insn_toregexp
     assert_compile_once('/#{true}/ =~ "true"', result_inspect: '0', insns: %i[toregexp])
   end

--- a/test/ruby/test_literal.rb
+++ b/test/ruby/test_literal.rb
@@ -187,7 +187,7 @@ class TestRubyLiteral < Test::Unit::TestCase
   if defined?(RubyVM::InstructionSequence.compile_option) and
     RubyVM::InstructionSequence.compile_option.key?(:debug_frozen_string_literal)
     def test_debug_frozen_string
-      src = 'n = 1; _="foo#{n ? "-#{n}" : ""}"'; f = "test.rb"; n = 1
+      src = '_="foo-1"'; f = "test.rb"; n = 1
       opt = {frozen_string_literal: true, debug_frozen_string_literal: true}
       str = RubyVM::InstructionSequence.compile(src, f, f, n, **opt).eval
       assert_equal("foo-1", str)

--- a/test/ruby/test_rubyoptions.rb
+++ b/test/ruby/test_rubyoptions.rb
@@ -1014,11 +1014,11 @@ class TestRubyOptions < Test::Unit::TestCase
       err = !freeze ? [] : debug ? with_debug_pat : wo_debug_pat
       [
         ['"foo" << "bar"', err],
-        ['"foo#{123}bar" << "bar"', err],
+        ['"foo#{123}bar" << "bar"', []],
         ['+"foo#{123}bar" << "bar"', []],
-        ['-"foo#{123}bar" << "bar"', freeze && debug ? with_debug_pat : wo_debug_pat],
+        ['-"foo#{123}bar" << "bar"', wo_debug_pat],
       ].each do |code, expected|
-        assert_in_out_err(opt, code, [], expected, [opt, code])
+        assert_in_out_err(opt, code, [], expected, "#{opt} #{code}")
       end
     end
   end

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -3816,15 +3816,6 @@ vm_get_special_object(const VALUE *const reg_ep,
     }
 }
 
-static void
-vm_freezestring(VALUE str, VALUE debug)
-{
-    if (!NIL_P(debug)) {
-	rb_ivar_set(str, id_debug_created_info, debug);
-    }
-    rb_str_freeze(str);
-}
-
 static VALUE
 vm_concat_array(VALUE ary1, VALUE ary2st)
 {


### PR DESCRIPTION
* Remove `freezestring` instruction since this was the only usage for it.
* [[Feature #17104]](https://bugs.ruby-lang.org/issues/17104)