### PR TITLE
[DOC] Clarify example for Enumerable#each_with_object

### DIFF
--- a/enum.c
+++ b/enum.c
@@ -3099,7 +3099,9 @@ each_with_object_i(RB_BLOCK_CALL_FUNC_ARGLIST(i, memo))
  *  and the given object:
  *
  *    (1..4).each_with_object([]) {|i, a| a.push(i**2) } # => [1, 4, 9, 16]
- *    h.each_with_object({}) {|element, h| k, v = *element; h[v] = k }
+ *
+ *    h = {foo: 0, bar: 1, baz: 2}
+ *    h.each_with_object({}) {|element, h| k, v = element; h[v] = k }
  *    # => {0=>:foo, 1=>:bar, 2=>:baz}
  *
  *  With no block given, returns an Enumerator.

--- a/enum.c
+++ b/enum.c
@@ -3101,14 +3101,6 @@ each_with_object_i(RB_BLOCK_CALL_FUNC_ARGLIST(i, memo))
  *    (1..4).each_with_object([]) {|i, a| a.push(i**2) }
  *    # => [1, 4, 9, 16]
  *
- *    {foo: 0, bar: 1, baz: 2}.each_with_object({}) do |element, h|
- *      k, v = element
- *      h[v] = k
- *    end
- *    # => {0=>:foo, 1=>:bar, 2=>:baz}
- *
- *  OR
- *
  *    {foo: 0, bar: 1, baz: 2}.each_with_object({}) {|(k, v), h| h[v] = k }
  *    # => {0=>:foo, 1=>:bar, 2=>:baz}
  *

--- a/enum.c
+++ b/enum.c
@@ -3098,10 +3098,18 @@ each_with_object_i(RB_BLOCK_CALL_FUNC_ARGLIST(i, memo))
  *  Calls the block once for each element, passing both the element
  *  and the given object:
  *
- *    (1..4).each_with_object([]) {|i, a| a.push(i**2) } # => [1, 4, 9, 16]
+ *    (1..4).each_with_object([]) {|i, a| a.push(i**2) }
+ *    # => [1, 4, 9, 16]
  *
- *    h = {foo: 0, bar: 1, baz: 2}
- *    h.each_with_object({}) {|element, h| k, v = element; h[v] = k }
+ *    {foo: 0, bar: 1, baz: 2}.each_with_object({}) do |element, h|
+ *      k, v = element
+ *      h[v] = k
+ *    end
+ *    # => {0=>:foo, 1=>:bar, 2=>:baz}
+ *
+ *  OR
+ *
+ *    {foo: 0, bar: 1, baz: 2}.each_with_object({}) {|(k, v), h| h[v] = k }
  *    # => {0=>:foo, 1=>:bar, 2=>:baz}
  *
  *  With no block given, returns an Enumerator.


### PR DESCRIPTION
## Problem

Colleague asked what the splat did in this example and I don't think it does anything but maybe tries to handle an edge case that doesn't exist in the provided for example. 

## What changed

- assign `h` to the hash used in the example similar to earlier examples
- remove unnecessary splat in front of element