### PR TITLE
Bring back RubyVM.stat(:global_constant_state)

### DIFF
--- a/vm.c
+++ b/vm.c
@@ -529,7 +529,7 @@ vm_stat_constant_cache_i(ID id, VALUE table, void *constant_cache)
 static VALUE
 vm_stat(int argc, VALUE *argv, VALUE self)
 {
-    static VALUE sym_constant_cache, sym_class_serial, sym_global_cvar_state;
+    static VALUE sym_global_constant_state, sym_constant_cache, sym_class_serial, sym_global_cvar_state;
     VALUE arg = Qnil;
     VALUE hash = Qnil, key = Qnil;
 
@@ -547,6 +547,7 @@ vm_stat(int argc, VALUE *argv, VALUE self)
     }
 
 #define S(s) sym_##s = ID2SYM(rb_intern_const(#s))
+    S(global_constant_state);
 	S(constant_cache);
 	S(class_serial);
 	S(global_cvar_state);
@@ -558,6 +559,7 @@ vm_stat(int argc, VALUE *argv, VALUE self)
     else if (hash != Qnil) \
 	rb_hash_aset(hash, sym_##name, SERIALT2NUM(attr));
 
+    SET(global_constant_state, ruby_vm_global_constant_state);
     SET(class_serial, ruby_vm_class_serial);
     SET(global_cvar_state, ruby_vm_global_cvar_state);
 #undef SET

--- a/vm_insnhelper.h
+++ b/vm_insnhelper.h
@@ -14,6 +14,7 @@
 MJIT_SYMBOL_EXPORT_BEGIN
 
 RUBY_EXTERN VALUE ruby_vm_const_missing_count;
+RUBY_EXTERN rb_serial_t ruby_vm_global_constant_state;
 RUBY_EXTERN rb_serial_t ruby_vm_class_serial;
 RUBY_EXTERN rb_serial_t ruby_vm_global_cvar_state;
 

--- a/vm_method.c
+++ b/vm_method.c
@@ -147,6 +147,7 @@ rb_clear_constant_cache_for_id(ID id)
     }
 
     rb_yjit_constant_state_changed();
+    ruby_vm_global_constant_state++;
 }
 
 static void


### PR DESCRIPTION
This was removed as part of [Feature #18589](https://bugs.ruby-lang.org/issues/18589). But some applications were relying on this behavior. So bringing this back to make it better for backward compatibility going forward.

cc @casperisfine 