### PR TITLE
Remove temporary directory properly

### DIFF
--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -301,9 +301,6 @@ class Gem::TestCase < Minitest::Test
 
   def setup
     @orig_env = ENV.to_hash
-    @tmp = File.expand_path("tmp")
-
-    FileUtils.mkdir_p @tmp
 
     ENV['GEM_VENDOR'] = nil
     ENV['GEMRC'] = nil
@@ -312,7 +309,6 @@ class Gem::TestCase < Minitest::Test
     ENV['XDG_DATA_HOME'] = nil
     ENV['SOURCE_DATE_EPOCH'] = nil
     ENV['BUNDLER_VERSION'] = nil
-    ENV["TMPDIR"] = @tmp
 
     @current_dir = Dir.pwd
     @fetcher     = nil
@@ -323,13 +319,10 @@ class Gem::TestCase < Minitest::Test
     # capture output
     Gem::DefaultUserInteraction.ui = Gem::MockGemUi.new
 
-    tmpdir = File.realpath Dir.tmpdir
+    tmpdir = File.realpath(Dir.mktmpdir("test_rubygems_"))
     tmpdir.tap(&Gem::UNTAINT)
-
-    @tempdir = File.join(tmpdir, "test_rubygems_#{$$}")
-    @tempdir.tap(&Gem::UNTAINT)
-
-    FileUtils.mkdir_p @tempdir
+    ENV["TMPDIR"] = @tmp = File.dirname(tmpdir)
+    @tempdir = tmpdir
 
     @orig_SYSTEM_WIDE_CONFIG_FILE = Gem::ConfigFile::SYSTEM_WIDE_CONFIG_FILE
     Gem::ConfigFile.send :remove_const, :SYSTEM_WIDE_CONFIG_FILE


### PR DESCRIPTION
For each `make check`, rubygems test makes "tmp" directory and some "gem_generate_index..." directories remain there.

* Do not create a (fixed name) directory in the current working directory
* Should remove its own temporary directory