### PR TITLE
Remove use of page-dir RDoc option in make html and .rdoc_options

### DIFF
--- a/.rdoc_options
+++ b/.rdoc_options
@@ -1,4 +1,3 @@
 ---
-page_dir: doc
 main_page: README.md
 title: Documentation for Ruby development version

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 Please see the [official issue tracker], [doc/contributing.rdoc] and wiki [HowToContribute].
 
 [official issue tracker]: https://bugs.ruby-lang.org
-[doc/contributing.rdoc]: contributing.rdoc
+[doc/contributing.rdoc]: doc/contributing.rdoc
 [HowToContribute]: https://bugs.ruby-lang.org/projects/ruby/wiki/HowToContribute

--- a/common.mk
+++ b/common.mk
@@ -70,7 +70,7 @@ RDOCOUT       = $(EXTOUT)/rdoc
 HTMLOUT       = $(EXTOUT)/html
 CAPIOUT       = doc/capi
 INSTALL_DOC_OPTS = --rdoc-output="$(RDOCOUT)" --html-output="$(HTMLOUT)"
-RDOC_GEN_OPTS = --page-dir "$(srcdir)/doc" --no-force-update \
+RDOC_GEN_OPTS = --no-force-update \
 	--title "Documentation for Ruby $(RUBY_API_VERSION)" \
 	--main README.md
 


### PR DESCRIPTION
This option isn't used in other Ruby documentation websites, including
https://docs.ruby-lang.org/ (the official one), and https://ruby-doc.org/
(the most popular one).  It's easier to change make html to not use
it than to try to get --page-dir added to all other places that
generate documentation.

Fix a link in CONTRIBUTING.md to fix a related bug.

Fixes [Bug #18628]