### PR TITLE
YJIT: Introduce jit_putobject

### DIFF
--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -1175,7 +1175,6 @@ jit_putobject(jitstate_t *jit, ctx_t *ctx, VALUE arg)
     }
 }
 
-
 static codegen_status_t
 gen_putnil(jitstate_t *jit, ctx_t *ctx, codeblock_t *cb)
 {


### PR DESCRIPTION
This extracts the logic previously inside `gen_putobject` to a more reusable helper method `jit_putobject`.

The motivation for this is that it both simplifies the implementation of other instructions, and other instructions can reuse the optimized behaviour for 32-bit special constants (most importantly `opt_getinlinecache`).

This commit also expands the optimization to use a `mov` directly to memory when we encounter a 32-bit immediate constant. Previously it covered fixnums and `Qtrue`/`Qfalse`, now it will cover any `SPECIAL_CONST_P` value which can be represented as a 32-bit immediate. Notably, this includes static symbols, and Qnil.

## Sample disassembly

### putobject with static symbol
```
:foo
```

**Before:**
```
  ; putobject
  55976964005d:  mov    eax, 0x84710c
  559769640062:  mov    qword ptr [rbx], rax
```

**After:**
```
  ; putobject
  55e4bb62105d:  mov    qword ptr [rbx], 0x84710c
```


### getinlinecache

```
FOO = 123

def get_foo
  FOO
end

10.times { get_foo }
```

**Before:**
```
  ; opt_getinlinecache
  55bc6656b11a:  mov    eax, 0xf7
  55bc6656b11f:  mov    qword ptr [rbx], rax
```

**After:**
```
  ; opt_getinlinecache
  55ab1a1f111a:  mov    qword ptr [rbx], 0xf7
```

