### PR TITLE
Fix ractor_copy for frozen objects

### DIFF
--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -1002,6 +1002,13 @@ assert_equal 'can not make a Proc shareable because it accesses outer variables 
   end
 }
 
+# Ractor deep copies frozen objects
+assert_equal '[true, false]', %q{
+  Ractor.new([[]].freeze) { |ary|
+    [ary.frozen?, ary.first.frozen? ]
+  }.take
+}
+
 ###
 ### Synchronization tests
 ###

--- a/include/ruby/internal/intern/object.h
+++ b/include/ruby/internal/intern/object.h
@@ -42,6 +42,7 @@ VALUE rb_obj_is_instance_of(VALUE, VALUE);
 VALUE rb_obj_is_kind_of(VALUE, VALUE);
 VALUE rb_obj_alloc(VALUE);
 VALUE rb_obj_clone(VALUE);
+VALUE rb_obj_clone_freeze(VALUE, VALUE);
 VALUE rb_obj_dup(VALUE);
 VALUE rb_obj_init_copy(VALUE,VALUE);
 VALUE rb_obj_taint(VALUE);

--- a/object.c
+++ b/object.c
@@ -401,6 +401,12 @@ static VALUE
 rb_obj_clone2(rb_execution_context_t *ec, VALUE obj, VALUE freeze)
 {
     VALUE kwfreeze = obj_freeze_opt(freeze);
+    return rb_obj_clone_freeze(obj, kwfreeze);
+}
+
+VALUE
+rb_obj_clone_freeze(VALUE obj, VALUE kwfreeze)
+{
     if (!special_object_p(obj))
 	return mutable_obj_clone(obj, kwfreeze);
     return immutable_obj_clone(obj, kwfreeze);


### PR DESCRIPTION
Found a bug with frozen (but not deeply) structures while paying with my backport. Trying to deep-copy that raises a `FrozenError`.

Wrote a patch for fun, it's fine if you prefer writing your own 😅 