### PR TITLE
Add a test for bug 18343

### DIFF
--- a/test/ruby/test_pack.rb
+++ b/test/ruby/test_pack.rb
@@ -638,6 +638,14 @@ EXPECTED
     end;
   end
 
+  def test_bug_18343
+    bug18343 = '[ruby-core:106096] [Bug #18343]'
+    assert_separately(%W[- #{bug18343}], <<-'end;')
+      bug = ARGV.shift
+      assert_raise(ArgumentError, bug){[0].pack('c', {})}
+    end;
+  end
+
   def test_pack_unpack_m0
     assert_equal("", [""].pack("m0"))
     assert_equal("AA==", ["\0"].pack("m0"))


### PR DESCRIPTION
This already passes in master, 3.0, and 2.7, but would fail in
ruby 2.6 as it segfaults instead of raising an exception. I think
it's good to have a test for this to catch possible future
regressions.