### PR TITLE
Simplify platform check for Windows-UCRT

### DIFF
--- a/test/ruby/test_env.rb
+++ b/test/ruby/test_env.rb
@@ -503,7 +503,7 @@ class TestEnv < Test::Unit::TestCase
   end
 
   def test_huge_value
-    if /mswin/ =~ RUBY_PLATFORM || /ucrt/ =~ RbConfig::CONFIG['sitearch']
+    if /mswin|ucrt/ =~ RUBY_PLATFORM
       # On Windows >= Vista each environment variable can be max 32768 characters
       huge_value = "bar" * 10900
     else


### PR DESCRIPTION
RUBY_PLATFORM can be used since commit 576b2e64cdc5ea42ad345dd3c1c215e006c06fca .