### PR TITLE
test/ruby: Check warning messages at a finer granularity

### DIFF
--- a/test/ruby/test_array.rb
+++ b/test/ruby/test_array.rb
@@ -7,7 +7,6 @@ require "rbconfig/sizeof"
 class TestArray < Test::Unit::TestCase
   def setup
     @verbose = $VERBOSE
-    $VERBOSE = nil
     @cls = Array
   end
 
@@ -662,7 +661,7 @@ class TestArray < Test::Unit::TestCase
     assert_equal(5, a.count)
     assert_equal(2, a.count(1))
     assert_equal(3, a.count {|x| x % 2 == 1 })
-    assert_equal(2, a.count(1) {|x| x % 2 == 1 })
+    assert_equal(2, assert_warning(/given block not used/) {a.count(1) {|x| x % 2 == 1 }})
     assert_raise(ArgumentError) { a.count(0, 1) }
 
     bug8654 = '[ruby-core:56072]'
@@ -1100,7 +1099,7 @@ class TestArray < Test::Unit::TestCase
     assert_nil(a.index('ca'))
     assert_nil(a.index([1,2]))
 
-    assert_equal(1, a.index(99) {|x| x == 'cat' })
+    assert_equal(1, assert_warn(/given block not used/) {a.index(99) {|x| x == 'cat' }})
   end
 
   def test_values_at
@@ -1111,42 +1110,42 @@ class TestArray < Test::Unit::TestCase
   end
 
   def test_join
-    $, = ""
+    assert_deprecated_warning {$, = ""}
     a = @cls[]
-    assert_equal("", a.join)
+    assert_equal("", assert_warn(/non-nil value/) {a.join})
     assert_equal("", a.join(','))
-    assert_equal(Encoding::US_ASCII, a.join.encoding)
+    assert_equal(Encoding::US_ASCII, assert_warn(/non-nil value/) {a.join}.encoding)
 
-    $, = ""
+    assert_deprecated_warning {$, = ""}
     a = @cls[1, 2]
-    assert_equal("12", a.join)
-    assert_equal("12", a.join(nil))
+    assert_equal("12", assert_warn(/non-nil value/) {a.join})
+    assert_equal("12", assert_warn(/non-nil value/) {a.join(nil)})
     assert_equal("1,2", a.join(','))
 
-    $, = ""
+    assert_deprecated_warning {$, = ""}
     a = @cls[1, 2, 3]
-    assert_equal("123", a.join)
-    assert_equal("123", a.join(nil))
+    assert_equal("123", assert_warn(/non-nil value/) {a.join})
+    assert_equal("123", assert_warn(/non-nil value/) {a.join(nil)})
     assert_equal("1,2,3", a.join(','))
 
-    $, = ":"
+    assert_deprecated_warning {$, = ":"}
     a = @cls[1, 2, 3]
-    assert_equal("1:2:3", a.join)
-    assert_equal("1:2:3", a.join(nil))
+    assert_equal("1:2:3", assert_warn(/non-nil value/) {a.join})
+    assert_equal("1:2:3", assert_warn(/non-nil value/) {a.join(nil)})
     assert_equal("1,2,3", a.join(','))
 
-    $, = ""
+    assert_deprecated_warning {$, = ""}
 
     e = ''.force_encoding('EUC-JP')
     u = ''.force_encoding('UTF-8')
-    assert_equal(Encoding::US_ASCII, [[]].join.encoding)
-    assert_equal(Encoding::US_ASCII, [1, [u]].join.encoding)
-    assert_equal(Encoding::UTF_8, [u, [e]].join.encoding)
-    assert_equal(Encoding::UTF_8, [u, [1]].join.encoding)
-    assert_equal(Encoding::UTF_8, [Struct.new(:to_str).new(u)].join.encoding)
+    assert_equal(Encoding::US_ASCII, assert_warn(/non-nil value/) {[[]].join}.encoding)
+    assert_equal(Encoding::US_ASCII, assert_warn(/non-nil value/) {[1, [u]].join}.encoding)
+    assert_equal(Encoding::UTF_8, assert_warn(/non-nil value/) {[u, [e]].join}.encoding)
+    assert_equal(Encoding::UTF_8, assert_warn(/non-nil value/) {[u, [1]].join}.encoding)
+    assert_equal(Encoding::UTF_8, assert_warn(/non-nil value/) {[Struct.new(:to_str).new(u)].join}.encoding)
     bug5379 = '[ruby-core:39776]'
-    assert_equal(Encoding::US_ASCII, [[], u, nil].join.encoding, bug5379)
-    assert_equal(Encoding::UTF_8, [[], "\u3042", nil].join.encoding, bug5379)
+    assert_equal(Encoding::US_ASCII, assert_warn(/non-nil value/) {[[], u, nil].join}.encoding, bug5379)
+    assert_equal(Encoding::UTF_8, assert_warn(/non-nil value/) {[[], "\u3042", nil].join}.encoding, bug5379)
   ensure
     $, = nil
   end
@@ -1440,7 +1439,7 @@ class TestArray < Test::Unit::TestCase
     assert_nil(a.rindex('ca'))
     assert_nil(a.rindex([1,2]))
 
-    assert_equal(3, a.rindex(99) {|x| x == [1,2,3] })
+    assert_equal(3, assert_warning(/given block not used/) {a.rindex(99) {|x| x == [1,2,3] }})
 
     bug15951 = "[Bug #15951]"
     o2 = Object.new
@@ -1734,19 +1733,19 @@ class TestArray < Test::Unit::TestCase
   end
 
   def test_to_s
-    $, = ""
+    assert_deprecated_warning {$, = ""}
     a = @cls[]
     assert_equal("[]", a.to_s)
 
-    $, = ""
+    assert_deprecated_warning {$, = ""}
     a = @cls[1, 2]
     assert_equal("[1, 2]", a.to_s)
 
-    $, = ""
+    assert_deprecated_warning {$, = ""}
     a = @cls[1, 2, 3]
     assert_equal("[1, 2, 3]", a.to_s)
 
-    $, = ":"
+    assert_deprecated_warning {$, = ""}
     a = @cls[1, 2, 3]
     assert_equal("[1, 2, 3]", a.to_s)
   ensure
@@ -2403,13 +2402,13 @@ class TestArray < Test::Unit::TestCase
 
   def test_initialize
     assert_nothing_raised { [].instance_eval { initialize } }
-    assert_nothing_raised { Array.new { } }
+    assert_warning(/given block not used/) { Array.new { } }
     assert_equal([1, 2, 3], Array.new([1, 2, 3]))
     assert_raise(ArgumentError) { Array.new(-1, 1) }
     assert_raise(ArgumentError) { Array.new(LONGP, 1) }
     assert_equal([1, 1, 1], Array.new(3, 1))
     assert_equal([1, 1, 1], Array.new(3) { 1 })
-    assert_equal([1, 1, 1], Array.new(3, 1) { 1 })
+    assert_equal([1, 1, 1], assert_warning(/block supersedes default value argument/) {Array.new(3, 1) { 1 }})
   end
 
   def test_aset_error
@@ -2462,7 +2461,7 @@ class TestArray < Test::Unit::TestCase
   end
 
   def test_fetch
-    assert_equal(1, [].fetch(0, 0) { 1 })
+    assert_equal(1, assert_warning(/block supersedes default value argument/) {[].fetch(0, 0) { 1 }})
     assert_equal(1, [0, 1].fetch(-1))
     assert_raise(IndexError) { [0, 1].fetch(2) }
     assert_raise(IndexError) { [0, 1].fetch(-3) }
@@ -3305,7 +3304,6 @@ end
 class TestArraySubclass < TestArray
   def setup
     @verbose = $VERBOSE
-    $VERBOSE = nil
     @cls = Class.new(Array)
   end
 

--- a/test/ruby/test_dir.rb
+++ b/test/ruby/test_dir.rb
@@ -8,7 +8,6 @@ class TestDir < Test::Unit::TestCase
 
   def setup
     @verbose = $VERBOSE
-    $VERBOSE = nil
     @root = File.realpath(Dir.mktmpdir('__test_dir__'))
     @nodir = File.join(@root, "dummy")
     @dirs = []

--- a/test/ruby/test_enum.rb
+++ b/test/ruby/test_enum.rb
@@ -27,7 +27,6 @@ class TestEnumerable < Test::Unit::TestCase
       end
     end
     @verbose = $VERBOSE
-    $VERBOSE = nil
   end
 
   def teardown
@@ -88,7 +87,7 @@ class TestEnumerable < Test::Unit::TestCase
     assert_equal(5, @obj.count)
     assert_equal(2, @obj.count(1))
     assert_equal(3, @obj.count {|x| x % 2 == 1 })
-    assert_equal(2, @obj.count(1) {|x| x % 2 == 1 })
+    assert_equal(2, assert_warning(/given block not used/) {@obj.count(1) {|x| x % 2 == 1 }})
     assert_raise(ArgumentError) { @obj.count(0, 1) }
 
     if RUBY_ENGINE == "ruby"
@@ -116,7 +115,7 @@ class TestEnumerable < Test::Unit::TestCase
     assert_equal(1, @obj.find_index {|x| x % 2 == 0 })
     assert_equal(nil, @obj.find_index {|x| false })
     assert_raise(ArgumentError) { @obj.find_index(0, 1) }
-    assert_equal(1, @obj.find_index(2) {|x| x == 1 })
+    assert_equal(1, assert_warning(/given block not used/) {@obj.find_index(2) {|x| x == 1 }})
   end
 
   def test_find_all
@@ -227,7 +226,7 @@ class TestEnumerable < Test::Unit::TestCase
     assert_equal(48, @obj.inject {|z, x| z * 2 + x })
     assert_equal(12, @obj.inject(:*))
     assert_equal(24, @obj.inject(2) {|z, x| z * x })
-    assert_equal(24, @obj.inject(2, :*) {|z, x| z * x })
+    assert_equal(24, assert_warning(/given block not used/) {@obj.inject(2, :*) {|z, x| z * x }})
     assert_equal(nil, @empty.inject() {9})
   end
 
@@ -437,7 +436,7 @@ class TestEnumerable < Test::Unit::TestCase
     assert_equal(false, [true, true, false].all?)
     assert_equal(true, [].all?)
     assert_equal(true, @empty.all?)
-    assert_equal(true, @obj.all?(Fixnum))
+    assert_equal(true, @obj.all?(Integer))
     assert_equal(false, @obj.all?(1..2))
   end
 

--- a/test/ruby/test_env.rb
+++ b/test/ruby/test_env.rb
@@ -22,7 +22,6 @@ class TestEnv < Test::Unit::TestCase
 
   def setup
     @verbose = $VERBOSE
-    $VERBOSE = nil
     @backup = ENV.to_hash
     ENV.delete('test')
     ENV.delete('TEST')

--- a/test/ruby/test_fixnum.rb
+++ b/test/ruby/test_fixnum.rb
@@ -4,7 +4,6 @@ require 'test/unit'
 class TestFixnum < Test::Unit::TestCase
   def setup
     @verbose = $VERBOSE
-    $VERBOSE = nil
   end
 
   def teardown

--- a/test/ruby/test_hash.rb
+++ b/test/ruby/test_hash.rb
@@ -86,7 +86,6 @@ class TestHash < Test::Unit::TestCase
       'nil' => nil
     ]
     @verbose = $VERBOSE
-    $VERBOSE = nil
   end
 
   def teardown
@@ -947,7 +946,7 @@ class TestHash < Test::Unit::TestCase
   end
 
   def test_fetch2
-    assert_equal(:bar, @h.fetch(0, :foo) { :bar })
+    assert_equal(:bar, assert_warning(/block supersedes default value argument/) {@h.fetch(0, :foo) { :bar }})
   end
 
   def test_default_proc
@@ -1112,6 +1111,7 @@ class TestHash < Test::Unit::TestCase
     def o.to_hash; @cls[]; end
     def o.==(x); true; end
     assert_equal({}, o)
+    o.singleton_class.remove_method(:==)
     def o.==(x); false; end
     assert_not_equal({}, o)
 
@@ -1128,6 +1128,7 @@ class TestHash < Test::Unit::TestCase
     def o.to_hash; @cls[]; end
     def o.eql?(x); true; end
     assert_send([@cls[], :eql?, o])
+    o.singleton_class.remove_method(:eql?)
     def o.eql?(x); false; end
     assert_not_send([@cls[], :eql?, o])
   end

--- a/test/ruby/test_marshal.rb
+++ b/test/ruby/test_marshal.rb
@@ -8,7 +8,6 @@ class TestMarshal < Test::Unit::TestCase
 
   def setup
     @verbose = $VERBOSE
-    $VERBOSE = nil
   end
 
   def teardown
@@ -157,20 +156,29 @@ class TestMarshal < Test::Unit::TestCase
   end
 
   def test_change_class_name
+    self.class.__send__(:remove_const, :C3) if self.class.const_defined?(:C3)
     eval("class C3; def _dump(s); 'foo'; end; end")
     m = Marshal.dump(C3.new)
     assert_raise(TypeError) { Marshal.load(m) }
+    self.class.__send__(:remove_const, :C3)
     eval("C3 = nil")
     assert_raise(TypeError) { Marshal.load(m) }
+  ensure
+    self.class.__send__(:remove_const, :C3) if self.class.const_defined?(:C3)
   end
 
   def test_change_struct
+    self.class.__send__(:remove_const, :C3) if self.class.const_defined?(:C3)
     eval("C3 = Struct.new(:foo, :bar)")
     m = Marshal.dump(C3.new("FOO", "BAR"))
+    self.class.__send__(:remove_const, :C3)
     eval("C3 = Struct.new(:foo)")
     assert_raise(TypeError) { Marshal.load(m) }
+    self.class.__send__(:remove_const, :C3)
     eval("C3 = Struct.new(:foo, :baz)")
     assert_raise(TypeError) { Marshal.load(m) }
+  ensure
+    self.class.__send__(:remove_const, :C3) if self.class.const_defined?(:C3)
   end
 
   class C4
@@ -542,7 +550,7 @@ class TestMarshal < Test::Unit::TestCase
   end
 
   class TestForRespondToFalse
-    def respond_to?(a)
+    def respond_to?(a, priv = false)
       false
     end
   end
@@ -570,7 +578,7 @@ class TestMarshal < Test::Unit::TestCase
   end
 
   def test_continuation
-    require "continuation"
+    EnvUtil.suppress_warning {require "continuation"}
     c = Bug9523.new
     assert_raise_with_message(RuntimeError, /Marshal\.dump reentered at marshal_dump/) do
       Marshal.dump(c)

--- a/test/ruby/test_method.rb
+++ b/test/ruby/test_method.rb
@@ -5,7 +5,6 @@ require 'test/unit'
 class TestMethod < Test::Unit::TestCase
   def setup
     @verbose = $VERBOSE
-    $VERBOSE = nil
   end
 
   def teardown

--- a/test/ruby/test_object.rb
+++ b/test/ruby/test_object.rb
@@ -5,7 +5,6 @@ require 'test/unit'
 class TestObject < Test::Unit::TestCase
   def setup
     @verbose = $VERBOSE
-    $VERBOSE = nil
   end
 
   def teardown
@@ -360,6 +359,7 @@ class TestObject < Test::Unit::TestCase
     o = Object.new
     def o.to_s; 1; end
     assert_raise(TypeError) { String(o) }
+    o.singleton_class.remove_method(:to_s)
     def o.to_s; "o"; end
     assert_equal("o", String(o))
     def o.to_str; "O"; end
@@ -372,6 +372,7 @@ class TestObject < Test::Unit::TestCase
     o = Object.new
     def o.to_a; 1; end
     assert_raise(TypeError) { Array(o) }
+    o.singleton_class.remove_method(:to_a)
     def o.to_a; [1]; end
     assert_equal([1], Array(o))
     def o.to_ary; [2]; end
@@ -389,6 +390,7 @@ class TestObject < Test::Unit::TestCase
     o = Object.new
     def o.to_hash; {a: 1, b: 2}; end
     assert_equal({a: 1, b: 2}, Hash(o))
+    o.singleton_class.remove_method(:to_hash)
     def o.to_hash; 9; end
     assert_raise(TypeError) { Hash(o) }
   end
@@ -397,6 +399,7 @@ class TestObject < Test::Unit::TestCase
     o = Object.new
     def o.to_i; nil; end
     assert_raise(TypeError) { Integer(o) }
+    o.singleton_class.remove_method(:to_i)
     def o.to_i; 42; end
     assert_equal(42, Integer(o))
     def o.respond_to?(*) false; end
@@ -631,7 +634,7 @@ class TestObject < Test::Unit::TestCase
 
     called = []
     p.singleton_class.class_eval do
-      define_method(:respond_to?) do |a|
+      define_method(:respond_to?) do |a, priv = false|
         called << [:respond_to?, a]
         false
       end

--- a/test/ruby/test_proc.rb
+++ b/test/ruby/test_proc.rb
@@ -4,7 +4,6 @@ require 'test/unit'
 class TestProc < Test::Unit::TestCase
   def setup
     @verbose = $VERBOSE
-    $VERBOSE = nil
   end
 
   def teardown
@@ -271,7 +270,7 @@ class TestProc < Test::Unit::TestCase
 
   def test_curry_given_blocks
     b = lambda {|x, y, &blk| blk.call(x + y) }.curry
-    b = b.call(2) { raise }
+    b = assert_warning(/given block not used/) {b.call(2) { raise }}
     b = b.call(3) {|x| x + 4 }
     assert_equal(9, b)
   end
@@ -281,7 +280,7 @@ class TestProc < Test::Unit::TestCase
     assert_equal(false, l.lambda?)
     assert_equal(false, l.curry.lambda?, '[ruby-core:24127]')
     assert_equal(false, proc(&l).lambda?)
-    assert_equal(false, lambda(&l).lambda?)
+    assert_equal(false, assert_deprecated_warning {lambda(&l)}.lambda?)
     assert_equal(false, Proc.new(&l).lambda?)
     l = lambda {}
     assert_equal(true, l.lambda?)
@@ -434,7 +433,7 @@ class TestProc < Test::Unit::TestCase
 
   def test_proc_lambda
     assert_raise(ArgumentError) { proc }
-    assert_raise(ArgumentError) { lambda }
+    assert_raise(ArgumentError) { assert_warn(/deprecated/) {lambda} }
 
     o = Object.new
     def o.foo
@@ -442,14 +441,18 @@ class TestProc < Test::Unit::TestCase
       1.times { b = lambda }
       b
     end
-    assert_raise(ArgumentError) {o.foo { :foo }.call}
+    assert_raise(ArgumentError) do
+      assert_deprecated_warning {o.foo { :foo }}.call
+    end
 
-    def o.foo(&b)
+    def o.bar(&b)
       b = nil
       1.times { b = lambda }
       b
     end
-    assert_raise(ArgumentError) {o.foo { :foo }.call}
+    assert_raise(ArgumentError) do
+      assert_deprecated_warning {o.bar { :foo }}.call
+    end
   end
 
   def test_arity2

--- a/test/ruby/test_refinement.rb
+++ b/test/ruby/test_refinement.rb
@@ -1652,7 +1652,6 @@ class TestRefinement < Test::Unit::TestCase
 
   def test_reopen_refinement_module
     assert_separately([], <<-"end;")
-      $VERBOSE = nil
       class C
       end
 
@@ -1669,6 +1668,7 @@ class TestRefinement < Test::Unit::TestCase
 
       module R
         refine C do
+          alias m m
           def m
             :bar
           end

--- a/test/ruby/test_regexp.rb
+++ b/test/ruby/test_regexp.rb
@@ -5,7 +5,6 @@ require 'test/unit'
 class TestRegexp < Test::Unit::TestCase
   def setup
     @verbose = $VERBOSE
-    $VERBOSE = nil
   end
 
   def teardown
@@ -43,13 +42,14 @@ class TestRegexp < Test::Unit::TestCase
 
   def test_yoshidam_net_20041111_1
     s = "[\xC2\xA0-\xC3\xBE]"
-    assert_match(Regexp.new(s, nil, "u"), "\xC3\xBE")
+    r = assert_warning(/ignored/) {Regexp.new(s, nil, "u")}
+    assert_match(r, "\xC3\xBE")
   end
 
   def test_yoshidam_net_20041111_2
     assert_raise(RegexpError) do
       s = "[\xFF-\xFF]".force_encoding("utf-8")
-      Regexp.new(s, nil, "u")
+      assert_warning(/ignored/) {Regexp.new(s, nil, "u")}
     end
   end
 
@@ -469,7 +469,7 @@ class TestRegexp < Test::Unit::TestCase
 
   def test_initialize
     assert_raise(ArgumentError) { Regexp.new }
-    assert_equal(/foo/, Regexp.new(/foo/, Regexp::IGNORECASE))
+    assert_equal(/foo/, assert_warning(/ignored/) {Regexp.new(/foo/, Regexp::IGNORECASE)})
 
     assert_equal(Encoding.find("US-ASCII"), Regexp.new("b..", nil, "n").encoding)
     assert_equal("bar", "foobarbaz"[Regexp.new("b..", nil, "n")])
@@ -561,7 +561,7 @@ class TestRegexp < Test::Unit::TestCase
     assert_equal("bc", /../.match('abc', -2)[0])
     assert_nil(/../.match("abc", -4))
     assert_nil(/../.match("abc", 4))
-    assert_equal('\x', /../n.match("\u3042" + '\x', 1)[0])
+    assert_equal('\x', assert_warning(/binary regexp/) {/../n.match("\u3042" + '\x', 1)}[0])
 
     r = nil
     /.../.match("abc") {|m| r = m[0] }
@@ -662,13 +662,9 @@ class TestRegexp < Test::Unit::TestCase
   end
 
   def test_ignorecase
-    assert_equal(false, $=)
-    assert_nothing_raised { $= = nil }
-  end
-
-  def test_ignorecase_warning
+    v = assert_warning(/variable \$= is no longer effective/) { $= }
+    assert_equal(false, v)
     assert_warning(/variable \$= is no longer effective; ignored/) { $= = nil }
-    assert_warning(/variable \$= is no longer effective/) { $= }
   end
 
   def test_match_setter
@@ -730,11 +726,11 @@ class TestRegexp < Test::Unit::TestCase
   end
 
   def test_rindex_regexp
-    assert_equal(3, "foobarbaz\u3042".rindex(/b../n, 5))
+    assert_equal(3, assert_warning(/binary regexp/) {"foobarbaz\u3042".rindex(/b../n, 5)})
   end
 
   def assert_regexp(re, ss, fs = [], msg = nil)
-    re = Regexp.new(re) unless re.is_a?(Regexp)
+    re = EnvUtil.suppress_warning {Regexp.new(re)} unless re.is_a?(Regexp)
     ss = [ss] unless ss.is_a?(Array)
     ss.each do |e, s|
       s ||= e
@@ -767,7 +763,7 @@ class TestRegexp < Test::Unit::TestCase
     check(/\A\80\z/, "80", ["\100", ""])
     check(/\A\77\z/, "?")
     check(/\A\78\z/, "\7" + '8', ["\100", ""])
-    check(eval('/\A\Qfoo\E\z/'), "QfooE")
+    check(assert_warning(/Unknown escape/) {eval('/\A\Qfoo\E\z/')}, "QfooE")
     check(/\Aa++\z/, "aaa")
     check('\Ax]\z', "x]")
     check(/x#foo/x, "x", "#foo")
@@ -811,8 +807,8 @@ class TestRegexp < Test::Unit::TestCase
     check(/^(A+|B(?>\g<1>)*)[AC]$/, %w(AAAC BBBAAAAC), %w(BBBAAA))
     check(/^()(?>\g<1>)*$/, "", "a")
     check(/^(?>(?=a)(#{ "a" * 1000 }|))++$/, ["a" * 1000, "a" * 2000, "a" * 3000], ["", "a" * 500, "b" * 1000])
-    check(eval('/^(?:a?)?$/'), ["", "a"], ["aa"])
-    check(eval('/^(?:a+)?$/'), ["", "a", "aa"], ["ab"])
+    check(assert_warning(/nested repeat operator/) {eval('/^(?:a?)?$/')}, ["", "a"], ["aa"])
+    check(assert_warning(/nested repeat operator/) {eval('/^(?:a+)?$/')}, ["", "a", "aa"], ["ab"])
     check(/^(?:a?)+?$/, ["", "a", "aa"], ["ab"])
     check(/^a??[ab]/, [["a", "a"], ["a", "aa"], ["b", "b"], ["a", "ab"]], ["c"])
     check(/^(?:a*){3,5}$/, ["", "a", "aa", "aaa", "aaaa", "aaaaa", "aaaaaa"], ["b"])
@@ -941,13 +937,13 @@ class TestRegexp < Test::Unit::TestCase
 
   def test_posix_bracket
     check(/\A[[:alpha:]0]\z/, %w(0 a), %w(1 .))
-    check(eval('/\A[[:^alpha:]0]\z/'), %w(0 1 .), "a")
-    check(eval('/\A[[:alpha\:]]\z/'), %w(a l p h a :), %w(b 0 1 .))
-    check(eval('/\A[[:alpha:foo]0]\z/'), %w(0 a), %w(1 .))
+    check(assert_warning(/duplicated range/) {eval('/\A[[:^alpha:]0]\z/')}, %w(0 1 .), "a")
+    check(assert_warning(/duplicated range/) {eval('/\A[[:alpha\:]]\z/')}, %w(a l p h a :), %w(b 0 1 .))
+    check(assert_warning(/duplicated range/) {eval('/\A[[:alpha:foo]0]\z/')}, %w(0 a), %w(1 .))
     check(/\A[[:xdigit:]&&[:alpha:]]\z/, "a", %w(g 0))
     check('\A[[:abcdefghijklmnopqrstu:]]+\z', "[]")
     failcheck('[[:alpha')
-    failcheck('[[:alpha:')
+    assert_warning(/duplicated range/) {failcheck('[[:alpha:')}
     failcheck('[[:alp:]]')
 
     assert_match(/\A[[:digit:]]+\z/, "\uff10\uff11\uff12\uff13\uff14\uff15\uff16\uff17\uff18\uff19")
@@ -1114,13 +1110,17 @@ class TestRegexp < Test::Unit::TestCase
   end
 
   def test_regexp_popped
-    assert_nothing_raised { eval("a = 1; /\#{ a }/; a") }
-    assert_nothing_raised { eval("a = 1; /\#{ a }/o; a") }
+    EnvUtil.suppress_warning do
+      assert_nothing_raised { eval("a = 1; /\#{ a }/; a") }
+      assert_nothing_raised { eval("a = 1; /\#{ a }/o; a") }
+    end
   end
 
   def test_invalid_fragment
     bug2547 = '[ruby-core:27374]'
-    assert_raise(SyntaxError, bug2547) {eval('/#{"\\\\"}y/')}
+    assert_raise(SyntaxError, bug2547) do
+      assert_warning(/ignored/) {eval('/#{"\\\\"}y/')}
+    end
   end
 
   def test_dup_warn
@@ -1160,7 +1160,8 @@ class TestRegexp < Test::Unit::TestCase
   def test_raw_hyphen_and_tk_char_type_after_range
     bug6853 = '[ruby-core:47115]'
     # use Regexp.new instead of literal to ignore a parser warning.
-    check(Regexp.new('[0-1-\\s]'), [' ', '-'], ['2', 'a'], bug6853)
+    re = assert_warning(/without escape/) {Regexp.new('[0-1-\\s]')}
+    check(re, [' ', '-'], ['2', 'a'], bug6853)
   end
 
   def test_error_message_on_failed_conversion
@@ -1201,8 +1202,8 @@ class TestRegexp < Test::Unit::TestCase
     assert_equal('aa', eval('/(?:a+?)*/').match('aa')[0])
 
     quantifiers = %w'? * + ?? *? +?'
-    quantifiers.each do |q1|
-      quantifiers.each do |q2|
+    quantifiers.product(quantifiers) do |q1, q2|
+      EnvUtil.suppress_warning do
         r1 = eval("/(a#{q1})#{q2}/").match('aa')[0]
         r2 = eval("/(?:a#{q1})#{q2}/").match('aa')[0]
         assert_equal(r1, r2)

--- a/test/ruby/test_time.rb
+++ b/test/ruby/test_time.rb
@@ -7,7 +7,6 @@ require 'delegate'
 class TestTime < Test::Unit::TestCase
   def setup
     @verbose = $VERBOSE
-    $VERBOSE = nil
   end
 
   def teardown

--- a/tool/lib/test/unit/core_assertions.rb
+++ b/tool/lib/test/unit/core_assertions.rb
@@ -587,6 +587,13 @@ eom
         assert_warning(*args) {$VERBOSE = false; yield}
       end
 
+      def assert_deprecated_warning(mesg = /deprecated/)
+        assert_warning(mesg) do
+          Warning[:deprecated] = true
+          yield
+        end
+      end
+
       class << (AssertFile = Struct.new(:failure_message).new)
         include CoreAssertions
         def assert_file_predicate(predicate, *args)


### PR DESCRIPTION
Instead of suppressing all warnings wholly in each test scripts by setting `$VERBOSE` to `nil` in `setup`.
