### PR TITLE
Skip a `File.atime` test randomly failing on Travis ppc64le.

### DIFF
--- a/spec/ruby/core/file/atime_spec.rb
+++ b/spec/ruby/core/file/atime_spec.rb
@@ -22,6 +22,11 @@ describe "File.atime" do
       if supports_subseconds != 0
         expected_time = Time.at(Time.now.to_i + 0.123456)
         File.utime expected_time, 0, @file
+        # FIXME: A random failing test on Travis ppc64le.
+        # https://bugs.ruby-lang.org/issues/17926
+        if ENV.key?('TRAVIS') && ENV['TRAVIS_CPU_ARCH'] == 'ppc64le'
+          skip '[ruby-core:17926] A random failure on Travis ppc64le'
+        end
         File.atime(@file).usec.should == expected_time.usec
       else
         File.atime(__FILE__).usec.should == 0


### PR DESCRIPTION
Skip the test for now to pass the ppc64le.

See <https://bugs.ruby-lang.org/issues/17926>.

---

I checked it is skipped intentionally on my local like this.

```
$ TRAVIS=true TRAVIS_CPU_ARCH=foo make test-spec SPECOPTS=spec/ruby/core/file/atime_spec.rb
...   
1 file, 5 examples, 5 expectations, 0 failures, 0 errors, 0 tagged


$ TRAVIS=true TRAVIS_CPU_ARCH=ppc64le make test-spec SPECOPTS=spec/ruby/core/file/atime_spec.rb
...
1 file, 5 examples, 4 expectations, 0 failures, 0 errors, 0 tagged
```
