### PR TITLE
Add alternative optional hook for `scheduler_close` to allow public usage of close.

### DIFF
--- a/scheduler.c
+++ b/scheduler.c
@@ -13,6 +13,7 @@
 #include "ruby/io.h"
 
 static ID id_close;
+static ID id_scheduler_close;
 
 static ID id_block;
 static ID id_unblock;
@@ -31,6 +32,7 @@ void
 Init_Fiber_Scheduler(void)
 {
     id_close = rb_intern_const("close");
+    id_scheduler_close = rb_intern_const("scheduler_close");
 
     id_block = rb_intern_const("block");
     id_unblock = rb_intern_const("unblock");
@@ -122,9 +124,13 @@ VALUE rb_fiber_scheduler_current_for_thread(VALUE thread)
 VALUE
 rb_fiber_scheduler_close(VALUE scheduler)
 {
-    if (rb_respond_to(scheduler, id_close)) {
-        return rb_funcall(scheduler, id_close, 0);
-    }
+    VALUE result;
+
+    result = rb_check_funcall(scheduler, id_scheduler_close, 0, NULL);
+    if (result != Qundef) return result;
+
+    result = rb_check_funcall(scheduler, id_close, 0, NULL);
+    if (result != Qundef) return result;
 
     return Qnil;
 }

--- a/test/fiber/scheduler.rb
+++ b/test/fiber/scheduler.rb
@@ -107,10 +107,22 @@ class Scheduler
     end
   end
 
-  def close
+  def scheduler_close
+    close(true)
+  end
+
+  def close(internal = false)
     # $stderr.puts [__method__, Fiber.current].inspect
 
-    raise "Scheduler already closed!" if @closed
+    unless internal
+      if Fiber.scheduler == self
+        return Fiber.set_scheduler(nil)
+      end
+    end
+
+    if @closed
+      raise "Scheduler already closed!"
+    end
 
     self.run
   ensure
@@ -119,7 +131,7 @@ class Scheduler
       @urgent = nil
     end
 
-    @closed = true
+    @closed ||= true
 
     # We freeze to detect any unintended modifications after the scheduler is closed:
     self.freeze


### PR DESCRIPTION
This gives implementations a bit more flexibility.