### PR TITLE
Fix absolute path predicate on Windows

### DIFF
--- a/lib/irb/ext/loader.rb
+++ b/lib/irb/ext/loader.rb
@@ -31,8 +31,31 @@ module IRB # :nodoc:
       load_file(path, priv)
     end
 
+    if File.respond_to?(:absolute_path?)
+      def absolute_path?(path)
+        File.absolute_path?(path)
+      end
+    else
+      separator =
+        if File::ALT_SEPARATOR
+          File::SEPARATOR
+        else
+          "[#{Regexp.quote(File::SEPARATOR + File::ALT_SEPARATOR)}]"
+        end
+      ABSOLUTE_PATH_PATTERN = # :nodoc:
+        case Dir.pwd
+        when /\A\w:/, /\A#{separator}{2}/
+          /\A(?:\w:|#{separator})#{separator}/
+        else
+          /\A#{separator}/
+        end
+      def absolute_path?(path)
+        ABSOLUTE_PATH_PATTERN =~ path
+      end
+    end
+
     def search_file_from_ruby_path(fn) # :nodoc:
-      if /^#{Regexp.quote(File::Separator)}/ =~ fn
+      if absolute_path?(fn)
         return fn if File.exist?(fn)
         return nil
       end


### PR DESCRIPTION
A path starts with '/' is not an absolute path on Windows, because of drive letter or UNC.