### PR TITLE
Get rid of exponential backtracks found by CodeQL

### DIFF
--- a/tool/mkconfig.rb
+++ b/tool/mkconfig.rb
@@ -88,7 +88,7 @@ File.foreach "config.status" do |line|
       unless $install_name
         $install_name = "ruby"
         val.gsub!(/\$\$/, '$')
-        val.scan(%r[\G[\s;]*(/(?:\\.|[^/])*/)?([sy])(\\?\W)((?:(?!\3)(?:\\.|.))*)\3((?:(?!\3)(?:\\.|.))*)\3([gi]*)]) do
+        val.scan(%r[\G[\s;]*(/(?:\\.|[^/])*+/)?([sy])(\\?\W)((?:(?!\3)(?:\\.|.))*+)\3((?:(?!\3)(?:\\.|.))*+)\3([gi]*)]) do
           |addr, cmd, sep, pat, rep, opt|
           if addr
             Regexp.new(addr[/\A\/(.*)\/\z/, 1]) =~ $install_name or next

--- a/tool/rbinstall.rb
+++ b/tool/rbinstall.rb
@@ -504,7 +504,7 @@ $script_installer = Class.new(installer) do
   if trans = CONFIG["program_transform_name"]
     exp = []
     trans.gsub!(/\$\$/, '$')
-    trans.scan(%r[\G[\s;]*(/(?:\\.|[^/])*/)?([sy])(\\?\W)((?:(?!\3)(?:\\.|.))*)\3((?:(?!\3)(?:\\.|.))*)\3([gi]*)]) do
+    trans.scan(%r[\G[\s;]*(/(?:\\.|[^/])*+/)?([sy])(\\?\W)((?:(?!\3)(?:\\.|.))*+)\3((?:(?!\3)(?:\\.|.))*+)\3([gi]*)]) do
       |addr, cmd, sep, pat, rep, opt|
       addr &&= Regexp.new(addr[/\A\/(.*)\/\z/, 1])
       case cmd


### PR DESCRIPTION
Since these regexps are used at build/installation, they are not vulnerabilities.