### PR TITLE
Add IPAddr#to_unmasked_string

### DIFF
--- a/lib/ipaddr.rb
+++ b/lib/ipaddr.rb
@@ -235,6 +235,10 @@ class IPAddr
     return _to_string(@addr)
   end
 
+  def to_unmasked_string
+    return _to_string(@unmasked_addr)
+  end
+
   # Returns a network byte ordered string form of the IP address.
   def hton
     case @family
@@ -589,6 +593,7 @@ class IPAddr
     if family != Socket::AF_UNSPEC && @family != family
       raise AddressFamilyError, "address family mismatch"
     end
+    @unmasked_addr = @addr
     if prefixlen
       mask!(prefixlen)
     else

--- a/test/test_ipaddr.rb
+++ b/test/test_ipaddr.rb
@@ -388,4 +388,11 @@ class TC_Operator < Test::Unit::TestCase
     assert_equal(true, s.include?(a5))
     assert_equal(true, s.include?(a6))
   end
+
+  def test_unmasked
+    assert_equal("1.2.3.4", IPAddr.new("1.2.3.4").to_unmasked_string)
+    assert_equal("1.2.3.4", IPAddr.new("1.2.3.4/8").to_unmasked_string)
+    assert_equal("0001:0002:0000:0000:0000:0000:0000:0003", IPAddr.new("1:2::3").to_unmasked_string)
+    assert_equal("0001:0002:0000:0000:0000:0000:0000:0003", IPAddr.new("1:2::3/16").to_unmasked_string)
+  end
 end


### PR DESCRIPTION
Prior to this commit there was no way to retrieve the unmasked address
for an `IPAddr`. For example, given the `IPAddr` below there is no
method or instance variable that would return `"1.2.3.4"`.

```rb
IPAddr.new("1.2.3.4/8")
```

This poses a problem for Rails in supporting the PostgreSQL inet type.
Rails uses `IPAddr` for both the cidr and inet types, but at the moment
cannot fully support the inet type, which "accepts values with nonzero
bits to the right of the netmask". This came up originally in
https://github.com/rails/rails/issues/14857, and more recently in
https://github.com/rails/rails/issues/40138. The change in this commit
would allow us to support the inet type without moving to another
library.

This commit holds onto the address before the mask is applied, in a new
instance variable `@unmasked_addr`. It then exposes this via
`to_unmasked_string`.

This was originally implemented back in
https://github.com/ruby/ruby/pull/599, but it got stale and was
eventually closed. There are also a few differences with that PR:

- That PR set up the instance variable inside of `mask!`, which meant
  that the new method was broken in the case of an `IPAddr` with no
  mask.
- That PR introduced a method that returned a `to_s`-like value, whereas
  this one returns a `to_string`-like value. This seems to fit better
  with the method name. And if folks need to get the `to_s` value they
  can always wrap the return value in another `IPAddr` and call `to_s`
  on that.
- As a result of the above, this version doesn't need to change the
  signature of `to_s`