### PR TITLE
Give `*` params a name

### DIFF
--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -1529,4 +1529,13 @@ assert_equal "ok", %q{
   end
 }
 
+assert_equal "ok", %q{
+  def foo((x), (y)); ->{ super }; end
+  begin
+    Ractor.make_shareable(foo([], []))
+  rescue Ractor::IsolationError
+    "ok"
+  end
+}
+
 end # if !ENV['GITHUB_WORKFLOW']

--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -1512,6 +1512,15 @@ assert_equal "ok", %q{
 }
 
 assert_equal "ok", %q{
+  def foo(**); ->{ super }; end
+  begin
+    Ractor.make_shareable(foo)
+  rescue Ractor::IsolationError
+    "ok"
+  end
+}
+
+assert_equal "ok", %q{
   def foo(...); ->{ super }; end
   begin
     Ractor.make_shareable(foo)

--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -1502,4 +1502,22 @@ assert_equal "ok", %q{
   "ok"
 }
 
+assert_equal "ok", %q{
+  def foo(*); ->{ super }; end
+  begin
+    Ractor.make_shareable(foo)
+  rescue Ractor::IsolationError
+    "ok"
+  end
+}
+
+assert_equal "ok", %q{
+  def foo(...); ->{ super }; end
+  begin
+    Ractor.make_shareable(foo)
+  rescue Ractor::IsolationError
+    "ok"
+  end
+}
+
 end # if !ENV['GITHUB_WORKFLOW']

--- a/iseq.c
+++ b/iseq.c
@@ -3157,7 +3157,9 @@ rb_iseq_parameters(const rb_iseq_t *iseq, int is_proc)
         PARAM_TYPE(keyrest);
         if (body->param.flags.has_kwrest &&
             rb_id2str(param = PARAM_ID(keyword->rest_start))) {
-            rb_ary_push(a, ID2SYM(param));
+            if (param_name(PARAM_ID(keyword->rest_start))) {
+                rb_ary_push(a, ID2SYM(param));
+            }
         }
         else if (body->param.flags.ruby2_keywords) {
             rb_ary_push(a, ID2SYM(idPow));

--- a/iseq.c
+++ b/iseq.c
@@ -2702,6 +2702,8 @@ static const rb_data_type_t label_wrapper = {
     0, 0, RUBY_TYPED_FREE_IMMEDIATELY
 };
 
+#define idREST '?'
+
 static VALUE
 iseq_data_to_ary(const rb_iseq_t *iseq)
 {
@@ -2770,7 +2772,7 @@ iseq_data_to_ary(const rb_iseq_t *iseq)
     for (i=0; i<iseq_body->local_table_size; i++) {
 	ID lid = iseq_body->local_table[i];
 	if (lid) {
-	    if (rb_id2str(lid)) {
+	    if (lid != idREST && rb_id2str(lid)) {
 		rb_ary_push(locals, ID2SYM(lid));
 	    }
 	    else { /* hidden variable from id_internal() */
@@ -3054,8 +3056,6 @@ iseq_data_to_ary(const rb_iseq_t *iseq)
     rb_ary_push(val, body);
     return val;
 }
-
-#define idREST '?'
 
 static VALUE
 param_name(ID name)

--- a/iseq.c
+++ b/iseq.c
@@ -3055,6 +3055,19 @@ iseq_data_to_ary(const rb_iseq_t *iseq)
     return val;
 }
 
+#define idREST '?'
+
+static VALUE
+param_name(ID name)
+{
+    if (name == idREST) {
+        return Qfalse;
+    }
+    else {
+        return rb_id2str(name);
+    }
+}
+
 VALUE
 rb_iseq_parameters(const rb_iseq_t *iseq, int is_proc)
 {
@@ -3067,7 +3080,7 @@ rb_iseq_parameters(const rb_iseq_t *iseq, int is_proc)
 #define PARAM_ID(i) body->local_table[(i)]
 #define PARAM(i, type) (		      \
 	PARAM_TYPE(type),		      \
-	rb_id2str(PARAM_ID(i)) ?	      \
+	param_name(PARAM_ID(i)) ?	      \
 	rb_ary_push(a, ID2SYM(PARAM_ID(i))) : \
 	a)
 

--- a/parse.y
+++ b/parse.y
@@ -699,6 +699,7 @@ static void numparam_pop(struct parser_params *p, NODE *prev_inner);
 # define METHOD_NOT '!'
 #endif
 
+#define idREST   '?'
 #define idFWD_REST   '*'
 #ifdef RUBY3_KEYWORDS
 #define idFWD_KWREST idPow /* Use simple "**", as tDSTAR is "**arg" */
@@ -5538,8 +5539,7 @@ f_rest_arg	: restarg_mark tIDENTIFIER
 		| restarg_mark
 		    {
 		    /*%%%*/
-			$$ = internal_id(p);
-			arg_var(p, $$);
+			arg_var(p, idREST);
 		    /*% %*/
 		    /*% ripper: rest_param!(Qnil) %*/
 		    }

--- a/parse.y
+++ b/parse.y
@@ -5465,8 +5465,7 @@ f_kwrest	: kwrest_mark tIDENTIFIER
 		| kwrest_mark
 		    {
 		    /*%%%*/
-			$$ = internal_id(p);
-			arg_var(p, $$);
+			arg_var(p, idREST);
 		    /*% %*/
 		    /*% ripper: kwrest_param!(Qnil) %*/
 		    }

--- a/symbol.c
+++ b/symbol.c
@@ -486,7 +486,8 @@ rb_id_serial_to_id(rb_id_serial_t num)
 {
     if (is_notop_id((ID)num)) {
         VALUE sym = get_id_serial_entry(num, 0, ID_ENTRY_SYM);
-	return SYM2ID(sym);
+	if (sym) return SYM2ID(sym);
+	return ((ID)num << ID_SCOPE_SHIFT) | ID_INTERNAL | ID_STATIC_SYM;
     }
     else {
 	return (ID)num;

--- a/test/ruby/test_iseq.rb
+++ b/test/ruby/test_iseq.rb
@@ -95,6 +95,16 @@ class TestISeq < Test::Unit::TestCase
     assert_equal(42, ISeq.load_from_binary(iseq.to_binary).eval)
   end
 
+  def test_super_with_block
+    iseq = compile(<<~EOF)
+      def touch(*) # :nodoc:
+        foo { super }
+      end
+      42
+    EOF
+    assert_equal(42, ISeq.load_from_binary(iseq.to_binary).eval)
+  end
+
   def test_lambda_with_ractor_roundtrip
     iseq = compile(<<~EOF)
       x = 42

--- a/test/ruby/test_iseq.rb
+++ b/test/ruby/test_iseq.rb
@@ -348,6 +348,14 @@ class TestISeq < Test::Unit::TestCase
     end
   end
 
+  def anon_star(*); end
+
+  def test_anon_param_in_disasm
+    iseq = RubyVM::InstructionSequence.of(method(:anon_star))
+    param_names = iseq.to_a[iseq.to_a.index(:method) + 1]
+    assert_equal [2], param_names
+  end
+
   def strip_lineno(source)
     source.gsub(/^.*?: /, "")
   end

--- a/test/ruby/test_iseq.rb
+++ b/test/ruby/test_iseq.rb
@@ -105,6 +105,16 @@ class TestISeq < Test::Unit::TestCase
     assert_equal(42, ISeq.load_from_binary(iseq.to_binary).eval)
   end
 
+  def test_super_with_block_and_kwrest
+    iseq = compile(<<~EOF)
+      def touch(**) # :nodoc:
+        foo { super }
+      end
+      42
+    EOF
+    assert_equal(42, ISeq.load_from_binary(iseq.to_binary).eval)
+  end
+
   def test_lambda_with_ractor_roundtrip
     iseq = compile(<<~EOF)
       x = 42


### PR DESCRIPTION
This commit gives `*` params a name of `*`.  Before this change, a
method like:

```ruby
def foo(*); ->{ super }; end
```

Would not assign a name to the anonymous `*` parameter.  The problem is
that when Ractors try to scan `getlocal` instructions, it puts the name
of the parameter in to a hash.  Since there is no name, we end up with a
strange exception.  This commit gives it a name so that we get the same
exception for `...` as `*`.

Co-Authored-By: John Hawthorn <john@hawthorn.email>