### PR TITLE
Revert "Prevent SystemStackError when calling super in module with activated refinement

### DIFF
--- a/spec/ruby/core/module/refine_spec.rb
+++ b/spec/ruby/core/module/refine_spec.rb
@@ -980,77 +980,38 @@ describe "Module#refine" do
       result.should == [:B, :A, :LAST, :C]
     end
 
-    ruby_version_is ""..."3.0" do
-      it "looks in the lexical scope refinements before other active refinements" do
-        refined_class = ModuleSpecs.build_refined_class(for_super: true)
+    it "looks in the lexical scope refinements before other active refinements" do
+      refined_class = ModuleSpecs.build_refined_class(for_super: true)
 
-        refinement_local = Module.new do
-          refine refined_class do
-            def foo
-              [:LOCAL] + super
-            end
-          end
-        end
-
-        a = Module.new do
-          using refinement_local
-
+      refinement_local = Module.new do
+        refine refined_class do
           def foo
-            [:A] + super
+            [:LOCAL] + super
           end
         end
-
-        refinement = Module.new do
-          refine refined_class do
-            include a
-          end
-        end
-
-        result = nil
-        Module.new do
-          using refinement
-          result = refined_class.new.foo
-        end
-
-        result.should == [:A, :LOCAL, :C]
       end
-    end
 
-    ruby_version_is "3.0" do
-      # https://bugs.ruby-lang.org/issues/17007
-      it "does not look in the lexical scope refinements before other active refinements" do
-        refined_class = ModuleSpecs.build_refined_class(for_super: true)
+      a = Module.new do
+        using refinement_local
 
-        refinement_local = Module.new do
-          refine refined_class do
-            def foo
-              [:LOCAL] + super
-            end
-          end
+        def foo
+          [:A] + super
         end
-
-        a = Module.new do
-          using refinement_local
-
-          def foo
-            [:A] + super
-          end
-        end
-
-        refinement = Module.new do
-          refine refined_class do
-            include a
-          end
-        end
-
-        result = nil
-        Module.new do
-          using refinement
-          result = refined_class.new.foo
-        end
-
-        result.should == [:A, :C]
       end
+
+      refinement = Module.new do
+        refine refined_class do
+          include a
+        end
+      end
+
+      result = nil
+      Module.new do
+        using refinement
+        result = refined_class.new.foo
+      end
+
+      result.should == [:A, :LOCAL, :C]
     end
   end
 

--- a/test/ruby/test_refinement.rb
+++ b/test/ruby/test_refinement.rb
@@ -484,37 +484,6 @@ class TestRefinement < Test::Unit::TestCase
     assert_equal("M#baz C#baz", RefineModule.call_baz)
   end
 
-  module RefineIncludeActivatedSuper
-    class C
-      def foo
-        ["C"]
-      end
-    end
-
-    module M; end
-
-    refinement = Module.new do
-      R = refine C do
-        def foo
-          ["R"] + super
-        end
-
-        include M
-      end
-    end
-
-    using refinement
-    M.define_method(:foo){["M"] + super()}
-
-    def self.foo
-      C.new.foo
-    end
-  end
-
-  def test_refine_include_activated_super
-    assert_equal(["R", "M", "C"], RefineIncludeActivatedSuper.foo)
-  end
-
   def test_refine_neither_class_nor_module
     assert_raise(TypeError) do
       Module.new {

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -3043,9 +3043,6 @@ search_refined_method(rb_execution_context_t *ec, rb_control_frame_t *cfp, struc
         if (ref_me) {
             if (vm_cc_call(cc) == vm_call_super_method) {
                 const rb_control_frame_t *top_cfp = current_method_entry(ec, cfp);
-                if (refinement == find_refinement(CREF_REFINEMENTS(vm_get_cref(top_cfp->ep)), vm_cc_cme(cc)->owner)) {
-                    continue;
-                }
                 const rb_callable_method_entry_t *top_me = rb_vm_frame_method_entry(top_cfp);
                 if (top_me && rb_method_definition_eq(ref_me->def, top_me->def)) {
                     continue;


### PR DESCRIPTION
This reverts commit eeef16e190cdabc2ba474622720f8e3df7bac43b.

This also reverts the spec change.

Preventing the SystemStackError would be nice, but there is valid
code that the fix breaks, and it is probably more common than cases
that cause the SystemStackError.

Fixes [Bug #17182]