### PR TITLE
Try --skip-gaps to prevent an error of annocheck

### DIFF
--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -88,7 +88,8 @@ jobs:
               # https://bugs.ruby-lang.org/issues/18061
               # https://sourceware.org/annobin/annobin.html/Test-pie.html
               # https://sourceware.org/annobin/annobin.html/Test-notes.html
-              TEST_ANNOCHECK_OPTS: "--skip-pie --skip-notes"
+              # https://sourceware.org/annobin/annobin.html/Test-gaps.html
+              TEST_ANNOCHECK_OPTS: "--skip-pie --skip-notes --skip-gaps"
             check: true
           - { key: default_cc, name: clang-15,  value: clang-15,  container: clang-15 }
           - { key: default_cc, name: clang-14,  value: clang-14,  container: clang-14 }


### PR DESCRIPTION
https://github.com/ruby/ruby/runs/6963759639?check_suite_focus=true
```
Hardened: ruby: MAYB: test: gaps because no notes found
Hardened: ruby: info: For more information visit: https://sourceware.org/annobin/annobin.html/Test-gaps.html
...
Hardened: ruby: Overall: FAIL (due to MAYB results).
```

[Bug #18061]