### PR TITLE
Remove trailing comma from FL_USER3

### DIFF
--- a/include/ruby/internal/core/rclass.h
+++ b/include/ruby/internal/core/rclass.h
@@ -58,7 +58,7 @@ enum ruby_rmodule_flags {
      * rb_mod_refine()  has this  flag set.   This  is the  bit which  controls
      * difference between normal inclusion versus refinements.
      */
-    RMODULE_IS_REFINEMENT            = RUBY_FL_USER3,
+    RMODULE_IS_REFINEMENT            = RUBY_FL_USER3
 };
 
 struct RClass; /* Opaque, declared here for RCLASS() macro. */


### PR DESCRIPTION
The [ruby/ruby CI is broken](https://github.com/ruby/ruby/runs/6615086377?check_suite_focus=true) due to trailing comma from [this commit](https://github.com/ruby/ruby/commit/33fdff3c300cbc2e37f1a0819418be313848754d) 