### PR TITLE
Check deprecated functions at compilation time

### DIFF
--- a/error.c
+++ b/error.c
@@ -3313,14 +3313,14 @@ rb_check_frozen(VALUE obj)
 void
 rb_error_untrusted(VALUE obj)
 {
-    rb_warn_deprecated_to_remove_at("3.2", "rb_error_untrusted", NULL);
+    rb_warn_deprecated_to_remove_at(3.2, "rb_error_untrusted", NULL);
 }
 
 #undef rb_check_trusted
 void
 rb_check_trusted(VALUE obj)
 {
-    rb_warn_deprecated_to_remove_at("3.2", "rb_check_trusted", NULL);
+    rb_warn_deprecated_to_remove_at(3.2, "rb_check_trusted", NULL);
 }
 
 void

--- a/error.c
+++ b/error.c
@@ -493,11 +493,13 @@ deprecation_warning_enabled(void)
 }
 
 static void
-warn_deprecated(VALUE mesg, bool removal, const char *suggest)
+warn_deprecated(VALUE mesg, const char *removal, const char *suggest)
 {
     rb_str_set_len(mesg, RSTRING_LEN(mesg) - 1);
     rb_str_cat_cstr(mesg, " is deprecated");
-    if (removal) rb_str_cat_cstr(mesg, ", and is planned for removal");
+    if (removal) {
+        rb_str_catf(mesg, " and will be removed in Ruby %s", removal);
+    }
     if (suggest) rb_str_catf(mesg, "; use %s instead", suggest);
     rb_str_cat_cstr(mesg, "\n");
     rb_warn_category(mesg, ID2SYM(id_deprecated));
@@ -513,11 +515,11 @@ rb_warn_deprecated(const char *fmt, const char *suggest, ...)
     VALUE mesg = warning_string(0, fmt, args);
     va_end(args);
 
-    warn_deprecated(mesg, false, suggest);
+    warn_deprecated(mesg, NULL, suggest);
 }
 
 void
-rb_warn_deprecated_to_remove(const char *fmt, const char *suggest, ...)
+rb_warn_deprecated_to_remove(const char *removal, const char *fmt, const char *suggest, ...)
 {
     if (!deprecation_warning_enabled()) return;
 
@@ -526,7 +528,7 @@ rb_warn_deprecated_to_remove(const char *fmt, const char *suggest, ...)
     VALUE mesg = warning_string(0, fmt, args);
     va_end(args);
 
-    warn_deprecated(mesg, true, suggest);
+    warn_deprecated(mesg, removal, suggest);
 }
 
 static inline int

--- a/hash.c
+++ b/hash.c
@@ -5043,7 +5043,7 @@ env_fetch(int argc, VALUE *argv, VALUE _)
 int
 rb_env_path_tainted(void)
 {
-    rb_warn_deprecated_to_remove_at("3.2", "rb_env_path_tainted", NULL);
+    rb_warn_deprecated_to_remove_at(3.2, "rb_env_path_tainted", NULL);
     return 0;
 }
 

--- a/hash.c
+++ b/hash.c
@@ -5043,7 +5043,7 @@ env_fetch(int argc, VALUE *argv, VALUE _)
 int
 rb_env_path_tainted(void)
 {
-    rb_warn_deprecated_to_remove("rb_env_path_tainted", "3.2");
+    rb_warn_deprecated_to_remove_at("3.2", "rb_env_path_tainted", NULL);
     return 0;
 }
 

--- a/internal/error.h
+++ b/internal/error.h
@@ -75,6 +75,7 @@ PRINTF_ARGS(void rb_warn_deprecated_to_remove(const char *removal, const char *f
 RBIMPL_ATTR_FORCEINLINE()
 static void
 rb_deprecated_method_to_be_removed(const char *removal)
+    RBIMPL_ATTR_DIAGNOSE_IF(!RUBY_VERSION_isdigit(removal[0]), "malformed version number", "error")
     RBIMPL_ATTR_DIAGNOSE_IF(RUBY_VERSION_SINCE(removal), "deprecated method to be removed", "error")
 {
 }
@@ -82,7 +83,7 @@ rb_deprecated_method_to_be_removed(const char *removal)
 RBIMPL_ATTR_ERROR(("deprecated"))
 void rb_deprecated_method_to_be_removed(const char *);
 #   define rb_deprecated_method_to_be_removed(removal) \
-    (sizeof(char[1-2*RUBY_VERSION_SINCE(removal)])!=1 ? \
+    (sizeof(char[1-2*(!RUBY_VERSION_isdigit(removal[0]) || RUBY_VERSION_SINCE(removal))])!=1 ? \
      rb_deprecated_method_to_be_removed(removal) : \
      RBIMPL_ASSERT_NOTHING)
 # endif

--- a/internal/error.h
+++ b/internal/error.h
@@ -88,11 +88,11 @@ void rb_deprecated_method_to_be_removed(const char *);
      RBIMPL_ASSERT_NOTHING)
 # endif
 # define rb_warn_deprecated_to_remove_at(removal, ...) \
-    (rb_deprecated_method_to_be_removed(removal), \
-     rb_warn_deprecated_to_remove(removal, __VA_ARGS__))
+    (rb_deprecated_method_to_be_removed(#removal), \
+     rb_warn_deprecated_to_remove(#removal, __VA_ARGS__))
 #else
 # define rb_warn_deprecated_to_remove_at(removal, ...) \
-        rb_warn_deprecated_to_remove(removal, __VA_ARGS__)
+        rb_warn_deprecated_to_remove(#removal, __VA_ARGS__)
 #endif
 VALUE rb_syntax_error_append(VALUE, VALUE, int, int, rb_encoding*, const char*, va_list);
 PRINTF_ARGS(void rb_enc_warn(rb_encoding *enc, const char *fmt, ...), 2, 3);

--- a/internal/error.h
+++ b/internal/error.h
@@ -49,7 +49,7 @@ NORETURN(void rb_async_bug_errno(const char *,int));
 const char *rb_builtin_type_name(int t);
 const char *rb_builtin_class_name(VALUE x);
 PRINTF_ARGS(void rb_warn_deprecated(const char *fmt, const char *suggest, ...), 1, 3);
-PRINTF_ARGS(void rb_warn_deprecated_to_remove(const char *fmt, const char *suggest, ...), 1, 3);
+PRINTF_ARGS(void rb_warn_deprecated_to_remove(const char *removal, const char *fmt, const char *suggest, ...), 2, 4);
 #if RUBY_DEBUG && (RBIMPL_HAS_ATTRIBUTE(diagnose_if) || defined(__OPTIMIZE__))
 # include "ruby/version.h"
 
@@ -88,10 +88,10 @@ void rb_deprecated_method_to_be_removed(const char *);
 # endif
 # define rb_warn_deprecated_to_remove_at(removal, ...) \
     (rb_deprecated_method_to_be_removed(removal), \
-     rb_warn_deprecated_to_remove(__VA_ARGS__))
+     rb_warn_deprecated_to_remove(removal, __VA_ARGS__))
 #else
 # define rb_warn_deprecated_to_remove_at(removal, ...) \
-        rb_warn_deprecated_to_remove(__VA_ARGS__)
+        rb_warn_deprecated_to_remove(removal, __VA_ARGS__)
 #endif
 VALUE rb_syntax_error_append(VALUE, VALUE, int, int, rb_encoding*, const char*, va_list);
 PRINTF_ARGS(void rb_enc_warn(rb_encoding *enc, const char *fmt, ...), 2, 3);

--- a/internal/error.h
+++ b/internal/error.h
@@ -49,7 +49,50 @@ NORETURN(void rb_async_bug_errno(const char *,int));
 const char *rb_builtin_type_name(int t);
 const char *rb_builtin_class_name(VALUE x);
 PRINTF_ARGS(void rb_warn_deprecated(const char *fmt, const char *suggest, ...), 1, 3);
-PRINTF_ARGS(void rb_warn_deprecated_to_remove(const char *fmt, const char *removal, ...), 1, 3);
+PRINTF_ARGS(void rb_warn_deprecated_to_remove(const char *fmt, const char *suggest, ...), 1, 3);
+#if RUBY_DEBUG && (RBIMPL_HAS_ATTRIBUTE(diagnose_if) || defined(__OPTIMIZE__))
+# include "ruby/version.h"
+
+#define RUBY_VERSION_isdigit(c) ('0'<=(c)&&(c)<='9')
+// upto 99
+#define RUBY_VERSION__number_len(v, ofs) \
+    (!RUBY_VERSION_isdigit((v)[ofs]) ? \
+     0 : !RUBY_VERSION_isdigit((v)[(ofs) + 1]) ? 1 : 2)
+#define RUBY_VERSION__to_number(v, ofs) \
+    (!RUBY_VERSION_isdigit((v)[ofs]) ? \
+     0 : !RUBY_VERSION_isdigit((v)[(ofs) + 1]) ? \
+     ((v)[ofs]-'0') : \
+     (((v)[ofs]-'0')*10+(v)[(ofs)+1]-'0'))
+
+#define RUBY_VERSION_CODE_FROM_MAJOR_MINOR_STRING(v) \
+    (RUBY_VERSION__to_number(v, 0) * 10000 + \
+     ((v)[RUBY_VERSION__number_len(v, 0)] == '.' ? \
+      RUBY_VERSION__to_number(v, RUBY_VERSION__number_len(v, 0)+1) * 100 : 0))
+#define RUBY_VERSION_SINCE(v) (RUBY_API_VERSION_CODE >= RUBY_VERSION_CODE_FROM_MAJOR_MINOR_STRING(v))
+#define RUBY_VERSION_BEFORE(v) (RUBY_API_VERSION_CODE < RUBY_VERSION_CODE_FROM_MAJOR_MINOR_STRING(v))
+
+# if RBIMPL_HAS_ATTRIBUTE(diagnose_if)
+RBIMPL_ATTR_FORCEINLINE()
+static void
+rb_deprecated_method_to_be_removed(const char *removal)
+    RBIMPL_ATTR_DIAGNOSE_IF(RUBY_VERSION_SINCE(removal), "deprecated method to be removed", "error")
+{
+}
+# else
+RBIMPL_ATTR_ERROR(("deprecated"))
+void rb_deprecated_method_to_be_removed(const char *);
+#   define rb_deprecated_method_to_be_removed(removal) \
+    (sizeof(char[1-2*RUBY_VERSION_SINCE(removal)])!=1 ? \
+     rb_deprecated_method_to_be_removed(removal) : \
+     RBIMPL_ASSERT_NOTHING)
+# endif
+# define rb_warn_deprecated_to_remove_at(removal, ...) \
+    (rb_deprecated_method_to_be_removed(removal), \
+     rb_warn_deprecated_to_remove(__VA_ARGS__))
+#else
+# define rb_warn_deprecated_to_remove_at(removal, ...) \
+        rb_warn_deprecated_to_remove(__VA_ARGS__)
+#endif
 VALUE rb_syntax_error_append(VALUE, VALUE, int, int, rb_encoding*, const char*, va_list);
 PRINTF_ARGS(void rb_enc_warn(rb_encoding *enc, const char *fmt, ...), 2, 3);
 PRINTF_ARGS(void rb_sys_enc_warning(rb_encoding *enc, const char *fmt, ...), 2, 3);

--- a/object.c
+++ b/object.c
@@ -1205,7 +1205,7 @@ rb_obj_dummy1(VALUE _x, VALUE _y)
 VALUE
 rb_obj_tainted(VALUE obj)
 {
-    rb_warn_deprecated_to_remove("Object#tainted?", "3.2");
+    rb_warn_deprecated_to_remove_at("3.2", "Object#tainted?", NULL);
     return Qfalse;
 }
 
@@ -1219,7 +1219,7 @@ rb_obj_tainted(VALUE obj)
 VALUE
 rb_obj_taint(VALUE obj)
 {
-    rb_warn_deprecated_to_remove("Object#taint", "3.2");
+    rb_warn_deprecated_to_remove_at("3.2", "Object#taint", NULL);
     return obj;
 }
 
@@ -1234,7 +1234,7 @@ rb_obj_taint(VALUE obj)
 VALUE
 rb_obj_untaint(VALUE obj)
 {
-    rb_warn_deprecated_to_remove("Object#untaint", "3.2");
+    rb_warn_deprecated_to_remove_at("3.2", "Object#untaint", NULL);
     return obj;
 }
 
@@ -1248,7 +1248,7 @@ rb_obj_untaint(VALUE obj)
 VALUE
 rb_obj_untrusted(VALUE obj)
 {
-    rb_warn_deprecated_to_remove("Object#untrusted?", "3.2");
+    rb_warn_deprecated_to_remove_at("3.2", "Object#untrusted?", NULL);
     return Qfalse;
 }
 
@@ -1262,7 +1262,7 @@ rb_obj_untrusted(VALUE obj)
 VALUE
 rb_obj_untrust(VALUE obj)
 {
-    rb_warn_deprecated_to_remove("Object#untrust", "3.2");
+    rb_warn_deprecated_to_remove_at("3.2", "Object#untrust", NULL);
     return obj;
 }
 
@@ -1277,7 +1277,7 @@ rb_obj_untrust(VALUE obj)
 VALUE
 rb_obj_trust(VALUE obj)
 {
-    rb_warn_deprecated_to_remove("Object#trust", "3.2");
+    rb_warn_deprecated_to_remove_at("3.2", "Object#trust", NULL);
     return obj;
 }
 
@@ -1288,7 +1288,7 @@ rb_obj_trust(VALUE obj)
 void
 rb_obj_infect(VALUE victim, VALUE carrier)
 {
-    rb_warn_deprecated_to_remove("rb_obj_infect", "3.2");
+    rb_warn_deprecated_to_remove_at("3.2", "rb_obj_infect", NULL);
 }
 
 /**

--- a/object.c
+++ b/object.c
@@ -1205,7 +1205,7 @@ rb_obj_dummy1(VALUE _x, VALUE _y)
 VALUE
 rb_obj_tainted(VALUE obj)
 {
-    rb_warn_deprecated_to_remove_at("3.2", "Object#tainted?", NULL);
+    rb_warn_deprecated_to_remove_at(3.2, "Object#tainted?", NULL);
     return Qfalse;
 }
 
@@ -1219,7 +1219,7 @@ rb_obj_tainted(VALUE obj)
 VALUE
 rb_obj_taint(VALUE obj)
 {
-    rb_warn_deprecated_to_remove_at("3.2", "Object#taint", NULL);
+    rb_warn_deprecated_to_remove_at(3.2, "Object#taint", NULL);
     return obj;
 }
 
@@ -1234,7 +1234,7 @@ rb_obj_taint(VALUE obj)
 VALUE
 rb_obj_untaint(VALUE obj)
 {
-    rb_warn_deprecated_to_remove_at("3.2", "Object#untaint", NULL);
+    rb_warn_deprecated_to_remove_at(3.2, "Object#untaint", NULL);
     return obj;
 }
 
@@ -1248,7 +1248,7 @@ rb_obj_untaint(VALUE obj)
 VALUE
 rb_obj_untrusted(VALUE obj)
 {
-    rb_warn_deprecated_to_remove_at("3.2", "Object#untrusted?", NULL);
+    rb_warn_deprecated_to_remove_at(3.2, "Object#untrusted?", NULL);
     return Qfalse;
 }
 
@@ -1262,7 +1262,7 @@ rb_obj_untrusted(VALUE obj)
 VALUE
 rb_obj_untrust(VALUE obj)
 {
-    rb_warn_deprecated_to_remove_at("3.2", "Object#untrust", NULL);
+    rb_warn_deprecated_to_remove_at(3.2, "Object#untrust", NULL);
     return obj;
 }
 
@@ -1277,7 +1277,7 @@ rb_obj_untrust(VALUE obj)
 VALUE
 rb_obj_trust(VALUE obj)
 {
-    rb_warn_deprecated_to_remove_at("3.2", "Object#trust", NULL);
+    rb_warn_deprecated_to_remove_at(3.2, "Object#trust", NULL);
     return obj;
 }
 
@@ -1288,7 +1288,7 @@ rb_obj_trust(VALUE obj)
 void
 rb_obj_infect(VALUE victim, VALUE carrier)
 {
-    rb_warn_deprecated_to_remove_at("3.2", "rb_obj_infect", NULL);
+    rb_warn_deprecated_to_remove_at(3.2, "rb_obj_infect", NULL);
 }
 
 /**

--- a/string.c
+++ b/string.c
@@ -944,14 +944,14 @@ rb_enc_str_new_static(const char *ptr, long len, rb_encoding *enc)
 VALUE
 rb_tainted_str_new(const char *ptr, long len)
 {
-    rb_warn_deprecated_to_remove_at("3.2", "rb_tainted_str_new", NULL);
+    rb_warn_deprecated_to_remove_at(3.2, "rb_tainted_str_new", NULL);
     return rb_str_new(ptr, len);
 }
 
 VALUE
 rb_tainted_str_new_cstr(const char *ptr)
 {
-    rb_warn_deprecated_to_remove_at("3.2", "rb_tainted_str_new_cstr", NULL);
+    rb_warn_deprecated_to_remove_at(3.2, "rb_tainted_str_new_cstr", NULL);
     return rb_str_new_cstr(ptr);
 }
 

--- a/string.c
+++ b/string.c
@@ -944,14 +944,14 @@ rb_enc_str_new_static(const char *ptr, long len, rb_encoding *enc)
 VALUE
 rb_tainted_str_new(const char *ptr, long len)
 {
-    rb_warn_deprecated_to_remove("rb_tainted_str_new", "3.2");
+    rb_warn_deprecated_to_remove_at("3.2", "rb_tainted_str_new", NULL);
     return rb_str_new(ptr, len);
 }
 
 VALUE
 rb_tainted_str_new_cstr(const char *ptr)
 {
-    rb_warn_deprecated_to_remove("rb_tainted_str_new_cstr", "3.2");
+    rb_warn_deprecated_to_remove_at("3.2", "rb_tainted_str_new_cstr", NULL);
     return rb_str_new_cstr(ptr);
 }
 


### PR DESCRIPTION
Currently `rb_warn_deprecated_to_remove` shows the deprecation warning with the version to remove. Often we can miss it however, especially as now deprecation warnings are suppressed by default. It's better to notice automatically, probably at build-time.

This is not perfect, but it can detect the miss at least a few jobs in the CIs.

Also, this changes the message not to print the future version, as [@shyouhei said](https://github.com/ruby/ruby/pull/3424/commits/2f730d89ada6f73b5e2bf06acc19452b7e900607).
> Proper annotation of when to remove a feature helps us a lot ("don't delete it now" sign), but can rarely be useful to end users. Let's just use the info internally.

[Feature #17432](https://bugs.ruby-lang.org/issues/17432)