### PR TITLE
Windows: Read ENV names and values as UTF-8 encoded Strings

### DIFF
--- a/include/ruby/win32.h
+++ b/include/ruby/win32.h
@@ -160,7 +160,7 @@ typedef int clockid_t;
 #define Sleep(msec)		(void)rb_w32_Sleep(msec)
 
 #undef execv
-#define execv(path,argv)	rb_w32_aspawn(P_OVERLAY,path,argv)
+#define execv(path,argv)	rb_w32_uaspawn(P_OVERLAY,path,argv)
 #undef isatty
 #define isatty(h)		rb_w32_isatty(h)
 
@@ -717,7 +717,7 @@ extern char *rb_w32_strerror(int);
 #define getcwd(b, s)		rb_w32_getcwd(b, s)
 
 #undef getenv
-#define getenv(n)		rb_w32_getenv(n)
+#define getenv(n)		rb_w32_ugetenv(n)
 
 #undef rename
 #define rename(o, n)		rb_w32_rename(o, n)

--- a/spec/ruby/core/env/element_reference_spec.rb
+++ b/spec/ruby/core/env/element_reference_spec.rb
@@ -59,6 +59,7 @@ describe "ENV.[]" do
     Encoding.default_internal = nil
 
     locale = Encoding.find('locale')
+    locale = Encoding::UTF_8 if platform_is :windows
     locale = Encoding::BINARY if locale == Encoding::US_ASCII
     ENV[@variable] = "\xC3\xB8"
     ENV[@variable].encoding.should == locale

--- a/spec/ruby/core/env/fetch_spec.rb
+++ b/spec/ruby/core/env/fetch_spec.rb
@@ -56,7 +56,8 @@ describe "ENV.fetch" do
   end
 
   it "uses the locale encoding" do
+    encoding = platform_is(:windows) ? Encoding::UTF_8 : Encoding.find('locale')
     ENV["foo"] = "bar"
-    ENV.fetch("foo").encoding.should == Encoding.find('locale')
+    ENV.fetch("foo").encoding.should == encoding
   end
 end

--- a/spec/ruby/core/env/shift_spec.rb
+++ b/spec/ruby/core/env/shift_spec.rb
@@ -42,9 +42,10 @@ describe "ENV.shift" do
   it "uses the locale encoding if Encoding.default_internal is nil" do
     Encoding.default_internal = nil
 
+    encoding = platform_is(:windows) ? Encoding::UTF_8 : Encoding.find('locale')
     pair = ENV.shift
-    pair.first.encoding.should equal(Encoding.find("locale"))
-    pair.last.encoding.should equal(Encoding.find("locale"))
+    pair.first.encoding.should equal(encoding)
+    pair.last.encoding.should equal(encoding)
   end
 
   it "transcodes from the locale encoding to Encoding.default_internal if set" do

--- a/spec/ruby/core/env/values_at_spec.rb
+++ b/spec/ruby/core/env/values_at_spec.rb
@@ -28,7 +28,8 @@ describe "ENV.values_at" do
   end
 
   it "uses the locale encoding" do
-    ENV.values_at(ENV.keys.first).first.encoding.should == Encoding.find('locale')
+    encoding = platform_is(:windows) ? Encoding::UTF_8 : Encoding.find('locale')
+    ENV.values_at(ENV.keys.first).first.encoding.should == encoding
   end
 
   it "raises TypeError when a key is not coercible to String" do

--- a/test/ruby/test_env.rb
+++ b/test/ruby/test_env.rb
@@ -370,7 +370,8 @@ class TestEnv < Test::Unit::TestCase
       assert_equal("foo", v)
     end
     assert_invalid_env {|var| ENV.assoc(var)}
-    assert_equal(Encoding.find("locale"), v.encoding)
+    encoding = /mswin|mingw/ =~ RUBY_PLATFORM ? Encoding::UTF_8 : Encoding.find("locale")
+    assert_equal(encoding, v.encoding)
   end
 
   def test_has_value2
@@ -580,15 +581,13 @@ class TestEnv < Test::Unit::TestCase
       end;
     end
 
-    if Encoding.find("locale") == Encoding::UTF_8
-      def test_utf8
-        text = "testing \u{e5 e1 e2 e4 e3 101 3042}"
-        test = ENV["test"]
-        ENV["test"] = text
-        assert_equal text, ENV["test"]
-      ensure
-        ENV["test"] = test
-      end
+    def test_utf8
+      text = "testing \u{e5 e1 e2 e4 e3 101 3042}"
+      test = ENV["test"]
+      ENV["test"] = text
+      assert_equal text, ENV["test"]
+    ensure
+      ENV["test"] = test
     end
   end
 end

--- a/test/ruby/test_m17n.rb
+++ b/test/ruby/test_m17n.rb
@@ -1325,10 +1325,14 @@ class TestM17N < Test::Unit::TestCase
   end
 
   def test_env
-    locale_encoding = Encoding.find("locale")
+    if RUBY_PLATFORM =~ /bccwin|mswin|mingw/
+      env_encoding = Encoding::UTF_8
+    else
+      env_encoding = Encoding.find("locale")
+    end
     ENV.each {|k, v|
-      assert_equal(locale_encoding, k.encoding, k)
-      assert_equal(locale_encoding, v.encoding, v)
+      assert_equal(env_encoding, k.encoding, k)
+      assert_equal(env_encoding, v.encoding, v)
     }
   end
 

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -74,7 +74,6 @@ static char *w32_getenv(const char *name, UINT cp);
 #define DLN_FIND_EXTRA_ARG_DECL ,UINT cp
 #define DLN_FIND_EXTRA_ARG ,cp
 #define rb_w32_stati128(path, st) w32_stati128(path, st, cp, FALSE)
-#define getenv(name) w32_getenv(name, cp)
 #undef CharNext
 #define CharNext(p) CharNextExA(cp, (p), 0)
 #define dln_find_exe_r rb_w32_udln_find_exe_r
@@ -1362,7 +1361,7 @@ w32_spawn(int mode, const char *cmd, const char *prog, UINT cp)
 	int redir = -1;
 	int nt;
 	while (ISSPACE(*cmd)) cmd++;
-	if ((shell = getenv("RUBYSHELL")) && (redir = has_redirection(cmd, cp))) {
+	if ((shell = w32_getenv("RUBYSHELL", cp)) && (redir = has_redirection(cmd, cp))) {
 	    size_t shell_len = strlen(shell);
 	    char *tmp = ALLOCV(v, shell_len + strlen(cmd) + sizeof(" -c ") + 2);
 	    memcpy(tmp, shell, shell_len + 1);
@@ -1370,7 +1369,7 @@ w32_spawn(int mode, const char *cmd, const char *prog, UINT cp)
 	    sprintf(tmp + shell_len, " -c \"%s\"", cmd);
 	    cmd = tmp;
 	}
-	else if ((shell = getenv("COMSPEC")) &&
+	else if ((shell = w32_getenv("COMSPEC", cp)) &&
 		 (nt = !is_command_com(shell),
 		  (redir < 0 ? has_redirection(cmd, cp) : redir) ||
 		  is_internal_cmd(cmd, nt))) {
@@ -1491,7 +1490,7 @@ w32_aspawn_flags(int mode, const char *prog, char *const *argv, DWORD flags, UIN
     if (check_spawn_mode(mode)) return -1;
 
     if (!prog) prog = argv[0];
-    if ((shell = getenv("COMSPEC")) &&
+    if ((shell = w32_getenv("COMSPEC", cp)) &&
 	internal_cmd_match(prog, tmpnt = !is_command_com(shell))) {
 	ntcmd = tmpnt;
 	prog = shell;


### PR DESCRIPTION
This implements [redmine issue 12650](https://bugs.ruby-lang.org/issues/12650), which was postponed to ruby-3.0, but isn't solved so far.

I splitted the PR into 3 commits, which are not necessary related. Please tell me, if I should open 3 separate PRs.

0c6c879: Read ENV names and values as UTF-8 encoded Strings

Implements issue #12650: https://bugs.ruby-lang.org/issues/12650 This also removes the special encoding for `ENV['PATH']` and some complexity in the code that is unnecessary now.

9532666: Improve readablity of `getenv()` encoding

`getenv()` did use the expected codepage as an implicit parameter of the macro. This is mis-leading since `include/ruby/win32.h` has a different definition. Using the "cp" variable explicit (like the other function calls) makes it more readable and consistent.

26ffdf0: Change external C-API macros `getenv()` and `execv()` to use UTF-8

They used to process and return strings with locale encoding, but since all ruby-internal spawn and environment functions use UTF-8, it makes sense to change the C-API equally.

I'm uncertain if this commit is desired, since it changes the C-API, so that getenv() and execv() might not be fully compatible to [getenv() from stdlib.h](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/getenv-wgetenv) or [execv()](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/execv-wexecv). On the other hand it seems more handy for work with UTF-8 in ruby extensions. Let me know, if I should remove this commit.

Please also note, that there's PR https://github.com/ruby/ruby/pull/2877 which is also related to UTF-8 on Windows and was postponed to ruby-3.0.