### PR TITLE
vm_opt_ltlt: call rb_str_buf_append directly if RHS is a String

### DIFF
--- a/benchmark/string_concat.yml
+++ b/benchmark/string_concat.yml
@@ -1,0 +1,13 @@
+prelude: |
+  CHUNK = "a" * 64
+benchmark:
+  string_concat: |
+    buffer = String.new(capacity: 4096)
+    buffer << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK
+    buffer << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK
+    buffer << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK
+    buffer << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK
+    buffer << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK
+    buffer << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK
+    buffer << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK
+    buffer << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK << CHUNK

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -5382,7 +5382,11 @@ vm_opt_ltlt(VALUE recv, VALUE obj)
     }
     else if (RBASIC_CLASS(recv) == rb_cString &&
 	     BASIC_OP_UNREDEFINED_P(BOP_LTLT, STRING_REDEFINED_OP_FLAG)) {
-	return rb_str_concat(recv, obj);
+	if (LIKELY(RB_TYPE_P(obj, T_STRING))) {
+	    return rb_str_buf_append(recv, obj);
+	} else {
+	    return rb_str_concat(recv, obj);
+	}
     }
     else if (RBASIC_CLASS(recv) == rb_cArray &&
 	     BASIC_OP_UNREDEFINED_P(BOP_LTLT, ARRAY_REDEFINED_OP_FLAG)) {

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -61,7 +61,7 @@ fn main() {
 
         // From include/ruby/internal/intern/string.h
         .allowlist_function("rb_utf8_str_new")
-        .allowlist_function("rb_str_append")
+        .allowlist_function("rb_str_buf_append")
         .allowlist_function("rb_str_dup")
 
         // This struct is public to Ruby C extensions

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -3770,7 +3770,7 @@ fn jit_rb_str_concat(
 
     // If encodings are different, use a slower encoding-aware concatenate
     cb.write_label(enc_mismatch);
-    call_ptr(cb, REG0, rb_str_append as *const u8);
+    call_ptr(cb, REG0, rb_str_buf_append as *const u8);
     // Drop through to return
 
     cb.write_label(ret_label);

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -224,10 +224,10 @@ extern "C" {
     ) -> VALUE;
 }
 extern "C" {
-    pub fn rb_str_dup(str_: VALUE) -> VALUE;
+    pub fn rb_str_buf_append(dst: VALUE, src: VALUE) -> VALUE;
 }
 extern "C" {
-    pub fn rb_str_append(dst: VALUE, src: VALUE) -> VALUE;
+    pub fn rb_str_dup(str_: VALUE) -> VALUE;
 }
 extern "C" {
     pub fn rb_str_intern(str_: VALUE) -> VALUE;


### PR DESCRIPTION
`rb_str_concat` does a lot of type checking we can easily bypass.

```

|               |compare-ruby|built-ruby|
|:--------------|-----------:|---------:|
|string_concat  |    362.007k|  398.965k|
|               |           -|     1.10x|
```

I have a bunch of other optimization, but I think it's worth submitting this one alone as it's easy to understand and very simple.