### PR TITLE
Stop double sweeping the heap during compaction

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -5936,30 +5936,30 @@ gc_sweep(rb_objspace_t *objspace)
     gc_sweep_start(objspace);
     if (objspace->flags.during_compacting) {
         gc_sweep_compact(objspace);
-    }
-
-    if (immediate_sweep) {
+    } else {
+        if (immediate_sweep) {
 #if !GC_ENABLE_LAZY_SWEEP
-	gc_prof_sweep_timer_start(objspace);
+            gc_prof_sweep_timer_start(objspace);
 #endif
-	gc_sweep_rest(objspace);
+            gc_sweep_rest(objspace);
 #if !GC_ENABLE_LAZY_SWEEP
-	gc_prof_sweep_timer_stop(objspace);
+            gc_prof_sweep_timer_stop(objspace);
 #endif
-    }
-    else {
-
-        /* Sweep every size pool. */
-        for (int i = 0; i < SIZE_POOL_COUNT; i++) {
-            rb_size_pool_t *size_pool = &size_pools[i];
-            gc_sweep_step(objspace, size_pool, SIZE_POOL_EDEN_HEAP(size_pool));
         }
-    }
+        else {
+
+            /* Sweep every size pool. */
+            for (int i = 0; i < SIZE_POOL_COUNT; i++) {
+                rb_size_pool_t *size_pool = &size_pools[i];
+                gc_sweep_step(objspace, size_pool, SIZE_POOL_EDEN_HEAP(size_pool));
+            }
+        }
 
 #if !USE_RVARGC
-    rb_size_pool_t *size_pool = &size_pools[0];
-    gc_heap_prepare_minimum_pages(objspace, size_pool, SIZE_POOL_EDEN_HEAP(size_pool));
+        rb_size_pool_t *size_pool = &size_pools[0];
+        gc_heap_prepare_minimum_pages(objspace, size_pool, SIZE_POOL_EDEN_HEAP(size_pool));
 #endif
+    }
 }
 
 /* Marking - Marking stack */


### PR DESCRIPTION
In #5637 I reversed the order of steps in the compaction algorithm. This meant changing the way pages are swept during compaction, however because of how `gc_sweep_step` and `gc_sweep_page` interact we still required a seperate sweep step after compaction had finished, to finalise the accounting and the free_pages/pool_pages lists.

This PR refactors `gc_sweep_step` and `gc_sweep_page` to make them more independent - `gc_sweep_page` now handles adding the page to the free/pool pages and incrementing the sweeping_page cursor - this is so that we can use `gc_sweep_page` directly during compaction to fully sweep a page and maintain correct accounting.

This has allowed us to change the entry point for compaction to a branch - either sweep and compact, or just sweep - removing the need for a seperate sweep step post compaction.