### PR TITLE
Require net/protocol instead of require_relative

### DIFF
--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -20,7 +20,7 @@
 # See Net::HTTP for an overview and examples.
 #
 
-require_relative 'protocol'
+require 'net/protocol'
 require 'uri'
 autoload :OpenSSL, 'openssl'
 


### PR DESCRIPTION
Rails now includes net-protocol as a gem dependency (via the net-smtp,
net-imap, and net-pop gems).

On Ruby 2.7 net-http loads the built-in version of net-protocol via a
`require_relative`. If both the gem and the built-in version are loaded
we end up with warnings about redefined constants, or errors in some
cases. We see such warnings on Rails CI.

Using `require 'net/protocol'` gives us the gem version if there is one,
or the built-in one if not, preventing us from loading both.

See https://github.com/rails/rails/pull/44175 for details. I had thought
of adding net-http as a gem dependency in Rails, but it seems like folks
are not too thrilled with that idea.