### PR TITLE
Introduce an option "--dump=insns_without_opt" for debugging purposes

### DIFF
--- a/iseq.c
+++ b/iseq.c
@@ -844,11 +844,11 @@ rb_iseq_new_top(const rb_ast_body_t *ast, VALUE name, VALUE path, VALUE realpath
 }
 
 rb_iseq_t *
-rb_iseq_new_main(const rb_ast_body_t *ast, VALUE path, VALUE realpath, const rb_iseq_t *parent)
+rb_iseq_new_main(const rb_ast_body_t *ast, VALUE path, VALUE realpath, const rb_iseq_t *parent, int opt)
 {
     return rb_iseq_new_with_opt(ast, rb_fstring_lit("<main>"),
 				path, realpath, INT2FIX(0),
-				parent, 0, ISEQ_TYPE_MAIN, &COMPILE_OPTION_DEFAULT);
+				parent, 0, ISEQ_TYPE_MAIN, opt ? &COMPILE_OPTION_DEFAULT : &COMPILE_OPTION_FALSE);
 }
 
 rb_iseq_t *

--- a/ruby.c
+++ b/ruby.c
@@ -318,7 +318,7 @@ usage(const char *name, int help, int highlight, int columns)
     };
     static const struct message dumps[] = {
 	M("insns",                  "", "instruction sequences"),
-	M("insns_without_out",      "", "instruction sequences compiled with no optimization"),
+	M("insns_without_opt",      "", "instruction sequences compiled with no optimization"),
 	M("yydebug",                "", "yydebug of yacc parser generator"),
 	M("parsetree",              "", "AST"),
 	M("parsetree_with_comment", "", "AST with comments"),

--- a/ruby.c
+++ b/ruby.c
@@ -140,13 +140,15 @@ enum feature_flag_bits {
     X(parsetree_with_comment) \
     SEP \
     X(insns) \
+    SEP \
+    X(insns_without_opt) \
     /* END OF DUMPS */
 enum dump_flag_bits {
     dump_version_v,
     EACH_DUMPS(DEFINE_DUMP, COMMA),
     dump_exit_bits = (DUMP_BIT(yydebug) | DUMP_BIT(syntax) |
 		      DUMP_BIT(parsetree) | DUMP_BIT(parsetree_with_comment) |
-		      DUMP_BIT(insns))
+		      DUMP_BIT(insns) | DUMP_BIT(insns_without_opt))
 };
 
 typedef struct ruby_cmdline_options ruby_cmdline_options_t;
@@ -316,6 +318,7 @@ usage(const char *name, int help, int highlight, int columns)
     };
     static const struct message dumps[] = {
 	M("insns",                  "", "instruction sequences"),
+	M("insns_without_out",      "", "instruction sequences compiled with no optimization"),
 	M("yydebug",                "", "yydebug of yacc parser generator"),
 	M("parsetree",              "", "AST"),
 	M("parsetree_with_comment", "", "AST with comments"),
@@ -2038,11 +2041,11 @@ process_options(int argc, char **argv, ruby_cmdline_options_t *opt)
         GetBindingPtr(rb_const_get(rb_cObject, rb_intern("TOPLEVEL_BINDING")),
                       toplevel_binding);
         const struct rb_block *base_block = toplevel_context(toplevel_binding);
-	iseq = rb_iseq_new_main(&ast->body, opt->script_name, path, vm_block_iseq(base_block));
+	iseq = rb_iseq_new_main(&ast->body, opt->script_name, path, vm_block_iseq(base_block), !(dump & DUMP_BIT(insns_without_opt)));
 	rb_ast_dispose(ast);
     }
 
-    if (dump & DUMP_BIT(insns)) {
+    if (dump & (DUMP_BIT(insns) | DUMP_BIT(insns_without_opt))) {
 	rb_io_write(rb_stdout, rb_iseq_disasm((const rb_iseq_t *)iseq));
 	rb_io_flush(rb_stdout);
 	dump &= ~DUMP_BIT(insns);

--- a/vm_core.h
+++ b/vm_core.h
@@ -1058,7 +1058,7 @@ RUBY_SYMBOL_EXPORT_BEGIN
 /* node -> iseq */
 rb_iseq_t *rb_iseq_new         (const rb_ast_body_t *ast, VALUE name, VALUE path, VALUE realpath,                     const rb_iseq_t *parent, enum iseq_type);
 rb_iseq_t *rb_iseq_new_top     (const rb_ast_body_t *ast, VALUE name, VALUE path, VALUE realpath,                     const rb_iseq_t *parent);
-rb_iseq_t *rb_iseq_new_main    (const rb_ast_body_t *ast,             VALUE path, VALUE realpath,                     const rb_iseq_t *parent);
+rb_iseq_t *rb_iseq_new_main    (const rb_ast_body_t *ast,             VALUE path, VALUE realpath,                     const rb_iseq_t *parent, int opt);
 rb_iseq_t *rb_iseq_new_eval    (const rb_ast_body_t *ast, VALUE name, VALUE path, VALUE realpath, VALUE first_lineno, const rb_iseq_t *parent, int isolated_depth);
 rb_iseq_t *rb_iseq_new_with_opt(const rb_ast_body_t *ast, VALUE name, VALUE path, VALUE realpath, VALUE first_lineno, const rb_iseq_t *parent, int isolated_depth,
                                 enum iseq_type, const rb_compile_option_t*);


### PR DESCRIPTION
```
$ ./miniruby --dump=insns -e '1 =~ 2'
== disasm: #<ISeq:<main>@-e:1 (1,0)-(1,6)> (catch: FALSE)
0000 putobject_INT2FIX_1_                                             (   1)[Li]
0001 putobject                              2
0003 opt_regexpmatch2                       <calldata!mid:=~, argc:1, ARGS_SIMPLE>[CcCr]
0005 leave
```

```
$ ./miniruby --dump=insns_without_opt -e '1 =~ 2'
== disasm: #<ISeq:<main>@-e:1 (1,0)-(1,6)> (catch: FALSE)
0000 putobject                              1                         (   1)[Li]
0002 putobject                              2
0004 send                                   <calldata!mid:=~, argc:1, ARGS_SIMPLE>, nil
0007 leave
```