### PR TITLE
YJIT: Reduce Rust version requirement to 1.58.1 

### DIFF
--- a/.github/workflows/yjit-ubuntu.yml
+++ b/.github/workflows/yjit-ubuntu.yml
@@ -42,7 +42,8 @@ jobs:
             configure: "--with-gcc=clang-12 --enable-yjit=dev"
 
           - test_task: "check"
-            configure: "--enable-yjit" # release build
+            configure: "--enable-yjit RUSTC='rustc +1.58.1'" # release build
+            rust_version: "1.58.1"
 
           - test_task: "check"
             configure: "--enable-yjit=dev"
@@ -70,6 +71,9 @@ jobs:
           set -x
           sudo apt-get update -q || :
           sudo apt-get install --no-install-recommends -q -y build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev bison autoconf ruby
+      - name: Install Rust
+        if: ${{ matrix.rust_version }}
+        run: rustup install ${{ matrix.rust_version }} --profile minimal
       - name: git config
         run: |
           git config --global advice.detachedHead 0

--- a/yjit/Cargo.toml
+++ b/yjit/Cargo.toml
@@ -6,7 +6,7 @@
 name = "yjit"
 version = "0.1.0"       # YJIT version
 edition = "2021"        # Rust 2021 edition to compile with
-rust-version = "1.60.0" # Minimally supported rust version
+rust-version = "1.58.1" # Minimally supported rust version
 publish = false         # Don't publish to crates.io
 
 [lib]


### PR DESCRIPTION
We want to make it convenient for people to build YJIT and >=1.58.1 is
available on Ubuntu Jammy, Debian testing, and Fedora 36 through the
usual package manager on those systems. This saves the need to install
`rustup` for some people.

Our code is already 1.58.1 compatible so this commit simply tweaks CI
to make sure that we keep supporting the version. We still test against
the latest Rust version in `--enable-yjit=dev` builds through the Rust
version available in GitHub's CI image.
