### PR TITLE
Add Hash#delete_at

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -2680,6 +2680,33 @@ rb_hash_values_at(int argc, VALUE *argv, VALUE hash)
 
 /*
  *  call-seq:
+ *    hash.delete_at(*keys) -> new_array
+ *
+ *  Deletes entries at the specified keys, and returns a new \Array
+ *  containing values for the given +keys+:
+ *    h = {foo: 0, bar: 1, baz: 2}
+ *    h.delete_at(:baz, :foo) # => [2, 0]
+ *    h # => {bar: 1}
+ *
+ *  The {default values}[#class-Hash-label-Default+Values] are returned
+ *  for any keys that are not found:
+ *    h.delete_at(:hello, :bar) # => [nil, 1]
+*/
+VALUE
+rb_hash_delete_at(int argc, VALUE *argv, VALUE hash)
+{
+    VALUE result = rb_ary_new2(argc);
+    long i;
+
+    for (i=0; i<argc; i++) {
+	rb_ary_push(result, rb_hash_aref(hash, argv[i]));
+	rb_hash_delete(hash, argv[i]);
+    }
+    return result;
+}
+
+/*
+ *  call-seq:
  *    hash.fetch_values(*keys) -> new_array
  *    hash.fetch_values(*keys) {|key| ... } -> new_array
  *
@@ -7029,6 +7056,7 @@ Init_Hash(void)
 
     rb_define_method(rb_cHash, "shift", rb_hash_shift, 0);
     rb_define_method(rb_cHash, "delete", rb_hash_delete_m, 1);
+    rb_define_method(rb_cHash, "delete_at", rb_hash_delete_at, -1);
     rb_define_method(rb_cHash, "delete_if", rb_hash_delete_if, 0);
     rb_define_method(rb_cHash, "keep_if", rb_hash_keep_if, 0);
     rb_define_method(rb_cHash, "select", rb_hash_select, 0);

--- a/test/-ext-/hash/test_delete_at.rb
+++ b/test/-ext-/hash/test_delete_at.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: false
+require 'test/unit'
+require '-test-/hash'
+
+class Test_Hash < Test::Unit::TestCase
+  class TestDeleteAt < Test::Unit::TestCase
+    def test_delete_at
+      original = { a: "a", b: "b", c: "c" }
+
+      assert_equal ["a", "c", nil], original.delete_at(:a, :c, :c)
+      assert_equal({ b: "b" }, original)
+    end
+
+    def test_delete_at_with_block
+      original = {}
+
+      assert_equal [0], original.delete_at(:a) { 0 }
+      assert_empty original
+    end
+
+    def test_delete_at_missing_key_with_default_value
+      original = Hash.new(0)
+
+      assert_equal [0], original.delete_at(:a)
+      assert_empty original
+    end
+
+    def test_delete_at_missing_key_with_default_block
+      original = Hash.new { 0 }
+
+      assert_equal [0], original.delete_at(:a)
+      assert_empty original
+    end
+  end
+end


### PR DESCRIPTION
Add `Hash#delete_at` to delete values from a list keyed by its
arguments. Mirrors the [Hash#values_at][] and [Array#delete_at][]
interfaces, and pairs nicely with multiple assignment.

```ruby
hash = { a: true, b: false, c: nil }
a, c = hash.delete_at(:a, :c) # => [ true, nil ]
hash # => { b: false }
```

[Array#delete_at]: https://ruby-doc.org/core-3.0.0/Array.html#method-i-delete_at
[Hash#values_at]: https://ruby-doc.org/core-3.0.0/Hash.html#method-i-values_at

Co-authored-by: Daniel Colson <danieljamescolson@gmail.com>