### PR TITLE
Fix type-o in insns.def

### DIFF
--- a/insns.def
+++ b/insns.def
@@ -696,7 +696,7 @@ checktype
 /**********************************************************/
 
 /* enter class definition scope. if super is Qfalse, and class
-   "klass" is defined, it's redefine. otherwise, define "klass" class.
+   "klass" is defined, it's redefined. Otherwise, define "klass" class.
  */
 DEFINE_INSN
 defineclass


### PR DESCRIPTION
This PR represents a simple change to fix a type-o in `insns.def` that I caught while reviewing another ruby PR.  I don't believe this requires a readme as the changes are purely in the comments.  

```
From 241f75153e61036b49b250bf0032e9804afbf052 Mon Sep 17 00:00:00 2001
From: ebrohman <ericbrohman@gmail.com>
Date: Mon, 26 Apr 2021 14:59:59 -0600
Subject: [PATCH] Fix type-o in insns.def

"redefine" -> "redefined"
---
 insns.def | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

diff --git a/insns.def b/insns.def
index aab53e3ff7f9..8d609927b587 100644
--- a/insns.def
+++ b/insns.def
@@ -696,7 +696,7 @@ checktype
 /**********************************************************/
 
 /* enter class definition scope. if super is Qfalse, and class
-   "klass" is defined, it's redefine. otherwise, define "klass" class.
+   "klass" is defined, it's redefined. Otherwise, define "klass" class.
  */
 DEFINE_INSN
 defineclass
```