### PR TITLE
array.c (rb_ary_zip): take only as many as needed from an Enumerator

### DIFF
--- a/array.c
+++ b/array.c
@@ -4311,10 +4311,9 @@ static VALUE
 take_i(RB_BLOCK_CALL_FUNC_ARGLIST(val, cbarg))
 {
     VALUE *args = (VALUE *)cbarg;
-    if (args[1] == 0) rb_iter_break();
-    else args[1]--;
     if (argc > 1) val = rb_ary_new4(argc, argv);
     rb_ary_push(args[0], val);
+    if (--args[1] == 0) rb_iter_break();
     return Qnil;
 }
 
@@ -4324,6 +4323,7 @@ take_items(VALUE obj, long n)
     VALUE result = rb_check_array_type(obj);
     VALUE args[2];
 
+    if (n == 0) return result;
     if (!NIL_P(result)) return rb_ary_subseq(result, 0, n);
     result = rb_ary_new2(n);
     args[0] = result; args[1] = (VALUE)n;

--- a/test/ruby/test_array.rb
+++ b/test/ruby/test_array.rb
@@ -2722,6 +2722,17 @@ class TestArray < Test::Unit::TestCase
     assert_equal [[42, 1]], [42].zip(r), bug8153
   end
 
+  def test_zip_with_enumerator
+    bug17814 = "ruby-core:103513"
+
+    step = 0.step
+    e = Enumerator.produce { step.next }
+    a = %w(a b c)
+    assert_equal([["a", 0], ["b", 1], ["c", 2]], a.zip(e))
+    assert_equal([["a", 3], ["b", 4], ["c", 5]], a.zip(e))
+    assert_equal([["a", 6], ["b", 7], ["c", 8]], a.zip(e))
+  end
+
   def test_transpose
     assert_equal([[1, :a], [2, :b], [3, :c]],
       [[1, 2, 3], [:a, :b, :c]].transpose)


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/17814 [Bug #17814]