### PR TITLE
[Win32] long path name support [Bug #12551]

### DIFF
--- a/test/ruby/test_process.rb
+++ b/test/ruby/test_process.rb
@@ -1771,6 +1771,7 @@ class TestProcess < Test::Unit::TestCase
     min = 1_000 / (cmd.size + sep.size)
     cmds = Array.new(min, cmd)
     exs = [Errno::ENOENT]
+    exs << Errno::EINVAL if windows?
     exs << Errno::E2BIG if defined?(Errno::E2BIG)
     opts = {[STDOUT, STDERR]=>File::NULL}
     opts[:rlimit_nproc] = 128 if defined?(Process::RLIMIT_NPROC)

--- a/win32/resource.rb
+++ b/win32/resource.rb
@@ -61,7 +61,7 @@ end
 #include <winver.h>
 
 #{icon || ''}
-1 24 "win32/ruby.manifest"
+#{type == 'VFT_APP' ? "1 RT_MANIFEST ruby.manifest" : ""}
 VS_VERSION_INFO VERSIONINFO
  FILEVERSION    #{nversion}
  PRODUCTVERSION #{nversion}
@@ -94,4 +94,3 @@ END
 EOF
   }
 end
-

--- a/win32/resource.rb
+++ b/win32/resource.rb
@@ -61,6 +61,7 @@ end
 #include <winver.h>
 
 #{icon || ''}
+1 24 "win32/ruby.manifest"
 VS_VERSION_INFO VERSIONINFO
  FILEVERSION    #{nversion}
  PRODUCTVERSION #{nversion}

--- a/win32/ruby.manifest
+++ b/win32/ruby.manifest
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings xmlns:ws2="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
+      <ws2:longPathAware>true</ws2:longPathAware>
+    </windowsSettings>
+  </application>
+</assembly>


### PR DESCRIPTION
Implement long path support on Windows by applying Microsoft's recommended application manifest.

To make this work on both Visual C++ and MinGW, include the manifest as a resource when generating the resource files. This way it will be embedded into the executables/libraries generated by both compilers.

It's important for the manifest resource to have ID 1, otherwise GCC will embed a default manifest. Resource type 24 corresponds to manifest resources.[1]

Note that in addition to this, the user needs to have long paths enabled either by modifying the registry or by enabling a group policy.[2]

[1]: https://docs.microsoft.com/en-us/windows/win32/menurc/resource-types
[2]: https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=cmd#enable-long-paths-in-windows-10-version-1607-and-later
