### PR TITLE
ruby_single_main_ractor for single ractor mode

### DIFF
--- a/ractor.c
+++ b/ractor.c
@@ -30,8 +30,10 @@ rb_ractor_error_class(void)
 }
 
 RUBY_SYMBOL_EXPORT_BEGIN
+
 // to share with MJIT
-bool ruby_multi_ractor;
+rb_ractor_t *ruby_single_main_ractor;
+
 RUBY_SYMBOL_EXPORT_END
 
 static void vm_ractor_blocking_cnt_inc(rb_vm_t *vm, rb_ractor_t *r, const char *file, int line);
@@ -1153,9 +1155,9 @@ vm_insert_ractor(rb_vm_t *vm, rb_ractor_t *r)
         else {
             vm_ractor_blocking_cnt_inc(vm, r, __FILE__, __LINE__);
 
-            RUBY_DEBUG_LOG("ruby_multi_ractor=true", 0);
             // enable multi-ractor mode
-            ruby_multi_ractor = true;
+            RUBY_DEBUG_LOG("enable multi-ractor mode", 0);
+            ruby_single_main_ractor = NULL;
 
             if (rb_warning_category_enabled_p(RB_WARN_CATEGORY_EXPERIMENTAL)) {
                 rb_warn("Ractor is experimental, and the behavior may change in future versions of Ruby! Also there are many implementation issues.");
@@ -1212,6 +1214,7 @@ rb_ractor_main_alloc(void)
     r->id = ++ractor_last_id;
     r->loc = Qnil;
     r->name = Qnil;
+    ruby_single_main_ractor = r;
 
     return r;
 }

--- a/ractor_core.h
+++ b/ractor_core.h
@@ -176,12 +176,10 @@ void rb_ractor_local_storage_delkey(rb_ractor_local_key_t key);
 
 RUBY_SYMBOL_EXPORT_END
 
-RUBY_EXTERN bool ruby_multi_ractor;
-
 static inline bool
 rb_ractor_main_p(void)
 {
-    if (!ruby_multi_ractor) {
+    if (ruby_single_main_ractor) {
         return true;
     }
     else {

--- a/vm_core.h
+++ b/vm_core.h
@@ -1799,11 +1799,18 @@ rb_current_thread(void)
     return rb_ec_thread_ptr(ec);
 }
 
+extern struct rb_ractor_struct *ruby_single_main_ractor; // ractor.c
+
 static inline rb_ractor_t *
 rb_current_ractor(void)
 {
-    const rb_execution_context_t *ec = GET_EC();
-    return rb_ec_ractor_ptr(ec);
+    if (ruby_single_main_ractor) {
+        return ruby_single_main_ractor;
+    }
+    else {
+        const rb_execution_context_t *ec = GET_EC();
+        return rb_ec_ractor_ptr(ec);
+    }
 }
 
 static inline rb_vm_t *

--- a/vm_sync.h
+++ b/vm_sync.h
@@ -3,7 +3,6 @@
 #define RUBY_VM_SYNC_H
 
 #include "vm_debug.h"
-RUBY_EXTERN bool ruby_multi_ractor;
 
 #if USE_RUBY_DEBUG_LOG
 #define LOCATION_ARGS const char *file, int line
@@ -29,10 +28,12 @@ void rb_vm_barrier(void);
 #include "vm_core.h"
 #endif
 
+extern struct rb_ractor_struct *ruby_single_main_ractor; // ractor.c
+
 static inline bool
 rb_multi_ractor_p(void)
 {
-    if (LIKELY(!ruby_multi_ractor)) {
+    if (LIKELY(ruby_single_main_ractor)) {
         // 0 on boot time.
         RUBY_ASSERT(GET_VM()->ractor.cnt <= 1);
         return false;


### PR DESCRIPTION
ruby_multi_ractor was a flag that indicates the interpreter doesn't
make any additional ractors (single ractor mode).
Instead of boolean flag, ruby_single_main_ractor pointer is introduced
which keeps main ractor's pointer if single ractor mode. If additional
ractors are created, ruby_single_main_ractor becomes NULL.