### PR TITLE
Tweak bundler synchronization from upstream

### DIFF
--- a/tool/sync_default_gems.rb
+++ b/tool/sync_default_gems.rb
@@ -89,7 +89,7 @@ def sync_default_gems(gem)
     cp_r(Dir.glob("#{upstream}/bundler/exe/bundle*"), "libexec")
 
     gemspec_content = File.readlines("#{upstream}/bundler/bundler.gemspec").map do |line|
-      next if line =~ /extra_rdoc_files/
+      next if line =~ /LICENSE\.md/
 
       line.gsub("bundler.gemspec", "lib/bundler/bundler.gemspec").gsub('"exe"', '"libexec"')
     end.compact.join


### PR DESCRIPTION
I'll be removing the `extra_rdoc_files` from bundler gemspec since it made documentation installation very slow.

So, we need to use something else to detect the line that adds markdown files to the gemspec file list in order to remove it.