### PR TITLE
Don't disable did_you_mean or error_highlight when disabling gems

### DIFF
--- a/ruby.c
+++ b/ruby.c
@@ -322,8 +322,8 @@ usage(const char *name, int help, int highlight, int columns)
     };
     static const struct message features[] = {
 	M("gems",    "",        "rubygems (only for debugging, default: "DEFAULT_RUBYGEMS_ENABLED")"),
-	M("error_highlight", "", "error_highlight (default: "DEFAULT_RUBYGEMS_ENABLED")"),
-	M("did_you_mean", "",   "did_you_mean (default: "DEFAULT_RUBYGEMS_ENABLED")"),
+        M("error_highlight", "", "error_highlight (default: enabled)"),
+        M("did_you_mean", "",   "did_you_mean (default: enabled)"),
 	M("rubyopt", "",        "RUBYOPT environment variable (default: enabled)"),
 	M("frozen-string-literal", "", "freeze all string literals (default: disabled)"),
         M("jit", "",            "JIT compiler (default: disabled)"),
@@ -1513,12 +1513,12 @@ ruby_opt_init(ruby_cmdline_options_t *opt)
 
     if (opt->features.set & FEATURE_BIT(gems)) {
         rb_define_module("Gem");
-        if (opt->features.set & FEATURE_BIT(error_highlight)) {
-            rb_define_module("ErrorHighlight");
-        }
-        if (opt->features.set & FEATURE_BIT(did_you_mean)) {
-            rb_define_module("DidYouMean");
-        }
+    }
+    if (opt->features.set & FEATURE_BIT(error_highlight)) {
+        rb_define_module("ErrorHighlight");
+    }
+    if (opt->features.set & FEATURE_BIT(did_you_mean)) {
+        rb_define_module("DidYouMean");
     }
 
     rb_warning_category_update(opt->warn.mask, opt->warn.set);

--- a/spec/bundler/bundler/fetcher/downloader_spec.rb
+++ b/spec/bundler/bundler/fetcher/downloader_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe Bundler::Fetcher::Downloader do
         let(:message) { "undefined method 'undefined_method_call'" }
 
         it "should raise the original NoMethodError" do
-          expect { subject.request(uri, options) }.to raise_error(NoMethodError, "undefined method 'undefined_method_call'")
+          expect { subject.request(uri, options) }.to raise_error(NoMethodError, /undefined method 'undefined_method_call'/)
         end
       end
     end

--- a/test/did_you_mean/test_rubyopt.rb
+++ b/test/did_you_mean/test_rubyopt.rb
@@ -1,0 +1,13 @@
+require_relative './helper'
+
+class DidYouMeanRubyOptTest < Test::Unit::TestCase
+  def test_disable_did_you_mean_opt
+    assert_in_out_err(%w(--disable-did-you-mean), "p '1'.suc", [], (<<-OUTPUT).split(/\r?\n/))
+-:1:in `<main>': undefined method `suc' for "1":String (NoMethodError)
+    OUTPUT
+  end
+
+  def test_disable_gems_opt
+    assert_in_out_err(%w(--disable-gems), "p '1'.suc", [], /Did you mean\?/)
+  end
+end

--- a/test/did_you_mean/test_verbose_formatter.rb
+++ b/test/did_you_mean/test_verbose_formatter.rb
@@ -17,6 +17,9 @@ class VerboseFormatterTest < Test::Unit::TestCase
     assert_match <<~MESSAGE.strip, @error.message
       undefined method `zeor?' for 1:Integer
 
+          @error = assert_raise(NoMethodError){ 1.zeor? }
+                                                 ^^^^^^
+
           Did you mean? zero?
     MESSAGE
   end

--- a/test/error_highlight/test_error_highlight.rb
+++ b/test/error_highlight/test_error_highlight.rb
@@ -1194,4 +1194,19 @@ undefined method `time' for 1:Integer
       end
     end
   end
+
+  def test_disable_error_highlight_opt
+    assert_in_out_err(%w(--disable-error-highlight -e 1+a), "", [], (<<-OUTPUT).split(/\r?\n/))
+-e:1:in `<main>': undefined local variable or method `a' for main:Object (NameError)
+    OUTPUT
+  end
+
+  def test_disable_gems_opt
+    assert_in_out_err(%w(--disable-gems -e 1+a), "", [], (<<-OUTPUT).split(/\r?\n/))
+-e:1:in `<main>': undefined local variable or method `a' for main:Object (NameError)
+
+1+a
+  ^
+    OUTPUT
+  end
 end

--- a/test/lib/jit_support.rb
+++ b/test/lib/jit_support.rb
@@ -36,7 +36,8 @@ module JITSupport
 
   def eval_with_jit_without_retry(env = nil, script, verbose: 0, min_calls: 5, save_temps: false, max_cache: 1000, wait: true, timeout: JIT_TIMEOUT)
     args = [
-      '--disable-gems', "--jit-verbose=#{verbose}",
+      '--disable-gems', '--disable-error-highlight', '--disable-did-you-mean',
+      "--jit-verbose=#{verbose}",
       "--jit-min-calls=#{min_calls}", "--jit-max-cache=#{max_cache}",
     ]
     args << '--jit-wait' if wait

--- a/test/ruby/test_module.rb
+++ b/test/ruby/test_module.rb
@@ -3100,7 +3100,7 @@ class TestModule < Test::Unit::TestCase
       methods = singleton_class.private_instance_methods(false)
       assert_include(methods, :#{method}, ":#{method} should be private")
 
-      assert_raise_with_message(NoMethodError, "private method `#{method}' called for main:Object") {
+      assert_raise_with_message(NoMethodError, /private method `#{method}' called for main:Object/) {
         recv = self
         recv.#{method}
       }

--- a/test/ruby/test_rubyoptions.rb
+++ b/test/ruby/test_rubyoptions.rb
@@ -182,7 +182,9 @@ class TestRubyOptions < Test::Unit::TestCase
     assert_in_out_err(%w(--disable), "", [], /missing argument for --disable/)
     assert_in_out_err(%w(--disable-gems -e) + ['p defined? Gem'], "", ["nil"], [])
     assert_in_out_err(%w(--disable-did_you_mean -e) + ['p defined? DidYouMean'], "", ["nil"], [])
-    assert_in_out_err(%w(--disable-gems -e) + ['p defined? DidYouMean'], "", ["nil"], [])
+    assert_in_out_err(%w(--disable-gems -e) + ['p defined? DidYouMean'], "", ['"constant"'], [])
+    assert_in_out_err(%w(--disable-error_highlight -e) + ['p defined? ErrorHighlight'], "", ["nil"], [])
+    assert_in_out_err(%w(--disable-gems -e) + ['p defined? ErrorHighlight'], "", ['"constant"'], [])
   end
 
   def test_kanji
@@ -463,10 +465,10 @@ class TestRubyOptions < Test::Unit::TestCase
                       "#!ruby -s\np [$abc, $def, $ghi_jkl, defined?($xyz)]\n",
                       ['[true, "foo", true, nil]'], [])
 
-    assert_in_out_err(%w(- -#), "#!ruby -s\n", [],
+    assert_in_out_err(%w(-s - -#), "#!ruby --disable-did_you_mean\n", [],
                       /invalid name for global variable - -# \(NameError\)/)
 
-    assert_in_out_err(%w(- -#=foo), "#!ruby -s\n", [],
+    assert_in_out_err(%w(-s - -#=foo), "#!ruby --disable-did_you_mean\n", [],
                       /invalid name for global variable - -# \(NameError\)/)
   end
 


### PR DESCRIPTION
These are default gems, not bundled gems, so they do not need
rubygems to function.

Fixes [Bug #18066]