### PR TITLE
Move f_boolcast definination

### DIFF
--- a/complex.c
+++ b/complex.c
@@ -54,8 +54,6 @@ static ID id_abs, id_arg,
 #define id_quo idQuo
 #define id_fdiv idFdiv
 
-#define f_boolcast(x) ((x) ? Qtrue : Qfalse)
-
 #define fun1(n) \
 inline static VALUE \
 f_##n(VALUE x)\

--- a/complex.c
+++ b/complex.c
@@ -1090,15 +1090,15 @@ nucomp_eqeq_p(VALUE self, VALUE other)
     if (RB_TYPE_P(other, T_COMPLEX)) {
 	get_dat2(self, other);
 
-	return f_boolcast(f_eqeq_p(adat->real, bdat->real) &&
+	return RBOOL(f_eqeq_p(adat->real, bdat->real) &&
 			  f_eqeq_p(adat->imag, bdat->imag));
     }
     if (k_numeric_p(other) && f_real_p(other)) {
 	get_dat1(self);
 
-	return f_boolcast(f_eqeq_p(dat->real, other) && f_zero_p(dat->imag));
+	return RBOOL(f_eqeq_p(dat->real, other) && f_zero_p(dat->imag));
     }
-    return f_boolcast(f_eqeq_p(other, self));
+    return RBOOL(f_eqeq_p(other, self));
 }
 
 static bool
@@ -1352,7 +1352,7 @@ nucomp_eql_p(VALUE self, VALUE other)
     if (RB_TYPE_P(other, T_COMPLEX)) {
 	get_dat2(self, other);
 
-	return f_boolcast((CLASS_OF(adat->real) == CLASS_OF(bdat->real)) &&
+	return RBOOL((CLASS_OF(adat->real) == CLASS_OF(bdat->real)) &&
 			  (CLASS_OF(adat->imag) == CLASS_OF(bdat->imag)) &&
 			  f_eqeq_p(self, other));
 

--- a/internal.h
+++ b/internal.h
@@ -106,4 +106,6 @@ RUBY_SYMBOL_EXPORT_END
 
 #define RBOOL(v) ((v) ? Qtrue : Qfalse)
 
+#define f_boolcast(x) ((x) ? Qtrue : Qfalse)
+
 #endif /* RUBY_INTERNAL_H */

--- a/internal.h
+++ b/internal.h
@@ -106,6 +106,4 @@ RUBY_SYMBOL_EXPORT_END
 
 #define RBOOL(v) ((v) ? Qtrue : Qfalse)
 
-#define f_boolcast(x) ((x) ? Qtrue : Qfalse)
-
 #endif /* RUBY_INTERNAL_H */

--- a/math.c
+++ b/math.c
@@ -620,7 +620,6 @@ math_sqrt(VALUE unused_obj, VALUE x)
     return rb_math_sqrt(x);
 }
 
-#define f_boolcast(x) ((x) ? Qtrue : Qfalse)
 inline static VALUE
 f_negative_p(VALUE x)
 {

--- a/math.c
+++ b/math.c
@@ -624,7 +624,7 @@ inline static VALUE
 f_negative_p(VALUE x)
 {
     if (FIXNUM_P(x))
-        return f_boolcast(FIX2LONG(x) < 0);
+        return RBOOL(FIX2LONG(x) < 0);
     return rb_funcall(x, '<', 1, INT2FIX(0));
 }
 inline static VALUE
@@ -632,7 +632,7 @@ f_signbit(VALUE x)
 {
     if (RB_TYPE_P(x, T_FLOAT)) {
         double f = RFLOAT_VALUE(x);
-        return f_boolcast(!isnan(f) && signbit(f));
+        return RBOOL(!isnan(f) && signbit(f));
     }
     return f_negative_p(x);
 }

--- a/rational.c
+++ b/rational.c
@@ -46,7 +46,6 @@ static ID id_abs, id_integer_p,
 #define id_idiv idDiv
 #define id_to_i idTo_i
 
-#define f_boolcast(x) ((x) ? Qtrue : Qfalse)
 #define f_inspect rb_inspect
 #define f_to_s rb_obj_as_string
 

--- a/rational.c
+++ b/rational.c
@@ -1135,12 +1135,12 @@ nurat_eqeq_p(VALUE self, VALUE other)
 	}
         else {
             const double d = nurat_to_double(self);
-            return f_boolcast(FIXNUM_ZERO_P(rb_dbl_cmp(d, NUM2DBL(other))));
+            return RBOOL(FIXNUM_ZERO_P(rb_dbl_cmp(d, NUM2DBL(other))));
         }
     }
     else if (RB_FLOAT_TYPE_P(other)) {
 	const double d = nurat_to_double(self);
-	return f_boolcast(FIXNUM_ZERO_P(rb_dbl_cmp(d, RFLOAT_VALUE(other))));
+	return RBOOL(FIXNUM_ZERO_P(rb_dbl_cmp(d, RFLOAT_VALUE(other))));
     }
     else if (RB_TYPE_P(other, T_RATIONAL)) {
 	{
@@ -1149,7 +1149,7 @@ nurat_eqeq_p(VALUE self, VALUE other)
 	    if (INT_ZERO_P(adat->num) && INT_ZERO_P(bdat->num))
 		return Qtrue;
 
-	    return f_boolcast(rb_int_equal(adat->num, bdat->num) &&
+	    return RBOOL(rb_int_equal(adat->num, bdat->num) &&
 			      rb_int_equal(adat->den, bdat->den));
 	}
     }
@@ -1200,7 +1200,7 @@ static VALUE
 nurat_positive_p(VALUE self)
 {
     get_dat1(self);
-    return f_boolcast(INT_POSITIVE_P(dat->num));
+    return RBOOL(INT_POSITIVE_P(dat->num));
 }
 
 /*
@@ -1213,7 +1213,7 @@ static VALUE
 nurat_negative_p(VALUE self)
 {
     get_dat1(self);
-    return f_boolcast(INT_NEGATIVE_P(dat->num));
+    return RBOOL(INT_NEGATIVE_P(dat->num));
 }
 
 /*


### PR DESCRIPTION
Some code has `f_boolcast` definination, but I think it's better to one difinination in `internal.h`.