### PR TITLE
Add YJIT codegen for objtostring

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -1214,6 +1214,23 @@ assert_equal 'foo123', %q{
   make_str("foo", 123)
 }
 
+# test string interpolation with overridden to_s
+assert_equal 'foo', %q{
+  class String
+    def to_s
+      "bad"
+    end
+  end
+
+  def make_str(foo)
+    "#{foo}"
+  end
+
+  make_str("foo")
+  make_str("foo")
+}
+
+
 # test invokebuiltin as used in struct assignment
 assert_equal '123', %q{
   def foo(obj)

--- a/test/ruby/test_yjit.rb
+++ b/test/ruby/test_yjit.rb
@@ -215,7 +215,7 @@ class TestYJIT < Test::Unit::TestCase
 
   def test_compile_tostring
     assert_no_exits('"i am a string #{true}"')
-  end if false # Until objtostring supported
+  end
 
   def test_compile_opt_aset
     assert_compiles('[1,2,3][2] = 4', insns: %i[opt_aset])
@@ -240,7 +240,7 @@ class TestYJIT < Test::Unit::TestCase
 
   def test_compile_regexp
     assert_no_exits('/#{true}/')
-  end if false # Until objtostring supported
+  end
 
   def test_getlocal_with_level
     assert_compiles(<<~RUBY, insns: %i[getlocal opt_plus], result: [[7]])
@@ -377,7 +377,7 @@ class TestYJIT < Test::Unit::TestCase
   end
 
   def test_string_interpolation
-    assert_compiles(<<~'RUBY', insns: %i[checktype concatstrings], result: "foobar", min_calls: 2)
+    assert_compiles(<<~'RUBY', insns: %i[objtostring anytostring concatstrings], result: "foobar", min_calls: 2)
       def make_str(foo, bar)
         "#{foo}#{bar}"
       end
@@ -385,17 +385,17 @@ class TestYJIT < Test::Unit::TestCase
       make_str("foo", "bar")
       make_str("foo", "bar")
     RUBY
-  end if false # Until objtostring supported
+  end
 
   def test_string_interpolation_cast
-    assert_compiles(<<~'RUBY', insns: %i[checktype concatstrings tostring], result: "123")
+    assert_compiles(<<~'RUBY', insns: %i[objtostring anytostring concatstrings], result: "123")
       def make_str(foo, bar)
         "#{foo}#{bar}"
       end
 
       make_str(1, 23)
     RUBY
-  end if false # Until objtostring supported
+  end
 
   def test_checkkeyword
     assert_compiles(<<~'RUBY', insns: %i[checkkeyword], result: [2, 5])


### PR DESCRIPTION
This is the minimal correct objtostring implementation in YJIT.
For correctness, it is important that to_string not get called on strings or subclasses of string.
There is a new test for this behavior.

A follow up should implement an optimized version for other types as performed in `vm_objtostring`.

Co-authored-by: John Hawthorn <jhawthorn@github.com>