### PR TITLE
YJIT: Remove unused branch_t::src_ctx field

### DIFF
--- a/yjit_core.c
+++ b/yjit_core.c
@@ -658,7 +658,7 @@ make_branch_entry(block_t *block, const ctx_t *src_ctx, branchgen_fn gen_fn)
     branch_t *branch = calloc(1, sizeof(branch_t));
 
     branch->block = block;
-    branch->src_ctx = *src_ctx;
+    (void)src_ctx; // Unused for now
     branch->gen_fn = gen_fn;
     branch->shape = SHAPE_DEFAULT;
 

--- a/yjit_core.h
+++ b/yjit_core.h
@@ -196,7 +196,8 @@ typedef struct yjit_branch_entry
     uint8_t *end_addr;
 
     // Context right after the branch instruction
-    ctx_t src_ctx;
+    // Unused for now.
+    // ctx_t src_ctx;
 
     // Branch target blocks and their contexts
     blockid_t targets[2];


### PR DESCRIPTION
No one reads it at the moment, and it's heap allocated.