### PR TITLE
Changed shareable literal semantics [Feature #17397]

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -488,7 +488,7 @@ static int value_expr_gen(struct parser_params*,NODE*);
 static void void_expr(struct parser_params*,NODE*);
 static NODE *remove_begin(NODE*);
 static NODE *remove_begin_all(NODE*);
-#define value_expr(node) value_expr_gen(p, (node) = remove_begin(node))
+#define value_expr(node) value_expr_gen(p, (node))
 static NODE *void_stmts(struct parser_params*,NODE*);
 static void reduce_nodes(struct parser_params*,NODE**);
 static void block_dup_check(struct parser_params*,NODE*,NODE*);

--- a/parse.y
+++ b/parse.y
@@ -11078,7 +11078,7 @@ shareable_literal_value(NODE *node)
 }
 
 #ifndef SHAREABLE_BARE_EXPRESSION
-#define SHAREABLE_BARE_EXPRESSION 0
+#define SHAREABLE_BARE_EXPRESSION 1
 #endif
 
 VALUE rb_ractor_make_shareable(VALUE obj);

--- a/ractor.c
+++ b/ractor.c
@@ -2445,10 +2445,10 @@ rb_ractor_make_shareable_copy(VALUE obj)
 VALUE
 rb_ractor_ensure_shareable(VALUE obj, VALUE name)
 {
-    if (!RTEST(rb_ractor_shareable_p(obj))) {
+    if (!rb_ractor_shareable_p(obj)) {
         VALUE message = rb_sprintf("cannot assign unshareable object to %"PRIsVALUE,
                                    name);
-        rb_exc_raise(rb_exc_new_str(rb_eRactorError, message));
+        rb_exc_raise(rb_exc_new_str(rb_eRactorIsolationError, message));
     }
     return obj;
 }

--- a/ractor.c
+++ b/ractor.c
@@ -2442,6 +2442,17 @@ rb_ractor_make_shareable_copy(VALUE obj)
     return copy;
 }
 
+VALUE
+rb_ractor_ensure_shareable(VALUE obj, VALUE name)
+{
+    if (!RTEST(rb_ractor_shareable_p(obj))) {
+        VALUE message = rb_sprintf("cannot assign unshareable object to %"PRIsVALUE,
+                                   name);
+        rb_exc_raise(rb_exc_new_str(rb_eRactorError, message));
+    }
+    return obj;
+}
+
 static enum obj_traverse_iterator_result
 shareable_p_enter(VALUE obj)
 {

--- a/test/ruby/test_parse.rb
+++ b/test/ruby/test_parse.rb
@@ -1192,13 +1192,19 @@ x = __ENCODING__
     assert !Ractor.shareable?(obj), ->{"Expected #{mu_pp(obj)} not to be ractor shareable"}
   end
 
-  def test_shareable_constant_value
+  def test_shareable_constant_value_invalid
     assert_warning(/invalid value/) do
       assert_valid_syntax("# shareable_constant_value: invalid-option", verbose: true)
     end
+  end
+
+  def test_shareable_constant_value_ignored
     assert_warning(/ignored/) do
       assert_valid_syntax("nil # shareable_constant_value: true", verbose: true)
     end
+  end
+
+  def test_shareable_constant_value_simple
     a, b, c = eval_separately("#{<<~"begin;"}\n#{<<~'end;'}")
     begin;
       # shareable_constant_value: experimental_everything
@@ -1216,7 +1222,9 @@ x = __ENCODING__
     assert_ractor_shareable(c)
     assert_equal([1], a[0])
     assert_ractor_shareable(a[0])
+  end
 
+  def test_shareable_constant_value_nested
     a, b = eval_separately("#{<<~"begin;"}\n#{<<~'end;'}")
     begin;
       # shareable_constant_value: none
@@ -1232,13 +1240,17 @@ x = __ENCODING__
     assert_not_ractor_shareable(b)
     assert_equal([1], a[0])
     assert_ractor_shareable(a[0])
+  end
 
+  def test_shareable_constant_value_unshareable_literal
     assert_ractor_error(/unshareable/, "#{<<~"begin;"}\n#{<<~'end;'}")
     begin;
       # shareable_constant_value: literal
       C = ["Not " + "shareable"]
     end;
+  end
 
+  def test_shareable_constant_value_nonliteral
     c, d = eval_separately("#{<<~"begin;"}\n#{<<~'end;'}")
     begin;
       # shareable_constant_value: literal
@@ -1249,7 +1261,9 @@ x = __ENCODING__
     end;
     assert_not_ractor_shareable(c)
     assert_not_ractor_shareable(d)
+  end
 
+  def test_shareable_constant_value_unfrozen
     assert_ractor_error(/does not freeze object correctly/, "#{<<~"begin;"}\n#{<<~'end;'}")
     begin;
       # shareable_constant_value: experimental_everything

--- a/test/ruby/test_parse.rb
+++ b/test/ruby/test_parse.rb
@@ -1213,11 +1213,13 @@ x = __ENCODING__
     assert_equal([1], a[0])
     assert_send([Ractor, :shareable?, a[0]])
 
-    assert_syntax_error("#{<<~"begin;"}\n#{<<~'end;'}", /unshareable expression/)
-    begin;
-      # shareable_constant_value: literal
-      C = ["Not " + "shareable"]
-    end;
+    assert_raise_with_message(Ractor::Error, /unshareable/) do
+      Class.new.class_eval("#{<<~"begin;"}\n#{<<~'end;'}")
+      begin;
+        # shareable_constant_value: literal
+        C = ["Not " + "shareable"]
+      end;
+    end
   end
 
 =begin

--- a/test/ruby/test_parse.rb
+++ b/test/ruby/test_parse.rb
@@ -1178,8 +1178,8 @@ x = __ENCODING__
     Class.new.class_eval(code)
   end
 
-  def assert_ractor_error(message, code)
-    assert_raise_with_message(Ractor::Error, message) do
+  def assert_raise_separately(error, message, code)
+    assert_raise_with_message(error, message) do
       eval_separately(code)
     end
   end
@@ -1243,7 +1243,8 @@ x = __ENCODING__
   end
 
   def test_shareable_constant_value_unshareable_literal
-    assert_ractor_error(/unshareable/, "#{<<~"begin;"}\n#{<<~'end;'}")
+    assert_raise_separately(Ractor::IsolationError, /unshareable/,
+                            "#{<<~"begin;"}\n#{<<~'end;'}")
     begin;
       # shareable_constant_value: literal
       C = ["Not " + "shareable"]
@@ -1264,7 +1265,8 @@ x = __ENCODING__
   end
 
   def test_shareable_constant_value_unfrozen
-    assert_ractor_error(/does not freeze object correctly/, "#{<<~"begin;"}\n#{<<~'end;'}")
+    assert_raise_separately(Ractor::Error, /does not freeze object correctly/,
+                            "#{<<~"begin;"}\n#{<<~'end;'}")
     begin;
       # shareable_constant_value: experimental_everything
       o = Object.new

--- a/test/ruby/test_parse.rb
+++ b/test/ruby/test_parse.rb
@@ -1222,7 +1222,8 @@ x = __ENCODING__
       # shareable_constant_value: none
       class X
         # shareable_constant_value: experimental_everything
-        A = [[1]]
+        var = [[1]]
+        A = var
       end
       B = []
       [X::A, B]
@@ -1236,6 +1237,25 @@ x = __ENCODING__
     begin;
       # shareable_constant_value: literal
       C = ["Not " + "shareable"]
+    end;
+
+    c, d = eval_separately("#{<<~"begin;"}\n#{<<~'end;'}")
+    begin;
+      # shareable_constant_value: literal
+      var = [:not_frozen]
+      C = var
+      D = begin [] end
+      [C, D]
+    end;
+    assert_not_ractor_shareable(c)
+    assert_not_ractor_shareable(d)
+
+    assert_ractor_error(/does not freeze object correctly/, "#{<<~"begin;"}\n#{<<~'end;'}")
+    begin;
+      # shareable_constant_value: experimental_everything
+      o = Object.new
+      def o.freeze; self; end
+      C = [o]
     end;
   end
 

--- a/test/ruby/test_parse.rb
+++ b/test/ruby/test_parse.rb
@@ -1252,16 +1252,18 @@ x = __ENCODING__
   end
 
   def test_shareable_constant_value_nonliteral
-    c, d = eval_separately("#{<<~"begin;"}\n#{<<~'end;'}")
+    assert_raise_separately(Ractor::IsolationError, /unshareable/, "#{<<~"begin;"}\n#{<<~'end;'}")
     begin;
       # shareable_constant_value: literal
       var = [:not_frozen]
       C = var
-      D = begin [] end
-      [C, D]
     end;
-    assert_not_ractor_shareable(c)
-    assert_not_ractor_shareable(d)
+
+    assert_raise_separately(Ractor::IsolationError, /unshareable/, "#{<<~"begin;"}\n#{<<~'end;'}")
+    begin;
+      # shareable_constant_value: literal
+      D = begin [] end
+    end;
   end
 
   def test_shareable_constant_value_unfrozen

--- a/vm.c
+++ b/vm.c
@@ -995,6 +995,7 @@ collect_outer_variable_names(ID id, VALUE val, void *ptr)
 }
 
 VALUE rb_ractor_make_shareable(VALUE obj);
+VALUE rb_ractor_ensure_shareable(VALUE obj, VALUE name);
 
 static const rb_env_t *
 env_copy(const VALUE *src_ep, VALUE read_only_variables)
@@ -3181,6 +3182,12 @@ m_core_make_shareable(VALUE recv, VALUE obj)
 }
 
 static VALUE
+m_core_ensure_shareable(VALUE recv, VALUE obj, VALUE name)
+{
+    return rb_ractor_ensure_shareable(obj, name);
+}
+
+static VALUE
 core_hash_merge_kwd(VALUE hash, VALUE kw)
 {
     rb_hash_foreach(rb_to_hash_type(kw), kwmerge_i, hash);
@@ -3345,6 +3352,7 @@ Init_VM(void)
     rb_define_method_id(klass, idProc, f_proc, 0);
     rb_define_method_id(klass, idLambda, f_lambda, 0);
     rb_define_method(klass, "make_shareable", m_core_make_shareable, 1);
+    rb_define_method(klass, "ensure_shareable", m_core_ensure_shareable, 2);
     rb_obj_freeze(fcore);
     RBASIC_CLEAR_CLASS(klass);
     rb_obj_freeze(klass);


### PR DESCRIPTION
When `literal`, check if the literal about to be assigned to a constant is ractor-shareable, otherwise raise `Ractor::Error` at runtime instead of `SyntaxError`.