### PR TITLE
Expose `rb_fiber_raise` and tidy up the internal implementation.

### DIFF
--- a/include/ruby/internal/intern/cont.h
+++ b/include/ruby/internal/intern/cont.h
@@ -239,6 +239,8 @@ VALUE rb_fiber_transfer(VALUE fiber, int argc, const VALUE *argv);
  */
 VALUE rb_fiber_transfer_kw(VALUE fiber, int argc, const VALUE *argv, int kw_splat);
 
+VALUE rb_fiber_raise(VALUE fiber, int argc, VALUE *argv);
+
 RBIMPL_SYMBOL_EXPORT_END()
 
 #endif /* RBIMPL_INTERN_CONT_H */

--- a/spec/ruby/optional/capi/ext/fiber_spec.c
+++ b/spec/ruby/optional/capi/ext/fiber_spec.c
@@ -44,6 +44,13 @@ VALUE fiber_spec_rb_fiber_new(VALUE self) {
   return rb_fiber_new(fiber_spec_rb_fiber_new_function, Qnil);
 }
 
+#ifdef RUBY_VERSION_IS_3_1
+VALUE fiber_spec_rb_fiber_raise(int argc, VALUE *argv, VALUE self) {
+  VALUE fiber = argv[0];
+  return rb_fiber_raise(fiber, argc-1, argv+1);
+}
+#endif
+
 void Init_fiber_spec(void) {
   VALUE cls = rb_define_class("CApiFiberSpecs", rb_cObject);
   rb_define_method(cls, "rb_fiber_current", fiber_spec_rb_fiber_current, 0);
@@ -51,6 +58,10 @@ void Init_fiber_spec(void) {
   rb_define_method(cls, "rb_fiber_resume", fiber_spec_rb_fiber_resume, 2);
   rb_define_method(cls, "rb_fiber_yield", fiber_spec_rb_fiber_yield, 1);
   rb_define_method(cls, "rb_fiber_new", fiber_spec_rb_fiber_new, 0);
+
+#ifdef RUBY_VERSION_IS_3_1
+  rb_define_method(cls, "rb_fiber_raise", fiber_spec_rb_fiber_raise, -1);
+#endif
 }
 
 #ifdef __cplusplus

--- a/spec/ruby/optional/capi/fiber_spec.rb
+++ b/spec/ruby/optional/capi/fiber_spec.rb
@@ -48,4 +48,42 @@ describe "C-API Fiber function" do
       fiber.resume(42).should == "42"
     end
   end
+
+  describe "rb_fiber_raise" do
+    ruby_version_is '3.1' do
+      it "raises an exception on the resumed fiber" do
+        fiber = Fiber.new do
+          begin
+            Fiber.yield
+          rescue => error
+            error
+          end
+        end
+
+        fiber.resume
+
+        result = @s.rb_fiber_raise(fiber, "Boom!")
+        result.should be_an_instance_of(RuntimeError)
+        result.message.should == "Boom!"
+      end
+
+      it "raises an exception on the transferred fiber" do
+        main = Fiber.current
+
+        fiber = Fiber.new do
+          begin
+            main.transfer
+          rescue => error
+            error
+          end
+        end
+
+        fiber.transfer
+
+        result = @s.rb_fiber_raise(fiber, "Boom!")
+        result.should be_an_instance_of(RuntimeError)
+        result.message.should == "Boom!"
+      end
+    end
+  end
 end


### PR DESCRIPTION
Expose `rb_fiber_raise` so it can be called from C extensions.

Rework the internal implementation to avoid all the indirection for `resuming_fiber` and `fiber_ptr` usage. This should generate slightly more efficient assembly.