### PR TITLE
Remove autoload for constant if the autoload fails

### DIFF
--- a/variable.c
+++ b/variable.c
@@ -2242,23 +2242,26 @@ autoload_delete(VALUE mod, ID id)
 	struct autoload_const *ac;
 
 	st_delete(tbl, &n, &load);
-	ele = get_autoload_data((VALUE)load, &ac);
-	VM_ASSERT(ele);
-	if (ele) {
-	    VM_ASSERT(!list_empty(&ele->constants));
-	}
+        /* Qfalse can indicate already deleted */
+        if (load != Qfalse) {
+            ele = get_autoload_data((VALUE)load, &ac);
+            VM_ASSERT(ele);
+            if (ele) {
+                VM_ASSERT(!list_empty(&ele->constants));
+            }
 
-	/*
-	 * we must delete here to avoid "already initialized" warnings
-	 * with parallel autoload.  Using list_del_init here so list_del
-	 * works in autoload_c_free
-	 */
-	list_del_init(&ac->cnode);
+            /*
+             * we must delete here to avoid "already initialized" warnings
+             * with parallel autoload.  Using list_del_init here so list_del
+             * works in autoload_c_free
+             */
+            list_del_init(&ac->cnode);
 
-	if (tbl->num_entries == 0) {
-	    n = autoload;
-	    st_delete(RCLASS_IV_TBL(mod), &n, &val);
-	}
+            if (tbl->num_entries == 0) {
+                n = autoload;
+                st_delete(RCLASS_IV_TBL(mod), &n, &val);
+            }
+        }
     }
 }
 
@@ -2509,6 +2512,8 @@ rb_autoload_load(VALUE mod, ID id)
 
     if (flag > 0 && (ce = rb_const_lookup(mod, id))) {
         ce->flag |= flag;
+    } else {
+        autoload_delete(mod, id);
     }
     RB_GC_GUARD(load);
     return result;


### PR DESCRIPTION
Previously, if an autoload failed (the file was loaded, but the
constant was not defined by the autoloaded file). Ruby will try
to autoload again if you delete the autoloaded file from
$LOADED_FEATURES.  With this change, the autoload is removed as
soon as it fails.

To handle cases where multiple threads are autoloading, when
deleting an autoload, handle the case where another thread
already deleted it.

Fixes [Bug #15790]