### PR TITLE
String#initialize leaks memory for STR_NOFREE strings

### DIFF
--- a/string.c
+++ b/string.c
@@ -1734,7 +1734,7 @@ rb_str_init(int argc, VALUE *argv, VALUE str)
                 const size_t osize = RSTRING(str)->as.heap.len + TERM_LEN(str);
                 char *new_ptr = ALLOC_N(char, (size_t)capa + termlen);
                 memcpy(new_ptr, old_ptr, osize < size ? osize : size);
-                FL_UNSET_RAW(str, STR_SHARED);
+                FL_UNSET_RAW(str, STR_SHARED|STR_NOFREE);
                 RSTRING(str)->as.heap.ptr = new_ptr;
 	    }
 	    else if (STR_HEAP_SIZE(str) != (size_t)capa + termlen) {

--- a/test/ruby/test_string.rb
+++ b/test/ruby/test_string.rb
@@ -105,6 +105,16 @@ PREP
 CODE
   end
 
+  # Bug #18154
+  def test_initialize_nofree_memory_leak
+    assert_no_memory_leak([], <<-PREP, <<-CODE, rss: true)
+code = proc {0.to_s.__send__(:initialize, capacity: 10000)}
+1_000.times(&code)
+PREP
+100_000.times(&code)
+CODE
+  end
+
   def test_AREF # '[]'
     assert_equal("A",  S("AooBar")[0])
     assert_equal("B",  S("FooBaB")[-1])


### PR DESCRIPTION
# Ticket: https://bugs.ruby-lang.org/issues/18154

There is a memory leak in calling the constructor on a string that is marked `STR_NOFREE` (e.g. a string created from a C string literal). The script below reproduces the memory leak. This is reproducible on all maintained Rubies (2.6.8, 2.7.4, 3.0.2, master) on Ubuntu 20.04.

We create a string marked `STR_NOFREE` with `0.to_s`. `to_s` for Fixnum has a [special optimization](https://github.com/ruby/ruby/blob/26153667f91f0c883f6af6b61fac2c0df5312b45/numeric.c#L3393) for the value `0` (it directly converts it to a C string literal). When we call `String#initialize` with a capacity it creates a buffer using `malloc` but does not unset the `STR_NOFREE` flag. This causes the buffer to be permanently leaked.

```ruby
100.times do
  1000.times do
    # 0.to_s is a special case that creates a string from a C string literal.
    # https://github.com/ruby/ruby/blob/26153667f91f0c883f6af6b61fac2c0df5312b45/numeric.c#L3393
    # C string literals are always marked STR_NOFREE.
    str = 0.to_s
    # Call String#initialize again to create a buffer with a capacity of 10000
    # characters.
    str.send(:initialize, capacity: 10000)
  end

  # Output the Resident Set Size (memory usage, in KB) of the current Ruby process.
  puts `ps -o rss= -p #{$$}`
end
```

We can see the leak through the following graph of the Resident Set Size (RSS) comparing the branch vs. master (at commit 26153667f91f0c883f6af6b61fac2c0df5312b45).

![](https://user-images.githubusercontent.com/15860699/132392215-9686259e-8c76-4fc9-9b63-427b89f8df2c.png)
