### PR TITLE
Simplify unary minus operations of unsigned type

### DIFF
--- a/iseq.c
+++ b/iseq.c
@@ -257,7 +257,7 @@ iseq_scan_bits(unsigned int page, iseq_bits_t bits, VALUE *code, iseq_value_itr_
                 original_iseq[page_offset + offset] = newop;
             }
         }
-        bits ^= bits & -bits; // Reset Lowest Set Bit (BLSR)
+        bits &= bits - 1; // Reset Lowest Set Bit (BLSR)
     }
 }
 

--- a/iseq.h
+++ b/iseq.h
@@ -21,7 +21,7 @@ RUBY_EXTERN const int ruby_api_version[];
 #define ISEQ_MBITS_BITLENGTH (ISEQ_MBITS_SIZE * CHAR_BIT)
 #define ISEQ_MBITS_SET(buf, i) (buf[(i) / ISEQ_MBITS_BITLENGTH] |= ((iseq_bits_t)1 << ((i) % ISEQ_MBITS_BITLENGTH)))
 #define ISEQ_MBITS_SET_P(buf, i) ((buf[(i) / ISEQ_MBITS_BITLENGTH] >> ((i) % ISEQ_MBITS_BITLENGTH)) & 0x1)
-#define ISEQ_MBITS_BUFLEN(size) (((size + (ISEQ_MBITS_BITLENGTH - 1)) & -ISEQ_MBITS_BITLENGTH) / ISEQ_MBITS_BITLENGTH)
+#define ISEQ_MBITS_BUFLEN(size) roomof(size, ISEQ_MBITS_BITLENGTH)
 
 #ifndef USE_ISEQ_NODE_ID
 #define USE_ISEQ_NODE_ID 1


### PR DESCRIPTION
Warnings by Visual C.

```
compiling ../src/compile.c
compile.c
../src/compile.c(2344): warning C4146: unary minus operator applied to unsigned type, result still unsigned
../src/compile.c(2348): warning C4146: unary minus operator applied to unsigned type, result still unsigned
../src/compile.c(2514): warning C4146: unary minus operator applied to unsigned type, result still unsigned
../src/compile.c(2537): warning C4146: unary minus operator applied to unsigned type, result still unsigned
../src/compile.c(11207): warning C4146: unary minus operator applied to unsigned type, result still unsigned
../src/compile.c(11211): warning C4146: unary minus operator applied to unsigned type, result still unsigned
../src/compile.c(11319): warning C4146: unary minus operator applied to unsigned type, result still unsigned
compiling ../src/iseq.c
iseq.c
../src/iseq.c(196): warning C4146: unary minus operator applied to unsigned type, result still unsigned
../src/iseq.c(260): warning C4146: unary minus operator applied to unsigned type, result still unsigned
../src/iseq.c(317): warning C4146: unary minus operator applied to unsigned type, result still unsigned
../src/iseq.c(322): warning C4146: unary minus operator applied to unsigned type, result still unsigned
../src/iseq.c(575): warning C4146: unary minus operator applied to unsigned type, result still unsigned
```