### PR TITLE
Clarify docs about magic comments placement

### DIFF
--- a/doc/syntax/comments.rdoc
+++ b/doc/syntax/comments.rdoc
@@ -41,8 +41,7 @@ syntax error:
 While comments are typically ignored by Ruby, special "magic comments" contain
 directives that affect how the code is interpreted.
 
-Top-level magic comments must start on the first line, or on the second line if
-the first line looks like <tt>#! shebang line</tt>.
+Top-level magic comments must appear in the first comment section of a file.
 
 NOTE: Magic comments affect only the file in which they appear;
 other files are unaffected.
@@ -74,7 +73,8 @@ regexp literals and <code>__ENCODING__</code>:
 
 Default encoding is UTF-8.
 
-It must appear in the first comment section of a file.
+Top-level magic comments must start on the first line, or on the second line if
+the first line looks like <tt>#! shebang line</tt>.
 
 The word "coding" may be used instead of "encoding".
 


### PR DESCRIPTION
Magic comments like `frozen_string_literal` may appear everywhere
within the first comment section while `encoding` have to be the first
line, or second line after shebang.

## Examples

### `frozen_string_literal` must appear in the first comment section

```ruby
# any comment
# It's OK as long it's not a "token"

# frozen_string_literal: true

p ''.frozen? # => true
```

### `encoding` must be first or second line

```ruby
# another comment or empty line
# encoding: big5

p ''.encoding # => #<Encoding:UTF-8> so not #<Encoding:Big5>
```