### PR TITLE
YJIT: Fix leak in compilation loop

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -1,3 +1,15 @@
+assert_normal_exit %q{
+  # regression test for a leak caught by an asert on --yjit-call-threshold=2
+  Foo = 1
+
+  eval("def foo = [#{(['Foo,']*256).join}]")
+
+  foo
+  foo
+
+  Object.send(:remove_const, :Foo)
+}
+
 assert_equal '[nil, nil, nil, nil, nil, nil]', %q{
   [NilClass, TrueClass, FalseClass, Integer, Float, Symbol].each do |klass|
     klass.class_eval("def foo = @foo")

--- a/yjit_core.c
+++ b/yjit_core.c
@@ -747,15 +747,14 @@ gen_block_version(blockid_t blockid, const ctx_t *start_ctx, rb_execution_contex
 
     // Generate code for the first block
     block = gen_single_block(blockid, start_ctx, ec);
-    batch_success = block && compiled_count < MAX_PER_BATCH;
-
-    if (batch_success) {
+    if (block) {
         // Track the block
         add_block_version(block);
 
         batch[compiled_count] = block;
         compiled_count++;
     }
+    batch_success = block;
 
     // For each successor block to compile
     while (batch_success) {
@@ -780,8 +779,12 @@ gen_block_version(blockid_t blockid, const ctx_t *start_ctx, rb_execution_contex
         // Generate code for the current block using context from the last branch.
         blockid_t requested_id = last_branch->targets[0];
         const ctx_t *requested_ctx = &last_branch->target_ctxs[0];
-        block = gen_single_block(requested_id, requested_ctx, ec);
-        batch_success = block && compiled_count < MAX_PER_BATCH;
+
+        batch_success = compiled_count < MAX_PER_BATCH;
+        if (batch_success) {
+            block = gen_single_block(requested_id, requested_ctx, ec);
+            batch_success = block;
+        }
 
         // If the batch failed, stop
         if (!batch_success) {


### PR DESCRIPTION
Previously, when there are too many blocks in a batch, the last block in
the batch is not tracked in the array of batches and not freed.