### PR TITLE
[DOC] Tweak the doc for `Process.kill` signature

### DIFF
--- a/process.c
+++ b/process.c
@@ -8721,7 +8721,7 @@ get_PROCESS_ID(ID _x, VALUE *_y)
 
 /*
  *  call-seq:
- *     Process.kill(signal, pid, ...)    -> integer
+ *     Process.kill(signal, pid, *pids)    -> integer
  *
  *  Sends the given signal to the specified process id(s) if _pid_ is positive.
  *  If _pid_ is zero, _signal_ is sent to all processes whose group ID is equal


### PR DESCRIPTION
Replacing `...` with `*pids` seems to clarify the expected variadic arguments.

Note that the expected arguments are two or more with a signal and pids.
That is, the method must have at least one pid, which cannot be omitted:

```console
% ruby -e 'Process.kill(0)'
-e:1:in `kill': wrong number of arguments (given 1, expected 2+) (ArgumentError)
        from -e:1:in `<main>'
```