### PR TITLE
Restore rb_exec_recursive_outer

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -7033,6 +7033,7 @@ hash.$(OBJEXT): $(top_srcdir)/internal/serial.h
 hash.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 hash.$(OBJEXT): $(top_srcdir)/internal/string.h
 hash.$(OBJEXT): $(top_srcdir)/internal/symbol.h
+hash.$(OBJEXT): $(top_srcdir)/internal/thread.h
 hash.$(OBJEXT): $(top_srcdir)/internal/time.h
 hash.$(OBJEXT): $(top_srcdir)/internal/vm.h
 hash.$(OBJEXT): $(top_srcdir)/internal/warnings.h

--- a/ext/-test-/recursion/recursion.c
+++ b/ext/-test-/recursion/recursion.c
@@ -16,7 +16,7 @@ exec_recursive(VALUE self, VALUE mid)
 static VALUE
 exec_recursive_outer(VALUE self, VALUE mid)
 {
-    return rb_exec_recursive_outer_mid(recursive_i, self, mid, rb_intern("exec_recursive_outer"));
+    return rb_exec_recursive_outer(recursive_i, self, mid);
 }
 
 void

--- a/hash.c
+++ b/hash.c
@@ -35,6 +35,7 @@
 #include "internal/object.h"
 #include "internal/proc.h"
 #include "internal/symbol.h"
+#include "internal/thread.h"
 #include "internal/time.h"
 #include "internal/vm.h"
 #include "probes.h"

--- a/include/ruby/internal/intern/thread.h
+++ b/include/ruby/internal/intern/thread.h
@@ -292,7 +292,6 @@ VALUE rb_exec_recursive_paired(VALUE (*f)(VALUE g, VALUE h, int r), VALUE g, VAL
  * @param[in]      f  The function that possibly recurs.
  * @param[in,out]  g  Passed as-is to `f`.
  * @param[in,out]  h  Passed as-is to `f`.
- * @param[in]      mid The ID of the method name being called
  * @return         The return value of f.
  *
  * @internal
@@ -300,7 +299,7 @@ VALUE rb_exec_recursive_paired(VALUE (*f)(VALUE g, VALUE h, int r), VALUE g, VAL
  * It seems  nobody uses the "it  calls rb_throw_obj()" part of  this function.
  * @shyouhei doesn't understand the needs.
  */
-VALUE rb_exec_recursive_outer_mid(VALUE (*f)(VALUE g, VALUE h, int r), VALUE g, VALUE h, ID mid);
+VALUE rb_exec_recursive_outer(VALUE (*f)(VALUE g, VALUE h, int r), VALUE g, VALUE h);
 
 /**
  * Identical to  rb_exec_recursive_outer(), except it checks  for the recursion

--- a/internal/thread.h
+++ b/internal/thread.h
@@ -35,6 +35,7 @@ int rb_thread_to_be_killed(VALUE thread);
 void rb_mutex_allow_trap(VALUE self, int val);
 VALUE rb_uninterruptible(VALUE (*b_proc)(VALUE), VALUE data);
 VALUE rb_mutex_owned_p(VALUE self);
+VALUE rb_exec_recursive_outer_mid(VALUE (*f)(VALUE g, VALUE h, int r), VALUE g, VALUE h, ID mid);
 
 int rb_thread_wait_for_single_fd(int fd, int events, struct timeval * timeout);
 

--- a/thread.c
+++ b/thread.c
@@ -5173,6 +5173,12 @@ rb_exec_recursive_paired(VALUE (*func) (VALUE, VALUE, int), VALUE obj, VALUE pai
  */
 
 VALUE
+rb_exec_recursive_outer(VALUE (*func) (VALUE, VALUE, int), VALUE obj, VALUE arg)
+{
+    return exec_recursive(func, obj, 0, arg, 1, rb_frame_last_func());
+}
+
+VALUE
 rb_exec_recursive_outer_mid(VALUE (*func) (VALUE, VALUE, int), VALUE obj, VALUE arg, ID mid)
 {
     return exec_recursive(func, obj, 0, arg, 1, mid);


### PR DESCRIPTION
Restores the public method previously removed in #6004