### PR TITLE
YJIT: Handle 0 total_exits YJIT Status Display

### DIFF
--- a/yjit.rb
+++ b/yjit.rb
@@ -233,19 +233,23 @@ module RubyVM::YJIT
       exits = exits.sort_by { |name, count| -count }[0...how_many]
       total_exits = total_exit_count(stats)
 
-      top_n_total = exits.map { |name, count| count }.sum
-      top_n_exit_pct = 100.0 * top_n_total / total_exits
+      if total_exits > 0
+        top_n_total = exits.map { |name, count| count }.sum
+        top_n_exit_pct = 100.0 * top_n_total / total_exits
 
-      $stderr.puts "Top-#{how_many} most frequent exit ops (#{"%.1f" % top_n_exit_pct}% of exits):"
+        $stderr.puts "Top-#{how_many} most frequent exit ops (#{"%.1f" % top_n_exit_pct}% of exits):"
 
-      longest_insn_name_len = exits.map { |name, count| name.length }.max
-      exits.each do |name, count|
-        padding = longest_insn_name_len + left_pad
-        padded_name = "%#{padding}s" % name
-        padded_count = "%10d" % count
-        percent = 100.0 * count / total_exits
-        formatted_percent = "%.1f" % percent
-        $stderr.puts("#{padded_name}: #{padded_count} (#{formatted_percent}%)" )
+        longest_insn_name_len = exits.map { |name, count| name.length }.max
+        exits.each do |name, count|
+          padding = longest_insn_name_len + left_pad
+          padded_name = "%#{padding}s" % name
+          padded_count = "%10d" % count
+          percent = 100.0 * count / total_exits
+          formatted_percent = "%.1f" % percent
+          $stderr.puts("#{padded_name}: #{padded_count} (#{formatted_percent}%)" )
+        end
+      else
+        $stderr.puts "total_exits:           " + ("%10d" % total_exits)
       end
     end
 


### PR DESCRIPTION
Currently if there are 0 `total_exits` the YJIT stats display we see a lot of NaN's in the output due to dividing by 0 in the display code:

Before Example:
```
yjit_insns_count:            4955
ratio_in_yjit:              91.1%
avg_len_in_yjit:              5.0
Top-20 most frequent exit ops (NaN% of exits):
    trace_putobject_INT2FIX_1_:          0 (NaN%)
                           nop:          0 (NaN%)
                      getlocal:          0 (NaN%)
                      setlocal:          0 (NaN%)
                 getblockparam:          0 (NaN%)
                 setblockparam:          0 (NaN%)
...
```

This change gets rid of the "Top-20 most frequent exit ops..." line and replaces it with a `total_exit` count line

After Example:
```
yjit_insns_count:            3964
ratio_in_yjit:              89.1%
avg_len_in_yjit:              4.0
total_exits:                    0
```