### PR TITLE
clear `@result` after `setup_message`

### DIFF
--- a/lib/drb/drb.rb
+++ b/lib/drb/drb.rb
@@ -1627,9 +1627,12 @@ module DRb
       end
 
       def perform
-        @result = nil
-        @succ = false
-        setup_message
+        begin
+          setup_message
+        ensure
+          @result = nil
+          @succ = false
+        end
 
         if @block
           @result = perform_with_block


### PR DESCRIPTION
For the remote object `ro`, method chain like `ro.foo.bar` the
result of `ro.foo` is stored in `@result`, but cleared just
before `setup_message` and it seems GCed on specific machine.

```
  1) Error:
DRbTests::TestDRbCore#test_05_eq:
RangeError: "140" is recycled object
    (druby://localhost:36141) /tmp/ruby/v3/src/trunk-repeat20-asserts/lib/drb/drb.rb:366:in `_id2ref'
    (druby://localhost:36141) /tmp/ruby/v3/src/trunk-repeat20-asserts/lib/drb/drb.rb:366:in `to_obj'
    (druby://localhost:36141) /tmp/ruby/v3/src/trunk-repeat20-asserts/lib/drb/drb.rb:1528:in `to_obj'
    (druby://localhost:36141) /tmp/ruby/v3/src/trunk-repeat20-asserts/lib/drb/drb.rb:1847:in `to_obj'
    (druby://localhost:36141) /tmp/ruby/v3/src/trunk-repeat20-asserts/lib/drb/drb.rb:620:in `recv_request'
    (druby://localhost:36141) /tmp/ruby/v3/src/trunk-repeat20-asserts/lib/drb/drb.rb:931:in `recv_request'
    (druby://localhost:36141) /tmp/ruby/v3/src/trunk-repeat20-asserts/lib/drb/drb.rb:1656:in `init_with_client'
    (druby://localhost:36141) /tmp/ruby/v3/src/trunk-repeat20-asserts/lib/drb/drb.rb:1668:in `setup_message'
    (druby://localhost:36141) /tmp/ruby/v3/src/trunk-repeat20-asserts/lib/drb/drb.rb:1632:in `perform'
    (druby://localhost:36141) /tmp/ruby/v3/src/trunk-repeat20-asserts/lib/drb/drb.rb:1725:in `block (2 levels) in main_loop'
    (druby://localhost:36141) /tmp/ruby/v3/src/trunk-repeat20-asserts/lib/drb/drb.rb:1721:in `loop'
    (druby://localhost:36141) /tmp/ruby/v3/src/trunk-repeat20-asserts/lib/drb/drb.rb:1721:in `block in main_loop'
    /tmp/ruby/v3/src/trunk-repeat20-asserts/test/drb/drbtest.rb:206:in `test_05_eq'
```

To prevent collecting, clear `@result` just after `setup_message`
and `setup_message` can get the last result object.