### PR TITLE
fix assertion on `gc_cc_cme()`

### DIFF
--- a/vm_callinfo.h
+++ b/vm_callinfo.h
@@ -334,7 +334,9 @@ static inline const struct rb_callable_method_entry_struct *
 vm_cc_cme(const struct rb_callcache *cc)
 {
     VM_ASSERT(IMEMO_TYPE_P(cc, imemo_callcache));
-    VM_ASSERT(!vm_cc_markable(cc) || cc->cme_ != NULL);
+    VM_ASSERT(cc->call_ == NULL   || // not initialized yet
+              !vm_cc_markable(cc) ||
+              cc->cme_ != NULL);
 
     return cc->cme_;
 }


### PR DESCRIPTION
`cc->cme_` can be NULL when it is not initialized yet.
It can be observed on `GC.stress == true` running.