### PR TITLE
Fix formatting of Comparable What's Here

### DIFF
--- a/compar.c
+++ b/compar.c
@@ -288,16 +288,16 @@ cmp_clamp(int argc, VALUE *argv, VALUE x)
  *
  *  \Module \Comparable provides these methods, all of which use method <tt><=></tt>:
  *
- *  - #<:: Returns whether +self+ is less than the given object.
- *  - #<=:: Returns whether +self+ is less than or equal to the given object.
- *  - #==:: Returns whether +self+ is equal to the given object.
- *  - #>:: Returns whether +self+ is greater than or equal to the given object.
- *  - #>=:: Returns whether +self+ is greater than the given object.
- *  - #between? Returns +true+ if +self+ is between two given objects.
- *  - #clamp:: For given objects +min+ and +max+, or range <tt>(min..max)</tt>, returns:
- *    - +min+ if <tt>(self <=> min) < 0</tt>.
- *    - +max+ if <tt>(self <=> max) > 0</tt>.
- *    - +self+ otherwise.
+ *  #< :: Returns whether +self+ is less than the given object.
+ *  #<= :: Returns whether +self+ is less than or equal to the given object.
+ *  #== :: Returns whether +self+ is equal to the given object.
+ *  #> :: Returns whether +self+ is greater than or equal to the given object.
+ *  #>= :: Returns whether +self+ is greater than the given object.
+ *  #between? :: Returns +true+ if +self+ is between two given objects.
+ *  #clamp :: For given objects +min+ and +max+, or range <tt>(min..max)</tt>, returns:
+ *            - +min+ if <tt>(self <=> min) < 0</tt>.
+ *            - +max+ if <tt>(self <=> max) > 0</tt>.
+ *            - +self+ otherwise.
  */
 
 void


### PR DESCRIPTION
From looking at other What's Here sections, this issue is not limited to Comparable.  All other What's Here sections should be fixed.  The general issue is that:

```
- foo:: bar
- baz:: quux
```

Is not good RDoc style.  It generates the equivalent of:

```html
<ul>
<li><dl><dt></dt><dd></dd></dl></li>
<li><dl><dt></dt><dd></dd></dl></li>
</ul>
```

Basically, you get a bulleted list with separate description list with a single entry inside each item in the bulleted list.

This changes the What's Here style to use:

```
foo :: bar
baz :: quux
```

This generates the equivalent of:

```html
<dl>
  <dt></dt>
  <dd></dd>
  <dt></dt>
  <dd></dd>
</dl>
```

So you get a single description list with separate entries.  This is better semantically and looks much better visually.

If you want to see the current visual problems with Comparable, see https://ruby-doc.org/core-3.1.1/Comparable.html#module-Comparable-label-What-27s+Here

I found this issue while looking into bug #18656.

@BurdetteLamar for all future documentation changes, please use `make html` in the repository, then review the appropriate files under `.ext/html` to confirm they do not have obvious visual problems.