### PR TITLE
Add Exception#detailed_message

### DIFF
--- a/error.c
+++ b/error.c
@@ -77,6 +77,7 @@ static ID id_category;
 static ID id_deprecated;
 static ID id_experimental;
 static VALUE sym_category;
+static VALUE sym_highlight;
 static struct {
     st_table *id2enum, *enum2id;
 } warning_categories;
@@ -1268,10 +1269,7 @@ check_highlight_keyword(VALUE opt, int auto_tty_detect)
     VALUE highlight = Qnil;
 
     if (!NIL_P(opt)) {
-        static VALUE kw_highlight;
-        if (!kw_highlight) kw_highlight = ID2SYM(rb_intern_const("highlight"));
-
-        highlight = rb_hash_aref(opt, kw_highlight);
+        highlight = rb_hash_aref(opt, sym_highlight);
 
         switch (highlight) {
           default:
@@ -1351,10 +1349,8 @@ exc_full_message(int argc, VALUE *argv, VALUE exc)
     order = check_order_keyword(opt);
 
     {
-        static VALUE kw_highlight;
-        if (!kw_highlight) kw_highlight = ID2SYM(rb_intern_const("highlight"));
         if (NIL_P(opt)) opt = rb_hash_new();
-        rb_hash_aset(opt, kw_highlight, highlight);
+        rb_hash_aset(opt, sym_highlight, highlight);
     }
 
     str = rb_str_new2("");
@@ -3076,6 +3072,7 @@ Init_Exception(void)
     id_recv = rb_make_internal_id();
 
     sym_category = ID2SYM(id_category);
+    sym_highlight = ID2SYM(rb_intern_const("highlight"));
 
     warning_categories.id2enum = rb_init_identtable();
     st_add_direct(warning_categories.id2enum, id_deprecated, RB_WARN_CATEGORY_DEPRECATED);

--- a/error.c
+++ b/error.c
@@ -1122,7 +1122,7 @@ static VALUE rb_eNOERROR;
 
 ID ruby_static_id_cause;
 #define id_cause ruby_static_id_cause
-static ID id_message, id_backtrace;
+static ID id_message, id_detailed_message, id_backtrace;
 static ID id_key, id_matchee, id_args, id_Errno, id_errno, id_i_path;
 static ID id_receiver, id_recv, id_iseq, id_local_variables;
 static ID id_private_call_p, id_top, id_bottom;
@@ -1224,12 +1224,27 @@ exc_to_s(VALUE exc)
 }
 
 /* FIXME: Include eval_error.c */
-void rb_error_write(VALUE errinfo, VALUE emesg, VALUE errat, VALUE str, VALUE highlight, VALUE reverse);
+void rb_error_write(VALUE errinfo, VALUE emesg, VALUE errat, VALUE str, VALUE opt, VALUE highlight, VALUE reverse);
 
 VALUE
 rb_get_message(VALUE exc)
 {
     VALUE e = rb_check_funcall(exc, id_message, 0, 0);
+    if (e == Qundef) return Qnil;
+    if (!RB_TYPE_P(e, T_STRING)) e = rb_check_string_type(e);
+    return e;
+}
+
+VALUE
+rb_get_detailed_message(VALUE exc, VALUE opt)
+{
+    VALUE e;
+    if (NIL_P(opt)) {
+        e = rb_check_funcall(exc, id_detailed_message, 0, 0);
+    }
+    else {
+        e = rb_check_funcall_kw(exc, id_detailed_message, 1, &opt, 1);
+    }
     if (e == Qundef) return Qnil;
     if (!RB_TYPE_P(e, T_STRING)) e = rb_check_string_type(e);
     return e;
@@ -1332,9 +1347,9 @@ exc_full_message(int argc, VALUE *argv, VALUE exc)
 
     str = rb_str_new2("");
     errat = rb_get_backtrace(exc);
-    emesg = rb_get_message(exc);
+    emesg = rb_get_detailed_message(exc, opt);
 
-    rb_error_write(exc, emesg, errat, str, highlight, order);
+    rb_error_write(exc, emesg, errat, str, opt, highlight, order);
     return str;
 }
 
@@ -1350,6 +1365,38 @@ static VALUE
 exc_message(VALUE exc)
 {
     return rb_funcallv(exc, idTo_s, 0, 0);
+}
+
+/*
+ * call-seq:
+ *   exception.detailed_message(highlight: bool, **opt)   ->  string
+ *
+ * Processes a string returned by #message.
+ *
+ * It may add the class name of the exception to the end of the first line.
+ * Also, when +highlight+ keyword is true, it adds ANSI escape sequences to
+ * make the message bold.
+ *
+ * If you override this method, it must be tolerant for unknown keyword
+ * arguments. All keyword arguments passed to #full_message are delegated
+ * to this method.
+ *
+ * This method is overridden by did_you_mean and error_highlight to add
+ * their information.
+ */
+
+static VALUE
+exc_detailed_message(int argc, VALUE *argv, VALUE exc)
+{
+    VALUE opt;
+
+    rb_scan_args(argc, argv, "0:", &opt);
+
+    VALUE highlight = check_highlight_keyword(opt);
+
+    extern VALUE rb_decorate_message(const VALUE eclass, const VALUE emesg, int highlight);
+
+    return rb_decorate_message(CLASS_OF(exc), rb_get_message(exc), highlight);
 }
 
 /*
@@ -2908,6 +2955,7 @@ Init_Exception(void)
     rb_define_method(rb_eException, "==", exc_equal, 1);
     rb_define_method(rb_eException, "to_s", exc_to_s, 0);
     rb_define_method(rb_eException, "message", exc_message, 0);
+    rb_define_method(rb_eException, "detailed_message", exc_detailed_message, -1);
     rb_define_method(rb_eException, "full_message", exc_full_message, -1);
     rb_define_method(rb_eException, "inspect", exc_inspect, 0);
     rb_define_method(rb_eException, "backtrace", exc_backtrace, 0);
@@ -2995,6 +3043,7 @@ Init_Exception(void)
 
     id_cause = rb_intern_const("cause");
     id_message = rb_intern_const("message");
+    id_detailed_message = rb_intern_const("detailed_message");
     id_backtrace = rb_intern_const("backtrace");
     id_key = rb_intern_const("key");
     id_matchee = rb_intern_const("matchee");

--- a/error.c
+++ b/error.c
@@ -1350,6 +1350,13 @@ exc_full_message(int argc, VALUE *argv, VALUE exc)
     highlight = check_highlight_keyword(opt, 1);
     order = check_order_keyword(opt);
 
+    {
+        static VALUE kw_highlight;
+        if (!kw_highlight) kw_highlight = ID2SYM(rb_intern_const("highlight"));
+        if (NIL_P(opt)) opt = rb_hash_new();
+        rb_hash_aset(opt, kw_highlight, highlight);
+    }
+
     str = rb_str_new2("");
     errat = rb_get_backtrace(exc);
     emesg = rb_get_detailed_message(exc, opt);

--- a/error.c
+++ b/error.c
@@ -1263,7 +1263,7 @@ exc_s_to_tty_p(VALUE self)
 }
 
 static VALUE
-check_highlight_keyword(VALUE opt)
+check_highlight_keyword(VALUE opt, int auto_tty_detect)
 {
     VALUE highlight = Qnil;
 
@@ -1283,7 +1283,12 @@ check_highlight_keyword(VALUE opt)
     }
 
     if (NIL_P(highlight)) {
-	highlight = rb_stderr_tty_p() ? Qtrue : Qfalse;
+        if (auto_tty_detect) {
+            highlight = rb_stderr_tty_p() ? Qtrue : Qfalse;
+        }
+        else {
+            highlight = Qfalse;
+        }
     }
 
     return highlight;
@@ -1342,7 +1347,7 @@ exc_full_message(int argc, VALUE *argv, VALUE exc)
 
     rb_scan_args(argc, argv, "0:", &opt);
 
-    highlight = check_highlight_keyword(opt);
+    highlight = check_highlight_keyword(opt, 1);
     order = check_order_keyword(opt);
 
     str = rb_str_new2("");
@@ -1392,11 +1397,11 @@ exc_detailed_message(int argc, VALUE *argv, VALUE exc)
 
     rb_scan_args(argc, argv, "0:", &opt);
 
-    VALUE highlight = check_highlight_keyword(opt);
+    VALUE highlight = check_highlight_keyword(opt, 0);
 
     extern VALUE rb_decorate_message(const VALUE eclass, const VALUE emesg, int highlight);
 
-    return rb_decorate_message(CLASS_OF(exc), rb_get_message(exc), highlight);
+    return rb_decorate_message(CLASS_OF(exc), rb_get_message(exc), RTEST(highlight));
 }
 
 /*

--- a/eval_error.c
+++ b/eval_error.c
@@ -79,47 +79,6 @@ error_print(rb_execution_context_t *ec)
     rb_ec_error_print(ec, ec->errinfo);
 }
 
-static void
-write_warnq(VALUE out, VALUE str, const char *ptr, long len)
-{
-    if (NIL_P(out)) {
-        const char *beg = ptr;
-        const long olen = len;
-        for (; len > 0; --len, ++ptr) {
-            unsigned char c = *ptr;
-            switch (c) {
-              case '\n': case '\t': continue;
-            }
-            if (rb_iscntrl(c)) {
-                char buf[5];
-                const char *cc = 0;
-                if (ptr > beg) rb_write_error2(beg, ptr - beg);
-                beg = ptr + 1;
-                cc = ruby_escaped_char(c);
-                if (cc) {
-                    rb_write_error2(cc, strlen(cc));
-                }
-                else {
-                    rb_write_error2(buf, snprintf(buf, sizeof(buf), "\\x%02X", c));
-                }
-            }
-            else if (c == '\\') {
-                rb_write_error2(beg, ptr - beg + 1);
-                beg = ptr;
-            }
-        }
-        if (ptr > beg) {
-            if (beg == RSTRING_PTR(str) && olen == RSTRING_LEN(str))
-                rb_write_error_str(str);
-            else
-                rb_write_error2(beg, ptr - beg);
-        }
-    }
-    else {
-        rb_str_cat(out, ptr, len);
-    }
-}
-
 #define CSI_BEGIN "\033["
 #define CSI_SGR "m"
 
@@ -174,11 +133,11 @@ print_errinfo(const VALUE eclass, const VALUE errat, const VALUE emesg, const VA
 	    if (RSTRING_PTR(epath)[0] == '#')
 		epath = 0;
 	    if ((tail = memchr(einfo, '\n', elen)) != 0) {
-                write_warnq(str, emesg, einfo, tail - einfo);
+                write_warn2(str, einfo, tail - einfo);
 		tail++;		/* skip newline */
 	    }
 	    else {
-                write_warnq(str, emesg, einfo, elen);
+                write_warn_str(str, emesg);
 	    }
 	    if (epath) {
 		write_warn(str, " (");
@@ -194,7 +153,7 @@ print_errinfo(const VALUE eclass, const VALUE errat, const VALUE emesg, const VA
 	    }
 	    if (tail && einfo+elen > tail) {
 		if (!highlight) {
-                    write_warnq(str, emesg, tail, einfo+elen-tail);
+                    write_warn2(str, tail, einfo+elen-tail);
 		    if (einfo[elen-1] != '\n') write_warn2(str, "\n", 1);
 		}
 		else {
@@ -205,7 +164,7 @@ print_errinfo(const VALUE eclass, const VALUE errat, const VALUE emesg, const VA
 			tail = memchr(einfo, '\n', elen);
 			if (!tail || tail > einfo) {
 			    write_warn(str, bold);
-                            write_warnq(str, emesg, einfo, tail ? tail-einfo : elen);
+                            write_warn2(str, einfo, tail ? tail-einfo : elen);
 			    write_warn(str, reset);
 			    if (!tail) {
 				write_warn2(str, "\n", 1);
@@ -215,7 +174,7 @@ print_errinfo(const VALUE eclass, const VALUE errat, const VALUE emesg, const VA
 			elen -= tail - einfo;
 			einfo = tail;
 			do ++tail; while (tail < einfo+elen && *tail == '\n');
-                        write_warnq(str, emesg, einfo, tail-einfo);
+                        write_warn2(str, einfo, tail-einfo);
 			elen -= tail - einfo;
 			einfo = tail;
 		    }

--- a/eval_error.c
+++ b/eval_error.c
@@ -189,7 +189,6 @@ rb_decorate_message(const VALUE eclass, const VALUE emesg, int highlight)
 		    einfo = tail;
                     write_warn2(str, "\n", 1);
 		    while (elen > 0) {
-                        write_warn2(str, "\n", 1);
 			tail = memchr(einfo, '\n', elen);
 			if (!tail || tail > einfo) {
 			    write_warn(str, bold);

--- a/test/ruby/test_exception.rb
+++ b/test/ruby/test_exception.rb
@@ -1400,4 +1400,33 @@ $stderr = $stdout; raise "\x82\xa0"') do |outs, errs, status|
       end
     end;
   end
+
+  def test_detailed_message
+    e = RuntimeError.new("message")
+    assert_equal("message (RuntimeError)", e.detailed_message)
+    assert_equal("\e[1mmessage (\e[1;4mRuntimeError\e[m\e[1m)\e[m", e.detailed_message(highlight: true))
+
+    e = RuntimeError.new("foo\nbar\nbaz")
+    assert_equal("foo (RuntimeError)\nbar\nbaz", e.detailed_message)
+    assert_equal("\e[1mfoo (\e[1;4mRuntimeError\e[m\e[1m)\e[m\n\e[1mbar\e[m\n\e[1mbaz\e[m", e.detailed_message(highlight: true))
+
+    e = RuntimeError.new("")
+    assert_equal("unhandled exception", e.detailed_message)
+    assert_equal("\e[1;4munhandled exception\e[m", e.detailed_message(highlight: true))
+
+    e = RuntimeError.new
+    assert_equal("RuntimeError (RuntimeError)", e.detailed_message)
+    assert_equal("\e[1mRuntimeError (\e[1;4mRuntimeError\e[m\e[1m)\e[m", e.detailed_message(highlight: true))
+  end
+
+  def test_full_message_with_custom_detailed_message
+    e = RuntimeError.new("message")
+    opt_ = nil
+    e.define_singleton_method(:detailed_message) do |**opt|
+      opt_ = opt
+      "BOO!"
+    end
+    assert_match("BOO!", e.full_message.lines.first)
+    assert_equal({ highlight: Exception.to_tty? }, opt_)
+  end
 end

--- a/test/ruby/test_exception.rb
+++ b/test/ruby/test_exception.rb
@@ -970,11 +970,12 @@ $stderr = $stdout; raise "\x82\xa0"') do |outs, errs, status|
     end
     assert_not_nil(e)
     assert_include(e.message, "\0")
-    assert_in_out_err([], src, [], [], *args, **opts) do |_, err,|
-      err.each do |e|
-        assert_not_include(e, "\0")
-      end
-    end
+    # Disabled by [Feature #18367]
+    #assert_in_out_err([], src, [], [], *args, **opts) do |_, err,|
+    #  err.each do |e|
+    #    assert_not_include(e, "\0")
+    #  end
+    #end
     e
   end
 

--- a/test/ruby/test_rubyoptions.rb
+++ b/test/ruby/test_rubyoptions.rb
@@ -357,9 +357,9 @@ class TestRubyOptions < Test::Unit::TestCase
 
     assert_in_out_err(%W(-\r -e) + [""], "", [], [])
 
-    assert_in_out_err(%W(-\rx), "", [], /invalid option -\\r  \(-h will show valid options\) \(RuntimeError\)/)
+    assert_in_out_err(%W(-\rx), "", [], /invalid option -\r  \(-h will show valid options\) \(RuntimeError\)/)
 
-    assert_in_out_err(%W(-\x01), "", [], /invalid option -\\x01  \(-h will show valid options\) \(RuntimeError\)/)
+    assert_in_out_err(%W(-\x01), "", [], /invalid option -\x01  \(-h will show valid options\) \(RuntimeError\)/)
 
     assert_in_out_err(%w(-Z), "", [], /invalid option -Z  \(-h will show valid options\) \(RuntimeError\)/)
   end

--- a/test/ruby/test_rubyoptions.rb
+++ b/test/ruby/test_rubyoptions.rb
@@ -357,7 +357,7 @@ class TestRubyOptions < Test::Unit::TestCase
 
     assert_in_out_err(%W(-\r -e) + [""], "", [], [])
 
-    assert_in_out_err(%W(-\rx), "", [], /invalid option -\r  \(-h will show valid options\) \(RuntimeError\)/)
+    assert_in_out_err(%W(-\rx), "", [], /invalid option -[\r\n]  \(-h will show valid options\) \(RuntimeError\)/)
 
     assert_in_out_err(%W(-\x01), "", [], /invalid option -\x01  \(-h will show valid options\) \(RuntimeError\)/)
 


### PR DESCRIPTION
Also, the default error printer and Exception#full_message use the
method instead of `Exception#message` to get the message string.

`Exception#detailed_message` calls `Exception#message`, decorates and
returns the result. It adds some escape sequences to highlight, and the
class name of the exception to the end of the first line of the message.

See https://bugs.ruby-lang.org/issues/18564 for details.