### PR TITLE
Fix the encoding of loaded feature names [Bug #18191]

### DIFF
--- a/file.c
+++ b/file.c
@@ -6369,6 +6369,10 @@ is_explicit_relative(const char *path)
 static VALUE
 copy_path_class(VALUE path, VALUE orig)
 {
+    int encidx = rb_enc_get_index(orig);
+    if (encidx == ENCINDEX_ASCII || encidx == ENCINDEX_US_ASCII)
+        encidx = rb_filesystem_encindex();
+    rb_enc_associate_index(path, encidx);
     str_shrink(path);
     RBASIC_SET_CLASS(path, rb_obj_class(orig));
     OBJ_FREEZE(path);

--- a/internal/string.h
+++ b/internal/string.h
@@ -42,6 +42,7 @@ size_t rb_str_memsize(VALUE);
 char *rb_str_to_cstr(VALUE str);
 const char *ruby_escaped_char(int c);
 void rb_str_make_independent(VALUE str);
+int rb_enc_str_coderange_scan(VALUE str, rb_encoding *enc);
 
 static inline bool STR_EMBED_P(VALUE str);
 static inline bool STR_SHARED_P(VALUE str);

--- a/ruby.c
+++ b/ruby.c
@@ -1931,13 +1931,17 @@ process_options(int argc, char **argv, ruby_cmdline_options_t *opt)
     }
     {
         VALUE loaded_features = vm->loaded_features;
+        bool modified = false;
         for (long i = loaded_before_enc; i < RARRAY_LEN(loaded_features); ++i) {
 	    VALUE path = RARRAY_AREF(loaded_features, i);
             if (rb_enc_get(path) == IF_UTF8_PATH(uenc, lenc)) continue;
             path = copy_str(path, IF_UTF8_PATH(uenc, lenc), true);
+            modified = true;
 	    RARRAY_ASET(loaded_features, i, path);
         }
-        rb_get_expanded_load_path();
+        if (modified) {
+            rb_ary_replace(vm->loaded_features_snapshot, loaded_features);
+        }
     }
 
     if (opt->features.mask & COMPILATION_FEATURES) {

--- a/string.c
+++ b/string.c
@@ -725,6 +725,12 @@ enc_coderange_scan(VALUE str, rb_encoding *enc, int encidx)
 }
 
 int
+rb_enc_str_coderange_scan(VALUE str, rb_encoding *enc)
+{
+    return enc_coderange_scan(str, enc, rb_enc_to_index(enc));
+}
+
+int
 rb_enc_str_coderange(VALUE str)
 {
     int cr = ENC_CODERANGE(str);


### PR DESCRIPTION
The feature names loaded from the default load paths should also be in the file system encoding.