### PR TITLE
Declare Ractor-safe for Fiber

### DIFF
--- a/cont.c
+++ b/cont.c
@@ -2744,6 +2744,9 @@ ruby_Init_Continuation_body(void)
 void
 ruby_Init_Fiber_as_Coroutine(void)
 {
+#ifdef HAVE_RB_EXT_RACTOR_SAFE
+    rb_ext_ractor_safe(true);
+#endif
     rb_define_method(rb_cFiber, "transfer", rb_fiber_m_transfer, -1);
     rb_define_method(rb_cFiber, "alive?", rb_fiber_alive_p, 0);
     rb_define_singleton_method(rb_cFiber, "current", rb_fiber_s_current, 0);

--- a/test/fiber/test_ractor.rb
+++ b/test/fiber/test_ractor.rb
@@ -10,6 +10,7 @@ class TestFiberCurrentRactor < Test::Unit::TestCase
   def test_ractor_shareable
     assert_separately([], "#{<<~"begin;"}\n#{<<~'end;'}")
     begin;
+      $VERBOSE = nil
       require "fiber"
       r = Ractor.new do
         Fiber.new do

--- a/test/fiber/test_ractor.rb
+++ b/test/fiber/test_ractor.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require "test/unit"
+require "fiber"
+
+class TestFiberCurrentRactor < Test::Unit::TestCase
+  def setup
+    skip unless defined? Ractor
+  end
+
+  def test_ractor_shareable
+    assert_separately([], "#{<<~"begin;"}\n#{<<~'end;'}")
+    begin;
+      require "fiber"
+      r = Ractor.new do
+        Fiber.new do
+          Fiber.current.class
+        end.resume
+      end
+      assert_equal(Fiber, r.take)
+    end;
+  end
+end


### PR DESCRIPTION
`Fiber.current` and `Fiber#transfer` is thread-based and `Fiber#alive?` is fiber-based. All of the methods should be able to be called inside Ractor, which is currently disabled.