### PR TITLE
Eliminate some redundant checks on `num` in `newhash`

### DIFF
--- a/insns.def
+++ b/insns.def
@@ -526,10 +526,12 @@ newhash
 {
     RUBY_DTRACE_CREATE_HOOK(HASH, num);
 
-    val = rb_hash_new_with_size(num / 2);
-
     if (num) {
+        val = rb_hash_new_with_size(num / 2);
         rb_hash_bulk_insert(num, STACK_ADDR_FROM_TOP(num), val);
+    }
+    else {
+        val = rb_hash_new();
     }
 }
 


### PR DESCRIPTION
The `newhash` instruction was checking if `num` is greater than 0, but
so is [`rb_hash_new_with_size`](https://github.com/ruby/ruby/blob/82e2443d8b1e3edd2607c78dddf5aac79a13492d/hash.c#L1564)
as well as [`rb_hash_bulk_insert`](https://github.com/ruby/ruby/blob/82e2443d8b1e3edd2607c78dddf5aac79a13492d/hash.c#L4764).

If we know the size is 0 in the instruction, we can just directly call
`rb_hash_new` and only check the size once.  Unfortunately, when num is
greater than 0, it's still checked 3 times.

I'm not sure if this improves any real-world benchmarks, I didn't test.  But this instruction does seem to test `num` many times.