### PR TITLE
Correct check for having too many ivars

### DIFF
--- a/variable.c
+++ b/variable.c
@@ -1321,7 +1321,7 @@ iv_index_tbl_extend(struct ivar_update *ivup, ID id, VALUE klass)
         ivup->index = ent->index;
 	return;
     }
-    if (ivup->u.iv_index_tbl->num_entries >= INT_MAX) {
+    if (ivup->u.iv_index_tbl->num_entries >= UINT32_MAX) {
 	rb_raise(rb_eArgError, "too many instance variables");
     }
     ent = ALLOC(struct rb_iv_index_tbl_entry);


### PR DESCRIPTION
f6661f50854e0cdccb03ee516a21ce62adf6c802 changed the type of ivar indices to be
`uint32_t` while the check for having too many indices still used `INT_MAX`. On
platforms where `UINT32_MAX < INT_MAX`, overflow for the index could happen.

Check for too many ivars with `UINT32_MAX` instead.

---

It's a theoretically problem since popular platforms have `INT_MAX < UINT32_MAX`. I guess maybe on SPARC64 `UINT32_MAX < INT_MAX` holds? 😅

For popular platforms this means allowing for more ivars. Going from ~2 billion to ~4 billion. I haven't actually tested what happens when trying to have 4 billion mappings, so leaving this as draft.

Maybe the better thing to do is to hard code some limit and statically assert that `uint32_t` can hold that many.