### PR TITLE
mkmf: Add a configure option to set verbose mode (V=1 or 0) in mkmf.rb.

### DIFF
--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -130,6 +130,7 @@ jobs:
           - { key: append_configure, name: 'coroutine=pthread',  value: '--with-coroutine=pthread' }
           - { key: append_configure, name: disable-jit-support,  value: '--disable-jit-support' }
           - { key: append_configure, name: disable-dln,          value: '--disable-dln' }
+          - { key: append_configure, name: enable-mkmf-verbose,  value: '--enable-mkmf-verbose' }
           - { key: append_configure, name: disable-rubygems,     value: '--disable-rubygems' }
 
           - { key: cppflags, name: OPT_THREADED_CODE=1,            value: '-DOPT_THREADED_CODE=1' }

--- a/configure.ac
+++ b/configure.ac
@@ -4266,6 +4266,13 @@ AS_IF([test -z "$MANTYPE"], [
 ])
 AC_SUBST(MANTYPE)
 
+MKMF_VERBOSE=0
+AC_ARG_ENABLE(mkmf-verbose,
+    AS_HELP_STRING([--enable-mkmf-verbose], [enable verbose in mkmf]),
+    [MKMF_VERBOSE=1],
+    [MKMF_VERBOSE=0])
+AC_SUBST(MKMF_VERBOSE)
+
 AC_ARG_ENABLE(rubygems,
 	AS_HELP_STRING([--disable-rubygems], [disable rubygems by default]),
 	[enable_rubygems="$enableval"], [enable_rubygems=yes])

--- a/lib/mkmf.rb
+++ b/lib/mkmf.rb
@@ -1964,13 +1964,14 @@ SRC
 
   def configuration(srcdir)
     mk = []
+    CONFIG['MKMF_VERBOSE'] ||= "0"
     vpath = $VPATH.dup
     CONFIG["hdrdir"] ||= $hdrdir
     mk << %{
 SHELL = /bin/sh
 
 # V=0 quiet, V=1 verbose.  other values don't work.
-V = 0
+V = #{CONFIG['MKMF_VERBOSE']}
 V0 = $(V:0=)
 Q1 = $(V:1=)
 Q = $(Q1:0=@)


### PR DESCRIPTION
Related to <https://bugs.ruby-lang.org/issues/18691>.

This PR is to configure the value of `V` in `mkmf.rb` by `configure` script. The benefit of this change is that we can check the compiling command such as `gcc <flags>` instead of text `compiling ...` when compiling a native extension. What do you think? Actually in Fedora Ruby RPM package, we have managed [this patch](https://src.fedoraproject.org/rpms/ruby/blob/rawhide/f/ruby-1.9.3-mkmf-verbose.patch) for years. And I wanted to contribute this to the Ruby project.

---

```
$ ./configure --help | grep mkmf
  --enable-mkmf-verbose   enable verbose in mkmf
```

Run the following command to enable the mkmf verbose mode.

```
$ ./configure --enable-mkmf-verbose
$ grep MKMF_VERBOSE config.status
S["MKMF_VERBOSE"]="1"
```

In this mkmf verbose mode, when compiling a native extension, the
`rake compile` prints the compiling commands such as
"gcc -I. <...> path/to/file" instead of "compiling path/to/file".

```
$ git clone https://github.com/deivid-rodriguez/byebug.git
$ cd byebug
$ bundle install --standalone
$ bundle exec rake compile
...
gcc -I. <...> path/to/file
...
```

---

Here is the actual difference between `mkmf.rb` `V=0` and `V=1` when running `rake compile` above.

```
$ diff -u rake_compile_mkmf_v0.log rake_compile_mkmf_v1.log 
--- rake_compile_mkmf_v0.log	2022-05-03 19:59:26.520003950 +0200
+++ rake_compile_mkmf_v1.log	2022-05-03 19:58:26.721685861 +0200
@@ -7,8 +7,8 @@
 /bin/gmake
 cd -
 cd tmp/x86_64-linux/byebug/3.2.0
-compiling ../../../../ext/byebug/breakpoint.c
-compiling ../../../../ext/byebug/byebug.c
+gcc -I. -I/home/jaruga/var/git/ruby/ruby/dest/ruby/include/ruby-3.2.0+1/x86_64-linux -I/home/jaruga/var/git/ruby/ruby/dest/ruby/include/ruby-3.2.0+1/ruby/backward -I/home/jaruga/var/git/ruby/ruby/dest/ruby/include/ruby-3.2.0+1 -I../../../../ext/byebug   -fPIC -O3 -fno-fast-math -ggdb3 -Wall -Wextra -Wdeprecated-declarations -Wdiv-by-zero -Wduplicated-cond -Werror=implicit-function-declaration -Wimplicit-int -Wmisleading-indentation -Wpointer-arith -Wwrite-strings -Wold-style-definition -Wimplicit-fallthrough=0 -Wmissing-noreturn -Wno-cast-function-type -Wno-constant-logical-operand -Wno-long-long -Wno-missing-field-initializers -Wno-overlength-strings -Wno-packed-bitfield-compat -Wno-parentheses-equality -Wno-self-assign -Wno-tautological-compare -Wno-unused-parameter -Wno-unused-value -Wsuggest-attribute=format -Wsuggest-attribute=noreturn -Wunused-variable -Wundef  -o breakpoint.o -c ../../../../ext/byebug/breakpoint.c
+gcc -I. -I/home/jaruga/var/git/ruby/ruby/dest/ruby/include/ruby-3.2.0+1/x86_64-linux -I/home/jaruga/var/git/ruby/ruby/dest/ruby/include/ruby-3.2.0+1/ruby/backward -I/home/jaruga/var/git/ruby/ruby/dest/ruby/include/ruby-3.2.0+1 -I../../../../ext/byebug   -fPIC -O3 -fno-fast-math -ggdb3 -Wall -Wextra -Wdeprecated-declarations -Wdiv-by-zero -Wduplicated-cond -Werror=implicit-function-declaration -Wimplicit-int -Wmisleading-indentation -Wpointer-arith -Wwrite-strings -Wold-style-definition -Wimplicit-fallthrough=0 -Wmissing-noreturn -Wno-cast-function-type -Wno-constant-logical-operand -Wno-long-long -Wno-missing-field-initializers -Wno-overlength-strings -Wno-packed-bitfield-compat -Wno-parentheses-equality -Wno-self-assign -Wno-tautological-compare -Wno-unused-parameter -Wno-unused-value -Wsuggest-attribute=format -Wsuggest-attribute=noreturn -Wunused-variable -Wundef  -o byebug.o -c ../../../../ext/byebug/byebug.c
 ../../../../ext/byebug/byebug.c: In function ‘check_started’:
 ../../../../ext/byebug/byebug.c:69:1: warning: old-style function definition [-Wold-style-definition]
    69 | check_started()
@@ -21,8 +21,8 @@
 cc1: note: unrecognized command-line option ‘-Wno-self-assign’ may have been intended to silence earlier diagnostics
 cc1: note: unrecognized command-line option ‘-Wno-parentheses-equality’ may have been intended to silence earlier diagnostics
 cc1: note: unrecognized command-line option ‘-Wno-constant-logical-operand’ may have been intended to silence earlier diagnostics
-compiling ../../../../ext/byebug/context.c
-compiling ../../../../ext/byebug/locker.c
+gcc -I. -I/home/jaruga/var/git/ruby/ruby/dest/ruby/include/ruby-3.2.0+1/x86_64-linux -I/home/jaruga/var/git/ruby/ruby/dest/ruby/include/ruby-3.2.0+1/ruby/backward -I/home/jaruga/var/git/ruby/ruby/dest/ruby/include/ruby-3.2.0+1 -I../../../../ext/byebug   -fPIC -O3 -fno-fast-math -ggdb3 -Wall -Wextra -Wdeprecated-declarations -Wdiv-by-zero -Wduplicated-cond -Werror=implicit-function-declaration -Wimplicit-int -Wmisleading-indentation -Wpointer-arith -Wwrite-strings -Wold-style-definition -Wimplicit-fallthrough=0 -Wmissing-noreturn -Wno-cast-function-type -Wno-constant-logical-operand -Wno-long-long -Wno-missing-field-initializers -Wno-overlength-strings -Wno-packed-bitfield-compat -Wno-parentheses-equality -Wno-self-assign -Wno-tautological-compare -Wno-unused-parameter -Wno-unused-value -Wsuggest-attribute=format -Wsuggest-attribute=noreturn -Wunused-variable -Wundef  -o context.o -c ../../../../ext/byebug/context.c
+gcc -I. -I/home/jaruga/var/git/ruby/ruby/dest/ruby/include/ruby-3.2.0+1/x86_64-linux -I/home/jaruga/var/git/ruby/ruby/dest/ruby/include/ruby-3.2.0+1/ruby/backward -I/home/jaruga/var/git/ruby/ruby/dest/ruby/include/ruby-3.2.0+1 -I../../../../ext/byebug   -fPIC -O3 -fno-fast-math -ggdb3 -Wall -Wextra -Wdeprecated-declarations -Wdiv-by-zero -Wduplicated-cond -Werror=implicit-function-declaration -Wimplicit-int -Wmisleading-indentation -Wpointer-arith -Wwrite-strings -Wold-style-definition -Wimplicit-fallthrough=0 -Wmissing-noreturn -Wno-cast-function-type -Wno-constant-logical-operand -Wno-long-long -Wno-missing-field-initializers -Wno-overlength-strings -Wno-packed-bitfield-compat -Wno-parentheses-equality -Wno-self-assign -Wno-tautological-compare -Wno-unused-parameter -Wno-unused-value -Wsuggest-attribute=format -Wsuggest-attribute=noreturn -Wunused-variable -Wundef  -o locker.o -c ../../../../ext/byebug/locker.c
 ../../../../ext/byebug/locker.c: In function ‘byebug_pop_from_locked’:
 ../../../../ext/byebug/locker.c:53:1: warning: old-style function definition [-Wold-style-definition]
    53 | byebug_pop_from_locked()
@@ -31,8 +31,9 @@
 cc1: note: unrecognized command-line option ‘-Wno-self-assign’ may have been intended to silence earlier diagnostics
 cc1: note: unrecognized command-line option ‘-Wno-parentheses-equality’ may have been intended to silence earlier diagnostics
 cc1: note: unrecognized command-line option ‘-Wno-constant-logical-operand’ may have been intended to silence earlier diagnostics
-compiling ../../../../ext/byebug/threads.c
-linking shared-object byebug/byebug.so
+gcc -I. -I/home/jaruga/var/git/ruby/ruby/dest/ruby/include/ruby-3.2.0+1/x86_64-linux -I/home/jaruga/var/git/ruby/ruby/dest/ruby/include/ruby-3.2.0+1/ruby/backward -I/home/jaruga/var/git/ruby/ruby/dest/ruby/include/ruby-3.2.0+1 -I../../../../ext/byebug   -fPIC -O3 -fno-fast-math -ggdb3 -Wall -Wextra -Wdeprecated-declarations -Wdiv-by-zero -Wduplicated-cond -Werror=implicit-function-declaration -Wimplicit-int -Wmisleading-indentation -Wpointer-arith -Wwrite-strings -Wold-style-definition -Wimplicit-fallthrough=0 -Wmissing-noreturn -Wno-cast-function-type -Wno-constant-logical-operand -Wno-long-long -Wno-missing-field-initializers -Wno-overlength-strings -Wno-packed-bitfield-compat -Wno-parentheses-equality -Wno-self-assign -Wno-tautological-compare -Wno-unused-parameter -Wno-unused-value -Wsuggest-attribute=format -Wsuggest-attribute=noreturn -Wunused-variable -Wundef  -o threads.o -c ../../../../ext/byebug/threads.c
+rm -f byebug.so
+gcc -shared -o byebug.so breakpoint.o byebug.o context.o locker.o threads.o -L. -L/home/jaruga/var/git/ruby/ruby/dest/ruby/lib -Wl,-rpath,/home/jaruga/var/git/ruby/ruby/dest/ruby/lib -L. -fstack-protector-strong -rdynamic -Wl,-export-dynamic -Wl,--compress-debug-sections=zlib    -lm  -lc
 cd -
 mkdir -p tmp/x86_64-linux/stage/lib/byebug
 cp CHANGELOG.md tmp/x86_64-linux/stage/CHANGELOG.md
```

Here is a behavior without this option `--enable-mkmf-verbose`.

```
$ ./configure
$ grep MKMF_VERBOSE config.status
S["MKMF_VERBOSE"]="0"
```
