### PR TITLE
Remove useless attribute set in `init_mark_stack`

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -5573,7 +5573,6 @@ init_mark_stack(mark_stack_t *stack)
 
     MEMZERO(stack, mark_stack_t, 1);
     stack->index = stack->limit = STACK_CHUNK_SIZE;
-    stack->cache_size = 0;
 
     for (i=0; i < 4; i++) {
         add_stack_chunk_cache(stack, stack_chunk_alloc());


### PR DESCRIPTION
`init_mark_stack` already clears the mark stack so we do not need to set the attribute `cache_size` to zero.