### PR TITLE
Fixed bug caused by empty path in function 'find_library'

### DIFF
--- a/lib/mkmf.rb
+++ b/lib/mkmf.rb
@@ -1057,7 +1057,7 @@ SRC
   def find_library(lib, func, *paths, &b)
     dir_config(lib)
     lib = with_config(lib+'lib', lib)
-    paths = paths.collect {|path| path.split(File::PATH_SEPARATOR)}.flatten
+    paths = paths.compact {|path| path.split(File::PATH_SEPARATOR)}.flatten
     checking_for checking_message(func && func.funcall_style, LIBARG%lib) do
       libpath = $LIBPATH
       libs = append_library($libs, lib)


### PR DESCRIPTION
mkmf.rb will produce error when there are empty items in the paths.

In my case, when I tried to install mysql2 using gem, the error output as follow:

```console
/usr/share/ruby/mkmf.rb:1051:in `block in find_library': undefined method `split' for nil:NilClass (NoMethodError)
	from /usr/share/ruby/mkmf.rb:1051:in `collect'
	from /usr/share/ruby/mkmf.rb:1051:in `find_library'
	from extconf.rb:87:in `<main>'
```

And, yes, I don't know how the paths contains nil, but this output doesn't tell me how to fix it.

after removing the nil value, the error message became much more clear:

```console
checking for -lmysqlclient... no
-----
mysql client is missing. You may need to 'sudo apt-get install libmariadb-dev', 'sudo apt-get install libmysqlclient-dev' or 'sudo yum install mysql-devel', and try again.
-----
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers. ...
```