### PR TITLE
Add OptionParser#require_exact accessor

### DIFF
--- a/lib/optparse.rb
+++ b/lib/optparse.rb
@@ -1091,6 +1091,7 @@ XXX
     @summary_width = width
     @summary_indent = indent
     @default_argv = ARGV
+    @require_exact = false
     add_officious
     yield self if block_given?
   end
@@ -1163,6 +1164,10 @@ XXX
 
   # Strings to be parsed in default.
   attr_accessor :default_argv
+
+  # Whether to require that options match exactly (disallows providing
+  # abbreviated long option as short option).
+  attr_accessor :require_exact
 
   #
   # Heading banner preceding summary.
@@ -1583,6 +1588,9 @@ XXX
           opt.tr!('_', '-')
           begin
             sw, = complete(:long, opt, true)
+            if require_exact && !sw.long.include?(arg)
+              raise InvalidOption, arg
+            end
           rescue ParseError
             raise $!.set_option(arg, true)
           end
@@ -1607,6 +1615,7 @@ XXX
                 val = arg.delete_prefix('-')
                 has_arg = true
               rescue InvalidOption
+                raise if require_exact
                 # if no short options match, try completion with long
                 # options.
                 sw, = complete(:long, opt)

--- a/test/optparse/test_optparse.rb
+++ b/test/optparse/test_optparse.rb
@@ -75,4 +75,26 @@ class TestOptionParser < Test::Unit::TestCase
     assert_equal({host: "localhost", port: 8000, verbose: true}, result)
     assert_equal(true, @verbose)
   end
+
+  def test_require_exact
+    @opt.def_option('-F', '--zrs=IRS', 'zrs')
+    %w(--zrs --zr --z -zfoo -z -F -Ffoo).each do |arg|
+      result = {}
+      @opt.parse([arg, 'foo'], into: result)
+      assert_equal({zrs: 'foo'}, result)
+    end
+
+    @opt.require_exact = true
+    %w(--zrs -F -Ffoo).each do |arg|
+      result = {}
+      @opt.parse([arg, 'foo'], into: result)
+      assert_equal({zrs: 'foo'}, result)
+    end
+
+    assert_raise(OptionParser::InvalidOption) {@opt.parse(%w(--zr foo))}
+    assert_raise(OptionParser::InvalidOption) {@opt.parse(%w(--z foo))}
+    assert_raise(OptionParser::InvalidOption) {@opt.parse(%w(-zrs foo))}
+    assert_raise(OptionParser::InvalidOption) {@opt.parse(%w(-zr foo))}
+    assert_raise(OptionParser::InvalidOption) {@opt.parse(%w(-z foo))}
+  end
 end


### PR DESCRIPTION
This allows you to disable allowing abbreviations of long options
and using short options for long options.

Implements [Feature #11523]