### PR TITLE
Make Object#method and Module#instance_method not skip ZSUPER methods

### DIFF
--- a/test/ruby/test_method.rb
+++ b/test/ruby/test_method.rb
@@ -199,6 +199,11 @@ class TestMethod < Test::Unit::TestCase
     assert_equal(o.method(:foo), o.method(:foo))
     assert_equal(o.method(:foo), o.method(:bar))
     assert_not_equal(o.method(:foo), o.method(:baz))
+
+    class << o
+      private :bar
+    end
+    assert_not_equal(o.method(:foo), o.method(:bar))
   end
 
   def test_hash
@@ -1198,6 +1203,31 @@ class TestMethod < Test::Unit::TestCase
     assert_equal(false, Visibility.instance_method(:mv2).public?)
     assert_equal(false, Visibility.instance_method(:mv3).private?)
     assert_equal(false, Visibility.instance_method(:mv1).protected?)
+  end
+
+  class VisibilitySub < Visibility
+    protected :mv1
+    public :mv2
+    private :mv3
+  end
+
+  def test_method_visibility_predicates_with_subclass_visbility_change
+    v = VisibilitySub.new
+    assert_equal(false, v.method(:mv1).public?)
+    assert_equal(false, v.method(:mv2).private?)
+    assert_equal(false, v.method(:mv3).protected?)
+    assert_equal(true, v.method(:mv2).public?)
+    assert_equal(true, v.method(:mv3).private?)
+    assert_equal(true, v.method(:mv1).protected?)
+  end
+
+  def test_unbound_method_visibility_predicates_with_subclass_visbility_change
+    assert_equal(false, VisibilitySub.instance_method(:mv1).public?)
+    assert_equal(false, VisibilitySub.instance_method(:mv2).private?)
+    assert_equal(false, VisibilitySub.instance_method(:mv3).protected?)
+    assert_equal(true, VisibilitySub.instance_method(:mv2).public?)
+    assert_equal(true, VisibilitySub.instance_method(:mv3).private?)
+    assert_equal(true, VisibilitySub.instance_method(:mv1).protected?)
   end
 
   def rest_parameter(*rest)


### PR DESCRIPTION
Among other things, this fixes calling visibility methods (public?,
protected?, and private?) on them.  It also fixes #owner to show the
class the zsuper method entry is defined in, instead of the original
class it references.

For some backwards compatibility, adjust #parameters and #source_location,
to show the parameters and source location of the method originally
defined. Also have the parameters and source location still be shown
by #inspect.

Fixes [Bug #18435]