### PR TITLE
Fix rb_gc_force_recycle unmarking before sweep

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -7170,7 +7170,7 @@ rb_gc_force_recycle(VALUE obj)
     }
     else {
 #endif
-	if (is_old || !GET_HEAP_PAGE(obj)->flags.before_sweep) {
+	if (is_old || GET_HEAP_PAGE(obj)->flags.before_sweep) {
 	    CLEAR_IN_BITMAP(GET_HEAP_MARK_BITS(obj), obj);
 	}
 	CLEAR_IN_BITMAP(GET_HEAP_MARKING_BITS(obj), obj);

--- a/gc.c
+++ b/gc.c
@@ -7160,23 +7160,15 @@ rb_gc_force_recycle(VALUE obj)
     CLEAR_IN_BITMAP(GET_HEAP_UNCOLLECTIBLE_BITS(obj), obj);
     CLEAR_IN_BITMAP(GET_HEAP_WB_UNPROTECTED_BITS(obj), obj);
 
+
 #if GC_ENABLE_INCREMENTAL_MARK
-    if (is_incremental_marking(objspace)) {
-	if (MARKED_IN_BITMAP(GET_HEAP_MARKING_BITS(obj), obj)) {
-	    invalidate_mark_stack(&objspace->mark_stack, obj);
-	    CLEAR_IN_BITMAP(GET_HEAP_MARKING_BITS(obj), obj);
-	}
-	CLEAR_IN_BITMAP(GET_HEAP_MARK_BITS(obj), obj);
-    }
-    else {
-#endif
-	if (is_old || GET_HEAP_PAGE(obj)->flags.before_sweep) {
-	    CLEAR_IN_BITMAP(GET_HEAP_MARK_BITS(obj), obj);
-	}
-	CLEAR_IN_BITMAP(GET_HEAP_MARKING_BITS(obj), obj);
-#if GC_ENABLE_INCREMENTAL_MARK
+    if (is_incremental_marking(objspace) && MARKED_IN_BITMAP(GET_HEAP_MARKING_BITS(obj), obj)) {
+        invalidate_mark_stack(&objspace->mark_stack, obj);
     }
 #endif
+
+    CLEAR_IN_BITMAP(GET_HEAP_MARKING_BITS(obj), obj);
+    CLEAR_IN_BITMAP(GET_HEAP_MARK_BITS(obj), obj);
 
     objspace->profile.total_freed_objects++;
 


### PR DESCRIPTION
If we force recycle an object before the page is swept, we should clear it in the mark bitmap. We should clear it in the bitmap before we sweep the page (rather than after we sweep the page) because after we sweep the page the object is only marked if it is uncollectable (i.e. old object). If we don't clear it in the bitmap, then during sweeping we won't account for this free slot so the `free_slots` count of the page will be incorrect. (This is the first commit).

But then I noticed that we are clearing the marking and mark bits in almost every case (and it does not do any harm when we clear a bit that is not set), so we can simplify this function. (This is the second commit).
