### PR TITLE
Remove unnecessary module flag, add module assertions to other module…

### DIFF
--- a/class.c
+++ b/class.c
@@ -1268,11 +1268,12 @@ do_include_modules_at(const VALUE klass, VALUE c, VALUE module, int search_super
             rb_module_add_to_subclasses_list(m, iclass);
 	}
 
-	if (FL_TEST(klass, RMODULE_IS_REFINEMENT)) {
+	if (BUILTIN_TYPE(klass) == T_MODULE && FL_TEST(klass, RMODULE_IS_REFINEMENT)) {
 	    VALUE refined_class =
 		rb_refinement_module_get_refined_class(klass);
 
             rb_id_table_foreach(RCLASS_M_TBL(module), add_refined_method_entry_i, (void *)refined_class);
+            RUBY_ASSERT(BUILTIN_TYPE(c) == T_MODULE);
 	    FL_SET(c, RMODULE_INCLUDED_INTO_REFINEMENT);
 	}
 
@@ -1497,7 +1498,7 @@ rb_mod_ancestors(VALUE mod)
 {
     VALUE p, ary = rb_ary_new();
     VALUE refined_class = Qnil;
-    if (FL_TEST(mod, RMODULE_IS_REFINEMENT)) {
+    if (BUILTIN_TYPE(mod) == T_MODULE && FL_TEST(mod, RMODULE_IS_REFINEMENT)) {
         refined_class = rb_refinement_module_get_refined_class(mod);
     }
 

--- a/include/ruby/internal/core/rclass.h
+++ b/include/ruby/internal/core/rclass.h
@@ -26,7 +26,6 @@
 #include "ruby/internal/cast.h"
 
 /** @cond INTERNAL_MACRO */
-#define RMODULE_IS_OVERLAID              RMODULE_IS_OVERLAID
 #define RMODULE_IS_REFINEMENT            RMODULE_IS_REFINEMENT
 #define RMODULE_INCLUDED_INTO_REFINEMENT RMODULE_INCLUDED_INTO_REFINEMENT
 /** @endcond */
@@ -55,15 +54,6 @@
  * Why is it here, given RClass itself is not?
  */
 enum ruby_rmodule_flags {
-
-    /**
-     * This flag has something to do with refinements... I guess?  It is set on
-     * occasions  for modules  that are  refined by  refinements, but  it seems
-     * ...  nobody cares  about  such things?   Not sure  but  this flag  could
-     * perhaps be a write-only information.
-     */
-    RMODULE_IS_OVERLAID              = RUBY_FL_USER2,
-
     /**
      * This flag has something to do  with refinements.  A module created using
      * rb_mod_refine()  has this  flag set.   This  is the  bit which  controls

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -3798,6 +3798,7 @@ static inline VALUE
 vm_search_normal_superclass(VALUE klass)
 {
     if (BUILTIN_TYPE(klass) == T_ICLASS &&
+            RB_TYPE_P(RBASIC(klass)->klass, T_MODULE) &&
 	FL_TEST_RAW(RBASIC(klass)->klass, RMODULE_IS_REFINEMENT)) {
 	klass = RBASIC(klass)->klass;
     }
@@ -3840,7 +3841,6 @@ vm_search_super_method(const rb_control_frame_t *reg_cfp, struct rb_call_data *c
     }
 
     if (BUILTIN_TYPE(current_defined_class) != T_MODULE &&
-	!FL_TEST_RAW(current_defined_class, RMODULE_INCLUDED_INTO_REFINEMENT) &&
         reg_cfp->iseq != method_entry_iseqptr(me) &&
         !rb_obj_is_kind_of(recv, current_defined_class)) {
 	VALUE m = RB_TYPE_P(current_defined_class, T_ICLASS) ?

--- a/vm_method.c
+++ b/vm_method.c
@@ -858,7 +858,7 @@ rb_method_entry_make(VALUE klass, ID mid, VALUE defined_class, rb_method_visibil
        rb_class_modify_check(klass);
     }
 
-    if (FL_TEST(klass, RMODULE_IS_REFINEMENT)) {
+    if (RB_TYPE_P(klass, T_MODULE) && FL_TEST(klass, RMODULE_IS_REFINEMENT)) {
 	VALUE refined_class = rb_refinement_module_get_refined_class(klass);
 	rb_add_refined_method_entry(refined_class, mid);
     }

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -5035,7 +5035,7 @@ fn gen_invokesuper(
     // vm_search_normal_superclass
     let rbasic_ptr: *const RBasic = current_defined_class.as_ptr();
     if current_defined_class.builtin_type() == RUBY_T_ICLASS
-        && unsafe { FL_TEST_RAW((*rbasic_ptr).klass, VALUE(RMODULE_IS_REFINEMENT)) != VALUE(0) }
+        && unsafe { RB_TYPE_P((*rbasic_ptr).klass, RUBY_T_MODULE) && FL_TEST_RAW((*rbasic_ptr).klass, VALUE(RMODULE_IS_REFINEMENT)) != VALUE(0) }
     {
         return CantCompile;
     }


### PR DESCRIPTION
… flags

This PR will allow us to use 16 `FL_USER` bits for Object Shape IDs. (See [this Redmine issue](https://bugs.ruby-lang.org/issues/18776) for more context.)