### PR TITLE
[Bug#18556] Fallback `MAP_ANONYMOUS`

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -138,6 +138,10 @@
 #define rb_jmp_buf rb_jmpbuf_t
 #undef rb_data_object_wrap
 
+#if !defined(MAP_ANONYMOUS) && defined(MAP_ANON)
+#define MAP_ANONYMOUS MAP_ANON
+#endif
+
 static inline struct rbimpl_size_mul_overflow_tag
 size_add_overflow(size_t x, size_t y)
 {


### PR DESCRIPTION
Define `MAP_ANONYMOUS` to `MAP_ANON` if undefined on old systems.