### PR TITLE
String#clear keep the string capacity

### DIFF
--- a/string.c
+++ b/string.c
@@ -5609,14 +5609,16 @@ rb_str_replace(VALUE str, VALUE str2)
 static VALUE
 rb_str_clear(VALUE str)
 {
-    str_discard(str);
-    STR_SET_EMBED(str);
-    STR_SET_EMBED_LEN(str, 0);
+    str_modifiable(str);
+    if (FL_TEST_RAW(str, STR_SHARED|STR_NOFREE)) {
+        STR_SET_EMBED(str);
+    }
+    STR_SET_LEN(str, 0);
     RSTRING_PTR(str)[0] = 0;
     if (rb_enc_asciicompat(STR_ENC_GET(str)))
-	ENC_CODERANGE_SET(str, ENC_CODERANGE_7BIT);
+        ENC_CODERANGE_SET(str, ENC_CODERANGE_7BIT);
     else
-	ENC_CODERANGE_SET(str, ENC_CODERANGE_VALID);
+        ENC_CODERANGE_SET(str, ENC_CODERANGE_VALID);
     return str;
 }
 


### PR DESCRIPTION
[Feature #17790] https://bugs.ruby-lang.org/issues/17790

This is useful when trying to efficiently re-use a buffer, and is consistent with `Array#clear`.