### PR TITLE
Using `rb_attr_get` in `rb_ivar_get` function

### DIFF
--- a/variable.c
+++ b/variable.c
@@ -1284,7 +1284,7 @@ rb_ivar_lookup(VALUE obj, ID id, VALUE undef)
 VALUE
 rb_ivar_get(VALUE obj, ID id)
 {
-    VALUE iv = rb_ivar_lookup(obj, id, Qnil);
+    VALUE iv = rb_attr_get(obj, id);
     RB_DEBUG_COUNTER_INC(ivar_get_base);
     return iv;
 }


### PR DESCRIPTION
In `rb_ivar_get` function is used  `rb_ivar_lookup` function.

```c
VALUE iv = rb_ivar_lookup(obj, id, Qnil);
```

But, this code same in `rb_attr_get` function's code.

```c
return rb_ivar_lookup(obj, id, Qnil);
```

I think better to using `rb_attr_get` in `rb_ivar_get` function.
