### PR TITLE
Add RSymbol struct back into RVALUE

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -583,6 +583,7 @@ typedef struct RVALUE {
 	struct RMatch  match;
 	struct RRational rational;
 	struct RComplex complex;
+        struct RSymbol symbol;
 	union {
 	    rb_cref_t cref;
 	    struct vm_svar svar;


### PR DESCRIPTION
Commit 0ca714fa1aa3fbe4fb60ae1e5b730e544dabc27b removed RSymbol from RVALUE. This commit adds RSymbol back into RVALUE.

@nobu can you confirm whether the removal was intentional or not?