### PR TITLE
Fast rb_obj_is_kind_of Class inheritance check

### DIFF
--- a/benchmark/module_eqq.yml
+++ b/benchmark/module_eqq.yml
@@ -1,0 +1,27 @@
+prelude: |
+  class SimpleClass; end
+  class MediumClass
+    10.times { include Module.new }
+  end
+  class LargeClass
+    100.times { include Module.new }
+  end
+  class HugeClass
+    300.times { include Module.new }
+  end
+  SimpleObj = SimpleClass.new
+  MediumObj = MediumClass.new
+  LargeObj = LargeClass.new
+  HugeObj = HugeClass.new
+benchmark:
+  simple_class_eqq_simple_obj: |
+    SimpleClass === SimpleObj
+  medium_class_eqq_simple_obj: |
+    MediumClass === SimpleObj
+  simple_class_eqq_medium_obj: |
+    SimpleClass === MediumObj
+  simple_class_eqq_large_obj: |
+    SimpleClass === LargeObj
+  simple_class_eqq_huge_obj: |
+    SimpleClass === HugeObj
+loop_count: 20000000

--- a/ext/objspace/objspace.c
+++ b/ext/objspace/objspace.c
@@ -61,14 +61,7 @@ total_i(VALUE v, void *ptr)
 {
     struct total_data *data = (struct total_data *)ptr;
 
-    switch (BUILTIN_TYPE(v)) {
-      case T_NONE:
-      case T_IMEMO:
-      case T_ICLASS:
-      case T_NODE:
-      case T_ZOMBIE:
-          return;
-      default:
+    if (!rb_objspace_internal_object_p(v)) {
           if (data->klass == 0 || rb_obj_is_kind_of(v, data->klass)) {
               data->total += rb_obj_memsize_of(v);
           }

--- a/internal/class.h
+++ b/internal/class.h
@@ -47,6 +47,8 @@ struct rb_classext_struct {
     struct rb_id_table *callable_m_tbl;
     struct rb_id_table *cc_tbl; /* ID -> [[ci, cc1], cc2, ...] */
     struct rb_id_table *cvc_tbl;
+    size_t superclass_depth;
+    VALUE *superclasses;
     struct rb_subclass_entry *subclasses;
     struct rb_subclass_entry *subclass_entry;
     /**
@@ -117,6 +119,8 @@ typedef struct rb_classext_struct rb_classext_t;
 #define RCLASS_MODULE_SUBCLASS_ENTRY(c) (RCLASS_EXT(c)->module_subclass_entry)
 #define RCLASS_ALLOCATOR(c) (RCLASS_EXT(c)->allocator)
 #define RCLASS_SUBCLASSES(c) (RCLASS_EXT(c)->subclasses)
+#define RCLASS_SUPERCLASS_DEPTH(c) (RCLASS_EXT(c)->superclass_depth)
+#define RCLASS_SUPERCLASSES(c) (RCLASS_EXT(c)->superclasses)
 
 #define RICLASS_IS_ORIGIN FL_USER5
 #define RCLASS_CLONED     FL_USER6
@@ -125,6 +129,8 @@ typedef struct rb_classext_struct rb_classext_t;
 /* class.c */
 void rb_class_subclass_add(VALUE super, VALUE klass);
 void rb_class_remove_from_super_subclasses(VALUE);
+void rb_class_update_superclasses(VALUE);
+void rb_class_remove_superclasses(VALUE);
 void rb_class_remove_subclass_head(VALUE);
 int rb_singleton_class_internal_p(VALUE sklass);
 VALUE rb_class_boot(VALUE);
@@ -197,6 +203,7 @@ RCLASS_SET_SUPER(VALUE klass, VALUE super)
         rb_class_subclass_add(super, klass);
     }
     RB_OBJ_WRITE(klass, &RCLASS(klass)->super, super);
+    rb_class_update_superclasses(klass);
     return super;
 }
 

--- a/object.c
+++ b/object.c
@@ -791,6 +791,8 @@ rb_obj_is_kind_of(VALUE obj, VALUE c)
 {
     VALUE cl = CLASS_OF(obj);
 
+    RUBY_ASSERT(cl);
+
     // Note: YJIT needs this function to never allocate and never raise when
     // `c` is a class or a module.
     c = class_or_module_required(c);


### PR DESCRIPTION
This PR implements a faster constant-time inheritance check when `rb_obj_is_kind_of` is passed a Class (a T_CLASS) and not a module.

Previously when checking ancestors, we would walk all the way up the ancestry chain checking each parent for a matching class or module. I believe it's most common to check a class against a parent class, to this commit aims to improve that case (unfortunately does not help checking for an included Module).

I believe this pointer chasing was especially unfriendly to CPU cache since for each step we need to check two cache lines (the class and class ext).

This check is used quite often in:
* `case` statements
* `rescue` statements
* Calling `protected` methods
* `Class#is_a?`
* `Module#===`
* `Module#<=>` (edit: I need to implement the optimization here 😅)

<img width="729" alt="Screen Shot 2022-02-17 at 4 42 58 PM" src="https://user-images.githubusercontent.com/131752/154595926-d1f8e616-3ab1-4ad3-bf59-1bab9d4173a3.png">

`rb_obj_is_kind_of` shows up in `perf` on many benchmarks. Above is yjit-bench's activerecord benchmark showing 2.4%. railsbench shows 1.70%. In GitHub's slowest test suite it takes about 3% of runtime.

In GitHub's largest app our largest model has just over 300 ancestors (mostly modules), and our `Object` has 13 ancestors. In other apps any ActiveRecord model will have about 70 ancestors, so avoiding scanning these linked lists is valuable.

This is done by storing on each class the number and an array of all parent classes, in order (BasicObject is at index 0). Using this we can check whether a class is a subclass of another in constant time since we know the location to expect it in the hierarchy.

With this commit applied in yjit-bench's activerecord `rb_obj_is_kind_of` is only 0.36% of runtime (possibly these are module checks).

The downside of this approach, of course, is more memory from storing the class array redundantly. I hope it is acceptable for the performance gains, it was for GitHub's application (I'll measure more precisely next week). There are some optimization we could do here (having a fixed array for the common cases or reusing identical ancestor arrays).

---

I graphed performance between Ruby 3.1 and this branch with x=module depth, y=runtime and found that this is faster in all cases 🚀

<img width="852" alt="Screen Shot 2022-02-17 at 4 57 13 PM" src="https://user-images.githubusercontent.com/131752/154597166-9fd19601-b954-447f-8767-7b9bccc41109.png">
<img width="555" alt="Screen Shot 2022-02-17 at 4 57 19 PM" src="https://user-images.githubusercontent.com/131752/154597169-e9147917-f822-4afb-a943-0768efdc6b6c.png">

