### PR TITLE
backport for ruby_2_7: 3796: Do not allow Module#include to insert modules before the origin in the lookup chain

### DIFF
--- a/class.c
+++ b/class.c
@@ -911,17 +911,22 @@ include_modules_at(const VALUE klass, VALUE c, VALUE module, int search_super)
     }
 
     while (module) {
+        int origin_seen = FALSE;
 	int superclass_seen = FALSE;
 	struct rb_id_table *tbl;
 
+        if (klass == c)
+            origin_seen = TRUE;
 	if (klass_m_tbl && klass_m_tbl == RCLASS_M_TBL(module))
 	    return -1;
 	/* ignore if the module included already in superclasses */
 	for (p = RCLASS_SUPER(klass); p; p = RCLASS_SUPER(p)) {
 	    int type = BUILTIN_TYPE(p);
+            if (c == p)
+                origin_seen = TRUE;
 	    if (type == T_ICLASS) {
 		if (RCLASS_M_TBL(p) == RCLASS_M_TBL(module)) {
-		    if (!superclass_seen) {
+		    if (!superclass_seen && origin_seen) {
 			c = p;  /* move insertion point */
 		    }
 		    goto skip;

--- a/test/ruby/test_module.rb
+++ b/test/ruby/test_module.rb
@@ -472,6 +472,16 @@ class TestModule < Test::Unit::TestCase
     assert_equal([Comparable, Kernel], String.included_modules - mixins)
   end
 
+  def test_include_with_prepend
+    c = Class.new{def m; [:c] end}
+    p = Module.new{def m; [:p] + super end}
+    q = Module.new{def m; [:q] + super end; include p}
+    r = Module.new{def m; [:r] + super end; prepend q}
+    s = Module.new{def m; [:s] + super end; include r}
+    a = Class.new(c){def m; [:a] + super end; prepend p; include s}
+    assert_equal([:p, :a, :s, :q, :r, :c], a.new.m)
+  end
+
   def test_instance_methods
     assert_equal([:user, :user2], User.instance_methods(false).sort)
     assert_equal([:user, :user2, :mixin].sort, User.instance_methods(true).sort)


### PR DESCRIPTION
Backport of https://github.com/ruby/ruby/pull/3796 to 2.7
Upgrading Ruby from 2.7 to 3.0 is too much work just for this bug fix
Especially when many existing gems don't work properly in 3.x

This backport is required to address [an issue about usage of a gem](https://github.com/panorama-ed/memo_wise/issues/135) which works in both 2.7 & 3.0