### PR TITLE
fix to choose correct callcache

### DIFF
--- a/test/ruby/test_iseq.rb
+++ b/test/ruby/test_iseq.rb
@@ -714,4 +714,11 @@ class TestISeq < Test::Unit::TestCase
       RubyVM::InstructionSequence.compile("", debug_level: 5)
     end;
   end
+
+  def test_mandatory_only
+    assert_separately [], <<~RUBY
+      at0 = Time.at(0)
+      assert_equal at0, Time.public_send(:at, 0, 0)
+    RUBY
+  end
 end


### PR DESCRIPTION
It should retun general `cc`, not for overloaded (mandatory only)
method call cache.

This issue is reported by @shugo and @ktou
https://twitter.com/shugomaeda/status/1463699797182119936