### PR TITLE
YJIT code pages refactoring for code GC

### DIFF
--- a/misc/yjit_asm_tests.c
+++ b/misc/yjit_asm_tests.c
@@ -426,10 +426,6 @@ void run_runtime_tests(void)
 
 int main(int argc, char** argv)
 {
-    // suppress -Wunused-function
-    (void)alloc_code_page;
-    (void)free_code_page;
-
     run_assembler_tests();
     run_runtime_tests();
 

--- a/yjit_asm.c
+++ b/yjit_asm.c
@@ -147,7 +147,7 @@ static uint8_t *align_ptr(uint8_t *ptr, uint32_t multiple)
 }
 
 // Allocate a block of executable memory
-uint8_t *alloc_exec_mem(uint32_t mem_size)
+static uint8_t *alloc_exec_mem(uint32_t mem_size)
 {
 #ifndef _WIN32
     uint8_t *mem_block;

--- a/yjit_asm.c
+++ b/yjit_asm.c
@@ -221,41 +221,6 @@ uint8_t *alloc_exec_mem(uint32_t mem_size)
 #endif
 }
 
-// Head of the list of free code pages
-static code_page_t *freelist = NULL;
-
-// Allocate a single code page from a pool of free pages
-code_page_t *alloc_code_page(void)
-{
-    // If the free list is empty
-    if (!freelist) {
-        // Allocate many pages at once
-        uint8_t *code_chunk = alloc_exec_mem(PAGES_PER_ALLOC * CODE_PAGE_SIZE);
-
-        // Do this in reverse order so we allocate our pages in order
-        for (int i = PAGES_PER_ALLOC - 1; i >= 0; --i) {
-            code_page_t *code_page = malloc(sizeof(code_page_t));
-            code_page->mem_block = code_chunk + i * CODE_PAGE_SIZE;
-            assert ((intptr_t)code_page->mem_block % CODE_PAGE_SIZE == 0);
-            code_page->page_size = CODE_PAGE_SIZE;
-            code_page->_next = freelist;
-            freelist = code_page;
-        }
-    }
-
-    code_page_t *free_page = freelist;
-    freelist = freelist->_next;
-
-    return free_page;
-}
-
-// Put a code page back into the allocation pool
-void free_code_page(code_page_t *code_page)
-{
-    code_page->_next = freelist;
-    freelist = code_page;
-}
-
 // Initialize a code block object
 void cb_init(codeblock_t *cb, uint8_t *mem_block, uint32_t mem_size)
 {

--- a/yjit_asm.h
+++ b/yjit_asm.h
@@ -5,12 +5,6 @@
 #include <stddef.h>
 #include <stdbool.h>
 
-// Size of code pages to allocate
-#define CODE_PAGE_SIZE 16 * 1024
-
-// How many code pages to allocate at once
-#define PAGES_PER_ALLOC 512
-
 // Maximum number of labels to link
 #define MAX_LABELS 32
 
@@ -137,20 +131,6 @@ typedef struct X86Opnd
 
 } x86opnd_t;
 
-// Struct representing a code page
-typedef struct code_page_struct
-{
-    // Chunk of executable memory
-    uint8_t *mem_block;
-
-    // Size of the executable memory chunk
-    uint32_t page_size;
-
-    // Next node in the free list (private)
-    struct code_page_struct *_next;
-
-} code_page_t;
-
 // Dummy none/null operand
 static const x86opnd_t NO_OPND = { OPND_NONE, 0, .as.imm = 0 };
 
@@ -264,12 +244,7 @@ static inline x86opnd_t const_ptr_opnd(const void *ptr);
      sizeof(((struct_type*)0)->member_name[0]) * idx)  \
 )
 
-// Machine code allocation
-static uint8_t *alloc_exec_mem(uint32_t mem_size);
-static code_page_t *alloc_code_page(void);
-static void free_code_page(code_page_t *code_page);
-
-
+// Code block functions
 static inline void cb_init(codeblock_t *cb, uint8_t *mem_block, uint32_t mem_size);
 static inline void cb_align_pos(codeblock_t *cb, uint32_t multiple);
 static inline void cb_set_pos(codeblock_t *cb, uint32_t pos);

--- a/yjit_asm.h
+++ b/yjit_asm.h
@@ -244,6 +244,9 @@ static inline x86opnd_t const_ptr_opnd(const void *ptr);
      sizeof(((struct_type*)0)->member_name[0]) * idx)  \
 )
 
+// Allocate executable memory
+static uint8_t *alloc_exec_mem(uint32_t mem_size);
+
 // Code block functions
 static inline void cb_init(codeblock_t *cb, uint8_t *mem_block, uint32_t mem_size);
 static inline void cb_align_pos(codeblock_t *cb, uint32_t multiple);

--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -620,7 +620,7 @@ yjit_gen_block(block_t *block, rb_execution_context_t *ec)
     };
 
     // Mark the start position of the block
-    block->start_pos = cb->write_pos;
+    block->start_addr = cb_get_write_ptr(cb);
 
     // For each instruction to compile
     for (;;) {
@@ -704,7 +704,7 @@ yjit_gen_block(block_t *block, rb_execution_context_t *ec)
     }
 
     // Mark the end position of the block
-    block->end_pos = cb->write_pos;
+    block->end_addr = cb_get_write_ptr(cb);
 
     // Store the index of the last instruction in the block
     block->end_idx = insn_idx;

--- a/yjit_core.h
+++ b/yjit_core.h
@@ -241,8 +241,8 @@ typedef struct yjit_block_version
     ctx_t ctx;
 
     // Positions where the generated code starts and ends
-    uint32_t start_pos;
-    uint32_t end_pos;
+    uint8_t* start_addr;
+    uint8_t* end_addr;
 
     // List of incoming branches (from predecessors)
     branch_array_t incoming;

--- a/yjit_core.h
+++ b/yjit_core.h
@@ -259,9 +259,6 @@ typedef struct yjit_block_version
     // block in the system.
     cme_dependency_array_t cme_dependencies;
 
-    // Code page this block lives on
-    VALUE code_page;
-
     // Index one past the last instruction in the iseq
     uint32_t end_idx;
 

--- a/yjit_core.h
+++ b/yjit_core.h
@@ -12,11 +12,10 @@
 
 // Scratch registers used by YJIT
 #define REG0 RAX
-#define REG1 RCX
 #define REG0_32 EAX
-#define REG1_32 ECX
-
 #define REG0_8 AL
+#define REG1 RCX
+#define REG1_32 ECX
 
 // Maximum number of temp value types we keep track of
 #define MAX_TEMP_TYPES 8

--- a/yjit_core.h
+++ b/yjit_core.h
@@ -192,8 +192,8 @@ typedef struct yjit_branch_entry
     struct yjit_block_version *block;
 
     // Positions where the generated code starts and ends
-    uint32_t start_pos;
-    uint32_t end_pos;
+    uint8_t* start_addr;
+    uint8_t* end_addr;
 
     // Context right after the branch instruction
     ctx_t src_ctx;

--- a/yjit_iface.c
+++ b/yjit_iface.c
@@ -60,6 +60,7 @@ yjit_iseq_pc_at_idx(const rb_iseq_t *iseq, uint32_t insn_idx)
 }
 
 // For debugging. Print the disassembly of an iseq.
+RBIMPL_ATTR_MAYBE_UNUSED()
 static void
 yjit_print_iseq(const rb_iseq_t *iseq)
 {
@@ -526,8 +527,7 @@ block_address(VALUE self)
 {
     block_t * block;
     TypedData_Get_Struct(self, block_t, &yjit_block_type, block);
-    uint8_t *code_addr = cb_get_ptr(cb, block->start_pos);
-    return LONG2NUM((intptr_t)code_addr);
+    return LONG2NUM((intptr_t)block->start_addr);
 }
 
 /* Get the machine code for YJIT::Block as a binary string */
@@ -538,8 +538,8 @@ block_code(VALUE self)
     TypedData_Get_Struct(self, block_t, &yjit_block_type, block);
 
     return (VALUE)rb_str_new(
-        (const char*)cb->mem_block + block->start_pos,
-        block->end_pos - block->start_pos
+        (const char*)block->start_addr,
+        block->end_addr - block->start_addr
     );
 }
 

--- a/yjit_iface.c
+++ b/yjit_iface.c
@@ -955,14 +955,6 @@ rb_yjit_iseq_free(const struct rb_iseq_constant_body *body)
     rb_darray_free(body->yjit_blocks);
 }
 
-
-
-
-
-
-
-
-
 // Struct representing a code page
 typedef struct code_page_struct
 {
@@ -1126,17 +1118,6 @@ yjit_get_code_page(uint32_t cb_bytes_needed, uint32_t ocb_bytes_needed)
 
     return yjit_cur_code_page;
 }
-
-
-
-
-
-
-
-
-
-
-
 
 bool
 rb_yjit_enabled_p(void)

--- a/yjit_iface.c
+++ b/yjit_iface.c
@@ -42,9 +42,6 @@ struct rb_yjit_options rb_yjit_opts;
 // How many code pages to allocate at once
 #define PAGES_PER_ALLOC 512
 
-// Current code page we are writing machine code into
-VALUE yjit_cur_code_page = Qfalse;
-
 static const rb_data_type_t yjit_block_type = {
     "YJIT/Block",
     {0, 0, 0, },
@@ -985,6 +982,9 @@ typedef struct code_page_struct
     struct code_page_struct* _next;
 
 } code_page_t;
+
+// Current code page we are writing machine code into
+static VALUE yjit_cur_code_page = Qfalse;
 
 // Head of the list of free code pages
 static code_page_t *code_page_freelist = NULL;

--- a/yjit_iface.c
+++ b/yjit_iface.c
@@ -36,6 +36,15 @@ extern st_table *rb_encoded_insn_data;
 
 struct rb_yjit_options rb_yjit_opts;
 
+// Size of code pages to allocate
+#define CODE_PAGE_SIZE 16 * 1024
+
+// How many code pages to allocate at once
+#define PAGES_PER_ALLOC 512
+
+// Current code page we are writing machine code into
+VALUE yjit_cur_code_page = Qfalse;
+
 static const rb_data_type_t yjit_block_type = {
     "YJIT/Block",
     {0, 0, 0, },
@@ -880,7 +889,7 @@ rb_yjit_iseq_mark(const struct rb_iseq_constant_body *body)
             }
 
             // Mark the machine code page this block lives on
-            rb_gc_mark_movable(block->code_page);
+            //rb_gc_mark_movable(block->code_page);
         }
     }
 }
@@ -926,7 +935,7 @@ rb_yjit_iseq_update_references(const struct rb_iseq_constant_body *body)
             }
 
             // Update the machine code page this block lives on
-            block->code_page = rb_gc_location(block->code_page);
+            //block->code_page = rb_gc_location(block->code_page);
         }
     }
 }
@@ -949,10 +958,44 @@ rb_yjit_iseq_free(const struct rb_iseq_constant_body *body)
     rb_darray_free(body->yjit_blocks);
 }
 
-static void
-yjit_code_page_free(void *code_page)
+
+
+
+
+
+
+
+
+// Struct representing a code page
+typedef struct code_page_struct
 {
-    free_code_page((code_page_t*)code_page);
+    // Chunk of executable memory
+    uint8_t* mem_block;
+
+    // Size of the executable memory chunk
+    uint32_t page_size;
+
+    // Inline code block
+    codeblock_t cb;
+
+    // Outlined code block
+    codeblock_t ocb;
+
+    // Next node in the free list (private)
+    struct code_page_struct* _next;
+
+} code_page_t;
+
+// Head of the list of free code pages
+code_page_t *freelist = NULL;
+
+// Free a code page, add it to the free list
+static void
+yjit_code_page_free(void *voidp)
+{
+    code_page_t* code_page = (code_page_t*)voidp;
+    code_page->_next = freelist;
+    freelist = code_page;
 }
 
 // Custom type for interacting with the GC
@@ -965,13 +1008,39 @@ static const rb_data_type_t yjit_code_page_type = {
 // Allocate a code page and wrap it into a Ruby object owned by the GC
 VALUE rb_yjit_code_page_alloc(void)
 {
-    code_page_t *code_page = alloc_code_page();
-    VALUE cp_obj = TypedData_Wrap_Struct(0, &yjit_code_page_type, code_page);
+    // If the free list is empty
+    if (!freelist) {
+        // Allocate many pages at once
+        uint8_t* code_chunk = alloc_exec_mem(PAGES_PER_ALLOC * CODE_PAGE_SIZE);
 
-    // Write a pointer to the wrapper object at the beginning of the code page
-    *((VALUE*)code_page->mem_block) = cp_obj;
+        // Do this in reverse order so we allocate our pages in order
+        for (int i = PAGES_PER_ALLOC - 1; i >= 0; --i) {
+            code_page_t* code_page = malloc(sizeof(code_page_t));
+            code_page->mem_block = code_chunk + i * CODE_PAGE_SIZE;
+            assert ((intptr_t)code_page->mem_block % CODE_PAGE_SIZE == 0);
+            code_page->page_size = CODE_PAGE_SIZE;
+            code_page->_next = freelist;
+            freelist = code_page;
+        }
+    }
 
-    return cp_obj;
+    code_page_t* code_page = freelist;
+    freelist = freelist->_next;
+
+    // Create a Ruby wrapper struct for the code page object
+    VALUE wrapper = TypedData_Wrap_Struct(0, &yjit_code_page_type, code_page);
+
+    // Write a pointer to the wrapper object on the page
+    *((VALUE*)code_page->mem_block) = wrapper;
+
+    // Initialize the code blocks
+    uint8_t* page_start = code_page->mem_block + sizeof(VALUE);
+    uint8_t* page_end = code_page->mem_block + CODE_PAGE_SIZE;
+    uint32_t halfsize = (uint32_t)(page_end - page_start) / 2;
+    cb_init(&code_page->cb, page_start, halfsize);
+    cb_init(&code_page->cb, page_start + halfsize, halfsize);
+
+    return wrapper;
 }
 
 // Unwrap the Ruby object representing a code page
@@ -983,21 +1052,21 @@ code_page_t *rb_yjit_code_page_unwrap(VALUE cp_obj)
 }
 
 // Get the code page wrapper object for a code pointer
-VALUE rb_yjit_code_page_from_ptr(uint8_t *code_ptr)
+VALUE rb_yjit_code_page_from_ptr(uint8_t* code_ptr)
 {
-    VALUE *page_start = (VALUE*)((intptr_t)code_ptr & ~(CODE_PAGE_SIZE - 1));
+    VALUE* page_start = (VALUE*)((intptr_t)code_ptr & ~(CODE_PAGE_SIZE - 1));
     VALUE wrapper = *page_start;
     return wrapper;
 }
 
 // Get the inline code block corresponding to a code pointer
-void rb_yjit_get_cb(codeblock_t *cb, uint8_t *code_ptr)
+void rb_yjit_get_cb(codeblock_t* cb, uint8_t* code_ptr)
 {
     VALUE page_wrapper = rb_yjit_code_page_from_ptr(code_ptr);
     code_page_t *code_page = rb_yjit_code_page_unwrap(page_wrapper);
 
     // A pointer to the page wrapper object is written at the start of the code page
-    uint8_t *mem_block = code_page->mem_block + sizeof(VALUE);
+    uint8_t* mem_block = code_page->mem_block + sizeof(VALUE);
     uint32_t mem_size = (code_page->page_size/2) - sizeof(VALUE);
     RUBY_ASSERT(mem_block);
 
@@ -1006,19 +1075,63 @@ void rb_yjit_get_cb(codeblock_t *cb, uint8_t *code_ptr)
 }
 
 // Get the outlined code block corresponding to a code pointer
-void rb_yjit_get_ocb(codeblock_t *cb, uint8_t *code_ptr)
+void rb_yjit_get_ocb(codeblock_t* cb, uint8_t* code_ptr)
 {
     VALUE page_wrapper = rb_yjit_code_page_from_ptr(code_ptr);
     code_page_t *code_page = rb_yjit_code_page_unwrap(page_wrapper);
 
     // A pointer to the page wrapper object is written at the start of the code page
-    uint8_t *mem_block = code_page->mem_block + (code_page->page_size/2);
+    uint8_t* mem_block = code_page->mem_block + (code_page->page_size/2);
     uint32_t mem_size = code_page->page_size/2;
     RUBY_ASSERT(mem_block);
 
     // Map the code block to this memory region
     cb_init(cb, mem_block, mem_size);
 }
+
+// Get the current code page or allocate a new one
+VALUE
+yjit_get_code_page(uint32_t cb_bytes_needed, uint32_t ocb_bytes_needed)
+{
+    // If this is the first code page
+    if (yjit_cur_code_page == Qfalse) {
+        yjit_cur_code_page = rb_yjit_code_page_alloc();
+    }
+
+    // Get the current code page
+    code_page_t *code_page = rb_yjit_code_page_unwrap(yjit_cur_code_page);
+
+    // Compute how many bytes are left in the code blocks
+    uint32_t cb_bytes_left = code_page->cb.mem_size - code_page->cb.write_pos;
+    uint32_t ocb_bytes_left = code_page->ocb.mem_size - code_page->ocb.write_pos;
+    RUBY_ASSERT_ALWAYS(cb_bytes_needed <= code_page->cb.mem_size);
+    RUBY_ASSERT_ALWAYS(ocb_bytes_needed <= code_page->ocb.mem_size);
+
+    // If there's enough space left in the current code page
+    if (cb_bytes_needed <= cb_bytes_left && ocb_bytes_needed <= ocb_bytes_left) {
+        return yjit_cur_code_page;
+    }
+
+    // Allocate a new code page
+    yjit_cur_code_page = rb_yjit_code_page_alloc();
+    code_page_t *new_code_page = rb_yjit_code_page_unwrap(yjit_cur_code_page);
+
+    // Jump to the new code page
+    jmp_ptr(&code_page->cb, new_code_page->cb.mem_block);
+
+    return yjit_cur_code_page;
+}
+
+
+
+
+
+
+
+
+
+
+
 
 bool
 rb_yjit_enabled_p(void)

--- a/yjit_iface.h
+++ b/yjit_iface.h
@@ -30,9 +30,16 @@ static const VALUE *yjit_count_side_exit_op(const VALUE *exit_pc);
 static void yjit_unlink_method_lookup_dependency(block_t *block);
 static void yjit_block_assumptions_free(block_t *block);
 
+
+
+VALUE yjit_get_code_page(uint32_t cb_bytes_needed, uint32_t ocb_bytes_needed);
 VALUE rb_yjit_code_page_alloc(void);
-code_page_t *rb_yjit_code_page_unwrap(VALUE cp_obj);
-void rb_yjit_get_cb(codeblock_t *cb, uint8_t *code_ptr);
-void rb_yjit_get_ocb(codeblock_t *cb, uint8_t *code_ptr);
+//code_page_t *rb_yjit_code_page_unwrap(VALUE cp_obj);
+//void rb_yjit_get_cb(codeblock_t* cb, uint8_t* code_ptr);
+//void rb_yjit_get_ocb(codeblock_t* cb, uint8_t* code_ptr);
+
+
+
+
 
 #endif // #ifndef YJIT_IFACE_H

--- a/yjit_iface.h
+++ b/yjit_iface.h
@@ -30,16 +30,9 @@ static const VALUE *yjit_count_side_exit_op(const VALUE *exit_pc);
 static void yjit_unlink_method_lookup_dependency(block_t *block);
 static void yjit_block_assumptions_free(block_t *block);
 
-
-
 static VALUE yjit_get_code_page(uint32_t cb_bytes_needed, uint32_t ocb_bytes_needed);
-static VALUE rb_yjit_code_page_alloc(void);
 //code_page_t *rb_yjit_code_page_unwrap(VALUE cp_obj);
 //void rb_yjit_get_cb(codeblock_t* cb, uint8_t* code_ptr);
 //void rb_yjit_get_ocb(codeblock_t* cb, uint8_t* code_ptr);
-
-
-
-
 
 #endif // #ifndef YJIT_IFACE_H

--- a/yjit_iface.h
+++ b/yjit_iface.h
@@ -32,8 +32,8 @@ static void yjit_block_assumptions_free(block_t *block);
 
 
 
-VALUE yjit_get_code_page(uint32_t cb_bytes_needed, uint32_t ocb_bytes_needed);
-VALUE rb_yjit_code_page_alloc(void);
+static VALUE yjit_get_code_page(uint32_t cb_bytes_needed, uint32_t ocb_bytes_needed);
+static VALUE rb_yjit_code_page_alloc(void);
 //code_page_t *rb_yjit_code_page_unwrap(VALUE cp_obj);
 //void rb_yjit_get_cb(codeblock_t* cb, uint8_t* code_ptr);
 //void rb_yjit_get_ocb(codeblock_t* cb, uint8_t* code_ptr);


### PR DESCRIPTION
New code page allocation logic.

Changes start_pos and end_pos in blocks and branches to be pointers.

Work towards the goal of eliminating global cb/ocb code block objects.