### PR TITLE
YJIT shovel operator (<<) speedup.

### DIFF
--- a/test/ruby/test_yjit.rb
+++ b/test/ruby/test_yjit.rb
@@ -316,6 +316,32 @@ class TestYJIT < Test::Unit::TestCase
     RUBY
   end
 
+  def test_string_concat_utf8
+    assert_compiles(<<~RUBY, frozen_string_literal: true, result: true)
+      def str_cat_utf8
+        s = String.new
+        10.times { s << "✅" }
+        s
+      end
+
+      str_cat_utf8 == "✅" * 10
+    RUBY
+  end
+
+  def test_string_concat_ascii
+    # Constant-get for classes (e.g. String, Encoding) can cause a side-exit in getinlinecache. For now, ignore exits.
+    assert_compiles(<<~RUBY, exits: :any)
+      str_arg = "b".encode(Encoding::ASCII)
+      def str_cat_ascii(arg)
+        s = String.new(encoding: Encoding::ASCII)
+        10.times { s << arg }
+        s
+      end
+
+      str_cat_ascii(str_arg) == str_arg * 10
+    RUBY
+  end
+
   def test_opt_length_in_method
     assert_compiles(<<~RUBY, insns: %i[opt_length], result: 5)
       def foo(str)
@@ -646,7 +672,7 @@ class TestYJIT < Test::Unit::TestCase
     disasm = stats[:disasm]
 
     # Check that exit counts are as expected
-    # Full stats are only available when RUBY_DEBUG enabled
+    # Full stats are only available when --enable-yjit=dev
     if runtime_stats[:all_stats]
       recorded_exits = runtime_stats.select { |k, v| k.to_s.start_with?("exit_") }
       recorded_exits = recorded_exits.reject { |k, v| v == 0 }
@@ -658,7 +684,7 @@ class TestYJIT < Test::Unit::TestCase
       end
     end
 
-    # Only available when RUBY_DEBUG enabled
+    # Only available when --enable-yjit=dev
     if runtime_stats[:all_stats]
       missed_insns = insns.dup
 
@@ -675,13 +701,18 @@ class TestYJIT < Test::Unit::TestCase
     end
   end
 
+  def script_shell_encode(s)
+    # We can't pass utf-8-encoded characters directly in a shell arg. But we can use Ruby \u constants.
+    s.chars.map { |c| c.ascii_only? ? c : "\\u%x" % c.codepoints[0] }.join
+  end
+
   def eval_with_jit(script, call_threshold: 1, timeout: 1000)
     args = [
       "--disable-gems",
       "--yjit-call-threshold=#{call_threshold}",
       "--yjit-stats"
     ]
-    args << "-e" << script
+    args << "-e" << script_shell_encode(script)
     stats_r, stats_w = IO.pipe
     out, err, status = EnvUtil.invoke_ruby(args,
       '', true, true, timeout: timeout, ios: {3 => stats_w}

--- a/yjit.c
+++ b/yjit.c
@@ -557,6 +557,12 @@ rb_leaf_builtin_function(const rb_iseq_t *iseq)
     return (const struct rb_builtin_function *)iseq->body->iseq_encoded[1];
 }
 
+VALUE
+rb_yjit_str_simple_append(VALUE str1, VALUE str2)
+{
+    return rb_str_cat(str1, RSTRING_PTR(str2), RSTRING_LEN(str2));
+}
+
 struct rb_control_frame_struct *
 rb_get_ec_cfp(rb_execution_context_t *ec)
 {
@@ -690,6 +696,13 @@ VALUE
 rb_RCLASS_ORIGIN(VALUE c)
 {
     return RCLASS_ORIGIN(c);
+}
+
+// Return the string encoding index
+int
+rb_ENCODING_GET(VALUE obj)
+{
+    return RB_ENCODING_GET(obj);
 }
 
 bool

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -33,6 +33,7 @@ fn main() {
 
     let bindings = bindgen::builder()
         .clang_args(filtered_clang_args)
+        .header("encindex.h")
         .header("internal.h")
         .header("internal/re.h")
         .header("include/ruby/ruby.h")
@@ -57,6 +58,7 @@ fn main() {
 
         // From include/ruby/internal/intern/string.h
         .allowlist_function("rb_utf8_str_new")
+        .allowlist_function("rb_str_append")
 
         // This struct is public to Ruby C extensions
         // From include/ruby/internal/core/rbasic.h
@@ -68,6 +70,9 @@ fn main() {
 
         // From ruby/internal/intern/object.h
         .allowlist_function("rb_obj_is_kind_of")
+
+        // From ruby/internal/encoding/encoding.h
+        .allowlist_type("ruby_encoding_consts")
 
         // From include/hash.h
         .allowlist_function("rb_hash_new")
@@ -228,6 +233,8 @@ fn main() {
         .allowlist_function("rb_yjit_dump_iseq_loc")
         .allowlist_function("rb_yjit_for_each_iseq")
         .allowlist_function("rb_yjit_obj_written")
+        .allowlist_function("rb_yjit_str_simple_append")
+        .allowlist_function("rb_ENCODING_GET")
 
         // from vm_sync.h
         .allowlist_function("rb_vm_barrier")

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -173,6 +173,9 @@ extern "C" {
     ) -> VALUE;
 }
 extern "C" {
+    pub fn rb_str_append(dst: VALUE, src: VALUE) -> VALUE;
+}
+extern "C" {
     pub fn rb_str_intern(str_: VALUE) -> VALUE;
 }
 extern "C" {
@@ -181,6 +184,11 @@ extern "C" {
 extern "C" {
     pub fn rb_attr_get(obj: VALUE, name: ID) -> VALUE;
 }
+pub const RUBY_ENCODING_INLINE_MAX: ruby_encoding_consts = 127;
+pub const RUBY_ENCODING_SHIFT: ruby_encoding_consts = 22;
+pub const RUBY_ENCODING_MASK: ruby_encoding_consts = 532676608;
+pub const RUBY_ENCODING_MAXNAMELEN: ruby_encoding_consts = 42;
+pub type ruby_encoding_consts = u32;
 extern "C" {
     pub fn rb_obj_info_dump(obj: VALUE);
 }
@@ -732,6 +740,9 @@ extern "C" {
     pub fn rb_leaf_builtin_function(iseq: *const rb_iseq_t) -> *const rb_builtin_function;
 }
 extern "C" {
+    pub fn rb_yjit_str_simple_append(str1: VALUE, str2: VALUE) -> VALUE;
+}
+extern "C" {
     pub fn rb_set_cfp_pc(cfp: *mut rb_control_frame_struct, pc: *const VALUE);
 }
 extern "C" {
@@ -742,6 +753,9 @@ extern "C" {
 }
 extern "C" {
     pub fn rb_yjit_dump_iseq_loc(iseq: *const rb_iseq_t, insn_idx: u32);
+}
+extern "C" {
+    pub fn rb_ENCODING_GET(obj: VALUE) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn rb_yjit_multi_ractor_p() -> bool;


### PR DESCRIPTION
For string concat, check at runtime if encoding of strings matches.
If so, use simple buffer string concat at runtime (rb_str_cat). Otherwise, use
encoding-checking string concat (rb_str_append.)