### PR TITLE
.travis.yml: Add `apt-get update`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,7 @@ env:
     compiler: gcc-10
     before_install:
       - tool/travis_retry.sh sudo bash -c "rm -rf '${TRAVIS_ROOT}/var/lib/apt/lists/'* && exec apt-get update -yq"
+      - tool/travis_retry.sh sudo apt-get -qq update
       - >-
         tool/travis_retry.sh sudo -E apt-get $travis_apt_get_options install
         ccache


### PR DESCRIPTION
To fix the following error happened on Traivs s390x.

https://app.travis-ci.com/github/ruby/ruby/jobs/524626085#L151
https://app.travis-ci.com/github/ruby/ruby/jobs/524643548#L151

```
+ sudo -E apt-get -yq --no-install-suggests --no-install-recommends --allow-downgrades --allow-remove-essential --allow-change-held-packages install ccache gcc-10 g++-10 libffi-dev libgdbm-dev libncurses-dev libncursesw5-dev libreadline-dev libssl-dev libyaml-dev openssl zlib1g-dev
Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package gcc-10
```