### PR TITLE
Accurately report VM memsize

### DIFF
--- a/process.c
+++ b/process.c
@@ -1090,6 +1090,21 @@ waitpid_signal(struct waitpid_state *w)
     return FALSE;
 }
 
+// Used for VM memsize reporting. Returns the size of a list of waitpid_state
+// structs. Defined here because the struct definition lives here as well.
+size_t
+rb_vm_memsize_waiting_list(struct list_head *waiting_list)
+{
+    struct waitpid_state *waitpid = 0;
+    size_t size = 0;
+
+    list_for_each(waiting_list, waitpid, wnode) {
+        size += sizeof(struct waitpid_state);
+    }
+
+    return size;
+}
+
 /*
  * When a thread is done using sigwait_fd and there are other threads
  * sleeping on waitpid, we must kick one of the threads out of

--- a/thread.c
+++ b/thread.c
@@ -5593,6 +5593,21 @@ rb_check_deadlock(rb_ractor_t *r)
     }
 }
 
+// Used for VM memsize reporting. Returns the size of a list of waiting_fd
+// structs. Defined here because the struct definition lives here as well.
+size_t
+rb_vm_memsize_waiting_fds(struct list_head *waiting_fds)
+{
+    struct waiting_fd *waitfd = 0;
+    size_t size = 0;
+
+    list_for_each(waiting_fds, waitfd, wfd_node) {
+        size += sizeof(struct waiting_fd);
+    }
+
+    return size;
+}
+
 static void
 update_line_coverage(VALUE data, const rb_trace_arg_t *trace_arg)
 {

--- a/vm_trace.c
+++ b/vm_trace.c
@@ -1578,6 +1578,29 @@ struct rb_workqueue_job {
     rb_postponed_job_t job;
 };
 
+// Used for VM memsize reporting. Returns the size of a list of rb_workqueue_job
+// structs. Defined here because the struct definition lives here as well.
+size_t
+rb_vm_memsize_workqueue(struct list_head *workqueue)
+{
+    struct rb_workqueue_job *work = 0;
+    size_t size = 0;
+
+    list_for_each(workqueue, work, jnode) {
+        size += sizeof(struct rb_workqueue_job);
+    }
+
+    return size;
+}
+
+// Used for VM memsize reporting. Returns the total size of the postponed job
+// buffer that was allocated at initialization.
+size_t
+rb_vm_memsize_postponed_job_buffer()
+{
+    return sizeof(rb_postponed_job_t) * MAX_POSTPONED_JOB;
+}
+
 void
 Init_vm_postponed_job(void)
 {


### PR DESCRIPTION
Currently the calculation only counts the size of the struct. This commit adds the size of the associated st tables, id tables, and linked lists.

Still missing is the size of the ractors and (potentially) the size of the object space.

cc @ko1 