### PR TITLE
Store array of original_insns on iseq

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -1408,13 +1408,13 @@ update_catch_except_flags(struct rb_iseq_constant_body *body)
     /* This assumes that a block has parent_iseq which may catch an exception from the block, and that
        BREAK/NEXT/REDO catch table entries are used only when `throw` insn is used in the block. */
     pos = 0;
-    while (pos < body->iseq_size) {
-        insn = rb_vm_insn_decode(body->iseq_encoded[pos]);
+    while (pos < body->original_insns.size) {
+        insn = body->original_insns.insns[pos];
         if (insn == BIN(throw)) {
             set_catch_except_p(body);
             break;
         }
-        pos += insn_len(insn);
+        pos++;
     }
 
     if (ct == NULL)

--- a/compile.c
+++ b/compile.c
@@ -889,14 +889,17 @@ rb_iseq_original_iseq(const rb_iseq_t *iseq) /* cold path */
 #if OPT_DIRECT_THREADED_CODE || OPT_CALL_THREADED_CODE
     {
 	unsigned int i;
+	unsigned int pc = 0;
 
-	for (i = 0; i < iseq->body->iseq_size; /* */ ) {
-	    const void *addr = (const void *)original_code[i];
-	    const int insn = rb_vm_insn_addr2insn(addr);
+        RUBY_ASSERT(iseq->body->original_insns.insns);
 
-	    original_code[i] = insn;
-	    i += insn_len(insn);
+	for (i = 0; i < iseq->body->original_insns.size; i++) {
+	    const int insn = iseq->body->original_insns.insns[i];
+	    original_code[pc] = insn;
+	    pc += insn_len(insn);
 	}
+
+        RUBY_ASSERT(pc == iseq->body->iseq_size);
     }
 #endif
     return original_code;

--- a/iseq.c
+++ b/iseq.c
@@ -145,7 +145,7 @@ rb_iseq_free(const rb_iseq_t *iseq)
 
 typedef VALUE iseq_value_itr_t(void *ctx, VALUE obj);
 
-void
+static void
 iseq_extract_values(VALUE insn, VALUE *code, size_t pos, iseq_value_itr_t * func, void *data)
 {
     int len = insn_len(insn);

--- a/vm_core.h
+++ b/vm_core.h
@@ -452,6 +452,11 @@ struct rb_iseq_constant_body {
 #endif
     } insns_info;
 
+    struct {
+        uint8_t *insns;
+        unsigned int size;
+    } original_insns;
+
     const ID *local_table;		/* must free */
 
     /* catch table */


### PR DESCRIPTION
This aims to fix https://bugs.ruby-lang.org/issues/18269 as well as making GC iseq marking (and anywhere else we iterate through the instructions) faster by avoiding the hash lookup inside `rb_vm_insn_addr2insn`.

This is done by storing the original instruction values as a byte array on the iseq before they are translated for threading. We can then use those values directly instead of using the hash table from threaded to non-threaded.

The array is per-instruction rather than per-PC-address, so getting the instruction at a specific PC/offset address is awkward and this is designed for iterating the entire iseq. The advantage is that the array is more compact.

The downside of this is that we need to record an extra byte per-vm-instruction.

TODO:
* [x] Replace remaining uses of rb_vm_insn_addr2insn and similar (To avoid conflicts with YJIT's port, avoiding modifications there)
* [ ] Check memory increase on a large app
* [ ] Should this code path be disabled if token threading is used?
* [ ] Add regression test for Bug18269

cc @nobu @k0kubun @jeremyevans from linked issue. What do you think of this approach?