### PR TITLE
[Doc] Fix multiple `Magic Comments` example

### DIFF
--- a/doc/syntax/comments.rdoc
+++ b/doc/syntax/comments.rdoc
@@ -58,7 +58,7 @@ Magic comments may consist of a single directive (as in the example above).
 Alternatively, multiple directives may appear on the same line if separated by ";"
 and wrapped between "-*-" (see Emacs' {file variables}[https://www.gnu.org/software/emacs/manual/html_node/emacs/Specifying-File-Variables.html]).
 
-  # emacs-compatible; -*- coding: big5; mode: ruby -*-
+  # emacs-compatible; -*- coding: big5; mode: ruby; frozen_string_literal: true -*-
 
   p 'hello'.frozen? # => true
   p 'hello'.encoding # => #<Encoding:Big5>


### PR DESCRIPTION
Just checked following behavior in Ruby 3.0,  not checked in [HEAD](https://github.com/ruby/ruby/tree/07ff1f4b0b040b594a6fec44d9888395343449c6) and not digging implementations 🙇 
Is this correct understanding?

From the current documentation
===

```sh
ruby -v; ruby <<EOF
# emacs-compatible; -*- coding: big5; mode: ruby -*-

p 'hello'.frozen?
p 'hello'.encoding
EOF
```

outputs

```
ruby 3.0.0p0 (2020-12-25 revision 95aff21468) [x86_64-darwin20]
false
#<Encoding:Big5>
```

Changed by this PR
===

```sh
ruby -v; ruby <<EOF
# emacs-compatible; -*- coding: big5; mode: ruby; frozen_string_literal: true -*-

p 'hello'.frozen?
p 'hello'.encoding
EOF
```

outputs 

```
ruby 3.0.0p0 (2020-12-25 revision 95aff21468) [x86_64-darwin20]
true
#<Encoding:Big5>
```