### PR TITLE
Revert "error.c: Let Exception#inspect inspect its message"

### DIFF
--- a/error.c
+++ b/error.c
@@ -34,7 +34,6 @@
 #include "internal/io.h"
 #include "internal/load.h"
 #include "internal/object.h"
-#include "internal/string.h"
 #include "internal/symbol.h"
 #include "internal/thread.h"
 #include "internal/variable.h"
@@ -1423,15 +1422,8 @@ exc_inspect(VALUE exc)
     str = rb_str_buf_new2("#<");
     klass = rb_class_name(klass);
     rb_str_buf_append(str, klass);
-
-    if (RTEST(rb_str_include(exc, rb_str_new2("\n")))) {
-        rb_str_catf(str, ":%+"PRIsVALUE, exc);
-    }
-    else {
-        rb_str_buf_cat(str, ": ", 2);
-        rb_str_buf_append(str, exc);
-    }
-
+    rb_str_buf_cat(str, ": ", 2);
+    rb_str_buf_append(str, exc);
     rb_str_buf_cat(str, ">", 1);
 
     return str;

--- a/internal/string.h
+++ b/internal/string.h
@@ -43,7 +43,6 @@ char *rb_str_to_cstr(VALUE str);
 const char *ruby_escaped_char(int c);
 void rb_str_make_independent(VALUE str);
 int rb_enc_str_coderange_scan(VALUE str, rb_encoding *enc);
-VALUE rb_str_include(VALUE str, VALUE arg);
 
 static inline bool STR_EMBED_P(VALUE str);
 static inline bool STR_SHARED_P(VALUE str);

--- a/string.c
+++ b/string.c
@@ -6376,7 +6376,7 @@ rb_str_reverse_bang(VALUE str)
  *
  */
 
-VALUE
+static VALUE
 rb_str_include(VALUE str, VALUE arg)
 {
     long i;

--- a/test/ruby/test_exception.rb
+++ b/test/ruby/test_exception.rb
@@ -478,12 +478,6 @@ end.join
       def to_s; ""; end
     end
     assert_equal(e.inspect, e.new.inspect)
-
-    # https://bugs.ruby-lang.org/issues/18170#note-13
-    assert_equal('#<Exception:"foo\nbar">', Exception.new("foo\nbar").inspect)
-    assert_equal('#<Exception: foo bar>', Exception.new("foo bar").inspect)
-    assert_equal('#<Exception: foo\bar>', Exception.new("foo\\bar").inspect)
-    assert_equal('#<Exception: "foo\nbar">', Exception.new('"foo\nbar"').inspect)
   end
 
   def test_to_s


### PR DESCRIPTION
Reverts ruby/ruby#4857

This change broke some tests of debug gem: https://github.com/ruby/ruby/runs/6766328682?check_suite_focus=true#step:16:2154 .