### PR TITLE
Let Fiber#raise work with transferring fibers (implicit)

### DIFF
--- a/spec/ruby/core/fiber/raise_spec.rb
+++ b/spec/ruby/core/fiber/raise_spec.rb
@@ -73,4 +73,29 @@ ruby_version_is "2.7" do
       -> { fiber.resume }.should raise_error(FiberError, /dead fiber called|attempt to resume a terminated fiber/)
     end
   end
+
+end
+
+ruby_version_is "2.7"..."3.0" do
+  describe "Fiber#raise" do
+    it "raises a FiberError if invoked on a transferring Fiber" do
+      require "fiber"
+      root = Fiber.current
+      fiber = Fiber.new { root.transfer }
+      fiber.transfer
+      -> { fiber.raise }.should raise_error(FiberError, "cannot resume transferred Fiber")
+    end
+  end
+end
+
+ruby_version_is "3.0" do
+  describe "Fiber#raise" do
+    it "transfers and raises on a transferring fiber" do
+      require "fiber"
+      root = Fiber.current
+      fiber = Fiber.new { root.transfer }
+      fiber.transfer
+      -> { fiber.raise "msg" }.should raise_error(RuntimeError, "msg")
+    end
+  end
 end

--- a/test/ruby/test_fiber.rb
+++ b/test/ruby/test_fiber.rb
@@ -169,6 +169,16 @@ class TestFiber < Test::Unit::TestCase
     assert_equal(:ok, fib.raise)
   end
 
+  def test_raise_transferring_fiber
+    root = Fiber.current
+    fib = Fiber.new { root.transfer }
+    fib.transfer
+    assert_raise(RuntimeError){
+      fib.raise "can raise with transfer: true"
+    }
+    assert_not_predicate(fib, :alive?)
+  end
+
   def test_transfer
     ary = []
     f2 = nil


### PR DESCRIPTION
This automatically chooses whether to use transfer on a transferring
fiber or resume on a yielding fiber.  If the fiber is resuming, it
raises a FiberError.

This is an alternative approach to #3783. I personally prefer the explicit approach, but I'll let others decide. :slightly_smiling_face: 

Ruby Issue: https://bugs.ruby-lang.org/issues/17331