### PR TITLE
Re-enable RGENGC_DEBUG_ENABLED when HAVE_VA_ARGS_MACRO

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -377,6 +377,8 @@ static ruby_gc_params_t gc_params = {
 #endif
 #if RGENGC_DEBUG < 0 && !defined(_MSC_VER)
 # define RGENGC_DEBUG_ENABLED(level) (-(RGENGC_DEBUG) >= (level) && ruby_rgengc_debug >= (level))
+#elif HAVE_VA_ARGS_MACRO
+# define RGENGC_DEBUG_ENABLED(level) ((RGENGC_DEBUG) >= (level))
 #else
 # define RGENGC_DEBUG_ENABLED(level) 0
 #endif


### PR DESCRIPTION
[This commit](https://github.com/ruby/ruby/commit/888cf28a7e3a07fc0a41688777a40910654005ad) disables RGENGC_DEBUG_ENABLED globally when RGENGC_DEBUG is greater than 0

The commit message indicates this is due to a bug with systems where HAVE_VA_ARGS_MACRO is 0.

This PR re-enables RGENGC_DEBUG support for systems that do provide HAVE_VA_ARGS_MACRO

cc @ko1 