### PR TITLE
undef `rb_vm_lookup_overloaded_cme()`

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -6363,8 +6363,6 @@ rb_mark_hash(st_table *tbl)
     mark_st(&rb_objspace, tbl);
 }
 
-const rb_callable_method_entry_t *rb_vm_lookup_overloaded_cme(const rb_callable_method_entry_t *cme);
-
 static void
 mark_method_entry(rb_objspace_t *objspace, const rb_method_entry_t *me)
 {
@@ -6378,10 +6376,11 @@ mark_method_entry(rb_objspace_t *objspace, const rb_method_entry_t *me)
           case VM_METHOD_TYPE_ISEQ:
             if (def->body.iseq.iseqptr) gc_mark(objspace, (VALUE)def->body.iseq.iseqptr);
             gc_mark(objspace, (VALUE)def->body.iseq.cref);
-            if (def->iseq_overload && me->defined_class) { // cme
-                if (rb_vm_lookup_overloaded_cme((const rb_callable_method_entry_t *)me)) {
-                    gc_mark_and_pin(objspace, (VALUE)me);
-                }
+
+            if (def->iseq_overload && me->defined_class) {
+                // it can be a key of "overloaded_cme" table
+                // so it should be pinned.
+                gc_mark_and_pin(objspace, (VALUE)me);
             }
             break;
 	  case VM_METHOD_TYPE_ATTRSET:

--- a/vm_method.c
+++ b/vm_method.c
@@ -979,12 +979,13 @@ lookup_overloaded_cme(const rb_callable_method_entry_t *cme)
     return monly_cme;
 }
 
-// used by gc.c
+#if VM_CHECK_MODE > 0
 MJIT_FUNC_EXPORTED const rb_callable_method_entry_t *
 rb_vm_lookup_overloaded_cme(const rb_callable_method_entry_t *cme)
 {
     return lookup_overloaded_cme(cme);
 }
+#endif
 
 static void
 delete_overloaded_cme(const rb_callable_method_entry_t *cme)


### PR DESCRIPTION
Some callable method entries (cme) can be a key of `overloaded_cme_table`
and the keys should be pinned because the table is numtable (VALUE is a key).
Before the patch GC checks the cme is in `overloaded_cme_table` by looking up
the table, but it needs VM locking.

It works well in normal GC marking because it is protected by the VM lock,
but it doesn't work on `rb_objspace_reachable_objects_from` because it doesn't
use VM lock.

Now, the number of target cmes are small enough, I decide to pin down
all possible cmes instead of using looking up the table.