### PR TITLE
random.c: simplify Random object deallocation

### DIFF
--- a/random.c
+++ b/random.c
@@ -259,14 +259,7 @@ const rb_data_type_t rb_random_data_type = {
 };
 
 #define random_mt_mark rb_random_mark
-
-static void
-random_mt_free(void *ptr)
-{
-    rb_random_mt_t *rnd = rb_ractor_local_storage_ptr(default_rand_key);
-    if (ptr != rnd)
-	xfree(ptr);
-}
+#define random_mt_free RUBY_TYPED_DEFAULT_FREE
 
 static size_t
 random_mt_memsize(const void *ptr)


### PR DESCRIPTION
This is a follow-up for commit 265c0022390e ("Do not allocate
ractor-local storage in dfree function during GC", 2021-02-09).

The comparison with the default rb_random_mt_t is useless in the first
place, since it is never equal: no actual Random object is associated
with it.

[Bug #17653] https://bugs.ruby-lang.org/issues/17653