### PR TITLE
Make hash returned by Hash#transform_values not have a default

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -3350,6 +3350,7 @@ rb_hash_transform_values(VALUE hash)
 
     RETURN_SIZED_ENUMERATOR(hash, 0, 0, hash_enum_size);
     result = hash_copy(hash_alloc(rb_cHash), hash);
+    SET_DEFAULT(result, Qnil);
 
     if (!RHASH_EMPTY_P(hash)) {
         rb_hash_stlike_foreach_with_replace(result, transform_values_foreach_func, transform_values_foreach_replace, result);

--- a/test/ruby/test_hash.rb
+++ b/test/ruby/test_hash.rb
@@ -1696,6 +1696,7 @@ class TestHash < Test::Unit::TestCase
     x.default_proc = proc {|h, k| k}
     y = x.transform_values {|v| v ** 2 }
     assert_nil(y.default_proc)
+    assert_nil(y.default)
 
     y = x.transform_values.with_index {|v, i| "#{v}.#{i}" }
     assert_equal(%w(1.0  2.1  3.2), y.values_at(:a, :b, :c))


### PR DESCRIPTION
This sets an explicit default of nil.  There is probably a better
approach of removing the default.

Fixes [Bug #17181]