### PR TITLE
Fix a use-after-free bug reported by ASAN

### DIFF
--- a/cont.c
+++ b/cont.c
@@ -940,9 +940,7 @@ cont_free(void *ptr)
     else {
         rb_fiber_t *fiber = (rb_fiber_t*)cont;
         coroutine_destroy(&fiber->context);
-        if (!fiber_is_root_p(fiber)) {
-            fiber_stack_release(fiber);
-        }
+        fiber_stack_release(fiber);
     }
 
     RUBY_FREE_UNLESS_NULL(cont->saved_vm_stack.ptr);


### PR DESCRIPTION
If a fiber and thread are collected at the same time, the thread might
get collected first and the pointer on the fiber will go bad.  I don't
think we need to check whether or not this is the main fiber in order to
release its stack