### PR TITLE
[Bug #18329] Fix crash caused by GC

### DIFF
--- a/test/ruby/test_super.rb
+++ b/test/ruby/test_super.rb
@@ -549,7 +549,13 @@ class TestSuper < Test::Unit::TestCase
 
     o = b.new
     o.danger!
-    2.times { o.missing rescue NoMethodError }
+    begin
+      original_gc_stress = GC.stress
+      GC.stress = true
+      2.times { o.missing rescue NoMethodError }
+    ensure
+      GC.stress = original_gc_stress
+    end
   end
 
   def test_from_eval

--- a/vm_callinfo.h
+++ b/vm_callinfo.h
@@ -359,7 +359,8 @@ vm_cc_markable(const struct rb_callcache *cc)
 static inline bool
 vm_cc_invalidated_p(const struct rb_callcache *cc)
 {
-    if (cc->klass && !METHOD_ENTRY_INVALIDATED(vm_cc_cme(cc))) {
+    const struct rb_callable_method_entry_struct *cme = vm_cc_cme(cc);
+    if (cc->klass && cme && !METHOD_ENTRY_INVALIDATED(cme)) {
         return false;
     }
     else {


### PR DESCRIPTION
Commit 84202963c52e02cecad3e6b2fad478bfbeee1bc7 fixed the bug but a segfault can still occur if a GC was triggerd in between.