### PR TITLE
trap on non-main ractor

### DIFF
--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -1133,6 +1133,24 @@ assert_equal '[true, false]', %q{
   }.take
 }
 
+# Can not trap with not isolated Proc on non-main ractor
+assert_equal '[:ok, :ok]', %q{
+  a = []
+  Ractor.new{
+    trap(:INT){p :ok}
+  }.take
+  a << :ok
+
+  begin
+    Ractor.new{
+      s = 'str'
+      trap(:INT){p s}
+    }.take
+  rescue => Ractor::RemoteError
+    a << :ok
+  end
+}
+
 ###
 ### Synchronization tests
 ###

--- a/common.mk
+++ b/common.mk
@@ -12692,6 +12692,7 @@ signal.$(OBJEXT): {$(VPATH)}defines.h
 signal.$(OBJEXT): {$(VPATH)}encoding.h
 signal.$(OBJEXT): {$(VPATH)}eval_intern.h
 signal.$(OBJEXT): {$(VPATH)}id.h
+signal.$(OBJEXT): {$(VPATH)}id_table.h
 signal.$(OBJEXT): {$(VPATH)}intern.h
 signal.$(OBJEXT): {$(VPATH)}internal.h
 signal.$(OBJEXT): {$(VPATH)}internal/anyargs.h
@@ -12839,6 +12840,8 @@ signal.$(OBJEXT): {$(VPATH)}missing.h
 signal.$(OBJEXT): {$(VPATH)}node.h
 signal.$(OBJEXT): {$(VPATH)}onigmo.h
 signal.$(OBJEXT): {$(VPATH)}oniguruma.h
+signal.$(OBJEXT): {$(VPATH)}ractor.h
+signal.$(OBJEXT): {$(VPATH)}ractor_core.h
 signal.$(OBJEXT): {$(VPATH)}ruby_assert.h
 signal.$(OBJEXT): {$(VPATH)}ruby_atomic.h
 signal.$(OBJEXT): {$(VPATH)}signal.c
@@ -12847,6 +12850,7 @@ signal.$(OBJEXT): {$(VPATH)}subst.h
 signal.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).h
 signal.$(OBJEXT): {$(VPATH)}thread_native.h
 signal.$(OBJEXT): {$(VPATH)}vm_core.h
+signal.$(OBJEXT): {$(VPATH)}vm_debug.h
 signal.$(OBJEXT): {$(VPATH)}vm_opts.h
 sprintf.$(OBJEXT): $(hdrdir)/ruby.h
 sprintf.$(OBJEXT): $(hdrdir)/ruby/ruby.h

--- a/signal.c
+++ b/signal.c
@@ -43,6 +43,7 @@
 #include "internal/thread.h"
 #include "ruby_atomic.h"
 #include "vm_core.h"
+#include "ractor_core.h"
 
 #ifdef NEED_RUBY_ATOMIC_OPS
 rb_atomic_t
@@ -1408,6 +1409,11 @@ sig_trap(int argc, VALUE *argv, VALUE _)
     else {
 	cmd = argv[1];
 	func = trap_handler(&cmd, sig);
+    }
+
+    if (rb_obj_is_proc(cmd) &&
+        !rb_ractor_main_p() && !rb_ractor_shareable_p(cmd)) {
+        cmd = rb_proc_isolate(cmd);
     }
 
     return trap(sig, func, cmd);


### PR DESCRIPTION
trap can accept blopck/Proc and it can violate Rator isolation,
so the Proc should be isolatable when trap is used on non-main ractor.