### PR TITLE
Fix Hash#slice consider compare_by_identity [Bug #17757]

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -2617,9 +2617,15 @@ rb_hash_slice(int argc, VALUE *argv, VALUE hash)
     VALUE key, value, result;
 
     if (argc == 0 || RHASH_EMPTY_P(hash)) {
-	return rb_hash_new();
+	result = rb_hash_new();
     }
-    result = rb_hash_new_with_size(argc);
+    else {
+	result = rb_hash_new_with_size(argc);
+    }
+
+    if (rb_hash_compare_by_id_p(hash)) {
+	RHASH_ST_TABLE_SET(result, st_init_table(&identhash));
+    }
 
     for (i = 0; i < argc; i++) {
 	key = argv[i];

--- a/test/ruby/test_hash.rb
+++ b/test/ruby/test_hash.rb
@@ -1090,12 +1090,39 @@ class TestHash < Test::Unit::TestCase
     assert_equal({}, {}.slice)
   end
 
+  def test_slice_on_identhash
+    h = @cls[1=>2,3=>4,5=>6]
+    h.compare_by_identity
+    str1 = +'str'
+    str2 = +'str'
+    h[str1] = 1
+    h[str2] = 2
+    sliced = h.slice(str1, str2)
+    expected = {}.compare_by_identity
+    expected[str1] = 1
+    expected[str2] = 2
+    assert_equal(expected, sliced)
+    assert_equal(true, sliced.compare_by_identity?)
+  end
+
   def test_except
     h = @cls[1=>2,3=>4,5=>6]
     assert_equal({5=>6}, h.except(1, 3))
     assert_equal({1=>2,3=>4,5=>6}, h.except(7))
     assert_equal({1=>2,3=>4,5=>6}, h.except)
     assert_equal({}, {}.except)
+  end
+
+  def test_except_on_identhash
+    h = @cls[1=>2,3=>4,5=>6]
+    h.compare_by_identity
+    str1 = +'str'
+    str2 = +'str'
+    h[str1] = 1
+    h[str2] = 2
+    excepted = h.except(str1, str2)
+    assert_equal({1=>2,3=>4,5=>6}.compare_by_identity, excepted)
+    assert_equal(true, excepted.compare_by_identity?)
   end
 
   def test_filter


### PR DESCRIPTION
ref: https://bugs.ruby-lang.org/issues/17757

```console
$ ruby -v
ruby 3.0.0p0 (2020-12-25 revision 95aff21468) [x86_64-darwin20]
```

```ruby
str1 = +'str'
str2 = +'str'
hash = {a: :a, b: :b, c: :c}.compare_by_identity
hash[str1] = 1
hash[str2] = 2
p hash.values_at(str1, str2) #=> [1, 2]
p hash.except.compare_by_identity? #=> true
p hash.slice.compare_by_identity? #=> false
p hash.except(str1, str2) #=> {:a=>:a, :b=>:b, :c=>:c}
p hash.slice(str1, str2) #=> {"str"=>2}
```

Is this an intentional behavior?
I would expect Hash#slice keeps compare_by_identity behaviors.