### PR TITLE
Move some function declarations to internal/hash.h

### DIFF
--- a/internal/hash.h
+++ b/internal/hash.h
@@ -84,6 +84,8 @@ int rb_hash_stlike_foreach_with_replace(VALUE hash, st_foreach_check_callback_fu
 int rb_hash_stlike_update(VALUE hash, st_data_t key, st_update_callback_func *func, st_data_t arg);
 extern st_table *rb_hash_st_table(VALUE hash);
 VALUE rb_ident_hash_new_with_size(st_index_t size);
+VALUE rb_envtbl(void);
+VALUE rb_env_to_hash(void);
 
 static inline unsigned RHASH_AR_TABLE_SIZE_RAW(VALUE h);
 static inline VALUE RHASH_IFNONE(VALUE h);

--- a/process.c
+++ b/process.c
@@ -178,9 +178,6 @@ static void check_uid_switch(void);
 static void check_gid_switch(void);
 static int exec_async_signal_safe(const struct rb_execarg *, char *, size_t);
 
-VALUE rb_envtbl(void);
-VALUE rb_env_to_hash(void);
-
 #if 1
 #define p_uid_from_name p_uid_from_name
 #define p_gid_from_name p_gid_from_name


### PR DESCRIPTION
Some function definition in `process.c`, but these function implimented in `hash.c`.
I think better to move these function definition to `internal/hash.h`.