### PR TITLE
`ID` in `rb_id_table_foreach_with_replace` [Feature #18253]

### DIFF
--- a/id_table.c
+++ b/id_table.c
@@ -274,12 +274,14 @@ rb_id_table_foreach_with_replace(struct rb_id_table *tbl, rb_id_table_foreach_fu
 
     for (i=0; i<capa; i++) {
         if (ITEM_KEY_ISSET(tbl, i)) {
-            enum rb_id_table_iterator_result ret = (*func)((ID)0, tbl->items[i].val, data);
-            assert(ITEM_GET_KEY(tbl, i));
+            const id_key_t key = ITEM_GET_KEY(tbl, i);
+            ID id = key2id(key);
+            enum rb_id_table_iterator_result ret = (*func)(id, tbl->items[i].val, data);
+            assert(key != 0);
 
             if (ret == ID_TABLE_REPLACE) {
                 VALUE val = tbl->items[i].val;
-                ret = (*replace)(NULL, &val, data, TRUE);
+                ret = (*replace)(&id, &val, data, TRUE);
                 tbl->items[i].val = val;
             }
             else if (ret == ID_TABLE_STOP)


### PR DESCRIPTION
Pass the `ID` from `rb_id_table_foreach_with_replace` to callback functions.