### PR TITLE
Do not create core file if it is intentional abort

### DIFF
--- a/test/-ext-/bug_reporter/test_bug_reporter.rb
+++ b/test/-ext-/bug_reporter/test_bug_reporter.rb
@@ -19,9 +19,10 @@ class TestBugReporter < Test::Unit::TestCase
     ]
     tmpdir = Dir.mktmpdir
 
+    no_core = "Process.setrlimit(Process::RLIMIT_CORE, 0); " if defined?(Process.setrlimit) && defined?(Process::RLIMIT_CORE)
     args = ["--disable-gems", "-r-test-/bug_reporter",
             "-C", tmpdir]
-    stdin = "register_sample_bug_reporter(12345); Process.kill :SEGV, $$"
+    stdin = "#{no_core}register_sample_bug_reporter(12345); Process.kill :SEGV, $$"
     assert_in_out_err(args, stdin, [], expected_stderr, encoding: "ASCII-8BIT")
   ensure
     FileUtils.rm_rf(tmpdir) if tmpdir

--- a/test/ruby/test_signal.rb
+++ b/test/ruby/test_signal.rb
@@ -291,7 +291,8 @@ class TestSignal < Test::Unit::TestCase
 
     if trap = Signal.list['TRAP']
       bug9820 = '[ruby-dev:48592] [Bug #9820]'
-      status = assert_in_out_err(['-e', 'Process.kill(:TRAP, $$)'])
+      no_core = "Process.setrlimit(Process::RLIMIT_CORE, 0); " if defined?(Process.setrlimit) && defined?(Process::RLIMIT_CORE)
+      status = assert_in_out_err(['-e', "#{no_core}Process.kill(:TRAP, $$)"])
       assert_predicate(status, :signaled?, bug9820)
       assert_equal(trap, status.termsig, bug9820)
     end

--- a/tool/lib/envutil.rb
+++ b/tool/lib/envutil.rb
@@ -152,7 +152,12 @@ module EnvUtil
     if RUBYLIB and lib = child_env["RUBYLIB"]
       child_env["RUBYLIB"] = [lib, RUBYLIB].join(File::PATH_SEPARATOR)
     end
-    child_env['ASAN_OPTIONS'] = ENV['ASAN_OPTIONS'] if ENV['ASAN_OPTIONS']
+
+    # remain env
+    %w(ASAN_OPTIONS RUBY_ON_BUG).each{|name|
+      child_env[name] = ENV[name] if ENV[name]
+    }
+
     args = [args] if args.kind_of?(String)
     pid = spawn(child_env, *precommand, rubybin, *args, opt)
     in_c.close


### PR DESCRIPTION
Two tests abort intentionally and they create core files if
possible. In these case, we don't need to see core files
so disable by `"Process.setrlimit(Process::RLIMIT_CORE, 0)` for
those cases.
