### PR TITLE
Fix `_MSC_VER` warnings

### DIFF
--- a/ext/win32ole/win32ole.c
+++ b/ext/win32ole/win32ole.c
@@ -995,7 +995,7 @@ ole_val2variant_ex(VALUE val, VARIANT *var, VARTYPE vt)
         }
         return;
     }
-#if (_MSC_VER >= 1300) || defined(__CYGWIN__) || defined(__MINGW32__)
+#if (defined(_MSC_VER) && (_MSC_VER >= 1300)) || defined(__CYGWIN__) || defined(__MINGW32__)
     switch(vt & ~VT_BYREF) {
     case VT_I8:
         V_VT(var) = VT_I8;
@@ -1009,7 +1009,7 @@ ole_val2variant_ex(VALUE val, VARIANT *var, VARTYPE vt)
         ole_val2variant2(val, var);
         break;
     }
-#else  /* (_MSC_VER >= 1300) || defined(__CYGWIN__) || defined(__MINGW32__) */
+#else  /* (defined(_MSC_VER) && (_MSC_VER >= 1300)) || defined(__CYGWIN__) || defined(__MINGW32__) */
     ole_val2variant2(val, var);
 #endif
 }
@@ -1063,7 +1063,7 @@ get_ptr_of_variant(VARIANT *pvar)
     case VT_R8:
         return &V_R8(pvar);
         break;
-#if (_MSC_VER >= 1300) || defined(__CYGWIN__) || defined(__MINGW32__)
+#if (defined(_MSC_VER) && (_MSC_VER >= 1300)) || defined(__CYGWIN__) || defined(__MINGW32__)
     case VT_I8:
         return &V_I8(pvar);
         break;
@@ -1550,10 +1550,10 @@ ole_variant2val(VARIANT *pvar)
             obj = RB_INT2NUM((long)V_UINT(pvar));
         break;
 
-#if (_MSC_VER >= 1300) || defined(__CYGWIN__) || defined(__MINGW32__)
+#if (defined(_MSC_VER) && (_MSC_VER >= 1300)) || defined(__CYGWIN__) || defined(__MINGW32__)
     case VT_I8:
         if(V_ISBYREF(pvar))
-#if (_MSC_VER >= 1300) || defined(__CYGWIN__) || defined(__MINGW32__)
+#if (defined(_MSC_VER) && (_MSC_VER >= 1300)) || defined(__CYGWIN__) || defined(__MINGW32__)
 #ifdef V_I8REF
             obj = I8_2_NUM(*V_I8REF(pvar));
 #endif
@@ -1565,7 +1565,7 @@ ole_variant2val(VARIANT *pvar)
         break;
     case VT_UI8:
         if(V_ISBYREF(pvar))
-#if (_MSC_VER >= 1300) || defined(__CYGWIN__) || defined(__MINGW32__)
+#if (defined(_MSC_VER) && (_MSC_VER >= 1300)) || defined(__CYGWIN__) || defined(__MINGW32__)
 #ifdef V_UI8REF
             obj = UI8_2_NUM(*V_UI8REF(pvar));
 #endif
@@ -1575,7 +1575,7 @@ ole_variant2val(VARIANT *pvar)
         else
             obj = UI8_2_NUM(V_UI8(pvar));
         break;
-#endif  /* (_MSC_VER >= 1300) || defined(__CYGWIN__) || defined(__MINGW32__) */
+#endif  /* (defined(_MSC_VER) && (_MSC_VER >= 1300)) || defined(__CYGWIN__) || defined(__MINGW32__) */
 
     case VT_R4:
         if(V_ISBYREF(pvar))
@@ -3753,7 +3753,7 @@ ole_typedesc2val(ITypeInfo *pTypeInfo, TYPEDESC *pTypeDesc, VALUE typedetails)
     case VT_UI4:
         typestr = rb_str_new2("UI4");
         break;
-#if (_MSC_VER >= 1300) || defined(__CYGWIN__) || defined(__MINGW32__)
+#if (defined(_MSC_VER) && (_MSC_VER >= 1300)) || defined(__CYGWIN__) || defined(__MINGW32__)
     case VT_I8:
         typestr = rb_str_new2("I8");
         break;

--- a/ext/win32ole/win32ole_variant.c
+++ b/ext/win32ole/win32ole_variant.c
@@ -94,7 +94,7 @@ ole_val2olevariantdata(VALUE val, VARTYPE vt, struct olevariantdata *pvar)
                 }
             }
         }
-#if (_MSC_VER >= 1300) || defined(__CYGWIN__) || defined(__MINGW32__)
+#if (defined(_MSC_VER) && (_MSC_VER >= 1300)) || defined(__CYGWIN__) || defined(__MINGW32__)
     } else if ( (vt & ~VT_BYREF) == VT_I8 || (vt & ~VT_BYREF) == VT_UI8) {
         ole_val2variant_ex(val, &(pvar->realvar), (vt & ~VT_BYREF));
         ole_val2variant_ex(val, &(pvar->var), (vt & ~VT_BYREF));
@@ -202,7 +202,7 @@ ole_set_byref(VARIANT *realvar, VARIANT *var,  VARTYPE vt)
             V_R8REF(var) = &V_R8(realvar);
             break;
 
-#if (_MSC_VER >= 1300) || defined(__CYGWIN__) || defined(__MINGW32__)
+#if (defined(_MSC_VER) && (_MSC_VER >= 1300)) || defined(__CYGWIN__) || defined(__MINGW32__)
 #ifdef V_I8REF
         case VT_I8:
             V_I8REF(var) = &V_I8(realvar);

--- a/ext/win32ole/win32ole_variant_m.c
+++ b/ext/win32ole/win32ole_variant_m.c
@@ -116,7 +116,7 @@ void Init_win32ole_variant_m(void)
      */
     rb_define_const(mWIN32OLE_VARIANT, "VT_UI4", RB_INT2FIX(VT_UI4));
 
-#if (_MSC_VER >= 1300) || defined(__CYGWIN__) || defined(__MINGW32__)
+#if (defined(_MSC_VER) && (_MSC_VER >= 1300)) || defined(__CYGWIN__) || defined(__MINGW32__)
     /*
      * represents VT_I8 type constant.
      */


### PR DESCRIPTION
`_MSC_VER` is not defined in win32ole/*.c

```
compiling win32ole.c
win32ole.c: In function ‘ole_val2variant_ex’:
win32ole.c:998:6: warning: "_MSC_VER" is not defined, evaluates to 0 [-Wundef]
  998 | #if (_MSC_VER >= 1300) || defined(__CYGWIN__) || defined(__MINGW32__)
      |      ^~~~~~~~
:
:
```