### PR TITLE
Document how to enable DTrace probes

### DIFF
--- a/doc/dtrace_probes.rdoc
+++ b/doc/dtrace_probes.rdoc
@@ -19,6 +19,13 @@ probe name is "method-entry", and the probe takes four arguments:
 * file name
 * line number
 
+== Enabling DTrace Probes
+
+Most DTrace probes are not enabled by default for performance reasons. To enable
+the DTrace probes, enable an empty TracePoint:
+
+  TracePoint.new{}.enable
+
 == Probes List
 
 === Stability


### PR DESCRIPTION
DTrace probes used to be enabled by default, but starting in 2.5,
you need to enable a TracePoint to enable most DTrace probes.

Note that I don't have access to a system with DTrace, so I'm not
sure this is correct.  Hopefully someone who knows more about
DTrace can confirm.

Fixes [Bug #14582]

https://bugs.ruby-lang.org/issues/14582
