### PR TITLE
Put same frozen Range literal if possible

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -8636,8 +8636,8 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
 	VALUE flag = INT2FIX(excl);
 	const NODE *b = node->nd_beg;
 	const NODE *e = node->nd_end;
-        // TODO: Ractor can not use cached Range objects
-	if (0 && optimizable_range_item_p(b) && optimizable_range_item_p(e)) {
+
+        if (optimizable_range_item_p(b) && optimizable_range_item_p(e)) {
 	    if (!popped) {
                 VALUE bv = nd_type(b) == NODE_LIT ? b->nd_lit : Qnil;
                 VALUE ev = nd_type(e) == NODE_LIT ? e->nd_lit : Qnil;


### PR DESCRIPTION
Range literal is now frozen so we can reuse same Range object if
the begin and the last are Numeric (frozen), such as `(1..2)`.