### PR TITLE
Added vm_ivar benchmark for initializing an embedded obj

### DIFF
--- a/benchmark/vm_ivar_embedded_obj_init.yml
+++ b/benchmark/vm_ivar_embedded_obj_init.yml
@@ -1,0 +1,12 @@
+prelude: |
+  class C
+    def initialize
+      @a = nil
+      @b = nil
+      @c = nil
+    end
+  end
+benchmark:
+  vm_ivar_embedded_obj_init: |
+    C.new
+loop_count: 30000000

--- a/benchmark/vm_ivar_extended_obj_init.yml
+++ b/benchmark/vm_ivar_extended_obj_init.yml
@@ -9,6 +9,6 @@ prelude: |
     end
   end
 benchmark:
-  vm_ivar_init: |
+  vm_ivar_extended_obj_init: |
     C.new
 loop_count: 30000000


### PR DESCRIPTION
Currently, there is a benchmark for initializing an object which is extended (more than 3 ivars). This PR adds a benchmark for initializing an object which is embedded (3 or fewer ivars).