### PR TITLE
Improve Enumerable#tally performance

### DIFF
--- a/benchmark/enum_tally.yml
+++ b/benchmark/enum_tally.yml
@@ -1,0 +1,4 @@
+prelude: |
+  list = ("aaa".."zzz").to_a*10
+benchmark:
+  tally: list.tally


### PR DESCRIPTION
Iteration per second (i/s)

|       |compare-ruby|built-ruby|
|:------|-----------:|---------:|
|tally  |      52.814|   114.936|
|       |           -|     2.18x|