### PR TITLE
Force recycle intermediate collection in Hash#transform_keys!

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -3295,6 +3295,7 @@ rb_hash_transform_keys_bang(int argc, VALUE *argv, VALUE hash)
         }
         rb_ary_clear(pairs);
         rb_hash_clear(new_keys);
+        rb_gc_force_recycle(new_keys);
     }
     return hash;
 }

--- a/hash.c
+++ b/hash.c
@@ -3294,6 +3294,7 @@ rb_hash_transform_keys_bang(int argc, VALUE *argv, VALUE hash)
             rb_hash_aset(new_keys, new_key, Qnil);
         }
         rb_ary_clear(pairs);
+        rb_gc_force_recycle(pairs);
         rb_hash_clear(new_keys);
         rb_gc_force_recycle(new_keys);
     }


### PR DESCRIPTION
This PR might be just a question 🙇 

https://github.com/ruby/ruby/blob/fb6ebe55d91187d9635e0183d47dbf38e95b1141/hash.c#L4389-L4411 looks using this function for the intermediate hash.
So this code needs to same way...? 🤔  (I'm not sure, hot to check changed behaviors in ruby code layer...)

ref: https://github.com/ruby/ruby/pull/4294, https://github.com/ruby/ruby/commit/5e5fb72f99701dc27c66ab148471893f14e6d6f0

@nobu Could you review? 🙏 