### PR TITLE
Skip Hash#rehash steps when it is comparing by id

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -1999,6 +1999,7 @@ rb_hash_rehash(VALUE hash)
 	rb_raise(rb_eRuntimeError, "rehash during iteration");
     }
     rb_hash_modify_check(hash);
+    if (rb_hash_compare_by_id_p(hash)) return hash;
     if (RHASH_AR_TABLE_P(hash)) {
         tmp = hash_alloc(0);
         ar_alloc_table(tmp);


### PR DESCRIPTION
This PR basically aims to question. :bow:
When a hash comparing by id, Will `Hash#rehash` needed in some case? I can't think of anything.
So I have just tried to skip steps in rehash.
It passed `make test-all TESTS=test/ruby/test_hash.rb`.
It looks made faster as below.

Benchmark Script
---

```ruby
require 'benchmark/ips'

base_hash = (1..10000).to_h { |n| [[n], [n.succ]] }

array1 = []
array2 = []

hash = base_hash.merge({array1 => :value})
identhash = base_hash.merge({array2 => :value}).compare_by_identity

Benchmark.ips do |x|
  x.report('hash') do
    array1 << Object.new
    hash.rehash
  end

  x.report('identhash') do
    array2 << Object.new
    identhash.rehash
  end

  x.compare!
end

p hash.key?(array1) #=> true
p hash.key?(array1.dup) #=> true
p({}.merge(hash) == hash) #=> true
p identhash.key?(array2) #=> true
p identhash.key?(array2.dup) #=> false
identhash2 = {}.merge(identhash)
p(identhash2 == identhash) #=> false
p(identhash2.compare_by_identity == identhash) #=> true
```

Before
---

On 816a1d97fdcb46cec51f6fa25d191630698106d1

```
Warming up --------------------------------------
                hash    32.000  i/100ms
           identhash   498.000  i/100ms
Calculating -------------------------------------
                hash    323.682  (± 2.5%) i/s -      1.632k in   5.045338s
           identhash      4.998k (± 1.6%) i/s -     25.398k in   5.083295s

Comparison:
           identhash:     4997.6 i/s
                hash:      323.7 i/s - 15.44x  (± 0.00) slower

true
true
true
true
false
false
true
```

After
---

```
Warming up --------------------------------------
                hash    30.000  i/100ms
           identhash   294.294k i/100ms
Calculating -------------------------------------
                hash    324.845  (± 2.8%) i/s -      1.650k in   5.083692s
           identhash      2.662M (±25.0%) i/s -     10.300M in   5.052430s

Comparison:
           identhash:  2661969.6 i/s
                hash:      324.8 i/s - 8194.59x  (± 0.00) slower

true
true
true
true
false
false
true
```


I guess when a user using `Hash#compare_by_identity`, they will not call `Hash#rehash`.
So I don't have confident this change has meaning or not.
Or this change is so dangerous from some reasons? 😨 
How do you think?