### PR TITLE
Remove unneeded rb_ident_hash_new function declaration

### DIFF
--- a/error.c
+++ b/error.c
@@ -64,7 +64,6 @@
 VALUE rb_iseqw_local_variables(VALUE iseqval);
 VALUE rb_iseqw_new(const rb_iseq_t *);
 int rb_str_end_with_asciichar(VALUE str, int c);
-VALUE rb_ident_hash_new(void);
 
 long rb_backtrace_length_limit = -1;
 VALUE rb_eEAGAIN;


### PR DESCRIPTION
Remove unneeded `rb_ident_hash_new` function declaration(in `error.c`).