### PR TITLE
Correct the result of casecmp? examples

### DIFF
--- a/string.c
+++ b/string.c
@@ -3556,7 +3556,7 @@ str_casecmp(VALUE str1, VALUE str2)
  *  Unicode case folding, otherwise +false+:
  *    'foo'.casecmp?('foo') # => true
  *    'foo'.casecmp?('food') # => false
- *    'food'.casecmp?('foo') # => true
+ *    'food'.casecmp?('foo') # => false
  *    'FOO'.casecmp?('foo') # => true
  *    'foo'.casecmp?('FOO') # => true
  *


### PR DESCRIPTION
JetBrains autogenerated Ruby stub for their auto-completion from the Ruby source code.
The documentation comments are accessible from their IDE, RubyMine, too.

I strumbled on one of them by chance and was very surprised at what I see.
~~~ruby
'food'.casecmp?('foo') # => true
~~~
I thought I need to reeducate myself and find out the definition of the "Unicode case folding".  
But before investing too much time into it, I quickly verified the result with `irb`.
Fortunately, it turns out the example is wrong, or I need to recheck all of my Ruby code from the past.