### PR TITLE
[DOC] Fix markup for `String`

### DIFF
--- a/doc/string/start_with_p.rdoc
+++ b/doc/string/start_with_p.rdoc
@@ -1,6 +1,6 @@
 Returns whether +self+ starts with any of the given +string_or_regexp+.
 
-Matches patterns against the beginning of+self+.
+Matches patterns against the beginning of +self+.
 For each given +string_or_regexp+, the pattern is:
 
 - +string_or_regexp+ itself, if it is a Regexp.

--- a/string.c
+++ b/string.c
@@ -7998,7 +7998,7 @@ rb_str_tr_bang(VALUE str, VALUE src, VALUE repl)
  *
  *  - Each occurrence of the first character specified by +selector+
  *    is translated to the first character in +replacements+.
- *  - Each occurrence of the second character specified by selector+
+ *  - Each occurrence of the second character specified by +selector+
  *    is translated to the second character in +replacements+.
  *  - And so on.
  *

--- a/string.rb
+++ b/string.rb
@@ -143,7 +143,7 @@
 #  consisting of any mixture of the following:
 #
 #  - NL (null): <tt>"\x00"</tt>, <tt>"\u0000"</tt>.
-#  - HT (horizontal tab): <tt>"\x09"</tt>, "<tt>\t"</tt>.
+#  - HT (horizontal tab): <tt>"\x09"</tt>, <tt>"\t"</tt>.
 #  - LF (line feed): <tt>"\x0a"</tt>, <tt>"\n"</tt>.
 #  - VT (vertical tab): <tt>"\x0b"</tt>, <tt>"\v"</tt>.
 #  - FF (form feed): <tt>"\x0c"</tt>, <tt>"\f"</tt>.
@@ -452,9 +452,9 @@
 #
 #  _Substitution_
 #
-#  - #dump: Returns a copy of +self with all non-printing characters replaced by \xHH notation
+#  - #dump: Returns a copy of +self+ with all non-printing characters replaced by \xHH notation
 #    and all special characters escaped.
-#  - #undump: Returns a copy of +self with all <tt>\xNN</tt> notation replace by <tt>\uNNNN</tt> notation
+#  - #undump: Returns a copy of +self+ with all <tt>\xNN</tt> notation replace by <tt>\uNNNN</tt> notation
 #    and all escaped characters unescaped.
 #  - #sub: Returns a copy of +self+ with the first substring matching a given pattern
 #    replaced with a given replacement string;.


### PR DESCRIPTION
* Add missing space for `String#start_with?`.
* Add missing pluses for `String#tr` and
  `Methods for Converting to New String` label.
* Move quote into the tag for `Whitespace in Strings` label.