### PR TITLE
net/http: No need to use a Windows-31J encoded regexp to strip the Host

### DIFF
--- a/lib/net/http/generic_request.rb
+++ b/lib/net/http/generic_request.rb
@@ -143,7 +143,7 @@ class Net::HTTPGenericRequest
     end
 
     if host = self['host']
-      host.sub!(/:.*/s, ''.freeze)
+      host.sub!(/:.*/, ''.freeze)
     elsif host = @uri.host
     else
      host = addr


### PR DESCRIPTION
I noticed this regexp because of the crash reported in https://github.com/ruby/ruby/pull/4119#issuecomment-800189841

It was introduced by @nurse in https://github.com/ruby/ruby/commit/c1652035644, but I don't see any reason to set a `Windows-31J` encoding on this regexp.

It's probably not a big deal, but I'm thinking we might as well use a default `US-ASCII`.

cc @XrXr @tenderlove 