### PR TITLE
Assert cc cme nonull

### DIFF
--- a/iseq.c
+++ b/iseq.c
@@ -366,12 +366,17 @@ rb_iseq_mark(const rb_iseq_t *iseq)
                 if (vm_ci_markable(ci)) {
                     rb_gc_mark_movable((VALUE)ci);
                 }
-                if (cc && vm_cc_markable(cc)) {
-                    if (!vm_cc_invalidated_p(cc)) {
-                        rb_gc_mark_movable((VALUE)cc);
-                    }
-                    else {
-                        cds[i].cc = rb_vm_empty_cc();
+
+                if (cc) {
+                    VM_ASSERT((cc->flags & VM_CALLCACHE_ON_STACK) == 0);
+
+                    if (vm_cc_markable(cc)) {
+                        if (!vm_cc_invalidated_p(cc)) {
+                            rb_gc_mark_movable((VALUE)cc);
+                        }
+                        else {
+                            cds[i].cc = rb_vm_empty_cc();
+                        }
                     }
                 }
             }

--- a/vm.c
+++ b/vm.c
@@ -439,6 +439,16 @@ static const struct rb_callcache vm_empty_cc = {
     }
 };
 
+static const struct rb_callcache vm_empty_cc_for_super = {
+    .flags = T_IMEMO | (imemo_callcache << FL_USHIFT) | VM_CALLCACHE_UNMARKABLE,
+    .klass = Qfalse,
+    .cme_  = NULL,
+    .call_ = vm_call_super_method,
+    .aux_  = {
+        .v = Qfalse,
+    }
+};
+
 static void thread_free(void *ptr);
 
 void
@@ -4174,6 +4184,12 @@ MJIT_FUNC_EXPORTED const struct rb_callcache *
 rb_vm_empty_cc(void)
 {
     return &vm_empty_cc;
+}
+
+MJIT_FUNC_EXPORTED const struct rb_callcache *
+rb_vm_empty_cc_for_super(void)
+{
+    return &vm_empty_cc_for_super;
 }
 
 #endif /* #ifndef MJIT_HEADER */

--- a/vm_callinfo.h
+++ b/vm_callinfo.h
@@ -332,6 +332,7 @@ static inline vm_call_handler
 vm_cc_call(const struct rb_callcache *cc)
 {
     VM_ASSERT(IMEMO_TYPE_P(cc, imemo_callcache));
+    VM_ASSERT(cc->call_ != NULL);
     return cc->call_;
 }
 

--- a/vm_callinfo.h
+++ b/vm_callinfo.h
@@ -382,6 +382,7 @@ vm_cc_valid_p(const struct rb_callcache *cc, const rb_callable_method_entry_t *c
 }
 
 extern const struct rb_callcache *rb_vm_empty_cc(void);
+extern const struct rb_callcache *rb_vm_empty_cc_for_super(void);
 #define vm_cc_empty() rb_vm_empty_cc()
 
 /* callcache: mutate */

--- a/vm_callinfo.h
+++ b/vm_callinfo.h
@@ -290,6 +290,7 @@ struct rb_callcache {
 };
 
 #define VM_CALLCACHE_UNMARKABLE IMEMO_FL_USER0
+#define VM_CALLCACHE_ON_STACK   IMEMO_FL_USER1
 
 static inline const struct rb_callcache *
 vm_cc_new(VALUE klass,
@@ -305,7 +306,8 @@ vm_cc_new(VALUE klass,
     (struct rb_callcache) {                   \
         .flags = T_IMEMO |                    \
             (imemo_callcache << FL_USHIFT) |  \
-            VM_CALLCACHE_UNMARKABLE,          \
+            VM_CALLCACHE_UNMARKABLE |         \
+            VM_CALLCACHE_ON_STACK,            \
         .klass = clazz,                       \
         .cme_  = cme,                         \
         .call_ = call,                        \

--- a/vm_callinfo.h
+++ b/vm_callinfo.h
@@ -321,10 +321,19 @@ vm_cc_class_check(const struct rb_callcache *cc, VALUE klass)
     return cc->klass == klass;
 }
 
+static inline int
+vm_cc_markable(const struct rb_callcache *cc)
+{
+    VM_ASSERT(IMEMO_TYPE_P(cc, imemo_callcache));
+    return FL_TEST_RAW((VALUE)cc, VM_CALLCACHE_UNMARKABLE) == 0;
+}
+
 static inline const struct rb_callable_method_entry_struct *
 vm_cc_cme(const struct rb_callcache *cc)
 {
     VM_ASSERT(IMEMO_TYPE_P(cc, imemo_callcache));
+    VM_ASSERT(!vm_cc_markable(cc) || cc->cme_ != NULL);
+
     return cc->cme_;
 }
 
@@ -348,13 +357,6 @@ vm_cc_cmethod_missing_reason(const struct rb_callcache *cc)
 {
     VM_ASSERT(IMEMO_TYPE_P(cc, imemo_callcache));
     return cc->aux_.method_missing_reason;
-}
-
-static inline int
-vm_cc_markable(const struct rb_callcache *cc)
-{
-    VM_ASSERT(IMEMO_TYPE_P(cc, imemo_callcache));
-    return FL_TEST_RAW((VALUE)cc, VM_CALLCACHE_UNMARKABLE) == 0;
 }
 
 static inline bool

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1949,8 +1949,7 @@ vm_search_method_fastpath(VALUE cd_owner, struct rb_call_data *cd, VALUE klass)
 
 #if OPT_INLINE_METHOD_CACHE
     if (LIKELY(vm_cc_class_check(cc, klass))) {
-        const struct rb_callable_method_entry_struct *cme = vm_cc_cme(cc);
-        if (LIKELY(cme && !METHOD_ENTRY_INVALIDATED(cme))) {
+        if (LIKELY(!METHOD_ENTRY_INVALIDATED(vm_cc_cme(cc)))) {
             VM_ASSERT(callable_method_entry_p(vm_cc_cme(cc)));
             RB_DEBUG_COUNTER_INC(mc_inline_hit);
             VM_ASSERT(vm_cc_cme(cc) == NULL ||                        // not found

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -38,6 +38,7 @@ extern VALUE rb_make_no_method_exception(VALUE exc, VALUE format, VALUE obj,
 
 #ifndef MJIT_HEADER
 static const struct rb_callcache vm_empty_cc;
+static const struct rb_callcache vm_empty_cc_for_super;
 #endif
 
 /* control stack frame */
@@ -3711,6 +3712,11 @@ vm_call_super_method(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, st
 {
     RB_DEBUG_COUNTER_INC(ccf_super_method);
 
+    // This line is introduced to make different from `vm_call_general` because some compilers (VC we found)
+    // can merge the function and the address of the function becomes same.
+    // The address of `vm_call_super_method` is used in `search_refined_method`, so it should be different.
+    if (ec == NULL) rb_bug("unreachable");
+
     /* this check is required to distinguish with other functions. */
     VM_ASSERT(vm_cc_call(calling->cc) == vm_call_super_method);
     return vm_call_method(ec, reg_cfp, calling);
@@ -3735,6 +3741,16 @@ static void
 vm_super_outside(void)
 {
     rb_raise(rb_eNoMethodError, "super called outside of method");
+}
+
+static const struct rb_callcache *
+empty_cc_for_super(void)
+{
+#ifdef MJIT_HEADER
+    return rb_vm_empty_cc_for_super();
+#else
+    return &vm_empty_cc_for_super;
+#endif
 }
 
 static const struct rb_callcache *
@@ -3800,19 +3816,18 @@ vm_search_super_method(const rb_control_frame_t *reg_cfp, struct rb_call_data *c
 
         // define_method can cache for different method id
         if (cached_cme == NULL) {
-            // temporary CC. revisit it
-            static const struct rb_callcache *empty_cc_for_super = NULL;
-            if (empty_cc_for_super == NULL) {
-                empty_cc_for_super = vm_cc_new(0, NULL, vm_call_super_method);
-                FL_SET_RAW((VALUE)empty_cc_for_super, VM_CALLCACHE_UNMARKABLE);
-                rb_gc_register_mark_object((VALUE)empty_cc_for_super);
-            }
-            RB_OBJ_WRITE(reg_cfp->iseq, &cd->cc, cc = empty_cc_for_super);
+            // empty_cc_for_super is not markable object
+            cd->cc = empty_cc_for_super();
         }
         else if (cached_cme->called_id != mid) {
             const rb_callable_method_entry_t *cme = rb_callable_method_entry(klass, mid);
-            cc = vm_cc_new(klass, cme, vm_call_super_method);
-            RB_OBJ_WRITE(reg_cfp->iseq, &cd->cc, cc);
+            if (cme) {
+                cc = vm_cc_new(klass, cme, vm_call_super_method);
+                RB_OBJ_WRITE(reg_cfp->iseq, &cd->cc, cc);
+            }
+            else {
+                cd->cc = cc = empty_cc_for_super();
+            }
         }
         else {
             switch (cached_cme->def->type) {
@@ -3828,6 +3843,8 @@ vm_search_super_method(const rb_control_frame_t *reg_cfp, struct rb_call_data *c
             }
         }
     }
+
+    VM_ASSERT((vm_cc_cme(cc), true));
 
     return cc;
 }

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -3712,8 +3712,7 @@ vm_call_super_method(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, st
     RB_DEBUG_COUNTER_INC(ccf_super_method);
 
     /* this check is required to distinguish with other functions. */
-    const struct rb_callcache *cc = calling->cc;
-    if (vm_cc_call(cc) != vm_call_super_method) rb_bug("bug");
+    VM_ASSERT(vm_cc_call(calling->cc) == vm_call_super_method);
     return vm_call_method(ec, reg_cfp, calling);
 }
 


### PR DESCRIPTION
Recently `cc->cme_` (`rb_callcache::cme_`) points NULL, but cached `cme_` should not be NULL (when it is markable).
This PR fixes the invariant violation.