### PR TITLE
check multi_ractor mode at main_p

### DIFF
--- a/ractor.c
+++ b/ractor.c
@@ -15,9 +15,12 @@ static VALUE rb_eRactorMovedError;
 static VALUE rb_eRactorClosedError;
 static VALUE rb_cRactorMovedObject;
 
+RUBY_SYMBOL_EXPORT_BEGIN
+// to share with MJIT
 bool ruby_multi_ractor;
-static void vm_ractor_blocking_cnt_inc(rb_vm_t *vm, rb_ractor_t *r, const char *file, int line);
+RUBY_SYMBOL_EXPORT_END
 
+static void vm_ractor_blocking_cnt_inc(rb_vm_t *vm, rb_ractor_t *r, const char *file, int line);
 
 static void
 ASSERT_ractor_unlocking(rb_ractor_t *r)
@@ -1423,9 +1426,10 @@ rb_ractor_self(const rb_ractor_t *r)
     return r->self;
 }
 
-MJIT_FUNC_EXPORTED int
-rb_ractor_main_p(void)
+MJIT_FUNC_EXPORTED bool
+rb_ractor_main_p_(void)
 {
+    VM_ASSERT(rb_multi_ractor_p());
     rb_execution_context_t *ec = GET_EC();
     return rb_ec_ractor_ptr(ec) == rb_ec_vm_ptr(ec)->ractor.main_ractor;
 }

--- a/ractor_pub.h
+++ b/ractor_pub.h
@@ -1,5 +1,20 @@
+#ifndef RACTOR_PUB_INCLUDED
+#define RACTOR_PUB_INCLUDED
 
-int rb_ractor_main_p(void);
+RUBY_EXTERN bool ruby_multi_ractor;
+
+bool rb_ractor_main_p_(void);
+
+static inline bool
+rb_ractor_main_p(void)
+{
+    if (!ruby_multi_ractor) {
+        return true;
+    }
+    else {
+        return rb_ractor_main_p_();
+    }
+}
 
 bool rb_ractor_shareable_p_continue(VALUE obj);
 
@@ -31,3 +46,5 @@ void rb_ractor_stdout_set(VALUE);
 void rb_ractor_stderr_set(VALUE);
 
 RUBY_SYMBOL_EXPORT_END
+
+#endif

--- a/vm_sync.h
+++ b/vm_sync.h
@@ -4,6 +4,7 @@
 
 #include "vm_core.h"
 #include "vm_debug.h"
+#include "ractor_pub.h"
 
 #if USE_RUBY_DEBUG_LOG
 #define LOCATION_ARGS const char *file, int line
@@ -25,8 +26,6 @@ void rb_vm_lock_leave_body(unsigned int *lev APPEND_LOCATION_ARGS);
 void rb_vm_barrier(void);
 void rb_vm_cond_wait(rb_vm_t *vm, rb_nativethread_cond_t *cond);
 void rb_vm_cond_timedwait(rb_vm_t *vm, rb_nativethread_cond_t *cond, unsigned long msec);
-
-extern bool ruby_multi_ractor;
 
 static inline bool
 rb_multi_ractor_p(void)


### PR DESCRIPTION
rb_ractor_main_p() need to access to the ractor pointer in TLS.
However it is slow operation so that we need to skip this check
if it is not multi-ractor mode (!ruby_multi_ractor).

This performance regression is pointed at
https://bugs.ruby-lang.org/issues/17100#note-27