### PR TITLE
Semicolon is missing in parse.y

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -1765,7 +1765,7 @@ expr_value_do	: {COND_PUSH(1);} expr_value do {COND_POP();}
 		    {
 			$$ = $2;
 		    }
-
+		;
 
 command_call	: command
 		| block_command


### PR DESCRIPTION
Add a missing semicolon in `parse.y`.