### PR TITLE
Fix visibility of alias of zsuper methods

### DIFF
--- a/test/ruby/test_alias.rb
+++ b/test/ruby/test_alias.rb
@@ -265,6 +265,16 @@ class TestAlias < Test::Unit::TestCase
     end;
   end
 
+  class C2
+    public :system
+    alias_method :bar, :system
+    alias_method :system, :bar
+  end
+
+  def test_zsuper_alias_visibility
+    assert(C2.new.respond_to?(:system))
+  end
+
   def test_alias_memory_leak
     assert_no_memory_leak([], "#{<<~"begin;"}", "#{<<~'end;'}", rss: true)
     begin;

--- a/vm_method.c
+++ b/vm_method.c
@@ -2133,6 +2133,7 @@ rb_alias(VALUE klass, ID alias_name, ID original_name)
 	visi = METHOD_ENTRY_VISI(orig_me);
 	goto again;
       case VM_METHOD_TYPE_ALIAS:
+        visi = METHOD_ENTRY_VISI(orig_me);
         orig_me = orig_me->def->body.alias.original_me;
         VM_ASSERT(orig_me->def->type != VM_METHOD_TYPE_ALIAS);
         break;


### PR DESCRIPTION
This was broken by 71c746379d5872e250d90ae45c585760afaf9516.

Fixes [Bug #18600]