### PR TITLE
Change objectspace walking to use eden heap linked list

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -3188,18 +3188,10 @@ struct each_obj_args {
 static void
 objspace_each_objects_without_setup(rb_objspace_t *objspace, each_obj_callback *callback, void *data)
 {
-    size_t i;
-    struct heap_page *page;
+    struct heap_page *page = 0, *next;
     RVALUE *pstart = NULL, *pend;
 
-    i = 0;
-    while (i < heap_allocated_pages) {
-	while (0 < i && pstart < heap_pages_sorted[i-1]->start)              i--;
-	while (i < heap_allocated_pages && heap_pages_sorted[i]->start <= pstart) i++;
-	if (heap_allocated_pages <= i) break;
-
-	page = heap_pages_sorted[i];
-
+    list_for_each_safe(&heap_eden->pages, page, next, page_node) {
 	pstart = page->start;
 	pend = pstart + page->total_slots;
 


### PR DESCRIPTION
This commit changes the object space walking function to use the linked
list in the eden heap.  The linked list in the eden heap is ordered by
which pages were allocated first (the head of the linked list is the
oldest page).  This allows us to better understand how older pages are
used vs newer pages.

This change means that `ObjectSpace.dump_all` will dump the heap from
oldest page to newest page.

@ko1 can you think of a reason why we *shouldn't* do this?  It's very convenient for heap visualization.