### PR TITLE
Link zlib always if available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2739,9 +2739,7 @@ AS_IF([test "$rb_cv_binary_elf" = yes], [
   AC_CHECK_HEADERS([elf.h elf_abi.h])
   AS_IF([test $ac_cv_header_elf_h = yes -o $ac_cv_header_elf_abi_h = yes], [
     AC_LIBOBJ([addr2line])
-    AS_IF([test "x$compress_debug_sections" = xzlib], [
-      AC_CHECK_LIB([z], [uncompress])
-    ])
+    AC_CHECK_LIB([z], [uncompress])
   ])
 ])
 


### PR DESCRIPTION
Major Linux distribution packages including Debian, Ubuntu, and Fedora
use `--compress-debug-sections=no` to build ruby, and then extract and
compress debug symbols as separate files. However, the configure option
makes ruby not link zlib, thus the generated binary cannot uncompress
the compressed separate debug symbol files, and fails to show C level
backtrace when a critical error like segfault occurs.

This change makes ruby always link zlib if it is available so that it
can show C level backtrace correctly.

Related: Debian packages require https://github.com/ruby/ruby/pull/3627
to load debug symbol files.