### PR TITLE
Let Fiber#raise work with transferring fibers (explicit kwarg)

### DIFF
--- a/test/ruby/test_fiber.rb
+++ b/test/ruby/test_fiber.rb
@@ -169,6 +169,20 @@ class TestFiber < Test::Unit::TestCase
     assert_equal(:ok, fib.raise)
   end
 
+  def test_raise_transferring_fiber
+    root = Fiber.current
+    fib = Fiber.new { root.transfer }
+    fib.transfer
+    assert_raise(FiberError){
+      fib.raise "cannot raise transferring fiber"
+    }
+    assert_predicate(fib, :alive?)
+    assert_raise(RuntimeError){
+      fib.raise "can raise with transfer: true", transfer: true
+    }
+    assert_not_predicate(fib, :alive?)
+  end
+
   def test_transfer
     ary = []
     f2 = nil


### PR DESCRIPTION
This seems like a feature that would be just as useful for transferring fibers as it is for yielding fibers.

I'm using a kwarg, so this is not automatic; the caller must know how to handle the fiber. If you call a yielding fiber with transfer: true or a transferring fiber without transfer: true, a FiberError will be raised.

```ruby
yielding_fiber.raise "message"
transferring_fiber.raise "message", transfer: true
```
Alternative (implicit) approach: #3795
Ruby issue: https://bugs.ruby-lang.org/issues/17331