### PR TITLE
Empty and return the buffer if zero size is given [Bug #18421]

### DIFF
--- a/io.c
+++ b/io.c
@@ -3161,8 +3161,10 @@ io_getpartial(int argc, VALUE *argv, VALUE io, int no_exception, int nonblock)
     GetOpenFile(io, fptr);
     rb_io_check_byte_readable(fptr);
 
-    if (len == 0)
+    if (len == 0) {
+	io_set_read_length(str, 0, shrinkable);
 	return str;
+    }
 
     if (!nonblock)
         READ_CHECK(fptr);
@@ -3305,8 +3307,10 @@ io_read_nonblock(rb_execution_context_t *ec, VALUE io, VALUE length, VALUE str, 
     GetOpenFile(io, fptr);
     rb_io_check_byte_readable(fptr);
 
-    if (len == 0)
+    if (len == 0) {
+	io_set_read_length(str, 0, shrinkable);
 	return str;
+    }
 
     n = read_buffered_data(RSTRING_PTR(str), len, fptr);
     if (n <= 0) {

--- a/test/ruby/test_io.rb
+++ b/test/ruby/test_io.rb
@@ -1494,6 +1494,13 @@ class TestIO < Test::Unit::TestCase
     end)
   end
 
+  def test_readpartial_zero_size
+    File.open(IO::NULL) do |r|
+      assert_empty(r.readpartial(0, s = "01234567"))
+      assert_empty(s)
+    end
+  end
+
   def test_readpartial_buffer_error
     with_pipe do |r, w|
       s = ""
@@ -1539,6 +1546,13 @@ class TestIO < Test::Unit::TestCase
     end)
   end
 
+  def test_read_zero_size
+    File.open(IO::NULL) do |r|
+      assert_empty(r.read(0, s = "01234567"))
+      assert_empty(s)
+    end
+  end
+
   def test_read_buffer_error
     with_pipe do |r, w|
       s = ""
@@ -1574,6 +1588,13 @@ class TestIO < Test::Unit::TestCase
       r.read_nonblock(5, s = "01234567")
       assert_equal("foob", s)
     }
+  end
+
+  def test_read_nonblock_zero_size
+    File.open(IO::NULL) do |r|
+      assert_empty(r.read_nonblock(0, s = "01234567"))
+      assert_empty(s)
+    end
   end
 
   def test_write_nonblock_simple_no_exceptions


### PR DESCRIPTION
In `IO#readpartial` and `IO#read_nonblock`, as well as `IO#read`.