### PR TITLE
Add documentation for regexp emoji named character property

### DIFF
--- a/doc/regexp.rdoc
+++ b/doc/regexp.rdoc
@@ -405,6 +405,7 @@ much like POSIX bracket classes.
 * <tt>/\p{Blank}/</tt> - Space or tab
 * <tt>/\p{Cntrl}/</tt> - Control character
 * <tt>/\p{Digit}/</tt> - Digit
+* <tt>/\p{Emoji}/</tt> - Unicode emoji
 * <tt>/\p{Graph}/</tt> - Non-blank character (excludes spaces, control
   characters, and similar)
 * <tt>/\p{Lower}/</tt> - Lowercase alphabetical character


### PR DESCRIPTION
For some reason there is no documentation that regexp has a emoji named character property for unicode characters. I only noticed that `regex = /\p{Emoji}/` does work in ruby by accident. I think this named character property should be mentioned in the documentation.