### PR TITLE
Remove unnecessary checks in `Range#each` [Bug #18237]

### DIFF
--- a/range.c
+++ b/range.c
@@ -347,7 +347,6 @@ step_i(VALUE i, VALUE arg)
 static int
 discrete_object_p(VALUE obj)
 {
-    if (rb_obj_is_kind_of(obj, rb_cTime)) return FALSE; /* until Time#succ removed */
     return rb_respond_to(obj, id_succ);
 }
 


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/18237

In commit:7817a438eb1803e7b3358f43bd1f38479badfbdc, the implementation of `Time#succ`, which had been deprecated for 10 years, was finally removed.

During that time, there was an explicit `instance_of?` check in source:range.c#L350 with a comment that the check should be removed once `Time#succ` is removed.

Since `Time#succ` is now gone, this check should be removed.

Note: this should be coordinated with adding a version guard to the corresponding check in ruby/spec as well.