### PR TITLE
Check type of instruction - can be INSN or ADJUST

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -3088,6 +3088,7 @@ iseq_peephole_optimize(rb_iseq_t *iseq, LINK_ELEMENT *list, const int do_tailcal
          */
         int stop_optimization =
 	    ISEQ_COVERAGE(iseq) && ISEQ_LINE_COVERAGE(iseq) &&
+            nobj->link.type == ISEQ_ELEMENT_INSN &&
             nobj->insn_info.events;
 	if (!stop_optimization) {
             INSN *pobj = (INSN *)iobj->link.prev;

--- a/test/coverage/test_coverage.rb
+++ b/test/coverage/test_coverage.rb
@@ -760,4 +760,18 @@ class TestCoverage < Test::Unit::TestCase
       foo { raise } rescue nil
     end;
   end
+
+  def test_coverage_with_asan
+    result = { :lines => [1, 1, 0, 0, nil, nil, nil] }
+
+    assert_coverage(<<~"end;", { lines: true }, result) # Bug #18001
+      class Foo
+        def bar
+          baz do |x|
+            next unless Integer == x
+          end
+        end
+      end
+    end;
+  end
 end


### PR DESCRIPTION
If the type is ADJUST we don't want to treat it like an INSN so we have
to check the type before reading from `insn_info.events`.

[Bug #18001] [ruby-core:104371]

Co-authored-by: Aaron Patterson <tenderlove@ruby-lang.org>

Fixes: https://bugs.ruby-lang.org/issues/18001