### PR TITLE
Do not enable RUBY_DEVEL by RUBY_PATCHLEVEL

### DIFF
--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -154,6 +154,7 @@ jobs:
 
           - { name: NDEBUG,                         env: { cppflags: '-DNDEBUG' } }
           - { name: RUBY_DEBUG,                     env: { cppflags: '-DRUBY_DEBUG' } }
+          - { name: RUBY_DEVEL,                     env: { cppflags: '-DRUBY_DEVEL' } }
 #         - { name: ARRAY_DEBUG,                    env: { cppflags: '-DARRAY_DEBUG' } }
 #         - { name: BIGNUM_DEBUG,                   env: { cppflags: '-DBIGNUM_DEBUG' } }
 #         - { name: CCAN_LIST_DEBUG,                env: { cppflags: '-DCCAN_LIST_DEBUG' } }

--- a/configure.ac
+++ b/configure.ac
@@ -622,8 +622,7 @@ AS_IF([test "$fdeclspec" = yes], [
     RUBY_APPEND_OPTIONS(CXXFLAGS, -fdeclspec)
 ])
 
-AS_CASE([$RUBY_PATCHLEVEL], [-*],
-	[RUBY_DEVEL=yes], [RUBY_DEVEL=no])
+AS_IF([test "x$RUBY_DEVEL" != xyes], [RUBY_DEVEL=no])
 particular_werror_flags=$RUBY_DEVEL
 AC_ARG_ENABLE(werror,
 	AS_HELP_STRING([--disable-werror],


### PR DESCRIPTION
This makes RUBY_DEVEL not enabled automatically.  It still can be
enabled manually.  If enabled manually, it defines USE_RUBY_DEBUG_LOG
to 1 if not defined.

Implements [Feature #17468]