### PR TITLE
Fix case when gc_marks_continue does not yield slots

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -2204,11 +2204,12 @@ heap_prepare(rb_objspace_t *objspace, rb_size_pool_t *size_pool, rb_heap_t *heap
 {
     GC_ASSERT(heap->free_pages == NULL);
 
-    if (is_lazy_sweeping(objspace)) {
-	gc_sweep_continue(objspace, size_pool, heap);
-    }
-    else if (is_incremental_marking(objspace)) {
+    if (is_incremental_marking(objspace)) {
 	gc_marks_continue(objspace, size_pool, heap);
+    }
+
+    if (heap->free_pages == NULL && is_lazy_sweeping(objspace)) {
+        gc_sweep_continue(objspace, size_pool, heap);
     }
 
     if (heap->free_pages == NULL &&


### PR DESCRIPTION
gc_marks_continue will start sweeping when it finishes marking. However,
if the heap we are trying to allocate into is full, then the sweeping
may not yield any free slots. If we don't call gc_sweep_continue
immediate after this, then another GC will be started halfway during
lazy sweeping. gc_sweep_continue will either grow the heap or finish
sweeping.