### PR TITLE
rb_enc_interned_str: handle autoloaded encodings

### DIFF
--- a/ext/-test-/string/depend
+++ b/ext/-test-/string/depend
@@ -1000,6 +1000,7 @@ fstring.o: $(hdrdir)/ruby/backward/2/long_long.h
 fstring.o: $(hdrdir)/ruby/backward/2/stdalign.h
 fstring.o: $(hdrdir)/ruby/backward/2/stdarg.h
 fstring.o: $(hdrdir)/ruby/defines.h
+fstring.o: $(hdrdir)/ruby/encoding.h
 fstring.o: $(hdrdir)/ruby/intern.h
 fstring.o: $(hdrdir)/ruby/internal/anyargs.h
 fstring.o: $(hdrdir)/ruby/internal/arithmetic.h
@@ -1142,6 +1143,8 @@ fstring.o: $(hdrdir)/ruby/internal/variable.h
 fstring.o: $(hdrdir)/ruby/internal/warning_push.h
 fstring.o: $(hdrdir)/ruby/internal/xmalloc.h
 fstring.o: $(hdrdir)/ruby/missing.h
+fstring.o: $(hdrdir)/ruby/onigmo.h
+fstring.o: $(hdrdir)/ruby/oniguruma.h
 fstring.o: $(hdrdir)/ruby/ruby.h
 fstring.o: $(hdrdir)/ruby/st.h
 fstring.o: $(hdrdir)/ruby/subst.h

--- a/ext/-test-/string/fstring.c
+++ b/ext/-test-/string/fstring.c
@@ -1,4 +1,5 @@
 #include "ruby.h"
+#include "ruby/encoding.h"
 
 VALUE rb_fstring(VALUE str);
 
@@ -8,8 +9,22 @@ bug_s_fstring(VALUE self, VALUE str)
     return rb_fstring(str);
 }
 
+VALUE
+bug_s_rb_enc_interned_str(VALUE self, VALUE encoding)
+{
+    return rb_enc_interned_str("foo", 3, RDATA(encoding)->data);
+}
+
+VALUE
+bug_s_rb_enc_str_new(VALUE self, VALUE encoding)
+{
+    return rb_enc_str_new("foo", 3, RDATA(encoding)->data);
+}
+
 void
 Init_string_fstring(VALUE klass)
 {
     rb_define_singleton_method(klass, "fstring", bug_s_fstring, 1);
+    rb_define_singleton_method(klass, "rb_enc_interned_str", bug_s_rb_enc_interned_str, 1);
+    rb_define_singleton_method(klass, "rb_enc_str_new", bug_s_rb_enc_str_new, 1);
 }

--- a/internal/encoding.h
+++ b/internal/encoding.h
@@ -12,12 +12,15 @@
 #include "ruby/ruby.h"          /* for ID */
 #include "ruby/encoding.h"      /* for rb_encoding */
 
+#define rb_enc_autoload_p(enc) (!rb_enc_mbmaxlen(enc))
+
 /* encoding.c */
 ID rb_id_encoding(void);
 rb_encoding *rb_enc_get_from_index(int index);
 rb_encoding *rb_enc_check_str(VALUE str1, VALUE str2);
 int rb_encdb_replicate(const char *alias, const char *orig);
 int rb_encdb_alias(const char *alias, const char *orig);
+int rb_enc_autoload(rb_encoding *enc);
 int rb_encdb_dummy(const char *name);
 void rb_encdb_declare(const char *name);
 void rb_enc_set_base(const char *name, const char *orig);

--- a/string.c
+++ b/string.c
@@ -11498,6 +11498,10 @@ rb_interned_str_cstr(const char *ptr)
 VALUE
 rb_enc_interned_str(const char *ptr, long len, rb_encoding *enc)
 {
+    if (UNLIKELY(rb_enc_autoload_p(enc))) {
+        rb_enc_autoload(enc);
+    }
+
     struct RString fake_str;
     return register_fstring(rb_setup_fake_str(&fake_str, ptr, len, enc), TRUE);
 }

--- a/test/-ext-/string/test_fstring.rb
+++ b/test/-ext-/string/test_fstring.rb
@@ -12,6 +12,22 @@ class Test_String_Fstring < Test::Unit::TestCase
     yield fstr
   end
 
+  def test_rb_enc_interned_str_autoloaded_encoding
+    assert_separately([], <<~RUBY)
+      require '-test-/string'
+      assert_include(Encoding::Windows_31J.inspect, 'autoload')
+      Bug::String.rb_enc_interned_str(Encoding::Windows_31J)
+    RUBY
+  end
+
+  def test_rb_enc_str_new_autoloaded_encoding
+    assert_separately([], <<~RUBY)
+      require '-test-/string'
+      assert_include(Encoding::Windows_31J.inspect, 'autoload')
+      Bug::String.rb_enc_str_new(Encoding::Windows_31J)
+    RUBY
+  end
+
   def test_instance_variable
     str = __method__.to_s * 3
     str.instance_variable_set(:@test, 42)


### PR DESCRIPTION
Redmine ticket: https://bugs.ruby-lang.org/issues/17732
Ref: https://github.com/ruby/ruby/pull/3586

If called with an autoloaded encoding that was not yet
initialized, `rb_enc_interned_str` would crash with
a NULL pointer exception.

See: https://github.com/ruby/ruby/pull/4119#issuecomment-800189841

I believe this fix should be backported to Ruby 3.0, I'll open an issue on Redmine.

cc @yahonda @XrXr @tenderlove @ko1 