### PR TITLE
Add T_MOVED to rp command of GDB

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -265,8 +265,13 @@ define rp
     printf "%sT_ZOMBIE%s: ", $color_type, $color_end
     print (struct RData *)($arg0)
   else
+  if ($flags & RUBY_T_MASK) == RUBY_T_MOVED
+    printf "%sT_MOVED%s: ", $color_type, $color_end
+    print *(struct RMoved *)$arg0
+  else
     printf "%sunknown%s: ", $color_type, $color_end
     print (struct RBasic *)($arg0)
+  end
   end
   end
   end


### PR DESCRIPTION
The `T_MOVED` type is not supported in GDB using the `rp` command, but supported in LLDB.

Before:
```
(gdb) rp obj
unknown: $1 = (struct RBasic *) 0x555555a67ef8
```

After:
```
(gdb) rp obj
T_MOVED: $2 = {flags = 0x1e, dummy = 0x34, destination = 0x5555559adf30}
```

cc. @tenderlove 