### PR TITLE
Replace and Using `LIKELY` and `UNLIKELY` macro

### DIFF
--- a/array.c
+++ b/array.c
@@ -1490,7 +1490,7 @@ rb_ary_behead(VALUE ary, long n)
 
     rb_ary_modify_check(ary);
 
-    if (RB_UNLIKELY(!ARY_SHARED_P(ary))) {
+    if (UNLIKELY(!ARY_SHARED_P(ary))) {
         if (RARRAY_LEN(ary) < ARY_DEFAULT_SIZE) {
             RARRAY_PTR_USE_TRANSIENT(ary, ptr, {
                 MEMMOVE(ptr, ptr + n, VALUE, RARRAY_LEN(ary) - n);

--- a/error.c
+++ b/error.c
@@ -1008,7 +1008,7 @@ rb_check_type(VALUE x, int t)
 {
     int xt;
 
-    if (RB_UNLIKELY(x == Qundef)) {
+    if (UNLIKELY(x == Qundef)) {
 	rb_bug(UNDEF_LEAKED);
     }
 
@@ -1029,7 +1029,7 @@ rb_check_type(VALUE x, int t)
 void
 rb_unexpected_type(VALUE x, int t)
 {
-    if (RB_UNLIKELY(x == Qundef)) {
+    if (UNLIKELY(x == Qundef)) {
 	rb_bug(UNDEF_LEAKED);
     }
 

--- a/range.c
+++ b/range.c
@@ -1190,7 +1190,7 @@ range_last(int argc, VALUE *argv, VALUE range)
     b = RANGE_BEG(range);
     e = RANGE_END(range);
     if (RB_INTEGER_TYPE_P(b) && RB_INTEGER_TYPE_P(e) &&
-        RB_LIKELY(rb_method_basic_definition_p(rb_cRange, idEach))) {
+        LIKELY(rb_method_basic_definition_p(rb_cRange, idEach))) {
         return rb_int_range_last(argc, argv, range);
     }
     return rb_ary_last(argc, argv, rb_Array(range));


### PR DESCRIPTION
Some code used `RB_LIKELY` and `UNLIKELY`.

```c
    if (RB_UNLIKELY(x == Qundef)) {
	rb_bug(UNDEF_LEAKED);
    }
``` 

But, alredy defined `LIKELY` and `UNLIKELY` macro in `internal.h`.
And, already used these macro in MRI source code.

 I thought better to using `LIKELY` and `UNLIKELY` macro instead of `RB_LIKELY` and `UNLIKELY`.