### PR TITLE
Add specialized opt_new instruction

### DIFF
--- a/benchmark/object_allocate.yml
+++ b/benchmark/object_allocate.yml
@@ -18,4 +18,4 @@ benchmark:
   allocate_32_deep: ThirtyTwo.new
   allocate_64_deep: SixtyFour.new
   allocate_128_deep: OneTwentyEight.new
-loop_count: 100000
+loop_count: 1000000

--- a/bootstraptest/test_insns.rb
+++ b/bootstraptest/test_insns.rb
@@ -213,6 +213,10 @@ tests = [
     'true'.freeze
   },
 
+  [ 'opt_new',      %q{ Struct.new(:foo).new(true).foo }, ],
+  [ 'opt_new',      %q{ String.new("testing") == "testing"}, ],
+  [ 'opt_new',      %q{ Thread.new do; true; end.value } ],
+
   [ 'opt_newarray_max', %q{ [ ].max.nil? }, ],
   [ 'opt_newarray_max', %q{ [1, x = 2, 3].max == 3 }, ],
   [ 'opt_newarray_max', <<-'},', ], # {

--- a/defs/id.def
+++ b/defs/id.def
@@ -25,6 +25,7 @@ firstline, predefined = __LINE__+1, %[\
   send
   __send__
   __attached__
+  new
   initialize
   initialize_copy
   initialize_clone

--- a/insns.def
+++ b/insns.def
@@ -778,6 +778,25 @@ opt_send_without_block
     }
 }
 
+/* optimized new/initialize */
+DEFINE_INSN
+opt_new
+(CALL_DATA cd_new, CALL_DATA cd_init, ISEQ blockiseq)
+(...)
+(VALUE val)
+// attr bool handles_sp = true;
+// attr rb_snum_t sp_inc = sp_inc_of_sendish(cd_new->ci);
+// attr rb_snum_t comptime_sp_inc = sp_inc_of_sendish(ci_new);
+{
+    VALUE bh = vm_caller_setup_arg_block(ec, GET_CFP(), cd_new->ci, blockiseq, false);
+    val = vm_opt_new(ec, GET_CFP(), cd_new, cd_init, bh);
+
+    if (val == Qundef) {
+        RESTORE_REGS();
+        NEXT_INSN();
+    }
+}
+
 DEFINE_INSN
 opt_str_freeze
 (VALUE str, CALL_DATA cd)

--- a/internal/object.h
+++ b/internal/object.h
@@ -42,6 +42,7 @@ void rb_obj_copy_ivar(VALUE dest, VALUE obj);
 VALUE rb_false(VALUE obj);
 VALUE rb_convert_type_with_id(VALUE v, int t, const char* nam, ID mid);
 VALUE rb_obj_size(VALUE self, VALUE args, VALUE obj);
+VALUE rb_class_alloc(VALUE klass);
 MJIT_SYMBOL_EXPORT_END
 
 static inline void

--- a/lib/erb.rb
+++ b/lib/erb.rb
@@ -736,7 +736,7 @@ class ERB
     end
 
     def warn_invalid_trim_mode(mode, uplevel:)
-      warn "Invalid ERB trim mode: #{mode.inspect} (trim_mode: nil, 0, 1, 2, or String composed of '%' and/or '-', '>', '<>')", uplevel: uplevel + 1
+      warn "Invalid ERB trim mode: #{mode.inspect} (trim_mode: nil, 0, 1, 2, or String composed of '%' and/or '-', '>', '<>')", uplevel: uplevel
     end
   end
 end

--- a/object.c
+++ b/object.c
@@ -2075,7 +2075,7 @@ rb_class_alloc_m(VALUE klass)
     return class_call_alloc_func(allocator, klass);
 }
 
-static VALUE
+VALUE
 rb_class_alloc(VALUE klass)
 {
     rb_alloc_func_t allocator = class_get_alloc_func(klass);

--- a/test/objspace/test_objspace.rb
+++ b/test/objspace/test_objspace.rb
@@ -189,8 +189,8 @@ class TestObjSpace < Test::Unit::TestCase
       assert_equal(line1,    ObjectSpace.allocation_sourceline(o1))
       assert_equal(__FILE__, ObjectSpace.allocation_sourcefile(o1))
       assert_equal(c1,       ObjectSpace.allocation_generation(o1))
-      assert_equal(Class.name, ObjectSpace.allocation_class_path(o1))
-      assert_equal(:new,       ObjectSpace.allocation_method_id(o1))
+      assert_equal(self.class.name, ObjectSpace.allocation_class_path(o1))
+      assert_equal(__method__,      ObjectSpace.allocation_method_id(o1))
 
       assert_equal(__FILE__, ObjectSpace.allocation_sourcefile(o2))
       assert_equal(line2,    ObjectSpace.allocation_sourceline(o2))

--- a/test/ruby/test_settracefunc.rb
+++ b/test/ruby/test_settracefunc.rb
@@ -1778,7 +1778,7 @@ class TestSetTraceFunc < Test::Unit::TestCase
     TracePoint.new(:c_call, &capture_events).enable{
       c.new
     }
-    assert_equal [:c_call, :itself, :initialize], events[1]
+    assert_equal [:c_call, :itself, :initialize], events[0]
     events.clear
 
     o = Class.new{


### PR DESCRIPTION
This introduces a specialized `opt_new` instruction to replace all `new` calls. In the case that `new` is defined on the receiver as `rb_class_new_instance_pass_kw` (the default for `Class`) this instruction will allocate a new instance and directly call `initialize`. When `new` is overridden (or the object was never a class to begin with) we call `new` as we would have before.

The main advantage to this new instruction is that we are able to use an inline cache for resolving both `new` and `initialize`, previously `rb_class_new_instance_pass_kw` would use `rb_funcallv_kw` for initialize, which wasn't provided an inline cache.

One gotcha of adding this method is that `new` no longer appears in the backtrace when taking the optimized path. I don't think this is out of line with other optimized methods (`send` has the same behaviour).

    $ make benchmark ITEM=object_allocate COMPARE_RUBY="/home/jhawthorn/.rubies/ruby-trunk/bin/ruby"
    compare-ruby: ruby 3.1.0dev (2021-05-10T10:19:35Z master 73136ebbde) [x86_64-linux]
    built-ruby: ruby 3.1.0dev (2021-05-10T16:54:45Z initialize_cache4 385c28c586) [x86_64-linux]
    # Iteration per second (i/s)

    |                   |compare-ruby|built-ruby|
    |:------------------|-----------:|---------:|
    |allocate_8_deep    |     16.858M|   27.162M|
    |                   |           -|     1.61x|
    |allocate_32_deep   |     16.590M|   22.841M|
    |                   |           -|     1.38x|
    |allocate_64_deep   |     16.898M|   25.860M|
    |                   |           -|     1.53x|
    |allocate_128_deep  |     16.717M|   26.260M|
    |                   |           -|     1.57x|