### PR TITLE
Improve the performance of super

### DIFF
--- a/benchmark/vm_iclass_super.yml
+++ b/benchmark/vm_iclass_super.yml
@@ -1,0 +1,20 @@
+prelude: |
+  class C
+    def m
+      1
+    end
+
+    ("A".."M").each do |module_name|
+      eval <<-EOM
+          module #{module_name}
+            def m; super; end
+          end
+          prepend #{module_name}
+      EOM
+    end
+  end
+
+  obj = C.new
+benchmark:
+  vm_iclass_super: obj.m
+loop_count: 6000000

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -673,8 +673,19 @@ rb_vm_frame_method_entry(const rb_control_frame_t *cfp)
     return check_method_entry(ep[VM_ENV_DATA_INDEX_ME_CREF], TRUE);
 }
 
+static rb_iseq_t *
+method_entry_iseqptr(const rb_callable_method_entry_t *me)
+{
+    switch (me->def->type) {
+      case VM_METHOD_TYPE_ISEQ:
+        return me->def->body.iseq.iseqptr;
+      default:
+        return NULL;
+    }
+}
+
 static rb_cref_t *
-method_entry_cref(rb_callable_method_entry_t *me)
+method_entry_cref(const rb_callable_method_entry_t *me)
 {
     switch (me->def->type) {
       case VM_METHOD_TYPE_ISEQ:
@@ -3266,7 +3277,7 @@ static inline VALUE
 vm_search_normal_superclass(VALUE klass)
 {
     if (BUILTIN_TYPE(klass) == T_ICLASS &&
-	FL_TEST(RBASIC(klass)->klass, RMODULE_IS_REFINEMENT)) {
+	FL_TEST_RAW(RBASIC(klass)->klass, RMODULE_IS_REFINEMENT)) {
 	klass = RBASIC(klass)->klass;
     }
     klass = RCLASS_ORIGIN(klass);
@@ -3299,6 +3310,7 @@ vm_search_super_method(const rb_control_frame_t *reg_cfp, struct rb_call_data *c
 
     if (BUILTIN_TYPE(current_defined_class) != T_MODULE &&
 	!FL_TEST(current_defined_class, RMODULE_INCLUDED_INTO_REFINEMENT) &&
+        reg_cfp->iseq != method_entry_iseqptr(me) &&
         !rb_obj_is_kind_of(recv, current_defined_class)) {
 	VALUE m = RB_TYPE_P(current_defined_class, T_ICLASS) ?
             RCLASS_INCLUDER(current_defined_class) : current_defined_class;


### PR DESCRIPTION
This PR improves the performance of `super` calls. While working on some
Rails optimizations jhawthorn discovered that `super` calls were slower
than expected.

The changes here do the following:

1) Adds a check for whether the call frame is not equal to the method
entry iseq. This avoids the `rb_obj_is_kind_of` check on the next line
which is quite slow. If the current call frame is equal to the method
entry we know we can't have an instance eval, etc.
2) Changes `FL_TEST` to `FL_TEST_RAW`. This is safe because we've
already done the check for `T_ICLASS` above.
3) Adds a benchmark for `T_ICLASS` super calls.
4) Note: makes a chage for `method_entry_cref` to use `const`.

On master the benchmarks showed that `super` is 1.76x slower. Our
changes improved the performance so that it is now only 1.36x slower.

Benchmark IPS:

```
ruby 3.0.0dev (2020-09-14T17:29:54Z master 28e60b0045) [x86_64-darwin19]
Warming up --------------------------------------
               super   248.792k i/100ms
         method call   434.392k i/100ms
Calculating -------------------------------------
               super      2.479M (± 1.3%) i/s -     12.440M in   5.018636s
         method call      4.354M (± 2.0%) i/s -     22.154M in   5.090333s

Comparison:
         method call:  4353993.7 i/s
               super:  2479084.2 i/s - 1.76x  (± 0.00) slower
```

With changes:

```
ruby 3.0.0dev (2020-09-14T19:18:30Z improve-performanc.. 1acc68eca0) [x86_64-darwin19]
Warming up --------------------------------------
               super   296.373k i/100ms
         method call   418.651k i/100ms
Calculating -------------------------------------
               super      3.090M (± 2.4%) i/s -     15.708M in   5.085938s
         method call      4.131M (± 1.5%) i/s -     20.933M in   5.068066s

Comparison:
         method call:  4131279.6 i/s
               super:  3090399.1 i/s - 1.34x  (± 0.00) slower
```

Ruby VM benchmarks also showed an improvement:

Existing `vm_super` benchmark`.

```
$ make benchmark ITEM=vm_super

|          |compare-ruby|built-ruby|
|:---------|-----------:|---------:|
|vm_super  |     32.045M|   34.361M|
|          |           -|     1.07x|
```

New `vm_iclass_super` benchmark:

```
$ make benchmark ITEM=vm_iclass_super

|          |compare-ruby|built-ruby|
|:---------|-----------:|---------:|
|vm_super  |      2.867M|    3.809M|
|          |           -|     1.33x|
```

This is the benchmark script used for the benchmark-ips benchmarks:

```ruby
require "benchmark/ips"

class Foo
  def zuper; end
  def top; end

  last_method = "top"

  ("A".."M").each do |module_name|
    eval <<-EOM
    module #{module_name}
      def zuper; super; end
      def #{module_name.downcase}
        #{last_method}
      end
    end
    prepend #{module_name}
    EOM
    last_method = module_name.downcase
  end
end

foo = Foo.new

Benchmark.ips do |x|
  x.report "super" do
    foo.zuper
  end

  x.report "method call" do
    foo.m
  end

  x.compare!
end
```

Co-authored-by: Aaron Patterson <tenderlove@ruby-lang.org>
Co-authored-by: John Hawthorn <john@hawthorn.email>