### PR TITLE
Improve `IO#close` performance and semantics.

### DIFF
--- a/doc/hacking/conventions.md
+++ b/doc/hacking/conventions.md
@@ -1,0 +1,32 @@
+# Naming Conventions
+
+This document gives an overview of naming conventions.
+
+## Avoid Exposing `struct`
+
+We should avoid exposing the internals of `struct` as a public interface unless absolutely necessary.
+
+## Avoid Naming With `_t` Suffix
+
+According to the [POSIX specification](https://pubs.opengroup.org/onlinepubs/9699919799/functions/V2_chap02.html), top level names ending in `_t` are reserved.
+
+## Avoid Redundant Names
+
+Avoid naming structs like this:
+
+``` c
+struct my_struct {} // redundant use of struct
+struct my_struct_t {} // reserved use of _t
+```
+
+Both of these are missing `rb_` prefix which should be standard part of public interface.
+
+## Public / Internal Interfaces
+
+Generally speaking, for a given Ruby object, e.g. `IO::Buffer` you would expect to use names like this:
+
+```c
+// ruby/include/io/buffer.h
+
+VALUE rb_io_buffer_new(void *base, size_t size, enum rb_io_buffer_flags flags);
+```

--- a/ext/socket/basicsocket.c
+++ b/ext/socket/basicsocket.c
@@ -597,7 +597,7 @@ rsock_bsock_send(int argc, VALUE *argv, VALUE socket)
         rb_io_wait(socket, RB_INT2NUM(RUBY_IO_WRITABLE), Qnil);
 #endif
 
-        ssize_t n = (ssize_t)BLOCKING_REGION_FD(func, &arg);
+        ssize_t n = (ssize_t)rb_thread_io_blocking_region(fptr, func, &arg);
 
         if (n >= 0) return SSIZET2NUM(n);
 

--- a/ext/socket/rubysocket.h
+++ b/ext/socket/rubysocket.h
@@ -296,8 +296,6 @@ int Rconnect();
 
 #include "constdefs.h"
 
-#define BLOCKING_REGION_FD(func, arg) (long)rb_thread_io_blocking_region((func), (arg), (arg)->fd)
-
 #define SockAddrStringValue(v) rsock_sockaddr_string_value(&(v))
 #define SockAddrStringValuePtr(v) rsock_sockaddr_string_value_ptr(&(v))
 #define SockAddrStringValueWithAddrinfo(v, rai_ret) rsock_sockaddr_string_value_with_addrinfo(&(v), &(rai_ret))
@@ -379,7 +377,7 @@ VALUE rsock_s_recvfrom_nonblock(VALUE sock, VALUE len, VALUE flg, VALUE str,
                                 VALUE ex, enum sock_recv_type from);
 VALUE rsock_s_recvfrom(VALUE sock, int argc, VALUE *argv, enum sock_recv_type from);
 
-int rsock_connect(int fd, const struct sockaddr *sockaddr, int len, int socks, struct timeval *timeout);
+int rsock_connect(VALUE io, const struct sockaddr *sockaddr, int len, int socks, struct timeval *timeout);
 
 VALUE rsock_s_accept(VALUE klass, VALUE io, struct sockaddr *sockaddr, socklen_t *len);
 VALUE rsock_s_accept_nonblock(VALUE klass, VALUE ex, rb_io_t *fptr,

--- a/ext/socket/socket.c
+++ b/ext/socket/socket.c
@@ -391,13 +391,14 @@ sock_connect(VALUE sock, VALUE addr)
 {
     VALUE rai;
     rb_io_t *fptr;
-    int fd, n;
+    int n;
 
     SockAddrStringValueWithAddrinfo(addr, rai);
     addr = rb_str_new4(addr);
     GetOpenFile(sock, fptr);
-    fd = fptr->fd;
-    n = rsock_connect(fd, (struct sockaddr*)RSTRING_PTR(addr), RSTRING_SOCKLEN(addr), 0, NULL);
+
+    n = rsock_connect(sock, (struct sockaddr*)RSTRING_PTR(addr), RSTRING_SOCKLEN(addr), 0, NULL);
+
     if (n < 0) {
         rsock_sys_fail_raddrinfo_or_sockaddr("connect(2)", addr, rai);
     }

--- a/ext/socket/unixsocket.c
+++ b/ext/socket/unixsocket.c
@@ -14,15 +14,14 @@
 struct unixsock_arg {
     struct sockaddr_un *sockaddr;
     socklen_t sockaddrlen;
-    int fd;
+    VALUE io;
 };
 
 static VALUE
 unixsock_connect_internal(VALUE a)
 {
     struct unixsock_arg *arg = (struct unixsock_arg *)a;
-    return (VALUE)rsock_connect(arg->fd, (struct sockaddr*)arg->sockaddr,
-                                arg->sockaddrlen, 0, NULL);
+    return (VALUE)rsock_connect(arg->io, (struct sockaddr*)arg->sockaddr, arg->sockaddrlen, 0, NULL);
 }
 
 static VALUE
@@ -51,7 +50,7 @@ unixsock_path_value(VALUE path)
 }
 
 VALUE
-rsock_init_unixsock(VALUE sock, VALUE path, int server)
+rsock_init_unixsock(VALUE io, VALUE path, int server)
 {
     struct sockaddr_un sockaddr;
     socklen_t sockaddrlen;
@@ -73,43 +72,46 @@ rsock_init_unixsock(VALUE sock, VALUE path, int server)
         rsock_sys_fail_path("socket(2)", path);
     }
 
+    rsock_init_sock(io, fd);
+    GetOpenFile(io, fptr);
+
     if (server) {
         status = bind(fd, (struct sockaddr*)&sockaddr, sockaddrlen);
     }
     else {
-        int prot;
+        int error_tag;
         struct unixsock_arg arg;
         arg.sockaddr = &sockaddr;
         arg.sockaddrlen = sockaddrlen;
-        arg.fd = fd;
-        status = (int)rb_protect(unixsock_connect_internal, (VALUE)&arg, &prot);
-        if (prot) {
-            close(fd);
-            rb_jump_tag(prot);
+        arg.io = io;
+
+        status = (int)rb_protect(unixsock_connect_internal, (VALUE)&arg, &error_tag);
+
+        if (error_tag) {
+            rb_io_close(io);
+            rb_jump_tag(error_tag);
         }
     }
 
     if (status < 0) {
         int e = errno;
-        close(fd);
+        rb_io_close(io);
         rsock_syserr_fail_path(e, "connect(2)", path);
     }
 
     if (server) {
         if (listen(fd, SOMAXCONN) < 0) {
             int e = errno;
-            close(fd);
+            rb_io_close(io);
             rsock_syserr_fail_path(e, "listen(2)", path);
         }
     }
 
-    rsock_init_sock(sock, fd);
     if (server) {
-        GetOpenFile(sock, fptr);
         fptr->pathv = rb_str_new_frozen(path);
     }
 
-    return sock;
+    return io;
 }
 
 /*
@@ -288,7 +290,7 @@ unix_send_io(VALUE sock, VALUE val)
 #endif
 
     arg.fd = fptr->fd;
-    while ((int)BLOCKING_REGION_FD(sendmsg_blocking, &arg) == -1) {
+    while ((int)rb_thread_io_blocking_region(fptr, sendmsg_blocking, &arg) == -1) {
         if (!rb_io_wait_writable(arg.fd))
             rsock_sys_fail_path("sendmsg(2)", fptr->pathv);
     }
@@ -390,7 +392,7 @@ retry:
 #endif
 
     arg.fd = fptr->fd;
-    while ((int)BLOCKING_REGION_FD(recvmsg_blocking, &arg) == -1) {
+    while ((int)rb_thread_io_blocking_region(fptr, recvmsg_blocking, &arg) == -1) {
         int e = errno;
         if (e == EMSGSIZE && !(gc_reason & GC_REASON_EMSGSIZE)) {
             /* FreeBSD gets here when we're out of FDs */

--- a/gc.c
+++ b/gc.c
@@ -3360,11 +3360,17 @@ make_zombie(rb_objspace_t *objspace, VALUE obj, void (*dfree)(void *), void *dat
     heap_pages_final_slots++;
 }
 
+static void
+io_fptr_finalize(void *fptr)
+{
+    rb_io_fptr_finalize((struct rb_io *)fptr);
+}
+
 static inline void
 make_io_zombie(rb_objspace_t *objspace, VALUE obj)
 {
     rb_io_t *fptr = RANY(obj)->as.file.fptr;
-    make_zombie(objspace, obj, rb_io_fptr_finalize_internal, fptr);
+    make_zombie(objspace, obj, io_fptr_finalize, fptr);
 }
 
 static void

--- a/include/ruby/internal/core/rfile.h
+++ b/include/ruby/internal/core/rfile.h
@@ -23,9 +23,8 @@
 #include "ruby/internal/core/rbasic.h"
 #include "ruby/internal/cast.h"
 
-/* rb_io is in ruby/io.h and internal/io.h.  The header file has historically
- * not been included into ruby/ruby.h.  We follow that tradition.
- */
+/* struct rb_io is in internal/io.h.  The header file has historically not been
+ * included into ruby/ruby.h.  We follow that tradition. */
 struct rb_io;
 
 /**

--- a/include/ruby/internal/globals.h
+++ b/include/ruby/internal/globals.h
@@ -119,6 +119,7 @@ RUBY_EXTERN VALUE rb_eStopIteration;             /**< `StopIteration` exception.
 RUBY_EXTERN VALUE rb_eKeyError;                  /**< `KeyError` exception. */
 RUBY_EXTERN VALUE rb_eRangeError;                /**< `RangeError` exception. */
 RUBY_EXTERN VALUE rb_eIOError;                   /**< `IOError` exception. */
+RUBY_EXTERN VALUE rb_eIOCancelled;               /**< `IO::Cancelled` exception. */
 RUBY_EXTERN VALUE rb_eRuntimeError;              /**< `RuntimeError` exception. */
 RUBY_EXTERN VALUE rb_eFrozenError;               /**< `FrozenError` exception. */
 RUBY_EXTERN VALUE rb_eSecurityError;             /**< `SecurityError` exception. */

--- a/internal.h
+++ b/internal.h
@@ -62,9 +62,6 @@
 /* internal/array.h */
 #define rb_ary_new_from_args(...) rb_nonexistent_symbol(__VA_ARGS__)
 
-/* internal/io.h */
-#define rb_io_fptr_finalize(...) rb_nonexistent_symbol(__VA_ARGS__)
-
 /* internal/string.h */
 #define rb_fstring_cstr(...) rb_nonexistent_symbol(__VA_ARGS__)
 

--- a/internal/thread.h
+++ b/internal/thread.h
@@ -10,10 +10,9 @@
  */
 #include "ruby/ruby.h"          /* for VALUE */
 #include "ruby/intern.h"        /* for rb_blocking_function_t */
-#include "ccan/list/list.h"     /* for list in rb_io_close_wait_list */
-#include "ruby/thread_native.h" /* for mutexes in rb_io_close_wait_list */
 
 struct rb_thread_struct;        /* in vm_core.h */
+struct rb_io;
 
 #define RB_VM_SAVE_MACHINE_CONTEXT(th)				\
     do {							\
@@ -54,17 +53,9 @@ VALUE rb_exec_recursive_outer_mid(VALUE (*f)(VALUE g, VALUE h, int r), VALUE g, 
 
 int rb_thread_wait_for_single_fd(int fd, int events, struct timeval * timeout);
 
-struct rb_io_close_wait_list {
-    struct ccan_list_head list;
-    rb_nativethread_lock_t mu;
-    rb_nativethread_cond_t cv;
-};
-int rb_notify_fd_close(int fd, struct rb_io_close_wait_list *busy);
-void rb_notify_fd_close_wait(struct rb_io_close_wait_list *busy);
-
 RUBY_SYMBOL_EXPORT_BEGIN
-/* Temporary.  This API will be removed (renamed). */
-VALUE rb_thread_io_blocking_region(rb_blocking_function_t *func, void *data1, int fd);
+
+VALUE rb_thread_io_blocking_region(struct rb_io *fptr, rb_blocking_function_t *func, void *data1);
 
 /* thread.c (export) */
 int ruby_thread_has_gvl_p(void); /* for ext/fiddle/closure.c */

--- a/io_buffer.c
+++ b/io_buffer.c
@@ -2440,10 +2440,10 @@ io_buffer_default_size(size_t page_size)
 }
 
 struct io_buffer_blocking_region_argument {
+    struct rb_io *io;
     struct rb_io_buffer *buffer;
     rb_blocking_function_t *function;
     void *data;
-    int descriptor;
 };
 
 static VALUE
@@ -2451,7 +2451,7 @@ io_buffer_blocking_region_begin(VALUE _argument)
 {
     struct io_buffer_blocking_region_argument *argument = (void*)_argument;
 
-    return rb_thread_io_blocking_region(argument->function, argument->data, argument->descriptor);
+    return rb_thread_io_blocking_region(argument->io, argument->function, argument->data);
 }
 
 static VALUE
@@ -2465,13 +2465,17 @@ io_buffer_blocking_region_ensure(VALUE _argument)
 }
 
 static VALUE
-io_buffer_blocking_region(struct rb_io_buffer *buffer, rb_blocking_function_t *function, void *data, int descriptor)
+io_buffer_blocking_region(VALUE io, struct rb_io_buffer *buffer, rb_blocking_function_t *function, void *data)
 {
+    io = rb_io_get_io(io);
+    struct rb_io *ioptr;
+    RB_IO_POINTER(io, ioptr);
+
     struct io_buffer_blocking_region_argument argument = {
+        .io = ioptr,
         .buffer = buffer,
         .function = function,
         .data = data,
-        .descriptor = descriptor,
     };
 
     // If the buffer is already locked, we can skip the ensure (unlock):
@@ -2587,7 +2591,7 @@ rb_io_buffer_read(VALUE self, VALUE io, size_t length, size_t offset)
         .length = length,
     };
 
-    return io_buffer_blocking_region(buffer, io_buffer_read_internal, &argument, descriptor);
+    return io_buffer_blocking_region(io, buffer, io_buffer_read_internal, &argument);
 }
 
 /*
@@ -2707,7 +2711,7 @@ rb_io_buffer_pread(VALUE self, VALUE io, rb_off_t from, size_t length, size_t of
         .offset = from,
     };
 
-    return io_buffer_blocking_region(buffer, io_buffer_pread_internal, &argument, descriptor);
+    return io_buffer_blocking_region(io, buffer, io_buffer_pread_internal, &argument);
 }
 
 /*
@@ -2828,7 +2832,7 @@ rb_io_buffer_write(VALUE self, VALUE io, size_t length, size_t offset)
         .length = length,
     };
 
-    return io_buffer_blocking_region(buffer, io_buffer_write_internal, &argument, descriptor);
+    return io_buffer_blocking_region(io, buffer, io_buffer_write_internal, &argument);
 }
 
 /*
@@ -2948,7 +2952,7 @@ rb_io_buffer_pwrite(VALUE self, VALUE io, rb_off_t from, size_t length, size_t o
         .offset = from,
     };
 
-    return io_buffer_blocking_region(buffer, io_buffer_pwrite_internal, &argument, descriptor);
+    return io_buffer_blocking_region(io, buffer, io_buffer_pwrite_internal, &argument);
 }
 
 /*

--- a/process.c
+++ b/process.c
@@ -15,6 +15,8 @@
 
 #include "ruby/fiber/scheduler.h"
 
+#include "internal/io.h"
+
 #include <ctype.h>
 #include <errno.h>
 #include <signal.h>
@@ -1839,7 +1841,7 @@ check_exec_redirect_fd(VALUE v, int iskey)
             goto wrong;
     }
     else if (!NIL_P(tmp = rb_io_check_io(v))) {
-        rb_io_t *fptr;
+        struct rb_io *fptr;
         GetOpenFile(tmp, fptr);
         if (fptr->tied_io_for_writing)
             rb_raise(rb_eArgError, "duplex IO redirection");

--- a/spec/ruby/core/io/fixtures/classes.rb
+++ b/spec/ruby/core/io/fixtures/classes.rb
@@ -2,7 +2,7 @@
 
 module IOSpecs
   THREAD_CLOSE_RETRIES = 10
-  THREAD_CLOSE_ERROR_MESSAGE = 'stream closed in another thread'
+  THREAD_CLOSE_ERROR_MESSAGE = 'stream closed in another context'
 
   class SubIO < IO
   end

--- a/spec/ruby/optional/capi/ext/io_spec.c
+++ b/spec/ruby/optional/capi/ext/io_spec.c
@@ -143,7 +143,11 @@ VALUE io_spec_rb_io_wait_readable(VALUE self, VALUE io, VALUE read_p) {
     errno = saved_errno;
   }
 
+#ifdef RUBY_VERSION_IS_3_0
+  ret = rb_io_maybe_wait_readable(errno, io, Qnil);
+#else
   ret = rb_io_wait_readable(fd);
+#endif
 
   if(RTEST(read_p)) {
     ssize_t r = read(fd, buf, RB_IO_WAIT_READABLE_BUF);
@@ -162,7 +166,11 @@ VALUE io_spec_rb_io_wait_readable(VALUE self, VALUE io, VALUE read_p) {
 }
 
 VALUE io_spec_rb_io_wait_writable(VALUE self, VALUE io) {
+#ifdef RUBY_VERSION_IS_3_0
+  int ret = rb_io_maybe_wait_writable(errno, io, Qnil);
+#else
   int ret = rb_io_wait_writable(io_spec_get_fd(io));
+#endif
   return ret ? Qtrue : Qfalse;
 }
 
@@ -226,13 +234,23 @@ VALUE io_spec_rb_thread_wait_fd(VALUE self, VALUE io) {
 }
 
 VALUE io_spec_rb_wait_for_single_fd(VALUE self, VALUE io, VALUE events, VALUE secs, VALUE usecs) {
-  int fd = io_spec_get_fd(io);
+#ifdef RUBY_VERSION_IS_3_0
+  VALUE timeout = Qnil;
+  if (!NIL_P(secs)) {
+      timeout = rb_float_new((double)FIX2INT(secs) + (0.000001f * FIX2INT(usecs)));
+  }
+  VALUE result = rb_io_wait(io, events, timeout);
+  if (result == Qfalse) return INT2FIX(0);
+  else return result;
+#else
   struct timeval tv;
   if (!NIL_P(secs)) {
     tv.tv_sec = FIX2INT(secs);
     tv.tv_usec = FIX2INT(usecs);
   }
+  int fd = io_spec_get_fd(io);
   return INT2FIX(rb_wait_for_single_fd(fd, FIX2INT(events), NIL_P(secs) ? NULL : &tv));
+#endif
 }
 
 VALUE io_spec_rb_thread_fd_writable(VALUE self, VALUE io) {

--- a/test/-ext-/thread_fd/test_thread_fd_close.rb
+++ b/test/-ext-/thread_fd/test_thread_fd_close.rb
@@ -5,6 +5,7 @@ require '-test-/thread_fd'
 class TestThreadFdClose < Test::Unit::TestCase
 
   def test_thread_fd_close
+    omit 'delete this test - we removed the implementation of rb_io_thread_close'
     IO.pipe do |r, w|
       th = Thread.new do
         begin

--- a/test/ruby/test_io.rb
+++ b/test/ruby/test_io.rb
@@ -3856,7 +3856,7 @@ __END__
         thread = Thread.new do
           begin
             q << true
-            assert_raise_with_message(IOError, /stream closed/) do
+            assert_raise_with_message(IO::Cancelled, /stream closed/) do
               while r.gets
               end
             end

--- a/test/ruby/test_process.rb
+++ b/test/ruby/test_process.rb
@@ -691,6 +691,7 @@ class TestProcess < Test::Unit::TestCase
   end unless windows? # does not support fifo
 
   def test_execopts_redirect_open_fifo_interrupt_print
+    omit "[Bug #19700]" if /darwin/ =~ RUBY_PLATFORM
     with_tmpchdir {|d|
       begin
         File.mkfifo("fifo")

--- a/test/socket/test_socket.rb
+++ b/test/socket/test_socket.rb
@@ -574,7 +574,7 @@ class TestSocket < Test::Unit::TestCase
     begin sleep(0.1) end until serv_thread.stop?
     sock = TCPSocket.new("localhost", server.addr[1])
     client_thread = Thread.new do
-      assert_raise(IOError, bug4390) {
+      assert_raise(IO::Cancelled, bug4390) {
         sock.readline
       }
     end

--- a/vm.c
+++ b/vm.c
@@ -2906,7 +2906,6 @@ ruby_vm_destruct(rb_vm_t *vm)
     return 0;
 }
 
-size_t rb_vm_memsize_waiting_fds(struct ccan_list_head *waiting_fds); // thread.c
 size_t rb_vm_memsize_postponed_job_buffer(void); // vm_trace.c
 size_t rb_vm_memsize_workqueue(struct ccan_list_head *workqueue); // vm_trace.c
 
@@ -2962,7 +2961,6 @@ vm_memsize(const void *ptr)
 
     return (
         sizeof(rb_vm_t) +
-        rb_vm_memsize_waiting_fds(&vm->waiting_fds) +
         rb_st_memsize(vm->loaded_features_index) +
         rb_st_memsize(vm->loading_table) +
         rb_st_memsize(vm->ensure_rollback_table) +

--- a/vm_core.h
+++ b/vm_core.h
@@ -647,7 +647,6 @@ typedef struct rb_vm_struct {
 #endif
 
     rb_serial_t fork_gen;
-    struct ccan_list_head waiting_fds; /* <=> struct waiting_fd */
 
     /* set in single-threaded processes only: */
     volatile int ubf_async_safe;
@@ -1746,7 +1745,6 @@ void rb_thread_wakeup_timer_thread(int);
 static inline void
 rb_vm_living_threads_init(rb_vm_t *vm)
 {
-    ccan_list_head_init(&vm->waiting_fds);
     ccan_list_head_init(&vm->workqueue);
     ccan_list_head_init(&vm->ractor.set);
 }


### PR DESCRIPTION
See <https://bugs.ruby-lang.org/issues/18455> for more context.

The first half of this PR (hiding `rb_io_t`) was done in <https://github.com/ruby/ruby/pull/6511>.