### PR TITLE
Mark `rb_clear_constant_cache` as internal use only

### DIFF
--- a/include/ruby/backward.h
+++ b/include/ruby/backward.h
@@ -13,6 +13,9 @@
 
 #define RBIMPL_ATTR_DEPRECATED_SINCE(ver) RBIMPL_ATTR_DEPRECATED(("since " #ver))
 #define RBIMPL_ATTR_DEPRECATED_INTERNAL(ver) RBIMPL_ATTR_DEPRECATED(("since "#ver", also internal"))
+#define RBIMPL_ATTR_DEPRECATED_INTERNAL_ONLY() RBIMPL_ATTR_DEPRECATED(("only for internal use"))
+
+RBIMPL_ATTR_DEPRECATED_INTERNAL_ONLY() void rb_clear_constant_cache(void);
 
 /* from version.c */
 #if defined(RUBY_SHOW_COPYRIGHT_TO_DIE) && !!(RUBY_SHOW_COPYRIGHT_TO_DIE+0)

--- a/include/ruby/internal/intern/vm.h
+++ b/include/ruby/internal/intern/vm.h
@@ -253,17 +253,6 @@ void rb_undef_alloc_func(VALUE klass);
 rb_alloc_func_t rb_get_alloc_func(VALUE klass);
 
 /**
- * Clears  the constant  cache.   Extension libraries  should  not bother  such
- * things.   Just forget  about this  API (or  even, the  presence of  constant
- * cache).
- *
- * @internal
- *
- * Completely no idea why this function is defined in vm_method.c.
- */
-void rb_clear_constant_cache(void);
-
-/**
  * Resembles `alias`.
  *
  * @param[out]  klass            Where to define an alias.

--- a/internal/vm.h
+++ b/internal/vm.h
@@ -96,6 +96,8 @@ MJIT_SYMBOL_EXPORT_BEGIN
 int rb_ec_obj_respond_to(struct rb_execution_context_struct *ec, VALUE obj, ID id, int priv);
 MJIT_SYMBOL_EXPORT_END
 
+void rb_clear_constant_cache(void);
+
 /* vm_dump.c */
 void rb_print_backtrace(void);
 


### PR DESCRIPTION
In the past, many internal functions are declared in intern.h under include/ruby directory, because there were no headers for internal use.