### PR TITLE
Return nil when argument to ObjectSpace.internal_class_of is T_IMEMO

### DIFF
--- a/ext/objspace/objspace.c
+++ b/ext/objspace/objspace.c
@@ -895,8 +895,13 @@ objspace_internal_class_of(VALUE self, VALUE obj)
 	obj = (VALUE)DATA_PTR(obj);
     }
 
-    klass = CLASS_OF(obj);
-    return wrap_klass_iow(klass);
+    if (RB_TYPE_P(obj, T_IMEMO)) {
+        return Qnil;
+    }
+    else {
+        klass = CLASS_OF(obj);
+        return wrap_klass_iow(klass);
+    }
 }
 
 /*

--- a/test/objspace/test_objspace.rb
+++ b/test/objspace/test_objspace.rb
@@ -487,6 +487,11 @@ class TestObjSpace < Test::Unit::TestCase
     assert_operator i, :>, 0
   end
 
+  def test_internal_class_of_on_ast
+    children = ObjectSpace.reachable_objects_from(RubyVM::AbstractSyntaxTree.parse("kadomatsu"))
+    children.each {|child| ObjectSpace.internal_class_of(child).itself} # this used to crash
+  end
+
   def traverse_super_classes klass
     while klass
       klass = ObjectSpace.internal_super_of(klass)


### PR DESCRIPTION
The added test case crashes the interpreter because it makes
ObjectSpace.internal_class_of return the second VALUE slot of an AST
imemo object. The second VALUE slot of `struct rb_ast_struct` is
not a VALUE and not a pointer to a Ruby object.

---
Here is a one line crasher `ruby -robjspace -e 'o = ObjectSpace; o.reachable_objects_from(RubyVM::AbstractSyntaxTree.parse("a")).each{|e| o.internal_class_of(e).itself}'`.
This should also fix flaky CI failures like [this one](http://ci.rvm.jp/results/trunk-random0@phosphorus-docker/3163204). I think
what's happening in those cases is that `ObjectSpace.internal_class_of` gets an
`imemo_svar` and ends up returning an `T_IMEMO` object to Ruby land.

A way to fix this this crash without make a breaking change is to make sure the second
`VALUE` slot of all the objects on the heap always store a valid object. I
think the freedom to put whatever we want there is more valuable than making
this niche API more useful, though.
