### PR TITLE
fix result of example [ci skip]

### DIFF
--- a/transcode.c
+++ b/transcode.c
@@ -3959,7 +3959,7 @@ econv_finish(VALUE self)
  *   ec = Encoding::Converter.new("EUC-JP", "Shift_JIS")
  *   ec.primitive_convert(src="\xff", dst="", nil, 10)
  *   p ec.primitive_errinfo
- *   #=> [:invalid_byte_sequence, "EUC-JP", "UTF-8", "\xFF", ""]
+ *   #=> [:invalid_byte_sequence, "EUC-JP", "Shift_JIS", "\xFF", ""]
  *
  *   # HIRAGANA LETTER A (\xa4\xa2 in EUC-JP) is not representable in ISO-8859-1.
  *   # Since this error is occur in UTF-8 to ISO-8859-1 conversion,


### PR DESCRIPTION
I guess that at the very first implementation had returned that value.

```
ruby-1.9.0-0        -e:1:in `<main>': uninitialized constant Encoding::Converter (NameError)
                exit 1
...
ruby-1.9.0-3        -e:1:in `<main>': uninitialized constant Encoding::Converter (NameError)
                exit 1
ruby-1.9.0-4        [:invalid_byte_sequence, "EUC-JP", "UTF-8", "\xFF", "", nil]
ruby-1.9.0-5        [:invalid_byte_sequence, "EUC-JP", "Shift_JIS", "\xFF", ""]
...
ruby-3.0.0          [:invalid_byte_sequence, "EUC-JP", "Shift_JIS", "\xFF", ""]
```