### PR TITLE
Slightly faster Lexer::Elem#to_a

### DIFF
--- a/ext/ripper/lib/ripper/lexer.rb
+++ b/ext/ripper/lib/ripper/lexer.rb
@@ -95,7 +95,7 @@ class Ripper
 
       def to_a
         a = super
-        a.pop unless a.last
+        a.pop unless a.empty?
         a
       end
     end


### PR DESCRIPTION
According to ruby-prof when lexing this document https://github.com/zombocom/dead_end/blob/e8eb54c651bfa196fc933f76def5d811bb5d57dc/spec/fixtures/ruby_buildpack.rb.txt the method `Lexer::Elem#to_a` is called 8350 times.

This method uses Array#last to determine if an element can be popped. I propose switching to using `Array#empty?` which is also faster:

## Empty versus last benchmark

```ruby
require 'benchmark/ips'

array = []
Benchmark.ips do |x|
  x.report("empty?") { array.empty? }
  x.report("last") { array.last }
  x.compare!
end; nil
```

Results:

```
Warming up --------------------------------------
              empty?     2.503M i/100ms
                last     1.879M i/100ms
Calculating -------------------------------------
              empty?     24.459M (± 5.6%) i/s -    122.631M in   5.032111s
                last     18.798M (± 5.4%) i/s -     93.968M in   5.017098s

Comparison:
              empty?: 24459005.3 i/s
                last: 18798268.9 i/s - 1.30x  (± 0.00) slower
```

This is a minor improvement. For a more substantial improvement, I am suggesting a larger change. Would you consider accepting to change the implementation of these Structs inside of Lexer to be real classes? Here are some benchmarks: 
https://gist.github.com/schneems/b7bc853ab1e7193f836f7296ac149024

## Real benchmark

```ruby
class State; def initialize(val); end; end

Elem = Struct.new(:pos, :event, :tok, :state, :message) do
  def initialize(pos, event, tok, state, message = nil)
    super(pos, event, tok, State.new(state), message)
  end

  # ...

  def to_a
    a = super
    a.pop unless a.last
    a
  end
end


class State; def initialize(val); end; end

ElemUpdated = Struct.new(:pos, :event, :tok, :state, :message) do
  def initialize(pos, event, tok, state, message = nil)
    super(pos, event, tok, State.new(state), message)
  end

  # ...

  def to_a
    a = super
    a.pop unless a.empty?
    a
  end
end

require 'benchmark/ips'
require 'ripper'

pos = [1, 2] 
event = :on_nl 
tok = "\n".freeze 
state = Ripper::EXPR_BEG

old = Elem.new(pos, event, tok, state)
updated =  ElemUpdated.new(pos, event, tok, state)

Benchmark.ips do |x|
  x.report("last   ") { old.to_a }
  x.report("empty? ") { updated.to_a }
  x.compare!
end; nil
```

Performance is faster, but within stdev:

```
Warming up --------------------------------------
             last      589.801k i/100ms
             empty?    629.091k i/100ms
Calculating -------------------------------------
             last         5.943M (± 5.0%) i/s -     30.080M in   5.075066s
             empty?       6.312M (± 6.9%) i/s -     31.455M in   5.010495s

Comparison:
             empty? :  6312431.2 i/s
             last   :  5943332.7 i/s - same-ish: difference falls within error
```

Would a change like https://gist.github.com/schneems/b7bc853ab1e7193f836f7296ac149024 interest you?

