### PR TITLE
Remove unneeded rb_ary_ptr_use_start defination in internal/array.h

### DIFF
--- a/internal/array.h
+++ b/internal/array.h
@@ -40,7 +40,6 @@ static inline void RARY_TRANSIENT_UNSET(VALUE ary);
 RUBY_SYMBOL_EXPORT_BEGIN
 /* array.c (export) */
 void rb_ary_detransient(VALUE a);
-VALUE *rb_ary_ptr_use_start(VALUE ary);
 void rb_ary_ptr_use_end(VALUE ary);
 RUBY_SYMBOL_EXPORT_END
 


### PR DESCRIPTION
`rb_ary_ptr_use_start` was not used in ruby core.
So, remove it.