### PR TITLE
Fix constant names set using const_set on a singleton class

### DIFF
--- a/spec/ruby/core/module/const_set_spec.rb
+++ b/spec/ruby/core/module/const_set_spec.rb
@@ -20,10 +20,20 @@ describe "Module#const_set" do
     m.name.should == "ConstantSpecs::CS_CONST1000"
   end
 
-  it "does not set the name of a module scoped by an anonymous module" do
-    a, b = Module.new, Module.new
-    a.const_set :B, b
-    b.name.should be_nil
+  ruby_version_is ""..."3.0" do
+    it "does not set the name of a module scoped by an anonymous module" do
+      a, b = Module.new, Module.new
+      a.const_set :B, b
+      b.name.should be_nil
+    end
+  end
+
+  ruby_version_is "3.0" do
+    it "sets the name of a module scoped by an anonymous module" do
+      a, b = Module.new, Module.new
+      a.const_set :B, b
+      b.name.should.end_with? '::B'
+    end
   end
 
   it "sets the name of contained modules when assigning a toplevel anonymous module" do

--- a/spec/ruby/core/module/name_spec.rb
+++ b/spec/ruby/core/module/name_spec.rb
@@ -6,10 +6,20 @@ describe "Module#name" do
     Module.new.name.should be_nil
   end
 
-  it "is nil when assigned to a constant in an anonymous module" do
-    m = Module.new
-    m::N = Module.new
-    m::N.name.should be_nil
+  ruby_version_is ""..."3.0" do
+    it "is nil when assigned to a constant in an anonymous module" do
+      m = Module.new
+      m::N = Module.new
+      m::N.name.should be_nil
+    end
+  end
+
+  ruby_version_is "3.0" do
+    it "is not nil when assigned to a constant in an anonymous module" do
+      m = Module.new
+      m::N = Module.new
+      m::N.name.should.end_with? '::N'
+    end
   end
 
   it "is not nil for a nested module created with the module keyword" do

--- a/spec/ruby/language/module_spec.rb
+++ b/spec/ruby/language/module_spec.rb
@@ -69,10 +69,20 @@ describe "Assigning an anonymous module to a constant" do
     mod.name.should == "ModuleSpecs_CS1"
   end
 
-  it "does not set the name of a module scoped by an anonymous module" do
-    a, b = Module.new, Module.new
-    a::B = b
-    b.name.should be_nil
+  ruby_version_is ""..."3.0" do
+    it "does not set the name of a module scoped by an anonymous module" do
+      a, b = Module.new, Module.new
+      a::B = b
+      b.name.should be_nil
+    end
+  end
+
+  ruby_version_is "3.0" do
+    it "sets the name of a module scoped by an anonymous module" do
+      a, b = Module.new, Module.new
+      a::B = b
+      b.name.should.end_with? '::B'
+    end
   end
 
   it "sets the name of contained modules when assigning a toplevel anonymous module" do

--- a/test/ruby/test_module.rb
+++ b/test/ruby/test_module.rb
@@ -767,13 +767,13 @@ class TestModule < Test::Unit::TestCase
     n = Module.new
     m.const_set(:N, n)
     assert_nil(m.name)
-    assert_nil(n.name)
+    assert_match(/::N$/, n.name)
     assert_equal([:N], m.constants)
     m.module_eval("module O end")
     assert_equal([:N, :O], m.constants.sort)
     m.module_eval("class C; end")
     assert_equal([:C, :N, :O], m.constants.sort)
-    assert_nil(m::N.name)
+    assert_match(/::N$/, m::N.name)
     assert_match(/\A#<Module:.*>::O\z/, m::O.name)
     assert_match(/\A#<Module:.*>::C\z/, m::C.name)
     self.class.const_set(:M, m)
@@ -2722,6 +2722,12 @@ class TestModule < Test::Unit::TestCase
     m = Module.new.freeze
     assert_predicate m.clone, :frozen?
     assert_not_predicate m.clone(freeze: false), :frozen?
+  end
+
+  def test_module_name_in_singleton_method
+    s = Object.new.singleton_class
+    mod = s.const_set(:Foo, Module.new)
+    assert_match(/::Foo$/, mod.name, '[Bug #14895]')
   end
 
   private

--- a/variable.c
+++ b/variable.c
@@ -2854,14 +2854,15 @@ rb_const_set(VALUE klass, ID id, VALUE val)
 	    else {
                 int parental_path_permanent;
                 VALUE parental_path = classname(klass, &parental_path_permanent);
-                if (!NIL_P(parental_path)) {
-                    if (parental_path_permanent && !val_path_permanent) {
-                        set_namespace_path(val, build_const_path(parental_path, id));
-                    }
-                    else if (!parental_path_permanent && NIL_P(val_path)) {
-                        rb_ivar_set(val, tmp_classpath, build_const_path(parental_path, id));
-                    }
-		}
+                if (NIL_P(parental_path)) {
+                    parental_path = rb_funcall(klass, rb_intern("to_s"), 0);
+                }
+                if (parental_path_permanent && !val_path_permanent) {
+                    set_namespace_path(val, build_const_path(parental_path, id));
+                }
+                else if (!parental_path_permanent && NIL_P(val_path)) {
+                    rb_ivar_set(val, tmp_classpath, build_const_path(parental_path, id));
+                }
 	    }
 	}
     }


### PR DESCRIPTION
Fixes [Bug #14895]

This PR insures that a Module assigned to a constant `Const`, even within an anonymous module, will have a `name`.