### PR TITLE
Remove uneeded initialize local variable

### DIFF
--- a/bignum.c
+++ b/bignum.c
@@ -462,7 +462,6 @@ static int
 bary_2comp(BDIGIT *ds, size_t n)
 {
     size_t i;
-    i = 0;
     for (i = 0; i < n; i++) {
         if (ds[i] != 0) {
             goto non_zero;


### PR DESCRIPTION
Remove uneeded inialize local variable in `bary_2comp` function.