### PR TITLE
spec: disable part of require_relative spec where uses symlink for WASI

### DIFF
--- a/spec/ruby/core/kernel/require_relative_spec.rb
+++ b/spec/ruby/core/kernel/require_relative_spec.rb
@@ -207,7 +207,7 @@ describe "Kernel#require_relative with a relative path" do
       $LOADED_FEATURES.should include(@abs_path)
     end
 
-    platform_is_not :windows do
+    platform_is_not :windows, :wasi do
       describe "with symlinks" do
         before :each do
           @symlink_to_code_dir = tmp("codesymlink")


### PR DESCRIPTION
cap-std, an underlying sandbox implementation of WASI in wasmtime, doesn't
allow to create a symlink to an absolute path to enforce sandbox restriction.

See also: https://github.com/bytecodealliance/cap-std/commit/257867a1d3a589b2561b00111ffa4db3bab0e8be