### PR TITLE
regparse.c: Suppress false-positive warnings of GCC 12.1

### DIFF
--- a/regparse.c
+++ b/regparse.c
@@ -28,6 +28,13 @@
  * SUCH DAMAGE.
  */
 
+// Suppress some false-positive compiler warnings
+#if defined(__GNUC__) && __GNUC__ >= 12
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#pragma GCC diagnostic ignored "-Wrestrict"
+#endif
+
 #include "regparse.h"
 #include <stdarg.h>
 


### PR DESCRIPTION
http://rubyci.s3.amazonaws.com/arch/ruby-master/log/20220613T030003Z.log.html.gz
```
regparse.c:264:15: warning: array subscript 56 is outside array bounds of ‘Node[1]’ {aka ‘struct _Node[1]’} [-Warray-bounds]
```

and

```
/usr/include/bits/string_fortified.h:29:10: warning: ‘__builtin_memcpy’ pointer overflow between offset 32 and size [9223372036854775792, 9223372036854775807] [-Warray-bounds]
```