### PR TITLE
Implement unused #.empty? meth & clean up booleans

### DIFF
--- a/lib/csv/fields_converter.rb
+++ b/lib/csv/fields_converter.rb
@@ -72,13 +72,12 @@ class CSV
     end
 
     private
-    def need_static_convert?
-      not (@nil_value.nil? and @empty_value_is_empty_string)
+    def need_convert?
+      values_exist? or not empty?
     end
 
-    def need_convert?
-      @need_static_convert or
-        (not @converters.empty?)
+    def values_exist?
+      not (@nil_value.nil? and @empty_value_is_empty_string)
     end
   end
 end


### PR DESCRIPTION
Noticed this boolean was using a large amount of chained negative statements. 

Figured a simpler implementation would be good for readers. 

Sidenote: `#.empty?` method on this class was written but not implemented, but for this case API is perfect - so I added it.

<img width="628" alt="Screen Shot 2021-03-09 at 5 54 27 AM" src="https://user-images.githubusercontent.com/46613794/110460241-ebd7b280-809b-11eb-918c-66eafd37b02e.png">
