### PR TITLE
YJIT: Implement duphash

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -2268,3 +2268,13 @@ assert_equal "true", %q{
 
     expected == events
 }
+
+# duphash
+assert_equal '{:foo=>123}', %q{
+  def foo
+    {foo: 123}
+  end
+
+  foo
+  foo
+}

--- a/common.mk
+++ b/common.mk
@@ -16899,6 +16899,7 @@ yjit.$(OBJEXT): $(top_srcdir)/internal/class.h
 yjit.$(OBJEXT): $(top_srcdir)/internal/compile.h
 yjit.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 yjit.$(OBJEXT): $(top_srcdir)/internal/gc.h
+yjit.$(OBJEXT): $(top_srcdir)/internal/hash.h
 yjit.$(OBJEXT): $(top_srcdir)/internal/imemo.h
 yjit.$(OBJEXT): $(top_srcdir)/internal/object.h
 yjit.$(OBJEXT): $(top_srcdir)/internal/re.h


### PR DESCRIPTION
`duphash` showed up in the top-20 most frequent exit ops for @jhawthorn's benchmark that renders github.com/about

The implementation was almost exactly the same as `duparray`

Co-authored-by: John Hawthorn <john@hawthorn.email>