### PR TITLE
Refactor setclassvariable

### DIFF
--- a/insns.def
+++ b/insns.def
@@ -250,7 +250,7 @@ setclassvariable
 // attr bool leaf = false; /* has rb_warning() */
 {
     vm_ensure_not_refinement_module(GET_SELF());
-    vm_setclassvariable(GET_ISEQ(), vm_get_cref(GET_EP()), GET_CFP(), id,  val, (ICVARC)ic);
+    vm_setclassvariable(GET_ISEQ(), GET_CFP(), id,  val, (ICVARC)ic);
 }
 
 /* Get constant variable id. If klass is Qnil and allow_nil is Qtrue, constants

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1347,8 +1347,10 @@ rb_vm_getclassvariable(const rb_iseq_t *iseq, const rb_control_frame_t *cfp, ID 
 }
 
 static inline void
-vm_setclassvariable(const rb_iseq_t *iseq, const rb_cref_t *cref, const rb_control_frame_t *cfp, ID id, VALUE val, ICVARC ic)
+vm_setclassvariable(const rb_iseq_t *iseq, const rb_control_frame_t *reg_cfp, ID id, VALUE val, ICVARC ic)
 {
+    const rb_cref_t *cref;
+
     if (ic->entry && ic->entry->global_cvar_state == GET_GLOBAL_CVAR_STATE()) {
         RB_DEBUG_COUNTER_INC(cvar_write_inline_hit);
 
@@ -1356,7 +1358,8 @@ vm_setclassvariable(const rb_iseq_t *iseq, const rb_cref_t *cref, const rb_contr
         return;
     }
 
-    VALUE klass = vm_get_cvar_base(cref, cfp, 1);
+    cref = vm_get_cref(GET_EP());
+    VALUE klass = vm_get_cvar_base(cref, reg_cfp, 1);
 
     rb_cvar_set(klass, id, val);
 


### PR DESCRIPTION
We only need the cref when we have a cache miss so don't look it up until we
need it. This likely speeds up class variable writes in the interpreter but
also simplifies the jit code.

Before

```
Warming up --------------------------------------
        write a cvar   192.280k i/100ms
Calculating -------------------------------------
        write a cvar      1.915M (± 3.5%) i/s -      9.614M in   5.026694s
```

After

```
Warming up --------------------------------------
        write a cvar   216.308k i/100ms
Calculating -------------------------------------
        write a cvar      2.140M (± 3.1%) i/s -     10.815M in   5.058079s
```

Followup to ruby/ruby#5137

cc/ @tenderlove 