### PR TITLE
Implement some Ractor helper methods

### DIFF
--- a/ractor.c
+++ b/ractor.c
@@ -1309,6 +1309,16 @@ ractor_init(rb_ractor_t *r, VALUE name, VALUE loc)
     rb_ractor_living_threads_init(r);
 
     // naming
+    if (!NIL_P(name)) {
+        rb_encoding *enc;
+        StringValueCStr(name);
+        enc = rb_enc_get(name);
+        if (!rb_enc_asciicompat(enc)) {
+            rb_raise(rb_eArgError, "ASCII incompatible encoding (%s)",
+                 rb_enc_name(enc));
+        }
+        name = rb_str_new_frozen(name);
+    }
     r->name = name;
     r->loc = loc;
 }
@@ -1347,6 +1357,29 @@ ractor_create(rb_execution_context_t *ec, VALUE self, VALUE loc, VALUE name, VAL
 
     RB_GC_GUARD(rv);
     return rv;
+}
+
+/*
+ * call-seq:
+ *   ractor.name=(name)   -> string
+ *
+ * set given name to a ractor.
+ */
+static VALUE
+rb_actor_setname(rb_ractor_t *r, VALUE name)
+{
+    if (!NIL_P(name)) {
+        rb_encoding *enc;
+        StringValueCStr(name);
+        enc = rb_enc_get(name);
+        if (!rb_enc_asciicompat(enc)) {
+            rb_raise(rb_eArgError, "ASCII incompatible encoding (%s)",
+                 rb_enc_name(enc));
+        }
+        name = rb_str_new_frozen(name);
+    }
+    r->name = name;
+    return name;
 }
 
 static void

--- a/ractor.rb
+++ b/ractor.rb
@@ -12,7 +12,7 @@ class Ractor
   # receive them.
   #
   # The result of the block is sent via the outgoing channel
-  # and other 
+  # and other
   #
   # r = Ractor.new do
   #   Ractor.recv    # recv via r's mailbox => 1
@@ -29,7 +29,7 @@ class Ractor
   #
   # other options:
   #   name: Ractor's name
-  # 
+  #
   def self.new *args, name: nil, &block
     b = block # TODO: builtin bug
     raise ArgumentError, "must be called with a block" unless block
@@ -48,6 +48,13 @@ class Ractor
   def self.count
     __builtin_cexpr! %q{
       ULONG2NUM(GET_VM()->ractor.cnt);
+    }
+  end
+
+  # return main Ractor
+  def self.main
+    __builtin_cexpr! %q{
+      GET_VM()->ractor.main_ractor->self
     }
   end
 
@@ -142,7 +149,6 @@ class Ractor
   def name=(new_name)
     __builtin_cexpr! %q{ rb_actor_setname(RACTOR_PTR(self), new_name) }
   end
-
 
   # Returns the status of a +ractor+.
   #

--- a/ractor.rb
+++ b/ractor.rb
@@ -139,6 +139,10 @@ class Ractor
     __builtin_cexpr! %q{ RACTOR_PTR(self)->name }
   end
 
+  def name=(new_name)
+    __builtin_cexpr! %q{ rb_actor_setname(RACTOR_PTR(self), new_name) }
+  end
+
   class RemoteError
     attr_reader :ractor
   end

--- a/ractor.rb
+++ b/ractor.rb
@@ -143,6 +143,23 @@ class Ractor
     __builtin_cexpr! %q{ rb_actor_setname(RACTOR_PTR(self), new_name) }
   end
 
+
+  # Returns the status of a +ractor+.
+  #
+  # [<tt>"created"</tt>]
+  #	Returned if a ractor has just been created and not ready to run
+  # [<tt>"blocking"</tt>]
+  #	Returned if all threads are blocking
+  # [<tt>"running"</tt>]
+  #	When any thread of a ractor is running
+  # [<tt>"terminated"</tt>]
+  #	Return if a ractor finishes its execution
+  def status
+    __builtin_cexpr! %q{
+      rb_str_new2(ractor_status_str(RACTOR_PTR(self)->status_))
+    }
+  end
+
   class RemoteError
     attr_reader :ractor
   end

--- a/ractor.rb
+++ b/ractor.rb
@@ -132,7 +132,7 @@ class Ractor
     loc  = __builtin_cexpr! %q{ RACTOR_PTR(self)->loc }
     name = __builtin_cexpr! %q{ RACTOR_PTR(self)->name }
     id   = __builtin_cexpr! %q{ INT2FIX(RACTOR_PTR(self)->id) }
-    "#<Ractor:##{id}#{name ? ' '+name : ''}#{loc ? " " + loc : ''}>"
+    "#<Ractor:##{id}#{name ? ' '+name : ''}#{loc ? " " + loc : ''} #{status}>"
   end
 
   def name

--- a/spec/ruby/core/ractor/count_spec.rb
+++ b/spec/ruby/core/ractor/count_spec.rb
@@ -1,0 +1,21 @@
+require_relative '../../spec_helper'
+
+ruby_version_is '3.0.0' do
+  describe 'Ractor.count' do
+    it 'returns currently alive ractors' do
+      Ractor.count.should == 1
+
+      ractors = (1..3).map { Ractor.new { Ractor.recv } }
+      Ractor.count.should == 4
+
+      ractors[0].send('End 0').take
+      Ractor.count.should == 3
+
+      ractors[1].send('End 1').take
+      Ractor.count.should == 2
+
+      ractors[2].send('End 2').take
+      Ractor.count.should == 1
+    end
+  end
+end

--- a/spec/ruby/core/ractor/inspect_spec.rb
+++ b/spec/ruby/core/ractor/inspect_spec.rb
@@ -1,0 +1,40 @@
+require_relative '../../spec_helper'
+
+ruby_version_is '3.0.0' do
+  describe 'Ractor#inspect' do
+    context 'Main ractor' do
+      it 'returns id number one and status' do
+        Ractor.current.inspect.should == '#<Ractor:#1 running>'
+      end
+    end
+
+    context 'New plain Ractor' do
+      it 'returns id, loc, and current status' do
+        file = __FILE__
+        lineno = __LINE__ + 1
+        r = Ractor.new { Ractor.recv }
+        r.inspect.should =~ /^#<Ractor:#([^ ]*?) #{file}:#{lineno} blocking>$/
+
+        r.send('End ractor')
+        r.take
+        r.inspect.should =~ /^#<Ractor:#([^ ]*?) #{file}:#{lineno} terminated>$/
+      end
+    end
+
+    context 'Named Ractor' do
+      it 'returns id, name, loc, and current status' do
+        file = __FILE__
+        lineno = __LINE__ + 1
+        r = Ractor.new(name: 'Super ractor') { Ractor.recv }
+        r.inspect.should =~ /^#<Ractor:#([^ ]*?) Super ractor #{file}:#{lineno} blocking>$/
+
+        r.send('End ractor')
+        r.take
+        r.inspect.should =~ /^#<Ractor:#([^ ]*?) Super ractor #{file}:#{lineno} terminated>$/
+
+        r.name = 'Hot ractor'
+        r.inspect.should =~ /^#<Ractor:#([^ ]*?) Hot ractor #{file}:#{lineno} terminated>$/
+      end
+    end
+  end
+end

--- a/spec/ruby/core/ractor/main_spec.rb
+++ b/spec/ruby/core/ractor/main_spec.rb
@@ -2,7 +2,7 @@ require_relative '../../spec_helper'
 
 ruby_version_is '3.0.0' do
   describe 'Ractor.main' do
-    it 'returns main ractor object outside' do
+    it 'returns main ractor object in main ractor' do
       Ractor.current.should == Ractor.main
     end
 

--- a/spec/ruby/core/ractor/main_spec.rb
+++ b/spec/ruby/core/ractor/main_spec.rb
@@ -1,0 +1,20 @@
+require_relative '../../spec_helper'
+
+ruby_version_is '3.0.0' do
+  describe 'Ractor.main' do
+    it 'returns main ractor object outside' do
+      Ractor.current.should == Ractor.main
+    end
+
+    it 'returns main ractor object inside other ractors' do
+      ractors = (1..3).map do
+        Ractor.new do
+          Ractor.main
+        end
+      end
+      ractors[0].take.should == Ractor.current
+      ractors[1].take.should == Ractor.current
+      ractors[2].take.should == Ractor.current
+    end
+  end
+end

--- a/spec/ruby/core/ractor/name_spec.rb
+++ b/spec/ruby/core/ractor/name_spec.rb
@@ -1,0 +1,97 @@
+require_relative '../../spec_helper'
+
+ruby_version_is '3.0.0' do
+  describe 'Ractor#name' do
+    context 'Default ractor name' do
+      it 'returns nil for main ractor' do
+        Ractor.current.name.should == nil
+      end
+
+      it 'returns nil for newly created ractor' do
+        r = Ractor.new do
+          Ractor.current.name
+        end
+        r.take.should == nil
+      end
+    end
+
+    context 'Create ractor with name' do
+      it 'returns ractor name outside named ractor' do
+        r = Ractor.new(name: 'Test ractor name') {}
+        r.name.should == 'Test ractor name'
+      end
+
+      it 'returns ractor name inside named ractor' do
+        r = Ractor.new(name: 'Test ractor name') { Ractor.current.name }
+        r.take.should == 'Test ractor name'
+      end
+
+      it 'raises exceptions if initialize with invalid name' do
+        -> do
+          Ractor.new(name: 123) {}
+        end.should raise_error(TypeError)
+        -> do
+          Ractor.new(name: [1, 2, 3]) {}
+        end.should raise_error(TypeError)
+        -> do
+          Ractor.new(name: {}) {}
+        end.should raise_error(TypeError)
+        -> do
+          Ractor.new(name: String.new('Invalid encoding', encoding: 'UTF-16BE')) {}
+        end.should raise_error(ArgumentError)
+      end
+    end
+
+    context 'Re-assign ractor name' do
+      it 'returns ractor new names outside named ractor' do
+        r = Ractor.new {}
+
+        r.name = 'New name 1'
+        r.name.should == 'New name 1'
+
+        r.name = 'New name 2'
+        r.name.should == 'New name 2'
+
+        r.name = nil
+        r.name.should == nil
+      end
+
+      it 'returns ractor new names inside named ractor' do
+        r = Ractor.new do
+          3.times { Ractor.recv; Ractor.yield(Ractor.current.name) }
+        end
+
+        r.name = 'New name 1'
+        r.send 'Rename event'
+        r.take.should == 'New name 1'
+
+        r.name = 'New name 2'
+        r.send 'Rename event'
+        r.take.should == 'New name 2'
+
+        r.name = nil
+        r.send 'Rename event'
+        r.take.should == nil
+      end
+
+      it 'raises exceptions if assign with invalid name' do
+        -> do
+          r = Ractor.new {}
+          r.name = 123
+        end.should raise_error(TypeError)
+        -> do
+          r = Ractor.new {}
+          r.name = [1, 2, 3]
+        end.should raise_error(TypeError)
+        -> do
+          r = Ractor.new {}
+          r.name = {}
+        end.should raise_error(TypeError)
+        -> do
+          r = Ractor.new {}
+          r.name = String.new('Invalid encoding', encoding: 'UTF-16BE')
+        end.should raise_error(ArgumentError)
+      end
+    end
+  end
+end

--- a/spec/ruby/core/ractor/status_spec.rb
+++ b/spec/ruby/core/ractor/status_spec.rb
@@ -1,0 +1,72 @@
+require_relative '../../spec_helper'
+
+ruby_version_is '3.0.0' do
+  describe 'Ractor#status' do
+    context 'ractor has 1 terminated thread' do
+      it 'returns terminated' do
+        r = Ractor.new { 'farewell' }
+        r.take
+        r.status.should == 'terminated'
+      end
+    end
+
+    context 'ractor has many terminated threads' do
+      it 'returns terminated' do
+        r = Ractor.new do
+          threads = (1..3).map do |index|
+            Thread.new do
+              a = 1
+            end
+          end
+          threads.map(&:join)
+          0
+        end
+        r.take
+        r.status.should == 'terminated'
+      end
+    end
+
+    context 'ractor is being blocked' do
+      it 'returns blocking' do
+        r = Ractor.new do
+          Ractor.recv
+        end
+        r.status.should == 'blocking'
+
+        r.send 'End ractor'
+        r.take
+        r.status.should == 'terminated'
+      end
+    end
+
+    context 'ractor has 1 blocking thread and some terminated threads' do
+      it 'returns blocking' do
+        r = Ractor.new do
+          threads = (1..3).map do |index|
+            Thread.new do
+              a = 1
+            end
+          end
+          threads.map(&:join)
+          Ractor.yield 'Finish join'
+          Ractor.recv
+        end
+
+        r.take
+        r.status.should == 'blocking'
+
+        r.send 'End ractor'
+        r.take
+        r.status.should == 'terminated'
+      end
+    end
+
+    context 'ractor is running' do
+      it 'returns running' do
+        Ractor.current.status.should == 'running'
+        r = Ractor.new { Ractor.current.status }
+        r.take.should == 'running'
+      end
+    end
+  end
+end


### PR DESCRIPTION
When playing around with Ractor, I found that ractors are missing some methods, comparing to other similar classes, like `Thread`. So, I would like to add some methods:

- `Ractor.main`, reflects the main ractor in VM. This is similar to `Thread.main`.
- `Ractor#status`, returns the current status of a ractor. The list of status are: `created`, `blocking`, `running`, `terminated`.
- `Ractor#name=`, re-assign a ractor's name after it's created. 
- Add status `Ractor#inspect`. It returns something like `#<Ractor:#2 Ractor name test_ractor.rb:1 terminated>`
- Validate Ractor name before initialization. Recently, initializing a ractor with invalid name `Ractor.new(name: [{}])` is still valid, and it silently fails later. I think an exception should be explicitly raised.

It's surprising that there isn't any unit tests for ractor, just a functional bootstrapest file. So, I added some tests to `spec/ruby/core/ractor/` folder. 