### PR TITLE
[DOC] Fix broken link in `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 Please see the [official issue tracker], [doc/contributing.rdoc] and wiki [HowToContribute].
 
 [official issue tracker]: https://bugs.ruby-lang.org
-[doc/contributing.rdoc]: contributing.rdoc
+[doc/contributing.rdoc]: doc/contributing.rdoc
 [HowToContribute]: https://bugs.ruby-lang.org/projects/ruby/wiki/HowToContribute


### PR DESCRIPTION
It appears this was accidentally introduced in a27c274f0476fa270b9e2f5d4f4ec36bd8c0b61a. Currently, clicking on this link 404s. I've updated the reference to point to `doc/contributing.rdoc`. 