### PR TITLE
Fix ARGF#lineno to return Integer as documented

### DIFF
--- a/io.c
+++ b/io.c
@@ -9348,7 +9348,7 @@ argf_set_lineno(VALUE argf, VALUE val)
 {
     ARGF.lineno = NUM2INT(val);
     ARGF.last_lineno = ARGF.lineno;
-    return Qnil;
+    return val;
 }
 
 /*


### PR DESCRIPTION
[[Bug #18753]](https://bugs.ruby-lang.org/issues/18753)