### PR TITLE
sync `vm->constant_cache`

### DIFF
--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -4963,7 +4963,12 @@ static void
 vm_ic_compile(rb_control_frame_t *cfp, IC ic)
 {
     const rb_iseq_t *iseq = cfp->iseq;
-    rb_iseq_each(iseq, cfp->pc - ISEQ_BODY(iseq)->iseq_encoded, vm_ic_compile_i, (void *) ic);
+
+    RB_VM_LOCK_ENTER();
+    {
+        rb_iseq_each(iseq, cfp->pc - ISEQ_BODY(iseq)->iseq_encoded, vm_ic_compile_i, (void *) ic);
+    }
+    RB_VM_LOCK_LEAVE();
 }
 
 // For MJIT inlining


### PR DESCRIPTION
On multi-ractors, `vm->constant_cache` (and so on) can be accessed
in parallel so we need to synchronize the accesses to them.

http://rubyci.s3.amazonaws.com/centos7/ruby-master/log/20220407T213003Z.log.html.gz#btest