### PR TITLE
Io rw nonblock mandatory only

### DIFF
--- a/benchmark/io_read_nonblock.yml
+++ b/benchmark/io_read_nonblock.yml
@@ -1,0 +1,8 @@
+prelude: |
+  r = IO.popen('yes')
+  sleep 0.5
+benchmark:
+  read_nonblock: |
+    r.read_nonblock(1)
+  'read_nonblock(exception: true)': |
+    r.read_nonblock(1, exception: true)

--- a/benchmark/io_write_nonblock.yml
+++ b/benchmark/io_write_nonblock.yml
@@ -1,0 +1,9 @@
+prelude: |
+  w = IO.popen('cat > /dev/null', 'w')
+  str = 'hello'
+  sleep 0.5
+benchmark:
+  write_nonblock: |
+    w.write_nonblock(str)
+  'write_nonblock(exception: true)': |
+    w.write_nonblock(str, exception: true)

--- a/io.c
+++ b/io.c
@@ -3277,6 +3277,12 @@ io_read_nonblock(rb_execution_context_t *ec, VALUE io, VALUE length, VALUE str, 
     return str;
 }
 
+static VALUE
+io_read_nonblock_len(rb_execution_context_t *ec, VALUE io, VALUE length)
+{
+    return io_read_nonblock(ec, io, length, Qnil, Qtrue);
+}
+
 /* :nodoc: */
 static VALUE
 io_write_nonblock(rb_execution_context_t *ec, VALUE io, VALUE str, VALUE ex)
@@ -3313,6 +3319,12 @@ io_write_nonblock(rb_execution_context_t *ec, VALUE io, VALUE str, VALUE ex)
     }
 
     return LONG2FIX(n);
+}
+
+static VALUE
+io_write_nonblock_buf(rb_execution_context_t *ec, VALUE io, VALUE str)
+{
+    return io_write_nonblock(ec, io, str, Qtrue);
 }
 
 /*

--- a/io.rb
+++ b/io.rb
@@ -60,7 +60,11 @@ class IO
   # return the symbol +:wait_readable+ instead. At EOF, it will return nil
   # instead of raising EOFError.
   def read_nonblock(len, buf = nil, exception: true)
-    Primitive.io_read_nonblock(len, buf, exception)
+    if Primitive.mandatory_only?
+      Primitive.io_read_nonblock_len(len)
+    else
+      Primitive.io_read_nonblock(len, buf, exception)
+    end
   end
 
   # call-seq:
@@ -118,6 +122,10 @@ class IO
   # that write_nonblock should not raise an IO::WaitWritable exception, but
   # return the symbol +:wait_writable+ instead.
   def write_nonblock(buf, exception: true)
-    Primitive.io_write_nonblock(buf, exception)
+    if Primitive.mandatory_only?
+      Primitive.io_write_nonblock_buf(buf)
+    else
+      Primitive.io_write_nonblock(buf, exception)
+    end
   end
 end


### PR DESCRIPTION
add write benchmark to #5116.
Same as read, only a few improvement.

```
ruby_2_7: ruby 2.7.3p140 (2020-12-09 revision 9b884df6dd) [x86_64-linux]
ruby_3_0: ruby 3.0.3p150 (2021-11-06 revision 6d540c1b98) [x86_64-linux]
master: ruby 3.1.0dev (2021-11-13T20:48:57Z master fc456adc6a) [x86_64-linux]
modified: ruby 3.1.0dev (2021-11-15T08:30:57Z IO_rw_nonblock_man.. 51e9ea1fb1) [x86_64-linux]
Warming up --------------------------------------
                  read_nonblock   893.586k i/s -    939.094k times in 1.050927s (1.12μs/i)
 read_nonblock(exception: true)   889.805k i/s -    938.366k times in 1.054575s (1.12μs/i)
                 write_nonblock   879.039k i/s -    913.402k times in 1.039092s (1.14μs/i)
write_nonblock(exception: true)   905.106k i/s -    962.355k times in 1.063251s (1.10μs/i)
Calculating -------------------------------------
                                  ruby_2_7    ruby_3_0      master    modified
                  read_nonblock   908.854k    889.247k    881.070k    893.607k i/s -      2.681M times in 2.949603s 3.014639s 3.042617s 2.999928s
 read_nonblock(exception: true)   904.968k    882.821k    870.981k    873.269k i/s -      2.669M times in 2.949734s 3.023731s 3.064836s 3.056806s
                 write_nonblock   887.510k    892.575k    876.139k    877.299k i/s -      2.637M times in 2.971366s 2.954504s 3.009930s 3.005948s
write_nonblock(exception: true)   878.111k    885.255k    884.745k    895.126k i/s -      2.715M times in 3.092227s 3.067269s 3.069041s 3.033446s

Comparison:
                               read_nonblock
                       ruby_2_7:    908853.8 i/s
                       modified:    893607.3 i/s - 1.02x  slower
                       ruby_3_0:    889246.7 i/s - 1.02x  slower
                         master:    881069.8 i/s - 1.03x  slower

              read_nonblock(exception: true)
                       ruby_2_7:    904967.8 i/s
                       ruby_3_0:    882821.2 i/s - 1.03x  slower
                       modified:    873269.1 i/s - 1.04x  slower
                         master:    870981.1 i/s - 1.04x  slower

                              write_nonblock
                       ruby_3_0:    892575.0 i/s
                       ruby_2_7:    887509.6 i/s - 1.01x  slower
                       modified:    877299.3 i/s - 1.02x  slower
                         master:    876138.6 i/s - 1.02x  slower

             write_nonblock(exception: true)
                       modified:    895126.2 i/s
                       ruby_3_0:    885255.5 i/s - 1.01x  slower
                         master:    884744.5 i/s - 1.01x  slower
                       ruby_2_7:    878110.6 i/s - 1.02x  slower
```
