### PR TITLE
Prohibit setter method names in all kinds of endless methods

### DIFF
--- a/test/ruby/test_syntax.rb
+++ b/test/ruby/test_syntax.rb
@@ -1429,7 +1429,12 @@ eom
     end
     assert_equal("class ok", k.rescued("ok"))
     assert_equal("instance ok", k.new.rescued("ok"))
-    assert_syntax_error('def foo=() = 42', /setter method cannot be defined in an endless method definition/)
+
+    error = /setter method cannot be defined in an endless method definition/
+    assert_syntax_error('def foo=() = 42', error)
+    assert_syntax_error('def obj.foo=() = 42', error)
+    assert_syntax_error('def foo=() = 42 rescue nil', error)
+    assert_syntax_error('def obj.foo=() = 42 rescue nil', error)
   end
 
   def test_methoddef_in_cond


### PR DESCRIPTION
Also unwrap `NODE_RIPPER` to check the method name.