### PR TITLE
Switch Kernel#binding to lookup only a single frame

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -1,34 +1,3 @@
-assert_equal '2022', %q{
- def contrivance(hash, key)
-    # Expect this to compile to an `opt_aref`.
-    hash[key]
-
-    # The [] call above tracks that the `hash` local has a VALUE that
-    # is a heap pointer and the guard for the Kernel#itself call below
-    # doesn't check that it's a heap pointer VALUE.
-    #
-    # As you can see from the crash, the call to rb_hash_aref() can set the
-    # `hash` local, making eliding the heap object guard unsound.
-    hash.itself
-  end
-
-  # This is similar to ->(recv, mid) { send(recv, mid).local_variable_set(...) }.
-  # By composing we avoid creating new Ruby frames and so sending :binding
-  # captures the environment of the frame that does the missing key lookup.
-  # We use it to capture the environment inside of `contrivance`.
-  cap_then_set =
-    Kernel.instance_method(:send).method(:bind_call).to_proc >>
-      ->(binding) { binding.local_variable_set(:hash, 2022) }
-  special_missing = Hash.new(&cap_then_set)
-
-  # Make YJIT speculate that it's a hash and generate code
-  # that calls rb_hash_aref().
-  contrivance({}, :warmup)
-  contrivance({}, :warmup)
-
-  contrivance(special_missing, :binding)
-}
-
 assert_equal '18374962167983112447', %q{
   # regression test for incorrectly discarding 32 bits of a pointer when it
   # comes to default values.

--- a/common.mk
+++ b/common.mk
@@ -10820,6 +10820,7 @@ proc.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 proc.$(OBJEXT): $(top_srcdir)/internal/error.h
 proc.$(OBJEXT): $(top_srcdir)/internal/eval.h
 proc.$(OBJEXT): $(top_srcdir)/internal/gc.h
+proc.$(OBJEXT): $(top_srcdir)/internal/hash.h
 proc.$(OBJEXT): $(top_srcdir)/internal/imemo.h
 proc.$(OBJEXT): $(top_srcdir)/internal/object.h
 proc.$(OBJEXT): $(top_srcdir)/internal/proc.h


### PR DESCRIPTION
Previously, Kernel#binding would continue looking up frames until
it found the next Ruby-level frame.  This could result in a change
of behavior for Kernel#binding depending on whether the method
calling it was defined in C or Ruby.

Switch this to only looking at the next frame instead of the next
Ruby-level frame.  If the next frame is not a Ruby-level frame,
the binding will be mostly empty.  Try to handle empty bindings
by making the binding methods recognize empty bindings and handle
them appropriately.

Since I'm not sure how local variables are supposed to be stored
in env for C-level bindings, repurpose pathobj as a plain Ruby
hash for storing local variables for C-level bindings.  Check the
block member of rb_binding_t to determine if the binding is C-level
or not.

Raise RuntimeError of eval and receiver for C-level bindings, since
the operations do not make sense.

Remove a yjit bootstrap test that depended on looking up more than
one binding (which is probably how this bug was originally
discovered).

Fixes [Bug #18487]