### PR TITLE
Correct documentation example on Hash#dig

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -4555,7 +4555,7 @@ rb_hash_any_p(int argc, VALUE *argv, VALUE hash)
  *  Nested Hashes:
  *    h = {foo: {bar: {baz: 2}}}
  *    h.dig(:foo) # => {:bar=>{:baz=>2}}
- *    h.dig(:foo, :bar) # => {:bar=>{:baz=>2}}
+ *    h.dig(:foo, :bar) # => {:baz=>2}
  *    h.dig(:foo, :bar, :baz) # => 2
  *    h.dig(:foo, :bar, :BAZ) # => nil
  *


### PR DESCRIPTION
Fixes [Misc #17842](https://bugs.ruby-lang.org/issues/17842). The current documentation suggests that:
```
{foo: {bar: {baz: 2}}}.dig(:foo, :bar) # => {:bar=>{:baz=>2}}
```
when it should be:
```
{foo: {bar: {baz: 2}}}.dig(:foo, :bar) # => {:baz=>2}
```