### PR TITLE
YJIT: Never enable yjit feature bit if YJIT isn't built

### DIFF
--- a/ruby.c
+++ b/ruby.c
@@ -199,13 +199,15 @@ cmdline_options_init(ruby_cmdline_options_t *opt)
     opt->features.set = DEFAULT_FEATURES;
 #ifdef MJIT_FORCE_ENABLE /* to use with: ./configure cppflags="-DMJIT_FORCE_ENABLE" */
     opt->features.set |= FEATURE_BIT(mjit);
-#elif defined(YJIT_FORCE_ENABLE)
+#elif YJIT_BUILD && defined(YJIT_FORCE_ENABLE)
     opt->features.set |= FEATURE_BIT(yjit);
 #endif
 
+#if YJIT_BUILD
     if (getenv("RUBY_YJIT_ENABLE")) {
         opt->features.set |= FEATURE_BIT(yjit);
     }
+#endif
 
     return opt;
 }


### PR DESCRIPTION
Previously we would always set the YJIT feature, even without YJIT_BUILD, when -DYJIT_FORCE_ENABLE was specified or the RUBY_YJIT_ENABLE var was set.

That's kind of a silly thing to do, of course. But we have a failing build related to it: http://ci.rvm.jp/results/trunk-yjit@phosphorus-docker/4069842

I think the right answer is *both* to turn off that build and to do something more sensible when we specify those settings.

CC: @XrXr @maximecb 