### PR TITLE
File rdoc

### DIFF
--- a/file.c
+++ b/file.c
@@ -1621,14 +1621,13 @@ rb_file_directory_p(VALUE obj, VALUE fname)
 
 /*
  * call-seq:
- *   File.pipe?(object) -> true or false
+ *   File.pipe?(filepath) -> true or false
  *
- * Returns +true+ if +object+ is a pipe, +false+ otherwise:
+ * Returns +true+ if +filepath+ points to a pipe, +false+ otherwise:
  *
- *   read_pipe, write_pipe = IO.pipe # => [#<IO:fd 5>, #<IO:fd 6>]
- *   File.pipe?(read_pipe)           # => true
- *   File.pipe?(write_pipe)          # => true
- *   File.pipe?(File.open('t.txt'))  # => false
+ *   File.mkfifo('tmp/fifo')
+ *   File.pipe?('tmp/fifo') # => true
+ *   File.pipe?('t.txt')    # => false
  *
  */
 
@@ -1651,9 +1650,9 @@ rb_file_pipe_p(VALUE obj, VALUE fname)
 
 /*
  * call-seq:
- *   File.symlink?(object) -> true or false
+ *   File.symlink?(filepath) -> true or false
  *
- * Returns +true+ if +object+ is a symbolic link, +false+ otherwise:
+ * Returns +true+ if +filepath+ points to a symbolic link, +false+ otherwise:
  *
  *   symlink = File.symlink('t.txt', 'symlink')
  *   File.symlink?('symlink') # => true
@@ -1692,9 +1691,9 @@ rb_file_symlink_p(VALUE obj, VALUE fname)
 
 /*
  * call-seq:
- *   File.socket?(object)   ->  true or false
+ *   File.socket?(filepath)   ->  true or false
  *
- * Returns +true+ if +object+ is a socket, +false+ otherwise:
+ * Returns +true+ if +filepath+ points to a socket, +false+ otherwise:
  *
  *   require 'socket'
  *   File.socket?(Socket.new(:INET, :STREAM)) # => true
@@ -1731,9 +1730,9 @@ rb_file_socket_p(VALUE obj, VALUE fname)
 
 /*
  * call-seq:
- *   File.blockdev?(object) -> true or false
+ *   File.blockdev?(filepath) -> true or false
  *
- * Returns +true+ if +object+ is a block device, +false+ otherwise:
+ * Returns +true+ if +filepath+ points to a block device, +false+ otherwise:
  *
  *   File.blockdev?('/dev/sda1')      # => true
  *   File.blockdev?(File.new('t.tmp') # => false
@@ -1763,9 +1762,9 @@ rb_file_blockdev_p(VALUE obj, VALUE fname)
 
 /*
  * call-seq:
- *   File.chardev?(object) -> true or false
+ *   File.chardev?(filepath) -> true or false
  *
- * Returns +true+ if +object+ is a character device, +false+ otherwise.
+ * Returns +true+ if +filepath+ points to a character device, +false+ otherwise.
  *
   *  File.chardev?($stdin)     # => true
  *   File.chardev?('t.txt')     # => false

--- a/file.c
+++ b/file.c
@@ -1621,11 +1621,15 @@ rb_file_directory_p(VALUE obj, VALUE fname)
 
 /*
  * call-seq:
- *   File.pipe?(file_name)   ->  true or false
+ *   File.pipe?(object) -> true or false
  *
- * Returns <code>true</code> if the named file is a pipe.
+ * Returns +true+ if +object+ is a pipe, +false+ otherwise:
  *
- * _file_name_ can be an IO object.
+ *   read_pipe, write_pipe = IO.pipe # => [#<IO:fd 5>, #<IO:fd 6>]
+ *   File.pipe?(read_pipe)           # => true
+ *   File.pipe?(write_pipe)          # => true
+ *   File.pipe?(File.open('t.txt'))  # => false
+ *
  */
 
 static VALUE
@@ -1647,9 +1651,14 @@ rb_file_pipe_p(VALUE obj, VALUE fname)
 
 /*
  * call-seq:
- *   File.symlink?(file_name)   ->  true or false
+ *   File.symlink?(object) -> true or false
  *
- * Returns <code>true</code> if the named file is a symbolic link.
+ * Returns +true+ if +object+ is a symbolic link, +false+ otherwise:
+ *
+ *   symlink = File.symlink('t.txt', 'symlink')
+ *   File.symlink?('symlink') # => true
+ *   File.symlink?('t.txt')   # => false
+ *
  */
 
 static VALUE
@@ -1683,11 +1692,14 @@ rb_file_symlink_p(VALUE obj, VALUE fname)
 
 /*
  * call-seq:
- *   File.socket?(file_name)   ->  true or false
+ *   File.socket?(object)   ->  true or false
  *
- * Returns <code>true</code> if the named file is a socket.
+ * Returns +true+ if +object+ is a socket, +false+ otherwise:
  *
- * _file_name_ can be an IO object.
+ *   require 'socket'
+ *   File.socket?(Socket.new(:INET, :STREAM)) # => true
+ *   File.socket?(File.new('t.txt'))          # => false
+ *
  */
 
 static VALUE
@@ -1719,11 +1731,13 @@ rb_file_socket_p(VALUE obj, VALUE fname)
 
 /*
  * call-seq:
- *   File.blockdev?(file_name)   ->  true or false
+ *   File.blockdev?(object) -> true or false
  *
- * Returns <code>true</code> if the named file is a block device.
+ * Returns +true+ if +object+ is a block device, +false+ otherwise:
  *
- * _file_name_ can be an IO object.
+ *   File.blockdev?('/dev/sda1')      # => true
+ *   File.blockdev?(File.new('t.tmp') # => false
+ *
  */
 
 static VALUE
@@ -1749,11 +1763,13 @@ rb_file_blockdev_p(VALUE obj, VALUE fname)
 
 /*
  * call-seq:
- *   File.chardev?(file_name)   ->  true or false
+ *   File.chardev?(object) -> true or false
  *
- * Returns <code>true</code> if the named file is a character device.
+ * Returns +true+ if +object+ is a character device, +false+ otherwise.
  *
- * _file_name_ can be an IO object.
+  *  File.chardev?($stdin)     # => true
+ *   File.chardev?('t.txt')     # => false
+ *
  */
 static VALUE
 rb_file_chardev_p(VALUE obj, VALUE fname)


### PR DESCRIPTION
Treats:
- ::pipe?
- ::symlink?
- ::socket?
- ::blockdev?
- ::chardev?

This work was begun in [PR 5861](https://github.com/ruby/ruby/pull/5861).  I've moved my operation onto a new machine, and also am now in Windows Subsystem for Linux (to have better examples).  Result is that my recent push came here, and not to 5861.  The few comments there (from @jeremyevans) are accommodated here.  Sorry for the mess.