### PR TITLE
Fix bundler CI

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1412,8 +1412,7 @@ yes-test-bundler-precheck: main
 no-test-bundler-prepare: no-test-bundler-precheck
 yes-test-bundler-prepare: yes-test-bundler-precheck
 	$(ACTIONS_GROUP)
-	$(XRUBY) -C "$(srcdir)" bin/gem install --no-document \
-		--install-dir .bundle --conservative "rspec:~> 3.8" "rake:~> 13.0" "parallel_tests:~> 2.29"
+	$(XRUBY) -C $(srcdir) -Ilib -e 'ENV["GEM_HOME"] = File.expand_path(".bundle"); ENV["BUNDLE_APP_CONFIG"] = File.expand_path(".bundle"); ENV["BUNDLE_PATH__SYSTEM"] = "true"; ENV["BUNDLE_WITHOUT"] = "lint doc"; load "spec/bundler/support/bundle.rb"' -- install --gemfile=tool/bundler/dev_gems.rb
 	$(ACTIONS_ENDGROUP)
 
 RSPECOPTS =

--- a/common.mk
+++ b/common.mk
@@ -1412,7 +1412,12 @@ yes-test-bundler-precheck: main
 no-test-bundler-prepare: no-test-bundler-precheck
 yes-test-bundler-prepare: yes-test-bundler-precheck
 	$(ACTIONS_GROUP)
-	$(XRUBY) -C $(srcdir) -Ilib -e 'ENV["GEM_HOME"] = File.expand_path(".bundle"); ENV["BUNDLE_APP_CONFIG"] = File.expand_path(".bundle"); ENV["BUNDLE_PATH__SYSTEM"] = "true"; ENV["BUNDLE_WITHOUT"] = "lint doc"; load "spec/bundler/support/bundle.rb"' -- install --gemfile=tool/bundler/dev_gems.rb
+	$(XRUBY) -C $(srcdir) -Ilib \
+		-e 'ENV["GEM_HOME"] = File.expand_path(".bundle")' \
+		-e 'ENV["BUNDLE_APP_CONFIG"] = File.expand_path(".bundle")' \
+		-e 'ENV["BUNDLE_PATH__SYSTEM"] = "true"' \
+		-e 'ENV["BUNDLE_WITHOUT"] = "lint doc"' \
+		-e 'load "spec/bundler/support/bundle.rb"' -- install --gemfile=tool/bundler/dev_gems.rb
 	$(ACTIONS_ENDGROUP)
 
 RSPECOPTS =

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -266,7 +266,7 @@ module Bundler
         else
           # Run a resolve against the locally available gems
           Bundler.ui.debug("Found changes from the lockfile, re-resolving dependencies because #{change_reason}")
-          expanded_dependencies = expand_dependencies(dependencies + metadata_dependencies, @remote)
+          expanded_dependencies = expand_dependencies(dependencies + metadata_dependencies, true)
           Resolver.resolve(expanded_dependencies, source_requirements, last_resolve, gem_version_promoter, additional_base_requirements_for_resolve, platforms)
         end
       end

--- a/lib/bundler/resolver.rb
+++ b/lib/bundler/resolver.rb
@@ -249,10 +249,11 @@ module Bundler
     end
 
     def verify_gemfile_dependencies_are_found!(requirements)
-      requirements.each do |requirement|
+      requirements.map! do |requirement|
         name = requirement.name
-        next if name == "bundler"
-        next unless search_for(requirement).empty?
+        next requirement if name == "bundler"
+        next requirement unless search_for(requirement).empty?
+        next unless requirement.current_platform?
 
         if (base = @base[name]) && !base.empty?
           version = base.first.version
@@ -266,7 +267,7 @@ module Bundler
           message = gem_not_found_message(name, requirement, source_for(name))
         end
         raise GemNotFound, message
-      end
+      end.compact!
     end
 
     def gem_not_found_message(name, requirement, source, extra_message = "")

--- a/spec/bundler/commands/binstubs_spec.rb
+++ b/spec/bundler/commands/binstubs_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe "bundle binstubs <gem>" do
         end
 
         context "and the version is older and the same major" do
-          let(:system_bundler_version) { "2.3.3" }
+          let(:system_bundler_version) { "2.999.999" }
 
           before do
             lockfile lockfile.gsub(/BUNDLED WITH\n   .*$/m, "BUNDLED WITH\n   2.3.0")
@@ -191,7 +191,7 @@ RSpec.describe "bundle binstubs <gem>" do
           it "installs and runs the exact version of bundler", :rubygems => ">= 3.3.0.dev" do
             sys_exec "bin/bundle install --verbose", :artifice => "vcr"
             expect(exitstatus).not_to eq(42)
-            expect(out).to include("Bundler 2.3.3 is running, but your lockfile was generated with 2.3.0. Installing Bundler 2.3.0 and restarting using that version.")
+            expect(out).to include("Bundler 2.999.999 is running, but your lockfile was generated with 2.3.0. Installing Bundler 2.3.0 and restarting using that version.")
             expect(out).to include("Using bundler 2.3.0")
             expect(err).not_to include("Activating bundler (~> 2.3.0) failed:")
           end
@@ -199,8 +199,8 @@ RSpec.describe "bundle binstubs <gem>" do
           it "runs the available version of bundler", :rubygems => "< 3.3.0.dev" do
             sys_exec "bin/bundle install --verbose"
             expect(exitstatus).not_to eq(42)
-            expect(out).not_to include("Bundler 2.3.3 is running, but your lockfile was generated with 2.3.0. Installing Bundler 2.3.0 and restarting using that version.")
-            expect(out).to include("Using bundler 2.3.3")
+            expect(out).not_to include("Bundler 2.999.999 is running, but your lockfile was generated with 2.3.0. Installing Bundler 2.3.0 and restarting using that version.")
+            expect(out).to include("Using bundler 2.999.999")
             expect(err).not_to include("Activating bundler (~> 2.3.0) failed:")
           end
         end

--- a/spec/bundler/commands/cache_spec.rb
+++ b/spec/bundler/commands/cache_spec.rb
@@ -403,14 +403,14 @@ RSpec.describe "bundle install with gem sources" do
 
       simulate_new_machine
 
-      simulate_platform "ruby" do
-        install_gemfile <<-G
-          source "#{file_uri_for(gem_repo1)}"
-          gem "platform_specific"
-        G
-        run "require 'platform_specific' ; puts PLATFORM_SPECIFIC"
-        expect(out).to eq("1.0.0 RUBY")
-      end
+      bundle "config set --local force_ruby_platform true"
+
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
+        gem "platform_specific"
+      G
+      run "require 'platform_specific' ; puts PLATFORM_SPECIFIC"
+      expect(out).to eq("1.0.0 RUBY")
     end
 
     it "does not update the cache if --no-cache is passed" do

--- a/spec/bundler/commands/clean_spec.rb
+++ b/spec/bundler/commands/clean_spec.rb
@@ -638,7 +638,12 @@ RSpec.describe "bundle clean" do
       s.executables = "irb"
     end
 
-    realworld_system_gems "fiddle --version 1.0.8", "tsort --version 0.1.0", "pathname --version 0.1.0", "set --version 1.0.1"
+    if Gem.win_platform? && RUBY_VERSION < "3.1.0"
+      default_fiddle_version = ruby "require 'fiddle'; puts Gem.loaded_specs['fiddle'].version"
+      realworld_system_gems "fiddle --version #{default_fiddle_version}"
+    end
+
+    realworld_system_gems "tsort --version 0.1.0", "pathname --version 0.1.0", "set --version 1.0.1"
 
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo2)}"

--- a/spec/bundler/commands/lock_spec.rb
+++ b/spec/bundler/commands/lock_spec.rb
@@ -337,7 +337,8 @@ RSpec.describe "bundle lock" do
          #{Bundler::VERSION}
     G
 
-    simulate_platform(rb) { bundle :lock }
+    bundle "config set --local force_ruby_platform true"
+    bundle :lock
 
     expect(lockfile).to eq <<~G
       GEM
@@ -507,6 +508,11 @@ RSpec.describe "bundle lock" do
 
       build_gem "raygun-apm", "1.0.78" do |s|
         s.platform = "x64-mingw32"
+        s.required_ruby_version = "< #{next_minor}.dev"
+      end
+
+      build_gem "raygun-apm", "1.0.78" do |s|
+        s.platform = "x64-mingw-ucrt"
         s.required_ruby_version = "< #{next_minor}.dev"
       end
     end

--- a/spec/bundler/install/gemfile/gemspec_spec.rb
+++ b/spec/bundler/install/gemfile/gemspec_spec.rb
@@ -429,13 +429,16 @@ RSpec.describe "bundle install from an existing gemspec" do
           gemspec
         G
 
-        simulate_platform("ruby") { bundle "install" }
+        bundle "config set --local force_ruby_platform true"
+        bundle "install"
+
+        simulate_new_machine
         simulate_platform("jruby") { bundle "install" }
       end
 
       context "on ruby" do
         before do
-          simulate_platform("ruby")
+          bundle "config set --local force_ruby_platform true"
           bundle :install
         end
 
@@ -546,7 +549,7 @@ RSpec.describe "bundle install from an existing gemspec" do
     end
 
     it "installs the ruby platform gemspec" do
-      simulate_platform "ruby"
+      bundle "config set --local force_ruby_platform true"
 
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
@@ -557,7 +560,7 @@ RSpec.describe "bundle install from an existing gemspec" do
     end
 
     it "installs the ruby platform gemspec and skips dev deps with `without development` configured" do
-      simulate_platform "ruby"
+      bundle "config set --local force_ruby_platform true"
 
       bundle "config set --local without development"
       install_gemfile <<-G
@@ -620,6 +623,66 @@ RSpec.describe "bundle install from an existing gemspec" do
       bundle "update"
 
       expect(lockfile).to eq initial_lockfile
+    end
+  end
+
+  context "with multiple locked platforms" do
+    before do
+      build_lib("activeadmin", :path => tmp.join("activeadmin")) do |s|
+        s.version = "2.9.0"
+        s.add_dependency "railties", ">= 5.2", "< 6.2"
+      end
+
+      build_repo4 do
+        build_gem "railties", "6.1.4"
+
+        build_gem "jruby-openssl", "0.10.7" do |s|
+          s.platform = "java"
+        end
+      end
+
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo4)}"
+        gemspec :path => "../activeadmin"
+        gem "jruby-openssl", :platform => :jruby
+      G
+
+      bundle "lock --add-platform java"
+    end
+
+    it "does not remove the platform specific specs from the lockfile when re-resolving due to gemspec changes" do
+      expect(lockfile).to eq <<~L
+        PATH
+          remote: ../activeadmin
+          specs:
+            activeadmin (2.9.0)
+              railties (>= 5.2, < 6.2)
+
+        GEM
+          remote: #{file_uri_for(gem_repo4)}/
+          specs:
+            jruby-openssl (0.10.7-java)
+            railties (6.1.4)
+
+        PLATFORMS
+          #{lockfile_platforms_for(["java"] + local_platforms)}
+
+        DEPENDENCIES
+          activeadmin!
+          jruby-openssl
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+
+      gemspec = tmp.join("activeadmin/activeadmin.gemspec")
+      File.write(gemspec, File.read(gemspec).sub(">= 5.2", ">= 6.0"))
+
+      previous_lockfile = lockfile
+
+      bundle "install --local"
+
+      expect(lockfile).to eq(previous_lockfile.sub(">= 5.2", ">= 6.0"))
     end
   end
 end

--- a/spec/bundler/install/gemfile/git_spec.rb
+++ b/spec/bundler/install/gemfile/git_spec.rb
@@ -92,9 +92,7 @@ RSpec.describe "bundle install with git sources" do
       expect(err).to include("The source contains the following gems matching 'foo':\n  * foo-1.0")
     end
 
-    it "complains with version and platform if pinned specs don't exist in the git repo" do
-      simulate_platform "java"
-
+    it "complains with version and platform if pinned specs don't exist in the git repo", :jruby do
       build_git "only_java" do |s|
         s.platform = "java"
       end
@@ -109,9 +107,7 @@ RSpec.describe "bundle install with git sources" do
       expect(err).to include("The source contains the following gems matching 'only_java':\n  * only_java-1.0-java")
     end
 
-    it "complains with multiple versions and platforms if pinned specs don't exist in the git repo" do
-      simulate_platform "java"
-
+    it "complains with multiple versions and platforms if pinned specs don't exist in the git repo", :jruby do
       build_git "only_java", "1.0" do |s|
         s.platform = "java"
       end

--- a/spec/bundler/install/gemfile/platform_spec.rb
+++ b/spec/bundler/install/gemfile/platform_spec.rb
@@ -86,13 +86,13 @@ RSpec.describe "bundle install across platforms" do
     expect(the_bundle).to include_gems "nokogiri 1.4.2 JAVA", "weakling 0.0.3"
 
     simulate_new_machine
-
-    simulate_platform "ruby"
+    bundle "config set --local force_ruby_platform true"
     bundle "install"
 
     expect(the_bundle).to include_gems "nokogiri 1.4.2"
     expect(the_bundle).not_to include_gems "weakling"
 
+    simulate_new_machine
     simulate_platform "java"
     bundle "install"
 
@@ -453,7 +453,7 @@ RSpec.describe "bundle install with platform conditionals" do
   end
 
   it "does not attempt to install gems from :rbx when using --local" do
-    simulate_platform "ruby"
+    bundle "config set --local force_ruby_platform true"
 
     gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
@@ -465,7 +465,7 @@ RSpec.describe "bundle install with platform conditionals" do
   end
 
   it "does not attempt to install gems from other rubies when using --local" do
-    simulate_platform "ruby"
+    bundle "config set --local force_ruby_platform true"
     other_ruby_version_tag = RUBY_VERSION =~ /^1\.8/ ? :ruby_19 : :ruby_18
 
     gemfile <<-G
@@ -478,7 +478,7 @@ RSpec.describe "bundle install with platform conditionals" do
   end
 
   it "does not print a warning when a dependency is unused on a platform different from the current one" do
-    simulate_platform "ruby"
+    bundle "config set --local force_ruby_platform true"
 
     gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"

--- a/spec/bundler/install/gems/standalone_spec.rb
+++ b/spec/bundler/install/gems/standalone_spec.rb
@@ -113,7 +113,12 @@ RSpec.shared_examples "bundle install --standalone" do
       skip "does not work on rubygems versions where `--install_dir` doesn't respect --default" unless Gem::Installer.for_spec(loaded_gemspec, :install_dir => "/foo").default_spec_file == "/foo/specifications/default/bundler-#{Bundler::VERSION}.gemspec" # Since rubygems 3.2.0.rc.2
       skip "does not work on old rubies because the realworld gems that need to be installed don't support them" if RUBY_VERSION < "2.7.0"
 
-      realworld_system_gems "fiddle --version 1.0.8", "tsort --version 0.1.0"
+      if Gem.win_platform? && RUBY_VERSION < "3.1.0"
+        default_fiddle_version = ruby "require 'fiddle'; puts Gem.loaded_specs['fiddle'].version"
+        realworld_system_gems "fiddle --version #{default_fiddle_version}"
+      end
+
+      realworld_system_gems "tsort --version 0.1.0"
 
       necessary_system_gems = ["optparse --version 0.1.1", "psych --version 3.3.2", "yaml --version 0.1.1", "logger --version 1.4.3", "etc --version 1.2.0", "stringio --version 3.0.0"]
       necessary_system_gems += ["shellwords --version 0.1.0", "base64 --version 0.1.0", "resolv --version 0.2.1"] if Gem.rubygems_version < Gem::Version.new("3.3.a")

--- a/spec/bundler/runtime/inline_spec.rb
+++ b/spec/bundler/runtime/inline_spec.rb
@@ -309,7 +309,7 @@ RSpec.describe "bundler/inline#gemfile" do
   end
 
   it "skips platform warnings" do
-    simulate_platform "ruby"
+    bundle "config set --local force_ruby_platform true"
 
     script <<-RUBY
       gemfile(true) do

--- a/spec/bundler/support/hax.rb
+++ b/spec/bundler/support/hax.rb
@@ -19,16 +19,6 @@ module Gem
       @local = new(ENV["BUNDLER_SPEC_PLATFORM"])
     end
     @platforms = [Gem::Platform::RUBY, Gem::Platform.local]
-
-    if ENV["BUNDLER_SPEC_PLATFORM"] == "ruby"
-      class << self
-        remove_method :finish_resolve
-
-        def finish_resolve
-          []
-        end
-      end
-    end
   end
 
   if ENV["BUNDLER_SPEC_GEM_SOURCES"]

--- a/spec/bundler/support/path.rb
+++ b/spec/bundler/support/path.rb
@@ -30,7 +30,7 @@ module Spec
     end
 
     def test_gemfile
-      @test_gemfile ||= source_root.join("tool/bundler/test_gems.rb")
+      @test_gemfile ||= tool_dir.join("test_gems.rb")
     end
 
     def rubocop_gemfile
@@ -42,7 +42,7 @@ module Spec
     end
 
     def dev_gemfile
-      @dev_gemfile ||= git_root.join("dev_gems.rb")
+      @dev_gemfile ||= tool_dir.join("dev_gems.rb")
     end
 
     def bindir
@@ -294,7 +294,7 @@ module Spec
       else
         "rubocop_gems"
       end
-      source_root.join("tool/bundler/#{filename}.rb")
+      tool_dir.join("#{filename}.rb")
     end
 
     def standard_gemfile_basename
@@ -305,7 +305,11 @@ module Spec
       else
         "standard_gems"
       end
-      source_root.join("tool/bundler/#{filename}.rb")
+      tool_dir.join("#{filename}.rb")
+    end
+
+    def tool_dir
+      source_root.join("tool/bundler")
     end
 
     extend self

--- a/test/rubygems/test_rubygems.rb
+++ b/test/rubygems/test_rubygems.rb
@@ -42,11 +42,7 @@ class GemTest < Gem::TestCase
       "require \"rubygems\"; puts Gem::Specification.stubs.map(&:full_name)",
       {:err => [:child, :out]}
     ).strip
-    begin
-      assert_empty output
-    rescue Test::Unit::AssertionFailedError
-      pend "Temporary pending custom default_dir test"
-    end
+    assert_empty output
   end
 
   private

--- a/tool/bundler/dev_gems.rb
+++ b/tool/bundler/dev_gems.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "rdoc", "6.2.0" # 6.2.1 is required > Ruby 2.3
+gem "test-unit", "~> 3.0"
+gem "rake", "~> 13.0"
+
+group :lint do
+  gem "rubocop", "~> 0.80.1"
+  gem "rubocop-performance", "~> 1.5.2"
+end
+
+gem "webrick", "~> 1.6"
+gem "parallel_tests", "~> 2.29"
+gem "parallel", "1.19.2" # 1.20+ is required > Ruby 2.3
+gem "rspec-core", "~> 3.8"
+gem "rspec-expectations", "~> 3.8"
+gem "rspec-mocks", "~> 3.8"
+gem "uri", "~> 0.10.1"
+
+group :doc do
+  gem "ronn", "~> 0.7.3", :platform => :ruby
+end

--- a/tool/bundler/dev_gems.rb.lock
+++ b/tool/bundler/dev_gems.rb.lock
@@ -1,0 +1,75 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.2)
+    diff-lcs (1.5.0)
+    hpricot (0.8.6)
+    jaro_winkler (1.5.4)
+    jaro_winkler (1.5.4-java)
+    mustache (1.1.1)
+    parallel (1.19.2)
+    parallel_tests (2.32.0)
+      parallel
+    parser (3.1.0.0)
+      ast (~> 2.4.1)
+    power_assert (2.0.1)
+    rainbow (3.1.1)
+    rake (13.0.6)
+    rdiscount (2.2.0.2)
+    rdoc (6.2.0)
+    rexml (3.2.5)
+    ronn (0.7.3)
+      hpricot (>= 0.8.2)
+      mustache (>= 0.7.0)
+      rdiscount (>= 1.5.8)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.3)
+    rubocop (0.80.1)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.7.0.1)
+      rainbow (>= 2.2.2, < 4.0)
+      rexml
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-performance (1.5.2)
+      rubocop (>= 0.71.0)
+    ruby-progressbar (1.11.0)
+    test-unit (3.5.3)
+      power_assert
+    unicode-display_width (1.6.1)
+    uri (0.10.1)
+    webrick (1.7.0)
+
+PLATFORMS
+  java
+  ruby
+  universal-java-11
+  x64-mingw32
+  x86_64-darwin-20
+  x86_64-linux
+
+DEPENDENCIES
+  parallel (= 1.19.2)
+  parallel_tests (~> 2.29)
+  rake (~> 13.0)
+  rdoc (= 6.2.0)
+  ronn (~> 0.7.3)
+  rspec-core (~> 3.8)
+  rspec-expectations (~> 3.8)
+  rspec-mocks (~> 3.8)
+  rubocop (~> 0.80.1)
+  rubocop-performance (~> 1.5.2)
+  test-unit (~> 3.0)
+  uri (~> 0.10.1)
+  webrick (~> 1.6)
+
+BUNDLED WITH
+   2.4.0.dev

--- a/tool/sync_default_gems.rb
+++ b/tool/sync_default_gems.rb
@@ -101,6 +101,7 @@ def sync_default_gems(gem)
     File.write("lib/bundler/bundler.gemspec", gemspec_content)
 
     cp_r("#{upstream}/bundler/spec", "spec/bundler")
+    cp_r(Dir.glob("#{upstream}/bundler/tool/bundler/dev_gems*"), "tool/bundler")
     cp_r(Dir.glob("#{upstream}/bundler/tool/bundler/test_gems*"), "tool/bundler")
     cp_r(Dir.glob("#{upstream}/bundler/tool/bundler/rubocop_gems*"), "tool/bundler")
     cp_r(Dir.glob("#{upstream}/bundler/tool/bundler/standard_gems*"), "tool/bundler")


### PR DESCRIPTION
The release of `rspec-mocks-3.10.3` caused some Bundler specs to fail.

In order to get things green, this PR:

* Pulls in some changes in Bundler to be able to pull in the lockfiles we use to lock our test dependencies.
* Changes the way ruby-core runs Bundler specs to respect the lockfiles with our test dependencies.

The idea is to get CI back to green and avoid similar issues in the future.