### PR TITLE
[DOC] Fix `TracePoint.trace` format [ci skip]

### DIFF
--- a/trace_point.rb
+++ b/trace_point.rb
@@ -118,13 +118,11 @@ class TracePoint
     Primitive.tracepoint_stat_s
   end
 
-  # Document-method: trace
-  #
   # call-seq:
-  #	TracePoint.trace(*events) { |obj| block }	-> obj
+  #	   TracePoint.trace(*events) { |obj| block }	-> obj
   #
-  #  A convenience method for TracePoint.new, that activates the trace
-  #  automatically.
+  # A convenience method for TracePoint.new, that activates the trace
+  # automatically.
   #
   #	    trace = TracePoint.trace(:call) { |tp| [tp.lineno, tp.event] }
   #	    #=> #<TracePoint:enabled>


### PR DESCRIPTION
Fixes https://ruby-doc.org/core-3.0.2/TracePoint.html#method-c-trace

![image](https://user-images.githubusercontent.com/11378424/134776956-e14d69d1-4066-4f68-9dd5-b1bc50769072.png)

---

Contributing guidelines are saying _Do as others do_, however, on documentation it seems like there is no consensus for indentation.. I've done what some did, choosing the option i felt was clearer 😅.