### PR TITLE
Needs `AC_PROG_CC`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -218,7 +218,7 @@ rb_test_CXXFLAGS=${CXXFLAGS+yes}
 # BSD's ports and MacPorts prefix GNU binutils with 'g'
 
 dnl Seems necessarily in order to add -std=gnu99 option for gcc 4.9.
-m4_version_prereq([2.70], [], [AC_PROG_CC_C99])
+m4_version_prereq([2.70], [AC_PROG_CC], [AC_PROG_CC_C99])
 
 AC_PROG_CXX
 AC_PROG_CPP


### PR DESCRIPTION
Although `AC_PROG_CC_C99` has been obsolete, `AC_PROG_CC` is not and the latter is necessary not to make C++ compiler mandatory.