### PR TITLE
Finer-grained constant invalidation

### DIFF
--- a/bootstraptest/test_constant_cache.rb
+++ b/bootstraptest/test_constant_cache.rb
@@ -1,0 +1,120 @@
+# Invalidate when a constant is set.
+assert_equal '2', %q{
+  CONST = 1
+
+  def const
+    CONST
+  end
+
+  const
+
+  CONST = 2
+
+  const
+}
+
+# Invalidate when a constant of the same name is set.
+assert_equal '1', %q{
+  CONST = 1
+
+  def const
+    CONST
+  end
+
+  const
+
+  class Container
+    CONST = 2
+  end
+
+  const
+}
+
+# Invalidate when a constant is removed.
+assert_equal 'missing', %q{
+  class Container
+    CONST = 1
+
+    def const
+      CONST
+    end
+
+    def self.const_missing(name)
+      'missing'
+    end
+
+    new.const
+    remove_const :CONST
+  end
+
+  Container.new.const
+}
+
+# Invalidate when a constant's visibility changes.
+assert_equal 'missing', %q{
+  class Container
+    CONST = 1
+
+    def self.const_missing(name)
+      'missing'
+    end
+  end
+
+  def const
+    Container::CONST
+  end
+
+  const
+
+  Container.private_constant :CONST
+
+  const
+}
+
+# Invalidate when a constant's visibility changes even if the call to the
+# visibility change method fails.
+assert_equal 'missing', %q{
+  class Container
+    CONST1 = 1
+
+    def self.const_missing(name)
+      'missing'
+    end
+  end
+
+  def const1
+    Container::CONST1
+  end
+
+  const1
+
+  begin
+    Container.private_constant :CONST1, :CONST2
+  rescue NameError
+  end
+
+  const1
+}
+
+# Invalidate when a module is included.
+assert_equal 'INCLUDE', %q{
+  module Include
+    CONST = :INCLUDE
+  end
+
+  class Parent
+    CONST = :PARENT
+  end
+
+  class Child < Parent
+    def const
+      CONST
+    end
+
+    new.const
+
+    include Include
+  end
+
+  Child.new.const
+}

--- a/class.c
+++ b/class.c
@@ -1009,11 +1009,18 @@ module_in_super_chain(const VALUE klass, VALUE module)
     return false;
 }
 
+static enum rb_id_table_iterator_result
+clear_constant_cache_i(ID id, VALUE value, void *data)
+{
+    rb_clear_constant_cache(id);
+    return ID_TABLE_CONTINUE;
+}
+
 static int
 do_include_modules_at(const VALUE klass, VALUE c, VALUE module, int search_super, bool check_cyclic)
 {
     VALUE p, iclass, origin_stack = 0;
-    int method_changed = 0, constant_changed = 0, add_subclass;
+    int method_changed = 0, add_subclass;
     long origin_len;
     VALUE klass_origin = RCLASS_ORIGIN(klass);
     VALUE original_klass = klass;
@@ -1106,12 +1113,12 @@ do_include_modules_at(const VALUE klass, VALUE c, VALUE module, int search_super
 	}
 
         tbl = RCLASS_CONST_TBL(module);
-	if (tbl && rb_id_table_size(tbl)) constant_changed = 1;
+	if (tbl && rb_id_table_size(tbl)) {
+        rb_id_table_foreach(tbl, clear_constant_cache_i, (void *) 0);
+    }
       skip:
 	module = RCLASS_SUPER(module);
     }
-
-    if (constant_changed) rb_clear_constant_cache();
 
     return method_changed;
 }

--- a/compile.c
+++ b/compile.c
@@ -8731,7 +8731,7 @@ compile_colon2(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, 
 	    ADD_SEQ(ret, body);
 
 	    if (ISEQ_COMPILE_DATA(iseq)->option->inline_const_cache) {
-		ADD_INSN1(ret, node, opt_setinlinecache, INT2FIX(ic_index));
+		ADD_INSN2(ret, node, opt_setinlinecache, ID2SYM(node->nd_mid), INT2FIX(ic_index));
 		ADD_LABEL(ret, lend);
 	    }
 	}
@@ -8772,7 +8772,7 @@ compile_colon3(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, 
     ADD_INSN1(ret, node, getconstant, ID2SYM(node->nd_mid));
 
     if (ISEQ_COMPILE_DATA(iseq)->option->inline_const_cache) {
-	ADD_INSN1(ret, node, opt_setinlinecache, INT2FIX(ic_index));
+	ADD_INSN2(ret, node, opt_setinlinecache, ID2SYM(node->nd_mid), INT2FIX(ic_index));
 	ADD_LABEL(ret, lend);
     }
 
@@ -9274,7 +9274,7 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const no
             ADD_INSN2(ret, node, opt_getinlinecache, lend, INT2FIX(ic_index));
             ADD_INSN1(ret, node, putobject, Qtrue);
             ADD_INSN1(ret, node, getconstant, ID2SYM(node->nd_vid));
-            ADD_INSN1(ret, node, opt_setinlinecache, INT2FIX(ic_index));
+            ADD_INSN2(ret, node, opt_setinlinecache, ID2SYM(node->nd_vid), INT2FIX(ic_index));
 	    ADD_LABEL(ret, lend);
 	}
 	else {

--- a/gc.c
+++ b/gc.c
@@ -5197,7 +5197,6 @@ gc_compact_finish(rb_objspace_t *objspace, rb_size_pool_t *pool, rb_heap_t *heap
         gc_profile_record *record = gc_prof_record(objspace);
         record->moved_objects = objspace->rcompactor.total_moved - record->moved_objects;
     }
-    rb_clear_constant_cache();
     objspace->flags.during_compacting = FALSE;
 }
 

--- a/include/ruby/internal/intern/vm.h
+++ b/include/ruby/internal/intern/vm.h
@@ -253,15 +253,11 @@ void rb_undef_alloc_func(VALUE klass);
 rb_alloc_func_t rb_get_alloc_func(VALUE klass);
 
 /**
- * Clears  the constant  cache.   Extension libraries  should  not bother  such
- * things.   Just forget  about this  API (or  even, the  presence of  constant
- * cache).
- *
- * @internal
- *
- * Completely no idea why this function is defined in vm_method.c.
+ * Increments the serial on the VM's constant cache for the given ID. This will
+ * make it so that any inline caches that correspond to the given ID will be
+ * refetched the next time the constant is accessed.
  */
-void rb_clear_constant_cache(void);
+void rb_clear_constant_cache(ID name);
 
 /**
  * Resembles `alias`.

--- a/insns.def
+++ b/insns.def
@@ -1024,12 +1024,12 @@ opt_getinlinecache
 /* set inline cache */
 DEFINE_INSN
 opt_setinlinecache
-(IC ic)
+(ID id, IC ic)
 (VALUE val)
 (VALUE val)
 // attr bool leaf = false;
 {
-    vm_ic_update(GET_ISEQ(), ic, val, GET_EP());
+    vm_ic_update(GET_ISEQ(), id, ic, val, GET_EP());
 }
 
 /* run iseq only once */

--- a/test/ruby/test_rubyvm.rb
+++ b/test/ruby/test_rubyvm.rb
@@ -4,11 +4,11 @@ require 'test/unit'
 class TestRubyVM < Test::Unit::TestCase
   def test_stat
     assert_kind_of Hash, RubyVM.stat
-    assert_kind_of Integer, RubyVM.stat[:global_constant_state]
+    assert_kind_of Integer, RubyVM.stat[:class_serial]
 
     RubyVM.stat(stat = {})
     assert_not_empty stat
-    assert_equal stat[:global_constant_state], RubyVM.stat(:global_constant_state)
+    assert_equal stat[:class_serial], RubyVM.stat(:class_serial)
   end
 
   def test_stat_unknown

--- a/tool/ruby_vm/views/_mjit_compile_getinlinecache.erb
+++ b/tool/ruby_vm/views/_mjit_compile_getinlinecache.erb
@@ -15,7 +15,7 @@
     struct iseq_inline_constant_cache_entry *ice = ic->entry;
     if (ice != NULL && ice->ic_serial && !status->compile_info->disable_const_cache) {
 %       # JIT: Inline everything in IC, and cancel the slow path
-        fprintf(f, "    if (vm_inlined_ic_hit_p(0x%"PRIxVALUE", 0x%"PRIxVALUE", (const rb_cref_t *)0x%"PRIxVALUE", %"PRI_SERIALT_PREFIX"u, reg_cfp->ep)) {", ice->flags, ice->value, (VALUE)ice->ic_cref, ice->ic_serial);
+        fprintf(f, "    if (vm_inlined_ic_hit_p(0x%"PRIxVALUE", 0x%"PRIxVALUE", (const rb_cref_t *)0x%"PRIxVALUE", %"PRI_SERIALT_PREFIX"u, (rb_serial_t *)0x%"PRIxVALUE", reg_cfp->ep)) {", ice->flags, ice->value, (VALUE)ice->ic_cref, ice->ic_serial, (VALUE)ice->constant_serial);
         fprintf(f, "        stack[%d] = 0x%"PRIxVALUE";\n", b->stack_size, ice->value);
         fprintf(f, "        goto label_%d;\n", pos + insn_len(insn) + (int)dst);
         fprintf(f, "    }");

--- a/vm_core.h
+++ b/vm_core.h
@@ -225,14 +225,15 @@ struct iseq_inline_constant_cache_entry {
 
     VALUE value;              // v0
     rb_serial_t ic_serial;    // v1
-#if (SIZEOF_SERIAL_T < 2 * SIZEOF_VOIDP)
-    VALUE ic_padding;         // v2
+#if (SIZEOF_SERIAL_T < SIZEOF_VOIDP)
+    VALUE ic_padding;         // v1.5
 #endif
-    const rb_cref_t *ic_cref; // v3
+    const rb_cref_t *ic_cref; // v2
+    rb_serial_t *constant_serial; // v3
 };
 STATIC_ASSERT(sizeof_iseq_inline_constant_cache_entry,
-              (offsetof(struct iseq_inline_constant_cache_entry, ic_cref) +
-	       sizeof(const rb_cref_t *)) <= sizeof(struct RObject));
+              (offsetof(struct iseq_inline_constant_cache_entry, constant_serial) +
+	       sizeof(rb_serial_t *)) <= sizeof(struct RObject));
 
 struct iseq_inline_constant_cache {
     struct iseq_inline_constant_cache_entry *entry;
@@ -682,6 +683,7 @@ typedef struct rb_vm_struct {
     int builtin_inline_index;
 
     struct rb_id_table *negative_cme_table;
+    struct rb_id_table *constant_cache;
 
 #ifndef VM_GLOBAL_CC_CACHE_TABLE_SIZE
 #define VM_GLOBAL_CC_CACHE_TABLE_SIZE 1023
@@ -1713,7 +1715,6 @@ VALUE rb_vm_make_binding(const rb_execution_context_t *ec, const rb_control_fram
 VALUE rb_vm_env_local_variables(const rb_env_t *env);
 const rb_env_t *rb_vm_env_prev_env(const rb_env_t *env);
 const VALUE *rb_binding_add_dynavars(VALUE bindval, rb_binding_t *bind, int dyncount, const ID *dynvars);
-void rb_vm_inc_const_missing_count(void);
 VALUE rb_vm_call_kw(rb_execution_context_t *ec, VALUE recv, VALUE id, int argc,
                  const VALUE *argv, const rb_callable_method_entry_t *me, int kw_splat);
 MJIT_STATIC void rb_vm_pop_frame(rb_execution_context_t *ec);

--- a/vm_insnhelper.h
+++ b/vm_insnhelper.h
@@ -13,8 +13,6 @@
 
 MJIT_SYMBOL_EXPORT_BEGIN
 
-RUBY_EXTERN VALUE ruby_vm_const_missing_count;
-RUBY_EXTERN rb_serial_t ruby_vm_global_constant_state;
 RUBY_EXTERN rb_serial_t ruby_vm_class_serial;
 RUBY_EXTERN rb_serial_t ruby_vm_global_cvar_state;
 
@@ -183,8 +181,6 @@ CC_SET_FASTPATH(const struct rb_callcache *cc, vm_call_handler func, bool enable
 
 #define PREV_CLASS_SERIAL() (ruby_vm_class_serial)
 #define NEXT_CLASS_SERIAL() (++ruby_vm_class_serial)
-#define GET_GLOBAL_CONSTANT_STATE() (ruby_vm_global_constant_state)
-#define INC_GLOBAL_CONSTANT_STATE() (++ruby_vm_global_constant_state)
 #define GET_GLOBAL_CVAR_STATE() (ruby_vm_global_cvar_state)
 #define INC_GLOBAL_CVAR_STATE() (++ruby_vm_global_cvar_state)
 

--- a/vm_method.c
+++ b/vm_method.c
@@ -127,10 +127,16 @@ vm_cme_invalidate(rb_callable_method_entry_t *cme)
 }
 
 void
-rb_clear_constant_cache(void)
+rb_clear_constant_cache(ID name)
 {
+    rb_vm_t *vm = GET_VM();
+    rb_serial_t *constant_serial;
+
+    if (rb_id_table_lookup(vm->constant_cache, name, (VALUE *) &constant_serial)) {
+        (*constant_serial)++;
+    }
+
     rb_yjit_constant_state_changed();
-    INC_GLOBAL_CONSTANT_STATE();
 }
 
 static void

--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -4088,8 +4088,6 @@ gen_leave(jitstate_t *jit, ctx_t *ctx, codeblock_t *cb)
     return YJIT_END_BLOCK;
 }
 
-RUBY_EXTERN rb_serial_t ruby_vm_global_constant_state;
-
 static codegen_status_t
 gen_getglobal(jitstate_t *jit, ctx_t *ctx, codeblock_t *cb)
 {
@@ -4302,7 +4300,8 @@ gen_opt_getinlinecache(jitstate_t *jit, ctx_t *ctx, codeblock_t *cb)
     // See vm_ic_hit_p(). The same conditions are checked in yjit_constant_ic_update().
     struct iseq_inline_constant_cache_entry *ice = ic->entry;
     if (!ice || // cache not filled
-        ice->ic_serial != ruby_vm_global_constant_state /* cache out of date */) {
+        !ice->constant_serial || // cache not filled
+        ice->ic_serial != *ice->constant_serial /* cache out of date */) {
         // In these cases, leave a block that unconditionally side exits
         // for the interpreter to invalidate.
         return YJIT_CANT_COMPILE;


### PR DESCRIPTION
Today, when you reference a static constant anywhere in your code YARV adds two instructions: `opt_getinlinecache` and `opt_setinlinecache`.

`opt_getinlinecache` stores a cached number which refers to the global constant state (`ruby_vm_global_constant_state`) that was set when the constant was last looked up. If the cached number matches the current global constant state, then it jumps to its target instruction. If it doesn't match, then it carries on to the next instruction which will look up the constant and put it on the stack.

`opt_setinlinecache` gets the value of the constant off the stack, looks up the current global constant state, and stores both of those values in the associated `opt_getinlinecache` instruction's cache entry.

Effectively, that means any time `ruby_vm_global_constant_state` is incremented, every constant cache is busted and must be looked up again. In the case where you have a system that dynamically defines constants, this means you can pay a significant penalty on constant lookup relatively frequently. This also has implications for JITs, because it forces them to discard generated code that specialized on the constant value in the cache.

The times when `ruby_vm_global_constant_state` is incremented include:

* A constant is assigned
* A constant is removed
* A constant's visibility changes
* A module is included
* A constant is autoloaded

You can inspect `ruby_vm_global_constant_state` by calling `RubyVM.stat(:global_constant_state)` which returns the value of the current constant state.

In this commit, we've added a ID table constant cache to the VM struct, which functions as a map between `ID`s and an `rb_serial_t`. Effectively it's storing a map of constant name to its own cache state. This means we can change `opt_getinlinecache` and `opt_setinlinecache` in the following ways.

`opt_getinlinecache` now stores both a constant state _and_ a pointer to an entry in the VM's constant cache. When this instruction is executed it checks if a cache entry exists for the given `ID` and that the state matches the one stored in the cache. Effectively this means that every `ID` now has its own global cache state.

`opt_setinlinecache` now accepts an additional operand that is the `ID` that is being checked. It does this so that it can increment the number in the cache corresponding to the given `ID`.

With this model, whenever a constant changes in the ways mentioned above it only clears the cache for its specific name (as opposed to for every constant globally). This avoids a lot of invalidation. The only caveat is that when a module is included, it must invalidate all of its constants as it means that constant lookup will change for the object that is including the module.

Because `global_constant_state` is no longer a thing, the commit changes `RubyVM.stat` to return a hash representing the VM's global constant cache. On start, it returns something that looks like:

```ruby
{
  :IO=>1,
  :READABLE=>1,
  :WRITABLE=>1,
  :PRIORITY=>1,
  :WaitReadable=>1,
  :WaitWritable=>1,
  :EAGAINWaitReadable=>1,
  :EAGAINWaitWritable=>1,
  :EWOULDBLOCKWaitReadable=>1,
  :EWOULDBLOCKWaitWritable=>1,
  :EINPROGRESSWaitReadable=>1,
  :EINPROGRESSWaitWritable=>1,
  :SEEK_SET=>1,
  :SEEK_CUR=>1,
  :SEEK_END=>1,
  :SEEK_DATA=>1,
  :SEEK_HOLE=>1,
  :STDIN=>1,
  :STDOUT=>1,
  :STDERR=>1,
  :ARGF=>1,
  ...
}
```