### PR TITLE
Use mutex for auto-loading.

### DIFF
--- a/test/fiber/autoload.rb
+++ b/test/fiber/autoload.rb
@@ -1,0 +1,3 @@
+sleep 0.01
+module TestFiberSchedulerAutoload
+end

--- a/test/fiber/test_scheduler.rb
+++ b/test/fiber/test_scheduler.rb
@@ -104,4 +104,23 @@ class TestFiberScheduler < Test::Unit::TestCase
 
     thread.join
   end
+
+  def test_autoload
+    Object.autoload(:TestFiberSchedulerAutoload, File.expand_path("autoload.rb", __dir__))
+
+    thread = Thread.new do
+      scheduler = Scheduler.new
+      Fiber.set_scheduler scheduler
+
+      10.times do
+        Fiber.schedule do
+          Object.const_get(:TestFiberSchedulerAutoload)
+        end
+      end
+    end
+
+    thread.join
+  ensure
+    Object.send(:remove_const, :TestFiberSchedulerAutoload)
+  end
 end


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/18663

`Object#autoload` implements a custom per-thread "mutex" for blocking threads waiting on autoloading a feature. This causes problems when used with the fiber scheduler. We swap the implementation to use a Ruby mutex which is fiber aware.