### PR TITLE
[wip] LSAN integration

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -6608,6 +6608,7 @@ gc.$(OBJEXT): {$(VPATH)}darray.h
 gc.$(OBJEXT): {$(VPATH)}debug.h
 gc.$(OBJEXT): {$(VPATH)}debug_counter.h
 gc.$(OBJEXT): {$(VPATH)}defines.h
+gc.$(OBJEXT): {$(VPATH)}drop_at_exit.c
 gc.$(OBJEXT): {$(VPATH)}encoding.h
 gc.$(OBJEXT): {$(VPATH)}eval_intern.h
 gc.$(OBJEXT): {$(VPATH)}gc.c

--- a/drop_at_exit.c
+++ b/drop_at_exit.c
@@ -1,0 +1,38 @@
+int rb_cleanup_at_exit_i(void *vstart, void *vend, size_t stride, void *data)
+{
+        rb_objspace_t *objspace = &rb_objspace;
+        VALUE v = (VALUE)vstart;
+        for (; v != (VALUE)vend; v += stride) {
+                asan_unpoison_object(v, false);
+                switch (BUILTIN_TYPE(v)) {
+                        case T_NONE:
+                                break;
+                        default:
+                                obj_free(objspace, v);
+                }
+        }
+        return 0;
+}
+
+void rb_cleanup_at_exit(void)
+{
+        rb_objspace_t *objspace = &rb_objspace;
+
+        // Fix FrozenCore flags.
+        // It's explicitly marked as ICLASS, but in fact it's a class
+        RBASIC(rb_mRubyVMFrozenCore)->flags = T_CLASS;
+
+        // Iterate over all pages and manually free all objects
+        struct each_obj_data each_obj_data = {
+                .objspace = objspace,
+                .reenable_incremental = false,
+
+                .callback = rb_cleanup_at_exit_i,
+                .data = NULL,
+
+                .pages = {NULL},
+                .pages_counts = {0},
+        };
+        objspace_each_objects_try((VALUE)&each_obj_data);
+        objspace_each_objects_ensure((VALUE)&each_obj_data);
+}

--- a/gc.c
+++ b/gc.c
@@ -13728,6 +13728,8 @@ rb_gcdebug_remove_stress_to_class(int argc, VALUE *argv, VALUE self)
 
 #include "gc.rbinc"
 
+#include "drop_at_exit.c"
+
 void
 Init_GC(void)
 {

--- a/gc.c
+++ b/gc.c
@@ -3394,9 +3394,13 @@ obj_free(rb_objspace_t *objspace, VALUE obj)
           case imemo_parser_strterm:
             RB_DEBUG_COUNTER_INC(obj_imemo_parser_strterm);
             break;
-          case imemo_callinfo:
+          case imemo_callinfo: {
+            struct rb_callinfo *ci = (struct rb_callinfo *)obj;
+            struct rb_callinfo_kwarg *kwarg = (struct rb_callinfo_kwarg *)ci->kwarg;
+            ruby_xfree(kwarg);
             RB_DEBUG_COUNTER_INC(obj_imemo_callinfo);
             break;
+          }
           case imemo_callcache:
             RB_DEBUG_COUNTER_INC(obj_imemo_callcache);
             break;

--- a/string.c
+++ b/string.c
@@ -899,6 +899,7 @@ str_new0(VALUE klass, const char *ptr, long len, int termlen)
             rb_xmalloc_mul_add_mul(sizeof(char), len, sizeof(char), termlen);
 	STR_SET_NOEMBED(str);
     }
+    asan_unpoison_memory_region(RSTRING_PTR(str), len + termlen, true);
     if (ptr) {
 	memcpy(RSTRING_PTR(str), ptr, len);
     }

--- a/vm.c
+++ b/vm.c
@@ -2697,6 +2697,15 @@ ruby_vm_destruct(rb_vm_t *vm)
 {
     RUBY_FREE_ENTER("vm");
 
+    rb_thread_t *th = vm->ractor.main_thread;
+    xfree(th->ec->vm_stack);
+
+    void rb_cleanup_at_exit(void);
+    rb_cleanup_at_exit();
+    RUBY_FREE_LEAVE("vm");
+    return 0;
+
+
     if (vm) {
 	rb_thread_t *th = vm->ractor.main_thread;
 	struct rb_objspace *objspace = vm->objspace;

--- a/vm_method.c
+++ b/vm_method.c
@@ -1086,7 +1086,12 @@ method_entry_set(VALUE klass, ID mid, const rb_method_entry_t *me,
 		 rb_method_visibility_t visi, VALUE defined_class)
 {
     rb_method_entry_t *newme = rb_method_entry_make(klass, mid, defined_class, visi,
-						    me->def->type, method_definition_addref(me->def), 0, NULL);
+						    me->def->type, me->def, 0, NULL);
+    if (newme != me) {
+        // increase alias_count only if new method is created.
+        // skip cases like `alias foo foo` that are no-op.
+        method_definition_addref(me->def);
+    }
     method_added(klass, mid);
     return newme;
 }


### PR DESCRIPTION
Spoiler: this is a WIP project.

By enabling `-O0 -fsanitize=address` and running `./miniruby -v` with `ASAN_OPTIONS=detect_leaks=1:malloc_context_size=100 LSAN_OPTIONS=report_objects=1` I was able to identify 2 memory leaks in prelude. Not even in any real-world complex Ruby code.

1. `alias foo foo` - this code prevents method `foo` from GC-ing. Very artificial, I guess that's why nobody noticed it. However, defining a method and aliasing it on itself in a loop eats memory indefinitely. 1 leak per one method-aliased-on-itself, caught in prelude/kernel that does `alias pp pp`.
2. Method call with kwargs leaves garbage after GC-ing. Basically when `compile_call` is called it allocates `rb_callinfo_kwarg` inside `rb_callinfo`, but the wrapper is an `imemo` that is fully managed by GC. This `imemo` had a very basic cleanup mechanism that didn't `free` any heap-allocated fields. 1 leak per one **method call definition**, not per actual call, so it's also minor.

I also added some dumb code that cleans the stack and all Ruby heap objects. This PR is WIP and so for now I'm going to keep it there (of course it will be hidden behind some feature flag, TBD).

Current state: `./miniruby -e 'p 42'` shows 0 leaks (well, because there's almost no Ruby code). `make` doesn't complete, it aborts on generating `transdb.h` via `tool/generic_erb.rb`. The error comes from ASAN, not LSAN. Initially there was a `use-after-poison` error from `rb_str_new`, and so I blindly added `asan_unpoison_memory_region(RSTRING_PTR(str), len + termlen, true);` to `str_new0`, but I'm pretty sure it's wrong. @peterzhu2118 Is it related to RVARGC changes?

Anyway, I added it locally and the error has gone. Then other appeared (`unknown-crash on address ...`):

``` sh
./miniruby -I./lib -I. -I.ext/common ./tool/generic_erb.rb -c -o transdb.h ./template/transdb.h.tmpl ./enc/trans enc/trans
==14131==ERROR: AddressSanitizer: unknown-crash on address 0x00010b1c0cd5 at pc 0x000102885d20 bp 0x7ffeed93a2f0 sp 0x7ffeed93a2e8
READ of size 8 at 0x00010b1c0cd5 thread T0
    #0 0x105e65b14 in __asan_memset (/usr/local/opt/llvm/lib/clang/13.0.0/lib/darwin/libclang_rt.asan_osx_dynamic.dylib:x86_64+0x42b14)
    #1 0x105581925 in rb_str_format ruby/sprintf.c:262:5
    #2 0x1055d7b47 in rb_str_format_m ruby/string.c:2380:16
    #3 0x1057733ac in ractor_safe_call_cfunc_1 ruby/./vm_insnhelper.c:2861:12
    #4 0x1057525f5 in vm_call_cfunc_with_frame ruby/./vm_insnhelper.c:3037:11
    #5 0x10575ed3c in vm_sendish ruby/./vm_insnhelper.c:4751:15
```

The worst part about it is that I'm getting the same error on the latest master. Any suggestions? I feel like there must be a `poison` call somewhere in the allocation mechanism, not in individual `String` constructors.

It can also can be reproduced with

```
./miniruby -e 'open("./enc/trans/big5.c") { |f| f.each_line { |l| p l } }'
```

it stops at line 9222 with `#define to_Big5_HKSCS_E4_AE_offsets 49372`, absolutely no idea why, it's the same as 20% of the file.