### PR TITLE
[wasm] Check exts build working on ci

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -107,6 +107,7 @@ jobs:
           ../src/configure \
             --host wasm32-unknown-wasi \
             --with-static-linked-ext \
+            --with-ext=bigdecimal,ripper,monitor,stringio,pathname \
             LDFLAGS=" \
               -Xlinker --stack-first \
               -Xlinker -z -Xlinker stack-size=16777216 \


### PR DESCRIPTION
This is a preparation for enabling spec test