### PR TITLE
Match parens for hidden files parenthetical

### DIFF
--- a/dir.c
+++ b/dir.c
@@ -3199,7 +3199,7 @@ fnmatch_brace(const char *pattern, VALUE val, void *enc)
  *    <code>\*c*</code>:: Matches all files that have <code>c</code> in them
  *                        (including at the beginning or end).
  *
- *    To match hidden files (that start with a <code>.</code> set the
+ *    To match hidden files (that start with a <code>.</code>) set the
  *    File::FNM_DOTMATCH flag.
  *
  *  <code>**</code>::


### PR DESCRIPTION
The open `(` is unmatched here.