### PR TITLE
Fix infinite loop when b_return TracePoint throw

### DIFF
--- a/test/ruby/test_settracefunc.rb
+++ b/test/ruby/test_settracefunc.rb
@@ -2401,4 +2401,18 @@ class TestSetTraceFunc < Test::Unit::TestCase
     }
     assert_equal [__LINE__ - 5, __LINE__ - 4, __LINE__ - 3], lines, 'Bug #17868'
   end
+
+  def test_b_return_raising_with_bmethod_and_break
+    assert_normal_exit <<-EOS
+      class Foo
+        define_singleton_method(:foo) { return }
+      end
+
+      TracePoint.trace(:b_return) do |tp|
+        raise
+      end
+
+      Foo.foo
+    EOS
+  end
 end

--- a/vm.c
+++ b/vm.c
@@ -2017,10 +2017,10 @@ hook_before_rewind(rb_execution_context_t *ec, const rb_control_frame_t *cfp,
             break;
           case VM_FRAME_MAGIC_BLOCK:
             if (VM_FRAME_BMETHOD_P(ec->cfp)) {
-                EXEC_EVENT_HOOK(ec, RUBY_EVENT_B_RETURN, ec->cfp->self, 0, 0, 0, frame_return_value(err));
+                EXEC_EVENT_HOOK_AND_POP_FRAME(ec, RUBY_EVENT_B_RETURN, ec->cfp->self, 0, 0, 0, frame_return_value(err));
                 if (UNLIKELY(local_hooks && local_hooks->events & RUBY_EVENT_B_RETURN)) {
                     rb_exec_event_hook_orig(ec, local_hooks, RUBY_EVENT_B_RETURN,
-                                            ec->cfp->self, 0, 0, 0, frame_return_value(err), FALSE);
+                                            ec->cfp->self, 0, 0, 0, frame_return_value(err), TRUE);
                 }
 
                 if (!will_finish_vm_exec) {

--- a/vm_trace.c
+++ b/vm_trace.c
@@ -361,6 +361,7 @@ exec_hooks_protected(rb_execution_context_t *ec, rb_hook_list_t *list, const rb_
     return state;
 }
 
+// pop_p: Whether to pop the frame for the TracePoint when it throws.
 MJIT_FUNC_EXPORTED void
 rb_exec_event_hooks(rb_trace_arg_t *trace_arg, rb_hook_list_t *hooks, int pop_p)
 {


### PR DESCRIPTION
Before this change, this script runs in an infinite loop:

```ruby
class Foo
  define_singleton_method(:foo) { return }
end

TracePoint.trace(:b_return) do |tp|
  p tp
  raise
end

Foo.foo
```