### PR TITLE
Adds `deconstruct_keys` to `CSV::Row`

### DIFF
--- a/lib/csv/row.rb
+++ b/lib/csv/row.rb
@@ -548,6 +548,21 @@ class CSV
     end
     alias_method :to_hash, :to_h
 
+    # :call-seq:
+    #   row.deconstruct_keys -> hash
+    #
+    # Consumes the results of \to_h for use in pattern matching by treating
+    # \Symbol keys as query parameters for \String \CSV headers:
+    #
+    #   source = "Name,Value\nfoo,0\nbar,1\nbaz,2\n"
+    #   table = CSV.parse(source, headers: true)
+    #   table.select { |row| row in Name: /^ba/ }
+    #   # => [#<CSV::Row "Name":"bar" "Value":"1">, #<CSV::Row "Name":"baz" "Value":"2">]
+    def deconstruct_keys(keys)
+      hash = self.to_h.transform_keys(&:to_sym)
+      keys ? hash.slice(*keys) : hash
+    end
+
     alias_method :to_ary, :to_a
 
     # :call-seq:

--- a/test/csv/test_row.rb
+++ b/test/csv/test_row.rb
@@ -351,6 +351,13 @@ class TestCSVRow < Test::Unit::TestCase
                   @row.to_csv(col_sep: "|", row_sep: "\r\n") )
   end
 
+  def test_deconstruct_keys
+    row = CSV::Row.new(%w{A B C}, [1, 2, 3])
+    match_result = row in A: 1..10, B: _, C: 3
+
+    assert_equal(true, match_result)
+  end
+
   def test_array_delegation
     assert_not_empty(@row, "Row was empty.")
 


### PR DESCRIPTION
### Description

Introduces hash-like pattern matching to `CSV::Row` by using `Symbol`
keys to query against `String` key headers:

```ruby
CSV::Row.new(%w{A B C}, [1, 2, 3])
row in A: 1..10, B: _, C: 3 # => true
```

Related to: https://bugs.ruby-lang.org/issues/18821

### Note to Maintainers

I am very new to contributing to direct Ruby code, feel free to make edits or correct mistakes I may have made here.

### Note on Precedent

This should be understood that this potentially establishes a precedent in which we can potentially query against `String`-key interfaces using `Symbol` keys.

I believe this follows reasonable and prior precedent given that many other Ruby methods will convert `Symbol` and `String` when we can reasonably guess what the user meant.

The precedent that I may suggest separately in more vague cases is that the `Symbol` keys in pattern matching are not really `Symbol`s as much as keywords signifying where we want to look for a pattern, and having a cascade of searching for `Symbol` then `String` if not found feels reasonable and Ruby-like to me.

I mention this as I do not want to sneak in potentially new precedent in Ruby, and that we agree on this matter first.