### PR TITLE
error.c: Add Exception#additional_message

### DIFF
--- a/lib/did_you_mean/core_ext/name_error.rb
+++ b/lib/did_you_mean/core_ext/name_error.rb
@@ -11,7 +11,7 @@ module DidYouMean
       meth.call
     end
 
-    def to_s
+    def additional_message
       msg = super.dup
       suggestion = DidYouMean.formatter.message_for(corrections)
 

--- a/lib/error_highlight/core_ext.rb
+++ b/lib/error_highlight/core_ext.rb
@@ -8,7 +8,7 @@ module ErrorHighlight
     SKIP_TO_S_FOR_SUPER_LOOKUP = true
     private_constant :SKIP_TO_S_FOR_SUPER_LOOKUP
 
-    def to_s
+    def additional_message(**_opt)
       msg = super.dup
 
       locs = backtrace_locations

--- a/lib/error_highlight/formatter.rb
+++ b/lib/error_highlight/formatter.rb
@@ -6,7 +6,7 @@ module ErrorHighlight
         indent = spot[:snippet][0...spot[:first_column]].gsub(/[^\t]/, " ")
         marker = indent + "^" * (spot[:last_column] - spot[:first_column])
 
-        "\n\n#{ spot[:snippet] }#{ marker }"
+        "\n#{ spot[:snippet] }#{ marker }"
       else
         ""
       end


### PR DESCRIPTION
The default error printer shows `#message`, `#additional_message`, and a
backtrace.

```ruby
class MyError < StandardError
  def message = "my error!"
  def additional_message = "This is\nan additional\nmessage"
end

raise MyError
```

```
$ ./miniruby test.rb
test.rb:6:in `<main>': my error! (MyError)
| This is
| an additional
| message
```

Also, let did_you_mean and error_highlight override the method instead
of `#messsage` experimentally.