### PR TITLE
[Bug #18382] Fix crash in compaction for ObjectSpace.trace_object_allocations

### DIFF
--- a/ext/objspace/object_tracing.c
+++ b/ext/objspace/object_tracing.c
@@ -208,7 +208,8 @@ allocation_info_tracer_compact(void *ptr)
 {
     struct traceobj_arg *trace_arg = (struct traceobj_arg *)ptr;
 
-    if (st_foreach_with_replace(trace_arg->object_table, hash_foreach_should_replace_key, hash_replace_key, 0)) {
+    if (trace_arg->object_table &&
+            st_foreach_with_replace(trace_arg->object_table, hash_foreach_should_replace_key, hash_replace_key, 0)) {
         rb_raise(rb_eRuntimeError, "hash modified during iteration");
     }
 }


### PR DESCRIPTION
# Redmine ticket: https://bugs.ruby-lang.org/issues/18382

`ObjectSpace.trace_object_allocations` can crash with auto-compaction. The following script demonstrates the crash:

```ruby
require "objspace"

GC.auto_compact = true
GC.stress = 0x4

ObjectSpace.trace_object_allocations {}
```

The crash log is as follows:

```
../test.rb:6: [BUG] Segmentation fault at 0x0000000000000018
ruby 3.1.0dev (2021-11-30T11:54:05Z master 7fd88da935) [x86_64-linux]

-- Control frame information -----------------------------------------------
c:0003 p:---- s:0010 e:000009 CFUNC  :trace_object_allocations
c:0002 p:0046 s:0006 e:000005 EVAL   ../test.rb:6 [FINISH]
c:0001 p:0000 s:0003 E:000980 (none) [FINISH]

-- Ruby level backtrace information ----------------------------------------
../test.rb:6:in `<main>'
../test.rb:6:in `trace_object_allocations'

-- Machine register context ------------------------------------------------
 RIP: 0x000055d3e4da0ca9 RBP: 0x00007ffce77fb860 RSP: 0x00007ffce77fb7c0
 RAX: 0x0000000000000000 RBX: 0x000055d3e7338c30 RCX: 0x0000000000000000
 RDX: 0x00007f3b1f3f695d RDI: 0x0000000000000000 RSI: 0x00007f3b1f3f691a
  R8: 0x0000000000000001  R9: 0x0000000000000000 R10: 0xfffffffffffff065
 R11: 0x000055d3e4da1073 R12: 0x000055d3e4c0e200 R13: 0x00007ffce77fd190
 R14: 0x000055d3e730db70 R15: 0x00007f3b22a7bf90 EFL: 0x0000000000010246

-- C level backtrace information -------------------------------------------
/home/peter/src/ruby/build/ruby(rb_print_backtrace+0x1d) [0x55d3e4e43c1b] ../vm_dump.c:759
/home/peter/src/ruby/build/ruby(rb_vm_bugreport+0x158) [0x55d3e4e44147] ../vm_dump.c:1045
/home/peter/src/ruby/build/ruby(rb_bug_for_fatal_signal+0x12c) [0x55d3e4c12c48] ../error.c:820
/home/peter/src/ruby/build/ruby(sigsegv+0x71) [0x55d3e4d943da] ../signal.c:964
/home/peter/src/ruby/build/ruby(sigill) (null):0
/lib/x86_64-linux-gnu/libpthread.so.0(__restore_rt+0x0) [0x7f3b23d043c0] ../sysdeps/pthread/funlockfile.c:28
/home/peter/src/ruby/build/ruby(st_general_foreach+0x3b) [0x55d3e4da0ca9] ../st.c:1468
/home/peter/src/ruby/build/ruby(rb_st_foreach_with_replace+0x3a) [0x55d3e4da10ad] ../st.c:1558
/home/peter/src/ruby/install/lib/ruby/3.1.0/x86_64-linux/objspace.so(allocation_info_tracer_compact+0x3b) [0x7f3b1f3f69d0] ../../../ext/objspace/object_tracing.c:211
/home/peter/src/ruby/build/ruby(gc_update_object_references+0x3c0) [0x55d3e4c40d89] ../gc.c:10009
/home/peter/src/ruby/build/ruby(gc_ref_update+0x16e) [0x55d3e4c413be] ../gc.c:10116
/home/peter/src/ruby/build/ruby(gc_update_references+0xed) [0x55d3e4c414f3] ../gc.c:10152
/home/peter/src/ruby/build/ruby(gc_compact_finish+0x8e) [0x55d3e4c35f74] ../gc.c:5159
/home/peter/src/ruby/build/ruby(gc_page_sweep+0x2bd) [0x55d3e4c36c17] ../gc.c:5410
/home/peter/src/ruby/build/ruby(gc_sweep_step+0xa8) [0x55d3e4c371bf] ../gc.c:5679
/home/peter/src/ruby/build/ruby(gc_sweep_rest+0x5d) [0x55d3e4c373ac] ../gc.c:5745
/home/peter/src/ruby/build/ruby(gc_sweep+0x89) [0x55d3e4c37965] ../gc.c:5892
/home/peter/src/ruby/build/ruby(gc_marks_rest+0xcb) [0x55d3e4c3bf9d] ../gc.c:8109
/home/peter/src/ruby/build/ruby(gc_marks+0x4b) [0x55d3e4c3c10b] ../gc.c:8160
/home/peter/src/ruby/build/ruby(gc_start+0x356) [0x55d3e4c3e186] ../gc.c:8976
/home/peter/src/ruby/build/ruby(garbage_collect+0x57) [0x55d3e4c3ddfc] ../gc.c:8862
/home/peter/src/ruby/build/ruby(garbage_collect_with_gvl+0x52) [0x55d3e4c3e8fa] ../gc.c:9234
/home/peter/src/ruby/build/ruby(objspace_malloc_gc_stress+0x79) [0x55d3e4c4448c] ../gc.c:11292
/home/peter/src/ruby/build/ruby(objspace_xmalloc0+0x37) [0x55d3e4c4469c] ../gc.c:11478
/home/peter/src/ruby/build/ruby(ruby_xmalloc0+0x2b) [0x55d3e4c44978] ../gc.c:11699
/home/peter/src/ruby/build/ruby(ruby_xmalloc_body+0x31) [0x55d3e4c449ab] ../gc.c:11708
/home/peter/src/ruby/build/ruby(ruby_xmalloc+0x1c) [0x55d3e4c49dd9] ../gc.c:13657
/home/peter/src/ruby/build/ruby(rb_st_init_table_with_size+0x2d) [0x55d3e4d9ef60] ../st.c:539
/home/peter/src/ruby/build/ruby(rb_st_init_table+0x21) [0x55d3e4d9f057] ../st.c:577
/home/peter/src/ruby/build/ruby(rb_st_init_numtable+0x14) [0x55d3e4d9f06d] ../st.c:585
/home/peter/src/ruby/install/lib/ruby/3.1.0/x86_64-linux/objspace.so(get_traceobj_arg+0xb7) [0x7f3b1f3f6aac] ../../../ext/objspace/object_tracing.c:242
/home/peter/src/ruby/install/lib/ruby/3.1.0/x86_64-linux/objspace.so(trace_object_allocations_start+0x15) [0x7f3b1f3f6ae3] ../../../ext/objspace/object_tracing.c:257
/home/peter/src/ruby/install/lib/ruby/3.1.0/x86_64-linux/objspace.so(trace_object_allocations+0x1c) [0x7f3b1f3f6c89] ../../../ext/objspace/object_tracing.c:357
/home/peter/src/ruby/build/ruby(call_cfunc_0+0x35) [0x55d3e4e15656] ../vm_insnhelper.c:2729
/home/peter/src/ruby/build/ruby(vm_call_cfunc_with_frame+0x259) [0x55d3e4e16ce6] ../vm_insnhelper.c:3051
/home/peter/src/ruby/build/ruby(vm_call_cfunc+0xaf) [0x55d3e4e16ea7] ../vm_insnhelper.c:3072
/home/peter/src/ruby/build/ruby(vm_call_method_each_type+0xf1) [0x55d3e4e18df5] ../vm_insnhelper.c:3653
/home/peter/src/ruby/build/ruby(vm_call_method+0x9e) [0x55d3e4e194dd] ../vm_insnhelper.c:3739
/home/peter/src/ruby/build/ruby(vm_call_general+0x2f) [0x55d3e4e196ce] ../vm_insnhelper.c:3782
/home/peter/src/ruby/build/ruby(vm_sendish+0x1e7) [0x55d3e4e1b9bd] ../vm_insnhelper.c:4765
/home/peter/src/ruby/build/ruby(vm_exec_core+0x372a) [0x55d3e4e226c3] ../insns.def:758
/home/peter/src/ruby/build/ruby(rb_vm_exec+0x1a4) [0x55d3e4e39342] ../vm.c:2214
/home/peter/src/ruby/build/ruby(rb_iseq_eval_main+0x42) [0x55d3e4e3a0ee] ../vm.c:2462
/home/peter/src/ruby/build/ruby(rb_ec_exec_node+0x12a) [0x55d3e4c1c4b5] ../eval.c:280
/home/peter/src/ruby/build/ruby(ruby_run_node+0x79) [0x55d3e4c1c605] ../eval.c:321
/home/peter/src/ruby/build/ruby(main+0x84) [0x55d3e4c0e36d] ../main.c:47
```
