### PR TITLE
Add space before parenthetical for bad URI

### DIFF
--- a/lib/uri/rfc3986_parser.rb
+++ b/lib/uri/rfc3986_parser.rb
@@ -15,7 +15,7 @@ module URI
       begin
         uri = uri.to_str
       rescue NoMethodError
-        raise InvalidURIError, "bad URI(is not URI?): #{uri.inspect}"
+        raise InvalidURIError, "bad URI (is not URI?): #{uri.inspect}"
       end
       uri.ascii_only? or
         raise InvalidURIError, "URI must be ascii only #{uri.dump}"
@@ -64,7 +64,7 @@ module URI
           m["fragment".freeze]
         ]
       else
-        raise InvalidURIError, "bad URI(is not URI?): #{uri.inspect}"
+        raise InvalidURIError, "bad URI (is not URI?): #{uri.inspect}"
       end
     end
 


### PR DESCRIPTION
I'm running `dkhamsing/awesome_bot:1.20.0` and it generated things like:

> bad URI(is not URI?): "http://nginx.org/en/docs/http/ngx_http_map_module.html#map](http://nginx.org/en/docs/http/ngx_http_map_module.html"