### PR TITLE
.travis.yml: Check failures for Travis arm64 again.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -123,10 +123,10 @@ matrix:
     - <<: *ppc64le-linux
     - <<: *s390x-linux
   allow_failures:
-    # An arm64 job sometimes does not start right now.
-    # https://travis-ci.community/t/11629
+    # The "TestReadline#test_interrupt_in_other_thread" started failing on arm32
+    # from https://www.travis-ci.com/github/ruby/ruby/jobs/529005145
     - name: arm32-linux
-    - name: arm64-linux
+    # - name: arm64-linux
     # - name: ppc64le-linux
     # - name: s390x-linux
   fast_finish: true


### PR DESCRIPTION
It seems the concurrent jobs are stable recently on arm64 pipeline.

On arm32 case, the TestReadline#test_interrupt_in_other_thread started to fails from the Travis build `#44531`.
https://www.travis-ci.com/github/ruby/ruby/jobs/529005145
https://www.travis-ci.com/github/ruby/ruby/builds/234464378

The commit is https://github.com/ruby/ruby/commit/6e55facdb38c070754ef4dc5921e9ad63d1a97e1 .

As a reference, here is the Travis build `#44530`.
https://www.travis-ci.com/github/ruby/ruby/builds/234455397
