### PR TITLE
Move rb_ractor_p definition

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -12354,8 +12354,6 @@ rb_raw_iseq_info(char *buff, const int buff_size, const rb_iseq_t *iseq)
     }
 }
 
-bool rb_ractor_p(VALUE rv);
-
 static int
 str_len_no_raise(VALUE str)
 {

--- a/ractor_core.h
+++ b/ractor_core.h
@@ -171,6 +171,7 @@ VALUE rb_thread_create_ractor(rb_ractor_t *g, VALUE args, VALUE proc); // define
 rb_global_vm_lock_t *rb_ractor_gvl(rb_ractor_t *);
 int rb_ractor_living_thread_num(const rb_ractor_t *);
 VALUE rb_ractor_thread_list(rb_ractor_t *r);
+bool rb_ractor_p(VALUE rv);
 
 void rb_ractor_living_threads_init(rb_ractor_t *r);
 void rb_ractor_living_threads_insert(rb_ractor_t *r, rb_thread_t *th);


### PR DESCRIPTION
Move `rb_ractor_p` definition(in `gc.c`) to `ractor_core.h`.