### PR TITLE
Add a check-yjit-bindgen-unused target. Add to CI.

### DIFF
--- a/yjit/bindgen/Cargo.lock
+++ b/yjit/bindgen/Cargo.lock
@@ -342,4 +342,5 @@ name = "yjit-bindgen"
 version = "0.1.0"
 dependencies = [
  "bindgen",
+ "env_logger",
 ]

--- a/yjit/bindgen/Cargo.toml
+++ b/yjit/bindgen/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 
 [dependencies]
 bindgen = "0.59.2"
+env_logger = "0.9.0"

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -27,6 +27,9 @@ fn main() {
         SRC_ROOT_ENV
     );
 
+    // We want Bindgen warnings printed to console
+    env_logger::init();
+
     // Remove this flag so rust-bindgen generates bindings
     // that are internal functions not public in libruby
     let filtered_clang_args = env::args().filter(|arg| arg != "-fvisibility=hidden");
@@ -145,8 +148,7 @@ fn main() {
         .allowlist_var("rb_mKernel")
 
         // From vm_callinfo.h
-        .allowlist_type("VM_CALL.*")         // This doesn't work, possibly due to the odd structure of the #defines
-        .allowlist_type("vm_call_flag_bits") // So instead we include the other enum and do the bit-shift ourselves.
+        .allowlist_type("vm_call_flag_bits")
         .allowlist_type("rb_call_data")
         .blocklist_type("rb_callcache.*")      // Not used yet - opaque to make it easy to import rb_call_data
         .opaque_type("rb_callcache.*")

--- a/yjit/yjit.mk
+++ b/yjit/yjit.mk
@@ -46,11 +46,14 @@ miniruby$(EXEEXT): $(YJIT_LIBS)
 # Generate Rust bindings. See source for details.
 # Needs `./configure --enable-yjit=dev` and Clang.
 ifneq ($(strip $(CARGO)),) # if configure found Cargo
-.PHONY: yjit-bindgen
+.PHONY: yjit-bindgen yjit-bindgen-show-unused
 yjit-bindgen: yjit.$(OBJEXT)
 	YJIT_SRC_ROOT_PATH='$(top_srcdir)' $(CARGO) run --manifest-path '$(top_srcdir)/yjit/bindgen/Cargo.toml' -- $(CFLAGS) $(XCFLAGS) $(CPPFLAGS)
 
+check-yjit-bindgen-unused: yjit.$(OBJEXT)
+	RUST_LOG=warn YJIT_SRC_ROOT_PATH='$(top_srcdir)' $(CARGO) run --manifest-path '$(top_srcdir)/yjit/bindgen/Cargo.toml' -- $(CFLAGS) $(XCFLAGS) $(CPPFLAGS) 2>&1 | (! grep "unused option: --allow")
+
 # For CI, check whether YJIT's FFI bindings are up-to-date.
-check-yjit-bindings: yjit-bindgen
+check-yjit-bindings: check-yjit-bindgen-unused
 	git -C "$(top_srcdir)" diff --exit-code yjit/src/cruby_bindings.inc.rs
 endif


### PR DESCRIPTION
This fails if there are any unused rust-bindgen "allow" entries. For
that target we turn on Rust warnings (there are a lot) and grep for the
ones that correspond to unused allow entries.

I've added check-yjit-bindgen-unused as a dependency of
check-yjit-bindings, so unused allow entries will now fail CI.

This change also removes our single unused allow entry (VM_CALL.*) which
was known to be bad.