### PR TITLE
Fix strict aliasing issue

### DIFF
--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -4937,12 +4937,16 @@ vm_ic_compile_i(VALUE *code, VALUE insn, size_t index, void *ic)
 
     if (insn == BIN(getconstant)) {
         ID id = code[index + 1];
-        rb_vm_t *vm = GET_VM();
-
+        struct rb_id_table *const_cache = GET_VM()->constant_cache;
+        VALUE lookup_result;
         st_table *ics;
-        if (!rb_id_table_lookup(vm->constant_cache, id, (VALUE *) &ics)) {
+
+        if (rb_id_table_lookup(const_cache, id, &lookup_result)) {
+            ics = (st_table *)lookup_result;
+        }
+        else {
             ics = st_init_numtable();
-            rb_id_table_insert(vm->constant_cache, id, (VALUE) ics);
+            rb_id_table_insert(const_cache, id, (VALUE)ics);
         }
 
         st_insert(ics, (st_data_t) ic, (st_data_t) Qtrue);


### PR DESCRIPTION
`rb_id_table_lookup()` writes to a `VALUE`, which is definitely a distinct
type from `st_table *`. With LTO, the compiler is allowed by N1256
§6.5p7 to remove the output parameter write via type-based alias
analysis.

See also: a0a8f2abf53