### PR TITLE
Make args info for RubyVM::AST to available on endless method without parens

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -5003,7 +5003,12 @@ superclass	: '<'
 		    }
 		;
 
-f_opt_paren_args: f_paren_args | none;
+f_opt_paren_args: f_paren_args
+		| none
+		    {
+			$$ = new_args_tail(p, Qnone, Qnone, Qnone, &@0);
+			$$ = new_args(p, Qnone, Qnone, Qnone, Qnone, $$, &@0);
+		    }
 
 f_paren_args	: '(' f_args rparen
 		    {

--- a/parse.y
+++ b/parse.y
@@ -5009,6 +5009,7 @@ f_opt_paren_args: f_paren_args
 			$$ = new_args_tail(p, Qnone, Qnone, Qnone, &@0);
 			$$ = new_args(p, Qnone, Qnone, Qnone, Qnone, $$, &@0);
 		    }
+		;
 
 f_paren_args	: '(' f_args rparen
 		    {


### PR DESCRIPTION
ticket: https://bugs.ruby-lang.org/issues/17495

Problem
===

Arguments information is missing for endless method without parens.
For example:

```ruby
# ok
pp RubyVM::AbstractSyntaxTree.parse(<<~RUBY).children[2]
  def x() = 42
RUBY
# => (DEFN@1:0-1:12
#     mid: :x
#     body:
#       (SCOPE@1:0-1:12
#        tbl: []
#        args:
#          (ARGS@1:5-1:6
#           pre_num: 0
#           pre_init: nil
#           opt: nil
#           first_post: nil
#           post_num: 0
#           post_init: nil
#           rest: nil
#           kw: nil
#           kwrest: nil
#           block: nil)
#        body: (LIT@1:10-1:12 42)))
```


```ruby
# ok
pp RubyVM::AbstractSyntaxTree.parse(<<~RUBY).children[2]
  def x() 42 end
RUBY
# => (DEFN@1:0-1:14
#     mid: :x
#     body:
#       (SCOPE@1:0-1:14
#        tbl: []
#        args:
#          (ARGS@1:5-1:6
#           pre_num: 0
#           pre_init: nil
#           opt: nil
#           first_post: nil
#           post_num: 0
#           post_init: nil
#           rest: nil
#           kw: nil
#           kwrest: nil
#           block: nil)
#        body: (LIT@1:8-1:10 42)))
```

```ruby
# It has a problem, the `args` is nil
pp RubyVM::AbstractSyntaxTree.parse(<<~RUBY).children[2]
  def x = 42
RUBY
# => (DEFN@1:0-1:10
#     mid: :x
#     body: (SCOPE@1:0-1:10 tbl: [] args: nil body: (LIT@1:8-1:10 42)))
```

It causes an error if a program expects `args` node exists.
For example: https://github.com/ruby/rbs/issues/551

Solution Proposal
====


Set `new_args` result to `$$`.



I referred to the normal method definition's implementation.  https://github.com/ruby/ruby/blob/48cf548beb8d641d7dd2cb05f8470526eff7661e/parse.y#L5138-L5142


 I am a very beginner at parse.y, so I'm not sure this solution is good. If something wrong, please tell me advice 🙏