### PR TITLE
Quick markup fix

### DIFF
--- a/doc/syntax/literals.rdoc
+++ b/doc/syntax/literals.rdoc
@@ -441,10 +441,10 @@ This proc will add one to its argument.
 Each of the literals in described in this section
 may use these paired delimiters:
 
-* <tt>[</tt> and </tt>]</tt>.
-* <tt>(</tt> and </tt>)</tt>.
-* <tt>{</tt> and </tt>}</tt>.
-* <tt><</tt> and </tt>></tt>.
+* <tt>[</tt> and <tt>]</tt>.
+* <tt>(</tt> and <tt>)</tt>.
+* <tt>{</tt> and <tt>}</tt>.
+* <tt><</tt> and <tt>></tt>.
 * Any other character, as both beginning and ending delimiters.
 
 These are demonstrated in the next section.


### PR DESCRIPTION
Just removing the `/` in the opening `tt` tags in `doc/syntax/literals.rdoc`.