### PR TITLE
`ENV` ivars should not be accessible from ractors

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -6657,7 +6657,7 @@ const rb_data_type_t env_data_type = {
     "ENV",
     {
         NULL,
-        RUBY_DEFAULT_FREE,
+        NULL,
         NULL,
         NULL,
     },

--- a/hash.c
+++ b/hash.c
@@ -6653,7 +6653,7 @@ env_dup(VALUE obj)
     rb_raise(rb_eTypeError, "Cannot dup ENV, use ENV.to_h to get a copy of ENV as a hash");
 }
 
-const rb_data_type_t env_data_type = {
+static const rb_data_type_t env_data_type = {
     "ENV",
     {
         NULL,

--- a/hash.c
+++ b/hash.c
@@ -6653,6 +6653,17 @@ env_dup(VALUE obj)
     rb_raise(rb_eTypeError, "Cannot dup ENV, use ENV.to_h to get a copy of ENV as a hash");
 }
 
+const rb_data_type_t env_data_type = {
+    "ENV",
+    {
+        NULL,
+        RUBY_DEFAULT_FREE,
+        NULL,
+        NULL,
+    },
+    0, 0, RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
+};
+
 /*
  *  A \Hash maps each of its unique keys to a specific value.
  *
@@ -7308,7 +7319,7 @@ Init_Hash(void)
      * envtbl = rb_define_class("ENV", rb_cObject);
      */
     origenviron = environ;
-    envtbl = rb_obj_alloc(rb_cObject);
+    envtbl = TypedData_Wrap_Struct(rb_cObject, &env_data_type, NULL);
     rb_extend_object(envtbl, rb_mEnumerable);
     FL_SET_RAW(envtbl, RUBY_FL_SHAREABLE);
 


### PR DESCRIPTION
The `ENV` object can have instance variables like other objects,
but they should be accessed only on the main ractor.

fix https://github.com/ruby/ruby/pull/5263#issuecomment-995585766