### PR TITLE
Various IO::Buffer improvements.

### DIFF
--- a/include/ruby/internal/intern/file.h
+++ b/include/ruby/internal/intern/file.h
@@ -198,6 +198,8 @@ int rb_is_absolute_path(const char *path);
  * @exception   rb_eFrozenError      `file` is frozen.
  * @exception   rb_eIOError          `file` is closed.
  * @exception   rb_eSystemCallError  Permission denied etc.
+ * @exception   rb_eNoMethodError    The given non-file object doesn't respond
+ *                                   to `#size`.
  * @return      The size of the passed file.
  * @note        Passing a non-regular file such as a UNIX domain socket to this
  *              function  is   not  a  failure.    But  the  return   value  is

--- a/include/ruby/io/buffer.h
+++ b/include/ruby/io/buffer.h
@@ -27,20 +27,24 @@ RUBY_EXTERN size_t RUBY_IO_BUFFER_DEFAULT_SIZE;
 
 enum rb_io_buffer_flags {
     // The memory in the buffer is owned by someone else.
-    RB_IO_BUFFER_EXTERNAL = 0,
+    // More specifically, it means that someone else owns the buffer and we shouldn't try to resize it.
+    RB_IO_BUFFER_EXTERNAL = 1,
     // The memory in the buffer is allocated internally.
-    RB_IO_BUFFER_INTERNAL = 1,
+    RB_IO_BUFFER_INTERNAL = 2,
     // The memory in the buffer is mapped.
-    RB_IO_BUFFER_MAPPED = 2,
+    // A non-private mapping is marked as external.
+    RB_IO_BUFFER_MAPPED = 4,
 
     // The buffer is locked and cannot be resized.
-    RB_IO_BUFFER_LOCKED = 16,
+    // More specifically, it means we can't change the base address or size.
+    // A buffer is typically locked before a system call that uses the data.
+    RB_IO_BUFFER_LOCKED = 32,
 
     // The buffer mapping is private and will not impact other processes or the underlying file.
-    RB_IO_BUFFER_PRIVATE = 32,
+    RB_IO_BUFFER_PRIVATE = 64,
 
     // The buffer is read-only and cannot be modified.
-    RB_IO_BUFFER_IMMUTABLE = 64
+    RB_IO_BUFFER_IMMUTABLE = 128
 };
 
 enum rb_io_buffer_endian {

--- a/include/ruby/io/buffer.h
+++ b/include/ruby/io/buffer.h
@@ -44,7 +44,7 @@ enum rb_io_buffer_flags {
     RB_IO_BUFFER_PRIVATE = 64,
 
     // The buffer is read-only and cannot be modified.
-    RB_IO_BUFFER_IMMUTABLE = 128
+    RB_IO_BUFFER_READONLY = 128
 };
 
 enum rb_io_buffer_endian {
@@ -71,8 +71,10 @@ VALUE rb_io_buffer_lock(VALUE self);
 VALUE rb_io_buffer_unlock(VALUE self);
 VALUE rb_io_buffer_free(VALUE self);
 
-void rb_io_buffer_get_mutable(VALUE self, void **base, size_t *size);
-void rb_io_buffer_get_immutable(VALUE self, const void **base, size_t *size);
+int rb_io_buffer_readonly_p(VALUE self);
+
+void rb_io_buffer_get(VALUE self, void **base, size_t *size);
+void rb_io_buffer_get_readonly(VALUE self, const void **base, size_t *size);
 
 VALUE rb_io_buffer_transfer(VALUE self);
 void rb_io_buffer_resize(VALUE self, size_t size);

--- a/include/ruby/io/buffer.h
+++ b/include/ruby/io/buffer.h
@@ -74,7 +74,6 @@ VALUE rb_io_buffer_free(VALUE self);
 void rb_io_buffer_get_mutable(VALUE self, void **base, size_t *size);
 void rb_io_buffer_get_immutable(VALUE self, const void **base, size_t *size);
 
-size_t rb_io_buffer_copy(VALUE self, VALUE source, size_t offset);
 VALUE rb_io_buffer_transfer(VALUE self);
 void rb_io_buffer_resize(VALUE self, size_t size);
 void rb_io_buffer_clear(VALUE self, uint8_t value, size_t offset, size_t length);

--- a/io_buffer.c
+++ b/io_buffer.c
@@ -279,7 +279,12 @@ rb_io_buffer_type_for(VALUE klass, VALUE string)
 
     rb_str_locktmp(string);
 
-    io_buffer_initialize(data, RSTRING_PTR(string), RSTRING_LEN(string), RB_IO_BUFFER_EXTERNAL, string);
+    enum rb_io_buffer_flags flags = RB_IO_BUFFER_EXTERNAL;
+
+    if (RB_OBJ_FROZEN(string))
+        flags |= RB_IO_BUFFER_IMMUTABLE;
+
+    io_buffer_initialize(data, RSTRING_PTR(string), RSTRING_LEN(string), flags, string);
 
     return instance;
 }

--- a/io_buffer.c
+++ b/io_buffer.c
@@ -1180,9 +1180,11 @@ io_buffer_clear(int argc, VALUE *argv, VALUE self)
         offset = NUM2SIZET(argv[1]);
     }
 
-    size_t length = data->size;
+    size_t length;
     if (argc >= 3) {
         length = NUM2SIZET(argv[2]);
+    } else {
+        length = data->size - offset;
     }
 
     rb_io_buffer_clear(self, value, offset, length);

--- a/io_buffer.c
+++ b/io_buffer.c
@@ -1125,7 +1125,7 @@ io_buffer_get_string(int argc, VALUE *argv, VALUE self)
 
     size_t offset = 0;
     size_t length = data->size;
-    rb_encoding *encoding = NULL;
+    rb_encoding *encoding = rb_ascii8bit_encoding();
 
     if (argc >= 1) {
         offset = NUM2SIZET(argv[0]);

--- a/io_buffer.c
+++ b/io_buffer.c
@@ -322,6 +322,9 @@ io_buffer_map(int argc, VALUE *argv, VALUE klass)
     }
 
     VALUE io = argv[0];
+    if (!RB_TYPE_P(io, T_FILE)) {
+        rb_raise(rb_eArgError, "Must be file/io!");
+    }
 
     size_t size;
     if (argc >= 2) {

--- a/scheduler.c
+++ b/scheduler.c
@@ -264,7 +264,7 @@ rb_fiber_scheduler_io_read_memory(VALUE scheduler, VALUE io, void *base, size_t 
 VALUE
 rb_fiber_scheduler_io_write_memory(VALUE scheduler, VALUE io, const void *base, size_t size, size_t length)
 {
-    VALUE buffer = rb_io_buffer_new((void*)base, size, RB_IO_BUFFER_LOCKED|RB_IO_BUFFER_IMMUTABLE);
+    VALUE buffer = rb_io_buffer_new((void*)base, size, RB_IO_BUFFER_LOCKED|RB_IO_BUFFER_READONLY);
 
     VALUE result = rb_fiber_scheduler_io_write(scheduler, io, buffer, length);
 

--- a/test/fiber/scheduler.rb
+++ b/test/fiber/scheduler.rb
@@ -288,7 +288,7 @@ class IOBufferScheduler < Scheduler
       else
         break unless result
 
-        buffer.copy(result, offset)
+        buffer.set_string(result, offset)
 
         size = result.bytesize
         offset += size
@@ -306,7 +306,7 @@ class IOBufferScheduler < Scheduler
     while true
       maximum_size = buffer.size - offset
 
-      chunk = buffer.to_str(offset, maximum_size)
+      chunk = buffer.get_string(offset, maximum_size)
       result = blocking{io.write_nonblock(chunk, exception: false)}
 
       # blocking{pp write: maximum_size, result: result, length: length}

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -9,10 +9,6 @@ class TestIOBuffer < Test::Unit::TestCase
     Warning[:experimental] = experimental
   end
 
-  def test_default_size
-    assert_equal IO::Buffer::DEFAULT_SIZE, IO::Buffer.new.size
-  end
-
   def assert_negative(value)
     assert(value < 0, "Expected #{value} to be negative!")
   end
@@ -38,6 +34,10 @@ class TestIOBuffer < Test::Unit::TestCase
     assert_equal 8, IO::Buffer::NETWORK_ENDIAN
 
     assert_include [IO::Buffer::LITTLE_ENDIAN, IO::Buffer::BIG_ENDIAN], IO::Buffer::HOST_ENDIAN
+  end
+
+  def test_default_size
+    assert_equal IO::Buffer::DEFAULT_SIZE, IO::Buffer.new.size
   end
 
   def test_new_internal
@@ -72,6 +72,12 @@ class TestIOBuffer < Test::Unit::TestCase
   def test_file_mapped
     buffer = File.open(__FILE__) {|file| IO::Buffer.map(file)}
     assert_include buffer.to_str, "Hello World"
+  end
+
+  def test_file_mapped_invalid
+    assert_raise ArgumentError do
+      IO::Buffer.map("foobar")
+    end
   end
 
   def test_string_mapped

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -25,7 +25,7 @@ class TestIOBuffer < Test::Unit::TestCase
     assert_equal 32, IO::Buffer::LOCKED
     assert_equal 64, IO::Buffer::PRIVATE
 
-    assert_equal 128, IO::Buffer::IMMUTABLE
+    assert_equal 128, IO::Buffer::READONLY
   end
 
   def test_endian
@@ -56,9 +56,9 @@ class TestIOBuffer < Test::Unit::TestCase
     assert buffer.mapped?
   end
 
-  def test_new_immutable
-    buffer = IO::Buffer.new(128, IO::Buffer::INTERNAL|IO::Buffer::IMMUTABLE)
-    assert buffer.immutable?
+  def test_new_readonly
+    buffer = IO::Buffer.new(128, IO::Buffer::INTERNAL|IO::Buffer::READONLY)
+    assert buffer.readonly?
 
     assert_raise IO::Buffer::MutationError do
       buffer.set_string("")
@@ -86,7 +86,7 @@ class TestIOBuffer < Test::Unit::TestCase
   def test_string_mapped
     string = "Hello World"
     buffer = IO::Buffer.for(string)
-    refute buffer.immutable?
+    refute buffer.readonly?
 
     # Cannot modify string as it's locked by the buffer:
     assert_raise RuntimeError do
@@ -107,7 +107,7 @@ class TestIOBuffer < Test::Unit::TestCase
     string = "Hello World".freeze
     buffer = IO::Buffer.for(string)
 
-    assert buffer.immutable?
+    assert buffer.readonly?
   end
 
   def test_non_string

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -18,14 +18,14 @@ class TestIOBuffer < Test::Unit::TestCase
   end
 
   def test_flags
-    assert_equal 0, IO::Buffer::EXTERNAL
-    assert_equal 1, IO::Buffer::INTERNAL
-    assert_equal 2, IO::Buffer::MAPPED
+    assert_equal 1, IO::Buffer::EXTERNAL
+    assert_equal 2, IO::Buffer::INTERNAL
+    assert_equal 4, IO::Buffer::MAPPED
 
-    assert_equal 16, IO::Buffer::LOCKED
-    assert_equal 32, IO::Buffer::PRIVATE
+    assert_equal 32, IO::Buffer::LOCKED
+    assert_equal 64, IO::Buffer::PRIVATE
 
-    assert_equal 64, IO::Buffer::IMMUTABLE
+    assert_equal 128, IO::Buffer::IMMUTABLE
   end
 
   def test_endian

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -71,7 +71,7 @@ class TestIOBuffer < Test::Unit::TestCase
 
   def test_file_mapped
     buffer = File.open(__FILE__) {|file| IO::Buffer.map(file)}
-    assert_include buffer.to_str, "Hello World"
+    assert_include buffer.get_string, "Hello World"
   end
 
   def test_file_mapped_invalid
@@ -130,7 +130,7 @@ class TestIOBuffer < Test::Unit::TestCase
     buffer = IO::Buffer.new(1024)
     buffer.copy(message, 0)
     buffer.resize(2048)
-    assert_equal message, buffer.to_str(0, message.bytesize)
+    assert_equal message, buffer.get_string(0, message.bytesize)
   end
 
   def test_compare_same_size
@@ -157,7 +157,7 @@ class TestIOBuffer < Test::Unit::TestCase
     buffer = IO::Buffer.new(128)
     slice = buffer.slice(8, 32)
     slice.copy("Hello World", 0)
-    assert_equal("Hello World", buffer.to_str(8, 11))
+    assert_equal("Hello World", buffer.get_string(8, 11))
   end
 
   def test_slice_bounds
@@ -188,6 +188,19 @@ class TestIOBuffer < Test::Unit::TestCase
     assert_equal 128, buffer.size
   end
 
+  def test_get_string
+    message = "Hello World 🤓"
+
+    buffer = IO::Buffer.new(128)
+    buffer.copy(message, 0)
+
+    chunk = buffer.get_string(0, message.bytesize, Encoding::UTF_8)
+    assert_equal message, chunk
+    assert_equal Encoding::UTF_8, chunk.encoding
+
+    chunk = buffer.get_string(0, message.bytesize, Encoding::BINARY)
+    assert_equal Encoding::BINARY, chunk.encoding
+  end
   def test_invalidation
     input, output = IO.pipe
 

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -71,7 +71,10 @@ class TestIOBuffer < Test::Unit::TestCase
 
   def test_file_mapped
     buffer = File.open(__FILE__) {|file| IO::Buffer.map(file)}
-    assert_include buffer.get_string, "Hello World"
+    contents = buffer.get_string
+
+    assert_include contents, "Hello World"
+    assert_equal Encoding::BINARY, contents.encoding
   end
 
   def test_file_mapped_invalid

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -83,6 +83,7 @@ class TestIOBuffer < Test::Unit::TestCase
   def test_string_mapped
     string = "Hello World"
     buffer = IO::Buffer.for(string)
+    refute buffer.immutable?
 
     # Cannot modify string as it's locked by the buffer:
     assert_raise RuntimeError do
@@ -97,6 +98,13 @@ class TestIOBuffer < Test::Unit::TestCase
     assert_equal "hello World", string
     string[0] = "H"
     assert_equal "Hello World", string
+  end
+
+  def test_string_mapped_frozen
+    string = "Hello World".freeze
+    buffer = IO::Buffer.for(string)
+
+    assert buffer.immutable?
   end
 
   def test_non_string

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -60,11 +60,11 @@ class TestIOBuffer < Test::Unit::TestCase
     buffer = IO::Buffer.new(128, IO::Buffer::INTERNAL|IO::Buffer::IMMUTABLE)
     assert buffer.immutable?
 
-    assert_raise RuntimeError do
+    assert_raise IO::Buffer::MutationError do
       buffer.copy("", 0)
     end
 
-    assert_raise RuntimeError do
+    assert_raise IO::Buffer::MutationError do
       buffer.copy("!", 1)
     end
   end
@@ -75,7 +75,7 @@ class TestIOBuffer < Test::Unit::TestCase
   end
 
   def test_file_mapped_invalid
-    assert_raise ArgumentError do
+    assert_raise NoMethodError do
       IO::Buffer.map("foobar")
     end
   end
@@ -163,8 +163,7 @@ class TestIOBuffer < Test::Unit::TestCase
   def test_slice_bounds
     buffer = IO::Buffer.new(128)
 
-    # What is best exception class?
-    assert_raise RuntimeError do
+    assert_raise ArgumentError do
       buffer.slice(128, 10)
     end
 
@@ -176,13 +175,13 @@ class TestIOBuffer < Test::Unit::TestCase
   def test_locked
     buffer = IO::Buffer.new(128, IO::Buffer::INTERNAL|IO::Buffer::LOCKED)
 
-    assert_raise RuntimeError do
+    assert_raise IO::Buffer::LockedError do
       buffer.resize(256)
     end
 
     assert_equal 128, buffer.size
 
-    assert_raise RuntimeError do
+    assert_raise IO::Buffer::LockedError do
       buffer.free
     end
 
@@ -203,7 +202,7 @@ class TestIOBuffer < Test::Unit::TestCase
 
     # (4) scheduler returns
     # (5) rb_write_internal invalidate the buffer object
-    assert_raise RuntimeError do
+    assert_raise IO::Buffer::LockedError do
       buffer.free
     end
 

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -201,6 +201,42 @@ class TestIOBuffer < Test::Unit::TestCase
     chunk = buffer.get_string(0, message.bytesize, Encoding::BINARY)
     assert_equal Encoding::BINARY, chunk.encoding
   end
+
+  # We check that values are correctly round tripped.
+  RANGES = {
+    :U8 => [0, 2**8-1],
+    :S8 => [-2**7, 0, 2**7-1],
+
+    :U16 => [0, 2**16-1],
+    :S16 => [-2**15, 0, 2**15-1],
+    :u16 => [0, 2**16-1],
+    :s16 => [-2**15, 0, 2**15-1],
+
+    :U32 => [0, 2**32-1],
+    :S32 => [-2**31, 0, 2**31-1],
+    :u32 => [0, 2**32-1],
+    :s32 => [-2**31, 0, 2**31-1],
+
+    :U64 => [0, 2**64-1],
+    :S64 => [-2**63, 0, 2**63-1],
+    :u64 => [0, 2**64-1],
+    :s64 => [-2**63, 0, 2**63-1],
+
+    :F32 => [-1.0, 0.0, 0.5, 1.0, 128.0],
+    :F64 => [-1.0, 0.0, 0.5, 1.0, 128.0],
+  }
+
+  def test_get_set
+    buffer = IO::Buffer.new(128)
+
+    RANGES.each do |type, values|
+      values.each do |value|
+        buffer.set(type, 0, value)
+        assert_equal value, buffer.get(type, 0), "Converting #{value} as #{type}."
+      end
+    end
+  end
+
   def test_invalidation
     input, output = IO.pipe
 


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/18417

- [x] `IO::Buffer.map('README.md')` (just a string, I experimented "whether it is smart enough") core dumps.
- [x] I suspect we might want to set buffer to IMMUTABLE if it is created from the frozen string. Currently, this works: (demo of broken behaviour changing frozen string contents).
- [x] The buffer raises `RuntimeError` as the only type of the error. I believe that in some places, it should be other standard errors (for example, "Offset + length out of bounds" could be at least `ArgumentError`?..), and in other occurrences, special error classes: for example, "Buffer is locked" would probably be helpful to have as some `IO::Buffer::LockedError`.
- [x] It seems `to_str` always returns a string in US-ASCII encoding, I am not sure it is the right behavior. For a low-level buffer, I'd rather expect ASCII-8BIT (what file read in binary mode produces in Ruby).
- [x] (Not sure if a bug or just not very useful behavior?) `#resize` applied to a buffer mapped from file seems to "break" the link between the buffer and file; no further copy or set would be reflected on file.
- [x] It seems that `#clear` behaves weirdly when offset is provided but length is not.

