### PR TITLE
support `GC.stat(:time)` with gc_enter/gc_exit

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -5852,6 +5852,7 @@ gc.$(OBJEXT): {$(VPATH)}encoding.h
 gc.$(OBJEXT): {$(VPATH)}eval_intern.h
 gc.$(OBJEXT): {$(VPATH)}gc.c
 gc.$(OBJEXT): {$(VPATH)}gc.h
+gc.$(OBJEXT): {$(VPATH)}gc.rb
 gc.$(OBJEXT): {$(VPATH)}gc.rbinc
 gc.$(OBJEXT): {$(VPATH)}id.h
 gc.$(OBJEXT): {$(VPATH)}id_table.h

--- a/gc.rb
+++ b/gc.rb
@@ -266,6 +266,51 @@ module GC
   def self.using_rvargc?
     GC::INTERNAL_CONSTANTS[:SIZE_POOL_COUNT] > 1
   end
+
+
+  # call-seq:
+  #    GC.measure_total_time = true/false
+  #
+  # Enable to measure GC time.
+  # You can get the result with `GC.stat(:time)`.
+  # Note that the GC time measurement can introduce the performance regression.
+  def self.measure_total_time=(flag)
+    Primitive.cstmt! %{
+      rb_objspace.flags.measure_gc = RTEST(flag) ? TRUE : FALSE;
+      return flag;
+    }
+  end
+
+  # call-seq:
+  #    GC.measure_total_time -> true/false
+  #
+  # Return measure_total_time flag (default: true).
+  # Note that measurement can affect the application performance.
+  def self.measure_total_time
+    Primitive.cexpr! %{
+      RBOOL(rb_objspace.flags.measure_gc)
+    }
+  end
+
+  Primitive.cinit! %{
+    #if SIZEOF_LONG == 8
+      #define UINT64_2NUM RB_ULONG2NUM
+    #elif SIZEOF_LONG_LONG == 8
+      #define UINT64_2NUM RB_ULL2NUM
+    #else
+      #error Can not make UINT64_2NUM
+    #endif
+  }
+
+  # call-seq:
+  #    GC.total_time -> int
+  #
+  # Return measured GC total time in nano seconds.
+  def self.total_time
+    Primitive.cexpr! %{
+      UINT64_2NUM(rb_objspace.profile.total_time_ns)
+    }
+  end
 end
 
 module ObjectSpace

--- a/gc.rb
+++ b/gc.rb
@@ -292,23 +292,13 @@ module GC
     }
   end
 
-  Primitive.cinit! %{
-    #if SIZEOF_LONG == 8
-      #define UINT64_2NUM RB_ULONG2NUM
-    #elif SIZEOF_LONG_LONG == 8
-      #define UINT64_2NUM RB_ULL2NUM
-    #else
-      #error Can not make UINT64_2NUM
-    #endif
-  }
-
   # call-seq:
   #    GC.total_time -> int
   #
   # Return measured GC total time in nano seconds.
   def self.total_time
     Primitive.cexpr! %{
-      UINT64_2NUM(rb_objspace.profile.total_time_ns)
+      ULL2NUM(rb_objspace.profile.total_time_ns)
     }
   end
 end


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/10917

    GC measurement feature

    * `GC.measure_total_time = true` enables total time measurement (default: true)
    * `GC.measure_total_time` returns current flag.
    * `GC.total_time` returns measured total time in nano seconds.
    * `GC.stat(:time)` (and Hash) returns measured total time in milli seconds.
