### PR TITLE
ext/psych/extconf.rb: Fail when libyaml is unavailable

### DIFF
--- a/ext/psych/extconf.rb
+++ b/ext/psych/extconf.rb
@@ -10,6 +10,11 @@ dir_config 'libyaml'
 if enable_config("bundled-libyaml", false) || !pkg_config('yaml-0.1') && !(find_header('yaml.h') && find_library('yaml', 'yaml_get_version'))
   # Embed libyaml since we could not find it.
 
+  unless File.exist?("#{$srcdir}/yaml")
+    puts "failed to build psych because no libyaml is available"
+    exit
+  end
+
   $VPATH << "$(srcdir)/yaml"
   $INCFLAGS << " -I$(srcdir)/yaml"
 


### PR DESCRIPTION
WHen libyaml is not installed, make fails with the following cryptic
message:

```
gmake[2]: Entering directory '/home/chkbuild/chkbuild-crossruby/tmp/build/20220325T045825Z/ruby/ext/psych'
gmake[2]: *** No rule to make target 'yaml/yaml.h', needed by 'psych.o'.  Stop.
gmake[2]: Leaving directory '/home/chkbuild/chkbuild-crossruby/tmp/build/20220325T045825Z/ruby/ext/psych'
```

I think it should give up building psych with a clear message.