### PR TITLE
Locindex

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -6790,6 +6790,7 @@ iseq.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 iseq.$(OBJEXT): {$(VPATH)}builtin.h
 iseq.$(OBJEXT): {$(VPATH)}config.h
 iseq.$(OBJEXT): {$(VPATH)}constant.h
+iseq.$(OBJEXT): {$(VPATH)}debug.h
 iseq.$(OBJEXT): {$(VPATH)}debug_counter.h
 iseq.$(OBJEXT): {$(VPATH)}defines.h
 iseq.$(OBJEXT): {$(VPATH)}encoding.h

--- a/ext/objspace/lib/objspace.rb
+++ b/ext/objspace/lib/objspace.rb
@@ -88,4 +88,44 @@ module ObjectSpace
     return nil if output == :stdout
     ret
   end
+
+  # call-seq: trace_object_allocations_start
+  #
+  # Starts tracing object allocations.
+  def trace_object_allocations_start light: false
+    trace_object_allocations_start_(light)
+  end
+
+  # call-seq: trace_object_allocations { block }
+  #
+  # Starts tracing object allocations from the ObjectSpace extension module.
+  #
+  # For example:
+  #
+  #	require 'objspace'
+  #
+  #	class C
+  #	  include ObjectSpace
+  #
+  #	  def foo
+  #	    trace_object_allocations do
+  #	      obj = Object.new
+  #	      p "#{allocation_sourcefile(obj)}:#{allocation_sourceline(obj)}"
+  #	    end
+  #	  end
+  #	end
+  #
+  #	C.new.foo #=> "objtrace.rb:8"
+  #
+  # This example has included the ObjectSpace module to make it easier to read,
+  # but you can also use the ::trace_object_allocations notation (recommended).
+  #
+  # Note that this feature introduces a huge performance decrease and huge
+  # memory consumption.
+  def trace_object_allocations light: false
+    trace_object_allocations_start_ light
+    yield
+  ensure
+    trace_object_allocations_stop
+  end
 end

--- a/ext/objspace/lib/objspace/trace.rb
+++ b/ext/objspace/lib/objspace/trace.rb
@@ -23,7 +23,7 @@
 #   4:
 #   5: p obj  #=> "str" @ test.rb:3
 
-require 'objspace.so'
+require 'objspace'
 
 module Kernel
   remove_method :p
@@ -40,6 +40,6 @@ module Kernel
   end
 end
 
-ObjectSpace.trace_object_allocations_start
+ObjectSpace.trace_object_allocations_start(light: true)
 
 warn "objspace/trace is enabled"

--- a/ext/objspace/objspace.h
+++ b/ext/objspace/objspace.h
@@ -9,12 +9,12 @@ struct allocation_info {
     VALUE klass;
 
     /* allocation info */
-    const char *path;
-    unsigned long line;
+    unsigned int locindex;
     const char *class_path;
     VALUE mid;
     size_t generation;
 };
 struct allocation_info *objspace_lookup_allocation_info(VALUE obj);
+unsigned int objspace_lookup_locindex(VALUE obj);
 
 #endif

--- a/include/ruby/debug.h
+++ b/include/ruby/debug.h
@@ -69,6 +69,7 @@ rb_event_flag_t rb_tracearg_event_flag(rb_trace_arg_t *trace_arg);
 VALUE rb_tracearg_event(rb_trace_arg_t *trace_arg);
 VALUE rb_tracearg_lineno(rb_trace_arg_t *trace_arg);
 VALUE rb_tracearg_path(rb_trace_arg_t *trace_arg);
+unsigned int rb_tracearg_locindex(rb_trace_arg_t *trace_arg);
 VALUE rb_tracearg_method_id(rb_trace_arg_t *trace_arg);
 VALUE rb_tracearg_callee_id(rb_trace_arg_t *trace_arg);
 VALUE rb_tracearg_defined_class(rb_trace_arg_t *trace_arg);
@@ -97,6 +98,8 @@ typedef enum {
 
 void rb_add_event_hook2(rb_event_hook_func_t func, rb_event_flag_t events, VALUE data, rb_event_hook_flag_t hook_flag);
 void rb_thread_add_event_hook2(VALUE thval, rb_event_hook_func_t func, rb_event_flag_t events, VALUE data, rb_event_hook_flag_t hook_flag);
+
+bool rb_locindex_resolve(unsigned int locindex, VALUE *fname, int *line);
 
 RBIMPL_SYMBOL_EXPORT_END()
 

--- a/iseq.c
+++ b/iseq.c
@@ -3623,7 +3623,7 @@ bool
 rb_locindex_resolve(unsigned int locindex, VALUE *fname, int *line)
 {
     VM_ASSERT(locindex > 0);
-    int len = RARRAY_LEN(recorded_iseq_ary);
+    int len = RARRAY_LENINT(recorded_iseq_ary);
 
     // TODO: bsearch
     for (int i=0; i<len; i++) {

--- a/iseq.h
+++ b/iseq.h
@@ -308,6 +308,10 @@ VALUE rb_iseq_defined_string(enum defined_type type);
 /* vm.c */
 VALUE rb_iseq_local_variables(const rb_iseq_t *iseq);
 
+// recorded information
+unsigned int rb_iseq_recorded_index(rb_iseq_t *iseq);
+unsigned int rb_iseq_recorded_locindex(rb_iseq_t *iseq, const VALUE *pc);
+
 RUBY_SYMBOL_EXPORT_END
 
 #endif /* RUBY_ISEQ_H */

--- a/vm_core.h
+++ b/vm_core.h
@@ -427,6 +427,8 @@ struct rb_iseq_constant_body {
 	VALUE coverage;
         VALUE pc2branchindex;
 	VALUE *original_iseq;
+        unsigned int recorded_index;
+        unsigned int recorded_locindex_start;
     } variable;
 
     unsigned int local_table_size;

--- a/vm_trace.c
+++ b/vm_trace.c
@@ -840,8 +840,13 @@ unsigned int
 rb_tracearg_locindex(rb_trace_arg_t *trace_arg)
 {
     const rb_control_frame_t *cfp = rb_vm_get_ruby_level_next_cfp(trace_arg->ec, trace_arg->cfp);
-    const rb_iseq_t *iseq = cfp->iseq;
-    return rb_iseq_recorded_locindex((rb_iseq_t *)iseq, cfp->pc);
+    if (LIKELY(cfp)) {
+        const rb_iseq_t *iseq = cfp->iseq;
+        return rb_iseq_recorded_locindex((rb_iseq_t *)iseq, cfp->pc);
+    }
+    else {
+        return 0;
+    }
 }
 
 static void

--- a/vm_trace.c
+++ b/vm_trace.c
@@ -828,11 +828,20 @@ rb_tracearg_lineno(rb_trace_arg_t *trace_arg)
     fill_path_and_lineno(trace_arg);
     return INT2FIX(trace_arg->lineno);
 }
+
 VALUE
 rb_tracearg_path(rb_trace_arg_t *trace_arg)
 {
     fill_path_and_lineno(trace_arg);
     return trace_arg->path;
+}
+
+unsigned int
+rb_tracearg_locindex(rb_trace_arg_t *trace_arg)
+{
+    const rb_control_frame_t *cfp = rb_vm_get_ruby_level_next_cfp(trace_arg->ec, trace_arg->cfp);
+    const rb_iseq_t *iseq = cfp->iseq;
+    return rb_iseq_recorded_locindex((rb_iseq_t *)iseq, cfp->pc);
 }
 
 static void


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/17884

Two features

    introduce "locindex" for profiling tools

    calculating line number from PC requires some calculation.
    Profiling tools need to record location information but it
    takes a time to calculate the line.

    This patch introduces "locindex" which is a unique index
    for PC. You can get "locindex" with current PC in a constant time
    and "locindex" can be translated into file:line information.
    Now you can get "locindex" with `rb_tracearg_locindex()`
    TracePoint API.

---

    light mode for `trace_object_allocations`

    `ObjectSpace.trace_object_allocations` records many information,
    but in many cases only file and line information are needed.

    This patch introduces "light" mode for this API. On light mode,
    only allocation site information (file and line) are recorded
    with "locindex".

    'objspace/trace' library now uses light mode, and we found the
    following performance improvements:

    ```
    real    0m19.764s
    user    0m19.200s
    sys     0m0.561s

    real    0m42.638s
    user    0m41.695s
    sys     0m0.920s

    real    0m25.850s
    user    0m25.085s
    sys     0m0.762s
    ```

    ```ruby
    require 'objspace/trace'
    require 'rdoc/rdoc'
    require 'tmpdir'

    srcdir = File.expand_path(__dir__)
    STDERR.puts srcdir

    Dir.mktmpdir('rdocbench-'){|d|
      dir = File.join(d, 'rdocbench')
      args = %W(--root #{srcdir} --page-dir #{srcdir}/doc --encoding=UTF-8 --no-force-update --all --ri --debug --quiet #{srcdir})
      args << '--op' << dir

      r = RDoc::RDoc.new
      r.document args
    }
    ```
