### PR TITLE
Array#fill ensure receiver is modifiable in given block [Bug #17736]

### DIFF
--- a/array.c
+++ b/array.c
@@ -4783,6 +4783,7 @@ rb_ary_fill(int argc, VALUE *argv, VALUE ary)
 	for (i=beg; i<end; i++) {
 	    v = rb_yield(LONG2NUM(i));
 	    if (i>=RARRAY_LEN(ary)) break;
+	    rb_ary_modify(ary);
 	    ARY_SET(ary, i, v);
 	}
     }

--- a/test/ruby/test_array.rb
+++ b/test/ruby/test_array.rb
@@ -217,6 +217,32 @@ class TestArray < Test::Unit::TestCase
     assert_equal([0, 1, 2, 13, 14, 15], [0, 1, 2, 3, 4, 5].fill(3...){|i| i+10})
   end
 
+  def test_fill_with_block_and_frozen_error
+    array = @cls[42, 43, 44, 45, 46, 47, 48]
+    assert_raise(FrozenError) do
+      array.fill{ |i| i < 2 ? i + 10 : array.freeze }
+    end
+    assert_equal([10, 11, 44, 45, 46, 47, 48], array)
+
+    array = @cls[42, 43, 44, 45, 46, 47, 48]
+    assert_raise(FrozenError) do
+      array.fill(2){ |i| i < 4 ? i + 10 : array.freeze }
+    end
+    assert_equal([42, 43, 12, 13, 46, 47, 48], array)
+
+    array = @cls[42, 43, 44, 45, 46, 47, 48]
+    assert_raise(FrozenError) do
+      array.fill(2, 3){ |i| i < 4 ? i + 10 : array.freeze }
+    end
+    assert_equal([42, 43, 12, 13, 46, 47, 48], array)
+
+    array = @cls[42, 43, 44, 45, 46, 47, 48]
+    assert_raise(FrozenError) do
+      array.fill(3..4){ |i| i < 4 ? i + 10 : array.freeze }
+    end
+    assert_equal([42, 43, 44, 13, 46, 47, 48], array)
+  end
+
   # From rubicon
 
   def test_00_new


### PR DESCRIPTION
This PR aims to fix a part of https://bugs.ruby-lang.org/issues/17736

```console
$ ruby -v
ruby 3.0.0p0 (2020-12-25 revision 95aff21468) [x86_64-darwin20]
```

```ruby
array = [1, 2, 3]
array.fill { |i| array.freeze; i + 20 }
p array #=> [20, 21, 22]
```

---

By the way...
When I writing some test cases, I found other behaviors caught my attention.

```ruby
array = [1, 2, 3]
array.fill(0, 5) { break }
p array #=> [1, 2, 3, nil, nil]
```

Is it an intentional behavior?

Then adding https://github.com/ruby/ruby/commit/945af748c45c24218ae3f7f4857c3901e1b12237 might be better?
Or should I create another ticket?