### PR TITLE
Solve deprecation warning in CSV

### DIFF
--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -2620,8 +2620,8 @@ end
 #     c.read.any? { |a| a.include?("zombies") }
 #   } #=> false
 #
-def CSV(*args, &block)
-  CSV.instance(*args, &block)
+def CSV(...)
+  CSV.instance(...)
 end
 
 require_relative "csv/version"


### PR DESCRIPTION
This uses the new delegation syntax to solve the "Using the last argument as keyword parameters is deprecated" warning from 2.7.1.