### PR TITLE
RDoc and aliases for Time

### DIFF
--- a/doc/time/in.rdoc
+++ b/doc/time/in.rdoc
@@ -1,7 +1,2 @@
 - <tt>in: zone</tt>: a timezone _zone_, which may be:
-  - A string offset from UTC.
-  - A single letter offset from UTC, in the range <tt>'A'..'Z'</tt>,
-    <tt>'J'</tt> (the so-called military timezone) excluded.
-  - An integer number of seconds.
-  - A timezone object;
-    see {Timezone Argument}[#class-Time-label-Timezone+Argument] for details.
+  :include: doc/time/zone_list.rdoc

--- a/doc/time/zone_and_in.rdoc
+++ b/doc/time/zone_and_in.rdoc
@@ -1,0 +1,3 @@
+- +zone+: a timezone _zone_, which may be:
+  :include: doc/time/zone_list.rdoc
+- <tt>in: zone</tt>: a timezone _zone_, as above.

--- a/doc/time/zone_list.rdoc
+++ b/doc/time/zone_list.rdoc
@@ -1,0 +1,6 @@
+- A string offset from UTC.
+- A single letter offset from UTC, in the range <tt>'A'..'Z'</tt>,
+  <tt>'J'</tt> (the so-called military timezone) excluded.
+- An integer number of seconds.
+- A timezone object;
+  see {Timezone Argument}[#class-Time-label-Timezone+Argument] for details.

--- a/timev.rb
+++ b/timev.rb
@@ -75,10 +75,9 @@ class Time
   # :include: doc/time/year.rdoc
   # :include: doc/time/mon-min.rdoc
   # :include: doc/time/sec.rdoc
-  # :include: doc/time/in.rdoc
+  # :include: doc/time/zone_and_in.rdoc
   #
-  def initialize(year = (now = true), mon = nil, mday = nil, hour = nil, min = nil, sec = nil, zone = nil, in: nil)
-    if zone
+  def initialize(year = (now = true), mon = nil, mday = nil, hour = nil, min = nil, sec = nil, zone = nil, in: nil)    if zone
       if __builtin.arg!(:in)
         raise ArgumentError, "timezone argument given as positional and keyword arguments"
       end


### PR DESCRIPTION
Enhanced RDoc for Time.
Methods treated:
- #to_i
- #to_f
- #to_r
- #<=>
- #eql?
- #hash
- #localtime
- #utc
- #localtime
- #utc
- #getlocal
- #getutc
Aliases added:
- rb_define_alias(rb_cTime, "tv_sec", "to_i");
- rb_define_alias(rb_cTime, "gmtime", "utc");
- rb_define_alias(rb_cTime, "getgm", "getutc");


