### PR TITLE
Make TracePoint#enable with block target current thread by default

### DIFF
--- a/spec/ruby/core/tracepoint/enable_spec.rb
+++ b/spec/ruby/core/tracepoint/enable_spec.rb
@@ -58,7 +58,7 @@ describe 'TracePoint#enable' do
     end
 
     ruby_version_is '3.2' do
-      it 'enables the trace object for any thread' do
+      it 'enables the trace object only for the current thread' do
         threads = []
         trace = TracePoint.new(:line) do |tp|
           # Runs on purpose on any Thread

--- a/spec/ruby/core/tracepoint/enable_spec.rb
+++ b/spec/ruby/core/tracepoint/enable_spec.rb
@@ -57,25 +57,50 @@ describe 'TracePoint#enable' do
       end.enable { event_name.should equal(:line) }
     end
 
-    it 'enables the trace object for any thread' do
-      threads = []
-      trace = TracePoint.new(:line) do |tp|
-        # Runs on purpose on any Thread
-        threads << Thread.current
-      end
-
-      thread = nil
-      trace.enable do
-        line_event = true
-        thread = Thread.new do
-          event_in_other_thread = true
+    ruby_version_is '3.2' do
+      it 'enables the trace object for any thread' do
+        threads = []
+        trace = TracePoint.new(:line) do |tp|
+          # Runs on purpose on any Thread
+          threads << Thread.current
         end
-        thread.join
-      end
 
-      threads = threads.uniq
-      threads.should.include?(Thread.current)
-      threads.should.include?(thread)
+        thread = nil
+        trace.enable do
+          line_event = true
+          thread = Thread.new do
+            event_in_other_thread = true
+          end
+          thread.join
+        end
+
+        threads = threads.uniq
+        threads.should.include?(Thread.current)
+        threads.should_not.include?(thread)
+      end
+    end
+
+    ruby_version_is ''...'3.2' do
+      it 'enables the trace object for any thread' do
+        threads = []
+        trace = TracePoint.new(:line) do |tp|
+          # Runs on purpose on any Thread
+          threads << Thread.current
+        end
+
+        thread = nil
+        trace.enable do
+          line_event = true
+          thread = Thread.new do
+            event_in_other_thread = true
+          end
+          thread.join
+        end
+
+        threads = threads.uniq
+        threads.should.include?(Thread.current)
+        threads.should.include?(thread)
+      end
     end
 
     it 'can accept arguments within a block but it should not yield arguments' do

--- a/spec/ruby/core/tracepoint/inspect_spec.rb
+++ b/spec/ruby/core/tracepoint/inspect_spec.rb
@@ -98,7 +98,7 @@ describe 'TracePoint#inspect' do
     TracePoint.new(:thread_begin) { |tp|
       next unless Thread.current == thread
       inspect ||= tp.inspect
-    }.enable do
+    }.enable(target_thread: nil) do
       thread = Thread.new {}
       thread_inspection = thread.inspect
       thread.join
@@ -114,7 +114,7 @@ describe 'TracePoint#inspect' do
     TracePoint.new(:thread_end) { |tp|
       next unless Thread.current == thread
       inspect ||= tp.inspect
-    }.enable do
+    }.enable(target_thread: nil) do
       thread = Thread.new {}
       thread_inspection = thread.inspect
       thread.join

--- a/test/ruby/test_settracefunc.rb
+++ b/test/ruby/test_settracefunc.rb
@@ -2280,7 +2280,7 @@ CODE
         events << :___
       end
     end
-    assert_equal [:tp1, :tp1, :tp1, :tp1, :tp1, :tp2, :tp1, :___], events
+    assert_equal [:tp1, :tp1, :tp1, :tp1, :tp2, :tp1, :___], events
 
     # success with two tracepoints (targeting/global)
     events = []

--- a/trace_point.rb
+++ b/trace_point.rb
@@ -168,7 +168,7 @@ class TracePoint
   #                   #   trace is still enabled
   #
   # If a block is given, the trace will only be enabled during the block call.
-  # block. If target and target_line are both nil, then target_thread will default
+  # If target and target_line are both nil, then target_thread will default
   # to the current thread if a block is given.
   #
   #    trace.enabled?

--- a/trace_point.rb
+++ b/trace_point.rb
@@ -167,7 +167,7 @@ class TracePoint
   #   trace.enable    #=> true (previous state)
   #                   #   trace is still enabled
   #
-  # If a block is given, the trace will only be enabled within the scope of the
+  # If a block is given, the trace will only be enabled during the block call.
   # block. If target and target_line are both nil, then target_thread will default
   # to the current thread if a block is given.
   #

--- a/trace_point.rb
+++ b/trace_point.rb
@@ -153,7 +153,7 @@ class TracePoint
 
   # call-seq:
   #    trace.enable(target: nil, target_line: nil, target_thread: nil)    -> true or false
-  #    trace.enable(target: nil, target_line: nil, target_thread: nil) { block }  -> obj
+  #    trace.enable(target: nil, target_line: nil, target_thread: Thread.current) { block }  -> obj
   #
   # Activates the trace.
   #
@@ -168,14 +168,15 @@ class TracePoint
   #                   #   trace is still enabled
   #
   # If a block is given, the trace will only be enabled within the scope of the
-  # block.
+  # block. If target and target_line are both nil, then target_thread will default
+  # to the current thread if a block is given.
   #
   #    trace.enabled?
   #    #=> false
   #
   #    trace.enable do
   #      trace.enabled?
-  #      # only enabled for this block
+  #      # only enabled for this block and thread
   #    end
   #
   #    trace.enabled?
@@ -208,7 +209,7 @@ class TracePoint
   #    trace.enable { p tp.lineno }
   #    #=> RuntimeError: access from outside
   #
-  def enable(target: nil, target_line: nil, target_thread: nil)
+  def enable(target: nil, target_line: nil, target_thread: (Thread.current if target.nil? && target_line.nil? && defined?(yield)))
     Primitive.tracepoint_enable_m(target, target_line, target_thread)
   end
 

--- a/trace_point.rb
+++ b/trace_point.rb
@@ -153,7 +153,7 @@ class TracePoint
 
   # call-seq:
   #    trace.enable(target: nil, target_line: nil, target_thread: nil)    -> true or false
-  #    trace.enable(target: nil, target_line: nil, target_thread: Thread.current) { block }  -> obj
+  #    trace.enable(target: nil, target_line: nil, target_thread: :default) { block }  -> obj
   #
   # Activates the trace.
   #
@@ -209,7 +209,7 @@ class TracePoint
   #    trace.enable { p tp.lineno }
   #    #=> RuntimeError: access from outside
   #
-  def enable(target: nil, target_line: nil, target_thread: (Thread.current if target.nil? && target_line.nil? && defined?(yield)))
+  def enable(target: nil, target_line: nil, target_thread: :default)
     Primitive.tracepoint_enable_m(target, target_line, target_thread)
   end
 

--- a/vm_trace.c
+++ b/vm_trace.c
@@ -34,6 +34,8 @@
 
 #include "builtin.h"
 
+static VALUE sym_default;
+
 /* (1) trace mechanisms */
 
 typedef struct rb_event_hook_struct {
@@ -1327,6 +1329,15 @@ tracepoint_enable_m(rb_execution_context_t *ec, VALUE tpval, VALUE target, VALUE
     rb_tp_t *tp = tpptr(tpval);
     int previous_tracing = tp->tracing;
 
+    if (target_thread == sym_default) {
+        if (rb_block_given_p() && NIL_P(target) && NIL_P(target_line)) {
+            target_thread = rb_thread_current();
+        }
+        else {
+            target_thread = Qnil;
+        }
+    }
+
     /* check target_thread */
     if (RTEST(target_thread)) {
         if (tp->target_th) {
@@ -1556,6 +1567,8 @@ tracepoint_allow_reentry(rb_execution_context_t *ec, VALUE self)
 void
 Init_vm_trace(void)
 {
+    sym_default = ID2SYM(rb_intern_const("default"));
+
     /* trace_func */
     rb_define_global_function("set_trace_func", set_trace_func, 1);
     rb_define_method(rb_cThread, "set_trace_func", thread_set_trace_func_m, 1);


### PR DESCRIPTION
If TracePoint#enable is passed a block, it previously started
the trace on all threads.  This changes it to trace only the
current thread by default.  To limit the scope of the change,
the current thread is only used by default if target and
target_line are both nil.  You can pass target_thread: nil
to enable tracing on all threads, to get the previous
default behavior.

This appears to cause issues with power_assert, causing
failures in the test-unit and power_assert bundled gem tests.
Maybe power_assert needs `target_thread: nil` added to the
`enable` call here?: https://github.com/ruby/power_assert/blob/30349ba15b16391b175cd3e3954568a5c53d187c/lib/power_assert/context.rb#L196

Fixes [Bug #16889]