### PR TITLE
Make a String hash fixable in hash lookup

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -211,7 +211,8 @@ any_hash(VALUE a, st_index_t (*other_func)(VALUE))
 	hnum = rb_objid_hash((st_index_t)a);
         break;
       case T_STRING:
-	hnum = rb_str_hash(a);
+        /* make hnum fixable to support delegated hash method: [Bug #17488] */
+        hnum = FIX2LONG(ST2FIX(rb_str_hash(a)));
         break;
       case T_BIGNUM:
 	hval = rb_big_hash(a);


### PR DESCRIPTION
When a delegator of a String value is passed to Hash lookup methods,
its hash method result is used. However, its value may differ from
the rb_str_hash result (which is used if String is directly passed)
since the delegator's hash method result loses some bits by ST2FIX.

To fix this issue, this makes any_hash to treat a string hash fixable.

Fixes https://bugs.ruby-lang.org/issues/17488