### PR TITLE
Header on universal

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1283,6 +1283,7 @@ AC_CHECK_HEADERS(utime.h)
 AS_CASE("$target_cpu", [x64|x86_64|i[3-6]86*], [
   AC_CHECK_HEADERS(x86intrin.h)
 ])
+RUBY_UNIVERSAL_CHECK_HEADER([x86_64, i386], x86intrin.h)
 
 AC_ARG_WITH([gmp],
   [AS_HELP_STRING([--without-gmp],

--- a/tool/m4/ruby_define_if.m4
+++ b/tool/m4/ruby_define_if.m4
@@ -1,12 +1,6 @@
 dnl -*- Autoconf -*-
 AC_DEFUN([RUBY_DEFINE_IF], [dnl
-    m4_ifval([$1], [AS_LITERAL_IF([$1], [], [test "X$1" = X || ])cat <<EOH >> confdefs.h
-@%:@if $1
-EOH
-])dnl
+    m4_ifval([$1], [AS_LITERAL_IF([$1], [], [test "X$1" = X || ])printf "@%:@if %s\n" "$1" >>confdefs.h])
 AC_DEFINE_UNQUOTED($2, $3)dnl
-    m4_ifval([$1], [AS_LITERAL_IF([$1], [], [test "X$1" = X || ])cat <<EOH >> confdefs.h
-@%:@endif /* $1 */
-EOH
-])dnl
+    m4_ifval([$1], [AS_LITERAL_IF([$1], [], [test "X$1" = X || ])printf "@%:@endif /* %s */\n" "$1" >>confdefs.h])
 ])dnl

--- a/tool/m4/ruby_universal_arch.m4
+++ b/tool/m4/ruby_universal_arch.m4
@@ -88,3 +88,35 @@ AS_IF([test "x${ARCH_FLAG}" != x], [
 ])
 # RUBY_UNIVERSAL_ARCH end
 ])dnl
+dnl
+AC_DEFUN([RUBY_UNIVERSAL_CHECK_HEADER_COND], [ dnl
+  AC_CACHE_CHECK([for $2 when $1], [$3],
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
+        [AC_INCLUDES_DEFAULT([$6])[
+          @%:@if ]$1[
+          @%:@include <]$2[>
+          @%:@endif]], [[]])],
+      [AS_VAR_SET($3, yes)],
+      [AS_VAR_SET($3, no)]))
+  AS_VAR_IF([$3], [yes], [dnl
+    printf "@%:@if %s\n" "$1" >>confdefs.h
+    AC_DEFINE_UNQUOTED(HAVE_[]AS_TR_CPP($2), 1)dnl
+    printf "@%:@endif\n" >>confdefs.h dnl
+  $4], [$5])
+])dnl
+dnl
+# RUBY_UNIVERSAL_CHECK_HEADER(CPU-LIST, HEADER,
+#                      [ACTION-IF-FOUND], [ACTION-IF-NOT-FOUND],
+#                      [INCLUDES = DEFAULT-INCLUDES])
+AC_DEFUN([RUBY_UNIVERSAL_CHECK_HEADER], [ dnl
+  m4_if([$# dnl
+  ], [0], [], [ dnl
+    m4_foreach([rb_Header], [$1],
+      [AS_CASE([",$target_archs,"], [*,]rb_Header[,*],
+        [RUBY_UNIVERSAL_CHECK_HEADER_COND]([defined(__[]rb_Header[]__)],
+          [$2], [rb_cv_header_[]AS_TR_SH($2)_on_[]AS_TR_SH(rb_Header)],
+          [$3], [$4], [$5])
+        )
+      ])
+  ])dnl
+])dnl


### PR DESCRIPTION
When universal build including x86_64/i386, x86intrin.h isn't checked.