### PR TITLE
Restrict Dir.glob sort kwarg value to boolean only

### DIFF
--- a/dir.c
+++ b/dir.c
@@ -2937,7 +2937,15 @@ dir_glob_option_base(VALUE base)
 static int
 dir_glob_option_sort(VALUE sort)
 {
-    return (sort ? 0 : FNM_GLOB_NOSORT);
+    switch (sort) {
+      case Qtrue: case Qfalse:
+        break;
+      default:
+        rb_raise(rb_eArgError, "true or false is expected as sort: %+"PRIsVALUE,
+                 sort);
+    }
+
+    return sort != Qfalse ? 0 : FNM_GLOB_NOSORT;
 }
 
 static VALUE

--- a/test/ruby/test_dir.rb
+++ b/test/ruby/test_dir.rb
@@ -176,6 +176,9 @@ class TestDir < Test::Unit::TestCase
     assert_raise_with_message(ArgumentError, /nul-separated/) do
       Dir.glob(@root + "\0\0\0" + File.join(@root, "*"))
     end
+    assert_raise_with_message(ArgumentError, /true or false is expected as sort: nil/) do
+      Dir.glob(File.join(@root, "*"), sort: nil)
+    end
 
     assert_equal(("a".."z").step(2).map {|f| File.join(File.join(@root, f), "") },
                  Dir.glob(File.join(@root, "*/")))


### PR DESCRIPTION
Right now `Dir.glob("*", sort: nil)` will produce the same result as `Dir.glob("*", sort: true)`.

```
irb(main):001:0> Dir.glob("brace/a{.js,*}", sort: true)
=> ["brace/a.js", "brace/a", "brace/a.erb", "brace/a.html.erb", "brace/a.js", "brace/a.js.rjs"]

irb(main):002:0> Dir.glob("brace/a{.js,*}", sort: false)
=> ["brace/a.js", "brace/a.js", "brace/a.html.erb", "brace/a.erb", "brace/a.js.rjs", "brace/a"]

irb(main):003:0> Dir.glob("brace/a{.js,*}", sort: nil)
=> ["brace/a.js", "brace/a", "brace/a.erb", "brace/a.html.erb", "brace/a.js", "brace/a.js.rjs"]
```

After this patch `Dir.glob("*", sort: nil)` will raise `true or false is expected as exception: nil (ArgumentError)` and only `true` or `false` will be possible as a value for `sort` kwarg.

Discussion: [Bugs#18287](https://bugs.ruby-lang.org/issues/18287)
Specs: https://github.com/ruby/spec/pull/899