### PR TITLE
Ractor-safe rb_objspace_reachable_objects_from

### DIFF
--- a/ractor.h
+++ b/ractor.h
@@ -121,12 +121,17 @@ struct rb_ractor_struct {
 
     struct list_node vmlr_node;
 
-
     VALUE r_stdin;
     VALUE r_stdout;
     VALUE r_stderr;
     VALUE verbose;
     VALUE debug;
+
+    // gc.c rb_objspace_reachable_objects_from
+    struct gc_mark_func_data_struct {
+        void *data;
+        void (*mark_func)(VALUE v, void *data);
+    } *mfd;
 }; // rb_ractor_t is defined in vm_core.h
 
 rb_ractor_t *rb_ractor_main_alloc(void);


### PR DESCRIPTION
rb_objspace_reachable_objects_from(obj) is used to traverse all
reachable objects from obj. This function modify objspace but it
is not ractor-safe (thread-safe). This patch fix the problem.

Strategy:
(1) call GC mark process during_gc
(2) call Ractor-local custom mark func when !during_gc