### PR TITLE
Use native thread locals.

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -2050,6 +2050,7 @@ ast.$(OBJEXT): {$(VPATH)}ruby_atomic.h
 ast.$(OBJEXT): {$(VPATH)}st.h
 ast.$(OBJEXT): {$(VPATH)}subst.h
 ast.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).h
+ast.$(OBJEXT): {$(VPATH)}thread_local.h
 ast.$(OBJEXT): {$(VPATH)}thread_native.h
 ast.$(OBJEXT): {$(VPATH)}util.h
 ast.$(OBJEXT): {$(VPATH)}vm_core.h
@@ -2417,6 +2418,7 @@ builtin.$(OBJEXT): {$(VPATH)}ruby_atomic.h
 builtin.$(OBJEXT): {$(VPATH)}st.h
 builtin.$(OBJEXT): {$(VPATH)}subst.h
 builtin.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).h
+builtin.$(OBJEXT): {$(VPATH)}thread_local.h
 builtin.$(OBJEXT): {$(VPATH)}thread_native.h
 builtin.$(OBJEXT): {$(VPATH)}vm_core.h
 builtin.$(OBJEXT): {$(VPATH)}vm_opts.h
@@ -2610,6 +2612,7 @@ class.$(OBJEXT): {$(VPATH)}ruby_atomic.h
 class.$(OBJEXT): {$(VPATH)}st.h
 class.$(OBJEXT): {$(VPATH)}subst.h
 class.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).h
+class.$(OBJEXT): {$(VPATH)}thread_local.h
 class.$(OBJEXT): {$(VPATH)}thread_native.h
 class.$(OBJEXT): {$(VPATH)}vm_core.h
 class.$(OBJEXT): {$(VPATH)}vm_opts.h
@@ -2997,6 +3000,7 @@ compile.$(OBJEXT): {$(VPATH)}ruby_atomic.h
 compile.$(OBJEXT): {$(VPATH)}st.h
 compile.$(OBJEXT): {$(VPATH)}subst.h
 compile.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).h
+compile.$(OBJEXT): {$(VPATH)}thread_local.h
 compile.$(OBJEXT): {$(VPATH)}thread_native.h
 compile.$(OBJEXT): {$(VPATH)}util.h
 compile.$(OBJEXT): {$(VPATH)}vm_callinfo.h
@@ -3376,6 +3380,7 @@ cont.$(OBJEXT): {$(VPATH)}ruby_atomic.h
 cont.$(OBJEXT): {$(VPATH)}st.h
 cont.$(OBJEXT): {$(VPATH)}subst.h
 cont.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).h
+cont.$(OBJEXT): {$(VPATH)}thread_local.h
 cont.$(OBJEXT): {$(VPATH)}thread_native.h
 cont.$(OBJEXT): {$(VPATH)}vm_core.h
 cont.$(OBJEXT): {$(VPATH)}vm_debug.h
@@ -3571,6 +3576,7 @@ debug.$(OBJEXT): {$(VPATH)}st.h
 debug.$(OBJEXT): {$(VPATH)}subst.h
 debug.$(OBJEXT): {$(VPATH)}symbol.h
 debug.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).h
+debug.$(OBJEXT): {$(VPATH)}thread_local.h
 debug.$(OBJEXT): {$(VPATH)}thread_native.h
 debug.$(OBJEXT): {$(VPATH)}util.h
 debug.$(OBJEXT): {$(VPATH)}vm_callinfo.h
@@ -5194,6 +5200,7 @@ error.$(OBJEXT): {$(VPATH)}ruby_atomic.h
 error.$(OBJEXT): {$(VPATH)}st.h
 error.$(OBJEXT): {$(VPATH)}subst.h
 error.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).h
+error.$(OBJEXT): {$(VPATH)}thread_local.h
 error.$(OBJEXT): {$(VPATH)}thread_native.h
 error.$(OBJEXT): {$(VPATH)}vm_core.h
 error.$(OBJEXT): {$(VPATH)}vm_opts.h
@@ -5405,6 +5412,7 @@ eval.$(OBJEXT): {$(VPATH)}ruby_atomic.h
 eval.$(OBJEXT): {$(VPATH)}st.h
 eval.$(OBJEXT): {$(VPATH)}subst.h
 eval.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).h
+eval.$(OBJEXT): {$(VPATH)}thread_local.h
 eval.$(OBJEXT): {$(VPATH)}thread_native.h
 eval.$(OBJEXT): {$(VPATH)}vm.h
 eval.$(OBJEXT): {$(VPATH)}vm_core.h
@@ -5833,6 +5841,7 @@ gc.$(OBJEXT): {$(VPATH)}subst.h
 gc.$(OBJEXT): {$(VPATH)}symbol.h
 gc.$(OBJEXT): {$(VPATH)}thread.h
 gc.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).h
+gc.$(OBJEXT): {$(VPATH)}thread_local.h
 gc.$(OBJEXT): {$(VPATH)}thread_native.h
 gc.$(OBJEXT): {$(VPATH)}transient_heap.h
 gc.$(OBJEXT): {$(VPATH)}util.h
@@ -6021,6 +6030,7 @@ golf_prelude.$(OBJEXT): {$(VPATH)}ruby_atomic.h
 golf_prelude.$(OBJEXT): {$(VPATH)}st.h
 golf_prelude.$(OBJEXT): {$(VPATH)}subst.h
 golf_prelude.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).h
+golf_prelude.$(OBJEXT): {$(VPATH)}thread_local.h
 golf_prelude.$(OBJEXT): {$(VPATH)}thread_native.h
 golf_prelude.$(OBJEXT): {$(VPATH)}vm_core.h
 golf_prelude.$(OBJEXT): {$(VPATH)}vm_opts.h
@@ -6957,6 +6967,7 @@ iseq.$(OBJEXT): {$(VPATH)}ruby_atomic.h
 iseq.$(OBJEXT): {$(VPATH)}st.h
 iseq.$(OBJEXT): {$(VPATH)}subst.h
 iseq.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).h
+iseq.$(OBJEXT): {$(VPATH)}thread_local.h
 iseq.$(OBJEXT): {$(VPATH)}thread_native.h
 iseq.$(OBJEXT): {$(VPATH)}util.h
 iseq.$(OBJEXT): {$(VPATH)}vm_callinfo.h
@@ -7158,6 +7169,7 @@ load.$(OBJEXT): {$(VPATH)}ruby_atomic.h
 load.$(OBJEXT): {$(VPATH)}st.h
 load.$(OBJEXT): {$(VPATH)}subst.h
 load.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).h
+load.$(OBJEXT): {$(VPATH)}thread_local.h
 load.$(OBJEXT): {$(VPATH)}thread_native.h
 load.$(OBJEXT): {$(VPATH)}util.h
 load.$(OBJEXT): {$(VPATH)}vm_core.h
@@ -8364,6 +8376,7 @@ miniinit.$(OBJEXT): {$(VPATH)}ruby_atomic.h
 miniinit.$(OBJEXT): {$(VPATH)}st.h
 miniinit.$(OBJEXT): {$(VPATH)}subst.h
 miniinit.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).h
+miniinit.$(OBJEXT): {$(VPATH)}thread_local.h
 miniinit.$(OBJEXT): {$(VPATH)}thread_native.h
 miniinit.$(OBJEXT): {$(VPATH)}trace_point.rb
 miniinit.$(OBJEXT): {$(VPATH)}vm_core.h
@@ -8597,6 +8610,7 @@ mjit.$(OBJEXT): {$(VPATH)}st.h
 mjit.$(OBJEXT): {$(VPATH)}subst.h
 mjit.$(OBJEXT): {$(VPATH)}thread.h
 mjit.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).h
+mjit.$(OBJEXT): {$(VPATH)}thread_local.h
 mjit.$(OBJEXT): {$(VPATH)}thread_native.h
 mjit.$(OBJEXT): {$(VPATH)}util.h
 mjit.$(OBJEXT): {$(VPATH)}vm_callinfo.h
@@ -8807,6 +8821,7 @@ mjit_compile.$(OBJEXT): {$(VPATH)}ruby_atomic.h
 mjit_compile.$(OBJEXT): {$(VPATH)}st.h
 mjit_compile.$(OBJEXT): {$(VPATH)}subst.h
 mjit_compile.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).h
+mjit_compile.$(OBJEXT): {$(VPATH)}thread_local.h
 mjit_compile.$(OBJEXT): {$(VPATH)}thread_native.h
 mjit_compile.$(OBJEXT): {$(VPATH)}vm_callinfo.h
 mjit_compile.$(OBJEXT): {$(VPATH)}vm_core.h
@@ -8995,6 +9010,7 @@ node.$(OBJEXT): {$(VPATH)}ruby_atomic.h
 node.$(OBJEXT): {$(VPATH)}st.h
 node.$(OBJEXT): {$(VPATH)}subst.h
 node.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).h
+node.$(OBJEXT): {$(VPATH)}thread_local.h
 node.$(OBJEXT): {$(VPATH)}thread_native.h
 node.$(OBJEXT): {$(VPATH)}vm_core.h
 node.$(OBJEXT): {$(VPATH)}vm_opts.h
@@ -9979,6 +9995,7 @@ proc.$(OBJEXT): {$(VPATH)}ruby_atomic.h
 proc.$(OBJEXT): {$(VPATH)}st.h
 proc.$(OBJEXT): {$(VPATH)}subst.h
 proc.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).h
+proc.$(OBJEXT): {$(VPATH)}thread_local.h
 proc.$(OBJEXT): {$(VPATH)}thread_native.h
 proc.$(OBJEXT): {$(VPATH)}vm_core.h
 proc.$(OBJEXT): {$(VPATH)}vm_opts.h
@@ -10183,6 +10200,7 @@ process.$(OBJEXT): {$(VPATH)}st.h
 process.$(OBJEXT): {$(VPATH)}subst.h
 process.$(OBJEXT): {$(VPATH)}thread.h
 process.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).h
+process.$(OBJEXT): {$(VPATH)}thread_local.h
 process.$(OBJEXT): {$(VPATH)}thread_native.h
 process.$(OBJEXT): {$(VPATH)}util.h
 process.$(OBJEXT): {$(VPATH)}vm_core.h
@@ -10380,6 +10398,7 @@ ractor.$(OBJEXT): {$(VPATH)}st.h
 ractor.$(OBJEXT): {$(VPATH)}subst.h
 ractor.$(OBJEXT): {$(VPATH)}thread.h
 ractor.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).h
+ractor.$(OBJEXT): {$(VPATH)}thread_local.h
 ractor.$(OBJEXT): {$(VPATH)}thread_native.h
 ractor.$(OBJEXT): {$(VPATH)}vm_core.h
 ractor.$(OBJEXT): {$(VPATH)}vm_debug.h
@@ -12295,6 +12314,7 @@ ruby.$(OBJEXT): {$(VPATH)}st.h
 ruby.$(OBJEXT): {$(VPATH)}subst.h
 ruby.$(OBJEXT): {$(VPATH)}thread.h
 ruby.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).h
+ruby.$(OBJEXT): {$(VPATH)}thread_local.h
 ruby.$(OBJEXT): {$(VPATH)}thread_native.h
 ruby.$(OBJEXT): {$(VPATH)}util.h
 ruby.$(OBJEXT): {$(VPATH)}vm_core.h
@@ -12811,6 +12831,7 @@ signal.$(OBJEXT): {$(VPATH)}signal.c
 signal.$(OBJEXT): {$(VPATH)}st.h
 signal.$(OBJEXT): {$(VPATH)}subst.h
 signal.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).h
+signal.$(OBJEXT): {$(VPATH)}thread_local.h
 signal.$(OBJEXT): {$(VPATH)}thread_native.h
 signal.$(OBJEXT): {$(VPATH)}vm_core.h
 signal.$(OBJEXT): {$(VPATH)}vm_opts.h
@@ -13754,6 +13775,7 @@ struct.$(OBJEXT): {$(VPATH)}st.h
 struct.$(OBJEXT): {$(VPATH)}struct.c
 struct.$(OBJEXT): {$(VPATH)}subst.h
 struct.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).h
+struct.$(OBJEXT): {$(VPATH)}thread_local.h
 struct.$(OBJEXT): {$(VPATH)}thread_native.h
 struct.$(OBJEXT): {$(VPATH)}transient_heap.h
 struct.$(OBJEXT): {$(VPATH)}vm_core.h
@@ -14152,6 +14174,7 @@ thread.$(OBJEXT): {$(VPATH)}thread.c
 thread.$(OBJEXT): {$(VPATH)}thread.h
 thread.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).c
 thread.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).h
+thread.$(OBJEXT): {$(VPATH)}thread_local.h
 thread.$(OBJEXT): {$(VPATH)}thread_native.h
 thread.$(OBJEXT): {$(VPATH)}thread_sync.c
 thread.$(OBJEXT): {$(VPATH)}timev.h
@@ -15075,6 +15098,7 @@ variable.$(OBJEXT): {$(VPATH)}ruby_atomic.h
 variable.$(OBJEXT): {$(VPATH)}st.h
 variable.$(OBJEXT): {$(VPATH)}subst.h
 variable.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).h
+variable.$(OBJEXT): {$(VPATH)}thread_local.h
 variable.$(OBJEXT): {$(VPATH)}thread_native.h
 variable.$(OBJEXT): {$(VPATH)}transient_heap.h
 variable.$(OBJEXT): {$(VPATH)}util.h
@@ -15266,6 +15290,7 @@ version.$(OBJEXT): {$(VPATH)}ruby_atomic.h
 version.$(OBJEXT): {$(VPATH)}st.h
 version.$(OBJEXT): {$(VPATH)}subst.h
 version.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).h
+version.$(OBJEXT): {$(VPATH)}thread_local.h
 version.$(OBJEXT): {$(VPATH)}thread_native.h
 version.$(OBJEXT): {$(VPATH)}version.c
 version.$(OBJEXT): {$(VPATH)}vm_core.h
@@ -15489,6 +15514,7 @@ vm.$(OBJEXT): {$(VPATH)}ruby_atomic.h
 vm.$(OBJEXT): {$(VPATH)}st.h
 vm.$(OBJEXT): {$(VPATH)}subst.h
 vm.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).h
+vm.$(OBJEXT): {$(VPATH)}thread_local.h
 vm.$(OBJEXT): {$(VPATH)}thread_native.h
 vm.$(OBJEXT): {$(VPATH)}variable.h
 vm.$(OBJEXT): {$(VPATH)}vm.c
@@ -15691,6 +15717,7 @@ vm_backtrace.$(OBJEXT): {$(VPATH)}ruby_atomic.h
 vm_backtrace.$(OBJEXT): {$(VPATH)}st.h
 vm_backtrace.$(OBJEXT): {$(VPATH)}subst.h
 vm_backtrace.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).h
+vm_backtrace.$(OBJEXT): {$(VPATH)}thread_local.h
 vm_backtrace.$(OBJEXT): {$(VPATH)}thread_native.h
 vm_backtrace.$(OBJEXT): {$(VPATH)}vm_backtrace.c
 vm_backtrace.$(OBJEXT): {$(VPATH)}vm_core.h
@@ -15881,6 +15908,7 @@ vm_dump.$(OBJEXT): {$(VPATH)}ruby_atomic.h
 vm_dump.$(OBJEXT): {$(VPATH)}st.h
 vm_dump.$(OBJEXT): {$(VPATH)}subst.h
 vm_dump.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).h
+vm_dump.$(OBJEXT): {$(VPATH)}thread_local.h
 vm_dump.$(OBJEXT): {$(VPATH)}thread_native.h
 vm_dump.$(OBJEXT): {$(VPATH)}vm_core.h
 vm_dump.$(OBJEXT): {$(VPATH)}vm_debug.h
@@ -16077,6 +16105,7 @@ vm_sync.$(OBJEXT): {$(VPATH)}ruby_atomic.h
 vm_sync.$(OBJEXT): {$(VPATH)}st.h
 vm_sync.$(OBJEXT): {$(VPATH)}subst.h
 vm_sync.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).h
+vm_sync.$(OBJEXT): {$(VPATH)}thread_local.h
 vm_sync.$(OBJEXT): {$(VPATH)}thread_native.h
 vm_sync.$(OBJEXT): {$(VPATH)}vm_core.h
 vm_sync.$(OBJEXT): {$(VPATH)}vm_debug.h
@@ -16271,6 +16300,7 @@ vm_trace.$(OBJEXT): {$(VPATH)}ruby_atomic.h
 vm_trace.$(OBJEXT): {$(VPATH)}st.h
 vm_trace.$(OBJEXT): {$(VPATH)}subst.h
 vm_trace.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).h
+vm_trace.$(OBJEXT): {$(VPATH)}thread_local.h
 vm_trace.$(OBJEXT): {$(VPATH)}thread_native.h
 vm_trace.$(OBJEXT): {$(VPATH)}trace_point.rbinc
 vm_trace.$(OBJEXT): {$(VPATH)}vm_core.h

--- a/ext/coverage/depend
+++ b/ext/coverage/depend
@@ -181,6 +181,7 @@ coverage.o: $(top_srcdir)/method.h
 coverage.o: $(top_srcdir)/node.h
 coverage.o: $(top_srcdir)/ruby_assert.h
 coverage.o: $(top_srcdir)/ruby_atomic.h
+coverage.o: $(top_srcdir)/thread_local.h
 coverage.o: $(top_srcdir)/thread_pthread.h
 coverage.o: $(top_srcdir)/vm_core.h
 coverage.o: $(top_srcdir)/vm_opts.h

--- a/ext/objspace/depend
+++ b/ext/objspace/depend
@@ -541,6 +541,7 @@ objspace_dump.o: $(top_srcdir)/method.h
 objspace_dump.o: $(top_srcdir)/node.h
 objspace_dump.o: $(top_srcdir)/ruby_assert.h
 objspace_dump.o: $(top_srcdir)/ruby_atomic.h
+objspace_dump.o: $(top_srcdir)/thread_local.h
 objspace_dump.o: $(top_srcdir)/thread_pthread.h
 objspace_dump.o: $(top_srcdir)/vm_core.h
 objspace_dump.o: $(top_srcdir)/vm_opts.h

--- a/ractor.h
+++ b/ractor.h
@@ -205,7 +205,7 @@ rb_ractor_thread_switch(rb_ractor_t *cr, rb_thread_t *th)
 static inline void
 rb_ractor_set_current_ec(rb_ractor_t *cr, rb_execution_context_t *ec)
 {
-    native_tls_set(ruby_current_ec_key, ec);
+    rb_current_execution_context_set(ec);
 
     if (cr->threads.running_ec != ec) {
         if (0) fprintf(stderr, "rb_ractor_set_current_ec ec:%p->%p\n",

--- a/thread_local.h
+++ b/thread_local.h
@@ -1,0 +1,28 @@
+#ifndef RUBY_THREAD_LOCAL_H
+#define RUBY_THREAD_LOCAL_H
+/**********************************************************************
+
+  thread_local.h -
+
+  This introduces `thread_local` compatibility for different compilers.
+
+  $Author$
+
+  Copyright (C) 2020 Samuel Grant Dawson Williams
+
+**********************************************************************/
+
+#ifndef thread_local
+	#if __STDC_VERSION__ >= 201112
+		#define thread_local _Thread_local
+	#elif defined(__GNUC__)
+		/* note that ICC (linux) and Clang are covered by __GNUC__ */
+		#define thread_local __thread
+	#elif defined(_WIN32)
+		#define thread_local __declspec(thread)
+	#else
+		#error "Cannot define thread_local!"
+	#endif
+#endif
+
+#endif /* RUBY_THREAD_LOCAL_H */

--- a/thread_pthread.h
+++ b/thread_pthread.h
@@ -83,24 +83,4 @@ typedef struct rb_global_vm_lock_struct {
     int wait_yield;
 } rb_global_vm_lock_t;
 
-typedef pthread_key_t native_tls_key_t;
-
-static inline void *
-native_tls_get(native_tls_key_t key)
-{
-    void *ptr = pthread_getspecific(key);
-    if (UNLIKELY(ptr == NULL)) {
-        rb_bug("pthread_getspecific returns NULL");
-    }
-    return ptr;
-}
-
-static inline void
-native_tls_set(native_tls_key_t key, void *ptr)
-{
-    if (UNLIKELY(pthread_setspecific(key, ptr) != 0)) {
-        rb_bug("pthread_setspecific error");
-    }
-}
-
 #endif /* RUBY_THREAD_PTHREAD_H */

--- a/thread_win32.h
+++ b/thread_win32.h
@@ -32,25 +32,6 @@ typedef struct rb_global_vm_lock_struct {
     HANDLE lock;
 } rb_global_vm_lock_t;
 
-typedef DWORD native_tls_key_t; // TLS index
-
-static inline void *
-native_tls_get(native_tls_key_t key)
-{
-    void *ptr = TlsGetValue(key);
-    if (UNLIKELY(ptr == NULL)) {
-        rb_bug("TlsGetValue() returns NULL");
-    }
-    return ptr;
-}
-
-static inline void
-native_tls_set(native_tls_key_t key, void *ptr)
-{
-    if (UNLIKELY(TlsSetValue(key, ptr) == 0)) {
-        rb_bug("TlsSetValue() error");
-    }
-}
 
 void rb_native_mutex_lock(rb_nativethread_lock_t *lock);
 void rb_native_mutex_unlock(rb_nativethread_lock_t *lock);

--- a/vm.c
+++ b/vm.c
@@ -60,8 +60,6 @@ MJIT_FUNC_EXPORTED
 #endif
 VALUE vm_exec(rb_execution_context_t *, int);
 
-thread_local rb_execution_context_t *rb_local_execution_context = NULL;
-
 PUREFUNC(static inline const VALUE *VM_EP_LEP(const VALUE *));
 static inline const VALUE *
 VM_EP_LEP(const VALUE *ep)
@@ -381,6 +379,7 @@ VALUE rb_block_param_proxy;
 #define ruby_vm_redefined_flag GET_VM()->redefined_flag
 VALUE ruby_vm_const_missing_count = 0;
 rb_vm_t *ruby_current_vm_ptr = NULL;
+thread_local rb_execution_context_t *rb_local_execution_context = NULL;
 
 rb_event_flag_t ruby_vm_event_flags;
 rb_event_flag_t ruby_vm_event_enabled_global_flags;

--- a/vm.c
+++ b/vm.c
@@ -381,6 +381,20 @@ VALUE ruby_vm_const_missing_count = 0;
 rb_vm_t *ruby_current_vm_ptr = NULL;
 thread_local rb_execution_context_t *rb_local_execution_context = NULL;
 
+rb_execution_context_t *
+rb_current_execution_context(void)
+{
+    VM_ASSERT(rb_local_execution_context != NULL);
+
+    return rb_local_execution_context;
+}
+
+void
+rb_current_execution_context_set(rb_execution_context_t *ec)
+{
+    rb_local_execution_context = ec;
+}
+
 rb_event_flag_t ruby_vm_event_flags;
 rb_event_flag_t ruby_vm_event_enabled_global_flags;
 unsigned int    ruby_vm_event_local_num;

--- a/vm.c
+++ b/vm.c
@@ -60,6 +60,8 @@ MJIT_FUNC_EXPORTED
 #endif
 VALUE vm_exec(rb_execution_context_t *, int);
 
+thread_local rb_execution_context_t *rb_local_execution_context = NULL;
+
 PUREFUNC(static inline const VALUE *VM_EP_LEP(const VALUE *));
 static inline const VALUE *
 VM_EP_LEP(const VALUE *ep)
@@ -379,7 +381,6 @@ VALUE rb_block_param_proxy;
 #define ruby_vm_redefined_flag GET_VM()->redefined_flag
 VALUE ruby_vm_const_missing_count = 0;
 rb_vm_t *ruby_current_vm_ptr = NULL;
-native_tls_key_t ruby_current_ec_key;
 
 rb_event_flag_t ruby_vm_event_flags;
 rb_event_flag_t ruby_vm_event_enabled_global_flags;

--- a/vm_core.h
+++ b/vm_core.h
@@ -1722,7 +1722,8 @@ RUBY_EXTERN rb_event_flag_t ruby_vm_event_flags;
 RUBY_EXTERN rb_event_flag_t ruby_vm_event_enabled_global_flags;
 RUBY_EXTERN unsigned int    ruby_vm_event_local_num;
 
-RUBY_EXTERN thread_local rb_execution_context_t *rb_local_execution_context;
+rb_execution_context_t * rb_current_execution_context(void);
+void rb_current_execution_context_set(rb_execution_context_t *ec);
 
 RUBY_SYMBOL_EXPORT_END
 
@@ -1760,20 +1761,6 @@ rb_ec_vm_ptr(const rb_execution_context_t *ec)
     else {
 	return NULL;
     }
-}
-
-static inline rb_execution_context_t *
-rb_current_execution_context(void)
-{
-    VM_ASSERT(rb_local_execution_context != NULL);
-
-    return rb_local_execution_context;
-}
-
-static inline void
-rb_current_execution_context_set(rb_execution_context_t *ec)
-{
-    rb_local_execution_context = ec;
 }
 
 static inline rb_thread_t *

--- a/vm_core.h
+++ b/vm_core.h
@@ -1722,6 +1722,8 @@ RUBY_EXTERN rb_event_flag_t ruby_vm_event_flags;
 RUBY_EXTERN rb_event_flag_t ruby_vm_event_enabled_global_flags;
 RUBY_EXTERN unsigned int    ruby_vm_event_local_num;
 
+RUBY_EXTERN thread_local rb_execution_context_t *rb_local_execution_context;
+
 RUBY_SYMBOL_EXPORT_END
 
 #define GET_VM()     rb_current_vm()
@@ -1759,8 +1761,6 @@ rb_ec_vm_ptr(const rb_execution_context_t *ec)
 	return NULL;
     }
 }
-
-extern thread_local rb_execution_context_t *rb_local_execution_context;
 
 static inline rb_execution_context_t *
 rb_current_execution_context(void)

--- a/vm_core.h
+++ b/vm_core.h
@@ -79,6 +79,7 @@
 #include "vm_opts.h"
 
 #include "ruby/thread_native.h"
+#include "thread_local.h"
 #if   defined(_WIN32)
 #include "thread_win32.h"
 #elif defined(HAVE_PTHREAD_H)
@@ -1721,8 +1722,6 @@ RUBY_EXTERN rb_event_flag_t ruby_vm_event_flags;
 RUBY_EXTERN rb_event_flag_t ruby_vm_event_enabled_global_flags;
 RUBY_EXTERN unsigned int    ruby_vm_event_local_num;
 
-RUBY_EXTERN native_tls_key_t ruby_current_ec_key;
-
 RUBY_SYMBOL_EXPORT_END
 
 #define GET_VM()     rb_current_vm()
@@ -1761,12 +1760,20 @@ rb_ec_vm_ptr(const rb_execution_context_t *ec)
     }
 }
 
+extern thread_local rb_execution_context_t *rb_local_execution_context;
+
 static inline rb_execution_context_t *
 rb_current_execution_context(void)
 {
-    rb_execution_context_t *ec = native_tls_get(ruby_current_ec_key);
-    VM_ASSERT(ec != NULL);
-    return ec;
+    VM_ASSERT(rb_local_execution_context != NULL);
+
+    return rb_local_execution_context;
+}
+
+static inline void
+rb_current_execution_context_set(rb_execution_context_t *ec)
+{
+    rb_local_execution_context = ec;
 }
 
 static inline rb_thread_t *


### PR DESCRIPTION
By using native thread locals, we can regain most of the lost performance. `compare-ruby` is one commit before `ractor` was merged. `built-ruby` is this PR on master. `master` was around 7.5m on my computer.

```
|                 |compare-ruby|built-ruby|
|:----------------|-----------:|---------:|
|vm_fiber_switch  |     11.608M|   10.431M|
|                 |       1.11x|         -|
```

However, I experienced some segfault, but I don't know why yet. The implementation is not changed. Maybe there is race condition.