### PR TITLE
Install gemspec even though no .rb and no .so

### DIFF
--- a/tool/rbinstall.rb
+++ b/tool/rbinstall.rb
@@ -966,7 +966,6 @@ def install_default_gem(dir, srcdir, bindir)
     spec = load_gemspec(src)
     file_collector = RbInstall::Specs::FileCollector.new(src)
     files = file_collector.collect
-    next if files.empty?
     spec.files = files
     spec
   }


### PR DESCRIPTION
When building with --with-static-linked-ext, some exts without rb file
doesn't produce neither .so or .rb under .ext/common. Therefore, change
rbinstall.rb to install gemspec even if there is no .so or .rb for that
case.

This issue can be reproducible by:

```console
$ ./configure --with-static-linked-ext --prefix=$(pwd)/install
$ make install
$ install/ruby -e 'gem "stringio"'
Ignoring debug-1.3.4 because its extensions are not built. Try: gem pristine debug --version 1.3.4
Ignoring rbs-1.8.0 because its extensions are not built. Try: gem pristine rbs --version 1.8.0
/Users/katei/.ghq/github.com/ruby/install/lib/ruby/3.1.0/rubygems/dependency.rb:311:in `to_specs': Could not find 'stringio' (>= 0) among 75 total gem(s) (Gem::MissingSpecError)
Checked in 'GEM_PATH=/Users/katei/.local/share/gem/ruby/3.1.0:/Users/katei/.ghq/github.com/ruby/install/lib/ruby/gems/3.1.0' , execute `gem env` for more information
        from /Users/katei/.ghq/github.com/ruby/install/lib/ruby/3.1.0/rubygems/dependency.rb:323:in `to_spec'
        from /Users/katei/.ghq/github.com/ruby/install/lib/ruby/3.1.0/rubygems/core_ext/kernel_gem.rb:62:in `gem'
        from -e:1:in `<main>'
```