### PR TITLE
memory_view.c: Add _memory_view_entry member in rb_memory_view_t

### DIFF
--- a/include/ruby/memory_view.h
+++ b/include/ruby/memory_view.h
@@ -146,8 +146,11 @@ typedef struct {
      * Or, NULL when this memory view exposes a flat array. */
     const ssize_t *sub_offsets;
 
-    /** the private data for managing this exported memory */
+    /** The private data for managing this exported memory */
     void *private_data;
+
+    /** DO NOT TOUCH THIS: The memory view entry for the internal use */
+    const struct rb_memory_view_entry *_memory_view_entry;
 } rb_memory_view_t;
 
 /** Type of function of ::rb_memory_view_entry_t::get_func. */
@@ -160,9 +163,10 @@ typedef bool (* rb_memory_view_release_func_t)(VALUE obj, rb_memory_view_t *view
 typedef bool (* rb_memory_view_available_p_func_t)(VALUE obj);
 
 /** Operations applied to a specific kind of a memory view. */
-typedef struct {
-
-    /** Exports a memory view from a Ruby object. */
+typedef struct rb_memory_view_entry {
+    /**
+     * Exports a memory view from a Ruby object.
+     */
     rb_memory_view_get_func_t get_func;
 
     /**

--- a/memory_view.c
+++ b/memory_view.c
@@ -108,9 +108,8 @@ static void
 unregister_exported_object(VALUE obj)
 {
     RB_VM_LOCK_ENTER();
-    if (!exported_object_table)
-        return;
-    st_update(exported_object_table, (st_data_t)obj, exported_object_dec_ref, 0);
+    if (exported_object_table)
+        st_update(exported_object_table, (st_data_t)obj, exported_object_dec_ref, 0);
     RB_VM_LOCK_LEAVE();
 }
 


### PR DESCRIPTION
To stop looking up the memory_view_entry from the class of the original object of a memory_view in rb_memory_view_release, a pointer of rb_memory_view_entry_t is added as a member of rb_memory_view_t.

This will fix #5012