### PR TITLE
Remove unneeded statement in iseq_peephole_optimize function

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -3247,8 +3247,8 @@ iseq_peephole_optimize(rb_iseq_t *iseq, LINK_ELEMENT *list, const int do_tailcal
 	IS_INSN_ID(iobj, duparray) ||
 	IS_INSN_ID(iobj, expandarray) ||
 	IS_INSN_ID(iobj, concatarray) ||
-	IS_INSN_ID(iobj, splatarray) ||
-	0) {
+	IS_INSN_ID(iobj, splatarray)
+	) {
 	/*
 	 *  newarray N
 	 *  splatarray


### PR DESCRIPTION
May be unused statement in `iseq_peephole_optimize` function.