### PR TITLE
Introduce mutating variant of -= (~1.22x faster)

### DIFF
--- a/array.c
+++ b/array.c
@@ -5568,7 +5568,7 @@ rb_ary_difference_multi(int argc, VALUE *argv, VALUE ary)
 }
 
 static VALUE
-rb_ary_diff_bang_i(VALUE a, VALUE ary2)
+rb_ary_subtract_bang_i(VALUE a, VALUE ary2)
 {
     VALUE hash;
     long i;
@@ -5604,17 +5604,17 @@ rb_ary_diff_bang_i(VALUE a, VALUE ary2)
 
 /*
  *  call-seq:
- *    array.diff!(other_array) -> self
+ *    array.subtract!(other_array) -> self
  *
  *  Removes values from target \Array that are found in
  *  +other_array+. Items are compared using <tt>eql?</tt>;
  *    order from +self+ is preserved:
  *
- *    [0, 1, 1, 2, 1, 1, 3, 1, 1].diff!([1]) # => [0, 2, 3]
- *    [0, 1, 2, 3].diff!([3, 0], [1, 3]) # => [2]
+ *    [0, 1, 1, 2, 1, 1, 3, 1, 1].subtract!([1]) # => [0, 2, 3]
+ *    [0, 1, 2, 3].subtract!([3, 0], [1, 3]) # => [2]
  *
  *    array = [1, 2, 3]
- *    result = array.diff!([4])
+ *    result = array.subtract!([4])
  *    array == result # => true
  *
  *  Returns a copy of +self+ if no arguments given.
@@ -5624,7 +5624,7 @@ rb_ary_diff_bang_i(VALUE a, VALUE ary2)
  */
 
 static VALUE
-rb_ary_diff_bang(VALUE ary, VALUE other)
+rb_ary_subtract_bang(VALUE ary, VALUE other)
 {
     struct select_bang_arg args;
     rb_ary_modify_check(ary);
@@ -5632,7 +5632,7 @@ rb_ary_diff_bang(VALUE ary, VALUE other)
     args.len[0] = RARRAY_LEN(ary);
     args.len[1] = 0;
 
-    rb_ary_diff_bang_i((VALUE)&args, other);
+    rb_ary_subtract_bang_i((VALUE)&args, other);
     select_bang_ensure((VALUE)&args);
 
     return args.ary;
@@ -8887,7 +8887,7 @@ Init_Array(void)
     rb_define_method(rb_cArray, "+", rb_ary_plus, 1);
     rb_define_method(rb_cArray, "*", rb_ary_times, 1);
 
-    rb_define_method(rb_cArray, "diff!", rb_ary_diff_bang, 1);
+    rb_define_method(rb_cArray, "subtract!", rb_ary_subtract_bang, 1);
     rb_define_method(rb_cArray, "-", rb_ary_diff, 1);
     rb_define_method(rb_cArray, "&", rb_ary_and, 1);
     rb_define_method(rb_cArray, "|", rb_ary_or, 1);

--- a/test/ruby/test_array.rb
+++ b/test/ruby/test_array.rb
@@ -285,22 +285,22 @@ class TestArray < Test::Unit::TestCase
     assert_equal(@cls['cat', 'dog', 1, 2, 3], %w(cat dog) + (1..3).to_a)
   end
 
-  def test_diff_bang
+  def test_subtract_bang
     a = @cls[1]
 
-    a.diff!([1])
+    a.subtract!([1])
     assert_equal(@cls[], a)
 
     a = @cls[1, 2, 3, 4, 5]
-    assert_equal(@cls[1], a.diff!(@cls[2, 3, 4, 5]))
+    assert_equal(@cls[1], a.subtract!(@cls[2, 3, 4, 5]))
     a = @cls[1, 2, 1]
-    assert_equal(@cls[1, 1],  a.diff!(@cls[2]))
+    assert_equal(@cls[1, 1],  a.subtract!(@cls[2]))
     a = @cls[1, 2, 1, 3, 1, 4, 1, 5]
-    assert_equal(@cls[1, 1, 1, 1], a.diff!(@cls[2, 3, 4, 5]))
+    assert_equal(@cls[1, 1, 1, 1], a.subtract!(@cls[2, 3, 4, 5]))
 
     a = [1]
-    assert_equal(@cls[1], a.dup.diff!(@cls[2]))
-    assert_equal(@cls[], a.dup.diff!(@cls[1]))
+    assert_equal(@cls[1], a.dup.subtract!(@cls[2]))
+    assert_equal(@cls[], a.dup.subtract!(@cls[1]))
     assert_equal(@cls[1], a)
   end
 

--- a/test/ruby/test_array.rb
+++ b/test/ruby/test_array.rb
@@ -285,6 +285,25 @@ class TestArray < Test::Unit::TestCase
     assert_equal(@cls['cat', 'dog', 1, 2, 3], %w(cat dog) + (1..3).to_a)
   end
 
+  def test_diff_bang
+    a = @cls[1]
+
+    a.diff!([1])
+    assert_equal(@cls[], a)
+
+    a = @cls[1, 2, 3, 4, 5]
+    assert_equal(@cls[1], a.diff!(@cls[2, 3, 4, 5]))
+    a = @cls[1, 2, 1]
+    assert_equal(@cls[1, 1],  a.diff!(@cls[2]))
+    a = @cls[1, 2, 1, 3, 1, 4, 1, 5]
+    assert_equal(@cls[1, 1, 1, 1], a.diff!(@cls[2, 3, 4, 5]))
+
+    a = [1]
+    assert_equal(@cls[1], a.dup.diff!(@cls[2]))
+    assert_equal(@cls[], a.dup.diff!(@cls[1]))
+    assert_equal(@cls[1], a)
+  end
+
   def test_MINUS # '-'
     assert_equal(@cls[],  @cls[1] - @cls[1])
     assert_equal(@cls[1], @cls[1, 2, 3, 4, 5] - @cls[2, 3, 4, 5])


### PR DESCRIPTION
## Problem

Right now there is no way to perform an array difference operation without also allocating a new array. Array allocation can be expensive.


## Why can't we mutate the caller in `-=`

We cannot mutate the caller because it may cause unexpected behavior if there were other assignments as well. For example:

```
array2 = array1 -= array3
array2 -= array4
```

If the `-=` call mutated, then `array1` would be modified on the second line which would be surprising.

## Proposed solution

Introduce a new mutating method on array that does not allocate an intermediate array and instead returns itself.

There is already a `Array#difference` method (which takes multiple arrays while `Array#-` takes a single array).

I'm currently proposing naming this new method `Array#diff!` it will mutate the caller, only accept a single array to diff against, and return itself.

The goal is to increase performance of `-=` like operations.

In these micro benchmarks:

```
$ cat test.rb
require 'benchmark'

b_array = [2, 2, 2, 2, 2, 5, 5, 5, 5, 5, 99]

n = 5_000_000
Benchmark.bm do |x|
  x.report("Array#subtract!") { n.times do; a = [1, 2, 3]; a.subtract!(b_array); end }
  x.report("Array#-=   ") { n.times do; a = [1, 2, 3]; a -= b_array; end }
end
$ make runruby
generating vm_call_iseq_optimized.inc
vm_call_iseq_optimized.inc unchanged
RUBY_ON_BUG='gdb -x ./.gdbinit -p' ./miniruby -I./lib -I. -I.ext/common  ./tool/runruby.rb --extout=.ext  -- --disable-gems  ./test.rb
       user     system      total        real
able-gems  ./test.rb
       user     system      total        real
Array#subtract!  1.168282   0.002174   1.170456 (  1.172227)
Array#-=     1.428345   0.004802   1.433147 (  1.439785)
```

`Array#subtract!` is ~1.22x faster than `-=` in this micro benchmark.