### PR TITLE
Reduce RubyVM::InstructionSequence.load_from_binary allocations

### DIFF
--- a/benchmark/iseq_load_from_binary.yml
+++ b/benchmark/iseq_load_from_binary.yml
@@ -1,0 +1,25 @@
+prelude: |
+  symbol = RubyVM::InstructionSequence.compile(":foo; :bar; :baz; :egg; :spam").to_binary
+
+  define_method = RubyVM::InstructionSequence.compile(%{
+    def foo; end
+    def bar; end
+    def baz; end
+    def egg; end
+    def spam; end
+  }).to_binary
+
+  all = RubyVM::InstructionSequence.compile(%{
+    module Foo; def foo; :foo; end; end
+    module Bar; def bar; :bar; end; end
+    module Baz; def baz; :baz; end; end
+    class Egg; def egg; :egg; end; end
+    class Spaml; def spam; :spam; end; end
+  }).to_binary
+
+benchmark:
+  symbol: RubyVM::InstructionSequence.load_from_binary(symbol)
+  define_method: RubyVM::InstructionSequence.load_from_binary(define_method)
+  all: RubyVM::InstructionSequence.load_from_binary(all)
+
+loop_count: 100_000

--- a/compile.c
+++ b/compile.c
@@ -8636,7 +8636,7 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
       }
       case NODE_CLASS:{
 	const rb_iseq_t *class_iseq = NEW_CHILD_ISEQ(node->nd_body,
-						     rb_sprintf("<class:%"PRIsVALUE">", rb_id2str(node->nd_cpath->nd_mid)),
+						     rb_str_freeze(rb_sprintf("<class:%"PRIsVALUE">", rb_id2str(node->nd_cpath->nd_mid))),
 						     ISEQ_TYPE_CLASS, line);
 	const int flags = VM_DEFINECLASS_TYPE_CLASS |
 	    (node->nd_super ? VM_DEFINECLASS_FLAG_HAS_SUPERCLASS : 0) |
@@ -8653,7 +8653,7 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
       }
       case NODE_MODULE:{
         const rb_iseq_t *module_iseq = NEW_CHILD_ISEQ(node->nd_body,
-						      rb_sprintf("<module:%"PRIsVALUE">", rb_id2str(node->nd_cpath->nd_mid)),
+						      rb_str_freeze(rb_sprintf("<module:%"PRIsVALUE">", rb_id2str(node->nd_cpath->nd_mid))),
 						      ISEQ_TYPE_CLASS, line);
 	const int flags = VM_DEFINECLASS_TYPE_MODULE |
 	    compile_cpath(ret, iseq, node->nd_cpath);

--- a/compile.c
+++ b/compile.c
@@ -11363,17 +11363,20 @@ ibf_load_object_string(const struct ibf_load *load, const struct ibf_object_head
     const long len = (long)ibf_load_small_value(load, &reading_pos);
     const char *ptr = load->current_buffer->buff + reading_pos;
 
-    VALUE str = rb_str_new(ptr, len);
-
     if (encindex > RUBY_ENCINDEX_BUILTIN_MAX) {
         VALUE enc_name_str = ibf_load_object(load, encindex - RUBY_ENCINDEX_BUILTIN_MAX);
         encindex = rb_enc_find_index(RSTRING_PTR(enc_name_str));
     }
-    rb_enc_associate_index(str, encindex);
 
-    if (header->internal) rb_obj_hide(str);
-    if (header->frozen)   str = rb_fstring(str);
+    VALUE str;
+    if (header->frozen && !header->internal) {
+        str = rb_enc_interned_str(ptr, len, rb_enc_from_index(encindex));
+    } else {
+        str = rb_enc_str_new(ptr, len, rb_enc_from_index(encindex));
 
+        if (header->internal) rb_obj_hide(str);
+        if (header->frozen)   str = rb_fstring(str);
+    }
     return str;
 }
 

--- a/compile.c
+++ b/compile.c
@@ -11608,21 +11608,7 @@ ibf_load_object_complex_rational(const struct ibf_load *load, const struct ibf_o
 static void
 ibf_dump_object_symbol(struct ibf_dump *dump, VALUE obj)
 {
-    VALUE str = rb_sym2str(obj);
-
-    long encindex = (long)rb_enc_get_index(str);
-    long len = RSTRING_LEN(str);
-    const char *ptr = RSTRING_PTR(str);
-
-    if (encindex > RUBY_ENCINDEX_BUILTIN_MAX) {
-        rb_encoding *enc = rb_enc_from_index((int)encindex);
-        const char *enc_name = rb_enc_name(enc);
-        encindex = RUBY_ENCINDEX_BUILTIN_MAX + ibf_dump_object(dump, rb_str_new2(enc_name));
-    }
-
-    ibf_dump_write_small_value(dump, encindex);
-    ibf_dump_write_small_value(dump, len);
-    IBF_WP(ptr, char, len);
+    ibf_dump_object_string(dump, rb_sym2str(obj));
 }
 
 static VALUE

--- a/compile.c
+++ b/compile.c
@@ -11606,17 +11606,37 @@ static void
 ibf_dump_object_symbol(struct ibf_dump *dump, VALUE obj)
 {
     VALUE str = rb_sym2str(obj);
-    VALUE str_index = ibf_dump_object(dump, str);
 
-    ibf_dump_write_small_value(dump, str_index);
+    long encindex = (long)rb_enc_get_index(str);
+    long len = RSTRING_LEN(str);
+    const char *ptr = RSTRING_PTR(str);
+
+    if (encindex > RUBY_ENCINDEX_BUILTIN_MAX) {
+        rb_encoding *enc = rb_enc_from_index((int)encindex);
+        const char *enc_name = rb_enc_name(enc);
+        encindex = RUBY_ENCINDEX_BUILTIN_MAX + ibf_dump_object(dump, rb_str_new2(enc_name));
+    }
+
+    ibf_dump_write_small_value(dump, encindex);
+    ibf_dump_write_small_value(dump, len);
+    IBF_WP(ptr, char, len);
 }
 
 static VALUE
 ibf_load_object_symbol(const struct ibf_load *load, const struct ibf_object_header *header, ibf_offset_t offset)
 {
-    VALUE str_index = ibf_load_small_value(load, &offset);
-    VALUE str = ibf_load_object(load, str_index);
-    ID id = rb_intern_str(str);
+    ibf_offset_t reading_pos = offset;
+
+    int encindex = (int)ibf_load_small_value(load, &reading_pos);
+    const long len = (long)ibf_load_small_value(load, &reading_pos);
+    const char *ptr = load->current_buffer->buff + reading_pos;
+
+    if (encindex > RUBY_ENCINDEX_BUILTIN_MAX) {
+        VALUE enc_name_str = ibf_load_object(load, encindex - RUBY_ENCINDEX_BUILTIN_MAX);
+        encindex = rb_enc_find_index(RSTRING_PTR(enc_name_str));
+    }
+
+    ID id = rb_intern3(ptr, len, rb_enc_from_index(encindex));
     return ID2SYM(id);
 }
 


### PR DESCRIPTION
Ruby issue: https://bugs.ruby-lang.org/issues/17610

### Context

While profiling our application allocations, I noticed `load_from_binary` would allocate a string for each method:

```
 305.68 kB    7642  "initialize"
              7454  bootsnap-1.5.1/lib/bootsnap/compile_cache/iseq.rb:19
```

This lead me to experiment with the following repro script:
```ruby
# frozen_string_literal: true

require 'objspace'
ObjectSpace.trace_object_allocations_start
preload = [:some_func, :some_sym, :Foo, :extend, "Foo"]

class Foo;end
class Bar;end

binary = RubyVM::InstructionSequence.compile(<<~RUBY).to_binary
  class Foo
    def initialize
    end
  end

  class Bar
    def initialize
    end
  end
RUBY

4.times { GC.start }
GC.disable
gen = GC.count
RubyVM::InstructionSequence.load_from_binary(binary)
RubyVM::InstructionSequence.load_from_binary(binary)

puts ObjectSpace.dump_all(output: :string, since: gen).lines.grep(/"type":"STRING"/)
```

On 3.0.0p0 it allocates 12 strings:
```json
{"address":"0x7f90e7027a40", "type":"STRING", "class":"0x7f90e78be870", "embedded":true, "bytesize":11, "value":"<class:Bar>", "file":"/tmp/load.rb", "line":27, "method":"load_from_binary", "generation":13, "memsize":40, "flags":{"wb_protected":true}}
{"address":"0x7f90e7027ab8", "type":"STRING", "class":"0x7f90e78be870", "embedded":true, "bytesize":3, "value":"Bar", "encoding":"US-ASCII", "file":"/tmp/load.rb", "line":27, "method":"load_from_binary", "generation":13, "memsize":40, "flags":{"wb_protected":true}}
{"address":"0x7f90e7027ae0", "type":"STRING", "class":"0x7f90e78be870", "embedded":true, "bytesize":11, "value":"<class:Foo>", "file":"/tmp/load.rb", "line":27, "method":"load_from_binary", "generation":13, "memsize":40, "flags":{"wb_protected":true}}
{"address":"0x7f90e7027b08", "type":"STRING", "class":"0x7f90e78be870", "embedded":true, "bytesize":10, "value":"<compiled>", "encoding":"US-ASCII", "file":"/tmp/load.rb", "line":27, "method":"load_from_binary", "generation":13, "memsize":40, "flags":{"wb_protected":true}}
{"address":"0x7f90e7027b58", "type":"STRING", "class":"0x7f90e78be870", "embedded":true, "bytesize":10, "value":"initialize", "encoding":"US-ASCII", "file":"/tmp/load.rb", "line":27, "method":"load_from_binary", "generation":13, "memsize":40, "flags":{"wb_protected":true}}
{"address":"0x7f90e7027ba8", "type":"STRING", "class":"0x7f90e78be870", "embedded":true, "bytesize":3, "value":"Foo", "encoding":"US-ASCII", "file":"/tmp/load.rb", "line":27, "method":"load_from_binary", "generation":13, "memsize":40, "flags":{"wb_protected":true}}
{"address":"0x7f90e7027cc0", "type":"STRING", "class":"0x7f90e78be870", "embedded":true, "bytesize":11, "value":"<class:Bar>", "file":"/tmp/load.rb", "line":26, "method":"load_from_binary", "generation":13, "memsize":40, "flags":{"wb_protected":true}}
{"address":"0x7f90e7027d38", "type":"STRING", "class":"0x7f90e78be870", "embedded":true, "bytesize":3, "value":"Bar", "encoding":"US-ASCII", "file":"/tmp/load.rb", "line":26, "method":"load_from_binary", "generation":13, "memsize":40, "flags":{"wb_protected":true}}
{"address":"0x7f90e7027d60", "type":"STRING", "class":"0x7f90e78be870", "embedded":true, "bytesize":11, "value":"<class:Foo>", "file":"/tmp/load.rb", "line":26, "method":"load_from_binary", "generation":13, "memsize":40, "flags":{"wb_protected":true}}
{"address":"0x7f90e7027d88", "type":"STRING", "class":"0x7f90e78be870", "embedded":true, "bytesize":10, "value":"<compiled>", "encoding":"US-ASCII", "file":"/tmp/load.rb", "line":26, "method":"load_from_binary", "generation":13, "memsize":40, "flags":{"wb_protected":true}}
{"address":"0x7f90e7027dd8", "type":"STRING", "class":"0x7f90e78be870", "embedded":true, "bytesize":10, "value":"initialize", "encoding":"US-ASCII", "file":"/tmp/load.rb", "line":26, "method":"load_from_binary", "generation":13, "memsize":40, "flags":{"wb_protected":true}}
{"address":"0x7f90e7027e28", "type":"STRING", "class":"0x7f90e78be870", "embedded":true, "bytesize":3, "value":"Foo", "encoding":"US-ASCII", "file":"/tmp/load.rb", "line":26, "method":"load_from_binary", "generation":13, "memsize":40, "flags":{"wb_protected":true}}
```

For a good part, these allocated strings are immediately passed to `rb_str_intern` to get a symbol, and since constant and method names are very likely to be referenced elsewhere in the application source, most of the time the symbol already exist and could be looked up without first allocating a String.

### This patch

By using `rb_intern3` and `rb_enc_interned_str`, we can lookup existing symbols and fstrings without allocating anything.

The same repro script with this patch only allocate a single string:
```json
{"address":"0x7f88ec8dfde8", "type":"STRING", "class":"0x7f88ec8be800", "frozen":true, "embedded":true, "fstring":true, "bytesize":10, "value":"<compiled>", "encoding":"US-ASCII", "file":"/tmp/load.rb", "line":25, "method":"load_from_binary", "generation":4, "memsize":40, "flags":{"wb_protected":true}}
```

### Performance

I added a small micro benchmark which show minor gains:

```
compare-ruby: ruby 3.1.0dev (2021-01-21T19:19:44Z master 32b7dcfb56) [x86_64-darwin19]
built-ruby: ruby 3.1.0dev (2021-01-25T09:58:02Z iseq-load-symbol 6b0e2c1580) [x86_64-darwin19]
# Iteration per second (i/s)

|               |compare-ruby|built-ruby|
|:--------------|-----------:|---------:|
|symbol         |    447.846k|  489.421k|
|               |           -|     1.09x|
|define_method  |    113.035k|  117.016k|
|               |           -|     1.04x|
|all            |     61.421k|   64.382k|
|               |           -|     1.05x|
```

In a more real world scenario, this patch reduce `load_from_binary` number of allocations by 65%  ( and number of allocations by `7.7%` during our entire application's boot process) (`~1.7M` allocations avoided), and WALL profiling show much less time spent in `load_from_binary`:

3.0.0-p0:
```
==================================
  Mode: wall(1000)
  Samples: 57745 (13.29% miss rate)
  GC: 16369 (28.35%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      6500  (11.3%)        6497  (11.3%)     RubyVM::InstructionSequence.load_from_binary
``` 

3.0.0-p0 + this patch:
```
==================================
  Mode: wall(1000)
  Samples: 46137 (13.32% miss rate)
  GC: 14094 (30.55%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      3333   (7.2%)        3331   (7.2%)     RubyVM::InstructionSequence.load_from_binary
```

I tried measuring the same thing on popular open source applications like Redmine or Discourse, unfortunately I couldn't make them work on Ruby 3.0 yet.

cc @XrXr @tenderlove thoughts?