### PR TITLE
Fix typo in README

### DIFF
--- a/sample/drb/README.rdoc
+++ b/sample/drb/README.rdoc
@@ -1,6 +1,6 @@
 = Sample scripts
 
-* array and iteretor
+* array and iterator
   * darray.rb --- server
   * darrayc.rb --- client
 


### PR DESCRIPTION
"iteretor" -> "iterator"