### PR TITLE
tool/ci_functions.sh: Fix typos and improve the comment. [ci skip]

### DIFF
--- a/tool/ci_functions.sh
+++ b/tool/ci_functions.sh
@@ -7,7 +7,7 @@
 # See `ruby tool/test/runner.rb --help` `-n` option.
 function ci_to_excluded_test_opts {
   local tests_str="${1}"
-  # Use the backward matching `!/name$/`, as the perfect matching does not work.
+  # Use the backward matching `!/name$/`, as the perfect matching doesn't work.
   # https://bugs.ruby-lang.org/issues/16936
   ruby <<EOF
     opts = "${tests_str}".split.map { |test| "-n \!/#{test}\$$/" }
@@ -16,7 +16,7 @@ EOF
   return 0
 }
 
-# Create options with patterns `-n /name1/ -n /name2/ ..` to exclude the test
+# Create options with patterns `-n name1 -n name2 ..` to include the test
 # method names by the method names `name1 name2 ..`.
 # See `ruby tool/test/runner.rb --help` `-n` option.
 function ci_to_included_test_opts {


### PR DESCRIPTION
Improve the comment in the `tool/ci_functions.sh`.
I am going to merge this without someone's review, as it is a small change.
 