### PR TITLE
Make rb_define_module{,_id}_under pin like rb_define_class{,_id}_under

### DIFF
--- a/class.c
+++ b/class.c
@@ -908,6 +908,8 @@ rb_define_module_id_under(VALUE outer, ID id)
 		     " (%"PRIsVALUE")",
 		     outer, rb_id2str(id), rb_obj_class(module));
 	}
+        /* Module may have been defined in Ruby and not pin-rooted */
+        rb_gc_register_mark_object(module);
 	return module;
     }
     module = rb_module_new();

--- a/class.c
+++ b/class.c
@@ -791,6 +791,7 @@ rb_define_class(const char *name, VALUE super)
  *
  * \note if a class named \a name is already defined and its superclass is
  *       \a super, the function just returns the defined class.
+ * \note the compaction GC does not move classes returned by this function.
  */
 VALUE
 rb_define_class_under(VALUE outer, const char *name, VALUE super)
@@ -814,6 +815,7 @@ rb_define_class_under(VALUE outer, const char *name, VALUE super)
  *
  * \note if a class named \a name is already defined and its superclass is
  *       \a super, the function just returns the defined class.
+ * \note the compaction GC does not move classes returned by this function.
  */
 VALUE
 rb_define_class_id_under(VALUE outer, ID id, VALUE super)
@@ -866,6 +868,9 @@ rb_define_module_id(ID id)
     return rb_module_new();
 }
 
+/*!
+ * \note the compaction GC does not move modules returned by this function.
+ */
 VALUE
 rb_define_module(const char *name)
 {
@@ -890,6 +895,9 @@ rb_define_module(const char *name)
     return module;
 }
 
+/*!
+ * \note the compaction GC does not move modules returned by this function.
+ */
 VALUE
 rb_define_module_under(VALUE outer, const char *name)
 {

--- a/include/ruby/internal/module.h
+++ b/include/ruby/internal/module.h
@@ -25,6 +25,10 @@
 
 RBIMPL_SYMBOL_EXPORT_BEGIN()
 
+/**
+ * GC compaction note: class and modules returned by these four functions
+ * do not move.
+ */
 VALUE rb_define_class(const char*,VALUE);
 VALUE rb_define_module(const char*);
 VALUE rb_define_class_under(VALUE, const char*, VALUE);


### PR DESCRIPTION
And add docs. The change makes these APIs consistent when it comes to pinning objects they return.