### PR TITLE
Assign temporary ID to anonymous ID [Bug #18250]

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -11554,6 +11554,7 @@ ibf_load_outer_variables(const struct ibf_load * load, ibf_offset_t outer_variab
     for (size_t i = 0; i < table_size; i++) {
         ID key = ibf_load_id(load, (ID)ibf_load_small_value(load, &reading_pos));
         VALUE value = ibf_load_small_value(load, &reading_pos);
+        if (!key) key = rb_make_temporary_id(i);
         rb_id_table_insert(tbl, key, value);
     }
 

--- a/internal/symbol.h
+++ b/internal/symbol.h
@@ -28,6 +28,7 @@ int rb_is_local_name(VALUE name);
 PUREFUNC(int rb_is_const_sym(VALUE sym));
 PUREFUNC(int rb_is_attrset_sym(VALUE sym));
 ID rb_make_internal_id(void);
+ID rb_make_temporary_id(size_t n);
 void rb_gc_free_dsymbol(VALUE);
 
 #if __has_builtin(__builtin_constant_p)

--- a/parse.y
+++ b/parse.y
@@ -13090,10 +13090,7 @@ rb_init_parse(void)
 static ID
 internal_id(struct parser_params *p)
 {
-    const ID max_id = RB_ID_SERIAL_MAX & ~0xffff;
-    ID id = (ID)vtable_size(p->lvtbl->args) + (ID)vtable_size(p->lvtbl->vars);
-    id = max_id - id;
-    return ID_STATIC_SYM | ID_INTERNAL | (id << ID_SCOPE_SHIFT);
+    return rb_make_temporary_id(vtable_size(p->lvtbl->args) + vtable_size(p->lvtbl->vars));
 }
 #endif /* !RIPPER */
 

--- a/symbol.c
+++ b/symbol.c
@@ -952,6 +952,17 @@ rb_make_internal_id(void)
     return next_id_base() | ID_INTERNAL | ID_STATIC_SYM;
 }
 
+ID
+rb_make_temporary_id(size_t n)
+{
+    const ID max_id = RB_ID_SERIAL_MAX & ~0xffff;
+    const ID id = max_id - (ID)n;
+    if (id <= ruby_global_symbols.last_id) {
+	rb_raise(rb_eRuntimeError, "too big to make temporary ID: %" PRIdSIZE, n);
+    }
+    return (id << ID_SCOPE_SHIFT) | ID_STATIC_SYM | ID_INTERNAL;
+}
+
 static int
 symbols_i(st_data_t key, st_data_t value, st_data_t arg)
 {

--- a/test/ruby/test_iseq.rb
+++ b/test/ruby/test_iseq.rb
@@ -105,6 +105,17 @@ class TestISeq < Test::Unit::TestCase
     assert_equal(42, ISeq.load_from_binary(iseq.to_binary).eval)
   end
 
+  def test_super_with_block_hash_0
+    iseq = compile(<<~EOF)
+      # [Bug #18250] `req` specifically cause `Assertion failed: (key != 0), function hash_table_raw_insert`
+      def touch(req, *)
+        foo { super }
+      end
+      42
+    EOF
+    assert_equal(42, ISeq.load_from_binary(iseq.to_binary).eval)
+  end
+
   def test_super_with_block_and_kwrest
     iseq = compile(<<~EOF)
       def touch2(**) # :nodoc:


### PR DESCRIPTION
Dumped iseq binary can not have unnamed symbols/IDs, and ID 0 is stored instead.
As `struct rb_id_table` disallows ID 0, also for the distinction, re-assign a new temporary ID based on the local variable table index when loading from the binary, as well as the parser.

The test comes from https://github.com/ruby/ruby/pull/5154.