### PR TITLE
introduce Transaction variables (STM support)

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1025,6 +1025,7 @@ BUILTIN_RB_SRCS = \
 		$(srcdir)/array.rb \
 		$(srcdir)/kernel.rb \
 		$(srcdir)/ractor.rb \
+		$(srcdir)/thread.rb \
 		$(srcdir)/prelude.rb \
 		$(srcdir)/gem_prelude.rb \
 		$(empty)
@@ -8358,6 +8359,7 @@ miniinit.$(OBJEXT): {$(VPATH)}ruby_assert.h
 miniinit.$(OBJEXT): {$(VPATH)}ruby_atomic.h
 miniinit.$(OBJEXT): {$(VPATH)}st.h
 miniinit.$(OBJEXT): {$(VPATH)}subst.h
+miniinit.$(OBJEXT): {$(VPATH)}thread.rb
 miniinit.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).h
 miniinit.$(OBJEXT): {$(VPATH)}thread_native.h
 miniinit.$(OBJEXT): {$(VPATH)}trace_point.rb
@@ -13952,6 +13954,7 @@ thread.$(OBJEXT): $(top_srcdir)/internal/class.h
 thread.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 thread.$(OBJEXT): $(top_srcdir)/internal/cont.h
 thread.$(OBJEXT): $(top_srcdir)/internal/error.h
+thread.$(OBJEXT): $(top_srcdir)/internal/fixnum.h
 thread.$(OBJEXT): $(top_srcdir)/internal/gc.h
 thread.$(OBJEXT): $(top_srcdir)/internal/hash.h
 thread.$(OBJEXT): $(top_srcdir)/internal/imemo.h
@@ -13977,6 +13980,7 @@ thread.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 thread.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
 thread.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 thread.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
+thread.$(OBJEXT): {$(VPATH)}builtin.h
 thread.$(OBJEXT): {$(VPATH)}config.h
 thread.$(OBJEXT): {$(VPATH)}debug.h
 thread.$(OBJEXT): {$(VPATH)}debug_counter.h
@@ -14145,11 +14149,15 @@ thread.$(OBJEXT): {$(VPATH)}st.h
 thread.$(OBJEXT): {$(VPATH)}subst.h
 thread.$(OBJEXT): {$(VPATH)}thread.c
 thread.$(OBJEXT): {$(VPATH)}thread.h
+thread.$(OBJEXT): {$(VPATH)}thread.rb
+thread.$(OBJEXT): {$(VPATH)}thread.rbinc
 thread.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).c
 thread.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).h
 thread.$(OBJEXT): {$(VPATH)}thread_native.h
 thread.$(OBJEXT): {$(VPATH)}thread_sync.c
+thread.$(OBJEXT): {$(VPATH)}thread_tvar.c
 thread.$(OBJEXT): {$(VPATH)}timev.h
+thread.$(OBJEXT): {$(VPATH)}util.h
 thread.$(OBJEXT): {$(VPATH)}vm_core.h
 thread.$(OBJEXT): {$(VPATH)}vm_debug.h
 thread.$(OBJEXT): {$(VPATH)}vm_opts.h

--- a/inits.c
+++ b/inits.c
@@ -87,6 +87,7 @@ rb_call_builtin_inits(void)
 #define BUILTIN(n) CALL(builtin_##n)
     BUILTIN(gc);
     BUILTIN(ractor);
+    BUILTIN(thread);
     BUILTIN(integer);
     BUILTIN(io);
     BUILTIN(dir);

--- a/ractor.h
+++ b/ractor.h
@@ -121,7 +121,6 @@ struct rb_ractor_struct {
 
     struct list_node vmlr_node;
 
-
     VALUE r_stdin;
     VALUE r_stdout;
     VALUE r_stderr;

--- a/test/ruby/test_thread_tvar.rb
+++ b/test/ruby/test_thread_tvar.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+require 'test/unit'
+require 'tmpdir'
+
+class TestThreadTVar < Test::Unit::TestCase
+  def test_tvar_new
+    tv = Thread::TVar.new(0)
+    assert_equal Thread::TVar, tv.class
+
+    assert_raise(ArgumentError, /only shareable object are allowed/) do
+      Thread::TVar.new([1, 2, 3])
+    end
+  end
+
+  # without atomically
+
+  def test_tvar_value_without_atomically
+    tv = Thread::TVar.new(42)
+    assert_equal 42, tv.value
+  end
+
+  def test_tvar_value_increment_without_atomically
+    tv = Thread::TVar.new(42)
+
+    # default +1
+    assert_equal 43, tv.increment
+    assert_equal 43, tv.value
+
+    assert_equal 40, tv.increment(-3)
+    assert_equal 40, tv.value
+  end
+
+  def test_tvar_value_set_raise_without_atomically
+    tv = Thread::TVar.new(42)
+    assert_raise(Thread::TransactionError){
+      tv.value = 43
+    }
+  end
+
+  # with atomically
+
+  def test_tvar_value_set
+    tv = Thread::TVar.new(42)
+    Thread.atomically do 
+      assert_equal 43, (tv.value += 1)
+    end
+    assert_equal 43, tv.value
+
+    q1 = Queue.new
+    q2 = Queue.new
+
+    t1 = Thread.new do
+      retried = false
+      Thread.atomically do
+        q1.pop unless retried
+        # (2)
+        if !retried
+          assert_equal 43, v = tv.value
+        else
+          # after retried
+          assert_equal 44, v = tv.value
+        end
+        q2 << true
+        q1.pop unless retried
+
+        retried = true
+        tv.value = v + 1 #=> abort because tv is already rewitten
+      end
+      assert_equal 45, tv.value
+      assert_equal true, retried
+    end
+
+    t2 = Thread.new do
+      # (1)
+      q1 << true
+      q2.pop
+      # (3)
+      tv.increment
+      q1 << true
+    end
+
+    t1.join
+  end
+
+  def test_tvar_value_get
+    # tv1 and tv2 should be same values
+    tv1 = Thread::TVar.new(42)
+    tv2 = Thread::TVar.new(42)
+
+    q1 = Queue.new
+    q2 = Queue.new
+
+    reader = Thread.new{
+      retried = false
+      Thread.atomically do
+        # (2)
+        q1.pop unless retried
+        a = tv1.value
+        q2 << true
+        q1.pop unless retried
+        # (4)
+        retried = true
+        b = tv2.value #=> retry because tv2 is written after tv1 read
+        assert_equal true, a == b
+        assert_equal true, retried
+      end
+    }
+
+    Thread.new{
+      Thread.atomically do
+        # (1)
+        q1 << true
+        q2.pop
+        # (3)
+        tv1.increment
+        tv2.increment
+        q1 << true
+      end
+    }
+
+    reader.join
+  end
+  
+  def test_tvar_value_increment
+    tv = Thread::TVar.new(42)
+
+    Thread.atomically do
+      assert_equal 43, tv.increment
+      assert_equal 43, tv.value
+    end
+    assert_equal 43, tv.value
+
+    Thread.atomically do
+      assert_equal 40, tv.increment(-3)
+      assert_equal 40, tv.value
+    end
+    assert_equal 40, tv.value
+  end
+
+  def test_tvar_nested_atomically
+    tv = Thread::TVar.new(42)
+
+    # nested atomically calls are just ignored
+    Thread.atomically do
+      Thread.atomically do
+        Thread.atomically do
+          tv.value += 1
+        end
+        tv.value += 1
+      end
+      tv.value += 1
+    end
+
+    assert_equal 45, tv.value
+  end
+end
+
+

--- a/thread.c
+++ b/thread.c
@@ -419,6 +419,7 @@ rb_thread_debug(
 #endif
 
 #include "thread_sync.c"
+#include "thread_tvar.c"
 
 void
 rb_vm_gvl_destroy(rb_global_vm_lock_t *gvl)
@@ -5567,6 +5568,7 @@ Init_Thread(void)
     rb_thread_create_timer_thread();
 
     Init_thread_sync();
+    Init_thread_tvar();
 }
 
 int

--- a/thread.rb
+++ b/thread.rb
@@ -1,0 +1,97 @@
+
+class Thread
+  ## Transactional Variables
+
+  # Make a transaction for TVar accesses.
+  # You can nest Thread.atomically any times.
+  #
+  # Thread.atomically do
+  #   tv1.value += 1
+  #   Thread.atomically do # just ignore nested call
+  #     tv2.value += tv1.value
+  #   end
+  # end
+  #
+  # If atomicity is violated, the given block will
+  # be retried. Note that all side-effect except
+  # `TVar#value=` will note be reverted.
+  # So you should not call IO operations and so on.
+  #
+  def self.atomically
+    if Primitive.tx_begin
+      # fast commit
+      begin
+        while true
+          ret = yield
+          return ret if Primitive.tx_commit
+          Primitive.tx_reset
+        end
+      rescue Thread::RetryTransaction
+        Primitive.tx_reset
+        retry
+      ensure
+        Primitive.tx_end
+      end
+    else
+      yield
+    end
+  end
+
+  # Ractor aware concurrent data structure.
+  # TVar can only hold a shareable object.
+  #
+  class TVar
+    def self.new init_value
+      Primitive.tvar_new init_value
+    end
+
+    # Access to the value.
+    #
+    # You can access some values atomically with
+    # Thread.atomically.
+    #
+    # tv1 = Thread::TVar.new(0)
+    # tv2 = Thread::TVar.new(0)
+    # Thread.atomically do
+    #   tv1.value += 1
+    #   tv2.value += 1
+    # end
+    #
+    # On this example, other threads and ractors can observe
+    # tv1.value == tv2.value within other transactions.
+    #
+    def value
+      Primitive.tvar_value
+    end
+
+    # Set the value with val.
+    #
+    # Thread.atomically do
+    #   tv1.value += 1
+    # end
+    #
+    # val should be a shareable object.
+    def value=(val)
+      Primitive.tvar_value_set(val)
+    end
+
+    # Thread.atomically{ self.value += 1 }
+    #
+    def increment inc = 1
+      Primitive.tvar_value_increment(inc)
+    end
+
+    def inspect
+      index = Primitive.cexpr! %q{ tvar_slot_ptr(self)->index }
+      value = Primitive.cexpr! %q{ tvar_slot_ptr(self)->value }
+      "<TVar #{index} value:#{value}>"
+    end
+
+    private
+    def __increment_any__ inc = 1
+      Thread.atomically do
+        self.value += inc
+      end
+    end
+  end
+end

--- a/thread_tvar.c
+++ b/thread_tvar.c
@@ -1,0 +1,601 @@
+#include "internal/fixnum.h"
+#include "ruby/util.h"
+
+// Thread/Ractor support transactional variable Thread::TVar
+
+// 0: null (BUG/only for evaluation)
+// 1: mutex
+// TODO: 1: atomic
+#define SLOT_LOCK_TYPE 1
+
+struct slot_lock {
+#if   SLOT_LOCK_TYPE == 0
+#elif SLOT_LOCK_TYPE == 1
+    rb_nativethread_lock_t lock;
+#else
+#error unknown
+#endif
+};
+
+struct tvar_slot {
+    uint64_t version;
+    VALUE value;
+    VALUE index;
+    struct slot_lock lock;
+};
+
+struct tx_global {
+    uint64_t version;
+    rb_nativethread_lock_t version_lock;
+
+    uint64_t slot_index;
+    rb_nativethread_lock_t slot_index_lock;
+};
+
+struct tx_log {
+    VALUE value;
+    struct tvar_slot *slot;
+    VALUE tvar; // mark slot
+};
+
+struct tx_logs {
+    uint64_t version;
+    uint32_t logs_cnt;
+    uint32_t logs_capa;
+
+    struct tx_log *logs;
+
+    bool enabled;
+    bool stop_adding;
+
+    uint32_t retry_history;
+    size_t retry_on_commit;
+    size_t retry_on_read_lock;
+    size_t retry_on_read_version;
+};
+
+static struct tx_global tx_global;
+
+static VALUE rb_eThreadTxRetry;
+static VALUE rb_eThreadTxError;
+static VALUE rb_exc_tx_retry;
+static VALUE rb_cThreadTVar;
+
+static VALUE
+txg_next_index(struct tx_global *txg)
+{
+    VALUE index;
+    rb_native_mutex_lock(&txg->slot_index_lock);
+    {
+        txg->slot_index++;
+        index = INT2FIX(txg->slot_index);
+    }
+    rb_native_mutex_unlock(&txg->slot_index_lock);
+
+    return index;
+}
+
+static struct tx_global *
+tx_global_ptr(rb_execution_context_t *ec)
+{
+    return &tx_global;
+}
+
+static uint64_t
+txg_version(const struct tx_global *txg)
+{
+    uint64_t version;
+    version = txg->version;
+    return version;
+}
+
+static uint64_t
+txg_next_version(struct tx_global *txg)
+{
+    uint64_t version;
+
+    rb_native_mutex_lock(&txg->version_lock);
+    {
+        txg->version++;
+        version = txg->version;
+        RUBY_DEBUG_LOG("new_version:%lu", version);
+    }
+    rb_native_mutex_unlock(&txg->version_lock);
+
+    return version;
+}
+
+// tx: transaction
+
+static void
+tx_slot_lock_init(struct slot_lock *lock)
+{
+#if   SLOT_LOCK_TYPE == 0
+#elif SLOT_LOCK_TYPE == 1
+    rb_native_mutex_initialize(&lock->lock);
+#else
+#error unknown
+#endif
+}
+
+static void
+tx_slot_lock_free(struct slot_lock *lock)
+{
+#if   SLOT_LOCK_TYPE == 0
+#elif SLOT_LOCK_TYPE == 1
+    rb_native_mutex_destroy(&lock->lock);
+#else
+#error unknown
+#endif
+}
+
+static bool
+tx_slot_lock_trylock(struct slot_lock *lock)
+{
+#if   SLOT_LOCK_TYPE == 0
+    return true;
+#elif SLOT_LOCK_TYPE == 1
+    return rb_native_mutex_trylock(&lock->lock) == 0;
+#else
+#error unknown
+#endif
+}
+
+static void
+tx_slot_lock_lock(struct slot_lock *lock)
+{
+#if   SLOT_LOCK_TYPE == 0
+#elif SLOT_LOCK_TYPE == 1
+    rb_native_mutex_lock(&lock->lock);
+#else
+#error unknown
+#endif
+}
+
+static void
+tx_slot_lock_unlock(struct slot_lock *lock)
+{
+#if   SLOT_LOCK_TYPE == 0
+#elif SLOT_LOCK_TYPE == 1
+    rb_native_mutex_unlock(&lock->lock);
+#else
+#error unknown
+#endif
+}
+
+static bool
+tx_slot_trylock(struct tvar_slot *slot)
+{
+    return tx_slot_lock_trylock(&slot->lock);
+}
+
+static void
+tx_slot_lock(struct tvar_slot *slot)
+{
+    tx_slot_lock_lock(&slot->lock);
+}
+
+static void
+tx_slot_unlock(struct tvar_slot *slot)
+{
+    tx_slot_lock_unlock(&slot->lock);
+}
+
+static struct tx_logs *
+tx_logs(rb_execution_context_t *ec)
+{
+    rb_thread_t *th = rb_ec_thread_ptr(ec);
+
+    if (UNLIKELY(th->tx == NULL)) {
+        th->tx = ZALLOC(struct tx_logs);
+        // th->tx->version = 0;
+        // th->tx->enabled = false;
+        // th->tx->stop_adding = false;
+        // th->tx->logs_cnt = 0;
+        th->tx->logs_capa = 0x10; // default
+        th->tx->logs = ALLOC_N(struct tx_log, th->tx->logs_capa);
+    }
+    return th->tx;
+}
+
+void
+rb_threadptr_tx_free(rb_thread_t *th)
+{
+    if (th->tx) {
+        RUBY_DEBUG_LOG("retry %5lu commit:%lu read_lock:%lu read_version:%lu",
+                       th->tx->retry_on_commit + th->tx->retry_on_read_lock + th->tx->retry_on_read_version,
+                       th->tx->retry_on_commit,
+                       th->tx->retry_on_read_lock,
+                       th->tx->retry_on_read_version);
+
+        ruby_xfree(th->tx->logs);
+        ruby_xfree(th->tx);
+    }
+}
+
+static struct tx_log *
+tx_lookup(struct tx_logs *tx, VALUE tvar)
+{
+    struct tx_log *copies = tx->logs;
+    uint32_t cnt = tx->logs_cnt;
+
+    for (uint32_t i = 0; i< cnt; i++) {
+        if (copies[i].tvar == tvar) {
+            return &copies[i];
+        }
+    }
+
+    return NULL;
+}
+
+static void
+tx_add(struct tx_logs *tx, VALUE val, struct tvar_slot *slot, VALUE tvar)
+{
+    if (UNLIKELY(tx->logs_capa == tx->logs_cnt)) {
+        uint32_t new_capa =  tx->logs_capa * 2;
+        SIZED_REALLOC_N(tx->logs, struct tx_log, new_capa, tx->logs_capa);
+        tx->logs_capa = new_capa;
+    }
+    if (UNLIKELY(tx->stop_adding)) {
+        rb_raise(rb_eThreadTxError, "can not handle more transactional variable: %"PRIxVALUE, rb_inspect(tvar));
+    }
+    struct tx_log *log = &tx->logs[tx->logs_cnt++];
+
+    log->value = val;
+    log->slot = slot;
+    log->tvar = tvar;
+}
+
+static VALUE
+tx_get(struct tx_logs *tx, struct tvar_slot *slot, VALUE tvar)
+{
+    struct tx_log *ent = tx_lookup(tx, tvar);
+
+    if (ent == NULL) {
+        VALUE val;
+
+        if (tx_slot_trylock(slot)) {
+            if (slot->version > tx->version) {
+                RUBY_DEBUG_LOG("RV < slot->V slot:%u slot->version:%lu, tx->version:%lu", FIX2INT(slot->index), slot->version, tx->version);
+                tx_slot_unlock(slot);
+                tx->retry_on_read_version++;
+                goto abort_and_retry;
+            }
+            val = slot->value;
+            tx_slot_unlock(slot);
+        }
+        else {
+            RUBY_DEBUG_LOG("RV < slot->V slot:%u slot->version:%lu, tx->version:%lu", FIX2INT(slot->index), slot->version, tx->version);
+            tx->retry_on_read_lock++;
+            goto abort_and_retry;
+        }
+        tx_add(tx, val, slot, tvar);
+        return val;
+
+      abort_and_retry:
+        rb_raise(rb_eThreadTxRetry, "retry");
+    }
+    else {
+        return ent->value;
+    }
+}
+
+static void
+tx_set(struct tx_logs *tx, VALUE val, struct tvar_slot *slot, VALUE tvar)
+{
+    struct tx_log *ent = tx_lookup(tx, tvar);
+
+    if (ent == NULL) {
+        tx_add(tx, val, slot, tvar);
+    }
+    else {
+        ent->value = val;
+    }
+}
+
+static void
+tx_check(struct tx_logs *tx)
+{
+    if (UNLIKELY(!tx->enabled)) {
+        rb_raise(rb_eThreadTxError, "can not set without transaction");
+    }
+}
+
+static void
+tx_setup(struct tx_global *txg, struct tx_logs *tx)
+{
+    VM_ASSERT(tx->enabled);
+    VM_ASSERT(tx->logs_cnt == 0);
+
+    tx->version = txg_version(txg);
+
+    RUBY_DEBUG_LOG("tx:%lu", tx->version);
+}
+
+static VALUE
+tx_begin(rb_execution_context_t *ec, VALUE self)
+{
+    struct tx_global *txg = tx_global_ptr(ec);
+    struct tx_logs *tx = tx_logs(ec);
+
+    VM_ASSERT(tx->stop_adding == false);
+    VM_ASSERT(tx->logs_cnt == 0);
+
+    if (tx->enabled == false) {
+        tx->enabled = true;
+        tx_setup(txg, tx);
+        return Qtrue;
+    }
+    else {
+        return Qfalse;
+    }
+}
+
+static VALUE
+tx_reset(rb_execution_context_t *ec, VALUE self)
+{
+    struct tx_global *txg = tx_global_ptr(ec);
+    struct tx_logs *tx = tx_logs(ec);
+    tx->logs_cnt = 0;
+
+    // contention management (CM)
+    if (tx->retry_history != 0) {
+        int recent_retries = rb_popcount32(tx->retry_history);
+        RUBY_DEBUG_LOG("retry recent_retries:%d", recent_retries);
+
+        struct timeval tv = {
+            .tv_sec = 0,
+            .tv_usec = 1 * recent_retries,
+        };
+
+        RUBY_DEBUG_LOG("CM tv_usec:%lu", (unsigned long)tv.tv_usec);
+        rb_thread_wait_for(tv);
+    }
+
+    tx_setup(txg, tx);
+    RUBY_DEBUG_LOG("tx:%lu", tx->version);
+
+    return Qnil;
+}
+
+static VALUE
+tx_end(rb_execution_context_t *ec, VALUE self)
+{
+    struct tx_logs *tx = tx_logs(ec);
+
+    RUBY_DEBUG_LOG("tx:%lu", tx->version);
+
+    VM_ASSERT(tx->enabled);
+    VM_ASSERT(tx->stop_adding == false);
+    tx->enabled = false;
+    tx->logs_cnt = 0;
+    return Qnil;
+}
+
+static void
+tx_commit_release(struct tx_logs *tx, uint32_t n)
+{
+    struct tx_log *copies = tx->logs;
+
+    for (uint32_t i = 0; i<n; i++) {
+        struct tx_log *copy = &copies[i];
+        struct tvar_slot *slot = copy->slot;
+        tx_slot_unlock(slot);
+    }
+}
+
+static VALUE
+tx_commit(rb_execution_context_t *ec, VALUE self)
+{
+    struct tx_global *txg = tx_global_ptr(ec);
+    struct tx_logs *tx = tx_logs(ec);
+    uint32_t i;
+    struct tx_log *copies = tx->logs;
+    uint32_t logs_cnt = tx->logs_cnt;
+
+    for (i=0; i<logs_cnt; i++) {
+        struct tx_log *copy = &copies[i];
+        struct tvar_slot *slot = copy->slot;
+
+        if (LIKELY(tx_slot_trylock(slot))) {
+            if (UNLIKELY(slot->version > tx->version)) {
+                RUBY_DEBUG_LOG("RV < slot->V slot:%lu tx:%lu rs:%lu", slot->version, tx->version, txg->version);
+                tx_commit_release(tx, i+1);
+                goto abort_and_retry;
+            }
+            else {
+                // lock success
+                RUBY_DEBUG_LOG("lock slot:%lu tx:%lu rs:%lu", slot->version, tx->version, txg->version);
+            }
+        }
+        else {
+            RUBY_DEBUG_LOG("trylock fail slot:%lu tx:%lu rs:%lu", slot->version, tx->version, txg->version);
+            tx_commit_release(tx, i);
+            goto abort_and_retry;
+        }
+    }
+
+    // ok
+    tx->retry_history <<= 1;
+
+    uint64_t new_version = txg_next_version(txg);
+
+    for (i=0; i<logs_cnt; i++) {
+        struct tx_log *copy = &copies[i];
+        struct tvar_slot *slot = copy->slot;
+
+        if (slot->value != copy->value) {
+            RUBY_DEBUG_LOG("write slot:%d %d->%d slot->version:%lu->%lu tx:%lu rs:%lu",
+                           FIX2INT(slot->index), FIX2INT(slot->value), FIX2INT(copy->value),
+                           slot->version, new_version, tx->version, txg->version);
+
+            slot->version = new_version;
+            slot->value = copy->value;
+        }
+    }
+
+    tx_commit_release(tx, logs_cnt);
+
+    return Qtrue;
+
+  abort_and_retry:
+    tx->retry_on_commit++;
+
+    return Qfalse;
+}
+
+// tvar
+
+static void
+tvar_mark(void *ptr)
+{
+    struct tvar_slot *slot = (struct tvar_slot *)ptr;
+    rb_gc_mark(slot->value);
+}
+
+static void
+tvar_free(void *ptr)
+{
+    struct tvar_slot *slot = (struct tvar_slot *)ptr;
+    tx_slot_lock_free(&slot->lock);
+    ruby_xfree(slot);
+}
+
+static const rb_data_type_t tvar_data_type = {
+    "Thread::TVar",
+    {tvar_mark, tvar_free, NULL,},
+    0, 0, RUBY_TYPED_FREE_IMMEDIATELY
+};
+
+static VALUE
+tvar_new(rb_execution_context_t *ec, VALUE self, VALUE init)
+{
+    // init should be shareable
+    if (UNLIKELY(!rb_ractor_shareable_p(init))) {
+        rb_raise(rb_eArgError, "only shareable object are allowed");
+    }
+
+    struct tx_global *txg = tx_global_ptr(ec);
+    struct tvar_slot *slot;
+    VALUE obj = TypedData_Make_Struct(rb_cThreadTVar, struct tvar_slot, &tvar_data_type, slot);
+    slot->version = 0;
+    slot->value = init;
+    slot->index = txg_next_index(txg);
+    tx_slot_lock_init(&slot->lock);
+
+    rb_obj_freeze(obj);
+    FL_SET_RAW(obj, RUBY_FL_SHAREABLE);
+
+    return obj;
+}
+
+static VALUE
+tvar_value(rb_execution_context_t *ec, VALUE self)
+{
+    struct tx_logs *tx = tx_logs(ec);
+    struct tvar_slot *slot = DATA_PTR(self);
+
+    if (tx->enabled) {
+        return tx_get(tx, slot, self);
+    }
+    else {
+        // TODO: warn on multi-ractors?
+        return slot->value;
+    }
+}
+
+static VALUE
+tvar_value_set(rb_execution_context_t *ec, VALUE self, VALUE val)
+{
+    if (UNLIKELY(!rb_ractor_shareable_p(val))) {
+        rb_raise(rb_eArgError, "only shareable object are allowed");
+    }
+
+    struct tx_logs *tx = tx_logs(ec);
+    tx_check(tx);
+    struct tvar_slot *slot = DATA_PTR(self);
+    tx_set(tx, val, slot, self);
+    return val;
+}
+
+static VALUE
+tvar_calc_inc(VALUE v, VALUE inc)
+{
+    if (LIKELY(FIXNUM_P(v) && FIXNUM_P(inc))) {
+        return rb_fix_plus_fix(v, inc);
+    }
+    else {
+        return Qundef;
+    }
+}
+
+static VALUE
+tvar_value_increment(rb_execution_context_t *ec, VALUE self, VALUE inc)
+{
+    struct tx_global *txg = tx_global_ptr(ec);
+    struct tx_logs *tx = tx_logs(ec);
+    VALUE recv, ret;
+    struct tvar_slot *slot = DATA_PTR(self);
+
+    if (!tx->enabled) {
+        tx_slot_lock(slot);
+        {
+            uint64_t new_version = txg_next_version(txg);
+            recv = slot->value;
+            ret = tvar_calc_inc(recv, inc);
+
+            if (LIKELY(ret != Qundef)) {
+                slot->value = ret;
+                slot->version = new_version;
+                txg->version = new_version;
+            }
+        }
+        tx_slot_unlock(slot);
+
+        if (UNLIKELY(ret == Qundef)) {
+            // atomically{ self.value += inc }
+            ret = rb_funcall(self, rb_intern("__increment_any__"), 1, inc);
+        }
+    }
+    else {
+        recv = tx_get(tx, slot, self);
+        if (UNLIKELY((ret = tvar_calc_inc(recv, inc)) == Qundef)) {
+            ret = rb_funcall(recv, rb_intern("+"), 1, inc);
+        }
+        tx_set(tx, ret, slot, self);
+    }
+
+    return ret;
+}
+
+static struct tvar_slot *
+tvar_slot_ptr(VALUE v)
+{
+    if (rb_typeddata_is_kind_of(v, &tvar_data_type)) {
+        return DATA_PTR(v);
+    }
+    else {
+        rb_raise(rb_eArgError, "TVar is needed");
+    }
+}
+
+static void
+Init_thread_tvar(void)
+{
+    struct tx_global *txg = tx_global_ptr(GET_EC());
+    txg->slot_index = 0;
+    txg->version = 0;
+    rb_native_mutex_initialize(&txg->slot_index_lock);
+    rb_native_mutex_initialize(&txg->version_lock);
+
+    rb_eThreadTxError = rb_define_class_under(rb_cThread, "TransactionError", rb_eRuntimeError);
+    rb_eThreadTxRetry = rb_define_class_under(rb_cThread, "RetryTransaction", rb_eException);
+
+    rb_cThreadTVar = rb_define_class_under(rb_cThread, "TVar", rb_cObject);
+
+    rb_exc_tx_retry = rb_exc_new_cstr(rb_eThreadTxRetry, "Thread::RetryTransaction");
+    rb_obj_freeze(rb_exc_tx_retry);
+    rb_gc_register_mark_object(rb_exc_tx_retry);
+}
+
+#include "thread.rbinc"

--- a/thread_win32.h
+++ b/thread_win32.h
@@ -53,6 +53,7 @@ native_tls_set(native_tls_key_t key, void *ptr)
 }
 
 void rb_native_mutex_lock(rb_nativethread_lock_t *lock);
+int  rb_native_mutex_trylock(rb_nativethread_lock_t *lock);
 void rb_native_mutex_unlock(rb_nativethread_lock_t *lock);
 void rb_native_mutex_initialize(rb_nativethread_lock_t *lock);
 void rb_native_mutex_destroy(rb_nativethread_lock_t *lock);

--- a/vm.c
+++ b/vm.c
@@ -2709,11 +2709,15 @@ thread_mark(void *ptr)
     RUBY_MARK_LEAVE("thread");
 }
 
+void rb_threadptr_tx_free(rb_thread_t *th); // tread_tvar.c
+
 static void
 thread_free(void *ptr)
 {
     rb_thread_t *th = ptr;
     RUBY_FREE_ENTER("thread");
+
+    rb_threadptr_tx_free(th);
 
     if (th->locking_mutex != Qfalse) {
 	rb_bug("thread_free: locking_mutex must be NULL (%p:%p)", (void *)th, (void *)th->locking_mutex);

--- a/vm_core.h
+++ b/vm_core.h
@@ -990,6 +990,9 @@ typedef struct rb_thread_struct {
     VALUE scheduler;
     unsigned blocking;
 
+    /* tvar */
+    struct tx_logs *tx;
+
     /* misc */
     VALUE name;
 


### PR DESCRIPTION
Introduce Thread::TVar and Thread.atomicaly to support transactional
variables (STM: Software Transactional Memory). STM is well known
feature to synchronize shared values and has several advantages
compare with traditional locking mechanisms.

TVar also shared with multiple ractors so you can program shared
state between ractors in transactions.

https://bugs.ruby-lang.org/issues/17261