### PR TITLE
Add eval_error.h

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -5048,6 +5048,7 @@ error.$(OBJEXT): {$(VPATH)}constant.h
 error.$(OBJEXT): {$(VPATH)}defines.h
 error.$(OBJEXT): {$(VPATH)}encoding.h
 error.$(OBJEXT): {$(VPATH)}error.c
+error.$(OBJEXT): {$(VPATH)}eval_error.h
 error.$(OBJEXT): {$(VPATH)}eval_intern.h
 error.$(OBJEXT): {$(VPATH)}id.h
 error.$(OBJEXT): {$(VPATH)}id_table.h

--- a/error.c
+++ b/error.c
@@ -41,6 +41,7 @@
 #include "ruby/st.h"
 #include "ruby_assert.h"
 #include "vm_core.h"
+#include "eval_error.h"
 
 #include "builtin.h"
 
@@ -1193,9 +1194,6 @@ exc_to_s(VALUE exc)
     if (NIL_P(mesg)) return rb_class_name(CLASS_OF(exc));
     return rb_String(mesg);
 }
-
-/* FIXME: Include eval_error.c */
-void rb_error_write(VALUE errinfo, VALUE emesg, VALUE errat, VALUE str, VALUE highlight, VALUE reverse);
 
 VALUE
 rb_get_message(VALUE exc)

--- a/eval_error.h
+++ b/eval_error.h
@@ -1,0 +1,7 @@
+#ifndef RUBY_EVAL_ERROR_H
+#define RUBY_EVAL_ERROR_H 1
+#include "ruby/ruby.h"
+
+void rb_error_write(VALUE errinfo, VALUE emesg, VALUE errat, VALUE str, VALUE highlight, VALUE reverse);
+
+#endif


### PR DESCRIPTION
In `error.c`

```c
/* FIXME: Include eval_error.c * /
void rb_ec_error_write (VALUE errinfo, VALUE errat, VALUE str);
```

I thought it would be better to separate this into a separate header(like eval_error.h).