### PR TITLE
Don't attempt to read ivars on T_ICLASS in struct

### DIFF
--- a/struct.c
+++ b/struct.c
@@ -43,13 +43,14 @@ struct_ivar_get(VALUE c, ID id)
 	return ivar;
 
     for (;;) {
-	c = RCLASS_SUPER(c);
-	if (c == 0 || c == rb_cStruct)
-	    return Qnil;
-	ivar = rb_attr_get(c, id);
-	if (!NIL_P(ivar)) {
-	    return rb_ivar_set(orig, id, ivar);
-	}
+        c = rb_class_superclass(c);
+        if (c == 0 || c == rb_cStruct)
+            return Qnil;
+        RUBY_ASSERT(RB_TYPE_P(c, T_CLASS));
+        ivar = rb_attr_get(c, id);
+        if (!NIL_P(ivar)) {
+            return rb_ivar_set(orig, id, ivar);
+        }
     }
 }
 


### PR DESCRIPTION
Similar to #5663, calling `rb_attr_get` on a `T_ICLASS` will always return `Qnil`, as `rb_ivar_lookup` isn't implemented for `T_ICLASS` in the way it is for `T_CLASS` and `T_MODULE`.

This commit uses rb_class_superclass instead to avoid looking up ivars on T_ICLASS. The existing behaviour didn't cause any problems but this may be slightly faster and could simplify future ivar improvements.