### PR TITLE
Add `hash_foreach_iter_status_check` function

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -1330,15 +1330,8 @@ struct hash_foreach_arg {
 };
 
 static int
-hash_ar_foreach_iter(st_data_t key, st_data_t value, st_data_t argp, int error)
+hash_foreach_iter_status_check(int status)
 {
-    struct hash_foreach_arg *arg = (struct hash_foreach_arg *)argp;
-    int status;
-
-    if (error) return ST_STOP;
-    status = (*arg->func)((VALUE)key, (VALUE)value, arg->arg);
-    /* TODO: rehash check? rb_raise(rb_eRuntimeError, "rehash occurred during iteration"); */
-
     switch (status) {
       case ST_DELETE:
         return ST_DELETE;
@@ -1348,6 +1341,19 @@ hash_ar_foreach_iter(st_data_t key, st_data_t value, st_data_t argp, int error)
         return ST_STOP;
     }
     return ST_CHECK;
+}
+
+static int
+hash_ar_foreach_iter(st_data_t key, st_data_t value, st_data_t argp, int error)
+{
+    struct hash_foreach_arg *arg = (struct hash_foreach_arg *)argp;
+    int status;
+
+    if (error) return ST_STOP;
+    status = (*arg->func)((VALUE)key, (VALUE)value, arg->arg);
+    /* TODO: rehash check? rb_raise(rb_eRuntimeError, "rehash occurred during iteration"); */
+
+    return hash_foreach_iter_status_check(status);
 }
 
 static int
@@ -1363,15 +1369,8 @@ hash_foreach_iter(st_data_t key, st_data_t value, st_data_t argp, int error)
     if (RHASH_ST_TABLE(arg->hash) != tbl) {
     	rb_raise(rb_eRuntimeError, "rehash occurred during iteration");
     }
-    switch (status) {
-      case ST_DELETE:
-	return ST_DELETE;
-      case ST_CONTINUE:
-	break;
-      case ST_STOP:
-	return ST_STOP;
-    }
-    return ST_CHECK;
+
+    return hash_foreach_iter_status_check(status);
 }
 
 static int


### PR DESCRIPTION
`hash_ar_foreach_iter` and `hash_foreach_iter` functions has same code.
I think better that cut out these same code to the function like a `hash_foreach_iter_status_check` function.