### PR TITLE
Reapply webrick commits

### DIFF
--- a/lib/webrick/server.rb
+++ b/lib/webrick/server.rb
@@ -100,7 +100,7 @@ module WEBrick
       @logger.info("ruby #{rubyv}")
 
       @listeners = []
-      @shutdown_pipe = nil
+      @shutdown_pipe = @config[:ShutdownPipe]
       unless @config[:DoNotListen]
         raise ArgumentError, "Port must an integer" unless @config[:Port].to_s == @config[:Port].to_i.to_s
 

--- a/test/webrick/test_server.rb
+++ b/test/webrick/test_server.rb
@@ -161,6 +161,18 @@ class TestWEBrickServer < Test::Unit::TestCase
     }
   end
 
+  def test_shutdown_pipe
+    pipe = IO.pipe
+    server = WEBrick::GenericServer.new(
+      :ShutdownPipe => pipe,
+      :BindAddress => '0.0.0.0',
+      :Port => 0,
+      :Logger => WEBrick::Log.new([], WEBrick::BasicLog::WARN))
+    server_thread = Thread.start { server.start }
+    pipe.last.puts('')
+    assert_join_threads([server_thread])
+  end
+
   def test_port_numbers
     config = {
       :BindAddress => '0.0.0.0',

--- a/test/webrick/test_server.rb
+++ b/test/webrick/test_server.rb
@@ -176,9 +176,13 @@ class TestWEBrickServer < Test::Unit::TestCase
         :Logger => WEBrick::Log.new([], WEBrick::BasicLog::WARN))
       server_threads << Thread.start { server.start }
       sleep 0.1 until server.status == :Running || !server_threads.last.status
-      if server_threads.last.status
-        pipe.last.puts('')
-        break
+      begin
+        if server_threads.last.status
+          pipe.last.puts('')
+          break
+        end
+      rescue IOError
+        nil
       end
     end
     assert_join_threads(server_threads)


### PR DESCRIPTION
@jeremyevans I reverted the following PRs

* https://github.com/ruby/webrick/pull/44
* https://github.com/ruby/webrick/pull/50
* https://github.com/ruby/webrick/pull/54

Because `test-spec` was failed with https://github.com/ruby/ruby/runs/1160423667?check_suite_focus=true#step:14:752 

and `test-all` was broken on sky that are @ko1 's test environment. 

We should fix `test-spec` at least.