### PR TITLE
introduce Array#mean

### DIFF
--- a/array.c
+++ b/array.c
@@ -7896,29 +7896,29 @@ rb_ary_sum(int argc, VALUE *argv, VALUE ary)
 
 /*
  * call-seq:
- *   array.average() -> object
- *   array.average() {|element| ... } -> object
+ *   array.mean() -> object
+ *   array.mean() {|element| ... } -> object
  *
  *  When no block is given, returns the object equivalent to:
  *    sum = 0
  *    array.each {|element| sum += element }
  *    sum / size
- *  For example, <tt>[e1, e2, e3].average</tt> returns <tt>(e1 + e2 + e3) / 3</tt>.
+ *  For example, <tt>[e1, e2, e3].mean</tt> returns <tt>(e1 + e2 + e3) / 3</tt>.
  *
  *  Examples:
  *    a = [0, 1, 2, 3]
- *    a.average # => 1.5
+ *    a.mean # => 1.5
  *
  *  When a block is given, it is called with each element
  *  and the block's return value (instead of the element itself) is used as the addend:
  *    a = [-3, -2, -1]
- *    s = a.average { |element| element.abs }
+ *    s = a.mean { |element| element.abs }
  *    s # => 2
  *
  */
 
 static VALUE
-rb_ary_average(int argc, VALUE *argv, VALUE ary)
+rb_ary_mean(int argc, VALUE *argv, VALUE ary)
 {
     long len = RARRAY_LEN(ary);
 
@@ -8500,7 +8500,7 @@ Init_Array(void)
     rb_define_method(rb_cArray, "one?", rb_ary_one_p, -1);
     rb_define_method(rb_cArray, "dig", rb_ary_dig, -1);
     rb_define_method(rb_cArray, "sum", rb_ary_sum, -1);
-    rb_define_method(rb_cArray, "average", rb_ary_average, -1);
+    rb_define_method(rb_cArray, "mean", rb_ary_mean, -1);
 
     rb_define_method(rb_cArray, "deconstruct", rb_ary_deconstruct, 0);
 }

--- a/array.c
+++ b/array.c
@@ -7925,12 +7925,12 @@ rb_ary_mean(int argc, VALUE *argv, VALUE ary)
     if (len == 0)
         return DBL2NUM(nan(""));
 
-    VALUE sum, average;
+    VALUE sum, mean;
 
     sum = rb_ary_sum(argc, 0, ary);
-    average = rb_funcall(sum, '/', 1, DBL2NUM(len));
+    mean = rb_funcall(sum, '/', 1, DBL2NUM(len));
 
-    return average;
+    return mean;
 }
 
 static VALUE

--- a/array.c
+++ b/array.c
@@ -7928,7 +7928,7 @@ rb_ary_mean(int argc, VALUE *argv, VALUE ary)
     VALUE sum, average;
 
     sum = rb_ary_sum(argc, 0, ary);
-    average = rb_funcall(sum, '/', 1, LONG2NUM(len));
+    average = rb_funcall(sum, '/', 1, DBL2NUM(len));
 
     return average;
 }

--- a/array.c
+++ b/array.c
@@ -7923,7 +7923,7 @@ rb_ary_average(int argc, VALUE *argv, VALUE ary)
     long len = RARRAY_LEN(ary);
 
     if (len == 0)
-        return 0;
+        return DBL2NUM(nan(""));
 
     VALUE sum, average;
 

--- a/array.c
+++ b/array.c
@@ -7894,6 +7894,45 @@ rb_ary_sum(int argc, VALUE *argv, VALUE ary)
     return v;
 }
 
+/*
+ * call-seq:
+ *   array.average() -> object
+ *   array.average() {|element| ... } -> object
+ *
+ *  When no block is given, returns the object equivalent to:
+ *    sum = 0
+ *    array.each {|element| sum += element }
+ *    sum / size
+ *  For example, <tt>[e1, e2, e3].average</tt> returns <tt>(e1 + e2 + e3) / 3</tt>.
+ *
+ *  Examples:
+ *    a = [0, 1, 2, 3]
+ *    a.average # => 1.5
+ *
+ *  When a block is given, it is called with each element
+ *  and the block's return value (instead of the element itself) is used as the addend:
+ *    a = [-3, -2, -1]
+ *    s = a.average { |element| element.abs }
+ *    s # => 2
+ *
+ */
+
+static VALUE
+rb_ary_average(int argc, VALUE *argv, VALUE ary)
+{
+    long len = RARRAY_LEN(ary);
+
+    if (len == 0)
+        return 0;
+
+    VALUE sum, average;
+
+    sum = rb_ary_sum(argc, 0, ary);
+    average = rb_funcall(sum, '/', 1, LONG2NUM(len));
+
+    return average;
+}
+
 static VALUE
 rb_ary_deconstruct(VALUE ary)
 {
@@ -8461,6 +8500,7 @@ Init_Array(void)
     rb_define_method(rb_cArray, "one?", rb_ary_one_p, -1);
     rb_define_method(rb_cArray, "dig", rb_ary_dig, -1);
     rb_define_method(rb_cArray, "sum", rb_ary_sum, -1);
+    rb_define_method(rb_cArray, "average", rb_ary_average, -1);
 
     rb_define_method(rb_cArray, "deconstruct", rb_ary_deconstruct, 0);
 }

--- a/test/ruby/test_array.rb
+++ b/test/ruby/test_array.rb
@@ -3377,27 +3377,23 @@ class TestArray < Test::Unit::TestCase
   end
 
   def test_average
-    assert_int_equal(0, [].average)
     assert_int_equal(3, [3].average)
     assert_int_equal(4, [3, 5].average)
     assert_rational_equal(4r, [3, 5r].average)
-    assert_float_equal(7.5, [3, 5, 7.0].average)
+    assert_float_equal(5.0, [3, 5, 7.0].average)
     assert_float_equal(5.0, [3, 5r, 7.0].average)
     assert_complex_equal((8r+1i)/3, [3, 5r, 1i].average)
-    assert_complex_equal((15.0+1i)/3, [3, 5r, 7.0, 1i].average)
+    assert_complex_equal(3.75-1/4i, [3, 5r, 7.0, 1i].average)
 
     assert_int_equal(FIXNUM_MAX, Array.new(2, FIXNUM_MAX).average)
     assert_int_equal((FIXNUM_MAX+1), Array.new(2, FIXNUM_MAX+1).average)
     assert_int_equal(FIXNUM_MAX, Array.new(10, FIXNUM_MAX).average)
 
-    assert_float_equal(0.0, [].average(0.0))
-    assert_float_equal(7.5, [3, 5, 7].average)
+    assert_float_equal(5.3, [3, 5, 7.9].average)
 
     assert_int_equal(2, [1.5, 2.1].average(&:round))
-    assert_int_equal(2, [-1.5, -2.1].average(&:abs))
-
-    assert_equal("abc", ["a", "b", "c"].average(""))
-    assert_equal([1, [2], 3], [[1], [[2]], [3]].average([]))
+    assert_float_equal(1.8, [-1.5, -2.1].average(&:abs))
+    assert_predicate([].average, :nan?)
 
     assert_raise(TypeError) {["ABC"].average}
   end

--- a/test/ruby/test_array.rb
+++ b/test/ruby/test_array.rb
@@ -3377,21 +3377,15 @@ class TestArray < Test::Unit::TestCase
   end
 
   def test_mean
-    assert_int_equal(3, [3].mean)
-    assert_int_equal(4, [3, 5].mean)
-    assert_rational_equal(4r, [3, 5r].mean)
+    assert_float_equal(3.0, [3].mean)
+    assert_float_equal(4.0, [3, 5].mean)
+    assert_float_equal(4.0, [3, 5r].mean)
     assert_float_equal(5.0, [3, 5, 7.0].mean)
     assert_float_equal(5.0, [3, 5r, 7.0].mean)
     assert_complex_equal((8r+1i)/3, [3, 5r, 1i].mean)
     assert_complex_equal(3.75-1/4i, [3, 5r, 7.0, 1i].mean)
 
-    assert_int_equal(FIXNUM_MAX, Array.new(2, FIXNUM_MAX).mean)
-    assert_int_equal((FIXNUM_MAX+1), Array.new(2, FIXNUM_MAX+1).mean)
-    assert_int_equal(FIXNUM_MAX, Array.new(10, FIXNUM_MAX).mean)
-
-    assert_float_equal(5.3, [3, 5, 7.9].mean)
-
-    assert_int_equal(2, [1.5, 2.1].mean(&:round))
+    assert_float_equal(2.0, [1.5, 2.1].mean(&:round))
     assert_float_equal(7.0/3.0, [1.5, 2.2, 3.1].mean(&:round))
     assert_float_equal(1.8, [-1.5, -2.1].mean(&:abs))
     assert_predicate([].mean, :nan?)

--- a/test/ruby/test_array.rb
+++ b/test/ruby/test_array.rb
@@ -3376,6 +3376,32 @@ class TestArray < Test::Unit::TestCase
     assert_raise(TypeError) {[1].sum("")}
   end
 
+  def test_average
+    assert_int_equal(0, [].average)
+    assert_int_equal(3, [3].average)
+    assert_int_equal(4, [3, 5].average)
+    assert_rational_equal(4r, [3, 5r].average)
+    assert_float_equal(7.5, [3, 5, 7.0].average)
+    assert_float_equal(5.0, [3, 5r, 7.0].average)
+    assert_complex_equal((8r+1i)/3, [3, 5r, 1i].average)
+    assert_complex_equal((15.0+1i)/3, [3, 5r, 7.0, 1i].average)
+
+    assert_int_equal(FIXNUM_MAX, Array.new(2, FIXNUM_MAX).average)
+    assert_int_equal((FIXNUM_MAX+1), Array.new(2, FIXNUM_MAX+1).average)
+    assert_int_equal(FIXNUM_MAX, Array.new(10, FIXNUM_MAX).average)
+
+    assert_float_equal(0.0, [].average(0.0))
+    assert_float_equal(7.5, [3, 5, 7].average)
+
+    assert_int_equal(2, [1.5, 2.1].average(&:round))
+    assert_int_equal(2, [-1.5, -2.1].average(&:abs))
+
+    assert_equal("abc", ["a", "b", "c"].average(""))
+    assert_equal([1, [2], 3], [[1], [[2]], [3]].average([]))
+
+    assert_raise(TypeError) {["ABC"].average}
+  end
+
   def test_big_array_literal_with_kwsplat
     lit = "["
     10000.times { lit << "{}," }

--- a/test/ruby/test_array.rb
+++ b/test/ruby/test_array.rb
@@ -3376,26 +3376,26 @@ class TestArray < Test::Unit::TestCase
     assert_raise(TypeError) {[1].sum("")}
   end
 
-  def test_average
-    assert_int_equal(3, [3].average)
-    assert_int_equal(4, [3, 5].average)
-    assert_rational_equal(4r, [3, 5r].average)
-    assert_float_equal(5.0, [3, 5, 7.0].average)
-    assert_float_equal(5.0, [3, 5r, 7.0].average)
-    assert_complex_equal((8r+1i)/3, [3, 5r, 1i].average)
-    assert_complex_equal(3.75-1/4i, [3, 5r, 7.0, 1i].average)
+  def test_mean
+    assert_int_equal(3, [3].mean)
+    assert_int_equal(4, [3, 5].mean)
+    assert_rational_equal(4r, [3, 5r].mean)
+    assert_float_equal(5.0, [3, 5, 7.0].mean)
+    assert_float_equal(5.0, [3, 5r, 7.0].mean)
+    assert_complex_equal((8r+1i)/3, [3, 5r, 1i].mean)
+    assert_complex_equal(3.75-1/4i, [3, 5r, 7.0, 1i].mean)
 
-    assert_int_equal(FIXNUM_MAX, Array.new(2, FIXNUM_MAX).average)
-    assert_int_equal((FIXNUM_MAX+1), Array.new(2, FIXNUM_MAX+1).average)
-    assert_int_equal(FIXNUM_MAX, Array.new(10, FIXNUM_MAX).average)
+    assert_int_equal(FIXNUM_MAX, Array.new(2, FIXNUM_MAX).mean)
+    assert_int_equal((FIXNUM_MAX+1), Array.new(2, FIXNUM_MAX+1).mean)
+    assert_int_equal(FIXNUM_MAX, Array.new(10, FIXNUM_MAX).mean)
 
-    assert_float_equal(5.3, [3, 5, 7.9].average)
+    assert_float_equal(5.3, [3, 5, 7.9].mean)
 
-    assert_int_equal(2, [1.5, 2.1].average(&:round))
-    assert_float_equal(1.8, [-1.5, -2.1].average(&:abs))
-    assert_predicate([].average, :nan?)
+    assert_int_equal(2, [1.5, 2.1].mean(&:round))
+    assert_float_equal(1.8, [-1.5, -2.1].mean(&:abs))
+    assert_predicate([].mean, :nan?)
 
-    assert_raise(TypeError) {["ABC"].average}
+    assert_raise(TypeError) {["ABC"].mean}
   end
 
   def test_big_array_literal_with_kwsplat

--- a/test/ruby/test_array.rb
+++ b/test/ruby/test_array.rb
@@ -3392,6 +3392,7 @@ class TestArray < Test::Unit::TestCase
     assert_float_equal(5.3, [3, 5, 7.9].mean)
 
     assert_int_equal(2, [1.5, 2.1].mean(&:round))
+    assert_float_equal(7.0/3.0, [1.5, 2.2, 3.1].mean(&:round))
     assert_float_equal(1.8, [-1.5, -2.1].mean(&:abs))
     assert_predicate([].mean, :nan?)
 


### PR DESCRIPTION
Introduce `Array#mean` to array.c:

https://bugs.ruby-lang.org/issues/18057

```ruby
array = [1, 2, 3]
array.mean # 2

array = [1.1, 2.2, 3.1]
array.mean(&:round) # 2

array = [-3, -2, -1]
array.average { |e| e.abs } # 2
```