### PR TITLE
.github: try GitHub Container Registry

### DIFF
--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -156,7 +156,7 @@ jobs:
 
     name: ${{ matrix.entry.name }}
     runs-on: ubuntu-latest
-    container: shyouhei/c-compilers:latest
+    container: ghcr.io/ruby/ruby-ci-image:latest
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     steps:
       - name: setenv


### PR DESCRIPTION
It is natural for a CI running on GitHub to use GitHub's facility.

See also https://github.blog/2020-09-01-introducing-github-container-registry/