### PR TITLE
Speed ISeq marking by using a bitmap and rearranging inline caches

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -2333,7 +2333,7 @@ iseq_set_sequence(rb_iseq_t *iseq, LINK_ANCHOR *const anchor)
 
     // Calculate the bitmask buffer size.
     // Round the generated_iseq size up to the nearest multiple
-    // of the number if bits in an unsigned long.
+    // of the number of bits in an unsigned long.
 
     // Allocate enough room for the bitmask list
     iseq_bits_t * mark_offset_bits = ZALLOC_N(iseq_bits_t, ISEQ_MBITS_BUFLEN(code_index));

--- a/iseq.h
+++ b/iseq.h
@@ -17,6 +17,12 @@ RUBY_EXTERN const int ruby_api_version[];
 #define ISEQ_MAJOR_VERSION ((unsigned int)ruby_api_version[0])
 #define ISEQ_MINOR_VERSION ((unsigned int)ruby_api_version[1])
 
+#define ISEQ_MBITS_SIZE sizeof(iseq_bits_t)
+#define ISEQ_MBITS_BITLENGTH (ISEQ_MBITS_SIZE * CHAR_BIT)
+#define ISEQ_MBITS_SET(buf, i) (buf[(i) / ISEQ_MBITS_BITLENGTH] |= ((iseq_bits_t)1 << ((i) % ISEQ_MBITS_BITLENGTH)))
+#define ISEQ_MBITS_SET_P(buf, i) ((buf[(i) / ISEQ_MBITS_BITLENGTH] >> ((i) % ISEQ_MBITS_BITLENGTH)) & 0x1)
+#define ISEQ_MBITS_BUFLEN(size) (((size + (ISEQ_MBITS_BITLENGTH - 1)) & -ISEQ_MBITS_BITLENGTH) / ISEQ_MBITS_BITLENGTH)
+
 #ifndef USE_ISEQ_NODE_ID
 #define USE_ISEQ_NODE_ID 1
 #endif

--- a/mjit_compile.c
+++ b/mjit_compile.c
@@ -327,7 +327,7 @@ mjit_capture_is_entries(const struct rb_iseq_constant_body *body, union iseq_inl
 {
     if (is_entries == NULL)
         return;
-    memcpy(is_entries, body->is_entries, sizeof(union iseq_inline_storage_entry) * body->is_size);
+    memcpy(is_entries, body->is_entries, sizeof(union iseq_inline_storage_entry) * ISEQ_IS_SIZE(body));
 }
 
 static bool
@@ -492,8 +492,8 @@ init_ivar_compile_status(const struct rb_iseq_constant_body *body, struct compil
         .stack_size_for_pos = (int *)alloca(sizeof(int) * body->iseq_size), \
         .inlined_iseqs = compile_root_p ? \
             alloca(sizeof(const struct rb_iseq_constant_body *) * body->iseq_size) : NULL, \
-        .is_entries = (body->is_size > 0) ? \
-            alloca(sizeof(union iseq_inline_storage_entry) * body->is_size) : NULL, \
+        .is_entries = (ISEQ_IS_SIZE(body) > 0) ? \
+            alloca(sizeof(union iseq_inline_storage_entry) * ISEQ_IS_SIZE(body)) : NULL, \
         .cc_entries_index = (body->ci_size > 0) ? \
             mjit_capture_cc_entries(status.compiled_iseq, body) : -1, \
         .compiled_id = status.compiled_id, \

--- a/vm_core.h
+++ b/vm_core.h
@@ -460,7 +460,7 @@ struct rb_iseq_constant_body {
     } variable;
 
     unsigned int local_table_size;
-    unsigned int ic_size;  // Number if IC caches
+    unsigned int ic_size;  // Number of IC caches
     unsigned int ise_size; // Number of ISE caches
     unsigned int ivc_size; // Number of IVC and ICVARC caches
     unsigned int ci_size;


### PR DESCRIPTION
A large percentage of major GC time is spent marking instruction sequence objects.  This PR aims to speed up major GC by speeding up marking instruction sequence objects.

## Marking ISeq objects

Today we have to disassemble instruction sequences in order to mark them.  The disassembly process looks for GC allocated objects and marks them.  To disassemble an iseq, we have to iterate over each instruction, convert the instruction from an address back to the original op code integer, then look up the parameters for the op code.  Once we know the parameter types, we can iterate though them and mark "interesting" references.  We can see this process in [the `iseq_extract_values` function](https://github.com/ruby/ruby/blob/744d17ff6c33b09334508e8110007ea2a82252f5/iseq.c#L247-L313).

According to profile results, the biggest bottleneck in this function is converting addresses back to instruction ids.

## Speeding up ISeq marking

To speed up ISeq marking, this PR introduces two changes.  The first change is adding a bitmap, and the second change is rearranging inline caches to be more "convenient".

## Bitmaps

At compilation time, we allocate a bitmap along side of the iseq object.  The bitmap indicates offsets of VALUE objects inside the instruction sequences.  When marking an instruction, we can simply iterate over the bitmap to find VALUE objects that need to be marked.

## Inline Cache Rearrangement

Inline cache types `IC`, `IVC`, `ICVARC`, and `ISE` are allocated from [a buffer that is stored on the iseq constant body](https://github.com/ruby/ruby/blob/744d17ff6c33b09334508e8110007ea2a82252f5/vm_core.h#L447).  These caches are a union type.  Unfortunately, these union types don't have a "type" field, so they can only be distinguished by looking at the parameter types of an instruction.

Take the following Ruby code for example:

```
Foo =~ /#{foo}/o;
```

The instruction sequences for this code are as follows:

```
== disasm: #<ISeq:<main>@-e:1 (1,0)-(1,17)> (catch: FALSE)
0000 opt_getinlinecache                     9, <is:0>                 (   1)[Li]
0003 putobject                              true
0005 getconstant                            :Foo
0007 opt_setinlinecache                     <is:0>
0009 once                                   block in <main>, <is:1>
0012 opt_regexpmatch2                       <calldata!mid:=~, argc:1, ARGS_SIMPLE>[CcCr]
0014 leave
```

The ISeq object contains two entries in the `is_entries` buffer, one for the `ISE` cache associated with the `once` instruction, and one for the `IC` cache associated with the `opt_getinlinecache` and `opt_setinlinecache` instructions.

Unfortunately we cannot iterate through the caches in the `is_entries` list because the union types don't have the same layout.  [Marking an `ISE`](https://github.com/ruby/ruby/blob/744d17ff6c33b09334508e8110007ea2a82252f5/iseq.c#L296-L306) is very different than [marking an `IC`](https://github.com/ruby/ruby/blob/744d17ff6c33b09334508e8110007ea2a82252f5/iseq.c#L270-L280), and we can only differentiate them by disassembling and checking the instruction sequences themselves.

To solve this problem, this PR introduces [3 counters for the different types of inline caches](https://github.com/ruby/ruby/compare/master...tenderlove:iseq-bitmap?expand=1#diff-2989766b46aac389cc58ca9c83fac2bb85c03f3a3d37b176b4be673c9d56e0e4R463-R465).  Then, we group inline cache types within the `is_entries` buffer.
Since the inline cache types are grouped, we can use the counters to iterate over the buffer and we know what type is being used.

Combining bitmap marking and inline cache arrangement means that we can mark instruction sequences without disassembling the instructions.

## Speed impact

I benchmarked this change with a basic Rails application using the following script:

```ruby
puts RUBY_DESCRIPTION

require "benchmark/ips"

Benchmark.ips do |x|
  x.report("major GC") { GC.start }
end
```

Here are the results with the master version of Ruby:

```
$ RAILS_ENV=production gel exec bin/rails r test.rb
ruby 3.2.0dev (2022-06-22T12:30:39Z master 744d17ff6c) [arm64-darwin21]
Warming up --------------------------------------
            major GC     4.000  i/100ms
Calculating -------------------------------------
            major GC     47.748  (± 2.1%) i/s -    240.000  in   5.028520s
```

Here it is with these patches applied:

```
$ RAILS_ENV=production gel exec bin/rails r test.rb
ruby 3.2.0dev (2022-06-22T20:52:13Z iseq-bitmap 2ba736a7f9) [arm64-darwin21]
Warming up --------------------------------------
            major GC     7.000  i/100ms
Calculating -------------------------------------
            major GC     77.208  (± 1.3%) i/s -    392.000  in   5.079023s
```

With these patches applied, major GC is about 60% faster.

## Memory impact

The memory increase is proportional to the number of instructions stored on an iseq.  This works about to be about 1% increase in the size of an iseq (`ceil(iseq_length / 64)` on 64 bit platforms).

## Future work

This PR always mallocs a bitmap table.  We can eliminate the malloc when:

1. There is nothing to mark
2. iseq_length is <= 64

We may also want to consider using a `succ_index_table` for storing the bitmap

Redmine issue is [here](https://bugs.ruby-lang.org/issues/18875)