### PR TITLE
Fixed default coroutine selection for musl

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2524,7 +2524,10 @@ AS_CASE([$rb_cv_coroutine], [yes|''], [
             rb_cv_coroutine=copy
         ],
         [
-            rb_cv_coroutine=ucontext
+            AC_CHECK_FUNCS([getcontext swapcontext makecontext],
+                [rb_cv_coroutine=ucontext],
+                [rb_cv_coroutine=copy; break]
+            )
         ]
     )
     AC_MSG_RESULT(${rb_cv_coroutine})

--- a/coroutine/copy/Context.c
+++ b/coroutine/copy/Context.c
@@ -5,6 +5,8 @@
  *  Copyright, 2019, by Samuel Williams.
 */
 
+#include <sys/types.h>
+
 #include "Context.h"
 
 // http://gcc.gnu.org/onlinedocs/gcc/Alternate-Keywords.html

--- a/coroutine/copy/Context.c
+++ b/coroutine/copy/Context.c
@@ -5,8 +5,6 @@
  *  Copyright, 2019, by Samuel Williams.
 */
 
-#include <sys/types.h>
-
 #include "Context.h"
 
 // http://gcc.gnu.org/onlinedocs/gcc/Alternate-Keywords.html


### PR DESCRIPTION
Related issue https://bugs.ruby-lang.org/issues/16455.

I've tested this patch using `qemu user` + `aarch64_be-gentoo-linux-musl
` container. You can download it [here](https://hub.docker.com/r/puchuu/test_aarch64_be-gentoo-linux-musl). You can just try to `emerge -v dev-lang/ruby`: `aarch64-linux*` match in `configure.ac` fails and default coroutine become active.