### PR TITLE
Disable compaction on platforms that can't support it

### DIFF
--- a/test/ruby/test_gc_compact.rb
+++ b/test/ruby/test_gc_compact.rb
@@ -4,11 +4,31 @@ require 'fiddle'
 require 'etc'
 
 class TestGCCompact < Test::Unit::TestCase
-  class AutoCompact < Test::Unit::TestCase
+  module SupportsCompact
     def setup
       skip "autocompact not supported on this platform" unless supports_auto_compact?
       super
     end
+
+    private
+
+    def supports_auto_compact?
+      return true unless defined?(Etc::SC_PAGE_SIZE)
+
+      begin
+        return GC::INTERNAL_CONSTANTS[:HEAP_PAGE_SIZE] % Etc.sysconf(Etc::SC_PAGE_SIZE) == 0
+      rescue NotImplementedError
+      rescue ArgumentError
+      end
+
+      true
+    end
+  end
+
+  include SupportsCompact
+
+  class AutoCompact < Test::Unit::TestCase
+    include SupportsCompact
 
     def test_enable_autocompact
       before = GC.auto_compact
@@ -59,24 +79,15 @@ class TestGCCompact < Test::Unit::TestCase
     ensure
       GC.auto_compact = before
     end
-
-    private
-
-    def supports_auto_compact?
-      return true unless defined?(Etc::SC_PAGE_SIZE)
-
-      begin
-        return GC::INTERNAL_CONSTANTS[:HEAP_PAGE_SIZE] % Etc.sysconf(Etc::SC_PAGE_SIZE) == 0
-      rescue NotImplementedError
-      rescue ArgumentError
-      end
-
-      true
-    end
   end
 
   def os_page_size
     return true unless defined?(Etc::SC_PAGE_SIZE)
+  end
+
+  def setup
+    skip "autocompact not supported on this platform" unless supports_auto_compact?
+    super
   end
 
   def test_gc_compact_stats


### PR DESCRIPTION
Manual compaction also requires a read barrier, so we need to disable
even manual compaction on platforms that don't support mprotect.

[Bug #17871]