### PR TITLE
Add ivar counter exits

### DIFF
--- a/yjit.c
+++ b/yjit.c
@@ -103,6 +103,7 @@ YJIT_DECLARE_COUNTERS(
 
     getivar_se_self_not_heap,
     getivar_idx_out_of_range,
+    getivar_megamorphic,
 
     setivar_se_self_not_heap,
     setivar_idx_out_of_range,

--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -1735,7 +1735,7 @@ gen_get_ivar(jitstate_t *jit, ctx_t *ctx, const int max_chain_depth, VALUE compt
         ADD_COMMENT(cb, "guard embedded getivar");
         x86opnd_t flags_opnd = member_opnd(REG0, struct RBasic, flags);
         test(cb, flags_opnd, imm_opnd(ROBJECT_EMBED));
-        jit_chain_guard(JCC_JZ, jit, &starting_context, max_chain_depth, side_exit);
+        jit_chain_guard(JCC_JZ, jit, &starting_context, max_chain_depth, COUNTED_EXIT(jit, side_exit, getivar_megamorphic));
 
         // Load the variable
         x86opnd_t ivar_opnd = mem_opnd(64, REG0, offsetof(struct RObject, as.ary) + ivar_index * SIZEOF_VALUE);
@@ -1758,7 +1758,7 @@ gen_get_ivar(jitstate_t *jit, ctx_t *ctx, const int max_chain_depth, VALUE compt
         ADD_COMMENT(cb, "guard extended getivar");
         x86opnd_t flags_opnd = member_opnd(REG0, struct RBasic, flags);
         test(cb, flags_opnd, imm_opnd(ROBJECT_EMBED));
-        jit_chain_guard(JCC_JNZ, jit, &starting_context, max_chain_depth, side_exit);
+        jit_chain_guard(JCC_JNZ, jit, &starting_context, max_chain_depth, COUNTED_EXIT(jit, side_exit, getivar_megamorphic));
 
         // check that the extended table is big enough
         if (ivar_index >= ROBJECT_EMBED_LEN_MAX + 1) {


### PR DESCRIPTION
On Rails we're seeing a lot of exits for ivars in the Active Record
tests. In trying to track them down it was hard to find what code is
exiting.

This change adds a counted exit for when an embedded object is now
extended and when an extended object is now embedded.

Co-authored-by: Aaron Patterson tenderlove@ruby-lang.org

cc/ @tenderlove 