### PR TITLE
Allow interrupting regexps that backtrack

### DIFF
--- a/regexec.c
+++ b/regexec.c
@@ -3175,6 +3175,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 #endif
 
       MOP_OUT;
+      CHECK_INTERRUPT_IN_MATCH_AT;
       JUMP;
 
     DEFAULT


### PR DESCRIPTION
This checks for interrupts every 1000 backtracks.

Fixes [Bug #14103]