### PR TITLE
Replace to INT2FIX macro to defined macro

### DIFF
--- a/complex.c
+++ b/complex.c
@@ -217,7 +217,7 @@ f_denominator(VALUE x)
     if (RB_FLOAT_TYPE_P(x)) {
         return rb_float_denominator(x);
     }
-    return INT2FIX(1);
+    return ONE;
 }
 
 inline static VALUE
@@ -1680,7 +1680,7 @@ nucomp_to_c(VALUE self)
 static VALUE
 nilclass_to_c(VALUE self)
 {
-    return rb_complex_new1(INT2FIX(0));
+    return rb_complex_new1(ZERO);
 }
 
 /*
@@ -2156,7 +2156,7 @@ numeric_real(VALUE self)
 static VALUE
 numeric_imag(VALUE self)
 {
-    return INT2FIX(0);
+    return ZERO;
 }
 
 /*
@@ -2183,7 +2183,7 @@ static VALUE
 numeric_arg(VALUE self)
 {
     if (f_positive_p(self))
-        return INT2FIX(0);
+        return ZERO;
     return DBL2NUM(M_PI);
 }
 
@@ -2197,7 +2197,7 @@ numeric_arg(VALUE self)
 static VALUE
 numeric_rect(VALUE self)
 {
-    return rb_assoc_new(self, INT2FIX(0));
+    return rb_assoc_new(self, ZERO);
 }
 
 /*
@@ -2257,7 +2257,7 @@ float_arg(VALUE self)
     if (isnan(RFLOAT_VALUE(self)))
 	return self;
     if (f_tpositive_p(self))
-	return INT2FIX(0);
+	return ZERO;
     return rb_const_get(rb_mMath, id_PI);
 }
 

--- a/rational.c
+++ b/rational.c
@@ -1173,7 +1173,7 @@ nurat_coerce(VALUE self, VALUE other)
     }
     else if (RB_TYPE_P(other, T_COMPLEX)) {
 	if (!k_exact_zero_p(RCOMPLEX(other)->imag))
-	    return rb_assoc_new(other, rb_Complex(self, INT2FIX(0)));
+	    return rb_assoc_new(other, rb_Complex(self, ZERO));
         other = RCOMPLEX(other)->real;
         if (RB_FLOAT_TYPE_P(other)) {
             other = float_to_r(other);
@@ -2074,7 +2074,7 @@ integer_numerator(VALUE self)
 static VALUE
 integer_denominator(VALUE self)
 {
-    return INT2FIX(1);
+    return ONE;
 }
 
 /*
@@ -2115,7 +2115,7 @@ rb_float_denominator(VALUE self)
     double d = RFLOAT_VALUE(self);
     VALUE r;
     if (!isfinite(d))
-	return INT2FIX(1);
+	return ONE;
     r = float_to_r(self);
     return nurat_denominator(r);
 }
@@ -2129,7 +2129,7 @@ rb_float_denominator(VALUE self)
 static VALUE
 nilclass_to_r(VALUE self)
 {
-    return rb_rational_new1(INT2FIX(0));
+    return rb_rational_new1(ZERO);
 }
 
 /*


### PR DESCRIPTION
In `complex.c` and `rational.c` has these macro.

```c
#define ZERO INT2FIX(0)
#define ONE INT2FIX(1)
#define TWO INT2FIX(2)
```

But, some code using `INT2FIX(1)` in `complex.c` and `rational.c` .

I think better to replace and using these macro(`ZERO`, `ONE` and `TWO`).