### PR TITLE
Fix evaluation of order of constant assignment

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,31 @@ Note that each entry is kept to a minimum, see links for details.
     end
     ```
 
+* Constant assignment evaluation order for constants set on explicit
+  objects has been made consistent with single attribute assignment
+  evaluation order.  With this code:
+
+    ```ruby
+    foo::BAR = baz
+    ```
+
+  `foo` is now called before `baz`. Similarly, for multiple assignment
+  to constants,  left-to-right evaluation order is used.  With this
+  code:
+
+    ```ruby
+      foo1::BAR1, foo2::BAR2 = baz1, baz2
+    ```
+
+  The following evaluation order is now used:
+
+  1. `foo1`
+  2. `foo2`
+  3. `baz1`
+  4. `baz2`
+
+  [[Bug #15928]]
+
 ## Command line options
 
 ## Core classes updates
@@ -110,6 +135,7 @@ The following deprecated APIs are removed.
 [Feature #12737]: https://bugs.ruby-lang.org/issues/12737
 [Feature #14332]: https://bugs.ruby-lang.org/issues/14332
 [Feature #15231]: https://bugs.ruby-lang.org/issues/15231
+[Bug #15928]:     https://bugs.ruby-lang.org/issues/15928
 [Feature #16131]: https://bugs.ruby-lang.org/issues/16131
 [Feature #17351]: https://bugs.ruby-lang.org/issues/17351
 [Feature #17391]: https://bugs.ruby-lang.org/issues/17391

--- a/spec/ruby/language/constants_spec.rb
+++ b/spec/ruby/language/constants_spec.rb
@@ -135,18 +135,34 @@ describe "Literal (A::X) constant resolution" do
       ConstantSpecs::ClassB::CS_CONST109.should == :const109_2
     end
 
-    it "evaluates the right hand side before evaluating a constant path" do
-      mod = Module.new
+    ruby_version_is "3.2" do
+      it "evaluates left-to-right" do
+        mod = Module.new
 
-      mod.module_eval <<-EOC
-        ConstantSpecsRHS::B = begin
-          module ConstantSpecsRHS; end
+        mod.module_eval <<-EOC
+          order = []
+          ConstantSpecsRHS = Module.new
+          (order << :lhs; ConstantSpecsRHS)::B = (order << :rhs)
+        EOC
 
-          "hello"
-        end
-      EOC
+        mod::ConstantSpecsRHS::B.should == [:lhs, :rhs]
+      end
+    end
 
-      mod::ConstantSpecsRHS::B.should == 'hello'
+    ruby_version_is ""..."3.2" do
+      it "evaluates the right hand side before evaluating a constant path" do
+        mod = Module.new
+
+        mod.module_eval <<-EOC
+          ConstantSpecsRHS::B = begin
+            module ConstantSpecsRHS; end
+
+            "hello"
+          end
+        EOC
+
+        mod::ConstantSpecsRHS::B.should == 'hello'
+      end
     end
   end
 

--- a/test/ruby/test_assignment.rb
+++ b/test/ruby/test_assignment.rb
@@ -139,6 +139,104 @@ class TestAssignment < Test::Unit::TestCase
     order.clear
   end
 
+  def test_massign_const_order
+    order = []
+
+    test_mod_class = Class.new(Module) do
+      define_method(:x1){order << :x1; self}
+      define_method(:y1){order << :y1; self}
+      define_method(:x2){order << :x2; self}
+      define_method(:x3){order << :x3; self}
+      define_method(:x4){order << :x4; self}
+      define_method(:[]){|*args| order << [:[], *args]; self}
+      define_method(:r1){order << :r1; :r1}
+      define_method(:r2){order << :r2; :r2}
+
+      define_method(:constant_values) do
+        h = {}
+        constants.each do |sym|
+          h[sym] = const_get(sym)
+        end
+        h
+      end
+
+      define_singleton_method(:run) do |code|
+        m = new
+        m.instance_eval(code)
+        ret = [order.dup, m.constant_values]
+        order.clear
+        ret
+      end
+    end
+
+    ord, constants = test_mod_class.run(
+      "x1.y1::A, x2[1, 2, 3]::B, self[4]::C = r1, 6, r2"
+    )
+    assert_equal([:x1, :y1, :x2, [:[], 1, 2, 3], [:[], 4], :r1, :r2], ord)
+    assert_equal({:A=>:r1, :B=>6, :C=>:r2}, constants)
+
+    ord, constants = test_mod_class.run(
+      "x1.y1::A, *x2[1, 2, 3]::B, self[4]::C = r1, 6, 7, r2"
+    )
+    assert_equal([:x1, :y1, :x2, [:[], 1, 2, 3], [:[], 4], :r1, :r2], ord)
+    assert_equal({:A=>:r1, :B=>[6, 7], :C=>:r2}, constants)
+
+    ord, constants = test_mod_class.run(
+      "x1.y1::A, *x2[1, 2, 3]::B, x3[4]::C = r1, 6, 7, r2"
+    )
+    assert_equal([:x1, :y1, :x2, [:[], 1, 2, 3], :x3, [:[], 4], :r1, :r2], ord)
+    assert_equal({:A=>:r1, :B=>[6, 7], :C=>:r2}, constants)
+
+
+    ord, constants = test_mod_class.run(
+      "x1.y1::A, *x2[1, 2, 3]::B, x3[4]::C, x4::D = r1, 6, 7, r2, 8"
+    )
+    assert_equal([:x1, :y1, :x2, [:[], 1, 2, 3], :x3, [:[], 4], :x4, :r1, :r2], ord)
+    assert_equal({:A=>:r1, :B=>[6, 7], :C=>:r2, :D=>8}, constants)
+
+    ord, constants = test_mod_class.run(
+      "(x1.y1::A, x2::B), _a = [r1, r2], 7"
+    )
+    assert_equal([:x1, :y1, :x2, :r1, :r2], ord)
+    assert_equal({:A=>:r1, :B=>:r2}, constants)
+
+    ord, constants = test_mod_class.run(
+      "(x1.y1::A, x1::B), *x2[1, 2, 3]::C = [r1, 5], 6, 7, r2, 8"
+    )
+    assert_equal([:x1, :y1, :x1, :x2, [:[], 1, 2, 3], :r1, :r2], ord)
+    assert_equal({:A=>:r1, :B=>5, :C=>[6, 7, :r2, 8]}, constants)
+
+    ord, constants = test_mod_class.run(
+      "*x2[1, 2, 3]::A, (x3[4]::B, x4::C) = 6, 7, [r2, 8]"
+    )
+    assert_equal([:x2, [:[], 1, 2, 3], :x3, [:[], 4], :x4, :r2], ord)
+    assert_equal({:A=>[6, 7], :B=>:r2, :C=>8}, constants)
+
+    ord, constants = test_mod_class.run(
+      "(x1.y1::A, x1::B), *x2[1, 2, 3]::C, x3[4]::D, x4::E = [r1, 5], 6, 7, r2, 8"
+    )
+    assert_equal([:x1, :y1, :x1, :x2, [:[], 1, 2, 3], :x3, [:[], 4], :x4, :r1, :r2], ord)
+    assert_equal({:A=>:r1, :B=>5, :C=>[6, 7], :D=>:r2, :E=>8}, constants)
+
+    ord, constants = test_mod_class.run(
+      "(x1.y1::A, x1::B), *x2[1, 2, 3]::C, (x3[4]::D, x4::E) = [r1, 5], 6, 7, [r2, 8]"
+    )
+    assert_equal([:x1, :y1, :x1, :x2, [:[], 1, 2, 3], :x3, [:[], 4], :x4, :r1, :r2], ord)
+    assert_equal({:A=>:r1, :B=>5, :C=>[6, 7], :D=>:r2, :E=>8}, constants)
+
+    ord, constants = test_mod_class.run(
+      "((x1.y1::A, x1::B), _a), *x2[1, 2, 3]::C, ((x3[4]::D, x4::E), _b) = [[r1, 5], 10], 6, 7, [[r2, 8], 11]"
+    )
+    assert_equal([:x1, :y1, :x1, :x2, [:[], 1, 2, 3], :x3, [:[], 4], :x4, :r1, :r2], ord)
+    assert_equal({:A=>:r1, :B=>5, :C=>[6, 7], :D=>:r2, :E=>8}, constants)
+
+    ord, constants = test_mod_class.run(
+      "((x1.y1::A, x1::B), _a), *x2[1, 2, 3]::C, ((*x3[4]::D, x4::E), _b) = [[r1, 5], 10], 6, 7, [[r2, 8], 11]"
+    )
+    assert_equal([:x1, :y1, :x1, :x2, [:[], 1, 2, 3], :x3, [:[], 4], :x4, :r1, :r2], ord)
+    assert_equal({:A=>:r1, :B=>5, :C=>[6, 7], :D=>[:r2], :E=>8}, constants)
+  end
+
   def test_massign_splat
     a,b,*c = *[]; assert_equal([nil,nil,[]], [a,b,c])
     a,b,*c = *[1]; assert_equal([1,nil,[]], [a,b,c])
@@ -618,6 +716,17 @@ class TestAssignment < Test::Unit::TestCase
   def test_massign_in_cond
     result = eval("if (a, b = MyObj.new); [a, b]; end", nil, __FILE__, __LINE__)
     assert_equal [[1,2],[3,4]], result
+  end
+
+  def test_const_assign_order
+    assert_raise(RuntimeError) do
+      eval('raise("recv")::C = raise(ArgumentError, "bar")')
+    end
+
+    assert_raise(RuntimeError) do
+      m = 1
+      eval('m::C = raise("bar")')
+    end
   end
 end
 


### PR DESCRIPTION
Previously, the right hand side was always evaluated before the
left hand side for constant assignments.  For the following:

```ruby
lhs::C = rhs
```

rhs was evaluated before lhs, which is inconsistant with attribute
assignment (lhs.m = rhs), and apparently also does not conform to
JIS 3017:2013 11.4.2.2.3.

Fix this by changing evaluation order.  Previously, the above
compiled to:

```
0000 putself                                                          (   1)[Li]
0001 opt_send_without_block                 <calldata!mid:rhs, argc:0, FCALL|VCALL|ARGS_SIMPLE>
0003 dup
0004 putself
0005 opt_send_without_block                 <calldata!mid:lhs, argc:0, FCALL|VCALL|ARGS_SIMPLE>
0007 setconstant                            :C
0009 leave
```

After this change:

```
0000 putself                                                          (   1)[Li]
0001 opt_send_without_block                 <calldata!mid:lhs, argc:0, FCALL|VCALL|ARGS_SIMPLE>
0003 putself
0004 opt_send_without_block                 <calldata!mid:rhs, argc:0, FCALL|VCALL|ARGS_SIMPLE>
0006 swap
0007 topn                                   1
0009 swap
0010 setconstant                            :C
0012 leave
```

Note that if expr is not a module/class, then a TypeError is not
raised until after the evaluation of rhs.  This is because that
error is raised by setconstant.  If we wanted to raise TypeError
before evaluation of rhs, we would have to add a VM instruction
for calling vm_check_if_namespace.

Changing assignment order for single assignments caused problems
in the multiple assignment code, revealing that the issue also
affected multiple assignment.  Fix the multiple assignment code
so left-to-right evaluation also works for constant assignemnts.

Do some refactoring of the multiple assignment code to reduce
duplication after adding support for constants. Rename struct
masgn_attrasgn to masgn_lhs_node, since it now handles both
constants and attributes. Add add_masgn_lhs_node static function
for adding data for lhs attribute and constant setting.

Add tests for the expected behavior.  Remove spec for the previous
broken behavior.

Fixes [Bug #15928]