### PR TITLE
Add a test that sometimes fail ractor asserts

### DIFF
--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -1543,6 +1543,22 @@ assert_equal "ok", %q{
   "ok"
 }
 
+# Regression test for
+# Assertion Failed: ractor.c:1312:ractor_select:cr->sync.wait.taken_basket.type == basket_type_none
+assert_equal "ok", %q{
+   workers = (0...8).map do
+     Ractor.new do
+       loop do
+         10.times.map { Object.new }
+         Ractor.yield Time.now
+       end
+     end
+   end
+
+   1_000.times { idle_worker, tmp_reporter = Ractor.select(*workers) }
+   "ok"
+}
+
 assert_equal "ok", %q{
   def foo(*); ->{ super }; end
   begin


### PR DESCRIPTION
This test is derived from the test above it. If I run the test in a
shell loop on a debug build it eventually trips the following assert:

    Assertion Failed: ractor.c:1312:ractor_select:cr->sync.wait.taken_basket.type == basket_type_none
    ruby 3.2.0dev (2022-02-16T14:50:29Z master 969ad5802d) [x86_64-linux]

It crashes without YJIT, but enabling YJIT seems to make it more
reproducible. It also seems to be more reproducible on Mac. Seems like
some sort of race condition. I haven't had a chance to dig into the code
yet. 

CC @ko1 