### PR TITLE
Fix pthread_setname_np arguments on NetBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2540,11 +2540,11 @@ AS_IF([test x"$enable_pthread" = xyes], [
 	AC_CACHE_CHECK([arguments of pthread_setname_np], [rb_cv_func_pthread_setname_np_arguments],
 	    [rb_cv_func_pthread_setname_np_arguments=
 	    # Linux,AIX,  (pthread_self(), name)
-	    # NetBSD (pthread_self(), name, \"%s\")
+	    # NetBSD (pthread_self(), \"%s\", name)
 	    # Darwin (name)
 	    for mac in \
 		"(pthread_self(), name)" \
-		"(pthread_self(), name, \"%s\")" \
+		"(pthread_self(), \"%s\", name)" \
 		"(name)" \
 		; do
 		AC_TRY_COMPILE([


### PR DESCRIPTION
The previous attempt to fix this in
b87df1bf243074edb2e6cc8a24bc00df81cebf3c reversed the argument
order instead of just fixing the quote escaping.

From Takahiro Kambe.

Fixes [Bug #15178]