### PR TITLE
Fix crash on RGENGC_CHECK_MODE=4

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -7977,7 +7977,9 @@ gc_marks_finish(rb_objspace_t *objspace)
     }
 
 #if RGENGC_CHECK_MODE >= 4
+    during_gc = FALSE;
     gc_marks_check(objspace, gc_check_after_marks_i, "after_marks");
+    during_gc = TRUE;
 #endif
 
     {


### PR DESCRIPTION
When running btest there is a crash when compiled with RGENGC_CHECK_MODE=4. The crash happens because `during_gc` is not turned off before `gc_marks_check` is called, causing the marking to happen on the main mark stack instead of mark stack created in `objspace_allrefs`.