### PR TITLE
Replace `Kernel.#open` with `URI.open` in doc

### DIFF
--- a/enumerator.c
+++ b/enumerator.c
@@ -1711,13 +1711,13 @@ lazy_generator_init(VALUE enumerator, VALUE procs)
  *
  *    # This will fetch all URLs before selecting
  *    # necessary data
- *    URLS.map { |u| JSON.parse(open(u).read) }
+ *    URLS.map { |u| JSON.parse(URI.open(u).read) }
  *      .select { |data| data.key?('stats') }
  *      .first(5)
  *
  *    # This will fetch URLs one-by-one, only till
  *    # there is enough data to satisfy the condition
- *    URLS.lazy.map { |u| JSON.parse(open(u).read) }
+ *    URLS.lazy.map { |u| JSON.parse(URI.open(u).read) }
  *      .select { |data| data.key?('stats') }
  *      .first(5)
  *

--- a/kernel.rb
+++ b/kernel.rb
@@ -105,7 +105,7 @@ module Kernel
   #     require 'json'
   #
   #     construct_url(arguments).
-  #       then {|url| open(url).read }.
+  #       then {|url| URI.open(url).read }.
   #       then {|response| JSON.parse(response) }
   #
   #  When called without block, the method returns +Enumerator+,
@@ -138,7 +138,7 @@ module Kernel
   #     require 'json'
   #
   #     construct_url(arguments).
-  #       then {|url| open(url).read }.
+  #       then {|url| URI.open(url).read }.
   #       then {|response| JSON.parse(response) }
   #
   def yield_self


### PR DESCRIPTION
Because `Kernel.#open` no longer opens URI since Ruby 3.0.