### PR TITLE
Refactor num_zero_p function

### DIFF
--- a/numeric.c
+++ b/numeric.c
@@ -748,10 +748,7 @@ num_abs(VALUE num)
 static VALUE
 num_zero_p(VALUE num)
 {
-    if (rb_equal(num, INT2FIX(0))) {
-        return Qtrue;
-    }
-    return Qfalse;
+    return rb_equal(num, INT2FIX(0));
 }
 
 static VALUE


### PR DESCRIPTION
`num_zero_p` function is implemented by these code(in `numeric.c`).

```c
static VALUE
num_zero_p(VALUE num)
{
    if (rb_equal(num, INT2FIX(0))) {
        return Qtrue;
    }
    return Qfalse;
}
```

However, `rb_equal` function return `Qtrue` or `Qfalse`.

So, I think that `num_zero_p` function can replace these code.

```c
static VALUE
num_zero_p(VALUE num)
{
    return rb_equal(num, INT2FIX(0));
}
```