### PR TITLE
Speed up and avoid kwarg hash alloc in Time.now

### DIFF
--- a/benchmark/time_now.yml
+++ b/benchmark/time_now.yml
@@ -1,0 +1,3 @@
+benchmark:
+  - 'Time.now'
+  - 'Time.now(in: "+09:00")'

--- a/time.c
+++ b/time.c
@@ -1932,6 +1932,13 @@ time_init_now(rb_execution_context_t *ec, VALUE time, VALUE zone)
 }
 
 static VALUE
+time_s_now(rb_execution_context_t *ec, VALUE klass, VALUE zone)
+{
+    VALUE t = time_s_alloc(klass);
+    return time_init_now(ec, t, zone);
+}
+
+static VALUE
 time_set_utc_offset(VALUE time, VALUE off)
 {
     struct time_object *tobj;

--- a/timev.rb
+++ b/timev.rb
@@ -221,7 +221,7 @@ class Time
   # Parameter:
   # :include: doc/time/in.rdoc
   def self.now(in: nil)
-    new(in: Primitive.arg!(:in))
+    Primitive.time_s_now(Primitive.arg!(:in))
   end
 
   # _Time_


### PR DESCRIPTION
Previously `Time.now` was switched to use `Time.new` as it added support for the `in:` argument. Unfortunately because `Class#new` is a cfunc this requires always allocating a Hash.

This commit switches Time.now back to using a builtin `time_s_now`. This avoids the extra Hash allocation and is about 3x faster.

    $ benchmark-driver -e './ruby;3.1::~/.rubies/ruby-3.1.0/bin/ruby;3.0::~/.rubies/ruby-3.0.2/bin/ruby' benchmark/time_now.yml
    Warming up --------------------------------------
                  Time.now     6.704M i/s -      6.710M times in 1.000814s (149.16ns/i, 328clocks/i)
    Time.now(in: "+09:00")     2.003M i/s -      2.112M times in 1.054330s (499.31ns/i)
    Calculating -------------------------------------
                               ./ruby         3.1         3.0
                  Time.now     7.693M      2.763M      6.394M i/s -     20.113M times in 2.614428s 7.278710s 3.145572s
    Time.now(in: "+09:00")     2.030M      1.260M      1.617M i/s -      6.008M times in 2.960132s 4.769378s 3.716537s

    Comparison:
                               Time.now
                    ./ruby:   7693129.7 i/s
                       3.0:   6394109.2 i/s - 1.20x  slower
                       3.1:   2763282.5 i/s - 2.78x  slower

                 Time.now(in: "+09:00")
                    ./ruby:   2029757.4 i/s
                       3.0:   1616652.3 i/s - 1.26x  slower
                       3.1:   1259776.2 i/s - 1.61x  slower