### PR TITLE
pend some tests while using to_binary

### DIFF
--- a/test/ruby/test_ast.rb
+++ b/test/ruby/test_ast.rb
@@ -255,6 +255,8 @@ class TestAst < Test::Unit::TestCase
   end
 
   def test_of_proc_and_method_under_eval_with_keep_script_lines
+    pend if ENV['RUBY_ISEQ_DUMP_DEBUG'] # TODO
+
     keep_script_lines_back = RubyVM.keep_script_lines
     RubyVM.keep_script_lines = true
 
@@ -302,6 +304,8 @@ class TestAst < Test::Unit::TestCase
   end
 
   def test_of_backtrace_location_under_eval_with_keep_script_lines
+    pend if ENV['RUBY_ISEQ_DUMP_DEBUG'] # TODO
+
     keep_script_lines_back = RubyVM.keep_script_lines
     RubyVM.keep_script_lines = true
 

--- a/test/ruby/test_rubyvm.rb
+++ b/test/ruby/test_rubyvm.rb
@@ -34,6 +34,8 @@ class TestRubyVM < Test::Unit::TestCase
   end
 
   def test_keep_script_lines
+    pend if ENV['RUBY_ISEQ_DUMP_DEBUG'] # TODO
+
     prev_conf = RubyVM.keep_script_lines
 
     # keep


### PR DESCRIPTION
ISeqs from ISeq#to_binary/load do not support `keep_script_lines`
now so some tests should be pending tests with
`RUBY_ISEQ_DUMP_DEBUG=to_binary`

http://ci.rvm.jp/results/trunk-iseq_binary@phosphorus-docker/3806868