### PR TITLE
Make Kernel#fork a simple delegator to Process.fork

### DIFF
--- a/process.c
+++ b/process.c
@@ -4356,8 +4356,23 @@ rb_f_fork(VALUE obj)
 	return PIDT2NUM(pid);
     }
 }
+
+/*
+ *  call-seq:
+ *     Kernel.fork  [{ block }]   -> integer or nil
+ *
+ *  Creates a subprocess.
+ *
+ *  See Process.fork
+ */
+
+static VALUE
+rb_f_call_fork(int argc, VALUE *argv, VALUE self) {
+    return rb_funcall_passing_block_kw(rb_mProcess, rb_intern("fork"), argc, argv, RB_PASS_CALLED_KEYWORDS);
+}
 #else
 #define rb_f_fork rb_f_notimplement
+#define rb_f_call_fork rb_f_notimplement
 #endif
 
 static int
@@ -8625,7 +8640,7 @@ InitVM_process(void)
     rb_gvar_ractor_local("$?");
 
     rb_define_global_function("exec", f_exec, -1);
-    rb_define_global_function("fork", rb_f_fork, 0);
+    rb_define_global_function("fork", rb_f_call_fork, -1);
     rb_define_global_function("exit!", rb_f_exit_bang, -1);
     rb_define_global_function("system", rb_f_system, -1);
     rb_define_global_function("spawn", rb_f_spawn, -1);


### PR DESCRIPTION
This change makes it much easier to properly decorate the fork method like in `nakayoshi_fork`.

For context I was about do a feature request for a proper `before_fork` / `after_fork` API (e.g. https://bugs.ruby-lang.org/issues/5446), but ultimately I think that if it was easy and clean enough to decorate the `fork` method with a prepended module, such extra API wouldn't be needed.

Right now such decorator is a bit involved because the method is available as both `Kernel.fork` and `Process.fork`, so [doing it cleanly is quite complicated](https://github.com/rails/rails/blob/0ff395e1b115c91e286f694a0dbd136ddcde2f2a/activesupport/lib/active_support/fork_tracker.rb), and as a matter of fact, `nakayoshi_fork` doesn't decorate `Process.fork`:

```ruby
>> require 'nakayoshi_fork'
=> true
>> Process.fork(cow_friendly: true)
(irb):2:in `fork': wrong number of arguments (given 1, expected 0) (ArgumentError)
```

With `Kernel.fork` becoming a delegator, it makes it much easier and reliable.

@ko1 would you be open to this change?

Also @tenderlove since you were involved in the `at_fork` discussion, as well as in the `nakayoshi_fork` issues.
