### PR TITLE
Scheduler optional close

### DIFF
--- a/scheduler.c
+++ b/scheduler.c
@@ -39,7 +39,9 @@ Init_Scheduler(void)
 
 VALUE rb_scheduler_close(VALUE scheduler)
 {
-    return rb_funcall(scheduler, id_close, 0);
+    if (rb_respond_to(scheduler, id_close)) {
+        return rb_funcall(scheduler, id_close, 0);
+    }
 }
 
 VALUE

--- a/test/fiber/scheduler.rb
+++ b/test/fiber/scheduler.rb
@@ -101,6 +101,8 @@ class Scheduler
   end
 
   def close
+    raise "Scheduler already closed!" if @closed
+
     self.run
   ensure
     @closed = true

--- a/test/fiber/test_scheduler.rb
+++ b/test/fiber/test_scheduler.rb
@@ -49,4 +49,12 @@ class TestFiberScheduler < Test::Unit::TestCase
     end
     RUBY
   end
+
+  def test_optional_close
+    thread = Thread.new do
+      Thread.current.scheduler = Object.new
+    end
+    
+    thread.join
+  end
 end


### PR DESCRIPTION
Stuck because there is no `close`

``` ruby
class Scheduler
  def fiber &b
    p b
  end
end

Thread.current.scheduler = Scheduler.new

Fiber.schedule do
  p 1
end
```