### PR TITLE
Enable Travis on the specific branches or forked repositories.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -203,11 +203,8 @@ script:
   - $SETARCH make -s test-spec MSPECOPT=-ff # not using `-j` because sometimes `mspec -j` silently dies
   - $SETARCH make -s -o showflags leaked-globals
 
-# Branch matrix.  Not all branches are Travis-ready so we limit branches here.
-branches:
-  only:
-    - master
-    - /^ruby_\d_\d$/
+# We enable Travis on the specific branches or forked repositories here.
+if: (repo = ruby/ruby AND (branch = master OR branch =~ /^ruby_\d_\d$/)) OR repo != ruby/ruby
 
 # We want to be notified when something happens.
 notifications:


### PR DESCRIPTION
This PR is to fix the Ruby ticket <https://bugs.ruby-lang.org/issues/17936>.

---

Align the Travis enabling timing with GitHub Actions.

For the syntax, see <https://docs.travis-ci.com/user/conditions-v1>.
We use `repo` syntax rather than `fork = true/false` syntax to show a general usage in any repositories on GitHub.
The non-forked repo is not always a primary repo in any GitHub repositories.

[Bug #17936]

---

Note the following condition without `repo = ruby/ruby AND` is not enough. Because when sending a PR from forked repo's `master` or `ruby_N_N` on the condition, the PR has 2 Travis builds (Travis CI - Pull-request, and Travis CI - Branch). So, we need to add the condition `repo = ruby/ruby AND`.

```
+if: branch = master OR branch =~ /^ruby_\d_\d$/ OR repo != ruby/ruby
```
