### PR TITLE
Raise proper exception when month argument is not a name

### DIFF
--- a/test/ruby/test_time.rb
+++ b/test/ruby/test_time.rb
@@ -49,7 +49,10 @@ class TestTime < Test::Unit::TestCase
     t = Time.new(*tm, "-12:00")
     assert_equal([2001,2,28,23,59,30,-43200], [t.year, t.month, t.mday, t.hour, t.min, t.sec, t.gmt_offset], bug4090)
     assert_raise(ArgumentError) { Time.new(2000,1,1, 0,0,0, "+01:60") }
-    assert_raise(ArgumentError) { Time.new(2021, 1, 1, "+09:99") }
+    msg = /invalid value for Integer/
+    assert_raise_with_message(ArgumentError, msg) { Time.new(2021, 1, 1, "+09:99") }
+    assert_raise_with_message(ArgumentError, msg) { Time.new(2021, 1, "+09:99") }
+    assert_raise_with_message(ArgumentError, msg) { Time.new(2021, "+09:99") }
   end
 
   def test_time_add()

--- a/time.c
+++ b/time.c
@@ -2789,9 +2789,10 @@ month_arg(VALUE arg)
         return obj2ubits(arg, 4);
     }
 
+    mon = 0;
     VALUE s = rb_check_string_type(arg);
     if (!NIL_P(s) && RSTRING_LEN(s) > 0) {
-        mon = 0;
+        arg = s;
         for (i=0; i<12; i++) {
             if (RSTRING_LEN(s) == 3 &&
                 STRNCASECMP(months[i], RSTRING_PTR(s), 3) == 0) {
@@ -2799,15 +2800,8 @@ month_arg(VALUE arg)
                 break;
             }
         }
-        if (mon == 0) {
-            char c = RSTRING_PTR(s)[0];
-
-            if ('0' <= c && c <= '9') {
-                mon = obj2ubits(s, 4);
-            }
-        }
     }
-    else {
+    if (mon == 0) {
         mon = obj2ubits(arg, 4);
     }
     return mon;


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/17485#change-89871