### PR TITLE
Make Encoding::Converter newline: :lf option a synonym for newline: :universal

### DIFF
--- a/enc/trans/newline.trans
+++ b/enc/trans/newline.trans
@@ -17,10 +17,16 @@
   map_cr["0a"] = "0d"
 
   transcode_generate_node(ActionMap.parse(map_cr), "cr_newline")
+
+  map_normalize = {}
+  map_normalize["{00-ff}"] = :func_so
+
+  transcode_generate_node(ActionMap.parse(map_normalize), "lf_newline")
 %>
 
 <%= transcode_generated_code %>
 
+#define lf_newline universal_newline
 #define STATE (sp[0])
 #define NORMAL 0
 #define JUST_AFTER_CR 1
@@ -126,10 +132,24 @@ rb_cr_newline = {
     0, 0, 0, 0
 };
 
+static const rb_transcoder
+rb_lf_newline = {
+    "", "lf_newline", lf_newline,
+    TRANSCODE_TABLE_INFO,
+    1, /* input_unit_length */
+    1, /* max_input */
+    2, /* max_output */
+    asciicompat_converter, /* asciicompat_type */
+    2, universal_newline_init, universal_newline_init, /* state_size, state_init, state_fini */
+    0, 0, 0, fun_so_universal_newline,
+    universal_newline_finish
+};
+
 void
 Init_newline(void)
 {
     rb_register_transcoder(&rb_universal_newline);
     rb_register_transcoder(&rb_crlf_newline);
     rb_register_transcoder(&rb_cr_newline);
+    rb_register_transcoder(&rb_lf_newline);
 }

--- a/include/ruby/internal/encoding/transcode.h
+++ b/include/ruby/internal/encoding/transcode.h
@@ -476,16 +476,16 @@ enum ruby_econv_flag_type {
     RUBY_ECONV_UNDEF_HEX_CHARREF                = 0x00000030,
 
     /** Decorators are there. */
-    RUBY_ECONV_DECORATOR_MASK                   = 0x0000ff00,
+    RUBY_ECONV_DECORATOR_MASK                   = 0x0001ff00,
 
     /** Newline converters are there. */
-    RUBY_ECONV_NEWLINE_DECORATOR_MASK           = 0x00003f00,
+    RUBY_ECONV_NEWLINE_DECORATOR_MASK           = 0x00007f00,
 
     /** (Unclear; seems unused). */
     RUBY_ECONV_NEWLINE_DECORATOR_READ_MASK      = 0x00000f00,
 
     /** (Unclear; seems unused). */
-    RUBY_ECONV_NEWLINE_DECORATOR_WRITE_MASK     = 0x00003000,
+    RUBY_ECONV_NEWLINE_DECORATOR_WRITE_MASK     = 0x00007000,
 
     /** Universal newline mode. */
     RUBY_ECONV_UNIVERSAL_NEWLINE_DECORATOR      = 0x00000100,
@@ -496,11 +496,14 @@ enum ruby_econv_flag_type {
     /** CRLF to CR conversion shall happen. */
     RUBY_ECONV_CR_NEWLINE_DECORATOR             = 0x00002000,
 
+    /** CRLF to LF conversion shall happen. */
+    RUBY_ECONV_LF_NEWLINE_DECORATOR             = 0x00004000,
+
     /** Texts shall be XML-escaped. */
-    RUBY_ECONV_XML_TEXT_DECORATOR               = 0x00004000,
+    RUBY_ECONV_XML_TEXT_DECORATOR               = 0x00008000,
 
     /** Texts shall be AttrValue escaped */
-    RUBY_ECONV_XML_ATTR_CONTENT_DECORATOR       = 0x00008000,
+    RUBY_ECONV_XML_ATTR_CONTENT_DECORATOR       = 0x00010000,
 
     /** (Unclear; seems unused). */
     RUBY_ECONV_STATEFUL_DECORATOR_MASK          = 0x00f00000,
@@ -529,6 +532,7 @@ enum ruby_econv_flag_type {
 #define ECONV_UNIVERSAL_NEWLINE_DECORATOR       RUBY_ECONV_UNIVERSAL_NEWLINE_DECORATOR  /**< @old{RUBY_ECONV_UNIVERSAL_NEWLINE_DECORATOR} */
 #define ECONV_CRLF_NEWLINE_DECORATOR            RUBY_ECONV_CRLF_NEWLINE_DECORATOR       /**< @old{RUBY_ECONV_CRLF_NEWLINE_DECORATOR} */
 #define ECONV_CR_NEWLINE_DECORATOR              RUBY_ECONV_CR_NEWLINE_DECORATOR         /**< @old{RUBY_ECONV_CR_NEWLINE_DECORATOR} */
+#define ECONV_LF_NEWLINE_DECORATOR              RUBY_ECONV_LF_NEWLINE_DECORATOR         /**< @old{RUBY_ECONV_LF_NEWLINE_DECORATOR} */
 #define ECONV_XML_TEXT_DECORATOR                RUBY_ECONV_XML_TEXT_DECORATOR           /**< @old{RUBY_ECONV_XML_TEXT_DECORATOR} */
 #define ECONV_XML_ATTR_CONTENT_DECORATOR        RUBY_ECONV_XML_ATTR_CONTENT_DECORATOR   /**< @old{RUBY_ECONV_XML_ATTR_CONTENT_DECORATOR} */
 #define ECONV_STATEFUL_DECORATOR_MASK           RUBY_ECONV_STATEFUL_DECORATOR_MASK      /**< @old{RUBY_ECONV_STATEFUL_DECORATOR_MASK} */
@@ -543,10 +547,10 @@ enum ruby_econv_flag_type {
      */
 
     /** Indicates the input is a part of much larger one. */
-    RUBY_ECONV_PARTIAL_INPUT                    = 0x00010000,
+    RUBY_ECONV_PARTIAL_INPUT                    = 0x00020000,
 
     /** Instructs the converter to stop after output. */
-    RUBY_ECONV_AFTER_OUTPUT                     = 0x00020000,
+    RUBY_ECONV_AFTER_OUTPUT                     = 0x00040000,
 #define ECONV_PARTIAL_INPUT                     RUBY_ECONV_PARTIAL_INPUT /**< @old{RUBY_ECONV_PARTIAL_INPUT} */
 #define ECONV_AFTER_OUTPUT                      RUBY_ECONV_AFTER_OUTPUT  /**< @old{RUBY_ECONV_AFTER_OUTPUT} */
 

--- a/test/ruby/test_transcode.rb
+++ b/test/ruby/test_transcode.rb
@@ -2305,5 +2305,7 @@ class TestTranscode < Test::Unit::TestCase
     assert_equal("A\rB\r\rC", s.encode(usascii, newline: :cr))
     assert_equal("A\r\nB\r\r\nC", s.encode(usascii, crlf_newline: true))
     assert_equal("A\r\nB\r\r\nC", s.encode(usascii, newline: :crlf))
+    assert_equal("A\nB\nC", s.encode(usascii, lf_newline: true))
+    assert_equal("A\nB\nC", s.encode(usascii, newline: :lf))
   end
 end


### PR DESCRIPTION
Previously, newline: :lf was accepted but ignored.  Where it
should have been used was commented out code that didn't work,
but unlike all other invalid values, using newline: :lf did
not raise an error.

However, as newline: :cr converts LF to CR, it only makes sense
for newline: :lf to convert CR to LF, which is the same behavior
as newline: :universal.  So make newline: :lf a synonym for
newline: :universal.

Add tests for the File.open :newline option to test this.

Fixes [Bug #12436]