### PR TITLE
Improve Kernel#itself method [Feature #17416]

### DIFF
--- a/benchmark/kernel_itself.yml
+++ b/benchmark/kernel_itself.yml
@@ -1,0 +1,18 @@
+prelude: |
+  obj = Object.new
+  ary = Array.new
+  str = String.new
+  int = 42
+  flt = 4.2
+benchmark:
+  object: |
+    obj.itself
+  array: |
+    ary.itself
+  string: |
+    str.itself
+  integer: |
+    int.itself
+  float: |
+    flt.itself
+loop_count: 20000000

--- a/benchmark/kernel_itself.yml
+++ b/benchmark/kernel_itself.yml
@@ -1,18 +1,9 @@
 prelude: |
-  obj = Object.new
-  ary = Array.new
-  str = String.new
-  int = 42
-  flt = 4.2
-benchmark:
-  object: |
-    obj.itself
+  ary = [1,2,3,4,5,1,2,2,3] 
+  str = "hello world"
+benchmark: 
   array: |
-    ary.itself
+    ary.group_by(&:itself)
   string: |
-    str.itself
-  integer: |
-    int.itself
-  float: |
-    flt.itself
+    str.chars.group_by(&:itself) 
 loop_count: 20000000

--- a/kernel.rb
+++ b/kernel.rb
@@ -148,6 +148,20 @@ module Kernel
     yield(self)
   end
 
+  #
+  #  call-seq:
+  #     obj.itself    -> obj
+  #
+  #  Returns the receiver.
+  #
+  #     string = "my string"
+  #     string.itself.object_id == string.object_id   #=> true
+  #
+  #
+  def itself
+    return self
+  end
+
   module_function
 
   #

--- a/object.c
+++ b/object.c
@@ -570,23 +570,6 @@ rb_obj_dup(VALUE obj)
     return dup;
 }
 
-/*
- *  call-seq:
- *     obj.itself    -> obj
- *
- *  Returns the receiver.
- *
- *     string = "my string"
- *     string.itself.object_id == string.object_id   #=> true
- *
- */
-
-static VALUE
-rb_obj_itself(VALUE obj)
-{
-    return obj;
-}
-
 VALUE
 rb_obj_size(VALUE self, VALUE args, VALUE obj)
 {
@@ -4540,7 +4523,6 @@ InitVM_Object(void)
 
     rb_define_method(rb_mKernel, "singleton_class", rb_obj_singleton_class, 0);
     rb_define_method(rb_mKernel, "dup", rb_obj_dup, 0);
-    rb_define_method(rb_mKernel, "itself", rb_obj_itself, 0);
     rb_define_method(rb_mKernel, "initialize_copy", rb_obj_init_copy, 1);
     rb_define_method(rb_mKernel, "initialize_dup", rb_obj_init_dup_clone, 1);
     rb_define_method(rb_mKernel, "initialize_clone", rb_obj_init_clone, -1);

--- a/test/ruby/test_settracefunc.rb
+++ b/test/ruby/test_settracefunc.rb
@@ -1713,19 +1713,19 @@ class TestSetTraceFunc < Test::Unit::TestCase
     c = Class.new{
       alias initialize itself
     }
-    TracePoint.new(:c_call, &capture_events).enable{
+    TracePoint.new(:call, &capture_events).enable{
       c.new
     }
-    assert_equal [:c_call, :itself, :initialize], events[1]
+    assert_equal [:call, :itself, :initialize], events[0]
     events.clear
 
     o = Class.new{
       alias alias_itself itself
     }.new
-    TracePoint.new(:c_call, :c_return, &capture_events).enable{
+    TracePoint.new(:call, :return, &capture_events).enable{
       o.alias_itself
     }
-    assert_equal [[:c_call, :itself, :alias_itself], [:c_return, :itself, :alias_itself]], events
+    assert_equal [[:call, :itself, :alias_itself], [:return, :itself, :alias_itself]], events
     events.clear
   end
 


### PR DESCRIPTION
Improve performance `Kernel#itself` with Ruby code.

like this.

```ruby
module Kernel
  #
  #  call-seq:
  #     obj.itself    -> obj
  #
  #  Returns the receiver.
  #
  #     string = "my string"
  #     string.itself.object_id == string.object_id   #=> true
  #
  #
  def itself
    return self
  end
end
```

benchmark:

```yaml
prelude: |
  obj = Object.new
  ary = Array.new
  str = String.new
  int = 42
  flt = 4.2
benchmark:
  object: |
    obj.itself
  array: |
    ary.itself
  string: |
    str.itself
  integer: |
    int.itself
  float: |
    flt.itself
loop_count: 20000000

```

benchmark result:
```bash
sh@MyComputer:~/rubydev/build$ make benchmark/benchmark.yml -e COMPARE_RUBY=~/.rbenv/shims/ruby -e BENCH_RUBY=../install/bin/ruby
# Iteration per second (i/s)

|         |compare-ruby|built-ruby|
|:--------|-----------:|---------:|
|object   |     58.924M|   70.285M|
|         |           -|     1.19x|
|array    |     56.428M|   65.275M|
|         |           -|     1.16x|
|string   |     50.311M|   63.087M|
|         |           -|     1.25x|
|integer  |     54.838M|   62.510M|
|         |           -|     1.14x|
|float    |     56.372M|   65.399M|
|         |           -|     1.16x|
```

COMPARE_RUBY is `ruby 3.0.0dev (2020-12-21T09:17:45Z master d84dd66da0) [x86_64-linux]`. BENCH_RUBY is ahead of `ruby 3.0.0dev (2020-12-21T09:17:45Z master d84dd66da0) [x86_64-linux]`.

ref: [Feature #17416 Improve performance Kernel#itself](https://bugs.ruby-lang.org/issues/17416)