### PR TITLE
Ignore <internal: entries from core library methods for Kernel#warn(message, uplevel: n)

### DIFF
--- a/error.c
+++ b/error.c
@@ -504,7 +504,8 @@ warning_write(int argc, VALUE *argv, VALUE buf)
     return buf;
 }
 
-VALUE rb_ec_backtrace_location_ary(rb_execution_context_t *ec, long lev, long n);
+VALUE rb_ec_backtrace_location_ary(const rb_execution_context_t *ec, long lev, long n, bool skip_internal);
+
 static VALUE
 rb_warn_m(rb_execution_context_t *ec, VALUE exc, VALUE msgs, VALUE uplevel, VALUE category)
 {
@@ -519,7 +520,7 @@ rb_warn_m(rb_execution_context_t *ec, VALUE exc, VALUE msgs, VALUE uplevel, VALU
             if (lev < 0) {
                 rb_raise(rb_eArgError, "negative level (%ld)", lev);
             }
-            location = rb_ec_backtrace_location_ary(ec, lev + 1, 1);
+            location = rb_ec_backtrace_location_ary(ec, lev + 1, 1, TRUE);
             if (!NIL_P(location)) {
                 location = rb_ary_entry(location, 0);
             }

--- a/eval_intern.h
+++ b/eval_intern.h
@@ -287,7 +287,7 @@ VALUE rb_vm_cbase(void);
 /* vm_backtrace.c */
 VALUE rb_ec_backtrace_object(const rb_execution_context_t *ec);
 VALUE rb_ec_backtrace_str_ary(const rb_execution_context_t *ec, long lev, long n);
-VALUE rb_ec_backtrace_location_ary(const rb_execution_context_t *ec, long lev, long n);
+VALUE rb_ec_backtrace_location_ary(const rb_execution_context_t *ec, long lev, long n, bool skip_internal);
 
 #ifndef CharNext		/* defined as CharNext[AW] on Windows. */
 # ifdef HAVE_MBLEN

--- a/spec/ruby/core/kernel/caller_locations_spec.rb
+++ b/spec/ruby/core/kernel/caller_locations_spec.rb
@@ -65,4 +65,16 @@ describe 'Kernel#caller_locations' do
   it "must return the same locations when called with 1..-1 and when called with no arguments" do
     caller_locations.map(&:to_s).should == caller_locations(1..-1).map(&:to_s)
   end
+
+  guard -> { Kernel.instance_method(:tap).source_location } do
+    it "includes core library methods defined in Ruby" do
+      file, line = Kernel.instance_method(:tap).source_location
+      file.should.start_with?('<internal:')
+
+      loc = nil
+      tap { loc = caller_locations(1, 1)[0] }
+      loc.label.should == "tap"
+      loc.path.should.start_with? "<internal:"
+    end
+  end
 end

--- a/spec/ruby/core/kernel/caller_spec.rb
+++ b/spec/ruby/core/kernel/caller_spec.rb
@@ -51,4 +51,16 @@ describe 'Kernel#caller' do
       locations2.map(&:to_s).should == locations1[2..-1].map(&:to_s)
     end
   end
+
+  guard -> { Kernel.instance_method(:tap).source_location } do
+    it "includes core library methods defined in Ruby" do
+      file, line = Kernel.instance_method(:tap).source_location
+      file.should.start_with?('<internal:')
+
+      loc = nil
+      tap { loc = caller(1, 1)[0] }
+      loc.should.end_with? "in `tap'"
+      loc.should.start_with? "<internal:"
+    end
+  end
 end

--- a/spec/ruby/core/kernel/fixtures/warn_core_method.rb
+++ b/spec/ruby/core/kernel/fixtures/warn_core_method.rb
@@ -1,0 +1,14 @@
+raise 'should be run without RubyGems' if defined?(Gem)
+
+def deprecated(n=1)
+  # puts nil, caller(0), nil
+  warn "use X instead", uplevel: n
+end
+
+1.times do # to test with a non-empty stack above the reported locations
+  deprecated
+  tap(&:deprecated)
+  tap { deprecated(2) }
+  # eval sources with a <internal: file are also ignored
+  eval "tap(&:deprecated)", nil, "<internal:should-be-skipped-by-warn-uplevel>"
+end

--- a/spec/ruby/core/kernel/warn_spec.rb
+++ b/spec/ruby/core/kernel/warn_spec.rb
@@ -114,6 +114,22 @@ describe "Kernel#warn" do
       end
     end
 
+    guard -> { Kernel.instance_method(:tap).source_location } do
+      it "skips <internal: core library methods defined in Ruby" do
+        file, line = Kernel.instance_method(:tap).source_location
+        file.should.start_with?('<internal:')
+
+        file = fixture(__FILE__ , "warn_core_method.rb")
+        n = 9
+        ruby_exe(file, options: "--disable-gems", args: "2>&1").lines.should == [
+          "#{file}:#{n+0}: warning: use X instead\n",
+          "#{file}:#{n+1}: warning: use X instead\n",
+          "#{file}:#{n+2}: warning: use X instead\n",
+          "#{file}:#{n+4}: warning: use X instead\n",
+        ]
+      end
+    end
+
     ruby_version_is "3.0" do
       it "accepts :category keyword with a symbol" do
         -> {


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/17259