### PR TITLE
.cirrus.yml: Add Cirrus CI for Arm64 tests.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,62 @@
+# This CI is used to test Arm cases. We can set the maximum 16 tasks.
+# The entire testing design is inspired from .github/workflows/compilers.yml.
+
+# By default, Cirrus mounts an empty volume to `/tmp`
+# which triggers all sorts of warnings like "system temporary path is world-writable: /tmp".
+# Lets workaround it by specifying a custom volume mount point.
+env:
+  CIRRUS_VOLUME: /cirrus-ci-volume
+
+task:
+  name: Arm64 Graviton2 / $CC
+  arm_container:
+    # We use the arm64 images at http://ghcr.io/ruby/ruby-ci-image .
+    image: ghcr.io/ruby/ruby-ci-image:$CC
+    # Define the used cpu core in each matrix task. We can use total 16 cpu
+    # cores in entire matrix. [cpu] = [total cpu: 16] / [number of tasks]
+    cpu: 8
+    # We can request maximum 4 GB per cpu.
+    # [memory per task] = [memory per cpu: 4 GB] * [cpu]
+    memory: 32G
+  env:
+    CIRRUS_CLONE_DEPTH: 50
+    optflags: '-O1'
+    debugflags: '-ggdb3'
+    RUBY_PREFIX: /tmp/ruby-prefix
+    RUBY_DEBUG: ci rgengc
+    RUBY_TESTOPTS: >-
+      -q
+      --color=always
+      --tty=no
+    matrix:
+      CC: clang-12
+      CC: gcc-11
+  id_script: id
+  set_env_script:
+    # Set `GNUMAKEFLAGS`, because the flags are GNU make specific. Note using
+    # the `make` environment variable used in compilers.yml causes some rubygems
+    # tests to fail.
+    # https://github.com/rubygems/rubygems/issues/4921
+    - echo "GNUMAKEFLAGS=-s -j$((1 + $CIRRUS_CPU))" >> $CIRRUS_ENV
+  print_env_script:
+    - echo "GNUMAKEFLAGS=$GNUMAKEFLAGS"
+  # Arm containers are executed in AWS's EKS, and it's not yet supporting IPv6
+  # See https://github.com/aws/containers-roadmap/issues/835
+  disable_ipv6_script: sudo ./tool/disable_ipv6.sh
+  autogen_script: ./autogen.sh
+  configure_script: >-
+    ./configure -C
+    --enable-debug-env
+    --disable-install-doc
+    --with-ext=-test-/cxxanyargs,+
+    --prefix="$RUBY_PREFIX"
+  make_extract-extlibs_script: make extract-extlibs
+  make_incs_script: make incs
+  make_script: make
+  make_leaked-globals_script: make leaked-globals
+  make_test_script: make test
+  make_install_script: make install
+  install_gems_for_test_script: $RUBY_PREFIX/bin/gem install --no-doc timezone tzinfo
+  make_test-tool_script: make test-tool
+  make_test-all_script: make test-all
+  make_test-spec_script: make test-spec

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Actions Status: Windows](https://github.com/ruby/ruby/workflows/Windows/badge.svg)](https://github.com/ruby/ruby/actions?query=workflow%3A"Windows")
 [![AppVeyor status](https://ci.appveyor.com/api/projects/status/0sy8rrxut4o0k960/branch/master?svg=true)](https://ci.appveyor.com/project/ruby/ruby/branch/master)
 [![Travis Status](https://app.travis-ci.com/ruby/ruby.svg?branch=master)](https://app.travis-ci.com/ruby/ruby)
+[![Cirrus Status](https://api.cirrus-ci.com/github/ruby/ruby.svg)](https://cirrus-ci.com/github/ruby/ruby/master)
 
 # What's Ruby
 

--- a/tool/disable_ipv6.sh
+++ b/tool/disable_ipv6.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -ex
+sysctl -w net.ipv6.conf.all.disable_ipv6=1
+sysctl -w net.ipv6.conf.default.disable_ipv6=1
+sysctl -w net.ipv6.conf.lo.disable_ipv6=1
+
+cat /etc/hosts
+ruby -e "hosts = File.read('/etc/hosts').sub(/^::1\s*localhost.*$/, ''); File.write('/etc/hosts', hosts)"
+cat /etc/hosts


### PR DESCRIPTION
This PR is based on https://github.com/ruby/ruby/pull/4772  to enable Cirrus CI to test Arm cases. Initially there are 2 cases, the latest clang 12 and gcc 11 available on our CI image: http://ghcr.io/ruby/ruby-ci-image .

I would like to use the Cirrus Ci to cover some cases on Arm. We can add maximum 16 cases. The entire testing design is inspired from .github/workflows/compilers.yml .

Note

* As I found an issue in rubygems tests with the environment variable `make`, I am using `make_cmd` for now, You can see https://github.com/rubygems/rubygems/issues/4921 for detail.
* I added the badge image to the README. The updated README is [here](https://github.com/junaruga/ruby/blob/wip/cirrus-ci-arm/README.md).
* This CI is also executed at the timing of push on forked repo like other CIs. It's good to test on your forked repo without sending PR.
* The `tool/disable_ipv6.sh` is what we used in ruby/ruby in the past. We reused the script again.



