### PR TITLE
Allow override of optimized method if class uses prepend

### DIFF
--- a/test/ruby/test_method.rb
+++ b/test/ruby/test_method.rb
@@ -1303,6 +1303,21 @@ class TestMethod < Test::Unit::TestCase
     end;
   end
 
+  def test_override_optimized_method_on_class_using_prepend
+    assert_separately(%w(--disable-gems), <<-'end;', timeout: 30)
+      # Bug #17725 [ruby-core:102884]
+      $VERBOSE = nil
+      String.prepend(Module.new)
+      class String
+        def + other
+          'blah blah'
+        end
+      end
+
+      assert_equal('blah blah', 'a' + 'b')
+    end;
+  end
+
   def test_eqq
     assert_operator(0.method(:<), :===, 5)
     assert_not_operator(0.method(:<), :===, -5)


### PR DESCRIPTION
When a class uses prepend, method entries change, causing
a matching entry not to be found in vm_opt_method_table
later when the method is redefined.

Replace vm_opt_method_table with vm_opt_mid_class_table,
which is a table mapping method ids to an array of classes.
When checking for optimized method redefinition, see if there
is an entry for the method id, and if so, see if the currently
class is in the array of classes.  If so, mark the optimized
method as having been overridden.

Fixes [Bug #17725]