### PR TITLE
Remove unused rb_ast_parse_array definiation

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -66,7 +66,6 @@ ast_new_internal(rb_ast_t *ast, const NODE *node)
 
 static VALUE rb_ast_parse_str(VALUE str);
 static VALUE rb_ast_parse_file(VALUE path);
-static VALUE rb_ast_parse_array(VALUE array);
 
 static VALUE
 ast_parse_new(void)


### PR DESCRIPTION
Remove unused `rb_ast_parse_array` definiation in `ast.c`