### PR TITLE
Fix small typo in comment in lib/irb.c

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -400,7 +400,7 @@ module IRB
     irb.run(@CONF)
   end
 
-  # Calls each event hook of <code>IRB.conf[:TA_EXIT]</code> when the current session quits.
+  # Calls each event hook of <code>IRB.conf[:AT_EXIT]</code> when the current session quits.
   def IRB.irb_at_exit
     @CONF[:AT_EXIT].each{|hook| hook.call}
   end


### PR DESCRIPTION
Fixes a small comment typo introduced in Ruby 2.7.2 that I noticed while perusing the release diff.