### PR TITLE
Check if `execv` is available for ruby/missing.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1149,6 +1149,7 @@ main()
 		ac_cv_header_sys_time_h=no
 		ac_cv_header_sys_times_h=no
 		ac_cv_header_sys_socket_h=no
+		ac_cv_func_execv=yes
 		ac_cv_func_lstat=yes
 		ac_cv_func_times=yes
 		ac_cv_func_waitpid=yes
@@ -1998,6 +1999,7 @@ AC_CHECK_FUNCS(endgrent)
 AC_CHECK_FUNCS(eventfd)
 AC_CHECK_FUNCS(execl)
 AC_CHECK_FUNCS(execle)
+AC_CHECK_FUNCS(execv)
 AC_CHECK_FUNCS(execve)
 AC_CHECK_FUNCS(explicit_memset)
 AC_CHECK_FUNCS(fcopyfile)


### PR DESCRIPTION
As MinGW has the declaration, the `dllimport` attribute difference is warned when compiling missing/*.c without including ruby/win32.h.

```
../src/include/ruby/missing.h:316:17: warning: 'execv' redeclared without dllimport attribute: previous dllimport ignored [-Wattributes]
  316 | RUBY_EXTERN int execv(const char *, char *const []);
      |                 ^~~~~
```
