### PR TITLE
Warn unless T_DATA object classes redefine or undefine the alloc function

### DIFF
--- a/ext/objspace/objspace.c
+++ b/ext/objspace/objspace.c
@@ -998,6 +998,7 @@ Init_objspace(void)
      * You can use the #type method to check the type of the internal object.
      */
     rb_cInternalObjectWrapper = rb_define_class_under(rb_mObjSpace, "InternalObjectWrapper", rb_cObject);
+    rb_undef_alloc_func(rb_cInternalObjectWrapper);
     rb_define_method(rb_cInternalObjectWrapper, "type", iow_type, 0);
     rb_define_method(rb_cInternalObjectWrapper, "inspect", iow_inspect, 0);
     rb_define_method(rb_cInternalObjectWrapper, "internal_object_id", iow_internal_object_id, 0);

--- a/ext/socket/ifaddr.c
+++ b/ext/socket/ifaddr.c
@@ -460,6 +460,7 @@ rsock_init_sockifaddr(void)
      * Socket::Ifaddr represents a result of getifaddrs() function.
      */
     rb_cSockIfaddr = rb_define_class_under(rb_cSocket, "Ifaddr", rb_cObject);
+    rb_undef_alloc_func(rb_cSockIfaddr);
     rb_define_method(rb_cSockIfaddr, "inspect", ifaddr_inspect, 0);
     rb_define_method(rb_cSockIfaddr, "name", ifaddr_name, 0);
     rb_define_method(rb_cSockIfaddr, "ifindex", ifaddr_ifindex, 0);

--- a/gc.c
+++ b/gc.c
@@ -2749,11 +2749,22 @@ rb_class_allocate_instance(VALUE klass)
     return obj;
 }
 
+static inline void
+rb_data_object_check(VALUE klass)
+{
+    if (klass != rb_cObject && (rb_get_alloc_func(klass) == rb_class_allocate_instance)) {
+        rb_undef_alloc_func(klass);
+#if 0 /* TODO: enable at the next release */
+        rb_warn("undefining the allocator of T_DATA class %"PRIsVALUE, klass);
+#endif
+    }
+}
+
 VALUE
 rb_data_object_wrap(VALUE klass, void *datap, RUBY_DATA_FUNC dmark, RUBY_DATA_FUNC dfree)
 {
     RUBY_ASSERT_ALWAYS(dfree != (RUBY_DATA_FUNC)1);
-    if (klass) Check_Type(klass, T_CLASS);
+    if (klass) rb_data_object_check(klass);
     return newobj_of(klass, T_DATA, (VALUE)dmark, (VALUE)dfree, (VALUE)datap, FALSE, sizeof(RVALUE));
 }
 
@@ -2769,7 +2780,7 @@ VALUE
 rb_data_typed_object_wrap(VALUE klass, void *datap, const rb_data_type_t *type)
 {
     RUBY_ASSERT_ALWAYS(type);
-    if (klass) Check_Type(klass, T_CLASS);
+    if (klass) rb_data_object_check(klass);
     return newobj_of(klass, T_DATA, (VALUE)type, (VALUE)1, (VALUE)datap, type->flags & RUBY_FL_WB_PROTECTED, sizeof(RVALUE));
 }
 


### PR DESCRIPTION
Backlink to https://bugs.ruby-lang.org/issues/18007


## Problem being solved

This option is intended to help developers of C extensions to check if their code meets the requirements explained in "doc/extension.rdoc". Specifically, I want to ensure that `T_DATA` object classes undefine or redefine the alloc function.

There is currently no easy way for an author of a C extension to easily see where they have made the mistake of letting the class's default alloc function remain.

## Description of the solution

Ruby will undefine the alloc func when a `T_DATA` object is created whose class has not undefined or redefined the alloc function.

A new function is defined, `rb_data_object_check`. That function is called from `rb_data_object_wrap()` and `rb_data_typed_object_wrap()` (which implement the `Data_Wrap_Struct` family of macros).

An optional warning can be enabled which, when emitted, looks like this:

```
warning: undefining the allocator of T_DATA class Nokogiri::XML::RelaxNG
```

## Examples of this problem in the wild

Using this code, I found that [many of Nokogiri's classes needed to undefine their alloc funcs](https://github.com/sparklemotion/nokogiri/commit/c5ba3a5).

This PR also updates these core Ruby classes by undefining their alloc func:

- `ObjectSpace::InternalObjectWrapper`
- `Socket::Ifaddr`

## Questions for reviewers

__Should this warning be emitted with the `deprecated` category?__

## Benchmarking

I benchmarked this code by allocating `Nokogiri::XML::NodeSet`s in a loop. This is a class with a [relatively simple alloc function](https://github.com/sparklemotion/nokogiri/blob/6d688d8c0f3351797e9576d3710acf458582bb30/ext/nokogiri/xml_node_set.c#L441-L464).

The runs cover the four combinations of enabled/disabled, and warnings/no-warnings.

```
ruby 3.1.0dev (2021-06-25T04:02:18Z flavorjones-extens.. de943189aa) [x86_64-linux]
Warming up --------------------------------------
disabled, warn=false   490.143k i/100ms
Calculating -------------------------------------
disabled, warn=false      4.863M (± 1.5%) i/s -     49.014M in  10.081177s

ruby 3.1.0dev (2021-06-25T04:02:18Z flavorjones-extens.. de943189aa) [x86_64-linux]
Warming up --------------------------------------
 disabled, warn=true   483.070k i/100ms
Calculating -------------------------------------
 disabled, warn=true      4.839M (± 1.4%) i/s -     48.790M in  10.083899s

Comparison:
disabled, warn=false:  4863064.0 i/s
 disabled, warn=true:  4839310.1 i/s - same-ish: difference falls within error


ruby 3.1.0dev (2021-06-25T04:02:18Z flavorjones-extens.. de943189aa) [x86_64-linux]
Warming up --------------------------------------
 enabled, warn=false   484.398k i/100ms
Calculating -------------------------------------
 enabled, warn=false      4.840M (± 1.9%) i/s -     48.440M in  10.011854s

Comparison:
disabled, warn=false:  4863064.0 i/s
 enabled, warn=false:  4840123.2 i/s - same-ish: difference falls within error
 disabled, warn=true:  4839310.1 i/s - same-ish: difference falls within error


ruby 3.1.0dev (2021-06-25T04:02:18Z flavorjones-extens.. de943189aa) [x86_64-linux]
Warming up --------------------------------------
  enabled, warn=true   492.200k i/100ms
Calculating -------------------------------------
  enabled, warn=true      4.866M (± 2.1%) i/s -     48.728M in  10.017455s

Comparison:
  enabled, warn=true:  4866434.8 i/s
disabled, warn=false:  4863064.0 i/s - same-ish: difference falls within error
 enabled, warn=false:  4840123.2 i/s - same-ish: difference falls within error
 disabled, warn=true:  4839310.1 i/s - same-ish: difference falls within error
```
