### PR TITLE
Swap results of `Ractor.select`

### DIFF
--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -109,11 +109,11 @@ else
 
 # Ractor.select(*ractors) receives a values from a ractors.
 # It is similar to select(2) and Go's select syntax.
-# The return value is [ch, received_value]
+# The return value is [received_value, ractor]
 assert_equal 'ok', %q{
   # select 1
   r1 = Ractor.new{'r1'}
-  r, obj = Ractor.select(r1)
+  obj, r = Ractor.select(r1)
   'ok' if r == r1 and obj == 'r1'
 }
 
@@ -123,10 +123,10 @@ assert_equal '["r1", "r2"]', %q{
   r2 = Ractor.new{'r2'}
   rs = [r1, r2]
   as = []
-  r, obj = Ractor.select(*rs)
+  obj, r = Ractor.select(*rs)
   rs.delete(r)
   as << obj
-  r, obj = Ractor.select(*rs)
+  obj, = Ractor.select(*rs)
   as << obj
   as.sort #=> ["r1", "r2"]
 }
@@ -142,7 +142,7 @@ assert_equal 'true', %q{
     all_rs = rs.dup
 
     n.times{
-      r, obj = Ractor.select(*rs)
+      obj, r = Ractor.select(*rs)
       as << [r, obj]
       rs.delete(r)
     }
@@ -324,7 +324,7 @@ assert_equal '[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]', %q{
     pipe << i
   }
   RN.times.map{
-    r, n = Ractor.select(*rs)
+    n, r = Ractor.select(*rs)
     rs.delete r
     n
   }.sort
@@ -345,7 +345,7 @@ assert_equal '[true, true, true]', %q{
   take = []
   yielded = []
   until rs.empty?
-    r, v = Ractor.select(CR, *rs, yield_value: 'yield')
+    v, r = Ractor.select(CR, *rs, yield_value: 'yield')
     case r
     when :receive
       received << v
@@ -663,7 +663,7 @@ assert_equal 'true', %q{
      '$stderr' => $stderr.inspect,
     }
   end
-  
+
   h = Ractor.new do
     ractor_local_globals
   end.take

--- a/ractor.rb
+++ b/ractor.rb
@@ -53,17 +53,17 @@ class Ractor
 
   # Multiplex multiple Ractor communications.
   #
-  #   r, obj = Ractor.select(r1, r2)
+  #   obj, r = Ractor.select(r1, r2)
   #   #=> wait for taking from r1 or r2
   #   #   returned obj is a taken object from Ractor r
   #
-  #   r, obj = Ractor.select(r1, r2, Ractor.current)
+  #   obj, r = Ractor.select(r1, r2, Ractor.current)
   #   #=> wait for taking from r1 or r2
   #   #         or receive from incoming queue
   #   #   If receive is succeed, then obj is received value
   #   #   and r is :receive (Ractor.current)
   #
-  #   r, obj = Ractor.select(r1, r2, Ractor.current, yield_value: obj)
+  #   obj, r = Ractor.select(r1, r2, Ractor.current, yield_value: obj)
   #   #=> wait for taking from r1 or r2
   #   #         or receive from incoming queue
   #   #         or yield (Ractor.yield) obj
@@ -77,7 +77,7 @@ class Ractor
       VALUE v = ractor_select(ec, rs, RARRAY_LENINT(ractors),
                               yield_unspecified == Qtrue ? Qundef : yield_value,
                               (bool)RTEST(move) ? true : false, &rv);
-      return rb_ary_new_from_args(2, rv, v);
+      return rb_ary_new_from_args(2, v, rv);
     }
   end
 


### PR DESCRIPTION
As [discussed before](https://bugs.ruby-lang.org/issues/17100#note-31), would you consider swapping the results of `Ractor.select`?