### PR TITLE
Make global ruby namespace usage explicit

### DIFF
--- a/include/ruby/backward/cxxanyargs.hpp
+++ b/include/ruby/backward/cxxanyargs.hpp
@@ -650,32 +650,32 @@ struct rb_define_global_function  : public driver0<const char *, ::rb_define_glo
 /// @brief        Defines klass\#mid.
 /// @param        klass  Where the method lives.
 /// @copydetails  #rb_define_global_function(mid, func, arity)
-#define rb_define_method(klass, mid, func, arity)           ruby::backward::cxxanyargs::define_method::rb_define_method::specific<arity>::define(klass, mid, func)
+#define rb_define_method(klass, mid, func, arity)           ::ruby::backward::cxxanyargs::define_method::rb_define_method::specific<arity>::define(klass, mid, func)
 
 /// @copydoc #rb_define_method(klass, mid, func, arity)
-#define rb_define_method_id(klass, mid, func, arity)        ruby::backward::cxxanyargs::define_method::rb_define_method_id::specific<arity>::define(klass, mid, func)
+#define rb_define_method_id(klass, mid, func, arity)        ::ruby::backward::cxxanyargs::define_method::rb_define_method_id::specific<arity>::define(klass, mid, func)
 
 /// @brief        Defines klass\#mid and makes it private.
 /// @copydetails  #rb_define_method(klass, mid, func, arity)
-#define rb_define_private_method(klass, mid, func, arity)   ruby::backward::cxxanyargs::define_method::rb_define_private_method::specific<arity>::define(klass, mid, func)
+#define rb_define_private_method(klass, mid, func, arity)   ::ruby::backward::cxxanyargs::define_method::rb_define_private_method::specific<arity>::define(klass, mid, func)
 
 /// @brief        Defines klass\#mid and makes it protected.
 /// @copydetails  #rb_define_method
-#define rb_define_protected_method(klass, mid, func, arity) ruby::backward::cxxanyargs::define_method::rb_define_protected_method::specific<arity>::define(klass, mid, func)
+#define rb_define_protected_method(klass, mid, func, arity) ::ruby::backward::cxxanyargs::define_method::rb_define_protected_method::specific<arity>::define(klass, mid, func)
 
 /// @brief        Defines klass.mid.(klass, mid, func, arity)
 /// @copydetails  #rb_define_method
-#define rb_define_singleton_method(klass, mid, func, arity) ruby::backward::cxxanyargs::define_method::rb_define_singleton_method::specific<arity>::define(klass, mid, func)
+#define rb_define_singleton_method(klass, mid, func, arity) ::ruby::backward::cxxanyargs::define_method::rb_define_singleton_method::specific<arity>::define(klass, mid, func)
 
 /// @brief        Defines klass\#mid and makes it a module function.
 /// @copydetails  #rb_define_method(klass, mid, func, arity)
-#define rb_define_module_function(klass, mid, func, arity)  ruby::backward::cxxanyargs::define_method::rb_define_module_function::specific<arity>::define(klass, mid, func)
+#define rb_define_module_function(klass, mid, func, arity)  ::ruby::backward::cxxanyargs::define_method::rb_define_module_function::specific<arity>::define(klass, mid, func)
 
 /// @brief Defines ::rb_mKernel \#mid.
 /// @param mid    Name of the defining method.
 /// @param func   Implementation of \#mid.
 /// @param arity  Arity of \#mid.
-#define rb_define_global_function(mid, func, arity)         ruby::backward::cxxanyargs::define_method::rb_define_global_function::specific<arity>::define(mid, func)
+#define rb_define_global_function(mid, func, arity)         ::ruby::backward::cxxanyargs::define_method::rb_define_global_function::specific<arity>::define(mid, func)
 
 }}}}}
 


### PR DESCRIPTION
If the use of the ruby namespace isn't prepended by `::` to make it
explicit that the global ruby namespace is referenced here, it can
clash with other non-global namespace named ruby, e.g.

```
  // declaration
  namespace myproject {
  namespace ruby {
    // my ruby classes
  }
  }

  // implementation
  using namespace myproject;

  [...]

  rb_define_method(...);

  [...]
```

leads to the following error:

```
../ruby/choice.cc: In function 'void {anonymous}::do_register_choice()':
../ruby/choice.cc:342:9: error: reference to 'ruby' is ambiguous
  342 |         rb_define_method(c_choices, "each", RUBY_FUNC_CAST(&choices_each), 0);
      |         ^~~~~~~~~~~~~~~~
In file included from ../ruby/choice.cc:20:
../ruby/paludis_ruby.hh:53:15: note: candidates are: 'namespace paludis::ruby { }'
   53 |     namespace ruby
      |               ^~~~
In file included from /usr/x86_64-pc-linux-gnu/include/ruby-3.0/ruby/backward/2/stdalign.h:23,
                 from /usr/x86_64-pc-linux-gnu/include/ruby-3.0/ruby/defines.h:77,
                 from /usr/x86_64-pc-linux-gnu/include/ruby-3.0/ruby/ruby.h:23,
                 from /usr/x86_64-pc-linux-gnu/include/ruby-3.0/ruby.h:38,
                 from ../ruby/paludis_ruby.hh:44,
                 from ../ruby/choice.cc:20:
/usr/x86_64-pc-linux-gnu/include/ruby-3.0/ruby/internal/stdalign.h:92:11: note:                 'namespace ruby { }'
   92 | namespace ruby {
      |           ^~~~
In file included from /usr/x86_64-pc-linux-gnu/include/ruby-3.0/ruby/internal/anyargs.h:83,
                 from /usr/x86_64-pc-linux-gnu/include/ruby-3.0/ruby/ruby.h:24,
                 from /usr/x86_64-pc-linux-gnu/include/ruby-3.0/ruby.h:38,
                 from ../ruby/paludis_ruby.hh:44,
                 from ../ruby/choice.cc:20:
../ruby/choice.cc:342:9: error: '::define' has not been declared
  342 |         rb_define_method(c_choices, "each", RUBY_FUNC_CAST(&choices_each), 0);
      |         ^~~~~~~~~~~~~~~~
../ruby/choice.cc:344:9: error: reference to 'ruby' is ambiguous
  344 |         rb_define_method(c_choices, "find_by_name_with_prefix", RUBY_FUNC_CAST(&choices_find_by_name_with_prefix), 1);
      |         ^~~~~~~~~~~~~~~~
```

This affects ruby 3 as well and should be backported/cherry-picked to that branch as well IMHO 