### PR TITLE
Fix RBS test failures of taint/trust

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -101,7 +101,7 @@ jobs:
         env:
           RUBY_TESTOPTS: "-q --tty=no"
           TESTS: ${{ matrix.test_task == 'check' && matrix.skipped_tests || '' }}
-          TEST_BUNDLED_GEMS_ALLOW_FAILURES: "rbs"
+          TEST_BUNDLED_GEMS_ALLOW_FAILURES: ""
       - name: make skipped tests
         run: |
           $SETARCH make -s test-all TESTS=`echo "$TESTS" | sed 's| |$/ -n/|g;s|^|-n/|;s|$|$$/|'`

--- a/.github/workflows/yjit-ubuntu.yml
+++ b/.github/workflows/yjit-ubuntu.yml
@@ -92,7 +92,7 @@ jobs:
         timeout-minutes: 60
         env:
           RUBY_TESTOPTS: "-q --tty=no"
-          TEST_BUNDLED_GEMS_ALLOW_FAILURES: "rbs"
+          TEST_BUNDLED_GEMS_ALLOW_FAILURES: ""
       - uses: k0kubun/action-slack@v2.0.0
         with:
           payload: |

--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -11,6 +11,6 @@ net-pop 0.1.1 https://github.com/ruby/net-pop
 net-smtp 0.3.1 https://github.com/ruby/net-smtp
 matrix 0.4.2 https://github.com/ruby/matrix
 prime 0.1.2 https://github.com/ruby/prime
-rbs 2.0.0 https://github.com/ruby/rbs
+rbs 2.0.0 https://github.com/ruby/rbs cdd6a3a896001e25bd1feda3eab7f470bae935c1
 typeprof 0.21.1 https://github.com/ruby/typeprof
 debug 1.4.0 https://github.com/ruby/debug


### PR DESCRIPTION
Tests for RBS fail on Ruby master because RBS calls `taint` and so on in the tests.
So the test failures were ignored since 3a223aec2e2c7ef393dcc0c4a05cb1c9bc383775.
I've removed `taint` calls from RBS tests in ruby/rbs#860, so we can now re-enable the tests.

cc/ @nobu @soutaro 