### PR TITLE
Fix segfault in new Rails app

### DIFF
--- a/vm.c
+++ b/vm.c
@@ -2806,6 +2806,11 @@ rb_execution_context_update(const rb_execution_context_t *ec)
             cfp->block_code = (void *)rb_gc_location((VALUE)cfp->block_code);
 
             if (!VM_ENV_LOCAL_P(ep)) {
+                const VALUE *prev_ep = VM_ENV_PREV_EP(ep);
+                if (VM_ENV_FLAGS(prev_ep, VM_ENV_FLAG_ESCAPED)) {
+                    VM_FORCE_WRITE(&prev_ep[VM_ENV_DATA_INDEX_ENV], rb_gc_location(prev_ep[VM_ENV_DATA_INDEX_ENV]));
+                }
+
                 if (VM_ENV_FLAGS(ep, VM_ENV_FLAG_ESCAPED)) {
                     VM_FORCE_WRITE(&ep[VM_ENV_DATA_INDEX_ENV], rb_gc_location(ep[VM_ENV_DATA_INDEX_ENV]));
                     VM_FORCE_WRITE(&ep[VM_ENV_DATA_INDEX_ME_CREF], rb_gc_location(ep[VM_ENV_DATA_INDEX_ME_CREF]));
@@ -2846,6 +2851,11 @@ rb_execution_context_mark(const rb_execution_context_t *ec)
             rb_gc_mark_movable((VALUE)cfp->block_code);
 
             if (!VM_ENV_LOCAL_P(ep)) {
+                const VALUE *prev_ep = VM_ENV_PREV_EP(ep);
+                if (VM_ENV_FLAGS(prev_ep, VM_ENV_FLAG_ESCAPED)) {
+                    rb_gc_mark_movable(prev_ep[VM_ENV_DATA_INDEX_ENV]);
+                }
+
 		if (VM_ENV_FLAGS(ep, VM_ENV_FLAG_ESCAPED)) {
                     rb_gc_mark_movable(ep[VM_ENV_DATA_INDEX_ENV]);
                     rb_gc_mark(ep[VM_ENV_DATA_INDEX_ME_CREF]);


### PR DESCRIPTION
[Redmine ticket](https://bugs.ruby-lang.org/issues/17622).

There is a segfault in Ruby master and Ruby 3.0.0, but not present in Ruby 2.7.2. A bisect shows that it's present since commit a53e2850c572135ed657144bc14e47b29c64fa94.

# Reproduction

1. Use Ruby 3.0.0 or Ruby master.
2. Create a new Rails app (`rails new repro`).
3. Add the following `script.rb`:

    ```ruby
    def load_rails
      tp = TracePoint.new(:c_return) do
      end

      require './config/application'
      rails = Object.const_get(:Rails)
      rails.application.require_environment!
      rails.application.eager_load!
    end

    def foo
      -> do
        load_rails
      end
    end

    foo.call
    puts "ok"
    ```

4. Run the script with `DISABLE_BOOTSNAP=1 ruby script.rb`

# Expected output

The script should print `ok`.

# Actual output

Crashes with a segfault (check file `crash.log` for full crash log).
