### PR TITLE
Fix script_lines in loaded iseq as nil

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -11835,7 +11835,8 @@ ibf_load_iseq_each(struct ibf_load *load, rb_iseq_t *iseq, ibf_offset_t offset)
 
     ISEQ_COVERAGE_SET(iseq, Qnil);
     ISEQ_ORIGINAL_ISEQ_CLEAR(iseq);
-    iseq->body->variable.flip_count = variable_flip_count;
+    load_body->variable.flip_count = variable_flip_count;
+    load_body->variable.script_lines = Qnil;
 
     load_body->location.first_lineno = location_first_lineno;
     load_body->location.node_id = location_node_id;

--- a/test/ruby/test_iseq.rb
+++ b/test/ruby/test_iseq.rb
@@ -464,6 +464,11 @@ class TestISeq < Test::Unit::TestCase
     a1 = iseq.to_a
     a2 = iseq2.to_a
     assert_equal(a1, a2, message(mesg) {diff iseq.disassemble, iseq2.disassemble})
+    if iseq2.script_lines
+      assert_kind_of(Array, iseq2.script_lines)
+    else
+      assert_nil(iseq2.script_lines)
+    end
     iseq2
   end
 


### PR DESCRIPTION
Fix the bug reported at https://github.com/ruby/ruby/pull/5035#issuecomment-953026347