### PR TITLE
Deprecate `rb_gc_force_recycle`

### DIFF
--- a/array.c
+++ b/array.c
@@ -514,13 +514,9 @@ rb_ary_decrement_share(VALUE shared_root)
 {
     if (shared_root) {
         long num = ARY_SHARED_ROOT_REFCNT(shared_root) - 1;
-	if (num == 0) {
-            rb_ary_free(shared_root);
-            rb_gc_force_recycle(shared_root);
-	}
-	else if (num > 0) {
+        if (num > 0) {
             ARY_SET_SHARED_ROOT_REFCNT(shared_root, num);
-	}
+        }
     }
 }
 

--- a/bignum.c
+++ b/bignum.c
@@ -6934,8 +6934,6 @@ rb_big_isqrt(VALUE n)
 	    bary_small_rshift(xds, xds, xn, 1, carry);
 	    tn = BIGNUM_LEN(t);
 	}
-	rb_big_realloc(t, 0);
-	rb_gc_force_recycle(t);
     }
     RBASIC_SET_CLASS_RAW(x, rb_cInteger);
     return x;

--- a/ext/readline/readline.c
+++ b/ext/readline/readline.c
@@ -696,7 +696,6 @@ str_subpos(const char *ptr, const char *end, long beg, long *sublen, rb_encoding
     VALUE str = rb_enc_str_new_static(ptr, end-ptr, enc);
     OBJ_FREEZE(str);
     ptr = rb_str_subpos(str, beg, sublen);
-    rb_gc_force_recycle(str);
     return ptr;
 }
 

--- a/ext/zlib/zlib.c
+++ b/ext/zlib/zlib.c
@@ -894,7 +894,6 @@ zstream_discard_input(struct zstream *z, long len)
 	}
 	rb_str_resize(z->input, newlen);
 	if (newlen == 0) {
-	    rb_gc_force_recycle(z->input);
 	    z->input = Qnil;
 	}
 	else {
@@ -1137,7 +1136,6 @@ loop:
     }
     if (!NIL_P(old_input)) {
 	rb_str_resize(old_input, 0);
-	rb_gc_force_recycle(old_input);
     }
 
     if (args.jump_state)
@@ -2906,8 +2904,6 @@ gzfile_readpartial(struct gzfile *gz, long len, VALUE outbuf)
     if (!NIL_P(outbuf)) {
         rb_str_resize(outbuf, RSTRING_LEN(dst));
         memcpy(RSTRING_PTR(outbuf), RSTRING_PTR(dst), RSTRING_LEN(dst));
-	rb_str_resize(dst, 0);
-	rb_gc_force_recycle(dst);
 	dst = outbuf;
     }
     return dst;

--- a/hash.c
+++ b/hash.c
@@ -1267,7 +1267,6 @@ rb_hash_transient_heap_evacuate(VALUE hash, int promote)
         ar_table *old_tab = RHASH_AR_TABLE(hash);
 
         if (UNLIKELY(old_tab == NULL)) {
-            rb_gc_force_recycle(hash);
             return;
         }
         HASH_ASSERT(old_tab != NULL);
@@ -4397,7 +4396,6 @@ rb_hash_compare_by_id(VALUE hash)
     st_free_table(RHASH_ST_TABLE(hash));
     RHASH_ST_TABLE_SET(hash, identtable);
     RHASH_ST_CLEAR(tmp);
-    rb_gc_force_recycle(tmp);
 
     return hash;
 }

--- a/include/ruby/internal/intern/gc.h
+++ b/include/ruby/internal/intern/gc.h
@@ -208,7 +208,9 @@ VALUE rb_gc_location(VALUE obj);
  * @post        `obj` could be invalidated.
  * @warning     It  is a  failure  to pass  an object  multiple  times to  this
  *              function.
+ * @deprecated  This is now a no-op function.
  */
+RBIMPL_ATTR_DEPRECATED(("this is now a no-op function"))
 void rb_gc_force_recycle(VALUE obj);
 
 /**

--- a/io.c
+++ b/io.c
@@ -9399,7 +9399,7 @@ rb_f_backquote(VALUE obj, VALUE str)
     rb_io_close(port);
     RFILE(port)->fptr = NULL;
     rb_io_fptr_finalize(fptr);
-    rb_gc_force_recycle(port); /* also guards from premature GC */
+    RB_GC_GUARD(port);
 
     return result;
 }

--- a/parse.y
+++ b/parse.y
@@ -13401,12 +13401,10 @@ rb_parser_free(struct parser_params *p, void *ptr)
     while ((n = *prev) != NULL) {
 	if (n->ptr == ptr) {
 	    *prev = n->next;
-	    rb_gc_force_recycle((VALUE)n);
 	    break;
 	}
 	prev = &n->next;
     }
-    xfree(ptr);
 }
 #endif
 

--- a/template/prelude.c.tmpl
+++ b/template/prelude.c.tmpl
@@ -270,9 +270,6 @@ Init_<%=init_name%><%=%>(void)
 %   next if sub
     prelude_eval(PRELUDE_CODE(<%=i%><%=%>), PRELUDE_NAME(<%=i%><%=%>), <%=start_line%>);
 % end
-% if @have_sublib
-    rb_gc_force_recycle(prelude);
-% end
 
 #if 0
 % preludes.length.times {|i|

--- a/thread.c
+++ b/thread.c
@@ -3459,7 +3459,6 @@ rb_thread_to_s(VALUE thread)
     if ((loc = threadptr_invoke_proc_location(target_th)) != Qnil) {
         rb_str_catf(str, " %"PRIsVALUE":%"PRIsVALUE,
                     RARRAY_AREF(loc, 0), RARRAY_AREF(loc, 1));
-        rb_gc_force_recycle(loc);
     }
     rb_str_catf(str, " %s>", status);
 

--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -1684,7 +1684,7 @@ native_set_thread_name(rb_thread_t *th)
             name = p + 1;
 
         n = snprintf(buf, sizeof(buf), "%s:%d", name, NUM2INT(RARRAY_AREF(loc, 1)));
-        rb_gc_force_recycle(loc); /* acts as a GC guard, too */
+        RB_GC_GUARD(loc);
 
         len = (size_t)n;
         if (len >= sizeof(buf)) {


### PR DESCRIPTION
I'm proposing to deprecate `rb_gc_force_recycle` and make it a no-op function because it is a burden to maintain and makes changes to the GC difficult. It is also easy to incorrectly use this function and cause memory leaks such as [#18065](https://bugs.ruby-lang.org/issues/18065).