### PR TITLE
Fix Traditional Ring example in Actor-model

### DIFF
--- a/doc/ractor.md
+++ b/doc/ractor.md
@@ -664,7 +664,7 @@ r = Ractor.new do
 end
 
 RN.times{
-  Ractor.new r do |next_r|
+  r = Ractor.new r do |next_r|
     next_r << Ractor.recv
   end
 }


### PR DESCRIPTION
This typo was found by **protobitshift** in the question on Reddit: https://www.reddit.com/r/ruby/comments/j47oux/understanding_an_example_in_the_new_ractor/