### PR TITLE
Fix typo in the auto compact announcement [ci-skip]

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -267,7 +267,7 @@ Outstanding ones only.
 
         * `GC.auto_compact=`, `GC.auto_compact` can be used to control when
           compaction runs.  Setting `auto_compact=` to true will cause
-          compaction to occurr duing major collections.  At the moment,
+          compaction to occurr during major collections.  At the moment,
           compaction adds significant overhead to major collections, so please
           test first!
           [[Feature #17176]]


### PR DESCRIPTION
I'm sorry, but I think there is a typo here.

This fix will help folks who are trying to translate this announcement to other languages. I hope this is not a joke and I didn't get it 🙏