### PR TITLE
Implement `ObjectSpace::WeakKeyMap`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,12 @@ Note: We're only listing outstanding class updates.
     * `String#unpack` now raises ArgumentError for unknown directives. [[Bug #19150]]
     * `String#bytesplice` now accepts new arguments index/length or range of the source string to be copied.  [[Feature #19314]]
 
+* ObjectSpace::WeakKeyMap
+
+    * New core class to build collections with weak references.
+      The class use equality semantic to lookup keys like a regular hash,
+      but it doesn't hold strong references on the keys. [[Feature #18498]]
+
 ## Stdlib updates
 
 The following default gems are updated.

--- a/hash.c
+++ b/hash.c
@@ -106,7 +106,7 @@ rb_hash_set_ifnone(VALUE hash, VALUE ifnone)
     return hash;
 }
 
-static int
+int
 rb_any_cmp(VALUE a, VALUE b)
 {
     if (a == b) return 0;
@@ -221,7 +221,7 @@ obj_any_hash(VALUE obj)
     return FIX2LONG(hval);
 }
 
-static st_index_t
+st_index_t
 rb_any_hash(VALUE a)
 {
     return any_hash(a, obj_any_hash);

--- a/internal/hash.h
+++ b/internal/hash.h
@@ -73,6 +73,8 @@ VALUE rb_hash_default_value(VALUE hash, VALUE key);
 VALUE rb_hash_set_default_proc(VALUE hash, VALUE proc);
 long rb_dbl_long_hash(double d);
 st_table *rb_init_identtable(void);
+st_index_t rb_any_hash(VALUE a);
+int rb_any_cmp(VALUE a, VALUE b);
 VALUE rb_to_hash_type(VALUE obj);
 VALUE rb_hash_key_str(VALUE);
 VALUE rb_hash_values(VALUE hash);

--- a/test/ruby/weakkeymap.rb
+++ b/test/ruby/weakkeymap.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: false
+require 'test/unit'
+
+class TestWeakKeyMap < Test::Unit::TestCase
+  def setup
+    @wm = ObjectSpace::WeakKeyMap.new
+  end
+
+  def test_map
+    x = Object.new
+    k = "foo"
+    @wm[k] = x
+    assert_same(x, @wm[k])
+    assert_same(x, @wm["FOO".downcase])
+  end
+
+  def test_aset_const
+    x = Object.new
+    assert_raise(ArgumentError) { @wm[true] = x }
+    assert_raise(ArgumentError) { @wm[false] = x }
+    assert_raise(ArgumentError) { @wm[nil] = x }
+    assert_raise(ArgumentError) { @wm[42] = x }
+    assert_raise(ArgumentError) { @wm[2**128] = x }
+    assert_raise(ArgumentError) { @wm[1.23] = x }
+    assert_raise(ArgumentError) { @wm[:foo] = x }
+    assert_raise(ArgumentError) { @wm["foo#{rand}".to_sym] = x }
+  end
+
+  def test_getkey
+    k = "foo"
+    @wm[k] = true
+    assert_same(k, @wm.getkey("FOO".downcase))
+  end
+
+  def test_key?
+    1.times do
+      assert_weak_include(:key?, "foo")
+    end
+    GC.start
+    assert_not_send([@wm, :key?, "FOO".downcase])
+  end
+
+  def test_clear
+    k = "foo"
+    @wm[k] = true
+    assert @wm[k]
+    assert_same @wm, @wm.clear
+    refute @wm[k]
+  end
+
+  def test_inspect
+    x = Object.new
+    k = Object.new
+    @wm[k] = x
+    assert_match(/\A\#<#{@wm.class.name}:[\dxa-f]+ size=\d+>\z/, @wm.inspect)
+
+    1000.times do |i|
+      @wm[i.to_s] = Object.new
+      @wm.inspect
+    end
+    assert_match(/\A\#<#{@wm.class.name}:[\dxa-f]+ size=\d+>\z/, @wm.inspect)
+  end
+
+  def test_no_hash_method
+    k = BasicObject.new
+    assert_raise NoMethodError do
+      @wm[k] = 42
+    end
+  end
+
+  def test_frozen_object
+    o = Object.new.freeze
+    assert_nothing_raised(FrozenError) {@wm[o] = 'foo'}
+    assert_nothing_raised(FrozenError) {@wm['foo'] = o}
+  end
+
+  def test_inconsistent_hash_key
+    assert_no_memory_leak [], '', <<~RUBY
+      class BadHash
+        def initialize
+          @hash = 0
+        end
+
+        def hash
+          @hash += 1
+        end
+      end
+
+      k = BadHash.new
+      wm = ObjectSpace::WeakKeyMap.new
+
+      100_000.times do |i|
+        wm[k] = i
+      end
+    RUBY
+  end
+
+  private
+
+  def assert_weak_include(m, k, n = 100)
+    if n > 0
+      return assert_weak_include(m, k, n-1)
+    end
+    1.times do
+      x = Object.new
+      @wm[k] = x
+      assert_send([@wm, m, k])
+      assert_send([@wm, m, "FOO".downcase])
+      x = Object.new
+    end
+  end
+end


### PR DESCRIPTION
[Feature #18498]

Ref: https://bugs.ruby-lang.org/issues/18498

### Methods

- `ObjectSpace::WeakKeyMap#[](key)`
- `ObjectSpace::WeakKeyMap#[]=(key, val)`
- `ObjectSpace::WeakKeyMap#getkey(key)`
- `ObjectSpace::WeakKeyMap#size`
- `ObjectSpace::WeakKeyMap#clear`
- `ObjectSpace::WeakKeyMap#inspect #=> #<ObjectSpace::WeakKeyMap size=100>`

### For `#[]=`:

  - Trying to use an immediate as a key fail with `ArgumentError`
  - For consistency, `BigNum` and dynamic Symbol also raise `ArgumentError`
  - Using an object without a `#hash` method raise `NoMethodError` like a regular hash.


### Notes

For simplicity, I took a shortcut. When a key is finalized we can no longer hash it, so I traverse the table in `O(N)` and delete entries pointing to the same object.

I'm not certain yet what's the best solution for this, but I assume we can record the hash inside a secondary `table` with identity semantic.

But this is good enough to experiment with the defined interface and see if there is problems with the spec.