### PR TITLE
Don't register non-heap allocated objects

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -8051,6 +8051,9 @@ rb_gc_force_recycle(VALUE obj)
 void
 rb_gc_register_mark_object(VALUE obj)
 {
+    if (!is_pointer_to_heap(&rb_objspace, (void *)obj))
+        return;
+
     RB_VM_LOCK_ENTER();
     {
         VALUE ary_ary = GET_VM()->mark_object_ary;


### PR DESCRIPTION
`rb_define_const` can add objects as "mark objects".  This is to make
code like this work:

  https://github.com/ruby/ruby/blob/33d6e92e0c6eaf1308ce7108e653c53bb5fb106c/ext/etc/etc.c#L1201

```
    rb_define_const(rb_cStruct, "Passwd", sPasswd); /* deprecated name */
```

sPasswd is a heap allocated object that is also a C global, so we can't
move it (it needs to be pinned).  However, we have many calls to
`rb_define_const` that just pass in an integer like this:

```
rb_define_const(rb_cDBM, "WRITER",  INT2FIX(O_RDWR|RUBY_DBM_RW_BIT));
```

Non heap allocated objects like integers will never move, so there is no
reason to waste time in the GC marking / pinning them.