### PR TITLE
ObjectSpace.each_object with Ractors

### DIFF
--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -764,6 +764,15 @@ assert_equal '[1, 4, 3, 2, 1]', %q{
   counts.inspect
 }
 
+# ObjectSpace.each_object can not handle unshareable objects with Ractors
+assert_equal '0', %q{
+  Ractor.new{
+    n = 0
+    ObjectSpace.each_object{|o| n += 1 unless Ractor.shareable?(o)}
+    n
+  }.take
+}
+
 ###
 ### Synchronization tests
 ###

--- a/gc.c
+++ b/gc.c
@@ -3292,8 +3292,10 @@ os_obj_of_i(void *vstart, void *vend, size_t stride, void *data)
 	volatile VALUE v = (VALUE)p;
 	if (!internal_object_p(v)) {
 	    if (!oes->of || rb_obj_is_kind_of(v, oes->of)) {
-		rb_yield(v);
-		oes->num++;
+                if (!rb_multi_ractor_p() || rb_ractor_shareable_p(v)) {
+                    rb_yield(v);
+                    oes->num++;
+                }
 	    }
 	}
     }

--- a/ractor.rb
+++ b/ractor.rb
@@ -166,4 +166,11 @@ class Ractor
     close_incoming
     close_outgoing
   end
+
+  # utility method
+  def self.shareable? obj
+    __builtin_cexpr! %q{
+      rb_ractor_shareable_p(obj) ? Qtrue : Qfalse;
+    }
+  end
 end


### PR DESCRIPTION
Unshareable objects should not be touched from multiple ractors
so ObjectSpace.each_object should be restricted. On multi-ractor
mode, ObjectSpace.each_object only iterates shareable objects.

https://bugs.ruby-lang.org/issues/17270