### PR TITLE
Refactor rb_class_new_instance function

### DIFF
--- a/object.c
+++ b/object.c
@@ -1995,13 +1995,7 @@ rb_class_new_instance_kw(int argc, const VALUE *argv, VALUE klass, int kw_splat)
 VALUE
 rb_class_new_instance(int argc, const VALUE *argv, VALUE klass)
 {
-    VALUE obj;
-    Check_Type(klass, T_CLASS);
-
-    obj = rb_class_alloc(klass);
-    rb_obj_call_init_kw(obj, argc, argv, RB_NO_KEYWORDS);
-
-    return obj;
+    return rb_class_new_instance_kw(argc, argv, klass, RB_NO_KEYWORDS);
 }
 
 /**


### PR DESCRIPTION
In `object.c`, `rb_class_new_instance` and `rb_class_new_instance_kw` has similar code.
Replace and Using `rb_class_new_instance_kw` in `rb_class_new_instance` function to refactor.