### PR TITLE
Improve performance Float#to_i [Feature #17670]

### DIFF
--- a/benchmark/float_to_i.yml
+++ b/benchmark/float_to_i.yml
@@ -1,0 +1,8 @@
+prelude: |
+  flo = 4.2
+benchmark:
+  to_i: |
+    flo.to_i
+  to_int: |
+    flo.to_int
+loop_count: 20000000

--- a/numeric.c
+++ b/numeric.c
@@ -2269,24 +2269,6 @@ float_round_underflow(int ndigits, int binexp)
     return FALSE;
 }
 
-/*
- *  call-seq:
- *     float.to_i    ->  integer
- *     float.to_int  ->  integer
- *
- *  Returns the +float+ truncated to an Integer.
- *
- *     1.2.to_i      #=> 1
- *     (-1.2).to_i   #=> -1
- *
- *  Note that the limited precision of floating point arithmetic
- *  might lead to surprising results:
- *
- *    (0.3 / 0.1).to_i  #=> 2 (!)
- *
- *  #to_int is an alias for #to_i.
- */
-
 static VALUE
 flo_to_i(VALUE num)
 {
@@ -5556,8 +5538,6 @@ Init_Numeric(void)
     rb_define_method(rb_cFloat, "eql?", flo_eql, 1);
     rb_define_method(rb_cFloat, "hash", flo_hash, 0);
 
-    rb_define_method(rb_cFloat, "to_i", flo_to_i, 0);
-    rb_define_method(rb_cFloat, "to_int", flo_to_i, 0);
     rb_define_method(rb_cFloat, "floor", flo_floor, -1);
     rb_define_method(rb_cFloat, "ceil", flo_ceil, -1);
     rb_define_method(rb_cFloat, "round", flo_round, -1);

--- a/numeric.rb
+++ b/numeric.rb
@@ -222,7 +222,7 @@ class Float
   #    (0.3 / 0.1).to_i  #=> 2 (!)
   #
   #  #to_int is an alias for #to_i.
-  # 
+  #
   def to_i
     Primitive.cexpr! 'flo_to_i(self)'
   end

--- a/numeric.rb
+++ b/numeric.rb
@@ -224,12 +224,10 @@ class Float
   #  #to_int is an alias for #to_i.
   # 
   def to_i
-    Primitive.attr! 'inline'
     Primitive.cexpr! 'flo_to_i(self)'
   end
 
   def to_int
-    Primitive.attr! 'inline'
     Primitive.cexpr! 'flo_to_i(self)'
   end
 

--- a/numeric.rb
+++ b/numeric.rb
@@ -208,6 +208,33 @@ class Float
 
   #
   #  call-seq:
+  #     float.to_i    ->  integer
+  #     float.to_int  ->  integer
+  #
+  #  Returns the +float+ truncated to an Integer.
+  #
+  #     1.2.to_i      #=> 1
+  #     (-1.2).to_i   #=> -1
+  #
+  #  Note that the limited precision of floating point arithmetic
+  #  might lead to surprising results:
+  #
+  #    (0.3 / 0.1).to_i  #=> 2 (!)
+  #
+  #  #to_int is an alias for #to_i.
+  # 
+  def to_i
+    Primitive.attr! 'inline'
+    Primitive.cexpr! 'flo_to_i(self)'
+  end
+
+  def to_int
+    Primitive.attr! 'inline'
+    Primitive.cexpr! 'flo_to_i(self)'
+  end
+
+  #
+  #  call-seq:
   #     float.abs        ->  float
   #     float.magnitude  ->  float
   #


### PR DESCRIPTION

Improve performance `Float#to_i` and `Float#to_int` methods(write in Ruby)

benchmark:
```yml
prelude: |
  flo = 4.2
benchmark:
  to_i: |
    flo.to_i
  to_int: |
    flo.to_int
loop_count: 20000000

```

result:
```bash
sh@DESKTOP-L0NI312:~/rubydev/build$ make benchmark/benchmark.yml -e COMPARE_RUBY=~/.rbenv/shims/ruby -e BENCH_RUBY=../install/bin/ruby
generating vm_call_iseq_optimized.inc
vm_call_iseq_optimized.inc unchanged
compare-ruby: ruby 3.1.0dev (2021-02-28T11:24:42Z master 80e2c45f55) [x86_64-linux]
built-ruby: ruby 3.1.0dev (2021-02-28T11:24:42Z master 80e2c45f55) [x86_64-linux]
# Iteration per second (i/s)

|        |compare-ruby|built-ruby|
|:-------|-----------:|---------:|
|to_i    |     66.872M|   75.080M|
|        |           -|     1.13x|
|to_int  |     65.597M|   75.298M|
|        |           -|     1.15x|
```

`COMPARE_RUBY` is `ruby 3.1.0dev (2021-02-28T11:24:42Z master 80e2c45f55) [x86_64-linux]`. `BENCH_RUBY` is ahead of `ruby 3.1.0dev (2021-02-28T11:24:42Z master 80e2c45f55) [x86_64-linux]`.

ticket: [Improve performance Float#to_i Feature #17670](https://bugs.ruby-lang.org/issues/17670?next_issue_id=17669)