### PR TITLE
Remove unneeded rb_func_proc_new declaration

### DIFF
--- a/internal/proc.h
+++ b/internal/proc.h
@@ -24,7 +24,6 @@ VALUE rb_block_to_s(VALUE self, const struct rb_block *block, const char *additi
 VALUE rb_callable_receiver(VALUE);
 
 MJIT_SYMBOL_EXPORT_BEGIN
-VALUE rb_func_proc_new(rb_block_call_func_t func, VALUE val);
 VALUE rb_func_lambda_new(rb_block_call_func_t func, VALUE val, int min_argc, int max_argc);
 VALUE rb_iseq_location(const struct rb_iseq_struct *iseq);
 VALUE rb_sym_to_proc(VALUE sym);


### PR DESCRIPTION
Remove unneeded `rb_func_proc_new` declaration(`rb_func_proc_new` is semms to not used in internal)

In tha past `rb_hash_to_proc` function used `rb_func_proc_new`, but now not uesed.

ref: https://github.com/ruby/ruby/commit/241244739f2b721ac7aa0961bd90d904c5e3fff6