### PR TITLE
Add usage_analysis_clear function

### DIFF
--- a/vm.c
+++ b/vm.c
@@ -4018,14 +4018,13 @@ usage_analysis_insn_clear(VALUE self)
   return Qtrue;
 }
 
-/* :nodoc: */
 static VALUE
-usage_analysis_operand_clear(VALUE self)
+usage_analysis_clear(VALUE self, const char *str)
 {
   ID usage_hash;
   VALUE uh;
 
-  CONST_ID(usage_hash, "USAGE_ANALYSIS_INSN");
+  CONST_ID(usage_hash, str);
   uh = rb_const_get(rb_cRubyVM, usage_hash);
   rb_hash_clear(uh);
 
@@ -4034,16 +4033,16 @@ usage_analysis_operand_clear(VALUE self)
 
 /* :nodoc: */
 static VALUE
+usage_analysis_operand_clear(VALUE self)
+{
+  return usage_analysis_clear(self, "USAGE_ANALYSIS_INSN");
+}
+
+/* :nodoc: */
+static VALUE
 usage_analysis_register_clear(VALUE self)
 {
-  ID usage_hash;
-  VALUE uh;
-
-  CONST_ID(usage_hash, "USAGE_ANALYSIS_REGS");
-  uh = rb_const_get(rb_cRubyVM, usage_hash);
-  rb_hash_clear(uh);
-
-  return Qtrue;
+  return usage_analysis_clear(self, "USAGE_ANALYSIS_REGS");
 }
 
 #else


### PR DESCRIPTION
`usage_analysis_operand_clear` and `usage_analysis_register_clear` functions has similar code.
Added `usage_analysis_clear` function and cut out these similar code.