### PR TITLE
Unlink file in test

### DIFF
--- a/test/ruby/test_file_exhaustive.rb
+++ b/test/ruby/test_file_exhaustive.rb
@@ -684,6 +684,7 @@ class TestFileExhaustive < Test::Unit::TestCase
         path = "foo\u{30b3 30d4 30fc}"
         File.write(path, "") rescue next
         assert_equal(1, File.utime(nil, nil, path))
+        File.unlink(path)
       end
     end
   end


### PR DESCRIPTION
When running all the Ruby tests locally on my machine I noticed that a
file named `fooコピー` showed up in my home directory. The change here
unlinks the file so it gets cleaned up after the test rather than
leaving it behind.

cc/ @tenderlove 