### PR TITLE
Add category to `rb_warn_deprecated`

### DIFF
--- a/error.c
+++ b/error.c
@@ -392,7 +392,22 @@ rb_warn_deprecated(const char *fmt, const char *suggest, ...)
     rb_str_cat_cstr(mesg, " is deprecated");
     if (suggest) rb_str_catf(mesg, "; use %s instead", suggest);
     rb_str_cat_cstr(mesg, "\n");
-    rb_write_warning_str(mesg);
+
+    VALUE warn_args[2];
+    warn_args[0] = mesg;
+
+    const rb_method_entry_t * me;
+    me = rb_method_entry(rb_singleton_class(rb_mWarning), id_warn);
+
+    if (rb_method_entry_arity(me) != 1) {
+        VALUE kwargs = rb_hash_new();
+        rb_hash_aset(kwargs, ID2SYM(rb_intern("category")), ID2SYM(rb_intern("deprecated")));
+        warn_args[1] = kwargs;
+
+        rb_funcallv_kw(rb_mWarning, id_warn, 2, warn_args, RB_PASS_KEYWORDS);
+    } else {
+        rb_funcall(rb_mWarning, id_warn, 1, mesg);
+    }
 }
 
 void
@@ -411,7 +426,7 @@ rb_warn_deprecated_to_remove(const char *fmt, const char *removal, ...)
     warn_args[0] = mesg;
 
     const rb_method_entry_t * me;
-    me = rb_method_entry(rb_mWarning, id_warn);
+    me = rb_method_entry(rb_singleton_class(rb_mWarning), id_warn);
 
     if (rb_method_entry_arity(me) != 1) {
         VALUE kwargs = rb_hash_new();

--- a/test/ruby/test_exception.rb
+++ b/test/ruby/test_exception.rb
@@ -960,13 +960,25 @@ $stderr = $stdout; raise "\x82\xa0"') do |outs, errs, status|
     assert_equal(["\n"],     capture_warning_warn {warn ""})
   end
 
-  def test_warn_backwards_compatibility
+  def test_warn_deprecated_backwards_compatibility_category
+    warning = capture_warning_warn { Dir.exists?("non-existent") }
+
+    assert_match(/deprecated/, warning[0])
+  end
+
+  def test_warn_deprecated_category
+    warning = capture_warning_warn(category: true) { Dir.exists?("non-existent") }
+
+    assert_equal :deprecated, warning[0][1]
+  end
+
+  def test_warn_deprecated_to_remove_backwards_compatibility_category
     warning = capture_warning_warn { Object.new.tainted? }
 
     assert_match(/deprecated/, warning[0])
   end
 
-  def test_warn_category
+  def test_warn_deprecated_to_remove_category
     warning = capture_warning_warn(category: true) { Object.new.tainted? }
 
     assert_equal :deprecated, warning[0][1]


### PR DESCRIPTION
PR https://github.com/ruby/ruby/pull/3418 added a category to
`rb_warn_deprecated_to_remove` but not to `rb_warn_deprecated`. This
adds the same code to `rb_warn_deprecated` so that those warnings also
get a category.

This change also adds tests for `rb_warn_deprecated` and updates the
tests for `rb_warn_deprecated_to_remove` to have clearer names.

Feature: https://bugs.ruby-lang.org/issues/17122