### PR TITLE
only add the trailing nop if the catch table is not break / next / redo

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -1413,11 +1413,19 @@ iseq_insert_nop_between_end_and_cont(rb_iseq_t *iseq)
         LINK_ELEMENT *end = (LINK_ELEMENT *)(ptr[2] & ~1);
         LINK_ELEMENT *cont = (LINK_ELEMENT *)(ptr[4] & ~1);
         LINK_ELEMENT *e;
-        for (e = end; e && (IS_LABEL(e) || IS_TRACE(e)); e = e->next) {
-            if (e == cont) {
-                INSN *nop = new_insn_core(iseq, 0, BIN(nop), 0, 0);
-                ELEM_INSERT_NEXT(end, &nop->link);
-                break;
+
+        enum catch_type ct = (enum catch_type)(ptr[0] & 0xffff);
+
+        if (ct != CATCH_TYPE_BREAK
+            && ct != CATCH_TYPE_NEXT
+            && ct != CATCH_TYPE_REDO) {
+
+            for (e = end; e && (IS_LABEL(e) || IS_TRACE(e)); e = e->next) {
+                if (e == cont) {
+                    INSN *nop = new_insn_core(iseq, 0, BIN(nop), 0, 0);
+                    ELEM_INSERT_NEXT(end, &nop->link);
+                    break;
+                }
             }
         }
     }


### PR DESCRIPTION
We don't need nop padding when the catch tables are only for break /
next / redo, so lets avoid them.  This eliminates nop padding in
many lambdas.

I think this is a better alternative to #4040.

Here are the instructions used for RailsBench on master:

![insn-count-master](https://user-images.githubusercontent.com/3124/104388070-4ebe2a80-54ed-11eb-9a40-66bb05c0c4c0.png)

Text version:

```
10               setinstancevariable  4332095
97                     getlocal_WC_1  5175882
17                            putnil  6911093
83                          opt_aref  8455003
19                         putobject  9321480
35                               pop  9635247
98                     setlocal_WC_0 11036016
62                          branchif 11088913
9                getinstancevariable 12011517
36                               dup 12020746
65                opt_getinlinecache 13121324
63                      branchunless 13441822
1                                nop 15066779
18                           putself 24045912
59                             leave 34046308
51            opt_send_without_block 45677897
96                     getlocal_WC_0 58353340
```

Here are the instructions used on this branch:

![insn-count-branch](https://user-images.githubusercontent.com/3124/104388088-58e02900-54ed-11eb-8249-6f0922aa4c4a.png)

```
97                     getlocal_WC_1  5175882
1                                nop  6869821
17                            putnil  6911093
83                          opt_aref  8455003
19                         putobject  9321480
35                               pop  9635251
98                     setlocal_WC_0 11036016
62                          branchif 11087301
9                getinstancevariable 12009905
36                               dup 12019146
65                opt_getinlinecache 13121328
63                      branchunless 13441838
18                           putself 24045118
59                             leave 34043898
51            opt_send_without_block 45675507
96                     getlocal_WC_0 58352550
```

This patch eliminates about 8mil nop calls.

Here is the req / s graph:

![speed](https://user-images.githubusercontent.com/3124/104388255-b4aab200-54ed-11eb-9046-8676c4a643c6.png)

It seems like there is some improvement, though it's not huge.

/cc @XrXr @jhawthorn 
