### PR TITLE
introduce struct `rb_native_thread`

### DIFF
--- a/thread.c
+++ b/thread.c
@@ -339,7 +339,7 @@ rb_thread_s_debug_set(VALUE self, VALUE val)
 #ifndef fill_thread_id_str
 # define fill_thread_id_string(thid, buf) ((void *)(uintptr_t)(thid))
 # define fill_thread_id_str(th) (void)0
-# define thread_id_str(th) ((void *)(uintptr_t)(th)->thread_id)
+# define thread_id_str(th) ((void *)(uintptr_t)(th)->nt->thread_id)
 # define PRI_THREAD_ID "p"
 #endif
 
@@ -3333,7 +3333,7 @@ rb_thread_setname(VALUE thread, VALUE name)
     }
     target_th->name = name;
     if (threadptr_initialized(target_th)) {
-	native_set_another_thread_name(target_th->thread_id, name);
+	native_set_another_thread_name(target_th->nt->thread_id, name);
     }
     return name;
 }

--- a/thread_none.c
+++ b/thread_none.c
@@ -126,11 +126,11 @@ ruby_thread_set_native(rb_thread_t *th)
 }
 
 void
-Init_native_thread(rb_thread_t *th)
+Init_native_thread(rb_thread_t *main_th)
 {
     // no TLS setup and no thread id setup
-    ruby_thread_set_native(th);
-    fill_thread_id_str(th);
+    ruby_thread_set_native(main_th);
+    fill_thread_id_str(main_th);
 }
 
 static void

--- a/thread_none.h
+++ b/thread_none.h
@@ -8,8 +8,11 @@
 // based implementation in vm.c
 #define RB_THREAD_LOCAL_SPECIFIER
 
-typedef struct native_thread_data_struct {} native_thread_data_t;
+struct rb_native_thread {
+    void *thread_id; // NULL
+};
 
+struct rb_thread_sched_item {};
 struct rb_thread_sched {};
 
 RUBY_EXTERN struct rb_execution_context_struct *ruby_current_ec;

--- a/thread_pthread.h
+++ b/thread_pthread.h
@@ -17,11 +17,30 @@
 #define RB_NATIVETHREAD_LOCK_INIT PTHREAD_MUTEX_INITIALIZER
 #define RB_NATIVETHREAD_COND_INIT PTHREAD_COND_INITIALIZER
 
-typedef struct native_thread_data_struct {
+// per-Thead scheduler helper data
+struct rb_thread_sched_item {
     union {
         struct ccan_list_node ubf;
         struct ccan_list_node readyq; // protected by sched->lock
     } node;
+};
+
+struct rb_native_thread {
+    int id;
+
+    rb_nativethread_id_t thread_id;
+
+#ifdef NON_SCALAR_THREAD_ID
+    rb_thread_id_string_t thread_id_string;
+#endif
+
+#ifdef RB_THREAD_T_HAS_NATIVE_ID
+    int tid;
+#endif
+
+    struct rb_thread_struct *running_thread;
+
+    // to control native thread
 #if defined(__GLIBC__) || defined(__FreeBSD__)
     union
 #else
@@ -31,11 +50,11 @@ typedef struct native_thread_data_struct {
      */
     struct
 #endif
-    {
+      {
         rb_nativethread_cond_t intr; /* th->interrupt_lock */
         rb_nativethread_cond_t readyq; /* use sched->lock */
     } cond;
-} native_thread_data_t;
+};
 
 #undef except
 #undef try

--- a/thread_win32.c
+++ b/thread_win32.c
@@ -155,7 +155,7 @@ ruby_thread_set_native(rb_thread_t *th)
 }
 
 void
-Init_native_thread(rb_thread_t *th)
+Init_native_thread(rb_thread_t *main_th)
 {
     if ((ruby_current_ec_key = TlsAlloc()) == TLS_OUT_OF_INDEXES) {
         rb_bug("TlsAlloc() for ruby_current_ec_key fails");
@@ -163,17 +163,21 @@ Init_native_thread(rb_thread_t *th)
     if ((ruby_native_thread_key = TlsAlloc()) == TLS_OUT_OF_INDEXES) {
         rb_bug("TlsAlloc() for ruby_native_thread_key fails");
     }
-    ruby_thread_set_native(th);
+
+    // setup main thread
+
+    ruby_thread_set_native(main_th);
+    main_th->nt->interrupt_event = CreateEvent(0, TRUE, FALSE, 0);
+
     DuplicateHandle(GetCurrentProcess(),
 		    GetCurrentThread(),
 		    GetCurrentProcess(),
-		    &th->thread_id, 0, FALSE, DUPLICATE_SAME_ACCESS);
-
-    th->native_thread_data.interrupt_event = CreateEvent(0, TRUE, FALSE, 0);
+		    &main_th->nt->thread_id, 0, FALSE, DUPLICATE_SAME_ACCESS);
 
     thread_debug("initial thread (th: %p, thid: %p, event: %p)\n",
-		 th, GET_THREAD()->thread_id,
-		 th->native_thread_data.interrupt_event);
+                 main_th,
+                 main_th->nt->thread_id,
+                 main_th->nt->interrupt_event);
 }
 
 static int
@@ -186,7 +190,7 @@ w32_wait_events(HANDLE *events, int count, DWORD timeout, rb_thread_t *th)
 
     thread_debug("  w32_wait_events events:%p, count:%d, timeout:%ld, th:%p\n",
 		 events, count, timeout, th);
-    if (th && (intr = th->native_thread_data.interrupt_event)) {
+    if (th && (intr = th->nt->interrupt_event)) {
 	if (ResetEvent(intr) && (!RUBY_VM_INTERRUPTED(th->ec) || SetEvent(intr))) {
 	    targets = ALLOCA_N(HANDLE, count + 1);
 	    memcpy(targets, events, sizeof(HANDLE) * count);
@@ -194,7 +198,7 @@ w32_wait_events(HANDLE *events, int count, DWORD timeout, rb_thread_t *th)
 	    targets[count++] = intr;
 	    thread_debug("  * handle: %p (count: %d, intr)\n", intr, count);
 	}
-	else if (intr == th->native_thread_data.interrupt_event) {
+	else if (intr == th->nt->interrupt_event) {
 	    w32_error("w32_wait_events");
 	}
     }
@@ -592,8 +596,8 @@ native_thread_init_stack(rb_thread_t *th)
 static void
 native_thread_destroy(rb_thread_t *th)
 {
-    HANDLE intr = InterlockedExchangePointer(&th->native_thread_data.interrupt_event, 0);
-    thread_debug("close handle - intr: %p, thid: %p\n", intr, th->thread_id);
+    HANDLE intr = InterlockedExchangePointer(&th->nt->interrupt_event, 0);
+    thread_debug("close handle - intr: %p, thid: %p\n", intr, th->nt->thread_id);
     w32_close_handle(intr);
 }
 
@@ -601,14 +605,14 @@ static unsigned long __stdcall
 thread_start_func_1(void *th_ptr)
 {
     rb_thread_t *th = th_ptr;
-    volatile HANDLE thread_id = th->thread_id;
+    volatile HANDLE thread_id = th->nt->thread_id;
 
     native_thread_init_stack(th);
-    th->native_thread_data.interrupt_event = CreateEvent(0, TRUE, FALSE, 0);
+    th->nt->interrupt_event = CreateEvent(0, TRUE, FALSE, 0);
 
     /* run */
     thread_debug("thread created (th: %p, thid: %p, event: %p)\n", th,
-		 th->thread_id, th->native_thread_data.interrupt_event);
+		 th->nt->thread_id, th->nt->interrupt_event);
 
     thread_start_func_2(th, th->ec->machine.stack_start);
 
@@ -621,19 +625,20 @@ static int
 native_thread_create(rb_thread_t *th)
 {
     const size_t stack_size = th->vm->default_params.thread_machine_stack_size + th->vm->default_params.thread_vm_stack_size;
-    th->thread_id = w32_create_thread(stack_size, thread_start_func_1, th);
+    th->nt = ZALLOC(struct rb_native_thread);
+    th->nt->thread_id = w32_create_thread(stack_size, thread_start_func_1, th);
 
-    if ((th->thread_id) == 0) {
+    if ((th->nt->thread_id) == 0) {
 	return thread_errno;
     }
 
-    w32_resume_thread(th->thread_id);
+    w32_resume_thread(th->nt->thread_id);
 
     if (THREAD_DEBUG) {
 	Sleep(0);
 	thread_debug("create: (th: %p, thid: %p, intr: %p), stack size: %"PRIuSIZE"\n",
-		     th, th->thread_id,
-		     th->native_thread_data.interrupt_event, stack_size);
+		     th, th->nt->thread_id,
+		     th->nt->interrupt_event, stack_size);
     }
     return 0;
 }
@@ -660,7 +665,7 @@ native_thread_apply_priority(rb_thread_t *th)
 	priority = THREAD_PRIORITY_NORMAL;
     }
 
-    SetThreadPriority(th->thread_id, priority);
+    SetThreadPriority(th->nt->thread_id, priority);
 }
 
 #endif /* USE_NATIVE_THREAD_PRIORITY */
@@ -699,7 +704,7 @@ ubf_handle(void *ptr)
     rb_thread_t *th = (rb_thread_t *)ptr;
     thread_debug("ubf_handle: %p\n", th);
 
-    if (!SetEvent(th->native_thread_data.interrupt_event)) {
+    if (!SetEvent(th->nt->interrupt_event)) {
 	w32_error("ubf_handle");
     }
 }
@@ -848,7 +853,7 @@ native_set_thread_name(rb_thread_t *th)
 static VALUE
 native_thread_native_thread_id(rb_thread_t *th)
 {
-    DWORD tid = GetThreadId(th->thread_id);
+    DWORD tid = GetThreadId(th->nt->thread_id);
     if (tid == 0) rb_sys_fail("GetThreadId");
     return ULONG2NUM(tid);
 }

--- a/thread_win32.h
+++ b/thread_win32.h
@@ -26,9 +26,14 @@ struct rb_thread_cond_struct {
     struct cond_event_entry *prev;
 };
 
-typedef struct native_thread_data_struct {
+struct rb_native_thread {
+    HANDLE thread_id;
     HANDLE interrupt_event;
-} native_thread_data_t;
+};
+
+struct rb_thread_sched_item {
+    char dmy;
+};
 
 struct rb_thread_sched {
     HANDLE lock;

--- a/vm_dump.c
+++ b/vm_dump.c
@@ -1194,10 +1194,10 @@ rb_vmdebug_stack_dump_all_threads(void)
     ccan_list_for_each(&r->threads.set, th, lt_node) {
 #ifdef NON_SCALAR_THREAD_ID
         rb_thread_id_string_t buf;
-	ruby_fill_thread_id_string(th->thread_id, buf);
+	ruby_fill_thread_id_string(th->nt->thread_id, buf);
 	fprintf(stderr, "th: %p, native_id: %s\n", th, buf);
 #else
-        fprintf(stderr, "th: %p, native_id: %p\n", (void *)th, (void *)(uintptr_t)th->thread_id);
+        fprintf(stderr, "th: %p, native_id: %p\n", (void *)th, (void *)(uintptr_t)th->nt->thread_id);
 #endif
 	rb_vmdebug_stack_dump_raw(th->ec, th->ec->cfp);
     }


### PR DESCRIPTION
`rb_thread_t` contained `native_thread_data_t` to represent
thread implementation dependent data. This patch separates
them and rename it `rb_native_thread` and point it from
`rb_thraed_t`.

Now, 1 Ruby thread (`rb_thread_t`) has 1 native thread (`rb_native_thread`).