### PR TITLE
increment alias_count on method aliasing only when new method is created

### DIFF
--- a/vm_method.c
+++ b/vm_method.c
@@ -1086,7 +1086,12 @@ method_entry_set(VALUE klass, ID mid, const rb_method_entry_t *me,
 		 rb_method_visibility_t visi, VALUE defined_class)
 {
     rb_method_entry_t *newme = rb_method_entry_make(klass, mid, defined_class, visi,
-						    me->def->type, method_definition_addref(me->def), 0, NULL);
+						    me->def->type, me->def, 0, NULL);
+    if (newme != me) {
+        // increase alias_count only if new method is created.
+        // skip cases like `alias foo foo` that are no-op.
+        method_definition_addref(me->def);
+    }
     method_added(klass, mid);
     return newme;
 }


### PR DESCRIPTION
[Ruby issue](https://bugs.ruby-lang.org/issues/18516)

it fixes a memory leak on calling `alias foo foo`. extracted from https://github.com/ruby/ruby/pull/5488

The following code produces a memory leak:

```ruby
class A
  1.upto(Float::INFINITY) do |i|
    define_method(:"foo_#{i}") {}

    alias :"foo_#{i}" :"foo_#{i}"

    remove_method :"foo_#{i}"
  end
end
```

It is very artificial, but it's required for LSAN/Valgrind integration.

The reason why it leaks is the following:

1. `alias foo foo` increments `alias_count` even if no alias is created
2. later during GC `rb_free_method_entry` is called that in turn calls `rb_method_definition_release` that calls `free` only if `alias_count + complemented_count == 0`.
3. In this particular case `alias_count` is 1, and so no cleanup happens.

@nobu in #5488 you mentioned that

> Aliasing to the same name is intentionally adding the count, to suppress the later method redefinition warning.

Could you provide a code example please? I've tried defining a method, aliasing it on itself, and redefining it, no warning appears with this patch.