### PR TITLE
Make RubyVM::AbstractSyntaxTree.of raise for method/proc created in eval

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -213,6 +213,9 @@ ast_s_of(rb_execution_context_t *ec, VALUE module, VALUE body, VALUE save_script
         else {
             iseq = rb_method_iseq(body);
         }
+        if (rb_iseq_from_eval_p(iseq)) {
+            rb_raise(rb_eArgError, "cannot get AST for method defined in eval");
+        }
         path = rb_iseq_path(iseq);
         node_id = iseq->body->location.node_id;
     }

--- a/iseq.c
+++ b/iseq.c
@@ -1115,6 +1115,12 @@ rb_iseq_absolute_path(const rb_iseq_t *iseq)
     return rb_iseq_realpath(iseq);
 }
 
+int
+rb_iseq_from_eval_p(const rb_iseq_t *iseq)
+{
+    return NIL_P(rb_iseq_realpath(iseq));
+}
+
 VALUE
 rb_iseq_label(const rb_iseq_t *iseq)
 {

--- a/iseq.h
+++ b/iseq.h
@@ -192,6 +192,7 @@ VALUE rb_iseqw_new(const rb_iseq_t *iseq);
 const rb_iseq_t *rb_iseqw_to_iseq(VALUE iseqw);
 
 VALUE rb_iseq_absolute_path(const rb_iseq_t *iseq); /* obsolete */
+int rb_iseq_from_eval_p(const rb_iseq_t *iseq);
 VALUE rb_iseq_label(const rb_iseq_t *iseq);
 VALUE rb_iseq_base_label(const rb_iseq_t *iseq);
 VALUE rb_iseq_first_lineno(const rb_iseq_t *iseq);

--- a/spec/ruby/core/thread/backtrace/location/absolute_path_spec.rb
+++ b/spec/ruby/core/thread/backtrace/location/absolute_path_spec.rb
@@ -18,10 +18,20 @@ describe 'Thread::Backtrace::Location#absolute_path' do
   end
 
   context "when used in eval with a given filename" do
-    it "returns filename" do
-      code = "caller_locations(0)[0].absolute_path"
-      eval(code, nil, "foo.rb").should == "foo.rb"
-      eval(code, nil, "foo/bar.rb").should == "foo/bar.rb"
+    code = "caller_locations(0)[0].absolute_path"
+
+    ruby_version_is ""..."3.1" do
+      it "returns filename with absolute_path" do
+        eval(code, nil, "foo.rb").should == "foo.rb"
+        eval(code, nil, "foo/bar.rb").should == "foo/bar.rb"
+      end
+    end
+
+    ruby_version_is "3.1" do
+      it "returns nil with absolute_path" do
+        eval(code, nil, "foo.rb").should == nil
+        eval(code, nil, "foo/bar.rb").should == nil
+      end
     end
   end
 

--- a/test/ruby/test_ast.rb
+++ b/test/ruby/test_ast.rb
@@ -211,6 +211,26 @@ class TestAst < Test::Unit::TestCase
     end
   end
 
+  def test_of_eval
+    method = self.method(eval("def example_method_#{$$}; end"))
+    assert_raise(ArgumentError) { RubyVM::AbstractSyntaxTree.of(method) }
+
+    method = self.method(eval("def self.example_singleton_method_#{$$}; end"))
+    assert_raise(ArgumentError) { RubyVM::AbstractSyntaxTree.of(method) }
+
+    method = eval("proc{}")
+    assert_raise(ArgumentError) { RubyVM::AbstractSyntaxTree.of(method) }
+
+    method = self.method(eval("singleton_class.define_method(:example_define_method_#{$$}){}"))
+    assert_raise(ArgumentError) { RubyVM::AbstractSyntaxTree.of(method) }
+
+    method = self.method(eval("define_singleton_method(:example_dsm_#{$$}){}"))
+    assert_raise(ArgumentError) { RubyVM::AbstractSyntaxTree.of(method) }
+
+    method = eval("Class.new{def example_method; end}.instance_method(:example_method)")
+    assert_raise(ArgumentError) { RubyVM::AbstractSyntaxTree.of(method) }
+  end
+
   def test_scope_local_variables
     node = RubyVM::AbstractSyntaxTree.parse("_x = 0")
     lv, _, body = *node.children


### PR DESCRIPTION
This adds a flag to the iseq field for whether it was defined in
eval.  For all iseqs created in compile.c, check whether the
current iseq or a parent iseq has type ISEQ_TYPE_EVAL, and if
so, set the defined in eval flag in the created iseq.  In AST.of,
raise an exception if the defined in eval flag is set on the iseq.

Fixes [Bug #16983]