### PR TITLE
Fix issues with Dir.glob when using FNM_DOTMATCH

### DIFF
--- a/spec/ruby/core/dir/fixtures/common.rb
+++ b/spec/ruby/core/dir/fixtures/common.rb
@@ -172,6 +172,8 @@ module DirSpecs
       expected_paths - ['..']
     end
   else
-    alias expected_glob_paths expected_paths
+    def self.expected_glob_paths
+      expected_paths
+    end
   end
 end

--- a/spec/ruby/core/dir/fixtures/common.rb
+++ b/spec/ruby/core/dir/fixtures/common.rb
@@ -166,4 +166,12 @@ module DirSpecs
       subdir_two
     ]
   end
+
+  if RUBY_VERSION > '3.0'
+    def self.expected_glob_paths
+      expected_paths - ['..']
+    end
+  else
+    alias expected_glob_paths expected_paths
+  end
 end

--- a/spec/ruby/core/dir/glob_spec.rb
+++ b/spec/ruby/core/dir/glob_spec.rb
@@ -39,7 +39,7 @@ describe "Dir.glob" do
   end
 
   it "matches both dot and non-dotfiles with '*' and option File::FNM_DOTMATCH" do
-    Dir.glob('*', File::FNM_DOTMATCH).sort.should == DirSpecs.expected_paths
+    Dir.glob('*', File::FNM_DOTMATCH).sort.should == DirSpecs.expected_glob_paths
   end
 
   it "matches files with any beginning with '*<non-special characters>' and option File::FNM_DOTMATCH" do
@@ -47,7 +47,7 @@ describe "Dir.glob" do
   end
 
   it "matches any files in the current directory with '**' and option File::FNM_DOTMATCH" do
-    Dir.glob('**', File::FNM_DOTMATCH).sort.should == DirSpecs.expected_paths
+    Dir.glob('**', File::FNM_DOTMATCH).sort.should == DirSpecs.expected_glob_paths
   end
 
   it "recursively matches any subdirectories except './' or '../' with '**/' from the current directory and option File::FNM_DOTMATCH" do

--- a/spec/ruby/core/dir/shared/glob.rb
+++ b/spec/ruby/core/dir/shared/glob.rb
@@ -120,8 +120,16 @@ describe :dir_glob, shared: true do
     Dir.send(@method, 'special/test\{1\}/*').should == ['special/test{1}/file[1]']
   end
 
-  it "matches dotfiles with '.*'" do
-    Dir.send(@method, '.*').sort.should == %w|. .. .dotfile .dotsubdir|.sort
+  ruby_version_is ''...'3.0' do
+    it "matches dotfiles with '.*'" do
+      Dir.send(@method, '.*').sort.should == %w|. .. .dotfile .dotsubdir|.sort
+    end
+  end
+
+  ruby_version_is '3.0' do
+    it "matches dotfiles except .. with '.*'" do
+      Dir.send(@method, '.*').sort.should == %w|. .dotfile .dotsubdir|.sort
+    end
   end
 
   it "matches non-dotfiles with '*<non-special characters>'" do
@@ -165,8 +173,16 @@ describe :dir_glob, shared: true do
     Dir.send(@method, '**').sort.should == expected
   end
 
-  it "matches dotfiles in the current directory with '.**'" do
-    Dir.send(@method, '.**').sort.should == %w|. .. .dotsubdir .dotfile|.sort
+  ruby_version_is ''...'3.0' do
+    it "matches dotfiles in the current directory with '.**'" do
+      Dir.send(@method, '.**').sort.should == %w|. .. .dotsubdir .dotfile|.sort
+    end
+  end
+
+  ruby_version_is '3.0' do
+    it "matches dotfiles in the current directory except .. with '.**'" do
+      Dir.send(@method, '.**').sort.should == %w|. .dotsubdir .dotfile|.sort
+    end
   end
 
   it "recursively matches any nondot subdirectories with '**/'" do
@@ -186,9 +202,19 @@ describe :dir_glob, shared: true do
     Dir.send(@method, '**/').sort.should == expected
   end
 
-  it "recursively matches any subdirectories including ./ and ../ with '.**/'" do
-    Dir.chdir("#{DirSpecs.mock_dir}/subdir_one") do
-      Dir.send(@method, '.**/').sort.should == %w|./ ../|.sort
+  ruby_version_is ''...'3.0' do
+    it "recursively matches any subdirectories including ./ and ../ with '.**/'" do
+      Dir.chdir("#{DirSpecs.mock_dir}/subdir_one") do
+        Dir.send(@method, '.**/').sort.should == %w|./ ../|.sort
+      end
+    end
+  end
+
+  ruby_version_is ''...'3.0' do
+    it "recursively matches any subdirectories including ./ with '.**/'" do
+      Dir.chdir("#{DirSpecs.mock_dir}/subdir_one") do
+        Dir.send(@method, '.**/').should == ['./']
+      end
     end
   end
 
@@ -231,7 +257,7 @@ describe :dir_glob, shared: true do
   end
 
   it "matches dot or non-dotfiles with '{,.}*'" do
-    Dir.send(@method, '{,.}*').sort.should == DirSpecs.expected_paths
+    Dir.send(@method, '{,.}*').sort.should == DirSpecs.expected_glob_paths
   end
 
   it "respects the order of {} expressions, expanding left most first" do

--- a/spec/ruby/core/dir/shared/glob.rb
+++ b/spec/ruby/core/dir/shared/glob.rb
@@ -210,7 +210,7 @@ describe :dir_glob, shared: true do
     end
   end
 
-  ruby_version_is ''...'3.0' do
+  ruby_version_is '3.0' do
     it "recursively matches any subdirectories including ./ with '.**/'" do
       Dir.chdir("#{DirSpecs.mock_dir}/subdir_one") do
         Dir.send(@method, '.**/').should == ['./']

--- a/test/pathname/test_pathname.rb
+++ b/test/pathname/test_pathname.rb
@@ -1266,7 +1266,7 @@ class TestPathname < Test::Unit::TestCase
       open("f", "w") {|f| f.write "abc" }
       Dir.chdir("/") {
         assert_equal(
-          [Pathname("."), Pathname(".."), Pathname("f")],
+          [Pathname("."), Pathname("f")],
           Pathname.glob("*", File::FNM_DOTMATCH, base: dir).sort)
       }
     }

--- a/test/ruby/test_dir.rb
+++ b/test/ruby/test_dir.rb
@@ -161,7 +161,7 @@ class TestDir < Test::Unit::TestCase
   end
 
   def test_glob
-    assert_equal((%w(. ..) + ("a".."z").to_a).map{|f| File.join(@root, f) },
+    assert_equal((%w(.) + ("a".."z").to_a).map{|f| File.join(@root, f) },
                  Dir.glob(File.join(@root, "*"), File::FNM_DOTMATCH))
     assert_equal([@root] + ("a".."z").map {|f| File.join(@root, f) },
                  Dir.glob([@root, File.join(@root, "*")]))


### PR DESCRIPTION
1) When using a recursive glob, do not include . entries if they
represent the same directory as the previous entry in the resulting
array.  This approach depends on . being the first entry in the
directory.

2) When using a magical, non-recursive glob such as *, do not
include .. entries.

Fixes [Bug #17280]