### PR TITLE
Improve Ractor#select

### DIFF
--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -204,22 +204,20 @@ assert_equal '[0, 1, 2, "end"]', %q{
 }
 
 # Ractor#select should raise ClosedError if requested ractor is actively closed
-assert_equal '[]', %q{
+assert_equal 'ok', %q{
   r1 = Ractor.new do
     Ractor.yield Ractor.recv
   end
   r1.close
   r2 = Ractor.new { Ractor.yield Ractor.recv }
 
-  result = []
   begin
     loop do
       _r, message = Ractor.select(r1, r2)
-      result << message
     end
     'Not reachable' # This line is not supposed to be reached
   rescue Ractor::ClosedError => e
-    result.inspect
+    'ok'
   end
 }
 

--- a/ractor.c
+++ b/ractor.c
@@ -1743,7 +1743,7 @@ Init_Ractor(void)
     rb_eRactorError       = rb_define_class_under(rb_cRactor, "Error", rb_eRuntimeError);
     rb_eRactorRemoteError = rb_define_class_under(rb_cRactor, "RemoteError", rb_eRactorError);
     rb_eRactorMovedError  = rb_define_class_under(rb_cRactor, "MovedError",  rb_eRactorError);
-    rb_eRactorClosedError = rb_define_class_under(rb_cRactor, "ClosedError", rb_eStopIteration);
+    rb_eRactorClosedError = rb_define_class_under(rb_cRactor, "ClosedError", rb_eRactorError);
 
     rb_cRactorMovedObject = rb_define_class_under(rb_cRactor, "MovedObject", rb_cBasicObject);
     rb_undef_alloc_func(rb_cRactorMovedObject);

--- a/ractor.c
+++ b/ractor.c
@@ -927,7 +927,16 @@ ractor_select(rb_execution_context_t *ec, const VALUE *rs, int alen, VALUE yield
         ractor_basket_setup(ec, &cr->wait.yielded_basket, yielded_value, move, false);
     }
 
-    // TODO: shuffle actions
+    // Shuffle actions
+    i = alen - 1;
+    while (i > 0) {
+        int j = (int)rb_random_ulong_limited(rb_cRandom, i);
+        struct ractor_select_action tmp;
+        tmp = actions[i];
+        actions[i] = actions[j];
+        actions[j] = tmp;
+        i--;
+    }
 
     while (1) {
         RUBY_DEBUG_LOG("try actions (%s)", wait_status_str(wait_status));

--- a/ractor.rb
+++ b/ractor.rb
@@ -89,9 +89,11 @@ class Ractor
   end
 
   private def recv
-    __builtin_cexpr! %q{
-      // TODO: check current actor
-      ractor_recv(ec, RACTOR_PTR(self))
+    __builtin_cstmt! %q{
+      if (rb_ec_ractor_ptr(ec)->self != self) {
+        rb_raise(rb_eNoMethodError, "private method `recv' called");
+      }
+      return ractor_recv(ec, RACTOR_PTR(self));
     }
   end
 


### PR DESCRIPTION
- Recent implementation of Ractor#select waits for the readiness of input ractors in order. So, in may cases, it leads to deterministic starvation such that the second to last ractors in the input array never have a chance to be taken. For example:

```ruby
r1 = Ractor.new do
  loop do
    sleep 1
    Ractor.yield 'From r1'
  end
end

r2 = Ractor.new do
  loop do
    sleep 1
    Ractor.yield 'From r2'
  end
end

re = Ractor.new(Ractor.current) do |r|
  loop do
    sleep 1
    r.send 'To Main'
  end
end

loop do
  sleep 2
  r, message = Ractor.select(r1, r2, Ractor.current, yield_value: 'yielded')
  puts "#{r}: #{message}"
end
```

As r1's outgoing queue always has at least 1 item in its outgoing port, Ractor#select always return message from r1. The rest are not touch, and blocked forever.

The solution is to shuffle the actions array before processing it in `ractor_select`. After this change, if many ractors are ready, a random ractor is picked out from the arrray.

- Fix a bug when I use Reactor#select on a closed ractor. Consider this use case:

```ruby
r = Ractor.new do
  3.times do |index|
    Ractor.yield index
  end
  'end'
end

result = []
begin
  loop do
    _r, message = Ractor.select(r)
    result << message
  end
  puts 'Not reachable' # This line is not supposed to be reached
rescue Ractor::ClosedError => e
  puts result.inspect
end
```

After the ractor is closed, it should raises Ractor::ClosedError. In fact, it exits the wrapping loop and jumps to `Not reachable` line instead. 

- Fix a bug that `Ractor#recv` can be called from other ractor with `__send__`.

- Question: In the scenario that multiple ractors are taking from a same ractor, the current implementation is first-come-first-serve. The following example prints r1 -> r2 -> r1 -> r2 -> ... in order. Is it intentional, or should I shuffle the waiting list when adding a new waiting ractor too?

```
R = Ractor.current

r1 = Ractor.new do
  loop do
    R.take
    puts 'r1'
  end
end

r2 = Ractor.new do
  loop do
    R.take
    puts 'r2'
  end
end

loop do
  sleep 1
  Ractor.yield 1
end
```