### PR TITLE
Write virtual PC to the stack frame less often

### DIFF
--- a/insns.def
+++ b/insns.def
@@ -363,6 +363,7 @@ putstring
 ()
 (VALUE val)
 {
+    GET_CFP()->pc = GET_PC();
     val = rb_str_resurrect(str);
 }
 
@@ -387,6 +388,7 @@ tostring
 (VALUE val, VALUE str)
 (VALUE val)
 {
+    GET_CFP()->pc = GET_PC();
     val = rb_obj_as_string_result(str, val);
 }
 
@@ -425,6 +427,7 @@ intern
 (VALUE str)
 (VALUE sym)
 {
+    GET_CFP()->pc = GET_PC();
     sym = rb_str_intern(str);
 }
 
@@ -436,6 +439,7 @@ newarray
 (VALUE val)
 // attr rb_snum_t sp_inc = 1 - (rb_snum_t)num;
 {
+    GET_CFP()->pc = GET_PC();
     val = rb_ary_new4(num, STACK_ADDR_FROM_TOP(num));
 }
 
@@ -451,6 +455,7 @@ newarraykwsplat
 (VALUE val)
 // attr rb_snum_t sp_inc = 1 - (rb_snum_t)num;
 {
+    GET_CFP()->pc = GET_PC();
     if (RHASH_EMPTY_P(*STACK_ADDR_FROM_TOP(1))) {
         val = rb_ary_new4(num-1, STACK_ADDR_FROM_TOP(num));
     }
@@ -466,6 +471,7 @@ duparray
 ()
 (VALUE val)
 {
+    GET_CFP()->pc = GET_PC();
     RUBY_DTRACE_CREATE_HOOK(ARRAY, RARRAY_LEN(ary));
     val = rb_ary_resurrect(ary);
 }

--- a/tool/ruby_vm/views/_insn_entry.erb
+++ b/tool/ruby_vm/views/_insn_entry.erb
@@ -36,6 +36,9 @@ INSN_ENTRY(<%= insn.name %>)
 
     /* ### Instruction preambles. ### */
     if (! leaf) ADD_PC(INSN_ATTR(width));
+#if USE_MACHINE_REGS
+    if (! leaf) GET_CFP()->pc = GET_PC();
+#endif
 % if insn.handles_sp?
     POPN(INSN_ATTR(popn));
 % end

--- a/tool/ruby_vm/views/_insn_entry.erb
+++ b/tool/ruby_vm/views/_insn_entry.erb
@@ -24,7 +24,7 @@ INSN_ENTRY(<%= insn.name %>)
     <%= ope[:decl] %> = (<%= ope[:type] %>)GET_OPERAND(<%= i + 1 %>);
 % end
 #   define INSN_ATTR(x) <%= insn.call_attribute(' ## x ## ') %>
-    bool leaf = INSN_ATTR(leaf);
+    const bool leaf = INSN_ATTR(leaf);
 % insn.pops.reverse_each.with_index.reverse_each do |pop, i|
     <%= pop[:decl] %> = <%= insn.cast_from_VALUE pop, "TOPN(#{i})"%>;
 % end

--- a/tool/ruby_vm/views/_trace_instruction.erb
+++ b/tool/ruby_vm/views/_trace_instruction.erb
@@ -10,6 +10,9 @@
 /* insn <%= insn.pretty_name %> */
 INSN_ENTRY(<%= insn.name %>)
 {
+#if USE_MACHINE_REGS
+    GET_CFP()->pc = GET_PC();
+#endif
     vm_trace(ec, GET_CFP());
     DISPATCH_ORIGINAL_INSN(<%= insn.jump_destination %>);
     END_INSN(<%= insn.name %>);

--- a/vm_exec.c
+++ b/vm_exec.c
@@ -120,7 +120,7 @@ vm_exec_core(rb_execution_context_t *ec, VALUE initial)
 #undef  GET_PC
 #define GET_PC() (reg_pc)
 #undef  SET_PC
-#define SET_PC(x) (reg_cfp->pc = VM_REG_PC = (x))
+#define SET_PC(x) (reg_pc = (x))
 #endif
 
 #if OPT_TOKEN_THREADED_CODE || OPT_DIRECT_THREADED_CODE


### PR DESCRIPTION
TODO need to clean this up. Maybe add an instruction attribute and call
it no allocation or whatever. I also didn't carefully audit each
instruction. When an allocation happens cfp->pc needs
to be up-to-date or else the allocation tracer reports the wrong line.

Seems to have a big impact on optcarrot on my laptop with Apple Clang:

```
post: ruby 3.0.0dev (2020-09-01T23:51:44Z fewer-pc-writes 6a2aa087bb) [x86_64-darwin19]
 pre: ruby 3.0.0dev (2020-09-01T17:52:47Z master de10a1f) [x86_64-darwin19]
 pre-no-mjit: ruby 3.0.0dev (2020-09-01T17:52:47Z master de10a1f) [x86_64-darwin19]
Calculating -------------------------------------
                               post         pre   pre-no-mjit
Optcarrot Lan_Master.nes     46.296      41.688        41.651 fps

Comparison:
             Optcarrot Lan_Master.nes
                    post:        46.3 fps
                     pre:        41.7 fps - 1.11x  slower
             pre-no-mjit:        41.7 fps - 1.11x  slower
```

Probably want to check GCC on GNU/Linux.