### PR TITLE
Add WB_PROTECTED to mutexes

### DIFF
--- a/thread_sync.c
+++ b/thread_sync.c
@@ -125,7 +125,7 @@ mutex_memsize(const void *ptr)
 static const rb_data_type_t mutex_data_type = {
     "mutex",
     {mutex_mark, mutex_free, mutex_memsize,},
-    0, 0, RUBY_TYPED_FREE_IMMEDIATELY
+    0, 0, RUBY_TYPED_WB_PROTECTED | RUBY_TYPED_FREE_IMMEDIATELY
 };
 
 static rb_mutex_t *


### PR DESCRIPTION
mutex_mark [is NULL](https://github.com/ruby/ruby/blob/126719b98ddd73ccb3f77cc1a3dbc3a322e0d22a/thread_sync.c#L90), so we don't have any references to mark. This means we should safely be able to mark Mutex as `WB_PROTECTED` without changing anything else.

Large Rails apps can have a lot of Mutexes which stick around for the entire process due to using `Concurrent::Map` from `concurrent-ruby`. Setting them as `WB_PROTECTED` means we don't need to do extra work re-checking them every minor GC.

### Benchmark

``` ruby
mutexes = 50_000.times.map { Mutex.new }
3.times { GC.start }

GC::Profiler.enable
500_000.times { String.new }
GC::Profiler.report
```

**Before**

```
GC 41 invokes.
Index    Invoke Time(sec)       Use Size(byte)     Total Size(byte)         Total Object                    GC Time(ms)
    1               0.021              2270480              2879360                71984         0.63729400000000357984
    2               0.023              2270520              2879360                71984         0.50372400000000405740
    3               0.025              2270480              2879360                71984         0.50454600000000848770
    4               0.027              2270480              2879360                71984         0.52775099999999297573
    5               0.028              2270480              2879360                71984         0.49205299999999574379
    6               0.030              2270480              2879360                71984         0.52542599999999550775
    7               0.032              2270480              2879360                71984         0.49352399999998824986
    8               0.034              2270480              2879360                71984         0.51327499999998660307
    9               0.035              2270480              2879360                71984         0.48903799999999025827
   10               0.037              2270480              2879360                71984         0.52496199999999682007
   11               0.039              2270480              2879360                71984         0.48780600000000728933
   12               0.041              2270480              2879360                71984         0.48754399999999947779
   13               0.042              2270480              2879360                71984         0.49092900000000799787
   14               0.044              2270480              2879360                71984         0.48755400000000115313
   15               0.046              2270480              2879360                71984         0.48736200000001200783
   16               0.048              2270480              2879360                71984         0.48696300000000691810
   17               0.049              2270480              2879360                71984         0.48770700000001776520
   18               0.051              2270480              2879360                71984         0.48745300000001962060
   19               0.053              2270480              2879360                71984         0.48747499999998722409
   20               0.054              2270480              2879360                71984         0.48739399999998128665
   21               0.056              2270480              2879360                71984         0.48763500000001402945
   22               0.058              2270480              2879360                71984         0.48719700000001558982
   23               0.060              2270480              2879360                71984         0.49530899999999933314
   24               0.061              2270480              2879360                71984         0.48419700000000565066
   25               0.063              2270480              2879360                71984         0.48892700000000011151
   26               0.065              2270480              2879360                71984         0.48660499999998718668
   27               0.067              2270480              2879360                71984         0.49016300000001566950
   28               0.068              2270480              2879360                71984         0.48415699999999894931
   29               0.070              2270480              2879360                71984         0.49572900000000030829
   30               0.072              2270480              2879360                71984         0.49280299999998611327
   31               0.073              2270480              2879360                71984         0.48846599999997908359
   32               0.075              2270480              2879360                71984         0.48782499999998341078
   33               0.077                    0                    0                    0         0.39117299999999466387
```

**After**

```
GC 41 invokes.
Index    Invoke Time(sec)       Use Size(byte)     Total Size(byte)         Total Object                    GC Time(ms)
    1               0.027              2270480              2879360                71984         0.30234999999999290221
    2               0.029              2270520              2879360                71984         0.17038799999999701407
    3               0.030              2270480              2879360                71984         0.15540899999999524539
    4               0.031              2270480              2879360                71984         0.15580099999999708071
    5               0.033              2270480              2879360                71984         0.15317700000001127636
    6               0.034              2270480              2879360                71984         0.15595200000000086771
    7               0.036              2270480              2879360                71984         0.15268700000000551276
    8               0.037              2270480              2879360                71984         0.15201399999999892776
    9               0.038              2270480              2879360                71984         0.15368899999999852124
   10               0.040              2270480              2879360                71984         0.15216500000000271475
   11               0.041              2270480              2879360                71984         0.15708300000000230412
   12               0.042              2270480              2879360                71984         0.15250700000001699008
   13               0.044              2270480              2879360                71984         0.15192400000000466642
   14               0.045              2270480              2879360                71984         0.15207700000000046181
   15               0.047              2270480              2879360                71984         0.15259600000001177778
   16               0.048              2270480              2879360                71984         0.15282900000000709806
   17               0.049              2270480              2879360                71984         0.15287599999999623712
   18               0.051              2270480              2879360                71984         0.15679600000000071258
   19               0.052              2270480              2879360                71984         0.15451800000000626145
   20               0.054              2270480              2879360                71984         0.15294899999999944651
   21               0.055              2270480              2879360                71984         0.15339799999999903513
   22               0.056              2270480              2879360                71984         0.15254500000001086635
   23               0.058              2270480              2879360                71984         0.15234499999999123743
   24               0.059              2270480              2879360                71984         0.15228700000000094938
   25               0.060              2270480              2879360                71984         0.15206500000000677808
   26               0.062              2270480              2879360                71984         0.15379100000001422188
   27               0.063              2270480              2879360                71984         0.15275500000001829282
   28               0.065              2270480              2879360                71984         0.15282700000000815077
   29               0.066              2270480              2879360                71984         0.15272600000000580156
   30               0.067              2270480              2879360                71984         0.15265699999998660896
   31               0.069              2270480              2879360                71984         0.15277600000000723934
   32               0.070              2270480              2879360                71984         0.15283499999999006214
   33               0.072                    0                    0                    0         0.05587499999999689937
```