### PR TITLE
ignore yield_atexit if outgoing port is closed

### DIFF
--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -309,6 +309,16 @@ assert_equal 'ok', %q{
   end
 }
 
+# a ractor with closed outgoing port should terminate
+assert_equal 'ok', %q{
+  Ractor.new do
+    close_outgoing
+  end
+
+  true until Ractor.count == 1
+  :ok
+}
+
 # multiple Ractors can receive (wait) from one Ractor
 assert_equal '[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]', %q{
   pipe = Ractor.new do

--- a/ractor.c
+++ b/ractor.c
@@ -1288,6 +1288,10 @@ ractor_create(rb_execution_context_t *ec, VALUE self, VALUE loc, VALUE name, VAL
 static void
 ractor_yield_atexit(rb_execution_context_t *ec, rb_ractor_t *cr, VALUE v, bool exc)
 {
+    if (cr->outgoing_port_closed) {
+        return;
+    }
+
     ASSERT_ractor_unlocking(cr);
 
     struct rb_ractor_basket basket;


### PR DESCRIPTION
If outgoing_port is closed, Ractor.yield never successes.
[Bug #17310]