### PR TITLE
Using NIL_P macro instead of RB_TYPE_P macro

### DIFF
--- a/numeric.c
+++ b/numeric.c
@@ -3079,7 +3079,7 @@ rb_num2ll(VALUE val)
 unsigned LONG_LONG
 rb_num2ull(VALUE val)
 {
-    if (RB_TYPE_P(val, T_NIL)) {
+    if (NIL_P(val)) {
 	rb_raise(rb_eTypeError, "no implicit conversion from nil");
     }
     else if (RB_TYPE_P(val, T_FIXNUM)) {


### PR DESCRIPTION
Using `NIL_P` macro instead of `RB_TYPE_P` macro.