### PR TITLE
Fix simple test on platforms where compaction is not supported

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -662,7 +662,11 @@ assert_equal "good", %q{
   foo
   foo
 
-  GC.verify_compaction_references(double_heap: true, toward: :empty)
+  begin
+    GC.verify_compaction_references(double_heap: true, toward: :empty)
+  rescue NotImplementedError
+    # in case compaction isn't supported
+  end
 
   foo
 }


### PR DESCRIPTION
844588f9157b364244a7d34ee0fcc70ccc2a7dd9 made it so that trying to call
gc_verify_compaction_references on unsupported platform result in an
exception rather than a crash. Rescue the exception in a simple test
that uses gc_verify_compaction_references.

---

The log linked in 844588f9157b364244a7d34ee0fcc70ccc2a7dd9 says that the crash might be coming from this YJIT bootstrap test. If the theory is right we should start seeing `NotImplementedError` on CI from PPC. cc @tenderlove 

Update, the theory is correct: http://rubyci.s3.amazonaws.com/ppc64le/ruby-master/log/20211022T130007Z.log.html.gz