### PR TITLE
Make ENV.clone and ENV.dup return ENV

### DIFF
--- a/test/ruby/test_env.rb
+++ b/test/ruby/test_env.rb
@@ -62,6 +62,31 @@ class TestEnv < Test::Unit::TestCase
     }
   end
 
+  def test_dup
+    assert_same(ENV, ENV.dup)
+  end
+
+  def test_clone
+    assert_same(ENV, ENV.clone)
+    assert_same(ENV, ENV.clone(freeze: nil))
+    assert_same(ENV, ENV.clone(freeze: false))
+    assert_raise(TypeError) {
+      ENV.clone(freeze: true)
+    }
+    assert_raise(ArgumentError) {
+      ENV.clone(freeze: 1)
+    }
+    assert_raise(ArgumentError) {
+      ENV.clone(foo: false)
+    }
+    assert_raise(ArgumentError) {
+      ENV.clone(1)
+    }
+    assert_raise(ArgumentError) {
+      ENV.clone(1, foo: false)
+    }
+  end
+
   def test_has_value
     val = 'a'
     val.succ! while ENV.has_value?(val) || ENV.has_value?(val.upcase)


### PR DESCRIPTION
ENV is a singleton object, and it doesn't make sense for clone
and dup to return a separate object as the same environment table
is used.

ENV.dup previously returned a regular instance of Object, and as
such was worthless.

Have ENV.clone(freeze: true) raise TypeError, the same as
ENV.freeze.

Also undef the ENV.initialize{,_dup,_clone,_copy} private methods
as they are not needed.

Fixes [Bug #17767]