### PR TITLE
make `overloaded_cme_table` truly weak key map

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -6379,9 +6379,7 @@ mark_method_entry(rb_objspace_t *objspace, const rb_method_entry_t *me)
             if (def->body.iseq.iseqptr) gc_mark(objspace, (VALUE)def->body.iseq.iseqptr);
             gc_mark(objspace, (VALUE)def->body.iseq.cref);
             if (def->iseq_overload && me->defined_class) { // cme
-                const rb_callable_method_entry_t *monly_cme = rb_vm_lookup_overloaded_cme((const rb_callable_method_entry_t *)me);
-                if (monly_cme) {
-                    gc_mark(objspace, (VALUE)monly_cme);
+                if (rb_vm_lookup_overloaded_cme((const rb_callable_method_entry_t *)me)) {
                     gc_mark_and_pin(objspace, (VALUE)me);
                 }
             }
@@ -10113,9 +10111,6 @@ gc_ref_update(void *vstart, void *vend, size_t stride, rb_objspace_t * objspace,
 extern rb_symbols_t ruby_global_symbols;
 #define global_symbols ruby_global_symbols
 
-
-st_table *rb_vm_overloaded_cme_table(void);
-
 static void
 gc_update_references(rb_objspace_t *objspace)
 {
@@ -10151,7 +10146,6 @@ gc_update_references(rb_objspace_t *objspace)
     gc_update_table_refs(objspace, objspace->id_to_obj_tbl);
     gc_update_table_refs(objspace, global_symbols.str_sym);
     gc_update_table_refs(objspace, finalizer_table);
-    gc_update_table_refs(objspace, rb_vm_overloaded_cme_table());
 }
 
 static VALUE

--- a/vm_core.h
+++ b/vm_core.h
@@ -714,6 +714,7 @@ typedef struct rb_vm_struct {
     int builtin_inline_index;
 
     struct rb_id_table *negative_cme_table;
+    st_table *overloaded_cme_table; // cme -> overloaded_cme
 
 #ifndef VM_GLOBAL_CC_CACHE_TABLE_SIZE
 #define VM_GLOBAL_CC_CACHE_TABLE_SIZE 1023


### PR DESCRIPTION
`overloaded_cme_table` keeps cme -> monly_cme pairs to manage
corresponding `monly_cme` for `cme`. The lifetime of the `monly_cme`
should be longer than `monly_cme`, but the previous patch losts the
reference to the living `monly_cme`.

Now `overloaded_cme_table` values are always root (keys are only weak
reference), it means `monly_cme` does not freed until corresponding
`cme` is invalidated.

To make managing easy, move `overloaded_cme_table` to `rb_vm_t`.