### PR TITLE
Reduce chance to receive EBADF when closing an IO from another thread.

### DIFF
--- a/io.c
+++ b/io.c
@@ -1422,6 +1422,13 @@ rb_thread_fd_writable(int fd)
 
 VALUE rb_io_maybe_wait(int error, VALUE io, VALUE events, VALUE timeout)
 {
+    // fptr->fd can be set to -1 at any time by another thread when the GVL is
+    // released. Many code, e.g. `io_bufread` didn't check this correctly and
+    // instead relies on `read(-1) -> -1` which causes this code path. We then
+    // check here whether the IO was in fact closed. Probably it's better to
+    // check that `fptr->fd != -1` before using it in syscall.
+    rb_io_check_closed(RFILE(io)->fptr);
+
     switch (error) {
       // In old Linux, several special files under /proc and /sys don't handle
       // select properly. Thus we need avoid to call if don't use O_NONBLOCK.
@@ -2646,31 +2653,32 @@ io_bufread(char *ptr, long len, rb_io_t *fptr)
     long c;
 
     if (READ_DATA_PENDING(fptr) == 0) {
-	while (n > 0) {
+        while (n > 0) {
           again:
-	    c = rb_read_internal(fptr->fd, ptr+offset, n);
-	    if (c == 0) break;
-	    if (c < 0) {
+            rb_io_check_closed(fptr);
+            c = rb_read_internal(fptr->fd, ptr+offset, n);
+            if (c == 0) break;
+            if (c < 0) {
                 if (fptr_wait_readable(fptr))
                     goto again;
-		return -1;
-	    }
-	    offset += c;
-	    if ((n -= c) <= 0) break;
-	}
-	return len - n;
+                return -1;
+            }
+            offset += c;
+            if ((n -= c) <= 0) break;
+        }
+        return len - n;
     }
 
     while (n > 0) {
-	c = read_buffered_data(ptr+offset, n, fptr);
-	if (c > 0) {
-	    offset += c;
-	    if ((n -= c) <= 0) break;
-	}
-	rb_io_check_closed(fptr);
-	if (io_fillbuf(fptr) < 0) {
-	    break;
-	}
+        c = read_buffered_data(ptr+offset, n, fptr);
+        if (c > 0) {
+            offset += c;
+            if ((n -= c) <= 0) break;
+        }
+        rb_io_check_closed(fptr);
+        if (io_fillbuf(fptr) < 0) {
+            break;
+        }
     }
     return len - n;
 }


### PR DESCRIPTION
I guess we have some bugs in `io.c`.

```
c = rb_read_internal(fd=9, ...);
c = rb_read_internal(fd=-1, ...); = 11
```
This is my log output. It comes from here:

```
static long
io_bufread(char *ptr, long len, rb_io_t *fptr)
{
    long offset = 0;
    long n = len;
    long c;

    if (READ_DATA_PENDING(fptr) == 0) {
        while (n > 0) {
          again:
            fprintf(stderr, "c = rb_read_internal(fd=%d, ...);\n", fptr->fd);
            c = rb_read_internal(fptr->fd, ptr+offset, n);
            fprintf(stderr, "c = rb_read_internal(fd=%d, ...); = %d\n", fptr->fd, c);
```

So, after `rb_read_internal` is done, `fptr->fd is -1`. It seems race condition on `fptr->fd`.

`rb_read_internal` can release GVL, and another thread can call `#close`, which cause `fd = -1`.

Sometimes Ruby can call `read(-1)` which returns `c = -1` - even 2.x branch probably.

Here is my test case:

``` ruby
puts RUBY_VERSION

100_000.times do
  $stdout.write "."

  i, o = IO.pipe
  
  t1 = Thread.new do
    i.read
  rescue IOError
    # ignore
  end

  t2 = Thread.new do
    i.close
  end

  t3 = Thread.new do
    o.write("Hello World")
    o.close
  rescue Errno::EPIPE
    # ignore
  end

  t1.join
  t2.join
  t3.join
end
```

There seem to be lots of cases where we use `fptr->fd` without any check. But we are just concerned with `#read` in the above test.

The PR does two things:

- Restore `rb_io_check_closed` to `fptr_wait_readable` and friends which ensures consistent behaviour with previous releases.
- Add a check before calling `read(fd)` to ensure that `fd != -1`. I believe maybe we need to do this in more places.
