### PR TITLE
rb_fix2uint should use FIXNUM_NEGATIVE_P

### DIFF
--- a/numeric.c
+++ b/numeric.c
@@ -2924,7 +2924,7 @@ rb_fix2uint(VALUE val)
     }
     num = FIX2ULONG(val);
 
-    check_uint(num, rb_num_negative_int_p(val));
+    check_uint(num, FIXNUM_NEGATIVE_P(val));
     return num;
 }
 #else
@@ -3022,7 +3022,7 @@ rb_fix2ushort(VALUE val)
     }
     num = FIX2ULONG(val);
 
-    check_ushort(num, rb_num_negative_int_p(val));
+    check_ushort(num, FIXNUM_NEGATIVE_P(val));
     return num;
 }
 


### PR DESCRIPTION
`rb_num_negative_int_p` is equivalent to calling the `<` method on `Integer` (and checking whether it is overridden), where in this case we are interested in whether the "actual" value can fit inside an `unsigned int`.

This also was slow because `rb_num_negative_int_p` calls `rb_method_basic_definition_p`, doing a method lookup to check for `<` being overridden.

This replaces the check with FIXNUM_NEGATIVE_P which simply checks whether the VALUE is signed.
