### PR TITLE
Sync iv index tbl

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -6760,6 +6760,7 @@ iseq.$(OBJEXT): $(hdrdir)/ruby.h
 iseq.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 iseq.$(OBJEXT): $(top_srcdir)/internal/array.h
 iseq.$(OBJEXT): $(top_srcdir)/internal/bits.h
+iseq.$(OBJEXT): $(top_srcdir)/internal/class.h
 iseq.$(OBJEXT): $(top_srcdir)/internal/compile.h
 iseq.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 iseq.$(OBJEXT): $(top_srcdir)/internal/error.h

--- a/compile.c
+++ b/compile.c
@@ -2332,6 +2332,8 @@ iseq_set_sequence(rb_iseq_t *iseq, LINK_ANCHOR *const anchor)
                                               ic_index, body->is_size);
 			    }
 			    generated_iseq[code_index + 1 + j] = (VALUE)ic;
+
+                            if (type == TS_IVC) FL_SET(iseqv, ISEQ_MARKABLE_ISEQ);
 			    break;
 			}
                         case TS_CALLDATA:

--- a/include/ruby/internal/core/robject.h
+++ b/include/ruby/internal/core/robject.h
@@ -61,10 +61,6 @@ struct RObject {
     } as;
 };
 
-RBIMPL_SYMBOL_EXPORT_BEGIN()
-struct st_table *rb_obj_iv_index_tbl(const struct RObject *obj);
-RBIMPL_SYMBOL_EXPORT_END()
-
 RBIMPL_ATTR_PURE_UNLESS_DEBUG()
 RBIMPL_ATTR_ARTIFICIAL()
 static inline uint32_t
@@ -95,19 +91,6 @@ ROBJECT_IVPTR(VALUE obj)
     else {
         return ptr->as.heap.ivptr;
     }
-}
-
-RBIMPL_ATTR_DEPRECATED(("Whoever have used it before?  Just tell us so.  We can stop deleting it."))
-RBIMPL_ATTR_PURE_UNLESS_DEBUG()
-RBIMPL_ATTR_ARTIFICIAL()
-static inline struct st_table *
-ROBJECT_IV_INDEX_TBL(VALUE obj)
-{
-    RBIMPL_ASSERT_TYPE(obj, RUBY_T_OBJECT);
-
-    struct RObject *const ptr = ROBJECT(obj);
-
-    return rb_obj_iv_index_tbl(ptr);
 }
 
 #endif /* RBIMPL_ROBJECT_H */

--- a/insns.def
+++ b/insns.def
@@ -213,7 +213,7 @@ getinstancevariable
 /* "instance variable not initialized" warning can be hooked. */
 // attr bool leaf = false; /* has rb_warning() */
 {
-    val = vm_getinstancevariable(GET_SELF(), id, ic);
+    val = vm_getinstancevariable(GET_ISEQ(), GET_SELF(), id, ic);
 }
 
 /* Set value of instance variable id of self to val. */
@@ -224,7 +224,7 @@ setinstancevariable
 ()
 // attr bool leaf = false; /* has rb_check_frozen_internal() */
 {
-    vm_setinstancevariable(GET_SELF(), id, val, ic);
+    vm_setinstancevariable(GET_ISEQ(), GET_SELF(), id, val, ic);
 }
 
 /* Get value of class variable id of klass as val. */

--- a/internal/class.h
+++ b/internal/class.h
@@ -25,8 +25,14 @@ struct rb_subclass_entry {
     struct rb_subclass_entry *next;
 };
 
+struct rb_iv_index_tbl_entry {
+    uint32_t index;
+    rb_serial_t class_serial;
+    VALUE class_value;
+};
+
 struct rb_classext_struct {
-    struct st_table *iv_index_tbl;
+    struct st_table *iv_index_tbl; // ID -> struct rb_iv_index_tbl_entry
     struct st_table *iv_tbl;
 #if SIZEOF_SERIAL_T == SIZEOF_VALUE /* otherwise m_tbl is in struct RClass */
     struct rb_id_table *m_tbl;

--- a/iseq.c
+++ b/iseq.c
@@ -23,6 +23,7 @@
 #include "id_table.h"
 #include "internal.h"
 #include "internal/bits.h"
+#include "internal/class.h"
 #include "internal/compile.h"
 #include "internal/error.h"
 #include "internal/file.h"
@@ -178,6 +179,20 @@ iseq_extract_values(VALUE *code, size_t pos, iseq_value_itr_t * func, void *data
                       code[pos + op_no + 1] = newop;
                   }
               }
+            }
+            break;
+          case TS_IVC:
+            {
+                IVC ivc = (IVC)code[pos + op_no + 1];
+                if (ivc->entry) {
+                    if (RB_TYPE_P(ivc->entry->class_value, T_NONE)) {
+                        rb_bug("!! %u", ivc->entry->index);
+                    }
+                    VALUE nv = func(data, ivc->entry->class_value);
+                    if (ivc->entry->class_value != nv) {
+                        ivc->entry->class_value = nv;
+                    }
+                }
             }
             break;
           case TS_ISE:

--- a/mjit_compile.c
+++ b/mjit_compile.c
@@ -443,17 +443,17 @@ init_ivar_compile_status(const struct rb_iseq_constant_body *body, struct compil
         if (insn == BIN(getinstancevariable) || insn == BIN(setinstancevariable)) {
             IVC ic = (IVC)body->iseq_encoded[pos+2];
             IVC ic_copy = &(status->is_entries + ((union iseq_inline_storage_entry *)ic - body->is_entries))->iv_cache;
-            if (ic_copy->ic_serial) { // Only initialized (ic_serial > 0) IVCs are optimized
+            if (ic_copy->entry) { // Only initialized (ic_serial > 0) IVCs are optimized
                 num_ivars++;
 
-                if (status->max_ivar_index < ic_copy->index) {
-                    status->max_ivar_index = ic_copy->index;
+                if (status->max_ivar_index < ic_copy->entry->index) {
+                    status->max_ivar_index = ic_copy->entry->index;
                 }
 
                 if (status->ivar_serial == 0) {
-                    status->ivar_serial = ic_copy->ic_serial;
+                    status->ivar_serial = ic_copy->entry->class_serial;
                 }
-                else if (status->ivar_serial != ic_copy->ic_serial) {
+                else if (status->ivar_serial != ic_copy->entry->class_serial) {
                     // Multiple classes have used this ISeq. Give up assuming one serial.
                     status->merge_ivar_guards_p = false;
                     return;

--- a/object.c
+++ b/object.c
@@ -320,14 +320,6 @@ rb_obj_singleton_class(VALUE obj)
     return rb_singleton_class(obj);
 }
 
-struct st_table *
-rb_obj_iv_index_tbl(const struct RObject *obj)
-{
-    /* This is a function that practically never gets used.  Just to keep
-     * backwards compatibility to ruby 2.x. */
-    return ROBJECT_IV_INDEX_TBL((VALUE)obj);
-}
-
 /*! \private */
 MJIT_FUNC_EXPORTED void
 rb_obj_copy_ivar(VALUE dest, VALUE obj)

--- a/st.c
+++ b/st.c
@@ -2238,4 +2238,19 @@ rb_hash_bulk_insert_into_st_table(long argc, const VALUE *argv, VALUE hash)
     else
         st_insert_generic(tab, argc, argv, hash);
 }
+
+// to iterate iv_index_tbl
+st_data_t
+rb_st_nth_key(st_table *tab, st_index_t index)
+{
+    if (LIKELY(tab->entries_start == 0 &&
+               tab->num_entries == tab->entries_bound &&
+               index < tab->num_entries)) {
+        return tab->entries[index].key;
+    }
+    else {
+        rb_bug("unreachable");
+    }
+}
+
 #endif

--- a/tool/ruby_vm/views/_mjit_compile_ivar.erb
+++ b/tool/ruby_vm/views/_mjit_compile_ivar.erb
@@ -16,18 +16,18 @@
 % # compiler: Use copied IVC to avoid race condition
     IVC ic_copy = &(status->is_entries + ((union iseq_inline_storage_entry *)ic - body->is_entries))->iv_cache;
 %
-    if (!status->compile_info->disable_ivar_cache && ic_copy->ic_serial) { // Only initialized (ic_serial > 0) IVCs are optimized
+    if (!status->compile_info->disable_ivar_cache && ic_copy->entry) { // Only ic_copy is enabled.
 % # JIT: optimize away motion of sp and pc. This path does not call rb_warning() and so it's always leaf and not `handles_sp`.
 % # <%= render 'mjit_compile_pc_and_sp', locals: { insn: insn } -%>
 %
 % # JIT: prepare vm_getivar/vm_setivar arguments and variables
         fprintf(f, "{\n");
         fprintf(f, "    VALUE obj = GET_SELF();\n");
-        fprintf(f, "    const st_index_t index = %"PRIuSIZE";\n", ic_copy->index);
+        fprintf(f, "    const uint32_t index = %u;\n", (ic_copy->entry->index));
         if (status->merge_ivar_guards_p) {
 % # JIT: Access ivar without checking these VM_ASSERTed prerequisites as we checked them in the beginning of `mjit_compile_body`
             fprintf(f, "    VM_ASSERT(RB_TYPE_P(obj, T_OBJECT));\n");
-            fprintf(f, "    VM_ASSERT((rb_serial_t)%"PRI_SERIALT_PREFIX"u == RCLASS_SERIAL(RBASIC(obj)->klass));\n", ic_copy->ic_serial);
+            fprintf(f, "    VM_ASSERT((rb_serial_t)%"PRI_SERIALT_PREFIX"u == RCLASS_SERIAL(RBASIC(obj)->klass));\n", ic_copy->entry->class_serial);
             fprintf(f, "    VM_ASSERT(index < ROBJECT_NUMIV(obj));\n");
 % if insn.name == 'setinstancevariable'
             fprintf(f, "    if (LIKELY(!RB_OBJ_FROZEN(obj) && %sRB_FL_ANY_RAW(obj, ROBJECT_EMBED))) {\n", status->max_ivar_index >= ROBJECT_EMBED_LEN_MAX ? "!" : "");
@@ -44,7 +44,7 @@
 %end
         }
         else {
-            fprintf(f, "    const rb_serial_t ic_serial = (rb_serial_t)%"PRI_SERIALT_PREFIX"u;\n", ic_copy->ic_serial);
+            fprintf(f, "    const rb_serial_t ic_serial = (rb_serial_t)%"PRI_SERIALT_PREFIX"u;\n", ic_copy->entry->class_serial);
 % # JIT: cache hit path of vm_getivar/vm_setivar, or cancel JIT (recompile it with exivar)
 % if insn.name == 'setinstancevariable'
             fprintf(f, "    if (LIKELY(RB_TYPE_P(obj, T_OBJECT) && ic_serial == RCLASS_SERIAL(RBASIC(obj)->klass) && index < ROBJECT_NUMIV(obj) && !RB_OBJ_FROZEN(obj))) {\n");
@@ -70,15 +70,15 @@
         break;
     }
 % if insn.name == 'getinstancevariable'
-    else if (!status->compile_info->disable_exivar_cache && ic_copy->ic_serial) {
+    else if (!status->compile_info->disable_exivar_cache && ic_copy->entry) {
 % # JIT: optimize away motion of sp and pc. This path does not call rb_warning() and so it's always leaf and not `handles_sp`.
 % # <%= render 'mjit_compile_pc_and_sp', locals: { insn: insn } -%>
 %
 % # JIT: prepare vm_getivar's arguments and variables
         fprintf(f, "{\n");
         fprintf(f, "    VALUE obj = GET_SELF();\n");
-        fprintf(f, "    const rb_serial_t ic_serial = (rb_serial_t)%"PRI_SERIALT_PREFIX"u;\n", ic_copy->ic_serial);
-        fprintf(f, "    const st_index_t index = %"PRIuSIZE";\n", ic_copy->index);
+        fprintf(f, "    const rb_serial_t ic_serial = (rb_serial_t)%"PRI_SERIALT_PREFIX"u;\n", ic_copy->entry->class_serial);
+        fprintf(f, "    const uint32_t index = %u;\n", ic_copy->entry->index);
 % # JIT: cache hit path of vm_getivar, or cancel JIT (recompile it without any ivar optimization)
         fprintf(f, "    struct gen_ivtbl *ivtbl;\n");
         fprintf(f, "    VALUE val;\n");

--- a/vm_core.h
+++ b/vm_core.h
@@ -225,8 +225,7 @@ struct iseq_inline_cache_entry {
 };
 
 struct iseq_inline_iv_cache_entry {
-    rb_serial_t ic_serial;
-    size_t index;
+    struct rb_iv_index_tbl_entry *entry;
 };
 
 union iseq_inline_storage_entry {

--- a/vm_sync.c
+++ b/vm_sync.c
@@ -124,14 +124,14 @@ vm_lock_leave(rb_vm_t *vm, unsigned int *lev APPEND_LOCATION_ARGS)
     }
 }
 
-void
+MJIT_FUNC_EXPORTED void
 rb_vm_lock_enter_body(unsigned int *lev APPEND_LOCATION_ARGS)
 {
     rb_vm_t *vm = GET_VM();
     vm_lock_enter(vm, vm_locked(vm), lev APPEND_LOCATION_PARAMS);
 }
 
-void
+MJIT_FUNC_EXPORTED void
 rb_vm_lock_leave_body(unsigned int *lev APPEND_LOCATION_ARGS)
 {
     vm_lock_leave(GET_VM(), lev APPEND_LOCATION_PARAMS);


### PR DESCRIPTION
iv_index_tbl manages instance variable indexes (ID -> index).
This data structure should be synchronized with other ractors
so introduce some VM locks.

This patch also introduced atomic ivar cache used by
set/getinlinecache instructions. To make updating ivar cache (IVC),
we changed iv_index_tbl data structure to manage (ID -> entry)
and an entry points serial and index. IVC points to this entry so
that cache update becomes atomically.
 