### PR TITLE
Fix VMDEBUG: Don't exit when PC is set, but VM is not initialized

### DIFF
--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -57,13 +57,7 @@ calc_lineno(const rb_iseq_t *iseq, const VALUE *pc)
             /* use pos-1 because PC points next instruction at the beginning of instruction */
             pos--;
         }
-#if VMDEBUG && defined(HAVE_BUILTIN___BUILTIN_TRAP)
-        else {
-            /* SDR() is not possible; that causes infinite loop. */
-            rb_print_backtrace();
-            __builtin_trap();
-        }
-#endif
+
         return rb_iseq_line_no(iseq, pos);
     }
 }


### PR DESCRIPTION
When `VMDEBUG` flag is set Ruby is unable to boot because `pc` is not null and `pc - iseq_encoded` is 0. See the debugger output below.

```
Process 46332 launched: '/Users/mattvh/src/ruby/miniruby' (x86_64)
/Users/mattvh/src/ruby/miniruby(rb_print_backtrace+0x19) [0x10033d639] vm_dump.c:758
/Users/mattvh/src/ruby/miniruby(rb_print_backtrace) (null):0
/Users/mattvh/src/ruby/miniruby(calc_lineno+0x83) [0x100336e63] vm_backtrace.c:63
/Users/mattvh/src/ruby/miniruby(rb_vm_get_sourceline+0x49) [0x100336d69] vm_backtrace.c:76
/Users/mattvh/src/ruby/miniruby(rb_vm_make_binding+0x19e) [0x10030e8ce] vm.c:1194
/Users/mattvh/src/ruby/miniruby(rb_binding_new+0x22) [0x1001d9132] proc.c:385
/Users/mattvh/src/ruby/miniruby(Init_VM+0x644) [0x100314434] vm.c:3667
/Users/mattvh/src/ruby/miniruby(rb_call_inits+0xd1) [0x1001012a1] inits.c:65
/Users/mattvh/src/ruby/miniruby(ruby_setup+0x102) [0x1000bbf32] eval.c:93
/Users/mattvh/src/ruby/miniruby(ruby_init+0xd) [0x1000bbfed] eval.c:110
/Users/mattvh/src/ruby/miniruby(main+0x68) [0x1000023b8] ./main.c:46
Process 46332 stopped
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_INSTRUCTION (code=EXC_I386_INVOP, subcode=0x0)
    frame #0: 0x0000000100336e63 miniruby`calc_lineno(iseq=0x00000001007d7d18, pc=0x0000000100f29050) at vm_backtrace.c:64:13
   61  	        else {
   62  	            /* SDR() is not possible; that causes infinite loop. */
   63  	            rb_print_backtrace();
-> 64  	            __builtin_trap();
   65  	        }
   66  	#endif
   67  	        return rb_iseq_line_no(iseq, pos);
Target 0: (miniruby) stopped.
```