### PR TITLE
Add connect_timeout to TCPSocket

### DIFF
--- a/ext/socket/rubysocket.h
+++ b/ext/socket/rubysocket.h
@@ -350,7 +350,7 @@ int rsock_socket(int domain, int type, int proto);
 int rsock_detect_cloexec(int fd);
 VALUE rsock_init_sock(VALUE sock, int fd);
 VALUE rsock_sock_s_socketpair(int argc, VALUE *argv, VALUE klass);
-VALUE rsock_init_inetsock(VALUE sock, VALUE remote_host, VALUE remote_serv, VALUE local_host, VALUE local_serv, int type, VALUE resolv_timeout);
+VALUE rsock_init_inetsock(VALUE sock, VALUE remote_host, VALUE remote_serv, VALUE local_host, VALUE local_serv, int type, VALUE resolv_timeout, VALUE connect_timeout);
 VALUE rsock_init_unixsock(VALUE sock, VALUE path, int server);
 
 struct rsock_send_arg {
@@ -375,7 +375,7 @@ VALUE rsock_s_recvfrom_nonblock(VALUE sock, VALUE len, VALUE flg, VALUE str,
 			        VALUE ex, enum sock_recv_type from);
 VALUE rsock_s_recvfrom(VALUE sock, int argc, VALUE *argv, enum sock_recv_type from);
 
-int rsock_connect(int fd, const struct sockaddr *sockaddr, int len, int socks);
+int rsock_connect(int fd, const struct sockaddr *sockaddr, int len, int socks, struct timeval *timeout);
 
 VALUE rsock_s_accept(VALUE klass, int fd, struct sockaddr *sockaddr, socklen_t *len);
 VALUE rsock_s_accept_nonblock(VALUE klass, VALUE ex, rb_io_t *fptr,

--- a/ext/socket/socket.c
+++ b/ext/socket/socket.c
@@ -393,7 +393,7 @@ sock_connect(VALUE sock, VALUE addr)
     addr = rb_str_new4(addr);
     GetOpenFile(sock, fptr);
     fd = fptr->fd;
-    n = rsock_connect(fd, (struct sockaddr*)RSTRING_PTR(addr), RSTRING_SOCKLEN(addr), 0);
+    n = rsock_connect(fd, (struct sockaddr*)RSTRING_PTR(addr), RSTRING_SOCKLEN(addr), 0, NULL);
     if (n < 0) {
 	rsock_sys_fail_raddrinfo_or_sockaddr("connect(2)", addr, rai);
     }

--- a/ext/socket/tcpserver.c
+++ b/ext/socket/tcpserver.c
@@ -36,7 +36,7 @@ tcp_svr_init(int argc, VALUE *argv, VALUE sock)
     VALUE hostname, port;
 
     rb_scan_args(argc, argv, "011", &hostname, &port);
-    return rsock_init_inetsock(sock, hostname, port, Qnil, Qnil, INET_SERVER, Qnil);
+    return rsock_init_inetsock(sock, hostname, port, Qnil, Qnil, INET_SERVER, Qnil, Qnil);
 }
 
 /*

--- a/ext/socket/tcpsocket.c
+++ b/ext/socket/tcpsocket.c
@@ -12,13 +12,14 @@
 
 /*
  * call-seq:
- *    TCPSocket.new(remote_host, remote_port, local_host=nil, local_port=nil, resolv_timeout: nil)
+ *    TCPSocket.new(remote_host, remote_port, local_host=nil, local_port=nil, resolv_timeout: nil, connect_timeout: nil)
  *
  * Opens a TCP connection to +remote_host+ on +remote_port+.  If +local_host+
  * and +local_port+ are specified, then those parameters are used on the local
  * end to establish the connection.
  *
  * [:resolv_timeout] specify the name resolution timeout in seconds.
+ * [:connect_timeout] specify the timeout in seconds.
  */
 static VALUE
 tcp_init(int argc, VALUE *argv, VALUE sock)
@@ -26,27 +27,28 @@ tcp_init(int argc, VALUE *argv, VALUE sock)
     VALUE remote_host, remote_serv;
     VALUE local_host, local_serv;
     VALUE opt;
-    static ID keyword_ids[1];
-    VALUE kwargs[1];
+    static ID keyword_ids[2];
+    VALUE kwargs[2];
     VALUE resolv_timeout = Qnil;
+    VALUE connect_timeout = Qnil;
 
     if (!keyword_ids[0]) {
 	CONST_ID(keyword_ids[0], "resolv_timeout");
+	CONST_ID(keyword_ids[1], "connect_timeout");
     }
 
     rb_scan_args(argc, argv, "22:", &remote_host, &remote_serv,
 			&local_host, &local_serv, &opt);
 
     if (!NIL_P(opt)) {
-	rb_get_kwargs(opt, keyword_ids, 0, 1, kwargs);
-	if (kwargs[0] != Qundef) {
-	    resolv_timeout = kwargs[0];
-	}
+	rb_get_kwargs(opt, keyword_ids, 0, 2, kwargs);
+	if (kwargs[0] != Qundef) { resolv_timeout = kwargs[0]; }
+	if (kwargs[1] != Qundef) { connect_timeout = kwargs[1]; }
     }
 
     return rsock_init_inetsock(sock, remote_host, remote_serv,
 			       local_host, local_serv, INET_CLIENT,
-			       resolv_timeout);
+			       resolv_timeout, connect_timeout);
 }
 
 static VALUE

--- a/ext/socket/udpsocket.c
+++ b/ext/socket/udpsocket.c
@@ -60,7 +60,7 @@ udp_connect_internal(VALUE v)
     rb_io_check_closed(fptr = arg->fptr);
     fd = fptr->fd;
     for (res = arg->res->ai; res; res = res->ai_next) {
-	if (rsock_connect(fd, res->ai_addr, res->ai_addrlen, 0) >= 0) {
+	if (rsock_connect(fd, res->ai_addr, res->ai_addrlen, 0, NULL) >= 0) {
 	    return Qtrue;
 	}
     }

--- a/ext/socket/unixsocket.c
+++ b/ext/socket/unixsocket.c
@@ -22,7 +22,7 @@ unixsock_connect_internal(VALUE a)
 {
     struct unixsock_arg *arg = (struct unixsock_arg *)a;
     return (VALUE)rsock_connect(arg->fd, (struct sockaddr*)arg->sockaddr,
-			        arg->sockaddrlen, 0);
+			        arg->sockaddrlen, 0, NULL);
 }
 
 static VALUE

--- a/test/socket/test_tcp.rb
+++ b/test/socket/test_tcp.rb
@@ -69,6 +69,12 @@ class TestSocket_TCPSocket < Test::Unit::TestCase
     end
   end
 
+  def test_initialize_connect_timeout
+    assert_raise(Errno::ETIMEDOUT) do
+      TCPSocket.new("192.0.2.1", 80, connect_timeout: 0)
+    end
+  end
+
   def test_recvfrom
     TCPServer.open("localhost", 0) {|svr|
       th = Thread.new {


### PR DESCRIPTION
Add connect_timeout to TCPSocket.new in the same way as Socket.tcp.
https://bugs.ruby-lang.org/issues/17187

```ruby
TCPSocket.new("192.0.2.1", 1234, connect_timeout: 1) #=> raise Errno::ETIMEDOUT
```