### PR TITLE
Disable read barrier on explicit compaction request

### DIFF
--- a/gc.rb
+++ b/gc.rb
@@ -199,8 +199,7 @@ module GC
   end
 
   def self.compact
-    Primitive.gc_start_internal true, true, true, true
-    Primitive.gc_compact_stats
+    Primitive.gc_compact
   end
 
   # call-seq:


### PR DESCRIPTION
We don't need a read barrier when the user calls `GC.compact` because we
don't allow allocations during GC, and all references should be "live"