### PR TITLE
Include JIT information in crash reports

### DIFF
--- a/error.c
+++ b/error.c
@@ -82,7 +82,7 @@ static struct {
     st_table *id2enum, *enum2id;
 } warning_categories;
 
-extern const char ruby_description[];
+extern const char *rb_dynamic_description;
 
 static const char *
 rb_strerrno(int err)
@@ -730,7 +730,7 @@ bug_report_begin_valist(FILE *out, const char *fmt, va_list args)
     fputs("[BUG] ", out);
     vsnprintf(buf, sizeof(buf), fmt, args);
     fputs(buf, out);
-    snprintf(buf, sizeof(buf), "\n%s\n\n", ruby_description);
+    snprintf(buf, sizeof(buf), "\n%s\n\n", rb_dynamic_description);
     fputs(buf, out);
     preface_dump(out);
 }
@@ -866,7 +866,7 @@ rb_async_bug_errno(const char *mesg, int errno_arg)
 	write_or_abort(2, errno_str, strlen(errno_str));
     }
     WRITE_CONST(2, "\n\n");
-    write_or_abort(2, ruby_description, strlen(ruby_description));
+    write_or_abort(2, rb_dynamic_description, strlen(rb_dynamic_description));
     abort();
 }
 
@@ -882,7 +882,7 @@ rb_assert_failure(const char *file, int line, const char *name, const char *expr
     FILE *out = stderr;
     fprintf(out, "Assertion Failed: %s:%d:", file, line);
     if (name) fprintf(out, "%s:", name);
-    fprintf(out, "%s\n%s\n\n", expr, ruby_description);
+    fprintf(out, "%s\n%s\n\n", expr, rb_dynamic_description);
     preface_dump(out);
     rb_vm_bugreport(NULL);
     bug_report_end(out);

--- a/include/ruby/version.h
+++ b/include/ruby/version.h
@@ -137,7 +137,8 @@ RUBY_EXTERN const int  ruby_patchlevel;
 
 /**
  * This is what `ruby -v` prints to the standard error.  Something like:
- * `"ruby 2.5.9p229 (2021-04-05 revision 67829) [x86_64-linux]"`
+ * `"ruby 2.5.9p229 (2021-04-05 revision 67829) [x86_64-linux]"`. This doesn't
+ * include runtime options like a JIT being enabled.
  */
 RUBY_EXTERN const char ruby_description[];
 

--- a/ruby.c
+++ b/ruby.c
@@ -1826,10 +1826,11 @@ process_options(int argc, char **argv, ruby_cmdline_options_t *opt)
         rb_yjit_init();
 #endif
     }
-    if (opt->dump & (DUMP_BIT(version) | DUMP_BIT(version_v))) {
 #if USE_MJIT
-        mjit_opts.on = opt->mjit.on; /* used by ruby_show_version(). mjit_init() still can't be called here. */
+    mjit_opts.on = opt->mjit.on; /* used by Init_ruby_description(). mjit_init() still can't be called here. */
 #endif
+    Init_ruby_description();
+    if (opt->dump & (DUMP_BIT(version) | DUMP_BIT(version_v))) {
 	ruby_show_version();
 	if (opt->dump & DUMP_BIT(version)) return Qtrue;
     }
@@ -1888,7 +1889,6 @@ process_options(int argc, char **argv, ruby_cmdline_options_t *opt)
         mjit_init(&opt->mjit);
 #endif
 
-    Init_ruby_description();
     Init_enc();
     lenc = rb_locale_encoding();
     rb_enc_associate(rb_progname, lenc);

--- a/test/-ext-/bug_reporter/test_bug_reporter.rb
+++ b/test/-ext-/bug_reporter/test_bug_reporter.rb
@@ -7,8 +7,6 @@ class TestBugReporter < Test::Unit::TestCase
     omit if ENV['RUBY_ON_BUG']
 
     description = RUBY_DESCRIPTION
-    description = description.sub(/\+MJIT /, '') if defined?(RubyVM::MJIT) && RubyVM::MJIT.enabled?
-    description = description.sub(/\+YJIT /, '') if defined?(RubyVM::YJIT.enabled?) && RubyVM::YJIT.enabled?
     expected_stderr = [
       :*,
       /\[BUG\]\sSegmentation\sfault.*\n/,

--- a/test/ruby/test_rubyoptions.rb
+++ b/test/ruby/test_rubyoptions.rb
@@ -740,7 +740,7 @@ class TestRubyOptions < Test::Unit::TestCase
         -e:(?:1:)?\s\[BUG\]\sSegmentation\sfault.*\n
       )x,
       %r(
-        #{ Regexp.quote(NO_JIT_DESCRIPTION) }\n\n
+        #{ Regexp.quote(RUBY_DESCRIPTION) }\n\n
       )x,
       %r(
         (?:--\s(?:.+\n)*\n)?

--- a/version.c
+++ b/version.c
@@ -47,6 +47,9 @@ static const char ruby_description_with_yjit[] = RUBY_DESCRIPTION_WITH(" +YJIT")
 const char ruby_copyright[] = RUBY_COPYRIGHT;
 const char ruby_engine[] = "ruby";
 
+// Might change after initialization
+const char *rb_dynamic_description = ruby_description;
+
 /*! Defines platform-depended Ruby-level constants */
 void
 Init_version(void)
@@ -104,9 +107,11 @@ Init_ruby_description(void)
     VALUE description;
 
     if (MJIT_OPTS_ON) {
+        rb_dynamic_description = ruby_description_with_mjit;
         description = MKSTR(description_with_mjit);
     }
     else if (rb_yjit_enabled_p()) {
+        rb_dynamic_description = ruby_description_with_yjit;
         description = MKSTR(description_with_yjit);
     }
     else {
@@ -122,15 +127,7 @@ Init_ruby_description(void)
 void
 ruby_show_version(void)
 {
-    if (MJIT_OPTS_ON) {
-        PRINT(description_with_mjit);
-    }
-    else if (rb_yjit_enabled_p()) {
-        PRINT(description_with_yjit);
-    }
-    else {
-        PRINT(description);
-    }
+    puts(rb_dynamic_description);
 
 #ifdef RUBY_LAST_COMMIT_TITLE
     fputs("last_commit=" RUBY_LAST_COMMIT_TITLE, stdout);


### PR DESCRIPTION
Issues fixed by this PR:

* logic was duplicated
* users in `error.c` weren't getting the JIT information
* the macro was (accidentally?) exposed in the header

I'm not intending to expose `rb_description()` as new public API - have I written the header correctly therefore?

Was the macro `RUBY_DESCRIPTION_WITH` previously public API? Why and should I keep it as public?

Motivation for this change is adding more option flags in the description string, such as which GC is in use.