### PR TITLE
Allow ostruct to return a value on super

### DIFF
--- a/lib/ostruct.rb
+++ b/lib/ostruct.rb
@@ -240,6 +240,7 @@ class OpenStruct
       end
       set_ostruct_member_value!(mname, args[0])
     elsif len == 0
+      @table[mid]
     else
       begin
         super

--- a/test/ostruct/test_ostruct.rb
+++ b/test/ostruct/test_ostruct.rb
@@ -249,6 +249,14 @@ class TC_OpenStruct < Test::Unit::TestCase
     assert_equal(:bar, os.format)
   end
 
+  def test_super
+    c = Class.new(OpenStruct) {
+      def foo; super; end
+    }
+    os = c.new(foo: :bar)
+    assert_equal(:bar, os.foo)
+  end
+  
   def test_overridden_public_methods
     os = OpenStruct.new(method: :foo, class: :bar)
     assert_equal(:foo, os.method)


### PR DESCRIPTION
This fixes cases where you can super in something that inherits from OpenStruct

This fixes a regression in ruby 3.0.0

```
require 'ostruct'

class Foo < OpenStruct
  def foo
    super
  end
end

p Foo.new(foo: 123).foo
```

Previously:
=> nil
Now:
=> 123

Ticket: https://bugs.ruby-lang.org/issues/17512