### PR TITLE
Fix `Ripper.lex("a <<b")`

### DIFF
--- a/ext/ripper/lib/ripper/lexer.rb
+++ b/ext/ripper/lib/ripper/lexer.rb
@@ -130,6 +130,7 @@ class Ripper
       @buf = []
       @stack = []
       super()
+      @buf = @stack.pop unless @stack.empty?
       if raise_errors and !@errors.empty?
         raise SyntaxError, @errors.map(&:message).join(' ;')
       end

--- a/test/ripper/test_lexer.rb
+++ b/test/ripper/test_lexer.rb
@@ -90,6 +90,16 @@ class TestRipper::Lexer < Test::Unit::TestCase
     assert_equal expect, Ripper.lex(src).map {|e| e[1]}
   end
 
+  def test_stack_at_on_heredoc_beg
+    src = "a <<b"
+    expect = %I[
+      on_ident
+      on_sp
+      on_heredoc_beg
+    ]
+    assert_equal expect, Ripper.lex(src).map {|e| e[1]}
+  end
+
   def test_slice
     assert_equal "string\#{nil}\n",
       Ripper.slice(%(<<HERE\nstring\#{nil}\nHERE), "heredoc_beg .*? nl $(.*?) heredoc_end", 1)


### PR DESCRIPTION
[Bug #17547]