### PR TITLE
Update the Travis badge URL in README. [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Actions Status: Ubuntu](https://github.com/ruby/ruby/workflows/Ubuntu/badge.svg)](https://github.com/ruby/ruby/actions?query=workflow%3A"Ubuntu")
 [![Actions Status: Windows](https://github.com/ruby/ruby/workflows/Windows/badge.svg)](https://github.com/ruby/ruby/actions?query=workflow%3A"Windows")
 [![AppVeyor status](https://ci.appveyor.com/api/projects/status/0sy8rrxut4o0k960/branch/master?svg=true)](https://ci.appveyor.com/project/ruby/ruby/branch/master)
-[![Travis Status](https://www.travis-ci.com/ruby/ruby.svg?branch=master)](https://www.travis-ci.com/ruby/ruby)
+[![Travis Status](https://app.travis-ci.com/ruby/ruby.svg?branch=master)](https://app.travis-ci.com/ruby/ruby)
 
 # What's Ruby
 


### PR DESCRIPTION
It seems the current URL: https://www.travis-ci.com/ruby/ruby is outdated, as it is not reachable.

---

Here is the modified README.
https://github.com/junaruga/ruby/blob/wip/travis-badge-url/README.md

