### PR TITLE
Use public allocators for creating new T_OBJECT objects

### DIFF
--- a/ext/socket/ancdata.c
+++ b/ext/socket/ancdata.c
@@ -88,9 +88,9 @@ ancillary_initialize(VALUE self, VALUE vfamily, VALUE vlevel, VALUE vtype, VALUE
 static VALUE
 ancdata_new(int family, int level, int type, VALUE data)
 {
-    NEWOBJ_OF(obj, struct RObject, rb_cAncillaryData, T_OBJECT);
+    VALUE obj = rb_obj_alloc(rb_cAncillaryData);
     StringValue(data);
-    ancillary_initialize((VALUE)obj, INT2NUM(family), INT2NUM(level), INT2NUM(type), data);
+    ancillary_initialize(obj, INT2NUM(family), INT2NUM(level), INT2NUM(type), data);
     return (VALUE)obj;
 }
 

--- a/ext/socket/option.c
+++ b/ext/socket/option.c
@@ -106,9 +106,9 @@ sockopt_initialize(VALUE self, VALUE vfamily, VALUE vlevel, VALUE voptname, VALU
 VALUE
 rsock_sockopt_new(int family, int level, int optname, VALUE data)
 {
-    NEWOBJ_OF(obj, struct RObject, rb_cSockOpt, T_OBJECT);
+    VALUE obj = rb_obj_alloc(rb_cSockOpt);
     StringValue(data);
-    sockopt_initialize((VALUE)obj, INT2NUM(family), INT2NUM(level), INT2NUM(optname), data);
+    sockopt_initialize(obj, INT2NUM(family), INT2NUM(level), INT2NUM(optname), data);
     return (VALUE)obj;
 }
 

--- a/range.c
+++ b/range.c
@@ -1676,10 +1676,7 @@ r_cover_p(VALUE range, VALUE beg, VALUE end, VALUE val)
 static VALUE
 range_dumper(VALUE range)
 {
-    VALUE v;
-    NEWOBJ_OF(m, struct RObject, rb_cObject, T_OBJECT | (RGENGC_WB_PROTECTED_OBJECT ? FL_WB_PROTECTED : 1));
-
-    v = (VALUE)m;
+    VALUE v = rb_obj_alloc(rb_cObject);
 
     rb_ivar_set(v, id_excl, RANGE_EXCL(range));
     rb_ivar_set(v, id_beg, RANGE_BEG(range));


### PR DESCRIPTION
This way the header flags and object internals are set correctly