### PR TITLE
Add doc for `a_call` and `a_return` events of TracePoint

### DIFF
--- a/trace_point.rb
+++ b/trace_point.rb
@@ -41,6 +41,8 @@
 # +:raise+:: raise an exception
 # +:b_call+:: event hook at block entry
 # +:b_return+:: event hook at block ending
+# +:a_call+:: event hook at all calls (+call+, +b_call+, and +c_call+)
+# +:a_return+:: event hook at all returns (+return+, +b_return+, and +c_return+)
 # +:thread_begin+:: event hook at thread beginning
 # +:thread_end+:: event hook at thread ending
 # +:fiber_switch+:: event hook at fiber switch


### PR DESCRIPTION
Ruby 2.1 added `a_call` and `a_return` events of TracePoint but they have no documentation.
This patch adds a doc for them.

I think the feature is useful so the documentation will be useful also. 
I was confused when I read debug gem code. https://github.com/ruby/debug/blob/9cdbfbf868ebf3ab167a7f76da7f2f7c7bb34f66/lib/debug/tracer.rb#L120 The documentation will avoid confusion.
