### PR TITLE
Refactor getclassvariable

### DIFF
--- a/insns.def
+++ b/insns.def
@@ -236,9 +236,8 @@ getclassvariable
 /* "class variable access from toplevel" warning can be hooked. */
 // attr bool leaf = false; /* has rb_warning() */
 {
-    rb_cref_t * cref = vm_get_cref(GET_EP());
     rb_control_frame_t *cfp = GET_CFP();
-    val = vm_getclassvariable(GET_ISEQ(), cref, cfp, id, (ICVARC)ic);
+    val = vm_getclassvariable(GET_ISEQ(), cfp, id, (ICVARC)ic);
 }
 
 /* Set value of class variable id of klass as val. */

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1321,8 +1321,10 @@ update_classvariable_cache(const rb_iseq_t *iseq, VALUE klass, ID id, ICVARC ic)
 }
 
 static inline VALUE
-vm_getclassvariable(const rb_iseq_t *iseq, const rb_cref_t *cref, const rb_control_frame_t *cfp, ID id, ICVARC ic)
+vm_getclassvariable(const rb_iseq_t *iseq, const rb_control_frame_t *reg_cfp, ID id, ICVARC ic)
 {
+    const rb_cref_t *cref;
+
     if (ic->entry && ic->entry->global_cvar_state == GET_GLOBAL_CVAR_STATE()) {
         VALUE v = Qundef;
         RB_DEBUG_COUNTER_INC(cvar_read_inline_hit);
@@ -1332,15 +1334,16 @@ vm_getclassvariable(const rb_iseq_t *iseq, const rb_cref_t *cref, const rb_contr
         }
     }
 
-    VALUE klass = vm_get_cvar_base(cref, cfp, 1);
+    cref = vm_get_cref(GET_EP());
+    VALUE klass = vm_get_cvar_base(cref, reg_cfp, 1);
 
     return update_classvariable_cache(iseq, klass, id, ic);
 }
 
 VALUE
-rb_vm_getclassvariable(const rb_iseq_t *iseq, const rb_cref_t *cref, const rb_control_frame_t *cfp, ID id, ICVARC ic)
+rb_vm_getclassvariable(const rb_iseq_t *iseq, const rb_control_frame_t *cfp, ID id, ICVARC ic)
 {
-    return vm_getclassvariable(iseq, cref, cfp, id, ic);
+    return vm_getclassvariable(iseq, cfp, id, ic);
 }
 
 static inline void

--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -4432,14 +4432,10 @@ gen_getclassvariable(jitstate_t* jit, ctx_t* ctx, codeblock_t* cb)
     // rb_vm_getclassvariable can raise exceptions.
     jit_prepare_routine_call(jit, ctx, REG0);
 
-    mov(cb, C_ARG_REGS[0], member_opnd(REG_CFP, rb_control_frame_t, ep));
-    call_ptr(cb, REG0, (void *)rb_vm_get_cref);
-
     mov(cb, C_ARG_REGS[0], member_opnd(REG_CFP, rb_control_frame_t, iseq));
-    mov(cb, C_ARG_REGS[1], RAX);
-    mov(cb, C_ARG_REGS[2], REG_CFP);
-    mov(cb, C_ARG_REGS[3], imm_opnd(jit_get_arg(jit, 0)));
-    mov(cb, C_ARG_REGS[4], imm_opnd(jit_get_arg(jit, 1)));
+    mov(cb, C_ARG_REGS[1], REG_CFP);
+    mov(cb, C_ARG_REGS[2], imm_opnd(jit_get_arg(jit, 0)));
+    mov(cb, C_ARG_REGS[3], imm_opnd(jit_get_arg(jit, 1)));
 
     call_ptr(cb, REG0, (void *)rb_vm_getclassvariable);
 

--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -4421,10 +4421,7 @@ gen_getspecial(jitstate_t *jit, ctx_t *ctx, codeblock_t *cb)
 }
 
 VALUE
-rb_vm_getclassvariable(const rb_iseq_t *iseq, const rb_cref_t *cref, const rb_control_frame_t *cfp, ID id, ICVARC ic);
-
-rb_cref_t *
-rb_vm_get_cref(const VALUE *ep);
+rb_vm_getclassvariable(const rb_iseq_t *iseq, const rb_control_frame_t *cfp, ID id, ICVARC ic);
 
 static codegen_status_t
 gen_getclassvariable(jitstate_t* jit, ctx_t* ctx, codeblock_t* cb)


### PR DESCRIPTION
We only need the cref when we have a cache miss so don't look it up until we
need it. This speeds up class variable reads in the interpreter but
also simplifies the jit code.

Benchmarks for master vs this branch (without yjit):

Before:

```
Warming up --------------------------------------
         read a cvar     1.276M i/100ms
Calculating -------------------------------------
         read a cvar     12.596M (± 1.7%) i/s -     63.781M in   5.064902s
```

After:

```
Warming up --------------------------------------
         read a cvar     1.336M i/100ms
Calculating -------------------------------------
         read a cvar     13.114M (± 3.6%) i/s -     65.488M in   5.000584s
```

Co-authored-by: Aaron Patterson <tenderlove@ruby-lang.org>

cc/ @tenderlove