### PR TITLE
Allow the thread-impl to be switched by configure option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -37,6 +37,7 @@ m4_include([tool/m4/ruby_replace_type.m4])dnl
 m4_include([tool/m4/ruby_rm_recursive.m4])dnl
 m4_include([tool/m4/ruby_setjmp_type.m4])dnl
 m4_include([tool/m4/ruby_stack_grow_direction.m4])dnl
+m4_include([tool/m4/ruby_thread.m4])dnl
 m4_include([tool/m4/ruby_try_cflags.m4])dnl
 m4_include([tool/m4/ruby_try_cxxflags.m4])dnl
 m4_include([tool/m4/ruby_try_ldflags.m4])dnl
@@ -3687,9 +3688,6 @@ AC_ARG_ENABLE(install-static-library,
 	    [INSTALL_STATIC_LIBRARY=yes]))
 AC_SUBST(INSTALL_STATIC_LIBRARY)
 
-AS_IF([test "$rb_with_pthread" = "yes"], [
-    THREAD_MODEL=pthread
-])
 AC_CACHE_CHECK([for prefix of external symbols], rb_cv_symbol_prefix, [
     AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[extern void conftest_external(void) {}]], [[]])],[
 	rb_cv_symbol_prefix=`$NM conftest.$ac_objext |
@@ -3763,7 +3761,6 @@ AS_CASE(["$target_os"],
 	    COMMON_LIBS=m
 #	    COMMON_MACROS="WIN32_LEAN_AND_MEAN="
 	    COMMON_HEADERS="winsock2.h windows.h"
-	    THREAD_MODEL=win32
 	    PLATFORM_DIR=win32
 	    ])
 	LIBRUBY_ALIASES=''
@@ -3785,11 +3782,7 @@ AS_CASE(["$target_os"],
 
 MINIOBJS="$MINIDLNOBJ"
 
-AS_CASE(["$THREAD_MODEL"],
-[pthread], [AC_CHECK_HEADERS(pthread.h)],
-[win32],   [],
-[""],      [AC_MSG_ERROR(thread model is missing)],
-           [AC_MSG_ERROR(unknown thread model $THREAD_MODEL)])
+RUBY_THREAD
 
 AC_ARG_ENABLE(debug-env,
        AS_HELP_STRING([--enable-debug-env], [enable RUBY_DEBUG environment variable]),

--- a/thread.c
+++ b/thread.c
@@ -349,8 +349,9 @@ ubf_sigwait(void *ignore)
     rb_thread_wakeup_timer_thread(0);
 }
 
+#include THREAD_IMPL_SRC
+
 #if   defined(_WIN32)
-#include "thread_win32.c"
 
 #define DEBUG_OUT() \
   WaitForSingleObject(&debug_mutex, INFINITE); \
@@ -359,7 +360,6 @@ ubf_sigwait(void *ignore)
   ReleaseMutex(&debug_mutex);
 
 #elif defined(HAVE_PTHREAD_H)
-#include "thread_pthread.c"
 
 #define DEBUG_OUT() \
   pthread_mutex_lock(&debug_mutex); \
@@ -368,8 +368,6 @@ ubf_sigwait(void *ignore)
   fflush(stdout); \
   pthread_mutex_unlock(&debug_mutex);
 
-#else
-#error "unsupported thread type"
 #endif
 
 /*

--- a/tool/m4/ruby_thread.m4
+++ b/tool/m4/ruby_thread.m4
@@ -16,4 +16,13 @@ AS_CASE(["$THREAD_MODEL"],
 [win32],   [],
 [""],      [AC_MSG_ERROR(thread model is missing)],
            [AC_MSG_ERROR(unknown thread model $THREAD_MODEL)])
+
+THREAD_IMPL_H=thread_$THREAD_MODEL.h
+AS_IF([test ! -f "$srcdir/$THREAD_IMPL_H"],
+      [AC_MSG_ERROR('$srcdir/$THREAD_IMPL_H' must exist)])
+THREAD_IMPL_SRC=thread_$THREAD_MODEL.c
+AS_IF([test ! -f "$srcdir/$THREAD_IMPL_SRC"],
+      [AC_MSG_ERROR('$srcdir/$THREAD_IMPL_SRC' must exist)])
+AC_DEFINE_UNQUOTED(THREAD_IMPL_H, ["$THREAD_IMPL_H"])
+AC_DEFINE_UNQUOTED(THREAD_IMPL_SRC, ["$THREAD_IMPL_SRC"])
 ])dnl

--- a/tool/m4/ruby_thread.m4
+++ b/tool/m4/ruby_thread.m4
@@ -1,0 +1,19 @@
+dnl -*- Autoconf -*-
+AC_DEFUN([RUBY_THREAD], [
+AS_CASE(["$target_os"],
+    [mingw*], [
+        THREAD_MODEL=win32
+    ],
+    [
+        AS_IF([test "$rb_with_pthread" = "yes"], [
+            THREAD_MODEL=pthread
+        ])
+    ]
+)
+
+AS_CASE(["$THREAD_MODEL"],
+[pthread], [AC_CHECK_HEADERS(pthread.h)],
+[win32],   [],
+[""],      [AC_MSG_ERROR(thread model is missing)],
+           [AC_MSG_ERROR(unknown thread model $THREAD_MODEL)])
+])dnl

--- a/tool/m4/ruby_thread.m4
+++ b/tool/m4/ruby_thread.m4
@@ -1,15 +1,20 @@
 dnl -*- Autoconf -*-
 AC_DEFUN([RUBY_THREAD], [
-AS_CASE(["$target_os"],
-    [mingw*], [
-        THREAD_MODEL=win32
-    ],
-    [
-        AS_IF([test "$rb_with_pthread" = "yes"], [
-            THREAD_MODEL=pthread
-        ])
-    ]
-)
+AC_ARG_WITH(thread,
+    AS_HELP_STRING([--with-thread=IMPLEMENTATION], [specify the thread implementation to use]),
+    [THREAD_MODEL=$withval], [
+    THREAD_MODEL=
+    AS_CASE(["$target_os"],
+        [mingw*], [
+            THREAD_MODEL=win32
+        ],
+        [
+            AS_IF([test "$rb_with_pthread" = "yes"], [
+                THREAD_MODEL=pthread
+            ])
+        ]
+    )
+])
 
 AS_CASE(["$THREAD_MODEL"],
 [pthread], [AC_CHECK_HEADERS(pthread.h)],

--- a/vm_core.h
+++ b/vm_core.h
@@ -79,11 +79,7 @@
 #include "vm_opts.h"
 
 #include "ruby/thread_native.h"
-#if   defined(_WIN32)
-#include "thread_win32.h"
-#elif defined(HAVE_PTHREAD_H)
-#include "thread_pthread.h"
-#endif
+#include THREAD_IMPL_H
 
 #define RUBY_VM_THREAD_MODEL 2
 

--- a/win32/Makefile.sub
+++ b/win32/Makefile.sub
@@ -414,6 +414,8 @@ LIBRUBYARG_SHARED = $(LIBRUBY)
 LIBRUBY_RELATIVE = yes
 
 THREAD_MODEL  = win32
+THREAD_IMPL_H   = thread_$(THREAD_MODEL).h
+THREAD_IMPL_SRC = thread_$(THREAD_MODEL).c
 
 !if "$(CROSS_COMPILING)" == "yes"
 PREP          = $(arch)-fake.rb
@@ -873,6 +875,8 @@ $(CONFIG_H): $(MKFILES) $(srcdir)/win32/Makefile.sub $(win_srcdir)/Makefile.sub
 #define STACK_GROW_DIRECTION -1
 !endif
 #define COROUTINE_H "$(COROUTINE_H)"
+#define THREAD_IMPL_H "$(THREAD_IMPL_H)"
+#define THREAD_IMPL_SRC "$(THREAD_IMPL_SRC)"
 #define LOAD_RELATIVE 1
 #define DLEXT ".so"
 !if "$(libdir_basename)" != "lib"


### PR DESCRIPTION
This is a preparation for porting MRI to WebAssembly. In WebAssembly, there is no thread feature, so we need to add "no thread mode" in MRI.
That mode is not limited to the WebAssembly target, and other platforms will be able to use it also. This means a platform will have multiple candidates for thread implementation.

This patch allows the thread impl to be switched by configure option instead of selecting an implementation based on target platform. e.g. `--with-thread=[pthread|win32]`