### PR TITLE
Small tweaks for Ractor

### DIFF
--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -17,6 +17,27 @@ assert_equal "must be called with a block", %q{
   end
 }
 
+# Ractor#inspect
+assert_equal "#<Ractor:#1 running>", %q{
+  Ractor.current.inspect
+}
+
+assert_match /^#<Ractor:#([^ ]*?) bootstraptest.tmp.rb:[0-9]+ blocking>$/, %q{
+  r = Ractor.new { Ractor.recv }
+  r.inspect
+}
+
+assert_match /^#<Ractor:#([^ ]*?) bootstraptest.tmp.rb:[0-9]+ terminated>$/, %q{
+  r = Ractor.new { '' }
+  r.take
+  r.inspect
+}
+
+assert_match /^#<Ractor:#([^ ]*?) Test Ractor bootstraptest.tmp.rb:[0-9]+ blocking>$/, %q{
+  r = Ractor.new(name: 'Test Ractor') { Ractor.recv }
+  r.inspect
+}
+
 # A return value of a Ractor block will be a message from the Ractor.
 assert_equal 'ok', %q{
   # join

--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -8,6 +8,37 @@ assert_equal 'Ractor', %q{
   Ractor.new{}.class
 }
 
+# A Ractor can have a name
+assert_equal 'test-name', %q{
+  r = Ractor.new name: 'test-name' do
+  end
+  r.name
+}
+
+# If Ractor doesn't have a name, Ractor#name returns nil.
+assert_equal 'nil', %q{
+  r = Ractor.new do
+  end
+  r.name.inspect
+}
+
+# Raises exceptions if initialize with invalid name
+assert_equal 'no implicit conversion of Array into String', %q{
+  begin
+    r = Ractor.new(name: [{}]) {}
+  rescue TypeError => e
+    e.message
+  end
+}
+
+assert_equal 'ASCII incompatible encoding (UTF-16BE)', %q{
+  begin
+    r = Ractor.new(name: String.new('Invalid encoding', encoding: 'UTF-16BE')) {}
+  rescue ArgumentError => e
+    e.message
+  end
+}
+
 # Ractor.new must call with a block
 assert_equal "must be called with a block", %q{
   begin
@@ -263,7 +294,7 @@ assert_equal 'false', %q{
   r = Ractor.new obj do |msg|
     msg.object_id
   end
-  
+
   obj.object_id == r.take
 }
 
@@ -360,7 +391,7 @@ assert_equal 'hello', %q{
 
   str = r.take
   begin
-    r.take 
+    r.take
   rescue Ractor::RemoteError
     str #=> "hello"
   end
@@ -528,20 +559,6 @@ assert_equal '[1000, 3]', %q{
   Ractor.new{ [A.size, H.size] }.take
 }
 
-# A Ractor can have a name
-assert_equal 'test-name', %q{
-  r = Ractor.new name: 'test-name' do
-  end
-  r.name
-}
-
-# If Ractor doesn't have a name, Ractor#name returns nil.
-assert_equal 'nil', %q{
-  r = Ractor.new do
-  end
-  r.name.inspect
-}
-
 ###
 ### Synchronization tests
 ###
@@ -559,4 +576,3 @@ assert_equal "#{N}#{N}", %Q{
 }
 
 end # if !ENV['GITHUB_WORKFLOW']
-

--- a/ractor.c
+++ b/ractor.c
@@ -492,7 +492,7 @@ ractor_copy_setup(struct rb_ractor_basket *b, VALUE obj)
 #if 0
         // TODO: consider custom copy protocol
         switch (BUILTIN_TYPE(obj)) {
-            
+
         }
 #endif
         b->v = rb_marshal_dump(obj, Qnil);
@@ -1309,6 +1309,16 @@ ractor_init(rb_ractor_t *r, VALUE name, VALUE loc)
     rb_ractor_living_threads_init(r);
 
     // naming
+    if (!NIL_P(name)) {
+        rb_encoding *enc;
+        StringValueCStr(name);
+        enc = rb_enc_get(name);
+        if (!rb_enc_asciicompat(enc)) {
+            rb_raise(rb_eArgError, "ASCII incompatible encoding (%s)",
+                 rb_enc_name(enc));
+        }
+        name = rb_str_new_frozen(name);
+    }
     r->name = name;
     r->loc = loc;
 }
@@ -1356,7 +1366,7 @@ ractor_atexit_yield(rb_execution_context_t *ec, rb_ractor_t *cr, VALUE v, bool e
 
     struct rb_ractor_basket basket;
     ractor_basket_setup(ec, &basket, v, Qfalse, exc);
- 
+
   retry:
     if (ractor_try_yield(ec, cr, &basket)) {
         // OK.

--- a/ractor.rb
+++ b/ractor.rb
@@ -12,7 +12,7 @@ class Ractor
   # receive them.
   #
   # The result of the block is sent via the outgoing channel
-  # and other 
+  # and other
   #
   # r = Ractor.new do
   #   Ractor.recv    # recv via r's mailbox => 1
@@ -29,7 +29,7 @@ class Ractor
   #
   # other options:
   #   name: Ractor's name
-  # 
+  #
   def self.new *args, name: nil, &block
     b = block # TODO: builtin bug
     raise ArgumentError, "must be called with a block" unless block
@@ -132,7 +132,10 @@ class Ractor
     loc  = __builtin_cexpr! %q{ RACTOR_PTR(self)->loc }
     name = __builtin_cexpr! %q{ RACTOR_PTR(self)->name }
     id   = __builtin_cexpr! %q{ INT2FIX(RACTOR_PTR(self)->id) }
-    "#<Ractor:##{id}#{name ? ' '+name : ''}#{loc ? " " + loc : ''}>"
+    status = __builtin_cexpr! %q{
+      rb_str_new2(ractor_status_str(RACTOR_PTR(self)->status_))
+    }
+    "#<Ractor:##{id}#{name ? ' '+name : ''}#{loc ? " " + loc : ''} #{status}>"
   end
 
   def name


### PR DESCRIPTION
This is an extraction from this PR: https://github.com/ruby/ruby/pull/3553

- Add status Ractor#inspect. It returns something like `#<Ractor:#2 Ractor name test_ractor.rb:1 terminated>` 
- Validate Ractor name before initialization. Recently, initializing a ractor with invalid name Ractor.new(name: [{}]) is still valid, and it silently fails later. I think an exception should be explicitly raised.
- Add some tests for initialization, inpsect, Ractor.count, Ractor#close, Ractor#close_incoming, Ractor#close_outgoing. This time, I insert tests into bootstraptest/test_ractor.rb instead of `spec/*`


