### PR TITLE
Fix Marshal.dump(closed_io) to raise TypeError

### DIFF
--- a/marshal.c
+++ b/marshal.c
@@ -621,7 +621,15 @@ static VALUE
 encoding_name(VALUE obj, struct dump_arg *arg)
 {
     if (rb_enc_capable(obj)) {
-        int encidx = rb_enc_get_index(obj);
+        int encidx;
+
+        /* encoding can't be retrieved from closed IO */
+        if (RB_TYPE_P(obj, T_FILE)) {
+            VALUE closed = rb_check_funcall(obj, rb_intern("closed?"), 0, 0);
+            if (closed) return Qnil;
+        }
+
+        encidx = rb_enc_get_index(obj);
         rb_encoding *enc = 0;
         st_data_t name;
 

--- a/test/ruby/test_io.rb
+++ b/test/ruby/test_io.rb
@@ -3991,6 +3991,17 @@ __END__
     }
   end
 
+  def test_external_encoding_index_on_closed
+    r, w = IO.pipe
+    r.close; w.close
+    assert_raise(TypeError) {Marshal.dump(r)}
+
+    class << r
+      undef_method :closed?
+    end
+    assert_raise(TypeError) {Marshal.dump(r)}
+  end
+
   def test_stdout_to_closed_pipe
     EnvUtil.invoke_ruby(["-e", "loop {puts :ok}"], "", true, true) do
       |in_p, out_p, err_p, pid|


### PR DESCRIPTION
Mashalling a closed IO object raised "closed stream (IOError)" before.

Alternative to #4746 without the side effect mentioned by @nobu: https://bugs.ruby-lang.org/issues/18077#note-1

Fixes bug [bug #18077](https://bugs.ruby-lang.org/issues/18077)
