### PR TITLE
Make `Hash#except` always return a Hash

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -2643,7 +2643,8 @@ rb_hash_except(int argc, VALUE *argv, VALUE hash)
     int i;
     VALUE key, result;
 
-    result = rb_obj_dup(hash);
+    result = hash_alloc(rb_cHash);
+    hash_copy(result, hash);
 
     for (i = 0; i < argc; i++) {
         key = argv[i];

--- a/spec/ruby/core/hash/except_spec.rb
+++ b/spec/ruby/core/hash/except_spec.rb
@@ -20,14 +20,15 @@ ruby_version_is "3.0" do
       @hash.except(:a, :chunky_bacon).should == { b: 2, c: 3 }
     end
 
-    it "returns an instance of a subclass" do
+    it "always returns a Hash without a default" do
       klass = Class.new(Hash)
-      h = klass.new
+      h = klass.new(:default)
       h[:bar] = 12
       h[:foo] = 42
       r = h.except(:foo)
       r.should == {bar: 12}
-      r.class.should == klass
+      r.class.should == Hash
+      r.default.should == nil
     end
   end
 end


### PR DESCRIPTION
Since Matz prefers returning [base class instead of subclass](https://bugs.ruby-lang.org/issues/6087#note-12)