### PR TITLE
[Doc] Link to doc/contributing.rdoc from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,5 @@
-Please see the [official issue tracker] and wiki [HowToContribute].
+Please see the [official issue tracker], [contributing.rdoc] and wiki [HowToContribute].
 
 [official issue tracker]: https://bugs.ruby-lang.org
+[contributing.rdoc]: https://github.com/ruby/ruby/blob/master/doc/contributing.rdoc
 [HowToContribute]: https://bugs.ruby-lang.org/projects/ruby/wiki/HowToContribute

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
-Please see the [official issue tracker], [contributing.rdoc] and wiki [HowToContribute].
+Please see the [official issue tracker], [doc/contributing.rdoc] and wiki [HowToContribute].
 
 [official issue tracker]: https://bugs.ruby-lang.org
-[contributing.rdoc]: https://github.com/ruby/ruby/blob/master/doc/contributing.rdoc
+[doc/contributing.rdoc]: https://github.com/ruby/ruby/blob/master/doc/contributing.rdoc
 [HowToContribute]: https://bugs.ruby-lang.org/projects/ruby/wiki/HowToContribute

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 Please see the [official issue tracker], [doc/contributing.rdoc] and wiki [HowToContribute].
 
 [official issue tracker]: https://bugs.ruby-lang.org
-[doc/contributing.rdoc]: https://github.com/ruby/ruby/blob/master/doc/contributing.rdoc
+[doc/contributing.rdoc]: doc/contributing.rdoc
 [HowToContribute]: https://bugs.ruby-lang.org/projects/ruby/wiki/HowToContribute


### PR DESCRIPTION
https://github.com/ruby/ruby/blob/c7e6914b3947cdf0e9c0d28d1162a084d0138887/doc/contributing.rdoc looks the active one of `How to contribute`. So adding link in `CONTRIBUTING.md` might help someone like me 🙏

In my case...
I often forgot `How to test specific test file with the built ruby?`
Nothing in README. And I can't find it in https://bugs.ruby-lang.org/projects/ruby/wiki/HowToContribute

But the rdoc describes as below.

```
This is also how you can run a specific test from our build dir:

make test-all TESTS=drb/test_drb.rb
```

It solved all. ☺️ 

