### PR TITLE
Using `TZMODE_SET_LOCALTIME` macro

### DIFF
--- a/time.c
+++ b/time.c
@@ -1919,7 +1919,7 @@ time_init_now(rb_execution_context_t *ec, VALUE time, VALUE zone)
 
     time_modify(time);
     GetNewTimeval(time, tobj);
-    tobj->tzmode = TIME_TZMODE_LOCALTIME;
+    TZMODE_SET_LOCALTIME(tobj);
     tobj->tm_got=0;
     tobj->timew = WINT2FIXWV(0);
     rb_timespec_now(&ts);
@@ -2181,7 +2181,7 @@ zone_set_offset(VALUE zone, struct time_object *tobj,
     validate_utc_offset(off);
     tobj->vtm.utc_offset = off;
     tobj->vtm.zone = zone;
-    tobj->tzmode = TIME_TZMODE_LOCALTIME;
+    TZMODE_SET_LOCALTIME(tobj);
 }
 
 static wideval_t
@@ -2399,7 +2399,7 @@ time_init_args(rb_execution_context_t *ec, VALUE time, VALUE year, VALUE mon, VA
         return time;
     }
 
-    tobj->tzmode = TIME_TZMODE_LOCALTIME;
+    TZMODE_SET_LOCALTIME(tobj);
     tobj->tm_got=0;
     tobj->timew = WINT2FIXWV(0);
 
@@ -2464,7 +2464,7 @@ time_new_timew(VALUE klass, wideval_t timew)
     struct time_object *tobj;
 
     tobj = DATA_PTR(time);	/* skip type check */
-    tobj->tzmode = TIME_TZMODE_LOCALTIME;
+    TZMODE_SET_LOCALTIME(tobj);
     tobj->timew = timew;
 
     return time;
@@ -5301,7 +5301,7 @@ end_submicro: ;
     }
 
     GetNewTimeval(time, tobj);
-    tobj->tzmode = TIME_TZMODE_LOCALTIME;
+    TZMODE_SET_LOCALTIME(tobj);
     tobj->tm_got = 0;
     tobj->timew = timew;
     if (gmt) {
@@ -5414,7 +5414,7 @@ tm_initialize(int argc, VALUE *argv, VALUE tm)
     {
 #if TM_IS_TIME
         struct time_object *tobj = DATA_PTR(tm);
-        tobj->tzmode = TIME_TZMODE_UTC;
+        TZMODE_SET_UTC(tobj);
         tobj->timew = t;
         tobj->vtm = vtm;
 #else


### PR DESCRIPTION
Some code set to tzmode(in localtime) in this code.

```c
tobj->tzmode = TIME_TZMODE_LOCALTIME;
```

But, useful `TZMODE_SET_LOCALTIME` macro was already defined and used in `time.c`.

I thought better to replace and using `TZMODE_SET_LOCALTIME` macro.