### PR TITLE
fix parallel test timeout retrying

### DIFF
--- a/tool/lib/test/unit.rb
+++ b/tool/lib/test/unit.rb
@@ -745,7 +745,19 @@ module Test
             end
             unless error.empty?
               puts "\n""Retrying hung up testcases..."
-              error.map! {|r| ::Object.const_get(r[:testcase])}
+              error = error.map do |r|
+                begin
+                  ::Object.const_get(r[:testcase])
+                rescue NameError
+                  # testcase doesn't specify the correct case, so show `r` for information
+                  require 'pp'
+
+                  $stderr.puts "Retrying is failed because the file and testcase is not consistent:"
+                  PP.pp r, $stderr
+                  @errors += 1
+                  nil
+                end
+              end.compact
               verbose = @verbose
               job_status = options[:job_status]
               options[:verbose] = @verbose = true


### PR DESCRIPTION
On the parallel test, workers can be killed because of timeout
and the information for the retrying can be inconsistent.
This patch will skip if the inconsistency is found and report
as an error.

http://ci.rvm.jp/results/trunk-asserts@phosphorus-docker/3834082