### PR TITLE
Enable frozen_string_literal in builtin_iseq_load

### DIFF
--- a/mini_builtin.c
+++ b/mini_builtin.c
@@ -23,7 +23,20 @@ builtin_iseq_load(const char *feature_name, const struct rb_builtin_function *ta
 
     vm->builtin_function_table = table;
     vm->builtin_inline_index = 0;
-    const rb_iseq_t *iseq = rb_iseq_new(&ast->body, name_str, name_str, Qnil, NULL, ISEQ_TYPE_TOP);
+    static const rb_compile_option_t optimization = {
+	TRUE, /* int inline_const_cache; */
+	TRUE, /* int peephole_optimization; */
+	FALSE,/* int tailcall_optimization; */
+	TRUE, /* int specialized_instruction; */
+	TRUE, /* int operands_unification; */
+	TRUE, /* int instructions_unification; */
+	TRUE, /* int stack_caching; */
+	TRUE, /* int frozen_string_literal; */
+	FALSE, /* int debug_frozen_string_literal; */
+	FALSE, /* unsigned int coverage_enabled; */
+	0, /* int debug_level; */
+    };
+    const rb_iseq_t *iseq = rb_iseq_new_with_opt(&ast->body, name_str, name_str, Qnil, INT2FIX(0), NULL, 0, ISEQ_TYPE_TOP, &optimization);
     GET_VM()->builtin_function_table = NULL;
 
     rb_ast_dispose(ast);


### PR DESCRIPTION
Currently this has a fairly minor effect as strings are not used heavily inside the builtins (outside of warnings, requires, and errors). Hopefully this allows us to use strings in the future where appropriate (_maybe_ things like `NilClass#to_s`...).

I noticed this when looking at

```
$ ./ruby --disable-gems -e 'puts RubyVM::InstructionSequence.disasm(Time.instance_method(:initialize))'
```

which previously had

```
0043 putstring  "timezone argument given as positional and keyword arguments"
```

and on this branch has

```
0043 putobject  timezone argument given as positional and keyword arguments"
```