### PR TITLE
.travis.yml: Remove skipped tests on ppc64le.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,12 +85,6 @@ env:
     name: ppc64le-linux
     arch: ppc64le
     <<: *gcc-10
-    env:
-      # FIXME: Skip some failing TestGCCompact tests.
-      # https://bugs.ruby-lang.org/issues/17871
-      - TEST_ALL_SKIPPED_TESTS="test_gc_compact_stats test_complex_hash_keys test_ast_compacts test_compact_count"
-      # The tests crash the process.
-      - RUN_SEPARATED_TESTS=false
 
   - &s390x-linux
     name: s390x-linux


### PR DESCRIPTION
It was fixed at fc832ffbfaf581ff63ef40dc3f4ec5c8ff39aae6 .
