### PR TITLE
[Doc] Fix a code in the Array#min documentation.

### DIFF
--- a/array.c
+++ b/array.c
@@ -5910,8 +5910,7 @@ ary_min_opt_string(VALUE ary, long i, VALUE vmin)
  *
  *  With an argument +n+ and a block, returns a new \Array with at most +n+ elements,
  *  in ascending order per the block:
- *    [0, 1, 2, 3].min(3) # => [0, 1, 2]
- *    [0, 1, 2, 3].min(6) # => [0, 1, 2, 3]
+ *    ['0', '00', '000'].min(2) {|a, b| a.size <=> b.size } # => ["0", "00"]
  */
 static VALUE
 rb_ary_min(int argc, VALUE *argv, VALUE ary)


### PR DESCRIPTION
The document code does not correspond to the description.

The description says "With an argument +n+ and a block", 
but there is currently no block in the code.

See also Array#max for reference.
https://github.com/ruby/ruby/blob/120b835fae2832ded4a02d3fcfc70749cad9d177/array.c#L5747-L5753