### PR TITLE
spec: skip ext's extension spec for --with-static-linked-ext

### DIFF
--- a/spec/ruby/language/predefined_spec.rb
+++ b/spec/ruby/language/predefined_spec.rb
@@ -1314,6 +1314,7 @@ ruby_version_is "2.7" do
 
     it "returns what will be loaded without actual loading, .so file" do
       require 'rbconfig'
+      skip "no dynamically loadable standard extension" if RbConfig::CONFIG["EXTSTATIC"] == "static"
 
       extension, path = $LOAD_PATH.resolve_feature_path('etc')
       extension.should == :so


### PR DESCRIPTION
`resolve_feature_path` doesn't return .so when the given ext is linked
statically by --with-static-linked-ext