### PR TITLE
Avoid pointless attempts to open .so file if already required

### DIFF
--- a/load.c
+++ b/load.c
@@ -35,6 +35,11 @@ static const char *const loadable_ext[] = {
     0
 };
 
+static const char *const ruby_ext[] = {
+    ".rb",
+    0
+};
+
 enum expand_type {
     EXPAND_ALL,
     EXPAND_RELATIVE,
@@ -963,7 +968,7 @@ search_required(VALUE fname, volatile VALUE *path, feature_func rb_feature_p)
 	return 'r';
     }
     tmp = fname;
-    type = rb_find_file_ext(&tmp, loadable_ext);
+    type = rb_find_file_ext(&tmp, ft == 's' ? ruby_ext : loadable_ext);
     switch (type) {
       case 0:
 	if (ft)


### PR DESCRIPTION
When attempting to require a file without an extension that has
already been required or provided with an .so extension, only
look for files with an .rb extension. There is no point in
trying to find files with an .so extension, since we already
know one has been loaded.

Previously, attempting to require such a file scanned the load
path twice, once for .rb and once for .so.  Now it only scans
once for .rb.  The scan once for .rb cannot be avoided, since
the .rb file would take precedence and should be loaded if it
exists.

Fixes [Bug #10902]