### PR TITLE
TestClass#test_subclass_gc reduce the number of iteration by 10x

### DIFF
--- a/test/ruby/test_class.rb
+++ b/test/ruby/test_class.rb
@@ -793,11 +793,11 @@ class TestClass < Test::Unit::TestCase
 
   def test_subclass_gc
     c = Class.new
-    100000.times do
+    10_000.times do
       cc = Class.new(c)
       100.times { Class.new(cc) }
     end
-    assert(c.subclasses.size <= 100000)
+    assert(c.subclasses.size <= 10_000)
   end
 
   def test_subclass_gc_stress


### PR DESCRIPTION
The test was taking 10 seconds on my machine and did timeout on CI once.

Ref: http://rubyci.s3.amazonaws.com/debian-riscv64/ruby-master/log/20211202T190018Z.fail.html.gz

```
[20535/21216] TestClass#test_subclass_gctimeout: command execution time exceeds 7200.0 seconds.
```

cc @mame 