### PR TITLE
Respect ZDOTDIR environment variable when looking for .zshrc

### DIFF
--- a/misc/rb_optparse.zsh
+++ b/misc/rb_optparse.zsh
@@ -7,9 +7,9 @@
 #      cp rb_optparse.zsh ~/.zsh.d/rb_optparse.zsh
 #
 # (2) load the script, and add a directory to fpath before compinit.
-#      echo '. ~/.zsh.d/rb_optparse.zsh' >> ~/.zshrc
-#      echo 'fpath=(~/.zsh.d/Completion $fpath)' >> ~/.zshrc
-#      echo 'autoload -U compinit; compinit' >> ~/.zshrc
+#      echo '. ~/.zsh.d/rb_optparse.zsh' >> "${ZDOTDIR:-$HOME}/.zshrc"
+#      echo 'fpath=(~/.zsh.d/Completion $fpath)' >> "${ZDOTDIR:-$HOME}/.zshrc"
+#      echo 'autoload -U compinit; compinit' >> "${ZDOTDIR:-$HOME}/.zshrc"
 #
 # (3) restart zsh.
 #


### PR DESCRIPTION
The location of `.zshrc` is not always `$HOME/.zshrc`. The environment variable `ZDOTDIR` defines in which directory `.zshrc` is in. Thus this contribution uses parameter expansion to check if `ZDOTDIR` is set and in that case uses that directory to locate `.zshrc`. If `ZDOTDIR` is not set, `$HOME` is used as fallback directory.