### PR TITLE
Fix Marshal.dump(closed_io) to raise TypeError

### DIFF
--- a/encoding.c
+++ b/encoding.c
@@ -923,13 +923,16 @@ rb_enc_find(const char *name)
 static inline int
 enc_capable(VALUE obj)
 {
+    VALUE closed;
     if (SPECIAL_CONST_P(obj)) return SYMBOL_P(obj);
     switch (BUILTIN_TYPE(obj)) {
       case T_STRING:
       case T_REGEXP:
-      case T_FILE:
       case T_SYMBOL:
 	return TRUE;
+      case T_FILE:
+        closed = rb_check_funcall(obj, rb_intern("closed?"), 0, 0);
+        return closed ? FALSE : TRUE;
       case T_DATA:
 	if (is_data_encoding(obj)) return TRUE;
       default:

--- a/test/ruby/test_io.rb
+++ b/test/ruby/test_io.rb
@@ -3991,6 +3991,17 @@ __END__
     }
   end
 
+  def test_external_encoding_index_on_closed
+    r, w = IO.pipe
+    r.close; w.close
+    assert_raise(TypeError) {Marshal.dump(r)}
+
+    class << r
+      undef_method :closed?
+    end
+    assert_raise(TypeError) {Marshal.dump(r)}
+  end
+
   def test_stdout_to_closed_pipe
     EnvUtil.invoke_ruby(["-e", "loop {puts :ok}"], "", true, true) do
       |in_p, out_p, err_p, pid|


### PR DESCRIPTION
Mashalling a closed IO object raised `closed stream (IOError)` before.

Fixes bug [bug #18077](https://bugs.ruby-lang.org/issues/18077)

Is this something for ruby-spec?
