### PR TITLE
Make `Yaml/Psych` Ractor-ready

### DIFF
--- a/ext/psych/lib/psych.rb
+++ b/ext/psych/lib/psych.rb
@@ -632,9 +632,29 @@ module Psych
   private_class_method :warn_with_uplevel, :parse_caller
 
   class << self
-    attr_accessor :load_tags
-    attr_accessor :dump_tags
-    attr_accessor :domain_types
+    if defined?(Ractor)
+      require 'forwardable'
+      extend Forwardable
+
+      class Config
+        attr_accessor :load_tags, :dump_tags, :domain_types
+        def initialize
+          @load_tags = {}
+          @dump_tags = {}
+          @domain_types = {}
+        end
+      end
+
+      def config
+        Ractor.current[:PsychConfig] ||= Config.new
+      end
+
+      def_delegators :config, :load_tags, :dump_tags, :domain_types, :load_tags=, :dump_tags=, :domain_types=
+    else
+      attr_accessor :load_tags
+      attr_accessor :dump_tags
+      attr_accessor :domain_types
+    end
   end
   self.load_tags = {}
   self.dump_tags = {}

--- a/ext/psych/lib/psych.rb
+++ b/ext/psych/lib/psych.rb
@@ -595,28 +595,25 @@ module Psych
   end
 
   # :stopdoc:
-  @domain_types = {}
   def self.add_domain_type domain, type_tag, &block
     key = ['tag', domain, type_tag].join ':'
-    @domain_types[key] = [key, block]
-    @domain_types["tag:#{type_tag}"] = [key, block]
+    domain_types[key] = [key, block]
+    domain_types["tag:#{type_tag}"] = [key, block]
   end
 
   def self.add_builtin_type type_tag, &block
     domain = 'yaml.org,2002'
     key = ['tag', domain, type_tag].join ':'
-    @domain_types[key] = [key, block]
+    domain_types[key] = [key, block]
   end
 
   def self.remove_type type_tag
-    @domain_types.delete type_tag
+    domain_types.delete type_tag
   end
 
-  @load_tags = {}
-  @dump_tags = {}
   def self.add_tag tag, klass
-    @load_tags[tag] = klass.name
-    @dump_tags[klass] = tag
+    load_tags[tag] = klass.name
+    dump_tags[klass] = tag
   end
 
   # Workaround for emulating `warn '...', uplevel: 1` in Ruby 2.4 or lower.
@@ -639,5 +636,8 @@ module Psych
     attr_accessor :dump_tags
     attr_accessor :domain_types
   end
+  self.load_tags = {}
+  self.dump_tags = {}
+  self.domain_types = {}
   # :startdoc:
 end

--- a/ext/psych/lib/psych.rb
+++ b/ext/psych/lib/psych.rb
@@ -233,9 +233,9 @@ require 'psych/class_loader'
 
 module Psych
   # The version of libyaml Psych is using
-  LIBYAML_VERSION = Psych.libyaml_version.join '.'
+  LIBYAML_VERSION = Psych.libyaml_version.join('.').freeze
   # Deprecation guard
-  NOT_GIVEN = Object.new
+  NOT_GIVEN = Object.new.freeze
   private_constant :NOT_GIVEN
 
   ###

--- a/ext/psych/lib/psych/class_loader.rb
+++ b/ext/psych/lib/psych/class_loader.rb
@@ -69,7 +69,7 @@ module Psych
       rescue
         nil
       end
-    }.compact]
+    }.compact].freeze
 
     class Restricted < ClassLoader
       def initialize classes, symbols

--- a/ext/psych/lib/psych/class_loader.rb
+++ b/ext/psych/lib/psych/class_loader.rb
@@ -35,9 +35,11 @@ module Psych
 
     constants.each do |const|
       konst = const_get const
-      define_method(const.to_s.downcase) do
-        load konst
-      end
+      class_eval <<~RUBY
+        def #{const.to_s.downcase}
+          load #{konst.inspect}
+        end
+      RUBY
     end
 
     private

--- a/ext/psych/lib/psych/visitors/visitor.rb
+++ b/ext/psych/lib/psych/visitors/visitor.rb
@@ -12,7 +12,7 @@ module Psych
       def self.dispatch_cache
         Hash.new do |hash, klass|
           hash[klass] = :"visit_#{klass.name.gsub('::', '_')}"
-        end
+        end.compare_by_identity
       end
 
       if defined?(Ractor)

--- a/ext/psych/lib/psych/visitors/visitor.rb
+++ b/ext/psych/lib/psych/visitors/visitor.rb
@@ -8,12 +8,26 @@ module Psych
 
       private
 
-      DISPATCH = Hash.new do |hash, klass|
-        hash[klass] = "visit_#{klass.name.gsub('::', '_')}"
+      # @api private
+      def self.dispatch_cache
+        Hash.new do |hash, klass|
+          hash[klass] = :"visit_#{klass.name.gsub('::', '_')}"
+        end
+      end
+
+      if defined?(Ractor)
+        def dispatch
+          Ractor.current[:Psych_Visitors_Visitor] ||= Visitor.dispatch_cache
+        end
+      else
+        DISPATCH = dispatch_cache
+        def dispatch
+          DISPATCH
+        end
       end
 
       def visit target
-        send DISPATCH[target.class], target
+        send dispatch[target.class], target
       end
     end
   end

--- a/ext/psych/lib/psych/visitors/yaml_tree.rb
+++ b/ext/psych/lib/psych/visitors/yaml_tree.rb
@@ -80,7 +80,7 @@ module Psych
           raise(TypeError, "Can't dump #{target.class}") unless method
 
           h[klass] = method
-        end
+        end.compare_by_identity
       end
 
       def start encoding = Nodes::Stream::UTF8

--- a/ext/psych/psych.c
+++ b/ext/psych/psych.c
@@ -22,6 +22,9 @@ VALUE mPsych;
 
 void Init_psych(void)
 {
+    #ifdef HAVE_RB_EXT_RACTOR_SAFE
+	RB_EXT_RACTOR_SAFE(true);
+    #endif
     mPsych = rb_define_module("Psych");
 
     rb_define_singleton_method(mPsych, "libyaml_version", libyaml_version, 0);

--- a/test/psych/test_ractor.rb
+++ b/test/psych/test_ractor.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+require_relative 'helper'
+
+class TestPsychRactor < Test::Unit::TestCase
+  def test_ractor_round_trip
+    assert_ractor(<<~RUBY, require_relative: 'helper')
+      obj = {foo: [42]}
+      obj2 = Ractor.new(obj) do |obj|
+        Psych.load(Psych.dump(obj))
+      end.take
+      assert_equal obj, obj2
+    RUBY
+  end
+
+  def test_not_shareable
+    # There's no point in making these frozen / shareable
+    # and the C-ext disregards begin frozen
+    assert_ractor(<<~RUBY, require_relative: 'helper')
+      parser = Psych::Parser.new
+      emitter = Psych::Emitter.new(nil)
+      assert_raise(Ractor::Error) { Ractor.make_shareable(parser) }
+      assert_raise(Ractor::Error) { Ractor.make_shareable(emitter) }
+    RUBY
+  end
+
+  def test_ractor_config
+    assert_ractor(<<~RUBY, require_relative: 'helper')
+      r = Ractor.new do
+        Psych.add_builtin_type 'omap' do |type, val|
+          val * 2
+        end
+        Psych.load('--- !!omap hello')
+      end.take
+      assert_equal 'hellohello', r
+      assert_equal 'hello', Psych.load('--- !!omap hello')
+    RUBY
+  end
+
+  def test_ractor_constants
+    assert_ractor(<<~RUBY, require_relative: 'helper')
+      r = Ractor.new do
+        Psych.libyaml_version.join('.') == Psych::LIBYAML_VERSION
+      end.take
+      assert_equal true, r
+    RUBY
+  end
+end

--- a/test/psych/test_ractor.rb
+++ b/test/psych/test_ractor.rb
@@ -24,6 +24,9 @@ class TestPsychRactor < Test::Unit::TestCase
   end
 
   def test_ractor_config
+    # Config is ractor-local
+    # Test is to make sure it works, even though usage is probably very low.
+    # The methods are not documented and might be deprecated one day
     assert_ractor(<<~RUBY, require_relative: 'helper')
       r = Ractor.new do
         Psych.add_builtin_type 'omap' do |type, val|


### PR DESCRIPTION
This PR makes it possible to call `YAML` from Ractors.