### PR TITLE
Fixing glitchy kill ring behavior in irb

### DIFF
--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -165,7 +165,7 @@ class Reline::LineEditor
     @cleared = false
     @rerender_all = false
     @history_pointer = nil
-    @kill_ring = Reline::KillRing.new
+    @kill_ring ||= Reline::KillRing.new
     @vi_clipboard = ''
     @vi_arg = nil
     @waiting_proc = nil


### PR DESCRIPTION
After killing a line (or part of a line) with Ctrl-K, it is normally retained and can be recalled with Ctrl-Y. Since Ruby 2.7.0, the kill buffer is cleared after a command is entered and Ctrl-Y does nothing. This patch fixes that.

See https://github.com/ruby/irb/issues/85 for details

Credit to @znz for identifying the problem and providing the solution. This patch just integrates his work.