### PR TITLE
Don't try to clear cache on garbage objects

### DIFF
--- a/vm_method.c
+++ b/vm_method.c
@@ -151,6 +151,7 @@ static void
 clear_method_cache_by_id_in_class(VALUE klass, ID mid)
 {
     VM_ASSERT(RB_TYPE_P(klass, T_CLASS) || RB_TYPE_P(klass, T_ICLASS));
+    if (rb_objspace_garbage_object_p(klass)) return;
 
     if (LIKELY(RCLASS_EXT(klass)->subclasses == NULL)) {
         // no subclasses


### PR DESCRIPTION
Method cache can be cleared during lazy sweeping.  An object that will
be collected during lazy sweep *should not* have it's method cache
cleared.  Soon-to-be-garbage objects can be in an inconsistent state and
this can lead to a crash.  This patch just leaves early if the object is
going to be collected.

Fixes [Bug #17536]

Co-Authored-By: John Hawthorn <john@hawthorn.email>
Co-Authored-By: Alan Wu <XrXr@users.noreply.github.com>