### PR TITLE
Move some function declaration to internal/io.h

### DIFF
--- a/internal/io.h
+++ b/internal/io.h
@@ -24,6 +24,10 @@ void rb_io_fptr_finalize_internal(void *ptr);
 #define rb_io_fptr_finalize rb_io_fptr_finalize_internal
 VALUE rb_io_popen(VALUE pname, VALUE pmode, VALUE env, VALUE opt);
 
+VALUE rb_io_prep_stdin(void);
+VALUE rb_io_prep_stdout(void);
+VALUE rb_io_prep_stderr(void);
+
 RUBY_SYMBOL_EXPORT_BEGIN
 /* io.c (export) */
 void rb_maygvl_fd_fix_cloexec(int fd);

--- a/thread.c
+++ b/thread.c
@@ -778,11 +778,6 @@ thread_do_start(rb_thread_t *th)
 
 void rb_ec_clear_current_thread_trace_func(const rb_execution_context_t *ec);
 
-// io.c
-VALUE rb_io_prep_stdin(void);
-VALUE rb_io_prep_stdout(void);
-VALUE rb_io_prep_stderr(void);
-
 static int
 thread_start_func_2(rb_thread_t *th, VALUE *stack_start)
 {


### PR DESCRIPTION
In `thread.c` has some function declaration that implimented in io.c .
But, I think better to move these declaration to `internal/io.h`.