### PR TITLE
Add checks for clang with Machine Function Splitter

### DIFF
--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -94,8 +94,8 @@ jobs:
             shared: '--disable-shared'
             # check: true
 
-          - { key: default_cc, name: clang-12,  value: clang-14 -O2 -fsplit-machine-functions',  container: clang-14 }
-          - { key: default_cc, name: clang-12,  value: clang-13 -O2 -fsplit-machine-functions',  container: clang-13 }
+          - { key: default_cc, name: clang-14,  value: clang-14 -O2 -fsplit-machine-functions',  container: clang-14 }
+          - { key: default_cc, name: clang-13,  value: clang-13 -O2 -fsplit-machine-functions',  container: clang-13 }
           - { key: default_cc, name: clang-12,  value: clang-12 -O2 -fsplit-machine-functions',  container: clang-12 }
 
           - { key: crosshost, name: aarch64-linux-gnu,     value: aarch64-linux-gnu, container: crossbuild-essential-arm64 }

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -94,6 +94,10 @@ jobs:
             shared: '--disable-shared'
             # check: true
 
+          - { key: default_cc, name: clang-12,  value: clang-14 -O2 -fsplit-machine-functions',  container: clang-14 }
+          - { key: default_cc, name: clang-12,  value: clang-13 -O2 -fsplit-machine-functions',  container: clang-13 }
+          - { key: default_cc, name: clang-12,  value: clang-12 -O2 -fsplit-machine-functions',  container: clang-12 }
+
           - { key: crosshost, name: aarch64-linux-gnu,     value: aarch64-linux-gnu, container: crossbuild-essential-arm64 }
 #         - { key: crosshost, name: arm-linux-gnueabi,     value: arm-linux-gnueabi }
 #         - { key: crosshost, name: arm-linux-gnueabihf,   value: arm-linux-gnueabihf }


### PR DESCRIPTION
TLB (Translation Lookaside Buffer) is a cache to reduce the time taken to access a user memory location, which is widely used in modern IA-32 and amd64 architectures. For Ruby programs, one of the potential performance bottleneck comes from L1i misses and ITLB misses according to profiling data with Intel VTune. When MJIT enabled, such problems would become even more serious. Also, Meltdown vulnerability patches would make the problem worse on some specific CPUs.

LLVM introduces Machine Function Splitter feature for x86 ELF since LLVM 12.0 by adding `-fsplit-machine-functions`. This optimization would make the hot code paths are loaded into the CPU cache while keeping the cold code paths at lower priority for the cache. According to the [LLVM mailing list](https://lists.llvm.org/pipermail/llvm-dev/2020-August/144012.html), developers found iTLB misses reduced by 16% to 35% and sTLB misses reduced by 62% to 67% for SPECInt 2017 benchmarks, and the overall performance is improved by ~1%.

This Pull Request is to add such optimization parameters part of the CI checks. I evaluate the `optcarrot` benchmark on the current main branch on either this parameter on or off 100 times each. The test platform is AMD Ryzen 7 5800H (Zen3, 8C16T) with 16GB RAM. The mean FPS of `optcarrot` improves from 47.412 to 48.676 (~2.65%).

<img width="586" alt="image" src="https://user-images.githubusercontent.com/2303500/147386008-5dd35fc9-f984-47d0-b955-e125bfb771d0.png">

The patch might need further investigation on whether this parameter would also help reducing L1i misses on Rails applications when MJIT enabled.
