### PR TITLE
Document unexpected behavior in each_with_object iteration

### DIFF
--- a/enum.c
+++ b/enum.c
@@ -2759,7 +2759,9 @@ each_with_object_i(RB_BLOCK_CALL_FUNC_ARGLIST(i, memo))
  *    enum.each_with_object(obj)                              ->  an_enumerator
  *
  *  Iterates the given block for each element with an arbitrary
- *  object given, and returns the initially given object.
+ *  object given, and returns the initially given object.  The 
+ *  object must not be reassigned within the block, or its value
+ *  in that iteration will be ignored.
  *
  *  If no block is given, returns an enumerator.
  *


### PR DESCRIPTION
Consider the following code:

```ruby
["a", "b", "c"].each_with_object([]) do |x, acc|
  if x == "b"
    acc = ["potatoes"]
  else
    acc << "#{x}-ok"
  end
end
```

This returns `["a-ok", "c-ok"]`, although `["potatoes", "c-ok"]` might be expected.  This is infuriating to debug, because all indications are that the assignment was successful.

The proper approach is to avoid assignment to the `memo_obj` at all costs.
```ruby
["a", "b", "c"].each_with_object([]) do |x, acc|
  if x == "b"
    acc.replace(["potatoes"])
  else
    acc << "#{x}-ok"
  end
end
```