### PR TITLE
Remove unneeded ruby_reset_leap_second_info function declaration

### DIFF
--- a/time.c
+++ b/time.c
@@ -674,7 +674,6 @@ static int leap_year_p(long y);
 static VALUE tm_from_time(VALUE klass, VALUE time);
 
 bool ruby_tz_uptodate_p;
-void ruby_reset_leap_second_info(void);
 
 void
 ruby_reset_timezone(void)


### PR DESCRIPTION
`ruby_reset_leap_second_info` declaration alredy define in `internal/time.h`, and included in `time.c`.
So, remove this declaration in `time.c`
