### PR TITLE
Only check if the current ep is a local or not, then mark

### DIFF
--- a/vm.c
+++ b/vm.c
@@ -2782,12 +2782,11 @@ rb_execution_context_update(const rb_execution_context_t *ec)
             cfp->iseq = (rb_iseq_t *)rb_gc_location((VALUE)cfp->iseq);
             cfp->block_code = (void *)rb_gc_location((VALUE)cfp->block_code);
 
-            while (!VM_ENV_LOCAL_P(ep)) {
+            if (!VM_ENV_LOCAL_P(ep)) {
                 if (VM_ENV_FLAGS(ep, VM_ENV_FLAG_ESCAPED)) {
                     VM_FORCE_WRITE(&ep[VM_ENV_DATA_INDEX_ENV], rb_gc_location(ep[VM_ENV_DATA_INDEX_ENV]));
                     VM_FORCE_WRITE(&ep[VM_ENV_DATA_INDEX_ME_CREF], rb_gc_location(ep[VM_ENV_DATA_INDEX_ME_CREF]));
                 }
-                ep = VM_ENV_PREV_EP(ep);
             }
 
             cfp = RUBY_VM_PREVIOUS_CONTROL_FRAME(cfp);
@@ -2823,12 +2822,11 @@ rb_execution_context_mark(const rb_execution_context_t *ec)
             rb_gc_mark_movable((VALUE)cfp->iseq);
             rb_gc_mark_movable((VALUE)cfp->block_code);
 
-            while (!VM_ENV_LOCAL_P(ep)) {
+            if (!VM_ENV_LOCAL_P(ep)) {
 		if (VM_ENV_FLAGS(ep, VM_ENV_FLAG_ESCAPED)) {
                     rb_gc_mark_movable(ep[VM_ENV_DATA_INDEX_ENV]);
                     rb_gc_mark(ep[VM_ENV_DATA_INDEX_ME_CREF]);
 		}
-                ep = VM_ENV_PREV_EP(ep);
             }
 
 	    cfp = RUBY_VM_PREVIOUS_CONTROL_FRAME(cfp);


### PR DESCRIPTION
The vm mark function should only check if the current frame is a local
or not and then mark values in that frame.  Since it's walking up the
stack looking at each cfp, then all ep's should be examined.

This fixes a bug in the Rails tests where we're seeing segv in railties.

Thanks Yasuo Honda for giving me a reliable repro!