### PR TITLE
Adds mixed hash value and value omission tests

### DIFF
--- a/test/ruby/test_keyword.rb
+++ b/test/ruby/test_keyword.rb
@@ -4357,6 +4357,7 @@ class TestKeywordArgumentsSymProcRefinements < Test::Unit::TestCase
     x = 1
     y = 2
     assert_equal({x: 1, y: 2}, f.call(x:, y:))
+    assert_equal({x: 1, y: 2, z: 3}, f.call(x:, y:, z: 3))
     assert_equal({one: 1, two: 2}, f.call(one:, two:))
   end
 

--- a/test/ruby/test_literal.rb
+++ b/test/ruby/test_literal.rb
@@ -510,6 +510,7 @@ class TestRubyLiteral < Test::Unit::TestCase
     x = 1
     y = 2
     assert_equal({x: 1, y: 2}, {x:, y:})
+    assert_equal({x: 1, y: 2, z: 3}, {x:, y:, z: 3})
     assert_equal({one: 1, two: 2}, {one:, two:})
     assert_syntax_error('{"#{x}":}', /'\}'/)
   end


### PR DESCRIPTION
Introduces specification tests for mixed values and value omissions for
Hashes and keyword arguments, such as `{ a:, b:, c: 3 }`.

While a minor addition I believe it would be useful to be explicit that mixing is acceptable behavior and expected to be supported.