### PR TITLE
Improve Base64.urlsafe_encode64 performance

### DIFF
--- a/lib/base64.rb
+++ b/lib/base64.rb
@@ -82,8 +82,14 @@ module Base64
   # You can remove the padding by setting +padding+ as false.
   def urlsafe_encode64(bin, padding: true)
     str = strict_encode64(bin)
+    unless padding
+      if str.end_with?("==")
+        str.delete_suffix!("==")
+      elsif str.end_with?("=")
+        str.chop!
+      end
+    end
     str.tr!("+/", "-_")
-    str.delete!("=") unless padding
     str
   end
 


### PR DESCRIPTION
str.delete!("=") iterates over the entire string looking for the equals
character, but we know that we will, at most, find 2 at the end of the
string.