### PR TITLE
Refactor clear_iclass_method_cache_by_id_for_refinements function

### DIFF
--- a/vm_method.c
+++ b/vm_method.c
@@ -236,8 +236,7 @@ static void
 clear_iclass_method_cache_by_id_for_refinements(VALUE klass, VALUE d)
 {
     if (RB_TYPE_P(klass, T_ICLASS)) {
-        ID mid = (ID)d;
-        clear_method_cache_by_id_in_class(klass, mid);
+        clear_iclass_method_cache_by_id(klass, d);
     }
 }
 


### PR DESCRIPTION
`clear_iclass_method_cache_by_id_for_refinements ` and `clear_iclass_method_cache_by_id` has similar code in `vm_method.c`.
So, this pull request was changed to use `clear_iclass_method_cache_by_id` in `clear_iclass_method_cache_by_id_for_refinements` function.