### PR TITLE
Remove duplicated rb_yjit_get_stats

### DIFF
--- a/yjit.c
+++ b/yjit.c
@@ -955,7 +955,6 @@ VALUE rb_yjit_reset_stats_bang(rb_execution_context_t *ec, VALUE self);
 VALUE rb_yjit_disasm_iseq(rb_execution_context_t *ec, VALUE self, VALUE iseq);
 VALUE rb_yjit_insns_compiled(rb_execution_context_t *ec, VALUE self, VALUE iseq);
 VALUE rb_yjit_simulate_oom_bang(rb_execution_context_t *ec, VALUE self);
-VALUE rb_yjit_get_stats(rb_execution_context_t *ec, VALUE self);
 VALUE rb_yjit_get_exit_locations(rb_execution_context_t *ec, VALUE self);
 
 // Preprocessed yjit.rb generated during build


### PR DESCRIPTION
`rb_yjit_get_stats` is defined twice in yjit.c, it only needs to be
defined once.