### PR TITLE
Silence GCC 11 warnings

### DIFF
--- a/strftime.c
+++ b/strftime.c
@@ -389,7 +389,7 @@ rb_strftime_with_timespec(VALUE ftime, const char *format, size_t format_len,
 				flags &= ~(BIT_OF(LOWER)|BIT_OF(CHCASE));
 				flags |= BIT_OF(UPPER);
 			}
-			if (vtm->wday < 0 || vtm->wday > 6)
+			if (vtm->wday > 6)
 				i = 1, tp = "?";
 			else
 				i = 3, tp = days_l[vtm->wday];
@@ -400,7 +400,7 @@ rb_strftime_with_timespec(VALUE ftime, const char *format, size_t format_len,
 				flags &= ~(BIT_OF(LOWER)|BIT_OF(CHCASE));
 				flags |= BIT_OF(UPPER);
 			}
-			if (vtm->wday < 0 || vtm->wday > 6)
+			if (vtm->wday > 6)
 				i = 1, tp = "?";
 			else
 				i = strlen(tp = days_l[vtm->wday]);


### PR DESCRIPTION
```
../strftime.c: In function 'rb_strftime_with_timespec':
../strftime.c:392:39: warning: comparison is always false due to limited range of data type [-Wtype-limits]
  392 |                         if (vtm->wday < 0 || vtm->wday > 6)
      |                                       ^
../strftime.c:403:39: warning: comparison is always false due to limited range of data type [-Wtype-limits]
  403 |                         if (vtm->wday < 0 || vtm->wday > 6)
      |                                       ^
```