### PR TITLE
.github/workflows: BASERUBY check for Ruby 3.1

### DIFF
--- a/.github/workflows/baseruby.yml
+++ b/.github/workflows/baseruby.yml
@@ -29,8 +29,9 @@ jobs:
 #         - ruby-2.4
 #         - ruby-2.5
 #         - ruby-2.6
-          - ruby-2.7
+#         - ruby-2.7
           - ruby-3.0
+          - ruby-3.1
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Just a nitpick; will merge this.