### PR TITLE
Reuse `rb_proc_arity`

### DIFF
--- a/proc.c
+++ b/proc.c
@@ -1214,9 +1214,7 @@ rb_block_arity(void)
 	return -1;
 
       case block_handler_type_proc:
-	{
         return rb_proc_arity(block_handler);
-	}
 
       default:
         min = rb_vm_block_min_max_arity(&block, &max);

--- a/proc.c
+++ b/proc.c
@@ -1217,9 +1217,7 @@ rb_block_arity(void)
       case block_handler_type_proc:
 	{
 	    VALUE procval = block_handler;
-	    rb_proc_t *proc;
-	    GetProcPtr(procval, proc);
-	    return (proc->is_lambda ? min == max : max != UNLIMITED_ARGUMENTS) ? min : -min-1;
+        return rb_proc_arity(procval);
 	}
 
       default:

--- a/proc.c
+++ b/proc.c
@@ -1208,7 +1208,6 @@ rb_block_arity(void)
     }
 
     block_setup(&block, block_handler);
-    min = rb_vm_block_min_max_arity(&block, &max);
 
     switch (vm_block_type(&block)) {
       case block_handler_type_symbol:
@@ -1216,11 +1215,11 @@ rb_block_arity(void)
 
       case block_handler_type_proc:
 	{
-	    VALUE procval = block_handler;
-        return rb_proc_arity(procval);
+        return rb_proc_arity(block_handler);
 	}
 
       default:
+        min = rb_vm_block_min_max_arity(&block, &max);
 	return max != UNLIMITED_ARGUMENTS ? min : -min-1;
     }
 }


### PR DESCRIPTION
`rb_block_arity` has same code in part as `rb_proc_arity`.
Better to reuse `rb_proc_arity`,  I think.