### PR TITLE
[DOC] Make sure new GC methods are documented

### DIFF
--- a/gc.rb
+++ b/gc.rb
@@ -257,13 +257,12 @@ module GC
     Primitive.gc_verify_compaction_references(double_heap, toward == :empty)
   end
 
-  # :nodoc:
   # call-seq:
   #     GC.using_rvargc? -> true or false
   #
   # Returns true if using experimental feature Variable Width Allocation, false
   # otherwise.
-  def self.using_rvargc?
+  def self.using_rvargc? # :nodoc:
     GC::INTERNAL_CONSTANTS[:SIZE_POOL_COUNT] > 1
   end
 
@@ -272,8 +271,8 @@ module GC
   #    GC.measure_total_time = true/false
   #
   # Enable to measure GC time.
-  # You can get the result with `GC.stat(:time)`.
-  # Note that the GC time measurement can introduce the performance regression.
+  # You can get the result with <tt>GC.stat(:time)</tt>.
+  # Note that GC time measurement can cause some performance overhead.
   def self.measure_total_time=(flag)
     Primitive.cstmt! %{
       rb_objspace.flags.measure_gc = RTEST(flag) ? TRUE : FALSE;
@@ -284,7 +283,7 @@ module GC
   # call-seq:
   #    GC.measure_total_time -> true/false
   #
-  # Return measure_total_time flag (default: true).
+  # Return measure_total_time flag (default: +true+).
   # Note that measurement can affect the application performance.
   def self.measure_total_time
     Primitive.cexpr! %{


### PR DESCRIPTION
The docs were already there, just unfortunately placed `:nodoc:` of other method made them not rendered.
Methods: `#measure_total_time`/`#measure_total_time=`, `#total_time`.
Screenshots:
![image](https://user-images.githubusercontent.com/129656/146727994-97141481-0e75-4864-a369-adb69a95148d.png)
![image](https://user-images.githubusercontent.com/129656/146728031-ef48de1f-9049-4f01-9e46-8fb85e0f5ec2.png)

PS: TBH, the docs of the new methods are too spartan for my liking, but they were already written, and with too much stuff on our hands before the release, it is better than nothing.