### PR TITLE
skip marking for uninitialized imemo_env.

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -6266,12 +6266,16 @@ gc_mark_imemo(rb_objspace_t *objspace, VALUE obj)
       case imemo_env:
 	{
 	    const rb_env_t *env = (const rb_env_t *)obj;
-            GC_ASSERT(env->ep[VM_ENV_DATA_INDEX_ENV] == obj);
-	    GC_ASSERT(VM_ENV_ESCAPED_P(env->ep));
-            gc_mark_values(objspace, (long)env->env_size, env->env);
-	    VM_ENV_FLAGS_SET(env->ep, VM_ENV_FLAG_WB_REQUIRED);
-            gc_mark(objspace, (VALUE)rb_vm_env_prev_env(env));
-	    gc_mark(objspace, (VALUE)env->iseq);
+
+            if (LIKELY(env->ep)) {
+                // just after newobj() can be NULL here.
+                GC_ASSERT(env->ep[VM_ENV_DATA_INDEX_ENV] == obj);
+                GC_ASSERT(VM_ENV_ESCAPED_P(env->ep));
+                gc_mark_values(objspace, (long)env->env_size, env->env);
+                VM_ENV_FLAGS_SET(env->ep, VM_ENV_FLAG_WB_REQUIRED);
+                gc_mark(objspace, (VALUE)rb_vm_env_prev_env(env));
+                gc_mark(objspace, (VALUE)env->iseq);
+            }
 	}
 	return;
       case imemo_cref:

--- a/test/objspace/test_objspace.rb
+++ b/test/objspace/test_objspace.rb
@@ -243,6 +243,19 @@ class TestObjSpace < Test::Unit::TestCase
     GC.enable
   end
 
+  def test_trace_object_allocations_gc_stress
+    prev = GC.stress
+    GC.stress = true
+
+    ObjectSpace.trace_object_allocations{
+      proc{}
+    }
+
+    assert true # success
+  ensure
+    GC.stress = prev
+  end
+
   def test_dump_flags
     info = ObjectSpace.dump("foo".freeze)
     assert_match(/"wb_protected":true, "old":true/, info)


### PR DESCRIPTION
RUBY_INTERNAL_EVENT_NEWOBJ can expose uninitialized imemo_env
objects and marking it will cause critical error. This patch
skips marking on uninitialized imemo_env.

See: http://rubyci.s3.amazonaws.com/centos7/ruby-master/log/20210329T183003Z.fail.html.gz

Shortest repro-code is provided by mame-san.