### PR TITLE
Evacuate transient heap when enabling ractors

### DIFF
--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -1405,4 +1405,17 @@ assert_equal "ok", %q{
   end
 }
 
+assert_equal "ok", %q{
+  GC.disable
+  Ractor.new {}
+  raise "not ok" unless GC.disable
+
+  foo = []
+  10.times { foo << 1 }
+
+  GC.start
+
+  'ok'
+}
+
 end # if !ENV['GITHUB_WORKFLOW']

--- a/ractor.c
+++ b/ractor.c
@@ -1420,8 +1420,14 @@ cancel_single_ractor_mode(void)
     // enable multi-ractor mode
     RUBY_DEBUG_LOG("enable multi-ractor mode", 0);
 
+    VALUE was_disabled = rb_gc_enable();
+
     rb_gc_start();
     rb_transient_heap_evacuate();
+
+    if (was_disabled) {
+        rb_gc_disable();
+    }
 
     ruby_single_main_ractor = NULL;
 


### PR DESCRIPTION
If the GC has been disabled we need to re-enable it so we can evacuate
the transient heap.

Fixes https://bugs.ruby-lang.org/issues/17985

Co-authored-by: Aaron Patterson <tenderlove@ruby-lang.org>