### PR TITLE
T#dup (T < Proc) should return T's object

### DIFF
--- a/test/ruby/test_proc.rb
+++ b/test/ruby/test_proc.rb
@@ -412,6 +412,11 @@ class TestProc < Test::Unit::TestCase
     assert_equal(:foo, bc.foo)
   end
 
+  def test_dup_subclass
+    c1 = Class.new(Proc)
+    assert_equal c1, c1.new{}.dup.class, '[Bug #17545]'
+  end
+
   def test_binding
     b = proc {|x, y, z| proc {}.binding }.call(1, 2, 3)
     class << b; attr_accessor :foo; end

--- a/vm.c
+++ b/vm.c
@@ -994,7 +994,7 @@ rb_proc_dup(VALUE self)
     rb_proc_t *src;
 
     GetProcPtr(self, src);
-    procval = proc_create(rb_cProc, &src->block, src->is_from_method, src->is_lambda);
+    procval = proc_create(rb_obj_class(self), &src->block, src->is_from_method, src->is_lambda);
     if (RB_OBJ_SHAREABLE_P(self)) FL_SET_RAW(procval, RUBY_FL_SHAREABLE);
     RB_GC_GUARD(self); /* for: body = rb_proc_dup(body) */
     return procval;


### PR DESCRIPTION
T#dup (T < Proc) returns Proc object (not T) from Ruby 1.9.
[Bug #17545]