### PR TITLE
Make RubyVM::InstructionSequence.compile_file use same encoding as load

### DIFF
--- a/iseq.c
+++ b/iseq.c
@@ -1303,7 +1303,7 @@ iseqw_s_compile_file(int argc, VALUE *argv, VALUE self)
 
     parser = rb_parser_new();
     rb_parser_set_context(parser, NULL, FALSE);
-    ast = rb_parser_compile_file_path(parser, file, f, NUM2INT(line));
+    ast = (rb_ast_t *)rb_parser_load_file(parser, file);
     if (!ast->body.root) exc = GET_EC()->errinfo;
 
     rb_io_close(f);

--- a/test/ruby/test_iseq.rb
+++ b/test/ruby/test_iseq.rb
@@ -98,6 +98,22 @@ class TestISeq < Test::Unit::TestCase
     assert_include(RubyVM::InstructionSequence.of(obj.method(name)).disasm, name)
   end
 
+  def test_compile_file_encoding
+    Tempfile.create(%w"test_iseq .rb") do |f|
+      f.puts "{ '\u00de' => 'Th', '\u00df' => 'ss', '\u00e0' => 'a' }"
+      f.close
+
+      previous_external = Encoding.default_external
+      Encoding.default_external = Encoding::US_ASCII
+      begin
+        load f.path
+        RubyVM::InstructionSequence.compile_file(f.path)
+      ensure
+        Encoding.default_external = previous_external
+      end
+    end
+  end
+
   LINE_BEFORE_METHOD = __LINE__
   def method_test_line_trace
 


### PR DESCRIPTION
This switches the internal function from rb_parser_compile_file_path
to rb_parser_load_file, which is the same internal method that
Kernel#load uses.

Fixes [Bug #17308]