### PR TITLE
Fix `Ractor.make_shareable` for recursive structures

### DIFF
--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -984,6 +984,17 @@ assert_equal '[false, false]', %q{
   [Ractor.shareable?(x), Ractor.shareable?(y)]
 }
 
+# Ractor.make_shareable(recursive_objects)
+assert_equal '[:ok, false, false]', %q{
+  o = Object.new
+  def o.freeze; raise; end
+  y = []
+  x = [y, o].freeze
+  y << x
+  y.freeze
+  [(Ractor.make_shareable(x) rescue :ok), Ractor.shareable?(x), Ractor.shareable?(y)]
+}
+
 # define_method() can invoke different Ractor's proc if the proc is shareable.
 assert_equal '1', %q{
   class C

--- a/ractor.c
+++ b/ractor.c
@@ -2089,7 +2089,7 @@ rb_ractor_make_shareable(VALUE obj)
 {
     rb_obj_traverse(obj,
                     make_shareable_check_shareable,
-                    mark_shareable, mark_shareable);
+                    null_leave, mark_shareable);
     return obj;
 }
 


### PR DESCRIPTION
(with unfreezable components)

Followup to #3823