### PR TITLE
Fix the tracepoint return location for bmethods

### DIFF
--- a/benchmark/method_calling.yml
+++ b/benchmark/method_calling.yml
@@ -1,0 +1,8 @@
+prelude: |
+  def a; end
+  define_method(:b){}
+  p = lambda{}
+benchmark:
+  def: "a"
+  define_method: "b"
+  lambda: "p.call"

--- a/insns.def
+++ b/insns.def
@@ -903,6 +903,12 @@ leave
 	}
     }
 
+    /* Must invoke bmethod hooks before popping frame so return
+     * location is correct */
+    if (VM_FRAME_BMETHOD_P(GET_CFP())) {
+        invoke_bmethod_return_hooks(ec, GET_CFP()->self, (const rb_callable_method_entry_t *)GET_EP()[VM_ENV_DATA_INDEX_ME_CREF], val);
+    }
+
     if (vm_pop_frame(ec, GET_CFP(), GET_EP())) {
 #if OPT_CALL_THREADED_CODE
 	rb_ec_thread_ptr(ec)->retval = val;

--- a/test/ruby/test_settracefunc.rb
+++ b/test/ruby/test_settracefunc.rb
@@ -393,7 +393,7 @@ class TestSetTraceFunc < Test::Unit::TestCase
     [["c-return", 3, :set_trace_func, Kernel],
      ["line", 6, __method__, self.class],
      ["call", 1, :foobar, FooBar],
-     ["return", 6, :foobar, FooBar],
+     ["return", 1, :foobar, FooBar],
      ["line", 7, __method__, self.class],
      ["c-call", 7, :set_trace_func, Kernel]].each{|e|
       assert_equal(e, events.shift)
@@ -2337,6 +2337,16 @@ class TestSetTraceFunc < Test::Unit::TestCase
     end
 
     assert_equal Array.new(2){th}, events
+  end
+
+  def test_return_bmethod_location
+    bug13392 = "[ruby-core:80515] incorrect bmethod return location"
+    actual = nil
+    expected = __LINE__ + 1
+    define_singleton_method(:t){}
+    tp = TracePoint.new(:return) {actual = tp.lineno}
+    tp.enable {t}
+    assert_equal(expected, actual, bug13392)
   end
 
   def test_return_event_with_rescue


### PR DESCRIPTION
Previously, the bmethod return hook was called after the VM frame
for the bmethod was popped, resulting in the location of the return
event being the caller location instead of the return location inside
the callee.

Fix this by extracting an invoke_bmethod_return_hooks function and
calling that  inside the leave instruction handling if the frame is a
bmethod frame, before the call to vm_pop_frame. Also call it inside
vm_exec_handle_exception to handle explicit returns inside bmethods.

Fixes [Bug #13392]