### PR TITLE
Extract correct processor name for ARM64 Macs

### DIFF
--- a/tool/m4/ruby_universal_arch.m4
+++ b/tool/m4/ruby_universal_arch.m4
@@ -66,6 +66,9 @@ AS_IF([test ${target_archs+set}], [
 #ifdef __ppc64__
 "processor-name=powerpc64"
 #endif
+#ifdef __arm64__
+"processor-name=arm64"
+#endif
 EOF
 	    sed -n 's/^"processor-name=\(.*\)"/\1/p'`
 	    target="$target_cpu${target}"


### PR DESCRIPTION
backport of https://github.com/ruby/ruby/pull/3272 to support Apple Silicon