### PR TITLE
YJIT: Support cfunc Ruby array varargs

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -2766,3 +2766,23 @@ assert_equal 'ok', %q{
   foo(s) rescue :ok
   foo(s) rescue :ok
 }
+
+# File.join is a cfunc accepting variable arguments as a Ruby array (argc = -2)
+assert_equal 'foo/bar', %q{
+  def foo
+    File.join("foo", "bar")
+  end
+
+  foo
+  foo
+}
+
+# File.join is a cfunc accepting variable arguments as a Ruby array (argc = -2)
+assert_equal '', %q{
+  def foo
+    File.join()
+  end
+
+  foo
+  foo
+}

--- a/yjit.c
+++ b/yjit.c
@@ -69,7 +69,6 @@ YJIT_DECLARE_COUNTERS(
     send_missing_method,
     send_bmethod,
     send_refined_method,
-    send_cfunc_ruby_array_varg,
     send_cfunc_argc_mismatch,
     send_cfunc_toomany_args,
     send_cfunc_tracing,


### PR DESCRIPTION
This adds support for cfuncs which take variable arguments using a Ruby array. This is specified with `argc == -2`.

This is relatively uncommon, except for `File.join`, which is very popular. Enough that in a benchmark of some GitHub code it was 4.3% of our "send" exits. Fortunately, it's relatively easy to support.

The one tricky part of this was ensuring the call to `rb_ec_ary_new_from_values` is safe, and I believe it is. When we call that we already have the future-callee's CFP saved, including an SP which which includes the values being put into the Array. (Thanks @tenderlove for helping me to reason about how this works).

The first commit in this PR moves the call to jit_save_sp (which changes the SP in the _caller_ only) slightly later, which I think simplified the logic here. But this could have been made to work either way.