### PR TITLE
Docs for some featurs missing in 3.0

### DIFF
--- a/proc.c
+++ b/proc.c
@@ -1273,6 +1273,32 @@ rb_proc_get_iseq(VALUE self, int *is_proc)
     return NULL;
 }
 
+/* call-seq:
+ *   prc == other -> true or false
+ *   prc.eql?(other) -> true or false
+ *
+ * Two proc are the same if, and only if, they were created from the same code block.
+ *
+ *   def return_block(&block)
+ *     block
+ *   end
+ *
+ *   def pass_block_twice(&block)
+ *     [return_block(&block), return_block(&block)]
+ *   end
+ *
+ *   block1, block2 = pass_block_twice { puts 'test' }
+ *   # Blocks might be instantiated into Proc's lazily, so they may, or may not,
+ *   # be the same object.
+ *   # But they are produced from the same code block, so they are equal
+ *   block1 == block2
+ *   #=> true
+ *
+ *   # Another Proc will never be equal, even if the code is the "same"
+ *   block1 == proc { puts 'test' }
+ *   #=> false
+ *
+ */
 static VALUE
 proc_eq(VALUE self, VALUE other)
 {

--- a/random.c
+++ b/random.c
@@ -1716,6 +1716,13 @@ InitVM_Random(void)
     rb_define_private_method(rb_cRandom, "left", rand_mt_left, 0);
     rb_define_method(rb_cRandom, "==", rand_mt_equal, 1);
 
+#if 0 /* for RDoc: it can't handle unnamed base class */
+    rb_define_method(rb_cRandom, "initialize", random_init, -1);
+    rb_define_method(rb_cRandom, "rand", random_rand, -1);
+    rb_define_method(rb_cRandom, "bytes", random_bytes, 1);
+    rb_define_method(rb_cRandom, "seed", random_get_seed, 0);
+#endif
+
     rb_define_const(rb_cRandom, "DEFAULT", rb_cRandom);
     rb_deprecate_constant(rb_cRandom, "DEFAULT");
 

--- a/string.c
+++ b/string.c
@@ -11052,6 +11052,26 @@ sym_inspect(VALUE sym)
     return str;
 }
 
+#if 0 /* for RDoc */
+/*
+ *  call-seq:
+ *     sym.name   -> string
+ *
+ *  Returns the name or string corresponding to <i>sym</i>. Unlike #to_s, the
+ *  returned string is frozen.
+ *
+ *     :fred.name         #=> "fred"
+ *     :fred.name.frozen? #=> true
+ *     :fred.to_s         #=> "fred"
+ *     :fred.to_s.frozen? #=> false
+ */
+VALUE
+rb_sym2str(VALUE sym)
+{
+
+}
+#endif
+
 
 /*
  *  call-seq:
@@ -11062,6 +11082,9 @@ sym_inspect(VALUE sym)
  *
  *     :fred.id2name   #=> "fred"
  *     :ginger.to_s    #=> "ginger"
+ *
+ *  Note that this string is not frozen (unlike the symbol itself).
+ *  To get a frozen string, use #name.
  */
 
 


### PR DESCRIPTION
This PR adds missing documentation for some new/changed features of Ruby 3.0 -- only where the docs were clearly missing, and their formulations are more or less simple. I'll add separate PRs with more complicated features.
In this PR:
* `Symbol#name`
* `Fiber#backtrace` and `#backtrace_locations` (but not new scheduler-related methods -- see #3891, and not `#transfer`s changed behaior, it requires thorough redocumenting)
* `Proc#==` and `#eql?`
* Lost `Random` instance methods are visible again.