### PR TITLE
.github/workflows/compilers.yml: Specify a container running user as root.

### DIFF
--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -168,8 +168,12 @@ jobs:
 
     name: ${{ matrix.entry.name }}
     runs-on: ubuntu-latest
-    container: ghcr.io/ruby/ruby-ci-image:${{ matrix.entry.container || 'clang-14' }}
+    container:
+      image: ghcr.io/ruby/ruby-ci-image:${{ matrix.entry.container || 'clang-14' }}
+      options: --user root
     steps:
+      - run: id
+        working-directory:
       - run: mkdir build
         working-directory:
       - name: setenv


### PR DESCRIPTION
Coming new ruby/ruby-ci-image images are required to run the container as
a regular user by default, while the root user is required to run the
compilers.yml. Add `id` command to print the user info.

Co-authored-by: fedor <fedor@cirruslabs.org>

---
This PR is based on the PR: https://github.com/ruby/ruby/pull/4750 . I updated the commit message, and container image URL and added the `id` command. This PR is a preparation for the coming new images.

Note the new ruby/ruby-ci-image images are here.
https://github.com/ruby/ruby-ci-image/pull/3

I tested this PR with both the current and coming container images too.

The newly added `id` command and current `mkdir build` command only work with `working-directory:` syntax. But doesn't work without the `working-directory:` syntax.

```
       - run: id
         working-directory:
       - run: mkdir build
         working-directory:
```

For example, the `mkdir build` without the `working-directory:` syntax prints the following error. I am not sure why the error happen. Anyway, I added the `working-directory:` to the commands.

https://github.com/junaruga/ruby/runs/3404442652?check_suite_focus=true#step:4:17

```
Run mkdir build
OCI runtime exec failed: exec failed: container_linux.go:380: starting container process caused: chdir to cwd ("/__w/ruby/ruby/build") set in config.json failed: no such file or directory: unknown
Error: Process completed with exit code 126.
```
