### PR TITLE
Move structs to classes, ~1.10x faster Ripper.lex

### DIFF
--- a/ext/ripper/lib/ripper/lexer.rb
+++ b/ext/ripper/lib/ripper/lexer.rb
@@ -53,10 +53,16 @@ class Ripper
   end
 
   class Lexer < ::Ripper   #:nodoc: internal use only
-    State = Struct.new(:to_int, :to_s) do
+    class State
+      attr_reader :to_int, :to_s
+
+      def initialize(i)
+        @to_int = i
+        @to_s = Ripper.lex_state_name(i)
+        freeze
+      end
+
       alias to_i to_int
-      def initialize(i) super(i, Ripper.lex_state_name(i)).freeze end
-      # def inspect; "#<#{self.class}: #{self}>" end
       alias inspect to_s
       def pretty_print(q) q.text(to_s) end
       def ==(i) super or to_int == i end
@@ -67,9 +73,15 @@ class Ripper
       def nobits?(i) to_int.nobits?(i) end
     end
 
-    Elem = Struct.new(:pos, :event, :tok, :state, :message) do
+    class Elem
+      attr_accessor :pos, :event, :tok, :state, :message
+
       def initialize(pos, event, tok, state, message = nil)
-        super(pos, event, tok, State.new(state), message)
+        @pos = pos
+        @event = event
+        @tok = tok
+        @state = State.new(state)
+        @message = message
       end
 
       def inspect
@@ -94,9 +106,11 @@ class Ripper
       end
 
       def to_a
-        a = super
-        a.pop unless a.last
-        a
+        if @message
+          [@pos, @event, @tok, @state, @message]
+        else
+          [@pos, @event, @tok, @state]
+        end
       end
     end
 

--- a/ext/ripper/lib/ripper/lexer.rb
+++ b/ext/ripper/lib/ripper/lexer.rb
@@ -62,6 +62,17 @@ class Ripper
         freeze
       end
 
+      def [](index)
+        case index
+        when 0
+          warn "Calling `Lexer::State#[0]` is deprecated, please use `Lexer::State#to_int` instead"
+          @to_int
+        when 1
+          warn "Calling `Lexer::State#[1]` is deprecated, please use `Lexer::State#to_s` instead"
+          @event
+        end
+      end
+
       alias to_i to_int
       alias inspect to_s
       def pretty_print(q) q.text(to_s) end
@@ -82,6 +93,26 @@ class Ripper
         @tok = tok
         @state = State.new(state)
         @message = message
+      end
+
+      def [](index)
+        case index
+        when 0
+          warn "Calling `Lexer::Elem#[0]` is deprecated, please use `Lexer::Elem#pos` instead"
+          @pos
+        when 1
+          warn "Calling `Lexer::Elem#[1]` is deprecated, please use `Lexer::Elem#event` instead"
+          @event
+        when 2
+          warn "Calling `Lexer::Elem#[2]` is deprecated, please use `Lexer::Elem#tok` instead"
+          @tok
+        when 3
+          warn "Calling `Lexer::Elem#[3]` is deprecated, please use `Lexer::Elem#state` instead"
+          @state
+        when 4
+          warn "Calling `Lexer::Elem#[4]` is deprecated, please use `Lexer::Elem#message` instead"
+          @message
+        end
       end
 
       def inspect

--- a/ext/ripper/lib/ripper/lexer.rb
+++ b/ext/ripper/lib/ripper/lexer.rb
@@ -166,17 +166,19 @@ class Ripper
     def on_heredoc_dedent(v, w)
       ignored_sp = []
       heredoc = @buf.last
-      heredoc.each_with_index do |e, i|
-        if Elem === e and e.event == :on_tstring_content and e.pos[1].zero?
-          tok = e.tok.dup if w > 0 and /\A\s/ =~ e.tok
-          if (n = dedent_string(e.tok, w)) > 0
-            if e.tok.empty?
-              e.tok = tok[0, n]
-              e.event = :on_ignored_sp
-              next
+      if Array === heredoc
+        heredoc.each_with_index do |e, i|
+          if Elem === e and e.event == :on_tstring_content and e.pos[1].zero?
+            tok = e.tok.dup if w > 0 and /\A\s/ =~ e.tok
+            if (n = dedent_string(e.tok, w)) > 0
+              if e.tok.empty?
+                e.tok = tok[0, n]
+                e.event = :on_ignored_sp
+                next
+              end
+              ignored_sp << [i, Elem.new(e.pos.dup, :on_ignored_sp, tok[0, n], e.state)]
+              e.pos[1] += n
             end
-            ignored_sp << [i, Elem.new(e.pos.dup, :on_ignored_sp, tok[0, n], e.state)]
-            e.pos[1] += n
           end
         end
       end

--- a/lib/irb/cmd/show_source.rb
+++ b/lib/irb/cmd/show_source.rb
@@ -64,7 +64,7 @@ module IRB
         prev_tokens = []
 
         # chunk with line number
-        tokens.chunk { |tok| tok[0][0] }.each do |lnum, chunk|
+        tokens.chunk { |tok| tok.pos[0] }.each do |lnum, chunk|
           code = lines[0..lnum].join
           prev_tokens.concat chunk
           continue = lex.process_continue(prev_tokens)

--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -87,8 +87,8 @@ class RubyLex
         tokens.each do |t|
           partial_tokens << t
           unprocessed_tokens << t
-          if t[2].include?("\n")
-            t_str = t[2]
+          if t.tok.include?("\n")
+            t_str = t.tok
             t_str.each_line("\n") do |s|
               code << s << "\n"
               ltype, indent, continue, code_block_open = check_state(code, partial_tokens, context: context)
@@ -97,9 +97,10 @@ class RubyLex
             end
             unprocessed_tokens = []
           else
-            code << t[2]
+            code << t.tok
           end
         end
+
         unless unprocessed_tokens.empty?
           ltype, indent, continue, code_block_open = check_state(code, unprocessed_tokens, context: context)
           result << @prompt.call(ltype, indent, continue || code_block_open, @line_no + line_num_offset)
@@ -107,6 +108,7 @@ class RubyLex
         result
       end
     end
+
     if p.respond_to?(:call)
       @input = p
     elsif block_given?
@@ -153,14 +155,14 @@ class RubyLex
         pos_to_index = {}
         lexer.scan.each do |t|
           next if t.pos.first == 0
-          if pos_to_index.has_key?(t[0])
-            index = pos_to_index[t[0]]
+          if pos_to_index.has_key?(t.pos)
+            index = pos_to_index[t.pos]
             found_tk = tokens[index]
-            if ERROR_TOKENS.include?(found_tk[1]) && !ERROR_TOKENS.include?(t[1])
+            if ERROR_TOKENS.include?(found_tk.event) && !ERROR_TOKENS.include?(t.event)
               tokens[index] = t
             end
           else
-            pos_to_index[t[0]] = tokens.size
+            pos_to_index[t.pos] = tokens.size
             tokens << t
           end
         end
@@ -175,17 +177,17 @@ class RubyLex
 
   def find_prev_spaces(line_index)
     return 0 if @tokens.size == 0
-    md = @tokens[0][2].match(/(\A +)/)
+    md = @tokens[0].tok.match(/(\A +)/)
     prev_spaces = md.nil? ? 0 : md[1].count(' ')
     line_count = 0
     @tokens.each_with_index do |t, i|
-      if t[2].include?("\n")
-        line_count += t[2].count("\n")
+      if t.tok.include?("\n")
+        line_count += t.tok.count("\n")
         if line_count >= line_index
           return prev_spaces
         end
         if (@tokens.size - 1) > i
-          md = @tokens[i + 1][2].match(/(\A +)/)
+          md = @tokens[i + 1].tok.match(/(\A +)/)
           prev_spaces = md.nil? ? 0 : md[1].count(' ')
         end
       end
@@ -295,18 +297,18 @@ class RubyLex
 
   def process_continue(tokens = @tokens)
     # last token is always newline
-    if tokens.size >= 2 and tokens[-2][1] == :on_regexp_end
+    if tokens.size >= 2 and tokens[-2].event == :on_regexp_end
       # end of regexp literal
       return false
-    elsif tokens.size >= 2 and tokens[-2][1] == :on_semicolon
+    elsif tokens.size >= 2 and tokens[-2].event == :on_semicolon
       return false
-    elsif tokens.size >= 2 and tokens[-2][1] == :on_kw and ['begin', 'else', 'ensure'].include?(tokens[-2][2])
+    elsif tokens.size >= 2 and tokens[-2].event == :on_kw and ['begin', 'else', 'ensure'].include?(tokens[-2].tok)
       return false
-    elsif !tokens.empty? and tokens.last[2] == "\\\n"
+    elsif !tokens.empty? and tokens.last.tok == "\\\n"
       return true
-    elsif tokens.size >= 1 and tokens[-1][1] == :on_heredoc_end # "EOH\n"
+    elsif tokens.size >= 1 and tokens[-1].event == :on_heredoc_end # "EOH\n"
       return false
-    elsif tokens.size >= 2 and defined?(Ripper::EXPR_BEG) and tokens[-2][3].anybits?(Ripper::EXPR_BEG | Ripper::EXPR_FNAME) and tokens[-2][2] !~ /\A\.\.\.?\z/
+    elsif tokens.size >= 2 and defined?(Ripper::EXPR_BEG) and tokens[-2].state.anybits?(Ripper::EXPR_BEG | Ripper::EXPR_FNAME) and tokens[-2].tok !~ /\A\.\.\.?\z/
       # end of literal except for regexp
       # endless range at end of line is not a continue
       return true
@@ -316,7 +318,7 @@ class RubyLex
 
   def check_code_block(code, tokens = @tokens)
     return true if tokens.empty?
-    if tokens.last[1] == :on_heredoc_beg
+    if tokens.last.event == :on_heredoc_beg
       return true
     end
 
@@ -388,7 +390,7 @@ class RubyLex
     end
 
     if defined?(Ripper::EXPR_BEG)
-      last_lex_state = tokens.last[3]
+      last_lex_state = tokens.last.state
       if last_lex_state.allbits?(Ripper::EXPR_BEG)
         return false
       elsif last_lex_state.allbits?(Ripper::EXPR_DOT)
@@ -413,14 +415,14 @@ class RubyLex
     tokens.each_with_index { |t, index|
       # detecting one-liner method definition
       if in_oneliner_def.nil?
-        if t[3].allbits?(Ripper::EXPR_ENDFN)
+        if t.state.allbits?(Ripper::EXPR_ENDFN)
           in_oneliner_def = :ENDFN
         end
       else
-        if t[3].allbits?(Ripper::EXPR_ENDFN)
+        if t.state.allbits?(Ripper::EXPR_ENDFN)
           # continuing
-        elsif t[3].allbits?(Ripper::EXPR_BEG)
-          if t[2] == '='
+        elsif t.state.allbits?(Ripper::EXPR_BEG)
+          if t.tok == '='
             in_oneliner_def = :BODY
           end
         else
@@ -432,14 +434,14 @@ class RubyLex
         end
       end
 
-      case t[1]
+      case t.event
       when :on_lbracket, :on_lbrace, :on_lparen, :on_tlambeg
         indent += 1
       when :on_rbracket, :on_rbrace, :on_rparen
         indent -= 1
       when :on_kw
-        next if index > 0 and tokens[index - 1][3].allbits?(Ripper::EXPR_FNAME)
-        case t[2]
+        next if index > 0 and tokens[index - 1].state.allbits?(Ripper::EXPR_FNAME)
+        case t.tok
         when 'do'
           syntax_of_do = take_corresponding_syntax_to_kw_do(tokens, index)
           indent += 1 if syntax_of_do == :method_calling
@@ -447,7 +449,7 @@ class RubyLex
           indent += 1
         when 'if', 'unless', 'while', 'until'
           # postfix if/unless/while/until must be Ripper::EXPR_LABEL
-          indent += 1 unless t[3].allbits?(Ripper::EXPR_LABEL)
+          indent += 1 unless t.state.allbits?(Ripper::EXPR_LABEL)
         when 'end'
           indent -= 1
         end
@@ -459,14 +461,14 @@ class RubyLex
 
   def is_method_calling?(tokens, index)
     tk = tokens[index]
-    if tk[3].anybits?(Ripper::EXPR_CMDARG) and tk[1] == :on_ident
+    if tk.state.anybits?(Ripper::EXPR_CMDARG) and tk.event == :on_ident
       # The target method call to pass the block with "do".
       return true
-    elsif tk[3].anybits?(Ripper::EXPR_ARG) and tk[1] == :on_ident
-      non_sp_index = tokens[0..(index - 1)].rindex{ |t| t[1] != :on_sp }
+    elsif tk.state.anybits?(Ripper::EXPR_ARG) and tk.event == :on_ident
+      non_sp_index = tokens[0..(index - 1)].rindex{ |t| t.event != :on_sp }
       if non_sp_index
         prev_tk = tokens[non_sp_index]
-        if prev_tk[3].anybits?(Ripper::EXPR_DOT) and prev_tk[1] == :on_period
+        if prev_tk.state.anybits?(Ripper::EXPR_DOT) and prev_tk.event == :on_period
           # The target method call with receiver to pass the block with "do".
           return true
         end
@@ -481,17 +483,17 @@ class RubyLex
     index.downto(0) do |i|
       tk = tokens[i]
       # In "continue", the token isn't the corresponding syntax to "do".
-      non_sp_index = tokens[0..(i - 1)].rindex{ |t| t[1] != :on_sp }
+      non_sp_index = tokens[0..(i - 1)].rindex{ |t| t.event != :on_sp }
       first_in_fomula = false
       if non_sp_index.nil?
         first_in_fomula = true
-      elsif [:on_ignored_nl, :on_nl, :on_comment].include?(tokens[non_sp_index][1])
+      elsif [:on_ignored_nl, :on_nl, :on_comment].include?(tokens[non_sp_index].event)
         first_in_fomula = true
       end
       if is_method_calling?(tokens, i)
         syntax_of_do = :method_calling
         break if first_in_fomula
-      elsif tk[1] == :on_kw && %w{while until for}.include?(tk[2])
+      elsif tk.event == :on_kw && %w{while until for}.include?(tk.tok)
         # A loop syntax in front of "do" found.
         #
         #   while cond do # also "until" or "for"
@@ -512,14 +514,14 @@ class RubyLex
     index.downto(0) do |i|
       tk = tokens[i]
       # In "continue", the token isn't the corresponding syntax to "do".
-      non_sp_index = tokens[0..(i - 1)].rindex{ |t| t[1] != :on_sp }
+      non_sp_index = tokens[0..(i - 1)].rindex{ |t| t.event != :on_sp }
       first_in_fomula = false
       if non_sp_index.nil?
         first_in_fomula = true
-      elsif [:on_ignored_nl, :on_nl, :on_comment].include?(tokens[non_sp_index][1])
+      elsif [:on_ignored_nl, :on_nl, :on_comment].include?(tokens[non_sp_index].event)
         first_in_fomula = true
       end
-      if tk[1] == :on_kw && tk[2] == 'for'
+      if tk.event == :on_kw && tk.tok == 'for'
         # A loop syntax in front of "do" found.
         #
         #   while cond do # also "until" or "for"
@@ -541,14 +543,14 @@ class RubyLex
     @tokens.each_with_index do |t, index|
       # detecting one-liner method definition
       if in_oneliner_def.nil?
-        if t[3].allbits?(Ripper::EXPR_ENDFN)
+        if t.state.allbits?(Ripper::EXPR_ENDFN)
           in_oneliner_def = :ENDFN
         end
       else
-        if t[3].allbits?(Ripper::EXPR_ENDFN)
+        if t.state.allbits?(Ripper::EXPR_ENDFN)
           # continuing
-        elsif t[3].allbits?(Ripper::EXPR_BEG)
-          if t[2] == '='
+        elsif t.state.allbits?(Ripper::EXPR_BEG)
+          if t.tok == '='
             in_oneliner_def = :BODY
           end
         else
@@ -560,7 +562,7 @@ class RubyLex
         end
       end
 
-      case t[1]
+      case t.event
       when :on_ignored_nl, :on_nl, :on_comment
         if index != (@tokens.size - 1) and in_oneliner_def != :BODY
           depth_difference = 0
@@ -570,15 +572,16 @@ class RubyLex
       when :on_sp
         next
       end
-      case t[1]
+
+      case t.event
       when :on_lbracket, :on_lbrace, :on_lparen, :on_tlambeg
         depth_difference += 1
         open_brace_on_line += 1
       when :on_rbracket, :on_rbrace, :on_rparen
         depth_difference -= 1 if open_brace_on_line > 0
       when :on_kw
-        next if index > 0 and @tokens[index - 1][3].allbits?(Ripper::EXPR_FNAME)
-        case t[2]
+        next if index > 0 and @tokens[index - 1].state.allbits?(Ripper::EXPR_FNAME)
+        case t.tok
         when 'do'
           syntax_of_do = take_corresponding_syntax_to_kw_do(@tokens, index)
           depth_difference += 1 if syntax_of_do == :method_calling
@@ -586,7 +589,7 @@ class RubyLex
           depth_difference += 1
         when 'if', 'unless', 'while', 'until', 'rescue'
           # postfix if/unless/while/until/rescue must be Ripper::EXPR_LABEL
-          unless t[3].allbits?(Ripper::EXPR_LABEL)
+          unless t.state.allbits?(Ripper::EXPR_LABEL)
             depth_difference += 1
           end
         when 'else', 'elsif', 'ensure', 'when'
@@ -619,14 +622,14 @@ class RubyLex
     @tokens.each_with_index do |t, index|
       # detecting one-liner method definition
       if in_oneliner_def.nil?
-        if t[3].allbits?(Ripper::EXPR_ENDFN)
+        if t.state.allbits?(Ripper::EXPR_ENDFN)
           in_oneliner_def = :ENDFN
         end
       else
-        if t[3].allbits?(Ripper::EXPR_ENDFN)
+        if t.state.allbits?(Ripper::EXPR_ENDFN)
           # continuing
-        elsif t[3].allbits?(Ripper::EXPR_BEG)
-          if t[2] == '='
+        elsif t.state.allbits?(Ripper::EXPR_BEG)
+          if t.tok == '='
             in_oneliner_def = :BODY
           end
         else
@@ -643,7 +646,7 @@ class RubyLex
         end
       end
 
-      case t[1]
+      case t.event
       when :on_ignored_nl, :on_nl, :on_comment
         if in_oneliner_def != :BODY
           corresponding_token_depth = nil
@@ -654,11 +657,12 @@ class RubyLex
         end
         next
       when :on_sp
-        spaces_at_line_head = t[2].count(' ') if is_first_spaces_of_line
+        spaces_at_line_head = t.tok.count(' ') if is_first_spaces_of_line
         is_first_spaces_of_line = false
         next
       end
-      case t[1]
+
+      case t.event
       when :on_lbracket, :on_lbrace, :on_lparen, :on_tlambeg
         spaces_of_nest.push(spaces_at_line_head + open_brace_on_line * 2)
         open_brace_on_line += 1
@@ -671,8 +675,8 @@ class RubyLex
         end
         open_brace_on_line -= 1
       when :on_kw
-        next if index > 0 and @tokens[index - 1][3].allbits?(Ripper::EXPR_FNAME)
-        case t[2]
+        next if index > 0 and @tokens[index - 1].state.allbits?(Ripper::EXPR_FNAME)
+        case t.tok
         when 'do'
           syntax_of_do = take_corresponding_syntax_to_kw_do(@tokens, index)
           if syntax_of_do == :method_calling
@@ -681,12 +685,12 @@ class RubyLex
         when 'def', 'case', 'for', 'begin', 'class', 'module'
           spaces_of_nest.push(spaces_at_line_head)
         when 'rescue'
-          unless t[3].allbits?(Ripper::EXPR_LABEL)
+          unless t.state.allbits?(Ripper::EXPR_LABEL)
             corresponding_token_depth = spaces_of_nest.last
           end
         when 'if', 'unless', 'while', 'until'
           # postfix if/unless/while/until must be Ripper::EXPR_LABEL
-          unless t[3].allbits?(Ripper::EXPR_LABEL)
+          unless t.state.allbits?(Ripper::EXPR_LABEL)
             spaces_of_nest.push(spaces_at_line_head)
           end
         when 'else', 'elsif', 'ensure', 'when', 'in'
@@ -712,7 +716,7 @@ class RubyLex
     end_type = []
     while i < tokens.size
       t = tokens[i]
-      case t[1]
+      case t.event
       when *end_type.last
         start_token.pop
         end_type.pop
@@ -725,7 +729,7 @@ class RubyLex
       when :on_symbeg
         acceptable_single_tokens = %i{on_ident on_const on_op on_cvar on_ivar on_gvar on_kw on_int on_backtick}
         if (i + 1) < tokens.size
-          if acceptable_single_tokens.all?{ |st| tokens[i + 1][1] != st }
+          if acceptable_single_tokens.all?{ |st| tokens[i + 1].event != st }
             start_token << t
             end_type << :on_tstring_end
           else
@@ -749,9 +753,11 @@ class RubyLex
 
   def process_literal_type(tokens = @tokens)
     start_token = check_string_literal(tokens)
-    case start_token[1]
+    return nil if start_token == ""
+
+    case start_token.event
     when :on_tstring_beg
-      case start_token[2]
+      case start_token.tok
       when ?"      then ?"
       when /^%.$/  then ?"
       when /^%Q.$/ then ?"
@@ -766,7 +772,7 @@ class RubyLex
     when :on_qsymbols_beg then ?]
     when :on_symbols_beg  then ?]
     when :on_heredoc_beg
-      start_token[2] =~ /<<[-~]?(['"`])[_a-zA-Z0-9]+\1/
+      start_token.tok =~ /<<[-~]?(['"`])[_a-zA-Z0-9]+\1/
       case $1
       when ?" then ?"
       when ?' then ?'
@@ -794,6 +800,7 @@ class RubyLex
         false
       end
     end
+
     if index
       first_token = nil
       last_line_tokens = tokens[(index + 1)..(tokens.size - 1)]
@@ -803,6 +810,7 @@ class RubyLex
           break
         end
       end
+
       if first_token.nil?
         return false
       elsif first_token && first_token.state == Ripper::EXPR_DOT

--- a/test/irb/test_ruby_lex.rb
+++ b/test/irb/test_ruby_lex.rb
@@ -581,8 +581,8 @@ module TestIRB
       tokens = RubyLex.ripper_lex_without_warning('%wwww')
       pos_to_index = {}
       tokens.each_with_index { |t, i|
-        assert_nil(pos_to_index[t[0]], "There is already another token in the position of #{t.inspect}.")
-        pos_to_index[t[0]] = i
+        assert_nil(pos_to_index[t.pos], "There is already another token in the position of #{t.inspect}.")
+        pos_to_index[t.pos] = i
       }
     end
 
@@ -598,8 +598,8 @@ module TestIRB
       EOC
       pos_to_index = {}
       tokens.each_with_index { |t, i|
-        assert_nil(pos_to_index[t[0]], "There is already another token in the position of #{t.inspect}.")
-        pos_to_index[t[0]] = i
+        assert_nil(pos_to_index[t.pos], "There is already another token in the position of #{t.inspect}.")
+        pos_to_index[t.pos] = i
       }
     end
   end


### PR DESCRIPTION
## Concept

I am proposing we replace the Struct implementation of data structures inside of ripper with real classes.

This will improve performance and the implementation is not meaningfully more complicated.

## Example

Struct versus class comparison:

```ruby
Elem = Struct.new(:pos, :event, :tok, :state, :message) do
  def initialize(pos, event, tok, state, message = nil)
    super(pos, event, tok, State.new(state), message)
  end

  # ...

  def to_a
    a = super
    a.pop unless a.empty?
    a
  end
end

class ElemClass
  attr_accessor :pos, :event, :tok, :state, :message

  def initialize(pos, event, tok, state, message = nil)
    @pos = pos
    @event = event
    @tok = tok
    @state = State.new(state)
    @message = message
  end

  def to_a
    if @message
      [@pos, @event, @tok, @state, @message]
    else
      [@pos, @event, @tok, @state]
    end
  end
end

# stub state class creation for now
class State; def initialize(val); end; end
```

## MicroBenchmark creation

```ruby
require 'benchmark/ips'
require 'ripper'

pos = [1, 2]
event = :on_nl
tok = "\n".freeze
state = Ripper::EXPR_BEG

Benchmark.ips do |x|
  x.report("struct") { Elem.new(pos, event, tok, state) }
  x.report("class ") { ElemClass.new(pos, event, tok, state) }
  x.compare!
end; nil
```

Gives ~1.2x faster creation:

```
Warming up --------------------------------------
              struct   263.983k i/100ms
              class    303.367k i/100ms
Calculating -------------------------------------
              struct      2.638M (± 5.9%) i/s -     13.199M in   5.023460s
              class       3.171M (± 4.6%) i/s -     16.078M in   5.082369s

Comparison:
              class :  3170690.2 i/s
              struct:  2638493.5 i/s - 1.20x  (± 0.00) slower
```

## MicroBenchmark `to_a` (Called by Ripper.lex for every element)

```ruby
require 'benchmark/ips'
require 'ripper'

pos = [1, 2]
event = :on_nl
tok = "\n".freeze
state = Ripper::EXPR_BEG

struct =  Elem.new(pos, event, tok, state)
from_class = ElemClass.new(pos, event, tok, state)

Benchmark.ips do |x|
  x.report("struct") { struct.to_a }
  x.report("class ") { from_class.to_a }
  x.compare!
end; nil
```

Gives 1.46x faster `to_a`:

```
Warming up --------------------------------------
              struct   612.094k i/100ms
              class    893.233k i/100ms
Calculating -------------------------------------
              struct      6.121M (± 5.4%) i/s -     30.605M in   5.015851s
              class       8.931M (± 7.9%) i/s -     44.662M in   5.039733s

Comparison:
              class :  8930619.0 i/s
              struct:  6121358.9 i/s - 1.46x  (± 0.00) slower
```

## MicroBenchmark data access

```ruby
require 'benchmark/ips'
require 'ripper'

pos = [1, 2]
event = :on_nl
tok = "\n".freeze
state = Ripper::EXPR_BEG

struct =  Elem.new(pos, event, tok, state)
from_class = ElemClass.new(pos, event, tok, state)

Benchmark.ips do |x|
  x.report("struct") { struct.pos[1] }
  x.report("class ") { from_class.pos[1] }
  x.compare!
end; nil
```

Gives ~1.17x faster data access:

```
Warming up --------------------------------------
              struct     1.694M i/100ms
              class      1.868M i/100ms
Calculating -------------------------------------
              struct     16.149M (± 6.8%) i/s -     81.318M in   5.060633s
              class      18.886M (± 2.9%) i/s -     95.262M in   5.048359s

Comparison:
              class : 18885669.6 i/s
              struct: 16149255.8 i/s - 1.17x  (± 0.00) slower
```

## Full benchmark integration of this inside of Ripper.lex

Inside of this repo with this commit

```
$ cd ext/ripper
$ make
$ cat test.rb
file = File.join(__dir__, "../../array.rb")
source = File.read(file)

bench = Benchmark.measure do
  10_000.times.each do
    Ripper.lex(source)
  end
end

puts bench
```

Then execute with and without this change 50 times:

```
rm new.txt
rm old.txt
for i in {0..50}
do
  `ruby -Ilib -rripper -rbenchmark ./test.rb >> new.txt`
  `ruby -rripper -rbenchmark ./test.rb >> old.txt`
done
```

I used derailed benchmarks internals to compare the results:

```
dir = Pathname(".")
branch_info = {}
branch_info["old"]  = { desc: "Struct lex", time: Time.now, file: dir.join("old.txt"), name: "old" }
branch_info["new"]  = { desc: "Class lex", time: Time.now, file: dir.join("new.txt"), name: "new" }
stats = DerailedBenchmarks::StatsFromDir.new(branch_info)
stats.call.banner
```

Which gave us:

```
❤️ ❤️ ❤️  (Statistically Significant) ❤️ ❤️ ❤️

[new] (3.3139 seconds) "Class lex" ref: "new"
  FASTER 🚀🚀🚀 by:
    1.1046x [older/newer]
    9.4700% [(older - newer) / older * 100]
[old] (3.6606 seconds) "Struct lex" ref: "old"

Iterations per sample:
Samples: 51

Test type: Kolmogorov Smirnov
Confidence level: 99.0 %
Is significant? (max > critical): true
D critical: 0.30049534876137013
D max: 0.9607843137254902

Histograms (time ranges are in seconds):

   [new] description:                                        [old] description:
     "Class lex"                                               "Struct lex"
              ┌                                        ┐                ┌                                        ┐
   [3.0, 3.3) ┤▇ 1                                           [3.0, 3.3) ┤ 0
   [3.3, 3.6) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 47       [3.3, 3.6) ┤ 0
   [3.5, 3.8) ┤▇▇ 2                                          [3.5, 3.8) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 46
   [3.8, 4.1) ┤▇ 1                                           [3.8, 4.1) ┤▇▇▇ 4
   [4.0, 4.3) ┤ 0                                            [4.0, 4.3) ┤ 0
   [4.3, 4.6) ┤ 0                                            [4.3, 4.6) ┤▇ 1
              └                                        ┘                └                                        ┘
                         # of runs in range                                        # of runs in range
```

To sum this up, the "new" version of this code (using real classes instead of structs) is 10% faster across 50 runs with a statistical significance confidence
level of 99%. Histograms are for visual checksum.

## Consequences

This is a breaking change as seen by the modifications needed to IRB (because the element no longer acts as an array as well). However, this constant is technically marked as "internal" via docs.

I want to gauge interest in such a change. What do you think of this opportunity to increase performance and tighten the API? If you like it, what are your thoughts on moving forwards? 

At a high level, the two options I see are: 

1) Break that API

If we go this route, we can support IRB's lex usage out of the box. I don't know how many other gems might be accessing the contents of `Lexer::Elem`. To gauge impact it might be possible to do some kind of a code scan on github, or maybe rubygems. By default it's not exposed via `Ripper.lex` so searching for `Lexer.new` should yield high-signal-low-noise results.

It looks like via https://github.com/search?q=Ripper%3A%3ALexer.new&type=code there are 1,225 results. However it looks like there's more than a few forks of the Ruby project that github does not identify as forks. I could filter by something else like more than 5 stars, but for some reason, the UI returns no results for these cases for me.

2) Perform a deprecation cycle where we deprecate the Struct methods (such as `[]` and `each_with_index`).

I've explored it a little, but the work is ultimately unknown. I think these are the methods we would need to implement in order to deprecate them:

```
[:pretty_print_cycle, :to_a, :==, :to_s, :[], :[]=, :deconstruct, :eql?, :each_pair, :select, :to_h, :filter, :values, :inspect, :deconstruct_keys, :dig, :members, :length, :size, :pretty_print, :each, :hash, :values_at]
```
