### PR TITLE
Raise ArgumentError when calling Enumberable#inject without block or arguments

### DIFF
--- a/enum.c
+++ b/enum.c
@@ -1010,8 +1010,16 @@ enum_inject(int argc, VALUE *argv, VALUE obj)
     VALUE init, op;
     rb_block_call_func *iter = inject_i;
     ID id;
+    int num_args;
 
-    switch (rb_scan_args(argc, argv, "02", &init, &op)) {
+    if (rb_block_given_p()) {
+        num_args = rb_scan_args(argc, argv, "02", &init, &op);
+    }
+    else {
+        num_args = rb_scan_args(argc, argv, "11", &init, &op);
+    }
+
+    switch (num_args) {
       case 0:
 	init = Qundef;
 	break;

--- a/test/ruby/test_enum.rb
+++ b/test/ruby/test_enum.rb
@@ -234,6 +234,8 @@ class TestEnumerable < Test::Unit::TestCase
     assert_equal(24, @obj.inject(2) {|z, x| z * x })
     assert_equal(24, assert_warning(/given block not used/) {@obj.inject(2, :*) {|z, x| z * x }})
     assert_equal(nil, @empty.inject() {9})
+
+    assert_raise(ArgumentError) {@obj.inject}
   end
 
   FIXNUM_MIN = RbConfig::LIMITS['FIXNUM_MIN']


### PR DESCRIPTION
Previously, this would work as expected if the enumerable contained
0 or 1 element, and would raise LocalJumpError otherwise. That
inconsistent behavior is likely to lead to bugs.

Fixes [Bug #18635]