### PR TITLE
Silence `-Wsizeof-array-div` warning

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -6290,7 +6290,7 @@ mark_current_machine_context(rb_objspace_t *objspace, rb_execution_context_t *ec
 {
     union {
 	rb_jmp_buf j;
-	VALUE v[sizeof(rb_jmp_buf) / sizeof(VALUE)];
+	VALUE v[sizeof(rb_jmp_buf) / (sizeof(VALUE))];
     } save_regs_gc_mark;
     VALUE *stack_start, *stack_end;
 


### PR DESCRIPTION
```
../gc.c: In function 'mark_current_machine_context':
../gc.c:5955:36: warning: expression does not compute the number of elements in this array; element type is 'struct __jmp_buf_tag', not 'VALUE' {aka 'long unsigned int'} [-Wsizeof-array-div]
 5955 |         VALUE v[sizeof(rb_jmp_buf) / sizeof(VALUE)];
      |                                    ^
../gc.c:5955:36: note: add parentheses around the second 'sizeof' to silence this warning
```