### PR TITLE
Add File.absolute_path? to NEWS-2.7.0

### DIFF
--- a/doc/NEWS-2.7.0
+++ b/doc/NEWS-2.7.0
@@ -366,6 +366,15 @@ See also Warning in {Core classes updates}[#label-Core+classes+updates+-28outsta
 
 [File]
 
+  [New method]
+
+    * Added File.absolute_path? to check whether a path is absolute or
+      not in a portable way.
+
+        File.absolute_path?("/foo")   # => true (on *nix)
+        File.absolute_path?("C:/foo") # => true (on Windows)
+        File.absolute_path?("foo")    # => false
+
   [Modified method]
 
     * File.extname now returns a dot string for names ending with a dot on

--- a/doc/NEWS-2.7.0
+++ b/doc/NEWS-2.7.0
@@ -369,7 +369,7 @@ See also Warning in {Core classes updates}[#label-Core+classes+updates+-28outsta
   [New method]
 
     * Added File.absolute_path? to check whether a path is absolute or
-      not in a portable way.
+      not in a portable way. [Feature #15868]
 
         File.absolute_path?("/foo")   # => true (on *nix)
         File.absolute_path?("C:/foo") # => true (on Windows)


### PR DESCRIPTION
`File.absolute_path?` has been added since Ruby 2.7.0, but it isn't
mentioned in the NEWS. So this patch adds a NEWS entry.

ref: https://bugs.ruby-lang.org/issues/15868



---


I expect that I can find all added methods from the NEWS file. But if the lack of entry is intentional, feel free to close this pull request.



---


ref: https://github.com/rurema/doctree/issues/2446 I noticed this problem by the issue on the Japanese Ruby document project.