### PR TITLE
display un.rb httpd URLs

### DIFF
--- a/lib/un.rb
+++ b/lib/un.rb
@@ -346,6 +346,14 @@ def httpd
     end
     options[:Port] ||= 8080     # HTTP Alternate
     options[:DocumentRoot] = argv.shift || '.'
+    s = nil
+    options[:StartCallback] = Proc.new do
+      logger = s.logger
+      logger.info("To access this server, open this file in a browser:")
+      s.listeners.each do |listener|
+        logger.info("    http://#{listener.connect_address.inspect_sockaddr}")
+      end
+    end
     s = WEBrick::HTTPServer.new(options)
     shut = proc {s.shutdown}
     siglist = %w"TERM QUIT"

--- a/lib/un.rb
+++ b/lib/un.rb
@@ -349,7 +349,7 @@ def httpd
     s = nil
     options[:StartCallback] = proc {
       logger = s.logger
-      logger.info("To access this server, open this file in a browser:")
+      logger.info("To access this server, open this URL in a browser:")
       s.listeners.each do |listener|
         if options[:SSLEnable]
           addr = listener.addr


### PR DESCRIPTION
`ruby -run -e httpd` displays URLs.  Some terminals make them clickable.