### PR TITLE
eval_error.c: Depracate error message escaping

### DIFF
--- a/ruby.c
+++ b/ruby.c
@@ -1543,8 +1543,9 @@ proc_options(long argc, char **argv, ruby_cmdline_options_t *opt, int envopt)
                 rb_backtrace_length_limit = n;
             }
 	    else {
+                VALUE opt = rb_str_escape(rb_str_new2(s - 2));
 		rb_raise(rb_eRuntimeError,
-			 "invalid option --%s  (-h will show valid options)", s);
+			 "invalid option %"PRIsVALUE"  (-h will show valid options)", opt);
 	    }
 	    break;
 
@@ -1554,9 +1555,12 @@ proc_options(long argc, char **argv, ruby_cmdline_options_t *opt, int envopt)
 
 	  default:
 	    {
+                char str[3] = "-?";
+                str[1] = *s;
+                VALUE opt = rb_str_escape(rb_str_new2(str));
                 rb_raise(rb_eRuntimeError,
-			"invalid option -%c  (-h will show valid options)",
-                        (int)(unsigned char)*s);
+			"invalid option %"PRIsVALUE"  (-h will show valid options)",
+                        opt);
 	    }
 	    goto switch_end;
 


### PR DESCRIPTION
Currently, Ruby's error printer escapes an error message.

```
$ ruby -e 'raise "foo\\bar"'
-e:1:in `<main>': foo\\bar (RuntimeError)
```

This change stops the behavior.

```
$ ruby -e 'raise "foo\\bar"'
-e:1:in `<main>': foo\bar (RuntimeError)
```

As a migration path, the behavior is kept when the message includes any
control character, with a warning is also printed.

```
$ ruby -e 'raise "\0"'
-e: warning: this error message is currently escaped because it includes control characters, but this will not be escaped in Ruby 3.3
-e:1:in `<main>': \0 (RuntimeError)
```

[Feature #18367]