### PR TITLE
Fix pending bundler specs

### DIFF
--- a/spec/bundler/commands/clean_spec.rb
+++ b/spec/bundler/commands/clean_spec.rb
@@ -792,7 +792,7 @@ RSpec.describe "bundle clean" do
     should_not_have_gems "foo-1.0"
   end
 
-  it "doesn't remove extensions artifacts from bundled git gems after clean", :ruby_repo do
+  it "doesn't remove extensions artifacts from bundled git gems after clean" do
     build_git "very_simple_git_binary", &:add_c_extension
 
     revision = revision_for(lib_path("very_simple_git_binary-1.0"))
@@ -815,7 +815,7 @@ RSpec.describe "bundle clean" do
     expect(vendored_gems("bundler/gems/very_simple_git_binary-1.0-#{revision[0..11]}")).to exist
   end
 
-  it "removes extension directories", :ruby_repo do
+  it "removes extension directories" do
     gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
 
@@ -851,7 +851,7 @@ RSpec.describe "bundle clean" do
     expect(simple_binary_extensions_dir).to exist
   end
 
-  it "removes git extension directories", :ruby_repo do
+  it "removes git extension directories" do
     build_git "very_simple_git_binary", &:add_c_extension
 
     revision = revision_for(lib_path("very_simple_git_binary-1.0"))

--- a/spec/bundler/commands/pristine_spec.rb
+++ b/spec/bundler/commands/pristine_spec.rb
@@ -2,7 +2,7 @@
 
 require "bundler/vendored_fileutils"
 
-RSpec.describe "bundle pristine", :ruby_repo do
+RSpec.describe "bundle pristine" do
   before :each do
     build_lib "baz", :path => bundled_app do |s|
       s.version = "1.0.0"

--- a/spec/bundler/install/gemfile/git_spec.rb
+++ b/spec/bundler/install/gemfile/git_spec.rb
@@ -1206,11 +1206,12 @@ RSpec.describe "bundle install with git sources" do
       expect(out).to include(Pathname.glob(default_bundle_path("bundler/gems/extensions/**/foo-1.0-*")).first.to_s)
     end
 
-    it "does not use old extension after ref changes", :ruby_repo do
+    it "does not use old extension after ref changes" do
       git_reader = build_git "foo", :no_default => true do |s|
         s.extensions = ["ext/extconf.rb"]
         s.write "ext/extconf.rb", <<-RUBY
           require "mkmf"
+          $extout = "$(topdir)/" + RbConfig::CONFIG["EXTOUT"] unless RUBY_VERSION < "2.4"
           create_makefile("foo")
         RUBY
         s.write "ext/foo.c", "void Init_foo() {}"

--- a/spec/bundler/install/gems/native_extensions_spec.rb
+++ b/spec/bundler/install/gems/native_extensions_spec.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
-RSpec.describe "installing a gem with native extensions", :ruby_repo do
+RSpec.describe "installing a gem with native extensions" do
   it "installs" do
     build_repo2 do
       build_gem "c_extension" do |s|
         s.extensions = ["ext/extconf.rb"]
         s.write "ext/extconf.rb", <<-E
           require "mkmf"
+          $extout = "$(topdir)/" + RbConfig::CONFIG["EXTOUT"] unless RUBY_VERSION < "2.4"
           name = "c_extension_bundle"
           dir_config(name)
           raise "OMG" unless with_config("c_extension") == "hello"
@@ -51,6 +52,7 @@ RSpec.describe "installing a gem with native extensions", :ruby_repo do
       s.extensions = ["ext/extconf.rb"]
       s.write "ext/extconf.rb", <<-E
         require "mkmf"
+        $extout = "$(topdir)/" + RbConfig::CONFIG["EXTOUT"] unless RUBY_VERSION < "2.4"
         name = "c_extension_bundle"
         dir_config(name)
         raise "OMG" unless with_config("c_extension") == "hello"
@@ -95,6 +97,7 @@ RSpec.describe "installing a gem with native extensions", :ruby_repo do
           s.extensions = ["ext/extconf.rb"]
           s.write "ext/extconf.rb", <<-E
             require "mkmf"
+            $extout = "$(topdir)/" + RbConfig::CONFIG["EXTOUT"] unless RUBY_VERSION < "2.4"
             name = "c_extension_bundle_#{n}"
             dir_config(name)
             raise "OMG" unless with_config("c_extension_#{n}") == "#{n}"
@@ -147,6 +150,7 @@ RSpec.describe "installing a gem with native extensions", :ruby_repo do
       s.extensions = ["ext/extconf.rb"]
       s.write "ext/extconf.rb", <<-E
         require "mkmf"
+        $extout = "$(topdir)/" + RbConfig::CONFIG["EXTOUT"] unless RUBY_VERSION < "2.4"
         name = "c_extension_bundle"
         dir_config(name)
         raise "OMG" unless with_config("c_extension") == "hello" && with_config("c_extension_bundle-dir") == "hola"

--- a/spec/bundler/install/gems/standalone_spec.rb
+++ b/spec/bundler/install/gems/standalone_spec.rb
@@ -205,7 +205,7 @@ RSpec.shared_examples "bundle install --standalone" do
     end
   end
 
-  describe "with gems with native extension", :ruby_repo do
+  describe "with gems with native extension" do
     before do
       bundle "config set --local path #{bundled_app("bundle")}"
       install_gemfile <<-G, :standalone => true, :dir => cwd

--- a/spec/bundler/install/global_cache_spec.rb
+++ b/spec/bundler/install/global_cache_spec.rb
@@ -205,7 +205,7 @@ RSpec.describe "global gem caching" do
   end
 
   describe "extension caching" do
-    it "works", :ruby_repo do
+    it "works" do
       skip "gets incorrect ref in path" if Gem.win_platform?
 
       build_git "very_simple_git_binary", &:add_c_extension

--- a/spec/bundler/install/path_spec.rb
+++ b/spec/bundler/install/path_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe "bundle install" do
       expect(the_bundle).to include_gems "rack 1.0.0"
     end
 
-    it "re-installs gems whose extensions have been deleted", :ruby_repo do
+    it "re-installs gems whose extensions have been deleted" do
       build_lib "very_simple_binary", "1.0.0", :to_system => true do |s|
         s.write "lib/very_simple_binary.rb", "raise 'FAIL'"
       end

--- a/spec/bundler/runtime/setup_spec.rb
+++ b/spec/bundler/runtime/setup_spec.rb
@@ -801,7 +801,7 @@ end
     expect(out).to eq("yay")
   end
 
-  it "should clean $LOAD_PATH properly", :ruby_repo do
+  it "should clean $LOAD_PATH properly" do
     gem_name = "very_simple_binary"
     full_gem_name = gem_name + "-1.0"
     ext_dir = File.join(tmp("extensions", full_gem_name))

--- a/spec/bundler/support/builders.rb
+++ b/spec/bundler/support/builders.rb
@@ -444,8 +444,7 @@ module Spec
         write "ext/extconf.rb", <<-RUBY
           require "mkmf"
 
-
-          # exit 1 unless with_config("simple")
+          $extout = "$(topdir)/" + RbConfig::CONFIG["EXTOUT"] unless RUBY_VERSION < "2.4"
 
           extension_name = "#{name}_c"
           if extra_lib_dir = with_config("ext-lib")


### PR DESCRIPTION
Fix several pending Bundler specs.

When testing under the ruby/ruby setup, mkmf.rb needs the `$extout` global variable to be set properly.

This is because, in this particular case, the `ruby.h` header needed to compile extensions is constructed from `$(extout)/include/$(arch)/ruby/config.h` but `$extout` is not set by default.

I tried to fix this in mkmf.rb itself but I couldn't figure it out. But setting it externally to workaround the issue fixes the specs, so I'll start with that. Setting it externally though causes issues when running specs upstream against Ruby 2.3 (I guess because of some difference with Ruby 2.3 mkmf.rb implementation). So I'm avoiding doing it on Ruby 2.3 to workaround that.