### PR TITLE
Fix docs about movement for rb_gc_register_mark_object()

### DIFF
--- a/include/ruby/internal/gc.h
+++ b/include/ruby/internal/gc.h
@@ -45,10 +45,8 @@ void rb_global_variable(VALUE *);
 void rb_gc_unregister_address(VALUE *valptr);
 
 /**
- * Inform the garbage collector that `object` is a live Ruby object. Note that
- * the garbage collector is free to move `object` and so it is not correct to
- * save `object` into a C global constant and assume that it will always refer
- * to the same Ruby object.
+ * Inform the garbage collector that `object` is a live Ruby object that should
+ * not be moved.
  *
  * See also: rb_gc_register_address()
  */


### PR DESCRIPTION
This API in fact pins objects passed to it. See [vm.c:2546](https://github.com/ruby/ruby/blob/e0944bde9178fda7281717a159d0ffbfd3154f47/vm.c#L2546-L2559).

---

Sorry, in the original [PR](https://github.com/ruby/ruby/pull/3733) I saw `rb_gc_mark_movable(vm->mark_object_ary);` and didn't read on. 😅  
