### PR TITLE
Fix compilation with jemalloc on macos

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2733,7 +2733,7 @@ main(int argc, char *argv[])
 ])
 
 AS_CASE([$target_os],
-    [darwin*], [ac_cv_header_sys_user_h=yes], dnl LIST_HEAD conflicts with sys/queue.h
+    [darwin*], [ac_cv_header_sys_user_h=no], dnl LIST_HEAD conflicts with sys/queue.h
     [AC_CHECK_HEADERS([sys/user.h])]
 )
 AS_IF([test "x$ac_cv_func_mmap:$ac_cv_header_sys_user_h" = xyes:yes], [


### PR DESCRIPTION
On darwin we avoid including `sys/user.h` to avoid a conflict. Previously we still ended up with `PAGE_SIZE` being defined because the headers for system malloc happened to define it. However, when compiling with jemalloc nothing would define `PAGE_SIZE`.

```
./configure --disable-install-doc --with-jemalloc && make gc.o
...
compiling gc.c
gc.c:10483:10: error: use of undeclared identifier 'PAGE_SIZE'
    if (!USE_MMAP_ALIGNED_ALLOC) {
```

This commit changes configure.ac so that we never use the `PAGE_SIZE` constant on darwin and to always use the `sysconf` fallback.

cc @peterzhu2118 