### PR TITLE
prohibit load by `autoload` on non-main Ractor

### DIFF
--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -211,6 +211,17 @@ assert_equal '[:a, :b, :c, :d, :e, :f, :g]', %q{
   Ractor.make_shareable(closure).call
 }
 
+# Now autoload in non-main Ractor is not supported
+assert_equal 'ok', %q{
+  autoload :Foo, 'foo.rb'
+  r = Ractor.new do
+    p Foo
+  rescue Ractor::UnsafeError
+    :ok
+  end
+  r.take
+}
+
 ###
 ###
 # Ractor still has several memory corruption so skip huge number of tests

--- a/variable.c
+++ b/variable.c
@@ -2553,6 +2553,10 @@ rb_autoload_load(VALUE mod, ID id)
     src = rb_sourcefile();
     if (src && loading && strcmp(src, loading) == 0) return Qfalse;
 
+    if (UNLIKELY(!rb_ractor_main_p())) {
+        rb_raise(rb_eRactorUnsafeError, "require by autoload on non-main Ractor is not supported (%s)", rb_id2name(id));
+    }
+
     if ((ce = rb_const_lookup(mod, id))) {
         flag = ce->flag & (CONST_DEPRECATED | CONST_VISIBILITY_MASK);
     }


### PR DESCRIPTION
fix [Bug #18120]