### PR TITLE
Fix example fiber scheduler reg. writable events

### DIFF
--- a/test/fiber/scheduler.rb
+++ b/test/fiber/scheduler.rb
@@ -60,6 +60,7 @@ class Scheduler
 
       readable&.each do |io|
         if fiber = @readable.delete(io)
+          @writable.delete(io) if @writable[io] == fiber
           selected[fiber] = IO::READABLE
         elsif io == @urgent.first
           @urgent.first.read_nonblock(1024)
@@ -68,7 +69,8 @@ class Scheduler
 
       writable&.each do |io|
         if fiber = @writable.delete(io)
-          selected[fiber] |= IO::WRITABLE
+          @readable.delete(io) if @readable[io] == fiber
+          selected[fiber] = selected.fetch(fiber, 0) | IO::WRITABLE
         end
       end
 


### PR DESCRIPTION
There were two issues:

1. When an IO object is waiting for writablility only (as in test_tcp_accept) the selected hash is empty.
   Therefore selected[fiber] returns nil but needs to default to 0 in order to be or'ed with IO::WRITABLE.

2. When an IO object is waiting for read- or writability (as in test_tcp_connect), but only one of these
   two events arrive, the Fiber and IO object need to be removed from the other `@readable` or `@writable` list.