### PR TITLE
configure.ac: fix for upcoming autoconf-2.70

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -271,13 +271,14 @@ AS_CASE(["$host_os:$build_os"],
     # clang version 1.0 (http://llvm.org/svn/llvm-project/cfe/tags/Apple/clang-23 exported)
     # Apple clang version 2.0 (tags/Apple/clang-137) (based on LLVM 2.9svn)
     # Apple clang version 2.1 (tags/Apple/clang-163.7.1) (based on LLVM 3.0svn)
-    AS_IF([! $CC -E -xc - <<SRC >/dev/null], [
-	@%:@if defined __APPLE_CC__ && defined __clang_major__ && __clang_major__ < 3
-	@%:@error premature clang
-	@%:@endif
-SRC
-	AC_MSG_ERROR([clang version 3.0 or later is required])
-    ])
+    AC_PREPROC_IFELSE(
+	[AC_LANG_PROGRAM([
+	    @%:@if defined __APPLE_CC__ && defined __clang_major__ && __clang_major__ < 3
+	    @%:@error premature clang
+	    @%:@endif
+	])],
+	[],
+	[AC_MSG_ERROR([clang version 3.0 or later is required])])
 ])
 
 AS_CASE(["$target_os"],


### PR DESCRIPTION
The failure initially noticed on `autoconf-2.69d` (soon to
become 2.70):

```
$ ./configure
./configure: line 8720: syntax error near unexpected token `fi'
./configure: line 8720: `fi'
```

Before the change generated `./configure ` snippet looked like:

```
    if ! $CC -E -xc - <<SRC >/dev/null
then :

	#if defined __APPLE_CC__ && defined __clang_major__ && __clang_major__ < 3
	#error premature clang
	#endif
SRC
	as_fn_error $? "clang version 3.0 or later is required" "$LINENO" 5
fi
```

Note the newline that breaks here-document syntax.

After the change the snippet does not use here-document.