### PR TITLE
Re-enable gem extension build

### DIFF
--- a/template/configure-ext.mk.tmpl
+++ b/template/configure-ext.mk.tmpl
@@ -27,7 +27,7 @@ SCRIPT_ARGS = <%=script_args.gsub("#", "\\#")%>
 EXTMK_ARGS = $(SCRIPT_ARGS) --gnumake=$(gnumake) --extflags="$(EXTLDFLAGS)" \
 	   --make-flags="MINIRUBY='$(MINIRUBY)'"
 
-all: exts # gems
+all: exts gems
 exts:
 gems:
 

--- a/template/exts.mk.tmpl
+++ b/template/exts.mk.tmpl
@@ -19,13 +19,13 @@ opt = OptionParser.new do |o|
   o.on('--configure-exts=FILE') {|v| confexts = v}
   o.order!(ARGV)
 end
-confexts &&= File.read(confexts).scan(/^exts: (.*\.mk)/).flatten rescue nil
+confexts &&= File.read(confexts).scan(/^(exts|gems): (.*\.mk)/).collect {|i| i.last } rescue nil
 confexts ||= []
 macros["old_extensions"] = []
 
 contpat = /(?>(?>[^\\\n]|\\.)*\\\n)*(?>[^\\\n]|\\.)*/
 Dir.glob("{ext,.bundle/gems}/*/exts.mk") do |e|
-  gem = /\Agems(?=\/)/ =~ e
+  gem = /\A.bundle\/gems(?=\/)/ =~ e
   s = File.read(e)
   s.scan(/^(extensions|SUBMAKEOPTS|EXT[A-Z]+|MFLAGS|NOTE_[A-Z]+)[ \t]*=[ \t]*(#{contpat})$/o) do |n, v|
     v.gsub!(/\\\n[ \t]*/, ' ')

--- a/tool/rbinstall.rb
+++ b/tool/rbinstall.rb
@@ -1042,7 +1042,7 @@ install?(:ext, :comm, :gem, :'bundled-gems') do
     :wrappers => true,
     :format_executable => true,
   }
-  gem_ext_dir = "#$extout/gems/#{CONFIG['arch']}"
+  gem_ext_dir = "#$extout/.bundle/gems/#{CONFIG['arch']}"
   extensions_dir = with_destdir(Gem::StubSpecification.gemspec_stub("", gem_dir, gem_dir).extensions_dir)
 
   File.foreach("#{srcdir}/gems/bundled_gems") do |name|
@@ -1075,7 +1075,7 @@ install?(:ext, :comm, :gem, :'bundled-gems') do
       File.chmod($data_mode, File.join(install_dir, "specifications", "#{spec.full_name}.gemspec"))
     end
     unless spec.extensions.empty?
-      install_recursive(ext, spec.extension_dir)
+      install_recursive(ext, without_destdir(spec.extension_dir))
     end
     installed_gems[spec.full_name] = true
   end

--- a/tool/rbinstall.rb
+++ b/tool/rbinstall.rb
@@ -1064,9 +1064,6 @@ install?(:ext, :comm, :gem, :'bundled-gems') do
       next
     end
     spec.extension_dir = "#{extensions_dir}/#{spec.full_name}"
-    if File.directory?(ext = "#{gem_ext_dir}/#{spec.full_name}")
-      spec.extensions[0] ||= "-"
-    end
     package = RbInstall::DirPackage.new spec
     ins = RbInstall::UnpackedInstaller.new(package, options)
     puts "#{INDENT}#{spec.name} #{spec.version}"
@@ -1075,6 +1072,7 @@ install?(:ext, :comm, :gem, :'bundled-gems') do
       File.chmod($data_mode, File.join(install_dir, "specifications", "#{spec.full_name}.gemspec"))
     end
     unless spec.extensions.empty?
+      ext = "#{gem_ext_dir}/#{spec.full_name}"
       install_recursive(ext, without_destdir(spec.extension_dir))
     end
     installed_gems[spec.full_name] = true


### PR DESCRIPTION
This re-enables the gem extension build in a way similar to all other extension. This should be enough to address https://bugs.ruby-lang.org/issues/18373#note-25

However, to fully address the issue [18373](https://bugs.ruby-lang.org/issues/18373), the `UnpackedInstaller` should be improved to pick the prebuilt extensions and not rebuild the gem extension in such case. Because I guess, the [workaround](https://bugs.ruby-lang.org/issues/18373#note-8) is still needed to pass the extension build, although the result is not used.
