### PR TITLE
pp is ractor-ready.

### DIFF
--- a/lib/pp.rb
+++ b/lib/pp.rb
@@ -93,11 +93,24 @@ class PP < PrettyPrint
   end
   # :startdoc:
 
-  @sharing_detection = false
-  class << self
-    # Returns the sharing detection flag as a boolean value.
-    # It is false by default.
-    attr_accessor :sharing_detection
+  if defined? ::Ractor
+    class << self
+      # Returns the sharing detection flag as a boolean value.
+      # It is false (nil) by default.
+      def sharing_detection
+        Ractor.current[:pp_sharing_detection]
+      end
+      def sharing_detection=(b)
+        Ractor.current[:pp_sharing_detection] = b
+      end
+    end
+  else
+    @sharing_detection = false
+    class << self
+      # Returns the sharing detection flag as a boolean value.
+      # It is false by default.
+      attr_accessor :sharing_detection
+    end
   end
 
   module PPMethods


### PR DESCRIPTION
`@sharing_detection` is only one obstruction to support pp on
non-main ractors, so make it ractor-local.