### PR TITLE
Enable riscv64 coroutines on riscv64-freebsd, arm32 on arm*-freebsd

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2825,6 +2825,9 @@ AS_CASE([$coroutine_type], [yes|''], [
         [riscv64-freebsd*], [
             coroutine_type=riscv64
         ],
+        [arm*-freebsd*], [
+            coroutine_type=arm32
+        ],
         [x86_64-netbsd*], [
             coroutine_type=amd64
         ],

--- a/configure.ac
+++ b/configure.ac
@@ -2822,6 +2822,9 @@ AS_CASE([$coroutine_type], [yes|''], [
         [powerpc64le-freebsd*], [
             coroutine_type=ppc64le
         ],
+        [riscv64-freebsd*], [
+            coroutine_type=riscv64
+        ],
         [x86_64-netbsd*], [
             coroutine_type=amd64
         ],


### PR DESCRIPTION
`make test` passes for both riscv64 and armv7 after enabling coroutines.