### PR TITLE
Always deliver postponed job to main ractor

### DIFF
--- a/ext/-test-/postponed_job/postponed_job.c
+++ b/ext/-test-/postponed_job/postponed_job.c
@@ -58,6 +58,34 @@ pjob_call_direct(VALUE self, VALUE obj)
     return self;
 }
 
+#ifdef HAVE_PTHREAD_H
+#include <pthread.h>
+
+static void *
+pjob_register_in_c_thread_i(void *obj)
+{
+    rb_postponed_job_register_one(0, pjob_one_callback, (void *)obj);
+    rb_postponed_job_register_one(0, pjob_one_callback, (void *)obj);
+    rb_postponed_job_register_one(0, pjob_one_callback, (void *)obj);
+    return NULL;
+}
+
+static VALUE
+pjob_register_in_c_thread(VALUE self, VALUE obj)
+{
+    pthread_t thread;
+    if (pthread_create(&thread, NULL, pjob_register_in_c_thread_i, (void *)obj)) {
+        return Qfalse;
+    }
+
+    if (pthread_join(thread, NULL)) {
+        return Qfalse;
+    }
+
+    return Qtrue;
+}
+#endif
+
 void
 Init_postponed_job(VALUE self)
 {
@@ -65,5 +93,8 @@ Init_postponed_job(VALUE self)
     rb_define_module_function(mBug, "postponed_job_register", pjob_register, 1);
     rb_define_module_function(mBug, "postponed_job_register_one", pjob_register_one, 1);
     rb_define_module_function(mBug, "postponed_job_call_direct", pjob_call_direct, 1);
+#ifdef HAVE_PTHREAD_H
+    rb_define_module_function(mBug, "postponed_job_register_in_c_thread", pjob_register_in_c_thread, 1);
+#endif
 }
 

--- a/test/-ext-/postponed_job/test_postponed_job.rb
+++ b/test/-ext-/postponed_job/test_postponed_job.rb
@@ -25,4 +25,11 @@ class TestPostponed_job < Test::Unit::TestCase
     Bug.postponed_job_register_one(ary = [])
     assert_equal [1], ary
   end
+
+  if Bug.respond_to?(:postponed_job_register_in_c_thread)
+    def test_register_in_c_thread
+      assert Bug.postponed_job_register_in_c_thread(ary = [])
+      assert_equal [1], ary
+    end
+  end
 end

--- a/vm_trace.c
+++ b/vm_trace.c
@@ -1599,8 +1599,8 @@ postponed_job_register(rb_execution_context_t *ec, rb_vm_t *vm,
 int
 rb_postponed_job_register(unsigned int flags, rb_postponed_job_func_t func, void *data)
 {
-    rb_execution_context_t *ec = GET_EC();
-    rb_vm_t *vm = rb_ec_vm_ptr(ec);
+    rb_vm_t *vm = GET_VM();
+    rb_execution_context_t *ec = rb_vm_main_ractor_ec(vm);
 
   begin:
     switch (postponed_job_register(ec, vm, flags, func, data, MAX_POSTPONED_JOB, vm->postponed_job_index)) {
@@ -1618,8 +1618,8 @@ rb_postponed_job_register(unsigned int flags, rb_postponed_job_func_t func, void
 int
 rb_postponed_job_register_one(unsigned int flags, rb_postponed_job_func_t func, void *data)
 {
-    rb_execution_context_t *ec = GET_EC();
-    rb_vm_t *vm = rb_ec_vm_ptr(ec);
+    rb_vm_t *vm = GET_VM();
+    rb_execution_context_t *ec = rb_vm_main_ractor_ec(vm);
     rb_postponed_job_t *pjob;
     rb_atomic_t i, index;
 


### PR DESCRIPTION
Profilers use `rb_postponed_job_register_one()` in signal handlers, and
signals don't necessarily land on a thread that runs Ruby code and has a
thread local execution context. The MJIT worker thread doesn't have an
execution context, for example.

Without an execution context, postponed job APIs were crashing. Always
use the main ractor's execution context so postponed job APIs can work
from non Ruby threads like in older versions.

Tests courtesy of John Crepezzi and John Hawthorn.

[Bug #17573](https://bugs.ruby-lang.org/issues/17573)

---

The test crashes without the code change.