### PR TITLE
ext/openssl/ossl_pkey.c: fix build with libressl >= 3.5.0

### DIFF
--- a/ext/openssl/ossl_pkey.c
+++ b/ext/openssl/ossl_pkey.c
@@ -670,7 +670,7 @@ ossl_pkey_export_traditional(int argc, VALUE *argv, VALUE self, int to_der)
 	}
     }
     else {
-#if OPENSSL_VERSION_NUMBER >= 0x10100000 && !defined(LIBRESSL_VERSION_NUMBER)
+#if OSSL_OPENSSL_PREREQ(1, 1, 0) || OSSL_LIBRESSL_PREREQ(3, 5, 0)
 	if (!PEM_write_bio_PrivateKey_traditional(bio, pkey, enc, NULL, 0,
 						  ossl_pem_passwd_cb,
 						  (void *)pass)) {


### PR DESCRIPTION
Fix the following build failure with libressl >= 3.5.0:

```
ossl_pkey.c: In function 'ossl_pkey_export_traditional':
ossl_pkey.c:681:62: error: invalid use of incomplete typedef 'EVP_PKEY' {aka 'struct evp_pkey_st'}
  681 |  EVP_PKEY_asn1_get0_info(NULL, NULL, NULL, NULL, &aname, pkey->ameth);
      |                                                              ^~
```

Fixes:
 - http://autobuild.buildroot.org/results/9b2622fbc4c2c2b787578ee83fc6a23795a84415

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>