### PR TITLE
Support aarch64 in YJIT

### DIFF
--- a/yjit.h
+++ b/yjit.h
@@ -18,6 +18,8 @@
 // We generate x86 assembly
 #if (defined(__x86_64__) && !defined(_WIN32)) || (defined(_WIN32) && defined(_M_AMD64)) // x64 platforms without mingw/msys
 # define YJIT_SUPPORTED_P 1
+#elif defined(__arm64__) || defined(__aarch64__)
+# define YJIT_SUPPORTED_P 1
 #else
 # define YJIT_SUPPORTED_P 0
 #endif

--- a/yjit/src/asm/aarch64/mod.rs
+++ b/yjit/src/asm/aarch64/mod.rs
@@ -1,0 +1,550 @@
+use crate::asm::*;
+
+// Import the assembler tests module
+mod tests;
+
+#[derive(Clone, Copy, Debug)]
+pub struct Aarch64Imm
+{
+    // Size in bits
+    num_bits: u8,
+
+    // The value of the immediate
+    value: i64
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct Aarch64ImmShift
+{
+    // Size in bits
+    num_bits: u8,
+
+    // The value of the immediate
+    value: u32,
+
+    shift_type: ShiftType,
+
+    shift_num: u8
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct Aarch64UImm
+{
+    // Size in bits
+    num_bits: u8,
+
+    // The value of the immediate
+    value: u64
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RegType
+{
+    GP,
+    STACK,
+    //ZERO,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AddrType
+{
+    PostIdx = 1,
+    Offset = 2,
+    PreIdx = 3,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ShiftType
+{
+    LSL,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct Aarc64Reg
+{
+    // Size in bits
+    num_bits: u8,
+
+    // Register type
+    reg_type: RegType,
+
+    // Register index number
+    reg_no: u8,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct Aarc64Mem
+{
+    // Size in bits
+    num_bits: u8,
+
+    // Base register number
+    base_reg_no: u8,
+
+    // Addressing type
+    addressing: AddrType,
+
+    // Constant displacement from the base, not scaled
+    disp: i32,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum YJitOpnd
+{
+    // Immediate value
+    Imm(Aarch64Imm),
+
+    // Immediate value with shift
+    ImmShift(Aarch64ImmShift),
+
+    // General-purpose register
+    Reg(Aarc64Reg),
+
+    // Memory location
+    Mem(Aarc64Mem),
+}
+
+impl YJitOpnd {
+}
+
+pub const X0: YJitOpnd  = YJitOpnd::Reg(Aarc64Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 0 });
+pub const X1: YJitOpnd  = YJitOpnd::Reg(Aarc64Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 1 });
+// pub const X2: YJitOpnd  = YJitOpnd::Reg(Aarc64Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 2 });
+// pub const X3: YJitOpnd  = YJitOpnd::Reg(Aarc64Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 3 });
+// pub const X4: YJitOpnd  = YJitOpnd::Reg(Aarc64Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 4 });
+// pub const X5: YJitOpnd  = YJitOpnd::Reg(Aarc64Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 5 });
+// pub const X6: YJitOpnd  = YJitOpnd::Reg(Aarc64Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 6 });
+// pub const X7: YJitOpnd  = YJitOpnd::Reg(Aarc64Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 7 });
+// pub const X8: YJitOpnd  = YJitOpnd::Reg(Aarc64Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 8 });
+// pub const X9: YJitOpnd  = YJitOpnd::Reg(Aarc64Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 9 });
+// pub const X10: YJitOpnd  = YJitOpnd::Reg(Aarc64Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 10 });
+// pub const X11: YJitOpnd  = YJitOpnd::Reg(Aarc64Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 11 });
+// pub const X12: YJitOpnd  = YJitOpnd::Reg(Aarc64Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 12 });
+// pub const X13: YJitOpnd  = YJitOpnd::Reg(Aarc64Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 13 });
+// pub const X14: YJitOpnd  = YJitOpnd::Reg(Aarc64Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 14 });
+// pub const X15: YJitOpnd  = YJitOpnd::Reg(Aarc64Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 15 });
+// pub const X16: YJitOpnd  = YJitOpnd::Reg(Aarc64Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 16 });
+// pub const X17: YJitOpnd  = YJitOpnd::Reg(Aarc64Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 17 });
+// pub const X18: YJitOpnd  = YJitOpnd::Reg(Aarc64Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 18 });
+pub const X19: YJitOpnd  = YJitOpnd::Reg(Aarc64Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 19 });
+pub const X20: YJitOpnd  = YJitOpnd::Reg(Aarc64Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 20 });
+pub const X21: YJitOpnd  = YJitOpnd::Reg(Aarc64Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 21 });
+// pub const X22: YJitOpnd  = YJitOpnd::Reg(Aarc64Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 22 });
+// pub const X23: YJitOpnd  = YJitOpnd::Reg(Aarc64Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 23 });
+// pub const X24: YJitOpnd  = YJitOpnd::Reg(Aarc64Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 24 });
+// pub const X25: YJitOpnd  = YJitOpnd::Reg(Aarc64Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 25 });
+// pub const X26: YJitOpnd  = YJitOpnd::Reg(Aarc64Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 26 });
+// pub const X27: YJitOpnd  = YJitOpnd::Reg(Aarc64Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 27 });
+// pub const X28: YJitOpnd  = YJitOpnd::Reg(Aarc64Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 28 });
+pub const X29: YJitOpnd  = YJitOpnd::Reg(Aarc64Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 29 });
+pub const X30: YJitOpnd  = YJitOpnd::Reg(Aarc64Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 30 });
+
+pub const SP: YJitOpnd  = YJitOpnd::Reg(Aarc64Reg { num_bits: 64, reg_type: RegType::STACK, reg_no: 31 });
+// pub const XZR: YJitOpnd  = YJitOpnd::Reg(Aarc64Reg { num_bits: 64, reg_type: RegType::ZERO, reg_no: 31 });
+
+//===========================================================================
+
+/// Compute the number of bits needed to encode a signed value
+pub fn sig_imm_size(imm: i64) -> u8
+{
+    // Compute the smallest size this immediate fits in
+    if imm >= i8::MIN.into() && imm <= i8::MAX.into() {
+        return 8;
+    }
+    if imm >= i16::MIN.into() && imm <= i16::MAX.into() {
+        return 16;
+    }
+    if imm >= i32::MIN.into() && imm <= i32::MAX.into() {
+        return 32;
+    }
+
+    return 64;
+}
+
+/// Compute the number of bits needed to encode an unsigned value
+pub fn unsig_imm_size(imm: u64) -> u8
+{
+    // Compute the smallest size this immediate fits in
+    if imm <= u8::MAX.into() {
+        return 8;
+    }
+    else if imm <= u16::MAX.into() {
+        return 16;
+    }
+    else if imm <= u32::MAX.into() {
+        return 32;
+    }
+
+    return 64;
+}
+
+/// Shorthand for memory operand with base register and displacement
+pub fn mem_opnd(num_bits: u8, base_reg: YJitOpnd, disp: i32) -> YJitOpnd
+{
+    let base_reg = match base_reg {
+        YJitOpnd::Reg(reg) => reg,
+        _ => unreachable!()
+    };
+
+    YJitOpnd::Mem(
+        Aarc64Mem {
+            num_bits,
+            base_reg_no: base_reg.reg_no,
+            addressing: AddrType::Offset,
+            disp,
+        }
+    )
+}
+
+pub fn mem_pre_opnd(num_bits: u8, base_reg: YJitOpnd, disp: i32) -> YJitOpnd {
+    let base_reg = match base_reg {
+        YJitOpnd::Reg(reg) => reg,
+        _ => unreachable!()
+    };
+
+    YJitOpnd::Mem(
+        Aarc64Mem {
+            num_bits,
+            base_reg_no: base_reg.reg_no,
+            addressing: AddrType::PreIdx,
+            disp,
+        }
+    )
+}
+
+pub fn mem_post_opnd(num_bits: u8, base_reg: YJitOpnd, disp: i32) -> YJitOpnd {
+    let base_reg = match base_reg {
+        YJitOpnd::Reg(reg) => reg,
+        _ => unreachable!()
+    };
+
+    YJitOpnd::Mem(
+        Aarc64Mem {
+            num_bits,
+            base_reg_no: base_reg.reg_no,
+            addressing: AddrType::PostIdx,
+            disp,
+        }
+    )
+}
+
+pub fn imm_opnd(value: i64) -> YJitOpnd
+{
+    YJitOpnd::Imm(Aarch64Imm { num_bits: sig_imm_size(value), value })
+}
+
+pub fn imm_shift_opnd(value: u32, shift_type: ShiftType, shift_num: u8) -> YJitOpnd
+{
+    YJitOpnd::ImmShift(Aarch64ImmShift { num_bits: unsig_imm_size(value as u64), value, shift_type, shift_num })
+}
+
+// call - Call a pointer, encode with a 32-bit offset if possible
+#[allow(unused)]
+pub fn call_ptr(_cb: &mut CodeBlock, _scratch_opnd: YJitOpnd, _dst_ptr: *const u8) {
+    unreachable!();
+}
+
+pub fn gen_jump_ptr (_cb: &mut CodeBlock, _ptr: CodePtr) {
+    unreachable!();
+}
+
+// ldr - Data load operation
+pub fn ldr(cb: &mut CodeBlock, dst: YJitOpnd, src: YJitOpnd) {
+    let src = match src {
+        YJitOpnd::Mem(mem) => mem,
+        _ => unreachable!(),
+    };
+    let dst = match dst {
+        YJitOpnd::Reg(reg) => reg,
+        _ => unreachable!(),
+    };
+    assert!(dst.num_bits == 64);
+
+    if src.disp % 8 != 0 {
+        unreachable!("unimplemented: ldr with not 8 scaled offset");
+    }
+    if src.disp < 0 {
+        unreachable!("unimplemented: ldr with negative offset");
+    }
+    if src.addressing != AddrType::Offset {
+        unreachable!("unimplemented: ldr with not-offset addressing");
+    }
+
+    let disp = src.disp as u16;
+    let uimm12:u16 = disp >> 3;
+    // 31-24:  1 1 1 1 1 0 0 1
+    // 23-16:  0 1 u_i_m_m_m_m
+    // 15-08: _m_m_m_m_1_2 R_n
+    // 07-00: _n_n_n R_t_t_t_t
+    cb.write_bytes(&[
+      dst.reg_no | (src.base_reg_no & 0x7) << 5,
+      src.base_reg_no >> 3 | (uimm12 as u8 & 0x3f) << 2,
+      (uimm12 >> 6) as u8 | 0x40,
+      0xf9,
+    ]);
+}
+
+// str - Data store operation
+pub fn str(cb: &mut CodeBlock, src: YJitOpnd, dst: YJitOpnd) {
+    let src = match src {
+        YJitOpnd::Reg(reg) => reg,
+        _ => unreachable!(),
+    };
+    let dst = match dst {
+        YJitOpnd::Mem(mem) => mem,
+        _ => unreachable!(),
+    };
+    assert!(src.num_bits == 64);
+
+    if dst.disp % 8 != 0 {
+        unreachable!("unimplemented: str with not 8 scaled offset");
+    }
+    if dst.disp < 0 {
+        unreachable!("unimplemented: str with negative offset");
+    }
+    if dst.addressing != AddrType::Offset {
+        unreachable!("unimplemented: ldr with not-offset addressing");
+    }
+
+    let uimm12:u16 = (dst.disp >> 3) as u16;
+    // 31-24:  1 1 1 1 1 0 0 1
+    // 23-16:  0 0 u_i_m_m_m_m
+    // 15-08: _m_m_m_m_1_2 R_n
+    // 07-00: _n_n_n R_t_t_t_t
+    cb.write_bytes(&[
+      src.reg_no | (dst.base_reg_no & 0x7) << 5,
+      dst.base_reg_no >> 3 | ((uimm12 & 0x3f) as u8) << 2,
+      (uimm12 >> 6) as u8,
+      0xf9
+    ]);
+}
+
+// ldp - Data pair load operation
+pub fn ldp(cb: &mut CodeBlock, dst1: YJitOpnd, dst2: YJitOpnd, src: YJitOpnd)
+{
+    let dst1 = match dst1 {
+        YJitOpnd::Reg(reg) => reg,
+        _ => unreachable!()
+    };
+    let dst2 = match dst2 {
+        YJitOpnd::Reg(reg) => reg,
+        _ => unreachable!()
+    };
+    let src = match src {
+        YJitOpnd::Mem(mem) => mem,
+        _ => unreachable!()
+    };
+
+    let z:bool = dst1.num_bits == 64;
+    let imm7:u8 = (src.disp / (if z { 8 } else { 4 })) as u8 & 0x7f;
+
+    // bit     7 6 5 4 3 2 1 0
+    // 31-24:  z 0 1 0 1 0 A_d
+    // 23-16: _r 1 i_m_m_7_7_7
+    // 15-08: _7 R_t_2_2_2 R_n
+    // 07-00: _n_n_n R_t_1_1_1
+    cb.write_bytes(&[
+      dst1.reg_no | (src.base_reg_no & 0x7) << 5,
+      src.base_reg_no >> 3 | dst2.reg_no << 2 | (imm7 & 0x1) << 7,
+      imm7 >> 1 | 0x40 | (src.addressing as u8 & 0x1) << 7,
+      src.addressing as u8 >> 1 | (if z { 0xa8 } else { 0x28 })
+    ]);
+}
+
+// stp - Data pair store operation
+pub fn stp(cb: &mut CodeBlock, src1: YJitOpnd, src2: YJitOpnd, dst: YJitOpnd) {
+    let src1 = match src1 {
+        YJitOpnd::Reg(reg) => reg,
+        _ => unreachable!(),
+    };
+    let src2 = match src2 {
+        YJitOpnd::Reg(reg) => reg,
+        _ => unreachable!(),
+    };
+    let dst = match dst {
+        YJitOpnd::Mem(mem) => mem,
+        _ => unreachable!(),
+    };
+    assert!(src1.num_bits == src2.num_bits);
+    let z:bool = src1.num_bits == 64;
+    let imm7:u8 = (dst.disp / (if z { 8 } else { 4 })) as u8 & 0x7f;
+
+    // bit     7 6 5 4 3 2 1 0
+    // 31-24:  z 0 1 0 1 0 A_d
+    // 23-16: _r 0 i_m_m_7_7_7
+    // 15-08: _7 R_t_2_2_2 R_n
+    // 07-00: _n_n_n R_t_1_1_1
+    cb.write_bytes(&[
+        src1.reg_no | (dst.base_reg_no & 0x7) << 5,
+        dst.base_reg_no >> 3 | src2.reg_no << 2 | (imm7 & 0x1) << 7,
+        imm7 >> 1 | (dst.addressing as u8 & 0x1) << 7,
+        dst.addressing as u8 >> 1 | (if z { 0xa8 } else { 0x28 }),
+    ]);
+}
+
+// mov - Data move operation
+pub fn mov(cb: &mut CodeBlock, dst: YJitOpnd, src: YJitOpnd) {
+    let dst = match dst {
+        YJitOpnd::Reg(reg) => reg,
+        _ => unreachable!(),
+    };
+    let src = match src {
+        YJitOpnd::Reg(reg) => reg,
+        _ => unreachable!(),
+    };
+
+    let z: bool = dst.num_bits == 64;
+
+    //         7 6 5 4 3 2 1 0
+    // 31-24:  z 0 1 0 1 0 1 0
+    // 23-16:  0 0 0 R_m_m_m_m
+    // 15-08:  0 0_0 0 0 0 1 1
+    // 07-00:  1 1 1 R_d_d_d_d
+    cb.write_bytes(&[
+      dst.reg_no | 0xe0,
+      3,
+      src.reg_no,
+      if z { 0xaa } else { 0x2a }
+    ]);
+}
+
+pub fn movz(cb: &mut CodeBlock, dst: YJitOpnd, src: YJitOpnd) {
+    let dst = match dst {
+        YJitOpnd::Reg(reg) => reg,
+        _ => unreachable!()
+    };
+
+    let z: bool = dst.num_bits == 64;
+    let imm16:u16;
+    let lsl:u8;
+
+    match src {
+      YJitOpnd::Imm(imm) => {
+        lsl = 0;
+        imm16 = imm.value as u16;
+      },
+      YJitOpnd::ImmShift(imm_shift) => {
+        assert!(imm_shift.shift_type == ShiftType::LSL);
+        lsl = imm_shift.shift_num;
+        assert!(lsl == 0 || lsl == 16 || lsl == 32 || lsl == 48);
+        imm16 = imm_shift.value as u16;
+      },
+      _ => unreachable!(),
+    };
+
+    //         7 6 5 4 3 2 1 0
+    // 31-24:  z 1 0 1 0 0 1 0
+    // 23-16:  1 h_w i_m_m_m_m
+    // 15-08: _m_m_m_m_m_m_m_m
+    // 07-00: _m_1_6 R_d_d_d_d
+    cb.write_bytes(&[
+      dst.reg_no | (imm16 as u8 & 0x0007) << 5,
+      ((imm16 & 0x07f8) >> 3) as u8,
+      (imm16 >> 11) as u8 | lsl << 1 | 0x80,
+      if z { 0xd2 } else { 0x52 }
+    ]);
+}
+
+// movk - Data move with keep operation
+pub fn movk(cb: &mut CodeBlock, dst: YJitOpnd, src: YJitOpnd) {
+    let dst = match dst {
+        YJitOpnd::Reg(reg) => reg,
+        _ => unreachable!()
+    };
+
+    let z: bool = dst.num_bits == 64;
+    let imm16:u16;
+    let lsl:u8;
+
+    match src {
+      YJitOpnd::Imm(imm) => {
+        lsl = 0;
+        imm16 = imm.value as u16;
+      },
+      YJitOpnd::ImmShift(imm_shift) => {
+        assert!(imm_shift.shift_type == ShiftType::LSL);
+        lsl = imm_shift.shift_num;
+        assert!(lsl == 0 || lsl == 16 || lsl == 32 || lsl == 48);
+        imm16 = imm_shift.value as u16;
+      },
+      _ => unreachable!(),
+    };
+
+    //         7 6 5 4 3 2 1 0
+    // 31-24:  z 1 1 1 0 0 1 0
+    // 23-16:  1 h_w i_m_m_m_m
+    // 15-08: _m_m_m_m_m_m_m_m
+    // 07-00: _m_1_6 R_d_d_d_d
+    cb.write_bytes(&[
+        dst.reg_no | (imm16 as u8 & 0x0007) << 5,
+      ((imm16 & 0x07f8) >> 3) as u8,
+      (imm16 >> 11) as u8 | lsl << 1 | 0x80,
+      if z { 0xf2 } else { 0x72 }
+    ]);
+}
+
+pub fn mov_u64(cb: &mut CodeBlock, dst: YJitOpnd, src: u64) {
+    let mut imm = src;
+    movz(cb, dst, imm_opnd((imm & 0xffff) as i64));
+    imm = imm >> 16;
+    if imm == 0 { return; }
+    movk(cb, dst, imm_shift_opnd((imm & 0xffff) as u32, ShiftType::LSL, 16));
+    imm = imm >> 16;
+    if imm == 0 { return; }
+    movk(cb, dst, imm_shift_opnd((imm & 0xffff) as u32, ShiftType::LSL, 32));
+    imm = imm >> 16;
+    if imm == 0 { return; }
+    movk(cb, dst, imm_shift_opnd((imm & 0xffff) as u32, ShiftType::LSL, 48))
+}
+
+// ret - Return from call, popping only the return address
+pub fn ret(cb: &mut CodeBlock, reg: YJitOpnd) {
+    let reg = match reg {
+        YJitOpnd::Reg(r) => r,
+        _ => unreachable!()
+    };
+    cb.write_bytes(&[
+        (reg.reg_no & 0x7) << 5,
+        (reg.reg_no & 0x18) >> 3,
+        0x5f,
+        0xd6,
+    ]);
+}
+
+// add - Add operation
+pub fn add(cb: &mut CodeBlock, dst: YJitOpnd, src1: YJitOpnd, src2: YJitOpnd) {
+    let (dst, src1) = match (dst, src1) {
+        (YJitOpnd::Reg(reg1), YJitOpnd::Reg(reg2)) => (reg1, reg2),
+        (_, _) => unreachable!()
+    };
+
+    let z: bool = dst.num_bits == 64;
+    let imm12:u16;
+    let sh:u8;
+
+    match src2 {
+      YJitOpnd::Imm(imm) => {
+        sh = 0;
+        imm12 = imm.value as u16 & 0xfff;
+      },
+      YJitOpnd::ImmShift(imm_shift) => {
+        sh = imm_shift.shift_num / 12;
+        assert!(imm_shift.shift_type == ShiftType::LSL);
+        assert!(imm_shift.shift_num == 0 || imm_shift.shift_num == 12);
+        imm12 = imm_shift.value as u16;
+      },
+      _ => unreachable!(),
+    };
+
+    //         7 6 5 4 3 2 1 0
+    // 31-24:  z 0 0 1 0 0 0 1
+    // 23-16:  s_h i_m_m_m_m_m
+    // 15-08: _m_m_m_m_1_2 R_n
+    // 07-00: _n_n_n R_d_d_d_d
+    cb.write_bytes(&[
+      dst.reg_no | (src1.reg_no & 0x7) << 5,
+      src1.reg_no >> 3 | (imm12 as u8 & 0x3f) << 2,
+      (imm12 >> 6) as u8 | sh,
+      if z { 0x91 } else { 0x11 }
+    ]);
+}

--- a/yjit/src/asm/aarch64/tests.rs
+++ b/yjit/src/asm/aarch64/tests.rs
@@ -1,0 +1,79 @@
+#![cfg(test)]
+
+use crate::asm::aarch64::*;
+use std::fmt;
+
+/// Produce hex string output from the bytes in a code block
+impl<'a> fmt::LowerHex for super::CodeBlock {
+    fn fmt(&self, fmtr: &mut fmt::Formatter) -> fmt::Result {
+        for pos in 0..self.write_pos {
+            let byte = unsafe { self.mem_block.add(pos).read() };
+            fmtr.write_fmt(format_args!("{:02x}", byte))?;
+        }
+        Ok(())
+    }
+}
+
+/// Check that the bytes for an instruction sequence match a hex string
+fn check_bytes<R>(bytes: &str, run: R) where R: FnOnce(&mut super::CodeBlock) {
+    let mut cb = super::CodeBlock::new_dummy(4096);
+    run(&mut cb);
+    assert_eq!(format!("{:x}", cb), bytes);
+}
+
+#[test]
+fn test_add() {
+    check_bytes("73220091", |cb| add(cb, X19, X19, imm_opnd(8)));
+}
+
+#[test]
+fn test_ldp() {
+    check_bytes("fd7b41a9", |cb| ldp(cb, X29, X30, mem_opnd(     64, SP,  16)));
+    check_bytes("fd7bc1a9", |cb| ldp(cb, X29, X30, mem_pre_opnd( 64, SP,  16)));
+    check_bytes("fd7bc1a8", |cb| ldp(cb, X29, X30, mem_post_opnd(64, SP,  16)));
+    check_bytes("fd7b7fa9", |cb| ldp(cb, X29, X30, mem_opnd(     64, SP, -16)));
+}
+
+#[test]
+fn test_ldr() {
+    check_bytes("200440f9", |cb| ldr(cb, X0, mem_opnd(64, X1, 8)));
+}
+
+#[test]
+fn test_mov() {
+    check_bytes("e00301aa", |cb| mov(cb, X0, X1));
+}
+
+#[test]
+fn test_mov_u64() {
+    check_bytes("e0bd99d26035b1f2e0acc8f26024e0f2", |cb| mov_u64(cb, X0, 0x123456789abcdef));
+}
+
+#[test]
+fn test_movk() {
+    check_bytes("6035b1f2", |cb| movk(cb, X0, imm_shift_opnd(0x89ab, ShiftType::LSL, 16)));
+}
+
+#[test]
+fn test_movz() {
+    check_bytes("e0bd99d2", |cb| movz(cb, X0, imm_opnd(0xcdef)));
+}
+
+
+#[test]
+fn test_ret() {
+    check_bytes("c0035fd6", |cb| ret(cb, X30));
+}
+
+#[test]
+fn test_stp() {
+    check_bytes("fd7b3fa9", |cb| stp(cb, X29, X30, mem_opnd(     64, SP, -16)));
+    check_bytes("fd7bbfa9", |cb| stp(cb, X29, X30, mem_pre_opnd( 64, SP, -16)));
+    check_bytes("fd7bbfa8", |cb| stp(cb, X29, X30, mem_post_opnd(64, SP, -16)));
+    check_bytes("fd7b01a9", |cb| stp(cb, X29, X30, mem_opnd(     64, SP,  16)));
+}
+
+#[test]
+fn test_str() {
+    check_bytes("200400f9", |cb| str(cb, X0, mem_opnd(64, X1, 8)));
+}

--- a/yjit/src/asm/mod.rs
+++ b/yjit/src/asm/mod.rs
@@ -9,6 +9,10 @@ use std::collections::BTreeMap;
 pub mod x86_64;
 #[cfg(target_arch = "x86_64")]
 pub use x86_64::*;
+#[cfg(target_arch = "aarch64")]
+pub mod aarch64;
+#[cfg(target_arch = "aarch64")]
+pub use aarch64::*;
 
 /// Pointer to a piece of machine code
 /// We may later change this to wrap an u32

--- a/yjit/src/asm/mod.rs
+++ b/yjit/src/asm/mod.rs
@@ -5,7 +5,10 @@ use std::collections::BTreeMap;
 
 // Lots of manual vertical alignment in there that rustfmt doesn't handle well.
 #[rustfmt::skip]
+#[cfg(target_arch = "x86_64")]
 pub mod x86_64;
+#[cfg(target_arch = "x86_64")]
+pub use x86_64::*;
 
 /// Pointer to a piece of machine code
 /// We may later change this to wrap an u32

--- a/yjit/src/asm/x86_64/mod.rs
+++ b/yjit/src/asm/x86_64/mod.rs
@@ -67,7 +67,7 @@ pub struct X86Mem
 }
 
 #[derive(Clone, Copy, Debug)]
-pub enum X86Opnd
+pub enum YJitOpnd
 {
     // Dummy operand
     None,
@@ -88,22 +88,22 @@ pub enum X86Opnd
     IPRel(i32)
 }
 
-impl X86Opnd {
+impl YJitOpnd {
     fn rex_needed(&self) -> bool {
         match self {
-            X86Opnd::None => false,
-            X86Opnd::Imm(_) => false,
-            X86Opnd::UImm(_) => false,
-            X86Opnd::Reg(reg) => reg.reg_no > 7 || reg.num_bits == 8 && reg.reg_no >= 4,
-            X86Opnd::Mem(mem) => (mem.base_reg_no > 7 || (mem.idx_reg_no.unwrap_or(0) > 7)),
-            X86Opnd::IPRel(_) => false
+            YJitOpnd::None => false,
+            YJitOpnd::Imm(_) => false,
+            YJitOpnd::UImm(_) => false,
+            YJitOpnd::Reg(reg) => reg.reg_no > 7 || reg.num_bits == 8 && reg.reg_no >= 4,
+            YJitOpnd::Mem(mem) => (mem.base_reg_no > 7 || (mem.idx_reg_no.unwrap_or(0) > 7)),
+            YJitOpnd::IPRel(_) => false
         }
     }
 
     // Check if an SIB byte is needed to encode this operand
     fn sib_needed(&self) -> bool {
         match self {
-            X86Opnd::Mem(mem) => {
+            YJitOpnd::Mem(mem) => {
                 mem.idx_reg_no.is_some() ||
                 mem.base_reg_no == RSP_REG_NO ||
                 mem.base_reg_no == R12_REG_NO
@@ -114,8 +114,8 @@ impl X86Opnd {
 
     fn disp_size(&self) -> u32 {
         match self {
-            X86Opnd::IPRel(_) => 32,
-            X86Opnd::Mem(mem) => {
+            YJitOpnd::IPRel(_) => 32,
+            YJitOpnd::Mem(mem) => {
                 if mem.disp != 0 {
                     // Compute the required displacement size
                     let num_bits = sig_imm_size(mem.disp.into());
@@ -138,17 +138,17 @@ impl X86Opnd {
 
     pub fn num_bits(&self) -> u8 {
         match self {
-            X86Opnd::Reg(reg) => reg.num_bits,
-            X86Opnd::Imm(imm) => imm.num_bits,
-            X86Opnd::UImm(uimm) => uimm.num_bits,
-            X86Opnd::Mem(mem) => mem.num_bits,
+            YJitOpnd::Reg(reg) => reg.num_bits,
+            YJitOpnd::Imm(imm) => imm.num_bits,
+            YJitOpnd::UImm(uimm) => uimm.num_bits,
+            YJitOpnd::Mem(mem) => mem.num_bits,
             _ => unreachable!()
         }
     }
 }
 
 // Instruction pointer
-pub const RIP: X86Opnd = X86Opnd::Reg(X86Reg { num_bits: 64, reg_type: RegType::IP, reg_no: 5 });
+pub const RIP: YJitOpnd = YJitOpnd::Reg(X86Reg { num_bits: 64, reg_type: RegType::IP, reg_no: 5 });
 
 // 64-bit GP registers
 const RAX_REG_NO: u8 = 0;
@@ -157,79 +157,79 @@ const RBP_REG_NO: u8 = 5;
 const R12_REG_NO: u8 = 12;
 const R13_REG_NO: u8 = 13;
 
-pub const RAX: X86Opnd  = X86Opnd::Reg(X86Reg { num_bits: 64, reg_type: RegType::GP, reg_no: RAX_REG_NO });
-pub const RCX: X86Opnd  = X86Opnd::Reg(X86Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 1 });
-pub const RDX: X86Opnd  = X86Opnd::Reg(X86Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 2 });
-pub const RBX: X86Opnd  = X86Opnd::Reg(X86Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 3 });
-pub const RSP: X86Opnd  = X86Opnd::Reg(X86Reg { num_bits: 64, reg_type: RegType::GP, reg_no: RSP_REG_NO });
-pub const RBP: X86Opnd  = X86Opnd::Reg(X86Reg { num_bits: 64, reg_type: RegType::GP, reg_no: RBP_REG_NO });
-pub const RSI: X86Opnd  = X86Opnd::Reg(X86Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 6 });
-pub const RDI: X86Opnd  = X86Opnd::Reg(X86Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 7 });
-pub const R8:  X86Opnd  = X86Opnd::Reg(X86Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 8 });
-pub const R9:  X86Opnd  = X86Opnd::Reg(X86Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 9 });
-pub const R10: X86Opnd  = X86Opnd::Reg(X86Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 10 });
-pub const R11: X86Opnd  = X86Opnd::Reg(X86Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 11 });
-pub const R12: X86Opnd  = X86Opnd::Reg(X86Reg { num_bits: 64, reg_type: RegType::GP, reg_no: R12_REG_NO });
-pub const R13: X86Opnd  = X86Opnd::Reg(X86Reg { num_bits: 64, reg_type: RegType::GP, reg_no: R13_REG_NO });
-pub const R14: X86Opnd  = X86Opnd::Reg(X86Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 14 });
-pub const R15: X86Opnd  = X86Opnd::Reg(X86Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 15 });
+pub const RAX: YJitOpnd  = YJitOpnd::Reg(X86Reg { num_bits: 64, reg_type: RegType::GP, reg_no: RAX_REG_NO });
+pub const RCX: YJitOpnd  = YJitOpnd::Reg(X86Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 1 });
+pub const RDX: YJitOpnd  = YJitOpnd::Reg(X86Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 2 });
+pub const RBX: YJitOpnd  = YJitOpnd::Reg(X86Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 3 });
+pub const RSP: YJitOpnd  = YJitOpnd::Reg(X86Reg { num_bits: 64, reg_type: RegType::GP, reg_no: RSP_REG_NO });
+pub const RBP: YJitOpnd  = YJitOpnd::Reg(X86Reg { num_bits: 64, reg_type: RegType::GP, reg_no: RBP_REG_NO });
+pub const RSI: YJitOpnd  = YJitOpnd::Reg(X86Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 6 });
+pub const RDI: YJitOpnd  = YJitOpnd::Reg(X86Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 7 });
+pub const R8:  YJitOpnd  = YJitOpnd::Reg(X86Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 8 });
+pub const R9:  YJitOpnd  = YJitOpnd::Reg(X86Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 9 });
+pub const R10: YJitOpnd  = YJitOpnd::Reg(X86Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 10 });
+pub const R11: YJitOpnd  = YJitOpnd::Reg(X86Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 11 });
+pub const R12: YJitOpnd  = YJitOpnd::Reg(X86Reg { num_bits: 64, reg_type: RegType::GP, reg_no: R12_REG_NO });
+pub const R13: YJitOpnd  = YJitOpnd::Reg(X86Reg { num_bits: 64, reg_type: RegType::GP, reg_no: R13_REG_NO });
+pub const R14: YJitOpnd  = YJitOpnd::Reg(X86Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 14 });
+pub const R15: YJitOpnd  = YJitOpnd::Reg(X86Reg { num_bits: 64, reg_type: RegType::GP, reg_no: 15 });
 
 // 32-bit GP registers
-pub const EAX: X86Opnd  = X86Opnd::Reg(X86Reg { num_bits: 32, reg_type: RegType::GP, reg_no: 0 });
-pub const ECX: X86Opnd  = X86Opnd::Reg(X86Reg { num_bits: 32, reg_type: RegType::GP, reg_no: 1 });
-pub const EDX: X86Opnd  = X86Opnd::Reg(X86Reg { num_bits: 32, reg_type: RegType::GP, reg_no: 2 });
-pub const EBX: X86Opnd  = X86Opnd::Reg(X86Reg { num_bits: 32, reg_type: RegType::GP, reg_no: 3 });
-pub const ESP: X86Opnd  = X86Opnd::Reg(X86Reg { num_bits: 32, reg_type: RegType::GP, reg_no: 4 });
-pub const EBP: X86Opnd  = X86Opnd::Reg(X86Reg { num_bits: 32, reg_type: RegType::GP, reg_no: 5 });
-pub const ESI: X86Opnd  = X86Opnd::Reg(X86Reg { num_bits: 32, reg_type: RegType::GP, reg_no: 6 });
-pub const EDI: X86Opnd  = X86Opnd::Reg(X86Reg { num_bits: 32, reg_type: RegType::GP, reg_no: 7 });
-pub const R8D: X86Opnd  = X86Opnd::Reg(X86Reg { num_bits: 32, reg_type: RegType::GP, reg_no: 8 });
-pub const R9D: X86Opnd  = X86Opnd::Reg(X86Reg { num_bits: 32, reg_type: RegType::GP, reg_no: 9 });
-pub const R10D: X86Opnd = X86Opnd::Reg(X86Reg { num_bits: 32, reg_type: RegType::GP, reg_no: 10 });
-pub const R11D: X86Opnd = X86Opnd::Reg(X86Reg { num_bits: 32, reg_type: RegType::GP, reg_no: 11 });
-pub const R12D: X86Opnd = X86Opnd::Reg(X86Reg { num_bits: 32, reg_type: RegType::GP, reg_no: 12 });
-pub const R13D: X86Opnd = X86Opnd::Reg(X86Reg { num_bits: 32, reg_type: RegType::GP, reg_no: 13 });
-pub const R14D: X86Opnd = X86Opnd::Reg(X86Reg { num_bits: 32, reg_type: RegType::GP, reg_no: 14 });
-pub const R15D: X86Opnd = X86Opnd::Reg(X86Reg { num_bits: 32, reg_type: RegType::GP, reg_no: 15 });
+pub const EAX: YJitOpnd  = YJitOpnd::Reg(X86Reg { num_bits: 32, reg_type: RegType::GP, reg_no: 0 });
+pub const ECX: YJitOpnd  = YJitOpnd::Reg(X86Reg { num_bits: 32, reg_type: RegType::GP, reg_no: 1 });
+pub const EDX: YJitOpnd  = YJitOpnd::Reg(X86Reg { num_bits: 32, reg_type: RegType::GP, reg_no: 2 });
+pub const EBX: YJitOpnd  = YJitOpnd::Reg(X86Reg { num_bits: 32, reg_type: RegType::GP, reg_no: 3 });
+pub const ESP: YJitOpnd  = YJitOpnd::Reg(X86Reg { num_bits: 32, reg_type: RegType::GP, reg_no: 4 });
+pub const EBP: YJitOpnd  = YJitOpnd::Reg(X86Reg { num_bits: 32, reg_type: RegType::GP, reg_no: 5 });
+pub const ESI: YJitOpnd  = YJitOpnd::Reg(X86Reg { num_bits: 32, reg_type: RegType::GP, reg_no: 6 });
+pub const EDI: YJitOpnd  = YJitOpnd::Reg(X86Reg { num_bits: 32, reg_type: RegType::GP, reg_no: 7 });
+pub const R8D: YJitOpnd  = YJitOpnd::Reg(X86Reg { num_bits: 32, reg_type: RegType::GP, reg_no: 8 });
+pub const R9D: YJitOpnd  = YJitOpnd::Reg(X86Reg { num_bits: 32, reg_type: RegType::GP, reg_no: 9 });
+pub const R10D: YJitOpnd = YJitOpnd::Reg(X86Reg { num_bits: 32, reg_type: RegType::GP, reg_no: 10 });
+pub const R11D: YJitOpnd = YJitOpnd::Reg(X86Reg { num_bits: 32, reg_type: RegType::GP, reg_no: 11 });
+pub const R12D: YJitOpnd = YJitOpnd::Reg(X86Reg { num_bits: 32, reg_type: RegType::GP, reg_no: 12 });
+pub const R13D: YJitOpnd = YJitOpnd::Reg(X86Reg { num_bits: 32, reg_type: RegType::GP, reg_no: 13 });
+pub const R14D: YJitOpnd = YJitOpnd::Reg(X86Reg { num_bits: 32, reg_type: RegType::GP, reg_no: 14 });
+pub const R15D: YJitOpnd = YJitOpnd::Reg(X86Reg { num_bits: 32, reg_type: RegType::GP, reg_no: 15 });
 
 // 16-bit GP registers
-pub const AX:   X86Opnd = X86Opnd::Reg(X86Reg { num_bits: 16, reg_type: RegType::GP, reg_no: 0 });
-pub const CX:   X86Opnd = X86Opnd::Reg(X86Reg { num_bits: 16, reg_type: RegType::GP, reg_no: 1 });
-pub const DX:   X86Opnd = X86Opnd::Reg(X86Reg { num_bits: 16, reg_type: RegType::GP, reg_no: 2 });
-pub const BX:   X86Opnd = X86Opnd::Reg(X86Reg { num_bits: 16, reg_type: RegType::GP, reg_no: 3 });
-pub const SP:   X86Opnd = X86Opnd::Reg(X86Reg { num_bits: 16, reg_type: RegType::GP, reg_no: 4 });
-pub const BP:   X86Opnd = X86Opnd::Reg(X86Reg { num_bits: 16, reg_type: RegType::GP, reg_no: 5 });
-pub const SI:   X86Opnd = X86Opnd::Reg(X86Reg { num_bits: 16, reg_type: RegType::GP, reg_no: 6 });
-pub const DI:   X86Opnd = X86Opnd::Reg(X86Reg { num_bits: 16, reg_type: RegType::GP, reg_no: 7 });
-pub const R8W:  X86Opnd = X86Opnd::Reg(X86Reg { num_bits: 16, reg_type: RegType::GP, reg_no: 8 });
-pub const R9W:  X86Opnd = X86Opnd::Reg(X86Reg { num_bits: 16, reg_type: RegType::GP, reg_no: 9 });
-pub const R10W: X86Opnd = X86Opnd::Reg(X86Reg { num_bits: 16, reg_type: RegType::GP, reg_no: 10 });
-pub const R11W: X86Opnd = X86Opnd::Reg(X86Reg { num_bits: 16, reg_type: RegType::GP, reg_no: 11 });
-pub const R12W: X86Opnd = X86Opnd::Reg(X86Reg { num_bits: 16, reg_type: RegType::GP, reg_no: 12 });
-pub const R13W: X86Opnd = X86Opnd::Reg(X86Reg { num_bits: 16, reg_type: RegType::GP, reg_no: 13 });
-pub const R14W: X86Opnd = X86Opnd::Reg(X86Reg { num_bits: 16, reg_type: RegType::GP, reg_no: 14 });
-pub const R15W: X86Opnd = X86Opnd::Reg(X86Reg { num_bits: 16, reg_type: RegType::GP, reg_no: 15 });
+pub const AX:   YJitOpnd = YJitOpnd::Reg(X86Reg { num_bits: 16, reg_type: RegType::GP, reg_no: 0 });
+pub const CX:   YJitOpnd = YJitOpnd::Reg(X86Reg { num_bits: 16, reg_type: RegType::GP, reg_no: 1 });
+pub const DX:   YJitOpnd = YJitOpnd::Reg(X86Reg { num_bits: 16, reg_type: RegType::GP, reg_no: 2 });
+pub const BX:   YJitOpnd = YJitOpnd::Reg(X86Reg { num_bits: 16, reg_type: RegType::GP, reg_no: 3 });
+pub const SP:   YJitOpnd = YJitOpnd::Reg(X86Reg { num_bits: 16, reg_type: RegType::GP, reg_no: 4 });
+pub const BP:   YJitOpnd = YJitOpnd::Reg(X86Reg { num_bits: 16, reg_type: RegType::GP, reg_no: 5 });
+pub const SI:   YJitOpnd = YJitOpnd::Reg(X86Reg { num_bits: 16, reg_type: RegType::GP, reg_no: 6 });
+pub const DI:   YJitOpnd = YJitOpnd::Reg(X86Reg { num_bits: 16, reg_type: RegType::GP, reg_no: 7 });
+pub const R8W:  YJitOpnd = YJitOpnd::Reg(X86Reg { num_bits: 16, reg_type: RegType::GP, reg_no: 8 });
+pub const R9W:  YJitOpnd = YJitOpnd::Reg(X86Reg { num_bits: 16, reg_type: RegType::GP, reg_no: 9 });
+pub const R10W: YJitOpnd = YJitOpnd::Reg(X86Reg { num_bits: 16, reg_type: RegType::GP, reg_no: 10 });
+pub const R11W: YJitOpnd = YJitOpnd::Reg(X86Reg { num_bits: 16, reg_type: RegType::GP, reg_no: 11 });
+pub const R12W: YJitOpnd = YJitOpnd::Reg(X86Reg { num_bits: 16, reg_type: RegType::GP, reg_no: 12 });
+pub const R13W: YJitOpnd = YJitOpnd::Reg(X86Reg { num_bits: 16, reg_type: RegType::GP, reg_no: 13 });
+pub const R14W: YJitOpnd = YJitOpnd::Reg(X86Reg { num_bits: 16, reg_type: RegType::GP, reg_no: 14 });
+pub const R15W: YJitOpnd = YJitOpnd::Reg(X86Reg { num_bits: 16, reg_type: RegType::GP, reg_no: 15 });
 
 // 8-bit GP registers
-pub const AL:   X86Opnd = X86Opnd::Reg(X86Reg { num_bits: 8, reg_type: RegType::GP, reg_no: 0 });
-pub const CL:   X86Opnd = X86Opnd::Reg(X86Reg { num_bits: 8, reg_type: RegType::GP, reg_no: 1 });
-pub const DL:   X86Opnd = X86Opnd::Reg(X86Reg { num_bits: 8, reg_type: RegType::GP, reg_no: 2 });
-pub const BL:   X86Opnd = X86Opnd::Reg(X86Reg { num_bits: 8, reg_type: RegType::GP, reg_no: 3 });
-pub const SPL:  X86Opnd = X86Opnd::Reg(X86Reg { num_bits: 8, reg_type: RegType::GP, reg_no: 4 });
-pub const BPL:  X86Opnd = X86Opnd::Reg(X86Reg { num_bits: 8, reg_type: RegType::GP, reg_no: 5 });
-pub const SIL:  X86Opnd = X86Opnd::Reg(X86Reg { num_bits: 8, reg_type: RegType::GP, reg_no: 6 });
-pub const DIL:  X86Opnd = X86Opnd::Reg(X86Reg { num_bits: 8, reg_type: RegType::GP, reg_no: 7 });
-pub const R8B:  X86Opnd = X86Opnd::Reg(X86Reg { num_bits: 8, reg_type: RegType::GP, reg_no: 8 });
-pub const R9B:  X86Opnd = X86Opnd::Reg(X86Reg { num_bits: 8, reg_type: RegType::GP, reg_no: 9 });
-pub const R10B: X86Opnd = X86Opnd::Reg(X86Reg { num_bits: 8, reg_type: RegType::GP, reg_no: 10 });
-pub const R11B: X86Opnd = X86Opnd::Reg(X86Reg { num_bits: 8, reg_type: RegType::GP, reg_no: 11 });
-pub const R12B: X86Opnd = X86Opnd::Reg(X86Reg { num_bits: 8, reg_type: RegType::GP, reg_no: 12 });
-pub const R13B: X86Opnd = X86Opnd::Reg(X86Reg { num_bits: 8, reg_type: RegType::GP, reg_no: 13 });
-pub const R14B: X86Opnd = X86Opnd::Reg(X86Reg { num_bits: 8, reg_type: RegType::GP, reg_no: 14 });
-pub const R15B: X86Opnd = X86Opnd::Reg(X86Reg { num_bits: 8, reg_type: RegType::GP, reg_no: 15 });
+pub const AL:   YJitOpnd = YJitOpnd::Reg(X86Reg { num_bits: 8, reg_type: RegType::GP, reg_no: 0 });
+pub const CL:   YJitOpnd = YJitOpnd::Reg(X86Reg { num_bits: 8, reg_type: RegType::GP, reg_no: 1 });
+pub const DL:   YJitOpnd = YJitOpnd::Reg(X86Reg { num_bits: 8, reg_type: RegType::GP, reg_no: 2 });
+pub const BL:   YJitOpnd = YJitOpnd::Reg(X86Reg { num_bits: 8, reg_type: RegType::GP, reg_no: 3 });
+pub const SPL:  YJitOpnd = YJitOpnd::Reg(X86Reg { num_bits: 8, reg_type: RegType::GP, reg_no: 4 });
+pub const BPL:  YJitOpnd = YJitOpnd::Reg(X86Reg { num_bits: 8, reg_type: RegType::GP, reg_no: 5 });
+pub const SIL:  YJitOpnd = YJitOpnd::Reg(X86Reg { num_bits: 8, reg_type: RegType::GP, reg_no: 6 });
+pub const DIL:  YJitOpnd = YJitOpnd::Reg(X86Reg { num_bits: 8, reg_type: RegType::GP, reg_no: 7 });
+pub const R8B:  YJitOpnd = YJitOpnd::Reg(X86Reg { num_bits: 8, reg_type: RegType::GP, reg_no: 8 });
+pub const R9B:  YJitOpnd = YJitOpnd::Reg(X86Reg { num_bits: 8, reg_type: RegType::GP, reg_no: 9 });
+pub const R10B: YJitOpnd = YJitOpnd::Reg(X86Reg { num_bits: 8, reg_type: RegType::GP, reg_no: 10 });
+pub const R11B: YJitOpnd = YJitOpnd::Reg(X86Reg { num_bits: 8, reg_type: RegType::GP, reg_no: 11 });
+pub const R12B: YJitOpnd = YJitOpnd::Reg(X86Reg { num_bits: 8, reg_type: RegType::GP, reg_no: 12 });
+pub const R13B: YJitOpnd = YJitOpnd::Reg(X86Reg { num_bits: 8, reg_type: RegType::GP, reg_no: 13 });
+pub const R14B: YJitOpnd = YJitOpnd::Reg(X86Reg { num_bits: 8, reg_type: RegType::GP, reg_no: 14 });
+pub const R15B: YJitOpnd = YJitOpnd::Reg(X86Reg { num_bits: 8, reg_type: RegType::GP, reg_no: 15 });
 
 // C argument registers
-pub const C_ARG_REGS: [X86Opnd; 6] = [RDI, RSI, RDX, RCX, R8, R9];
+pub const C_ARG_REGS: [YJitOpnd; 6] = [RDI, RSI, RDX, RCX, R8, R9];
 
 //===========================================================================
 
@@ -268,17 +268,17 @@ pub fn unsig_imm_size(imm: u64) -> u8
 }
 
 /// Shorthand for memory operand with base register and displacement
-pub fn mem_opnd(num_bits: u8, base_reg: X86Opnd, disp: i32) -> X86Opnd
+pub fn mem_opnd(num_bits: u8, base_reg: YJitOpnd, disp: i32) -> YJitOpnd
 {
     let base_reg = match base_reg {
-        X86Opnd::Reg(reg) => reg,
+        YJitOpnd::Reg(reg) => reg,
         _ => unreachable!()
     };
 
     if base_reg.reg_type == RegType::IP {
-        X86Opnd::IPRel(disp)
+        YJitOpnd::IPRel(disp)
     } else {
-        X86Opnd::Mem(
+        YJitOpnd::Mem(
             X86Mem {
                 num_bits: num_bits,
                 base_reg_no: base_reg.reg_no,
@@ -291,8 +291,8 @@ pub fn mem_opnd(num_bits: u8, base_reg: X86Opnd, disp: i32) -> X86Opnd
 }
 
 /// Memory operand with SIB (Scale Index Base) indexing
-pub fn mem_opnd_sib(num_bits: u8, base_opnd: X86Opnd, index_opnd: X86Opnd, scale: i32, disp: i32) -> X86Opnd {
-    if let (X86Opnd::Reg(base_reg), X86Opnd::Reg(index_reg)) = (base_opnd, index_opnd) {
+pub fn mem_opnd_sib(num_bits: u8, base_opnd: YJitOpnd, index_opnd: YJitOpnd, scale: i32, disp: i32) -> YJitOpnd {
+    if let (YJitOpnd::Reg(base_reg), YJitOpnd::Reg(index_reg)) = (base_opnd, index_opnd) {
         let scale_exp: u8;
 
         match scale {
@@ -303,7 +303,7 @@ pub fn mem_opnd_sib(num_bits: u8, base_opnd: X86Opnd, index_opnd: X86Opnd, scale
             _ => unreachable!()
         };
 
-        X86Opnd::Mem(X86Mem {
+        YJitOpnd::Mem(X86Mem {
             num_bits,
             base_reg_no: base_reg.reg_no,
             idx_reg_no: Some(index_reg.reg_no),
@@ -333,7 +333,7 @@ pub fn mem_opnd_sib(num_bits: u8, base_opnd: X86Opnd, index_opnd: X86Opnd, scale
 */
 
 /*
-// TODO: this should be a method, X86Opnd.resize() or X86Opnd.subreg()
+// TODO: this should be a method, YJitOpnd.resize() or YJitOpnd.subreg()
 static x86opnd_t resize_opnd(x86opnd_t opnd, uint32_t num_bits)
 {
     assert (num_bits % 8 == 0);
@@ -343,22 +343,22 @@ static x86opnd_t resize_opnd(x86opnd_t opnd, uint32_t num_bits)
 }
 */
 
-pub fn imm_opnd(value: i64) -> X86Opnd
+pub fn imm_opnd(value: i64) -> YJitOpnd
 {
-    X86Opnd::Imm(X86Imm { num_bits: sig_imm_size(value), value })
+    YJitOpnd::Imm(X86Imm { num_bits: sig_imm_size(value), value })
 }
 
-pub fn uimm_opnd(value: u64) -> X86Opnd
+pub fn uimm_opnd(value: u64) -> YJitOpnd
 {
-    X86Opnd::UImm(X86UImm { num_bits: unsig_imm_size(value), value })
+    YJitOpnd::UImm(X86UImm { num_bits: unsig_imm_size(value), value })
 }
 
-pub fn const_ptr_opnd(ptr: *const u8) -> X86Opnd
+pub fn const_ptr_opnd(ptr: *const u8) -> YJitOpnd
 {
     uimm_opnd(ptr as u64)
 }
 
-pub fn code_ptr_opnd(code_ptr: CodePtr) -> X86Opnd
+pub fn code_ptr_opnd(code_ptr: CodePtr) -> YJitOpnd
 {
     uimm_opnd(code_ptr.raw_ptr() as u64)
 }
@@ -386,10 +386,10 @@ fn write_opcode(cb: &mut CodeBlock, opcode: u8, reg: X86Reg) {
 }
 
 /// Encode an RM instruction
-fn write_rm(cb: &mut CodeBlock, sz_pref: bool, rex_w: bool, r_opnd: X86Opnd, rm_opnd: X86Opnd, op_ext: u8, bytes: &[u8]) {
+fn write_rm(cb: &mut CodeBlock, sz_pref: bool, rex_w: bool, r_opnd: YJitOpnd, rm_opnd: YJitOpnd, op_ext: u8, bytes: &[u8]) {
     let op_len = bytes.len();
     assert!(op_len > 0 && op_len <= 3);
-    assert!(matches!(r_opnd, X86Opnd::Reg(_) | X86Opnd::None), "Can only encode an RM instruction with a register or a none");
+    assert!(matches!(r_opnd, YJitOpnd::Reg(_) | YJitOpnd::None), "Can only encode an RM instruction with a register or a none");
 
     // Flag to indicate the REX prefix is needed
     let need_rex = rex_w || r_opnd.rex_needed() || rm_opnd.rex_needed();
@@ -412,19 +412,19 @@ fn write_rm(cb: &mut CodeBlock, sz_pref: bool, rex_w: bool, r_opnd: X86Opnd, rm_
 
         let w = if rex_w { 1 } else { 0 };
         let r = match r_opnd {
-            X86Opnd::None => 0,
-            X86Opnd::Reg(reg) => if (reg.reg_no & 8) > 0 { 1 } else { 0 },
+            YJitOpnd::None => 0,
+            YJitOpnd::Reg(reg) => if (reg.reg_no & 8) > 0 { 1 } else { 0 },
             _ => unreachable!()
         };
 
         let x = match (need_sib, rm_opnd) {
-            (true, X86Opnd::Mem(mem)) => if (mem.idx_reg_no.unwrap_or(0) & 8) > 0 { 1 } else { 0 },
+            (true, YJitOpnd::Mem(mem)) => if (mem.idx_reg_no.unwrap_or(0) & 8) > 0 { 1 } else { 0 },
             _ => 0
         };
 
         let b = match rm_opnd {
-            X86Opnd::Reg(reg) => if (reg.reg_no & 8) > 0 { 1 } else { 0 },
-            X86Opnd::Mem(mem) => if (mem.base_reg_no & 8) > 0 { 1 } else { 0 },
+            YJitOpnd::Reg(reg) => if (reg.reg_no & 8) > 0 { 1 } else { 0 },
+            YJitOpnd::Mem(mem) => if (mem.base_reg_no & 8) > 0 { 1 } else { 0 },
             _ => 0
         };
 
@@ -443,15 +443,15 @@ fn write_rm(cb: &mut CodeBlock, sz_pref: bool, rex_w: bool, r_opnd: X86Opnd, rm_
     // MODRM.rm  (3 bits)
 
     assert!(
-        !(op_ext != 0xff && !matches!(r_opnd, X86Opnd::None)),
+        !(op_ext != 0xff && !matches!(r_opnd, YJitOpnd::None)),
         "opcode extension and register operand present"
     );
 
     // Encode the mod field
     let rm_mod = match rm_opnd {
-        X86Opnd::Reg(_) => 3,
-        X86Opnd::IPRel(_) => 0,
-        X86Opnd::Mem(_mem) => {
+        YJitOpnd::Reg(_) => 3,
+        YJitOpnd::IPRel(_) => 0,
+        YJitOpnd::Mem(_mem) => {
             match rm_opnd.disp_size() {
                 0 => 0,
                 8 => 1,
@@ -468,16 +468,16 @@ fn write_rm(cb: &mut CodeBlock, sz_pref: bool, rex_w: bool, r_opnd: X86Opnd, rm_
         reg = op_ext;
     } else {
         reg = match r_opnd {
-            X86Opnd::Reg(reg) => reg.reg_no & 7,
+            YJitOpnd::Reg(reg) => reg.reg_no & 7,
             _ => 0
         };
     }
 
     // Encode the rm field
     let rm = match rm_opnd {
-        X86Opnd::Reg(reg) => reg.reg_no & 7,
-        X86Opnd::Mem(mem) => if need_sib { 4 } else { mem.base_reg_no & 7 },
-        X86Opnd::IPRel(_) => 0b101,
+        YJitOpnd::Reg(reg) => reg.reg_no & 7,
+        YJitOpnd::Mem(mem) => if need_sib { 4 } else { mem.base_reg_no & 7 },
+        YJitOpnd::IPRel(_) => 0b101,
         _ => unreachable!()
     };
 
@@ -492,7 +492,7 @@ fn write_rm(cb: &mut CodeBlock, sz_pref: bool, rex_w: bool, r_opnd: X86Opnd, rm_
         // SIB.base  (3 bits)
 
         match rm_opnd {
-            X86Opnd::Mem(mem) => {
+            YJitOpnd::Mem(mem) => {
                 // Encode the scale value
                 let scale = mem.scale_exp;
 
@@ -512,13 +512,13 @@ fn write_rm(cb: &mut CodeBlock, sz_pref: bool, rex_w: bool, r_opnd: X86Opnd, rm_
 
     // Add the displacement
     match rm_opnd {
-        X86Opnd::Mem(mem) => {
+        YJitOpnd::Mem(mem) => {
             let disp_size = rm_opnd.disp_size();
             if disp_size > 0 {
                 cb.write_int(mem.disp as u64, disp_size);
             }
         },
-        X86Opnd::IPRel(rel) => {
+        YJitOpnd::IPRel(rel) => {
             cb.write_int(rel as u64, 32);
         },
         _ => ()
@@ -526,24 +526,24 @@ fn write_rm(cb: &mut CodeBlock, sz_pref: bool, rex_w: bool, r_opnd: X86Opnd, rm_
 }
 
 // Encode a mul-like single-operand RM instruction
-fn write_rm_unary(cb: &mut CodeBlock, op_mem_reg_8: u8, op_mem_reg_pref: u8, op_ext: u8, opnd: X86Opnd) {
-    assert!(matches!(opnd, X86Opnd::Reg(_) | X86Opnd::Mem(_)));
+fn write_rm_unary(cb: &mut CodeBlock, op_mem_reg_8: u8, op_mem_reg_pref: u8, op_ext: u8, opnd: YJitOpnd) {
+    assert!(matches!(opnd, YJitOpnd::Reg(_) | YJitOpnd::Mem(_)));
 
     let opnd_size = opnd.num_bits();
     assert!(opnd_size == 8 || opnd_size == 16 || opnd_size == 32 || opnd_size == 64);
 
     if opnd_size == 8 {
-        write_rm(cb, false, false, X86Opnd::None, opnd, op_ext, &[op_mem_reg_8]);
+        write_rm(cb, false, false, YJitOpnd::None, opnd, op_ext, &[op_mem_reg_8]);
     } else {
         let sz_pref = opnd_size == 16;
         let rex_w = opnd_size == 64;
-        write_rm(cb, sz_pref, rex_w, X86Opnd::None, opnd, op_ext, &[op_mem_reg_pref]);
+        write_rm(cb, sz_pref, rex_w, YJitOpnd::None, opnd, op_ext, &[op_mem_reg_pref]);
     }
 }
 
 // Encode an add-like RM instruction with multiple possible encodings
-fn write_rm_multi(cb: &mut CodeBlock, op_mem_reg8: u8, op_mem_reg_pref: u8, op_reg_mem8: u8, op_reg_mem_pref: u8, op_mem_imm8: u8, op_mem_imm_sml: u8, op_mem_imm_lrg: u8, op_ext_imm: u8, opnd0: X86Opnd, opnd1: X86Opnd) {
-    assert!(matches!(opnd0, X86Opnd::Reg(_) | X86Opnd::Mem(_)));
+fn write_rm_multi(cb: &mut CodeBlock, op_mem_reg8: u8, op_mem_reg_pref: u8, op_reg_mem8: u8, op_reg_mem_pref: u8, op_mem_imm8: u8, op_mem_imm_sml: u8, op_mem_imm_lrg: u8, op_ext_imm: u8, opnd0: YJitOpnd, opnd1: YJitOpnd) {
+    assert!(matches!(opnd0, YJitOpnd::Reg(_) | YJitOpnd::Mem(_)));
 
     // Check the size of opnd0
     let opnd_size = opnd0.num_bits();
@@ -551,10 +551,10 @@ fn write_rm_multi(cb: &mut CodeBlock, op_mem_reg8: u8, op_mem_reg_pref: u8, op_r
 
     // Check the size of opnd1
     match opnd1 {
-        X86Opnd::Reg(reg) => assert!(reg.num_bits == opnd_size),
-        X86Opnd::Mem(mem) => assert!(mem.num_bits == opnd_size),
-        X86Opnd::Imm(imm) => assert!(imm.num_bits <= opnd_size),
-        X86Opnd::UImm(uimm) => assert!(uimm.num_bits <= opnd_size),
+        YJitOpnd::Reg(reg) => assert!(reg.num_bits == opnd_size),
+        YJitOpnd::Mem(mem) => assert!(mem.num_bits == opnd_size),
+        YJitOpnd::Imm(imm) => assert!(imm.num_bits <= opnd_size),
+        YJitOpnd::UImm(uimm) => assert!(uimm.num_bits <= opnd_size),
         _ => ()
     };
 
@@ -563,7 +563,7 @@ fn write_rm_multi(cb: &mut CodeBlock, op_mem_reg8: u8, op_mem_reg_pref: u8, op_r
 
     match (opnd0, opnd1) {
         // R/M + Reg
-        (X86Opnd::Mem(_), X86Opnd::Reg(_)) | (X86Opnd::Reg(_), X86Opnd::Reg(_)) => {
+        (YJitOpnd::Mem(_), YJitOpnd::Reg(_)) | (YJitOpnd::Reg(_), YJitOpnd::Reg(_)) => {
             if opnd_size == 8 {
                 write_rm(cb, false, false, opnd1, opnd0, 0xff, &[op_mem_reg8]);
             } else {
@@ -571,7 +571,7 @@ fn write_rm_multi(cb: &mut CodeBlock, op_mem_reg8: u8, op_mem_reg_pref: u8, op_r
             }
         },
         // Reg + R/M/IPRel
-        (X86Opnd::Reg(_), X86Opnd::Mem(_) | X86Opnd::IPRel(_)) => {
+        (YJitOpnd::Reg(_), YJitOpnd::Mem(_) | YJitOpnd::IPRel(_)) => {
             if opnd_size == 8 {
                 write_rm(cb, false, false, opnd0, opnd1, 0xff, &[op_reg_mem8]);
             } else {
@@ -579,14 +579,14 @@ fn write_rm_multi(cb: &mut CodeBlock, op_mem_reg8: u8, op_mem_reg_pref: u8, op_r
             }
         },
         // R/M + Imm
-        (_, X86Opnd::Imm(imm)) => {
+        (_, YJitOpnd::Imm(imm)) => {
             if imm.num_bits <= 8 {
                 // 8-bit immediate
 
                 if opnd_size == 8 {
-                    write_rm(cb, false, false, X86Opnd::None, opnd0, op_ext_imm, &[op_mem_imm8]);
+                    write_rm(cb, false, false, YJitOpnd::None, opnd0, op_ext_imm, &[op_mem_imm8]);
                 } else {
-                    write_rm(cb, sz_pref, rex_w, X86Opnd::None, opnd0, op_ext_imm, &[op_mem_imm_sml]);
+                    write_rm(cb, sz_pref, rex_w, YJitOpnd::None, opnd0, op_ext_imm, &[op_mem_imm_sml]);
                 }
 
                 cb.write_int(imm.value as u64, 8);
@@ -594,23 +594,23 @@ fn write_rm_multi(cb: &mut CodeBlock, op_mem_reg8: u8, op_mem_reg_pref: u8, op_r
                 // 32-bit immediate
 
                 assert!(imm.num_bits <= opnd_size);
-                write_rm(cb, sz_pref, rex_w, X86Opnd::None, opnd0, op_ext_imm, &[op_mem_imm_lrg]);
+                write_rm(cb, sz_pref, rex_w, YJitOpnd::None, opnd0, op_ext_imm, &[op_mem_imm_lrg]);
                 cb.write_int(imm.value as u64, if opnd_size > 32 { 32 } else { opnd_size.into() });
             } else {
                 panic!("immediate value too large");
             }
         },
         // R/M + UImm
-        (_, X86Opnd::UImm(uimm)) => {
+        (_, YJitOpnd::UImm(uimm)) => {
             let num_bits = sig_imm_size(uimm.value.try_into().unwrap());
 
             if num_bits <= 8 {
                 // 8-bit immediate
 
                 if opnd_size == 8 {
-                    write_rm(cb, false, false, X86Opnd::None, opnd0, op_ext_imm, &[op_mem_imm8]);
+                    write_rm(cb, false, false, YJitOpnd::None, opnd0, op_ext_imm, &[op_mem_imm8]);
                 } else {
-                    write_rm(cb, sz_pref, rex_w, X86Opnd::None, opnd0, op_ext_imm, &[op_mem_imm_sml]);
+                    write_rm(cb, sz_pref, rex_w, YJitOpnd::None, opnd0, op_ext_imm, &[op_mem_imm_sml]);
                 }
 
                 cb.write_int(uimm.value, 8);
@@ -618,7 +618,7 @@ fn write_rm_multi(cb: &mut CodeBlock, op_mem_reg8: u8, op_mem_reg_pref: u8, op_r
                 // 32-bit immediate
 
                 assert!(num_bits <= opnd_size);
-                write_rm(cb, sz_pref, rex_w, X86Opnd::None, opnd0, op_ext_imm, &[op_mem_imm_lrg]);
+                write_rm(cb, sz_pref, rex_w, YJitOpnd::None, opnd0, op_ext_imm, &[op_mem_imm_lrg]);
                 cb.write_int(uimm.value, if opnd_size > 32 { 32 } else { opnd_size.into() });
             } else {
                 panic!("immediate value too large");
@@ -634,7 +634,7 @@ pub fn write_lock_prefix(cb: &mut CodeBlock) {
 }
 
 /// add - Integer addition
-pub fn add(cb: &mut CodeBlock, opnd0: X86Opnd, opnd1: X86Opnd) {
+pub fn add(cb: &mut CodeBlock, opnd0: YJitOpnd, opnd1: YJitOpnd) {
     write_rm_multi(
         cb,
         0x00, // opMemReg8
@@ -651,7 +651,7 @@ pub fn add(cb: &mut CodeBlock, opnd0: X86Opnd, opnd1: X86Opnd) {
 }
 
 /// and - Bitwise AND
-pub fn and(cb: &mut CodeBlock, opnd0: X86Opnd, opnd1: X86Opnd) {
+pub fn and(cb: &mut CodeBlock, opnd0: YJitOpnd, opnd1: YJitOpnd) {
     write_rm_multi(
         cb,
         0x20, // opMemReg8
@@ -677,8 +677,8 @@ pub fn call_rel32(cb: &mut CodeBlock, rel32: i32) {
 }
 
 /// call - Call a pointer, encode with a 32-bit offset if possible
-pub fn call_ptr(cb: &mut CodeBlock, scratch_opnd: X86Opnd, dst_ptr: *const u8) {
-    if let X86Opnd::Reg(_scratch_reg) = scratch_opnd {
+pub fn call_ptr(cb: &mut CodeBlock, scratch_opnd: YJitOpnd, dst_ptr: *const u8) {
+    if let YJitOpnd::Reg(_scratch_reg) = scratch_opnd {
         // Pointer to the end of this call instruction
         let end_ptr = cb.get_ptr(cb.write_pos + 5);
 
@@ -712,16 +712,16 @@ pub fn call_label(cb: &mut CodeBlock, label_idx: usize) {
 }
 
 /// call - Indirect call with an R/M operand
-pub fn call(cb: &mut CodeBlock, opnd: X86Opnd) {
-    write_rm(cb, false, false, X86Opnd::None, opnd, 2, &[0xff]);
+pub fn call(cb: &mut CodeBlock, opnd: YJitOpnd) {
+    write_rm(cb, false, false, YJitOpnd::None, opnd, 2, &[0xff]);
 }
 
 /// Encode a conditional move instruction
-fn write_cmov(cb: &mut CodeBlock, opcode1: u8, dst: X86Opnd, src: X86Opnd) {
-    if let X86Opnd::Reg(reg) = dst {
+fn write_cmov(cb: &mut CodeBlock, opcode1: u8, dst: YJitOpnd, src: YJitOpnd) {
+    if let YJitOpnd::Reg(reg) = dst {
         match src {
-            X86Opnd::Reg(_) => (),
-            X86Opnd::Mem(_) => (),
+            YJitOpnd::Reg(_) => (),
+            YJitOpnd::Mem(_) => (),
             _ => unreachable!()
         };
 
@@ -736,39 +736,39 @@ fn write_cmov(cb: &mut CodeBlock, opcode1: u8, dst: X86Opnd, src: X86Opnd) {
 }
 
 // cmovcc - Conditional move
-pub fn cmova(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) { write_cmov(cb, 0x47, dst, src); }
-pub fn cmovae(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) { write_cmov(cb, 0x43, dst, src); }
-pub fn cmovb(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) { write_cmov(cb, 0x42, dst, src); }
-pub fn cmovbe(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) { write_cmov(cb, 0x46, dst, src); }
-pub fn cmovc(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) { write_cmov(cb, 0x42, dst, src); }
-pub fn cmove(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) { write_cmov(cb, 0x44, dst, src); }
-pub fn cmovg(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) { write_cmov(cb, 0x4f, dst, src); }
-pub fn cmovge(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) { write_cmov(cb, 0x4d, dst, src); }
-pub fn cmovl(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) { write_cmov(cb, 0x4c, dst, src); }
-pub fn cmovle(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) { write_cmov(cb, 0x4e, dst, src); }
-pub fn cmovna(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) { write_cmov(cb, 0x46, dst, src); }
-pub fn cmovnae(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) { write_cmov(cb, 0x42, dst, src); }
-pub fn cmovnb(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) { write_cmov(cb, 0x43, dst, src); }
-pub fn cmovnbe(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) { write_cmov(cb, 0x47, dst, src); }
-pub fn cmovnc(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) { write_cmov(cb, 0x43, dst, src); }
-pub fn cmovne(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) { write_cmov(cb, 0x45, dst, src); }
-pub fn cmovng(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) { write_cmov(cb, 0x4e, dst, src); }
-pub fn cmovnge(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) { write_cmov(cb, 0x4c, dst, src); }
-pub fn cmovnl(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) { write_cmov(cb,  0x4d, dst, src); }
-pub fn cmovnle(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) { write_cmov(cb, 0x4f, dst, src); }
-pub fn cmovno(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) { write_cmov(cb, 0x41, dst, src); }
-pub fn cmovnp(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) { write_cmov(cb, 0x4b, dst, src); }
-pub fn cmovns(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) { write_cmov(cb, 0x49, dst, src); }
-pub fn cmovnz(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) { write_cmov(cb, 0x45, dst, src); }
-pub fn cmovo(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) { write_cmov(cb, 0x40, dst, src); }
-pub fn cmovp(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) { write_cmov(cb, 0x4a, dst, src); }
-pub fn cmovpe(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) { write_cmov(cb, 0x4a, dst, src); }
-pub fn cmovpo(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) { write_cmov(cb, 0x4b, dst, src); }
-pub fn cmovs(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) { write_cmov(cb, 0x48, dst, src); }
-pub fn cmovz(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) { write_cmov(cb, 0x44, dst, src); }
+pub fn cmova(cb: &mut CodeBlock, dst: YJitOpnd, src: YJitOpnd) { write_cmov(cb, 0x47, dst, src); }
+pub fn cmovae(cb: &mut CodeBlock, dst: YJitOpnd, src: YJitOpnd) { write_cmov(cb, 0x43, dst, src); }
+pub fn cmovb(cb: &mut CodeBlock, dst: YJitOpnd, src: YJitOpnd) { write_cmov(cb, 0x42, dst, src); }
+pub fn cmovbe(cb: &mut CodeBlock, dst: YJitOpnd, src: YJitOpnd) { write_cmov(cb, 0x46, dst, src); }
+pub fn cmovc(cb: &mut CodeBlock, dst: YJitOpnd, src: YJitOpnd) { write_cmov(cb, 0x42, dst, src); }
+pub fn cmove(cb: &mut CodeBlock, dst: YJitOpnd, src: YJitOpnd) { write_cmov(cb, 0x44, dst, src); }
+pub fn cmovg(cb: &mut CodeBlock, dst: YJitOpnd, src: YJitOpnd) { write_cmov(cb, 0x4f, dst, src); }
+pub fn cmovge(cb: &mut CodeBlock, dst: YJitOpnd, src: YJitOpnd) { write_cmov(cb, 0x4d, dst, src); }
+pub fn cmovl(cb: &mut CodeBlock, dst: YJitOpnd, src: YJitOpnd) { write_cmov(cb, 0x4c, dst, src); }
+pub fn cmovle(cb: &mut CodeBlock, dst: YJitOpnd, src: YJitOpnd) { write_cmov(cb, 0x4e, dst, src); }
+pub fn cmovna(cb: &mut CodeBlock, dst: YJitOpnd, src: YJitOpnd) { write_cmov(cb, 0x46, dst, src); }
+pub fn cmovnae(cb: &mut CodeBlock, dst: YJitOpnd, src: YJitOpnd) { write_cmov(cb, 0x42, dst, src); }
+pub fn cmovnb(cb: &mut CodeBlock, dst: YJitOpnd, src: YJitOpnd) { write_cmov(cb, 0x43, dst, src); }
+pub fn cmovnbe(cb: &mut CodeBlock, dst: YJitOpnd, src: YJitOpnd) { write_cmov(cb, 0x47, dst, src); }
+pub fn cmovnc(cb: &mut CodeBlock, dst: YJitOpnd, src: YJitOpnd) { write_cmov(cb, 0x43, dst, src); }
+pub fn cmovne(cb: &mut CodeBlock, dst: YJitOpnd, src: YJitOpnd) { write_cmov(cb, 0x45, dst, src); }
+pub fn cmovng(cb: &mut CodeBlock, dst: YJitOpnd, src: YJitOpnd) { write_cmov(cb, 0x4e, dst, src); }
+pub fn cmovnge(cb: &mut CodeBlock, dst: YJitOpnd, src: YJitOpnd) { write_cmov(cb, 0x4c, dst, src); }
+pub fn cmovnl(cb: &mut CodeBlock, dst: YJitOpnd, src: YJitOpnd) { write_cmov(cb,  0x4d, dst, src); }
+pub fn cmovnle(cb: &mut CodeBlock, dst: YJitOpnd, src: YJitOpnd) { write_cmov(cb, 0x4f, dst, src); }
+pub fn cmovno(cb: &mut CodeBlock, dst: YJitOpnd, src: YJitOpnd) { write_cmov(cb, 0x41, dst, src); }
+pub fn cmovnp(cb: &mut CodeBlock, dst: YJitOpnd, src: YJitOpnd) { write_cmov(cb, 0x4b, dst, src); }
+pub fn cmovns(cb: &mut CodeBlock, dst: YJitOpnd, src: YJitOpnd) { write_cmov(cb, 0x49, dst, src); }
+pub fn cmovnz(cb: &mut CodeBlock, dst: YJitOpnd, src: YJitOpnd) { write_cmov(cb, 0x45, dst, src); }
+pub fn cmovo(cb: &mut CodeBlock, dst: YJitOpnd, src: YJitOpnd) { write_cmov(cb, 0x40, dst, src); }
+pub fn cmovp(cb: &mut CodeBlock, dst: YJitOpnd, src: YJitOpnd) { write_cmov(cb, 0x4a, dst, src); }
+pub fn cmovpe(cb: &mut CodeBlock, dst: YJitOpnd, src: YJitOpnd) { write_cmov(cb, 0x4a, dst, src); }
+pub fn cmovpo(cb: &mut CodeBlock, dst: YJitOpnd, src: YJitOpnd) { write_cmov(cb, 0x4b, dst, src); }
+pub fn cmovs(cb: &mut CodeBlock, dst: YJitOpnd, src: YJitOpnd) { write_cmov(cb, 0x48, dst, src); }
+pub fn cmovz(cb: &mut CodeBlock, dst: YJitOpnd, src: YJitOpnd) { write_cmov(cb, 0x44, dst, src); }
 
 /// cmp - Compare and set flags
-pub fn cmp(cb: &mut CodeBlock, opnd0: X86Opnd, opnd1: X86Opnd) {
+pub fn cmp(cb: &mut CodeBlock, opnd0: YJitOpnd, opnd1: YJitOpnd) {
     write_rm_multi(
         cb,
         0x38, // opMemReg8
@@ -907,9 +907,13 @@ pub fn js_ptr  (cb: &mut CodeBlock, ptr: CodePtr) { write_jcc_ptr(cb, 0x0F, 0x88
 pub fn jz_ptr  (cb: &mut CodeBlock, ptr: CodePtr) { write_jcc_ptr(cb, 0x0F, 0x84, ptr); }
 pub fn jmp_ptr (cb: &mut CodeBlock, ptr: CodePtr) { write_jcc_ptr(cb, 0xFF, 0xE9, ptr); }
 
+pub fn gen_jump_ptr(cb: &mut CodeBlock, ptr: CodePtr) {
+    jmp_ptr(cb, ptr);
+}
+
 /// jmp - Indirect jump near to an R/M operand.
-pub fn jmp_rm(cb: &mut CodeBlock, opnd: X86Opnd) {
-    write_rm(cb, false, false, X86Opnd::None, opnd, 4, &[0xff]);
+pub fn jmp_rm(cb: &mut CodeBlock, opnd: YJitOpnd) {
+    write_rm(cb, false, false, YJitOpnd::None, opnd, 4, &[0xff]);
 }
 
 // jmp - Jump with relative 32-bit offset
@@ -919,8 +923,8 @@ pub fn jmp32(cb: &mut CodeBlock, offset: i32) {
 }
 
 /// lea - Load Effective Address
-pub fn lea(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) {
-    if let X86Opnd::Reg(reg) = dst {
+pub fn lea(cb: &mut CodeBlock, dst: YJitOpnd, src: YJitOpnd) {
+    if let YJitOpnd::Reg(reg) = dst {
         assert!(reg.num_bits == 64);
         write_rm(cb, false, true, dst, src, 0xff, &[0x8d]);
     } else {
@@ -929,10 +933,10 @@ pub fn lea(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) {
 }
 
 /// mov - Data move operation
-pub fn mov(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) {
+pub fn mov(cb: &mut CodeBlock, dst: YJitOpnd, src: YJitOpnd) {
     match (dst, src) {
         // R + Imm
-        (X86Opnd::Reg(reg), X86Opnd::Imm(imm)) => {
+        (YJitOpnd::Reg(reg), YJitOpnd::Imm(imm)) => {
             assert!(imm.num_bits <= reg.num_bits);
 
             // In case the source immediate could be zero extended to be 64
@@ -959,7 +963,7 @@ pub fn mov(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) {
             }
         },
         // R + UImm
-        (X86Opnd::Reg(reg), X86Opnd::UImm(uimm)) => {
+        (YJitOpnd::Reg(reg), YJitOpnd::UImm(uimm)) => {
             assert!(uimm.num_bits <= reg.num_bits);
 
             // In case the source immediate could be zero extended to be 64
@@ -986,13 +990,13 @@ pub fn mov(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) {
             }
         },
         // M + Imm
-        (X86Opnd::Mem(mem), X86Opnd::Imm(imm)) => {
+        (YJitOpnd::Mem(mem), YJitOpnd::Imm(imm)) => {
             assert!(imm.num_bits <= mem.num_bits);
 
             if mem.num_bits == 8 {
-                write_rm(cb, false, false, X86Opnd::None, dst, 0xff, &[0xc6]);
+                write_rm(cb, false, false, YJitOpnd::None, dst, 0xff, &[0xc6]);
             } else {
-                write_rm(cb, mem.num_bits == 16, mem.num_bits == 64, X86Opnd::None, dst, 0, &[0xc7]);
+                write_rm(cb, mem.num_bits == 16, mem.num_bits == 64, YJitOpnd::None, dst, 0, &[0xc7]);
             }
 
             let output_num_bits:u32 = if mem.num_bits > 32 { 32 } else { mem.num_bits.into() };
@@ -1000,14 +1004,14 @@ pub fn mov(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) {
             cb.write_int(imm.value as u64, output_num_bits);
         },
         // M + UImm
-        (X86Opnd::Mem(mem), X86Opnd::UImm(uimm)) => {
+        (YJitOpnd::Mem(mem), YJitOpnd::UImm(uimm)) => {
             assert!(uimm.num_bits <= mem.num_bits);
 
             if mem.num_bits == 8 {
-                write_rm(cb, false, false, X86Opnd::None, dst, 0xff, &[0xc6]);
+                write_rm(cb, false, false, YJitOpnd::None, dst, 0xff, &[0xc6]);
             }
             else {
-                write_rm(cb, mem.num_bits == 16, mem.num_bits == 64, X86Opnd::None, dst, 0, &[0xc7]);
+                write_rm(cb, mem.num_bits == 16, mem.num_bits == 64, YJitOpnd::None, dst, 0, &[0xc7]);
             }
 
             let output_num_bits = if mem.num_bits > 32 { 32 } else { mem.num_bits.into() };
@@ -1015,7 +1019,7 @@ pub fn mov(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) {
             cb.write_int(uimm.value, output_num_bits);
         },
         // * + Imm/UImm
-        (_, X86Opnd::Imm(_) | X86Opnd::UImm(_)) => unreachable!(),
+        (_, YJitOpnd::Imm(_) | YJitOpnd::UImm(_)) => unreachable!(),
         // * + *
         (_, _) => {
             write_rm_multi(
@@ -1036,9 +1040,9 @@ pub fn mov(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) {
 }
 
 /// movsx - Move with sign extension (signed integers)
-pub fn movsx(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) {
-    if let X86Opnd::Reg(_dst_reg) = dst {
-        assert!(matches!(src, X86Opnd::Reg(_) | X86Opnd::Mem(_)));
+pub fn movsx(cb: &mut CodeBlock, dst: YJitOpnd, src: YJitOpnd) {
+    if let YJitOpnd::Reg(_dst_reg) = dst {
+        assert!(matches!(src, YJitOpnd::Reg(_) | YJitOpnd::Mem(_)));
 
         let src_num_bits = src.num_bits();
         let dst_num_bits = dst.num_bits();
@@ -1120,7 +1124,7 @@ pub fn nop(cb: &mut CodeBlock, length: u32) {
 }
 
 /// not - Bitwise NOT
-pub fn not(cb: &mut CodeBlock, opnd: X86Opnd) {
+pub fn not(cb: &mut CodeBlock, opnd: YJitOpnd) {
     write_rm_unary(
         cb,
         0xf6, // opMemReg8
@@ -1131,7 +1135,7 @@ pub fn not(cb: &mut CodeBlock, opnd: X86Opnd) {
 }
 
 /// or - Bitwise OR
-pub fn or(cb: &mut CodeBlock, opnd0: X86Opnd, opnd1: X86Opnd) {
+pub fn or(cb: &mut CodeBlock, opnd0: YJitOpnd, opnd1: YJitOpnd) {
     write_rm_multi(
         cb,
         0x08, // opMemReg8
@@ -1148,9 +1152,9 @@ pub fn or(cb: &mut CodeBlock, opnd0: X86Opnd, opnd1: X86Opnd) {
 }
 
 /// pop - Pop a register off the stack
-pub fn pop(cb: &mut CodeBlock, opnd: X86Opnd) {
+pub fn pop(cb: &mut CodeBlock, opnd: YJitOpnd) {
     match opnd {
-        X86Opnd::Reg(reg) => {
+        YJitOpnd::Reg(reg) => {
             assert!(reg.num_bits == 64);
 
             if opnd.rex_needed() {
@@ -1158,10 +1162,10 @@ pub fn pop(cb: &mut CodeBlock, opnd: X86Opnd) {
             }
             write_opcode(cb, 0x58, reg);
         },
-        X86Opnd::Mem(mem) => {
+        YJitOpnd::Mem(mem) => {
             assert!(mem.num_bits == 64);
 
-            write_rm(cb, false, false, X86Opnd::None, opnd, 0, &[0x8f]);
+            write_rm(cb, false, false, YJitOpnd::None, opnd, 0, &[0x8f]);
         },
         _ => unreachable!()
     };
@@ -1174,16 +1178,16 @@ pub fn popfq(cb: &mut CodeBlock) {
 }
 
 /// push - Push an operand on the stack
-pub fn push(cb: &mut CodeBlock, opnd: X86Opnd) {
+pub fn push(cb: &mut CodeBlock, opnd: YJitOpnd) {
     match opnd {
-        X86Opnd::Reg(reg) => {
+        YJitOpnd::Reg(reg) => {
             if opnd.rex_needed() {
                 write_rex(cb, false, 0, 0, reg.reg_no);
             }
             write_opcode(cb, 0x50, reg);
         },
-        X86Opnd::Mem(_mem) => {
-            write_rm(cb, false, false, X86Opnd::None, opnd, 6, &[0xff]);
+        YJitOpnd::Mem(_mem) => {
+            write_rm(cb, false, false, YJitOpnd::None, opnd, 6, &[0xff]);
         },
         _ => unreachable!()
     }
@@ -1200,8 +1204,8 @@ pub fn ret(cb: &mut CodeBlock) {
 }
 
 // Encode a single-operand shift instruction
-fn write_shift(cb: &mut CodeBlock, op_mem_one_pref: u8, _op_mem_cl_pref: u8, op_mem_imm_pref: u8, op_ext: u8, opnd0: X86Opnd, opnd1: X86Opnd) {
-    assert!(matches!(opnd0, X86Opnd::Reg(_) | X86Opnd::Mem(_)));
+fn write_shift(cb: &mut CodeBlock, op_mem_one_pref: u8, _op_mem_cl_pref: u8, op_mem_imm_pref: u8, op_ext: u8, opnd0: YJitOpnd, opnd1: YJitOpnd) {
+    assert!(matches!(opnd0, YJitOpnd::Reg(_) | YJitOpnd::Mem(_)));
 
     // Check the size of opnd0
     let opnd_size = opnd0.num_bits();
@@ -1210,12 +1214,12 @@ fn write_shift(cb: &mut CodeBlock, op_mem_one_pref: u8, _op_mem_cl_pref: u8, op_
     let sz_pref = opnd_size == 16;
     let rex_w = opnd_size == 64;
 
-    if let X86Opnd::UImm(imm) = opnd1 {
+    if let YJitOpnd::UImm(imm) = opnd1 {
         if imm.value == 1 {
-            write_rm(cb, sz_pref, rex_w, X86Opnd::None, opnd0, op_ext, &[op_mem_one_pref]);
+            write_rm(cb, sz_pref, rex_w, YJitOpnd::None, opnd0, op_ext, &[op_mem_one_pref]);
         } else {
             assert!(imm.num_bits <= 8);
-            write_rm(cb, sz_pref, rex_w, X86Opnd::None, opnd0, op_ext, &[op_mem_imm_pref]);
+            write_rm(cb, sz_pref, rex_w, YJitOpnd::None, opnd0, op_ext, &[op_mem_imm_pref]);
             cb.write_byte(imm.value as u8);
         }
     } else {
@@ -1224,7 +1228,7 @@ fn write_shift(cb: &mut CodeBlock, op_mem_one_pref: u8, _op_mem_cl_pref: u8, op_
 }
 
 // sal - Shift arithmetic left
-pub fn sal(cb: &mut CodeBlock, opnd0: X86Opnd, opnd1: X86Opnd) {
+pub fn sal(cb: &mut CodeBlock, opnd0: YJitOpnd, opnd1: YJitOpnd) {
     write_shift(
         cb,
         0xD1, // opMemOnePref,
@@ -1237,7 +1241,7 @@ pub fn sal(cb: &mut CodeBlock, opnd0: X86Opnd, opnd1: X86Opnd) {
 }
 
 /// sar - Shift arithmetic right (signed)
-pub fn sar(cb: &mut CodeBlock, opnd0: X86Opnd, opnd1: X86Opnd) {
+pub fn sar(cb: &mut CodeBlock, opnd0: YJitOpnd, opnd1: YJitOpnd) {
     write_shift(
         cb,
         0xD1, // opMemOnePref,
@@ -1250,7 +1254,7 @@ pub fn sar(cb: &mut CodeBlock, opnd0: X86Opnd, opnd1: X86Opnd) {
 }
 
 // shl - Shift logical left
-pub fn shl(cb: &mut CodeBlock, opnd0: X86Opnd, opnd1: X86Opnd) {
+pub fn shl(cb: &mut CodeBlock, opnd0: YJitOpnd, opnd1: YJitOpnd) {
     write_shift(
         cb,
         0xD1, // opMemOnePref,
@@ -1263,7 +1267,7 @@ pub fn shl(cb: &mut CodeBlock, opnd0: X86Opnd, opnd1: X86Opnd) {
 }
 
 /// shr - Shift logical right (unsigned)
-pub fn shr(cb: &mut CodeBlock, opnd0: X86Opnd, opnd1: X86Opnd) {
+pub fn shr(cb: &mut CodeBlock, opnd0: YJitOpnd, opnd1: YJitOpnd) {
     write_shift(
         cb,
         0xD1, // opMemOnePref,
@@ -1276,7 +1280,7 @@ pub fn shr(cb: &mut CodeBlock, opnd0: X86Opnd, opnd1: X86Opnd) {
 }
 
 /// sub - Integer subtraction
-pub fn sub(cb: &mut CodeBlock, opnd0: X86Opnd, opnd1: X86Opnd) {
+pub fn sub(cb: &mut CodeBlock, opnd0: YJitOpnd, opnd1: YJitOpnd) {
     write_rm_multi(
         cb,
         0x28, // opMemReg8
@@ -1292,29 +1296,29 @@ pub fn sub(cb: &mut CodeBlock, opnd0: X86Opnd, opnd1: X86Opnd) {
     );
 }
 
-fn resize_opnd(opnd: X86Opnd, num_bits: u8) -> X86Opnd {
+fn resize_opnd(opnd: YJitOpnd, num_bits: u8) -> YJitOpnd {
     match opnd {
-        X86Opnd::Reg(reg) => {
+        YJitOpnd::Reg(reg) => {
             let mut cloned = reg;
             cloned.num_bits = num_bits;
-            X86Opnd::Reg(cloned)
+            YJitOpnd::Reg(cloned)
         },
-        X86Opnd::Mem(mem) => {
+        YJitOpnd::Mem(mem) => {
             let mut cloned = mem;
             cloned.num_bits = num_bits;
-            X86Opnd::Mem(cloned)
+            YJitOpnd::Mem(cloned)
         },
         _ => unreachable!()
     }
 }
 
 /// test - Logical Compare
-pub fn test(cb: &mut CodeBlock, rm_opnd: X86Opnd, test_opnd: X86Opnd) {
-    assert!(matches!(rm_opnd, X86Opnd::Reg(_) | X86Opnd::Mem(_)));
+pub fn test(cb: &mut CodeBlock, rm_opnd: YJitOpnd, test_opnd: YJitOpnd) {
+    assert!(matches!(rm_opnd, YJitOpnd::Reg(_) | YJitOpnd::Mem(_)));
     let rm_num_bits = rm_opnd.num_bits();
 
     match test_opnd {
-        X86Opnd::UImm(uimm) => {
+        YJitOpnd::UImm(uimm) => {
             assert!(uimm.num_bits <= 32);
             assert!(uimm.num_bits <= rm_num_bits);
 
@@ -1323,22 +1327,22 @@ pub fn test(cb: &mut CodeBlock, rm_opnd: X86Opnd, test_opnd: X86Opnd) {
             let rm_resized = resize_opnd(rm_opnd, uimm.num_bits);
 
             if uimm.num_bits == 8 {
-                write_rm(cb, false, false, X86Opnd::None, rm_resized, 0x00, &[0xf6]);
+                write_rm(cb, false, false, YJitOpnd::None, rm_resized, 0x00, &[0xf6]);
                 cb.write_int(uimm.value, uimm.num_bits.into());
             } else {
-                write_rm(cb, uimm.num_bits == 16, false, X86Opnd::None, rm_resized, 0x00, &[0xf7]);
+                write_rm(cb, uimm.num_bits == 16, false, YJitOpnd::None, rm_resized, 0x00, &[0xf7]);
                 cb.write_int(uimm.value, uimm.num_bits.into());
             }
         },
-        X86Opnd::Imm(imm) => {
+        YJitOpnd::Imm(imm) => {
             // This mode only applies to 64-bit R/M operands with 32-bit signed immediates
             assert!(imm.num_bits <= 32);
             assert!(rm_num_bits == 64);
 
-            write_rm(cb, false, true, X86Opnd::None, rm_opnd, 0x00, &[0xf7]);
+            write_rm(cb, false, true, YJitOpnd::None, rm_opnd, 0x00, &[0xf7]);
             cb.write_int(imm.value as u64, 32);
         },
-        X86Opnd::Reg(reg) => {
+        YJitOpnd::Reg(reg) => {
             assert!(reg.num_bits == rm_num_bits);
 
             if rm_num_bits == 8 {
@@ -1357,8 +1361,8 @@ pub fn ud2(cb: &mut CodeBlock) {
 }
 
 /// xchg - Exchange Register/Memory with Register
-pub fn xchg(cb: &mut CodeBlock, rm_opnd: X86Opnd, r_opnd: X86Opnd) {
-    if let (X86Opnd::Reg(rm_reg), X86Opnd::Reg(r_reg)) = (rm_opnd, r_opnd) {
+pub fn xchg(cb: &mut CodeBlock, rm_opnd: YJitOpnd, r_opnd: YJitOpnd) {
+    if let (YJitOpnd::Reg(rm_reg), YJitOpnd::Reg(r_reg)) = (rm_opnd, r_opnd) {
         assert!(rm_reg.num_bits == 64);
         assert!(r_reg.num_bits == 64);
 
@@ -1378,7 +1382,7 @@ pub fn xchg(cb: &mut CodeBlock, rm_opnd: X86Opnd, r_opnd: X86Opnd) {
 }
 
 /// xor - Exclusive bitwise OR
-pub fn xor(cb: &mut CodeBlock, opnd0: X86Opnd, opnd1: X86Opnd) {
+pub fn xor(cb: &mut CodeBlock, opnd0: YJitOpnd, opnd1: YJitOpnd) {
     write_rm_multi(
         cb,
         0x30, // opMemReg8

--- a/yjit/src/codegen/aarch64.rs
+++ b/yjit/src/codegen/aarch64.rs
@@ -1,0 +1,284 @@
+use crate::asm::aarch64::*;
+use crate::asm::*;
+use crate::cruby::*;
+use crate::codegen::*;
+
+// Callee-saved registers
+pub const REG_CFP: YJitOpnd = X21;
+pub const REG_EC: YJitOpnd = X20;
+pub const REG_SP: YJitOpnd = X19;
+
+// Scratch registers used by YJIT
+pub const REG0: YJitOpnd = X0;
+// pub const REG1: YJitOpnd = X1;
+
+// Save the incremented PC on the CFP
+// This is necessary when callees can raise or allocate
+#[allow(unused)]
+pub fn jit_save_pc(jit: &JITState, cb: &mut CodeBlock, scratch_reg: YJitOpnd) {
+    unreachable!("unimplemented yet: jit_save_pc");
+}
+
+/// Save the current SP on the CFP
+/// This realigns the interpreter SP with the JIT SP
+/// Note: this will change the current value of REG_SP,
+///       which could invalidate memory operands
+#[allow(unused)]
+pub fn gen_save_sp(cb: &mut CodeBlock, ctx: &mut Context) {
+    unreachable!("unimplemented yet: gen_save_sp");
+}
+
+/// Generate an exit to return to the interpreter
+pub fn gen_exit(exit_pc: *mut VALUE, ctx: &Context, cb: &mut CodeBlock) -> CodePtr {
+    let code_ptr = cb.get_write_ptr();
+
+    add_comment(cb, "exit to interpreter");
+
+    // Generate the code to exit to the interpreters
+    // Write the adjusted SP back into the CFP
+    if ctx.get_sp_offset() != 0 {
+        add(cb, REG_SP, REG_SP, ctx.sp_imm_opnd(0));
+        str(cb, REG_SP, mem_opnd(64, REG_CFP, RUBY_OFFSET_CFP_SP));
+    }
+
+    // Update CFP->PC
+    mov_u64(cb, X0, exit_pc as u64);
+    str(cb, X0, mem_opnd(64, REG_CFP, RUBY_OFFSET_CFP_PC));
+
+    // Accumulate stats about interpreter exits
+    #[cfg(feature = "stats")]
+    if get_option!(gen_stats) {
+        mov(cb, RDI, const_ptr_opnd(exit_pc as *const u8));
+        call_ptr(cb, RSI, rb_yjit_count_side_exit_op as *const u8);
+    }
+
+    ldp(cb, REG_EC, REG_SP, mem_post_opnd(64, SP, 16));
+    ldp(cb, X30, REG_CFP, mem_post_opnd(64, SP, 16));
+
+    mov_u64(cb, X0, Qundef.into());
+    ret(cb, X30);
+
+    return code_ptr;
+}
+// Fill code_for_exit_from_stub. This is used by branch_stub_hit() to exit
+// to the interpreter when it cannot service a stub by generating new code.
+// Before coming here, branch_stub_hit() takes care of fully reconstructing
+// interpreter state.
+pub fn gen_code_for_exit_from_stub(ocb: &mut OutlinedCb) -> CodePtr {
+    let ocb = ocb.unwrap();
+    let code_ptr = ocb.get_write_ptr();
+
+    gen_counter_incr!(ocb, exit_from_branch_stub);
+
+    ldp(ocb, REG_EC, REG_SP, mem_post_opnd(64, SP, 16));
+    ldp(ocb, X30, REG_CFP, mem_post_opnd(64, SP, 16));
+
+    mov_u64(ocb, X0, Qundef.into());
+    ret(ocb, X30);
+
+    return code_ptr;
+}
+
+// Generate a runtime guard that ensures the PC is at the expected
+// instruction index in the iseq, otherwise takes a side-exit.
+// This is to handle the situation of optional parameters.
+// When a function with optional parameters is called, the entry
+// PC for the method isn't necessarily 0.
+fn gen_pc_guard(_cb: &mut CodeBlock, _iseq: IseqPtr, _insn_idx: u32) {
+    unreachable!("unimplemented yet: gen_pc_guard")
+}
+
+// Landing code for when c_return tracing is enabled. See full_cfunc_return().
+pub fn gen_full_cfunc_return(ocb: &mut OutlinedCb) -> CodePtr {
+    let cb = ocb.unwrap();
+    let code_ptr = cb.get_write_ptr();
+
+    // This chunk of code expect REG_EC to be filled properly and
+    // RAX to contain the return value of the C method.
+
+    // Call full_cfunc_return()
+    // TODO
+
+    // Count the exit
+    gen_counter_incr!(cb, traced_cfunc_return);
+
+    // Return to the interpreter
+    // TODO
+
+    return code_ptr;
+}
+
+/// Generate a continuation for leave that exits to the interpreter at REG_CFP->pc.
+/// This is used by gen_leave() and gen_entry_prologue()
+pub fn gen_leave_exit(ocb: &mut OutlinedCb) -> CodePtr {
+    let ocb = ocb.unwrap();
+    let code_ptr = ocb.get_write_ptr();
+
+    // Note, gen_leave() fully reconstructs interpreter state and leaves the
+    // return value in RAX before coming here.
+
+    // Every exit to the interpreter should be counted
+    gen_counter_incr!(ocb, leave_interp_return);
+
+    ldp(ocb, REG_EC, REG_SP, mem_post_opnd(64, SP, 16));
+    ldp(ocb, X30, REG_CFP, mem_post_opnd(64, SP, 16));
+
+    ret(ocb, X30);
+
+    return code_ptr;
+}
+
+/// Compile an interpreter entry block to be inserted into an iseq
+/// Returns None if compilation fails.
+pub fn gen_entry_prologue(cb: &mut CodeBlock, iseq: IseqPtr, insn_idx: u32) -> Option<CodePtr> {
+    const MAX_PROLOGUE_SIZE: usize = 1024;
+
+    // Check if we have enough executable memory
+    if !cb.has_capacity(MAX_PROLOGUE_SIZE) {
+        return None;
+    }
+
+    let old_write_pos = cb.get_write_pos();
+
+    // Align the current write position to cache line boundaries
+    cb.align_pos(64);
+
+    let code_ptr = cb.get_write_ptr();
+    add_comment(cb, "yjit entry");
+
+    stp(cb, X30, REG_CFP, mem_pre_opnd(64, SP, -16));
+    stp(cb, REG_EC, REG_SP, mem_pre_opnd(64, SP, -16));
+
+    // We are passed EC and CFP
+    mov(cb, REG_EC, X0);
+    mov(cb, REG_CFP, X1);
+
+    // Load the current SP from the CFP into REG_SP
+    ldr(cb, REG_SP, mem_opnd(64, REG_CFP, RUBY_OFFSET_CFP_SP));
+
+    // Setup cfp->jit_return
+    // TODO: this could use an IP relative LEA instead of an 8 byte immediate
+    mov_u64(cb, REG0, CodegenGlobals::get_leave_exit_code().raw_ptr() as u64);
+    str(cb, REG0, mem_opnd(64, REG_CFP, RUBY_OFFSET_CFP_JIT_RETURN));
+
+    // We're compiling iseqs that we *expect* to start at `insn_idx`. But in
+    // the case of optional parameters, the interpreter can set the pc to a
+    // different location depending on the optional parameters.  If an iseq
+    // has optional parameters, we'll add a runtime check that the PC we've
+    // compiled for is the same PC that the interpreter wants us to run with.
+    // If they don't match, then we'll take a side exit.
+    if unsafe { get_iseq_flags_has_opt(iseq) } {
+        gen_pc_guard(cb, iseq, insn_idx);
+    }
+
+    // Verify MAX_PROLOGUE_SIZE
+    assert!(cb.get_write_pos() - old_write_pos <= MAX_PROLOGUE_SIZE);
+
+    return Some(code_ptr);
+}
+
+fn gen_nop(
+    _jit: &mut JITState,
+    _ctx: &mut Context,
+    _cb: &mut CodeBlock,
+    _ocb: &mut OutlinedCb,
+) -> CodegenStatus {
+    // Do nothing
+    KeepCompiling
+}
+
+fn gen_putnil(
+    jit: &mut JITState,
+    ctx: &mut Context,
+    cb: &mut CodeBlock,
+    _ocb: &mut OutlinedCb,
+) -> CodegenStatus {
+    jit_putobject(jit, ctx, cb, Qnil);
+    KeepCompiling
+}
+
+fn jit_putobject(_jit: &mut JITState, ctx: &mut Context, cb: &mut CodeBlock, arg: VALUE) {
+    let val_type: Type = Type::from(arg);
+    let stack_top = ctx.stack_push(val_type);
+
+    if arg.special_const_p() {
+        mov_u64(cb, REG0, arg.as_u64());
+        str(cb, REG0, stack_top);
+    } else {
+        // TODO
+        unreachable!("unimplemented: jit_putobject for not SPECIAL_CONST");
+    }
+}
+
+/// Maps a YARV opcode to a code generation function (if supported)
+pub fn get_gen_fn(opcode: VALUE) -> Option<InsnGenFn> {
+    let VALUE(opcode) = opcode;
+    assert!(opcode < VM_INSTRUCTION_SIZE);
+
+    match opcode {
+        OP_NOP => Some(gen_nop),
+        OP_PUTNIL => Some(gen_putnil),
+
+        // Unimplemented opcode, YJIT won't generate code for this yet
+        _ => None,
+    }
+}
+
+impl CodegenGlobals {
+    /// Register codegen functions for some Ruby core methods
+    pub fn reg_method_codegen_fns(&mut self) {
+    }
+}
+
+pub fn gen_call_branch_stub_hit(_ocb: &mut CodeBlock, _target_idx: u32, _branch_ptr: *const u8, _branch_stub_hit_ptr: *mut u8) {
+    unreachable!("unimplemented yet: gen_call_branch_stub_hit")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn setup_codegen() -> (JITState, Context, CodeBlock, OutlinedCb) {
+        let blockid = BlockId {
+            iseq: ptr::null(),
+            idx: 0,
+        };
+        let block = Block::new(blockid, &Context::default());
+
+        return (
+            JITState::new(&block),
+            Context::new(),
+            CodeBlock::new_dummy(256 * 1024),
+            OutlinedCb::wrap(CodeBlock::new_dummy(256 * 1024)),
+        );
+    }
+
+    #[test]
+    fn test_gen_exit() {
+        let (_, ctx, mut cb, _) = setup_codegen();
+        gen_exit(0 as *mut VALUE, &ctx, &mut cb);
+        assert!(cb.get_write_pos() > 0);
+    }
+
+    #[test]
+    fn test_gen_nop() {
+        let (mut jit, mut context, mut cb, mut ocb) = setup_codegen();
+        let status = gen_nop(&mut jit, &mut context, &mut cb, &mut ocb);
+
+        assert_eq!(status, KeepCompiling);
+        assert_eq!(context.diff(&Context::new()), 0);
+        assert_eq!(cb.get_write_pos(), 0);
+    }
+
+    #[test]
+    fn test_putnil() {
+        let (mut jit, mut context, mut cb, mut ocb) = setup_codegen();
+        let status = gen_putnil(&mut jit, &mut context, &mut cb, &mut ocb);
+
+        let (_, tmp_type_top) = context.get_opnd_mapping(StackOpnd(0));
+
+        assert_eq!(status, KeepCompiling);
+        assert_eq!(tmp_type_top, Type::Nil);
+        assert!(cb.get_write_pos() > 0);
+    }
+}

--- a/yjit/src/codegen/mod.rs
+++ b/yjit/src/codegen/mod.rs
@@ -20,6 +20,10 @@ use std::ptr;
 pub mod x86_64;
 #[cfg(target_arch = "x86_64")]
 pub use x86_64::*;
+#[cfg(target_arch = "aarch64")]
+pub mod aarch64;
+#[cfg(target_arch = "aarch64")]
+pub use aarch64::*;
 
 /// Status returned by code generation functions
 #[derive(PartialEq, Debug)]

--- a/yjit/src/codegen/mod.rs
+++ b/yjit/src/codegen/mod.rs
@@ -1,0 +1,794 @@
+use crate::asm::*;
+use crate::core::*;
+use crate::cruby::*;
+use crate::options::*;
+use crate::utils::*;
+use CodegenStatus::*;
+use InsnOpnd::*;
+#[cfg(feature = "stats")]
+use crate::stats::*;
+
+use std::cell::RefMut;
+use std::cmp;
+use std::collections::HashMap;
+use std::ffi::CStr;
+use std::mem;
+use std::os::raw::c_uint;
+use std::ptr;
+
+#[cfg(target_arch = "x86_64")]
+pub mod x86_64;
+#[cfg(target_arch = "x86_64")]
+pub use x86_64::*;
+
+/// Status returned by code generation functions
+#[derive(PartialEq, Debug)]
+pub enum CodegenStatus {
+    EndBlock,
+    KeepCompiling,
+    CantCompile,
+}
+
+/// Code generation function signature
+type InsnGenFn = fn(
+    jit: &mut JITState,
+    ctx: &mut Context,
+    cb: &mut CodeBlock,
+    ocb: &mut OutlinedCb,
+) -> CodegenStatus;
+
+/// Code generation state
+/// This struct only lives while code is being generated
+pub struct JITState {
+    // Block version being compiled
+    block: BlockRef,
+
+    // Instruction sequence this is associated with
+    iseq: IseqPtr,
+
+    // Index of the current instruction being compiled
+    insn_idx: u32,
+
+    // Opcode for the instruction being compiled
+    opcode: usize,
+
+    // PC of the instruction being compiled
+    pc: *mut VALUE,
+
+    // Side exit to the instruction being compiled. See :side-exit:.
+    side_exit_for_pc: Option<CodePtr>,
+
+    // Execution context when compilation started
+    // This allows us to peek at run-time values
+    ec: Option<EcPtr>,
+
+    // Whether we need to record the code address at
+    // the end of this bytecode instruction for global invalidation
+    record_boundary_patch_point: bool,
+}
+
+impl JITState {
+    pub fn new(blockref: &BlockRef) -> Self {
+        JITState {
+            block: blockref.clone(),
+            iseq: ptr::null(), // TODO: initialize this from the blockid
+            insn_idx: 0,
+            opcode: 0,
+            pc: ptr::null_mut::<VALUE>(),
+            side_exit_for_pc: None,
+            ec: None,
+            record_boundary_patch_point: false,
+        }
+    }
+
+    pub fn get_block(&self) -> BlockRef {
+        self.block.clone()
+    }
+
+    pub fn get_insn_idx(&self) -> u32 {
+        self.insn_idx
+    }
+
+    pub fn get_iseq(self: &JITState) -> IseqPtr {
+        self.iseq
+    }
+
+    pub fn get_opcode(self: &JITState) -> usize {
+        self.opcode
+    }
+
+    pub fn add_gc_object_offset(self: &mut JITState, ptr_offset: u32) {
+        let mut gc_obj_vec: RefMut<_> = self.block.borrow_mut();
+        gc_obj_vec.add_gc_object_offset(ptr_offset);
+    }
+
+    pub fn get_pc(self: &JITState) -> *mut VALUE {
+        self.pc
+    }
+}
+
+pub fn jit_get_arg(jit: &JITState, arg_idx: isize) -> VALUE {
+    // insn_len require non-test config
+    #[cfg(not(test))]
+    assert!(insn_len(jit.get_opcode()) > (arg_idx + 1).try_into().unwrap());
+    unsafe { *(jit.pc.offset(arg_idx + 1)) }
+}
+
+// Get the index of the next instruction
+fn jit_next_insn_idx(jit: &JITState) -> u32 {
+    jit.insn_idx + insn_len(jit.get_opcode())
+}
+
+// Check if we are compiling the instruction at the stub PC
+// Meaning we are compiling the instruction that is next to execute
+fn jit_at_current_insn(jit: &JITState) -> bool {
+    let ec_pc: *mut VALUE = unsafe { get_cfp_pc(get_ec_cfp(jit.ec.unwrap())) };
+    ec_pc == jit.pc
+}
+
+// Peek at the nth topmost value on the Ruby stack.
+// Returns the topmost value when n == 0.
+fn jit_peek_at_stack(jit: &JITState, ctx: &Context, n: isize) -> VALUE {
+    assert!(jit_at_current_insn(jit));
+    assert!(n < ctx.get_stack_size() as isize);
+
+    // Note: this does not account for ctx->sp_offset because
+    // this is only available when hitting a stub, and while
+    // hitting a stub, cfp->sp needs to be up to date in case
+    // codegen functions trigger GC. See :stub-sp-flush:.
+    return unsafe {
+        let sp: *mut VALUE = get_cfp_sp(get_ec_cfp(jit.ec.unwrap()));
+
+        *(sp.offset(-1 - n))
+    };
+}
+
+fn jit_peek_at_self(jit: &JITState) -> VALUE {
+    unsafe { get_cfp_self(get_ec_cfp(jit.ec.unwrap())) }
+}
+
+fn jit_peek_at_local(jit: &JITState, n: i32) -> VALUE {
+    assert!(jit_at_current_insn(jit));
+
+    let local_table_size: isize = unsafe { get_iseq_body_local_table_size(jit.iseq) }
+        .try_into()
+        .unwrap();
+    assert!(n < local_table_size.try_into().unwrap());
+
+    unsafe {
+        let ep = get_cfp_ep(get_ec_cfp(jit.ec.unwrap()));
+        let n_isize: isize = n.try_into().unwrap();
+        let offs: isize = -(VM_ENV_DATA_SIZE as isize) - local_table_size + n_isize + 1;
+        *ep.offset(offs)
+    }
+}
+
+// Add a comment at the current position in the code block
+fn add_comment(cb: &mut CodeBlock, comment_str: &str) {
+    if cfg!(feature = "asm_comments") {
+        cb.add_comment(comment_str);
+    }
+}
+
+/// Increment a profiling counter with counter_name
+#[cfg(not(feature = "stats"))]
+macro_rules! gen_counter_incr {
+    ($cb:tt, $counter_name:ident) => {};
+}
+#[cfg(feature = "stats")]
+macro_rules! gen_counter_incr {
+    ($cb:tt, $counter_name:ident) => {
+        if (get_option!(gen_stats)) {
+            // Get a pointer to the counter variable
+            let ptr = ptr_to_counter!($counter_name);
+
+            gen_counter_increment($cb, ptr as *const u8);
+        }
+    };
+}
+pub(crate) use gen_counter_incr;
+
+
+/// Increment a counter then take an existing side exit
+#[cfg(not(feature = "stats"))]
+macro_rules! counted_exit {
+    ($ocb:tt, $existing_side_exit:tt, $counter_name:ident) => {{
+        let _ = $ocb;
+        $existing_side_exit
+    }};
+}
+#[cfg(feature = "stats")]
+macro_rules! counted_exit {
+    ($ocb:tt, $existing_side_exit:tt, $counter_name:ident) => {
+        // The counter is only incremented when stats are enabled
+        if (!get_option!(gen_stats)) {
+            $existing_side_exit
+        } else {
+            let ocb = $ocb.unwrap();
+            let code_ptr = ocb.get_write_ptr();
+
+            // Increment the counter
+            gen_counter_incr!(ocb, $counter_name);
+
+            // Jump to the existing side exit
+            gen_jump_ptr(ocb, $existing_side_exit);
+
+            // Pointer to the side-exit code
+            code_ptr
+        }
+    };
+}
+
+pub(crate) use counted_exit;
+
+/// jit_save_pc() + gen_save_sp(). Should be used before calling a routine that
+/// could:
+///  - Perform GC allocation
+///  - Take the VM lock through RB_VM_LOCK_ENTER()
+///  - Perform Ruby method call
+fn jit_prepare_routine_call(
+    jit: &mut JITState,
+    ctx: &mut Context,
+    cb: &mut CodeBlock,
+    scratch_reg: YJitOpnd,
+) {
+    jit.record_boundary_patch_point = true;
+    jit_save_pc(jit, cb, scratch_reg);
+    gen_save_sp(cb, ctx);
+
+    // In case the routine calls Ruby methods, it can set local variables
+    // through Kernel#binding and other means.
+    ctx.clear_local_types();
+}
+
+/// Record the current codeblock write position for rewriting into a jump into
+/// the outlined block later. Used to implement global code invalidation.
+fn record_global_inval_patch(cb: &mut CodeBlock, outline_block_target_pos: CodePtr) {
+    CodegenGlobals::push_global_inval_patch(cb.get_write_ptr(), outline_block_target_pos);
+}
+
+/// Verify the ctx's types and mappings against the compile-time stack, self,
+/// and locals.
+fn verify_ctx(jit: &JITState, ctx: &Context) {
+    fn obj_info_str<'a>(val: VALUE) -> &'a str {
+        unsafe { CStr::from_ptr(rb_obj_info(val)).to_str().unwrap() }
+    }
+
+    // Only able to check types when at current insn
+    assert!(jit_at_current_insn(jit));
+
+    let self_val = jit_peek_at_self(jit);
+    let self_val_type = Type::from(self_val);
+
+    // Verify self operand type
+    if self_val_type.diff(ctx.get_opnd_type(SelfOpnd)) == usize::MAX {
+        panic!(
+            "verify_ctx: ctx self type ({:?}) incompatible with actual value of self {}",
+            ctx.get_opnd_type(SelfOpnd),
+            obj_info_str(self_val)
+        );
+    }
+
+    // Verify stack operand types
+    let top_idx = cmp::min(ctx.get_stack_size(), MAX_TEMP_TYPES as u16);
+    for i in 0..top_idx {
+        let (learned_mapping, learned_type) = ctx.get_opnd_mapping(StackOpnd(i));
+        let stack_val = jit_peek_at_stack(jit, ctx, i as isize);
+        let val_type = Type::from(stack_val);
+
+        match learned_mapping {
+            TempMapping::MapToSelf => {
+                if self_val != stack_val {
+                    panic!(
+                        "verify_ctx: stack value was mapped to self, but values did not match!\n  stack: {}\n  self: {}",
+                        obj_info_str(stack_val),
+                        obj_info_str(self_val)
+                    );
+                }
+            }
+            TempMapping::MapToLocal(local_idx) => {
+                let local_val = jit_peek_at_local(jit, local_idx.into());
+                if local_val != stack_val {
+                    panic!(
+                        "verify_ctx: stack value was mapped to local, but values did not match\n  stack: {}\n  local {}: {}",
+                        obj_info_str(stack_val),
+                        local_idx,
+                        obj_info_str(local_val)
+                    );
+                }
+            }
+            TempMapping::MapToStack => {}
+        }
+
+        // If the actual type differs from the learned type
+        if val_type.diff(learned_type) == usize::MAX {
+            panic!(
+                "verify_ctx: ctx type ({:?}) incompatible with actual value on stack: {}",
+                learned_type,
+                obj_info_str(stack_val)
+            );
+        }
+    }
+
+    // Verify local variable types
+    let local_table_size = unsafe { get_iseq_body_local_table_size(jit.iseq) };
+    let top_idx: usize = cmp::min(local_table_size as usize, MAX_TEMP_TYPES);
+    for i in 0..top_idx {
+        let learned_type = ctx.get_local_type(i);
+        let local_val = jit_peek_at_local(jit, i as i32);
+        let local_type = Type::from(local_val);
+
+        if local_type.diff(learned_type) == usize::MAX {
+            panic!(
+                "verify_ctx: ctx type ({:?}) incompatible with actual value of local: {} (type {:?})",
+                learned_type,
+                obj_info_str(local_val),
+                local_type
+            );
+        }
+    }
+}
+
+// :side-exit:
+// Get an exit for the current instruction in the outlined block. The code
+// for each instruction often begins with several guards before proceeding
+// to do work. When guards fail, an option we have is to exit to the
+// interpreter at an instruction boundary. The piece of code that takes
+// care of reconstructing interpreter state and exiting out of generated
+// code is called the side exit.
+//
+// No guards change the logic for reconstructing interpreter state at the
+// moment, so there is one unique side exit for each context. Note that
+// it's incorrect to jump to the side exit after any ctx stack push/pop operations
+// since they change the logic required for reconstructing interpreter state.
+pub fn get_side_exit(jit: &mut JITState, ocb: &mut OutlinedCb, ctx: &Context) -> CodePtr {
+    match jit.side_exit_for_pc {
+        None => {
+            let exit_code = gen_exit(jit.pc, ctx, ocb.unwrap());
+            jit.side_exit_for_pc = Some(exit_code);
+            exit_code
+        }
+        Some(code_ptr) => code_ptr,
+    }
+}
+
+// Ensure that there is an exit for the start of the block being compiled.
+// Block invalidation uses this exit.
+pub fn jit_ensure_block_entry_exit(jit: &mut JITState, ocb: &mut OutlinedCb) {
+    let blockref = jit.block.clone();
+    let mut block = blockref.borrow_mut();
+    let block_ctx = block.get_ctx();
+    let blockid = block.get_blockid();
+
+    if block.entry_exit.is_some() {
+        return;
+    }
+
+    if jit.insn_idx == blockid.idx {
+        // We are compiling the first instruction in the block.
+        // Generate the exit with the cache in jitstate.
+        block.entry_exit = Some(get_side_exit(jit, ocb, &block_ctx));
+    } else {
+        let pc = unsafe { rb_iseq_pc_at_idx(blockid.iseq, blockid.idx) };
+        block.entry_exit = Some(gen_exit(pc, &block_ctx, ocb.unwrap()));
+    }
+}
+
+// Generate a stubbed unconditional jump to the next bytecode instruction.
+// Blocks that are part of a guard chain can use this to share the same successor.
+fn jump_to_next_insn(
+    jit: &mut JITState,
+    current_context: &Context,
+    cb: &mut CodeBlock,
+    ocb: &mut OutlinedCb,
+) {
+    // Reset the depth since in current usages we only ever jump to to
+    // chain_depth > 0 from the same instruction.
+    let mut reset_depth = *current_context;
+    reset_depth.reset_chain_depth();
+
+    let jump_block = BlockId {
+        iseq: jit.iseq,
+        idx: jit_next_insn_idx(jit),
+    };
+
+    // We are at the end of the current instruction. Record the boundary.
+    if jit.record_boundary_patch_point {
+        let next_insn = unsafe { jit.pc.offset(insn_len(jit.opcode).try_into().unwrap()) };
+        let exit_pos = gen_exit(next_insn, &reset_depth, ocb.unwrap());
+        record_global_inval_patch(cb, exit_pos);
+        jit.record_boundary_patch_point = false;
+    }
+
+    // Generate the jump instruction
+    gen_direct_jump(jit, &reset_depth, jump_block, cb);
+}
+
+// Compile a sequence of bytecode instructions for a given basic block version.
+// Part of gen_block_version().
+// Note: this function will mutate its context while generating code,
+//       but the input start_ctx argument should remain immutable.
+pub fn gen_single_block(
+    blockid: BlockId,
+    start_ctx: &Context,
+    ec: EcPtr,
+    cb: &mut CodeBlock,
+    ocb: &mut OutlinedCb,
+) -> Result<BlockRef, ()> {
+    // Limit the number of specialized versions for this block
+    let mut ctx = limit_block_versions(blockid, start_ctx);
+
+    verify_blockid(blockid);
+    assert!(!(blockid.idx == 0 && ctx.get_stack_size() > 0));
+
+    // Instruction sequence to compile
+    let iseq = blockid.iseq;
+    let iseq_size = unsafe { get_iseq_encoded_size(iseq) };
+    let mut insn_idx: c_uint = blockid.idx;
+    let starting_insn_idx = insn_idx;
+
+    // Allocate the new block
+    let blockref = Block::new(blockid, &ctx);
+
+    // Initialize a JIT state object
+    let mut jit = JITState::new(&blockref);
+    jit.iseq = blockid.iseq;
+    jit.ec = Some(ec);
+
+    // Mark the start position of the block
+    blockref.borrow_mut().set_start_addr(cb.get_write_ptr());
+
+    // For each instruction to compile
+    // NOTE: could rewrite this loop with a std::iter::Iterator
+    while insn_idx < iseq_size {
+        // Get the current pc and opcode
+        let pc = unsafe { rb_iseq_pc_at_idx(iseq, insn_idx) };
+        // try_into() call below is unfortunate. Maybe pick i32 instead of usize for opcodes.
+        let opcode: usize = unsafe { rb_iseq_opcode_at_pc(iseq, pc) }
+            .try_into()
+            .unwrap();
+
+        // opt_getinlinecache wants to be in a block all on its own. Cut the block short
+        // if we run into it. See gen_opt_getinlinecache() for details.
+        if opcode == OP_OPT_GETINLINECACHE && insn_idx > starting_insn_idx {
+            jump_to_next_insn(&mut jit, &ctx, cb, ocb);
+            break;
+        }
+
+        // Set the current instruction
+        jit.insn_idx = insn_idx;
+        jit.opcode = opcode;
+        jit.pc = pc;
+        jit.side_exit_for_pc = None;
+
+        // If previous instruction requested to record the boundary
+        if jit.record_boundary_patch_point {
+            // Generate an exit to this instruction and record it
+            let exit_pos = gen_exit(jit.pc, &ctx, ocb.unwrap());
+            record_global_inval_patch(cb, exit_pos);
+            jit.record_boundary_patch_point = false;
+        }
+
+        // In debug mode, verify our existing assumption
+        if cfg!(debug_assertions) && get_option!(verify_ctx) && jit_at_current_insn(&jit) {
+            verify_ctx(&jit, &ctx);
+        }
+
+        // Lookup the codegen function for this instruction
+        let mut status = CantCompile;
+        if let Some(gen_fn) = get_gen_fn(VALUE(opcode)) {
+            // :count-placement:
+            // Count bytecode instructions that execute in generated code.
+            // Note that the increment happens even when the output takes side exit.
+            gen_counter_incr!(cb, exec_instruction);
+
+            // Add a comment for the name of the YARV instruction
+            add_comment(cb, &insn_name(opcode));
+
+            // If requested, dump instructions for debugging
+            if get_option!(dump_insns) {
+                println!("compiling {}", insn_name(opcode));
+                print_str(cb, &format!("executing {}", insn_name(opcode)));
+            }
+
+            // Call the code generation function
+            status = gen_fn(&mut jit, &mut ctx, cb, ocb);
+        }
+
+        // If we can't compile this instruction
+        // exit to the interpreter and stop compiling
+        if status == CantCompile {
+            let mut block = jit.block.borrow_mut();
+
+            // TODO: if the codegen function makes changes to ctx and then return YJIT_CANT_COMPILE,
+            // the exit this generates would be wrong. We could save a copy of the entry context
+            // and assert that ctx is the same here.
+            let exit = gen_exit(jit.pc, &ctx, cb);
+
+            // If this is the first instruction in the block, then we can use
+            // the exit for block->entry_exit.
+            if insn_idx == block.get_blockid().idx {
+                block.entry_exit = Some(exit);
+            }
+
+            break;
+        }
+
+        // For now, reset the chain depth after each instruction as only the
+        // first instruction in the block can concern itself with the depth.
+        ctx.reset_chain_depth();
+
+        // Move to the next instruction to compile
+        insn_idx += insn_len(opcode);
+
+        // If the instruction terminates this block
+        if status == EndBlock {
+            break;
+        }
+    }
+
+    // Finish filling out the block
+    {
+        let mut block = jit.block.borrow_mut();
+
+        // Mark the end position of the block
+        block.set_end_addr(cb.get_write_ptr());
+
+        // Store the index of the last instruction in the block
+        block.set_end_idx(insn_idx);
+    }
+
+    // We currently can't handle cases where the request is for a block that
+    // doesn't go to the next instruction.
+    //assert!(!jit.record_boundary_patch_point);
+
+    // If code for the block doesn't fit, fail
+    if cb.has_dropped_bytes() || ocb.unwrap().has_dropped_bytes() {
+        return Err(());
+    }
+
+    // TODO: we may want a feature for this called dump_insns? Can leave commented for now
+    /*
+    if (YJIT_DUMP_MODE >= 2) {
+        // Dump list of compiled instrutions
+        fprintf(stderr, "Compiled the following for iseq=%p:\n", (void *)iseq);
+        for (uint32_t idx = block->blockid.idx; idx < insn_idx; ) {
+            int opcode = yjit_opcode_at_pc(iseq, yjit_iseq_pc_at_idx(iseq, idx));
+            fprintf(stderr, "  %04d %s\n", idx, insn_name(opcode));
+            idx += insn_len(opcode);
+        }
+    }
+    */
+
+    // Block compiled successfully
+    Ok(blockref)
+}
+
+// Return true when the codegen function generates code.
+// known_recv_klass is non-NULL when the caller has used jit_guard_known_klass().
+// See yjit_reg_method().
+type MethodGenFn = fn(
+    jit: &mut JITState,
+    ctx: &mut Context,
+    cb: &mut CodeBlock,
+    ocb: &mut OutlinedCb,
+    ci: *const rb_callinfo,
+    cme: *const rb_callable_method_entry_t,
+    block: Option<IseqPtr>,
+    argc: i32,
+    known_recv_class: *const VALUE,
+) -> bool;
+
+/// Global state needed for code generation
+pub struct CodegenGlobals {
+    /// Inline code block (fast path)
+    inline_cb: CodeBlock,
+
+    /// Outlined code block (slow path)
+    outlined_cb: OutlinedCb,
+
+    /// Code for exiting back to the interpreter from the leave instruction
+    leave_exit_code: CodePtr,
+
+    // For exiting from YJIT frame from branch_stub_hit().
+    // Filled by gen_code_for_exit_from_stub().
+    stub_exit_code: CodePtr,
+
+    // Code for full logic of returning from C method and exiting to the interpreter
+    outline_full_cfunc_return_pos: CodePtr,
+
+    /// For implementing global code invalidation
+    global_inval_patches: Vec<CodepagePatch>,
+
+    /// For implementing global code invalidation. The number of bytes counting from the beginning
+    /// of the inline code block that should not be changed. After patching for global invalidation,
+    /// no one should make changes to the invalidated code region anymore. This is used to
+    /// break out of invalidation race when there are multiple ractors.
+    inline_frozen_bytes: usize,
+
+    // Methods for generating code for hardcoded (usually C) methods
+    method_codegen_table: HashMap<u64, MethodGenFn>,
+}
+
+/// For implementing global code invalidation. A position in the inline
+/// codeblock to patch into a JMP rel32 which jumps into some code in
+/// the outlined codeblock to exit to the interpreter.
+pub struct CodepagePatch {
+    pub inline_patch_pos: CodePtr,
+    pub outlined_target_pos: CodePtr,
+}
+
+/// Private singleton instance of the codegen globals
+static mut CODEGEN_GLOBALS: Option<CodegenGlobals> = None;
+
+impl CodegenGlobals {
+    /// Initialize the codegen globals
+    pub fn init() {
+        // Executable memory size in MiB
+        let mem_size = get_option!(exec_mem_size) * 1024 * 1024;
+
+        #[cfg(not(test))]
+        let (mut cb, mut ocb) = {
+            let page_size = unsafe { rb_yjit_get_page_size() }.as_usize();
+            let mem_block: *mut u8 = unsafe { alloc_exec_mem(mem_size.try_into().unwrap()) };
+            let cb = CodeBlock::new(mem_block, mem_size / 2, page_size);
+            let ocb = OutlinedCb::wrap(CodeBlock::new(
+                unsafe { mem_block.add(mem_size / 2) },
+                mem_size / 2,
+                page_size,
+            ));
+            (cb, ocb)
+        };
+
+        // In test mode we're not linking with the C code
+        // so we don't allocate executable memory
+        #[cfg(test)]
+        let mut cb = CodeBlock::new_dummy(mem_size / 2);
+        #[cfg(test)]
+        let mut ocb = OutlinedCb::wrap(CodeBlock::new_dummy(mem_size / 2));
+
+        let leave_exit_code = gen_leave_exit(&mut ocb);
+
+        let stub_exit_code = gen_code_for_exit_from_stub(&mut ocb);
+
+        // Generate full exit code for C func
+        let cfunc_exit_code = gen_full_cfunc_return(&mut ocb);
+
+        // Mark all code memory as executable
+        cb.mark_all_executable();
+        ocb.unwrap().mark_all_executable();
+
+        let mut codegen_globals = CodegenGlobals {
+            inline_cb: cb,
+            outlined_cb: ocb,
+            leave_exit_code: leave_exit_code,
+            stub_exit_code: stub_exit_code,
+            outline_full_cfunc_return_pos: cfunc_exit_code,
+            global_inval_patches: Vec::new(),
+            inline_frozen_bytes: 0,
+            method_codegen_table: HashMap::new(),
+        };
+
+        // Register the method codegen functions
+        codegen_globals.reg_method_codegen_fns();
+
+        // Initialize the codegen globals instance
+        unsafe {
+            CODEGEN_GLOBALS = Some(codegen_globals);
+        }
+    }
+
+    // Register a specialized codegen function for a particular method. Note that
+    // the if the function returns true, the code it generates runs without a
+    // control frame and without interrupt checks. To avoid creating observable
+    // behavior changes, the codegen function should only target simple code paths
+    // that do not allocate and do not make method calls.
+    fn yjit_reg_method(&mut self, klass: VALUE, mid_str: &str, gen_fn: MethodGenFn) {
+        let id_string = std::ffi::CString::new(mid_str).expect("couldn't convert to CString!");
+        let mid = unsafe { rb_intern(id_string.as_ptr()) };
+        let me = unsafe { rb_method_entry_at(klass, mid) };
+
+        if me.is_null() {
+            panic!("undefined optimized method!");
+        }
+
+        // For now, only cfuncs are supported
+        //RUBY_ASSERT(me && me->def);
+        //RUBY_ASSERT(me->def->type == VM_METHOD_TYPE_CFUNC);
+
+        let method_serial = unsafe {
+            let def = (*me).def;
+            get_def_method_serial(def)
+        };
+
+        self.method_codegen_table.insert(method_serial, gen_fn);
+    }
+
+    /// Get a mutable reference to the codegen globals instance
+    pub fn get_instance() -> &'static mut CodegenGlobals {
+        unsafe { CODEGEN_GLOBALS.as_mut().unwrap() }
+    }
+
+    /// Get a mutable reference to the inline code block
+    pub fn get_inline_cb() -> &'static mut CodeBlock {
+        &mut CodegenGlobals::get_instance().inline_cb
+    }
+
+    /// Get a mutable reference to the outlined code block
+    pub fn get_outlined_cb() -> &'static mut OutlinedCb {
+        &mut CodegenGlobals::get_instance().outlined_cb
+    }
+
+    pub fn get_leave_exit_code() -> CodePtr {
+        CodegenGlobals::get_instance().leave_exit_code
+    }
+
+    pub fn get_stub_exit_code() -> CodePtr {
+        CodegenGlobals::get_instance().stub_exit_code
+    }
+
+    pub fn push_global_inval_patch(i_pos: CodePtr, o_pos: CodePtr) {
+        let patch = CodepagePatch {
+            inline_patch_pos: i_pos,
+            outlined_target_pos: o_pos,
+        };
+        CodegenGlobals::get_instance()
+            .global_inval_patches
+            .push(patch);
+    }
+
+    // Drain the list of patches and return it
+    pub fn take_global_inval_patches() -> Vec<CodepagePatch> {
+        let globals = CodegenGlobals::get_instance();
+        mem::take(&mut globals.global_inval_patches)
+    }
+
+    pub fn get_inline_frozen_bytes() -> usize {
+        CodegenGlobals::get_instance().inline_frozen_bytes
+    }
+
+    pub fn set_inline_frozen_bytes(frozen_bytes: usize) {
+        CodegenGlobals::get_instance().inline_frozen_bytes = frozen_bytes;
+    }
+
+    pub fn get_outline_full_cfunc_return_pos() -> CodePtr {
+        CodegenGlobals::get_instance().outline_full_cfunc_return_pos
+    }
+
+    pub fn look_up_codegen_method(method_serial: u64) -> Option<MethodGenFn> {
+        let table = &CodegenGlobals::get_instance().method_codegen_table;
+
+        let option_ref = table.get(&method_serial);
+        match option_ref {
+            None => None,
+            Some(&mgf) => Some(mgf), // Deref
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn setup_codegen() -> (JITState, Context, CodeBlock, OutlinedCb) {
+        let blockid = BlockId {
+            iseq: ptr::null(),
+            idx: 0,
+        };
+        let block = Block::new(blockid, &Context::default());
+
+        return (
+            JITState::new(&block),
+            Context::new(),
+            CodeBlock::new_dummy(256 * 1024),
+            OutlinedCb::wrap(CodeBlock::new_dummy(256 * 1024)),
+        );
+    }
+
+    #[test]
+    fn test_get_side_exit() {
+        let (mut jit, ctx, _, mut ocb) = setup_codegen();
+        get_side_exit(&mut jit, &mut ocb, &ctx);
+        assert!(ocb.unwrap().get_write_pos() > 0);
+    }
+}

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -910,6 +910,13 @@ impl Context {
         return mem_opnd(64, REG_SP, offset);
     }
 
+    #[cfg(target_arch = "aarch64")]
+    pub fn sp_imm_opnd(&self, offset_bytes: isize) -> YJitOpnd {
+        let offset = ((self.sp_offset as isize) * (SIZEOF_VALUE as isize)) + offset_bytes;
+        let offset = offset as i64;
+        return imm_opnd(offset);
+    }
+
     /// Push one new value on the temp stack with an explicit mapping
     /// Return a pointer to the new stack top
     pub fn stack_push_mapping(&mut self, (mapping, temp_type): (TempMapping, Type)) -> YJitOpnd {

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -601,7 +601,7 @@ impl From<VALUE> for i32 {
 /// Produce a Ruby string from a Rust string slice
 #[cfg(feature = "asm_comments")]
 pub fn rust_str_to_ruby(str: &str) -> VALUE {
-    unsafe { rb_utf8_str_new(str.as_ptr() as *const i8, str.len() as i64) }
+    unsafe { rb_utf8_str_new(str.as_ptr() as *const ::std::os::raw::c_char, str.len() as i64) }
 }
 
 /// Produce a Ruby symbol from a Rust string slice

--- a/yjit/src/invariants.rs
+++ b/yjit/src/invariants.rs
@@ -523,7 +523,7 @@ pub extern "C" fn rb_yjit_tracing_invalidate_all() {
         return;
     }
 
-    use crate::asm::x86_64::jmp_ptr;
+    use crate::asm::gen_jump_ptr;
 
     // Stop other ractors since we are going to patch machine code.
     with_vm_lock(src_loc!(), || {
@@ -559,7 +559,7 @@ pub extern "C" fn rb_yjit_tracing_invalidate_all() {
         let patches = CodegenGlobals::take_global_inval_patches();
         for patch in &patches {
             cb.set_write_ptr(patch.inline_patch_pos);
-            jmp_ptr(cb, patch.outlined_target_pos);
+            gen_jump_ptr(cb, patch.outlined_target_pos);
 
             // FIXME: Can't easily check we actually wrote out the JMP at the moment.
             // assert!(!cb.has_dropped_bytes(), "patches should have space and jump offsets should fit in JMP rel32");

--- a/yjit/src/utils/aarch64.rs
+++ b/yjit/src/utils/aarch64.rs
@@ -1,0 +1,6 @@
+use crate::asm::*;
+
+// Generate code to print constant string to stdout
+pub fn print_str(_cb: &mut CodeBlock, _str: &str) {
+    unreachable!("unimplemented yet: print_str");
+}

--- a/yjit/src/utils/mod.rs
+++ b/yjit/src/utils/mod.rs
@@ -4,6 +4,10 @@
 pub mod x86_64;
 #[cfg(target_arch = "x86_64")]
 pub use x86_64::*;
+#[cfg(target_arch = "aarch64")]
+pub mod aarch64;
+#[cfg(target_arch = "aarch64")]
+pub use aarch64::*;
 
 /// Trait for casting to [usize] that allows you to say `.as_usize()`.
 /// Implementation conditional on the the cast preserving the numeric value on

--- a/yjit/src/utils/mod.rs
+++ b/yjit/src/utils/mod.rs
@@ -1,9 +1,9 @@
 #![allow(dead_code)] // Some functions for print debugging in here
 
-use crate::asm::x86_64::*;
-use crate::asm::*;
-use crate::cruby::*;
-use std::slice;
+#[cfg(target_arch = "x86_64")]
+pub mod x86_64;
+#[cfg(target_arch = "x86_64")]
+pub use x86_64::*;
 
 /// Trait for casting to [usize] that allows you to say `.as_usize()`.
 /// Implementation conditional on the the cast preserving the numeric value on
@@ -115,124 +115,3 @@ yjit_print_iseq(const rb_iseq_t *iseq)
     fprintf(stderr, "%.*s\n", (int)len, ptr);
 }
 */
-
-// Save caller-save registers on the stack before a C call
-fn push_regs(cb: &mut CodeBlock) {
-    push(cb, RAX);
-    push(cb, RCX);
-    push(cb, RDX);
-    push(cb, RSI);
-    push(cb, RDI);
-    push(cb, R8);
-    push(cb, R9);
-    push(cb, R10);
-    push(cb, R11);
-    pushfq(cb);
-}
-
-// Restore caller-save registers from the after a C call
-fn pop_regs(cb: &mut CodeBlock) {
-    popfq(cb);
-    pop(cb, R11);
-    pop(cb, R10);
-    pop(cb, R9);
-    pop(cb, R8);
-    pop(cb, RDI);
-    pop(cb, RSI);
-    pop(cb, RDX);
-    pop(cb, RCX);
-    pop(cb, RAX);
-}
-
-pub fn print_int(cb: &mut CodeBlock, opnd: X86Opnd) {
-    extern "sysv64" fn print_int_fn(val: i64) {
-        println!("{}", val);
-    }
-
-    push_regs(cb);
-
-    match opnd {
-        X86Opnd::Mem(_) | X86Opnd::Reg(_) => {
-            // Sign-extend the value if necessary
-            if opnd.num_bits() < 64 {
-                movsx(cb, C_ARG_REGS[0], opnd);
-            } else {
-                mov(cb, C_ARG_REGS[0], opnd);
-            }
-        }
-        X86Opnd::Imm(_) | X86Opnd::UImm(_) => {
-            mov(cb, C_ARG_REGS[0], opnd);
-        }
-        _ => unreachable!(),
-    }
-
-    mov(cb, RAX, const_ptr_opnd(print_int_fn as *const u8));
-    call(cb, RAX);
-    pop_regs(cb);
-}
-
-/// Generate code to print a pointer
-pub fn print_ptr(cb: &mut CodeBlock, opnd: X86Opnd) {
-    extern "sysv64" fn print_ptr_fn(ptr: *const u8) {
-        println!("{:p}", ptr);
-    }
-
-    assert!(opnd.num_bits() == 64);
-
-    push_regs(cb);
-    mov(cb, C_ARG_REGS[0], opnd);
-    mov(cb, RAX, const_ptr_opnd(print_ptr_fn as *const u8));
-    call(cb, RAX);
-    pop_regs(cb);
-}
-
-/// Generate code to print a value
-pub fn print_value(cb: &mut CodeBlock, opnd: X86Opnd) {
-    extern "sysv64" fn print_value_fn(val: VALUE) {
-        unsafe { rb_obj_info_dump(val) }
-    }
-
-    assert!(opnd.num_bits() == 64);
-
-    push_regs(cb);
-
-    mov(cb, RDI, opnd);
-    mov(cb, RAX, const_ptr_opnd(print_value_fn as *const u8));
-    call(cb, RAX);
-
-    pop_regs(cb);
-}
-
-/// Generate code to print constant string to stdout
-pub fn print_str(cb: &mut CodeBlock, str: &str) {
-    extern "sysv64" fn print_str_cfun(ptr: *const u8, num_bytes: usize) {
-        unsafe {
-            let slice = slice::from_raw_parts(ptr, num_bytes);
-            let str = std::str::from_utf8(slice).unwrap();
-            println!("{}", str);
-        }
-    }
-
-    let bytes = str.as_ptr();
-    let num_bytes = str.len();
-
-    push_regs(cb);
-
-    // Load the string address and jump over the string data
-    lea(cb, C_ARG_REGS[0], mem_opnd(8, RIP, 5));
-    jmp32(cb, num_bytes as i32);
-
-    // Write the string chars and a null terminator
-    for i in 0..num_bytes {
-        cb.write_byte(unsafe { *bytes.add(i) });
-    }
-
-    // Pass the string length as an argument
-    mov(cb, C_ARG_REGS[1], uimm_opnd(num_bytes as u64));
-
-    // Call the print function
-    mov(cb, RAX, const_ptr_opnd(print_str_cfun as *const u8));
-    call(cb, RAX);
-
-    pop_regs(cb);
-}

--- a/yjit/src/utils/x86_64.rs
+++ b/yjit/src/utils/x86_64.rs
@@ -1,0 +1,126 @@
+#![allow(dead_code)] // Some functions for print debugging in here
+
+use crate::asm::*;
+use crate::cruby::*;
+use std::slice;
+
+// Save caller-save registers on the stack before a C call
+fn push_regs(cb: &mut CodeBlock) {
+    push(cb, RAX);
+    push(cb, RCX);
+    push(cb, RDX);
+    push(cb, RSI);
+    push(cb, RDI);
+    push(cb, R8);
+    push(cb, R9);
+    push(cb, R10);
+    push(cb, R11);
+    pushfq(cb);
+}
+
+// Restore caller-save registers from the after a C call
+fn pop_regs(cb: &mut CodeBlock) {
+    popfq(cb);
+    pop(cb, R11);
+    pop(cb, R10);
+    pop(cb, R9);
+    pop(cb, R8);
+    pop(cb, RDI);
+    pop(cb, RSI);
+    pop(cb, RDX);
+    pop(cb, RCX);
+    pop(cb, RAX);
+}
+
+pub fn print_int(cb: &mut CodeBlock, opnd: YJitOpnd) {
+    extern "C" fn print_int_fn(val: i64) {
+        println!("{}", val);
+    }
+
+    push_regs(cb);
+
+    match opnd {
+        YJitOpnd::Mem(_) | YJitOpnd::Reg(_) => {
+            // Sign-extend the value if necessary
+            if opnd.num_bits() < 64 {
+                movsx(cb, C_ARG_REGS[0], opnd);
+            } else {
+                mov(cb, C_ARG_REGS[0], opnd);
+            }
+        }
+        YJitOpnd::Imm(_) | YJitOpnd::UImm(_) => {
+            mov(cb, C_ARG_REGS[0], opnd);
+        }
+        _ => unreachable!(),
+    }
+
+    mov(cb, RAX, const_ptr_opnd(print_int_fn as *const u8));
+    call(cb, RAX);
+    pop_regs(cb);
+}
+
+/// Generate code to print a pointer
+pub fn print_ptr(cb: &mut CodeBlock, opnd: YJitOpnd) {
+    extern "C" fn print_ptr_fn(ptr: *const u8) {
+        println!("{:p}", ptr);
+    }
+
+    assert!(opnd.num_bits() == 64);
+
+    push_regs(cb);
+    mov(cb, C_ARG_REGS[0], opnd);
+    mov(cb, RAX, const_ptr_opnd(print_ptr_fn as *const u8));
+    call(cb, RAX);
+    pop_regs(cb);
+}
+
+/// Generate code to print a value
+pub fn print_value(cb: &mut CodeBlock, opnd: YJitOpnd) {
+    extern "C" fn print_value_fn(val: VALUE) {
+        unsafe { rb_obj_info_dump(val) }
+    }
+
+    assert!(opnd.num_bits() == 64);
+
+    push_regs(cb);
+
+    mov(cb, RDI, opnd);
+    mov(cb, RAX, const_ptr_opnd(print_value_fn as *const u8));
+    call(cb, RAX);
+
+    pop_regs(cb);
+}
+
+/// Generate code to print constant string to stdout
+pub fn print_str(cb: &mut CodeBlock, str: &str) {
+    extern "C" fn print_str_cfun(ptr: *const u8, num_bytes: usize) {
+        unsafe {
+            let slice = slice::from_raw_parts(ptr, num_bytes);
+            let str = std::str::from_utf8(slice).unwrap();
+            println!("{}", str);
+        }
+    }
+
+    let bytes = str.as_ptr();
+    let num_bytes = str.len();
+
+    push_regs(cb);
+
+    // Load the string address and jump over the string data
+    lea(cb, C_ARG_REGS[0], mem_opnd(8, RIP, 5));
+    jmp32(cb, num_bytes as i32);
+
+    // Write the string chars and a null terminator
+    for i in 0..num_bytes {
+        cb.write_byte(unsafe { *bytes.add(i) });
+    }
+
+    // Pass the string length as an argument
+    mov(cb, C_ARG_REGS[1], uimm_opnd(num_bytes as u64));
+
+    // Call the print function
+    mov(cb, RAX, const_ptr_opnd(print_str_cfun as *const u8));
+    call(cb, RAX);
+
+    pop_regs(cb);
+}


### PR DESCRIPTION
How about making YJIT available for multiple architectures?
At first, I tried to make it possible to JIT compile putnil-only insn on aarch64(arm64).

I have confirmed that it works in my local environment as follows:

```
$ cat Dockerfile 
FROM arm64v8/ubuntu
RUN apt-get update && apt-get -y install build-essential autoconf libyaml-dev libssl-dev ruby bison curl
RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash /dev/stdin -- -y

$ cat docker-compose.yml 
version: '3'
services:
  ruby:
    build: 
      context: docker
    volumes:
      - "../../:/ruby"
      - "./.bash_history:/root/.bash_history"
    working_dir: /ruby/tmp/arm64
$ sed ../../yjit/src/codegen/aarch64.rs -i -e '/^fn gen_putnil/,/^}/{s/Qnil/Qtrue/}' # temporary replacing just for debug

$ docker-compose run ruby bash -lc 'make miniruby >build.log 2>&1 && ./miniruby -v --enable-yjit -e "def f; end; 10.times { p f }"'
Creating arm64_ruby_run ... done
ruby 3.2.0dev (2022-05-05T04:23:37Z work 6d5a906b6d) +YJIT [aarch64-linux]
nil
nil
nil
nil
nil
nil
nil
nil
nil
true

```