### PR TITLE
Allow include before calling Module#initialize

### DIFF
--- a/class.c
+++ b/class.c
@@ -406,7 +406,6 @@ rb_module_check_initializable(VALUE mod)
     if (!RMODULE_UNINITIALIZED(mod)) {
         rb_raise(rb_eTypeError, "already initialized module");
     }
-    RB_OBJ_WRITE(mod, &RCLASS(mod)->super, 0);
 }
 
 /* :nodoc: */
@@ -913,6 +912,7 @@ rb_module_s_alloc(VALUE klass)
     VALUE mod = class_alloc(T_MODULE, klass);
     RCLASS_M_TBL_INIT(mod);
     FL_SET(mod, RMODULE_ALLOCATED_BUT_NOT_INITIALIZED);
+    RB_OBJ_WRITE(mod, &RCLASS(mod)->super, 0);
     return mod;
 }
 

--- a/class.c
+++ b/class.c
@@ -912,7 +912,6 @@ rb_module_s_alloc(VALUE klass)
     VALUE mod = class_alloc(T_MODULE, klass);
     RCLASS_M_TBL_INIT(mod);
     FL_SET(mod, RMODULE_ALLOCATED_BUT_NOT_INITIALIZED);
-    RB_OBJ_WRITE(mod, &RCLASS(mod)->super, 0);
     return mod;
 }
 

--- a/object.c
+++ b/object.c
@@ -1689,7 +1689,6 @@ static VALUE rb_mod_initialize_exec(VALUE module);
 static VALUE
 rb_mod_initialize(VALUE module)
 {
-    rb_module_check_initializable(module);
     return rb_mod_initialize_exec(module);
 }
 

--- a/test/ruby/test_module.rb
+++ b/test/ruby/test_module.rb
@@ -519,6 +519,16 @@ class TestModule < Test::Unit::TestCase
     assert_raise(ArgumentError) { Module.new { include } }
   end
 
+  def test_include_before_initialize
+    m = Class.new(Module) do
+      def initialize(...)
+        include Enumerable
+        super
+      end
+    end.new
+    assert_equal(true, m < Enumerable)
+  end
+
   def test_prepend_self
     m = Module.new
     assert_equal([m], m.ancestors)

--- a/test/ruby/test_module.rb
+++ b/test/ruby/test_module.rb
@@ -526,7 +526,7 @@ class TestModule < Test::Unit::TestCase
         super
       end
     end.new
-    assert_equal(true, m < Enumerable)
+    assert_operator(m, :<, Enumerable)
   end
 
   def test_prepend_self


### PR DESCRIPTION
This is to allow Module subclasses that include modules before
calling super in the subclass's initialize.

Remove rb_module_check_initializable from Module#initialize.
Module#initialize only calls module_exec if a block is passed,
it doesn't have other issues that would cause problems if
called multiple times or with an already initialized module.

Move initialization of super to Module#allocate, though I'm not
sure it is required there.  However, it's needed to be removed
from Module#initialize for this to work.

Fixes [Bug #18292]