### PR TITLE
Using `IS_INSN_ID` macro

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -7866,7 +7866,7 @@ delegate_call_p(const rb_iseq_t *iseq, unsigned int argc, const LINK_ANCHOR *arg
 
             for (unsigned int i=start; i-start<argc; i++) {
                 if (IS_INSN(elem) &&
-                    INSN_OF(elem) == BIN(getlocal)) {
+                    IS_INSN_ID(elem, getlocal)) {
                     int local_index = FIX2INT(OPERAND_AT(elem, 0));
                     int local_level = FIX2INT(OPERAND_AT(elem, 1));
 


### PR DESCRIPTION
In `delegate_call_p`, used`INSN_OF` and `BIN` macro to check YARV basic instruction name.

```c
INSN_OF(elem) == BIN(getlocal)
```

But, already define `IS_INSN_ID` to check YARV basic instruction name in `compile.c`.

```c
#define IS_INSN_ID(iobj, insn) (INSN_OF(iobj) == BIN(insn))
```

I thoguht that better to use `IS_INSN_ID` that was more simpily.