### PR TITLE
[wasm] get rid of workaround use of older binaryen and update to latest

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -34,8 +34,7 @@ jobs:
       GITPULLOPTIONS: --no-tags origin ${{github.ref}}
       WASI_SDK_VERSION_MAJOR: 14
       WASI_SDK_VERSION_MINOR: 0
-      # Use older version, which uses glibc instead of musl, to avoid https://github.com/WebAssembly/binaryen/issues/4401
-      BINARYEN_VERSION: 91
+      BINARYEN_VERSION: 109
       WASMTIME_VERSION: v0.33.0
     runs-on: ubuntu-20.04
     if: ${{ !contains(github.event.head_commit.message, '[DOC]') && !contains(github.event.pull_request.labels.*.name, 'Documentation') }}
@@ -67,10 +66,10 @@ jobs:
           wget -O - "$wasmtime_url" | tar xJf -
           sudo ln -fs "$PWD/wasmtime-${WASMTIME_VERSION}-x86_64-linux/wasmtime" /usr/local/bin/wasmtime
 
-          binaryen_tarball="binaryen-version_${BINARYEN_VERSION}-x86-linux.tar.gz"
+          binaryen_tarball="binaryen-version_${BINARYEN_VERSION}-x86_64-linux.tar.gz"
           binaryen_url="https://github.com/WebAssembly/binaryen/releases/download/version_${BINARYEN_VERSION}/${binaryen_tarball}"
           wget -O - "$binaryen_url" | tar xfz -
-          sudo ln -fs "$PWD/binaryen-version_${BINARYEN_VERSION}/wasm-opt" /usr/local/bin/wasm-opt
+          sudo ln -fs "$PWD/binaryen-version_${BINARYEN_VERSION}/bin/wasm-opt" /usr/local/bin/wasm-opt
         working-directory: src
       - name: Set ENV
         run: |

--- a/wasm/README.md
+++ b/wasm/README.md
@@ -7,8 +7,7 @@
 - Ruby (the same version as the building target version) (baseruby)
 - GNU make
 - [WASI SDK](https://github.com/WebAssembly/wasi-sdk) 14.0 or later
-- [Binaryen](https://github.com/WebAssembly/binaryen) **version 91**
-  - See also: https://github.com/WebAssembly/binaryen/issues/4401
+- [Binaryen](https://github.com/WebAssembly/binaryen) version 106 or later
 - Linux or macOS build machine
 
 ### Steps


### PR DESCRIPTION
We no longer need to use older version of binaryen since the blocker
issue has been resolved https://github.com/WebAssembly/binaryen/issues/4401