### PR TITLE
Ractor newobj cache

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -10384,6 +10384,7 @@ ractor.$(OBJEXT): {$(VPATH)}subst.h
 ractor.$(OBJEXT): {$(VPATH)}thread.h
 ractor.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).h
 ractor.$(OBJEXT): {$(VPATH)}thread_native.h
+ractor.$(OBJEXT): {$(VPATH)}transient_heap.h
 ractor.$(OBJEXT): {$(VPATH)}variable.h
 ractor.$(OBJEXT): {$(VPATH)}vm_core.h
 ractor.$(OBJEXT): {$(VPATH)}vm_debug.h

--- a/debug.c
+++ b/debug.c
@@ -424,7 +424,7 @@ ruby_debug_log(const char *file, int line, const char *func_name, const char *fm
     }
 
     // ractor information
-    if (GET_VM()->ractor.cnt > 1) {
+    if (ruby_single_main_ractor == NULL) {
         rb_ractor_t *cr = GET_RACTOR();
         if (r && len < MAX_DEBUG_LOG_MESSAGE_LEN) {
             r = snprintf(buff + len, MAX_DEBUG_LOG_MESSAGE_LEN - len, "\tr:#%u/%u",

--- a/gc.c
+++ b/gc.c
@@ -2335,7 +2335,7 @@ rb_wb_protected_newobj_of(VALUE klass, VALUE flags)
 }
 
 VALUE
-rb_wb_protected_newobj_of_ec(rb_execution_context_t *ec, VALUE klass, VALUE flags)
+rb_ec_wb_protected_newobj_of(rb_execution_context_t *ec, VALUE klass, VALUE flags)
 {
     GC_ASSERT((flags & FL_WB_PROTECTED) == 0);
     return newobj_of_cr(rb_ec_ractor_ptr(ec), klass, flags, 0, 0, 0, TRUE);

--- a/insns.def
+++ b/insns.def
@@ -363,7 +363,7 @@ putstring
 ()
 (VALUE val)
 {
-    val = rb_str_resurrect(str);
+    val = rb_ec_str_resurrect(ec, str);
 }
 
 /* put concatenate strings */
@@ -426,7 +426,7 @@ newarray
 (VALUE val)
 // attr rb_snum_t sp_inc = 1 - (rb_snum_t)num;
 {
-    val = rb_ary_new4(num, STACK_ADDR_FROM_TOP(num));
+    val = rb_ec_ary_new_from_values(ec, num, STACK_ADDR_FROM_TOP(num));
 }
 
 /* put new array initialized with num values on the stack. There

--- a/internal/array.h
+++ b/internal/array.h
@@ -48,6 +48,9 @@ VALUE rb_ary_tmp_new_from_values(VALUE, long, const VALUE *);
 VALUE rb_check_to_array(VALUE ary);
 VALUE rb_ary_behead(VALUE, long);
 VALUE rb_ary_aref1(VALUE ary, VALUE i);
+
+struct rb_execution_context_struct;
+VALUE rb_ec_ary_new_from_values(struct rb_execution_context_struct *ec, long n, const VALUE *elts);
 MJIT_SYMBOL_EXPORT_END
 
 static inline VALUE

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -30,6 +30,12 @@ struct rb_objspace; /* in vm_core.h */
   T *(var) = (T *)(((f) & FL_WB_PROTECTED) ? \
                    rb_wb_protected_newobj_of((c), (f) & ~FL_WB_PROTECTED) : \
                    rb_wb_unprotected_newobj_of((c), (f)))
+
+#define RB_EC_NEWOBJ_OF(ec, var, T, c, f) \
+  T *(var) = (T *)(((f) & FL_WB_PROTECTED) ? \
+                   rb_ec_wb_protected_newobj_of((ec), (c), (f) & ~FL_WB_PROTECTED) : \
+                   rb_wb_unprotected_newobj_of((c), (f)))
+
 #define NEWOBJ_OF(var, T, c, f) RB_NEWOBJ_OF((var), T, (c), (f))
 #define RB_OBJ_GC_FLAGS_MAX 6   /* used in ext/objspace */
 
@@ -85,6 +91,7 @@ RUBY_SYMBOL_EXPORT_BEGIN
 const char *rb_objspace_data_type_name(VALUE obj);
 VALUE rb_wb_protected_newobj_of(VALUE, VALUE);
 VALUE rb_wb_unprotected_newobj_of(VALUE, VALUE);
+VALUE rb_ec_wb_protected_newobj_of(struct rb_execution_context_struct *ec, VALUE klass, VALUE flags);
 size_t rb_obj_memsize_of(VALUE);
 void rb_gc_verify_internal_consistency(void);
 size_t rb_obj_gc_flags(VALUE, ID[], size_t);

--- a/internal/string.h
+++ b/internal/string.h
@@ -69,6 +69,9 @@ VALUE rb_str_concat_literals(size_t num, const VALUE *strary);
 VALUE rb_str_eql(VALUE str1, VALUE str2);
 VALUE rb_id_quote_unprintable(ID);
 VALUE rb_sym_proc_call(ID mid, int argc, const VALUE *argv, int kw_splat, VALUE passed_proc);
+
+struct rb_execution_context_struct;
+VALUE rb_ec_str_resurrect(struct rb_execution_context_struct *ec, VALUE str);
 MJIT_SYMBOL_EXPORT_END
 
 #define rb_fstring_lit(str) rb_fstring_new((str), rb_strlen_lit(str))

--- a/ractor.c
+++ b/ractor.c
@@ -30,13 +30,6 @@ rb_ractor_error_class(void)
     return rb_eRactorError;
 }
 
-RUBY_SYMBOL_EXPORT_BEGIN
-
-// to share with MJIT
-rb_ractor_t *ruby_single_main_ractor;
-
-RUBY_SYMBOL_EXPORT_END
-
 static void vm_ractor_blocking_cnt_inc(rb_vm_t *vm, rb_ractor_t *r, const char *file, int line);
 
 static void

--- a/ractor.c
+++ b/ractor.c
@@ -30,8 +30,10 @@ rb_ractor_error_class(void)
 }
 
 RUBY_SYMBOL_EXPORT_BEGIN
+
 // to share with MJIT
-bool ruby_multi_ractor;
+rb_ractor_t *ruby_single_main_ractor;
+
 RUBY_SYMBOL_EXPORT_END
 
 static void vm_ractor_blocking_cnt_inc(rb_vm_t *vm, rb_ractor_t *r, const char *file, int line);
@@ -1158,9 +1160,9 @@ vm_insert_ractor(rb_vm_t *vm, rb_ractor_t *r)
         else {
             vm_ractor_blocking_cnt_inc(vm, r, __FILE__, __LINE__);
 
-            RUBY_DEBUG_LOG("ruby_multi_ractor=true", 0);
             // enable multi-ractor mode
-            ruby_multi_ractor = true;
+            RUBY_DEBUG_LOG("enable multi-ractor mode", 0);
+            ruby_single_main_ractor = NULL;
 
             if (rb_warning_category_enabled_p(RB_WARN_CATEGORY_EXPERIMENTAL)) {
                 rb_warn("Ractor is experimental, and the behavior may change in future versions of Ruby! Also there are many implementation issues.");
@@ -1217,6 +1219,7 @@ rb_ractor_main_alloc(void)
     r->id = ++ractor_last_id;
     r->loc = Qnil;
     r->name = Qnil;
+    ruby_single_main_ractor = r;
 
     return r;
 }

--- a/ractor.c
+++ b/ractor.c
@@ -1230,6 +1230,7 @@ rb_ractor_main_alloc(void)
     r->id = ++ractor_last_id;
     r->loc = Qnil;
     r->name = Qnil;
+    r->self = Qnil;
     ruby_single_main_ractor = r;
 
     return r;
@@ -2154,7 +2155,6 @@ static VALUE
 ractor_reset_belonging(VALUE obj)
 {
 #if RACTOR_CHECK_MODE > 0
-    rp(obj);
     rb_obj_traverse(obj, reset_belonging_enter, null_leave, NULL);
 #endif
     return obj;

--- a/ractor_core.h
+++ b/ractor_core.h
@@ -176,12 +176,10 @@ void rb_ractor_local_storage_delkey(rb_ractor_local_key_t key);
 
 RUBY_SYMBOL_EXPORT_END
 
-RUBY_EXTERN bool ruby_multi_ractor;
-
 static inline bool
 rb_ractor_main_p(void)
 {
-    if (!ruby_multi_ractor) {
+    if (ruby_single_main_ractor) {
         return true;
     }
     else {

--- a/ractor_core.h
+++ b/ractor_core.h
@@ -133,6 +133,11 @@ struct rb_ractor_struct {
     VALUE verbose;
     VALUE debug;
 
+    struct {
+        struct RVALUE *freelist;
+        struct heap_page *using_page;
+    } newobj_cache;
+
     // gc.c rb_objspace_reachable_objects_from
     struct gc_mark_func_data_struct {
         void *data;

--- a/transient_heap.c
+++ b/transient_heap.c
@@ -364,74 +364,72 @@ transient_heap_allocatable_header(struct transient_heap* theap, size_t size)
 void *
 rb_transient_heap_alloc(VALUE obj, size_t req_size)
 {
+    // only on single main ractor
+    if (ruby_single_main_ractor == NULL) return NULL;
+
     void *ret;
+    struct transient_heap* theap = transient_heap_get();
+    size_t size = ROUND_UP(req_size + sizeof(struct transient_alloc_header), TRANSIENT_HEAP_ALLOC_ALIGN);
 
-    RB_VM_LOCK_ENTER();
-    {
-        struct transient_heap* theap = transient_heap_get();
-        size_t size = ROUND_UP(req_size + sizeof(struct transient_alloc_header), TRANSIENT_HEAP_ALLOC_ALIGN);
+    TH_ASSERT(RB_TYPE_P(obj, T_ARRAY)  ||
+              RB_TYPE_P(obj, T_OBJECT) ||
+              RB_TYPE_P(obj, T_STRUCT) ||
+              RB_TYPE_P(obj, T_HASH)); /* supported types */
 
-        TH_ASSERT(RB_TYPE_P(obj, T_ARRAY)  ||
-                  RB_TYPE_P(obj, T_OBJECT) ||
-                  RB_TYPE_P(obj, T_STRUCT) ||
-                  RB_TYPE_P(obj, T_HASH)); /* supported types */
-
-        if (size > TRANSIENT_HEAP_ALLOC_MAX) {
-            if (TRANSIENT_HEAP_DEBUG >= 3) fprintf(stderr, "rb_transient_heap_alloc: [too big: %ld] %s\n", (long)size, rb_obj_info(obj));
-            ret = NULL;
-        }
+    if (size > TRANSIENT_HEAP_ALLOC_MAX) {
+        if (TRANSIENT_HEAP_DEBUG >= 3) fprintf(stderr, "rb_transient_heap_alloc: [too big: %ld] %s\n", (long)size, rb_obj_info(obj));
+        ret = NULL;
+    }
 #if TRANSIENT_HEAP_DEBUG_DONT_PROMOTE == 0
-        else if (RB_OBJ_PROMOTED_RAW(obj)) {
-            if (TRANSIENT_HEAP_DEBUG >= 3)  fprintf(stderr, "rb_transient_heap_alloc: [promoted object] %s\n", rb_obj_info(obj));
-            ret = NULL;
-        }
+    else if (RB_OBJ_PROMOTED_RAW(obj)) {
+        if (TRANSIENT_HEAP_DEBUG >= 3)  fprintf(stderr, "rb_transient_heap_alloc: [promoted object] %s\n", rb_obj_info(obj));
+        ret = NULL;
+    }
 #else
-        else if (RBASIC_CLASS(obj) == 0) {
-            if (TRANSIENT_HEAP_DEBUG >= 3)  fprintf(stderr, "rb_transient_heap_alloc: [hidden object] %s\n", rb_obj_info(obj));
-            ret = NULL;
-        }
+    else if (RBASIC_CLASS(obj) == 0) {
+        if (TRANSIENT_HEAP_DEBUG >= 3)  fprintf(stderr, "rb_transient_heap_alloc: [hidden object] %s\n", rb_obj_info(obj));
+        ret = NULL;
+    }
 #endif
-        else {
-            struct transient_alloc_header *header = transient_heap_allocatable_header(theap, size);
-            if (header) {
-                void *ptr;
+    else {
+        struct transient_alloc_header *header = transient_heap_allocatable_header(theap, size);
+        if (header) {
+            void *ptr;
 
-                /* header is poisoned to prevent buffer overflow, should
-                 * unpoison first... */
-                asan_unpoison_memory_region(header, sizeof *header, true);
+            /* header is poisoned to prevent buffer overflow, should
+             * unpoison first... */
+            asan_unpoison_memory_region(header, sizeof *header, true);
 
-                header->size = size;
-                header->magic = TRANSIENT_HEAP_ALLOC_MAGIC;
-                header->next_marked_index = TRANSIENT_HEAP_ALLOC_MARKING_FREE;
-                header->obj = obj; /* TODO: can we eliminate it? */
+            header->size = size;
+            header->magic = TRANSIENT_HEAP_ALLOC_MAGIC;
+            header->next_marked_index = TRANSIENT_HEAP_ALLOC_MARKING_FREE;
+            header->obj = obj; /* TODO: can we eliminate it? */
 
-                /* header is fixed; shall poison again */
-                asan_poison_memory_region(header, sizeof *header);
-                ptr = header + 1;
+            /* header is fixed; shall poison again */
+            asan_poison_memory_region(header, sizeof *header);
+            ptr = header + 1;
 
-                theap->total_objects++; /* statistics */
+            theap->total_objects++; /* statistics */
 
 #if TRANSIENT_HEAP_DEBUG_DONT_PROMOTE
-                if (RB_OBJ_PROMOTED_RAW(obj)) {
-                    transient_heap_promote_add(theap, obj);
-                }
+            if (RB_OBJ_PROMOTED_RAW(obj)) {
+                transient_heap_promote_add(theap, obj);
+            }
 #endif
-                if (TRANSIENT_HEAP_DEBUG >= 3) fprintf(stderr, "rb_transient_heap_alloc: header:%p ptr:%p size:%d obj:%s\n", (void *)header, ptr, (int)size, rb_obj_info(obj));
+            if (TRANSIENT_HEAP_DEBUG >= 3) fprintf(stderr, "rb_transient_heap_alloc: header:%p ptr:%p size:%d obj:%s\n", (void *)header, ptr, (int)size, rb_obj_info(obj));
 
-                RB_DEBUG_COUNTER_INC(theap_alloc);
+            RB_DEBUG_COUNTER_INC(theap_alloc);
 
-                /* ptr is set up; OK to unpoison. */
-                asan_unpoison_memory_region(ptr, size - sizeof *header, true);
-                ret = ptr;
-            }
-            else {
-                if (TRANSIENT_HEAP_DEBUG >= 3) fprintf(stderr, "rb_transient_heap_alloc: [no enough space: %ld] %s\n", (long)size, rb_obj_info(obj));
-                RB_DEBUG_COUNTER_INC(theap_alloc_fail);
-                ret = NULL;
-            }
+            /* ptr is set up; OK to unpoison. */
+            asan_unpoison_memory_region(ptr, size - sizeof *header, true);
+            ret = ptr;
+        }
+        else {
+            if (TRANSIENT_HEAP_DEBUG >= 3) fprintf(stderr, "rb_transient_heap_alloc: [no enough space: %ld] %s\n", (long)size, rb_obj_info(obj));
+            RB_DEBUG_COUNTER_INC(theap_alloc_fail);
+            ret = NULL;
         }
     }
-    RB_VM_LOCK_LEAVE();
 
     return ret;
 }
@@ -775,16 +773,16 @@ transient_heap_update_status(struct transient_heap* theap, enum transient_heap_s
 static void
 transient_heap_evacuate(void *dmy)
 {
-    RB_VM_LOCK_ENTER();
-    rb_vm_barrier();
-    {
-        struct transient_heap* theap = transient_heap_get();
+    struct transient_heap* theap = transient_heap_get();
 
-        if (theap->status == transient_heap_marking) {
-            if (TRANSIENT_HEAP_DEBUG >= 1) fprintf(stderr, "!! transient_heap_evacuate: skip while transient_heap_marking\n");
-        }
-        else {
-            VALUE gc_disabled = rb_gc_disable_no_rest();
+    if (theap->total_marked_objects == 0) return;
+    if (ruby_single_main_ractor == NULL) rb_bug("not single ractor mode");
+    if (theap->status == transient_heap_marking) {
+        if (TRANSIENT_HEAP_DEBUG >= 1) fprintf(stderr, "!! transient_heap_evacuate: skip while transient_heap_marking\n");
+    }
+    else {
+        VALUE gc_disabled = rb_gc_disable_no_rest();
+        {
             struct transient_heap_block* block;
 
             RUBY_DEBUG_LOG("start gc_disabled:%d", RTEST(gc_disabled));
@@ -825,12 +823,16 @@ transient_heap_evacuate(void *dmy)
 
             transient_heap_verify(theap);
             transient_heap_update_status(theap, transient_heap_none);
-
-            if (gc_disabled != Qtrue) rb_gc_enable();
-            RUBY_DEBUG_LOG("finish", 0);
         }
+        if (gc_disabled != Qtrue) rb_gc_enable();
+        RUBY_DEBUG_LOG("finish", 0);
     }
-    RB_VM_LOCK_LEAVE();
+}
+
+void
+rb_transient_heap_evacuate(void)
+{
+    transient_heap_evacuate(NULL);
 }
 
 static void
@@ -964,9 +966,9 @@ rb_transient_heap_finish_marking(void)
 
     struct transient_heap* theap = transient_heap_get();
 
-    if (TRANSIENT_HEAP_DEBUG >= 1) fprintf(stderr, "!! rb_transient_heap_finish_marking objects:%d, marked:%d\n",
-                                           theap->total_objects,
-                                           theap->total_marked_objects);
+    RUBY_DEBUG_LOG("objects:%d, marked:%d",
+                   theap->total_objects,
+                   theap->total_marked_objects);
     if (TRANSIENT_HEAP_DEBUG >= 2) transient_heap_dump(theap);
 
     TH_ASSERT(theap->total_objects >= theap->total_marked_objects);

--- a/transient_heap.h
+++ b/transient_heap.h
@@ -31,6 +31,9 @@ void rb_transient_heap_start_marking(int full_marking);
 void rb_transient_heap_finish_marking(void);
 void rb_transient_heap_update_references(void);
 
+/* used by ractor.c */
+void rb_transient_heap_evacuate(void);
+
 /* for debug API */
 void rb_transient_heap_dump(void);
 void rb_transient_heap_verify(void);
@@ -49,6 +52,7 @@ void rb_struct_transient_heap_evacuate(VALUE st, int promote);
 #define rb_transient_heap_promote(obj) ((void)0)
 #define rb_transient_heap_start_marking(full_marking) ((void)0)
 #define rb_transient_heap_update_references() ((void)0)
+#define rb_transient_heap_evacuate() ((void)0)
 #define rb_transient_heap_finish_marking() ((void)0)
 #define rb_transient_heap_mark(obj, ptr) ((void)0)
 

--- a/vm.c
+++ b/vm.c
@@ -378,6 +378,7 @@ VALUE rb_block_param_proxy;
 #define ruby_vm_redefined_flag GET_VM()->redefined_flag
 VALUE ruby_vm_const_missing_count = 0;
 rb_vm_t *ruby_current_vm_ptr = NULL;
+rb_ractor_t *ruby_single_main_ractor;
 
 #ifdef RB_THREAD_LOCAL_SPECIFIER
 RB_THREAD_LOCAL_SPECIFIER rb_execution_context_t *ruby_current_ec;

--- a/vm_core.h
+++ b/vm_core.h
@@ -1799,11 +1799,18 @@ rb_current_thread(void)
     return rb_ec_thread_ptr(ec);
 }
 
+extern struct rb_ractor_struct *ruby_single_main_ractor; // ractor.c
+
 static inline rb_ractor_t *
 rb_current_ractor(void)
 {
-    const rb_execution_context_t *ec = GET_EC();
-    return rb_ec_ractor_ptr(ec);
+    if (ruby_single_main_ractor) {
+        return ruby_single_main_ractor;
+    }
+    else {
+        const rb_execution_context_t *ec = GET_EC();
+        return rb_ec_ractor_ptr(ec);
+    }
 }
 
 static inline rb_vm_t *

--- a/vm_core.h
+++ b/vm_core.h
@@ -1733,6 +1733,7 @@ rb_execution_context_t *rb_vm_main_ractor_ec(rb_vm_t *vm); // ractor.c
 #if RUBY_VM_THREAD_MODEL == 2
 RUBY_SYMBOL_EXPORT_BEGIN
 
+RUBY_EXTERN struct rb_ractor_struct *ruby_single_main_ractor; // ractor.c
 RUBY_EXTERN rb_vm_t *ruby_current_vm_ptr;
 RUBY_EXTERN rb_event_flag_t ruby_vm_event_flags;
 RUBY_EXTERN rb_event_flag_t ruby_vm_event_enabled_global_flags;
@@ -1798,8 +1799,6 @@ rb_current_thread(void)
     const rb_execution_context_t *ec = GET_EC();
     return rb_ec_thread_ptr(ec);
 }
-
-extern struct rb_ractor_struct *ruby_single_main_ractor; // ractor.c
 
 static inline rb_ractor_t *
 rb_current_ractor(void)

--- a/vm_sync.c
+++ b/vm_sync.c
@@ -41,6 +41,8 @@ rb_vm_locked_p(void)
 static void
 vm_lock_enter(rb_ractor_t *cr, rb_vm_t *vm, bool locked, unsigned int *lev APPEND_LOCATION_ARGS)
 {
+    RUBY_DEBUG_LOG2(file, line, "start locked:%d", locked);
+
     if (locked) {
         ASSERT_vm_locking();
     }

--- a/vm_sync.h
+++ b/vm_sync.h
@@ -19,6 +19,9 @@
 bool rb_vm_locked_p(void);
 void rb_vm_lock_body(LOCATION_ARGS);
 void rb_vm_unlock_body(LOCATION_ARGS);
+
+struct rb_ractor_struct;
+void rb_vm_lock_enter_body_cr(struct rb_ractor_struct *cr, unsigned int *lev APPEND_LOCATION_ARGS);
 void rb_vm_lock_enter_body(unsigned int *lev APPEND_LOCATION_ARGS);
 void rb_vm_lock_leave_body(unsigned int *lev APPEND_LOCATION_ARGS);
 void rb_vm_barrier(void);
@@ -72,8 +75,20 @@ static inline void
 rb_vm_lock_leave(unsigned int *lev, const char *file, int line)
 {
     if (rb_multi_ractor_p()) {
-        rb_vm_lock_leave_body(lev APPEND_LOCATION_PARAMS);
+      rb_vm_lock_leave_body(lev APPEND_LOCATION_PARAMS);
     }
+}
+
+static inline void
+rb_vm_lock_enter_cr(struct rb_ractor_struct *cr, unsigned int *levp, const char *file, int line)
+{
+    rb_vm_lock_enter_body_cr(cr, levp APPEND_LOCATION_PARAMS);
+}
+
+static inline void
+rb_vm_lock_leave_cr(struct rb_ractor_struct *cr, unsigned int *levp, const char *file, int line)
+{
+    rb_vm_lock_leave_body(levp APPEND_LOCATION_PARAMS);
 }
 
 #define RB_VM_LOCKED_P()   rb_vm_locked_p()
@@ -81,6 +96,8 @@ rb_vm_lock_leave(unsigned int *lev, const char *file, int line)
 #define RB_VM_LOCK()       rb_vm_lock(__FILE__, __LINE__)
 #define RB_VM_UNLOCK()     rb_vm_unlock(__FILE__, __LINE__)
 
+#define RB_VM_LOCK_ENTER_CR_LEV(cr, levp) rb_vm_lock_enter_cr(cr, levp, __FILE__, __LINE__)
+#define RB_VM_LOCK_LEAVE_CR_LEV(cr, levp) rb_vm_lock_leave_cr(cr, levp, __FILE__, __LINE__)
 #define RB_VM_LOCK_ENTER_LEV(levp) rb_vm_lock_enter(levp, __FILE__, __LINE__)
 #define RB_VM_LOCK_LEAVE_LEV(levp) rb_vm_lock_leave(levp, __FILE__, __LINE__)
 

--- a/vm_sync.h
+++ b/vm_sync.h
@@ -3,7 +3,6 @@
 #define RUBY_VM_SYNC_H
 
 #include "vm_debug.h"
-RUBY_EXTERN bool ruby_multi_ractor;
 
 #if USE_RUBY_DEBUG_LOG
 #define LOCATION_ARGS const char *file, int line
@@ -29,10 +28,12 @@ void rb_vm_barrier(void);
 #include "vm_core.h"
 #endif
 
+extern struct rb_ractor_struct *ruby_single_main_ractor; // ractor.c
+
 static inline bool
 rb_multi_ractor_p(void)
 {
-    if (LIKELY(!ruby_multi_ractor)) {
+    if (LIKELY(ruby_single_main_ractor)) {
         // 0 on boot time.
         RUBY_ASSERT(GET_VM()->ractor.cnt <= 1);
         return false;

--- a/vm_sync.h
+++ b/vm_sync.h
@@ -31,7 +31,7 @@ void rb_vm_barrier(void);
 #include "vm_core.h"
 #endif
 
-extern struct rb_ractor_struct *ruby_single_main_ractor; // ractor.c
+RUBY_EXTERN struct rb_ractor_struct *ruby_single_main_ractor; // ractor.c
 
 static inline bool
 rb_multi_ractor_p(void)


### PR DESCRIPTION
Now object allocation requires VM global lock to synchronize objspace.
However, of course, it introduces huge overhead.
This patch caches some slots (in a page) by each ractor and use cached
slots for object allocation. If there is no cached slots, acquire the global lock
and get new cached slots, or start GC (marking or lazy sweeping).