### PR TITLE
Remove printf family from the mjit header

### DIFF
--- a/gc.h
+++ b/gc.h
@@ -35,7 +35,7 @@ extern int ruby_gc_debug_indent;
 static inline void
 rb_gc_debug_indent(void)
 {
-    printf("%*s", ruby_gc_debug_indent, "");
+    ruby_debug_printf("%*s", ruby_gc_debug_indent, "");
 }
 
 static inline void
@@ -45,7 +45,7 @@ rb_gc_debug_body(const char *mode, const char *msg, int st, void *ptr)
 	ruby_gc_debug_indent--;
     }
     rb_gc_debug_indent();
-    printf("%s: %s %s (%p)\n", mode, st ? "->" : "<-", msg, ptr);
+    ruby_debug_printf("%s: %s %s (%p)\n", mode, st ? "->" : "<-", msg, ptr);
 
     if (st) {
 	ruby_gc_debug_indent++;
@@ -58,7 +58,7 @@ rb_gc_debug_body(const char *mode, const char *msg, int st, void *ptr)
 #define RUBY_MARK_LEAVE(msg) rb_gc_debug_body("mark", (msg), 0, ptr)
 #define RUBY_FREE_ENTER(msg) rb_gc_debug_body("free", (msg), 1, ptr)
 #define RUBY_FREE_LEAVE(msg) rb_gc_debug_body("free", (msg), 0, ptr)
-#define RUBY_GC_INFO         rb_gc_debug_indent(); printf
+#define RUBY_GC_INFO         rb_gc_debug_indent(), ruby_debug_printf
 
 #else
 #define RUBY_MARK_ENTER(msg)

--- a/include/ruby/internal/core/rstring.h
+++ b/include/ruby/internal/core/rstring.h
@@ -371,6 +371,16 @@ void rb_check_safe_str(VALUE);
  *              only.  You can safely forget about it.
  */
 #define Check_SafeStr(v) rb_check_safe_str(RBIMPL_CAST((VALUE)(v)))
+
+/**
+ * @private
+ *
+ * Prints diagnostic message to stderr when RSTRING_PTR or RSTRING_END
+ * is NULL.
+ *
+ * @param[in]  func           The function name where encountered NULL pointer.
+ */
+void rb_debug_rstring_null_ptr(const char *func);
 RBIMPL_SYMBOL_EXPORT_END()
 
 RBIMPL_ATTR_PURE_UNLESS_DEBUG()
@@ -476,12 +486,7 @@ RSTRING_PTR(VALUE str)
          * Also,  this is  not rb_warn()  because RSTRING_PTR()  can be  called
          * during GC (see  what obj_info() does).  rb_warn()  needs to allocate
          * Ruby objects.  That is not possible at this moment. */
-        fprintf(stderr, "%s\n",
-            "RSTRING_PTR is returning NULL!! "
-            "SIGSEGV is highly expected to follow immediately. "
-            "If you could reproduce, attach your debugger here, "
-            "and look at the passed string."
-        );
+        rb_debug_rstring_null_ptr("RSTRING_PTR");
     }
 
     return ptr;
@@ -502,12 +507,7 @@ RSTRING_END(VALUE str)
 
     if (RB_UNLIKELY(! buf.as.heap.ptr)) {
         /* Ditto. */
-        fprintf(stderr, "%s\n",
-            "RSTRING_END is returning NULL!! "
-            "SIGSEGV is highly expected to follow immediately. "
-            "If you could reproduce, attach your debugger here, "
-            "and look at the passed string."
-        );
+        rb_debug_rstring_null_ptr("RSTRING_END");
     }
 
     return &buf.as.heap.ptr[buf.as.heap.len];

--- a/internal.h
+++ b/internal.h
@@ -95,8 +95,8 @@ RUBY_SYMBOL_EXPORT_END
 
 // same as rp, but add message header
 #define rp_m(msg, obj) do { \
-    fprintf(stderr, "%s", (msg)); \
-    rb_obj_info_dump((VALUE)obj); \
+    fputs((msg), stderr); \
+    rb_obj_info_dump((VALUE)(obj)); \
 } while (0)
 
 // `ruby_debug_breakpoint()` does nothing,

--- a/ractor_core.h
+++ b/ractor_core.h
@@ -237,9 +237,11 @@ rb_ractor_sleeper_thread_num(rb_ractor_t *r)
 static inline void
 rb_ractor_thread_switch(rb_ractor_t *cr, rb_thread_t *th)
 {
-  if (cr->threads.running_ec != th->ec) {
-        if (0) fprintf(stderr, "rb_ractor_thread_switch ec:%p->%p\n",
-                       (void *)cr->threads.running_ec, (void *)th->ec);
+    if (cr->threads.running_ec != th->ec) {
+        if (0) {
+            ruby_debug_printf("rb_ractor_thread_switch ec:%p->%p\n",
+                              (void *)cr->threads.running_ec, (void *)th->ec);
+        }
     }
     else {
         return;
@@ -268,8 +270,10 @@ rb_ractor_set_current_ec(rb_ractor_t *cr, rb_execution_context_t *ec)
 #endif
 
     if (cr->threads.running_ec != ec) {
-        if (0) fprintf(stderr, "rb_ractor_set_current_ec ec:%p->%p\n",
-                       (void *)cr->threads.running_ec, (void *)ec);
+        if (0) {
+            ruby_debug_printf("rb_ractor_set_current_ec ec:%p->%p\n",
+                              (void *)cr->threads.running_ec, (void *)ec);
+        }
     }
     else {
         VM_ASSERT(0); // should be different

--- a/string.c
+++ b/string.c
@@ -223,6 +223,16 @@ rb_str_make_independent(VALUE str)
     }
 }
 
+void
+rb_debug_rstring_null_ptr(const char *func)
+{
+    fprintf(stderr, "%s is returning NULL!! "
+            "SIGSEGV is highly expected to follow immediately. "
+            "If you could reproduce, attach your debugger here, "
+            "and look at the passed string.",
+	    func);
+}
+
 /* symbols for [up|down|swap]case/capitalize options */
 static VALUE sym_ascii, sym_turkic, sym_lithuanian, sym_fold;
 

--- a/vm.c
+++ b/vm.c
@@ -315,10 +315,10 @@ rb_vm_cref_new_toplevel(void)
 static void
 vm_cref_dump(const char *mesg, const rb_cref_t *cref)
 {
-    fprintf(stderr, "vm_cref_dump: %s (%p)\n", mesg, (void *)cref);
+    ruby_debug_printf("vm_cref_dump: %s (%p)\n", mesg, (void *)cref);
 
     while (cref) {
-	fprintf(stderr, "= cref| klass: %s\n", RSTRING_PTR(rb_class_path(CREF_CLASS(cref))));
+	ruby_debug_printf("= cref| klass: %s\n", RSTRING_PTR(rb_class_path(CREF_CLASS(cref))));
 	cref = CREF_NEXT(cref);
     }
 }
@@ -686,15 +686,15 @@ static VALUE check_env_value(const rb_env_t *env);
 static int
 check_env(const rb_env_t *env)
 {
-    fprintf(stderr, "---\n");
-    fprintf(stderr, "envptr: %p\n", (void *)&env->ep[0]);
-    fprintf(stderr, "envval: %10p ", (void *)env->ep[1]);
+    fputs("---\n", stderr);
+    ruby_debug_printf("envptr: %p\n", (void *)&env->ep[0]);
+    ruby_debug_printf("envval: %10p ", (void *)env->ep[1]);
     dp(env->ep[1]);
-    fprintf(stderr, "ep:    %10p\n", (void *)env->ep);
+    ruby_debug_printf("ep:    %10p\n", (void *)env->ep);
     if (rb_vm_env_prev_env(env)) {
-	fprintf(stderr, ">>\n");
+	fputs(">>\n", stderr);
 	check_env_value(rb_vm_env_prev_env(env));
-	fprintf(stderr, "<<\n");
+	fputs("<<\n", stderr);
     }
     return 1;
 }
@@ -2719,7 +2719,7 @@ get_param(const char *name, size_t default_value, size_t min_value)
 	}
 	result = (size_t)(((val -1 + RUBY_VM_SIZE_ALIGN) / RUBY_VM_SIZE_ALIGN) * RUBY_VM_SIZE_ALIGN);
     }
-    if (0) fprintf(stderr, "%s: %"PRIuSIZE"\n", name, result); /* debug print */
+    if (0) ruby_debug_printf("%s: %"PRIuSIZE"\n", name, result); /* debug print */
 
     return result;
 }
@@ -3706,7 +3706,7 @@ Init_BareVM(void)
     rb_vm_t * vm = ruby_mimmalloc(sizeof(*vm));
     rb_thread_t * th = ruby_mimmalloc(sizeof(*th));
     if (!vm || !th) {
-	fprintf(stderr, "[FATAL] failed to allocate memory\n");
+	fputs("[FATAL] failed to allocate memory\n", stderr);
 	exit(EXIT_FAILURE);
     }
     MEMZERO(th, rb_thread_t, 1);

--- a/vm_args.c
+++ b/vm_args.c
@@ -701,7 +701,7 @@ setup_parameters_complex(rb_execution_context_t * const ec, const rb_iseq_t * co
     {
 	int i;
 	for (i=0; i<iseq->body->param.size; i++) {
-	    fprintf(stderr, "local[%d] = %p\n", i, (void *)locals[i]);
+	    ruby_debug_printf("local[%d] = %p\n", i, (void *)locals[i]);
 	}
     }
 #endif

--- a/vm_callinfo.h
+++ b/vm_callinfo.h
@@ -168,8 +168,8 @@ static inline void
 vm_ci_dump(const struct rb_callinfo *ci)
 {
     if (vm_ci_packed_p(ci)) {
-        fprintf(stderr, "packed_ci ID:%s flag:%x argc:%u\n",
-                rb_id2name(vm_ci_mid(ci)), vm_ci_flag(ci), vm_ci_argc(ci));
+        ruby_debug_printf("packed_ci ID:%s flag:%x argc:%u\n",
+                          rb_id2name(vm_ci_mid(ci)), vm_ci_flag(ci), vm_ci_argc(ci));
     }
     else {
         rp(ci);
@@ -204,7 +204,7 @@ vm_ci_new_(ID mid, unsigned int flag, unsigned int argc, const struct rb_callinf
 #endif
 
     const bool debug = 0;
-    if (debug) fprintf(stderr, "%s:%d ", file, line);
+    if (debug) ruby_debug_printf("%s:%d ", file, line);
 
     // TODO: dedup
     const struct rb_callinfo *ci = (const struct rb_callinfo *)

--- a/vm_exec.h
+++ b/vm_exec.h
@@ -37,8 +37,8 @@ typedef rb_iseq_t *ISEQ;
 #define DEBUG_END_INSN()
 #endif
 
-#define throwdebug if(0)printf
-/* #define throwdebug printf */
+#define throwdebug if(0)ruby_debug_printf
+/* #define throwdebug ruby_debug_printf */
 
 #ifndef USE_INSNS_COUNTER
 #define USE_INSNS_COUNTER 0
@@ -74,11 +74,13 @@ error !
 #define LABEL_PTR(x) RB_GNUC_EXTENSION(&&LABEL(x))
 
 #define INSN_ENTRY_SIG(insn) \
-  if (0) fprintf(stderr, "exec: %s@(%"PRIdPTRDIFF", %"PRIdPTRDIFF")@%s:%u\n", #insn, \
-                 (reg_pc - reg_cfp->iseq->body->iseq_encoded), \
-                 (reg_cfp->pc - reg_cfp->iseq->body->iseq_encoded), \
-                 RSTRING_PTR(rb_iseq_path(reg_cfp->iseq)), \
-                 rb_iseq_line_no(reg_cfp->iseq, reg_pc - reg_cfp->iseq->body->iseq_encoded)); \
+  if (0) { \
+      ruby_debug_printf("exec: %s@(%"PRIdPTRDIFF", %"PRIdPTRDIFF")@%s:%u\n", #insn, \
+                        (reg_pc - reg_cfp->iseq->body->iseq_encoded), \
+                        (reg_cfp->pc - reg_cfp->iseq->body->iseq_encoded), \
+                        RSTRING_PTR(rb_iseq_path(reg_cfp->iseq)), \
+                        rb_iseq_line_no(reg_cfp->iseq, reg_pc - reg_cfp->iseq->body->iseq_encoded)); \
+  } \
   if (USE_INSNS_COUNTER) vm_insns_counter_count_insn(BIN(insn));
 
 #define INSN_DISPATCH_SIG(insn)

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -275,7 +275,7 @@ rb_vm_check_canary(const rb_execution_context_t *ec, VALUE *sp)
     /* rb_bug() is not capable of outputting this large contents.  It
        is designed to run form a SIGSEGV handler, which tends to be
        very restricted. */
-    fprintf(stderr,
+    ruby_debug_printf(
         "We are killing the stack canary set by %s, "
         "at %s@pc=%"PRIdPTR"\n"
         "watch out the C stack trace.\n"
@@ -1690,7 +1690,7 @@ vm_ccs_push(VALUE klass, struct rb_class_cc_entries *ccs, const struct rb_callin
 void
 rb_vm_ccs_dump(struct rb_class_cc_entries *ccs)
 {
-    fprintf(stderr, "ccs:%p (%d,%d)\n", (void *)ccs, ccs->len, ccs->capa);
+    ruby_debug_printf("ccs:%p (%d,%d)\n", (void *)ccs, ccs->len, ccs->capa);
     for (int i=0; i<ccs->len; i++) {
         vm_ci_dump(ccs->entries[i].ci);
         rp(ccs->entries[i].cc);
@@ -2164,7 +2164,7 @@ vm_base_ptr(const rb_control_frame_t *cfp)
 	}
 #if VM_DEBUG_BP_CHECK
 	if (bp != cfp->bp_check) {
-	    fprintf(stderr, "bp_check: %ld, bp: %ld\n",
+	    ruby_debug_printf("bp_check: %ld, bp: %ld\n",
 		    (long)(cfp->bp_check - GET_EC()->vm_stack),
 		    (long)(bp - GET_EC()->vm_stack));
 	    rb_bug("vm_base_ptr: unreachable");
@@ -2328,7 +2328,7 @@ static void
 opt_hist_show_results_at_exit(void)
 {
     for (int i=0; i<OPT_HIST_MAX; i++) {
-        fprintf(stderr, "opt_hist\t%d\t%d\n", i, opt_hist[i]);
+        ruby_debug_printf("opt_hist\t%d\t%d\n", i, opt_hist[i]);
     }
 }
 #endif
@@ -5428,12 +5428,12 @@ vm_trace(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp)
             rb_hook_list_t *global_hooks = rb_ec_ractor_hooks(ec);
 
             if (0) {
-                fprintf(stderr, "vm_trace>>%4d (%4x) - %s:%d %s\n",
-                        (int)pos,
-                        (int)pc_events,
-                        RSTRING_PTR(rb_iseq_path(iseq)),
-                        (int)rb_iseq_line_no(iseq, pos),
-                        RSTRING_PTR(rb_iseq_label(iseq)));
+                ruby_debug_printf("vm_trace>>%4d (%4x) - %s:%d %s\n",
+                                  (int)pos,
+                                  (int)pc_events,
+                                  RSTRING_PTR(rb_iseq_path(iseq)),
+                                  (int)rb_iseq_line_no(iseq, pos),
+                                  RSTRING_PTR(rb_iseq_label(iseq)));
             }
             VM_ASSERT(reg_cfp->pc == pc);
             VM_ASSERT(pc_events != 0);
@@ -5666,12 +5666,11 @@ static VALUE
 vm_invoke_builtin_delegate(rb_execution_context_t *ec, rb_control_frame_t *cfp, const struct rb_builtin_function *bf, unsigned int start_index)
 {
     if (0) { // debug print
-        fprintf(stderr, "vm_invoke_builtin_delegate: passing -> ");
+        fputs("vm_invoke_builtin_delegate: passing -> ", stderr);
         for (int i=0; i<bf->argc; i++) {
-            fprintf(stderr, ":%s ", rb_id2name(cfp->iseq->body->local_table[i+start_index]));
+            ruby_debug_printf(":%s ", rb_id2name(cfp->iseq->body->local_table[i+start_index]));
         }
-        fprintf(stderr, "\n");
-        fprintf(stderr, "%s %s(%d):%p\n", RUBY_FUNCTION_NAME_STRING, bf->name, bf->argc, bf->func_ptr);
+        ruby_debug_printf("\n" "%s %s(%d):%p\n", RUBY_FUNCTION_NAME_STRING, bf->name, bf->argc, bf->func_ptr);
     }
 
     if (bf->argc == 0) {


### PR DESCRIPTION
Linking `printf` family functions makes mjit objects to link unnecessary code.