### PR TITLE
Add hook for `Timeout.timeout`.

### DIFF
--- a/cont.c
+++ b/cont.c
@@ -1997,6 +1997,20 @@ rb_fiber_s_scheduler(VALUE klass)
 
 /*
  *  call-seq:
+ *     Fiber.current_scheduler -> obj or nil
+ *
+ *  Returns the Fiber scheduler, that was last set for the current thread with Fiber.set_scheduler
+ *  iff the current fiber is non-blocking.
+ *
+ */
+static VALUE
+rb_fiber_current_scheduler(VALUE klass)
+{
+    return rb_fiber_scheduler_current();
+}
+
+/*
+ *  call-seq:
  *     Fiber.set_scheduler(scheduler) -> scheduler
  *
  *  Sets the Fiber scheduler for the current thread. If the scheduler is set, non-blocking
@@ -3084,6 +3098,7 @@ Init_Cont(void)
     rb_define_singleton_method(rb_cFiber, "blocking?", rb_fiber_s_blocking_p, 0);
     rb_define_singleton_method(rb_cFiber, "scheduler", rb_fiber_s_scheduler, 0);
     rb_define_singleton_method(rb_cFiber, "set_scheduler", rb_fiber_set_scheduler, 1);
+    rb_define_singleton_method(rb_cFiber, "current_scheduler", rb_fiber_current_scheduler, 0);
 
     rb_define_singleton_method(rb_cFiber, "schedule", rb_fiber_s_schedule, -1);
 

--- a/doc/fiber.md
+++ b/doc/fiber.md
@@ -76,8 +76,18 @@ class Scheduler
 
   # Sleep the current task for the specified duration, or forever if not
   # specified.
-  # @param duration [Numeric] The amount of time to sleep in seconds.
+  # @parameter duration [Numeric] The amount of time to sleep in seconds.
   def kernel_sleep(duration = nil)
+  end
+
+  # Execute the given block. If the block execution exceeds the given timeout,
+  # the specified exception `klass` will be raised. Typically, only non-blocking
+  # methods which enter the scheduler will raise such exceptions.
+  # @parameter duration [Integer] The amount of time to wait, after which an exception will be raised.
+  # @parameter klass [Class] The exception class to raise.
+  # @parameter *arguments [Array] The arguments to send to the constructor of the exception.
+  # @yields {...} The user code to execute.
+  def timeout_after(duration, klass, *arguments, &block)
   end
 
   # Block the calling fiber.

--- a/include/ruby/fiber/scheduler.h
+++ b/include/ruby/fiber/scheduler.h
@@ -22,6 +22,8 @@ VALUE rb_fiber_scheduler_make_timeout(struct timeval *timeout);
 
 VALUE rb_fiber_scheduler_close(VALUE scheduler);
 
+VALUE rb_fiber_scheduler_timeout_raise(VALUE scheduler, VALUE duration);
+
 VALUE rb_fiber_scheduler_kernel_sleep(VALUE scheduler, VALUE duration);
 VALUE rb_fiber_scheduler_kernel_sleepv(VALUE scheduler, int argc, VALUE * argv);
 

--- a/include/ruby/fiber/scheduler.h
+++ b/include/ruby/fiber/scheduler.h
@@ -22,7 +22,8 @@ VALUE rb_fiber_scheduler_make_timeout(struct timeval *timeout);
 
 VALUE rb_fiber_scheduler_close(VALUE scheduler);
 
-VALUE rb_fiber_scheduler_timeout_raise(VALUE scheduler, VALUE duration);
+VALUE rb_fiber_scheduler_timeout_raise(VALUE scheduler, VALUE timeout, VALUE exception, VALUE message);
+VALUE rb_fiber_scheduler_timeout_raisev(VALUE scheduler, int argc, VALUE * argv);
 
 VALUE rb_fiber_scheduler_kernel_sleep(VALUE scheduler, VALUE duration);
 VALUE rb_fiber_scheduler_kernel_sleepv(VALUE scheduler, int argc, VALUE * argv);

--- a/include/ruby/fiber/scheduler.h
+++ b/include/ruby/fiber/scheduler.h
@@ -22,11 +22,13 @@ VALUE rb_fiber_scheduler_make_timeout(struct timeval *timeout);
 
 VALUE rb_fiber_scheduler_close(VALUE scheduler);
 
-VALUE rb_fiber_scheduler_timeout_raise(VALUE scheduler, VALUE timeout, VALUE exception, VALUE message);
-VALUE rb_fiber_scheduler_timeout_raisev(VALUE scheduler, int argc, VALUE * argv);
-
 VALUE rb_fiber_scheduler_kernel_sleep(VALUE scheduler, VALUE duration);
 VALUE rb_fiber_scheduler_kernel_sleepv(VALUE scheduler, int argc, VALUE * argv);
+
+#if 0
+VALUE rb_fiber_scheduler_timeout_after(VALUE scheduler, VALUE timeout, VALUE exception, VALUE message);
+VALUE rb_fiber_scheduler_timeout_afterv(VALUE scheduler, int argc, VALUE * argv);
+#endif
 
 int rb_fiber_scheduler_supports_process_wait(VALUE scheduler);
 VALUE rb_fiber_scheduler_process_wait(VALUE scheduler, rb_pid_t pid, int flags);

--- a/lib/timeout.rb
+++ b/lib/timeout.rb
@@ -84,7 +84,7 @@ module Timeout
 
     message ||= "execution expired".freeze
 
-    if (scheduler = Fiber.scheduler)&.respond_to?(:timeout_after)
+    if (scheduler = Fiber.current_scheduler)&.respond_to?(:timeout_after)
       return scheduler.timeout_after(sec, klass || Error, message, &block)
     end
 

--- a/lib/timeout.rb
+++ b/lib/timeout.rb
@@ -76,9 +76,15 @@ module Timeout
   # Note that this is both a method of module Timeout, so you can <tt>include
   # Timeout</tt> into your classes so they have a #timeout method, as well as
   # a module method, so you can call it directly as Timeout.timeout().
-  def timeout(sec, klass = nil, message = nil)   #:yield: +sec+
+  def timeout(sec, klass = nil, message = nil, &block)   #:yield: +sec+
     return yield(sec) if sec == nil or sec.zero?
+
     message ||= "execution expired".freeze
+
+    if scheduler = Fiber.scheduler and scheduler.respond_to?(:timeout_raise)
+      return scheduler.timeout_raise(sec, klass || Error, message, &block)
+    end
+
     from = "from #{caller_locations(1, 1)[0]}" if $DEBUG
     e = Error
     bl = proc do |exception|

--- a/lib/timeout.rb
+++ b/lib/timeout.rb
@@ -81,7 +81,7 @@ module Timeout
 
     message ||= "execution expired".freeze
 
-    if scheduler = Fiber.scheduler and scheduler.respond_to?(:timeout_raise)
+    if (scheduler = Fiber.scheduler)&.respond_to?(:timeout_raise)
       return scheduler.timeout_raise(sec, klass || Error, message, &block)
     end
 

--- a/lib/timeout.rb
+++ b/lib/timeout.rb
@@ -73,6 +73,9 @@ module Timeout
   # ensure to prevent the handling of the exception.  For that reason, this
   # method cannot be relied on to enforce timeouts for untrusted blocks.
   #
+  # If a scheduler is defined, it will be used to handle the timeout by invoking
+  # Scheduler#timeout_after.
+  #
   # Note that this is both a method of module Timeout, so you can <tt>include
   # Timeout</tt> into your classes so they have a #timeout method, as well as
   # a module method, so you can call it directly as Timeout.timeout().
@@ -81,8 +84,8 @@ module Timeout
 
     message ||= "execution expired".freeze
 
-    if (scheduler = Fiber.scheduler)&.respond_to?(:timeout_raise)
-      return scheduler.timeout_raise(sec, klass || Error, message, &block)
+    if (scheduler = Fiber.scheduler)&.respond_to?(:timeout_after)
+      return scheduler.timeout_after(sec, klass || Error, message, &block)
     end
 
     from = "from #{caller_locations(1, 1)[0]}" if $DEBUG

--- a/scheduler.c
+++ b/scheduler.c
@@ -17,6 +17,7 @@ static ID id_close;
 static ID id_block;
 static ID id_unblock;
 
+static ID id_timeout_raise;
 static ID id_kernel_sleep;
 static ID id_process_wait;
 
@@ -32,6 +33,7 @@ Init_Fiber_Scheduler(void)
     id_block = rb_intern_const("block");
     id_unblock = rb_intern_const("unblock");
 
+    id_timeout_raise = rb_intern_const("timeout_raise");
     id_kernel_sleep = rb_intern_const("kernel_sleep");
     id_process_wait = rb_intern_const("process_wait");
 
@@ -106,6 +108,12 @@ rb_fiber_scheduler_make_timeout(struct timeval *timeout)
     }
 
     return Qnil;
+}
+
+VALUE
+rb_fiber_scheduler_timeout_raise(VALUE scheduler, VALUE timeout)
+{
+    return rb_funcall(scheduler, id_timeout_raise, 1, timeout);
 }
 
 VALUE

--- a/scheduler.c
+++ b/scheduler.c
@@ -113,7 +113,7 @@ rb_fiber_scheduler_make_timeout(struct timeval *timeout)
 VALUE
 rb_fiber_scheduler_timeout_raise(VALUE scheduler, VALUE timeout)
 {
-    return rb_check_funcall(scheduler, id_timeout_raise, 1, timeout);
+    return rb_check_funcall(scheduler, id_timeout_raise, 1, &timeout);
 }
 
 VALUE

--- a/scheduler.c
+++ b/scheduler.c
@@ -113,7 +113,7 @@ rb_fiber_scheduler_make_timeout(struct timeval *timeout)
 VALUE
 rb_fiber_scheduler_timeout_raise(VALUE scheduler, VALUE timeout)
 {
-    return rb_funcall(scheduler, id_timeout_raise, 1, timeout);
+    return rb_check_funcall(scheduler, id_timeout_raise, 1, timeout);
 }
 
 VALUE

--- a/scheduler.c
+++ b/scheduler.c
@@ -17,7 +17,7 @@ static ID id_close;
 static ID id_block;
 static ID id_unblock;
 
-static ID id_timeout_raise;
+static ID id_timeout_after;
 static ID id_kernel_sleep;
 static ID id_process_wait;
 
@@ -33,7 +33,7 @@ Init_Fiber_Scheduler(void)
     id_block = rb_intern_const("block");
     id_unblock = rb_intern_const("unblock");
 
-    id_timeout_raise = rb_intern_const("timeout_raise");
+    id_timeout_after = rb_intern_const("timeout_after");
     id_kernel_sleep = rb_intern_const("kernel_sleep");
     id_process_wait = rb_intern_const("process_wait");
 
@@ -110,19 +110,20 @@ rb_fiber_scheduler_make_timeout(struct timeval *timeout)
     return Qnil;
 }
 
-VALUE rb_fiber_scheduler_timeout_raise(VALUE scheduler, VALUE timeout, VALUE exception, VALUE message)
+VALUE
+rb_fiber_scheduler_timeout_after(VALUE scheduler, VALUE timeout, VALUE exception, VALUE message)
 {
     VALUE arguments[] = {
         timeout, exception, message
     };
 
-    return rb_check_funcall(scheduler, id_timeout_raise, 3, arguments);
+    return rb_check_funcall(scheduler, id_timeout_after, 3, arguments);
 }
 
 VALUE
-rb_fiber_scheduler_timeout_raisev(VALUE scheduler, int argc, VALUE * argv)
+rb_fiber_scheduler_timeout_afterv(VALUE scheduler, int argc, VALUE * argv)
 {
-    return rb_check_funcall(scheduler, id_timeout_raise, argc, argv);
+    return rb_check_funcall(scheduler, id_timeout_after, argc, argv);
 }
 
 VALUE

--- a/scheduler.c
+++ b/scheduler.c
@@ -111,6 +111,19 @@ rb_fiber_scheduler_make_timeout(struct timeval *timeout)
 }
 
 VALUE
+rb_fiber_scheduler_kernel_sleep(VALUE scheduler, VALUE timeout)
+{
+    return rb_funcall(scheduler, id_kernel_sleep, 1, timeout);
+}
+
+VALUE
+rb_fiber_scheduler_kernel_sleepv(VALUE scheduler, int argc, VALUE * argv)
+{
+    return rb_funcallv(scheduler, id_kernel_sleep, argc, argv);
+}
+
+#if 0
+VALUE
 rb_fiber_scheduler_timeout_after(VALUE scheduler, VALUE timeout, VALUE exception, VALUE message)
 {
     VALUE arguments[] = {
@@ -125,18 +138,7 @@ rb_fiber_scheduler_timeout_afterv(VALUE scheduler, int argc, VALUE * argv)
 {
     return rb_check_funcall(scheduler, id_timeout_after, argc, argv);
 }
-
-VALUE
-rb_fiber_scheduler_kernel_sleep(VALUE scheduler, VALUE timeout)
-{
-    return rb_funcall(scheduler, id_kernel_sleep, 1, timeout);
-}
-
-VALUE
-rb_fiber_scheduler_kernel_sleepv(VALUE scheduler, int argc, VALUE * argv)
-{
-    return rb_funcallv(scheduler, id_kernel_sleep, argc, argv);
-}
+#endif
 
 VALUE
 rb_fiber_scheduler_process_wait(VALUE scheduler, rb_pid_t pid, int flags)

--- a/scheduler.c
+++ b/scheduler.c
@@ -110,10 +110,19 @@ rb_fiber_scheduler_make_timeout(struct timeval *timeout)
     return Qnil;
 }
 
-VALUE
-rb_fiber_scheduler_timeout_raise(VALUE scheduler, VALUE timeout)
+VALUE rb_fiber_scheduler_timeout_raise(VALUE scheduler, VALUE timeout, VALUE exception, VALUE message)
 {
-    return rb_check_funcall(scheduler, id_timeout_raise, 1, &timeout);
+    VALUE arguments[] = {
+        timeout, exception, message
+    };
+
+    return rb_check_funcall(scheduler, id_timeout_raise, 3, arguments);
+}
+
+VALUE
+rb_fiber_scheduler_timeout_raisev(VALUE scheduler, int argc, VALUE * argv)
+{
+    return rb_check_funcall(scheduler, id_timeout_raise, argc, argv);
 }
 
 VALUE

--- a/test/fiber/scheduler.rb
+++ b/test/fiber/scheduler.rb
@@ -129,7 +129,7 @@ class Scheduler
     Process.clock_gettime(Process::CLOCK_MONOTONIC)
   end
 
-  def timeout_raise(duration, klass, message, &block)
+  def timeout_after(duration, klass, message, &block)
     fiber = Fiber.current
 
     self.fiber do

--- a/test/fiber/test_scheduler.rb
+++ b/test/fiber/test_scheduler.rb
@@ -73,4 +73,20 @@ class TestFiberScheduler < Test::Unit::TestCase
 
     thread.join
   end
+
+  def test_current_scheduler
+    thread = Thread.new do
+      scheduler = Scheduler.new
+      Fiber.set_scheduler scheduler
+
+      assert Fiber.scheduler
+      refute Fiber.current_scheduler
+
+      Fiber.schedule do
+        assert Fiber.current_scheduler
+      end
+    end
+
+    thread.join
+  end
 end

--- a/test/fiber/test_timeout.rb
+++ b/test/fiber/test_timeout.rb
@@ -5,7 +5,7 @@ require_relative 'scheduler'
 require 'timeout'
 
 class TestFiberTimeout < Test::Unit::TestCase
-  def test_timeout_raise
+  def test_timeout_after
     error = nil
 
     thread = Thread.new do

--- a/test/fiber/test_timeout.rb
+++ b/test/fiber/test_timeout.rb
@@ -37,6 +37,8 @@ class TestFiberTimeout < Test::Unit::TestCase
       scheduler = Scheduler.new
       Fiber.set_scheduler scheduler
 
+      assert_nil Fiber.current_scheduler
+
       Timeout.timeout(1) do
         message = MESSAGE
       end

--- a/test/fiber/test_timeout.rb
+++ b/test/fiber/test_timeout.rb
@@ -14,7 +14,7 @@ class TestFiberTimeout < Test::Unit::TestCase
 
       Fiber.schedule do
         begin
-          Timeout.timeout(0.01) do
+          Timeout.timeout(0.001) do
             sleep(1)
           end
         rescue
@@ -26,5 +26,24 @@ class TestFiberTimeout < Test::Unit::TestCase
     thread.join
 
     assert_kind_of(Timeout::Error, error)
+  end
+
+  MESSAGE = "Hello World"
+
+  def test_timeout_on_main_fiber
+    message = nil
+
+    thread = Thread.new do
+      scheduler = Scheduler.new
+      Fiber.set_scheduler scheduler
+
+      Timeout.timeout(1) do
+        message = MESSAGE
+      end
+    end
+
+    thread.join
+
+    assert_equal MESSAGE, message
   end
 end

--- a/test/fiber/test_timeout.rb
+++ b/test/fiber/test_timeout.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+require 'test/unit'
+require_relative 'scheduler'
+
+require 'timeout'
+
+class TestFiberTimeout < Test::Unit::TestCase
+  def test_timeout_raise
+    error = nil
+
+    thread = Thread.new do
+      scheduler = Scheduler.new
+      Fiber.set_scheduler scheduler
+
+      Fiber.schedule do
+        begin
+          Timeout.timeout(0.01) do
+            sleep(1)
+          end
+        rescue
+          error = $!
+        end
+      end
+    end
+
+    thread.join
+
+    assert_kind_of(Timeout::Error, error)
+  end
+end


### PR DESCRIPTION
Also, I'd like to consider renaming it to `Timeout.raise` or `Timeout.after` because I'm not sure the current name makes sense. We can leave existing name as alias.