### PR TITLE
Fix typo in rb_class_real doc

### DIFF
--- a/object.c
+++ b/object.c
@@ -279,7 +279,7 @@ rb_obj_not_equal(VALUE obj1, VALUE obj2)
  * It returns the \a cl itself if it is neither a singleton class or a module.
  *
  * \param[in] cl a Class object.
- * \return the ancestor class found, or a falsey value if nothing found.
+ * \return the ancestor class found, or a false value if nothing found.
  */
 VALUE
 rb_class_real(VALUE cl)

--- a/object.c
+++ b/object.c
@@ -279,7 +279,7 @@ rb_obj_not_equal(VALUE obj1, VALUE obj2)
  * It returns the \a cl itself if it is neither a singleton class or a module.
  *
  * \param[in] cl a Class object.
- * \return the ancestor class found, or a false value if nothing found.
+ * \return the ancestor class found, or Qfalse if nothing found.
  */
 VALUE
 rb_class_real(VALUE cl)


### PR DESCRIPTION
Hi.

I found typo in `object.c`(but, I'm not sure that was correct)

```c
 * \return the ancestor class found, or a falsey value if nothing found.
```

`falsey` is `false` typo?