### PR TITLE
RubyVM.stat constant cache metrics

### DIFF
--- a/insns.def
+++ b/insns.def
@@ -1044,6 +1044,7 @@ opt_getinlinecache
         JUMP(dst);
     }
     else {
+        ruby_vm_constant_cache_misses++;
         val = Qnil;
     }
 }

--- a/vm_insnhelper.h
+++ b/vm_insnhelper.h
@@ -14,7 +14,8 @@
 MJIT_SYMBOL_EXPORT_BEGIN
 
 RUBY_EXTERN VALUE ruby_vm_const_missing_count;
-RUBY_EXTERN rb_serial_t ruby_vm_global_constant_state;
+RUBY_EXTERN rb_serial_t ruby_vm_constant_cache_invalidations;
+RUBY_EXTERN rb_serial_t ruby_vm_constant_cache_misses;
 RUBY_EXTERN rb_serial_t ruby_vm_class_serial;
 RUBY_EXTERN rb_serial_t ruby_vm_global_cvar_state;
 

--- a/vm_method.c
+++ b/vm_method.c
@@ -144,10 +144,10 @@ rb_clear_constant_cache_for_id(ID id)
 
     if (rb_id_table_lookup(vm->constant_cache, id, (VALUE *) &ics)) {
         st_foreach(ics, rb_clear_constant_cache_for_id_i, (st_data_t) NULL);
+        ruby_vm_constant_cache_invalidations += ics->num_entries;
     }
 
     rb_yjit_constant_state_changed();
-    ruby_vm_global_constant_state++;
 }
 
 static void


### PR DESCRIPTION
Before the new constant cache behavior, caches were invalidated by a
single global variable. You could inspect the value of this variable
with `RubyVM.stat(:global_constant_state)`. This was mostly useful to
verify the behavior of the VM or to test constant loading like in Rails.

With the new constant cache behavior, we introduced
`RubyVM.stat(:constant_cache)` which returned a hash with symbol keys and
integer values that represented the number of live constant caches
associated with the given symbol. Additionally, we removed the old
`RubyVM.stat(:global_constant_state)`.

This was proven to be not very useful, so it doesn't help you diagnose
constant loading issues. So, instead we added the global constant state
back into the `RubyVM` output. However, that number can be misleading as
now when you invalidate something like `Foo::Bar::Baz` you're actually
invalidating 3 different lists of inline caches.

This commit attempts to get the best of both worlds. We remove
`RubyVM.stat(:global_constant_state)` like we did originally, as it
doesn't have the same semantic meaning and it could be confusing going
forward. Instead we add `RubyVM.stat(:constant_cache_invalidations)` and
`RubyVM.stat(:constant_cache_misses)`. These two metrics should provide
enough information to diagnose any constant loading issues, as well as
provide a replacement for the old global constant state.

cc @byroot @XrXr @tenderlove 