### PR TITLE
[Documentation] Fix typo, formatting in `time.c`

### DIFF
--- a/time.c
+++ b/time.c
@@ -3458,10 +3458,10 @@ time_to_i(VALUE time)
  *  the exact number of nanoseconds since the Epoch.
  *  (IEEE 754 double has 53bit mantissa.
  *  So it can represent exact number of nanoseconds only in
- *  `2 ** 53 / 1_000_000_000 / 60 / 60 / 24 = 104.2` days.)
+ *  <tt>2 ** 53 / 1_000_000_000 / 60 / 60 / 24 = 104.2</tt> days.)
  *  When Ruby uses a nanosecond-resolution clock function,
  *  such as +clock_gettime+ of POSIX, to obtain the current time,
- *  Time#to_f can lost information of a Time object created with +Time.now+.
+ *  Time#to_f can lose information of a Time object created with +Time.now+.
  */
 
 static VALUE


### PR DESCRIPTION
Backticks do not result in code formatting.

Before:
![Screenshot 2021-06-22 at 13-13-59 class Time - RDoc Documentation](https://user-images.githubusercontent.com/1301152/122915362-f91f6100-d35b-11eb-9ba9-b93cbf16363d.png)

After:
![Screenshot 2021-06-22 at 13-13-25 class Time - RDoc Documentation](https://user-images.githubusercontent.com/1301152/122915418-050b2300-d35c-11eb-8a15-ab7bcb0712cf.png)
