### PR TITLE
parse.y: Fix a bug of shadowing underline-prefixed variables

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -10994,9 +10994,8 @@ is_private_local_id(ID name)
 static int
 shadowing_lvar_0(struct parser_params *p, ID name)
 {
-    if (is_private_local_id(name)) return 1;
     if (dyna_in_block(p)) {
-	if (dvar_curr(p, name)) {
+	if (dvar_curr(p, name) && !is_private_local_id(name)) {
 	    yyerror0("duplicated argument name");
 	}
 	else if (dvar_defined(p, name) || local_id(p, name)) {
@@ -11008,7 +11007,7 @@ shadowing_lvar_0(struct parser_params *p, ID name)
 	}
     }
     else {
-	if (local_id(p, name)) {
+	if (local_id(p, name) && !is_private_local_id(name)) {
 	    yyerror0("duplicated argument name");
 	}
     }

--- a/test/ruby/test_variable.rb
+++ b/test/ruby/test_variable.rb
@@ -218,6 +218,18 @@ class TestVariable < Test::Unit::TestCase
     assert_equal([:x, :bug9486], tap {|;x| x = x; break local_variables}, bug9486)
   end
 
+  def test_shadowing_private_local_variables
+    bug18629 = '[ruby-core:107883] [Bug #18629]'
+
+    _ = 1
+    [[2]].each{ |(_)| }
+    assert_equal(1, _, bug18629)
+
+    _x = 1
+    [[2]].each{ |(_x)| }
+    assert_equal(1, _x, bug18629)
+  end
+
   def test_global_variables
     gv = global_variables
     assert_empty(gv.grep(/\A(?!\$)/))


### PR DESCRIPTION
[Bug #18629]