### PR TITLE
Optimize `String#<<` 

### DIFF
--- a/benchmark/string_buffer_append.yml
+++ b/benchmark/string_buffer_append.yml
@@ -1,0 +1,35 @@
+prelude: |
+  CHUNK = "a" * 64
+  raise "Expected encoding to be UTF-8, got: #{CHUNK.encoding}" unless CHUNK.encoding == Encoding::UTF_8
+  BCHUNK = "a".b * 64
+benchmark:
+  binary_buffer_mixed_append: |
+    buffer = String.new(capacity: 4096, encoding: Encoding::BINARY)
+    buffer << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK
+    buffer << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK
+    buffer << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK
+    buffer << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK
+    buffer << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK
+    buffer << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK
+    buffer << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK
+    buffer << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK
+  binary_buffer_append: |
+    buffer = String.new(capacity: 4096, encoding: Encoding::BINARY)
+    buffer << BCHUNK << BCHUNK << BCHUNK << BCHUNK << BCHUNK << BCHUNK << BCHUNK << BCHUNK
+    buffer << BCHUNK << BCHUNK << BCHUNK << BCHUNK << BCHUNK << BCHUNK << BCHUNK << BCHUNK
+    buffer << BCHUNK << BCHUNK << BCHUNK << BCHUNK << BCHUNK << BCHUNK << BCHUNK << BCHUNK
+    buffer << BCHUNK << BCHUNK << BCHUNK << BCHUNK << BCHUNK << BCHUNK << BCHUNK << BCHUNK
+    buffer << BCHUNK << BCHUNK << BCHUNK << BCHUNK << BCHUNK << BCHUNK << BCHUNK << BCHUNK
+    buffer << BCHUNK << BCHUNK << BCHUNK << BCHUNK << BCHUNK << BCHUNK << BCHUNK << BCHUNK
+    buffer << BCHUNK << BCHUNK << BCHUNK << BCHUNK << BCHUNK << BCHUNK << BCHUNK << BCHUNK
+    buffer << BCHUNK << BCHUNK << BCHUNK << BCHUNK << BCHUNK << BCHUNK << BCHUNK << BCHUNK
+  utf8_buffer_append: |
+    buffer = String.new(capacity: 4096, encoding: Encoding::UTF_8)
+    buffer << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK
+    buffer << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK
+    buffer << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK
+    buffer << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK
+    buffer << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK
+    buffer << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK
+    buffer << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK
+    buffer << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK

--- a/common.mk
+++ b/common.mk
@@ -1272,7 +1272,7 @@ OPTS =
 # See benchmark/README.md for details.
 benchmark: miniruby$(EXEEXT) update-benchmark-driver PHONY
 	$(BASERUBY) -rrubygems -I$(srcdir)/benchmark/lib $(srcdir)/benchmark/benchmark-driver/exe/benchmark-driver \
-	            --executables="compare-ruby::$(COMPARE_RUBY) -I$(EXTOUT)/common --disable-gem" \
+	            --executables="compare-ruby::$(COMPARE_RUBY) -I$(EXTOUT)/common -I$(EXTOUT)/$(arch) -Ilib --disable-gem" \
 	            --executables="built-ruby::$(BENCH_RUBY) --disable-gem" \
 	            $(BENCH_OPTS) $(ARGS) $(OPTS)
 

--- a/enc/depend
+++ b/enc/depend
@@ -1007,6 +1007,7 @@ enc/emacs_mule.$(OBJEXT): onigmo.h
 enc/emacs_mule.$(OBJEXT): st.h
 enc/emacs_mule.$(OBJEXT): subst.h
 enc/encdb.$(OBJEXT): $(hdrdir)/ruby/ruby.h
+enc/encdb.$(OBJEXT): $(top_srcdir)/encindex.h
 enc/encdb.$(OBJEXT): $(top_srcdir)/internal/encoding.h
 enc/encdb.$(OBJEXT): assert.h
 enc/encdb.$(OBJEXT): backward.h

--- a/encoding.c
+++ b/encoding.c
@@ -952,29 +952,6 @@ rb_id_encoding(void)
     return id_encoding;
 }
 
-static int
-enc_get_index_str(VALUE str)
-{
-    int i = ENCODING_GET_INLINED(str);
-    if (i == ENCODING_INLINE_MAX) {
-	VALUE iv;
-
-#if 0
-	iv = rb_ivar_get(str, rb_id_encoding());
-	i = NUM2INT(iv);
-#else
-        /*
-         * Tentatively, assume ASCII-8BIT, if encoding index instance
-         * variable is not found.  This can happen when freeing after
-         * all instance variables are removed in `obj_free`.
-         */
-        iv = rb_attr_get(str, rb_id_encoding());
-        i = NIL_P(iv) ? ENCINDEX_ASCII : NUM2INT(iv);
-#endif
-    }
-    return i;
-}
-
 int
 rb_enc_get_index(VALUE obj)
 {

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -5378,18 +5378,20 @@ static VALUE
 vm_opt_ltlt(VALUE recv, VALUE obj)
 {
     if (SPECIAL_CONST_P(recv)) {
-	return Qundef;
+        return Qundef;
     }
-    else if (RBASIC_CLASS(recv) == rb_cString &&
-	     BASIC_OP_UNREDEFINED_P(BOP_LTLT, STRING_REDEFINED_OP_FLAG)) {
-	return rb_str_concat(recv, obj);
+    else if (RBASIC_CLASS(recv) == rb_cString && BASIC_OP_UNREDEFINED_P(BOP_LTLT, STRING_REDEFINED_OP_FLAG)) {
+        if (LIKELY(!SPECIAL_CONST_P(obj) && RBASIC_CLASS(obj) == rb_cString)) {
+            return rb_str_buf_append(recv, obj);
+        } else {
+            return rb_str_concat(recv, obj);
+        }
     }
-    else if (RBASIC_CLASS(recv) == rb_cArray &&
-	     BASIC_OP_UNREDEFINED_P(BOP_LTLT, ARRAY_REDEFINED_OP_FLAG)) {
-	return rb_ary_push(recv, obj);
+    else if (RBASIC_CLASS(recv) == rb_cArray && BASIC_OP_UNREDEFINED_P(BOP_LTLT, ARRAY_REDEFINED_OP_FLAG)) {
+        return rb_ary_push(recv, obj);
     }
     else {
-	return Qundef;
+        return Qundef;
     }
 }
 


### PR DESCRIPTION
It is common for network clients to use binary strings as buffer.
However it is somehow sligthly slower than UTF-8 strings which makes
no sense as in theory, less work is required.

Benchmark:

```
|                            |compare-ruby|built-ruby|
|:---------------------------|-----------:|---------:|
|binary_buffer_mixed_append  |    354.176k|  622.517k|
|                            |           -|     1.76x|
|binary_buffer_append        |    387.443k|  623.491k|
|                            |           -|     1.61x|
|utf8_buffer_append          |    391.916k|  409.689k|
|                            |           -|     1.05x|
```

Improvements:

  - `vm_opt_ltlt`: call `rb_str_buf_append` if the right hand side is also a String.
  - `rb_str_buf_append` if the left hand side is binary and the right hand side
     ASCII-compatible we skip coderange checks.
  - `str_buf_cat` speedup extracting the encoding.