### PR TITLE
Define HAVE_ISINF for Visual Studio >= 2013

### DIFF
--- a/win32/Makefile.sub
+++ b/win32/Makefile.sub
@@ -863,6 +863,9 @@ $(CONFIG_H): $(MKFILES) $(srcdir)/win32/Makefile.sub $(win_srcdir)/Makefile.sub
 #define HAVE_STRCHR 1
 #define HAVE_STRSTR 1
 #define HAVE_FLOCK 1
+!if $(MSC_VER) >= 1800
+#define HAVE_ISINF 1
+!endif
 #define HAVE_ISNAN 1
 #define HAVE_FINITE 1
 !if $(RT_VER) >= 120


### PR DESCRIPTION
`isinf` is defined in Visual Studio since version 2013 (see https://devblogs.microsoft.com/cppblog/c99-library-support-in-visual-studio-2013/). 

Defining `HAVE_ISINF` permit to avoid the conflict of `isinf` defined as a macro and the `std::isinf` function used in C++, see for example https://github.com/conda-forge/ruby-feedstock/issues/47 .