### PR TITLE
yjit_codegen.c: Prevent a possible out-of-bound access

### DIFF
--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -3704,7 +3704,7 @@ gen_send_iseq(jitstate_t *jit, ctx_t *ctx, const struct rb_callinfo *ci, const r
 
     const struct rb_builtin_function *leaf_builtin = rb_leaf_builtin_function(iseq);
 
-    if (leaf_builtin && !block && leaf_builtin->argc + 1 <= NUM_C_ARG_REGS) {
+    if (leaf_builtin && !block && leaf_builtin->argc + 1 /* for self */ + 1 /* for ec */ <= NUM_C_ARG_REGS) {
         ADD_COMMENT(cb, "inlined leaf builtin");
 
         // Call the builtin func (ec, recv, arg1, arg2, ...)


### PR DESCRIPTION
The code attempts to read `C_ARG_REGS[leaf_builtin->argc + 1]`, and the
size of `C_ARG_REGS` is `NUM_C_ARG_REGS`.  So, the guard condition must
be `leaf_builtin->argc + 1 + 1 <= NUM_C_ARG_REGS`.

This change fixes the off-by-one error. This issue was found by Coverity
Scan.