### PR TITLE
Look in prepended modules before class during constant lookup

### DIFF
--- a/test/ruby/test_module.rb
+++ b/test/ruby/test_module.rb
@@ -2890,6 +2890,58 @@ class TestModule < Test::Unit::TestCase
     }
   end
 
+  def test_prepend_constant_lookup
+    m = Module.new do
+      const_set(:C, :m)
+    end
+    c = Class.new do
+      const_set(:C, :c)
+      prepend m
+    end
+    sc = Class.new(c)
+    assert_equal(:m, sc.const_get(:C))
+    assert_equal(:m, sc::C)
+
+    assert_equal(:m, c.const_get(:C))
+    assert_equal(:m, c::C)
+    assert_equal(:m, c.const_get(:C, false))
+
+    m2 = Module.new do
+      const_set(:C, :m2)
+      prepend m
+    end
+    assert_equal(:m, m2.const_get(:C))
+    assert_equal(:m, m2::C)
+
+    c2 = Class.new do
+      const_set(:C, :c2)
+      prepend m2
+    end
+    assert_equal(:m, c2.const_get(:C))
+    assert_equal(:m, c2::C)
+
+    m3 = Module.new do
+      const_set(:C, :m3)
+      include m
+    end
+    assert_equal(:m3, m3.const_get(:C))
+    assert_equal(:m3, m3::C)
+
+    c3 = Class.new do
+      const_set(:C, :c3)
+      prepend m3
+    end
+    assert_equal(:m3, c3.const_get(:C))
+    assert_equal(:m3, c3::C)
+
+    c4 = Class.new do
+      const_set(:C, :c4)
+      include m2
+    end
+    assert_equal(:c4, c4.const_get(:C))
+    assert_equal(:c4, c4::C)
+  end
+
   def test_inspect_segfault
     bug_10282 = '[ruby-core:65214] [Bug #10282]'
     assert_separately [], "#{<<~"begin;"}\n#{<<~'end;'}"


### PR DESCRIPTION
When looking for constants in a class, previously prepended modules were
not considered until after the class.  This is different than method
lookup, where methods in prepended modules are considered before the
class.

The reason for this behavior is that when an origin iclass is created,
the methods are moved from the original class to the origin class, but
the constant table is not moved to the origin class, it stays in the
original class.

There are two ways to fix this.  One would be to move the constant
table to the origin class, just as the method table is moved.  This
may be a better long term fix, but I'm guessing that will break any
internal code that assumes the constant table will be in the class
itself. I did not attempt that approach.

This commit uses a more localized fix.  During constant lookup, when
we come to a class that has an origin class and prepended module(s),
skip the class and try the lookup in the prepended module(s). Once
we reach the origin class, then look in the original class, before
continuing lookup with the ancestor of the origin class. This can
be a recursive process as a class can prepend a module that has
prepended other modules.

This code is a bit more complex than I'd like in order to use
recursion to handle looking in prepended modules.  The recursive
method is chosen here as origin classes operate as a stack, and
using recursion allows for using the C stack to store information
needed during the lookup in prepended modules.  I think it is best
to avoid allocating heap memory during constant lookup.

Fixes [Bug #17887]