### PR TITLE
Revert "Enable Variable Width Allocation by default"

### DIFF
--- a/include/ruby/internal/config.h
+++ b/include/ruby/internal/config.h
@@ -147,7 +147,7 @@
 #endif /* HAVE_VA_ARGS_MACRO */
 
 #ifndef USE_RVARGC
-# define USE_RVARGC 1
+# define USE_RVARGC 0
 #endif
 
 #endif /* RBIMPL_CONFIG_H */


### PR DESCRIPTION
This reverts commit d4a95428bb244ca8c4a97ad50f3837f191f1f0c3.