### PR TITLE
Fix leaked file descriptor in passwd test

### DIFF
--- a/test/etc/test_etc.rb
+++ b/test/etc/test_etc.rb
@@ -171,6 +171,7 @@ class TestEtc < Test::Unit::TestCase
 
   def test_ractor
     return unless Etc.passwd # => skip test if no platform support
+    Etc.endpwent
 
     assert_ractor(<<~RUBY, require: 'etc')
       ractor = Ractor.new do


### PR DESCRIPTION
`TestEtc#test_ractor` has a leaked file descriptor because `Etc.passwd` opens the passwd file but does not close it.

```
Leaked file descriptor: TestEtc#test_ractor: 5 #<File::Stat dev=0x100058, ino=4908211, mode=0100644, nlink=1, uid=0, gid=0, rdev=0x0, size=1317, blksize=4096, blocks=8, atime=2021-03-11 09:25:20 +0000, mtime=2021-03-11 09:25:20 +0000, ctime=2021-03-11 17:19:50.071249721 +0000>
```