### PR TITLE
Assert `Array#permutation` arity before to return enumerator

### DIFF
--- a/array.c
+++ b/array.c
@@ -6744,10 +6744,12 @@ rb_ary_permutation(int argc, VALUE *argv, VALUE ary)
 {
     long r, n, i;
 
+    rb_check_arity(argc, 0, 1);
+
     n = RARRAY_LEN(ary);                  /* Array length */
     RETURN_SIZED_ENUMERATOR(ary, argc, argv, rb_ary_permutation_size);   /* Return enumerator if no block */
     r = n;
-    if (rb_check_arity(argc, 0, 1) && !NIL_P(argv[0]))
+    if (argc > 0 && !NIL_P(argv[0]))
         r = NUM2LONG(argv[0]);            /* Permutation size from argument */
 
     if (r < 0 || n < r) {

--- a/test/ruby/test_array.rb
+++ b/test/ruby/test_array.rb
@@ -2251,6 +2251,12 @@ class TestArray < Test::Unit::TestCase
     assert_equal("abcde".each_char.to_a.permutation(5).sort,
                  "edcba".each_char.to_a.permutation(5).sort)
     assert_equal(@cls[].permutation(0).to_a, @cls[[]])
+    assert_raise_with_message(ArgumentError, /wrong number of arguments/) do
+      a.permutation(0, 0)
+    end
+    assert_raise_with_message(ArgumentError, /wrong number of arguments/) do
+      a.permutation(0, 0) {}
+    end
 
     a = @cls[1, 2, 3, 4]
     b = @cls[]


### PR DESCRIPTION
```console
$ ruby -v
ruby 3.0.0p0 (2020-12-25 revision 95aff21468) [x86_64-darwin20]
```

```console
$ ruby -e 'p [].permutation(1, 3)'
#<Enumerator: []:permutation(1, 3)>
$ ruby -e 'p [].permutation(1, 3).to_a'
-e:1:in `permutation': wrong number of arguments (given 2, expected 0..1) (ArgumentError)
```

Not that I know of this lazy arity checking makes pleasure. 🤔 
In the other hand `Array#cycle` behavior looks expected to me.

```console
$ ruby -e 'p [].cycle(1, 3)'
-e:1:in `cycle': wrong number of arguments (given 2, expected 0..1) (ArgumentError)
$ ruby -e 'p [].cycle(1, 3) {}'
-e:1:in `cycle': wrong number of arguments (given 2, expected 0..1) (ArgumentError)
```

Is this an intentional behavior?

ref: https://bugs.ruby-lang.org/issues/17737