### PR TITLE
Pattern matching for CSV rows

### DIFF
--- a/lib/csv/row.rb
+++ b/lib/csv/row.rb
@@ -548,7 +548,25 @@ class CSV
     end
     alias_method :to_hash, :to_h
 
+    # :call-seq:
+    #   row.deconstruct_keys(keys) -> hash
+    #
+    # Returns the new \Hash suitable for pattern matching containing only the
+    # keys specified as an argument.
+    def deconstruct_keys(keys)
+      keys.to_h { |key| [key, self[key]] }
+    end
+
     alias_method :to_ary, :to_a
+
+    # :call-seq:
+    #   row.deconstruct -> array
+    #
+    # Returns the new \Array suitable for pattern matching containing the values
+    # of the row.
+    def deconstruct
+      @row.map(&:last)
+    end
 
     # :call-seq:
     #   row.to_csv -> csv_string

--- a/test/csv/test_row.rb
+++ b/test/csv/test_row.rb
@@ -432,4 +432,19 @@ class TestCSVRow < Test::Unit::TestCase
     assert_equal(["foo", nil],
                  [row["A"], dupped_row["A"]])
   end
+
+  def test_pattern_matching_hash
+    case CSV::Row.new(%i{A B C}, [1, 2, 3])
+    in B: b, C: c
+      assert_equal(2, b)
+      assert_equal(3, c)
+    end
+  end
+
+  def test_pattern_matching_array
+    case CSV::Row.new(%i{A B C}, [1, 2, 3])
+    in *, matched
+      assert_equal(3, matched)
+    end
+  end
 end


### PR DESCRIPTION
I'd like to be able to use pattern matching against CSV rows, so this commit adds deconstruct and deconstruct_keys methods to CSV::Row.