### PR TITLE
YJIT: Allow calling iseq with mixed optional and keyword args and fix required kwarg check

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -2234,6 +2234,14 @@ assert_equal '[:ok]', %q{
   5.times.map { kwargs() rescue :ok }.uniq
 }
 
+assert_equal '[:ok]', %q{
+  def kwargs(a:, b: nil)
+    value
+  end
+
+  5.times.map { kwargs(b: 123) rescue :ok }.uniq
+}
+
 assert_equal '[[1, 2]]', %q{
   def kwargs(left:, right:)
     [left, right]

--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -2226,6 +2226,14 @@ assert_equal '[1]', %q{
   5.times.map { kwargs(value: 1) }.uniq
 }
 
+assert_equal '[:ok]', %q{
+  def kwargs(value:)
+    value
+  end
+
+  5.times.map { kwargs() rescue :ok }.uniq
+}
+
 assert_equal '[[1, 2]]', %q{
   def kwargs(left:, right:)
     [left, right]
@@ -2246,6 +2254,24 @@ assert_equal '[[1, 2]]', %q{
 
   5.times.map { kwargs(1, kwarg: 2) }.uniq
 }
+
+# optional and keyword args
+assert_equal '[[1, 2, 3]]', %q{
+  def opt_and_kwargs(a, b=2, c: nil)
+    [a,b,c]
+  end
+
+  5.times.map { opt_and_kwargs(1, c: 3) }.uniq
+}
+
+assert_equal '[[1, 2, 3]]', %q{
+  def opt_and_kwargs(a, b=nil, c: nil)
+    [a,b,c]
+  end
+
+  5.times.map { opt_and_kwargs(1, 2, c: 3) }.uniq
+}
+
 
 # leading and keyword arguments are swapped into the right order
 assert_equal '[[1, 2, 3, 4, 5, 6]]', %q{

--- a/test/ruby/test_yjit.rb
+++ b/test/ruby/test_yjit.rb
@@ -506,6 +506,17 @@ class TestYJIT < Test::Unit::TestCase
     RUBY
   end
 
+  def test_optarg_and_kwarg
+    assert_no_exits(<<~'RUBY')
+      def opt_and_kwarg(a, b=nil, c: nil)
+      end
+
+      2.times do
+        opt_and_kwarg(1, 2, c: 3)
+      end
+    RUBY
+  end
+
   def test_ctx_different_mappings
     # regression test simplified from URI::Generic#hostname=
     assert_compiles(<<~'RUBY', frozen_string_literal: true)


### PR DESCRIPTION
This started as a cleanup to combine the branches we had in `gen_send_iseq`

Previously we mirrored the fast paths the interpreter has for having either kwargs or optional args. The first commit aims to combine those cases and reduce complexity.

Though this allows calling iseqs which have have both optional and keyword arguments, it requires that all optional arguments are specified when there are keyword arguments, since unspecified optional arguments appear before the kwargs. Support for this can be added a in a future PR.

The second commit fixes a bug found while adding additional tests to the changes to gen_send_iseq. Previously, YJIT would not check that all the required keywords were specified in the case that there were optional arguments specified. In
this case YJIT would incorrectly call the method with invalid arguments. This is solved by counting and verifying that all required kwargs are specified.

I'm pleased that this ended up with about 20 fewer lines of code 🙂.