### PR TITLE
WIP: Don't update iseq if already present

### DIFF
--- a/benchmark/vm_iclass_super.yml
+++ b/benchmark/vm_iclass_super.yml
@@ -1,0 +1,20 @@
+prelude: |
+  class C
+    def m
+      1
+    end
+
+    ("A".."M").each do |module_name|
+      eval <<-EOM
+          module #{module_name}
+            def m; super; end
+          end
+          prepend #{module_name}
+      EOM
+    end
+  end
+
+  obj = C.new
+benchmark:
+  vm_super: obj.m
+loop_count: 6000000

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -673,8 +673,19 @@ rb_vm_frame_method_entry(const rb_control_frame_t *cfp)
     return check_method_entry(ep[VM_ENV_DATA_INDEX_ME_CREF], TRUE);
 }
 
+static rb_iseq_t *
+method_entry_iseqptr(const rb_callable_method_entry_t *me)
+{
+    switch (me->def->type) {
+      case VM_METHOD_TYPE_ISEQ:
+        return me->def->body.iseq.iseqptr;
+      default:
+        return NULL;
+    }
+}
+
 static rb_cref_t *
-method_entry_cref(rb_callable_method_entry_t *me)
+method_entry_cref(const rb_callable_method_entry_t *me)
 {
     switch (me->def->type) {
       case VM_METHOD_TYPE_ISEQ:
@@ -3266,7 +3277,7 @@ static inline VALUE
 vm_search_normal_superclass(VALUE klass)
 {
     if (BUILTIN_TYPE(klass) == T_ICLASS &&
-	FL_TEST(RBASIC(klass)->klass, RMODULE_IS_REFINEMENT)) {
+	FL_TEST_RAW(RBASIC(klass)->klass, RMODULE_IS_REFINEMENT)) {
 	klass = RBASIC(klass)->klass;
     }
     klass = RCLASS_ORIGIN(klass);
@@ -3299,6 +3310,7 @@ vm_search_super_method(const rb_control_frame_t *reg_cfp, struct rb_call_data *c
 
     if (BUILTIN_TYPE(current_defined_class) != T_MODULE &&
 	!FL_TEST(current_defined_class, RMODULE_INCLUDED_INTO_REFINEMENT) &&
+        reg_cfp->iseq != method_entry_iseqptr(me) &&
         !rb_obj_is_kind_of(recv, current_defined_class)) {
 	VALUE m = RB_TYPE_P(current_defined_class, T_ICLASS) ?
             RCLASS_INCLUDER(current_defined_class) : current_defined_class;

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -3331,7 +3331,7 @@ vm_search_super_method(const rb_control_frame_t *reg_cfp, struct rb_call_data *c
     }
 
     // update iseq. really? (TODO)
-    if (!vm_ci_mid(cd->ci)) {
+    if (!(reg_cfp->iseq == method_entry_iseqptr(me) && vm_ci_mid(cd->ci))) {
         cd->ci = vm_ci_new_runtime(me->def->original_id,
                                    vm_ci_flag(cd->ci),
                                    vm_ci_argc(cd->ci),

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -3331,11 +3331,13 @@ vm_search_super_method(const rb_control_frame_t *reg_cfp, struct rb_call_data *c
     }
 
     // update iseq. really? (TODO)
-    cd->ci = vm_ci_new_runtime(me->def->original_id,
-                               vm_ci_flag(cd->ci),
-                               vm_ci_argc(cd->ci),
-                               vm_ci_kwarg(cd->ci));
-    RB_OBJ_WRITTEN(reg_cfp->iseq, Qundef, cd->ci);
+    if (!vm_ci_mid(cd->ci)) {
+        cd->ci = vm_ci_new_runtime(me->def->original_id,
+                                   vm_ci_flag(cd->ci),
+                                   vm_ci_argc(cd->ci),
+                                   vm_ci_kwarg(cd->ci));
+        RB_OBJ_WRITTEN(reg_cfp->iseq, Qundef, cd->ci);
+    }
 
     klass = vm_search_normal_superclass(me->defined_class);
 


### PR DESCRIPTION
This change speeds up calls to `super` by skipping the iseq update if
it's already present.

WIP: will include benchmarks after running CI.

Co-authored-by: Aaron Patterson tenderlove@ruby-lang.org

Related: #3545