### PR TITLE
Skip bundled gem with an extension library under with-static-linked-ext

### DIFF
--- a/tool/rbinstall.rb
+++ b/tool/rbinstall.rb
@@ -1039,6 +1039,10 @@ install?(:ext, :comm, :gem, :'bundled-gems') do
     end
     next unless spec.platform == Gem::Platform::RUBY
     next unless spec.full_name == gem_name
+    if !spec.extensions.empty? && CONFIG["EXTSTATIC"] == "static"
+      puts "skip installation of #{spec.name} #{spec.version}; bundled gem with an extension library is not supported on --with-static-linked-ext"
+      next
+    end
     spec.extension_dir = "#{extensions_dir}/#{spec.full_name}"
     if File.directory?(ext = "#{gem_ext_dir}/#{spec.full_name}")
       spec.extensions[0] ||= "-"


### PR DESCRIPTION
.. mainly to fix emscripten CI

http://rubyci.s3.amazonaws.com/crossruby/crossruby-master-wasm64_emscripten/log/20211104T024621Z.fail.html.gz