### PR TITLE
Hash#{update, merge!} ensure the receiver modifiable [Bug #17736]

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -1039,6 +1039,7 @@ ar_update(VALUE hash, st_data_t key,
     }
     old_key = key;
     retval = (*func)(&key, &value, arg, existing);
+    rb_hash_modify(hash);
     /* pair can be invalid here because of theap */
 
     switch (retval) {
@@ -1631,7 +1632,7 @@ rb_hash_tbl(VALUE hash, const char *file, int line)
     return rb_hash_tbl_raw(hash, file, line);
 }
 
-static void
+void
 rb_hash_modify(VALUE hash)
 {
     rb_hash_modify_check(hash);

--- a/include/ruby/internal/intern/hash.h
+++ b/include/ruby/internal/intern/hash.h
@@ -35,6 +35,7 @@ VALUE rb_hash(VALUE);
 VALUE rb_hash_new(void);
 VALUE rb_hash_dup(VALUE);
 VALUE rb_hash_freeze(VALUE);
+void rb_hash_modify(VALUE);
 VALUE rb_hash_aref(VALUE, VALUE);
 VALUE rb_hash_lookup(VALUE, VALUE);
 VALUE rb_hash_lookup2(VALUE, VALUE, VALUE);

--- a/test/ruby/test_hash.rb
+++ b/test/ruby/test_hash.rb
@@ -1232,6 +1232,14 @@ class TestHash < Test::Unit::TestCase
     assert_equal({1=>8, 2=>4, 3=>4, 5=>7}, h1)
   end
 
+  def test_update5
+    h = @cls[a: 1, b: 2, c: 3]
+    assert_raise(FrozenError) do
+      h.update({a: 10, b: 20}){ |key, v1, v2| key == :b && h.freeze; v2 }
+    end
+    assert_equal(@cls[a: 10, b: 2, c: 3], h)
+  end
+
   def test_merge
     h1 = @cls[1=>2, 3=>4]
     h2 = {1=>3, 5=>7}
@@ -1241,6 +1249,14 @@ class TestHash < Test::Unit::TestCase
     assert_equal({1=>6, 3=>4, 5=>7}, h1.merge(h2) {|k, v1, v2| k + v1 + v2 })
     assert_equal({1=>1, 2=>4, 3=>4, 5=>7}, h1.merge(h2, h3))
     assert_equal({1=>8, 2=>4, 3=>4, 5=>7}, h1.merge(h2, h3) {|k, v1, v2| k + v1 + v2 })
+  end
+
+  def test_merge!
+    h = @cls[a: 1, b: 2, c: 3]
+    assert_raise(FrozenError) do
+      h.merge!({a: 10, b: 20}){ |key, v1, v2| key == :b && h.freeze; v2 }
+    end
+    assert_equal(@cls[a: 10, b: 2, c: 3], h)
   end
 
   def test_assoc


### PR DESCRIPTION
This PR aims a part of https://bugs.ruby-lang.org/issues/17736

```console
$ ruby -w -v -e '(h={a: 1, b: 2, c: 3}).update({b: 4}) { h.freeze; 42 }; p h'
ruby 3.0.0p0 (2020-12-25 revision 95aff21468) [x86_64-darwin20]
{:a=>1, :b=>42, :c=>3}
```