### PR TITLE
Ractor usability improvements

### DIFF
--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -62,6 +62,28 @@ assert_match /^#<Ractor:#([^ ]*?) Test Ractor .+:[0-9]+ terminated>$/, %q{
   r.inspect
 }
 
+# Ractor#to_s is the same as #inspect
+assert_equal "#<Ractor:#1 running>", %q{
+  Ractor.current.to_s
+}
+
+# Ractor#status
+assert_equal ":running", %q{
+  Ractor.current.status.inspect
+}
+
+assert_equal ":terminated", %q{
+  r = Ractor.new {}
+  sleep(0.1) until r.inspect =~ /terminated/
+  r.status.inspect
+}
+
+assert_equal ":blocking", %q{
+  r = Ractor.new { Ractor.yield }
+  sleep(0.1) until r.inspect =~ /blocking/
+  r.status.inspect
+}
+
 # A return value of a Ractor block will be a message from the Ractor.
 assert_equal 'ok', %q{
   # join

--- a/common.mk
+++ b/common.mk
@@ -10213,6 +10213,7 @@ ractor.$(OBJEXT): $(top_srcdir)/internal/serial.h
 ractor.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 ractor.$(OBJEXT): $(top_srcdir)/internal/string.h
 ractor.$(OBJEXT): $(top_srcdir)/internal/struct.h
+ractor.$(OBJEXT): $(top_srcdir)/internal/symbol.h
 ractor.$(OBJEXT): $(top_srcdir)/internal/thread.h
 ractor.$(OBJEXT): $(top_srcdir)/internal/vm.h
 ractor.$(OBJEXT): $(top_srcdir)/internal/warnings.h

--- a/ractor.c
+++ b/ractor.c
@@ -12,6 +12,7 @@
 #include "internal/hash.h"
 #include "internal/rational.h"
 #include "internal/struct.h"
+#include "internal/symbol.h"
 #include "internal/thread.h"
 #include "variable.h"
 #include "gc.h"

--- a/ractor.rb
+++ b/ractor.rb
@@ -660,9 +660,25 @@ class Ractor
     "#<Ractor:##{id}#{name ? ' '+name : ''}#{loc ? " " + loc : ''} #{status}>"
   end
 
+  alias to_s inspect
+
   # The name set in Ractor.new, or +nil+.
   def name
     __builtin_cexpr! %q{RACTOR_PTR(self)->name}
+  end
+
+  # Returns the current status of the ractor.
+  #
+  # Possible values are:
+  # * <tt>:created</tt> -- the ractor is just created
+  # * <tt>:running</tt> -- the ractor is running
+  # * <tt>:blocking</tt> -- the ractor is waiting on Ractor.receive or Ractor.yield
+  # * <tt>:terminated</tt> -- the ractor is finished
+  #
+  def status
+    __builtin_cexpr! %q{
+      rb_sym_intern_ascii_cstr(ractor_status_str(RACTOR_PTR(self)->status_))
+    }
   end
 
   class RemoteError


### PR DESCRIPTION
Small improvements to `Ractor` usability:

* alias `#to_s` to `#inspect`:
  ```
  ./ruby --disable-gems -e 'r = Ractor.new{}; puts "Created a ractor: #{r}"'
  # before:
  Created a ractor: #<Ractor:0x00005600e210c2d0>
  # after:
  Created a ractor: #<Ractor:#2 -e:1 blocking>
  ```
* expose `Ractor#status`:
  ```
  $ ./ruby --disable-gems -e "p Ractor.new{}.status"
  :blocking
  ```

TODO: 
1. ~I haven't found in the repo tests for basic ractor behaior, am I missing something? So I tested it only manually (though I doubt anything might be broken)~
2. ~Suddenly, I can't find a better way for producing symbols from `__builtin_cexpr!`~
@ko1 @marcandre @eregon 