### PR TITLE
Fix thread debug

### DIFF
--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -163,7 +163,6 @@ jobs:
 #         - { key: cppflags, name: ID_TABLE_DEBUG,                 value: '-DID_TABLE_DEBUG' }
 #         - { key: cppflags, name: RGENGC_DEBUG=-1,                value: '-DRGENGC_DEBUG=-1' }
 #         - { key: cppflags, name: SYMBOL_DEBUG,                   value: '-DSYMBOL_DEBUG' }
-#         - { key: cppflags, name: THREAD_DEBUG=-1,                value: '-DTHREAD_DEBUG=-1' }
 
 #         - { key: cppflags, name: RGENGC_CHECK_MODE,              value: '-DRGENGC_CHECK_MODE' }
 #         - { key: cppflags, name: TRANSIENT_HEAP_CHECK_MODE,      value: '-DTRANSIENT_HEAP_CHECK_MODE' }

--- a/debug.c
+++ b/debug.c
@@ -474,7 +474,7 @@ ruby_debug_log(const char *file, int line, const char *func_name, const char *fm
         // thread information
         const rb_thread_t *th = GET_THREAD();
         if (r && len < MAX_DEBUG_LOG_MESSAGE_LEN) {
-            r = snprintf(buff + len, MAX_DEBUG_LOG_MESSAGE_LEN - len, "\tth:%u", (unsigned int)th->serial);
+            r = snprintf(buff + len, MAX_DEBUG_LOG_MESSAGE_LEN - len, "\tth:%u", rb_th_serial(th));
             if (r < 0) rb_bug("ruby_debug_log returns %d\n", r);
             len += r;
         }

--- a/thread_none.c
+++ b/thread_none.c
@@ -130,7 +130,6 @@ Init_native_thread(rb_thread_t *main_th)
 {
     // no TLS setup and no thread id setup
     ruby_thread_set_native(main_th);
-    fill_thread_id_str(main_th);
 }
 
 static void

--- a/thread_pthread.h
+++ b/thread_pthread.h
@@ -30,10 +30,6 @@ struct rb_native_thread {
 
     rb_nativethread_id_t thread_id;
 
-#ifdef NON_SCALAR_THREAD_ID
-    rb_thread_id_string_t thread_id_string;
-#endif
-
 #ifdef RB_THREAD_T_HAS_NATIVE_ID
     int tid;
 #endif

--- a/thread_pthread.h
+++ b/thread_pthread.h
@@ -102,11 +102,8 @@ typedef pthread_key_t native_tls_key_t;
 static inline void *
 native_tls_get(native_tls_key_t key)
 {
-    void *ptr = pthread_getspecific(key);
-    if (UNLIKELY(ptr == NULL)) {
-        rb_bug("pthread_getspecific returns NULL");
-    }
-    return ptr;
+    // return value should be checked by caller
+    return pthread_getspecific(key);
 }
 
 static inline void

--- a/thread_win32.h
+++ b/thread_win32.h
@@ -44,11 +44,8 @@ typedef DWORD native_tls_key_t; // TLS index
 static inline void *
 native_tls_get(native_tls_key_t key)
 {
-    void *ptr = TlsGetValue(key);
-    if (UNLIKELY(ptr == NULL)) {
-        rb_bug("TlsGetValue() returns NULL");
-    }
-    return ptr;
+    // return value should be checked by caller.
+    return TlsGetValue(key);
 }
 
 static inline void

--- a/vm.c
+++ b/vm.c
@@ -3275,10 +3275,6 @@ th_init(rb_thread_t *th, VALUE self, rb_vm_t *vm)
     th->top_self = vm->top_self; // 0 while self == 0
     th->value = Qundef;
 
-#if  defined(NON_SCALAR_THREAD_ID) && !defined(__wasm__) && !defined(__EMSCRIPTEN__)
-    th->nt->thread_id_string[0] = '\0';
-#endif
-
     th->ec->errinfo = Qnil;
     th->ec->root_svar = Qfalse;
     th->ec->local_storage_recursive_hash = Qnil;

--- a/vm_core.h
+++ b/vm_core.h
@@ -896,8 +896,6 @@ typedef struct rb_ensure_list {
     struct rb_ensure_entry entry;
 } rb_ensure_list_t;
 
-typedef char rb_thread_id_string_t[sizeof(rb_nativethread_id_t) * 2 + 3];
-
 typedef struct rb_fiber_struct rb_fiber_t;
 
 struct rb_waiting_list {

--- a/vm_core.h
+++ b/vm_core.h
@@ -1078,6 +1078,12 @@ typedef struct rb_thread_struct {
 #endif
 } rb_thread_t;
 
+static inline unsigned int
+rb_th_serial(const rb_thread_t *th)
+{
+    return (unsigned int)th->serial;
+}
+
 typedef enum {
     VM_DEFINECLASS_TYPE_CLASS           = 0x00,
     VM_DEFINECLASS_TYPE_SINGLETON_CLASS = 0x01,

--- a/vm_dump.c
+++ b/vm_dump.c
@@ -1180,10 +1180,6 @@ rb_vm_bugreport(const void *ctx)
     }
 }
 
-#ifdef NON_SCALAR_THREAD_ID
-const char *ruby_fill_thread_id_string(rb_nativethread_id_t thid, rb_thread_id_string_t buf);
-#endif
-
 void
 rb_vmdebug_stack_dump_all_threads(void)
 {
@@ -1193,9 +1189,7 @@ rb_vmdebug_stack_dump_all_threads(void)
     // TODO: now it only shows current ractor
     ccan_list_for_each(&r->threads.set, th, lt_node) {
 #ifdef NON_SCALAR_THREAD_ID
-        rb_thread_id_string_t buf;
-	ruby_fill_thread_id_string(th->nt->thread_id, buf);
-	fprintf(stderr, "th: %p, native_id: %s\n", th, buf);
+	fprintf(stderr, "th: %p, native_id: N/A\n", th);
 #else
         fprintf(stderr, "th: %p, native_id: %p\n", (void *)th, (void *)(uintptr_t)th->nt->thread_id);
 #endif


### PR DESCRIPTION
use `RUBY_DEBUG_LOG` instead of `thread_debug`

`thread_debug()` was introduced to print debug messages
on `THREAD_DEBUG > 0` but `RUBY_DEBUG_LOG()` is more controllable.
