### PR TITLE
 Subsecond of Time::tm should be 0

### DIFF
--- a/test/ruby/test_time_tz.rb
+++ b/test/ruby/test_time_tz.rb
@@ -752,6 +752,16 @@ class TestTimeTZ::DummyTZ < Test::Unit::TestCase
   def self.make_timezone(tzname, abbr, utc_offset, abbr2 = nil, utc_offset2 = nil)
     TestTimeTZ::TZ.new(tzname, abbr, utc_offset, abbr2, utc_offset2)
   end
+
+  def test_fractional_second
+    x = Object.new
+    def x.local_to_utc(t); t + 8*3600; end
+    def x.utc_to_local(t); t - 8*3600; end
+
+    t1 = Time.new(2020,11,11,12,13,14.124r, '-08:00')
+    t2 = Time.new(2020,11,11,12,13,14.124r, x)
+    assert_equal(t1, t2)
+  end
 end
 
 begin

--- a/time.c
+++ b/time.c
@@ -5498,6 +5498,7 @@ tm_from_time(VALUE klass, VALUE time)
     ttm = DATA_PTR(tm);
     v = &vtm;
     GMTIMEW(ttm->timew = tobj->timew, v);
+    ttm->timew = wsub(ttm->timew, v->subsecx);
     v->subsecx = INT2FIX(0);
     v->zone = Qnil;
     ttm->vtm = *v;


### PR DESCRIPTION
Fix PR #3819.