### PR TITLE
Remove get_insn_idx from iseq_inline_constant_cache struct 

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -2414,12 +2414,6 @@ iseq_set_sequence(rb_iseq_t *iseq, LINK_ANCHOR *const anchor)
 			    }
 			    generated_iseq[code_index + 1 + j] = (VALUE)ic;
                             FL_SET(iseqv, ISEQ_MARKABLE_ISEQ);
-
-                            if (insn == BIN(opt_getinlinecache) && type == TS_IC) {
-                                // Store the instruction index for opt_getinlinecache on the IC for
-                                // YJIT to invalidate code when opt_setinlinecache runs.
-                                ic->get_insn_idx = (unsigned int)code_index;
-                            }
 			    break;
 			}
                         case TS_CALLDATA:
@@ -11165,7 +11159,6 @@ ibf_load_code(const struct ibf_load *load, rb_iseq_t *iseq, ibf_offset_t bytecod
     for (code_index=0; code_index<iseq_size;) {
         /* opcode */
         const VALUE insn = code[code_index] = ibf_load_small_value(load, &reading_pos);
-        const unsigned int insn_index = code_index;
         const char *types = insn_op_types(insn);
         int op_index;
 
@@ -11223,12 +11216,6 @@ ibf_load_code(const struct ibf_load *load, rb_iseq_t *iseq, ibf_offset_t bytecod
                 {
                     VALUE op = ibf_load_small_value(load, &reading_pos);
                     code[code_index] = (VALUE)&is_entries[op];
-
-                    if (insn == BIN(opt_getinlinecache) && operand_type == TS_IC) {
-                        // Store the instruction index for opt_getinlinecache on the IC for
-                        // YJIT to invalidate code when opt_setinlinecache runs.
-                        is_entries[op].ic_cache.get_insn_idx = insn_index;
-                    }
                 }
                 FL_SET(iseqv, ISEQ_MARKABLE_ISEQ);
                 break;

--- a/vm_core.h
+++ b/vm_core.h
@@ -269,9 +269,6 @@ set_ic_serial(struct iseq_inline_constant_cache_entry *ice, rb_serial_t v)
 
 struct iseq_inline_constant_cache {
     struct iseq_inline_constant_cache_entry *entry;
-    // For YJIT: the index to the opt_getinlinecache instruction in the same iseq.
-    // It's set during compile time and constant once set.
-    unsigned get_insn_idx;
 };
 
 struct iseq_inline_iv_cache_entry {

--- a/yjit_iface.c
+++ b/yjit_iface.c
@@ -644,8 +644,6 @@ rb_yjit_constant_ic_update(const rb_iseq_t *const iseq, IC ic)
         VALUE *code = body->iseq_encoded;
         const unsigned get_insn_idx = find_get_insn_idx(iseq, ic);
 
-        RUBY_ASSERT(get_insn_idx == ic->get_insn_idx);
-
         RUBY_ASSERT(rb_vm_insn_addr2insn((const void *)code[get_insn_idx]) == BIN(opt_getinlinecache));
         RUBY_ASSERT(get_insn_idx < body->iseq_size);
         RUBY_ASSERT(insn_op_type(BIN(opt_getinlinecache), 1) == TS_IC);


### PR DESCRIPTION
I want to reduce the size of the `iseq_inline_storage_entry` union, which is currently 16 bytes due to the `get_insn_idx` used by YJIT and because of the `once` struct (which I'll tackle in a separate PR).

```
union iseq_inline_storage_entry {
        struct {
                struct rb_thread_struct * running_thread;                                /*     0     8 */
                /* typedef VALUE */ long unsigned int  value;                            /*     8     8 */
        } once;                                                                          /*     0    16 */
        struct iseq_inline_constant_cache {
                struct iseq_inline_constant_cache_entry * entry;                         /*     0     8 */
                unsigned int       get_insn_idx;                                         /*     8     4 */
        }ic_cache; /*     0    16 */
        struct iseq_inline_iv_cache_entry {
                struct rb_iv_index_tbl_entry * entry;                                    /*     0     8 */
        }iv_cache; /*     0     8 */
};
```

This PR replaces the stored index with a scan to find a matching instruction and operand.

This is slower than just storing the index, but I think we should expect IC updates to be uncommon and tolerate them being slow. This would also be made faster by #5622 if merged.

This is similar to what is done in rb_iseq_mark for direct marking.