### PR TITLE
Fix "ruby -v --yjit --yjit-stats"

### DIFF
--- a/ruby.c
+++ b/ruby.c
@@ -88,6 +88,8 @@ char *getenv();
 #define DEFAULT_RUBYGEMS_ENABLED "enabled"
 #endif
 
+RUBY_EXTERN struct rb_yjit_options rb_yjit_opts;
+
 void rb_warning_category_update(unsigned int mask, unsigned int bits);
 
 #define COMMA ,
@@ -1894,7 +1896,8 @@ process_options(int argc, char **argv, ruby_cmdline_options_t *opt)
             exit(1);
         }
 #endif
-        rb_yjit_init(&opt->yjit);
+        opt->yjit.yjit_enabled = true;
+        rb_yjit_opts.yjit_enabled = true;
     }
     if (opt->dump & (DUMP_BIT(version) | DUMP_BIT(version_v))) {
 #if USE_MJIT
@@ -1957,6 +1960,9 @@ process_options(int argc, char **argv, ruby_cmdline_options_t *opt)
         /* Using TMP_RUBY_PREFIX created by ruby_init_loadpath(). */
         mjit_init(&opt->mjit);
 #endif
+
+    if (opt->yjit.yjit_enabled)
+        rb_yjit_init(&opt->yjit);
 
     Init_ruby_description();
     Init_enc();

--- a/version.c
+++ b/version.c
@@ -98,6 +98,8 @@ Init_version(void)
 #define MJIT_OPTS_ON 0
 #endif
 
+RUBY_EXTERN struct rb_yjit_options rb_yjit_opts;
+
 void
 Init_ruby_description(void)
 {
@@ -106,7 +108,7 @@ Init_ruby_description(void)
     if (MJIT_OPTS_ON) {
         description = MKSTR(description_with_jit);
     }
-    else if (rb_yjit_enabled_p()) {
+    else if (rb_yjit_opts.yjit_enabled) {
         description = MKSTR(description_with_yjit);
     }
     else {
@@ -125,7 +127,7 @@ ruby_show_version(void)
     if (MJIT_OPTS_ON) {
         PRINT(description_with_jit);
     }
-    else if (rb_yjit_enabled_p()) {
+    else if (rb_yjit_opts.yjit_enabled) {
         PRINT(description_with_yjit);
     }
     else {


### PR DESCRIPTION
Previously running "ruby -v --yjit --yjit-stats" would say that _print_stats didn't exist in the YJIT module. Its at_exit handler was set up to run, but _print_stats wasn't created when run with -v.

YJIT should set a boolean before ruby_show_version(), to be used by ruby_show_version, and then not do its init until after ruby_show_version and ruby_show_copyright have been called. MJIT already does this with mjit_opts.on.

That way YJIT won't be initialized if "ruby -v" is going to cause Ruby to exit without executing any code.