### PR TITLE
YJIT: add a counter for gc object refs in the machine code

### DIFF
--- a/yjit.rb
+++ b/yjit.rb
@@ -211,6 +211,7 @@ module RubyVM::YJIT
       $stderr.puts "constant_state_bumps:  " + ("%10d" % stats[:constant_state_bumps])
       $stderr.puts "inline_code_size:      " + ("%10d" % stats[:inline_code_size])
       $stderr.puts "outlined_code_size:    " + ("%10d" % stats[:outlined_code_size])
+      $stderr.puts "num_gc_obj_refs:       " + ("%10d" % stats[:num_gc_obj_refs])
 
       $stderr.puts "total_exit_count:      " + ("%10d" % total_exits)
       $stderr.puts "total_insns_count:     " + ("%10d" % total_insns_count)

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -121,6 +121,8 @@ impl JITState {
     pub fn add_gc_object_offset(self: &mut JITState, ptr_offset: u32) {
         let mut gc_obj_vec: RefMut<_> = self.block.borrow_mut();
         gc_obj_vec.add_gc_object_offset(ptr_offset);
+
+        incr_counter!(num_gc_obj_refs);
     }
 
     pub fn get_pc(self: &JITState) -> *mut VALUE {

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -218,6 +218,14 @@ make_counters! {
 
     opt_getinlinecache_miss,
 
+    expandarray_splat,
+    expandarray_postarg,
+    expandarray_not_array,
+    expandarray_rhs_too_small,
+
+    gbpp_block_param_modified,
+    gbpp_block_handler_not_iseq,
+
     binding_allocations,
     binding_set,
 
@@ -237,17 +245,11 @@ make_counters! {
 
     constant_state_bumps,
 
-    expandarray_splat,
-    expandarray_postarg,
-    expandarray_not_array,
-    expandarray_rhs_too_small,
-
-    gbpp_block_param_modified,
-    gbpp_block_handler_not_iseq,
-
     // Currently, it's out of the ordinary (might be impossible) for YJIT to leave gaps in
     // executable memory, so this should be 0.
     exec_mem_non_bump_alloc,
+
+    num_gc_obj_refs,
 }
 
 //===========================================================================


### PR DESCRIPTION
This is to gather data for the eventual implementation of a constant pool.