### PR TITLE
Using `is_ascii_string` to check encoding

### DIFF
--- a/file.c
+++ b/file.c
@@ -4001,7 +4001,7 @@ rb_file_expand_path_internal(VALUE fname, VALUE dname, int abs_mode, int long_na
 	rb_str_set_len(result, p - buf + strlen(p));
 	encidx = ENCODING_GET(result);
 	tmp = result;
-	if (encidx != ENCINDEX_UTF_8 && rb_enc_str_coderange(result) != ENC_CODERANGE_7BIT) {
+	if (encidx != ENCINDEX_UTF_8 && !is_ascii_string(result)) {
 	    tmp = rb_str_encode_ospath(result);
 	}
 	len = MultiByteToWideChar(CP_UTF8, 0, RSTRING_PTR(tmp), -1, NULL, 0);

--- a/io.c
+++ b/io.c
@@ -3830,7 +3830,7 @@ check_getline_args(VALUE *rsp, long *limit, VALUE io)
 	enc_rs = rb_enc_get(rs);
 	enc_io = io_read_encoding(fptr);
 	if (enc_io != enc_rs &&
-	    (rb_enc_str_coderange(rs) != ENC_CODERANGE_7BIT ||
+	    (!is_ascii_string(rs) ||
 	     (RSTRING_LEN(rs) > 0 && !rb_enc_asciicompat(enc_io)))) {
             if (rs == rb_default_rs) {
                 rs = rb_enc_str_new(0, 0, enc_io);

--- a/marshal.c
+++ b/marshal.c
@@ -481,7 +481,7 @@ w_symbol(VALUE sym, struct dump_arg *arg)
 	}
 	encname = encoding_name(sym, arg);
 	if (NIL_P(encname) ||
-	    rb_enc_str_coderange(sym) == ENC_CODERANGE_7BIT) {
+	    is_ascii_string(sym)) {
 	    encname = Qnil;
 	}
 	else {

--- a/parse.y
+++ b/parse.y
@@ -6578,7 +6578,7 @@ parser_str_new(const char *ptr, long len, rb_encoding *enc, int func, rb_encodin
 
     str = rb_enc_str_new(ptr, len, enc);
     if (!(func & STR_FUNC_REGEXP) && rb_enc_asciicompat(enc)) {
-	if (rb_enc_str_coderange(str) == ENC_CODERANGE_7BIT) {
+	if (is_ascii_string(str)) {
 	}
 	else if (enc0 == rb_usascii_encoding() && enc != rb_utf8_encoding()) {
 	    rb_enc_associate(str, rb_ascii8bit_encoding());
@@ -12931,21 +12931,21 @@ rb_reg_fragment_setenc(struct parser_params* p, VALUE str, int options)
 	int opt, idx;
 	rb_char_to_option_kcode(c, &opt, &idx);
 	if (idx != ENCODING_GET(str) &&
-	    rb_enc_str_coderange(str) != ENC_CODERANGE_7BIT) {
+	    !is_ascii_string(str)) {
             goto error;
 	}
 	ENCODING_SET(str, idx);
     }
     else if (RE_OPTION_ENCODING_NONE(options)) {
         if (!ENCODING_IS_ASCII8BIT(str) &&
-            rb_enc_str_coderange(str) != ENC_CODERANGE_7BIT) {
+            !is_ascii_string(str)) {
             c = 'n';
             goto error;
         }
 	rb_enc_associate(str, rb_ascii8bit_encoding());
     }
     else if (p->enc == rb_usascii_encoding()) {
-	if (rb_enc_str_coderange(str) != ENC_CODERANGE_7BIT) {
+	if (!is_ascii_string(str)) {
 	    /* raise in re.c */
 	    rb_enc_associate(str, rb_usascii_encoding());
 	}

--- a/string.c
+++ b/string.c
@@ -792,7 +792,7 @@ rb_enc_str_asciionly_p(VALUE str)
 
     if (!rb_enc_asciicompat(enc))
         return FALSE;
-    else if (rb_enc_str_coderange(str) == ENC_CODERANGE_7BIT)
+    else if (is_ascii_string(str))
         return TRUE;
     return FALSE;
 }
@@ -1212,7 +1212,7 @@ rb_external_str_with_enc(VALUE str, rb_encoding *eenc)
 {
     int eidx = rb_enc_to_index(eenc);
     if (eidx == rb_usascii_encindex() &&
-	rb_enc_str_coderange(str) != ENC_CODERANGE_7BIT) {
+	!is_ascii_string(str)) {
 	rb_enc_associate_index(str, rb_ascii8bit_encindex());
 	return str;
     }
@@ -3458,7 +3458,7 @@ st_index_t
 rb_str_hash(VALUE str)
 {
     int e = ENCODING_GET(str);
-    if (e && rb_enc_str_coderange(str) == ENC_CODERANGE_7BIT) {
+    if (e && is_ascii_string(str)) {
 	e = 0;
     }
     return rb_memhash((const void *)RSTRING_PTR(str), RSTRING_LEN(str)) ^ e;

--- a/transcode.c
+++ b/transcode.c
@@ -2721,7 +2721,7 @@ str_transcode0(int argc, VALUE *argv, VALUE *self, int ecflags, VALUE ecopts)
             return NIL_P(arg2) ? -1 : dencidx;
         }
         if (senc && denc && rb_enc_asciicompat(senc) && rb_enc_asciicompat(denc)) {
-            if (rb_enc_str_coderange(str) == ENC_CODERANGE_7BIT) {
+            if (is_ascii_string(str)) {
                 return dencidx;
             }
         }


### PR DESCRIPTION
Some code has this code to check encoding is ascii.

```c
rb_enc_str_coderange(result) != ENC_CODERANGE_7BIT
```

But, already implemented `is_ascii_string` function that check ascii encoding in `internal/string.h`.

```c
static inline bool
is_ascii_string(VALUE str)
{
    return rb_enc_str_coderange(str) == ENC_CODERANGE_7BIT;
}
```

I thought better to these check code replace and using `is_ascii_string` function.

And, #5554 add build dependence but that was unneeded.
So, I recreate pull request.