### PR TITLE
Refactor rb_str_empty function

### DIFF
--- a/string.c
+++ b/string.c
@@ -2001,9 +2001,9 @@ rb_str_bytesize(VALUE str)
 static VALUE
 rb_str_empty(VALUE str)
 {
-    if (RSTRING_LEN(str) == 0)
-	return Qtrue;
-    return Qfalse;
+    if (RSTRING_LEN(str))
+	return Qfalse;
+    return Qtrue;
 }
 
 /*


### PR DESCRIPTION
`rb_str_empty` function is used  `RSTRING_LEN` to `String` length check.

```c
static VALUE
rb_str_empty(VALUE str)
{
    if (RSTRING_LEN(str) == 0)
	return Qtrue;
    return Qfalse;
}
```

`RSTRINGLEN` return length like `42` or `0`.
So, I think that can replace these code.

```c
static VALUE
rb_str_empty(VALUE str)
{
    if (RSTRING_LEN(str))
	return Qfalse;
    return Qtrue;
}
```