### PR TITLE
tune parallel test

### DIFF
--- a/test/ruby/test_jit_debug.rb
+++ b/test/ruby/test_jit_debug.rb
@@ -7,6 +7,8 @@ return if ENV['RUBY_DEBUG']&.include?('ci') # ci.rvm.jp
 return if /mswin/ =~ RUBY_PLATFORM
 
 class TestJITDebug < TestJIT
+  @@test_suites.delete TestJIT if self.respond_to? :on_parallel_worker?
+
   def setup
     super
     # let `#eval_with_jit` use --jit-debug

--- a/tool/lib/minitest/unit.rb
+++ b/tool/lib/minitest/unit.rb
@@ -1405,6 +1405,7 @@ module MiniTest
 
       def self.test_suites # :nodoc:
         suites = @@test_suites.keys
+
         case self.test_order
         when :random
           # shuffle test suites based on CRC32 of their names

--- a/tool/lib/test/unit/parallel.rb
+++ b/tool/lib/test/unit/parallel.rb
@@ -198,6 +198,9 @@ if $0 == __FILE__
         def on_parallel_worker?
           true
         end
+        def self.on_parallel_worker?
+          true
+        end
       end
     end
   end


### PR DESCRIPTION
This patch contains the fowllowing hacks:

(1) Add "--timetable-data=FILE" option for test-all
    This option enables to dump timeline event
    contains worker, suite, and start/end time.
(2) remove TestJIT in test_jit_debug.rb on parallel test.
    it is duplicated test.
(3) move test_jit.rb and test_jit_debug.rb at first
    because these two tests are bottleneck of parallel tests.

On my environment, `make test-all TESTS=-j12` reduced the total time
190 seconds -> 140 seconds.