### PR TITLE
parse.y: handle "duplicated argument name" appropriately on ripper.y

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -7871,7 +7871,9 @@ formal_argument(struct parser_params *p, ID lhs)
 formal_argument(struct parser_params *p, VALUE lhs)
 #endif
 {
-    switch (id_type(get_id(lhs))) {
+    ID id = get_id(lhs);
+
+    switch (id_type(id)) {
       case ID_LOCAL:
 	break;
 #ifndef RIPPER
@@ -7896,7 +7898,7 @@ formal_argument(struct parser_params *p, VALUE lhs)
 	return 0;
 #undef ERR
     }
-    shadowing_lvar(p, lhs);
+    shadowing_lvar(p, id);
     return lhs;
 }
 

--- a/test/ripper/test_lexer.rb
+++ b/test/ripper/test_lexer.rb
@@ -148,6 +148,7 @@ class TestRipper::Lexer < Test::Unit::TestCase
 
   BAD_CODE = [
     [:parse_error,      'def req(true) end',         %r[unexpected `true'],         'true'],
+    [:parse_error,      'def req(a, a) end',         %r[duplicated argument name],  'a'],
     [:assign_error,     'begin; nil = 1; end',       %r[assign to nil],             'nil'],
     [:alias_error,      'begin; alias $x $1; end',   %r[number variables],          '$1'],
     [:class_name_error, 'class bad; end',            %r[class/module name],         'bad'],


### PR DESCRIPTION
refs: 733ed1e184