### PR TITLE
Add URI.escape and URI.unescape to NEWS-3.0.0

### DIFF
--- a/doc/NEWS/NEWS-3.0.0.md
+++ b/doc/NEWS/NEWS-3.0.0.md
@@ -512,6 +512,18 @@ Outstanding ones only.
 
     * This version is Ractor compatible.
 
+* URI
+
+    * URI.escape and URI.unescape have been removed.
+      Instead, use the following methods depending on your specific use case.
+
+        * CGI.escape
+        * URI.encode_www_form
+        * URI.encode_www_form_component
+        * CGI.unescape
+        * URI.decode_www_form
+        * URI.decode_www_form_component
+
 ## Compatibility issues
 
 Excluding feature bug fixes.


### PR DESCRIPTION
Add `URI.escape` and `URI.unescape` to NEWS-3.0.0.md.

https://github.com/ruby/ruby/commit/abbd3241522495e8d8634c0c01a42453f76ce6b8
