### PR TITLE
Allow to share frozen structs between ractors

### DIFF
--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -261,7 +261,7 @@ assert_equal 'no _dump_data is defined for class Thread', %q{
 }
 
 # send sharable and unsharable objects
-assert_equal "[[[1, true], [:sym, true], [:xyzzy, true], [\"frozen\", true], " \
+assert_equal "[[[#<struct Person name=\"Matz\">, true], [1, true], [:sym, true], [:xyzzy, true], [\"frozen\", true], " \
              "[(3/1), true], [(3+4i), true], [/regexp/, true], [C, true]], " \
              "[[\"mutable str\", false], [[:array], false], [{:hash=>true}, false]]]", %q{
   r = Ractor.new do
@@ -273,7 +273,9 @@ assert_equal "[[[1, true], [:sym, true], [:xyzzy, true], [\"frozen\", true], " \
   class C
   end
 
-  sharable_objects = [1, :sym, 'xyzzy'.to_sym, 'frozen'.freeze, 1+2r, 3+4i, /regexp/, C]
+  Person = Struct.new(:name)
+
+  sharable_objects = [Person.new("Matz".freeze).freeze, 1, :sym, 'xyzzy'.to_sym, 'frozen'.freeze, 1+2r, 3+4i, /regexp/, C]
 
   sr = sharable_objects.map{|o|
     r << o

--- a/ractor.c
+++ b/ractor.c
@@ -1778,6 +1778,20 @@ rb_ractor_shareable_p_continue(VALUE obj)
             goto shareable;
         }
         return false;
+      case T_STRUCT:
+        if (!RB_OBJ_FROZEN_RAW(obj) ||
+            FL_TEST_RAW(obj, RUBY_FL_EXIVAR)) {
+            return false;
+        }
+        for (int i=0; i<RSTRUCT_LEN(obj); i++) {
+            VALUE item;
+            item = RSTRUCT_GET(obj, i);
+            if (!RB_OBJ_FROZEN_RAW(item) ||
+                FL_TEST_RAW(obj, RUBY_FL_EXIVAR)) {
+                return false;
+            }
+        }
+        goto shareable;
       case T_ARRAY:
         if (!RB_OBJ_FROZEN_RAW(obj) ||
             FL_TEST_RAW(obj, RUBY_FL_EXIVAR)) {


### PR DESCRIPTION
```ruby
Config = Struct.new(:min, :max)
module App
  DEFAULT_CONFIG = Config.new(10, 20).freeze
end

Ractor.new do
  # calls some code in App module that relies on DEFAULT_CONFIG
end
```

We should be developer friendly and allow ractors to reference frozen structs.

This attempts to address some of the feedback I've shared in https://bugs.ruby-lang.org/issues/17180.