### PR TITLE
ast.rb: RubyVM::AST.parse and .of accepts `save_script_lines: true`

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -710,7 +710,7 @@ ast_node_script_lines(rb_execution_context_t *ec, VALUE self)
     struct ASTNodeData *data;
     TypedData_Get_Struct(self, struct ASTNodeData, &rb_node_type, data);
     VALUE ret = data->ast->body.script_lines;
-    if (!ret) ret = Qnil;
+    if (!RB_TYPE_P(ret, T_ARRAY)) return Qnil;
     return ret;
 }
 

--- a/compile.c
+++ b/compile.c
@@ -1329,6 +1329,7 @@ new_child_iseq(rb_iseq_t *iseq, const NODE *const node,
     ast.root = node;
     ast.compile_option = 0;
     ast.line_count = -1;
+    ast.script_lines = Qfalse;
 
     debugs("[new_child_iseq]> ---------------------------------------\n");
     int isolated_depth = ISEQ_COMPILE_DATA(iseq)->isolated_depth;

--- a/compile.c
+++ b/compile.c
@@ -1328,8 +1328,7 @@ new_child_iseq(rb_iseq_t *iseq, const NODE *const node,
 
     ast.root = node;
     ast.compile_option = 0;
-    ast.line_count = -1;
-    ast.script_lines = Qfalse;
+    ast.script_lines = INT2FIX(-1);
 
     debugs("[new_child_iseq]> ---------------------------------------\n");
     int isolated_depth = ISEQ_COMPILE_DATA(iseq)->isolated_depth;

--- a/internal/parse.h
+++ b/internal/parse.h
@@ -15,6 +15,7 @@ struct rb_iseq_struct;          /* in vm_core.h */
 /* parse.y */
 VALUE rb_parser_set_yydebug(VALUE, VALUE);
 void *rb_parser_load_file(VALUE parser, VALUE name);
+void rb_parser_save_script_lines(VALUE vparser);
 
 RUBY_SYMBOL_EXPORT_BEGIN
 VALUE rb_parser_set_context(VALUE, const struct rb_iseq_struct *, int);

--- a/iseq.c
+++ b/iseq.c
@@ -813,13 +813,23 @@ rb_iseq_new(const rb_ast_body_t *ast, VALUE name, VALUE path, VALUE realpath,
                                 0, type, &COMPILE_OPTION_DEFAULT);
 }
 
+static int
+ast_line_count(const rb_ast_body_t *ast)
+{
+    if (RB_TYPE_P(ast->script_lines, T_ARRAY)){
+        return (int)RARRAY_LEN(ast->script_lines);
+    }
+    return FIX2INT(ast->script_lines);
+}
+
 rb_iseq_t *
 rb_iseq_new_top(const rb_ast_body_t *ast, VALUE name, VALUE path, VALUE realpath, const rb_iseq_t *parent)
 {
     VALUE coverages = rb_get_coverages();
     if (RTEST(coverages)) {
-        if (ast->line_count >= 0) {
-            int len = (rb_get_coverage_mode() & COVERAGE_TARGET_ONESHOT_LINES) ? 0 : ast->line_count;
+        int line_count = ast_line_count(ast);
+        if (line_count >= 0) {
+            int len = (rb_get_coverage_mode() & COVERAGE_TARGET_ONESHOT_LINES) ? 0 : line_count;
             VALUE coverage = rb_default_coverage(len);
             rb_hash_aset(coverages, path, coverage);
         }

--- a/node.c
+++ b/node.c
@@ -1407,6 +1407,7 @@ rb_ast_mark(rb_ast_t *ast)
 
         iterate_node_values(&nb->markable, mark_ast_value, NULL);
     }
+    if (ast->body.script_lines) rb_gc_mark(ast->body.script_lines);
 }
 
 void

--- a/node.h
+++ b/node.h
@@ -399,6 +399,7 @@ typedef struct rb_ast_body_struct {
     const NODE *root;
     VALUE compile_option;
     int line_count;
+    VALUE script_lines;
 } rb_ast_body_t;
 typedef struct rb_ast_struct {
     VALUE flags;

--- a/node.h
+++ b/node.h
@@ -398,8 +398,10 @@ typedef struct node_buffer_struct node_buffer_t;
 typedef struct rb_ast_body_struct {
     const NODE *root;
     VALUE compile_option;
-    int line_count;
     VALUE script_lines;
+    // script_lines is either:
+    // - a Fixnum that represents the line count of the original source, or
+    // - an Array that contains the lines of the original source
 } rb_ast_body_t;
 typedef struct rb_ast_struct {
     VALUE flags;

--- a/parse.y
+++ b/parse.y
@@ -337,6 +337,7 @@ struct parser_params {
     unsigned int do_loop: 1;
     unsigned int do_chomp: 1;
     unsigned int do_split: 1;
+    unsigned int save_script_lines: 1;
 
     NODE *eval_tree_begin;
     NODE *eval_tree;
@@ -6240,6 +6241,13 @@ yycompile0(VALUE arg)
 	if (!e_option_supplied(p)) {
 	    cov = Qtrue;
 	}
+    }
+    if (p->save_script_lines) {
+        if (!p->debug_lines) {
+            p->debug_lines = rb_ary_new();
+        }
+
+        RB_OBJ_WRITE(p->ast, &p->ast->body.script_lines, p->debug_lines);
     }
 
     parser_prepare(p);
@@ -13185,6 +13193,15 @@ rb_parser_set_context(VALUE vparser, const struct rb_iseq_struct *base, int main
     p->error_buffer = main ? Qfalse : Qnil;
     p->parent_iseq = base;
     return vparser;
+}
+
+void
+rb_parser_save_script_lines(VALUE vparser)
+{
+    struct parser_params *p;
+
+    TypedData_Get_Struct(vparser, struct parser_params, &parser_data_type, p);
+    p->save_script_lines = 1;
 }
 #endif
 

--- a/parse.y
+++ b/parse.y
@@ -6286,7 +6286,7 @@ yycompile0(VALUE arg)
         RB_OBJ_WRITE(p->ast, &p->ast->body.compile_option, opt);
     }
     p->ast->body.root = tree;
-    p->ast->body.line_count = p->line_count;
+    if (!p->ast->body.script_lines) p->ast->body.script_lines = INT2FIX(p->line_count);
     return TRUE;
 }
 

--- a/vm.c
+++ b/vm.c
@@ -1223,7 +1223,7 @@ rb_binding_add_dynavars(VALUE bindval, rb_binding_t *bind, int dyncount, const I
     rb_node_init(&tmp_node, NODE_SCOPE, (VALUE)dyns, 0, 0);
     ast.root = &tmp_node;
     ast.compile_option = 0;
-    ast.line_count = -1;
+    ast.script_lines = INT2FIX(-1);
 
     if (base_iseq) {
 	iseq = rb_iseq_new(&ast, base_iseq->body->location.label, path, realpath, base_iseq, ISEQ_TYPE_EVAL);


### PR DESCRIPTION
Synopsis:

```
node = RubyVM::AbstractSyntaxTree.parse(<<END, save_script_lines: true)
puts 'Hello', 'world'
__END__
foobar
END

p node.script_lines #=> ["puts 'Hello', 'world'\n", "__END__\n"]

p node.source                                            #=> "puts 'Hello', 'world'"
p node.children.last.children.last.source                #=> "'Hello', 'world'"
p node.children.last.children.last.children.first.source #=> "'Hello'"
```

This option makes the parser keep the original source as an array of
the original code lines. This feature exploits the mechanism of
`SCRIPT_LINES__` but records only the specified code that is passed to
RubyVM::AST.of or .parse, instead of recording all parsed program texts.

`RubyVM::AST::Node` instances created with `save_script_lines: true`
option respond to `#script_lines` and `#source`. The former returns
the whole original source code as an array of the lines. The latter returns
the code fragment that corresponds to this AST.
Note that RubyVM::AST is just for ruby internal use, so the compatibility
of the methods is never guaranteed.

This changeset is approved by @matz .