### PR TITLE
Speedup require of native library without extension

### DIFF
--- a/load.c
+++ b/load.c
@@ -921,9 +921,14 @@ search_required(VALUE fname, volatile VALUE *path, feature_func rb_feature_p)
 	    }
 	}
     }
-    else if ((ft = rb_feature_p(ftptr, 0, FALSE, FALSE, &loading)) == 'r') {
-	if (loading) *path = rb_filesystem_str_new_cstr(loading);
-	return 'r';
+    else {
+        ft = rb_feature_p(ftptr, 0, FALSE, FALSE, &loading);
+        switch (ft) {
+          case 'r':
+          case 's':
+            if (loading) *path = rb_filesystem_str_new_cstr(loading);
+            return ft;
+        }
     }
     tmp = fname;
     type = rb_find_file_ext(&tmp, loadable_ext);

--- a/spec/ruby/core/kernel/shared/require.rb
+++ b/spec/ruby/core/kernel/shared/require.rb
@@ -269,14 +269,28 @@ describe :kernel_require, shared: true do
       ScratchPad.recorded.should == [:loaded]
     end
 
-    it "loads a .rb extensioned file when a C-extension file of the same name is loaded" do
-      $LOADED_FEATURES << File.expand_path("load_fixture.bundle", CODE_LOADING_DIR)
-      $LOADED_FEATURES << File.expand_path("load_fixture.dylib", CODE_LOADING_DIR)
-      $LOADED_FEATURES << File.expand_path("load_fixture.so", CODE_LOADING_DIR)
-      $LOADED_FEATURES << File.expand_path("load_fixture.dll", CODE_LOADING_DIR)
-      path = File.expand_path "load_fixture", CODE_LOADING_DIR
-      @object.require(path).should be_true
-      ScratchPad.recorded.should == [:loaded]
+    ruby_version_is '3.1' do
+      it "does not load a .rb extensioned file when a C-extension file of the same name is loaded" do
+        $LOADED_FEATURES << File.expand_path("load_fixture.bundle", CODE_LOADING_DIR)
+        $LOADED_FEATURES << File.expand_path("load_fixture.dylib", CODE_LOADING_DIR)
+        $LOADED_FEATURES << File.expand_path("load_fixture.so", CODE_LOADING_DIR)
+        $LOADED_FEATURES << File.expand_path("load_fixture.dll", CODE_LOADING_DIR)
+        path = File.expand_path "load_fixture", CODE_LOADING_DIR
+        @object.require(path).should be_false
+        ScratchPad.recorded.should == []
+      end
+    end
+
+    ruby_version_is ''...'3.1' do
+      it "loads a .rb extensioned file when a C-extension file of the same name is loaded" do
+        $LOADED_FEATURES << File.expand_path("load_fixture.bundle", CODE_LOADING_DIR)
+        $LOADED_FEATURES << File.expand_path("load_fixture.dylib", CODE_LOADING_DIR)
+        $LOADED_FEATURES << File.expand_path("load_fixture.so", CODE_LOADING_DIR)
+        $LOADED_FEATURES << File.expand_path("load_fixture.dll", CODE_LOADING_DIR)
+        path = File.expand_path "load_fixture", CODE_LOADING_DIR
+        @object.require(path).should be_true
+        ScratchPad.recorded.should == [:loaded]
+      end
     end
 
     it "does not load a C-extension file if a .rb extensioned file is already loaded" do


### PR DESCRIPTION
This treats native libraries the same as pure ruby libraries when
requiring, so that a require without an extension will consider
the library already loaded if the native extension for the
library has been loaded.

This can break things, but the speedup it provides is substantial.

Basic idea from deivid (David Rodriguez).

Implements [Feature #15856]