### PR TITLE
RBASIC_SET_CLASS_RAW: follow strict aliasing rule

### DIFF
--- a/internal/object.h
+++ b/internal/object.h
@@ -47,8 +47,8 @@ MJIT_SYMBOL_EXPORT_END
 static inline void
 RBASIC_SET_CLASS_RAW(VALUE obj, VALUE klass)
 {
-    struct { VALUE flags; VALUE klass; } *ptr = (void *)obj;
-    ptr->klass = klass;
+    const VALUE *ptr = &RBASIC(obj)->klass;
+    *(VALUE *)ptr = klass;
 }
 
 static inline void


### PR DESCRIPTION
Instead of rather euphemistic struct cast, just reomve the `const` qualifier and assign directly.  According to ISO/IEC 9899:2018 section 6.5 paragraph 7, `VALUE` and `const VALUE` are allowed to alias (but two distinct structs are not, even when their structures are the same).

[[Bug #17540]](https://bugs.ruby-lang.org/issues/17540#change-90693)