### PR TITLE
Memory usage improvements to ISeq bitmaps

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -2340,6 +2340,7 @@ iseq_set_sequence(rb_iseq_t *iseq, LINK_ANCHOR *const anchor)
     int code_size = code_index;
 
     iseq_bits_t tmp[1] = {0};
+    bool needs_bitmap = false;
 
     if (ISEQ_MBITS_BUFLEN(code_index) == 1) {
         mark_offset_bits = tmp;
@@ -2397,6 +2398,7 @@ iseq_set_sequence(rb_iseq_t *iseq, LINK_ANCHOR *const anchor)
                             ISEQ_MBITS_SET(mark_offset_bits, code_index + 1 + j);
 			    RB_OBJ_WRITTEN(iseq, Qundef, map);
                             FL_SET(iseqv, ISEQ_MARKABLE_ISEQ);
+                            needs_bitmap = true;
 			    break;
 			}
 		      case TS_LINDEX:
@@ -2413,6 +2415,7 @@ iseq_set_sequence(rb_iseq_t *iseq, LINK_ANCHOR *const anchor)
 				RB_OBJ_WRITTEN(iseq, Qundef, v);
                                 ISEQ_MBITS_SET(mark_offset_bits, code_index + 1 + j);
                                 FL_SET(iseqv, ISEQ_MARKABLE_ISEQ);
+                                needs_bitmap = true;
 			    }
 			    break;
 			}
@@ -2542,7 +2545,13 @@ iseq_set_sequence(rb_iseq_t *iseq, LINK_ANCHOR *const anchor)
         body->mark_bits.single = mark_offset_bits[0];
     }
     else {
-        body->mark_bits.list = mark_offset_bits;
+        if (needs_bitmap) {
+            body->mark_bits.list = mark_offset_bits;
+        }
+        else {
+            body->mark_bits.list = 0;
+            ruby_xfree(mark_offset_bits);
+        }
     }
 
     /* get rid of memory leak when REALLOC failed */
@@ -11217,6 +11226,7 @@ ibf_load_code(const struct ibf_load *load, rb_iseq_t *iseq, ibf_offset_t bytecod
     else {
         mark_offset_bits = ZALLOC_N(iseq_bits_t, ISEQ_MBITS_BUFLEN(iseq_size));
     }
+    bool needs_bitmap = false;
 
     unsigned int min_ic_index, min_ise_index, min_ivc_index;
     min_ic_index = min_ise_index = min_ivc_index = UINT_MAX;
@@ -11243,6 +11253,7 @@ ibf_load_code(const struct ibf_load *load, rb_iseq_t *iseq, ibf_offset_t bytecod
                         RB_OBJ_WRITTEN(iseqv, Qundef, v);
                         ISEQ_MBITS_SET(mark_offset_bits, code_index);
                         FL_SET(iseqv, ISEQ_MARKABLE_ISEQ);
+                        needs_bitmap = true;
                     }
                     break;
                 }
@@ -11264,6 +11275,7 @@ ibf_load_code(const struct ibf_load *load, rb_iseq_t *iseq, ibf_offset_t bytecod
                     ISEQ_MBITS_SET(mark_offset_bits, code_index);
                     RB_OBJ_WRITTEN(iseqv, Qundef, v);
                     FL_SET(iseqv, ISEQ_MARKABLE_ISEQ);
+                    needs_bitmap = true;
                     break;
                 }
               case TS_ISEQ:
@@ -11275,6 +11287,7 @@ ibf_load_code(const struct ibf_load *load, rb_iseq_t *iseq, ibf_offset_t bytecod
                         RB_OBJ_WRITTEN(iseqv, Qundef, v);
                         ISEQ_MBITS_SET(mark_offset_bits, code_index);
                         FL_SET(iseqv, ISEQ_MARKABLE_ISEQ);
+                        needs_bitmap = true;
                     }
                     break;
                 }
@@ -11359,7 +11372,13 @@ ibf_load_code(const struct ibf_load *load, rb_iseq_t *iseq, ibf_offset_t bytecod
         load_body->mark_bits.single = mark_offset_bits[0];
     }
     else {
-        load_body->mark_bits.list = mark_offset_bits;
+        if (needs_bitmap) {
+            load_body->mark_bits.list = mark_offset_bits;
+        }
+        else {
+            load_body->mark_bits.list = 0;
+            ruby_xfree(mark_offset_bits);
+        }
     }
 
     assert(code_index == iseq_size);

--- a/iseq.c
+++ b/iseq.c
@@ -193,7 +193,7 @@ rb_iseq_free(const rb_iseq_t *iseq)
 	}
 	ruby_xfree((void *)body->catch_table);
 	ruby_xfree((void *)body->param.opt_table);
-        if (ISEQ_MBITS_BUFLEN(body->iseq_size) > 1) {
+        if (ISEQ_MBITS_BUFLEN(body->iseq_size) > 1 && body->mark_bits.list) {
             ruby_xfree((void *)body->mark_bits.list);
         }
 
@@ -388,9 +388,11 @@ rb_iseq_each_value(const rb_iseq_t *iseq, iseq_value_itr_t * func, void *data)
         iseq_scan_bits(0, body->mark_bits.single, code, func, data);
     }
     else {
-        for (unsigned int i = 0; i < ISEQ_MBITS_BUFLEN(size); i++) {
-            iseq_bits_t bits = body->mark_bits.list[i];
-            iseq_scan_bits(i, bits, code, func, data);
+        if (body->mark_bits.list) {
+            for (unsigned int i = 0; i < ISEQ_MBITS_BUFLEN(size); i++) {
+                iseq_bits_t bits = body->mark_bits.list[i];
+                iseq_scan_bits(i, bits, code, func, data);
+            }
         }
     }
 }

--- a/vm_core.h
+++ b/vm_core.h
@@ -465,7 +465,10 @@ struct rb_iseq_constant_body {
     unsigned int ivc_size; // Number of IVC and ICVARC caches
     unsigned int ci_size;
     unsigned int stack_max; /* for stack overflow check */
-    iseq_bits_t * mark_offset_bits; /* Find references for GC */
+    union {
+        iseq_bits_t * list; /* Find references for GC */
+        iseq_bits_t single;
+    } mark_bits;
 
     char catch_except_p; /* If a frame of this ISeq may catch exception, set TRUE */
     // If true, this ISeq is leaf *and* backtraces are not used, for example,


### PR DESCRIPTION
Two improvements:

1. If the iseqs are short enough, then use a single integer for the bitmap so we don't allocate a buffer
2. If the iseqs don't contain any values that need marking, immediately free the bitmap buffer (if it had been allocated)