### PR TITLE
Introduce `RBIMPL_NONNULL_ARG` macro

### DIFF
--- a/enumerator.c
+++ b/enumerator.c
@@ -3446,11 +3446,9 @@ rb_arithmetic_sequence_extract(VALUE obj, rb_arithmetic_sequence_components_t *c
 VALUE
 rb_arithmetic_sequence_beg_len_step(VALUE obj, long *begp, long *lenp, long *stepp, long len, int err)
 {
-#if !RBIMPL_HAS_ATTRIBUTE(nonnull)
-    RUBY_ASSERT(begp != NULL);
-    RUBY_ASSERT(lenp != NULL);
-    RUBY_ASSERT(stepp != NULL);
-#endif
+    RBIMPL_NONNULL_ARG(begp);
+    RBIMPL_NONNULL_ARG(lenp);
+    RBIMPL_NONNULL_ARG(stepp);
 
     rb_arithmetic_sequence_components_t aseq;
     if (!rb_arithmetic_sequence_extract(obj, &aseq)) {

--- a/gc.c
+++ b/gc.c
@@ -2767,20 +2767,13 @@ rb_data_object_zalloc(VALUE klass, size_t size, RUBY_DATA_FUNC dmark, RUBY_DATA_
     return obj;
 }
 
-COMPILER_WARNING_PUSH
-#if __has_warning("-Wnonnull-compare") || GCC_VERSION_SINCE(6, 1, 0)
-COMPILER_WARNING_IGNORED(-Wnonnull-compare)
-#endif
-
 VALUE
 rb_data_typed_object_wrap(VALUE klass, void *datap, const rb_data_type_t *type)
 {
-    RUBY_ASSERT_ALWAYS(type);
+    RBIMPL_NONNULL_ARG(type);
     if (klass) rb_data_object_check(klass);
     return newobj_of(klass, T_DATA, (VALUE)type, (VALUE)1, (VALUE)datap, type->flags & RUBY_FL_WB_PROTECTED, sizeof(RVALUE));
 }
-
-COMPILER_WARNING_POP
 
 VALUE
 rb_data_typed_object_zalloc(VALUE klass, size_t size, const rb_data_type_t *type)

--- a/include/ruby/internal/attr/nonnull.h
+++ b/include/ruby/internal/attr/nonnull.h
@@ -25,8 +25,10 @@
 /** Wraps (or simulates) `__attribute__((nonnull))` */
 #if RBIMPL_HAS_ATTRIBUTE(nonnull)
 # define RBIMPL_ATTR_NONNULL(list) __attribute__((__nonnull__ list))
+# define RBIMPL_NONNULL_ARG(arg) RBIMPL_ASSERT_NOTHING
 #else
 # define RBIMPL_ATTR_NONNULL(list) /* void */
+# define RBIMPL_NONNULL_ARG(arg) RUBY_ASSERT(arg)
 #endif
 
 #endif /* RBIMPL_ATTR_NONNULL_H */


### PR DESCRIPTION
Runtime assertion for the argument declared as non-null.
This macro does nothing if `RBIMPL_ATTR_NONNULL` is effective, otherwise asserts that the argument is non-null.