### PR TITLE
Ractor#close_outgoping cancel Ractor.yield

### DIFF
--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -257,6 +257,7 @@ assert_equal 'ok', %q{
     Ractor.recv
   end
 
+  sleep 0.01 # wait for Ractor.yield in r
   r.close_outgoing
   begin
     r.take

--- a/ractor.h
+++ b/ractor.h
@@ -47,6 +47,7 @@ struct rb_ractor_struct {
 
     bool incoming_port_closed;
     bool outgoing_port_closed;
+    bool yield_atexit;
 
     struct rb_ractor_waiting_list taking_ractors;
 


### PR DESCRIPTION
Ractor#close_outgoing should cancel waiting Ractor.yield. However,
yield a value by the Ractor's block should not cancel (to recognize
terminating Ractor, introduce rb_ractor_t::yield_atexit flag).

This patch fix the issue like:
https://github.com/ruby/ruby/runs/1152361318#step:14:70
```
# Raise Ractor::ClosedError when try to take from a ractor with closed outgoing port
assert_equal 'ok', %q{
  r = Ractor.new do
    Ractor.yield 1
    Ractor.recv
  end

  sleep 0.01 # wait for Ractor.yield in r
  r.close_outgoing
  begin
    r.take
  rescue Ractor::ClosedError
    'ok'
  else
    'ng'
  end
}
```
