### PR TITLE
Skip ancestry check and allow method caching for protected FCALLs 

### DIFF
--- a/method.h
+++ b/method.h
@@ -75,7 +75,6 @@ typedef struct rb_callable_method_entry_struct { /* same fields with rb_method_e
 #define METHOD_ENTRY_CACHED_SET(me)          ((me)->flags |= IMEMO_FL_USER4)
 #define METHOD_ENTRY_INVALIDATED(me)         ((me)->flags & IMEMO_FL_USER5)
 #define METHOD_ENTRY_INVALIDATED_SET(me)     ((me)->flags |= IMEMO_FL_USER5)
-#define METHOD_ENTRY_CACHEABLE(me)           !(METHOD_ENTRY_VISI(me) == METHOD_VISI_PROTECTED)
 
 static inline void
 METHOD_ENTRY_VISI_SET(rb_method_entry_t *me, rb_method_visibility_t visi)

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -2534,12 +2534,12 @@ vm_callee_setup_arg(rb_execution_context_t *ec, struct rb_calling_info *calling,
             if (LIKELY(!(vm_ci_flag(ci) & VM_CALL_TAILCALL))) {
                 CC_SET_FASTPATH(cc, vm_call_iseq_setup_normal_opt_start,
                                 !IS_ARGS_SPLAT(ci) && !IS_ARGS_KEYWORD(ci) &&
-                                cacheable_ci && METHOD_ENTRY_CACHEABLE(vm_cc_cme(cc)));
+                                cacheable_ci && vm_call_cacheable(ci, cc));
             }
             else {
                 CC_SET_FASTPATH(cc, vm_call_iseq_setup_tailcall_opt_start,
                                 !IS_ARGS_SPLAT(ci) && !IS_ARGS_KEYWORD(ci) &&
-                                cacheable_ci && METHOD_ENTRY_CACHEABLE(vm_cc_cme(cc)));
+                                cacheable_ci && vm_call_cacheable(ci, cc));
             }
 
             /* initialize opt vars for self-references */
@@ -2567,7 +2567,7 @@ vm_callee_setup_arg(rb_execution_context_t *ec, struct rb_calling_info *calling,
                     args_setup_kw_parameters(ec, iseq, ci_kws, ci_kw_len, ci_keywords, klocals);
 
                     CC_SET_FASTPATH(cc, vm_call_iseq_setup_kwparm_kwarg,
-                                    cacheable_ci && METHOD_ENTRY_CACHEABLE(vm_cc_cme(cc)));
+                                    cacheable_ci && vm_call_cacheable(ci, cc));
 
                     return 0;
                 }
@@ -2580,7 +2580,7 @@ vm_callee_setup_arg(rb_execution_context_t *ec, struct rb_calling_info *calling,
                 if (klocals[kw_param->num] == INT2FIX(0)) {
                     /* copy from default_values */
                     CC_SET_FASTPATH(cc, vm_call_iseq_setup_kwparm_nokwarg,
-                                    cacheable_ci && METHOD_ENTRY_CACHEABLE(vm_cc_cme(cc)));
+                                    cacheable_ci && vm_call_cacheable(ci, cc));
                 }
 
                 return 0;

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -3749,7 +3749,7 @@ vm_call_method(rb_execution_context_t *ec, rb_control_frame_t *cfp, struct rb_ca
             return vm_call_method_each_type(ec, cfp, calling);
 
 	  case METHOD_VISI_PROTECTED:
-	    if (!(vm_ci_flag(ci) & VM_CALL_OPT_SEND)) {
+	    if (!(vm_ci_flag(ci) & (VM_CALL_OPT_SEND | VM_CALL_FCALL))) {
                 VALUE defined_class = vm_defined_class_for_protected_call(vm_cc_cme(cc));
                 if (!rb_obj_is_kind_of(cfp->self, defined_class)) {
                     vm_cc_method_missing_reason_set(cc, MISSING_PROTECTED);

--- a/vm_insnhelper.h
+++ b/vm_insnhelper.h
@@ -252,13 +252,18 @@ THROW_DATA_CONSUMED_SET(struct vm_throw_data *obj)
 #define IS_ARGS_KW_OR_KW_SPLAT(ci) (vm_ci_flag(ci) & (VM_CALL_KWARG | VM_CALL_KW_SPLAT))
 #define IS_ARGS_KW_SPLAT_MUT(ci)   (vm_ci_flag(ci) & VM_CALL_KW_SPLAT_MUT)
 
+static inline bool
+vm_call_cacheable(const struct rb_callinfo *ci, const struct rb_callcache *cc)
+{
+    return (vm_ci_flag(ci) & VM_CALL_FCALL) ||
+        METHOD_ENTRY_VISI(vm_cc_cme(cc)) != METHOD_VISI_PROTECTED;
+}
 /* If this returns true, an optimized function returned by `vm_call_iseq_setup_func`
    can be used as a fastpath. */
 static inline bool
 vm_call_iseq_optimizable_p(const struct rb_callinfo *ci, const struct rb_callcache *cc)
 {
-    return !IS_ARGS_SPLAT(ci) && !IS_ARGS_KEYWORD(ci) &&
-        METHOD_ENTRY_CACHEABLE(vm_cc_cme(cc));
+    return !IS_ARGS_SPLAT(ci) && !IS_ARGS_KEYWORD(ci) && vm_call_cacheable(ci, cc);
 }
 
 #endif /* RUBY_INSNHELPER_H */

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -4825,7 +4825,12 @@ fn gen_send_general(
             }
         }
         METHOD_VISI_PROTECTED => {
-            jit_protected_callee_ancestry_guard(jit, cb, ocb, cme, side_exit);
+            // If the method call is an FCALL, it is always valid
+            if flags & VM_CALL_FCALL == 0 {
+                // otherwise we need an ancestry check to ensure the receiver is vaild to be called
+                // as protected
+                jit_protected_callee_ancestry_guard(jit, cb, ocb, cme, side_exit);
+            }
         }
         _ => {
             panic!("cmes should always have a visibility!");


### PR DESCRIPTION
If we are making an FCALL, we know we are calling a method on self. This is the same check made for private method visibility, so _I think_ it should also guarantee we can call the protected method. (Hopefully I haven't missed some case the check was needed)

For example in the following `foo` we should not have to check the ancestry of the `bar` receiver, as we know it is self:

```
class Foo
  def foo
    bar
  end

  protected
  def bar
    123
  end
end
```

This allows us to skip the ancestry check on the receiver (which was recently made faster, but still not as fast as skipping the check entirely 😁). And allows setting the fastpath to the inline method cache in the interpreter.

I don't think this pattern is particularly common, and probably most often found in code that should be using `private`, but there are some proper uses (when a method is sometimes called via fcall and sometimes on a different receiver). Fortunately I think this optimization is essentially free, as we were already checking flags everywhere this PR changes.

<details>
<summary>Benchmark</summary>

```
prelude: |
  class BaseClass
    def call_public
      public_foo
      public_foo
      public_foo
      public_foo
      public_foo
      public_foo
      public_foo
      public_foo
      public_foo
      public_foo
    end
    def call_self
      foo
      foo
      foo
      foo
      foo
      foo
      foo
      foo
      foo
      foo
    end
    def call_other(other)
      other.foo
      other.foo
      other.foo
      other.foo
      other.foo
      other.foo
      other.foo
      other.foo
      other.foo
      other.foo
    end
    def public_foo
      123
    end
    protected
    def foo
      123
    end
  end
  class MyClass < BaseClass
    10.times { include Module.new }
  end
  OBJ = MyClass.new
benchmark:
  call_public: |
    OBJ.call_public
  call_self: |
    OBJ.call_self
  call_other: |
    OBJ.call_other(OBJ)
loop_count: 2000000
```

</details>


Interpreter:

```
|             |Ruby 3.1|   trunk|This branch|
|:------------|-------:|-------:|----------:|
|call_public  |  6.216M|  6.303M|     6.337M|
|             |       -|   1.01x|      1.02x|
|call_self    |  2.292M|  2.973M|     6.357M|
|             |       -|   1.30x|      2.77x|
|call_other   |  2.349M|  2.945M|     2.973M|
|             |       -|   1.25x|      1.27x|
```

YJIT:

```
|             |Ruby 3.1|   trunk|This branch|
|:------------|-------:|-------:|----------:|
|call_public  | 18.945M| 18.873M|    19.575M|
|             |   1.00x|       -|      1.04x|
|call_self    |  6.454M| 13.706M|    19.452M|
|             |       -|   2.12x|      3.01x|
|call_other   |  6.535M| 13.234M|    13.449M|
|             |       -|   2.02x|      2.06x|
```