### PR TITLE
Strip out YJIT at build time when unsupported or disabled

### DIFF
--- a/test/ruby/test_yjit.rb
+++ b/test/ruby/test_yjit.rb
@@ -3,7 +3,7 @@ require 'test/unit'
 require 'envutil'
 require 'tmpdir'
 
-return unless YJIT.enabled?
+return unless defined?(YJIT) && YJIT.enabled?
 
 # Tests for YJIT with assertions on compilation and side exits
 # insipired by the MJIT tests in test/ruby/test_jit.rb

--- a/yjit.rb
+++ b/yjit.rb
@@ -1,3 +1,10 @@
+# This module allows for introspection on YJIT, CRuby's experimental in-process
+# just-in-time compiler. This module is for development purposes only;
+# everything in this module is highly implementation specific and comes with no
+# API stability guarantee whatsoever.
+#
+# This module is only defined when YJIT has support for the particular platform
+# on which CRuby is built.
 module YJIT
   if defined?(Disasm)
     def self.disasm(iseq, tty: $stdout && $stdout.tty?)


### PR DESCRIPTION
In an effort to minimize build issues on non x64 platforms, we can
decide at build time to not build the bulk of YJIT. This should fix
obscure build errors like this one on riscv64:

    yjit_asm.c:137:(.text+0x3fa): relocation truncated to fit: R_RISCV_PCREL_HI20 against `alloc_exec_mem'

We also don't need to bulid YJIT on `--disable-jit-support` builds.

One wrinkle to this is that the YJIT Ruby module will not be defined
when YJIT is stripped from the build. I think that's a fair change as
it's only meant to be used for YJIT development. cc @maximecb 