### PR TITLE
YJIT: Implement intern

### DIFF
--- a/test/ruby/test_yjit.rb
+++ b/test/ruby/test_yjit.rb
@@ -256,6 +256,11 @@ class TestYJIT < Test::Unit::TestCase
     assert_no_exits('/#{true}/')
   end
 
+  def test_compile_dynamic_symbol
+    assert_compiles(':"#{"foo"}"', insns: %i[intern])
+    assert_compiles('s = "bar"; :"foo#{s}"', insns: %i[intern])
+  end
+
   def test_getlocal_with_level
     assert_compiles(<<~RUBY, insns: %i[getlocal opt_plus], result: [[7]])
       def foo(foo, bar)

--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -4514,6 +4514,25 @@ gen_toregexp(jitstate_t *jit, ctx_t *ctx, codeblock_t *cb)
 }
 
 static codegen_status_t
+gen_intern(jitstate_t *jit, ctx_t *ctx, codeblock_t *cb)
+{
+    // Save the PC and SP because we might allocate
+    jit_prepare_routine_call(jit, ctx, REG0);
+
+    x86opnd_t str = ctx_stack_pop(ctx, 1);
+
+    mov(cb, C_ARG_REGS[0], str);
+
+    call_ptr(cb, REG0, (void *)&rb_str_intern);
+
+    // Push the return value
+    x86opnd_t stack_ret = ctx_stack_push(ctx, TYPE_UNKNOWN);
+    mov(cb, stack_ret, RAX);
+
+    return YJIT_KEEP_COMPILING;
+}
+
+static codegen_status_t
 gen_getspecial(jitstate_t *jit, ctx_t *ctx, codeblock_t *cb)
 {
     // This takes two arguments, key and type
@@ -5024,6 +5043,7 @@ yjit_init_codegen(void)
     yjit_reg_op(BIN(anytostring), gen_anytostring);
     yjit_reg_op(BIN(objtostring), gen_objtostring);
     yjit_reg_op(BIN(toregexp), gen_toregexp);
+    yjit_reg_op(BIN(intern), gen_intern);
     yjit_reg_op(BIN(getspecial), gen_getspecial);
     yjit_reg_op(BIN(getclassvariable), gen_getclassvariable);
     yjit_reg_op(BIN(setclassvariable), gen_setclassvariable);


### PR DESCRIPTION
`intern` showed up in the top 20 most frequent exit ops (granted with a
fairly small percentage) in a benchmark run by @jhawthorn on
github/github.

This implementation is similar to gen_anytostring, but with 1
stack pop instead of 2.