### PR TITLE
rename thread internal naming

### DIFF
--- a/ractor.c
+++ b/ractor.c
@@ -1545,7 +1545,7 @@ rb_ractor_atfork(rb_vm_t *vm, rb_thread_t *th)
 }
 #endif
 
-void rb_gvl_init(rb_global_vm_lock_t *gvl);
+void rb_thread_sched_init(struct rb_thread_sched *);
 
 void
 rb_ractor_living_threads_init(rb_ractor_t *r)
@@ -1564,7 +1564,7 @@ ractor_init(rb_ractor_t *r, VALUE name, VALUE loc)
     rb_native_cond_initialize(&r->barrier_wait_cond);
 
     // thread management
-    rb_gvl_init(&r->threads.gvl);
+    rb_thread_sched_init(&r->threads.sched);
     rb_ractor_living_threads_init(r);
 
     // naming
@@ -1715,12 +1715,6 @@ rb_obj_is_main_ractor(VALUE gv)
     if (!rb_ractor_p(gv)) return false;
     rb_ractor_t *r = DATA_PTR(gv);
     return r == GET_VM()->ractor.main_ractor;
-}
-
-rb_global_vm_lock_t *
-rb_ractor_gvl(rb_ractor_t *r)
-{
-    return &r->threads.gvl;
 }
 
 int

--- a/ractor_core.h
+++ b/ractor_core.h
@@ -95,7 +95,7 @@ struct rb_ractor_struct {
         unsigned int cnt;
         unsigned int blocking_cnt;
         unsigned int sleeper;
-        rb_global_vm_lock_t gvl;
+        struct rb_thread_sched sched;
         rb_execution_context_t *running_ec;
         rb_thread_t *main;
     } threads;
@@ -165,7 +165,6 @@ void rb_ractor_send_parameters(rb_execution_context_t *ec, rb_ractor_t *g, VALUE
 
 VALUE rb_thread_create_ractor(rb_ractor_t *g, VALUE args, VALUE proc); // defined in thread.c
 
-rb_global_vm_lock_t *rb_ractor_gvl(rb_ractor_t *);
 int rb_ractor_living_thread_num(const rb_ractor_t *);
 VALUE rb_ractor_thread_list(rb_ractor_t *r);
 bool rb_ractor_p(VALUE rv);

--- a/thread_none.c
+++ b/thread_none.c
@@ -23,29 +23,31 @@
 
 // Do nothing for GVL
 static void
-gvl_acquire(rb_global_vm_lock_t *gvl, rb_thread_t *th)
+thread_sched_to_running(struct rb_thread_sched *sched, rb_thread_t *th)
 {
 }
 
 static void
-gvl_release(rb_global_vm_lock_t *gvl)
+thread_sched_to_waiting(struct rb_thread_sched *sched)
 {
 }
 
 static void
-gvl_yield(rb_global_vm_lock_t *gvl, rb_thread_t *th)
+thread_sched_yield(struct rb_thread_sched *sched, rb_thread_t *th)
 {
 }
 
 void
-rb_gvl_init(rb_global_vm_lock_t *gvl)
+rb_thread_sched_init(struct rb_thread_sched *sched)
 {
 }
 
+#if 0
 static void
-gvl_destroy(rb_global_vm_lock_t *gvl)
+rb_thread_sched_destroy(struct rb_thread_sched *sched)
 {
 }
+#endif
 
 // Do nothing for mutex guard
 void

--- a/thread_none.h
+++ b/thread_none.h
@@ -10,7 +10,7 @@
 
 typedef struct native_thread_data_struct {} native_thread_data_t;
 
-typedef struct rb_global_vm_lock_struct {} rb_global_vm_lock_t;
+struct rb_thread_sched {};
 
 RUBY_EXTERN struct rb_execution_context_struct *ruby_current_ec;
 

--- a/thread_win32.h
+++ b/thread_win32.h
@@ -30,9 +30,9 @@ typedef struct native_thread_data_struct {
     HANDLE interrupt_event;
 } native_thread_data_t;
 
-typedef struct rb_global_vm_lock_struct {
+struct rb_thread_sched {
     HANDLE lock;
-} rb_global_vm_lock_t;
+};
 
 typedef DWORD native_tls_key_t; // TLS index
 

--- a/vm_core.h
+++ b/vm_core.h
@@ -1735,8 +1735,6 @@ VALUE rb_vm_call_kw(rb_execution_context_t *ec, VALUE recv, VALUE id, int argc,
                  const VALUE *argv, const rb_callable_method_entry_t *me, int kw_splat);
 MJIT_STATIC void rb_vm_pop_frame(rb_execution_context_t *ec);
 
-void rb_gvl_destroy(rb_global_vm_lock_t *gvl);
-
 void rb_thread_start_timer_thread(void);
 void rb_thread_stop_timer_thread(void);
 void rb_thread_reset_timer_thread(void);


### PR DESCRIPTION
Now GVL is not process *Global* so this patch try to use
another words.

* `rb_global_vm_lock_t` -> `struct rb_thread_sched`
  * `gvl->owner` -> `sched->running`
  * `gvl->waitq` -> `sched->readyq`
* `rb_gvl_init` -> `rb_thread_sched_init`
* `gvl_destroy` -> `rb_thread_sched_destroy`
* `gvl_acquire` -> `thread_sched_to_running` # waiting -> ready -> running
* `gvl_release` -> `thread_sched_to_waiting` # running -> waiting
* `gvl_yield`   -> `thread_sched_yield`
* `GVL_UNLOCK_BEGIN` -> `THREAD_BLOCKING_BEGIN`
* `GVL_UNLOCK_END` -> `THREAD_BLOCKING_END`

and 

* removed
  * `rb_ractor_gvl`
  * `rb_vm_gvl_destroy` (not used)

There are GVL functions such as `rb_thread_call_without_gvl()` yet
but I don't have good name to replace them. Maybe GVL stands for
"Greate Valuable Lock" or something like that.
