### PR TITLE
Fix `GC.total_time` example

### DIFF
--- a/spec/ruby/core/gc/total_time_spec.rb
+++ b/spec/ruby/core/gc/total_time_spec.rb
@@ -9,7 +9,7 @@ ruby_version_is "3.1" do
     it "increases as collections are run" do
       time_before = GC.total_time
       GC.start
-      GC.total_time.should > time_before
+      GC.total_time.should >= time_before
     end
   end
 end


### PR DESCRIPTION
The result may increase actually or not, since GC can finish shorter than the timer granularity.