### PR TITLE
configure: add -Wl,--no-as-needed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3383,6 +3383,11 @@ AS_CASE("$enable_shared", [yes], [
   AC_DEFINE_UNQUOTED(LIBDIR_BASENAME, ["${libdir_basename}"])
   libdir_basename="${libdir_basename}"${multiarch+'/${arch}'}
 
+  RUBY_TRY_LDFLAGS([${linker_flag}--no-as-needed], [no_as_needed=yes], [no_as_needed=no])
+  AS_IF([test "$no_as_needed" = yes], [
+      RUBY_APPEND_OPTIONS(LDFLAGS, [${linker_flag}--no-as-needed])
+  ])
+
   AS_CASE(["$target_os"],
     [freebsd*|dragonfly*], [],
     [

--- a/configure.ac
+++ b/configure.ac
@@ -3383,6 +3383,12 @@ AS_CASE("$enable_shared", [yes], [
   AC_DEFINE_UNQUOTED(LIBDIR_BASENAME, ["${libdir_basename}"])
   libdir_basename="${libdir_basename}"${multiarch+'/${arch}'}
 
+  # Debian bullseye reportedly has its ld(1) patched, which breaks
+  # --enable-shared --with-jemalloc combination.  We might have to deal with
+  # the ld(1) change sooner or later, but in the meantime let us force it
+  # the old way.
+  #
+  # See https://github.com/ruby/ruby/pull/4627
   RUBY_TRY_LDFLAGS([${linker_flag}--no-as-needed], [no_as_needed=yes], [no_as_needed=no])
   AS_IF([test "$no_as_needed" = yes], [
       RUBY_APPEND_OPTIONS(LDFLAGS, [${linker_flag}--no-as-needed])


### PR DESCRIPTION
This is my take to fix #4627.

- Instead of tweaking `--with-jemalloc` I opted to modity `--enable-shared`.
- The linker flag is checked for availability.

Confirmed working for debian bullseye.