### PR TITLE
Specify RBS commit hash to fix test failure on test-bundled-gems

### DIFF
--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -11,6 +11,6 @@ net-pop 0.1.1 https://github.com/ruby/net-pop
 net-smtp 0.3.1 https://github.com/ruby/net-smtp
 matrix 0.4.2 https://github.com/ruby/matrix
 prime 0.1.2 https://github.com/ruby/prime
-rbs 2.5.1 https://github.com/ruby/rbs
+rbs 2.6.0 https://github.com/ruby/rbs 14abbbae8885a09a2ed82de2ef31d67a9c0a108d
 typeprof 0.21.2 https://github.com/ruby/typeprof 8577943c042145af4c87914fa323c0a854da2e6d
 debug 1.5.0 https://github.com/ruby/debug 5053a795864a1e14863bd912fc5818754105d64c


### PR DESCRIPTION
It introduces https://github.com/ruby/rbs/pull/1051 and update RBS to v2.6.0

@soutaro If it is ok to update RBS to v2.6.0, could you approve this PR?