### PR TITLE
objspace_dump.c: use rb_class_real to lookup singleton_class names

### DIFF
--- a/ext/objspace/objspace_dump.c
+++ b/ext/objspace/objspace_dump.c
@@ -422,7 +422,7 @@ dump_object(VALUE obj, struct dump_config *dc)
       case T_CLASS:
       case T_MODULE:
         if (dc->cur_obj_klass) {
-            VALUE mod_name = rb_mod_name(obj);
+            VALUE mod_name = rb_mod_name(rb_class_real(obj));
             if (!NIL_P(mod_name)) {
                 dump_append(dc, ", \"name\":\"");
                 dump_append(dc, RSTRING_PTR(mod_name));

--- a/test/objspace/test_objspace.rb
+++ b/test/objspace/test_objspace.rb
@@ -276,6 +276,12 @@ class TestObjSpace < Test::Unit::TestCase
     assert_dump_object(info, line)
   end
 
+  def test_dump_singleton_class_name
+    assert_include(ObjectSpace.dump(Object), '"name":"Object"')
+    assert_include(ObjectSpace.dump(Kernel), '"name":"Kernel"')
+    assert_include(ObjectSpace.dump(Object.new.singleton_class), '"name":"Object"')
+  end
+
   def assert_dump_object(info, line)
     loc = caller_locations(1, 1)[0]
     assert_match(/"type":"STRING"/, info)


### PR DESCRIPTION
This fixes a regression introduced in https://github.com/ruby/ruby/pull/3349

In 2.7.2 `rb_class2name` would go up the inheritance chain to get a name for singleton classes. In 3.0 it no longer works:

2.7.2:

```
$ ruby -robjspace -e 'puts ObjectSpace.dump(Object.new.singleton_class)'
{"address":"0x7fca778cdab8", "type":"CLASS", "class":"0x7fca738bfbb0", "name":"Object", "references":["0x7fca778cdb30", "0x7fca738c57b8"], "memsize":456, "flags":{"wb_protected":true}}
```

3.0.0:
```
$ ruby -robjspace -e 'puts ObjectSpace.dump(Object.new.singleton_class)'
{"address":"0x7fdf440a7cd0", "type":"CLASS", "class":"0x7fdf408c9728", "references":["0x7fdf408ca8a8", "0x7fdf440a7d70"], "memsize":472, "flags":{"wb_protected":true}}
```

This name is very useful for https://github.com/Shopify/heap-profiler.

cc @XrXr @tenderlove 