### PR TITLE
Keep right operand within width when right shifting

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -4956,7 +4956,7 @@ try_move(rb_objspace_t *objspace, rb_heap_t *heap, struct heap_page *sweep_page,
 
         bits_t bits = mark_bits[index] & ~pin_bits[index];
 
-        bits >>= NUM_IN_PAGE(p);
+        bits >>= NUM_IN_PAGE(p) % BITS_BITLENGTH;
         if (try_move_plane(objspace, heap, sweep_page, (uintptr_t)p, bits, dest)) return 1;
 
         if (index == 0) {


### PR DESCRIPTION
NUM_IN_PAGE could return a value much larger than 64. According to the
C11 spec 6.5.7 paragraph 3 this is undefined behavior:

> If the value of the right operand is negative or is greater than or
> equal to the width of the promoted left operand, the behavior is
> undefined.

On most platforms, this is usually not a problem as the architecture
will mask off all out-of-range bits.