### PR TITLE
debug.gem 1.2.3

### DIFF
--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -13,4 +13,4 @@ matrix 0.4.2 https://github.com/ruby/matrix
 prime 0.1.2 https://github.com/ruby/prime
 rbs 1.6.2 https://github.com/ruby/rbs
 typeprof 0.15.3 https://github.com/ruby/typeprof
-debug 1.2.2 https://github.com/ruby/debug
+debug 1.2.3 https://github.com/ruby/debug


### PR DESCRIPTION
This version uses tempdir instead of homedir to store UNIX domain
socket.