### PR TITLE
Variable Width Allocation Phase II (take 2)

### DIFF
--- a/class.c
+++ b/class.c
@@ -185,8 +185,7 @@ class_alloc(VALUE flags, VALUE klass)
     RVARGC_NEWOBJ_OF(obj, struct RClass, klass, (flags & T_MASK) | FL_PROMOTED1 /* start from age == 2 */ | (RGENGC_WB_PROTECTED_CLASS ? FL_WB_PROTECTED : 0), payload_size);
 
 #if USE_RVARGC
-    obj->ptr = (rb_classext_t *)rb_rvargc_payload_data_ptr((VALUE)obj + rb_slot_size());
-    RB_OBJ_WRITTEN(obj, Qundef, (VALUE)obj + rb_slot_size());
+    obj->ptr = (rb_classext_t *)rb_gc_rvargc_object_data((VALUE)obj);
 #else
     obj->ptr = ZALLOC(rb_classext_t);
 #endif

--- a/ext/objspace/objspace.c
+++ b/ext/objspace/objspace.c
@@ -66,7 +66,6 @@ total_i(VALUE v, void *ptr)
       case T_IMEMO:
       case T_ICLASS:
       case T_NODE:
-      case T_PAYLOAD:
       case T_ZOMBIE:
           return;
       default:
@@ -225,7 +224,6 @@ type2sym(enum ruby_value_type i)
 	CASE_TYPE(T_ICLASS);
         CASE_TYPE(T_MOVED);
 	CASE_TYPE(T_ZOMBIE);
-	CASE_TYPE(T_PAYLOAD);
 #undef CASE_TYPE
       default: rb_bug("type2sym: unknown type (%d)", i);
     }

--- a/include/ruby/internal/value_type.h
+++ b/include/ruby/internal/value_type.h
@@ -81,7 +81,6 @@
 #define T_TRUE     RUBY_T_TRUE
 #define T_UNDEF    RUBY_T_UNDEF
 #define T_ZOMBIE   RUBY_T_ZOMBIE
-#define T_PAYLOAD  RUBY_T_PAYLOAD
 
 #define BUILTIN_TYPE      RB_BUILTIN_TYPE
 #define DYNAMIC_SYM_P     RB_DYNAMIC_SYM_P
@@ -134,7 +133,6 @@ ruby_value_type {
     RUBY_T_SYMBOL   = 0x14, /**< @see struct ::RSymbol */
     RUBY_T_FIXNUM   = 0x15, /**< Integers formerly known as Fixnums. */
     RUBY_T_UNDEF    = 0x16, /**< @see ::RUBY_Qundef */
-    RUBY_T_PAYLOAD  = 0x17, /**< @see ::RPayload */
 
     RUBY_T_IMEMO    = 0x1a, /**< @see struct ::RIMemo */
     RUBY_T_NODE     = 0x1b, /**< @see struct ::RNode */

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -101,6 +101,7 @@ static inline void *ruby_sized_xrealloc2_inlined(void *ptr, size_t new_count, si
 static inline void ruby_sized_xfree_inlined(void *ptr, size_t size);
 VALUE rb_class_allocate_instance(VALUE klass);
 void rb_gc_ractor_newobj_cache_clear(rb_ractor_newobj_cache_t *newobj_cache);
+void *rb_gc_rvargc_object_data(VALUE obj);
 
 RUBY_SYMBOL_EXPORT_BEGIN
 /* gc.c (export) */
@@ -116,7 +117,6 @@ void rb_gc_mark_vm_stack_values(long n, const VALUE *values);
 void *ruby_sized_xrealloc(void *ptr, size_t new_size, size_t old_size) RUBY_ATTR_RETURNS_NONNULL RUBY_ATTR_ALLOC_SIZE((2));
 void *ruby_sized_xrealloc2(void *ptr, size_t new_count, size_t element_size, size_t old_count) RUBY_ATTR_RETURNS_NONNULL RUBY_ATTR_ALLOC_SIZE((2, 3));
 void ruby_sized_xfree(void *x, size_t size);
-int rb_slot_size(void);
 RUBY_SYMBOL_EXPORT_END
 
 MJIT_SYMBOL_EXPORT_BEGIN

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -71,8 +71,6 @@ struct rb_objspace; /* in vm_core.h */
     rb_obj_write((VALUE)(a), UNALIGNED_MEMBER_ACCESS((VALUE *)(slot)), \
                  (VALUE)(b), __FILE__, __LINE__)
 
-#define RVARGC_PAYLOAD_INIT(obj, size) (void *)rb_rvargc_payload_init((VALUE)obj, (size_t)size)
-
 typedef struct ractor_newobj_cache {
     struct RVALUE *freelist;
     struct heap_page *using_page;
@@ -110,8 +108,6 @@ const char *rb_objspace_data_type_name(VALUE obj);
 VALUE rb_wb_protected_newobj_of(VALUE, VALUE, size_t);
 VALUE rb_wb_unprotected_newobj_of(VALUE, VALUE, size_t);
 VALUE rb_ec_wb_protected_newobj_of(struct rb_execution_context_struct *ec, VALUE klass, VALUE flags, size_t);
-VALUE rb_rvargc_payload_init(VALUE obj, size_t size);
-void * rb_rvargc_payload_data_ptr(VALUE obj);
 size_t rb_obj_memsize_of(VALUE);
 void rb_gc_verify_internal_consistency(void);
 size_t rb_obj_gc_flags(VALUE, ID[], size_t);

--- a/misc/lldb_cruby.py
+++ b/misc/lldb_cruby.py
@@ -330,9 +330,6 @@ def lldb_inspect(debugger, target, result, val):
         elif flType == RUBY_T_HASH:
             result.write("T_HASH: %s" % flaginfo)
             append_command_output(debugger, "p *(struct RHash *) %0#x" % val.GetValueAsUnsigned(), result)
-        elif flType == RUBY_T_PAYLOAD:
-            result.write("T_PAYLOAD: %s" % flaginfo)
-            append_command_output(debugger, "p *(struct RPayload *) %0#x" % val.GetValueAsUnsigned(), result)
         elif flType == RUBY_T_BIGNUM:
             tRBignum = target.FindFirstType("struct RBignum").GetPointerType()
             val = val.Cast(tRBignum)

--- a/misc/lldb_cruby.py
+++ b/misc/lldb_cruby.py
@@ -533,14 +533,15 @@ class HeapPageIter:
         self.target = target
         self.start = page.GetChildMemberWithName('start').GetValueAsUnsigned();
         self.num_slots = page.GetChildMemberWithName('total_slots').unsigned
+        self.slot_size = page.GetChildMemberWithName('size_pool').GetChildMemberWithName('slot_size').unsigned
         self.counter = 0
         self.tRBasic = target.FindFirstType("struct RBasic")
         self.tRValue = target.FindFirstType("struct RVALUE")
 
     def is_valid(self):
         heap_page_header_size = self.target.FindFirstType("struct heap_page_header").GetByteSize()
-        rvalue_size = self.tRValue.GetByteSize()
-        heap_page_obj_limit = int((HEAP_PAGE_SIZE - heap_page_header_size) / rvalue_size)
+        rvalue_size = self.slot_size
+        heap_page_obj_limit = int((HEAP_PAGE_SIZE - heap_page_header_size) / self.slot_size)
 
         return (heap_page_obj_limit - 1) <= self.num_slots <= heap_page_obj_limit
 
@@ -549,7 +550,7 @@ class HeapPageIter:
 
     def __next__(self):
         if self.counter < self.num_slots:
-            obj_addr_i = self.start + (self.counter * self.tRValue.GetByteSize())
+            obj_addr_i = self.start + (self.counter * self.slot_size)
             obj_addr = lldb.SBAddress(obj_addr_i, self.target)
             slot_info = (self.counter, obj_addr_i, self.target.CreateValueFromAddress("object", obj_addr, self.tRBasic))
             self.counter += 1

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -731,7 +731,6 @@ rb_type_str(enum ruby_value_type type)
       case type_case(T_ICLASS);
       case type_case(T_ZOMBIE);
       case type_case(T_MOVED);
-      case type_case(T_PAYLOAD);
       case T_MASK: break;
     }
 #undef type_case


### PR DESCRIPTION
#4680 caused build failures on Debian i386 and Solaris SPARC due to the most significant bit in pointers being set so the pointers would become negative when casted to `intptr_t`. This is problematic for pointer comparisons. We now use `uintptr_t` which does not have these problems. This branch has been tested on the previously crashing systems to ensure it works.