### PR TITLE
Add Windows Server 2022 with Visual Studio 2022

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -5,8 +5,13 @@ jobs:
     strategy:
       matrix:
         test_task: [check] # to make job names consistent
-        os: [windows-2019]
-        vs: [2019]
+        os: [windows-2019, windows-2022]
+        vs: [2019, 2022]
+        exclude:
+          - os: windows-2019
+            vs: 2022
+          - os: windows-2022
+            vs: 2019
       fail-fast: false
     runs-on: ${{ matrix.os }}
     env:


### PR DESCRIPTION
https://github.blog/changelog/2021-08-23-github-actions-windows-server-2022-with-visual-studio-2022-is-now-available-on-github-hosted-runners-public-beta/