### PR TITLE
Revert "[Bug #11213] let defined?(super) call respond_to_missing?" [Bug #17509]

### DIFF
--- a/internal/vm.h
+++ b/internal/vm.h
@@ -94,7 +94,7 @@ MJIT_SYMBOL_EXPORT_END
 /* vm_method.c */
 struct rb_execution_context_struct;
 MJIT_SYMBOL_EXPORT_BEGIN
-int rb_ec_obj_respond_to(struct rb_execution_context_struct *ec, VALUE klass, VALUE obj, ID id, int priv);
+int rb_ec_obj_respond_to(struct rb_execution_context_struct *ec, VALUE obj, ID id, int priv);
 MJIT_SYMBOL_EXPORT_END
 
 /* vm_dump.c */

--- a/test/ruby/test_defined.rb
+++ b/test/ruby/test_defined.rb
@@ -302,39 +302,6 @@ class TestDefined < Test::Unit::TestCase
     assert_nil(defined?(TestDefined::Object))
   end
 
-  def test_super_with_method_missing
-    c0 = EnvUtil.labeled_class("C0") do
-      attr_reader :calls
-
-      def initialize
-        @calls = []
-      end
-
-      def method_missing(*args)
-        @calls << [:method_missing, *args]
-      end
-
-      def respond_to_missing?(*args)
-        @calls << [:respond_to_missing?, *args]
-        true
-      end
-    end
-
-    c1 = EnvUtil.labeled_class("C1", c0) do
-      def foo
-        super
-        defined?(super)
-      end
-    end
-
-    c = c1.new
-    assert_not_nil(c.foo)
-    assert_equal([
-                   [:method_missing, :foo],
-                   [:respond_to_missing?, :foo, true],
-                 ], c.calls)
-  end
-
   class RefinedClass
   end
 

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -3997,7 +3997,7 @@ vm_defined(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, rb_num_t op_
       }
       case DEFINED_FUNC:
 	klass = CLASS_OF(v);
-	if (rb_ec_obj_respond_to(ec, klass, v, SYM2ID(obj), TRUE)) {
+	if (rb_ec_obj_respond_to(ec, v, SYM2ID(obj), TRUE)) {
 	    expr_type = DEFINED_METHOD;
 	}
 	break;
@@ -4038,7 +4038,7 @@ vm_defined(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, rb_num_t op_
 		VALUE klass = vm_search_normal_superclass(me->defined_class);
 		ID id = me->def->original_id;
 
-		if (rb_ec_obj_respond_to(ec, klass, GET_SELF(), id, TRUE)) {
+		if (rb_method_boundp(klass, id, 0)) {
 		    expr_type = DEFINED_ZSUPER;
 		}
 	    }

--- a/vm_method.c
+++ b/vm_method.c
@@ -2435,8 +2435,9 @@ basic_obj_respond_to_missing(rb_execution_context_t *ec, VALUE klass, VALUE obj,
 }
 
 static inline int
-basic_obj_respond_to(rb_execution_context_t *ec, VALUE klass, VALUE obj, ID id, int pub)
+basic_obj_respond_to(rb_execution_context_t *ec, VALUE obj, ID id, int pub)
 {
+    VALUE klass = CLASS_OF(obj);
     VALUE ret;
 
     switch (method_boundp(klass, id, pub|BOUND_RESPONDS)) {
@@ -2506,14 +2507,15 @@ int
 rb_obj_respond_to(VALUE obj, ID id, int priv)
 {
     rb_execution_context_t *ec = GET_EC();
-    return rb_ec_obj_respond_to(ec, CLASS_OF(obj), obj, id, priv);
+    return rb_ec_obj_respond_to(ec, obj, id, priv);
 }
 
 int
-rb_ec_obj_respond_to(rb_execution_context_t *ec, VALUE klass, VALUE obj, ID id, int priv)
+rb_ec_obj_respond_to(rb_execution_context_t *ec, VALUE obj, ID id, int priv)
 {
+    VALUE klass = CLASS_OF(obj);
     int ret = vm_respond_to(ec, klass, obj, id, priv);
-    if (ret == -1) ret = basic_obj_respond_to(ec, klass, obj, id, !priv);
+    if (ret == -1) ret = basic_obj_respond_to(ec, obj, id, !priv);
     return ret;
 }
 
@@ -2558,7 +2560,7 @@ obj_respond_to(int argc, VALUE *argv, VALUE obj)
 	if (ret == Qundef) ret = Qfalse;
 	return ret;
     }
-    if (basic_obj_respond_to(ec, CLASS_OF(obj), obj, id, !RTEST(priv)))
+    if (basic_obj_respond_to(ec, obj, id, !RTEST(priv)))
 	return Qtrue;
     return Qfalse;
 }


### PR DESCRIPTION
Reverts [Bug #11213] (ruby/ruby#3777) for now, due to the breakage in the case `super` is called in `respond_to?`.