### PR TITLE
Enable "make annocheck" on platforms other than Linux.

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1447,10 +1447,11 @@ yes-test-bundler-parallel: yes-test-bundler-prepare
 		$(PARALLELRSPECOPTS) $(srcdir)/spec/bundler/$(BUNDLER_SPECS)
 no-test-bundler-parallel:
 
-test-annocheck: $(target_os)-test-annocheck
-linux-test-annocheck: $(PROGRAM)
+# The annocheck supports ELF format binaries compiled for any OS and for any
+# architecture. It is designed to be independent of the host OS and the
+# architecture. The test-annocheck.sh requires docker or podman.
+test-annocheck: $(PROGRAM)
 	$(tooldir)/test-annocheck.sh $(PROGRAM)
-$(target_os)-test-annocheck: PHONY
 
 GEM = up
 sync-default-gems:


### PR DESCRIPTION
Right now the "make annocheck" is only enabled on host os: Linux (target_os: linux). However I think the "make annocheck" can be enabled on all the platforms basically, as the script executed in `make annocheck` only requires `docker` or `podman`.

I compiled Ruby on Mac and FreeBSD, then copied the binaries to my machine Fedora 35 where `annocheck` command is installed.

## Mac OSX

On Mac OSX, I built Ruby as follows. The `target_os` is `darwin17` on the environment, Mac OSX 10.13.6.

```
$ brew install gcc@11

$ gcc-11 --version
gcc-11 (Homebrew GCC 11.3.0) 11.3.0
Copyright (C) 2021 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

$ ./autogen.sh
$ ./configure --enable-shared --with-gcc="gcc-11"
$ make
```

Then copied the `./ruby` and `./libruby.3.2.dylib` binaries from Mac OSX to my Fedora 35, and I executed the `annocheck`. I saw the `annocheck` command on Fedora 35 cannot scan a binary `ruby` built on Mac OSX.

```
$ cat /etc/fedora-release
Fedora release 35 (Thirty Five)

$ annocheck ruby
annocheck: Version 10.66.
annocheck: Warning: ruby: is not an ELF format file.

$ annocheck ./libruby.3.2.dylib
annocheck: Version 10.66.
annocheck: Warning: ./libruby.3.2.dylib: is not an ELF format file.
```

## FreeBSD 12

However the `annocheck` command can scan a binary `ruby` built on FreeBSD 12
(target_os: freebsd12.2). I see the `annocheck` command can scan at least.

On FreeBSD 12, I built as follows.

```
$ gcc --version
gcc (FreeBSD Ports Collection) 10.3.0
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

$ ./autogen.sh
$ ./configure --enable-shared --with-gcc="gcc -fcf-protection -Wl,-z,now"
$ make
```

Then I copied the binaries `./ruby` and `./libruby.so.32` from FreeBSD 12 to Fedora 35, and executed the `annocheck`. The `annocheck` can scan the binaries, but the result is a little different from Linux (Fedora and Ubuntu).

```
$ cat /etc/fedora-release
Fedora release 35 (Thirty Five)

$ annocheck ruby
annocheck: Version 10.66.
Hardened: ruby: FAIL: entry test because instruction at entry is not ENDBR64 
Hardened: ruby: FAIL: notes test because annobin notes were not found 
Hardened: ruby: FAIL: cf-protection test because .note.gnu.property section did not contain the necessary flags 
Hardened: ruby: FAIL: gnu-relro test because not linked with -Wl,-z,relro 
Hardened: ruby: FAIL: pie test because not built with '-Wl,-pie' 
Hardened: Rerun annocheck with --verbose to see more information on the tests.
Hardened: ruby: Overall: FAIL.

$ annocheck libruby.so.32
annocheck: Version 10.66.
Hardened: libruby.so.32: FAIL: notes test because annobin notes were not found 
Hardened: libruby.so.32: FAIL: cf-protection test because .note.gnu.property section did not contain the necessary flags 
Hardened: libruby.so.32: FAIL: gnu-relro test because not linked with -Wl,-z,relro 
Hardened: Rerun annocheck with --verbose to see more information on the tests.
Hardened: libruby.so.32: Overall: FAIL.
```

I will ask the [`annobin`](https://sourceware.org/annobin/) project (`annocheck` command is developed in the project) which platform the `annocheck` would support or consider, and to open an issue ticket on the [issue tracker](https://sourceware.org/bugzilla/buglist.cgi?component=annobin&product=annobin&resolution=--- ). So, right now this PR is working in progress status.

