### PR TITLE
[DOC] Clarify Class#subclases behavior quirks

### DIFF
--- a/class.c
+++ b/class.c
@@ -1572,6 +1572,27 @@ class_descendants(VALUE klass, bool immediate_only)
  *     A.subclasses        #=> [D, B]
  *     B.subclasses        #=> [C]
  *     C.subclasses        #=> []
+ *
+ *  Anonymous subclasses (not associated with a constant) are
+ *  returned, too:
+ *
+ *     c = Class.new(A)
+ *     A.subclasses        # => [#<Class:0x00007f003c77bd78>, D, B]
+ *
+ *  Note that the parent does not hold references to subclasses
+ *  and doesn't prevent them from being garbage collected. This
+ *  means that the subclass might disappear when all references
+ *  to it are dropped:
+ *
+ *     # drop the reference to subclass, it can be garbage-collected now
+ *     c = nil
+ *
+ *     A.subclasses
+ *     # It can be
+ *     #  => [#<Class:0x00007f003c77bd78>, D, B]
+ *     # ...or just
+ *     #  => [D, B]
+ *     # ...depending on whether garbage collector was run
  */
 
 VALUE


### PR DESCRIPTION
As per discussion in [Feature #18273](https://bugs.ruby-lang.org/issues/18273), explain the non-deterministic nature of the method.

Rendering of a version achieved after some discussion:
![image](https://user-images.githubusercontent.com/129656/151247556-f31f8b1b-167c-40b7-9eb3-1f1ec329a60d.png)
