### PR TITLE
[Doc] Standardize wording s/sweeped/swept/

### DIFF
--- a/include/ruby/internal/value_type.h
+++ b/include/ruby/internal/value_type.h
@@ -108,7 +108,7 @@
 enum
 RBIMPL_ATTR_ENUM_EXTENSIBILITY(closed)
 ruby_value_type {
-    RUBY_T_NONE     = 0x00, /**< Non-object (sweeped etc.) */
+    RUBY_T_NONE     = 0x00, /**< Non-object (swept etc.) */
 
     RUBY_T_OBJECT   = 0x01, /**< @see struct ::RObject */
     RUBY_T_CLASS    = 0x02, /**< @see struct ::RClass and ::rb_cClass */


### PR DESCRIPTION
I don't know much about it, but `sweeped` looks isolated for now. 🤔 
If it points another thing, please close this PR 🙇 

```console
$ git grep -i sweeped
include/ruby/internal/value_type.h:111:    RUBY_T_NONE     = 0x00, /**< Non-object (sweeped etc.) */
```

```console
$ git grep -i swept
doc/ChangeLog-2.0.0:5764:	* gc.c (is_swept_object): extract from is_dead_object().
doc/ChangeLog-2.0.0:5768:	  marked, in heap, swept).
doc/ChangeLog-2.0.0:23321:	  to prevent arguments from being swept by GC. [ruby-core:38546]
doc/ChangeLog-2.1.0:1408:	  If we resurrect dying objects (non-marked, but not swept yet),
doc/ChangeLog-2.1.0:1712:	  * heap_swept_slot
doc/ChangeLog-2.1.0:1862:	* gc.c: Rename heap_pages_swept_num to heap_pages_swept_slots to
doc/ChangeLog-2.1.0:2201:	* gc.c (heap_is_swept_object): use heap_page::before_sweep flag.
doc/ChangeLog-2.1.0:3524:	    if (swept_slots < min_free_slots) pages++
doc/ChangeLog-2.1.0:3525:	    if (swept_slots > max_free_slots) pages--
doc/ChangeLog-2.1.0:3560:	           there is enough empty slots (checking by swept_num)
doc/ChangeLog-2.1.0:4227:	  already and swept at next time, so mark it for the time being.
doc/ChangeLog-2.1.0:4462:	* gc.c: rename heap.free_num as heap.swept_num to clarify meaning and
doc/ChangeLog-2.2.0:4442:	  * heap_swept_slot -> heap_swept_slots
doc/ChangeLog-2.2.0:5140:	  Garbage keys can be swept by lazy sweeping invoked by creating new
doc/ChangeLog-2.2.0:8422:	* gc.c (gc_before_sweep): heap_pages_swept_slots should contains
doc/ChangeLog-2.4.0:6551:	  Because of this fix, heap_pages_swept_slots is no longer needed.
doc/ChangeLog-2.4.0:6557:	    * swept_slots (and heap_pages_swept_slots)
gc.c:3895:heap_is_swept_object(rb_objspace_t *objspace, rb_heap_t *heap, VALUE ptr)
gc.c:3902:is_swept_object(rb_objspace_t *objspace, VALUE ptr)
gc.c:3904:    if (heap_is_swept_object(objspace, heap_eden, ptr)) {
gc.c:3917:	is_swept_object(objspace, ptr) ||
gc.c:4796:gc_fill_swept_page(rb_objspace_t *objspace, rb_heap_t *heap, struct heap_page *sweep_page, int *freed_slots, int *empty_slots)
gc.c:4988:        if (gc_fill_swept_page(objspace, heap, sweep_page, &freed_slots, &empty_slots)) {
gc.c:5139:    int swept_slots = 0;
gc.c:5178:                    swept_slots += free_slots;
gc.c:5179:                    if (swept_slots > 2048) {
gc.c:7380:	size_t sweep_slots = total_slots - objspace->marked_slots; /* will be swept slots */
gc.c:8068:        /* Disable counting swept_slots because there are no meaning.
gc.c:8070:         *   objspace->heap.swept_slots++;
gc.c:12630:        fprintf(stderr, "swept?: %s\n", is_swept_object(objspace, obj) ? "done" : "not yet");
string.c:306:	/* because of lazy sweep, str may be unmarked already and swept
```