### PR TITLE
Improve consistency of RCLASS macros

### DIFF
--- a/class.c
+++ b/class.c
@@ -56,11 +56,11 @@ rb_class_subclass_add(VALUE super, VALUE klass)
 	head = RCLASS_EXT(super)->subclasses;
 	if (head) {
 	    entry->next = head;
-	    RCLASS_EXT(head->klass)->parent_subclasses = &entry->next;
+	    RCLASS_PARENT_SUBCLASSES(head->klass) = &entry->next;
 	}
 
 	RCLASS_EXT(super)->subclasses = entry;
-	RCLASS_EXT(klass)->parent_subclasses = &RCLASS_EXT(super)->subclasses;
+	RCLASS_PARENT_SUBCLASSES(klass) = &RCLASS_EXT(super)->subclasses;
     }
 }
 
@@ -88,17 +88,17 @@ rb_class_remove_from_super_subclasses(VALUE klass)
 {
     rb_subclass_entry_t *entry;
 
-    if (RCLASS_EXT(klass)->parent_subclasses) {
-	entry = *RCLASS_EXT(klass)->parent_subclasses;
+    if (RCLASS_PARENT_SUBCLASSES(klass)) {
+	entry = *RCLASS_PARENT_SUBCLASSES(klass);
 
-	*RCLASS_EXT(klass)->parent_subclasses = entry->next;
+	*RCLASS_PARENT_SUBCLASSES(klass) = entry->next;
 	if (entry->next) {
-	    RCLASS_EXT(entry->next->klass)->parent_subclasses = RCLASS_EXT(klass)->parent_subclasses;
+	    RCLASS_PARENT_SUBCLASSES(entry->next->klass) = RCLASS_PARENT_SUBCLASSES(klass);
 	}
 	xfree(entry);
     }
 
-    RCLASS_EXT(klass)->parent_subclasses = NULL;
+    RCLASS_PARENT_SUBCLASSES(klass) = NULL;
 }
 
 void
@@ -182,7 +182,7 @@ class_alloc(VALUE flags, VALUE klass)
       RCLASS_IV_INDEX_TBL(obj) = 0;
       RCLASS_SET_SUPER((VALUE)obj, 0);
       RCLASS_EXT(obj)->subclasses = NULL;
-      RCLASS_EXT(obj)->parent_subclasses = NULL;
+      RCLASS_PARENT_SUBCLASSES(obj) = NULL;
       RCLASS_EXT(obj)->module_subclasses = NULL;
      */
     RCLASS_SET_ORIGIN((VALUE)obj, (VALUE)obj);

--- a/class.c
+++ b/class.c
@@ -76,11 +76,11 @@ rb_module_add_to_subclasses_list(VALUE module, VALUE iclass)
     head = RCLASS_EXT(module)->subclasses;
     if (head) {
 	entry->next = head;
-	RCLASS_EXT(head->klass)->module_subclasses = &entry->next;
+	RCLASS_MODULE_SUBCLASSES(head->klass) = &entry->next;
     }
 
     RCLASS_EXT(module)->subclasses = entry;
-    RCLASS_EXT(iclass)->module_subclasses = &RCLASS_EXT(module)->subclasses;
+    RCLASS_MODULE_SUBCLASSES(iclass) = &RCLASS_EXT(module)->subclasses;
 }
 
 void
@@ -106,18 +106,18 @@ rb_class_remove_from_module_subclasses(VALUE klass)
 {
     rb_subclass_entry_t *entry;
 
-    if (RCLASS_EXT(klass)->module_subclasses) {
-	entry = *RCLASS_EXT(klass)->module_subclasses;
-	*RCLASS_EXT(klass)->module_subclasses = entry->next;
+    if (RCLASS_MODULE_SUBCLASSES(klass)) {
+	entry = *RCLASS_MODULE_SUBCLASSES(klass);
+	*RCLASS_MODULE_SUBCLASSES(klass) = entry->next;
 
 	if (entry->next) {
-	    RCLASS_EXT(entry->next->klass)->module_subclasses = RCLASS_EXT(klass)->module_subclasses;
+	    RCLASS_MODULE_SUBCLASSES(entry->next->klass) = RCLASS_MODULE_SUBCLASSES(klass);
 	}
 
 	xfree(entry);
     }
 
-    RCLASS_EXT(klass)->module_subclasses = NULL;
+    RCLASS_MODULE_SUBCLASSES(klass) = NULL;
 }
 
 void
@@ -183,7 +183,7 @@ class_alloc(VALUE flags, VALUE klass)
       RCLASS_SET_SUPER((VALUE)obj, 0);
       RCLASS_EXT(obj)->subclasses = NULL;
       RCLASS_PARENT_SUBCLASSES(obj) = NULL;
-      RCLASS_EXT(obj)->module_subclasses = NULL;
+      RCLASS_MODULE_SUBCLASSES(obj) = NULL;
      */
     RCLASS_SET_ORIGIN((VALUE)obj, (VALUE)obj);
     RCLASS_SERIAL(obj) = rb_next_class_serial();

--- a/class.c
+++ b/class.c
@@ -188,7 +188,7 @@ class_alloc(VALUE flags, VALUE klass)
     RCLASS_SET_ORIGIN((VALUE)obj, (VALUE)obj);
     RCLASS_SERIAL(obj) = rb_next_class_serial();
     RB_OBJ_WRITE(obj, &RCLASS_REFINED_CLASS(obj), Qnil);
-    RCLASS_EXT(obj)->allocator = 0;
+    RCLASS_ALLOCATOR(obj) = 0;
 
     return (VALUE)obj;
 }
@@ -372,7 +372,7 @@ rb_mod_init_copy(VALUE clone, VALUE orig)
         RBASIC_SET_CLASS(clone, rb_singleton_class_clone(orig));
         rb_singleton_class_attached(RBASIC(clone)->klass, (VALUE)clone);
     }
-    RCLASS_EXT(clone)->allocator = RCLASS_EXT(orig)->allocator;
+    RCLASS_ALLOCATOR(clone) = RCLASS_ALLOCATOR(orig);
     copy_tables(clone, orig);
     if (RCLASS_M_TBL(orig)) {
 	struct clone_method_arg arg;
@@ -409,7 +409,7 @@ rb_mod_init_copy(VALUE clone, VALUE orig)
             RCLASS_M_TBL(clone_p) = RCLASS_M_TBL(p);
             RCLASS_CONST_TBL(clone_p) = RCLASS_CONST_TBL(p);
             RCLASS_IV_TBL(clone_p) = RCLASS_IV_TBL(p);
-            RCLASS_EXT(clone_p)->allocator = RCLASS_EXT(p)->allocator;
+            RCLASS_ALLOCATOR(clone_p) = RCLASS_ALLOCATOR(p);
             if (RB_TYPE_P(clone, T_CLASS)) {
                 RCLASS_SET_INCLUDER(clone_p, clone);
             }
@@ -492,7 +492,7 @@ rb_singleton_class_clone_and_attach(VALUE obj, VALUE attach)
 	}
 
 	RCLASS_SET_SUPER(clone, RCLASS_SUPER(klass));
-	RCLASS_EXT(clone)->allocator = RCLASS_EXT(klass)->allocator;
+	RCLASS_ALLOCATOR(clone) = RCLASS_ALLOCATOR(klass);
 	if (RCLASS_IV_TBL(klass)) {
 	    rb_iv_tbl_copy(clone, klass);
 	}

--- a/class.c
+++ b/class.c
@@ -53,14 +53,14 @@ rb_class_subclass_add(VALUE super, VALUE klass)
 	entry->klass = klass;
 	entry->next = NULL;
 
-	head = RCLASS_EXT(super)->subclasses;
+	head = RCLASS_SUBCLASSES(super);
 	if (head) {
 	    entry->next = head;
 	    RCLASS_PARENT_SUBCLASSES(head->klass) = &entry->next;
 	}
 
-	RCLASS_EXT(super)->subclasses = entry;
-	RCLASS_PARENT_SUBCLASSES(klass) = &RCLASS_EXT(super)->subclasses;
+	RCLASS_SUBCLASSES(super) = entry;
+	RCLASS_PARENT_SUBCLASSES(klass) = &RCLASS_SUBCLASSES(super);
     }
 }
 
@@ -73,14 +73,14 @@ rb_module_add_to_subclasses_list(VALUE module, VALUE iclass)
     entry->klass = iclass;
     entry->next = NULL;
 
-    head = RCLASS_EXT(module)->subclasses;
+    head = RCLASS_SUBCLASSES(module);
     if (head) {
 	entry->next = head;
 	RCLASS_MODULE_SUBCLASSES(head->klass) = &entry->next;
     }
 
-    RCLASS_EXT(module)->subclasses = entry;
-    RCLASS_MODULE_SUBCLASSES(iclass) = &RCLASS_EXT(module)->subclasses;
+    RCLASS_SUBCLASSES(module) = entry;
+    RCLASS_MODULE_SUBCLASSES(iclass) = &RCLASS_SUBCLASSES(module);
 }
 
 void
@@ -123,7 +123,7 @@ rb_class_remove_from_module_subclasses(VALUE klass)
 void
 rb_class_foreach_subclass(VALUE klass, void (*f)(VALUE, VALUE), VALUE arg)
 {
-    rb_subclass_entry_t *cur = RCLASS_EXT(klass)->subclasses;
+    rb_subclass_entry_t *cur = RCLASS_SUBCLASSES(klass);
 
     /* do not be tempted to simplify this loop into a for loop, the order of
        operations is important here if `f` modifies the linked list */
@@ -181,7 +181,7 @@ class_alloc(VALUE flags, VALUE klass)
       RCLASS_M_TBL(obj) = 0;
       RCLASS_IV_INDEX_TBL(obj) = 0;
       RCLASS_SET_SUPER((VALUE)obj, 0);
-      RCLASS_EXT(obj)->subclasses = NULL;
+      RCLASS_SUBCLASSES(obj) = NULL;
       RCLASS_PARENT_SUBCLASSES(obj) = NULL;
       RCLASS_MODULE_SUBCLASSES(obj) = NULL;
      */
@@ -969,7 +969,7 @@ rb_include_module(VALUE klass, VALUE module)
 	rb_raise(rb_eArgError, "cyclic include detected");
 
     if (RB_TYPE_P(klass, T_MODULE)) {
-        rb_subclass_entry_t *iclass = RCLASS_EXT(klass)->subclasses;
+        rb_subclass_entry_t *iclass = RCLASS_SUBCLASSES(klass);
         int do_include = 1;
         while (iclass) {
             VALUE check_class = iclass->klass;
@@ -1180,7 +1180,7 @@ rb_prepend_module(VALUE klass, VALUE module)
 	rb_vm_check_redefinition_by_prepend(klass);
     }
     if (RB_TYPE_P(klass, T_MODULE)) {
-        rb_subclass_entry_t *iclass = RCLASS_EXT(klass)->subclasses;
+        rb_subclass_entry_t *iclass = RCLASS_SUBCLASSES(klass);
         VALUE klass_origin = RCLASS_ORIGIN(klass);
         struct rb_id_table *klass_m_tbl = RCLASS_M_TBL(klass);
         struct rb_id_table *klass_origin_m_tbl = RCLASS_M_TBL(klass_origin);

--- a/gc.c
+++ b/gc.c
@@ -2845,9 +2845,9 @@ obj_free(rb_objspace_t *objspace, VALUE obj)
 	}
 	rb_class_remove_from_module_subclasses(obj);
 	rb_class_remove_from_super_subclasses(obj);
-	if (RANY(obj)->as.klass.ptr)
-	    xfree(RANY(obj)->as.klass.ptr);
-	RANY(obj)->as.klass.ptr = NULL;
+	if (RCLASS_EXT(obj))
+	    xfree(RCLASS_EXT(obj));
+	RCLASS_EXT(obj) = NULL;
 
         (void)RB_DEBUG_COUNTER_INC_IF(obj_module_ptr, BUILTIN_TYPE(obj) == T_MODULE);
         (void)RB_DEBUG_COUNTER_INC_IF(obj_class_ptr, BUILTIN_TYPE(obj) == T_CLASS);
@@ -3013,8 +3013,8 @@ obj_free(rb_objspace_t *objspace, VALUE obj)
         cc_table_free(objspace, obj, FALSE);
 	rb_class_remove_from_module_subclasses(obj);
 	rb_class_remove_from_super_subclasses(obj);
-	xfree(RANY(obj)->as.klass.ptr);
-	RANY(obj)->as.klass.ptr = NULL;
+	xfree(RCLASS_EXT(obj));
+	RCLASS_EXT(obj) = NULL;
 
         RB_DEBUG_COUNTER_INC(obj_iclass_ptr);
 	break;

--- a/gc.c
+++ b/gc.c
@@ -2834,14 +2834,14 @@ obj_free(rb_objspace_t *objspace, VALUE obj)
 	if (RCLASS_IV_INDEX_TBL(obj)) {
             iv_index_tbl_free(RCLASS_IV_INDEX_TBL(obj));
 	}
-	if (RCLASS_EXT(obj)->subclasses) {
+	if (RCLASS_SUBCLASSES(obj)) {
 	    if (BUILTIN_TYPE(obj) == T_MODULE) {
 		rb_class_detach_module_subclasses(obj);
 	    }
 	    else {
 		rb_class_detach_subclasses(obj);
 	    }
-	    RCLASS_EXT(obj)->subclasses = NULL;
+	    RCLASS_SUBCLASSES(obj) = NULL;
 	}
 	rb_class_remove_from_module_subclasses(obj);
 	rb_class_remove_from_super_subclasses(obj);
@@ -3006,9 +3006,9 @@ obj_free(rb_objspace_t *objspace, VALUE obj)
 	if (RCLASS_CALLABLE_M_TBL(obj) != NULL) {
 	    rb_id_table_free(RCLASS_CALLABLE_M_TBL(obj));
 	}
-	if (RCLASS_EXT(obj)->subclasses) {
+	if (RCLASS_SUBCLASSES(obj)) {
 	    rb_class_detach_subclasses(obj);
-	    RCLASS_EXT(obj)->subclasses = NULL;
+	    RCLASS_SUBCLASSES(obj) = NULL;
 	}
         cc_table_free(objspace, obj, FALSE);
 	rb_class_remove_from_module_subclasses(obj);

--- a/internal/class.h
+++ b/internal/class.h
@@ -92,6 +92,7 @@ typedef struct rb_classext_struct rb_classext_t;
 # define RCLASS_SERIAL(c) (RCLASS_EXT(c)->class_serial)
 #endif
 #define RCLASS_INCLUDER(c) (RCLASS_EXT(c)->includer)
+#define RCLASS_PARENT_SUBCLASSES(c) (RCLASS_EXT(c)->parent_subclasses)
 
 #define RICLASS_IS_ORIGIN FL_USER5
 #define RCLASS_CLONED     FL_USER6

--- a/internal/class.h
+++ b/internal/class.h
@@ -93,6 +93,7 @@ typedef struct rb_classext_struct rb_classext_t;
 #endif
 #define RCLASS_INCLUDER(c) (RCLASS_EXT(c)->includer)
 #define RCLASS_PARENT_SUBCLASSES(c) (RCLASS_EXT(c)->parent_subclasses)
+#define RCLASS_MODULE_SUBCLASSES(c) (RCLASS_EXT(c)->module_subclasses)
 
 #define RICLASS_IS_ORIGIN FL_USER5
 #define RCLASS_CLONED     FL_USER6

--- a/internal/class.h
+++ b/internal/class.h
@@ -94,6 +94,7 @@ typedef struct rb_classext_struct rb_classext_t;
 #define RCLASS_INCLUDER(c) (RCLASS_EXT(c)->includer)
 #define RCLASS_PARENT_SUBCLASSES(c) (RCLASS_EXT(c)->parent_subclasses)
 #define RCLASS_MODULE_SUBCLASSES(c) (RCLASS_EXT(c)->module_subclasses)
+#define RCLASS_ALLOCATOR(c) (RCLASS_EXT(c)->allocator)
 
 #define RICLASS_IS_ORIGIN FL_USER5
 #define RCLASS_CLONED     FL_USER6

--- a/internal/class.h
+++ b/internal/class.h
@@ -95,6 +95,7 @@ typedef struct rb_classext_struct rb_classext_t;
 #define RCLASS_PARENT_SUBCLASSES(c) (RCLASS_EXT(c)->parent_subclasses)
 #define RCLASS_MODULE_SUBCLASSES(c) (RCLASS_EXT(c)->module_subclasses)
 #define RCLASS_ALLOCATOR(c) (RCLASS_EXT(c)->allocator)
+#define RCLASS_SUBCLASSES(c) (RCLASS_EXT(c)->subclasses)
 
 #define RICLASS_IS_ORIGIN FL_USER5
 #define RCLASS_CLONED     FL_USER6

--- a/vm_method.c
+++ b/vm_method.c
@@ -941,7 +941,7 @@ void
 rb_define_alloc_func(VALUE klass, VALUE (*func)(VALUE))
 {
     Check_Type(klass, T_CLASS);
-    RCLASS_EXT(klass)->allocator = func;
+    RCLASS_ALLOCATOR(klass) = func;
 }
 
 void
@@ -956,7 +956,7 @@ rb_get_alloc_func(VALUE klass)
     Check_Type(klass, T_CLASS);
 
     for (; klass; klass = RCLASS_SUPER(klass)) {
-	rb_alloc_func_t allocator = RCLASS_EXT(klass)->allocator;
+	rb_alloc_func_t allocator = RCLASS_ALLOCATOR(klass);
 	if (allocator == UNDEF_ALLOC_FUNC) break;
 	if (allocator) return allocator;
     }

--- a/vm_method.c
+++ b/vm_method.c
@@ -153,7 +153,7 @@ clear_method_cache_by_id_in_class(VALUE klass, ID mid)
     VM_ASSERT(RB_TYPE_P(klass, T_CLASS) || RB_TYPE_P(klass, T_ICLASS));
     if (rb_objspace_garbage_object_p(klass)) return;
 
-    if (LIKELY(RCLASS_EXT(klass)->subclasses == NULL)) {
+    if (LIKELY(RCLASS_SUBCLASSES(klass) == NULL)) {
         // no subclasses
         // check only current class
 


### PR DESCRIPTION
Macro's for the members of `RCLASS_EXT` are inconsistent, some existed and some relied on direct member access.

This PR adds missing macros for access to the other members of `RCLASS_EXT` and additionally uses `RCLASS_EXT` in some cases where the pointer was being accessed directly