### PR TITLE
Detect the premature end of char property in regexp

### DIFF
--- a/regparse.c
+++ b/regparse.c
@@ -4348,7 +4348,7 @@ fetch_char_property_to_ctype(UChar** src, UChar* end, ScanEnv* env)
   OnigEncoding enc = env->enc;
   UChar *prev, *start, *p = *src;
 
-  r = 0;
+  r = ONIGERR_INVALID_CHAR_PROPERTY_NAME;
   start = prev = p;
 
   while (!PEND) {
@@ -4362,7 +4362,6 @@ fetch_char_property_to_ctype(UChar** src, UChar* end, ScanEnv* env)
       return r;
     }
     else if (c == '(' || c == ')' || c == '{' || c == '|') {
-      r = ONIGERR_INVALID_CHAR_PROPERTY_NAME;
       break;
     }
   }

--- a/test/ruby/test_regexp.rb
+++ b/test/ruby/test_regexp.rb
@@ -57,6 +57,17 @@ class TestRegexp < Test::Unit::TestCase
     assert_equal('Ruby', 'Ruby'.sub(/[^a-z]/i, '-'))
   end
 
+  def test_premature_end_char_property
+    ["\\p{",
+     "\\p{".dup.force_encoding("UTF-8"),
+     "\\p{".dup.force_encoding("US-ASCII")
+    ].each do |string|
+      assert_raise(RegexpError) do
+        Regexp.new(string)
+      end
+    end
+  end
+
   def test_assert_normal_exit
     # moved from knownbug.  It caused core.
     Regexp.union("a", "a")


### PR DESCRIPTION
Default to ONIGERR_INVALID_CHAR_PROPERTY_NAME in
fetch_char_property_to_ctype and only set otherwise if an ending
} is found.

Fixes [Bug #17340]