### PR TITLE
Fixed Kernel#rand spec

### DIFF
--- a/spec/ruby/core/kernel/rand_spec.rb
+++ b/spec/ruby/core/kernel/rand_spec.rb
@@ -119,9 +119,9 @@ describe "Kernel.rand" do
 
   context "given an inclusive range between 0 and 1" do
     it "returns an Integer between the two Integers" do
-        x = rand(0..1)
-        x.should be_kind_of(Integer)
-        (0..1).should include(x)
+      x = rand(0..1)
+      x.should be_kind_of(Integer)
+      (0..1).should include(x)
     end
 
     it "returns a Float if at least one side is Float" do
@@ -131,8 +131,8 @@ describe "Kernel.rand" do
       x3 = Random.new(seed).rand(0.0..1)
 
       x3.should be_kind_of(Float)
-      x1.should equal(x3)
-      x2.should equal(x3)
+      x1.should eql(x3)
+      x2.should eql(x3)
 
       (0.0..1.0).should include(x3)
     end
@@ -140,9 +140,9 @@ describe "Kernel.rand" do
 
   context "given an exclusive range between 0 and 1" do
     it "returns zero as an Integer" do
-        x = rand(0...1)
-        x.should be_kind_of(Integer)
-        x.should eql(0)
+      x = rand(0...1)
+      x.should be_kind_of(Integer)
+      x.should eql(0)
     end
 
     it "returns a Float if at least one side is Float" do
@@ -152,8 +152,8 @@ describe "Kernel.rand" do
       x3 = Random.new(seed).rand(0.0...1)
 
       x3.should be_kind_of(Float)
-      x1.should equal(x3)
-      x2.should equal(x3)
+      x1.should eql(x3)
+      x2.should eql(x3)
 
       (0.0...1.0).should include(x3)
     end


### PR DESCRIPTION
`Float` should not be compared by identity.