### PR TITLE
Delay the RUBY_INTERNAL_EVENT_NEWOBJ event until setup the object [Bug #17599]

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -2254,7 +2254,6 @@ newobj_slowpath(VALUE klass, VALUE flags, rb_objspace_t *objspace, rb_ractor_t *
         }
         GC_ASSERT(obj != 0);
         newobj_init(klass, flags, wb_protected, objspace, obj);
-        gc_event_hook(objspace, RUBY_INTERNAL_EVENT_NEWOBJ, obj);
     }
     RB_VM_LOCK_LEAVE_CR_LEV(cr, &lev);
 
@@ -2313,6 +2312,7 @@ newobj_of_cr(rb_ractor_t *cr, VALUE klass, VALUE flags, VALUE v1, VALUE v2, VALU
          (obj = ractor_cached_freeobj(objspace, cr)) != Qfalse)) {
 
         newobj_init(klass, flags, wb_protected, objspace, obj);
+        newobj_fill(obj, v1, v2, v3);
     }
     else {
         RB_DEBUG_COUNTER_INC(obj_newobj_slowpath);
@@ -2320,9 +2320,10 @@ newobj_of_cr(rb_ractor_t *cr, VALUE klass, VALUE flags, VALUE v1, VALUE v2, VALU
         obj = wb_protected ?
           newobj_slowpath_wb_protected(klass, flags, objspace, cr) :
           newobj_slowpath_wb_unprotected(klass, flags, objspace, cr);
+        newobj_fill(obj, v1, v2, v3);
+        gc_event_hook(objspace, RUBY_INTERNAL_EVENT_NEWOBJ, obj);
     }
 
-    return newobj_fill(obj, v1, v2, v3);
     return obj;
 }
 

--- a/gc.c
+++ b/gc.c
@@ -2279,7 +2279,17 @@ newobj_slowpath_wb_unprotected(VALUE klass, VALUE flags, rb_objspace_t *objspace
 }
 
 static inline VALUE
-newobj_of0(VALUE klass, VALUE flags, int wb_protected, rb_ractor_t *cr)
+newobj_fill(VALUE obj, VALUE v1, VALUE v2, VALUE v3)
+{
+    RVALUE *p = (RVALUE *)obj;
+    p->as.values.v1 = v1;
+    p->as.values.v2 = v2;
+    p->as.values.v3 = v3;
+    return obj;
+}
+
+static inline VALUE
+newobj_of_cr(rb_ractor_t *cr, VALUE klass, VALUE flags, VALUE v1, VALUE v2, VALUE v3, int wb_protected)
 {
     VALUE obj;
     rb_objspace_t *objspace = &rb_objspace;
@@ -2312,31 +2322,14 @@ newobj_of0(VALUE klass, VALUE flags, int wb_protected, rb_ractor_t *cr)
           newobj_slowpath_wb_unprotected(klass, flags, objspace, cr);
     }
 
-    return obj;
-}
-
-static inline VALUE
-newobj_fill(VALUE obj, VALUE v1, VALUE v2, VALUE v3)
-{
-    RVALUE *p = (RVALUE *)obj;
-    p->as.values.v1 = v1;
-    p->as.values.v2 = v2;
-    p->as.values.v3 = v3;
+    return newobj_fill(obj, v1, v2, v3);
     return obj;
 }
 
 static inline VALUE
 newobj_of(VALUE klass, VALUE flags, VALUE v1, VALUE v2, VALUE v3, int wb_protected)
 {
-    VALUE obj = newobj_of0(klass, flags, wb_protected, GET_RACTOR());
-    return newobj_fill(obj, v1, v2, v3);
-}
-
-static inline VALUE
-newobj_of_cr(rb_ractor_t *cr, VALUE klass, VALUE flags, VALUE v1, VALUE v2, VALUE v3, int wb_protected)
-{
-    VALUE obj = newobj_of0(klass, flags, wb_protected, cr);
-    return newobj_fill(obj, v1, v2, v3);
+    return newobj_of_cr(GET_RACTOR(), klass, flags, v1, v2, v3, wb_protected);
 }
 
 VALUE

--- a/test/objspace/test_objspace.rb
+++ b/test/objspace/test_objspace.rb
@@ -243,6 +243,20 @@ class TestObjSpace < Test::Unit::TestCase
     GC.enable
   end
 
+  def test_trace_object_allocations_in_stress
+    assert_in_out_err(%w[-robjspace], "#{<<-"begin;"}\n#{<<-'end;'}") do |(output), (error)|
+      begin;
+        ObjectSpace.trace_object_allocations_start
+        GC.stress = true
+        10.times { Object.new }
+        puts :ok
+      end;
+      assert_nil error
+      assert_equal 'ok', output, '[ruby-core:102334] [Bug #17599]'
+    end
+  end
+
+
   def test_dump_flags
     info = ObjectSpace.dump("foo".freeze)
     assert_match(/"wb_protected":true, "old":true/, info)


### PR DESCRIPTION
ref: https://bugs.ruby-lang.org/issues/17599

This change will fix the SEGV on `ObjectSpace.trace_object_allocations_start` under `GC.stress = true`.

Note:
* The problem was caused by `ractor_cached_freeobj` returning an object with an old value.
* Originally, I thought I could just do zero paddings before the event hook.
  * However, I reconsidered that it would be more correct to initialize the object in v1-v3 and then hook the event.
* Zero-padding would be fine for now since `ext/objspace/object_tracing.c` does not refer v1-v3.
  * But there is no guarantee that other programs will not use the event in the future.