### PR TITLE
Using RBOOL in `syserr_eqq` function

### DIFF
--- a/error.c
+++ b/error.c
@@ -2421,9 +2421,7 @@ syserr_eqq(VALUE self, VALUE exc)
 	num = rb_funcallv(exc, id_errno, 0, 0);
     }
     e = rb_const_get(self, id_Errno);
-    if (FIXNUM_P(num) ? num == e : rb_equal(num, e))
-	return Qtrue;
-    return Qfalse;
+    return RBOOL(FIXNUM_P(num) ? num == e : rb_equal(num, e));
 }
 
 


### PR DESCRIPTION
Replace and Using `RBOOL` macro in `sys_err_eqq` function.