### PR TITLE
WIP: Try to add a fake frame when iseq compilation

### DIFF
--- a/iseq.c
+++ b/iseq.c
@@ -1046,7 +1046,10 @@ rb_iseq_new_with_opt(const rb_ast_body_t *ast, VALUE name, VALUE path, VALUE rea
     prepare_iseq_build(iseq, name, path, realpath, first_lineno, node ? &node->nd_loc : NULL, node ? nd_node_id(node) : -1,
                        parent, isolated_depth, type, script_lines, &new_opt);
 
+
+    if (type == ISEQ_TYPE_TOP) rb_iseq_set_top_stack(iseq);
     rb_iseq_compile_node(iseq, node);
+    if (type == ISEQ_TYPE_TOP) rb_iseq_pop_top_stack();
     finish_iseq_build(iseq);
 
     return iseq_translate(iseq);

--- a/vm.c
+++ b/vm.c
@@ -2530,6 +2530,21 @@ vm_exec_handle_exception(rb_execution_context_t *ec, enum ruby_tag_type state,
 
 /* misc */
 
+void
+rb_iseq_set_top_stack(const rb_iseq_t *iseq)
+{
+    rb_execution_context_t *ec = GET_EC();
+    vm_set_top_stack(ec, iseq);
+    VM_ASSERT(VM_FRAME_RUBYFRAME_P(ec->cfp));
+}
+
+void
+rb_iseq_pop_top_stack(void)
+{
+    rb_execution_context_t *ec = GET_EC();
+    rb_vm_pop_frame(ec);
+}
+
 VALUE
 rb_iseq_eval(const rb_iseq_t *iseq)
 {

--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -38,8 +38,6 @@ calc_pos(const rb_iseq_t *iseq, const VALUE *pc, int *lineno, int *node_id)
 {
     VM_ASSERT(iseq);
     VM_ASSERT(ISEQ_BODY(iseq));
-    VM_ASSERT(ISEQ_BODY(iseq)->iseq_encoded);
-    VM_ASSERT(ISEQ_BODY(iseq)->iseq_size);
     if (! pc) {
         if (ISEQ_BODY(iseq)->type == ISEQ_TYPE_TOP) {
             VM_ASSERT(! ISEQ_BODY(iseq)->local_table);
@@ -53,6 +51,8 @@ calc_pos(const rb_iseq_t *iseq, const VALUE *pc, int *lineno, int *node_id)
         return 1;
     }
     else {
+        VM_ASSERT(ISEQ_BODY(iseq)->iseq_encoded);
+        VM_ASSERT(ISEQ_BODY(iseq)->iseq_size);
         ptrdiff_t n = pc - ISEQ_BODY(iseq)->iseq_encoded;
         VM_ASSERT(n <= ISEQ_BODY(iseq)->iseq_size);
         VM_ASSERT(n >= 0);

--- a/vm_core.h
+++ b/vm_core.h
@@ -1711,6 +1711,8 @@ NORETURN(void rb_bug_for_fatal_signal(ruby_sighandler_t default_sighandler, int 
 
 /* functions about thread/vm execution */
 RUBY_SYMBOL_EXPORT_BEGIN
+void rb_iseq_set_top_stack(const rb_iseq_t *iseq);
+void rb_iseq_pop_top_stack(void);
 VALUE rb_iseq_eval(const rb_iseq_t *iseq);
 VALUE rb_iseq_eval_main(const rb_iseq_t *iseq);
 VALUE rb_iseq_path(const rb_iseq_t *iseq);


### PR DESCRIPTION
Ref: https://bugs.ruby-lang.org/issues/18559

When tracing allocations, all the objects created by the compiler are attributed to `Kernel.require`, making it impossible to measure the static overhead of various parts of an application.

I paired on this with @peterzhu2118, we found a way to push a stack frame before an iseq is compiled, allowing `TracePoint` to report the right `sourcefile`.

We haven't however figured a way to set the line number, so all these allocations are reported on line `0`.