### PR TITLE
[YJIT] Implement getblockparam

### DIFF
--- a/test/ruby/test_yjit.rb
+++ b/test/ruby/test_yjit.rb
@@ -483,6 +483,32 @@ class TestYJIT < Test::Unit::TestCase
     RUBY
   end
 
+  def test_getblockparam
+    assert_compiles(<<~'RUBY', insns: [:getblockparam])
+      def foo &blk
+        2.times do
+          blk
+        end
+      end
+
+      foo {}
+      foo {}
+    RUBY
+  end
+
+  def test_getblockparamproxy
+    # Currently two side exits as OPTIMIZED_METHOD_TYPE_CALL is unimplemented
+    assert_compiles(<<~'RUBY', insns: [:getblockparamproxy], exits: { opt_send_without_block: 2 })
+      def foo &blk
+        p blk.call
+        p blk.call
+      end
+
+      foo { 1 }
+      foo { 2 }
+    RUBY
+  end
+
   def test_getivar_opt_plus
     assert_no_exits(<<~RUBY)
       class TheClass

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -210,6 +210,7 @@ fn main() {
         .opaque_type("rb_execution_context_.*")
         .blocklist_type("rb_control_frame_struct")
         .opaque_type("rb_control_frame_struct")
+        .allowlist_function("rb_vm_bh_to_procval")
 
         // From yjit.c
         .allowlist_function("rb_iseq_(get|set)_yjit_payload")

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -589,6 +589,9 @@ pub const VM_ENV_FLAG_WB_REQUIRED: vm_frame_env_flags = 8;
 pub const VM_ENV_FLAG_ISOLATED: vm_frame_env_flags = 16;
 pub type vm_frame_env_flags = u32;
 extern "C" {
+    pub fn rb_vm_bh_to_procval(ec: *const rb_execution_context_t, block_handler: VALUE) -> VALUE;
+}
+extern "C" {
     pub fn rb_vm_frame_method_entry(
         cfp: *const rb_control_frame_t,
     ) -> *const rb_callable_method_entry_t;


### PR DESCRIPTION
This implements the getblockparam instruction.

There are two cases we need to handle depending on whether or not
VM_FRAME_FLAG_MODIFIED_BLOCK_PARAM is set in the environment flag.

When the modified flag is unset, we need to call rb_vm_bh_to_procval to
get a proc from our passed block, save the proc in the environment, and
set the modified flag.

In the case that the modified flag is set we are able to just use the
existing proc in the environment.

One quirk of this is that we need to call jit_prepare_routine_call early
and ensure we update PC and SP regardless of the branch taken, so that
we have a consistent SP offset at the start of the next instruction.

We considered using a chain guard to generate these two paths
separately, but decided against it because it's very common to see both
and the modified case is basically a subset of the instructions in the
unmodified case.

This includes tests for both getblockparam and getblockparamproxy which
was previously missing a test.