### PR TITLE
Reuse `operation` rule for `operation2` rule in `parse.y`

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -5740,9 +5740,7 @@ operation	: tIDENTIFIER
 		| tFID
 		;
 
-operation2	: tIDENTIFIER
-		| tCONSTANT
-		| tFID
+operation2	: operation
 		| op
 		;
 


### PR DESCRIPTION
In `parse.y`, `operation` and `operation2` pattern rule has similar pattern.

```y
operation	: tIDENTIFIER
		| tCONSTANT
		| tFID
		;
operation2	: tIDENTIFIER
		| tCONSTANT
		| tFID
		| op
		;
```

It may be more simpler to reuse `operation` rule.


```y
operation	: tIDENTIFIER
		| tCONSTANT
		| tFID
		;

operation2	: operation
		| op
		;
```
