### PR TITLE
Remove unneeded rb_fiber_transfer_kw declaration

### DIFF
--- a/cont.c
+++ b/cont.c
@@ -2498,8 +2498,6 @@ rb_fiber_m_resume(int argc, VALUE *argv, VALUE fiber)
     return rb_fiber_resume_kw(fiber, argc, argv, rb_keyword_given_p());
 }
 
-VALUE rb_fiber_transfer_kw(VALUE fiber_value, int argc, const VALUE *argv, int kw_splat);
-
 /*
  *  call-seq:
  *     fiber.raise                                 -> obj


### PR DESCRIPTION
Remove unneeded `rb_fiber_transfer_kw` declaration(`rb_fiber_transfer_kw` already declated in `internal/intern/cont.h` with `ruby/ruby.h`)