### PR TITLE
Raise LocalJumpError if returning from proc inside lambda inside method outside of the lambda

### DIFF
--- a/test/ruby/test_lambda.rb
+++ b/test/ruby/test_lambda.rb
@@ -74,6 +74,94 @@ class TestLambdaParameters < Test::Unit::TestCase
     assert_raise(ArgumentError, bug9605) {proc(&plus).call [1,2]}
   end
 
+  def test_proc_inside_lambda_inside_method_return_inside_lambda_inside_method
+    def self.a
+      r = -> do
+        p = Proc.new{return :a}
+        p.call
+      end.call
+    end
+    assert_equal(:a, a)
+
+    def self.b
+      r = lambda do
+        p = Proc.new{return :b}
+        p.call
+      end.call
+    end
+    assert_equal(:b, b)
+  end
+
+  def test_proc_inside_lambda_inside_method_return_inside_lambda_outside_method
+    def self.a
+      r = -> do
+        p = Proc.new{return :a}
+        p.call
+      end
+    end
+    assert_equal(:a, a.call)
+
+    def self.b
+      r = lambda do
+        p = Proc.new{return :b}
+        p.call
+      end
+    end
+    assert_equal(:b, b.call)
+  end
+
+  def test_proc_inside_lambda_inside_method_return_outside_lambda_inside_method
+    def self.a
+      r = -> do
+        Proc.new{return :a}
+      end.call.call
+    end
+    assert_raise(LocalJumpError) {a}
+
+    def self.b
+      r = lambda do
+        Proc.new{return :b}
+      end.call.call
+    end
+    assert_raise(LocalJumpError) {b}
+  end
+
+  def test_proc_inside_lambda_inside_method_return_outside_lambda_outside_method
+    def self.a
+      r = -> do
+        Proc.new{return :a}
+      end
+    end
+    assert_raise(LocalJumpError) {a.call.call}
+
+    def self.b
+      r = lambda do
+        Proc.new{return :b}
+      end
+    end
+    assert_raise(LocalJumpError) {b.call.call}
+  end
+
+  def test_proc_inside_lambda2_inside_method_return_outside_lambda1_inside_method
+    def self.a
+      r = -> do
+        -> do
+          Proc.new{return :a}
+        end.call.call
+      end.call
+    end
+    assert_raise(LocalJumpError) {a}
+
+    def self.b
+      r = lambda do
+        lambda do
+          Proc.new{return :a}
+        end.call.call
+      end.call
+    end
+    assert_raise(LocalJumpError) {b}
+  end
+
   def pass_along(&block)
     lambda(&block)
   end

--- a/vm.c
+++ b/vm.c
@@ -913,6 +913,10 @@ vm_proc_create_from_captured(VALUE klass,
     proc->is_from_method = is_from_method;
     proc->is_lambda = is_lambda;
 
+    if (is_lambda && rb_obj_is_iseq(captured->code.val)) {
+        ((rb_iseq_t *)captured->code.val)->body->param.flags.lambda_proc = 1;
+    }
+
     return procval;
 }
 

--- a/vm_core.h
+++ b/vm_core.h
@@ -354,6 +354,7 @@ struct rb_iseq_constant_body {
 	    unsigned int ambiguous_param0 : 1; /* {|a|} */
 	    unsigned int accepts_no_kwarg : 1;
             unsigned int ruby2_keywords: 1;
+            unsigned int lambda_proc: 1;
 	} flags;
 
 	unsigned int size;


### PR DESCRIPTION
Previously, return in a proc inside a lambda inside a method could
return to two separate places.  If the return occurred while still
inside the lambda, it returned to the lambda.  If the return occured
while outside the lambda, it returned to the method.

Fix this by checking the parent iseqs of the proc for a lambda proc,
and recording the iseq.  When processing the callstack looking for
the return target, if you don't find a lambda proc or you find a
different lambda proc that the expected lambda proc, it means the
lambda proc has already returned, and therefore the proc return
should raise a LocalJumpError.

This currently adds a param flag on the iseq for whether the iseq is
a lambda proc, since I cannot figure out how to get the proc object
from the parent iseq to check whether it is a lambda proc.

Fixes [Bug #17105]