### PR TITLE
Thread#value: handle threads killed by a fork

### DIFF
--- a/test/ruby/test_thread.rb
+++ b/test/ruby/test_thread.rb
@@ -1249,6 +1249,20 @@ q.pop
     assert_predicate(status, :success?, bug9751)
   end if Process.respond_to?(:fork)
 
+  def test_fork_value
+    bug18902 = "[Bug #18902]"
+    th = Thread.start { sleep 2 }
+    begin
+      pid = fork do
+        th.value
+      end
+      _, status = Process.wait2(pid)
+      assert_predicate(status, :success?, bug18902)
+    ensure
+      th.kill
+    end
+  end if Process.respond_to?(:fork)
+
   def test_fork_while_locked
     m = Thread::Mutex.new
     thrs = []

--- a/thread.c
+++ b/thread.c
@@ -1214,6 +1214,10 @@ thread_value(VALUE self)
 {
     rb_thread_t *th = rb_thread_ptr(self);
     thread_join(th, Qnil, 0);
+    if (th->value == Qundef) {
+        // If the thread is dead because we forked th->value is still Qundef.
+        return Qnil;
+    }
     return th->value;
 }
 


### PR DESCRIPTION
[Bug #18902]

When a thread is killed because we forked, the `value` if left to `Qundef`. Returning it woudl crash the VM.