### PR TITLE
Fix invalid mkdir detection on OpenBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -492,6 +492,11 @@ AS_CASE(["$target_os"],
 AC_PROG_LN_S
 AC_PROG_MAKE_SET
 AC_PROG_INSTALL
+
+AS_CASE(["$target_os"],[openbsd*],[
+    ac_cv_path_mkdir="mkdir"
+])
+
 RUBY_PROG_MAKEDIRS
 
 AC_CHECK_PROG([DTRACE], [${ac_tool_prefix}dtrace], [${ac_tool_prefix}dtrace])


### PR DESCRIPTION
This was broken by 67e54ce4081abaa16774b93ccd33ccbd1d6c6531, which
resulted in " -d" being used as the mkdir_p program. I think this
is because $ac_install_sh has been set to '' at the point it is
used.

There's probably a better way to fix this, but this should allow
the OpenBSD CI to continue to work until a better fix is in place.