### PR TITLE
Prevent printing crash report in a loop

### DIFF
--- a/vm_dump.c
+++ b/vm_dump.c
@@ -1021,6 +1021,17 @@ rb_vm_bugreport(const void *ctx)
         }
     }
 
+    // Thread unsafe best effort attempt to stop printing the bug report in an
+    // infinite loop. Can happen with corrupt Ruby stack.
+    {
+        static bool crashing = false;
+        if (crashing) {
+            fprintf(stderr, "Crashed while printing bug report\n");
+            return;
+        }
+        crashing = true;
+    }
+
 #ifdef __linux__
 # define PROC_MAPS_NAME "/proc/self/maps"
 #endif


### PR DESCRIPTION
In the event that we are crashing due to a corrupt Ruby stack, we might
re-enter rb_vm_bugreport() due to failed assertions in
rb_backtrace_print_as_bugreport() or SDR(). In these cases we were
printing the bug report ad infinitum with unbounded recusion.

I seem to run into this every once in a while and the amount of log it
prints out is pretty distracting. On CI environments it makes the log
output unnecessarily big. Let's fix this.