### PR TITLE
Work around issue transcoding issue with non-ASCII compatible encodings and xml escaping

### DIFF
--- a/test/ruby/test_transcode.rb
+++ b/test/ruby/test_transcode.rb
@@ -126,6 +126,25 @@ class TestTranscode < Test::Unit::TestCase
     assert_equal("D\xFCrst".force_encoding('iso-8859-2'), "D\xFCrst".encode('iso-8859-2', 'iso-8859-1'))
   end
 
+  def test_encode_xml_multibyte
+    encodings = %w'UTF-8 UTF-16LE UTF-16BE UTF-32LE UTF-32BE'
+    encodings.each do |src_enc|
+      encodings.each do |dst_enc|
+        escaped = "<>".encode(src_enc).encode(dst_enc, :xml=>:text)
+        assert_equal("&lt;&gt;", escaped.encode('UTF-8'), "failed encoding #{src_enc} to #{dst_enc} with xml: :text")
+
+        escaped = '<">'.encode(src_enc).encode(dst_enc, :xml=>:attr)
+        assert_equal('"&lt;&quot;&gt;"', escaped.encode('UTF-8'), "failed encoding #{src_enc} to  #{dst_enc} with xml: :attr")
+
+        escaped = "<>".encode(src_enc).force_encoding("UTF-8").encode(dst_enc, src_enc, :xml=>:text)
+        assert_equal("&lt;&gt;", escaped.encode('UTF-8'), "failed encoding #{src_enc} to #{dst_enc} with xml: :text")
+
+        escaped = '<">'.encode(src_enc).force_encoding("UTF-8").encode(dst_enc, src_enc, :xml=>:attr)
+        assert_equal('"&lt;&quot;&gt;"', escaped.encode('UTF-8'), "failed encoding #{src_enc} to  #{dst_enc} with xml: :attr")
+      end
+    end
+  end
+
   def test_ascii_range
     encodings = [
       'US-ASCII', 'ASCII-8BIT',

--- a/test/ruby/test_transcode.rb
+++ b/test/ruby/test_transcode.rb
@@ -134,13 +134,13 @@ class TestTranscode < Test::Unit::TestCase
         assert_equal("&lt;&gt;", escaped.encode('UTF-8'), "failed encoding #{src_enc} to #{dst_enc} with xml: :text")
 
         escaped = '<">'.encode(src_enc).encode(dst_enc, :xml=>:attr)
-        assert_equal('"&lt;&quot;&gt;"', escaped.encode('UTF-8'), "failed encoding #{src_enc} to  #{dst_enc} with xml: :attr")
+        assert_equal('"&lt;&quot;&gt;"', escaped.encode('UTF-8'), "failed encoding #{src_enc} to #{dst_enc} with xml: :attr")
 
         escaped = "<>".encode(src_enc).force_encoding("UTF-8").encode(dst_enc, src_enc, :xml=>:text)
         assert_equal("&lt;&gt;", escaped.encode('UTF-8'), "failed encoding #{src_enc} to #{dst_enc} with xml: :text")
 
         escaped = '<">'.encode(src_enc).force_encoding("UTF-8").encode(dst_enc, src_enc, :xml=>:attr)
-        assert_equal('"&lt;&quot;&gt;"', escaped.encode('UTF-8'), "failed encoding #{src_enc} to  #{dst_enc} with xml: :attr")
+        assert_equal('"&lt;&quot;&gt;"', escaped.encode('UTF-8'), "failed encoding #{src_enc} to #{dst_enc} with xml: :attr")
       end
     end
   end

--- a/transcode.c
+++ b/transcode.c
@@ -51,6 +51,8 @@ static VALUE sym_finished;
 static VALUE sym_after_output;
 static VALUE sym_incomplete_input;
 
+static ID id_encode;
+
 static unsigned char *
 allocate_converted_string(const char *sname, const char *dname,
         const unsigned char *str, size_t len,
@@ -2719,6 +2721,14 @@ str_transcode0(int argc, VALUE *argv, VALUE *self, int ecflags, VALUE ecopts)
         }
     }
     else {
+        if (senc && denc && !rb_enc_asciicompat(senc) && !rb_enc_asciicompat(denc)) {
+            VALUE encode_args[2];
+            encode_args[1] = rb_enc_from_encoding(senc);
+            senc = rb_utf8_encoding();
+            encode_args[0] = rb_enc_from_encoding(senc);
+            str = rb_funcallv_kw(str, id_encode, 2, encode_args, RB_NO_KEYWORDS);
+            sname = "UTF-8";
+        }
         if (encoding_equal(sname, dname)) {
             sname = "";
             dname = "";
@@ -4578,6 +4588,8 @@ InitVM_transcode(void)
     rb_define_method(rb_eInvalidByteSequenceError, "error_bytes", ecerr_error_bytes, 0);
     rb_define_method(rb_eInvalidByteSequenceError, "readagain_bytes", ecerr_readagain_bytes, 0);
     rb_define_method(rb_eInvalidByteSequenceError, "incomplete_input?", ecerr_incomplete_input, 0);
+
+    id_encode = rb_intern("encode");
 
     Init_newline();
 }

--- a/transcode.c
+++ b/transcode.c
@@ -51,8 +51,6 @@ static VALUE sym_finished;
 static VALUE sym_after_output;
 static VALUE sym_incomplete_input;
 
-static ID id_encode;
-
 static unsigned char *
 allocate_converted_string(const char *sname, const char *dname,
         const unsigned char *str, size_t len,
@@ -2722,11 +2720,9 @@ str_transcode0(int argc, VALUE *argv, VALUE *self, int ecflags, VALUE ecopts)
     }
     else {
         if (senc && denc && !rb_enc_asciicompat(senc) && !rb_enc_asciicompat(denc)) {
-            VALUE encode_args[2];
-            encode_args[1] = rb_enc_from_encoding(senc);
-            senc = rb_utf8_encoding();
-            encode_args[0] = rb_enc_from_encoding(senc);
-            str = rb_funcallv_kw(str, id_encode, 2, encode_args, RB_NO_KEYWORDS);
+            rb_encoding *utf8 = rb_utf8_encoding();
+            str = rb_str_conv_enc(str, senc, utf8);
+            senc = utf8;
             sname = "UTF-8";
         }
         if (encoding_equal(sname, dname)) {
@@ -4588,8 +4584,6 @@ InitVM_transcode(void)
     rb_define_method(rb_eInvalidByteSequenceError, "error_bytes", ecerr_error_bytes, 0);
     rb_define_method(rb_eInvalidByteSequenceError, "readagain_bytes", ecerr_readagain_bytes, 0);
     rb_define_method(rb_eInvalidByteSequenceError, "incomplete_input?", ecerr_incomplete_input, 0);
-
-    id_encode = rb_intern("encode");
 
     Init_newline();
 }


### PR DESCRIPTION
When using a non-ASCII compatible source and destination encoding
and xml escaping (the :xml option to String#encode), the resulting
string was broken, as it used the correct non-ASCII compatible
encoding, but contained data that was ASCII-compatible instead of
compatible with the string's encoding.

Work around this issue by detecting the case where both the
source and destination encoding are non-ASCII compatible, and
transcoding the source string from the non-ASCII compatible
encoding to UTF-8. The xml escaping code will correctly handle
the UTF-8 source string and the return the correctly encoded
and escaped value.

Fixes [Bug #12052]