### PR TITLE
Allow configuring TRANSIENT_HEAP_TOTAL_SIZE at build-time

### DIFF
--- a/transient_heap.c
+++ b/transient_heap.c
@@ -59,7 +59,9 @@
 
                                           /*  K      M */
 #define TRANSIENT_HEAP_BLOCK_SIZE  (1024 *   32       ) /* 32KB int16_t */
+#ifndef TRANSIENT_HEAP_TOTAL_SIZE
 #define TRANSIENT_HEAP_TOTAL_SIZE  (1024 * 1024 *   32) /* 32 MB */
+#endif
 #define TRANSIENT_HEAP_ALLOC_MAX   (1024 *    2       ) /* 2 KB */
 #define TRANSIENT_HEAP_BLOCK_NUM   (TRANSIENT_HEAP_TOTAL_SIZE / TRANSIENT_HEAP_BLOCK_SIZE)
 #define TRANSIENT_HEAP_USABLE_SIZE (TRANSIENT_HEAP_BLOCK_SIZE - sizeof(struct transient_heap_block_header))


### PR DESCRIPTION
Some platforms (e.g. Fastly Compute@Edge limits heap size up to 32MB) have memory resource limits, but theap's memory area is too large for such situations.
So allow configuring the size at build-time.