### PR TITLE
(WIP) Allow `--enable-dtrace` option in configure of FreeBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3423,7 +3423,7 @@ AS_CASE(["${enable_dtrace}"],
     rb_cv_dtrace_available=no
 ])
 AS_CASE(["$target_os"],[freebsd*],[
-         rb_cv_dtrace_available=no
+         enable_dtrace=no
 	 ])
 AS_IF([test "${enable_dtrace}" = yes], [dnl
     AS_IF([test -z "$DTRACE"], [dnl


### PR DESCRIPTION
I intended to make the default setting not to use `--enable-dtrace` option,
but I made a fix to ban the use of `--enable-dtrace` option.

This commit fllow to use `--enable-dtrace` option on FreeBSD.

ref. #3999

---

FreeBSD で `--enable-dtrace` をデフォルトから外すだけにするつもりが、使用を禁止してしまっていました(`--enable-dtrace` をつけると `configure` そのものが通らくなっていた)。
この修正では `--enable-dtrace` を禁止ではなくて、デフォルトで無効という挙動になります。

なお、現在 FreeBSD では `--enable-dtrace` を有効にしてもビルドできない状況なのでユーザ影響はほとんどないと思います。
DTrace を有効にしてコンパイルできるようにデバッグする作業者が困る、という影響だと思います。