### PR TITLE
[ci skip] [lldb] Ensure rbbt has loaded the globals

### DIFF
--- a/misc/lldb_cruby.py
+++ b/misc/lldb_cruby.py
@@ -501,6 +501,8 @@ def dump_node(debugger, command, ctx, result, internal_dict):
     output_string(ctx, result, dump)
 
 def rb_backtrace(debugger, command, result, internal_dict):
+    if not ('RUBY_Qfalse' in globals()):
+        lldb_init(debugger)
     bt = BackTrace(debugger, command, result, internal_dict)
     frame = bt.frame
 


### PR DESCRIPTION
rb_backtrace relies on the existend of RUBY_T_MASK. This is set up by
the global loading code in lldb_init()

rb_backtrace does not call lldb_init previously, and therefore would
only work if called after another lldb function that _did_ load the
globals.