### PR TITLE
Build CDHASH properly when loading iseq from binary

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -10501,7 +10501,6 @@ ibf_table_find_or_insert(struct st_table *table, st_data_t key)
 static void ibf_dump_object_list(struct ibf_dump *dump, ibf_offset_t *obj_list_offset, unsigned int *obj_list_size);
 
 static VALUE ibf_load_object(const struct ibf_load *load, VALUE object_index);
-static VALUE ibf_load_cdhash(const struct ibf_load *load, VALUE object_index);
 static rb_iseq_t *ibf_load_iseq(const struct ibf_load *load, const rb_iseq_t *index_iseq);
 
 static st_table *
@@ -10773,7 +10772,12 @@ ibf_load_code(const struct ibf_load *load, rb_iseq_t *iseq, ibf_offset_t bytecod
               case TS_CDHASH:
                 {
                     VALUE op = ibf_load_small_value(load, &reading_pos);
-                    VALUE v = ibf_load_cdhash(load, op);
+                    VALUE v = ibf_load_object(load, op);
+                    v = rb_hash_dup(v); // hash dumped as frozen
+                    RHASH_TBL_RAW(v)->type = &cdhash_type;
+                    rb_hash_rehash(v); // hash function changed
+                    freeze_hide_obj(v);
+
                     code[code_index] = v;
                     RB_OBJ_WRITTEN(iseqv, Qundef, v);
                     FL_SET(iseqv, ISEQ_MARKABLE_ISEQ);
@@ -12116,60 +12120,6 @@ ibf_load_object(const struct ibf_load *load, VALUE object_index)
 #endif
         return obj;
     }
-}
-
-// Similar to ibf_load_object(), but specifically for CDHASH.
-static VALUE
-ibf_load_cdhash(const struct ibf_load *load, VALUE object_index)
-{
-    if (UNLIKELY(object_index == 0)) {
-        rb_raise(rb_eIndexError, "unexpected zero index for CDHASH operand");
-    }
-    VALUE cdhash = pinned_list_fetch(load->current_buffer->obj_list, (long)object_index);
-    if (!cdhash) {
-        ibf_offset_t *offsets = (ibf_offset_t *)(load->current_buffer->obj_list_offset + load->current_buffer->buff);
-        ibf_offset_t offset = offsets[object_index];
-        const struct ibf_object_header header = ibf_load_object_object_header(load, &offset);
-
-#if IBF_ISEQ_DEBUG
-        fprintf(stderr, "ibf_load_cdhash: list=%#x offsets=%p offset=%#x\n",
-                load->current_buffer->obj_list_offset, (void *)offsets, offset);
-#endif
-
-        if (offset >= load->current_buffer->size) {
-            rb_raise(rb_eIndexError, "object offset out of range: %u", offset);
-        }
-
-        if (! (header.type == T_HASH && !header.special_const && header.frozen && header.internal)) {
-            rb_raise(rb_eRuntimeError, "broken CDHASH object header");
-        }
-
-        // Load the CDHASH. Similar to ibf_load_object_hash().
-        {
-            long len = (long)ibf_load_small_value(load, &offset);
-            cdhash = rb_hash_new_with_size(len);
-            RHASH_TBL_RAW(cdhash)->type = &cdhash_type;
-
-            for (long i = 0; i < len; i++) {
-                VALUE key_index = ibf_load_small_value(load, &offset);
-                VALUE val_index = ibf_load_small_value(load, &offset);
-
-                VALUE key = ibf_load_object(load, key_index);
-                VALUE val = ibf_load_object(load, val_index);
-                rb_hash_aset(cdhash, key, val);
-            }
-
-            rb_hash_rehash(cdhash);
-            freeze_hide_obj(cdhash);
-        }
-
-        pinned_list_store(load->current_buffer->obj_list, (long)object_index, cdhash);
-    }
-#if IBF_ISEQ_DEBUG
-    fprintf(stderr, "ibf_load_cdhash: index=%#"PRIxVALUE" obj=%#"PRIxVALUE"\n",
-            object_index, cdhash);
-#endif
-    return cdhash;
 }
 
 struct ibf_dump_object_list_arg

--- a/test/ruby/test_iseq.rb
+++ b/test/ruby/test_iseq.rb
@@ -82,6 +82,19 @@ class TestISeq < Test::Unit::TestCase
     end;
   end if defined?(RubyVM::InstructionSequence.load)
 
+  def test_cdhash_after_roundtrip
+    # CDHASH was not built properly when loading from binary and
+    # was causing opt_case_dispatch to clobber its stack canary
+    # for its "leaf" instruction attribute.
+    iseq = compile(<<~EOF)
+      case Class.new(String).new("foo")
+      when "foo"
+        42
+      end
+    EOF
+    assert_equal(42, ISeq.load_from_binary(iseq.to_binary).eval)
+  end
+
   def test_disasm_encoding
     src = "\u{3042} = 1; \u{3042}; \u{3043}"
     asm = compile(src).disasm


### PR DESCRIPTION
Before this change, CDHASH operands were built as plain hashes when
loaded from binary. Without setting up the hash with the correct
st_table type, the hash can sometimes be an ar_table. When the hash is
an ar_table, lookups can call the `eql?` method on keys of the hash,
which makes the `opt_case_dispatch` instruction not "leaf" as it
implicitly declares.

The following script trips the stack canary for checking the leaf
attribute for `opt_case_dispatch` on VM_CHECK_MODE > 0 (enabled by
default with RUBY_DEBUG).

    rb_vm_iseq = RubyVM::InstructionSequence

    iseq = rb_vm_iseq.compile(<<-EOF)
      case Class.new(String).new("foo")
      when "foo"
        42
      end
    EOF

    puts rb_vm_iseq.load_from_binary(iseq.to_binary).eval

This commit changes the binary loading logic to build CDHASH with the
right st_table type. The dumping logic and the dump format stays the
same.