### PR TITLE
Fix PAGE_SIZE macro detection in autoconf

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2727,23 +2727,26 @@ main(int argc, char *argv[])
     test x$rb_cv_fork_with_pthread = xyes || AC_DEFINE(CANNOT_FORK_WITH_PTHREAD)
 ])
 
-AS_IF([test "x$ac_cv_func_mmap" = xyes], [
-    malloc_headers=`sed -n '/MALLOC_HEADERS_BEGIN/,/MALLOC_HEADERS_END/p' ${srcdir}/gc.c`
+AC_CHECK_HEADERS([sys/user.h])
+AS_IF([test "x$ac_cv_func_mmap:$ac_cv_header_sys_user_h" = xyes:yes], [
     AC_CACHE_CHECK([PAGE_SIZE is defined], rb_cv_page_size,
-        [AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[${malloc_headers}
+        [AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+            @%:@include <sys/user.h>
             typedef char conftest_page[PAGE_SIZE];
         ]], [[]])],
         [rb_cv_page_size=const],
-        [AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[${malloc_headers}]], [[
+        [AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+            @%:@include <sys/user.h>
+        ]], [[
             int page_size = (int)PAGE_SIZE;
             (void)page_size;
         ]])],
         [rb_cv_page_size=variable], [rb_cv_page_size=no])])])
-    AS_CASE([$rb_cv_page_size],
-    [const], [AC_DEFINE(USE_MMAP_ALIGNED_ALLOC, [(PAGE_SIZE <= HEAP_PAGE_SIZE)])],
-    [no], [AC_DEFINE(USE_MMAP_ALIGNED_ALLOC, 1)],
+    AS_IF([test "x$rb_cv_page_size" = xconst],
+        [AC_DEFINE(HAVE_CONST_PAGE_SIZE, 1)],
+        [AC_DEFINE(HAVE_CONST_PAGE_SIZE, 0)]
     )
-], [AC_DEFINE(USE_MMAP_ALIGNED_ALLOC, 0)])
+], [AC_DEFINE(HAVE_CONST_PAGE_SIZE, 0)])
 }
 
 : "runtime section" && {


### PR DESCRIPTION
The current fix for PAGE_SIZE macro detection in autoconf does not work correctly. I see the following output with running configure on Linux:

```
checking PAGE_SIZE is defined... no
```

Linux has PAGE_SIZE macro. This is happening because the macro exists in sys/user.h and not in the malloc headers.