### PR TITLE
Remove unsued int_round_zero_p definiation

### DIFF
--- a/numeric.c
+++ b/numeric.c
@@ -176,7 +176,6 @@ static VALUE fix_lshift(long, unsigned long);
 static VALUE fix_rshift(long, unsigned long);
 static VALUE int_pow(long x, unsigned long y);
 static VALUE int_even_p(VALUE x);
-static int int_round_zero_p(VALUE num, int ndigits);
 static VALUE rb_int_floor(VALUE num, int ndigits);
 static VALUE rb_int_ceil(VALUE num, int ndigits);
 static VALUE flo_to_i(VALUE num);


### PR DESCRIPTION
I read `numeric.c` and find that `int_round_zero_p` prototytpe definiation, but seems be not used.