### PR TITLE
[DOC] Stop mentioning Qfalse==0 for C extensions

### DIFF
--- a/doc/extension.ja.rdoc
+++ b/doc/extension.ja.rdoc
@@ -623,7 +623,7 @@ Qnil ::
 
   C言語から見た「nil」．
 
-RTEST(obj)というマクロはobjがQfalseとQnilの場合限り0を返します．
+RTEST(obj)というマクロはobjがQfalseかQnilのとき0を返します．
 
 === CとRubyで共有される大域変数
 

--- a/doc/extension.ja.rdoc
+++ b/doc/extension.ja.rdoc
@@ -617,11 +617,13 @@ C言語とRubyの間で情報を共有する方法について解説します．
 Qtrue ::
 Qfalse ::
 
-  真偽値．QfalseはC言語でも偽とみなされます(つまり0)．
+  真偽値．C言語から見た「true」と「false」．
 
 Qnil ::
 
   C言語から見た「nil」．
+
+RTEST(obj)というマクロはobjがQfalseとQnilの場合限り0を返します．
 
 === CとRubyで共有される大域変数
 


### PR DESCRIPTION
See [Feature [#18397](https://bugs.ruby-lang.org/issues/18397)] for detail. Follow up for
b859397e1b25a3f7847a380e7dd7db62f94fbe66.

[ci skip]