### PR TITLE
Fix GCC 11 warning about [[maybe_unused]]

### DIFF
--- a/include/ruby/internal/attr/maybe_unused.h
+++ b/include/ruby/internal/attr/maybe_unused.h
@@ -27,7 +27,7 @@
 /** Wraps  (or simulates)  `[[maybe_unused]]` */
 #if RBIMPL_HAS_CPP_ATTRIBUTE(maybe_unused)
 # define RBIMPL_ATTR_MAYBE_UNUSED() [[maybe_unused]]
-#elif RBIMPL_HAS_C_ATTRIBUTE(maybe_unused)
+#elif RBIMPL_HAS_C_ATTRIBUTE(maybe_unused) && (__STDC_VERSION__ >= 202000L)
 # define RBIMPL_ATTR_MAYBE_UNUSED() [[maybe_unused]]
 #elif RBIMPL_HAS_ATTRIBUTE(unused)
 # define RBIMPL_ATTR_MAYBE_UNUSED() __attribute__((__unused__))


### PR DESCRIPTION
GCC 11 warns like the following:

    ../../../src/ext/bigdecimal/bigdecimal.c:303:5: warning: 'maybe_unused' attribute ignored [-Wattributes]
      303 |     ENTER(1);

Under GCC 11 with -std=gnu99, `__has_c_attribute(maybe_unused)` returns non-zero,
but attributes using the [[attribute]] syntax seem to be ignored. Hence the warning.
Check for C standard version to handle this.

---

Found this warning on the Github Actions compilation pipeline. Here is a sample: https://github.com/ruby/ruby/runs/2906565220?check_suite_focus=true#step:10:618