### PR TITLE
[Document][Array] Add missing call-seq for Array#append

### DIFF
--- a/array.c
+++ b/array.c
@@ -1323,6 +1323,7 @@ rb_ary_cat(VALUE ary, const VALUE *argv, long len)
 /*
  *  call-seq:
  *    array.push(*objects) -> self
+ *    array.append(*objects) -> self
  *
  *  Appends trailing elements.
  *


### PR DESCRIPTION
Originally reported by @by-ron at https://github.com/ruby/www.ruby-lang.org/issues/2614.

This PR adds a missing call-seq document for `Array#append`.