### PR TITLE
Add a specialized instruction for `obj.class`

### DIFF
--- a/benchmark/vm_opt_class.yml
+++ b/benchmark/vm_opt_class.yml
@@ -1,0 +1,8 @@
+prelude: |
+  class C
+  end
+  obj = C.new
+benchmark:
+  vm_opt_class: |
+    obj.class
+loop_count: 8000000

--- a/compile.c
+++ b/compile.c
@@ -3458,6 +3458,7 @@ iseq_specialized_instruction(rb_iseq_t *iseq, INSN *iobj)
 		  case idSize:	 SP_INSN(size);	  return COMPILE_OK;
 		  case idEmptyP: SP_INSN(empty_p);return COMPILE_OK;
                   case idNilP:   SP_INSN(nil_p);  return COMPILE_OK;
+                  case idClass:  SP_INSN(class);  return COMPILE_OK;
 		  case idSucc:	 SP_INSN(succ);	  return COMPILE_OK;
 		  case idNot:	 SP_INSN(not);	  return COMPILE_OK;
 		}

--- a/defs/id.def
+++ b/defs/id.def
@@ -4,6 +4,7 @@ firstline, predefined = __LINE__+1, %[\
   min
   freeze
   nil?
+  class
   inspect
   intern
   object_id

--- a/insns.def
+++ b/insns.def
@@ -825,6 +825,20 @@ opt_nil_p
     }
 }
 
+/* optimized class */
+DEFINE_INSN
+opt_class
+(CALL_DATA cd)
+(VALUE recv)
+(VALUE val)
+{
+    val = vm_opt_class(GET_ISEQ(), cd, recv);
+
+    if (val == Qundef) {
+        CALL_SIMPLE_METHOD();
+    }
+}
+
 DEFINE_INSN
 opt_str_uminus
 (VALUE str, CALL_DATA cd)

--- a/kernel.rb
+++ b/kernel.rb
@@ -1,27 +1,6 @@
 module Kernel
   #
   #  call-seq:
-  #     obj.class    -> class
-  #
-  #  Returns the class of <i>obj</i>. This method must always be called
-  #  with an explicit receiver, as #class is also a reserved word in
-  #  Ruby.
-  #
-  #     1.class      #=> Integer
-  #     self.class   #=> Object
-  #--
-  # Equivalent to \c Object\#class in Ruby.
-  #
-  # Returns the class of \c obj, skipping singleton classes or module inclusions.
-  #++
-  #
-  def class
-    Primitive.attr! 'inline'
-    Primitive.cexpr! 'rb_obj_class(self)'
-  end
-
-  #
-  #  call-seq:
   #     obj.clone(freeze: nil) -> an_object
   #
   #  Produces a shallow copy of <i>obj</i>---the instance variables of

--- a/object.c
+++ b/object.c
@@ -291,6 +291,23 @@ rb_class_real(VALUE cl)
     return cl;
 }
 
+/*
+ *
+ *  call-seq:
+ *     obj.class    -> class
+ *
+ *  Returns the class of <i>obj</i>. This method must always be called
+ *  with an explicit receiver, as #class is also a reserved word in
+ *  Ruby.
+ *
+ *     1.class      #=> Integer
+ *     self.class   #=> Object
+ *--
+ * Equivalent to \c Object\#class in Ruby.
+ *
+ * Returns the class of \c obj, skipping singleton classes or module inclusions.
+ *++
+ */
 VALUE
 rb_obj_class(VALUE obj)
 {
@@ -4574,6 +4591,7 @@ InitVM_Object(void)
     rb_define_method(rb_mKernel, "eql?", rb_obj_equal, 1);
     rb_define_method(rb_mKernel, "hash", rb_obj_hash, 0); /* in hash.c */
     rb_define_method(rb_mKernel, "<=>", rb_obj_cmp, 1);
+    rb_define_method(rb_mKernel, "class", rb_obj_class, 0);
 
     rb_define_method(rb_mKernel, "singleton_class", rb_obj_singleton_class, 0);
     rb_define_method(rb_mKernel, "dup", rb_obj_dup, 0);

--- a/vm.c
+++ b/vm.c
@@ -1931,6 +1931,8 @@ vm_init_redefined_flag(void)
     OP(NilP, NIL_P), (C(NilClass));
 #undef C
 #undef OP
+    ruby_vm_redefined_flag[BOP_CLASS] = 0;
+    add_opt_method(rb_mKernel, idClass, BOP_CLASS);
 }
 
 /* for vm development */

--- a/vm_core.h
+++ b/vm_core.h
@@ -530,6 +530,7 @@ enum ruby_basic_operators {
     BOP_CALL,
     BOP_AND,
     BOP_OR,
+    BOP_CLASS,
 
     BOP_LAST_
 };
@@ -721,6 +722,7 @@ typedef struct rb_vm_struct {
 #define TRUE_REDEFINED_OP_FLAG   (1 << 10)
 #define FALSE_REDEFINED_OP_FLAG  (1 << 11)
 #define PROC_REDEFINED_OP_FLAG   (1 << 12)
+#define CLASS_REDEFINED_OP_FLAG   (1 << 13)
 
 #define BASIC_OP_UNREDEFINED_P(op, klass) (LIKELY((GET_VM()->redefined_flag[(op)]&(klass)) == 0))
 

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -5154,6 +5154,19 @@ vm_opt_nil_p(const rb_iseq_t *iseq, CALL_DATA cd, VALUE recv)
 }
 
 static VALUE
+vm_opt_class(const rb_iseq_t *iseq, CALL_DATA cd, VALUE recv)
+{
+    if (!BASIC_OP_UNREDEFINED_P(BOP_CLASS, CLASS_REDEFINED_OP_FLAG)) {
+        return Qundef;
+    }
+    if (vm_method_cfunc_is(iseq, cd, recv, rb_obj_class)) {
+        return rb_class_real(cd->cc->klass);
+    }
+
+    return Qundef;
+}
+
+static VALUE
 fix_succ(VALUE x)
 {
     switch (x) {


### PR DESCRIPTION
This was inspired by this commit in Rails:

  https://github.com/rails/rails/commit/f172129256e17899c19502b5494fa975c8ff2bbe

(Thanks to @rafaelfranca for showing me)

This adds a specialized instruction for `object.class` to speed up the
call.  I've added a benchmark as well, and here are the results
(compared to master Ruby):

```
compare-ruby: ruby 3.1.0dev (2021-03-24T18:31:10Z master b25361f731) [x86_64-darwin20]
built-ruby: ruby 3.1.0dev (2021-03-29T17:53:34Z bop-class dd38bc1d5f) [x86_64-darwin20]

|              |compare-ruby|built-ruby|
|:-------------|-----------:|---------:|
|vm_opt_class  |     81.000M|  238.202M|
|              |           -|     2.94x|
```

Here is @kamipo's benchmark:

```ruby
class A
  def self.foo
  end

  def foo1
    self.class.foo
    self.class.foo
    self.class.foo
    self.class.foo
  end

  def foo2
    klass = self.class
    klass.foo
    klass.foo
    klass.foo
    klass.foo
  end
end

a = A.new

Benchmark.ips do |x|
  x.report("foo1") { a.foo1 }
  x.report("foo2") { a.foo2 }
end
```

Using @kamipo's benchmark, it seems the overhead of calling `self.class`
is much smaller:

```
$ ./ruby -v x.rb
ruby 3.1.0dev (2021-03-29T17:53:34Z bop-class dd38bc1d5f) [x86_64-darwin20]
Warming up --------------------------------------
                foo1   765.012k i/100ms
                foo2   737.167k i/100ms
Calculating -------------------------------------
                foo1      7.570M (± 1.0%) i/s -     38.251M in   5.053240s
                foo2      7.329M (± 1.5%) i/s -     36.858M in   5.030233s

Comparison:
                foo1:  7570245.1 i/s
                foo2:  7329207.5 i/s - 1.03x  (± 0.00) slower
```