### PR TITLE
Ripper.{lex,tokenize} return full tokens even if syntax error

### DIFF
--- a/ext/ripper/lib/ripper/lexer.rb
+++ b/ext/ripper/lib/ripper/lexer.rb
@@ -31,6 +31,10 @@ class Ripper
       raise SyntaxError, r.errors.map(&:message).join(' ;')
     end
 
+    until (tokens = r.tokenize).empty?
+      ret.concat(tokens)
+    end
+
     ret
   end
 
@@ -63,6 +67,10 @@ class Ripper
 
     if raise_errors && !r.errors.empty?
       raise SyntaxError, r.errors.map(&:message).join(' ;')
+    end
+
+    until (tokens = r.lex).empty?
+      ret.concat(tokens)
     end
 
     ret

--- a/test/ripper/test_lexer.rb
+++ b/test/ripper/test_lexer.rb
@@ -150,4 +150,12 @@ class TestRipper::Lexer < Test::Unit::TestCase
     assert_raise(SyntaxError) { Ripper.tokenize('def req(true) end', raise_errors: true) }
     assert_raise(SyntaxError) { Ripper.tokenize('def req(true) end', raise_errors: true) }
   end
+
+  def test_tokenize_with_syntax_error
+    assert_equal "end", Ripper.tokenize("def req(true) end").last
+  end
+
+  def test_lex_with_syntax_error
+    assert_equal [[1, 14], :on_kw, "end", state(:EXPR_END)], Ripper.lex("def req(true) end").last
+  end
 end


### PR DESCRIPTION
yet another implements [Feature #17276]
