### PR TITLE
Add missing write barrier

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -8334,6 +8334,7 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
 	debugp_param("lit", node->nd_lit);
 	if (!popped) {
 	    ADD_INSN1(ret, line, putobject, node->nd_lit);
+            RB_OBJ_WRITTEN(iseq, Qundef, node->nd_lit);
 	}
 	break;
       }


### PR DESCRIPTION
The write barrier wasn't being called for this object, so add the
missing WB.  Automatic compaction moved the reference because it didn't
know about the relationship (that's how I found the missing WB).