### PR TITLE
Switch rb_category_warn{,ing} API and use :deprecated/:experimental warning categories

### DIFF
--- a/array.c
+++ b/array.c
@@ -2835,7 +2835,7 @@ rb_ary_join_m(int argc, VALUE *argv, VALUE ary)
     if (rb_check_arity(argc, 0, 1) == 0 || NIL_P(sep = argv[0])) {
         sep = rb_output_fs;
         if (!NIL_P(sep)) {
-            rb_warn("$, is set to non-nil value");
+            rb_category_warn(RB_WARN_CATEGORY_DEPRECATED, "$, is set to non-nil value");
         }
     }
 

--- a/error.c
+++ b/error.c
@@ -77,6 +77,7 @@ static ID id_deprecated;
 static ID id_experimental;
 static VALUE sym_category;
 static VALUE warning_categories;
+static VALUE warning_category_t_map;
 
 extern const char ruby_description[];
 
@@ -403,11 +404,11 @@ rb_warn(const char *fmt, ...)
 }
 
 void
-rb_category_warn(const char *category, const char *fmt, ...)
+rb_category_warn(rb_warning_category_t category, const char *fmt, ...)
 {
     if (!NIL_P(ruby_verbose)) {
         with_warning_string(mesg, 0, fmt) {
-            rb_warn_category(mesg, ID2SYM(rb_intern(category)));
+            rb_warn_category(mesg, rb_hash_fetch(warning_category_t_map, INT2NUM(category)));
         }
     }
 }
@@ -435,11 +436,11 @@ rb_warning(const char *fmt, ...)
 
 /* rb_category_warning() reports only in verbose mode */
 void
-rb_category_warning(const char *category, const char *fmt, ...)
+rb_category_warning(rb_warning_category_t category, const char *fmt, ...)
 {
     if (RTEST(ruby_verbose)) {
         with_warning_string(mesg, 0, fmt) {
-            rb_warn_category(mesg, ID2SYM(rb_intern(category)));
+            rb_warn_category(mesg, rb_hash_fetch(warning_category_t_map, INT2NUM(category)));
         }
     }
 }
@@ -2839,6 +2840,13 @@ Init_Exception(void)
     rb_gc_register_mark_object(warning_categories);
     rb_hash_aset(warning_categories, ID2SYM(rb_intern_const("deprecated")), Qtrue);
     rb_obj_freeze(warning_categories);
+
+    warning_category_t_map = rb_hash_new();
+    rb_gc_register_mark_object(warning_category_t_map);
+    rb_hash_aset(warning_category_t_map, INT2NUM(RB_WARN_CATEGORY_NONE), Qnil);
+    rb_hash_aset(warning_category_t_map, INT2NUM(RB_WARN_CATEGORY_DEPRECATED), ID2SYM(rb_intern_const("deprecated")));
+    rb_hash_aset(warning_category_t_map, INT2NUM(RB_WARN_CATEGORY_EXPERIMENTAL), ID2SYM(rb_intern_const("experimental")));
+    rb_obj_freeze(warning_category_t_map);
 }
 
 void

--- a/error.c
+++ b/error.c
@@ -375,6 +375,20 @@ rb_compile_warning(const char *file, int line, const char *fmt, ...)
     rb_write_warning_str(str);
 }
 
+void
+rb_category_compile_warn(rb_warning_category_t category, const char *file, int line, const char *fmt, ...)
+{
+    VALUE str;
+    va_list args;
+
+    if (NIL_P(ruby_verbose)) return;
+
+    va_start(args, fmt);
+    str = warn_vsprintf(NULL, file, line, fmt, args);
+    va_end(args);
+    rb_warn_category(str, rb_hash_fetch(warning_category_t_map, INT2NUM(category)));
+}
+
 static VALUE
 warning_string(rb_encoding *enc, const char *fmt, va_list args)
 {

--- a/include/ruby/internal/error.h
+++ b/include/ruby/internal/error.h
@@ -70,12 +70,13 @@ VALUE *rb_ruby_debug_ptr(void);
 
 /* reports if `-W' specified */
 PRINTF_ARGS(void rb_warning(const char*, ...), 1, 2);
-PRINTF_ARGS(void rb_category_warning(rb_warning_category_t category, const char*, ...), 2, 3);
+PRINTF_ARGS(void rb_category_warning(rb_warning_category_t, const char*, ...), 2, 3);
 PRINTF_ARGS(void rb_compile_warning(const char *, int, const char*, ...), 3, 4);
+PRINTF_ARGS(void rb_category_compile_warn(rb_warning_category_t, const char *, int, const char*, ...), 4, 5);
 PRINTF_ARGS(void rb_sys_warning(const char*, ...), 1, 2);
 /* reports always */
 COLDFUNC PRINTF_ARGS(void rb_warn(const char*, ...), 1, 2);
-COLDFUNC PRINTF_ARGS(void rb_category_warn(rb_warning_category_t category, const char*, ...), 2, 3);
+COLDFUNC PRINTF_ARGS(void rb_category_warn(rb_warning_category_t, const char*, ...), 2, 3);
 PRINTF_ARGS(void rb_compile_warn(const char *, int, const char*, ...), 3, 4);
 
 RBIMPL_SYMBOL_EXPORT_END()

--- a/include/ruby/internal/error.h
+++ b/include/ruby/internal/error.h
@@ -29,6 +29,13 @@ RBIMPL_SYMBOL_EXPORT_BEGIN()
 VALUE rb_errinfo(void);
 void rb_set_errinfo(VALUE);
 
+typedef enum {
+    RB_WARN_CATEGORY_NONE,
+    RB_WARN_CATEGORY_DEPRECATED,
+    RB_WARN_CATEGORY_EXPERIMENTAL,
+    RB_WARN_CATEGORY_ALL_BITS = 0x6 /* no RB_WARN_CATEGORY_NONE bit */
+} rb_warning_category_t;
+
 /* for rb_readwrite_sys_fail first argument */
 enum rb_io_wait_readwrite {RB_IO_WAIT_READABLE, RB_IO_WAIT_WRITABLE};
 #define RB_IO_WAIT_READABLE RB_IO_WAIT_READABLE
@@ -63,12 +70,12 @@ VALUE *rb_ruby_debug_ptr(void);
 
 /* reports if `-W' specified */
 PRINTF_ARGS(void rb_warning(const char*, ...), 1, 2);
-PRINTF_ARGS(void rb_category_warning(const char*, const char*, ...), 2, 3);
+PRINTF_ARGS(void rb_category_warning(rb_warning_category_t category, const char*, ...), 2, 3);
 PRINTF_ARGS(void rb_compile_warning(const char *, int, const char*, ...), 3, 4);
 PRINTF_ARGS(void rb_sys_warning(const char*, ...), 1, 2);
 /* reports always */
 COLDFUNC PRINTF_ARGS(void rb_warn(const char*, ...), 1, 2);
-COLDFUNC PRINTF_ARGS(void rb_category_warn(const char *, const char*, ...), 2, 3);
+COLDFUNC PRINTF_ARGS(void rb_category_warn(rb_warning_category_t category, const char*, ...), 2, 3);
 PRINTF_ARGS(void rb_compile_warn(const char *, int, const char*, ...), 3, 4);
 
 RBIMPL_SYMBOL_EXPORT_END()

--- a/internal/error.h
+++ b/internal/error.h
@@ -40,13 +40,6 @@
 #endif
 
 /* error.c */
-typedef enum {
-    RB_WARN_CATEGORY_NONE,
-    RB_WARN_CATEGORY_DEPRECATED,
-    RB_WARN_CATEGORY_EXPERIMENTAL,
-    RB_WARN_CATEGORY_ALL_BITS = 0x6, /* no RB_WARN_CATEGORY_NONE bit */
-} rb_warning_category_t;
-
 extern long rb_backtrace_length_limit;
 extern VALUE rb_eEAGAIN;
 extern VALUE rb_eEWOULDBLOCK;

--- a/io.c
+++ b/io.c
@@ -1956,7 +1956,7 @@ rb_io_writev(VALUE io, int argc, const VALUE *argv)
 	if (io != rb_ractor_stderr() && RTEST(ruby_verbose)) {
 	    VALUE klass = CLASS_OF(io);
 	    char sep = FL_TEST(klass, FL_SINGLETON) ? (klass = io, '.') : '#';
-	    rb_warning("%+"PRIsVALUE"%c""write is outdated interface"
+            rb_category_warning(RB_WARN_CATEGORY_DEPRECATED, "%+"PRIsVALUE"%c""write is outdated interface"
 		       " which accepts just one argument",
 		       klass, sep);
 	}
@@ -7717,7 +7717,7 @@ rb_io_print(int argc, const VALUE *argv, VALUE out)
 	argv = &line;
     }
     if (argc > 1 && !NIL_P(rb_output_fs)) {
-        rb_warn("$, is set to non-nil value");
+        rb_category_warn(RB_WARN_CATEGORY_DEPRECATED, "$, is set to non-nil value");
     }
     for (i=0; i<argc; i++) {
 	if (!NIL_P(rb_output_fs) && i>0) {
@@ -10238,7 +10238,8 @@ rb_f_syscall(int argc, VALUE *argv, VALUE _)
     int i;
 
     if (RTEST(ruby_verbose)) {
-	rb_warning("We plan to remove a syscall function at future release. DL(Fiddle) provides safer alternative.");
+        rb_category_warning(RB_WARN_CATEGORY_DEPRECATED,
+            "We plan to remove a syscall function at future release. DL(Fiddle) provides safer alternative.");
     }
 
     if (argc == 0)

--- a/object.c
+++ b/object.c
@@ -1590,7 +1590,7 @@ static VALUE
 rb_obj_match(VALUE obj1, VALUE obj2)
 {
     if (rb_warning_category_enabled_p(RB_WARN_CATEGORY_DEPRECATED)) {
-        rb_warn("deprecated Object#=~ is called on %"PRIsVALUE
+        rb_category_warn(RB_WARN_CATEGORY_DEPRECATED, "deprecated Object#=~ is called on %"PRIsVALUE
                 "; it always returns nil", rb_obj_class(obj1));
     }
     return Qnil;
@@ -2295,7 +2295,7 @@ VALUE
 rb_mod_attr(int argc, VALUE *argv, VALUE klass)
 {
     if (argc == 2 && (argv[1] == Qtrue || argv[1] == Qfalse)) {
-	rb_warning("optional boolean argument is obsoleted");
+        rb_category_warning(RB_WARN_CATEGORY_DEPRECATED, "optional boolean argument is obsoleted");
 	rb_attr(klass, id_for_attr(klass, argv[0]), 1, RTEST(argv[1]), TRUE);
 	return Qnil;
     }

--- a/parse.y
+++ b/parse.y
@@ -1034,6 +1034,7 @@ static ID id_warn, id_warning, id_gets, id_assoc;
 # define WARN_ID(i) rb_id2str(i)
 # define WARN_IVAL(i) i
 # define PRIsWARN "s"
+# define rb_warn0L_experimental(l,fmt)         WARN_CALL(WARN_ARGS_L(l, fmt, 1))
 # define WARN_ARGS(fmt,n) p->value, id_warn, n, rb_usascii_str_new_lit(fmt)
 # define WARN_ARGS_L(l,fmt,n) WARN_ARGS(fmt,n)
 # ifdef HAVE_VA_ARGS_MACRO
@@ -1060,6 +1061,7 @@ PRINTF_ARGS(static void ripper_compile_error(struct parser_params*, const char *
 # define WARN_ARGS(fmt,n) WARN_ARGS_L(p->ruby_sourceline,fmt,n)
 # define WARN_ARGS_L(l,fmt,n) p->ruby_sourcefile, (l), (fmt)
 # define WARN_CALL rb_compile_warn
+# define rb_warn0L_experimental(l,fmt) rb_category_compile_warn(RB_WARN_CATEGORY_EXPERIMENTAL, WARN_ARGS_L(l, fmt, 1))
 # define WARNING_ARGS(fmt,n) WARN_ARGS(fmt,n)
 # define WARNING_ARGS_L(l,fmt,n) WARN_ARGS_L(l,fmt,n)
 # define WARNING_CALL rb_compile_warning
@@ -4229,7 +4231,7 @@ p_find		: p_rest ',' p_args_post ',' p_rest
 			$$ = new_find_pattern_tail(p, $1, $3, $5, &@$);
 
 			if (rb_warning_category_enabled_p(RB_WARN_CATEGORY_EXPERIMENTAL))
-			    rb_warn0L(nd_line($$), "Find pattern is experimental, and the behavior may change in future versions of Ruby!");
+			    rb_warn0L_experimental(nd_line($$), "Find pattern is experimental, and the behavior may change in future versions of Ruby!");
 		    }
 		;
 
@@ -11955,7 +11957,7 @@ warn_one_line_pattern_matching(struct parser_params *p, NODE *node, NODE *patter
 
     if (rb_warning_category_enabled_p(RB_WARN_CATEGORY_EXPERIMENTAL) &&
 	!(right_assign && (type == NODE_LASGN || type == NODE_DASGN || type == NODE_DASGN_CURR)))
-	rb_warn0L(nd_line(node), "One-line pattern matching is experimental, and the behavior may change in future versions of Ruby!");
+	rb_warn0L_experimental(nd_line(node), "One-line pattern matching is experimental, and the behavior may change in future versions of Ruby!");
 }
 
 static NODE*

--- a/ractor.c
+++ b/ractor.c
@@ -1394,8 +1394,9 @@ cancel_single_ractor_mode(void)
     rb_transient_heap_evacuate();
 
     if (rb_warning_category_enabled_p(RB_WARN_CATEGORY_EXPERIMENTAL)) {
-        rb_warn("Ractor is experimental, and the behavior may change in future versions of Ruby! "
-                "Also there are many implementation issues.");
+        rb_category_warn(RB_WARN_CATEGORY_EXPERIMENTAL,
+                         "Ractor is experimental, and the behavior may change in future versions of Ruby! "
+                         "Also there are many implementation issues.");
     }
 
     ruby_single_main_ractor = NULL;

--- a/re.c
+++ b/re.c
@@ -3467,7 +3467,7 @@ rb_reg_initialize_m(int argc, VALUE *argv, VALUE self)
 		flags |= ARG_ENCODING_NONE;
 	    }
 	    else {
-		rb_warn("encoding option is ignored - %s", kcode);
+                rb_category_warn(RB_WARN_CATEGORY_DEPRECATED, "encoding option is ignored - %s", kcode);
 	    }
 	}
 	str = StringValue(argv[0]);
@@ -3922,14 +3922,14 @@ rb_reg_regsub(VALUE str, VALUE src, struct re_registers *regs, VALUE regexp)
 static VALUE
 ignorecase_getter(ID _x, VALUE *_y)
 {
-    rb_warn("variable $= is no longer effective");
+    rb_category_warn(RB_WARN_CATEGORY_DEPRECATED, "variable $= is no longer effective");
     return Qfalse;
 }
 
 static void
 ignorecase_setter(VALUE val, ID id, VALUE *_)
 {
-    rb_warn("variable $= is no longer effective; ignored");
+    rb_category_warn(RB_WARN_CATEGORY_DEPRECATED, "variable $= is no longer effective; ignored");
 }
 
 static VALUE

--- a/ruby.c
+++ b/ruby.c
@@ -1747,7 +1747,10 @@ process_options(int argc, char **argv, ruby_cmdline_options_t *opt)
     }
 
     if (opt->src.enc.name)
-	rb_warning("-K is specified; it is for 1.8 compatibility and may cause odd behavior");
+        /* cannot set deprecated category, as enabling deprecation warnings based on flags
+         * has not happened yet.
+         */
+        rb_warning("-K is specified; it is for 1.8 compatibility and may cause odd behavior");
 
 #if USE_MJIT
     if (opt->features.set & FEATURE_BIT(jit)) {

--- a/string.c
+++ b/string.c
@@ -8187,7 +8187,7 @@ rb_str_split_m(int argc, VALUE *argv, VALUE str)
 	rb_raise(rb_eTypeError, "value of $; must be String or Regexp");
     }
     else {
-        rb_warn("$; is set to non-nil value");
+        rb_category_warn(RB_WARN_CATEGORY_DEPRECATED, "$; is set to non-nil value");
     }
     if (split_type != SPLIT_TYPE_AWK) {
         switch (BUILTIN_TYPE(spat)) {
@@ -8413,7 +8413,7 @@ get_rs(void)
 	(!RB_TYPE_P(rs, T_STRING) ||
 	 RSTRING_LEN(rs) != 1 ||
 	 RSTRING_PTR(rs)[0] != '\n')) {
-        rb_warn("$/ is set to non-default value");
+        rb_category_warn(RB_WARN_CATEGORY_DEPRECATED, "$/ is set to non-default value");
     }
     return rs;
 }

--- a/test/ruby/test_array.rb
+++ b/test/ruby/test_array.rb
@@ -1112,40 +1112,40 @@ class TestArray < Test::Unit::TestCase
   def test_join
     assert_deprecated_warning {$, = ""}
     a = @cls[]
-    assert_equal("", assert_warn(/non-nil value/) {a.join})
+    assert_equal("", assert_deprecated_warn(/non-nil value/) {a.join})
     assert_equal("", a.join(','))
-    assert_equal(Encoding::US_ASCII, assert_warn(/non-nil value/) {a.join}.encoding)
+    assert_equal(Encoding::US_ASCII, assert_deprecated_warn(/non-nil value/) {a.join}.encoding)
 
     assert_deprecated_warning {$, = ""}
     a = @cls[1, 2]
-    assert_equal("12", assert_warn(/non-nil value/) {a.join})
-    assert_equal("12", assert_warn(/non-nil value/) {a.join(nil)})
+    assert_equal("12", assert_deprecated_warn(/non-nil value/) {a.join})
+    assert_equal("12", assert_deprecated_warn(/non-nil value/) {a.join(nil)})
     assert_equal("1,2", a.join(','))
 
     assert_deprecated_warning {$, = ""}
     a = @cls[1, 2, 3]
-    assert_equal("123", assert_warn(/non-nil value/) {a.join})
-    assert_equal("123", assert_warn(/non-nil value/) {a.join(nil)})
+    assert_equal("123", assert_deprecated_warn(/non-nil value/) {a.join})
+    assert_equal("123", assert_deprecated_warn(/non-nil value/) {a.join(nil)})
     assert_equal("1,2,3", a.join(','))
 
     assert_deprecated_warning {$, = ":"}
     a = @cls[1, 2, 3]
-    assert_equal("1:2:3", assert_warn(/non-nil value/) {a.join})
-    assert_equal("1:2:3", assert_warn(/non-nil value/) {a.join(nil)})
+    assert_equal("1:2:3", assert_deprecated_warn(/non-nil value/) {a.join})
+    assert_equal("1:2:3", assert_deprecated_warn(/non-nil value/) {a.join(nil)})
     assert_equal("1,2,3", a.join(','))
 
     assert_deprecated_warning {$, = ""}
 
     e = ''.force_encoding('EUC-JP')
     u = ''.force_encoding('UTF-8')
-    assert_equal(Encoding::US_ASCII, assert_warn(/non-nil value/) {[[]].join}.encoding)
-    assert_equal(Encoding::US_ASCII, assert_warn(/non-nil value/) {[1, [u]].join}.encoding)
-    assert_equal(Encoding::UTF_8, assert_warn(/non-nil value/) {[u, [e]].join}.encoding)
-    assert_equal(Encoding::UTF_8, assert_warn(/non-nil value/) {[u, [1]].join}.encoding)
-    assert_equal(Encoding::UTF_8, assert_warn(/non-nil value/) {[Struct.new(:to_str).new(u)].join}.encoding)
+    assert_equal(Encoding::US_ASCII, assert_deprecated_warn(/non-nil value/) {[[]].join}.encoding)
+    assert_equal(Encoding::US_ASCII, assert_deprecated_warn(/non-nil value/) {[1, [u]].join}.encoding)
+    assert_equal(Encoding::UTF_8, assert_deprecated_warn(/non-nil value/) {[u, [e]].join}.encoding)
+    assert_equal(Encoding::UTF_8, assert_deprecated_warn(/non-nil value/) {[u, [1]].join}.encoding)
+    assert_equal(Encoding::UTF_8, assert_deprecated_warn(/non-nil value/) {[Struct.new(:to_str).new(u)].join}.encoding)
     bug5379 = '[ruby-core:39776]'
-    assert_equal(Encoding::US_ASCII, assert_warn(/non-nil value/) {[[], u, nil].join}.encoding, bug5379)
-    assert_equal(Encoding::UTF_8, assert_warn(/non-nil value/) {[[], "\u3042", nil].join}.encoding, bug5379)
+    assert_equal(Encoding::US_ASCII, assert_deprecated_warn(/non-nil value/) {[[], u, nil].join}.encoding, bug5379)
+    assert_equal(Encoding::UTF_8, assert_deprecated_warn(/non-nil value/) {[[], "\u3042", nil].join}.encoding, bug5379)
   ensure
     $, = nil
   end

--- a/test/ruby/test_io.rb
+++ b/test/ruby/test_io.rb
@@ -2621,7 +2621,7 @@ class TestIO < Test::Unit::TestCase
     end
 
     capture.clear
-    assert_warning(/[.#]write is outdated/) do
+    assert_deprecated_warning(/[.#]write is outdated/) do
       stdout, $stdout = $stdout, capture
       puts "hey"
     ensure

--- a/test/ruby/test_module.rb
+++ b/test/ruby/test_module.rb
@@ -906,10 +906,10 @@ class TestModule < Test::Unit::TestCase
         @foo = :foo
         @bar = :bar
       end
-      assert_warning(/optional boolean argument/) do
+      assert_deprecated_warning(/optional boolean argument/) do
         attr :foo, true
       end
-      assert_warning(/optional boolean argument/) do
+      assert_deprecated_warning(/optional boolean argument/) do
         attr :bar, false
       end
     end

--- a/test/ruby/test_regexp.rb
+++ b/test/ruby/test_regexp.rb
@@ -42,7 +42,7 @@ class TestRegexp < Test::Unit::TestCase
 
   def test_yoshidam_net_20041111_1
     s = "[\xC2\xA0-\xC3\xBE]"
-    r = assert_warning(/ignored/) {Regexp.new(s, nil, "u")}
+    r = assert_deprecated_warning(/ignored/) {Regexp.new(s, nil, "u")}
     assert_match(r, "\xC3\xBE")
   end
 
@@ -665,9 +665,9 @@ class TestRegexp < Test::Unit::TestCase
   end
 
   def test_ignorecase
-    v = assert_warning(/variable \$= is no longer effective/) { $= }
+    v = assert_deprecated_warning(/variable \$= is no longer effective/) { $= }
     assert_equal(false, v)
-    assert_warning(/variable \$= is no longer effective; ignored/) { $= = nil }
+    assert_deprecated_warning(/variable \$= is no longer effective; ignored/) { $= = nil }
   end
 
   def test_match_setter

--- a/tool/lib/test/unit/core_assertions.rb
+++ b/tool/lib/test/unit/core_assertions.rb
@@ -594,6 +594,13 @@ eom
         end
       end
 
+      def assert_deprecated_warn(mesg = /deprecated/)
+        assert_warn(mesg) do
+          Warning[:deprecated] = true
+          yield
+        end
+      end
+
       class << (AssertFile = Struct.new(:failure_message).new)
         include CoreAssertions
         def assert_file_predicate(predicate, *args)

--- a/variable.c
+++ b/variable.c
@@ -2530,10 +2530,10 @@ rb_const_warn_if_deprecated(const rb_const_entry_t *ce, VALUE klass, ID id)
     if (RB_CONST_DEPRECATED_P(ce) &&
         rb_warning_category_enabled_p(RB_WARN_CATEGORY_DEPRECATED)) {
 	if (klass == rb_cObject) {
-	    rb_warn("constant ::%"PRIsVALUE" is deprecated", QUOTE_ID(id));
+            rb_category_warn(RB_WARN_CATEGORY_DEPRECATED, "constant ::%"PRIsVALUE" is deprecated", QUOTE_ID(id));
 	}
 	else {
-	    rb_warn("constant %"PRIsVALUE"::%"PRIsVALUE" is deprecated",
+            rb_category_warn(RB_WARN_CATEGORY_DEPRECATED, "constant %"PRIsVALUE"::%"PRIsVALUE" is deprecated",
 		    rb_class_name(klass), QUOTE_ID(id));
 	}
     }

--- a/vm_method.c
+++ b/vm_method.c
@@ -2450,7 +2450,8 @@ vm_respond_to(rb_execution_context_t *ec, VALUE klass, VALUE obj, ID id, int pri
 	    }
 	    else if (!NIL_P(ruby_verbose)) {
 		VALUE location = rb_method_entry_location((const rb_method_entry_t *)cme);
-		rb_warn("%"PRIsVALUE"%c""respond_to?(:%"PRIsVALUE") uses"
+                rb_category_warn(RB_WARN_CATEGORY_DEPRECATED,
+                        "%"PRIsVALUE"%c""respond_to?(:%"PRIsVALUE") uses"
 			" the deprecated method signature, which takes one parameter",
 			(FL_TEST(klass, FL_SINGLETON) ? obj : klass),
 			(FL_TEST(klass, FL_SINGLETON) ? '.' : '#'),

--- a/warning.rb
+++ b/warning.rb
@@ -39,9 +39,14 @@ module Kernel
   #
   #    baz.rb:6: warning: invalid call to foo
   #
-  # If the +category+ keyword argument is given, it is passed to
-  # Warning.warn method.
+  # If <code>category</code> keyword argument is given, passes the category
+  # to <code>Warning.warn</code>.  The category given must be be one of the
+  # following categories:
   #
+  # :deprecated :: Used for warning for deprecated functionality that may
+  #                be removed in the future.
+  # :experimental :: Used for experimental features that may change in
+  #                  future releases.
   def warn(*msgs, uplevel: nil, category: nil)
     Primitive.rb_warn_m(msgs, uplevel, category)
   end


### PR DESCRIPTION
Switch rb_category_warn{,ing} to accept an rb_warning_category_t

Since we decided to only allowing specific warning categories,
there is no reason to have an API that accepts a general string,
as it is more error-prone.  Switch to only allowing the specific
warning categories.
    
As rb_category_warn{,ing} are public API, this requires making
rb_warning_category_t public API as well.

Make warning_categories a map of category symbols to category numbers
    
Use this to simplify rb_warning_category_from_name.
    
This also adds support for using the :experimental category in
Kernel#warn and Warning.warn.

Use category: :deprecated and :experimental in warnings that are related
to deprecation. Also document that both :deprecated and :experimental
are supported :category option values.
    
The locations where warnings were marked as deprecation warnings
was previously reviewed by shyouhei.
    
Comment a couple locations where deprecation warnings should probably
be used but are not currently used because deprecation warning
enablement has not occurred at the time they are called
(RUBY_FREE_MIN, RUBY_HEAP_MIN_SLOTS, -K).

This adds rb_category_compile_warn in order to emit compiler warnings
with categories.  Note that Ripper currently ignores the category
for these warnings, but by default it ignores the warnings completely,
so this shouldn't matter.