### PR TITLE
Try to fix download error

### DIFF
--- a/tool/downloader.rb
+++ b/tool/downloader.rb
@@ -51,7 +51,12 @@ class Downloader
   class GNU < self
     def self.download(name, *rest)
       if https?
-        super("https://cdn.jsdelivr.net/gh/gcc-mirror/gcc@master/#{name}", name, *rest)
+        begin
+          super("https://cdn.jsdelivr.net/gh/gcc-mirror/gcc@master/#{name}", name, *rest)
+        rescue => e
+          STDERR.puts "Download failed (#{e.message}), try another URL"
+          super("https://raw.githubusercontent.com/gcc-mirror/gcc/master/#{name}", name, *rest)
+        end
       else
         super("https://repo.or.cz/official-gcc.git/blob_plain/HEAD:/#{name}", name, *rest)
       end


### PR DESCRIPTION
https://github.com/ruby/ruby/runs/1428320660?check_suite_focus=true#step:9:10
```
tool/downloader.rb:243:in `rescue in download': failed to download config.guess (RuntimeError)
OpenURI::HTTPError: 403 Forbidden: https://cdn.jsdelivr.net/gh/gcc-mirror/gcc@master/config.guess
```