### PR TITLE
`Primitive.mandatory_only?` consider splat args

### DIFF
--- a/test/ruby/test_time.rb
+++ b/test/ruby/test_time.rb
@@ -241,6 +241,10 @@ class TestTime < Test::Unit::TestCase
     assert_equal(1, Time.at(0, 0.001).nsec)
   end
 
+  def test_at_splat
+    assert_equal(Time.at(1, 2), Time.at(*[1, 2]))
+  end
+
   def test_at_with_unit
     assert_equal(123456789, Time.at(0, 123456789, :nanosecond).nsec)
     assert_equal(123456789, Time.at(0, 123456789, :nsec).nsec)

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1848,8 +1848,10 @@ vm_search_cc(const VALUE klass, const struct rb_callinfo * const ci)
         }
     }
 
-    if ((cme->def->iseq_overload &&
-         (int)vm_ci_argc(ci) == method_entry_iseqptr(cme)->body->param.lead_num)) {
+    if (cme->def->iseq_overload &&
+        (vm_ci_flag(ci) & (VM_CALL_ARGS_SIMPLE)) &&
+        (int)vm_ci_argc(ci) == method_entry_iseqptr(cme)->body->param.lead_num
+    ) {
         // use alternative
         cme = overloaded_cme(cme);
         METHOD_ENTRY_CACHED_SET((struct rb_callable_method_entry_struct *)cme);


### PR DESCRIPTION
Ref: https://github.com/ruby/ruby/pull/5112

`vm_ci_argc` gives the number of arguments, but `*[1, 2, 3]` only counts for one.

I highly doubt this is the right fix, but it's kind of a learning exercise for me.

cc @ko1 