### PR TITLE
Move C heap allocations into GC heap for RVALUE object data

### DIFF
--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -123,6 +123,7 @@ jobs:
 #         - { key: cppflags, name: USE_GC_MALLOC_OBJ_INFO_DETAILS, value: '-DUSE_GC_MALLOC_OBJ_INFO_DETAILS' }
           - { key: cppflags, name: USE_LAZY_LOAD,                  value: '-DUSE_LAZY_LOAD' }
 #         - { key: cppflags, name: USE_RINCGC=0,                   value: '-DUSE_RINCGC=0' }
+          - { key: cppflags, name: USE_RVARGC=1,                   value: '-DUSE_RVARGC=1' }
 #         - { key: cppflags, name: USE_SYMBOL_GC=0,                value: '-DUSE_SYMBOL_GC=0' }
 #         - { key: cppflags, name: USE_THREAD_CACHE=0,             value: '-DUSE_THREAD_CACHE=0' }
 #         - { key: cppflags, name: USE_TRANSIENT_HEAP=0,           value: '-DUSE_TRANSIENT_HEAP=0' }

--- a/class.c
+++ b/class.c
@@ -173,8 +173,13 @@ rb_class_detach_module_subclasses(VALUE klass)
 static VALUE
 class_alloc(VALUE flags, VALUE klass)
 {
+#if USE_RVARGC
+    NEWOBJ_OF_SIZE(obj, struct RClass, klass, (flags & T_MASK) | FL_PROMOTED1 /* start from age == 2 */ | (RGENGC_WB_PROTECTED_CLASS ? FL_WB_PROTECTED : 0), sizeof(rb_classext_t));
+    obj->ptr = rb_payload_start_zero((VALUE)obj);
+#else
     NEWOBJ_OF(obj, struct RClass, klass, (flags & T_MASK) | FL_PROMOTED1 /* start from age == 2 */ | (RGENGC_WB_PROTECTED_CLASS ? FL_WB_PROTECTED : 0));
     obj->ptr = ZALLOC(rb_classext_t);
+#endif
     /* ZALLOC
       RCLASS_IV_TBL(obj) = 0;
       RCLASS_CONST_TBL(obj) = 0;

--- a/ext/objspace/objspace_dump.c
+++ b/ext/objspace/objspace_dump.c
@@ -357,6 +357,12 @@ dump_object(VALUE obj, struct dump_config *dc)
     dump_append_ref(dc, obj);
 
     dump_append(dc, ", \"type\":\"");
+#if USE_RVARGC
+    if (rb_is_payload_object(obj)) {
+        dump_append(dc, "PAYLOAD\" }\n");
+        return;
+    }
+#endif
     dump_append(dc, obj_type(obj));
     dump_append(dc, "\"");
 
@@ -636,7 +642,11 @@ objspace_dump_all(VALUE os, VALUE output, VALUE full, VALUE since)
     }
 
     /* dump all objects */
+#if USE_RVARGC
+    rb_objspace_each_objects_with_payload(heap_i, &dc);
+#else
     rb_objspace_each_objects(heap_i, &dc);
+#endif
 
     return dump_result(&dc);
 }

--- a/gc.c
+++ b/gc.c
@@ -2514,6 +2514,31 @@ rb_ec_wb_protected_newobj_of(rb_execution_context_t *ec, VALUE klass, VALUE flag
 }
 
 #if USE_RVARGC
+static inline VALUE
+newobj_of_with_size(VALUE klass, VALUE flags, VALUE v1, VALUE v2, VALUE v3, int wb_protected, size_t payload_size)
+{
+    rb_ractor_t *cr = GET_RACTOR();
+    unsigned short slots = (unsigned short)roomof(payload_size + sizeof(struct RPayloadHead), sizeof(RVALUE));
+    GC_ASSERT(cr->newobj_cache.requested_payload_slots == 0);
+    GC_ASSERT(slots > 0);
+    cr->newobj_cache.requested_payload_slots = slots;
+    return newobj_of_cr(cr, klass, flags, v1, v2, v3, wb_protected);
+}
+
+VALUE
+rb_wb_unprotected_newobj_of_with_size(VALUE klass, VALUE flags, size_t payload_size)
+{
+    GC_ASSERT((flags & FL_WB_PROTECTED) == 0);
+    return newobj_of_with_size(klass, flags, 0, 0, 0, FALSE, payload_size);
+}
+
+VALUE
+rb_wb_protected_newobj_of_with_size(VALUE klass, VALUE flags, size_t payload_size)
+{
+    GC_ASSERT((flags & FL_WB_PROTECTED) == 0);
+    return newobj_of_with_size(klass, flags, 0, 0, 0, TRUE, payload_size);
+}
+
 void *
 rb_payload_start_zero(VALUE obj)
 {

--- a/gc.h
+++ b/gc.h
@@ -131,6 +131,14 @@ void rb_objspace_each_objects(
     int (*callback)(void *start, void *end, size_t stride, void *data),
     void *data);
 
+#if USE_RVARGC
+void rb_objspace_each_objects_with_payload(
+    int (*callback)(void *start, void *end, size_t stride, void *data),
+    void *data);
+
+int rb_is_payload_object(VALUE obj);
+#endif
+
 void rb_objspace_each_objects_without_setup(
     int (*callback)(void *, void *, size_t, void *),
     void *data);

--- a/include/ruby/internal/value_type.h
+++ b/include/ruby/internal/value_type.h
@@ -80,6 +80,9 @@
 #define T_TRUE     RUBY_T_TRUE
 #define T_UNDEF    RUBY_T_UNDEF
 #define T_ZOMBIE   RUBY_T_ZOMBIE
+#if USE_RVARGC
+#define T_PAYLOAD  RUBY_T_PAYLOAD
+#endif
 
 #define BUILTIN_TYPE      RB_BUILTIN_TYPE
 #define DYNAMIC_SYM_P     RB_DYNAMIC_SYM_P
@@ -132,6 +135,10 @@ ruby_value_type {
     RUBY_T_SYMBOL   = 0x14, /**< @see struct ::RSymbol */
     RUBY_T_FIXNUM   = 0x15, /**< Integers formerly known as Fixnums. */
     RUBY_T_UNDEF    = 0x16, /**< @see ::RUBY_Qundef */
+#if USE_RVARGC
+    RUBY_T_PAYLOAD  = 0x17, /**< @see struct ::RPayload */
+#endif
+
 
     RUBY_T_IMEMO    = 0x1a, /**< @see struct ::RIMemo */
     RUBY_T_NODE     = 0x1b, /**< @see struct ::RNode */

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -103,7 +103,7 @@ VALUE rb_ec_wb_protected_newobj_of(struct rb_execution_context_struct *ec, VALUE
 #if USE_RVARGC
 VALUE rb_wb_unprotected_newobj_of_with_size(VALUE klass, VALUE flags, size_t size);
 VALUE rb_wb_protected_newobj_of_with_size(VALUE klass, VALUE flags, size_t size);
-void *rb_payload_data_start_ptr(VALUE obj);
+void *rb_payload_start_zero(VALUE obj);
 #endif
 size_t rb_obj_memsize_of(VALUE);
 void rb_gc_verify_internal_consistency(void);

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -39,6 +39,14 @@ struct rb_objspace; /* in vm_core.h */
 #define NEWOBJ_OF(var, T, c, f) RB_NEWOBJ_OF((var), T, (c), (f))
 #define RB_OBJ_GC_FLAGS_MAX 6   /* used in ext/objspace */
 
+#if USE_RVARGC
+#define RB_NEWOBJ_OF_SIZE(var, T, c, f, s) \
+  T *(var) = (T *)(((f) & FL_WB_PROTECTED) ? \
+                   rb_wb_protected_newobj_of_with_size((c), (f) & ~FL_WB_PROTECTED, s) : \
+                   rb_wb_unprotected_newobj_of_with_size((c), (f), s))
+#define NEWOBJ_OF_SIZE RB_NEWOBJ_OF_SIZE
+#endif
+
 #ifndef USE_UNALIGNED_MEMBER_ACCESS
 # define UNALIGNED_MEMBER_ACCESS(expr) (expr)
 #elif ! USE_UNALIGNED_MEMBER_ACCESS
@@ -92,6 +100,11 @@ const char *rb_objspace_data_type_name(VALUE obj);
 VALUE rb_wb_protected_newobj_of(VALUE, VALUE);
 VALUE rb_wb_unprotected_newobj_of(VALUE, VALUE);
 VALUE rb_ec_wb_protected_newobj_of(struct rb_execution_context_struct *ec, VALUE klass, VALUE flags);
+#if USE_RVARGC
+VALUE rb_wb_unprotected_newobj_of_with_size(VALUE klass, VALUE flags, size_t size);
+VALUE rb_wb_protected_newobj_of_with_size(VALUE klass, VALUE flags, size_t size);
+void *rb_payload_data_start_ptr(VALUE obj);
+#endif
 size_t rb_obj_memsize_of(VALUE);
 void rb_gc_verify_internal_consistency(void);
 size_t rb_obj_gc_flags(VALUE, ID[], size_t);

--- a/ractor_core.h
+++ b/ractor_core.h
@@ -142,6 +142,10 @@ struct rb_ractor_struct {
     struct {
         struct RVALUE *freelist;
         struct heap_page *using_page;
+
+#if USE_RVARGC
+        unsigned short requested_payload_slots;
+#endif
     } newobj_cache;
 
     // gc.c rb_objspace_reachable_objects_from

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -729,6 +729,9 @@ rb_type_str(enum ruby_value_type type)
       case type_case(T_ICLASS);
       case type_case(T_ZOMBIE);
       case type_case(T_MOVED);
+#if USE_RVARGC
+      case type_case(T_PAYLOAD);
+#endif
       case T_MASK: break;
     }
 #undef type_case


### PR DESCRIPTION
[Redmine ticket](https://bugs.ruby-lang.org/issues/17570)

`RVALUE` is fixed width (40 bytes), some of which is used for accounting information and the remainder being used for storage of the object data (e.g. string contents). If the data required is larger than the available space inside the `RVALUE`, memory is allocated outside of the GC heap using malloc and a pointer to the malloc’d region is stored inside the `RVALUE` instead.

We intend to remove this extra memory allocation in favour of storing the extra data in a contiguous region of slots in the heap that are adjacent to the original `RVALUE`.

This branch is the minimum viable implementation required to test our hypothesis. We introduce an API to allocate regions that are multiple slots wide in the heap and we implement this API for objects of type `T_CLASS` so that the `rb_classext_t` struct is stored in the heap alongside its owning `RVALUE`.

cc @peterzhu2118 
