### PR TITLE
Fix documentation typo

### DIFF
--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -694,7 +694,7 @@ using CSV::MatchP if CSV.const_defined?(:MatchP)
 # Header converters operate only on headers (and not on other rows).
 #
 # There are three ways to use header \converters;
-# these examples use built-in header converter +:dowhcase+,
+# these examples use built-in header converter +:downcase+,
 # which downcases each parsed header.
 #
 # - Option +header_converters+ with a singleton parsing method:


### PR DESCRIPTION
Fixes a typo in the CSV documentation:
`dowhcase` -> `downcase`
