### PR TITLE
Make ConditionVariable#wait return false if timed out

### DIFF
--- a/ext/monitor/monitor.c
+++ b/ext/monitor/monitor.c
@@ -149,8 +149,8 @@ monitor_wait_for_cond_body(VALUE v)
     struct wait_for_cond_data *data = (struct wait_for_cond_data *)v;
     struct rb_monitor *mc = monitor_ptr(data->monitor);
     // cond.wait(monitor.mutex, timeout)
-    rb_funcall(data->cond, rb_intern("wait"), 2, mc->mutex, data->timeout);
-    return Qtrue;
+    VALUE signaled = rb_funcall(data->cond, rb_intern("wait"), 2, mc->mutex, data->timeout);
+    return RTEST(signaled) ? Qtrue : Qfalse;
 }
 
 static VALUE

--- a/test/monitor/test_monitor.rb
+++ b/test/monitor/test_monitor.rb
@@ -294,7 +294,7 @@ class TestMonitor < Test::Unit::TestCase
       @monitor.synchronize do
         assert_equal("foo", c)
         result3 = cond.wait(0.1)
-        assert_equal(true, result3) # wait always returns true in Ruby 1.9
+        assert_equal(false, result3)
         assert_equal("foo", c)
         queue3.enq(nil)
         result4 = cond.wait

--- a/test/ruby/test_thread_cv.rb
+++ b/test/ruby/test_thread_cv.rb
@@ -16,6 +16,7 @@ class TestThreadConditionVariable < Test::Unit::TestCase
     mutex = Thread::Mutex.new
     condvar = Thread::ConditionVariable.new
     result = []
+    woken = nil
     mutex.synchronize do
       t = Thread.new do
         mutex.synchronize do
@@ -25,11 +26,12 @@ class TestThreadConditionVariable < Test::Unit::TestCase
       end
 
       result << 0
-      condvar.wait(mutex)
+      woken = condvar.wait(mutex)
       result << 2
       t.join
     end
     assert_equal([0, 1, 2], result)
+    assert(woken)
   end
 
   def test_condvar_wait_exception_handling
@@ -140,11 +142,12 @@ INPUT
     condvar = Thread::ConditionVariable.new
     timeout = 0.3
     locked = false
+    woken = true
 
     t0 = Time.now
     mutex.synchronize do
       begin
-        condvar.wait(mutex, timeout)
+        woken = condvar.wait(mutex, timeout)
       ensure
         locked = mutex.locked?
       end
@@ -154,6 +157,7 @@ INPUT
 
     assert_operator(timeout*0.9, :<, t)
     assert(locked)
+    assert_nil(woken)
   end
 
   def test_condvar_nolock

--- a/thread.c
+++ b/thread.c
@@ -132,7 +132,7 @@ rb_thread_local_storage(VALUE thread)
     return rb_ivar_get(thread, idLocals);
 }
 
-static void sleep_hrtime(rb_thread_t *, rb_hrtime_t, unsigned int fl);
+static int sleep_hrtime(rb_thread_t *, rb_hrtime_t, unsigned int fl);
 static void sleep_forever(rb_thread_t *th, unsigned int fl);
 static void rb_thread_sleep_deadly_allow_spurious_wakeup(VALUE blocker);
 static int rb_threadptr_dead(rb_thread_t *th);
@@ -1479,7 +1479,7 @@ hrtime_update_expire(rb_hrtime_t *timeout, const rb_hrtime_t end)
 }
 COMPILER_WARNING_POP
 
-static void
+static int
 sleep_hrtime(rb_thread_t *th, rb_hrtime_t rel, unsigned int fl)
 {
     enum rb_thread_status prev_status = th->status;
@@ -1495,8 +1495,10 @@ sleep_hrtime(rb_thread_t *th, rb_hrtime_t rel, unsigned int fl)
 	    break;
 	if (hrtime_update_expire(&rel, end))
 	    break;
+        woke = 1;
     }
     th->status = prev_status;
+    return woke;
 }
 
 void


### PR DESCRIPTION
This was the historical Ruby 1.8 behavior.

This uses @nobu's patch from #2884, but restores backwards compatibility for `Mutex#sleep` to always return the slept time.  It adds `Mutex#sleep_for` that requires a timeout argument and will return nil if the sleep times out.