### PR TITLE
Remove unneeded set value code in `opt_f_block_arg` pattern

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -5598,9 +5598,6 @@ opt_f_block_arg	: ',' f_block_arg
 			$$ = $2;
 		    }
 		| none
-		    {
-			$$ = Qnull;
-		    }
 		;
 
 singleton	: var_ref


### PR DESCRIPTION
`opt_f_block_arg` use `none` rule pattern. in `parse.y`

```y
opt_f_block_arg	: ',' f_block_arg
		    {
			$$ = $2;
		    }
		| none
		    {
			$$ = Qnull;
		    }
```

But, `none` pattern already set `Qnull` value.

```y
none		: /* none */
		    {
			$$ = Qnull;
		    }
		;
```

I thought these set value code in `opt_f_block_arg` was unneed code.
