### PR TITLE
marshal.c: don't call the proc with partially initialized objects.

### DIFF
--- a/marshal.c
+++ b/marshal.c
@@ -1137,6 +1137,7 @@ struct load_arg {
     long offset;
     st_table *symbols;
     st_table *data;
+    st_table *partial_objects;
     VALUE proc;
     st_table *compat_tbl;
 };
@@ -1163,6 +1164,7 @@ mark_load_arg(void *ptr)
         return;
     rb_mark_tbl(p->symbols);
     rb_mark_tbl(p->data);
+    rb_mark_tbl(p->partial_objects);
     rb_mark_hash(p->compat_tbl);
 }
 
@@ -1507,6 +1509,7 @@ r_entry0(VALUE v, st_index_t num, struct load_arg *arg)
         st_lookup(arg->compat_tbl, v, &real_obj);
     }
     st_insert(arg->data, num, real_obj);
+    st_insert(arg->partial_objects, (st_data_t)real_obj, Qtrue);
     return v;
 }
 
@@ -1537,10 +1540,15 @@ r_post_proc(VALUE v, struct load_arg *arg)
 }
 
 static VALUE
-r_leave(VALUE v, struct load_arg *arg)
+r_leave(VALUE v, struct load_arg *arg, bool partial)
 {
     v = r_fixup_compat(v, arg);
-    v = r_post_proc(v, arg);
+    if (!partial) {
+	st_data_t data;
+	st_data_t key = (st_data_t)v;
+	st_delete(arg->partial_objects, &key, &data);
+	v = r_post_proc(v, arg);
+    }
     return v;
 }
 
@@ -1667,7 +1675,7 @@ append_extmod(VALUE obj, VALUE extmod)
     } while (0)
 
 static VALUE
-r_object0(struct load_arg *arg, int *ivp, VALUE extmod)
+r_object0(struct load_arg *arg, bool partial, int *ivp, VALUE extmod)
 {
     VALUE v = Qnil;
     int type = r_byte(arg);
@@ -1681,18 +1689,18 @@ r_object0(struct load_arg *arg, int *ivp, VALUE extmod)
 	    rb_raise(rb_eArgError, "dump format error (unlinked)");
 	}
 	v = (VALUE)link;
-	v = r_post_proc(v, arg);
+	if (!st_lookup(arg->partial_objects, (st_data_t)v, &link)) {
+	    v = r_post_proc(v, arg);
+	}
 	break;
 
       case TYPE_IVAR:
         {
 	    int ivar = TRUE;
 
-	    v = r_object0(arg, &ivar, extmod);
+	    v = r_object0(arg, true, &ivar, extmod);
 	    if (ivar) r_ivar(v, NULL, arg);
-	    if (RB_TYPE_P(v, T_STRING)) {
-	        v = r_leave(v, arg);
-	    }
+	    v = r_leave(v, arg, partial);
 	}
 	break;
 
@@ -1705,7 +1713,7 @@ r_object0(struct load_arg *arg, int *ivp, VALUE extmod)
 	    if (RB_TYPE_P(m, T_CLASS)) { /* prepended */
 		VALUE c;
 
-		v = r_object0(arg, 0, Qnil);
+		v = r_object0(arg, true, 0, Qnil);
 		c = CLASS_OF(v);
 		if (c != m || FL_TEST(c, FL_SINGLETON)) {
 		    rb_raise(rb_eArgError,
@@ -1722,7 +1730,7 @@ r_object0(struct load_arg *arg, int *ivp, VALUE extmod)
 		must_be_module(m, path);
 		rb_ary_push(extmod, m);
 
-		v = r_object0(arg, 0, extmod);
+		v = r_object0(arg, true, 0, extmod);
 		while (RARRAY_LEN(extmod) > 0) {
 		    m = rb_ary_pop(extmod);
 		    rb_extend_object(v, m);
@@ -1738,7 +1746,7 @@ r_object0(struct load_arg *arg, int *ivp, VALUE extmod)
 	    if (FL_TEST(c, FL_SINGLETON)) {
 		rb_raise(rb_eTypeError, "singleton can't be loaded");
 	    }
-	    v = r_object0(arg, 0, extmod);
+	    v = r_object0(arg, partial, 0, extmod);
 	    if (rb_special_const_p(v) || RB_TYPE_P(v, T_OBJECT) || RB_TYPE_P(v, T_CLASS)) {
                 goto format_error;
 	    }
@@ -1756,17 +1764,17 @@ r_object0(struct load_arg *arg, int *ivp, VALUE extmod)
 
       case TYPE_NIL:
 	v = Qnil;
-	v = r_leave(v, arg);
+	v = r_leave(v, arg, false);
 	break;
 
       case TYPE_TRUE:
 	v = Qtrue;
-	v = r_leave(v, arg);
+	v = r_leave(v, arg, false);
 	break;
 
       case TYPE_FALSE:
 	v = Qfalse;
-	v = r_leave(v, arg);
+	v = r_leave(v, arg, false);
 	break;
 
       case TYPE_FIXNUM:
@@ -1774,7 +1782,7 @@ r_object0(struct load_arg *arg, int *ivp, VALUE extmod)
 	    long i = r_long(arg);
 	    v = LONG2FIX(i);
 	}
-	v = r_leave(v, arg);
+	v = r_leave(v, arg, false);
 	break;
 
       case TYPE_FLOAT:
@@ -1799,7 +1807,7 @@ r_object0(struct load_arg *arg, int *ivp, VALUE extmod)
 	    }
 	    v = DBL2NUM(d);
 	    v = r_entry(v, arg);
-            v = r_leave(v, arg);
+            v = r_leave(v, arg, false);
 	}
 	break;
 
@@ -1816,15 +1824,13 @@ r_object0(struct load_arg *arg, int *ivp, VALUE extmod)
                 INTEGER_PACK_LITTLE_ENDIAN | (sign == '-' ? INTEGER_PACK_NEGATIVE : 0));
 	    rb_str_resize(data, 0L);
 	    v = r_entry(v, arg);
-            v = r_leave(v, arg);
+            v = r_leave(v, arg, false);
 	}
 	break;
 
       case TYPE_STRING:
 	v = r_entry(r_string(arg), arg);
-	if (!ivp) {
-	    v = r_leave(v, arg);
-	}
+	v = r_leave(v, arg, partial);
 	break;
 
       case TYPE_REGEXP:
@@ -1859,7 +1865,7 @@ r_object0(struct load_arg *arg, int *ivp, VALUE extmod)
 		rb_str_set_len(str, dst - ptr);
 	    }
 	    v = r_entry0(rb_reg_new_str(str, options), idx, arg);
-	    v = r_leave(v, arg);
+	    v = r_leave(v, arg, partial);
 	}
 	break;
 
@@ -1874,7 +1880,7 @@ r_object0(struct load_arg *arg, int *ivp, VALUE extmod)
 		rb_ary_push(v, r_object(arg));
 		arg->readable--;
 	    }
-            v = r_leave(v, arg);
+            v = r_leave(v, arg, partial);
 	    arg->readable++;
 	}
 	break;
@@ -1897,7 +1903,7 @@ r_object0(struct load_arg *arg, int *ivp, VALUE extmod)
 	    if (type == TYPE_HASH_DEF) {
 		RHASH_SET_IFNONE(v, r_object(arg));
 	    }
-            v = r_leave(v, arg);
+            v = r_leave(v, arg, partial);
 	}
 	break;
 
@@ -1949,7 +1955,7 @@ r_object0(struct load_arg *arg, int *ivp, VALUE extmod)
 		}
 	    }
             rb_struct_initialize(v, values);
-            v = r_leave(v, arg);
+            v = r_leave(v, arg, partial);
 	    arg->readable += 2;
 	}
 	break;
@@ -1976,7 +1982,7 @@ r_object0(struct load_arg *arg, int *ivp, VALUE extmod)
 		marshal_compat_t *compat = (marshal_compat_t*)d;
 		v = compat->loader(klass, v);
 	    }
-	    v = r_post_proc(v, arg);
+	    if (!partial) v = r_post_proc(v, arg);
 	}
         break;
 
@@ -2018,7 +2024,7 @@ r_object0(struct load_arg *arg, int *ivp, VALUE extmod)
 	    }
 	    v = r_entry0(v, idx, arg);
 	    r_ivar(v, NULL, arg);
-	    v = r_leave(v, arg);
+	    v = r_leave(v, arg, partial);
 	}
 	break;
 
@@ -2039,9 +2045,9 @@ r_object0(struct load_arg *arg, int *ivp, VALUE extmod)
 			 "class %"PRIsVALUE" needs to have instance method `_load_data'",
 			 name);
 	    }
-	    r = r_object0(arg, 0, extmod);
+	    r = r_object0(arg, partial, 0, extmod);
 	    load_funcall(arg, v, s_load_data, 1, &r);
-	    v = r_leave(v, arg);
+	    v = r_leave(v, arg, partial);
 	}
 	break;
 
@@ -2052,7 +2058,7 @@ r_object0(struct load_arg *arg, int *ivp, VALUE extmod)
 	    v = rb_path_to_class(str);
 	    prohibit_ivar("class/module", str);
 	    v = r_entry(v, arg);
-            v = r_leave(v, arg);
+            v = r_leave(v, arg, partial);
 	}
 	break;
 
@@ -2063,7 +2069,7 @@ r_object0(struct load_arg *arg, int *ivp, VALUE extmod)
 	    v = path2class(str);
 	    prohibit_ivar("class", str);
 	    v = r_entry(v, arg);
-            v = r_leave(v, arg);
+            v = r_leave(v, arg, partial);
 	}
 	break;
 
@@ -2074,7 +2080,7 @@ r_object0(struct load_arg *arg, int *ivp, VALUE extmod)
 	    v = path2module(str);
 	    prohibit_ivar("module", str);
 	    v = r_entry(v, arg);
-            v = r_leave(v, arg);
+            v = r_leave(v, arg, partial);
 	}
 	break;
 
@@ -2087,7 +2093,7 @@ r_object0(struct load_arg *arg, int *ivp, VALUE extmod)
 	    v = r_symreal(arg, 0);
 	}
 	v = rb_str_intern(v);
-	v = r_leave(v, arg);
+	v = r_leave(v, arg, partial);
 	break;
 
       case TYPE_SYMLINK:
@@ -2109,7 +2115,7 @@ r_object0(struct load_arg *arg, int *ivp, VALUE extmod)
 static VALUE
 r_object(struct load_arg *arg)
 {
-    return r_object0(arg, 0, Qnil);
+    return r_object0(arg, false, 0, Qnil);
 }
 
 static void
@@ -2127,6 +2133,8 @@ clear_load_arg(struct load_arg *arg)
     arg->symbols = 0;
     st_free_table(arg->data);
     arg->data = 0;
+    st_free_table(arg->partial_objects);
+    arg->partial_objects = 0;
     if (arg->compat_tbl) {
 	st_free_table(arg->compat_tbl);
 	arg->compat_tbl = 0;
@@ -2181,6 +2189,7 @@ rb_marshal_load_with_proc(VALUE port, VALUE proc)
     arg->offset = 0;
     arg->symbols = st_init_numtable();
     arg->data    = rb_init_identtable();
+    arg->partial_objects = rb_init_identtable();
     arg->compat_tbl = 0;
     arg->proc = 0;
     arg->readable = 0;

--- a/test/ruby/test_marshal.rb
+++ b/test/ruby/test_marshal.rb
@@ -840,4 +840,16 @@ class TestMarshal < Test::Unit::TestCase
       assert_nil(e2.backtrace_locations) # temporal
     end
   end
+
+  class TestMarshalFreezeProc < Test::Unit::TestCase
+    include MarshalTestLib
+
+    def encode(o)
+      Marshal.dump(o)
+    end
+
+    def decode(s)
+      Marshal.load(s, :freeze.to_proc)
+    end
+  end
 end


### PR DESCRIPTION
Fix: https://bugs.ruby-lang.org/issues/18141
Followup: https://github.com/ruby/ruby/pull/4797

For cyclic objects, it requires to keep a `st_table` of the partially initialized objects which is unfortunate, but I couldn't find any other solution.

Many of the related tests were broken because they often used a pattern such as:

```ruby
arr = []
Marshal.load('...', proc { |o| arr << o; o })
assert_equal [...], arr
```

The issue with the above pattern is that the objects were yielded before they were fully mutated, so to write a proper test we need to keep a copy rather than the actual object.