### PR TITLE
node.c (rb_ast_new): imemo_ast is WB-unprotected

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -2435,6 +2435,13 @@ rb_imemo_new(enum imemo_type type, VALUE v1, VALUE v2, VALUE v3, VALUE v0)
     return newobj_of(v0, flags, v1, v2, v3, TRUE);
 }
 
+rb_ast_t *
+rb_imemo_ast_new(VALUE node_buffer)
+{
+    VALUE flags = T_IMEMO | (imemo_ast << FL_USHIFT);
+    return (rb_ast_t *)newobj_of(node_buffer, flags, 0, 0, 0, FALSE);
+}
+
 static VALUE
 rb_imemo_tmpbuf_new(VALUE v1, VALUE v2, VALUE v3, VALUE v0)
 {

--- a/internal/imemo.h
+++ b/internal/imemo.h
@@ -130,6 +130,7 @@ struct MEMO {
 
 typedef struct rb_imemo_tmpbuf_struct rb_imemo_tmpbuf_t;
 VALUE rb_imemo_new(enum imemo_type type, VALUE v1, VALUE v2, VALUE v3, VALUE v0);
+struct rb_ast_struct *rb_imemo_ast_new(VALUE node_buffer);
 rb_imemo_tmpbuf_t *rb_imemo_tmpbuf_parser_heap(void *buf, rb_imemo_tmpbuf_t *old_heap, size_t cnt);
 struct vm_ifunc *rb_vm_ifunc_new(rb_block_call_func_t func, const void *data, int min_argc, int max_argc);
 void rb_strterm_mark(VALUE obj);

--- a/lib/time.rb
+++ b/lib/time.rb
@@ -480,17 +480,10 @@ class Time
       t
     end
 
-# TODO: CI failure on FreeBSD
-#       http://rubyci.s3.amazonaws.com/freebsd12/ruby-master/log/20210425T203001Z.fail.html.gz
-# shareable_constant_value: none
-
-    MonthValue = Ractor.make_shareable({ # :nodoc:
+    MonthValue = { # :nodoc:
       'JAN' => 1, 'FEB' => 2, 'MAR' => 3, 'APR' => 4, 'MAY' => 5, 'JUN' => 6,
       'JUL' => 7, 'AUG' => 8, 'SEP' => 9, 'OCT' =>10, 'NOV' =>11, 'DEC' =>12
-    })
-
-# shareable_constant_value: literal
-
+    }
 
     #
     # Parses +date+ as date-time defined by RFC 2822 and converts it to a Time

--- a/node.c
+++ b/node.c
@@ -1299,7 +1299,7 @@ rb_ast_t *
 rb_ast_new(void)
 {
     node_buffer_t *nb = rb_node_buffer_new();
-    rb_ast_t *ast = (rb_ast_t *)rb_imemo_new(imemo_ast, 0, 0, 0, (VALUE)nb);
+    rb_ast_t *ast = rb_imemo_ast_new((VALUE)nb);
     return ast;
 }
 

--- a/test/ruby/test_gc.rb
+++ b/test/ruby/test_gc.rb
@@ -494,4 +494,11 @@ class TestGc < Test::Unit::TestCase
     b = 1000.times.map { Object.new.object_id }
     assert_empty(a & b)
   end
+
+  def test_ast_node_buffer
+    # https://github.com/ruby/ruby/pull/4416
+    Module.new.class_eval do
+      eval((["# shareable_constant_value: literal"] + (0..100000).map {|i| "M#{ i } = {}" }).join("\n"))
+    end
+  end
 end


### PR DESCRIPTION
Previously imemo_ast was handled as WB-protected which caused a segfault
of the following code:

    # shareable_constant_value: literal
    M0 = {}
    M1 = {}
    ...
    M100000 = {}

My analysis is here: `shareable_constant_value: literal` creates many
Hash instances during parsing, and add them to node_buffer of imemo_ast.
However, the contents are missed because imemo_ast is incorrectly
WB-protected.

This changeset makes imemo_ast as WB-unprotected.