### PR TITLE
test/net/ftp/test_ftp.rb - fix intermittent MinGW failure

### DIFF
--- a/test/net/ftp/test_ftp.rb
+++ b/test/net/ftp/test_ftp.rb
@@ -425,7 +425,7 @@ class FTPTest < Test::Unit::TestCase
           end
           conn.print(l, "\r\n")
         end
-      rescue Errno::EPIPE
+      rescue Errno::EPIPE, Errno::ECONNRESET
       ensure
         assert_nil($!)
         conn.close


### PR DESCRIPTION
Fixes intermittent error as below:
```
[242/838] 5316=test_ftp
#<Thread:0x0000020aa8733f20 D:/a/ruby/ruby/src/test/net/ftp/test_ftp.rb:2532 run> terminated with exception (report_on_exception is true):
D:/a/ruby/ruby/src/tool/lib/minitest/unit.rb:199:in `assert': Expected #<Errno::ECONNRESET: An existing connection was forcibly closed by the remote host.> to be nil. (MiniTest::Assertion)
	from D:/a/ruby/ruby/src/tool/lib/test/unit/core_assertions.rb:504:in `assert'
	from D:/a/ruby/ruby/src/tool/lib/minitest/unit.rb:299:in `assert_nil'
	from D:/a/ruby/ruby/src/test/net/ftp/test_ftp.rb:430:in `ensure in block in test_list_read_timeout_exceeded'
	from D:/a/ruby/ruby/src/test/net/ftp/test_ftp.rb:431:in `block in test_list_read_timeout_exceeded'
	from D:/a/ruby/ruby/src/test/net/ftp/test_ftp.rb:2539:in `block in create_ftp_server'
D:/a/ruby/ruby/src/test/net/ftp/test_ftp.rb:426:in `write': An existing connection was forcibly closed by the remote host. (Errno::ECONNRESET)
	from D:/a/ruby/ruby/src/test/net/ftp/test_ftp.rb:426:in `print'
	from D:/a/ruby/ruby/src/test/net/ftp/test_ftp.rb:426:in `block (2 levels) in test_list_read_timeout_exceeded'
	from D:/a/ruby/ruby/src/test/net/ftp/test_ftp.rb:420:in `each'
	from D:/a/ruby/ruby/src/test/net/ftp/test_ftp.rb:420:in `each_with_index'
	from D:/a/ruby/ruby/src/test/net/ftp/test_ftp.rb:420:in `block in test_list_read_timeout_exceeded'
	from D:/a/ruby/ruby/src/test/net/ftp/test_ftp.rb:2539:in `block in create_ftp_server'
```

I've seen this at least twice in recent CI, one example:
https://github.com/ruby/ruby/runs/2499495392#step:15:282

Can't duplicate locally using parallel testing...