### PR TITLE
Fixed race in dtoa [Bug #17612]

### DIFF
--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -158,6 +158,17 @@ assert_equal '[[:e1, 1], [:e2, 2]]', %q{
   a #
 }
 
+# dtoa race condition
+assert_equal '[:ok, :ok, :ok]', %q{
+  n = 3
+  n.times.map{
+    Ractor.new{
+      10_000.times{ rand.to_s }
+      :ok
+    }
+  }.map(&:take)
+}
+
 ###
 ###
 # Ractor still has several memory corruption so skip huge number of tests


### PR DESCRIPTION
Fixed the race condition when replacing `freelist` entry with its chained next element.
At acquiring an entry, hold the entry once with the special value, then release by replacing it with the next element again after acquired.
If another thread is holding the same entry at that time, spinning until the entry gets released.

Co-Authored-By: Koichi Sasada <ko1@atdot.net>