### PR TITLE
Remove dependency on libcapstone

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1268,15 +1268,6 @@ AC_CHECK_LIB(crypt, crypt)      # glibc (GNU/Linux, GNU/Hurd, GNU/kFreeBSD)
 AC_CHECK_LIB(dl, dlopen)	# Dynamic linking for SunOS/Solaris and SYSV
 AC_CHECK_LIB(socket, shutdown)  # SunOS/Solaris
 
-AS_IF([test -n "${PKG_CONFIG}" && ${PKG_CONFIG} --exists capstone], [
-   CAPSTONE_CFLAGS=`${PKG_CONFIG} --cflags capstone`
-   CAPSTONE_LIB_L=`${PKG_CONFIG} --libs-only-L capstone`
-   LDFLAGS="$LDFLAGS $CAPSTONE_LIB_L"
-   CFLAGS="$CFLAGS $CAPSTONE_CFLAGS"
-])
-
-AC_CHECK_LIB(capstone, cs_open) # Capstone disassembler for debugging YJIT
-
 dnl Checks for header files.
 AC_HEADER_DIRENT
 dnl AC_HEADER_STDC has been checked in AC_USE_SYSTEM_EXTENSIONS


### PR DESCRIPTION
We have received reports of build failures due to this configuration
check modifying linking flags. Since only YJIT devs use this library
we can remove it to make Ruby easier to build for users.

See: https://github.com/rbenv/ruby-build/discussions/1933