### PR TITLE
test-all - test/net/smtp - use TCPSocket when UNIXSocket unavailable

### DIFF
--- a/test/net/smtp/test_sslcontext.rb
+++ b/test/net/smtp/test_sslcontext.rb
@@ -39,7 +39,8 @@ module Net
     end
 
     def start_smtpd(starttls)
-      @server_socket, @client_socket = UNIXSocket.pair
+      @server_socket, @client_socket = Object.const_defined?(:UNIXSocket) ?
+        UNIXSocket.pair : Socket.pair(:INET, :STREAM, 0)
       @starttls_executed = false
       @server_thread = Thread.new(@server_socket) do |s|
         s.puts "220 fakeserver\r\n"
@@ -125,4 +126,4 @@ module Net
     end
 
   end
-end unless /mswin|mingw/ =~ RUBY_PLATFORM
+end

--- a/test/net/smtp/test_starttls.rb
+++ b/test/net/smtp/test_starttls.rb
@@ -25,7 +25,8 @@ module Net
     end
 
     def start_smtpd(starttls)
-      @server_socket, @client_socket = UNIXSocket.pair
+      @server_socket, @client_socket = Object.const_defined?(:UNIXSocket) ?
+        UNIXSocket.pair : Socket.pair(:INET, :STREAM, 0)
       @starttls_executed = false
       @server_thread = Thread.new(@server_socket) do |s|
         s.puts "220 fakeserver\r\n"
@@ -118,4 +119,4 @@ module Net
       assert_nothing_raised { smtp.enable_starttls_auto }
     end
   end
-end unless /mswin|mingw/ =~ RUBY_PLATFORM
+end


### PR DESCRIPTION
Recently added tests for TLS in net/smtp use UNIXSockets, which are not available on Windows.

Use TCPSocket when UNIXSocket unavailable.

Passed on both mingw & mswin in ruby-loco.

See:
0683912db888  'Skip tests related TLS with Windows platform.'
cada6d85d0c1 'Import net-smtp-0.2.0 from https://github.com/ruby/net-smtp'