### PR TITLE
Support tracing of attr_reader and attr_writer

### DIFF
--- a/benchmark/attr_accessor.yml
+++ b/benchmark/attr_accessor.yml
@@ -1,0 +1,29 @@
+prelude: |
+  class C
+    attr_accessor :x
+    def initialize
+      @x = nil
+    end
+    class_eval <<-END
+      def ar
+        #{'x;'*256}
+      end
+      def aw
+        #{'self.x = nil;'*256}
+      end
+      def arm
+        m = method(:x)
+        #{'m.call;'*256}
+      end
+      def awm
+        m = method(:x=)
+        #{'m.call(nil);'*256}
+      end
+    END
+  end
+  obj = C.new
+benchmark:
+  attr_reader: "obj.ar"
+  attr_writer: "obj.aw"
+  attr_reader_method: "obj.arm"
+  attr_writer_method: "obj.awm"

--- a/iseq.c
+++ b/iseq.c
@@ -3407,6 +3407,32 @@ rb_iseq_trace_set(const rb_iseq_t *iseq, rb_event_flag_t turnon_events)
     }
 }
 
+bool rb_vm_call_ivar_attrset_p(const vm_call_handler ch);
+void rb_vm_cc_general(const struct rb_callcache *cc);
+
+static int
+clear_attr_ccs_i(void *vstart, void *vend, size_t stride, void *data)
+{
+    VALUE v = (VALUE)vstart;
+    for (; v != (VALUE)vend; v += stride) {
+        void *ptr = asan_poisoned_object_p(v);
+        asan_unpoison_object(v, false);
+
+        if (imemo_type_p(v, imemo_callcache) && rb_vm_call_ivar_attrset_p(((const struct rb_callcache *)v)->call_)) {
+            rb_vm_cc_general((struct rb_callcache *)v);
+        }
+
+        asan_poison_object_if(ptr, v);
+    }
+    return 0;
+}
+
+void
+rb_clear_attr_ccs(void)
+{
+    rb_objspace_each_objects(clear_attr_ccs_i, NULL);
+}
+
 static int
 trace_set_i(void *vstart, void *vend, size_t stride, void *data)
 {
@@ -3420,6 +3446,9 @@ trace_set_i(void *vstart, void *vend, size_t stride, void *data)
 	if (rb_obj_is_iseq(v)) {
 	    rb_iseq_trace_set(rb_iseq_check((rb_iseq_t *)v), turnon_events);
 	}
+        else if (imemo_type_p(v, imemo_callcache) && rb_vm_call_ivar_attrset_p(((const struct rb_callcache *)v)->call_)) {
+            rb_vm_cc_general((struct rb_callcache *)v);
+        }
 
         asan_poison_object_if(ptr, v);
     }

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -190,7 +190,16 @@ vm_call0_body(rb_execution_context_t *ec, struct rb_calling_info *calling, const
         }
 
 	rb_check_arity(calling->argc, 1, 1);
-	ret = rb_ivar_set(calling->recv, vm_cc_cme(cc)->def->body.attr.id, argv[0]);
+        if (UNLIKELY(ruby_vm_event_flags & (RUBY_EVENT_C_CALL | RUBY_EVENT_C_RETURN))) {
+            EXEC_EVENT_HOOK(ec, RUBY_EVENT_C_CALL, calling->recv,
+                vm_cc_cme(cc)->def->original_id, vm_ci_mid(ci), vm_cc_cme(cc)->owner, Qundef);
+            ret = rb_ivar_set(calling->recv, vm_cc_cme(cc)->def->body.attr.id, argv[0]);
+            EXEC_EVENT_HOOK(ec, RUBY_EVENT_C_RETURN, calling->recv,
+                vm_cc_cme(cc)->def->original_id, vm_ci_mid(ci), vm_cc_cme(cc)->owner, ret);
+        }
+        else {
+            ret = rb_ivar_set(calling->recv, vm_cc_cme(cc)->def->body.attr.id, argv[0]);
+        }
 	goto success;
       case VM_METHOD_TYPE_IVAR:
         if (calling->kw_splat &&
@@ -201,7 +210,16 @@ vm_call0_body(rb_execution_context_t *ec, struct rb_calling_info *calling, const
         }
 
 	rb_check_arity(calling->argc, 0, 0);
-	ret = rb_attr_get(calling->recv, vm_cc_cme(cc)->def->body.attr.id);
+        if (UNLIKELY(ruby_vm_event_flags & (RUBY_EVENT_C_CALL | RUBY_EVENT_C_RETURN))) {
+            EXEC_EVENT_HOOK(ec, RUBY_EVENT_C_CALL, calling->recv,
+                vm_cc_cme(cc)->def->original_id, vm_ci_mid(ci), vm_cc_cme(cc)->owner, Qundef);
+            ret = rb_attr_get(calling->recv, vm_cc_cme(cc)->def->body.attr.id);
+            EXEC_EVENT_HOOK(ec, RUBY_EVENT_C_RETURN, calling->recv,
+                vm_cc_cme(cc)->def->original_id, vm_ci_mid(ci), vm_cc_cme(cc)->owner, ret);
+        }
+        else {
+            ret = rb_attr_get(calling->recv, vm_cc_cme(cc)->def->body.attr.id);
+        }
 	goto success;
       case VM_METHOD_TYPE_BMETHOD:
         ret = vm_call_bmethod_body(ec, calling, argv);

--- a/vm_trace.c
+++ b/vm_trace.c
@@ -74,6 +74,8 @@ rb_hook_list_free(rb_hook_list_t *hooks)
 
 /* ruby_vm_event_flags management */
 
+void rb_clear_attr_ccs(void);
+
 static void
 update_global_event_hook(rb_event_flag_t vm_events)
 {
@@ -90,6 +92,9 @@ update_global_event_hook(rb_event_flag_t vm_events)
 
 	/* write all ISeqs if and only if new events are added */
 	rb_iseq_trace_set_all(new_iseq_events | enabled_iseq_events);
+    }
+    else {
+        rb_clear_attr_ccs();
     }
 
     ruby_vm_event_flags = vm_events;


### PR DESCRIPTION
This allows support of tracing attr_reader and attr_writer methods.
These were previously not traced for performance reasons. However,
by checking for the currently traced events, and only calling
EXEC_EVENT_HOOK if c_call or c_return are traced, we can avoid
a significant slowdown.

This includes a benchmark showing the performance decrease is minimal
Here `miniruby.master` is the master branch without this commit, and
`miniruby` is the master branch with this commit:

```ruby
Comparison:
                      attr_reader
            miniruby:  29810571.6 i/s
     miniruby.master:  29360751.1 i/s - 1.02x  slower

                      attr_writer
     miniruby.master:  26711040.5 i/s
            miniruby:  26589230.2 i/s - 1.00x  slower

               attr_reader_method
     miniruby.master:   5570973.3 i/s
            miniruby:   5505409.7 i/s - 1.01x  slower

               attr_writer_method
            miniruby:   5257277.9 i/s
     miniruby.master:   5156980.9 i/s - 1.02x  slower
```

This currently causes test failures in `power_assert` bundled gems tests, which doesn't expect to be able to trace attr methods: https://github.com/ruby/power_assert/blob/master/test/block_test.rb#L278-L310.  Those tests will need to be fixed to support both the old behavior and this fixed behavior before this can be merged.

Fixes [Bug #16383]
Fixes [Bug #10470]