### PR TITLE
YJIT: Fix warning in iface.c

### DIFF
--- a/yjit_iface.c
+++ b/yjit_iface.c
@@ -1277,6 +1277,7 @@ rb_yjit_init(struct rb_yjit_options *options)
 
     // YJIT::Block (block version, code block)
     cYjitBlock = rb_define_class_under(mYjit, "Block", rb_cObject);
+    rb_undef_alloc_func(cYjitBlock);
     rb_define_method(cYjitBlock, "address", block_address, 0);
     rb_define_method(cYjitBlock, "id", block_id, 0);
     rb_define_method(cYjitBlock, "code", block_code, 0);


### PR DESCRIPTION
This fixes the warning which appeared after 7c738ce5e649b82bdc1305d5c347e81886ee759a:

    <internal:yjit>:16: warning: undefining the allocator of T_DATA class RubyVM::YJIT::Block

I don't believe we want the allocator defined because `RubyVM::YJIT::Block` is always allocated by `yjit_blocks_for`.