### PR TITLE
Sync io-console 0.5.11 to ruby_3_1

### DIFF
--- a/ext/io/console/console.c
+++ b/ext/io/console/console.c
@@ -90,6 +90,10 @@ extern VALUE rb_scheduler_timeout(struct timeval *timeout);
 #define sys_fail_fptr(fptr) rb_sys_fail_str((fptr)->pathv)
 
 #ifndef HAVE_RB_F_SEND
+#ifndef RB_PASS_CALLED_KEYWORDS
+# define rb_funcallv_kw(recv, mid, arg, argv, kw_splat) rb_funcallv(recv, mid, arg, argv)
+#endif
+
 static ID id___send__;
 
 static VALUE
@@ -104,7 +108,7 @@ rb_f_send(int argc, VALUE *argv, VALUE recv)
     else {
 	vid = id___send__;
     }
-    return rb_funcallv(recv, vid, argc, argv);
+    return rb_funcallv_kw(recv, vid, argc, argv, RB_PASS_CALLED_KEYWORDS);
 }
 #endif
 

--- a/ext/io/console/io-console.gemspec
+++ b/ext/io/console/io-console.gemspec
@@ -1,5 +1,5 @@
 # -*- ruby -*-
-_VERSION = "0.5.10"
+_VERSION = "0.5.11"
 
 Gem::Specification.new do |s|
   s.name = "io-console"

--- a/test/io/console/test_io_console.rb
+++ b/test/io/console/test_io_console.rb
@@ -488,7 +488,9 @@ defined?(IO.console) and TestIO_Console.class_eval do
     end
 
     def test_console_kw
-      assert_kind_of(IO, IO.console(:clone, freeze: true))
+      io = IO.console(:clone, freeze: true)
+      io.close
+      assert_kind_of(IO, io)
     end
 
     def test_sync

--- a/test/io/console/test_io_console.rb
+++ b/test/io/console/test_io_console.rb
@@ -407,6 +407,10 @@ defined?(PTY) and defined?(IO.console) and TestIO_Console.class_eval do
       assert_equal(["true"], run_pty("IO.console(:close); p IO.console(:tty?)"))
     end
 
+    def test_console_kw
+      assert_equal(["File"], run_pty("IO.console.close; p IO.console(:clone, freeze: true).class"))
+    end
+
     def test_sync
       assert_equal(["true"], run_pty("p IO.console.sync"))
     end
@@ -481,6 +485,10 @@ defined?(IO.console) and TestIO_Console.class_eval do
       assert(IO.console(:tty?))
     ensure
       IO.console(:close)
+    end
+
+    def test_console_kw
+      assert_kind_of(IO, IO.console(:clone, freeze: true))
     end
 
     def test_sync


### PR DESCRIPTION
https://github.com/ruby/ruby/pull/5473 contains the fix for io-console.gem. I'd like to synchronize to the released version of default gems.
The main changeset in io-console-0.5.11 was https://github.com/ruby/ruby/commit/f27eb8148f5a72bbacfebfecc7de9305471bb5c9 and the part of it was backported by https://github.com/ruby/ruby/pull/5473. I think we can safely synchronize ext/io/console to io-console-0.5.11.
see: https://github.com/ruby/io-console/compare/v0.5.10..v0.5.11

This PR contains the extra changes to synchronize ext/io/console to io-console v0.5.11, and one more commit to fix fd leak in the test.