### PR TITLE
[Doc] Update regex engine to Onigumo in doc/extension.*

### DIFF
--- a/doc/extension.ja.rdoc
+++ b/doc/extension.ja.rdoc
@@ -1108,9 +1108,8 @@ lex.c         :: 自動生成
     -> opt*.inc            : 自動生成
     -> vm.inc              : 自動生成
 
-=== 正規表現エンジン (鬼車)
+=== 正規表現エンジン (鬼雲)
 
-  regex.c
   regcomp.c
   regenc.c
   regerror.c

--- a/doc/extension.rdoc
+++ b/doc/extension.rdoc
@@ -1076,9 +1076,8 @@ lex.c         :: automatically generated from keywords
     -> opt*.inc            : automatically generated
     -> vm.inc              : automatically generated
 
-=== Regular Expression Engine (Oniguruma)
+=== Regular Expression Engine (Onigumo)
 
-  regex.c
   regcomp.c
   regenc.c
   regerror.c


### PR DESCRIPTION
```console
$ ggrep Oniguruma reg*.c
regcomp.c:  regcomp.c -  Onigmo (Oniguruma-mod) (regular expression library)
regenc.c:  regenc.c -  Onigmo (Oniguruma-mod) (regular expression library)
regerror.c:  regerror.c -  Onigmo (Oniguruma-mod) (regular expression library)
regexec.c:  regexec.c -  Onigmo (Oniguruma-mod) (regular expression library)
regparse.c:  regparse.c -  Onigmo (Oniguruma-mod) (regular expression library)
regsyntax.c:  regsyntax.c -  Onigmo (Oniguruma-mod) (regular expression library)
```

* regex.c has been removed in 8e65234086a15f90585bc09cce82dbad2aa647d7
* I do not intentionally touch https://github.com/ruby/ruby/blob/32a13591e0bb6e96b05452e214f14eda21ee3aa9/ext/stringio/stringio.c#L1084, because it looks saying history.