### PR TITLE
Improve performance some Numeric methods [Feature #17632]

### DIFF
--- a/benchmark/numeric_methods.yml
+++ b/benchmark/numeric_methods.yml
@@ -1,0 +1,13 @@
+prelude: |
+  int = 42
+  flo = 4.2
+benchmark:
+  real?: |
+    int.real?
+  integer?: |
+    flo.integer?
+  finite?: |
+    int.finite?
+  infinite?: |
+    int.infinite?
+loop_count: 20000000

--- a/numeric.c
+++ b/numeric.c
@@ -712,35 +712,6 @@ num_divmod(VALUE x, VALUE y)
 
 /*
  *  call-seq:
- *     num.real?  ->  true or false
- *
- *  Returns +true+ if +num+ is a real number (i.e. not Complex).
- */
-
-static VALUE
-num_real_p(VALUE num)
-{
-    return Qtrue;
-}
-
-/*
- *  call-seq:
- *     num.integer?  ->  true or false
- *
- *  Returns +true+ if +num+ is an Integer.
- *
- *      1.0.integer?   #=> false
- *      1.integer?     #=> true
- */
-
-static VALUE
-num_int_p(VALUE num)
-{
-    return Qfalse;
-}
-
-/*
- *  call-seq:
  *     num.abs        ->  numeric
  *     num.magnitude  ->  numeric
  *
@@ -822,31 +793,6 @@ num_nonzero_p(VALUE num)
 	return Qnil;
     }
     return num;
-}
-
-/*
- *  call-seq:
- *     num.finite?  ->  true or false
- *
- *  Returns +true+ if +num+ is a finite number, otherwise returns +false+.
- */
-static VALUE
-num_finite_p(VALUE num)
-{
-    return Qtrue;
-}
-
-/*
- *  call-seq:
- *     num.infinite?  ->  -1, 1, or nil
- *
- *  Returns +nil+, -1, or 1 depending on whether the value is
- *  finite, <code>-Infinity</code>, or <code>+Infinity</code>.
- */
-static VALUE
-num_infinite_p(VALUE num)
-{
-    return Qnil;
 }
 
 /*
@@ -5430,12 +5376,8 @@ Init_Numeric(void)
     rb_define_method(rb_cNumeric, "magnitude", num_abs, 0);
     rb_define_method(rb_cNumeric, "to_int", num_to_int, 0);
 
-    rb_define_method(rb_cNumeric, "real?", num_real_p, 0);
-    rb_define_method(rb_cNumeric, "integer?", num_int_p, 0);
     rb_define_method(rb_cNumeric, "zero?", num_zero_p, 0);
     rb_define_method(rb_cNumeric, "nonzero?", num_nonzero_p, 0);
-    rb_define_method(rb_cNumeric, "finite?", num_finite_p, 0);
-    rb_define_method(rb_cNumeric, "infinite?", num_infinite_p, 0);
 
     rb_define_method(rb_cNumeric, "floor", num_floor, -1);
     rb_define_method(rb_cNumeric, "ceil", num_ceil, -1);

--- a/numeric.rb
+++ b/numeric.rb
@@ -1,3 +1,49 @@
+class Numeric
+  #
+  #  call-seq:
+  #     num.real?  ->  true or false
+  #
+  #  Returns +true+ if +num+ is a real number (i.e. not Complex).
+  # 
+  def real?
+    return true
+  end
+
+  #
+  #  call-seq:
+  #     num.integer?  ->  true or false
+  #
+  #  Returns +true+ if +num+ is an Integer.
+  #
+  #      1.0.integer?   #=> false
+  #      1.integer?     #=> true
+  # 
+  def integer?
+    return false
+  end
+
+  #
+  #  call-seq:
+  #     num.finite?  ->  true or false
+  #
+  #  Returns +true+ if +num+ is a finite number, otherwise returns +false+.
+  #
+  def finite?
+    return true
+  end
+
+  #
+  #  call-seq:
+  #     num.infinite?  ->  -1, 1, or nil
+  #
+  #  Returns +nil+, -1, or 1 depending on whether the value is
+  #  finite, <code>-Infinity</code>, or <code>+Infinity</code>.
+  #
+  def infinite?
+    return nil
+  end
+end
+
 class Integer
   # call-seq:
   #    -int  ->  integer


### PR DESCRIPTION
Improve performance some `Nuemric` methods(write in Ruby)

benchmark:
```yml
prelude: |
  int = 42
  flo = 4.2
benchmark:
  real?: |
    int.real?
  integer?: |
    flo.integer?
  finite?: |
    int.finite?
  infinite?: |
    int.infinite?
loop_count: 20000000

```

result:
```bash
sh@DESKTOP-L0NI312:~/rubydev/build$ make benchmark/numeric_methods.yml -e COMPARE_RUBY=~/.rbenv/shims/ruby -e BENCH_RUBY=../install/bin/ruby
generating vm_call_iseq_optimized.inc
vm_call_iseq_optimized.inc unchanged
compare-ruby: ruby 3.1.0dev (2021-02-15T09:29:35Z master 37b90bcdc1) [x86_64-linux]
built-ruby: ruby 3.1.0dev (2021-02-15T13:18:32Z improve_numeric_me.. 349c5721ad) [x86_64-linux]
last_commit=Improve Numeric methods
# Iteration per second (i/s)

|           |compare-ruby|built-ruby|
|:----------|-----------:|---------:|
|real?      |     90.157M|  106.604M|
|           |           -|     1.18x|
|integer?   |     93.559M|  105.397M|
|           |           -|     1.13x|
|finite?    |     90.229M|  104.325M|
|           |           -|     1.16x|
|infinite?  |     89.233M|  113.647M|
|           |           -|     1.27x|

```

`COMPARE_RUBY` is `ruby 3.1.0dev (2021-02-15T09:29:35Z master 37b90bcdc1) [x86_64-linux]`. BENCH_RUBY is ahead of `ruby 3.1.0dev (2021-02-15T09:29:35Z master 37b90bcdc1) [x86_64-linux]`.

ticket: [Feature #17632 Improve performance some Numeric methods](https://bugs.ruby-lang.org/issues/17632)