### PR TITLE
Make RCLASS_EXT(c)->subclasses a doubly linked list

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -3134,15 +3134,7 @@ obj_free(rb_objspace_t *objspace, VALUE obj)
             rb_id_table_foreach_values(RCLASS_CVC_TBL(obj), cvar_table_free_i, NULL);
             rb_id_table_free(RCLASS_CVC_TBL(obj));
 	}
-	if (RCLASS_SUBCLASSES(obj)) {
-	    if (BUILTIN_TYPE(obj) == T_MODULE) {
-		rb_class_detach_module_subclasses(obj);
-	    }
-	    else {
-		rb_class_detach_subclasses(obj);
-	    }
-	    RCLASS_SUBCLASSES(obj) = NULL;
-	}
+        rb_class_remove_subclass_head(obj);
 	rb_class_remove_from_module_subclasses(obj);
 	rb_class_remove_from_super_subclasses(obj);
 #if !USE_RVARGC
@@ -3307,10 +3299,7 @@ obj_free(rb_objspace_t *objspace, VALUE obj)
 	if (RCLASS_CALLABLE_M_TBL(obj) != NULL) {
 	    rb_id_table_free(RCLASS_CALLABLE_M_TBL(obj));
 	}
-	if (RCLASS_SUBCLASSES(obj)) {
-	    rb_class_detach_subclasses(obj);
-	    RCLASS_SUBCLASSES(obj) = NULL;
-	}
+        rb_class_remove_subclass_head(obj);
         cc_table_free(objspace, obj, FALSE);
 	rb_class_remove_from_module_subclasses(obj);
 	rb_class_remove_from_super_subclasses(obj);

--- a/internal/class.h
+++ b/internal/class.h
@@ -22,6 +22,7 @@
 struct rb_subclass_entry {
     VALUE klass;
     struct rb_subclass_entry *next;
+    struct rb_subclass_entry *prev;
 };
 
 struct rb_iv_index_tbl_entry {
@@ -47,13 +48,13 @@ struct rb_classext_struct {
     struct rb_id_table *cc_tbl; /* ID -> [[ci, cc1], cc2, ...] */
     struct rb_id_table *cvc_tbl;
     struct rb_subclass_entry *subclasses;
-    struct rb_subclass_entry **parent_subclasses;
+    struct rb_subclass_entry *subclass_entry;
     /**
      * In the case that this is an `ICLASS`, `module_subclasses` points to the link
      * in the module's `subclasses` list that indicates that the klass has been
      * included. Hopefully that makes sense.
      */
-    struct rb_subclass_entry **module_subclasses;
+    struct rb_subclass_entry *module_subclass_entry;
 #if SIZEOF_SERIAL_T != SIZEOF_VALUE /* otherwise class_serial is in struct RClass */
     rb_serial_t class_serial;
 #endif
@@ -105,8 +106,8 @@ typedef struct rb_classext_struct rb_classext_t;
 # define RCLASS_SERIAL(c) (RCLASS_EXT(c)->class_serial)
 #endif
 #define RCLASS_INCLUDER(c) (RCLASS_EXT(c)->includer)
-#define RCLASS_PARENT_SUBCLASSES(c) (RCLASS_EXT(c)->parent_subclasses)
-#define RCLASS_MODULE_SUBCLASSES(c) (RCLASS_EXT(c)->module_subclasses)
+#define RCLASS_SUBCLASS_ENTRY(c) (RCLASS_EXT(c)->subclass_entry)
+#define RCLASS_MODULE_SUBCLASS_ENTRY(c) (RCLASS_EXT(c)->module_subclass_entry)
 #define RCLASS_ALLOCATOR(c) (RCLASS_EXT(c)->allocator)
 #define RCLASS_SUBCLASSES(c) (RCLASS_EXT(c)->subclasses)
 
@@ -117,6 +118,7 @@ typedef struct rb_classext_struct rb_classext_t;
 /* class.c */
 void rb_class_subclass_add(VALUE super, VALUE klass);
 void rb_class_remove_from_super_subclasses(VALUE);
+void rb_class_remove_subclass_head(VALUE);
 int rb_singleton_class_internal_p(VALUE sklass);
 VALUE rb_class_boot(VALUE);
 VALUE rb_class_s_alloc(VALUE klass);


### PR DESCRIPTION
When sweeping a class, we have to remove it from it's superclass's subclass list and remove all it's subclasses. the `rb_classext_t` retains a double pointer to the classes superclass's list of subclasses in order to facilitate this.

This means that when we free a class, we have to modify the superclass to remove/reset that link. This is fine when RVARGC is disabled as the `rb_classext_t` is not stored in the Ruby heap.

with RVARGC enabled the `rb_classext_t` lives in the Ruby heap, which means that when we're sweep and compacting, we need to modify the heap in ways that we aren't expecting.

This PR removes the need to modify the Ruby heap when freeing classes by keeping the entire subclass list in the C heap and making it a doubly linked list with a dedicated list head.