### PR TITLE
Show whether object is garbage in rb_raw_obj_info()

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -13093,13 +13093,14 @@ rb_raw_obj_info(char *buff, const int buff_size, VALUE obj)
 	const int age = RVALUE_FLAGS_AGE(RBASIC(obj)->flags);
 
         if (is_pointer_to_heap(&rb_objspace, (void *)obj)) {
-            APPENDF((BUFF_ARGS, "%p [%d%s%s%s%s%s] %s ",
+            APPENDF((BUFF_ARGS, "%p [%d%s%s%s%s%s%s] %s ",
                      (void *)obj, age,
                      C(RVALUE_UNCOLLECTIBLE_BITMAP(obj),  "L"),
                      C(RVALUE_MARK_BITMAP(obj),           "M"),
                      C(RVALUE_PIN_BITMAP(obj),            "P"),
                      C(RVALUE_MARKING_BITMAP(obj),        "R"),
                      C(RVALUE_WB_UNPROTECTED_BITMAP(obj), "U"),
+                     C(rb_objspace_garbage_object_p(obj), "G"),
                      obj_type_name(obj)));
         }
         else {


### PR DESCRIPTION
When using `rp(obj)` for debugging during development, it may be useful
information to know that an object is soon to be swept. Add a new letter
to the object dump for whether the object is garbage. It's easy to forget
about lazy sweep.

cc @tenderlove @ko1 