### PR TITLE
Fix a type error in the docs for Hash

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -6737,7 +6737,7 @@ env_update(VALUE env, VALUE hash)
  *      end
  *
  *      def ==(other)
- *        self.class === other &&
+ *        self.class === other.class &&
  *          other.author == @author &&
  *          other.title == @title
  *      end


### PR DESCRIPTION
I found this by accident by browsing through the docs. Please tell me if I'm missing something.