### PR TITLE
When setting current thread scheduler to nil, invoke `#close`.

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -5214,6 +5214,7 @@ eval.$(OBJEXT): $(top_srcdir)/internal/object.h
 eval.$(OBJEXT): $(top_srcdir)/internal/serial.h
 eval.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 eval.$(OBJEXT): $(top_srcdir)/internal/string.h
+eval.$(OBJEXT): $(top_srcdir)/internal/thread.h
 eval.$(OBJEXT): $(top_srcdir)/internal/variable.h
 eval.$(OBJEXT): $(top_srcdir)/internal/vm.h
 eval.$(OBJEXT): $(top_srcdir)/internal/warnings.h

--- a/eval.c
+++ b/eval.c
@@ -28,6 +28,7 @@
 #include "internal/io.h"
 #include "internal/mjit.h"
 #include "internal/object.h"
+#include "internal/thread.h"
 #include "internal/variable.h"
 #include "iseq.h"
 #include "mjit.h"
@@ -158,6 +159,13 @@ rb_ec_teardown(rb_execution_context_t *ec)
 }
 
 static void
+rb_ec_scheduler_finalize(rb_execution_context_t *ec)
+{
+    rb_thread_t *thread = rb_ec_thread_ptr(ec);
+    rb_thread_scheduler_set(thread->self, Qnil);
+}
+
+static void
 rb_ec_finalize(rb_execution_context_t *ec)
 {
     ruby_sig_finalize();
@@ -269,6 +277,9 @@ rb_ec_cleanup(rb_execution_context_t *ec, volatile int ex)
 	    sysex = EXIT_FAILURE;
 	}
     }
+
+    // If the user code defined a scheduler for the top level thread, run it:
+    rb_ec_scheduler_finalize(ec);
 
     mjit_finish(true); // We still need ISeqs here.
 

--- a/internal/scheduler.h
+++ b/internal/scheduler.h
@@ -14,6 +14,8 @@
 
 VALUE rb_scheduler_timeout(struct timeval *timeout);
 
+VALUE rb_scheduler_close(VALUE scheduler);
+
 VALUE rb_scheduler_kernel_sleep(VALUE scheduler, VALUE duration);
 VALUE rb_scheduler_kernel_sleepv(VALUE scheduler, int argc, VALUE * argv);
 

--- a/scheduler.c
+++ b/scheduler.c
@@ -11,9 +11,13 @@
 #include "internal/scheduler.h"
 #include "ruby/io.h"
 
-static ID id_kernel_sleep;
+static ID id_close;
+
 static ID id_block;
 static ID id_unblock;
+
+static ID id_kernel_sleep;
+
 static ID id_io_read;
 static ID id_io_write;
 static ID id_io_wait;
@@ -21,12 +25,21 @@ static ID id_io_wait;
 void
 Init_Scheduler(void)
 {
-    id_kernel_sleep = rb_intern_const("kernel_sleep");
+    id_close = rb_intern_const("close");
+
     id_block = rb_intern_const("block");
     id_unblock = rb_intern_const("unblock");
+
+    id_kernel_sleep = rb_intern_const("kernel_sleep");
+
     id_io_read = rb_intern_const("io_read");
     id_io_write = rb_intern_const("io_write");
     id_io_wait = rb_intern_const("io_wait");
+}
+
+VALUE rb_scheduler_close(VALUE scheduler)
+{
+    return rb_funcall(scheduler, id_close, 0);
 }
 
 VALUE

--- a/test/fiber/scheduler.rb
+++ b/test/fiber/scheduler.rb
@@ -19,6 +19,8 @@ class Scheduler
     @writable = {}
     @waiting = {}
 
+    @closed = false
+
     @lock = Mutex.new
     @locking = 0
     @ready = []
@@ -94,6 +96,19 @@ class Scheduler
   ensure
     @urgent.each(&:close)
     @urgent = nil
+  end
+
+  def close
+    self.run
+  ensure
+    @closed = true
+    
+    # We freeze to detect any inadvertant modifications after the scheduler is closed:
+    self.freeze
+  end
+
+  def closed?
+    @closed
   end
 
   def current_time

--- a/test/fiber/test_scheduler.rb
+++ b/test/fiber/test_scheduler.rb
@@ -10,4 +10,29 @@ class TestFiberScheduler < Test::Unit::TestCase
       end
     end
   end
+  
+  def test_closed_at_thread_exit
+    scheduler = Scheduler.new
+
+    thread = Thread.new do
+      Thread.current.scheduler = scheduler
+    end
+
+    thread.join
+
+    assert scheduler.closed?
+  end
+
+  def test_closed_when_set_to_nil
+    scheduler = Scheduler.new
+
+    thread = Thread.new do
+      Thread.current.scheduler = scheduler
+      Thread.current.scheduler = nil
+
+      assert scheduler.closed?
+    end
+
+    thread.join
+  end
 end


### PR DESCRIPTION
This standardises the behaviour of handling scheduler behaviour at thread exit (including main thread/ec).