### PR TITLE
Remove misleading ifndefs

### DIFF
--- a/vm_opts.h
+++ b/vm_opts.h
@@ -58,13 +58,8 @@
 #define OPT_STACK_CACHING            0
 
 /* misc */
-#ifndef OPT_SUPPORT_JOKE
 #define OPT_SUPPORT_JOKE             0
-#endif
-
-#ifndef OPT_SUPPORT_CALL_C_FUNCTION
 #define OPT_SUPPORT_CALL_C_FUNCTION  0
-#endif
 
 #ifndef VM_COLLECT_USAGE_DETAILS
 #define VM_COLLECT_USAGE_DETAILS     0


### PR DESCRIPTION
This PR removes misleading ifndefs. We can't dynamically set `OPT_SUPPORT_JOKE` and `OPT_SUPPORT_CALL_C_FUNCTION` since [`RubyVM::VmOptsH`](https://github.com/ruby/ruby/blob/266c90eaf944aa6d51791177966c10fd44c39e4e/tool/ruby_vm/loaders/vm_opts_h.rb#L26) uses only default values.

So, for example, including `-D OPT_SUPPORT_JOKE` now produces `compile.c:7366:13: error: use of undeclared identifier 'YARVINSN_bitblt'` error.

PS. We can make `RubyVM::VmOptsH` work with dynamically defined opts, for example by parsing `config.status`, but I don't know if this is necessary. Any suggestions are welcome.
