### PR TITLE
Mandatory only builtin function

### DIFF
--- a/array.c
+++ b/array.c
@@ -6337,7 +6337,7 @@ rb_ary_shuffle(rb_execution_context_t *ec, VALUE ary, VALUE randgen)
 }
 
 static VALUE
-rb_ary_sample(rb_execution_context_t *ec, VALUE ary, VALUE randgen, VALUE nv, VALUE to_array)
+ary_sample(rb_execution_context_t *ec, VALUE ary, VALUE randgen, VALUE nv, VALUE to_array)
 {
     VALUE result;
     long n, len, i, j, k, idx[10];
@@ -6464,6 +6464,12 @@ rb_ary_sample(rb_execution_context_t *ec, VALUE ary, VALUE randgen, VALUE nv, VA
     ARY_SET_LEN(result, n);
 
     return result;
+}
+
+static VALUE
+ary_sample0(rb_execution_context_t *ec, VALUE ary)
+{
+    return ary_sample(ec, ary, rb_cRandom, Qfalse, Qfalse);
 }
 
 static VALUE

--- a/array.rb
+++ b/array.rb
@@ -58,6 +58,12 @@ class Array
   #    a.sample(random: Random.new(1))     #=> 6
   #    a.sample(4, random: Random.new(1))  #=> [6, 10, 9, 2]
   def sample(n = (ary = false), random: Random)
-    Primitive.rb_ary_sample(random, n, ary)
+    if Primitive.mandatory_only?
+      # Primitive.cexpr! %{ rb_ary_sample(self, rb_cRandom, Qfalse, Qfalse) }
+      Primitive.ary_sample0
+    else
+      # Primitive.cexpr! %{ rb_ary_sample(self, random, n, ary) }
+      Primitive.ary_sample(random, n, ary)
+    end
   end
 end

--- a/benchmark/array_sample.yml
+++ b/benchmark/array_sample.yml
@@ -1,0 +1,5 @@
+
+prelude: ary = (1..10_000).to_a
+benchmark:
+  - ary.sample
+  - ary.sample(2)

--- a/benchmark/time_at.yml
+++ b/benchmark/time_at.yml
@@ -1,0 +1,5 @@
+benchmark:
+  - 'Time.at(0)'
+  - 'Time.at(0, 500)'
+  - 'Time.at(0, in: "+09:00")'
+  - 'Time.at(0, 500, in: "+09:00")'

--- a/iseq.c
+++ b/iseq.c
@@ -272,6 +272,9 @@ rb_iseq_update_references(rb_iseq_t *iseq)
         if (body->parent_iseq) {
             body->parent_iseq = (struct rb_iseq_struct *)rb_gc_location((VALUE)body->parent_iseq);
         }
+        if (body->mandatory_only_iseq) {
+            body->mandatory_only_iseq = (struct rb_iseq_struct *)rb_gc_location((VALUE)body->mandatory_only_iseq);
+        }
         if (body->call_data) {
             for (unsigned int i=0; i<body->ci_size; i++) {
                 struct rb_call_data *cds = body->call_data;
@@ -351,6 +354,7 @@ rb_iseq_mark(const rb_iseq_t *iseq)
         rb_gc_mark_movable(body->location.label);
         rb_gc_mark_movable(body->location.base_label);
         rb_gc_mark_movable(body->location.pathobj);
+        RUBY_MARK_MOVABLE_UNLESS_NULL((VALUE)body->mandatory_only_iseq);
         RUBY_MARK_MOVABLE_UNLESS_NULL((VALUE)body->parent_iseq);
 
         if (body->call_data) {

--- a/iseq.h
+++ b/iseq.h
@@ -117,6 +117,7 @@ struct iseq_compile_data {
     const rb_compile_option_t *option;
     struct rb_id_table *ivar_cache_table;
     const struct rb_builtin_function *builtin_function_table;
+    const NODE *root_node;
 #if OPT_SUPPORT_JOKE
     st_table *labels_table;
 #endif

--- a/method.h
+++ b/method.h
@@ -132,8 +132,9 @@ typedef struct rb_iseq_struct rb_iseq_t;
 #endif
 
 typedef struct rb_method_iseq_struct {
-    rb_iseq_t * iseqptr; /*!< iseq pointer, should be separated from iseqval */
+    const rb_iseq_t * iseqptr; /*!< iseq pointer, should be separated from iseqval */
     rb_cref_t * cref;          /*!< class reference, should be marked */
+    const rb_callable_method_entry_t *mandatory_only_cme;
 } rb_method_iseq_t; /* check rb_add_method_iseq() when modify the fields */
 
 typedef struct rb_method_cfunc_struct {
@@ -171,7 +172,8 @@ enum method_optimized_type {
 
 struct rb_method_definition_struct {
     BITFIELD(rb_method_type_t, type, VM_METHOD_TYPE_MINIMUM_BITS);
-    int alias_count : 28;
+    unsigned int iseq_overload: 1;
+    int alias_count : 27;
     int complemented_count : 28;
 
     union {

--- a/time.c
+++ b/time.c
@@ -2708,6 +2708,12 @@ time_s_at(rb_execution_context_t *ec, VALUE klass, VALUE time, VALUE subsec, VAL
     return t;
 }
 
+static VALUE
+time_s_at1(rb_execution_context_t *ec, VALUE klass, VALUE time)
+{
+    return time_s_at(ec, klass, time, Qfalse, ID2SYM(id_microsecond), Qnil);
+}
+
 static const char months[][4] = {
     "jan", "feb", "mar", "apr", "may", "jun",
     "jul", "aug", "sep", "oct", "nov", "dec",

--- a/timev.rb
+++ b/timev.rb
@@ -268,7 +268,11 @@ class Time
   # :include: doc/time/in.rdoc
   #
   def self.at(time, subsec = false, unit = :microsecond, in: nil)
-    Primitive.time_s_at(time, subsec, unit, Primitive.arg!(:in))
+    if Primitive.mandatory_only?
+      Primitive.time_s_at1(time)
+    else
+      Primitive.time_s_at(time, subsec, unit, Primitive.arg!(:in))
+    end
   end
 
   # Returns a new \Time object based the on given arguments.

--- a/tool/mk_builtin_loader.rb
+++ b/tool/mk_builtin_loader.rb
@@ -100,6 +100,7 @@ def collect_builtin base, tree, name, bs, inlines, locals = nil
     when :call, :command_call   # CALL
       _, recv, sep, mid, (_, args) = tree
     end
+
     if mid
       raise "unknown sexp: #{mid.inspect}" unless %i[@ident @const].include?(mid.first)
       _, mid, (lineno,) = mid
@@ -126,7 +127,7 @@ def collect_builtin base, tree, name, bs, inlines, locals = nil
         args.pop unless (args ||= []).last
         argc = args.size
 
-        if /(.+)\!\z/ =~ func_name
+        if /(.+)[\!\?]\z/ =~ func_name
           case $1
           when 'attr'
             text = inline_text(argc, args.first)
@@ -156,6 +157,8 @@ def collect_builtin base, tree, name, bs, inlines, locals = nil
             func_name = nil # required
             inlines[inlines.size] = [lineno, text, nil, nil]
             argc -= 1
+          when 'mandatory_only'
+            func_name = nil
           when 'arg'
             argc == 1 or raise "unexpected argument number #{argc}"
             (arg = args.first)[0] == :symbol_literal or raise "symbol literal expected #{args}"

--- a/vm_callinfo.h
+++ b/vm_callinfo.h
@@ -446,6 +446,25 @@ vm_ccs_p(const struct rb_class_cc_entries *ccs)
 {
     return ccs->debug_sig == ~(VALUE)ccs;
 }
+
+static inline bool
+vm_cc_check_cme(const struct rb_callcache *cc, const rb_callable_method_entry_t *cme)
+{
+    if (vm_cc_cme(cc) == cme ||
+        (cme->def->iseq_overload && vm_cc_cme(cc) == cme->def->body.iseq.mandatory_only_cme)) {
+        return true;
+    }
+    else {
+#if 1
+        fprintf(stderr, "iseq_overload:%d mandatory_only_cme:%p eq:%d\n",
+                (int)cme->def->iseq_overload,
+                (void *)cme->def->body.iseq.mandatory_only_cme,
+                vm_cc_cme(cc) == cme->def->body.iseq.mandatory_only_cme);
+#endif
+        return false;
+    }
+}
+
 #endif
 
 // gc.c

--- a/vm_core.h
+++ b/vm_core.h
@@ -482,6 +482,8 @@ struct rb_iseq_constant_body {
     bool builtin_inline_p;
     struct rb_id_table *outer_variables;
 
+    const rb_iseq_t *mandatory_only_iseq;
+
 #if USE_MJIT
     /* The following fields are MJIT related info.  */
     VALUE (*jit_func)(struct rb_execution_context_struct *,

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -455,7 +455,7 @@ gccct_method_search(rb_execution_context_t *ec, VALUE recv, ID mid, int argc)
             if (LIKELY(!METHOD_ENTRY_INVALIDATED(cme) &&
                        cme->called_id == mid)) {
 
-                VM_ASSERT(vm_cc_cme(cc) == rb_callable_method_entry(klass, mid));
+                VM_ASSERT(vm_cc_check_cme(cc, rb_callable_method_entry(klass, mid)));
                 RB_DEBUG_COUNTER_INC(gccct_hit);
 
                 return cc;


### PR DESCRIPTION
`Primitive.mandatory_only?` for fast path

Compare with the C methods, A built-in methods written in Ruby is
slower if only mandatory parameters are given because it needs to
check the argumens and fill default values for optional and keyword
parameters (C methods can check the number of parameters with `argc`,
so there are no overhead). Passing mandatory arguments are common
(optional arguments are exceptional, in many cases) so it is important
to provide the fast path for such common cases.

`Primitive.mandatory_only?` is a special builtin function used with
`if` expression like that:

```ruby
  def self.at(time, subsec = false, unit = :microsecond, in: nil)
    if Primitive.mandatory_only?
      Primitive.time_s_at1(time)
    else
      Primitive.time_s_at(time, subsec, unit, Primitive.arg!(:in))
    end
  end
```

and it makes two ISeq,

```
  def self.at(time, subsec = false, unit = :microsecond, in: nil)
    Primitive.time_s_at(time, subsec, unit, Primitive.arg!(:in))
  end

  def self.at(time)
    Primitive.time_s_at1(time)
  end
```

and (2) is pointed by (1). Note that `Primitive.mandatory_only?`
should be used only in a condition of an `if` statement and the
`if` statement should be equal to the methdo body (you can not
put any expression before and after the `if` statement).

A method entry with `mandatory_only?` (`Time.at` on the above case)
is marked as `iseq_overload`. When the method will be dispatch only
with mandatory arguments (`Time.at(0)` for example), make another
method entry with ISeq (2) as mandatory only method entry and it
will be cached in an inline method cache.

The idea is similar discussed in https://bugs.ruby-lang.org/issues/16254
but it only checks mandatory parameters or more, because many cases
only mandatory parameters are given. If we find other cases (optional
or keyword parameters are used frequently and it hurts performance),
we can extend the feature.


----

add benchmark/array_sample.yml

```
                      ruby_2_6    ruby_2_7    ruby_3_0      master    modified
         ary.sample    32.113M     30.146M     11.162M     10.539M     26.620M i/s -     64.882M times in 2.020428s 2.152296s 5.812981s 6.156398s 2.437325s
      ary.sample(2)     9.420M      8.987M      7.500M      6.973M      7.191M i/s -     25.170M times in 2.672085s 2.800616s 3.355896s 3.609534s 3.500108s
```

add benchmark/time_at.yml

```
                                ruby_2_6    ruby_2_7    ruby_3_0      master    modified
                   Time.at(0)    12.362M     11.015M      9.499M      6.615M      9.000M i/s -     32.115M times in 2.597946s 2.915517s 3.380725s 4.854651s 3.568234s
              Time.at(0, 500)     7.542M      7.136M      8.252M      5.707M      5.646M i/s -     20.713M times in 2.746279s 2.902556s 2.510166s 3.629644s 3.668854s
     Time.at(0, in: "+09:00")     1.426M      1.346M      1.565M      1.674M      1.667M i/s -      4.240M times in 2.974049s 3.149753s 2.709416s 2.533043s 2.542853s
```

```
ruby_2_6: ruby 2.6.7p150 (2020-12-09 revision 67888) [x86_64-linux]
ruby_2_7: ruby 2.7.3p140 (2020-12-09 revision 9b884df6dd) [x86_64-linux]
ruby_3_0: ruby 3.0.3p150 (2021-11-06 revision 6d540c1b98) [x86_64-linux]
master: ruby 3.1.0dev (2021-11-13T20:48:57Z master fc456adc6a) [x86_64-linux]
modified: ruby 3.1.0dev (2021-11-15T01:12:51Z mandatory_only_bui.. b0228446db) [x86_64-linux]


