### PR TITLE
Eagerly allocate ivar lists along with objects

### DIFF
--- a/benchmark/ivar_extend.yml
+++ b/benchmark/ivar_extend.yml
@@ -1,0 +1,23 @@
+prelude: |
+  class Embedded
+    def initialize
+      @a = 1
+      @b = 1
+      @c = 1
+    end
+  end
+
+  class Extended
+    def initialize
+      @a = 1
+      @b = 1
+      @c = 1
+      @d = 1
+      @e = 1
+      @f = 1
+    end
+  end
+benchmark:
+  embedded: Embedded.new
+  extended: Extended.new
+loop_count: 20_000_000


### PR DESCRIPTION
If an object instance has had ivars set on it, then it is very likely
subsequent instances will too.  If we eagerly allocate ivar lists, we
can eventually start allocating the ivar list next to the object
instance.

I added some benchmarks, and this doesn't seem to have any impact on performance:

```
aaron@whiteclaw ~/g/ruby (eager-ivar)> make benchmark ITEM='ivar_extend.yml'
/home/aaron/.rubies/ruby-trunk/bin/ruby --disable=gems -rrubygems -I./benchmark/lib ./benchmark/benchmark-driver/exe/benchmark-driver \
            --executables="compare-ruby::/home/aaron/.rubies/ruby-trunk/bin/ruby --disable=gems -I.ext/common --disable-gem" \
            --executables="built-ruby::./miniruby -I./lib -I. -I.ext/common  ./tool/runruby.rb --extout=.ext  -- --disable-gems --disable-gem" \
            --output=markdown --output-compare -v $(find ./benchmark -maxdepth 1 -name 'ivar_extend.yml' -o -name '*ivar_extend.yml*.yml' -o -name '*ivar_extend.yml*.rb' | sort) 
compare-ruby: ruby 3.1.0dev (2021-04-27T14:58:49Z master 1c1c91535c) [x86_64-linux]
built-ruby: ruby 3.1.0dev (2021-04-27T16:15:49Z eager-ivar bca2234ff7) [x86_64-linux]
# Iteration per second (i/s)

|          |compare-ruby|built-ruby|
|:---------|-----------:|---------:|
|embedded  |      9.581M|    9.904M|
|          |           -|     1.03x|
|extended  |      7.482M|    7.609M|
|          |           -|     1.02x|
aaron@whiteclaw ~/g/ruby (eager-ivar)> make benchmark ITEM='ivar_extend.yml'
/home/aaron/.rubies/ruby-trunk/bin/ruby --disable=gems -rrubygems -I./benchmark/lib ./benchmark/benchmark-driver/exe/benchmark-driver \
            --executables="compare-ruby::/home/aaron/.rubies/ruby-trunk/bin/ruby --disable=gems -I.ext/common --disable-gem" \
            --executables="built-ruby::./miniruby -I./lib -I. -I.ext/common  ./tool/runruby.rb --extout=.ext  -- --disable-gems --disable-gem" \
            --output=markdown --output-compare -v $(find ./benchmark -maxdepth 1 -name 'ivar_extend.yml' -o -name '*ivar_extend.yml*.yml' -o -name '*ivar_extend.yml*.rb' | sort) 
compare-ruby: ruby 3.1.0dev (2021-04-27T14:58:49Z master 1c1c91535c) [x86_64-linux]
built-ruby: ruby 3.1.0dev (2021-04-27T16:15:49Z eager-ivar bca2234ff7) [x86_64-linux]
# Iteration per second (i/s)

|          |compare-ruby|built-ruby|
|:---------|-----------:|---------:|
|embedded  |      9.608M|    9.588M|
|          |       1.00x|         -|
|extended  |      7.605M|    7.523M|
|          |       1.01x|         -|
aaron@whiteclaw ~/g/ruby (eager-ivar)> make benchmark ITEM='ivar_extend.yml'
/home/aaron/.rubies/ruby-trunk/bin/ruby --disable=gems -rrubygems -I./benchmark/lib ./benchmark/benchmark-driver/exe/benchmark-driver \
            --executables="compare-ruby::/home/aaron/.rubies/ruby-trunk/bin/ruby --disable=gems -I.ext/common --disable-gem" \
            --executables="built-ruby::./miniruby -I./lib -I. -I.ext/common  ./tool/runruby.rb --extout=.ext  -- --disable-gems --disable-gem" \
            --output=markdown --output-compare -v $(find ./benchmark -maxdepth 1 -name 'ivar_extend.yml' -o -name '*ivar_extend.yml*.yml' -o -name '*ivar_extend.yml*.rb' | sort) 
compare-ruby: ruby 3.1.0dev (2021-04-27T14:58:49Z master 1c1c91535c) [x86_64-linux]
built-ruby: ruby 3.1.0dev (2021-04-27T16:15:49Z eager-ivar bca2234ff7) [x86_64-linux]
# Iteration per second (i/s)

|          |compare-ruby|built-ruby|
|:---------|-----------:|---------:|
|embedded  |      9.720M|    9.625M|
|          |       1.01x|         -|
|extended  |      7.504M|    7.702M|
|          |           -|     1.03x|
```