### PR TITLE
YJIT: Enable out of memory tests

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -2450,10 +2450,10 @@ assert_equal 'ok', %q{
   RubyVM::YJIT.simulate_oom! if defined?(RubyVM::YJIT)
 
   nimai(false)
-} if false  # disabled for now since OOM crashes in the test harness
+}
 
-# block invalidation while out of memory
 assert_equal 'new', %q{
+  # test block invalidation while out of memory
   def foo
     :old
   end
@@ -2472,7 +2472,7 @@ assert_equal 'new', %q{
   end
 
   test
-} if false # disabled for now since OOM crashes in the test harness
+}
 
 assert_equal 'ok', %q{
   # Try to compile new method while OOM


### PR DESCRIPTION
```
As of [1] and [2], YJIT has enough support for out of memory conditions
to pass these two basic tests.

OOM code paths are prone to bugs since they are rarely exercised in
common workloads. We might want to add CI runs that stress test these
code paths. Maybe outside of GitHub Actions for capacity reasons.


[1]: f41b4d44f95978dfa97af04af00055dc3fbf7978
[2]: b5b6ab4194f16e96ee5004288cc469ac1bca41a3
```