### PR TITLE
Lazily create singletons on instance_{exec,eval}

### DIFF
--- a/bootstraptest/test_eval.rb
+++ b/bootstraptest/test_eval.rb
@@ -116,6 +116,22 @@ assert_equal %q{1}, %q{
     Const
   }
 }
+assert_equal %q{1}, %q{
+  class TrueClass
+    Const = 1
+  end
+  true.instance_eval %{
+    Const
+  }
+}
+assert_equal %q{[:Const]}, %q{
+  mod = Module.new
+  mod.instance_eval %{
+    Const = 1
+  }
+  raise if defined?(Module::Const)
+  mod.singleton_class.constants
+}
 assert_equal %q{top}, %q{
   Const = :top
   class C

--- a/bootstraptest/test_eval.rb
+++ b/bootstraptest/test_eval.rb
@@ -132,6 +132,17 @@ assert_equal %q{[:Const]}, %q{
   raise if defined?(Module::Const)
   mod.singleton_class.constants
 }
+assert_equal %q{can't define singleton}, %q{
+  begin
+    123.instance_eval %{
+      Const = 1
+    }
+    "bad"
+  rescue TypeError => e
+    raise "bad" if defined?(Integer::Const)
+    e.message
+  end
+}
 assert_equal %q{top}, %q{
   Const = :top
   class C

--- a/eval_intern.h
+++ b/eval_intern.h
@@ -173,11 +173,28 @@ rb_ec_tag_jump(const rb_execution_context_t *ec, enum ruby_tag_type st)
 
 #define CREF_FL_PUSHED_BY_EVAL IMEMO_FL_USER1
 #define CREF_FL_OMOD_SHARED    IMEMO_FL_USER2
+#define CREF_FL_SINGLETON      IMEMO_FL_USER3
+
+static inline int CREF_SINGLETON(const rb_cref_t *cref);
 
 static inline VALUE
 CREF_CLASS(const rb_cref_t *cref)
 {
-    return cref->klass;
+    if (CREF_SINGLETON(cref)) {
+        return CLASS_OF(cref->klass_or_self);
+    } else {
+        return cref->klass_or_self;
+    }
+}
+
+static inline VALUE
+CREF_CLASS_FOR_DEFINITION(const rb_cref_t *cref)
+{
+    if (CREF_SINGLETON(cref)) {
+        return rb_singleton_class(cref->klass_or_self);
+    } else {
+        return cref->klass_or_self;
+    }
 }
 
 static inline rb_cref_t *
@@ -214,6 +231,18 @@ static inline void
 CREF_PUSHED_BY_EVAL_SET(rb_cref_t *cref)
 {
     cref->flags |= CREF_FL_PUSHED_BY_EVAL;
+}
+
+static inline int
+CREF_SINGLETON(const rb_cref_t *cref)
+{
+    return cref->flags & CREF_FL_SINGLETON;
+}
+
+static inline void
+CREF_SINGLETON_SET(rb_cref_t *cref)
+{
+    cref->flags |= CREF_FL_SINGLETON;
 }
 
 static inline int

--- a/gc.c
+++ b/gc.c
@@ -6869,7 +6869,7 @@ gc_mark_imemo(rb_objspace_t *objspace, VALUE obj)
 	}
 	return;
       case imemo_cref:
-	gc_mark(objspace, RANY(obj)->as.imemo.cref.klass);
+	gc_mark(objspace, RANY(obj)->as.imemo.cref.klass_or_self);
 	gc_mark(objspace, (VALUE)RANY(obj)->as.imemo.cref.next);
 	gc_mark(objspace, RANY(obj)->as.imemo.cref.refinements);
 	return;
@@ -9734,7 +9734,7 @@ gc_ref_update_imemo(rb_objspace_t *objspace, VALUE obj)
         }
         break;
       case imemo_cref:
-        UPDATE_IF_MOVED(objspace, RANY(obj)->as.imemo.cref.klass);
+        UPDATE_IF_MOVED(objspace, RANY(obj)->as.imemo.cref.klass_or_self);
         TYPED_UPDATE_IF_MOVED(objspace, struct rb_cref_struct *, RANY(obj)->as.imemo.cref.next);
         UPDATE_IF_MOVED(objspace, RANY(obj)->as.imemo.cref.refinements);
         break;

--- a/insns.def
+++ b/insns.def
@@ -716,7 +716,7 @@ defineclass
     /* enter scope */
     vm_push_frame(ec, class_iseq, VM_FRAME_MAGIC_CLASS | VM_ENV_FLAG_LOCAL, klass,
 		  GET_BLOCK_HANDLER(),
-		  (VALUE)vm_cref_push(ec, klass, NULL, FALSE),
+		  (VALUE)vm_cref_push(ec, klass, NULL, FALSE, FALSE),
 		  class_iseq->body->iseq_encoded, GET_SP(),
 		  class_iseq->body->local_table_size,
 		  class_iseq->body->stack_max);

--- a/insns.def
+++ b/insns.def
@@ -350,6 +350,7 @@ putspecialobject
 (rb_num_t value_type)
 ()
 (VALUE val)
+// attr bool leaf = (value_type != VM_SPECIAL_OBJECT_CBASE); /* get cbase may allocate a singleton */
 {
     enum vm_special_object_type type;
 

--- a/insns.def
+++ b/insns.def
@@ -350,7 +350,7 @@ putspecialobject
 (rb_num_t value_type)
 ()
 (VALUE val)
-// attr bool leaf = (value_type != VM_SPECIAL_OBJECT_CBASE); /* get cbase may allocate a singleton */
+// attr bool leaf = (value_type == VM_SPECIAL_OBJECT_VMCORE); /* others may raise when allocating singleton */
 {
     enum vm_special_object_type type;
 

--- a/method.h
+++ b/method.h
@@ -44,7 +44,7 @@ typedef struct rb_scope_visi_struct {
 typedef struct rb_cref_struct {
     VALUE flags;
     VALUE refinements;
-    VALUE klass;
+    VALUE klass_or_self;
     struct rb_cref_struct * next;
     const rb_scope_visibility_t scope_visi;
 } rb_cref_t;

--- a/test/ruby/test_undef.rb
+++ b/test/ruby/test_undef.rb
@@ -35,4 +35,20 @@ class TestUndef < Test::Unit::TestCase
       end
     end
   end
+
+  def test_singleton_undef
+    klass = Class.new do
+      def foo
+        :ok
+      end
+    end
+
+    klass.new.foo
+
+    klass.new.instance_eval do
+      undef foo
+    end
+
+    klass.new.foo
+  end
 end

--- a/vm.c
+++ b/vm.c
@@ -223,7 +223,7 @@ vm_passed_block_handler(rb_execution_context_t *ec)
 }
 
 static rb_cref_t *
-vm_cref_new0(VALUE klass, rb_method_visibility_t visi, int module_func, rb_cref_t *prev_cref, int pushed_by_eval, int use_prev_prev)
+vm_cref_new0(VALUE klass, rb_method_visibility_t visi, int module_func, rb_cref_t *prev_cref, int pushed_by_eval, int use_prev_prev, int singleton)
 {
     VALUE refinements = Qnil;
     int omod_shared = FALSE;
@@ -248,26 +248,27 @@ vm_cref_new0(VALUE klass, rb_method_visibility_t visi, int module_func, rb_cref_
 	}
     }
 
-    VM_ASSERT(klass);
+    VM_ASSERT(singleton || klass);
 
     cref = (rb_cref_t *)rb_imemo_new(imemo_cref, klass, (VALUE)(use_prev_prev ? CREF_NEXT(prev_cref) : prev_cref), scope_visi.value, refinements);
 
     if (pushed_by_eval) CREF_PUSHED_BY_EVAL_SET(cref);
     if (omod_shared) CREF_OMOD_SHARED_SET(cref);
+    if (singleton) CREF_SINGLETON_SET(cref);
 
     return cref;
 }
 
 static rb_cref_t *
-vm_cref_new(VALUE klass, rb_method_visibility_t visi, int module_func, rb_cref_t *prev_cref, int pushed_by_eval)
+vm_cref_new(VALUE klass, rb_method_visibility_t visi, int module_func, rb_cref_t *prev_cref, int pushed_by_eval, int singleton)
 {
-    return vm_cref_new0(klass, visi, module_func, prev_cref, pushed_by_eval, FALSE);
+    return vm_cref_new0(klass, visi, module_func, prev_cref, pushed_by_eval, FALSE, singleton);
 }
 
 static rb_cref_t *
 vm_cref_new_use_prev(VALUE klass, rb_method_visibility_t visi, int module_func, rb_cref_t *prev_cref, int pushed_by_eval)
 {
-    return vm_cref_new0(klass, visi, module_func, prev_cref, pushed_by_eval, TRUE);
+    return vm_cref_new0(klass, visi, module_func, prev_cref, pushed_by_eval, TRUE, FALSE);
 }
 
 static int
@@ -282,18 +283,15 @@ vm_cref_dup(const rb_cref_t *cref)
     const rb_scope_visibility_t *visi = CREF_SCOPE_VISI(cref);
     rb_cref_t *next_cref = CREF_NEXT(cref), *new_cref;
     int pushed_by_eval = CREF_PUSHED_BY_EVAL(cref);
+    int singleton = CREF_SINGLETON(cref);
 
-    new_cref = vm_cref_new(cref->klass_or_self, visi->method_visi, visi->module_func, next_cref, pushed_by_eval);
+    new_cref = vm_cref_new(cref->klass_or_self, visi->method_visi, visi->module_func, next_cref, pushed_by_eval, singleton);
 
     if (!NIL_P(CREF_REFINEMENTS(cref))) {
         VALUE ref = rb_hash_dup(CREF_REFINEMENTS(cref));
         rb_hash_foreach(ref, ref_delete_symkey, Qnil);
         CREF_REFINEMENTS_SET(new_cref, ref);
         CREF_OMOD_SHARED_UNSET(new_cref);
-    }
-
-    if (CREF_SINGLETON(cref)) {
-        CREF_SINGLETON_SET(new_cref);
     }
 
     return new_cref;
@@ -303,12 +301,12 @@ vm_cref_dup(const rb_cref_t *cref)
 rb_cref_t *
 rb_vm_cref_dup_without_refinements(const rb_cref_t *cref)
 {
-    VALUE klass = CREF_CLASS(cref);
     const rb_scope_visibility_t *visi = CREF_SCOPE_VISI(cref);
     rb_cref_t *next_cref = CREF_NEXT(cref), *new_cref;
     int pushed_by_eval = CREF_PUSHED_BY_EVAL(cref);
+    int singleton = CREF_SINGLETON(cref);
 
-    new_cref = vm_cref_new(klass, visi->method_visi, visi->module_func, next_cref, pushed_by_eval);
+    new_cref = vm_cref_new(cref->klass_or_self, visi->method_visi, visi->module_func, next_cref, pushed_by_eval, singleton);
 
     if (!NIL_P(CREF_REFINEMENTS(cref))) {
         CREF_REFINEMENTS_SET(new_cref, Qnil);
@@ -321,11 +319,11 @@ rb_vm_cref_dup_without_refinements(const rb_cref_t *cref)
 static rb_cref_t *
 vm_cref_new_toplevel(rb_execution_context_t *ec)
 {
-    rb_cref_t *cref = vm_cref_new(rb_cObject, METHOD_VISI_PRIVATE /* toplevel visibility is private */, FALSE, NULL, FALSE);
+    rb_cref_t *cref = vm_cref_new(rb_cObject, METHOD_VISI_PRIVATE /* toplevel visibility is private */, FALSE, NULL, FALSE, FALSE);
     VALUE top_wrapper = rb_ec_thread_ptr(ec)->top_wrapper;
 
     if (top_wrapper) {
-	cref = vm_cref_new(top_wrapper, METHOD_VISI_PRIVATE, FALSE, cref, FALSE);
+	cref = vm_cref_new(top_wrapper, METHOD_VISI_PRIVATE, FALSE, cref, FALSE, FALSE);
     }
 
     return cref;
@@ -3757,7 +3755,7 @@ Init_VM(void)
 	th->ec->cfp->self = th->top_self;
 
 	VM_ENV_FLAGS_UNSET(th->ec->cfp->ep, VM_FRAME_FLAG_CFRAME);
-	VM_STACK_ENV_WRITE(th->ec->cfp->ep, VM_ENV_DATA_INDEX_ME_CREF, (VALUE)vm_cref_new(rb_cObject, METHOD_VISI_PRIVATE, FALSE, NULL, FALSE));
+	VM_STACK_ENV_WRITE(th->ec->cfp->ep, VM_ENV_DATA_INDEX_ME_CREF, (VALUE)vm_cref_new(rb_cObject, METHOD_VISI_PRIVATE, FALSE, NULL, FALSE, FALSE));
 
 	/*
 	 * The Binding of the top level scope

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -1959,11 +1959,8 @@ yield_under(VALUE self, int singleton, int argc, const VALUE *argv, int kw_splat
     }
 
     VM_ASSERT(singleton || RB_TYPE_P(self, T_MODULE) || RB_TYPE_P(self, T_CLASS));
-    cref = vm_cref_push(ec, self, ep, TRUE);
+    cref = vm_cref_push(ec, self, ep, TRUE, singleton);
 
-    if (singleton) {
-        CREF_SINGLETON_SET(cref);
-    }
     return vm_yield_with_cref(ec, argc, argv, kw_splat, cref, is_lambda);
 }
 
@@ -1981,7 +1978,7 @@ rb_yield_refine_block(VALUE refinement, VALUE refinements)
 	struct rb_captured_block new_captured = *captured;
 	VALUE new_block_handler = VM_BH_FROM_ISEQ_BLOCK(&new_captured);
 	const VALUE *ep = captured->ep;
-	rb_cref_t *cref = vm_cref_push(ec, refinement, ep, TRUE);
+	rb_cref_t *cref = vm_cref_push(ec, refinement, ep, TRUE, FALSE);
 	CREF_REFINEMENTS_SET(cref, refinements);
 	VM_FORCE_WRITE_SPECIAL_CONST(&VM_CF_LEP(ec->cfp)[VM_ENV_DATA_INDEX_SPECVAL], new_block_handler);
 	new_captured.self = refinement;
@@ -1993,10 +1990,7 @@ rb_yield_refine_block(VALUE refinement, VALUE refinements)
 static VALUE
 eval_under(VALUE self, int singleton, VALUE src, VALUE file, int line)
 {
-    rb_cref_t *cref = vm_cref_push(GET_EC(), self, NULL, FALSE);
-    if (singleton) {
-        CREF_SINGLETON_SET(cref);
-    }
+    rb_cref_t *cref = vm_cref_push(GET_EC(), self, NULL, FALSE, singleton);
     SafeStringValue(src);
 
     return eval_string_with_cref(self, src, cref, file, line);

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -1855,7 +1855,7 @@ eval_string_wrap_protect(VALUE data)
 {
     const struct eval_string_wrap_arg *const arg = (struct eval_string_wrap_arg*)data;
     rb_cref_t *cref = rb_vm_cref_new_toplevel();
-    cref->klass = arg->klass;
+    cref->klass_or_self = arg->klass;
     return eval_string_with_cref(arg->top_self, rb_str_new_cstr(arg->str), cref, rb_str_new_cstr("eval"), 1);
 }
 
@@ -1917,7 +1917,7 @@ rb_eval_cmd_kw(VALUE cmd, VALUE arg, int kw_splat)
 /* block eval under the class/module context */
 
 static VALUE
-yield_under(VALUE under, VALUE self, int argc, const VALUE *argv, int kw_splat)
+yield_under(VALUE under, int singleton, VALUE self, int argc, const VALUE *argv, int kw_splat)
 {
     rb_execution_context_t *ec = GET_EC();
     rb_control_frame_t *cfp = ec->cfp;
@@ -1958,7 +1958,14 @@ yield_under(VALUE under, VALUE self, int argc, const VALUE *argv, int kw_splat)
 	VM_FORCE_WRITE_SPECIAL_CONST(&VM_CF_LEP(ec->cfp)[VM_ENV_DATA_INDEX_SPECVAL], new_block_handler);
     }
 
+    //rb_obj_info_dump(under);
+    // Make crefs log that this is a special lazy singleton?
+
     cref = vm_cref_push(ec, under, ep, TRUE);
+    if (singleton) {
+        cref->klass_or_self = self;
+        CREF_SINGLETON_SET(cref);
+    }
     return vm_yield_with_cref(ec, argc, argv, kw_splat, cref, is_lambda);
 }
 
@@ -1986,19 +1993,24 @@ rb_yield_refine_block(VALUE refinement, VALUE refinements)
 
 /* string eval under the class/module context */
 static VALUE
-eval_under(VALUE under, VALUE self, VALUE src, VALUE file, int line)
+eval_under(VALUE under, int singleton, VALUE self, VALUE src, VALUE file, int line)
 {
-    rb_cref_t *cref = vm_cref_push(GET_EC(), under, NULL, SPECIAL_CONST_P(self) && !NIL_P(under));
+    rb_cref_t *cref = vm_cref_push(GET_EC(), under, NULL, FALSE);
+    if (singleton) {
+        cref->klass_or_self = self;
+        CREF_SINGLETON_SET(cref);
+    }
     SafeStringValue(src);
+
     return eval_string_with_cref(self, src, cref, file, line);
 }
 
 static VALUE
-specific_eval(int argc, const VALUE *argv, VALUE klass, VALUE self, int kw_splat)
+specific_eval(int argc, const VALUE *argv, VALUE klass, VALUE self, int singleton, int kw_splat)
 {
     if (rb_block_given_p()) {
 	rb_check_arity(argc, 0, 0);
-        return yield_under(klass, self, 1, &self, kw_splat);
+        return yield_under(klass, singleton, self, 1, &self, kw_splat);
     }
     else {
 	VALUE file = Qundef;
@@ -2014,23 +2026,7 @@ specific_eval(int argc, const VALUE *argv, VALUE klass, VALUE self, int kw_splat
 	    file = argv[1];
 	    if (!NIL_P(file)) StringValue(file);
 	}
-	return eval_under(klass, self, code, file, line);
-    }
-}
-
-static VALUE
-singleton_class_for_eval(VALUE self)
-{
-    if (SPECIAL_CONST_P(self)) {
-	return rb_special_singleton_class(self);
-    }
-    switch (BUILTIN_TYPE(self)) {
-      case T_FLOAT: case T_BIGNUM: case T_SYMBOL:
-	return Qnil;
-      case T_STRING:
-	if (FL_TEST_RAW(self, RSTRING_FSTR)) return Qnil;
-      default:
-	return rb_singleton_class(self);
+	return eval_under(klass, singleton, self, code, file, line);
     }
 }
 
@@ -2070,15 +2066,15 @@ singleton_class_for_eval(VALUE self)
 static VALUE
 rb_obj_instance_eval_internal(int argc, const VALUE *argv, VALUE self)
 {
-    VALUE klass = singleton_class_for_eval(self);
-    return specific_eval(argc, argv, klass, self, RB_PASS_CALLED_KEYWORDS);
+    VALUE klass = CLASS_OF(self);
+    return specific_eval(argc, argv, klass, self, TRUE, RB_PASS_CALLED_KEYWORDS);
 }
 
 VALUE
 rb_obj_instance_eval(int argc, const VALUE *argv, VALUE self)
 {
-    VALUE klass = singleton_class_for_eval(self);
-    return specific_eval(argc, argv, klass, self, RB_NO_KEYWORDS);
+    VALUE klass = CLASS_OF(self);
+    return specific_eval(argc, argv, klass, self, TRUE, RB_NO_KEYWORDS);
 }
 
 /*
@@ -2102,15 +2098,15 @@ rb_obj_instance_eval(int argc, const VALUE *argv, VALUE self)
 static VALUE
 rb_obj_instance_exec_internal(int argc, const VALUE *argv, VALUE self)
 {
-    VALUE klass = singleton_class_for_eval(self);
-    return yield_under(klass, self, argc, argv, RB_PASS_CALLED_KEYWORDS);
+    VALUE klass = CLASS_OF(self);
+    return yield_under(klass, TRUE, self, argc, argv, RB_PASS_CALLED_KEYWORDS);
 }
 
 VALUE
 rb_obj_instance_exec(int argc, const VALUE *argv, VALUE self)
 {
-    VALUE klass = singleton_class_for_eval(self);
-    return yield_under(klass, self, argc, argv, RB_NO_KEYWORDS);
+    VALUE klass = CLASS_OF(self);
+    return yield_under(klass, TRUE, self, argc, argv, RB_NO_KEYWORDS);
 }
 
 /*
@@ -2143,13 +2139,13 @@ rb_obj_instance_exec(int argc, const VALUE *argv, VALUE self)
 static VALUE
 rb_mod_module_eval_internal(int argc, const VALUE *argv, VALUE mod)
 {
-    return specific_eval(argc, argv, mod, mod, RB_PASS_CALLED_KEYWORDS);
+    return specific_eval(argc, argv, mod, mod, FALSE, RB_PASS_CALLED_KEYWORDS);
 }
 
 VALUE
 rb_mod_module_eval(int argc, const VALUE *argv, VALUE mod)
 {
-    return specific_eval(argc, argv, mod, mod, RB_NO_KEYWORDS);
+    return specific_eval(argc, argv, mod, mod, FALSE, RB_NO_KEYWORDS);
 }
 
 /*
@@ -2177,13 +2173,13 @@ rb_mod_module_eval(int argc, const VALUE *argv, VALUE mod)
 static VALUE
 rb_mod_module_exec_internal(int argc, const VALUE *argv, VALUE mod)
 {
-    return yield_under(mod, mod, argc, argv, RB_PASS_CALLED_KEYWORDS);
+    return yield_under(mod, FALSE, mod, argc, argv, RB_PASS_CALLED_KEYWORDS);
 }
 
 VALUE
 rb_mod_module_exec(int argc, const VALUE *argv, VALUE mod)
 {
-    return yield_under(mod, mod, argc, argv, RB_NO_KEYWORDS);
+    return yield_under(mod, FALSE, mod, argc, argv, RB_NO_KEYWORDS);
 }
 
 /*

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -892,7 +892,7 @@ rb_vm_rewrite_cref(rb_cref_t *cref, VALUE old_klass, VALUE new_klass, rb_cref_t 
 }
 
 static rb_cref_t *
-vm_cref_push(const rb_execution_context_t *ec, VALUE klass, const VALUE *ep, int pushed_by_eval)
+vm_cref_push(const rb_execution_context_t *ec, VALUE klass, const VALUE *ep, int pushed_by_eval, int singleton)
 {
     rb_cref_t *prev_cref = NULL;
 
@@ -907,7 +907,7 @@ vm_cref_push(const rb_execution_context_t *ec, VALUE klass, const VALUE *ep, int
 	}
     }
 
-    return vm_cref_new(klass, METHOD_VISI_PUBLIC, FALSE, prev_cref, pushed_by_eval);
+    return vm_cref_new(klass, METHOD_VISI_PUBLIC, FALSE, prev_cref, pushed_by_eval, singleton);
 }
 
 static inline VALUE

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -915,25 +915,22 @@ vm_get_cbase(const VALUE *ep)
 {
     const rb_cref_t *cref = vm_get_cref(ep);
 
-    VALUE klass = CREF_CLASS_FOR_DEFINITION(cref);
-    return klass;
+    return CREF_CLASS_FOR_DEFINITION(cref);
 }
 
 static inline VALUE
 vm_get_const_base(const VALUE *ep)
 {
     const rb_cref_t *cref = vm_get_cref(ep);
-    VALUE klass = Qundef;
 
     while (cref) {
-	if (!CREF_PUSHED_BY_EVAL(cref) &&
-	    (klass = CREF_CLASS_FOR_DEFINITION(cref)) != 0) {
-	    break;
-	}
-	cref = CREF_NEXT(cref);
+        if (!CREF_PUSHED_BY_EVAL(cref)) {
+            return CREF_CLASS_FOR_DEFINITION(cref);
+        }
+        cref = CREF_NEXT(cref);
     }
 
-    return klass;
+    return Qundef;
 }
 
 static inline void


### PR DESCRIPTION
Previously when `instance_exec` or `instance_eval` was called on an object, that object would be given a singleton class so that method definitions inside the block would be added to the object rather than its class.

This commit aims to improve performance by delaying the creation of the singleton class unless/until one is needed for method definition, based on the discussion in [#18276](https://bugs.ruby-lang.org/issues/18276). Most of the time `instance_eval` is used without any method definition.

This was implemented by adding a flag to the cref indicating that it represents a singleton of the object rather than a class itself. In this case `CREF_CLASS` returns the object's existing class, but in cases that we are defining a method (either via `definemethod` or `VM_SPECIAL_OBJECT_CBASE` which is used for undef and alias).

This also happens to fix what I  [believe](https://twitter.com/jhawthorn/status/1460442596417826821) is a bug. Previously `instance_eval` behaved differently with regards to constant access for `true`/`false`/`nil` than for all other objects. I don't think this was intentional.

    String::Foo = "foo"
    "".instance_eval("Foo")   # => "foo"
    Integer::Foo = "foo"
    123.instance_eval("Foo")  # => "foo"
    TrueClass::Foo = "foo"
    true.instance_eval("Foo") # NameError: uninitialized constant Foo

With this change TrueClass/NilClass/FalseClass behave the same as everything else.

This also slightly changes the error message when trying to define a method  through `instance_eval` on an object which can't have a singleton class.

Before:

    $ ruby -e '123.instance_eval { def foo; end }'
    -e:1:in `block in <main>': no class/module to add method (TypeError)

After:

    $ ./ruby -e '123.instance_eval { def foo; end }'
    -e:1:in `block in <main>': can't define singleton (TypeError)

IMO this error is a small improvement on the original and better matches
the (both old and new) message when definging a method using `def self.`

    $ ruby -e '123.instance_eval{ def self.foo; end }'
    -e:1:in `block in <main>': can't define singleton (TypeError)

---

With this change we can observe that instance_eval doesn't change an object's class unless necessary.

**Before**

```
$ ruby -robjspace -e 'obj = Object.new; puts ObjectSpace.dump(obj); obj.instance_eval { self }; puts ObjectSpace.dump(obj)'
{"address":"0x562155967e00", "type":"OBJECT", "class":"0x56215571a8a0", "ivars":3, "memsize":40, "flags":{"wb_protected":true}}
{"address":"0x562155967e00", "type":"OBJECT", "class":"0x562155967ae0", "ivars":3, "memsize":40, "flags":{"wb_protected":true}}
```

(the "class" address changes)

**After**

```
$ ./ruby -robjspace -e 'obj = Object.new; puts ObjectSpace.dump(obj); obj.instance_eval { self }; puts ObjectSpace.dump(obj)'
{"address":"0x7fa089ce7698", "type":"OBJECT", "class":"0x7fa08d19e850", "ivars":3, "memsize":40, "flags":{"wb_protected":true}}
{"address":"0x7fa089ce7698", "type":"OBJECT", "class":"0x7fa08d19e850", "ivars":3, "memsize":40, "flags":{"wb_protected":true}}
```

(the "class" address remains the same)

---

This should be particularly helpful for Rails apps, which use `instance_eval` as part of the `ActiveSupport::Callbacks` mechanism when provided a `Proc` (which is common for developers to do). Under the interpreter, this should be faster due to not allocating a new singleton, and keeping method entries and inline caches valid. Under both MJIT and YJIT this should be even more helpful as we'll be able to use jitted methods on objects which previously had been given singleton classes.

I ran railsbench from yjit-bench on this (on my local AMD zen2 Linux machine) and the numbers look great (great enough that I'd love someone to double check this because it's in "too good to be true" territory 😳 🤞)

**Before**

```
end_time="2021-11-18 15:57:24 PST (-0800)"
yjit_opts=""
ruby_version="ruby 3.1.0dev (2021-11-18T23:49:36Z lazy_singleton 8ba9639805) [x86_64-linux]"
git_branch="lazy_singleton"
git_commit="8ba9639805"

----------  -----------  ----------  ---------  ----------  -----------  ------------
bench       interp (ms)  stddev (%)  yjit (ms)  stddev (%)  interp/yjit  yjit 1st itr
railsbench  2092.0       1.0         1644.6     1.8         1.27         1.24
----------  -----------  ----------  ---------  ----------  -----------  ------------
Legend:
- interp/yjit: ratio of interp/yjit time. Higher is better. Above 1 represents a speedup.
- 1st itr: ratio of interp/yjit time for the first benchmarking iteration.
```

**After**

```
end_time="2021-11-18 16:03:25 PST (-0800)"
yjit_opts=""
ruby_version="ruby 3.1.0dev (2021-11-18T21:57:23Z lazy_singleton f09b438e6b) [x86_64-linux]"
git_branch="lazy_singleton"
git_commit="f09b438e6b"

----------  -----------  ----------  ---------  ----------  -----------  ------------
bench       interp (ms)  stddev (%)  yjit (ms)  stddev (%)  interp/yjit  yjit 1st itr
railsbench  1908.1       1.1         1415.9     1.6         1.35         1.29
----------  -----------  ----------  ---------  ----------  -----------  ------------
Legend:
- interp/yjit: ratio of interp/yjit time. Higher is better. Above 1 represents a speedup.
- 1st itr: ratio of interp/yjit time for the first benchmarking iteration.
```

So this change makes YJIT 1.16x faster than it was previously, and the interpreter 1.09x faster than it used to be! (and for fun old_interp/new_yjit = 1.47)

Ref: https://bugs.ruby-lang.org/issues/18354