### PR TITLE
Reuse `opt_nl` rule

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -5779,8 +5779,7 @@ rbracket	: opt_nl ']'
 rbrace		: opt_nl '}'
 		;
 
-trailer		: /* none */
-		| '\n'
+trailer		: opt_nl
 		| ','
 		;
 


### PR DESCRIPTION
`trailer` and `opt_nl` pattern rule has same pattern in `parse.y`.

```y
trailer		: /* none */
		| '\n'
		| ','
		;
```

```y
opt_nl		: /* none */
		| '\n'
		;
```

It may be more simpler to reuse `opt_nl` rule.

```y
trailer		: opt_nl
		| ','
		;
```