### PR TITLE
Fix macro redefinition warning for MacOS

### DIFF
--- a/internal.h
+++ b/internal.h
@@ -107,6 +107,7 @@ RUBY_SYMBOL_EXPORT_END
 #define RB_BIGNUM_TYPE_P(x) RB_TYPE_P((x), T_BIGNUM)
 
 #ifndef __MINGW32__
+#undef memcpy
 #define memcpy ruby_nonempty_memcpy
 #endif
 #endif /* RUBY_INTERNAL_H */


### PR DESCRIPTION
Introduced by 7f64989e5c913ef7624e084badd1a43ce65b3ccc

```
./internal.h:110:9: warning: 'memcpy' macro redefined [-Wmacro-redefined]
        ^
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/secure/_string.h:62:9: note: previous definition is here
        ^
1 warning generated.
```

The previous implementation used `undef` to remove the existing macro before redefining, so we'll do the same for the new internal macro