### PR TITLE
Speed up Ractors for Variable Width Allocation

### DIFF
--- a/class.c
+++ b/class.c
@@ -177,7 +177,9 @@ class_alloc(VALUE flags, VALUE klass)
 
     RVARGC_NEWOBJ_OF(obj, struct RClass, klass, (flags & T_MASK) | FL_PROMOTED1 /* start from age == 2 */ | (RGENGC_WB_PROTECTED_CLASS ? FL_WB_PROTECTED : 0), alloc_size);
 
-#if !USE_RVARGC
+#if USE_RVARGC
+    memset(RCLASS_EXT(obj), 0, sizeof(rb_classext_t));
+#else
     obj->ptr = ZALLOC(rb_classext_t);
 #endif
 

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -67,9 +67,19 @@ struct rb_objspace; /* in vm_core.h */
     rb_obj_write((VALUE)(a), UNALIGNED_MEMBER_ACCESS((VALUE *)(slot)), \
                  (VALUE)(b), __FILE__, __LINE__)
 
-typedef struct ractor_newobj_cache {
+#if USE_RVARGC
+# define SIZE_POOL_COUNT 4
+#else
+# define SIZE_POOL_COUNT 1
+#endif
+
+typedef struct ractor_newobj_size_pool_cache {
     struct RVALUE *freelist;
     struct heap_page *using_page;
+} rb_ractor_newobj_size_pool_cache_t;
+
+typedef struct ractor_newobj_cache {
+    rb_ractor_newobj_size_pool_cache_t size_pool_caches[SIZE_POOL_COUNT];
 } rb_ractor_newobj_cache_t;
 
 /* gc.c */


### PR DESCRIPTION
This commit adds a Ractor cache for every size pool. Previously, all VWA
allocated objects used the slowpath and locked the VM.

On a micro-benchmark that benchmarks String allocation:

```ruby
require "benchmark"

puts(Benchmark.measure do |x|
  rs = 8.times.map do
    Ractor.new do
      10_000.times do
        400.times do |i|
          "a" * i
        end
      end
    end
  end

  rs.map(&:take)
end)
```

VWA turned off:
  29.196591   0.889709  30.086300 (  9.434059)

VWA before this commit:
  29.279486  41.477869  70.757355 ( 12.527379)

VWA after this commit:
  16.782903   0.557117  17.340020 (  4.255603)

cc. @ko1