### PR TITLE
Tweak description of TracePoint :line event

### DIFF
--- a/trace_point.rb
+++ b/trace_point.rb
@@ -31,7 +31,7 @@
 #
 # To filter what is traced, you can pass any of the following as +events+:
 #
-# +:line+:: execute code on a new line
+# +:line+:: execute an expression or statement on a new line
 # +:class+:: start a class or module definition
 # +:end+:: finish a class or module definition
 # +:call+:: call a Ruby method


### PR DESCRIPTION
"code" here is too ambiguous. TracePoint events only occur if there
is a new statement or expression on that line, not if the line
is a continuation of a previous statement or expression and there
is no new statement or expression on the line.

For example:

```
[
 foo,   # start of expression, line event
 bar    # continuation of expression, no line event
]

[
 foo,   # start of expression, line event
 (bar)  # new expression, line event
]

foo(    # start of expression, line event
  bar   # continuation of expression, no line event
)

foo(    # start of expression, line event
  (bar) # new expression, line event
)
```

Fixes [Bug #15634]