### PR TITLE
object_tracing.c: add RB_GC_GUARD

### DIFF
--- a/ext/objspace/object_tracing.c
+++ b/ext/objspace/object_tracing.c
@@ -106,6 +106,7 @@ newobj_i(VALUE tpval, void *data)
     info->class_path = class_path_cstr;
     info->generation = rb_gc_count();
     st_insert(arg->object_table, (st_data_t)obj, (st_data_t)info);
+    RB_GC_GUARD(obj);
 }
 
 static void


### PR DESCRIPTION
When object tracing is enabled, the call to st_insert() may attempt
invoke a garbage collection that may remove the `obj` that may have
been optimized out of the stack.