### PR TITLE
Testing bundled_gems with arbitrary commits

### DIFF
--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -1,7 +1,8 @@
+# gem-name version-to-bundle repository-url [optional-commit-hash-to-test-or-defaults-to-v-version]
 minitest 5.14.2 https://github.com/seattlerb/minitest
 power_assert 1.2.0 https://github.com/ruby/power_assert
 rake 13.0.1 https://github.com/ruby/rake
-test-unit 3.3.6 https://github.com/test-unit/test-unit
+test-unit 3.3.6 https://github.com/test-unit/test-unit 3.3.6
 rexml 3.2.4 https://github.com/ruby/rexml
-rss 0.2.9 https://github.com/ruby/rss
+rss 0.2.9 https://github.com/ruby/rss 0.2.9
 rbs 0.12.2 https://github.com/ruby/rbs

--- a/tool/fetch-bundled_gems.rb
+++ b/tool/fetch-bundled_gems.rb
@@ -8,18 +8,20 @@ BEGIN {
   Dir.chdir(dir)
 }
 
-n, v, u = $F
+n, v, u, r = $F
+
+next if n =~ /^#/
 
 if File.directory?(n)
   puts "updating #{n} ..."
-  system("git", (v == "master" ? "pull" : "fetch"), chdir: n) or abort
+  system("git", "fetch", chdir: n) or abort
 else
   puts "retrieving #{n} ..."
   system(*%W"git clone #{u} #{n}") or abort
 end
+c = r || "v#{v}"
 checkout = %w"git -c advice.detachedHead=false checkout"
-unless system(*checkout, v.sub(/\A(?=\d)/, 'v'), chdir: n)
-  unless /\A\d/ =~ v and system(*checkout, v, chdir: n)
-    abort
-  end
+puts "checking out #{c} (v=#{v}, r=#{r}) ..."
+unless system(*checkout, c, "--", chdir: n)
+  abort
 end


### PR DESCRIPTION
This PR updates the syntax of `bundled_gems` file.

1. Allow writing `#` at the beginning of lines for comments.
2. Allow writing refs to commits to be tested during CI.
3. Skip trying tag names automatically for `test-unit` and `rss`. (They have tag names explicitly in `bundled_gems` file.)

This allows testing bundled gems without releasing it. Note that we shouldn't merge commits with commit hashes in `bundled_gems` file.