### PR TITLE
Get rid of typedef redefinition

### DIFF
--- a/thread_win32.h
+++ b/thread_win32.h
@@ -21,10 +21,10 @@
 WINBASEAPI BOOL WINAPI
 TryEnterCriticalSection(IN OUT LPCRITICAL_SECTION lpCriticalSection);
 
-typedef struct rb_thread_cond_struct {
+struct rb_thread_cond_struct {
     struct cond_event_entry *next;
     struct cond_event_entry *prev;
-} rb_nativethread_cond_t;
+};
 
 typedef struct native_thread_data_struct {
     HANDLE interrupt_event;


### PR DESCRIPTION
Redefinition of typedef is a C11 feature.