### PR TITLE
Add --enable-yjit=stats configure option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3736,7 +3736,7 @@ CARGO=
 CARGO_BUILD_ARGS=
 YJIT_LIBS=
 AS_CASE(["${YJIT_SUPPORT}"],
-[yes|dev|stats], [
+[yes|dev|stats|dev_nodebug], [
     AS_IF([test x"$enable_jit_support" = "xno"],
         AC_MSG_ERROR([--disable-jit-support but --enable-yjit. YJIT requires JIT support])
     )
@@ -3754,9 +3754,13 @@ AS_CASE(["${YJIT_SUPPORT}"],
 	CARGO_BUILD_ARGS='--features stats,disasm,asm_comments'
 	AC_DEFINE(RUBY_DEBUG, 1)
     ],
+    [dev_nodebug], [
+	rb_rust_target_subdir=dev_nodebug
+	CARGO_BUILD_ARGS='--profile dev_nodebug --features stats,disasm,asm_comments'
+    ],
     [stats], [
 	rb_rust_target_subdir=stats
-	CARGO_BUILD_ARGS='--profile stats --features stats,disasm,asm_comments'
+	CARGO_BUILD_ARGS='--profile stats --features stats'
     ])
 
     AS_IF([test -n "${CARGO_BUILD_ARGS}"], [

--- a/configure.ac
+++ b/configure.ac
@@ -3736,7 +3736,7 @@ CARGO=
 CARGO_BUILD_ARGS=
 YJIT_LIBS=
 AS_CASE(["${YJIT_SUPPORT}"],
-[yes|dev], [
+[yes|dev|stats], [
     AS_IF([test x"$enable_jit_support" = "xno"],
         AC_MSG_ERROR([--disable-jit-support but --enable-yjit. YJIT requires JIT support])
     )
@@ -3744,16 +3744,27 @@ AS_CASE(["${YJIT_SUPPORT}"],
     AS_IF([test x"$RUSTC" = "xno"],
         AC_MSG_ERROR([rustc is required. Installation instructions available at https://www.rust-lang.org/tools/install])
     )
-    AS_IF([test x"$YJIT_SUPPORT" = "xyes"],
-            [rb_rust_target_subdir=release
-             CARGO_BUILD_ARGS='--release'],
-            [rb_rust_target_subdir=debug
-             CARGO_BUILD_ARGS='--features stats,disasm,asm_comments'
+
+    AS_CASE(["${YJIT_SUPPORT}"],
+    [yes], [
+	rb_rust_target_subdir=release
+    ],
+    [dev], [
+	rb_rust_target_subdir=debug
+	CARGO_BUILD_ARGS='--features stats,disasm,asm_comments'
+	AC_DEFINE(RUBY_DEBUG, 1)
+    ],
+    [stats], [
+	rb_rust_target_subdir=stats
+	CARGO_BUILD_ARGS='--profile stats --features stats,disasm,asm_comments'
+    ])
+
+    AS_IF([test -n "${CARGO_BUILD_ARGS}"], [
              AC_CHECK_TOOL(CARGO, [cargo], [no])
              AS_IF([test x"$CARGO" = "xno"],
                 AC_MSG_ERROR([cargo is required. Installation instructions available at https://www.rust-lang.org/tools/install])
-             )
-             AC_DEFINE(RUBY_DEBUG, 1)])
+             ]))
+
     YJIT_LIBS="yjit/target/${rb_rust_target_subdir}/libyjit.a"
     YJIT_OBJ='yjit.$(OBJEXT)'
     AC_DEFINE(USE_YJIT, 1)

--- a/yjit/Cargo.toml
+++ b/yjit/Cargo.toml
@@ -30,6 +30,9 @@ debug = true
 debug-assertions = true
 overflow-checks = true
 
+[profile.stats]
+inherits = "release"
+
 [profile.release]
 # NOTE: --enable-yjit builds use `rustc` without going through Cargo. You
 # might want to update the `rustc` invocation if you change this profile.

--- a/yjit/Cargo.toml
+++ b/yjit/Cargo.toml
@@ -33,6 +33,9 @@ overflow-checks = true
 [profile.stats]
 inherits = "release"
 
+[profile.dev_nodebug]
+inherits = "release"
+
 [profile.release]
 # NOTE: --enable-yjit builds use `rustc` without going through Cargo. You
 # might want to update the `rustc` invocation if you change this profile.

--- a/yjit/yjit.mk
+++ b/yjit/yjit.mk
@@ -25,12 +25,15 @@ yjit-static-lib-no:
 	$(ECHO) 'Error: Tried to build YJIT without configuring it first. Check `make showconfig`?'
 	@false
 
-yjit-static-lib-dev:
-	$(ECHO) 'building Rust YJIT (dev mode)'
+yjit-static-lib-cargo:
+	$(ECHO) 'building Rust YJIT ($(YJIT_SUPPORT) mode)'
 	$(Q)$(CHDIR) $(top_srcdir)/yjit && \
 	        CARGO_TARGET_DIR='$(CARGO_TARGET_DIR)' \
 	        CARGO_TERM_PROGRESS_WHEN='never' \
 	        $(CARGO) $(CARGO_VERBOSE) build $(CARGO_BUILD_ARGS)
+
+yjit-static-lib-dev: yjit-static-lib-cargo
+yjit-static-lib-stats: yjit-static-lib-cargo
 
 # This PHONY prerequisite makes it so that we always run cargo. When there are
 # no Rust changes on rebuild, Cargo does not touch the mtime of the static

--- a/yjit/yjit.mk
+++ b/yjit/yjit.mk
@@ -33,6 +33,7 @@ yjit-static-lib-cargo:
 	        $(CARGO) $(CARGO_VERBOSE) build $(CARGO_BUILD_ARGS)
 
 yjit-static-lib-dev: yjit-static-lib-cargo
+yjit-static-lib-dev_nodebug: yjit-static-lib-cargo
 yjit-static-lib-stats: yjit-static-lib-cargo
 
 # This PHONY prerequisite makes it so that we always run cargo. When there are


### PR DESCRIPTION
This adds `--enable-yjit=stats`, which configures Ruby and YJIT in a non-debug build with optimizations enabled, but enabling YJIT's stats, disasm, and asm_comments features.

This is intended to make it easier to profile and gather stats on larger applications and slower benchmarks.

I added a new cargo profile (and therefore target dir) for this. Currently this profile uses the same settings as release.

I removed setting `CARGO_BUILD_ARGS` from `--enable-yjit=yes`, since we don't use cargo in release mode, which allowed testing for the presence of that var to determine if cargo is required.

@maximecb and @noahgibbs suggested the name `--enable-yjit=stats` which I also like.