### PR TITLE
compile.c: Pass node instead of nd_line(node) to ADD_INSN* functions

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -245,6 +245,17 @@ ast_node_type(rb_execution_context_t *ec, VALUE self)
     return rb_sym_intern_ascii_cstr(node_type_to_str(data->node));
 }
 
+#ifdef EXPERIMENTAL_ISEQ_NODE_ID
+static VALUE
+ast_node_node_id(VALUE self)
+{
+    struct ASTNodeData *data;
+    TypedData_Get_Struct(self, struct ASTNodeData, &rb_node_type, data);
+
+    return INT2FIX(nd_node_id(data->node));
+}
+#endif
+
 #define NEW_CHILD(ast, node) node ? ast_new_internal(ast, node) : Qnil
 
 static VALUE
@@ -695,4 +706,7 @@ Init_ast(void)
     rb_mAST = rb_define_module_under(rb_cRubyVM, "AbstractSyntaxTree");
     rb_cNode = rb_define_class_under(rb_mAST, "Node", rb_cObject);
     rb_undef_alloc_func(rb_cNode);
+#ifdef EXPERIMENTAL_ISEQ_NODE_ID
+    rb_define_method(rb_cNode, "node_id", ast_node_node_id, 0);
+#endif
 }

--- a/compile.c
+++ b/compile.c
@@ -93,6 +93,7 @@ typedef struct iseq_insn_data {
     VALUE *operands;
     struct {
 	int line_no;
+        int node_id;
 	rb_event_flag_t events;
     } insn_info;
 } INSN;
@@ -216,77 +217,77 @@ const ID rb_iseq_shared_exc_local_tbl[] = {idERROR_INFO};
   APPEND_LIST((seq1), (seq2))
 
 /* add an instruction */
-#define ADD_INSN(seq, line, insn) \
-  ADD_ELEM((seq), (LINK_ELEMENT *) new_insn_body(iseq, (line), BIN(insn), 0))
+#define ADD_INSN(seq, line_node, insn) \
+  ADD_ELEM((seq), (LINK_ELEMENT *) new_insn_body(iseq, (line_node), BIN(insn), 0))
 
 /* insert an instruction before next */
-#define INSERT_BEFORE_INSN(next, line, insn) \
-  ELEM_INSERT_PREV(&(next)->link, (LINK_ELEMENT *) new_insn_body(iseq, (line), BIN(insn), 0))
+#define INSERT_BEFORE_INSN(next, line_node, insn) \
+  ELEM_INSERT_PREV(&(next)->link, (LINK_ELEMENT *) new_insn_body(iseq, (line_node), BIN(insn), 0))
 
 /* insert an instruction after prev */
-#define INSERT_AFTER_INSN(prev, line, insn) \
-  ELEM_INSERT_NEXT(&(prev)->link, (LINK_ELEMENT *) new_insn_body(iseq, (line), BIN(insn), 0))
+#define INSERT_AFTER_INSN(prev, line_node, insn) \
+  ELEM_INSERT_NEXT(&(prev)->link, (LINK_ELEMENT *) new_insn_body(iseq, (line_node), BIN(insn), 0))
 
 /* add an instruction with some operands (1, 2, 3, 5) */
-#define ADD_INSN1(seq, line, insn, op1) \
+#define ADD_INSN1(seq, line_node, insn, op1) \
   ADD_ELEM((seq), (LINK_ELEMENT *) \
-           new_insn_body(iseq, (line), BIN(insn), 1, (VALUE)(op1)))
+           new_insn_body(iseq, (line_node), BIN(insn), 1, (VALUE)(op1)))
 
 /* insert an instruction with some operands (1, 2, 3, 5) before next */
-#define INSERT_BEFORE_INSN1(next, line, insn, op1) \
+#define INSERT_BEFORE_INSN1(next, line_node, insn, op1) \
   ELEM_INSERT_PREV(&(next)->link, (LINK_ELEMENT *) \
-           new_insn_body(iseq, (line), BIN(insn), 1, (VALUE)(op1)))
+           new_insn_body(iseq, (line_node), BIN(insn), 1, (VALUE)(op1)))
 
 /* insert an instruction with some operands (1, 2, 3, 5) after prev */
-#define INSERT_AFTER_INSN1(prev, line, insn, op1) \
+#define INSERT_AFTER_INSN1(prev, line_node, insn, op1) \
   ELEM_INSERT_NEXT(&(prev)->link, (LINK_ELEMENT *) \
-           new_insn_body(iseq, (line), BIN(insn), 1, (VALUE)(op1)))
+           new_insn_body(iseq, (line_node), BIN(insn), 1, (VALUE)(op1)))
 
 #define LABEL_REF(label) ((label)->refcnt++)
 
 /* add an instruction with label operand (alias of ADD_INSN1) */
-#define ADD_INSNL(seq, line, insn, label) (ADD_INSN1(seq, line, insn, label), LABEL_REF(label))
+#define ADD_INSNL(seq, line_node, insn, label) (ADD_INSN1(seq, line_node, insn, label), LABEL_REF(label))
 
-#define ADD_INSN2(seq, line, insn, op1, op2) \
+#define ADD_INSN2(seq, line_node, insn, op1, op2) \
   ADD_ELEM((seq), (LINK_ELEMENT *) \
-           new_insn_body(iseq, (line), BIN(insn), 2, (VALUE)(op1), (VALUE)(op2)))
+           new_insn_body(iseq, (line_node), BIN(insn), 2, (VALUE)(op1), (VALUE)(op2)))
 
-#define ADD_INSN3(seq, line, insn, op1, op2, op3) \
+#define ADD_INSN3(seq, line_node, insn, op1, op2, op3) \
   ADD_ELEM((seq), (LINK_ELEMENT *) \
-           new_insn_body(iseq, (line), BIN(insn), 3, (VALUE)(op1), (VALUE)(op2), (VALUE)(op3)))
+           new_insn_body(iseq, (line_node), BIN(insn), 3, (VALUE)(op1), (VALUE)(op2), (VALUE)(op3)))
 
 /* Specific Insn factory */
-#define ADD_SEND(seq, line, id, argc) \
-  ADD_SEND_R((seq), (line), (id), (argc), NULL, (VALUE)INT2FIX(0), NULL)
+#define ADD_SEND(seq, line_node, id, argc) \
+  ADD_SEND_R((seq), (line_node), (id), (argc), NULL, (VALUE)INT2FIX(0), NULL)
 
-#define ADD_SEND_WITH_FLAG(seq, line, id, argc, flag) \
-  ADD_SEND_R((seq), (line), (id), (argc), NULL, (VALUE)(flag), NULL)
+#define ADD_SEND_WITH_FLAG(seq, line_node, id, argc, flag) \
+  ADD_SEND_R((seq), (line_node), (id), (argc), NULL, (VALUE)(flag), NULL)
 
-#define ADD_SEND_WITH_BLOCK(seq, line, id, argc, block) \
-  ADD_SEND_R((seq), (line), (id), (argc), (block), (VALUE)INT2FIX(0), NULL)
+#define ADD_SEND_WITH_BLOCK(seq, line_node, id, argc, block) \
+  ADD_SEND_R((seq), (line_node), (id), (argc), (block), (VALUE)INT2FIX(0), NULL)
 
-#define ADD_CALL_RECEIVER(seq, line) \
-  ADD_INSN((seq), (line), putself)
+#define ADD_CALL_RECEIVER(seq, line_node) \
+  ADD_INSN((seq), (line_node), putself)
 
-#define ADD_CALL(seq, line, id, argc) \
-  ADD_SEND_R((seq), (line), (id), (argc), NULL, (VALUE)INT2FIX(VM_CALL_FCALL), NULL)
+#define ADD_CALL(seq, line_node, id, argc) \
+  ADD_SEND_R((seq), (line_node), (id), (argc), NULL, (VALUE)INT2FIX(VM_CALL_FCALL), NULL)
 
-#define ADD_CALL_WITH_BLOCK(seq, line, id, argc, block) \
-  ADD_SEND_R((seq), (line), (id), (argc), (block), (VALUE)INT2FIX(VM_CALL_FCALL), NULL)
+#define ADD_CALL_WITH_BLOCK(seq, line_node, id, argc, block) \
+  ADD_SEND_R((seq), (line_node), (id), (argc), (block), (VALUE)INT2FIX(VM_CALL_FCALL), NULL)
 
-#define ADD_SEND_R(seq, line, id, argc, block, flag, keywords) \
-  ADD_ELEM((seq), (LINK_ELEMENT *) new_insn_send(iseq, (line), (id), (VALUE)(argc), (block), (VALUE)(flag), (keywords)))
+#define ADD_SEND_R(seq, line_node, id, argc, block, flag, keywords) \
+  ADD_ELEM((seq), (LINK_ELEMENT *) new_insn_send(iseq, (line_node), (id), (VALUE)(argc), (block), (VALUE)(flag), (keywords)))
 
 #define ADD_TRACE(seq, event) \
   ADD_ELEM((seq), (LINK_ELEMENT *)new_trace_body(iseq, (event), 0))
 #define ADD_TRACE_WITH_DATA(seq, event, data) \
   ADD_ELEM((seq), (LINK_ELEMENT *)new_trace_body(iseq, (event), (data)))
 
-static void iseq_add_getlocal(rb_iseq_t *iseq, LINK_ANCHOR *const seq, int line, int idx, int level);
-static void iseq_add_setlocal(rb_iseq_t *iseq, LINK_ANCHOR *const seq, int line, int idx, int level);
+static void iseq_add_getlocal(rb_iseq_t *iseq, LINK_ANCHOR *const seq, const NODE *const line_node, int idx, int level);
+static void iseq_add_setlocal(rb_iseq_t *iseq, LINK_ANCHOR *const seq, const NODE *const line_node, int idx, int level);
 
-#define ADD_GETLOCAL(seq, line, idx, level) iseq_add_getlocal(iseq, (seq), (line), (idx), (level))
-#define ADD_SETLOCAL(seq, line, idx, level) iseq_add_setlocal(iseq, (seq), (line), (idx), (level))
+#define ADD_GETLOCAL(seq, line_node, idx, level) iseq_add_getlocal(iseq, (seq), (line_node), (idx), (level))
+#define ADD_SETLOCAL(seq, line_node, idx, level) iseq_add_setlocal(iseq, (seq), (line_node), (idx), (level))
 
 /* add label */
 #define ADD_LABEL(seq, label) \
@@ -295,8 +296,8 @@ static void iseq_add_setlocal(rb_iseq_t *iseq, LINK_ANCHOR *const seq, int line,
 #define APPEND_LABEL(seq, before, label) \
   APPEND_ELEM((seq), (before), (LINK_ELEMENT *) (label))
 
-#define ADD_ADJUST(seq, line, label) \
-  ADD_ELEM((seq), (LINK_ELEMENT *) new_adjust_body(iseq, (label), (line)))
+#define ADD_ADJUST(seq, line_node, label) \
+  ADD_ELEM((seq), (LINK_ELEMENT *) new_adjust_body(iseq, (label), nd_line(line_node)))
 
 #define ADD_ADJUST_RESTORE(seq, label) \
   ADD_ELEM((seq), (LINK_ELEMENT *) new_adjust_body(iseq, (label), -1))
@@ -332,7 +333,7 @@ static void iseq_add_setlocal(rb_iseq_t *iseq, LINK_ANCHOR *const seq, int line,
 
 #define COMPILE_RECV(anchor, desc, node) \
     (private_recv_p(node) ? \
-     (ADD_INSN(anchor, nd_line(node), putself), VM_CALL_FCALL) : \
+     (ADD_INSN(anchor, node, putself), VM_CALL_FCALL) : \
      COMPILE(anchor, desc, node->nd_recv) ? 0 : -1)
 
 #define OPERAND_AT(insn, idx) \
@@ -468,7 +469,7 @@ static void dump_disasm_list(const LINK_ELEMENT *elem);
 static int insn_data_length(INSN *iobj);
 static int calc_sp_depth(int depth, INSN *iobj);
 
-static INSN *new_insn_body(rb_iseq_t *iseq, int line_no, enum ruby_vminsn_type insn_id, int argc, ...);
+static INSN *new_insn_body(rb_iseq_t *iseq, const NODE *const line_node, enum ruby_vminsn_type insn_id, int argc, ...);
 static LABEL *new_label_body(rb_iseq_t *iseq, long line);
 static ADJUST *new_adjust_body(rb_iseq_t *iseq, LABEL *label, int line);
 static TRACE *new_trace_body(rb_iseq_t *iseq, rb_event_flag_t event, long data);
@@ -645,6 +646,15 @@ decl_branch_base(rb_iseq_t *iseq, const NODE *node, const char *type)
     return branches;
 }
 
+static NODE
+generate_dummy_line_node(int lineno, int node_id)
+{
+    NODE dummy = { 0 };
+    nd_set_line(&dummy, lineno);
+    nd_set_node_id(&dummy, node_id);
+    return dummy;
+}
+
 static void
 add_trace_branch_coverage(rb_iseq_t *iseq, LINK_ANCHOR *const seq, const NODE *node, int branch_id, const char *type, VALUE branches)
 {
@@ -683,7 +693,9 @@ add_trace_branch_coverage(rb_iseq_t *iseq, LINK_ANCHOR *const seq, const NODE *n
     }
 
     ADD_TRACE_WITH_DATA(seq, RUBY_EVENT_COVERAGE_BRANCH, counter_idx);
-    ADD_INSN(seq, last_lineno, nop);
+
+    NODE dummy_line_node = generate_dummy_line_node(last_lineno, nd_node_id(node));
+    ADD_INSN(seq, &dummy_line_node, nop);
 }
 
 #define ISEQ_LAST_LINE(iseq) (ISEQ_COMPILE_DATA(iseq)->last_line)
@@ -718,7 +730,8 @@ rb_iseq_compile_callback(rb_iseq_t *iseq, const struct rb_iseq_new_with_callback
 
     (*ifunc->func)(iseq, ret, ifunc->data);
 
-    ADD_INSN(ret, ISEQ_COMPILE_DATA(iseq)->last_line, leave);
+    NODE dummy_line_node = generate_dummy_line_node(ISEQ_COMPILE_DATA(iseq)->last_line, -1);
+    ADD_INSN(ret, &dummy_line_node, leave);
 
     CHECK(iseq_setup_insn(iseq, ret));
     return iseq_setup(iseq, ret);
@@ -754,7 +767,8 @@ rb_iseq_compile_node(rb_iseq_t *iseq, const NODE *node)
 		end->rescued = LABEL_RESCUE_END;
 
 		ADD_TRACE(ret, RUBY_EVENT_B_CALL);
-		ADD_INSN (ret, FIX2INT(iseq->body->location.first_lineno), nop);
+                NODE dummy_line_node = generate_dummy_line_node(FIX2INT(iseq->body->location.first_lineno), -1);
+		ADD_INSN (ret, &dummy_line_node, nop);
 		ADD_LABEL(ret, start);
 		CHECK(COMPILE(ret, "block body", node->nd_body));
 		ADD_LABEL(ret, end);
@@ -821,11 +835,13 @@ rb_iseq_compile_node(rb_iseq_t *iseq, const NODE *node)
     }
 
     if (iseq->body->type == ISEQ_TYPE_RESCUE || iseq->body->type == ISEQ_TYPE_ENSURE) {
-	ADD_GETLOCAL(ret, 0, LVAR_ERRINFO, 0);
-	ADD_INSN1(ret, 0, throw, INT2FIX(0) /* continue throw */ );
+        NODE dummy_line_node = generate_dummy_line_node(0, -1);
+	ADD_GETLOCAL(ret, &dummy_line_node, LVAR_ERRINFO, 0);
+	ADD_INSN1(ret, &dummy_line_node, throw, INT2FIX(0) /* continue throw */ );
     }
     else {
-	ADD_INSN(ret, ISEQ_COMPILE_DATA(iseq)->last_line, leave);
+        NODE dummy_line_node = generate_dummy_line_node(ISEQ_COMPILE_DATA(iseq)->last_line, -1);
+	ADD_INSN(ret, &dummy_line_node, leave);
     }
 
 #if OPT_SUPPORT_JOKE
@@ -1227,17 +1243,18 @@ new_adjust_body(rb_iseq_t *iseq, LABEL *label, int line)
 }
 
 static INSN *
-new_insn_core(rb_iseq_t *iseq, int line_no,
+new_insn_core(rb_iseq_t *iseq, const NODE *line_node,
 	      int insn_id, int argc, VALUE *argv)
 {
     INSN *iobj = compile_data_alloc_insn(iseq);
 
-    /* printf("insn_id: %d, line: %d\n", insn_id, line_no); */
+    /* printf("insn_id: %d, line: %d\n", insn_id, nd_line(line_node)); */
 
     iobj->link.type = ISEQ_ELEMENT_INSN;
     iobj->link.next = 0;
     iobj->insn_id = insn_id;
-    iobj->insn_info.line_no = line_no;
+    iobj->insn_info.line_no = nd_line(line_node);
+    iobj->insn_info.node_id = nd_node_id(line_node);
     iobj->insn_info.events = 0;
     iobj->operands = argv;
     iobj->operand_size = argc;
@@ -1246,7 +1263,7 @@ new_insn_core(rb_iseq_t *iseq, int line_no,
 }
 
 static INSN *
-new_insn_body(rb_iseq_t *iseq, int line_no, enum ruby_vminsn_type insn_id, int argc, ...)
+new_insn_body(rb_iseq_t *iseq, const NODE *const line_node, enum ruby_vminsn_type insn_id, int argc, ...)
 {
     VALUE *operands = 0;
     va_list argv;
@@ -1260,7 +1277,7 @@ new_insn_body(rb_iseq_t *iseq, int line_no, enum ruby_vminsn_type insn_id, int a
 	}
 	va_end(argv);
     }
-    return new_insn_core(iseq, line_no, insn_id, argc, operands);
+    return new_insn_core(iseq, line_node, insn_id, argc, operands);
 }
 
 static const struct rb_callinfo *
@@ -1286,7 +1303,7 @@ new_callinfo(rb_iseq_t *iseq, ID mid, int argc, unsigned int flag, struct rb_cal
 }
 
 static INSN *
-new_insn_send(rb_iseq_t *iseq, int line_no, ID id, VALUE argc, const rb_iseq_t *blockiseq, VALUE flag, struct rb_callinfo_kwarg *keywords)
+new_insn_send(rb_iseq_t *iseq, const NODE *const line_node, ID id, VALUE argc, const rb_iseq_t *blockiseq, VALUE flag, struct rb_callinfo_kwarg *keywords)
 {
     VALUE *operands = compile_data_calloc2(iseq, sizeof(VALUE), 2);
     VALUE ci = (VALUE)new_callinfo(iseq, id, FIX2INT(argc), FIX2INT(flag), keywords, blockiseq != NULL);
@@ -1295,7 +1312,7 @@ new_insn_send(rb_iseq_t *iseq, int line_no, ID id, VALUE argc, const rb_iseq_t *
     if (blockiseq) {
         RB_OBJ_WRITTEN(iseq, Qundef, blockiseq);
     }
-    INSN *insn = new_insn_core(iseq, line_no, BIN(send), 2, operands);
+    INSN *insn = new_insn_core(iseq, line_node, BIN(send), 2, operands);
     RB_OBJ_WRITTEN(iseq, Qundef, ci);
     RB_GC_GUARD(ci);
     return insn;
@@ -1413,7 +1430,8 @@ iseq_insert_nop_between_end_and_cont(rb_iseq_t *iseq)
 
             for (e = end; e && (IS_LABEL(e) || IS_TRACE(e)); e = e->next) {
                 if (e == cont) {
-                    INSN *nop = new_insn_core(iseq, 0, BIN(nop), 0, 0);
+                    NODE dummy_line_node = generate_dummy_line_node(0, -1);
+                    INSN *nop = new_insn_core(iseq, &dummy_line_node, BIN(nop), 0, 0);
                     ELEM_INSERT_NEXT(end, &nop->link);
                     break;
                 }
@@ -1659,25 +1677,25 @@ iseq_lvar_id(const rb_iseq_t *iseq, int idx, int level)
 }
 
 static void
-iseq_add_getlocal(rb_iseq_t *iseq, LINK_ANCHOR *const seq, int line, int idx, int level)
+iseq_add_getlocal(rb_iseq_t *iseq, LINK_ANCHOR *const seq, const NODE *const line_node, int idx, int level)
 {
     if (iseq_local_block_param_p(iseq, idx, level)) {
-	ADD_INSN2(seq, line, getblockparam, INT2FIX((idx) + VM_ENV_DATA_SIZE - 1), INT2FIX(level));
+	ADD_INSN2(seq, line_node, getblockparam, INT2FIX((idx) + VM_ENV_DATA_SIZE - 1), INT2FIX(level));
     }
     else {
-	ADD_INSN2(seq, line, getlocal, INT2FIX((idx) + VM_ENV_DATA_SIZE - 1), INT2FIX(level));
+	ADD_INSN2(seq, line_node, getlocal, INT2FIX((idx) + VM_ENV_DATA_SIZE - 1), INT2FIX(level));
     }
     if (level > 0) access_outer_variables(iseq, level, iseq_lvar_id(iseq, idx, level), Qfalse);
 }
 
 static void
-iseq_add_setlocal(rb_iseq_t *iseq, LINK_ANCHOR *const seq, int line, int idx, int level)
+iseq_add_setlocal(rb_iseq_t *iseq, LINK_ANCHOR *const seq, const NODE *const line_node, int idx, int level)
 {
     if (iseq_local_block_param_p(iseq, idx, level)) {
-	ADD_INSN2(seq, line, setblockparam, INT2FIX((idx) + VM_ENV_DATA_SIZE - 1), INT2FIX(level));
+	ADD_INSN2(seq, line_node, setblockparam, INT2FIX((idx) + VM_ENV_DATA_SIZE - 1), INT2FIX(level));
     }
     else {
-	ADD_INSN2(seq, line, setlocal, INT2FIX((idx) + VM_ENV_DATA_SIZE - 1), INT2FIX(level));
+	ADD_INSN2(seq, line_node, setlocal, INT2FIX((idx) + VM_ENV_DATA_SIZE - 1), INT2FIX(level));
     }
     if (level > 0) access_outer_variables(iseq, level, iseq_lvar_id(iseq, idx, level), Qtrue);
 }
@@ -2181,8 +2199,14 @@ add_insn_info(struct iseq_insn_info_entry *insns_info, unsigned int *positions,
 {
     if (insns_info_index == 0 ||
         insns_info[insns_info_index-1].line_no != iobj->insn_info.line_no ||
+#ifdef EXPERIMENTAL_ISEQ_NODE_ID
+        insns_info[insns_info_index-1].node_id != iobj->insn_info.node_id ||
+#endif
         insns_info[insns_info_index-1].events  != iobj->insn_info.events) {
         insns_info[insns_info_index].line_no    = iobj->insn_info.line_no;
+#ifdef EXPERIMENTAL_ISEQ_NODE_ID
+        insns_info[insns_info_index].node_id    = iobj->insn_info.node_id;
+#endif
         insns_info[insns_info_index].events     = iobj->insn_info.events;
         positions[insns_info_index]             = code_index;
         return TRUE;
@@ -2776,7 +2800,7 @@ optimize_checktype(rb_iseq_t *iseq, INSN *iobj)
      *   jump L2
      * L2:
      */
-    int line;
+    int line, node_id;
     INSN *niobj, *ciobj, *dup = 0;
     LABEL *dest = 0;
     VALUE type;
@@ -2822,6 +2846,8 @@ optimize_checktype(rb_iseq_t *iseq, INSN *iobj)
         return FALSE;
     }
     line = ciobj->insn_info.line_no;
+    node_id = ciobj->insn_info.node_id;
+    NODE dummy_line_node = generate_dummy_line_node(line, node_id);
     if (!dest) {
 	if (niobj->link.next && IS_LABEL(niobj->link.next)) {
 	    dest = (LABEL *)niobj->link.next; /* reuse label */
@@ -2831,9 +2857,9 @@ optimize_checktype(rb_iseq_t *iseq, INSN *iobj)
 	    ELEM_INSERT_NEXT(&niobj->link, &dest->link);
 	}
     }
-    INSERT_AFTER_INSN1(iobj, line, jump, dest);
+    INSERT_AFTER_INSN1(iobj, &dummy_line_node, jump, dest);
     LABEL_REF(dest);
-    if (!dup) INSERT_AFTER_INSN(iobj, line, pop);
+    if (!dup) INSERT_AFTER_INSN(iobj, &dummy_line_node, pop);
     return TRUE;
 }
 
@@ -2966,8 +2992,8 @@ iseq_peephole_optimize(rb_iseq_t *iseq, LINK_ELEMENT *list, const int do_tailcal
 		 *   pop
 		 *   jump L1
 		 */
-		INSN *popiobj = new_insn_core(iseq, iobj->insn_info.line_no,
-					      BIN(pop), 0, 0);
+                NODE dummy_line_node = generate_dummy_line_node(iobj->insn_info.line_no, iobj->insn_info.node_id);
+		INSN *popiobj = new_insn_core(iseq, &dummy_line_node, BIN(pop), 0, 0);
 		ELEM_REPLACE(&piobj->link, &popiobj->link);
 	    }
 	}
@@ -3130,12 +3156,14 @@ iseq_peephole_optimize(rb_iseq_t *iseq, LINK_ELEMENT *list, const int do_tailcal
                         ELEM_REMOVE(iobj->link.prev);
                     }
                     else if (!iseq_pop_newarray(iseq, pobj)) {
-                        pobj = new_insn_core(iseq, pobj->insn_info.line_no, BIN(pop), 0, NULL);
+                        NODE dummy_line_node = generate_dummy_line_node(pobj->insn_info.line_no, pobj->insn_info.node_id);
+                        pobj = new_insn_core(iseq, &dummy_line_node, BIN(pop), 0, NULL);
                         ELEM_INSERT_PREV(&iobj->link, &pobj->link);
                     }
                     if (cond) {
                         if (prev_dup) {
-                            pobj = new_insn_core(iseq, pobj->insn_info.line_no, BIN(putnil), 0, NULL);
+                            NODE dummy_line_node = generate_dummy_line_node(pobj->insn_info.line_no, pobj->insn_info.node_id);
+                            pobj = new_insn_core(iseq, &dummy_line_node, BIN(putnil), 0, NULL);
                             ELEM_INSERT_NEXT(&iobj->link, &pobj->link);
                         }
                         iobj->insn_id = BIN(jump);
@@ -3181,7 +3209,8 @@ iseq_peephole_optimize(rb_iseq_t *iseq, LINK_ELEMENT *list, const int do_tailcal
 	    }
 	    else if (previ == BIN(concatarray)) {
 		INSN *piobj = (INSN *)prev;
-		INSERT_BEFORE_INSN1(piobj, piobj->insn_info.line_no, splatarray, Qfalse);
+                NODE dummy_line_node = generate_dummy_line_node(piobj->insn_info.line_no, piobj->insn_info.node_id);
+		INSERT_BEFORE_INSN1(piobj, &dummy_line_node, splatarray, Qfalse);
 		INSN_OF(piobj) = BIN(pop);
 	    }
 	    else if (previ == BIN(concatstrings)) {
@@ -3597,7 +3626,8 @@ new_unified_insn(rb_iseq_t *iseq,
 	list = list->next;
     }
 
-    return new_insn_core(iseq, iobj->insn_info.line_no, insn_id, argc, operands);
+    NODE dummy_line_node = generate_dummy_line_node(iobj->insn_info.line_no, iobj->insn_info.node_id);
+    return new_insn_core(iseq, &dummy_line_node, insn_id, argc, operands);
 }
 #endif
 
@@ -3748,8 +3778,9 @@ iseq_set_sequence_stackcaching(rb_iseq_t *iseq, LINK_ANCHOR *const anchor)
 		    {
 			/* exception merge point */
 			if (state != SCS_AX) {
+                            NODE dummy_line_node = generate_dummy_line_node(0, -1);
 			    INSN *rpobj =
-				new_insn_body(iseq, 0, BIN(reput), 0);
+				new_insn_body(iseq, &dummy_line_node, BIN(reput), 0);
 
 			    /* replace this insn */
 			    ELEM_REPLACE(list, (LINK_ELEMENT *)rpobj);
@@ -3857,7 +3888,7 @@ compile_dstr_fragments(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *cons
 	    return COMPILE_NG;
 	}
 	lit = rb_fstring(lit);
-	ADD_INSN1(ret, nd_line(node), putobject, lit);
+	ADD_INSN1(ret, node, putobject, lit);
         RB_OBJ_WRITTEN(iseq, Qundef, lit);
 	if (RSTRING_LEN(lit) == 0) first_lit = LAST_ELEMENT(ret);
     }
@@ -3866,7 +3897,7 @@ compile_dstr_fragments(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *cons
 	const NODE *const head = list->nd_head;
 	if (nd_type(head) == NODE_STR) {
 	    lit = rb_fstring(head->nd_lit);
-	    ADD_INSN1(ret, nd_line(head), putobject, lit);
+	    ADD_INSN1(ret, head, putobject, lit);
             RB_OBJ_WRITTEN(iseq, Qundef, lit);
 	    lit = Qnil;
 	}
@@ -3891,13 +3922,12 @@ compile_dstr(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node)
     int cnt;
     if (!node->nd_next) {
         VALUE lit = rb_fstring(node->nd_lit);
-        const int line = (int)nd_line(node);
-        ADD_INSN1(ret, line, putstring, lit);
+        ADD_INSN1(ret, node, putstring, lit);
         RB_OBJ_WRITTEN(iseq, Qundef, lit);
     }
     else {
         CHECK(compile_dstr_fragments(iseq, ret, node, &cnt));
-        ADD_INSN1(ret, nd_line(node), concatstrings, INT2FIX(cnt));
+        ADD_INSN1(ret, node, concatstrings, INT2FIX(cnt));
     }
     return COMPILE_OK;
 }
@@ -3907,7 +3937,7 @@ compile_dregx(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node)
 {
     int cnt;
     CHECK(compile_dstr_fragments(iseq, ret, node, &cnt));
-    ADD_INSN2(ret, nd_line(node), toregexp, INT2FIX(node->nd_cflag), INT2FIX(cnt));
+    ADD_INSN2(ret, node, toregexp, INT2FIX(node->nd_cflag), INT2FIX(cnt));
     return COMPILE_OK;
 }
 
@@ -3921,25 +3951,25 @@ compile_flip_flop(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const nod
 	+ VM_SVAR_FLIPFLOP_START;
     VALUE key = INT2FIX(cnt);
 
-    ADD_INSN2(ret, line, getspecial, key, INT2FIX(0));
-    ADD_INSNL(ret, line, branchif, lend);
+    ADD_INSN2(ret, node, getspecial, key, INT2FIX(0));
+    ADD_INSNL(ret, node, branchif, lend);
 
     /* *flip == 0 */
     CHECK(COMPILE(ret, "flip2 beg", node->nd_beg));
-    ADD_INSNL(ret, line, branchunless, else_label);
-    ADD_INSN1(ret, line, putobject, Qtrue);
-    ADD_INSN1(ret, line, setspecial, key);
+    ADD_INSNL(ret, node, branchunless, else_label);
+    ADD_INSN1(ret, node, putobject, Qtrue);
+    ADD_INSN1(ret, node, setspecial, key);
     if (!again) {
-	ADD_INSNL(ret, line, jump, then_label);
+	ADD_INSNL(ret, node, jump, then_label);
     }
 
     /* *flip == 1 */
     ADD_LABEL(ret, lend);
     CHECK(COMPILE(ret, "flip2 end", node->nd_end));
-    ADD_INSNL(ret, line, branchunless, then_label);
-    ADD_INSN1(ret, line, putobject, Qfalse);
-    ADD_INSN1(ret, line, setspecial, key);
-    ADD_INSNL(ret, line, jump, then_label);
+    ADD_INSNL(ret, node, branchunless, then_label);
+    ADD_INSN1(ret, node, putobject, Qfalse);
+    ADD_INSN1(ret, node, setspecial, key);
+    ADD_INSNL(ret, node, jump, then_label);
 
     return COMPILE_OK;
 }
@@ -3956,7 +3986,7 @@ compile_branch_condition(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *co
 	    CHECK(compile_branch_condition(iseq, ret, cond->nd_1st, label,
 					   else_label));
             if (!label->refcnt) {
-                ADD_INSN(ret, nd_line(cond), putnil);
+                ADD_INSN(ret, cond, putnil);
                 break;
             }
 	    ADD_LABEL(ret, label);
@@ -3969,7 +3999,7 @@ compile_branch_condition(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *co
 	    CHECK(compile_branch_condition(iseq, ret, cond->nd_1st, then_label,
 					   label));
             if (!label->refcnt) {
-                ADD_INSN(ret, nd_line(cond), putnil);
+                ADD_INSN(ret, cond, putnil);
                 break;
             }
 	    ADD_LABEL(ret, label);
@@ -3982,19 +4012,19 @@ compile_branch_condition(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *co
       case NODE_ZLIST:
       case NODE_LAMBDA:
 	/* printf("useless condition eliminate (%s)\n",  ruby_node_name(nd_type(cond))); */
-	ADD_INSNL(ret, nd_line(cond), jump, then_label);
+	ADD_INSNL(ret, cond, jump, then_label);
         return COMPILE_OK;
       case NODE_FALSE:
       case NODE_NIL:
 	/* printf("useless condition eliminate (%s)\n", ruby_node_name(nd_type(cond))); */
-	ADD_INSNL(ret, nd_line(cond), jump, else_label);
+	ADD_INSNL(ret, cond, jump, else_label);
         return COMPILE_OK;
       case NODE_LIST:
       case NODE_ARGSCAT:
       case NODE_DREGX:
       case NODE_DSTR:
 	CHECK(COMPILE_POPPED(ret, "branch condition", cond));
-	ADD_INSNL(ret, nd_line(cond), jump, then_label);
+	ADD_INSNL(ret, cond, jump, then_label);
         return COMPILE_OK;
       case NODE_FLIP2:
 	CHECK(compile_flip_flop(iseq, ret, cond, TRUE, then_label, else_label));
@@ -4010,8 +4040,8 @@ compile_branch_condition(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *co
         break;
     }
 
-    ADD_INSNL(ret, nd_line(cond), branchunless, else_label);
-    ADD_INSNL(ret, nd_line(cond), jump, then_label);
+    ADD_INSNL(ret, cond, branchunless, else_label);
+    ADD_INSNL(ret, cond, jump, then_label);
     return COMPILE_OK;
 }
 
@@ -4159,11 +4189,11 @@ static_literal_value(const NODE *node, rb_iseq_t *iseq)
 static int
 compile_array(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, int popped)
 {
-    int line = (int)nd_line(node);
+    const NODE *line_node = node;
 
     if (nd_type(node) == NODE_ZLIST) {
 	if (!popped) {
-	    ADD_INSN1(ret, line, newarray, INT2FIX(0));
+	    ADD_INSN1(ret, line_node, newarray, INT2FIX(0));
 	}
         return 0;
     }
@@ -4222,8 +4252,8 @@ compile_array(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, int pop
     /* Convert pushed elements to an array, and concatarray if needed */
 #define FLUSH_CHUNK(newarrayinsn)                               \
     if (stack_len) {                                            \
-        ADD_INSN1(ret, line, newarrayinsn, INT2FIX(stack_len)); \
-        if (!first_chunk) ADD_INSN(ret, line, concatarray);     \
+        ADD_INSN1(ret, line_node, newarrayinsn, INT2FIX(stack_len)); \
+        if (!first_chunk) ADD_INSN(ret, line_node, concatarray);     \
         first_chunk = stack_len = 0;                            \
     }
 
@@ -4249,12 +4279,12 @@ compile_array(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, int pop
                 /* Emit optimized code */
                 FLUSH_CHUNK(newarray);
                 if (first_chunk) {
-                    ADD_INSN1(ret, line, duparray, ary);
+                    ADD_INSN1(ret, line_node, duparray, ary);
                     first_chunk = 0;
                 }
                 else {
-                    ADD_INSN1(ret, line, putobject, ary);
-                    ADD_INSN(ret, line, concatarray);
+                    ADD_INSN1(ret, line_node, putobject, ary);
+                    ADD_INSN(ret, line_node, concatarray);
                 }
                 RB_OBJ_WRITTEN(iseq, Qundef, ary);
             }
@@ -4294,13 +4324,13 @@ static_literal_node_pair_p(const NODE *node, const rb_iseq_t *iseq)
 static int
 compile_hash(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, int method_call_keywords, int popped)
 {
-    int line = (int)nd_line(node);
+    const NODE *line_node = node;
 
     node = node->nd_head;
 
     if (!node || nd_type(node) == NODE_ZLIST) {
 	if (!popped) {
-	    ADD_INSN1(ret, line, newhash, INT2FIX(0));
+	    ADD_INSN1(ret, line_node, newhash, INT2FIX(0));
 	}
         return 0;
     }
@@ -4344,13 +4374,13 @@ compile_hash(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, int meth
     if (stack_len) {                                                                    \
         if (first_chunk) {                                                              \
             APPEND_LIST(ret, anchor);                                                   \
-            ADD_INSN1(ret, line, newhash, INT2FIX(stack_len));                          \
+            ADD_INSN1(ret, line_node, newhash, INT2FIX(stack_len));                          \
         }                                                                               \
         else {                                                                          \
-            ADD_INSN1(ret, line, putspecialobject, INT2FIX(VM_SPECIAL_OBJECT_VMCORE));  \
-            ADD_INSN(ret, line, swap);                                                  \
+            ADD_INSN1(ret, line_node, putspecialobject, INT2FIX(VM_SPECIAL_OBJECT_VMCORE));  \
+            ADD_INSN(ret, line_node, swap);                                                  \
             APPEND_LIST(ret, anchor);                                                   \
-            ADD_SEND(ret, line, id_core_hash_merge_ptr, INT2FIX(stack_len + 1));        \
+            ADD_SEND(ret, line_node, id_core_hash_merge_ptr, INT2FIX(stack_len + 1));        \
         }                                                                               \
         INIT_ANCHOR(anchor);                                                            \
         first_chunk = stack_len = 0;                                                    \
@@ -4385,16 +4415,16 @@ compile_hash(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, int meth
                 /* Emit optimized code */
                 FLUSH_CHUNK();
                 if (first_chunk) {
-                    ADD_INSN1(ret, line, duphash, hash);
+                    ADD_INSN1(ret, line_node, duphash, hash);
                     first_chunk = 0;
                 }
                 else {
-                    ADD_INSN1(ret, line, putspecialobject, INT2FIX(VM_SPECIAL_OBJECT_VMCORE));
-                    ADD_INSN(ret, line, swap);
+                    ADD_INSN1(ret, line_node, putspecialobject, INT2FIX(VM_SPECIAL_OBJECT_VMCORE));
+                    ADD_INSN(ret, line_node, swap);
 
-                    ADD_INSN1(ret, line, putobject, hash);
+                    ADD_INSN1(ret, line_node, putobject, hash);
 
-                    ADD_SEND(ret, line, id_core_hash_merge_kwd, INT2FIX(2));
+                    ADD_SEND(ret, line_node, id_core_hash_merge_kwd, INT2FIX(2));
                 }
                 RB_OBJ_WRITTEN(iseq, Qundef, hash);
             }
@@ -4441,7 +4471,7 @@ compile_hash(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, int meth
                         /* **{} appears as the first keyword argument, so it may be modified.
                          * We need to create a fresh hash object.
                          */
-                        ADD_INSN1(ret, line, newhash, INT2FIX(0));
+                        ADD_INSN1(ret, line_node, newhash, INT2FIX(0));
                     }
                     /* Any empty keyword splats that are not the first can be ignored.
                      * since merging an empty hash into the existing hash is the same
@@ -4461,13 +4491,13 @@ compile_hash(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, int meth
                          * call.  In that case, we need to add an empty hash (if first keyword),
                          * or merge the hash to the accumulated hash (if not the first keyword).
                          */
-                        ADD_INSN1(ret, line, putspecialobject, INT2FIX(VM_SPECIAL_OBJECT_VMCORE));
-                        if (first_kw) ADD_INSN1(ret, line, newhash, INT2FIX(0));
-                        else ADD_INSN(ret, line, swap);
+                        ADD_INSN1(ret, line_node, putspecialobject, INT2FIX(VM_SPECIAL_OBJECT_VMCORE));
+                        if (first_kw) ADD_INSN1(ret, line_node, newhash, INT2FIX(0));
+                        else ADD_INSN(ret, line_node, swap);
 
                         NO_CHECK(COMPILE(ret, "keyword splat", kw));
 
-                        ADD_SEND(ret, line, id_core_hash_merge_kwd, INT2FIX(2));
+                        ADD_SEND(ret, line_node, id_core_hash_merge_kwd, INT2FIX(2));
                     }
                 }
 
@@ -4524,20 +4554,20 @@ when_vals(rb_iseq_t *iseq, LINK_ANCHOR *const cond_seq, const NODE *vals,
             rb_hash_aset(literals, lit, (VALUE)(l1) | 1);
 	}
 
-	ADD_INSN(cond_seq, nd_line(val), dup); /* dup target */
+	ADD_INSN(cond_seq, val, dup); /* dup target */
 
 	if (nd_type(val) == NODE_STR) {
 	    debugp_param("nd_lit", val->nd_lit);
 	    lit = rb_fstring(val->nd_lit);
-	    ADD_INSN1(cond_seq, nd_line(val), putobject, lit);
+	    ADD_INSN1(cond_seq, val, putobject, lit);
             RB_OBJ_WRITTEN(iseq, Qundef, lit);
 	}
 	else {
 	    if (!COMPILE(cond_seq, "when cond", val)) return -1;
 	}
 
-	ADD_INSN1(cond_seq, nd_line(vals), checkmatch, INT2FIX(VM_CHECKMATCH_TYPE_CASE));
-	ADD_INSNL(cond_seq, nd_line(val), branchif, l1);
+	ADD_INSN1(cond_seq, vals, checkmatch, INT2FIX(VM_CHECKMATCH_TYPE_CASE));
+	ADD_INSNL(cond_seq, val, branchif, l1);
 	vals = vals->nd_next;
     }
     return only_special_literals;
@@ -4547,7 +4577,7 @@ static int
 when_splat_vals(rb_iseq_t *iseq, LINK_ANCHOR *const cond_seq, const NODE *vals,
                 LABEL *l1, int only_special_literals, VALUE literals)
 {
-    const int line = nd_line(vals);
+    const NODE *line_node = vals;
 
     switch (nd_type(vals)) {
       case NODE_LIST:
@@ -4555,11 +4585,11 @@ when_splat_vals(rb_iseq_t *iseq, LINK_ANCHOR *const cond_seq, const NODE *vals,
             return COMPILE_NG;
         break;
       case NODE_SPLAT:
-        ADD_INSN (cond_seq, line, dup);
+        ADD_INSN (cond_seq, line_node, dup);
         CHECK(COMPILE(cond_seq, "when splat", vals->nd_head));
-        ADD_INSN1(cond_seq, line, splatarray, Qfalse);
-        ADD_INSN1(cond_seq, line, checkmatch, INT2FIX(VM_CHECKMATCH_TYPE_CASE | VM_CHECKMATCH_ARRAY));
-        ADD_INSNL(cond_seq, line, branchif, l1);
+        ADD_INSN1(cond_seq, line_node, splatarray, Qfalse);
+        ADD_INSN1(cond_seq, line_node, checkmatch, INT2FIX(VM_CHECKMATCH_TYPE_CASE | VM_CHECKMATCH_ARRAY));
+        ADD_INSNL(cond_seq, line_node, branchif, l1);
         break;
       case NODE_ARGSCAT:
         CHECK(when_splat_vals(iseq, cond_seq, vals->nd_head, l1, only_special_literals, literals));
@@ -4567,17 +4597,17 @@ when_splat_vals(rb_iseq_t *iseq, LINK_ANCHOR *const cond_seq, const NODE *vals,
         break;
       case NODE_ARGSPUSH:
         CHECK(when_splat_vals(iseq, cond_seq, vals->nd_head, l1, only_special_literals, literals));
-        ADD_INSN (cond_seq, line, dup);
+        ADD_INSN (cond_seq, line_node, dup);
         CHECK(COMPILE(cond_seq, "when argspush body", vals->nd_body));
-        ADD_INSN1(cond_seq, line, checkmatch, INT2FIX(VM_CHECKMATCH_TYPE_CASE));
-        ADD_INSNL(cond_seq, line, branchif, l1);
+        ADD_INSN1(cond_seq, line_node, checkmatch, INT2FIX(VM_CHECKMATCH_TYPE_CASE));
+        ADD_INSNL(cond_seq, line_node, branchif, l1);
         break;
       default:
-        ADD_INSN (cond_seq, line, dup);
+        ADD_INSN (cond_seq, line_node, dup);
         CHECK(COMPILE(cond_seq, "when val", vals));
-        ADD_INSN1(cond_seq, line, splatarray, Qfalse);
-        ADD_INSN1(cond_seq, line, checkmatch, INT2FIX(VM_CHECKMATCH_TYPE_CASE | VM_CHECKMATCH_ARRAY));
-        ADD_INSNL(cond_seq, line, branchif, l1);
+        ADD_INSN1(cond_seq, line_node, splatarray, Qfalse);
+        ADD_INSN1(cond_seq, line_node, checkmatch, INT2FIX(VM_CHECKMATCH_TYPE_CASE | VM_CHECKMATCH_ARRAY));
+        ADD_INSNL(cond_seq, line_node, branchif, l1);
         break;
     }
     return COMPILE_OK;
@@ -4670,7 +4700,7 @@ when_splat_vals(rb_iseq_t *iseq, LINK_ANCHOR *const cond_seq, const NODE *vals,
 struct masgn_attrasgn {
   INSN *before_insn;
   struct masgn_attrasgn *next;
-  int line;
+  const NODE *line_node;
   int argn;
   int num_args;
   int lhs_pos;
@@ -4696,7 +4726,7 @@ compile_massign_lhs(rb_iseq_t *iseq, LINK_ANCHOR *const pre, LINK_ANCHOR *const 
         }
 
 	INSN *iobj;
-	int line = nd_line(node);
+        const NODE *line_node = node;
 
         CHECK(COMPILE_POPPED(pre, "masgn lhs (NODE_ATTRASGN)", node));
 
@@ -4713,10 +4743,10 @@ compile_massign_lhs(rb_iseq_t *iseq, LINK_ANCHOR *const pre, LINK_ANCHOR *const 
         RB_OBJ_WRITTEN(iseq, Qundef, ci);
 
         if (argc == 1) {
-            ADD_INSN(lhs, line, swap);
+            ADD_INSN(lhs, line_node, swap);
         }
         else {
-            ADD_INSN1(lhs, line, topn, INT2FIX(argc));
+            ADD_INSN1(lhs, line_node, topn, INT2FIX(argc));
         }
 
         struct masgn_attrasgn *memo;
@@ -4725,7 +4755,7 @@ compile_massign_lhs(rb_iseq_t *iseq, LINK_ANCHOR *const pre, LINK_ANCHOR *const 
             return 0;
         }
         memo->before_insn = (INSN *)LAST_ELEMENT(lhs);
-        memo->line = line;
+        memo->line_node = line_node;
         memo->argn = state->num_args + 1;
         memo->num_args = argc;
         state->num_args += argc;
@@ -4745,15 +4775,15 @@ compile_massign_lhs(rb_iseq_t *iseq, LINK_ANCHOR *const pre, LINK_ANCHOR *const 
             ci = ci_argc_set(iseq, ci, argc - 1);
             OPERAND_AT(iobj, 0) = (VALUE)ci;
             RB_OBJ_WRITTEN(iseq, Qundef, iobj);
-            INSERT_BEFORE_INSN1(iobj, line, newarray, INT2FIX(1));
-	    INSERT_BEFORE_INSN(iobj, line, concatarray);
+            INSERT_BEFORE_INSN1(iobj, line_node, newarray, INT2FIX(1));
+	    INSERT_BEFORE_INSN(iobj, line_node, concatarray);
 	}
-        ADD_INSN(lhs, line, pop);
+        ADD_INSN(lhs, line_node, pop);
         if (argc != 1) {
-            ADD_INSN(lhs, line, pop);
+            ADD_INSN(lhs, line_node, pop);
         }
         for (int i=0; i < argc; i++) {
-            ADD_INSN(post, line, pop);
+            ADD_INSN(post, line_node, pop);
         }
 	break;
       }
@@ -4853,7 +4883,7 @@ compile_massign_opt(rb_iseq_t *iseq, LINK_ANCHOR *const ret,
 
     if (llen > rlen) {
 	for (i=0; i<llen-rlen; i++) {
-	    ADD_INSN(ret, nd_line(orig_lhsn), putnil);
+	    ADD_INSN(ret, orig_lhsn, putnil);
 	}
     }
 
@@ -4893,8 +4923,7 @@ compile_massign0(rb_iseq_t *iseq, LINK_ANCHOR *const pre, LINK_ANCHOR *const rhs
             int ppos = 0;
             int flag = 0x02 | (NODE_NAMED_REST_P(restn) ? 0x01 : 0x00);
 
-            ADD_INSN2(lhs, nd_line(splatn), expandarray,
-                      INT2FIX(plen), INT2FIX(flag));
+            ADD_INSN2(lhs, splatn, expandarray, INT2FIX(plen), INT2FIX(flag));
 
             if (NODE_NAMED_REST_P(restn)) {
                 CHECK(compile_massign_lhs(iseq, pre, rhs, lhs, post, restn, state, 1 + plen + state->lhs_level));
@@ -4917,11 +4946,10 @@ compile_massign0(rb_iseq_t *iseq, LINK_ANCHOR *const pre, LINK_ANCHOR *const rhs
     }
 
     if (!popped) {
-        ADD_INSN(rhs, nd_line(node), dup);
+        ADD_INSN(rhs, node, dup);
     }
     if (expand) {
-        ADD_INSN2(rhs, nd_line(node), expandarray,
-                  INT2FIX(llen), INT2FIX(lhs_splat));
+        ADD_INSN2(rhs, node, expandarray, INT2FIX(llen), INT2FIX(lhs_splat));
     }
     return COMPILE_OK;
 }
@@ -4951,7 +4979,7 @@ compile_massign(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node,
         while (memo) {
             VALUE topn_arg = INT2FIX((state.num_args - memo->argn) + memo->lhs_pos);
             for(int i = 0; i < memo->num_args; i++) {
-                INSERT_BEFORE_INSN1(memo->before_insn, memo->line, topn, topn_arg);
+                INSERT_BEFORE_INSN1(memo->before_insn, memo->line_node, topn, topn_arg);
             }
             tmp_memo = memo->next;
             free(memo);
@@ -4964,7 +4992,7 @@ compile_massign(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node,
         ADD_SEQ(ret, lhs);
         if (!popped && state.num_args >= 1) {
             /* make sure rhs array is returned before popping */
-            ADD_INSN1(ret, nd_line(node), setn, INT2FIX(state.num_args));
+            ADD_INSN1(ret, node, setn, INT2FIX(state.num_args));
         }
         ADD_SEQ(ret, post);
     }
@@ -4978,21 +5006,21 @@ compile_const_prefix(rb_iseq_t *iseq, const NODE *const node,
     switch (nd_type(node)) {
       case NODE_CONST:
 	debugi("compile_const_prefix - colon", node->nd_vid);
-        ADD_INSN1(body, nd_line(node), putobject, Qtrue);
-        ADD_INSN1(body, nd_line(node), getconstant, ID2SYM(node->nd_vid));
+        ADD_INSN1(body, node, putobject, Qtrue);
+        ADD_INSN1(body, node, getconstant, ID2SYM(node->nd_vid));
 	break;
       case NODE_COLON3:
 	debugi("compile_const_prefix - colon3", node->nd_mid);
-	ADD_INSN(body, nd_line(node), pop);
-	ADD_INSN1(body, nd_line(node), putobject, rb_cObject);
-        ADD_INSN1(body, nd_line(node), putobject, Qtrue);
-        ADD_INSN1(body, nd_line(node), getconstant, ID2SYM(node->nd_mid));
+	ADD_INSN(body, node, pop);
+	ADD_INSN1(body, node, putobject, rb_cObject);
+        ADD_INSN1(body, node, putobject, Qtrue);
+        ADD_INSN1(body, node, getconstant, ID2SYM(node->nd_mid));
 	break;
       case NODE_COLON2:
 	CHECK(compile_const_prefix(iseq, node->nd_head, pref, body));
 	debugi("compile_const_prefix - colon2", node->nd_mid);
-        ADD_INSN1(body, nd_line(node), putobject, Qfalse);
-        ADD_INSN1(body, nd_line(node), getconstant, ID2SYM(node->nd_mid));
+        ADD_INSN1(body, node, putobject, Qfalse);
+        ADD_INSN1(body, node, getconstant, ID2SYM(node->nd_mid));
 	break;
       default:
 	CHECK(COMPILE(pref, "const colon2 prefix", node));
@@ -5006,7 +5034,7 @@ compile_cpath(LINK_ANCHOR *const ret, rb_iseq_t *iseq, const NODE *cpath)
 {
     if (nd_type(cpath) == NODE_COLON3) {
 	/* toplevel class ::Foo */
-	ADD_INSN1(ret, nd_line(cpath), putobject, rb_cObject);
+	ADD_INSN1(ret, cpath, putobject, rb_cObject);
 	return VM_DEFINECLASS_FLAG_SCOPED;
     }
     else if (cpath->nd_head) {
@@ -5016,7 +5044,7 @@ compile_cpath(LINK_ANCHOR *const ret, rb_iseq_t *iseq, const NODE *cpath)
     }
     else {
 	/* class at cbase Foo */
-	ADD_INSN1(ret, nd_line(cpath), putspecialobject,
+	ADD_INSN1(ret, cpath, putspecialobject,
 		  INT2FIX(VM_SPECIAL_OBJECT_CONST_BASE));
 	return 0;
     }
@@ -5037,7 +5065,7 @@ defined_expr(rb_iseq_t *iseq, LINK_ANCHOR *const ret,
 	     const NODE *const node, LABEL **lfinish, VALUE needstr);
 
 static int
-compile_call(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, const enum node_type type, int line, int popped, bool assume_receiver);
+compile_call(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, const enum node_type type, const NODE *const line_node, int popped, bool assume_receiver);
 
 static void
 defined_expr0(rb_iseq_t *iseq, LINK_ANCHOR *const ret,
@@ -5047,6 +5075,7 @@ defined_expr0(rb_iseq_t *iseq, LINK_ANCHOR *const ret,
     enum defined_type expr_type = DEFINED_NOT_DEFINED;
     enum node_type type;
     const int line = nd_line(node);
+    const NODE *line_node = node;
 
     switch (type = nd_type(node)) {
 
@@ -5073,7 +5102,7 @@ defined_expr0(rb_iseq_t *iseq, LINK_ANCHOR *const ret,
 	    if (!lfinish[1]) {
                 lfinish[1] = NEW_LABEL(line);
 	    }
-            ADD_INSNL(ret, line, branchunless, lfinish[1]);
+            ADD_INSNL(ret, line_node, branchunless, lfinish[1]);
 	} while ((vals = vals->nd_next) != NULL);
       }
         /* fall through */
@@ -5094,26 +5123,26 @@ defined_expr0(rb_iseq_t *iseq, LINK_ANCHOR *const ret,
 
 #define PUSH_VAL(type) (needstr == Qfalse ? Qtrue : rb_iseq_defined_string(type))
       case NODE_IVAR:
-        ADD_INSN(ret, line, putnil);
-        ADD_INSN3(ret, line, defined, INT2FIX(DEFINED_IVAR),
+        ADD_INSN(ret, line_node, putnil);
+        ADD_INSN3(ret, line_node, defined, INT2FIX(DEFINED_IVAR),
 		  ID2SYM(node->nd_vid), PUSH_VAL(DEFINED_IVAR));
         return;
 
       case NODE_GVAR:
-        ADD_INSN(ret, line, putnil);
-        ADD_INSN3(ret, line, defined, INT2FIX(DEFINED_GVAR),
+        ADD_INSN(ret, line_node, putnil);
+        ADD_INSN3(ret, line_node, defined, INT2FIX(DEFINED_GVAR),
 		  ID2SYM(node->nd_entry), PUSH_VAL(DEFINED_GVAR));
         return;
 
       case NODE_CVAR:
-        ADD_INSN(ret, line, putnil);
-        ADD_INSN3(ret, line, defined, INT2FIX(DEFINED_CVAR),
+        ADD_INSN(ret, line_node, putnil);
+        ADD_INSN3(ret, line_node, defined, INT2FIX(DEFINED_CVAR),
 		  ID2SYM(node->nd_vid), PUSH_VAL(DEFINED_CVAR));
         return;
 
       case NODE_CONST:
-        ADD_INSN(ret, line, putnil);
-        ADD_INSN3(ret, line, defined, INT2FIX(DEFINED_CONST),
+        ADD_INSN(ret, line_node, putnil);
+        ADD_INSN3(ret, line_node, defined, INT2FIX(DEFINED_CONST),
 		  ID2SYM(node->nd_vid), PUSH_VAL(DEFINED_CONST));
         return;
       case NODE_COLON2:
@@ -5121,21 +5150,21 @@ defined_expr0(rb_iseq_t *iseq, LINK_ANCHOR *const ret,
             lfinish[1] = NEW_LABEL(line);
 	}
         defined_expr0(iseq, ret, node->nd_head, lfinish, Qfalse, false);
-        ADD_INSNL(ret, line, branchunless, lfinish[1]);
+        ADD_INSNL(ret, line_node, branchunless, lfinish[1]);
         NO_CHECK(COMPILE(ret, "defined/colon2#nd_head", node->nd_head));
 
         if (rb_is_const_id(node->nd_mid)) {
-            ADD_INSN3(ret, line, defined, INT2FIX(DEFINED_CONST_FROM),
+            ADD_INSN3(ret, line_node, defined, INT2FIX(DEFINED_CONST_FROM),
                     ID2SYM(node->nd_mid), PUSH_VAL(DEFINED_CONST));
         }
         else {
-            ADD_INSN3(ret, line, defined, INT2FIX(DEFINED_METHOD),
+            ADD_INSN3(ret, line_node, defined, INT2FIX(DEFINED_METHOD),
                     ID2SYM(node->nd_mid), PUSH_VAL(DEFINED_METHOD));
         }
         return;
       case NODE_COLON3:
-        ADD_INSN1(ret, line, putobject, rb_cObject);
-        ADD_INSN3(ret, line, defined,
+        ADD_INSN1(ret, line_node, putobject, rb_cObject);
+        ADD_INSN3(ret, line_node, defined,
 		  INT2FIX(DEFINED_CONST_FROM), ID2SYM(node->nd_mid), PUSH_VAL(DEFINED_CONST));
         return;
 
@@ -5159,7 +5188,7 @@ defined_expr0(rb_iseq_t *iseq, LINK_ANCHOR *const ret,
         }
 	if (node->nd_args) {
             defined_expr0(iseq, ret, node->nd_args, lfinish, Qfalse, false);
-            ADD_INSNL(ret, line, branchunless, lfinish[1]);
+            ADD_INSNL(ret, line_node, branchunless, lfinish[1]);
 	}
 	if (explicit_receiver) {
             defined_expr0(iseq, ret, node->nd_recv, lfinish, Qfalse, true);
@@ -5169,49 +5198,49 @@ defined_expr0(rb_iseq_t *iseq, LINK_ANCHOR *const ret,
               case NODE_VCALL:
               case NODE_FCALL:
               case NODE_ATTRASGN:
-                ADD_INSNL(ret, line, branchunless, lfinish[2]);
-                compile_call(iseq, ret, node->nd_recv, nd_type(node->nd_recv), line, 0, true);
+                ADD_INSNL(ret, line_node, branchunless, lfinish[2]);
+                compile_call(iseq, ret, node->nd_recv, nd_type(node->nd_recv), line_node, 0, true);
                 break;
               default:
-                ADD_INSNL(ret, line, branchunless, lfinish[1]);
+                ADD_INSNL(ret, line_node, branchunless, lfinish[1]);
                 NO_CHECK(COMPILE(ret, "defined/recv", node->nd_recv));
                 break;
             }
             if (keep_result) {
-                ADD_INSN(ret, line, dup);
+                ADD_INSN(ret, line_node, dup);
             }
-            ADD_INSN3(ret, line, defined, INT2FIX(DEFINED_METHOD),
+            ADD_INSN3(ret, line_node, defined, INT2FIX(DEFINED_METHOD),
 		      ID2SYM(node->nd_mid), PUSH_VAL(DEFINED_METHOD));
 	}
 	else {
-            ADD_INSN(ret, line, putself);
+            ADD_INSN(ret, line_node, putself);
             if (keep_result) {
-                ADD_INSN(ret, line, dup);
+                ADD_INSN(ret, line_node, dup);
             }
-            ADD_INSN3(ret, line, defined, INT2FIX(DEFINED_FUNC),
+            ADD_INSN3(ret, line_node, defined, INT2FIX(DEFINED_FUNC),
 		      ID2SYM(node->nd_mid), PUSH_VAL(DEFINED_METHOD));
 	}
         return;
       }
 
       case NODE_YIELD:
-        ADD_INSN(ret, line, putnil);
-        ADD_INSN3(ret, line, defined, INT2FIX(DEFINED_YIELD), 0,
+        ADD_INSN(ret, line_node, putnil);
+        ADD_INSN3(ret, line_node, defined, INT2FIX(DEFINED_YIELD), 0,
 		  PUSH_VAL(DEFINED_YIELD));
         return;
 
       case NODE_BACK_REF:
       case NODE_NTH_REF:
-        ADD_INSN(ret, line, putnil);
-        ADD_INSN3(ret, line, defined, INT2FIX(DEFINED_REF),
+        ADD_INSN(ret, line_node, putnil);
+        ADD_INSN3(ret, line_node, defined, INT2FIX(DEFINED_REF),
 		  INT2FIX((node->nd_nth << 1) | (type == NODE_BACK_REF)),
 		  PUSH_VAL(DEFINED_GVAR));
         return;
 
       case NODE_SUPER:
       case NODE_ZSUPER:
-        ADD_INSN(ret, line, putnil);
-        ADD_INSN3(ret, line, defined, INT2FIX(DEFINED_ZSUPER), 0,
+        ADD_INSN(ret, line_node, putnil);
+        ADD_INSN3(ret, line_node, defined, INT2FIX(DEFINED_ZSUPER), 0,
 		  PUSH_VAL(DEFINED_ZSUPER));
         return;
 
@@ -5236,17 +5265,18 @@ defined_expr0(rb_iseq_t *iseq, LINK_ANCHOR *const ret,
 
     if (needstr != Qfalse) {
         VALUE str = rb_iseq_defined_string(expr_type);
-        ADD_INSN1(ret, line, putobject, str);
+        ADD_INSN1(ret, line_node, putobject, str);
     }
     else {
-        ADD_INSN1(ret, line, putobject, Qtrue);
+        ADD_INSN1(ret, line_node, putobject, Qtrue);
     }
 }
 
 static void
 build_defined_rescue_iseq(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const void *unused)
 {
-    ADD_INSN(ret, 0, putnil);
+    NODE dummy_line_node = generate_dummy_line_node(0, -1);
+    ADD_INSN(ret, &dummy_line_node, putnil);
     iseq_set_exception_local_table(iseq);
 }
 
@@ -5279,9 +5309,10 @@ static int
 compile_defined_expr(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, VALUE needstr)
 {
     const int line = nd_line(node);
+    const NODE *line_node = node;
     if (!node->nd_head) {
 	VALUE str = rb_iseq_defined_string(DEFINED_NIL);
-	ADD_INSN1(ret, line, putobject, str);
+	ADD_INSN1(ret, line_node, putobject, str);
     }
     else {
         LABEL *lfinish[3];
@@ -5291,12 +5322,12 @@ compile_defined_expr(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const 
         lfinish[2] = 0;
 	defined_expr(iseq, ret, node->nd_head, lfinish, needstr);
 	if (lfinish[1]) {
-	    ELEM_INSERT_NEXT(last, &new_insn_body(iseq, line, BIN(putnil), 0)->link);
-	    ADD_INSN(ret, line, swap);
+	    ELEM_INSERT_NEXT(last, &new_insn_body(iseq, line_node, BIN(putnil), 0)->link);
+	    ADD_INSN(ret, line_node, swap);
             if (lfinish[2]) {
                 ADD_LABEL(ret, lfinish[2]);
             }
-	    ADD_INSN(ret, line, pop);
+	    ADD_INSN(ret, line_node, pop);
 	    ADD_LABEL(ret, lfinish[1]);
 	}
 	ADD_LABEL(ret, lfinish[0]);
@@ -5427,7 +5458,7 @@ setup_args_core(rb_iseq_t *iseq, LINK_ANCHOR *const args, const NODE *argn,
         switch (nd_type(argn)) {
           case NODE_SPLAT: {
             NO_CHECK(COMPILE(args, "args (splat)", argn->nd_head));
-            ADD_INSN1(args, nd_line(argn), splatarray, dup_rest ? Qtrue : Qfalse);
+            ADD_INSN1(args, argn, splatarray, dup_rest ? Qtrue : Qfalse);
             if (flag) *flag |= VM_CALL_ARGS_SPLAT;
             return INT2FIX(1);
           }
@@ -5438,7 +5469,7 @@ setup_args_core(rb_iseq_t *iseq, LINK_ANCHOR *const args, const NODE *argn,
             if (nd_type(argn->nd_body) == NODE_LIST) {
                 /* This branch is needed to avoid "newarraykwsplat" [Bug #16442] */
                 int rest_len = compile_args(iseq, args, argn->nd_body, NULL, NULL);
-                ADD_INSN1(args, nd_line(argn), newarray, INT2FIX(rest_len));
+                ADD_INSN1(args, argn, newarray, INT2FIX(rest_len));
             }
             else {
                 NO_CHECK(COMPILE(args, "args (cat: splat)", argn->nd_body));
@@ -5452,18 +5483,18 @@ setup_args_core(rb_iseq_t *iseq, LINK_ANCHOR *const args, const NODE *argn,
             }
             if (nd_type(argn) == NODE_ARGSCAT) {
                 if (next_is_list) {
-                    ADD_INSN1(args, nd_line(argn), splatarray, Qtrue);
+                    ADD_INSN1(args, argn, splatarray, Qtrue);
                     return INT2FIX(FIX2INT(argc) + 1);
                 }
                 else {
-                    ADD_INSN1(args, nd_line(argn), splatarray, Qfalse);
-                    ADD_INSN(args, nd_line(argn), concatarray);
+                    ADD_INSN1(args, argn, splatarray, Qfalse);
+                    ADD_INSN(args, argn, concatarray);
                     return argc;
                 }
             }
             else {
-                ADD_INSN1(args, nd_line(argn), newarray, INT2FIX(1));
-                ADD_INSN(args, nd_line(argn), concatarray);
+                ADD_INSN1(args, argn, newarray, INT2FIX(1));
+                ADD_INSN(args, argn, concatarray);
                 return argc;
             }
           }
@@ -5519,8 +5550,8 @@ build_postexe_iseq(rb_iseq_t *iseq, LINK_ANCHOR *ret, const void *ptr)
     VALUE argc = INT2FIX(0);
     const rb_iseq_t *block = NEW_CHILD_ISEQ(body, make_name_for_block(iseq->body->parent_iseq), ISEQ_TYPE_BLOCK, line);
 
-    ADD_INSN1(ret, line, putspecialobject, INT2FIX(VM_SPECIAL_OBJECT_VMCORE));
-    ADD_CALL_WITH_BLOCK(ret, line, id_core_set_postexe, argc, block);
+    ADD_INSN1(ret, body, putspecialobject, INT2FIX(VM_SPECIAL_OBJECT_VMCORE));
+    ADD_CALL_WITH_BLOCK(ret, body, id_core_set_postexe, argc, block);
     RB_OBJ_WRITTEN(iseq, Qundef, (VALUE)block);
     iseq_set_local_table(iseq, 0);
 }
@@ -5531,25 +5562,26 @@ compile_named_capture_assign(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE
     const NODE *vars;
     LINK_ELEMENT *last;
     int line = nd_line(node);
+    const NODE *line_node = node;
     LABEL *fail_label = NEW_LABEL(line), *end_label = NEW_LABEL(line);
 
 #if !(defined(NAMED_CAPTURE_BY_SVAR) && NAMED_CAPTURE_BY_SVAR-0)
-    ADD_INSN1(ret, line, getglobal, ID2SYM(idBACKREF));
+    ADD_INSN1(ret, line_node, getglobal, ID2SYM(idBACKREF));
 #else
-    ADD_INSN2(ret, line, getspecial, INT2FIX(1) /* '~' */, INT2FIX(0));
+    ADD_INSN2(ret, line_node, getspecial, INT2FIX(1) /* '~' */, INT2FIX(0));
 #endif
-    ADD_INSN(ret, line, dup);
-    ADD_INSNL(ret, line, branchunless, fail_label);
+    ADD_INSN(ret, line_node, dup);
+    ADD_INSNL(ret, line_node, branchunless, fail_label);
 
     for (vars = node; vars; vars = vars->nd_next) {
 	INSN *cap;
 	if (vars->nd_next) {
-	    ADD_INSN(ret, line, dup);
+	    ADD_INSN(ret, line_node, dup);
 	}
 	last = ret->last;
         NO_CHECK(COMPILE_POPPED(ret, "capture", vars->nd_head));
 	last = last->next; /* putobject :var */
-	cap = new_insn_send(iseq, line, idAREF, INT2FIX(1),
+	cap = new_insn_send(iseq, line_node, idAREF, INT2FIX(1),
 			    NULL, INT2FIX(0), NULL);
 	ELEM_INSERT_PREV(last->next, (LINK_ELEMENT *)cap);
 #if !defined(NAMED_CAPTURE_SINGLE_OPT) || NAMED_CAPTURE_SINGLE_OPT-0
@@ -5558,11 +5590,11 @@ compile_named_capture_assign(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE
 	    DECL_ANCHOR(nom);
 
 	    INIT_ANCHOR(nom);
-	    ADD_INSNL(nom, line, jump, end_label);
+	    ADD_INSNL(nom, line_node, jump, end_label);
 	    ADD_LABEL(nom, fail_label);
 # if 0				/* $~ must be MatchData or nil */
-	    ADD_INSN(nom, line, pop);
-	    ADD_INSN(nom, line, putnil);
+	    ADD_INSN(nom, line_node, pop);
+	    ADD_INSN(nom, line_node, putnil);
 # endif
 	    ADD_LABEL(nom, end_label);
 	    (nom->last->next = cap->link.next)->prev = nom->last;
@@ -5571,9 +5603,9 @@ compile_named_capture_assign(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE
 	}
 #endif
     }
-    ADD_INSNL(ret, line, jump, end_label);
+    ADD_INSNL(ret, line_node, jump, end_label);
     ADD_LABEL(ret, fail_label);
-    ADD_INSN(ret, line, pop);
+    ADD_INSN(ret, line_node, pop);
     for (vars = node; vars; vars = vars->nd_next) {
 	last = ret->last;
         NO_CHECK(COMPILE_POPPED(ret, "capture", vars->nd_head));
@@ -5606,6 +5638,7 @@ compile_if(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, int 
     const NODE *const node_else = type == NODE_IF ? node->nd_else : node->nd_body;
 
     const int line = nd_line(node);
+    const NODE *line_node = node;
     DECL_ANCHOR(cond_seq);
     DECL_ANCHOR(then_seq);
     DECL_ANCHOR(else_seq);
@@ -5664,9 +5697,9 @@ compile_if(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, int 
 		type == NODE_IF ? "then" : "else",
 		branches);
 	    end_label = NEW_LABEL(line);
-	    ADD_INSNL(then_seq, line, jump, end_label);
+	    ADD_INSNL(then_seq, line_node, jump, end_label);
             if (!popped) {
-                ADD_INSN(then_seq, line, pop);
+                ADD_INSN(then_seq, line_node, pop);
             }
 	}
 	ADD_SEQ(ret, then_seq);
@@ -5706,6 +5739,7 @@ compile_case(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const orig_nod
     VALUE literals = rb_hash_new();
     int line;
     enum node_type type;
+    const NODE *line_node;
     VALUE branches = Qfalse;
     int branch_id = 0;
 
@@ -5723,6 +5757,7 @@ compile_case(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const orig_nod
     EXPECT_NODE("NODE_CASE", node, NODE_WHEN, COMPILE_NG);
     type = nd_type(node);
     line = nd_line(node);
+    line_node = node;
 
     endlabel = NEW_LABEL(line);
     elselabel = NEW_LABEL(line);
@@ -5734,7 +5769,7 @@ compile_case(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const orig_nod
 
 	l1 = NEW_LABEL(line);
 	ADD_LABEL(body_seq, l1);
-	ADD_INSN(body_seq, line, pop);
+	ADD_INSN(body_seq, line_node, pop);
 	add_trace_branch_coverage(
                 iseq,
 		body_seq,
@@ -5743,7 +5778,7 @@ compile_case(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const orig_nod
 		"when",
 		branches);
 	CHECK(COMPILE_(body_seq, "when body", node->nd_body, popped));
-	ADD_INSNL(body_seq, line, jump, endlabel);
+	ADD_INSNL(body_seq, line_node, jump, endlabel);
 
 	vals = node->nd_head;
 	if (vals) {
@@ -5772,29 +5807,30 @@ compile_case(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const orig_nod
 	}
 	type = nd_type(node);
 	line = nd_line(node);
+        line_node = node;
     }
     /* else */
     if (node) {
 	ADD_LABEL(cond_seq, elselabel);
-	ADD_INSN(cond_seq, line, pop);
+	ADD_INSN(cond_seq, line_node, pop);
 	add_trace_branch_coverage(iseq, cond_seq, node, branch_id, "else", branches);
 	CHECK(COMPILE_(cond_seq, "else", node, popped));
-	ADD_INSNL(cond_seq, line, jump, endlabel);
+	ADD_INSNL(cond_seq, line_node, jump, endlabel);
     }
     else {
 	debugs("== else (implicit)\n");
 	ADD_LABEL(cond_seq, elselabel);
-	ADD_INSN(cond_seq, nd_line(orig_node), pop);
+	ADD_INSN(cond_seq, orig_node, pop);
 	add_trace_branch_coverage(iseq, cond_seq, orig_node, branch_id, "else", branches);
 	if (!popped) {
-	    ADD_INSN(cond_seq, nd_line(orig_node), putnil);
+	    ADD_INSN(cond_seq, orig_node, putnil);
 	}
-	ADD_INSNL(cond_seq, nd_line(orig_node), jump, endlabel);
+	ADD_INSNL(cond_seq, orig_node, jump, endlabel);
     }
 
     if (only_special_literals && ISEQ_COMPILE_DATA(iseq)->option->specialized_instruction) {
-	ADD_INSN(ret, nd_line(orig_node), dup);
-	ADD_INSN2(ret, nd_line(orig_node), opt_case_dispatch, literals, elselabel);
+	ADD_INSN(ret, orig_node, dup);
+	ADD_INSN2(ret, orig_node, opt_case_dispatch, literals, elselabel);
         RB_OBJ_WRITTEN(iseq, Qundef, literals);
 	LABEL_REF(elselabel);
     }
@@ -5833,7 +5869,7 @@ compile_case2(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const orig_no
 		"when",
 		branches);
 	CHECK(COMPILE_(body_seq, "when", node->nd_body, popped));
-	ADD_INSNL(body_seq, line, jump, endlabel);
+	ADD_INSNL(body_seq, node, jump, endlabel);
 
 	vals = node->nd_head;
 	if (!vals) {
@@ -5854,10 +5890,10 @@ compile_case2(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const orig_no
 	  case NODE_SPLAT:
 	  case NODE_ARGSCAT:
 	  case NODE_ARGSPUSH:
-	    ADD_INSN(ret, nd_line(vals), putnil);
+	    ADD_INSN(ret, vals, putnil);
 	    CHECK(COMPILE(ret, "when2/cond splat", vals));
-	    ADD_INSN1(ret, nd_line(vals), checkmatch, INT2FIX(VM_CHECKMATCH_TYPE_WHEN | VM_CHECKMATCH_ARRAY));
-	    ADD_INSNL(ret, nd_line(vals), branchif, l1);
+	    ADD_INSN1(ret, vals, checkmatch, INT2FIX(VM_CHECKMATCH_TYPE_WHEN | VM_CHECKMATCH_ARRAY));
+	    ADD_INSNL(ret, vals, branchif, l1);
 	    break;
 	  default:
 	    UNKNOWN_NODE("NODE_WHEN", vals, COMPILE_NG);
@@ -5873,7 +5909,7 @@ compile_case2(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const orig_no
 	"else",
 	branches);
     CHECK(COMPILE_(ret, "else", node, popped));
-    ADD_INSNL(ret, nd_line(orig_node), jump, endlabel);
+    ADD_INSNL(ret, orig_node, jump, endlabel);
 
     ADD_SEQ(ret, body_seq);
     ADD_LABEL(ret, endlabel);
@@ -5888,6 +5924,7 @@ static int
 iseq_compile_pattern_each(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, LABEL *matched, LABEL *unmatched, int in_alt_pattern, int deconstructed_pos)
 {
     const int line = nd_line(node);
+    const NODE *line_node = node;
 
     switch (nd_type(node)) {
       case NODE_ARYPTN: {
@@ -5960,97 +5997,97 @@ iseq_compile_pattern_each(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *c
         deconstructed = NEW_LABEL(line);
 
         if (use_rest_num) {
-            ADD_INSN1(ret, line, putobject, INT2FIX(0)); /* allocate stack for rest_num */
-            ADD_INSN(ret, line, swap);
+            ADD_INSN1(ret, line_node, putobject, INT2FIX(0)); /* allocate stack for rest_num */
+            ADD_INSN(ret, line_node, swap);
             if (deconstructed_pos) {
                 deconstructed_pos++;
             }
         }
 
         if (node->nd_pconst) {
-            ADD_INSN(ret, line, dup);
+            ADD_INSN(ret, line_node, dup);
             CHECK(COMPILE(ret, "constant", node->nd_pconst));
-            ADD_INSN1(ret, line, checkmatch, INT2FIX(VM_CHECKMATCH_TYPE_CASE));
-            ADD_INSNL(ret, line, branchunless, match_failed);
+            ADD_INSN1(ret, line_node, checkmatch, INT2FIX(VM_CHECKMATCH_TYPE_CASE));
+            ADD_INSNL(ret, line_node, branchunless, match_failed);
         }
 
         CHECK(iseq_compile_array_deconstruct(iseq, ret, node, deconstruct, deconstructed, match_failed, type_error, deconstructed_pos));
 
-        ADD_INSN(ret, line, dup);
-        ADD_SEND(ret, line, idLength, INT2FIX(0));
-        ADD_INSN1(ret, line, putobject, INT2FIX(min_argc));
-        ADD_SEND(ret, line, apinfo->rest_arg ? idGE : idEq, INT2FIX(1));
-        ADD_INSNL(ret, line, branchunless, match_failed);
+        ADD_INSN(ret, line_node, dup);
+        ADD_SEND(ret, line_node, idLength, INT2FIX(0));
+        ADD_INSN1(ret, line_node, putobject, INT2FIX(min_argc));
+        ADD_SEND(ret, line_node, apinfo->rest_arg ? idGE : idEq, INT2FIX(1));
+        ADD_INSNL(ret, line_node, branchunless, match_failed);
 
         for (i = 0; i < pre_args_num; i++) {
-            ADD_INSN(ret, line, dup);
-            ADD_INSN1(ret, line, putobject, INT2FIX(i));
-            ADD_SEND(ret, line, idAREF, INT2FIX(1));
+            ADD_INSN(ret, line_node, dup);
+            ADD_INSN1(ret, line_node, putobject, INT2FIX(i));
+            ADD_SEND(ret, line_node, idAREF, INT2FIX(1));
             CHECK(iseq_compile_pattern_match(iseq, ret, args->nd_head, match_failed, in_alt_pattern, FALSE));
             args = args->nd_next;
         }
 
         if (apinfo->rest_arg) {
             if (NODE_NAMED_REST_P(apinfo->rest_arg)) {
-                ADD_INSN(ret, line, dup);
-                ADD_INSN1(ret, line, putobject, INT2FIX(pre_args_num));
-                ADD_INSN1(ret, line, topn, INT2FIX(1));
-                ADD_SEND(ret, line, idLength, INT2FIX(0));
-                ADD_INSN1(ret, line, putobject, INT2FIX(min_argc));
-                ADD_SEND(ret, line, idMINUS, INT2FIX(1));
-                ADD_INSN1(ret, line, setn, INT2FIX(4));
-                ADD_SEND(ret, line, idAREF, INT2FIX(2));
+                ADD_INSN(ret, line_node, dup);
+                ADD_INSN1(ret, line_node, putobject, INT2FIX(pre_args_num));
+                ADD_INSN1(ret, line_node, topn, INT2FIX(1));
+                ADD_SEND(ret, line_node, idLength, INT2FIX(0));
+                ADD_INSN1(ret, line_node, putobject, INT2FIX(min_argc));
+                ADD_SEND(ret, line_node, idMINUS, INT2FIX(1));
+                ADD_INSN1(ret, line_node, setn, INT2FIX(4));
+                ADD_SEND(ret, line_node, idAREF, INT2FIX(2));
 
                 CHECK(iseq_compile_pattern_match(iseq, ret, apinfo->rest_arg, match_failed, in_alt_pattern, FALSE));
             }
             else {
                 if (post_args_num > 0) {
-                    ADD_INSN(ret, line, dup);
-                    ADD_SEND(ret, line, idLength, INT2FIX(0));
-                    ADD_INSN1(ret, line, putobject, INT2FIX(min_argc));
-                    ADD_SEND(ret, line, idMINUS, INT2FIX(1));
-                    ADD_INSN1(ret, line, setn, INT2FIX(2));
-                    ADD_INSN(ret, line, pop);
+                    ADD_INSN(ret, line_node, dup);
+                    ADD_SEND(ret, line_node, idLength, INT2FIX(0));
+                    ADD_INSN1(ret, line_node, putobject, INT2FIX(min_argc));
+                    ADD_SEND(ret, line_node, idMINUS, INT2FIX(1));
+                    ADD_INSN1(ret, line_node, setn, INT2FIX(2));
+                    ADD_INSN(ret, line_node, pop);
                 }
             }
         }
 
         args = apinfo->post_args;
         for (i = 0; i < post_args_num; i++) {
-            ADD_INSN(ret, line, dup);
+            ADD_INSN(ret, line_node, dup);
 
-            ADD_INSN1(ret, line, putobject, INT2FIX(pre_args_num + i));
-            ADD_INSN1(ret, line, topn, INT2FIX(3));
-            ADD_SEND(ret, line, idPLUS, INT2FIX(1));
+            ADD_INSN1(ret, line_node, putobject, INT2FIX(pre_args_num + i));
+            ADD_INSN1(ret, line_node, topn, INT2FIX(3));
+            ADD_SEND(ret, line_node, idPLUS, INT2FIX(1));
 
-            ADD_SEND(ret, line, idAREF, INT2FIX(1));
+            ADD_SEND(ret, line_node, idAREF, INT2FIX(1));
             CHECK(iseq_compile_pattern_match(iseq, ret, args->nd_head, match_failed, in_alt_pattern, FALSE));
             args = args->nd_next;
         }
 
-        ADD_INSN(ret, line, pop);
+        ADD_INSN(ret, line_node, pop);
         if (use_rest_num) {
-            ADD_INSN(ret, line, pop);
+            ADD_INSN(ret, line_node, pop);
         }
-        ADD_INSNL(ret, line, jump, matched);
-        ADD_INSN(ret, line, putnil);
+        ADD_INSNL(ret, line_node, jump, matched);
+        ADD_INSN(ret, line_node, putnil);
         if (use_rest_num) {
-            ADD_INSN(ret, line, putnil);
+            ADD_INSN(ret, line_node, putnil);
         }
 
         ADD_LABEL(ret, type_error);
-        ADD_INSN1(ret, line, putspecialobject, INT2FIX(VM_SPECIAL_OBJECT_VMCORE));
-        ADD_INSN1(ret, line, putobject, rb_eTypeError);
-        ADD_INSN1(ret, line, putobject, rb_fstring_lit("deconstruct must return Array"));
-        ADD_SEND(ret, line, id_core_raise, INT2FIX(2));
-        ADD_INSN(ret, line, pop);
+        ADD_INSN1(ret, line_node, putspecialobject, INT2FIX(VM_SPECIAL_OBJECT_VMCORE));
+        ADD_INSN1(ret, line_node, putobject, rb_eTypeError);
+        ADD_INSN1(ret, line_node, putobject, rb_fstring_lit("deconstruct must return Array"));
+        ADD_SEND(ret, line_node, id_core_raise, INT2FIX(2));
+        ADD_INSN(ret, line_node, pop);
 
         ADD_LABEL(ret, match_failed);
-        ADD_INSN(ret, line, pop);
+        ADD_INSN(ret, line_node, pop);
         if (use_rest_num) {
-            ADD_INSN(ret, line, pop);
+            ADD_INSN(ret, line_node, pop);
         }
-        ADD_INSNL(ret, line, jump, unmatched);
+        ADD_INSNL(ret, line_node, jump, unmatched);
 
         break;
       }
@@ -6114,19 +6151,19 @@ iseq_compile_pattern_each(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *c
         deconstructed = NEW_LABEL(line);
 
         if (node->nd_pconst) {
-            ADD_INSN(ret, line, dup);
+            ADD_INSN(ret, line_node, dup);
             CHECK(COMPILE(ret, "constant", node->nd_pconst));
-            ADD_INSN1(ret, line, checkmatch, INT2FIX(VM_CHECKMATCH_TYPE_CASE));
-            ADD_INSNL(ret, line, branchunless, match_failed);
+            ADD_INSN1(ret, line_node, checkmatch, INT2FIX(VM_CHECKMATCH_TYPE_CASE));
+            ADD_INSNL(ret, line_node, branchunless, match_failed);
         }
 
         CHECK(iseq_compile_array_deconstruct(iseq, ret, node, deconstruct, deconstructed, match_failed, type_error, deconstructed_pos));
 
-        ADD_INSN(ret, line, dup);
-        ADD_SEND(ret, line, idLength, INT2FIX(0));
-        ADD_INSN1(ret, line, putobject, INT2FIX(args_num));
-        ADD_SEND(ret, line, idGE, INT2FIX(1));
-        ADD_INSNL(ret, line, branchunless, match_failed);
+        ADD_INSN(ret, line_node, dup);
+        ADD_SEND(ret, line_node, idLength, INT2FIX(0));
+        ADD_INSN1(ret, line_node, putobject, INT2FIX(args_num));
+        ADD_SEND(ret, line_node, idGE, INT2FIX(1));
+        ADD_INSNL(ret, line_node, branchunless, match_failed);
 
         {
             LABEL *while_begin = NEW_LABEL(nd_line(node));
@@ -6135,85 +6172,85 @@ iseq_compile_pattern_each(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *c
             LABEL *find_failed = NEW_LABEL(nd_line(node));
             int j;
 
-            ADD_INSN(ret, line, dup); /* allocate stack for len */
-            ADD_SEND(ret, line, idLength, INT2FIX(0));
+            ADD_INSN(ret, line_node, dup); /* allocate stack for len */
+            ADD_SEND(ret, line_node, idLength, INT2FIX(0));
 
-            ADD_INSN(ret, line, dup); /* allocate stack for limit */
-            ADD_INSN1(ret, line, putobject, INT2FIX(args_num));
-            ADD_SEND(ret, line, idMINUS, INT2FIX(1));
+            ADD_INSN(ret, line_node, dup); /* allocate stack for limit */
+            ADD_INSN1(ret, line_node, putobject, INT2FIX(args_num));
+            ADD_SEND(ret, line_node, idMINUS, INT2FIX(1));
 
-            ADD_INSN1(ret, line, putobject, INT2FIX(0)); /* allocate stack for i */
+            ADD_INSN1(ret, line_node, putobject, INT2FIX(0)); /* allocate stack for i */
 
             ADD_LABEL(ret, while_begin);
 
-            ADD_INSN(ret, line, dup);
-            ADD_INSN1(ret, line, topn, INT2FIX(2));
-            ADD_SEND(ret, line, idLE, INT2FIX(1));
-            ADD_INSNL(ret, line, branchunless, find_failed);
+            ADD_INSN(ret, line_node, dup);
+            ADD_INSN1(ret, line_node, topn, INT2FIX(2));
+            ADD_SEND(ret, line_node, idLE, INT2FIX(1));
+            ADD_INSNL(ret, line_node, branchunless, find_failed);
 
             for (j = 0; j < args_num; j++) {
-                ADD_INSN1(ret, line, topn, INT2FIX(3));
-                ADD_INSN1(ret, line, topn, INT2FIX(1));
+                ADD_INSN1(ret, line_node, topn, INT2FIX(3));
+                ADD_INSN1(ret, line_node, topn, INT2FIX(1));
                 if (j != 0) {
-                    ADD_INSN1(ret, line, putobject, INT2FIX(j));
-                    ADD_SEND(ret, line, idPLUS, INT2FIX(1));
+                    ADD_INSN1(ret, line_node, putobject, INT2FIX(j));
+                    ADD_SEND(ret, line_node, idPLUS, INT2FIX(1));
                 }
-                ADD_SEND(ret, line, idAREF, INT2FIX(1));
+                ADD_SEND(ret, line_node, idAREF, INT2FIX(1));
 
                 CHECK(iseq_compile_pattern_match(iseq, ret, args->nd_head, next_loop, in_alt_pattern, FALSE));
                 args = args->nd_next;
             }
 
             if (NODE_NAMED_REST_P(fpinfo->pre_rest_arg)) {
-                ADD_INSN1(ret, line, topn, INT2FIX(3));
-                ADD_INSN1(ret, line, putobject, INT2FIX(0));
-                ADD_INSN1(ret, line, topn, INT2FIX(2));
-                ADD_SEND(ret, line, idAREF, INT2FIX(2));
+                ADD_INSN1(ret, line_node, topn, INT2FIX(3));
+                ADD_INSN1(ret, line_node, putobject, INT2FIX(0));
+                ADD_INSN1(ret, line_node, topn, INT2FIX(2));
+                ADD_SEND(ret, line_node, idAREF, INT2FIX(2));
                 CHECK(iseq_compile_pattern_match(iseq, ret, fpinfo->pre_rest_arg, find_failed, in_alt_pattern, FALSE));
             }
             if (NODE_NAMED_REST_P(fpinfo->post_rest_arg)) {
-                ADD_INSN1(ret, line, topn, INT2FIX(3));
-                ADD_INSN1(ret, line, topn, INT2FIX(1));
-                ADD_INSN1(ret, line, putobject, INT2FIX(args_num));
-                ADD_SEND(ret, line, idPLUS, INT2FIX(1));
-                ADD_INSN1(ret, line, topn, INT2FIX(3));
-                ADD_SEND(ret, line, idAREF, INT2FIX(2));
+                ADD_INSN1(ret, line_node, topn, INT2FIX(3));
+                ADD_INSN1(ret, line_node, topn, INT2FIX(1));
+                ADD_INSN1(ret, line_node, putobject, INT2FIX(args_num));
+                ADD_SEND(ret, line_node, idPLUS, INT2FIX(1));
+                ADD_INSN1(ret, line_node, topn, INT2FIX(3));
+                ADD_SEND(ret, line_node, idAREF, INT2FIX(2));
                 CHECK(iseq_compile_pattern_match(iseq, ret, fpinfo->post_rest_arg, find_failed, in_alt_pattern, FALSE));
             }
-            ADD_INSNL(ret, line, jump, find_succeeded);
+            ADD_INSNL(ret, line_node, jump, find_succeeded);
 
             ADD_LABEL(ret, next_loop);
-            ADD_INSN1(ret, line, putobject, INT2FIX(1));
-            ADD_SEND(ret, line, idPLUS, INT2FIX(1));
-            ADD_INSNL(ret, line, jump, while_begin);
+            ADD_INSN1(ret, line_node, putobject, INT2FIX(1));
+            ADD_SEND(ret, line_node, idPLUS, INT2FIX(1));
+            ADD_INSNL(ret, line_node, jump, while_begin);
 
             ADD_LABEL(ret, find_failed);
-            ADD_INSN(ret, line, pop);
-            ADD_INSN(ret, line, pop);
-            ADD_INSN(ret, line, pop);
-            ADD_INSNL(ret, line, jump, match_failed);
-            ADD_INSN1(ret, line, dupn, INT2FIX(3));
+            ADD_INSN(ret, line_node, pop);
+            ADD_INSN(ret, line_node, pop);
+            ADD_INSN(ret, line_node, pop);
+            ADD_INSNL(ret, line_node, jump, match_failed);
+            ADD_INSN1(ret, line_node, dupn, INT2FIX(3));
 
             ADD_LABEL(ret, find_succeeded);
-            ADD_INSN(ret, line, pop);
-            ADD_INSN(ret, line, pop);
-            ADD_INSN(ret, line, pop);
+            ADD_INSN(ret, line_node, pop);
+            ADD_INSN(ret, line_node, pop);
+            ADD_INSN(ret, line_node, pop);
         }
 
-        ADD_INSN(ret, line, pop);
-        ADD_INSNL(ret, line, jump, matched);
-        ADD_INSN(ret, line, putnil);
+        ADD_INSN(ret, line_node, pop);
+        ADD_INSNL(ret, line_node, jump, matched);
+        ADD_INSN(ret, line_node, putnil);
 
         ADD_LABEL(ret, type_error);
-        ADD_INSN1(ret, line, putspecialobject, INT2FIX(VM_SPECIAL_OBJECT_VMCORE));
-        ADD_INSN1(ret, line, putobject, rb_eTypeError);
-        ADD_INSN1(ret, line, putobject, rb_fstring_lit("deconstruct must return Array"));
-        ADD_SEND(ret, line, id_core_raise, INT2FIX(2));
-        ADD_INSN(ret, line, pop);
+        ADD_INSN1(ret, line_node, putspecialobject, INT2FIX(VM_SPECIAL_OBJECT_VMCORE));
+        ADD_INSN1(ret, line_node, putobject, rb_eTypeError);
+        ADD_INSN1(ret, line_node, putobject, rb_fstring_lit("deconstruct must return Array"));
+        ADD_SEND(ret, line_node, id_core_raise, INT2FIX(2));
+        ADD_INSN(ret, line_node, pop);
 
         ADD_LABEL(ret, match_failed);
-        ADD_INSN(ret, line, pop);
-        ADD_INSNL(ret, line, jump, unmatched);
+        ADD_INSN(ret, line_node, pop);
+        ADD_INSNL(ret, line_node, jump, unmatched);
 
         break;
       }
@@ -6293,32 +6330,32 @@ iseq_compile_pattern_each(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *c
         }
 
         if (node->nd_pconst) {
-            ADD_INSN(ret, line, dup);
+            ADD_INSN(ret, line_node, dup);
             CHECK(COMPILE(ret, "constant", node->nd_pconst));
-            ADD_INSN1(ret, line, checkmatch, INT2FIX(VM_CHECKMATCH_TYPE_CASE));
-            ADD_INSNL(ret, line, branchunless, match_failed);
+            ADD_INSN1(ret, line_node, checkmatch, INT2FIX(VM_CHECKMATCH_TYPE_CASE));
+            ADD_INSNL(ret, line_node, branchunless, match_failed);
         }
 
-        ADD_INSN(ret, line, dup);
-        ADD_INSN1(ret, line, putobject, ID2SYM(rb_intern("deconstruct_keys")));
-        ADD_SEND(ret, line, idRespond_to, INT2FIX(1));
-        ADD_INSNL(ret, line, branchunless, match_failed);
+        ADD_INSN(ret, line_node, dup);
+        ADD_INSN1(ret, line_node, putobject, ID2SYM(rb_intern("deconstruct_keys")));
+        ADD_SEND(ret, line_node, idRespond_to, INT2FIX(1));
+        ADD_INSNL(ret, line_node, branchunless, match_failed);
 
         if (NIL_P(keys)) {
-            ADD_INSN(ret, line, putnil);
+            ADD_INSN(ret, line_node, putnil);
         }
         else {
-            ADD_INSN1(ret, line, duparray, keys);
+            ADD_INSN1(ret, line_node, duparray, keys);
             RB_OBJ_WRITTEN(iseq, Qundef, rb_obj_hide(keys));
         }
-        ADD_SEND(ret, line, rb_intern("deconstruct_keys"), INT2FIX(1));
+        ADD_SEND(ret, line_node, rb_intern("deconstruct_keys"), INT2FIX(1));
 
-        ADD_INSN(ret, line, dup);
-        ADD_INSN1(ret, line, checktype, INT2FIX(T_HASH));
-        ADD_INSNL(ret, line, branchunless, type_error);
+        ADD_INSN(ret, line_node, dup);
+        ADD_INSN1(ret, line_node, checktype, INT2FIX(T_HASH));
+        ADD_INSNL(ret, line_node, branchunless, type_error);
 
         if (node->nd_pkwrestarg) {
-            ADD_SEND(ret, line, rb_intern("dup"), INT2FIX(0));
+            ADD_SEND(ret, line_node, rb_intern("dup"), INT2FIX(0));
         }
 
         if (node->nd_pkwargs) {
@@ -6340,14 +6377,14 @@ iseq_compile_pattern_each(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *c
                     }
                     key = key_node->nd_lit;
 
-                    ADD_INSN(ret, line, dup);
-                    ADD_INSN1(ret, line, putobject, key);
-                    ADD_SEND(ret, line, rb_intern("key?"), INT2FIX(1));
-                    ADD_INSNL(ret, line, branchunless, match_failed);
+                    ADD_INSN(ret, line_node, dup);
+                    ADD_INSN1(ret, line_node, putobject, key);
+                    ADD_SEND(ret, line_node, rb_intern("key?"), INT2FIX(1));
+                    ADD_INSNL(ret, line_node, branchunless, match_failed);
 
-                    ADD_INSN(match_values, line, dup);
-                    ADD_INSN1(match_values, line, putobject, key);
-                    ADD_SEND(match_values, line, node->nd_pkwrestarg ? rb_intern("delete") : idAREF, INT2FIX(1));
+                    ADD_INSN(match_values, line_node, dup);
+                    ADD_INSN1(match_values, line_node, putobject, key);
+                    ADD_SEND(match_values, line_node, node->nd_pkwrestarg ? rb_intern("delete") : idAREF, INT2FIX(1));
                     CHECK(iseq_compile_pattern_match(iseq, match_values, value_node, match_failed, in_alt_pattern, FALSE));
                     args = args->nd_next->nd_next;
                 }
@@ -6355,37 +6392,37 @@ iseq_compile_pattern_each(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *c
             }
         }
         else {
-            ADD_INSN(ret, line, dup);
-            ADD_SEND(ret, line, idEmptyP, INT2FIX(0));
-            ADD_INSNL(ret, line, branchunless, match_failed);
+            ADD_INSN(ret, line_node, dup);
+            ADD_SEND(ret, line_node, idEmptyP, INT2FIX(0));
+            ADD_INSNL(ret, line_node, branchunless, match_failed);
         }
 
         if (node->nd_pkwrestarg) {
             if (node->nd_pkwrestarg == NODE_SPECIAL_NO_REST_KEYWORD) {
-                ADD_INSN(ret, line, dup);
-                ADD_SEND(ret, line, idEmptyP, INT2FIX(0));
-                ADD_INSNL(ret, line, branchunless, match_failed);
+                ADD_INSN(ret, line_node, dup);
+                ADD_SEND(ret, line_node, idEmptyP, INT2FIX(0));
+                ADD_INSNL(ret, line_node, branchunless, match_failed);
             }
             else {
-                ADD_INSN(ret, line, dup);
+                ADD_INSN(ret, line_node, dup);
                 CHECK(iseq_compile_pattern_match(iseq, ret, node->nd_pkwrestarg, match_failed, in_alt_pattern, FALSE));
             }
         }
 
-        ADD_INSN(ret, line, pop);
-        ADD_INSNL(ret, line, jump, matched);
-        ADD_INSN(ret, line, putnil);
+        ADD_INSN(ret, line_node, pop);
+        ADD_INSNL(ret, line_node, jump, matched);
+        ADD_INSN(ret, line_node, putnil);
 
         ADD_LABEL(ret, type_error);
-        ADD_INSN1(ret, line, putspecialobject, INT2FIX(VM_SPECIAL_OBJECT_VMCORE));
-        ADD_INSN1(ret, line, putobject, rb_eTypeError);
-        ADD_INSN1(ret, line, putobject, rb_fstring_lit("deconstruct_keys must return Hash"));
-        ADD_SEND(ret, line, id_core_raise, INT2FIX(2));
-        ADD_INSN(ret, line, pop);
+        ADD_INSN1(ret, line_node, putspecialobject, INT2FIX(VM_SPECIAL_OBJECT_VMCORE));
+        ADD_INSN1(ret, line_node, putobject, rb_eTypeError);
+        ADD_INSN1(ret, line_node, putobject, rb_fstring_lit("deconstruct_keys must return Hash"));
+        ADD_SEND(ret, line_node, id_core_raise, INT2FIX(2));
+        ADD_INSN(ret, line_node, pop);
 
         ADD_LABEL(ret, match_failed);
-        ADD_INSN(ret, line, pop);
-        ADD_INSNL(ret, line, jump, unmatched);
+        ADD_INSN(ret, line_node, pop);
+        ADD_INSNL(ret, line_node, jump, unmatched);
         break;
       }
       case NODE_LIT:
@@ -6410,9 +6447,9 @@ iseq_compile_pattern_each(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *c
       case NODE_COLON3:
       case NODE_BEGIN:
         CHECK(COMPILE(ret, "case in literal", node));
-        ADD_INSN1(ret, line, checkmatch, INT2FIX(VM_CHECKMATCH_TYPE_CASE));
-        ADD_INSNL(ret, line, branchif, matched);
-        ADD_INSNL(ret, line, jump, unmatched);
+        ADD_INSN1(ret, line_node, checkmatch, INT2FIX(VM_CHECKMATCH_TYPE_CASE));
+        ADD_INSNL(ret, line_node, branchif, matched);
+        ADD_INSNL(ret, line_node, jump, unmatched);
         break;
       case NODE_LASGN: {
         struct rb_iseq_constant_body *const body = iseq->body;
@@ -6428,8 +6465,8 @@ iseq_compile_pattern_each(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *c
             }
         }
 
-        ADD_SETLOCAL(ret, line, idx, get_lvar_level(iseq));
-        ADD_INSNL(ret, line, jump, matched);
+        ADD_SETLOCAL(ret, line_node, idx, get_lvar_level(iseq));
+        ADD_INSNL(ret, line_node, jump, matched);
         break;
       }
       case NODE_DASGN:
@@ -6453,8 +6490,8 @@ iseq_compile_pattern_each(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *c
                           rb_id2str(id));
             return COMPILE_NG;
         }
-        ADD_SETLOCAL(ret, line, ls - idx, lv);
-        ADD_INSNL(ret, line, jump, matched);
+        ADD_SETLOCAL(ret, line_node, ls - idx, lv);
+        ADD_INSNL(ret, line_node, jump, matched);
         break;
       }
       case NODE_IF:
@@ -6464,12 +6501,12 @@ iseq_compile_pattern_each(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *c
         CHECK(iseq_compile_pattern_match(iseq, ret, node->nd_body, unmatched, in_alt_pattern, deconstructed_pos));
         CHECK(COMPILE(ret, "case in if", node->nd_cond));
         if (nd_type(node) == NODE_IF) {
-            ADD_INSNL(ret, line, branchunless, match_failed);
+            ADD_INSNL(ret, line_node, branchunless, match_failed);
         }
         else {
-            ADD_INSNL(ret, line, branchif, match_failed);
+            ADD_INSNL(ret, line_node, branchif, match_failed);
         }
-        ADD_INSNL(ret, line, jump, matched);
+        ADD_INSNL(ret, line_node, jump, matched);
         break;
       }
       case NODE_HASH: {
@@ -6483,14 +6520,14 @@ iseq_compile_pattern_each(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *c
             return COMPILE_NG;
         }
 
-        ADD_INSN(ret, line, dup);
+        ADD_INSN(ret, line_node, dup);
         CHECK(iseq_compile_pattern_match(iseq, ret, n->nd_head, match_failed, in_alt_pattern, deconstructed_pos ? deconstructed_pos + 1 : FALSE));
         CHECK(iseq_compile_pattern_each(iseq, ret, n->nd_next->nd_head, matched, match_failed, in_alt_pattern, FALSE));
-        ADD_INSN(ret, line, putnil);
+        ADD_INSN(ret, line_node, putnil);
 
         ADD_LABEL(ret, match_failed);
-        ADD_INSN(ret, line, pop);
-        ADD_INSNL(ret, line, jump, unmatched);
+        ADD_INSN(ret, line_node, pop);
+        ADD_INSNL(ret, line_node, jump, unmatched);
         break;
       }
       case NODE_OR: {
@@ -6498,12 +6535,12 @@ iseq_compile_pattern_each(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *c
         match_succeeded = NEW_LABEL(line);
         fin = NEW_LABEL(line);
 
-        ADD_INSN(ret, line, dup);
+        ADD_INSN(ret, line_node, dup);
         CHECK(iseq_compile_pattern_each(iseq, ret, node->nd_1st, match_succeeded, fin, TRUE, deconstructed_pos ? deconstructed_pos + 1 : FALSE));
         ADD_LABEL(ret, match_succeeded);
-        ADD_INSN(ret, line, pop);
-        ADD_INSNL(ret, line, jump, matched);
-        ADD_INSN(ret, line, putnil);
+        ADD_INSN(ret, line_node, pop);
+        ADD_INSNL(ret, line_node, jump, matched);
+        ADD_INSN(ret, line_node, putnil);
         ADD_LABEL(ret, fin);
         CHECK(iseq_compile_pattern_each(iseq, ret, node->nd_2nd, matched, unmatched, TRUE, deconstructed_pos));
         break;
@@ -6526,7 +6563,7 @@ iseq_compile_pattern_match(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *
 static int
 iseq_compile_array_deconstruct(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, LABEL *deconstruct, LABEL *deconstructed, LABEL *match_failed, LABEL *type_error, int deconstructed_pos)
 {
-    const int line = nd_line(node);
+    const NODE *line_node = node;
 
     // NOTE: this optimization allows us to re-use the #deconstruct value
     // (or its absence).
@@ -6534,45 +6571,45 @@ iseq_compile_array_deconstruct(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NO
     // where the value is stored.
     if (deconstructed_pos) {
         // If value is nil then we haven't tried to deconstruct
-        ADD_INSN1(ret, line, topn, INT2FIX(deconstructed_pos));
-        ADD_INSNL(ret, line, branchnil, deconstruct);
+        ADD_INSN1(ret, line_node, topn, INT2FIX(deconstructed_pos));
+        ADD_INSNL(ret, line_node, branchnil, deconstruct);
 
         // If false then the value is not deconstructable
-        ADD_INSN1(ret, line, topn, INT2FIX(deconstructed_pos));
-        ADD_INSNL(ret, line, branchunless, match_failed);
+        ADD_INSN1(ret, line_node, topn, INT2FIX(deconstructed_pos));
+        ADD_INSNL(ret, line_node, branchunless, match_failed);
 
         // Drop value, add deconstructed to the stack and jump
-        ADD_INSN(ret, line, pop);
-        ADD_INSN1(ret, line, topn, INT2FIX(deconstructed_pos - 1));
-        ADD_INSNL(ret, line, jump, deconstructed);
+        ADD_INSN(ret, line_node, pop);
+        ADD_INSN1(ret, line_node, topn, INT2FIX(deconstructed_pos - 1));
+        ADD_INSNL(ret, line_node, jump, deconstructed);
     }
     else {
-        ADD_INSNL(ret, line, jump, deconstruct);
+        ADD_INSNL(ret, line_node, jump, deconstruct);
     }
 
     ADD_LABEL(ret, deconstruct);
-    ADD_INSN(ret, line, dup);
-    ADD_INSN1(ret, line, putobject, ID2SYM(rb_intern("deconstruct")));
-    ADD_SEND(ret, line, idRespond_to, INT2FIX(1));
+    ADD_INSN(ret, line_node, dup);
+    ADD_INSN1(ret, line_node, putobject, ID2SYM(rb_intern("deconstruct")));
+    ADD_SEND(ret, line_node, idRespond_to, INT2FIX(1));
 
     // Cache the result of respond_to? (in case it's false is stays there, if true - it's overwritten after #deconstruct)
     if (deconstructed_pos) {
-        ADD_INSN1(ret, line, setn, INT2FIX(deconstructed_pos + 1));
+        ADD_INSN1(ret, line_node, setn, INT2FIX(deconstructed_pos + 1));
     }
 
-    ADD_INSNL(ret, line, branchunless, match_failed);
+    ADD_INSNL(ret, line_node, branchunless, match_failed);
 
-    ADD_SEND(ret, line, rb_intern("deconstruct"), INT2FIX(0));
+    ADD_SEND(ret, line_node, rb_intern("deconstruct"), INT2FIX(0));
 
     // Cache the result (if it's cacheable - currently, only top-level array patterns)
     if (deconstructed_pos) {
-        ADD_INSN1(ret, line, setn, INT2FIX(deconstructed_pos));
+        ADD_INSN1(ret, line_node, setn, INT2FIX(deconstructed_pos));
     }
 
-    ADD_INSN(ret, line, dup);
-    ADD_INSN1(ret, line, checktype, INT2FIX(T_ARRAY));
-    ADD_INSNL(ret, line, branchunless, type_error);
-    ADD_INSNL(ret, line, jump, deconstructed);
+    ADD_INSN(ret, line_node, dup);
+    ADD_INSN1(ret, line_node, checktype, INT2FIX(T_ARRAY));
+    ADD_INSNL(ret, line_node, branchunless, type_error);
+    ADD_INSNL(ret, line_node, jump, deconstructed);
 
     ADD_LABEL(ret, deconstructed);
 
@@ -6590,6 +6627,7 @@ compile_case3(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const orig_no
     DECL_ANCHOR(cond_seq);
     int line;
     enum node_type type;
+    const NODE *line_node;
     VALUE branches = 0;
     int branch_id = 0;
 
@@ -6603,11 +6641,12 @@ compile_case3(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const orig_no
     EXPECT_NODE("NODE_CASE3", node, NODE_IN, COMPILE_NG);
     type = nd_type(node);
     line = nd_line(node);
+    line_node = node;
 
     endlabel = NEW_LABEL(line);
     elselabel = NEW_LABEL(line);
 
-    ADD_INSN(head, line, putnil); /* allocate stack for cached #deconstruct value */
+    ADD_INSN(head, line_node, putnil); /* allocate stack for cached #deconstruct value */
 
     CHECK(COMPILE(head, "case base", orig_node->nd_head));
 
@@ -6617,12 +6656,12 @@ compile_case3(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const orig_no
         LABEL *l1;
 
         if (branch_id) {
-            ADD_INSN(body_seq, line, putnil);
+            ADD_INSN(body_seq, line_node, putnil);
         }
         l1 = NEW_LABEL(line);
         ADD_LABEL(body_seq, l1);
-        ADD_INSN(body_seq, line, pop);
-        ADD_INSN(body_seq, line, pop); /* discard cached #deconstruct value */
+        ADD_INSN(body_seq, line_node, pop);
+        ADD_INSN(body_seq, line_node, pop); /* discard cached #deconstruct value */
         add_trace_branch_coverage(
             iseq,
             body_seq,
@@ -6631,13 +6670,13 @@ compile_case3(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const orig_no
             "in",
             branches);
         CHECK(COMPILE_(body_seq, "in body", node->nd_body, popped));
-        ADD_INSNL(body_seq, line, jump, endlabel);
+        ADD_INSNL(body_seq, line_node, jump, endlabel);
 
         pattern = node->nd_head;
         if (pattern) {
             int pat_line = nd_line(pattern);
             LABEL *next_pat = NEW_LABEL(pat_line);
-            ADD_INSN (cond_seq, pat_line, dup);
+            ADD_INSN (cond_seq, pattern, dup);
             // NOTE: set deconstructed_pos to the current cached value location
             // (it's "under" the matchee value, so it's position is 2)
             CHECK(iseq_compile_pattern_each(iseq, cond_seq, pattern, l1, next_pat, FALSE, 2));
@@ -6655,38 +6694,39 @@ compile_case3(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const orig_no
         }
         type = nd_type(node);
         line = nd_line(node);
+        line_node = node;
     }
     /* else */
     if (node) {
         ADD_LABEL(cond_seq, elselabel);
-        ADD_INSN(cond_seq, line, pop);
-        ADD_INSN(cond_seq, line, pop); /* discard cached #deconstruct value */
+        ADD_INSN(cond_seq, line_node, pop);
+        ADD_INSN(cond_seq, line_node, pop); /* discard cached #deconstruct value */
         add_trace_branch_coverage(iseq, cond_seq, node, branch_id, "else", branches);
         CHECK(COMPILE_(cond_seq, "else", node, popped));
-        ADD_INSNL(cond_seq, line, jump, endlabel);
-        ADD_INSN(cond_seq, line, putnil);
+        ADD_INSNL(cond_seq, line_node, jump, endlabel);
+        ADD_INSN(cond_seq, line_node, putnil);
         if (popped) {
-            ADD_INSN(cond_seq, line, putnil);
+            ADD_INSN(cond_seq, line_node, putnil);
         }
     }
     else {
         debugs("== else (implicit)\n");
         ADD_LABEL(cond_seq, elselabel);
         add_trace_branch_coverage(iseq, cond_seq, orig_node, branch_id, "else", branches);
-        ADD_INSN1(cond_seq, nd_line(orig_node), putspecialobject, INT2FIX(VM_SPECIAL_OBJECT_VMCORE));
-        ADD_INSN1(cond_seq, nd_line(orig_node), putobject, rb_eNoMatchingPatternError);
-        ADD_INSN1(cond_seq, nd_line(orig_node), topn, INT2FIX(2));
-        ADD_SEND(cond_seq, nd_line(orig_node), id_core_raise, INT2FIX(2));
-        ADD_INSN(cond_seq, nd_line(orig_node), pop);
-        ADD_INSN(cond_seq, nd_line(orig_node), pop);
-        ADD_INSN(cond_seq, nd_line(orig_node), pop); /* discard cached #deconstruct value */
+        ADD_INSN1(cond_seq, orig_node, putspecialobject, INT2FIX(VM_SPECIAL_OBJECT_VMCORE));
+        ADD_INSN1(cond_seq, orig_node, putobject, rb_eNoMatchingPatternError);
+        ADD_INSN1(cond_seq, orig_node, topn, INT2FIX(2));
+        ADD_SEND(cond_seq, orig_node, id_core_raise, INT2FIX(2));
+        ADD_INSN(cond_seq, orig_node, pop);
+        ADD_INSN(cond_seq, orig_node, pop);
+        ADD_INSN(cond_seq, orig_node, pop); /* discard cached #deconstruct value */
         if (!popped) {
-            ADD_INSN(cond_seq, nd_line(orig_node), putnil);
+            ADD_INSN(cond_seq, orig_node, putnil);
         }
-        ADD_INSNL(cond_seq, nd_line(orig_node), jump, endlabel);
-        ADD_INSN(cond_seq, line, putnil);
+        ADD_INSNL(cond_seq, orig_node, jump, endlabel);
+        ADD_INSN(cond_seq, line_node, putnil);
         if (popped) {
-            ADD_INSN(cond_seq, line, putnil);
+            ADD_INSN(cond_seq, line_node, putnil);
         }
     }
 
@@ -6700,6 +6740,7 @@ static int
 compile_loop(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, int popped, const enum node_type type)
 {
     const int line = (int)nd_line(node);
+    const NODE *line_node = node;
 
     LABEL *prev_start_label = ISEQ_COMPILE_DATA(iseq)->start_label;
     LABEL *prev_end_label = ISEQ_COMPILE_DATA(iseq)->end_label;
@@ -6722,17 +6763,17 @@ compile_loop(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, in
     push_ensure_entry(iseq, &enl, NULL, NULL);
 
     if (node->nd_state == 1) {
-	ADD_INSNL(ret, line, jump, next_label);
+	ADD_INSNL(ret, line_node, jump, next_label);
     }
     else {
 	tmp_label = NEW_LABEL(line);
-	ADD_INSNL(ret, line, jump, tmp_label);
+	ADD_INSNL(ret, line_node, jump, tmp_label);
     }
     ADD_LABEL(ret, adjust_label);
-    ADD_INSN(ret, line, putnil);
+    ADD_INSN(ret, line_node, putnil);
     ADD_LABEL(ret, next_catch_label);
-    ADD_INSN(ret, line, pop);
-    ADD_INSNL(ret, line, jump, next_label);
+    ADD_INSN(ret, line_node, pop);
+    ADD_INSNL(ret, line_node, jump, next_label);
     if (tmp_label) ADD_LABEL(ret, tmp_label);
 
     ADD_LABEL(ret, redo_label);
@@ -6761,18 +6802,18 @@ compile_loop(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, in
     ADD_ADJUST_RESTORE(ret, adjust_label);
 
     if (node->nd_state == Qundef) {
-	/* ADD_INSN(ret, line, putundef); */
+	/* ADD_INSN(ret, line_node, putundef); */
 	COMPILE_ERROR(ERROR_ARGS "unsupported: putundef");
 	return COMPILE_NG;
     }
     else {
-	ADD_INSN(ret, line, putnil);
+	ADD_INSN(ret, line_node, putnil);
     }
 
     ADD_LABEL(ret, break_label);	/* break */
 
     if (popped) {
-	ADD_INSN(ret, line, pop);
+	ADD_INSN(ret, line_node, pop);
     }
 
     ADD_CATCH_ENTRY(CATCH_TYPE_BREAK, redo_label, break_label, NULL,
@@ -6794,6 +6835,7 @@ static int
 compile_iter(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, int popped)
 {
     const int line = nd_line(node);
+    const NODE *line_node = node;
     const rb_iseq_t *prevblock = ISEQ_COMPILE_DATA(iseq)->current_block;
     LABEL *retry_label = NEW_LABEL(line);
     LABEL *retry_end_l = NEW_LABEL(line);
@@ -6806,7 +6848,7 @@ compile_iter(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, in
 	ISEQ_COMPILE_DATA(iseq)->current_block = child_iseq =
 	    NEW_CHILD_ISEQ(node->nd_body, make_name_for_block(iseq),
 			   ISEQ_TYPE_BLOCK, line);
-	ADD_SEND_WITH_BLOCK(ret, line, idEach, INT2FIX(0), child_iseq);
+	ADD_SEND_WITH_BLOCK(ret, line_node, idEach, INT2FIX(0), child_iseq);
     }
     else {
 	ISEQ_COMPILE_DATA(iseq)->current_block = child_iseq =
@@ -6817,7 +6859,7 @@ compile_iter(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, in
     ADD_LABEL(ret, retry_end_l);
 
     if (popped) {
-	ADD_INSN(ret, line, pop);
+	ADD_INSN(ret, line_node, pop);
     }
 
     ISEQ_COMPILE_DATA(iseq)->current_block = prevblock;
@@ -6832,27 +6874,27 @@ compile_for_masgn(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const nod
     /* massign to var in "for"
      * (args.length == 1 && Array.try_convert(args[0])) || args
      */
-    const int line = nd_line(node);
+    const NODE *line_node = node;
     const NODE *var = node->nd_var;
     LABEL *not_single = NEW_LABEL(nd_line(var));
     LABEL *not_ary = NEW_LABEL(nd_line(var));
     CHECK(COMPILE(ret, "for var", var));
-    ADD_INSN(ret, line, dup);
-    ADD_CALL(ret, line, idLength, INT2FIX(0));
-    ADD_INSN1(ret, line, putobject, INT2FIX(1));
-    ADD_CALL(ret, line, idEq, INT2FIX(1));
-    ADD_INSNL(ret, line, branchunless, not_single);
-    ADD_INSN(ret, line, dup);
-    ADD_INSN1(ret, line, putobject, INT2FIX(0));
-    ADD_CALL(ret, line, idAREF, INT2FIX(1));
-    ADD_INSN1(ret, line, putobject, rb_cArray);
-    ADD_INSN(ret, line, swap);
-    ADD_CALL(ret, line, rb_intern("try_convert"), INT2FIX(1));
-    ADD_INSN(ret, line, dup);
-    ADD_INSNL(ret, line, branchunless, not_ary);
-    ADD_INSN(ret, line, swap);
+    ADD_INSN(ret, line_node, dup);
+    ADD_CALL(ret, line_node, idLength, INT2FIX(0));
+    ADD_INSN1(ret, line_node, putobject, INT2FIX(1));
+    ADD_CALL(ret, line_node, idEq, INT2FIX(1));
+    ADD_INSNL(ret, line_node, branchunless, not_single);
+    ADD_INSN(ret, line_node, dup);
+    ADD_INSN1(ret, line_node, putobject, INT2FIX(0));
+    ADD_CALL(ret, line_node, idAREF, INT2FIX(1));
+    ADD_INSN1(ret, line_node, putobject, rb_cArray);
+    ADD_INSN(ret, line_node, swap);
+    ADD_CALL(ret, line_node, rb_intern("try_convert"), INT2FIX(1));
+    ADD_INSN(ret, line_node, dup);
+    ADD_INSNL(ret, line_node, branchunless, not_ary);
+    ADD_INSN(ret, line_node, swap);
     ADD_LABEL(ret, not_ary);
-    ADD_INSN(ret, line, pop);
+    ADD_INSN(ret, line_node, pop);
     ADD_LABEL(ret, not_single);
     return COMPILE_OK;
 }
@@ -6860,22 +6902,22 @@ compile_for_masgn(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const nod
 static int
 compile_break(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, int popped)
 {
-    const int line = nd_line(node);
+    const NODE *line_node = node;
     unsigned long throw_flag = 0;
 
     if (ISEQ_COMPILE_DATA(iseq)->redo_label != 0 && can_add_ensure_iseq(iseq)) {
 	/* while/until */
 	LABEL *splabel = NEW_LABEL(0);
 	ADD_LABEL(ret, splabel);
-	ADD_ADJUST(ret, line, ISEQ_COMPILE_DATA(iseq)->redo_label);
+	ADD_ADJUST(ret, line_node, ISEQ_COMPILE_DATA(iseq)->redo_label);
 	CHECK(COMPILE_(ret, "break val (while/until)", node->nd_stts,
 		       ISEQ_COMPILE_DATA(iseq)->loopval_popped));
 	add_ensure_iseq(ret, iseq, 0);
-	ADD_INSNL(ret, line, jump, ISEQ_COMPILE_DATA(iseq)->end_label);
+	ADD_INSNL(ret, line_node, jump, ISEQ_COMPILE_DATA(iseq)->end_label);
 	ADD_ADJUST_RESTORE(ret, splabel);
 
 	if (!popped) {
-	    ADD_INSN(ret, line, putnil);
+	    ADD_INSN(ret, line_node, putnil);
 	}
     }
     else {
@@ -6904,9 +6946,9 @@ compile_break(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, i
 
             /* escape from block */
             CHECK(COMPILE(ret, "break val (block)", node->nd_stts));
-            ADD_INSN1(ret, line, throw, INT2FIX(throw_flag | TAG_BREAK));
+            ADD_INSN1(ret, line_node, throw, INT2FIX(throw_flag | TAG_BREAK));
             if (popped) {
-                ADD_INSN(ret, line, pop);
+                ADD_INSN(ret, line_node, pop);
             }
             return COMPILE_OK;
 	}
@@ -6919,7 +6961,7 @@ compile_break(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, i
 static int
 compile_next(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, int popped)
 {
-    const int line = nd_line(node);
+    const NODE *line_node = node;
     unsigned long throw_flag = 0;
 
     if (ISEQ_COMPILE_DATA(iseq)->redo_label != 0 && can_add_ensure_iseq(iseq)) {
@@ -6928,26 +6970,26 @@ compile_next(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, in
 	ADD_LABEL(ret, splabel);
 	CHECK(COMPILE(ret, "next val/valid syntax?", node->nd_stts));
 	add_ensure_iseq(ret, iseq, 0);
-	ADD_ADJUST(ret, line, ISEQ_COMPILE_DATA(iseq)->redo_label);
-	ADD_INSNL(ret, line, jump, ISEQ_COMPILE_DATA(iseq)->start_label);
+	ADD_ADJUST(ret, line_node, ISEQ_COMPILE_DATA(iseq)->redo_label);
+	ADD_INSNL(ret, line_node, jump, ISEQ_COMPILE_DATA(iseq)->start_label);
 	ADD_ADJUST_RESTORE(ret, splabel);
 	if (!popped) {
-	    ADD_INSN(ret, line, putnil);
+	    ADD_INSN(ret, line_node, putnil);
 	}
     }
     else if (ISEQ_COMPILE_DATA(iseq)->end_label && can_add_ensure_iseq(iseq)) {
 	LABEL *splabel = NEW_LABEL(0);
 	debugs("next in block\n");
 	ADD_LABEL(ret, splabel);
-	ADD_ADJUST(ret, line, ISEQ_COMPILE_DATA(iseq)->start_label);
+	ADD_ADJUST(ret, line_node, ISEQ_COMPILE_DATA(iseq)->start_label);
 	CHECK(COMPILE(ret, "next val", node->nd_stts));
 	add_ensure_iseq(ret, iseq, 0);
-	ADD_INSNL(ret, line, jump, ISEQ_COMPILE_DATA(iseq)->end_label);
+	ADD_INSNL(ret, line_node, jump, ISEQ_COMPILE_DATA(iseq)->end_label);
 	ADD_ADJUST_RESTORE(ret, splabel);
 	splabel->unremovable = FALSE;
 
 	if (!popped) {
-	    ADD_INSN(ret, line, putnil);
+	    ADD_INSN(ret, line_node, putnil);
 	}
     }
     else {
@@ -6976,10 +7018,10 @@ compile_next(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, in
 	}
 	if (ip != 0) {
 	    CHECK(COMPILE(ret, "next val", node->nd_stts));
-            ADD_INSN1(ret, line, throw, INT2FIX(throw_flag | TAG_NEXT));
+            ADD_INSN1(ret, line_node, throw, INT2FIX(throw_flag | TAG_NEXT));
 
 	    if (popped) {
-		ADD_INSN(ret, line, pop);
+		ADD_INSN(ret, line_node, pop);
 	    }
 	}
 	else {
@@ -6993,18 +7035,18 @@ compile_next(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, in
 static int
 compile_redo(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, int popped)
 {
-    const int line = nd_line(node);
+    const NODE *line_node = node;
 
     if (ISEQ_COMPILE_DATA(iseq)->redo_label && can_add_ensure_iseq(iseq)) {
 	LABEL *splabel = NEW_LABEL(0);
 	debugs("redo in while");
 	ADD_LABEL(ret, splabel);
-	ADD_ADJUST(ret, line, ISEQ_COMPILE_DATA(iseq)->redo_label);
+	ADD_ADJUST(ret, line_node, ISEQ_COMPILE_DATA(iseq)->redo_label);
 	add_ensure_iseq(ret, iseq, 0);
-	ADD_INSNL(ret, line, jump, ISEQ_COMPILE_DATA(iseq)->redo_label);
+	ADD_INSNL(ret, line_node, jump, ISEQ_COMPILE_DATA(iseq)->redo_label);
 	ADD_ADJUST_RESTORE(ret, splabel);
 	if (!popped) {
-	    ADD_INSN(ret, line, putnil);
+	    ADD_INSN(ret, line_node, putnil);
 	}
     }
     else if (iseq->body->type != ISEQ_TYPE_EVAL && ISEQ_COMPILE_DATA(iseq)->start_label && can_add_ensure_iseq(iseq)) {
@@ -7013,12 +7055,12 @@ compile_redo(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, in
 	debugs("redo in block");
 	ADD_LABEL(ret, splabel);
 	add_ensure_iseq(ret, iseq, 0);
-	ADD_ADJUST(ret, line, ISEQ_COMPILE_DATA(iseq)->start_label);
-	ADD_INSNL(ret, line, jump, ISEQ_COMPILE_DATA(iseq)->start_label);
+	ADD_ADJUST(ret, line_node, ISEQ_COMPILE_DATA(iseq)->start_label);
+	ADD_INSNL(ret, line_node, jump, ISEQ_COMPILE_DATA(iseq)->start_label);
 	ADD_ADJUST_RESTORE(ret, splabel);
 
 	if (!popped) {
-	    ADD_INSN(ret, line, putnil);
+	    ADD_INSN(ret, line_node, putnil);
 	}
     }
     else {
@@ -7044,11 +7086,11 @@ compile_redo(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, in
 	    ip = ip->body->parent_iseq;
 	}
 	if (ip != 0) {
-	    ADD_INSN(ret, line, putnil);
-            ADD_INSN1(ret, line, throw, INT2FIX(VM_THROW_NO_ESCAPE_FLAG | TAG_REDO));
+	    ADD_INSN(ret, line_node, putnil);
+            ADD_INSN1(ret, line_node, throw, INT2FIX(VM_THROW_NO_ESCAPE_FLAG | TAG_REDO));
 
 	    if (popped) {
-		ADD_INSN(ret, line, pop);
+		ADD_INSN(ret, line_node, pop);
 	    }
 	}
 	else {
@@ -7062,14 +7104,14 @@ compile_redo(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, in
 static int
 compile_retry(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, int popped)
 {
-    const int line = nd_line(node);
+    const NODE *line_node = node;
 
     if (iseq->body->type == ISEQ_TYPE_RESCUE) {
-	ADD_INSN(ret, line, putnil);
-	ADD_INSN1(ret, line, throw, INT2FIX(TAG_RETRY));
+	ADD_INSN(ret, line_node, putnil);
+	ADD_INSN1(ret, line_node, throw, INT2FIX(TAG_RETRY));
 
 	if (popped) {
-	    ADD_INSN(ret, line, pop);
+	    ADD_INSN(ret, line_node, pop);
 	}
     }
     else {
@@ -7083,6 +7125,7 @@ static int
 compile_rescue(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, int popped)
 {
     const int line = nd_line(node);
+    const NODE *line_node = node;
     LABEL *lstart = NEW_LABEL(line);
     LABEL *lend = NEW_LABEL(line);
     LABEL *lcont = NEW_LABEL(line);
@@ -7103,14 +7146,14 @@ compile_rescue(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, 
 
     ADD_LABEL(ret, lend);
     if (node->nd_else) {
-	ADD_INSN(ret, line, pop);
+	ADD_INSN(ret, line_node, pop);
 	CHECK(COMPILE(ret, "rescue else", node->nd_else));
     }
-    ADD_INSN(ret, line, nop);
+    ADD_INSN(ret, line_node, nop);
     ADD_LABEL(ret, lcont);
 
     if (popped) {
-	ADD_INSN(ret, line, pop);
+	ADD_INSN(ret, line_node, pop);
     }
 
     /* register catch entry */
@@ -7123,6 +7166,7 @@ static int
 compile_resbody(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, int popped)
 {
     const int line = nd_line(node);
+    const NODE *line_node = node;
     const NODE *resq = node;
     const NODE *narg;
     LABEL *label_miss, *label_hit;
@@ -7136,38 +7180,38 @@ compile_resbody(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node,
 	    switch (nd_type(narg)) {
 	      case NODE_LIST:
 		while (narg) {
-		    ADD_GETLOCAL(ret, line, LVAR_ERRINFO, 0);
+		    ADD_GETLOCAL(ret, line_node, LVAR_ERRINFO, 0);
 		    CHECK(COMPILE(ret, "rescue arg", narg->nd_head));
-		    ADD_INSN1(ret, line, checkmatch, INT2FIX(VM_CHECKMATCH_TYPE_RESCUE));
-		    ADD_INSNL(ret, line, branchif, label_hit);
+		    ADD_INSN1(ret, line_node, checkmatch, INT2FIX(VM_CHECKMATCH_TYPE_RESCUE));
+		    ADD_INSNL(ret, line_node, branchif, label_hit);
 		    narg = narg->nd_next;
 		}
 		break;
 	      case NODE_SPLAT:
 	      case NODE_ARGSCAT:
 	      case NODE_ARGSPUSH:
-		ADD_GETLOCAL(ret, line, LVAR_ERRINFO, 0);
+		ADD_GETLOCAL(ret, line_node, LVAR_ERRINFO, 0);
 		CHECK(COMPILE(ret, "rescue/cond splat", narg));
-		ADD_INSN1(ret, line, checkmatch, INT2FIX(VM_CHECKMATCH_TYPE_RESCUE | VM_CHECKMATCH_ARRAY));
-		ADD_INSNL(ret, line, branchif, label_hit);
+		ADD_INSN1(ret, line_node, checkmatch, INT2FIX(VM_CHECKMATCH_TYPE_RESCUE | VM_CHECKMATCH_ARRAY));
+		ADD_INSNL(ret, line_node, branchif, label_hit);
 		break;
 	      default:
 		UNKNOWN_NODE("NODE_RESBODY", narg, COMPILE_NG);
 	    }
 	}
 	else {
-	    ADD_GETLOCAL(ret, line, LVAR_ERRINFO, 0);
-	    ADD_INSN1(ret, line, putobject, rb_eStandardError);
-	    ADD_INSN1(ret, line, checkmatch, INT2FIX(VM_CHECKMATCH_TYPE_RESCUE));
-	    ADD_INSNL(ret, line, branchif, label_hit);
+	    ADD_GETLOCAL(ret, line_node, LVAR_ERRINFO, 0);
+	    ADD_INSN1(ret, line_node, putobject, rb_eStandardError);
+	    ADD_INSN1(ret, line_node, checkmatch, INT2FIX(VM_CHECKMATCH_TYPE_RESCUE));
+	    ADD_INSNL(ret, line_node, branchif, label_hit);
 	}
-	ADD_INSNL(ret, line, jump, label_miss);
+	ADD_INSNL(ret, line_node, jump, label_miss);
 	ADD_LABEL(ret, label_hit);
 	CHECK(COMPILE(ret, "resbody body", resq->nd_body));
 	if (ISEQ_COMPILE_DATA(iseq)->option->tailcall_optimization) {
-	    ADD_INSN(ret, line, nop);
+	    ADD_INSN(ret, line_node, nop);
 	}
-	ADD_INSN(ret, line, leave);
+	ADD_INSN(ret, line_node, leave);
 	ADD_LABEL(ret, label_miss);
 	resq = resq->nd_head;
     }
@@ -7178,6 +7222,7 @@ static int
 compile_ensure(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, int popped)
 {
     const int line = nd_line(node);
+    const NODE *line_node = node;
     DECL_ANCHOR(ensr);
     const rb_iseq_t *ensure = NEW_CHILD_ISEQ(node->nd_ensr,
 					     rb_str_concat(rb_str_new2 ("ensure in "), iseq->body->location.label),
@@ -7205,9 +7250,9 @@ compile_ensure(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, 
     CHECK(COMPILE_(ret, "ensure head", node->nd_head, (popped | last_leave)));
     ADD_LABEL(ret, lend);
     ADD_SEQ(ret, ensr);
-    if (!popped && last_leave) ADD_INSN(ret, line, putnil);
+    if (!popped && last_leave) ADD_INSN(ret, line_node, putnil);
     ADD_LABEL(ret, lcont);
-    if (last_leave) ADD_INSN(ret, line, pop);
+    if (last_leave) ADD_INSN(ret, line_node, pop);
 
     erange = ISEQ_COMPILE_DATA(iseq)->ensure_node_stack->erange;
     if (lstart->link.next != &lend->link) {
@@ -7225,7 +7270,7 @@ compile_ensure(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, 
 static int
 compile_return(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, int popped)
 {
-    const int line = nd_line(node);
+    const NODE *line_node = node;
 
     if (iseq) {
 	enum iseq_type type = iseq->body->type;
@@ -7256,7 +7301,7 @@ compile_return(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, 
 	if (type == ISEQ_TYPE_METHOD) {
 	    splabel = NEW_LABEL(0);
 	    ADD_LABEL(ret, splabel);
-	    ADD_ADJUST(ret, line, 0);
+	    ADD_ADJUST(ret, line_node, 0);
 	}
 
 	CHECK(COMPILE(ret, "return nd_stts (return val)", retval));
@@ -7264,17 +7309,17 @@ compile_return(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, 
 	if (type == ISEQ_TYPE_METHOD && can_add_ensure_iseq(iseq)) {
 	    add_ensure_iseq(ret, iseq, 1);
 	    ADD_TRACE(ret, RUBY_EVENT_RETURN);
-	    ADD_INSN(ret, line, leave);
+	    ADD_INSN(ret, line_node, leave);
 	    ADD_ADJUST_RESTORE(ret, splabel);
 
 	    if (!popped) {
-		ADD_INSN(ret, line, putnil);
+		ADD_INSN(ret, line_node, putnil);
 	    }
 	}
 	else {
-	    ADD_INSN1(ret, line, throw, INT2FIX(TAG_RETURN));
+	    ADD_INSN1(ret, line_node, throw, INT2FIX(TAG_RETURN));
 	    if (popped) {
-		ADD_INSN(ret, line, pop);
+		ADD_INSN(ret, line_node, pop);
 	    }
 	}
     }
@@ -7288,56 +7333,57 @@ compile_evstr(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, i
 
     if (!popped && !all_string_result_p(node)) {
 	const int line = nd_line(node);
+        const NODE *line_node = node;
 	const unsigned int flag = VM_CALL_FCALL;
 	LABEL *isstr = NEW_LABEL(line);
-	ADD_INSN(ret, line, dup);
-	ADD_INSN1(ret, line, checktype, INT2FIX(T_STRING));
-	ADD_INSNL(ret, line, branchif, isstr);
-	ADD_INSN(ret, line, dup);
-	ADD_SEND_R(ret, line, idTo_s, INT2FIX(0), NULL, INT2FIX(flag), NULL);
-	ADD_INSN(ret, line, tostring);
+	ADD_INSN(ret, line_node, dup);
+	ADD_INSN1(ret, line_node, checktype, INT2FIX(T_STRING));
+	ADD_INSNL(ret, line_node, branchif, isstr);
+	ADD_INSN(ret, line_node, dup);
+	ADD_SEND_R(ret, line_node, idTo_s, INT2FIX(0), NULL, INT2FIX(flag), NULL);
+	ADD_INSN(ret, line_node, tostring);
 	ADD_LABEL(ret, isstr);
     }
     return COMPILE_OK;
 }
 
 static void
-compile_lvar(rb_iseq_t *iseq, LINK_ANCHOR *const ret, int line, ID id)
+compile_lvar(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *line_node, ID id)
 {
     int idx = iseq->body->local_iseq->body->local_table_size - get_local_var_idx(iseq, id);
 
     debugs("id: %s idx: %d\n", rb_id2name(id), idx);
-    ADD_GETLOCAL(ret, line, idx, get_lvar_level(iseq));
+    ADD_GETLOCAL(ret, line_node, idx, get_lvar_level(iseq));
 }
 
 static LABEL *
-qcall_branch_start(rb_iseq_t *iseq, LINK_ANCHOR *const recv, VALUE *branches, const NODE *node, int line)
+qcall_branch_start(rb_iseq_t *iseq, LINK_ANCHOR *const recv, VALUE *branches, const NODE *node, const NODE *line_node)
 {
-    LABEL *else_label = NEW_LABEL(line);
+    LABEL *else_label = NEW_LABEL(nd_line(line_node));
     VALUE br = 0;
 
     br = decl_branch_base(iseq, node, "&.");
     *branches = br;
-    ADD_INSN(recv, line, dup);
-    ADD_INSNL(recv, line, branchnil, else_label);
+    ADD_INSN(recv, line_node, dup);
+    ADD_INSNL(recv, line_node, branchnil, else_label);
     add_trace_branch_coverage(iseq, recv, node, 0, "then", br);
     return else_label;
 }
 
 static void
-qcall_branch_end(rb_iseq_t *iseq, LINK_ANCHOR *const ret, LABEL *else_label, VALUE branches, const NODE *node, int line)
+qcall_branch_end(rb_iseq_t *iseq, LINK_ANCHOR *const ret, LABEL *else_label, VALUE branches, const NODE *node, const NODE *line_node)
 {
     LABEL *end_label;
     if (!else_label) return;
-    end_label = NEW_LABEL(line);
-    ADD_INSNL(ret, line, jump, end_label);
+    end_label = NEW_LABEL(nd_line(line_node));
+    ADD_INSNL(ret, line_node, jump, end_label);
     ADD_LABEL(ret, else_label);
     add_trace_branch_coverage(iseq, ret, node, 1, "else", branches);
     ADD_LABEL(ret, end_label);
 }
 
 static int
-compile_call_precheck_freeze(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, int line, int popped)
+compile_call_precheck_freeze(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, const NODE *line_node, int popped)
 {
     /* optimization shortcut
      *   "literal".freeze -> opt_str_freeze("literal")
@@ -7349,16 +7395,16 @@ compile_call_precheck_freeze(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE
         ISEQ_COMPILE_DATA(iseq)->option->specialized_instruction) {
         VALUE str = rb_fstring(node->nd_recv->nd_lit);
         if (node->nd_mid == idUMinus) {
-            ADD_INSN2(ret, line, opt_str_uminus, str,
+            ADD_INSN2(ret, line_node, opt_str_uminus, str,
                       new_callinfo(iseq, idUMinus, 0, 0, NULL, FALSE));
         }
         else {
-            ADD_INSN2(ret, line, opt_str_freeze, str,
+            ADD_INSN2(ret, line_node, opt_str_freeze, str,
                       new_callinfo(iseq, idFreeze, 0, 0, NULL, FALSE));
         }
         RB_OBJ_WRITTEN(iseq, Qundef, str);
         if (popped) {
-            ADD_INSN(ret, line, pop);
+            ADD_INSN(ret, line_node, pop);
         }
         return TRUE;
     }
@@ -7373,11 +7419,11 @@ compile_call_precheck_freeze(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE
         ISEQ_COMPILE_DATA(iseq)->option->specialized_instruction) {
         VALUE str = rb_fstring(node->nd_args->nd_head->nd_lit);
         CHECK(COMPILE(ret, "recv", node->nd_recv));
-        ADD_INSN2(ret, line, opt_aref_with, str,
+        ADD_INSN2(ret, line_node, opt_aref_with, str,
                   new_callinfo(iseq, idAREF, 1, 0, NULL, FALSE));
         RB_OBJ_WRITTEN(iseq, Qundef, str);
         if (popped) {
-            ADD_INSN(ret, line, pop);
+            ADD_INSN(ret, line_node, pop);
         }
         return TRUE;
     }
@@ -7502,7 +7548,7 @@ delegate_call_p(const rb_iseq_t *iseq, unsigned int argc, const LINK_ANCHOR *arg
 }
 
 static int
-compile_builtin_arg(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, int line, int popped)
+compile_builtin_arg(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, const NODE *line_node, int popped)
 {
     if (!node) goto no_arg;
     if (nd_type(node) != NODE_LIST) goto bad_arg;
@@ -7513,7 +7559,7 @@ compile_builtin_arg(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, i
     VALUE name = node->nd_lit;
     if (!SYMBOL_P(name)) goto non_symbol_arg;
     if (!popped) {
-        compile_lvar(iseq, ret, line, SYM2ID(name));
+        compile_lvar(iseq, ret, line_node, SYM2ID(name));
     }
     return COMPILE_OK;
   no_arg:
@@ -7531,13 +7577,13 @@ compile_builtin_arg(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, i
 }
 
 static int
-compile_builtin_function_call(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, int line, int popped,
+compile_builtin_function_call(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, const NODE *line_node, int popped,
                               const rb_iseq_t *parent_block, LINK_ANCHOR *args, const char *builtin_func)
 {
     NODE *args_node = node->nd_args;
 
     if (parent_block != NULL) {
-        COMPILE_ERROR(iseq, line, "should not call builtins here.");
+        COMPILE_ERROR(iseq, nd_line(line_node), "should not call builtins here.");
         return COMPILE_NG;
     }
     else {
@@ -7566,7 +7612,7 @@ compile_builtin_function_call(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NOD
                 return COMPILE_OK;
             }
             else if (strcmp("arg!", builtin_func) == 0) {
-                return compile_builtin_arg(iseq, ret, args_node, line, popped);
+                return compile_builtin_arg(iseq, ret, args_node, line_node, popped);
             }
             else if (1) {
                 rb_bug("can't find builtin function:%s", builtin_func);
@@ -7589,7 +7635,7 @@ compile_builtin_function_call(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NOD
         if (cconst) {
             typedef VALUE(*builtin_func0)(void *, VALUE);
             VALUE const_val = (*(builtin_func0)bf->func_ptr)(NULL, Qnil);
-            ADD_INSN1(ret, line, putobject, const_val);
+            ADD_INSN1(ret, line_node, putobject, const_val);
             return COMPILE_OK;
         }
 
@@ -7607,20 +7653,20 @@ compile_builtin_function_call(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NOD
 
         unsigned int start_index;
         if (delegate_call_p(iseq, FIX2INT(argc), args, &start_index)) {
-            ADD_INSN2(ret, line, opt_invokebuiltin_delegate, bf, INT2FIX(start_index));
+            ADD_INSN2(ret, line_node, opt_invokebuiltin_delegate, bf, INT2FIX(start_index));
         }
         else {
             ADD_SEQ(ret, args);
-            ADD_INSN1(ret,line, invokebuiltin, bf);
+            ADD_INSN1(ret, line_node, invokebuiltin, bf);
         }
 
-        if (popped) ADD_INSN(ret, line, pop);
+        if (popped) ADD_INSN(ret, line_node, pop);
         return COMPILE_OK;
     }
 }
 
 static int
-compile_call(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, const enum node_type type, int line, int popped, bool assume_receiver)
+compile_call(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, const enum node_type type, const NODE *const line_node, int popped, bool assume_receiver)
 {
     /* call:  obj.method(...)
      * fcall: func(...)
@@ -7649,11 +7695,11 @@ compile_call(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, co
         CONST_ID(id_answer, "the_answer_to_life_the_universe_and_everything");
 
         if (mid == id_bitblt) {
-            ADD_INSN(ret, line, bitblt);
+            ADD_INSN(ret, line_node, bitblt);
             return COMPILE_OK;
         }
         else if (mid == id_answer) {
-            ADD_INSN(ret, line, answer);
+            ADD_INSN(ret, line_node, answer);
             return COMPILE_OK;
         }
     }
@@ -7681,8 +7727,8 @@ compile_call(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, co
 
                 label_name = node->nd_args->nd_head->nd_lit;
                 if (!st_lookup(labels_table, (st_data_t)label_name, &data)) {
-                    label = NEW_LABEL(line);
-                    label->position = line;
+                    label = NEW_LABEL(nd_line(line_node));
+                    label->position = nd_line(line_node);
                     st_insert(labels_table, (st_data_t)label_name, (st_data_t)label);
                 }
                 else {
@@ -7695,7 +7741,7 @@ compile_call(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, co
             }
 
             if (mid == goto_id) {
-                ADD_INSNL(ret, line, jump, label);
+                ADD_INSNL(ret, line_node, jump, label);
             }
             else {
                 ADD_LABEL(ret, label);
@@ -7708,7 +7754,7 @@ compile_call(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, co
     const char *builtin_func;
     if (UNLIKELY(iseq_has_builtin_function_table(iseq)) &&
         (builtin_func = iseq_builtin_function_name(type, node->nd_recv, mid)) != NULL) {
-        return compile_builtin_function_call(iseq, ret, node, line, popped, parent_block, args, builtin_func);
+        return compile_builtin_function_call(iseq, ret, node, line_node, popped, parent_block, args, builtin_func);
     }
 
     /* receiver */
@@ -7719,10 +7765,10 @@ compile_call(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, co
             if (mid == idCall &&
                 nd_type(node->nd_recv) == NODE_LVAR &&
                 iseq_block_param_id_p(iseq, node->nd_recv->nd_vid, &idx, &level)) {
-                ADD_INSN2(recv, nd_line(node->nd_recv), getblockparamproxy, INT2FIX(idx + VM_ENV_DATA_SIZE - 1), INT2FIX(level));
+                ADD_INSN2(recv, node->nd_recv, getblockparamproxy, INT2FIX(idx + VM_ENV_DATA_SIZE - 1), INT2FIX(level));
             }
             else if (private_recv_p(node)) {
-                ADD_INSN(recv, nd_line(node), putself);
+                ADD_INSN(recv, node, putself);
                 flag |= VM_CALL_FCALL;
             }
             else {
@@ -7730,11 +7776,11 @@ compile_call(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, co
             }
 
             if (type == NODE_QCALL) {
-                else_label = qcall_branch_start(iseq, recv, &branches, node, line);
+                else_label = qcall_branch_start(iseq, recv, &branches, node, line_node);
             }
         }
         else if (type == NODE_FCALL || type == NODE_VCALL) {
-            ADD_CALL_RECEIVER(recv, line);
+            ADD_CALL_RECEIVER(recv, line_node);
         }
     }
 
@@ -7761,11 +7807,11 @@ compile_call(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, co
         flag |= VM_CALL_FCALL;
     }
 
-    ADD_SEND_R(ret, line, mid, argc, parent_block, INT2FIX(flag), keywords);
+    ADD_SEND_R(ret, line_node, mid, argc, parent_block, INT2FIX(flag), keywords);
 
-    qcall_branch_end(iseq, ret, else_label, branches, node, line);
+    qcall_branch_end(iseq, ret, else_label, branches, node, line_node);
     if (popped) {
-        ADD_INSN(ret, line, pop);
+        ADD_INSN(ret, line_node, pop);
     }
     return COMPILE_OK;
 }
@@ -7787,7 +7833,8 @@ iseq_compile_each(rb_iseq_t *iseq, LINK_ANCHOR *ret, const NODE *node, int poppe
             int lineno = ISEQ_COMPILE_DATA(iseq)->last_line;
             if (lineno == 0) lineno = FIX2INT(rb_iseq_first_lineno(iseq));
             debugs("node: NODE_NIL(implicit)\n");
-            ADD_INSN(ret, lineno, putnil);
+            NODE dummy_line_node = generate_dummy_line_node(lineno, -1);
+            ADD_INSN(ret, &dummy_line_node, putnil);
         }
         return COMPILE_OK;
     }
@@ -7811,6 +7858,7 @@ static int
 iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, int popped)
 {
     const int line = (int)nd_line(node);
+    const NODE *line_node = node;
     const enum node_type type = nd_type(node);
     struct rb_iseq_constant_body *const body = iseq->body;
 
@@ -7899,16 +7947,16 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
 	LABEL *end_label = NEW_LABEL(line);
 	CHECK(COMPILE(ret, "nd_1st", node->nd_1st));
 	if (!popped) {
-	    ADD_INSN(ret, line, dup);
+	    ADD_INSN(ret, line_node, dup);
 	}
 	if (type == NODE_AND) {
-	    ADD_INSNL(ret, line, branchunless, end_label);
+	    ADD_INSNL(ret, line_node, branchunless, end_label);
 	}
 	else {
-	    ADD_INSNL(ret, line, branchif, end_label);
+	    ADD_INSNL(ret, line_node, branchif, end_label);
 	}
 	if (!popped) {
-	    ADD_INSN(ret, line, pop);
+	    ADD_INSN(ret, line_node, pop);
 	}
 	CHECK(COMPILE_(ret, "nd_2nd", node->nd_2nd, popped));
 	ADD_LABEL(ret, end_label);
@@ -7928,9 +7976,9 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
 	CHECK(COMPILE(ret, "rvalue", node->nd_value));
 
 	if (!popped) {
-	    ADD_INSN(ret, line, dup);
+	    ADD_INSN(ret, line_node, dup);
 	}
-	ADD_SETLOCAL(ret, line, idx, get_lvar_level(iseq));
+	ADD_SETLOCAL(ret, line_node, idx, get_lvar_level(iseq));
 	break;
       }
       case NODE_DASGN:
@@ -7941,7 +7989,7 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
 	debugi("dassn id", rb_id2str(id) ? id : '*');
 
 	if (!popped) {
-	    ADD_INSN(ret, line, dup);
+	    ADD_INSN(ret, line_node, dup);
 	}
 
 	idx = get_dyna_var_idx(iseq, id, &lv, &ls);
@@ -7951,24 +7999,24 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
 			  rb_id2str(id));
 	    goto ng;
 	}
-	ADD_SETLOCAL(ret, line, ls - idx, lv);
+	ADD_SETLOCAL(ret, line_node, ls - idx, lv);
 	break;
       }
       case NODE_GASGN:{
 	CHECK(COMPILE(ret, "lvalue", node->nd_value));
 
 	if (!popped) {
-	    ADD_INSN(ret, line, dup);
+	    ADD_INSN(ret, line_node, dup);
 	}
-	ADD_INSN1(ret, line, setglobal, ID2SYM(node->nd_entry));
+	ADD_INSN1(ret, line_node, setglobal, ID2SYM(node->nd_entry));
 	break;
       }
       case NODE_IASGN:{
 	CHECK(COMPILE(ret, "lvalue", node->nd_value));
 	if (!popped) {
-	    ADD_INSN(ret, line, dup);
+	    ADD_INSN(ret, line_node, dup);
 	}
-	ADD_INSN2(ret, line, setinstancevariable,
+	ADD_INSN2(ret, line_node, setinstancevariable,
 		  ID2SYM(node->nd_vid),
 		  get_ivar_ic_value(iseq,node->nd_vid));
 	break;
@@ -7977,26 +8025,26 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
         CHECK(COMPILE(ret, "lvalue", node->nd_value));
 
         if (!popped) {
-            ADD_INSN(ret, line, dup);
+            ADD_INSN(ret, line_node, dup);
         }
 
 	if (node->nd_vid) {
-	    ADD_INSN1(ret, line, putspecialobject,
+	    ADD_INSN1(ret, line_node, putspecialobject,
 		      INT2FIX(VM_SPECIAL_OBJECT_CONST_BASE));
-            ADD_INSN1(ret, line, setconstant, ID2SYM(node->nd_vid));
+            ADD_INSN1(ret, line_node, setconstant, ID2SYM(node->nd_vid));
 	}
 	else {
 	    compile_cpath(ret, iseq, node->nd_else);
-            ADD_INSN1(ret, line, setconstant, ID2SYM(node->nd_else->nd_mid));
+            ADD_INSN1(ret, line_node, setconstant, ID2SYM(node->nd_else->nd_mid));
 	}
 	break;
       }
       case NODE_CVASGN:{
 	CHECK(COMPILE(ret, "cvasgn val", node->nd_value));
 	if (!popped) {
-	    ADD_INSN(ret, line, dup);
+	    ADD_INSN(ret, line_node, dup);
 	}
-	ADD_INSN1(ret, line, setclassvariable,
+	ADD_INSN1(ret, line_node, setclassvariable,
 		  ID2SYM(node->nd_vid));
 	break;
       }
@@ -8031,7 +8079,7 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
 	 */
 
 	if (!popped) {
-	    ADD_INSN(ret, line, putnil);
+	    ADD_INSN(ret, line_node, putnil);
 	}
 	asgnflag = COMPILE_RECV(ret, "NODE_OP_ASGN1 recv", node);
         CHECK(asgnflag != -1);
@@ -8046,9 +8094,9 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
 	    argc = setup_args(iseq, ret, node->nd_args->nd_head, &flag, NULL);
 	    CHECK(!NIL_P(argc));
 	}
-	ADD_INSN1(ret, line, dupn, FIXNUM_INC(argc, 1 + boff));
+	ADD_INSN1(ret, line_node, dupn, FIXNUM_INC(argc, 1 + boff));
         flag |= asgnflag;
-	ADD_SEND_WITH_FLAG(ret, line, idAREF, argc, INT2FIX(flag));
+	ADD_SEND_WITH_FLAG(ret, line_node, idAREF, argc, INT2FIX(flag));
 
 	if (id == idOROP || id == idANDOP) {
 	    /* a[x] ||= y  or  a[x] &&= y
@@ -8062,75 +8110,75 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
 	    LABEL *label = NEW_LABEL(line);
 	    LABEL *lfin = NEW_LABEL(line);
 
-	    ADD_INSN(ret, line, dup);
+	    ADD_INSN(ret, line_node, dup);
 	    if (id == idOROP) {
-		ADD_INSNL(ret, line, branchif, label);
+		ADD_INSNL(ret, line_node, branchif, label);
 	    }
 	    else { /* idANDOP */
-		ADD_INSNL(ret, line, branchunless, label);
+		ADD_INSNL(ret, line_node, branchunless, label);
 	    }
-	    ADD_INSN(ret, line, pop);
+	    ADD_INSN(ret, line_node, pop);
 
 	    CHECK(COMPILE(ret, "NODE_OP_ASGN1 args->body: ", node->nd_args->nd_body));
 	    if (!popped) {
-		ADD_INSN1(ret, line, setn, FIXNUM_INC(argc, 2+boff));
+		ADD_INSN1(ret, line_node, setn, FIXNUM_INC(argc, 2+boff));
 	    }
 	    if (flag & VM_CALL_ARGS_SPLAT) {
-		ADD_INSN1(ret, line, newarray, INT2FIX(1));
+		ADD_INSN1(ret, line_node, newarray, INT2FIX(1));
 		if (boff > 0) {
-		    ADD_INSN1(ret, line, dupn, INT2FIX(3));
-		    ADD_INSN(ret, line, swap);
-		    ADD_INSN(ret, line, pop);
+		    ADD_INSN1(ret, line_node, dupn, INT2FIX(3));
+		    ADD_INSN(ret, line_node, swap);
+		    ADD_INSN(ret, line_node, pop);
 		}
-		ADD_INSN(ret, line, concatarray);
+		ADD_INSN(ret, line_node, concatarray);
 		if (boff > 0) {
-		    ADD_INSN1(ret, line, setn, INT2FIX(3));
-		    ADD_INSN(ret, line, pop);
-		    ADD_INSN(ret, line, pop);
+		    ADD_INSN1(ret, line_node, setn, INT2FIX(3));
+		    ADD_INSN(ret, line_node, pop);
+		    ADD_INSN(ret, line_node, pop);
 		}
-		ADD_SEND_WITH_FLAG(ret, line, idASET, argc, INT2FIX(flag));
+		ADD_SEND_WITH_FLAG(ret, line_node, idASET, argc, INT2FIX(flag));
 	    }
 	    else {
 		if (boff > 0)
-		    ADD_INSN(ret, line, swap);
-		ADD_SEND_WITH_FLAG(ret, line, idASET, FIXNUM_INC(argc, 1), INT2FIX(flag));
+		    ADD_INSN(ret, line_node, swap);
+		ADD_SEND_WITH_FLAG(ret, line_node, idASET, FIXNUM_INC(argc, 1), INT2FIX(flag));
 	    }
-	    ADD_INSN(ret, line, pop);
-	    ADD_INSNL(ret, line, jump, lfin);
+	    ADD_INSN(ret, line_node, pop);
+	    ADD_INSNL(ret, line_node, jump, lfin);
 	    ADD_LABEL(ret, label);
 	    if (!popped) {
-		ADD_INSN1(ret, line, setn, FIXNUM_INC(argc, 2+boff));
+		ADD_INSN1(ret, line_node, setn, FIXNUM_INC(argc, 2+boff));
 	    }
-	    ADD_INSN1(ret, line, adjuststack, FIXNUM_INC(argc, 2+boff));
+	    ADD_INSN1(ret, line_node, adjuststack, FIXNUM_INC(argc, 2+boff));
 	    ADD_LABEL(ret, lfin);
 	}
 	else {
 	    CHECK(COMPILE(ret, "NODE_OP_ASGN1 args->body: ", node->nd_args->nd_body));
-	    ADD_SEND(ret, line, id, INT2FIX(1));
+	    ADD_SEND(ret, line_node, id, INT2FIX(1));
 	    if (!popped) {
-		ADD_INSN1(ret, line, setn, FIXNUM_INC(argc, 2+boff));
+		ADD_INSN1(ret, line_node, setn, FIXNUM_INC(argc, 2+boff));
 	    }
 	    if (flag & VM_CALL_ARGS_SPLAT) {
-		ADD_INSN1(ret, line, newarray, INT2FIX(1));
+		ADD_INSN1(ret, line_node, newarray, INT2FIX(1));
 		if (boff > 0) {
-		    ADD_INSN1(ret, line, dupn, INT2FIX(3));
-		    ADD_INSN(ret, line, swap);
-		    ADD_INSN(ret, line, pop);
+		    ADD_INSN1(ret, line_node, dupn, INT2FIX(3));
+		    ADD_INSN(ret, line_node, swap);
+		    ADD_INSN(ret, line_node, pop);
 		}
-		ADD_INSN(ret, line, concatarray);
+		ADD_INSN(ret, line_node, concatarray);
 		if (boff > 0) {
-		    ADD_INSN1(ret, line, setn, INT2FIX(3));
-		    ADD_INSN(ret, line, pop);
-		    ADD_INSN(ret, line, pop);
+		    ADD_INSN1(ret, line_node, setn, INT2FIX(3));
+		    ADD_INSN(ret, line_node, pop);
+		    ADD_INSN(ret, line_node, pop);
 		}
-		ADD_SEND_WITH_FLAG(ret, line, idASET, argc, INT2FIX(flag));
+		ADD_SEND_WITH_FLAG(ret, line_node, idASET, argc, INT2FIX(flag));
 	    }
 	    else {
 		if (boff > 0)
-		    ADD_INSN(ret, line, swap);
-		ADD_SEND_WITH_FLAG(ret, line, idASET, FIXNUM_INC(argc, 1), INT2FIX(flag));
+		    ADD_INSN(ret, line_node, swap);
+		ADD_SEND_WITH_FLAG(ret, line_node, idASET, FIXNUM_INC(argc, 1), INT2FIX(flag));
 	    }
-	    ADD_INSN(ret, line, pop);
+	    ADD_INSN(ret, line_node, pop);
 	}
 
 	break;
@@ -8188,52 +8236,52 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
         CHECK(asgnflag != -1);
 	if (node->nd_next->nd_aid) {
 	    lskip = NEW_LABEL(line);
-	    ADD_INSN(ret, line, dup);
-	    ADD_INSNL(ret, line, branchnil, lskip);
+	    ADD_INSN(ret, line_node, dup);
+	    ADD_INSNL(ret, line_node, branchnil, lskip);
 	}
-	ADD_INSN(ret, line, dup);
-        ADD_SEND_WITH_FLAG(ret, line, vid, INT2FIX(0), INT2FIX(asgnflag));
+	ADD_INSN(ret, line_node, dup);
+        ADD_SEND_WITH_FLAG(ret, line_node, vid, INT2FIX(0), INT2FIX(asgnflag));
 
 	if (atype == idOROP || atype == idANDOP) {
-	    ADD_INSN(ret, line, dup);
+	    ADD_INSN(ret, line_node, dup);
 	    if (atype == idOROP) {
-		ADD_INSNL(ret, line, branchif, lcfin);
+		ADD_INSNL(ret, line_node, branchif, lcfin);
 	    }
 	    else { /* idANDOP */
-		ADD_INSNL(ret, line, branchunless, lcfin);
+		ADD_INSNL(ret, line_node, branchunless, lcfin);
 	    }
-	    ADD_INSN(ret, line, pop);
+	    ADD_INSN(ret, line_node, pop);
 	    CHECK(COMPILE(ret, "NODE_OP_ASGN2 val", node->nd_value));
-	    ADD_INSN(ret, line, swap);
-	    ADD_INSN1(ret, line, topn, INT2FIX(1));
-	    ADD_SEND_WITH_FLAG(ret, line, aid, INT2FIX(1), INT2FIX(asgnflag));
-	    ADD_INSNL(ret, line, jump, lfin);
+	    ADD_INSN(ret, line_node, swap);
+	    ADD_INSN1(ret, line_node, topn, INT2FIX(1));
+	    ADD_SEND_WITH_FLAG(ret, line_node, aid, INT2FIX(1), INT2FIX(asgnflag));
+	    ADD_INSNL(ret, line_node, jump, lfin);
 
 	    ADD_LABEL(ret, lcfin);
-	    ADD_INSN(ret, line, swap);
+	    ADD_INSN(ret, line_node, swap);
 
 	    ADD_LABEL(ret, lfin);
-	    ADD_INSN(ret, line, pop);
+	    ADD_INSN(ret, line_node, pop);
 	    if (lskip) {
 		ADD_LABEL(ret, lskip);
 	    }
 	    if (popped) {
 		/* we can apply more optimize */
-		ADD_INSN(ret, line, pop);
+		ADD_INSN(ret, line_node, pop);
 	    }
 	}
 	else {
 	    CHECK(COMPILE(ret, "NODE_OP_ASGN2 val", node->nd_value));
-	    ADD_SEND(ret, line, atype, INT2FIX(1));
+	    ADD_SEND(ret, line_node, atype, INT2FIX(1));
 	    if (!popped) {
-		ADD_INSN(ret, line, swap);
-		ADD_INSN1(ret, line, topn, INT2FIX(1));
+		ADD_INSN(ret, line_node, swap);
+		ADD_INSN1(ret, line_node, topn, INT2FIX(1));
 	    }
-	    ADD_SEND_WITH_FLAG(ret, line, aid, INT2FIX(1), INT2FIX(asgnflag));
+	    ADD_SEND_WITH_FLAG(ret, line_node, aid, INT2FIX(1), INT2FIX(asgnflag));
 	    if (lskip && popped) {
 		ADD_LABEL(ret, lskip);
 	    }
-	    ADD_INSN(ret, line, pop);
+	    ADD_INSN(ret, line_node, pop);
 	    if (lskip && !popped) {
 		ADD_LABEL(ret, lskip);
 	    }
@@ -8247,7 +8295,7 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
 
 	switch (nd_type(node->nd_head)) {
 	  case NODE_COLON3:
-	    ADD_INSN1(ret, line, putobject, rb_cObject);
+	    ADD_INSN1(ret, line_node, putobject, rb_cObject);
 	    break;
 	  case NODE_COLON2:
 	    CHECK(COMPILE(ret, "NODE_OP_CDECL/colon2#nd_head", node->nd_head->nd_head));
@@ -8261,49 +8309,49 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
 	/* cref */
 	if (node->nd_aid == idOROP) {
 	    lassign = NEW_LABEL(line);
-	    ADD_INSN(ret, line, dup); /* cref cref */
-	    ADD_INSN3(ret, line, defined, INT2FIX(DEFINED_CONST_FROM),
+	    ADD_INSN(ret, line_node, dup); /* cref cref */
+	    ADD_INSN3(ret, line_node, defined, INT2FIX(DEFINED_CONST_FROM),
 		      ID2SYM(mid), Qtrue); /* cref bool */
-	    ADD_INSNL(ret, line, branchunless, lassign); /* cref */
+	    ADD_INSNL(ret, line_node, branchunless, lassign); /* cref */
 	}
-	ADD_INSN(ret, line, dup); /* cref cref */
-        ADD_INSN1(ret, line, putobject, Qtrue);
-        ADD_INSN1(ret, line, getconstant, ID2SYM(mid)); /* cref obj */
+	ADD_INSN(ret, line_node, dup); /* cref cref */
+        ADD_INSN1(ret, line_node, putobject, Qtrue);
+        ADD_INSN1(ret, line_node, getconstant, ID2SYM(mid)); /* cref obj */
 
 	if (node->nd_aid == idOROP || node->nd_aid == idANDOP) {
 	    lfin = NEW_LABEL(line);
-	    if (!popped) ADD_INSN(ret, line, dup); /* cref [obj] obj */
+	    if (!popped) ADD_INSN(ret, line_node, dup); /* cref [obj] obj */
 	    if (node->nd_aid == idOROP)
-		ADD_INSNL(ret, line, branchif, lfin);
+		ADD_INSNL(ret, line_node, branchif, lfin);
 	    else /* idANDOP */
-		ADD_INSNL(ret, line, branchunless, lfin);
+		ADD_INSNL(ret, line_node, branchunless, lfin);
 	    /* cref [obj] */
-	    if (!popped) ADD_INSN(ret, line, pop); /* cref */
+	    if (!popped) ADD_INSN(ret, line_node, pop); /* cref */
 	    if (lassign) ADD_LABEL(ret, lassign);
 	    CHECK(COMPILE(ret, "NODE_OP_CDECL#nd_value", node->nd_value));
 	    /* cref value */
 	    if (popped)
-		ADD_INSN1(ret, line, topn, INT2FIX(1)); /* cref value cref */
+		ADD_INSN1(ret, line_node, topn, INT2FIX(1)); /* cref value cref */
 	    else {
-		ADD_INSN1(ret, line, dupn, INT2FIX(2)); /* cref value cref value */
-		ADD_INSN(ret, line, swap); /* cref value value cref */
+		ADD_INSN1(ret, line_node, dupn, INT2FIX(2)); /* cref value cref value */
+		ADD_INSN(ret, line_node, swap); /* cref value value cref */
 	    }
-	    ADD_INSN1(ret, line, setconstant, ID2SYM(mid)); /* cref [value] */
+	    ADD_INSN1(ret, line_node, setconstant, ID2SYM(mid)); /* cref [value] */
 	    ADD_LABEL(ret, lfin);			    /* cref [value] */
-	    if (!popped) ADD_INSN(ret, line, swap); /* [value] cref */
-	    ADD_INSN(ret, line, pop); /* [value] */
+	    if (!popped) ADD_INSN(ret, line_node, swap); /* [value] cref */
+	    ADD_INSN(ret, line_node, pop); /* [value] */
 	}
 	else {
 	    CHECK(COMPILE(ret, "NODE_OP_CDECL#nd_value", node->nd_value));
 	    /* cref obj value */
-	    ADD_CALL(ret, line, node->nd_aid, INT2FIX(1));
+	    ADD_CALL(ret, line_node, node->nd_aid, INT2FIX(1));
 	    /* cref value */
-	    ADD_INSN(ret, line, swap); /* value cref */
+	    ADD_INSN(ret, line_node, swap); /* value cref */
 	    if (!popped) {
-		ADD_INSN1(ret, line, topn, INT2FIX(1)); /* value cref value */
-		ADD_INSN(ret, line, swap); /* value value cref */
+		ADD_INSN1(ret, line_node, topn, INT2FIX(1)); /* value cref value */
+		ADD_INSN(ret, line_node, swap); /* value value cref */
 	    }
-	    ADD_INSN1(ret, line, setconstant, ID2SYM(mid));
+	    ADD_INSN1(ret, line_node, setconstant, ID2SYM(mid));
 	}
 	break;
       }
@@ -8321,42 +8369,42 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
 	    if (!lassign) {
 		lassign = NEW_LABEL(line);
 	    }
-	    ADD_INSNL(ret, line, branchunless, lassign);
+	    ADD_INSNL(ret, line_node, branchunless, lassign);
 	}
 	else {
 	    lassign = NEW_LABEL(line);
 	}
 
 	CHECK(COMPILE(ret, "NODE_OP_ASGN_AND/OR#nd_head", node->nd_head));
-	ADD_INSN(ret, line, dup);
+	ADD_INSN(ret, line_node, dup);
 
 	if (nd_type(node) == NODE_OP_ASGN_AND) {
-	    ADD_INSNL(ret, line, branchunless, lfin);
+	    ADD_INSNL(ret, line_node, branchunless, lfin);
 	}
 	else {
-	    ADD_INSNL(ret, line, branchif, lfin);
+	    ADD_INSNL(ret, line_node, branchif, lfin);
 	}
 
-	ADD_INSN(ret, line, pop);
+	ADD_INSN(ret, line_node, pop);
 	ADD_LABEL(ret, lassign);
 	CHECK(COMPILE(ret, "NODE_OP_ASGN_AND/OR#nd_value", node->nd_value));
 	ADD_LABEL(ret, lfin);
 
 	if (popped) {
 	    /* we can apply more optimize */
-	    ADD_INSN(ret, line, pop);
+	    ADD_INSN(ret, line_node, pop);
 	}
 	break;
       }
       case NODE_CALL:   /* obj.foo */
       case NODE_OPCALL: /* foo[] */
-        if (compile_call_precheck_freeze(iseq, ret, node, line, popped) == TRUE) {
+        if (compile_call_precheck_freeze(iseq, ret, node, line_node, popped) == TRUE) {
             break;
         }
       case NODE_QCALL: /* obj&.foo */
       case NODE_FCALL: /* foo() */
       case NODE_VCALL: /* foo (variable or call) */
-        if (compile_call(iseq, ret, node, type, line, popped, false) == COMPILE_NG) {
+        if (compile_call(iseq, ret, node, type, line_node, popped, false) == COMPILE_NG) {
             goto ng;
         }
         break;
@@ -8388,7 +8436,7 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
 	    /* normal arguments */
 	    for (i = 0; i < local_body->param.lead_num; i++) {
 		int idx = local_body->local_table_size - i;
-		ADD_GETLOCAL(args, line, idx, lvar_level);
+		ADD_GETLOCAL(args, line_node, idx, lvar_level);
 	    }
 
 	    if (local_body->param.flags.has_opt) {
@@ -8396,7 +8444,7 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
 		int j;
 		for (j = 0; j < local_body->param.opt_num; j++) {
 		    int idx = local_body->local_table_size - (i + j);
-		    ADD_GETLOCAL(args, line, idx, lvar_level);
+		    ADD_GETLOCAL(args, line_node, idx, lvar_level);
 		}
 		i += j;
 		argc = i;
@@ -8405,8 +8453,8 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
 		/* rest argument */
 		int idx = local_body->local_table_size - local_body->param.rest_start;
 
-		ADD_GETLOCAL(args, line, idx, lvar_level);
-		ADD_INSN1(args, line, splatarray, Qfalse);
+		ADD_GETLOCAL(args, line_node, idx, lvar_level);
+		ADD_INSN1(args, line_node, splatarray, Qfalse);
 
 		argc = local_body->param.rest_start + 1;
 		flag |= VM_CALL_ARGS_SPLAT;
@@ -8420,17 +8468,17 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
 		    int j;
 		    for (j=0; j<post_len; j++) {
 			int idx = local_body->local_table_size - (post_start + j);
-			ADD_GETLOCAL(args, line, idx, lvar_level);
+			ADD_GETLOCAL(args, line_node, idx, lvar_level);
 		    }
-		    ADD_INSN1(args, line, newarray, INT2FIX(j));
-		    ADD_INSN (args, line, concatarray);
+		    ADD_INSN1(args, line_node, newarray, INT2FIX(j));
+		    ADD_INSN (args, line_node, concatarray);
 		    /* argc is settled at above */
 		}
 		else {
 		    int j;
 		    for (j=0; j<post_len; j++) {
 			int idx = local_body->local_table_size - (post_start + j);
-			ADD_GETLOCAL(args, line, idx, lvar_level);
+			ADD_GETLOCAL(args, line_node, idx, lvar_level);
 		    }
 		    argc = post_len + post_start;
 		}
@@ -8440,41 +8488,41 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
 		int local_size = local_body->local_table_size;
 		argc++;
 
-		ADD_INSN1(args, line, putspecialobject, INT2FIX(VM_SPECIAL_OBJECT_VMCORE));
+		ADD_INSN1(args, line_node, putspecialobject, INT2FIX(VM_SPECIAL_OBJECT_VMCORE));
 
 		if (local_body->param.flags.has_kwrest) {
 		    int idx = local_body->local_table_size - local_kwd->rest_start;
-		    ADD_GETLOCAL(args, line, idx, lvar_level);
+		    ADD_GETLOCAL(args, line_node, idx, lvar_level);
                     if (local_kwd->num > 0) {
-                        ADD_SEND(args, line, rb_intern("dup"), INT2FIX(0));
+                        ADD_SEND(args, line_node, rb_intern("dup"), INT2FIX(0));
                         flag |= VM_CALL_KW_SPLAT_MUT;
                     }
 		}
 		else {
-		    ADD_INSN1(args, line, newhash, INT2FIX(0));
+		    ADD_INSN1(args, line_node, newhash, INT2FIX(0));
                     flag |= VM_CALL_KW_SPLAT_MUT;
 		}
 		for (i = 0; i < local_kwd->num; ++i) {
 		    ID id = local_kwd->table[i];
 		    int idx = local_size - get_local_var_idx(liseq, id);
-		    ADD_INSN1(args, line, putobject, ID2SYM(id));
-		    ADD_GETLOCAL(args, line, idx, lvar_level);
+		    ADD_INSN1(args, line_node, putobject, ID2SYM(id));
+		    ADD_GETLOCAL(args, line_node, idx, lvar_level);
 		}
-		ADD_SEND(args, line, id_core_hash_merge_ptr, INT2FIX(i * 2 + 1));
+		ADD_SEND(args, line_node, id_core_hash_merge_ptr, INT2FIX(i * 2 + 1));
 		if (local_body->param.flags.has_rest) {
-		    ADD_INSN1(args, line, newarray, INT2FIX(1));
-		    ADD_INSN (args, line, concatarray);
+		    ADD_INSN1(args, line_node, newarray, INT2FIX(1));
+		    ADD_INSN (args, line_node, concatarray);
 		    --argc;
 		}
 		flag |= VM_CALL_KW_SPLAT;
 	    }
 	    else if (local_body->param.flags.has_kwrest) {
 		int idx = local_body->local_table_size - local_kwd->rest_start;
-		ADD_GETLOCAL(args, line, idx, lvar_level);
+		ADD_GETLOCAL(args, line_node, idx, lvar_level);
 
 		if (local_body->param.flags.has_rest) {
-		    ADD_INSN1(args, line, newarray, INT2FIX(1));
-		    ADD_INSN (args, line, concatarray);
+		    ADD_INSN1(args, line_node, newarray, INT2FIX(1));
+		    ADD_INSN (args, line_node, concatarray);
 		}
 		else {
 		    argc++;
@@ -8483,14 +8531,14 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
 	    }
 	}
 
-	ADD_INSN(ret, line, putself);
+	ADD_INSN(ret, line_node, putself);
 	ADD_SEQ(ret, args);
-        ADD_INSN2(ret, line, invokesuper,
+        ADD_INSN2(ret, line_node, invokesuper,
                   new_callinfo(iseq, 0, argc, flag | VM_CALL_SUPER | (type == NODE_ZSUPER ? VM_CALL_ZSUPER : 0) | VM_CALL_FCALL, keywords, parent_block != NULL),
 		  parent_block);
 
 	if (popped) {
-	    ADD_INSN(ret, line, pop);
+	    ADD_INSN(ret, line_node, pop);
 	}
 	break;
       }
@@ -8500,7 +8548,7 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
       }
       case NODE_ZLIST:{
 	if (!popped) {
-	    ADD_INSN1(ret, line, newarray, INT2FIX(0));
+	    ADD_INSN1(ret, line_node, newarray, INT2FIX(0));
 	}
 	break;
       }
@@ -8513,7 +8561,7 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
 	    CHECK(COMPILE(ret, "values item", n->nd_head));
 	    n = n->nd_next;
 	}
-	ADD_INSN1(ret, line, newarray, INT2FIX(node->nd_alen));
+	ADD_INSN1(ret, line_node, newarray, INT2FIX(node->nd_alen));
 	break;
       }
       case NODE_HASH:
@@ -8544,10 +8592,10 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
 	}
 
 	ADD_SEQ(ret, args);
-	ADD_INSN1(ret, line, invokeblock, new_callinfo(iseq, 0, FIX2INT(argc), flag, keywords, FALSE));
+	ADD_INSN1(ret, line_node, invokeblock, new_callinfo(iseq, 0, FIX2INT(argc), flag, keywords, FALSE));
 
 	if (popped) {
-	    ADD_INSN(ret, line, pop);
+	    ADD_INSN(ret, line_node, pop);
 	}
 
         int level = 0;
@@ -8560,7 +8608,7 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
       }
       case NODE_LVAR:{
 	if (!popped) {
-	    compile_lvar(iseq, ret, line, node->nd_vid);
+	    compile_lvar(iseq, ret, line_node, node->nd_vid);
 	}
 	break;
       }
@@ -8574,21 +8622,21 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
 			      rb_id2str(node->nd_vid));
 		goto ng;
 	    }
-	    ADD_GETLOCAL(ret, line, ls - idx, lv);
+	    ADD_GETLOCAL(ret, line_node, ls - idx, lv);
 	}
 	break;
       }
       case NODE_GVAR:{
-	ADD_INSN1(ret, line, getglobal, ID2SYM(node->nd_entry));
+	ADD_INSN1(ret, line_node, getglobal, ID2SYM(node->nd_entry));
 	if (popped) {
-	    ADD_INSN(ret, line, pop);
+	    ADD_INSN(ret, line_node, pop);
 	}
 	break;
       }
       case NODE_IVAR:{
 	debugi("nd_vid", node->nd_vid);
 	if (!popped) {
-	    ADD_INSN2(ret, line, getinstancevariable,
+	    ADD_INSN2(ret, line_node, getinstancevariable,
 		      ID2SYM(node->nd_vid),
 		      get_ivar_ic_value(iseq,node->nd_vid));
 	}
@@ -8601,26 +8649,26 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
 	    LABEL *lend = NEW_LABEL(line);
 	    int ic_index = body->is_size++;
 
-            ADD_INSN2(ret, line, opt_getinlinecache, lend, INT2FIX(ic_index));
-            ADD_INSN1(ret, line, putobject, Qtrue);
-            ADD_INSN1(ret, line, getconstant, ID2SYM(node->nd_vid));
-            ADD_INSN1(ret, line, opt_setinlinecache, INT2FIX(ic_index));
+            ADD_INSN2(ret, line_node, opt_getinlinecache, lend, INT2FIX(ic_index));
+            ADD_INSN1(ret, line_node, putobject, Qtrue);
+            ADD_INSN1(ret, line_node, getconstant, ID2SYM(node->nd_vid));
+            ADD_INSN1(ret, line_node, opt_setinlinecache, INT2FIX(ic_index));
 	    ADD_LABEL(ret, lend);
 	}
 	else {
-	    ADD_INSN(ret, line, putnil);
-            ADD_INSN1(ret, line, putobject, Qtrue);
-            ADD_INSN1(ret, line, getconstant, ID2SYM(node->nd_vid));
+	    ADD_INSN(ret, line_node, putnil);
+            ADD_INSN1(ret, line_node, putobject, Qtrue);
+            ADD_INSN1(ret, line_node, getconstant, ID2SYM(node->nd_vid));
 	}
 
 	if (popped) {
-	    ADD_INSN(ret, line, pop);
+	    ADD_INSN(ret, line_node, pop);
 	}
 	break;
       }
       case NODE_CVAR:{
 	if (!popped) {
-	    ADD_INSN1(ret, line, getclassvariable,
+	    ADD_INSN1(ret, line_node, getclassvariable,
 		      ID2SYM(node->nd_vid));
 	}
 	break;
@@ -8628,17 +8676,17 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
       case NODE_NTH_REF:{
         if (!popped) {
 	    if (!node->nd_nth) {
-		ADD_INSN(ret, line, putnil);
+		ADD_INSN(ret, line_node, putnil);
 		break;
 	    }
-	    ADD_INSN2(ret, line, getspecial, INT2FIX(1) /* '~'  */,
+	    ADD_INSN2(ret, line_node, getspecial, INT2FIX(1) /* '~'  */,
 		      INT2FIX(node->nd_nth << 1));
 	}
 	break;
       }
       case NODE_BACK_REF:{
 	if (!popped) {
-	    ADD_INSN2(ret, line, getspecial, INT2FIX(1) /* '~' */,
+	    ADD_INSN2(ret, line_node, getspecial, INT2FIX(1) /* '~' */,
 		      INT2FIX(0x01 | (node->nd_nth << 1)));
 	}
 	break;
@@ -8653,8 +8701,8 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
 	INIT_ANCHOR(val);
 	switch (nd_type(node)) {
 	  case NODE_MATCH:
-	    ADD_INSN1(recv, line, putobject, node->nd_lit);
-	    ADD_INSN2(val, line, getspecial, INT2FIX(0),
+	    ADD_INSN1(recv, line_node, putobject, node->nd_lit);
+	    ADD_INSN2(val, line_node, getspecial, INT2FIX(0),
 		      INT2FIX(0));
 	    break;
 	  case NODE_MATCH2:
@@ -8669,21 +8717,21 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
 
         ADD_SEQ(ret, recv);
         ADD_SEQ(ret, val);
-        ADD_SEND(ret, line, idEqTilde, INT2FIX(1));
+        ADD_SEND(ret, line_node, idEqTilde, INT2FIX(1));
 
 	if (node->nd_args) {
 	    compile_named_capture_assign(iseq, ret, node->nd_args);
 	}
 
 	if (popped) {
-	    ADD_INSN(ret, line, pop);
+	    ADD_INSN(ret, line_node, pop);
 	}
 	break;
       }
       case NODE_LIT:{
 	debugp_param("lit", node->nd_lit);
 	if (!popped) {
-	    ADD_INSN1(ret, line, putobject, node->nd_lit);
+	    ADD_INSN1(ret, line_node, putobject, node->nd_lit);
             RB_OBJ_WRITTEN(iseq, Qundef, node->nd_lit);
 	}
 	break;
@@ -8694,7 +8742,7 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
 	    VALUE lit = node->nd_lit;
 	    if (!ISEQ_COMPILE_DATA(iseq)->option->frozen_string_literal) {
 		lit = rb_fstring(lit);
-		ADD_INSN1(ret, line, putstring, lit);
+		ADD_INSN1(ret, line_node, putstring, lit);
                 RB_OBJ_WRITTEN(iseq, Qundef, lit);
 	    }
 	    else {
@@ -8707,7 +8755,7 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
 		else {
 		    lit = rb_fstring(lit);
 		}
-		ADD_INSN1(ret, line, putobject, lit);
+		ADD_INSN1(ret, line_node, putobject, lit);
                 RB_OBJ_WRITTEN(iseq, Qundef, lit);
 	    }
 	}
@@ -8717,29 +8765,29 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
 	compile_dstr(iseq, ret, node);
 
 	if (popped) {
-	    ADD_INSN(ret, line, pop);
+	    ADD_INSN(ret, line_node, pop);
 	}
 	break;
       }
       case NODE_XSTR:{
-	ADD_CALL_RECEIVER(ret, line);
+	ADD_CALL_RECEIVER(ret, line_node);
         VALUE str = rb_fstring(node->nd_lit);
-	ADD_INSN1(ret, line, putobject, str);
+	ADD_INSN1(ret, line_node, putobject, str);
         RB_OBJ_WRITTEN(iseq, Qundef, str);
-	ADD_CALL(ret, line, idBackquote, INT2FIX(1));
+	ADD_CALL(ret, line_node, idBackquote, INT2FIX(1));
 
 	if (popped) {
-	    ADD_INSN(ret, line, pop);
+	    ADD_INSN(ret, line_node, pop);
 	}
 	break;
       }
       case NODE_DXSTR:{
-	ADD_CALL_RECEIVER(ret, line);
+	ADD_CALL_RECEIVER(ret, line_node);
 	compile_dstr(iseq, ret, node);
-	ADD_CALL(ret, line, idBackquote, INT2FIX(1));
+	ADD_CALL(ret, line_node, idBackquote, INT2FIX(1));
 
 	if (popped) {
-	    ADD_INSN(ret, line, pop);
+	    ADD_INSN(ret, line_node, pop);
 	}
 	break;
       }
@@ -8750,7 +8798,7 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
 	compile_dregx(iseq, ret, node);
 
 	if (popped) {
-	    ADD_INSN(ret, line, pop);
+	    ADD_INSN(ret, line_node, pop);
 	}
 	break;
       }
@@ -8759,51 +8807,51 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
 	const rb_iseq_t *block_iseq;
 	block_iseq = NEW_CHILD_ISEQ(node->nd_body, make_name_for_block(iseq), ISEQ_TYPE_PLAIN, line);
 
-	ADD_INSN2(ret, line, once, block_iseq, INT2FIX(ic_index));
+	ADD_INSN2(ret, line_node, once, block_iseq, INT2FIX(ic_index));
         RB_OBJ_WRITTEN(iseq, Qundef, (VALUE)block_iseq);
 
 	if (popped) {
-	    ADD_INSN(ret, line, pop);
+	    ADD_INSN(ret, line_node, pop);
 	}
 	break;
       }
       case NODE_ARGSCAT:{
 	if (popped) {
 	    CHECK(COMPILE(ret, "argscat head", node->nd_head));
-	    ADD_INSN1(ret, line, splatarray, Qfalse);
-	    ADD_INSN(ret, line, pop);
+	    ADD_INSN1(ret, line_node, splatarray, Qfalse);
+	    ADD_INSN(ret, line_node, pop);
 	    CHECK(COMPILE(ret, "argscat body", node->nd_body));
-	    ADD_INSN1(ret, line, splatarray, Qfalse);
-	    ADD_INSN(ret, line, pop);
+	    ADD_INSN1(ret, line_node, splatarray, Qfalse);
+	    ADD_INSN(ret, line_node, pop);
 	}
 	else {
 	    CHECK(COMPILE(ret, "argscat head", node->nd_head));
 	    CHECK(COMPILE(ret, "argscat body", node->nd_body));
-	    ADD_INSN(ret, line, concatarray);
+	    ADD_INSN(ret, line_node, concatarray);
 	}
 	break;
       }
       case NODE_ARGSPUSH:{
 	if (popped) {
 	    CHECK(COMPILE(ret, "arsgpush head", node->nd_head));
-	    ADD_INSN1(ret, line, splatarray, Qfalse);
-	    ADD_INSN(ret, line, pop);
+	    ADD_INSN1(ret, line_node, splatarray, Qfalse);
+	    ADD_INSN(ret, line_node, pop);
 	    CHECK(COMPILE_(ret, "argspush body", node->nd_body, popped));
 	}
 	else {
 	    CHECK(COMPILE(ret, "arsgpush head", node->nd_head));
 	    CHECK(COMPILE_(ret, "argspush body", node->nd_body, popped));
-	    ADD_INSN1(ret, line, newarray, INT2FIX(1));
-	    ADD_INSN(ret, line, concatarray);
+	    ADD_INSN1(ret, line_node, newarray, INT2FIX(1));
+	    ADD_INSN(ret, line_node, concatarray);
 	}
 	break;
       }
       case NODE_SPLAT:{
 	CHECK(COMPILE(ret, "splat", node->nd_head));
-	ADD_INSN1(ret, line, splatarray, Qtrue);
+	ADD_INSN1(ret, line_node, splatarray, Qtrue);
 
 	if (popped) {
-	    ADD_INSN(ret, line, pop);
+	    ADD_INSN(ret, line_node, pop);
 	}
 	break;
       }
@@ -8814,11 +8862,11 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
 						ISEQ_TYPE_METHOD, line);
 
 	debugp_param("defn/iseq", rb_iseqw_new(method_iseq));
-        ADD_INSN2(ret, line, definemethod, ID2SYM(mid), method_iseq);
+        ADD_INSN2(ret, line_node, definemethod, ID2SYM(mid), method_iseq);
         RB_OBJ_WRITTEN(iseq, Qundef, (VALUE)method_iseq);
 
         if (!popped) {
-            ADD_INSN1(ret, line, putobject, ID2SYM(mid));
+            ADD_INSN1(ret, line_node, putobject, ID2SYM(mid));
 	}
 
 	break;
@@ -8831,45 +8879,45 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
 
         debugp_param("defs/iseq", rb_iseqw_new(singleton_method_iseq));
         CHECK(COMPILE(ret, "defs: recv", node->nd_recv));
-        ADD_INSN2(ret, line, definesmethod, ID2SYM(mid), singleton_method_iseq);
+        ADD_INSN2(ret, line_node, definesmethod, ID2SYM(mid), singleton_method_iseq);
         RB_OBJ_WRITTEN(iseq, Qundef, (VALUE)singleton_method_iseq);
 
         if (!popped) {
-            ADD_INSN1(ret, line, putobject, ID2SYM(mid));
+            ADD_INSN1(ret, line_node, putobject, ID2SYM(mid));
         }
 	break;
       }
       case NODE_ALIAS:{
-	ADD_INSN1(ret, line, putspecialobject, INT2FIX(VM_SPECIAL_OBJECT_VMCORE));
-	ADD_INSN1(ret, line, putspecialobject, INT2FIX(VM_SPECIAL_OBJECT_CBASE));
+	ADD_INSN1(ret, line_node, putspecialobject, INT2FIX(VM_SPECIAL_OBJECT_VMCORE));
+	ADD_INSN1(ret, line_node, putspecialobject, INT2FIX(VM_SPECIAL_OBJECT_CBASE));
 	CHECK(COMPILE(ret, "alias arg1", node->nd_1st));
 	CHECK(COMPILE(ret, "alias arg2", node->nd_2nd));
-	ADD_SEND(ret, line, id_core_set_method_alias, INT2FIX(3));
+	ADD_SEND(ret, line_node, id_core_set_method_alias, INT2FIX(3));
 
 	if (popped) {
-	    ADD_INSN(ret, line, pop);
+	    ADD_INSN(ret, line_node, pop);
 	}
 	break;
       }
       case NODE_VALIAS:{
-	ADD_INSN1(ret, line, putspecialobject, INT2FIX(VM_SPECIAL_OBJECT_VMCORE));
-	ADD_INSN1(ret, line, putobject, ID2SYM(node->nd_alias));
-	ADD_INSN1(ret, line, putobject, ID2SYM(node->nd_orig));
-	ADD_SEND(ret, line, id_core_set_variable_alias, INT2FIX(2));
+	ADD_INSN1(ret, line_node, putspecialobject, INT2FIX(VM_SPECIAL_OBJECT_VMCORE));
+	ADD_INSN1(ret, line_node, putobject, ID2SYM(node->nd_alias));
+	ADD_INSN1(ret, line_node, putobject, ID2SYM(node->nd_orig));
+	ADD_SEND(ret, line_node, id_core_set_variable_alias, INT2FIX(2));
 
 	if (popped) {
-	    ADD_INSN(ret, line, pop);
+	    ADD_INSN(ret, line_node, pop);
 	}
 	break;
       }
       case NODE_UNDEF:{
-	ADD_INSN1(ret, line, putspecialobject, INT2FIX(VM_SPECIAL_OBJECT_VMCORE));
-	ADD_INSN1(ret, line, putspecialobject, INT2FIX(VM_SPECIAL_OBJECT_CBASE));
+	ADD_INSN1(ret, line_node, putspecialobject, INT2FIX(VM_SPECIAL_OBJECT_VMCORE));
+	ADD_INSN1(ret, line_node, putspecialobject, INT2FIX(VM_SPECIAL_OBJECT_CBASE));
 	CHECK(COMPILE(ret, "undef arg", node->nd_undef));
-	ADD_SEND(ret, line, id_core_undef_method, INT2FIX(2));
+	ADD_SEND(ret, line_node, id_core_undef_method, INT2FIX(2));
 
 	if (popped) {
-	    ADD_INSN(ret, line, pop);
+	    ADD_INSN(ret, line_node, pop);
 	}
 	break;
       }
@@ -8882,11 +8930,11 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
 	    compile_cpath(ret, iseq, node->nd_cpath);
 
 	CHECK(COMPILE(ret, "super", node->nd_super));
-	ADD_INSN3(ret, line, defineclass, ID2SYM(node->nd_cpath->nd_mid), class_iseq, INT2FIX(flags));
+	ADD_INSN3(ret, line_node, defineclass, ID2SYM(node->nd_cpath->nd_mid), class_iseq, INT2FIX(flags));
         RB_OBJ_WRITTEN(iseq, Qundef, (VALUE)class_iseq);
 
 	if (popped) {
-	    ADD_INSN(ret, line, pop);
+	    ADD_INSN(ret, line_node, pop);
 	}
 	break;
       }
@@ -8897,12 +8945,12 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
 	const int flags = VM_DEFINECLASS_TYPE_MODULE |
 	    compile_cpath(ret, iseq, node->nd_cpath);
 
-	ADD_INSN (ret, line, putnil); /* dummy */
-	ADD_INSN3(ret, line, defineclass, ID2SYM(node->nd_cpath->nd_mid), module_iseq, INT2FIX(flags));
+	ADD_INSN (ret, line_node, putnil); /* dummy */
+	ADD_INSN3(ret, line_node, defineclass, ID2SYM(node->nd_cpath->nd_mid), module_iseq, INT2FIX(flags));
         RB_OBJ_WRITTEN(iseq, Qundef, (VALUE)module_iseq);
 
 	if (popped) {
-	    ADD_INSN(ret, line, pop);
+	    ADD_INSN(ret, line_node, pop);
 	}
 	break;
       }
@@ -8912,15 +8960,15 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
 						    ISEQ_TYPE_CLASS, line);
 
 	CHECK(COMPILE(ret, "sclass#recv", node->nd_recv));
-	ADD_INSN (ret, line, putnil);
+	ADD_INSN (ret, line_node, putnil);
 	CONST_ID(singletonclass, "singletonclass");
-	ADD_INSN3(ret, line, defineclass,
+	ADD_INSN3(ret, line_node, defineclass,
 		  ID2SYM(singletonclass), singleton_class,
 		  INT2FIX(VM_DEFINECLASS_TYPE_SINGLETON_CLASS));
         RB_OBJ_WRITTEN(iseq, Qundef, (VALUE)singleton_class);
 
 	if (popped) {
-	    ADD_INSN(ret, line, pop);
+	    ADD_INSN(ret, line_node, pop);
 	}
 	break;
       }
@@ -8938,16 +8986,16 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
 	    CHECK(compile_const_prefix(iseq, node, pref, body));
 	    if (LIST_INSN_SIZE_ZERO(pref)) {
 		if (ISEQ_COMPILE_DATA(iseq)->option->inline_const_cache) {
-                    ADD_INSN2(ret, line, opt_getinlinecache, lend, INT2FIX(ic_index));
+                    ADD_INSN2(ret, line_node, opt_getinlinecache, lend, INT2FIX(ic_index));
 		}
 		else {
-		    ADD_INSN(ret, line, putnil);
+		    ADD_INSN(ret, line_node, putnil);
 		}
 
 		ADD_SEQ(ret, body);
 
 		if (ISEQ_COMPILE_DATA(iseq)->option->inline_const_cache) {
-                    ADD_INSN1(ret, line, opt_setinlinecache, INT2FIX(ic_index));
+                    ADD_INSN1(ret, line_node, opt_setinlinecache, INT2FIX(ic_index));
 		    ADD_LABEL(ret, lend);
 		}
 	    }
@@ -8958,12 +9006,12 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
 	}
 	else {
 	    /* function call */
-	    ADD_CALL_RECEIVER(ret, line);
+	    ADD_CALL_RECEIVER(ret, line_node);
 	    CHECK(COMPILE(ret, "colon2#nd_head", node->nd_head));
-	    ADD_CALL(ret, line, node->nd_mid, INT2FIX(1));
+	    ADD_CALL(ret, line_node, node->nd_mid, INT2FIX(1));
 	}
 	if (popped) {
-	    ADD_INSN(ret, line, pop);
+	    ADD_INSN(ret, line_node, pop);
 	}
 	break;
       }
@@ -8975,21 +9023,21 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
 
 	/* add cache insn */
 	if (ISEQ_COMPILE_DATA(iseq)->option->inline_const_cache) {
-            ADD_INSN2(ret, line, opt_getinlinecache, lend, INT2FIX(ic_index));
-	    ADD_INSN(ret, line, pop);
+            ADD_INSN2(ret, line_node, opt_getinlinecache, lend, INT2FIX(ic_index));
+	    ADD_INSN(ret, line_node, pop);
 	}
 
-	ADD_INSN1(ret, line, putobject, rb_cObject);
-        ADD_INSN1(ret, line, putobject, Qtrue);
-        ADD_INSN1(ret, line, getconstant, ID2SYM(node->nd_mid));
+	ADD_INSN1(ret, line_node, putobject, rb_cObject);
+        ADD_INSN1(ret, line_node, putobject, Qtrue);
+        ADD_INSN1(ret, line_node, getconstant, ID2SYM(node->nd_mid));
 
 	if (ISEQ_COMPILE_DATA(iseq)->option->inline_const_cache) {
-            ADD_INSN1(ret, line, opt_setinlinecache, INT2FIX(ic_index));
+            ADD_INSN1(ret, line_node, opt_setinlinecache, INT2FIX(ic_index));
 	    ADD_LABEL(ret, lend);
 	}
 
 	if (popped) {
-	    ADD_INSN(ret, line, pop);
+	    ADD_INSN(ret, line_node, pop);
 	}
 	break;
       }
@@ -9005,7 +9053,7 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
                 VALUE bv = nd_type(b) == NODE_LIT ? b->nd_lit : Qnil;
                 VALUE ev = nd_type(e) == NODE_LIT ? e->nd_lit : Qnil;
                 VALUE val = rb_range_new(bv, ev, excl);
-                ADD_INSN1(ret, line, putobject, val);
+                ADD_INSN1(ret, line_node, putobject, val);
                 RB_OBJ_WRITTEN(iseq, Qundef, val);
 	    }
 	}
@@ -9013,7 +9061,7 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
 	    CHECK(COMPILE_(ret, "min", b, popped));
 	    CHECK(COMPILE_(ret, "max", e, popped));
 	    if (!popped) {
-		ADD_INSN1(ret, line, newrange, flag);
+		ADD_INSN1(ret, line_node, newrange, flag);
 	    }
 	}
 	break;
@@ -9026,41 +9074,41 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
 	CHECK(compile_flip_flop(iseq, ret, node, type == NODE_FLIP2,
 				ltrue, lfalse));
 	ADD_LABEL(ret, ltrue);
-	ADD_INSN1(ret, line, putobject, Qtrue);
-	ADD_INSNL(ret, line, jump, lend);
+	ADD_INSN1(ret, line_node, putobject, Qtrue);
+	ADD_INSNL(ret, line_node, jump, lend);
 	ADD_LABEL(ret, lfalse);
-	ADD_INSN1(ret, line, putobject, Qfalse);
+	ADD_INSN1(ret, line_node, putobject, Qfalse);
 	ADD_LABEL(ret, lend);
 	break;
       }
       case NODE_SELF:{
 	if (!popped) {
-	    ADD_INSN(ret, line, putself);
+	    ADD_INSN(ret, line_node, putself);
 	}
 	break;
       }
       case NODE_NIL:{
 	if (!popped) {
-	    ADD_INSN(ret, line, putnil);
+	    ADD_INSN(ret, line_node, putnil);
 	}
 	break;
       }
       case NODE_TRUE:{
 	if (!popped) {
-	    ADD_INSN1(ret, line, putobject, Qtrue);
+	    ADD_INSN1(ret, line_node, putobject, Qtrue);
 	}
 	break;
       }
       case NODE_FALSE:{
 	if (!popped) {
-	    ADD_INSN1(ret, line, putobject, Qfalse);
+	    ADD_INSN1(ret, line_node, putobject, Qfalse);
 	}
 	break;
       }
       case NODE_ERRINFO:{
 	if (!popped) {
 	    if (body->type == ISEQ_TYPE_RESCUE) {
-		ADD_GETLOCAL(ret, line, LVAR_ERRINFO, 0);
+		ADD_GETLOCAL(ret, line_node, LVAR_ERRINFO, 0);
 	    }
 	    else {
 		const rb_iseq_t *ip = iseq;
@@ -9073,10 +9121,10 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
 		    level++;
 		}
 		if (ip) {
-		    ADD_GETLOCAL(ret, line, LVAR_ERRINFO, level);
+		    ADD_GETLOCAL(ret, line_node, LVAR_ERRINFO, level);
 		}
 		else {
-		    ADD_INSN(ret, line, putnil);
+		    ADD_INSN(ret, line_node, putnil);
 		}
 	    }
 	}
@@ -9098,11 +9146,11 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
             new_child_iseq_with_callback(iseq, ifunc,
 				 rb_fstring(make_name_for_block(iseq)), iseq, ISEQ_TYPE_BLOCK, line);
 
-	ADD_INSN2(ret, line, once, once_iseq, INT2FIX(is_index));
+	ADD_INSN2(ret, line_node, once, once_iseq, INT2FIX(is_index));
         RB_OBJ_WRITTEN(iseq, Qundef, (VALUE)once_iseq);
 
 	if (popped) {
-	    ADD_INSN(ret, line, pop);
+	    ADD_INSN(ret, line_node, pop);
 	}
 	break;
       }
@@ -9131,8 +9179,8 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
 		int kw_bits_idx = body->local_table_size - body->param.keyword->bits_start;
 		int keyword_idx = body->param.keyword->num;
 
-		ADD_INSN2(ret, line, checkkeyword, INT2FIX(kw_bits_idx + VM_ENV_DATA_SIZE - 1), INT2FIX(keyword_idx));
-		ADD_INSNL(ret, line, branchif, end_label);
+		ADD_INSN2(ret, line_node, checkkeyword, INT2FIX(kw_bits_idx + VM_ENV_DATA_SIZE - 1), INT2FIX(keyword_idx));
+		ADD_INSNL(ret, line_node, branchif, end_label);
 		CHECK(COMPILE_POPPED(ret, "keyword default argument", node->nd_body));
 		ADD_LABEL(ret, end_label);
 	    }
@@ -9142,10 +9190,10 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
       case NODE_DSYM:{
 	compile_dstr(iseq, ret, node);
 	if (!popped) {
-	    ADD_INSN(ret, line, intern);
+	    ADD_INSN(ret, line_node, intern);
 	}
 	else {
-	    ADD_INSN(ret, line, pop);
+	    ADD_INSN(ret, line_node, pop);
 	}
 	break;
       }
@@ -9172,13 +9220,13 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
 	    CHECK(COMPILE(ret, "recv", node->nd_recv));
 	    CHECK(COMPILE(ret, "value", node->nd_args->nd_next->nd_head));
 	    if (!popped) {
-		ADD_INSN(ret, line, swap);
-		ADD_INSN1(ret, line, topn, INT2FIX(1));
+		ADD_INSN(ret, line_node, swap);
+		ADD_INSN1(ret, line_node, topn, INT2FIX(1));
 	    }
-            ADD_INSN2(ret, line, opt_aset_with, str,
+            ADD_INSN2(ret, line_node, opt_aset_with, str,
                       new_callinfo(iseq, idASET, 2, 0, NULL, FALSE));
             RB_OBJ_WRITTEN(iseq, Qundef, str);
-	    ADD_INSN(ret, line, pop);
+	    ADD_INSN(ret, line_node, pop);
 	    break;
 	}
 
@@ -9197,40 +9245,40 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
 	if (!rb_is_attrset_id(mid)) {
 	    /* safe nav attr */
 	    mid = rb_id_attrset(mid);
-            else_label = qcall_branch_start(iseq, recv, &branches, node, line);
+            else_label = qcall_branch_start(iseq, recv, &branches, node, line_node);
 	}
 	if (!popped) {
-	    ADD_INSN(ret, line, putnil);
+	    ADD_INSN(ret, line_node, putnil);
 	    ADD_SEQ(ret, recv);
 	    ADD_SEQ(ret, args);
 
 	    if (flag & VM_CALL_ARGS_BLOCKARG) {
-		ADD_INSN1(ret, line, topn, INT2FIX(1));
+		ADD_INSN1(ret, line_node, topn, INT2FIX(1));
 		if (flag & VM_CALL_ARGS_SPLAT) {
-		    ADD_INSN1(ret, line, putobject, INT2FIX(-1));
-                    ADD_SEND_WITH_FLAG(ret, line, idAREF, INT2FIX(1), INT2FIX(asgnflag));
+		    ADD_INSN1(ret, line_node, putobject, INT2FIX(-1));
+                    ADD_SEND_WITH_FLAG(ret, line_node, idAREF, INT2FIX(1), INT2FIX(asgnflag));
 		}
-		ADD_INSN1(ret, line, setn, FIXNUM_INC(argc, 3));
-		ADD_INSN (ret, line, pop);
+		ADD_INSN1(ret, line_node, setn, FIXNUM_INC(argc, 3));
+		ADD_INSN (ret, line_node, pop);
 	    }
 	    else if (flag & VM_CALL_ARGS_SPLAT) {
-		ADD_INSN(ret, line, dup);
-		ADD_INSN1(ret, line, putobject, INT2FIX(-1));
-                ADD_SEND_WITH_FLAG(ret, line, idAREF, INT2FIX(1), INT2FIX(asgnflag));
-		ADD_INSN1(ret, line, setn, FIXNUM_INC(argc, 2));
-		ADD_INSN (ret, line, pop);
+		ADD_INSN(ret, line_node, dup);
+		ADD_INSN1(ret, line_node, putobject, INT2FIX(-1));
+                ADD_SEND_WITH_FLAG(ret, line_node, idAREF, INT2FIX(1), INT2FIX(asgnflag));
+		ADD_INSN1(ret, line_node, setn, FIXNUM_INC(argc, 2));
+		ADD_INSN (ret, line_node, pop);
 	    }
 	    else {
-		ADD_INSN1(ret, line, setn, FIXNUM_INC(argc, 1));
+		ADD_INSN1(ret, line_node, setn, FIXNUM_INC(argc, 1));
 	    }
 	}
 	else {
 	    ADD_SEQ(ret, recv);
 	    ADD_SEQ(ret, args);
 	}
-	ADD_SEND_WITH_FLAG(ret, line, mid, argc, INT2FIX(flag));
-        qcall_branch_end(iseq, ret, else_label, branches, node, line);
-	ADD_INSN(ret, line, pop);
+	ADD_SEND_WITH_FLAG(ret, line_node, mid, argc, INT2FIX(flag));
+        qcall_branch_end(iseq, ret, else_label, branches, node, line_node);
+	ADD_INSN(ret, line_node, pop);
 
 	break;
       }
@@ -9239,12 +9287,12 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, in
 	const rb_iseq_t *block = NEW_CHILD_ISEQ(node->nd_body, make_name_for_block(iseq), ISEQ_TYPE_BLOCK, line);
 	VALUE argc = INT2FIX(0);
 
-	ADD_INSN1(ret, line, putspecialobject, INT2FIX(VM_SPECIAL_OBJECT_VMCORE));
-	ADD_CALL_WITH_BLOCK(ret, line, idLambda, argc, block);
+	ADD_INSN1(ret, line_node, putspecialobject, INT2FIX(VM_SPECIAL_OBJECT_VMCORE));
+	ADD_CALL_WITH_BLOCK(ret, line_node, idLambda, argc, block);
         RB_OBJ_WRITTEN(iseq, Qundef, (VALUE)block);
 
 	if (popped) {
-	    ADD_INSN(ret, line, pop);
+	    ADD_INSN(ret, line_node, pop);
 	}
 	break;
       }
@@ -9694,8 +9742,9 @@ iseq_build_from_ary_body(rb_iseq_t *iseq, LINK_ANCHOR *const anchor,
                 argv = compile_data_calloc2(iseq, sizeof(VALUE), argc);
 
                 // add element before operand setup to make GC root
+                NODE dummy_line_node = generate_dummy_line_node(line_no, -1);
                 ADD_ELEM(anchor,
-                         (LINK_ELEMENT*)new_insn_core(iseq, line_no,
+                         (LINK_ELEMENT*)new_insn_core(iseq, &dummy_line_node,
                                                       (enum ruby_vminsn_type)insn_id, argc, argv));
 
 		for (j=0; j<argc; j++) {
@@ -9777,8 +9826,9 @@ iseq_build_from_ary_body(rb_iseq_t *iseq, LINK_ANCHOR *const anchor,
 		}
 	    }
             else {
+                NODE dummy_line_node = generate_dummy_line_node(line_no, -1);
                 ADD_ELEM(anchor,
-                         (LINK_ELEMENT*)new_insn_core(iseq, line_no,
+                         (LINK_ELEMENT*)new_insn_core(iseq, &dummy_line_node,
                                                       (enum ruby_vminsn_type)insn_id, argc, NULL));
             }
 	}
@@ -10135,8 +10185,9 @@ for_self_aref(rb_iseq_t *iseq, LINK_ANCHOR *ret, const void *a)
     body->param.lead_num = 0;
     body->param.size = 0;
 
-    ADD_INSN1(ret, line, putobject, args->arg);
-    ADD_INSN1(ret, line, invokebuiltin, args->func);
+    NODE dummy_line_node = generate_dummy_line_node(line, -1);
+    ADD_INSN1(ret, &dummy_line_node, putobject, args->arg);
+    ADD_INSN1(ret, &dummy_line_node, invokebuiltin, args->func);
 }
 
 static void
@@ -10151,9 +10202,10 @@ for_self_aset(rb_iseq_t *iseq, LINK_ANCHOR *ret, const void *a)
     body->param.lead_num = 1;
     body->param.size = 1;
 
-    ADD_GETLOCAL(ret, line, numberof(vars)-1, 0);
-    ADD_INSN1(ret, line, putobject, args->arg);
-    ADD_INSN1(ret, line, invokebuiltin, args->func);
+    NODE dummy_line_node = generate_dummy_line_node(line, -1);
+    ADD_GETLOCAL(ret, &dummy_line_node, numberof(vars)-1, 0);
+    ADD_INSN1(ret, &dummy_line_node, putobject, args->arg);
+    ADD_INSN1(ret, &dummy_line_node, invokebuiltin, args->func);
 }
 
 /*

--- a/iseq.h
+++ b/iseq.h
@@ -17,6 +17,8 @@ RUBY_EXTERN const int ruby_api_version[];
 #define ISEQ_MAJOR_VERSION ((unsigned int)ruby_api_version[0])
 #define ISEQ_MINOR_VERSION ((unsigned int)ruby_api_version[1])
 
+//#define EXPERIMENTAL_ISEQ_NODE_ID
+
 #ifndef rb_iseq_t
 typedef struct rb_iseq_struct rb_iseq_t;
 #define rb_iseq_t rb_iseq_t
@@ -176,6 +178,9 @@ void rb_iseq_mark_insn_storage(struct iseq_compile_data_storage *arena);
 VALUE rb_iseq_load(VALUE data, VALUE parent, VALUE opt);
 VALUE rb_iseq_parameters(const rb_iseq_t *iseq, int is_proc);
 unsigned int rb_iseq_line_no(const rb_iseq_t *iseq, size_t pos);
+#ifdef EXPERIMENTAL_ISEQ_NODE_ID
+int rb_iseq_node_id(const rb_iseq_t *iseq, size_t pos);
+#endif
 void rb_iseq_trace_set(const rb_iseq_t *iseq, rb_event_flag_t turnon_events);
 void rb_iseq_trace_set_all(rb_event_flag_t turnon_events);
 void rb_iseq_insns_info_encode_positions(const rb_iseq_t *iseq);
@@ -213,6 +218,9 @@ struct rb_compile_option_struct {
 
 struct iseq_insn_info_entry {
     int line_no;
+#ifdef EXPERIMENTAL_ISEQ_NODE_ID
+    int node_id;
+#endif
     rb_event_flag_t events;
 };
 


### PR DESCRIPTION
... then, new_insn_core extracts nd_line(node).

Also, if a macro "EXPERIMENTAL_ISEQ_NODE_ID" is defined, this changeset
keeps nd_node_id(node) for each instruction. This is intended for
TypeProf to identify what AST::Node corresponds to each instruction.

This patch is originally authored by @yui-knk for showing which column a
NoMethodError occurred.

https://github.com/ruby/ruby/compare/master...yui-knk:feature/node_id

Co-Authored-By: Yuichiro Kaneko <yui-knk@ruby-lang.org>