### PR TITLE
Reenable GC at the end of test

### DIFF
--- a/test/ruby/test_objectspace.rb
+++ b/test/ruby/test_objectspace.rb
@@ -191,6 +191,8 @@ End
       assert(false)
     rescue my_error
     end
+  ensure
+    GC.enable
   end
 
   def test_each_object


### PR DESCRIPTION
The test disables GC but never reenables it. Before this patch, running all tests would have a peak RSS in the main process of >4GB. After this patch, peak RSS in the main process is <500MB.