### PR TITLE
Treat ICVARC cache as separate from IVC cache

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -2401,6 +2401,7 @@ iseq_set_sequence(rb_iseq_t *iseq, LINK_ANCHOR *const anchor)
 			}
 		      case TS_IC: /* inline cache */
 		      case TS_ISE: /* inline storage entry */
+              case TS_ICVARC: /* inline cvar cache */
 		      case TS_IVC: /* inline ivar cache */
 			{
 			    unsigned int ic_index = FIX2UINT(operands[j]);
@@ -9900,6 +9901,7 @@ insn_data_to_s_detail(INSN *iobj)
 		break;
 	      case TS_IC:	/* inline cache */
 	      case TS_IVC:	/* inline ivar cache */
+          case TS_ICVARC: /* inline cvar cache */
 	      case TS_ISE:	/* inline storage entry */
 		rb_str_catf(str, "<ic:%d>", FIX2INT(OPERAND_AT(iobj, j)));
 		break;
@@ -10293,6 +10295,7 @@ iseq_build_from_ary_body(rb_iseq_t *iseq, LINK_ANCHOR *const anchor,
 		      case TS_ISE:
 		      case TS_IC:
                       case TS_IVC:  /* inline ivar cache */
+                      case TS_ICVARC:  /* inline cvar cache */
 			argv[j] = op;
 			if (NUM2UINT(op) >= iseq->body->is_size) {
 			    iseq->body->is_size = NUM2INT(op) + 1;
@@ -11109,6 +11112,7 @@ ibf_dump_code(struct ibf_dump *dump, const rb_iseq_t *iseq)
                 break;
               case TS_IC:
               case TS_IVC:
+              case TS_ICVARC:
               case TS_ISE:
                 {
                     unsigned int i;
@@ -11215,6 +11219,7 @@ ibf_load_code(const struct ibf_load *load, rb_iseq_t *iseq, ibf_offset_t bytecod
               case TS_ISE:
               case TS_IC:
               case TS_IVC:
+              case TS_ICVARC:
                 {
                     VALUE op = ibf_load_small_value(load, &reading_pos);
                     code[code_index] = (VALUE)&is_entries[op];

--- a/insns.def
+++ b/insns.def
@@ -230,27 +230,27 @@ setinstancevariable
 /* Get value of class variable id of klass as val. */
 DEFINE_INSN
 getclassvariable
-(ID id, IVC ic)
+(ID id, ICVARC ic)
 ()
 (VALUE val)
 /* "class variable access from toplevel" warning can be hooked. */
 // attr bool leaf = false; /* has rb_warning() */
 {
     rb_control_frame_t *cfp = GET_CFP();
-    val = vm_getclassvariable(GET_ISEQ(), cfp, id, (ICVARC)ic);
+    val = vm_getclassvariable(GET_ISEQ(), cfp, id, ic);
 }
 
 /* Set value of class variable id of klass as val. */
 DEFINE_INSN
 setclassvariable
-(ID id, IVC ic)
+(ID id, ICVARC ic)
 (VALUE val)
 ()
 /* "class variable access from toplevel" warning can be hooked. */
 // attr bool leaf = false; /* has rb_warning() */
 {
     vm_ensure_not_refinement_module(GET_SELF());
-    vm_setclassvariable(GET_ISEQ(), GET_CFP(), id,  val, (ICVARC)ic);
+    vm_setclassvariable(GET_ISEQ(), GET_CFP(), id,  val, ic);
 }
 
 /* Get constant variable id. If klass is Qnil and allow_nil is Qtrue, constants

--- a/iseq.c
+++ b/iseq.c
@@ -196,6 +196,7 @@ iseq_extract_values(VALUE *code, size_t pos, iseq_value_itr_t * func, void *data
             }
             break;
           case TS_IVC:
+          case TS_ICVARC:
             {
                 IVC ivc = (IVC)code[pos + op_no + 1];
                 if (ivc->entry) {
@@ -2060,6 +2061,7 @@ rb_insn_operand_intern(const rb_iseq_t *iseq,
 
       case TS_IC:
       case TS_IVC:
+      case TS_ICVARC:
       case TS_ISE:
 	ret = rb_sprintf("<is:%"PRIdPTRDIFF">", (union iseq_inline_storage_entry *)op - iseq->body->is_entries);
 	break;
@@ -2893,6 +2895,7 @@ iseq_data_to_ary(const rb_iseq_t *iseq)
 		break;
 	      case TS_IC:
               case TS_IVC:
+          case TS_ICVARC:
 	      case TS_ISE:
 		{
 		    union iseq_inline_storage_entry *is = (union iseq_inline_storage_entry *)*seq;

--- a/misc/lldb_disasm.py
+++ b/misc/lldb_disasm.py
@@ -27,6 +27,7 @@ class IseqDisassembler:
     TS_CDHASH   = b'H'[0]
     TS_IC       = b'K'[0]
     TS_IVC      = b'A'[0]
+    TS_ICVARC   = b'J'[0]
     TS_ID       = b'I'[0]
     TS_ISE      = b'T'[0]
     TS_ISEQ     = b'S'[0]
@@ -48,6 +49,7 @@ class IseqDisassembler:
             TS_ISE: "(iseq_inline_storage_entry *)%0#x",
             TS_ID: "ID: %0#x",
             TS_IVC: "(struct iseq_inline_iv_cache_entry *)%0#x",
+            TS_ICVARC: "(struct iseq_inline_cvar_cache_entry *)%0#x",
             TS_IC: "(struct iseq_inline_cache_entry *)%0#x",
             TS_CDHASH: "CDHASH (VALUE)%0#x",
             TS_CALLDATA: "(struct rb_call_data *)%0#x",

--- a/tool/ruby_vm/models/typemap.rb
+++ b/tool/ruby_vm/models/typemap.rb
@@ -16,6 +16,7 @@ RubyVM::Typemap = {
   "CDHASH"         => %w[H TS_CDHASH],
   "IC"             => %w[K TS_IC],
   "IVC"            => %w[A TS_IVC],
+  "ICVARC"         => %w[J TS_ICVARC],
   "ID"             => %w[I TS_ID],
   "ISE"            => %w[T TS_ISE],
   "ISEQ"           => %w[S TS_ISEQ],


### PR DESCRIPTION
Currently, the inline cvar cache is being treated as the same as the inline ivar cache. This unnecessarily ties the two caches together, and makes refactoring either cache difficult. 

This PR appropriately separates TS_ICVARC and TS_IVC.