### PR TITLE
include/ruby/win32.h: explicitly define HAVE_SHUTDOWN

### DIFF
--- a/include/ruby/win32.h
+++ b/include/ruby/win32.h
@@ -653,6 +653,8 @@ extern char *rb_w32_strerror(int);
 #undef setsockopt
 #define setsockopt(s, v, n, o, l) rb_w32_setsockopt(s, v, n, o, l)
 
+#undef HAVE_SHUTDOWN
+#define HAVE_SHUTDOWN 1
 #undef shutdown
 #define shutdown(s, h)		rb_w32_shutdown(s, h)
 


### PR DESCRIPTION
Configuration for mingw32 can't detect 'shutdown' due to wrong -l
option even though it's available (this has been going on for a while,
and it needs to be fixed).
In this situation, include/ruby/missing.h declares a stub shutdown
function since 7ee786388a, and another shutdown decl comes from
system header. They are incompatible at stdcall attribute, so it
causes compilation failure.
This change defines a HAVE_SHUTDOWN to guard a newly introduced stub
decl in include/ruby/missing.h