### PR TITLE
Don't pin `val` passed in to `rb_define_const`.

### DIFF
--- a/variable.c
+++ b/variable.c
@@ -3154,7 +3154,6 @@ rb_define_const(VALUE klass, const char *name, VALUE val)
     if (!rb_is_const_id(id)) {
 	rb_warn("rb_define_const: invalid name `%s' for constant", name);
     }
-    rb_gc_register_mark_object(val);
     rb_const_set(klass, id, val);
 }
 


### PR DESCRIPTION
The caller should be responsible for holding a pinned reference (if they
need that)