### PR TITLE
[Doc] Fix a typo around Hash#compare_by_identity

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -6689,8 +6689,8 @@ env_update(VALUE env, VALUE hash)
  *  ==== User-Defined \Hash Keys
  *
  *  To be useable as a \Hash key, objects must implement the methods <code>hash</code> and <code>eql?</code>.
- *  Note: this requirement does not apply if the \Hash uses #compare_by_id since comparison will then rely on
- *  the keys' object id instead of <code>hash</code> and <code>eql?</code>.
+ *  Note: this requirement does not apply if the \Hash uses #compare_by_identity since comparison will then
+ *  rely on the keys' object id instead of <code>hash</code> and <code>eql?</code>.
  *
  *  \Object defines basic implementation for <code>hash</code> and <code>eq?</code> that makes each object
  *  a distinct key. Typically, user-defined classes will want to override these methods to provide meaningful


### PR DESCRIPTION
I don't have confident this is a typo or intentional one.

The `Hash#compare_by_identity` looks defined as `rb_hash_compare_by_id` in implementation. If this wording described the implementation, this is not a typo 🙇 

https://github.com/ruby/ruby/blob/d36ac283d188ba6d923c905a85341761fa1305c3/hash.c#L4382