### PR TITLE
strftime.c: support unknown offset UTC in RFC 3339 [Feature #17544]

### DIFF
--- a/strftime.c
+++ b/strftime.c
@@ -547,7 +547,7 @@ rb_strftime_with_timespec(VALUE ftime, const char *format, size_t format_len,
 			else {
 				off = NUM2LONG(rb_funcall(vtm->utc_offset, rb_intern("round"), 0));
 			}
-			if (off < 0 || (off == 0 && (flags & BIT_OF(LEFT)))) {
+			if (off < 0 || (gmt && (flags & BIT_OF(LEFT)))) {
 				off = -off;
 				sign = -1;
 			}

--- a/strftime.c
+++ b/strftime.c
@@ -547,7 +547,7 @@ rb_strftime_with_timespec(VALUE ftime, const char *format, size_t format_len,
 			else {
 				off = NUM2LONG(rb_funcall(vtm->utc_offset, rb_intern("round"), 0));
 			}
-			if (off < 0) {
+			if (off < 0 || (off == 0 && (flags & BIT_OF(LEFT)))) {
 				off = -off;
 				sign = -1;
 			}

--- a/test/ruby/test_time.rb
+++ b/test/ruby/test_time.rb
@@ -920,6 +920,11 @@ class TestTime < Test::Unit::TestCase
     assert_equal("+09:00", t.strftime("%:z"))
     assert_equal("+09:00:01", t.strftime("%::z"))
     assert_equal("+09:00:01", t.strftime("%:::z"))
+
+    assert_equal("+0000", t2000.strftime("%z"))
+    assert_equal("-0000", t2000.strftime("%-z"))
+    assert_equal("-00:00", t2000.strftime("%-:z"))
+    assert_equal("-00:00:00", t2000.strftime("%-::z"))
   end
 
   def test_strftime_padding

--- a/test/ruby/test_time.rb
+++ b/test/ruby/test_time.rb
@@ -925,6 +925,12 @@ class TestTime < Test::Unit::TestCase
     assert_equal("-0000", t2000.strftime("%-z"))
     assert_equal("-00:00", t2000.strftime("%-:z"))
     assert_equal("-00:00:00", t2000.strftime("%-::z"))
+
+    t = t2000.getlocal("+00:00")
+    assert_equal("+0000", t.strftime("%z"))
+    assert_equal("+0000", t.strftime("%-z"))
+    assert_equal("+00:00", t.strftime("%-:z"))
+    assert_equal("+00:00:00", t.strftime("%-::z"))
   end
 
   def test_strftime_padding

--- a/test/ruby/test_time_tz.rb
+++ b/test/ruby/test_time_tz.rb
@@ -261,6 +261,8 @@ class TestTimeTZ < Test::Unit::TestCase
     assert_predicate(Time.new(2019, 1, 1, 0, 0, 0, "UTC"), :utc?)
     assert_predicate(Time.new(2019, 1, 1, 0, 0, 0, "utc"), :utc?)
     assert_predicate(Time.new(2019, 1, 1, 0, 0, 0, "Z"), :utc?)
+    assert_predicate(Time.new(2019, 1, 1, 0, 0, 0, "-00:00"), :utc?)
+    assert_not_predicate(Time.new(2019, 1, 1, 0, 0, 0, "+00:00"), :utc?)
   end
 
   def test_military_names

--- a/time.c
+++ b/time.c
@@ -2150,8 +2150,10 @@ utc_offset_arg(VALUE arg)
         if (s[0] != '+' && s[0] != '-') goto invalid_utc_offset;
         if (!ISDIGIT(s[1]) || !ISDIGIT(s[2])) goto invalid_utc_offset;
         n += (s[1] * 10 + s[2] - '0' * 11) * 3600;
-        if (s[0] == '-')
+        if (s[0] == '-') {
+            if (n == 0) return UTC_ZONE;
             n = -n;
+        }
         return INT2FIX(n);
     }
     else {


### PR DESCRIPTION
In RFC 3339, -00:00 is used for the time in UTC is known, but the offset to local time is unknown.
Support that representation by `-` flag for `z`.