### PR TITLE
Decouple GC slot sizes from RVALUE

### DIFF
--- a/test/-ext-/string/test_capacity.rb
+++ b/test/-ext-/string/test_capacity.rb
@@ -5,13 +5,14 @@ require 'rbconfig/sizeof'
 
 class Test_StringCapacity < Test::Unit::TestCase
   def test_capacity_embedded
-    assert_equal GC::INTERNAL_CONSTANTS[:RVALUE_SIZE] - embed_header_size - 1, capa('foo')
+    assert_equal GC::INTERNAL_CONSTANTS[:BASE_SLOT_SIZE] - embed_header_size - 1, capa('foo')
     assert_equal max_embed_len, capa('1' * max_embed_len)
     assert_equal max_embed_len, capa('1' * (max_embed_len - 1))
   end
 
   def test_capacity_shared
-    assert_equal 0, capa(:abcdefghijklmnopqrstuvwxyz.to_s)
+    sym = ("a" * GC::INTERNAL_CONSTANTS[:BASE_SLOT_SIZE]).to_sym
+    assert_equal 0, capa(sym.to_s)
   end
 
   def test_capacity_normal
@@ -46,13 +47,13 @@ class Test_StringCapacity < Test::Unit::TestCase
 
   def test_capacity_frozen
     s = String.new("I am testing", capacity: 1000)
-    s << "fstring capacity"
+    s << "a" * GC::INTERNAL_CONSTANTS[:BASE_SLOT_SIZE]
     s.freeze
     assert_equal(s.length, capa(s))
   end
 
   def test_capacity_fstring
-    s = String.new("a" * max_embed_len, capacity: 1000)
+    s = String.new("a" * max_embed_len, capacity: max_embed_len * 3)
     s << "fstring capacity"
     s = -s
     assert_equal(s.length, capa(s))

--- a/test/-ext-/string/test_set_len.rb
+++ b/test/-ext-/string/test_set_len.rb
@@ -4,18 +4,20 @@ require "-test-/string"
 
 class Test_StrSetLen < Test::Unit::TestCase
   def setup
-    @s0 = [*"a".."z"].join("").freeze
+    # Make string long enough so that it is not embedded
+    @range_end = ("0".ord + GC::INTERNAL_CONSTANTS[:BASE_SLOT_SIZE]).chr
+    @s0 = [*"0"..@range_end].join("").freeze
     @s1 = Bug::String.new(@s0)
   end
 
   def teardown
-    orig = [*"a".."z"].join("")
+    orig = [*"0"..@range_end].join("")
     assert_equal(orig, @s0)
   end
 
   def test_non_shared
     @s1.modify!
-    assert_equal("abc", @s1.set_len(3))
+    assert_equal("012", @s1.set_len(3))
   end
 
   def test_shared

--- a/test/objspace/test_objspace.rb
+++ b/test/objspace/test_objspace.rb
@@ -33,7 +33,7 @@ class TestObjSpace < Test::Unit::TestCase
     b = a.dup
     c = nil
     ObjectSpace.each_object(String) {|x| break c = x if x == a and x.frozen?}
-    rv_size = GC::INTERNAL_CONSTANTS[:RVALUE_SIZE]
+    rv_size = GC::INTERNAL_CONSTANTS[:BASE_SLOT_SIZE]
     assert_equal([rv_size, rv_size, a.length + 1 + rv_size], [a, b, c].map {|x| ObjectSpace.memsize_of(x)})
   end
 

--- a/test/ruby/test_file_exhaustive.rb
+++ b/test/ruby/test_file_exhaustive.rb
@@ -872,9 +872,9 @@ class TestFileExhaustive < Test::Unit::TestCase
     bug9934 = '[ruby-core:63114] [Bug #9934]'
     require "objspace"
     path = File.expand_path("/foo")
-    assert_operator(ObjectSpace.memsize_of(path), :<=, path.bytesize + GC::INTERNAL_CONSTANTS[:RVALUE_SIZE], bug9934)
+    assert_operator(ObjectSpace.memsize_of(path), :<=, path.bytesize + GC::INTERNAL_CONSTANTS[:BASE_SLOT_SIZE], bug9934)
     path = File.expand_path("/a"*25)
-    assert_equal(path.bytesize+1 + GC::INTERNAL_CONSTANTS[:RVALUE_SIZE], ObjectSpace.memsize_of(path), bug9934)
+    assert_equal(path.bytesize + 1 + GC::INTERNAL_CONSTANTS[:BASE_SLOT_SIZE], ObjectSpace.memsize_of(path), bug9934)
   end
 
   def test_expand_path_encoding

--- a/test/ruby/test_gc.rb
+++ b/test/ruby/test_gc.rb
@@ -152,7 +152,7 @@ class TestGc < Test::Unit::TestCase
       GC.stat_heap(i, stat_heap)
       GC.stat(stat)
 
-      assert_equal GC::INTERNAL_CONSTANTS[:RVALUE_SIZE] * (2**i), stat_heap[:slot_size]
+      assert_equal GC::INTERNAL_CONSTANTS[:BASE_SLOT_SIZE] * (2**i), stat_heap[:slot_size]
       assert_operator stat_heap[:heap_allocatable_pages], :<=, stat[:heap_allocatable_pages]
       assert_operator stat_heap[:heap_eden_pages], :<=, stat[:heap_eden_pages]
       assert_operator stat_heap[:heap_eden_slots], :>=, 0


### PR DESCRIPTION
Add a new macro BASE_SLOT_SIZE that determines the slot size.

For Variable Width Allocation (compiled with USE_RVARGC=1), all slot
sizes are powers-of-2 multiples of BASE_SLOT_SIZE.

For USE_RVARGC=0, BASE_SLOT_SIZE is set to sizeof(RVALUE).