### PR TITLE
Clarify `=` useable cases in `Magic Comments`

### DIFF
--- a/doc/syntax/comments.rdoc
+++ b/doc/syntax/comments.rdoc
@@ -78,6 +78,12 @@ It must appear in the first comment section of a file.
 
 The word "coding" may be used instead of "encoding".
 
+NOTE: "coding" and "encoding" is the only case to be useable <code> = </code> in directives.
+
+  # coding = big5
+
+  ''.encoding # => #<Encoding:Big5>
+
 === +frozen_string_literal+ Directive
 
 Indicates that string literals should be allocated once at parse time and frozen.

--- a/test/ruby/test_parse.rb
+++ b/test/ruby/test_parse.rb
@@ -677,12 +677,36 @@ x = __ENCODING__
     end
     assert_equal(Encoding.find("UTF-8"), x)
 
+    assert_nothing_raised do
+      eval <<-END, nil, __FILE__, __LINE__+1
+# coding: big5
+x = __ENCODING__
+      END
+    end
+    assert_equal(Encoding.find("Big5"), x)
+
     assert_raise(ArgumentError) do
       eval <<-END, nil, __FILE__, __LINE__+1
 # coding = foobarbazquxquux_dummy_enconding
 x = __ENCODING__
       END
     end
+
+    assert_nothing_raised do
+      eval <<-END, nil, __FILE__, __LINE__+1
+# frozen_string_literal: true
+x = ''
+      END
+    end
+    assert_equal(true, x.frozen?)
+
+    assert_nothing_raised do
+      eval <<-END, nil, __FILE__, __LINE__+1
+# frozen_string_literal = true
+x = ''
+      END
+    end
+    assert_equal(false, x.frozen?)
   end
 
   def test_utf8_bom


### PR DESCRIPTION
When I investigating around `Magic Comments` specs.
Learned for the first time `# coding = utf-8` is useable syntax, I didn't know that. 😮 
As far as I know, other directives can't use the style, so noting it might help someone like me. I hope. 🙏 
(Or it should be a deprecated syntax? 🤔 )