### PR TITLE
Remove shift of ep when computing Proc#hash

### DIFF
--- a/proc.c
+++ b/proc.c
@@ -1451,7 +1451,7 @@ rb_hash_proc(st_index_t hash, VALUE prc)
     GetProcPtr(prc, proc);
     hash = rb_hash_uint(hash, (st_index_t)proc->block.as.captured.code.val);
     hash = rb_hash_uint(hash, (st_index_t)proc->block.as.captured.self);
-    return rb_hash_uint(hash, (st_index_t)proc->block.as.captured.ep >> 16);
+    return rb_hash_uint(hash, (st_index_t)proc->block.as.captured.ep);
 }
 
 MJIT_FUNC_EXPORTED VALUE

--- a/test/ruby/test_proc.rb
+++ b/test/ruby/test_proc.rb
@@ -159,6 +159,15 @@ class TestProc < Test::Unit::TestCase
     assert_equal(*m_nest{}, "[ruby-core:84583] Feature #14627")
   end
 
+  def test_hash
+    def self.capture(&block)
+      block
+    end
+
+   procs = Array.new(1000){capture{:foo }}
+   assert_operator(procs.map(&:hash).uniq.size, :>=, 500)
+  end
+
   def test_block_par
     assert_equal(10, Proc.new{|&b| b.call(10)}.call {|x| x})
     assert_equal(12, Proc.new{|a,&b| b.call(a)}.call(12) {|x| x})


### PR DESCRIPTION
The shift was causing far fewer unique values of hash than expected.

Fix pointed out by xtkoba (Tee KOBAYASHI)

Fixes [Bug #17951]