### PR TITLE
Kh.fix read after close with stringio

### DIFF
--- a/ext/stringio/stringio.c
+++ b/ext/stringio/stringio.c
@@ -826,8 +826,11 @@ strio_each_byte(VALUE self)
     RETURN_ENUMERATOR(self, 0, 0);
 
     while (ptr->pos < RSTRING_LEN(ptr->string)) {
-	char c = RSTRING_PTR(ptr->string)[ptr->pos++];
-	rb_yield(CHR2FIX(c));
+        if (!READABLE(self)) {
+            rb_raise(rb_eIOError, "not opened for reading");
+        }
+        char c = RSTRING_PTR(ptr->string)[ptr->pos++];
+        rb_yield(CHR2FIX(c));
     }
     return self;
 }

--- a/spec/ruby/library/stringio/shared/each_byte.rb
+++ b/spec/ruby/library/stringio/shared/each_byte.rb
@@ -45,4 +45,15 @@ describe :stringio_each_byte_not_readable, shared: true do
     io.close_read
     -> { io.send(@method) { |b| b } }.should raise_error(IOError)
   end
+
+  ruby_version_is '3.0.1' do
+    it "raises IOError when stream is closed mid-read" do
+      io = StringIO.new("xyz")
+      -> do
+        io.each_byte do |byte|
+          io.close
+        end
+      end.should raise_error(IOError)
+    end
+  end
 end

--- a/spec/ruby/library/stringio/shared/each_byte.rb
+++ b/spec/ruby/library/stringio/shared/each_byte.rb
@@ -46,7 +46,7 @@ describe :stringio_each_byte_not_readable, shared: true do
     -> { io.send(@method) { |b| b } }.should raise_error(IOError)
   end
 
-  ruby_version_is '3.0.1' do
+  ruby_bug '#17675', ''...'3.0.1' do
     it "raises IOError when stream is closed mid-read" do
       io = StringIO.new("xyz")
       -> do


### PR DESCRIPTION
This fix is for https://bugs.ruby-lang.org/issues/17675

`each_byte` of StringIO does not check for readability while it is iterating over the object's buffer. This does not cause a segmentation fault on a read after closing the object, as it does with a regular IO, but it does ignore the close, and continue reading the remainder of the buffer.

Other iteration methods, such as `each_char`, check readability on each iteration, so the fix included here is to likewise insert a readability check in to the loop.

A spec for this issue is included.