### PR TITLE
Allow method chaining with Pathname#mkpath

### DIFF
--- a/ext/pathname/lib/pathname.rb
+++ b/ext/pathname/lib/pathname.rb
@@ -588,7 +588,7 @@ class Pathname    # * FileUtils *
   def mkpath(mode: nil)
     require 'fileutils'
     FileUtils.mkpath(@path, mode: mode)
-    nil
+    self
   end
 
   # Recursively deletes a directory, including all directories beneath it.
@@ -599,7 +599,7 @@ class Pathname    # * FileUtils *
     # File::Path provides "mkpath" and "rmtree".
     require 'fileutils'
     FileUtils.rm_rf(@path, noop: noop, verbose: verbose, secure: secure)
-    nil
+    self
   end
 end
 
@@ -619,4 +619,3 @@ class Pathname    # * tmpdir *
     end
   end
 end
-

--- a/test/pathname/test_pathname.rb
+++ b/test/pathname/test_pathname.rb
@@ -1475,7 +1475,8 @@ class TestPathname < Test::Unit::TestCase
 
   def test_mkpath
     with_tmpchdir('rubytest-pathname') {|dir|
-      Pathname("a/b/c/d").mkpath
+      path = Pathname("a/b/c/d")
+      assert_equal(path, path.mkpath)
       assert_file.directory?("a/b/c/d")
       unless File.stat(dir).world_readable?
         # mktmpdir should make unreadable
@@ -1491,7 +1492,8 @@ class TestPathname < Test::Unit::TestCase
     with_tmpchdir('rubytest-pathname') {|dir|
       Pathname("a/b/c/d").mkpath
       assert_file.exist?("a/b/c/d")
-      Pathname("a").rmtree
+      path = Pathname("a")
+      assert_equal(path, path.rmtree)
       assert_file.not_exist?("a")
     }
   end

--- a/tool/rbs_skip_tests
+++ b/tool/rbs_skip_tests
@@ -77,3 +77,7 @@ test_merge_types(RBS::RuntimePrototypeTest)
 test_reflection(RBS::RuntimePrototypeTest)
 test_todo(RBS::RuntimePrototypeTest)
 test_of(RubyVM::AbstractSyntaxTreeSingletonTest)
+
+# Pathname#mkpath and #rmtree https://github.com/ruby/ruby/pull/3705
+test_mkpath(PathnameInstanceTest)
+test_rmtree(PathnameInstanceTest)


### PR DESCRIPTION
Currently in my code when I want to create a pathname object and create a path at the same time I must use tap

```
path = Pathname.new("/tmp/new").tap(&:mkpath)
```

I think it would be cleaner to be able to chain on the results of these methods instead:

```
path = Pathname.new("/tmp/new").mkpath
```