### PR TITLE
-> creates a lambda so this updates the documentation to reflect that

### DIFF
--- a/doc/syntax/literals.rdoc
+++ b/doc/syntax/literals.rdoc
@@ -363,7 +363,7 @@ See Regexp for a description of the syntax of regular expressions.
 
 == Procs
 
-A proc can be created with <tt>-></tt>:
+A lambda proc can be created with <tt>-></tt>:
 
   -> { 1 + 1 }
 


### PR DESCRIPTION
The `->` literal creates a lambda object so it has all the relevant differences from a normal proc object.

ex:
```
$ irb
irb(main):001:-> -> { 1 + 1 }
=> #<Proc:0x0000559fde76a498 (irb):1 (lambda)>
irb(main):002:-> ->(x) { x }
=> #<Proc:0x0000559fde6a6fe8 (irb):2 (lambda)>
irb(main):003:-> ->(x) { x }.call(2,3)
Traceback (most recent call last):
5: from /usr/bin/irb:23:in `<main>'
4: from /usr/bin/irb:23:in `load'
3: from /usr/lib/ruby/gems/2.7.0/gems/irb-1.2.1/exe/irb:11:in `<top (required)>'
2: from (irb):3
1: from (irb):3:in `block in irb_binding'
ArgumentError (wrong number of arguments (given 2, expected 1)) 
```
for reference:
```
$ ruby --version
ruby 2.7.0p0 (2019-12-25 revision 647ee6f091) [x86_64-linux-gnu]
```

This behavior was also tested and seen in ruby version 2.5.1

**This pull request just adds that the object created by the `->` literal is a lambda**

since this is a one-line fix I'm submitting a pull request here as per [HowToContribute](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToContribute)