### PR TITLE
Delete autoload data from global features after autoload has completed.

### DIFF
--- a/test/ruby/test_autoload.rb
+++ b/test/ruby/test_autoload.rb
@@ -491,4 +491,32 @@ p Foo::Bar
     ::Object.class_eval {remove_const(:AutoloadTest)} if defined? Object::AutoloadTest
     TestAutoload.class_eval {remove_const(:AutoloadTest)} if defined? TestAutoload::AutoloadTest
   end
+
+  def test_autoload_parallel_race
+    Dir.mktmpdir('autoload') do |tmpdir|
+      autoload_path = File.join(tmpdir, "autoload_parallel_race.rb")
+      File.write(autoload_path, 'module Foo; end; module Bar; end')
+
+      assert_separately([], <<-RUBY, timeout: 100)
+        autoload_path = #{File.realpath(autoload_path).inspect}
+
+        # This should work with no errors or failures.
+        1000.times do
+          autoload :Foo, autoload_path
+          autoload :Bar, autoload_path
+
+          t1 = Thread.new {Foo}
+          t2 = Thread.new {Bar}
+
+          t1.join
+          t2.join
+
+          Object.send(:remove_const, :Foo)
+          Object.send(:remove_const, :Bar)
+
+          $LOADED_FEATURES.delete(autoload_path)
+        end
+      RUBY
+    end
+  end
 end

--- a/thread.c
+++ b/thread.c
@@ -1563,7 +1563,7 @@ blocking_region_begin(rb_thread_t *th, struct rb_blocking_region_buffer *region,
 		      rb_unblock_function_t *ubf, void *arg, int fail_if_interrupted)
 {
 #ifdef RUBY_VM_CRITICAL_SECTION
-    VM_ASSERT(rb_vm_critical_section_entered == 0);
+    VM_ASSERT(ruby_assert_critical_section_entered == 0);
 #endif
 
     region->prev_status = th->status;

--- a/vm.c
+++ b/vm.c
@@ -48,8 +48,8 @@
 #endif
 #include "probes_helper.h"
 
-#ifdef RUBY_VM_CRITICAL_SECTION
-int rb_vm_critical_section_entered = 0;
+#ifdef RUBY_ASSERT_CRITICAL_SECTION
+int ruby_assert_critical_section_entered = 0;
 #endif
 
 VALUE rb_str_concat_literals(size_t, const VALUE*);


### PR DESCRIPTION
This is a follow up from my previous PR which continues to improve the synchronisation of autoload.

The current implementation feeds all threads through the same load process in the hopes one of them will eventually work. This PR attempts to enforce the following logic:

1. Is autoloading definitely not going to happen? return false.
2. Check non-main Ractor -> fail.
3. Take the `autoload_mutex` and double check that autoloading is necessary.
4. If not necessary -> return false, otherwise take a reference to the per-feature mutex.
5. Synchronise on the per-feature mutex and attempt to load the feature.
6. If the feature was loaded, assign all the constants and clear the autoloading state, otherwise, exit and allow any other threads to try.