### PR TITLE
Skip repeated scan of object during compaction

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -4484,7 +4484,7 @@ try_move(rb_objspace_t *objspace, rb_heap_t *heap, struct heap_page *sweep_page,
                             objspace->rcompactor.total_moved++;
                             gc_move(objspace, (VALUE)p, dest);
                             gc_pin(objspace, (VALUE)p);
-                            heap->compact_cursor_index = i;
+                            heap->compact_cursor_index = i + 1;
                             if (from_freelist) {
                                 FL_SET((VALUE)p, FL_FROM_FREELIST);
                             }


### PR DESCRIPTION
`heap->compact_cursor_index` is used to store the index where the compaction cursor should begin from. However, this index should be `i + 1` because we just moved the object at index `i` so we shouldn't have to scan it again.

cc. @tenderlove