### PR TITLE
Fix backtrace to not skip frames with iseq without pc

### DIFF
--- a/test/ruby/test_backtrace.rb
+++ b/test/ruby/test_backtrace.rb
@@ -138,6 +138,18 @@ class TestBacktrace < Test::Unit::TestCase
     rec[m]
   end
 
+  def test_caller_with_limit
+    x = nil
+    c = Class.new do
+      define_method(:bar) do
+        x = caller(1, 1)
+      end
+    end
+    [c.new].group_by(&:bar)
+    assert_equal 1, x.length
+    assert_equal caller(0), caller(0, nil)
+  end
+
   def test_caller_with_nil_length
     assert_equal caller(0), caller(0, nil)
   end


### PR DESCRIPTION
Previously, frames with iseq but no pc were skipped (even before
the refactoring in 3b24b7914c16930bfadc89d6aff6326a51c54295).
Because the entire backtrace was procesed before the refactoring,
this was handled by using later frames instead.  However, after
the refactoring, we need to handle those frames or they get
lost.

Keep two iteration counters when iterating, one for the desired
backtrace size (so we generate the desired number of frames), and
one for the actual backtrace size (so we don't process off the end
of the stack).  When skipping over an iseq frame with no pc,
decrement the counter for the desired backtrace, so it will
continue to process the expected number of backtrace frames.

Fixes [Bug #17581]