### PR TITLE
Run MJIT worker on Ractor

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1023,6 +1023,7 @@ BUILTIN_RB_SRCS = \
 		$(srcdir)/gc.rb \
 		$(srcdir)/numeric.rb \
 		$(srcdir)/io.rb \
+		$(srcdir)/mjit_worker.rb \
 		$(srcdir)/pack.rb \
 		$(srcdir)/trace_point.rb \
 		$(srcdir)/warning.rb \
@@ -8375,6 +8376,7 @@ miniinit.$(OBJEXT): {$(VPATH)}mini_builtin.c
 miniinit.$(OBJEXT): {$(VPATH)}miniinit.c
 miniinit.$(OBJEXT): {$(VPATH)}miniprelude.c
 miniinit.$(OBJEXT): {$(VPATH)}missing.h
+miniinit.$(OBJEXT): {$(VPATH)}mjit_worker.rb
 miniinit.$(OBJEXT): {$(VPATH)}node.h
 miniinit.$(OBJEXT): {$(VPATH)}numeric.rb
 miniinit.$(OBJEXT): {$(VPATH)}onigmo.h
@@ -8611,6 +8613,8 @@ mjit.$(OBJEXT): {$(VPATH)}method.h
 mjit.$(OBJEXT): {$(VPATH)}missing.h
 mjit.$(OBJEXT): {$(VPATH)}mjit.c
 mjit.$(OBJEXT): {$(VPATH)}mjit.h
+mjit.$(OBJEXT): {$(VPATH)}mjit_worker.rb
+mjit.$(OBJEXT): {$(VPATH)}mjit_worker.rbinc
 mjit.$(OBJEXT): {$(VPATH)}mjit_config.h
 mjit.$(OBJEXT): {$(VPATH)}mjit_worker.c
 mjit.$(OBJEXT): {$(VPATH)}node.h

--- a/eval.c
+++ b/eval.c
@@ -226,6 +226,10 @@ rb_ec_cleanup(rb_execution_context_t *ec, volatile int ex)
     volatile int sysex = EXIT_SUCCESS;
     volatile int step = 0;
 
+    // This must be called before rb_threadptr_interrupt() and rb_ractor_terminate_all()
+    // because make_pch must not be interrupted to complete mjit_finish().
+    mjit_finish(true);
+
     rb_threadptr_interrupt(th);
     rb_threadptr_check_signal(th);
 
@@ -289,8 +293,6 @@ rb_ec_cleanup(rb_execution_context_t *ec, volatile int ex)
 	    sysex = EXIT_FAILURE;
 	}
     }
-
-    mjit_finish(true); // We still need ISeqs here.
 
     rb_ec_finalize(ec);
 

--- a/inits.c
+++ b/inits.c
@@ -87,6 +87,9 @@ rb_call_builtin_inits(void)
 #define BUILTIN(n) CALL(builtin_##n)
     BUILTIN(gc);
     BUILTIN(ractor);
+#if USE_MJIT
+    BUILTIN(mjit_worker);
+#endif
     BUILTIN(numeric);
     BUILTIN(io);
     BUILTIN(dir);

--- a/mjit.c
+++ b/mjit.c
@@ -23,10 +23,10 @@
 #include "internal/file.h"
 #include "internal/hash.h"
 #include "internal/warnings.h"
+#include "builtin.h"
 
 #include "mjit_worker.c"
-
-extern int rb_thread_create_mjit_thread(void (*worker_func)(void));
+#include "mjit_worker.rbinc"
 
 // Return an unique file name in /tmp with PREFIX and SUFFIX and
 // number ID.  Use getpid if ID == 0.  The return file name exists
@@ -247,11 +247,15 @@ create_unit(const rb_iseq_t *iseq)
 
 // Return true if given ISeq body should be compiled by MJIT
 static inline int
-mjit_target_iseq_p(struct rb_iseq_constant_body *body)
+mjit_target_iseq_p(const rb_iseq_t *iseq)
 {
+    const struct rb_iseq_constant_body *body = iseq->body;
     return (body->type == ISEQ_TYPE_METHOD || body->type == ISEQ_TYPE_BLOCK)
         && !body->builtin_inline_p
-        && body->iseq_size < JIT_ISEQ_SIZE_THRESHOLD;
+        && body->iseq_size < JIT_ISEQ_SIZE_THRESHOLD
+        // This is needed to avoid hanging on first `RubyVM::MJITWorker.start` with `--jit-wait --jit-min-calls=1`.
+        // We don't want to pressure an overall code size by MJIT worker itself either anyway.
+        && strcmp("<internal:mjit_worker>", RSTRING_PTR(rb_iseq_path(iseq)));
 }
 
 static void
@@ -260,7 +264,7 @@ mjit_add_iseq_to_process(const rb_iseq_t *iseq, const struct rb_mjit_compile_inf
     if (!mjit_enabled || pch_status == PCH_FAILED)
         return;
 
-    if (!mjit_target_iseq_p(iseq->body)) {
+    if (!mjit_target_iseq_p(iseq)) {
         iseq->body->jit_func = (mjit_func_t)NOT_COMPILED_JIT_ISEQ_FUNC; // skip mjit_wait
         return;
     }
@@ -603,24 +607,14 @@ system_tmpdir(void)
 // A default threshold used to add iseq to JIT.
 #define DEFAULT_MIN_CALLS_TO_ADD 10000
 
-// Start MJIT worker. Return TRUE if worker is successfully started.
-static bool
+// Start MJIT worker.
+static void
 start_worker(void)
 {
     stop_worker_p = false;
+    VALUE rb_cMJITWorker = rb_const_get(rb_cRubyVM, rb_intern("MJITWorker"));
+    rb_funcall(rb_cMJITWorker, rb_intern("start"), 0);
     worker_stopped = false;
-
-    if (!rb_thread_create_mjit_thread(mjit_worker)) {
-        mjit_enabled = false;
-        rb_native_mutex_destroy(&mjit_engine_mutex);
-        rb_native_cond_destroy(&mjit_pch_wakeup);
-        rb_native_cond_destroy(&mjit_client_wakeup);
-        rb_native_cond_destroy(&mjit_worker_wakeup);
-        rb_native_cond_destroy(&mjit_gc_wakeup);
-        verbose(1, "Failure in MJIT thread initialization\n");
-        return false;
-    }
-    return true;
 }
 
 // There's no strndup on Windows
@@ -723,8 +717,15 @@ mjit_init(const struct mjit_options *opts)
     // meaning mjit_cont_new is skipped for the root_fiber. Therefore we need to call
     // rb_fiber_init_mjit_cont again with mjit_enabled=true to set the root_fiber's mjit_cont.
     rb_fiber_init_mjit_cont(GET_EC()->fiber_ptr);
+}
 
-    // Initialize worker thread
+// Initialize MJIT worker. This is separated from mjit_init because mjit_init
+// needs to be executed early for initializing mutex, and mjit_worker_init needs
+// to be called late to use builtin.
+void
+mjit_worker_init(void)
+{
+    // Initialize worker ractor
     start_worker();
 }
 
@@ -783,9 +784,7 @@ mjit_resume(void)
         return Qfalse;
     }
 
-    if (!start_worker()) {
-        rb_raise(rb_eRuntimeError, "Failed to resume MJIT worker");
-    }
+    start_worker();
     return Qtrue;
 }
 

--- a/mjit.h
+++ b/mjit.h
@@ -92,6 +92,7 @@ RUBY_SYMBOL_EXPORT_END
 
 extern bool mjit_compile(FILE *f, const rb_iseq_t *iseq, const char *funcname, int id);
 extern void mjit_init(const struct mjit_options *opts);
+extern void mjit_worker_init(void);
 extern void mjit_gc_start_hook(void);
 extern void mjit_gc_exit_hook(void);
 extern void mjit_free_iseq(const rb_iseq_t *iseq);

--- a/mjit_worker.c
+++ b/mjit_worker.c
@@ -1331,11 +1331,10 @@ unload_units(void)
     }
 }
 
-// The function implementing a worker. It is executed in a separate
-// thread by rb_thread_create_mjit_thread. It compiles precompiled header
-// and then compiles requested ISeqs.
-void
-mjit_worker(void)
+// The function implementing a worker. It is executed in a Ractor by `RubyVM::MJITWorker.start`.
+// It compiles precompiled header and then compiles requested ISeqs.
+VALUE
+mjit_worker(RB_UNUSED_VAR(rb_execution_context_t *ec), RB_UNUSED_VAR(VALUE self))
 {
     // Allow only `max_cache_size / 10` times (default: 10) of compaction.
     // Note: GC of compacted code has not been implemented yet.
@@ -1358,7 +1357,7 @@ mjit_worker(void)
         verbose(3, "Sending wakeup signal to client in a mjit-worker");
         rb_native_cond_signal(&mjit_client_wakeup);
         CRITICAL_SECTION_FINISH(3, "in worker to update worker_stopped");
-        return; // TODO: do the same thing in the latter half of mjit_finish
+        return Qnil; // TODO: do the same thing in the latter half of mjit_finish
     }
 
     // main worker loop
@@ -1443,4 +1442,6 @@ mjit_worker(void)
 
     // To keep mutex unlocked when it is destroyed by mjit_finish, don't wrap CRITICAL_SECTION here.
     worker_stopped = true;
+
+    return Qnil;
 }

--- a/mjit_worker.rb
+++ b/mjit_worker.rb
@@ -1,0 +1,15 @@
+class RubyVM::MJITWorker
+  def self.start
+    $VERBOSE, verbose = nil, $VERBOSE # shut up "warning: Ractor is experimental"
+    Ractor.new(name: 'mjit-worker') do
+      RubyVM.const_get(:MJITWorker, false).new.run
+    end
+  ensure
+    $VERBOSE = verbose
+  end
+
+  def run
+    Primitive.mjit_worker
+  end
+end
+RubyVM.private_constant(:MJITWorker)

--- a/ruby.c
+++ b/ruby.c
@@ -2046,6 +2046,11 @@ process_options(int argc, char **argv, ruby_cmdline_options_t *opt)
     rb_gvar_ractor_local("$-l");
     rb_gvar_ractor_local("$-a");
 
+#if USE_MJIT
+    if (opt->mjit.on)
+        mjit_worker_init(); // Using builtin and Ractor.
+#endif
+
     if ((rb_e_script = opt->e_script) != 0) {
         rb_gc_register_mark_object(opt->e_script);
     }

--- a/test/ruby/test_jit.rb
+++ b/test/ruby/test_jit.rb
@@ -661,7 +661,7 @@ class TestJIT < Test::Unit::TestCase
   def test_unload_units_and_compaction
     Dir.mktmpdir("jit_test_unload_units_") do |dir|
       # MIN_CACHE_SIZE is 10
-      out, err = eval_with_jit({"TMPDIR"=>dir}, "#{<<~"begin;"}\n#{<<~'end;'}", verbose: 1, min_calls: 1, max_cache: 10)
+      out, err = eval_with_jit({"TMPDIR"=>dir}, "#{<<~"begin;"}\n#{<<~'end;'}", verbose: 1, min_calls: 1, max_cache: 11) # 11 = 10 + Ractor.new
       begin;
         i = 0
         while i < 11
@@ -683,14 +683,14 @@ class TestJIT < Test::Unit::TestCase
 
       debug_info = %Q[stdout:\n"""\n#{out}\n"""\n\nstderr:\n"""\n#{err}"""\n]
       assert_equal('012345678910', out, debug_info)
-      compactions, errs = err.lines.partition do |l|
+      compactions, errs = strip_mjit_deps(err).lines.partition do |l|
         l.match?(/\AJIT compaction \(\d+\.\dms\): Compacted \d+ methods /)
       end
       10.times do |i|
         assert_match(/\A#{JIT_SUCCESS_PREFIX}: mjit#{i}@\(eval\):/, errs[i], debug_info)
       end
 
-      assert_equal("No units can be unloaded -- incremented max-cache-size to 11 for --jit-wait\n", errs[10], debug_info)
+      assert_equal("No units can be unloaded -- incremented max-cache-size to 12 for --jit-wait\n", errs[10], debug_info)
       assert_match(/\A#{JIT_SUCCESS_PREFIX}: mjit10@\(eval\):/, errs[11], debug_info)
       # On --jit-wait, when the number of JIT-ed code reaches --jit-max-cache,
       # it should trigger compaction.
@@ -1126,7 +1126,7 @@ class TestJIT < Test::Unit::TestCase
 
         Process.waitpid(pid)
       end;
-      success_count = err.scan(/^#{JIT_SUCCESS_PREFIX}:/).size
+      success_count = strip_mjit_deps(err).scan(/^#{JIT_SUCCESS_PREFIX}:/).size
       debug_info = "stdout:\n```\n#{out}\n```\n\nstderr:\n```\n#{err}```\n"
       assert_equal(3, success_count, debug_info)
 
@@ -1153,7 +1153,7 @@ class TestJIT < Test::Unit::TestCase
   # Shorthand for normal test cases
   def assert_eval_with_jit(script, stdout: nil, success_count:, recompile_count: nil, min_calls: 1, max_cache: 1000, insns: [], uplevel: 1, ignorable_patterns: [])
     out, err = eval_with_jit(script, verbose: 1, min_calls: min_calls, max_cache: max_cache)
-    success_actual = err.scan(/^#{JIT_SUCCESS_PREFIX}:/).size
+    success_actual = strip_mjit_deps(err).scan(/^#{JIT_SUCCESS_PREFIX}:/).size
     recompile_actual = err.scan(/^#{JIT_RECOMPILE_PREFIX}:/).size
     # Add --jit-verbose=2 logs for cl.exe because compiler's error message is suppressed
     # for cl.exe with --jit-verbose=1. See `start_process` in mjit_worker.c.
@@ -1228,5 +1228,10 @@ class TestJIT < Test::Unit::TestCase
       end
     end
     insns
+  end
+
+  # Ignore MJIT's own dependencies
+  def strip_mjit_deps(err)
+    err.gsub(/^#{JIT_SUCCESS_PREFIX}: new@<internal:ractor>:\d+ -> [^ ]+\n/, '')
   end
 end

--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -1928,40 +1928,6 @@ rb_nativethread_self(void)
     return pthread_self();
 }
 
-#if USE_MJIT
-/* A function that wraps actual worker function, for pthread abstraction. */
-static void *
-mjit_worker(void *arg)
-{
-    void (*worker_func)(void) = (void(*)(void))arg;
-
-#ifdef SET_CURRENT_THREAD_NAME
-    SET_CURRENT_THREAD_NAME("ruby-mjitworker"); /* 16 byte including NUL */
-#endif
-    worker_func();
-    return NULL;
-}
-
-/* Launch MJIT thread. Returns FALSE if it fails to create thread. */
-int
-rb_thread_create_mjit_thread(void (*worker_func)(void))
-{
-    pthread_attr_t attr;
-    pthread_t worker_pid;
-    int ret = FALSE;
-
-    if (pthread_attr_init(&attr) != 0) return ret;
-
-    /* jit_worker thread is not to be joined */
-    if (pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED) == 0
-        && pthread_create(&worker_pid, &attr, mjit_worker, (void *)worker_func) == 0) {
-        ret = TRUE;
-    }
-    pthread_attr_destroy(&attr);
-    return ret;
-}
-#endif
-
 int
 rb_sigwait_fd_get(const rb_thread_t *th)
 {

--- a/thread_win32.c
+++ b/thread_win32.c
@@ -824,29 +824,4 @@ native_set_thread_name(rb_thread_t *th)
 {
 }
 
-#if USE_MJIT
-static unsigned long __stdcall
-mjit_worker(void *arg)
-{
-    void (*worker_func)(void) = arg;
-    rb_w32_set_thread_description(GetCurrentThread(), L"ruby-mjitworker");
-    worker_func();
-    return 0;
-}
-
-/* Launch MJIT thread. Returns FALSE if it fails to create thread. */
-int
-rb_thread_create_mjit_thread(void (*worker_func)(void))
-{
-    size_t stack_size = 4 * 1024; /* 4KB is the minimum commit size */
-    HANDLE thread_id = w32_create_thread(stack_size, mjit_worker, worker_func);
-    if (thread_id == 0) {
-        return FALSE;
-    }
-
-    w32_resume_thread(thread_id);
-    return TRUE;
-}
-#endif
-
 #endif /* THREAD_SYSTEM_DEPENDENT_IMPLEMENTATION */


### PR DESCRIPTION
so that we can gradually rewrite its C implementations to Ruby for better maintainability.