### PR TITLE
Finish GC before calling gc_set_initial_pages

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -10773,6 +10773,8 @@ gc_set_initial_pages(void)
     size_t min_pages;
     rb_objspace_t *objspace = &rb_objspace;
 
+    gc_rest(objspace);
+
     min_pages = gc_params.heap_init_slots / HEAP_PAGE_OBJ_LIMIT;
     if (min_pages > heap_eden->total_pages) {
 	heap_add_pages(objspace, heap_eden, min_pages - heap_eden->total_pages);


### PR DESCRIPTION
If we are during incremental sweeping when calling gc_set_initial_pages there is an assertion error. The following patch will artificially produce the bug:

```diff
diff --git a/gc.c b/gc.c
index c3157dbe2c..d7282cf8f0 100644
--- a/gc.c
+++ b/gc.c
@@ -404,7 +404,7 @@ int ruby_rgengc_debug;
  * 5: show all references
  */
 #ifndef RGENGC_CHECK_MODE
-#define RGENGC_CHECK_MODE  0
+#define RGENGC_CHECK_MODE  1
 #endif
 // Note: using RUBY_ASSERT_WHEN() extend a macro in expr (info by nobu).
@@ -10821,6 +10821,10 @@ gc_set_initial_pages(void)
 void
 ruby_gc_set_params(void)
 {
+    for (int i = 0; i < 10000; i++) {
+        rb_ary_new();
+    }
+
     /* RUBY_GC_HEAP_FREE_SLOTS */
     if (get_envparam_size("RUBY_GC_HEAP_FREE_SLOTS", &gc_params.heap_free_slots, 0)) {
        /* ok */
```

The crash looks like:

```
Assertion Failed: ../gc.c:2038:heap_add_page:!(heap == heap_eden && heap->sweeping_page)
```