### PR TITLE
Avoid null pointer subtraction in digest/md5

### DIFF
--- a/ext/digest/md5/md5.c
+++ b/ext/digest/md5/md5.c
@@ -225,7 +225,7 @@ md5_process(MD5_CTX *pms, const uint8_t *data /*[64]*/)
     uint32_t xbuf[16];
     const uint32_t *X;
 
-    if (!((data - (const uint8_t *)0) & 3)) {
+    if (!(((uintptr_t)data) & 3)) {
 	/* data are properly aligned */
 	X = (const uint32_t *)data;
     } else {


### PR DESCRIPTION
Fixes warning on Clang 13.

Fixes [Bug #18076]