### PR TITLE
Remove the uninitialized instance variable verbose mode warning

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -578,6 +578,8 @@ end
   message and backtrace are printed in order from the innermost.
   [[Feature #8661]]
 
+* Accessing an uninitialized instance variable no longer emits a
+  warning in verbose mode. [[Feature #17055]]
 
 [Bug #4352]:      https://bugs.ruby-lang.org/issues/4352
 [Bug #6087]:      https://bugs.ruby-lang.org/issues/6087
@@ -625,6 +627,7 @@ end
 [Feature #16815]: https://bugs.ruby-lang.org/issues/16815
 [Feature #16828]: https://bugs.ruby-lang.org/issues/16828
 [Misc #16961]:    https://bugs.ruby-lang.org/issues/16961
+[Feature #17055]: https://bugs.ruby-lang.org/issues/17055
 [Feature #17104]: https://bugs.ruby-lang.org/issues/17104
 [Feature #17122]: https://bugs.ruby-lang.org/issues/17122
 [Feature #17134]: https://bugs.ruby-lang.org/issues/17134

--- a/insns.def
+++ b/insns.def
@@ -210,8 +210,6 @@ getinstancevariable
 (ID id, IVC ic)
 ()
 (VALUE val)
-/* "instance variable not initialized" warning can be hooked. */
-// attr bool leaf = false; /* has rb_warning() */
 {
     val = vm_getinstancevariable(GET_ISEQ(), GET_SELF(), id, ic);
 }

--- a/test/-ext-/symbol/test_inadvertent_creation.rb
+++ b/test/-ext-/symbol/test_inadvertent_creation.rb
@@ -485,10 +485,8 @@ module Test_Symbol
 
     def test_iv_get
       obj = Object.new
-      assert_warning(/not initialized/) do
-        assert_no_immortal_symbol_created("rb_iv_get") do |name|
-          Bug::Symbol.iv_get(obj, name)
-        end
+      assert_no_immortal_symbol_created("rb_iv_get") do |name|
+        Bug::Symbol.iv_get(obj, name)
       end
     end
   end

--- a/test/ruby/test_exception.rb
+++ b/test/ruby/test_exception.rb
@@ -955,8 +955,8 @@ $stderr = $stdout; raise "\x82\xa0"') do |outs, errs, status|
   end
 
   def test_warning_warn
-    warning = capture_warning_warn {@a}
-    assert_match(/instance variable @a not initialized/, warning[0])
+    warning = capture_warning_warn {$asdfasdsda_test_warning_warn}
+    assert_match(/global variable `\$asdfasdsda_test_warning_warn' not initialized/, warning[0])
 
     assert_equal(["a\nz\n"], capture_warning_warn {warn "a\n", "z"})
     assert_equal([],         capture_warning_warn {warn})
@@ -1040,7 +1040,7 @@ $stderr = $stdout; raise "\x82\xa0"') do |outs, errs, status|
   end
 
   def test_warning_warn_super
-    assert_in_out_err(%[-W0], "#{<<~"{#"}\n#{<<~'};'}", [], /instance variable @a not initialized/)
+    assert_in_out_err(%[-W0], "#{<<~"{#"}\n#{<<~'};'}", [], /global variable `\$asdfiasdofa_test_warning_warn_super' not initialized/)
     {#
       module Warning
         def warn(message)
@@ -1049,7 +1049,7 @@ $stderr = $stdout; raise "\x82\xa0"') do |outs, errs, status|
       end
 
       $VERBOSE = true
-      @a
+      $asdfiasdofa_test_warning_warn_super
     };
   end
 

--- a/test/ruby/test_jit.rb
+++ b/test/ruby/test_jit.rb
@@ -829,11 +829,9 @@ class TestJIT < Test::Unit::TestCase
         end
       end
 
-      verbose, $VERBOSE = $VERBOSE, false # suppress "instance variable @b not initialized"
       print(Foo.new.bar)
       print(Foo.new.bar)
       print(Foo.new.bar)
-      $VERBOSE = verbose
     end;
   end
 

--- a/test/ruby/test_module.rb
+++ b/test/ruby/test_module.rb
@@ -2401,7 +2401,7 @@ class TestModule < Test::Unit::TestCase
 
   def test_uninitialized_instance_variable
     a = AttrTest.new
-    assert_warning(/instance variable @ivar not initialized/) do
+    assert_warning('') do
       assert_nil(a.ivar)
     end
     a.instance_variable_set(:@ivar, 42)
@@ -2410,7 +2410,7 @@ class TestModule < Test::Unit::TestCase
     end
 
     name = "@\u{5909 6570}"
-    assert_warning(/instance variable #{name} not initialized/) do
+    assert_warning('') do
       assert_nil(a.instance_eval(name))
     end
   end

--- a/variable.c
+++ b/variable.c
@@ -1217,14 +1217,8 @@ rb_ivar_lookup(VALUE obj, ID id, VALUE undef)
 VALUE
 rb_ivar_get(VALUE obj, ID id)
 {
-    VALUE iv = rb_ivar_lookup(obj, id, Qundef);
+    VALUE iv = rb_ivar_lookup(obj, id, Qnil);
     RB_DEBUG_COUNTER_INC(ivar_get_base);
-
-    if (iv == Qundef) {
-	if (RTEST(ruby_verbose))
-	    rb_warning("instance variable %"PRIsVALUE" not initialized", QUOTE_ID(id));
-	iv = Qnil;
-    }
     return iv;
 }
 
@@ -3526,8 +3520,6 @@ rb_iv_get(VALUE obj, const char *name)
     ID id = rb_check_id_cstr(name, strlen(name), rb_usascii_encoding());
 
     if (!id) {
-        if (RTEST(ruby_verbose))
-            rb_warning("instance variable %s not initialized", name);
         return Qnil;
     }
     return rb_ivar_get(obj, id);

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1179,9 +1179,6 @@ vm_getivar(VALUE obj, ID id, const rb_iseq_t *iseq, IVC ic, const struct rb_call
             return val;
         }
         else {
-            if (!is_attr && RTEST(ruby_verbose)) {
-                rb_warning("instance variable %"PRIsVALUE" not initialized", QUOTE_ID(id));
-            }
             return Qnil;
         }
     }


### PR DESCRIPTION
This speeds up all instance variable access, even when not in
verbose mode.  Uninitialized instance variable warnings were
rarely helpful, and resulted in slower code if you wanted to
avoid warnings when run in verbose mode.

Implements [Feature #17055]