### PR TITLE
Fix build failure on macOS with --enable-shared

### DIFF
--- a/defs/gmake.mk
+++ b/defs/gmake.mk
@@ -362,7 +362,7 @@ spec/bundler: test-bundler-parallel
 
 # workaround to avoid matching non ruby files with "spec/%/" under GNU make 3.81
 spec/%_spec.c spec/%_spec.bundle:
-	$(NOOP)
+	$(empty)
 
 spec/%/ spec/%_spec.rb: programs exts PHONY
 	+$(RUNRUBY) -r./$(arch)-fake $(srcdir)/spec/mspec/bin/mspec-run -B $(srcdir)/spec/default.mspec $(SPECOPTS) $(patsubst %,$(srcdir)/%,$@)

--- a/defs/gmake.mk
+++ b/defs/gmake.mk
@@ -360,6 +360,10 @@ spec/bundler/%: PHONY
 spec/bundler: test-bundler-parallel
 	$(Q)$(NULLCMD)
 
+# workaround to avoid matching non ruby files with "spec/%/" under GNU make 3.81
+spec/%_spec.c spec/%_spec.bundle:
+	$(NOOP)
+
 spec/%/ spec/%_spec.rb: programs exts PHONY
 	+$(RUNRUBY) -r./$(arch)-fake $(srcdir)/spec/mspec/bin/mspec-run -B $(srcdir)/spec/default.mspec $(SPECOPTS) $(patsubst %,$(srcdir)/%,$@)
 


### PR DESCRIPTION
`./spec/ruby/optional/capi/ext/array_spec.c` can match with `spec/%/` if
using GNU Make under version 3.81. make command installed on macOS is
3.81, so ruby can't be built with default make on macOS with
  --enable-shared option since https://github.com/ruby/ruby/commit/bda56a03a625793cb3fd110458c3f7323d73705e

This patch repairs [ruby-dev-builder's daily builds](https://github.com/ruby/ruby-dev-builder/runs/3414721331?check_suite_focus=true)