### PR TITLE
Make `Thread#join` non-blocking.

### DIFF
--- a/internal/scheduler.h
+++ b/internal/scheduler.h
@@ -19,7 +19,7 @@ VALUE rb_scheduler_close(VALUE scheduler);
 VALUE rb_scheduler_kernel_sleep(VALUE scheduler, VALUE duration);
 VALUE rb_scheduler_kernel_sleepv(VALUE scheduler, int argc, VALUE * argv);
 
-VALUE rb_scheduler_block(VALUE scheduler, VALUE blocker);
+VALUE rb_scheduler_block(VALUE scheduler, VALUE blocker, VALUE timeout);
 VALUE rb_scheduler_unblock(VALUE scheduler, VALUE blocker, VALUE fiber);
 
 VALUE rb_scheduler_io_wait(VALUE scheduler, VALUE io, VALUE events, VALUE timeout);

--- a/scheduler.c
+++ b/scheduler.c
@@ -61,9 +61,9 @@ VALUE rb_scheduler_kernel_sleepv(VALUE scheduler, int argc, VALUE * argv)
     return rb_funcallv(scheduler, id_kernel_sleep, argc, argv);
 }
 
-VALUE rb_scheduler_block(VALUE scheduler, VALUE blocker)
+VALUE rb_scheduler_block(VALUE scheduler, VALUE blocker, VALUE timeout)
 {
-    return rb_funcall(scheduler, id_block, 1, blocker);
+    return rb_funcall(scheduler, id_block, 2, blocker, timeout);
 }
 
 VALUE rb_scheduler_unblock(VALUE scheduler, VALUE blocker, VALUE fiber)

--- a/spec/ruby/core/thread/join_spec.rb
+++ b/spec/ruby/core/thread/join_spec.rb
@@ -19,8 +19,13 @@ describe "Thread#join" do
     t.join(0).should equal(t)
     t.join(0.0).should equal(t)
     t.join(nil).should equal(t)
+  end
+
+  it "raises TypeError if the argument is not a valid timeout" do
+    t = Thread.new {sleep}
     -> { t.join(:foo) }.should raise_error TypeError
     -> { t.join("bar") }.should raise_error TypeError
+    t.kill
   end
 
   it "returns nil if it is not finished when given a timeout" do

--- a/thread_sync.c
+++ b/thread_sync.c
@@ -246,7 +246,7 @@ mutex_owned_p(rb_fiber_t *fiber, rb_mutex_t *mutex)
 }
 
 static VALUE call_rb_scheduler_block(VALUE mutex) {
-    return rb_scheduler_block(rb_thread_current_scheduler(), mutex);
+    return rb_scheduler_block(rb_thread_current_scheduler(), mutex, Qnil);
 }
 
 static VALUE remove_from_mutex_lock_waiters(VALUE arg) {

--- a/vm_core.h
+++ b/vm_core.h
@@ -812,11 +812,6 @@ struct rb_unblock_callback {
 
 struct rb_mutex_struct;
 
-typedef struct rb_thread_list_struct{
-    struct rb_thread_list_struct *next;
-    struct rb_thread_struct *th;
-} rb_thread_list_t;
-
 typedef struct rb_ensure_entry {
     VALUE marker;
     VALUE (*e_proc)(VALUE);
@@ -831,6 +826,12 @@ typedef struct rb_ensure_list {
 typedef char rb_thread_id_string_t[sizeof(rb_nativethread_id_t) * 2 + 3];
 
 typedef struct rb_fiber_struct rb_fiber_t;
+
+struct rb_waiting_list {
+    struct rb_waiting_list *next;
+    struct rb_thread_struct *thread;
+    struct rb_fiber_struct *fiber;
+};
 
 struct rb_execution_context_struct {
     /* execution information */
@@ -958,7 +959,7 @@ typedef struct rb_thread_struct {
     VALUE locking_mutex;
     struct rb_mutex_struct *keeping_mutexes;
 
-    rb_thread_list_t *join_list;
+    struct rb_waiting_list *join_list;
 
     union {
         struct {


### PR DESCRIPTION
`Thread#join` being per-fiber non-blocking is going to be the most universal tool to addressing gaps in the current interface.

Things like `Process#wait` can be stuck on another thread, provided `Thread#join` is non-blocking.

The scheduler could choose to use a thread pool, (e.g. for `Process#spawn`) rather than extending the scheduler (maybe not supported to wait on PID).