### PR TITLE
Reuse `nonlocal_var` rule for `sym` rule

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -5030,9 +5030,7 @@ ssym		: tSYMBEG sym
 		;
 
 sym		: fname
-		| tIVAR
-		| tGVAR
-		| tCVAR
+		| nonlocal_var
 		;
 
 dsym		: tSYMBEG string_contents tSTRING_END


### PR DESCRIPTION
In `parse.y`, `sym` and `nonlocal_var` pattern rule has similar pattern.

```y
sym		: fname
		| tIVAR
		| tGVAR
		| tCVAR
		;
```

```y
nonlocal_var    : tIVAR
		| tGVAR
		| tCVAR
		;
```

It may be more simpler to reuse `nonlocal_var` rule.

```y
sym		: fname
		| nonlocal_var
		;
```