### PR TITLE
Document MakeMakefile#append_cflags

### DIFF
--- a/lib/mkmf.rb
+++ b/lib/mkmf.rb
@@ -680,16 +680,6 @@ MSG
     try_compile(MAIN_DOES_NOTHING, flags, {:werror => true}.update(opts))
   end
 
-  def append_cflags(flags, *opts)
-    Array(flags).each do |flag|
-      if checking_for("whether #{flag} is accepted as CFLAGS") {
-           try_cflags(flag, *opts)
-         }
-        $CFLAGS << " " << flag
-      end
-    end
-  end
-
   def with_ldflags(flags)
     ldflags = $LDFLAGS
     $LDFLAGS = flags.dup
@@ -1023,6 +1013,21 @@ SRC
   end
 
   # :startdoc:
+
+  # Check whether each given C compiler flag is acceptable and append it
+  # to <tt>$CFLAGS</tt> if so.
+  #
+  # [+flags+] a C compiler flag as a +String+ or an +Array+ of them
+  #
+  def append_cflags(flags, *opts)
+    Array(flags).each do |flag|
+      if checking_for("whether #{flag} is accepted as CFLAGS") {
+           try_cflags(flag, *opts)
+         }
+        $CFLAGS << " " << flag
+      end
+    end
+  end
 
   # Returns whether or not +macro+ is defined either in the common header
   # files or within any +headers+ you provide.


### PR DESCRIPTION
This method is at least 7 years old and is widely used in the wild.
Since we need to support it, let's document it to make it discoverable.
Add docs and move it out of the `# :stopdoc:` zone.

<img width="708" alt="Screen Shot 2022-04-04 at 15 33 26" src="https://user-images.githubusercontent.com/6457510/161618442-ce700ee3-2250-45bc-839d-ec83a54bc506.png">

There are other similar methods like `append_cppflags` we might want to document too. Instead of moving the method we could also do some `:{start,stop}doc:` juggling.