### PR TITLE
Resolve several markedown warnings in readmes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -33,14 +33,14 @@ Note that each entry is kept to a minimum, see links for details.
 
 * Constant assignment evaluation order for constants set on explicit
   objects has been made consistent with single attribute assignment
-  evaluation order.  With this code:
+  evaluation order. With this code:
 
     ```ruby
     foo::BAR = baz
     ```
 
-  `foo` is now called before `baz`. Similarly, for multiple assignment
-  to constants,  left-to-right evaluation order is used.  With this
+  `foo` is now called before `baz`. Similarly, for multiple assignments
+  to constants,  left-to-right evaluation order is used. With this
   code:
 
     ```ruby
@@ -121,7 +121,7 @@ Note: We're only listing outstanding class updates.
     * Refinement#refined_class has been added. [[Feature #12737]]
 
 * Set
-    * Set is now available as a builtin class without the need for `require "set"`. [[Feature #16989]]
+    * Set is now available as a built-in class without the need for `require "set"`. [[Feature #16989]]
       It is currently autoloaded via the `Set` constant or a call to `Enumerable#to_set`.
 
 * String
@@ -143,7 +143,7 @@ Note: We're only listing outstanding class updates.
 
 ## Stdlib updates
 
-*   The following default gem are updated.
+*   The following default gems are updated.
     * RubyGems 3.4.0.dev
     * bigdecimal 3.1.2
     * bundler 2.4.0.dev
@@ -194,7 +194,7 @@ The following deprecated methods are removed.
 
 * `Psych` no longer bundles libyaml sources.
   Users need to install the libyaml library themselves via the package
-  system.  [[Feature #18571]]
+  system. [[Feature #18571]]
 
 ## C API updates
 

--- a/README.md
+++ b/README.md
@@ -15,18 +15,17 @@ It is simple, straightforward, and extensible.
 
 ## Features of Ruby
 
-*   Simple Syntax
-*   **Normal** Object-oriented Features (e.g. class, method calls)
-*   **Advanced** Object-oriented Features (e.g. mix-in, singleton-method)
-*   Operator Overloading
-*   Exception Handling
-*   Iterators and Closures
-*   Garbage Collection
-*   Dynamic Loading of Object Files (on some architectures)
-*   Highly Portable (works on many Unix-like/POSIX compatible platforms as
-    well as Windows, macOS, etc.) cf.
-    https://github.com/ruby/ruby/blob/master/doc/maintainers.rdoc#label-Platform+Maintainers
-
+* Simple Syntax
+* **Normal** Object-oriented Features (e.g. class, method calls)
+* **Advanced** Object-oriented Features (e.g. mix-in, singleton-method)
+* Operator Overloading
+* Exception Handling
+* Iterators and Closures
+* Garbage Collection
+* Dynamic Loading of Object Files (on some architectures)
+* Highly Portable (works on many Unix-like/POSIX compatible platforms as
+  well as Windows, macOS, etc.) cf.
+  https://github.com/ruby/ruby/blob/master/doc/maintainers.rdoc#label-Platform+Maintainers
 
 ## How to get Ruby
 
@@ -60,7 +59,6 @@ Try the following command to see the list of branches:
 
     $ svn ls https://svn.ruby-lang.org/repos/ruby/branches/
 
-
 ## Ruby home page
 
 https://www.ruby-lang.org/
@@ -90,10 +88,10 @@ is required.
 
 ## How to compile and install
 
-1.  If you want to use Microsoft Visual C++ to compile Ruby, read
+1. If you want to use Microsoft Visual C++ to compile Ruby, read
     [win32/README.win32](rdoc-ref:win32/README.win32) instead of this document.
 
-2.  Run `./autogen.sh` to generate configure, when you build the source checked
+2. Run `./autogen.sh` to generate configure, when you build the source checked
     out from the Git repository.
 
 3.  Run `./configure`, which will generate `config.h` and `Makefile`.
@@ -104,7 +102,7 @@ is required.
 
 4.  Edit `include/ruby/defines.h` if you need. Usually this step will not be needed.
 
-5.  Optional: Remove comment mark(`#`) before the module names from `ext/Setup`.
+5. Optional: Remove comment mark(`#`) before the module names from `ext/Setup`.
 
     This step is only necessary if you want to link modules statically.
 
@@ -114,16 +112,16 @@ is required.
 
     Usually this step will not be needed.
 
-6.  Run `make`.
+6. Run `make`.
 
     * On Mac, set RUBY\_CODESIGN environment variable with a signing identity.
       It uses the identity to sign `ruby` binary. See also codesign(1).
 
-7.  Optionally, run '`make check`' to check whether the compiled Ruby
+7. Optionally, run '`make check`' to check whether the compiled Ruby
     interpreter works well. If you see the message "`check succeeded`", your
     Ruby works as it should (hopefully).
 
-8.  Run '`make install`'.
+8. Run '`make install`'.
 
     This command will create the following directories and install files into
     them.
@@ -144,7 +142,6 @@ is required.
     *   `${DESTDIR}${prefix}/lib/ruby/gems/${MAJOR}.${MINOR}.${TEENY}`
     *   `${DESTDIR}${prefix}/share/man/man1`
     *   `${DESTDIR}${prefix}/share/ri/${MAJOR}.${MINOR}.${TEENY}/system`
-
 
     If Ruby's API version is '*x.y.z*', the `${MAJOR}` is '*x*', the
     `${MINOR}` is '*y*', and the `${TEENY}` is '*z*'.

--- a/spec/README.md
+++ b/spec/README.md
@@ -5,6 +5,7 @@ spec/bundler is rspec examples for bundler library (`lib/bundler.rb`, `lib/bundl
 ## Running spec/bundler
 
 To run rspec for bundler:
+
 ```bash
 make test-bundler
 ```
@@ -37,6 +38,7 @@ which change behavior or are removed. This is necessary for other Ruby implement
 to still be able to run the specs and contribute new specs.
 
 For example, change:
+
 ```ruby
 describe "Some spec" do
   it "some example" do
@@ -44,7 +46,9 @@ describe "Some spec" do
   end
 end
 ```
+
 to:
+
 ```ruby
 describe "Some spec" do
   ruby_version_is ""..."2.7" do
@@ -64,7 +68,8 @@ end
 See `spec/ruby/CONTRIBUTING.md` for more documentation about guards.
 
 To verify specs are compatible with older Ruby versions:
-```
+
+```bash
 cd spec/ruby
 $RUBY_MANAGER use 2.4.9
 ../mspec/bin/mspec -j
@@ -73,28 +78,33 @@ $RUBY_MANAGER use 2.4.9
 ## Running ruby/spec
 
 To run all specs:
+
 ```bash
 make test-spec
 ```
 
 Extra arguments can be added via `MSPECOPT`.
 For instance, to show the help:
+
 ```bash
 make test-spec MSPECOPT=-h
 ```
 
 You can also run the specs in parallel, which is currently experimental.
 It takes around 10s instead of 60s on a quad-core laptop.
+
 ```bash
 make test-spec MSPECOPT=-j
 ```
 
 To run a specific test, add its path to the command:
+
 ```bash
 make test-spec MSPECOPT=spec/ruby/language/for_spec.rb
 ```
 
 If ruby trunk is your current `ruby` in `$PATH`, you can also run `mspec` directly:
+
 ```bash
 # change ruby to trunk
 ruby -v # => trunk

--- a/spec/ruby/CONTRIBUTING.md
+++ b/spec/ruby/CONTRIBUTING.md
@@ -13,12 +13,14 @@ Spec are grouped in 5 separate top-level groups:
 * `optional/capi`: for functions available to the Ruby C-extension API
 
 The exact file for methods is decided by the `#owner` of a method, for instance for `#group_by`:
+
 ```ruby
 > [].method(:group_by)
 => #<Method: Array(Enumerable)#group_by>
 > [].method(:group_by).owner
 => Enumerable
 ```
+
 Which should therefore be specified in `core/enumerable/group_by_spec.rb`.
 
 ### MkSpec - a tool to generate the spec structure
@@ -220,7 +222,7 @@ If an implementation does not support some feature, simply tag the related specs
 ### Shared Specs
 
 Often throughout Ruby, identical functionality is used by different methods and modules. In order
-to avoid duplication of specs, we have shared specs that are re-used in other specs.  The use is a
+to avoid duplication of specs, we have shared specs that are re-used in other specs. The use is a
 bit tricky however, so let's go over it.
 
 Commonly, if a shared spec is only reused within its own module, the shared spec will live within a
@@ -232,7 +234,7 @@ An example of this is the `shared/file/socket.rb` which is used by `core/file/so
 `core/filetest/socket_spec.rb`, and `core/file/state/socket_spec.rb` and so it lives in the root `shared/`.
 
 Defining a shared spec involves adding a `shared: true` option to the top-level `describe` block. This
-will signal not to run the specs directly by the runner.  Shared specs have access to two instance
+will signal not to run the specs directly by the runner. Shared specs have access to two instance
 variables from the implementor spec: `@method` and `@object`, which the implementor spec will pass in.
 
 Here's an example of a snippet of a shared spec and two specs which integrates it:
@@ -257,12 +259,12 @@ end
 ```
 
 In the example, the first `describe` defines the shared spec `:hash_key_p`, which defines a spec that
-calls the `@method` method with an expectation.  In the implementor spec, we use `it_behaves_like` to
-integrate the shared spec.  `it_behaves_like` takes 3 parameters: the key of the shared spec, a method,
-and an object.  These last two parameters are accessible via `@method` and `@object` in the shared spec.
+calls the `@method` method with an expectation. In the implementor spec, we use `it_behaves_like` to
+integrate the shared spec. `it_behaves_like` takes 3 parameters: the key of the shared spec, a method,
+and an object. These last two parameters are accessible via `@method` and `@object` in the shared spec.
 
 Sometimes, shared specs require more context from the implementor class than a simple object. We can address
-this by passing a lambda as the method, which will have the scope of the implementor.  Here's an example of
+this by passing a lambda as the method, which will have the scope of the implementor. Here's an example of
 how this is used currently:
 
 ```ruby

--- a/spec/ruby/README.md
+++ b/spec/ruby/README.md
@@ -24,6 +24,7 @@ The specs describe the [language syntax](language/), the [core library](core/), 
 The language specs are grouped by keyword while the core and standard library specs are grouped by class and method.
 
 ruby/spec is known to be tested in these implementations for every commit:
+
 * [MRI](https://rubyci.org/) on 30 platforms and 4 versions
 * [JRuby](https://github.com/jruby/jruby/tree/master/spec/ruby) for both 1.7 and 9.x
 * [TruffleRuby](https://github.com/oracle/truffleruby/tree/master/spec/ruby)
@@ -53,6 +54,7 @@ $ ../mspec/bin/mspec
 ### Specs for old Ruby versions
 
 For older specs try these commits:
+
 * Ruby 2.0.0-p647 - [Suite](https://github.com/ruby/spec/commit/245862558761d5abc676843ef74f86c9bcc8ea8d) using [MSpec](https://github.com/ruby/mspec/commit/f90efa068791064f955de7a843e96e2d7d3041c2) (may encounter 2 failures)
 * Ruby 2.1.9 - [Suite](https://github.com/ruby/spec/commit/f029e65241374386077ac500add557ae65069b55) using [MSpec](https://github.com/ruby/mspec/commit/55568ea3918c6380e64db8c567d732fa5781efed)
 * Ruby 2.2.10 - [Suite](https://github.com/ruby/spec/commit/cbaa0e412270c944df0c2532fc500c920dba0e92) using [MSpec](https://github.com/ruby/mspec/commit/d84d7668449e96856c5f6bac8cb1526b6d357ce3)


### PR DESCRIPTION
- Spaces before and after blocks.
- Single spaces after sentences everywhere
- Properly indent lists

Signed-off-by: Tim Smith <tsmith@mondoo.com>