### PR TITLE
Replace iff with if

### DIFF
--- a/include/ruby/assert.h
+++ b/include/ruby/assert.h
@@ -167,7 +167,7 @@ RBIMPL_SYMBOL_EXPORT_END()
 #define RUBY_ASSERT_ALWAYS(expr) RUBY_ASSERT_MESG((expr), #expr)
 
 /**
- * Asserts that the given expression is truthy iff #RUBY_DEBUG is truthy.
+ * Asserts that the given expression is truthy if and only if #RUBY_DEBUG is truthy.
  *
  * @param  expr  What supposedly evaluates to true.
  */

--- a/include/ruby/internal/attr/const.h
+++ b/include/ruby/internal/attr/const.h
@@ -36,7 +36,7 @@
 # define RBIMPL_ATTR_CONST() /* void */
 #endif
 
-/** Enables #RBIMPL_ATTR_CONST iff. ! #RUBY_DEBUG. */
+/** Enables #RBIMPL_ATTR_CONST if and only if. ! #RUBY_DEBUG. */
 #if !RUBY_DEBUG
 # define RBIMPL_ATTR_CONST_UNLESS_DEBUG() RBIMPL_ATTR_CONST()
 #else

--- a/include/ruby/internal/attr/constexpr.h
+++ b/include/ruby/internal/attr/constexpr.h
@@ -75,7 +75,7 @@
 # define RBIMPL_ATTR_CONSTEXPR(_) /* void */
 #endif
 
-/** Enables #RBIMPL_ATTR_CONSTEXPR iff. ! #RUBY_DEBUG. */
+/** Enables #RBIMPL_ATTR_CONSTEXPR if and only if. ! #RUBY_DEBUG. */
 #if !RUBY_DEBUG
 # define RBIMPL_ATTR_CONSTEXPR_UNLESS_DEBUG(_) RBIMPL_ATTR_CONSTEXPR(_)
 #else

--- a/include/ruby/internal/attr/pure.h
+++ b/include/ruby/internal/attr/pure.h
@@ -33,7 +33,7 @@
 # define RBIMPL_ATTR_PURE() /* void */
 #endif
 
-/** Enables #RBIMPL_ATTR_PURE iff. ! #RUBY_DEBUG. */
+/** Enables #RBIMPL_ATTR_PURE if and only if. ! #RUBY_DEBUG. */
 #if !RUBY_DEBUG
 # define RBIMPL_ATTR_PURE_UNLESS_DEBUG() RBIMPL_ATTR_PURE()
 #else

--- a/lib/mkmf.rb
+++ b/lib/mkmf.rb
@@ -1821,7 +1821,7 @@ SRC
   # without modifying any of the global values mentioned above.
   def pkg_config(pkg, option=nil)
     if pkgconfig = with_config("#{pkg}-config") and find_executable0(pkgconfig)
-      # iff package specific config command is given
+      # if and only if package specific config command is given
     elsif ($PKGCONFIG ||=
            (pkgconfig = with_config("pkg-config", ("pkg-config" unless CROSS_COMPILING))) &&
            find_executable0(pkgconfig) && pkgconfig) and

--- a/signal.c
+++ b/signal.c
@@ -723,7 +723,7 @@ sighandler(int sig)
         rb_vm_t *vm = GET_VM();
         ATOMIC_EXCHANGE(sigchld_hit, 1);
 
-        /* avoid spurious wakeup in main thread iff nobody uses trap(:CHLD) */
+        /* avoid spurious wakeup in main thread if and only if nobody uses trap(:CHLD) */
         if (vm && ACCESS_ONCE(VALUE, vm->trap_list.cmd[sig])) {
             signal_enque(sig);
         }

--- a/spec/ruby/core/gc/disable_spec.rb
+++ b/spec/ruby/core/gc/disable_spec.rb
@@ -5,7 +5,7 @@ describe "GC.disable" do
     GC.enable
   end
 
-  it "returns true iff the garbage collection was previously disabled" do
+  it "returns true if and only if the garbage collection was previously disabled" do
     GC.enable
     GC.disable.should == false
     GC.disable.should == true

--- a/spec/ruby/core/gc/enable_spec.rb
+++ b/spec/ruby/core/gc/enable_spec.rb
@@ -2,7 +2,7 @@ require_relative '../../spec_helper'
 
 describe "GC.enable" do
 
-  it "returns true iff the garbage collection was already disabled" do
+  it "returns true if and only if the garbage collection was already disabled" do
     GC.enable
     GC.enable.should == false
     GC.disable

--- a/spec/ruby/core/hash/shared/eql.rb
+++ b/spec/ruby/core/hash/shared/eql.rb
@@ -118,7 +118,7 @@ describe :hash_eql_additional, shared: true do
     { 1.0 => "x" }.send(@method, { 1 => "x" }).should be_false
   end
 
-  it "returns true iff other Hash has the same number of keys and each key-value pair matches" do
+  it "returns true if and only if other Hash has the same number of keys and each key-value pair matches" do
     a = { a: 5 }
     b = {}
     a.send(@method, b).should be_false

--- a/spec/ruby/core/integer/allbits_spec.rb
+++ b/spec/ruby/core/integer/allbits_spec.rb
@@ -1,7 +1,7 @@
 require_relative '../../spec_helper'
 
 describe "Integer#allbits?" do
-  it "returns true iff all the bits of the argument are set in the receiver" do
+  it "returns true if and only if all the bits of the argument are set in the receiver" do
     42.allbits?(42).should == true
     0b1010_1010.allbits?(0b1000_0010).should == true
     0b1010_1010.allbits?(0b1000_0001).should == false

--- a/spec/ruby/core/integer/anybits_spec.rb
+++ b/spec/ruby/core/integer/anybits_spec.rb
@@ -1,7 +1,7 @@
 require_relative '../../spec_helper'
 
 describe "Integer#anybits?" do
-  it "returns true iff all the bits of the argument are set in the receiver" do
+  it "returns true if and only if all the bits of the argument are set in the receiver" do
     42.anybits?(42).should == true
     0b1010_1010.anybits?(0b1000_0010).should == true
     0b1010_1010.anybits?(0b1000_0001).should == true

--- a/spec/ruby/core/integer/nobits_spec.rb
+++ b/spec/ruby/core/integer/nobits_spec.rb
@@ -1,7 +1,7 @@
 require_relative '../../spec_helper'
 
 describe "Integer#nobits?" do
-  it "returns true iff all no bits of the argument are set in the receiver" do
+  it "returns true if and only if all no bits of the argument are set in the receiver" do
     42.nobits?(42).should == false
     0b1010_1010.nobits?(0b1000_0010).should == false
     0b1010_1010.nobits?(0b1000_0001).should == false

--- a/st.c
+++ b/st.c
@@ -768,7 +768,7 @@ rebuild_table(st_table *tab)
    guarantees traversing all table bins in extreme case.
 
    According the Hull-Dobell theorem a generator
-   "Xnext = (a*Xprev + c) mod m" is a full cycle generator iff
+   "Xnext = (a*Xprev + c) mod m" is a full cycle generator if and only if
      o m and c are relatively prime
      o a-1 is divisible by all prime factors of m
      o a-1 is divisible by 4 if m is divisible by 4.

--- a/thread.c
+++ b/thread.c
@@ -5149,7 +5149,7 @@ recursive_list_access(VALUE sym)
 }
 
 /*
- * Returns Qtrue iff obj (or the pair <obj, paired_obj>) is already
+ * Returns Qtrue if and only if obj (or the pair <obj, paired_obj>) is already
  * in the recursion list.
  * Assumes the recursion list is valid.
  */

--- a/variable.c
+++ b/variable.c
@@ -2481,7 +2481,7 @@ rb_autoload_load(VALUE mod, ID id)
 
 	/*
 	 * autoload_reset will wake up any threads added to this
-	 * iff the GVL is released during autoload_require
+	 * if and only if the GVL is released during autoload_require
 	 */
 	list_head_init((struct list_head *)&state.waitq);
     }

--- a/vm_trace.c
+++ b/vm_trace.c
@@ -86,7 +86,7 @@ update_global_event_hook(rb_event_flag_t vm_events)
         mjit_call_p = FALSE;
 #endif
 
-	/* write all ISeqs iff new events are added */
+	/* write all ISeqs if and only if new events are added */
 	rb_iseq_trace_set_all(new_iseq_events | enabled_iseq_events);
     }
 

--- a/vsnprintf.c
+++ b/vsnprintf.c
@@ -161,7 +161,7 @@ struct __sbuf {
  * _ub, _up, and _ur are used when ungetc() pushes back more characters
  * than fit in the current _bf, or when ungetc() pushes back a character
  * that does not match the previous one in _bf.  When this happens,
- * _ub._base becomes non-nil (i.e., a stream has ungetc() data iff
+ * _ub._base becomes non-nil (i.e., a stream has ungetc() data if and only if
  * _ub._base!=NULL) and _up and _ur save the current values of _p and _r.
  *
  * NB: see WARNING above before changing the layout of this structure!
@@ -196,7 +196,7 @@ typedef	struct __sFILE {
 #define	__SSTR	0x0200		/* this is an sprintf/snprintf string */
 #define	__SOPT	0x0400		/* do fseek() optimisation */
 #define	__SNPT	0x0800		/* do not do fseek() optimisation */
-#define	__SOFF	0x1000		/* set iff _offset is in fact correct */
+#define	__SOFF	0x1000		/* set if and only if _offset is in fact correct */
 #define	__SMOD	0x2000		/* true => fgetln modified _p text */
 
 


### PR DESCRIPTION
iff means if and only if, but readers without that knowledge might assume this to be a spelling mistake (see [examples](https://github.com/ruby/ruby/pulls?q=iff+)). To me, this seems like exclusionary language that is unnecessary. Simply using "if" instead should suffice.

I left some [vendored code](https://github.com/CocoaPods/Molinillo) comments and changelogs. Also happy to discuss alternatives like using "if and only if" expanded. Thanks!

cc @tenderlove 