### PR TITLE
tuning ivar set

### DIFF
--- a/internal/variable.h
+++ b/internal/variable.h
@@ -52,7 +52,7 @@ VALUE rb_gvar_get(ID);
 VALUE rb_gvar_set(ID, VALUE);
 VALUE rb_gvar_defined(ID);
 void rb_const_warn_if_deprecated(const rb_const_entry_t *, VALUE, ID);
-void rb_init_iv_list(VALUE obj, uint32_t len, uint32_t newsize, st_table * index_tbl);
+void rb_init_iv_list(VALUE obj);
 MJIT_SYMBOL_EXPORT_END
 
 static inline bool

--- a/variable.c
+++ b/variable.c
@@ -1413,8 +1413,8 @@ rb_obj_transient_heap_evacuate(VALUE obj, int promote)
 }
 #endif
 
-void
-rb_init_iv_list(VALUE obj, uint32_t len, uint32_t newsize, st_table * index_tbl)
+static void
+init_iv_list(VALUE obj, uint32_t len, uint32_t newsize, st_table *index_tbl)
 {
     VALUE *ptr = ROBJECT_IVPTR(obj);
     VALUE *newptr;
@@ -1435,6 +1435,15 @@ rb_init_iv_list(VALUE obj, uint32_t len, uint32_t newsize, st_table * index_tbl)
     ROBJECT(obj)->as.heap.iv_index_tbl = index_tbl;
 }
 
+void
+rb_init_iv_list(VALUE obj)
+{
+    st_table *index_tbl = ROBJECT_IV_INDEX_TBL(obj);
+    uint32_t newsize = (uint32_t)index_tbl->num_entries;
+    uint32_t len = ROBJECT_NUMIV(obj);
+    init_iv_list(obj, len, newsize, index_tbl);
+}
+
 static VALUE
 obj_ivar_set(VALUE obj, ID id, VALUE val)
 {
@@ -1453,7 +1462,7 @@ obj_ivar_set(VALUE obj, ID id, VALUE val)
     len = ROBJECT_NUMIV(obj);
     if (len <= ivup.index) {
         uint32_t newsize = iv_index_tbl_newsize(&ivup);
-        rb_init_iv_list(obj, len, newsize, ivup.u.iv_index_tbl);
+        init_iv_list(obj, len, newsize, ivup.u.iv_index_tbl);
     }
     RB_OBJ_WRITE(obj, &ROBJECT_IVPTR(obj)[ivup.index], val);
 


### PR DESCRIPTION
* make rb_init_iv_list() simple
* introduce vm_setivar_slowpath() for cache miss cases

../clean/miniruby is 647ee6f091.
```
Calculating -------------------------------------
                      ./miniruby  ../clean/miniruby  ../ruby_2_7/miniruby
         vm_ivar_init     7.388M             6.814M                5.771M i/s -     30.000M times in 4.060420s 4.402534s 5.198781s
vm_ivar_init_subclass     2.158M             2.147M                1.974M i/s -      3.000M times in 1.390328s 1.397587s 1.519951s
          vm_ivar_set   128.607M            97.931M              140.668M i/s -     30.000M times in 0.233269s 0.306338s 0.213268s
              vm_ivar   144.315M           151.722M              117.734M i/s -     30.000M times in 0.207879s 0.197730s 0.254811s

Comparison:
                      vm_ivar_init
           ./miniruby:   7388398.8 i/s
    ../clean/miniruby:   6814257.1 i/s - 1.08x  slower
 ../ruby_2_7/miniruby:   5770583.9 i/s - 1.28x  slower

             vm_ivar_init_subclass
           ./miniruby:   2157763.6 i/s
    ../clean/miniruby:   2146557.0 i/s - 1.01x  slower
 ../ruby_2_7/miniruby:   1973747.9 i/s - 1.09x  slower

                       vm_ivar_set
 ../ruby_2_7/miniruby: 140668063.8 i/s
           ./miniruby: 128606912.1 i/s - 1.09x  slower
    ../clean/miniruby:  97931027.8 i/s - 1.44x  slower

                           vm_ivar
    ../clean/miniruby: 151722121.9 i/s
           ./miniruby: 144314526.5 i/s - 1.05x  slower
 ../ruby_2_7/miniruby: 117734305.5 i/s - 1.29x  slower
```
