### PR TITLE
Let String#slice! return nil

### DIFF
--- a/string.c
+++ b/string.c
@@ -4961,7 +4961,10 @@ rb_str_slice_bang(int argc, VALUE *argv, VALUE str)
 	    return Qnil;
 	  case Qfalse:
 	    beg = NUM2LONG(indx);
-	    goto num_index;
+	    if (!(p = rb_str_subpos(str, beg, &len))) return Qnil;
+	    if (!len) return Qnil;
+	    beg = p - RSTRING_PTR(str);
+	    goto subseq;
 	  default:
 	    goto num_index;
 	}

--- a/test/ruby/test_string.rb
+++ b/test/ruby/test_string.rb
@@ -1588,8 +1588,10 @@ CODE
     a = S("FooBar")
     if @aref_slicebang_silent
       assert_nil( a.slice!(6) )
+      assert_nil( a.slice!(6r) )
     else
       assert_raise(IndexError) { a.slice!(6) }
+      assert_raise(IndexError) { a.slice!(6r) }
     end
     assert_equal(S("FooBar"), a)
 


### PR DESCRIPTION
Make `String#slice!` to return `nil` instead of an empty string when non-integer number is given (to make it 2.7 compatible).

```rb
# master
"abc".slice!(3)       # => nil
"abc".slice!(3r)      # => ""

# Ruby 2.7 (and HEAD)
"abc".slice!(3)       # => nil
"abc".slice!(3r)      # => nil
```