### PR TITLE
Improve performance Array#deconstruct & Array#to_ary [Feature #17311]

### DIFF
--- a/array.c
+++ b/array.c
@@ -2902,19 +2902,6 @@ rb_ary_to_h(VALUE ary)
     return hash;
 }
 
-/*
- *  call-seq:
- *    array.to_ary -> self
- *
- *  Returns +self+.
- */
-
-static VALUE
-rb_ary_to_ary_m(VALUE ary)
-{
-    return ary;
-}
-
 static void
 ary_reverse(VALUE *p1, VALUE *p2)
 {
@@ -7750,12 +7737,6 @@ rb_ary_sum(int argc, VALUE *argv, VALUE ary)
     return v;
 }
 
-static VALUE
-rb_ary_deconstruct(VALUE ary)
-{
-    return ary;
-}
-
 /*
  *  An \Array is an ordered, integer-indexed collection of objects,
  *  called _elements_.  Any object may be an \Array element.
@@ -8029,7 +8010,6 @@ Init_Array(void)
     rb_define_alias(rb_cArray,  "to_s", "inspect");
     rb_define_method(rb_cArray, "to_a", rb_ary_to_a, 0);
     rb_define_method(rb_cArray, "to_h", rb_ary_to_h, 0);
-    rb_define_method(rb_cArray, "to_ary", rb_ary_to_ary_m, 0);
 
     rb_define_method(rb_cArray, "==", rb_ary_equal, 1);
     rb_define_method(rb_cArray, "eql?", rb_ary_eql, 1);
@@ -8136,8 +8116,6 @@ Init_Array(void)
     rb_define_method(rb_cArray, "one?", rb_ary_one_p, -1);
     rb_define_method(rb_cArray, "dig", rb_ary_dig, -1);
     rb_define_method(rb_cArray, "sum", rb_ary_sum, -1);
-
-    rb_define_method(rb_cArray, "deconstruct", rb_ary_deconstruct, 0);
 }
 
 #include "array.rbinc"

--- a/array.rb
+++ b/array.rb
@@ -56,4 +56,18 @@ class Array
   def sample(n = (ary = false), random: Random)
     Primitive.rb_ary_sample(random, n, ary)
   end
+
+  #
+  #  call-seq:
+  #    array.to_ary -> self
+  #
+  #  Returns +self+.
+  #
+  def to_ary
+    return self
+  end
+
+  def deconstruct
+    return self
+  end
 end

--- a/benchmark/array_return_self.yml
+++ b/benchmark/array_return_self.yml
@@ -1,0 +1,12 @@
+prelude: |
+  sary = Array.new(10)
+  mary = Array.new(1000)
+  lary = Array.new(30_000_000)
+benchmark:
+  - sary.deconstruct
+  - mary.deconstruct
+  - lary.deconstruct
+  - sary.to_ary
+  - mary.to_ary
+  - lary.to_ary
+loop_count: 20000000


### PR DESCRIPTION
ref: [Feature #17311 Improve performance Array#deconstruct & Array#to_ary](https://bugs.ruby-lang.org/issues/17311)

benchmark:

```yml
prelude: |
  sary = Array.new(10)
  mary = Array.new(1000)
  lary = Array.new(30_000_000)
benchmark:
  - sary.deconstruct
  - mary.deconstruct
  - lary.deconstruct
  - sary.to_ary
  - mary.to_ary
  - lary.to_ary
loop_count: 20000000
```

benchmark result: 

```bash
sh@MyComputer:~/rubydev/build$ make benchmark/benchmark.yml -e COMPARE_RUBY=~/.rbenv/shims/ruby -e BENCH_RUBY=../install/bin/ruby
# Iteration per second (i/s)

|                  |compare-ruby|built-ruby|
|:-----------------|-----------:|---------:|
|sary.deconstruct  |     72.866M|   74.310M|
|                  |           -|     1.02x|
|mary.deconstruct  |     73.665M|   80.049M|
|                  |           -|     1.09x|
|lary.deconstruct  |     74.924M|   86.865M|
|                  |           -|     1.16x|
|sary.to_ary       |     70.203M|   81.387M|
|                  |           -|     1.16x|
|mary.to_ary       |     72.142M|   78.847M|
|                  |           -|     1.09x|
|lary.to_ary       |     70.473M|   86.382M|
|                  |           -|     1.23x|
```