### PR TITLE
Skip the ssl tests in case of raising the additional Errno:: classes.

### DIFF
--- a/test/rubygems/test_bundled_ca.rb
+++ b/test/rubygems/test_bundled_ca.rb
@@ -32,7 +32,7 @@ class TestBundledCA < Gem::TestCase
     http.verify_mode = OpenSSL::SSL::VERIFY_PEER
     http.cert_store = bundled_certificate_store
     http.get('/')
-  rescue Errno::ENOENT, Errno::ETIMEDOUT, SocketError
+  rescue Errno::ECONNREFUSED, Errno::ENETUNREACH, Errno::ENOENT, Errno::ETIMEDOUT, SocketError
     skip "#{host} seems offline, I can't tell whether ssl would work."
   rescue OpenSSL::SSL::SSLError => e
     # Only fail for certificate verification errors


### PR DESCRIPTION
I am seeing the following errors running the tests with Ruby 3.0.0 (+ some patches) on our internal build environment where the internet is always not available.
The errors might come from our build system's new setting to disable the internet. Because I have not seen it in the past there.
After applying this patch for the PR, I see the tests pass correctly skipping the test logic.
It would be great if this patch is merged. Thank you.

```
+ make check 'TESTS=-v ' 'MSPECOPT=-fs  -P '\''raises TypeError if one of the passed exceptions is not a Module'\'''
...
  1) Error:
TestBundledCA#test_accessing_new_index:
Errno::ECONNREFUSED: Failed to open TCP connection to index.rubygems.org:443 (Connection refused - connect(2) for "index.rubygems.org" port 443)
    /builddir/build/BUILD/ruby-3.0.0/lib/net/http.rb:987:in `initialize'
    /builddir/build/BUILD/ruby-3.0.0/lib/net/http.rb:987:in `open'
    /builddir/build/BUILD/ruby-3.0.0/lib/net/http.rb:987:in `block in connect'
    /builddir/build/BUILD/ruby-3.0.0/lib/timeout.rb:97:in `block in timeout'
    /builddir/build/BUILD/ruby-3.0.0/lib/timeout.rb:107:in `timeout'
    /builddir/build/BUILD/ruby-3.0.0/lib/net/http.rb:985:in `connect'
    /builddir/build/BUILD/ruby-3.0.0/lib/net/http.rb:970:in `do_start'
    /builddir/build/BUILD/ruby-3.0.0/lib/net/http.rb:959:in `start'
    /builddir/build/BUILD/ruby-3.0.0/lib/net/http.rb:1512:in `request'
    /builddir/build/BUILD/ruby-3.0.0/lib/net/http.rb:1270:in `get'
    /builddir/build/BUILD/ruby-3.0.0/test/rubygems/test_bundled_ca.rb:34:in `assert_https'
    /builddir/build/BUILD/ruby-3.0.0/test/rubygems/test_bundled_ca.rb:58:in `test_accessing_new_index'
  2) Error:
TestBundledCA#test_accessing_rubygems:
Errno::ECONNREFUSED: Failed to open TCP connection to rubygems.org:443 (Connection refused - connect(2) for "rubygems.org" port 443)
    /builddir/build/BUILD/ruby-3.0.0/lib/net/http.rb:987:in `initialize'
    /builddir/build/BUILD/ruby-3.0.0/lib/net/http.rb:987:in `open'
    /builddir/build/BUILD/ruby-3.0.0/lib/net/http.rb:987:in `block in connect'
    /builddir/build/BUILD/ruby-3.0.0/lib/timeout.rb:97:in `block in timeout'
    /builddir/build/BUILD/ruby-3.0.0/lib/timeout.rb:107:in `timeout'
    /builddir/build/BUILD/ruby-3.0.0/lib/net/http.rb:985:in `connect'
    /builddir/build/BUILD/ruby-3.0.0/lib/net/http.rb:970:in `do_start'
    /builddir/build/BUILD/ruby-3.0.0/lib/net/http.rb:959:in `start'
    /builddir/build/BUILD/ruby-3.0.0/lib/net/http.rb:1512:in `request'
    /builddir/build/BUILD/ruby-3.0.0/lib/net/http.rb:1270:in `get'
    /builddir/build/BUILD/ruby-3.0.0/test/rubygems/test_bundled_ca.rb:34:in `assert_https'
    /builddir/build/BUILD/ruby-3.0.0/test/rubygems/test_bundled_ca.rb:46:in `test_accessing_rubygems'
  3) Error:
TestBundledCA#test_accessing_staging:
Errno::ECONNREFUSED: Failed to open TCP connection to staging.rubygems.org:443 (Connection refused - connect(2) for "staging.rubygems.org" port 443)
    /builddir/build/BUILD/ruby-3.0.0/lib/net/http.rb:987:in `initialize'
    /builddir/build/BUILD/ruby-3.0.0/lib/net/http.rb:987:in `open'
    /builddir/build/BUILD/ruby-3.0.0/lib/net/http.rb:987:in `block in connect'
    /builddir/build/BUILD/ruby-3.0.0/lib/timeout.rb:97:in `block in timeout'
    /builddir/build/BUILD/ruby-3.0.0/lib/timeout.rb:107:in `timeout'
    /builddir/build/BUILD/ruby-3.0.0/lib/net/http.rb:985:in `connect'
    /builddir/build/BUILD/ruby-3.0.0/lib/net/http.rb:970:in `do_start'
    /builddir/build/BUILD/ruby-3.0.0/lib/net/http.rb:959:in `start'
    /builddir/build/BUILD/ruby-3.0.0/lib/net/http.rb:1512:in `request'
    /builddir/build/BUILD/ruby-3.0.0/lib/net/http.rb:1270:in `get'
    /builddir/build/BUILD/ruby-3.0.0/test/rubygems/test_bundled_ca.rb:34:in `assert_https'
    /builddir/build/BUILD/ruby-3.0.0/test/rubygems/test_bundled_ca.rb:54:in `test_accessing_staging'
  4) Error:
TestBundledCA#test_accessing_www_rubygems:
Errno::ECONNREFUSED: Failed to open TCP connection to www.rubygems.org:443 (Connection refused - connect(2) for "www.rubygems.org" port 443)
    /builddir/build/BUILD/ruby-3.0.0/lib/net/http.rb:987:in `initialize'
    /builddir/build/BUILD/ruby-3.0.0/lib/net/http.rb:987:in `open'
    /builddir/build/BUILD/ruby-3.0.0/lib/net/http.rb:987:in `block in connect'
    /builddir/build/BUILD/ruby-3.0.0/lib/timeout.rb:97:in `block in timeout'
    /builddir/build/BUILD/ruby-3.0.0/lib/timeout.rb:107:in `timeout'
    /builddir/build/BUILD/ruby-3.0.0/lib/net/http.rb:985:in `connect'
    /builddir/build/BUILD/ruby-3.0.0/lib/net/http.rb:970:in `do_start'
    /builddir/build/BUILD/ruby-3.0.0/lib/net/http.rb:959:in `start'
    /builddir/build/BUILD/ruby-3.0.0/lib/net/http.rb:1512:in `request'
    /builddir/build/BUILD/ruby-3.0.0/lib/net/http.rb:1270:in `get'
    /builddir/build/BUILD/ruby-3.0.0/test/rubygems/test_bundled_ca.rb:34:in `assert_https'
    /builddir/build/BUILD/ruby-3.0.0/test/rubygems/test_bundled_ca.rb:50:in `test_accessing_www_rubygems'
Finished tests in 590.922615s, 35.4953 tests/s, 4504.4731 assertions/s.
20975 tests, 2661795 assertions, 0 failures, 4 errors, 57 skips
```

