### PR TITLE
Rename ::YJIT to RubyVM::YJIT

### DIFF
--- a/spec/ruby/command_line/dash_v_spec.rb
+++ b/spec/ruby/command_line/dash_v_spec.rb
@@ -7,6 +7,6 @@ describe "The -v command line option" do
   describe "when used alone" do
     it "prints version and ends" do
       ruby_exe(nil, args: '-v').should include(RUBY_DESCRIPTION)
-    end unless defined?(YJIT) && YJIT.enabled? # pending. not sure why MJIT doesn't need anything to fix this.
+    end unless defined?(RubyVM::YJIT) && RubyVM::YJIT.enabled? # pending. not sure why MJIT doesn't need anything to fix this.
   end
 end

--- a/test/-ext-/bug_reporter/test_bug_reporter.rb
+++ b/test/-ext-/bug_reporter/test_bug_reporter.rb
@@ -8,7 +8,7 @@ class TestBugReporter < Test::Unit::TestCase
 
     description = RUBY_DESCRIPTION
     description = description.sub(/\+JIT /, '') if defined?(RubyVM::JIT) && RubyVM::JIT.enabled?
-    description = description.sub(/\+YJIT /, '') if defined?(YJIT.enabled?) && YJIT.enabled?
+    description = description.sub(/\+YJIT /, '') if defined?(RubyVM::YJIT.enabled?) && RubyVM::YJIT.enabled?
     expected_stderr = [
       :*,
       /\[BUG\]\sSegmentation\sfault.*\n/,

--- a/test/ruby/test_rubyoptions.rb
+++ b/test/ruby/test_rubyoptions.rb
@@ -7,10 +7,12 @@ require 'tempfile'
 require_relative '../lib/jit_support'
 
 class TestRubyOptions < Test::Unit::TestCase
+  def self.yjit_enabled? = defined?(RubyVM::YJIT.enabled?) && RubyVM::YJIT.enabled?
+
   NO_JIT_DESCRIPTION =
     if defined?(RubyVM::JIT) && RubyVM::JIT.enabled? # checking -DMJIT_FORCE_ENABLE
       RUBY_DESCRIPTION.sub(/\+JIT /, '')
-    elsif defined?(YJIT.enabled?) && YJIT.enabled? # checking -DYJIT_FORCE_ENABLE
+    elsif yjit_enabled? # checking -DYJIT_FORCE_ENABLE
       RUBY_DESCRIPTION.sub(/\+YJIT /, '')
     else
       RUBY_DESCRIPTION
@@ -146,7 +148,7 @@ class TestRubyOptions < Test::Unit::TestCase
       assert_match(VERSION_PATTERN, r[0])
       if defined?(RubyVM::JIT) && RubyVM::JIT.enabled? && !mjit_force_enabled? # checking -DMJIT_FORCE_ENABLE
         assert_equal(NO_JIT_DESCRIPTION, r[0])
-      elsif defined?(YJIT.enabled?) && YJIT.enabled? && !yjit_force_enabled? # checking -DYJIT_FORCE_ENABLE
+      elsif self.class.yjit_enabled? && !yjit_force_enabled? # checking -DYJIT_FORCE_ENABLE
         assert_equal(NO_JIT_DESCRIPTION, r[0])
       else
         assert_equal(RUBY_DESCRIPTION, r[0])
@@ -212,7 +214,7 @@ class TestRubyOptions < Test::Unit::TestCase
       assert_match(VERSION_PATTERN, r[0])
       if ENV['RUBY_YJIT_ENABLE'] == '1'
         assert_equal(NO_JIT_DESCRIPTION, r[0])
-      elsif defined?(RubyVM::JIT) && RubyVM::JIT.enabled? || defined?(YJIT.enabled?) && YJIT.enabled? # checking -D(M|Y)JIT_FORCE_ENABLE
+      elsif defined?(RubyVM::JIT) && RubyVM::JIT.enabled? || self.class.yjit_enabled? # checking -D(M|Y)JIT_FORCE_ENABLE
         assert_equal(EnvUtil.invoke_ruby(['-e', 'print RUBY_DESCRIPTION'], '', true).first, r[0])
       else
         assert_equal(RUBY_DESCRIPTION, r[0])

--- a/test/ruby/test_yjit.rb
+++ b/test/ruby/test_yjit.rb
@@ -3,7 +3,7 @@ require 'test/unit'
 require 'envutil'
 require 'tmpdir'
 
-return unless defined?(YJIT) && YJIT.enabled?
+return unless defined?(RubyVM::YJIT) && RubyVM::YJIT.enabled?
 
 # Tests for YJIT with assertions on compilation and side exits
 # insipired by the MJIT tests in test/ruby/test_jit.rb
@@ -49,7 +49,7 @@ class TestYJIT < Test::Unit::TestCase
       assert_equal([], stderr)
     end
     assert_in_out_err([yjit_child_env, '-e puts RUBY_DESCRIPTION'], '', [RUBY_DESCRIPTION])
-    assert_in_out_err([yjit_child_env, '-e p YJIT.enabled?'], '', ['true'])
+    assert_in_out_err([yjit_child_env, '-e p RubyVM::YJIT.enabled?'], '', ['true'])
   end
 
   def test_compile_getclassvariable
@@ -498,7 +498,7 @@ class TestYJIT < Test::Unit::TestCase
         objects[1].foo
       }
 
-      stats = YJIT.runtime_stats
+      stats = RubyVM::YJIT.runtime_stats
       return :ok unless stats[:all_stats]
       return :ok if stats[:invalidation_count] < 10
 
@@ -513,12 +513,12 @@ class TestYJIT < Test::Unit::TestCase
   ANY = Object.new
   def assert_compiles(test_script, insns: [], min_calls: 1, stdout: nil, exits: {}, result: ANY, frozen_string_literal: nil)
     reset_stats = <<~RUBY
-      YJIT.runtime_stats
-      YJIT.reset_stats!
+      RubyVM::YJIT.runtime_stats
+      RubyVM::YJIT.reset_stats!
     RUBY
 
     write_results = <<~RUBY
-      stats = YJIT.runtime_stats
+      stats = RubyVM::YJIT.runtime_stats
 
       def collect_blocks(blocks)
         blocks.sort_by(&:address).map { |b| [b.iseq_start_index, b.iseq_end_index] }
@@ -527,7 +527,7 @@ class TestYJIT < Test::Unit::TestCase
       def collect_iseqs(iseq)
         iseq_array = iseq.to_a
         insns = iseq_array.last.grep(Array)
-        blocks = YJIT.blocks_for(iseq)
+        blocks = RubyVM::YJIT.blocks_for(iseq)
         h = {
           name: iseq_array[5],
           insns: insns,

--- a/yjit.rb
+++ b/yjit.rb
@@ -5,12 +5,12 @@
 #
 # This module is only defined when YJIT has support for the particular platform
 # on which CRuby is built.
-module YJIT
+module RubyVM::YJIT
   if defined?(Disasm)
     def self.disasm(iseq, tty: $stdout && $stdout.tty?)
       iseq = RubyVM::InstructionSequence.of(iseq)
 
-      blocks = YJIT.blocks_for(iseq)
+      blocks = blocks_for(iseq)
       return if blocks.empty?
 
       str = String.new
@@ -28,7 +28,7 @@ module YJIT
         end
       }
 
-      cs = YJIT::Disasm.new
+      cs = Disasm.new
       sorted_blocks.each_with_index do |block, i|
         str << "== BLOCK #{i+1}/#{blocks.length}: #{block.code.length} BYTES, ISEQ RANGE [#{block.iseq_start_index},#{block.iseq_end_index}) ".ljust(80, "=")
         str << "\n"
@@ -65,7 +65,7 @@ module YJIT
 
     def self.graphviz_for(iseq)
       iseq = RubyVM::InstructionSequence.of(iseq)
-      cs = YJIT::Disasm.new
+      cs = Disasm.new
 
       highlight = ->(comment) { "<b>#{comment}</b>" }
       linebreak = "<br align=\"left\"/>\n"

--- a/yjit_iface.c
+++ b/yjit_iface.c
@@ -1119,7 +1119,7 @@ rb_yjit_init(struct rb_yjit_options *options)
     yjit_init_codegen();
 
     // YJIT Ruby module
-    mYjit = rb_define_module("YJIT");
+    mYjit = rb_define_module_under(rb_cRubyVM, "YJIT");
     rb_define_module_function(mYjit, "blocks_for", yjit_blocks_for, 1);
 
     // YJIT::Block (block version, code block)


### PR DESCRIPTION
Since the YJIT Ruby module is CRuby specific and not meant for general
use, it should live under RubyVM instead of at top level.