### PR TITLE
irb: add more syntax errors colorizing support

### DIFF
--- a/lib/irb/color.rb
+++ b/lib/irb/color.rb
@@ -60,6 +60,10 @@ module IRB # :nodoc:
         on_words_beg:       [[RED, BOLD],             ALL],
         on_parse_error:     [[RED, REVERSE],          ALL],
         compile_error:      [[RED, REVERSE],          ALL],
+        on_assign_error:    [[RED, REVERSE],          ALL],
+        on_alias_error:     [[RED, REVERSE],          ALL],
+        on_class_name_error:[[RED, REVERSE],          ALL],
+        on_param_error:     [[RED, REVERSE],          ALL],
       }
     rescue NameError
       # Give up highlighting Ripper-incompatible older Ruby

--- a/test/irb/test_color.rb
+++ b/test/irb/test_color.rb
@@ -82,9 +82,23 @@ module TestIRB
         tests.merge!({
           "[1]]]\u0013" => "[#{BLUE}#{BOLD}1#{CLEAR}]#{RED}#{REVERSE}]#{CLEAR}#{RED}#{REVERSE}]#{CLEAR}#{RED}#{REVERSE}^S#{CLEAR}",
         })
+        tests.merge!({
+          "def req(true) end" => "#{GREEN}def#{CLEAR} #{BLUE}#{BOLD}req#{CLEAR}(#{RED}#{REVERSE}true#{CLEAR}) #{RED}#{REVERSE}end#{CLEAR}",
+          "nil = 1" => "#{RED}#{REVERSE}nil#{CLEAR} = #{BLUE}#{BOLD}1#{CLEAR}",
+          "alias $x $1" => "#{GREEN}alias#{CLEAR} #{GREEN}#{BOLD}$x#{CLEAR} #{RED}#{REVERSE}$1#{CLEAR}",
+          "class bad; end" => "#{GREEN}class#{CLEAR} #{RED}#{REVERSE}bad#{CLEAR}; #{GREEN}end#{CLEAR}",
+          "def req(@a) end" => "#{GREEN}def#{CLEAR} #{BLUE}#{BOLD}req#{CLEAR}(#{RED}#{REVERSE}@a#{CLEAR}) #{GREEN}end#{CLEAR}",
+        })
       else
         tests.merge!({
           "[1]]]\u0013" => "[1]]]^S",
+          })
+        tests.merge!({
+          "def req(true) end" => "def req(true) end",
+          "nil = 1" => "#{CYAN}#{BOLD}nil#{CLEAR} = #{BLUE}#{BOLD}1#{CLEAR}",
+          "alias $x $1" => "#{GREEN}alias#{CLEAR} #{GREEN}#{BOLD}$x#{CLEAR} $1",
+          "class bad; end" => "#{GREEN}class#{CLEAR} bad; #{GREEN}end#{CLEAR}",
+          "def req(@a) end" => "#{GREEN}def#{CLEAR} #{BLUE}#{BOLD}req#{CLEAR}(@a) #{GREEN}end#{CLEAR}",
         })
       end
 


### PR DESCRIPTION
I'm not sure the `end` on the first sample for 3.0.0+ should be highlighted or not.

```
$ ./ruby -e 'def req(true) end' 2>&1 | cat
-e:1: syntax error, unexpected `true', expecting ')'
def req(true) end
        ^~~~
```
