### PR TITLE
Support additional ipv6 link local iface names

### DIFF
--- a/lib/resolv.rb
+++ b/lib/resolv.rb
@@ -2464,7 +2464,7 @@ class Resolv
     Regex_8HexLinkLocal = /\A
       [Ff][Ee]80
       (?::[0-9A-Fa-f]{1,4}){7}
-      %[0-9A-Za-z]+
+      %[0-9A-Za-z.-]+
       \z/x
 
     ##
@@ -2478,7 +2478,7 @@ class Resolv
         |
         :((?:[0-9A-Fa-f]{1,4}(?::[0-9A-Fa-f]{1,4})*)?)
       )?
-      :[0-9A-Fa-f]{1,4}%[0-9A-Za-z.]+
+      :[0-9A-Fa-f]{1,4}%[0-9A-Za-z.-]+
       \z/x
 
     ##

--- a/test/resolv/test_addr.rb
+++ b/test/resolv/test_addr.rb
@@ -28,6 +28,8 @@ class TestResolvAddr < Test::Unit::TestCase
     assert_match(Resolv::IPv6::Regex, "FE80:2:3:4:5:6:7:8%EM1", bug17112)
     assert_match(Resolv::IPv6::Regex, "FE80::20D:3AFF:FE7D:9760%ETH0", bug17112)
     assert_match(Resolv::IPv6::Regex, "FE80::1%EM1", bug17112)
+    assert_match(Resolv::IPv6::Regex, "fe80::42:b0ff:fe93:c2f3%br-326bf571f36a", bug17112)
+    assert_match(Resolv::IPv6::Regex, "fe80::1%br-326bf571f36a", bug17112)
   end
 
   def test_valid_socket_ip_address_list


### PR DESCRIPTION
On my machine (Arch Linux) I have a bridge network interface named like `br-123abc123abc`, which I believe is generated by docker. Previously this caused a test failure in `TestResolvAddr#test_valid_socket_ip_address_list` because the `-` in the interface name was unexpected.

This commit adds support for `-` in the interface name and also makes the interface part of the regex the same between `Regex_8HexLinkLocal` and `Regex_CompressedHexLinkLocal` (previously `Regex_8HexLinkLocal` was didn't allow `.`).