### PR TITLE
use latest debug.gem

### DIFF
--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -13,4 +13,4 @@ matrix 0.4.2 https://github.com/ruby/matrix
 prime 0.1.2 https://github.com/ruby/prime
 rbs 2.5.1 https://github.com/ruby/rbs
 typeprof 0.21.2 https://github.com/ruby/typeprof 8577943c042145af4c87914fa323c0a854da2e6d
-debug 1.5.0 https://github.com/ruby/debug 1fce2583d1e71419998507898ba5f7eea815133f
+debug 1.5.0 https://github.com/ruby/debug 5053a795864a1e14863bd912fc5818754105d64c


### PR DESCRIPTION
If `XDG_RUNTIME_DIR` is available, test-bundled-gems fails with old debug.gem tests.