### PR TITLE
[Feature #18033] `Time.at` with string

### DIFF
--- a/benchmark/time_parse.yml
+++ b/benchmark/time_parse.yml
@@ -6,3 +6,5 @@ benchmark:
   - Time.iso8601(iso8601)
   - Time.parse(iso8601)
   - Time.parse(inspect)
+  - Time.new(iso8601) rescue Time.iso8601(iso8601)
+  - Time.new(inspect) rescue Time.parse(inspect)

--- a/benchmark/time_parse.yml
+++ b/benchmark/time_parse.yml
@@ -6,5 +6,5 @@ benchmark:
   - Time.iso8601(iso8601)
   - Time.parse(iso8601)
   - Time.parse(inspect)
-  - Time.new(iso8601) rescue Time.iso8601(iso8601)
-  - Time.new(inspect) rescue Time.parse(inspect)
+  - Time.at(iso8601) rescue Time.iso8601(iso8601)
+  - Time.at(inspect) rescue Time.parse(inspect)

--- a/spec/ruby/core/time/at_spec.rb
+++ b/spec/ruby/core/time/at_spec.rb
@@ -83,9 +83,20 @@ describe "Time.at" do
     end
   end
 
+  ruby_version_is '3.1' do
+    describe "passed time String" do
+      it "converts inspect-ed time string" do
+        t = Time.now
+        Time.at(t.inspect).should == t
+      end
+    end
+  end
+
   describe "passed non-Time, non-Numeric" do
-    it "raises a TypeError with a String argument" do
-      -> { Time.at("0") }.should raise_error(TypeError)
+    ruby_version_is ''...'3.1' do
+      it "raises a TypeError with a String argument" do
+        -> { Time.at("0") }.should raise_error(TypeError)
+      end
     end
 
     it "raises a TypeError with a nil argument" do

--- a/test/ruby/test_time.rb
+++ b/test/ruby/test_time.rb
@@ -50,6 +50,23 @@ class TestTime < Test::Unit::TestCase
     assert_equal([2001,2,28,23,59,30,-43200], [t.year, t.month, t.mday, t.hour, t.min, t.sec, t.gmt_offset], bug4090)
     assert_raise(ArgumentError) { Time.new(2000,1,1, 0,0,0, "+01:60") }
     assert_raise(ArgumentError) { Time.new(2021, 1, 1, "+09:99") }
+
+    t = Time.utc(2020, 12, 24, 15, 56, 17)
+    assert_equal(t, Time.new("2020-12-24T15:56:17Z"))
+    assert_equal(t, Time.new("2020-12-25 00:56:17 +09:00"))
+    assert_equal(t, Time.new("2020-12-25 00:57:47 +09:01:30"))
+    assert_equal(t, Time.new("2020-12-25 00:56:17 +0900"))
+    assert_equal(t, Time.new("2020-12-25 00:57:47 +090130"))
+    assert_equal(t, Time.new("2020-12-25T00:56:17+09:00"))
+    assert_equal(Time.utc(2020, 12, 24, 15, 56, 0), Time.new("2020-12-25 00:56 +09:00"))
+    assert_equal(Time.utc(2020, 12, 24, 15, 0, 0), Time.new("2020-12-25 00 +09:00"))
+
+    assert_equal(Time.new(2021, 12, 25, in: "+09:00"), Time.new("2021-12-25+09:00"))
+
+    assert_equal(0.123456r, Time.new("2021-12-25 00:00:00.123456 +09:00").subsec)
+    assert_raise_with_message(ArgumentError, "subsecond expected after dot: 00:56:17. ") {
+      Time.new("2020-12-25 00:56:17. +0900")
+    }
   end
 
   def test_time_add()

--- a/test/ruby/test_time.rb
+++ b/test/ruby/test_time.rb
@@ -50,62 +50,6 @@ class TestTime < Test::Unit::TestCase
     assert_equal([2001,2,28,23,59,30,-43200], [t.year, t.month, t.mday, t.hour, t.min, t.sec, t.gmt_offset], bug4090)
     assert_raise(ArgumentError) { Time.new(2000,1,1, 0,0,0, "+01:60") }
     assert_raise(ArgumentError) { Time.new(2021, 1, 1, "+09:99") }
-
-    t = Time.utc(2020, 12, 24, 15, 56, 17)
-    assert_equal(t, Time.new("2020-12-24T15:56:17Z"))
-    assert_equal(t, Time.new("2020-12-25 00:56:17 +09:00"))
-    assert_equal(t, Time.new("2020-12-25 00:57:47 +09:01:30"))
-    assert_equal(t, Time.new("2020-12-25 00:56:17 +0900"))
-    assert_equal(t, Time.new("2020-12-25 00:57:47 +090130"))
-    assert_equal(t, Time.new("2020-12-25T00:56:17+09:00"))
-    assert_equal(Time.utc(2020, 12, 24, 15, 56, 0), Time.new("2020-12-25 00:56 +09:00"))
-    assert_equal(Time.utc(2020, 12, 24, 15, 0, 0), Time.new("2020-12-25 00 +09:00"))
-
-    assert_equal(Time.new(2021, 12, 25, in: "+09:00"), Time.new("2021-12-25+09:00"))
-
-    assert_equal(0.123456r, Time.new("2021-12-25 00:00:00.123456 +09:00").subsec)
-    assert_equal(0.123456789r, Time.new("2021-12-25 00:00:00.123456789876 +09:00").subsec)
-    assert_equal(0.123r, Time.new("2021-12-25 00:00:00.123456789876 +09:00", precision: 3).subsec)
-    assert_equal(0.123456789876r, Time.new("2021-12-25 00:00:00.123456789876 +09:00", precision: nil).subsec)
-    assert_raise_with_message(ArgumentError, "subsecond expected after dot: 00:56:17. ") {
-      Time.new("2020-12-25 00:56:17. +0900")
-    }
-    assert_raise_with_message(ArgumentError, /year must be 2 or 4\+/) {
-      Time.new("021-12-25 00:00:00.123456 +09:00")
-    }
-    assert_raise_with_message(ArgumentError, /fraction min is.*56\./) {
-      Time.new("2020-12-25 00:56. +0900")
-    }
-    assert_raise_with_message(ArgumentError, /fraction hour is.*00\./) {
-      Time.new("2020-12-25 00. +0900")
-    }
-    assert_raise_with_message(ArgumentError, /two digits sec.*:017\b/) {
-      Time.new("2020-12-25 00:56:017 +0900")
-    }
-    assert_raise_with_message(ArgumentError, /two digits sec.*:9\b/) {
-      Time.new("2020-12-25 00:56:9 +0900")
-    }
-    assert_raise_with_message(ArgumentError, /two digits min.*:056\b/) {
-      Time.new("2020-12-25 00:056:17 +0900")
-    }
-    assert_raise_with_message(ArgumentError, /two digits min.*:5\b/) {
-      Time.new("2020-12-25 00:5:17 +0900")
-    }
-    assert_raise_with_message(ArgumentError, /two digits hour.*\b000\b/) {
-      Time.new("2020-12-25 000:56:17 +0900")
-    }
-    assert_raise_with_message(ArgumentError, /two digits hour.*\b0\b/) {
-      Time.new("2020-12-25 0:56:17 +0900")
-    }
-    assert_raise_with_message(ArgumentError, /two digits mday.*\b025\b/) {
-      Time.new("2020-12-025 00:56:17 +0900")
-    }
-    assert_raise_with_message(ArgumentError, /two digits mon.*\b012\b/) {
-      Time.new("2020-012-25 00:56:17 +0900")
-    }
-    assert_raise_with_message(ArgumentError, /two digits mon.*\b1\b/) {
-      Time.new("2020-1-25 00:56:17 +0900")
-    }
   end
 
   def test_time_add()
@@ -317,6 +261,64 @@ class TestTime < Test::Unit::TestCase
   def test_at_rational
     assert_equal(1, Time.at(Rational(1,1) / 1000000000).nsec)
     assert_equal(1, Time.at(1167609600 + Rational(1,1) / 1000000000).nsec)
+  end
+
+  def test_at_string
+    t = Time.utc(2020, 12, 24, 15, 56, 17)
+    assert_equal(t, Time.at("2020-12-24T15:56:17Z"))
+    assert_equal(t, Time.at("2020-12-25 00:56:17 +09:00"))
+    assert_equal(t, Time.at("2020-12-25 00:57:47 +09:01:30"))
+    assert_equal(t, Time.at("2020-12-25 00:56:17 +0900"))
+    assert_equal(t, Time.at("2020-12-25 00:57:47 +090130"))
+    assert_equal(t, Time.at("2020-12-25T00:56:17+09:00"))
+    assert_equal(Time.utc(2020, 12, 24, 15, 56, 0), Time.at("2020-12-25 00:56 +09:00"))
+    assert_equal(Time.utc(2020, 12, 24, 15, 0, 0), Time.at("2020-12-25 00 +09:00"))
+
+    assert_equal(Time.new(2021, 12, 25, in: "+09:00"), Time.at("2021-12-25+09:00"))
+
+    assert_equal(0.123456r, Time.at("2021-12-25 00:00:00.123456 +09:00").subsec)
+    assert_equal(0.123456789r, Time.at("2021-12-25 00:00:00.123456789876 +09:00").subsec)
+    assert_equal(0.123r, Time.at("2021-12-25 00:00:00.123456789876 +09:00", precision: 3).subsec)
+    assert_equal(0.123456789876r, Time.at("2021-12-25 00:00:00.123456789876 +09:00", precision: nil).subsec)
+    assert_raise_with_message(ArgumentError, "subsecond expected after dot: 00:56:17. ") {
+      Time.at("2020-12-25 00:56:17. +0900")
+    }
+    assert_raise_with_message(ArgumentError, /year must be 2 or 4\+/) {
+      Time.at("021-12-25 00:00:00.123456 +09:00")
+    }
+    assert_raise_with_message(ArgumentError, /fraction min is.*56\./) {
+      Time.at("2020-12-25 00:56. +0900")
+    }
+    assert_raise_with_message(ArgumentError, /fraction hour is.*00\./) {
+      Time.at("2020-12-25 00. +0900")
+    }
+    assert_raise_with_message(ArgumentError, /two digits sec.*:017\b/) {
+      Time.at("2020-12-25 00:56:017 +0900")
+    }
+    assert_raise_with_message(ArgumentError, /two digits sec.*:9\b/) {
+      Time.at("2020-12-25 00:56:9 +0900")
+    }
+    assert_raise_with_message(ArgumentError, /two digits min.*:056\b/) {
+      Time.at("2020-12-25 00:056:17 +0900")
+    }
+    assert_raise_with_message(ArgumentError, /two digits min.*:5\b/) {
+      Time.at("2020-12-25 00:5:17 +0900")
+    }
+    assert_raise_with_message(ArgumentError, /two digits hour.*\b000\b/) {
+      Time.at("2020-12-25 000:56:17 +0900")
+    }
+    assert_raise_with_message(ArgumentError, /two digits hour.*\b0\b/) {
+      Time.at("2020-12-25 0:56:17 +0900")
+    }
+    assert_raise_with_message(ArgumentError, /two digits mday.*\b025\b/) {
+      Time.at("2020-12-025 00:56:17 +0900")
+    }
+    assert_raise_with_message(ArgumentError, /two digits mon.*\b012\b/) {
+      Time.at("2020-012-25 00:56:17 +0900")
+    }
+    assert_raise_with_message(ArgumentError, /two digits mon.*\b1\b/) {
+      Time.at("2020-1-25 00:56:17 +0900")
+    }
   end
 
   def test_utc_subsecond

--- a/test/ruby/test_time.rb
+++ b/test/ruby/test_time.rb
@@ -64,6 +64,9 @@ class TestTime < Test::Unit::TestCase
     assert_equal(Time.new(2021, 12, 25, in: "+09:00"), Time.new("2021-12-25+09:00"))
 
     assert_equal(0.123456r, Time.new("2021-12-25 00:00:00.123456 +09:00").subsec)
+    assert_equal(0.123456789r, Time.new("2021-12-25 00:00:00.123456789876 +09:00").subsec)
+    assert_equal(0.123r, Time.new("2021-12-25 00:00:00.123456789876 +09:00", precision: 3).subsec)
+    assert_equal(0.123456789876r, Time.new("2021-12-25 00:00:00.123456789876 +09:00", precision: nil).subsec)
     assert_raise_with_message(ArgumentError, "subsecond expected after dot: 00:56:17. ") {
       Time.new("2020-12-25 00:56:17. +0900")
     }

--- a/test/ruby/test_time.rb
+++ b/test/ruby/test_time.rb
@@ -67,6 +67,42 @@ class TestTime < Test::Unit::TestCase
     assert_raise_with_message(ArgumentError, "subsecond expected after dot: 00:56:17. ") {
       Time.new("2020-12-25 00:56:17. +0900")
     }
+    assert_raise_with_message(ArgumentError, /year must be 2 or 4\+/) {
+      Time.new("021-12-25 00:00:00.123456 +09:00")
+    }
+    assert_raise_with_message(ArgumentError, /fraction min is.*56\./) {
+      Time.new("2020-12-25 00:56. +0900")
+    }
+    assert_raise_with_message(ArgumentError, /fraction hour is.*00\./) {
+      Time.new("2020-12-25 00. +0900")
+    }
+    assert_raise_with_message(ArgumentError, /two digits sec.*:017\b/) {
+      Time.new("2020-12-25 00:56:017 +0900")
+    }
+    assert_raise_with_message(ArgumentError, /two digits sec.*:9\b/) {
+      Time.new("2020-12-25 00:56:9 +0900")
+    }
+    assert_raise_with_message(ArgumentError, /two digits min.*:056\b/) {
+      Time.new("2020-12-25 00:056:17 +0900")
+    }
+    assert_raise_with_message(ArgumentError, /two digits min.*:5\b/) {
+      Time.new("2020-12-25 00:5:17 +0900")
+    }
+    assert_raise_with_message(ArgumentError, /two digits hour.*\b000\b/) {
+      Time.new("2020-12-25 000:56:17 +0900")
+    }
+    assert_raise_with_message(ArgumentError, /two digits hour.*\b0\b/) {
+      Time.new("2020-12-25 0:56:17 +0900")
+    }
+    assert_raise_with_message(ArgumentError, /two digits mday.*\b025\b/) {
+      Time.new("2020-12-025 00:56:17 +0900")
+    }
+    assert_raise_with_message(ArgumentError, /two digits mon.*\b012\b/) {
+      Time.new("2020-012-25 00:56:17 +0900")
+    }
+    assert_raise_with_message(ArgumentError, /two digits mon.*\b1\b/) {
+      Time.new("2020-1-25 00:56:17 +0900")
+    }
   end
 
   def test_time_add()

--- a/time.c
+++ b/time.c
@@ -2415,12 +2415,18 @@ time_init_args(rb_execution_context_t *ec, VALUE time, VALUE year, VALUE mon, VA
 }
 
 static int
-two_digits(const char *ptr, const char *end, const char **endp)
+two_digits(const char *ptr, const char *end, const char **endp, const char *name)
 {
     ssize_t len = end - ptr;
-    if (len < 2) return -1;
-    if (!ISDIGIT(ptr[0]) || !ISDIGIT(ptr[1])) return -1;
-    if ((len > 2) && ISDIGIT(ptr[2])) return -1;
+    if (len < 2 || (!ISDIGIT(ptr[0]) || !ISDIGIT(ptr[1])) ||
+        ((len > 2) && ISDIGIT(ptr[2]))) {
+        VALUE mesg = rb_sprintf("two digits %s is expected", name);
+        if (ptr[-1] == '-' || ptr[-1] == ':') {
+            rb_str_catf(mesg, " after `%c'", ptr[-1]);
+        }
+        rb_str_catf(mesg, ": %.*s", ((len > 10) ? 10 : (int)(end - ptr)) + 1, ptr - 1);
+        rb_exc_raise(rb_exc_new_str(rb_eArgError, mesg));
+    }
     *endp = ptr + 2;
     return (ptr[0] - '0') * 10 + (ptr[1] - '0');
 }
@@ -2455,22 +2461,34 @@ time_init_parse(rb_execution_context_t *ec, VALUE time, VALUE str, VALUE zone)
     if (NIL_P(year)) {
         rb_raise(rb_eArgError, "can't parse: %+"PRIsVALUE, str);
     }
+    else if (ndigits != 2 && ndigits < 4) {
+        rb_raise(rb_eArgError, "year must be 2 or 4+ digits: %.*s", (int)ndigits, ptr - ndigits);
+    }
     do {
 #define peek_n(c, n) ((ptr + n < end) && ((unsigned char)ptr[n] == (c)))
 #define peek(c) peek_n(c, 0)
 #define peekc_n(n) ((ptr + n < end) ? (int)(unsigned char)ptr[n] : -1)
 #define peekc() peek_n(0)
+#define expect_two_digits(x) \
+        x = two_digits(ptr + 1, end, &ptr, #x)
         if (!peek('-')) break;
-        if ((mon = two_digits(ptr + 1, end, &ptr)) < 0) break;
+        expect_two_digits(mon);
         if (!peek('-')) break;
-        if ((mday = two_digits(ptr + 1, end, &ptr)) < 0) break;
+        expect_two_digits(mday);
         if (!peek(' ') && !peek('T')) break;
         const char *const time_part = ptr + 1;
-        if ((hour = two_digits(ptr + 1, end, &ptr)) < 0) break;
+        if (!ISDIGIT(peekc_n(1))) break;
+#define nofraction(x) \
+        if (peek('.')) \
+            rb_raise(rb_eArgError, "fraction %s is not supported: %.*s", #x, \
+                     (int)(ptr + 1 - time_part), time_part)
+        expect_two_digits(hour);
+        nofraction(hour);
         if (!peek(':')) break;
-        if ((min = two_digits(ptr + 1, end, &ptr)) < 0) break;
+        expect_two_digits(min);
+        nofraction(min);
         if (!peek(':')) break;
-        if ((sec = two_digits(ptr + 1, end, &ptr)) < 0) break;
+        expect_two_digits(sec);
         if (peek('.')) {
             ptr++;
             for (ndigits = 0; ndigits < 45 && ISDIGIT(peekc_n(ndigits)); ++ndigits);

--- a/time.c
+++ b/time.c
@@ -2318,7 +2318,8 @@ find_timezone(VALUE time, VALUE zone)
 }
 
 static VALUE
-time_init_args(rb_execution_context_t *ec, VALUE time, VALUE year, VALUE mon, VALUE mday, VALUE hour, VALUE min, VALUE sec, VALUE zone)
+time_init_args(rb_execution_context_t *ec, VALUE time, VALUE year, VALUE mon, VALUE mday,
+               VALUE hour, VALUE min, VALUE sec, VALUE subsec, VALUE zone)
 {
     struct vtm vtm;
     VALUE utc = Qnil;
@@ -2341,6 +2342,10 @@ time_init_args(rb_execution_context_t *ec, VALUE time, VALUE year, VALUE mon, VA
     if (NIL_P(sec)) {
         vtm.sec = 0;
         vtm.subsecx = INT2FIX(0);
+    }
+    else if (!NIL_P(subsec)) {
+        vtm.sec = obj2ubits(sec, 6);
+        vtm.subsecx = subsec;
     }
     else {
         VALUE subsecx;
@@ -2407,6 +2412,112 @@ time_init_args(rb_execution_context_t *ec, VALUE time, VALUE year, VALUE mon, VA
         tobj->timew = timelocalw(&vtm);
         return time_localtime(time);
     }
+}
+
+static int
+two_digits(const char *ptr, const char *end, const char **endp)
+{
+    ssize_t len = end - ptr;
+    if (len < 2) return -1;
+    if (!ISDIGIT(ptr[0]) || !ISDIGIT(ptr[1])) return -1;
+    if ((len > 2) && ISDIGIT(ptr[2])) return -1;
+    *endp = ptr + 2;
+    return (ptr[0] - '0') * 10 + (ptr[1] - '0');
+}
+
+static VALUE
+parse_int(const char *ptr, const char *end, const char **endp, size_t *ndigits, bool sign)
+{
+    ssize_t len = (end - ptr);
+    int flags = sign ? RB_INT_PARSE_SIGN : 0;
+    return rb_int_parse_cstr(ptr, len, (char **)endp, ndigits, 10, flags);
+}
+
+static VALUE
+time_init_parse(rb_execution_context_t *ec, VALUE time, VALUE str, VALUE zone)
+{
+    if (NIL_P(str = rb_check_string_type(str))) return Qnil;
+    if (!rb_enc_str_asciicompat_p(str)) {
+	rb_raise(rb_eArgError, "time string should have ASCII compatible encoding");
+    }
+
+    const char *const begin = RSTRING_PTR(str);
+    const char *const end = RSTRING_END(str);
+    const char *ptr = begin;
+    VALUE year = Qnil, subsec = Qnil;
+    int mon = -1, mday = -1, hour = -1, min = -1, sec = -1;
+    size_t ndigits;
+
+#define date_time_sep_p(c) ((c) == ' ' || (c) == 'T')
+
+    while ((ptr < end) && ISSPACE(*ptr)) ptr++;
+    year = parse_int(ptr, end, &ptr, &ndigits, true);
+    if (NIL_P(year)) {
+        rb_raise(rb_eArgError, "can't parse: %+"PRIsVALUE, str);
+    }
+    do {
+#define peek_n(c, n) ((ptr + n < end) && ((unsigned char)ptr[n] == (c)))
+#define peek(c) peek_n(c, 0)
+#define peekc_n(n) ((ptr + n < end) ? (int)(unsigned char)ptr[n] : -1)
+#define peekc() peek_n(0)
+        if (!peek('-')) break;
+        if ((mon = two_digits(ptr + 1, end, &ptr)) < 0) break;
+        if (!peek('-')) break;
+        if ((mday = two_digits(ptr + 1, end, &ptr)) < 0) break;
+        if (!peek(' ') && !peek('T')) break;
+        const char *const time_part = ptr + 1;
+        if ((hour = two_digits(ptr + 1, end, &ptr)) < 0) break;
+        if (!peek(':')) break;
+        if ((min = two_digits(ptr + 1, end, &ptr)) < 0) break;
+        if (!peek(':')) break;
+        if ((sec = two_digits(ptr + 1, end, &ptr)) < 0) break;
+        if (peek('.')) {
+            ptr++;
+            for (ndigits = 0; ndigits < 45 && ISDIGIT(peekc_n(ndigits)); ++ndigits);
+            if (!ndigits) {
+                int clen = rb_enc_precise_mbclen(ptr, end, rb_enc_get(str));
+                if (clen < 0) clen = 0;
+                rb_raise(rb_eArgError, "subsecond expected after dot: %.*s",
+                         (int)(ptr - time_part) + clen, time_part);
+            }
+            subsec = parse_int(ptr, ptr + ndigits, &ptr, &ndigits, false);
+            if (NIL_P(subsec)) break;
+            while (ptr < end && ISDIGIT(*ptr)) ptr++;
+        }
+    } while (0);
+    while (ptr < end && ISSPACE(*ptr)) ptr++;
+    const char *const zstr = ptr;
+    while (ptr < end && !ISSPACE(*ptr)) ptr++;
+    const char *const zend = ptr;
+    while (ptr < end && ISSPACE(*ptr)) ptr++;
+    if (ptr < end) {
+        VALUE mesg = rb_str_new_cstr("can't parse at: ");
+        rb_str_cat(mesg, ptr, end - ptr);
+        rb_exc_raise(rb_exc_new_str(rb_eArgError, mesg));
+    }
+    if (zend > zstr) {
+        zone = rb_str_subseq(str, zstr - begin, zend - zstr);
+    }
+    if (!NIL_P(subsec)) {
+        /* subseconds is the last using ndigits */
+        if (ndigits < 9) {
+            VALUE mul = rb_int_positive_pow(10, 9 - ndigits);
+            subsec = rb_int_mul(subsec, mul);
+        }
+        else if (ndigits > 9) {
+            VALUE num = rb_int_positive_pow(10, ndigits - 9);
+            subsec = rb_rational_new(subsec, num);
+        }
+    }
+
+#define non_negative(x) ((x) < 0 ? Qnil : INT2FIX(x))
+    return time_init_args(ec, time, year,
+                          non_negative(mon),
+                          non_negative(mday),
+                          non_negative(hour),
+                          non_negative(min),
+                          non_negative(sec),
+                          subsec, zone);
 }
 
 static void

--- a/time.c
+++ b/time.c
@@ -2440,7 +2440,7 @@ parse_int(const char *ptr, const char *end, const char **endp, size_t *ndigits, 
 }
 
 static VALUE
-time_init_parse(rb_execution_context_t *ec, VALUE time, VALUE str, VALUE zone)
+time_init_parse(rb_execution_context_t *ec, VALUE time, VALUE str, VALUE zone, VALUE precision)
 {
     if (NIL_P(str = rb_check_string_type(str))) return Qnil;
     if (!rb_enc_str_asciicompat_p(str)) {
@@ -2453,6 +2453,7 @@ time_init_parse(rb_execution_context_t *ec, VALUE time, VALUE str, VALUE zone)
     VALUE year = Qnil, subsec = Qnil;
     int mon = -1, mday = -1, hour = -1, min = -1, sec = -1;
     size_t ndigits;
+    size_t prec = NIL_P(precision) ? SIZE_MAX : NUM2SIZET(precision);
 
 #define date_time_sep_p(c) ((c) == ' ' || (c) == 'T')
 
@@ -2491,7 +2492,7 @@ time_init_parse(rb_execution_context_t *ec, VALUE time, VALUE str, VALUE zone)
         expect_two_digits(sec);
         if (peek('.')) {
             ptr++;
-            for (ndigits = 0; ndigits < 45 && ISDIGIT(peekc_n(ndigits)); ++ndigits);
+            for (ndigits = 0; ndigits < prec && ISDIGIT(peekc_n(ndigits)); ++ndigits);
             if (!ndigits) {
                 int clen = rb_enc_precise_mbclen(ptr, end, rb_enc_get(str));
                 if (clen < 0) clen = 0;

--- a/timev.rb
+++ b/timev.rb
@@ -289,6 +289,8 @@ class Time
   #   Time.new('2000-12-31 23:59:59.5')              # => 2000-12-31 23:59:59.5 -0600
   #   Time.new('2000-12-31 23:59:59.5 +0900')        # => 2000-12-31 23:59:59.5 +0900
   #   Time.new('2000-12-31 23:59:59.5', in: '+0900') # => 2000-12-31 23:59:59.5 +0900
+  #   Time.new('2000-12-31 23:59:59.5')              # => 2000-12-31 23:59:59.5 -0600
+  #   Time.new('2000-12-31 23:59:59.56789', precision: 3) # => 2000-12-31 23:59:59.567 -0600
   #
   # Parameters:
   #
@@ -296,8 +298,12 @@ class Time
   # :include: doc/time/mon-min.rdoc
   # :include: doc/time/sec.rdoc
   # :include: doc/time/zone_and_in.rdoc
+  # - +precision+: maximum effective digits in sub-second part, default is 9.
+  #   More digits will be truncated, as other operations of \Time.
+  #   Ignored unless the first argument is a string.
   #
-  def initialize(year = (now = true), mon = (str = year; nil), mday = nil, hour = nil, min = nil, sec = nil, zone = nil, in: nil)
+  def initialize(year = (now = true), mon = (str = year; nil), mday = nil, hour = nil, min = nil, sec = nil, zone = nil,
+                 in: nil, precision: 9)
     if zone
       if Primitive.arg!(:in)
         raise ArgumentError, "timezone argument given as positional and keyword arguments"
@@ -310,7 +316,7 @@ class Time
       return Primitive.time_init_now(zone)
     end
 
-    if str and Primitive.time_init_parse(str, zone)
+    if str and Primitive.time_init_parse(str, zone, precision)
       return self
     end
 

--- a/timev.rb
+++ b/timev.rb
@@ -260,18 +260,34 @@ class Time
   #   Time.at(946702800, 500000000, :nsec, in: '+09:00')       # => 2000-01-01 14:00:00.5 +0900
   #   Time.at(946702800, 500000000, :nanosecond, in: '+09:00') # => 2000-01-01 14:00:00.5 +0900
   #
+  # _String_
+  #
+  # This form accepts a string representing a time, and an optional
+  # keyword argument +in+ and +precision+:
+  #
+  #   Time.at('2000-12-31 23:59:59.5')                   # => 2000-12-31 23:59:59.5 -0600
+  #   Time.at('2000-12-31 23:59:59.5 +0900')             # => 2000-12-31 23:59:59.5 +0900
+  #   Time.at('2000-12-31 23:59:59.5', in: '+0900')      # => 2000-12-31 23:59:59.5 +0900
+  #   Time.at('2000-12-31 23:59:59.5')                   # => 2000-12-31 23:59:59.5 -0600
+  #
+  #   Time.at('2000-12-31 23:59:59.56789')               # => 2000-12-31 23:59:59.56789 -0600
+  #   Time.at('2000-12-31 23:59:59.56789', precision: 3) # => 2000-12-31 23:59:59.567 -0600
+  #
   # Parameters:
   # :include: doc/time/sec_i.rdoc
   # :include: doc/time/msec.rdoc
   # :include: doc/time/usec.rdoc
   # :include: doc/time/nsec.rdoc
   # :include: doc/time/in.rdoc
+  # - +precision+: maximum effective digits in sub-second part, default is 9.
+  #   More digits will be truncated, as other operations of \Time.
+  #   Ignored unless the first argument is a string.
   #
-  def self.at(time, subsec = false, unit = :microsecond, in: nil)
+  def self.at(time, subsec = false, unit = :microsecond, in: nil, precision: 9)
     if Primitive.mandatory_only?
       Primitive.time_s_at1(time)
     else
-      Primitive.time_s_at(time, subsec, unit, Primitive.arg!(:in))
+      Primitive.time_s_at(time, subsec, unit, Primitive.arg!(:in), precision)
     end
   end
 
@@ -286,11 +302,6 @@ class Time
   #   Time.new(2000)                                 # => 2000-01-01 00:00:00 -0600
   #   Time.new(2000, 12, 31, 23, 59, 59.5)           # => 2000-12-31 23:59:59.5 -0600
   #   Time.new(2000, 12, 31, 23, 59, 59.5, '+09:00') # => 2000-12-31 23:59:59.5 +0900
-  #   Time.new('2000-12-31 23:59:59.5')              # => 2000-12-31 23:59:59.5 -0600
-  #   Time.new('2000-12-31 23:59:59.5 +0900')        # => 2000-12-31 23:59:59.5 +0900
-  #   Time.new('2000-12-31 23:59:59.5', in: '+0900') # => 2000-12-31 23:59:59.5 +0900
-  #   Time.new('2000-12-31 23:59:59.5')              # => 2000-12-31 23:59:59.5 -0600
-  #   Time.new('2000-12-31 23:59:59.56789', precision: 3) # => 2000-12-31 23:59:59.567 -0600
   #
   # Parameters:
   #
@@ -298,12 +309,8 @@ class Time
   # :include: doc/time/mon-min.rdoc
   # :include: doc/time/sec.rdoc
   # :include: doc/time/zone_and_in.rdoc
-  # - +precision+: maximum effective digits in sub-second part, default is 9.
-  #   More digits will be truncated, as other operations of \Time.
-  #   Ignored unless the first argument is a string.
   #
-  def initialize(year = (now = true), mon = (str = year; nil), mday = nil, hour = nil, min = nil, sec = nil, zone = nil,
-                 in: nil, precision: 9)
+  def initialize(year = (now = true), mon = nil, mday = nil, hour = nil, min = nil, sec = nil, zone = nil, in: nil)
     if zone
       if Primitive.arg!(:in)
         raise ArgumentError, "timezone argument given as positional and keyword arguments"
@@ -316,10 +323,6 @@ class Time
       return Primitive.time_init_now(zone)
     end
 
-    if str and Primitive.time_init_parse(str, zone, precision)
-      return self
-    end
-
-    Primitive.time_init_args(year, mon, mday, hour, min, sec, nil, zone)
+    Primitive.time_init_args(year, mon, mday, hour, min, sec, zone)
   end
 end

--- a/timev.rb
+++ b/timev.rb
@@ -286,6 +286,9 @@ class Time
   #   Time.new(2000)                                 # => 2000-01-01 00:00:00 -0600
   #   Time.new(2000, 12, 31, 23, 59, 59.5)           # => 2000-12-31 23:59:59.5 -0600
   #   Time.new(2000, 12, 31, 23, 59, 59.5, '+09:00') # => 2000-12-31 23:59:59.5 +0900
+  #   Time.new('2000-12-31 23:59:59.5')              # => 2000-12-31 23:59:59.5 -0600
+  #   Time.new('2000-12-31 23:59:59.5 +0900')        # => 2000-12-31 23:59:59.5 +0900
+  #   Time.new('2000-12-31 23:59:59.5', in: '+0900') # => 2000-12-31 23:59:59.5 +0900
   #
   # Parameters:
   #
@@ -294,7 +297,7 @@ class Time
   # :include: doc/time/sec.rdoc
   # :include: doc/time/zone_and_in.rdoc
   #
-  def initialize(year = (now = true), mon = nil, mday = nil, hour = nil, min = nil, sec = nil, zone = nil, in: nil)
+  def initialize(year = (now = true), mon = (str = year; nil), mday = nil, hour = nil, min = nil, sec = nil, zone = nil, in: nil)
     if zone
       if Primitive.arg!(:in)
         raise ArgumentError, "timezone argument given as positional and keyword arguments"
@@ -307,6 +310,10 @@ class Time
       return Primitive.time_init_now(zone)
     end
 
-    Primitive.time_init_args(year, mon, mday, hour, min, sec, zone)
+    if str and Primitive.time_init_parse(str, zone)
+      return self
+    end
+
+    Primitive.time_init_args(year, mon, mday, hour, min, sec, nil, zone)
   end
 end


### PR DESCRIPTION
`Time.at` now parses strings such as the result of `Time#inspect` and restricted ISO-8601 formats.

Based on #4825.