### PR TITLE
Feature: Create a directory and file with Pathname#touch

### DIFF
--- a/ext/pathname/lib/pathname.rb
+++ b/ext/pathname/lib/pathname.rb
@@ -591,6 +591,27 @@ class Pathname    # * FileUtils *
     nil
   end
 
+  # Creates a file and the full path to the file including any intermediate directories that don't yet
+  # exist.
+  #
+  # Example:
+  #
+  #   Dir.exist?("/a/b/c") # => false
+  #
+  #   p = Pathname.new("/a/b/c/d.txt")
+  #   p.file? => false
+  #   p.touch
+  #   p.file? => true
+  #
+  #   Dir.exist?("/a/b/c") # => true
+  def touch
+    require 'fileutils'
+    dirname.mkpath
+
+    FileUtils.touch(self)
+    self
+  end
+
   # Recursively deletes a directory, including all directories beneath it.
   #
   # See FileUtils.rm_rf

--- a/test/pathname/test_pathname.rb
+++ b/test/pathname/test_pathname.rb
@@ -1479,6 +1479,14 @@ class TestPathname < Test::Unit::TestCase
     }
   end
 
+  def test_touch
+    with_tmpchdir('rubytest-pathname') {|dir|
+      Pathname("a/b/c/d.txt").touch
+      assert_file.directory?("a/b/c")
+      assert_file.file?("a/b/c/d.txt")
+    }
+  end
+
   def test_rmtree
     with_tmpchdir('rubytest-pathname') {|dir|
       Pathname("a/b/c/d").mkpath


### PR DESCRIPTION
Right now if a developer wants to create a file and is not sure if the path exists yet or not they must:

```ruby
Pathname.new("/a/b/c/d.txt").tap {|p| p.dirname.mkpath; FileUtils.touch(p)}
```

After this patch a developer can instead call:

```ruby
Pathname.new("/a/b/c/d.txt").touch
```

An alternative name for this behavior could be `mkfile` but I think it is confusing to have a `mkfile` and a `mkpath` where one creates a directory and one creates a file.