### PR TITLE
[ruby/irb] Avoid top-level local variables [Fixes #17623]

### DIFF
--- a/bin/irb
+++ b/bin/irb
@@ -8,20 +8,22 @@
 
 require 'rubygems'
 
-version = ">= 0.a"
+-> { # avoid creating local variables in TOPLEVEL_BINDING
+  version = ">= 0.a"
 
-str = ARGV.first
-if str
-  str = str.b[/\A_(.*)_\z/, 1]
-  if str and Gem::Version.correct?(str)
-    version = str
-    ARGV.shift
+  str = ARGV.first
+  if str
+    str = str.b[/\A_(.*)_\z/, 1]
+    if str and Gem::Version.correct?(str)
+      version = str
+      ARGV.shift
+    end
   end
-end
 
-if Gem.respond_to?(:activate_bin_path)
-load Gem.activate_bin_path('irb', 'irb', version)
-else
-gem "irb", version
-load Gem.bin_path("irb", "irb", version)
-end
+  if Gem.respond_to?(:activate_bin_path)
+    load Gem.activate_bin_path('irb', 'irb', version)
+  else
+    gem "irb", version
+    load Gem.bin_path("irb", "irb", version)
+  end
+}.call


### PR DESCRIPTION
This is an improvement but not a perfect solution; any script loading `bin/irb` creating a local variable (like `ruby-installer` apparently does, but `rbenv` is fine) would pollute the `irb` session.