### PR TITLE
intern/select/posix.h: remove unused parameter from `rb_fd_dup`

### DIFF
--- a/include/ruby/internal/intern/select/posix.h
+++ b/include/ruby/internal/intern/select/posix.h
@@ -95,11 +95,10 @@ RBIMPL_ATTR_NOALIAS()
  *
  * @param[out]  dst   Target fdset.
  * @param[in]   src   Source fdset.
- * @param[in]   n     Unused parameter.
  * @post        `dst` is a copy of `src`.
  */
 static inline void
-rb_fd_dup(rb_fdset_t *dst, const fd_set *src, int n)
+rb_fd_dup(rb_fdset_t *dst, const fd_set *src)
 {
     *dst = *src;
 }


### PR DESCRIPTION
wasm32-wasi uses `select/posix.h` variant but it cannot be compiled due to the mismatch of the number of parameters in rb_fd_dup.
`select/largesize.h` and `select/win32.h` variants takes two parameters, but `select/posix.h` has extra unused parameter `n`.
https://github.com/ruby/ruby/blob/d6817d05380afb18bd2af0ca43fdd4b62f0a8a0c/thread.c#L4048
https://github.com/ruby/ruby/blob/d6817d05380afb18bd2af0ca43fdd4b62f0a8a0c/include/ruby/internal/intern/select/win32.h#L181

This unused parameter seems to be accidentally introduced by https://github.com/ruby/ruby/commit/9e6e39c
