### PR TITLE
Add support for non-blocking `Process.wait`, `Kernel.system` and other related methods.

### DIFF
--- a/include/ruby/internal/arithmetic/pid_t.h
+++ b/include/ruby/internal/arithmetic/pid_t.h
@@ -23,12 +23,22 @@
 #include "ruby/internal/config.h"
 #include "ruby/internal/arithmetic/long.h"
 
-#ifndef PIDT2NUM
-# define PIDT2NUM RB_LONG2NUM
+#ifndef RB_PIDT2NUM
+# define RB_PIDT2NUM RB_LONG2NUM
 #endif
 
+// Deprecated.
+#ifndef PIDT2NUM
+# define PIDT2NUM RB_PIDT2NUM
+#endif
+
+#ifndef RB_NUM2PIDT
+# define RB_NUM2PIDT RB_NUM2LONG
+#endif
+
+// Deprecated.
 #ifndef NUM2PIDT
-# define NUM2PIDT RB_NUM2LONG
+# define NUM2PIDT RB_NUM2PIDT
 #endif
 
 #endif /* RBIMPL_ARITHMETIC_PID_T_H */

--- a/include/ruby/internal/intern/process.h
+++ b/include/ruby/internal/intern/process.h
@@ -30,7 +30,7 @@ RBIMPL_SYMBOL_EXPORT_BEGIN()
 /* process.c */
 RUBY_EXTERN void (* rb_socket_before_exec_func)();
 
-void rb_last_status_set(int status, rb_pid_t pid);
+void rb_last_status_set(rb_pid_t pid, int status, int error);
 VALUE rb_last_status_get(void);
 int rb_proc_exec(const char*);
 

--- a/internal/scheduler.h
+++ b/internal/scheduler.h
@@ -25,6 +25,9 @@ VALUE rb_scheduler_close(VALUE scheduler);
 VALUE rb_scheduler_kernel_sleep(VALUE scheduler, VALUE duration);
 VALUE rb_scheduler_kernel_sleepv(VALUE scheduler, int argc, VALUE * argv);
 
+int rb_scheduler_supports_process_wait(VALUE scheduler);
+VALUE rb_scheduler_process_wait(VALUE scheduler, rb_pid_t pid, int flags);
+
 VALUE rb_scheduler_block(VALUE scheduler, VALUE blocker, VALUE timeout);
 VALUE rb_scheduler_unblock(VALUE scheduler, VALUE blocker, VALUE fiber);
 

--- a/io.c
+++ b/io.c
@@ -4913,9 +4913,8 @@ fptr_waitpid(rb_io_t *fptr, int nohang)
 {
     int status;
     if (fptr->pid) {
-	rb_last_status_clear();
-	rb_waitpid(fptr->pid, &status, nohang ? WNOHANG : 0);
-	fptr->pid = 0;
+        rb_waitpid(fptr->pid, &status, nohang ? WNOHANG : 0);
+        fptr->pid = 0;
     }
 }
 
@@ -6437,7 +6436,7 @@ pipe_finalize(rb_io_t *fptr, int noraise)
     }
     fptr->fd = -1;
     fptr->stdio_file = 0;
-    rb_last_status_set(status, fptr->pid);
+    rb_last_status_set(fptr->pid, status, 0);
 #else
     fptr_finalize(fptr, noraise);
 #endif

--- a/process.c
+++ b/process.c
@@ -4657,9 +4657,13 @@ rb_f_system(int argc, VALUE *argv, VALUE _)
     /* may be different from waitpid_state.pid on exec failure */
     rb_pid_t pid = rb_execarg_spawn(execarg_obj, 0, 0);
 
+    rb_last_status_clear();
+
     if (pid > 0) {
         VALUE status = rb_process_status_wait(pid, 0);
         struct rb_process_status *data = RTYPEDDATA_DATA(status);
+
+        GET_THREAD()->last_status = status;
 
         // fork failure:
         if (data->error != 0) {

--- a/scheduler.c
+++ b/scheduler.c
@@ -18,6 +18,7 @@ static ID id_block;
 static ID id_unblock;
 
 static ID id_kernel_sleep;
+static ID id_process_wait;
 
 static ID id_io_read;
 static ID id_io_write;
@@ -32,6 +33,7 @@ Init_Scheduler(void)
     id_unblock = rb_intern_const("unblock");
 
     id_kernel_sleep = rb_intern_const("kernel_sleep");
+    id_process_wait = rb_intern_const("process_wait");
 
     id_io_read = rb_intern_const("io_read");
     id_io_write = rb_intern_const("io_write");
@@ -116,6 +118,18 @@ VALUE
 rb_scheduler_kernel_sleepv(VALUE scheduler, int argc, VALUE * argv)
 {
     return rb_funcallv(scheduler, id_kernel_sleep, argc, argv);
+}
+
+int
+rb_scheduler_supports_process_wait(VALUE scheduler)
+{
+    return rb_respond_to(scheduler, id_process_wait);
+}
+
+VALUE
+rb_scheduler_process_wait(VALUE scheduler, rb_pid_t pid, int flags)
+{
+    return rb_funcall(scheduler, id_process_wait, 2, RB_PIDT2NUM(pid), RB_INT2NUM(flags));
 }
 
 VALUE

--- a/test/fiber/scheduler.rb
+++ b/test/fiber/scheduler.rb
@@ -121,7 +121,7 @@ class Scheduler
     # This is a very simple way to implement a non-blocking wait:
     Thread.new do
       Process::Status.wait(pid, flags)
-    end.join
+    end.value
   end
 
   def io_wait(io, events, duration)

--- a/test/fiber/scheduler.rb
+++ b/test/fiber/scheduler.rb
@@ -117,6 +117,13 @@ class Scheduler
     Process.clock_gettime(Process::CLOCK_MONOTONIC)
   end
 
+  def process_wait(pid, flags)
+    # This is a very simple way to implement a non-blocking wait:
+    Thread.new do
+      Process::Status.wait(pid, flags)
+    end.join
+  end
+
   def io_wait(io, events, duration)
     unless (events & IO::READABLE).zero?
       @readable[io] = Fiber.current

--- a/test/fiber/test_process.rb
+++ b/test/fiber/test_process.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+require 'test/unit'
+require_relative 'scheduler'
+
+class TestFiberProcess < Test::Unit::TestCase
+  def test_system
+    Thread.new do
+      scheduler = Scheduler.new
+      Fiber.set_scheduler scheduler
+
+      Fiber.schedule do
+        system("sleep 1")
+      end
+    end.join
+  end
+end

--- a/test/fiber/test_process.rb
+++ b/test/fiber/test_process.rb
@@ -9,7 +9,8 @@ class TestFiberProcess < Test::Unit::TestCase
       Fiber.set_scheduler scheduler
 
       Fiber.schedule do
-        system("sleep 1")
+        system("true")
+        assert_predicate $?, :success?
       end
     end.join
   end


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/17369

See https://github.com/ruby/ruby/pull/3853 for updated PR.