### PR TITLE
dir.c: refresh pathtype when emulating `IFTODT` in `glob_helper`

### DIFF
--- a/dir.c
+++ b/dir.c
@@ -2148,7 +2148,7 @@ dirent_copy(const struct dirent *dp, rb_dirent_t *rdp)
         newrdp->d_altname = dp->d_altname;
 #endif
     }
-#ifdef DT_UNKNOWN
+#if !EMULATE_IFTODT
     newrdp->d_type = dp->d_type;
 #else
     newrdp->d_type = 0;
@@ -2470,7 +2470,7 @@ glob_helper(
 		break;
 	    }
 	    name = buf + pathlen + (dirsep != 0);
-#ifdef DT_UNKNOWN
+#if !EMULATE_IFTODT
 	    if (dp->d_type != DT_UNKNOWN) {
 		/* Got it. We need no more lstat. */
 		new_pathtype = dp->d_type;


### PR DESCRIPTION
When using `IFTODT` defined in libc, `dirent.d_type` oriented pathtype
is compatible with `IFTODT(stat.st_mode)`. However they are not
compatible when emulating `IFTODT`, so `glob_helper` has to stat instead
of reusing dirent result by passing unknown pathtype to `glob_helper`.

This is a follow-up fix of 0c90ca4dd0abbd28d7bb34b9241d93995ab9cfb7