### PR TITLE
This fixes a segfault bug with IO#each_byte.

### DIFF
--- a/io.c
+++ b/io.c
@@ -3989,6 +3989,7 @@ rb_io_each_byte(VALUE io)
 
     do {
 	while (fptr->rbuf.len > 0) {
+	    rb_io_check_byte_readable(fptr);
 	    char *p = fptr->rbuf.ptr + fptr->rbuf.off++;
 	    fptr->rbuf.len--;
 	    rb_yield(INT2FIX(*p & 0xff));

--- a/spec/ruby/core/io/each_byte_spec.rb
+++ b/spec/ruby/core/io/each_byte_spec.rb
@@ -15,6 +15,14 @@ describe "IO#each_byte" do
     -> { IOSpecs.closed_io.each_byte {} }.should raise_error(IOError)
   end
 
+  it "raises IOError when stream is closed mid-read" do
+    -> do
+      @io.each_byte do |byte|
+        @io.close
+      end
+    end.should raise_error(IOError)
+  end
+
   it "yields each byte" do
     count = 0
     @io.each_byte do |byte|


### PR DESCRIPTION
As reported here: https://twitter.com/asterite/status/1363487990203506689 when iterating through a file's contents with #each_byte, if the filehandle is closed inside of the block yielded to by #each byte, this condition is not detected, and a segmentation fault is thrown.

I have fixed the problem by adding a check inside the inner loop that iterates over the filehandle read buffer, and I have added a spec that will both expose the bug in an unfixed ruby, and pass in a fixed ruby.

The bug exists on every build of Ruby that I have available on my systems, and in looking at the history of `io.c`, it likely exists all the way back to 1.9.1.