### PR TITLE
Check descendant liveliness in `class_descendants_recursive`

### DIFF
--- a/class.c
+++ b/class.c
@@ -19,6 +19,7 @@
 
 #include "constant.h"
 #include "debug_counter.h"
+#include "gc.h"
 #include "id_table.h"
 #include "internal.h"
 #include "internal/class.h"
@@ -1337,7 +1338,7 @@ rb_mod_ancestors(VALUE mod)
 static void
 class_descendants_recursive(VALUE klass, VALUE ary)
 {
-    if (BUILTIN_TYPE(klass) == T_CLASS && !FL_TEST(klass, FL_SINGLETON)) {
+    if (BUILTIN_TYPE(klass) == T_CLASS && !FL_TEST(klass, FL_SINGLETON) && !rb_objspace_garbage_object_p(klass)) {
         rb_ary_push(ary, klass);
     }
     rb_class_foreach_subclass(klass, class_descendants_recursive, ary);

--- a/test/ruby/test_class.rb
+++ b/test/ruby/test_class.rb
@@ -755,4 +755,10 @@ class TestClass < Test::Unit::TestCase
     assert_include(object_descendants, sc)
     assert_include(object_descendants, ssc)
   end
+
+  def test_descendants_weak_ref
+    c = Class.new
+    100000.times { Class.new(c) }
+    c.descendants
+  end
 end


### PR DESCRIPTION
[Bug #18282]

Since `rb_class_foreach_subclass` access weak references we have to make sure the object isn't marked for sweeping already.