### PR TITLE
relax Fiber#transfer's restriction

### DIFF
--- a/spec/ruby/library/fiber/current_spec.rb
+++ b/spec/ruby/library/fiber/current_spec.rb
@@ -42,10 +42,22 @@ describe "Fiber.current" do
     fiber3 = Fiber.new do
       states << :fiber3
       fiber2.transfer
-      flunk
+      ruby_version_is '3.0' do
+        states << :fiber3_terminated
+      end
+      ruby_version_is '' ... '3.0' do
+        flunk
+      end
     end
 
     fiber3.resume
-    states.should == [:fiber3, :fiber2, :fiber]
+
+    ruby_version_is "" ... "3.0" do
+      states.should == [:fiber3, :fiber2, :fiber]
+    end
+
+    ruby_version_is "3.0" do
+      states.should == [:fiber3, :fiber2, :fiber, :fiber3_terminated]
+    end
   end
 end

--- a/spec/ruby/library/fiber/resume_spec.rb
+++ b/spec/ruby/library/fiber/resume_spec.rb
@@ -3,10 +3,21 @@ require_relative '../../spec_helper'
 require 'fiber'
 
 describe "Fiber#resume" do
-  it "raises a FiberError if the Fiber has transferred control to another Fiber" do
-    fiber1 = Fiber.new { true }
-    fiber2 = Fiber.new { fiber1.transfer; Fiber.yield }
-    fiber2.resume
-    -> { fiber2.resume }.should raise_error(FiberError)
+  ruby_version_is '' ... '3.0' do
+    it "raises a FiberError if the Fiber has transferred control to another Fiber" do
+      fiber1 = Fiber.new { true }
+      fiber2 = Fiber.new { fiber1.transfer; Fiber.yield }
+      fiber2.resume
+      -> { fiber2.resume }.should raise_error(FiberError)
+    end
+  end
+
+  ruby_version_is '3.0' do
+    it "can work with Fiber#transfer" do
+      fiber1 = Fiber.new { true }
+      fiber2 = Fiber.new { fiber1.transfer; Fiber.yield 10 ; Fiber.yield 20; raise }
+      fiber2.resume.should == 10
+      fiber2.resume.should == 20
+    end
   end
 end

--- a/spec/ruby/library/fiber/transfer_spec.rb
+++ b/spec/ruby/library/fiber/transfer_spec.rb
@@ -11,7 +11,13 @@ describe "Fiber#transfer" do
   it "transfers control from one Fiber to another when called from a Fiber" do
     fiber1 = Fiber.new { :fiber1 }
     fiber2 = Fiber.new { fiber1.transfer; :fiber2 }
-    fiber2.resume.should == :fiber1
+
+    ruby_version_is '' ... '3.0' do
+      fiber2.resume.should == :fiber1
+    end
+    ruby_version_is '3.0' do
+      fiber2.resume.should == :fiber2
+    end
   end
 
   it "returns to the root Fiber when finished" do
@@ -34,12 +40,24 @@ describe "Fiber#transfer" do
     states.should == [:start, :end]
   end
 
-  it "can transfer control to a Fiber that has transferred to another Fiber" do
-    states = []
-    fiber1 = Fiber.new { states << :fiber1 }
-    fiber2 = Fiber.new { states << :fiber2_start; fiber1.transfer; states << :fiber2_end}
-    fiber2.resume.should == [:fiber2_start, :fiber1]
-    fiber2.transfer.should == [:fiber2_start, :fiber1, :fiber2_end]
+  ruby_version_is '' ... '3.0' do
+    it "can transfer control to a Fiber that has transferred to another Fiber" do
+      states = []
+      fiber1 = Fiber.new { states << :fiber1 }
+      fiber2 = Fiber.new { states << :fiber2_start; fiber1.transfer; states << :fiber2_end}
+      fiber2.resume.should == [:fiber2_start, :fiber1]
+      fiber2.transfer.should == [:fiber2_start, :fiber1, :fiber2_end]
+    end
+  end
+
+  ruby_version_is '3.0' do
+    it "can not transfer control to a Fiber that has suspended by Fiber.yield" do
+      states = []
+      fiber1 = Fiber.new { states << :fiber1 }
+      fiber2 = Fiber.new { states << :fiber2_start; Fiber.yield fiber1.transfer; states << :fiber2_end}
+      fiber2.resume.should == [:fiber2_start, :fiber1]
+      -> { fiber2.transfer }.should raise_error(FiberError)
+    end
   end
 
   it "raises a FiberError when transferring to a Fiber which resumes itself" do
@@ -82,5 +100,29 @@ describe "Fiber#transfer" do
     end
     thread.join
     states.should == [0, 1, 2, 3]
+  end
+
+  ruby_version_is "" ... "3.0" do
+    it "runs until Fiber.yield" do
+      obj = mock('obj')
+      obj.should_not_receive(:do)
+      fiber = Fiber.new { 1 + 2; Fiber.yield; obj.do }
+      fiber.transfer
+    end
+
+    it "resumes from the last call to Fiber.yield on subsequent invocations" do
+      fiber = Fiber.new { Fiber.yield :first; :second }
+      fiber.transfer.should == :first
+      fiber.transfer.should == :second
+    end
+
+    it "sets the block parameters to its arguments on the first invocation" do
+      first = mock('first')
+      first.should_receive(:arg).with(:first).twice
+
+      fiber = Fiber.new { |arg| first.arg arg; Fiber.yield; first.arg arg; }
+      fiber.transfer :first
+      fiber.transfer :second
+    end
   end
 end

--- a/spec/ruby/shared/fiber/resume.rb
+++ b/spec/ruby/shared/fiber/resume.rb
@@ -35,30 +35,9 @@ describe :fiber_resume, shared: true do
     fiber.send(@method)
   end
 
-  it "runs until Fiber.yield" do
-    obj = mock('obj')
-    obj.should_not_receive(:do)
-    fiber = Fiber.new { 1 + 2; Fiber.yield; obj.do }
-    fiber.send(@method)
-  end
-
-  it "resumes from the last call to Fiber.yield on subsequent invocations" do
-    fiber = Fiber.new { Fiber.yield :first; :second }
-    fiber.send(@method).should == :first
-    fiber.send(@method).should == :second
-  end
-
   it "accepts any number of arguments" do
     fiber = Fiber.new { |a| }
     -> { fiber.send(@method, *(1..10).to_a) }.should_not raise_error
-  end
-
-  it "sets the block parameters to its arguments on the first invocation" do
-    first = mock('first')
-    first.should_receive(:arg).with(:first).twice
-    fiber = Fiber.new { |arg| first.arg arg; Fiber.yield; first.arg arg; }
-    fiber.send(@method, :first)
-    fiber.send(@method, :second)
   end
 
   it "raises a FiberError if the Fiber is dead" do


### PR DESCRIPTION
Using Fiber#transfer with Fiber#resume for a same Fiber is
limited (once Fiber#transfer is called for a fiber, the fiber
can not resume more). This restriction is introduced to protect
the resume/yield chain, but we realized that it is too much to
protect the resume/yield chain. Instead of the current restriction,
we introduce some other protection.

(1) can not transfer to the resuming fiber.
(2) can not transfer to the yielding fiber.
(3) can not resume transferred fiber.

https://bugs.ruby-lang.org/issues/17221