### PR TITLE
Add branch protection to aarch64 targets

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -780,6 +780,20 @@ AS_IF([test "$GCC" = yes], [
 	RUBY_APPEND_OPTION(LDFLAGS, $stack_protector)
     ])
 
+    # aarch64 branch protection
+    AS_CASE(["$target_cpu"], [aarch64], [
+        branch_protection=no
+        RUBY_TRY_CFLAGS(-mbranch-protection=pac-ret,[branch_protection=yes])
+        AS_IF([test "x$branch_protection" = xyes], [
+            RUBY_APPEND_OPTION(XCFLAGS, -mbranch-protection=pac-ret)
+        ],
+        [
+            RUBY_TRY_CFLAGS(-msign-return-address=all, [
+                RUBY_APPEND_OPTION(XCFLAGS, -msign-return-address=all)
+            ])
+        ])
+    ])
+
     AS_CASE("${compress_debug_sections:-zlib}",
     [none|no], [], [
     RUBY_TRY_LDFLAGS(${linker_flag}--compress-debug-sections=${compress_debug_sections:-zlib},

--- a/configure.ac
+++ b/configure.ac
@@ -782,14 +782,11 @@ AS_IF([test "$GCC" = yes], [
 
     # aarch64 branch protection
     AS_CASE(["$target_cpu"], [aarch64], [
-        branch_protection=no
-        RUBY_TRY_CFLAGS(-mbranch-protection=pac-ret,[branch_protection=yes])
-        AS_IF([test "x$branch_protection" = xyes], [
-            RUBY_APPEND_OPTION(XCFLAGS, -mbranch-protection=pac-ret)
-        ],
-        [
-            RUBY_TRY_CFLAGS(-msign-return-address=all, [
-                RUBY_APPEND_OPTION(XCFLAGS, -msign-return-address=all)
+	AS_FOR(option, opt, [-mbranch-protection=pac-ret -msign-return-address=all], [
+            RUBY_TRY_CFLAGS(option, [branch_protection=yes], [branch_protection=no])
+            AS_IF([test "x$branch_protection" = xyes], [
+                RUBY_APPEND_OPTION(XCFLAGS, option)
+                break
             ])
         ])
     ])


### PR DESCRIPTION
ARM64v8.3 supports [Pointer Authentication](https://www.qualcomm.com/media/documents/files/whitepaper-pointer-authentication-on-armv8-3.pdf) with the PACIASP and AUTIASP instructions which are interpreted as NOP instructions on pre-8.3 architectures.  These instructions sign the stack pointer and validate the stack pointer prior to return to mitigate [return oriented programming](https://en.wikipedia.org/wiki/Return-oriented_programming).

GCC supports these [options](https://gcc.gnu.org/onlinedocs/gcc/AArch64-Options.html) on arm64 / aarch64.  The legacy option was `-msign-return-address=[all | non-leaf | none]` and the modern option is `-mbranch-protection=none|standard|pac-ret[+leaf+b-key]|bti`

I would like to suggest that the arm64 build be modified to include `-mbranch-protection=pac-ret` with the `-march` being set to ARMv8.2 or earlier or not configured, so that GCC will generate [PACIASP](https://developer.arm.com/documentation/100076/0100/A64-Instruction-Set-Reference/A64-General-Instructions/PACIA--PACIZA--PACIA1716--PACIASP--PACIAZ?lang=en) and [AUTIASP](https://developer.arm.com/documentation/100076/0100/A64-Instruction-Set-Reference/A64-General-Instructions/AUTIA--AUTIZA--AUTIA1716--AUTIASP--AUTIAZ?lang=en) instructions.  It is critical that `-march=armv8.3` or higher not be passed or the non-backwards compatible RETAA instruction will be generated.

The benefit of enabling pointer authentication for the stack pointer on ARM64 would be to mitigate [return oriented programming](https://en.wikipedia.org/wiki/Return-oriented_programming) attacks against the Ruby runtime.

Presently we (GoDaddy) are pursuing custom compiles of the Ruby runtime for the new Graviton3 CPUs that support pointer authentication in AWS.
