### PR TITLE
Remove const and `rb_ary_clear`

### DIFF
--- a/insns.def
+++ b/insns.def
@@ -405,9 +405,8 @@ toregexp
 // attr bool leaf = false;
 // attr rb_snum_t sp_inc = 1 - (rb_snum_t)cnt;
 {
-    const VALUE ary = rb_ary_tmp_new_from_values(0, cnt, STACK_ADDR_FROM_TOP(cnt));
+    VALUE ary = rb_ary_tmp_new_from_values(0, cnt, STACK_ADDR_FROM_TOP(cnt));
     val = rb_reg_new_ary(ary, (int)opt);
-    rb_ary_clear(ary);
 }
 
 /* intern str to Symbol and push it. */


### PR DESCRIPTION
Let GC clean up this temporary array.

Co-authored-by: Aaron Patterson <tenderlove@ruby-lang.org>

cc/ @tenderlove 