### PR TITLE
Load ~/.mspecrc only when $HOME is available

### DIFF
--- a/spec/mspec/lib/mspec/utils/script.rb
+++ b/spec/mspec/lib/mspec/utils/script.rb
@@ -73,7 +73,12 @@ class MSpecScript
 
     names.each do |name|
       config[:path].each do |dir|
-        file = File.expand_path name, dir
+        begin
+          file = File.expand_path name, dir
+        rescue ArgumentError
+          # File.expand_path can issue error e.g. if HOME is not available
+          next
+        end
         if @loaded.include?(file)
           return true
         elsif File.exist? file


### PR DESCRIPTION
Some platforms (e.g. WASI) doesn't have HOME concept, so `~` cannot be
expanded