### PR TITLE
Keep non evaluated keys in `Hash#transform_keys!`

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -3260,8 +3260,8 @@ rb_hash_transform_keys_bang(int argc, VALUE *argv, VALUE hash)
     rb_hash_modify_check(hash);
     if (!RHASH_TABLE_EMPTY_P(hash)) {
         long i;
+        VALUE new_keys = hash_alloc(0);
         VALUE pairs = rb_hash_flatten(0, NULL, hash);
-        rb_hash_clear(hash);
         for (i = 0; i < RARRAY_LEN(pairs); i += 2) {
             VALUE key = RARRAY_AREF(pairs, i), new_key, val;
 
@@ -3278,7 +3278,11 @@ rb_hash_transform_keys_bang(int argc, VALUE *argv, VALUE hash)
                 new_key = key;
             }
             val = RARRAY_AREF(pairs, i+1);
+            if (!hash_stlike_lookup(new_keys, key, NULL)) {
+                rb_hash_stlike_delete(hash, &key, NULL);
+            }
             rb_hash_aset(hash, new_key, val);
+            rb_hash_aset(new_keys, new_key, Qnil);
         }
     }
     return hash;

--- a/spec/ruby/core/hash/transform_keys_spec.rb
+++ b/spec/ruby/core/hash/transform_keys_spec.rb
@@ -84,13 +84,23 @@ describe "Hash#transform_keys!" do
     end
   end
 
-  ruby_version_is "2.5.1" do
+  ruby_version_is "2.5.1"..."3.1" do
     it "returns the processed keys if we broke from the block" do
       @hash.transform_keys! do |v|
         break if v == :c
         v.succ
       end
       @hash.should == { b: 1, c: 2 }
+    end
+  end
+
+  ruby_version_is "3.1" do
+    it "returns the processed keys and non evaluated keys if we broke from the block" do
+      @hash.transform_keys! do |v|
+        break if v == :c
+        v.succ
+      end
+      @hash.should == { b: 1, c: 2, d: 4 }
     end
   end
 

--- a/test/ruby/test_hash.rb
+++ b/test/ruby/test_hash.rb
@@ -1695,6 +1695,10 @@ class TestHash < Test::Unit::TestCase
     x.transform_keys! {|k| -k }
     assert_equal([-1, :a, 1, :b], x.flatten)
 
+    x = @cls[a: 1, b: 2, c: 3]
+    x.transform_keys! { |k| k == :b && break }
+    assert_equal({false => 1, b: 2, c: 3}, x)
+
     x = @cls[true => :a, false => :b]
     x.transform_keys! {|k| !k }
     assert_equal([false, :a, true, :b], x.flatten)
@@ -1729,6 +1733,10 @@ class TestHash < Test::Unit::TestCase
     y = x.transform_values! {|v| v ** 2 }
     assert_equal([1, 4, 9], y.values_at(:a, :b, :c))
     assert_same(x, y)
+
+    x = @cls[a: 1, b: 2, c: 3]
+    x.transform_values! { |v| v == 2 && break }
+    assert_equal({a: false, b: 2, c: 3}, x)
 
     x = @cls[a: 1, b: 2, c: 3]
     y = x.transform_values!.with_index {|v, i| "#{v}.#{i}" }


### PR DESCRIPTION
```ruby
hash = {a: 1, b: 2, c: 3}
hash.transform_values!(){ raise } rescue
p hash #=> {:a=>1, :b=>2, :c=>3}
```

```ruby
hash = {a: 1, b: 2, c: 3}
hash.transform_keys!(){ raise } rescue
p hash #=> {}
```

Is this an intentional behavior?
I expected behavior like `transform_values!` in `transform_keys!` (Keeping non evaluated key-value pairs when exiting the block).

`ruby -v`: `ruby 3.0.0p0 (2020-12-25 revision 95aff21468) [x86_64-darwin20]`

ref: https://bugs.ruby-lang.org/issues/17735