### PR TITLE
[DOC] Set the documentation title and main page

### DIFF
--- a/.rdoc_options
+++ b/.rdoc_options
@@ -1,2 +1,4 @@
 ---
 page_dir: doc
+main_page: README.md
+title: Documentation for Ruby development version

--- a/common.mk
+++ b/common.mk
@@ -70,7 +70,9 @@ RDOCOUT       = $(EXTOUT)/rdoc
 HTMLOUT       = $(EXTOUT)/html
 CAPIOUT       = doc/capi
 INSTALL_DOC_OPTS = --rdoc-output="$(RDOCOUT)" --html-output="$(HTMLOUT)"
-RDOC_GEN_OPTS = --page-dir "$(srcdir)/doc" --no-force-update
+RDOC_GEN_OPTS = --page-dir "$(srcdir)/doc" --no-force-update \
+	--title "Documentation for Ruby $(RUBY_API_VERSION)" \
+	--main README.md
 
 INITOBJS      = dmyext.$(OBJEXT) dmyenc.$(OBJEXT)
 NORMALMAINOBJ = main.$(OBJEXT)


### PR DESCRIPTION
Copied from https://github.com/ruby/docs.ruby-lang.org/ to be as same as docs.ruby-lang.org.