### PR TITLE
mkmf: pkg_config accepts multiple options

### DIFF
--- a/lib/mkmf.rb
+++ b/lib/mkmf.rb
@@ -1836,26 +1836,26 @@ SRC
     $config_dirs[target] = [idir, ldir]
   end
 
-  # Returns compile/link information about an installed library in a
-  # tuple of <code>[cflags, ldflags, libs]</code>, by using the
-  # command found first in the following commands:
+  # Returns compile/link information about an installed library in a tuple of <code>[cflags,
+  # ldflags, libs]</code>, by using the command found first in the following commands:
   #
   # 1. If <code>--with-{pkg}-config={command}</code> is given via
-  #    command line option: <code>{command} {option}</code>
+  #    command line option: <code>{command} {options}</code>
   #
-  # 2. <code>{pkg}-config {option}</code>
+  # 2. <code>{pkg}-config {options}</code>
   #
-  # 3. <code>pkg-config {option} {pkg}</code>
+  # 3. <code>pkg-config {options} {pkg}</code>
   #
-  # Where {option} is, for instance, <code>--cflags</code>.
+  # Where +options+ is the option name without dashes, for instance <code>"cflags"</code> for the
+  # <code>--cflags</code> flag.
   #
-  # The values obtained are appended to +$INCFLAGS+, +$CFLAGS+, +$LDFLAGS+ and
-  # +$libs+.
+  # The values obtained are appended to <code>$INCFLAGS</code>, <code>$CFLAGS</code>,
+  # <code>$LDFLAGS</code> and <code>$libs</code>.
   #
-  # If an <code>option</code> argument is given, the config command is
-  # invoked with the option and a stripped output string is returned
-  # without modifying any of the global values mentioned above.
-  def pkg_config(pkg, option=nil)
+  # If one or more <code>options</code> argument is given, the config command is
+  # invoked with the options and a stripped output string is returned without
+  # modifying any of the global values mentioned above.
+  def pkg_config(pkg, *options)
     _, ldir = dir_config(pkg)
     if ldir
       pkg_config_path = "#{ldir}/pkgconfig"
@@ -1872,10 +1872,11 @@ SRC
         xsystem([*envs, $PKGCONFIG, "--exists", pkg])
       # default to pkg-config command
       pkgconfig = $PKGCONFIG
-      get = proc {|opt|
-        opt = xpopen([*envs, $PKGCONFIG, "--#{opt}", pkg], err:[:child, :out], &:read)
-        Logging.open {puts opt.each_line.map{|s|"=> #{s.inspect}"}}
-        opt.strip if $?.success?
+      get = proc {|opts|
+        opts = Array(opts).map { |o| "--#{o}" }
+        opts = xpopen([*envs, $PKGCONFIG, *opts, pkg], err:[:child, :out], &:read)
+        Logging.open {puts opts.each_line.map{|s|"=> #{s.inspect}"}}
+        opts.strip if $?.success?
       }
     elsif find_executable0(pkgconfig = "#{pkg}-config")
       # default to package specific config command, as a last resort.
@@ -1883,15 +1884,16 @@ SRC
       pkgconfig = nil
     end
     if pkgconfig
-      get ||= proc {|opt|
-        opt = xpopen([*envs, pkgconfig, "--#{opt}"], err:[:child, :out], &:read)
-        Logging.open {puts opt.each_line.map{|s|"=> #{s.inspect}"}}
-        opt.strip if $?.success?
+      get ||= proc {|opts|
+        opts = Array(opts).map { |o| "--#{o}" }
+        opts = xpopen([*envs, pkgconfig, *opts], err:[:child, :out], &:read)
+        Logging.open {puts opts.each_line.map{|s|"=> #{s.inspect}"}}
+        opts.strip if $?.success?
       }
     end
     orig_ldflags = $LDFLAGS
-    if get and option
-      get[option]
+    if get and !options.empty?
+      get[options]
     elsif get and try_ldflags(ldflags = get['libs'])
       if incflags = get['cflags-only-I']
         $INCFLAGS << " " << incflags

--- a/test/mkmf/test_pkg_config.rb
+++ b/test/mkmf/test_pkg_config.rb
@@ -57,5 +57,12 @@ class TestMkmf
       actual = pkg_config("test1", "cflags").shellsplit.sort
       assert_equal(expected, actual, MKMFLOG)
     end
+
+    def test_pkgconfig_with_multiple_options
+      pend("skipping because pkg-config is not installed") unless PKG_CONFIG
+      expected = ["-L#{@fixtures_lib_dir}", "-ltest1-public", "-ltest1-private"].sort
+      actual = pkg_config("test1", "libs", "static").shellsplit.sort
+      assert_equal(expected, actual, MKMFLOG)
+    end
   end
 end

--- a/test/mkmf/test_pkg_config.rb
+++ b/test/mkmf/test_pkg_config.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: false
+require_relative 'base'
+require 'shellwords'
+
+class TestMkmf
+  class TestPkgConfig < TestMkmf
+    PKG_CONFIG = find_executable0("pkg-config")
+
+    def setup
+      super
+
+      if PKG_CONFIG
+        @fixtures_dir = File.join(Dir.pwd, "fixtures")
+        @fixtures_lib_dir = File.join(@fixtures_dir, "lib")
+        @fixtures_inc_dir = File.join(@fixtures_dir, "include")
+
+        FileUtils.mkdir(@fixtures_dir)
+        File.write("fixtures/test1.pc", <<~EOF)
+          libdir=#{@fixtures_lib_dir}
+          includedir=#{@fixtures_inc_dir}
+
+          Name: test1
+          Description: Test for mkmf pkg-config method
+          Version: 1.2.3
+          Libs: -L${libdir} -ltest1-public
+          Libs.private: -ltest1-private
+          Cflags: -I${includedir}/cflags-I --cflags-other
+        EOF
+
+        @pkg_config_path, ENV["PKG_CONFIG_PATH"] = ENV["PKG_CONFIG_PATH"], File.join(Dir.pwd, "fixtures")
+      end
+    end
+
+    def teardown
+      if PKG_CONFIG
+        ENV["PKG_CONFIG_PATH"] = @pkg_config_path
+      end
+
+      super
+    end
+
+    def test_pkgconfig_with_option_returns_nil_on_error
+      pend("skipping because pkg-config is not installed") unless PKG_CONFIG
+      assert_nil(pkg_config("package-does-not-exist", "exists"), MKMFLOG)
+    end
+
+    def test_pkgconfig_with_libs_option_returns_output
+      pend("skipping because pkg-config is not installed") unless PKG_CONFIG
+      expected = ["-L#{@fixtures_lib_dir}", "-ltest1-public"].sort
+      actual = pkg_config("test1", "libs").shellsplit.sort
+      assert_equal(expected, actual, MKMFLOG)
+    end
+
+    def test_pkgconfig_with_cflags_option_returns_output
+      pend("skipping because pkg-config is not installed") unless PKG_CONFIG
+      expected = ["--cflags-other", "-I#{@fixtures_inc_dir}/cflags-I"].sort
+      actual = pkg_config("test1", "cflags").shellsplit.sort
+      assert_equal(expected, actual, MKMFLOG)
+    end
+  end
+end


### PR DESCRIPTION
`MakeMakefile.pkg_config` only accepts one option. However, some packages may require using multiple options simultaneously.

One such example is `libmagic` for which we need to use both `--libs` and `--static` to retrieve the linker flags for a static build. See https://github.com/kwilczynski/ruby-magic/issues/29 for an example of this in the wild.

This PR modifies `pkg_config` to accept a splat of `options` where it currently accepts a single string `option`. It also introduces some test coverage for `pkg_config`.

This has been submitted for discussion and review at https://bugs.ruby-lang.org/issues/18490