### PR TITLE
Clean up lambda output from exyacc.rb

### DIFF
--- a/sample/exyacc.rb
+++ b/sample/exyacc.rb
@@ -8,7 +8,7 @@ ARGF.each(nil) do |source|
   grammar = source[sbeg, send-sbeg]
   grammar.sub!(/.*\n/, "")
   grammar.gsub!(/'\{'/, "'\001'")
-  grammar.gsub!(/'\}'/, "'\002'")
+  grammar.gsub!(/["']\}["']/, "'\002'")
   grammar.gsub!(%r{\*/}, "\003\003")
   grammar.gsub!(%r{/\*[^\003]*\003\003}, '')
   while grammar.gsub!(/\{[^{}]*\}/, ''); end


### PR DESCRIPTION
The `lambda_body` grammar rule has a `"}"`, which is throwing off the `exyacc.rb` regular expressions. This changes the regular expression to account for `"}"` as well, which makes the output of `ruby sample/exyacc.rb < parse.y` change by the following diff:

```diff
632,634d631
< 		    ", &@3);
< 			$$ = $2;
< 		    }
```

Which makes it closer to a valid EBNF.