### PR TITLE
Fixed the return value of Module#ruby2_keywords [Bug #17560]

### DIFF
--- a/test/ruby/test_keyword.rb
+++ b/test/ruby/test_keyword.rb
@@ -2791,7 +2791,7 @@ class TestKeywordArguments < Test::Unit::TestCase
     assert_nothing_raised(ArgumentError) { o.clear_last_empty_method(a: 1) }
 
     assert_warn(/Skipping set of ruby2_keywords flag for bar \(method accepts keywords or method does not accept argument splat\)/) do
-      assert_nil(c.send(:ruby2_keywords, :bar))
+      c.send(:ruby2_keywords, :bar)
     end
 
     o = Object.new
@@ -2799,7 +2799,7 @@ class TestKeywordArguments < Test::Unit::TestCase
       alias bar p
     end
     assert_warn(/Skipping set of ruby2_keywords flag for bar \(method not defined in Ruby\)/) do
-      assert_nil(o.singleton_class.send(:ruby2_keywords, :bar))
+      o.singleton_class.send(:ruby2_keywords, :bar)
     end
     sc = Class.new(c)
     assert_warn(/Skipping set of ruby2_keywords flag for bar \(can only set in method defining module\)/) do

--- a/vm_method.c
+++ b/vm_method.c
@@ -2620,7 +2620,7 @@ rb_mod_ruby2_keywords(int argc, VALUE *argv, VALUE module)
             rb_warn("Skipping set of ruby2_keywords flag for %s (can only set in method defining module)", rb_id2name(name));
         }
     }
-    return Qnil;
+    return module;
 }
 
 /*
@@ -2713,7 +2713,7 @@ top_private(int argc, VALUE *argv, VALUE _)
 
 /*
  *  call-seq:
- *     ruby2_keywords(method_name, ...) -> self
+ *     ruby2_keywords(method_name, ...)
  *
  *  For the given method names, marks the method as passing keywords through
  *  a normal argument splat.  See Module#ruby2_keywords in detail.


### PR DESCRIPTION
As mentioned in the RDoc.

Also toplevel ruby2_keywords does not return meaningful value, as well as other toplevel visibility methods, e.g., public, private.