### PR TITLE
Fix code example in Readline::HISTORY documentation.

### DIFF
--- a/ext/readline/readline.c
+++ b/ext/readline/readline.c
@@ -2060,7 +2060,7 @@ Init_readline(void)
      * The history buffer. It extends Enumerable module, so it behaves
      * just like an array.
      * For example, gets the fifth content that the user input by
-     * HISTORY[4].
+     * <code>HISTORY[4]</code>.
      */
     rb_define_const(mReadline, "HISTORY", history);
 


### PR DESCRIPTION
Wrapping the example into a `<code>` block to avoid it being rendered as a link.