### PR TITLE
[DOC] Fix typo in String documentation

### DIFF
--- a/string.c
+++ b/string.c
@@ -2960,7 +2960,7 @@ rb_str_freeze(VALUE str)
  *
  * Returns +self+ if +self+ is not frozen.
  *
- * Otherwise. returns <tt>self.dup</tt>, which is not frozen.
+ * Otherwise returns <tt>self.dup</tt>, which is not frozen.
  */
 static VALUE
 str_uplus(VALUE str)


### PR DESCRIPTION
Noticed a typo for `+@` in [`String` docs.](https://ruby-doc.org/core-3.1.0/String.html#2B-40-method) (Remove extraneous period)