### PR TITLE
Use the updated test of rbs

### DIFF
--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -11,6 +11,6 @@ net-pop 0.1.1 https://github.com/ruby/net-pop
 net-smtp 0.3.0 https://github.com/ruby/net-smtp
 matrix 0.4.2 https://github.com/ruby/matrix
 prime 0.1.2 https://github.com/ruby/prime
-rbs 1.7.0 https://github.com/ruby/rbs
+rbs 1.7.0 https://github.com/ruby/rbs 39a2351936cd4b6a37f76d7f532c3c3c5a7431b6
 typeprof 0.20.3 https://github.com/ruby/typeprof
 debug 1.3.4 https://github.com/ruby/debug


### PR DESCRIPTION
To prevent the CI failure due to the change of io-wait
https://github.com/ruby/rbs/pull/828/