### PR TITLE
Thread fixes backports

### DIFF
--- a/test/fiber/scheduler.rb
+++ b/test/fiber/scheduler.rb
@@ -188,3 +188,11 @@ class Scheduler
     return fiber
   end
 end
+
+class BrokenUnblockScheduler < Scheduler
+  def unblock(blocker, fiber)
+    super
+
+    raise "Broken unblock!"
+  end
+end

--- a/test/fiber/scheduler.rb
+++ b/test/fiber/scheduler.rb
@@ -100,8 +100,10 @@ class Scheduler
 
     self.run
   ensure
-    @urgent.each(&:close)
-    @urgent = nil
+    if @urgent
+      @urgent.each(&:close)
+      @urgent = nil
+    end
 
     @closed = true
 
@@ -194,5 +196,15 @@ class BrokenUnblockScheduler < Scheduler
     super
 
     raise "Broken unblock!"
+  end
+end
+
+class SleepingUnblockScheduler < Scheduler
+  # This method is invoked when the thread is exiting.
+  def unblock(blocker, fiber)
+    super
+
+    # This changes the current thread state to `THREAD_RUNNING` which causes `thread_join_sleep` to hang.
+    sleep(0.1)
   end
 end

--- a/test/fiber/test_scheduler.rb
+++ b/test/fiber/test_scheduler.rb
@@ -66,9 +66,23 @@ class TestFiberScheduler < Test::Unit::TestCase
     RUBY
   end
 
-  def test_optional_close
+  def test_minimal_interface
+    scheduler = Object.new
+
+    def scheduler.block
+    end
+
+    def scheduler.unblock
+    end
+
+    def scheduler.io_wait
+    end
+
+    def scheduler.kernel_sleep
+    end
+
     thread = Thread.new do
-      Fiber.set_scheduler Object.new
+      Fiber.set_scheduler scheduler
     end
 
     thread.join

--- a/test/fiber/test_sleep.rb
+++ b/test/fiber/test_sleep.rb
@@ -59,6 +59,9 @@ class TestFiberSleep < Test::Unit::TestCase
       Fiber.schedule do
         sleep 0
       end
+
+    ensure
+      scheduler.close
     end
 
     assert_raise(RuntimeError) do

--- a/test/fiber/test_sleep.rb
+++ b/test/fiber/test_sleep.rb
@@ -43,4 +43,26 @@ class TestFiberSleep < Test::Unit::TestCase
 
     assert_operator seconds, :>=, 2, "actual: %p" % seconds
   end
+
+  def test_broken_sleep
+    thread = Thread.new do
+      Thread.current.report_on_exception = false
+
+      scheduler = Scheduler.new
+
+      def scheduler.kernel_sleep(duration = nil)
+        raise "Broken sleep!"
+      end
+
+      Fiber.set_scheduler scheduler
+
+      Fiber.schedule do
+        sleep 0
+      end
+    end
+
+    assert_raise(RuntimeError) do
+      thread.join
+    end
+  end
 end

--- a/test/fiber/test_thread.rb
+++ b/test/fiber/test_thread.rb
@@ -56,6 +56,8 @@ class TestFiberThread < Test::Unit::TestCase
       end
 
       scheduler.run
+    ensure
+      scheduler.close
     end
 
     assert_raise(RuntimeError) do

--- a/test/fiber/test_thread.rb
+++ b/test/fiber/test_thread.rb
@@ -42,4 +42,24 @@ class TestFiberThread < Test::Unit::TestCase
 
     assert_equal :done, thread.value
   end
+
+  def test_broken_unblock
+    thread = Thread.new do
+      Thread.current.report_on_exception = false
+
+      scheduler = BrokenUnblockScheduler.new
+
+      Fiber.set_scheduler scheduler
+
+      Fiber.schedule do
+        Thread.new{}.join
+      end
+
+      scheduler.run
+    end
+
+    assert_raise(RuntimeError) do
+      thread.join
+    end
+  end
 end

--- a/test/fiber/test_thread.rb
+++ b/test/fiber/test_thread.rb
@@ -52,7 +52,9 @@ class TestFiberThread < Test::Unit::TestCase
       Fiber.set_scheduler scheduler
 
       Fiber.schedule do
-        Thread.new{}.join
+        Thread.new{
+          Thread.current.report_on_exception = false
+        }.join
       end
 
       scheduler.run

--- a/thread.c
+++ b/thread.c
@@ -539,9 +539,12 @@ terminate_all(rb_ractor_t *r, const rb_thread_t *main_thread)
 static void
 rb_threadptr_join_list_wakeup(rb_thread_t *thread)
 {
-    struct rb_waiting_list *join_list = thread->join_list;
+    while (thread->join_list) {
+        struct rb_waiting_list *join_list = thread->join_list;
 
-    while (join_list) {
+        // Consume the entry from the join list:
+        thread->join_list = join_list->next;
+
         rb_thread_t *target_thread = join_list->thread;
 
         if (target_thread->scheduler != Qnil && rb_fiberptr_blocking(join_list->fiber) == 0) {
@@ -557,25 +560,20 @@ rb_threadptr_join_list_wakeup(rb_thread_t *thread)
                     break;
             }
         }
-
-        join_list = join_list->next;
     }
 }
 
 void
 rb_threadptr_unlock_all_locking_mutexes(rb_thread_t *th)
 {
-    const char *err;
-    rb_mutex_t *mutex;
-    rb_mutex_t *mutexes = th->keeping_mutexes;
+    while (th->keeping_mutexes) {
+        rb_mutex_t *mutex = th->keeping_mutexes;
+        th->keeping_mutexes = mutex->next_mutex;
 
-    while (mutexes) {
-	mutex = mutexes;
-	/* rb_warn("mutex #<%p> remains to be locked by terminated thread",
-		(void *)mutexes); */
-	mutexes = mutex->next_mutex;
-	err = rb_mutex_unlock_th(mutex, th, mutex->fiber);
-	if (err) rb_bug("invalid keeping_mutexes: %s", err);
+        /* rb_warn("mutex #<%p> remains to be locked by terminated thread", (void *)mutexes); */
+
+        const char *error_message = rb_mutex_unlock_th(mutex, th, mutex->fiber);
+        if (error_message) rb_bug("invalid keeping_mutexes: %s", error_message);
     }
 }
 
@@ -816,86 +814,86 @@ thread_start_func_2(rb_thread_t *th, VALUE *stack_start)
     th->ec->machine.stack_start = STACK_DIR_UPPER(vm_stack + size, vm_stack);
     th->ec->machine.stack_maxsize -= size * sizeof(VALUE);
 
-    {
-	thread_debug("thread start (get lock): %p\n", (void *)th);
+    thread_debug("thread start (get lock): %p\n", (void *)th);
 
-	EC_PUSH_TAG(th->ec);
-	if ((state = EC_EXEC_TAG()) == TAG_NONE) {
-            SAVE_ROOT_JMPBUF(th, thread_do_start(th));
-	}
-	else {
-	    errinfo = th->ec->errinfo;
+    EC_PUSH_TAG(th->ec);
 
-            if (state == TAG_FATAL) {
-                if (th->invoke_type == thread_invoke_type_ractor_proc) {
-                    rb_ractor_atexit(th->ec, Qnil);
-                }
-		/* fatal error within this thread, need to stop whole script */
-	    }
-	    else if (rb_obj_is_kind_of(errinfo, rb_eSystemExit)) {
-		/* exit on main_thread. */
-	    }
-	    else {
-                if (th->report_on_exception) {
-		    VALUE mesg = rb_thread_to_s(th->self);
-		    rb_str_cat_cstr(mesg, " terminated with exception (report_on_exception is true):\n");
-		    rb_write_error_str(mesg);
-		    rb_ec_error_print(th->ec, errinfo);
-		}
+    if ((state = EC_EXEC_TAG()) == TAG_NONE) {
+        SAVE_ROOT_JMPBUF(th, thread_do_start(th));
+    } else {
+        errinfo = th->ec->errinfo;
 
-                if (th->invoke_type == thread_invoke_type_ractor_proc) {
-                    rb_ractor_atexit_exception(th->ec);
-                }
-
-                if (th->vm->thread_abort_on_exception ||
-                    th->abort_on_exception || RTEST(ruby_debug)) {
-		    /* exit on main_thread */
-		}
-		else {
-		    errinfo = Qnil;
-		}
-	    }
-	    th->value = Qnil;
-	}
-
-        if (th->invoke_type == thread_invoke_type_ractor_proc) {
-            rb_thread_terminate_all(th);
-            rb_ractor_teardown(th->ec);
+        if (state == TAG_FATAL) {
+            if (th->invoke_type == thread_invoke_type_ractor_proc) {
+                rb_ractor_atexit(th->ec, Qnil);
+            }
+            /* fatal error within this thread, need to stop whole script */
         }
+        else if (rb_obj_is_kind_of(errinfo, rb_eSystemExit)) {
+            /* exit on main_thread. */
+        }
+        else {
+            if (th->report_on_exception) {
+                VALUE mesg = rb_thread_to_s(th->self);
+                rb_str_cat_cstr(mesg, " terminated with exception (report_on_exception is true):\n");
+                rb_write_error_str(mesg);
+                rb_ec_error_print(th->ec, errinfo);
+            }
 
-	th->status = THREAD_KILLED;
-	thread_debug("thread end: %p\n", (void *)th);
+            if (th->invoke_type == thread_invoke_type_ractor_proc) {
+                rb_ractor_atexit_exception(th->ec);
+            }
 
-        if (th->vm->ractor.main_thread == th) {
-	    ruby_stop(0);
-	}
-
-        if (RB_TYPE_P(errinfo, T_OBJECT)) {
-	    /* treat with normal error object */
-	    rb_threadptr_raise(ractor_main_th, 1, &errinfo);
-	}
-	EC_POP_TAG();
-
-	rb_ec_clear_current_thread_trace_func(th->ec);
-
-	/* locking_mutex must be Qfalse */
-	if (th->locking_mutex != Qfalse) {
-	    rb_bug("thread_start_func_2: locking_mutex must not be set (%p:%"PRIxVALUE")",
-		   (void *)th, th->locking_mutex);
-	}
-
-        if (ractor_main_th->status == THREAD_KILLED &&
-            th->ractor->threads.cnt <= 2 /* main thread and this thread */) {
-	    /* I'm last thread. wake up main thread from rb_thread_terminate_all */
-            rb_threadptr_interrupt(ractor_main_th);
-	}
-
-        rb_threadptr_join_list_wakeup(th);
-        rb_threadptr_unlock_all_locking_mutexes(th);
-        rb_check_deadlock(th->ractor);
-
-        rb_fiber_close(th->ec->fiber_ptr);
+            if (th->vm->thread_abort_on_exception ||
+                th->abort_on_exception || RTEST(ruby_debug)) {
+                /* exit on main_thread */
+            }
+            else {
+                errinfo = Qnil;
+            }
+        }
+        th->value = Qnil;
     }
+
+    if (th->invoke_type == thread_invoke_type_ractor_proc) {
+        rb_thread_terminate_all(th);
+        rb_ractor_teardown(th->ec);
+    }
+
+    th->status = THREAD_KILLED;
+    thread_debug("thread end: %p\n", (void *)th);
+
+    if (th->vm->ractor.main_thread == th) {
+        ruby_stop(0);
+    }
+
+    if (RB_TYPE_P(errinfo, T_OBJECT)) {
+        /* treat with normal error object */
+        rb_threadptr_raise(ractor_main_th, 1, &errinfo);
+    }
+
+    rb_threadptr_join_list_wakeup(th);
+    rb_threadptr_unlock_all_locking_mutexes(th);
+
+    EC_POP_TAG();
+
+    rb_ec_clear_current_thread_trace_func(th->ec);
+
+    /* locking_mutex must be Qfalse */
+    if (th->locking_mutex != Qfalse) {
+        rb_bug("thread_start_func_2: locking_mutex must not be set (%p:%"PRIxVALUE")",
+               (void *)th, th->locking_mutex);
+    }
+
+    if (ractor_main_th->status == THREAD_KILLED &&
+        th->ractor->threads.cnt <= 2 /* main thread and this thread */) {
+        /* I'm last thread. wake up main thread from rb_thread_terminate_all */
+        rb_threadptr_interrupt(ractor_main_th);
+    }
+
+    rb_check_deadlock(th->ractor);
+
+    rb_fiber_close(th->ec->fiber_ptr);
 
     thread_cleanup_func(th, FALSE);
     VM_ASSERT(th->ec->vm_stack == NULL);

--- a/thread.c
+++ b/thread.c
@@ -631,6 +631,7 @@ thread_cleanup_func_before_exec(void *th_ptr)
 {
     rb_thread_t *th = th_ptr;
     th->status = THREAD_KILLED;
+
     // The thread stack doesn't exist in the forked process:
     th->ec->machine.stack_start = th->ec->machine.stack_end = NULL;
 
@@ -687,7 +688,7 @@ rb_vm_proc_local_ep(VALUE proc)
 VALUE rb_vm_invoke_proc_with_self(rb_execution_context_t *ec, rb_proc_t *proc, VALUE self,
                                   int argc, const VALUE *argv, int kw_splat, VALUE passed_block_handler);
 
-static void
+static VALUE
 thread_do_start_proc(rb_thread_t *th)
 {
     VALUE args = th->invoke_arg.proc.args;
@@ -701,7 +702,6 @@ thread_do_start_proc(rb_thread_t *th)
     th->ec->root_lep = rb_vm_proc_local_ep(procval);
     th->ec->root_svar = Qfalse;
 
-    EXEC_EVENT_HOOK(th->ec, RUBY_EVENT_THREAD_BEGIN, th->self, 0, 0, 0, Qundef);
     vm_check_ints_blocking(th->ec);
 
     if (th->invoke_type == thread_invoke_type_ractor_proc) {
@@ -712,11 +712,12 @@ thread_do_start_proc(rb_thread_t *th)
         rb_ractor_receive_parameters(th->ec, th->ractor, args_len, (VALUE *)args_ptr);
         vm_check_ints_blocking(th->ec);
 
-        // kick thread
-        th->value = rb_vm_invoke_proc_with_self(th->ec, proc, self,
-                                                args_len, args_ptr,
-                                                th->invoke_arg.proc.kw_splat,
-                                                VM_BLOCK_HANDLER_NONE);
+        return rb_vm_invoke_proc_with_self(
+            th->ec, proc, self,
+            args_len, args_ptr,
+            th->invoke_arg.proc.kw_splat,
+            VM_BLOCK_HANDLER_NONE
+        );
     }
     else {
         args_len = RARRAY_LENINT(args);
@@ -732,17 +733,12 @@ thread_do_start_proc(rb_thread_t *th)
 
         vm_check_ints_blocking(th->ec);
 
-        // kick thread
-        th->value = rb_vm_invoke_proc(th->ec, proc,
-                                      args_len, args_ptr,
-                                      th->invoke_arg.proc.kw_splat,
-                                      VM_BLOCK_HANDLER_NONE);
-    }
-
-    EXEC_EVENT_HOOK(th->ec, RUBY_EVENT_THREAD_END, th->self, 0, 0, 0, Qundef);
-
-    if (th->invoke_type == thread_invoke_type_ractor_proc) {
-        rb_ractor_atexit(th->ec, th->value);
+        return rb_vm_invoke_proc(
+            th->ec, proc,
+            args_len, args_ptr,
+            th->invoke_arg.proc.kw_splat,
+            VM_BLOCK_HANDLER_NONE
+        );
     }
 }
 
@@ -750,20 +746,33 @@ static void
 thread_do_start(rb_thread_t *th)
 {
     native_set_thread_name(th);
+    VALUE result = Qundef;
+
+    EXEC_EVENT_HOOK(th->ec, RUBY_EVENT_THREAD_BEGIN, th->self, 0, 0, 0, Qundef);
 
     switch (th->invoke_type) {
       case thread_invoke_type_proc:
+        result = thread_do_start_proc(th);
+        break;
+
       case thread_invoke_type_ractor_proc:
-        thread_do_start_proc(th);
+        result = thread_do_start_proc(th);
+        rb_ractor_atexit(th->ec, result);
         break;
+
       case thread_invoke_type_func:
-        th->value = (*th->invoke_arg.func.func)(th->invoke_arg.func.arg);
+        result = (*th->invoke_arg.func.func)(th->invoke_arg.func.arg);
         break;
+
       case thread_invoke_type_none:
         rb_bug("unreachable");
     }
 
     rb_scheduler_set(Qnil);
+
+    th->value = result;
+
+    EXEC_EVENT_HOOK(th->ec, RUBY_EVENT_THREAD_END, th->self, 0, 0, 0, Qundef);
 }
 
 void rb_ec_clear_current_thread_trace_func(const rb_execution_context_t *ec);
@@ -816,6 +825,9 @@ thread_start_func_2(rb_thread_t *th, VALUE *stack_start)
 
     thread_debug("thread start (get lock): %p\n", (void *)th);
 
+    // Ensure that we are not joinable.
+    VM_ASSERT(th->value == Qundef);
+
     EC_PUSH_TAG(th->ec);
 
     if ((state = EC_EXEC_TAG()) == TAG_NONE) {
@@ -855,6 +867,12 @@ thread_start_func_2(rb_thread_t *th, VALUE *stack_start)
         th->value = Qnil;
     }
 
+    // The thread is effectively finished and can be joined.
+    VM_ASSERT(th->value != Qundef);
+
+    rb_threadptr_join_list_wakeup(th);
+    rb_threadptr_unlock_all_locking_mutexes(th);
+
     if (th->invoke_type == thread_invoke_type_ractor_proc) {
         rb_thread_terminate_all(th);
         rb_ractor_teardown(th->ec);
@@ -871,9 +889,6 @@ thread_start_func_2(rb_thread_t *th, VALUE *stack_start)
         /* treat with normal error object */
         rb_threadptr_raise(ractor_main_th, 1, &errinfo);
     }
-
-    rb_threadptr_join_list_wakeup(th);
-    rb_threadptr_unlock_all_locking_mutexes(th);
 
     EC_POP_TAG();
 
@@ -1151,6 +1166,12 @@ remove_from_join_list(VALUE arg)
 
 static rb_hrtime_t *double2hrtime(rb_hrtime_t *, double);
 
+static int
+thread_finished(rb_thread_t *th)
+{
+    return th->status == THREAD_KILLED || th->value != Qundef;
+}
+
 static VALUE
 thread_join_sleep(VALUE arg)
 {
@@ -1177,7 +1198,7 @@ thread_join_sleep(VALUE arg)
         end = rb_hrtime_add(*limit, rb_hrtime_now());
     }
 
-    while (target_th->status != THREAD_KILLED) {
+    while (!thread_finished(target_th)) {
         VALUE scheduler = rb_scheduler_current();
 
         if (scheduler != Qnil) {
@@ -3318,11 +3339,11 @@ rb_thread_status(VALUE thread)
 static VALUE
 rb_thread_alive_p(VALUE thread)
 {
-    if (rb_threadptr_dead(rb_thread_ptr(thread))) {
-	return Qfalse;
+    if (thread_finished(rb_thread_ptr(thread))) {
+        return Qfalse;
     }
     else {
-	return Qtrue;
+        return Qtrue;
     }
 }
 

--- a/vm.c
+++ b/vm.c
@@ -3083,6 +3083,8 @@ th_init(rb_thread_t *th, VALUE self)
     th->thread_id_string[0] = '\0';
 #endif
 
+    th->value = Qundef;
+
 #if OPT_CALL_THREADED_CODE
     th->retval = Qundef;
 #endif
@@ -3095,16 +3097,17 @@ static VALUE
 ruby_thread_init(VALUE self)
 {
     rb_thread_t *th = GET_THREAD();
-    rb_thread_t *targe_th = rb_thread_ptr(self);
+    rb_thread_t *target_th = rb_thread_ptr(self);
     rb_vm_t *vm = th->vm;
 
-    targe_th->vm = vm;
-    th_init(targe_th, self);
+    target_th->vm = vm;
+    th_init(target_th, self);
 
-    targe_th->top_wrapper = 0;
-    targe_th->top_self = rb_vm_top_self();
-    targe_th->ec->root_svar = Qfalse;
-    targe_th->ractor = th->ractor;
+    target_th->top_wrapper = 0;
+    target_th->top_self = rb_vm_top_self();
+    target_th->ec->root_svar = Qfalse;
+    target_th->ractor = th->ractor;
+
     return self;
 }
 


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/18048

This PR is made from:

```
git cherry-pick 050a89543952a2c9e7c9bc938f4fdb538f6c9278
git cherry-pick 57eaa07ba6c1ee958c16d5c451e2dceb2208edf1
git cherry-pick edbe0e224c2594b7a7b055f0986cbfd690d754d5
git cherry-pick 2d4f29e77e883c29e35417799f8001b8046cde03
```

+ renaming `rb_fiber_scheduler_current` -> `rb_scheduler_current`.