### PR TITLE
Get `ruby_nonempty_memcpy` to have C linkage

### DIFF
--- a/include/ruby/internal/memory.h
+++ b/include/ruby/internal/memory.h
@@ -256,6 +256,7 @@ rb_alloc_tmp_buffer2(volatile VALUE *store, long count, size_t elsize)
 }
 
 #ifndef __MINGW32__
+RBIMPL_SYMBOL_EXPORT_BEGIN()
 RBIMPL_ATTR_NOALIAS()
 RBIMPL_ATTR_NONNULL((1))
 RBIMPL_ATTR_RETURNS_NONNULL()
@@ -272,6 +273,7 @@ ruby_nonempty_memcpy(void *dest, const void *src, size_t n)
         return dest;
     }
 }
+RBIMPL_SYMBOL_EXPORT_END()
 #undef memcpy
 #define memcpy ruby_nonempty_memcpy
 #endif


### PR DESCRIPTION
Fixes [Bug #17788]