### PR TITLE
Hash#transform_values! ensures receiver modifiable in block [Bug #17736]

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -3303,6 +3303,7 @@ transform_values_foreach_replace(st_data_t *key, st_data_t *value, st_data_t arg
 {
     VALUE new_value = rb_yield((VALUE)*value);
     VALUE hash = (VALUE)argp;
+    rb_hash_modify(hash);
     RB_OBJ_WRITE(hash, value, new_value);
     return ST_CONTINUE;
 }

--- a/test/ruby/test_hash.rb
+++ b/test/ruby/test_hash.rb
@@ -1803,6 +1803,15 @@ class TestHash < Test::Unit::TestCase
     x = @cls[a: 1, b: 2, c: 3]
     y = x.transform_values!.with_index {|v, i| "#{v}.#{i}" }
     assert_equal(%w(1.0  2.1  3.2), y.values_at(:a, :b, :c))
+
+    x = @cls[a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8, i: 9, j: 10]
+    assert_raise(FrozenError) do
+      x.transform_values!() do |v|
+        x.freeze if v == 2
+        v.succ
+      end
+    end
+    assert_equal(@cls[a: 2, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8, i: 9, j: 10], x)
   end
 
   def test_broken_hash_value


### PR DESCRIPTION
For a part of https://bugs.ruby-lang.org/issues/17736

This fixes following behavior.

```console
$ ruby -v
ruby 3.1.0dev (2021-03-21T15:20:48Z master db0ad48309) [x86_64-darwin20]
```

```ruby
hash = {a: 1, b: 2, c: 3, d: 4, e: 5}
hash.transform_values!() do |v|
  hash.freeze if v == 2
  v.succ
end
p hash #=> {:a=>2, :b=>3, :c=>4, :d=>5, :e=>6}
```