### PR TITLE
YJIT: Use bindgen to import CRuby constants wherever possible.

### DIFF
--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -125,6 +125,21 @@ fn main() {
         .allowlist_var("rb_cArray")
         .allowlist_var("rb_cHash")
 
+        // From include/ruby/internal/fl_type.h
+        .allowlist_type("ruby_fl_type")
+        .allowlist_type("ruby_fl_ushift")
+
+        // From include/ruby/internal/core/robject.h
+        .allowlist_type("ruby_robject_flags")
+        .allowlist_type("ruby_robject_consts")
+
+        // From include/ruby/internal/core/rarray.h
+        .allowlist_type("ruby_rarray_flags")
+        .allowlist_type("ruby_rarray_consts")
+
+        // From include/ruby/internal/core/rclass.h
+        .allowlist_type("ruby_rmodule_flags")
+
         // From ruby/internal/globals.h
         .allowlist_var("rb_mKernel")
 
@@ -214,6 +229,10 @@ fn main() {
         .blocklist_type("rb_control_frame_struct")
         .opaque_type("rb_control_frame_struct")
         .allowlist_function("rb_vm_bh_to_procval")
+        .allowlist_type("vm_special_object_type")
+        .allowlist_var("VM_ENV_DATA_INDEX_SPECVAL")
+        .allowlist_var("VM_ENV_DATA_INDEX_FLAGS")
+        .allowlist_var("VM_ENV_DATA_SIZE")
 
         // From yjit.c
         .allowlist_function("rb_iseq_(get|set)_yjit_payload")

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -1038,7 +1038,7 @@ fn gen_putspecialobject(
 ) -> CodegenStatus {
     let object_type = jit_get_arg(jit, 0);
 
-    if object_type == VALUE(VM_SPECIAL_OBJECT_VMCORE) {
+    if object_type == VALUE(VM_SPECIAL_OBJECT_VMCORE.as_usize()) {
         let stack_top: X86Opnd = ctx.stack_push(Type::UnknownHeap);
         jit_mov_gc_ptr(jit, cb, REG0, unsafe { rb_mRubyVMFrozenCore });
         mov(cb, stack_top, REG0);
@@ -1956,8 +1956,8 @@ fn gen_get_ivar(
     }
 
     // Compile time self is embedded and the ivar index lands within the object
-    let test_result = unsafe { FL_TEST_RAW(comptime_receiver, VALUE(ROBJECT_EMBED)) != VALUE(0) };
-    if test_result && ivar_index < ROBJECT_EMBED_LEN_MAX {
+    let test_result = unsafe { FL_TEST_RAW(comptime_receiver, VALUE(ROBJECT_EMBED.as_usize())) != VALUE(0) };
+    if test_result && ivar_index < (ROBJECT_EMBED_LEN_MAX.as_usize()) {
         // See ROBJECT_IVPTR() from include/ruby/internal/core/robject.h
 
         // Guard that self is embedded
@@ -2009,7 +2009,7 @@ fn gen_get_ivar(
         );
 
         // Check that the extended table is big enough
-        if ivar_index > ROBJECT_EMBED_LEN_MAX {
+        if ivar_index > (ROBJECT_EMBED_LEN_MAX.as_usize()) {
             // Check that the slot is inside the extended table (num_slots > index)
             let num_slots = mem_opnd(32, REG0, RUBY_OFFSET_ROBJECT_AS_HEAP_NUMIV);
 
@@ -3422,7 +3422,7 @@ fn jit_guard_known_klass(
             ctx.upgrade_opnd_type(insn_opnd, Type::Flonum);
         }
     } else if unsafe {
-        FL_TEST(known_klass, VALUE(RUBY_FL_SINGLETON)) != VALUE(0)
+        FL_TEST(known_klass, VALUE(RUBY_FL_SINGLETON as usize)) != VALUE(0)
             && sample_instance == rb_attr_get(known_klass, id__attached__ as ID)
     } {
         // Singleton classes are attached to one specific object, so we can
@@ -5012,7 +5012,7 @@ fn gen_invokesuper(
     // vm_search_normal_superclass
     let rbasic_ptr: *const RBasic = current_defined_class.as_ptr();
     if current_defined_class.builtin_type() == RUBY_T_ICLASS
-        && unsafe { RB_TYPE_P((*rbasic_ptr).klass, RUBY_T_MODULE) && FL_TEST_RAW((*rbasic_ptr).klass, VALUE(RMODULE_IS_REFINEMENT)) != VALUE(0) }
+        && unsafe { RB_TYPE_P((*rbasic_ptr).klass, RUBY_T_MODULE) && FL_TEST_RAW((*rbasic_ptr).klass, VALUE(RMODULE_IS_REFINEMENT.as_usize())) != VALUE(0) }
     {
         return CantCompile;
     }

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -701,7 +701,8 @@ pub const Qundef: VALUE = VALUE(52);
 mod manual_defs {
     use super::*;
 
-    pub const RUBY_SYMBOL_FLAG: usize = 0x0c;
+    pub const SIZEOF_VALUE: usize = 8;
+    pub const SIZEOF_VALUE_I32: i32 = SIZEOF_VALUE as i32;
 
     pub const RUBY_LONG_MIN: isize = std::os::raw::c_long::MIN as isize;
     pub const RUBY_LONG_MAX: isize = std::os::raw::c_long::MAX as isize;
@@ -710,20 +711,16 @@ mod manual_defs {
     pub const RUBY_FIXNUM_MAX: isize = RUBY_LONG_MAX / 2;
     pub const RUBY_FIXNUM_FLAG: usize = 0x1;
 
+    // All these are defined in include/ruby/internal/special_consts.h,
+    // in the same enum as RUBY_Qfalse, etc.
+    // Do we want to switch to using Ruby's definition of Qnil, Qfalse, etc?
+    pub const RUBY_SYMBOL_FLAG: usize = 0x0c;
     pub const RUBY_FLONUM_FLAG: usize = 0x2;
     pub const RUBY_FLONUM_MASK: usize = 0x3;
-
+    pub const RUBY_SPECIAL_SHIFT: usize = 8;
     pub const RUBY_IMMEDIATE_MASK: usize = 0x7;
 
-    pub const RUBY_SPECIAL_SHIFT: usize = 8;
-
-    // Constants from vm_core.h
-    pub const VM_SPECIAL_OBJECT_VMCORE: usize = 0x1;
-    pub const VM_ENV_DATA_INDEX_SPECVAL: isize = -1;
-    pub const VM_ENV_DATA_INDEX_FLAGS: isize = 0;
-    pub const VM_ENV_DATA_SIZE: usize = 3;
-
-    // From vm_callinfo.h
+    // From vm_callinfo.h - uses calculation that seems to confuse bindgen
     pub const VM_CALL_ARGS_SPLAT: u32 = 1 << VM_CALL_ARGS_SPLAT_bit;
     pub const VM_CALL_ARGS_BLOCKARG: u32 = 1 << VM_CALL_ARGS_BLOCKARG_bit;
     pub const VM_CALL_FCALL: u32 = 1 << VM_CALL_FCALL_bit;
@@ -731,49 +728,11 @@ mod manual_defs {
     pub const VM_CALL_KW_SPLAT: u32 = 1 << VM_CALL_KW_SPLAT_bit;
     pub const VM_CALL_TAILCALL: u32 = 1 << VM_CALL_TAILCALL_bit;
 
-    pub const SIZEOF_VALUE: usize = 8;
-    pub const SIZEOF_VALUE_I32: i32 = SIZEOF_VALUE as i32;
+    // From internal/struct.h - in anonymous enum, so we can't easily import it
+    pub const RSTRUCT_EMBED_LEN_MASK: usize = (RUBY_FL_USER2 | RUBY_FL_USER1) as usize;
 
-    pub const RUBY_FL_SINGLETON: usize = RUBY_FL_USER_0;
-
-    pub const ROBJECT_EMBED: usize = RUBY_FL_USER_1;
-    pub const ROBJECT_EMBED_LEN_MAX: usize = 3; // This is a complex calculation in ruby/internal/core/robject.h
-
-    pub const RMODULE_IS_REFINEMENT: usize = RUBY_FL_USER_3;
-
-    // Constants from include/ruby/internal/fl_type.h
-    pub const RUBY_FL_USHIFT: usize = 12;
-    pub const RUBY_FL_USER_0: usize = 1 << (RUBY_FL_USHIFT + 0);
-    pub const RUBY_FL_USER_1: usize = 1 << (RUBY_FL_USHIFT + 1);
-    pub const RUBY_FL_USER_2: usize = 1 << (RUBY_FL_USHIFT + 2);
-    pub const RUBY_FL_USER_3: usize = 1 << (RUBY_FL_USHIFT + 3);
-    pub const RUBY_FL_USER_4: usize = 1 << (RUBY_FL_USHIFT + 4);
-    pub const RUBY_FL_USER_5: usize = 1 << (RUBY_FL_USHIFT + 5);
-    pub const RUBY_FL_USER_6: usize = 1 << (RUBY_FL_USHIFT + 6);
-    pub const RUBY_FL_USER_7: usize = 1 << (RUBY_FL_USHIFT + 7);
-    pub const RUBY_FL_USER_8: usize = 1 << (RUBY_FL_USHIFT + 8);
-    pub const RUBY_FL_USER_9: usize = 1 << (RUBY_FL_USHIFT + 9);
-    pub const RUBY_FL_USER_10: usize = 1 << (RUBY_FL_USHIFT + 10);
-    pub const RUBY_FL_USER_11: usize = 1 << (RUBY_FL_USHIFT + 11);
-    pub const RUBY_FL_USER_12: usize = 1 << (RUBY_FL_USHIFT + 12);
-    pub const RUBY_FL_USER_13: usize = 1 << (RUBY_FL_USHIFT + 13);
-    pub const RUBY_FL_USER_14: usize = 1 << (RUBY_FL_USHIFT + 14);
-    pub const RUBY_FL_USER_15: usize = 1 << (RUBY_FL_USHIFT + 15);
-    pub const RUBY_FL_USER_16: usize = 1 << (RUBY_FL_USHIFT + 16);
-    pub const RUBY_FL_USER_17: usize = 1 << (RUBY_FL_USHIFT + 17);
-    pub const RUBY_FL_USER_18: usize = 1 << (RUBY_FL_USHIFT + 18);
-    pub const RUBY_FL_USER_19: usize = 1 << (RUBY_FL_USHIFT + 19);
-
-    // Constants from include/ruby/internal/core/rarray.h
-    pub const RARRAY_EMBED_FLAG: usize = RUBY_FL_USER_1;
-    pub const RARRAY_EMBED_LEN_SHIFT: usize = RUBY_FL_USHIFT + 3;
-    pub const RARRAY_EMBED_LEN_MASK: usize = RUBY_FL_USER_3 | RUBY_FL_USER_4;
-
-    // From internal/struct.h
-    pub const RSTRUCT_EMBED_LEN_MASK: usize = RUBY_FL_USER_2 | RUBY_FL_USER_1;
-
-    // From iseq.h
-    pub const ISEQ_TRANSLATED: usize = RUBY_FL_USER_7;
+    // From iseq.h - via a different constant, which seems to confuse bindgen
+    pub const ISEQ_TRANSLATED: usize = RUBY_FL_USER7 as usize;
 
     // We'll need to encode a lot of Ruby struct/field offsets as constants unless we want to
     // redeclare all the Ruby C structs and write our own offsetof macro. For now, we use constants.

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -12,7 +12,10 @@ pub const NIL_REDEFINED_OP_FLAG: u32 = 512;
 pub const TRUE_REDEFINED_OP_FLAG: u32 = 1024;
 pub const FALSE_REDEFINED_OP_FLAG: u32 = 2048;
 pub const PROC_REDEFINED_OP_FLAG: u32 = 4096;
+pub const VM_ENV_DATA_SIZE: u32 = 3;
 pub const VM_ENV_DATA_INDEX_ME_CREF: i32 = -2;
+pub const VM_ENV_DATA_INDEX_SPECVAL: i32 = -1;
+pub const VM_ENV_DATA_INDEX_FLAGS: u32 = 0;
 pub const VM_BLOCK_HANDLER_NONE: u32 = 0;
 pub type ID = ::std::os::raw::c_ulong;
 extern "C" {
@@ -56,11 +59,59 @@ pub const RUBY_T_ZOMBIE: ruby_value_type = 29;
 pub const RUBY_T_MOVED: ruby_value_type = 30;
 pub const RUBY_T_MASK: ruby_value_type = 31;
 pub type ruby_value_type = u32;
+pub const RUBY_FL_USHIFT: ruby_fl_ushift = 12;
+pub type ruby_fl_ushift = u32;
+pub const RUBY_FL_WB_PROTECTED: ruby_fl_type = 32;
+pub const RUBY_FL_PROMOTED0: ruby_fl_type = 32;
+pub const RUBY_FL_PROMOTED1: ruby_fl_type = 64;
+pub const RUBY_FL_PROMOTED: ruby_fl_type = 96;
+pub const RUBY_FL_FINALIZE: ruby_fl_type = 128;
+pub const RUBY_FL_TAINT: ruby_fl_type = 256;
+pub const RUBY_FL_SHAREABLE: ruby_fl_type = 256;
+pub const RUBY_FL_UNTRUSTED: ruby_fl_type = 256;
+pub const RUBY_FL_SEEN_OBJ_ID: ruby_fl_type = 512;
+pub const RUBY_FL_EXIVAR: ruby_fl_type = 1024;
+pub const RUBY_FL_FREEZE: ruby_fl_type = 2048;
+pub const RUBY_FL_USER0: ruby_fl_type = 4096;
+pub const RUBY_FL_USER1: ruby_fl_type = 8192;
+pub const RUBY_FL_USER2: ruby_fl_type = 16384;
+pub const RUBY_FL_USER3: ruby_fl_type = 32768;
+pub const RUBY_FL_USER4: ruby_fl_type = 65536;
+pub const RUBY_FL_USER5: ruby_fl_type = 131072;
+pub const RUBY_FL_USER6: ruby_fl_type = 262144;
+pub const RUBY_FL_USER7: ruby_fl_type = 524288;
+pub const RUBY_FL_USER8: ruby_fl_type = 1048576;
+pub const RUBY_FL_USER9: ruby_fl_type = 2097152;
+pub const RUBY_FL_USER10: ruby_fl_type = 4194304;
+pub const RUBY_FL_USER11: ruby_fl_type = 8388608;
+pub const RUBY_FL_USER12: ruby_fl_type = 16777216;
+pub const RUBY_FL_USER13: ruby_fl_type = 33554432;
+pub const RUBY_FL_USER14: ruby_fl_type = 67108864;
+pub const RUBY_FL_USER15: ruby_fl_type = 134217728;
+pub const RUBY_FL_USER16: ruby_fl_type = 268435456;
+pub const RUBY_FL_USER17: ruby_fl_type = 536870912;
+pub const RUBY_FL_USER18: ruby_fl_type = 1073741824;
+pub const RUBY_FL_USER19: ruby_fl_type = -2147483648;
+pub const RUBY_ELTS_SHARED: ruby_fl_type = 16384;
+pub const RUBY_FL_SINGLETON: ruby_fl_type = 4096;
+pub type ruby_fl_type = i32;
 pub type st_data_t = ::std::os::raw::c_ulong;
 pub type st_index_t = st_data_t;
+pub const RARRAY_EMBED_FLAG: ruby_rarray_flags = 8192;
+pub const RARRAY_EMBED_LEN_MASK: ruby_rarray_flags = 4161536;
+pub const RARRAY_TRANSIENT_FLAG: ruby_rarray_flags = 33554432;
+pub type ruby_rarray_flags = u32;
+pub const RARRAY_EMBED_LEN_SHIFT: ruby_rarray_consts = 15;
+pub type ruby_rarray_consts = u32;
+pub const RMODULE_IS_REFINEMENT: ruby_rmodule_flags = 32768;
+pub type ruby_rmodule_flags = u32;
 extern "C" {
     pub fn rb_class_get_superclass(klass: VALUE) -> VALUE;
 }
+pub const ROBJECT_EMBED: ruby_robject_flags = 8192;
+pub type ruby_robject_flags = u32;
+pub const ROBJECT_EMBED_LEN_MAX: ruby_robject_consts = 3;
+pub type ruby_robject_consts = u32;
 extern "C" {
     pub static mut rb_mKernel: VALUE;
 }
@@ -563,6 +614,10 @@ extern "C" {
 extern "C" {
     pub static mut rb_block_param_proxy: VALUE;
 }
+pub const VM_SPECIAL_OBJECT_VMCORE: vm_special_object_type = 1;
+pub const VM_SPECIAL_OBJECT_CBASE: vm_special_object_type = 2;
+pub const VM_SPECIAL_OBJECT_CONST_BASE: vm_special_object_type = 3;
+pub type vm_special_object_type = u32;
 pub type IC = *mut iseq_inline_constant_cache;
 pub type IVC = *mut iseq_inline_iv_cache_entry;
 pub type ICVARC = *mut iseq_inline_cvar_cache_entry;

--- a/yjit/src/invariants.rs
+++ b/yjit/src/invariants.rs
@@ -463,7 +463,7 @@ pub extern "C" fn rb_yjit_constant_ic_update(iseq: *const rb_iseq_t, ic: IC) {
 
         // This should come from a running iseq, so direct threading translation
         // should have been done
-        assert!(unsafe { FL_TEST(iseq.into(), VALUE(ISEQ_TRANSLATED)) } != VALUE(0));
+        assert!(unsafe { FL_TEST(iseq.into(), VALUE(ISEQ_TRANSLATED as usize)) } != VALUE(0));
         assert!(get_insn_idx < unsafe { get_iseq_encoded_size(iseq) });
 
         // Ensure that the instruction the get_insn_idx is pointing to is in


### PR DESCRIPTION
Constants that can't be imported via bindgen should have a comment saying why not.

I'm doing this as preparatory cleanup before some other changes that touch cruby.rs constants.