### PR TITLE
Improve performance Float#positive? and Float#negative? [Feature #17614]

### DIFF
--- a/benchmark/float_neg_posi.yml
+++ b/benchmark/float_neg_posi.yml
@@ -1,0 +1,8 @@
+prelude: |
+  flo = 4.2
+benchmark:
+  negative?: |
+    flo.negative?
+  positive?: |
+    flo.positive?
+loop_count: 20000000

--- a/numeric.c
+++ b/numeric.c
@@ -2386,34 +2386,6 @@ flo_truncate(int argc, VALUE *argv, VALUE num)
 
 /*
  *  call-seq:
- *     float.positive?  ->  true or false
- *
- *  Returns +true+ if +float+ is greater than 0.
- */
-
-static VALUE
-flo_positive_p(VALUE num)
-{
-    double f = RFLOAT_VALUE(num);
-    return f > 0.0 ? Qtrue : Qfalse;
-}
-
-/*
- *  call-seq:
- *     float.negative?  ->  true or false
- *
- *  Returns +true+ if +float+ is less than 0.
- */
-
-static VALUE
-flo_negative_p(VALUE num)
-{
-    double f = RFLOAT_VALUE(num);
-    return f < 0.0 ? Qtrue : Qfalse;
-}
-
-/*
- *  call-seq:
  *     num.floor([ndigits])  ->  integer or float
  *
  *  Returns the largest number less than or equal to +num+ with
@@ -5654,8 +5626,6 @@ Init_Numeric(void)
     rb_define_method(rb_cFloat, "finite?",   rb_flo_is_finite_p, 0);
     rb_define_method(rb_cFloat, "next_float", flo_next_float, 0);
     rb_define_method(rb_cFloat, "prev_float", flo_prev_float, 0);
-    rb_define_method(rb_cFloat, "positive?", flo_positive_p, 0);
-    rb_define_method(rb_cFloat, "negative?", flo_negative_p, 0);
 }
 
 #undef rb_float_value

--- a/numeric.rb
+++ b/numeric.rb
@@ -204,4 +204,26 @@ class Float
     Primitive.attr! 'inline'
     Primitive.cexpr! 'FLOAT_ZERO_P(self) ? Qtrue : Qfalse'
   end
+
+  #
+  #  call-seq:
+  #     float.positive?  ->  true or false
+  #
+  #  Returns +true+ if +float+ is greater than 0.
+  #
+  def positive?
+    Primitive.attr! 'inline'
+    Primitive.cexpr! 'RFLOAT_VALUE(self) > 0.0 ? Qtrue : Qfalse'
+  end
+
+  #
+  #  call-seq:
+  #     float.negative?  ->  true or false
+  #
+  #  Returns +true+ if +float+ is less than 0.
+  #
+  def negative?
+    Primitive.attr! 'inline'
+    Primitive.cexpr! 'RFLOAT_VALUE(self) < 0.0 ? Qtrue : Qfalse'
+  end
 end


### PR DESCRIPTION
Improve performance `Float#negative?` and `Float#positive?`(write in Ruby)

benchmark:
```yml
prelude: |
  flo = 4.2
benchmark:
  negative?: |
    flo.negative?
  positive?: |
    flo.positive?
loop_count: 20000000

```

result:
```bash
sh@DESKTOP-L0NI312:~/rubydev/build$ make benchmark/benchmark.yml -e COMPARE_RUBY=~/.rbenv/shims/ruby -e BENCH_RUBY=../install/bin/ruby
generating vm_call_iseq_optimized.inc
vm_call_iseq_optimized.inc unchanged
compare-ruby: ruby 3.1.0dev (2021-02-08T12:46:07Z master 4186cd6435) [x86_64-linux]
built-ruby: ruby 3.1.0dev (2021-02-08T13:12:22Z improve_float_method 0dbc6d3f5f) [x86_64-linux]
# Iteration per second (i/s)

|           |compare-ruby|built-ruby|
|:----------|-----------:|---------:|
|negative?  |     80.954M|   94.642M|
|           |           -|     1.17x|
|positive?  |     79.471M|   95.963M|
|           |           -|     1.21x|
```

ticket: [Feature #17614 Improve performance Float#negative? and Float#positive? ](https://bugs.ruby-lang.org/issues/17614)