### PR TITLE
Reference process PID using the Process.pid

### DIFF
--- a/lib/logger/formatter.rb
+++ b/lib/logger/formatter.rb
@@ -12,7 +12,7 @@ class Logger
     end
 
     def call(severity, time, progname, msg)
-      Format % [severity[0..0], format_datetime(time), $$, severity, progname,
+      Format % [severity[0..0], format_datetime(time), Process.pid, severity, progname,
         msg2str(msg)]
     end
 


### PR DESCRIPTION
This change will allow formatter to run from Ractors other than main.

bug report here: https://bugs.ruby-lang.org/issues/17203