### PR TITLE
Explicit refs to Enumerable in RDoc for Array and Hash

### DIFF
--- a/array.c
+++ b/array.c
@@ -8077,7 +8077,10 @@ rb_ary_deconstruct(VALUE ary)
  *
  *  == What's Here
  *
- *  Class Array provides methods that are useful for:
+ *  First, what's elsewhere. \Array includes the module Enumerable,
+ *  which provides dozens of additional methods.
+ *
+ *  Here, class \Array provides methods that are useful for:
  *
  *  - {Creating an Array}[#class-Array-label-Methods+for+Creating+an+Array]
  *  - {Querying}[#class-Array-label-Methods+for+Querying]

--- a/hash.c
+++ b/hash.c
@@ -6845,7 +6845,10 @@ env_update(VALUE env, VALUE hash)
  *
  *  === What's Here
  *
- *  \Class \Hash provides methods that are useful for:
+ *  First, what's elsewhere. \Hash includes the module Enumerable,
+ *  which provides dozens of additional methods.
+ *
+ *  Here, class \Hash provides methods that are useful for:
  *
  *  - {Creating a Hash}[#class-Hash-label-Methods+for+Creating+a+Hash]
  *  - {Setting Hash State}[#class-Hash-label-Methods+for+Setting+Hash+State]


### PR DESCRIPTION
In What's Here for Array and Hash, add an explicit reference to Enumerable.