### PR TITLE
class.c: calculate the length of Class.descendants in advance

### DIFF
--- a/class.c
+++ b/class.c
@@ -1383,13 +1383,17 @@ rb_class_descendants(VALUE klass)
     rb_class_foreach_subclass(klass, class_descendants_recursive, (VALUE) &data);
 
     // this allocation may cause GC which may reduce the subclasses
-    data.buffer = ALLOCA_N(VALUE, data.count);
+    data.buffer = ALLOC_N(VALUE, data.count);
     data.count = 0;
 
     // enumerate subclasses
     rb_class_foreach_subclass(klass, class_descendants_recursive, (VALUE) &data);
 
-    return rb_ary_new_from_values(data.count, data.buffer);
+    VALUE ary = rb_ary_new_from_values(data.count, data.buffer);
+
+    free(data.buffer);
+
+    return ary;
 }
 
 static void

--- a/class.c
+++ b/class.c
@@ -1349,7 +1349,7 @@ class_descendants_recursive(VALUE klass, VALUE v)
     struct subclass_traverse_data *data = (struct subclass_traverse_data *) v;
 
     if (BUILTIN_TYPE(klass) == T_CLASS && !FL_TEST(klass, FL_SINGLETON)) {
-        if (data->buffer && (data->count < data->maxcount || data->maxcount == -1)) {
+        if (data->buffer && data->count < data->maxcount) {
             data->buffer[data->count] = klass;
         }
         data->count++;
@@ -1383,7 +1383,7 @@ rb_class_descendants(VALUE klass)
     // estimate the count of subclasses
     rb_class_foreach_subclass(klass, class_descendants_recursive, (VALUE) &data);
 
-    // this allocation may cause GC which may reduce the subclasses
+    // the following allocation may cause GC which may change the number of subclasses
     data.buffer = ALLOC_N(VALUE, data.count);
     data.maxcount = data.count;
     data.count = 0;

--- a/test/ruby/test_class.rb
+++ b/test/ruby/test_class.rb
@@ -755,4 +755,10 @@ class TestClass < Test::Unit::TestCase
     assert_include(object_descendants, sc)
     assert_include(object_descendants, ssc)
   end
+
+  def test_descendants_gc
+    c = Class.new
+    100000.times { Class.new(c) }
+    assert(c.descendants.size <= 100000)
+  end
 end


### PR DESCRIPTION
GC must not be triggered during callback of rb_class_foreach_subclass.
To prevent GC, we can not use rb_ary_push. Instead, this changeset calls
rb_class_foreach_subclass twice: first counts the subclasses, then
allocates a buffer (which may cause GC and reduce subclasses, but not
increase), and finally stores the subclasses to the buffer.

[Bug #18282] [Feature #14394]