### PR TITLE
Fix broken link

### DIFF
--- a/doc/ractor.md
+++ b/doc/ractor.md
@@ -691,7 +691,7 @@ TABLE = {a: 'ko1', b: 'ko2', c: 'ko3'}
 
 Except the `none` mode (default), it is guaranteed that the assigned constants refer to only shareable objects.
 
-See [doc/syntax/comment.rdoc](syntax/comment.rdoc) for more details.
+See [doc/syntax/comments.rdoc](syntax/comments.rdoc) for more details.
 
 ## Implementation note
 


### PR DESCRIPTION
The document should point to doc/syntax/comments.rdoc (with an "s") as there currently no `doc/syntax/comment.rdoc`