### PR TITLE
Reduce number of instructions when fetching constants

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -5106,21 +5106,18 @@ compile_const_prefix(rb_iseq_t *iseq, const NODE *const node,
     switch (nd_type(node)) {
       case NODE_CONST:
 	debugi("compile_const_prefix - colon", node->nd_vid);
-        ADD_INSN1(body, node, putobject, Qtrue);
-        ADD_INSN1(body, node, getconstant, ID2SYM(node->nd_vid));
+        ADD_INSN2(body, node, getconstant, ID2SYM(node->nd_vid), Qtrue);
 	break;
       case NODE_COLON3:
 	debugi("compile_const_prefix - colon3", node->nd_mid);
 	ADD_INSN(body, node, pop);
 	ADD_INSN1(body, node, putobject, rb_cObject);
-        ADD_INSN1(body, node, putobject, Qtrue);
-        ADD_INSN1(body, node, getconstant, ID2SYM(node->nd_mid));
+        ADD_INSN2(body, node, getconstant, ID2SYM(node->nd_mid), Qtrue);
 	break;
       case NODE_COLON2:
 	CHECK(compile_const_prefix(iseq, node->nd_head, pref, body));
 	debugi("compile_const_prefix - colon2", node->nd_mid);
-        ADD_INSN1(body, node, putobject, Qfalse);
-        ADD_INSN1(body, node, getconstant, ID2SYM(node->nd_mid));
+        ADD_INSN2(body, node, getconstant, ID2SYM(node->nd_mid), Qfalse);
 	break;
       default:
 	CHECK(COMPILE(pref, "const colon2 prefix", node));
@@ -8528,8 +8525,7 @@ compile_op_cdecl(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node
 	ADD_INSNL(ret, node, branchunless, lassign); /* cref */
     }
     ADD_INSN(ret, node, dup); /* cref cref */
-    ADD_INSN1(ret, node, putobject, Qtrue);
-    ADD_INSN1(ret, node, getconstant, ID2SYM(mid)); /* cref obj */
+    ADD_INSN2(ret, node, getconstant, ID2SYM(mid), Qtrue); /* cref obj */
 
     if (node->nd_aid == idOROP || node->nd_aid == idANDOP) {
 	lfin = NEW_LABEL(line);
@@ -8896,8 +8892,7 @@ compile_colon3(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, 
     }
 
     ADD_INSN1(ret, node, putobject, rb_cObject);
-    ADD_INSN1(ret, node, putobject, Qtrue);
-    ADD_INSN1(ret, node, getconstant, ID2SYM(node->nd_mid));
+    ADD_INSN2(ret, node, getconstant, ID2SYM(node->nd_mid), Qtrue);
 
     if (ISEQ_COMPILE_DATA(iseq)->option->inline_const_cache) {
 	ADD_INSN1(ret, node, opt_setinlinecache, INT2FIX(ic_index));
@@ -9407,15 +9402,13 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const no
 	    int ic_index = body->is_size++;
 
             ADD_INSN2(ret, node, opt_getinlinecache, lend, INT2FIX(ic_index));
-            ADD_INSN1(ret, node, putobject, Qtrue);
-            ADD_INSN1(ret, node, getconstant, ID2SYM(node->nd_vid));
+            ADD_INSN2(ret, node, getconstant, ID2SYM(node->nd_vid), Qtrue);
             ADD_INSN1(ret, node, opt_setinlinecache, INT2FIX(ic_index));
 	    ADD_LABEL(ret, lend);
 	}
 	else {
 	    ADD_INSN(ret, node, putnil);
-            ADD_INSN1(ret, node, putobject, Qtrue);
-            ADD_INSN1(ret, node, getconstant, ID2SYM(node->nd_vid));
+            ADD_INSN2(ret, node, getconstant, ID2SYM(node->nd_vid), Qtrue);
 	}
 
 	if (popped) {

--- a/insns.def
+++ b/insns.def
@@ -259,8 +259,8 @@ setclassvariable
  */
 DEFINE_INSN
 getconstant
-(ID id)
-(VALUE klass, VALUE allow_nil)
+(ID id, VALUE allow_nil)
+(VALUE klass)
 (VALUE val)
 /* getconstant can kick autoload */
 // attr bool leaf = false; /* has rb_autoload_load() */


### PR DESCRIPTION
Currently every time there is a getconstant instruction we push a boolean onto the stack to let it know if it can search the global scope. This boolean is always known at compile-time though, so there's no need for it to be pushed onto the stack. Instead we can pass it directly as an argument to the getconstant instruction, thereby reducing the number of instructions in total.

After this change, it appears to be quite a bit faster on the constant invalidation benchmark.

```
|                       |compare-ruby|built-ruby|
|:----------------------|-----------:|---------:|
|constant_invalidation  |       3.198|     5.337|
|                       |           -|     1.67x|
```