### PR TITLE
thread_pthread.c: trigger THREAD_EVENT_READY when going throuhg the fast path.

### DIFF
--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -377,16 +377,16 @@ thread_sched_to_ready_common(struct rb_thread_sched *sched, rb_thread_t *th)
 static void
 thread_sched_to_running_common(struct rb_thread_sched *sched, rb_thread_t *th)
 {
+    if (rb_internal_thread_event_hooks) {
+        rb_thread_execute_hooks(RUBY_INTERNAL_THREAD_EVENT_READY);
+    }
+
     if (sched->running) {
         VM_ASSERT(th->unblock.func == 0 &&
                   "we must not be in ubf_list and GVL readyq at the same time");
 
         // waiting -> ready
         thread_sched_to_ready_common(sched, th);
-
-        if (rb_internal_thread_event_hooks) {
-            rb_thread_execute_hooks(RUBY_INTERNAL_THREAD_EVENT_READY);
-        }
 
         // wait for running chance
         do {


### PR DESCRIPTION
Followup: https://github.com/ruby/ruby/pull/5983

The extra failure information indicated that it's the `READY` event that wasn't firing.
After looking at the code, it indeed appears that there's a fastpath for when no tread is currently running that I missed.
