### PR TITLE
Using NIL_P macro instead of Qnil

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -10139,7 +10139,7 @@ iseq_build_from_ary_body(rb_iseq_t *iseq, LINK_ANCHOR *const anchor,
 			break;
 		      case TS_ISEQ:
 			{
-			    if (op != Qnil) {
+			    if (!NIL_P(op)) {
 				VALUE v = (VALUE)iseq_build_load_iseq(iseq, op);
 				argv[j] = v;
 				RB_OBJ_WRITTEN(iseq, Qundef, v);
@@ -11711,7 +11711,7 @@ static VALUE
 ibf_load_location_str(const struct ibf_load *load, VALUE str_index)
 {
     VALUE str = ibf_load_object(load, str_index);
-    if (str != Qnil) {
+    if (!NIL_P(str)) {
         str = rb_fstring(str);
     }
     return str;

--- a/cont.c
+++ b/cont.c
@@ -1923,7 +1923,7 @@ rb_fiber_s_schedule_kw(int argc, VALUE* argv, int kw_splat)
     VALUE scheduler = th->scheduler;
     VALUE fiber = Qnil;
 
-    if (scheduler != Qnil) {
+    if (!NIL_P(scheduler)) {
         fiber = rb_funcall_passing_block_kw(scheduler, rb_intern("fiber"), argc, argv, kw_splat);
     }
     else {

--- a/gc.c
+++ b/gc.c
@@ -10413,7 +10413,7 @@ gc_info_decode(rb_objspace_t *objspace, const VALUE hash_or_key, const unsigned 
 #define SET(name, attr) \
     if (key == sym_##name) \
         return (attr); \
-    else if (hash != Qnil) \
+    else if (!NIL_P(hash)) \
         rb_hash_aset(hash, sym_##name, (attr));
 
     major_by =
@@ -10586,7 +10586,7 @@ gc_stat_internal(VALUE hash_or_sym)
 #define SET(name, attr) \
     if (key == gc_stat_symbols[gc_stat_sym_##name]) \
 	return attr; \
-    else if (hash != Qnil) \
+    else if (!NIL_P(hash)) \
 	rb_hash_aset(hash, gc_stat_symbols[gc_stat_sym_##name], SIZET2NUM(attr));
 
     SET(count, objspace->profile.count);
@@ -10637,7 +10637,7 @@ gc_stat_internal(VALUE hash_or_sym)
     }
 
 #if defined(RGENGC_PROFILE) && RGENGC_PROFILE >= 2
-    if (hash != Qnil) {
+    if (!NIL_P(hash)) {
 	gc_count_add_each_types(hash, "generated_normal_object_count_types", objspace->profile.generated_normal_object_count_types);
 	gc_count_add_each_types(hash, "generated_shady_object_count_types", objspace->profile.generated_shady_object_count_types);
 	gc_count_add_each_types(hash, "shade_operation_count_types", objspace->profile.shade_operation_count_types);

--- a/hash.c
+++ b/hash.c
@@ -5812,7 +5812,7 @@ env_slice(int argc, VALUE *argv, VALUE _)
     for (i = 0; i < argc; i++) {
         key = argv[i];
         value = rb_f_getenv(Qnil, key);
-        if (value != Qnil)
+        if (!NIL_P(value))
             rb_hash_aset(result, key, value);
     }
 

--- a/io.c
+++ b/io.c
@@ -1273,7 +1273,7 @@ rb_io_wait(VALUE io, VALUE events, VALUE timeout)
 {
     VALUE scheduler = rb_fiber_scheduler_current();
 
-    if (scheduler != Qnil) {
+    if (!NIL_P(scheduler)) {
         return rb_fiber_scheduler_io_wait(scheduler, io, events, timeout);
     }
 
@@ -1283,7 +1283,7 @@ rb_io_wait(VALUE io, VALUE events, VALUE timeout)
     struct timeval tv_storage;
     struct timeval *tv = NULL;
 
-    if (timeout != Qnil) {
+    if (!NIL_P(timeout)) {
         tv_storage = rb_time_interval(timeout);
         tv = &tv_storage;
     }
@@ -1316,7 +1316,7 @@ io_wait_for_single_fd(int fd, int events, struct timeval *timeout)
 {
     VALUE scheduler = rb_fiber_scheduler_current();
 
-    if (scheduler != Qnil) {
+    if (!NIL_P(scheduler)) {
         return RTEST(
             rb_fiber_scheduler_io_wait(scheduler, io_from_fd(fd), RB_INT2NUM(events), rb_fiber_scheduler_make_timeout(timeout))
         );
@@ -1344,7 +1344,7 @@ rb_io_wait_readable(int f)
 #if defined(EWOULDBLOCK) && EWOULDBLOCK != EAGAIN
       case EWOULDBLOCK:
 #endif
-        if (scheduler != Qnil) {
+        if (!NIL_P(scheduler)) {
             return RTEST(
                 rb_fiber_scheduler_io_wait_readable(scheduler, io_from_fd(f))
             );
@@ -1387,7 +1387,7 @@ rb_io_wait_writable(int f)
 #if defined(EWOULDBLOCK) && EWOULDBLOCK != EAGAIN
       case EWOULDBLOCK:
 #endif
-        if (scheduler != Qnil) {
+        if (!NIL_P(scheduler)) {
             return RTEST(
                 rb_fiber_scheduler_io_wait_writable(scheduler, io_from_fd(f))
             );
@@ -1621,7 +1621,7 @@ io_binwrite(VALUE str, const char *ptr, long len, rb_io_t *fptr, int nosync)
     if ((n = len) <= 0) return n;
 
     VALUE scheduler = rb_fiber_scheduler_current();
-    if (scheduler != Qnil) {
+    if (!NIL_P(scheduler)) {
         VALUE result = rb_fiber_scheduler_io_write(scheduler, fptr->self, str, offset, len);
 
         if (result != Qundef) {
@@ -2706,7 +2706,7 @@ static long
 io_fread(VALUE str, long offset, long size, rb_io_t *fptr)
 {
     VALUE scheduler = rb_fiber_scheduler_current();
-    if (scheduler != Qnil) {
+    if (!NIL_P(scheduler)) {
         VALUE result = rb_fiber_scheduler_io_read(scheduler, fptr->self, str, offset, size);
 
         if (result != Qundef) {
@@ -5968,9 +5968,9 @@ rb_io_extract_encoding_option(VALUE opt, rb_encoding **enc_p, rb_encoding **enc2
     if (!NIL_P(opt)) {
 	VALUE v;
 	v = rb_hash_lookup2(opt, sym_encoding, Qnil);
-	if (v != Qnil) encoding = v;
+	if (!NIL_P(v)) encoding = v;
 	v = rb_hash_lookup2(opt, sym_extenc, Qundef);
-	if (v != Qnil) extenc = v;
+	if (!NIL_P(v)) extenc = v;
 	v = rb_hash_lookup2(opt, sym_intenc, Qundef);
 	if (v != Qundef) intenc = v;
     }
@@ -11210,7 +11210,7 @@ static int
 nogvl_wait_for_single_fd(VALUE th, int fd, short events)
 {
     VALUE scheduler = rb_fiber_scheduler_current_for_thread(th);
-    if (scheduler != Qnil) {
+    if (!NIL_P(scheduler)) {
         struct wait_for_single_fd args = {.scheduler = scheduler, .fd = fd, .events = events};
         rb_thread_call_with_gvl(rb_thread_fiber_scheduler_wait_for_single_fd, &args);
         return RTEST(args.result);
@@ -11229,7 +11229,7 @@ static int
 nogvl_wait_for_single_fd(VALUE th, int fd, short events)
 {
     VALUE scheduler = rb_fiber_scheduler_current_for_thread(th);
-    if (scheduler != Qnil) {
+    if (!NIL_P(scheduler)) {
         struct wait_for_single_fd args = {.scheduler = scheduler, .fd = fd, .events = events};
         rb_thread_call_with_gvl(rb_thread_fiber_scheduler_wait_for_single_fd, &args);
         return RTEST(args.result);

--- a/parse.y
+++ b/parse.y
@@ -12903,7 +12903,7 @@ reg_fragment_check(struct parser_params* p, VALUE str, int options)
     VALUE err;
     reg_fragment_setenc(p, str, options);
     err = rb_reg_check_preprocess(str);
-    if (err != Qnil) {
+    if (!NIL_P(err)) {
         err = rb_obj_as_string(err);
         compile_error(p, "%"PRIsVALUE, err);
 	return 0;

--- a/process.c
+++ b/process.c
@@ -5143,7 +5143,7 @@ rb_f_sleep(int argc, VALUE *argv, VALUE _)
     time_t beg = time(0);
     VALUE scheduler = rb_fiber_scheduler_current();
 
-    if (scheduler != Qnil) {
+    if (!NIL_P(scheduler)) {
         rb_fiber_scheduler_kernel_sleepv(scheduler, argc, argv);
     }
     else {

--- a/range.c
+++ b/range.c
@@ -77,7 +77,7 @@ range_modify(VALUE range)
 {
     rb_check_frozen(range);
     /* Ranges are immutable, so that they should be initialized only once. */
-    if (RANGE_EXCL(range) != Qnil) {
+    if (!NIL_P(RANGE_EXCL(range))) {
 	rb_name_err_raise("`initialize' called twice", range, ID2SYM(idInitialize));
     }
 }

--- a/scheduler.c
+++ b/scheduler.c
@@ -88,12 +88,12 @@ rb_fiber_scheduler_set(VALUE scheduler)
     rb_thread_t *thread = GET_THREAD();
     VM_ASSERT(thread);
 
-    if (scheduler != Qnil) {
+    if (!NIL_P(scheduler)) {
         verify_interface(scheduler);
     }
 
     // We invoke Scheduler#close when setting it to something else, to ensure the previous scheduler runs to completion before changing the scheduler. That way, we do not need to consider interactions, e.g., of a Fiber from the previous scheduler with the new scheduler.
-    if (thread->scheduler != Qnil) {
+    if (!NIL_P(thread->scheduler)) {
         rb_fiber_scheduler_close(thread->scheduler);
     }
 

--- a/sprintf.c
+++ b/sprintf.c
@@ -363,7 +363,7 @@ rb_str_format(int argc, const VALUE *argv, VALUE fmt)
 		}
 #endif
 		len = (int)(p - start + 1); /* including parenthesis */
-		if (sym != Qnil) {
+		if (!NIL_P(sym)) {
 		    rb_enc_raise(enc, rb_eArgError, "named%.*s after <%"PRIsVALUE">",
 				 len, start, rb_sym2str(sym));
 		}

--- a/struct.c
+++ b/struct.c
@@ -745,7 +745,7 @@ rb_struct_initialize_m(int argc, const VALUE *argv, VALUE self)
 	arg.self = self;
 	arg.unknown_keywords = Qnil;
 	rb_hash_foreach(argv[0], struct_hash_set_i, (VALUE)&arg);
-	if (arg.unknown_keywords != Qnil) {
+	if (!NIL_P(arg.unknown_keywords)) {
 	    rb_raise(rb_eArgError, "unknown keywords: %s",
 		     RSTRING_PTR(rb_ary_join(arg.unknown_keywords, rb_str_new2(", "))));
 	}

--- a/thread.c
+++ b/thread.c
@@ -547,7 +547,7 @@ rb_threadptr_join_list_wakeup(rb_thread_t *thread)
 
         rb_thread_t *target_thread = join_list->thread;
 
-        if (target_thread->scheduler != Qnil && rb_fiberptr_blocking(join_list->fiber) == 0) {
+        if (!NIL_P(target_thread->scheduler) && rb_fiberptr_blocking(join_list->fiber) == 0) {
             rb_fiber_scheduler_unblock(target_thread->scheduler, target_thread->self, rb_fiberptr_self(join_list->fiber));
         }
         else {
@@ -1184,7 +1184,7 @@ thread_join_sleep(VALUE arg)
     while (!thread_finished(target_th)) {
         VALUE scheduler = rb_fiber_scheduler_current();
 
-        if (scheduler != Qnil) {
+        if (!NIL_P(scheduler)) {
             rb_fiber_scheduler_block(scheduler, target_th->self, p->timeout);
         }
         else if (!limit) {
@@ -1250,7 +1250,7 @@ thread_join(rb_thread_t *target_th, VALUE timeout, rb_hrtime_t *limit)
     thread_debug("thread_join: success (thid: %"PRI_THREAD_ID", status: %s)\n",
                  thread_id_str(target_th), thread_status_name(target_th, TRUE));
 
-    if (target_th->ec->errinfo != Qnil) {
+    if (!NIL_P(target_th->ec->errinfo)) {
         VALUE err = target_th->ec->errinfo;
 
         if (FIXNUM_P(err)) {
@@ -1540,7 +1540,7 @@ static void
 rb_thread_sleep_deadly_allow_spurious_wakeup(VALUE blocker)
 {
     VALUE scheduler = rb_fiber_scheduler_current();
-    if (scheduler != Qnil) {
+    if (!NIL_P(scheduler)) {
         rb_fiber_scheduler_block(scheduler, blocker, Qnil);
     }
     else {
@@ -2019,7 +2019,7 @@ rb_threadptr_pending_interrupt_check_mask(rb_thread_t *th, VALUE err)
 		continue;
 	    }
 
-	    if ((sym = rb_hash_aref(mask, klass)) != Qnil) {
+	    if (!NIL_P(sym = rb_hash_aref(mask, klass))) {
 		if (sym == sym_immediate) {
 		    return INTERRUPT_IMMEDIATE;
 		}
@@ -3458,7 +3458,7 @@ rb_thread_to_s(VALUE thread)
     if (!NIL_P(target_th->name)) {
         rb_str_catf(str, "@%"PRIsVALUE, target_th->name);
     }
-    if ((loc = threadptr_invoke_proc_location(target_th)) != Qnil) {
+    if (!NIL_P(loc = threadptr_invoke_proc_location(target_th))) {
         rb_str_catf(str, " %"PRIsVALUE":%"PRIsVALUE,
                     RARRAY_AREF(loc, 0), RARRAY_AREF(loc, 1));
         rb_gc_force_recycle(loc);
@@ -3861,7 +3861,7 @@ rb_thread_variable_p(VALUE thread, VALUE key)
     }
     locals = rb_thread_local_storage(thread);
 
-    return RBOOL(rb_hash_lookup(locals, rb_to_symbol(key)) != Qnil);
+    return RBOOL(!NIL_P(rb_hash_lookup(locals, rb_to_symbol(key))));
 }
 
 /*
@@ -4687,7 +4687,7 @@ clear_coverage_i(st_data_t key, st_data_t val, st_data_t dummy)
         else {
             int i;
             for (i = 0; i < RARRAY_LEN(lines); i++) {
-                if (RARRAY_AREF(lines, i) != Qnil)
+                if (!NIL_P(RARRAY_AREF(lines, i)))
                     RARRAY_ASET(lines, i, INT2FIX(0));
             }
         }

--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -1672,7 +1672,7 @@ native_set_thread_name(rb_thread_t *th)
     if (!NIL_P(loc = th->name)) {
         SET_CURRENT_THREAD_NAME(RSTRING_PTR(loc));
     }
-    else if ((loc = threadptr_invoke_proc_location(th)) != Qnil) {
+    else if (!NIL_P(loc = threadptr_invoke_proc_location(th))) {
         char *name, *p;
         char buf[THREAD_NAME_MAX];
         size_t len;

--- a/thread_sync.c
+++ b/thread_sync.c
@@ -31,7 +31,7 @@ sync_wakeup(struct list_head *head, long max)
 
         if (cur->th->status != THREAD_KILLED) {
 
-            if (cur->th->scheduler != Qnil && rb_fiberptr_blocking(cur->fiber) == 0) {
+            if (!NIL_P(cur->th->scheduler) && rb_fiberptr_blocking(cur->fiber) == 0) {
                 rb_fiber_scheduler_unblock(cur->th->scheduler, cur->self, rb_fiberptr_self(cur->fiber));
             }
             else {
@@ -295,7 +295,7 @@ do_mutex_lock(VALUE self, int interruptible_p)
 
         while (mutex->fiber != fiber) {
             VALUE scheduler = rb_fiber_scheduler_current();
-            if (scheduler != Qnil) {
+            if (!NIL_P(scheduler)) {
                 struct sync_waiter sync_waiter = {
                     .self = self,
                     .th = th,
@@ -430,7 +430,7 @@ rb_mutex_unlock_th(rb_mutex_t *mutex, rb_thread_t *th, rb_fiber_t *fiber)
         list_for_each_safe(&mutex->waitq, cur, next, node) {
             list_del_init(&cur->node);
 
-            if (cur->th->scheduler != Qnil && rb_fiberptr_blocking(cur->fiber) == 0) {
+            if (!NIL_P(cur->th->scheduler) && rb_fiberptr_blocking(cur->fiber) == 0) {
                 rb_fiber_scheduler_unblock(cur->th->scheduler, cur->self, rb_fiberptr_self(cur->fiber));
                 goto found;
             }
@@ -540,7 +540,7 @@ rb_mutex_sleep(VALUE self, VALUE timeout)
     time_t beg = time(0);
 
     VALUE scheduler = rb_fiber_scheduler_current();
-    if (scheduler != Qnil) {
+    if (!NIL_P(scheduler)) {
         rb_fiber_scheduler_kernel_sleep(scheduler, timeout);
         mutex_lock_uninterruptible(self);
     }

--- a/time.c
+++ b/time.c
@@ -5260,11 +5260,11 @@ time_mload(VALUE time, VALUE str)
 
 
         vtm.subsecx = mulquov(LONG2FIX(nsec), INT2FIX(TIME_SCALE), LONG2FIX(1000000000));
-        if (nano_num != Qnil) {
+        if (!NIL_P(nano_num)) {
             VALUE nano = quov(num_exact(nano_num), num_exact(nano_den));
             vtm.subsecx = addv(vtm.subsecx, mulquov(nano, INT2FIX(TIME_SCALE), LONG2FIX(1000000000)));
         }
-        else if (submicro != Qnil) { /* for Ruby 1.9.1 compatibility */
+        else if (!NIL_P(submicro)) { /* for Ruby 1.9.1 compatibility */
             unsigned char *ptr;
             long len;
             int digit;

--- a/transient_heap.c
+++ b/transient_heap.c
@@ -720,7 +720,7 @@ transient_heap_block_evacuate(struct transient_heap* theap, struct transient_hea
 
         if (TRANSIENT_HEAP_DEBUG >= 3) fprintf(stderr, " * transient_heap_block_evacuate %p %s\n", (void *)header, rb_obj_info(obj));
 
-        if (obj != Qnil) {
+        if (!NIL_P(obj)) {
             RB_DEBUG_COUNTER_INC(theap_evacuate);
 
             switch (BUILTIN_TYPE(obj)) {

--- a/vm.c
+++ b/vm.c
@@ -514,7 +514,7 @@ vm_stat(int argc, VALUE *argv, VALUE self)
 #define SET(name, attr) \
     if (key == sym_##name) \
 	return SERIALT2NUM(attr); \
-    else if (hash != Qnil) \
+    else if (!NIL_P(hash)) \
 	rb_hash_aset(hash, sym_##name, SERIALT2NUM(attr));
 
     SET(global_constant_state, ruby_vm_global_constant_state);

--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -1645,11 +1645,11 @@ rb_profile_frame_method_name(VALUE frame)
 static VALUE
 qualified_method_name(VALUE frame, VALUE method_name)
 {
-    if (method_name != Qnil) {
+    if (!NIL_P(method_name)) {
 	VALUE classpath = rb_profile_frame_classpath(frame);
 	VALUE singleton_p = rb_profile_frame_singleton_method_p(frame);
 
-	if (classpath != Qnil) {
+	if (!NIL_P(classpath)) {
 	    return rb_sprintf("%"PRIsVALUE"%s%"PRIsVALUE,
 			      classpath, singleton_p == Qtrue ? "." : "#", method_name);
 	}

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -4150,7 +4150,7 @@ vm_defined(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, rb_num_t op_
 	}
 	break;
       case DEFINED_REF:{
-	return vm_getspecial(ec, GET_LEP(), Qfalse, FIX2INT(obj)) != Qnil;
+	return !NIL_P(vm_getspecial(ec, GET_LEP(), Qfalse, FIX2INT(obj)));
 	break;
       }
       default:

--- a/vm_method.c
+++ b/vm_method.c
@@ -2052,7 +2052,7 @@ set_method_visibility(VALUE self, int argc, const VALUE *argv, rb_method_visibil
 
     VALUE v;
 
-    if (argc == 1 && (v = rb_check_array_type(argv[0])) != Qnil) {
+    if (argc == 1 && !NIL_P(v = rb_check_array_type(argv[0]))) {
         long j;
 
 	for (j = 0; j < RARRAY_LEN(v); j++) {


### PR DESCRIPTION
Some code has `!= Qnil`, but I think that bette to using `NIL_P` macro.