### PR TITLE
[DOC] Fix a link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 Please see the [official issue tracker], [doc/contributing.rdoc] and wiki [HowToContribute].
 
 [official issue tracker]: https://bugs.ruby-lang.org
-[doc/contributing.rdoc]: contributing.rdoc
+[doc/contributing.rdoc]: doc/contributing.rdoc
 [HowToContribute]: https://bugs.ruby-lang.org/projects/ruby/wiki/HowToContribute


### PR DESCRIPTION
The `doc/contributing.rdoc` link was leading to a 404 page.