### PR TITLE
Move rb_str_escape function declaration

### DIFF
--- a/internal/string.h
+++ b/internal/string.h
@@ -38,6 +38,7 @@ VALUE rb_external_str_with_enc(VALUE str, rb_encoding *eenc);
 VALUE rb_str_cat_conv_enc_opts(VALUE newstr, long ofs, const char *ptr, long len,
                                rb_encoding *from, int ecflags, VALUE ecopts);
 VALUE rb_enc_str_scrub(rb_encoding *enc, VALUE str, VALUE repl);
+VALUE rb_str_escape(VALUE str);
 size_t rb_str_memsize(VALUE);
 char *rb_str_to_cstr(VALUE str);
 const char *ruby_escaped_char(int c);

--- a/object.c
+++ b/object.c
@@ -30,6 +30,7 @@
 #include "internal/numeric.h"
 #include "internal/object.h"
 #include "internal/struct.h"
+#include "internal/string.h"
 #include "internal/symbol.h"
 #include "internal/variable.h"
 #include "probes.h"
@@ -688,7 +689,6 @@ rb_any_to_s(VALUE obj)
     return str;
 }
 
-VALUE rb_str_escape(VALUE str);
 /*!
  * Convenient wrapper of \c Object#inspect.
  * Returns a human-readable string representation of \a obj,


### PR DESCRIPTION
I saw `rb_str_escape` function declaration in `object.c`.
But, `rb_str_escape` is'not export C API and only used in internal.

So, I think better move `rb_str_escape` declaration to `internal/string.h`.