### PR TITLE
Add imemo types to global namespace in lldb helpers

### DIFF
--- a/misc/lldb_cruby.py
+++ b/misc/lldb_cruby.py
@@ -168,6 +168,12 @@ def lldb_init(debugger):
 
     value_types = []
     g = globals()
+
+    imemo_types = target.FindFirstType('enum imemo_type')
+
+    for member in imemo_types.GetEnumMembers():
+        g[member.GetName()] = member.GetValueAsUnsigned()
+
     for enum in target.FindFirstGlobalVariable('ruby_dummy_gdb_enums'):
         enum = enum.GetType()
         members = enum.GetEnumMembers()


### PR DESCRIPTION
Adds imemo types to global namespaces. This is useful for debugging imemos with lldb. 