### PR TITLE
[CI] Actions - Windows mswin - use pre-built vcpkg, update to OpenSSL 3

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -44,23 +44,16 @@ jobs:
         shell: msys2 {0}
         run: echo PATCH=$(cygpath -wa $(command -v patch)) >> $GITHUB_ENV
         if: ${{ steps.setup-msys2.outcome == 'success' }}
-      - uses: actions/cache@v3
-        with:
-          path: C:\vcpkg\downloads
-          key: ${{ runner.os }}-vcpkg-download-${{ env.OS_VER }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-vcpkg-download-${{ env.OS_VER }}-
-            ${{ runner.os }}-vcpkg-download-
-      - uses: actions/cache@v3
-        with:
-          path: C:\vcpkg\installed
-          key: ${{ runner.os }}-vcpkg-installed-${{ matrix.os }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-vcpkg-installed-${{ matrix.os }}-
-            ${{ runner.os }}-vcpkg-installed-
-      - name: Install libraries with vcpkg
+      - name: Install pre-built vcpkg libraries
         run: |
-          vcpkg --triplet x64-windows install libffi libyaml openssl readline zlib
+          cd $env:VCPKG_INSTALLATION_ROOT
+          $uri = "https://github.com/MSP-Greg/setup-msys2-gcc/releases/download/msys2-gcc-pkgs/mswin.7z"
+          curl -L $uri -o $env:RUNNER_TEMP/mswin_temp.7z
+          &"C:\Program Files\7-Zip\7z" x $env:RUNNER_TEMP/mswin_temp.7z -aoa
+          echo "`n———————————— ./vcpkg list ————————————"
+          ./vcpkg list
+        shell: pwsh
+        timeout-minutes: 5
       - uses: actions/cache@v3
         with:
           path: C:\Users\runneradmin\AppData\Local\Temp\chocolatey

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install pre-built vcpkg libraries
         run: |
           cd $env:VCPKG_INSTALLATION_ROOT
-          $uri = "https://github.com/MSP-Greg/setup-msys2-gcc/releases/download/msys2-gcc-pkgs/mswin.7z"
+          $uri = "https://github.com/ruby/setup-msys2-gcc/releases/download/msys2-gcc-pkgs/mswin.7z"
           curl -L $uri -o $env:RUNNER_TEMP/mswin_temp.7z
           &"C:\Program Files\7-Zip\7z" x $env:RUNNER_TEMP/mswin_temp.7z -aoa
           echo "`n———————————— ./vcpkg list ————————————"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -111,7 +111,6 @@ jobs:
           ../src/win32/configure.bat --disable-install-doc
           --with-opt-dir=C:/vcpkg/installed/x64-windows
       - run: nmake incs
-      - run: nmake extract-extlibs
       - run: nmake
         env:
           YACC: win_bison

--- a/ext/openssl/extconf.rb
+++ b/ext/openssl/extconf.rb
@@ -184,7 +184,7 @@ have_func("EVP_PKEY_dup")
 
 Logging::message "=== Checking done. ===\n"
 
-if openssl_3
+if openssl_3 && $warnflags
   if $warnflags.sub!(/-W\K(?=deprecated-declarations)/, 'no-')
     $warnflags << " -Wno-incompatible-pointer-types-discards-qualifiers"
   end


### PR DESCRIPTION
Adds using a vcpkg 7z archive which contains all the packages needed for Ruby (libffi, libyaml, openssl, readline, & zlib).

See https://bugs.ruby-lang.org/issues/18689

~~Note that all unchanged workflows were disabled...~~

See the first two commits (https://github.com/ruby/ruby/pull/5792/commits/839626a8218a and https://github.com/ruby/ruby/pull/5792/commits/a80d908eb6a8)~~, the last commit is just for the draft PR~~.