### PR TITLE
Pass an optional range object to #deconstruct

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -6820,9 +6820,9 @@ iseq_compile_array_deconstruct(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NO
     // Otherwise, we're going to construct a range object that represents the
     // number of elements that are being matched against.
     ADD_LABEL(ret, deconstruct_arity1);
-    ADD_INSN1(ret, line_node, putobject, INT2FIX(min_argc));
-    ADD_INSN1(ret, line_node, putobject, endless ? Qnil : INT2FIX(min_argc));
-    ADD_INSN1(ret, line_node, newrange, INT2FIX(0));
+    VALUE range_min = INT2FIX(min_argc);
+    VALUE range = rb_range_new(range_min, (endless ? Qnil : range_min), FALSE);
+    ADD_INSN1(ret, line_node, putobject, range);
     ADD_SEND(ret, line_node, rb_intern("deconstruct"), INT2FIX(1));
 
     // Finally, we now have deconstructed depending on the arity.

--- a/test/ruby/test_pattern_matching.rb
+++ b/test/ruby/test_pattern_matching.rb
@@ -1674,4 +1674,59 @@ END
       end
     end
   end
+
+  class DeconstructWithRange
+    def initialize(values)
+      @values = values
+    end
+
+    def deconstruct(range)
+      range.cover?(@values.length) ? @values : []
+    end
+  end
+
+  def test_passes_range_to_deconstruct
+    assert_block do
+      case DeconstructWithRange.new([1, 2])
+      in [1, 2]
+        true
+      end
+    end
+
+    assert_block do
+      case DeconstructWithRange.new([1, 2])
+      in [1, 2, *]
+        true
+      end
+    end
+
+    assert_block do
+      case DeconstructWithRange.new([1, 2])
+      in [*, 1, 2]
+        true
+      end
+    end
+
+    assert_block do
+      case DeconstructWithRange.new([1, 2])
+      in [1, *, 2]
+        true
+      end
+    end
+
+    assert_block do
+      case DeconstructWithRange.new([1, 2])
+      in [1, *]
+        true
+      end
+    end
+
+    assert_block do
+      case DeconstructWithRange.new([1, 2])
+      in [1, 2, 3]
+      else
+        true
+      end
+    end
+  end
 end


### PR DESCRIPTION
When you're matching against an array and it's expensive to compute the array, pattern matching can become surprisingly expensive. In order to avoid this, Ruby can pass a range to #deconstruct calls to make it easier for users to reject a match quickly without having to compute the whole array.

Tracked in https://bugs.ruby-lang.org/issues/18773.