### PR TITLE
Move rb_int_coerce

### DIFF
--- a/bignum.c
+++ b/bignum.c
@@ -6728,33 +6728,6 @@ rb_big_hash(VALUE x)
     return ST2FIX(hash);
 }
 
-/*
- * call-seq:
- *   big.coerce(numeric)  ->  array
- *
- * Returns an array with both a +numeric+ and a +big+ represented as Bignum
- * objects.
- *
- * This is achieved by converting +numeric+ to a Bignum.
- *
- * A TypeError is raised if the +numeric+ is not a Fixnum or Bignum type.
- *
- *     (0x3FFFFFFFFFFFFFFF+1).coerce(42)   #=> [42, 4611686018427387904]
- */
-
-static VALUE
-rb_int_coerce(VALUE x, VALUE y)
-{
-    if (RB_INTEGER_TYPE_P(y)) {
-        return rb_assoc_new(y, x);
-    }
-    else {
-        x = rb_Float(x);
-        y = rb_Float(y);
-        return rb_assoc_new(y, x);
-    }
-}
-
 VALUE
 rb_big_abs(VALUE x)
 {
@@ -7177,8 +7150,6 @@ Init_Bignum(void)
     /* An obsolete class, use Integer */
     rb_define_const(rb_cObject, "Bignum", rb_cInteger);
     rb_deprecate_constant(rb_cObject, "Bignum");
-
-    rb_define_method(rb_cInteger, "coerce", rb_int_coerce, 1);
 
 #ifdef USE_GMP
     /* The version of loaded GMP. */

--- a/numeric.c
+++ b/numeric.c
@@ -4280,6 +4280,33 @@ rb_num_coerce_bit(VALUE x, VALUE y, ID func)
 }
 
 /*
+ * call-seq:
+ *   big.coerce(numeric)  ->  array
+ *
+ * Returns an array with both a +numeric+ and a +big+ represented as Bignum
+ * objects.
+ *
+ * This is achieved by converting +numeric+ to a Bignum.
+ *
+ * A TypeError is raised if the +numeric+ is not a Fixnum or Bignum type.
+ *
+ *     (0x3FFFFFFFFFFFFFFF+1).coerce(42)   #=> [42, 4611686018427387904]
+ */
+
+static VALUE
+rb_int_coerce(VALUE x, VALUE y)
+{
+    if (RB_INTEGER_TYPE_P(y)) {
+        return rb_assoc_new(y, x);
+    }
+    else {
+        x = rb_Float(x);
+        y = rb_Float(y);
+        return rb_assoc_new(y, x);
+    }
+}
+
+/*
  * Document-method: Integer#&
  * call-seq:
  *   int & other_int  ->  integer
@@ -5436,6 +5463,7 @@ Init_Numeric(void)
     rb_define_method(rb_cInteger, ">=", rb_int_ge, 1);
     rb_define_method(rb_cInteger, "<", int_lt, 1);
     rb_define_method(rb_cInteger, "<=", int_le, 1);
+    rb_define_method(rb_cInteger, "coerce", rb_int_coerce, 1);
 
     rb_define_method(rb_cInteger, "&", rb_int_and, 1);
     rb_define_method(rb_cInteger, "|", int_or,  1);

--- a/numeric.c
+++ b/numeric.c
@@ -4281,14 +4281,13 @@ rb_num_coerce_bit(VALUE x, VALUE y, ID func)
 
 /*
  * call-seq:
- *   big.coerce(numeric)  ->  array
+ *   int.coerce(numeric)  ->  array
  *
- * Returns an array with both a +numeric+ and a +big+ represented as Bignum
+ * Returns an array with both a +numeric+ and a +int+ represented as Integer or Float
  * objects.
  *
- * This is achieved by converting +numeric+ to a Bignum.
  *
- * A TypeError is raised if the +numeric+ is not a Fixnum or Bignum type.
+ * A TypeError is raised if the +numeric+ is not a Integer type.
  *
  *     (0x3FFFFFFFFFFFFFFF+1).coerce(42)   #=> [42, 4611686018427387904]
  */


### PR DESCRIPTION
defined `Integer#coerce` in `bingnum.c`, but I think that better defined in `numeric.c`.