### PR TITLE
[DOC] Fix typo in yjit docs

### DIFF
--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -146,7 +146,7 @@ jit_peek_at_local(jitstate_t *jit, ctx_t *ctx, int n)
 }
 
 // Save the incremented PC on the CFP
-// This is necessary when calleees can raise or allocate
+// This is necessary when callees can raise or allocate
 static void
 jit_save_pc(jitstate_t *jit, x86opnd_t scratch_reg)
 {


### PR DESCRIPTION
I noticed this yesterday when pairing with Aaron, there was an extra "e"
in "callees".