### PR TITLE
YJIT: Implement checkkeyword

### DIFF
--- a/test/ruby/test_yjit.rb
+++ b/test/ruby/test_yjit.rb
@@ -397,6 +397,16 @@ class TestYJIT < Test::Unit::TestCase
     RUBY
   end
 
+  def test_checkkeyword
+    assert_compiles(<<~'RUBY', insns: %i[checkkeyword], result: [2, 5])
+      def foo(foo: 1+1)
+        foo
+      end
+
+      [foo, foo(foo: 5)]
+    RUBY
+  end
+
   def test_invokebuiltin
     assert_compiles(<<~RUBY)
       def foo(obj)


### PR DESCRIPTION
@seejohnrun and I implemented this together on his Twitch stream 😁

The `checkkeyword` instruction is used to check whether or not a keyword (specifically keywords with expressions as default values) was specified. I think the most common case for this will be when constants or other methods are used as default values.

This works by checking a bit in the hidden "unspecified bits" local variable and pushing Qtrue or Qfalse depending on its value. We're able to do fewer checks than the interpreter in this because the interpreter must check whether the variable is a FIXNUM (a Hash is used for functions with many keywords), but we can check the number of keywords for our iseq at compile time to assume that.

Example:

```
SOME_CONST = 123

def foo(keyword: SOME_CONST)
  keyword
end
```

 Compiles to:

```
== BLOCK 1/3: 48 BYTES, ISEQ RANGE [0,5) =======================================
  ; checkkeyword
  55a437d3605d:  mov    rax, qword ptr [r13 + 0x20]
  55a437d36061:  test   byte ptr [rax - 0x18], 2
  55a437d36065:  movabs rax, 0
  55a437d3606f:  movabs rcx, 0x14
  55a437d36079:  cmove  rax, rcx
  55a437d3607d:  mov    qword ptr [rbx], rax
  ; branchif
  55a437d36080:  test   qword ptr [rbx], -9
  55a437d36087:  jne    0x55a43fd3601b
== BLOCK 2/3: 13 BYTES, ISEQ RANGE [5,8) =======================================
  ; opt_getinlinecache
  55a437d3608d:  movabs rax, 0xf7
  55a437d36097:  mov    qword ptr [rbx], rax
== BLOCK 3/3: 76 BYTES, ISEQ RANGE [14,19) =====================================
  ; setlocal_WC_0
  55a437d3609a:  mov    rax, qword ptr [r13 + 0x20]
  55a437d3609e:  test   byte ptr [rax], 8
  55a437d360a1:  jne    0x55a43fd36057
  55a437d360a7:  mov    rcx, qword ptr [rbx]
  55a437d360aa:  mov    qword ptr [rax - 0x20], rcx
  ; getlocal_WC_0
  55a437d360ae:  mov    rax, qword ptr [r13 + 0x20]
  55a437d360b2:  mov    rax, qword ptr [rax - 0x20]
  55a437d360b6:  mov    qword ptr [rbx], rax
  ; leave
  55a437d360b9:  mov    rcx, qword ptr [r13 + 0x20]
  ; check for interrupts
  ; RUBY_VM_CHECK_INTS(ec)
  55a437d360bd:  mov    eax, dword ptr [r12 + 0x24]
  55a437d360c2:  not    eax
  55a437d360c4:  test   dword ptr [r12 + 0x20], eax
  55a437d360c9:  jne    0x55a43fd3607d
  55a437d360cf:  mov    rax, qword ptr [rbx]
  55a437d360d2:  add    r13, 0x40
  55a437d360d6:  mov    qword ptr [r12 + 0x10], r13
  55a437d360db:  mov    rbx, qword ptr [r13 + 8]
  55a437d360df:  mov    qword ptr [rbx], rax
  55a437d360e2:  jmp    qword ptr [r13 - 8]
```

cc @kddnewton for extra 👀 on kwargs