### PR TITLE
Refactor rb_obj_call_init and rb_obj_call_init_kw

### DIFF
--- a/eval.c
+++ b/eval.c
@@ -1698,6 +1698,13 @@ rb_mod_s_used_modules(VALUE _)
     return rb_funcall(ary, rb_intern("uniq"), 0);
 }
 
+static void
+rb_obj_init(VALUE obj, int argc, const VALUE *argv, int kw_splat)
+{
+    PASS_PASSED_BLOCK_HANDLER();
+    rb_funcallv_kw(obj, idInitialize, argc, argv, kw_splat);    
+}
+
 /*!
  * Calls \c #initialize method of \a obj with the given arguments.
  *
@@ -1711,15 +1718,13 @@ rb_mod_s_used_modules(VALUE _)
 void
 rb_obj_call_init(VALUE obj, int argc, const VALUE *argv)
 {
-    PASS_PASSED_BLOCK_HANDLER();
-    rb_funcallv_kw(obj, idInitialize, argc, argv, RB_NO_KEYWORDS);
+    rb_obj_init(obj, argc, argv, RB_NO_KEYWORDS);
 }
 
 void
 rb_obj_call_init_kw(VALUE obj, int argc, const VALUE *argv, int kw_splat)
 {
-    PASS_PASSED_BLOCK_HANDLER();
-    rb_funcallv_kw(obj, idInitialize, argc, argv, kw_splat);
+    rb_obj_init(obj, argc, argv, kw_splat);
 }
 
 /*!

--- a/eval.c
+++ b/eval.c
@@ -1698,12 +1698,7 @@ rb_mod_s_used_modules(VALUE _)
     return rb_funcall(ary, rb_intern("uniq"), 0);
 }
 
-static void
-rb_obj_init(VALUE obj, int argc, const VALUE *argv, int kw_splat)
-{
-    PASS_PASSED_BLOCK_HANDLER();
-    rb_funcallv_kw(obj, idInitialize, argc, argv, kw_splat);
-}
+void rb_obj_call_init_kw(VALUE obj, int argc, const VALUE *argv, int kw_splat);
 
 /*!
  * Calls \c #initialize method of \a obj with the given arguments.
@@ -1718,13 +1713,14 @@ rb_obj_init(VALUE obj, int argc, const VALUE *argv, int kw_splat)
 void
 rb_obj_call_init(VALUE obj, int argc, const VALUE *argv)
 {
-    rb_obj_init(obj, argc, argv, RB_NO_KEYWORDS);
+    rb_obj_call_init_kw(obj, argc, argv, RB_NO_KEYWORDS);
 }
 
 void
 rb_obj_call_init_kw(VALUE obj, int argc, const VALUE *argv, int kw_splat)
 {
-    rb_obj_init(obj, argc, argv, kw_splat);
+    PASS_PASSED_BLOCK_HANDLER();
+    rb_funcallv_kw(obj, idInitialize, argc, argv, kw_splat);
 }
 
 /*!

--- a/eval.c
+++ b/eval.c
@@ -1698,8 +1698,6 @@ rb_mod_s_used_modules(VALUE _)
     return rb_funcall(ary, rb_intern("uniq"), 0);
 }
 
-void rb_obj_call_init_kw(VALUE obj, int argc, const VALUE *argv, int kw_splat);
-
 /*!
  * Calls \c #initialize method of \a obj with the given arguments.
  *

--- a/eval.c
+++ b/eval.c
@@ -1702,7 +1702,7 @@ static void
 rb_obj_init(VALUE obj, int argc, const VALUE *argv, int kw_splat)
 {
     PASS_PASSED_BLOCK_HANDLER();
-    rb_funcallv_kw(obj, idInitialize, argc, argv, kw_splat);    
+    rb_funcallv_kw(obj, idInitialize, argc, argv, kw_splat);
 }
 
 /*!


### PR DESCRIPTION
`rb_obj_call_init` and `rb_obj_call_init_kw` func have similar code(in `eval.c`).
~~I think that better cut out and replace these code like `rb_obj_init` function.~~
I think that better refactor `rb_obj_init` and `rb_obj_call_init_kw`.