### PR TITLE
Annotate Hash#key? and the likes as inline

### DIFF
--- a/.document
+++ b/.document
@@ -15,6 +15,7 @@ array.rb
 ast.rb
 dir.rb
 gc.rb
+hash.rb
 io.rb
 kernel.rb
 numeric.rb

--- a/benchmark/mjit_hash.yml
+++ b/benchmark/mjit_hash.yml
@@ -1,0 +1,17 @@
+type: lib/benchmark_driver/runner/mjit
+prelude: |
+  def hash_include?(hash, key) hash.include?(key) end
+  def hash_member?(hash, key)  hash.member?(key)  end
+  def hash_has_key?(hash, key) hash.has_key?(key) end
+  def hash_key?(hash, key)     hash.key?(key)     end
+
+  hash = { key: 1 }
+  key = :key
+
+benchmark:
+  - hash_include?(hash, key)
+  - hash_member?(hash, key)
+  - hash_has_key?(hash, key)
+  - hash_key?(hash, key)
+
+loop_count: 40000000

--- a/common.mk
+++ b/common.mk
@@ -1022,6 +1022,7 @@ BUILTIN_RB_SRCS = \
 		$(srcdir)/ast.rb \
 		$(srcdir)/dir.rb \
 		$(srcdir)/gc.rb \
+		$(srcdir)/hash.rb \
 		$(srcdir)/numeric.rb \
 		$(srcdir)/io.rb \
 		$(srcdir)/pack.rb \
@@ -6216,11 +6217,14 @@ hash.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 hash.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
 hash.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 hash.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
+hash.$(OBJEXT): {$(VPATH)}builtin.h
 hash.$(OBJEXT): {$(VPATH)}config.h
 hash.$(OBJEXT): {$(VPATH)}debug_counter.h
 hash.$(OBJEXT): {$(VPATH)}defines.h
 hash.$(OBJEXT): {$(VPATH)}encoding.h
 hash.$(OBJEXT): {$(VPATH)}hash.c
+hash.$(OBJEXT): {$(VPATH)}hash.rb
+hash.$(OBJEXT): {$(VPATH)}hash.rbinc
 hash.$(OBJEXT): {$(VPATH)}id.h
 hash.$(OBJEXT): {$(VPATH)}id_table.h
 hash.$(OBJEXT): {$(VPATH)}intern.h
@@ -8199,6 +8203,7 @@ miniinit.$(OBJEXT): {$(VPATH)}dir.rb
 miniinit.$(OBJEXT): {$(VPATH)}encoding.h
 miniinit.$(OBJEXT): {$(VPATH)}gc.rb
 miniinit.$(OBJEXT): {$(VPATH)}gem_prelude.rb
+miniinit.$(OBJEXT): {$(VPATH)}hash.rb
 miniinit.$(OBJEXT): {$(VPATH)}id.h
 miniinit.$(OBJEXT): {$(VPATH)}intern.h
 miniinit.$(OBJEXT): {$(VPATH)}internal.h

--- a/hash.c
+++ b/hash.c
@@ -43,6 +43,7 @@
 #include "ruby_assert.h"
 #include "symbol.h"
 #include "transient_heap.h"
+#include "builtin.h"
 
 #ifndef HASH_DEBUG
 #define HASH_DEBUG 0
@@ -3630,18 +3631,6 @@ rb_hash_values(VALUE hash)
     return values;
 }
 
-/*
- *  call-seq:
- *    hash.include?(key) -> true or false
- *    hash.has_key?(key) -> true or false
- *    hash.key?(key) -> true or false
- *    hash.member?(key) -> true or false
-
- *  Methods #has_key?, #key?, and #member? are aliases for \#include?.
- *
- *  Returns +true+ if +key+ is a key in +self+, otherwise +false+.
- */
-
 MJIT_FUNC_EXPORTED VALUE
 rb_hash_has_key(VALUE hash, VALUE key)
 {
@@ -7035,11 +7024,7 @@ Init_Hash(void)
     rb_define_method(rb_cHash, "compact", rb_hash_compact, 0);
     rb_define_method(rb_cHash, "compact!", rb_hash_compact_bang, 0);
 
-    rb_define_method(rb_cHash, "include?", rb_hash_has_key, 1);
-    rb_define_method(rb_cHash, "member?", rb_hash_has_key, 1);
-    rb_define_method(rb_cHash, "has_key?", rb_hash_has_key, 1);
     rb_define_method(rb_cHash, "has_value?", rb_hash_has_value, 1);
-    rb_define_method(rb_cHash, "key?", rb_hash_has_key, 1);
     rb_define_method(rb_cHash, "value?", rb_hash_has_value, 1);
 
     rb_define_method(rb_cHash, "compare_by_identity", rb_hash_compare_by_id, 0);
@@ -7206,3 +7191,5 @@ Init_Hash(void)
 
     HASH_ASSERT(sizeof(ar_hint_t) * RHASH_AR_TABLE_MAX_SIZE == sizeof(VALUE));
 }
+
+#include "hash.rbinc"

--- a/hash.rb
+++ b/hash.rb
@@ -1,0 +1,39 @@
+class Hash
+  # call-seq:
+  #   hash.include?(key) -> true or false
+  #
+  # Methods #has_key?, #key?, and #member? are aliases for \#include?.
+  #
+  # Returns +true+ if +key+ is a key in +self+, otherwise +false+.
+  def include?(key)
+    Primitive.attr! 'inline'
+    Primitive.cexpr! 'rb_hash_has_key(self, key)'
+  end
+
+  # call-seq:
+  #   hash.member?(key) -> true or false
+  #
+  # Returns +true+ if +key+ is a key in +self+, otherwise +false+.
+  def member?(key)
+    Primitive.attr! 'inline'
+    Primitive.cexpr! 'rb_hash_has_key(self, key)'
+  end
+
+  # call-seq:
+  #   hash.has_key?(key) -> true or false
+  #
+  # Returns +true+ if +key+ is a key in +self+, otherwise +false+.
+  def has_key?(key)
+    Primitive.attr! 'inline'
+    Primitive.cexpr! 'rb_hash_has_key(self, key)'
+  end
+
+  # call-seq:
+  #   hash.key?(key) -> true or false
+  #
+  # Returns +true+ if +key+ is a key in +self+, otherwise +false+.
+  def key?(key)
+    Primitive.attr! 'inline'
+    Primitive.cexpr! 'rb_hash_has_key(self, key)'
+  end
+end

--- a/inits.c
+++ b/inits.c
@@ -86,6 +86,7 @@ rb_call_builtin_inits(void)
 {
 #define BUILTIN(n) CALL(builtin_##n)
     BUILTIN(gc);
+    BUILTIN(hash);
     BUILTIN(ractor);
     BUILTIN(numeric);
     BUILTIN(io);


### PR DESCRIPTION
## Benchmark

```
$ benchmark-driver benchmark/mjit_hash.yml -v --rbenv 'before --jit;after --jit'
before --jit: ruby 3.1.0dev (2021-05-22T06:36:56Z master fb4195b969) +JIT [x86_64-linux]
after --jit: ruby 3.1.0dev (2021-05-22T07:31:34Z inline-hash-key f4c65bfdd3) +JIT [x86_64-linux]
Calculating -------------------------------------
                         before --jit  after --jit
hash_include?(hash, key)      28.187M      32.555M i/s -     40.000M times in 1.419075s 1.228708s
 hash_member?(hash, key)      27.858M      32.444M i/s -     40.000M times in 1.435856s 1.232886s
hash_has_key?(hash, key)      28.178M      32.563M i/s -     40.000M times in 1.419551s 1.228397s
    hash_key?(hash, key)      26.726M      32.805M i/s -     40.000M times in 1.496653s 1.219334s

Comparison:
             hash_include?(hash, key)
             after --jit:  32554529.5 i/s
            before --jit:  28187373.4 i/s - 1.15x  slower

              hash_member?(hash, key)
             after --jit:  32444198.8 i/s
            before --jit:  27857944.9 i/s - 1.16x  slower

             hash_has_key?(hash, key)
             after --jit:  32562775.1 i/s
            before --jit:  28177917.8 i/s - 1.16x  slower

                 hash_key?(hash, key)
             after --jit:  32804780.3 i/s
            before --jit:  26726307.0 i/s - 1.23x  slower
```

<details>
<summary>VM performance isn't impacted by this.</summary>

```
$ benchmark-driver benchmark/mjit_hash.yml -v --rbenv 'before;after'
before: ruby 3.1.0dev (2021-05-22T06:36:56Z master fb4195b969) [x86_64-linux]
after: ruby 3.1.0dev (2021-05-22T07:31:34Z inline-hash-key f4c65bfdd3) [x86_64-linux]
Calculating -------------------------------------
                             before       after
hash_include?(hash, key)    24.405M     24.516M i/s -     40.000M times in 1.639013s 1.631577s
 hash_member?(hash, key)    23.984M     24.149M i/s -     40.000M times in 1.667805s 1.656405s
hash_has_key?(hash, key)    25.367M     24.303M i/s -     40.000M times in 1.576830s 1.645916s
    hash_key?(hash, key)    24.978M     24.549M i/s -     40.000M times in 1.601419s 1.629409s

Comparison:
             hash_include?(hash, key)
                   after:  24516154.2 i/s
                  before:  24404934.7 i/s - 1.00x  slower

              hash_member?(hash, key)
                   after:  24148684.2 i/s
                  before:  23983612.7 i/s - 1.01x  slower

             hash_has_key?(hash, key)
                  before:  25367357.0 i/s
                   after:  24302582.1 i/s - 1.04x  slower

                 hash_key?(hash, key)
                  before:  24977841.3 i/s
                   after:  24548783.8 i/s - 1.02x  slower
```

</details>