### PR TITLE
Remove USE_LAZY_LOAD compilation flag

### DIFF
--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -121,7 +121,6 @@ jobs:
           - { key: cppflags, name: USE_EMBED_CI=0,                 value: '-DUSE_EMBED_CI=0' }
           - { key: cppflags, name: USE_FLONUM=0,                   value: '-DUSE_FLONUM=0' }
 #         - { key: cppflags, name: USE_GC_MALLOC_OBJ_INFO_DETAILS, value: '-DUSE_GC_MALLOC_OBJ_INFO_DETAILS' }
-          - { key: cppflags, name: USE_LAZY_LOAD,                  value: '-DUSE_LAZY_LOAD' }
 #         - { key: cppflags, name: USE_RINCGC=0,                   value: '-DUSE_RINCGC=0' }
 #         - { key: cppflags, name: USE_SYMBOL_GC=0,                value: '-DUSE_SYMBOL_GC=0' }
 #         - { key: cppflags, name: USE_THREAD_CACHE=0,             value: '-DUSE_THREAD_CACHE=0' }

--- a/builtin.c
+++ b/builtin.c
@@ -51,7 +51,7 @@ rb_load_with_builtin_functions(const char *feature_name, const struct rb_builtin
     vm->builtin_function_table = NULL;
 
     // exec
-    rb_iseq_eval(rb_iseq_check(iseq));
+    rb_iseq_eval(iseq);
 }
 
 #endif

--- a/insns.def
+++ b/insns.def
@@ -722,8 +722,6 @@ defineclass
 {
     VALUE klass = vm_find_or_create_class_by_id(id, flags, cbase, super);
 
-    rb_iseq_check(class_iseq);
-
     /* enter scope */
     vm_push_frame(ec, class_iseq, VM_FRAME_MAGIC_CLASS | VM_ENV_FLAG_LOCAL, klass,
 		  GET_BLOCK_HANDLER(),

--- a/iseq.c
+++ b/iseq.c
@@ -1970,7 +1970,7 @@ rb_insn_operand_intern(const rb_iseq_t *iseq,
       case TS_ISEQ:		/* iseq */
 	{
 	    if (op) {
-		const rb_iseq_t *iseq = rb_iseq_check((rb_iseq_t *)op);
+		const rb_iseq_t *iseq = (rb_iseq_t *)op;
 		ret = iseq->body->location.label;
 		if (child) {
 		    rb_ary_push(child, (VALUE)iseq);
@@ -2242,7 +2242,7 @@ rb_iseq_disasm_recursive(const rb_iseq_t *iseq, VALUE indent)
 			catch_type((int)entry->type), (int)entry->start,
 			(int)entry->end, (int)entry->sp, (int)entry->cont);
 	    if (entry->iseq && !(done_iseq && st_is_member(done_iseq, (st_data_t)entry->iseq))) {
-		rb_str_concat(str, rb_iseq_disasm_recursive(rb_iseq_check(entry->iseq), indent));
+		rb_str_concat(str, rb_iseq_disasm_recursive(entry->iseq, indent));
 		if (!done_iseq) {
                     done_iseq = st_init_numtable();
                     done_iseq_wrapper = TypedData_Wrap_Struct(0, &tmp_set, done_iseq);
@@ -2323,7 +2323,7 @@ rb_iseq_disasm_recursive(const rb_iseq_t *iseq, VALUE indent)
 	VALUE isv = rb_ary_entry(child, l);
 	if (done_iseq && st_is_member(done_iseq, (st_data_t)isv)) continue;
 	rb_str_cat_cstr(str, "\n");
-	rb_str_concat(str, rb_iseq_disasm_recursive(rb_iseq_check((rb_iseq_t *)isv), indent));
+	rb_str_concat(str, rb_iseq_disasm_recursive((rb_iseq_t *)isv, indent));
 	indent_str = RSTRING_PTR(indent);
     }
     RB_GC_GUARD(done_iseq_wrapper);
@@ -2797,7 +2797,7 @@ iseq_data_to_ary(const rb_iseq_t *iseq)
 		{
 		    const rb_iseq_t *iseq = (rb_iseq_t *)*seq;
 		    if (iseq) {
-			VALUE val = iseq_data_to_ary(rb_iseq_check(iseq));
+			VALUE val = iseq_data_to_ary(iseq);
 			rb_ary_push(ary, val);
 		    }
 		    else {
@@ -2903,7 +2903,7 @@ iseq_data_to_ary(const rb_iseq_t *iseq)
 	    UNALIGNED_MEMBER_PTR(iseq_body->catch_table, entries[i]);
 	rb_ary_push(ary, exception_type2symbol(entry->type));
 	if (entry->iseq) {
-	    rb_ary_push(ary, iseq_data_to_ary(rb_iseq_check(entry->iseq)));
+	    rb_ary_push(ary, iseq_data_to_ary(entry->iseq));
 	}
 	else {
 	    rb_ary_push(ary, Qnil);
@@ -3367,7 +3367,7 @@ trace_set_i(void *vstart, void *vend, size_t stride, void *data)
         asan_unpoison_object(v, false);
 
 	if (rb_obj_is_iseq(v)) {
-	    rb_iseq_trace_set(rb_iseq_check((rb_iseq_t *)v), turnon_events);
+	    rb_iseq_trace_set((rb_iseq_t *)v, turnon_events);
 	}
 
         asan_poison_object_if(ptr, v);

--- a/proc.c
+++ b/proc.c
@@ -1100,7 +1100,7 @@ rb_vm_block_min_max_arity(const struct rb_block *block, int *max)
   again:
     switch (vm_block_type(block)) {
       case block_type_iseq:
-	return rb_iseq_min_max_arity(rb_iseq_check(block->as.captured.code.iseq), max);
+	return rb_iseq_min_max_arity(block->as.captured.code.iseq, max);
       case block_type_proc:
 	block = vm_proc_block(block->as.proc);
 	goto again;
@@ -1264,7 +1264,7 @@ rb_proc_get_iseq(VALUE self, int *is_proc)
 
     switch (vm_block_type(block)) {
       case block_type_iseq:
-	return rb_iseq_check(block->as.captured.code.iseq);
+	return block->as.captured.code.iseq;
       case block_type_proc:
 	return rb_proc_get_iseq(block->as.proc, is_proc);
       case block_type_ifunc:
@@ -1376,7 +1376,6 @@ iseq_location(const rb_iseq_t *iseq)
     VALUE loc[2];
 
     if (!iseq) return Qnil;
-    rb_iseq_check(iseq);
     loc[0] = rb_iseq_path(iseq);
     loc[1] = iseq->body->location.first_lineno;
 
@@ -1514,7 +1513,7 @@ rb_block_to_s(VALUE self, const struct rb_block *block, const char *additional_i
 	goto again;
       case block_type_iseq:
 	{
-	    const rb_iseq_t *iseq = rb_iseq_check(block->as.captured.code.iseq);
+	    const rb_iseq_t *iseq = block->as.captured.code.iseq;
             rb_str_catf(str, "%p %"PRIsVALUE":%d", (void *)self,
 			rb_iseq_path(iseq),
 			FIX2INT(iseq->body->location.first_lineno));
@@ -2669,7 +2668,7 @@ rb_method_entry_min_max_arity(const rb_method_entry_t *me, int *max)
       case VM_METHOD_TYPE_BMETHOD:
         return rb_proc_min_max_arity(def->body.bmethod.proc, max);
       case VM_METHOD_TYPE_ISEQ:
-	return rb_iseq_min_max_arity(rb_iseq_check(def->body.iseq.iseqptr), max);
+	return rb_iseq_min_max_arity(def->body.iseq.iseqptr, max);
       case VM_METHOD_TYPE_UNDEF:
       case VM_METHOD_TYPE_NOTIMPLEMENTED:
 	return *max = 0;
@@ -2832,7 +2831,7 @@ method_def_iseq(const rb_method_definition_t *def)
 {
     switch (def->type) {
       case VM_METHOD_TYPE_ISEQ:
-	return rb_iseq_check(def->body.iseq.iseqptr);
+	return def->body.iseq.iseqptr;
       case VM_METHOD_TYPE_BMETHOD:
         return rb_proc_get_iseq(def->body.bmethod.proc, 0);
       case VM_METHOD_TYPE_ALIAS:
@@ -3355,7 +3354,6 @@ proc_binding(VALUE self)
     RB_OBJ_WRITTEN(bindval, Qundef, VM_ENV_ENVVAL(env->ep));
 
     if (iseq) {
-	rb_iseq_check(iseq);
 	RB_OBJ_WRITE(bindval, &bind->pathobj, iseq->body->location.pathobj);
 	bind->first_lineno = FIX2INT(rb_iseq_first_lineno(iseq));
     }

--- a/thread.c
+++ b/thread.c
@@ -5689,7 +5689,6 @@ rb_resolve_me_location(const rb_method_entry_t *me, VALUE resolved_location[5])
         const rb_iseq_t *iseq = rb_proc_get_iseq(me->def->body.bmethod.proc, 0);
 	if (iseq) {
 	    rb_iseq_location_t *loc;
-	    rb_iseq_check(iseq);
 	    path = rb_iseq_path(iseq);
 	    loc = &iseq->body->location;
 	    beg_pos_lineno = INT2FIX(loc->code_location.beg_pos.lineno);

--- a/vm.c
+++ b/vm.c
@@ -1311,7 +1311,7 @@ invoke_iseq_block_from_c(rb_execution_context_t *ec, const struct rb_captured_bl
 			 VALUE self, int argc, const VALUE *argv, int kw_splat, VALUE passed_block_handler,
                          const rb_cref_t *cref, int is_lambda, const rb_callable_method_entry_t *me)
 {
-    const rb_iseq_t *iseq = rb_iseq_check(captured->code.iseq);
+    const rb_iseq_t *iseq = captured->code.iseq;
     int i, opt_pc;
     VALUE type = VM_FRAME_MAGIC_BLOCK | (is_lambda ? VM_FRAME_FLAG_LAMBDA : 0);
     rb_control_frame_t *cfp = ec->cfp;
@@ -2360,7 +2360,6 @@ vm_exec_handle_exception(rb_execution_context_t *ec, enum ruby_tag_type state,
 	    /* enter catch scope */
 	    const int arg_size = 1;
 
-	    rb_iseq_check(catch_iseq);
 	    cfp->sp = vm_base_ptr(cfp) + cont_sp;
 	    cfp->pc = cfp->iseq->body->iseq_encoded + cont_pc;
 

--- a/vm_core.h
+++ b/vm_core.h
@@ -462,25 +462,6 @@ struct rb_iseq_struct {
     } aux;
 };
 
-#ifndef USE_LAZY_LOAD
-#define USE_LAZY_LOAD 0
-#endif
-
-#if USE_LAZY_LOAD
-const rb_iseq_t *rb_iseq_complete(const rb_iseq_t *iseq);
-#endif
-
-static inline const rb_iseq_t *
-rb_iseq_check(const rb_iseq_t *iseq)
-{
-#if USE_LAZY_LOAD
-    if (iseq->body == NULL) {
-	rb_iseq_complete((rb_iseq_t *)iseq);
-    }
-#endif
-    return iseq;
-}
-
 static inline const rb_iseq_t *
 def_iseq_ptr(rb_method_definition_t *def)
 {
@@ -488,7 +469,7 @@ def_iseq_ptr(rb_method_definition_t *def)
 #if VM_CHECK_MODE > 0
     if (def->type != VM_METHOD_TYPE_ISEQ) rb_bug("def_iseq_ptr: not iseq (%d)", def->type);
 #endif
-    return rb_iseq_check(def->body.iseq.iseqptr);
+    return def->body.iseq.iseqptr;
 }
 
 enum ruby_special_exceptions {
@@ -1563,7 +1544,7 @@ static inline const rb_iseq_t *
 vm_block_iseq(const struct rb_block *block)
 {
     switch (vm_block_type(block)) {
-      case block_type_iseq: return rb_iseq_check(block->as.captured.code.iseq);
+      case block_type_iseq: return block->as.captured.code.iseq;
       case block_type_proc: return vm_proc_iseq(block->as.proc);
       case block_type_ifunc:
       case block_type_symbol: return NULL;

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -3805,7 +3805,7 @@ vm_invoke_iseq_block(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp,
                      bool is_lambda, VALUE block_handler)
 {
     const struct rb_captured_block *captured = VM_BH_TO_ISEQ_BLOCK(block_handler);
-    const rb_iseq_t *iseq = rb_iseq_check(captured->code.iseq);
+    const rb_iseq_t *iseq = captured->code.iseq;
     const int arg_size = iseq->body->param.size;
     VALUE * const rsp = GET_SP() - calling->argc;
     int opt_pc = vm_callee_setup_block_arg(ec, calling, ci, iseq, rsp, is_lambda ? arg_setup_method : arg_setup_block);

--- a/vm_method.c
+++ b/vm_method.c
@@ -2210,7 +2210,7 @@ rb_mod_ruby2_keywords(int argc, VALUE *argv, VALUE module)
 
                 if (vm_block_handler_type(procval) == block_handler_type_iseq) {
                     const struct rb_captured_block *captured = VM_BH_TO_ISEQ_BLOCK(procval);
-                    const rb_iseq_t *iseq = rb_iseq_check(captured->code.iseq);
+                    const rb_iseq_t *iseq = captured->code.iseq;
                     if (iseq->body->param.flags.has_rest &&
                             !iseq->body->param.flags.has_kw &&
                             !iseq->body->param.flags.has_kwrest) {


### PR DESCRIPTION
I'm looking at the possibility of loading ISeq directly from Bootsnap's C ext, either by passing a file descriptor or a C buffer, as it would remove the need to copy fairly large strings just to feed the parser.

While doing so I noticed `USE_LAZY_LOAD`, It was introduced at the same time than ISeq loading https://github.com/ruby/ruby/commit/3dbb390180a but I'm not too sure what benefits it's supposed to provide, and I assume that flag is almost always disabled.

@ko1 is there a reason I'm missing to keep this flag?