### PR TITLE
[Doc] Fix Array#count comparing strategy

### DIFF
--- a/array.c
+++ b/array.c
@@ -6093,7 +6093,7 @@ rb_ary_compact(VALUE ary)
  *    [0, 1, 2].count # => 3
  *    [].count # => 0
  *
- *  With argument +obj+, returns the count of elements <tt>eql?</tt> to +obj+:
+ *  With argument +obj+, returns the count of elements <tt>==</tt> to +obj+:
  *    [0, 1, 2, 0].count(0) # => 2
  *    [0, 1, 2].count(3) # => 0
  *
@@ -6102,7 +6102,7 @@ rb_ary_compact(VALUE ary)
  *    [0, 1, 2, 3].count {|element| element > 1} # => 2
  *
  *  With argument +obj+ and a block given, issues a warning, ignores the block,
- *  and returns the count of elements <tt>eql?</tt> to +obj+:
+ *  and returns the count of elements <tt>==</tt> to +obj+:
  */
 
 static VALUE


### PR DESCRIPTION
https://github.com/ruby/ruby/blob/e019dd24df4ed7063ad80d4c2e4070141793f598/array.c#L6131

```console
$ ruby -v
ruby 3.0.0p0 (2020-12-25 revision 95aff21468) [x86_64-darwin20]
```

I have confirmed the behavior with following script.

```ruby
class Foo
  def self.memo(obj)
    puts "#{caller} - #{obj}"
  end

  def eql?(other)
    self.class.memo(other)
    false
  end

  def ==(other)
    self.class.memo(other)
    true
  end
end

p [Foo.new, Foo.new, Foo.new].count('bar') # =>
# ["-:12:in `=='", "-:17:in `count'", "-:17:in `<main>'"] - bar
# ["-:12:in `=='", "-:17:in `count'", "-:17:in `<main>'"] - bar
# ["-:12:in `=='", "-:17:in `count'", "-:17:in `<main>'"] - bar
# 3
```