### PR TITLE
Cached respond to

### DIFF
--- a/benchmark/object_respond_to.yml
+++ b/benchmark/object_respond_to.yml
@@ -1,0 +1,11 @@
+prelude: |
+  class Base; def foo; end end
+  class OneTwentyEight < Base
+    128.times { include(Module.new) }
+  end
+  obj = OneTwentyEight.new
+benchmark:
+  respond_to_false: obj.respond_to?(:bar)
+  respond_to_true: obj.respond_to?(:foo)
+loop_count: 1_000_000
+

--- a/vm_method.c
+++ b/vm_method.c
@@ -1124,7 +1124,12 @@ static const rb_method_entry_t *resolve_refined_method(VALUE refinements, const 
 static const rb_method_entry_t *
 method_entry_resolve_refinement(VALUE klass, ID id, int with_refinement, VALUE *defined_class_ptr)
 {
-    const rb_method_entry_t *me = search_method_protect(klass, id, defined_class_ptr);
+    const rb_method_entry_t *me;
+    if (RB_TYPE_P(klass, T_CLASS) || RB_TYPE_P(klass, T_ICLASS)) {
+        me = (const rb_method_entry_t*)callable_method_entry(klass, id, defined_class_ptr);
+    } else {
+        me = search_method_protect(klass, id, defined_class_ptr);
+    }
 
     if (me) {
 	if (me->def->type == VM_METHOD_TYPE_REFINED) {


### PR DESCRIPTION
Use the pCMC for calls to `respond_to?`.  This patch only works with "positive" cases (cases where `respond_to?` will return true).

This change makes the `true` case of respond to about 8x faster but the difference depends on the depth of the module:

```
[aaron@tc-lan-adapter ~/g/ruby (cached-respond-to)]$ make benchmark ITEM='respond_to'
/Users/aaron/.rubies/ruby-trunk/bin/ruby --disable=gems -rrubygems -I./benchmark/lib ./benchmark/benchmark-driver/exe/benchmark-driver \
	            --executables="compare-ruby::/Users/aaron/.rubies/ruby-trunk/bin/ruby --disable=gems -I.ext/common --disable-gem" \
	            --executables="built-ruby::./miniruby -I./lib -I. -I.ext/common  ./tool/runruby.rb --extout=.ext  -- --disable-gems --disable-gem" \
	            --output=markdown --output-compare $(find ./benchmark -maxdepth 1 -name 'respond_to' -o -name '*respond_to*.yml' -o -name '*respond_to*.rb' | sort) 
# Iteration per second (i/s)

|                  |compare-ruby|built-ruby|
|:-----------------|-----------:|---------:|
|respond_to_false  |      3.556M|    3.383M|
|                  |       1.05x|         -|
|respond_to_true   |      3.929M|   33.893M|
|                  |           -|     8.63x|
```