### PR TITLE
`USE_RUBY_DEBUG_LOG` doesn't check `RUBY_DEVEL`

### DIFF
--- a/debug.c
+++ b/debug.c
@@ -248,11 +248,7 @@ set_debug_option(const char *str, int len, void *arg)
     }
 }
 
-#ifdef USE_RUBY_DEBUG_LOG
-STATIC_ASSERT(USE_RUBY_DEBUG_LOG, USE_RUBY_DEBUG_LOG ? RUBY_DEVEL : 1);
-#endif
-
-#if RUBY_DEVEL
+#if USE_RUBY_DEBUG_LOG
 static void setup_debug_log(void);
 #else
 #define setup_debug_log()
@@ -265,7 +261,7 @@ ruby_set_debug_option(const char *str)
     setup_debug_log();
 }
 
-#if RUBY_DEVEL
+#if USE_RUBY_DEBUG_LOG
 
 // RUBY_DEBUG_LOG features
 // See vm_debug.h comments for details.
@@ -511,4 +507,4 @@ ruby_debug_log_dump(const char *fname, unsigned int n)
         fclose(fp);
     }
 }
-#endif // #if RUBY_DEVEL
+#endif // #if USE_RUBY_DEBUG_LOG

--- a/ractor.c
+++ b/ractor.c
@@ -545,7 +545,7 @@ ractor_sleep_interrupt(void *ptr)
     RACTOR_UNLOCK(r);
 }
 
-#if defined(USE_RUBY_DEBUG_LOG) && USE_RUBY_DEBUG_LOG
+#if USE_RUBY_DEBUG_LOG
 static const char *
 wait_status_str(enum ractor_wait_status wait_status)
 {

--- a/transient_heap.c
+++ b/transient_heap.c
@@ -748,7 +748,7 @@ transient_heap_block_evacuate(struct transient_heap* theap, struct transient_hea
     }
 }
 
-#if defined(USE_RUBY_DEBUG_LOG) && USE_RUBY_DEBUG_LOG
+#if USE_RUBY_DEBUG_LOG
 static const char *
 transient_heap_status_cstr(enum transient_heap_status status)
 {
@@ -964,8 +964,6 @@ void
 rb_transient_heap_finish_marking(void)
 {
     ASSERT_vm_locking();
-    RUBY_DEBUG_LOG("");
-
     struct transient_heap* theap = transient_heap_get();
 
     RUBY_DEBUG_LOG("objects:%d, marked:%d",

--- a/vm_debug.h
+++ b/vm_debug.h
@@ -31,19 +31,8 @@ void ruby_set_debug_option(const char *str);
 
 RUBY_SYMBOL_EXPORT_END
 
-#ifndef RUBY_DEVEL
-# define RUBY_DEVEL 0
-#endif
-
-#if RUBY_DEVEL
 #ifndef USE_RUBY_DEBUG_LOG
 #define USE_RUBY_DEBUG_LOG 0
-#endif
-#else
-// disable on !RUBY_DEVEL
-#ifdef USE_RUBY_DEBUG_LOG
-#undef USE_RUBY_DEBUG_LOG
-#endif
 #endif
 
 /* RUBY_DEBUG_LOG: Logging debug information mechanism
@@ -101,7 +90,7 @@ bool ruby_debug_log_filter(const char *func_name);
 // You can use this macro for temporary usage (you should not commit it).
 #define _RUBY_DEBUG_LOG(...) ruby_debug_log(__FILE__, __LINE__, RUBY_FUNCTION_NAME_STRING, "" __VA_ARGS__)
 
-#if defined(USE_RUBY_DEBUG_LOG) && USE_RUBY_DEBUG_LOG
+#if USE_RUBY_DEBUG_LOG
 # define RUBY_DEBUG_LOG_ENABLED(func_name) \
     (ruby_debug_log_mode && ruby_debug_log_filter(func_name))
 
@@ -115,7 +104,7 @@ bool ruby_debug_log_filter(const char *func_name);
         ruby_debug_log(file, line, RUBY_FUNCTION_NAME_STRING, "" __VA_ARGS__); \
 } while (0)
 
-#else
+#else // USE_RUBY_DEBUG_LOG
 // do nothing
 #define RUBY_DEBUG_LOG(...)
 #define RUBY_DEBUG_LOG2(file, line, ...)

--- a/vm_sync.h
+++ b/vm_sync.h
@@ -4,7 +4,7 @@
 #include "vm_debug.h"
 #include "debug_counter.h"
 
-#if defined(USE_RUBY_DEBUG_LOG) && USE_RUBY_DEBUG_LOG
+#if USE_RUBY_DEBUG_LOG
 #define LOCATION_ARGS const char *file, int line
 #define LOCATION_PARAMS file, line
 #define APPEND_LOCATION_ARGS , const char *file, int line


### PR DESCRIPTION
`USE_RUBY_DEBUG_LOG` was only defined when `RUBY_DEVEL` is defined.
This patch makes this dependency (`USE_RUBY_DEBUG_LOG` is defined
independently from `RUBY_DEVEL`).

Do not commit a patch which enables `USE_RUBY_DEBUG_LOG`.