### PR TITLE
Simplify instance variable setting

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -2304,7 +2304,11 @@ rb_newobj(void)
 VALUE
 rb_newobj_of(VALUE klass, VALUE flags)
 {
-    return newobj_of(klass, flags & ~FL_WB_PROTECTED, 0, 0, 0, flags & FL_WB_PROTECTED);
+    if ((flags & RUBY_T_MASK) == T_OBJECT) {
+        return newobj_of(klass, (flags | ROBJECT_EMBED) & ~FL_WB_PROTECTED , Qundef, Qundef, Qundef, flags & FL_WB_PROTECTED);
+    } else {
+        return newobj_of(klass, flags & ~FL_WB_PROTECTED, 0, 0, 0, flags & FL_WB_PROTECTED);
+    }
 }
 
 #define UNEXPECTED_NODE(func) \


### PR DESCRIPTION
Simplify setting instance variables on T_OBJECT.

When `T_OBJECT` is allocated, we default it to an embedded object and initialize the internal ivar slots to `Qundef`.  That means `ROBJECT_NUMIV` will always return a value `>= ROBJECT_EMBED_LEN_MAX` for `T_OBJECT` objects.  We can use this invariant to simplify the logic in `obj_ivar_set`.

If `ivup.index` is greater than `ROBJECT_NUMIV(obj)`, we know that the instance variable must be stored in the extended ivar table, which means we can remove the `ivup.index < ROBJECT_EMBED_LEN_MAX` test.