### PR TITLE
Fix class ancestry checks for duped classes

### DIFF
--- a/class.c
+++ b/class.c
@@ -567,6 +567,8 @@ rb_mod_init_copy(VALUE clone, VALUE orig)
         else {
             rb_bug("no origin for class that has origin");
         }
+
+        rb_class_update_superclasses(clone);
     }
 
     return clone;

--- a/test/ruby/test_module.rb
+++ b/test/ruby/test_module.rb
@@ -572,6 +572,26 @@ class TestModule < Test::Unit::TestCase
     assert_equal(2, a2.b)
   end
 
+  def test_ancestry_of_duped_classes
+    m = Module.new
+    sc = Class.new
+    a = Class.new(sc) do
+      def b; 2 end
+      prepend m
+    end
+
+    a2 = a.dup.new
+
+    assert_kind_of Object, a2
+    assert_kind_of sc, a2
+    refute_kind_of a, a2
+    assert_kind_of m, a2
+
+    assert_kind_of Class, a2.class
+    assert_kind_of sc.singleton_class, a2.class
+    assert_same sc, a2.class.superclass
+  end
+
   def test_gc_prepend_chain
     assert_separately([], <<-EOS)
       10000.times { |i|


### PR DESCRIPTION
Previously in some cases when classes were duped (specifically those with a prepended module), they would not correctly have their "superclasses" array or depth filled in.

This could cause ancestry checks (like `is_a?` and Module comparisons) to return incorrect results.

This happened because `rb_mod_init_copy` builds origin classes in an order that doesn't have the `super` linked list fully connected until it's finished. This commit fixes the previous issue by calling `rb_class_update_superclasses` before returning the cloned class. This is similar to what's already done in `make_metaclass` (which similarly in some cases constructs metaclasses top-down).

I found this through debugging the crash seen on CI from https://github.com/ruby/ruby/pull/5662 (since reverted). That change exposed this issue because unlike ancestry checks there is no comparison on depth to access the superclass, so it resulted in a crash attempting to access `NULL[-1]` 😅. This change fixes that issue and I will re-attempt that PR soon.