### PR TITLE
YJIT: Support iseq sends with mixed kwargs

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -2187,6 +2187,60 @@ assert_equal '[3]', %q{
   5.times.map { default_expression }.uniq
 }
 
+# reordered optional kwargs
+assert_equal '[[100, 1]]', %q{
+  def foo(capacity: 100, max: nil)
+    [capacity, max]
+  end
+
+  5.times.map { foo(max: 1) }.uniq
+}
+
+# invalid lead param
+assert_equal 'ok', %q{
+  def bar(baz: 2)
+    baz
+  end
+
+  def foo
+    bar(1, baz: 123)
+  end
+
+  begin
+    foo
+    foo
+  rescue ArgumentError => e
+    print "ok"
+  end
+}
+
+# reordered required kwargs
+assert_equal '[[1, 2, 3, 4]]', %q{
+  def foo(default1: 1, required1:, default2: 3, required2:)
+    [default1, required1, default2, required2]
+  end
+
+  5.times.map { foo(required1: 2, required2: 4) }.uniq
+}
+
+# reordered default expression kwargs
+assert_equal '[[:one, :two, 3]]', %q{
+  def foo(arg1: (1+0), arg2: (2+0), arg3: (3+0))
+    [arg1, arg2, arg3]
+  end
+
+  5.times.map { foo(arg2: :two, arg1: :one) }.uniq
+}
+
+# complex kwargs
+assert_equal '[[1, 2, 3, 4]]', %q{
+  def foo(required:, specified: 999, simple_default: 3, complex_default: "4".to_i)
+    [required, specified, simple_default, complex_default]
+  end
+
+  5.times.map { foo(specified: 2, required: 1) }.uniq
+}
+
 # attr_reader on frozen object
 assert_equal 'false', %q{
   class Foo

--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -3711,6 +3711,7 @@ gen_send_iseq(jitstate_t *jit, ctx_t *ctx, const struct rb_callinfo *ci, const r
     x86opnd_t recv = ctx_stack_opnd(ctx, argc);
 
     // Store the updated SP on the current frame (pop arguments and receiver)
+    ADD_COMMENT(cb, "store caller sp");
     lea(cb, REG0, ctx_sp_opnd(ctx, sizeof(VALUE) * -(argc + 1)));
     mov(cb, member_opnd(REG_CFP, rb_control_frame_t, sp), REG0);
 
@@ -3733,6 +3734,7 @@ gen_send_iseq(jitstate_t *jit, ctx_t *ctx, const struct rb_callinfo *ci, const r
         mov(cb, mem_opnd(64, REG0, sizeof(VALUE) * (i - num_locals - 3)), imm_opnd(Qnil));
     }
 
+    ADD_COMMENT(cb, "push env");
     // Put compile time cme into REG1. It's assumed to be valid because we are notified when
     // any cme we depend on become outdated. See rb_yjit_method_lookup_change().
     jit_mov_gc_ptr(jit, cb, REG1, (VALUE)cme);
@@ -3757,6 +3759,7 @@ gen_send_iseq(jitstate_t *jit, ctx_t *ctx, const struct rb_callinfo *ci, const r
     uint64_t frame_type = VM_FRAME_MAGIC_METHOD | VM_ENV_FLAG_LOCAL;
     mov(cb, mem_opnd(64, REG0, 8 * -1), imm_opnd(frame_type));
 
+    ADD_COMMENT(cb, "push callee CFP");
     // Allocate a new CFP (ec->cfp--)
     sub(cb, REG_CFP, imm_opnd(sizeof(rb_control_frame_t)));
     mov(cb, member_opnd(REG_EC, rb_execution_context_t, cfp), REG_CFP);


### PR DESCRIPTION
Previously we only supported kwargs in two cases: when all arguments were specified, or when none were (and all keywords were optional). This commit adds support for calls which have a mix of specified and default arguments.

We chose to implement this by pushing the default values for unspecified keywords and then allowing the existing shuffling logic to move both specified and default values into the correct location. This isn't optimal for performance (ideally we could only write each value once), but we'd like to use this approach at least initially for the simplicity. This commit actually reduces the lines of code due to removing checks for cases that we now support 😁.

@kddnewton and I paired to make this ❤️