### PR TITLE
LLDB: Extend the dump_page methods

### DIFF
--- a/misc/lldb_cruby.py
+++ b/misc/lldb_cruby.py
@@ -552,7 +552,7 @@ class HeapPageIter:
             raise StopIteration
 
 
-def dump_page_internal(page, target, process, thread, frame, result, debugger):
+def dump_page_internal(page, target, process, thread, frame, result, debugger, highlight=None):
     if not ('RUBY_Qfalse' in globals()):
         lldb_init(debugger)
 
@@ -581,6 +581,10 @@ def dump_page_internal(page, target, process, thread, frame, result, debugger):
                 flidx = '   '
 
         result_str = "%s idx: [%3d] freelist_idx: {%s} Addr: %0#x (flags: %0#x)" % (rb_type(flags, ruby_type_map), page_index, flidx, obj_addr, flags)
+
+        if highlight == obj_addr:
+            result_str = ' '.join([result_str, "<<<<<"])
+
         print(result_str, file=result)
 
 
@@ -608,7 +612,7 @@ def dump_page_rvalue(debugger, command, result, internal_dict):
     page_type = target.FindFirstType("struct heap_page").GetPointerType()
     page.Cast(page_type)
 
-    dump_page_internal(page, target, process, thread, frame, result, debugger)
+    dump_page_internal(page, target, process, thread, frame, result, debugger, highlight=val.GetValueAsUnsigned())
 
 
 

--- a/misc/lldb_cruby.py
+++ b/misc/lldb_cruby.py
@@ -552,18 +552,9 @@ class HeapPageIter:
             raise StopIteration
 
 
-def dump_page(debugger, command, result, internal_dict):
+def dump_page_internal(page, target, process, thread, frame, result, debugger):
     if not ('RUBY_Qfalse' in globals()):
         lldb_init(debugger)
-
-    target = debugger.GetSelectedTarget()
-    process = target.GetProcess()
-    thread = process.GetSelectedThread()
-    frame = thread.GetSelectedFrame()
-
-    tHeapPageP = target.FindFirstType("struct heap_page").GetPointerType()
-    page = frame.EvaluateExpression(command)
-    page = page.Cast(tHeapPageP)
 
     ruby_type_map = ruby_types(debugger)
 
@@ -591,6 +582,34 @@ def dump_page(debugger, command, result, internal_dict):
 
         result_str = "%s idx: [%3d] freelist_idx: {%s} Addr: %0#x (flags: %0#x)" % (rb_type(flags, ruby_type_map), page_index, flidx, obj_addr, flags)
         print(result_str, file=result)
+
+
+def dump_page(debugger, command, result, internal_dict):
+    target = debugger.GetSelectedTarget()
+    process = target.GetProcess()
+    thread = process.GetSelectedThread()
+    frame = thread.GetSelectedFrame()
+
+    tHeapPageP = target.FindFirstType("struct heap_page").GetPointerType()
+    page = frame.EvaluateExpression(command)
+    page = page.Cast(tHeapPageP)
+
+    dump_page_internal(page, target, process, thread, frame, result, debugger)
+
+
+def dump_page_rvalue(debugger, command, result, internal_dict):
+    target = debugger.GetSelectedTarget()
+    process = target.GetProcess()
+    thread = process.GetSelectedThread()
+    frame = thread.GetSelectedFrame()
+
+    val = frame.EvaluateExpression(command)
+    page = get_page(lldb, target, val)
+    page_type = target.FindFirstType("struct heap_page").GetPointerType()
+    page.Cast(page_type)
+
+    dump_page_internal(page, target, process, thread, frame, result, debugger)
+
 
 
 def rb_type(flags, ruby_types):
@@ -623,6 +642,7 @@ def __lldb_init_module(debugger, internal_dict):
     debugger.HandleCommand("command script add -f lldb_cruby.heap_page_body heap_page_body")
     debugger.HandleCommand("command script add -f lldb_cruby.rb_backtrace rbbt")
     debugger.HandleCommand("command script add -f lldb_cruby.dump_page dump_page")
+    debugger.HandleCommand("command script add -f lldb_cruby.dump_page_rvalue dump_page_rvalue")
 
     lldb_init(debugger)
     print("lldb scripts for ruby has been installed.")


### PR DESCRIPTION
I frequently use `dump_page` in lldb to visualise heap pages, but the process of seeing the heap page containing a `VALUE` is annoying. First we have to `heap_page obj` to get the page and then call `dump_page` on the returned page address.

This PR adds `dump_page_rvalue` that combines both steap, dumping the page containing the `VALUE` passed as an argument - and also highlights that slots position in the page.
