### PR TITLE
[Bug #18173] Update loaded_features_index

### DIFF
--- a/load.c
+++ b/load.c
@@ -598,6 +598,7 @@ rb_provide_feature(VALUE feature)
     }
     rb_str_freeze(feature);
 
+    get_loaded_features_index();
     rb_ary_push(features, rb_fstring(feature));
     features_index_add(feature, INT2FIX(RARRAY_LEN(features)-1));
     reset_loaded_features_snapshot();

--- a/test/ruby/test_require.rb
+++ b/test/ruby/test_require.rb
@@ -839,6 +839,23 @@ class TestRequire < Test::Unit::TestCase
     }
   end
 
+  def test_provide_in_required_file
+    paths, loaded = $:.dup, $".dup
+    Dir.mktmpdir do |tmp|
+      provide = File.realdirpath("provide.rb", tmp)
+      File.write(File.join(tmp, "target.rb"), "raise __FILE__\n")
+      File.write(provide, '$" << '"'target.rb'\n")
+      $:.replace([tmp])
+      assert(require("provide"))
+      assert(!require("target"))
+      assert_equal($".pop, provide)
+      assert_equal($".pop, "target.rb")
+    end
+  ensure
+    $:.replace(paths)
+    $".replace(loaded)
+  end
+
   if defined?($LOAD_PATH.resolve_feature_path)
     def test_resolve_feature_path
       paths, loaded = $:.dup, $".dup


### PR DESCRIPTION
If $LOADED_FEATURES is changed in the just required file, also the index table needs to be updated before loaded_features_snapshot is reset.
If the snapshot is reset without updating the table, the name of the added feature will not be found.