### PR TITLE
Windows: Add support for MINGW-UCRT platform

### DIFF
--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -8,8 +8,7 @@ jobs:
   make:
     runs-on: windows-2019
     env:
-      MSYSTEM: MINGW64
-      MSYSTEM_PREFIX: /mingw64
+      MSYSTEM: ${{ matrix.msystem }}
       MSYS2_ARCH: x86_64
       CHOST: "x86_64-w64-mingw32"
       CFLAGS:   "-march=x86-64 -mtune=generic -O3 -pipe -fstack-protector-strong"
@@ -20,7 +19,13 @@ jobs:
       GITPULLOPTIONS: --no-tags origin ${{github.ref}}
     strategy:
       matrix:
-        test_task: [ "check" ] # to make job names consistent
+        include:
+          - msystem: "MINGW64"
+            base_ruby: 2.6
+            test_task: [ "check" ] # to make job names consistent
+          - msystem: "UCRT64"
+            base_ruby: head
+            test_task: [ "check" ] # to make job names consistent
       fail-fast: false
     steps:
       - run: mkdir build
@@ -35,10 +40,11 @@ jobs:
         with:
           path: src
       - name: Set up Ruby & MSYS2
-        uses: MSP-Greg/setup-ruby-pkgs@v1
+        uses: MSP-Greg/setup-ruby-pkgs@ucrt
         with:
-          ruby-version: 2.6
-          mingw: _upgrade_ gmp libffi libyaml openssl ragel readline
+          ruby-version: ${{ matrix.base_ruby }}
+          setup-ruby-ref: MSP-Greg/ruby-setup-ruby/00-win-ucrt
+          mingw: _upgrade_ gmp libffi libyaml openssl ragel readline gcc
           msys2: automake1.16 bison
       - name: where check
         run: |

--- a/configure.ac
+++ b/configure.ac
@@ -450,11 +450,13 @@ AS_CASE(["$target_os"],
 		    [[FILE* volatile f = stdin; return 0;]])],
 		    [rb_cv_msvcrt=`$OBJDUMP -p conftest$ac_exeext |
 				   tr A-Z a-z |
-				   sed -n '/^[[ 	]]*dll name: \(msvc.*\)\.dll$/{s//\1/p;q;}'`],
+				   sed -n '/^[[ 	]]*dll name: \(msvc.*\)\.dll$/{s//\1/p;q;};
+					/^[[ 	]]*dll name: \(ucrtbase\|api-ms-win-crt-.*\)\.dll$/{s//ucrt/p;q;}'`],
 		    [rb_cv_msvcrt=msvcrt])
 	test "$rb_cv_msvcrt" = "" && rb_cv_msvcrt=msvcrt])
 	RT_VER=`echo "$rb_cv_msvcrt" | tr -cd [0-9]`
 	test "$RT_VER" = "" && RT_VER=60
+	test "$rb_cv_msvcrt" = "ucrt" && RT_VER=140
 	AC_DEFINE_UNQUOTED(RUBY_MSVCRT_VERSION, $RT_VER)
 	sysconfdir=
     ])

--- a/configure.ac
+++ b/configure.ac
@@ -2508,10 +2508,10 @@ AS_CASE([$coroutine_type], [yes|''], [
         [*86-linux*], [
             coroutine_type=x86
         ],
-        [x64-mingw32], [
+        [x64-mingw*], [
             coroutine_type=win64
         ],
-        [*86-mingw32], [
+        [*86-mingw*], [
             coroutine_type=win32
         ],
         [arm*-linux*], [

--- a/configure.ac
+++ b/configure.ac
@@ -4070,7 +4070,11 @@ AS_IF([test "${universal_binary-no}" = yes ], [
     AC_DEFINE_UNQUOTED(RUBY_ARCH, "universal-" RUBY_PLATFORM_OS)
     AC_DEFINE_UNQUOTED(RUBY_PLATFORM, "universal." RUBY_PLATFORM_CPU "-" RUBY_PLATFORM_OS)
 ], [
-    arch="${target_cpu}-${target_os}"
+    AS_IF([test "${target_os}-${rb_cv_msvcrt}" = "mingw32-ucrt" ], [
+        arch="${target_cpu}-mingw-ucrt"
+    ], [
+        arch="${target_cpu}-${target_os}"
+    ])
     AC_DEFINE_UNQUOTED(RUBY_PLATFORM, "$arch")
 ])
 

--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -104,6 +104,7 @@ class Gem::Platform
                       when /^dotnet([\d.]*)/ then       [ 'dotnet',    $1  ]
                       when /linux-?((?!gnu)\w+)?/ then  [ 'linux',     $1  ]
                       when /mingw32/ then               [ 'mingw32',   nil ]
+                      when /mingw-?(\w+)?/ then         [ 'mingw',     $1  ]
                       when /(mswin\d+)(\_(\d+))?/ then
                         os, version = $1, $3
                         @cpu = 'x86' if @cpu.nil? and os =~ /32$/

--- a/test/ruby/test_env.rb
+++ b/test/ruby/test_env.rb
@@ -503,15 +503,15 @@ class TestEnv < Test::Unit::TestCase
   end
 
   def test_huge_value
-    huge_value = "bar" * 40960
-    ENV["foo"] = "bar"
-    if /mswin/ =~ RUBY_PLATFORM
-      assert_raise(Errno::EINVAL) { ENV["foo"] = huge_value }
-      assert_equal("bar", ENV["foo"])
+    if /mswin/ =~ RUBY_PLATFORM || /ucrt/ =~ RbConfig::CONFIG['sitearch']
+      # On Windows >= Vista each environment variable can be max 32768 characters
+      huge_value = "bar" * 10900
     else
-      assert_nothing_raised { ENV["foo"] = huge_value }
-      assert_equal(huge_value, ENV["foo"])
+      huge_value = "bar" * 40960
     end
+    ENV["foo"] = "overwritten"
+    assert_nothing_raised { ENV["foo"] = huge_value }
+    assert_equal(huge_value, ENV["foo"])
   end
 
   if /mswin|mingw/ =~ RUBY_PLATFORM

--- a/test/rubygems/test_gem_platform.rb
+++ b/test/rubygems/test_gem_platform.rb
@@ -122,6 +122,7 @@ class TestGemPlatform < Gem::TestCase
       'i586-linux-gnu'         => ['x86',       'linux',     nil],
       'i386-linux-gnu'         => ['x86',       'linux',     nil],
       'i386-mingw32'           => ['x86',       'mingw32',   nil],
+      'x64-mingw-ucrt'         => ['x64',       'mingw',     'ucrt'],
       'i386-mswin32'           => ['x86',       'mswin32',   nil],
       'i386-mswin32_80'        => ['x86',       'mswin32',   '80'],
       'i386-mswin32-80'        => ['x86',       'mswin32',   '80'],

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -887,6 +887,13 @@ socklist_delete(SOCKET *sockp, int *flagp)
     return ret;
 }
 
+#if RUBY_MSVCRT_VERSION >= 80
+# ifdef __MINGW32__
+#  define _CrtSetReportMode(type,mode) ((void)0)
+#  define _RTC_SetErrorFunc(func) ((void)0)
+# endif
+static void set_pioinfo_extra(void);
+#endif
 static int w32_cmdvector(const WCHAR *, char ***, UINT, rb_encoding *);
 //
 // Initialization stuff
@@ -896,7 +903,6 @@ void
 rb_w32_sysinit(int *argc, char ***argv)
 {
 #if RUBY_MSVCRT_VERSION >= 80
-    static void set_pioinfo_extra(void);
 
     _CrtSetReportMode(_CRT_ASSERT, 0);
     _set_invalid_parameter_handler(invalid_parameter);

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -2578,7 +2578,7 @@ set_pioinfo_extra(void)
     char *pend = p;
     /* _osfile(fh) & FDEV */
 
-# if _WIN64
+# ifdef _WIN64
     int32_t rel;
     char *rip;
     /* add rsp, _ */
@@ -2620,7 +2620,7 @@ set_pioinfo_extra(void)
 
     found:
     p += sizeof(PIOINFO_MARK) - 1;
-#if _WIN64
+#ifdef _WIN64
     rel = *(int32_t*)(p);
     rip = p + sizeof(int32_t);
     __pioinfo = (ioinfo**)(rip + rel);


### PR DESCRIPTION
As discussed in https://bugs.ruby-lang.org/issues/17845 , these are the patches by @xtkoba (Tee KOBAYASHI) and me to enable the build on MINGW-UCRT and to add a CI run in Github Actions.

The following platform information is defined for MINGW-UCRT build (compared with classic MINGW-MSVCRT build):

variable | MINGW-UCRT | MINGW-MSVCRT | MSWIN64
------------ | ------------ | ------------ | ------------
`CONFIG['arch']` | "x64-mingw-ucrt" | "x64-mingw32" | "x64-mswin64_140"
`CONFIG['sitearch']` | "x64-ucrt" | "x64-msvcrt" | "x64-vcruntime140"
`CONFIG['RUBY_SO_NAME']` | "x64-ucrt-ruby310" | "x64-msvcrt-ruby310" | "x64-vcruntime140-ruby310"
`RUBY_PLATFORM` | "x64-mingw-ucrt" | "x64-mingw32" | "x64-mswin64_140"
`Gem::Platform.local.to_s` | "x64-mingw-ucrt" | "x64-mingw32" | "x64-mswin64-140"

[RubyInstaller-head-x64](https://github.com/oneclick/rubyinstaller2/releases/tag/rubyinstaller-head) is already built on UCRT with these patches.