### PR TITLE
Repalce to `NIL_P` macro

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -13612,7 +13612,7 @@ ripper_validate_object(VALUE self, VALUE x)
 {
     if (x == Qfalse) return x;
     if (x == Qtrue) return x;
-    if (x == Qnil) return x;
+    if (NIL_P(x)) return x;
     if (x == Qundef)
 	rb_raise(rb_eArgError, "Qundef given");
     if (FIXNUM_P(x)) return x;

--- a/variable.c
+++ b/variable.c
@@ -2605,7 +2605,7 @@ autoload_load_needed(VALUE _arguments)
         return Qfalse;
     }
 
-    if (autoload_data->mutex == Qnil) {
+    if (NIL_P(autoload_data->mutex)) {
         autoload_data->mutex = rb_mutex_new();
         autoload_data->fork_gen = GET_VM()->fork_gen;
     }

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -4841,7 +4841,7 @@ vm_objtostring(const rb_iseq_t *iseq, VALUE recv, CALL_DATA cd)
             // going to use this string for interpolation, it's fine to use the
             // frozen string.
             VALUE val = rb_mod_name(recv);
-            if (val == Qnil) {
+            if (NIL_P(val)) {
                 val = rb_mod_to_s(recv);
             }
             return val;


### PR DESCRIPTION
MRI has code that using these check `Qnil`.

```c
if (x == Qnil) return x;
```

But, I thought better to use `NIL_P` macro that more short.
