### PR TITLE
Remove safe level in finalizer

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -3938,7 +3938,7 @@ define_final0(VALUE obj, VALUE block)
 
             for (i = 0; i < len; i++) {
                 VALUE recv = RARRAY_AREF(table, i);
-                if (rb_funcall(recv, idEq, 1, block)) {
+                if (rb_equal(recv, block)) {
                     block = recv;
                     goto end;
 		}


### PR DESCRIPTION
Finalizers no longer restore the safe level since while ago.