### PR TITLE
Increase SIZE_POOL_COUNT to 5

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -5626,6 +5626,11 @@ gc_sweep_finish_size_pool(rb_objspace_t *objspace, rb_size_pool_t *size_pool)
     size_t swept_slots = size_pool->freed_slots + size_pool->empty_slots;
 
     size_t min_free_slots = (size_t)(total_slots * gc_params.heap_free_slots_min_ratio);
+    /* Some size pools may have very few pages (or even no pages). These size pools
+     * should still have allocatable pages. */
+    if (min_free_slots < gc_params.heap_init_slots) {
+        min_free_slots = gc_params.heap_init_slots;
+    }
 
     if (swept_slots < min_free_slots) {
         bool grow_heap = is_full_marking(objspace);

--- a/gc.c
+++ b/gc.c
@@ -5659,8 +5659,6 @@ gc_sweep_finish_size_pool(rb_objspace_t *objspace, rb_size_pool_t *size_pool)
             if (extend_page_count > size_pool->allocatable_pages) {
                 size_pool_allocatable_pages_set(objspace, size_pool, extend_page_count);
             }
-
-            heap_increment(objspace, size_pool, SIZE_POOL_EDEN_HEAP(size_pool));
         }
     }
 }

--- a/include/ruby/internal/core/rarray.h
+++ b/include/ruby/internal/core/rarray.h
@@ -131,7 +131,7 @@ enum ruby_rarray_flags {
      * store array elements.  It was a bad idea to expose this to them.
      */
 #if USE_RVARGC
-    RARRAY_EMBED_LEN_MASK  = RUBY_FL_USER8 | RUBY_FL_USER7 | RUBY_FL_USER6 |
+    RARRAY_EMBED_LEN_MASK  = RUBY_FL_USER9 | RUBY_FL_USER8 | RUBY_FL_USER7 | RUBY_FL_USER6 |
                                  RUBY_FL_USER5 | RUBY_FL_USER4 | RUBY_FL_USER3
 #else
     RARRAY_EMBED_LEN_MASK  = RUBY_FL_USER4 | RUBY_FL_USER3

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -68,7 +68,7 @@ struct rb_objspace; /* in vm_core.h */
                  (VALUE)(b), __FILE__, __LINE__)
 
 #if USE_RVARGC
-# define SIZE_POOL_COUNT 4
+# define SIZE_POOL_COUNT 5
 #else
 # define SIZE_POOL_COUNT 1
 #endif


### PR DESCRIPTION
Having more size pools will allow us to allocate larger objects
through Variable Width Allocation.

I have attached some benchmark results below.

Discourse:
  On Discourse, we don't see much change in response times. We do see
  a small reduction in RSS.

  Branch RSS: 377.8 MB
  Master RSS: 396.3 MB

railsbench:
  On railsbench, we don't see a big change in RPS or p99 performance.
  We see a small increase in RSS.

  Branch RPS: 815.38
  Master RPS: 811.73

  Branch p99: 1.69 ms
  Master p99: 1.68 ms

  Branch RSS: 90.6 MB
  Master RSS: 89.4 MB

liquid:
  We don't see a significant change in liquid performance.

  Branch parse & render: 29.041 I/s
  Master parse & render: 29.211 I/s