### PR TITLE
ruby_vm_global_method_state is no longer needed.

### DIFF
--- a/test/ruby/test_module.rb
+++ b/test/ruby/test_module.rb
@@ -2529,31 +2529,6 @@ class TestModule < Test::Unit::TestCase
     assert_raise(NoMethodError, bug8284) {Object.remove_const}
   end
 
-  def test_include_module_with_constants_does_not_invalidate_method_cache
-    assert_in_out_err([], <<-RUBY, %w(123 456 true), [])
-      A = 123
-
-      class Foo
-        def self.a
-          A
-        end
-      end
-
-      module M
-        A = 456
-      end
-
-      puts Foo.a
-      starting = RubyVM.stat[:global_method_state]
-
-      Foo.send(:include, M)
-
-      ending = RubyVM.stat[:global_method_state]
-      puts Foo.a
-      puts starting == ending
-    RUBY
-  end
-
   def test_return_value_of_define_method
     retvals = []
     Class.new.class_eval do

--- a/test/ruby/test_rubyvm.rb
+++ b/test/ruby/test_rubyvm.rb
@@ -4,11 +4,11 @@ require 'test/unit'
 class TestRubyVM < Test::Unit::TestCase
   def test_stat
     assert_kind_of Hash, RubyVM.stat
-    assert_kind_of Integer, RubyVM.stat[:global_method_state]
+    assert_kind_of Integer, RubyVM.stat[:global_constant_state]
 
     RubyVM.stat(stat = {})
     assert_not_empty stat
-    assert_equal stat[:global_method_state], RubyVM.stat(:global_method_state)
+    assert_equal stat[:global_constant_state], RubyVM.stat(:global_constant_state)
   end
 
   def test_stat_unknown

--- a/vm.c
+++ b/vm.c
@@ -385,7 +385,6 @@ rb_event_flag_t ruby_vm_event_flags;
 rb_event_flag_t ruby_vm_event_enabled_global_flags;
 unsigned int    ruby_vm_event_local_num;
 
-rb_serial_t ruby_vm_global_method_state = 1;
 rb_serial_t ruby_vm_global_constant_state = 1;
 rb_serial_t ruby_vm_class_serial = 1;
 
@@ -456,7 +455,6 @@ rb_dtrace_setup(rb_execution_context_t *ec, VALUE klass, ID id,
  *  This hash includes information about method/constant cache serials:
  *
  *    {
- *      :global_method_state=>251,
  *      :global_constant_state=>481,
  *      :class_serial=>9029
  *    }
@@ -470,7 +468,7 @@ rb_dtrace_setup(rb_execution_context_t *ec, VALUE klass, ID id,
 static VALUE
 vm_stat(int argc, VALUE *argv, VALUE self)
 {
-    static VALUE sym_global_method_state, sym_global_constant_state, sym_class_serial;
+    static VALUE sym_global_constant_state, sym_class_serial;
     VALUE arg = Qnil;
     VALUE hash = Qnil, key = Qnil;
 
@@ -487,9 +485,8 @@ vm_stat(int argc, VALUE *argv, VALUE self)
 	hash = rb_hash_new();
     }
 
-    if (sym_global_method_state == 0) {
+    if (sym_global_constant_state == 0) {
 #define S(s) sym_##s = ID2SYM(rb_intern_const(#s))
-	S(global_method_state);
 	S(global_constant_state);
 	S(class_serial);
 #undef S
@@ -501,7 +498,6 @@ vm_stat(int argc, VALUE *argv, VALUE self)
     else if (hash != Qnil) \
 	rb_hash_aset(hash, sym_##name, SERIALT2NUM(attr));
 
-    SET(global_method_state, ruby_vm_global_method_state);
     SET(global_constant_state, ruby_vm_global_constant_state);
     SET(class_serial, ruby_vm_class_serial);
 #undef SET

--- a/vm_insnhelper.h
+++ b/vm_insnhelper.h
@@ -14,7 +14,6 @@
 RUBY_SYMBOL_EXPORT_BEGIN
 
 RUBY_EXTERN VALUE ruby_vm_const_missing_count;
-RUBY_EXTERN rb_serial_t ruby_vm_global_method_state;
 RUBY_EXTERN rb_serial_t ruby_vm_global_constant_state;
 RUBY_EXTERN rb_serial_t ruby_vm_class_serial;
 
@@ -178,8 +177,6 @@ CC_SET_FASTPATH(const struct rb_callcache *cc, vm_call_handler func, bool enable
 
 #define PREV_CLASS_SERIAL() (ruby_vm_class_serial)
 #define NEXT_CLASS_SERIAL() (++ruby_vm_class_serial)
-#define GET_GLOBAL_METHOD_STATE() (ruby_vm_global_method_state)
-#define INC_GLOBAL_METHOD_STATE() (++ruby_vm_global_method_state)
 #define GET_GLOBAL_CONSTANT_STATE() (ruby_vm_global_constant_state)
 #define INC_GLOBAL_CONSTANT_STATE() (++ruby_vm_global_constant_state)
 


### PR DESCRIPTION
Now ruby_vm_global_method_state is not used so let's remove it.