### PR TITLE
Invalidate negative cache

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -12402,31 +12402,34 @@ rb_raw_obj_info(char *buff, const int buff_size, VALUE obj)
             APPENDF((BUFF_ARGS, "<%s> ", rb_imemo_name(imemo_type(obj))));
 
 	    switch (imemo_type(obj)) {
-	      case imemo_ment: {
-		const rb_method_entry_t *me = &RANY(obj)->as.imemo.ment;
-		if (me->def) {
+	      case imemo_ment:
+                {
+                    const rb_method_entry_t *me = &RANY(obj)->as.imemo.ment;
+
                     APPENDF((BUFF_ARGS, ":%s (%s%s%s%s) type:%s alias:%d owner:%p defined_class:%p",
-			     rb_id2name(me->called_id),
+                             rb_id2name(me->called_id),
                              METHOD_ENTRY_VISI(me) == METHOD_VISI_PUBLIC ?  "pub" :
                              METHOD_ENTRY_VISI(me) == METHOD_VISI_PRIVATE ? "pri" : "pro",
                              METHOD_ENTRY_COMPLEMENTED(me) ? ",cmp" : "",
                              METHOD_ENTRY_CACHED(me) ? ",cc" : "",
                              METHOD_ENTRY_INVALIDATED(me) ? ",inv" : "",
-                             rb_method_type_name(me->def->type),
-                             me->def->alias_count,
+                             me->def ? rb_method_type_name(me->def->type) : "NULL",
+                             me->def ? me->def->alias_count : -1,
                              (void *)me->owner, // obj_info(me->owner),
                              (void *)me->defined_class)); //obj_info(me->defined_class)));
 
-                    if (me->def->type == VM_METHOD_TYPE_ISEQ) {
-                        // APPENDF((BUFF_ARGS, " (iseq:%p)", (void *)me->def->body.iseq.iseqptr));
-                        APPENDF((BUFF_ARGS, " (iseq:%s)", obj_info((VALUE)me->def->body.iseq.iseqptr)));
+                    if (me->def) {
+                        switch (me->def->type) {
+                          case VM_METHOD_TYPE_ISEQ:
+                            APPENDF((BUFF_ARGS, " (iseq:%s)", obj_info((VALUE)me->def->body.iseq.iseqptr)));
+                            break;
+                          default:
+                            break;
+                        }
                     }
-		}
-		else {
-                    APPENDF((BUFF_ARGS, "%s", rb_id2name(me->called_id)));
-		}
-		break;
-	      }
+
+                    break;
+                }
 	      case imemo_iseq: {
 		const rb_iseq_t *iseq = (const rb_iseq_t *)obj;
                 rb_raw_iseq_info(BUFF_ARGS, iseq);

--- a/test/ruby/test_method_cache.rb
+++ b/test/ruby/test_method_cache.rb
@@ -61,5 +61,16 @@ class TestMethodCache < Test::Unit::TestCase
 
     assert_equal :c2, c3.new.foo
   end
+
+  def test_negative_cache_with_and_without_subclasses
+    c0 = Class.new{}
+    c1 = Class.new(c0){}
+    c0.new.foo rescue nil
+    c1.new.foo rescue nil
+    c1.module_eval{ def foo = :c1 }
+    c0.module_eval{ def foo = :c0 }
+
+    assert_equal :c0, c0.new.foo
+  end
 end
 

--- a/vm_method.c
+++ b/vm_method.c
@@ -129,17 +129,15 @@ rb_clear_constant_cache(void)
 }
 
 static void
-invalidate_negative_cache(ID mid, bool invalidate_cme)
+invalidate_negative_cache(ID mid)
 {
     const rb_callable_method_entry_t *cme;
     rb_vm_t *vm = GET_VM();
 
     if (rb_id_table_lookup(vm->negative_cme_table, mid, (VALUE *)&cme)) {
         rb_id_table_delete(vm->negative_cme_table, mid);
-        if (invalidate_cme) {
-            vm_cme_invalidate((rb_callable_method_entry_t *)cme);
-            RB_DEBUG_COUNTER_INC(cc_invalidate_negative);
-        }
+        vm_cme_invalidate((rb_callable_method_entry_t *)cme);
+        RB_DEBUG_COUNTER_INC(cc_invalidate_negative);
     }
 }
 
@@ -162,7 +160,7 @@ clear_method_cache_by_id_in_class(VALUE klass, ID mid)
 
         // invalidate CCs
         if (cc_tbl && rb_id_table_lookup(cc_tbl, mid, (VALUE *)&ccs)) {
-            if (NIL_P(ccs->cme->owner)) invalidate_negative_cache(mid, false);
+            if (NIL_P(ccs->cme->owner)) invalidate_negative_cache(mid);
             rb_vm_ccs_free(ccs);
             rb_id_table_delete(cc_tbl, mid);
             RB_DEBUG_COUNTER_INC(cc_invalidate_leaf_ccs);
@@ -211,7 +209,7 @@ clear_method_cache_by_id_in_class(VALUE klass, ID mid)
             RB_DEBUG_COUNTER_INC(cc_invalidate_tree);
         }
         else {
-            invalidate_negative_cache(mid, true);
+            invalidate_negative_cache(mid);
         }
     }
 }


### PR DESCRIPTION
invalidate negative cache any time.

    negative cache on a class which does not have subclasses was not
    invalidated, but it should be invalidated because other classes
    can cache this negative cache.
    [Bug #17553]
