### PR TITLE
Use rb_attr_get() for hidden ivar

### DIFF
--- a/class.c
+++ b/class.c
@@ -1811,7 +1811,7 @@ singleton_class_of(VALUE obj)
 
     klass = RBASIC(obj)->klass;
     if (!(FL_TEST(klass, FL_SINGLETON) &&
-	  rb_ivar_get(klass, id_attached) == obj)) {
+          rb_attr_get(klass, id_attached) == obj)) {
 	rb_serial_t serial = RCLASS_SERIAL(klass);
 	klass = rb_make_metaclass(obj, klass);
 	RCLASS_SERIAL(klass) = serial;
@@ -1852,7 +1852,7 @@ rb_singleton_class_get(VALUE obj)
     }
     klass = RBASIC(obj)->klass;
     if (!FL_TEST(klass, FL_SINGLETON)) return Qnil;
-    if (rb_ivar_get(klass, id_attached) != obj) return Qnil;
+    if (rb_attr_get(klass, id_attached) != obj) return Qnil;
     return klass;
 }
 


### PR DESCRIPTION
rb_ivar_get() can issue an uninitialized ivar warning. We never want to
issue warnings about hidden ivars as they are not actionable for users.