### PR TITLE
ObjectSpace._id2ref should not return unshareable

### DIFF
--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -919,6 +919,19 @@ assert_equal '0', %q{
   }.take
 }
 
+# ObjectSpace._id2ref can not handle unshareable objects with Ractors
+assert_equal 'ok', %q{
+  s = 'hello'
+
+  Ractor.new s.object_id do |id ;s|
+    begin
+      s = ObjectSpace._id2ref(id)
+    rescue => e
+      :ok
+    end
+  end.take
+}
+
 # Ractor.make_shareable(obj)
 assert_equal 'true', %q{
   class C

--- a/gc.c
+++ b/gc.c
@@ -3986,6 +3986,8 @@ id2ref_obj_tbl(rb_objspace_t *objspace, VALUE objid)
  *     r = ObjectSpace._id2ref(s.object_id)   #=> "I am a string"
  *     r == s                                 #=> true
  *
+ *  On multi-ractor mode, if the object is not sharable, it raises
+ *  RangeError.
  */
 
 static VALUE
@@ -4022,7 +4024,13 @@ id2ref(VALUE objid)
 
     if ((orig = id2ref_obj_tbl(objspace, objid)) != Qundef &&
         is_live_object(objspace, orig)) {
-        return orig;
+
+        if (!rb_multi_ractor_p() || rb_ractor_shareable_p(orig)) {
+            return orig;
+        }
+        else {
+            rb_raise(rb_eRangeError, "%+"PRIsVALUE" is id of the unshareable object on multi-ractor", rb_int2str(objid, 10));
+        }
     }
 
     if (rb_int_ge(objid, objspace->next_object_id)) {


### PR DESCRIPTION
ObjectSpace._id2ref(id) can return any objects even if they are
unshareable, so this patch raises RangeError if it runs on multi-ractor
mode and the found object is unshareable.