### PR TITLE
YJIT: Fail gracefully while OOM for new entry points

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -2474,6 +2474,18 @@ assert_equal 'new', %q{
   test
 } if false # disabled for now since OOM crashes in the test harness
 
+assert_equal 'ok', %q{
+  # Try to compile new method while OOM
+  def foo
+    :ok
+  end
+
+  RubyVM::YJIT.simulate_oom! if defined?(RubyVM::YJIT)
+
+  foo
+  foo
+}
+
 # struct aref embedded
 assert_equal '2', %q{
   def foo(s)

--- a/yjit.c
+++ b/yjit.c
@@ -122,6 +122,7 @@ YJIT_DECLARE_COUNTERS(
     vm_insns_count,
     compiled_iseq_count,
     compiled_block_count,
+    compilation_failure,
 
     exit_from_branch_stub,
 

--- a/yjit.rb
+++ b/yjit.rb
@@ -193,8 +193,12 @@ module RubyVM::YJIT
       total_insns_count = retired_in_yjit + stats[:vm_insns_count]
       yjit_ratio_pct = 100.0 * retired_in_yjit.to_f / total_insns_count
 
+      # Number of failed compiler invocations
+      compilation_failure = stats[:compilation_failure]
+
       $stderr.puts "bindings_allocations:  " + ("%10d" % stats[:binding_allocations])
       $stderr.puts "bindings_set:          " + ("%10d" % stats[:binding_set])
+      $stderr.puts "compilation_failure:   " + ("%10d" % compilation_failure) if compilation_failure != 0
       $stderr.puts "compiled_iseq_count:   " + ("%10d" % stats[:compiled_iseq_count])
       $stderr.puts "compiled_block_count:  " + ("%10d" % stats[:compiled_block_count])
       $stderr.puts "invalidation_count:    " + ("%10d" % stats[:invalidation_count])

--- a/yjit_codegen.h
+++ b/yjit_codegen.h
@@ -14,7 +14,7 @@ static void jit_ensure_block_entry_exit(jitstate_t *jit);
 
 static uint8_t *yjit_entry_prologue(codeblock_t *cb, const rb_iseq_t *iseq);
 
-static void yjit_gen_block(block_t *block, rb_execution_context_t *ec);
+static block_t *gen_single_block(blockid_t blockid, const ctx_t *start_ctx, rb_execution_context_t *ec);
 
 static void gen_code_for_exit_from_stub(void);
 

--- a/yjit_iface.c
+++ b/yjit_iface.c
@@ -483,8 +483,7 @@ rb_yjit_compile_iseq(const rb_iseq_t *iseq, rb_execution_context_t *ec)
     // Compile a block version starting at the first instruction
     uint8_t *code_ptr = gen_entry_point(iseq, 0, ec);
 
-    if (code_ptr)
-    {
+    if (code_ptr) {
         iseq->body->jit_func = (yjit_func_t)code_ptr;
     }
     else {


### PR DESCRIPTION
Previously, YJIT crashes with rb_bug() when asked to compile new methods
while out of executable memory.

To handle this situation gracefully, this change keeps track of all the
blocks compiled each invocation in case YJIT runs out of memory in the
middle of a compliation sequence. The list is used to free all blocks in
case compilation fails.

yjit_gen_block() is renamed to gen_one_block() to make it distinct from
gen_block_version(). Call to limit_block_version() and block_t
allocation is moved into the function to help tidy error checking in the
outer loop.

This change introduces `RubyVM::YJIT.simulate_oom!` to help with testing
running out of executable memory.