### PR TITLE
Don't segfault if Warning.warn is undefined

### DIFF
--- a/error.c
+++ b/error.c
@@ -317,7 +317,8 @@ rb_warning_warn(VALUE mod, VALUE str)
 static int
 rb_warning_warn_arity(void)
 {
-    return rb_method_entry_arity(rb_method_entry(rb_singleton_class(rb_mWarning), id_warn));
+    const rb_method_entry_t *me = rb_method_entry(rb_singleton_class(rb_mWarning), id_warn);
+    return me ? rb_method_entry_arity(me) : 1;
 }
 
 static VALUE

--- a/test/ruby/test_exception.rb
+++ b/test/ruby/test_exception.rb
@@ -1192,6 +1192,14 @@ $stderr = $stdout; raise "\x82\xa0"') do |outs, errs, status|
     assert_empty warning
   end
 
+  def test_undef_Warning_warn
+    assert_separately([], "#{<<-"begin;"}\n#{<<-"end;"}")
+    begin;
+      Warning.undef_method(:warn)
+      assert_raise(NoMethodError) { warn "" }
+    end;
+  end
+
   def test_undefined_backtrace
     assert_separately([], "#{<<-"begin;"}\n#{<<-"end;"}")
     begin;


### PR DESCRIPTION
Check that there is a method entry for the method before passing
it to rb_method_entry_arity.

Fixes [Bug #18458]