### PR TITLE
Fix assertion failed in Complex.polar without NDEBUG

### DIFF
--- a/complex.c
+++ b/complex.c
@@ -732,6 +732,14 @@ nucomp_s_polar(int argc, VALUE *argv, VALUE klass)
 	nucomp_real_check(arg);
 	break;
     }
+    if (RB_TYPE_P(abs, T_COMPLEX)) {
+        get_dat1(abs);
+        abs = dat->real;
+    }
+    if (RB_TYPE_P(arg, T_COMPLEX)) {
+        get_dat1(arg);
+        arg = dat->real;
+    }
     return f_complex_polar(klass, abs, arg);
 }
 

--- a/test/ruby/test_complex.rb
+++ b/test/ruby/test_complex.rb
@@ -220,6 +220,11 @@ class Complex_Test < Test::Unit::TestCase
   def test_polar
     assert_equal([1,2], Complex.polar(1,2).polar)
     assert_equal(Complex.polar(1.0, Math::PI * 2 / 3), Complex.polar(1, Math::PI * 2 / 3))
+
+    assert_in_out_err([], <<-'end;', ['OK'], [])
+      Complex.polar(1, Complex(1, 0))
+      puts :OK
+    end;
   end
 
   def test_uplus


### PR DESCRIPTION
This fixes [Bug #17172](https://bugs.ruby-lang.org/issues/17172).