### PR TITLE
Move rb_big_isqrt declaration

### DIFF
--- a/internal/bignum.h
+++ b/internal/bignum.h
@@ -131,6 +131,7 @@ VALUE rb_big_ge(VALUE x, VALUE y);
 VALUE rb_big_lt(VALUE x, VALUE y);
 VALUE rb_big_le(VALUE x, VALUE y);
 VALUE rb_int_powm(int const argc, VALUE * const argv, VALUE const num);
+VALUE rb_big_isqrt(VALUE n);
 static inline bool BIGNUM_SIGN(VALUE b);
 static inline bool BIGNUM_POSITIVE_P(VALUE b);
 static inline bool BIGNUM_NEGATIVE_P(VALUE b);

--- a/numeric.c
+++ b/numeric.c
@@ -5269,8 +5269,6 @@ DEFINE_INT_SQRT(BDIGIT, rb_bdigit_dbl, BDIGIT_DBL)
 #define domain_error(msg) \
     rb_raise(rb_eMathDomainError, "Numerical argument is out of domain - " #msg)
 
-VALUE rb_big_isqrt(VALUE);
-
 /*
  *  Document-method: Integer::sqrt
  *  call-seq:


### PR DESCRIPTION
Move `rb_big_isqrt` declaration to `internal/bignum.h`