### PR TITLE
Avoid unnecessary conditional

### DIFF
--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -630,7 +630,8 @@ rb_ec_partial_backtrace_object(const rb_execution_context_t *ec, long start_fram
                 }
             }
         }
-        else if (RUBYVM_CFUNC_FRAME_P(cfp)) {
+        else {
+            VM_ASSERT(RUBYVM_CFUNC_FRAME_P(cfp));
             if (start_frame > 0) {
                 start_frame--;
             }
@@ -846,7 +847,8 @@ backtrace_each(const rb_execution_context_t *ec,
                 iter_iseq(arg, cfp);
             }
         }
-        else if (RUBYVM_CFUNC_FRAME_P(cfp)) {
+        else {
+            VM_ASSERT(RUBYVM_CFUNC_FRAME_P(cfp));
             const rb_callable_method_entry_t *me = rb_vm_frame_method_entry(cfp);
             ID mid = me->def->original_id;
 


### PR DESCRIPTION
All frames should be either iseq frames or cfunc frames.  Use a
VM assert instead of a conditional to check for a cfunc frame if
the current frame is not an iseq frame.