### PR TITLE
Work around shell syntax error on Solaris

### DIFF
--- a/template/Makefile.in
+++ b/template/Makefile.in
@@ -272,6 +272,13 @@ DESTDIR       = @DESTDIR@
 configure_args = @configure_args@
 #### End of variables
 
+# Shell short-circuiting for dodging syntax error on older shells, e.g.
+# Solaris. Hack: make sends <backslash><newline> to the shell per POSIX, and
+# two backslashes stops escaping the newline.
+YJIT_BUILD_ONLY0 = $(YJIT_SUPPORT:no=exit; \\)
+YJIT_BUILD_ONLY1 = $(YJIT_BUILD_ONLY0:dev=)
+YJIT_BUILD_ONLY  = $(YJIT_BUILD_ONLY1:yes=)
+
 ABI_VERSION_HDR = $(hdrdir)/ruby/internal/abi.h
 
 .SUFFIXES: .inc .h .c .y .i .$(ASMEXT) .$(DTRACE_EXT)
@@ -305,15 +312,14 @@ $(LIBRUBY_A):
 		@-[ -z "$(EXTSTATIC)" ] || $(PRE_LIBRUBY_UPDATE)
 		$(ECHO) linking static-library $@
 		$(Q) $(AR) $(ARFLAGS) $@ $(LIBRUBY_A_OBJS) $(INITOBJS)
-		$(Q) if [ -f '$(YJIT_LIBS)' ]; then \
+		$(Q) $(YJIT_BUILD_ONLY)\
 		  set -eu && \
 		  echo 'merging $(YJIT_LIBS) into $@' && \
 		  $(RMALL)    '$(CARGO_TARGET_DIR)/libyjit/' && \
 		  $(MAKEDIRS) '$(CARGO_TARGET_DIR)/libyjit/' && \
 		  $(CP) '$(YJIT_LIBS)' '$(CARGO_TARGET_DIR)/libyjit/' && \
 		  (cd '$(CARGO_TARGET_DIR)/libyjit/' && $(AR) -x libyjit.a) && \
-		  $(AR) $(ARFLAGS) $@ $$(find '$(CARGO_TARGET_DIR)/libyjit/' -name '*.o') ; \
-		fi
+		  $(AR) $(ARFLAGS) $@ $$(find '$(CARGO_TARGET_DIR)/libyjit/' -name '*.o') ;
 		@-$(RANLIB) $@ 2> /dev/null || true
 
 verify-static-library: $(LIBRUBY_A)


### PR DESCRIPTION
The shell in Solaris 10 has trouble understanding the syntax I used in
YJIT's library merging script.

This commit reduces the code the shell needs to parse before exiting on
non-YJIT builds to hopefully fix the error on Solaris.