### PR TITLE
[DOC] Fix documentation typo for Process#clock_gettime

### DIFF
--- a/process.c
+++ b/process.c
@@ -8331,7 +8331,7 @@ ruby_real_ms_time(void)
  *  The underlying function, clock_gettime(), returns a number of nanoseconds.
  *  Float object (IEEE 754 double) is not enough to represent
  *  the return value for CLOCK_REALTIME.
- *  If the exact nanoseconds value is required, use +:nanoseconds+ as the +unit+.
+ *  If the exact nanoseconds value is required, use +:nanosecond+ as the +unit+.
  *
  *  The origin (zero) of the returned value varies.
  *  For example, system start up time, process start up time, the Epoch, etc.


### PR DESCRIPTION
`:nanoseconds` => `:nanosecond`

<img width="1497" alt="Screen Shot 2022-03-04 at 12 47 24 PM" src="https://user-images.githubusercontent.com/207902/156815216-8da094cf-a3a9-4776-9c86-e10d63c4895b.png">

Fixes [Misc #18610]