### PR TITLE
Fibers should update themselves on compaction

### DIFF
--- a/vm.c
+++ b/vm.c
@@ -2658,11 +2658,10 @@ static void
 thread_compact(void *ptr)
 {
     rb_thread_t *th = ptr;
-    rb_fiber_update_self(th->ec->fiber_ptr);
 
-    if (th->root_fiber) rb_fiber_update_self(th->root_fiber);
-
-    rb_execution_context_update(th->ec);
+    if (!th->root_fiber) {
+        rb_execution_context_update(th->ec);
+    }
 }
 
 static void


### PR DESCRIPTION
We should let fibers update their own references on compaction.  I don't
think we need the thread to update the associated fiber because there
will be a fiber object on the heap that knows how to update itself.