### PR TITLE
[wasm] Disallow compaction

### DIFF
--- a/test/ruby/test_gc_compact.rb
+++ b/test/ruby/test_gc_compact.rb
@@ -18,6 +18,7 @@ class TestGCCompact < Test::Unit::TestCase
     private
 
     def supports_auto_compact?
+      return false if /wasm/ =~ RUBY_PLATFORM
       return true unless defined?(Etc::SC_PAGE_SIZE)
 
       begin


### PR DESCRIPTION
WebAssembly doesn't support signals so we can't use read barriers so we can't use compaction.