### PR TITLE
Experiment to add signposts to instructions

### DIFF
--- a/tool/ruby_vm/views/_insn_entry.erb
+++ b/tool/ruby_vm/views/_insn_entry.erb
@@ -13,6 +13,7 @@ INSN_ENTRY(<%= insn.name %>)
 {
     /* ###  Declare that we have just entered into an instruction. ### */
     START_OF_ORIGINAL_INSN(<%= insn.name %>);
+    INSN_SIGNPOST_ENTER(<%=cstr insn.name %>);
     DEBUG_ENTER_INSN(<%=cstr insn.name %>);
 
     /* ###  Declare and assign variables. ### */
@@ -72,5 +73,6 @@ INSN_ENTRY(<%= insn.name %>)
 #   undef INSN_ATTR
 
     /* ### Leave the instruction. ### */
+    INSN_SIGNPOST_EXIT(<%=cstr insn.name %>);
     END_INSN(<%= insn.name %>);
 }

--- a/vm.c
+++ b/vm.c
@@ -47,6 +47,11 @@
 #endif
 #include "probes_helper.h"
 
+#include <os/signpost.h>
+
+os_log_t event_log;
+unsigned long long signpost_id;
+
 VALUE rb_str_concat_literals(size_t, const VALUE*);
 
 /* :FIXME: This #ifdef is because we build pch in case of mswin and
@@ -3083,6 +3088,9 @@ Init_VM(void)
     VALUE klass;
     VALUE fcore;
     VALUE mjit;
+
+    event_log = os_log_create("RubyVM", OS_LOG_CATEGORY_POINTS_OF_INTEREST);
+    signpost_id = os_signpost_id_generate(event_log);
 
     /*
      * Document-class: RubyVM

--- a/vm_core.h
+++ b/vm_core.h
@@ -763,7 +763,12 @@ typedef struct rb_control_frame_struct {
 #endif
 } rb_control_frame_t;
 
+#include <os/signpost.h>
+
 extern const rb_data_type_t ruby_threadptr_data_type;
+
+extern os_log_t event_log;
+extern unsigned long long signpost_id;
 
 static inline struct rb_thread_struct *
 rb_thread_ptr(VALUE thval)

--- a/vm_exec.c
+++ b/vm_exec.c
@@ -65,6 +65,9 @@ static void vm_insns_counter_count_insn(int insn) {}
 #endif
 /* #define DECL_SC_REG(r, reg) VALUE reg_##r */
 
+#define INSN_SIGNPOST_ENTER(name) os_signpost_interval_begin(event_log, signpost_id, name);
+#define INSN_SIGNPOST_EXIT(name) os_signpost_interval_end(event_log, signpost_id, name);
+
 #if !OPT_CALL_THREADED_CODE
 static VALUE
 vm_exec_core(rb_execution_context_t *ec, VALUE initial)


### PR DESCRIPTION
This is just an experiment to add sign posts to instructions so we can
see instruction profiles from instruments.

This is just a POC commit to demonstrate integrating [signposts](https://developer.apple.com/videos/play/wwdc2018/405/) in the VM.  Here is what a profile looks like in instruments:

<img width="1835" alt="instrumentscli2 2020-09-29 17-10-21" src="https://user-images.githubusercontent.com/3124/94629242-07ca6300-0277-11eb-8943-05c4d1510b46.png">

I think the overhead for this is way too high to integrate, but I wanted to send this PR in case anyone is interested.