### PR TITLE
Make exception raised in ensure not caught by rescue prior to ensure

### DIFF
--- a/test/ruby/test_exception.rb
+++ b/test/ruby/test_exception.rb
@@ -78,6 +78,35 @@ class TestException < Test::Unit::TestCase
     assert(!bad)
   end
 
+  def test_exception_in_ensure_with_next
+    string = "[ruby-core:82936] [Bug #13930]"
+    assert_raise_with_message(RuntimeError, string) do
+      lambda do
+        next
+      rescue
+        assert(false)
+      ensure
+        raise string
+      end.call
+      assert(false)
+    end
+  end
+
+  def test_exception_in_ensure_with_return
+    @string = "[ruby-core:97104] [Bug #16618]"
+    def self.meow
+      return
+      assert(false)
+    rescue
+      assert(false)
+    ensure
+      raise @string
+    end
+    assert_raise_with_message(RuntimeError, @string) do
+      meow
+    end
+  end
+
   def test_errinfo_in_debug
     bug9568 = EnvUtil.labeled_class("[ruby-core:61091] [Bug #9568]", RuntimeError) do
       def to_s


### PR DESCRIPTION
In certain circumstances, such as when next/return/break/redo is used
in a begin block where there is a rescue block and an ensure block,
the rescue catch entry range will be miscalculated to include the
ensure block.  This commit checks for cases where both a rescue
catch entry and ensure catch entry are used.  If both have the same
starting position, but the rescue end position is after the ensure
end position, this makes the rescue end position the same as the
ensure end position.

This also fixes the related issue that if an exception is raised in
ensure will result in the ensure block being called twice.

This seems to fix the related code, but there is probably a better
way to fix it that involves calculating the correct positions up
front, instead of trying to recognize incorrect positions and fix
them later.  Unfortunately, my knowledge of the compiler is too
limited to fix this in a better way.

This probably doesn't catch all cases, and there may be cases
where this change causes problems.  I've limited the adjustment to
only those catch tables with a single rescue entry, as having it
affect catch tables with multiple rescue entries resulted in two
failures in the rubygems tests, though all other tests passes, as
well as rubyspec, bundled gems, and bundler tests passing.

Fixes [Bug #13930]
Fixes [Bug #16618]