### PR TITLE
Add support of sort argument as nil for Dir.glob

### DIFF
--- a/dir.c
+++ b/dir.c
@@ -2937,7 +2937,7 @@ dir_glob_option_base(VALUE base)
 static int
 dir_glob_option_sort(VALUE sort)
 {
-    return (sort ? 0 : FNM_GLOB_NOSORT);
+    return ((NIL_P(sort) || sort == Qfalse) ? FNM_GLOB_NOSORT : 0);
 }
 
 static VALUE


### PR DESCRIPTION
Right now `Dir.glob("*", sort: nil)` will produce the same result as `Dir.glob("*", sort: true)`.

```
irb(main):001:0> Dir.glob("brace/a{.js,*}", sort: true)
=> ["brace/a.js", "brace/a", "brace/a.erb", "brace/a.html.erb", "brace/a.js", "brace/a.js.rjs"]

irb(main):001:0> Dir.glob("brace/a{.js,*}", sort: false)
=> ["brace/a.js", "brace/a.js", "brace/a.html.erb", "brace/a.erb", "brace/a.js.rjs", "brace/a"]

irb(main):001:0> Dir.glob("brace/a{.js,*}", sort: nil)
=> ["brace/a.js", "brace/a", "brace/a.erb", "brace/a.html.erb", "brace/a.js", "brace/a.js.rjs"]
```

After this patch both `Dir.glob("*", sort: false)` and `Dir.glob("*"
sort: nil)` will produce identical unsorted results.

Current behaviour was noted here: https://github.com/ruby/spec/pull/894 and @eregon suggested addressing it [bugs#18287](https://bugs.ruby-lang.org/issues/18287)