### PR TITLE
Root class and modules once only

### DIFF
--- a/class.c
+++ b/class.c
@@ -626,7 +626,7 @@ boot_defclass(const char *name, VALUE super)
     ID id = rb_intern(name);
 
     rb_const_set((rb_cObject ? rb_cObject : obj), id, obj);
-    rb_vm_add_root_module(id, obj);
+    rb_vm_add_root_module(obj);
     return obj;
 }
 
@@ -748,14 +748,14 @@ rb_define_class(const char *name, VALUE super)
 	}
 
         /* Class may have been defined in Ruby and not pin-rooted */
-        rb_vm_add_root_module(id, klass);
+        rb_vm_add_root_module(klass);
 	return klass;
     }
     if (!super) {
 	rb_raise(rb_eArgError, "no super class for `%s'", name);
     }
     klass = rb_define_class_id(id, super);
-    rb_vm_add_root_module(id, klass);
+    rb_vm_add_root_module(klass);
     rb_const_set(rb_cObject, id, klass);
     rb_class_inherited(super, klass);
 
@@ -821,7 +821,7 @@ rb_define_class_id_under(VALUE outer, ID id, VALUE super)
 		     outer, rb_id2str(id), RCLASS_SUPER(klass), super);
 	}
         /* Class may have been defined in Ruby and not pin-rooted */
-        rb_vm_add_root_module(id, klass);
+        rb_vm_add_root_module(klass);
 
 	return klass;
     }
@@ -833,7 +833,7 @@ rb_define_class_id_under(VALUE outer, ID id, VALUE super)
     rb_set_class_path_string(klass, outer, rb_id2str(id));
     rb_const_set(outer, id, klass);
     rb_class_inherited(super, klass);
-    rb_vm_add_root_module(id, klass);
+    rb_vm_add_root_module(klass);
     rb_gc_register_mark_object(klass);
 
     return klass;
@@ -867,11 +867,11 @@ rb_define_module(const char *name)
 		     name, rb_obj_class(module));
 	}
         /* Module may have been defined in Ruby and not pin-rooted */
-        rb_vm_add_root_module(id, module);
+        rb_vm_add_root_module(module);
 	return module;
     }
     module = rb_define_module_id(id);
-    rb_vm_add_root_module(id, module);
+    rb_vm_add_root_module(module);
     rb_gc_register_mark_object(module);
     rb_const_set(rb_cObject, id, module);
 

--- a/class.c
+++ b/class.c
@@ -834,7 +834,6 @@ rb_define_class_id_under(VALUE outer, ID id, VALUE super)
     rb_const_set(outer, id, klass);
     rb_class_inherited(super, klass);
     rb_vm_add_root_module(klass);
-    rb_gc_register_mark_object(klass);
 
     return klass;
 }
@@ -872,7 +871,6 @@ rb_define_module(const char *name)
     }
     module = rb_define_module_id(id);
     rb_vm_add_root_module(module);
-    rb_gc_register_mark_object(module);
     rb_const_set(rb_cObject, id, module);
 
     return module;

--- a/internal/vm.h
+++ b/internal/vm.h
@@ -54,7 +54,7 @@ const void **rb_vm_get_insns_address_table(void);
 VALUE rb_source_location(int *pline);
 const char *rb_source_location_cstr(int *pline);
 MJIT_STATIC void rb_vm_pop_cfunc_frame(void);
-int rb_vm_add_root_module(ID id, VALUE module);
+int rb_vm_add_root_module(VALUE module);
 void rb_vm_check_redefinition_by_prepend(VALUE klass);
 int rb_vm_check_optimizable_mid(VALUE mid);
 VALUE rb_yield_refine_block(VALUE refinement, VALUE refinements);

--- a/vm.c
+++ b/vm.c
@@ -2597,7 +2597,7 @@ rb_vm_register_special_exception_str(enum ruby_special_exceptions sp, VALUE cls,
 }
 
 int
-rb_vm_add_root_module(ID id, VALUE module)
+rb_vm_add_root_module(VALUE module)
 {
     rb_vm_t *vm = GET_VM();
 


### PR DESCRIPTION
rb_vm_add_root_module() is enough to make sure the object become a GC
root.

---

Off topic, `rb_vm_add_root_module()` looks like it should take the VM lock to me, but I'm not sure. It's similar in structure to `rb_gc_register_mark_object()`. CC @ko1 

https://github.com/ruby/ruby/blob/46f3b68fbf9f0ae3eb678de0fea1fef79ced4d9e/vm.c#L2599-L2607