### PR TITLE
Move rb_str_end_with_asciichar function declaration

### DIFF
--- a/error.c
+++ b/error.c
@@ -63,7 +63,6 @@
 
 VALUE rb_iseqw_local_variables(VALUE iseqval);
 VALUE rb_iseqw_new(const rb_iseq_t *);
-int rb_str_end_with_asciichar(VALUE str, int c);
 
 long rb_backtrace_length_limit = -1;
 VALUE rb_eEAGAIN;

--- a/internal/io.h
+++ b/internal/io.h
@@ -23,6 +23,7 @@ void rb_io_fptr_finalize_internal(void *ptr);
 #endif
 #define rb_io_fptr_finalize rb_io_fptr_finalize_internal
 VALUE rb_io_popen(VALUE pname, VALUE pmode, VALUE env, VALUE opt);
+int rb_str_end_with_asciichar(VALUE str, int c);
 
 VALUE rb_io_prep_stdin(void);
 VALUE rb_io_prep_stdout(void);


### PR DESCRIPTION
Move `rb_str_end_with_asciichar` function declaration in `internal/io.h`(`rb_str_end_with_asciichar` only used in `io.c` and `error.c`)