### PR TITLE
Make rb_vm_insn_null_translator match rb_vm_insn_addr2insn2 semantics.

### DIFF
--- a/iseq.c
+++ b/iseq.c
@@ -154,7 +154,7 @@ rb_vm_insn_addr2insn2(const void *addr)
 static VALUE
 rb_vm_insn_null_translator(const void *addr)
 {
-    VALUE opcode = (VALUE) addr;
+    VALUE opcode = (VALUE)addr;
     VALUE trace_opcode_threshold = (VM_INSTRUCTION_SIZE / 2);
 
     if (opcode >= trace_opcode_threshold) {

--- a/iseq.c
+++ b/iseq.c
@@ -154,7 +154,13 @@ rb_vm_insn_addr2insn2(const void *addr)
 static VALUE
 rb_vm_insn_null_translator(const void *addr)
 {
-    return (VALUE)addr;
+    VALUE opcode = (VALUE) addr;
+    VALUE trace_opcode_threshold = (VM_INSTRUCTION_SIZE / 2);
+
+    if (opcode >= trace_opcode_threshold) {
+        return opcode - trace_opcode_threshold;
+    }
+    return opcode;
 }
 
 typedef VALUE iseq_value_itr_t(void *ctx, VALUE obj);


### PR DESCRIPTION
When you're iterating through instruction sequences and using the translator functions to get back the instruction structs, you're either using `rb_vm_insn_null_translator` or `rb_vm_insn_addr2insn2` depending on if directing threading is on or not. `rb_vm_insn_addr2insn2` does some normalization to always return to you the non-trace version of whatever instruction you're looking at. `rb_vm_insn_null_translator` does not do that normalization.

This means that when you're looping through the instructions if you're trying to do a `BIN` comparison against the type, it can change depending on the type of threading that you're using. This can be very confusing. So, this commit changes `rb_vm_insn_null_translator` to always return the non-trace version so that `BIN` comparisons will always work without having to worry about the threading.

cc @tenderlove @XrXr 