### PR TITLE
Query embedded string capacity without GC.

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -2374,12 +2374,6 @@ static inline void heap_add_freepage(rb_heap_t *heap, struct heap_page *page);
 static struct heap_page *heap_next_freepage(rb_objspace_t *objspace, rb_size_pool_t *size_pool, rb_heap_t *heap);
 static inline void ractor_set_cache(rb_ractor_t *cr, struct heap_page *page, size_t size_pool_idx);
 
-size_t
-rb_gc_obj_slot_size(VALUE obj)
-{
-    return GET_HEAP_PAGE(obj)->slot_size;
-}
-
 static inline size_t
 size_pool_slot_size(unsigned char pool_id)
 {

--- a/gc.h
+++ b/gc.h
@@ -136,8 +136,6 @@ void rb_objspace_each_objects_without_setup(
     int (*callback)(void *, void *, size_t, void *),
     void *data);
 
-size_t rb_gc_obj_slot_size(VALUE obj);
-
 RUBY_SYMBOL_EXPORT_END
 
 #endif /* RUBY_GC_H */

--- a/include/ruby/internal/core/rarray.h
+++ b/include/ruby/internal/core/rarray.h
@@ -223,21 +223,25 @@ struct RArray {
             const VALUE *ptr;
         } heap;
 
-        /**
-         * Embedded elements.  When an array is short enough, it uses this area
-         * to store its elements.  In this  case the length is encoded into the
-         * flags.
-         */
+        struct {
+            /**
+            * Embedded elements.  When an array is short enough, it uses this area
+            * to store its elements.  In this  case the length is encoded into the
+            * flags.
+            */
 #if USE_RVARGC
-        /* This is a length 1 array because:
-         *   1. GCC has a bug that does not optimize C flexible array members
-         *      (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=102452)
-         *   2. Zero length arrays are not supported by all compilers
-         */
-        const VALUE ary[1];
+            short len;
+            short capa;
+            /* This is a length 1 array because:
+            *   1. GCC has a bug that does not optimize C flexible array members
+            *      (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=102452)
+            *   2. Zero length arrays are not supported by all compilers
+            */
+            const VALUE ary[1];
 #else
-        const VALUE ary[RARRAY_EMBED_LEN_MAX];
+            const VALUE ary[RARRAY_EMBED_LEN_MAX];
 #endif
+        } embed;
     } as;
 };
 
@@ -388,7 +392,7 @@ rb_array_const_ptr_transient(VALUE a)
     RBIMPL_ASSERT_TYPE(a, RUBY_T_ARRAY);
 
     if (RB_FL_ANY_RAW(a, RARRAY_EMBED_FLAG)) {
-        return FIX_CONST_VALUE_PTR(RARRAY(a)->as.ary);
+        return FIX_CONST_VALUE_PTR(RARRAY(a)->as.embed.ary);
     }
     else {
         return FIX_CONST_VALUE_PTR(RARRAY(a)->as.heap.ptr);

--- a/include/ruby/internal/core/rstring.h
+++ b/include/ruby/internal/core/rstring.h
@@ -280,7 +280,8 @@ struct RString {
         /** Embedded contents. */
         struct {
 #if USE_RVARGC
-            long len;
+            short len;
+            short capa;
             /* This is a length 1 array because:
              *   1. GCC has a bug that does not optimize C flexible array members
              *      (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=102452)

--- a/string.c
+++ b/string.c
@@ -848,7 +848,7 @@ str_alloc(VALUE klass, size_t size)
 
 #if USE_RVARGC
 static inline void
-ensure_embed_capacity_for_growth(size_t *size, size_t *capa) {
+str_ensure_embed_capacity_for_growth(size_t *size, size_t *capa) {
     // We must allocate at least sizeof(struct RString) bytes.
     // Strings may grow.  Once exceeded capacity, it will become non-embedded,
     // and it will need RString::as::heap.
@@ -866,7 +866,7 @@ str_alloc_embed(VALUE klass, size_t capa)
 {
     size_t size = str_embed_size(capa);
 #if USE_RVARGC
-    ensure_embed_capacity_for_growth(&size, &capa);
+    str_ensure_embed_capacity_for_growth(&size, &capa);
 #else
     assert(size <= sizeof(struct RString));
 #endif
@@ -1716,7 +1716,7 @@ ec_str_alloc_embed(struct rb_execution_context_struct *ec, VALUE klass, size_t c
 {
     size_t size = str_embed_size(capa);
 #if USE_RVARGC
-    ensure_embed_capacity_for_growth(&size, &capa);
+    str_ensure_embed_capacity_for_growth(&size, &capa);
 #else
     assert(size <= sizeof(struct RString));
 #endif

--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -1124,7 +1124,7 @@ gen_expandarray(jitstate_t *jit, ctx_t *ctx, codeblock_t *cb)
 
     // Load the address of the embedded array into REG1.
     // (struct RArray *)(obj)->as.ary
-    lea(cb, REG1, member_opnd(REG0, struct RArray, as.ary));
+    lea(cb, REG1, member_opnd(REG0, struct RArray, as.embed.ary));
 
     // Conditionally load the address of the heap array into REG1.
     // (struct RArray *)(obj)->as.heap.ptr


### PR DESCRIPTION
After RVARGC is introduced, RString uses `rb_gc_obj_slot_size` to
compute the size and capacity of embedded strings.  This practice
requires the GC to be able to report the object size, which is possible
for the current free-list allocator.  However, it is not practical for
bump-pointer allocators which offer better performance for copying GC.
Depending on the GC to report object size will hinder the improvement of
GC.

We replace the `long len` field of `RString::as::embed` with a pair of
`short len` and `short capa` fields, and store the capacity of
embedded strings in `capa`.  This allows up to 32767 bytes of capacity.
increasing object size.  We also removed the `rb_gc_obj_slot_size`
function previously used to compute the capacity.