### PR TITLE
[Bug #18264] Fix memory leak in TracePoint

### DIFF
--- a/test/ruby/test_settracefunc.rb
+++ b/test/ruby/test_settracefunc.rb
@@ -564,6 +564,16 @@ class TestSetTraceFunc < Test::Unit::TestCase
     }
   end
 
+  # Bug #18264
+  def test_tracpoint_memory_leak
+    assert_no_memory_leak([], <<-PREP, <<-CODE, rss: true)
+code = proc { TracePoint.new(:line) { } }
+1_000.times(&code)
+PREP
+1_000_000.times(&code)
+CODE
+  end
+
   def trace_by_set_trace_func
     events = []
     trace = nil

--- a/vm_trace.c
+++ b/vm_trace.c
@@ -748,7 +748,7 @@ tp_memsize(const void *ptr)
 
 static const rb_data_type_t tp_data_type = {
     "tracepoint",
-    {tp_mark, RUBY_TYPED_NEVER_FREE, tp_memsize,},
+    {tp_mark, RUBY_TYPED_DEFAULT_FREE, tp_memsize,},
     0, 0, RUBY_TYPED_FREE_IMMEDIATELY
 };
 


### PR DESCRIPTION
# Redmine ticket: https://bugs.ruby-lang.org/issues/18264

TracePoint leaks memory because it allocates a `rb_tp_t` struct without ever freeing it (it is created with `RUBY_TYPED_NEVER_FREE`). This is reproducible on all maintained Rubies (2.6.8, 2.7.4, 3.0.2, master) on Ubuntu 20.04.

The follow string demonstrates the issue.

```ruby
100.times do
  10000.times do
    TracePoint.new(:line) {}
  end

  # Output the Resident Set Size (memory usage, in KB) of the current Ruby process
  puts `ps -o rss= -p #{$$}`
end
```

We can see the leak through the following graph of the Resident Set Size (RSS) comparing the branch vs. master (at commit 6b9285e8d45e88c5b014b8428520ffa2401789ad).

![](https://user-images.githubusercontent.com/15860699/138502310-007bd725-d364-4be4-b128-ebdb859b8613.png)
