### PR TITLE
[Feature #18290] Remove tests that test use of rb_gc_force_recycle

### DIFF
--- a/test/ruby/test_io.rb
+++ b/test/ruby/test_io.rb
@@ -3847,30 +3847,6 @@ __END__
       end
       end;
     end
-
-    def test_write_no_garbage
-      skip "multiple threads already active" if Thread.list.size > 1
-      res = {}
-      ObjectSpace.count_objects(res) # creates strings on first call
-      [ 'foo'.b, '*' * 24 ].each do |buf|
-        with_pipe do |r, w|
-          GC.disable
-          begin
-            before = ObjectSpace.count_objects(res)[:T_STRING]
-            n = w.write(buf)
-            s = w.syswrite(buf)
-            after = ObjectSpace.count_objects(res)[:T_STRING]
-          ensure
-            GC.enable
-          end
-          assert_equal before, after,
-            "no strings left over after write [ruby-core:78898] [Bug #13085]: #{ before } strings before write -> #{ after } strings after write"
-          assert_not_predicate buf, :frozen?, 'no inadvertent freeze'
-          assert_equal buf.bytesize, n, 'IO#write wrote expected size'
-          assert_equal s, n, 'IO#syswrite wrote expected size'
-        end
-      end
-    end
   end
 
   def test_pread

--- a/test/ruby/test_sprintf.rb
+++ b/test/ruby/test_sprintf.rb
@@ -528,19 +528,4 @@ class TestSprintf < Test::Unit::TestCase
       sprintf("%*s", RbConfig::LIMITS["INT_MIN"], "")
     end
   end
-
-  def test_no_hidden_garbage
-    skip unless Thread.list.size == 1
-
-    fmt = [4, 2, 2].map { |x| "%0#{x}d" }.join('-') # defeats optimization
-    ObjectSpace.count_objects(res = {}) # creates strings on first call
-    GC.disable
-    before = ObjectSpace.count_objects(res)[:T_STRING]
-    val = sprintf(fmt, 1970, 1, 1)
-    after = ObjectSpace.count_objects(res)[:T_STRING]
-    assert_equal before + 1, after, 'only new string is the created one'
-    assert_equal '1970-01-01', val
-  ensure
-    GC.enable
-  end
 end

--- a/test/ruby/test_time.rb
+++ b/test/ruby/test_time.rb
@@ -1282,22 +1282,6 @@ class TestTime < Test::Unit::TestCase
     assert_equal("366", t.strftime("%j"))
   end
 
-  def test_strftime_no_hidden_garbage
-    skip unless Thread.list.size == 1
-
-    fmt = %w(Y m d).map { |x| "%#{x}" }.join('-') # defeats optimization
-    t = Time.at(0).getutc
-    ObjectSpace.count_objects(res = {}) # creates strings on first call
-    GC.disable
-    before = ObjectSpace.count_objects(res)[:T_STRING]
-    val = t.strftime(fmt)
-    after = ObjectSpace.count_objects(res)[:T_STRING]
-    assert_equal before + 1, after, 'only new string is the created one'
-    assert_equal '1970-01-01', val
-  ensure
-    GC.enable
-  end
-
   def test_num_exact_error
     bad = EnvUtil.labeled_class("BadValue").new
     x = EnvUtil.labeled_class("Inexact") do


### PR DESCRIPTION
Remove tests that assume objects get force recycled.