### PR TITLE
[DOC] Add Enumerable::Lazy#with_index to NEWS-2.7.0 [ci skip]

### DIFF
--- a/doc/NEWS-2.7.0
+++ b/doc/NEWS-2.7.0
@@ -357,6 +357,16 @@ See also Warning in {Core classes updates}[#label-Core+classes+updates+-28outsta
       can be directly passed to another method as a block
       argument.  [Feature #15618]
 
+    * Added Enumerator::Lazy#with_index be lazy
+      Previously, Enumerator::Lazy#with_index was not defined, so it
+      picked up the default implementation from Enumerator, which was
+      not lazy.  [Bug #7877]
+
+        ("a"..).lazy.with_index(1) { |it, index| puts "#{index}:#{it}" }.take(3).force
+        # => 1:a
+        #    2:b
+        #    3:c
+
 [Fiber]
 
   [New method]


### PR DESCRIPTION
The behavior of `Enumerable::Lazy#with_index` has changed in Ruby 2.7.

```ruby
# Block don't called in Ruby 2.7
p [1, 2, 3].lazy.with_index { |it, i| p [it, i] }
# Ruby 2.6 => [1, 2, 3]
# Ruby 2.7 => #<Enumerator::Lazy: #<Enumerator::Lazy: [1, 2, 3]>:with_index(0)>
```

This change was not listed in the Ruby 2.7 news, so I added it.

see: [[Bug #7877] E::Lazy#with_index should be lazy](https://bugs.ruby-lang.org/issues/7877)

