### PR TITLE
Revert "Add {Method,UnboundMethod}#{public?,private?,protected?}"

### DIFF
--- a/test/ruby/test_method.rb
+++ b/test/ruby/test_method.rb
@@ -199,11 +199,6 @@ class TestMethod < Test::Unit::TestCase
     assert_equal(o.method(:foo), o.method(:foo))
     assert_equal(o.method(:foo), o.method(:bar))
     assert_not_equal(o.method(:foo), o.method(:baz))
-
-    class << o
-      private :bar
-    end
-    assert_not_equal(o.method(:foo), o.method(:bar))
   end
 
   def test_hash
@@ -330,8 +325,8 @@ class TestMethod < Test::Unit::TestCase
     def PUBLIC_SINGLETON_TEST.def; end
   end
   def test_define_singleton_method_public
-    assert_equal(true, PUBLIC_SINGLETON_TEST.method(:dsm).public?)
-    assert_equal(true, PUBLIC_SINGLETON_TEST.method(:def).public?)
+    assert_nil(PUBLIC_SINGLETON_TEST.dsm)
+    assert_nil(PUBLIC_SINGLETON_TEST.def)
   end
 
   def test_define_singleton_method_no_proc
@@ -1195,50 +1190,6 @@ class TestMethod < Test::Unit::TestCase
     method = m.instance_method(:f)
     super_method = method.super_method
     assert_nil(super_method)
-  end
-
-  def test_method_visibility_predicates
-    v = Visibility.new
-    assert_equal(true, v.method(:mv1).public?)
-    assert_equal(true, v.method(:mv2).private?)
-    assert_equal(true, v.method(:mv3).protected?)
-    assert_equal(false, v.method(:mv2).public?)
-    assert_equal(false, v.method(:mv3).private?)
-    assert_equal(false, v.method(:mv1).protected?)
-  end
-
-  def test_unbound_method_visibility_predicates
-    assert_equal(true, Visibility.instance_method(:mv1).public?)
-    assert_equal(true, Visibility.instance_method(:mv2).private?)
-    assert_equal(true, Visibility.instance_method(:mv3).protected?)
-    assert_equal(false, Visibility.instance_method(:mv2).public?)
-    assert_equal(false, Visibility.instance_method(:mv3).private?)
-    assert_equal(false, Visibility.instance_method(:mv1).protected?)
-  end
-
-  class VisibilitySub < Visibility
-    protected :mv1
-    public :mv2
-    private :mv3
-  end
-
-  def test_method_visibility_predicates_with_subclass_visbility_change
-    v = VisibilitySub.new
-    assert_equal(false, v.method(:mv1).public?)
-    assert_equal(false, v.method(:mv2).private?)
-    assert_equal(false, v.method(:mv3).protected?)
-    assert_equal(true, v.method(:mv2).public?)
-    assert_equal(true, v.method(:mv3).private?)
-    assert_equal(true, v.method(:mv1).protected?)
-  end
-
-  def test_unbound_method_visibility_predicates_with_subclass_visbility_change
-    assert_equal(false, VisibilitySub.instance_method(:mv1).public?)
-    assert_equal(false, VisibilitySub.instance_method(:mv2).private?)
-    assert_equal(false, VisibilitySub.instance_method(:mv3).protected?)
-    assert_equal(true, VisibilitySub.instance_method(:mv2).public?)
-    assert_equal(true, VisibilitySub.instance_method(:mv3).private?)
-    assert_equal(true, VisibilitySub.instance_method(:mv1).protected?)
   end
 
   def rest_parameter(*rest)


### PR DESCRIPTION
This reverts commit 27278150685e738f84105d09843d3ba371146c7a and
58dc8bf8f15df9a33d191074e8a5d4946a3d59d5.

Visibility is an attribute of the method entry in a class, not an
attribute of the Method object.

This currently fails the bundled gem tests due to use of these methods in
rbs.  That will need to be fixed before this is committed.

Fixes [#18729]
Fixes [#18751]
Fixes [#18435]