### PR TITLE
Capture lambda block-local variables in ripper

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -3830,7 +3830,7 @@ f_larglist	: '(' f_args opt_bv_decl ')'
 			$$ = $2;
 			p->max_numparam = ORDINAL_PARAM;
 		    /*% %*/
-		    /*% ripper: paren!($2) %*/
+		    /*% ripper: paren!(lambda_var!($2, escape_Qundef($3))) %*/
 		    }
 		| f_args
 		    {
@@ -3839,6 +3839,7 @@ f_larglist	: '(' f_args opt_bv_decl ')'
 			if (!args_info_empty_p($1->nd_ainfo))
 			    p->max_numparam = ORDINAL_PARAM;
 		    /*% %*/
+            /*% ripper: lambda_var!($1, Qnil) %*/
 			$$ = $1;
 		    }
 		;

--- a/parse.y
+++ b/parse.y
@@ -3839,7 +3839,7 @@ f_larglist	: '(' f_args opt_bv_decl ')'
 			if (!args_info_empty_p($1->nd_ainfo))
 			    p->max_numparam = ORDINAL_PARAM;
 		    /*% %*/
-            /*% ripper: lambda_var!($1, Qnil) %*/
+		    /*% ripper[$1]: lambda_var!($1, Qnil) %*/
 			$$ = $1;
 		    }
 		;

--- a/test/ripper/test_parser_events.rb
+++ b/test/ripper/test_parser_events.rb
@@ -864,6 +864,16 @@ class TestRipper::ParserEvents < Test::Unit::TestCase
     assert_equal false, recv_locals
 
     recv_params, recv_locals = nil, nil
+    parse('-> foo {}', :on_lambda_var) do |_, params, locals|
+      recv_params, recv_locals = params.list, locals
+    end
+
+    # parameters without block-local variables should return the list of
+    # parameters and false for locals
+    assert_equal ['foo'], recv_params
+    assert_equal false, recv_locals
+
+    recv_params, recv_locals = nil, nil
     parse('-> (foo; bar) {}', :on_lambda_var) do |_, params, locals|
       recv_params, recv_locals = params.list, locals
     end


### PR DESCRIPTION
You can declare block-local variables in lambda literals like this:

```
-> (; local) {}
```

but there's no way to access that information in ripper. This commit
adds a new lambda_var ripper event (much like the block_var event) that
captures both the params and the locals.