### PR TITLE
Make the uninitialized module code handle modules that include other modules

### DIFF
--- a/test/ruby/test_module.rb
+++ b/test/ruby/test_module.rb
@@ -446,6 +446,29 @@ class TestModule < Test::Unit::TestCase
     end
   end
 
+  def test_initialize_subclass_with_included_module
+    mod = Class.new(Module) do
+      const_set(:InstanceMethods, Module.new)
+      define_method(:initialize) do |aaa:|
+        include mod::InstanceMethods
+      end
+    end
+    foo = Class.new do
+      def initialize(key:)
+      end
+    end
+
+    bar = Class.new(foo) do
+      include mod.new(aaa: 1)
+    end
+
+    ancestors = bar.ancestors
+    assert_equal(bar, ancestors.shift)
+    assert_instance_of(mod, ancestors.shift)
+    assert_equal([mod::InstanceMethods, foo, Object], ancestors[0..2])
+    assert_instance_of(bar, bar.new(key: 1))
+  end
+
   def test_dup
     OtherSetup.call
 


### PR DESCRIPTION
We cannot check RCLASS_SUPER directly in the module, we need to
walk the entire super pointer chain to handle included modules.
However, we don't want to do this for refinement modules, as those
are expected to have rb_cBasicObject at the end of the super chain.

Fixes [Bug #18182]
Fixes [Bug #18185]