### PR TITLE
Struct#initialize also accepts keyword arguments by default

### DIFF
--- a/struct.c
+++ b/struct.c
@@ -665,7 +665,7 @@ rb_struct_initialize_m(int argc, const VALUE *argv, VALUE self)
     }
 
     VALUE keyword_init = rb_struct_s_keyword_init(klass);
-    if (RTEST(keyword_init)) {
+    if ((keyword_init == Qnil && argc == 1 && RB_TYPE_P(argv[0], T_HASH) && rb_keyword_given_p()) || RTEST(keyword_init)) {
 	struct struct_hash_set_arg arg;
 	if (argc > 1 || !RB_TYPE_P(argv[0], T_HASH)) {
 	    rb_raise(rb_eArgError, "wrong number of arguments (given %d, expected 0)", argc);
@@ -683,10 +683,6 @@ rb_struct_initialize_m(int argc, const VALUE *argv, VALUE self)
 	if (n < argc) {
 	    rb_raise(rb_eArgError, "struct size differs");
 	}
-        if (keyword_init == Qnil && argc == 1 && RB_TYPE_P(argv[0], T_HASH) && rb_keyword_given_p()) {
-            rb_warn("Passing only keyword arguments to Struct#initialize will behave differently from Ruby 3.2. "\
-                    "Please use a Hash literal like .new({k: v}) instead of .new(k: v).");
-        }
         for (long i=0; i<argc; i++) {
 	    RSTRUCT_SET(self, i, argv[i]);
 	}

--- a/test/ruby/test_struct.rb
+++ b/test/ruby/test_struct.rb
@@ -350,16 +350,15 @@ module TestStruct
     end
   end
 
-  def test_keyword_args_warning
-    warning = /warning: Passing only keyword arguments to Struct#initialize will behave differently from Ruby 3\.2\./
-    assert_warn(warning) { assert_equal({a: 1}, @Struct.new(:a).new(a: 1).a) }
-    assert_warn(warning) { assert_equal({a: 1}, @Struct.new(:a, keyword_init: nil).new(a: 1).a) }
-    assert_warn('') { assert_equal({a: 1}, @Struct.new(:a).new({a: 1}).a) }
-    assert_warn('') { assert_equal({a: 1}, @Struct.new(:a, :b).new(1, a: 1).b) }
-    assert_warn('') { assert_equal(1, @Struct.new(:a, keyword_init: true).new(a: 1).a) }
-    assert_warn('') { assert_equal({a: 1}, @Struct.new(:a, keyword_init: nil).new({a: 1}).a) }
-    assert_warn('') { assert_equal({a: 1}, @Struct.new(:a, keyword_init: false).new(a: 1).a) }
-    assert_warn('') { assert_equal({a: 1}, @Struct.new(:a, keyword_init: false).new({a: 1}).a) }
+  def test_keyword_args
+    assert_equal(1, @Struct.new(:a).new(a: 1).a)
+    assert_equal(1, @Struct.new(:a, keyword_init: nil).new(a: 1).a)
+    assert_equal({a: 1}, @Struct.new(:a).new({a: 1}).a)
+    assert_equal({a: 1}, @Struct.new(:a, :b).new(1, a: 1).b)
+    assert_equal(1, @Struct.new(:a, keyword_init: true).new(a: 1).a)
+    assert_equal({a: 1}, @Struct.new(:a, keyword_init: nil).new({a: 1}).a)
+    assert_equal({a: 1}, @Struct.new(:a, keyword_init: false).new(a: 1).a)
+    assert_equal({a: 1}, @Struct.new(:a, keyword_init: false).new({a: 1}).a)
   end
 
   def test_nonascii


### PR DESCRIPTION
[Feature #16806]

This is a Ruby 3.2 feature. This should not be merged to Ruby 3.1.