### PR TITLE
Faster rb_class_superclass

### DIFF
--- a/object.c
+++ b/object.c
@@ -2038,19 +2038,18 @@ rb_class_new_instance(int argc, const VALUE *argv, VALUE klass)
 VALUE
 rb_class_superclass(VALUE klass)
 {
+    RUBY_ASSERT(RB_TYPE_P(klass, T_CLASS));
+
     VALUE super = RCLASS_SUPER(klass);
 
     if (!super) {
 	if (klass == rb_cBasicObject) return Qnil;
 	rb_raise(rb_eTypeError, "uninitialized class");
+    } else {
+        super = RCLASS_SUPERCLASSES(klass)[RCLASS_SUPERCLASS_DEPTH(klass) - 1];
+        RUBY_ASSERT(RB_TYPE_P(klass, T_CLASS));
+        return super;
     }
-    while (RB_TYPE_P(super, T_ICLASS)) {
-	super = RCLASS_SUPER(super);
-    }
-    if (!super) {
-	return Qnil;
-    }
-    return super;
 }
 
 VALUE


### PR DESCRIPTION
Previously attempted in #5662 but reverted. Should now work thanks to #5808

---

This uses the RCLASS_SUPERCLASSES array to quickly find the next SUPERCLASS of klass which is a T_CLASS.

This is the same speed (possibly slightly faster because we aren't checking the superclass's type) when the immediate super is a T_CLASS, but can be significantly faster when the class includes many modules.

<details>
<summary>Benchmark</summary>

```
prelude: |
  class SimpleClass; end
  class OneModuleClass
    1.times { include Module.new }
  end
  class MediumClass
    10.times { include Module.new }
  end
  class LargeClass
    100.times { include Module.new }
  end
benchmark:
  simple_class_superclass: |
    SimpleClass.superclass
  one_module_superclass: |
    OneModuleClass.superclass
  medium_class_superclass: |
    MediumClass.superclass
  large_class_superclass: |
    LargeClass.superclass
loop_count: 20000000
```

</details>

```
compare-ruby: ruby 3.2.0dev (2022-03-05T12:06:52Z master 7cc0c53169) [x86_64-linux]
built-ruby: ruby 3.2.0dev (2022-03-15T19:26:02Z fast_superclass_su.. 4f182d6ee2) [x86_64-linux]
# Iteration per second (i/s)

|                         |compare-ruby|built-ruby|
|:------------------------|-----------:|---------:|
|simple_class_superclass  |     83.318M|   83.323M|
|                         |           -|     1.00x|
|one_module_superclass    |     79.711M|   87.785M|
|                         |           -|     1.10x|
|medium_class_superclass  |     56.513M|   84.002M|
|                         |           -|     1.49x|
|large_class_superclass   |      8.727M|   81.813M|
|                         |           -|     9.37x|
```