### PR TITLE
Make ext/objspace ASAN friendly

### DIFF
--- a/ext/objspace/objspace.c
+++ b/ext/objspace/objspace.c
@@ -59,7 +59,7 @@ total_i(void *vstart, void *vend, size_t stride, void *ptr)
     struct total_data *data = (struct total_data *)ptr;
 
     for (v = (VALUE)vstart; v != (VALUE)vend; v += stride) {
-        void *ptr = asan_poisoned_object_p(v);
+        void *poisoned = asan_poisoned_object_p(v);
         asan_unpoison_object(v, false);
 
 	if (RBASIC(v)->flags) {
@@ -77,7 +77,7 @@ total_i(void *vstart, void *vend, size_t stride, void *ptr)
 	    }
 	}
 
-        if (ptr) {
+        if (poisoned) {
             asan_poison_object(v);
         }
     }

--- a/vm.c
+++ b/vm.c
@@ -25,6 +25,7 @@
 #include "internal/re.h"
 #include "internal/symbol.h"
 #include "internal/vm.h"
+#include "internal/sanitizers.h"
 #include "iseq.h"
 #include "mjit.h"
 #include "ruby/st.h"

--- a/vm_method.c
+++ b/vm_method.c
@@ -240,6 +240,8 @@ invalidate_all_cc(void *vstart, void *vend, size_t stride, void *data)
 {
     VALUE v = (VALUE)vstart;
     for (; v != (VALUE)vend; v += stride) {
+        void *ptr = asan_poisoned_object_p(v);
+        asan_unpoison_object(v, false);
         if (RBASIC(v)->flags) { // liveness check
             if (RB_TYPE_P(v, T_CLASS) ||
                 RB_TYPE_P(v, T_ICLASS)) {
@@ -248,6 +250,9 @@ invalidate_all_cc(void *vstart, void *vend, size_t stride, void *data)
                 }
                 RCLASS_CC_TBL(v) = NULL;
             }
+        }
+        if (ptr) {
+            asan_poison_object(v);
         }
     }
     return 0; // continue to iteration


### PR DESCRIPTION
ext/objspace iterates over the heap, but some slots in the heap are
poisoned, so we need to take care of that when running with ASAN