### PR TITLE
IO bugfixes backport

### DIFF
--- a/ext/io/console/console.c
+++ b/ext/io/console/console.c
@@ -555,7 +555,7 @@ console_getch(int argc, VALUE *argv, VALUE io)
 	    if (w < 0) rb_eof_error();
 	    if (!(w & RB_WAITFD_IN)) return Qnil;
 # else
-	    VALUE result = rb_io_wait(io, RUBY_IO_READABLE, timeout);
+	    VALUE result = rb_io_wait(io, RB_INT2NUM(RUBY_IO_READABLE), timeout);
 	    if (!RTEST(result)) return Qnil;
 # endif
 	}

--- a/io.c
+++ b/io.c
@@ -1133,14 +1133,10 @@ rb_read_internal(rb_io_t *fptr, void *buf, size_t count)
 {
     VALUE scheduler = rb_fiber_scheduler_current();
     if (scheduler != Qnil) {
-        VALUE result = rb_fiber_scheduler_io_read_memory(scheduler, fptr->self, buf, count, count);
+        VALUE result = rb_fiber_scheduler_io_read_memory(scheduler, fptr->self, buf, count, 0);
 
         if (result != Qundef) {
-            ssize_t length = rb_fiber_scheduler_io_result_apply(result);
-
-            if (length < 0) rb_sys_fail_path(fptr->pathv);
-
-            return length;
+            return rb_fiber_scheduler_io_result_apply(result);
         }
     }
 

--- a/lib/irb/input-method.rb
+++ b/lib/irb/input-method.rb
@@ -84,8 +84,7 @@ module IRB
     #
     # See IO#eof? for more information.
     def eof?
-      rs, = IO.select([@stdin], [], [], 0.00001)
-      if rs and rs[0]
+      if @stdin.wait_readable(0.00001)
         c = @stdin.getc
         result = c.nil? ? true : false
         @stdin.ungetc(c) unless c.nil?


### PR DESCRIPTION
Backport of the following commits:

```
commit 0bd3af32d8fde429e1962ebe346adbc3afe34e2a
Author: Samuel Williams <samuel.williams@oriontransfer.co.nz>
Date:   Mon Dec 27 17:08:35 2021 +1300

    Prefer `wait_readable` rather than `IO.select`.

commit 36dc5d302d38754559efa0e4208f0203dbbb84af
Author: Samuel Williams <samuel.williams@oriontransfer.co.nz>
Date:   Mon Dec 27 17:06:00 2021 +1300

    Fix incorrect minimum read length.

commit 9488031e8597f6a4327fd97999ccd603a27d1fd6
Author: Samuel Williams <samuel.williams@oriontransfer.co.nz>
Date:   Mon Dec 27 17:05:42 2021 +1300

    Fix console.c usage of `rb_io_wait`.
```

cc @nagachika 