### PR TITLE
Do not check pending interrupts when running finalizers

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -4088,10 +4088,14 @@ static void
 finalize_deferred(rb_objspace_t *objspace)
 {
     VALUE zombie;
+    rb_execution_context_t *ec = GET_EC();
+    ec->interrupt_mask |= PENDING_INTERRUPT_MASK;
 
     while ((zombie = ATOMIC_VALUE_EXCHANGE(heap_pages_deferred_final, 0)) != 0) {
 	finalize_list(objspace, zombie);
     }
+
+    ec->interrupt_mask &= ~PENDING_INTERRUPT_MASK;
 }
 
 static void

--- a/test/ruby/test_objectspace.rb
+++ b/test/ruby/test_objectspace.rb
@@ -168,6 +168,31 @@ End
     end;
   end
 
+  def test_finalizer_thread_raise
+    GC.disable
+    fzer = proc do |id|
+      sleep 0.2
+    end
+    2.times do
+      o = Object.new
+      ObjectSpace.define_finalizer(o, fzer)
+    end
+
+    my_error = Class.new(RuntimeError)
+    begin
+      main_th = Thread.current
+      Thread.new do
+        sleep 0.1
+        main_th.raise(my_error)
+      end
+      GC.start
+      puts "After GC"
+      sleep(10)
+      assert(false)
+    rescue my_error
+    end
+  end
+
   def test_each_object
     klass = Class.new
     new_obj = klass.new


### PR DESCRIPTION
This fixes cases where exceptions raised using Thread#raise are
swallowed by finalizers and not delivered to the running thread.

This could cause issues with more finalizers that rely on
pending interrupts.

Fixes [Bug #13876]