### PR TITLE
Make Range#reverse_each to raise an exception if endless

### DIFF
--- a/range.c
+++ b/range.c
@@ -1133,6 +1133,11 @@ range_reverse_each(VALUE range)
     VALUE end = RANGE_END(range);
     int excl = EXCL(range);
 
+    if (NIL_P(end)) {
+        rb_raise(rb_eTypeError, "can't iterate from %s",
+                 rb_obj_classname(end));
+    }
+
     if (FIXNUM_P(beg) && FIXNUM_P(end)) {
         if (excl) {
             if (end == LONG2FIX(FIXNUM_MIN)) return range;

--- a/test/ruby/test_range.rb
+++ b/test/ruby/test_range.rb
@@ -582,6 +582,14 @@ class TestRange < Test::Unit::TestCase
     assert_equal([fmin-2, fmin-3], a)
   end
 
+  def test_reverse_each_for_endless_range
+    assert_raise(TypeError) { (1..).reverse_each {} }
+
+    enum = nil
+    assert_nothing_raised { enum = (1..).reverse_each }
+    assert_raise(TypeError) { enum.each {} }
+  end
+
   def test_reverse_each_for_single_point_range
     fmin = RbConfig::LIMITS['FIXNUM_MIN']
     fmax = RbConfig::LIMITS['FIXNUM_MAX']


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/18551

Currently, `Range#reverse_each` for an endless range never returns.

```
% ruby -e '(1..).reverse_each { }'
# never return ...
```

(This is because `Enumerable#reverse_each` tries `#to_a` and `#to_a` for an endless range comes into an infinite loop.)

I think `Range#reverse_each` for an endless range should raise an exception, similar to `Range#each` for a beginless range.

```
% ruby -e '(..1).each { }' 
-e:1:in `each': can't iterate from NilClass (TypeError)
	from -e:1:in `<main>'
```
