### PR TITLE
Fix regex equivalency for fnmatch of the glob `*`

### DIFF
--- a/dir.c
+++ b/dir.c
@@ -3191,7 +3191,7 @@ fnmatch_brace(const char *pattern, VALUE val, void *enc)
  *
  *  <code>*</code>::
  *    Matches any file. Can be restricted by other values in the glob.
- *    Equivalent to <code>/ .* /x</code> in regexp.
+ *    Equivalent to <code>/ [^/]* /x</code> in regexp.
  *
  *    <code>*</code>::    Matches all files regular files
  *    <code>c*</code>::   Matches all files beginning with <code>c</code>


### PR DESCRIPTION
In Perl, or JavaScript, `.` matches any character, including `/`.

Documentation that offers regular expression equivalents should really use `[^/]` when they mean "character valid in filenames" and not `.`.