### PR TITLE
configure.ac: Check x86intrin.h only when the target CPU is x86

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1204,7 +1204,9 @@ AC_CHECK_HEADERS(syscall.h)
 AC_CHECK_HEADERS(time.h)
 AC_CHECK_HEADERS(ucontext.h)
 AC_CHECK_HEADERS(utime.h)
-AC_CHECK_HEADERS(x86intrin.h)
+AS_CASE("$target_cpu", [x64|x86_64|i[3-6]86*], [
+  AC_CHECK_HEADERS(x86intrin.h)
+])
 
 AC_ARG_WITH([gmp],
   [AS_HELP_STRING([--without-gmp],


### PR DESCRIPTION
The check output a warning on M1 Mac mini

http://rubyci.s3.amazonaws.com/osx1100arm/ruby-master/log/20201127T074507Z.log.html.gz
```
checking x86intrin.h usability... no
checking x86intrin.h presence... yes
configure: WARNING: x86intrin.h: present but cannot be compiled
configure: WARNING: x86intrin.h:     check for missing prerequisite headers?
configure: WARNING: x86intrin.h: see the Autoconf documentation
configure: WARNING: x86intrin.h:     section "Present But Cannot Be Compiled"
configure: WARNING: x86intrin.h: proceeding with the compiler's result
checking for x86intrin.h... no
```