### PR TITLE
Fix integer/float remainder with infinity argument of opposite sign

### DIFF
--- a/numeric.c
+++ b/numeric.c
@@ -656,6 +656,11 @@ num_remainder(VALUE x, VALUE y)
 	  rb_num_positive_int_p(y)) ||
 	 (rb_num_positive_int_p(x) &&
 	  rb_num_negative_int_p(y)))) {
+        if (RB_TYPE_P(y, T_FLOAT)) {
+            if (isinf(RFLOAT_VALUE(y))) {
+                return x;
+            }
+        }
 	return rb_funcall(z, '-', 1, y);
     }
     return z;
@@ -1151,11 +1156,11 @@ flodivmod(double x, double y, double *divp, double *modp)
 	div = x;
     else {
 	div = (x - mod) / y;
-	if (modp && divp) div = round(div);
+        if (modp && divp) div = round(div);
     }
     if (y*mod < 0) {
-	mod += y;
-	div -= 1.0;
+        mod += y;
+        div -= 1.0;
     }
     if (modp) *modp = mod;
     if (divp) *divp = div;

--- a/test/ruby/test_numeric.rb
+++ b/test/ruby/test_numeric.rb
@@ -384,6 +384,18 @@ class TestNumeric < Test::Unit::TestCase
     end;
   end
 
+  def test_remainder_infinity
+    assert_equal(4, 4.remainder(Float::INFINITY))
+    assert_equal(4, 4.remainder(-Float::INFINITY))
+    assert_equal(-4, -4.remainder(Float::INFINITY))
+    assert_equal(-4, -4.remainder(-Float::INFINITY))
+
+    assert_equal(4.2, 4.2.remainder(Float::INFINITY))
+    assert_equal(4.2, 4.2.remainder(-Float::INFINITY))
+    assert_equal(-4.2, -4.2.remainder(Float::INFINITY))
+    assert_equal(-4.2, -4.2.remainder(-Float::INFINITY))
+  end
+
   def test_comparison_comparable
     bug12864 = '[ruby-core:77713] [Bug #12864]'
 


### PR DESCRIPTION
Previously, the result was incorrect:

```ruby
4.2.divmod(-Float::INFINITY)
Before: => [-1, -Infinity]
After: => [0, 4.2]

4.2.modulo(-Float::INFINITY) # or %
Before: => -Infinity
After: => 4.2

4.2.remainder(-Float::INFINITY)
Before: => NaN
After: => Infinity
```

Fixes [Bug #6120]