### PR TITLE
Fix error in Hash#fetch documentation

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -2120,7 +2120,6 @@ rb_hash_lookup(VALUE hash, VALUE key)
  *  If +key+ is not found and no block was given,
  *  returns +default_value+:
  *    {}.fetch(:nosuch, :default) # => :default
- *    {}.fetch(:nosuch) # => nil
  *
  *  If +key+ is not found and a block was given,
  *  yields +key+ to the block and returns the block's return value:


### PR DESCRIPTION
Documentation wrongly describes the behaviour of `{}.fetch(:nosuch)` which doesn't return `nil` but raises a `KeyError` exception, as explained a few lines after:

> Raises KeyError if neither +default_value+ nor a block was given.