### PR TITLE
Fix Range#include? for beginless exclusive string ranges

### DIFF
--- a/range.c
+++ b/range.c
@@ -1792,6 +1792,9 @@ range_include_internal(VALUE range, VALUE val, int string_use_cover)
         else if (NIL_P(beg)) {
 	    VALUE r = rb_funcall(val, id_cmp, 1, end);
 	    if (NIL_P(r)) return Qfalse;
+            if (RANGE_EXCL(range)) {
+                return RBOOL(rb_cmpint(r, val, end) < 0);
+            }
             return RBOOL(rb_cmpint(r, val, end) <= 0);
         }
 	else if (NIL_P(end)) {

--- a/test/ruby/test_range.rb
+++ b/test/ruby/test_range.rb
@@ -604,6 +604,10 @@ class TestRange < Test::Unit::TestCase
     assert_include(0...10, 5)
     assert_include(5..., 10)
     assert_not_include(5..., 0)
+    assert_include(.."z", "z")
+    assert_not_include(..."z", "z")
+    assert_include(..10, 10)
+    assert_not_include(...10, 10)
   end
 
   def test_cover


### PR DESCRIPTION
Previously, include? would return true for the end of the range,
when it should return false because the range is exclusive.

Research and Analysis by Victor Shepelev.

Fixes [Bug #18577]