### PR TITLE
Add special-case code for the String unary plus operator

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -1393,6 +1393,33 @@ assert_equal 'foo', %q{
   make_str("foo")
 }
 
+# Test that String unary plus returns the same object ID for an unfrozen string.
+assert_equal '', %q{
+  str = "bar"
+
+  old_obj_id = str.object_id
+  uplus_str = +str
+
+  if uplus_str.object_id != old_obj_id
+    raise "String unary plus on unfrozen should return the string exactly, not a duplicate"
+  end
+
+  ''
+}
+
+# Test that String unary plus returns a different unfrozen string when given a frozen string
+assert_equal 'false', %q{
+  frozen_str = "foo".freeze
+
+  old_obj_id = frozen_str.object_id
+  uplus_str = +frozen_str
+
+  if uplus_str.object_id == old_obj_id
+    raise "String unary plus on frozen should return a new duplicated string"
+  end
+
+  uplus_str.frozen?
+}
 
 # test invokebuiltin as used in struct assignment
 assert_equal '123', %q{

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -62,6 +62,7 @@ fn main() {
         // From include/ruby/internal/intern/string.h
         .allowlist_function("rb_utf8_str_new")
         .allowlist_function("rb_str_append")
+        .allowlist_function("rb_str_dup")
 
         // This struct is public to Ruby C extensions
         // From include/ruby/internal/core/rbasic.h

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -224,6 +224,9 @@ extern "C" {
     ) -> VALUE;
 }
 extern "C" {
+    pub fn rb_str_dup(str_: VALUE) -> VALUE;
+}
+extern "C" {
     pub fn rb_str_append(dst: VALUE, src: VALUE) -> VALUE;
 }
 extern "C" {


### PR DESCRIPTION
For a string, this will generate and optimised hardcoded unary +, which is basically "dup the string if it's frozen, otherwise do nothing." If we ever decide to include whether an object is frozen in the type info, this is an operation that would benefit from it.

I don't hardcode unary minus here. Unary minus directly on a string literal has a YARV bytecode already (opt_uminus), and the unary minus is a more complicated operator than unary plus. So there's less benefit and more complexity. Unary plus is *not* optimised already by the CRuby parser, and it only needs a little machine code.