### PR TITLE
Ignore timeout option to Addrinfo.getaddrinfo

### DIFF
--- a/ext/socket/raddrinfo.c
+++ b/ext/socket/raddrinfo.c
@@ -2496,9 +2496,7 @@ addrinfo_s_getaddrinfo(int argc, VALUE *argv, VALUE self)
     rb_scan_args(argc, argv, "24:", &node, &service, &family, &socktype,
 		 &protocol, &flags, &opts);
     rb_get_kwargs(opts, &id_timeout, 0, 1, &timeout);
-    if (timeout == Qundef) {
-	timeout = Qnil;
-    }
+    timeout = Qnil;
 
     return addrinfo_list_new(node, service, family, socktype, protocol, flags, timeout);
 }


### PR DESCRIPTION
This was already ignored on platforms that do not implement
getaddrinfo_a. Using getaddrinfo_a causes issues with many
calls to Addrinfo.getaddrinfo and also when using
Addrinfo.getaddrinfo with fork.

I would have updated the documentation for this, but the
option was already not documented.