### PR TITLE
Add nilclass.rb to .document

### DIFF
--- a/.document
+++ b/.document
@@ -18,6 +18,7 @@ gc.rb
 io.rb
 kernel.rb
 numeric.rb
+nilclass.rb
 pack.rb
 ractor.rb
 timev.rb


### PR DESCRIPTION
Merged #3366, but not added `nilclass.rb` to `.document`