### PR TITLE
[DOC] Remove outdated note from WeakRef#initialize

### DIFF
--- a/lib/weakref.rb
+++ b/lib/weakref.rb
@@ -30,9 +30,6 @@ class WeakRef < Delegator
 
   ##
   # Creates a weak reference to +orig+
-  #
-  # Raises an ArgumentError if the given +orig+ is immutable, such as Symbol,
-  # Integer, or Float.
 
   def initialize(orig)
     case orig


### PR DESCRIPTION
The note

> Raises an ArgumentError if the given +orig+ is immutable, such as Symbol,
> Integer, or Float.

has not been true since #2313 (GH-2313, Feature #16035) when @casperisfine enabled storing non-finalizable objects in the underlying `ObjectSpace::WeakMap`.

On Ruby 2.7+, `WeakRef.new(1) + 1` works fine and the result is the expected 2.