### PR TITLE
[ruby/optparse] Also accept '-' as optional argument

### DIFF
--- a/lib/optparse.rb
+++ b/lib/optparse.rb
@@ -765,15 +765,15 @@ class OptionParser
     end
 
     #
-    # Switch that takes an argument, which does not begin with '-'.
+    # Switch that takes an argument, which does not begin with '-' or is '-'.
     #
     class PlacedArgument < self
 
       #
-      # Returns nil if argument is not present or begins with '-'.
+      # Returns nil if argument is not present or begins with '-' and is not '-'.
       #
       def parse(arg, argv, &error)
-        if !(val = arg) and (argv.empty? or /\A-/ =~ (val = argv[0]))
+        if !(val = arg) and (argv.empty? or /\A-./ =~ (val = argv[0]))
           return nil, block, nil
         end
         opt = (val = parse_arg(val, &error))[1]


### PR DESCRIPTION
A single dash is already recognized as a non-option argument when not specified as argument to an option, but it isn't when it is.  This change corrects it.