### PR TITLE
The Queue constructor should take an initial set of objects

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -71,6 +71,6 @@ Excluding feature bug fixes.
 
 [Feature #14256]: https://bugs.ruby-lang.org/issues/14256
 [Feature #16806]: https://bugs.ruby-lang.org/issues/16806
-[Feature #17327]: https://bugs.ruby-lang.org/issues/17327
 [Feature #17312]: https://bugs.ruby-lang.org/issues/17312
+[Feature #17327]: https://bugs.ruby-lang.org/issues/17327
 [Bug #17423]: https://bugs.ruby-lang.org/issues/17423

--- a/NEWS.md
+++ b/NEWS.md
@@ -34,6 +34,11 @@ Outstanding ones only.
       You need to use a Hash literal to set a Hash to a first member.
       [[Feature #16806]]
 
+* Queue
+
+    * Queue#initialize now accepts an Enumerable of initial values.
+      [[Feature #17327]]
+
 ## Stdlib updates
 
 Outstanding ones only.
@@ -66,5 +71,6 @@ Excluding feature bug fixes.
 
 [Feature #14256]: https://bugs.ruby-lang.org/issues/14256
 [Feature #16806]: https://bugs.ruby-lang.org/issues/16806
+[Feature #17327]: https://bugs.ruby-lang.org/issues/17327
 [Feature #17312]: https://bugs.ruby-lang.org/issues/17312
 [Bug #17423]: https://bugs.ruby-lang.org/issues/17423

--- a/spec/ruby/core/queue/initialize_spec.rb
+++ b/spec/ruby/core/queue/initialize_spec.rb
@@ -1,0 +1,44 @@
+require_relative '../../spec_helper'
+
+describe "Queue#initialize" do
+  it "can be passed no arguments for an empty Queue" do
+    q = Queue.new
+    q.size.should == 0
+    q.should.empty?
+  end
+
+  ruby_version_is '3.1' do
+    it "adds all elements of the passed Enumerable to self" do
+      q = Queue.new([1, 2, 3])
+      q.size.should == 3
+      q.should_not.empty?
+      q.pop.should == 1
+      q.pop.should == 2
+      q.pop.should == 3
+      q.should.empty?
+    end
+
+    it "uses #to_ary on the provided Enumerable" do
+      enumerable = MockObject.new('mock-enumerable')
+      enumerable.should_receive(:to_ary).and_return([1, 2, 3])
+      q = Queue.new(enumerable)
+      q.size.should == 3
+      q.should_not.empty?
+      q.pop.should == 1
+      q.pop.should == 2
+      q.pop.should == 3
+      q.should.empty?
+    end
+
+    it "raises if the provided Enumerable does not respond to #to_ary" do
+      enumerable = MockObject.new('mock-enumerable')
+      -> { Queue.new(enumerable) }.should raise_error(TypeError, "no implicit conversion of MockObject into Array")
+    end
+
+    it "raises if the provided Enumerable #to_ary does not return an Array" do
+      enumerable = MockObject.new('mock-enumerable')
+      enumerable.should_receive(:to_ary).and_return(14)
+      -> { Queue.new(enumerable) }.should raise_error(TypeError, "can't convert MockObject to Array (MockObject#to_ary gives Integer)")
+    end
+  end
+end

--- a/thread_sync.c
+++ b/thread_sync.c
@@ -839,15 +839,27 @@ queue_closed_result(VALUE self, struct rb_queue *q)
 /*
  * Document-method: Queue::new
  *
- * Creates a new queue instance.
+ * Creates a new queue instance, optionally using the contents of an Enumerable
+ * for its initial state.
+ *
+ *  Example:
+ *
+ *    	q = Queue.new
+ *    	q = Queue.new([a, b, c])
+ *    	q = Queue.new(items)
  */
 
 static VALUE
-rb_queue_initialize(VALUE self)
+rb_queue_initialize(int argc, VALUE *argv, VALUE self)
 {
+    VALUE initial;
     struct rb_queue *q = queue_ptr(self);
     RB_OBJ_WRITE(self, &q->que, ary_buf_new());
     list_head_init(queue_waitq(q));
+    rb_scan_args(argc, argv, "01", &initial);
+    if (argc == 1) {
+        rb_ary_concat(q->que, rb_convert_type(initial, T_ARRAY, "Array", "to_ary"));
+    }
     return self;
 }
 
@@ -1570,7 +1582,7 @@ Init_thread_sync(void)
 
     rb_eClosedQueueError = rb_define_class("ClosedQueueError", rb_eStopIteration);
 
-    rb_define_method(rb_cQueue, "initialize", rb_queue_initialize, 0);
+    rb_define_method(rb_cQueue, "initialize", rb_queue_initialize, -1);
     rb_undef_method(rb_cQueue, "initialize_copy");
     rb_define_method(rb_cQueue, "marshal_dump", undumpable, 0);
     rb_define_method(rb_cQueue, "close", rb_queue_close, 0);


### PR DESCRIPTION
Sorry I broke https://github.com/ruby/ruby/pull/3768 while trying to divide it up. GitHub won't let me re-open it!

Implements https://bugs.ruby-lang.org/issues/17327, including feedback from @ko1, @nobu, @baweaver.

`Set` specs moved to https://github.com/ruby/spec/pull/830.