### PR TITLE
Add yjit object file to DTRACE_DEPENDENT_OBJS list

### DIFF
--- a/template/Makefile.in
+++ b/template/Makefile.in
@@ -200,7 +200,7 @@ DTRACE_DEPENDENT_OBJS = array.$(OBJEXT) \
 			string.$(OBJEXT) \
 			symbol.$(OBJEXT) \
 			vm.$(OBJEXT) \
-			yjit.$(OBJEXT)
+			$(YJIT_OBJ)
 
 THREAD_MODEL  = @THREAD_MODEL@
 

--- a/template/Makefile.in
+++ b/template/Makefile.in
@@ -199,7 +199,8 @@ DTRACE_DEPENDENT_OBJS = array.$(OBJEXT) \
 			parse.$(OBJEXT) \
 			string.$(OBJEXT) \
 			symbol.$(OBJEXT) \
-			vm.$(OBJEXT)
+			vm.$(OBJEXT) \
+			yjit.$(OBJEXT)
 
 THREAD_MODEL  = @THREAD_MODEL@
 


### PR DESCRIPTION
On systems where dtrace requires a recompilation (DTRACE_REBUILD=yes), this is necessary for successful build (as yjit contains new dtrace probes).

This addresses the following issue:
https://bugs.ruby-lang.org/issues/18480