### PR TITLE
Fix inspect for unicode codepoint 0x85

### DIFF
--- a/string.c
+++ b/string.c
@@ -6777,7 +6777,15 @@ rb_str_inspect(VALUE str)
             prev = p;
             continue;
         }
-        if ((enc == resenc && rb_enc_isprint(c, enc)) ||
+        /* The special casing of 0x85 (NEXT_LINE) here is because
+         * Oniguruma historically treats it as printable, but it
+         * doesn't match the print POSIX bracket class or character
+         * property in regexps.
+         *
+         * See Ruby Bug #16842 for details:
+         * https://bugs.ruby-lang.org/issues/16842
+         */
+        if ((enc == resenc && rb_enc_isprint(c, enc) && c != 0x85) ||
             (asciicompat && rb_enc_isascii(c, enc) && ISPRINT(c))) {
             continue;
         }

--- a/test/ruby/test_string.rb
+++ b/test/ruby/test_string.rb
@@ -2614,6 +2614,11 @@ CODE
     assert_equal '"\x0012"', s.inspect, bug8290
   end
 
+  def test_inspect_next_line
+    bug16842 = '[ruby-core:98231]'
+    assert_equal '"\\u0085"', 0x85.chr(Encoding::UTF_8).inspect, bug16842
+  end
+
   def test_partition
     assert_equal(%w(he l lo), S("hello").partition(/l/))
     assert_equal(%w(he l lo), S("hello").partition("l"))


### PR DESCRIPTION
This is an inelegant hack, by manually checking for this specific
code point in rb_str_inspect.  Some testing indicates that this is
the only code point affected.

It's possible a better fix would be inside of lower-level encoding
code, such that rb_enc_isprint would return false and not true for
codepoint 0x85.

Fixes [Bug #16842]