### PR TITLE
Fix RGENGC CHECK MODE >= 4

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -6754,12 +6754,17 @@ allrefs_roots_i(VALUE obj, void *ptr)
 	push_mark_stack(&data->mark_stack, obj);
     }
 }
+#define PUSH_MARK_FUNC_DATA(v) do { \
+    struct gc_mark_func_data_struct *prev_mark_func_data = GET_RACTOR()->mfd; \
+    GET_RACTOR()->mfd = (v);
+
+#define POP_MARK_FUNC_DATA() GET_RACTOR()->mfd = prev_mark_func_data;} while (0)
 
 static st_table *
 objspace_allrefs(rb_objspace_t *objspace)
 {
     struct allrefs data;
-    struct mark_func_data_struct mfd;
+    struct gc_mark_func_data_struct mfd;
     VALUE obj;
     int prev_dont_gc = dont_gc_val();
     dont_gc_on();
@@ -6773,7 +6778,7 @@ objspace_allrefs(rb_objspace_t *objspace)
 
     /* traverse root objects */
     PUSH_MARK_FUNC_DATA(&mfd);
-    objspace->mark_func_data = &mfd;
+    GET_RACTOR()->mfd = &mfd;
     gc_mark_roots(objspace, &data.category);
     POP_MARK_FUNC_DATA();
 


### PR DESCRIPTION
[A previous commit](https://github.com/ruby/ruby/commit/b59077eecf912a16efefc0256f6e94a000ce3888) removes some macro definitions that are used when RGENGC_CHECK_MODE >=4 because they were using data stored against objspace, which is not ractor safe

This commit reinstates those macro definitions, using the current ractor

cc @ko1 