### PR TITLE
remove `DEBUG_OUT()` macro

### DIFF
--- a/thread_none.c
+++ b/thread_none.c
@@ -15,8 +15,6 @@
 
 #include <time.h>
 
-#define DEBUG_OUT() (void)(0);
-
 #define TIME_QUANTUM_MSEC (100)
 #define TIME_QUANTUM_USEC (TIME_QUANTUM_MSEC * 1000)
 #define TIME_QUANTUM_NSEC (TIME_QUANTUM_USEC * 1000)

--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -51,18 +51,6 @@
 #  define USE_EVENTFD (0)
 #endif
 
-#ifdef NON_SCALAR_THREAD_ID
-  #define DEBUG_OUT_NT_ID (NULL)
-#else
-  #define DEBUG_OUT_NT_ID ((void *)pthread_self())
-#endif
-
-#define DEBUG_OUT() \
-  pthread_mutex_lock(&debug_mutex); \
-  printf(POSITION_FORMAT"%"PRI_THREAD_ID" - %s" POSITION_ARGS, DEBUG_OUT_NT_ID, buf);	\
-  fflush(stdout); \
-  pthread_mutex_unlock(&debug_mutex);
-
 #if defined(SIGVTALRM) && !defined(__CYGWIN__) && !defined(__EMSCRIPTEN__)
 #  define USE_UBF_LIST 1
 #endif

--- a/thread_win32.c
+++ b/thread_win32.c
@@ -25,12 +25,6 @@
 #define ubf_timer_disarm() do {} while (0)
 #define ubf_list_atfork() do {} while (0)
 
-#define DEBUG_OUT() \
-  WaitForSingleObject(&debug_mutex, INFINITE); \
-  printf(POSITION_FORMAT"%#lx - %s" POSITION_ARGS, GetCurrentThreadId(), buf); \
-  fflush(stdout); \
-  ReleaseMutex(&debug_mutex);
-
 static volatile DWORD ruby_native_thread_key = TLS_OUT_OF_INDEXES;
 
 static int w32_wait_events(HANDLE *events, int count, DWORD timeout, rb_thread_t *th);


### PR DESCRIPTION
This macro is no longer used ([GH-5933]).