### PR TITLE
WIP EXPERIMENT: Constant caching "superinstruction"

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -2237,7 +2237,7 @@ add_adjust_info(struct iseq_insn_info_entry *insns_info, unsigned int *positions
 
 static ID *array_to_idlist(VALUE arr) {
     RUBY_ASSERT(RB_TYPE_P(arr, T_ARRAY));
-    int size = RARRAY_LEN(arr);
+    long size = RARRAY_LEN(arr);
     ID *ids = (ID *)ALLOC_N(ID, size + 1);
     for (int i = 0; i < size; i++) {
         VALUE sym = RARRAY_AREF(arr, i);
@@ -11208,7 +11208,6 @@ ibf_load_code(const struct ibf_load *load, rb_iseq_t *iseq, ibf_offset_t bytecod
     for (code_index=0; code_index<iseq_size;) {
         /* opcode */
         const VALUE insn = code[code_index] = ibf_load_small_value(load, &reading_pos);
-        const unsigned int insn_index = code_index;
         const char *types = insn_op_types(insn);
         int op_index;
 

--- a/compile.c
+++ b/compile.c
@@ -2435,11 +2435,6 @@ iseq_set_sequence(rb_iseq_t *iseq, LINK_ANCHOR *const anchor)
 			    generated_iseq[code_index + 1 + j] = (VALUE)ic;
                             FL_SET(iseqv, ISEQ_MARKABLE_ISEQ);
 
-                            if (insn == BIN(opt_getinlinecache) && type == TS_IC) {
-                                // Store the instruction index for opt_getinlinecache on the IC for
-                                // YJIT to invalidate code when opt_setinlinecache runs.
-                                ic->get_insn_idx = (unsigned int)code_index;
-                            }
 			    break;
 			}
                         case TS_CALLDATA:
@@ -11271,12 +11266,6 @@ ibf_load_code(const struct ibf_load *load, rb_iseq_t *iseq, ibf_offset_t bytecod
                 {
                     VALUE op = ibf_load_small_value(load, &reading_pos);
                     code[code_index] = (VALUE)&is_entries[op];
-
-                    if (insn == BIN(opt_getinlinecache) && operand_type == TS_IC) {
-                        // Store the instruction index for opt_getinlinecache on the IC for
-                        // YJIT to invalidate code when opt_setinlinecache runs.
-                        is_entries[op].ic_cache.get_insn_idx = insn_index;
-                    }
                 }
                 FL_SET(iseqv, ISEQ_MARKABLE_ISEQ);
                 break;

--- a/insns.def
+++ b/insns.def
@@ -1039,46 +1039,6 @@ branchnil
 /* for optimize                                           */
 /**********************************************************/
 
-/* push inline-cached value and go to dst if it is valid */
-DEFINE_INSN
-opt_getinlinecache
-(OFFSET dst, IC ic)
-()
-(VALUE val)
-{
-    struct iseq_inline_constant_cache_entry *ice = ic->entry;
-
-    // If there isn't an entry, then we're going to walk through the ISEQ
-    // starting at this instruction until we get to the associated
-    // opt_setinlinecache and associate this inline cache with every getconstant
-    // listed in between. We're doing this here instead of when the instructions
-    // are first compiled because it's possible to turn off inline caches and we
-    // want this to work in either case.
-    if (!ice) {
-        vm_ic_compile(GET_CFP(), ic);
-    }
-
-    if (ice && vm_ic_hit_p(ice, GET_EP())) {
-        val = ice->value;
-        JUMP(dst);
-    }
-    else {
-        ruby_vm_constant_cache_misses++;
-        val = Qnil;
-    }
-}
-
-/* set inline cache */
-DEFINE_INSN
-opt_setinlinecache
-(IC ic)
-(VALUE val)
-(VALUE val)
-// attr bool leaf = false;
-{
-    vm_ic_update(GET_ISEQ(), ic, val, GET_EP());
-}
-
 /* run iseq only once */
 DEFINE_INSN
 once

--- a/insns.def
+++ b/insns.def
@@ -253,6 +253,25 @@ setclassvariable
     vm_setclassvariable(GET_ISEQ(), GET_CFP(), id,  val, ic);
 }
 
+DEFINE_INSN
+opt_getconst
+(IDLIST segments, IC ic)
+()
+(VALUE val)
+// attr bool leaf = false; /* may autoload */
+{
+    struct iseq_inline_constant_cache_entry *ice = ic->entry;
+    if (ice && vm_ic_hit_p(ice, GET_EP())) {
+        val = ice->value;
+
+        VM_ASSERT(val == vm_get_ev_const_chain(ec, segments));
+    } else {
+        val = vm_get_ev_const_chain(ec, segments);
+	vm_ic_track_const_chain(GET_CFP(), ic, segments);
+        vm_ic_update(GET_ISEQ(), ic, val, GET_EP());
+    }
+}
+
 /* Get constant variable id. If klass is Qnil and allow_nil is Qtrue, constants
    are searched in the current scope. Otherwise, get constant under klass
    class or module.

--- a/iseq.c
+++ b/iseq.c
@@ -133,20 +133,6 @@ iseq_clear_ic_references_i(VALUE *code, VALUE insn, size_t index, void *data)
     struct iseq_clear_ic_references_data *ic_data = (struct iseq_clear_ic_references_data *) data;
 
     switch (insn) {
-      case BIN(opt_getinlinecache): {
-        RUBY_ASSERT_ALWAYS(ic_data->ic == NULL);
-
-        ic_data->ic = (IC) code[index + 2];
-        return true;
-      }
-      case BIN(getconstant): {
-        if (ic_data->ic != NULL) {
-            ID id = (ID) code[index + 1];
-            remove_from_constant_cache(id, (st_data_t)ic_data->ic);
-        }
-
-        return true;
-      }
       case BIN(opt_getconst): {
         IDLIST segments = (IDLIST)code[index + 1];
         st_data_t ic = code[index + 2];
@@ -155,12 +141,6 @@ iseq_clear_ic_references_i(VALUE *code, VALUE insn, size_t index, void *data)
             if (id == idNULL) continue;
             remove_from_constant_cache(id, ic);
         }
-        return true;
-      }
-      case BIN(opt_setinlinecache): {
-        RUBY_ASSERT_ALWAYS(ic_data->ic != NULL);
-
-        ic_data->ic = NULL;
         return true;
       }
       default:

--- a/iseq.c
+++ b/iseq.c
@@ -2140,6 +2140,16 @@ rb_insn_operand_intern(const rb_iseq_t *iseq,
 	ret = rb_inspect(ID2SYM(op));
 	break;
 
+      case TS_IDLIST:		/* IDLIST */
+        {
+            IDLIST ids = (IDLIST)op;
+            ret = rb_str_new2(rb_id2name(ids[0]));
+            for (int i = 1; ids[i]; i++) {
+                rb_str_catf(ret, "::%s", rb_id2name(ids[i]));
+            }
+            break;
+        }
+
       case TS_VALUE:		/* VALUE */
 	op = obj_resurrect(op);
 	if (insn == BIN(defined) && op_no == 1 && FIXNUM_P(op)) {
@@ -3051,6 +3061,17 @@ iseq_data_to_ary(const rb_iseq_t *iseq)
 		break;
 	      case TS_ID:
 		rb_ary_push(ary, ID2SYM(*seq));
+		break;
+	      case TS_IDLIST:
+                {
+                    VALUE list = rb_ary_new();
+                    IDLIST ids = (IDLIST)*seq;
+                    for (int i = 0; ids[i]; i++) {
+                        rb_ary_push(list, ID2SYM(ids[i]));
+                    }
+                    rb_ary_push(ary, list);
+                    break;
+                }
 		break;
 	      case TS_CDHASH:
 		{

--- a/tool/ruby_vm/models/typemap.rb
+++ b/tool/ruby_vm/models/typemap.rb
@@ -18,6 +18,7 @@ RubyVM::Typemap = {
   "IVC"            => %w[A TS_IVC],
   "ICVARC"         => %w[J TS_ICVARC],
   "ID"             => %w[I TS_ID],
+  "IDLIST"         => %w[D TS_IDLIST],
   "ISE"            => %w[T TS_ISE],
   "ISEQ"           => %w[S TS_ISEQ],
   "OFFSET"         => %w[O TS_OFFSET],

--- a/vm_core.h
+++ b/vm_core.h
@@ -1205,6 +1205,7 @@ typedef const struct rb_callcache *CALL_CACHE;
 typedef struct rb_call_data *CALL_DATA;
 
 typedef VALUE CDHASH;
+typedef ID *IDLIST;
 
 #ifndef FUNC_FASTCALL
 #define FUNC_FASTCALL(x) x


### PR DESCRIPTION
This is an experiment to explore some ideas that have been discussed surrounding YARV's constant caching. The implementation here is not complete and this is not (yet) a proposal to be merged into Ruby.

I'm interested in feedback on the overall idea, not this implementation (which would be changed before submitting to the bug tracker). Does this idea seem worth pursuing?

## Idea

In the current Ruby we implement constant caching by wrapping a series of `getconstant` calls with `opt_getinlinecache`/`opt_setinlinecache`.

```
$ ruby --dump=insns -e 'Foo::Bar::Baz'
== disasm: #<ISeq:<main>@-e:1 (1,0)-(1,13)> (catch: FALSE)
0000 opt_getinlinecache                     17, <is:0>                (   1)[Li]
0003 putobject                              true
0005 getconstant                            :Foo
0007 putobject                              false
0009 getconstant                            :Bar
0011 putobject                              false
0013 getconstant                            :Baz
0015 opt_setinlinecache                     <is:0>
0017 leave
```

In many ways this is quite elegant, as it's a small change to the generated bytecode, but has some disadvantages in terms of making the bytecode larger and making other optimizations on constant caches more complex.

An alternative could be a combined instruction performing both the inline caching, and fetching the entire chain of constants.

```
$ ./miniruby --dump=insns -e 'Foo::Bar::Baz'
== disasm: #<ISeq:<main>@-e:1 (1,0)-(1,13)> (catch: FALSE)
0000 opt_getconst                           Foo::Bar::Baz, <is:0>     (   1)[Li]
0003 leave
```

## Immediate advantages

This reduces the size of the bytecode significantly. Previously it spanned 128 bytes, now only 24 bytes. The new approach would also need to store the ids separately, however that's still a significant savings (48 bytes vs 128 bytes). Moving this storage out of the compiled iseq should also slightly improve interpreter performance by reducing CPU cache usage, as when the cache is warm the IDs don't need to be accessed.

With the introduction of [fine-grained constant invalidation](https://bugs.ruby-lang.org/issues/18589), when a constant is first cached we need to disassemble the iseq following `opt_getinlinecache` to discover what constant names we are caching and tracks them in the global table for invalidation. In my view this is an implicit decision that the `getconstant`/`{get,set}inlinecache` are conceptually a single operation that we just represent in a series of instructions. The same operation is required when garbage collecting an iseq to remove the IC from the invalidation from the global table.

This approach would simplify the fine grained constant invalidation, by removing the need for disassembling the iseq. I don't think the performance gains would be too significant (we should only be invalidating constants rarely), but it would be simpler and would simplify other places we want to do similar work.

## Immediate tradeoffs

The proposed `opt_getconst` can't be a "leaf" instruction, since it may cause autoloading or an exception. However, since `opt_getinlinecache` is a "jump" instruction, that's about the same (both have to save PC). I expect there to be no significant performance difference on a warm cache between the two approaches.

This would change the bytecode (when optimizations are enabled) which may require updating some tools.

## Potential future improvements

Most of these possible improvements could also be done by disassembling the iseq and "emulating" the `getconstant` instructions, but it's a lot cleaner, simpler, and more likely to be implemented with the approach proposed here.

### YJIT handling of "cold" inline constant caches

This was the original motivation for investigating this.

YJIT mostly doesn't use the inline caches that the interpreter uses, instead using the authoritative data (ie. it uses method lookups, not the inline method cache). However that isn't the case for constants, where YJIT needs the interpreter to "warm" the inline constant cache before it will compile the instruction.

The current implementation means that YJIT often generates side exits, only to be taken and immediately invalidated as the inline cache is filled. We've hoped that this isn't too substantial an issue, as we hope that constant invalidation is rare, and that the caches will be warm from the method being run before the threshold, but it's not ideal (and it makes testing with `--yjit-call-threshold=1` not always work correctly).

This new approach would solve that issue by making it possible for YJIT to encounter a `getconst` bytecode and call the interpreter method which fills that constant (may need some extra precautions around autoloading, exceptions, and const_missing but something should be viable here). This should remove the need to rely on the caches being filled, and we should be more consistent and faster.

This current implementation also leads to some consistently odd behaviour when the constant fetch is the first instruction of the iseq. For example here we can see an unrelated constant invalidation permanently de-optimize a method (thanks to "fine-grained constant invalidation" this only happens because the name partly matches, previously any constant invalidation would have caused this behaviour)

``` ruby
class Foo
  class Bar
    Baz = 123
  end
end

def bench
  10_000_000.times { Foo::Bar::Baz+1+1+1+1+1+1+1+1+1+1+1+1 }
end

require "benchmark"
p Benchmark.realtime { bench }
Baz = 123
p Benchmark.realtime { bench }
```

``` ruby
$ ruby --yjit test.rb
0.2620004729833454
0.665440459968522
```

### Even more granular constant invalidation

As it would be easier to know the chain of constants any IC cache is responsible for. When invalidating it we could . (There are some tradeoffs here in that the checks could be more expensive if we're invalidating many times in a row before ever using the constant. Would need to be investigated.)

This should also help YJIT, as we can avoid invalidating generated code.

### Improved handling of "fully qualified" constant "cref-dependent" caches
In the following example:

``` ruby
Bar = 123
module Foo
  def self.test1
    Bar
  end

  class << self
    def test2
      Bar
    end

    def test3
      ::Bar
    end
  end
end
```

`test1` is faster than both `test2` and `test3`. The latter two methods store the cref in the IC and check it against the current cref on each invocation. I believe we should never have to do that for "fully qualified" constants, and should be able to skip that check. (I think there are other improvements that could be made here, as in this specific example the crefs will never change)


### Eager loading constants caches

A feature that could be nice, especially for pre-forking CoW web servers, would be to eagerly fill in constant caches, so that they have valid entries before the code is first run. If possible 😅, this change should make it easier to do.