### PR TITLE
Fix unsigned int overflow in error message for chr

### DIFF
--- a/numeric.c
+++ b/numeric.c
@@ -3417,7 +3417,7 @@ int_chr(int argc, VALUE *argv, VALUE num)
 	if (0xff < i) {
 	    enc = rb_default_internal_encoding();
 	    if (!enc) {
-		rb_raise(rb_eRangeError, "%d out of char range", i);
+		rb_raise(rb_eRangeError, "%u out of char range", i);
 	    }
 	    goto decode;
 	}

--- a/test/ruby/test_integer.rb
+++ b/test/ruby/test_integer.rb
@@ -260,6 +260,7 @@ class TestInteger < Test::Unit::TestCase
     assert_equal("a", "a".ord.chr)
     assert_raise(RangeError) { (-1).chr }
     assert_raise(RangeError) { 0x100.chr }
+    assert_raise_with_message(RangeError, "3000000000 out of char range") { 3_000_000_000.chr }
   end
 
   def test_upto


### PR DESCRIPTION
The error message has an integer overflow because it treats an unsigned int as a signed int.

Before:
```
> 3_000_000_000.chr
-1294967296 out of char range (RangeError)
```

After:
```
> 3_000_000_000.chr
3000000000 out of char range (RangeError)
```

Redmine ticket: https://bugs.ruby-lang.org/issues/17186