### PR TITLE
[Bug #18898] Fallback invalid external encoding to the default

### DIFF
--- a/io.c
+++ b/io.c
@@ -2914,6 +2914,8 @@ io_enc_str(VALUE str, rb_io_t *fptr)
     return str;
 }
 
+static rb_encoding *io_read_encoding(rb_io_t *fptr);
+
 static void
 make_readconv(rb_io_t *fptr, int size)
 {
@@ -2925,7 +2927,7 @@ make_readconv(rb_io_t *fptr, int size)
         ecopts = fptr->encs.ecopts;
         if (fptr->encs.enc2) {
             sname = rb_enc_name(fptr->encs.enc2);
-            dname = rb_enc_name(fptr->encs.enc);
+            dname = rb_enc_name(io_read_encoding(fptr));
         }
         else {
             sname = dname = "";

--- a/test/ruby/test_io_m17n.rb
+++ b/test/ruby/test_io_m17n.rb
@@ -1142,8 +1142,14 @@ EOT
     IO.pipe do |r, w|
       assert_nothing_raised(bug5567) do
         assert_warning(/Unsupported/, bug5567) {r.set_encoding("fffffffffffxx")}
+        w.puts("foo")
+        assert_equal("foo\n", r.gets)
         assert_warning(/Unsupported/, bug5567) {r.set_encoding("fffffffffffxx", "us-ascii")}
+        w.puts("bar")
+        assert_equal("bar\n", r.gets)
         assert_warning(/Unsupported/, bug5567) {r.set_encoding("us-ascii", "fffffffffffxx")}
+        w.puts("zot")
+        assert_equal("zot\n", r.gets)
       end
     end
   end


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/18898