### PR TITLE
win32/win32.c Fix PROT_EXEC bit flag check for FlushInstrucitonCache()

### DIFF
--- a/win32/win32.c
+++ b/win32/win32.c
@@ -8264,7 +8264,7 @@ rb_w32_mprotect(void *addr, size_t len, int prot)
         return -1;
     }
 */
-    if (prot | PROT_EXEC) {
+    if (prot & PROT_EXEC) {
         if (!FlushInstructionCache(GetCurrentProcess(), addr, len)) {
             errno = rb_w32_map_errno(GetLastError());
             return -1;


### PR DESCRIPTION
Though I'm not sure what does FlushInstructionCache() do, I think the operator to check a bit flag should be `&` operator.