### PR TITLE
Fixed premature return

### DIFF
--- a/test/ruby/test_keyword.rb
+++ b/test/ruby/test_keyword.rb
@@ -2366,6 +2366,11 @@ class TestKeywordArguments < Test::Unit::TestCase
         baz(*args)
       end
 
+      define_method(:block_splat) {|*args| }
+      ruby2_keywords :block_splat, def foo_bar_after_bmethod(*args)
+        bar(*args)
+      end
+
       ruby2_keywords def foo_baz2(*args)
         baz(*args)
         baz(*args)
@@ -2501,6 +2506,7 @@ class TestKeywordArguments < Test::Unit::TestCase
     assert_equal([1, h1], o.foo(:foo_baz, 1, :a=>1))
     assert_equal([[1], h1], o.foo_foo_bar(1, :a=>1))
     assert_equal([1, h1], o.foo_foo_baz(1, :a=>1))
+    assert_equal([[1], h1], o.foo_bar_after_bmethod(1, :a=>1))
 
     assert_equal([[1], h1], o.foo(:bar, 1, **h1))
     assert_equal([1, h1], o.foo(:baz, 1, **h1))
@@ -2516,6 +2522,7 @@ class TestKeywordArguments < Test::Unit::TestCase
     assert_equal([1, h1], o.foo(:foo_baz, 1, **h1))
     assert_equal([[1], h1], o.foo_foo_bar(1, **h1))
     assert_equal([1, h1], o.foo_foo_baz(1, **h1))
+    assert_equal([[1], h1], o.foo_bar_after_bmethod(1, **h1))
 
     assert_equal([[h1], {}], o.foo(:bar, h1, **{}))
     assert_equal([h1], o.foo(:baz, h1, **{}))
@@ -2531,6 +2538,7 @@ class TestKeywordArguments < Test::Unit::TestCase
     assert_equal([h1], o.foo(:foo_baz, h1, **{}))
     assert_equal([[h1], {}], o.foo_foo_bar(h1, **{}))
     assert_equal([h1], o.foo_foo_baz(h1, **{}))
+    assert_equal([[h1], {}], o.foo_bar_after_bmethod(h1, **{}))
 
     assert_equal([[1, h1], {}], o.foo(:bar, 1, h1))
     assert_equal([1, h1], o.foo(:baz, 1, h1))
@@ -2540,6 +2548,7 @@ class TestKeywordArguments < Test::Unit::TestCase
     assert_equal([1, h1], o.store_foo(:baz, 1, h1))
     assert_equal([[1, h1], {}], o.foo_bar(1, h1))
     assert_equal([1, h1], o.foo_baz(1, h1))
+    assert_equal([[1, h1], {}], o.foo_bar_after_bmethod(1, h1))
 
     assert_equal([[1, h1, 1], {}], o.foo_mod(:bar, 1, :a=>1))
     assert_equal([1, h1, 1], o.foo_mod(:baz, 1, :a=>1))

--- a/vm_method.c
+++ b/vm_method.c
@@ -2208,7 +2208,7 @@ rb_mod_ruby2_keywords(int argc, VALUE *argv, VALUE module)
                     else {
                         rb_warn("Skipping set of ruby2_keywords flag for %s (method accepts keywords or method does not accept argument splat)", rb_id2name(name));
                     }
-                    return Qnil;
+                    break;
                 }
               }
               /* fallthrough */


### PR DESCRIPTION
After setting ruby2_keywords for bmethod, the rest of arguments had been ignored. [Bug #17558]