### PR TITLE
Consider environment variable case-insensitiveness

### DIFF
--- a/tool/lib/leakchecker.rb
+++ b/tool/lib/leakchecker.rb
@@ -209,13 +209,28 @@ class LeakChecker
     return leaked
   end
 
-  def find_env
-    ENV.to_h
+  e = ENV["_Ruby_Env_Ignorecase_"], ENV["_RUBY_ENV_IGNORECASE_"]
+  begin
+    ENV["_Ruby_Env_Ignorecase_"] = ENV["_RUBY_ENV_IGNORECASE_"] = nil
+    ENV["_RUBY_ENV_IGNORECASE_"] = "ENV_CASE_TEST"
+    ENV_IGNORECASE = ENV["_Ruby_Env_Ignorecase_"] == "ENV_CASE_TEST"
+  ensure
+    ENV["_Ruby_Env_Ignorecase_"], ENV["_RUBY_ENV_IGNORECASE_"] = e
+  end
+
+  if ENV_IGNORECASE
+    def find_env
+      ENV.to_h {|k, v| [k.upcase, v]}
+    end
+  else
+    def find_env
+      ENV.to_h
+    end
   end
 
   def check_env(test_name)
     old_env = @env_info
-    new_env = ENV.to_h
+    new_env = find_env
     return false if old_env == new_env
     (old_env.keys | new_env.keys).sort.each {|k|
       if old_env.has_key?(k)


### PR DESCRIPTION
Fix messages from test_gem_ext_ext_conf_builder:
```
Environment variable changed: TestGemExtExtConfBuilder#test_class_build_env_MAKE : "MAKE" deleted
Environment variable changed: TestGemExtExtConfBuilder#test_class_build_env_MAKE : "make" added
```
