### PR TITLE
Fix  links for link.springer.com

### DIFF
--- a/array.c
+++ b/array.c
@@ -7687,7 +7687,7 @@ rb_ary_sum(int argc, VALUE *argv, VALUE ary)
     if (RB_FLOAT_TYPE_P(e)) {
         /*
          * Kahan-Babuska balancing compensated summation algorithm
-         * See http://link.springer.com/article/10.1007/s00607-005-0139-x
+         * See https://link.springer.com/article/10.1007/s00607-005-0139-x
          */
         double f, c;
         double x, t;

--- a/enum.c
+++ b/enum.c
@@ -3903,7 +3903,7 @@ sum_iter_Kahan_Babuska(VALUE i, struct enum_sum_memo *memo)
 {
     /*
      * Kahan-Babuska balancing compensated summation algorithm
-     * See http://link.springer.com/article/10.1007/s00607-005-0139-x
+     * See https://link.springer.com/article/10.1007/s00607-005-0139-x
      */
     double x;
 


### PR DESCRIPTION
`http://link.springer.com/article/10.1007/s00607-005-0139-x` redirect to `https://link.springer.com/article/10.1007/s00607-005-0139-x`