### PR TITLE
YJIT: Enable default rustc lints (warnings)

### DIFF
--- a/yjit/src/asm/x86_64/mod.rs
+++ b/yjit/src/asm/x86_64/mod.rs
@@ -1,5 +1,5 @@
-use std::io::{Result, Write};
-use std::mem;
+#![allow(dead_code)] // For instructions we don't currently generate
+
 use crate::asm::*;
 
 // Import the assembler tests module

--- a/yjit/src/asm/x86_64/tests.rs
+++ b/yjit/src/asm/x86_64/tests.rs
@@ -7,7 +7,7 @@ use std::fmt;
 impl<'a> fmt::LowerHex for super::CodeBlock {
     fn fmt(&self, fmtr: &mut fmt::Formatter) -> fmt::Result {
         for pos in 0..self.write_pos {
-            let byte = self.read_byte(pos);
+            let byte = unsafe { self.mem_block.add(pos).read() };
             fmtr.write_fmt(format_args!("{:02x}", byte))?;
         }
         Ok(())

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -28,7 +28,7 @@ pub const REG0: X86Opnd = RAX;
 pub const REG0_32: X86Opnd = EAX;
 pub const REG0_8: X86Opnd = AL;
 pub const REG1: X86Opnd = RCX;
-pub const REG1_32: X86Opnd = ECX;
+// pub const REG1_32: X86Opnd = ECX;
 
 /// Status returned by code generation functions
 #[derive(PartialEq, Debug)]
@@ -106,10 +106,6 @@ impl JITState {
         self.opcode
     }
 
-    pub fn set_opcode(self: &mut JITState, opcode: usize) {
-        self.opcode = opcode;
-    }
-
     pub fn add_gc_object_offset(self: &mut JITState, ptr_offset: u32) {
         let mut gc_obj_vec: RefMut<_> = self.block.borrow_mut();
         gc_obj_vec.add_gc_object_offset(ptr_offset);
@@ -118,15 +114,11 @@ impl JITState {
     pub fn get_pc(self: &JITState) -> *mut VALUE {
         self.pc
     }
-
-    pub fn set_pc(self: &mut JITState, pc: *mut VALUE) {
-        self.pc = pc;
-    }
 }
 
 use crate::codegen::JCCKinds::*;
 
-#[allow(non_camel_case_types)]
+#[allow(non_camel_case_types, unused)]
 pub enum JCCKinds {
     JCC_JNE,
     JCC_JNZ,
@@ -749,8 +741,7 @@ pub fn gen_single_block(
         }
 
         // In debug mode, verify our existing assumption
-        #[cfg(debug_assertions)]
-        if get_option!(verify_ctx) && jit_at_current_insn(&jit) {
+        if cfg!(debug_assertions) && get_option!(verify_ctx) && jit_at_current_insn(&jit) {
             verify_ctx(&jit, &ctx);
         }
 
@@ -6007,7 +5998,7 @@ mod tests {
 
         let mut value_array: [u64; 2] = [0, 2]; // We only compile for n == 2
         let pc: *mut VALUE = &mut value_array as *mut u64 as *mut VALUE;
-        jit.set_pc(pc);
+        jit.pc = pc;
 
         let status = gen_dupn(&mut jit, &mut context, &mut cb, &mut ocb);
 
@@ -6056,7 +6047,7 @@ mod tests {
 
         let mut value_array: [u64; 2] = [0, Qtrue.into()];
         let pc: *mut VALUE = &mut value_array as *mut u64 as *mut VALUE;
-        jit.set_pc(pc);
+        jit.pc = pc;
 
         let status = gen_putobject(&mut jit, &mut context, &mut cb, &mut ocb);
 
@@ -6075,7 +6066,7 @@ mod tests {
         // The Fixnum 7 is encoded as 7 * 2 + 1, or 15
         let mut value_array: [u64; 2] = [0, 15];
         let pc: *mut VALUE = &mut value_array as *mut u64 as *mut VALUE;
-        jit.set_pc(pc);
+        jit.pc = pc;
 
         let status = gen_putobject(&mut jit, &mut context, &mut cb, &mut ocb);
 
@@ -6117,7 +6108,7 @@ mod tests {
 
         let mut value_array: [u64; 2] = [0, 2];
         let pc: *mut VALUE = &mut value_array as *mut u64 as *mut VALUE;
-        jit.set_pc(pc);
+        jit.pc = pc;
 
         let status = gen_setn(&mut jit, &mut context, &mut cb, &mut ocb);
 
@@ -6138,7 +6129,7 @@ mod tests {
 
         let mut value_array: [u64; 2] = [0, 1];
         let pc: *mut VALUE = &mut value_array as *mut u64 as *mut VALUE;
-        jit.set_pc(pc);
+        jit.pc = pc;
 
         let status = gen_topn(&mut jit, &mut context, &mut cb, &mut ocb);
 
@@ -6160,7 +6151,7 @@ mod tests {
 
         let mut value_array: [u64; 3] = [0, 2, 0];
         let pc: *mut VALUE = &mut value_array as *mut u64 as *mut VALUE;
-        jit.set_pc(pc);
+        jit.pc = pc;
 
         let status = gen_adjuststack(&mut jit, &mut context, &mut cb, &mut ocb);
 

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -10,8 +10,7 @@ use std::cell::*;
 use std::hash::{Hash, Hasher};
 use std::mem;
 use std::mem::size_of;
-use std::ptr;
-use std::rc::{Rc, Weak};
+use std::rc::{Rc};
 use InsnOpnd::*;
 use TempMapping::*;
 
@@ -35,7 +34,10 @@ pub enum Type {
     Array,
     Hash,
     ImmSymbol,
+
+    #[allow(unused)]
     HeapSymbol,
+
     String,
 }
 
@@ -242,6 +244,7 @@ struct Branch {
     end_addr: Option<CodePtr>,
 
     // Context right after the branch instruction
+    #[allow(unused)] // set but not read at the moment
     src_ctx: Context,
 
     // Branch target blocks and their contexts
@@ -416,7 +419,6 @@ pub unsafe fn load_iseq_payload(iseq: IseqPtr) -> Option<&'static mut IseqPayloa
 
 /// Get the payload object associated with an iseq. Create one if none exists.
 fn get_iseq_payload(iseq: IseqPtr) -> &'static mut IseqPayload {
-    use core::ffi::c_void;
     type VoidPtr = *mut c_void;
 
     let payload_non_null = unsafe {
@@ -799,10 +801,12 @@ impl Block {
         self.ctx
     }
 
+    #[allow(unused)]
     pub fn get_start_addr(&self) -> Option<CodePtr> {
         self.start_addr
     }
 
+    #[allow(unused)]
     pub fn get_end_addr(&self) -> Option<CodePtr> {
         self.end_addr
     }
@@ -1018,11 +1022,7 @@ impl Context {
 
     /// Get the currently tracked type for a local variable
     pub fn get_local_type(&self, idx: usize) -> Type {
-        if idx > MAX_LOCAL_TYPES {
-            return Type::Unknown;
-        }
-
-        return self.local_types[idx];
+        *self.local_types.get(idx).unwrap_or(&Type::Unknown)
     }
 
     /// Upgrade (or "learn") the type of an instruction operand
@@ -1251,6 +1251,7 @@ impl Context {
 impl BlockId {
     /// Print Ruby source location for debugging
     #[cfg(debug_assertions)]
+    #[allow(dead_code)]
     pub fn dump_src_loc(&self) {
         unsafe { rb_yjit_dump_iseq_loc(self.iseq, self.idx) }
     }

--- a/yjit/src/disasm.rs
+++ b/yjit/src/disasm.rs
@@ -1,9 +1,6 @@
-use crate::asm::*;
-use crate::codegen::*;
 use crate::core::*;
 use crate::cruby::*;
 use crate::yjit::yjit_enabled_p;
-use std::fmt::Write;
 
 /// Primitive called in yjit.rb
 /// Produce a string representing the disassembly for an ISEQ
@@ -43,7 +40,7 @@ fn disasm_iseq(iseq: IseqPtr) -> String {
     let mut block_list = get_iseq_block_list(iseq);
 
     // Get a list of codeblocks relevant to this iseq
-    let global_cb = CodegenGlobals::get_inline_cb();
+    let global_cb = crate::codegen::CodegenGlobals::get_inline_cb();
 
     // Sort the blocks by increasing start addresses
     block_list.sort_by(|a, b| {

--- a/yjit/src/lib.rs
+++ b/yjit/src/lib.rs
@@ -1,9 +1,3 @@
-// Silence dead code warnings until we are done porting YJIT
-#![allow(unused_imports)]
-#![allow(dead_code)]
-#![allow(unused_assignments)]
-#![allow(unused_macros)]
-
 // Clippy disagreements
 #![allow(clippy::style)] // We are laid back about style
 #![allow(clippy::too_many_arguments)] // :shrug:

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -1,6 +1,8 @@
 //! Everything related to the collection of runtime stats in YJIT
 //! See the stats feature and the --yjit-stats command-line option
 
+#![allow(dead_code)] // Counters are only used with the stats features
+
 use crate::codegen::CodegenGlobals;
 use crate::cruby::*;
 use crate::options::*;
@@ -12,17 +14,17 @@ static mut EXIT_OP_COUNT: [u64; VM_INSTRUCTION_SIZE] = [0; VM_INSTRUCTION_SIZE];
 // Macro to declare the stat counters
 macro_rules! make_counters {
     ($($counter_name:ident,)+) => {
-        // Struct containing the counter values
+        /// Struct containing the counter values
         #[derive(Default, Debug)]
         pub struct Counters { $(pub $counter_name: u64),+ }
 
-        // Global counters instance, initialized to zero
+        /// Global counters instance, initialized to zero
         pub static mut COUNTERS: Counters = Counters { $($counter_name: 0),+ };
 
-        // Counter names constant
+        /// Counter names constant
         const COUNTER_NAMES: &'static [&'static str] = &[ $(stringify!($counter_name)),+ ];
 
-        // Map a counter name string to a counter pointer
+        /// Map a counter name string to a counter pointer
         fn get_counter_ptr(name: &str) -> *mut u64 {
             match name {
                 $( stringify!($counter_name) => { ptr_to_counter!($counter_name) } ),+

--- a/yjit/src/yjit.rs
+++ b/yjit/src/yjit.rs
@@ -86,8 +86,7 @@ pub extern "C" fn rb_yjit_simulate_oom_bang(_ec: EcPtr, _ruby_self: VALUE) -> VA
     }
 
     // Enabled in debug mode only for security
-    #[cfg(debug_assertions)]
-    {
+    if cfg!(debug_assertions) {
         let cb = CodegenGlobals::get_inline_cb();
         let ocb = CodegenGlobals::get_outlined_cb().unwrap();
         cb.set_pos(cb.get_mem_size() - 1);


### PR DESCRIPTION
`rustc` performs in depth dead code analysis and issues warning
even for things like unused struct fields and unconstructed enum
variants. This was annoying for us during the port but hopefully
they are less of an issue now.

This patch enables all the unused warnings we disabled and address
all the warnings we previously ignored. Generally, the approach I've
taken is to use `cfg!` instead of using the `cfg` attribute and
to delete code where it makes sense. I've put `#[allow(unused)]`
on things we intentionally keep around for printf style debugging.