### PR TITLE
always inline vm_setivar

### DIFF
--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1197,6 +1197,7 @@ vm_getivar(VALUE obj, ID id, const rb_iseq_t *iseq, IVC ic, const struct rb_call
     }
 }
 
+ALWAYS_INLINE(static VALUE vm_setivar(VALUE, ID, VALUE, const rb_iseq_t *, IVC, const struct rb_callcache *, int));
 static inline VALUE
 vm_setivar(VALUE obj, ID id, VALUE val, const rb_iseq_t *iseq, IVC ic, const struct rb_callcache *cc, int is_attr)
 {


### PR DESCRIPTION
It seems like GCC version 9.3.0 isn't inlining this function even though it says `static inline`.  Since the compiler isn't inlining `vm_setivar`, the `is_attr` variable test doesn't get removed, and we can see that in a report from perf:

<img width="1033" alt="ruby — perf :home:aaron:git:ruby — ssh whiteclaw local — 128×47 2020-11-19 14-25-35" src="https://user-images.githubusercontent.com/3124/99731816-47414e80-2a73-11eb-9420-0e60f633f55b.png">

`is_attr` is a hardcoded number [here](https://github.com/ruby/ruby/blob/44ad72fa2113d0e111a1cf76327bcc13de8393e1/vm_insnhelper.c#L1273) and [here](https://github.com/ruby/ruby/blob/44ad72fa2113d0e111a1cf76327bcc13de8393e1/vm_insnhelper.c#L2696), so this should be trivial for the compiler to remove.

Forcing this function to always be inline shows a small speed improvement on optcarrot:

![iv-set](https://user-images.githubusercontent.com/3124/99732120-c6cf1d80-2a73-11eb-809d-b3ee3f288e24.png)

