### PR TITLE
Fix interpreter crash caused by RUBY_INTERNAL_EVENT_NEWOBJ + Ractors

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -2483,6 +2483,7 @@ rb_objspace_set_event_hook(const rb_event_flag_t event)
 static void
 gc_event_hook_body(rb_execution_context_t *ec, rb_objspace_t *objspace, const rb_event_flag_t event, VALUE data)
 {
+    if (UNLIKELY(!ec->cfp)) return;
     const VALUE *pc = ec->cfp->pc;
     if (pc && VM_FRAME_RUBYFRAME_P(ec->cfp)) {
         /* increment PC because source line is calculated with PC-1 */

--- a/test/objspace/test_ractor.rb
+++ b/test/objspace/test_ractor.rb
@@ -1,0 +1,17 @@
+require "test/unit"
+
+class TestObjSpaceRactor < Test::Unit::TestCase
+    def test_tracing_does_not_crash
+        assert_ractor(<<~RUBY, require: 'objspace')
+            ObjectSpace.trace_object_allocations do
+                r = Ractor.new do
+                    obj = 'a' * 1024
+                    Ractor.yield obj
+                end
+
+                r.take
+                r.take
+            end
+        RUBY
+    end
+end


### PR DESCRIPTION
When a Ractor is created whilst a tracepoint for
RUBY_INTERNAL_EVENT_NEWOBJ is active, the interpreter crashes. This is
because during the early setup of the Ractor, the stdio objects are
created, which allocates Ruby objects, which fires the tracepoint.
However, the tracepoint machinery tries to dereference the control frame
(ec->cfp->pc), which isn't set up yet and so crashes with a null pointer
dereference.

Fix this by not firing GC tracepoints if cfp isn't yet set up.

More details in the bug I filed: https://bugs.ruby-lang.org/issues/18464