### PR TITLE
Provide Hash#count for performance improvement [Feature #17758]

### DIFF
--- a/benchmark/hash_count.yml
+++ b/benchmark/hash_count.yml
@@ -1,0 +1,7 @@
+prelude: |
+  list = ("aaa".."zzz").to_a*10
+  hash = list.each_with_index.to_h { |v, i| [ "#{v}#{i}", v ] }
+benchmark:
+  count: hash.count
+  count_with_arg: hash.count(['a', 'z'])
+  count_with_block: hash.count(&:itself)

--- a/hash.c
+++ b/hash.c
@@ -2998,6 +2998,26 @@ rb_hash_size_num(VALUE hash)
 
 /*
  *  call-seq:
+ *    hash.count                  -> integer
+ *    hash.count(item)            -> integer
+ *    hash.count { |pair| block } -> integer
+ *
+ *  Identical to Enumerable#count, except optimized for no arguments.
+ */
+
+static VALUE
+rb_hash_count(int argc, VALUE *argv, VALUE hash)
+{
+    if (argc == 0 && !rb_block_given_p()) {
+        return rb_hash_size(hash);
+    }
+    else {
+        return rb_call_super(argc, argv);
+    }
+}
+
+/*
+ *  call-seq:
  *    hash.empty? -> true or false
  *
  *  Returns +true+ if there are no hash entries, +false+ otherwise:
@@ -6992,6 +7012,7 @@ Init_Hash(void)
     rb_define_method(rb_cHash, "key", rb_hash_key, 1);
     rb_define_method(rb_cHash, "size", rb_hash_size, 0);
     rb_define_method(rb_cHash, "length", rb_hash_size, 0);
+    rb_define_method(rb_cHash, "count", rb_hash_count, -1);
     rb_define_method(rb_cHash, "empty?", rb_hash_empty_p, 0);
 
     rb_define_method(rb_cHash, "each_value", rb_hash_each_value, 0);

--- a/test/ruby/test_hash.rb
+++ b/test/ruby/test_hash.rb
@@ -816,6 +816,18 @@ class TestHash < Test::Unit::TestCase
     assert_equal(7, @h.length)
   end
 
+  def test_count
+    assert_equal(0, @cls[].count)
+    hash = @cls[a: 1, b: 2, c: 3, d: 4, e: 5]
+    assert_equal(5, hash.count)
+    assert_equal(1, hash.count([:d, 4]))
+    assert_equal(0, hash.count([:d, 42]))
+    assert_equal(3, hash.count() { |pair| pair.last > 2 })
+    assert_warning(/warning: given block not used/) do
+      assert_equal(1, hash.count([:d, 4]) { raise Exception })
+    end
+  end
+
   def test_sort
     h = @cls[].sort
     assert_equal([], h)


### PR DESCRIPTION
ref: https://bugs.ruby-lang.org/issues/17758

In my experience, many developers choice `size`, `length` and `count` as a matter of taste.
And Ruby already provide `Array#count` for performance improvement reason since https://github.com/ruby/ruby/commit/921fb6ae2593d07d35df0f1f487b9d64a0db9520

So how about to provide simple bridge implementation into Hash?

I have checked the result with `benchmark-driver`, it looks made faster for no arguments pattern, and does not make much slower other arguments pattern.
It is compared with recently code https://github.com/ruby/ruby/tree/989e22f394c48aae301a0239cad14871dfa96d43.

```console
$ /Users/kachick/.rubies/ruby-3.1.0dev-989e22f394/bin/ruby -v
ruby 3.1.0dev (2021-03-28T14:42:38Z master 989e22f394) [x86_64-darwin20]

$ ./ruby -v
ruby 3.1.0dev (2021-03-28T17:45:56Z hash-count 94b052d7fa) [x86_64-darwin20]

$ benchmark-driver benchmark/hash_count.yml -e /Users/kachick/.rubies/ruby-3.1.0dev-989e22f394/bin/ruby -e ./ruby

Warming up --------------------------------------
               count                                                   94.814 i/s -     100.000 times in 1.054702s (10.55ms/i)
      count_with_arg                                                   17.106 i/s -      18.000 times in 1.052250s (58.46ms/i)
    count_with_block                                                   54.992 i/s -      60.000 times in 1.091072s (18.18ms/i)
Calculating -------------------------------------
                     /Users/kachick/.rubies/ruby-3.1.0dev-989e22f394/bin/ruby      ./ruby 
               count                                                   92.080     40.571M i/s -     284.000 times in 3.084282s 0.000007s
      count_with_arg                                                   20.483      20.571 i/s -      51.000 times in 2.489822s 2.479206s
    count_with_block                                                   56.792      54.271 i/s -     164.000 times in 2.887742s 3.021896s

Comparison:
                            count
              ./ruby:  40571119.6 i/s 
/Users/kachick/.rubies/ruby-3.1.0dev-989e22f394/bin/ruby:        92.1 i/s - 440608.36x  slower

                   count_with_arg
              ./ruby:        20.6 i/s 
/Users/kachick/.rubies/ruby-3.1.0dev-989e22f394/bin/ruby:        20.5 i/s - 1.00x  slower

                 count_with_block
/Users/kachick/.rubies/ruby-3.1.0dev-989e22f394/bin/ruby:        56.8 i/s 
              ./ruby:        54.3 i/s - 1.05x  slower
```

How do you think?