### PR TITLE
Fast object is ICLASS checks

### DIFF
--- a/object.c
+++ b/object.c
@@ -817,18 +817,32 @@ rb_obj_is_kind_of(VALUE obj, VALUE c)
     // class without checking type and can return immediately.
     if (cl == c) return Qtrue;
 
-    // Fast path: Both are T_CLASS
-    if (LIKELY(RB_TYPE_P(c, T_CLASS))) {
-        return class_search_class_ancestor(cl, c);
-    }
-
     // Note: YJIT needs this function to never allocate and never raise when
     // `c` is a class or a module.
-    c = class_or_module_required(c);
-    c = RCLASS_ORIGIN(c);
 
-    // Slow path: check each ancestor in the linked list and its method table
-    return RBOOL(class_search_ancestor(cl, c));
+    if (LIKELY(RB_TYPE_P(c, T_CLASS))) {
+        // Fast path: Both are T_CLASS
+        return class_search_class_ancestor(cl, c);
+    } else if (RB_TYPE_P(c, T_ICLASS)) {
+        // First check if we inherit the includer
+        // If we do we can return true immediately
+        VALUE includer = RCLASS_INCLUDER(c);
+        RUBY_ASSERT(RB_TYPE_P(includer, T_CLASS));
+        if (cl == includer) return Qtrue;
+
+        if(class_search_class_ancestor(cl, includer))
+            return Qtrue;
+
+        // We don't include the ICLASS directly, but must check if we inherit
+        // the module via another include
+        return RBOOL(class_search_ancestor(cl, RCLASS_ORIGIN(c)));
+    } else if (RB_TYPE_P(c, T_MODULE)) {
+        // Slow path: check each ancestor in the linked list and its method table
+        return RBOOL(class_search_ancestor(cl, RCLASS_ORIGIN(c)));
+    } else {
+        rb_raise(rb_eTypeError, "class or module required");
+        UNREACHABLE_RETURN(Qfalse);
+    }
 }
 
 


### PR DESCRIPTION
Another follow up to #5568

Calling rb_obj_is_kind_of with an ICLASS returns the same result as calling it with the ICLASS's original Module.

Most of the time we encounter an ICLASS here checking the validity of a protected method or super call, which we expect to return true (or raise a slow exception anyways). We can take advantage of this by performing a fast class inheritance check on the ICLASS's "includer" in hopes that it returns true.

If the includer class check returns false we still have to fallback to the full inheritance chain scan for the module's inclusion, but this should be less common.