### PR TITLE
cont.c: prevent a warning of GCC 12.1

### DIFF
--- a/cont.c
+++ b/cont.c
@@ -1486,6 +1486,10 @@ cont_restore_0(rb_context_t *cont, VALUE *addr_in_prev_frame)
             if (&space[0] > end) {
 # ifdef HAVE_ALLOCA
                 volatile VALUE *sp = ALLOCA_N(VALUE, &space[0] - end);
+                // We need to make sure that the stack pointer is moved,
+                // but some compilers may remove the allocation by optimization.
+                // We hope that the following read/write will prevent such an optimization.
+                *sp = Qfalse;
                 space[0] = *sp;
 # else
                 cont_restore_0(cont, &space[0]);


### PR DESCRIPTION
... by assigning a dummy value to the allocated stack.

http://rubyci.s3.amazonaws.com/arch/ruby-master/log/20220613T000004Z.log.html.gz
```
cont.c: In function ‘cont_restore_0.constprop’:
cont.c:1489:28: warning: ‘*sp’ may be used uninitialized [-Wmaybe-uninitialized]
 1489 |                 space[0] = *sp;
      |                            ^~~
```

Also it adds some comments about the hack of dummy stack allocation.