### PR TITLE
Add Related link from String#hash to Object#hash

### DIFF
--- a/string.c
+++ b/string.c
@@ -3311,6 +3311,8 @@ rb_str_hash_cmp(VALUE str1, VALUE str2)
  *
  * Returns the integer hash value for +self+.
  * The value is based on the length, content and encoding of +self+.
+ *
+ * Related: Object#hash
  */
 
 static VALUE


### PR DESCRIPTION
We came across a bug in our code because we assumed `String#hash` to be consistent across Ruby processes, which was incorrect.

Our search lead us to `Object#hash` which has the right warning that `String#hash` doesn't. We also noticed that a previous version of the documentation for `String#hash` pointed to `Object#hash` that was removed by https://github.com/ruby/ruby/pull/3565.
We think this removal might not be intended and just got missed amidst other changes.