### PR TITLE
ractor local storage C-API

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -10570,6 +10570,7 @@ random.$(OBJEXT): {$(VPATH)}missing.h
 random.$(OBJEXT): {$(VPATH)}mt19937.c
 random.$(OBJEXT): {$(VPATH)}onigmo.h
 random.$(OBJEXT): {$(VPATH)}oniguruma.h
+random.$(OBJEXT): {$(VPATH)}ractor.h
 random.$(OBJEXT): {$(VPATH)}random.c
 random.$(OBJEXT): {$(VPATH)}random.h
 random.$(OBJEXT): {$(VPATH)}ruby_atomic.h

--- a/gc.c
+++ b/gc.c
@@ -7266,6 +7266,7 @@ gc_marks_finish(rb_objspace_t *objspace)
     }
 
     rb_transient_heap_finish_marking();
+    rb_ractor_finish_marking();
 
     gc_event_hook(objspace, RUBY_INTERNAL_EVENT_GC_END_MARK, 0);
 

--- a/include/ruby/ractor.h
+++ b/include/ruby/ractor.h
@@ -12,6 +12,14 @@
  *             file COPYING are met.  Consult the file for details.
  */
 
+struct rb_ractor_local_storage_type {
+    void (*mark)(void *ptr);
+    void (*free)(void *ptr);
+    // TODO: update
+};
+
+typedef struct rb_ractor_local_key_struct *rb_ractor_local_key_t;
+
 RUBY_SYMBOL_EXPORT_BEGIN
 RUBY_EXTERN VALUE rb_cRactor;
 
@@ -21,6 +29,17 @@ VALUE rb_ractor_stderr(void);
 void rb_ractor_stdin_set(VALUE);
 void rb_ractor_stdout_set(VALUE);
 void rb_ractor_stderr_set(VALUE);
+
+rb_ractor_local_key_t rb_ractor_local_storage_value_newkey(void);
+VALUE rb_ractor_local_storage_value(rb_ractor_local_key_t key);
+void  rb_ractor_local_storage_value_set(rb_ractor_local_key_t key, VALUE val);
+
+RUBY_EXTERN const struct rb_ractor_local_storage_type rb_ractor_local_storage_type_free;
+#define RB_RACTOR_LOCAL_STORAGE_TYPE_FREE (&rb_ractor_local_storage_type_free)
+
+rb_ractor_local_key_t rb_ractor_local_storage_ptr_newkey(const struct rb_ractor_local_storage_type *type);
+void *rb_ractor_local_storage_ptr(rb_ractor_local_key_t key);
+void  rb_ractor_local_storage_ptr_set(rb_ractor_local_key_t key, void *ptr);
 
 RUBY_SYMBOL_EXPORT_END
 

--- a/ractor_core.h
+++ b/ractor_core.h
@@ -123,13 +123,15 @@ struct rb_ractor_struct {
 
     struct list_node vmlr_node;
 
+    // ractor local data
+
+    st_table *local_storage;
+
     VALUE r_stdin;
     VALUE r_stdout;
     VALUE r_stderr;
     VALUE verbose;
     VALUE debug;
-
-    struct rb_random_struct *default_rand; // used in random.c
 
     // gc.c rb_objspace_reachable_objects_from
     struct gc_mark_func_data_struct {
@@ -163,9 +165,15 @@ void rb_ractor_vm_barrier_interrupt_running_thread(rb_ractor_t *r);
 void rb_ractor_terminate_interrupt_main_thread(rb_ractor_t *r);
 void rb_ractor_terminate_all(void);
 bool rb_ractor_main_p_(void);
+void rb_ractor_finish_marking(void);
 
 RUBY_SYMBOL_EXPORT_BEGIN
 bool rb_ractor_shareable_p_continue(VALUE obj);
+
+// THIS FUNCTION SHOULD NOT CALL WHILE INCREMENTAL MARKING!!
+// This function is for T_DATA::free_func
+void rb_ractor_local_storage_delkey(rb_ractor_local_key_t key);
+
 RUBY_SYMBOL_EXPORT_END
 
 RUBY_EXTERN bool ruby_multi_ractor;


### PR DESCRIPTION
To manage ractor-local data for C extension, the following APIs
are defined.

* rb_ractor_local_newkey
* rb_ractor_local_storage_value_ref
* rb_ractor_local_storage_value_set
* rb_ractor_local_storage_ptr_ref
* rb_ractor_local_storage_ptr_set

At first, you need to create a key of storage by
rb_ractor_local_newkey(). This function accepts the type of storage,
how to mark and how to free with ractor's lifetime.

rb_ractor_local_storage_value_ref/set are used to access VALUE
and rb_ractor_local_storage_ptr_ref/set are used to access a pointer.

random.c uses this API.