### PR TITLE
remove Ractor#close

### DIFF
--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -201,8 +201,8 @@ assert_equal 'ok', %q{
 # Raise Ractor::ClosedError when try to send into a closed actor
 assert_equal 'ok', %q{
   r = Ractor.new { Ractor.receive }
+  r.close_incoming
 
-  r.close
   begin
     r.send(1)
   rescue Ractor::ClosedError
@@ -219,7 +219,7 @@ assert_equal 'ok', %q{
     Ractor.receive
   end
 
-  r.close
+  r.close_outgoing
   begin
     r.take
   rescue Ractor::ClosedError

--- a/ractor.rb
+++ b/ractor.rb
@@ -164,14 +164,6 @@ class Ractor
     }
   end
 
-  # Closes both incoming and outgoing ports.
-  def close
-    close_incoming
-    close_outgoing
-
-    self
-  end
-
   # utility method
   def self.shareable? obj
     __builtin_cexpr! %q{


### PR DESCRIPTION
close_incoming by antoher ractor means there is no other messages
will be sent to the ractor, so Ractor.receive will block forever,
and it should raise and stop.

close_outgoing by antoher ractor means, ... I don't have good idea
to use it. It can be a private method.

Ractor#close calls both, but it does not make sense to call
different purpose methods, so I remove it.