### PR TITLE
Hash.ruby2_keywords_hash?(value) support any Object

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -1919,7 +1919,7 @@ rb_hash_s_try_convert(VALUE dummy, VALUE hash)
 static VALUE
 rb_hash_s_ruby2_keywords_hash_p(VALUE dummy, VALUE hash)
 {
-    Check_Type(hash, T_HASH);
+    if (!RB_TYPE_P(hash, T_HASH)) return Qfalse;
     return (RHASH(hash)->basic.flags & RHASH_PASS_AS_KEYWORDS) ? Qtrue : Qfalse;
 }
 

--- a/spec/ruby/core/hash/ruby2_keywords_hash_spec.rb
+++ b/spec/ruby/core/hash/ruby2_keywords_hash_spec.rb
@@ -1,7 +1,7 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
-ruby_version_is "2.7" do
+ruby_version_is "2.7"..."3.0" do
   describe "Hash.ruby2_keywords_hash?" do
     it "returns false if the Hash is not a keywords Hash" do
       Hash.ruby2_keywords_hash?({}).should == false
@@ -18,6 +18,12 @@ ruby_version_is "2.7" do
 
     it "raises TypeError for non-Hash" do
       -> { Hash.ruby2_keywords_hash?(nil) }.should raise_error(TypeError)
+    end
+
+    ruby_version_is "3.0" do
+      it "returns false for non-Hash" do
+        Hash.ruby2_keywords_hash?(nil).should == false
+      end
     end
   end
 

--- a/test/ruby/test_hash.rb
+++ b/test/ruby/test_hash.rb
@@ -1783,7 +1783,7 @@ class TestHash < Test::Unit::TestCase
     flagged_hash = get_flagged_hash(k: 1)
     assert_equal(true, Hash.ruby2_keywords_hash?(flagged_hash))
     assert_equal(false, Hash.ruby2_keywords_hash?({}))
-    assert_raise(TypeError) { Hash.ruby2_keywords_hash?(1) }
+    assert_equal(false, Hash.ruby2_keywords_hash?(1))
   end
 
   def test_ruby2_keywords_hash


### PR DESCRIPTION
Change `Hash.ruby2_keywords_hash?(value)` to don't raise when the argument is not an `Hash`: returns `false` instead.

Closes [Feature #16697](https://bugs.ruby-lang.org/issues/16697)
