### PR TITLE
[lldb] Handle MacOS 64Kb heap pages in the lldb helpers

### DIFF
--- a/misc/lldb_cruby.py
+++ b/misc/lldb_cruby.py
@@ -10,8 +10,13 @@ from __future__ import print_function
 import lldb
 import os
 import shlex
+import platform
 
-HEAP_PAGE_ALIGN_LOG = 14
+if platform.system() == 'Darwin':
+    HEAP_PAGE_ALIGN_LOG = 16
+else:
+    HEAP_PAGE_ALIGN_LOG = 14
+
 HEAP_PAGE_ALIGN_MASK = (~(~0 << HEAP_PAGE_ALIGN_LOG))
 HEAP_PAGE_ALIGN = (1 << HEAP_PAGE_ALIGN_LOG)
 HEAP_PAGE_SIZE = HEAP_PAGE_ALIGN


### PR DESCRIPTION
the `HeapPageIter` checks for the pages validity before allowing you to dump the pages contents in the debugger. This has not worked on MacOS since https://github.com/ruby/ruby/pull/5373 was merged.

This patch sets the correct value for HEAP_PAGE_ALIGN_LOG in the debug helpers for MacOS only, to ensure the page validity checks work again.