### PR TITLE
Refactor `rb_hash` function

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -223,7 +223,7 @@ rb_any_hash(VALUE a)
 VALUE
 rb_hash(VALUE obj)
 {
-    return LONG2FIX(any_hash(obj, obj_any_hash));
+    return LONG2FIX(rb_any_hash(obj));
 }
 
 


### PR DESCRIPTION
`rb_hash` and `rb_any_hash` has almost same code in `hash.c`.
Using `rb_any_hash` function in `rb_hash` to remove duplicate code.