### PR TITLE
Decouple incremental marking step from page sizes

### DIFF
--- a/internal/gc.h
+++ b/internal/gc.h
@@ -79,6 +79,7 @@ typedef struct ractor_newobj_size_pool_cache {
 } rb_ractor_newobj_size_pool_cache_t;
 
 typedef struct ractor_newobj_cache {
+    size_t incremental_mark_step_allocated_slots;
     rb_ractor_newobj_size_pool_cache_t size_pool_caches[SIZE_POOL_COUNT];
 } rb_ractor_newobj_cache_t;
 


### PR DESCRIPTION
Currently, the number of incremental marking steps is calculated based on the number of pooled pages available. This means that if we make Ruby heap pages larger, it would run fewer incremental marking steps (which would mean each incremental marking step takes longer).

This commit changes incremental marking to run after every `INCREMENTAL_MARK_STEP_ALLOCATIONS` number of allocations. This means that the behaviour of incremental marking remains the same regardless of the Ruby heap page size.

I've benchmarked against discourse benchmarks and did not get a significant change in response times beyond the margin of error. This is expected as this new incremental marking algorithm behaves very similarly to the previous one.