### PR TITLE
Fix documentation of #<=> and #casecmp

### DIFF
--- a/lib/error_highlight/base.rb
+++ b/lib/error_highlight/base.rb
@@ -148,7 +148,7 @@ module ErrorHighlight
       nd_recv, mid, nd_args = @node.children
       lineno = nd_recv.last_lineno
       lines = @fetch[lineno, @node.last_lineno]
-      if mid == :[] && lines.match(/\G\s*(\[(?:\s*\])?)/, nd_recv.last_column)
+      if mid == :[] && lines.match(/\G[\s)]*(\[(?:\s*\])?)/, nd_recv.last_column)
         @beg_column = $~.begin(1)
         @snippet = lines[/.*\n/]
         @beg_lineno = @end_lineno = lineno
@@ -157,11 +157,11 @@ module ErrorHighlight
             @end_column = $~.end(0)
           end
         else
-          if lines.match(/\G\s*?\[\s*\]/, nd_recv.last_column)
+          if lines.match(/\G[\s)]*?\[\s*\]/, nd_recv.last_column)
             @end_column = $~.end(0)
           end
         end
-      elsif lines.match(/\G\s*?(\&?\.)(\s*?)(#{ Regexp.quote(mid) }).*\n/, nd_recv.last_column)
+      elsif lines.match(/\G[\s)]*?(\&?\.)(\s*?)(#{ Regexp.quote(mid) }).*\n/, nd_recv.last_column)
         lines = $` + $&
         @beg_column = $~.begin($2.include?("\n") ? 3 : 1)
         @end_column = $~.end(3)
@@ -207,16 +207,16 @@ module ErrorHighlight
       nd_recv, mid, nd_args = @node.children
       *nd_args, _nd_last_arg, _nil = nd_args.children
       fetch_line(nd_recv.last_lineno)
-      if mid == :[]= && @snippet.match(/\G\s*(\[)/, nd_recv.last_column)
+      if mid == :[]= && @snippet.match(/\G[\s)]*(\[)/, nd_recv.last_column)
         @beg_column = $~.begin(1)
         args_last_column = $~.end(0)
         if nd_args.last && nd_recv.last_lineno == nd_args.last.last_lineno
           args_last_column = nd_args.last.last_column
         end
-        if @snippet.match(/\s*\]\s*=/, args_last_column)
+        if @snippet.match(/[\s)]*\]\s*=/, args_last_column)
           @end_column = $~.end(0)
         end
-      elsif @snippet.match(/\G\s*(\.\s*#{ Regexp.quote(mid.to_s.sub(/=\z/, "")) }\s*=)/, nd_recv.last_column)
+      elsif @snippet.match(/\G[\s)]*(\.\s*#{ Regexp.quote(mid.to_s.sub(/=\z/, "")) }\s*=)/, nd_recv.last_column)
         @beg_column = $~.begin(1)
         @end_column = $~.end(1)
       end
@@ -232,7 +232,7 @@ module ErrorHighlight
     def spot_attrasgn_for_args
       nd_recv, mid, nd_args = @node.children
       fetch_line(nd_recv.last_lineno)
-      if mid == :[]= && @snippet.match(/\G\s*\[/, nd_recv.last_column)
+      if mid == :[]= && @snippet.match(/\G[\s)]*\[/, nd_recv.last_column)
         @beg_column = $~.end(0)
         if nd_recv.last_lineno == nd_args.last_lineno
           @end_column = nd_args.last_column
@@ -254,7 +254,7 @@ module ErrorHighlight
       fetch_line(nd_recv.last_lineno)
       if nd_arg
         # binary operator
-        if @snippet.match(/\G\s*(#{ Regexp.quote(op) })/, nd_recv.last_column)
+        if @snippet.match(/\G[\s)]*(#{ Regexp.quote(op) })/, nd_recv.last_column)
           @beg_column = $~.begin(1)
           @end_column = $~.end(1)
         end
@@ -330,7 +330,7 @@ module ErrorHighlight
     def spot_op_asgn1_for_name
       nd_recv, op, nd_args, _nd_rhs = @node.children
       fetch_line(nd_recv.last_lineno)
-      if @snippet.match(/\G\s*(\[)/, nd_recv.last_column)
+      if @snippet.match(/\G[\s)]*(\[)/, nd_recv.last_column)
         bracket_beg_column = $~.begin(1)
         args_last_column = $~.end(0)
         if nd_args && nd_recv.last_lineno == nd_args.last_lineno
@@ -377,7 +377,7 @@ module ErrorHighlight
     def spot_op_asgn2_for_name
       nd_recv, _qcall, attr, op, _nd_rhs = @node.children
       fetch_line(nd_recv.last_lineno)
-      if @snippet.match(/\G\s*(\.)\s*#{ Regexp.quote(attr) }()\s*(#{ Regexp.quote(op) })(=)/, nd_recv.last_column)
+      if @snippet.match(/\G[\s)]*(\.)\s*#{ Regexp.quote(attr) }()\s*(#{ Regexp.quote(op) })(=)/, nd_recv.last_column)
         case @name
         when attr
           @beg_column = $~.begin(1)

--- a/test/error_highlight/test_error_highlight.rb
+++ b/test/error_highlight/test_error_highlight.rb
@@ -66,6 +66,18 @@ undefined method `foo' for nil:NilClass
     end
   end
 
+  def test_CALL_noarg_4
+    assert_error_message(NoMethodError, <<~END) do
+undefined method `foo' for nil:NilClass
+
+      (nil).foo + 1
+           ^^^^
+    END
+
+      (nil).foo + 1
+    end
+  end
+
   def test_CALL_arg_1
     assert_error_message(NoMethodError, <<~END) do
 undefined method `foo' for nil:NilClass
@@ -222,6 +234,18 @@ undefined method `[]' for #{ v.inspect }
     end
   end
 
+  def test_CALL_aref_5
+    assert_error_message(NoMethodError, <<~END) do
+undefined method `[]' for nil:NilClass
+
+      (nil)[ ]
+           ^^^
+    END
+
+      (nil)[ ]
+    end
+  end
+
   def test_CALL_aset
     assert_error_message(NoMethodError, <<~END) do
 undefined method `[]=' for nil:NilClass
@@ -313,6 +337,30 @@ undefined method `foo=' for nil:NilClass
     end
   end
 
+  def test_ATTRASGN_4
+    assert_error_message(NoMethodError, <<~END) do
+undefined method `[]=' for nil:NilClass
+
+      (nil)[0] = 42
+           ^^^^^
+    END
+
+      (nil)[0] = 42
+    end
+  end
+
+  def test_ATTRASGN_5
+    assert_error_message(NoMethodError, <<~END) do
+undefined method `foo=' for nil:NilClass
+
+      (nil).foo = 42
+           ^^^^^^
+    END
+
+      (nil).foo = 42
+    end
+  end
+
   def test_OPCALL_binary_1
     assert_error_message(NoMethodError, <<~END) do
 undefined method `+' for nil:NilClass
@@ -338,7 +386,19 @@ undefined method `+' for nil:NilClass
     end
   end
 
-  def test_OPCALL_unary
+  def test_OPCALL_binary_3
+    assert_error_message(NoMethodError, <<~END) do
+undefined method `+' for nil:NilClass
+
+      (nil) + 42
+            ^
+    END
+
+      (nil) + 42
+    end
+  end
+
+  def test_OPCALL_unary_1
     assert_error_message(NoMethodError, <<~END) do
 undefined method `+@' for nil:NilClass
 
@@ -347,6 +407,18 @@ undefined method `+@' for nil:NilClass
     END
 
       + nil
+    end
+  end
+
+  def test_OPCALL_unary_2
+    assert_error_message(NoMethodError, <<~END) do
+undefined method `+@' for nil:NilClass
+
+      +(nil)
+      ^
+    END
+
+      +(nil)
     end
   end
 
@@ -429,6 +501,20 @@ undefined method `[]' for nil:NilClass
     end
   end
 
+  def test_OP_ASGN1_aref_4
+    v = nil
+
+    assert_error_message(NoMethodError, <<~END) do
+undefined method `[]' for nil:NilClass
+
+      (v)[0] += 42
+         ^^^
+    END
+
+      (v)[0] += 42
+    end
+  end
+
   def test_OP_ASGN1_op_1
     v = Object.new
     def v.[](x); nil; end
@@ -472,6 +558,21 @@ undefined method `+' for nil:NilClass
         0
       ] +=
         42
+    end
+  end
+
+  def test_OP_ASGN1_op_4
+    v = Object.new
+    def v.[](x); nil; end
+
+    assert_error_message(NoMethodError, <<~END) do
+undefined method `+' for nil:NilClass
+
+      (v)[0] += 42
+             ^
+    END
+
+      (v)[0] += 42
     end
   end
 
@@ -521,6 +622,21 @@ undefined method `[]=' for #{ v.inspect }
     end
   end
 
+  def test_OP_ASGN1_aset_4
+    v = Object.new
+    def v.[](x); 1; end
+
+    assert_error_message(NoMethodError, <<~END) do
+undefined method `[]=' for #{ v.inspect }
+
+      (v)[0] += 42
+         ^^^^^^
+    END
+
+      (v)[0] += 42
+    end
+  end
+
   def test_OP_ASGN2_read_1
     v = nil
 
@@ -547,6 +663,20 @@ undefined method `foo' for nil:NilClass
 
       v.foo += # comment
         42
+    end
+  end
+
+  def test_OP_ASGN2_read_3
+    v = nil
+
+    assert_error_message(NoMethodError, <<~END) do
+undefined method `foo' for nil:NilClass
+
+      (v).foo += 42
+         ^^^^
+    END
+
+      (v).foo += 42
     end
   end
 
@@ -581,6 +711,21 @@ undefined method `+' for nil:NilClass
     end
   end
 
+  def test_OP_ASGN2_op_3
+    v = Object.new
+    def v.foo; nil; end
+
+    assert_error_message(NoMethodError, <<~END) do
+undefined method `+' for nil:NilClass
+
+      (v).foo += 42
+              ^
+    END
+
+      (v).foo += 42
+    end
+  end
+
   def test_OP_ASGN2_write_1
     v = Object.new
     def v.foo; 1; end
@@ -609,6 +754,21 @@ undefined method `foo=' for #{ v.inspect }
 
       v.foo += # comment
         42
+    end
+  end
+
+  def test_OP_ASGN2_write_3
+    v = Object.new
+    def v.foo; 1; end
+
+    assert_error_message(NoMethodError, <<~END) do
+undefined method `foo=' for #{ v.inspect }
+
+      (v).foo += 42
+         ^^^^^^^
+    END
+
+      (v).foo += 42
     end
   end
 


### PR DESCRIPTION
The descriptions for return values of 1 and -1 are reversed.