### PR TITLE
`rb_thread_t::serial` for debug

### DIFF
--- a/debug.c
+++ b/debug.c
@@ -410,36 +410,36 @@ ruby_debug_log(const char *file, int line, const char *func_name, const char *fm
         len += r;
     }
 
-    // Ruby location
-    int ruby_line;
-    const char *ruby_file = rb_source_location_cstr(&ruby_line);
-    if (len < MAX_DEBUG_LOG_MESSAGE_LEN) {
-        if (ruby_file) {
-            r = snprintf(buff + len, MAX_DEBUG_LOG_MESSAGE_LEN - len, "\t%s:%d", pretty_filename(ruby_file), ruby_line);
-        }
-        else {
-            r = snprintf(buff + len, MAX_DEBUG_LOG_MESSAGE_LEN - len, "\t");
-        }
-        if (r < 0) rb_bug("ruby_debug_log returns %d\n", r);
-        len += r;
-    }
-
-    // ractor information
-    if (ruby_single_main_ractor == NULL) {
-        rb_ractor_t *cr = GET_RACTOR();
-        if (r && len < MAX_DEBUG_LOG_MESSAGE_LEN) {
-            r = snprintf(buff + len, MAX_DEBUG_LOG_MESSAGE_LEN - len, "\tr:#%u/%u",
-                         (unsigned int)rb_ractor_id(cr), GET_VM()->ractor.cnt);
+    if (rb_current_execution_context(false)) {
+        // Ruby location
+        int ruby_line;
+        const char *ruby_file = rb_source_location_cstr(&ruby_line);
+        if (len < MAX_DEBUG_LOG_MESSAGE_LEN) {
+            if (ruby_file) {
+                r = snprintf(buff + len, MAX_DEBUG_LOG_MESSAGE_LEN - len, "\t%s:%d", pretty_filename(ruby_file), ruby_line);
+            }
+            else {
+                r = snprintf(buff + len, MAX_DEBUG_LOG_MESSAGE_LEN - len, "\t");
+            }
             if (r < 0) rb_bug("ruby_debug_log returns %d\n", r);
             len += r;
         }
-    }
 
-    // thread information
-    if (!rb_thread_alone()) {
+        // ractor information
+        if (ruby_single_main_ractor == NULL) {
+            rb_ractor_t *cr = GET_RACTOR();
+            if (r && len < MAX_DEBUG_LOG_MESSAGE_LEN) {
+                r = snprintf(buff + len, MAX_DEBUG_LOG_MESSAGE_LEN - len, "\tr:#%u/%u",
+                             (unsigned int)rb_ractor_id(cr), GET_VM()->ractor.cnt);
+                if (r < 0) rb_bug("ruby_debug_log returns %d\n", r);
+                len += r;
+            }
+        }
+
+        // thread information
         const rb_thread_t *th = GET_THREAD();
         if (r && len < MAX_DEBUG_LOG_MESSAGE_LEN) {
-            r = snprintf(buff + len, MAX_DEBUG_LOG_MESSAGE_LEN - len, "\tth:%p", (void *)th);
+            r = snprintf(buff + len, MAX_DEBUG_LOG_MESSAGE_LEN - len, "\tth:%u", (unsigned int)th->serial);
             if (r < 0) rb_bug("ruby_debug_log returns %d\n", r);
             len += r;
         }

--- a/vm.c
+++ b/vm.c
@@ -3292,6 +3292,11 @@ th_init(rb_thread_t *th, VALUE self, rb_vm_t *vm, rb_ractor_t *r)
     th->name = Qnil;
     th->report_on_exception = vm->thread_report_on_exception;
     th->ext_config.ractor_safe = true;
+
+#if USE_RUBY_DEBUG_LOG
+    static rb_atomic_t thread_serial = 0;
+    th->serial = RUBY_ATOMIC_FETCH_ADD(thread_serial, 1);
+#endif
 }
 
 VALUE

--- a/vm_core.h
+++ b/vm_core.h
@@ -997,6 +997,7 @@ typedef struct rb_thread_struct {
     rb_execution_context_t *ec;
 
     struct rb_thread_sched_item sched;
+    rb_atomic_t serial; // only for RUBY_DEBUG_LOG()
 
     VALUE last_status; /* $? */
 


### PR DESCRIPTION
`rb_thread_t::serial` is auto-incremented serial number for
threads and it can overflow, it means the serial is not a ID
for each thread, it is only for debug print.

`RUBY_DEBUG_LOG` shows this information.

Also skip EC related information if EC is NULL. This patch
enable to use `RUBY_DEBUG_LOG` without setup EC.