### PR TITLE
Add Thread::BacktraceLocation#node_id

### DIFF
--- a/sample/rich_trace_sample.rb
+++ b/sample/rich_trace_sample.rb
@@ -1,0 +1,36 @@
+def check
+  foo = "foo"
+  bar = nil   # accidentally nil
+  baz = "baz"
+
+  puts(foo.upcase, bar.upcase, baz.upcase)
+end
+
+begin
+  check
+rescue Exception
+  find_node_by_id = -> id, node {
+    return nil unless node.is_a?(RubyVM::AbstractSyntaxTree::Node)
+    return node if node.node_id == id
+    node.children.each do |child_node|
+      ret = find_node_by_id[id, child_node]
+      return ret if ret
+    end
+    return nil
+  }
+
+  root_node =
+
+  $!.full_message.lines.zip($!.backtrace_locations) do |line, loc|
+    puts line
+    node = find_node_by_id[loc.node_id, RubyVM::AbstractSyntaxTree.parse_file(loc.path)]
+    if File.readable?(loc.path)
+      lines = File.foreach(loc.path).to_a[node.first_lineno - 1 .. node.last_lineno - 1]
+      lines[-1][node.last_column, 0] = "\e[0m"
+      lines[0][node.first_column, 0] = "\e[4m"
+      puts
+      lines.each {|line| puts "> " + line }
+      puts
+    end
+  end
+end


### PR DESCRIPTION
... only if EXPERIMENTAL_ISEQ_NODE_ID is defined.
This is useful for indentifying which method call an exception occur in.

Example:

```
foo = "foo"
bar = nil   # accidentally nil
baz = "baz"

puts(foo.upcase, bar.upcase, baz.upcase)
```

```
test.rb:5:in `<main>`: undefined method `upcase' for nil:NilClass

puts(foo.upcase, bar.upcase, baz.upcase)
                 ^^^^^^^^^^
```

Co-Authored-By: Yuichiro Kaneko <yui-knk@ruby-lang.org>