### PR TITLE
thread.c: Convert TAG_BREAK to a normal exception at thread top-level

### DIFF
--- a/test/ruby/test_enum.rb
+++ b/test/ruby/test_enum.rb
@@ -461,6 +461,17 @@ class TestEnumerable < Test::Unit::TestCase
       empty.first
       empty.block.call
     end;
+
+    bug18475 = '[ruby-dev:107059]'
+    assert_in_out_err([], <<-'end;', [], /unexpected break/, bug18475)
+      e = Enumerator.new do |g|
+        Thread.new do
+          g << 1
+        end.join
+      end
+
+      e.first
+    end;
   end
 
   def test_sort

--- a/thread.c
+++ b/thread.c
@@ -830,6 +830,9 @@ thread_start_func_2(rb_thread_t *th, VALUE *stack_start)
     else {
         errinfo = th->ec->errinfo;
 
+        VALUE exc = rb_vm_make_jump_tag_but_local_jump(state, Qundef);
+        if (!NIL_P(exc)) errinfo = exc;
+
         if (state == TAG_FATAL) {
             if (th->invoke_type == thread_invoke_type_ractor_proc) {
                 rb_ractor_atexit(th->ec, Qnil);


### PR DESCRIPTION
[Bug #18475]