### PR TITLE
Remove unused and accidentally public rb_str_shared_root_p()

### DIFF
--- a/include/ruby/internal/core/rstring.h
+++ b/include/ruby/internal/core/rstring.h
@@ -556,9 +556,6 @@ RSTRING_LENINT(VALUE str)
     return rb_long2int(RSTRING_LEN(str));
 }
 
-bool
-rb_str_shared_root_p(VALUE str);
-
 /**
  * Convenient macro to obtain the contents and length at once.
  *

--- a/string.c
+++ b/string.c
@@ -233,12 +233,6 @@ rb_str_embed_size(long capa)
     return offsetof(struct RString, as.embed.ary) + capa;
 }
 
-bool
-rb_str_shared_root_p(VALUE str)
-{
-    return FL_TEST_RAW(str, STR_SHARED_ROOT);
-}
-
 size_t
 rb_str_size_as_embedded(VALUE str)
 {


### PR DESCRIPTION
This function was added to a public header in 56cc3e99b6b9ec004255280337f6b8353f5e5b06 probably
unintentionally since it's not used anywhere, exposes implementation
details, and isn't related to the goal of that pull request.

CC @eightbitraptor 
