### PR TITLE
Don't escape backslash in error message

### DIFF
--- a/eval_error.c
+++ b/eval_error.c
@@ -103,10 +103,6 @@ write_warnq(VALUE out, VALUE str, const char *ptr, long len)
                     rb_write_error2(buf, snprintf(buf, sizeof(buf), "\\x%02X", c));
                 }
             }
-            else if (c == '\\') {
-                rb_write_error2(beg, ptr - beg + 1);
-                beg = ptr;
-            }
         }
         if (ptr > beg) {
             if (beg == RSTRING_PTR(str) && olen == RSTRING_LEN(str))


### PR DESCRIPTION
ref: https://github.com/ruby/error_highlight/issues/9



Escaping backslash prints unexpected message, especially for error_message gem. It has been introduced in https://bugs.ruby-lang.org/issues/15497
This PR removes the escape.

By this change, we cannot distinguish escaped strings and backslashes in code.
For example:

```ruby
"^@\0".foo
```

```
# before

test.rb:1:in `<main>': undefined method `foo' for "\\u0000\\u0000":String (NoMethodError)

"\0\\0".foo
     ^^^^


# after

$ ruby test.rb
test.rb:1:in `<main>': undefined method `foo' for "\u0000\u0000":String (NoMethodError)

"\0\0".foo
     ^^^^
```

Personally I think it is not a problem because the error message is for humans but not machines. We can distinguish them by reading the actual code. And escape sequence in code is a rare case.