### PR TITLE
Use symbols for non-numeric `clockid_t`

### DIFF
--- a/process.c
+++ b/process.c
@@ -9123,45 +9123,46 @@ InitVM_process(void)
 void
 Init_process(void)
 {
-    id_in = rb_intern_const("in");
-    id_out = rb_intern_const("out");
-    id_err = rb_intern_const("err");
-    id_pid = rb_intern_const("pid");
-    id_uid = rb_intern_const("uid");
-    id_gid = rb_intern_const("gid");
-    id_close = rb_intern_const("close");
-    id_child = rb_intern_const("child");
+#define define_id(name) id_##name = rb_intern_const(#name)
+    define_id(in);
+    define_id(out);
+    define_id(err);
+    define_id(pid);
+    define_id(uid);
+    define_id(gid);
+    define_id(close);
+    define_id(child);
 #ifdef HAVE_SETPGID
-    id_pgroup = rb_intern_const("pgroup");
+    define_id(pgroup);
 #endif
 #ifdef _WIN32
-    id_new_pgroup = rb_intern_const("new_pgroup");
+    define_id(new_pgroup);
 #endif
-    id_unsetenv_others = rb_intern_const("unsetenv_others");
-    id_chdir = rb_intern_const("chdir");
-    id_umask = rb_intern_const("umask");
-    id_close_others = rb_intern_const("close_others");
-    id_nanosecond = rb_intern_const("nanosecond");
-    id_microsecond = rb_intern_const("microsecond");
-    id_millisecond = rb_intern_const("millisecond");
-    id_second = rb_intern_const("second");
-    id_float_microsecond = rb_intern_const("float_microsecond");
-    id_float_millisecond = rb_intern_const("float_millisecond");
-    id_float_second = rb_intern_const("float_second");
-    id_GETTIMEOFDAY_BASED_CLOCK_REALTIME = rb_intern_const("GETTIMEOFDAY_BASED_CLOCK_REALTIME");
-    id_TIME_BASED_CLOCK_REALTIME = rb_intern_const("TIME_BASED_CLOCK_REALTIME");
+    define_id(unsetenv_others);
+    define_id(chdir);
+    define_id(umask);
+    define_id(close_others);
+    define_id(nanosecond);
+    define_id(microsecond);
+    define_id(millisecond);
+    define_id(second);
+    define_id(float_microsecond);
+    define_id(float_millisecond);
+    define_id(float_second);
+    define_id(GETTIMEOFDAY_BASED_CLOCK_REALTIME);
+    define_id(TIME_BASED_CLOCK_REALTIME);
 #ifdef HAVE_TIMES
-    id_TIMES_BASED_CLOCK_MONOTONIC = rb_intern_const("TIMES_BASED_CLOCK_MONOTONIC");
-    id_TIMES_BASED_CLOCK_PROCESS_CPUTIME_ID = rb_intern_const("TIMES_BASED_CLOCK_PROCESS_CPUTIME_ID");
+    define_id(TIMES_BASED_CLOCK_MONOTONIC);
+    define_id(TIMES_BASED_CLOCK_PROCESS_CPUTIME_ID);
 #endif
 #ifdef RUSAGE_SELF
-    id_GETRUSAGE_BASED_CLOCK_PROCESS_CPUTIME_ID = rb_intern_const("GETRUSAGE_BASED_CLOCK_PROCESS_CPUTIME_ID");
+    define_id(GETRUSAGE_BASED_CLOCK_PROCESS_CPUTIME_ID);
 #endif
-    id_CLOCK_BASED_CLOCK_PROCESS_CPUTIME_ID = rb_intern_const("CLOCK_BASED_CLOCK_PROCESS_CPUTIME_ID");
+    define_id(CLOCK_BASED_CLOCK_PROCESS_CPUTIME_ID);
 #ifdef __APPLE__
-    id_MACH_ABSOLUTE_TIME_BASED_CLOCK_MONOTONIC = rb_intern_const("MACH_ABSOLUTE_TIME_BASED_CLOCK_MONOTONIC");
+    define_id(MACH_ABSOLUTE_TIME_BASED_CLOCK_MONOTONIC);
 #endif
-    id_hertz = rb_intern_const("hertz");
+    define_id(hertz);
 
     InitVM(process);
 }

--- a/tool/m4/ruby_replace_type.m4
+++ b/tool/m4/ruby_replace_type.m4
@@ -6,6 +6,13 @@ AC_DEFUN([RUBY_REPLACE_TYPE], [dnl
 		  [n="patsubst([$2],["],[\\"])"],
 		  [$4])
     AC_CACHE_CHECK([for convertible type of [$1]], rb_cv_[$1]_convertible, [
+	AC_COMPILE_IFELSE(
+	    [AC_LANG_BOOL_COMPILE_TRY([AC_INCLUDES_DEFAULT([$4])]
+		[typedef $n rbcv_conftest_target_type;
+		extern rbcv_conftest_target_type rbcv_conftest_var;
+		], [sizeof(&*rbcv_conftest_var)])],
+	[rb_cv_[$1]_convertible=PTR],
+	[
 	u= t=
 	AS_CASE(["$n "],
 	  [*" signed "*], [ ],
@@ -37,6 +44,7 @@ AC_DEFUN([RUBY_REPLACE_TYPE], [dnl
 	  [
 	    t=INT])
 	rb_cv_[$1]_convertible=${u}${t}])
+    ])
     AS_IF([test "${AS_TR_SH(ac_cv_type_[$1])}" = "yes"], [
 	n="$1"
     ], [
@@ -48,11 +56,13 @@ AC_DEFUN([RUBY_REPLACE_TYPE], [dnl
 	AS_CASE(["${rb_cv_[$1]_convertible}"],
 		[U*], [n="unsigned $n"])
     ])
-    AS_CASE("${rb_cv_[$1]_convertible}", [U*], [u=+1], [u=-1])
+    AS_CASE("${rb_cv_[$1]_convertible}", [PTR], [u=], [U*], [u=+1], [u=-1])
     AC_DEFINE_UNQUOTED(rb_[$1], $n)
+    AS_IF([test $u], [
     AC_DEFINE_UNQUOTED([SIGNEDNESS_OF_]AS_TR_CPP($1), $u)
     AC_DEFINE_UNQUOTED([$3]2NUM[(v)], [${rb_cv_[$1]_convertible}2NUM(v)])
     AC_DEFINE_UNQUOTED(NUM2[$3][(v)], [NUM2${rb_cv_[$1]_convertible}(v)])
     AC_DEFINE_UNQUOTED(PRI_[$3]_PREFIX,
 	[PRI_`echo ${rb_cv_[$1]_convertible} | sed ['s/^U//']`_PREFIX])
+    ])
 ])dnl


### PR DESCRIPTION
This type is declared as a pointer on wasm, and `Process::CLOCK_REALTIME` etc have meaningless values in the Ruby layer.