### PR TITLE
Make ErrorHighlight.formatter Ractor-ready

### DIFF
--- a/lib/error_highlight/formatter.rb
+++ b/lib/error_highlight/formatter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ErrorHighlight
   class DefaultFormatter
     def message_for(spot)
@@ -13,13 +15,18 @@ module ErrorHighlight
     end
   end
 
+  DEFAULT_FORMATTER = DefaultFormatter.new
+  Ractor.make_shareable(DEFAULT_FORMATTER) if defined?(Ractor)
+
   def self.formatter
-    @@formatter
+    DEFAULT_FORMATTER
   end
 
   def self.formatter=(formatter)
-    @@formatter = formatter
+    provider = proc {
+      formatter
+    }
+    Ractor.make_shareable(provider) if defined?(Ractor)
+    define_singleton_method(:formatter, &provider)
   end
-
-  self.formatter = DefaultFormatter.new
 end


### PR DESCRIPTION
Otherwise, exceptions shown on console will cause the error below:
```
/Users/tagomoris/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/error_highlight/formatter.rb:21:in `formatter': can not access non-shareable objects in constant ErrorHighlight::DEFAULT_FORMATTER by non-main ractor. (Ractor::IsolationError)
	from /Users/tagomoris/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/error_highlight/core_ext.rb:36:in `to_s'
	from /Users/tagomoris/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/did_you_mean/core_ext/name_error.rb:21:in `rescue in to_s'
	from /Users/tagomoris/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/did_you_mean/core_ext/name_error.rb:14:in `to_s'
	from snippets/ractor_server.rb:21:in `message'
	from snippets/ractor_server.rb:21:in `full_message'
	from snippets/ractor_server.rb:21:in `rescue in block (2 levels) in <main>'
	from snippets/ractor_server.rb:10:in `block (2 levels) in <main>'
```
