### PR TITLE
[Doc] Drop signature around removed `IO#codepoints`

### DIFF
--- a/io.c
+++ b/io.c
@@ -4143,9 +4143,7 @@ rb_io_each_char(VALUE io)
 /*
  *  call-seq:
  *     ios.each_codepoint {|c| block }  -> ios
- *     ios.codepoints     {|c| block }  -> ios
  *     ios.each_codepoint               -> an_enumerator
- *     ios.codepoints                   -> an_enumerator
  *
  *  Passes the Integer ordinal of each character in <i>ios</i>,
  *  passing the codepoint as an argument. The stream must be opened for


### PR DESCRIPTION
It looks removed in 43b95bafd57d04c8fb401d3a9b52aca3f5b4b0be

```console
$ ruby -v -e 'p STDIN.codepoints'
ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-darwin20]
-e:1: warning: IO#codepoints is deprecated; use #each_codepoint instead
#<Enumerator: #<IO:<STDIN>>:each_codepoint>
```

```console
$ ruby -v -e 'p STDIN.codepoints'
ruby 3.0.0p0 (2020-12-25 revision 95aff21468) [x86_64-darwin20]
-e:1:in `<main>': undefined method `codepoints' for #<IO:<STDIN>> (NoMethodError)
```