### PR TITLE
Remove unused RMODULE_INCLUDED_INTO_REFINEMENT flag

### DIFF
--- a/class.c
+++ b/class.c
@@ -1274,7 +1274,6 @@ do_include_modules_at(const VALUE klass, VALUE c, VALUE module, int search_super
 
             rb_id_table_foreach(RCLASS_M_TBL(module), add_refined_method_entry_i, (void *)refined_class);
             RUBY_ASSERT(BUILTIN_TYPE(c) == T_MODULE);
-	    FL_SET(c, RMODULE_INCLUDED_INTO_REFINEMENT);
 	}
 
         tbl = RCLASS_CONST_TBL(module);

--- a/include/ruby/internal/core/rclass.h
+++ b/include/ruby/internal/core/rclass.h
@@ -27,7 +27,6 @@
 
 /** @cond INTERNAL_MACRO */
 #define RMODULE_IS_REFINEMENT            RMODULE_IS_REFINEMENT
-#define RMODULE_INCLUDED_INTO_REFINEMENT RMODULE_INCLUDED_INTO_REFINEMENT
 /** @endcond */
 
 /**
@@ -60,42 +59,6 @@ enum ruby_rmodule_flags {
      * difference between normal inclusion versus refinements.
      */
     RMODULE_IS_REFINEMENT            = RUBY_FL_USER3,
-
-    /**
-     * This flag  has something  to do  with refinements.  This  is set  when a
-     * (non-refinement)  module is  included into  another module,  which is  a
-     * refinement.  This amends the way `super` searches for a super method.
-     *
-     * ```ruby
-     * class Foo
-     *   def foo
-     *     "Foo"
-     *   end
-     * end
-     *
-     * module Bar
-     *   def foo
-     *     "[#{super}]" # this
-     *   end
-     * end
-     *
-     * module Baz
-     *   refine Foo do
-     *     include Bar
-     *     def foo
-     *       "<#{super}>"
-     *     end
-     *   end
-     * end
-     *
-     * using Baz
-     * Foo.new.foo # => "[<Foo>]"
-     * ```
-     *
-     * The  `super`  marked  with  "this"   comment  shall  look  for  overlaid
-     * `Foo#foo`, which is not the ordinal method lookup direction.
-     */
-    RMODULE_INCLUDED_INTO_REFINEMENT = RUBY_FL_USER4
 };
 
 struct RClass; /* Opaque, declared here for RCLASS() macro. */


### PR DESCRIPTION
This PR will allow us to use 16 `FL_USER` bits for Object Shape IDs. (See [this Redmine issue](https://bugs.ruby-lang.org/issues/18776) for more context.)