### PR TITLE
spec: disable a part of Kernel.open spec where spawns a process for WASI

### DIFF
--- a/spec/ruby/core/kernel/open_spec.rb
+++ b/spec/ruby/core/kernel/open_spec.rb
@@ -27,7 +27,7 @@ describe "Kernel#open" do
     open(@name, "r") { |f| f.gets }.should == @content
   end
 
-  platform_is_not :windows do
+  platform_is_not :windows, :wasi do
     it "opens an io when path starts with a pipe" do
       @io = open("|date")
       begin


### PR DESCRIPTION
WASI doesn't provide a way to spawn a new process