### PR TITLE
Remove declarations of deprecated functions

### DIFF
--- a/include/ruby/internal/intern/error.h
+++ b/include/ruby/internal/intern/error.h
@@ -202,12 +202,6 @@ RBIMPL_ATTR_NORETURN()
 void rb_error_frozen_object(VALUE what);
 
 /**
- * @deprecated  Does nothing.  This method is deprecated and will be removed in
- *              Ruby 3.2.
- */
-void rb_error_untrusted(VALUE);
-
-/**
  * Queries  if the  passed  object is  frozen.
  *
  * @param[in]  obj  Target object to test frozen-ness.
@@ -215,12 +209,6 @@ void rb_error_untrusted(VALUE);
  * @post       Upon successful return it is guaranteed _not_ frozen.
  */
 void rb_check_frozen(VALUE obj);
-
-/**
- * @deprecated  Does nothing.  This method is deprecated and will be removed in
- *              Ruby 3.2.
- */
-void rb_check_trusted(VALUE);
 
 /**
  * Ensures that the passed object  can be `initialize_copy` relationship.  When


### PR DESCRIPTION
Missed `rb_error_untrusted` and `rb_check_trusted`.