### PR TITLE
Raise ArgumentError for IO.foreach with limit of 0

### DIFF
--- a/io.c
+++ b/io.c
@@ -11275,6 +11275,8 @@ io_s_foreach(VALUE v)
     struct getline_arg *arg = (void *)v;
     VALUE str;
 
+    if (arg->limit == 0)
+        rb_raise(rb_eArgError, "invalid limit: 0 for foreach");
     while (!NIL_P(str = rb_io_getline_1(arg->rs, arg->limit, arg->chomp, arg->io))) {
 	rb_lastline_set(str);
 	rb_yield(str);

--- a/test/ruby/test_io.rb
+++ b/test/ruby/test_io.rb
@@ -2588,6 +2588,8 @@ class TestIO < Test::Unit::TestCase
       bug = '[ruby-dev:31525]'
       assert_raise(ArgumentError, bug) {IO.foreach}
 
+      assert_raise(ArgumentError, "[Bug #18767] [ruby-core:108499]") {IO.foreach(__FILE__, 0){}}
+
       a = nil
       assert_nothing_raised(ArgumentError, bug) {a = IO.foreach(t.path).to_a}
       assert_equal(["foo\n", "bar\n", "baz\n"], a, bug)


### PR DESCRIPTION
Makes behavior consistent with IO.readlines.

Fixes [Bug #18767]