### PR TITLE
class.c: descendants must not cause GC until the result array is created

### DIFF
--- a/class.c
+++ b/class.c
@@ -29,7 +29,6 @@
 #include "internal/variable.h"
 #include "ruby/st.h"
 #include "vm_core.h"
-#include "gc.h"
 
 #define id_attached id__attached__
 

--- a/gc.h
+++ b/gc.h
@@ -127,7 +127,6 @@ void rb_objspace_reachable_objects_from_root(void (func)(const char *category, V
 int rb_objspace_markable_object_p(VALUE obj);
 int rb_objspace_internal_object_p(VALUE obj);
 int rb_objspace_marked_object_p(VALUE obj);
-int rb_objspace_garbage_object_p(VALUE obj);
 
 void rb_objspace_each_objects(
     int (*callback)(void *start, void *end, size_t stride, void *data),

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -99,6 +99,7 @@ VALUE rb_class_allocate_instance(VALUE klass);
 void rb_gc_ractor_newobj_cache_clear(rb_ractor_newobj_cache_t *newobj_cache);
 size_t rb_gc_obj_slot_size(VALUE obj);
 bool rb_gc_size_allocatable_p(size_t size);
+int rb_objspace_garbage_object_p(VALUE obj);
 
 RUBY_SYMBOL_EXPORT_BEGIN
 /* gc.c (export) */

--- a/test/ruby/test_class.rb
+++ b/test/ruby/test_class.rb
@@ -761,4 +761,12 @@ class TestClass < Test::Unit::TestCase
     100000.times { Class.new(c) }
     assert(c.descendants.size <= 100000)
   end
+
+  def test_descendants_gc_stress
+    10000.times do
+      c = Class.new
+      100.times { Class.new(c) }
+      assert(c.descendants.size <= 100)
+    end
+  end
 end


### PR DESCRIPTION
Follow up of 428227472fc6563046d8138aab17f07bef6af753. The previous fix
uses `rb_ary_new_from_values` to create the result array, but it may
trigger the GC.

This second try is to create the result array by `rb_ary_new_capa`
before the second iteration, and assume that `rb_ary_push` does not
trigger GC. This assumption is very fragile, so should be improved in
future.

[Bug #18282] [Feature #14394]