### PR TITLE
Don't pack queue structs.

### DIFF
--- a/thread_sync.c
+++ b/thread_sync.c
@@ -637,21 +637,21 @@ void rb_mutex_allow_trap(VALUE self, int val)
 /* Queue */
 
 #define queue_waitq(q) UNALIGNED_MEMBER_PTR(q, waitq)
-PACKED_STRUCT_UNALIGNED(struct rb_queue {
+struct rb_queue {
     struct list_head waitq;
     rb_serial_t fork_gen;
     const VALUE que;
     int num_waiting;
-});
+};
 
 #define szqueue_waitq(sq) UNALIGNED_MEMBER_PTR(sq, q.waitq)
 #define szqueue_pushq(sq) UNALIGNED_MEMBER_PTR(sq, pushq)
-PACKED_STRUCT_UNALIGNED(struct rb_szqueue {
+struct rb_szqueue {
     struct rb_queue q;
     int num_waiting_push;
     struct list_head pushq;
     long max;
-});
+};
 
 static void
 queue_mark(void *ptr)


### PR DESCRIPTION
It's packed: https://github.com/ioquatix/ruby/blame/master/thread_sync.c#L640

But recently I saw this warning come up:

```
In file included from thread.c:420:
thread_sync.c: In function ‘queue_do_pop’:
thread_sync.c:1021:122: warning: taking address of packed member of ‘struct rb_queue’ may result in an unaligned pointer value [-Waddress-of-packed-member]
 1021 |             list_add_tail(queue_waitq(queue_waiter.as.q), &queue_waiter.w.node);
      |                                                                                                                          ^                           
```

This PR might introduce other issues because I believe we are assuming the address of the struct is also the address of the first element.