### PR TITLE
.github/workflows/compilers.yml: annocheck: Fix gaps and notes test.

### DIFF
--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -80,16 +80,14 @@ jobs:
           - key: default_cc
             name: 'gcc-11 annocheck'
             # Minimal flags to pass the check.
-            value: 'gcc-11 -O2 -fcf-protection'
+            value: 'gcc-11 -O2 -fcf-protection -Wa,--generate-missing-build-notes=yes'
             container: gcc-11
             env:
               append_configure: 'LDFLAGS=-Wl,-z,now'
               # FIXME: Drop skipping options
               # https://bugs.ruby-lang.org/issues/18061
               # https://sourceware.org/annobin/annobin.html/Test-pie.html
-              # https://sourceware.org/annobin/annobin.html/Test-notes.html
-              # https://sourceware.org/annobin/annobin.html/Test-gaps.html
-              TEST_ANNOCHECK_OPTS: "--skip-pie --skip-notes --skip-gaps"
+              TEST_ANNOCHECK_OPTS: "--skip-pie"
             check: true
           - { key: default_cc, name: clang-15,  value: clang-15,  container: clang-15 }
           - { key: default_cc, name: clang-14,  value: clang-14,  container: clang-14 }


### PR DESCRIPTION
Ths PR fixes https://bugs.ruby-lang.org/issues/18061 .

This commit fixes on the annocheck gaps and notes tests on Ubuntu focal on CI.
Added the gcc `-Wa,--generate-missing-build-notes=yes` flag.

See the links below.
* -Wa,option: <https://gcc.gnu.org/onlinedocs/gcc-11.3.0/gcc/Assembler-Options.html#Assembler-Options>.
* --generate-missing-build-notes=yes: <https://www.man7.org/linux/man-pages/man1/as.1.html>.