### PR TITLE
Issue deprecation warning in Hash#shift if hash empty and default value is not nil

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -2469,7 +2469,12 @@ rb_hash_shift(VALUE hash)
 	    }
 	}
     }
-    return rb_hash_default_value(hash, Qnil);
+
+    VALUE ret = rb_hash_default_value(hash, Qnil);
+    if (ret != Qnil) {
+        rb_warn_deprecated("Hash#shift returning default value for empty hash", NULL);
+    }
+    return ret;
 }
 
 static int

--- a/test/ruby/test_hash.rb
+++ b/test/ruby/test_hash.rb
@@ -764,6 +764,25 @@ class TestHash < Test::Unit::TestCase
     assert_equal(0, h.length)
   end
 
+  def test_shift_empty
+    h = {}
+    assert_deprecated_warning('') do
+      assert_equal(nil, {}.shift)
+      assert_equal(nil, Hash.new(nil).shift)
+      assert_equal(nil, Hash.new{nil}.shift)
+    end
+
+    h = Hash.new(1)
+    assert_deprecated_warning(/Hash#shift returning default value for empty hash is deprecated/) do
+      assert_equal(1, h.shift)
+    end
+
+    h = Hash.new{|_,k| [k, 1]}
+    assert_deprecated_warning(/Hash#shift returning default value for empty hash is deprecated/) do
+      assert_equal([nil, 1], h.shift)
+    end
+  end
+
   def test_size
     assert_equal(0, @cls[].length)
     assert_equal(7, @h.length)


### PR DESCRIPTION
This behavior should change in a later version of Ruby to always
return nil (probably in 3.2).  However, it's best to warn now so
that users can fix their code.

Fixes [Bug #16908]

Note that @akr was against a warning in the developer meeting,
but since this is a type of deprecation, I think a deprecation
warning should be added.  Deprecation warnings are not shown
by default, so the warnings won't be shown unless Ruby is set to
display deprecation warnings.