### PR TITLE
Document the need to require strscan library when using StringScanner

### DIFF
--- a/ext/strscan/strscan.c
+++ b/ext/strscan/strscan.c
@@ -1468,6 +1468,8 @@ strscan_fixed_anchor_p(VALUE self)
  * StringScanner provides for lexical scanning operations on a String.  Here is
  * an example of its usage:
  *
+ *   require 'strscan'
+ *
  *   s = StringScanner.new('This is an example string')
  *   s.eos?               # -> false
  *


### PR DESCRIPTION
Tripped me up when using it for the first time, and looks like I'm not the first to hit this https://www.ruby-forum.com/t/strange-stringscanner-behaviour/50892

Thanks!