### PR TITLE
cdhash_cmp: can take rational literals

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -2807,6 +2807,7 @@ compile.$(OBJEXT): $(top_srcdir)/internal/hash.h
 compile.$(OBJEXT): $(top_srcdir)/internal/imemo.h
 compile.$(OBJEXT): $(top_srcdir)/internal/numeric.h
 compile.$(OBJEXT): $(top_srcdir)/internal/object.h
+compile.$(OBJEXT): $(top_srcdir)/internal/rational.h
 compile.$(OBJEXT): $(top_srcdir)/internal/re.h
 compile.$(OBJEXT): $(top_srcdir)/internal/serial.h
 compile.$(OBJEXT): $(top_srcdir)/internal/static_assert.h

--- a/compile.c
+++ b/compile.c
@@ -28,6 +28,7 @@
 #include "internal/hash.h"
 #include "internal/numeric.h"
 #include "internal/object.h"
+#include "internal/rational.h"
 #include "internal/re.h"
 #include "internal/symbol.h"
 #include "internal/thread.h"
@@ -1986,6 +1987,10 @@ cdhash_cmp(VALUE val, VALUE lit)
     else if (tlit == T_FLOAT) {
         return rb_float_cmp(lit, val);
     }
+    else if (tlit ==  T_RATIONAL) {
+        /* Rational literals don't have fractions. */
+        return cdhash_cmp(val, rb_rational_num(lit));
+    }
     else {
         UNREACHABLE_RETURN(-1);
     }
@@ -2004,6 +2009,8 @@ cdhash_hash(VALUE a)
         return FIX2LONG(rb_big_hash(a));
       case T_FLOAT:
         return rb_dbl_long_hash(RFLOAT_VALUE(a));
+      case T_RATIONAL:
+        return rb_rational_hash(a);
       default:
         UNREACHABLE_RETURN(0);
     }

--- a/compile.c
+++ b/compile.c
@@ -1987,10 +1987,15 @@ cdhash_cmp(VALUE val, VALUE lit)
     else if (tlit == T_FLOAT) {
         return rb_float_cmp(lit, val);
     }
-    else if (tlit ==  T_RATIONAL) {
-        const struct RRational *dat1 = RRATIONAL(val);
-        const struct RRational *dat2 = RRATIONAL(lit);
-        return (dat1->num == dat2->num) && (dat1->den == dat2->den);
+    else if (tlit == T_RATIONAL) {
+        const struct RRational *rat1 = RRATIONAL(val);
+        const struct RRational *rat2 = RRATIONAL(lit);
+        return (rat1->num == rat2->num) && (rat1->den == rat2->den);
+    }
+    else if (tlit == T_COMPLEX) {
+        const struct RComplex *comp1 = RCOMPLEX(val);
+        const struct RComplex *comp2 = RCOMPLEX(lit);
+        return (comp1->real == comp2->real) && (comp1->imag == comp2->imag);
     }
     else {
         UNREACHABLE_RETURN(-1);
@@ -2012,6 +2017,8 @@ cdhash_hash(VALUE a)
         return rb_dbl_long_hash(RFLOAT_VALUE(a));
       case T_RATIONAL:
         return rb_rational_hash(a);
+      case T_COMPLEX:
+        return rb_complex_hash(a);
       default:
         UNREACHABLE_RETURN(0);
     }

--- a/compile.c
+++ b/compile.c
@@ -1988,8 +1988,9 @@ cdhash_cmp(VALUE val, VALUE lit)
         return rb_float_cmp(lit, val);
     }
     else if (tlit ==  T_RATIONAL) {
-        /* Rational literals don't have fractions. */
-        return cdhash_cmp(val, rb_rational_num(lit));
+        const struct RRational *dat1 = RRATIONAL(val);
+        const struct RRational *dat2 = RRATIONAL(lit);
+        return (dat1->num == dat2->num) && (dat1->den == dat2->den);
     }
     else {
         UNREACHABLE_RETURN(-1);

--- a/compile.c
+++ b/compile.c
@@ -1990,12 +1990,12 @@ cdhash_cmp(VALUE val, VALUE lit)
     else if (tlit == T_RATIONAL) {
         const struct RRational *rat1 = RRATIONAL(val);
         const struct RRational *rat2 = RRATIONAL(lit);
-        return cdhash_cmp(rat1->num, rat2->num) && cdhash_cmp(rat1->den, rat2->den);
+        return cdhash_cmp(rat1->num, rat2->num) || cdhash_cmp(rat1->den, rat2->den);
     }
     else if (tlit == T_COMPLEX) {
         const struct RComplex *comp1 = RCOMPLEX(val);
         const struct RComplex *comp2 = RCOMPLEX(lit);
-        return cdhash_cmp(comp1->real, comp2->real) && cdhash_cmp(comp1->imag, comp2->imag);
+        return cdhash_cmp(comp1->real, comp2->real) || cdhash_cmp(comp1->imag, comp2->imag);
     }
     else {
         UNREACHABLE_RETURN(-1);

--- a/compile.c
+++ b/compile.c
@@ -1990,12 +1990,12 @@ cdhash_cmp(VALUE val, VALUE lit)
     else if (tlit == T_RATIONAL) {
         const struct RRational *rat1 = RRATIONAL(val);
         const struct RRational *rat2 = RRATIONAL(lit);
-        return (rat1->num == rat2->num) && (rat1->den == rat2->den);
+        return cdhash_cmp(rat1->num, rat2->num) && cdhash_cmp(rat1->den, rat2->den);
     }
     else if (tlit == T_COMPLEX) {
         const struct RComplex *comp1 = RCOMPLEX(val);
         const struct RComplex *comp2 = RCOMPLEX(lit);
-        return (comp1->real == comp2->real) && (comp1->imag == comp2->imag);
+        return cdhash_cmp(comp1->real, comp2->real) && cdhash_cmp(comp1->imag, comp2->imag);
     }
     else {
         UNREACHABLE_RETURN(-1);

--- a/complex.c
+++ b/complex.c
@@ -1326,8 +1326,8 @@ nucomp_numerator(VALUE self)
 }
 
 /* :nodoc: */
-static VALUE
-nucomp_hash(VALUE self)
+st_index_t
+rb_complex_hash(VALUE self)
 {
     st_index_t v, h[2];
     VALUE n;
@@ -1338,7 +1338,13 @@ nucomp_hash(VALUE self)
     n = rb_hash(dat->imag);
     h[1] = NUM2LONG(n);
     v = rb_memhash(h, sizeof(h));
-    return ST2FIX(v);
+    return v;
+}
+
+static VALUE
+nucomp_hash(VALUE self)
+{
+    return ST2FIX(rb_complex_hash(self));
 }
 
 /* :nodoc: */

--- a/internal/complex.h
+++ b/internal/complex.h
@@ -25,5 +25,6 @@ struct RComplex {
 
 /* complex.c */
 VALUE rb_dbl_complex_new_polar_pi(double abs, double ang);
+st_index_t rb_complex_hash(VALUE comp);
 
 #endif /* INTERNAL_COMPLEX_H */

--- a/internal/rational.h
+++ b/internal/rational.h
@@ -33,6 +33,7 @@ VALUE rb_rational_div(VALUE self, VALUE other);
 VALUE rb_lcm(VALUE x, VALUE y);
 VALUE rb_rational_reciprocal(VALUE x);
 VALUE rb_cstr_to_rat(const char *, int);
+VALUE rb_rational_hash(VALUE self);
 VALUE rb_rational_abs(VALUE self);
 VALUE rb_rational_cmp(VALUE self, VALUE other);
 VALUE rb_rational_pow(VALUE self, VALUE other);

--- a/rational.c
+++ b/rational.c
@@ -1742,8 +1742,8 @@ nurat_rationalize(int argc, VALUE *argv, VALUE self)
 }
 
 /* :nodoc: */
-static VALUE
-nurat_hash(VALUE self)
+st_index_t
+rb_rational_hash(VALUE self)
 {
     st_index_t v, h[2];
     VALUE n;
@@ -1754,8 +1754,15 @@ nurat_hash(VALUE self)
     n = rb_hash(dat->den);
     h[1] = NUM2LONG(n);
     v = rb_memhash(h, sizeof(h));
-    return ST2FIX(v);
+    return v;
 }
+
+static VALUE
+nurat_hash(VALUE self)
+{
+    return ST2FIX(rb_rational_hash(self));
+}
+
 
 static VALUE
 f_format(VALUE self, VALUE (*func)(VALUE))

--- a/test/ruby/test_rational.rb
+++ b/test/ruby/test_rational.rb
@@ -835,6 +835,10 @@ class Rational_Test < Test::Unit::TestCase
       n = case 1 when 2r then false else true end
       assert_equal(n, true, '[ruby-core:103759] [Bug #17854]')
     RUBY
+    assert_separately([], <<-RUBY)
+      n = case 3/2r when 1.5r then true else false end
+      assert_equal(n, true, '[ruby-core:103759] [Bug #17854]')
+    RUBY
   end
 
   def test_Rational_with_invalid_exception

--- a/test/ruby/test_rational.rb
+++ b/test/ruby/test_rational.rb
@@ -830,21 +830,6 @@ class Rational_Test < Test::Unit::TestCase
     assert_raise(ZeroDivisionError) {Rational("1/0")}
   end
 
-  def test_cdhash
-    assert_separately([], <<-RUBY)
-      n = case 1 when 2r then false else true end
-      assert_equal(n, true, '[ruby-core:103759] [Bug #17854]')
-    RUBY
-    assert_separately([], <<-RUBY)
-      n = case 3/2r when 1.5r then true else false end
-      assert_equal(n, true, '[ruby-core:103759] [Bug #17854]')
-    RUBY
-    assert_separately([], <<-RUBY)
-      n = case 1i when 1i then true else false end
-      assert_equal(n, true, '[ruby-core:103759] [Bug #17854]')
-    RUBY
-  end
-
   def test_Rational_with_invalid_exception
     assert_raise(ArgumentError) {
       Rational("1/1", exception: 1)

--- a/test/ruby/test_rational.rb
+++ b/test/ruby/test_rational.rb
@@ -830,6 +830,13 @@ class Rational_Test < Test::Unit::TestCase
     assert_raise(ZeroDivisionError) {Rational("1/0")}
   end
 
+  def test_cdhash
+    assert_separately([], <<-RUBY)
+      n = case 1 when 2r then false else true end
+      assert_equal(n, true, '[ruby-core:103759] [Bug #17854]')
+    RUBY
+  end
+
   def test_Rational_with_invalid_exception
     assert_raise(ArgumentError) {
       Rational("1/1", exception: 1)

--- a/test/ruby/test_rational.rb
+++ b/test/ruby/test_rational.rb
@@ -839,6 +839,10 @@ class Rational_Test < Test::Unit::TestCase
       n = case 3/2r when 1.5r then true else false end
       assert_equal(n, true, '[ruby-core:103759] [Bug #17854]')
     RUBY
+    assert_separately([], <<-RUBY)
+      n = case 1i when 1i then true else false end
+      assert_equal(n, true, '[ruby-core:103759] [Bug #17854]')
+    RUBY
   end
 
   def test_Rational_with_invalid_exception

--- a/test/ruby/test_syntax.rb
+++ b/test/ruby/test_syntax.rb
@@ -1730,6 +1730,21 @@ eom
     assert_equal [[4, 1, 5, 2, 3], {a: 1}], obj.foo(4, 5, 2, 3, a: 1){|args, kws| [args, kws]}
   end
 
+  def test_cdhash
+    assert_separately([], <<-RUBY)
+      n = case 1 when 2r then false else true end
+      assert_equal(n, true, '[ruby-core:103759] [Bug #17854]')
+    RUBY
+    assert_separately([], <<-RUBY)
+      n = case 3/2r when 1.5r then true else false end
+      assert_equal(n, true, '[ruby-core:103759] [Bug #17854]')
+    RUBY
+    assert_separately([], <<-RUBY)
+      n = case 1i when 1i then true else false end
+      assert_equal(n, true, '[ruby-core:103759] [Bug #17854]')
+    RUBY
+  end
+
   private
 
   def not_label(x) @result = x; @not_label ||= nil end


### PR DESCRIPTION
"Rational literal"s are those ~~integers~~ numeric literals suffixed with `r`.  They tend to be a part of more complex expressions like `123/456r`, but in theory they can live alone.  When such "bare" rational literals are passed to case-when branch, we have to take care of them.  Fixes [Bug #17854]

CC: @metalefty