### PR TITLE
`Time.new` to parse a string

### DIFF
--- a/benchmark/time_new.yml
+++ b/benchmark/time_new.yml
@@ -1,0 +1,4 @@
+benchmark:
+  - 'Time.new(2021)'
+  - 'Time.new(2021, 8, 22)'
+  - 'Time.new(2021, 8, 22, in: "+09:00")'

--- a/benchmark/time_parse.yml
+++ b/benchmark/time_parse.yml
@@ -1,0 +1,6 @@
+prelude: |
+  require 'time'
+  s = Time.now.iso8601
+benchmark:
+  - Time.iso8601(s)
+  - Time.parse(s)

--- a/test/ruby/test_time.rb
+++ b/test/ruby/test_time.rb
@@ -53,6 +53,7 @@ class TestTime < Test::Unit::TestCase
     assert_equal(t, Time.new("2020-12-24T15:56:17Z"))
     assert_equal(t, Time.new("2020-12-25 00:56:17 +09:00"))
     assert_equal(t, Time.new("2020-12-25 00:57:47 +09:01:30"))
+    assert_equal(t, Time.new("20201225T005617 +0900"))
   end
 
   def test_time_add()

--- a/test/ruby/test_time.rb
+++ b/test/ruby/test_time.rb
@@ -37,6 +37,7 @@ class TestTime < Test::Unit::TestCase
   end
 
   def test_new
+    assert_equal(Time.new(2000,1,1,0,0,0), Time.new(2000))
     assert_equal(Time.utc(2000,2,10), Time.new(2000,2,10, 11,0,0, 3600*11))
     assert_equal(Time.utc(2000,2,10), Time.new(2000,2,9, 13,0,0, -3600*11))
     assert_equal(Time.utc(2000,2,10), Time.new(2000,2,10, 11,0,0, "+11:00"))
@@ -47,6 +48,11 @@ class TestTime < Test::Unit::TestCase
     assert_equal([2001,2,28,23,59,30,-43200], [t.year, t.month, t.mday, t.hour, t.min, t.sec, t.gmt_offset], bug4090)
     assert_raise(ArgumentError) { Time.new(2000,1,1, 0,0,0, "+01:60") }
     assert_raise(ArgumentError) { Time.new(2021, 1, 1, "+09:99") }
+
+    t = Time.utc(2020, 12, 24, 15, 56, 17)
+    assert_equal(t, Time.new("2020-12-24T15:56:17Z"))
+    assert_equal(t, Time.new("2020-12-25 00:56:17 +09:00"))
+    assert_equal(t, Time.new("2020-12-25 00:57:47 +09:01:30"))
   end
 
   def test_time_add()

--- a/timev.rb
+++ b/timev.rb
@@ -286,7 +286,7 @@ class Time
   # :include: doc/time/zone_and_in.rdoc
   #
   def initialize(year = (now = true), mon = (time = String.try_convert(year); nil),
-                 mday = nil, hour = nil, min = nil, sec = nil, zone = nil, in: nil)
+                 mday = nil, hour = nil, min = nil, sec = nil, zone = nil, in: nil, base: nil)
     if zone
       if __builtin.arg!(:in)
         raise ArgumentError, "timezone argument given as positional and keyword arguments"
@@ -344,6 +344,6 @@ class Time
       zone = z if z
     end
 
-    __builtin.time_init_args(year, mon, mday, hour, min, sec, zone)
+    __builtin.time_init_args(year, mon, mday, hour, min, sec, zone, base)
   end
 end

--- a/timev.rb
+++ b/timev.rb
@@ -285,7 +285,8 @@ class Time
   # :include: doc/time/sec.rdoc
   # :include: doc/time/zone_and_in.rdoc
   #
-  def initialize(year = (now = true), mon = nil, mday = nil, hour = nil, min = nil, sec = nil, zone = nil, in: nil)
+  def initialize(year = (now = true), mon = (time = String.try_convert(year); nil),
+                 mday = nil, hour = nil, min = nil, sec = nil, zone = nil, in: nil)
     if zone
       if __builtin.arg!(:in)
         raise ArgumentError, "timezone argument given as positional and keyword arguments"
@@ -296,6 +297,22 @@ class Time
 
     if now
       return __builtin.time_init_now(zone)
+    end
+
+    if time and !(year = Integer(time, 10, exception: false))
+      year = time
+      %r[\A\s*
+        (?<year>[-+]?\d{2,})-(?<mon>\d\d)
+        (?:-(?<mday>\d\d)
+          (?:(?:T|\s+)
+            (?<hour>\d\d)
+            (?::(?<min>\d\d)
+              (?::(?<sec>\d\d(?:\.\d+)?))?)?)?)?\s*
+        (?<z>[-+]\d\d(?:(?:\d\d){0,2}|(?::\d\d){0,2})|
+          [A-IK-Z]|
+          (?i:[a-z]+/[a-z]+(?:_[a-z]+)*))?
+      \s*\z]x =~ time or raise ArgumentError, "cannot parse: #{time}"
+      zone = z if z
     end
 
     __builtin.time_init_args(year, mon, mday, hour, min, sec, zone)


### PR DESCRIPTION
Make `Time.new` parse `Time#inspect` and ISO-8601 like strings.

https://bugs.ruby-lang.org/issues/18033