### PR TITLE
MinGW also uses `rb_w32_shutdown`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1158,6 +1158,7 @@ main()
 		ac_cv_func_lchown=yes
 		ac_cv_func_link=yes
 		ac_cv_func_readlink=yes
+		ac_cv_func_shutdown=yes
 		ac_cv_func_symlink=yes
 		ac_cv_lib_crypt_crypt=no
 		ac_cv_func_getpgrp_void=no


### PR DESCRIPTION
Winsock's `shutdown` is incompatible with the other platforms.
And autoconf fails to detect WINAPI functions on 32bit Windows, probably due to the argument size suffixes.
