### PR TITLE
Add Range#reverse_each implementation for performance

### DIFF
--- a/test/ruby/test_range.rb
+++ b/test/ruby/test_range.rb
@@ -456,6 +456,71 @@ class TestRange < Test::Unit::TestCase
     assert_equal(["a", "b", "c"], a)
   end
 
+  def test_reverse_each
+    a = []
+    (1..3).reverse_each {|x| a << x }
+    assert_equal([3, 2, 1], a)
+
+    a = []
+    (1...3).reverse_each {|x| a << x }
+    assert_equal([2, 1], a)
+
+    a = []
+    (3..1).reverse_each {|x| a << x }
+    assert_equal([], a)
+
+    a = []
+    (3...1).reverse_each {|x| a << x }
+    assert_equal([], a)
+
+    fixnum_max = RbConfig::LIMITS['FIXNUM_MAX']
+    fixnum_min = RbConfig::LIMITS['FIXNUM_MIN']
+
+    a = []
+    (fixnum_max-1..fixnum_max+1).reverse_each {|x| a << x }
+    assert_equal([fixnum_max+1, fixnum_max, fixnum_max-1], a)
+
+    a = []
+    (fixnum_max-1..fixnum_max).reverse_each {|x| a << x }
+    assert_equal([fixnum_max, fixnum_max-1], a)
+
+    a = []
+    (fixnum_max-1...fixnum_max+1).reverse_each {|x| a << x }
+    assert_equal([fixnum_max, fixnum_max-1], a)
+
+    a = []
+    (fixnum_max+1..fixnum_max+3).reverse_each {|x| a << x }
+    assert_equal([fixnum_max+3, fixnum_max+2, fixnum_max+1], a)
+
+    a = []
+    (0..fixnum_min-1).reverse_each {|x| a << x }
+    assert_equal([], a)
+
+    a = []
+    (fixnum_max+3..fixnum_max+1).reverse_each {|x| a << x }
+    assert_equal([], a)
+
+    a = []
+    (fixnum_max+1..0).reverse_each {|x| a << x }
+    assert_equal([], a)
+
+    a = []
+    (fixnum_max+1..fixnum_min-1).reverse_each {|x| a << x }
+    assert_equal([], a)
+
+    a = []
+    (..3).reverse_each {|x| a << x; break if x <= 0 }
+    assert_equal([3, 2, 1, 0], a)
+
+    a = []
+    (...3).reverse_each {|x| a << x; break if x <= 0 }
+    assert_equal([2, 1, 0], a)
+
+    a = []
+    ("a".."c").reverse_each {|x| a << x }
+    assert_equal(["c", "b", "a"], a)
+  end
+
   def test_begin_end
     assert_equal(0, (0..1).begin)
     assert_equal(1, (0..1).end)


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/18515

Current `Range#reverse_each` uses `Enumerable#reverse_each` which is implemented with `#to_a`.
So we are virtually not able to use `#reverse_each` for a very large or beginless range, even if few elements are iterated on actually.

```
(1..2**100).reverse_each { |x| p x; break if x.odd? }
(..5).reverse_each { |x| p x; break if x == 0 }
(1..2**32).reverse_each.lazy.select { |x| Prime.prime?(x) }.take(3).to_a
```

This patch, implements `Range#reverse_each` for Integer elements,  enables these examples.

I think `#reverse_each` for an endless range should raise an exception.
This is a different issue, so I'll create another ticket later.