### PR TITLE
Using SYMBOL_P macro

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -4103,7 +4103,7 @@ compile_keyword_arg(rb_iseq_t *iseq, LINK_ANCHOR *const ret,
             seen_nodes++;
 
 	    assert(nd_type(node) == NODE_LIST);
-            if (key_node && nd_type(key_node) == NODE_LIT && RB_TYPE_P(key_node->nd_lit, T_SYMBOL)) {
+            if (key_node && nd_type(key_node) == NODE_LIT && SYMBOL_P(key_node->nd_lit)) {
 		/* can be keywords */
 	    }
 	    else {
@@ -12331,7 +12331,7 @@ ibf_dump_object_object(struct ibf_dump *dump, VALUE obj)
     current_offset = ibf_dump_pos(dump);
 
     if (SPECIAL_CONST_P(obj) &&
-        ! (RB_TYPE_P(obj, T_SYMBOL) ||
+        ! (SYMBOL_P(obj) ||
            RB_TYPE_P(obj, T_FLOAT))) {
         obj_header.special_const = TRUE;
         obj_header.frozen = TRUE;

--- a/struct.c
+++ b/struct.c
@@ -1060,7 +1060,7 @@ rb_struct_pos(VALUE s, VALUE *name)
     long i;
     VALUE idx = *name;
 
-    if (RB_TYPE_P(idx, T_SYMBOL)) {
+    if (SYMBOL_P(idx)) {
 	return struct_member_pos(s, idx);
     }
     else if (RB_TYPE_P(idx, T_STRING)) {

--- a/transcode.c
+++ b/transcode.c
@@ -2464,7 +2464,7 @@ econv_opts(VALUE opt, int ecflags)
         else if (v==sym_attr) {
             ecflags |= ECONV_XML_ATTR_CONTENT_DECORATOR|ECONV_XML_ATTR_QUOTE_DECORATOR|ECONV_UNDEF_HEX_CHARREF;
         }
-        else if (RB_TYPE_P(v, T_SYMBOL)) {
+        else if (SYMBOL_P(v)) {
             rb_raise(rb_eArgError, "unexpected value for xml option: %"PRIsVALUE, rb_sym2str(v));
         }
         else {


### PR DESCRIPTION
Some code using `RB_TYPE_P` macro to check `T_SYMBOL`.

But, `SYMBOL_P` macro was defined and ussed by some code.

So, this pull request replace `SYMBOL_P` macro instead of `RB_TYPE_P` macro.