### PR TITLE
[Bug #18667] Define RUBY_API_VERSION on Windows

### DIFF
--- a/win32/Makefile.sub
+++ b/win32/Makefile.sub
@@ -156,7 +156,7 @@ RUBY_VERSION_NAME = $(RUBY_BASE_NAME)-$(ruby_version)
 RUBY_PROGRAM_VERSION = $(MAJOR).$(MINOR).$(TEENY)
 
 !ifndef RUBY_SO_NAME
-RUBY_SO_NAME = $(RT)-$(RUBY_BASE_NAME)$(ruby_version:.=)
+RUBY_SO_NAME = $(RT)-$(RUBY_BASE_NAME)$(MAJOR)$(MINOR)0
 !if "$(ARCH)" != "i386"
 RUBY_SO_NAME = $(ARCH)-$(RUBY_SO_NAME)
 !endif


### PR DESCRIPTION
On other platforms, RUBY_SO_NAME is defined from RUBY_API_VERSION.
ruby_version contains the ABI version, which is not needed.
RUBY_API_VERSION is defined as MAJOR.MINOR.