### PR TITLE
Cast `tv_usec` to int32_t to fit in `tv_nsec`

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -12395,7 +12395,7 @@ current_process_time(struct timespec *ts)
         if (getrusage(RUSAGE_SELF, &usage) == 0) {
             time = usage.ru_utime;
             ts->tv_sec = time.tv_sec;
-            ts->tv_nsec = time.tv_usec * 1000;
+            ts->tv_nsec = (int32_t)time.tv_usec * 1000;
             return true;
         }
     }


### PR DESCRIPTION
`suseconds_t`, which is the type of `tv_usec`, may be defined with a longer size type than tv_nsec's type (long).
So usec to nsec conversion needs an explicit casting for source level portability.