### PR TITLE
YJIT: Add opt_succ

### DIFF
--- a/test/ruby/test_yjit.rb
+++ b/test/ruby/test_yjit.rb
@@ -86,6 +86,10 @@ class TestYJIT < Test::Unit::TestCase
     assert_compiles(':foo', insns: %i[putobject], result: :foo)
   end
 
+  def test_compile_opt_succ
+    assert_compiles('1.succ', insns: %i[opt_succ], result: 2)
+  end
+
   def test_compile_opt_not
     assert_compiles('!false', insns: %i[opt_not], result: true)
     assert_compiles('!nil', insns: %i[opt_not], result: true)

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -2991,6 +2991,16 @@ fn gen_opt_empty_p(
     gen_opt_send_without_block(jit, ctx, cb, ocb)
 }
 
+fn gen_opt_succ(
+    jit: &mut JITState,
+    ctx: &mut Context,
+    cb: &mut CodeBlock,
+    ocb: &mut OutlinedCb,
+) -> CodegenStatus {
+    // Delegate to send, call the method on the recv
+    gen_opt_send_without_block(jit, ctx, cb, ocb)
+}
+
 fn gen_opt_str_freeze(
     jit: &mut JITState,
     ctx: &mut Context,
@@ -5820,6 +5830,7 @@ fn get_gen_fn(opcode: VALUE) -> Option<InsnGenFn> {
         OP_OPT_LTLT => Some(gen_opt_ltlt),
         OP_OPT_NIL_P => Some(gen_opt_nil_p),
         OP_OPT_EMPTY_P => Some(gen_opt_empty_p),
+        OP_OPT_SUCC => Some(gen_opt_succ),
         OP_OPT_NOT => Some(gen_opt_not),
         OP_OPT_SIZE => Some(gen_opt_size),
         OP_OPT_LENGTH => Some(gen_opt_length),


### PR DESCRIPTION
Is it intentional that it's missing? This PR optimizes nothing, but looking at the code, it felt inconsistent that this is not there.