### PR TITLE
Fix ISeq dump / load in array cases

### DIFF
--- a/iseq.c
+++ b/iseq.c
@@ -2943,6 +2943,26 @@ iseq_type_id(enum iseq_type type)
     rb_bug("unsupported iseq type: %d", (int)type);
 }
 
+union iseq_inline_storage_entry *
+ISEQ_IS_ENTRY_START(const struct rb_iseq_constant_body *body, char op_type)
+{
+    unsigned int relative_ic_offset = 0;
+
+    switch(op_type) {
+      case TS_IC:
+          relative_ic_offset += body->ise_size;
+      case TS_ISE:
+          relative_ic_offset += body->ivc_size;
+      case TS_IVC:
+      case TS_ICVARC:
+          break;
+      default:
+          rb_bug("Wrong op type");
+    }
+
+    return &body->is_entries[relative_ic_offset];
+}
+
 static VALUE
 iseq_data_to_ary(const rb_iseq_t *iseq)
 {
@@ -3048,7 +3068,9 @@ iseq_data_to_ary(const rb_iseq_t *iseq)
 
         rb_ary_push(ary, ID2SYM(insn_syms[insn%numberof(insn_syms)]));
 	for (j=0; j<len-1; j++, seq++) {
-	    switch (insn_op_type(insn, j)) {
+	    enum ruby_insn_type_chars op_type = insn_op_type(insn, j);
+
+	    switch (op_type) {
 	      case TS_OFFSET: {
 		unsigned long idx = nseq - iseq_original + *seq;
 		rb_ary_push(ary, register_label(labels_table, idx));
@@ -3079,7 +3101,7 @@ iseq_data_to_ary(const rb_iseq_t *iseq)
 	      case TS_ISE:
 		{
 		    union iseq_inline_storage_entry *is = (union iseq_inline_storage_entry *)*seq;
-		    rb_ary_push(ary, INT2FIX(is - iseq_body->is_entries));
+		    rb_ary_push(ary, INT2FIX(is - ISEQ_IS_ENTRY_START(ISEQ_BODY(iseq), op_type)));
 		}
 		break;
               case TS_CALLDATA:

--- a/iseq.c
+++ b/iseq.c
@@ -2943,26 +2943,6 @@ iseq_type_id(enum iseq_type type)
     rb_bug("unsupported iseq type: %d", (int)type);
 }
 
-union iseq_inline_storage_entry *
-ISEQ_IS_ENTRY_START(const struct rb_iseq_constant_body *body, char op_type)
-{
-    unsigned int relative_ic_offset = 0;
-
-    switch(op_type) {
-      case TS_IC:
-          relative_ic_offset += body->ise_size;
-      case TS_ISE:
-          relative_ic_offset += body->ivc_size;
-      case TS_IVC:
-      case TS_ICVARC:
-          break;
-      default:
-          rb_bug("Wrong op type");
-    }
-
-    return &body->is_entries[relative_ic_offset];
-}
-
 static VALUE
 iseq_data_to_ary(const rb_iseq_t *iseq)
 {

--- a/iseq.h
+++ b/iseq.h
@@ -169,7 +169,6 @@ void rb_iseq_init_trace(rb_iseq_t *iseq);
 int rb_iseq_add_local_tracepoint_recursively(const rb_iseq_t *iseq, rb_event_flag_t turnon_events, VALUE tpval, unsigned int target_line, bool target_bmethod);
 int rb_iseq_remove_local_tracepoint_recursively(const rb_iseq_t *iseq, VALUE tpval);
 const rb_iseq_t *rb_iseq_load_iseq(VALUE fname);
-union iseq_inline_storage_entry *ISEQ_IS_ENTRY_START(const struct rb_iseq_constant_body *body, char op_type);
 
 #if VM_INSN_INFO_TABLE_IMPL == 2
 unsigned int *rb_iseq_insns_info_decode_positions(const struct rb_iseq_constant_body *body);

--- a/iseq.h
+++ b/iseq.h
@@ -169,6 +169,7 @@ void rb_iseq_init_trace(rb_iseq_t *iseq);
 int rb_iseq_add_local_tracepoint_recursively(const rb_iseq_t *iseq, rb_event_flag_t turnon_events, VALUE tpval, unsigned int target_line, bool target_bmethod);
 int rb_iseq_remove_local_tracepoint_recursively(const rb_iseq_t *iseq, VALUE tpval);
 const rb_iseq_t *rb_iseq_load_iseq(VALUE fname);
+union iseq_inline_storage_entry *ISEQ_IS_ENTRY_START(const struct rb_iseq_constant_body *body, char op_type);
 
 #if VM_INSN_INFO_TABLE_IMPL == 2
 unsigned int *rb_iseq_insns_info_decode_positions(const struct rb_iseq_constant_body *body);

--- a/tool/ruby_vm/views/_insn_type_chars.erb
+++ b/tool/ruby_vm/views/_insn_type_chars.erb
@@ -11,3 +11,19 @@ enum ruby_insn_type_chars {
     <%= t %> = '<%= c %>',
 % end
 };
+
+static inline union iseq_inline_storage_entry * ISEQ_IS_ENTRY_START(const struct rb_iseq_constant_body *body, char op_type) {
+    unsigned int relative_ic_offset = 0;
+    switch(op_type) {
+      case TS_IC:
+          relative_ic_offset += body->ise_size;
+      case TS_ISE:
+          relative_ic_offset += body->ivc_size;
+      case TS_IVC:
+      case TS_ICVARC:
+          break;
+      default:
+          rb_bug("Wrong op type");
+    }
+    return &body->is_entries[relative_ic_offset];
+}


### PR DESCRIPTION
We need to dump relative offsets for inline storage entries so that
loading iseqs as an array works as well.  This commit also has some
minor refactoring to make computing relative ISE information easier.

This should fix the iseq dump / load as array tests we're seeing fail in
CI.

Co-Authored-By: John Hawthorn <john@hawthorn.email>