### PR TITLE
dir.c: use self-made IFTODT in rb_pathtype_t if available

### DIFF
--- a/dir.c
+++ b/dir.c
@@ -187,12 +187,18 @@ has_nonascii(const char *ptr, size_t len)
 # define IF_NORMALIZE_UTF8PATH(something) /* nothing */
 #endif
 
-#ifndef IFTODT
+#if defined(IFTODT) && defined(DT_UNKNOWN)
+# define EMULATE_IFTODT 0
+#else
+# define EMULATE_IFTODT 1
+#endif
+
+#if EMULATE_IFTODT
 # define IFTODT(m)	(((m) & S_IFMT) / ((~S_IFMT & (S_IFMT-1)) + 1))
 #endif
 
 typedef enum {
-#ifdef DT_UNKNOWN
+#if !EMULATE_IFTODT
     path_exist     = DT_UNKNOWN,
     path_directory = DT_DIR,
     path_regular   = DT_REG,


### PR DESCRIPTION
dir.c defines IFTODT if the system doesn't have it. The macro is used
when comparing with rb_pathtype_t's cases. rb_pathtype_t's cases are
defined by DT_XXX macro if they are available, or defined using IFTODT.
Most POSIX-compatible platforms have both IFTODT and DT_XXX and most of
other platforms like MinGW have neither of them. On those platforms,
DT_XXX-oriented rb_pathtype_t is always compared with values converted
by system's IFTODT, and emulated-IFTODT-oriented rb_pathtype_t is always
compared with values converted by emulated-IFTODT.

However, when IFTODT is *not defined* and DT_XXX is *defined*, like
on wasi-libc, DT_XXX-oriented rb_pathtype_t was compared with values
converted by emulated-IFTODT, and they are not guaranteed to be
compatible.

This patch fixes such a situation by using emulated-IFTODT to define
rb_pathtype_t when either IFTODT or DT_XXX is not available.