### PR TITLE
Refactor "defined" strings to be embedded in instruction sequences

### DIFF
--- a/insns.def
+++ b/insns.def
@@ -667,7 +667,7 @@ defined
 (VALUE val)
 // attr bool leaf = leafness_of_defined(op_type);
 {
-    if (vm_defined(ec, GET_CFP(), op_type, obj, Qfalse, v)) {
+    if (vm_defined(ec, GET_CFP(), op_type, obj, v)) {
       val = needstr;
     }
     else {

--- a/insns.def
+++ b/insns.def
@@ -662,14 +662,14 @@ adjuststack
 /* defined? */
 DEFINE_INSN
 defined
-(rb_num_t op_type, VALUE obj, VALUE needstr)
+(rb_num_t op_type, VALUE obj, VALUE pushval)
 (VALUE v)
 (VALUE val)
 // attr bool leaf = leafness_of_defined(op_type);
 {
     val = Qnil;
     if (vm_defined(ec, GET_CFP(), op_type, obj, v)) {
-      val = needstr;
+      val = pushval;
     }
 }
 

--- a/insns.def
+++ b/insns.def
@@ -667,7 +667,12 @@ defined
 (VALUE val)
 // attr bool leaf = leafness_of_defined(op_type);
 {
-    val = vm_defined(ec, GET_CFP(), op_type, obj, needstr, v);
+    if (vm_defined(ec, GET_CFP(), op_type, obj, Qfalse, v)) {
+      val = needstr;
+    }
+    else {
+      val = Qnil;
+    }
 }
 
 /* check `target' matches `pattern'.

--- a/insns.def
+++ b/insns.def
@@ -667,11 +667,9 @@ defined
 (VALUE val)
 // attr bool leaf = leafness_of_defined(op_type);
 {
+    val = Qnil;
     if (vm_defined(ec, GET_CFP(), op_type, obj, v)) {
       val = needstr;
-    }
-    else {
-      val = Qnil;
     }
 }
 

--- a/iseq.c
+++ b/iseq.c
@@ -3103,24 +3103,10 @@ rb_iseq_defined_string(enum defined_type type)
 	"expression",
     };
     const char *estr;
-    VALUE *defs, str;
 
     if ((unsigned)(type - 1) >= (unsigned)numberof(expr_names)) rb_bug("unknown defined type %d", type);
     estr = expr_names[type - 1];
-    if (!estr[0]) return 0;
-    defs = GET_VM()->defined_strings;
-    if (!defs) {
-	defs = ruby_xcalloc(numberof(expr_names), sizeof(VALUE));
-	GET_VM()->defined_strings = defs;
-    }
-    str = defs[type-1];
-    if (!str) {
-	str = rb_str_new_cstr(estr);
-	OBJ_FREEZE(str);
-	defs[type-1] = str;
-	rb_gc_register_mark_object(str);
-    }
-    return str;
+    return rb_fstring_cstr(estr);
 }
 
 /* A map from encoded_insn to insn_data: decoded insn number, its len,

--- a/iseq.c
+++ b/iseq.c
@@ -3105,7 +3105,7 @@ rb_iseq_defined_string(enum defined_type type)
     const char *estr;
     VALUE *defs, str;
 
-    if ((unsigned)(type - 1) >= (unsigned)numberof(expr_names)) return 0;
+    if ((unsigned)(type - 1) >= (unsigned)numberof(expr_names)) rb_bug("unknown defined type %d", type);
     estr = expr_names[type - 1];
     if (!estr[0]) return 0;
     defs = GET_VM()->defined_strings;

--- a/vm.c
+++ b/vm.c
@@ -2677,15 +2677,11 @@ ruby_vm_destruct(rb_vm_t *vm)
 static size_t
 vm_memsize(const void *ptr)
 {
-    const rb_vm_t *vmobj = ptr;
     size_t size = sizeof(rb_vm_t);
 
     // TODO
     // size += vmobj->ractor_num * sizeof(rb_ractor_t);
 
-    if (vmobj->defined_strings) {
-	size += DEFINED_EXPR * sizeof(VALUE);
-    }
     return size;
 }
 

--- a/vm_core.h
+++ b/vm_core.h
@@ -650,7 +650,6 @@ typedef struct rb_vm_struct {
 
     rb_at_exit_list *at_exit;
 
-    VALUE *defined_strings;
     st_table *frozen_strings;
 
     const struct rb_builtin_function *builtin_function_table;

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -3969,7 +3969,7 @@ vm_once_clear(VALUE data)
 
 /* defined insn */
 
-static VALUE
+static bool
 check_respond_to_missing(VALUE obj, VALUE v)
 {
     VALUE args[2];
@@ -3978,14 +3978,14 @@ check_respond_to_missing(VALUE obj, VALUE v)
     args[0] = obj; args[1] = Qfalse;
     r = rb_check_funcall(v, idRespond_to_missing, 2, args);
     if (r != Qundef && RTEST(r)) {
-	return Qtrue;
+	return true;
     }
     else {
-	return Qfalse;
+	return false;
     }
 }
 
-static VALUE
+static bool
 vm_defined(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, rb_num_t op_type, VALUE obj, VALUE v)
 {
     VALUE klass;
@@ -4028,7 +4028,7 @@ vm_defined(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, rb_num_t op_
 		    break;
 		}
 	      case METHOD_VISI_PUBLIC:
-                return Qtrue;
+                return true;
 		break;
 	      default:
 		rb_bug("vm_defined: unreachable: %u", (unsigned int)METHOD_ENTRY_VISI(me));
@@ -4041,7 +4041,7 @@ vm_defined(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, rb_num_t op_
       }
       case DEFINED_YIELD:
 	if (GET_BLOCK_HANDLER() != VM_BLOCK_HANDLER_NONE) {
-            return Qtrue;
+            return true;
 	}
 	break;
       case DEFINED_ZSUPER:
@@ -4065,7 +4065,7 @@ vm_defined(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, rb_num_t op_
 	break;
     }
 
-    return Qfalse;
+    return false;
 }
 
 static const VALUE *

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -3986,7 +3986,7 @@ check_respond_to_missing(VALUE obj, VALUE v)
 }
 
 static VALUE
-vm_defined(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, rb_num_t op_type, VALUE obj, VALUE needstr, VALUE v)
+vm_defined(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, rb_num_t op_type, VALUE obj, VALUE v)
 {
     VALUE klass;
     enum defined_type expr_type = DEFINED_NOT_DEFINED;
@@ -4081,15 +4081,10 @@ vm_defined(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, rb_num_t op_
     }
 
     if (expr_type != 0) {
-	if (needstr != Qfalse) {
-	    return rb_iseq_defined_string(expr_type);
-	}
-	else {
-	    return Qtrue;
-	}
+        return Qtrue;
     }
     else {
-	return Qnil;
+	return Qfalse;
     }
 }
 


### PR DESCRIPTION
This PR refactors "defined" strings to be embedded in instruction sequences rather than stored on the VM.  We can know the required string at compile time, then embed the string in the instruction sequences.  This means we can eliminate the string table `defined_strings` from the VM.

For this test program:

```ruby
def check_ivar
  puts defined?(@foo)
end

puts RubyVM::InstructionSequence.disasm(method(:check_ivar))
```

Here are the iseqs before:

```
$ ruby -v test.rb
ruby 3.1.0dev (2021-03-16T19:10:11Z master 58660e9434) [x86_64-darwin20]
== disasm: #<ISeq:check_ivar@test.rb:1 (1,0)-(3,3)> (catch: FALSE)
0000 putself                                                          (   2)[LiCa]
0001 putnil
0002 defined                                instance-variable, :@foo, true
0006 opt_send_without_block                 <calldata!mid:puts, argc:1, FCALL|ARGS_SIMPLE>
0008 leave                                                            (   3)[Re]
```

Here are the iseqs after:

```
$ ./ruby -v test.rb
ruby 3.1.0dev (2021-03-16T22:30:47Z refactor-defined df289a0a5e) [x86_64-darwin20]
== disasm: #<ISeq:check_ivar@test.rb:1 (1,0)-(3,3)> (catch: FALSE)
0000 putself                                                          (   2)[LiCa]
0001 putnil
0002 defined                                instance-variable, :@foo, "instance-variable"
0006 opt_send_without_block                 <calldata!mid:puts, argc:1, FCALL|ARGS_SIMPLE>
0008 leave                                                            (   3)[Re]
```

The string `"instance-variable"` is now embedded in the instructions.  If the instance variable is defined, we push that string on the stack.