### PR TITLE
Revert "Force recycle intermediate collection in Hash#transform_keys!"

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -3294,9 +3294,7 @@ rb_hash_transform_keys_bang(int argc, VALUE *argv, VALUE hash)
             rb_hash_aset(new_keys, new_key, Qnil);
         }
         rb_ary_clear(pairs);
-        rb_gc_force_recycle(pairs);
         rb_hash_clear(new_keys);
-        rb_gc_force_recycle(new_keys);
     }
     return hash;
 }


### PR DESCRIPTION
Reverts ruby/ruby#4329

https://github.com/ruby/ruby/pull/4329#issuecomment-810842130

>Please Do not use force_recycle because it is an exceptional operation and slow, now a day . It can violate GC assumptions. I wanted to make it no-op, but I couldn't make it because some code depends on this behavior.

@ko1 🙏 Please merge if it is needed... 🙇 