### PR TITLE
[Actions] use windows-2022 for mingw

### DIFF
--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -20,7 +20,7 @@ concurrency:
 #
 jobs:
   make:
-    runs-on: windows-2019
+    runs-on: windows-2022
     name: ${{ github.workflow }} (${{ matrix.msystem }})
     env:
       MSYSTEM: ${{ matrix.msystem }}
@@ -55,12 +55,9 @@ jobs:
         with:
           path: src
       - name: Set up Ruby & MSYS2
-        uses: MSP-Greg/setup-ruby-pkgs@ucrt
+        uses: MSP-Greg/ruby-setup-ruby@win-ucrt-1
         with:
           ruby-version: ${{ matrix.base_ruby }}
-          setup-ruby-ref: MSP-Greg/ruby-setup-ruby/00-win-ucrt
-          mingw: _upgrade_ gmp libffi libyaml openssl ragel readline gcc
-          msys2: automake1.16 bison
       - name: set env
         run: |
           echo "GNUMAKEFLAGS=-j$((2 * NUMBER_OF_PROCESSORS))" >> $GITHUB_ENV
@@ -112,7 +109,7 @@ jobs:
           make test
 
       - name: test-all
-        timeout-minutes: 40
+        timeout-minutes: 45
         run: |
           # Actions uses UTF8, causes test failures, similar to normal OS setup
           chcp.com 437


### PR DESCRIPTION
The MINGW workflow currently uses MSP-Greg/setup-ruby-pkgs@ucrt to install Ruby and a build environment.  That was part of a quick POC for ucrt builds.

This PR uses MSP-Greg/ruby-setup-ruby@win-ucrt-1, which is submitted as [PR 224](https://github.com/ruby/setup-ruby/pull/224) to [setup-ruby](https://github.com/ruby/setup-ruby).  It also switches the Actions Image to windows-2022.

Note that the installed MSYS2 gcc tools (MINGW64 or UCRT64) are selected based on the enabled Ruby.  So, for UCRT64, either `head` or `ucrt` can be used.  To install MINGW64, any other Ruby, version 2.4 or later, can be used.  RubyInstaller's 3.1 release will be a UCRT64 build.  Also, when using windows-2022, all packages needed to build Ruby are installed, so there's no need to use MSP-Greg/setup-ruby-pkgs.

The code is faster than the previous code, but it's insignificant when building Ruby.
