### PR TITLE
Backport io-console 0.5.7 to Ruby 3.0

### DIFF
--- a/ext/io/console/console.c
+++ b/ext/io/console/console.c
@@ -1574,6 +1574,10 @@ str_chomp(VALUE str)
  * Reads and returns a line without echo back.
  * Prints +prompt+ unless it is +nil+.
  *
+ * The newline character that terminates the
+ * read line is removed from the returned string,
+ * see String#chomp!.
+ *
  * You must require 'io/console' to use this method.
  */
 static VALUE

--- a/ext/io/console/console.c
+++ b/ext/io/console/console.c
@@ -1562,7 +1562,7 @@ static VALUE
 str_chomp(VALUE str)
 {
     if (!NIL_P(str)) {
-	str = rb_funcallv(str, rb_intern("chomp!"), 0, 0);
+	rb_funcallv(str, rb_intern("chomp!"), 0, 0);
     }
     return str;
 }

--- a/ext/io/console/console.c
+++ b/ext/io/console/console.c
@@ -1223,8 +1223,8 @@ console_key_pressed_p(VALUE io, VALUE k)
 }
 #else
 struct query_args {
-    const char *qstr;
-    int opt;
+    char qstr[6];
+    unsigned char opt;
 };
 
 static int

--- a/ext/io/console/console.c
+++ b/ext/io/console/console.c
@@ -77,7 +77,7 @@ getattr(int fd, conmode *t)
 
 static ID id_getc, id_console, id_close, id_min, id_time, id_intr;
 #if ENABLE_IO_GETPASS
-static ID id_gets;
+static ID id_gets, id_chomp_bang;
 #endif
 
 #ifdef HAVE_RB_SCHEDULER_TIMEOUT
@@ -1562,7 +1562,7 @@ static VALUE
 str_chomp(VALUE str)
 {
     if (!NIL_P(str)) {
-	rb_funcallv(str, rb_intern("chomp!"), 0, 0);
+	rb_funcallv(str, id_chomp_bang, 0, 0);
     }
     return str;
 }
@@ -1622,6 +1622,7 @@ Init_console(void)
     id_getc = rb_intern("getc");
 #if ENABLE_IO_GETPASS
     id_gets = rb_intern("gets");
+    id_chomp_bang = rb_intern("chomp!");
 #endif
     id_console = rb_intern("console");
     id_close = rb_intern("close");

--- a/ext/io/console/io-console.gemspec
+++ b/ext/io/console/io-console.gemspec
@@ -1,5 +1,5 @@
 # -*- ruby -*-
-_VERSION = "0.5.6"
+_VERSION = "0.5.7"
 
 Gem::Specification.new do |s|
   s.name = "io-console"

--- a/test/io/console/test_io_console.rb
+++ b/test/io/console/test_io_console.rb
@@ -235,6 +235,15 @@ defined?(PTY) and defined?(IO.console) and TestIO_Console.class_eval do
       assert_equal("\r\n", r.gets)
       assert_equal("\"asdf\"", r.gets.chomp)
     end
+
+    run_pty("p IO.console.getpass('> ')") do |r, w|
+      assert_equal("> ", r.readpartial(10))
+      sleep 0.1
+      w.print "asdf\C-D\C-D"
+      sleep 0.1
+      assert_equal("\r\n", r.gets)
+      assert_equal("\"asdf\"", r.gets.chomp)
+    end
   end
 
   def test_iflush


### PR DESCRIPTION
This should ensure the io-console version that ships with Ruby 3.0.x matches the code available in a released io-console gem. Ruby 3.0.0 contains an io-console between 0.5.6 and 0.5.7.  I compared this to an io-console 0.5.7 checkout and the only different file is `ext/io/console/depend`.

Fixes Ruby Bug 17508