### PR TITLE
Handle old C-extenion gems that still expect ruby.h in top source directory

### DIFF
--- a/lib/mkmf.rb
+++ b/lib/mkmf.rb
@@ -2144,6 +2144,7 @@ RULES
       line.gsub!(/\.o\b/, ".#{$OBJEXT}")
       line.gsub!(/\{\$\(VPATH\)\}/, "") unless $nmake
       line.gsub!(/\$\((?:hdr|top)dir\)\/config.h/, $config_h)
+      line.gsub!(%r"\$\(hdrdir\)/(?!ruby(?![^:;/\s]))(?=[-\w]+\.h)", '\&ruby/')
       if $nmake && /\A\s*\$\(RM|COPY\)/ =~ line
         line.gsub!(%r"[-\w\./]{2,}"){$&.tr("/", "\\")}
         line.gsub!(/(\$\((?!RM|COPY)[^:)]+)(?=\))/, '\1:/=\\')


### PR DESCRIPTION
This line was removed in 3d1c86a26f0c96a9c1d0247b968aa96e6f3c30bb,
but at least the tmail gem (last updated in 2010) still relies on
this behavior.

Fixes [Bug #16490]