### PR TITLE
Use macos-10.15 and macos-11 instead of macos-latest

### DIFF
--- a/.github/workflows/check_dependencies.yml
+++ b/.github/workflows/check_dependencies.yml
@@ -4,7 +4,7 @@ jobs:
   update-deps:
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-latest]
+        os: [ubuntu-20.04, macos-11]
       fail-fast: true
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -2,13 +2,14 @@ name: macOS
 on: [push, pull_request]
 jobs:
   make:
-    runs-on: macos-latest
     strategy:
       matrix:
+        os: [macos-10.15, macos-11]
         test_task: [ "check", "test-bundler-parallel" ] #, "test-bundled-gems" ] matrix tests has unknown issues
       fail-fast: false
     env:
       GITPULLOPTIONS: --no-tags origin ${{github.ref}}
+    runs-on: ${{ matrix.os }}
     steps:
       - run: mkdir build
         working-directory:


### PR DESCRIPTION
https://github.blog/changelog/2021-09-29-github-actions-jobs-running-on-macos-latest-are-now-running-on-macos-big-sur-11/