### PR TITLE
Push compaction page alignment check down

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -9296,6 +9296,24 @@ gc_start_internal(rb_execution_context_t *ec, VALUE self, VALUE full_mark, VALUE
 
     /* For now, compact implies full mark / sweep, so ignore other flags */
     if (RTEST(compact)) {
+#if defined(HAVE_SYSCONF) && defined(_SC_PAGE_SIZE)
+        /* If Ruby's heap pages are not a multiple of the system page size, we
+         * cannot use mprotect for the read barrier, so we must disable compaction. */
+        int pagesize;
+        pagesize = (int)sysconf(_SC_PAGE_SIZE);
+        if ((HEAP_PAGE_SIZE % pagesize) != 0) {
+            rb_raise(rb_eNotImpError, "Compaction isn't available on this platform");
+        }
+#endif
+
+    /* If not MinGW, Windows, or does not have mmap, we cannot use mprotect for
+     * the read barrier, so we must disable compaction. */
+#if !defined(__MINGW32__) && !defined(_WIN32)
+        if (!USE_MMAP_ALIGNED_ALLOC) {
+            rb_raise(rb_eNotImpError, "Compaction isn't available on this platform");
+        }
+#endif
+
         reason |= GPR_FLAG_COMPACT;
     }
     else {
@@ -10250,24 +10268,6 @@ heap_check_moved_i(void *vstart, void *vend, size_t stride, void *data)
 static VALUE
 gc_compact(rb_execution_context_t *ec, VALUE self)
 {
-#if defined(HAVE_SYSCONF) && defined(_SC_PAGE_SIZE)
-    /* If Ruby's heap pages are not a multiple of the system page size, we
-     * cannot use mprotect for the read barrier, so we must disable compaction. */
-    int pagesize;
-    pagesize = (int)sysconf(_SC_PAGE_SIZE);
-    if ((HEAP_PAGE_SIZE % pagesize) != 0) {
-        rb_raise(rb_eNotImpError, "Compaction isn't available on this platform");
-    }
-#endif
-
-    /* If not MinGW, Windows, or does not have mmap, we cannot use mprotect for
-     * the read barrier, so we must disable compaction. */
-#if !defined(__MINGW32__) && !defined(_WIN32)
-    if (!USE_MMAP_ALIGNED_ALLOC) {
-        rb_raise(rb_eNotImpError, "Compaction isn't available on this platform");
-    }
-#endif
-
     /* Run GC with compaction enabled */
     gc_start_internal(ec, self, Qtrue, Qtrue, Qtrue, Qtrue);
 


### PR DESCRIPTION
It seems like `gc_verify_compaction_references` is not protected in case
alignment is wrong.  This commit pushes the alignment check down to
`gc_start_internal` so that anyone trying to compact will check page
alignment

I think this method may be getting called on PowerPC and the alignment
might be wrong.

  http://rubyci.s3.amazonaws.com/ppc64le/ruby-master/log/20211021T190006Z.fail.html.gz