### PR TITLE
Fix fake.rb RUBY_DESCRIPTION faking for JITs

### DIFF
--- a/template/fake.rb.in
+++ b/template/fake.rb.in
@@ -18,6 +18,7 @@ if inc = arg['i']
     version[n] = src.value(v)
   end
   arg['RUBY_DESCRIPTION_WITH_MJIT'] = src.value('description_with_mjit')
+  arg['RUBY_DESCRIPTION_WITH_YJIT'] = src.value('description_with_yjit')
 end
 %>baseruby="<%=arg['BASERUBY']%>"
 _\
@@ -34,9 +35,14 @@ class Object
   CROSS_COMPILING = RUBY_PLATFORM
   constants.grep(/^RUBY_/) {|n| remove_const n}
 % arg['versions'].each {|n, v|
-  <%=n%> = <%if n=='RUBY_DESCRIPTION' %>RubyVM.const_defined?(:JIT) && RubyVM::MJIT.enabled? ?
-    <%=arg['RUBY_DESCRIPTION_WITH_JIT'].inspect%> :
-    <%end%><%=v.inspect%>
+  <%=n%> = <%if n=='RUBY_DESCRIPTION' %>case
+    when RubyVM.const_defined?(:MJIT) && RubyVM::MJIT.enabled?
+      <%=arg['RUBY_DESCRIPTION_WITH_MJIT'].inspect%>
+    when RubyVM.const_defined?(:YJIT) && RubyVM::YJIT.enabled?
+      <%=arg['RUBY_DESCRIPTION_WITH_YJIT'].inspect%>
+    else
+      <%=v.inspect%>
+    end<%else%><%=v.inspect%><%end%>
 % }
 end
 builddir = File.dirname(File.expand_path(__FILE__))


### PR DESCRIPTION
Previously, `make test-spec` was not printing the description with +YJIT
even when YJIT was indeed enabled. It was confusing on CI. `fake.rb` was
changing the RUBY_DESCRIPTION constant incorrectly.

I suppose for `make test-spec` mostly needs the mkmf faking and not the
faking for RUBY_.* constants, so maybe there is opportunity to simplify.