### PR TITLE
Use language TLS specifier if it is possible.

### DIFF
--- a/ractor.h
+++ b/ractor.h
@@ -205,7 +205,15 @@ rb_ractor_thread_switch(rb_ractor_t *cr, rb_thread_t *th)
 static inline void
 rb_ractor_set_current_ec(rb_ractor_t *cr, rb_execution_context_t *ec)
 {
+#ifdef RB_THREAD_LOCAL_SPECIFIER
+  #if __APPLE__
+    rb_current_ec_set(ec);
+  #else
+    ruby_current_ec = ec;
+  #endif
+#else
     native_tls_set(ruby_current_ec_key, ec);
+#endif
 
     if (cr->threads.running_ec != ec) {
         if (0) fprintf(stderr, "rb_ractor_set_current_ec ec:%p->%p\n",

--- a/thread_win32.h
+++ b/thread_win32.h
@@ -63,4 +63,8 @@ void rb_native_cond_timedwait(rb_nativethread_cond_t *cond, rb_nativethread_lock
 void rb_native_cond_initialize(rb_nativethread_cond_t *cond);
 void rb_native_cond_destroy(rb_nativethread_cond_t *cond);
 
+RUBY_SYMBOL_EXPORT_BEGIN
+RUBY_EXTERN native_tls_key_t ruby_current_ec_key;
+RUBY_SYMBOL_EXPORT_END
+
 #endif /* RUBY_THREAD_WIN32_H */

--- a/vm.c
+++ b/vm.c
@@ -379,7 +379,26 @@ VALUE rb_block_param_proxy;
 #define ruby_vm_redefined_flag GET_VM()->redefined_flag
 VALUE ruby_vm_const_missing_count = 0;
 rb_vm_t *ruby_current_vm_ptr = NULL;
+
+#ifdef RB_THREAD_LOCAL_SPECIFIER
+RB_THREAD_LOCAL_SPECIFIER rb_execution_context_t *ruby_current_ec;
+
+#ifdef __APPLE__
+  rb_execution_context_t *
+  rb_current_ec(void)
+  {
+      return ruby_current_ec;
+  }
+  void
+  rb_current_ec_set(rb_execution_context_t *ec)
+  {
+      ruby_current_ec = ec;
+  }
+#endif
+
+#else
 native_tls_key_t ruby_current_ec_key;
+#endif
 
 rb_event_flag_t ruby_vm_event_flags;
 rb_event_flag_t ruby_vm_event_enabled_global_flags;

--- a/vm_core.h
+++ b/vm_core.h
@@ -1721,8 +1721,6 @@ RUBY_EXTERN rb_event_flag_t ruby_vm_event_flags;
 RUBY_EXTERN rb_event_flag_t ruby_vm_event_enabled_global_flags;
 RUBY_EXTERN unsigned int    ruby_vm_event_local_num;
 
-RUBY_EXTERN native_tls_key_t ruby_current_ec_key;
-
 RUBY_SYMBOL_EXPORT_END
 
 #define GET_VM()     rb_current_vm()
@@ -1764,7 +1762,15 @@ rb_ec_vm_ptr(const rb_execution_context_t *ec)
 static inline rb_execution_context_t *
 rb_current_execution_context(void)
 {
+#ifdef RB_THREAD_LOCAL_SPECIFIER
+  #if __APPLE__
+    rb_execution_context_t *ec = rb_current_ec();
+  #else
+    rb_execution_context_t *ec = ruby_current_ec;
+  #endif
+#else
     rb_execution_context_t *ec = native_tls_get(ruby_current_ec_key);
+#endif
     VM_ASSERT(ec != NULL);
     return ec;
 }


### PR DESCRIPTION
To access TLS, it is faster to use language TLS specifier instead
of using pthread_get/setspecific functions.

Original proposal is: Use native thread locals. #3665