### PR TITLE
Man page: correct defaults for RUBY_THREAD_VM_STACK_SIZE

### DIFF
--- a/man/ruby.1
+++ b/man/ruby.1
@@ -618,7 +618,7 @@ All values are specified in bytes.
 .Bl -hang -compact -width "RUBY_THREAD_MACHINE_STACK_SIZE"
 .It Ev RUBY_THREAD_VM_STACK_SIZE
 VM stack size used at thread creation.
-default: 131072 (32-bit CPU) or 262144 (64-bit)
+default: 524288 (32-bit CPU) or 1048575 (64-bit)
 .Pp
 .It Ev RUBY_THREAD_MACHINE_STACK_SIZE
 Machine stack size used at thread creation.


### PR DESCRIPTION
See RUBY_VM_THREAD_VM_STACK_SIZE in vm_core.h.