### PR TITLE
rbinstall: Also do `Gem.ruby` patching for unpacked bundled gems

### DIFF
--- a/tool/rbinstall.rb
+++ b/tool/rbinstall.rb
@@ -1039,6 +1039,13 @@ install?(:ext, :comm, :gem, :'bundled-gems') do
   specifications_dir = File.join(gem_dir, "specifications")
   build_dir = Gem::StubSpecification.gemspec_stub("", ".bundle", ".bundle").extensions_dir
 
+  # We are about to build extensions, and want to configure extensions with the
+  # newly installed ruby.
+  Gem.instance_variable_set(:@ruby, with_destdir(File.join(bindir, ruby_install_name)))
+  # Prevent fake.rb propagation. It conflicts with the natural mkmf configs of
+  # the newly installed ruby.
+  ENV.delete('RUBYOPT')
+
   File.foreach("#{srcdir}/gems/bundled_gems") do |name|
     next if /^\s*(?:#|$)/ =~ name
     next unless /^(\S+)\s+(\S+).*/ =~ name
@@ -1066,7 +1073,6 @@ install?(:ext, :comm, :gem, :'bundled-gems') do
   end
   next if gems.empty?
   if defined?(Zlib)
-    Gem.instance_variable_set(:@ruby, with_destdir(File.join(bindir, ruby_install_name)))
     silent = Gem::SilentUI.new
     gems.each do |gem|
       package = Gem::Package.new(gem)


### PR DESCRIPTION
Pointing `Gem.ruby` to the newly installed ruby gives mkmf the right
inputs to build extensions in bundled gems. Previously, this patching
was only done for compressed bundled gems.

This patch also prevents `tool/fake.rb` from propagating to the child
process running mkmf for the native extension. The way `tool/fake.rb`
changes mkmf variables using `Kernel#trace_var` created spooky action at
a distance which made debugging difficult.

AppVeyor Windows CI started to fail starting with
8a3663789c52ec5635194656af6b69d3d03120ee because it enabled extension
building for bundled gems on mswin. This patch should address the CI
failures.