### PR TITLE
Make write atomic.

### DIFF
--- a/benchmark/io_write.rb
+++ b/benchmark/io_write.rb
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+
+require 'benchmark'
+
+i, o = IO.pipe
+o.sync = true
+
+DOT = ".".freeze
+
+chunks = 100_000.times.collect{DOT}
+
+thread = Thread.new do
+  while i.read(1024)
+  end
+end
+
+100.times do
+  o.write(*chunks)
+end
+
+o.close
+thread.join

--- a/io.c
+++ b/io.c
@@ -1940,13 +1940,11 @@ io_binwritev_internal(VALUE arg)
 
             iov->iov_base = (char *)iov->iov_base + result;
             iov->iov_len -= result;
-
-            errno = EAGAIN;
         }
-
-        if (rb_io_maybe_wait_writable(errno, fptr->self, Qnil)) {
+        else if (rb_io_maybe_wait_writable(errno, fptr->self, Qnil)) {
             rb_io_check_closed(fptr);
-        } else {
+        }
+        else {
             return -1;
         }
     }

--- a/io.c
+++ b/io.c
@@ -1695,6 +1695,9 @@ io_allocate_write_buffer(rb_io_t *fptr, int sync)
         fptr->wbuf.len = 0;
         fptr->wbuf.capa = IO_WBUF_CAPA_MIN;
         fptr->wbuf.ptr = ALLOC_N(char, fptr->wbuf.capa);
+    }
+
+    if (!fptr->write_lock) {
         fptr->write_lock = rb_mutex_new();
         rb_mutex_allow_trap(fptr->write_lock, 1);
     }

--- a/io.c
+++ b/io.c
@@ -8678,14 +8678,14 @@ rb_p_result(int argc, const VALUE *argv)
     VALUE ret = Qnil;
 
     if (argc == 1) {
-	ret = argv[0];
+        ret = argv[0];
     }
     else if (argc > 1) {
-	ret = rb_ary_new4(argc, argv);
+        ret = rb_ary_new4(argc, argv);
     }
     VALUE r_stdout = rb_ractor_stdout();
     if (RB_TYPE_P(r_stdout, T_FILE)) {
-	rb_io_flush(r_stdout);
+        rb_uninterruptible(rb_io_flush, r_stdout);
     }
     return ret;
 }


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/18465

Right now, `IO#write` including everything that calls it including `IO#puts`, has a poorly specified behaviour w.r.t. other fibers/threads that call `IO#write` at the same time.

Internally, we have a write lock, however it's only used to lock against individual writes rather than the whole operation. From a user point of view, there is some kind of atomicity, but it's not clearly defined and depends on many factors, e.g. whether `write` or `writev` is used internally.

We propose to make `IO#write` an atomic operation, that is, `IO#write` on a synchronous/buffered IO will always perform the write operation using a lock around the entire operation, regardless of the internal implementation.

In theory, this should actually be more efficient than the current approach which may acquire and release the lock several times per operation, however in practice I'm sure it's almost unnoticeable.

Where it does matter, is when interleaved operations invoke the fiber scheduler. By using a single lock around the entire operation, rather than one or more locks around the system calls, the entire operation is more predictable and behaves more robustly.