### PR TITLE
[WIP] Use Fiber#transfer in the test Scheduler

### DIFF
--- a/test/fiber/enumerator.rb
+++ b/test/fiber/enumerator.rb
@@ -1,0 +1,28 @@
+require_relative 'scheduler'
+
+def some_yielder
+  p [Fiber.current, Thread.current.scheduler, Thread.current.blocking?]
+  yield 1
+  sleep 0.1
+  yield 2
+end
+
+def enumerator
+  to_enum(:some_yielder)
+end
+
+scheduler = Scheduler.new
+Thread.current.scheduler = scheduler
+
+ary = []
+Fiber.schedule do
+  p [:scheduled_fiber, Fiber.current]
+  enum = enumerator()
+  ary << p(enum.next)
+  ary << p(enum.next)
+  ary << (enum.next rescue $!)
+end
+
+scheduler.run
+
+p ary # should be [1, 2, #<StopIteration: iteration reached an end>]

--- a/test/fiber/enumerator.rb
+++ b/test/fiber/enumerator.rb
@@ -1,7 +1,7 @@
 require_relative 'scheduler'
 
 def some_yielder
-  p [Fiber.current, Thread.current.scheduler, Thread.current.blocking?]
+  p [Fiber.current, Fiber.scheduler, Fiber.blocking?]
   yield 1
   sleep 0.1
   yield 2
@@ -12,7 +12,7 @@ def enumerator
 end
 
 scheduler = Scheduler.new
-Thread.current.scheduler = scheduler
+Fiber.set_scheduler(scheduler)
 
 ary = []
 Fiber.schedule do

--- a/test/fiber/user_fiber.rb
+++ b/test/fiber/user_fiber.rb
@@ -1,0 +1,23 @@
+require_relative 'scheduler'
+
+scheduler = Scheduler.new
+Thread.current.scheduler = scheduler
+
+ary = []
+Fiber.schedule do
+  p [:scheduled_fiber, Fiber.current]
+  f = Fiber.new(blocking: false) do # blocking: false is just to simulate "all Fibers are non-blocking"
+    Fiber.yield 1
+    sleep 0.1
+    Fiber.yield 2
+    sleep 0.2
+    :last
+  end
+  ary << p(f.resume)
+  ary << p(f.resume)
+  ary << p(f.resume)
+end
+
+scheduler.run
+
+p ary # [1, nil, 2] but should be [1, 2, :last]

--- a/test/fiber/user_fiber.rb
+++ b/test/fiber/user_fiber.rb
@@ -1,7 +1,7 @@
 require_relative 'scheduler'
 
 scheduler = Scheduler.new
-Thread.current.scheduler = scheduler
+Fiber.set_scheduler scheduler
 
 ary = []
 Fiber.schedule do


### PR DESCRIPTION
@ioquatix @mame @ko1 This is my prototype from when we discussed using Fiber#transfer to correctly handle enumerators and user Fibers with the scheduler.
I think we should merge something like that.
Otherwise both cases (`test/fiber/enumerator.rb`, `test/fiber/user_fiber.rb`) are broken with the current scheduler.