### PR TITLE
Refactor rb_add_event_hook function

### DIFF
--- a/vm_trace.c
+++ b/vm_trace.c
@@ -167,8 +167,7 @@ rb_thread_add_event_hook(VALUE thval, rb_event_hook_func_t func, rb_event_flag_t
 void
 rb_add_event_hook(rb_event_hook_func_t func, rb_event_flag_t events, VALUE data)
 {
-    rb_event_hook_t *hook = alloc_event_hook(func, events, data, RUBY_EVENT_HOOK_FLAG_SAFE);
-    connect_event_hook(GET_EC(), hook);
+    rb_add_event_hook2(func, events, data, RUBY_EVENT_HOOK_FLAG_SAFE);
 }
 
 void


### PR DESCRIPTION
`rb_add_event_hook` and `rb_add_event_hook2` has almost similar code.
Using `rb_add_event_hook2` function to `rb_add_event_hook` function to refactor.