### PR TITLE
Hide read function warning in string_spec_RSTRING_PTR_read function

### DIFF
--- a/spec/ruby/optional/capi/ext/string_spec.c
+++ b/spec/ruby/optional/capi/ext/string_spec.c
@@ -389,7 +389,6 @@ VALUE string_spec_RSTRING_PTR_after_yield(VALUE self, VALUE str) {
 VALUE string_spec_RSTRING_PTR_read(VALUE self, VALUE str, VALUE path) {
   char *cpath = StringValueCStr(path);
   int fd = open(cpath, O_RDONLY);
-  int r;
   VALUE capacities = rb_ary_new();
   if (fd < 0) {
     rb_syserr_fail(errno, "open");
@@ -398,16 +397,14 @@ VALUE string_spec_RSTRING_PTR_read(VALUE self, VALUE str, VALUE path) {
   rb_str_modify_expand(str, 30);
   rb_ary_push(capacities, SIZET2NUM(rb_str_capacity(str)));
   char *buffer = RSTRING_PTR(str);
-  r = read(fd, buffer, 30);
-  if (r < 0) {
+  if (read(fd, buffer, 30) < 0) {
     rb_syserr_fail(errno, "read");
   }
 
   rb_str_modify_expand(str, 53);
   rb_ary_push(capacities, SIZET2NUM(rb_str_capacity(str)));
   char *buffer2 = RSTRING_PTR(str);
-  r = read(fd, buffer2 + 30, 53 - 30);
-  if (r < 0) {
+  if (read(fd, buffer2 + 30, 53 - 30) < 0) {
     rb_syserr_fail(errno, "read");
   }
 

--- a/spec/ruby/optional/capi/ext/string_spec.c
+++ b/spec/ruby/optional/capi/ext/string_spec.c
@@ -389,6 +389,7 @@ VALUE string_spec_RSTRING_PTR_after_yield(VALUE self, VALUE str) {
 VALUE string_spec_RSTRING_PTR_read(VALUE self, VALUE str, VALUE path) {
   char *cpath = StringValueCStr(path);
   int fd = open(cpath, O_RDONLY);
+  int r;
   VALUE capacities = rb_ary_new();
   if (fd < 0) {
     rb_syserr_fail(errno, "open");
@@ -397,12 +398,18 @@ VALUE string_spec_RSTRING_PTR_read(VALUE self, VALUE str, VALUE path) {
   rb_str_modify_expand(str, 30);
   rb_ary_push(capacities, SIZET2NUM(rb_str_capacity(str)));
   char *buffer = RSTRING_PTR(str);
-  read(fd, buffer, 30);
+  r = read(fd, buffer, 30);
+  if (r < 0) {
+    rb_syserr_fail(errno, "read");
+  }
 
   rb_str_modify_expand(str, 53);
   rb_ary_push(capacities, SIZET2NUM(rb_str_capacity(str)));
   char *buffer2 = RSTRING_PTR(str);
-  read(fd, buffer2 + 30, 53 - 30);
+  r = read(fd, buffer2 + 30, 53 - 30);
+  if (r < 0) {
+    rb_syserr_fail(errno, "read");
+  }
 
   rb_str_set_len(str, 53);
   close(fd);


### PR DESCRIPTION
Run `make test-spec` shown these warning.

```bash
string_spec.c: In function ‘string_spec_RSTRING_PTR_read’:
string_spec.c:400:3: warning: ignoring return value of ‘read’, declared with attribute warn_unused_result [-Wunused-result]
  400 |   read(fd, buffer, 30);
      |   ^~~~~~~~~~~~~~~~~~~~
string_spec.c:405:3: warning: ignoring return value of ‘read’, declared with attribute warn_unused_result [-Wunused-result]
  405 |   read(fd, buffer2 + 30, 53 - 30);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This pull request fix it with using return value.


Env: Windows 10 With WSL(Ubuntu 20.04)

```
gcc (Ubuntu 9.3.0-10ubuntu2) 9.3.0
Copyright (C) 2019 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```
