### PR TITLE
[DOC] Fix documentation typo for Array#min

### DIFF
--- a/array.c
+++ b/array.c
@@ -8110,7 +8110,7 @@ rb_ary_deconstruct(VALUE ary)
  *  #last:: Returns one or more trailing elements.
  *  #max:: Returns one or more maximum-valued elements,
  *         as determined by <tt><=></tt> or a given block.
- *  #max:: Returns one or more minimum-valued elements,
+ *  #min:: Returns one or more minimum-valued elements,
  *         as determined by <tt><=></tt> or a given block.
  *  #minmax:: Returns the minimum-valued and maximum-valued elements,
  *            as determined by <tt><=></tt> or a given block.


### PR DESCRIPTION
It is just a minor fixes about a typo in Array#min doc.

![image](https://user-images.githubusercontent.com/79608556/156595014-d36ab7fb-6ed1-4c35-8b9a-da74a2d7d795.png)

I read [HowToCotribute](https://bugs.ruby-lang.org/projects/ruby/wiki/HowToContribute) and hope it is all right. It's my first time doing it.

https://bugs.ruby-lang.org/issues/18606