### PR TITLE
[DOC] Fix documentation of Numeric#div: Complex does not have #div

### DIFF
--- a/numeric.c
+++ b/numeric.c
@@ -645,7 +645,7 @@ num_fdiv(VALUE x, VALUE y)
  *  (\Numeric itself does not define method +/+.)
  *
  *  Of the Core and Standard Library classes,
- *  Float, Rational, and Complex use this implementation.
+ *  Only Float and Rational use this implementation.
  *
  */
 


### PR DESCRIPTION
```
% ~/tmp/r/bin/ruby -e '1i.div(2)'
-e:1:in `<main>': undefined method `div' for (0+1i):Complex (NoMethodError)

1i.div(2)
  ^^^^
Did you mean?  fdiv
```