### PR TITLE
Fix regression on Solaris after change to use realpath on loaded features

### DIFF
--- a/test/ruby/test_process.rb
+++ b/test/ruby/test_process.rb
@@ -1732,9 +1732,6 @@ class TestProcess < Test::Unit::TestCase
   end
 
   def test_no_curdir
-    if /solaris/i =~ RUBY_PLATFORM
-      skip "Temporary skip to avoid CI failures after commit to use realpath on required files"
-    end
     with_tmpchdir {|d|
       Dir.mkdir("vd")
       status = nil


### PR DESCRIPTION
After the change to use realpath on loaded features, Solaris CI
started failing in test_no_curdir (which tests behavior for running
ruby without a working directory).

I was able to trace the problem to the following call chain:

rb_call_inits->Init_Thread->Init_thread_sync->rb_provide->
get_loaded_features_index->rb_check_realpath->rb_dir_getwd_ospath->
ruby_getcwd

This will throw an exception, but because Ruby hasn't been fully
initialized at the point the exception is thrown, it just exits
with a status of 1.

The bug here is that rb_check_realpath should not raise an
exception, it should return nil.  This bug is hit on Solaris
because Solaris uses the realpath emulation instead of native
realpath, and the realpath emualation raised instead of
returning nil if the mode was RB_REALPATH_CHECK. Use rb_rescue
in the realpath emulation if the mode is RB_REALPATH_CHECK, and
swallow any exceptions raised and return nil.