### PR TITLE
.travis.yml: Comment out the 2nd arm64 pipeline.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -120,7 +120,8 @@ matrix:
   include:
     # Build every commit (Allowed Failures):
     - <<: *arm32-linux
-    - <<: *arm64-linux
+    # Comment out as the 2nd arm64 pipeline is unstable.
+    # - <<: *arm64-linux
     - <<: *ppc64le-linux
     - <<: *s390x-linux
   allow_failures:


### PR DESCRIPTION
The Travis arm64 pipeline don't start correctly. Here are the logs. It seems the 2nd arm64 pipeline is unstable again in Travis.
https://app.travis-ci.com/github/ruby/ruby/builds/239641693
https://app.travis-ci.com/github/ruby/ruby/builds/239645568
https://app.travis-ci.com/github/ruby/ruby/builds/239650294

As Cirrus CI has arm64 pipelines, it's not a problem to drop the arm64 pipeline in Travis.

