### PR TITLE
Cache downloaded files

### DIFF
--- a/.github/workflows/baseruby.yml
+++ b/.github/workflows/baseruby.yml
@@ -33,6 +33,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: .downloaded-cache
+          key: downloaded-cache
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}

--- a/.github/workflows/bundled_gems.yml
+++ b/.github/workflows/bundled_gems.yml
@@ -38,6 +38,11 @@ jobs:
           sudo apt-get install --no-install-recommends -q -y build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev bison autoconf ruby
         if: ${{ steps.diff.outcome == 'failure' }}
 
+      - uses: actions/cache@v2
+        with:
+          path: .downloaded-cache
+          key: downloaded-cache
+
       - name: Build
         run: |
           ./autogen.sh

--- a/.github/workflows/check_dependencies.yml
+++ b/.github/workflows/check_dependencies.yml
@@ -39,6 +39,10 @@ jobs:
           git config --global advice.detachedHead 0
           git config --global init.defaultBranch garbage
       - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: .downloaded-cache
+          key: downloaded-cache
       - run: ./autogen.sh
       - name: Run configure
         run: ./configure -C --disable-install-doc --disable-rubygems --with-gcc 'optflags=-O0' 'debugflags=-save-temps=obj -g'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,6 +37,11 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
 
+    - uses: actions/cache@v2
+      with:
+        path: .downloaded-cache
+        key: downloaded-cache
+
     - name: Remove an obsolete rubygems vendored file
       run: sudo rm /usr/lib/ruby/vendor_ruby/rubygems/defaults/operating_system.rb
 

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -200,6 +200,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           path: src
+      - uses: actions/cache@v2
+        with:
+          path: src/.downloaded-cache
+          key: downloaded-cache
       - run: ./autogen.sh
         working-directory: src
       - name: Run configure

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -54,6 +54,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           path: src
+      - uses: actions/cache@v2
+        with:
+          path: src/.downloaded-cache
+          key: downloaded-cache
       - name: Set up Ruby & MSYS2
         uses: MSP-Greg/ruby-setup-ruby@win-ucrt-1
         with:

--- a/.github/workflows/mjit.yml
+++ b/.github/workflows/mjit.yml
@@ -42,6 +42,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           path: src
+      - uses: actions/cache@v2
+        with:
+          path: src/.downloaded-cache
+          key: downloaded-cache
       - name: Fixed world writable dirs
         run: |
           chmod -v go-w $HOME $HOME/.config

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -66,6 +66,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           path: src
+      - uses: actions/cache@v2
+        with:
+          path: src/.downloaded-cache
+          key: downloaded-cache
       - name: Fixed world writable dirs
         run: |
           chmod -v go-w $HOME $HOME/.config

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -80,6 +80,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           path: src
+      - uses: actions/cache@v2
+        with:
+          path: src/.downloaded-cache
+          key: downloaded-cache
       - name: setup env
         # %TEMP% is inconsistent with %TMP% and test-all expects they are consistent.
         # https://github.com/actions/virtual-environments/issues/712#issuecomment-613004302

--- a/.github/workflows/yjit-ubuntu.yml
+++ b/.github/workflows/yjit-ubuntu.yml
@@ -58,6 +58,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           path: src
+      - uses: actions/cache@v2
+        with:
+          path: src/.downloaded-cache
+          key: downloaded-cache
       - name: Fixed world writable dirs
         run: |
           chmod -v go-w $HOME $HOME/.config


### PR DESCRIPTION
External libraries/gems do not change frequently.
Also often zlib returns the date header in wrong format, and checksums mismatch at that time.