### PR TITLE
`Cloned ENV` inconsistently returns `ENV` or `self` [Bug #17767]

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -5014,7 +5014,7 @@ rb_f_getenv(VALUE obj, VALUE name)
  * See {Invalid Names and Values}[#class-ENV-label-Invalid+Names+and+Values].
  */
 static VALUE
-env_fetch(int argc, VALUE *argv, VALUE _)
+env_fetch(int argc, VALUE *argv, VALUE ehash)
 {
     VALUE key;
     long block_given;
@@ -5031,7 +5031,7 @@ env_fetch(int argc, VALUE *argv, VALUE _)
     if (!env) {
 	if (block_given) return rb_yield(key);
 	if (argc == 1) {
-	    rb_key_err_raise(rb_sprintf("key not found: \"%"PRIsVALUE"\"", key), envtbl, key);
+	    rb_key_err_raise(rb_sprintf("key not found: \"%"PRIsVALUE"\"", key), ehash, key);
 	}
 	return argv[1];
     }
@@ -5600,7 +5600,7 @@ env_reject_bang(VALUE ehash)
     }
     RB_GC_GUARD(keys);
     if (del == 0) return Qnil;
-    return envtbl;
+    return ehash;
 }
 
 /*
@@ -5628,7 +5628,7 @@ env_delete_if(VALUE ehash)
 {
     RETURN_SIZED_ENUMERATOR(ehash, 0, 0, rb_env_size);
     env_reject_bang(ehash);
-    return envtbl;
+    return ehash;
 }
 
 /*
@@ -5764,7 +5764,7 @@ env_select_bang(VALUE ehash)
     }
     RB_GC_GUARD(keys);
     if (del == 0) return Qnil;
-    return envtbl;
+    return ehash;
 }
 
 /*
@@ -5790,7 +5790,7 @@ env_keep_if(VALUE ehash)
 {
     RETURN_SIZED_ENUMERATOR(ehash, 0, 0, rb_env_size);
     env_select_bang(ehash);
-    return envtbl;
+    return ehash;
 }
 
 /*
@@ -5826,8 +5826,8 @@ env_slice(int argc, VALUE *argv, VALUE _)
     return result;
 }
 
-VALUE
-rb_env_clear(void)
+static VALUE
+rb_env_clear2(VALUE ehash)
 {
     VALUE keys;
     long i;
@@ -5839,7 +5839,13 @@ rb_env_clear(void)
         ruby_setenv(nam, 0);
     }
     RB_GC_GUARD(keys);
-    return envtbl;
+    return ehash;
+}
+
+VALUE
+rb_env_clear(void)
+{
+    return rb_env_clear2(envtbl);
 }
 
 /*
@@ -5853,9 +5859,9 @@ rb_env_clear(void)
  *   ENV.size # => 0
  */
 static VALUE
-env_clear(VALUE _)
+env_clear(VALUE ehash)
 {
-    return rb_env_clear();
+    return rb_env_clear2(ehash);
 }
 
 /*


### PR DESCRIPTION
ref: https://bugs.ruby-lang.org/issues/17767

Is this an expected behavior? 😅 

```console
$ ruby -v
ruby 3.0.0p0 (2020-12-25 revision 95aff21468) [x86_64-darwin20]
```

```ruby
cloned_env = ENV.clone

p ENV.each_key{}.equal?(ENV) #=> true
p cloned_env.each_key{}.equal?(cloned_env) #=> true

ENV.delete('TEST')

err = ENV.fetch('TEST') rescue $!
p err.receiver.equal?(ENV) #=> true
err = cloned_env.fetch('TEST') rescue $!
p err.receiver.equal?(cloned_env) #=> false

ENV['TEST'] = 'TRUE'
p ENV.select!{ false }.equal?(ENV) #=> true

cloned_env['TEST'] = 'TRUE'
p cloned_env.select!{ false }.equal?(cloned_env) #=> false
```

I guess ruby don't care `Cloned ENV` objects.
Yes, anyone basically do not write these code.
But the behaviors looks weird to me. 😓 

Should block to clone?
Should return ENV?
Should return self?

I think `they return self` makes consistently behaviors and does not break compatibilities.
So I have created this PR 😅 