### PR TITLE
btest: assign $stderr = STDOUT instead of IO#reopen to be more portable

### DIFF
--- a/bootstraptest/test_eval.rb
+++ b/bootstraptest/test_eval.rb
@@ -218,7 +218,7 @@ assert_equal %q{[10, main]}, %q{
 
 %w[break next redo].each do |keyword|
   assert_match %r"Can't escape from eval with #{keyword}\b", %{
-    STDERR.reopen(STDOUT)
+    $stderr = STDOUT
     begin
       eval "0 rescue #{keyword}"
     rescue SyntaxError => e
@@ -228,7 +228,7 @@ assert_equal %q{[10, main]}, %q{
 end
 
 assert_normal_exit %q{
-  STDERR.reopen(STDOUT)
+  $stderr = STDOUT
   class Foo
      def self.add_method
        class_eval("def some-bad-name; puts 'hello' unless @some_variable.some_function(''); end")

--- a/bootstraptest/test_jump.rb
+++ b/bootstraptest/test_jump.rb
@@ -147,7 +147,7 @@ assert_equal %q{131}, %q{
   }
 }
 assert_match %r{Invalid retry}, %q{
-STDERR.reopen(STDOUT)
+$stderr = STDOUT
 begin
   eval %q{
     1.times{
@@ -297,7 +297,7 @@ assert_equal "true", %q{
 }, '[ruby-core:21379]'
 
 assert_match %r{Invalid yield}, %q{
-STDERR.reopen(STDOUT)
+$stderr = STDOUT
 begin
   eval %q{
     class Object

--- a/bootstraptest/test_syntax.rb
+++ b/bootstraptest/test_syntax.rb
@@ -628,7 +628,7 @@ assert_equal '2', %q{
 }
 
 assert_match /invalid multibyte char/, %q{
-  STDERR.reopen(STDOUT)
+  $stderr = STDOUT
   eval("\"\xf0".force_encoding("utf-8"))
 }, '[ruby-dev:32429]'
 


### PR DESCRIPTION
`IO#reopen` internally uses dup syscall but some platforms don't support
the syscall. re-assigning `$stderr` is enough to capture the interpreter's
errors and warnings. In this way, dup is unnecessary.