### PR TITLE
Revivie Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,291 @@
+# -*- YAML -*-
+# Copyright (C) 2011 Urabe, Shyouhei.  All rights reserved.
+#
+# This file is  a part of the programming language  Ruby.  Permission is hereby
+# granted,  to either  redistribute  or  modify this  file,  provided that  the
+# conditions  mentioned in  the file  COPYING are  met.  Consult  the  file for
+# details.
+
+# This is  a Travis-CI  build configuration file.   The list  of configurations
+# available is located in
+#
+#     http://about.travis-ci.org/docs/user/build-configuration/
+#
+# and as Ruby itself is a project written in C language,
+#
+#     http://about.travis-ci.org/docs/user/languages/c/
+#
+# is also a good place to look at.
+
+language: c
+
+os: linux
+
+dist: xenial
+
+git:
+  quiet: true
+
+cache:
+  ccache: true
+  directories:
+    - $HOME/config_2nd
+    - $HOME/.downloaded-cache
+
+env:
+  global:
+    # Reset timestamps early
+    - _=$(touch NEWS && find . -type f -exec touch -r NEWS {} +)
+    - CONFIGURE_TTY=no
+    - CCACHE_COMPILERCHECK=none
+    - CCACHE_NOCOMPRESS=1
+    - CCACHE_MAXSIZE=512Mi
+    - NPROC="`nproc`"
+    # JOBS and SETARCH are overridden when necessary; see below.
+    - JOBS=-j$((1+${NPROC}))
+    - SETARCH=
+    - RUBY_PREFIX=/tmp/ruby-prefix
+    - GEMS_FOR_TEST='timezone tzinfo'
+    - UPDATE_UNICODE="UNICODE_FILES=. UNICODE_PROPERTY_FILES=. UNICODE_AUXILIARY_FILES=. UNICODE_EMOJI_FILES=."
+    - BEFORE_INSTALL=true
+    # https://github.com/travis-ci/travis-build/blob/e411371dda21430a60f61b8f3f57943d2fe4d344/lib/travis/build/bash/travis_apt_get_options.bash#L7
+    - travis_apt_get_options='--allow-downgrades --allow-remove-essential --allow-change-held-packages'
+    - travis_apt_get_options="-yq --no-install-suggests --no-install-recommends $travis_apt_get_options"
+
+.org.ruby-lang.ci.matrix-definitions:
+
+  - &make-test-only
+    script:
+      - $SETARCH make -s test TESTOPTS="${TESTOPTS=$JOBS -q --tty=no}"
+
+  - &gcc-8
+    compiler: gcc-8
+    # # Not using addon to control retries
+    # addons:
+    #   apt:
+    #     sources:
+    #       - ubuntu-toolchain-r-test
+    before_install:
+      - bash -cx "${BEFORE_INSTALL}"
+      - tool/travis_retry.sh sudo -E apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
+      - tool/travis_retry.sh sudo bash -c "rm -rf '${TRAVIS_ROOT}/var/lib/apt/lists/'* && exec apt-get update -yq"
+      - >-
+        tool/travis_retry.sh sudo -E apt-get $travis_apt_get_options install
+        ccache
+        gcc-8
+        g++-8
+        libffi-dev
+        libgdbm-dev
+        libncurses5-dev
+        libncursesw5-dev
+        libreadline6-dev
+        libssl-dev
+        libyaml-dev
+        openssl
+        zlib1g-dev
+
+  - &clang-8
+    compiler: clang-8
+    addons:
+      apt:
+        # Not doing this manually unlike other sources, because it has been stable.
+        sources:
+          - llvm-toolchain-xenial-8
+        config:
+          retries: true
+    before_install:
+      - tool/travis_retry.sh sudo bash -c "rm -rf '${TRAVIS_ROOT}/var/lib/apt/lists/'* && exec apt-get update -yq"
+      - >-
+        tool/travis_retry.sh sudo -E apt-get $travis_apt_get_options install
+        clang-8
+        llvm-8-tools
+        libffi-dev
+        libgdbm-dev
+        libncurses5-dev
+        libncursesw5-dev
+        libreadline6-dev
+        libssl-dev
+        libyaml-dev
+        openssl
+        zlib1g-dev
+
+  # --------
+
+  - &x86_64-linux
+    name: x86_64-linux
+    <<: *gcc-8
+
+  - &arm64-linux
+    name: arm64-linux
+    arch: arm64
+    <<: *gcc-8
+
+  - &s390x-linux
+    name: s390x-linux
+    arch: s390x
+    <<: *gcc-8
+
+  - &i686-linux
+    name: i686-linux
+    compiler: gcc-8
+    env:
+      - GCC_FLAGS=-m32
+      - CXX='g++-8 -m32'
+      - debugflags=-g0
+      - SETARCH='setarch i686 --verbose --3gb'
+    # # Not using addon to control retries
+    # addons:
+    #   apt:
+    #     sources:
+    #       - ubuntu-toolchain-r-test
+    before_install:
+      - tool/travis_retry.sh sudo -E apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
+      - tool/travis_retry.sh sudo bash -c "rm -rf '${TRAVIS_ROOT}/var/lib/apt/lists/'* && exec apt-get update -yq"
+      - >-
+        tool/travis_retry.sh sudo -E apt-get $travis_apt_get_options install
+        gcc-8-multilib
+        g++-8
+        g++-8-multilib
+        libstdc++-8-dev:i386
+        libffi-dev:i386
+        libffi6:i386
+        libgdbm-dev:i386
+        libgdbm3:i386
+        libncurses5-dev:i386
+        libncurses5:i386
+        libncursesw5-dev:i386
+        libreadline6-dev:i386
+        libreadline6:i386
+        libssl-dev:i386
+        libssl1.0.0:i386
+        linux-libc-dev:i386
+        zlib1g-dev:i386
+        zlib1g:i386
+
+  - &arm32-linux
+    name: arm32-linux
+    arch: arm64
+    # https://packages.ubuntu.com/xenial/crossbuild-essential-armhf
+    compiler: arm-linux-gnueabihf-gcc
+    env:
+      - debugflags=-g0
+      - SETARCH='setarch linux32 --verbose --32bit'
+    before_install:
+      - sudo dpkg --add-architecture armhf
+      - tool/travis_retry.sh sudo bash -c "rm -rf '${TRAVIS_ROOT}/var/lib/apt/lists/'* && exec apt-get update -yq"
+      - >-
+        tool/travis_retry.sh sudo -E apt-get $travis_apt_get_options install
+        ccache
+        crossbuild-essential-armhf
+        libc6:armhf
+        libstdc++-5-dev:armhf
+        libffi-dev:armhf
+        libffi6:armhf
+        libgdbm-dev:armhf
+        libgdbm3:armhf
+        libncurses5-dev:armhf
+        libncurses5:armhf
+        libncursesw5-dev:armhf
+        libreadline6-dev:armhf
+        libreadline6:armhf
+        libssl-dev:armhf
+        libssl1.0.0:armhf
+        linux-libc-dev:armhf
+        zlib1g-dev:armhf
+        zlib1g:armhf
+
+matrix:
+  include:
+    # Build every commit:
+    - <<: *i686-linux
+    # Build every commit (Allowed Failures):
+    - <<: *arm32-linux
+    - <<: *arm64-linux
+    - <<: *s390x-linux
+  allow_failures:
+    - name: arm32-linux
+    - name: arm64-linux
+    - name: s390x-linux
+  fast_finish: true
+
+before_script:
+  - rm -fr .ext autom4te.cache
+  - |-
+    [ -d ~/.downloaded-cache ] ||
+    mkdir ~/.downloaded-cache
+  - ln -s ~/.downloaded-cache
+  - "> config.status"
+  - "> .rbconfig.time"
+  - sed -f tool/prereq.status template/Makefile.in common.mk > Makefile
+  - make touch-unicode-files
+  - make -s $JOBS $UPDATE_UNICODE up
+  - make -s $JOBS srcs
+  - rm -f config.status Makefile rbconfig.rb .rbconfig.time
+  - |-
+    if [ -d ~/config_2nd ]; then
+      cp -pr ~/config_2nd build
+    else
+      mkdir build
+    fi
+  - mkdir config_1st config_2nd
+  - chmod -R a-w .
+  - chmod -R u+w build config_1st config_2nd
+  - cd build
+  - |-
+    case "$CC" in
+    gcc*)   CC="ccache $CC${GCC_FLAGS:+ }$GCC_FLAGS -fno-diagnostics-color";;
+    clang*) CC="ccache $CC${GCC_FLAGS:+ }$GCC_FLAGS -fno-color-diagnostics";;
+    esac
+  - |-
+    [ ! -f config.cache ] ||
+    [ "$CC" = "`sed -n s/^ac_cv_prog_CC=//p config.cache`" ] ||
+    (set -x; exec rm config.cache)
+  - $SETARCH ../configure -C --disable-install-doc --prefix=$RUBY_PREFIX $CONFIG_FLAG
+  - cp -pr config.cache config.status .ext/include ../config_1st
+  - $SETARCH make reconfig
+  - cp -pr config.cache config.status .ext/include ../config_2nd
+  - (cd .. && exec diff -ru config_1st config_2nd)
+  - chmod u+w ..
+  - rm -rf ~/config_2nd
+  - mv ../config_2nd ~
+  - chmod u-w ..
+  - $SETARCH make -s $JOBS
+  - make -s install
+  - |-
+    [ -z "${GEMS_FOR_TEST}" ] ||
+    $RUBY_PREFIX/bin/gem install --no-document $GEMS_FOR_TEST
+  - echo "raise 'do not load ~/.irbrc in test'" > ~/.irbrc
+
+script:
+  - $SETARCH make -s test -o showflags TESTOPTS="${TESTOPTS=$JOBS -q --tty=no}"
+  - travis_wait 50 $SETARCH make -s test-all -o exts TESTOPTS="${TESTOPTS} ${TEST_ALL_OPTS}" RUBYOPT="-w"
+  - $SETARCH make -s test-spec MSPECOPT=-ff # not using `-j` because sometimes `mspec -j` silently dies
+  - $SETARCH make -s -o showflags leaked-globals
+
+# Branch matrix.  Not all branches are Travis-ready so we limit branches here.
+branches:
+  only:
+    - master
+    - ruby_2_4
+    - ruby_2_5
+    - ruby_2_6
+    - ruby_2_7
+
+# We want to be notified when something happens.
+notifications:
+  irc:
+    channels:
+      - "chat.freenode.net#ruby-core"
+    on_success: change # [always|never|change] # default: always
+    on_failure: always # [always|never|change] # default: always
+    template:
+      - "%{message} by @%{author}: See %{build_url}"
+
+  webhooks:
+    urls:
+      - secure: mRsoS/UbqDkKkW5p3AEqM27d4SZnV6Gsylo3bm8T/deltQzTsGzZwrm7OIBXZv0UFZdE68XmPlyHfZFLSP2V9QZ7apXMf9/vw0GtcSe1gchtnjpAPF6lYBn7nMCbVPPx9cS0dwL927fjdRM1vj7IKZ2bk4F0lAJ25R25S6teqdk= # ruby-lang slack: ruby/simpler-alerts-bot (travis)
+    on_success: never
+    on_failure: always
+
+  email:
+    - ko1c-failure@atdot.net

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ language: c
 
 os: linux
 
-dist: xenial
+dist: focal
 
 git:
   quiet: true
@@ -58,52 +58,45 @@ env:
     script:
       - $SETARCH make -s test TESTOPTS="${TESTOPTS=$JOBS -q --tty=no}"
 
-  - &gcc-8
-    compiler: gcc-8
-    # # Not using addon to control retries
-    # addons:
-    #   apt:
-    #     sources:
-    #       - ubuntu-toolchain-r-test
+  - &gcc-9
+    compiler: gcc-9
     before_install:
-      - bash -cx "${BEFORE_INSTALL}"
-      - tool/travis_retry.sh sudo -E apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
       - tool/travis_retry.sh sudo bash -c "rm -rf '${TRAVIS_ROOT}/var/lib/apt/lists/'* && exec apt-get update -yq"
       - >-
         tool/travis_retry.sh sudo -E apt-get $travis_apt_get_options install
         ccache
-        gcc-8
-        g++-8
+        gcc-9
+        g++-9
         libffi-dev
         libgdbm-dev
         libncurses5-dev
         libncursesw5-dev
-        libreadline6-dev
+        libreadline-dev
         libssl-dev
         libyaml-dev
         openssl
         zlib1g-dev
 
-  - &clang-8
-    compiler: clang-8
+  - &clang-10
+    compiler: clang-10
     addons:
       apt:
         # Not doing this manually unlike other sources, because it has been stable.
         sources:
-          - llvm-toolchain-xenial-8
+          - llvm-toolchain-xenial-10
         config:
           retries: true
     before_install:
       - tool/travis_retry.sh sudo bash -c "rm -rf '${TRAVIS_ROOT}/var/lib/apt/lists/'* && exec apt-get update -yq"
       - >-
         tool/travis_retry.sh sudo -E apt-get $travis_apt_get_options install
-        clang-8
-        llvm-8-tools
+        clang-10
+        llvm-10-tools
         libffi-dev
         libgdbm-dev
         libncurses5-dev
         libncursesw5-dev
-        libreadline6-dev
+        libreadline8-dev
         libssl-dev
         libyaml-dev
         openssl
@@ -113,21 +106,145 @@ env:
 
   - &x86_64-linux
     name: x86_64-linux
-    <<: *gcc-8
+    <<: *gcc-9
 
   - &arm64-linux
     name: arm64-linux
     arch: arm64
-    <<: *gcc-8
+    <<: *gcc-9
 
   - &s390x-linux
     name: s390x-linux
     arch: s390x
-    <<: *gcc-8
+    <<: *gcc-9
+
+  - &jemalloc
+    name: --with-jemalloc
+    <<: *gcc-9
+    <<: *cron-only
+    env:
+      - CONFIG_FLAG='--with-gmp --with-jemalloc --with-valgrind'
+
+  - &assertions
+    name: RUBY_DEBUG=1
+    <<: *gcc-9
+    #<<: *cron-only
+    <<: *make-test-only
+    env:
+      - GEMS_FOR_TEST=
+      - cppflags='-DRUBY_DEBUG -DVM_CHECK_MODE=1 -DTRANSIENT_HEAP_CHECK_MODE -DRGENGC_CHECK_MODE -DENC_DEBUG'
+
+  - &VM_CHECK_MODE
+    name: VM_CHECK_MODE=3
+    <<: *gcc-9
+    <<: *cron-only
+    <<: *make-test-only
+    env:
+      - GEMS_FOR_TEST=
+      - cppflags=-DVM_CHECK_MODE=0x0003
+
+  - &SUPPORT_JOKE
+    name: SUPPORT_JOKE
+    <<: *gcc-9
+    <<: *cron-only
+    <<: *make-test-only
+    env:
+      - BEFORE_INSTALL="sed vm_opts.h -e 's/OPT_SUPPORT_JOKE *0/OPT_SUPPORT_JOKE 1/' -i"
+
+  - &CPDEBUG
+    name: CPDEBUG
+    <<: *gcc-9
+    <<: *cron-only
+    <<: *make-test-only
+    env:
+      - cppflags=-DCPDEBUG
+
+  - &WITH_COROUTINE_UCONTEXT
+    name: COROUTINE=ucontext
+    <<: *gcc-9
+    <<: *cron-only
+    env:
+      - CONFIG_FLAG='--with-coroutine=ucontext'
+
+  - &WITH_COROUTINE_COPY
+    name: COROUTINE=copy
+    <<: *gcc-9
+    <<: *cron-only
+    env:
+      - CONFIG_FLAG='--with-coroutine=copy'
+
+  - &TOKEN_THREADED_CODE
+    name: TOKEN_THREADED_CODE
+    <<: *gcc-9
+    <<: *cron-only
+    <<: *make-test-only
+    env:
+      - GEMS_FOR_TEST=
+      - cppflags=-DOPT_THREADED_CODE=1
+
+  - &CALL_THREADED_CODE
+    name: CALL_THREADED_CODE
+    <<: *gcc-9
+    <<: *cron-only
+    <<: *make-test-only
+    env:
+      - GEMS_FOR_TEST=
+      - cppflags=-DOPT_THREADED_CODE=2
+
+  - &NO_THREADED_CODE
+    name: NO_THREADED_CODE
+    <<: *gcc-9
+    <<: *cron-only
+    <<: *make-test-only
+    env:
+      - GEMS_FOR_TEST=
+      - cppflags=-DOPT_THREADED_CODE=3
+
+  - &ASAN
+    name: -fsanitize=address
+    <<: *clang-8
+    #<<: *cron-only
+    <<: *make-test-only
+    env:
+      - GEMS_FOR_TEST=
+      - ASAN_OPTIONS=detect_leaks=0
+      - cflags='-U_FORTIFY_SOURCE -march=native -fsanitize=address -fno-omit-frame-pointer -fPIC'
+      - debugflags=-ggdb3
+      - optflags=-O1
+      - LD=clang-8
+      - LDFLAGS='-fsanitize=address -fPIC'
+      - CONFIG_FLAG='--with-out-ext=openssl --without-gmp --without-jemalloc --without-valgrind'
+
+  - &MSAN
+    name: -fsanitize=memory
+    <<: *clang-8
+    #<<: *cron-only
+    <<: *make-test-only
+    env:
+      - GEMS_FOR_TEST=
+      - cflags='-U_FORTIFY_SOURCE -fsanitize=memory -fsanitize-memory-track-origins=2 -fno-omit-frame-pointer -fPIC'
+      - optflags=-O1
+      - LD=clang-8
+      - LDFLAGS='-fsanitize=memory -fPIC'
+      - CONFIG_FLAG='--with-out-ext=openssl --without-gmp --without-jemalloc --without-valgrind'
+
+  - &UBSAN
+    name: -fsanitize=undefined
+    <<: *clang-8
+    #<<: *cron-only
+    <<: *make-test-only
+    env:
+      - GEMS_FOR_TEST=
+      - cflags='-U_FORTIFY_SOURCE -fsanitize=undefined,integer,nullability -fno-sanitize=implicit-integer-sign-change,unsigned-integer-overflow'
+      - cppflags=-DUNALIGNED_WORD_ACCESS=0
+      - debugflags=-ggdb3
+      - optflags='-O1 -march=native'
+      - LD=clang-8
+      - LDFLAGS='-fsanitize=undefined,integer,nullability -fno-sanitize=implicit-integer-sign-change,unsigned-integer-overflow'
 
   - &i686-linux
     name: i686-linux
-    compiler: gcc-8
+    compiler: gcc-9
     env:
       - GCC_FLAGS=-m32
       - CXX='g++-8 -m32'
@@ -143,7 +260,7 @@ env:
       - tool/travis_retry.sh sudo bash -c "rm -rf '${TRAVIS_ROOT}/var/lib/apt/lists/'* && exec apt-get update -yq"
       - >-
         tool/travis_retry.sh sudo -E apt-get $travis_apt_get_options install
-        gcc-8-multilib
+        gcc-9-multilib
         g++-8
         g++-8-multilib
         libstdc++-8-dev:i386
@@ -182,17 +299,112 @@ env:
         libffi-dev:armhf
         libffi6:armhf
         libgdbm-dev:armhf
-        libgdbm3:armhf
+        libgdbm6:armhf
         libncurses5-dev:armhf
         libncurses5:armhf
         libncursesw5-dev:armhf
-        libreadline6-dev:armhf
-        libreadline6:armhf
+        libreadline8-dev:armhf
+        libreadline8:armhf
         libssl-dev:armhf
         libssl1.0.0:armhf
         linux-libc-dev:armhf
         zlib1g-dev:armhf
         zlib1g:armhf
+
+  - &pedanticism
+    name: -std=c99 -pedantic
+    compiler: clang
+    <<: *make-test-only
+    env:
+      - GEMS_FOR_TEST=
+      - GCC_FLAGS='-std=c99 -Werror=pedantic -pedantic-errors'
+      - CONFIG_FLAG=
+      - JOBS=
+      - >-
+        warnflags='
+        -Wall
+        -Wextra
+        -Werror=deprecated-declarations
+        -Werror=division-by-zero
+        -Werror=extra-tokens
+        -Werror=implicit-function-declaration
+        -Werror=implicit-int
+        -Werror=pointer-arith
+        -Werror=shorten-64-to-32
+        -Werror=write-strings
+        -Wmissing-noreturn
+        -Wno-constant-logical-operand
+        -Wno-missing-field-initializers
+        -Wno-overlength-strings
+        -Wno-parentheses-equality
+        -Wno-self-assign
+        -Wno-tautological-compare
+        -Wno-unused-local-typedef
+        -Wno-unused-parameter
+        -Wunused-variable'
+      - LDFLAGS=-Wno-unused-command-line-argument
+
+  - &spec-on-old-ruby
+    language: ruby
+    before_install:
+    install:
+    before_script: chmod -R u+w spec/ruby
+    # -j randomly hangs.
+    script: ruby -C spec/ruby ../mspec/bin/mspec .
+
+  - &rubyspec25
+    name: Check ruby/spec version guards on Ruby 2.5
+    rvm: 2.5.7
+    <<: *spec-on-old-ruby
+    after_failure:
+      - echo "ruby/spec failed on Ruby 2.5. This is likely because of a missing ruby_version_is guard, please add it. See spec/README.md."
+
+  - &rubyspec27
+    name: Check ruby/spec version guards on Ruby 2.7
+    rvm: 2.7.0
+    <<: *spec-on-old-ruby
+    after_failure:
+      - echo "ruby/spec failed on Ruby 2.7. This is likely because of a missing ruby_version_is guard, please add it. See spec/README.md."
+
+  - &baseruby
+    name: "BASERUBY: Ruby 2.2"
+    <<: *gcc-9
+    <<: *make-test-only
+    language: ruby
+    rvm: 2.2
+
+  - &dependency
+    name: Check dependencies in makefiles
+    language: ruby
+    before_install:
+    install:
+    before_script:
+      - |-
+        ruby -e 'new = []
+          Dir.glob("ext/**/extconf.rb") {|ex|
+            unless File.exist?(dep = File.dirname(ex)+"/depend")
+              puts "Adding "+dep
+              File.copy_stream("template/depend.tmpl", dep)
+              new << dep
+            end
+          }
+          exec("git", "add", *new) unless new.empty?'
+      - git diff --cached
+      - "> config.status"
+      - "> .rbconfig.time"
+      - sed -f tool/prereq.status template/Makefile.in common.mk > Makefile
+      - make touch-unicode-files
+      - make -s $JOBS $UPDATE_UNICODE up
+      - make -s $JOBS srcs
+      - rm -f config.status Makefile rbconfig.rb .rbconfig.time
+      - $SETARCH ./configure -C --disable-install-doc --prefix=$RUBY_PREFIX --disable-rubygems 'optflags=-O0' 'debugflags=-save-temps=obj -g'
+      - ruby tool/update-deps --fix
+    script:
+      - git diff --no-ext-diff --ignore-submodules --exit-code
+    after_failure:
+      - echo "Dependencies need to update"
+    env:
+      - CONFIG_FLAG=
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,8 @@
 # conditions  mentioned in  the file  COPYING are  met.  Consult  the  file for
 # details.
 
-# This is  a Travis-CI  build configuration file.   The list  of configurations
-# available is located in
-#
-#     http://about.travis-ci.org/docs/user/build-configuration/
-#
-# and as Ruby itself is a project written in C language,
-#
-#     http://about.travis-ci.org/docs/user/languages/c/
-#
-# is also a good place to look at.
+# We only manage non-amd64 free pipelines.
+# https://docs.travis-ci.com/user/billing-overview/
 
 language: c
 
@@ -47,29 +39,34 @@ env:
     - RUBY_PREFIX=/tmp/ruby-prefix
     - GEMS_FOR_TEST='timezone tzinfo'
     - UPDATE_UNICODE="UNICODE_FILES=. UNICODE_PROPERTY_FILES=. UNICODE_AUXILIARY_FILES=. UNICODE_EMOJI_FILES=."
-    - BEFORE_INSTALL=true
+    # The tests skipped in `make test-all`.
+    - TEST_ALL_SKIPPED_TESTS=
+    # Run the separated tests with allowing failures.
+    - RUN_SEPARATED_TESTS=true
+    # The tests executed separately by `make test-all`.
+    - TEST_ALL_SEPARATED_TESTS=
     # https://github.com/travis-ci/travis-build/blob/e411371dda21430a60f61b8f3f57943d2fe4d344/lib/travis/build/bash/travis_apt_get_options.bash#L7
     - travis_apt_get_options='--allow-downgrades --allow-remove-essential --allow-change-held-packages'
     - travis_apt_get_options="-yq --no-install-suggests --no-install-recommends $travis_apt_get_options"
+    # -O1 is faster than -O3 in our tests.
+    - optflags=-O1
+    # -g0 disables backtraces when SEGV.  Do not set that.
+    - debugflags=-ggdb3
 
 .org.ruby-lang.ci.matrix-definitions:
 
-  - &make-test-only
-    script:
-      - $SETARCH make -s test TESTOPTS="${TESTOPTS=$JOBS -q --tty=no}"
-
-  - &gcc-9
-    compiler: gcc-9
+  - &gcc-10
+    compiler: gcc-10
     before_install:
       - tool/travis_retry.sh sudo bash -c "rm -rf '${TRAVIS_ROOT}/var/lib/apt/lists/'* && exec apt-get update -yq"
       - >-
         tool/travis_retry.sh sudo -E apt-get $travis_apt_get_options install
         ccache
-        gcc-9
-        g++-9
+        gcc-10
+        g++-10
         libffi-dev
         libgdbm-dev
-        libncurses5-dev
+        libncurses-dev
         libncursesw5-dev
         libreadline-dev
         libssl-dev
@@ -77,215 +74,35 @@ env:
         openssl
         zlib1g-dev
 
-  - &clang-10
-    compiler: clang-10
-    addons:
-      apt:
-        # Not doing this manually unlike other sources, because it has been stable.
-        sources:
-          - llvm-toolchain-xenial-10
-        config:
-          retries: true
-    before_install:
-      - tool/travis_retry.sh sudo bash -c "rm -rf '${TRAVIS_ROOT}/var/lib/apt/lists/'* && exec apt-get update -yq"
-      - >-
-        tool/travis_retry.sh sudo -E apt-get $travis_apt_get_options install
-        clang-10
-        llvm-10-tools
-        libffi-dev
-        libgdbm-dev
-        libncurses5-dev
-        libncursesw5-dev
-        libreadline8-dev
-        libssl-dev
-        libyaml-dev
-        openssl
-        zlib1g-dev
-
   # --------
-
-  - &x86_64-linux
-    name: x86_64-linux
-    <<: *gcc-9
 
   - &arm64-linux
     name: arm64-linux
     arch: arm64
-    <<: *gcc-9
+    <<: *gcc-10
+
+  - &ppc64le-linux
+    name: ppc64le-linux
+    arch: ppc64le
+    <<: *gcc-10
+    env:
+      # FIXME: Skip some failing TestGCCompact tests.
+      # https://bugs.ruby-lang.org/issues/17871
+      - TEST_ALL_SKIPPED_TESTS="test_gc_compact_stats test_complex_hash_keys test_ast_compacts test_compact_count"
+      # The tests crash the process.
+      - RUN_SEPARATED_TESTS=false
 
   - &s390x-linux
     name: s390x-linux
     arch: s390x
-    <<: *gcc-9
-
-  - &jemalloc
-    name: --with-jemalloc
-    <<: *gcc-9
-    <<: *cron-only
-    env:
-      - CONFIG_FLAG='--with-gmp --with-jemalloc --with-valgrind'
-
-  - &assertions
-    name: RUBY_DEBUG=1
-    <<: *gcc-9
-    #<<: *cron-only
-    <<: *make-test-only
-    env:
-      - GEMS_FOR_TEST=
-      - cppflags='-DRUBY_DEBUG -DVM_CHECK_MODE=1 -DTRANSIENT_HEAP_CHECK_MODE -DRGENGC_CHECK_MODE -DENC_DEBUG'
-
-  - &VM_CHECK_MODE
-    name: VM_CHECK_MODE=3
-    <<: *gcc-9
-    <<: *cron-only
-    <<: *make-test-only
-    env:
-      - GEMS_FOR_TEST=
-      - cppflags=-DVM_CHECK_MODE=0x0003
-
-  - &SUPPORT_JOKE
-    name: SUPPORT_JOKE
-    <<: *gcc-9
-    <<: *cron-only
-    <<: *make-test-only
-    env:
-      - BEFORE_INSTALL="sed vm_opts.h -e 's/OPT_SUPPORT_JOKE *0/OPT_SUPPORT_JOKE 1/' -i"
-
-  - &CPDEBUG
-    name: CPDEBUG
-    <<: *gcc-9
-    <<: *cron-only
-    <<: *make-test-only
-    env:
-      - cppflags=-DCPDEBUG
-
-  - &WITH_COROUTINE_UCONTEXT
-    name: COROUTINE=ucontext
-    <<: *gcc-9
-    <<: *cron-only
-    env:
-      - CONFIG_FLAG='--with-coroutine=ucontext'
-
-  - &WITH_COROUTINE_COPY
-    name: COROUTINE=copy
-    <<: *gcc-9
-    <<: *cron-only
-    env:
-      - CONFIG_FLAG='--with-coroutine=copy'
-
-  - &TOKEN_THREADED_CODE
-    name: TOKEN_THREADED_CODE
-    <<: *gcc-9
-    <<: *cron-only
-    <<: *make-test-only
-    env:
-      - GEMS_FOR_TEST=
-      - cppflags=-DOPT_THREADED_CODE=1
-
-  - &CALL_THREADED_CODE
-    name: CALL_THREADED_CODE
-    <<: *gcc-9
-    <<: *cron-only
-    <<: *make-test-only
-    env:
-      - GEMS_FOR_TEST=
-      - cppflags=-DOPT_THREADED_CODE=2
-
-  - &NO_THREADED_CODE
-    name: NO_THREADED_CODE
-    <<: *gcc-9
-    <<: *cron-only
-    <<: *make-test-only
-    env:
-      - GEMS_FOR_TEST=
-      - cppflags=-DOPT_THREADED_CODE=3
-
-  - &ASAN
-    name: -fsanitize=address
-    <<: *clang-8
-    #<<: *cron-only
-    <<: *make-test-only
-    env:
-      - GEMS_FOR_TEST=
-      - ASAN_OPTIONS=detect_leaks=0
-      - cflags='-U_FORTIFY_SOURCE -march=native -fsanitize=address -fno-omit-frame-pointer -fPIC'
-      - debugflags=-ggdb3
-      - optflags=-O1
-      - LD=clang-8
-      - LDFLAGS='-fsanitize=address -fPIC'
-      - CONFIG_FLAG='--with-out-ext=openssl --without-gmp --without-jemalloc --without-valgrind'
-
-  - &MSAN
-    name: -fsanitize=memory
-    <<: *clang-8
-    #<<: *cron-only
-    <<: *make-test-only
-    env:
-      - GEMS_FOR_TEST=
-      - cflags='-U_FORTIFY_SOURCE -fsanitize=memory -fsanitize-memory-track-origins=2 -fno-omit-frame-pointer -fPIC'
-      - optflags=-O1
-      - LD=clang-8
-      - LDFLAGS='-fsanitize=memory -fPIC'
-      - CONFIG_FLAG='--with-out-ext=openssl --without-gmp --without-jemalloc --without-valgrind'
-
-  - &UBSAN
-    name: -fsanitize=undefined
-    <<: *clang-8
-    #<<: *cron-only
-    <<: *make-test-only
-    env:
-      - GEMS_FOR_TEST=
-      - cflags='-U_FORTIFY_SOURCE -fsanitize=undefined,integer,nullability -fno-sanitize=implicit-integer-sign-change,unsigned-integer-overflow'
-      - cppflags=-DUNALIGNED_WORD_ACCESS=0
-      - debugflags=-ggdb3
-      - optflags='-O1 -march=native'
-      - LD=clang-8
-      - LDFLAGS='-fsanitize=undefined,integer,nullability -fno-sanitize=implicit-integer-sign-change,unsigned-integer-overflow'
-
-  - &i686-linux
-    name: i686-linux
-    compiler: gcc-9
-    env:
-      - GCC_FLAGS=-m32
-      - CXX='g++-8 -m32'
-      - debugflags=-g0
-      - SETARCH='setarch i686 --verbose --3gb'
-    # # Not using addon to control retries
-    # addons:
-    #   apt:
-    #     sources:
-    #       - ubuntu-toolchain-r-test
-    before_install:
-      - tool/travis_retry.sh sudo -E apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
-      - tool/travis_retry.sh sudo bash -c "rm -rf '${TRAVIS_ROOT}/var/lib/apt/lists/'* && exec apt-get update -yq"
-      - >-
-        tool/travis_retry.sh sudo -E apt-get $travis_apt_get_options install
-        gcc-9-multilib
-        g++-8
-        g++-8-multilib
-        libstdc++-8-dev:i386
-        libffi-dev:i386
-        libffi6:i386
-        libgdbm-dev:i386
-        libgdbm3:i386
-        libncurses5-dev:i386
-        libncurses5:i386
-        libncursesw5-dev:i386
-        libreadline6-dev:i386
-        libreadline6:i386
-        libssl-dev:i386
-        libssl1.0.0:i386
-        linux-libc-dev:i386
-        zlib1g-dev:i386
-        zlib1g:i386
+    <<: *gcc-10
 
   - &arm32-linux
     name: arm32-linux
     arch: arm64
-    # https://packages.ubuntu.com/xenial/crossbuild-essential-armhf
+    # https://packages.ubuntu.com/focal/crossbuild-essential-armhf
     compiler: arm-linux-gnueabihf-gcc
     env:
-      - debugflags=-g0
       - SETARCH='setarch linux32 --verbose --32bit'
     before_install:
       - sudo dpkg --add-architecture armhf
@@ -295,132 +112,46 @@ env:
         ccache
         crossbuild-essential-armhf
         libc6:armhf
-        libstdc++-5-dev:armhf
+        libstdc++-10-dev:armhf
         libffi-dev:armhf
-        libffi6:armhf
         libgdbm-dev:armhf
-        libgdbm6:armhf
-        libncurses5-dev:armhf
-        libncurses5:armhf
+        libncurses-dev:armhf
         libncursesw5-dev:armhf
-        libreadline8-dev:armhf
-        libreadline8:armhf
+        libreadline-dev:armhf
         libssl-dev:armhf
-        libssl1.0.0:armhf
         linux-libc-dev:armhf
         zlib1g-dev:armhf
-        zlib1g:armhf
-
-  - &pedanticism
-    name: -std=c99 -pedantic
-    compiler: clang
-    <<: *make-test-only
-    env:
-      - GEMS_FOR_TEST=
-      - GCC_FLAGS='-std=c99 -Werror=pedantic -pedantic-errors'
-      - CONFIG_FLAG=
-      - JOBS=
-      - >-
-        warnflags='
-        -Wall
-        -Wextra
-        -Werror=deprecated-declarations
-        -Werror=division-by-zero
-        -Werror=extra-tokens
-        -Werror=implicit-function-declaration
-        -Werror=implicit-int
-        -Werror=pointer-arith
-        -Werror=shorten-64-to-32
-        -Werror=write-strings
-        -Wmissing-noreturn
-        -Wno-constant-logical-operand
-        -Wno-missing-field-initializers
-        -Wno-overlength-strings
-        -Wno-parentheses-equality
-        -Wno-self-assign
-        -Wno-tautological-compare
-        -Wno-unused-local-typedef
-        -Wno-unused-parameter
-        -Wunused-variable'
-      - LDFLAGS=-Wno-unused-command-line-argument
-
-  - &spec-on-old-ruby
-    language: ruby
-    before_install:
-    install:
-    before_script: chmod -R u+w spec/ruby
-    # -j randomly hangs.
-    script: ruby -C spec/ruby ../mspec/bin/mspec .
-
-  - &rubyspec25
-    name: Check ruby/spec version guards on Ruby 2.5
-    rvm: 2.5.7
-    <<: *spec-on-old-ruby
-    after_failure:
-      - echo "ruby/spec failed on Ruby 2.5. This is likely because of a missing ruby_version_is guard, please add it. See spec/README.md."
-
-  - &rubyspec27
-    name: Check ruby/spec version guards on Ruby 2.7
-    rvm: 2.7.0
-    <<: *spec-on-old-ruby
-    after_failure:
-      - echo "ruby/spec failed on Ruby 2.7. This is likely because of a missing ruby_version_is guard, please add it. See spec/README.md."
-
-  - &baseruby
-    name: "BASERUBY: Ruby 2.2"
-    <<: *gcc-9
-    <<: *make-test-only
-    language: ruby
-    rvm: 2.2
-
-  - &dependency
-    name: Check dependencies in makefiles
-    language: ruby
-    before_install:
-    install:
-    before_script:
-      - |-
-        ruby -e 'new = []
-          Dir.glob("ext/**/extconf.rb") {|ex|
-            unless File.exist?(dep = File.dirname(ex)+"/depend")
-              puts "Adding "+dep
-              File.copy_stream("template/depend.tmpl", dep)
-              new << dep
-            end
-          }
-          exec("git", "add", *new) unless new.empty?'
-      - git diff --cached
-      - "> config.status"
-      - "> .rbconfig.time"
-      - sed -f tool/prereq.status template/Makefile.in common.mk > Makefile
-      - make touch-unicode-files
-      - make -s $JOBS $UPDATE_UNICODE up
-      - make -s $JOBS srcs
-      - rm -f config.status Makefile rbconfig.rb .rbconfig.time
-      - $SETARCH ./configure -C --disable-install-doc --prefix=$RUBY_PREFIX --disable-rubygems 'optflags=-O0' 'debugflags=-save-temps=obj -g'
-      - ruby tool/update-deps --fix
-    script:
-      - git diff --no-ext-diff --ignore-submodules --exit-code
-    after_failure:
-      - echo "Dependencies need to update"
-    env:
-      - CONFIG_FLAG=
 
 matrix:
   include:
-    # Build every commit:
-    - <<: *i686-linux
     # Build every commit (Allowed Failures):
     - <<: *arm32-linux
     - <<: *arm64-linux
+    - <<: *ppc64le-linux
     - <<: *s390x-linux
   allow_failures:
+    # An arm64 job sometimes does not start right now.
+    # https://travis-ci.community/t/11629
     - name: arm32-linux
     - name: arm64-linux
-    - name: s390x-linux
+    # - name: ppc64le-linux
+    # - name: s390x-linux
   fast_finish: true
 
 before_script:
+  - . tool/ci_functions.sh
+  - |-
+    if [ -n "${TEST_ALL_SKIPPED_TESTS}" ]; then
+      TEST_ALL_OPTS="${TEST_ALL_OPTS} $(ci_to_excluded_test_opts "${TEST_ALL_SKIPPED_TESTS}")"
+      if [ -z "${TEST_ALL_SEPARATED_TESTS}" ]; then
+        TEST_ALL_SEPARATED_TESTS="${TEST_ALL_SKIPPED_TESTS}"
+      fi
+    fi
+  - |-
+    if [ -n "${TEST_ALL_SEPARATED_TESTS}" ]; then
+      TEST_ALL_OPTS_SEPARATED="$(ci_to_included_test_opts "${TEST_ALL_SEPARATED_TESTS}")"
+    fi
+  - echo TEST_ALL_OPTS="${TEST_ALL_OPTS}" TEST_ALL_OPTS_SEPARATED="${TEST_ALL_OPTS_SEPARATED}"
   - rm -fr .ext autom4te.cache
   - |-
     [ -d ~/.downloaded-cache ] ||
@@ -470,7 +201,13 @@ before_script:
 
 script:
   - $SETARCH make -s test -o showflags TESTOPTS="${TESTOPTS=$JOBS -q --tty=no}"
-  - travis_wait 50 $SETARCH make -s test-all -o exts TESTOPTS="${TESTOPTS} ${TEST_ALL_OPTS}" RUBYOPT="-w"
+  - ../tool/travis_wait.sh $SETARCH make -s test-all -o exts TESTOPTS="$JOBS -q --tty=no ${TEST_ALL_OPTS}" RUBYOPT="-w"
+  # Run the failing tests separately returning ok status to check if it works,
+  # visualize them.
+  - |
+    if [ "${RUN_SEPARATED_TESTS}" = true -a -n "${TEST_ALL_OPTS_SEPARATED}" ]; then
+      $SETARCH make -s test-all -o exts TESTOPTS="$JOBS -v --tty=no ${TEST_ALL_OPTS_SEPARATED}" RUBYOPT="-w" || :
+    fi
   - $SETARCH make -s test-spec MSPECOPT=-ff # not using `-j` because sometimes `mspec -j` silently dies
   - $SETARCH make -s -o showflags leaked-globals
 
@@ -478,10 +215,7 @@ script:
 branches:
   only:
     - master
-    - ruby_2_4
-    - ruby_2_5
-    - ruby_2_6
-    - ruby_2_7
+    - /^ruby_\d_\d$/
 
 # We want to be notified when something happens.
 notifications:
@@ -500,4 +234,4 @@ notifications:
     on_failure: always
 
   email:
-    - ko1c-failure@atdot.net
+    - jaruga@ruby-lang.org

--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -248,7 +248,8 @@ assert_equal 30.times.map { 'ok' }.to_s, %q{
   30.times.map{|i|
     test i
   }
-} unless ENV['RUN_OPTS'] =~ /--jit-min-calls=5/ # This always fails with --jit-wait --jit-min-calls=5
+} unless ENV['RUN_OPTS'] =~ /--jit-min-calls=5/ || # This always fails with --jit-wait --jit-min-calls=5
+  (ENV.key?('TRAVIS') && ENV['TRAVIS_CPU_ARCH'] == 'arm64') # https://bugs.ruby-lang.org/issues/17878
 
 # Exception for empty select
 assert_match /specify at least one ractor/, %q{

--- a/tool/ci_functions.sh
+++ b/tool/ci_functions.sh
@@ -1,0 +1,29 @@
+# -*- BASH -*-
+# Manage functions used on a CI.
+# Run `. tool/ci_functions.sh` to use it.
+
+# Create options with patterns `-n !/name1/ -n !/name2/ ..` to exclude the test
+# method names by the method names `name1 name2 ..`.
+# See `ruby tool/test/runner.rb --help` `-n` option.
+function ci_to_excluded_test_opts {
+  local tests_str="${1}"
+  # Use the backward matching `!/name$/`, as the perfect matching does not work.
+  # https://bugs.ruby-lang.org/issues/16936
+  ruby <<EOF
+    opts = "${tests_str}".split.map { |test| "-n \!/#{test}\$$/" }
+    puts opts.join(' ')
+EOF
+  return 0
+}
+
+# Create options with patterns `-n /name1/ -n /name2/ ..` to exclude the test
+# method names by the method names `name1 name2 ..`.
+# See `ruby tool/test/runner.rb --help` `-n` option.
+function ci_to_included_test_opts {
+  local tests_str="${1}"
+  ruby <<EOF
+    opts = "${tests_str}".split.map { |test| "-n #{test}" }
+    puts opts.join(' ')
+EOF
+  return 0
+}

--- a/tool/travis_wait.sh
+++ b/tool/travis_wait.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -eu
+# The modified version of `travis_wait` to output a log as the command goes.
+# https://github.com/travis-ci/travis-ci/issues/4190#issuecomment-353342526
+
+# Produce an output log every 9 minutes as the timeout without output is 10
+# minutes. A job finishes with a timeout if it takes longer than 50 minutes.
+# https://docs.travis-ci.com/user/customizing-the-build#build-timeouts
+while sleep 9m; do
+  # Print message with bash variable SECONDS.
+  echo "====[ $SECONDS seconds still running ]===="
+done &
+
+echo "+ $@"
+"$@"
+
+jobs
+kill %1
+exit 0


### PR DESCRIPTION
This PR to revive Travis related to  the ticket: https://bugs.ruby-lang.org/issues/17818 .

As I wrote [the comment 4](https://bugs.ruby-lang.org/issues/17818#note-4), the i686 case is not included in Travis. I would send another PR to add the i686 case on GitHub Actions.

This PR has 6 commits. I tested on [my forked repo](https://travis-ci.com/github/junaruga/ruby/builds) 10+ times .

## The 1st commit

The 1st commit to revert 6b978d542704a5614af5e9375c4b31b8d2618652 that is a kind to make a starting point for the PR. I solved the following 2 things written below, fixing the failed builds and updating all the case to Ubuntu focal, the latest available Ubuntu version on Travis. For the running time, the longest job is around 13 or 14 minutes. You can see [my forked repo's history](https://travis-ci.com/github/junaruga/ruby/builds).

```
Remove .travis.yml

Reason:
* Recent build is failed.
  https://travis-ci.org/github/ruby/ruby/jobs/762561190
* Current configuration uses Ubuntu 16.04 (xenial), whose EOL is Apr 2021.
```

```
22bb644737707dd50e2d67479465db7ede7414b3 Revert "Remove .travis.yml" to revive Travis.
```

## The 2nd, 3rd, 4th commits

The 2nd, 3rd, 4th commits are ones cherry-picked from #3173.

```
2e14e000e07f9383f4140eaeaa3cec7c35c8672f .travis.yml: Ubuntu 20.04 Focal Fossa
6e7daccb5245eab9a8ca33c400c5ddede4e97f48 .travis.yml: use bionic for i686
a858691ed09cbffdd7ade8f0de872d6d550284a7 Try Focal i386 packages
```

## The 5th commit

The 5th commit is the main commit of this PR, updating `.travis.yml`.

```
da155ea25dab1adcaaae54fa86d7d138e94191f8 .travis.yml: Update to use arm64/ppc64le/s390x.
```

```
    .travis.yml: Update to use arm64/ppc64le/s390x.
    
    * Use only the free pipelines arm64/ppc64le/s390x without credits on Travis.
      See <https://docs.travis-ci.com/user/billing-overview/#partner-queue-solution>.
    * Add ppc64le case.
    * Update the gcc to gcc-11.
    * Remove unused logic.
    * Add the `tool/travis_wait.sh` to avoid a command timeout.
    * Run the tests skipping some failing tests.
      * Set `TEST_ALL_SKIPPED_TESTS` env to skip the tests.
      * Run the tests separately returning ok status.
        The tests are executed if `TEST_ALL_SKIPPED_TESTS` env is set or
        `TEST_ALL_SEPARATED_TESTS` env is set.
      * Add `tool/ci_functions.sh` to manage the functions used in CI.
    * Add arm64 to allow_failures due to the following issue.
      An arm64 job sometimes does not start right now.
      https://travis-ci.community/t/11629
```

### Run the tests skipping some failing tests.

Let me explain about the feature. The feature is to skip some tests in the `make test-all` or run the specific tests separately.

```
    # The tests skipped in `make test-all`.
    - TEST_ALL_SKIPPED_TESTS=
    # Run the separated tests with allowing failures.
    - RUN_SEPARATED_TESTS=true
    # The tests executed separately by `make test-all`.
    - TEST_ALL_SEPARATED_TESTS=
```

For the actual use case on ppc64le, as you know, there are gc related test failures that crash the testing process itself. So, setting like this, we can skip the tests and we would not run the the tests separately with the skipped tests.

```
    env:
      # FIXME: Skip some failing TestGCCompact tests.
      # https://bugs.ruby-lang.org/issues/17871
      - TEST_ALL_SKIPPED_TESTS="test_gc_compact_stats test_complex_hash_keys test_ast_compacts test_compact_count"
      # The tests crash the process.
      - RUN_SEPARATED_TESTS=false
 ```

The following example is to skip the `test_recovery_sigint` test in `make test-all` "and" run the `test_recovery_sigint` test separately. Because I did not want to hide the error, not to forget to fix it. When the `TEST_ALL_SEPARATED_TESTS` is not set, the tests in `TEST_ALL_SKIPPED_TESTS` is used for the the tests separately executed. I did hit this failure working in progress. But when I rebased my working branch on the latest commit including the commit: eef406acf413d61db9f9ec12f036386eda61e338 for IRB to use the latest Reline, 0.2.5. I guess the commit fixed the failure. I don't see the issue any more.

```
    env:
      # FIXME: Skip the failing TestIRB::TestInit#test_recovery_sigint test
      # where an infinity loop might happen.
      - TEST_ALL_SKIPPED_TESTS="test_recovery_sigint"
```

The following example is to run the `make test-all` without skipping specific tests, and only run the tests separately with the tests in `TEST_ALL_SEPARATED_TESTS`.

```
    env:
      # FIXME: Skip the failing TestIRB::TestInit#test_recovery_sigint test
      # where an infinity loop might happen.
      - TEST_ALL_SEPARATED_TESTS="test_recovery_sigint"
```

## The 6th commit

The last commit is to skip an assertion that rarely fails. I opened the ticket https://bugs.ruby-lang.org/issues/17878 . As the `make test` does not have a feature to skip a specific test or assertion, I just skipped the assertion in the source code.

```
d32d324a52fd9f9fa98cd553d3fb4ecd4dcaa968 test_ractor.rb: Skip an assertion to test the `Ractor.select` on Travis arm64.
```

That's all!
