### PR TITLE
Enhanced RDoc for Numeric

### DIFF
--- a/numeric.c
+++ b/numeric.c
@@ -790,6 +790,10 @@ num_divmod(VALUE x, VALUE y)
  *
  *  Returns the absolute value of +self+.
  *
+ *    12.abs        #=> 12
+ *    (-34.56).abs  #=> 34.56
+ *    -34.56.abs    #=> 34.56
+ *
  *  Numeric#magnitude is an alias for Numeric#abs.
  *
  */


### PR DESCRIPTION
Treated:
- #@-
- #fdiv
- #div
- #abs
- #zero?
- #nonzero?
- #to_int
- #positive?
- #negative?

This will finish up Numeric.

There are a couple of these that are overridden everywhere in the core and standard library.  I have not remarked on this in the doc, but am also not comfortable to show examples using classes that actually don't rely on the method in Numeric.
