### PR TITLE
Scheduler condition variable synchronization

### DIFF
--- a/doc/scheduler.md
+++ b/doc/scheduler.md
@@ -73,7 +73,7 @@ program.
 Fibers can be used to create non-blocking execution contexts.
 
 ~~~ ruby
-Fiber.new(blocking: false) do
+Fiber.new do
   puts Fiber.current.blocking? # false
 
   # May invoke `Fiber.scheduler&.io_wait`.

--- a/test/fiber/scheduler.rb
+++ b/test/fiber/scheduler.rb
@@ -135,12 +135,7 @@ class Scheduler
 
   # Used for Kernel#sleep and Mutex#sleep
   def kernel_sleep(duration = nil)
-    # p [__method__, duration]
-    if duration
-      @waiting[Fiber.current] = current_time + duration
-    end
-
-    Fiber.yield
+    self.block(:sleep, duration)
 
     return true
   end

--- a/test/fiber/scheduler.rb
+++ b/test/fiber/scheduler.rb
@@ -25,7 +25,7 @@ class Scheduler
     @blocking = 0
     @ready = []
 
-    @urgent = nil
+    @urgent = IO.pipe
   end
 
   attr :readable
@@ -47,8 +47,6 @@ class Scheduler
   end
 
   def run
-    @urgent = IO.pipe
-
     while @readable.any? or @writable.any? or @waiting.any? or @blocking.positive?
       # Can only handle file descriptors up to 1024...
       readable, writable = IO.select(@readable.keys + [@urgent.first], @writable.keys, [], next_timeout)
@@ -95,9 +93,6 @@ class Scheduler
         end
       end
     end
-  ensure
-    @urgent.each(&:close)
-    @urgent = nil
   end
 
   def close
@@ -105,6 +100,9 @@ class Scheduler
 
     self.run
   ensure
+    @urgent.each(&:close)
+    @urgent = nil
+
     @closed = true
 
     # We freeze to detect any unintended modifications after the scheduler is closed:
@@ -142,7 +140,8 @@ class Scheduler
 
   # Used when blocking on synchronization (Mutex#lock, Queue#pop, SizedQueue#push, ...)
   def block(blocker, timeout = nil)
-    # p [__method__, blocker, timeout]
+    # $stderr.puts [__method__, blocker, timeout].inspect
+
     if timeout
       @waiting[Fiber.current] = current_time + timeout
       begin
@@ -164,14 +163,14 @@ class Scheduler
   # Used when synchronization wakes up a previously-blocked fiber (Mutex#unlock, Queue#push, ...).
   # This might be called from another thread.
   def unblock(blocker, fiber)
-    # p [__method__, blocker, fiber]
+    # $stderr.puts [__method__, blocker, fiber].inspect
+
     @lock.synchronize do
       @ready << fiber
     end
 
-    if io = @urgent&.last
-      io.write_nonblock('.')
-    end
+    io = @urgent.last
+    io.write_nonblock('.')
   end
 
   def fiber(&block)

--- a/thread_sync.c
+++ b/thread_sync.c
@@ -29,15 +29,15 @@ sync_wakeup(struct list_head *head, long max)
     list_for_each_safe(head, cur, next, node) {
         list_del_init(&cur->node);
 
-        if (cur->th->scheduler != Qnil) {
-            rb_scheduler_unblock(cur->th->scheduler, cur->self, rb_fiberptr_self(cur->fiber));
-        }
-
         if (cur->th->status != THREAD_KILLED) {
-            if (cur->th->scheduler == Qnil) {
+            
+            if (cur->th->scheduler != Qnil) {
+                rb_scheduler_unblock(cur->th->scheduler, cur->self, rb_fiberptr_self(cur->fiber));
+            } else {
                 rb_threadptr_interrupt(cur->th);
                 cur->th->status = THREAD_RUNNABLE;
             }
+
             if (--max == 0) return;
         }
     }

--- a/thread_sync.c
+++ b/thread_sync.c
@@ -193,14 +193,35 @@ rb_mutex_locked_p(VALUE self)
 }
 
 static void
+thread_mutex_insert(rb_thread_t *thread, rb_mutex_t *mutex) {
+    if (thread->keeping_mutexes) {
+        mutex->next_mutex = thread->keeping_mutexes;
+    }
+
+    thread->keeping_mutexes = mutex;
+}
+
+static void
+thread_mutex_remove(rb_thread_t *thread, rb_mutex_t *mutex) {
+    rb_mutex_t **keeping_mutexes = &thread->keeping_mutexes;
+
+    while (*keeping_mutexes && *keeping_mutexes != mutex) {
+        // Move to the next mutex in the list:
+        keeping_mutexes = &(*keeping_mutexes)->next_mutex;
+    }
+
+    if (*keeping_mutexes) {
+        *keeping_mutexes = mutex->next_mutex;
+        mutex->next_mutex = NULL;
+    }
+}
+
+static void
 mutex_locked(rb_thread_t *th, VALUE self)
 {
     rb_mutex_t *mutex = mutex_ptr(self);
 
-    if (th->keeping_mutexes) {
-	mutex->next_mutex = th->keeping_mutexes;
-    }
-    th->keeping_mutexes = mutex;
+    thread_mutex_insert(th, mutex);
 }
 
 /*
@@ -392,18 +413,17 @@ rb_mutex_unlock_th(rb_mutex_t *mutex, rb_thread_t *th, rb_fiber_t *fiber)
     const char *err = NULL;
 
     if (mutex->fiber == 0) {
-	err = "Attempt to unlock a mutex which is not locked";
+        err = "Attempt to unlock a mutex which is not locked";
     }
     else if (mutex->fiber != fiber) {
-	err = "Attempt to unlock a mutex which is locked by another thread/fiber";
+        err = "Attempt to unlock a mutex which is locked by another thread/fiber";
     }
     else {
-	struct sync_waiter *cur = 0, *next;
-	rb_mutex_t **th_mutex = &th->keeping_mutexes;
+        struct sync_waiter *cur = 0, *next;
 
-	mutex->fiber = 0;
-	list_for_each_safe(&mutex->waitq, cur, next, node) {
-	    list_del_init(&cur->node);
+        mutex->fiber = 0;
+        list_for_each_safe(&mutex->waitq, cur, next, node) {
+            list_del_init(&cur->node);
 
             if (cur->th->scheduler != Qnil) {
                 rb_scheduler_unblock(cur->th->scheduler, cur->self, rb_fiberptr_self(cur->fiber));
@@ -422,13 +442,10 @@ rb_mutex_unlock_th(rb_mutex_t *mutex, rb_thread_t *th, rb_fiber_t *fiber)
                     continue;
                 }
             }
-	}
-      found:
-	while (*th_mutex != mutex) {
-	    th_mutex = &(*th_mutex)->next_mutex;
-	}
-	*th_mutex = mutex->next_mutex;
-	mutex->next_mutex = NULL;
+        }
+
+    found:
+        thread_mutex_remove(th, mutex);
     }
 
     return err;


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/17300

I found two issues:

- There was a race condition when accessing `th->keeping_mutexes` in `rb_mutex_unlock_th`. The time when it was fetched, to the time it was used, it could already be changed and thus the original pointer was invalid.

- `Scheduler#kernel_sleep` was not implemented correctly. It did not increment `@blocking` which caused the run loop to exit prematurely.