### PR TITLE
YJIT: special-case jit_guard_known_klass for strings

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -1337,6 +1337,16 @@ assert_equal 'foo123', %q{
   make_str("foo", 123)
 }
 
+# test that invalidation of String#to_s doesn't crash
+assert_equal 'meh', %q{
+  class String
+    def to_s
+      "meh"
+    end
+  end
+  "".to_s
+}
+
 # test string interpolation with overridden to_s
 assert_equal 'foo', %q{
   class String

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -461,6 +461,11 @@ impl VALUE {
         self == Qnil
     }
 
+    /// Returns true or false depending whether the value is a string
+    pub fn string_p(self) -> bool {
+        unsafe { CLASS_OF(self) == rb_cString }
+    }
+
     /// Read the flags bits from the RBasic object, then return a Ruby type enum (e.g. RUBY_T_ARRAY)
     pub fn builtin_type(self) -> ruby_value_type {
         assert!(!self.special_const_p());


### PR DESCRIPTION
This can remove runtime guard-checks for String#to_s, making some blocks too short to invalidate later. Add NOPs in those cases to reserve space.

There are a couple of slightly odd things here. First, we can write up to two bytes in order to make sure the block is at least 5 bytes. But the block isn't passed into gen_send_cfunc or gen_send_general, or most similar functions. So instead we assume in the constant that we need the specialised cfunc JIT function to write at least two bytes, or else we'll add NOPs to get to that point. That's conceptually messy, but the code is simple.

The other odd thing is that we add NOPs *before* the jump_to_next_insn so that they're executed even in cases where it will take a jump. However, jump_to_next_insn does some branch bookkeeping -- we expect a branch's end address to match the start of the following block. So adding NOPs *after* the jump ruins that bookkeeping and we fail the assertion (see: https://github.com/ruby/ruby/blob/5c843a1a6e24aeabb3497065a362caf7b3e2d3b1/yjit/src/core.rs#L1357). So instead, we add NOPs before jump_to_next_insn, where we'd normally add code. We could fix that by having some recognition of "padding" NOPs at the end of a block (after the branch, before the next block.) But that seemed like a lot of extra redesign for a change this small.