### PR TITLE
Avoid unnecessary BOP invalidation

### DIFF
--- a/vm.c
+++ b/vm.c
@@ -1885,9 +1885,11 @@ rb_vm_check_redefinition_opt_method(const rb_method_entry_t *me, VALUE klass)
     if (vm_redefinition_check_method_type(me->def)) {
         if (st_lookup(vm_opt_method_def_table, (st_data_t)me->def, &bop)) {
             int flag = vm_redefinition_check_flag(klass);
-            rb_yjit_bop_redefined(klass, me, (enum ruby_basic_operators)bop);
-	    ruby_vm_redefined_flag[bop] |= flag;
-	}
+            if (flag != 0) {
+                rb_yjit_bop_redefined(klass, me, (enum ruby_basic_operators)bop);
+                ruby_vm_redefined_flag[bop] |= flag;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
This fixes two cases where we would unnecessarily mark BOPs as overridden (one specific to YJIT). This didn't result in any behaviour changes (as BOPs should be invisible to users) but could result in slower code (in uncommon scenarios).

First, YJIT would consider a BOP invalidation on subclasses, rather than on the specific classes BOPs should apply to. This is fixed by checking that flags isn't 0 (which I did for both cases for readability).

Second, BOPs would be invalidated if their `alias` was modified, because they shared the same definition. This can be avoided by comparing against `original_id`. This check is done in `vm_redefinition_check_method_type` which also ensures we have no aliases when first registering the BOPs.

This was spotted because Rails [has a subclass of Hash which modifies an alias](https://github.com/rails/rails/blob/main/activesupport/lib/active_support/ordered_options.rb#L31-L33) which was causing YJIT to invalidate some blocks. I think these blocks would later be compiled successfully, so there shouldn't be a substantial performance difference.