### PR TITLE
NEWS: Add --backtrace-limit option [ci skip]

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -105,6 +105,11 @@ non-empty value, and the standard input and output are tty, `--help`
 option shows the help message via the pager designated by the value.
 [[Feature #16754]]
 
+### `--backtrace-limit` option
+
+`--backtrace-limit` option limits the maximum length of backtrace.
+[[Feature #8661]]
+
 ## Core classes updates
 
 Outstanding ones only.


### PR DESCRIPTION
I think `--backtrace-limit` option is a visible new feature in Ruby 3.0.