### PR TITLE
WIP: thread storage API

### DIFF
--- a/test/-ext-/thread/test_instrumentation_api.rb
+++ b/test/-ext-/thread/test_instrumentation_api.rb
@@ -1,78 +1,110 @@
 # frozen_string_literal: false
-require 'envutil'
 
 class TestThreadInstrumentation < Test::Unit::TestCase
-  def setup
-    pend("TODO: No windows support yet") if /mswin|mingw|bccwin/ =~ RUBY_PLATFORM
+  STARTED = 0
+  READY = 1
+  RESUMED = 2
+  SUSPENDED = 3
+  EXITED = 4
+  FREED = 5
+
+  if /mswin|mingw|bccwin/ =~ RUBY_PLATFORM
+    def setup
+      pend("No windows support")
+    end
+  else
+    def setup
+      require '-test-/thread/instrumentation'
+      Bug::ThreadInstrumentation.reset_counters
+    end
+
+    def teardown
+      Bug::ThreadInstrumentation::unregister_callback
+      Bug::ThreadInstrumentation.reset_counters
+    end
   end
 
   THREADS_COUNT = 3
 
   def test_thread_instrumentation
-    require '-test-/thread/instrumentation'
-    Bug::ThreadInstrumentation.reset_counters
     Bug::ThreadInstrumentation::register_callback
 
-    begin
-      threads = threaded_cpu_work
-      assert_equal [false] * THREADS_COUNT, threads.map(&:status)
-      counters = Bug::ThreadInstrumentation.counters
-      counters.each do |c|
-        assert_predicate c, :nonzero?, "Call counters: #{counters.inspect}"
-      end
+    threads = threaded_cpu_work
+    assert_equal [false] * THREADS_COUNT, threads.map(&:status)
+    counters = Bug::ThreadInstrumentation.counters
 
-      assert_equal THREADS_COUNT, counters.first
-      assert_in_delta THREADS_COUNT, counters.last, 1 # It's possible that a thread didn't execute its EXIT hook yet.
-    ensure
-      Bug::ThreadInstrumentation::unregister_callback
+    counters.each do |c|
+      assert_predicate c, :nonzero?, "Call counters: #{counters.inspect}"
     end
+
+    # It's possible that a joined thread didn't execute its EXIT hook yet.
+    assert_in_delta THREADS_COUNT, counters[EXITED], 1
+    assert_in_delta THREADS_COUNT, counters[FREED], 1
   end
 
   def test_thread_instrumentation_fork_safe
     skip "No fork()" unless Process.respond_to?(:fork)
 
-    require '-test-/thread/instrumentation'
     Bug::ThreadInstrumentation::register_callback
 
     read_pipe, write_pipe = IO.pipe
 
-    begin
-      pid = fork do
-        Bug::ThreadInstrumentation.reset_counters
-        threads = threaded_cpu_work
-        write_pipe.write(Marshal.dump(threads.map(&:status)))
-        write_pipe.write(Marshal.dump(Bug::ThreadInstrumentation.counters))
-        write_pipe.close
-        exit!(0)
-      end
+    pid = fork do
+      Bug::ThreadInstrumentation.reset_counters
+      threads = threaded_cpu_work
+      write_pipe.write(Marshal.dump(threads.map(&:status)))
+      write_pipe.write(Marshal.dump(Bug::ThreadInstrumentation.counters))
       write_pipe.close
-      _, status = Process.wait2(pid)
-      assert_predicate status, :success?
-
-      thread_statuses = Marshal.load(read_pipe)
-      assert_equal [false] * THREADS_COUNT, thread_statuses
-
-      counters = Marshal.load(read_pipe)
-      read_pipe.close
-      counters.each do |c|
-        assert_predicate c, :nonzero?, "Call counters: #{counters.inspect}"
-      end
-
-      assert_equal THREADS_COUNT, counters.first
-      assert_in_delta THREADS_COUNT, counters.last, 1 # It's possible that a thread didn't execute its EXIT hook yet.
-    ensure
-      Bug::ThreadInstrumentation::unregister_callback
+      exit!(0)
     end
+    write_pipe.close
+    _, status = Process.wait2(pid)
+    assert_predicate status, :success?
+
+    thread_statuses = Marshal.load(read_pipe)
+    assert_equal [false] * THREADS_COUNT, thread_statuses
+
+    counters = Marshal.load(read_pipe)
+    read_pipe.close
+
+    counters.each do |c|
+      assert_predicate c, :nonzero?, "Call counters: #{counters.inspect}"
+    end
+
+    assert_equal THREADS_COUNT, counters[STARTED]
+
+    # It's possible that a joined thread didn't execute its EXIT hook yet.
+    assert_in_delta THREADS_COUNT, counters[EXITED], 1
+    assert_in_delta THREADS_COUNT, counters[FREED], 1
   end
 
   def test_thread_instrumentation_unregister
-    require '-test-/thread/instrumentation'
     assert Bug::ThreadInstrumentation::register_and_unregister_callbacks
+  end
+
+  def test_thread_local_counters
+    Bug::ThreadInstrumentation::register_callback
+
+    Thread.new {
+      assert_equal [1, 1, 1, 0, 0], Bug::ThreadInstrumentation.local_counters
+    }.join
   end
 
   private
 
-  def threaded_cpu_work
-    THREADS_COUNT.times.map { Thread.new { 100.times { |i| i + i } } }.each(&:join)
+  def cpu_work
+    fibonacci(20)
+  end
+
+  def fibonacci(number)
+    number <= 1 ? number : fibonacci(number - 1) + fibonacci(number - 2)
+  end
+
+  def spawn_threaded_cpu_work(thread_count = THREADS_COUNT)
+    thread_count.times.map { Thread.new { cpu_work } }
+  end
+
+  def threaded_cpu_work(thread_count = THREADS_COUNT)
+    spawn_threaded_cpu_work.each(&:join)
   end
 end

--- a/thread.c
+++ b/thread.c
@@ -171,7 +171,7 @@ static inline void blocking_region_end(rb_thread_t *th, struct rb_blocking_regio
 #define THREAD_BLOCKING_BEGIN(th) do { \
   struct rb_thread_sched * const sched = TH_SCHED(th); \
   RB_GC_SAVE_MACHINE_CONTEXT(th); \
-  thread_sched_to_waiting(sched);
+  thread_sched_to_waiting(sched, th);
 
 #define THREAD_BLOCKING_END(th) \
   thread_sched_to_running(sched, th); \
@@ -631,6 +631,7 @@ thread_do_start(rb_thread_t *th)
 }
 
 void rb_ec_clear_current_thread_trace_func(const rb_execution_context_t *ec);
+static void rb_internal_thread_store_clear(rb_thread_t *th);
 
 static int
 thread_start_func_2(rb_thread_t *th, VALUE *stack_start)
@@ -646,8 +647,9 @@ thread_start_func_2(rb_thread_t *th, VALUE *stack_start)
     RUBY_DEBUG_LOG("th:%u", rb_th_serial(th));
 
     // setup native thread
-    thread_sched_to_running(TH_SCHED(th), th);
     ruby_thread_set_native(th);
+    RB_INTERNAL_THREAD_HOOK(th, RUBY_INTERNAL_THREAD_EVENT_STARTED);
+    thread_sched_to_running(TH_SCHED(th), th);
 
     RUBY_DEBUG_LOG("got lock. th:%u", rb_th_serial(th));
 
@@ -771,13 +773,16 @@ thread_start_func_2(rb_thread_t *th, VALUE *stack_start)
         // after rb_ractor_living_threads_remove()
         // GC will happen anytime and this ractor can be collected (and destroy GVL).
         // So gvl_release() should be before it.
-        thread_sched_to_dead(TH_SCHED(th));
+        thread_sched_to_dead(TH_SCHED(th), th);
         rb_ractor_living_threads_remove(th->ractor, th);
     }
     else {
         rb_ractor_living_threads_remove(th->ractor, th);
-        thread_sched_to_dead(TH_SCHED(th));
+        thread_sched_to_dead(TH_SCHED(th), th);
     }
+
+    RB_INTERNAL_THREAD_HOOK(th, RUBY_INTERNAL_THREAD_EVENT_EXITED);
+    rb_internal_thread_store_clear(th);
 
     return 0;
 }
@@ -1452,7 +1457,7 @@ blocking_region_begin(rb_thread_t *th, struct rb_blocking_region_buffer *region,
         RUBY_DEBUG_LOG("%s", "");
 
         RB_GC_SAVE_MACHINE_CONTEXT(th);
-	thread_sched_to_waiting(TH_SCHED(th));
+	thread_sched_to_waiting(TH_SCHED(th), th);
 	return TRUE;
     }
     else {

--- a/thread_none.c
+++ b/thread_none.c
@@ -19,6 +19,61 @@
 #define TIME_QUANTUM_USEC (TIME_QUANTUM_MSEC * 1000)
 #define TIME_QUANTUM_NSEC (TIME_QUANTUM_USEC * 1000)
 
+#define RB_INTERNAL_THREAD_HOOK(th, event) // noop
+
+rb_internal_thread_event_hook_t *
+rb_internal_thread_add_event_hook(rb_internal_thread_event_callback callback, rb_event_flag_t internal_event, void *user_data)
+{
+    return NULL; // not implemented
+}
+
+bool
+rb_internal_thread_remove_event_hook(rb_internal_thread_event_hook_t * hook)
+{
+    return false; // not implemented
+}
+
+unsigned int
+rb_internal_thread_store_slots_count(void)
+{
+    return 0; // not implemented
+}
+
+bool
+rb_internal_thread_store_create_key(rb_internal_thread_store_key_t *key, rb_internal_thread_store_destructor func)
+{
+    return false; // not implemented
+}
+
+static void
+rb_internal_thread_store_clear(rb_thread_t *th) {
+     // not implemented
+}
+
+void *
+rb_internal_thread_store_get(const rb_internal_thread_event_data_t *hook_data, rb_internal_thread_store_key_t key)
+{
+    return NULL; // not implemented
+}
+
+bool
+rb_internal_thread_store_set(const rb_internal_thread_event_data_t *hook_data, rb_internal_thread_store_key_t key, void *data)
+{
+    return false;  // not implemented
+}
+
+void *
+rb_internal_thread_store_get_with_gvl(rb_internal_thread_store_key_t key)
+{
+    return NULL; // not implemented
+}
+
+bool
+rb_internal_thread_store_set_with_gvl(rb_internal_thread_store_key_t key, void *data)
+{
+    return false;  // not implemented
+}
+
 // Do nothing for GVL
 static void
 thread_sched_to_running(struct rb_thread_sched *sched, rb_thread_t *th)
@@ -26,7 +81,7 @@ thread_sched_to_running(struct rb_thread_sched *sched, rb_thread_t *th)
 }
 
 static void
-thread_sched_to_waiting(struct rb_thread_sched *sched)
+thread_sched_to_waiting(struct rb_thread_sched *sched, rb_thread_t *th)
 {
 }
 

--- a/thread_none.h
+++ b/thread_none.h
@@ -17,4 +17,6 @@ struct rb_thread_sched {};
 
 RUBY_EXTERN struct rb_execution_context_struct *ruby_current_ec;
 
+unsigned int rb_internal_thread_store_slots_count(void);
+
 #endif /* RUBY_THREAD_NONE_H */

--- a/thread_pthread.h
+++ b/thread_pthread.h
@@ -115,6 +115,8 @@ native_tls_set(native_tls_key_t key, void *ptr)
 }
 #endif
 
+unsigned int rb_internal_thread_store_slots_count(void);
+
 RUBY_SYMBOL_EXPORT_BEGIN
 #ifdef RB_THREAD_LOCAL_SPECIFIER
   #ifdef __APPLE__

--- a/thread_win32.c
+++ b/thread_win32.c
@@ -29,18 +29,59 @@ static volatile DWORD ruby_native_thread_key = TLS_OUT_OF_INDEXES;
 
 static int w32_wait_events(HANDLE *events, int count, DWORD timeout, rb_thread_t *th);
 
+#define RB_INTERNAL_THREAD_HOOK(th, event) // noop
+
 rb_internal_thread_event_hook_t *
 rb_internal_thread_add_event_hook(rb_internal_thread_event_callback callback, rb_event_flag_t internal_event, void *user_data)
 {
-    // not implemented
-    return NULL;
+    return NULL; // not implemented
 }
 
 bool
 rb_internal_thread_remove_event_hook(rb_internal_thread_event_hook_t * hook)
 {
-    // not implemented
-    return false;
+    return false; // not implemented
+}
+
+unsigned int
+rb_internal_thread_store_slots_count(void)
+{
+    return 0; // not implemented
+}
+
+bool
+rb_internal_thread_store_create_key(rb_internal_thread_store_key_t *key, rb_internal_thread_store_destructor func)
+{
+    return false; // not implemented
+}
+
+static void
+rb_internal_thread_store_clear(rb_thread_t *th) {
+     // not implemented
+}
+
+void *
+rb_internal_thread_store_get(const rb_internal_thread_event_data_t *hook_data, rb_internal_thread_store_key_t key)
+{
+    return NULL; // not implemented
+}
+
+bool
+rb_internal_thread_store_set(const rb_internal_thread_event_data_t *hook_data, rb_internal_thread_store_key_t key, void *data)
+{
+    return false;  // not implemented
+}
+
+void *
+rb_internal_thread_store_get_with_gvl(rb_internal_thread_store_key_t key)
+{
+    return NULL; // not implemented
+}
+
+bool
+rb_internal_thread_store_set_with_gvl(rb_internal_thread_store_key_t key, void *data)
+{
+    return false;  // not implemented
 }
 
 RBIMPL_ATTR_NORETURN()
@@ -132,7 +173,7 @@ thread_sched_to_running(struct rb_thread_sched *sched, rb_thread_t *th)
 }
 
 static void
-thread_sched_to_waiting(struct rb_thread_sched *sched)
+thread_sched_to_waiting(struct rb_thread_sched *sched, rb_thread_t *th)
 {
     ReleaseMutex(sched->lock);
 }
@@ -142,7 +183,7 @@ thread_sched_to_waiting(struct rb_thread_sched *sched)
 static void
 thread_sched_yield(struct rb_thread_sched *sched, rb_thread_t *th)
 {
-    thread_sched_to_waiting(sched);
+    thread_sched_to_waiting(sched, th);
     native_thread_yield();
     thread_sched_to_running(sched, th);
 }

--- a/thread_win32.h
+++ b/thread_win32.h
@@ -56,6 +56,8 @@ native_tls_set(native_tls_key_t key, void *ptr)
     }
 }
 
+unsigned int rb_internal_thread_store_slots_count(void);
+
 RUBY_SYMBOL_EXPORT_BEGIN
 RUBY_EXTERN native_tls_key_t ruby_current_ec_key;
 RUBY_SYMBOL_EXPORT_END

--- a/vm.c
+++ b/vm.c
@@ -3170,7 +3170,10 @@ thread_free(void *ptr)
     }
     else {
         ruby_xfree(th->nt); // TODO
-	ruby_xfree(th);
+        if (th->store) {
+            ruby_xfree(th->store);
+        }
+        ruby_xfree(th);
     }
 
     RUBY_FREE_LEAVE("thread");
@@ -3213,7 +3216,11 @@ static VALUE
 thread_alloc(VALUE klass)
 {
     rb_thread_t *th;
-    return TypedData_Make_Struct(klass, rb_thread_t, &thread_data_type, th);
+    VALUE thread = TypedData_Make_Struct(klass, rb_thread_t, &thread_data_type, th);
+    if ((th->store_size = rb_internal_thread_store_slots_count())) {
+        th->store = ZALLOC_N(void *, th->store_size);
+    }
+    return thread;
 }
 
 inline void

--- a/vm_core.h
+++ b/vm_core.h
@@ -1072,6 +1072,8 @@ typedef struct rb_thread_struct {
     VALUE name;
 
     struct rb_ext_config ext_config;
+    unsigned int store_size;
+    void **store;
 } rb_thread_t;
 
 static inline unsigned int


### PR DESCRIPTION
### Context

Something I discussed with @ko1 after experimenting on https://github.com/Shopify/gvltools.

It seems a common need for the thread callbacks to have to store some thread local data. It's doable using `_Thread_local` (or equivalent) however native threads don't map very well with Ruby thread.

Currently MRI has an optimization where when a Ruby thread is dead, rather than to free the native thread, it's kept in cache and re-used for a future Ruby thread. In this scenario the `_Thread_local` are not re-initialized, which makes it an easy mistake to leak state.

There's also some project to implement N:M threads in MRI, if this was to happen, then `_Thread_local` would become entirely unusable.

### Feature

The idea here is to expose an API similar to `pthread_key_create / pthread_getspecific / pthread_setspecific (3)`:

```c
typedef void (*rb_thread_storage_destructor)(void *data);
bool rb_thread_storage_create_key(rb_internal_thread_store_key_t *key, rb_thread_storage_destructor func);
void *rb_internal_thread_store_get(rb_thread_storage_key_t key);
bool rb_internal_thread_store_set(rb_thread_storage_key_t key, void *data);
```

If a destructor is provided, it's called with the data pointer unless the data pointer is `NULL` (inspired from `pthread_key_create`).

The destructor is called after `RUBY_INTERNAL_THREAD_EVENT_EXITED` is fired.