### PR TITLE
[ruby/zlib] Resume zstream if available [Bug #10961]

### DIFF
--- a/ext/zlib/zlib.c
+++ b/ext/zlib/zlib.c
@@ -1095,6 +1095,12 @@ loop:
                                RB_NOGVL_UBF_ASYNC_SAFE);
 #endif
 
+    /* retry if no exception is thrown */
+    if (err == Z_OK && args.interrupt) {
+       args.interrupt = 0;
+       goto loop;
+    }
+
     if (flush != Z_FINISH && err == Z_BUF_ERROR
 	    && z->stream.avail_out > 0) {
 	z->flags |= ZSTREAM_FLAG_IN_STREAM;


### PR DESCRIPTION
This is just a port of https://github.com/ruby/zlib/pull/22. Please refer it for details.
