### PR TITLE
 Make method id explicit in rb_exec_recursive_outer

### DIFF
--- a/ext/-test-/recursion/recursion.c
+++ b/ext/-test-/recursion/recursion.c
@@ -16,7 +16,7 @@ exec_recursive(VALUE self, VALUE mid)
 static VALUE
 exec_recursive_outer(VALUE self, VALUE mid)
 {
-    return rb_exec_recursive_outer(recursive_i, self, mid);
+    return rb_exec_recursive_outer_mid(recursive_i, self, mid, rb_intern("exec_recursive_outer"));
 }
 
 void

--- a/hash.c
+++ b/hash.c
@@ -195,7 +195,7 @@ obj_any_hash(VALUE obj)
     VALUE hval = rb_check_funcall_basic_kw(obj, id_hash, rb_mKernel, 0, 0, 0);
 
     if (hval == Qundef) {
-        hval = rb_exec_recursive_outer(hash_recursive, obj, 0);
+        hval = rb_exec_recursive_outer_mid(hash_recursive, obj, 0, id_hash);
     }
 
     while (!FIXNUM_P(hval)) {

--- a/include/ruby/internal/intern/thread.h
+++ b/include/ruby/internal/intern/thread.h
@@ -292,6 +292,7 @@ VALUE rb_exec_recursive_paired(VALUE (*f)(VALUE g, VALUE h, int r), VALUE g, VAL
  * @param[in]      f  The function that possibly recurs.
  * @param[in,out]  g  Passed as-is to `f`.
  * @param[in,out]  h  Passed as-is to `f`.
+ * @param[in]      mid The ID of the method name being called
  * @return         The return value of f.
  *
  * @internal
@@ -299,7 +300,7 @@ VALUE rb_exec_recursive_paired(VALUE (*f)(VALUE g, VALUE h, int r), VALUE g, VAL
  * It seems  nobody uses the "it  calls rb_throw_obj()" part of  this function.
  * @shyouhei doesn't understand the needs.
  */
-VALUE rb_exec_recursive_outer(VALUE (*f)(VALUE g, VALUE h, int r), VALUE g, VALUE h);
+VALUE rb_exec_recursive_outer_mid(VALUE (*f)(VALUE g, VALUE h, int r), VALUE g, VALUE h, ID mid);
 
 /**
  * Identical to  rb_exec_recursive_outer(), except it checks  for the recursion

--- a/test/ruby/test_hash.rb
+++ b/test/ruby/test_hash.rb
@@ -2166,6 +2166,27 @@ class TestHash < Test::Unit::TestCase
     end
   end
 
+  # Previously this test would fail because rb_hash inside opt_aref would look
+  # at the current method name
+  def test_hash_recursion_independent_of_mid
+    o = Class.new do
+      def hash(h, k)
+        h[k]
+      end
+
+      def any_other_name(h, k)
+        h[k]
+      end
+    end.new
+
+    rec = []; rec << rec
+
+    h = @cls[]
+    h[rec] = 1
+    assert o.hash(h, rec)
+    assert o.any_other_name(h, rec)
+  end
+
   def test_any_hash_fixable
     20.times do
       assert_separately([], "#{<<~"begin;"}\n#{<<~'end;'}")

--- a/thread.c
+++ b/thread.c
@@ -5070,10 +5070,9 @@ exec_recursive_i(RB_BLOCK_CALL_FUNC_ARGLIST(tag, data))
  */
 
 static VALUE
-exec_recursive(VALUE (*func) (VALUE, VALUE, int), VALUE obj, VALUE pairid, VALUE arg, int outer)
+exec_recursive(VALUE (*func) (VALUE, VALUE, int), VALUE obj, VALUE pairid, VALUE arg, int outer, ID mid)
 {
     VALUE result = Qundef;
-    const ID mid = rb_frame_last_func();
     const VALUE sym = mid ? ID2SYM(mid) : ID2SYM(idNULL);
     struct exec_recursive_params p;
     int outermost;
@@ -5138,7 +5137,7 @@ exec_recursive(VALUE (*func) (VALUE, VALUE, int), VALUE obj, VALUE pairid, VALUE
 VALUE
 rb_exec_recursive(VALUE (*func) (VALUE, VALUE, int), VALUE obj, VALUE arg)
 {
-    return exec_recursive(func, obj, 0, arg, 0);
+    return exec_recursive(func, obj, 0, arg, 0, rb_frame_last_func());
 }
 
 /*
@@ -5149,7 +5148,7 @@ rb_exec_recursive(VALUE (*func) (VALUE, VALUE, int), VALUE obj, VALUE arg)
 VALUE
 rb_exec_recursive_paired(VALUE (*func) (VALUE, VALUE, int), VALUE obj, VALUE paired_obj, VALUE arg)
 {
-    return exec_recursive(func, obj, rb_memory_id(paired_obj), arg, 0);
+    return exec_recursive(func, obj, rb_memory_id(paired_obj), arg, 0, rb_frame_last_func());
 }
 
 /*
@@ -5161,7 +5160,7 @@ rb_exec_recursive_paired(VALUE (*func) (VALUE, VALUE, int), VALUE obj, VALUE pai
 VALUE
 rb_exec_recursive_outer(VALUE (*func) (VALUE, VALUE, int), VALUE obj, VALUE arg)
 {
-    return exec_recursive(func, obj, 0, arg, 1);
+    return exec_recursive(func, obj, 0, arg, 1, rb_frame_last_func());
 }
 
 /*
@@ -5173,7 +5172,7 @@ rb_exec_recursive_outer(VALUE (*func) (VALUE, VALUE, int), VALUE obj, VALUE arg)
 VALUE
 rb_exec_recursive_paired_outer(VALUE (*func) (VALUE, VALUE, int), VALUE obj, VALUE paired_obj, VALUE arg)
 {
-    return exec_recursive(func, obj, rb_memory_id(paired_obj), arg, 1);
+    return exec_recursive(func, obj, rb_memory_id(paired_obj), arg, 1, rb_frame_last_func());
 }
 
 /*

--- a/thread.c
+++ b/thread.c
@@ -5158,9 +5158,9 @@ rb_exec_recursive_paired(VALUE (*func) (VALUE, VALUE, int), VALUE obj, VALUE pai
  */
 
 VALUE
-rb_exec_recursive_outer(VALUE (*func) (VALUE, VALUE, int), VALUE obj, VALUE arg)
+rb_exec_recursive_outer_mid(VALUE (*func) (VALUE, VALUE, int), VALUE obj, VALUE arg, ID mid)
 {
-    return exec_recursive(func, obj, 0, arg, 1, rb_frame_last_func());
+    return exec_recursive(func, obj, 0, arg, 1, mid);
 }
 
 /*


### PR DESCRIPTION
Previously, because `opt_aref` and `opt_aset` don't push a frame, when they would call `rb_hash` to determine the hash value of the key, the initial level of recursion would incorrectly use the method id at the top of the stack instead of "hash".

```
$ cat test.rb
module Hacks
  # aref from a named "hash" (not overriding hash) causes a different result
  def self.hash(h, k)
    h[k]
  end

  def self.any_other_name(h, k)
    h[k]
  end
end

rec = []; rec << rec

h = {}
h[rec] = 1
p Hacks.hash(h, rec)
p Hacks.any_other_name(h, rec)

$ make run
./miniruby -I./lib -I. -I.ext/common  -r./x86_64-linux-fake  ./test.rb
nil
1
```

This commit replaces `rb_exec_recursive_outer` with `rb_exec_recursive_outer_mid`, which takes an explicit method id, so that we can make the hash calculation behave consistently.

`rb_exec_recursive_outer` was documented as being internal, so I believe this should be okay to change.