### PR TITLE
test/ruby/test_gc_compact.rb: Do not run on s390x

### DIFF
--- a/test/ruby/test_gc_compact.rb
+++ b/test/ruby/test_gc_compact.rb
@@ -4,7 +4,7 @@ require 'fiddle'
 require 'etc'
 
 if RUBY_PLATFORM =~ /s390x/
-  puts "Currently, it is known that the compaction does not work well on s390x; contribution is welcome https://github.com/ruby/ruby/pull/XXXX"
+  puts "Currently, it is known that the compaction does not work well on s390x; contribution is welcome https://github.com/ruby/ruby/pull/5077"
   return
 end
 

--- a/test/ruby/test_gc_compact.rb
+++ b/test/ruby/test_gc_compact.rb
@@ -3,6 +3,11 @@ require 'test/unit'
 require 'fiddle'
 require 'etc'
 
+if RUBY_PLATFORM =~ /s390x/
+  puts "Currently, it is known that the compaction does not work well on s390x; contribution is welcome https://github.com/ruby/ruby/pull/XXXX"
+  return
+end
+
 class TestGCCompact < Test::Unit::TestCase
   module SupportsCompact
     def setup


### PR DESCRIPTION
The compaction tests get stuck randomly on s390x for unknown reason.

http://rubyci.s3.amazonaws.com/s390x/ruby-master/log/20211104T030003Z.fail.html.gz
```
[13715/21145] TestGCCompact#test_gc_compact_statstimeout: output interval exceeds 1800.0 seconds.
```

We spent some time to investigate this issue, but we can't figure out
why, and it is unlikely that we'll be able to fix it anytime soon.

This random failure makes the CI unuseful, so tentatively we suppress
this test for a while. A contribution from those who are familiar with
s390x is welcome.