### PR TITLE
Add rb_exc_exception function

### DIFF
--- a/eval.c
+++ b/eval.c
@@ -701,6 +701,17 @@ rb_longjmp(rb_execution_context_t *ec, int tag, volatile VALUE mesg, VALUE cause
 
 static VALUE make_exception(int argc, const VALUE *argv, int isstr);
 
+static void
+rb_exec_exception(VALUE mesg, int tag, VALUE cause)
+{
+    if (!NIL_P(mesg)) {
+	mesg = make_exception(1, &mesg, FALSE);
+    }
+    rb_longjmp(GET_EC(), tag, mesg, cause);
+}
+
+NORETURN(static void rb_exec_exception(VALUE mesg, int tag, VALUE cause));
+
 /*!
  * Raises an exception in the current thread.
  * \param[in] mesg an Exception class or an \c Exception object.
@@ -711,10 +722,7 @@ static VALUE make_exception(int argc, const VALUE *argv, int isstr);
 void
 rb_exc_raise(VALUE mesg)
 {
-    if (!NIL_P(mesg)) {
-	mesg = make_exception(1, &mesg, FALSE);
-    }
-    rb_longjmp(GET_EC(), TAG_RAISE, mesg, Qundef);
+    rb_exec_exception(mesg, TAG_RAISE, Qundef);
 }
 
 /*!
@@ -727,10 +735,7 @@ rb_exc_raise(VALUE mesg)
 void
 rb_exc_fatal(VALUE mesg)
 {
-    if (!NIL_P(mesg)) {
-	mesg = make_exception(1, &mesg, FALSE);
-    }
-    rb_longjmp(GET_EC(), TAG_FATAL, mesg, Qnil);
+    rb_exec_exception(mesg, TAG_FATAL, Qnil);
 }
 
 /*!

--- a/eval.c
+++ b/eval.c
@@ -701,6 +701,8 @@ rb_longjmp(rb_execution_context_t *ec, int tag, volatile VALUE mesg, VALUE cause
 
 static VALUE make_exception(int argc, const VALUE *argv, int isstr);
 
+NORETURN(static void rb_exec_exception(VALUE mesg, int tag, VALUE cause));
+
 static void
 rb_exec_exception(VALUE mesg, int tag, VALUE cause)
 {
@@ -709,8 +711,6 @@ rb_exec_exception(VALUE mesg, int tag, VALUE cause)
     }
     rb_longjmp(GET_EC(), tag, mesg, cause);
 }
-
-NORETURN(static void rb_exec_exception(VALUE mesg, int tag, VALUE cause));
 
 /*!
  * Raises an exception in the current thread.

--- a/eval.c
+++ b/eval.c
@@ -722,7 +722,7 @@ rb_exc_exception(VALUE mesg, int tag, VALUE cause)
 void
 rb_exc_raise(VALUE mesg)
 {
-    rb_exec_exception(mesg, TAG_RAISE, Qundef);
+    rb_exc_exception(mesg, TAG_RAISE, Qundef);
 }
 
 /*!
@@ -735,7 +735,7 @@ rb_exc_raise(VALUE mesg)
 void
 rb_exc_fatal(VALUE mesg)
 {
-    rb_exec_exception(mesg, TAG_FATAL, Qnil);
+    rb_exc_exception(mesg, TAG_FATAL, Qnil);
 }
 
 /*!

--- a/eval.c
+++ b/eval.c
@@ -701,10 +701,10 @@ rb_longjmp(rb_execution_context_t *ec, int tag, volatile VALUE mesg, VALUE cause
 
 static VALUE make_exception(int argc, const VALUE *argv, int isstr);
 
-NORETURN(static void rb_exec_exception(VALUE mesg, int tag, VALUE cause));
+NORETURN(static void rb_exc_exception(VALUE mesg, int tag, VALUE cause));
 
 static void
-rb_exec_exception(VALUE mesg, int tag, VALUE cause)
+rb_exc_exception(VALUE mesg, int tag, VALUE cause)
 {
     if (!NIL_P(mesg)) {
 	mesg = make_exception(1, &mesg, FALSE);


### PR DESCRIPTION
`rb_exc_raise` and `rb_fatal` func have similar code(in `eval.c`).
I think that better cut out and replace these code like `rb_exc_exception` function.