### PR TITLE
[DOC] Fix broken links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 Please see the [official issue tracker], [doc/contributing.rdoc] and wiki [HowToContribute].
 
 [official issue tracker]: https://bugs.ruby-lang.org
-[doc/contributing.rdoc]: doc/contributing.rdoc
+[doc/contributing.rdoc]: contributing.rdoc
 [HowToContribute]: https://bugs.ruby-lang.org/projects/ruby/wiki/HowToContribute

--- a/array.c
+++ b/array.c
@@ -3423,7 +3423,7 @@ static VALUE rb_ary_bsearch_index(VALUE ary);
  *
  *  Returns an element from +self+ selected by a binary search.
  *
- *  See {Binary Searching}[doc/bsearch_rdoc.html].
+ *  See {Binary Searching}[rdoc-ref:bsearch.rdoc].
  */
 
 static VALUE
@@ -7628,7 +7628,7 @@ rb_ary_one_p(int argc, VALUE *argv, VALUE ary)
  *  Finds and returns the object in nested objects
  *  that is specified by +index+ and +identifiers+.
  *  The nested objects may be instances of various classes.
- *  See {Dig Methods}[rdoc-ref:doc/dig_methods.rdoc].
+ *  See {Dig Methods}[rdoc-ref:dig_methods.rdoc].
  *
  *  Examples:
  *    a = [:foo, [:bar, :baz, [:bat, :bam]]]

--- a/doc/NEWS-3.0.0.md
+++ b/doc/NEWS-3.0.0.md
@@ -86,7 +86,7 @@ Note that each entry is kept to a minimum, see links for details.
   `# frozen-string-literal: true` is used. [[Feature #17104]]
 
 * Magic comment `shareable_constant_value` added to freeze constants.
-  See {Magic Comments}[rdoc-ref:doc/syntax/comments.rdoc@Magic+Comments] for more details.
+  See {Magic Comments}[rdoc-ref:syntax/comments.rdoc@Magic+Comments] for more details.
   [[Feature #17273]]
 
 * A {static analysis}[rdoc-label:label-Static+analysis] foundation is

--- a/hash.c
+++ b/hash.c
@@ -4534,7 +4534,7 @@ rb_hash_any_p(int argc, VALUE *argv, VALUE hash)
  *  Finds and returns the object in nested objects
  *  that is specified by +key+ and +identifiers+.
  *  The nested objects may be instances of various classes.
- *  See {Dig Methods}[rdoc-ref:doc/dig_methods.rdoc].
+ *  See {Dig Methods}[rdoc-ref:dig_methods.rdoc].
  *
  *  Nested Hashes:
  *    h = {foo: {bar: {baz: 2}}}

--- a/lib/ostruct.rb
+++ b/lib/ostruct.rb
@@ -308,7 +308,7 @@ class OpenStruct
   # Finds and returns the object in nested objects
   # that is specified by +name+ and +identifiers+.
   # The nested objects may be instances of various classes.
-  # See {Dig Methods}[rdoc-ref:doc/dig_methods.rdoc].
+  # See {Dig Methods}[rdoc-ref:dig_methods.rdoc].
   #
   # Examples:
   #   require "ostruct"

--- a/ractor.rb
+++ b/ractor.rb
@@ -195,7 +195,7 @@
 #     # can not access instance variables of classes/modules from non-main Ractors (RuntimeError)
 #
 # See also the description of <tt># shareable_constant_value</tt> pragma in
-# {Comments syntax}[rdoc-ref:doc/syntax/comments.rdoc] explanation.
+# {Comments syntax}[rdoc-ref:syntax/comments.rdoc] explanation.
 #
 # == Ractors vs threads
 #
@@ -223,7 +223,7 @@
 #
 # == Reference
 #
-# See {Ractor design doc}[rdoc-ref:doc/ractor.md] for more details.
+# See {Ractor design doc}[rdoc-ref:ractor.md] for more details.
 #
 class Ractor
   #

--- a/range.c
+++ b/range.c
@@ -664,7 +664,7 @@ bsearch_integer_range(VALUE beg, VALUE end, int excl)
  *
  *  Returns an element from +self+ selected by a binary search.
  *
- *  See {Binary Searching}[doc/bsearch_rdoc.html].
+ *  See {Binary Searching}[rdoc-ref:bsearch.rdoc].
  *
  */
 

--- a/struct.c
+++ b/struct.c
@@ -1366,7 +1366,7 @@ rb_struct_size(VALUE s)
  * Finds and returns the object in nested objects
  * that is specified by +key+ and +identifiers+.
  * The nested objects may be instances of various classes.
- * See {Dig Methods}[rdoc-ref:doc/dig_methods.rdoc].
+ * See {Dig Methods}[rdoc-ref:dig_methods.rdoc].
  *
  * Examples:
  *   Foo = Struct.new(:a)


### PR DESCRIPTION
* Remove "doc/" prefix from rdoc references.
* Refer the original .rdoc instead of converted .html.