### PR TITLE
Add printf-style format attribute to oniguruma functions

### DIFF
--- a/regerror.c
+++ b/regerror.c
@@ -312,7 +312,7 @@ onig_error_code_to_str(UChar* s, OnigPosition code, ...)
 
 void
 onig_vsnprintf_with_pattern(UChar buf[], int bufsize, OnigEncoding enc,
-                           UChar* pat, UChar* pat_end, const UChar *fmt, va_list args)
+                           UChar* pat, UChar* pat_end, const char *fmt, va_list args)
 {
   size_t need;
   int n, len;
@@ -376,7 +376,7 @@ onig_vsnprintf_with_pattern(UChar buf[], int bufsize, OnigEncoding enc,
 #if 0 /* unused */
 void
 onig_snprintf_with_pattern(UChar buf[], int bufsize, OnigEncoding enc,
-                           UChar* pat, UChar* pat_end, const UChar *fmt, ...)
+                           UChar* pat, UChar* pat_end, const char *fmt, ...)
 {
   va_list args;
   va_start(args, fmt);

--- a/regint.h
+++ b/regint.h
@@ -903,9 +903,13 @@ extern void onig_print_statistics(FILE* f);
 # endif
 #endif
 
+#ifndef PRINTF_ARGS
+#define PRINTF_ARGS(func, fmt, vargs) func
+#endif
+
 extern UChar* onig_error_code_to_format(OnigPosition code);
-extern void onig_vsnprintf_with_pattern(UChar buf[], int bufsize, OnigEncoding enc, UChar* pat, UChar* pat_end, const UChar *fmt, va_list args);
-extern void onig_snprintf_with_pattern(UChar buf[], int bufsize, OnigEncoding enc, UChar* pat, UChar* pat_end, const UChar *fmt, ...);
+PRINTF_ARGS(extern void onig_vsnprintf_with_pattern(UChar buf[], int bufsize, OnigEncoding enc, UChar* pat, UChar* pat_end, const char *fmt, va_list args), 6, 0);
+PRINTF_ARGS(extern void onig_snprintf_with_pattern(UChar buf[], int bufsize, OnigEncoding enc, UChar* pat, UChar* pat_end, const char *fmt, ...), 6, 7);
 extern int  onig_bbuf_init(BBuf* buf, OnigDistance size);
 extern int  onig_compile(regex_t* reg, const UChar* pattern, const UChar* pattern_end, OnigErrorInfo* einfo);
 #ifdef RUBY

--- a/regparse.c
+++ b/regparse.c
@@ -2833,6 +2833,10 @@ fetch_name(OnigCodePoint start_code, UChar** src, UChar* end,
 #endif /* USE_NAMED_GROUP */
 
 
+#ifdef PRINTF_ARGS
+PRINTF_ARGS(static void onig_syntax_warn(ScanEnv *env, const char *fmt, ...), 2, 3);
+#endif
+
 static void
 onig_syntax_warn(ScanEnv *env, const char *fmt, ...)
 {
@@ -2841,7 +2845,7 @@ onig_syntax_warn(ScanEnv *env, const char *fmt, ...)
     va_start(args, fmt);
     onig_vsnprintf_with_pattern(buf, WARN_BUFSIZE, env->enc,
 		env->pattern, env->pattern_end,
-		(const UChar *)fmt, args);
+		fmt, args);
     va_end(args);
 #ifdef RUBY
     if (env->sourcefile == NULL)


### PR DESCRIPTION
Also make the format string compatible with literal strings which are const arrays of "plain" chars.