### PR TITLE
When allocating new pages, add them to the end of the linked list

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -1914,7 +1914,7 @@ heap_add_page(rb_objspace_t *objspace, rb_heap_t *heap, struct heap_page *page)
     /* Adding to eden heap during incremental sweeping is forbidden */
     GC_ASSERT(!(heap == heap_eden && heap->sweeping_page));
     page->flags.in_tomb = (heap == heap_tomb);
-    list_add(&heap->pages, &page->page_node);
+    list_add_tail(&heap->pages, &page->page_node);
     heap->total_pages++;
     heap->total_slots += page->total_slots;
 }
@@ -5036,7 +5036,7 @@ gc_sweep_step(rb_objspace_t *objspace, rb_heap_t *heap)
 
     do {
 	int free_slots = gc_page_sweep(objspace, heap, sweep_page);
-	heap->sweeping_page = list_next(&heap->pages, sweep_page, page_node);
+        heap->sweeping_page = list_next(&heap->pages, sweep_page, page_node);
 
 	if (sweep_page->final_slots + free_slots == sweep_page->total_slots &&
 	    heap_pages_freeable_pages > 0 &&


### PR DESCRIPTION
When we allocate new pages, allocate them on the end of the linked list.
Then when we compact we can move things to the head of the list

This patch changes heap page allocation to add heap pages to the *end* of the heap page linked list.

## Current Behavior

The current page allocation behavior is like this:

![heap-page-current](https://user-images.githubusercontent.com/3124/100780002-0bd14900-33be-11eb-99ba-23034709526b.gif)

It always puts new pages at the beginning of the linked list.  The sweep step starts at the beginning of the linked list, and the compact step starts at the end of the linked list.  So compaction always moves objects *to the head* of the linked list, like this:

![compact-current](https://user-images.githubusercontent.com/3124/100779206-e132c080-33bc-11eb-8ae1-fd9bb6e0cc39.gif)

Depending on the number of pages added, this can result in more objects moving than necessary.

## Proposed Behavior

This patch appends heap pages to the end of the linked list.  Sweeping still starts at the beginning of the linked list, and compaction still starts at the end.  But since the head of the linked list never changes, objects at the head of the list will stabilize.

This patch changes heap page allocation to be like this:

![heap-page-proposed](https://user-images.githubusercontent.com/3124/100780080-25729080-33be-11eb-8d6a-5bc85213b71e.gif)

Which results in compaction behavior like this:

![compaction-proposed](https://user-images.githubusercontent.com/3124/100779576-70d86f00-33bd-11eb-997e-377e6cb77b30.gif)
