### PR TITLE
Add a separate doc for contributing to stdlibs

### DIFF
--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -5,6 +5,7 @@ This guide outlines ways to get started with contributing to Ruby:
 * [Reporting issues](contributing/reporting_issues.md): How to report issues, how to request features, and how backporting works
 * [Building Ruby](contributing/building_ruby.md): How to build Ruby on your local machine for development
 * [Testing Ruby](contributing/testing_ruby.md): How to test Ruby on your local machine once you've built it
-* [Making changes to Ruby](contributing/making_changes_to_ruby.md): How to submit pull requests 
+* [Making changes to Ruby](contributing/making_changes_to_ruby.md): How to submit pull requests
   to change Ruby's documentation, code, test suite, or standard libraries
+* [Making changes to Ruby standard libraries](contributing/making_changes_to_stdlibs.md): How to build, test, and contribute to Ruby standard libraries
 * [Making changes to Ruby documentation](contributing/documentation_guide.md): How to make changes to Ruby documentation

--- a/doc/contributing/making_changes_to_ruby.md
+++ b/doc/contributing/making_changes_to_ruby.md
@@ -26,11 +26,3 @@ Use the following style for commit messages:
 GitHub actions will run on each pull request.
 
 There is [a CI that runs on master](https://rubyci.org/). It has broad coverage of different systems and architectures, such as Solaris SPARC and macOS.
-
-# Contributing to standard libraries
-
-Everything in the [lib](https://github.com/ruby/ruby/tree/master/lib) directory is mirrored from a standalone repository into the Ruby repository.
-If you'd like to make contributions to standard libraries, do so in the standalone repositories, and the
-changes will be automatically mirrored into the Ruby repository.
-
-For example, CSV lives in [a separate repository](https://github.com/ruby/csv) and is mirrored into [Ruby](https://github.com/ruby/ruby/tree/master/lib/csv).

--- a/doc/contributing/making_changes_to_stdlibs.md
+++ b/doc/contributing/making_changes_to_stdlibs.md
@@ -1,0 +1,49 @@
+# Making Changes To Standard Libraries
+
+Everything in the [lib](https://github.com/ruby/ruby/tree/master/lib) directory is mirrored from a standalone repository into the Ruby repository.
+If you'd like to make contributions to standard libraries, do so in the standalone repositories, and the
+changes will be automatically mirrored into the Ruby repository.
+
+For example, CSV lives in [a separate repository](https://github.com/ruby/csv) and is mirrored into [Ruby](https://github.com/ruby/ruby/tree/master/lib/csv).
+
+## Maintainers
+
+You can find the list of maintainers [here](https://docs.ruby-lang.org/en/master/maintainers_rdoc.html#label-Maintainers).
+
+## Build
+
+First, install its dependencies using:
+
+```
+bundle install
+```
+
+### Libraries with C-extension
+
+If the library has a `/ext` directory, it has C files that you need to compile with:
+
+```
+bundle exec rake compile
+```
+
+## Running tests
+
+All standard libraries use [test-unit](https://github.com/test-unit/test-unit) as the test framework.
+
+To run all tests:
+
+```
+bundle exec rake test
+```
+
+To run a single test file:
+
+```
+bundle exec rake test TEST="test/test_foo.rb"
+```
+
+To run a single test case:
+
+```
+bundle exec rake test TEST="test/test_foo.rb" TESTOPS="--name=/test_mytest/"
+```


### PR DESCRIPTION
The plan is to have this basic guideline here, and add `CONTRIBUTING.md` that links to this file to standard libraries.

co-authored-by: Peter Zhu <peter@peterzhu.ca>

