### PR TITLE
unused rb_class_name in rb_mod_freeze

### DIFF
--- a/object.c
+++ b/object.c
@@ -1733,7 +1733,6 @@ rb_mod_to_s(VALUE klass)
 static VALUE
 rb_mod_freeze(VALUE mod)
 {
-    rb_class_name(mod);
     return rb_obj_freeze(mod);
 }
 


### PR DESCRIPTION
Isn't `rb_class_name` func not used in` Module#freeze`?