### PR TITLE
Improve string info in rb_raw_obj_info

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -13304,8 +13304,15 @@ rb_raw_obj_info(char *buff, const int buff_size, VALUE obj)
             }
 	    break;
 	  case T_STRING: {
-            if (STR_SHARED_P(obj)) APPENDF((BUFF_ARGS, " [shared] "));
-            APPENDF((BUFF_ARGS, "%.*s", str_len_no_raise(obj), RSTRING_PTR(obj)));
+            if (STR_SHARED_P(obj)) {
+                APPENDF((BUFF_ARGS, " [shared] len: %ld", RSTRING_LEN(obj)));
+            }
+            else {
+                if (STR_EMBED_P(obj)) APPENDF((BUFF_ARGS, " [embed]"));
+
+                APPENDF((BUFF_ARGS, " len: %ld, capa: %ld", RSTRING_LEN(obj), rb_str_capacity(obj)));
+            }
+            APPENDF((BUFF_ARGS, " \"%.*s\"", str_len_no_raise(obj), RSTRING_PTR(obj)));
 	    break;
 	  }
           case T_SYMBOL: {


### PR DESCRIPTION
Improve rb_raw_obj_info to output additional into about strings
including the length, capacity, and whether or not it is embedded.