### PR TITLE
ostruct fixes & tweaks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -411,7 +411,7 @@ Excluding feature bug fixes.
 
 * RBS is a new language for type definition of Ruby programs.
   It allows writing types of classes and modules with advanced
-  types including union types, overloading, generics, and 
+  types including union types, overloading, generics, and
   _interface types_ for duck typing.
 
 * Ruby ships with type definitions for core/stdlib classes.

--- a/NEWS.md
+++ b/NEWS.md
@@ -275,6 +275,7 @@ Outstanding ones only.
     * Builtin methods can now be overridden safely. [[Bug #15409]]
     * Implementation uses only methods ending with `!`.
     * Ractor compatible.
+    * Improved support for YAML [[Bug #8382]]
     * Use officially discouraged. Read "Caveats" section.
 
 * Reline

--- a/NEWS.md
+++ b/NEWS.md
@@ -269,6 +269,14 @@ Outstanding ones only.
 
     * Update to IRB 1.2.6
 
+* OpenStruct
+
+    * Initialization no longer lazy [[Bug #12136]]
+    * Builtin methods can now be overridden safely. [[Bug #15409]]
+    * Implementation uses only methods ending with `!`.
+    * Ractor compatible.
+    * Use officially discouraged. Read "Caveats" section.
+
 * Reline
 
     * Update to Reline 0.1.5

--- a/lib/ostruct.rb
+++ b/lib/ostruct.rb
@@ -62,6 +62,8 @@
 #   first_pet                 # => #<OpenStruct name="Rowdy">
 #   first_pet == second_pet   # => true
 #
+# Ractor compatibility: A frozen OpenStruct with shareable values is itself shareable.
+#
 # == Caveats
 #
 # An OpenStruct utilizes Ruby's method lookup structure to find and define the

--- a/lib/ostruct.rb
+++ b/lib/ostruct.rb
@@ -121,11 +121,10 @@ class OpenStruct
   #   data   # => #<OpenStruct country="Australia", capital="Canberra">
   #
   def initialize(hash=nil)
-    @table = {}
     if hash
-      hash.each_pair do |k, v|
-        set_ostruct_member_value!(k, v)
-      end
+      update_to_values!(hash)
+    else
+      @table = {}
     end
   end
 
@@ -137,7 +136,14 @@ class OpenStruct
 
   private def initialize_dup(orig) # :nodoc:
     super
-    initialize(@table)
+    update_to_values!(@table)
+  end
+
+  private def update_to_values!(hash) # :nodoc:
+    @table = {}
+    hash.each_pair do |k, v|
+      set_ostruct_member_value!(k, v)
+    end
   end
 
   #

--- a/lib/ostruct.rb
+++ b/lib/ostruct.rb
@@ -76,6 +76,10 @@
 # Creating an open struct from a small Hash and accessing a few of the
 # entries can be 200 times slower than accessing the hash directly.
 #
+# This is a potential security issue; building OpenStruct from untrusted user data
+# (e.g. JSON web request) may be susceptible to a "symbol denial of service" attack
+# since the keys create methods and names of methods are never garbage collected.
+#
 # This may also be the source of incompatibilities between Ruby versions:
 #
 #   o = OpenStruct.new
@@ -191,14 +195,14 @@ class OpenStruct
   #
   # Provides marshalling support for use by the Marshal library.
   #
-  def marshal_dump
+  def marshal_dump # :nodoc:
     @table
   end
 
   #
   # Provides marshalling support for use by the Marshal library.
   #
-  def marshal_load(x)
+  def marshal_load(x) # :nodoc:
     x.each_key{|key| new_ostruct_member!(key)}
     @table = x
   end
@@ -253,7 +257,7 @@ class OpenStruct
   # :call-seq:
   #   ostruct[name]  -> object
   #
-  # Returns the value of an attribute.
+  # Returns the value of an attribute, or `nil` if there is no such attribute.
   #
   #   require "ostruct"
   #   person = OpenStruct.new("name" => "John Smith", "age" => 70)
@@ -313,7 +317,7 @@ class OpenStruct
   #
   #   person = OpenStruct.new(name: "John", age: 70, pension: 300)
   #
-  #   person.delete_field("age")   # => 70
+  #   person.delete_field!("age")  # => 70
   #   person                       # => #<OpenStruct name="John", pension=300>
   #
   # Setting the value to +nil+ will not remove the attribute:
@@ -388,11 +392,7 @@ class OpenStruct
   end
 
   # Computes a hash code for this OpenStruct.
-  # Two OpenStruct objects with the same content will have the same hash code
-  # (and will compare using #eql?).
-  #
-  # See also Object#hash.
-  def hash
+  def hash # :nodoc:
     @table.hash
   end
 

--- a/lib/ostruct.rb
+++ b/lib/ostruct.rb
@@ -239,8 +239,6 @@ class OpenStruct
       end
       set_ostruct_member_value!(mname, args[0])
     elsif len == 0
-    elsif @table.key?(mid)
-      raise! ArgumentError, "wrong number of arguments (given #{len}, expected 0)"
     else
       begin
         super

--- a/lib/ostruct.rb
+++ b/lib/ostruct.rb
@@ -398,6 +398,33 @@ class OpenStruct
     @table.hash
   end
 
+  #
+  # Provides marshalling support for use by the YAML library.
+  #
+  def encode_with(coder) # :nodoc:
+    @table.each_pair do |key, value|
+      coder[key.to_s] = value
+    end
+    if @table.size == 1 && @table.key?(:table) # support for legacy format
+      # in the very unlikely case of a single entry called 'table'
+      coder['legacy_support!'] = true # add a bogus second entry
+    end
+  end
+
+  #
+  # Provides marshalling support for use by the YAML library.
+  #
+  def init_with(coder) # :nodoc:
+    h = coder.map
+    if h.size == 1 # support for legacy format
+      key, val = h.first
+      if key == 'table'
+        h = val
+      end
+    end
+    update_to_values!(h)
+  end
+
   # Make all public methods (builtin or our own) accessible with `!`:
   instance_methods.each do |method|
     new_name = "#{method}!"

--- a/lib/ostruct.rb
+++ b/lib/ostruct.rb
@@ -94,17 +94,14 @@
 #   o.class # => :luxury
 #   o.class! # => OpenStruct
 #
-# It is recommended (but not enforced) to not use fields ending in `!`.
+# It is recommended (but not enforced) to not use fields ending in `!`;
+# Note that a subclass' methods may not be overwritten, nor can OpenStruct's own methods
+# ending with `!`.
 #
 # For all these reasons, consider not using OpenStruct at all.
 #
 class OpenStruct
   VERSION = "0.2.0"
-
-  instance_methods.each do |method|
-    new_name = "#{method}!"
-    alias_method new_name, method
-  end
 
   #
   # Creates a new OpenStruct object.  By default, the resulting OpenStruct
@@ -164,7 +161,7 @@ class OpenStruct
   #               # => {"country" => "AUSTRALIA", "capital" => "CANBERRA" }
   #
   def to_h(&block)
-    if block_given?
+    if block
       @table.to_h(&block)
     else
       @table.dup
@@ -210,12 +207,22 @@ class OpenStruct
   # define_singleton_method for both the getter method and the setter method.
   #
   def new_ostruct_member!(name) # :nodoc:
-    unless @table.key?(name)
-      define_singleton_method(name) { @table[name] }
-      define_singleton_method("#{name}=") {|x| @table[name] = x}
+    unless @table.key?(name) || is_method_protected!(name)
+      define_singleton_method!(name) { @table[name] }
+      define_singleton_method!("#{name}=") {|x| @table[name] = x}
     end
   end
   private :new_ostruct_member!
+
+  private def is_method_protected!(name) # :nodoc:
+    if !respond_to?(name, true)
+      false
+    elsif name.end_with?('!')
+      true
+    else
+      method!(name).owner < OpenStruct
+    end
+  end
 
   def freeze
     @table.freeze
@@ -226,18 +233,18 @@ class OpenStruct
     len = args.length
     if mname = mid[/.*(?==\z)/m]
       if len != 1
-        raise ArgumentError, "wrong number of arguments (given #{len}, expected 1)", caller(1)
+        raise! ArgumentError, "wrong number of arguments (given #{len}, expected 1)", caller(1)
       end
       set_ostruct_member_value!(mname, args[0])
     elsif len == 0
     elsif @table.key?(mid)
-      raise ArgumentError, "wrong number of arguments (given #{len}, expected 0)"
+      raise! ArgumentError, "wrong number of arguments (given #{len}, expected 0)"
     else
       begin
         super
       rescue NoMethodError => err
         err.backtrace.shift
-        raise
+        raise!
       end
     end
   end
@@ -293,7 +300,7 @@ class OpenStruct
     begin
       name = name.to_sym
     rescue NoMethodError
-      raise TypeError, "#{name} is not a symbol nor a string"
+      raise! TypeError, "#{name} is not a symbol nor a string"
     end
     @table.dig(name, *names)
   end
@@ -321,7 +328,7 @@ class OpenStruct
     rescue NameError
     end
     @table.delete(sym) do
-      raise NameError.new("no field `#{sym}' in #{self}", sym)
+      raise! NameError.new("no field `#{sym}' in #{self}", sym)
     end
   end
 
@@ -344,13 +351,13 @@ class OpenStruct
         ids.pop
       end
     end
-    ['#<', self.class, detail, '>'].join
+    ['#<', self.class!, detail, '>'].join
   end
   alias :to_s :inspect
 
   attr_reader :table # :nodoc:
-  protected :table
   alias table! table
+  protected :table!
 
   #
   # Compares this object and +other+ for equality.  An OpenStruct is equal to
@@ -388,4 +395,13 @@ class OpenStruct
   def hash
     @table.hash
   end
+
+  # Make all public methods (builtin or our own) accessible with `!`:
+  instance_methods.each do |method|
+    new_name = "#{method}!"
+    alias_method new_name, method
+  end
+  # Other builtin private methods we use:
+  alias_method :raise!, :raise
+  private :raise!
 end

--- a/spec/ruby/library/yaml/dump_spec.rb
+++ b/spec/ruby/library/yaml/dump_spec.rb
@@ -37,7 +37,9 @@ describe "YAML.dump" do
   it "dumps an OpenStruct" do
     require "ostruct"
     os = OpenStruct.new("age" => 20, "name" => "John")
-    YAML.dump(os).should match_yaml("--- !ruby/object:OpenStruct\ntable:\n  :age: 20\n  :name: John\n")
+    os2 = YAML.load(YAML.dump(os))
+    os2.age.should == 20
+    os2.name.should == "John"
   end
 
   it "dumps a File without any state" do

--- a/test/ostruct/test_ostruct.rb
+++ b/test/ostruct/test_ostruct.rb
@@ -204,6 +204,15 @@ class TC_OpenStruct < Test::Unit::TestCase
     assert_instance_of(c, os)
   end
 
+  def test_initialize_subclass
+    c = Class.new(OpenStruct) {
+      def initialize(x,y={})super(y);end
+    }
+    o = c.new(1, {a: 42})
+    assert_equal(42, o.dup.a)
+    assert_equal(42, o.clone.a)
+  end
+
   def test_private_method
     os = OpenStruct.new
     class << os

--- a/test/ostruct/test_ostruct.rb
+++ b/test/ostruct/test_ostruct.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require 'test/unit'
 require 'ostruct'
+require 'yaml'
 
 class TC_OpenStruct < Test::Unit::TestCase
   def test_initialize
@@ -309,4 +310,24 @@ class TC_OpenStruct < Test::Unit::TestCase
     end.take
     assert obj1.object_id == obj2.object_id
   end if defined?(Ractor)
+
+  def test_legacy_yaml
+    s = "--- !ruby/object:OpenStruct\ntable:\n  :foo: 42\n"
+    o = YAML.load(s)
+    assert_equal(42, o.foo)
+
+    o = OpenStruct.new(table: {foo: 42})
+    assert_equal({foo: 42}, YAML.load(YAML.dump(o)).table)
+  end
+
+  def test_yaml
+    h = {name: "John Smith", age: 70, pension: 300.42}
+    yaml = "--- !ruby/object:OpenStruct\nname: John Smith\nage: 70\npension: 300.42\n"
+    os1 = OpenStruct.new(h)
+    os2 = YAML.load(os1.to_yaml)
+    assert_equal yaml, os1.to_yaml
+    assert_equal os1, os2
+    assert_equal true, os1.eql?(os2)
+    assert_equal 300.42, os2.pension
+  end
 end

--- a/test/ostruct/test_ostruct.rb
+++ b/test/ostruct/test_ostruct.rb
@@ -298,4 +298,15 @@ class TC_OpenStruct < Test::Unit::TestCase
     o.foo = 42
     assert_equal 42, o.foo
   end
+
+  def test_ractor
+    obj1 = OpenStruct.new(a: 42, b: 42)
+    obj1.c = 42
+    obj1.freeze
+
+    obj2 = Ractor.new obj1 do |obj|
+      obj
+    end.take
+    assert obj1.object_id == obj2.object_id
+  end if defined?(Ractor)
 end


### PR DESCRIPTION
This PR fixes most open issues and requests for `ostruct`.

* It builds on recent changes to make the limit between overridable methods and non-overridable methods well defined.
* It improves YAML serialization.

Also tests that recent changes make `OpenStruct` Ractor-shareable.

