### PR TITLE
Remove extra spaces

### DIFF
--- a/include/ruby/internal/value_type.h
+++ b/include/ruby/internal/value_type.h
@@ -368,7 +368,7 @@ RBIMPL_ATTR_ARTIFICIAL()
  *
  * @internal
  *
- * This  function is  a super-duper  hot  path.  Optimised  targeting modern  C
+ * This function is a super-duper hot path. Optimised targeting modern C
  * compilers and x86_64 architecture.
  */
 static inline bool


### PR DESCRIPTION
`include/internal/value_type.h` has these comments.

```c
 * This  function is  a super-duper  hot  path.  Optimised  targeting modern  C
 * compilers and x86_64 architecture.
```

But, this comments may be has extra spaces(dobule space).
Remove these extra space in this pull request.