### PR TITLE
Add `Set#compact` and `Set#compact!` methods

### DIFF
--- a/lib/set.rb
+++ b/lib/set.rb
@@ -168,6 +168,28 @@ class Set
     self
   end
 
+  # Removes the nil element from self. Returns self if the element was removed,
+  # otherwise nil.
+  #
+  #     set = Set[1, 'c', nil]            #=> #<Set: {1, "c", nil}>
+  #     set.compact!                      #=> #<Set: {1, "c"}>
+  #     set                               #=> #<Set: {1, "c"}>
+  def compact!
+    @hash.delete(nil) { return nil }
+    self
+  end
+
+  # Returns a new Set containing all non-nil elements from self.
+  #
+  #     set = Set[1, 'c', nil]            #=> #<Set: {1, "c", nil}>
+  #     set.compact                       #=> #<Set: {1, "c"}>
+  #     set                               #=> #<Set: {1, "c", nil}>
+  def compact
+    set = dup
+    set.compact!
+    set
+  end
+
   # Replaces the contents of the set with the contents of the given
   # enumerable object and returns self.
   #

--- a/test/test_set.rb
+++ b/test/test_set.rb
@@ -96,6 +96,37 @@ class TC_Set < Test::Unit::TestCase
     assert_equal(true, set.empty?)
   end
 
+  def test_compact!
+    set = Set[1,2,nil]
+    ret = set.compact!
+
+    assert_equal(Set[1,2], set)
+    assert_equal(Set[1,2], ret)
+    assert_same(set, ret)
+
+    set = Set[1,2]
+    ret = set.compact!
+
+    assert_equal(Set[1,2], set)
+    assert_nil(ret)
+  end
+
+  def test_compact
+    set = Set[1,2,nil]
+    ret = set.compact
+
+    assert_equal(Set[1,2,nil], set)
+    assert_equal(Set[1,2], ret)
+    assert_not_same(set, ret)
+
+    set = Set[1,2]
+    ret = set.compact
+
+    assert_equal(Set[1,2], set)
+    assert_equal(Set[1,2], ret)
+    assert_not_same(set, ret)
+  end
+
   def test_replace
     set = Set[1,2]
     ret = set.replace('a'..'c')


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/17208

This is a proposal to add `compact` and `compact!` methods already owned by `Array` and `Hash` to `Set`.

- `Array#compact` and `Array#compact!` has been around for a long time.
- `Hash#compact` has `Hash#compact!` been added since Ruby 2.4
... https://bugs.ruby-lang.org/issues/11818
- There is `Set` in collection libraries other than `Array` and
`Hash`. But `Set` doesn't have `compact` and `compact!` methods.

It behaves the same as `compact` and `compact!` methods of `Array` and `Hash` as follows.

`Set#compact!`:

```ruby
# Removes all nil elements from self. Returns self if any
elements removed, otherwise nil.
set = Set[1, 'c', nil]            #=> #<Set: {1, "c", nil}>
set.compact!                      #=> #<Set: {1, "c"}>
set                               #=> #<Set: {1, "c"}>

set = Set[1, 'c']                 #=> #<Set: {1, "c"}>
set.compact!                      #=> nil
set                               #=> #<Set: {1, "c"}>
```

`Set#compact`:

```ruby
# Returns a new Set containing all non-nil elements from self.
set = Set[1, 'c', nil]            #=> #<Set: {1, "c", nil}>
set.compact                       #=> #<Set: {1, "c"}>
set                               #=> #<Set: {1, "c", nil}>

set = Set[1, 'c']                 #=> #<Set: {1, "c"}>
set.compact                       #=> #<Set: {1, "c"}>
set                               #=> #<Set: {1, "c"}>
```