### PR TITLE
Remove unneeded rb_str_initialize defination in internal/string.h

### DIFF
--- a/internal/string.h
+++ b/internal/string.h
@@ -38,7 +38,6 @@ VALUE rb_external_str_with_enc(VALUE str, rb_encoding *eenc);
 VALUE rb_str_cat_conv_enc_opts(VALUE newstr, long ofs, const char *ptr, long len,
                                rb_encoding *from, int ecflags, VALUE ecopts);
 VALUE rb_enc_str_scrub(rb_encoding *enc, VALUE str, VALUE repl);
-VALUE rb_str_initialize(VALUE str, const char *ptr, long len, rb_encoding *enc);
 size_t rb_str_memsize(VALUE);
 char *rb_str_to_cstr(VALUE str);
 const char *ruby_escaped_char(int c);


### PR DESCRIPTION
`rb_str_initialize` was not used in ruby core, remove it.