### PR TITLE
st.c: Do not clear entries_bound when calling Hash#shift for empty hash

### DIFF
--- a/st.c
+++ b/st.c
@@ -1363,7 +1363,6 @@ st_shift(st_table *tab, st_data_t *key, st_data_t *value)
 	    return 1;
 	}
     }
-    tab->entries_start = tab->entries_bound = 0;
     if (value != 0) *value = 0;
     return 0;
 }

--- a/test/ruby/test_hash.rb
+++ b/test/ruby/test_hash.rb
@@ -1069,6 +1069,19 @@ class TestHash < Test::Unit::TestCase
     assert_nil(h.shift)
   end
 
+  def test_shift_for_empty_hash
+    # [ruby-dev:51159]
+    h = @cls[]
+    100.times{|n|
+      while h.size < n
+        k = Random.rand 0..1<<30
+        h[k] = 1
+      end
+      0 while h.shift
+      assert_equal({}, h)
+    }
+  end
+
   def test_reject_bang2
     assert_equal({1=>2}, @cls[1=>2,3=>4].reject! {|k, v| k + v == 7 })
     assert_nil(@cls[1=>2,3=>4].reject! {|k, v| k == 5 })


### PR DESCRIPTION
tab->entries_bound is used to check if the bins are full in
rebuild_table_if_necessary.

Hash#shift against an empty hash assigned 0 to tab->entries_bound, but
didn't clear the bins. Thus, the table is not rebuilt even when the bins
are full. Attempting to add a new element into full-bin hash gets stuck.

This change stops clearing tab->entries_bound in Hash#shift.
[Bug #18578]