### PR TITLE
Add one more test example for swap instruction

### DIFF
--- a/bootstraptest/test_insns.rb
+++ b/bootstraptest/test_insns.rb
@@ -120,6 +120,7 @@ tests = [
   [ 'dup',     %q{ x = y = true; x }, ],
   [ 'dupn',    %q{ Object::X ||= true }, ],
   [ 'reverse', %q{ q, (w, e), r = 1, [2, 3], 4; e == 3 }, ],
+  [ 'swap',    %q{ !!defined?([[]]) }, ],
   [ 'swap',    <<-'},', ],      # {
     x = [[false, true]]
     for i, j in x               # here


### PR DESCRIPTION
I may be confusing the purpose of this test file but personally I am using it to find examples of the ruby code that generate certain instructions. This is really helpful but the code example for the `swap` instruction is really complicated compared to other examples.

The added example generates much smaller number of instructions:
```ruby
ruby --dump=insns -e "defined? [[]]"

== disasm: #<ISeq:<main>@-e:1 (1,0)-(1,13)> (catch: TRUE)
== catch table
| catch type: rescue st: 0001 ed: 0003 sp: 0000 cont: 0005
| == disasm: #<ISeq:defined guard in <main>@-e:0 (0,0)-(-1,-1)> (catch: FALSE)
| local table (size: 1, argc: 0 [opts: 0, rest: -1, post: 0, block: -1, kw: -1@-1, kwrest: -1])
| [ 1] "\#$!"@0
| 0000 putnil
| 0001 leave
|------------------------------------------------------------------------
0000 putnil                                                           (   1)[Li]
0001 putobject                    "expression"
0003 swap
0004 pop
0005 leave
```

I'm keeping the existing example because for my purposes the more examples we have - the better 🙃 