### PR TITLE
Improve performance some Float methods

### DIFF
--- a/.document
+++ b/.document
@@ -14,7 +14,7 @@ array.rb
 ast.rb
 dir.rb
 gc.rb
-integer.rb
+numeric.rb
 io.rb
 kernel.rb
 pack.rb

--- a/benchmark/float_methods.yml
+++ b/benchmark/float_methods.yml
@@ -1,0 +1,14 @@
+prelude: |
+  flo = 4.2
+benchmark:
+  to_f: |
+    flo.to_f
+  abs: |
+    flo.abs
+  magnitude: |
+    flo.magnitude
+  -@: |
+    -flo
+  zero?: |
+    flo.zero?
+loop_count: 20000000

--- a/common.mk
+++ b/common.mk
@@ -1020,7 +1020,7 @@ BUILTIN_RB_SRCS = \
 		$(srcdir)/ast.rb \
 		$(srcdir)/dir.rb \
 		$(srcdir)/gc.rb \
-		$(srcdir)/integer.rb \
+		$(srcdir)/numeric.rb \
 		$(srcdir)/io.rb \
 		$(srcdir)/pack.rb \
 		$(srcdir)/trace_point.rb \
@@ -8224,7 +8224,6 @@ miniinit.$(OBJEXT): {$(VPATH)}encoding.h
 miniinit.$(OBJEXT): {$(VPATH)}gc.rb
 miniinit.$(OBJEXT): {$(VPATH)}gem_prelude.rb
 miniinit.$(OBJEXT): {$(VPATH)}id.h
-miniinit.$(OBJEXT): {$(VPATH)}integer.rb
 miniinit.$(OBJEXT): {$(VPATH)}intern.h
 miniinit.$(OBJEXT): {$(VPATH)}internal.h
 miniinit.$(OBJEXT): {$(VPATH)}internal/anyargs.h
@@ -8376,6 +8375,7 @@ miniinit.$(OBJEXT): {$(VPATH)}miniinit.c
 miniinit.$(OBJEXT): {$(VPATH)}miniprelude.c
 miniinit.$(OBJEXT): {$(VPATH)}missing.h
 miniinit.$(OBJEXT): {$(VPATH)}node.h
+miniinit.$(OBJEXT): {$(VPATH)}numeric.rb
 miniinit.$(OBJEXT): {$(VPATH)}onigmo.h
 miniinit.$(OBJEXT): {$(VPATH)}oniguruma.h
 miniinit.$(OBJEXT): {$(VPATH)}pack.rb
@@ -9062,8 +9062,6 @@ numeric.$(OBJEXT): {$(VPATH)}defines.h
 numeric.$(OBJEXT): {$(VPATH)}encoding.h
 numeric.$(OBJEXT): {$(VPATH)}id.h
 numeric.$(OBJEXT): {$(VPATH)}id_table.h
-numeric.$(OBJEXT): {$(VPATH)}integer.rb
-numeric.$(OBJEXT): {$(VPATH)}integer.rbinc
 numeric.$(OBJEXT): {$(VPATH)}intern.h
 numeric.$(OBJEXT): {$(VPATH)}internal.h
 numeric.$(OBJEXT): {$(VPATH)}internal/anyargs.h
@@ -9208,6 +9206,8 @@ numeric.$(OBJEXT): {$(VPATH)}internal/warning_push.h
 numeric.$(OBJEXT): {$(VPATH)}internal/xmalloc.h
 numeric.$(OBJEXT): {$(VPATH)}missing.h
 numeric.$(OBJEXT): {$(VPATH)}numeric.c
+numeric.$(OBJEXT): {$(VPATH)}numeric.rb
+numeric.$(OBJEXT): {$(VPATH)}numeric.rbinc
 numeric.$(OBJEXT): {$(VPATH)}onigmo.h
 numeric.$(OBJEXT): {$(VPATH)}oniguruma.h
 numeric.$(OBJEXT): {$(VPATH)}ruby_assert.h

--- a/inits.c
+++ b/inits.c
@@ -87,7 +87,7 @@ rb_call_builtin_inits(void)
 #define BUILTIN(n) CALL(builtin_##n)
     BUILTIN(gc);
     BUILTIN(ractor);
-    BUILTIN(integer);
+    BUILTIN(numeric);
     BUILTIN(io);
     BUILTIN(dir);
     BUILTIN(ast);

--- a/numeric.c
+++ b/numeric.c
@@ -1030,13 +1030,6 @@ flo_coerce(VALUE x, VALUE y)
     return rb_assoc_new(rb_Float(y), x);
 }
 
-/*
- * call-seq:
- *    -float  ->  float
- *
- * Returns +float+, negated.
- */
-
 VALUE
 rb_float_uminus(VALUE flt)
 {
@@ -1701,51 +1694,11 @@ rb_float_eql(VALUE x, VALUE y)
 
 #define flo_eql rb_float_eql
 
-/*
- * call-seq:
- *    float.to_f  ->  self
- *
- * Since +float+ is already a Float, returns +self+.
- */
-
-static VALUE
-flo_to_f(VALUE num)
-{
-    return num;
-}
-
-/*
- *  call-seq:
- *     float.abs        ->  float
- *     float.magnitude  ->  float
- *
- *  Returns the absolute value of +float+.
- *
- *     (-34.56).abs   #=> 34.56
- *     -34.56.abs     #=> 34.56
- *     34.56.abs      #=> 34.56
- *
- *  Float#magnitude is an alias for Float#abs.
- */
-
 VALUE
 rb_float_abs(VALUE flt)
 {
     double val = fabs(RFLOAT_VALUE(flt));
     return DBL2NUM(val);
-}
-
-/*
- *  call-seq:
- *     float.zero?  ->  true or false
- *
- *  Returns +true+ if +float+ is 0.0.
- */
-
-static VALUE
-flo_zero_p(VALUE num)
-{
-    return flo_iszero(num) ? Qtrue : Qfalse;
 }
 
 /*
@@ -5677,7 +5630,6 @@ Init_Numeric(void)
     rb_define_method(rb_cFloat, "to_s", flo_to_s, 0);
     rb_define_alias(rb_cFloat, "inspect", "to_s");
     rb_define_method(rb_cFloat, "coerce", flo_coerce, 1);
-    rb_define_method(rb_cFloat, "-@", rb_float_uminus, 0);
     rb_define_method(rb_cFloat, "+", rb_float_plus, 1);
     rb_define_method(rb_cFloat, "-", rb_float_minus, 1);
     rb_define_method(rb_cFloat, "*", rb_float_mul, 1);
@@ -5697,10 +5649,6 @@ Init_Numeric(void)
     rb_define_method(rb_cFloat, "<=", flo_le, 1);
     rb_define_method(rb_cFloat, "eql?", flo_eql, 1);
     rb_define_method(rb_cFloat, "hash", flo_hash, 0);
-    rb_define_method(rb_cFloat, "to_f", flo_to_f, 0);
-    rb_define_method(rb_cFloat, "abs", rb_float_abs, 0);
-    rb_define_method(rb_cFloat, "magnitude", rb_float_abs, 0);
-    rb_define_method(rb_cFloat, "zero?", flo_zero_p, 0);
 
     rb_define_method(rb_cFloat, "to_i", flo_to_i, 0);
     rb_define_method(rb_cFloat, "to_int", flo_to_i, 0);
@@ -5732,4 +5680,4 @@ rb_float_new(double d)
     return rb_float_new_inline(d);
 }
 
-#include "integer.rbinc"
+#include "numeric.rbinc"

--- a/numeric.rb
+++ b/numeric.rb
@@ -148,3 +148,60 @@ class Integer
     Primitive.cexpr! 'rb_int_zero_p(self)'
   end
 end
+
+class Float
+  #
+  # call-seq:
+  #    float.to_f  ->  self
+  #
+  # Since +float+ is already a Float, returns +self+.
+  #
+  def to_f
+    return self
+  end
+
+  #
+  #  call-seq:
+  #     float.abs        ->  float
+  #     float.magnitude  ->  float
+  #
+  #  Returns the absolute value of +float+.
+  #
+  #     (-34.56).abs   #=> 34.56
+  #     -34.56.abs     #=> 34.56
+  #     34.56.abs      #=> 34.56
+  #
+  #  Float#magnitude is an alias for Float#abs.
+  #
+  def abs
+    Primitive.attr! 'inline'
+    Primitive.cexpr! 'rb_float_abs(self)'
+  end
+
+  def magnitude
+    Primitive.attr! 'inline'
+    Primitive.cexpr! 'rb_float_abs(self)'
+  end
+
+  #
+  # call-seq:
+  #    -float  ->  float
+  #
+  # Returns +float+, negated.
+  #
+  def -@
+    Primitive.attr! 'inline'
+    Primitive.cexpr! 'rb_float_uminus(self)'
+  end
+
+  #
+  #  call-seq:
+  #     float.zero?  ->  true or false
+  #
+  #  Returns +true+ if +float+ is 0.0.
+  #
+  def zero?
+    Primitive.attr! 'inline'
+    Primitive.cexpr! 'flo_iszero(self) ? Qtrue : Qfalse'
+  end
+end


### PR DESCRIPTION
Improve performance some Float methods(write in Ruby)

benchmark:

```yml
prelude: |
  flo = 4.2
benchmark:
  to_f: |
    flo.to_f
  abs: |
    flo.abs
  magnitude: |
    flo.magnitude
  -@: |
    -flo
  zero?: |
    flo.zero?
loop_count: 20000000


```

result:

```bash
sh@DESKTOP-L0NI312:~/rubydev/build$ make benchmark/float_methods.yml -e BENCH_RUBY=../install/bin/ruby -e COMPARE_RUBY=~/.rbenv/shims/ruby
# Iteration per second (i/s)

|           |compare-ruby|built-ruby|
|:----------|-----------:|---------:|
|to_f       |     60.880M|   81.272M|
|           |           -|     1.33x|
|abs        |     68.162M|   81.264M|
|           |           -|     1.19x|
|magnitude  |     53.441M|   78.829M|
|           |           -|     1.48x|
|-@         |     67.193M|   84.731M|
|           |           -|     1.26x|
|zero?      |     69.894M|   82.032M|
|           |           -|     1.17x|
```

`COMPARE_RUBY` is `ruby 3.1.0dev (2020-12-31T22:55:59Z master 3d7f71801a) [x86_64-linux]`. `BENCH_RUBY` is ahead of `ruby 3.1.0dev (2020-12-31T22:55:59Z master 3d7f71801a) [x86_64-linux]`.

ticket: [Feature #17498 
Improve performance some Float methods](https://bugs.ruby-lang.org/issues/17498)