### PR TITLE
Mark JIT code as writeable / executable depending on the situation

### DIFF
--- a/misc/yjit_asm_tests.c
+++ b/misc/yjit_asm_tests.c
@@ -401,7 +401,7 @@ void run_runtime_tests(void)
     int (*function)(void);
     function = (int (*)(void))mem_block;
 
-    #define TEST(BODY) cb_set_pos(cb, 0); BODY ret(cb); assert_equal(7, function());
+    #define TEST(BODY) cb_set_pos(cb, 0); BODY ret(cb); cb_mark_all_executable(cb); assert_equal(7, function());
 
     // add
     TEST({ mov(cb, RAX, imm_opnd(0)); add(cb, RAX, imm_opnd(7)); })

--- a/yjit_asm.h
+++ b/yjit_asm.h
@@ -55,7 +55,13 @@ typedef struct CodeBlock
     // Flag to enable or disable comments
     bool has_asm;
 
+    // Keep track of the current aligned write position.
+    // Used for changing protection when writing to the JIT buffer
+    uint32_t current_aligned_write_pos;
 } codeblock_t;
+
+// 1 is not aligned so this won't match any pages
+#define ALIGNED_WRITE_POSITION_NONE 1
 
 enum OpndType
 {
@@ -261,6 +267,9 @@ static inline uint32_t cb_new_label(codeblock_t *cb, const char *name);
 static inline void cb_write_label(codeblock_t *cb, uint32_t label_idx);
 static inline void cb_label_ref(codeblock_t *cb, uint32_t label_idx);
 static inline void cb_link_labels(codeblock_t *cb);
+static inline void cb_mark_all_writeable(codeblock_t *cb);
+static inline void cb_mark_position_writeable(codeblock_t *cb, uint32_t write_pos);
+static inline void cb_mark_all_executable(codeblock_t *cb);
 
 // Encode individual instructions into a code block
 static inline void add(codeblock_t *cb, x86opnd_t opnd0, x86opnd_t opnd1);

--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -4876,6 +4876,8 @@ rb_yjit_tracing_invalidate_all(void)
     RUBY_ASSERT_ALWAYS(yjit_codepage_frozen_bytes <= old_pos && "frozen bytes should increase monotonically");
     yjit_codepage_frozen_bytes = old_pos;
 
+    cb_mark_all_executable(ocb);
+    cb_mark_all_executable(cb);
     RB_VM_LOCK_LEAVE();
 }
 
@@ -4957,6 +4959,7 @@ yjit_init_codegen(void)
 
     // Generate full exit code for C func
     gen_full_cfunc_return();
+    cb_mark_all_executable(cb);
 
     // Map YARV opcodes to the corresponding codegen functions
     yjit_reg_op(BIN(nop), gen_nop);

--- a/yjit_iface.c
+++ b/yjit_iface.c
@@ -962,8 +962,15 @@ rb_yjit_iseq_update_references(const struct rb_iseq_constant_body *body)
             //block->code_page = rb_gc_location(block->code_page);
         }
     }
-    cb_mark_all_executable(cb);
-    cb_mark_all_executable(ocb);
+
+    /* If YJIT isn't initialized, then cb or ocb could be NULL. */
+    if (cb) {
+        cb_mark_all_executable(cb);
+    }
+
+    if (ocb) {
+        cb_mark_all_executable(ocb);
+    }
 }
 
 // Free the yjit resources associated with an iseq


### PR DESCRIPTION
Some platforms don't want memory to be marked as writeable and
executable at the same time.  This commit introduces two functions for
marking code blocks as either writeable or executable depending on the
situation.  When we need to write to memory, we call `cb_mark_writeable`
and when we're done writing to memory, call `cb_mark_executable`

This is an initial stab at implementing memory protection for JIT code