### PR TITLE
fix return from orphan Proc in lambda

### DIFF
--- a/test/ruby/test_lambda.rb
+++ b/test/ruby/test_lambda.rb
@@ -74,6 +74,109 @@ class TestLambdaParameters < Test::Unit::TestCase
     assert_raise(ArgumentError, bug9605) {proc(&plus).call [1,2]}
   end
 
+  def test_proc_inside_lambda_inside_method_return_inside_lambda_inside_method
+    def self.a
+      r = -> do
+        p = Proc.new{return :a}
+        p.call
+      end.call
+    end
+    assert_equal(:a, a)
+
+    def self.b
+      r = lambda do
+        p = Proc.new{return :b}
+        p.call
+      end.call
+    end
+    assert_equal(:b, b)
+  end
+
+  def test_proc_inside_lambda_inside_method_return_inside_lambda_outside_method
+    def self.a
+      r = -> do
+        p = Proc.new{return :a}
+        p.call
+      end
+    end
+    assert_equal(:a, a.call)
+
+    def self.b
+      r = lambda do
+        p = Proc.new{return :b}
+        p.call
+      end
+    end
+    assert_equal(:b, b.call)
+  end
+
+  def test_proc_inside_lambda_inside_method_return_outside_lambda_inside_method
+    def self.a
+      r = -> do
+        Proc.new{return :a}
+      end.call.call
+    end
+    assert_raise(LocalJumpError) {a}
+
+    def self.b
+      r = lambda do
+        Proc.new{return :b}
+      end.call.call
+    end
+    assert_raise(LocalJumpError) {b}
+  end
+
+  def test_proc_inside_lambda_inside_method_return_outside_lambda_outside_method
+    def self.a
+      r = -> do
+        Proc.new{return :a}
+      end
+    end
+    assert_raise(LocalJumpError) {a.call.call}
+
+    def self.b
+      r = lambda do
+        Proc.new{return :b}
+      end
+    end
+    assert_raise(LocalJumpError) {b.call.call}
+  end
+
+  def test_proc_inside_lambda2_inside_method_return_outside_lambda1_inside_method
+    def self.a
+      r = -> do
+        -> do
+          Proc.new{return :a}
+        end.call.call
+      end.call
+    end
+    assert_raise(LocalJumpError) {a}
+
+    def self.b
+      r = lambda do
+        lambda do
+          Proc.new{return :a}
+        end.call.call
+      end.call
+    end
+    assert_raise(LocalJumpError) {b}
+  end
+
+  def test_proc_inside_lambda_toplevel
+    assert_separately [], <<~RUBY
+      lambda{
+        $g = proc{ return :pr }
+      }.call
+      begin
+        $g.call
+      rescue LocalJumpError
+        # OK!
+      else
+        raise
+      end
+    RUBY
+  end
+
   def pass_along(&block)
     lambda(&block)
   end


### PR DESCRIPTION
A "return" statement in a Proc in a lambda like:
  `lambda{ proc{ return }.call }`
should return outer lambda block. However, the inner Proc can become
orphan Proc from the lambda block.
  `lambda{ $g = proc{ return } }.call; $g.call`
This "return" escape outer-scope
like method, but this behavior was decieded as a bug.
[Bug #17105]

This patch raises LocalJumpError by checking the proc is orphan or
not from lambda blocks before escaping by "return".