### PR TITLE
Preserve the encoding of the argument in IndexError [Bug #18160]

### DIFF
--- a/re.c
+++ b/re.c
@@ -1159,6 +1159,13 @@ name_to_backref_error(VALUE name)
 	     name);
 }
 
+static void
+backref_number_check(struct re_registers *regs, int i)
+{
+    if (i < 0 || regs->num_regs <= i)
+	rb_raise(rb_eIndexError, "index %d out of matches", i);
+}
+
 static int
 match_backref_number(VALUE match, VALUE backref)
 {
@@ -1217,8 +1224,7 @@ match_offset(VALUE match, VALUE n)
     struct re_registers *regs = RMATCH_REGS(match);
 
     match_check(match);
-    if (i < 0 || regs->num_regs <= i)
-	rb_raise(rb_eIndexError, "index %d out of matches", i);
+    backref_number_check(regs, i);
 
     if (BEG(i) < 0)
 	return rb_assoc_new(Qnil, Qnil);
@@ -1253,8 +1259,7 @@ match_begin(VALUE match, VALUE n)
     struct re_registers *regs = RMATCH_REGS(match);
 
     match_check(match);
-    if (i < 0 || regs->num_regs <= i)
-	rb_raise(rb_eIndexError, "index %d out of matches", i);
+    backref_number_check(regs, i);
 
     if (BEG(i) < 0)
 	return Qnil;
@@ -1288,8 +1293,7 @@ match_end(VALUE match, VALUE n)
     struct re_registers *regs = RMATCH_REGS(match);
 
     match_check(match);
-    if (i < 0 || regs->num_regs <= i)
-	rb_raise(rb_eIndexError, "index %d out of matches", i);
+    backref_number_check(regs, i);
 
     if (BEG(i) < 0)
 	return Qnil;

--- a/test/ruby/test_regexp.rb
+++ b/test/ruby/test_regexp.rb
@@ -712,11 +712,16 @@ class TestRegexp < Test::Unit::TestCase
     test = proc {|&blk| "abc".sub("a", ""); blk.call($~) }
 
     bug10877 = '[ruby-core:68209] [Bug #10877]'
+    bug18160 = '[Bug #18160]'
     test.call {|m| assert_raise_with_message(IndexError, /foo/, bug10877) {m["foo"]} }
     key = "\u{3042}"
     [Encoding::UTF_8, Encoding::Shift_JIS, Encoding::EUC_JP].each do |enc|
       idx = key.encode(enc)
-      test.call {|m| assert_raise_with_message(IndexError, /#{idx}/, bug10877) {m[idx]} }
+      pat = /#{idx}/
+      test.call {|m| assert_raise_with_message(IndexError, pat, bug10877) {m[idx]} }
+      test.call {|m| assert_raise_with_message(IndexError, pat, bug18160) {m.offset(idx)} }
+      test.call {|m| assert_raise_with_message(IndexError, pat, bug18160) {m.begin(idx)} }
+      test.call {|m| assert_raise_with_message(IndexError, pat, bug18160) {m.end(idx)} }
     end
     test.call {|m| assert_equal(/a/, m.regexp) }
     test.call {|m| assert_equal("abc", m.string) }


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/18160