### PR TITLE
spec: skip specs where set TZ environment variable for WASI

### DIFF
--- a/spec/mspec/lib/mspec/helpers/datetime.rb
+++ b/spec/mspec/lib/mspec/helpers/datetime.rb
@@ -25,6 +25,7 @@ def new_datetime(opts = {})
 end
 
 def with_timezone(name, offset = nil, daylight_saving_zone = "")
+  skip "WASI doesn't have TZ concept" if PlatformGuard.wasi?
   zone = name.dup
 
   if offset


### PR DESCRIPTION
WASI doesn't respect TZ env var for now