### PR TITLE
.github/workflows/compilers.yml: Skip gaps test on annocheck 10.76.

### DIFF
--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -88,7 +88,8 @@ jobs:
               # https://bugs.ruby-lang.org/issues/18061
               # https://sourceware.org/annobin/annobin.html/Test-pie.html
               # https://sourceware.org/annobin/annobin.html/Test-notes.html
-              TEST_ANNOCHECK_OPTS: "--skip-pie --skip-notes"
+              # https://sourceware.org/annobin/annobin.html/Test-gaps.html
+              TEST_ANNOCHECK_OPTS: "--skip-pie --skip-notes --skip-gaps"
             check: true
           - { key: default_cc, name: clang-15,  value: clang-15,  container: clang-15 }
           - { key: default_cc, name: clang-14,  value: clang-14,  container: clang-14 }


### PR DESCRIPTION
This commit is to skip a failure with annocheck 10.76 on the annocheck test
case on the CI. Previously the test worked with annocheck 10.73.

The issue was reported at <https://bugs.ruby-lang.org/issues/18061#note-24>.
> Hardened: ruby: MAYB: test: gaps because no notes found
> Hardened: ruby: info: For more information visit: https://sourceware.org/annobin/annobin.html/Test-gaps.html

It seems that the annocheck added the gaps test at 10.76. Maybe the upstream commit is below.

https://sourceware.org/annobin/
```
$ git clone git://sourceware.org/git/annobin.git

$ git show 61184ae1180a134bfbbd125e9fe339baedd67c18
commit 61184ae1180a134bfbbd125e9fe339baedd67c18
Author: Nick Clifton <nickc@redhat.com>
Date:   Mon Jun 13 16:56:46 2022 +0100

    Annocheck: Add TEST_GAPS.  Add MAYB for TEST_NOTES if DWARF info could not be found
...
```