### PR TITLE
Refactor rb_define_class_variable function

### DIFF
--- a/variable.c
+++ b/variable.c
@@ -3412,8 +3412,7 @@ rb_cv_get(VALUE klass, const char *name)
 void
 rb_define_class_variable(VALUE klass, const char *name, VALUE val)
 {
-    ID id = cv_intern(klass, name);
-    rb_cvar_set(klass, id, val);
+    rb_cv_set(klass, name, val);
 }
 
 static int


### PR DESCRIPTION
`rb_define_class_variable` and `rb_cv_set` functions has same code(in `variable.c`).
Using `rb_cv_set` in `rb_define_class_variable` function.