### PR TITLE
Silence LoadError only if it is for `rubygems` itself

### DIFF
--- a/gem_prelude.rb
+++ b/gem_prelude.rb
@@ -1,6 +1,8 @@
 begin
   require 'rubygems'
-rescue LoadError
+rescue LoadError => e
+  raise unless e.path == 'rubygems'
+
   warn "`RubyGems' were not loaded."
 end if defined?(Gem)
 


### PR DESCRIPTION
## Background

https://github.com/ruby/ruby/pull/2764 attempted to prevent raising `LoadError` when requiring `rubygems` because it might not be available optionally when Ruby is delivered via packaging systems and instead prints a warning message.

## Context

I was working on a feature in RubyGems to better communicate to users that something went wrong when loading `rubygems/defaults/operating_system` and after writing a test, I saw that any `LoadError` exception raised by the `rubygems` will be captured and a warning will be printed instead (https://github.com/rubygems/rubygems/pull/4824). Although https://github.com/ruby/ruby/pull/2764 intention was to prevent failure when 'rubygems' are not available, it's capturing every `LoadError` that might happen inside the `rubygems` at runtime.


## Change

Prevent raising the `LoadError` exception only if it's related directly to loading `rubygems`.