### PR TITLE
Replace master/slave with controller/worker in pty.c

### DIFF
--- a/test/io/console/test_io_console.rb
+++ b/test/io/console/test_io_console.rb
@@ -49,45 +49,45 @@ defined?(PTY) and defined?(IO.console) and TestIO_Console.class_eval do
   Bug6116 = '[ruby-dev:45309]'
 
   def test_raw
-    helper {|m, s|
-      s.print "abc\n"
-      assert_equal("abc\r\n", m.gets)
-      assert_send([s, :echo?])
-      s.raw {
-        assert_not_send([s, :echo?], Bug6116)
-        s.print "def\n"
-        assert_equal("def\n", m.gets)
+    helper {|controller, worker|
+      worker.print "abc\n"
+      assert_equal("abc\r\n", controller.gets)
+      assert_send([worker, :echo?])
+      worker.raw {
+        assert_not_send([worker, :echo?], Bug6116)
+        worker.print "def\n"
+        assert_equal("def\n", controller.gets)
       }
-      assert_send([s, :echo?])
-      s.print "ghi\n"
-      assert_equal("ghi\r\n", m.gets)
+      assert_send([worker, :echo?])
+      worker.print "ghi\n"
+      assert_equal("ghi\r\n", controller.gets)
     }
   end
 
   def test_raw_minchar
     q = Thread::Queue.new
-    helper {|m, s|
+    helper {|controller, worker|
       len = 0
-      assert_equal([nil, 0], [s.getch(min: 0), len])
+      assert_equal([nil, 0], [worker.getch(min: 0), len])
       main = Thread.current
       go = false
       th = Thread.start {
         q.pop
         sleep 0.01 until main.stop?
         len += 1
-        m.print("a")
-        m.flush
+        controller.print("a")
+        controller.flush
         sleep 0.01 until go and main.stop?
         len += 10
-        m.print("1234567890")
-        m.flush
+        controller.print("1234567890")
+        controller.flush
       }
       begin
         sleep 0.1
         q.push(1)
-        assert_equal(["a", 1], [s.getch(min: 1), len])
+        assert_equal(["a", 1], [worker.getch(min: 1), len])
         go = true
-        assert_equal(["1", 11], [s.getch, len])
+        assert_equal(["1", 11], [worker.getch, len])
       ensure
         th.join
       end
@@ -95,18 +95,18 @@ defined?(PTY) and defined?(IO.console) and TestIO_Console.class_eval do
   end
 
   def test_raw_timeout
-    helper {|m, s|
+    helper {|controller, worker|
       len = 0
-      assert_equal([nil, 0], [s.getch(min: 0, time: 0.1), len])
+      assert_equal([nil, 0], [worker.getch(min: 0, time: 0.1), len])
       main = Thread.current
       th = Thread.start {
         sleep 0.01 until main.stop?
         len += 2
-        m.print("ab")
+        controller.print("ab")
       }
       begin
-        assert_equal(["a", 2], [s.getch(min: 1, time: 1), len])
-        assert_equal(["b", 2], [s.getch(time: 1), len])
+        assert_equal(["a", 2], [worker.getch(min: 1, time: 1), len])
+        assert_equal(["b", 2], [worker.getch(time: 1), len])
       ensure
         th.join
       end
@@ -114,114 +114,114 @@ defined?(PTY) and defined?(IO.console) and TestIO_Console.class_eval do
   end
 
   def test_raw!
-    helper {|m, s|
-      s.raw!
-      s.print "foo\n"
-      assert_equal("foo\n", m.gets)
+    helper {|controller, worker|
+      worker.raw!
+      worker.print "foo\n"
+      assert_equal("foo\n", controller.gets)
     }
   end
 
   def test_cooked
-    helper {|m, s|
-      assert_send([s, :echo?])
-      s.raw {
-        s.print "abc\n"
-        assert_equal("abc\n", m.gets)
-        assert_not_send([s, :echo?], Bug6116)
-        s.cooked {
-          assert_send([s, :echo?])
-          s.print "def\n"
-          assert_equal("def\r\n", m.gets)
+    helper {|controller, worker|
+      assert_send([worker, :echo?])
+      worker.raw {
+        worker.print "abc\n"
+        assert_equal("abc\n", controller.gets)
+        assert_not_send([worker, :echo?], Bug6116)
+        worker.cooked {
+          assert_send([worker, :echo?])
+          worker.print "def\n"
+          assert_equal("def\r\n", controller.gets)
         }
-        assert_not_send([s, :echo?], Bug6116)
+        assert_not_send([worker, :echo?], Bug6116)
       }
-      assert_send([s, :echo?])
-      s.print "ghi\n"
-      assert_equal("ghi\r\n", m.gets)
+      assert_send([worker, :echo?])
+      worker.print "ghi\n"
+      assert_equal("ghi\r\n", controller.gets)
     }
   end
 
   def test_echo
-    helper {|m, s|
-      assert_send([s, :echo?])
-      m.print "a"
-      assert_equal("a", m.readpartial(10))
+    helper {|controller, worker|
+      assert_send([worker, :echo?])
+      controller.print "a"
+      assert_equal("a", controller.readpartial(10))
     }
   end
 
   def test_noecho
-    helper {|m, s|
-      s.noecho {
-	assert_not_send([s, :echo?])
-	m.print "a"
+    helper {|controller, worker|
+      worker.noecho {
+	assert_not_send([worker, :echo?])
+	controller.print "a"
 	sleep 0.1
       }
-      m.print "b"
-      assert_equal("b", m.readpartial(10))
+      controller.print "b"
+      assert_equal("b", controller.readpartial(10))
     }
   end
 
   def test_noecho2
-    helper {|m, s|
-      assert_send([s, :echo?])
-      m.print "a\n"
+    helper {|controller, worker|
+      assert_send([worker, :echo?])
+      controller.print "a\n"
       sleep 0.1
-      s.print "b\n"
+      worker.print "b\n"
       sleep 0.1
-      assert_equal("a\r\nb\r\n", m.gets + m.gets)
-      assert_equal("a\n", s.gets)
-      s.noecho {
-        assert_not_send([s, :echo?])
-        m.print "a\n"
-        s.print "b\n"
-        assert_equal("b\r\n", m.gets)
-        assert_equal("a\n", s.gets)
+      assert_equal("a\r\nb\r\n", controller.gets + controller.gets)
+      assert_equal("a\n", worker.gets)
+      worker.noecho {
+        assert_not_send([worker, :echo?])
+        controller.print "a\n"
+        worker.print "b\n"
+        assert_equal("b\r\n", controller.gets)
+        assert_equal("a\n", worker.gets)
       }
-      assert_send([s, :echo?])
-      m.print "a\n"
+      assert_send([worker, :echo?])
+      controller.print "a\n"
       sleep 0.1
-      s.print "b\n"
+      worker.print "b\n"
       sleep 0.1
-      assert_equal("a\r\nb\r\n", m.gets + m.gets)
-      assert_equal("a\n", s.gets)
+      assert_equal("a\r\nb\r\n", controller.gets + controller.gets)
+      assert_equal("a\n", worker.gets)
     }
   end
 
   def test_setecho
-    helper {|m, s|
-      assert_send([s, :echo?])
-      s.echo = false
-      m.print "a"
+    helper {|controller, worker|
+      assert_send([worker, :echo?])
+      worker.echo = false
+      controller.print "a"
       sleep 0.1
-      s.echo = true
-      m.print "b"
-      assert_equal("b", m.readpartial(10))
+      worker.echo = true
+      controller.print "b"
+      assert_equal("b", controller.readpartial(10))
     }
   end
 
   def test_setecho2
-    helper {|m, s|
-      assert_send([s, :echo?])
-      m.print "a\n"
+    helper {|controller, worker|
+      assert_send([worker, :echo?])
+      controller.print "a\n"
       sleep 0.1
-      s.print "b\n"
+      worker.print "b\n"
       sleep 0.1
-      assert_equal("a\r\nb\r\n", m.gets + m.gets)
-      assert_equal("a\n", s.gets)
-      s.echo = false
-      assert_not_send([s, :echo?])
-      m.print "a\n"
-      s.print "b\n"
-      assert_equal("b\r\n", m.gets)
-      assert_equal("a\n", s.gets)
-      s.echo = true
-      assert_send([s, :echo?])
-      m.print "a\n"
+      assert_equal("a\r\nb\r\n", controller.gets + controller.gets)
+      assert_equal("a\n", worker.gets)
+      worker.echo = false
+      assert_not_send([worker, :echo?])
+      controller.print "a\n"
+      worker.print "b\n"
+      assert_equal("b\r\n", controller.gets)
+      assert_equal("a\n", worker.gets)
+      worker.echo = true
+      assert_send([worker, :echo?])
+      controller.print "a\n"
       sleep 0.1
-      s.print "b\n"
+      worker.print "b\n"
       sleep 0.1
-      assert_equal("a\r\nb\r\n", m.gets + m.gets)
-      assert_equal("a\n", s.gets)
+      assert_equal("a\r\nb\r\n", controller.gets + controller.gets)
+      assert_equal("a\n", worker.gets)
     }
   end
 
@@ -247,59 +247,59 @@ defined?(PTY) and defined?(IO.console) and TestIO_Console.class_eval do
   end
 
   def test_iflush
-    helper {|m, s|
-      m.print "a"
-      s.iflush
-      m.print "b\n"
-      m.flush
-      assert_equal("b\n", s.gets)
+    helper {|controller, worker|
+      controller.print "a"
+      worker.iflush
+      controller.print "b\n"
+      controller.flush
+      assert_equal("b\n", worker.gets)
     }
   end
 
   def test_oflush
-    helper {|m, s|
-      s.print "a"
-      s.oflush # oflush may be issued after "a" is already sent.
-      s.print "b"
-      s.flush
+    helper {|controller, worker|
+      worker.print "a"
+      worker.oflush # oflush may be issued after "a" is already sent.
+      worker.print "b"
+      worker.flush
       sleep 0.1
-      assert_include(["b", "ab"], m.readpartial(10))
+      assert_include(["b", "ab"], controller.readpartial(10))
     }
   end
 
   def test_ioflush
-    helper {|m, s|
-      m.print "a"
-      s.ioflush
-      m.print "b\n"
-      m.flush
-      assert_equal("b\n", s.gets)
+    helper {|controller, worker|
+      controller.print "a"
+      worker.ioflush
+      controller.print "b\n"
+      controller.flush
+      assert_equal("b\n", worker.gets)
     }
   end
 
   def test_ioflush2
-    helper {|m, s|
-      s.print "a"
-      s.ioflush # ioflush may be issued after "a" is already sent.
-      s.print "b"
-      s.flush
+    helper {|controller, worker|
+      worker.print "a"
+      worker.ioflush # ioflush may be issued after "a" is already sent.
+      worker.print "b"
+      worker.flush
       sleep 0.1
-      assert_include(["b", "ab"], m.readpartial(10))
+      assert_include(["b", "ab"], controller.readpartial(10))
     }
   end
 
   def test_winsize
-    helper {|m, s|
+    helper {|controller, worker|
       begin
-        assert_equal([0, 0], s.winsize)
+        assert_equal([0, 0], worker.winsize)
       rescue Errno::EINVAL # OpenSolaris 2009.06 TIOCGWINSZ causes Errno::EINVAL before TIOCSWINSZ.
       else
-        assert_equal([80, 25], s.winsize = [80, 25])
-        assert_equal([80, 25], s.winsize)
-        #assert_equal([80, 25], m.winsize)
-        assert_equal([100, 40], m.winsize = [100, 40])
-        #assert_equal([100, 40], s.winsize)
-        assert_equal([100, 40], m.winsize)
+        assert_equal([80, 25], worker.winsize = [80, 25])
+        assert_equal([80, 25], worker.winsize)
+        #assert_equal([80, 25], controller.winsize)
+        assert_equal([100, 40], controller.winsize = [100, 40])
+        #assert_equal([100, 40], worker.winsize)
+        assert_equal([100, 40], controller.winsize)
       end
     }
   end
@@ -408,14 +408,14 @@ defined?(PTY) and defined?(IO.console) and TestIO_Console.class_eval do
 
   private
   def helper
-    m, s = PTY.open
+    controller, worker = PTY.open
   rescue RuntimeError
     omit $!
   else
-    yield m, s
+    yield controller, worker
   ensure
-    m.close if m
-    s.close if s
+    controller.close if controller
+    worker.close if worker
   end
 
   def run_pty(src, n = 1)

--- a/test/ruby/test_rubyoptions.rb
+++ b/test/ruby/test_rubyoptions.rb
@@ -826,10 +826,10 @@ class TestRubyOptions < Test::Unit::TestCase
     result = nil
     IO.pipe {|r, w|
       begin
-        PTY.open {|m, s|
-          s.echo = false
-          m.print("\C-d")
-          pid = spawn(EnvUtil.rubybin, :in => s, :out => w)
+        PTY.open {|controller, worker|
+          worker.echo = false
+          controller.print("\C-d")
+          pid = spawn(EnvUtil.rubybin, :in => worker, :out => w)
           w.close
           assert_nothing_raised('[ruby-dev:37798]') do
             result = EnvUtil.timeout(3) {r.read}
@@ -842,13 +842,13 @@ class TestRubyOptions < Test::Unit::TestCase
     }
     assert_equal("", result, '[ruby-dev:37798]')
     IO.pipe {|r, w|
-      PTY.open {|m, s|
-	s.echo = false
-	pid = spawn(EnvUtil.rubybin, :in => s, :out => w)
+      PTY.open {|controller, worker|
+	worker.echo = false
+	pid = spawn(EnvUtil.rubybin, :in => worker, :out => w)
 	w.close
-	m.print("$stdin.read; p $stdin.gets\n\C-d")
-	m.print("abc\n\C-d")
-	m.print("zzz\n")
+	controller.print("$stdin.read; p $stdin.gets\n\C-d")
+	controller.print("abc\n\C-d")
+	controller.print("zzz\n")
 	result = r.read
 	Process.wait pid
       }

--- a/test/test_pty.rb
+++ b/test/test_pty.rb
@@ -75,9 +75,9 @@ class TestPTY < Test::Unit::TestCase
     assert_equal(2, ret.length)
     assert_equal(IO, ret[0].class)
     assert_equal(File, ret[1].class)
-    _, slave = ret
-    assert(slave.tty?)
-    assert(File.chardev?(slave.path))
+    _, worker = ret
+    assert(worker.tty?)
+    assert(File.chardev?(worker.path))
   ensure
     if ret
       ret[0].close
@@ -94,9 +94,9 @@ class TestPTY < Test::Unit::TestCase
       assert_equal(2, ret.length)
       assert_equal(IO, ret[0].class)
       assert_equal(File, ret[1].class)
-      _, slave = ret
-      assert(slave.tty?)
-      assert(File.chardev?(slave.path))
+      _, worker = ret
+      assert(worker.tty?)
+      assert(File.chardev?(worker.path))
       x
     }
   rescue RuntimeError
@@ -108,37 +108,37 @@ class TestPTY < Test::Unit::TestCase
   end
 
   def test_close_in_block
-    PTY.open {|master, slave|
-      slave.close
-      master.close
-      assert(slave.closed?)
-      assert(master.closed?)
+    PTY.open {|controller, worker|
+      worker.close
+      controller.close
+      assert(worker.closed?)
+      assert(controller.closed?)
     }
   rescue RuntimeError
     skip $!
   else
     assert_nothing_raised {
-      PTY.open {|master, slave|
-        slave.close
-        master.close
+      PTY.open {|controller, worker|
+        worker.close
+        controller.close
       }
     }
   end
 
   def test_open
-    PTY.open {|master, slave|
-      slave.puts "foo"
-      assert_equal("foo", master.gets.chomp)
-      master.puts "bar"
-      assert_equal("bar", slave.gets.chomp)
+    PTY.open {|controller, worker|
+      worker.puts "foo"
+      assert_equal("foo", controller.gets.chomp)
+      controller.puts "bar"
+      assert_equal("bar", worker.gets.chomp)
     }
   rescue RuntimeError
     skip $!
   end
 
   def test_stat_slave
-    PTY.open {|master, slave|
-      s =  File.stat(slave.path)
+    PTY.open {|controller, worker|
+      s =  File.stat(worker.path)
       assert_equal(Process.uid, s.uid)
       assert_equal(0600, s.mode & 0777)
     }
@@ -147,22 +147,22 @@ class TestPTY < Test::Unit::TestCase
   end
 
   def test_close_master
-    PTY.open {|master, slave|
-      master.close
-      assert_raise(EOFError) { slave.readpartial(10) }
+    PTY.open {|controller, worker|
+      controller.close
+      assert_raise(EOFError) { worker.readpartial(10) }
     }
   rescue RuntimeError
     skip $!
   end
 
   def test_close_slave
-    PTY.open {|master, slave|
-      slave.close
+    PTY.open {|controller, worker|
+      worker.close
       # This exception is platform dependent.
       assert_raise(
         EOFError,       # FreeBSD
         Errno::EIO      # GNU/Linux
-      ) { master.readpartial(10) }
+      ) { controller.readpartial(10) }
     }
   rescue RuntimeError
     skip $!
@@ -219,9 +219,9 @@ class TestPTY < Test::Unit::TestCase
   end
 
   def test_cloexec
-    PTY.open {|m, s|
-      assert(m.close_on_exec?)
-      assert(s.close_on_exec?)
+    PTY.open {|controller, worker|
+      assert(controller.close_on_exec?)
+      assert(worker.close_on_exec?)
     }
     PTY.spawn(RUBY, '-e', '') {|r, w, pid|
       begin


### PR DESCRIPTION
As per discussions on **Misc #17828: [Deprecate use of master and slave](https://bugs.ruby-lang.org/issues/17828)** on Ruby Issue Tracking System

Terms such as **master** and **slave** are replaced with new **controller** and **worker** respectively in `/ext/pty.c`. 

Although my first pick was **controller** and **agent** just like Jenkins community did, in the end, **controller** and **worker** were chosen to reflect the decisions and conventions followed by larger communities like Linux's.
Visit:
- https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=49decddd39e5f6132ccd7d9fdc3d7c470b0061bb
- https://en.wikipedia.org/wiki/Master/slave_(technology)#Replacements

Although tests were not discussed in the above thread, they are also taken care of in this PR as I decided that it would be confusing to retain both new and old terms existing.

Note: `/doc/pty/README.ja` and `/doc/pty/README.ja` are not modified nor removed as they contain copyright statements and explanations. I did not know what to do with them.

Any suggestions would be appreciated, including how to go on to modify the official documentations once this PR is accepted.