### PR TITLE
Improve man page docs around --dump options

### DIFF
--- a/man/ruby.1
+++ b/man/ruby.1
@@ -423,35 +423,37 @@ Dump some information.
 .Pp
 Prints the specified target.
 .Ar target
-can be one of;
+can be one of:
 .Bl -hang -offset indent
 .It Sy version
-version description same as
-.Fl -version
+Print version description (same as
+.Fl -version).
 .It Sy usage
-brief usage message same as
-.Fl h
+Print a brief usage message (same as
+.Fl h).
 .It Sy help
-Show long help message same as
-.Fl -help
+Show long help message (same as
+.Fl -help).
 .It Sy syntax
-check of syntax same as
+Check syntax (same as
 .Fl c
-.Fl -yydebug
+.Fl -yydebug).
+.Pp
+.El
+.Pp
+Or one of the following, which are intended for debugging the interpreter:
+.Bl -hang -offset indent -tag -width "parsetree_with_comment"
 .It Sy yydebug
-compiler debug mode, same as
-.Fl -yydebug
-.Pp
-Only specify this switch if you are going to debug the Ruby interpreter.
+Enable compiler debug mode (same as
+.Fl -yydebug).
 .It Sy parsetree
+Print a textual representation of the Ruby AST for the program.
 .It Sy parsetree_with_comment
-AST nodes tree
-.Pp
-Only specify this switch if you are going to debug the Ruby interpreter.
+Print a textual representation of the Ruby AST for the program, but with each node annoted with the associated Ruby source code.
 .It Sy insns
-disassembled instructions
-.Pp
-Only specify this switch if you are going to debug the Ruby interpreter.
+Print a list of disassembled bytecode instructions.
+.It Sy insns_without_opt
+Print the list of disassembled bytecode instructions before various optimizations have been applied.
 .El
 .Pp
 .It Fl -verbose


### PR DESCRIPTION
When reading the man page for `ruby` I noticed that the `--dump` targets `parsetree`, `parsetree_with_comments` and `insns` had very little explanation and that `insns_without_opt` was missing entirely. So I've added a little more documentation to clarify what these options do.

This change affects the output displayed by `man ruby`

**Before**:
```
     --dump=target  Dump some informations.

                    Prints the specified target.  target can be one of;

                          version version description same as --version

                          usage   brief usage message same as -h

                          help    Show long help message same as --help

                          syntax  check of syntax same as -c --yydebug

                          yydebug compiler debug mode, same as --yydebug

                                  Only specify this switch if you are going to debug the Ruby interpreter.

                          parsetree

                          parsetree_with_comment AST nodes tree

                                  Only specify this switch if you are going to debug the Ruby interpreter.

                          insns   disassembled instructions

                                  Only specify this switch if you are going to debug the Ruby interpreter.
```

**After**:

```
      --dump=target  Dump some information.

                    Prints the specified target.  target can be one of:

                          version Print version description (same as --version)

                          usage   Print a brief usage message (same as -h)

                          help    Show long help message (same as --help)

                          syntax  Check syntax (same as -c --yydebug)

                    Or one of the following, which are intended for debugging the interpreter:

                          yydebug                 Enable compiler debug mode (same as --yydebug)

                          parsetree               Print a textual representation of the Ruby AST for the program

                          parsetree_with_comment  Print a textual representation of the Ruby AST for the program, but with each node annoted with the
                                                  associated Ruby source code.

                          insns                   Print a list of disassembled bytecode instructions.

                          insns_without_opt       Print the list of disassembled bytecode instructions before various optimizations have been applied.
```