### PR TITLE
Fix a memory leak introduced in 8bbd319

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -3141,8 +3141,10 @@ obj_free(rb_objspace_t *objspace, VALUE obj)
 	}
 	rb_class_remove_from_module_subclasses(obj);
 	rb_class_remove_from_super_subclasses(obj);
+#if !USE_RVARGC
 	if (RCLASS_EXT(obj))
-            RCLASS_EXT(obj) = NULL;
+            xfree(RCLASS_EXT(obj));
+#endif
 
         (void)RB_DEBUG_COUNTER_INC_IF(obj_module_ptr, BUILTIN_TYPE(obj) == T_MODULE);
         (void)RB_DEBUG_COUNTER_INC_IF(obj_class_ptr, BUILTIN_TYPE(obj) == T_CLASS);
@@ -3308,7 +3310,9 @@ obj_free(rb_objspace_t *objspace, VALUE obj)
         cc_table_free(objspace, obj, FALSE);
 	rb_class_remove_from_module_subclasses(obj);
 	rb_class_remove_from_super_subclasses(obj);
-	RCLASS_EXT(obj) = NULL;
+#if !USE_RVARGC
+        xfree(RCLASS_EXT(obj));
+#endif
 
         RB_DEBUG_COUNTER_INC(obj_iclass_ptr);
 	break;

--- a/test/ruby/test_class.rb
+++ b/test/ruby/test_class.rb
@@ -769,4 +769,13 @@ class TestClass < Test::Unit::TestCase
       assert(c.descendants.size <= 100)
     end
   end
+
+  def test_classext_memory_leak
+    assert_no_memory_leak([], <<-PREP, <<-CODE, rss: true)
+code = proc { Class.new }
+1_000.times(&code)
+PREP
+3_000_000.times(&code)
+CODE
+  end
 end


### PR DESCRIPTION
This commit fixes a memory leak introduced in an early part of the
variable width allocation project that would prevent the rb_classext_t
struct from being free'd when the class is swept.