### PR TITLE
Clear each test own temporary directories

### DIFF
--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -301,9 +301,7 @@ class Gem::TestCase < Minitest::Test
 
   def setup
     @orig_env = ENV.to_hash
-    @tmp = File.expand_path("tmp")
-
-    FileUtils.mkdir_p @tmp
+    @tmp = Dir.mktmpdir("tmp", Dir.pwd)
 
     ENV['GEM_VENDOR'] = nil
     ENV['GEMRC'] = nil
@@ -451,6 +449,7 @@ class Gem::TestCase < Minitest::Test
     Dir.chdir @current_dir
 
     FileUtils.rm_rf @tempdir
+    FileUtils.rm_rf @tmp
 
     ENV.replace(@orig_env)
 


### PR DESCRIPTION
Still `test/rubygems/test_gem_commands_sources_command.rb` creates one `.config/gem/gemrc` file **AFTER** `teardown` run.