### PR TITLE
Validate string type when constructing `IO::Buffer` for string mapping.

### DIFF
--- a/io_buffer.c
+++ b/io_buffer.c
@@ -259,6 +259,8 @@ rb_io_buffer_type_allocate(VALUE self)
 VALUE
 rb_io_buffer_type_for(VALUE klass, VALUE string)
 {
+    StringValue(string);
+
     VALUE instance = rb_io_buffer_type_allocate(klass);
 
     struct rb_io_buffer *data = NULL;

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -81,6 +81,14 @@ class TestIOBuffer < Test::Unit::TestCase
     assert_equal "Hello World", string
   end
 
+  def test_non_string
+    not_string = Object.new
+
+    assert_raise TypeError do
+      IO::Buffer.for(not_string)
+    end
+  end
+
   def test_resize
     buffer = IO::Buffer.new(1024, IO::Buffer::MAPPED)
     buffer.resize(2048, 0)


### PR DESCRIPTION
> You need to check it's actually a String before calling this.
> And also you need to pin it to avoid it moving when GC.compact/autocompact is used.