### PR TITLE
Add documentation for Ractor

### DIFF
--- a/.document
+++ b/.document
@@ -20,6 +20,7 @@ kernel.rb
 pack.rb
 trace_point.rb
 warning.rb
+ractor.rb
 
 # the lib/ directory (which has its own .document file)
 lib

--- a/ractor.c
+++ b/ractor.c
@@ -2020,7 +2020,7 @@ ractor_moved_missing(int argc, VALUE *argv, VALUE self)
  */
 
 // Main docs are in ractor.rb, but without this clause there are weird artifacts
-// it their rendering.
+// in their rendering.
 /*
  *  Document-class: Ractor
  *

--- a/ractor.rb
+++ b/ractor.rb
@@ -70,8 +70,8 @@
 #     Server received: pong
 #
 # It is said that Ractor receives messages via the <em>incoming port</em>, and sends them
-# to the <em>outgoing port</em>. Either one can be disabled with Ractor.close_incoming and
-# Ractor.close_outgoing respectively.
+# to the <em>outgoing port</em>. Either one can be disabled with Ractor#close_incoming and
+# Ractor#close_outgoing respectively.
 #
 # == Shareable and unshareable objects
 #
@@ -157,8 +157,8 @@
 #     # I see C
 #     # can not access instance variables of classes/modules from non-main Ractors (RuntimeError)
 #
-# Ractors also can't access constants from the main scope, but only if their values are frozen, or
-# they are classes/modules (but again, not their instance variables):
+# Ractors can access constants if they are shareable. The main Ractor is the only one that can
+# access non-shareable constants.
 #
 #     GOOD = 'good'.freeze
 #     BAD = 'bad'
@@ -180,6 +180,9 @@
 #     r.take
 #     # I see C
 #     # can not access instance variables of classes/modules from non-main Ractors (RuntimeError)
+#
+# See also the description of <tt># shareable_constant_value</tt> pragma in
+# {Comments syntax}[rdoc-ref:doc/syntax/comments.rdoc] explanation.
 #
 # == Ractors vs threads
 #
@@ -267,7 +270,7 @@ class Ractor
 
   # call-seq: Ractor.select(*ractors, [yield_value:, move: false]) -> [ractor or symbol, obj]
   #
-  # Wait for the first ractor to have something in its outgoing port, reads from this ractor, and
+  # Waits for the first ractor to have something in its outgoing port, reads from this ractor, and
   # returns that ractor and the object received.
   #
   #    r1 = Ractor.new {Ractor.yield 'from 1'}
@@ -698,7 +701,7 @@ class Ractor
 
   # Checks if the object is shareable by ractors.
   #
-  #     Ractor.shareable?(1)            #=> true -- numbers and other immutable basic values are
+  #     Ractor.shareable?(1)            #=> true -- numbers and other immutable basic values are frozen
   #     Ractor.shareable?('foo')        #=> false, unless the string is frozen due to # freeze_string_literals: true
   #     Ractor.shareable?('foo'.freeze) #=> true
   #


### PR DESCRIPTION
Currently, ractors documented only by [doc/ractor.md](https://docs.ruby-lang.org/en/master/doc/ractor_md.html), which has a flavor of a design/discussion document. I wanted to establish some _base_ documentation, which will allow to understand and use the concept immediately. Currently, Ractor class [has no docs at all](https://docs.ruby-lang.org/en/master/Ractor.html) -- it is partially due to the fact that `ractor.rb` is not included in the `.document` list for RDoc, but even so, per-method [docs in ractor.rb](https://github.com/ruby/ruby/blob/master/ractor.rb) seem kinda sparse and chaotic to me.

I've completely rewritten the class docs. They are now somewhat duplicating `doc/ractor.md`, but from a different perspective.

Test rendering of the docs on my personal site: [Ractor.html](https://zverok.github.io/ruby-rdoc/Ractor.html)

@ko1 @marcandre @eregon Can you please review it?

And one question I couldn't clarify by myself: can somebody please show an example of the code throwing `Ractor::UnsafeError` and maybe provide some brief explanation about it?.. From the sources I kinda get the idea, but my knowledge is not deep enough.