### PR TITLE
Fix Method#super_method for module alias

### DIFF
--- a/proc.c
+++ b/proc.c
@@ -3227,7 +3227,7 @@ method_super_method(VALUE method)
     TypedData_Get_Struct(method, struct METHOD, &method_data_type, data);
     iclass = data->iclass;
     if (!iclass) return Qnil;
-    if (data->me->def->type == VM_METHOD_TYPE_ALIAS) {
+    if (data->me->def->type == VM_METHOD_TYPE_ALIAS && data->me->defined_class) {
         super_class = RCLASS_SUPER(rb_find_defined_class_by_owner(data->me->defined_class,
             data->me->def->body.alias.original_me->owner));
         mid = data->me->def->body.alias.original_me->def->original_id;

--- a/test/ruby/test_method.rb
+++ b/test/ruby/test_method.rb
@@ -1168,6 +1168,19 @@ class TestMethod < Test::Unit::TestCase
     assert_nil(m.super_method)
   end
 
+  # Bug 17780
+  def test_super_method_module_alias
+    m = Module.new do
+      def foo
+      end
+      alias :f :foo
+    end
+
+    method = m.instance_method(:f)
+    super_method = method.super_method
+    assert_nil(super_method)
+  end
+
   def rest_parameter(*rest)
     rest
   end


### PR DESCRIPTION
Redmine ticket: https://bugs.ruby-lang.org/issues/17780

Method#super_method crashes for aliased module methods because they are not defined on a class. This bug was introduced in c60aaed1856b2b6f90de0992c34771830019e021 as part of bug #17130 (PR #3458).