### PR TITLE
Add `nd_type_p` macro

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -298,7 +298,7 @@ dump_block(rb_ast_t *ast, const NODE *node)
     do {
         rb_ary_push(ary, NEW_CHILD(ast, node->nd_head));
     } while (node->nd_next &&
-        nd_type(node->nd_next) == NODE_BLOCK &&
+        nd_type_p(node->nd_next, NODE_BLOCK) &&
         (node = node->nd_next, 1));
     if (node->nd_next) {
         rb_ary_push(ary, NEW_CHILD(ast, node->nd_next));
@@ -313,7 +313,7 @@ dump_array(rb_ast_t *ast, const NODE *node)
     VALUE ary = rb_ary_new();
     rb_ary_push(ary, NEW_CHILD(ast, node->nd_head));
 
-    while (node->nd_next && nd_type(node->nd_next) == NODE_LIST) {
+    while (node->nd_next && nd_type_p(node->nd_next, NODE_LIST)) {
         node = node->nd_next;
         rb_ary_push(ary, NEW_CHILD(ast, node->nd_head));
     }
@@ -399,7 +399,7 @@ node_children(rb_ast_t *ast, const NODE *node)
 
             while (1) {
                 rb_ary_push(ary, NEW_CHILD(ast, node->nd_1st));
-                if (!node->nd_2nd || nd_type(node->nd_2nd) != (int)type)
+                if (!node->nd_2nd || !nd_type_p(node->nd_2nd, (int)type))
                     break;
                 node = node->nd_2nd;
             }

--- a/ast.c
+++ b/ast.c
@@ -399,7 +399,7 @@ node_children(rb_ast_t *ast, const NODE *node)
 
             while (1) {
                 rb_ary_push(ary, NEW_CHILD(ast, node->nd_1st));
-                if (!node->nd_2nd || !nd_type_p(node->nd_2nd, (int)type))
+                if (!node->nd_2nd || !nd_type_p(node->nd_2nd, type))
                     break;
                 node = node->nd_2nd;
             }

--- a/compile.c
+++ b/compile.c
@@ -1783,7 +1783,7 @@ iseq_set_arguments_keywords(rb_iseq_t *iseq, LINK_ANCHOR *const optargs,
 		dv = Qfalse;
 		break;
 	      default:
-                NO_CHECK(COMPILE_POPPED(optargs, "kwarg", node)); /* nd_type(node) == NODE_KW_ARG */
+                NO_CHECK(COMPILE_POPPED(optargs, "kwarg", node)); /* nd_type_p(node, NODE_KW_ARG) */
 		dv = complex_mark;
 	    }
 

--- a/compile.c
+++ b/compile.c
@@ -753,7 +753,7 @@ rb_iseq_compile_node(rb_iseq_t *iseq, const NODE *node)
 	iseq_set_local_table(iseq, 0);
     }
     /* assume node is T_NODE */
-    else if (nd_type(node) == NODE_SCOPE) {
+    else if (nd_type_p(node, NODE_SCOPE)) {
 	/* iseq type of top, method, class, block */
 	iseq_set_local_table(iseq, node->nd_tbl);
 	iseq_set_arguments(iseq, ret, node->nd_args);
@@ -3914,7 +3914,7 @@ compile_dstr_fragments(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *cons
 
     while (list) {
 	const NODE *const head = list->nd_head;
-	if (nd_type(head) == NODE_STR) {
+	if (nd_type_p(head, NODE_STR)) {
 	    lit = rb_fstring(head->nd_lit);
 	    ADD_INSN1(ret, head, putobject, lit);
             RB_OBJ_WRITTEN(iseq, Qundef, lit);
@@ -3938,7 +3938,7 @@ compile_dstr_fragments(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *cons
 static int
 compile_block(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, int popped)
 {
-    while (node && nd_type(node) == NODE_BLOCK) {
+    while (node && nd_type_p(node, NODE_BLOCK)) {
         CHECK(COMPILE_(ret, "BLOCK body", node->nd_head,
                        (node->nd_next ? 1 : popped)));
         node = node->nd_next;
@@ -4083,7 +4083,7 @@ compile_branch_condition(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *co
 static int
 keyword_node_p(const NODE *const node)
 {
-    return nd_type(node) == NODE_HASH && (node->nd_brace & HASH_BRACE) != HASH_BRACE;
+    return nd_type_p(node, NODE_HASH) && (node->nd_brace & HASH_BRACE) != HASH_BRACE;
 }
 
 static int
@@ -4094,7 +4094,7 @@ compile_keyword_arg(rb_iseq_t *iseq, LINK_ANCHOR *const ret,
 {
     if (kw_arg_ptr == NULL) return FALSE;
 
-    if (root_node->nd_head && nd_type(root_node->nd_head) == NODE_LIST) {
+    if (root_node->nd_head && nd_type_p(root_node->nd_head, NODE_LIST)) {
 	const NODE *node = root_node->nd_head;
         int seen_nodes = 0;
 
@@ -4102,8 +4102,8 @@ compile_keyword_arg(rb_iseq_t *iseq, LINK_ANCHOR *const ret,
 	    const NODE *key_node = node->nd_head;
             seen_nodes++;
 
-	    assert(nd_type(node) == NODE_LIST);
-            if (key_node && nd_type(key_node) == NODE_LIT && SYMBOL_P(key_node->nd_lit)) {
+	    assert(nd_type_p(node, NODE_LIST));
+            if (key_node && nd_type_p(key_node, NODE_LIT) && SYMBOL_P(key_node->nd_lit)) {
 		/* can be keywords */
 	    }
 	    else {
@@ -4224,7 +4224,7 @@ compile_array(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, int pop
 {
     const NODE *line_node = node;
 
-    if (nd_type(node) == NODE_ZLIST) {
+    if (nd_type_p(node, NODE_ZLIST)) {
 	if (!popped) {
 	    ADD_INSN1(ret, line_node, newarray, INT2FIX(0));
 	}
@@ -4361,7 +4361,7 @@ compile_hash(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, int meth
 
     node = node->nd_head;
 
-    if (!node || nd_type(node) == NODE_ZLIST) {
+    if (!node || nd_type_p(node, NODE_ZLIST)) {
 	if (!popped) {
 	    ADD_INSN1(ret, line_node, newhash, INT2FIX(0));
 	}
@@ -4484,7 +4484,7 @@ compile_hash(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, int meth
                 FLUSH_CHUNK();
 
                 const NODE *kw = node->nd_next->nd_head;
-                int empty_kw = nd_type(kw) == NODE_LIT && RB_TYPE_P(kw->nd_lit, T_HASH); /* foo(  ..., **{}, ...) */
+                int empty_kw = nd_type_p(kw, NODE_LIT) && RB_TYPE_P(kw->nd_lit, T_HASH); /* foo(  ..., **{}, ...) */
                 int first_kw = first_chunk && stack_len == 0; /* foo(1,2,3, **kw, ...) */
                 int last_kw = !node->nd_next->nd_next;        /* foo(  ..., **kw) */
                 int only_kw = last_kw && first_kw;            /* foo(1,2,3, **kw) */
@@ -4590,7 +4590,7 @@ when_vals(rb_iseq_t *iseq, LINK_ANCHOR *const cond_seq, const NODE *vals,
             rb_hash_aset(literals, lit, (VALUE)(l1) | 1);
 	}
 
-	if (nd_type(val) == NODE_STR) {
+	if (nd_type_p(val, NODE_STR)) {
 	    debugp_param("nd_lit", val->nd_lit);
 	    lit = rb_fstring(val->nd_lit);
 	    ADD_INSN1(cond_seq, val, putobject, lit);
@@ -4884,7 +4884,7 @@ compile_massign_opt(rb_iseq_t *iseq, LINK_ANCHOR *const ret,
     mem[memindex++] = (v); \
 }
 
-    if (rhsn == 0 || nd_type(rhsn) != NODE_LIST) {
+    if (rhsn == 0 || !nd_type_p(rhsn, NODE_LIST)) {
 	return 0;
     }
 
@@ -4952,7 +4952,7 @@ compile_massign0(rb_iseq_t *iseq, LINK_ANCHOR *const pre, LINK_ANCHOR *const rhs
     }
 
     if (lhs_splat) {
-        if (nd_type(splatn) == NODE_POSTARG) {
+        if (nd_type_p(splatn, NODE_POSTARG)) {
             /*a, b, *r, p1, p2 */
             const NODE *postn = splatn->nd_2nd;
             const NODE *restn = splatn->nd_1st;
@@ -5069,7 +5069,7 @@ compile_const_prefix(rb_iseq_t *iseq, const NODE *const node,
 static int
 compile_cpath(LINK_ANCHOR *const ret, rb_iseq_t *iseq, const NODE *cpath)
 {
-    if (nd_type(cpath) == NODE_COLON3) {
+    if (nd_type_p(cpath, NODE_COLON3)) {
 	/* toplevel class ::Foo */
 	ADD_INSN1(ret, cpath, putobject, rb_cObject);
 	return VM_DEFINECLASS_FLAG_SCOPED;
@@ -5090,7 +5090,7 @@ compile_cpath(LINK_ANCHOR *const ret, rb_iseq_t *iseq, const NODE *cpath)
 static inline int
 private_recv_p(const NODE *node)
 {
-    if (nd_type(node->nd_recv) == NODE_SELF) {
+    if (nd_type_p(node->nd_recv, NODE_SELF)) {
         NODE *self = node->nd_recv;
         return self->nd_state != 0;
     }
@@ -5479,7 +5479,7 @@ check_keyword(const NODE *node)
 {
     /* This check is essentially a code clone of compile_keyword_arg. */
 
-    if (nd_type(node) == NODE_LIST) {
+    if (nd_type_p(node, NODE_LIST)) {
         while (node->nd_next) {
             node = node->nd_next;
         }
@@ -5503,9 +5503,9 @@ setup_args_core(rb_iseq_t *iseq, LINK_ANCHOR *const args, const NODE *argn,
           }
           case NODE_ARGSCAT:
           case NODE_ARGSPUSH: {
-            int next_is_list = (nd_type(argn->nd_head) == NODE_LIST);
+            int next_is_list = (nd_type_p(argn->nd_head, NODE_LIST));
             VALUE argc = setup_args_core(iseq, args, argn->nd_head, 1, NULL, NULL);
-            if (nd_type(argn->nd_body) == NODE_LIST) {
+            if (nd_type_p(argn->nd_body, NODE_LIST)) {
                 /* This branch is needed to avoid "newarraykwsplat" [Bug #16442] */
                 int rest_len = compile_args(iseq, args, argn->nd_body, NULL, NULL);
                 ADD_INSN1(args, argn, newarray, INT2FIX(rest_len));
@@ -5520,7 +5520,7 @@ setup_args_core(rb_iseq_t *iseq, LINK_ANCHOR *const args, const NODE *argn,
                 if (check_keyword(argn->nd_body))
                     *flag |= VM_CALL_KW_SPLAT;
             }
-            if (nd_type(argn) == NODE_ARGSCAT) {
+            if (nd_type_p(argn, NODE_ARGSCAT)) {
                 if (next_is_list) {
                     ADD_INSN1(args, argn, splatarray, Qtrue);
                     return INT2FIX(FIX2INT(argc) + 1);
@@ -5554,7 +5554,7 @@ setup_args(rb_iseq_t *iseq, LINK_ANCHOR *const args, const NODE *argn,
 	   unsigned int *flag, struct rb_callinfo_kwarg **keywords)
 {
     VALUE ret;
-    if (argn && nd_type(argn) == NODE_BLOCK_PASS) {
+    if (argn && nd_type_p(argn, NODE_BLOCK_PASS)) {
         unsigned int dup_rest = 1;
         DECL_ANCHOR(arg_block);
         INIT_ANCHOR(arg_block);
@@ -5896,7 +5896,7 @@ compile_case2(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const orig_no
     INIT_ANCHOR(body_seq);
     endlabel = NEW_LABEL(nd_line(node));
 
-    while (node && nd_type(node) == NODE_WHEN) {
+    while (node && nd_type_p(node, NODE_WHEN)) {
 	const int line = nd_line(node);
 	LABEL *l1 = NEW_LABEL(line);
 	ADD_LABEL(body_seq, l1);
@@ -6427,7 +6427,7 @@ iseq_compile_pattern_each(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *c
                     NODE *value_node = args->nd_next->nd_head;
                     VALUE key;
 
-                    if (nd_type(key_node) != NODE_LIT) {
+                    if (!nd_type_p(key_node, NODE_LIT)) {
                         UNKNOWN_NODE("NODE_IN", key_node, COMPILE_NG);
                     }
                     key = key_node->nd_lit;
@@ -6595,7 +6595,7 @@ iseq_compile_pattern_each(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *c
             match_succeeded = NEW_LABEL(line);
 
             ADD_INSN(ret, line_node, dup);
-            if (nd_type(node) == NODE_IF) {
+            if (nd_type_p(node, NODE_IF)) {
                 ADD_INSNL(ret, line_node, branchif, match_succeeded);
             }
             else {
@@ -6612,7 +6612,7 @@ iseq_compile_pattern_each(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *c
 
             ADD_LABEL(ret, match_succeeded);
         }
-        if (nd_type(node) == NODE_IF) {
+        if (nd_type_p(node, NODE_IF)) {
             ADD_INSNL(ret, line_node, branchunless, match_failed);
         }
         else {
@@ -6627,7 +6627,7 @@ iseq_compile_pattern_each(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *c
         match_failed = NEW_LABEL(line);
 
         n = node->nd_head;
-        if (! (nd_type(n) == NODE_LIST && n->nd_alen == 2)) {
+        if (! (nd_type_p(n, NODE_LIST) && n->nd_alen == 2)) {
             COMPILE_ERROR(ERROR_ARGS "unexpected node");
             return COMPILE_NG;
         }
@@ -7144,7 +7144,7 @@ compile_iter(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, in
     const rb_iseq_t *child_iseq;
 
     ADD_LABEL(ret, retry_label);
-    if (nd_type(node) == NODE_FOR) {
+    if (nd_type_p(node, NODE_FOR)) {
 	CHECK(COMPILE(ret, "iter caller (for)", node->nd_iter));
 
 	ISEQ_COMPILE_DATA(iseq)->current_block = child_iseq =
@@ -7687,7 +7687,7 @@ compile_call_precheck_freeze(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE
     /* optimization shortcut
      *   "literal".freeze -> opt_str_freeze("literal")
      */
-    if (node->nd_recv && nd_type(node->nd_recv) == NODE_STR &&
+    if (node->nd_recv && nd_type_p(node->nd_recv, NODE_STR) &&
         (node->nd_mid == idFreeze || node->nd_mid == idUMinus) &&
         node->nd_args == NULL &&
         ISEQ_COMPILE_DATA(iseq)->current_block == NULL &&
@@ -7711,8 +7711,8 @@ compile_call_precheck_freeze(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE
      *   obj["literal"] -> opt_aref_with(obj, "literal")
      */
     if (node->nd_mid == idAREF && !private_recv_p(node) && node->nd_args &&
-        nd_type(node->nd_args) == NODE_LIST && node->nd_args->nd_alen == 1 &&
-        nd_type(node->nd_args->nd_head) == NODE_STR &&
+        nd_type_p(node->nd_args, NODE_LIST) && node->nd_args->nd_alen == 1 &&
+        nd_type_p(node->nd_args->nd_head, NODE_STR) &&
         ISEQ_COMPILE_DATA(iseq)->current_block == NULL &&
         !ISEQ_COMPILE_DATA(iseq)->option->frozen_string_literal &&
         ISEQ_COMPILE_DATA(iseq)->option->specialized_instruction) {
@@ -7850,11 +7850,11 @@ static int
 compile_builtin_arg(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, const NODE *line_node, int popped)
 {
     if (!node) goto no_arg;
-    if (nd_type(node) != NODE_LIST) goto bad_arg;
+    if (!nd_type_p(node, NODE_LIST)) goto bad_arg;
     if (node->nd_next) goto too_many_arg;
     node = node->nd_head;
     if (!node) goto no_arg;
-    if (nd_type(node) != NODE_LIT) goto bad_arg;
+    if (!nd_type_p(node, NODE_LIT)) goto bad_arg;
     VALUE name = node->nd_lit;
     if (!SYMBOL_P(name)) goto non_symbol_arg;
     if (!popped) {
@@ -8060,7 +8060,7 @@ compile_call(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, co
     INIT_ANCHOR(recv);
     INIT_ANCHOR(args);
 #if OPT_SUPPORT_JOKE
-    if (nd_type(node) == NODE_VCALL) {
+    if (nd_type_p(node, NODE_VCALL)) {
         ID id_bitblt;
         ID id_answer;
 
@@ -8084,7 +8084,7 @@ compile_call(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, co
         CONST_ID(goto_id, "__goto__");
         CONST_ID(label_id, "__label__");
 
-        if (nd_type(node) == NODE_FCALL &&
+        if (nd_type_p(node, NODE_FCALL) &&
             (mid == goto_id || mid == label_id)) {
             LABEL *label;
             st_data_t data;
@@ -8095,7 +8095,7 @@ compile_call(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, co
                 labels_table = st_init_numtable();
                 ISEQ_COMPILE_DATA(iseq)->labels_table = labels_table;
             }
-            if (nd_type(node->nd_args->nd_head) == NODE_LIT &&
+            if (nd_type_p(node->nd_args->nd_head, NODE_LIT) &&
                 SYMBOL_P(node->nd_args->nd_head->nd_lit)) {
 
                 label_name = node->nd_args->nd_head->nd_lit;
@@ -8136,7 +8136,7 @@ compile_call(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, co
             int idx, level;
 
             if (mid == idCall &&
-                nd_type(node->nd_recv) == NODE_LVAR &&
+                nd_type_p(node->nd_recv, NODE_LVAR) &&
                 iseq_block_param_id_p(iseq, node->nd_recv->nd_vid, &idx, &level)) {
                 ADD_INSN2(recv, node->nd_recv, getblockparamproxy, INT2FIX(idx + VM_ENV_DATA_SIZE - 1), INT2FIX(level));
             }
@@ -8514,7 +8514,7 @@ compile_op_log(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, 
     LABEL *lfin = NEW_LABEL(line);
     LABEL *lassign;
 
-    if (type == NODE_OP_ASGN_OR && nd_type(node->nd_head) != NODE_IVAR) {
+    if (type == NODE_OP_ASGN_OR && !nd_type_p(node->nd_head, NODE_IVAR)) {
 	LABEL *lfinish[2];
 	lfinish[0] = lfin;
 	lfinish[1] = 0;
@@ -8857,8 +8857,8 @@ compile_dots(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, in
 
     if (optimizable_range_item_p(b) && optimizable_range_item_p(e)) {
 	if (!popped) {
-            VALUE bv = nd_type(b) == NODE_LIT ? b->nd_lit : Qnil;
-            VALUE ev = nd_type(e) == NODE_LIT ? e->nd_lit : Qnil;
+            VALUE bv = nd_type_p(b, NODE_LIT) ? b->nd_lit : Qnil;
+            VALUE ev = nd_type_p(e, NODE_LIT) ? e->nd_lit : Qnil;
 	    VALUE val = rb_range_new(bv, ev, excl);
 	    ADD_INSN1(ret, node, putobject, val);
 	    RB_OBJ_WRITTEN(iseq, Qundef, val);
@@ -8914,10 +8914,10 @@ compile_kw_arg(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, 
 	COMPILE_ERROR(ERROR_ARGS "unreachable");
 	return COMPILE_NG;
     }
-    else if (nd_type(default_value) == NODE_LIT ||
-	     nd_type(default_value) == NODE_NIL ||
-	     nd_type(default_value) == NODE_TRUE ||
-	     nd_type(default_value) == NODE_FALSE) {
+    else if (nd_type_p(default_value, NODE_LIT) ||
+	     nd_type_p(default_value, NODE_NIL) ||
+	     nd_type_p(default_value, NODE_TRUE) ||
+	     nd_type_p(default_value, NODE_FALSE)) {
 	COMPILE_ERROR(ERROR_ARGS "unreachable");
 	return COMPILE_NG;
     }
@@ -8952,8 +8952,8 @@ compile_attrasgn(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node
      *   obj["literal"] = value -> opt_aset_with(obj, "literal", value)
      */
     if (mid == idASET && !private_recv_p(node) && node->nd_args &&
-	nd_type(node->nd_args) == NODE_LIST && node->nd_args->nd_alen == 2 &&
-	nd_type(node->nd_args->nd_head) == NODE_STR &&
+	nd_type_p(node->nd_args, NODE_LIST) && node->nd_args->nd_alen == 2 &&
+	nd_type_p(node->nd_args->nd_head, NODE_STR) &&
 	ISEQ_COMPILE_DATA(iseq)->current_block == NULL &&
 	!ISEQ_COMPILE_DATA(iseq)->option->frozen_string_literal &&
 	ISEQ_COMPILE_DATA(iseq)->option->specialized_instruction)

--- a/node.c
+++ b/node.c
@@ -370,7 +370,7 @@ dump_node(VALUE buf, VALUE indent, int comment, const NODE * node)
       andor:
 	while (1) {
 	    F_NODE(nd_1st, "left expr");
-	    if (!node->nd_2nd || !nd_type_p(node->nd_2nd, (int)type))
+	    if (!node->nd_2nd || !nd_type_p(node->nd_2nd, type))
 		break;
 	    node = node->nd_2nd;
 	}

--- a/node.c
+++ b/node.c
@@ -136,7 +136,7 @@ dump_array(VALUE buf, VALUE indent, int comment, const NODE *node)
     const char *next_indent = default_indent;
     F_LONG(nd_alen, "length");
     F_NODE(nd_head, "element");
-    while (node->nd_next && nd_type(node->nd_next) == NODE_LIST) {
+    while (node->nd_next && nd_type_p(node->nd_next, NODE_LIST)) {
 	node = node->nd_next;
 	F_NODE(nd_head, "element");
     }
@@ -175,7 +175,7 @@ dump_node(VALUE buf, VALUE indent, int comment, const NODE * node)
 	    dump_node(buf, indent, comment, node->nd_head);
 	    D_DEDENT;
 	} while (node->nd_next &&
-		 nd_type(node->nd_next) == NODE_BLOCK &&
+		 nd_type_p(node->nd_next, NODE_BLOCK) &&
 		 (node = node->nd_next, 1));
 	if (node->nd_next) {
 	    LAST_NODE;
@@ -370,7 +370,7 @@ dump_node(VALUE buf, VALUE indent, int comment, const NODE * node)
       andor:
 	while (1) {
 	    F_NODE(nd_1st, "left expr");
-	    if (!node->nd_2nd || nd_type(node->nd_2nd) != (int)type)
+	    if (!node->nd_2nd || !nd_type_p(node->nd_2nd, (int)type))
 		break;
 	    node = node->nd_2nd;
 	}

--- a/node.h
+++ b/node.h
@@ -193,6 +193,7 @@ typedef struct RNode {
 #define NODE_TYPEMASK  (((VALUE)0x7f)<<NODE_TYPESHIFT)
 
 #define nd_type(n) ((int) (((n)->flags & NODE_TYPEMASK)>>NODE_TYPESHIFT))
+#define nd_type_p(n, t) (nd_type((n)) == (t))
 #define nd_set_type(n,t) \
     rb_node_set_type(n, t)
 #define nd_init_type(n,t) \

--- a/parse.y
+++ b/parse.y
@@ -11865,9 +11865,9 @@ logop(struct parser_params *p, ID id, NODE *left, NODE *right,
     enum node_type type = id == idAND || id == idANDOP ? NODE_AND : NODE_OR;
     NODE *op;
     value_expr(left);
-    if (left && (enum node_type)nd_type_p(left, type)) {
+    if (left && nd_type_p(left, type)) {
 	NODE *node = left, *second;
-	while ((second = node->nd_2nd) != 0 && (enum node_type)nd_type_p(second, type)) {
+	while ((second = node->nd_2nd) != 0 && nd_type_p(second, type)) {
 	    node = second;
 	}
 	node->nd_2nd = NEW_NODE(type, second, right, 0, loc);

--- a/parse.y
+++ b/parse.y
@@ -607,7 +607,7 @@ ripper_new_yylval(struct parser_params *p, ID a, VALUE b, VALUE c)
 static inline int
 ripper_is_node_yylval(VALUE n)
 {
-    return RB_TYPE_P(n, T_NODE) && nd_type(RNODE(n)) == NODE_RIPPER;
+    return RB_TYPE_P(n, T_NODE) && nd_type_p(RNODE(n), NODE_RIPPER);
 }
 
 #define value_expr(node) ((void)(node))
@@ -1335,7 +1335,7 @@ program		:  {
 			if ($2 && !compile_for_eval) {
 			    NODE *node = $2;
 			    /* last expression should not be void */
-			    if (nd_type(node) == NODE_BLOCK) {
+			    if (nd_type_p(node, NODE_BLOCK)) {
 				while (node->nd_next) {
 				    node = node->nd_next;
 				}
@@ -1530,7 +1530,7 @@ stmt		: keyword_alias fitem {SET_LEX_STATE(EXPR_FNAME|EXPR_FITEM);} fitem
 		| stmt modifier_while expr_value
 		    {
 		    /*%%%*/
-			if ($1 && nd_type($1) == NODE_BEGIN) {
+			if ($1 && nd_type_p($1, NODE_BEGIN)) {
 			    $$ = NEW_WHILE(cond(p, $3, &@3), $1->nd_body, 0, &@$);
 			}
 			else {
@@ -1542,7 +1542,7 @@ stmt		: keyword_alias fitem {SET_LEX_STATE(EXPR_FNAME|EXPR_FITEM);} fitem
 		| stmt modifier_until expr_value
 		    {
 		    /*%%%*/
-			if ($1 && nd_type($1) == NODE_BEGIN) {
+			if ($1 && nd_type_p($1, NODE_BEGIN)) {
 			    $$ = NEW_UNTIL(cond(p, $3, &@3), $1->nd_body, 0, &@$);
 			}
 			else {
@@ -2973,7 +2973,7 @@ primary		: literal
 		| tLPAREN_ARG stmt {SET_LEX_STATE(EXPR_ENDARG);} rparen
 		    {
 		    /*%%%*/
-			if (nd_type($2) == NODE_SELF) $2->nd_state = 0;
+			if (nd_type_p($2, NODE_SELF)) $2->nd_state = 0;
 			$$ = $2;
 		    /*% %*/
 		    /*% ripper: paren!($2) %*/
@@ -2981,7 +2981,7 @@ primary		: literal
 		| tLPAREN compstmt ')'
 		    {
 		    /*%%%*/
-			if (nd_type($2) == NODE_SELF) $2->nd_state = 0;
+			if (nd_type_p($2, NODE_SELF)) $2->nd_state = 0;
 			$$ = $2;
 		    /*% %*/
 		    /*% ripper: paren!($2) %*/
@@ -3835,7 +3835,7 @@ do_block	: k_do_block do_body k_end
 block_call	: command do_block
 		    {
 		    /*%%%*/
-			if (nd_type($1) == NODE_YIELD) {
+			if (nd_type_p($1, NODE_YIELD)) {
 			    compile_error(p, "block given to yield");
 			}
 			else {
@@ -3934,7 +3934,7 @@ method_call	: fcall paren_args
 		| primary_value '[' opt_call_args rbracket
 		    {
 		    /*%%%*/
-			if ($1 && nd_type($1) == NODE_SELF)
+			if ($1 && nd_type_p($1, NODE_SELF))
 			    $$ = NEW_FCALL(tAREF, $3, &@$);
 			else
 			    $$ = NEW_CALL($1, tAREF, $3, &@$);
@@ -4424,7 +4424,7 @@ p_kw_label	: tLABEL
 		    {
 			YYLTYPE loc = code_loc_gen(&@1, &@3);
 		    /*%%%*/
-			if (!$2 || nd_type($2) == NODE_STR) {
+			if (!$2 || nd_type_p($2, NODE_STR)) {
 			    NODE *node = dsym_node(p, $2, &loc);
 			    $$ = SYM2ID(node->nd_lit);
 			}
@@ -4551,7 +4551,7 @@ p_var_ref	: '^' tIDENTIFIER
 		    {
 		    /*%%%*/
 			NODE *n = gettable(p, $2, &@$);
-			if (!(nd_type(n) == NODE_LVAR || nd_type(n) == NODE_DVAR)) {
+			if (!(nd_type_p(n, NODE_LVAR) || nd_type_p(n, NODE_DVAR))) {
 			    compile_error(p, "%"PRIsVALUE": no such local variable", rb_id2str($2));
 			}
 			$$ = n;
@@ -5624,8 +5624,8 @@ assocs		: assoc
 			}
 			else if (tail) {
                             if (assocs->nd_head &&
-                                !tail->nd_head && nd_type(tail->nd_next) == NODE_LIST &&
-                                nd_type(tail->nd_next->nd_head) == NODE_HASH) {
+                                !tail->nd_head && nd_type_p(tail->nd_next, NODE_LIST) &&
+                                nd_type_p(tail->nd_next->nd_head, NODE_HASH)) {
                                 /* DSTAR */
                                 tail = tail->nd_next->nd_head->nd_head;
                             }
@@ -5640,7 +5640,7 @@ assocs		: assoc
 assoc		: arg_value tASSOC arg_value
 		    {
 		    /*%%%*/
-			if (nd_type($1) == NODE_STR) {
+			if (nd_type_p($1, NODE_STR)) {
 			    nd_set_type($1, NODE_LIT);
 			    RB_OBJ_WRITE(p->ast, &$1->nd_lit, rb_fstring($1->nd_lit));
 			}
@@ -5675,7 +5675,7 @@ assoc		: arg_value tASSOC arg_value
 		| tDSTAR arg_value
 		    {
 		    /*%%%*/
-                        if (nd_type($2) == NODE_HASH &&
+                        if (nd_type_p($2, NODE_HASH) &&
                             !($2->nd_head && $2->nd_head->nd_alen)) {
                             static VALUE empty_hash;
                             if (!empty_hash) {
@@ -7643,7 +7643,7 @@ heredoc_dedent(struct parser_params *p, NODE *root)
     if (!root) return root;
 
     prev_node = node = str_node = root;
-    if (nd_type(root) == NODE_LIST) str_node = root->nd_head;
+    if (nd_type_p(root, NODE_LIST)) str_node = root->nd_head;
 
     while (str_node) {
 	VALUE lit = str_node->nd_lit;
@@ -7660,7 +7660,7 @@ heredoc_dedent(struct parser_params *p, NODE *root)
 	    NODE *end = node->nd_end;
 	    node = prev_node->nd_next = node->nd_next;
 	    if (!node) {
-		if (nd_type(prev_node) == NODE_DSTR)
+		if (nd_type_p(prev_node, NODE_DSTR))
 		    nd_set_type(prev_node, NODE_STR);
 		break;
 	    }
@@ -7671,7 +7671,7 @@ heredoc_dedent(struct parser_params *p, NODE *root)
 	str_node = 0;
 	while ((node = (prev_node = node)->nd_next) != 0) {
 	  next_str:
-	    if (nd_type(node) != NODE_LIST) break;
+	    if (!nd_type_p(node, NODE_LIST)) break;
 	    if ((str_node = node->nd_head) != 0) {
 		enum node_type type = nd_type(str_node);
 		if (type == NODE_STR || type == NODE_DSTR) break;
@@ -10058,7 +10058,7 @@ block_append(struct parser_params *p, NODE *head, NODE *tail)
 	break;
     }
 
-    if (nd_type(tail) != NODE_BLOCK) {
+    if (!nd_type_p(tail, NODE_BLOCK)) {
 	tail = NEW_BLOCK(tail, &tail->nd_loc);
 	tail->nd_end = tail;
     }
@@ -10140,7 +10140,7 @@ string_literal_head(enum node_type htype, NODE *head)
     if (htype != NODE_DSTR) return Qfalse;
     if (head->nd_next) {
 	head = head->nd_next->nd_end->nd_head;
-	if (!head || nd_type(head) != NODE_STR) return Qfalse;
+	if (!head || !nd_type_p(head, NODE_STR)) return Qfalse;
     }
     const VALUE lit = head->nd_lit;
     ASSUME(lit != Qfalse);
@@ -10239,7 +10239,7 @@ literal_concat(struct parser_params *p, NODE *head, NODE *tail, const YYLTYPE *l
 static NODE *
 evstr2dstr(struct parser_params *p, NODE *node)
 {
-    if (nd_type(node) == NODE_EVSTR) {
+    if (nd_type_p(node, NODE_EVSTR)) {
 	node = new_dstr(p, node, &node->nd_loc);
     }
     return node;
@@ -10314,7 +10314,7 @@ new_command_qcall(struct parser_params* p, ID atype, NODE *recv, ID mid, NODE *a
     return ret;
 }
 
-#define nd_once_body(node) (nd_type(node) == NODE_ONCE ? (node)->nd_body : node)
+#define nd_once_body(node) (nd_type_p((node), NODE_ONCE) ? (node)->nd_body : node)
 static NODE*
 match_op(struct parser_params *p, NODE *node1, NODE *node2, const YYLTYPE *op_loc, const YYLTYPE *loc)
 {
@@ -10636,7 +10636,7 @@ check_literal_when(struct parser_params *p, NODE *arg, const YYLTYPE *loc)
 
     lit = rb_node_case_when_optimizable_literal(arg);
     if (lit == Qundef) return;
-    if (nd_type(arg) == NODE_STR) {
+    if (nd_type_p(arg, NODE_STR)) {
 	RB_OBJ_WRITTEN(p->ast, Qnil, arg->nd_lit = lit);
     }
 
@@ -10997,7 +10997,7 @@ aryset(struct parser_params *p, NODE *recv, NODE *idx, const YYLTYPE *loc)
 static void
 block_dup_check(struct parser_params *p, NODE *node1, NODE *node2)
 {
-    if (node2 && node1 && nd_type(node1) == NODE_BLOCK_PASS) {
+    if (node2 && node1 && nd_type_p(node1, NODE_BLOCK_PASS)) {
 	compile_error(p, "both block arg and actual block given");
     }
 }
@@ -11049,7 +11049,7 @@ arg_append(struct parser_params *p, NODE *node1, NODE *node2, const YYLTYPE *loc
 	nd_set_type(node1, NODE_ARGSCAT);
 	return node1;
       case NODE_ARGSCAT:
-        if (nd_type(node1->nd_body) != NODE_LIST) break;
+        if (!nd_type_p(node1->nd_body, NODE_LIST)) break;
         node1->nd_body = list_append(p, node1->nd_body, node2);
         node1->nd_loc.end_pos = node1->nd_body->nd_loc.end_pos;
         return node1;
@@ -11069,13 +11069,13 @@ arg_concat(struct parser_params *p, NODE *node1, NODE *node2, const YYLTYPE *loc
 	    node1->nd_head = NEW_LIST(node2, loc);
 	return node1;
       case NODE_ARGSPUSH:
-	if (nd_type(node2) != NODE_LIST) break;
+	if (!nd_type_p(node2, NODE_LIST)) break;
 	node1->nd_body = list_concat(NEW_LIST(node1->nd_body, loc), node2);
 	nd_set_type(node1, NODE_ARGSCAT);
 	return node1;
       case NODE_ARGSCAT:
-	if (nd_type(node2) != NODE_LIST ||
-	    nd_type(node1->nd_body) != NODE_LIST) break;
+	if (!nd_type_p(node2, NODE_LIST) ||
+	    !nd_type_p(node1->nd_body, NODE_LIST)) break;
 	node1->nd_body = list_concat(node1->nd_body, node2);
 	return node1;
     }
@@ -11096,7 +11096,7 @@ static NODE *
 rest_arg_append(struct parser_params *p, NODE *args, NODE *rest_arg, const YYLTYPE *loc)
 {
     NODE *n1;
-    if ((nd_type(rest_arg) == NODE_LIST) && (n1 = splat_array(args)) != 0) {
+    if ((nd_type_p(rest_arg, NODE_LIST)) && (n1 = splat_array(args)) != 0) {
 	return list_concat(n1, rest_arg);
     }
     return arg_concat(p, args, rest_arg, loc);
@@ -11105,8 +11105,8 @@ rest_arg_append(struct parser_params *p, NODE *args, NODE *rest_arg, const YYLTY
 static NODE *
 splat_array(NODE* node)
 {
-    if (nd_type(node) == NODE_SPLAT) node = node->nd_head;
-    if (nd_type(node) == NODE_LIST) return node;
+    if (nd_type_p(node, NODE_SPLAT)) node = node->nd_head;
+    if (nd_type_p(node, NODE_LIST)) return node;
     return 0;
 }
 
@@ -11141,7 +11141,7 @@ static NODE *
 const_decl_path(struct parser_params *p, NODE **dest)
 {
     NODE *n = *dest;
-    if (nd_type(n) != NODE_CALL) {
+    if (!nd_type_p(n, NODE_CALL)) {
 	const YYLTYPE *loc = &n->nd_loc;
 	VALUE path;
 	if (n->nd_vid) {
@@ -11150,14 +11150,14 @@ const_decl_path(struct parser_params *p, NODE **dest)
 	else {
 	    n = n->nd_else;
 	    path = rb_ary_new();
-	    for (; n && nd_type(n) == NODE_COLON2; n = n->nd_head) {
+	    for (; n && nd_type_p(n, NODE_COLON2); n = n->nd_head) {
 		rb_ary_push(path, rb_id2str(n->nd_mid));
 	    }
-	    if (n && nd_type(n) == NODE_CONST) {
+	    if (n && nd_type_p(n, NODE_CONST)) {
 		// Const::Name
 		rb_ary_push(path, rb_id2str(n->nd_vid));
 	    }
-	    else if (n && nd_type(n) == NODE_COLON3) {
+	    else if (n && nd_type_p(n, NODE_COLON3)) {
 		// ::Const::Name
 		rb_ary_push(path, rb_str_new(0, 0));
 	    }
@@ -11435,7 +11435,7 @@ value_expr_check(struct parser_params *p, NODE *node)
 	    return void_node ? void_node : node;
 
 	  case NODE_CASE3:
-	    if (!node->nd_body || nd_type(node->nd_body) != NODE_IN) {
+	    if (!node->nd_body || !nd_type_p(node->nd_body, NODE_IN)) {
 		compile_error(p, "unexpected node");
 		return NULL;
 	    }
@@ -11591,7 +11591,7 @@ void_stmts(struct parser_params *p, NODE *node)
     NODE *const n = node;
     if (!RTEST(ruby_verbose)) return n;
     if (!node) return n;
-    if (nd_type(node) != NODE_BLOCK) return n;
+    if (!nd_type_p(node, NODE_BLOCK)) return n;
 
     while (node->nd_next) {
 	void_expr(p, node->nd_head);
@@ -11604,7 +11604,7 @@ static NODE *
 remove_begin(NODE *node)
 {
     NODE **n = &node, *n1 = node;
-    while (n1 && nd_type(n1) == NODE_BEGIN && n1->nd_body) {
+    while (n1 && nd_type_p(n1, NODE_BEGIN) && n1->nd_body) {
 	*n = n1 = n1->nd_body;
     }
     return node;
@@ -11614,7 +11614,7 @@ static NODE *
 remove_begin_all(NODE *node)
 {
     NODE **n = &node, *n1 = node;
-    while (n1 && nd_type(n1) == NODE_BEGIN) {
+    while (n1 && nd_type_p(n1, NODE_BEGIN)) {
 	*n = n1 = n1->nd_body;
     }
     return node;
@@ -11791,8 +11791,8 @@ cond0(struct parser_params *p, NODE *node, enum cond_type type, const YYLTYPE *l
       case NODE_DOT3:
 	node->nd_beg = range_op(p, node->nd_beg, loc);
 	node->nd_end = range_op(p, node->nd_end, loc);
-	if (nd_type(node) == NODE_DOT2) nd_set_type(node,NODE_FLIP2);
-	else if (nd_type(node) == NODE_DOT3) nd_set_type(node, NODE_FLIP3);
+	if (nd_type_p(node, NODE_DOT2)) nd_set_type(node,NODE_FLIP2);
+	else if (nd_type_p(node, NODE_DOT3)) nd_set_type(node, NODE_FLIP3);
 	break;
 
       case NODE_DSYM:
@@ -11865,9 +11865,9 @@ logop(struct parser_params *p, ID id, NODE *left, NODE *right,
     enum node_type type = id == idAND || id == idANDOP ? NODE_AND : NODE_OR;
     NODE *op;
     value_expr(left);
-    if (left && (enum node_type)nd_type(left) == type) {
+    if (left && (enum node_type)nd_type_p(left, type)) {
 	NODE *node = left, *second;
-	while ((second = node->nd_2nd) != 0 && (enum node_type)nd_type(second) == type) {
+	while ((second = node->nd_2nd) != 0 && (enum node_type)nd_type_p(second, type)) {
 	    node = second;
 	}
 	node->nd_2nd = NEW_NODE(type, second, right, 0, loc);
@@ -11883,7 +11883,7 @@ logop(struct parser_params *p, ID id, NODE *left, NODE *right,
 static void
 no_blockarg(struct parser_params *p, NODE *node)
 {
-    if (node && nd_type(node) == NODE_BLOCK_PASS) {
+    if (node && nd_type_p(node, NODE_BLOCK_PASS)) {
 	compile_error(p, "block argument should not be given");
     }
 }
@@ -11893,7 +11893,7 @@ ret_args(struct parser_params *p, NODE *node)
 {
     if (node) {
 	no_blockarg(p, node);
-	if (nd_type(node) == NODE_LIST) {
+	if (nd_type_p(node, NODE_LIST)) {
 	    if (node->nd_next == 0) {
 		node = node->nd_head;
 	    }
@@ -12281,7 +12281,7 @@ remove_duplicate_keys(struct parser_params *p, NODE *hash)
 	st_data_t key = (st_data_t)head;
 	st_data_t data;
 	value->nd_next = 0;
-	if (nd_type(head) == NODE_LIT &&
+	if (nd_type_p(head, NODE_LIT) &&
 	    st_delete(literal_keys, (key = (st_data_t)head->nd_lit, &key), &data)) {
 	    NODE *dup_value = ((NODE *)data)->nd_next;
 	    rb_compile_warn(p->ruby_sourcefile, nd_line((NODE *)data),
@@ -12295,7 +12295,7 @@ remove_duplicate_keys(struct parser_params *p, NODE *hash)
 	    }
 	}
 	st_insert(literal_keys, (st_data_t)key, (st_data_t)hash);
-	last_expr = nd_type(head) == NODE_LIT ? value : head;
+	last_expr = nd_type_p(head, NODE_LIT) ? value : head;
 	hash = next;
     }
     st_foreach(literal_keys, append_literal_keys, (st_data_t)&result);
@@ -12417,7 +12417,7 @@ new_ary_op_assign(struct parser_params *p, NODE *ary,
     NODE *asgn;
 
     args = make_list(args, args_loc);
-    if (nd_type(args) == NODE_BLOCK_PASS) {
+    if (nd_type_p(args, NODE_BLOCK_PASS)) {
 	args = NEW_ARGSCAT(args, rhs, loc);
     }
     else {
@@ -13564,7 +13564,7 @@ ripper_validate_object(VALUE self, VALUE x)
       case T_RATIONAL:
 	break;
       case T_NODE:
-	if (nd_type((NODE *)x) != NODE_RIPPER) {
+	if (!nd_type_p((NODE *)x, NODE_RIPPER)) {
 	    rb_raise(rb_eArgError, "NODE given: %p", (void *)x);
 	}
 	x = ((NODE *)x)->nd_rval;
@@ -13653,7 +13653,7 @@ ripper_get_id(VALUE v)
     NODE *nd;
     if (!RB_TYPE_P(v, T_NODE)) return 0;
     nd = (NODE *)v;
-    if (nd_type(nd) != NODE_RIPPER) return 0;
+    if (!nd_type_p(nd, NODE_RIPPER)) return 0;
     return nd->nd_vid;
 }
 
@@ -13664,7 +13664,7 @@ ripper_get_value(VALUE v)
     if (v == Qundef) return Qnil;
     if (!RB_TYPE_P(v, T_NODE)) return v;
     nd = (NODE *)v;
-    if (nd_type(nd) != NODE_RIPPER) return Qnil;
+    if (!nd_type_p(nd, NODE_RIPPER)) return Qnil;
     return nd->nd_rval;
 }
 


### PR DESCRIPTION
MRI has these code using `nd_type` macro to check NODE type.

```c
static NODE *
rest_arg_append(struct parser_params *p, NODE *args, NODE *rest_arg, const YYLTYPE *loc)
{
    NODE *n1;
    if ((nd_type(rest_arg) == NODE_LIST) && (n1 = splat_array(args)) != 0) {
	return list_concat(n1, rest_arg);
    }
    return arg_concat(p, args, rest_arg, loc);
}
```

However, conditions will be long and sometimes difficult to read, I think.

So, I think better to introduce `nd_type_p` macro like this.

```h
#define nd_type_p(n, t) (nd_type((n)) == (t))
```

I think that conditions can be more shorter to using `nd_type_p` macro.
How about it？

```c
static NODE *
rest_arg_append(struct parser_params *p, NODE *args, NODE *rest_arg, const YYLTYPE *loc)
{
    NODE *n1;
    if ((nd_type_p(rest_arg, NODE_LIST)) && (n1 = splat_array(args)) != 0) {
	return list_concat(n1, rest_arg);
    }
    return arg_concat(p, args, rest_arg, loc);
}
```