### PR TITLE
`Ractor.make_shareable` checks proc's self

### DIFF
--- a/vm.c
+++ b/vm.c
@@ -1181,6 +1181,10 @@ rb_proc_ractor_make_shareable(VALUE self)
         rb_proc_t *proc = (rb_proc_t *)RTYPEDDATA_DATA(self);
         if (proc->block.type != block_type_iseq) rb_raise(rb_eRuntimeError, "not supported yet");
 
+        if (!rb_ractor_shareable_p(vm_block_self(&proc->block))) {
+            rb_raise(rb_eRactorIsolationError, "Proc's self is not shareable");
+        }
+
         VALUE read_only_variables = Qfalse;
 
         if (iseq->body->outer_variables) {


### PR DESCRIPTION
`Ractor.make_shareable(proc_obj)` raises an `IsolationError`
if the self of `proc_obj` is not a shareable object.

[Bug #18243]