### PR TITLE
Don't call + and < in Integer.times for !FIXNUM

### DIFF
--- a/numeric.c
+++ b/numeric.c
@@ -5697,9 +5697,9 @@ int_dotimes(VALUE num)
 	VALUE i = INT2FIX(0);
 
 	for (;;) {
-	    if (!RTEST(rb_funcall(i, '<', 1, num))) break;
+            if (!RTEST(int_le(i, num))) break;
 	    rb_yield(i);
-	    i = rb_funcall(i, '+', 1, INT2FIX(1));
+            i = rb_int_plus(i, INT2FIX(1));
 	}
     }
     return num;

--- a/test/ruby/test_integer.rb
+++ b/test/ruby/test_integer.rb
@@ -299,6 +299,31 @@ class TestInteger < Test::Unit::TestCase
     end
   end
 
+  def test_times_bignum_redefine_plus_lt
+    assert_separately([], "#{<<-"begin;"}\n#{<<~"end;"}")
+    begin;
+      called = false
+      Integer.class_eval do
+        alias old_plus +
+        undef +
+        define_method(:+){|x| called = true; 1}
+        alias old_lt <
+        undef <
+        define_method(:<){|x| called = true}
+      end
+      big = 2**65
+      big.times{break 0}
+      Integer.class_eval do
+        undef +
+        alias + old_plus
+        undef <
+        alias < old_lt
+      end
+      bug18377 = "[ruby-core:106361]"
+      assert_equal(false, called, bug18377)
+    end;
+  end
+
   def assert_int_equal(expected, result, mesg = nil)
     assert_kind_of(Integer, result, mesg)
     assert_equal(expected, result, mesg)


### PR DESCRIPTION
The methods aren't called for FIXNUM, and it's best to have
consistent behavior.

Fixes [Bug #18377]