### PR TITLE
[Bug #18884] `class` cannot be just followed by modifiers

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -9235,7 +9235,7 @@ parse_ident(struct parser_params *p, int c, int cmd_state)
 		    return keyword_do_block;
 		return keyword_do;
 	    }
-	    if (IS_lex_state_for(state, (EXPR_BEG | EXPR_LABELED)))
+	    if (IS_lex_state_for(state, (EXPR_BEG | EXPR_LABELED | EXPR_CLASS)))
 		return kw->id[0];
 	    else {
 		if (kw->id[0] != kw->id[1])

--- a/test/ruby/test_parse.rb
+++ b/test/ruby/test_parse.rb
@@ -1359,6 +1359,13 @@ x = __ENCODING__
     end;
   end
 
+  def test_if_after_class
+    assert_valid_syntax('module if true; Object end::Kernel; end')
+    assert_valid_syntax('module while true; break Object end::Kernel; end')
+    assert_valid_syntax('class if true; Object end::Kernel; end')
+    assert_valid_syntax('class while true; break Object end::Kernel; end')
+  end
+
 =begin
   def test_past_scope_variable
     assert_warning(/past scope/) {catch {|tag| eval("BEGIN{throw tag}; tap {a = 1}; a")}}


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/18884
https://twitter.com/qnighy/status/1540909277061074944