### PR TITLE
try IO#read_nonblock

### DIFF
--- a/benchmark/io_read_nonblock.yml
+++ b/benchmark/io_read_nonblock.yml
@@ -1,0 +1,8 @@
+prelude: |
+  r, _w = IO.popen('yes')
+  sleep 0.5
+benchmark:
+  read_nonblock: |
+    r.read_nonblock(1)
+  'read_nonblock(exception: true)': |
+    r.read_nonblock(1, exception: true)

--- a/io.c
+++ b/io.c
@@ -3277,6 +3277,12 @@ io_read_nonblock(rb_execution_context_t *ec, VALUE io, VALUE length, VALUE str, 
     return str;
 }
 
+static VALUE
+io_read_nonblock_len(rb_execution_context_t *ec, VALUE io, VALUE length)
+{
+    return io_read_nonblock(ec, io, length, Qnil, Qtrue);
+}
+
 /* :nodoc: */
 static VALUE
 io_write_nonblock(rb_execution_context_t *ec, VALUE io, VALUE str, VALUE ex)
@@ -3313,6 +3319,12 @@ io_write_nonblock(rb_execution_context_t *ec, VALUE io, VALUE str, VALUE ex)
     }
 
     return LONG2FIX(n);
+}
+
+static VALUE
+io_write_nonblock_buf(rb_execution_context_t *ec, VALUE io, VALUE str)
+{
+    return io_write_nonblock(ec, io, str, Qtrue);
 }
 
 /*

--- a/io.rb
+++ b/io.rb
@@ -60,7 +60,11 @@ class IO
   # return the symbol +:wait_readable+ instead. At EOF, it will return nil
   # instead of raising EOFError.
   def read_nonblock(len, buf = nil, exception: true)
-    Primitive.io_read_nonblock(len, buf, exception)
+    if Primitive.mandatory_only?
+      Primitive.io_read_nonblock_len(len)
+    else
+      Primitive.io_read_nonblock(len, buf, exception)
+    end
   end
 
   # call-seq:
@@ -118,6 +122,10 @@ class IO
   # that write_nonblock should not raise an IO::WaitWritable exception, but
   # return the symbol +:wait_writable+ instead.
   def write_nonblock(buf, exception: true)
-    Primitive.io_write_nonblock(buf, exception)
+    if Primitive.mandatory_only?
+      Primitive.io_write_nonblock_buf(buf)
+    else
+      Primitive.io_write_nonblock(buf, exception)
+    end
   end
 end


### PR DESCRIPTION
Try to use `Primitive.mandatory_only?` for `IO#read_nonblock` but only a few performance improvement. So I reject it. This ticket is only for recording.

```
ruby_2_7: ruby 2.7.3p140 (2020-12-09 revision 9b884df6dd) [x86_64-linux]
ruby_3_0: ruby 3.0.3p150 (2021-11-06 revision 6d540c1b98) [x86_64-linux]
master: ruby 3.1.0dev (2021-11-13T20:48:57Z master fc456adc6a) [x86_64-linux]
modified: ruby 3.1.0dev (2021-11-15T08:08:19Z master ba2cf9ba12) [x86_64-linux]
last_commit=try IO#read_nonblock
Warming up --------------------------------------
                 read_nonblock   901.456k i/s -    921.219k times in 1.021923s (1.11μs/i)
read_nonblock(exception: true)   896.741k i/s -    921.453k times in 1.027557s (1.12μs/i)
Calculating -------------------------------------
                                 ruby_2_7    ruby_3_0      master    modified
                 read_nonblock   914.114k    887.808k    881.946k    908.338k i/s -      2.704M times in 2.958459s 3.046120s 3.066367s 2.977270s
read_nonblock(exception: true)   900.714k    884.010k    874.377k    875.961k i/s -      2.690M times in 2.986768s 3.043205s 3.076733s 3.071167s

Comparison:
                              read_nonblock
                      ruby_2_7:    914114.2 i/s
                      modified:    908338.4 i/s - 1.01x  slower
                      ruby_3_0:    887807.8 i/s - 1.03x  slower
                        master:    881945.7 i/s - 1.04x  slower

             read_nonblock(exception: true)
                      ruby_2_7:    900713.7 i/s
                      ruby_3_0:    884009.7 i/s - 1.02x  slower
                      modified:    875961.0 i/s - 1.03x  slower
                        master:    874376.6 i/s - 1.03x  slower
```
