### PR TITLE
Fix Enumerable#tally with some arguments pattern [Feature #17744]

### DIFF
--- a/enum.c
+++ b/enum.c
@@ -1072,7 +1072,8 @@ enum_tally(int argc, VALUE *argv, VALUE obj)
     if (rb_check_arity(argc, 0, 1)) {
         hash = rb_convert_type(argv[0], T_HASH, "Hash", "to_hash");
         rb_check_frozen(hash);
-    } else {
+    }
+    else {
         hash = rb_hash_new();
     }
 

--- a/enum.c
+++ b/enum.c
@@ -1069,10 +1069,13 @@ static VALUE
 enum_tally(int argc, VALUE *argv, VALUE obj)
 {
     VALUE hash;
-    if (rb_check_arity(argc, 0, 1))
+    if (rb_check_arity(argc, 0, 1)) {
+        rb_check_frozen(argv[0]);
         hash = rb_check_hash_type(argv[0]);
-    else
+    } else {
         hash = rb_hash_new();
+    }
+
     return enum_hashify_into(obj, 0, 0, tally_i, hash);
 }
 

--- a/enum.c
+++ b/enum.c
@@ -1070,8 +1070,8 @@ enum_tally(int argc, VALUE *argv, VALUE obj)
 {
     VALUE hash;
     if (rb_check_arity(argc, 0, 1)) {
-        rb_check_frozen(argv[0]);
-        hash = rb_check_hash_type(argv[0]);
+        hash = rb_convert_type(argv[0], T_HASH, "Hash", "to_hash");
+        rb_check_frozen(hash);
     } else {
         hash = rb_hash_new();
     }

--- a/spec/ruby/core/enumerable/tally_spec.rb
+++ b/spec/ruby/core/enumerable/tally_spec.rb
@@ -45,6 +45,25 @@ ruby_version_is "3.1" do
       enum.tally({ 'foo' => 1 }).should == { 'foo' => 3, 'bar' => 1, 'baz' => 1}
     end
 
+    it "returns the given hash" do
+      enum = EnumerableSpecs::Numerous.new('foo', 'bar', 'foo', 'baz')
+      hash = { 'foo' => 1 }
+      enum.tally(hash).should equal(hash)
+    end
+
+    it "raises a FrozenError and does not udpate the given hash when the hash is frozen" do
+      enum = EnumerableSpecs::Numerous.new('foo', 'bar', 'foo', 'baz')
+      hash = { 'foo' => 1 }.freeze
+      -> { enum.tally(hash) }.should raise_error(FrozenError)
+      hash.should == { 'foo' => 1 }
+    end
+
+    it "does not call given block" do
+      enum = EnumerableSpecs::Numerous.new('foo', 'bar', 'foo', 'baz')
+      enum.tally({ 'foo' => 1 }) { |v| ScratchPad << v }
+      ScratchPad.recorded.should == []
+    end
+
     it "ignores the default value" do
       enum = EnumerableSpecs::Numerous.new('foo', 'bar', 'foo', 'baz')
       enum.tally(Hash.new(100)).should == { 'foo' => 2, 'bar' => 1, 'baz' => 1}

--- a/test/ruby/test_enum.rb
+++ b/test/ruby/test_enum.rb
@@ -403,6 +403,15 @@ class TestEnumerable < Test::Unit::TestCase
     end
 
     h = {1 => 2, 2 => 2, 3 => 1}
+    assert_same(h, @obj.tally(h))
+
+    h = {1 => 2, 2 => 2, 3 => 1}.freeze
+    assert_raise(FrozenError) do
+      @obj.tally(h)
+    end
+    assert_equal({1 => 2, 2 => 2, 3 => 1}, h)
+
+    h = {1 => 2, 2 => 2, 3 => 1}
     assert_equal(h, @obj.tally(Hash.new(100)))
     assert_equal(h, @obj.tally(Hash.new {100}))
   end

--- a/test/ruby/test_enum.rb
+++ b/test/ruby/test_enum.rb
@@ -411,6 +411,25 @@ class TestEnumerable < Test::Unit::TestCase
     end
     assert_equal({1 => 2, 2 => 2, 3 => 1}, h)
 
+    hash_convertible = Object.new
+    def hash_convertible.to_hash
+      {1 => 3, 4 => "x"}
+    end
+    assert_equal({1 => 5, 2 => 2, 3 => 1, 4 => "x"}, @obj.tally(hash_convertible))
+
+    hash_convertible = Object.new
+    def hash_convertible.to_hash
+      {1 => 3, 4 => "x"}.freeze
+    end
+    assert_raise(FrozenError) do
+      @obj.tally(hash_convertible)
+    end
+    assert_equal({1 => 3, 4 => "x"}, hash_convertible.to_hash)
+
+    assert_raise(TypeError) do
+      @obj.tally(BasicObject.new)
+    end
+
     h = {1 => 2, 2 => 2, 3 => 1}
     assert_equal(h, @obj.tally(Hash.new(100)))
     assert_equal(h, @obj.tally(Hash.new {100}))


### PR DESCRIPTION
The feature has been applied in https://github.com/ruby/ruby/pull/4318
Looks having two issues.

* Given argument can't be convertible to Hash, it makes `Segmentation fault`
* Given Hash will be updated even if it is frozen.

This PR aims to fix both.

---

SEGV
---

```console
$ ruby -v -e '[1].tally(Object.new)'
ruby 3.1.0dev (2021-03-26T07:29:21Z master 9143d21b1b) [x86_64-darwin20]
-e:1: [BUG] Segmentation fault at 0x0000000000000008
```

The report file is below.

```
Process:               ruby [45080]
Path:                  /Users/USER/*/ruby
Identifier:            ruby
Version:               0
Code Type:             X86-64 (Native)
Parent Process:        zsh [81240]
Responsible:           iTerm2 [775]
User ID:               501

Date/Time:             2021-03-27 06:37:39.743 +0900
OS Version:            macOS 11.2.3 (20D91)
Report Version:        12
Bridge OS Version:     5.2 (18P4347)
Anonymous UUID:        45AC3339-EF82-D14F-C1BE-DDCB9F9108C6

Sleep/Wake UUID:       0AD4D99C-03F5-4D5D-B113-FFDF3BBD23ED

Time Awake Since Boot: 290000 seconds
Time Since Wake:       4900 seconds

System Integrity Protection: enabled

Crashed Thread:        0  Dispatch queue: com.apple.main-thread

Exception Type:        EXC_BAD_ACCESS (SIGABRT)
Exception Codes:       KERN_INVALID_ADDRESS at 0x0000000000000008
Exception Note:        EXC_CORPSE_NOTIFY

VM Regions Near 0x8:
--> 
    __TEXT                      108d87000-1090c7000    [ 3328K] r-x/r-x SM=COW  /Users/*

Application Specific Information:
abort() called

Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
0   libsystem_kernel.dylib        	0x00007fff203fd462 __pthread_kill + 10
1   libsystem_pthread.dylib       	0x00007fff2042b610 pthread_kill + 263
2   libsystem_c.dylib             	0x00007fff2037e720 abort + 120
3   ruby                          	0x0000000108e2c8f9 die + 9 (error.c:765)
4   ruby                          	0x0000000108e2cb29 rb_bug_for_fatal_signal + 553 (error.c:805)
5   ruby                          	0x0000000108f699bb sigsegv + 91 (signal.c:960)
6   libsystem_platform.dylib      	0x00007fff2046fd7d _sigtramp + 29
7   ???                           	000000000000000000 0 + 0
8   ruby                          	0x0000000108e1eabe rb_enum_tally_up + 18 (enum.c:1040) [inlined]
9   ruby                          	0x0000000108e1eabe tally_i + 62 (enum.c:1048)
10  ruby                          	0x000000010900be87 vm_yield_with_cfunc + 181 (vm_insnhelper.c:3730) [inlined]
11  ruby                          	0x000000010900be87 invoke_block_from_c_bh + 1079 (vm.c:1357)
12  ruby                          	0x0000000108ff3567 rb_yield + 167
13  ruby                          	0x0000000108d8e5f7 rb_ary_each + 55 (array.c:2529)
14  ruby                          	0x0000000108ff15ac vm_call0_cfunc_with_frame + 243 (vm_eval.c:135) [inlined]
15  ruby                          	0x0000000108ff15ac vm_call0_cfunc + 243 (vm_eval.c:149) [inlined]
16  ruby                          	0x0000000108ff15ac vm_call0_body + 2060 (vm_eval.c:182)
17  ruby                          	0x000000010900b552 rb_call0 + 946
18  ruby                          	0x0000000108ff4081 rb_call + 29 (vm_eval.c:844) [inlined]
19  ruby                          	0x0000000108ff4081 iterate_method + 65 (vm_eval.c:1578)
20  ruby                          	0x0000000108ff3f41 rb_iterate0 + 545 (vm_eval.c:1527)
21  ruby                          	0x0000000108ff4016 rb_iterate + 58 (vm_eval.c:1559) [inlined]
22  ruby                          	0x0000000108ff4016 rb_block_call + 102 (vm_eval.c:1592)
23  ruby                          	0x0000000108e1bad0 enum_hashify_into + 27 (enum.c:693) [inlined]
24  ruby                          	0x0000000108e1bad0 enum_tally + 64 (enum.c:1076)
25  ruby                          	0x000000010900833f vm_call_cfunc_with_frame + 335 (vm_insnhelper.c:2924)
26  ruby                          	0x0000000109000196 vm_sendish + 1302
27  ruby                          	0x0000000108fe5cb0 vm_exec_core + 14448 (insns.def:792)
28  ruby                          	0x0000000108ffb82b rb_vm_exec + 3195
29  ruby                          	0x0000000108e37f06 rb_ec_exec_node + 310 (eval.c:317)
30  ruby                          	0x0000000108e37d77 ruby_run_node + 87 (eval.c:375)
31  ruby                          	0x0000000108d8b6e1 main + 113 (main.c:47)
32  libdyld.dylib                 	0x00007fff20446621 start + 1

Thread 1:
0   libsystem_kernel.dylib        	0x00007fff203fd4fe poll + 10
1   ruby                          	0x0000000108fb600e timer_pthread_fn + 158 (thread_pthread.c:2228)
2   libsystem_pthread.dylib       	0x00007fff2042b950 _pthread_start + 224
3   libsystem_pthread.dylib       	0x00007fff2042747b thread_start + 15

Thread 0 crashed with X86 Thread State (64-bit):
  rax: 0x0000000000000000  rbx: 0x000000010fa89e00  rcx: 0x00007fca40021fd8  rdx: 0x0000000000000000
  rdi: 0x0000000000000307  rsi: 0x0000000000000006  rbp: 0x00007fca40022000  rsp: 0x00007fca40021fd8
   r8: 0x00000000000130a8   r9: 0x00007fff88a65da8  r10: 0x000000010fa89e00  r11: 0x0000000000000246
  r12: 0x0000000000000307  r13: 0x00007fff88a65f80  r14: 0x0000000000000006  r15: 0x0000000000000016
  rip: 0x00007fff203fd462  rfl: 0x0000000000000246  cr2: 0x000055bbf2291e94
  
Logical CPU:     0
Error Code:      0x02000148
Trap Number:     133

Thread 0 instruction stream:
  c7 47 10 00 00 00 00 41-80 4f 01 80 4d 89 77 10  .G.....A.O..M.w.
  4c 89 f0 48 83 c4 08 5b-41 5c 41 5d 41 5e 41 5f  L..H...[A\A]A^A_
  5d c3 0f 1f 80 00 00 00-00 55 48 89 e5 53 50 48  ]........UH..SPH
  89 fb e8 a2 b4 fe ff 48-89 df 48 83 c4 08 5b 5d  .......H..H...[]
  e9 e4 fe ff ff 0f 1f 40-00 55 48 89 e5 41 57 41  .......@.UH..AWA
  56 41 54 53 49 89 ce 49-89 d7 49 89 f4 48 89 fb  VATSI..I..I..H..
 [66]83 3f 00 78 27 48 89-df 4c 89 e6 4c 89 fa 4c  f.?.x'H..L..L..L	<==
  89 f1 e8 32 00 00 00 83-f8 ff 74 09 5b 41 5c 41  ...2......t.[A\A
  5e 41 5f 5d c3 48 89 df-e8 2c 04 00 00 48 8b 7b  ^A_].H...,...H.{
  10 4c 89 e6 4c 89 fa 4c-89 f1 5b 41 5c 41 5e 41  .L..L..L..[A\A^A
  5f 5d e9 92 33 11 00 66-90 55 48 89 e5 41 57 41  _]..3..f.UH..AWA
  56 41 55 41 54 53 48 83-ec 38 49 89 cf 49 89 d6  VAUATSH..8I..I..
  
Thread 0 last branch register state not available.


Binary Images:
       0x108d87000 -        0x1090c6fff +ruby (0) <CAC5104E-8B04-3A62-BE63-8F8293DF4696> /Users/USER/*/ruby
       0x10c728000 -        0x10c72bfff +encdb.bundle (0) <130CA3C0-6FDA-3187-9D4E-2C6495B88E94> /usr/local/lib/ruby/3.1.0/x86_64-darwin20/enc/encdb.bundle
       0x10c738000 -        0x10c73bfff +transdb.bundle (0) <7519E4AA-0480-3C51-AC9F-46C7BD56EC91> /usr/local/lib/ruby/3.1.0/x86_64-darwin20/enc/trans/transdb.bundle
       0x10c818000 -        0x10c81bfff +monitor.bundle (0) <9DAE4C50-D9AD-3DC8-B62E-BC11AA489119> /usr/local/lib/ruby/3.1.0/x86_64-darwin20/monitor.bundle
       0x10f9b2000 -        0x10fa4dfff  dyld (832.7.3) <0D4EA85F-7E30-338B-9215-314A5A5539B6> /usr/lib/dyld
    0x7fff20160000 -     0x7fff20161fff  libsystem_blocks.dylib (78) <E644CAA0-65B7-36E4-8041-520F3301F3DB> /usr/lib/system/libsystem_blocks.dylib
    0x7fff20162000 -     0x7fff20197fff  libxpc.dylib (2038.80.3) <70F26262-01AA-3CEC-9FAD-2701D24096F0> /usr/lib/system/libxpc.dylib
    0x7fff20198000 -     0x7fff201affff  libsystem_trace.dylib (1277.80.2) <87FEF600-48D9-31C9-B8FC-D5249B2AE95D> /usr/lib/system/libsystem_trace.dylib
    0x7fff201b0000 -     0x7fff2024ffff  libcorecrypto.dylib (1000.80.5) <1EB11CFB-ABD7-36DD-97C7-C112A6601416> /usr/lib/system/libcorecrypto.dylib
    0x7fff20250000 -     0x7fff2027cfff  libsystem_malloc.dylib (317.40.8) <A498D1EF-E43D-310C-84E8-9C0AADA0C475> /usr/lib/system/libsystem_malloc.dylib
    0x7fff2027d000 -     0x7fff202c1fff  libdispatch.dylib (1271.40.12) <AD988EEA-1A2F-3404-9A6E-390FC2504223> /usr/lib/system/libdispatch.dylib
    0x7fff202c2000 -     0x7fff202fafff  libobjc.A.dylib (818.2) <EB6B543F-D42C-3FB2-A2EC-43407C5F80D3> /usr/lib/libobjc.A.dylib
    0x7fff202fb000 -     0x7fff202fdfff  libsystem_featureflags.dylib (28.60.1) <9CECB43A-094E-3CA9-B730-24DEA1A6DE05> /usr/lib/system/libsystem_featureflags.dylib
    0x7fff202fe000 -     0x7fff20386fff  libsystem_c.dylib (1439.40.11) <4AF71812-4099-3E96-B271-1F259491A2B2> /usr/lib/system/libsystem_c.dylib
    0x7fff20387000 -     0x7fff203dcfff  libc++.1.dylib (904.4) <B217D905-4F9C-3DE0-8844-88FAA3C2C851> /usr/lib/libc++.1.dylib
    0x7fff203dd000 -     0x7fff203f5fff  libc++abi.dylib (904.4) <3C9FE530-3CD2-3A64-8A36-70816AEBDF0D> /usr/lib/libc++abi.dylib
    0x7fff203f6000 -     0x7fff20424fff  libsystem_kernel.dylib (7195.81.3) <AB413518-ECDE-3F04-A61C-278D3CF43076> /usr/lib/system/libsystem_kernel.dylib
    0x7fff20425000 -     0x7fff20430fff  libsystem_pthread.dylib (454.80.2) <B989DF6C-ADFE-3AF9-9C91-07D2521F9E47> /usr/lib/system/libsystem_pthread.dylib
    0x7fff20431000 -     0x7fff2046bfff  libdyld.dylib (832.7.3) <4641E48F-75B5-3CC7-8263-47BF79F15394> /usr/lib/system/libdyld.dylib
    0x7fff2046c000 -     0x7fff20475fff  libsystem_platform.dylib (254.80.2) <1C3E1A0A-92A8-3CDE-B622-8940B43A5DF2> /usr/lib/system/libsystem_platform.dylib
    0x7fff20476000 -     0x7fff204a1fff  libsystem_info.dylib (542.40.3) <0C96CFE8-71F5-3335-8423-581BC3DE5846> /usr/lib/system/libsystem_info.dylib
    0x7fff204a2000 -     0x7fff2093dfff  com.apple.CoreFoundation (6.9 - 1774.101) <2A0E160E-9EE6-3B23-8832-6979A16EC250> /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation
    0x7fff2262e000 -     0x7fff2288ffff  libicucore.A.dylib (66109) <8F8D8A8B-4EE0-3C09-9F45-725A1FBDD38C> /usr/lib/libicucore.A.dylib
    0x7fff22890000 -     0x7fff22899fff  libsystem_darwin.dylib (1439.40.11) <E016D8F7-C87F-36F8-B8A0-6A61B8E4BACB> /usr/lib/system/libsystem_darwin.dylib
    0x7fff22cab000 -     0x7fff22cb6fff  libsystem_notify.dylib (279.40.4) <B2BF20C7-448A-3FBD-A2F5-AB7618D173F6> /usr/lib/system/libsystem_notify.dylib
    0x7fff24c07000 -     0x7fff24c15fff  libsystem_networkextension.dylib (1295.80.3) <5213D866-7D0E-3FD9-8E1A-03C0E39CEC44> /usr/lib/system/libsystem_networkextension.dylib
    0x7fff24c73000 -     0x7fff24c89fff  libsystem_asl.dylib (385) <5B48071E-85EB-33B0-AE9B-127AEB398AEC> /usr/lib/system/libsystem_asl.dylib
    0x7fff26372000 -     0x7fff26379fff  libsystem_symptoms.dylib (1431.40.36) <BC85B46C-02EE-31FF-861D-F0DE01E8F6CF> /usr/lib/system/libsystem_symptoms.dylib
    0x7fff283c2000 -     0x7fff283d2fff  libsystem_containermanager.dylib (318.80.2) <6F08275F-B912-3D8E-9D74-4845158AE4F3> /usr/lib/system/libsystem_containermanager.dylib
    0x7fff290cf000 -     0x7fff290d2fff  libsystem_configuration.dylib (1109.60.2) <4917D824-4DE8-32CC-9ED2-1FBF371FEB9F> /usr/lib/system/libsystem_configuration.dylib
    0x7fff290d3000 -     0x7fff290d7fff  libsystem_sandbox.dylib (1441.60.4) <5F7F3DD1-4B38-310C-AA8F-19FF1B0F5276> /usr/lib/system/libsystem_sandbox.dylib
    0x7fff29ddb000 -     0x7fff29dddfff  libquarantine.dylib (119.40.2) <40D35D75-524B-3DA6-8159-E7E0FA66F5BC> /usr/lib/system/libquarantine.dylib
    0x7fff2a35d000 -     0x7fff2a361fff  libsystem_coreservices.dylib (127) <529A0663-A936-309C-9318-1B04B7F70658> /usr/lib/system/libsystem_coreservices.dylib
    0x7fff2a578000 -     0x7fff2a5bffff  libsystem_m.dylib (3186.40.2) <DD26CC5C-AFF6-305F-A567-14909DD57163> /usr/lib/system/libsystem_m.dylib
    0x7fff2a5c1000 -     0x7fff2a5c6fff  libmacho.dylib (973.4) <C2584BC4-497B-3170-ADDF-21B8E10B4DFD> /usr/lib/system/libmacho.dylib
    0x7fff2a5e3000 -     0x7fff2a5eefff  libcommonCrypto.dylib (60178.40.2) <822A29CE-BF54-35AD-BB15-8FAECB800C7D> /usr/lib/system/libcommonCrypto.dylib
    0x7fff2a5ef000 -     0x7fff2a5f9fff  libunwind.dylib (200.10) <1D0A4B4A-4370-3548-8DC1-42A7B4BD45D3> /usr/lib/system/libunwind.dylib
    0x7fff2a5fa000 -     0x7fff2a601fff  liboah.dylib (203.30) <44C477D9-013F-3A6D-A9FE-68A89214E6A5> /usr/lib/liboah.dylib
    0x7fff2a602000 -     0x7fff2a60cfff  libcopyfile.dylib (173.40.2) <39DBE613-135B-3AFE-A6AF-7898A37F70C2> /usr/lib/system/libcopyfile.dylib
    0x7fff2a60d000 -     0x7fff2a614fff  libcompiler_rt.dylib (102.2) <62EE1D14-5ED7-3CEC-81C0-9C93833641F1> /usr/lib/system/libcompiler_rt.dylib
    0x7fff2a615000 -     0x7fff2a617fff  libsystem_collections.dylib (1439.40.11) <C53D5E0C-0C4F-3B35-A24B-E0D7101A3F95> /usr/lib/system/libsystem_collections.dylib
    0x7fff2a618000 -     0x7fff2a61afff  libsystem_secinit.dylib (87.60.1) <E05E35BC-1BAB-365B-8BEE-D774189EFD3B> /usr/lib/system/libsystem_secinit.dylib
    0x7fff2a61b000 -     0x7fff2a61dfff  libremovefile.dylib (49.40.3) <5CC12A16-82CB-32F0-9040-72CFC88A48DF> /usr/lib/system/libremovefile.dylib
    0x7fff2a61e000 -     0x7fff2a61efff  libkeymgr.dylib (31) <803F6AED-99D5-3CCF-B0FA-361BCF14C8C0> /usr/lib/system/libkeymgr.dylib
    0x7fff2a61f000 -     0x7fff2a626fff  libsystem_dnssd.dylib (1310.80.1) <E0A0CAB3-6779-3C83-AC67-046CFE69F9C2> /usr/lib/system/libsystem_dnssd.dylib
    0x7fff2a627000 -     0x7fff2a62cfff  libcache.dylib (83) <1A98B064-8FED-39CF-BB2E-5BDA1EF5B65A> /usr/lib/system/libcache.dylib
    0x7fff2a62d000 -     0x7fff2a62efff  libSystem.B.dylib (1292.60.1) <83503CE0-32B1-36DB-A4F0-3CC6B7BCF50A> /usr/lib/libSystem.B.dylib
    0x7fff2a62f000 -     0x7fff2a632fff  libfakelink.dylib (3) <D939A124-9FD5-37A2-B03B-72E98CBC98FE> /usr/lib/libfakelink.dylib
    0x7fff2a633000 -     0x7fff2a633fff  com.apple.SoftLinking (1.0 - 1) <EF2AC5FF-B98D-3252-ABA8-2FC721CBA942> /System/Library/PrivateFrameworks/SoftLinking.framework/Versions/A/SoftLinking
    0x7fff2da66000 -     0x7fff2da66fff  liblaunch.dylib (2038.80.3) <C7C51322-8491-3B78-9CFA-2B4753662BCF> /usr/lib/system/liblaunch.dylib
    0x7fff2ff1a000 -     0x7fff2ff1afff  libsystem_product_info_filter.dylib (8.40.1) <20310EE6-2C3F-361A-9ECA-4223AFC03B65> /usr/lib/system/libsystem_product_info_filter.dylib
    0x7fff59101000 -     0x7fff5911cfff  libJapaneseConverter.dylib (90) <78F1A09D-07FD-34B0-8011-2ED89520133E> /System/Library/CoreServices/Encodings/libJapaneseConverter.dylib

External Modification Summary:
  Calls made by other processes targeting this process:
    task_for_pid: 0
    thread_create: 0
    thread_set_state: 0
  Calls made by this process:
    task_for_pid: 0
    thread_create: 0
    thread_set_state: 0
  Calls made by all processes on this machine:
    task_for_pid: 306704
    thread_create: 0
    thread_set_state: 0

VM Region Summary:
ReadOnly portion of Libraries: Total=505.5M resident=0K(0%) swapped_out_or_unallocated=505.5M(100%)
Writable regions: Total=128.1M written=0K(0%) resident=0K(0%) swapped_out=0K(0%) unallocated=128.1M(100%)
 
                                VIRTUAL   REGION 
REGION TYPE                        SIZE    COUNT (non-coalesced) 
===========                     =======  ======= 
Activity Tracing                   256K        1 
Kernel Alloc Once                    8K        1 
MALLOC                            66.1M       29 
MALLOC guard page                   16K        4 
STACK GUARD                          4K        1 
Stack                             8712K        2 
Stack Guard                       56.0M        1 
VM_ALLOCATE                       53.0M      117 
__DATA                             563K       52 
__DATA_CONST                      3067K       43 
__DATA_DIRTY                        95K       23 
__LINKEDIT                       490.2M       11 
__OBJC_RO                         60.5M        1 
__OBJC_RW                         2449K        2 
__TEXT                            15.3M       52 
__UNICODE                          588K        1 
mapped file                       33.8M        1 
shared memory                        8K        2 
===========                     =======  ======= 
TOTAL                            790.5M      344 
```

Given a frozen Hash
---

```console
$ ruby -v -e 'h={a: 1}.freeze; [1, 2].tally(h); p h'
ruby 3.1.0dev (2021-03-26T07:29:21Z master 9143d21b1b) [x86_64-darwin20]
{:a=>1, 1=>1, 2=>1}
```

@nobu Could you review? 🙏 