### PR TITLE
include/ruby/io.h: use 0 as POLLPRI when no support for it

### DIFF
--- a/include/ruby/io.h
+++ b/include/ruby/io.h
@@ -35,11 +35,10 @@
 #    undef revents
 #  endif
 #  define RB_WAITFD_IN  POLLIN
-#  if defined(__wasi__) && !defined(POLLPRI)
-//   wasi-libc doesn't have POLLPRI and 0x002 is already reserved for POLLOUT, so use 0x003
-#    define RB_WAITFD_PRI 0x003
-#  else
+#  if defined(POLLPRI)
 #    define RB_WAITFD_PRI POLLPRI
+#  else
+#    define RB_WAITFD_PRI 0
 #  endif
 #  define RB_WAITFD_OUT POLLOUT
 #else


### PR DESCRIPTION
0x003 is not suitable as a bit mask, and it's ok just to be 0 to avoid
setting unsupported bit.