### PR TITLE
freeze dynamic regexp literals

### DIFF
--- a/re.c
+++ b/re.c
@@ -2943,7 +2943,9 @@ rb_reg_init_str_enc(VALUE re, VALUE s, rb_encoding *enc, int options)
 MJIT_FUNC_EXPORTED VALUE
 rb_reg_new_ary(VALUE ary, int opt)
 {
-    return rb_reg_new_str(rb_reg_preprocess_dregexp(ary, opt), opt);
+    VALUE re = rb_reg_new_str(rb_reg_preprocess_dregexp(ary, opt), opt);
+    rb_obj_freeze(re);
+    return re;
 }
 
 VALUE

--- a/tool/lib/test/unit.rb
+++ b/tool/lib/test/unit.rb
@@ -125,6 +125,7 @@ module Test
             filter = /\A(?=.*#{filter})(?!.*#{negative})/
           end
           if Regexp === filter
+            filter = filter.dup
             # bypass conversion in minitest
             def filter.=~(other)    # :nodoc:
               super unless Regexp === other


### PR DESCRIPTION
Regexp literals are frozen, and also dynamically comppiled Regexp
literals (/#{expr}/) are frozen.