### PR TITLE
tool/test-bundled-gems.rb: Use the bundled RBS code to test TypeProf

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1372,7 +1372,7 @@ no-test-bundled-gems-prepare: no-test-bundled-gems-precheck
 yes-test-bundled-gems-prepare: yes-test-bundled-gems-precheck
 	$(ACTIONS_GROUP)
 	$(XRUBY) -C "$(srcdir)" bin/gem install --no-document \
-		--install-dir .bundle --conservative "bundler" "minitest:~> 5" "test-unit" "rake" "hoe" "yard" "pry" "packnga" "rexml" "json-schema" "rbs"
+		--install-dir .bundle --conservative "bundler" "minitest:~> 5" "test-unit" "rake" "hoe" "yard" "pry" "packnga" "rexml" "json-schema"
 	$(ACTIONS_ENDGROUP)
 
 PREPARE_BUNDLED_GEMS = test-bundled-gems-prepare

--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -11,5 +11,5 @@ net-pop 0.1.1 https://github.com/ruby/net-pop
 net-smtp 0.2.1 https://github.com/ruby/net-smtp
 matrix 0.4.2 https://github.com/ruby/matrix
 prime 0.1.2 https://github.com/ruby/prime
-typeprof 0.15.2 https://github.com/ruby/typeprof
 rbs 1.5.1 https://github.com/ruby/rbs
+typeprof 0.15.2 https://github.com/ruby/typeprof

--- a/tool/test-bundled-gems.rb
+++ b/tool/test-bundled-gems.rb
@@ -20,6 +20,11 @@ File.foreach("#{gem_dir}/bundled_gems") do |line|
   test_command = "#{ruby} -C #{gem_dir}/src/#{gem} -Ilib #{rake} test"
   first_timeout = 600 # 10min
 
+  if gem == "typeprof"
+    raise "need to run rbs test suite before typeprof" unless File.readable?("#{gem_dir}/src/rbs/lib/rbs/parser.rb")
+    ENV["RUBYLIB"] = ["#{gem_dir}/src/rbs/lib", ENV.fetch("RUBYLIB", nil)].compact.join(":")
+  end
+
   if gem == "rbs"
     racc = File.realpath("../../libexec/racc", __FILE__)
     pid = Process.spawn("#{ruby} -C #{gem_dir}/src/#{gem} -Ilib #{racc} -v -o lib/rbs/parser.rb lib/rbs/parser.y")


### PR DESCRIPTION
Formerly, TypeProf was tested with the latest RBS code during
`make test-bundled-gems`. However, when a new version of rbs is
released, and if it is incompatible with TypeProf,
`make test-bundled-gems` starts failing, which was annoying.

By this change, TypeProf is tested with the bundled version of RBS.