### PR TITLE
Using is_ascii_string function to check encoding

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -8887,6 +8887,7 @@ marshal.$(OBJEXT): {$(VPATH)}internal/special_consts.h
 marshal.$(OBJEXT): {$(VPATH)}internal/static_assert.h
 marshal.$(OBJEXT): {$(VPATH)}internal/stdalign.h
 marshal.$(OBJEXT): {$(VPATH)}internal/stdbool.h
+marshal.$(OBJEXT): {$(VPATH)}internal/string.h
 marshal.$(OBJEXT): {$(VPATH)}internal/symbol.h
 marshal.$(OBJEXT): {$(VPATH)}internal/value.h
 marshal.$(OBJEXT): {$(VPATH)}internal/value_type.h
@@ -10837,6 +10838,7 @@ parse.$(OBJEXT): {$(VPATH)}internal/special_consts.h
 parse.$(OBJEXT): {$(VPATH)}internal/static_assert.h
 parse.$(OBJEXT): {$(VPATH)}internal/stdalign.h
 parse.$(OBJEXT): {$(VPATH)}internal/stdbool.h
+parse.$(OBJEXT): {$(VPATH)}internal/string.h
 parse.$(OBJEXT): {$(VPATH)}internal/symbol.h
 parse.$(OBJEXT): {$(VPATH)}internal/value.h
 parse.$(OBJEXT): {$(VPATH)}internal/value_type.h
@@ -14734,6 +14736,7 @@ string.$(OBJEXT): {$(VPATH)}internal/special_consts.h
 string.$(OBJEXT): {$(VPATH)}internal/static_assert.h
 string.$(OBJEXT): {$(VPATH)}internal/stdalign.h
 string.$(OBJEXT): {$(VPATH)}internal/stdbool.h
+string.$(OBJEXT): {$(VPATH)}internal/string.h
 string.$(OBJEXT): {$(VPATH)}internal/symbol.h
 string.$(OBJEXT): {$(VPATH)}internal/value.h
 string.$(OBJEXT): {$(VPATH)}internal/value_type.h
@@ -15777,6 +15780,7 @@ transcode.$(OBJEXT): {$(VPATH)}internal/special_consts.h
 transcode.$(OBJEXT): {$(VPATH)}internal/static_assert.h
 transcode.$(OBJEXT): {$(VPATH)}internal/stdalign.h
 transcode.$(OBJEXT): {$(VPATH)}internal/stdbool.h
+transcode.$(OBJEXT): {$(VPATH)}internal/string.h
 transcode.$(OBJEXT): {$(VPATH)}internal/symbol.h
 transcode.$(OBJEXT): {$(VPATH)}internal/value.h
 transcode.$(OBJEXT): {$(VPATH)}internal/value_type.h

--- a/marshal.c
+++ b/marshal.c
@@ -30,6 +30,7 @@
 #include "internal/hash.h"
 #include "internal/object.h"
 #include "internal/struct.h"
+#include "internal/string.h"
 #include "internal/symbol.h"
 #include "internal/util.h"
 #include "internal/vm.h"
@@ -481,7 +482,7 @@ w_symbol(VALUE sym, struct dump_arg *arg)
 	}
 	encname = encoding_name(sym, arg);
 	if (NIL_P(encname) ||
-	    rb_enc_str_coderange(sym) == ENC_CODERANGE_7BIT) {
+	    is_ascii_string(sym)) {
 	    encname = Qnil;
 	}
 	else {

--- a/parse.y
+++ b/parse.y
@@ -40,6 +40,7 @@ struct lex_context;
 #include "internal/parse.h"
 #include "internal/rational.h"
 #include "internal/re.h"
+#include "internal/string.h"
 #include "internal/symbol.h"
 #include "internal/thread.h"
 #include "internal/variable.h"
@@ -6578,7 +6579,7 @@ parser_str_new(const char *ptr, long len, rb_encoding *enc, int func, rb_encodin
 
     str = rb_enc_str_new(ptr, len, enc);
     if (!(func & STR_FUNC_REGEXP) && rb_enc_asciicompat(enc)) {
-	if (rb_enc_str_coderange(str) == ENC_CODERANGE_7BIT) {
+	if (is_ascii_string(str)) {
 	}
 	else if (enc0 == rb_usascii_encoding() && enc != rb_utf8_encoding()) {
 	    rb_enc_associate(str, rb_ascii8bit_encoding());

--- a/string.c
+++ b/string.c
@@ -792,7 +792,7 @@ rb_enc_str_asciionly_p(VALUE str)
 
     if (!rb_enc_asciicompat(enc))
         return FALSE;
-    else if (rb_enc_str_coderange(str) == ENC_CODERANGE_7BIT)
+    else if (is_ascii_string(str))
         return TRUE;
     return FALSE;
 }
@@ -3468,7 +3468,7 @@ st_index_t
 rb_str_hash(VALUE str)
 {
     int e = ENCODING_GET(str);
-    if (e && rb_enc_str_coderange(str) == ENC_CODERANGE_7BIT) {
+    if (e && is_ascii_string(str)) {
 	e = 0;
     }
     return rb_memhash((const void *)RSTRING_PTR(str), RSTRING_LEN(str)) ^ e;

--- a/transcode.c
+++ b/transcode.c
@@ -2721,7 +2721,7 @@ str_transcode0(int argc, VALUE *argv, VALUE *self, int ecflags, VALUE ecopts)
             return NIL_P(arg2) ? -1 : dencidx;
         }
         if (senc && denc && rb_enc_asciicompat(senc) && rb_enc_asciicompat(denc)) {
-            if (rb_enc_str_coderange(str) == ENC_CODERANGE_7BIT) {
+            if (is_ascii_string(str)) {
                 return dencidx;
             }
         }


### PR DESCRIPTION
Some code has `rb_enc_str_coderange(sym) == ENC_CODERANGE_7BIT)`, but already implemented  `is_ascii_string` function that check encoding.

I thought better to using `is_ascii_string` instead of these code like a `rb_enc_str_coderange(sym) == ENC_CODERANGE_7BIT)`.