### PR TITLE
Add specialized code generation for objtostring

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -1214,6 +1214,20 @@ assert_equal 'foo123', %q{
   make_str("foo", 123)
 }
 
+# test string interpolation where the type changes
+assert_equal 'foo123', %q{
+  def make_str(foo, bar)
+    "#{foo}#{bar}"
+  end
+
+  make_str("foo", 123)
+  make_str("foo", 123)
+  make_str(:foo, 123)
+  make_str(:foo, 123)
+  make_str(nil, :foo123)
+  make_str(nil, :foo123)
+}
+
 # test string interpolation with overridden to_s
 assert_equal 'foo', %q{
   class String
@@ -1230,6 +1244,21 @@ assert_equal 'foo', %q{
   make_str("foo")
 }
 
+# test string interpolation with overridden to_s on fixnums
+assert_equal 'ok', %q{
+  class Integer
+    def to_s
+      "ok"
+    end
+  end
+
+  def make_str(foo)
+    "#{foo}"
+  end
+
+  make_str(123)
+  make_str(123)
+}
 
 # test invokebuiltin as used in struct assignment
 assert_equal '123', %q{


### PR DESCRIPTION
This introduces type specialized code for objtostring. 

In addition, this introduces a helper `assume_cfunc_matches` which checks that the methods like `to_s` on strings are not redefined.

- String

```
; objtostring
11d807094:  mov	rax, qword ptr [rbx + 8]
; guard not immediate
11d807098:  test	al, 7
11d80709b:  jne	0x12580707c
11d8070a1:  cmp	rax, 8
11d8070a5:  jbe	0x125807095
; guard known class
11d8070ab:  movabs	rcx, 0x11026e3d0
11d8070b5:  cmp	qword ptr [rax + 8], rcx
11d8070b9:  jne	0x1258070ae
```

- Symbol

```
; objtostring
105935094:  mov	rax, qword ptr [rbx + 8]
; guard object is static symbol
105935098:  cmp	al, 0xc
10593509b:  jne	0x10d93507c
1059350a1:  mov	rdi, qword ptr [rbx + 8]
1059350a5:  call	0x10166ba50
1059350aa:  mov	qword ptr [rbx + 8], rax
```

- Fixnum

```
; objtostring
10e61b094:  mov	rax, qword ptr [rbx + 8]
; guard object is fixnum
10e61b098:  test	al, 1
10e61b09b:  je	0x11661b07c
10e61b0a1:  mov	rdi, qword ptr [rbx + 8]
10e61b0a5:  movabs	rcx, 0x7f7f9d40ef38
10e61b0af:  mov	qword ptr [r13], rcx
10e61b0b3:  lea	rbx, [rbx + 0x10]
10e61b0b7:  mov	qword ptr [r13 + 8], rbx
10e61b0bb:  call	0x109d19df0
10e61b0c0:  mov	qword ptr [rbx - 8], rax
```

- False

```
; objtostring
115b7a094:  mov	rax, qword ptr [rbx + 8]
; guard object is false
115b7a098:  test	rax, rax
115b7a09b:  jne	0x11db7a07c
115b7a0a1:  movabs	rax, 0x10cb283d0
115b7a0ab:  mov	qword ptr [rbx + 8], rax
```

- True

```
; objtostring
111c58094:  mov	rax, qword ptr [rbx + 8]
; guard object is true
111c58098:  cmp	rax, 0x14
111c5809c:  jne	0x119c5807c
```