### PR TITLE
Allow caller/caller_locations to take a block

### DIFF
--- a/test/ruby/test_backtrace.rb
+++ b/test/ruby/test_backtrace.rb
@@ -154,6 +154,42 @@ class TestBacktrace < Test::Unit::TestCase
     assert_equal caller(0), caller(0, nil)
   end
 
+  def test_caller_block
+    i = 0
+    ary = []
+    cllr = caller(1, 2); last = caller{|x| ary << x; i+=1; break x if i == 2}
+    assert_equal(cllr, ary)
+    assert_equal(cllr.last, last)
+    assert_kind_of(String, last)
+
+    i = 0
+    ary = []
+    ->{->{
+      cllr = caller(1, 4); last = caller{|x| ary << x; i+=1; break x if i == 4}
+    }.()}.()
+    assert_equal(cllr, ary)
+    assert_equal(cllr.last, last)
+    assert_kind_of(String, last)
+  end
+
+  def test_caller_locations_block
+    i = 0
+    ary = []
+    cllr = caller_locations(1, 2); last = caller_locations{|x| ary << x; i+=1; break x if i == 2}
+    assert_equal(cllr.map(&:to_s), ary.map(&:to_s))
+    assert_equal(cllr.last.to_s, last.to_s)
+    assert_kind_of(Thread::Backtrace::Location, last)
+
+    i = 0
+    ary = []
+    ->{->{
+      cllr = caller_locations(1, 2); last = caller_locations{|x| ary << x; i+=1; break x if i == 2}
+    }.()}.()
+    assert_equal(cllr.map(&:to_s), ary.map(&:to_s))
+    assert_equal(cllr.last.to_s, last.to_s)
+    assert_kind_of(Thread::Backtrace::Location, last)
+  end
+
   def test_caller_locations_first_label
     def self.label
       caller_locations.first.label


### PR DESCRIPTION
If caller/caller_locations is passed a block, the block is yielded
the string or Thread::Backtrace::Location object as the VM frames
are being scanned.  The caller can break/return for an early exit.
This allows for constructing partial backtraces where you don't
know the size or level of the backtrace up front, as the part
of the backtrace you want depends on the location.

This has rb_ec_partial_backtrace_object accept to_str and do_yield
arguments.  If do_yield is true, then the array of backtrace
strings/locations is created up front, and for each frame of the
backtrace, after the string/location is added to the array, it is
yielded to the block.  If the array is created up front, we skip
recreating it after the scan.

Implements [Feature #16663]

Documentation/NEWS not modified yet, I will take care of that
before merging if this is accepted.