### PR TITLE
Fix docs rendering for Process._fork

### DIFF
--- a/process.c
+++ b/process.c
@@ -4349,8 +4349,8 @@ rb_call_proc__fork(void)
  *     Process._fork   -> integer
  *
  *  An internal API for fork. Do not call this method directly.
- *  Currently, this is called via <tt>Kernel.#fork</tt>, +Process.fork+, and
- *  +popen+ with <tt>"-"</tt>.
+ *  Currently, this is called via Kernel#fork, Process.fork, and
+ *  IO.popen with <tt>"-"</tt>.
  *
  *  This method is not for casual code but for application monitoring
  *  libraries. You can add custom code before and after fork events

--- a/process.c
+++ b/process.c
@@ -4349,8 +4349,8 @@ rb_call_proc__fork(void)
  *     Process._fork   -> integer
  *
  *  An internal API for fork. Do not call this method directly.
- *  Currently, this is called via +Kernel.#fork+, +Process.fork+, and
- *  +popen+ with +"-"+.
+ *  Currently, this is called via <tt>Kernel.#fork</tt>, +Process.fork+, and
+ *  +popen+ with <tt>"-"</tt>.
  *
  *  This method is not for casual code but for application monitoring
  *  libraries. You can add custom code before and after fork events


### PR DESCRIPTION
I'm not sure why, but docs weren't rendering properly for `Process._fork`.

Before x After

![image](https://user-images.githubusercontent.com/20938712/146048243-114f9849-425f-4b8f-8808-bcdabb29b3f5.png)
![image](https://user-images.githubusercontent.com/20938712/146056266-4b95847f-e2ee-425c-a274-fdfa37fbe8c2.png)

