### PR TITLE
Avoid Array allocation when appending to args array

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -3053,6 +3053,22 @@ iseq_peephole_optimize(rb_iseq_t *iseq, LINK_ELEMENT *list, const int do_tailcal
 	remove_unreachable_chunk(iseq, iobj->link.next);
     }
 
+    /*
+     *  ...
+     *  duparray [...]
+     *  concatarray
+     * =>
+     *  ...
+     *  putobject [...]
+     *  concatarray
+     */
+    if (IS_INSN_ID(iobj, duparray)) {
+        LINK_ELEMENT *next = iobj->link.next;
+        if (IS_INSN(next) && IS_INSN_ID(next, concatarray)) {
+            iobj->insn_id = BIN(putobject);
+        }
+    }
+
     if (IS_INSN_ID(iobj, branchif) ||
 	IS_INSN_ID(iobj, branchnil) ||
 	IS_INSN_ID(iobj, branchunless)) {

--- a/compile.c
+++ b/compile.c
@@ -4364,21 +4364,17 @@ compile_array(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, int pop
 
 /* Compile an array containing the single element represented by node */
 static int
-compile_array_1(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, int popped)
+compile_array_1(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node)
 {
-    if (popped) {
-        CHECK(COMPILE_(ret, "array element", node, popped));
-        return 1;
-    }
-
     if (static_literal_node_p(node, iseq)) {
         VALUE ary = rb_ary_tmp_new(1);
         rb_ary_push(ary, static_literal_value(node, iseq));
         OBJ_FREEZE(ary);
 
         ADD_INSN1(ret, node, duparray, ary);
-    } else {
-        CHECK(COMPILE_(ret, "array element", node, popped));
+    }
+    else {
+        CHECK(COMPILE_(ret, "array element", node, FALSE));
         ADD_INSN1(ret, node, newarray, INT2FIX(1));
     }
 
@@ -9534,7 +9530,7 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const no
 	}
 	else {
 	    CHECK(COMPILE(ret, "argspush head", node->nd_head));
-	    CHECK(compile_array_1(iseq, ret, node->nd_body, popped));
+	    CHECK(compile_array_1(iseq, ret, node->nd_body));
 	    ADD_INSN(ret, node, concatarray);
 	}
 	break;


### PR DESCRIPTION
This PR aims to avoid an Array allocation in the cast of either `NODE_ARGSPUSH` or `NODE_ARGSCAT` with a suffix of one or more constant objects. For example: `[*some_var, 1]` or `[*some_var, 1, 2, 3]`.

cc @iancanderson 

## ARGSPUSH

**Before:**

```
$ ruby --dump=insns -e 'arr = [1,2]; [*arr, 3]'
== disasm: #<ISeq:<main>@-e:1 (1,0)-(1,22)> (catch: FALSE)
local table (size: 1, argc: 0 [opts: 0, rest: -1, post: 0, block: -1, kw: -1@-1, kwrest: -1])
[ 1] arr@0
0000 duparray                               [1, 2]                    (   1)[Li]
0002 setlocal_WC_0                          arr@0
0004 getlocal_WC_0                          arr@0
0006 splatarray                             true
0008 putobject                              3
0010 newarray                               1
0012 concatarray
0013 leave
```

**After:**

```
$ ./ruby --dump=insns -e 'arr = [1,2]; [*arr, 3]'
== disasm: #<ISeq:<main>@-e:1 (1,0)-(1,22)> (catch: FALSE)
local table (size: 1, argc: 0 [opts: 0, rest: -1, post: 0, block: -1, kw: -1@-1, kwrest: -1])
[ 1] arr@0
0000 duparray                               [1, 2]                    (   1)[Li]
0002 setlocal_WC_0                          arr@0
0004 getlocal_WC_0                          arr@0
0006 splatarray                             true
0008 putobject                              [3]
0010 concatarray
0011 leave
```

We're able to combine `pubobject 3`/`newarray 1` into a single `putobject [3]`, to avoid the array allocation (and perform one less instruction)

## ARGSCAT

```
$ ruby --dump=insns -e 'arr = [1,2]; [*arr, 3, 4]'
== disasm: #<ISeq:<main>@-e:1 (1,0)-(1,25)> (catch: FALSE)
local table (size: 1, argc: 0 [opts: 0, rest: -1, post: 0, block: -1, kw: -1@-1, kwrest: -1])
[ 1] arr@0
0000 duparray                               [1, 2]                    (   1)[Li]
0002 setlocal_WC_0                          arr@0
0004 getlocal_WC_0                          arr@0
0006 splatarray                             true
0008 duparray                               [3, 4]
0010 concatarray
0011 leave
```

```
$ ./ruby --dump=insns -e 'arr = [1,2]; [*arr, 3, 4]'
== disasm: #<ISeq:<main>@-e:1 (1,0)-(1,25)> (catch: FALSE)
local table (size: 1, argc: 0 [opts: 0, rest: -1, post: 0, block: -1, kw: -1@-1, kwrest: -1])
[ 1] arr@0
0000 duparray                               [1, 2]                    (   1)[Li]
0002 setlocal_WC_0                          arr@0
0004 getlocal_WC_0                          arr@0
0006 splatarray                             true
0008 putobject                              [3, 4]
0010 concatarray
0011 leave
```

We're able to replace `duparray` with `putobject`, to avoid the array allocation.