### PR TITLE
Kernel#sleep and Mutex#sleep can simply call Scheduler#block

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -226,7 +226,7 @@ Outstanding ones only.
 
 * Kernel
 
-    * `Kernel.sleep(...)` invokes the scheduler hook `#kernel_sleep(...)` in a
+    * `Kernel.sleep(...)` invokes the scheduler hook `#block(...)` in a
       non-blocking execution context. [[Feature #16786]]
 
 * IO

--- a/doc/scheduler.md
+++ b/doc/scheduler.md
@@ -21,12 +21,6 @@ class Scheduler
   def io_wait(io, events, timeout)
   end
 
-  # Sleep the current task for the specified duration, or forever if not
-  # specified.
-  # @param duration [Numeric] The amount of time to sleep in seconds.
-  def kernel_sleep(duration = nil)
-  end
-
   # Block the calling fiber.
   # @parameter blocker [Object] What we are waiting on, informational only.
   # @parameter timeout [Numeric | Nil] The amount of time to wait for in seconds.
@@ -82,7 +76,7 @@ Fiber.new do
   # May invoke `Fiber.scheduler&.io_wait`.
   io.write(...)
 
-  # Will invoke `Fiber.scheduler&.kernel_sleep`.
+  # Will invoke `Thread.scheduler&.block(:sleep, n)`.
   sleep(n)
 end.resume
 ~~~

--- a/internal/scheduler.h
+++ b/internal/scheduler.h
@@ -22,9 +22,6 @@ VALUE rb_scheduler_timeout(struct timeval *timeout);
 
 VALUE rb_scheduler_close(VALUE scheduler);
 
-VALUE rb_scheduler_kernel_sleep(VALUE scheduler, VALUE duration);
-VALUE rb_scheduler_kernel_sleepv(VALUE scheduler, int argc, VALUE * argv);
-
 VALUE rb_scheduler_block(VALUE scheduler, VALUE blocker, VALUE timeout);
 VALUE rb_scheduler_unblock(VALUE scheduler, VALUE blocker, VALUE fiber);
 

--- a/scheduler.c
+++ b/scheduler.c
@@ -17,8 +17,6 @@ static ID id_close;
 static ID id_block;
 static ID id_unblock;
 
-static ID id_kernel_sleep;
-
 static ID id_io_read;
 static ID id_io_write;
 static ID id_io_wait;
@@ -30,8 +28,6 @@ Init_Scheduler(void)
 
     id_block = rb_intern_const("block");
     id_unblock = rb_intern_const("unblock");
-
-    id_kernel_sleep = rb_intern_const("kernel_sleep");
 
     id_io_read = rb_intern_const("io_read");
     id_io_write = rb_intern_const("io_write");
@@ -104,18 +100,6 @@ rb_scheduler_timeout(struct timeval *timeout)
     }
 
     return Qnil;
-}
-
-VALUE
-rb_scheduler_kernel_sleep(VALUE scheduler, VALUE timeout)
-{
-    return rb_funcall(scheduler, id_kernel_sleep, 1, timeout);
-}
-
-VALUE
-rb_scheduler_kernel_sleepv(VALUE scheduler, int argc, VALUE * argv)
-{
-    return rb_funcallv(scheduler, id_kernel_sleep, argc, argv);
 }
 
 VALUE

--- a/test/fiber/scheduler.rb
+++ b/test/fiber/scheduler.rb
@@ -131,13 +131,6 @@ class Scheduler
     return true
   end
 
-  # Used for Kernel#sleep and Mutex#sleep
-  def kernel_sleep(duration = nil)
-    self.block(:sleep, duration)
-
-    return true
-  end
-
   # Used when blocking on synchronization (Mutex#lock, Queue#pop, SizedQueue#push, ...)
   def block(blocker, timeout = nil)
     # $stderr.puts [__method__, blocker, timeout].inspect


### PR DESCRIPTION
* Remove the no-longer-needed `#kernel_sleep` callback.