### PR TITLE
Use a lock level for a less granular lock.

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -8843,10 +8843,12 @@ gc_compact(rb_objspace_t *objspace, int use_toward_empty, int use_double_pages, 
 
     objspace->flags.during_compacting = TRUE;
     {
+        mjit_gc_start_hook();
         /* pin objects referenced by maybe pointers */
         garbage_collect(objspace, GPR_DEFAULT_REASON);
         /* compact */
         gc_compact_after_gc(objspace, use_toward_empty, use_double_pages, use_verifier);
+        mjit_gc_exit_hook();
     }
     objspace->flags.during_compacting = FALSE;
 }

--- a/mjit_worker.c
+++ b/mjit_worker.c
@@ -220,8 +220,8 @@ static rb_nativethread_cond_t mjit_client_wakeup;
 static rb_nativethread_cond_t mjit_worker_wakeup;
 // A thread conditional to wake up workers if at the end of GC.
 static rb_nativethread_cond_t mjit_gc_wakeup;
-// True when GC is working.
-static bool in_gc = false;
+// Greater than 0 when GC is working.
+static int in_gc = 0;
 // True when JIT is working.
 static bool in_jit = false;
 // True when JIT compaction is running.


### PR DESCRIPTION
We are seeing an error where code that is generated with MJIT contains
references to objects that have been moved.  I believe this is due to a
race condition in the compaction function.

`gc_compact` has two steps:

1. [Run a full GC to pin objects](https://github.com/ruby/ruby/blob/587feb0b6e47477ec3b1872de0c951e3d062db98/gc.c#L8847)
2. [Compact / update references](https://github.com/ruby/ruby/blob/587feb0b6e47477ec3b1872de0c951e3d062db98/gc.c#L8849)

Step one is executed with `garbage_collect`.  `garbage_collect` calls
`gc_enter` / `gc_exit`, these functions acquire a JIT lock and release a
JIT lock.  So a lock is held for the duration of step 1.

Step two is executed by `gc_compact_after_gc`.  It also holds a JIT
lock.

I believe the problem is that the JIT is free to execute between step 1
and step 2.  It copies call cache values, but doesn't pin them when it
copies them.  So the compactor thinks it's OK to move the call cache
even though it is not safe.

We need to hold a lock for the duration of `garbage_collect` *and*
`gc_compact_after_gc`.  This patch introduces a lock level which
increments and decrements.  The compaction function can increment and
decrement the lock level and prevent MJIT from executing during both
steps.