### PR TITLE
Fix windows net https issues in test-all and test-spec

### DIFF
--- a/spec/ruby/library/net/http/http/fixtures/http_server.rb
+++ b/spec/ruby/library/net/http/http/fixtures/http_server.rb
@@ -64,7 +64,7 @@ module NetHTTPSpecs
 
     def start_server
       server_config = {
-        BindAddress: "127.0.0.1",
+        BindAddress: "localhost",
         Port: 0,
         Logger: WEBrick::Log.new(NullWriter.new),
         AccessLog: [],

--- a/test/net/http/test_https.rb
+++ b/test/net/http/test_https.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: false
 require "test/unit"
+require_relative "utils"
 begin
   require 'net/https'
-  require 'stringio'
-  require 'timeout'
-  require File.expand_path("utils", File.dirname(__FILE__))
 rescue LoadError
   # should skip this test
 end
@@ -16,6 +14,8 @@ class TestNetHTTPS < Test::Unit::TestCase
     File.read(File.expand_path("../fixtures/#{key}", __dir__))
   end
 
+  HOST = 'localhost'
+  HOST_IP = '127.0.0.1'
   CA_CERT = OpenSSL::X509::Certificate.new(read_fixture("cacert.pem"))
   SERVER_KEY = OpenSSL::PKey.read(read_fixture("server.key"))
   SERVER_CERT = OpenSSL::X509::Certificate.new(read_fixture("server.crt"))
@@ -23,7 +23,7 @@ class TestNetHTTPS < Test::Unit::TestCase
   TEST_STORE = OpenSSL::X509::Store.new.tap {|s| s.add_cert(CA_CERT) }
 
   CONFIG = {
-    'host' => '127.0.0.1',
+    'host' => HOST,
     'proxy_host' => nil,
     'proxy_port' => nil,
     'ssl_enable' => true,
@@ -33,7 +33,7 @@ class TestNetHTTPS < Test::Unit::TestCase
   }
 
   def test_get
-    http = Net::HTTP.new("localhost", config("port"))
+    http = Net::HTTP.new(HOST, config("port"))
     http.use_ssl = true
     http.cert_store = TEST_STORE
     certs = []
@@ -45,15 +45,13 @@ class TestNetHTTPS < Test::Unit::TestCase
       assert_equal($test_net_http_data, res.body)
     }
     # TODO: OpenSSL 1.1.1h seems to yield only SERVER_CERT; need to check the incompatibility
-    certs.zip([CA_CERT, SERVER_CERT][-certs.size..]) do |actual, expected|
+    certs.zip([CA_CERT, SERVER_CERT][-certs.size..-1]) do |actual, expected|
       assert_equal(expected.to_der, actual.to_der)
     end
-  rescue SystemCallError
-    skip $!
   end
 
   def test_get_SNI
-    http = Net::HTTP.new("localhost", config("port"))
+    http = Net::HTTP.new(HOST, config("port"))
     http.ipaddr = config('host')
     http.use_ssl = true
     http.cert_store = TEST_STORE
@@ -66,16 +64,16 @@ class TestNetHTTPS < Test::Unit::TestCase
       assert_equal($test_net_http_data, res.body)
     }
     # TODO: OpenSSL 1.1.1h seems to yield only SERVER_CERT; need to check the incompatibility
-    certs.zip([CA_CERT, SERVER_CERT][-certs.size..]) do |actual, expected|
+    certs.zip([CA_CERT, SERVER_CERT][-certs.size..-1]) do |actual, expected|
       assert_equal(expected.to_der, actual.to_der)
     end
   end
 
   def test_get_SNI_proxy
-    TCPServer.open("127.0.0.1", 0) {|serv|
+    TCPServer.open(HOST_IP, 0) {|serv|
       _, port, _, _ = serv.addr
       client_thread = Thread.new {
-        proxy = Net::HTTP.Proxy("127.0.0.1", port, 'user', 'password')
+        proxy = Net::HTTP.Proxy(HOST_IP, port, 'user', 'password')
         http = proxy.new("foo.example.org", 8000)
         http.ipaddr = "192.0.2.1"
         http.use_ssl = true
@@ -127,24 +125,21 @@ class TestNetHTTPS < Test::Unit::TestCase
   end
 
   def test_post
-    http = Net::HTTP.new("localhost", config("port"))
+    http = Net::HTTP.new(HOST, config("port"))
     http.use_ssl = true
     http.cert_store = TEST_STORE
     data = config('ssl_private_key').to_der
     http.request_post("/", data, {'content-type' => 'application/x-www-form-urlencoded'}) {|res|
       assert_equal(data, res.body)
     }
-  rescue SystemCallError
-    skip $!
   end
 
   def test_session_reuse
     # FIXME: The new_session_cb is known broken for clients in OpenSSL 1.1.0h.
     # See https://github.com/openssl/openssl/pull/5967 for details.
     skip if OpenSSL::OPENSSL_LIBRARY_VERSION =~ /OpenSSL 1.1.0h/
-    skip if /mswin|mingw/ =~ RUBY_PLATFORM
 
-    http = Net::HTTP.new("localhost", config("port"))
+    http = Net::HTTP.new(HOST, config("port"))
     http.use_ssl = true
     http.cert_store = TEST_STORE
 
@@ -157,26 +152,21 @@ class TestNetHTTPS < Test::Unit::TestCase
     end
 
     http.start
+    assert_equal false, http.instance_variable_get(:@socket).io.session_reused?
     http.get("/")
     http.finish
 
     http.start
-    http.get("/")
-
-    socket = http.instance_variable_get(:@socket).io
-    assert_equal true, socket.session_reused?
-
+    assert_equal true, http.instance_variable_get(:@socket).io.session_reused?
+    assert_equal $test_net_http_data, http.get("/").body
     http.finish
-  rescue SystemCallError
-    skip $!
   end
 
   def test_session_reuse_but_expire
     # FIXME: The new_session_cb is known broken for clients in OpenSSL 1.1.0h.
     skip if OpenSSL::OPENSSL_LIBRARY_VERSION =~ /OpenSSL 1.1.0h/
-    skip if /mswin|mingw/ =~ RUBY_PLATFORM
 
-    http = Net::HTTP.new("localhost", config("port"))
+    http = Net::HTTP.new(HOST, config("port"))
     http.use_ssl = true
     http.cert_store = TEST_STORE
 
@@ -192,8 +182,6 @@ class TestNetHTTPS < Test::Unit::TestCase
     assert_equal false, socket.session_reused?
 
     http.finish
-  rescue SystemCallError
-    skip $!
   end
 
   if ENV["RUBY_OPENSSL_TEST_ALL"]
@@ -208,14 +196,12 @@ class TestNetHTTPS < Test::Unit::TestCase
   end
 
   def test_verify_none
-    http = Net::HTTP.new("localhost", config("port"))
+    http = Net::HTTP.new(HOST, config("port"))
     http.use_ssl = true
     http.verify_mode = OpenSSL::SSL::VERIFY_NONE
     http.request_get("/") {|res|
       assert_equal($test_net_http_data, res.body)
     }
-  rescue SystemCallError
-    skip $!
   end
 
   def test_skip_hostname_verification
@@ -244,14 +230,10 @@ class TestNetHTTPS < Test::Unit::TestCase
   end
 
   def test_certificate_verify_failure
-    http = Net::HTTP.new("localhost", config("port"))
+    http = Net::HTTP.new(HOST, config("port"))
     http.use_ssl = true
     ex = assert_raise(OpenSSL::SSL::SSLError){
-      begin
-        http.request_get("/") {|res| }
-      rescue SystemCallError
-        skip $!
-      end
+      http.request_get("/") {|res| }
     }
     assert_match(/certificate verify failed/, ex.message)
     unless /mswin|mingw/ =~ RUBY_PLATFORM
@@ -266,14 +248,14 @@ class TestNetHTTPS < Test::Unit::TestCase
 
   def test_identity_verify_failure
     # the certificate's subject has CN=localhost
-    http = Net::HTTP.new("127.0.0.1", config("port"))
+    http = Net::HTTP.new(HOST_IP, config("port"))
     http.use_ssl = true
     http.cert_store = TEST_STORE
     @log_tester = lambda {|_| }
     ex = assert_raise(OpenSSL::SSL::SSLError){
       http.request_get("/") {|res| }
     }
-    re_msg = /certificate verify failed|hostname \"127.0.0.1\" does not match/
+    re_msg = /certificate verify failed|hostname \"#{HOST_IP}\" does not match/
     assert_match(re_msg, ex.message)
   end
 
@@ -281,10 +263,10 @@ class TestNetHTTPS < Test::Unit::TestCase
     bug4246 = "expected the SSL connection to have timed out but have not. [ruby-core:34203]"
 
     # listen for connections... but deliberately do not complete SSL handshake
-    TCPServer.open('localhost', 0) {|server|
+    TCPServer.open(HOST, 0) {|server|
       port = server.addr[1]
 
-      conn = Net::HTTP.new('localhost', port)
+      conn = Net::HTTP.new(HOST, port)
       conn.use_ssl = true
       conn.read_timeout = 0.01
       conn.open_timeout = 0.01
@@ -299,7 +281,7 @@ class TestNetHTTPS < Test::Unit::TestCase
   end
 
   def test_min_version
-    http = Net::HTTP.new("localhost", config("port"))
+    http = Net::HTTP.new(HOST, config("port"))
     http.use_ssl = true
     http.min_version = :TLS1
     http.cert_store = TEST_STORE
@@ -309,7 +291,7 @@ class TestNetHTTPS < Test::Unit::TestCase
   end
 
   def test_max_version
-    http = Net::HTTP.new("127.0.0.1", config("port"))
+    http = Net::HTTP.new(HOST_IP, config("port"))
     http.use_ssl = true
     http.max_version = :SSL2
     http.verify_callback = Proc.new do |preverify_ok, store_ctx|


### PR DESCRIPTION
Various tests create servers and clients.  Using `localhost` for one and `127.0.0.1` for the other can cause issues on Windows.

Two commits: 

1. test-all net/http.  The changes here match the test file changes in https://github.com/ruby/net-http/pull/20, which includes additional changes to Actions CI, using with trunk, etc.

2. test-spec - this commit should be duplicated in ruby/rspec.