### PR TITLE
Test kind of raised error in overtaken cvar tests.

### DIFF
--- a/test/ruby/test_variable.rb
+++ b/test/ruby/test_variable.rb
@@ -95,6 +95,7 @@ class TestVariable < Test::Unit::TestCase
       end
     EORB
 
+    assert_kind_of RuntimeError, error
     assert_equal "class variable @@cvar of TestVariable::Child is overtaken by TestVariable::Parent", error.message
   ensure
     TestVariable.send(:remove_const, :Child) rescue nil
@@ -126,6 +127,7 @@ class TestVariable < Test::Unit::TestCase
       end
     EORB
 
+    assert_kind_of RuntimeError, error
     assert_equal "class variable @@cvar of TestVariable::ParentForModule is overtaken by TestVariable::Mixin", error.message
   ensure
     TestVariable.send(:remove_const, :Mixin) rescue nil


### PR DESCRIPTION
@eileencodes I tried to comment on merged pr or commit, but it is not probably possible. Is there any reason to not test for the actual error kind (klass)? That seems best practice to me.

- original test added in cbc7c1c06145b02b3d887a6fb2c3b6d9e4bb22dd