### PR TITLE
Add Thread.ignore_deadlock accessor

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -178,6 +178,9 @@ Outstanding ones only.
       blocking. [[Feature #16786]]
     * `Thread#join` invokes the scheduler hooks `block`/`unblock` in a
       non-blocking execution context. [[Feature #16786]]
+    * `Thread.ignore_deadlock` accessor for disabling the default deadlock
+      detection, allowing the use of signal handlers to break deadlock.
+      [[Bug #13768]]
 
 * Mutex
 

--- a/test/ruby/test_thread.rb
+++ b/test/ruby/test_thread.rb
@@ -491,6 +491,9 @@ class TestThread < Test::Unit::TestCase
   end
 
   def test_ignore_deadlock
+    if /mswin|mingw/ =~ RUBY_PLATFORM
+      skip "can't trap a signal from another process on Windows"
+    end
     assert_in_out_err([], <<-INPUT, %w(false :sig), [], :signal=>:INT, timeout: 1, timeout_error: nil)
       p Thread.ignore_deadlock
       q = Queue.new

--- a/test/ruby/test_thread.rb
+++ b/test/ruby/test_thread.rb
@@ -490,6 +490,16 @@ class TestThread < Test::Unit::TestCase
     end;
   end
 
+  def test_ignore_deadlock
+    assert_in_out_err([], <<-INPUT, %w(false :sig), [], timeout: 1, timeout_error: nil)
+      p Thread.ignore_deadlock
+      q = Queue.new
+      trap(:SIGTERM){q.push :sig}
+      Thread.ignore_deadlock = true
+      p q.pop
+    INPUT
+  end
+
   def test_status_and_stop_p
     a = ::Thread.new {
       Thread.current.report_on_exception = false

--- a/test/ruby/test_thread.rb
+++ b/test/ruby/test_thread.rb
@@ -491,10 +491,10 @@ class TestThread < Test::Unit::TestCase
   end
 
   def test_ignore_deadlock
-    assert_in_out_err([], <<-INPUT, %w(false :sig), [], timeout: 1, timeout_error: nil)
+    assert_in_out_err([], <<-INPUT, %w(false :sig), [], :signal=>:INT, timeout: 1, timeout_error: nil)
       p Thread.ignore_deadlock
       q = Queue.new
-      trap(:SIGTERM){q.push :sig}
+      trap(:INT){q.push :sig}
       Thread.ignore_deadlock = true
       p q.pop
     INPUT

--- a/thread.c
+++ b/thread.c
@@ -3127,7 +3127,7 @@ rb_thread_s_report_exc_set(VALUE self, VALUE val)
 static VALUE
 rb_thread_s_ignore_deadlock(VALUE _)
 {
-    return GET_THREAD()->vm->ignore_deadlock ? Qtrue : Qfalse;
+    return GET_THREAD()->vm->thread_ignore_deadlock ? Qtrue : Qfalse;
 }
 
 
@@ -3154,7 +3154,7 @@ rb_thread_s_ignore_deadlock(VALUE _)
 static VALUE
 rb_thread_s_ignore_deadlock_set(VALUE self, VALUE val)
 {
-    GET_THREAD()->vm->ignore_deadlock = RTEST(val);
+    GET_THREAD()->vm->thread_ignore_deadlock = RTEST(val);
     return val;
 }
 
@@ -5659,12 +5659,13 @@ debug_deadlock_check(rb_ractor_t *r, VALUE msg)
 static void
 rb_check_deadlock(rb_ractor_t *r)
 {
+    if (GET_THREAD()->vm->thread_ignore_deadlock) return;
+
     int found = 0;
     rb_thread_t *th = NULL;
     int sleeper_num = rb_ractor_sleeper_thread_num(r);
     int ltnum = rb_ractor_living_thread_num(r);
 
-    if (GET_THREAD()->vm->ignore_deadlock) return;
     if (ltnum > sleeper_num) return;
     if (ltnum < sleeper_num) rb_bug("sleeper must not be more than vm_living_thread_num(vm)");
     if (patrol_thread && patrol_thread != GET_THREAD()) return;

--- a/vm_core.h
+++ b/vm_core.h
@@ -595,7 +595,7 @@ typedef struct rb_vm_struct {
     unsigned int running: 1;
     unsigned int thread_abort_on_exception: 1;
     unsigned int thread_report_on_exception: 1;
-    unsigned int ignore_deadlock: 1;
+    unsigned int thread_ignore_deadlock: 1;
 
     /* object management */
     VALUE mark_object_ary;

--- a/vm_core.h
+++ b/vm_core.h
@@ -595,7 +595,7 @@ typedef struct rb_vm_struct {
     unsigned int running: 1;
     unsigned int thread_abort_on_exception: 1;
     unsigned int thread_report_on_exception: 1;
-    unsigned int safe_level_: 1;
+    unsigned int ignore_deadlock: 1;
 
     /* object management */
     VALUE mark_object_ary;


### PR DESCRIPTION
Setting this to true disables the deadlock detector.  It should
only be used in cases where the deadlock could be broken via some
external means, such as via a signal.

Now that $SAFE is no longer used, replace the safe_level_ VM flag
with ignore_deadlock for storing the setting.

Fixes [Bug #13768]