### PR TITLE
Remove RCLASS(obj)->ptr when RVARGC is enabled

### DIFF
--- a/class.c
+++ b/class.c
@@ -177,9 +177,7 @@ class_alloc(VALUE flags, VALUE klass)
 
     RVARGC_NEWOBJ_OF(obj, struct RClass, klass, (flags & T_MASK) | FL_PROMOTED1 /* start from age == 2 */ | (RGENGC_WB_PROTECTED_CLASS ? FL_WB_PROTECTED : 0), alloc_size);
 
-#if USE_RVARGC
-    obj->ptr = (rb_classext_t *)((char *)obj + sizeof(struct RClass));
-#else
+#if !USE_RVARGC
     obj->ptr = ZALLOC(rb_classext_t);
 #endif
 

--- a/gc.c
+++ b/gc.c
@@ -4588,11 +4588,11 @@ obj_memsize_of(VALUE obj, int use_all_types)
                 // TODO: more correct value
 		size += st_memsize(RCLASS_IV_INDEX_TBL(obj));
 	    }
-	    if (RCLASS(obj)->ptr->iv_tbl) {
-		size += st_memsize(RCLASS(obj)->ptr->iv_tbl);
+            if (RCLASS_EXT(obj)->iv_tbl) {
+                size += st_memsize(RCLASS_EXT(obj)->iv_tbl);
 	    }
-	    if (RCLASS(obj)->ptr->const_tbl) {
-		size += rb_id_table_memsize(RCLASS(obj)->ptr->const_tbl);
+            if (RCLASS_EXT(obj)->const_tbl) {
+                size += rb_id_table_memsize(RCLASS_EXT(obj)->const_tbl);
 	    }
             if (RCLASS_CC_TBL(obj)) {
                 size += cc_table_memsize(RCLASS_CC_TBL(obj));

--- a/internal/class.h
+++ b/internal/class.h
@@ -66,7 +66,9 @@ struct rb_classext_struct {
 struct RClass {
     struct RBasic basic;
     VALUE super;
+#if !USE_RVARGC
     struct rb_classext_struct *ptr;
+#endif
 #if SIZEOF_SERIAL_T == SIZEOF_VALUE
     /* Class serial is as wide as VALUE.  Place it here. */
     rb_serial_t class_serial;
@@ -79,7 +81,11 @@ struct RClass {
 typedef struct rb_subclass_entry rb_subclass_entry_t;
 typedef struct rb_classext_struct rb_classext_t;
 
-#define RCLASS_EXT(c) (RCLASS(c)->ptr)
+#if USE_RVARGC
+#  define RCLASS_EXT(c) ((rb_classext_t *)((char *)c + sizeof(struct RClass)))
+#else
+#  define RCLASS_EXT(c) (RCLASS(c)->ptr)
+#endif
 #define RCLASS_IV_TBL(c) (RCLASS_EXT(c)->iv_tbl)
 #define RCLASS_CONST_TBL(c) (RCLASS_EXT(c)->const_tbl)
 #if SIZEOF_SERIAL_T == SIZEOF_VALUE


### PR DESCRIPTION
With RVARGC we always store the rb_classext_t in the same slot as the
RClass struct that refers to it. So we don't need to store the pointer
or access through the pointer anymore and can switch the RCLASS_EXT
macro to use an offset