### PR TITLE
Implement Happy Eyeballs Version 2 (RFC8305) in Socket.tcp

### DIFF
--- a/ext/socket/lib/socket.rb
+++ b/ext/socket/lib/socket.rb
@@ -721,9 +721,8 @@ class Socket < BasicSocket
       end
 
       if readable_pipes && !readable_pipes.empty? # handle an event
-        event = pipe_read.getc
+        event = pipe_read.getbyte
         if event
-          event.chomp!
           case event
           when GETADDRINFO_V6_DONE
             getaddrinfo_v6_done = true

--- a/ext/socket/lib/socket.rb
+++ b/ext/socket/lib/socket.rb
@@ -642,10 +642,10 @@ class Socket < BasicSocket
       rescue => ex
         error_queue.push(ex)
       ensure
+        ai_list.each {|ai| ai_queue_v4.push(ai) }
         mutex.synchronize { pipe_write.putc(GETADDRINFO_V4_DONE) unless pipe_write.closed? }
       end
       if ai_list # if getaddrinfo finished successfully
-        ai_list.each {|ai| ai_queue_v4.push(ai) }
         sleep(RESOLUTION_DELAY) # 50ms is the recommended value for the resolution delay for IPv4 in RFC8305
         mutex.synchronize { pipe_write.putc(RESOLUTION_DELAY_DONE) unless pipe_write.closed? }
       end

--- a/ext/socket/lib/socket.rb
+++ b/ext/socket/lib/socket.rb
@@ -772,7 +772,7 @@ class Socket < BasicSocket
         end
       rescue SystemCallError => ex
         last_error = ex
-        sock.close()
+        sock&.close()
       end
     end
 

--- a/test/socket/test_socket.rb
+++ b/test/socket/test_socket.rb
@@ -674,39 +674,40 @@ class TestSocket < Test::Unit::TestCase
   end
 
   def test_resolv_timeout
-    original = Addrinfo.singleton_method(:getaddrinfo)
-    Addrinfo.define_singleton_method(:getaddrinfo) {|*arg| sleep }
-    sock = nil
-    assert_raise(Errno::ETIMEDOUT) do
-      sock = Socket.tcp("localhost", 9, resolv_timeout: 0.1)
-    end
-  ensure
-    Addrinfo.define_singleton_method(:getaddrinfo, original)
-    sock.close if sock && ! sock.closed?
+    assert_separately(%w[-W1], <<-'EOS')
+      require "socket"
+
+      original = Addrinfo.singleton_method(:getaddrinfo)
+      Addrinfo.define_singleton_method(:getaddrinfo) {|*arg| sleep }
+      sock = nil
+      assert_raise(Errno::ETIMEDOUT) do
+        sock = Socket.tcp("localhost", 9, resolv_timeout: 0.1)
+      end
+    EOS
   end
 
   def test_unhandled_exception_in_getaddrinfo_th
-    original = Addrinfo.singleton_method(:getaddrinfo)
-    Addrinfo.define_singleton_method(:getaddrinfo) {|*arg| raise }
-    sock = nil
-    assert_raise(Errno::ETIMEDOUT) do
-      sock = Socket.tcp("localhost", 9, resolv_timeout: 0.1)
-    end
-  ensure
-    Addrinfo.define_singleton_method(:getaddrinfo, original)
-    sock.close if sock && ! sock.closed?
+    assert_separately(%w[-W1], <<-'EOS')
+      require "socket"
+
+      Addrinfo.define_singleton_method(:getaddrinfo) {|*arg| raise }
+      sock = nil
+      assert_raise(Errno::ETIMEDOUT) do
+        sock = Socket.tcp("localhost", 9, resolv_timeout: 0.1)
+      end
+    EOS
   end
 
   def test_unhandled_socketerror_in_getaddrinfo_th
-    original = Addrinfo.singleton_method(:getaddrinfo)
-    Addrinfo.define_singleton_method(:getaddrinfo) {|*arg| raise SocketError }
-    sock = nil
-    assert_raise(Errno::ETIMEDOUT) do
-      sock = Socket.tcp("localhost", 9, resolv_timeout: 0.1)
-    end
-  ensure
-    Addrinfo.define_singleton_method(:getaddrinfo, original)
-    sock.close if sock && ! sock.closed?
+    assert_separately(%w[-W1], <<-'EOS')
+      require "socket"
+
+      Addrinfo.define_singleton_method(:getaddrinfo) {|*arg| raise SocketError }
+      sock = nil
+      assert_raise(Errno::ETIMEDOUT) do
+        sock = Socket.tcp("localhost", 9, resolv_timeout: 0.1)
+      end
+    EOS
   end
 
   def test_getifaddrs


### PR DESCRIPTION
This change implements Happy Eyeballs Version 2 (RFC8305) in Socket.tcp.
It enables fallback from IPv6 to IPv4 without a long waiting time.