### PR TITLE
Revert "Faster rb_class_superclass"

### DIFF
--- a/object.c
+++ b/object.c
@@ -2034,18 +2034,19 @@ rb_class_new_instance(int argc, const VALUE *argv, VALUE klass)
 VALUE
 rb_class_superclass(VALUE klass)
 {
-    RUBY_ASSERT(RB_TYPE_P(klass, T_CLASS));
-
     VALUE super = RCLASS_SUPER(klass);
 
     if (!super) {
 	if (klass == rb_cBasicObject) return Qnil;
 	rb_raise(rb_eTypeError, "uninitialized class");
-    } else {
-        super = RCLASS_SUPERCLASSES(klass)[RCLASS_SUPERCLASS_DEPTH(klass) - 1];
-        RUBY_ASSERT(RB_TYPE_P(klass, T_CLASS));
-        return super;
     }
+    while (RB_TYPE_P(super, T_ICLASS)) {
+	super = RCLASS_SUPER(super);
+    }
+    if (!super) {
+	return Qnil;
+    }
+    return super;
 }
 
 VALUE


### PR DESCRIPTION
Reverts ruby/ruby#5662

I'm not sure why yet, but this definitely broke something 😩 

```
<pre>

/tmp/ruby/v3/src/trunk/test/ruby/test_class.rb:758: [BUG] Segmentation fault at 0xfffffffffffffff8
--
  | ruby 3.2.0dev (2022-03-17T18:48:39Z master 29b68b89a0) [x86_64-linux]
  | -- Control frame information -----------------------------------------------
  | c:0017 p:---- s:0113 e:000112 CFUNC  :superclass
  | me:
  | called_id: superclass, type: cfunc
  | owner class: 0x00007faaa8d8bd50 [3LM R  ] T_CLASS Class
  | self: 0x00007faaa377cf18 [3LM    ] T_CLASS (annon)
  | c:0016 p:0014 s:0109 e:000106 BLOCK  /tmp/ruby/v3/src/trunk/test/ruby/test_class.rb:758 [FINISH]
  | me:
  | called_id: test_subclasses, type: iseq
  | owner class: 0x00007faaa3740f18 [3LM R  ] T_CLASS TestClass
  | self: 0x00007faaa391d598 [0      ] T_OBJECT (TestClass)len:8 ptr:0x00007faaaacdfd20
  | lvars:
  | subclass: 0x00007faaa377cf18 [3LM    ] T_CLASS (annon)

</pre>[](http://ci.rvm.jp/logfiles/brlog.trunk.20220317-184853#L529)[](http://ci.rvm.jp/logfiles/brlog.trunk.20220317-184853#L531)[](http://ci.rvm.jp/logfiles/brlog.trunk.20220317-184853#L532)[](http://ci.rvm.jp/logfiles/brlog.trunk.20220317-184853#L533)[](http://ci.rvm.jp/logfiles/brlog.trunk.20220317-184853#L534)[](http://ci.rvm.jp/logfiles/brlog.trunk.20220317-184853#L535)[](http://ci.rvm.jp/logfiles/brlog.trunk.20220317-184853#L536)[](http://ci.rvm.jp/logfiles/brlog.trunk.20220317-184853#L537)[](http://ci.rvm.jp/logfiles/brlog.trunk.20220317-184853#L538)[](http://ci.rvm.jp/logfiles/brlog.trunk.20220317-184853#L539)[](http://ci.rvm.jp/logfiles/brlog.trunk.20220317-184853#L540)[](http://ci.rvm.jp/logfiles/brlog.trunk.20220317-184853#L541)[](http://ci.rvm.jp/logfiles/brlog.trunk.20220317-184853#L542)[](http://ci.rvm.jp/logfiles/brlog.trunk.20220317-184853#L543)/tmp/ruby/v3/src/trunk/test/ruby/test_class.rb:758: [BUG] Segmentation fault at 0xfffffffffffffff8
	ruby 3.2.0dev (2022-03-17T18:48:39Z master 29b68b89a0) [x86_64-linux]
	-- Control frame information -----------------------------------------------
	c:0017 p:---- s:0113 e:000112 CFUNC  :superclass
	  me:
	    called_id: superclass, type: cfunc
	    owner class: 0x00007faaa8d8bd50 [3LM R  ] T_CLASS Class
	  self: 0x00007faaa377cf18 [3LM    ] T_CLASS (annon)
	c:0016 p:0014 s:0109 e:000106 BLOCK  /tmp/ruby/v3/src/trunk/test/ruby/test_class.rb:758 [FINISH]
	  me:
	    called_id: test_subclasses, type: iseq
	    owner class: 0x00007faaa3740f18 [3LM R  ] T_CLASS TestClass
	  self: 0x00007faaa391d598 [0      ] T_OBJECT (TestClass)len:8 ptr:0x00007faaaacdfd20
	  lvars:
	    subclass: 0x00007faaa377cf18 [3LM    ] T_CLASS (annon)
```