### PR TITLE
Improve performance of embedded string allocation

### DIFF
--- a/string.c
+++ b/string.c
@@ -1739,7 +1739,6 @@ str_duplicate_setup(VALUE klass, VALUE str, VALUE dup)
         assert(str_embed_capa(dup) >= len + 1);
         STR_SET_EMBED_LEN(dup, len);
         MEMCPY(RSTRING(dup)->as.embed.ary, RSTRING(str)->as.embed.ary, char, len + 1);
-        flags &= ~RSTRING_NOEMBED;
     }
     else {
         VALUE root = str;
@@ -1781,7 +1780,7 @@ static inline VALUE
 ec_str_duplicate(struct rb_execution_context_struct *ec, VALUE klass, VALUE str)
 {
     VALUE dup;
-    if (FL_TEST(str, STR_NOEMBED)) {
+    if (!USE_RVARGC || FL_TEST(str, STR_NOEMBED)) {
         dup = ec_str_alloc_heap(ec, klass);
     }
     else {
@@ -1795,7 +1794,7 @@ static inline VALUE
 str_duplicate(VALUE klass, VALUE str)
 {
     VALUE dup;
-    if (FL_TEST(str, STR_NOEMBED)) {
+    if (!USE_RVARGC || FL_TEST(str, STR_NOEMBED)) {
         dup = str_alloc_heap(klass);
     }
     else {


### PR DESCRIPTION
Non-VWA embedded string allocation had a performance regression. This commit improves performance of non-VWA embedded string allocation.

Benchmark script:

```yml
benchmark:
  ary: |
      a = []; b = []; c = []; d = []; e = []
      a = []; b = []; c = []; d = []; e = []
      a = []; b = []; c = []; d = []; e = []
      a = []; b = []; c = []; d = []; e = []
      a = []; b = []; c = []; d = []; e = []
      a = []; b = []; c = []; d = []; e = []
  str: |
      a = "str"; b = "str"; c = "str"; d = "str"; e = "str"
      a = "str"; b = "str"; c = "str"; d = "str"; e = "str"
      a = "str"; b = "str"; c = "str"; d = "str"; e = "str"
      a = "str"; b = "str"; c = "str"; d = "str"; e = "str"
      a = "str"; b = "str"; c = "str"; d = "str"; e = "str"
      a = "str"; b = "str"; c = "str"; d = "str"; e = "str"
```

Before this commit:

```
Warming up --------------------------------------
                 ary                                  1.919M i/s -      2.013M times in 1.049053s (521.12ns/i)
                 str                                  1.731M i/s -      1.748M times in 1.010009s (577.66ns/i)
Calculating -------------------------------------
                     /home/peter/.rubies/ruby-3.0.3/bin/ruby  /home/peter/src/ruby/install/bin/ruby
                 ary                                  1.962M                                 1.870M i/s -      5.757M times in 2.934596s 3.077806s
                 str                                  1.784M                                 1.122M i/s -      5.193M times in 2.911832s 4.630396s

Comparison:
                              ary
/home/peter/.rubies/ruby-3.0.3/bin/ruby:   1961712.7 i/s
/home/peter/src/ruby/install/bin/ruby:   1870434.4 i/s - 1.05x  slower

                              str
/home/peter/.rubies/ruby-3.0.3/bin/ruby:   1783550.4 i/s
/home/peter/src/ruby/install/bin/ruby:   1121588.6 i/s - 1.59x  slower
```

After this commit:

```
Warming up --------------------------------------
                 ary                                  1.899M i/s -      2.000M times in 1.052945s (526.47ns/i)
                 str                                  1.741M i/s -      1.756M times in 1.008239s (574.22ns/i)
Calculating -------------------------------------
                     /home/peter/.rubies/ruby-3.0.3/bin/ruby  /home/peter/src/ruby/install/bin/ruby
                 ary                                  1.963M                                 1.885M i/s -      5.698M times in 2.902366s 3.022505s
                 str                                  1.754M                                 1.649M i/s -      5.224M times in 2.979164s 3.169046s

Comparison:
                              ary
/home/peter/.rubies/ruby-3.0.3/bin/ruby:   1963341.0 i/s
/home/peter/src/ruby/install/bin/ruby:   1885301.6 i/s - 1.04x  slower

                              str
/home/peter/.rubies/ruby-3.0.3/bin/ruby:   1753669.0 i/s
/home/peter/src/ruby/install/bin/ruby:   1648592.8 i/s - 1.06x  slower
```