### PR TITLE
[Doc] Add Hash#value? into call-seq

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -3651,6 +3651,9 @@ rb_hash_search_value(VALUE key, VALUE value, VALUE arg)
 /*
  *  call-seq:
  *    hash.has_value?(value) -> true or false
+ *    hash.value?(value) -> true or false
+ *
+ *  Method #value? is an alias for \#has_value?.
  *
  *  Returns +true+ if +value+ is a value in +self+, otherwise +false+.
  */


### PR DESCRIPTION
Because `Hash#include?`,  `Hash#has_key?`, `Hash#key?`, `Hash#member?` has the description in call-seq

https://github.com/ruby/ruby/blob/2d6617d32787a7815a699e5d991fc6a445c0c4d4/hash.c#L3616-L3626