### PR TITLE
Switch `is_pointer_to_heap` to use library bsearch

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -2785,13 +2785,49 @@ rb_objspace_data_type_name(VALUE obj)
     }
 }
 
+static int
+ptr_in_page_body_p(const void *ptr, const void *memb)
+{
+    struct heap_page *page = *(struct heap_page **)memb;
+    uintptr_t p_body = (uintptr_t)GET_PAGE_BODY(page->start);
+
+    if ((uintptr_t)ptr >= p_body) {
+        return (uintptr_t)ptr < (p_body + HEAP_PAGE_SIZE) ? 0 : 1;
+    }
+    else {
+        return -1;
+    }
+}
+
+PUREFUNC(static inline struct heap_page * heap_page_for_ptr(rb_objspace_t *objspace, uintptr_t ptr);)
+static inline struct heap_page *
+heap_page_for_ptr(rb_objspace_t *objspace, uintptr_t ptr)
+{
+    struct heap_page **res;
+
+    if (ptr < (uintptr_t)heap_pages_lomem ||
+            ptr > (uintptr_t)heap_pages_himem) {
+        return NULL;
+    }
+
+    res = bsearch((void *)ptr, heap_pages_sorted,
+                  (size_t)heap_allocated_pages, sizeof(struct heap_page *),
+                  ptr_in_page_body_p);
+
+    if (res) {
+        return *res;
+    }
+    else {
+        return NULL;
+    }
+}
+
 PUREFUNC(static inline int is_pointer_to_heap(rb_objspace_t *objspace, void *ptr);)
 static inline int
 is_pointer_to_heap(rb_objspace_t *objspace, void *ptr)
 {
     register RVALUE *p = RANY(ptr);
     register struct heap_page *page;
-    register size_t hi, lo, mid;
 
     RB_DEBUG_COUNTER_INC(gc_isptr_trial);
 
@@ -2801,30 +2837,21 @@ is_pointer_to_heap(rb_objspace_t *objspace, void *ptr)
     if ((VALUE)p % sizeof(RVALUE) != 0) return FALSE;
     RB_DEBUG_COUNTER_INC(gc_isptr_align);
 
-    /* check if p looks like a pointer using bsearch*/
-    lo = 0;
-    hi = heap_allocated_pages;
-    while (lo < hi) {
-	mid = (lo + hi) / 2;
-	page = heap_pages_sorted[mid];
-	if (page->start <= p) {
-            if ((uintptr_t)p < ((uintptr_t)page->start + (page->total_slots * page->slot_size))) {
-                RB_DEBUG_COUNTER_INC(gc_isptr_maybe);
+    page = heap_page_for_ptr(objspace, (uintptr_t)ptr);
+    if (page) {
+        GC_ASSERT(page == GET_HEAP_PAGE(ptr));
 
-                if (page->flags.in_tomb) {
-                    return FALSE;
-                }
-                else {
-                    if ((NUM_IN_PAGE(p) * sizeof(RVALUE)) % page->slot_size != 0) return FALSE;
+        RB_DEBUG_COUNTER_INC(gc_isptr_maybe);
+        if (page->flags.in_tomb) {
+            return FALSE;
+        }
+        else {
+            if ((uintptr_t)p < ((uintptr_t)page->start)) return FALSE;
+            if ((uintptr_t)p >= ((uintptr_t)page->start + (page->total_slots * page->slot_size))) return FALSE;
+            if ((NUM_IN_PAGE(p) * sizeof(RVALUE)) % page->slot_size != 0) return FALSE;
 
-                    return TRUE;
-                }
-	    }
-	    lo = mid + 1;
-	}
-	else {
-	    hi = mid;
-	}
+            return TRUE;
+        }
     }
     return FALSE;
 }


### PR DESCRIPTION
This commit switches from a custom implemented bsearch algorithm to use the one provided by the C standard library.

Because `is_pointer_to_heap` will only return true if the pointer being searched for is a valid slot starting address within the heap page body, we've extracted the bsearch call site into a more general function so we can use it elsewhere.

The new function `heap_page_for_ptr` returns the heap page for any heap page pointer, regardless of whether that is at the start of a slot or in the middle of one.

We then use this function as the basis of `is_pointer_to_heap`.

We measured the impact of this this change on GC times using the following script in `test.rb`

```
50.times do
  list = []
  # Try to make some fragmentation
  25000.times {
    list << Class.new(eval "Class.new")
    Class.new
    Object.new
  }

  t = Process.clock_gettime(Process::CLOCK_MONOTONIC)
  GC.start

  p Process.clock_gettime(Process::CLOCK_MONOTONIC) - t
end
```

In each test Ruby was compiled with default settings. 

```
---
Configuration summary for ruby version 3.1.0

   * Installation prefix: /home/mattvh/.rbenv/versions/main
   * exec prefix:         ${prefix}
   * arch:                x86_64-linux
   * site arch:           ${arch}
   * RUBY_BASE_NAME:      ruby
   * ruby lib prefix:     ${libdir}/${RUBY_BASE_NAME}
   * site libraries path: ${rubylibprefix}/${sitearch}
   * vendor path:         ${rubylibprefix}/vendor_ruby
   * target OS:           linux
   * compiler:            gcc
   * with pthread:        yes
   * with coroutine:      amd64
   * enable shared libs:  no
   * dynamic library ext: so
   * CFLAGS:              ${optflags} ${debugflags} ${warnflags}
   * LDFLAGS:             -L. -fstack-protector-strong -rdynamic -Wl,-export-dynamic
   * DLDFLAGS:            -Wl,--compress-debug-sections=zlib
   * optflags:            -O3 -fno-fast-math
   * debugflags:          -ggdb3
   * warnflags:           -Wall -Wextra -Werror=deprecated-declarations -Werror=duplicated-cond -Werror=implicit-function-declaration -Werror=implicit-int -Werror=misleading-indentation -Werror=pointer-arith \
                          -Werror=write-strings -Wimplicit-fallthrough=0 -Wmissing-noreturn -Wno-cast-function-type -Wno-constant-logical-operand -Wno-long-long -Wno-missing-field-initializers -Wno-overlength-strings \
                          -Wno-packed-bitfield-compat -Wno-parentheses-equality -Wno-self-assign -Wno-tautological-compare -Wno-unused-parameter -Wno-unused-value -Wsuggest-attribute=format -Wsuggest-attribute=noreturn \
                          -Wunused-variable -Werror=undef
   * strip command:       strip -S -x
   * install doc:         no
   * JIT support:         yes
   * man page type:       doc
   * BASERUBY -v:         ruby 3.0.1p64 (2021-04-05 revision 0fb782ee38) [x86_64-linux]

---
```

We ran the benchmark script 3 times on both branches and collected the results.

![GC time_ is_pointer_to_heap - master vs libc bsearch](https://user-images.githubusercontent.com/31869/144060107-5087e9ba-003c-498a-9d96-31f87126a91e.png)

as can be seen from the chart, using library bsearch is almost the same speed as our original algorithm.

```
master: 0.1347000586s
new_bsearch: 0.1346081357s
```

Shows a modest speed improvement of 0.06% - This shows that there will be no performance impact from switching to a library bsearch implementation.

One risk of this PR is that the C standard library doesn't make any timing guarantees of its bsearch implementation. However, given that a bsearch implementation with this same function signature appeared in the C89 standard and that bsearch is a very well understood algorithm I believe that the likelihood of this function changing to become slower is very small.

The benefits of this PR (readabillty, and a more general purpose heap page search function) outweigh the slight risk of relying on standard library functions.

