### PR TITLE
Generating note.GNU-stack section for FreeBSD on x86.

### DIFF
--- a/coroutine/amd64/Context.S
+++ b/coroutine/amd64/Context.S
@@ -41,6 +41,6 @@ PREFIXED_SYMBOL(SYMBOL_PREFIX,coroutine_transfer):
 	# We pop the return address and jump to it
 	ret
 
-#if defined(__linux__) && defined(__ELF__)
+#if (defined(__linux__) || defined(__FreeBSD__)) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/coroutine/x86/Context.S
+++ b/coroutine/x86/Context.S
@@ -37,6 +37,6 @@ PREFIXED_SYMBOL(SYMBOL_PREFIX,coroutine_transfer):
 	# Jump to the address on the stack
 	ret
 
-#if defined(__linux__) && defined(__ELF__)
+#if (defined(__linux__) || defined(__FreeBSD__)) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif


### PR DESCRIPTION
Not enabling for ELF in general as not all platform support it
 (e.g. NetBSD, implictly stack never executable).