### PR TITLE
objspace_dump.c: Handle allocation path and line missing

### DIFF
--- a/ext/objspace/objspace_dump.c
+++ b/ext/objspace/objspace_dump.c
@@ -471,10 +471,15 @@ dump_object(VALUE obj, struct dump_config *dc)
         dump_append(dc, "]");
 
     if (ainfo) {
-        dump_append(dc, ", \"file\":\"");
-        dump_append(dc, ainfo->path);
-        dump_append(dc, "\", \"line\":");
-        dump_append_lu(dc, ainfo->line);
+        if (ainfo->path) {
+            dump_append(dc, ", \"file\":\"");
+            dump_append(dc, ainfo->path);
+            dump_append(dc, "\"");
+        }
+        if (ainfo->line) {
+            dump_append(dc, ", \"line\":");
+            dump_append_lu(dc, ainfo->line);
+        }
         if (RTEST(ainfo->mid)) {
             VALUE m = rb_sym2str(ainfo->mid);
             dump_append(dc, ", \"method\":");


### PR DESCRIPTION
<details>
<summary>Crash report</summary>

```
/usr/local/lib/ruby/3.0.0/objspace.rb:87: [BUG] Segmentation fault at 0x0000000000000000
ruby 3.0.0p0 (2021-01-14 revision 29777cb32a) [x86_64-linux]
-- Control frame information -----------------------------------------------
c:0022 p:---- s:0149 e:000148 CFUNC  :_dump_all
c:0021 p:0130 s:0142 e:000141 METHOD /usr/local/lib/ruby/3.0.0/objspace.rb:87
c:0020 p:0013 s:0132 e:000131 METHOD __hprof:93
c:0019 p:0035 s:0127 e:000126 METHOD /tmp/bundle/ruby/3.0.0/gems/heap-profiler-0.2.1/lib/heap_profiler/reporter.rb:59
c:0018 p:0008 s:0123 e:000122 METHOD /tmp/bundle/ruby/3.0.0/gems/heap-profiler-0.2.1/lib/heap_profiler/runtime.rb:22
c:0017 p:0011 s:0119 e:000118 TOP    /app/lib/profilers/heap_prof_end.rb:3 [FINISH]
c:0016 p:---- s:0116 e:000115 CFUNC  :load
c:0015 p:0086 s:0110 e:000109 METHOD /tmp/bundle/ruby/3.0.0/gems/bootsnap-1.5.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:64
c:0014 p:0132 s:0100 e:000099 METHOD /tmp/bundle/ruby/3.0.0/bundler/gems/rails-f250208dd477/railties/lib/rails/commands/runner/runner_command.rb:42
c:0013 p:0054 s:0093 e:000092 METHOD /tmp/bundle/ruby/3.0.0/gems/thor-1.0.1/lib/thor/command.rb:27
c:0012 p:0040 s:0085 e:000084 METHOD /tmp/bundle/ruby/3.0.0/gems/thor-1.0.1/lib/thor/invocation.rb:127
c:0011 p:0235 s:0078 e:000077 METHOD /tmp/bundle/ruby/3.0.0/gems/thor-1.0.1/lib/thor.rb:392
c:0010 p:0045 s:0065 e:000064 METHOD /tmp/bundle/ruby/3.0.0/bundler/gems/rails-f250208dd477/railties/lib/rails/command/base.rb:69
c:0009 p:0153 s:0058 e:000057 METHOD /tmp/bundle/ruby/3.0.0/bundler/gems/rails-f250208dd477/railties/lib/rails/command.rb:50
c:0008 p:0063 s:0046 e:000045 TOP    /tmp/bundle/ruby/3.0.0/bundler/gems/rails-f250208dd477/railties/lib/rails/commands.rb:18 [FINISH]
c:0007 p:---- s:0041 e:000040 CFUNC  :require
c:0006 p:0012 s:0036 e:000035 BLOCK  /tmp/bundle/ruby/3.0.0/gems/bootsnap-1.5.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23
c:0005 p:0070 s:0033 e:000032 METHOD /tmp/bundle/ruby/3.0.0/gems/bootsnap-1.5.1/lib/bootsnap/load_path_cache/loaded_features_index.rb:92
c:0004 p:0025 s:0021 e:000020 METHOD /tmp/bundle/ruby/3.0.0/gems/bootsnap-1.5.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22
c:0003 p:0065 s:0015 e:000014 METHOD /tmp/bundle/ruby/3.0.0/gems/bootsnap-1.5.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:31
c:0002 p:0050 s:0007 E:001128 EVAL   bin/rails:9 [FINISH]
c:0001 p:0000 s:0003 E:000e80 (none) [FINISH]
-- Ruby level backtrace information ----------------------------------------
bin/rails:9:in `<main>'
/tmp/bundle/ruby/3.0.0/gems/bootsnap-1.5.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:31:in `require'
/tmp/bundle/ruby/3.0.0/gems/bootsnap-1.5.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `require_with_bootsnap_lfi'
/tmp/bundle/ruby/3.0.0/gems/bootsnap-1.5.1/lib/bootsnap/load_path_cache/loaded_features_index.rb:92:in `register'
/tmp/bundle/ruby/3.0.0/gems/bootsnap-1.5.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `block in require_with_bootsnap_lfi'
/tmp/bundle/ruby/3.0.0/gems/bootsnap-1.5.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `require'
/tmp/bundle/ruby/3.0.0/bundler/gems/rails-f250208dd477/railties/lib/rails/commands.rb:18:in `<main>'
/tmp/bundle/ruby/3.0.0/bundler/gems/rails-f250208dd477/railties/lib/rails/command.rb:50:in `invoke'
/tmp/bundle/ruby/3.0.0/bundler/gems/rails-f250208dd477/railties/lib/rails/command/base.rb:69:in `perform'
/tmp/bundle/ruby/3.0.0/gems/thor-1.0.1/lib/thor.rb:392:in `dispatch'
/tmp/bundle/ruby/3.0.0/gems/thor-1.0.1/lib/thor/invocation.rb:127:in `invoke_command'
/tmp/bundle/ruby/3.0.0/gems/thor-1.0.1/lib/thor/command.rb:27:in `run'
/tmp/bundle/ruby/3.0.0/bundler/gems/rails-f250208dd477/railties/lib/rails/commands/runner/runner_command.rb:42:in `perform'
/tmp/bundle/ruby/3.0.0/gems/bootsnap-1.5.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:64:in `load'
/tmp/bundle/ruby/3.0.0/gems/bootsnap-1.5.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:64:in `load'
/app/lib/profilers/heap_prof_end.rb:3:in `<main>'
/tmp/bundle/ruby/3.0.0/gems/heap-profiler-0.2.1/lib/heap_profiler/runtime.rb:22:in `stop'
/tmp/bundle/ruby/3.0.0/gems/heap-profiler-0.2.1/lib/heap_profiler/reporter.rb:59:in `stop'
__hprof:93:in `dump_heap'
/usr/local/lib/ruby/3.0.0/objspace.rb:87:in `dump_all'
/usr/local/lib/ruby/3.0.0/objspace.rb:87:in `_dump_all'
-- Machine register context ------------------------------------------------
 RIP: 0x00007f3ea64dd675 RBP: 0x00007ffca1eba330 RSP: 0x00007ffca1eba0c8
 RAX: 0x00007ffca1ebaa9e RBX: 0x0000000000000000 RCX: 0x0000000000000000
 RDX: 0x0000000000000000 RDI: 0x0000000000000000 RSI: 0x22656c696622202c
  R8: 0x00007f3ea5bc7e48  R9: 0x00007f3e960e99e0 R10: 0x0000000000000002
 R11: 0x0000000000000008 R12: 0x00007f3e961f8958 R13: 0x00007f3e99e01140
 R14: 0x0000000000000000 R15: 0x00007f3ea507e3f0 EFL: 0x0000000000010283
-- C level backtrace information -------------------------------------------
/usr/local/lib/libruby.so.3.0(rb_print_backtrace+0x11) [0x7f3ea68116e3] vm_dump.c:758
/usr/local/lib/libruby.so.3.0(rb_vm_bugreport) vm_dump.c:998
/usr/local/lib/libruby.so.3.0(rb_bug_for_fatal_signal+0x162) [0x7f3ea661cce2] error.c:786
/usr/local/lib/libruby.so.3.0(sigsegv+0x4d) [0x7f3ea67686ed] signal.c:960
/lib/x86_64-linux-gnu/libc.so.6(0x7f3ea6398210) [0x7f3ea6398210]
/lib/x86_64-linux-gnu/libc.so.6(0x7f3ea64dd675) [0x7f3ea64dd675]
/usr/local/lib/ruby/3.0.0/x86_64-linux/objspace.so(dump_object+0x396) [0x7f3ea507d836] objspace_dump.c:475
/usr/local/lib/ruby/3.0.0/x86_64-linux/objspace.so(heap_i+0x37) [0x7f3ea507e427] objspace_dump.c:516
/usr/local/lib/libruby.so.3.0(objspace_each_objects_without_setup+0xa3) [0x7f3ea66355f3] gc.c:3222
/usr/local/lib/libruby.so.3.0(objspace_each_objects_protected+0x26) [0x7f3ea6635636] gc.c:3232
/usr/local/lib/libruby.so.3.0(rb_ensure+0x12e) [0x7f3ea662564e] eval.c:1158
/usr/local/lib/libruby.so.3.0(objspace_each_objects+0x29) [0x7f3ea6646eb9] gc.c:3300
/usr/local/lib/libruby.so.3.0(rb_objspace_each_objects) gc.c:3288
/usr/local/lib/ruby/3.0.0/x86_64-linux/objspace.so(objspace_dump_all+0xb3) [0x7f3ea507c7b3] objspace_dump.c:611
/usr/local/lib/libruby.so.3.0(vm_call_cfunc_with_frame+0x11b) [0x7f3ea67e9acb] vm_insnhelper.c:2898
/usr/local/lib/libruby.so.3.0(vm_call_method_each_type+0x79) [0x7f3ea67fe359] vm_insnhelper.c:3388
/usr/local/lib/libruby.so.3.0(vm_call_method+0xb4) [0x7f3ea67fea34] vm_insnhelper.c:3506
/usr/local/lib/libruby.so.3.0(vm_sendish+0xe) [0x7f3ea67f7017] vm_insnhelper.c:4499
/usr/local/lib/libruby.so.3.0(vm_exec_core) insns.def:789
/usr/local/lib/libruby.so.3.0(rb_vm_exec+0x1a4) [0x7f3ea67fcbd4] vm.c:2163
/usr/local/lib/libruby.so.3.0(raise_load_if_failed+0x0) [0x7f3ea667f1b9] load.c:594
/usr/local/lib/libruby.so.3.0(rb_load_internal) load.c:654
/usr/local/lib/libruby.so.3.0(rb_f_load) load.c:726
/usr/local/lib/libruby.so.3.0(vm_call_cfunc_with_frame+0x11b) [0x7f3ea67e9acb] vm_insnhelper.c:2898
/usr/local/lib/libruby.so.3.0(vm_call_method_each_type+0x79) [0x7f3ea67fe359] vm_insnhelper.c:3388
/usr/local/lib/libruby.so.3.0(vm_call_alias+0x86) [0x7f3ea67ff926] vm_insnhelper.c:3038
/usr/local/lib/libruby.so.3.0(vm_call_method_each_type+0x249) [0x7f3ea67fe529] vm_insnhelper.c:3418
/usr/local/lib/libruby.so.3.0(vm_call_method+0xb4) [0x7f3ea67fea34] vm_insnhelper.c:3506
/usr/local/lib/libruby.so.3.0(vm_sendish+0xe) [0x7f3ea67f7017] vm_insnhelper.c:4499
/usr/local/lib/libruby.so.3.0(vm_exec_core) insns.def:789
/usr/local/lib/libruby.so.3.0(rb_vm_exec+0xa45) [0x7f3ea67fd475] vm.c:2172
/usr/local/lib/libruby.so.3.0(load_iseq_eval+0x9) [0x7f3ea6680aa0] load.c:594
/usr/local/lib/libruby.so.3.0(require_internal) load.c:1065
/usr/local/lib/libruby.so.3.0(rb_require_string+0x30) [0x7f3ea66814e0] load.c:1142
/usr/local/lib/libruby.so.3.0(vm_call_cfunc_with_frame+0x11b) [0x7f3ea67e9acb] vm_insnhelper.c:2898
/usr/local/lib/libruby.so.3.0(vm_call_method_each_type+0x79) [0x7f3ea67fe359] vm_insnhelper.c:3388
/usr/local/lib/libruby.so.3.0(vm_call_alias+0x86) [0x7f3ea67ff926] vm_insnhelper.c:3038
/usr/local/lib/libruby.so.3.0(vm_call_method_each_type+0x249) [0x7f3ea67fe529] vm_insnhelper.c:3418
/usr/local/lib/libruby.so.3.0(vm_call_alias+0x86) [0x7f3ea67ff926] vm_insnhelper.c:3038
/usr/local/lib/libruby.so.3.0(vm_sendish+0xe) [0x7f3ea67f7017] vm_insnhelper.c:4499
/usr/local/lib/libruby.so.3.0(vm_exec_core) insns.def:789
/usr/local/lib/libruby.so.3.0(rb_vm_exec+0xa45) [0x7f3ea67fd475] vm.c:2172
/usr/local/lib/libruby.so.3.0(rb_ec_exec_node+0xed) [0x7f3ea6621b6d] eval.c:317
/usr/local/lib/libruby.so.3.0(ruby_run_node+0x5a) [0x7f3ea6627a8a] eval.c:375
/usr/local/bin/ruby(main+0x5f) [0x55d5cf8c917f] ./main.c:50
```
</details>

### Reproduction

So apparently some objects can have an attached `allocation_info`, with the `path` being `NULL`, but I have no idea how to create such situation. If someone have an idea I'd like to write a test case for it.

It's also not quite clear how this was working in 2.7 and older, as `ainfo->path` was directly passed to `vfprintf`, so it would have ended up with JSON such as `"path":(null)` which is invalid.

So maybe `->path` being `NULL` is new to ruby 3.0.0 ?

cc @tenderlove @XrXr 