### PR TITLE
Ractor::LVar

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -7224,6 +7224,7 @@ gc_marks_finish(rb_objspace_t *objspace)
     }
 
     rb_transient_heap_finish_marking();
+    rb_ractor_finish_marking();
 
     gc_event_hook(objspace, RUBY_INTERNAL_EVENT_GC_END_MARK, 0);
 

--- a/ractor.h
+++ b/ractor.h
@@ -121,6 +121,10 @@ struct rb_ractor_struct {
 
     struct list_node vmlr_node;
 
+    // ractor local data
+
+    st_table *local_storage;
+
     VALUE r_stdin;
     VALUE r_stdout;
     VALUE r_stderr;
@@ -158,6 +162,8 @@ void rb_ractor_blocking_threads_dec(rb_ractor_t *r, const char *file, int line);
 void rb_ractor_vm_barrier_interrupt_running_thread(rb_ractor_t *r);
 void rb_ractor_terminate_interrupt_main_thread(rb_ractor_t *r);
 void rb_ractor_terminate_all(void);
+
+void rb_ractor_finish_marking(void);
 
 static inline bool
 rb_ractor_status_p(rb_ractor_t *r, enum ractor_status status)

--- a/ractor.rb
+++ b/ractor.rb
@@ -176,4 +176,29 @@ class Ractor
       rb_ractor_make_shareable(obj);
     }
   end
+
+  class LVar
+    def self.new &b
+      b = b # TODO: builtin system's bug
+      __builtin_cexpr! %q{
+        ractor_lvar_new(ec, b)
+      }
+    end
+
+    def value
+      __builtin_cexpr! %q{
+        ractor_lvar_value(ec, self)
+      }
+    end
+
+    def value= val
+      __builtin_cexpr! %q{
+        ractor_lvar_value_set(ec, self, val)
+      }
+    end
+
+    def inspect
+      "#<Ractor::LVar #{self.value.inspect}>"
+    end
+  end
 end


### PR DESCRIPTION
Ractor::LVar is Ractor-Local-Variable.
You can access LVar with value and value= methods, and they are
stored in per-Ractor storage.

https://bugs.ruby-lang.org/issues/17323