### PR TITLE
[Actions] mingw - use ruby/setup-ruby@v1 again

### DIFF
--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -60,7 +60,7 @@ jobs:
           path: src/.downloaded-cache
           key: downloaded-cache
       - name: Set up Ruby & MSYS2
-        uses: MSP-Greg/ruby-setup-ruby@db14f2dde9ceeaa8acbcd31884475a7ce97ae9d3
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.base_ruby }}
       - name: set env
@@ -71,6 +71,8 @@ jobs:
       - name: where check
         run: |
           # show where
+          mv /c/Windows/System32/libcrypto-1_1-x64.dll /c/Windows/System32/libcrypto-1_1-x64.dll_
+          mv /c/Windows/System32/libssl-1_1-x64.dll    /c/Windows/System32/libssl-1_1-x64.dll_
           result=true
           for e in gcc.exe ragel.exe make.exe bison.exe libcrypto-1_1-x64.dll libssl-1_1-x64.dll; do
             echo '##['group']'$'\033[93m'$e$'\033[m'


### PR DESCRIPTION
Note that `ruby/setup-ruby` only installs all packages needed for building when using the Actions windows-2022 image.  Also, the selected toolset (mingw64 or ucrt64) is selected based on the Ruby version that `setup-ruby` installs/enables.

Finally, when used in 'normal' CI, Windows Ruby dll resolution is done via the code in the RubyInstaller2 runtime.  When the `make` tests are ran, the ruby.exe file is from the build directory, and it's dll resolution is 'Path' based.  Hence, the system32 file renames.  The files are third party files, not Microsoft files.  They are needed for Ruby mswin builds.