### PR TITLE
wasm/README.md: add manual config.guess download and autoconf steps

### DIFF
--- a/wasm/README.md
+++ b/wasm/README.md
@@ -23,7 +23,14 @@ $ export WASI_SDK_PATH=/path/to/wasi-sdk-X.Y
 ```console
 $ export PATH=path/to/binaryen:$PATH
 ```
-5. Configure
+5. Download the latest `config.guess` with WASI support, and run `./autogen.sh` to generate configure when you
+   are building from the source checked out from Git repository
+```console
+$ ruby tool/downloader.rb -d tool -e gnu config.guess config.sub
+$ ./autogen.sh
+```
+
+6. Configure
   - You can select which extensions you want to build.
   - If you got `Out of bounds memory access` while running the produced ruby, you may need to increase the maximum size of stack.
 ```console
@@ -34,7 +41,7 @@ $ ./configure LDFLAGS="-Xlinker -zstack-size=16777216" \
   --with-ext=ripper,monitor
 ```
 
-6. Make
+7. Make
 ```console
 $ make install
 ```


### PR DESCRIPTION
Autoconf distributed with Ubuntu 22.04 is very old and doesn't support
WASI as an OS, so add instructions to download the latest config.guess,
then run `./autogen.sh`.

See also: https://github.com/ruby/chkbuild/commit/2297012efd6364f6fde45f54531b6fc0f0838ec9