### PR TITLE
@@cv is not accessible from non-main ractors

### DIFF
--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -1101,6 +1101,28 @@ assert_equal 'can not access class variables from non-main Ractors', %q{
   end
 }
 
+# also cached cvar in shareable-objects are not allowed to access from non-main Ractor
+assert_equal 'can not access class variables from non-main Ractors', %q{
+  class C
+    @@cv = 'str'
+    def self.cv
+      @@cv
+    end
+  end
+
+  C.cv # cache
+
+  r = Ractor.new do
+    C.cv
+  end
+
+  begin
+    r.take
+  rescue Ractor::RemoteError => e
+    e.cause.message
+  end
+}
+
 # Getting non-shareable objects via constants by other Ractors is not allowed
 assert_equal 'can not access non-shareable objects in constant C::CONST by non-main Ractor.', %q{
   class C

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1320,7 +1320,9 @@ vm_getclassvariable(const rb_iseq_t *iseq, const rb_control_frame_t *reg_cfp, ID
         VALUE v = Qundef;
         RB_DEBUG_COUNTER_INC(cvar_read_inline_hit);
 
-        if (st_lookup(RCLASS_IV_TBL(ic->entry->class_value), (st_data_t)id, &v)) {
+        if (st_lookup(RCLASS_IV_TBL(ic->entry->class_value), (st_data_t)id, &v) &&
+            LIKELY(rb_ractor_main_p())) {
+
             return v;
         }
     }


### PR DESCRIPTION
Class variables (`@@cv`) is not accessible from non-main ractors.
But without this patch cached `@@cv` can be read.

fix [Bug #18128]