### PR TITLE
enc/depend: fix out-of-src build with --with-static-linked-ext

### DIFF
--- a/enc/depend
+++ b/enc/depend
@@ -143,10 +143,16 @@ enc/<%=e%>.$(OBJEXT): <%=deps.map {|n| rule_subst % n}.join(' ')%>
 	$(Q)<%=cmd%>
 
 % end
-% dependencies.each do |e|
+% (ENCS + ["trans/transdb"]).each do |e|
 <%="enc/#{e}.$(OBJEXT)"%>: <%="$(encsrcdir)/#{e}.c"%>
 	$(ECHO) compiling <%= "$(encsrcdir)/#{e}.c"%>
 	$(Q)<%=COMPILE_C.gsub(/\$(\()?<(\:[^)]+)?(\))?/){"$(encsrcdir)/#{e}.c"}%>
+
+% end
+% ATRANS.each do |e|
+<%="enc/trans/#{e}.$(OBJEXT)"%>: <%=transvpath % "#{e}.c"%>
+	$(ECHO) compiling <%=transvpath % "#{e}.c"%>
+	$(Q)<%=COMPILE_C.gsub(/\$(\()?<(\:[^)]+)?(\))?/){ transvpath % "#{e}.c"}%>
 
 % end
 


### PR DESCRIPTION
When out-of-src build, at the beginning of a build, `make -f enc.mk
srcs` generates trans C sources under build dir.

On the other hand, `enc/trans/*.o` were built from trans C sources
generated under srcdir due to the following auto-generated rules from
enc/depend.

```
encsrcdir = ../src/enc
...
enc/trans/big5.$(OBJEXT): $(encsrcdir)/trans/big5.c
```

Therefore, trans C sources are generated twice under srcdir and build
dir during a build.

Ideally, trans C sources have always been built before compilation of
`enc/trans/*.o` because the source generation is prereq. So making
`enc/trans/*.o` shouldn't trigger trans C source generation and shouldn't
require MINIRUBY as a make arg for enc.mk. However, the second trans C
source gen is unintentionally triggered by `enc/trans/*.o`, so `make -f
enc.mk libencs` requires MINIRUBY for now.

When no `--with-static-linked-ext`, `make -f enc.mk libencs` is
triggered from common.mk with MINIRUBY, so there is no problem.
But when `--with-static-linked-ext`, libencs should be statically-linked
to ruby, so `make -f enc.mk libencs` is triggered from exts.mk, and
exts.mk invokes it without MINIRUBY.

Therefore, when out-of-src build and with `--with-static-linked-ext`,
the second trans C source gen fails due to missing MINIRUBY.
This issue is deterministically reproducible without -j because
common.mk's `main` rule also has libencs prerequisite.

This patch supresses the second trans C source gen.