### PR TITLE
Revert "enc/depend: fix out-of-src build with --with-static-linked-ext"

### DIFF
--- a/enc/depend
+++ b/enc/depend
@@ -143,16 +143,10 @@ enc/<%=e%>.$(OBJEXT): <%=deps.map {|n| rule_subst % n}.join(' ')%>
 	$(Q)<%=cmd%>
 
 % end
-% (ENCS + ["trans/transdb"]).each do |e|
+% dependencies.each do |e|
 <%="enc/#{e}.$(OBJEXT)"%>: <%="$(encsrcdir)/#{e}.c"%>
 	$(ECHO) compiling <%= "$(encsrcdir)/#{e}.c"%>
 	$(Q)<%=COMPILE_C.gsub(/\$(\()?<(\:[^)]+)?(\))?/){"$(encsrcdir)/#{e}.c"}%>
-
-% end
-% ATRANS.each do |e|
-<%="enc/trans/#{e}.$(OBJEXT)"%>: <%=transvpath % "#{e}.c"%>
-	$(ECHO) compiling <%=transvpath % "#{e}.c"%>
-	$(Q)<%=COMPILE_C.gsub(/\$(\()?<(\:[^)]+)?(\))?/){ transvpath % "#{e}.c"}%>
 
 % end
 


### PR DESCRIPTION
ruby/ruby#5611 broke out-of-src build with pre-generated sources.