### PR TITLE
exts.mk.tmpl: propagate MINIRUBY to enc.mk even though invoking from …

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -305,7 +305,7 @@ configure-ext: $(EXTS_MK)
 
 build-ext: $(EXTS_MK)
 	$(Q)$(MAKE) -f $(EXTS_MK) $(mflags) libdir="$(libdir)" LIBRUBY_EXTS=$(LIBRUBY_EXTS) \
-	    EXTENCS="$(ENCOBJS)" UPDATE_LIBRARIES=no $(EXTSTATIC)
+	    EXTENCS="$(ENCOBJS)" MINIRUBY="$(MINIRUBY)" UPDATE_LIBRARIES=no $(EXTSTATIC)
 	$(Q)$(MAKE) $(EXTS_NOTE)
 
 exts-note: $(EXTS_MK)

--- a/template/exts.mk.tmpl
+++ b/template/exts.mk.tmpl
@@ -133,7 +133,7 @@ distclean:
 % end
 
 libencs:
-	$(Q)$(MAKE)<%=mflags%> -f enc.mk V=$(V) $@
+	$(Q)$(MAKE)<%=mflags%> -f enc.mk V=$(V) MINIRUBY="$(MINIRUBY)" $@
 ext/extinit.<%=objext%>:
 	$(Q)$(MAKE)<%=mflags%> V=$(V) EXTINITS="$(EXTINITS)" $@
 


### PR DESCRIPTION
…exts.mk

This is another attempt to fix out-of-src build with
--with-static-linked-ext. The first attempt was
4f1888bda70981d9f5b1bf55ab692e0ce18e79f4 but reverted because it broke
out-of-src build from pre-generated sources via `make dist`.
This patch fixes the second trans C source gen, mentiioned in the
previous commit message, by passing MINIRUBY as well as when invoking
from common.mk