### PR TITLE
Fix handling TAG_THROW through require

### DIFF
--- a/load.c
+++ b/load.c
@@ -1155,7 +1155,7 @@ require_internal(rb_execution_context_t *ec, VALUE fname, int exception, bool wa
     if (ftptr) load_unlock(th2->vm, RSTRING_PTR(path), !state);
 
     if (state) {
-        if (state == TAG_FATAL) {
+        if (state == TAG_FATAL || state == TAG_THROW) {
             EC_JUMP_TAG(ec, state);
         }
         else if (exception) {

--- a/test/ruby/test_exception.rb
+++ b/test/ruby/test_exception.rb
@@ -252,6 +252,27 @@ class TestException < Test::Unit::TestCase
     }
   end
 
+  def test_catch_throw_in_require_cant_be_rescued
+    bug18562 = '[ruby-core:107403]'
+    Tempfile.create(["dep", ".rb"]) {|t|
+      t.puts("throw :extdep, 42")
+      t.close
+
+      rescue_all = Class.new(Exception)
+      def rescue_all.===(_)
+        raise "should not reach here"
+      end
+
+      v = assert_throw(:extdep, bug18562) do
+        require t.path
+      rescue rescue_all => e
+        assert(false, "should not reach here")
+      end
+
+      assert_equal(42, v, bug18562)
+    }
+  end
+
   def test_throw_false
     bug12743 = '[ruby-core:77229] [Bug #12743]'
     Thread.start {


### PR DESCRIPTION
Previously this was being incorrectly swapped with TAG_RAISE in the next line. This would end up checking the `T_IMEMO` throw_data to the exception handling (which calls `Module#===`). This happened to not break existing tests because `Module#===` returned false when klass is `NULL`.

This commit handles throw from require correctly by jumping to the tag retaining the `TAG_THROW` state.

---

https://bugs.ruby-lang.org/issues/18562

```
echo "throw :extdep, 42" > test_throw.rb
```
```
class Anything < Exception
  def self.===(_); true; end
end

catch(:extdep) do
  begin
    require "./test_throw"
  rescue Anything => e
    p e
  end
end
```

```
 in 'p': method inspect' called on unexpected T_IMEMO object (0x00007f5e1486b130 flags=0x10000301a) (NotImplementedError)
```
