### PR TITLE
Always mark jemalloc needed if jemalloc is enabled

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1301,6 +1301,7 @@ AS_IF([test "x$with_jemalloc" != xno],[
     [
       AC_DEFINE(HAVE_LIBJEMALLOC, 1)
       with_jemalloc=yes
+      LDFLAGS="$LDFLAGS -Wl,--push-state,--no-as-needed,-ljemalloc,--pop-state"
     ],
     [test x$with_jemalloc = xyes && with_jemalloc=no])
   AC_CHECK_HEADER(jemalloc/jemalloc.h, [


### PR DESCRIPTION
Symbols exported by jemalloc is referred by the shared library but not by the executables when building Ruby as a shared library with jemalloc. It causes shared libraries such as the GNU C++ library occasionally rely on the memory allocator provided by the standard C library. Worse, the resolved symbols can later be replaced with jemalloc, and jemalloc may see pointers from the standard C library, which results in various failures. e.g. https://github.com/tootsuite/mastodon/issues/15751

Always mark jemalloc needed so that memory allocator symbols of other shared libraries are also resolved with jemalloc.