### PR TITLE
Fix malloc_increase is not correctly calculated

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -8881,7 +8881,7 @@ ready_to_gc(rb_objspace_t *objspace)
 }
 
 static void
-gc_reset_malloc_info(rb_objspace_t *objspace)
+gc_reset_malloc_info(rb_objspace_t *objspace, bool full_mark)
 {
     gc_prof_set_malloc_info(objspace);
     {
@@ -8915,7 +8915,7 @@ gc_reset_malloc_info(rb_objspace_t *objspace)
 
     /* reset oldmalloc info */
 #if RGENGC_ESTIMATE_OLDMALLOC
-    if (!is_full_marking(objspace)) {
+    if (!full_mark) {
 	if (objspace->rgengc.oldmalloc_increase > objspace->rgengc.oldmalloc_increase_limit) {
 	    objspace->rgengc.need_major_gc |= GPR_FLAG_MAJOR_BY_OLDMALLOC;
 	    objspace->rgengc.oldmalloc_increase_limit =
@@ -9071,7 +9071,7 @@ gc_start(rb_objspace_t *objspace, unsigned int reason)
     objspace->profile.total_allocated_objects_at_gc_start = objspace->total_allocated_objects;
     objspace->profile.heap_used_at_gc_start = heap_allocated_pages;
     gc_prof_setup_new_record(objspace, reason);
-    gc_reset_malloc_info(objspace);
+    gc_reset_malloc_info(objspace, do_full_mark);
     rb_transient_heap_start_marking(do_full_mark);
 
     gc_event_hook(objspace, RUBY_INTERNAL_EVENT_GC_START, 0 /* TODO: pass minor/immediate flag? */);


### PR DESCRIPTION
Commit 123eeb1c1a904923754ce65148dbef045b56e083 added incremental GC which moved resetting malloc_increase, oldmalloc_increase to before marking. However, during_minor_gc is not set until gc_marks_start. So the value will be from the last GC run, rather than the current one. Before the incremental GC commit, this code was in gc_before_sweep which ran before sweep (after marking) so the value during_minor_gc was correct.

If we run the following script:

```ruby
arr = []

# Ensure that all objects are promoted to old by triggering GC
3.times do
  GC.start
end

before = GC.stat(:malloc_increase_bytes)
before_old = GC.stat(:oldmalloc_increase_bytes)

# Expand arr so that it reallocates
100.times do
  arr << 0
end

after = GC.stat(:malloc_increase_bytes)
after_old = GC.stat(:oldmalloc_increase_bytes)

# Minor GC
GC.start(full_mark: false)

after_gc = GC.stat(:malloc_increase_bytes)
after_gc_old = GC.stat(:oldmalloc_increase_bytes)

puts before, after, after_gc
puts before_old, after_old, after_gc_old
```

Before this patch we get this output:

```
1064
2096
0
1064
2096
0
```

After this patch we get this output:

```
272
1304
0
272
1304
1320
```

A minor GC should not reset `oldmalloc_increase_bytes`.