### PR TITLE
Added Fiber#cancel, which forces a Fiber to return

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -3379,8 +3379,10 @@ cont.$(OBJEXT): {$(VPATH)}st.h
 cont.$(OBJEXT): {$(VPATH)}subst.h
 cont.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).h
 cont.$(OBJEXT): {$(VPATH)}thread_native.h
+cont.$(OBJEXT): {$(VPATH)}vm_callinfo.h
 cont.$(OBJEXT): {$(VPATH)}vm_core.h
 cont.$(OBJEXT): {$(VPATH)}vm_debug.h
+cont.$(OBJEXT): {$(VPATH)}vm_insnhelper.h
 cont.$(OBJEXT): {$(VPATH)}vm_opts.h
 debug.$(OBJEXT): $(CCAN_DIR)/check_type/check_type.h
 debug.$(OBJEXT): $(CCAN_DIR)/container_of/container_of.h

--- a/cont.c
+++ b/cont.c
@@ -2298,7 +2298,7 @@ fiber_cancel(VALUE fiber_value, VALUE reason)
     rb_thread_t *th = GET_THREAD();
 
     if (FIBER_TERMINATED_P(fiber)) {
-        rb_raise(rb_eFiberError, "attempt to cancel a terminated fiber");
+        return Qnil;
     }
     else if (cont_thread_value(cont) != th->self) {
         rb_raise(rb_eFiberError, "fiber called across threads");
@@ -2358,8 +2358,8 @@ fiber_cancel(VALUE fiber_value, VALUE reason)
  *  The most recent cancel reason will be returned.
  *
  *  Immediately returns +reason+ if called on the current fiber or an unstarted
- *  fiber. Terminates an unstarted fiber without starting it. Raises
- *  +FiberError+ if fiber is already terminated.
+ *  fiber. Terminates an unstarted fiber without starting it. Returns nil if the
+ *  fiber is already terminated.
  *
  */
 static VALUE

--- a/internal/cont.h
+++ b/internal/cont.h
@@ -21,5 +21,6 @@ void ruby_register_rollback_func_for_ensure(VALUE (*ensure_func)(VALUE), VALUE (
 void rb_fiber_init_mjit_cont(struct rb_fiber_struct *fiber);
 
 VALUE rb_fiberptr_self(struct rb_fiber_struct *fiber);
+NORETURN(void rb_fiber_break(VALUE));
 
 #endif /* INTERNAL_CONT_H */

--- a/test/ruby/test_fiber.rb
+++ b/test/ruby/test_fiber.rb
@@ -351,23 +351,11 @@ class TestFiber < Test::Unit::TestCase
     assert_not_predicate(fib, :alive?)
   end
 
-  def test_cancel_aliver_fiber
-    assert_raise(FiberError){
-      fib = Fiber.new{}
-      fib.resume
-      fib.cancel "cancel in dead fiber"
-    }
-  end
-
-  def test_cancel_unborn_and_dead_fibers
-    fib = Fiber.new{ :unreachable }
-    assert_equal("cancel unborn", fib.cancel("cancel unborn"))
-    assert_not_predicate(fib, :alive?)
-    assert_raise(FiberError){
-      fib = Fiber.new{}
-      fib.resume
-      fib.cancel "cancel in dead fiber"
-    }
+  def test_cancel_dead_fiber
+    fib = Fiber.new{}
+    fib.resume
+    assert_equal(nil, fib.cancel("cancel dead"))
+    assert_not_predicate(fib, :canceled?)
   end
 
   def test_transfer


### PR DESCRIPTION
This skips rescue and catch blocks but runs all ensure blocks. It can be run on any living fiber, and propagates cancellation to child (resumed) fibers.

Basically, I want it to behave as if you called `break` or `return` to jump all the way to the top frame of the fiber from wherever it is.. Exceptions might be too heavy-weight, can't (and shouldn't) be sent to resuming fibers, and can be caught. This can also be emulated via `catch/throw` with an anonymous `Object.new`, but that adds an extra stack frame, and implementing it reliably requires interception of `Fiber.yield`, e.g. adding a `Fiber.throw` (analogous to `Fiber.raise`) which also shouldn't be sent to resuming fibers.

I tried to match the new _(much improved!)_ transfer/resume switch semantics with cancel propagation. When the cancelation propagates all the way to the bottom of the fiber resume stack, the last fiber in the chain will then be resumed. Resuming fibers will not run until they are yielded back into.

I think it's important to allow future `resume` and `transfer` out of a canceled fiber, in case it's necessary to close resources from `ensure` blocks. However, I may have chosen the wrong behavior for multiple `cancels` on a `canceling`. I chose to use the same propagate/resume/transfer semantics but _not `break` again_ after subsequent cancels. On second thought, I think it should behave more like a standard `break`, and do exactly the same thing that `break` or `return` would normally do if they are called from an `ensure` block. I'll update this PR with that behavior when I'm able to.

This is my first big foray into the ruby C API, so I hope it makes sense what I was trying to do. Did I handle `vm_fiber_break` and `fiber_start` appropriately? Is there is somewhere more appropriate to save the cancel reason than a new `VALUE` on `rb_fiber_struct`? E.g. could I safely assign the canceled fiber's `ec->errinfo` from the calling Fiber, instead of using `cancel_reason`?

When this compiles, it warns about:
```
vm_insnhelper.h:251:1: warning: ‘vm_call_iseq_optimizable_p’ defined but not used [-Wunused-function]
  251 | vm_call_iseq_optimizable_p(const struct rb_callinfo *ci, const struct rb_callcache *cc)     
```
So I'm probably doing something wrong there, too.