### PR TITLE
Actions mingw - add tool/test for WEBrick in spec tests

### DIFF
--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -120,7 +120,7 @@ jobs:
           [Console]::OutputEncoding = [System.Text.Encoding]::GetEncoding("IBM437")
           [Console]::InputEncoding  = [System.Text.Encoding]::GetEncoding("IBM437")
           ruby -v
-          ruby ../mspec/bin/mspec -j
+          ruby -I../../tool/test ../mspec/bin/mspec -j
 
       - uses: k0kubun/action-slack@v2.0.0
         with:


### PR DESCRIPTION
Some spec tests require WEBrick, and the spec tests are run from install with the MinGW CI.