### PR TITLE
Ractor.select requires an argument or yield_value

### DIFF
--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -163,6 +163,15 @@ assert_equal 30.times.map { 'ok' }.to_s, %q{
   }
 } unless ENV['RUN_OPTS'] =~ /--jit-min-calls=5/ # This always fails with --jit-wait --jit-min-calls=5
 
+# Exception for empty select
+assert_match /specify at least one ractor/, %q{
+  begin
+    Ractor.select
+  rescue ArgumentError => e
+    e.message
+  end
+}
+
 # Outgoing port of a ractor will be closed when the Ractor is terminated.
 assert_equal 'ok', %q{
   r = Ractor.new do

--- a/ractor.rb
+++ b/ractor.rb
@@ -71,6 +71,8 @@ class Ractor
   #   #   and r is :yield
   #
   def self.select(*ractors, yield_value: yield_unspecified = true, move: false)
+    raise ArgumentError, 'specify at least one ractor or `yield_value`' if yield_unspecified && ractors.empty?
+
     __builtin_cstmt! %q{
       const VALUE *rs = RARRAY_CONST_PTR_TRANSIENT(ractors);
       VALUE rv;


### PR DESCRIPTION
Currently `Ractor.select()` loops indefinitely.