### PR TITLE
Fix extconf.rb for OpenSSL 3 without $warnflags

### DIFF
--- a/ext/openssl/extconf.rb
+++ b/ext/openssl/extconf.rb
@@ -185,7 +185,7 @@ have_func("EVP_PKEY_dup")
 Logging::message "=== Checking done. ===\n"
 
 if openssl_3
-  if $warnflags.sub!(/-W\K(?=deprecated-declarations)/, 'no-')
+  if $warnflags&.sub!(/-W\K(?=deprecated-declarations)/, 'no-')
     $warnflags << " -Wno-incompatible-pointer-types-discards-qualifiers"
   end
 end


### PR DESCRIPTION
On Windows with OpenSSL 3, the gem fails to compile with the following
error message:

```
ruby/src/ext/openssl/extconf.rb:188: undefined method \`sub!' for nil:NilClass
```

This is because $warnflags is nil.