### PR TITLE
Don't double fractional seconds when passing timezone object to Time.new

### DIFF
--- a/test/ruby/test_time_tz.rb
+++ b/test/ruby/test_time_tz.rb
@@ -752,6 +752,16 @@ class TestTimeTZ::DummyTZ < Test::Unit::TestCase
   def self.make_timezone(tzname, abbr, utc_offset, abbr2 = nil, utc_offset2 = nil)
     TestTimeTZ::TZ.new(tzname, abbr, utc_offset, abbr2, utc_offset2)
   end
+
+  def test_fractional_second
+    x = Object.new
+    def x.local_to_utc(t); t + 8*3600; end
+    def x.utc_to_local(t); t - 8*3600; end
+
+    t1 = Time.new(2020,11,11,12,13,14.124r, '-08:00')
+    t2 = Time.new(2020,11,11,12,13,14.124r, x)
+    assert_equal(t1, t2)
+  end
 end
 
 begin

--- a/time.c
+++ b/time.c
@@ -2259,9 +2259,6 @@ zone_timelocal(VALUE zone, VALUE time)
     s = extract_time(utc);
     zone_set_offset(zone, tobj, t, s);
     s = rb_time_magnify(s);
-    if (tobj->vtm.subsecx != INT2FIX(0)) {
-        s = wadd(s, v2w(tobj->vtm.subsecx));
-    }
     tobj->timew = s;
     zone_set_dst(zone, tobj, tm);
     return 1;


### PR DESCRIPTION
I found that fractional seconds were doubled when using the timezone
feature of Time in Sequel's named_timezones extension (which uses
TZInfo for the timezone object), and traced the problem to this code.

There is no subsecx being modified in the utc_to_local call below
this, and I'm not sure why you would want to add in the fractional
seconds unless you assumed the timezone conversion would drop the
existing fractional seconds (TZInfo doesn't drop fractional seconds).