### PR TITLE
Add debug assertion in `rb_funcall*` that the current thread has the gvl.

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -15206,6 +15206,7 @@ vm.$(OBJEXT): $(top_srcdir)/internal/serial.h
 vm.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 vm.$(OBJEXT): $(top_srcdir)/internal/string.h
 vm.$(OBJEXT): $(top_srcdir)/internal/symbol.h
+vm.$(OBJEXT): $(top_srcdir)/internal/thread.h
 vm.$(OBJEXT): $(top_srcdir)/internal/variable.h
 vm.$(OBJEXT): $(top_srcdir)/internal/vm.h
 vm.$(OBJEXT): $(top_srcdir)/internal/warnings.h

--- a/vm.c
+++ b/vm.c
@@ -23,6 +23,7 @@
 #include "internal/proc.h"
 #include "internal/re.h"
 #include "internal/symbol.h"
+#include "internal/thread.h"
 #include "internal/vm.h"
 #include "internal/sanitizers.h"
 #include "iseq.h"

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -1036,12 +1036,16 @@ rb_funcallv_scope(VALUE recv, ID mid, int argc, const VALUE *argv, call_type sco
 VALUE
 rb_funcallv(VALUE recv, ID mid, int argc, const VALUE *argv)
 {
+    VM_ASSERT(ruby_thread_has_gvl_p());
+
     return rb_funcallv_scope(recv, mid, argc, argv, CALL_FCALL);
 }
 
 VALUE
 rb_funcallv_kw(VALUE recv, ID mid, int argc, const VALUE *argv, int kw_splat)
 {
+    VM_ASSERT(ruby_thread_has_gvl_p());
+
     return rb_call(recv, mid, argc, argv, kw_splat ? CALL_FCALL_KW : CALL_FCALL);
 }
 


### PR DESCRIPTION
We discussed this and decided it might be acceptable as long as performance is not severely impacted (in debug build). This is kind of a superset of https://github.com/ruby/ruby/pull/4656