### PR TITLE
Merge wait_readable and wait_writable into core IO

### DIFF
--- a/ext/io/wait/wait.c
+++ b/ext/io/wait/wait.c
@@ -393,9 +393,15 @@ Init_wait(void)
 
     rb_define_method(rb_cIO, "wait", io_wait, -1);
 
-    rb_define_method(rb_cIO, "wait_readable", io_wait_readable, -1);
-    rb_define_method(rb_cIO, "wait_writable", io_wait_writable, -1);
+    if (!RTEST(rb_funcall(rb_cIO, rb_intern("method_defined?"), 1, ID2SYM(rb_intern("wait_readable"))))) {
+        rb_define_method(rb_cIO, "wait_readable", io_wait_readable, -1);
+    }
+    if (!RTEST(rb_funcall(rb_cIO, rb_intern("method_defined?"), 1, ID2SYM(rb_intern("wait_writable"))))) {
+        rb_define_method(rb_cIO, "wait_writable", io_wait_writable, -1);
+    }
+
 #ifdef HAVE_RB_IO_WAIT
     rb_define_method(rb_cIO, "wait_priority", io_wait_priority, -1);
 #endif
 }
+


### PR DESCRIPTION
These are very simple and useful methods, and there's no benefit for them being in a gem.

Ruby issue: https://bugs.ruby-lang.org/issues/18655.

This is part of https://bugs.ruby-lang.org/issues/18566, the merge of these two methods should be uncontroversial, other methods can be discussed on a case by case basis.