### PR TITLE
Optimize Integer == (Symbol or String) as a fastpath

### DIFF
--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1927,7 +1927,11 @@ opt_equality_specialized(VALUE recv, VALUE obj)
         goto compare_by_identity;
     }
     else if (SPECIAL_CONST_P(recv)) {
-        //
+        if (FIXNUM_P(recv) && EQ_UNREDEFINED_P(INTEGER)) {
+            if (STATIC_SYM_P(obj) && EQ_UNREDEFINED_P(SYMBOL)) return Qfalse;
+            if (RB_TYPE_P(obj, T_STRING) && EQ_UNREDEFINED_P(STRING)) return Qfalse;
+        }
+        return Qundef;
     }
     else if (RBASIC_CLASS(recv) == rb_cFloat && RB_FLOAT_TYPE_P(obj) && EQ_UNREDEFINED_P(FLOAT)) {
         double a = RFLOAT_VALUE(recv);


### PR DESCRIPTION
Previously `0 == :foo` was much slower than `0 == -1` because the VM
optimizes only the case where the arguments are both Fixnums.

```
require "benchmark"

Benchmark.bmbm do |b|
  b.report { 10000000.times { 0 == -1 } }
  b.report { 10000000.times { 0 == :foo } }
end
```

Before:

```
       user     system      total        real
   0.291631   0.000000   0.291631 (  0.291660)
   1.636855   0.000000   1.636855 (  1.636883)
```

After:

```
       user     system      total        real
   0.290631   0.000000   0.290631 (  0.290632)
   0.291385   0.000000   0.291385 (  0.291387)
```

I encountered this issue when tweaking a program for programming
contest. It used some magic numbers like -1 for special meaning.
Because it is not a good practice, I replaced it with `:special`, but
unfortunately the code became significantly slower (for my case, three
times slower in total).

Note: Interestingly, Symbol == Integer is already fast enough; there is
another fastpath for Object#== which is used for Symbol == Integer
because there is no Symbol#== defined.