### PR TITLE
Remove uneeded rb_parser_warn_location function declaration

### DIFF
--- a/vm_eval.c
+++ b/vm_eval.c
@@ -1659,8 +1659,6 @@ rb_each(VALUE obj)
     return rb_call(obj, idEach, 0, 0, CALL_FCALL);
 }
 
-void rb_parser_warn_location(VALUE, int);
-
 static VALUE eval_default_path;
 
 static const rb_iseq_t *


### PR DESCRIPTION
`rb_parser_warn_location` function was deleted in #2816
But, `rb_parser_warn_location` function declaration was not deleted in `vm_eval.c`.

This PR removed it.