### PR TITLE
Introduce Ractor::IsolationError

### DIFF
--- a/ractor.c
+++ b/ractor.c
@@ -18,18 +18,14 @@
 #include "transient_heap.h"
 
 VALUE rb_cRactor;
+
+VALUE rb_eRactorUnsafeError;
+VALUE rb_eRactorIsolationError;
 static VALUE rb_eRactorError;
 static VALUE rb_eRactorRemoteError;
 static VALUE rb_eRactorMovedError;
 static VALUE rb_eRactorClosedError;
 static VALUE rb_cRactorMovedObject;
-VALUE rb_eRactorUnsafeError;
-
-VALUE
-rb_ractor_error_class(void)
-{
-    return rb_eRactorError;
-}
 
 static void vm_ractor_blocking_cnt_inc(rb_vm_t *vm, rb_ractor_t *r, const char *file, int line);
 
@@ -2023,11 +2019,12 @@ void
 Init_Ractor(void)
 {
     rb_cRactor = rb_define_class("Ractor", rb_cObject);
-    rb_eRactorError       = rb_define_class_under(rb_cRactor, "Error", rb_eRuntimeError);
-    rb_eRactorRemoteError = rb_define_class_under(rb_cRactor, "RemoteError", rb_eRactorError);
-    rb_eRactorMovedError  = rb_define_class_under(rb_cRactor, "MovedError",  rb_eRactorError);
-    rb_eRactorClosedError = rb_define_class_under(rb_cRactor, "ClosedError", rb_eStopIteration);
-    rb_eRactorUnsafeError = rb_define_class_under(rb_cRactor, "UnsafeError", rb_eRactorError);
+    rb_eRactorError          = rb_define_class_under(rb_cRactor, "Error", rb_eRuntimeError);
+    rb_eRactorIsolationError = rb_define_class_under(rb_cRactor, "IsolationError", rb_eRactorError);
+    rb_eRactorRemoteError    = rb_define_class_under(rb_cRactor, "RemoteError", rb_eRactorError);
+    rb_eRactorMovedError     = rb_define_class_under(rb_cRactor, "MovedError",  rb_eRactorError);
+    rb_eRactorClosedError    = rb_define_class_under(rb_cRactor, "ClosedError", rb_eStopIteration);
+    rb_eRactorUnsafeError    = rb_define_class_under(rb_cRactor, "UnsafeError", rb_eRactorError);
 
     rb_cRactorMovedObject = rb_define_class_under(rb_cRactor, "MovedObject", rb_cBasicObject);
     rb_undef_alloc_func(rb_cRactorMovedObject);

--- a/vm.c
+++ b/vm.c
@@ -994,7 +994,6 @@ collect_outer_variable_names(ID id, VALUE val, void *ptr)
     return ID_TABLE_CONTINUE;
 }
 
-VALUE rb_ractor_error_class(void);
 VALUE rb_ractor_make_shareable(VALUE obj);
 
 static const rb_env_t *
@@ -1015,7 +1014,7 @@ env_copy(const VALUE *src_ep, VALUE read_only_variables)
                 if (id ==  src_env->iseq->body->local_table[j]) {
                     VALUE v = src_env->env[j];
                     if (!rb_ractor_shareable_p(v)) {
-                        rb_raise(rb_ractor_error_class(),
+                        rb_raise(rb_eRactorIsolationError,
                                  "can not make shareable Proc because it can refer unshareable object %"
                                  PRIsVALUE" from variable `%s'", rb_inspect(v), rb_id2name(id));
                     }

--- a/vm_core.h
+++ b/vm_core.h
@@ -2011,6 +2011,7 @@ extern void rb_reset_coverages(void);
 void rb_postponed_job_flush(rb_vm_t *vm);
 
 extern VALUE rb_eRactorUnsafeError; // ractor.c
+extern VALUE rb_eRactorIsolationError;
 
 RUBY_SYMBOL_EXPORT_END
 

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1002,7 +1002,7 @@ vm_get_ev_const(rb_execution_context_t *ec, VALUE orig_klass, ID id, bool allow_
                         else {
                             if (UNLIKELY(!rb_ractor_main_p())) {
                                 if (!rb_ractor_shareable_p(val)) {
-                                    rb_raise(rb_eNameError,
+                                    rb_raise(rb_eRactorIsolationError,
                                              "can not access non-shareable objects in constant %"PRIsVALUE"::%s by non-main ractor.", rb_class_path(klass), rb_id2name(id));
                                 }
                             }


### PR DESCRIPTION
Ractor has several restrictions to keep each ractor being isolated
and some operation such as `CONST="foo"` in non-main ractor raises
an exception. This kind of operation raises an error but there is
confusion (some code raises RuntimeError and some code raises
NameError).

To make clear we introduce Ractor::IsolationError which is raised
when the isolation between ractors is violated.