### PR TITLE
Implement interruptible getaddrinfo

### DIFF
--- a/ext/socket/raddrinfo.c
+++ b/ext/socket/raddrinfo.c
@@ -180,6 +180,8 @@ struct getaddrinfo_arg
     const char *service;
     const struct addrinfo *hints;
     struct addrinfo **res;
+    VALUE queue;
+    int ret;
 };
 
 static void *
@@ -198,6 +200,57 @@ nogvl_getaddrinfo(void *arg)
     return (void *)(VALUE)ret;
 }
 #endif
+
+VALUE getaddrinfo_queue;
+
+static void
+getaddrinfo_arg_mark(void *ptr)
+{
+    struct getaddrinfo_arg *arg = (struct getaddrinfo_arg *)ptr;
+    rb_gc_mark(arg->queue);
+}
+
+static void
+getaddrinfo_arg_free(void *ptr)
+{
+    struct getaddrinfo_arg *arg = (struct getaddrinfo_arg *)ptr;
+    ruby_xfree(arg);
+}
+
+static size_t
+getaddrinfo_arg_memsize(const void *ptr)
+{
+    return sizeof(struct getaddrinfo_arg);
+}
+
+static const rb_data_type_t getaddrinfo_arg_data_type = {
+    "socket/getaddrinfo_arg",
+    {getaddrinfo_arg_mark, getaddrinfo_arg_free, getaddrinfo_arg_memsize,},
+};
+
+static VALUE
+push_getaddrinfo_result(VALUE arg)
+{
+    struct getaddrinfo_arg *ptr = (struct getaddrinfo_arg *)arg;
+    return rb_queue_push(ptr->queue, INT2FIX(ptr->ret));
+}
+
+static VALUE
+start_getaddrinfo(void *unused)
+{
+    struct getaddrinfo_arg *ptr;
+    VALUE arg_wrapper;
+
+    while (NUM2INT(rb_szqueue_num_waiting(getaddrinfo_queue)) == 0) {
+        arg_wrapper = rb_szqueue_pop(0, NULL, getaddrinfo_queue);
+        if (NIL_P(arg_wrapper)) { break; }
+        TypedData_Get_Struct(arg_wrapper, struct getaddrinfo_arg, &getaddrinfo_arg_data_type, ptr);
+        ptr->ret = (int)(VALUE)rb_thread_call_without_gvl(nogvl_getaddrinfo, ptr, RUBY_UBF_IO, 0);
+        rb_protect(push_getaddrinfo_result, (VALUE)ptr, NULL);
+    }
+
+    return Qnil;
+}
 
 static int
 numeric_getaddrinfo(const char *node, const char *service,
@@ -300,13 +353,19 @@ rb_getaddrinfo(const char *node, const char *service,
 #ifdef GETADDRINFO_EMU
         ret = getaddrinfo(node, service, hints, &ai);
 #else
-        struct getaddrinfo_arg arg;
-        MEMZERO(&arg, struct getaddrinfo_arg, 1);
-        arg.node = node;
-        arg.service = service;
-        arg.hints = hints;
-        arg.res = &ai;
-        ret = (int)(VALUE)rb_thread_call_without_gvl(nogvl_getaddrinfo, &arg, RUBY_UBF_IO, 0);
+        struct getaddrinfo_arg *ptr;
+        VALUE arg_wrapper = TypedData_Make_Struct(0, struct getaddrinfo_arg, &getaddrinfo_arg_data_type, ptr);
+        MEMZERO(ptr, struct getaddrinfo_arg, 1);
+        ptr->node = node;
+        ptr->service = service;
+        ptr->hints = hints;
+        ptr->res = &ai;
+        ptr->queue = rb_queue_new();
+        rb_szqueue_push(1, &arg_wrapper, getaddrinfo_queue);
+        if (NUM2INT(rb_szqueue_num_waiting(getaddrinfo_queue)) == 0) {
+            rb_thread_create(start_getaddrinfo, NULL);
+        }
+        ret = FIX2INT(rb_queue_pop(0, NULL, ptr->queue));
 #endif
     }
 
@@ -2567,6 +2626,8 @@ rsock_init_addrinfo(void)
      * structure identifies an Internet host and a service.
      */
     id_timeout = rb_intern("timeout");
+    getaddrinfo_queue = rb_szqueue_new(20); // same as maximal number of threads in getaddrinfo_a(3)
+    rb_gc_register_mark_object(getaddrinfo_queue);
 
     rb_cAddrinfo = rb_define_class("Addrinfo", rb_cObject);
     rb_define_alloc_func(rb_cAddrinfo, addrinfo_s_allocate);

--- a/include/ruby/internal/intern/thread.h
+++ b/include/ruby/internal/intern/thread.h
@@ -71,6 +71,15 @@ VALUE rb_mutex_unlock(VALUE mutex);
 VALUE rb_mutex_sleep(VALUE self, VALUE timeout);
 VALUE rb_mutex_synchronize(VALUE mutex, VALUE (*func)(VALUE arg), VALUE arg);
 
+VALUE rb_queue_new(void);
+VALUE rb_queue_push(VALUE self, VALUE obj);
+VALUE rb_queue_pop(int argc, VALUE *argv, VALUE self);
+
+VALUE rb_szqueue_new(long max);
+VALUE rb_szqueue_push(int argc, VALUE *argv, VALUE self);
+VALUE rb_szqueue_pop(int argc, VALUE *argv, VALUE self);
+VALUE rb_szqueue_num_waiting(VALUE self);
+
 RBIMPL_SYMBOL_EXPORT_END()
 
 #endif /* RBIMPL_INTERN_THREAD_H */


### PR DESCRIPTION
Addrinfo.getaddrinfo (and other methods using getaddrinfo(3)) was not
interruptible because it is blocked on C level.
This change makes those methods interruptible by using Thread and Queue.