### PR TITLE
Ractor's "will" doesn't need copying.

### DIFF
--- a/ractor.h
+++ b/ractor.h
@@ -10,15 +10,15 @@
 
 enum rb_ractor_basket_type {
     basket_type_none,
-    basket_type_shareable,
-    basket_type_copy_marshal,
-    basket_type_copy_custom,
+    basket_type_ref,
+    basket_type_copy,
     basket_type_move,
-    basket_type_exception,
+    basket_type_will,
 };
 
 struct rb_ractor_basket {
     enum rb_ractor_basket_type type;
+    bool exception;
     VALUE v;
     VALUE sender;
 };


### PR DESCRIPTION
`r = Ractor.new{ expr }` generates the block return value from `expr`
and we can get this value by `r.take`. Ractor.yield and Ractor#take
passing values by copying on default. However, the block return value
(we named it "will" in the code) is not referred from the Ractor
because the Ractor is already dead. So we can pass the reference
of "will" to another ractor without copying. We can apply same story
for the propagated exception.