### PR TITLE
No sync on ASCII/US_ASCCII/UTF-8

### DIFF
--- a/encoding.c
+++ b/encoding.c
@@ -418,9 +418,16 @@ rb_encoding *
 rb_enc_from_index(int index)
 {
     rb_encoding *enc;
-    GLOBAL_ENC_TABLE_EVAL(enc_table,
-                          enc = enc_from_index(enc_table, index));
-    return enc;
+
+    switch (index) {
+      case ENCINDEX_ASCII:    return global_enc_ascii;
+      case ENCINDEX_UTF_8:    return global_enc_utf_8;
+      case ENCINDEX_US_ASCII: return global_enc_us_ascii;
+      default:
+        GLOBAL_ENC_TABLE_EVAL(enc_table,
+                              enc = enc_from_index(enc_table, index));
+        return enc;
+    }
 }
 
 int


### PR DESCRIPTION
rb_enc_from_index(index) doesn't need locking if index specify
ASCII/US_ASCCII/UTF-8.
rb_enc_from_index() is called frequently so it has impact.

```
                               user     system      total        real
r_parallel/miniruby       174  0.000209   0.000000   5.559872 (  1.811501)
r_parallel/master_mini    175  0.000238   0.000000  12.664707 (  3.523641)
```
(left-side number is GC counts)
(repeat x1000 `s.split(/,/)` where s = '0,,' * 1000)