### PR TITLE
[DOC] Enhanced RDoc for io.c

### DIFF
--- a/io.c
+++ b/io.c
@@ -8001,25 +8001,23 @@ rb_freopen(VALUE fname, const char *mode, FILE *fp)
  *
  *  Reassociates the stream with another stream,
  *  which may be of a different class.
+ *  This method may be used to redirect an existing stream
+ *  to a new destination.
  *
  *  With argument +other_io+ given, reassociates with that stream:
  *
- *    f = File.new('t.txt') # => #<File:t.txt>
- *    f.reopen($stdout)     # => #<IO:<STDOUT>>
- *    f.puts('foo')
+ *    # Redirect $stdin from a file.
+ *    f = File.open('t.txt')
+ *    $stdin.reopen(f)
  *
- *  Output:
+ *    # Redirect $stdout to a file.
+ *    f = File.open('t.tmp', 'w')
+ *    $stdout.reopen(f)
  *
- *    foo
+ *  With argument +path+ given, reassociates with a new stream to that file path:
  *
- *  With argument +path+ given, opens a new stream to that file path
- *  (see IO.open):
- *
- *    f = File.open('t.txt') # => #<File:t.txt>
- *    f.reopen('t.tmp', 'w') # => #<File:t.tmp>
- *    f.write('foo')         # => 3
- *    f.close                # => nil
- *    File.new('t.tmp').read # => "foo"
+ *    $stdin.reopen('t.txt')
+ *    $stdout.reopen('t.tmp', 'w')
  *
  */
 

--- a/io.c
+++ b/io.c
@@ -8171,11 +8171,32 @@ rb_io_printf(int argc, const VALUE *argv, VALUE out)
 
 /*
  *  call-seq:
- *    printf(string, *objects)     -> nil
+ *    printf(io = $stdout, string, *objects) -> nil
+ *    printf                                 -> nil
  *
  *  Equivalent to:
  *
- *    io.write(sprintf(string, objects))
+ *    io.write(sprintf(string, *objects))
+ *
+ *  With the single argument +string+, formats +objects+ into the string,
+ *  then writes the formatted string to $stdout:
+ *
+ *    printf('%4.4d %10s %2.2f', 24, 24, 24.0)
+ *
+ *  Output (on $stdout):
+ *
+ *    0024         24 24.00#
+ *
+ *  With arguments +io+ and +string, formats +objects+ into the string,
+ *  then writes the formatted string to +io+:
+ *
+ *    printf($stderr, '%4.4d %10s %2.2f', 24, 24, 24.0)
+ *
+ *  Output (on $stderr):
+ *
+ *    0024         24 24.00# => nil
+ *
+ *  With no arguments, does nothing.
  *
  */
 
@@ -8211,7 +8232,6 @@ deprecated_str_setter(VALUE val, ID id, VALUE *var)
 /*
  *  call-seq:
  *    print(*objects) -> nil
- *    print           -> nil
  *
  *  Writes to the stream; returns +nil+.
  *  Appends the output record separator <tt>$OUTPUT_RECORD_SEPARATOR</tt>
@@ -8295,7 +8315,7 @@ rb_io_print(int argc, const VALUE *argv, VALUE out)
  *  call-seq:
  *    print(*objects)    -> nil
  *
- *  Equivalent to <tt>$stdout.print(objects)</tt>.
+ *  Equivalent to <tt>$stdout.print(*objects)</tt>.
  *  See IO#print.
  */
 
@@ -8312,7 +8332,8 @@ rb_f_print(int argc, const VALUE *argv, VALUE _)
  *
  *  Writes a character to the stream.
  *
- *  If +object+ is numeric, writes the character whose code is the
+ *  If +object+ is numeric, converts to integer if necessary,
+ *  then writes the character whose code is the
  *  least significant byte;
  *  if +object+ is a string, writes the first character:
  *

--- a/io.c
+++ b/io.c
@@ -8233,14 +8233,14 @@ deprecated_str_setter(VALUE val, ID id, VALUE *var)
  *
  *  Writes the given objects to the stream; returns +nil+.
  *  Appends the output record separator <tt>$OUTPUT_RECORD_SEPARATOR</tt>
- *  <tt>$\\</tt>), if it is not +nil+.
+ *  (<tt>$\\</tt>), if it is not +nil+.
  *
  *  With argument +objects+ given, for each object:
  *
  *  - Converts via its method +to_s+ if not a string.
  *  - Writes to the stream.
  *  - If not the last object, writes the output field separator
- *    <tt>$OUTPUT_FIELD_SEPARATOR</tt> (<tt>$,</tt> if it is not +nil+.
+ *    <tt>$OUTPUT_FIELD_SEPARATOR</tt> (<tt>$,</tt>) if it is not +nil+.
  *
  *  With default separators:
  *
@@ -9009,7 +9009,7 @@ rb_io_initialize(int argc, VALUE *argv, VALUE io)
  *    set_encoding_by_bom -> encoding or nil
  *
  *  If the stream begins with a BOM
- *  ({byte order marker}[https://en.wikipedia.org/wiki/Byte_order_mark],
+ *  ({byte order marker}[https://en.wikipedia.org/wiki/Byte_order_mark]),
  *  consumes the BOM and sets the external encoding accordingly;
  *  returns the result encoding if found, or +nil+ otherwise:
  *

--- a/io.c
+++ b/io.c
@@ -8171,6 +8171,7 @@ rb_io_printf(int argc, const VALUE *argv, VALUE out)
 
 /*
  *  call-seq:
+ *    printf(string, *objects)               -> nil
  *    printf(io = $stdout, string, *objects) -> nil
  *    printf                                 -> nil
  *


### PR DESCRIPTION
Treats:
- IO#reopen
- IO#printf
- Kernel#printf
- IO#print
- Kernel#print
- IO#putc
- IO.new
- IO#set_encoding_by_bom
- IO.for_fd
