### PR TITLE
Wake up join list within thread EC context.

### DIFF
--- a/scheduler.c
+++ b/scheduler.c
@@ -55,11 +55,35 @@ rb_fiber_scheduler_get(void)
     return thread->scheduler;
 }
 
+static void
+verify_interface(VALUE scheduler)
+{
+    if (!rb_respond_to(scheduler, id_block)) {
+        rb_raise(rb_eArgError, "Scheduler must implement #block!");
+    }
+
+    if (!rb_respond_to(scheduler, id_unblock)) {
+        rb_raise(rb_eArgError, "Scheduler must implement #unblock!");
+    }
+
+    if (!rb_respond_to(scheduler, id_kernel_sleep)) {
+        rb_raise(rb_eArgError, "Scheduler must implement #kernel_sleep!");
+    }
+
+    if (!rb_respond_to(scheduler, id_io_wait)) {
+        rb_raise(rb_eArgError, "Scheduler must implement #io_wait!");
+    }
+}
+
 VALUE
 rb_fiber_scheduler_set(VALUE scheduler)
 {
     rb_thread_t *thread = GET_THREAD();
     VM_ASSERT(thread);
+
+    if (scheduler != Qnil) {
+        verify_interface(scheduler);
+    }
 
     // We invoke Scheduler#close when setting it to something else, to ensure the previous scheduler runs to completion before changing the scheduler. That way, we do not need to consider interactions, e.g., of a Fiber from the previous scheduler with the new scheduler.
     if (thread->scheduler != Qnil) {

--- a/test/fiber/scheduler.rb
+++ b/test/fiber/scheduler.rb
@@ -230,3 +230,11 @@ class Scheduler
     end.value
   end
 end
+
+class BrokenUnblockScheduler < Scheduler
+  def unblock(blocker, fiber)
+    super
+
+    raise "Broken unblock!"
+  end
+end

--- a/test/fiber/test_scheduler.rb
+++ b/test/fiber/test_scheduler.rb
@@ -66,9 +66,23 @@ class TestFiberScheduler < Test::Unit::TestCase
     RUBY
   end
 
-  def test_optional_close
+  def test_minimal_interface
+    scheduler = Object.new
+
+    def scheduler.block
+    end
+
+    def scheduler.unblock
+    end
+
+    def scheduler.io_wait
+    end
+
+    def scheduler.kernel_sleep
+    end
+
     thread = Thread.new do
-      Fiber.set_scheduler Object.new
+      Fiber.set_scheduler scheduler
     end
 
     thread.join

--- a/test/fiber/test_sleep.rb
+++ b/test/fiber/test_sleep.rb
@@ -43,4 +43,26 @@ class TestFiberSleep < Test::Unit::TestCase
 
     assert_operator seconds, :>=, 2, "actual: %p" % seconds
   end
+
+  def test_broken_sleep
+    thread = Thread.new do
+      Thread.current.report_on_exception = false
+
+      scheduler = Scheduler.new
+
+      def scheduler.kernel_sleep(duration = nil)
+        raise "Broken sleep!"
+      end
+
+      Fiber.set_scheduler scheduler
+
+      Fiber.schedule do
+        sleep 0
+      end
+    end
+
+    assert_raise(RuntimeError) do
+      thread.join
+    end
+  end
 end

--- a/test/fiber/test_thread.rb
+++ b/test/fiber/test_thread.rb
@@ -42,4 +42,24 @@ class TestFiberThread < Test::Unit::TestCase
 
     assert_equal :done, thread.value
   end
+
+  def test_broken_unblock
+    thread = Thread.new do
+      Thread.current.report_on_exception = false
+
+      scheduler = BrokenUnblockScheduler.new
+
+      Fiber.set_scheduler scheduler
+
+      Fiber.schedule do
+        Thread.new{}.join
+      end
+
+      scheduler.run
+    end
+
+    assert_raise(RuntimeError) do
+      thread.join
+    end
+  end
 end

--- a/thread.c
+++ b/thread.c
@@ -542,6 +542,9 @@ rb_threadptr_join_list_wakeup(rb_thread_t *thread)
     struct rb_waiting_list *join_list = thread->join_list;
 
     while (join_list) {
+        // Consume the entry from the join list:
+        thread->join_list = join_list->next;
+
         rb_thread_t *target_thread = join_list->thread;
 
         if (target_thread->scheduler != Qnil && rb_fiberptr_blocking(join_list->fiber) == 0) {

--- a/thread.c
+++ b/thread.c
@@ -874,6 +874,9 @@ thread_start_func_2(rb_thread_t *th, VALUE *stack_start)
 	    /* treat with normal error object */
 	    rb_threadptr_raise(ractor_main_th, 1, &errinfo);
 	}
+
+	rb_threadptr_join_list_wakeup(th);
+
 	EC_POP_TAG();
 
 	rb_ec_clear_current_thread_trace_func(th->ec);
@@ -890,7 +893,6 @@ thread_start_func_2(rb_thread_t *th, VALUE *stack_start)
             rb_threadptr_interrupt(ractor_main_th);
 	}
 
-        rb_threadptr_join_list_wakeup(th);
         rb_threadptr_unlock_all_locking_mutexes(th);
         rb_check_deadlock(th->ractor);
 


### PR DESCRIPTION
It's possible for `rb_fiber_scheduler_unblock` to raise an exception. So, it should be done within an EC context otherwise it will segfault. Additionally, we need to process the join list atomically, so that exceptions won't cause us to enter an infinite loop processing the same join list over and over again.