### PR TITLE
Support AST.of(Thread::Backtrace::Location)

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -254,7 +254,7 @@ ast_node_type(rb_execution_context_t *ec, VALUE self)
     return rb_sym_intern_ascii_cstr(node_type_to_str(data->node));
 }
 
-#ifdef EXPERIMENTAL_ISEQ_NODE_ID
+#ifdef DEBUG_ISEQ_NODE_ID
 static VALUE
 ast_node_node_id(VALUE self)
 {
@@ -725,7 +725,7 @@ Init_ast(void)
     rb_mAST = rb_define_module_under(rb_cRubyVM, "AbstractSyntaxTree");
     rb_cNode = rb_define_class_under(rb_mAST, "Node", rb_cObject);
     rb_undef_alloc_func(rb_cNode);
-#ifdef EXPERIMENTAL_ISEQ_NODE_ID
+#ifdef DEBUG_ISEQ_NODE_ID
     rb_define_method(rb_cNode, "node_id", ast_node_node_id, 0);
 #endif
 }

--- a/compile.c
+++ b/compile.c
@@ -2216,12 +2216,12 @@ add_insn_info(struct iseq_insn_info_entry *insns_info, unsigned int *positions,
 {
     if (insns_info_index == 0 ||
         insns_info[insns_info_index-1].line_no != iobj->insn_info.line_no ||
-#ifdef EXPERIMENTAL_ISEQ_NODE_ID
+#ifdef USE_ISEQ_NODE_ID
         insns_info[insns_info_index-1].node_id != iobj->insn_info.node_id ||
 #endif
         insns_info[insns_info_index-1].events  != iobj->insn_info.events) {
         insns_info[insns_info_index].line_no    = iobj->insn_info.line_no;
-#ifdef EXPERIMENTAL_ISEQ_NODE_ID
+#ifdef USE_ISEQ_NODE_ID
         insns_info[insns_info_index].node_id    = iobj->insn_info.node_id;
 #endif
         insns_info[insns_info_index].events     = iobj->insn_info.events;
@@ -10059,7 +10059,7 @@ rb_iseq_build_from_ary(rb_iseq_t *iseq, VALUE misc, VALUE locals, VALUE params,
     }
 
     VALUE node_ids = Qfalse;
-#ifdef EXPERIMENTAL_ISEQ_NODE_ID
+#ifdef USE_ISEQ_NODE_ID
     node_ids = rb_hash_aref(misc, ID2SYM(rb_intern("node_ids")));
     if (!RB_TYPE_P(node_ids, T_ARRAY)) {
 	rb_raise(rb_eTypeError, "node_ids is not an array");
@@ -10940,7 +10940,7 @@ ibf_dump_insns_info_body(struct ibf_dump *dump, const rb_iseq_t *iseq)
     unsigned int i;
     for (i = 0; i < iseq->body->insns_info.size; i++) {
         ibf_dump_write_small_value(dump, entries[i].line_no);
-#ifdef EXPERIMENTAL_ISEQ_NODE_ID
+#ifdef USE_ISEQ_NODE_ID
         ibf_dump_write_small_value(dump, entries[i].node_id);
 #endif
         ibf_dump_write_small_value(dump, entries[i].events);
@@ -10958,7 +10958,7 @@ ibf_load_insns_info_body(const struct ibf_load *load, ibf_offset_t body_offset, 
     unsigned int i;
     for (i = 0; i < size; i++) {
         entries[i].line_no = (int)ibf_load_small_value(load, &reading_pos);
-#ifdef EXPERIMENTAL_ISEQ_NODE_ID
+#ifdef USE_ISEQ_NODE_ID
         entries[i].node_id = (int)ibf_load_small_value(load, &reading_pos);
 #endif
         entries[i].events = (rb_event_flag_t)ibf_load_small_value(load, &reading_pos);

--- a/internal/vm.h
+++ b/internal/vm.h
@@ -111,6 +111,8 @@ int rb_backtrace_p(VALUE obj);
 VALUE rb_backtrace_to_str_ary(VALUE obj);
 VALUE rb_backtrace_to_location_ary(VALUE obj);
 void rb_backtrace_each(VALUE (*iter)(VALUE recv, VALUE str), VALUE output);
+int rb_frame_info_p(VALUE obj);
+void rb_frame_info_get(VALUE obj, VALUE *path, int *node_id);
 
 MJIT_SYMBOL_EXPORT_BEGIN
 VALUE rb_ec_backtrace_object(const struct rb_execution_context_struct *ec);

--- a/iseq.c
+++ b/iseq.c
@@ -1840,7 +1840,7 @@ rb_iseq_line_no(const rb_iseq_t *iseq, size_t pos)
     }
 }
 
-#ifdef EXPERIMENTAL_ISEQ_NODE_ID
+#ifdef USE_ISEQ_NODE_ID
 int
 rb_iseq_node_id(const rb_iseq_t *iseq, size_t pos)
 {
@@ -2943,7 +2943,7 @@ iseq_data_to_ary(const rb_iseq_t *iseq)
     /* make body with labels and insert line number */
     body = rb_ary_new();
     prev_insn_info = NULL;
-#ifdef EXPERIMENTAL_ISEQ_NODE_ID
+#ifdef USE_ISEQ_NODE_ID
     VALUE node_ids = rb_ary_new();
 #endif
 
@@ -2957,7 +2957,7 @@ iseq_data_to_ary(const rb_iseq_t *iseq)
 	}
 
 	info = get_insn_info(iseq, pos);
-#ifdef EXPERIMENTAL_ISEQ_NODE_ID
+#ifdef USE_ISEQ_NODE_ID
         rb_ary_push(node_ids, INT2FIX(info->node_id));
 #endif
 
@@ -2997,7 +2997,7 @@ iseq_data_to_ary(const rb_iseq_t *iseq)
 		INT2FIX(iseq_body->location.code_location.beg_pos.column),
 		INT2FIX(iseq_body->location.code_location.end_pos.lineno),
 		INT2FIX(iseq_body->location.code_location.end_pos.column)));
-#ifdef EXPERIMENTAL_ISEQ_NODE_ID
+#ifdef USE_ISEQ_NODE_ID
     rb_hash_aset(misc, ID2SYM(rb_intern("node_ids")), node_ids);
 #endif
 

--- a/iseq.c
+++ b/iseq.c
@@ -2998,7 +2998,7 @@ iseq_data_to_ary(const rb_iseq_t *iseq)
 		INT2FIX(iseq_body->location.code_location.end_pos.lineno),
 		INT2FIX(iseq_body->location.code_location.end_pos.column)));
 #ifdef EXPERIMENTAL_ISEQ_NODE_ID
-    rb_hash_aset(misc, ID2SYM(rb_intern("node_ids_for_each_insn")), node_ids);
+    rb_hash_aset(misc, ID2SYM(rb_intern("node_ids")), node_ids);
 #endif
 
     /*

--- a/iseq.h
+++ b/iseq.h
@@ -17,7 +17,9 @@ RUBY_EXTERN const int ruby_api_version[];
 #define ISEQ_MAJOR_VERSION ((unsigned int)ruby_api_version[0])
 #define ISEQ_MINOR_VERSION ((unsigned int)ruby_api_version[1])
 
-//#define EXPERIMENTAL_ISEQ_NODE_ID
+#ifndef USE_ISEQ_NODE_ID
+#define USE_ISEQ_NODE_ID 1
+#endif
 
 #ifndef rb_iseq_t
 typedef struct rb_iseq_struct rb_iseq_t;
@@ -178,7 +180,7 @@ void rb_iseq_mark_insn_storage(struct iseq_compile_data_storage *arena);
 VALUE rb_iseq_load(VALUE data, VALUE parent, VALUE opt);
 VALUE rb_iseq_parameters(const rb_iseq_t *iseq, int is_proc);
 unsigned int rb_iseq_line_no(const rb_iseq_t *iseq, size_t pos);
-#ifdef EXPERIMENTAL_ISEQ_NODE_ID
+#ifdef USE_ISEQ_NODE_ID
 int rb_iseq_node_id(const rb_iseq_t *iseq, size_t pos);
 #endif
 void rb_iseq_trace_set(const rb_iseq_t *iseq, rb_event_flag_t turnon_events);
@@ -218,7 +220,7 @@ struct rb_compile_option_struct {
 
 struct iseq_insn_info_entry {
     int line_no;
-#ifdef EXPERIMENTAL_ISEQ_NODE_ID
+#ifdef USE_ISEQ_NODE_ID
     int node_id;
 #endif
     rb_event_flag_t events;

--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -47,7 +47,7 @@ calc_pos(const rb_iseq_t *iseq, const VALUE *pc, int *lineno, int *node_id)
             return 0;
         }
         if (lineno) *lineno = FIX2INT(iseq->body->location.first_lineno);
-#ifdef EXPERIMENTAL_ISEQ_NODE_ID
+#ifdef USE_ISEQ_NODE_ID
         if (node_id) *node_id = -1;
 #endif
         return 1;
@@ -70,7 +70,7 @@ calc_pos(const rb_iseq_t *iseq, const VALUE *pc, int *lineno, int *node_id)
         }
 #endif
         if (lineno) *lineno = rb_iseq_line_no(iseq, pos);
-#ifdef EXPERIMENTAL_ISEQ_NODE_ID
+#ifdef USE_ISEQ_NODE_ID
         if (node_id) *node_id = rb_iseq_node_id(iseq, pos);
 #endif
         return 1;
@@ -85,7 +85,7 @@ calc_lineno(const rb_iseq_t *iseq, const VALUE *pc)
     return 0;
 }
 
-#ifdef EXPERIMENTAL_ISEQ_NODE_ID
+#ifdef USE_ISEQ_NODE_ID
 inline static int
 calc_node_id(const rb_iseq_t *iseq, const VALUE *pc)
 {
@@ -319,7 +319,7 @@ location_path_m(VALUE self)
     return location_path(location_ptr(self));
 }
 
-#ifdef EXPERIMENTAL_ISEQ_NODE_ID
+#ifdef USE_ISEQ_NODE_ID
 static int
 location_node_id(rb_backtrace_location_t *loc)
 {
@@ -341,7 +341,7 @@ location_node_id(rb_backtrace_location_t *loc)
 void
 rb_frame_info_get(VALUE obj, VALUE *path, int *node_id)
 {
-#ifdef EXPERIMENTAL_ISEQ_NODE_ID
+#ifdef USE_ISEQ_NODE_ID
     rb_backtrace_location_t *loc = location_ptr(obj);
     *path = location_path(loc);
     *node_id = location_node_id(loc);

--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -41,11 +41,12 @@ calc_lineno(const rb_iseq_t *iseq, const VALUE *pc)
     VM_ASSERT(iseq->body->iseq_encoded);
     VM_ASSERT(iseq->body->iseq_size);
     if (! pc) {
-        /* This can happen during VM bootup. */
-        VM_ASSERT(iseq->body->type == ISEQ_TYPE_TOP);
-        VM_ASSERT(! iseq->body->local_table);
-        VM_ASSERT(! iseq->body->local_table_size);
-        return 0;
+        if (iseq->body->type == ISEQ_TYPE_TOP) {
+            VM_ASSERT(! iseq->body->local_table);
+            VM_ASSERT(! iseq->body->local_table_size);
+            return 0;
+        }
+        return FIX2INT(iseq->body->location.first_lineno);
     }
     else {
         ptrdiff_t n = pc - iseq->body->iseq_encoded;
@@ -89,17 +90,13 @@ rb_vm_get_sourceline(const rb_control_frame_t *cfp)
 typedef struct rb_backtrace_location_struct {
     enum LOCATION_TYPE {
 	LOCATION_TYPE_ISEQ = 1,
-	LOCATION_TYPE_ISEQ_CALCED,
 	LOCATION_TYPE_CFUNC,
     } type;
 
     union {
 	struct {
 	    const rb_iseq_t *iseq;
-	    union {
-		const VALUE *pc;
-		int lineno;
-	    } lineno;
+            const VALUE *pc;
 	} iseq;
 	struct {
 	    ID mid;
@@ -125,7 +122,6 @@ location_mark_entry(rb_backtrace_location_t *fi)
 {
     switch (fi->type) {
       case LOCATION_TYPE_ISEQ:
-      case LOCATION_TYPE_ISEQ_CALCED:
 	rb_gc_mark_movable((VALUE)fi->body.iseq.iseq);
 	break;
       case LOCATION_TYPE_CFUNC:
@@ -160,10 +156,7 @@ location_lineno(rb_backtrace_location_t *loc)
 {
     switch (loc->type) {
       case LOCATION_TYPE_ISEQ:
-	loc->type = LOCATION_TYPE_ISEQ_CALCED;
-	return (loc->body.iseq.lineno.lineno = calc_lineno(loc->body.iseq.iseq, loc->body.iseq.lineno.pc));
-      case LOCATION_TYPE_ISEQ_CALCED:
-	return loc->body.iseq.lineno.lineno;
+	return calc_lineno(loc->body.iseq.iseq, loc->body.iseq.pc);
       case LOCATION_TYPE_CFUNC:
 	if (loc->body.cfunc.prev_loc) {
 	    return location_lineno(loc->body.cfunc.prev_loc);
@@ -194,7 +187,6 @@ location_label(rb_backtrace_location_t *loc)
 {
     switch (loc->type) {
       case LOCATION_TYPE_ISEQ:
-      case LOCATION_TYPE_ISEQ_CALCED:
 	return loc->body.iseq.iseq->body->location.label;
       case LOCATION_TYPE_CFUNC:
 	return rb_id2str(loc->body.cfunc.mid);
@@ -242,7 +234,6 @@ location_base_label(rb_backtrace_location_t *loc)
 {
     switch (loc->type) {
       case LOCATION_TYPE_ISEQ:
-      case LOCATION_TYPE_ISEQ_CALCED:
 	return loc->body.iseq.iseq->body->location.base_label;
       case LOCATION_TYPE_CFUNC:
 	return rb_id2str(loc->body.cfunc.mid);
@@ -268,7 +259,6 @@ location_path(rb_backtrace_location_t *loc)
 {
     switch (loc->type) {
       case LOCATION_TYPE_ISEQ:
-      case LOCATION_TYPE_ISEQ_CALCED:
 	return rb_iseq_path(loc->body.iseq.iseq);
       case LOCATION_TYPE_CFUNC:
 	if (loc->body.cfunc.prev_loc) {
@@ -302,7 +292,6 @@ location_realpath(rb_backtrace_location_t *loc)
 {
     switch (loc->type) {
       case LOCATION_TYPE_ISEQ:
-      case LOCATION_TYPE_ISEQ_CALCED:
 	return rb_iseq_realpath(loc->body.iseq.iseq);
       case LOCATION_TYPE_CFUNC:
 	if (loc->body.cfunc.prev_loc) {
@@ -355,13 +344,7 @@ location_to_str(rb_backtrace_location_t *loc)
 	file = rb_iseq_path(loc->body.iseq.iseq);
 	name = loc->body.iseq.iseq->body->location.label;
 
-	lineno = loc->body.iseq.lineno.lineno = calc_lineno(loc->body.iseq.iseq, loc->body.iseq.lineno.pc);
-	loc->type = LOCATION_TYPE_ISEQ_CALCED;
-	break;
-      case LOCATION_TYPE_ISEQ_CALCED:
-	file = rb_iseq_path(loc->body.iseq.iseq);
-	lineno = loc->body.iseq.lineno.lineno;
-	name = loc->body.iseq.iseq->body->location.label;
+	lineno = calc_lineno(loc->body.iseq.iseq, loc->body.iseq.pc);
 	break;
       case LOCATION_TYPE_CFUNC:
 	if (loc->body.cfunc.prev_loc) {
@@ -433,7 +416,6 @@ location_update_entry(rb_backtrace_location_t *fi)
 {
     switch (fi->type) {
       case LOCATION_TYPE_ISEQ:
-      case LOCATION_TYPE_ISEQ_CALCED:
 	fi->body.iseq.iseq = (rb_iseq_t*)rb_gc_location((VALUE)fi->body.iseq.iseq);
 	break;
       case LOCATION_TYPE_CFUNC:
@@ -684,7 +666,7 @@ bt_iter_iseq(void *ptr, const rb_control_frame_t *cfp)
     rb_backtrace_location_t *loc = &arg->bt->backtrace[arg->bt->backtrace_size++-1];
     loc->type = LOCATION_TYPE_ISEQ;
     loc->body.iseq.iseq = iseq;
-    loc->body.iseq.lineno.pc = pc;
+    loc->body.iseq.pc = pc;
     arg->prev_loc = loc;
 }
 
@@ -697,13 +679,13 @@ bt_iter_iseq_skip_internal(void *ptr, const rb_control_frame_t *cfp)
     if (!is_internal_location(cfp)) {
         loc->type = LOCATION_TYPE_ISEQ;
         loc->body.iseq.iseq = cfp->iseq;
-        loc->body.iseq.lineno.pc = cfp->pc;
+        loc->body.iseq.pc = cfp->pc;
         arg->prev_loc = loc;
     }
     else if (arg->prev_cfp) {
         loc->type = LOCATION_TYPE_ISEQ;
         loc->body.iseq.iseq = arg->prev_cfp->iseq;
-        loc->body.iseq.lineno.pc = arg->prev_cfp->pc;
+        loc->body.iseq.pc = arg->prev_cfp->pc;
         arg->prev_loc = loc;
     }
     else {
@@ -726,7 +708,7 @@ bt_iter_cfunc(void *ptr, const rb_control_frame_t *cfp, ID mid)
         const VALUE *pc = arg->prev_cfp->pc;
         arg->init_loc->type = LOCATION_TYPE_ISEQ;
         arg->init_loc->body.iseq.iseq = iseq;
-        arg->init_loc->body.iseq.lineno.pc = pc;
+        arg->init_loc->body.iseq.pc = pc;
         loc->body.cfunc.prev_loc = arg->prev_loc = arg->init_loc;
     }
     else {
@@ -828,19 +810,16 @@ MJIT_FUNC_EXPORTED void
 rb_backtrace_use_iseq_first_lineno_for_last_location(VALUE self)
 {
     const rb_backtrace_t *bt;
-    const rb_iseq_t *iseq;
     rb_backtrace_location_t *loc;
 
     GetCoreDataFromValue(self, rb_backtrace_t, bt);
     VM_ASSERT(bt->backtrace_size > 1);
 
     loc = &bt->backtrace[bt->backtrace_size - 2];
-    iseq = loc->body.iseq.iseq;
 
     VM_ASSERT(loc->type == LOCATION_TYPE_ISEQ);
 
-    loc->body.iseq.lineno.lineno = FIX2INT(iseq->body->location.first_lineno);
-    loc->type = LOCATION_TYPE_ISEQ_CALCED;
+    loc->body.iseq.pc = NULL; // means location.first_lineno
 }
 
 static VALUE


### PR DESCRIPTION
Synopsis:

```
def target
  RubyVM::AbstractSyntaxTree.of(caller_locations[0])
end

p target #=> #<RubyVM::AbstractSyntaxTree::Node:VCALL@5:2-5:8>
# ^^^^^^ Line 5, Column 2--8
```

The result node represents the method call `target`.

https://bugs.ruby-lang.org/issues/17930