### PR TITLE
[DOC] Fix String#getbyte doc

### DIFF
--- a/string.c
+++ b/string.c
@@ -6120,10 +6120,10 @@ rb_str_chr(VALUE str)
  *
  *  Returns the byte at zero-based +index+ as an integer, or +nil+ if +index+ is out of range:
  *
- *    s = 'abcde'  # => "abcde"
- *    s.getbyte(0) # => 97
- *    s.getbyte(1) # => 98
- *    s.getbyte(5) # => nil
+ *    s = 'abcde'   # => "abcde"
+ *    s.getbyte(0)  # => 97
+ *    s.getbyte(-1) # => 101
+ *    s.getbyte(5)  # => nil
  *
  *  Related: String#setbyte.
  */

--- a/string.c
+++ b/string.c
@@ -6123,6 +6123,7 @@ rb_str_chr(VALUE str)
  *    s = 'abcde'  # => "abcde"
  *    s.getbyte(0) # => 97
  *    s.getbyte(1) # => 98
+ *    s.getbyte(5) # => nil
  *
  *  Related: String#setbyte.
  */

--- a/string.c
+++ b/string.c
@@ -6116,9 +6116,9 @@ rb_str_chr(VALUE str)
 
 /*
  *  call-seq:
- *    getbyte(index) -> integer
+ *    getbyte(index) -> integer or nil
  *
- *  Returns the byte at zero-based +index+ as an integer:
+ *  Returns the byte at zero-based +index+ as an integer, or +nil+ if +index+ is out of range:
  *
  *    s = 'abcde'  # => "abcde"
  *    s.getbyte(0) # => 97


### PR DESCRIPTION
String#getbyte returns ``nil`` if index is out of range.