### PR TITLE
Dedup superclass array in leaf sibling classes

### DIFF
--- a/internal/class.h
+++ b/internal/class.h
@@ -124,13 +124,14 @@ typedef struct rb_classext_struct rb_classext_t;
 
 #define RICLASS_IS_ORIGIN FL_USER5
 #define RCLASS_CLONED     FL_USER6
+#define RCLASS_SUPERCLASSES_INCLUDE_SELF FL_USER7
 #define RICLASS_ORIGIN_SHARED_MTBL FL_USER8
 
 /* class.c */
 void rb_class_subclass_add(VALUE super, VALUE klass);
 void rb_class_remove_from_super_subclasses(VALUE);
 void rb_class_update_superclasses(VALUE);
-void rb_class_remove_superclasses(VALUE);
+size_t rb_class_superclasses_memsize(VALUE);
 void rb_class_remove_subclass_head(VALUE);
 int rb_singleton_class_internal_p(VALUE sklass);
 VALUE rb_class_boot(VALUE);


### PR DESCRIPTION
Previously, since #5568 we would build a new `superclasses` array for each class, even though for all immediate subclasses of a class, the array is identical.

This avoids duplicating the arrays on leaf classes (those without subclasses) by calculating and storing a "superclasses including self" array on a class when it's first inherited and sharing that among all superclasses.

An additional trick used is that the "superclass array including self" is valid as "self"'s superclass array. It just has it's own class at the end. We can use this to avoid an extra pointer of storage and can use one bit of a flag to track that we've "upgraded" the array.

This doesn't change any code called within of `rb_obj_is_kind_of`, so this should have the same performance as measured in #5568, possibly better as we share arrays so CPU cache is more likely to be warm.

(I will update this with measurements from GitHub on monday)