### PR TITLE
Ignore invalid escapes in regexp comments

### DIFF
--- a/re.c
+++ b/re.c
@@ -2786,14 +2786,12 @@ escape_asis:
             rb_str_buf_cat(buf, (char *)&c, 1);
             break;
           case '[':
-            if (!in_char_class) {
-                in_char_class = 1;
-            }
+            in_char_class++;
             rb_str_buf_cat(buf, (char *)&c, 1);
             break;
           case ']':
             if (in_char_class) {
-                in_char_class = 0;
+                in_char_class--;
             }
             rb_str_buf_cat(buf, (char *)&c, 1);
             break;

--- a/test/ruby/test_regexp.rb
+++ b/test/ruby/test_regexp.rb
@@ -132,6 +132,10 @@ class TestRegexp < Test::Unit::TestCase
       re = /[-(?# fca)]oobar/
       assert_match(re, 'foobar')
       assert_not_match(re, 'foobaz')
+
+      re = /f(?# ca\0\\M-ca)oobar/
+      assert_match(re, 'foobar')
+      assert_not_match(re, 'foobaz')
     RUBY
 
     assert_raise(SyntaxError) {eval "/\\users/x"}

--- a/test/ruby/test_regexp.rb
+++ b/test/ruby/test_regexp.rb
@@ -91,6 +91,48 @@ class TestRegexp < Test::Unit::TestCase
     assert_warn('', '[ruby-core:82328] [Bug #13798]') {re.to_s}
   end
 
+  def test_extended_comment_invalid_escape_bug_18294
+    assert_separately([], <<-RUBY)
+      re = / C:\\\\[a-z]{5} # e.g. C:\\users /x
+      assert_match(re, 'C:\\users')
+      assert_not_match(re, 'C:\\user')
+
+      re = /
+        foo  # \\M-ca
+        bar
+      /x
+      assert_match(re, 'foobar')
+      assert_not_match(re, 'foobaz')
+
+      re = /
+        f[#o]o  # \\M-ca
+        bar
+      /x
+      assert_match(re, 'foobar')
+      assert_not_match(re, 'foobaz')
+
+      re = /
+        f(?# \\M-ca)oo  # \\M-ca
+        bar
+      /x
+      assert_match(re, 'foobar')
+      assert_not_match(re, 'foobaz')
+
+      re = /f(?# \\M-ca)oobar/
+      assert_match(re, 'foobar')
+      assert_not_match(re, 'foobaz')
+
+      re = /[-(?# fca)]oobar/
+      assert_match(re, 'foobar')
+      assert_not_match(re, 'foobaz')
+    RUBY
+
+    assert_raise(SyntaxError) {eval "/\\users/x"}
+    assert_raise(SyntaxError) {eval "/[\\users]/x"}
+    assert_raise(SyntaxError) {eval "/(?<\\users)/x"}
+    assert_raise(SyntaxError) {eval "/# \\users/"}
+  end
+
   def test_union
     assert_equal :ok, begin
       Regexp.union(

--- a/test/ruby/test_regexp.rb
+++ b/test/ruby/test_regexp.rb
@@ -112,6 +112,13 @@ class TestRegexp < Test::Unit::TestCase
       assert_not_match(re, 'foobaz')
 
       re = /
+        f[[:alnum:]#]o  # \\M-ca
+        bar
+      /x
+      assert_match(re, 'foobar')
+      assert_not_match(re, 'foobaz')
+
+      re = /
         f(?# \\M-ca)oo  # \\M-ca
         bar
       /x


### PR DESCRIPTION
Invalid escapes are handled at multiple levels.  The first level
is in parse.y, so skip invalid unicode escape checks for regexps
in parse.y.

Make rb_reg_preprocess and unescape_nonascii accept the regexp
options.  In unescape_nonascii, if the regexp is an extended
regexp, when "#" is encountered, ignore all characters until the
end of line or end of regexp.

Unfortunately, in extended regexps, you can use "#" as a non-comment
character inside a character class, so also parse "[" and "]"
specially for extended regexps, and only skip comments if "#" is
not inside a character class.

This issue doesn't just affect extended regexps, it also affects
"(#?" comments inside all regexps.  So for those comments, scan
until trailing ")" and ignore content inside.

I'm not sure if there are other corner cases not handled.  A
better fix would be to redesign the regexp parser so that it
unescaped during parsing instead of before parsing, so you already
know the current parsing state.

Fixes [Bug #18294]