### PR TITLE
Add econv_get_encoding function

### DIFF
--- a/transcode.c
+++ b/transcode.c
@@ -3500,7 +3500,8 @@ check_econv(VALUE self)
 }
 
 static VALUE
-ecov_get_encoding(rb_encoding *encoding){
+ecov_get_encoding(rb_encoding *encoding)
+{
     if (!encoding)
         return Qnil;
     return rb_enc_from_encoding(encoding);

--- a/transcode.c
+++ b/transcode.c
@@ -3500,7 +3500,7 @@ check_econv(VALUE self)
 }
 
 static VALUE
-ecov_get_encoding(rb_encoding *encoding)
+econv_get_encoding(rb_encoding *encoding)
 {
     if (!encoding)
         return Qnil;

--- a/transcode.c
+++ b/transcode.c
@@ -3499,6 +3499,13 @@ check_econv(VALUE self)
     return ec;
 }
 
+static VALUE
+ecov_get_encoding(rb_encoding *encoding){
+    if (!encoding)
+        return Qnil;
+    return rb_enc_from_encoding(encoding);  
+}
+
 /*
  * call-seq:
  *   ec.source_encoding -> encoding
@@ -3509,9 +3516,7 @@ static VALUE
 econv_source_encoding(VALUE self)
 {
     rb_econv_t *ec = check_econv(self);
-    if (!ec->source_encoding)
-        return Qnil;
-    return rb_enc_from_encoding(ec->source_encoding);
+    return ecov_get_encoding(ec->source_encoding);
 }
 
 /*
@@ -3524,9 +3529,7 @@ static VALUE
 econv_destination_encoding(VALUE self)
 {
     rb_econv_t *ec = check_econv(self);
-    if (!ec->destination_encoding)
-        return Qnil;
-    return rb_enc_from_encoding(ec->destination_encoding);
+    return ecov_get_encoding(ec->destination_encoding);
 }
 
 /*

--- a/transcode.c
+++ b/transcode.c
@@ -3503,7 +3503,7 @@ static VALUE
 ecov_get_encoding(rb_encoding *encoding){
     if (!encoding)
         return Qnil;
-    return rb_enc_from_encoding(encoding);  
+    return rb_enc_from_encoding(encoding);
 }
 
 /*

--- a/transcode.c
+++ b/transcode.c
@@ -3517,7 +3517,7 @@ static VALUE
 econv_source_encoding(VALUE self)
 {
     rb_econv_t *ec = check_econv(self);
-    return ecov_get_encoding(ec->source_encoding);
+    return econv_get_encoding(ec->source_encoding);
 }
 
 /*
@@ -3530,7 +3530,7 @@ static VALUE
 econv_destination_encoding(VALUE self)
 {
     rb_econv_t *ec = check_econv(self);
-    return ecov_get_encoding(ec->destination_encoding);
+    return econv_get_encoding(ec->destination_encoding);
 }
 
 /*


### PR DESCRIPTION
`econv_source_encoding` and `econv_destination_encoding` has similar code that get encoding.

```c
    if (!ec->source_encoding)
        return Qnil;
    return rb_enc_from_encoding(ec->source_encoding);
```

I think better to cut out these code and added function like a `ecov_get_encoding`.