### PR TITLE
Improve performance Kernel#Float with using Primitive.mandatory_only? method

### DIFF
--- a/kernel.rb
+++ b/kernel.rb
@@ -169,6 +169,10 @@ module Kernel
   #     Float("123.0_badstring", exception: false)  #=> nil
   #
   def Float(arg, exception: true)
-    Primitive.rb_f_float(arg, exception)
+    if Primitive.mandatory_only?
+      Primitive.rb_f_float1(arg)
+    else
+      Primitive.rb_f_float(arg, exception)
+    end
   end
 end

--- a/object.c
+++ b/object.c
@@ -3532,6 +3532,12 @@ rb_Float(VALUE val)
 }
 
 static VALUE
+rb_f_float1(rb_execution_context_t *ec, VALUE obj, VALUE arg)
+{
+    return rb_convert_to_float(arg, TRUE);
+}
+
+static VALUE
 rb_f_float(rb_execution_context_t *ec, VALUE obj, VALUE arg, VALUE opts)
 {
     int exception = rb_bool_expected(opts, "exception");


### PR DESCRIPTION
Recently, introduce `Primitive.mandatory_only?` method(to improve performance Time.at methods).
And, I tried to if can improve `Kernel#Float` method perfomance  with using `Primitive.mandatory_only?` method.

benchmark:
```yml
benchmark:
  float: "Float(42)"
  float_true: "Float(42, exception: true)"
  float_false: "Float(42, exception: false)"
loop_count: 10000

```

result:
```
sh@DESKTOP-L0NI312:~/rubydev/build$ make benchmark/kernel_float.yml -e COMPARE_RUBY=~/.rbenv/shims/ruby -e BENCH_RUBY=../install/bin/ruby -e BENCH_OPTS=--repeat-count=4
generating vm_call_iseq_optimized.inc
vm_call_iseq_optimized.inc unchanged
Calculating -------------------------------------
                     compare-ruby  built-ruby
               float      41.000M     47.416M i/s -     10.000k times in 0.000244s 0.000211s
          float_true      10.875M     21.317M i/s -     10.000k times in 0.000920s 0.000469s
         float_false      13.910M     22.847M i/s -     10.000k times in 0.000719s 0.000438s

Comparison:
                            float
          built-ruby:  47415837.0 i/s
        compare-ruby:  41000410.0 i/s - 1.16x  slower

                       float_true
          built-ruby:  21317416.4 i/s
        compare-ruby:  10875475.8 i/s - 1.96x  slower

                      float_false
          built-ruby:  22846698.6 i/s
        compare-ruby:  13910140.5 i/s - 1.64x  slower
```

`COMPARE_RUBY` is `ruby 3.1.0dev (2021-11-17T13:21:42Z master b95d7d2099) [x86_64-linux]`. BENCH_RUBY is ahead of `ruby 3.1.0dev (2021-11-17T13:21:42Z master b95d7d2099) [x86_64-linux]`.

ref: [Improve performance Kernel#Float with using Primitive.mandatory_only? method Feature #18344](https://bugs.ruby-lang.org/issues/18344)