### PR TITLE
.github/workflows/compilers.yml: Use `GNUMAKEFLAGS`.

### DIFF
--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -181,7 +181,7 @@ jobs:
       - name: setenv
         run: |
           echo "${{ matrix.entry.key }}=${{ matrix.entry.value }}" >> $GITHUB_ENV
-          echo "make=make -sj$((1 + $(nproc --all)))" >> $GITHUB_ENV
+          echo "GNUMAKEFLAGS=-sj$((1 + $(nproc --all)))" >> $GITHUB_ENV
       - uses: actions/checkout@v2
         with:
           path: src
@@ -192,20 +192,20 @@ jobs:
           ../src/configure -C ${default_configure} ${append_configure}
           ${{ matrix.entry.key == 'crosshost' && '--host="${crosshost}"' || '--with-gcc="${default_cc} ${append_cc}"' }}
           ${{ matrix.entry.shared || '--enable-shared' }}
-      - run: $make extract-extlibs
-      - run: $make incs
-      - run: $make
-      - run: $make leaked-globals
-      - run: $make test
-      - run: $make install
+      - run: make extract-extlibs
+      - run: make incs
+      - run: make
+      - run: make leaked-globals
+      - run: make test
+      - run: make install
         if: ${{ matrix.entry.check }}
       - run: /usr/local/bin/gem install --no-doc timezone tzinfo
         if: ${{ matrix.entry.check }}
-      - run: $make test-tool
+      - run: make test-tool
         if: ${{ matrix.entry.check }}
-      - run: $make test-all TESTS='-- ruby -ext-'
+      - run: make test-all TESTS='-- ruby -ext-'
         if: ${{ matrix.entry.check }}
-      - run: $make test-spec
+      - run: make test-spec
         if: ${{ matrix.entry.check }}
 
       - uses: k0kubun/action-slack@v2.0.0


### PR DESCRIPTION
This PR comes from https://github.com/ruby/ruby/pull/4875#issuecomment-924609257 .

Because the `make` environment variable causes some rubygems tests to fail.
And to align with `.cirrus.yml`.

I also tested with `check: true` on my forked repo, as currently there is no test enabling `check: true`. And here is the [CI result](https://github.com/junaruga/ruby/runs/3672627511?check_suite_focus=true).

```
-          - { key: default_cc, name: gcc-11,    value: gcc-11,    container: gcc-11 }
+          - { key: default_cc, name: gcc-11,    value: gcc-11,    container: gcc-11, check: true }
...
-          - { key: default_cc, name: clang-14,  value: clang-14,  container: clang-14 }
+          - { key: default_cc, name: clang-14,  value: clang-14,  container: clang-14, check: true }
```

