### PR TITLE
[Bug #18813] Warn when autoload has to lookup in parent namespace

### DIFF
--- a/spec/ruby/core/module/autoload_spec.rb
+++ b/spec/ruby/core/module/autoload_spec.rb
@@ -577,6 +577,36 @@ describe "Module#autoload" do
       end
     end
 
+    ruby_version_is "3.2" do
+      it "warns once in verbose mode if the constant was defined in a parent scope" do
+        ScratchPad.record -> {
+          ModuleSpecs::DeclaredInCurrentDefinedInParent = :declared_in_current_defined_in_parent
+        }
+
+        module ModuleSpecs
+          module Autoload
+            autoload :DeclaredInCurrentDefinedInParent, fixture(__FILE__, "autoload_callback.rb")
+            self.autoload?(:DeclaredInCurrentDefinedInParent).should == fixture(__FILE__, "autoload_callback.rb")
+            const_defined?(:DeclaredInCurrentDefinedInParent).should == true
+
+            -> {
+              DeclaredInCurrentDefinedInParent
+            }.should complain(
+              /Expected .*autoload_callback.rb to define ModuleSpecs::Autoload::DeclaredInCurrentDefinedInParent but it didn't/,
+              verbose: true,
+            )
+
+            -> {
+              DeclaredInCurrentDefinedInParent
+            }.should_not complain(/.*/, verbose: true)
+            self.autoload?(:DeclaredInCurrentDefinedInParent).should == nil
+            const_defined?(:DeclaredInCurrentDefinedInParent).should == false
+            ModuleSpecs.const_defined?(:DeclaredInCurrentDefinedInParent).should == true
+          end
+        end
+      end
+    end
+
     ruby_version_is "3.1" do
       it "looks up in parent scope after failed autoload" do
         @remove << :DeclaredInCurrentDefinedInParent

--- a/variable.c
+++ b/variable.c
@@ -2672,6 +2672,22 @@ autoload_try_load(VALUE _arguments)
         result = Qfalse;
 
         rb_const_remove(arguments->module, arguments->name);
+
+        if (arguments->module == rb_cObject) {
+            rb_warning(
+                "Expected %"PRIsVALUE" to define %"PRIsVALUE" but it didn't",
+                arguments->autoload_data->feature,
+                ID2SYM(arguments->name)
+            );
+        }
+        else {
+            rb_warning(
+                "Expected %"PRIsVALUE" to define %"PRIsVALUE"::%"PRIsVALUE" but it didn't",
+                arguments->autoload_data->feature,
+                arguments->module,
+                ID2SYM(arguments->name)
+            );
+        }
     }
     else {
         // Otherwise, it was loaded, copy the flags from the autoload constant:


### PR DESCRIPTION
Ref: https://bugs.ruby-lang.org/issues/18813#note-5
Closes: https://github.com/ruby/ruby/pull/5949

This is a verbose mode only warning.
