### PR TITLE
`IO#close_on_exec=` returns given argument [Bug #17745] 

### DIFF
--- a/io.c
+++ b/io.c
@@ -4580,7 +4580,7 @@ rb_io_set_close_on_exec(VALUE io, VALUE arg)
             if (ret != 0) rb_sys_fail_path(fptr->pathv);
         }
     }
-    return Qnil;
+    return arg;
 }
 #else
 #define rb_io_set_close_on_exec rb_f_notimplement

--- a/spec/ruby/core/io/close_on_exec_spec.rb
+++ b/spec/ruby/core/io/close_on_exec_spec.rb
@@ -50,14 +50,8 @@ describe "IO#close_on_exec=" do
       (@io.close_on_exec = truthy).should equal(truthy)
     end
 
-    ruby_version_is ''...'3.1' do
-      it "returns nil when called with send" do
-        @io.send(:close_on_exec=, true).should be_nil
-      end
-    end
-
     ruby_version_is '3.1' do
-      it "returns given argument when called with send" do
+      it "returns given argument even if called with send" do
         truthy = Object.new
         @io.send(:close_on_exec=, truthy).should equal(truthy)
       end

--- a/spec/ruby/core/io/close_on_exec_spec.rb
+++ b/spec/ruby/core/io/close_on_exec_spec.rb
@@ -45,8 +45,22 @@ describe "IO#close_on_exec=" do
       -> { @io.close_on_exec = true }.should raise_error(IOError)
     end
 
-    it "returns nil" do
-      @io.send(:close_on_exec=, true).should be_nil
+    it "returns given argument" do
+      truthy = Object.new
+      (@io.close_on_exec = truthy).should equal(truthy)
+    end
+
+    ruby_version_is ''...'3.1' do
+      it "returns nil when called with send" do
+        @io.send(:close_on_exec=, true).should be_nil
+      end
+    end
+
+    ruby_version_is '3.1' do
+      it "returns given argument when called with send" do
+        truthy = Object.new
+        @io.send(:close_on_exec=, truthy).should equal(truthy)
+      end
     end
   end
 end

--- a/spec/ruby/core/io/close_on_exec_spec.rb
+++ b/spec/ruby/core/io/close_on_exec_spec.rb
@@ -45,13 +45,8 @@ describe "IO#close_on_exec=" do
       -> { @io.close_on_exec = true }.should raise_error(IOError)
     end
 
-    it "returns given argument" do
-      truthy = Object.new
-      (@io.close_on_exec = truthy).should equal(truthy)
-    end
-
     ruby_version_is '3.1' do
-      it "returns given argument even if called with send" do
+      it "returns given argument" do
         truthy = Object.new
         @io.send(:close_on_exec=, truthy).should equal(truthy)
       end

--- a/test/ruby/test_io.rb
+++ b/test/ruby/test_io.rb
@@ -1903,6 +1903,9 @@ class TestIO < Test::Unit::TestCase
       assert_equal(true, f.close_on_exec?)
       f.close_on_exec = false
       assert_equal(false, f.close_on_exec?)
+      truthy = Object.new
+      assert_same(truthy, f.public_send(:close_on_exec=, truthy))
+      assert_equal(true, f.close_on_exec?)
     end
 
     with_pipe do |r, w|


### PR DESCRIPTION
```console
$ ruby -v -e 'p(STDIN.close_on_exec = 42)'
ruby 3.0.0p0 (2020-12-25 revision 95aff21468) [x86_64-darwin20]
42
```

```console
$ ruby -v -e 'p(STDIN.__send__ :close_on_exec=, 42)'
ruby 3.0.0p0 (2020-12-25 revision 95aff21468) [x86_64-darwin20]
nil
```

Is this an intentional behavior?
`ruby/spec` has the test case, But I can't think any benefit this different returning value 🤔  

ref: https://bugs.ruby-lang.org/issues/17745