### PR TITLE
Expand relative paths before calling children

### DIFF
--- a/ext/pathname/lib/pathname.rb
+++ b/ext/pathname/lib/pathname.rb
@@ -443,7 +443,9 @@ class Pathname
   def children(with_directory=true)
     with_directory = false if @path == '.'
     result = []
-    Dir.foreach(@path) {|e|
+    path = absolute? ? @path : expand_path.to_s
+
+    Dir.foreach(path) {|e|
       next if e == '.' || e == '..'
       if with_directory
         result << self.class.new(File.join(@path, e))

--- a/test/pathname/test_pathname.rb
+++ b/test/pathname/test_pathname.rb
@@ -648,6 +648,10 @@ class TestPathname < Test::Unit::TestCase
     }
   end
 
+  def test_children_path_expansion
+    assert_nothing_raised { Pathname("~/").children }
+  end
+
   def test_each_child
     with_tmpchdir('rubytest-pathname') {|dir|
       open("a", "w") {}


### PR DESCRIPTION
This avoids having to explicitly call `expand_path` for some relative
paths:

Before:
```
Pathname.new("~/tmp").children #=> Errno::NOENT
Pathname.new("../tmp").children #=> No error
```

After:
```
Pathname.new("~/tmp").children #=> No error
Pathname.new("../tmp").children #=> No error
```