### PR TITLE
fix to use `node.gvl` instead of `node.ubf`

### DIFF
--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -331,7 +331,7 @@ gvl_release_common(rb_global_vm_lock_t *gvl)
 {
     native_thread_data_t *next;
     gvl->owner = 0;
-    next = ccan_list_top(&gvl->waitq, native_thread_data_t, node.ubf);
+    next = ccan_list_top(&gvl->waitq, native_thread_data_t, node.gvl);
     if (next) rb_native_cond_signal(&next->cond.gvlq);
 
     return next;


### PR DESCRIPTION
The last parameter of `ccan_list_top()` is to acquire the pointer
of the top of element, so `node.ubf` is no problem. But this context
it accesses gvl list, so `node.gvl` is better.