### PR TITLE
Refactor hacky ID tables to struct rb_ast_id_table_t

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -600,11 +600,11 @@ node_children(rb_ast_t *ast, const NODE *node)
         }
       case NODE_SCOPE:
         {
-            ID *tbl = node->nd_tbl;
-            int i, size = tbl ? (int)*tbl++ : 0;
+            rb_ast_id_table_t *tbl = node->nd_tbl;
+            int i, size = tbl ? tbl->size : 0;
             VALUE locals = rb_ary_new_capa(size);
             for (i = 0; i < size; i++) {
-                rb_ary_push(locals, var_name(tbl[i]));
+                rb_ary_push(locals, var_name(tbl->ids[i]));
             }
             return rb_ary_new_from_args(3, locals, NEW_CHILD(ast, node->nd_args), NEW_CHILD(ast, node->nd_body));
         }

--- a/common.mk
+++ b/common.mk
@@ -7937,6 +7937,7 @@ localeinit.$(OBJEXT): {$(VPATH)}st.h
 localeinit.$(OBJEXT): {$(VPATH)}subst.h
 main.$(OBJEXT): $(hdrdir)/ruby.h
 main.$(OBJEXT): $(hdrdir)/ruby/ruby.h
+main.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 main.$(OBJEXT): {$(VPATH)}assert.h
 main.$(OBJEXT): {$(VPATH)}backward.h
 main.$(OBJEXT): {$(VPATH)}backward/2/assume.h
@@ -8463,6 +8464,7 @@ math.$(OBJEXT): {$(VPATH)}missing.h
 math.$(OBJEXT): {$(VPATH)}st.h
 math.$(OBJEXT): {$(VPATH)}subst.h
 memory_view.$(OBJEXT): $(hdrdir)/ruby/ruby.h
+memory_view.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 memory_view.$(OBJEXT): $(top_srcdir)/internal/hash.h
 memory_view.$(OBJEXT): $(top_srcdir)/internal/variable.h
 memory_view.$(OBJEXT): {$(VPATH)}assert.h

--- a/node.c
+++ b/node.c
@@ -1043,12 +1043,12 @@ dump_node(VALUE buf, VALUE indent, int comment, const NODE * node)
 	ANN("new scope");
 	ANN("format: [nd_tbl]: local table, [nd_args]: arguments, [nd_body]: body");
 	F_CUSTOM1(nd_tbl, "local table") {
-	    ID *tbl = node->nd_tbl;
+	    rb_ast_id_table_t *tbl = node->nd_tbl;
 	    int i;
-	    int size = tbl ? (int)*tbl++ : 0;
+	    int size = tbl ? tbl->size : 0;
 	    if (size == 0) A("(empty)");
 	    for (i = 0; i < size; i++) {
-		A_ID(tbl[i]); if (i < size - 1) A(",");
+		A_ID(tbl->ids[i]); if (i < size - 1) A(",");
 	    }
 	}
 	F_NODE(nd_args, "arguments");
@@ -1162,7 +1162,7 @@ typedef struct {
 struct node_buffer_struct {
     node_buffer_list_t unmarkable;
     node_buffer_list_t markable;
-    ID *local_tables;
+    struct rb_ast_local_table_link *local_tables;
     VALUE mark_hash;
 };
 
@@ -1205,15 +1205,22 @@ node_buffer_list_free(node_buffer_list_t * nb)
     }
 }
 
+struct rb_ast_local_table_link {
+    struct rb_ast_local_table_link *next;
+    // struct rb_ast_id_table {
+    int size;
+    ID ids[FLEX_ARY_LEN];
+    // }
+};
+
 static void
 rb_node_buffer_free(node_buffer_t *nb)
 {
     node_buffer_list_free(&nb->unmarkable);
     node_buffer_list_free(&nb->markable);
-    ID * local_table = nb->local_tables;
+    struct rb_ast_local_table_link *local_table = nb->local_tables;
     while (local_table) {
-        unsigned int size = (unsigned int)*local_table;
-        ID * next_table = (ID *)local_table[size + 1];
+        struct rb_ast_local_table_link *next_table = local_table->next;
         xfree(local_table);
         local_table = next_table;
     }
@@ -1277,12 +1284,28 @@ rb_ast_node_type_change(NODE *n, enum node_type type)
     }
 }
 
-void
-rb_ast_add_local_table(rb_ast_t *ast, ID *buf)
+rb_ast_id_table_t *
+rb_ast_new_local_table(rb_ast_t *ast, int size)
 {
-    unsigned int size = (unsigned int)*buf;
-    buf[size + 1] = (ID)ast->node_buffer->local_tables;
-    ast->node_buffer->local_tables = buf;
+    size_t alloc_size = sizeof(struct rb_ast_local_table_link) + size * sizeof(ID);
+    struct rb_ast_local_table_link *link = ruby_xmalloc(alloc_size);
+    link->next = ast->node_buffer->local_tables;
+    ast->node_buffer->local_tables = link;
+    link->size = size;
+
+    return (rb_ast_id_table_t *) &link->size;
+}
+
+rb_ast_id_table_t *
+rb_ast_resize_latest_local_table(rb_ast_t *ast, int size)
+{
+    struct rb_ast_local_table_link *link = ast->node_buffer->local_tables;
+    size_t alloc_size = sizeof(struct rb_ast_local_table_link) + size * sizeof(ID);
+    link = ruby_xrealloc(link, alloc_size);
+    ast->node_buffer->local_tables = link;
+    link->size = size;
+
+    return (rb_ast_id_table_t *) &link->size;
 }
 
 void

--- a/node.h
+++ b/node.h
@@ -11,6 +11,8 @@
 
 **********************************************************************/
 
+#include "internal/compilers.h"
+
 #if defined(__cplusplus)
 extern "C" {
 #if 0
@@ -146,13 +148,18 @@ code_loc_gen(const rb_code_location_t *loc1, const rb_code_location_t *loc2)
     return loc;
 }
 
+typedef struct rb_ast_id_table {
+    int size;
+    ID ids[FLEX_ARY_LEN];
+} rb_ast_id_table_t;
+
 typedef struct RNode {
     VALUE flags;
     union {
 	struct RNode *node;
 	ID id;
 	VALUE value;
-	ID *tbl;
+	rb_ast_id_table_t *tbl;
     } u1;
     union {
 	struct RNode *node;
@@ -411,13 +418,14 @@ typedef struct rb_ast_struct {
 rb_ast_t *rb_ast_new(void);
 void rb_ast_mark(rb_ast_t*);
 void rb_ast_update_references(rb_ast_t*);
-void rb_ast_add_local_table(rb_ast_t*, ID *buf);
 void rb_ast_dispose(rb_ast_t*);
 void rb_ast_free(rb_ast_t*);
 size_t rb_ast_memsize(const rb_ast_t*);
 void rb_ast_add_mark_object(rb_ast_t*, VALUE);
 NODE *rb_ast_newnode(rb_ast_t*, enum node_type type);
 void rb_ast_delete_node(rb_ast_t*, NODE *n);
+rb_ast_id_table_t *rb_ast_new_local_table(rb_ast_t*, int);
+rb_ast_id_table_t *rb_ast_resize_latest_local_table(rb_ast_t*, int);
 
 VALUE rb_parser_new(void);
 VALUE rb_parser_end_seen_p(VALUE);

--- a/vm.c
+++ b/vm.c
@@ -1256,18 +1256,17 @@ rb_binding_add_dynavars(VALUE bindval, rb_binding_t *bind, int dyncount, const I
     const rb_iseq_t *base_iseq, *iseq;
     rb_ast_body_t ast;
     NODE tmp_node;
-    ID minibuf[4], *dyns = minibuf;
-    VALUE idtmp = 0;
 
     if (dyncount < 0) return 0;
 
     base_block = &bind->block;
     base_iseq = vm_block_iseq(base_block);
 
-    if (dyncount >= numberof(minibuf)) dyns = ALLOCV_N(ID, idtmp, dyncount + 1);
+    VALUE idtmp = 0;
+    rb_ast_id_table_t *dyns = ALLOCV(idtmp, sizeof(rb_ast_id_table_t) + dyncount * sizeof(ID));
+    dyns->size = dyncount;
+    MEMCPY(dyns->ids, dynvars, ID, dyncount);
 
-    dyns[0] = dyncount;
-    MEMCPY(dyns + 1, dynvars, ID, dyncount);
     rb_node_init(&tmp_node, NODE_SCOPE, (VALUE)dyns, 0, 0);
     ast.root = &tmp_node;
     ast.compile_option = 0;


### PR DESCRIPTION
The implementation of a local variable tables was represented as `ID*`,
but it was very hacky: the first element is not an ID but the size of
the table, and, the last element is (sometimes) a link to the next local
table only when the id tables are a linked list.

This change converts the hacky implementation to a normal struct.