### PR TITLE
fix inline method cache sync bug

### DIFF
--- a/debug_counter.h
+++ b/debug_counter.h
@@ -40,7 +40,8 @@ RB_DEBUG_COUNTER(ci_runtime) //           creating temporary CI
 // callcache
 RB_DEBUG_COUNTER(cc_new)        // number of CC
 RB_DEBUG_COUNTER(cc_temp)       //           dummy CC (stack-allocated)
-RB_DEBUG_COUNTER(cc_found_ccs)  // count for CC lookup success in CCS
+RB_DEBUG_COUNTER(cc_found_in_ccs)      // count for CC lookup success in CCS
+RB_DEBUG_COUNTER(cc_not_found_in_ccs)  // count for CC lookup success in CCS
 
 RB_DEBUG_COUNTER(cc_ent_invalidate) // count for invalidating cc (cc->klass = 0)
 RB_DEBUG_COUNTER(cc_cme_invalidate) // count for invalidating CME
@@ -57,6 +58,10 @@ RB_DEBUG_COUNTER(ccs_free)   // count for free'ing ccs
 RB_DEBUG_COUNTER(ccs_maxlen) // maximum length of ccs
 RB_DEBUG_COUNTER(ccs_found)      // count for finding corresponding ccs on method lookup
 RB_DEBUG_COUNTER(ccs_not_found)  // count for not found corresponding ccs on method lookup
+
+// vm_eval.c
+RB_DEBUG_COUNTER(call0_public)
+RB_DEBUG_COUNTER(call0_other)
 
 // iseq
 RB_DEBUG_COUNTER(iseq_num)    // number of total created iseq

--- a/insns.def
+++ b/insns.def
@@ -891,11 +891,6 @@ invokeblock
 // attr rb_snum_t sp_inc = sp_inc_of_invokeblock(cd->ci);
 // attr rb_snum_t comptime_sp_inc = sp_inc_of_invokeblock(ci);
 {
-    if (UNLIKELY(vm_cc_call(cd->cc) != vm_invokeblock_i)) {
-        const struct rb_callcache *cc = vm_cc_new(0, NULL, vm_invokeblock_i);
-        RB_OBJ_WRITE(GET_ISEQ(), &cd->cc, cc);
-    }
-
     VALUE bh = VM_BLOCK_HANDLER_NONE;
     val = vm_sendish(ec, GET_CFP(), cd, bh, vm_search_invokeblock);
 

--- a/internal/vm.h
+++ b/internal/vm.h
@@ -27,8 +27,7 @@ struct rb_callable_method_entry_struct; /* in method.h */
 struct rb_method_definition_struct;     /* in method.h */
 struct rb_execution_context_struct;     /* in vm_core.h */
 struct rb_control_frame_struct;         /* in vm_core.h */
-struct rb_calling_info;                 /* in vm_core.h */
-struct rb_call_data;
+struct rb_callinfo;                     /* in vm_core.h */
 
 enum method_missing_reason {
     MISSING_NOENTRY   = 0x00,
@@ -93,7 +92,7 @@ VALUE rb_eql_opt(VALUE obj1, VALUE obj2);
 
 struct rb_iseq_struct;
 MJIT_SYMBOL_EXPORT_BEGIN
-void rb_vm_search_method_slowpath(VALUE cd_owner, struct rb_call_data *cd, VALUE klass);
+const struct rb_callcache *rb_vm_search_method_slowpath(const struct rb_callinfo *ci, VALUE klass);
 MJIT_SYMBOL_EXPORT_END
 
 /* vm_method.c */

--- a/template/call_iseq_optimized.inc.tmpl
+++ b/template/call_iseq_optimized.inc.tmpl
@@ -16,10 +16,10 @@
 % P.each{|param|
 %   L.each{|local|
 static VALUE
-<%= fname(param, local) %>(rb_execution_context_t *ec, rb_control_frame_t *cfp, struct rb_calling_info *calling, struct rb_call_data *cd)
+<%= fname(param, local) %>(rb_execution_context_t *ec, rb_control_frame_t *cfp, struct rb_calling_info *calling)
 {
     RB_DEBUG_COUNTER_INC(ccf_iseq_fix);
-    return vm_call_iseq_setup_normal(ec, cfp, calling, vm_cc_cme(cd->cc), 0, <%= param %>, <%= local %>);
+    return vm_call_iseq_setup_normal(ec, cfp, calling, vm_cc_cme(calling->cc), 0, <%= param %>, <%= local %>);
 }
 
 %   }

--- a/tool/ruby_vm/views/_mjit_compile_send.erb
+++ b/tool/ruby_vm/views/_mjit_compile_send.erb
@@ -76,8 +76,9 @@
 
             if (vm_cc_cme(captured_cc)->def->type == VM_METHOD_TYPE_CFUNC) {
 %               # TODO: optimize this more
-                fprintf(f, "        struct rb_call_data cc_cd = { .ci = (CALL_INFO)0x%"PRIxVALUE", .cc = cc };\n", (VALUE)ci); // creating local cd here because operand's cd->cc may not be the same as inlined cc.
-                fprintf(f, "        val = vm_call_cfunc_with_frame(ec, reg_cfp, &calling, &cc_cd);\n");
+                fprintf(f, "        calling.ci = (CALL_INFO)0x%"PRIxVALUE";\n", (VALUE)ci); // creating local cd here because operand's cd->cc may not be the same as inlined cc.
+                fprintf(f, "        calling.cc = cc;");
+                fprintf(f, "        val = vm_call_cfunc_with_frame(ec, reg_cfp, &calling);\n");
             }
             else { // VM_METHOD_TYPE_ISEQ
 %               # fastpath_applied_iseq_p checks rb_simple_iseq_p, which ensures has_opt == FALSE

--- a/vm_callinfo.h
+++ b/vm_callinfo.h
@@ -267,8 +267,7 @@ vm_ci_markable(const struct rb_callinfo *ci)
 typedef VALUE (*vm_call_handler)(
     struct rb_execution_context_struct *ec,
     struct rb_control_frame_struct *cfp,
-    struct rb_calling_info *calling,
-    struct rb_call_data *cd);
+    struct rb_calling_info *calling);
 
 // imemo_callcache
 

--- a/vm_core.h
+++ b/vm_core.h
@@ -238,6 +238,8 @@ union iseq_inline_storage_entry {
 };
 
 struct rb_calling_info {
+    const struct rb_callinfo *ci;
+    const struct rb_callcache *cc;
     VALUE block_handler;
     VALUE recv;
     int argc;

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -345,9 +345,11 @@ rb_call0(rb_execution_context_t *ec,
     }
 
     if (scope == CALL_PUBLIC) {
+        RB_DEBUG_COUNTER_INC(call0_public);
         me = rb_callable_method_entry_with_refinements(CLASS_OF(recv), mid, NULL);
     }
     else {
+        RB_DEBUG_COUNTER_INC(call0_other);
         me = rb_search_method_entry(recv, mid);
     }
     call_status = rb_method_call_status(ec, me, scope, self);


### PR DESCRIPTION
`cd` is passed to method call functions to method invocation
functions, but `cd` can be manipulated by other ractors simultaneously
so it contains thread-safety issue.

To solve this issue, this patch stores `ci` and found `cc` to `calling`
and stops to pass `cd`.