### PR TITLE
Reuse `p_kwnorest` rule for `f_no_kwarg`

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -5474,7 +5474,7 @@ kwrest_mark	: tPOW
 		| tDSTAR
 		;
 
-f_no_kwarg	: kwrest_mark keyword_nil
+f_no_kwarg	: p_kwnorest
 		    {
 		    /*%%%*/
 		    /*% %*/


### PR DESCRIPTION
`p_kwnorest` and `f_no_kwarg` using same pattern in `parse.y`, 
and these rule not set value.

```y
p_kwnorest	: kwrest_mark keyword_nil
		    {
		        $$ = 0;
		    }
		;

f_no_kwarg	: kwrest_mark keyword_nil
		    {
		    /*%%%*/
		    /*% %*/
		    /*% ripper: nokw_param!(Qnil) %*/
		    }
		;```

I thik that these rule can be resuse, but not sure.
