### PR TITLE
Fix Ractor.make_shareable changing locals for Procs

### DIFF
--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -187,6 +187,28 @@ assert_equal '[:ok, :ok, :ok]', %q{
   }.map(&:take)
 }
 
+# Ractor.make_shareable issue for locals in proc [Bug #18023]
+assert_equal '[:a, :b, :c, :d, :e]', %q{
+  v1, v2, v3, v4, v5 = :a, :b, :c, :d, :e
+  closure = Proc.new { [v1, v2, v3, v4, v5] }
+
+  Ractor.make_shareable(closure).call
+}
+
+# Ractor.make_shareable issue for locals in proc [Bug #18023]
+assert_equal '[:a, :b, :c, :d, :e, :f, :g]', %q{
+  a = :a
+  closure = -> {
+    b, c, d = :b, :c, :d
+    -> {
+      e, f, g = :e, :f, :g
+      -> { [a, b, c, d, e, f, g] }
+    }.call
+  }.call
+
+  Ractor.make_shareable(closure).call
+}
+
 ###
 ###
 # Ractor still has several memory corruption so skip huge number of tests

--- a/vm.c
+++ b/vm.c
@@ -1006,7 +1006,7 @@ env_copy(const VALUE *src_ep, VALUE read_only_variables)
     volatile VALUE prev_env = Qnil;
 
     if (read_only_variables) {
-        for (int i=0; i<RARRAY_LENINT(read_only_variables); i++) {
+        for (int i=RARRAY_LENINT(read_only_variables)-1; i>=0; i--) {
             ID id = SYM2ID(rb_str_intern(RARRAY_AREF(read_only_variables, i)));
 
             for (unsigned int j=0; j<src_env->iseq->body->local_table_size; j++) {


### PR DESCRIPTION
env_copy() uses rb_ary_delete_at() with a loop counting up while
iterating through the list of read only locals. rb_ary_delete_at() can
shift elements in the array to an index lesser than the loop index,
causing locals to be missed and being set to Qfalse in the returned
environment.

Iterate through the list of locals in reverse instead, this way we
always remove the last element and not cause elements in the array to
shift. This ensures that all read only locals are handled.

[Bug #18023]