### PR TITLE
compile.c (add_adjust_info): Remove `insns_info_index > 0`

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -2226,8 +2226,7 @@ static int
 add_adjust_info(struct iseq_insn_info_entry *insns_info, unsigned int *positions,
                 int insns_info_index, int code_index, const ADJUST *adjust)
 {
-    if (insns_info_index > 0 ||
-        insns_info[insns_info_index-1].line_no != adjust->line_no) {
+    if (insns_info[insns_info_index-1].line_no != adjust->line_no) {
         insns_info[insns_info_index].line_no    = adjust->line_no;
         insns_info[insns_info_index].events     = 0;
         positions[insns_info_index]             = code_index;
@@ -2474,6 +2473,10 @@ iseq_set_sequence(rb_iseq_t *iseq, LINK_ANCHOR *const anchor)
 		if (adjust->line_no != -1) {
 		    const int diff = orig_sp - sp;
 		    if (diff > 0) {
+                        if (insns_info_index == 0) {
+                            COMPILE_ERROR(iseq, adjust->line_no,
+                                          "iseq_set_sequence: adjust bug (ISEQ_ELEMENT_ADJUST must not be the first in iseq)");
+                        }
 			if (add_adjust_info(insns_info, positions, insns_info_index, code_index, adjust)) insns_info_index++;
 		    }
 		    if (diff > 1) {


### PR DESCRIPTION
... because insns_info_index could not be zero here. Also it adds an
invariant check for that.

This change will prevent the following warning of GCC 12.1

http://rubyci.s3.amazonaws.com/arch/ruby-master/log/20220613T000004Z.log.html.gz
```
compile.c:2230:39: warning: array subscript 2147483647 is outside array bounds of ‘struct iseq_insn_info_entry[2147483647]’ [-Warray-bounds]
 2230 |         insns_info[insns_info_index-1].line_no != adjust->line_no) {
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~
```