### PR TITLE
Undefine RUBY_DLN_CHECK_ABI on cygwin

### DIFF
--- a/include/ruby/internal/abi.h
+++ b/include/ruby/internal/abi.h
@@ -26,7 +26,7 @@
 
 /* Windows does not support weak symbols so ruby_abi_version will not exist
  * in the shared library. */
-#if defined(HAVE_FUNC_WEAK) && !defined(_WIN32) && !defined(__MINGW32__)
+#if defined(HAVE_FUNC_WEAK) && !defined(_WIN32) && !defined(__MINGW32__) && !defined(__CYGWIN__)
 # define RUBY_DLN_CHECK_ABI
 #endif
 


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/18727
