### PR TITLE
Fix typo otherBasis -> orthoBasis

### DIFF
--- a/benchmark/app_aobench.rb
+++ b/benchmark/app_aobench.rb
@@ -151,7 +151,7 @@ def clamp(f)
   i.to_i
 end
 
-def otherBasis(basis, n)
+def orthoBasis(basis, n)
   basis[2] = Vec.new(n.x, n.y, n.z)
   basis[1] = Vec.new(0.0, 0.0, 0.0)
 
@@ -183,7 +183,7 @@ class Scene
 
   def ambient_occlusion(isect)
     basis = Array.new
-    otherBasis(basis, isect.n)
+    orthoBasis(basis, isect.n)
 
     ntheta    = NAO_SAMPLES
     nphi      = NAO_SAMPLES


### PR DESCRIPTION
This function is generating orthonormal basis (https://en.wikipedia.org/wiki/Orthonormal_basis), and the function name in the original aobench code ao.c was also orthoBasis (https://github.com/syoyo/aobench/blob/master/ao.c#L131).
Therefore, I think the function name should be fixed from "otherBasis" to "orthoBasis".