### PR TITLE
Fix calling enumerator methods such as with_index on Enumerator::Chain

### DIFF
--- a/enumerator.c
+++ b/enumerator.c
@@ -4200,6 +4200,11 @@ InitVM_Enumerator(void)
     rb_define_method(rb_cEnumChain, "size", enum_chain_size, 0);
     rb_define_method(rb_cEnumChain, "rewind", enum_chain_rewind, 0);
     rb_define_method(rb_cEnumChain, "inspect", enum_chain_inspect, 0);
+    rb_undef_method(rb_cEnumChain, "feed");
+    rb_undef_method(rb_cEnumChain, "next");
+    rb_undef_method(rb_cEnumChain, "next_values");
+    rb_undef_method(rb_cEnumChain, "peek");
+    rb_undef_method(rb_cEnumChain, "peek_values");
 
     /* ArithmeticSequence */
     rb_cArithSeq = rb_define_class_under(rb_cEnumerator, "ArithmeticSequence", rb_cEnumerator);

--- a/enumerator.c
+++ b/enumerator.c
@@ -3137,6 +3137,20 @@ enum_chain_initialize(VALUE obj, VALUE enums)
     return obj;
 }
 
+static VALUE
+new_enum_chain(VALUE enums) {
+    long i;
+    VALUE obj = enum_chain_initialize(enum_chain_allocate(rb_cEnumChain), enums);
+
+    for (i = 0; i < RARRAY_LEN(enums); i++) {
+        if (RTEST(rb_obj_is_kind_of(RARRAY_AREF(enums, i), rb_cLazy))) {
+            return enumerable_lazy(obj);
+        }
+    }
+
+    return obj;
+}
+
 /* :nodoc: */
 static VALUE
 enum_chain_init_copy(VALUE obj, VALUE orig)
@@ -3306,8 +3320,7 @@ enum_chain(int argc, VALUE *argv, VALUE obj)
 {
     VALUE enums = rb_ary_new_from_values(1, &obj);
     rb_ary_cat(enums, argv, argc);
-
-    return enum_chain_initialize(enum_chain_allocate(rb_cEnumChain), enums);
+    return new_enum_chain(enums);
 }
 
 /*
@@ -3323,9 +3336,7 @@ enum_chain(int argc, VALUE *argv, VALUE obj)
 static VALUE
 enumerator_plus(VALUE obj, VALUE eobj)
 {
-    VALUE enums = rb_ary_new_from_args(2, obj, eobj);
-
-    return enum_chain_initialize(enum_chain_allocate(rb_cEnumChain), enums);
+    return new_enum_chain(rb_ary_new_from_args(2, obj, eobj));
 }
 
 /*

--- a/test/ruby/test_enumerator.rb
+++ b/test/ruby/test_enumerator.rb
@@ -816,6 +816,10 @@ class TestEnumerator < Test::Unit::TestCase
     )
   end
 
+  def test_chain_with_index
+    assert_equal([[3, 0], [4, 1]], [3].chain([4]).with_index.to_a)
+  end
+
   def test_produce
     assert_raise(ArgumentError) { Enumerator.produce }
 

--- a/test/ruby/test_enumerator.rb
+++ b/test/ruby/test_enumerator.rb
@@ -832,6 +832,12 @@ class TestEnumerator < Test::Unit::TestCase
     assert_equal(33, chain.next)
   end
 
+  def test_chain_undef_methods
+    chain = [1].to_enum + [2].to_enum
+    meths = (chain.methods & [:feed, :next, :next_values, :peek, :peek_values])
+    assert_equal(0, meths.size)
+  end
+
   def test_produce
     assert_raise(ArgumentError) { Enumerator.produce }
 

--- a/test/ruby/test_enumerator.rb
+++ b/test/ruby/test_enumerator.rb
@@ -820,6 +820,18 @@ class TestEnumerator < Test::Unit::TestCase
     assert_equal([[3, 0], [4, 1]], [3].chain([4]).with_index.to_a)
   end
 
+  def test_lazy_chain
+    ea = (10..).lazy.select(&:even?).take(10)
+    ed = (20..).lazy.select(&:odd?)
+    chain = (ea + ed).select{|x| x % 3 == 0}
+    assert_equal(12, chain.next)
+    assert_equal(18, chain.next)
+    assert_equal(24, chain.next)
+    assert_equal(21, chain.next)
+    assert_equal(27, chain.next)
+    assert_equal(33, chain.next)
+  end
+
   def test_produce
     assert_raise(ArgumentError) { Enumerator.produce }
 


### PR DESCRIPTION
This previously raised a TypeError.  Wrap the Enumerator::Chain in
an Enumerator to work around the problem.

Fixes [Bug #17216]