### PR TITLE
Change ROBJECT_TRANSIENT_FLAG to use FL_USER2

### DIFF
--- a/internal/variable.h
+++ b/internal/variable.h
@@ -16,7 +16,7 @@
 
 /* global variable */
 
-#define ROBJECT_TRANSIENT_FLAG    FL_USER13
+#define ROBJECT_TRANSIENT_FLAG    FL_USER2
 
 /* variable.c */
 void rb_gc_mark_global_tbl(void);


### PR DESCRIPTION
[Object Shapes](https://bugs.ruby-lang.org/issues/18776) will use the latter 16 `FL_USER` bits. Nothing else in transient objects uses `FL_USER2`.