### PR TITLE
dir.c: chdir conflict should raise only when called in different thread

### DIFF
--- a/dir.c
+++ b/dir.c
@@ -1064,8 +1064,10 @@ dir_s_chdir(int argc, VALUE *argv, VALUE obj)
     }
 
     if (chdir_blocking > 0) {
-	if (!rb_block_given_p() || rb_thread_current() != chdir_thread)
+	if (rb_thread_current() != chdir_thread)
             rb_raise(rb_eRuntimeError, "conflicting chdir during another chdir block");
+        if (!rb_block_given_p())
+            rb_warn("conflicting chdir during another chdir block");
     }
 
     if (rb_block_given_p()) {

--- a/test/ruby/test_dir.rb
+++ b/test/ruby/test_dir.rb
@@ -97,9 +97,22 @@ class TestDir < Test::Unit::TestCase
     assert_raise(ArgumentError) { Dir.chdir }
     ENV["HOME"] = pwd
     Dir.chdir do
-      assert_equal(pwd, Dir.pwd)
-      assert_raise(RuntimeError) { Dir.chdir(@root) }
-      assert_equal(pwd, Dir.pwd)
+      assert_warning(/conflicting chdir during another chdir block/) { Dir.chdir(pwd) }
+
+      assert_warning(/conflicting chdir during another chdir block/) { Dir.chdir(@root) }
+      assert_equal(@root, Dir.pwd)
+
+      assert_warning(/conflicting chdir during another chdir block/) { Dir.chdir(pwd) }
+
+      assert_raise(RuntimeError) { Thread.new { Thread.current.report_on_exception = false; Dir.chdir(@root) }.join }
+      assert_raise(RuntimeError) { Thread.new { Thread.current.report_on_exception = false; Dir.chdir(@root) { } }.join }
+
+      assert_warning(/conflicting chdir during another chdir block/) { Dir.chdir(pwd) }
+
+      assert_warning(/conflicting chdir during another chdir block/) { Dir.chdir(@root) }
+      assert_equal(@root, Dir.pwd)
+
+      assert_warning(/conflicting chdir during another chdir block/) { Dir.chdir(pwd) }
       Dir.chdir(@root) do
         assert_equal(@root, Dir.pwd)
       end


### PR DESCRIPTION
... and keep it as a warning (like 2.7) when it is called in the same
thread. [Bug #15661]