### PR TITLE
Fix a regression of b2e58b02aec73f9c350bf109c021c180fc699ccc

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -2226,13 +2226,10 @@ static int
 add_adjust_info(struct iseq_insn_info_entry *insns_info, unsigned int *positions,
                 int insns_info_index, int code_index, const ADJUST *adjust)
 {
-    if (insns_info[insns_info_index-1].line_no != adjust->line_no) {
-        insns_info[insns_info_index].line_no    = adjust->line_no;
-        insns_info[insns_info_index].events     = 0;
-        positions[insns_info_index]             = code_index;
-        return TRUE;
-    }
-    return FALSE;
+    insns_info[insns_info_index].line_no    = adjust->line_no;
+    insns_info[insns_info_index].events     = 0;
+    positions[insns_info_index]             = code_index;
+    return TRUE;
 }
 
 /**

--- a/test/coverage/test_coverage.rb
+++ b/test/coverage/test_coverage.rb
@@ -181,6 +181,27 @@ class TestCoverage < Test::Unit::TestCase
     end;
   end
 
+  def test_coverage_ensure_if_return
+    result = {
+      :branches => {
+        [:if, 0, 3, 1, 6, 4] => {
+          [:then, 1, 3, 6, 3, 6] => 0,
+          [:else, 2, 5, 3, 5, 9] => 1,
+	},
+      },
+    }
+    assert_coverage(<<~"end;", { branches: true }, result)
+      def flush
+      ensure
+	if $!
+	else
+	  return
+	end
+      end
+      flush
+    end;
+  end
+
   def assert_coverage(code, opt, stdout)
     stdout = [stdout] unless stdout.is_a?(Array)
     stdout = stdout.map {|s| s.to_s }


### PR DESCRIPTION
At that commit, I fixed a wrong conditional expression that was always
true.  However, that seemed to have caused a regression. [Bug #18906]

This change removes the condition to make the code always enabled.
It had been enabled until that commit, albeit unintentionally, and even
if it is enabled it only consumes a tiny bit of memory, so I believe it
is harmless. [Bug #18906]