### PR TITLE
Document mandatory require for using io/wait methods

### DIFF
--- a/ext/io/wait/wait.c
+++ b/ext/io/wait/wait.c
@@ -77,6 +77,8 @@ wait_for_single_fd(rb_io_t *fptr, int events, struct timeval *tv)
  *
  * Returns number of bytes that can be read without blocking.
  * Returns zero if no information available.
+ *
+ * You must require 'io/wait' to use this method.
  */
 
 static VALUE
@@ -122,6 +124,8 @@ io_wait_event(VALUE io, int event, VALUE timeout)
  *   io.ready? -> true or false
  *
  * Returns +true+ if input available without blocking, or +false+.
+ *
+ * You must require 'io/wait' to use this method.
  */
 
 static VALUE
@@ -154,6 +158,8 @@ io_ready_p(VALUE io)
  * Waits until IO is readable and returns +true+, or
  * +false+ when times out.
  * Returns +true+ immediately when buffered data is available.
+ *
+ * You must require 'io/wait' to use this method.
  */
 
 static VALUE
@@ -193,6 +199,8 @@ io_wait_readable(int argc, VALUE *argv, VALUE io)
  *
  * Waits until IO is writable and returns +true+ or
  * +false+ when times out.
+ *
+ * You must require 'io/wait' to use this method.
  */
 static VALUE
 io_wait_writable(int argc, VALUE *argv, VALUE io)
@@ -228,6 +236,8 @@ io_wait_writable(int argc, VALUE *argv, VALUE io)
  *
  * Waits until IO is priority and returns +true+ or
  * +false+ when times out.
+ *
+ * You must require 'io/wait' to use this method.
  */
 static VALUE
 io_wait_priority(int argc, VALUE *argv, VALUE io)
@@ -295,6 +305,8 @@ wait_mode_sym(VALUE mode)
  *
  * Optional parameter +mode+ is one of +:read+, +:write+, or
  * +:read_write+.
+ *
+ * You must require 'io/wait' to use this method.
  */
 
 static VALUE


### PR DESCRIPTION
Currently, the [IO Method documentation](https://docs.ruby-lang.org/en/master/IO.html) doesn't indicate `io/wait` is required for some of the methods. 

Currently, for a beginner this will result in errors which are very hard to debug. For example:


```bash
(ins)) ruby experiments.rb
experiments.rb:1:in `<main>': undefined method `nread' for #<IO:<STDIN>> (NoMethodError)
Did you mean?  read
               pread


(ins)) cat experiments.rb 
puts $stdin.nread

(ins)) ruby --version
ruby 3.0.3p157 (2021-11-24 revision 3fb7d2cadc) [x86_64-darwin20]
```