### PR TITLE
Removed YYUSE [Bug #17582]

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -13334,7 +13334,6 @@ count_char(const char *str, int c)
 RUBY_FUNC_EXPORTED size_t
 rb_yytnamerr(struct parser_params *p, char *yyres, const char *yystr)
 {
-    YYUSE(p);
     if (*yystr == '"') {
 	size_t yyn = 0, bquote = 0;
 	const char *yyp = yystr;


### PR DESCRIPTION
Although it was used just to suppress an "unsed argument" warning in the same manner as other bison-provided functions, it has been dropped since Bision 3.7.5.
And we always suppress that warnings.