### PR TITLE
[DOC] Enhanced RDoc for String#split

### DIFF
--- a/doc/string.rdoc
+++ b/doc/string.rdoc
@@ -47,4 +47,79 @@ class String
   def initialize(str = '', encoding: nil, capacity: nil)
     Primitive.rb_str_init(str, encoding, capacity)
   end
-end
+
+  #  call-seq:
+  #    split(pattern = $FIELD_SEPARATOR, limit = nil) -> array
+  #    split(pattern = $FIELD_SEPARATOR, limit = nil) {|sub| block } -> object
+  #
+  #  Returns an array of substrings of +self+;
+  #  the substrings are copied from +self+, based on the given arguments.
+  #
+  #  When argument +pattern+ is $FIELD_SEPARATOR:
+  #
+  #  - If $FIELD_SEPARATOR is +nil+ (its default value),
+  #    the split occurs just as if +pattern+ were given as a space character
+  #    (see below).
+  #
+  #  - If $FIELD_SEPARATOR is a string,
+  #    the split ocurs just as if +pattern+ were given as that string
+  #    (see below).
+  #
+  #  When argument +pattern+ is <tt>' '</tt> and argument +limit+ is +nil+,
+  #  the split occurs at each sequence of whitespace:
+  #
+  #    'abc def ghi'.split(' ')          # => ["abc", "def", "ghi"]
+  #    "abc \n\tdef\t\n  ghi".split(' ') # => ["abc", "def", "ghi"]
+  #    'abc  def   ghi'.split(' ')       # => ["abc", "def", "ghi"]
+  #    ''.split(' ')                     # => []
+  #
+  #  When argument +pattern+ is a string different from <tt>' '</tt>
+  #  and argument +limit+ is +nil+,
+  #  the split occurs at each occurrence of the pattern;
+  #  trailing null substrings are not returned:
+  #
+  #    'abracadabra'.split('ab')   # => ["", "racad", "ra"]
+  #    'aaabcdaaa'.split('a')      # => ["", "", "", "bcd"]
+  #    ''.split('a')               # => []
+  #    '3.14159'.split('1')        # => ["3.", "4", "59"]
+  #    '!@#$%^$&*($)_+'.split('$') # => ["!@#", "%^", "&*(", ")_+"]
+  #    'тест'.split('т')           # => ["", "ес"]
+  #    'こんにちは'.split('に')     # => ["こん", "ちは"]
+  #
+  #  When argument +pattern+ is a Regexp and argument +limit+ is +nil+,
+  #  the split occurs at each occurrence of a match;
+  #  trailing null substrings are not returned:
+  #
+  #    'abracadabra'.split(/ab/) # => ["", "racad", "ra"]
+  #    'aaabcdaaa'.split(/a/)    # => ["", "", "", "bcd"]
+  #    'aaabcdaaa'.split(/       # => ["a", "a", "a", "b", "c", "d", "a", "a", "a"]
+  #
+  #  If the \Regexp contains groups, their matches are also included
+  #  in the returned array.
+  #
+  #  As seen above, if argument +limit+ is +nil+,
+  #  trailing null substrings are not returned;
+  #  the same is true if +limit+ is zero:
+  #
+  #    'aaabcdaaa'.split('a')    # => ["", "", "", "bcd"]
+  #    'aaabcdaaa'.split('a', 0) # => ["", "", "", "bcd"]
+  #
+  #  If +limit+ is positive integer +n+, no more than <tt>n - 1-</tt>
+  #  splits occur, so that at most +n+ substrings are returned,
+  #  and trailing null substrings are included:
+  #
+  #    'aaabcdaaa'.split('a', 1) # => ["aaabcdaaa"]
+  #    'aaabcdaaa'.split('a', 2) # => ["", "aabcdaaa"]
+  #    'aaabcdaaa'.split('a', 5) # => ["", "", "", "bcd", "aa"]
+  #    'aaabcdaaa'.split('a', 7) # => ["", "", "", "bcd", "", "", ""]
+  #    'aaabcdaaa'.split('a', 8) # => ["", "", "", "bcd", "", "", ""]
+  #
+  #  Note that if +pattern+ is a \Regexp containing groups,
+  #  their matches are in the returned array, but do not count toward the limit.
+  #
+  #  If +limit+ is negative, there is no limit,
+  #  and trailing null substrings are included:
+  #
+  #    'aaabcdaaa'.split('a', -1) # => ["", "", "", "bcd", "", "", ""]
+  #
+  def split; end

--- a/doc/string.rdoc
+++ b/doc/string.rdoc
@@ -120,7 +120,8 @@ class String
   #  Note that if +separator+ is a \Regexp containing groups,
   #  their matches are in the returned array, but do not count toward the limit.
   #
-  #  If +limit+ is negative, there is no limit,
+  #  If +limit+ is negative, it behaves the same as if +limit+ was +nil+,
+  #  meaning that there is no limit,
   #  and trailing empty substrings are included:
   #
   #    'aaabcdaaa'.split('a', -1) # => ["", "", "", "bcd", "", "", ""]

--- a/doc/string.rdoc
+++ b/doc/string.rdoc
@@ -1,5 +1,5 @@
 # :markup: ruby
-7
+
 class String
   # call-seq:
   #   String.new(string = '') -> new_string
@@ -94,6 +94,7 @@ class String
   #    'abracadabra'.split(/ab/) # => ["", "racad", "ra"]
   #    'aaabcdaaa'.split(/a/)    # => ["", "", "", "bcd"]
   #    'aaabcdaaa'.split(//)     # => ["a", "a", "a", "b", "c", "d", "a", "a", "a"]
+  #    '1 + 1 == 2'.split(/\W+/) # => ["1", "1", "2"]
   #
   #  If the \Regexp contains groups, their matches are also included
   #  in the returned array:

--- a/doc/string.rdoc
+++ b/doc/string.rdoc
@@ -1,5 +1,5 @@
 # :markup: ruby
-
+7
 class String
   # call-seq:
   #   String.new(string = '') -> new_string
@@ -49,23 +49,24 @@ class String
   end
 
   #  call-seq:
-  #    split(pattern = $FIELD_SEPARATOR, limit = nil) -> array
-  #    split(pattern = $FIELD_SEPARATOR, limit = nil) {|sub| block } -> object
+  #    split(separator = $;, limit = nil) -> array
+  #    split(separator = $;, limit = nil) {|substring| ... } -> self
   #
-  #  Returns an array of substrings of +self+;
-  #  the substrings are copied from +self+, based on the given arguments.
+  #  Returns an array of substrings of +self+
+  #  that are the result of splitting +self+
+  #  at each occurrence of the given +separator+.
   #
-  #  When argument +pattern+ is $FIELD_SEPARATOR:
+  #  When argument +separator+ is <tt>$;</tt>:
   #
-  #  - If $FIELD_SEPARATOR is +nil+ (its default value),
-  #    the split occurs just as if +pattern+ were given as a space character
+  #  - If <tt>$;</tt> is +nil+ (its default value),
+  #    the split occurs just as if +separator+ were given as a space character
   #    (see below).
   #
-  #  - If $FIELD_SEPARATOR is a string,
-  #    the split ocurs just as if +pattern+ were given as that string
+  #  - If <tt>$;</tt> is a string,
+  #    the split ocurs just as if +separator+ were given as that string
   #    (see below).
   #
-  #  When argument +pattern+ is <tt>' '</tt> and argument +limit+ is +nil+,
+  #  When argument +separator+ is <tt>' '</tt> and argument +limit+ is +nil+,
   #  the split occurs at each sequence of whitespace:
   #
   #    'abc def ghi'.split(' ')          # => ["abc", "def", "ghi"]
@@ -73,10 +74,10 @@ class String
   #    'abc  def   ghi'.split(' ')       # => ["abc", "def", "ghi"]
   #    ''.split(' ')                     # => []
   #
-  #  When argument +pattern+ is a string different from <tt>' '</tt>
+  #  When argument +separator+ is a string different from <tt>' '</tt>
   #  and argument +limit+ is +nil+,
-  #  the split occurs at each occurrence of the pattern;
-  #  trailing null substrings are not returned:
+  #  the split occurs at each occurrence of the separator;
+  #  trailing empty substrings are not returned:
   #
   #    'abracadabra'.split('ab')   # => ["", "racad", "ra"]
   #    'aaabcdaaa'.split('a')      # => ["", "", "", "bcd"]
@@ -84,21 +85,23 @@ class String
   #    '3.14159'.split('1')        # => ["3.", "4", "59"]
   #    '!@#$%^$&*($)_+'.split('$') # => ["!@#", "%^", "&*(", ")_+"]
   #    'тест'.split('т')           # => ["", "ес"]
-  #    'こんにちは'.split('に')     # => ["こん", "ちは"]
+  #    'こんにちは'.split('に')      # => ["こん", "ちは"]
   #
-  #  When argument +pattern+ is a Regexp and argument +limit+ is +nil+,
+  #  When argument +separator+ is a Regexp and argument +limit+ is +nil+,
   #  the split occurs at each occurrence of a match;
-  #  trailing null substrings are not returned:
+  #  trailing empty substrings are not returned:
   #
   #    'abracadabra'.split(/ab/) # => ["", "racad", "ra"]
   #    'aaabcdaaa'.split(/a/)    # => ["", "", "", "bcd"]
-  #    'aaabcdaaa'.split(/       # => ["a", "a", "a", "b", "c", "d", "a", "a", "a"]
+  #    'aaabcdaaa'.split(//)     # => ["a", "a", "a", "b", "c", "d", "a", "a", "a"]
   #
   #  If the \Regexp contains groups, their matches are also included
-  #  in the returned array.
+  #  in the returned array:
+  #
+  #    '1:2:3'.split(/(:)()()/, 2) # => ["1", ":", "", "", "2:3"]
   #
   #  As seen above, if argument +limit+ is +nil+,
-  #  trailing null substrings are not returned;
+  #  trailing empty substrings are not returned;
   #  the same is true if +limit+ is zero:
   #
   #    'aaabcdaaa'.split('a')    # => ["", "", "", "bcd"]
@@ -106,7 +109,7 @@ class String
   #
   #  If +limit+ is positive integer +n+, no more than <tt>n - 1-</tt>
   #  splits occur, so that at most +n+ substrings are returned,
-  #  and trailing null substrings are included:
+  #  and trailing empty substrings are included:
   #
   #    'aaabcdaaa'.split('a', 1) # => ["aaabcdaaa"]
   #    'aaabcdaaa'.split('a', 2) # => ["", "aabcdaaa"]
@@ -114,13 +117,23 @@ class String
   #    'aaabcdaaa'.split('a', 7) # => ["", "", "", "bcd", "", "", ""]
   #    'aaabcdaaa'.split('a', 8) # => ["", "", "", "bcd", "", "", ""]
   #
-  #  Note that if +pattern+ is a \Regexp containing groups,
+  #  Note that if +separator+ is a \Regexp containing groups,
   #  their matches are in the returned array, but do not count toward the limit.
   #
   #  If +limit+ is negative, there is no limit,
-  #  and trailing null substrings are included:
+  #  and trailing empty substrings are included:
   #
   #    'aaabcdaaa'.split('a', -1) # => ["", "", "", "bcd", "", "", ""]
+  #
+  #  If a block is given, it is called with each substring:
+  #
+  #    'abc def ghi'.split(' ') {|substring| p substring }
+  #
+  #  Output:
+  #
+  #    "abc"
+  #    "def"
+  #    "ghi"
   #
   def split; end
 

--- a/doc/string.rdoc
+++ b/doc/string.rdoc
@@ -123,3 +123,5 @@ class String
   #    'aaabcdaaa'.split('a', -1) # => ["", "", "", "bcd", "", "", ""]
   #
   def split; end
+
+end

--- a/string.c
+++ b/string.c
@@ -8583,58 +8583,7 @@ literal_split_pattern(VALUE spat, split_type_t default_type)
 }
 
 /*
- *  call-seq:
- *     str.split(pattern=nil, [limit])                -> an_array
- *     str.split(pattern=nil, [limit]) {|sub| block } -> str
- *
- *  Divides <i>str</i> into substrings based on a delimiter, returning an array
- *  of these substrings.
- *
- *  If <i>pattern</i> is a String, then its contents are used as
- *  the delimiter when splitting <i>str</i>. If <i>pattern</i> is a single
- *  space, <i>str</i> is split on whitespace, with leading and trailing
- *  whitespace and runs of contiguous whitespace characters ignored.
- *
- *  If <i>pattern</i> is a Regexp, <i>str</i> is divided where the
- *  pattern matches. Whenever the pattern matches a zero-length string,
- *  <i>str</i> is split into individual characters. If <i>pattern</i> contains
- *  groups, the respective matches will be returned in the array as well.
- *
- *  If <i>pattern</i> is <code>nil</code>, the value of <code>$;</code> is used.
- *  If <code>$;</code> is <code>nil</code> (which is the default), <i>str</i> is
- *  split on whitespace as if ' ' were specified.
- *
- *  If the <i>limit</i> parameter is omitted, trailing null fields are
- *  suppressed. If <i>limit</i> is a positive number, at most that number
- *  of split substrings will be returned (captured groups will be returned
- *  as well, but are not counted towards the limit).
- *  If <i>limit</i> is <code>1</code>, the entire
- *  string is returned as the only entry in an array. If negative, there is no
- *  limit to the number of fields returned, and trailing null fields are not
- *  suppressed.
- *
- *  When the input +str+ is empty an empty Array is returned as the string is
- *  considered to have no fields to split.
- *
- *     " now's  the time ".split       #=> ["now's", "the", "time"]
- *     " now's  the time ".split(' ')  #=> ["now's", "the", "time"]
- *     " now's  the time".split(/ /)   #=> ["", "now's", "", "the", "time"]
- *     "1, 2.34,56, 7".split(%r{,\s*}) #=> ["1", "2.34", "56", "7"]
- *     "hello".split(//)               #=> ["h", "e", "l", "l", "o"]
- *     "hello".split(//, 3)            #=> ["h", "e", "llo"]
- *     "hi mom".split(%r{\s*})         #=> ["h", "i", "m", "o", "m"]
- *
- *     "mellow yellow".split("ello")   #=> ["m", "w y", "w"]
- *     "1,2,,3,4,,".split(',')         #=> ["1", "2", "", "3", "4"]
- *     "1,2,,3,4,,".split(',', 4)      #=> ["1", "2", "", "3,4,,"]
- *     "1,2,,3,4,,".split(',', -4)     #=> ["1", "2", "", "3", "4", "", ""]
- *
- *     "1:2:3".split(/(:)()()/, 2)     #=> ["1", ":", "", "", "2:3"]
- *
- *     "".split(',', -1)               #=> []
- *
- *  If a block is given, invoke the block with each split substring.
- *
+ * String#split is documented at doc/string.rdoc.
  */
 
 static VALUE


### PR DESCRIPTION
Revises doc for String#split, and moves it from string.c to doc/string.rdoc to allow non-US-ASCII in examples.