### PR TITLE
Free iv index table

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -2628,6 +2628,7 @@ static void
 iv_index_tbl_free(struct st_table *tbl)
 {
     st_foreach(tbl, free_iv_index_tbl_free_i, 0);
+    st_free_table(tbl);
 }
 
 // alive: if false, target pointers can be freed already.


### PR DESCRIPTION
IV index tables weren't being freed.  This program would leak memory:

```ruby
loop do
  k = Class.new do
    def initialize
      @a = 1
      @b = 1
      @c = 1
      @d = 1
      @e = 1
      @f = 1
      @g = 1
    end
  end
  k.new
end
```

This commit fixes the leak.