### PR TITLE
Negative method cache

### DIFF
--- a/debug_counter.h
+++ b/debug_counter.h
@@ -45,6 +45,7 @@ RB_DEBUG_COUNTER(cc_invalidate_leaf_callable) //                        complime
 RB_DEBUG_COUNTER(cc_invalidate_tree)          // count for invalidating klass if klass has sublcasses
 RB_DEBUG_COUNTER(cc_invalidate_tree_cme)      //                        cme if cme is found in this class or superclasses
 RB_DEBUG_COUNTER(cc_invalidate_tree_callable) //                        complimented cache (subclasses)
+RB_DEBUG_COUNTER(cc_invalidate_negative)      // count for invalidating negative cache
 
 RB_DEBUG_COUNTER(ccs_free)   // count for free'ing ccs
 RB_DEBUG_COUNTER(ccs_maxlen) // maximum length of ccs

--- a/test/ruby/test_method_cache.rb
+++ b/test/ruby/test_method_cache.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+require 'test/unit'
+
+class TestMethodCache < Test::Unit::TestCase
+  def test_undef
+    # clear same
+    c0 = Class.new do
+      def foo; end
+      undef foo
+    end
+
+    assert_raise(NoMethodError) do
+      c0.new.foo
+    end
+
+    c0.class_eval do
+      def foo; :ok; end
+    end
+
+    assert_equal :ok, c0.new.foo
+  end
+
+  def test_undef_with_subclasses
+    # with subclasses
+    c0 = Class.new do
+      def foo; end
+      undef foo
+    end
+
+    c1 = Class.new(c0)
+
+    assert_raise(NoMethodError) do
+      c0.new.foo
+    end
+
+    c0.class_eval do
+      def foo; :ok; end
+    end
+
+    assert_equal :ok, c0.new.foo
+  end
+
+  def test_undef_with_subclasses_complicated
+    c0 = Class.new{ def foo; end }
+    c1 = Class.new(c0){ undef foo }
+    c2 = Class.new(c1)
+    c3 = Class.new(c2)
+    c4 = Class.new(c3)
+
+    assert_raise(NoMethodError) do
+      c3.new.foo
+    end
+
+    c2.class_eval do
+      def foo; :c2; end
+    end
+
+    assert_raise(NoMethodError) do
+      c1.new.foo
+    end
+
+    assert_equal :c2, c3.new.foo
+  end
+end
+

--- a/thread.c
+++ b/thread.c
@@ -5671,6 +5671,8 @@ rb_resolve_me_location(const rb_method_entry_t *me, VALUE resolved_location[5])
 {
     VALUE path, beg_pos_lineno, beg_pos_column, end_pos_lineno, end_pos_column;
 
+    if (!me->def) return NULL; // negative cme
+
   retry:
     switch (me->def->type) {
       case VM_METHOD_TYPE_ISEQ: {

--- a/vm_core.h
+++ b/vm_core.h
@@ -649,6 +649,8 @@ typedef struct rb_vm_struct {
     const struct rb_builtin_function *builtin_function_table;
     int builtin_inline_index;
 
+    struct rb_id_table *negative_cme_table;
+
 #if USE_VM_CLOCK
     uint32_t clock;
 #endif

--- a/vm_method.c
+++ b/vm_method.c
@@ -198,6 +198,8 @@ clear_method_cache_by_id_in_class(VALUE klass, ID mid)
             if (rb_id_table_lookup(vm->negative_cme_table, mid, (VALUE *)&cme)) {
                 rb_id_table_delete(vm->negative_cme_table, mid);
                 vm_me_invalidate_cache((rb_callable_method_entry_t *)cme);
+
+                RB_DEBUG_COUNTER_INC(cc_invalidate_negative);
             }
         }
     }


### PR DESCRIPTION
pCMC doesn't have negative method cache so this patch  implements it.