### PR TITLE
Add documentation for hash value omission syntax

### DIFF
--- a/doc/syntax/calling_methods.rdoc
+++ b/doc/syntax/calling_methods.rdoc
@@ -210,6 +210,24 @@ definition.  If a keyword argument is given that the method did not list,
 and the method definition does not accept arbitrary keyword arguments, an
 ArgumentError will be raised.
 
+Keyword argument value can be omitted, meaning the value will be be fetched
+from the context by the name of the key
+
+  keyword1 = 'some value'
+  my_method(positional1, keyword1:)
+  # ...is the same as
+  my_method(positional1, keyword1: keyword1)
+
+Be aware that when method parenthesis are omitted, too, the parsing order might
+be unexpected:
+
+  my_method positional1, keyword1:
+
+  some_other_expression
+
+  # ...is actually parsed as
+  my_method(positional1, keyword1: some_other_expression)
+
 === Block Argument
 
 The block argument sends a closure from the calling scope to the method.

--- a/doc/syntax/literals.rdoc
+++ b/doc/syntax/literals.rdoc
@@ -356,6 +356,14 @@ is equal to
 
   { :"a 1" => 1, :"b 2" => 2 }
 
+Hash values can be omitted, meaning that value will be fetched from the context
+by the name of the key:
+
+  x = 100
+  y = 200
+  h = { x:, y: }
+  #=> {:x=>100, :y=>200}
+
 See Hash for the methods you may use with a hash.
 
 == \Range Literals

--- a/hash.c
+++ b/hash.c
@@ -6565,6 +6565,14 @@ env_dup(VALUE obj)
  *    # Raises SyntaxError (syntax error, unexpected ':', expecting =>):
  *    h = {0: 'zero'}
  *
+ *  Hash value can be omitted, meaning that value will be fetched from the context
+ *  by the name of the key:
+ *
+ *    x = 0
+ *    y = 100
+ *    h = {x:, y:}
+ *    h # => {:x=>0, :y=>100}
+ *
  *  === Common Uses
  *
  *  You can use a \Hash to give names to objects:


### PR DESCRIPTION
What the subject says. Adds doc to:
* method call syntax description
* hash literal syntax decriptioin
* `Hash` class docs