### PR TITLE
Fix handling of exceptions raised inside TracePoint :call handling

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -7154,6 +7154,14 @@ compile_rescue(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, 
 					     rb_str_concat(rb_str_new2("rescue in "), iseq->body->location.label),
 					     ISEQ_TYPE_RESCUE, line);
 
+    /* Add nop so that exceptions during tracepoint :call processing
+     * do not get rescued by a method's rescue.
+     */
+    LABEL *prestart = NEW_LABEL(line - 1);
+    NODE dummy_line_node = generate_dummy_line_node(line, -1);
+    ADD_INSN (ret, &dummy_line_node, nop);
+    ADD_LABEL(ret, prestart);
+
     lstart->rescued = LABEL_RESCUE_BEG;
     lend->rescued = LABEL_RESCUE_END;
     ADD_LABEL(ret, lstart);


### PR DESCRIPTION
Previously, exceptions raised inside a TracePoint :call handler could
be handled by a rescue clause inside the method.  However, TracePoint
:call handling should occur before the body of the method is executed.
Exceptions in TracePoint :call handling should be treated similarly to
exceptions raised when getting default values for arguments, and not
be rescued by exception handlers inside the method.

This fixes the issue by inserting a nop during rescue compilation, so
the start of the rescue catch table will definitely be after TracePoint
:call handling.  It also works if you insert a nop during method
compilation, but I think it is better to make rescue handling slower
than than making method calling slower.  Possibly this nop could be
optimized out in cases where it is not needed, but I was not able to
figure out how to do that.  Hopefully someone with more knowledge of
the compiler will be able to do so.

Fixes [Bug #14479]

This apparently causes a failure in the typeprof tests, though I'm not sure
why that is.