### PR TITLE
Make heap page sizes 64KiB by default

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -882,7 +882,12 @@ enum {
 #endif
 
 #ifdef HAVE_MMAP
-# if HAVE_CONST_PAGE_SIZE
+/* wasmtime does not have proper support for mmap.
+ * See https://github.com/bytecodealliance/wasmtime/blob/main/docs/WASI-rationale.md#why-no-mmap-and-friends
+ */
+# if defined(__wasm__)
+static const bool HEAP_PAGE_ALLOC_USE_MMAP = false;
+# elif HAVE_CONST_PAGE_SIZE
 /* If we have the HEAP_PAGE and it is a constant, then we can directly use it. */
 static const bool HEAP_PAGE_ALLOC_USE_MMAP = (PAGE_SIZE <= HEAP_PAGE_SIZE);
 # elif defined(PAGE_MAX_SIZE) && (PAGE_MAX_SIZE <= HEAP_PAGE_SIZE)
@@ -3632,7 +3637,7 @@ Init_heap(void)
 {
     rb_objspace_t *objspace = &rb_objspace;
 
-#if defined(HAVE_MMAP) && !HAVE_CONST_PAGE_SIZE && !defined(PAGE_MAX_SIZE)
+#if defined(HAVE_MMAP) && !defined(__wasm__) && !HAVE_CONST_PAGE_SIZE && !defined(PAGE_MAX_SIZE)
     /* Need to determine if we can use mmap at runtime. */
 # ifdef PAGE_SIZE
     /* If the PAGE_SIZE macro can be used. */

--- a/gc.c
+++ b/gc.c
@@ -858,14 +858,9 @@ typedef struct rb_objspace {
 } rb_objspace_t;
 
 
-#if defined(__APPLE__) && defined(__LP64__) && !defined(HEAP_PAGE_ALIGN_LOG)
-/* for slow mmap: 64KiB */
-#define HEAP_PAGE_ALIGN_LOG 16
-#endif
-
 #ifndef HEAP_PAGE_ALIGN_LOG
-/* default tiny heap size: 16KB */
-#define HEAP_PAGE_ALIGN_LOG 14
+/* default tiny heap size: 64KiB */
+#define HEAP_PAGE_ALIGN_LOG 16
 #endif
 
 #define BASE_SLOT_SIZE sizeof(RVALUE)

--- a/misc/lldb_cruby.py
+++ b/misc/lldb_cruby.py
@@ -12,10 +12,7 @@ import os
 import shlex
 import platform
 
-if platform.system() == 'Darwin':
-    HEAP_PAGE_ALIGN_LOG = 16
-else:
-    HEAP_PAGE_ALIGN_LOG = 14
+HEAP_PAGE_ALIGN_LOG = 16
 
 HEAP_PAGE_ALIGN_MASK = (~(~0 << HEAP_PAGE_ALIGN_LOG))
 HEAP_PAGE_ALIGN = (1 << HEAP_PAGE_ALIGN_LOG)


### PR DESCRIPTION
Commit https://github.com/ruby/ruby/commit/dde164e968e382d50b07ad4559468885cbff33ef decoupled incremental marking from page sizes. This commit changes Ruby heap page sizes to 64KiB. Doing so will have several benefits:

1. We can use compaction on systems with 64KiB system page sizes (e.g. PowerPC).
2. Larger page sizes will allow Variable Width Allocation to increase slot sizes and embed larger objects.
3. Since commit https://github.com/ruby/ruby/commit/002fa2859962f22de8afdbeece04966ea57b7da9, macOS has 64 KiB pages. Making page sizes 64 KiB will bring these systems to parity.

I have attached some bechmark results below.

### Discourse

On Discourse, we saw much better p99 performance (e.g. for "categories" it went from 214ms on master to 134ms on branch, for "home" it went from 265ms to 251ms). We don’t see much change in p60, p75, and p90 performance. We also see a slight decrease in memory usage by 1.04x.

    Branch RSS: 354.9MB
    Master RSS: 368.2MB

### railsbench

On rails bench, we don’t see a big change in RPS or p99 performance. We don’t see a big difference in memory usage.

    Branch RPS: 826.27
    Master RPS: 824.85

    Branch p99: 1.67
    Master p99: 1.72

    Branch RSS: 88.72MB
    Master RSS: 88.48MB

### liquid

We don’t see a significant change in liquid performance.

    Branch parse & render: 28.653 I/s
    Master parse & render: 28.563 i/s