### PR TITLE
Fix crash when clearing method cache for builtin method

### DIFF
--- a/vm_method.c
+++ b/vm_method.c
@@ -209,7 +209,7 @@ clear_method_cache_by_id_in_class(VALUE klass, ID mid)
                 vm_cme_invalidate((rb_callable_method_entry_t *)cme);
                 RB_DEBUG_COUNTER_INC(cc_invalidate_tree_cme);
 
-                if (cme->def->iseq_overload) {
+                if (cme->def->iseq_overload && cme->def->body.iseq.mandatory_only_cme) {
                     vm_cme_invalidate((rb_callable_method_entry_t *)cme->def->body.iseq.mandatory_only_cme);
                 }
             }


### PR DESCRIPTION
Builtin methods do not always have their mandatory_only_cme created (it is only created when called with only mandatory parameters), so it could be null. If we try to clear the cme, it will crash because it is null.

The following script crashes:

```ruby
class Foo < Time
end

Time.at(0, 100, :usec)

class Time
  class << self
    def at2(*args, **kwargs)
    end
    alias_method :at, :at2
  end
end
```

Backtrace:

```
../test.rb:11: [BUG] Segmentation fault at 0x0000000000000000
ruby 3.1.0dev (2021-11-16T14:01:54Z master 8a816fbe7b) [x86_64-linux]

-- Control frame information -----------------------------------------------
c:0005 p:---- s:0018 e:000017 CFUNC  :alias_method
c:0004 p:0025 s:0012 e:000011 CLASS  ../test.rb:11
c:0003 p:0006 s:0009 e:000008 CLASS  ../test.rb:7
c:0002 p:0040 s:0006 e:000005 EVAL   ../test.rb:6 [FINISH]
c:0001 p:0000 s:0003 E:001d40 (none) [FINISH]

-- Ruby level backtrace information ----------------------------------------
../test.rb:6:in `<main>'
../test.rb:7:in `<class:Time>'
../test.rb:11:in `singleton class'
../test.rb:11:in `alias_method'

-- Machine register context ------------------------------------------------
 RIP: 0x00005591a6d4cb42 RBP: 0x00007ffebe9053e0 RSP: 0x00007ffebe9053d0
 RAX: 0x0000000000000000 RBX: 0x00007f615481e088 RCX: 0x0000000000000010
 RDX: 0x000000000031607a RDI: 0x0000000000000000 RSI: 0x0000000000000001
  R8: 0x000000000000013c  R9: 0x0000000000000001 R10: 0x0000000000000007
 R11: 0x00007f61559edbe0 R12: 0x00007f615481e058 R13: 0x0000000000000000
 R14: 0x00005591a8bf2dc8 R15: 0x00007f615491df10 EFL: 0x0000000000010202

-- C level backtrace information -------------------------------------------
/home/peter/src/ruby/build/ruby(rb_print_backtrace+0x1d) [0x5591a6d684bc] ../vm_dump.c:759
/home/peter/src/ruby/build/ruby(rb_vm_bugreport+0x158) [0x5591a6d689e8] ../vm_dump.c:1045
/home/peter/src/ruby/build/ruby(rb_bug_for_fatal_signal+0x12c) [0x5591a6b38c48] ../error.c:820
/home/peter/src/ruby/build/ruby(sigsegv+0x71) [0x5591a6cb919d] ../signal.c:964
/home/peter/src/ruby/build/ruby(sigill) (null):0
/lib/x86_64-linux-gnu/libpthread.so.0(__restore_rt+0x0) [0x7f6155ba63c0] ../sysdeps/pthread/funlockfile.c:28
/home/peter/src/ruby/build/ruby(vm_cme_invalidate+0x10) [0x5591a6d4cb42] ../vm_method.c:123
/home/peter/src/ruby/build/ruby(clear_method_cache_by_id_in_class+0x1f8) [0x5591a6d4ce05] ../vm_method.c:213
/home/peter/src/ruby/build/ruby(rb_clear_method_cache+0xad) [0x5591a6d4cfa8] ../vm_method.c:268
/home/peter/src/ruby/build/ruby(rb_method_entry_make+0x3fe) [0x5591a6d4e7a9] ../vm_method.c:869
/home/peter/src/ruby/build/ruby(method_entry_set+0x62) [0x5591a6d4ebf6] ../vm_method.c:980
/home/peter/src/ruby/build/ruby(rb_alias+0x2bd) [0x5591a6d50dc4] ../vm_method.c:2036
/home/peter/src/ruby/build/ruby(rb_mod_alias_method+0x69) [0x5591a6d50ea6] ../vm_method.c:2072
/home/peter/src/ruby/build/ruby(ractor_safe_call_cfunc_2+0x46) [0x5591a6d3b037] ../vm_insnhelper.c:2867
/home/peter/src/ruby/build/ruby(vm_call_cfunc_with_frame+0x259) [0x5591a6d3bbf4] ../vm_insnhelper.c:3036
/home/peter/src/ruby/build/ruby(vm_call_cfunc+0xaf) [0x5591a6d3bdb5] ../vm_insnhelper.c:3057
/home/peter/src/ruby/build/ruby(vm_call_method_each_type+0xf1) [0x5591a6d3d976] ../vm_insnhelper.c:3553
/home/peter/src/ruby/build/ruby(vm_call_method+0x9e) [0x5591a6d3e138] ../vm_insnhelper.c:3652
/home/peter/src/ruby/build/ruby(vm_call_general+0x2f) [0x5591a6d3e329] ../vm_insnhelper.c:3695
/home/peter/src/ruby/build/ruby(vm_sendish+0x1ff) [0x5591a6d406f0] ../vm_insnhelper.c:4663
/home/peter/src/ruby/build/ruby(vm_exec_core+0x38bb) [0x5591a6d47396] ../insns.def:777
/home/peter/src/ruby/build/ruby(rb_vm_exec+0x14e) [0x5591a6d5db9e] ../vm.c:2196
/home/peter/src/ruby/build/ruby(rb_iseq_eval_main+0x42) [0x5591a6d5e9a0] ../vm.c:2453
/home/peter/src/ruby/build/ruby(rb_ec_exec_node+0x12a) [0x5591a6b424b5] ../eval.c:280
/home/peter/src/ruby/build/ruby(ruby_run_node+0x79) [0x5591a6b42605] ../eval.c:321
/home/peter/src/ruby/build/ruby(main+0x84) [0x5591a6b3436d] ../main.c:47
```