### PR TITLE
Don't call to_s in const_set

### DIFF
--- a/variable.c
+++ b/variable.c
@@ -2855,7 +2855,8 @@ rb_const_set(VALUE klass, ID id, VALUE val)
                 int parental_path_permanent;
                 VALUE parental_path = classname(klass, &parental_path_permanent);
                 if (NIL_P(parental_path)) {
-                    parental_path = rb_funcall(klass, rb_intern("to_s"), 0);
+                    int throwaway;
+                    parental_path = rb_tmp_class_path(klass, &throwaway, make_temporary_path);
                 }
                 if (parental_path_permanent && !val_path_permanent) {
                     set_namespace_path(val, build_const_path(parental_path, id));


### PR DESCRIPTION
Follow up for 5e16857315bf55307c5fc887ca6f03bfa0630a93. Calling a method
in the middle of const_set adds a way that it would fail. It also makes
it inconsistent with declaring a constant using `::`, which doesn't call
`to_s`.