### PR TITLE
Using RB_BIGNUM_TYPE_P macro

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -199,7 +199,7 @@ obj_any_hash(VALUE obj)
     }
 
     while (!FIXNUM_P(hval)) {
-        if (RB_TYPE_P(hval, T_BIGNUM)) {
+        if (RB_BIGNUM_TYPE_P(hval)) {
             int sign;
             unsigned long ul;
             sign = rb_integer_pack(hval, &ul, 1, sizeof(ul), 0,

--- a/random.c
+++ b/random.c
@@ -1421,7 +1421,7 @@ rand_range(VALUE obj, rb_random_t* rnd, VALUE range)
 		v = ULONG2NUM(r);
 	    }
 	}
-	else if (BUILTIN_TYPE(vmax) == T_BIGNUM && BIGNUM_SIGN(vmax) && !rb_bigzero_p(vmax)) {
+	else if (RB_BIGNUM_TYPE_P(vmax) && BIGNUM_SIGN(vmax) && !rb_bigzero_p(vmax)) {
 	    vmax = excl ? rb_big_minus(vmax, INT2FIX(1)) : rb_big_norm(vmax);
 	    if (FIXNUM_P(vmax)) {
 		excl = 0;


### PR DESCRIPTION
Using `RB_BIGNUM_TYPE_P` macro instead of `RB_TYPE_P`.