### PR TITLE
Fix Enumerator::ArithmeticSequence#last with rational ends and step

### DIFF
--- a/enumerator.c
+++ b/enumerator.c
@@ -3633,9 +3633,9 @@ arith_seq_last(int argc, VALUE *argv, VALUE self)
         return rb_ary_new_capa(0);
     }
 
-    last = rb_int_plus(b, rb_int_mul(s, len_1));
+    last = rb_funcall(b, '+', 1, rb_funcall(s, '*', 1, len_1));
     if ((last_is_adjusted = arith_seq_exclude_end_p(self) && rb_equal(last, e))) {
-        last = rb_int_minus(last, s);
+        last = rb_funcall(last, '-', 1, s);
     }
 
     if (argc == 0) {

--- a/test/ruby/test_arithmetic_sequence.rb
+++ b/test/ruby/test_arithmetic_sequence.rb
@@ -264,6 +264,11 @@ class TestArithmeticSequence < Test::Unit::TestCase
     assert_instance_of Integer, res[1]
   end
 
+  def test_last_with_rational_ends_and_step
+    res = (1.0997r..1.1r).step(0.0001r)
+    assert_equal(1.1r, res.last)
+  end
+
   def test_to_a
     assert_equal([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 1.step(10).to_a)
     assert_equal([1, 3, 5, 7, 9], 1.step(10, 2).to_a)


### PR DESCRIPTION
Call +, *, - methods to determine the last value, instead of using
rb_int_plus, rb_int_mul, and rb_int_minus.

There are additional rb_int_* calls in the arith_seq_last function,
I'm not sure whether they should also be switched to method calls
or not.

Fixes [Bug #17218]