### PR TITLE
simple rescue+while+break should not use `throw`

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -5409,12 +5409,14 @@ add_ensure_range(rb_iseq_t *iseq, struct ensure_range *erange,
 static bool
 can_add_ensure_iseq(const rb_iseq_t *iseq)
 {
-    if (ISEQ_COMPILE_DATA(iseq)->in_rescue && ISEQ_COMPILE_DATA(iseq)->ensure_node_stack) {
-        return false;
+    struct iseq_compile_data_ensure_node_stack *e;
+    if (ISEQ_COMPILE_DATA(iseq)->in_rescue && (e = ISEQ_COMPILE_DATA(iseq)->ensure_node_stack) != NULL) {
+        while (e) {
+            if (e->ensure_node) return false;
+            e = e->prev;
+        }
     }
-    else {
-        return true;
-    }
+    return true;
 }
 
 static void

--- a/test/ruby/test_exception.rb
+++ b/test/ruby/test_exception.rb
@@ -104,6 +104,17 @@ class TestException < Test::Unit::TestCase
         end
       end
     end
+
+    iseq = RubyVM::InstructionSequence.compile(<<-RUBY)
+    begin
+      while true
+        break
+      end
+    rescue
+    end
+    RUBY
+
+    assert_equal false, iseq.to_a[13].any?{|(e,_)| e == :throw}
   end
 
   def test_exception_in_ensure_with_redo


### PR DESCRIPTION
609de71f043e8ba34f22b9993e444e2e5bb05709 fixes the issue by using
`throw` insn if `ensure` is used. However, that patch introduce
additional `throw` even if it is not needed. This patch solves
the issue.

This issue is pointed by @mame.