### PR TITLE
Fix various autoload race conditions.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -208,6 +208,8 @@ The following deprecated APIs are removed.
 
 ## Implementation improvements
 
+* Fixed several race conditions in `Kernel#autoload`. [[Bug #18782]]
+
 ## JIT
 
 ### MJIT
@@ -253,3 +255,4 @@ The following deprecated APIs are removed.
 [Feature #18598]: https://bugs.ruby-lang.org/issues/18598
 [Bug #18625]:     https://bugs.ruby-lang.org/issues/18625
 [Bug #18633]:     https://bugs.ruby-lang.org/issues/18633
+[Bug #18782]:     https://bugs.ruby-lang.org/issues/18782

--- a/thread.c
+++ b/thread.c
@@ -1562,6 +1562,10 @@ static inline int
 blocking_region_begin(rb_thread_t *th, struct rb_blocking_region_buffer *region,
 		      rb_unblock_function_t *ubf, void *arg, int fail_if_interrupted)
 {
+#ifdef RUBY_VM_CRITICAL_SECTION
+    VM_ASSERT(rb_vm_critical_section_entered == 0);
+#endif
+
     region->prev_status = th->status;
     if (unblock_function_set(th, ubf, arg, fail_if_interrupted)) {
 	th->blocking_region_buffer = region;

--- a/variable.c
+++ b/variable.c
@@ -48,6 +48,11 @@ static struct rb_id_table *rb_global_tbl;
 static ID autoload, classpath, tmp_classpath;
 static VALUE autoload_featuremap; /* feature => autoload_i */
 
+// This mutex is used to protect autoloading state. We use a global mutex which
+// is held until a per-feature mutex can be created. This ensures there are no
+// race conditions relating to autoload state.
+static VALUE autoload_mutex;
+
 static void check_before_mod_set(VALUE, ID, VALUE, const char *);
 static void setup_const_entry(rb_const_entry_t *, VALUE, VALUE, rb_const_flag_t);
 static VALUE rb_const_search(VALUE klass, ID id, int exclude, int recurse, int visibility);
@@ -72,6 +77,9 @@ Init_var_tables(void)
     classpath = rb_intern_const("__classpath__");
     /* __tmp_classpath__: temporary class path which contains anonymous names */
     tmp_classpath = rb_intern_const("__tmp_classpath__");
+
+    autoload_mutex = rb_mutex_new();
+    rb_gc_register_mark_object(autoload_mutex);
 }
 
 static inline bool
@@ -2233,18 +2241,18 @@ rb_autoload_str(VALUE mod, ID id, VALUE file)
 
     Check_Type(file, T_STRING);
     if (!RSTRING_LEN(file)) {
-	rb_raise(rb_eArgError, "empty file name");
+        rb_raise(rb_eArgError, "empty file name");
     }
 
     ce = rb_const_lookup(mod, id);
     if (ce && ce->value != Qundef) {
-	return;
+        return;
     }
 
     const_set(mod, id, Qundef);
     tbl = RCLASS_IV_TBL(mod);
     if (tbl && st_lookup(tbl, (st_data_t)autoload, &av)) {
-	tbl = check_autoload_table((VALUE)av);
+        tbl = check_autoload_table((VALUE)av);
     }
     else {
 	if (!tbl) tbl = RCLASS_IV_TBL(mod) = st_init_numtable();
@@ -2382,9 +2390,11 @@ rb_autoloading_value(VALUE mod, ID id, VALUE* value, rb_const_flag_t *flag)
     if (value) {
         *value = ac->value;
     }
+
     if (flag) {
         *flag = ac->flag;
     }
+
     return TRUE;
 }
 
@@ -2393,6 +2403,9 @@ autoload_by_current(struct autoload_data_i *ele) {
     return ele->state && ele->state->mutex != Qnil && rb_mutex_owned_p(ele->state->mutex);
 }
 
+// If there is an autoloading constant and it has been set by the current
+// execution context, return it. This allows threads which are loading code to
+// refer to their own autoloaded constants.
 struct autoload_const *
 autoloading_const_entry(VALUE mod, ID id)
 {
@@ -2400,10 +2413,13 @@ autoloading_const_entry(VALUE mod, ID id)
     struct autoload_data_i *ele;
     struct autoload_const *ac;
 
+    // Find the autoloading state:
     if (!load || !(ele = get_autoload_data(load, &ac))) {
+        // Couldn't be found:
         return 0;
     }
 
+    // Check if it's being loaded by the current thread/fiber:
     if (autoload_by_current(ele)) {
         if (ac->value != Qundef) {
             return ac;
@@ -2418,13 +2434,17 @@ autoload_defined_p(VALUE mod, ID id)
 {
     rb_const_entry_t *ce = rb_const_lookup(mod, id);
 
+    // If there is no constant or the constant is not undefined (special marker for autoloading):
     if (!ce || ce->value != Qundef) {
-	return 0;
+        // We are not autoloading:
+        return 0;
     }
+
+    // Otherwise check if there is an autoload in flight right now:
     return !rb_autoloading_value(mod, id, NULL, NULL);
 }
 
-static void const_tbl_update(struct autoload_const *);
+static void const_tbl_update(struct autoload_const *, int);
 
 static VALUE
 autoload_const_set(struct autoload_const *ac)
@@ -2435,7 +2455,7 @@ autoload_const_set(struct autoload_const *ac)
 
     RB_VM_LOCK_ENTER();
     {
-        const_tbl_update(ac);
+        const_tbl_update(ac, true);
     }
     RB_VM_LOCK_LEAVE();
 
@@ -2466,50 +2486,65 @@ autoload_reset(VALUE arg)
     ele = rb_check_typeddata(ac->ad, &autoload_data_i_type);
     VALUE mutex = state->mutex;
 
+    // If we are the main thread to execute...
     if (ele->state == state) {
+        // Prepare to update the state of the world:
+        rb_mutex_lock(autoload_mutex);
+
+        // At the last, move a value defined in autoload to constant table:
+        if (RTEST(state->result)) {
+            // Can help to test race conditions:
+            // rb_thread_schedule();
+
+            struct autoload_const *next;
+
+            ccan_list_for_each_safe(&ele->constants, ac, next, cnode) {
+                if (ac->value != Qundef) {
+                    autoload_const_set(ac);
+                }
+            }
+        }
+
+        // Reset the autoload state - i.e. clear our state from the autoload data:
         ele->state = 0;
         ele->fork_gen = 0;
+
+        rb_mutex_unlock(autoload_mutex);
     }
 
     rb_mutex_unlock(mutex);
 
-    /* At the last, move a value defined in autoload to constant table */
-    if (RTEST(state->result)) {
-        struct autoload_const *next;
-
-        ccan_list_for_each_safe(&ele->constants, ac, next, cnode) {
-            if (ac->value != Qundef) {
-                autoload_const_set(ac);
-            }
-        }
-    }
-
     return 0; /* ignored */
 }
 
-VALUE
-rb_autoload_load(VALUE mod, ID id)
+struct autoload_load_arguments {
+    VALUE module;
+    ID name;
+    struct autoload_state *state;
+};
+
+static VALUE
+autoload_load_synchronized(VALUE _arguments)
 {
+    struct autoload_load_arguments *arguments = (struct autoload_load_arguments*)_arguments;
+
     VALUE load;
     const char *loading = 0, *src;
     struct autoload_data_i *ele;
     struct autoload_const *ac;
-    struct autoload_state state;
-    int flag = -1;
-    rb_const_entry_t *ce;
 
-    if (!autoload_defined_p(mod, id)) return Qfalse;
-    load = check_autoload_required(mod, id, &loading);
-    if (!load) return Qfalse;
-    src = rb_sourcefile();
-    if (src && loading && strcmp(src, loading) == 0) return Qfalse;
-
-    if (UNLIKELY(!rb_ractor_main_p())) {
-        rb_raise(rb_eRactorUnsafeError, "require by autoload on non-main Ractor is not supported (%s)", rb_id2name(id));
+    if (!autoload_defined_p(arguments->module, arguments->name)) {
+        return Qfalse;
     }
 
-    if ((ce = rb_const_lookup(mod, id))) {
-        flag = ce->flag & (CONST_DEPRECATED | CONST_VISIBILITY_MASK);
+    load = check_autoload_required(arguments->module, arguments->name, &loading);
+    if (!load) {
+        return Qfalse;
+    }
+
+    src = rb_sourcefile();
+    if (src && loading && strcmp(src, loading) == 0) {
+        return Qfalse;
     }
 
     /* set ele->state for a marker of autoloading thread */
@@ -2517,34 +2552,71 @@ rb_autoload_load(VALUE mod, ID id)
         return Qfalse;
     }
 
-    state.ac = ac;
+    struct autoload_state * state = arguments->state;
+    state->ac = ac;
 
     if (!ele->state) {
-        ele->state = &state;
-        ele->state->mutex = rb_mutex_new();
+        state->mutex = rb_mutex_new();
         ele->fork_gen = GET_VM()->fork_gen;
+        ele->state = state;
     }
     else if (rb_mutex_owned_p(ele->state->mutex)) {
         return Qfalse;
     } else {
-        state.mutex = ele->state->mutex;
+        state->mutex = ele->state->mutex;
     }
 
-    // Block all other threads that come here until we are done in autoload_reset. At that point, all threads can continue. Current implementation prevents threads from executing in parallel even though at that point there are no data races.
+    return load;
+}
+
+VALUE
+rb_autoload_load(VALUE module, ID name)
+{
+    rb_const_entry_t *ce = rb_const_lookup(module, name);
+
+    // We bail out as early as possible without any synchronisation:
+    if (!ce || ce->value != Qundef) {
+        return Qfalse;
+    }
+
+    // At this point, we assume there might be autoloading.
+
+    if (UNLIKELY(!rb_ractor_main_p())) {
+        rb_raise(rb_eRactorUnsafeError, "require by autoload on non-main Ractor is not supported (%s)", rb_id2name(name));
+    }
+
+    // This state is stored on thes stack and is used during the autoload process.
+    struct autoload_state state = {.mutex = Qnil, .result = Qfalse};
+    struct autoload_load_arguments arguments = {.module = module, .name = name, .state = &state};
+
+    // Figure out whether we can autoload the named constant:
+    VALUE load = rb_mutex_synchronize(autoload_mutex, autoload_load_synchronized, (VALUE)&arguments);
+
+    // This confirms whether autoloading is required or not:
+    if (load == Qfalse) return load;
+
+    // Every thread that tries to autoload a variable will stop here:
     rb_mutex_lock(state.mutex);
 
-    /* autoload_data_i can be deleted by another thread while require */
-    state.result = Qfalse;
+    // Every thread goes through this process, but only one of them will ultimately require the file.
+
+    int flag = 0;
+
+    // Capture any flags on the specified "Qundef" constant so we can re-apply them later:
+    if (ce) {
+        flag = ce->flag & (CONST_DEPRECATED | CONST_VISIBILITY_MASK);
+    }
+
     VALUE result = rb_ensure(autoload_require, (VALUE)&state, autoload_reset, (VALUE)&state);
 
-    if (!(ce = rb_const_lookup(mod, id)) || ce->value == Qundef) {
-        rb_const_remove(mod, id);
+    // If we did not apply the constant after requiring it, remove it:
+    if (!(ce = rb_const_lookup(module, name)) || ce->value == Qundef) {
+        rb_const_remove(module, name);
     }
     else if (flag > 0) {
+        // Re-apply any flags:
         ce->flag |= flag;
     }
-
-    RB_GC_GUARD(load);
 
     return result;
 }
@@ -3090,7 +3162,7 @@ const_set(VALUE klass, ID id, VALUE val)
                 .value = val, .flag = CONST_PUBLIC,
                 /* fill the rest with 0 */
             };
-            const_tbl_update(&ac);
+            const_tbl_update(&ac, false);
         }
     }
     RB_VM_LOCK_LEAVE();
@@ -3148,7 +3220,7 @@ current_autoload_data(VALUE mod, ID id, struct autoload_const **acp)
 }
 
 static void
-const_tbl_update(struct autoload_const *ac)
+const_tbl_update(struct autoload_const *ac, int autoload_force)
 {
     VALUE value;
     VALUE klass = ac->mod;
@@ -3163,7 +3235,7 @@ const_tbl_update(struct autoload_const *ac)
         if (ce->value == Qundef) {
             struct autoload_data_i *ele = current_autoload_data(klass, id, &ac);
 
-            if (ele) {
+            if (!autoload_force && ele) {
                 rb_clear_constant_cache_for_id(id);
 
                 ac->value = val; /* autoload_i is non-WB-protected */

--- a/variable.c
+++ b/variable.c
@@ -2141,22 +2141,6 @@ autoload_i_mark(void *ptr)
     struct autoload_data_i *p = ptr;
 
     rb_gc_mark_movable(p->feature);
-
-    /* allow GC to free us if no modules refer to this via autoload_const.ad */
-    if (ccan_list_empty(&p->constants)) {
-        rb_hash_delete(autoload_featuremap, p->feature);
-    }
-}
-
-static void
-autoload_i_free(void *ptr)
-{
-    struct autoload_data_i *p = ptr;
-
-    /* we may leak some memory at VM shutdown time, no big deal */
-    if (ccan_list_empty(&p->constants)) {
-	xfree(p);
-    }
 }
 
 static size_t
@@ -2167,7 +2151,7 @@ autoload_i_memsize(const void *ptr)
 
 static const rb_data_type_t autoload_data_i_type = {
     "autoload_i",
-    {autoload_i_mark, autoload_i_free, autoload_i_memsize, autoload_i_compact},
+    {autoload_i_mark, ruby_xfree, autoload_i_memsize, autoload_i_compact},
     0, 0, RUBY_TYPED_FREE_IMMEDIATELY
 };
 
@@ -2193,14 +2177,6 @@ autoload_c_mark(void *ptr)
     rb_gc_mark_movable(ac->file);
 }
 
-static void
-autoload_c_free(void *ptr)
-{
-    struct autoload_const *ac = ptr;
-    ccan_list_del(&ac->cnode);
-    xfree(ac);
-}
-
 static size_t
 autoload_c_memsize(const void *ptr)
 {
@@ -2209,7 +2185,7 @@ autoload_c_memsize(const void *ptr)
 
 static const rb_data_type_t autoload_const_type = {
     "autoload_const",
-    {autoload_c_mark, autoload_c_free, autoload_c_memsize, autoload_c_compact,},
+    {autoload_c_mark, ruby_xfree, autoload_c_memsize, autoload_c_compact,},
     0, 0, RUBY_TYPED_FREE_IMMEDIATELY
 };
 

--- a/vm.c
+++ b/vm.c
@@ -48,6 +48,10 @@
 #endif
 #include "probes_helper.h"
 
+#ifdef RUBY_VM_CRITICAL_SECTION
+int rb_vm_critical_section_entered = 0;
+#endif
+
 VALUE rb_str_concat_literals(size_t, const VALUE*);
 
 /* :FIXME: This #ifdef is because we build pch in case of mswin and

--- a/vm_core.h
+++ b/vm_core.h
@@ -56,10 +56,19 @@
 #if VM_CHECK_MODE > 0
 #define VM_ASSERT(expr) RUBY_ASSERT_MESG_WHEN(VM_CHECK_MODE > 0, expr, #expr)
 #define VM_UNREACHABLE(func) rb_bug(#func ": unreachable")
-
+#define RUBY_VM_CRITICAL_SECTION
 #else
 #define VM_ASSERT(expr) ((void)0)
 #define VM_UNREACHABLE(func) UNREACHABLE
+#endif
+
+#if defined(RUBY_VM_CRITICAL_SECTION)
+extern int rb_vm_critical_section_entered;
+#define RUBY_VM_CRITICAL_SECTION_ENTER rb_vm_critical_section_entered += 1;
+#define RUBY_VM_CRITICAL_SECTION_EXIT rb_vm_critical_section_entered -= 1;
+#else
+#define RUBY_VM_CRITICAL_SECTION_ENTER
+#define RUBY_VM_CRITICAL_SECTION_EXIT
 #endif
 
 #if defined(__wasm__) && !defined(__EMSCRIPTEN__)


### PR DESCRIPTION
This PR attempts to address two race conditions outlined in <https://bugs.ruby-lang.org/issues/18782>.

1. It's possible to race on adding and then deleting items in `autoload_featuremap`. When this happens, two threads will try to load the same file with different autoload data and deadlock.
2. When finishing autoload, it's necessary to clear `ele->state` before setting constants. If this is not synchronised, a thread can see the cleared `ele->state` before seeing the constants and assume the constant is not being autoloaded and then fail with `NameError`.

This PR also introduces a new critical section macro for helping debug these issues. You can quickly reproduce these issues by inserting `rb_thread_schedule()` at relevant locations (i.e. (1) after setting hash in or (2) after calling `ele->state = 0`).

This test case can reproduce both cases:

```
# test.rb
autoload_path = File.join(__dir__, "foobar.rb")
File.write(autoload_path, 'module Foo; end; module Bar; end')

100_000.times do
	$stderr.puts "--------------------"
	autoload :Foo, autoload_path
	autoload :Bar, autoload_path

	t1 = Thread.new {Foo}
	t2 = Thread.new {Bar}

	t1.join
	t2.join

	Object.send(:remove_const, :Foo)
	Object.send(:remove_const, :Bar)

	$LOADED_FEATURES.delete(autoload_path)
end
```

Example failure of case (1):

```
-------------------- (success)
autoload_by_someone_else ele=0x55f33b806a30 ele->state=(nil)
autoload_by_someone_else ele=0x55f33b806a30 ele->state=(nil)
check_autoload_required 2
autoload_by_someone_else ele=0x55f33b806a30 ele->state=0x7fdd678be780
check_autoload_required 4
autoload_by_someone_else ele=0x55f33b806a30 ele->state=0x7fdd678be780
check_autoload_required 4
ele=0x55f33b806a30 ele->state=0x7fdd678be780 = NULL
check_autoload_required 4
-------------------- (failure)
autoload_by_someone_else ele=0x55f33b806a30 ele->state=(nil)
autoload_by_someone_else ele=0x55f33b6e8f40 ele->state=(nil)
check_autoload_required 2
check_autoload_required 3
autoload_by_someone_else ele=0x55f33b806a30 ele->state=0x7fdd6779d780
check_autoload_required 1
autoload_by_someone_else ele=0x55f33b806a30 ele->state=0x7fdd6779d780
check_autoload_required 1
ele=0x55f33b806a30 ele->state=0x7fdd6779d780 = NULL
ele=0x55f33b6e8f40 ele->state=0x7fdd678be780 = NULL
../test.rb:12:in `join': No live threads left. Deadlock? (fatal)
3 threads, 3 sleeps current:0x000055f33b771250 main thread:0x000055f33b66e090
* #<Thread:0x00007fdd6a2cb0b0 sleep_forever>
   rb_thread_t:0x000055f33b66e090 native:0x00007fdd6a71c3c0 int:0
   
* #<Thread:0x00007fdd676e0090 ../test.rb:9 sleep_forever>
   rb_thread_t:0x000055f33b770ff0 native:0x00007fdd6789e640 int:1 mutex:0x000055f33b7c5100 cond:1
    depended by: tb_thread_id:0x000055f33b66e090
   
* #<Thread:0x00007fdd676e1238 ../test.rb:10 sleep_forever>
   rb_thread_t:0x000055f33b771250 native:0x00007fdd679bf640 int:0
   

	from ../test.rb:12:in `block in <main>'
	from ../test.rb:4:in `times'
	from ../test.rb:4:in `<main>'
make: *** [uncommon.mk:1250: runruby] Error 1
```

Example failure of case (2):

```
[0x7f175fe5b0c8] rb_autoload_str mod=Object id=Foo file="/home/samuel/Projects/ioquatix/ruby/foobar.rb"
[0x7f175fe5b0c8] rb_autoload_str const_set mod=Object id=Foo file="/home/samuel/Projects/ioquatix/ruby/foobar.rb"
[0x7f175fe5b0c8] rb_autoload_str mod=Object id=Bar file="/home/samuel/Projects/ioquatix/ruby/foobar.rb"
[0x7f175fe5b0c8] rb_autoload_str const_set mod=Object id=Bar file="/home/samuel/Projects/ioquatix/ruby/foobar.rb"
[0x7f175fe61d88] rb_const_search_from value == Qundef -> autoloading
[0x7f175fe61e78] rb_const_search_from value == Qundef -> autoloading
[0x7f175fe61e78] Assigning constants...
[0x7f175fe61d88] rb_const_search_from value == Qundef -> autoloading
[0x7f175fe61e78] autoload_const_set name=:Foo value=Foo
[0x7f175fe61e78] autoload_const_set name=:Bar value=Bar
#<Thread:0x00007f175fe61d88 ../test.rb:11 run> terminated with exception (report_on_exception is true):
../test.rb:11:in `block (2 levels) in <main>': uninitialized constant Bar (NameError)
../test.rb:11:in `block (2 levels) in <main>': uninitialized constant Bar (NameError)
make: *** [uncommon.mk:1250: runruby] Error 1
```

These failures are very uncommon but it does impact Ruby as far back as 2.7, and probably earlier.