### PR TITLE
Refactor rb_str_export and rb_str_export_locale function's

### DIFF
--- a/string.c
+++ b/string.c
@@ -1180,13 +1180,13 @@ rb_filesystem_str_new_cstr(const char *ptr)
 VALUE
 rb_str_export(VALUE str)
 {
-    return rb_str_conv_enc(str, STR_ENC_GET(str), rb_default_external_encoding());
+    return rb_str_export_to_enc(str, rb_default_external_encoding());
 }
 
 VALUE
 rb_str_export_locale(VALUE str)
 {
-    return rb_str_conv_enc(str, STR_ENC_GET(str), rb_locale_encoding());
+    return rb_str_export_to_enc(str, rb_locale_encoding());
 }
 
 VALUE


### PR DESCRIPTION
`rb_str_export_to_enc`, `rb_str_export` and `rb_str_export_locale` function has similar code.
Using `rb_str_export_to_enc` in `rb_str_export` and `rb_str_export_locale` for refactor these functions.