### PR TITLE
Revert Range#max changes for integer ranges with non-integer ends

### DIFF
--- a/range.c
+++ b/range.c
@@ -1255,15 +1255,6 @@ range_max(int argc, VALUE *argv, VALUE range)
             return rb_funcall(e, '-', 1, INT2FIX(1));
         }
         if (RB_INTEGER_TYPE_P(b) && !RB_INTEGER_TYPE_P(e)) {
-            if (RB_TYPE_P(e, T_FLOAT)) {
-                VALUE inf = rb_funcall(e, rb_intern("infinite?"), 0);
-                if (inf != Qnil) {
-                  /* For backwards compatibility, return end if the end
-                   * is Float::Infinity and the beginning is integer.
-                     If end is -Float::Infinity, return nil. */
-                  return(inf == INT2FIX(1) ? e : Qnil);
-                }
-            }
             e = rb_funcall(e, rb_intern("floor"), 0);
         }
         return e;

--- a/range.c
+++ b/range.c
@@ -1200,14 +1200,34 @@ range_min(int argc, VALUE *argv, VALUE range)
  *     rng.max(n)                    -> obj
  *     rng.max(n) {| a,b | block }   -> obj
  *
- *  Returns the maximum value in the range. Returns +nil+ if the begin
- *  value of the range larger than the end value. Returns +nil+ if
- *  the begin value of an exclusive range is equal to the end value.
+ *  Returns the maximum value in the range, or an array of maximum
+ *  values in the range if given an \Integer argument.
  *
- *  Can be given an optional block to override the default comparison
- *  method <code>a <=> b</code>.
+ *  For inclusive ranges with an end, the maximum value of the range
+ *  is the same as the end of the range.
  *
- *    (10..20).max    #=> 20
+ *  If an argument or block is given, or +self+ is an exclusive,
+ *  non-numeric range, calls Enumerable#max (via +super+) with the
+ *  argument and/or block to get the maximum values, unless +self+ is
+ *  a beginless range, in which case it raises a RangeError.
+ *
+ *  If +self+ is an exclusive, integer range (both start and end of the
+ *  range are integers), and no arguments or block are provided, returns
+ *  last value in the range (1 before the end).  Otherwise, if +self+ is
+ *  an exclusive, numeric range, raises a TypeError.
+ * 
+ *  Returns +nil+ if the begin value of the range larger than the
+ *  end value. Returns +nil+ if the begin value of an exclusive
+ *  range is equal to the end value.  Raises a RangeError if called on
+ *  an endless range.
+ *
+ *  Examples:
+ *    (10..20).max                        #=> 20
+ *    (10..20).max(2)                     #=> [20, 19]
+ *    (10...20).max                       #=> 19
+ *    (10...20).max(2)                    #=> [19, 18]
+ *    (10...20).max{|x, y| -x <=> -y }    #=> 10
+ *    (10...20).max(2){|x, y| -x <=> -y } #=> [10, 11]
  */
 
 static VALUE

--- a/range.c
+++ b/range.c
@@ -1235,13 +1235,6 @@ range_max(int argc, VALUE *argv, VALUE range)
         if (c > 0)
             return Qnil;
         if (EXCL(range)) {
-            if (RB_INTEGER_TYPE_P(b) && !RB_INTEGER_TYPE_P(e)) {
-                VALUE end = e;
-                e = rb_funcall(e, rb_intern("floor"), 0);
-                if (!RTEST(rb_funcall(e, rb_intern("=="), 1, end))) {
-                    return e;
-                }
-            }
             if (!RB_INTEGER_TYPE_P(e)) {
                 rb_raise(rb_eTypeError, "cannot exclude non Integer end value");
             }
@@ -1253,9 +1246,6 @@ range_max(int argc, VALUE *argv, VALUE range)
                 return LONG2NUM(FIX2LONG(e) - 1);
             }
             return rb_funcall(e, '-', 1, INT2FIX(1));
-        }
-        if (RB_INTEGER_TYPE_P(b) && !RB_INTEGER_TYPE_P(e)) {
-            e = rb_funcall(e, rb_intern("floor"), 0);
         }
         return e;
     }
@@ -1604,14 +1594,9 @@ r_cover_range_p(VALUE range, VALUE beg, VALUE end, VALUE val)
     else if (cmp_end >= 0) {
         return TRUE;
     }
-    if (RB_INTEGER_TYPE_P(val_beg) && RB_INTEGER_TYPE_P(beg) &&
-            RB_INTEGER_TYPE_P(val_end) != RB_INTEGER_TYPE_P(end)) {
-        val_max = val_end;
-    }
-    else {
-        val_max = rb_rescue2(r_call_max, val, 0, Qnil, rb_eTypeError, (VALUE)0);
-        if (val_max == Qnil) return FALSE;
-    }
+
+    val_max = rb_rescue2(r_call_max, val, 0, Qnil, rb_eTypeError, (VALUE)0);
+    if (val_max == Qnil) return FALSE;
 
     return r_less(end, val_max) >= 0;
 }

--- a/test/ruby/test_range.rb
+++ b/test/ruby/test_range.rb
@@ -107,13 +107,11 @@ class TestRange < Test::Unit::TestCase
     assert_equal(1, (1...2).max)
     assert_raise(RangeError) { (1..).max }
     assert_raise(RangeError) { (1...).max }
-    assert_equal(2, (1..2.1).max)
-    assert_equal(2, (1...2.1).max)
 
     assert_equal(2.0, (1.0..2.0).max)
     assert_equal(nil, (2.0..1.0).max)
     assert_raise(TypeError) { (1.0...2.0).max }
-    assert_equal(1, (1...1.5).max)
+    assert_raise(TypeError) { (1...1.5).max }
     assert_raise(TypeError) { (1.5...2).max }
 
     assert_equal(-0x80000002, ((-0x80000002)...(-0x80000001)).max)
@@ -139,13 +137,11 @@ class TestRange < Test::Unit::TestCase
     assert_equal([1, 1], (1...2).minmax)
     assert_raise(RangeError) { (1..).minmax }
     assert_raise(RangeError) { (1...).minmax }
-    assert_equal([1, 2], (1..2.1).minmax)
-    assert_equal([1, 2], (1...2.1).minmax)
 
     assert_equal([1.0, 2.0], (1.0..2.0).minmax)
     assert_equal([nil, nil], (2.0..1.0).minmax)
     assert_raise(TypeError) { (1.0...2.0).minmax }
-    assert_equal([1, 1], (1..1.5).minmax)
+    assert_raise(TypeError) { (1...1.5).minmax }
     assert_raise(TypeError) { (1.5...2).minmax }
 
     assert_equal([-0x80000002, -0x80000002], ((-0x80000002)...(-0x80000001)).minmax)
@@ -660,12 +656,7 @@ class TestRange < Test::Unit::TestCase
     assert_not_operator(1..10, :cover?, 3...2)
     assert_not_operator(1..10, :cover?, 3...3)
     assert_not_operator('aa'..'zz', :cover?, 'aa'...'zzz')
-
     assert_not_operator(1..10, :cover?, 1...10.1)
-    assert_not_operator(1...10.1, :cover?, 1..10.1)
-    assert_operator(1..10.1, :cover?, 1...10.1)
-    assert_operator(1..10.1, :cover?, 1...10)
-    assert_operator(1..10.1, :cover?, 1..10)
   end
 
   def test_beg_len

--- a/test/ruby/test_range.rb
+++ b/test/ruby/test_range.rb
@@ -131,9 +131,6 @@ class TestRange < Test::Unit::TestCase
     assert_equal(2, (..2).max)
     assert_raise(TypeError) { (...2).max }
     assert_raise(TypeError) { (...2.0).max }
-
-    assert_equal(Float::INFINITY, (1..Float::INFINITY).max)
-    assert_nil((1..-Float::INFINITY).max)
   end
 
   def test_minmax
@@ -160,9 +157,6 @@ class TestRange < Test::Unit::TestCase
 
     assert_equal(['a', 'c'], ('a'..'c').minmax)
     assert_equal(['a', 'b'], ('a'...'c').minmax)
-
-    assert_equal([1, Float::INFINITY], (1..Float::INFINITY).minmax)
-    assert_equal([nil, nil], (1..-Float::INFINITY).minmax)
   end
 
   def test_initialize_twice


### PR DESCRIPTION
@matz stated that he preferred the 2.7 behavior.  Update the Range#max documentation while here to reflect the behavior after the revert.