### PR TITLE
Fast object is ICLASS checks

### DIFF
--- a/test/ruby/test_module.rb
+++ b/test/ruby/test_module.rb
@@ -756,6 +756,25 @@ class TestModule < Test::Unit::TestCase
     assert_equal([:m1, :m0, :m, :sc, :m1, :m0, :c], sc.new.m)
   end
 
+  def test_protected_include_into_included_module
+    m1 = Module.new do
+      def other_foo(other)
+        other.foo
+      end
+
+      protected
+      def foo
+        :ok
+      end
+    end
+    m2 = Module.new
+    c1 = Class.new { include m2 }
+    c2 = Class.new { include m2 }
+    m2.include(m1)
+
+    assert_equal :ok, c1.new.other_foo(c2.new)
+  end
+
   def test_instance_methods
     assert_equal([:user, :user2], User.instance_methods(false).sort)
     assert_equal([:user, :user2, :mixin].sort, User.instance_methods(true).sort)


### PR DESCRIPTION
Re-attempting https://github.com/ruby/ruby/pull/5619 which was reverted due to a CI failure 😅

Calling rb_obj_is_kind_of with an ICLASS returns the same result as calling it with the `ICLASS`'s original Module.

Most of the time we encounter an `ICLASS` here checking the validity of a protected method or super call, which we expect to return true (or raise a slow exception anyways). We can take advantage of this by performing a fast class inheritance check on the `ICLASS`'s `includer` in hopes that it returns true.

If the `includer` class check returns `false` we still have to fallback to the full inheritance chain scan for the module's inclusion, but this should be uncommon.

---

The previous attempt had an assertion that the `includer` of the ICLASS being checked was a T_CLASS. I thought this was always the case as it _usually_ is (even when including into a Module and then including it into a Class), but isn't when a Module is included into another Module _after_ the module has been included into a class (in which case it has a `T_ICLASS` `includer`, whose includer is the `T_CLASS`). I'm not 100% sure that's how it _should_ work, but this PR now checks that the includer is a T_CLASS, and uses the slowpath otherwise.

We could loop and find the "true" includer, which is a `T_CLASS`, and use that, but since this is just a fast path and that case is rare (the issue was only exposed by tests of other edge cases). I'm happy to fall back to the slow path for that.

I've included a test which reliably failed on the previous commit.

cc @XrXr @jeremyevans 