### PR TITLE
Use make gdb-ruby and make lldb-ruby

### DIFF
--- a/doc/contributing/building_ruby.md
+++ b/doc/contributing/building_ruby.md
@@ -70,5 +70,5 @@ with the Ruby script you'd like to run. You can use the following make targets:
 * `make lldb`: Runs `test.rb` using Miniruby in lldb
 * `make gdb`: Runs `test.rb` using Miniruby in gdb
 * `make runruby`: Runs `test.rb` using Ruby
-* `make lldb-runruby`: Runs `test.rb` using Ruby in lldb
-* `make gdb-runruby`: Runs `test.rb` using Ruby in gdb
+* `make lldb-ruby`: Runs `test.rb` using Ruby in lldb
+* `make gdb-ruby`: Runs `test.rb` using Ruby in gdb


### PR DESCRIPTION
I am still learning how to debug the source code, so I can be missing some information.

make lldb-runruby and make gdb-runruby do not seem to exist when I try.

```
# make lldb-runruby
make: *** No rule to make target 'lldb-runruby'.  Stop.
# make gdb-runruby
make: *** No rule to make target 'gdb-runruby'.  Stop.
```
I am able to use make gdb-ruby and make lldb-ruby though.



