### PR TITLE
Require a local `run.rb` file on `ruby -run`

### DIFF
--- a/lib/un.rb
+++ b/lib/un.rb
@@ -392,3 +392,6 @@ module UN # :nodoc:
     end
   end
 end
+
+local_run_file = File.join(Dir.pwd, 'run.rb')
+require(local_run_file) if File.file?(local_run_file)


### PR DESCRIPTION
Crazy idea, I know, but hear me out!

This is to allow more functinality to be built on top of what `lib/un.rb`
provides. With this change you can have a `run.rb` file locally with
arbitrary ruby code...

```ruby
puts 'Hello!'
```

...which will be executed when you do `ruby -run` from that directory.

You should aslo be able to execut functions...

```ruby
def greet
  puts 'Hello!'
end
```

...using the `-e` flag: `ruby -run -e greet`

Best of all, you can reuse the `setup` provided in `un.rb` to handle
extra flags:

```ruby
def greet
  setup('w') do |argv, options|
    puts "Hello #{argv[0]}"
  end
end
```

...which gets executed with: `ruby -run -e greet -- -w World`

The possibilities are endless!