### PR TITLE
Add gvl and fiber assertions to scheduler interface to catch invalid usage.

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -12215,6 +12215,7 @@ scheduler.$(OBJEXT): $(top_srcdir)/internal/gc.h
 scheduler.$(OBJEXT): $(top_srcdir)/internal/imemo.h
 scheduler.$(OBJEXT): $(top_srcdir)/internal/serial.h
 scheduler.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
+scheduler.$(OBJEXT): $(top_srcdir)/internal/thread.h
 scheduler.$(OBJEXT): $(top_srcdir)/internal/vm.h
 scheduler.$(OBJEXT): $(top_srcdir)/internal/warnings.h
 scheduler.$(OBJEXT): {$(VPATH)}assert.h

--- a/scheduler.c
+++ b/scheduler.c
@@ -11,6 +11,7 @@
 #include "vm_core.h"
 #include "ruby/fiber/scheduler.h"
 #include "ruby/io.h"
+#include "internal/thread.h"
 
 static ID id_close;
 static ID id_scheduler_close;
@@ -51,6 +52,8 @@ Init_Fiber_Scheduler(void)
 VALUE
 rb_fiber_scheduler_get(void)
 {
+    VM_ASSERT(ruby_thread_has_gvl_p());
+
     rb_thread_t *thread = GET_THREAD();
     VM_ASSERT(thread);
 
@@ -80,6 +83,8 @@ verify_interface(VALUE scheduler)
 VALUE
 rb_fiber_scheduler_set(VALUE scheduler)
 {
+    VM_ASSERT(ruby_thread_has_gvl_p());
+
     rb_thread_t *thread = GET_THREAD();
     VM_ASSERT(thread);
 
@@ -124,6 +129,8 @@ VALUE rb_fiber_scheduler_current_for_thread(VALUE thread)
 VALUE
 rb_fiber_scheduler_close(VALUE scheduler)
 {
+    VM_ASSERT(ruby_thread_has_gvl_p());
+
     VALUE result;
 
     result = rb_check_funcall(scheduler, id_scheduler_close, 0, NULL);
@@ -194,6 +201,8 @@ rb_fiber_scheduler_block(VALUE scheduler, VALUE blocker, VALUE timeout)
 VALUE
 rb_fiber_scheduler_unblock(VALUE scheduler, VALUE blocker, VALUE fiber)
 {
+    VM_ASSERT(rb_obj_is_fiber(fiber));
+
     return rb_funcall(scheduler, id_unblock, 2, blocker, fiber);
 }
 

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -645,6 +645,8 @@ rb_check_funcall(VALUE recv, ID mid, int argc, const VALUE *argv)
 static VALUE
 rb_check_funcall_default_kw(VALUE recv, ID mid, int argc, const VALUE *argv, VALUE def, int kw_splat)
 {
+    VM_ASSERT(ruby_thread_has_gvl_p());
+
     VALUE klass = CLASS_OF(recv);
     const rb_callable_method_entry_t *me;
     rb_execution_context_t *ec = GET_EC();


### PR DESCRIPTION
This is an attempt to diagnose/catch the following error reported by @jeremyevans: https://github.com/ruby/ruby/pull/4616/checks?check_run_id=3078517784#step:15:27