### PR TITLE
Fix `rb_profile_frames` output includes dummy main thread frame

### DIFF
--- a/ext/-test-/debug/profile_frames.c
+++ b/ext/-test-/debug/profile_frames.c
@@ -29,6 +29,7 @@ profile_frames(VALUE self, VALUE start_v, VALUE num_v)
         rb_ary_push(ary, rb_profile_frame_singleton_method_p(buff[i]));
         rb_ary_push(ary, rb_profile_frame_method_name(buff[i]));
         rb_ary_push(ary, rb_profile_frame_qualified_method_name(buff[i]));
+        rb_ary_push(ary, INT2NUM(lines[i]));
 
         rb_ary_push(result, ary);
     }

--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -1551,6 +1551,9 @@ rb_profile_frames(int start, int limit, VALUE *buff, int *lines)
     const rb_control_frame_t *cfp = ec->cfp, *end_cfp = RUBY_VM_END_CONTROL_FRAME(ec);
     const rb_callable_method_entry_t *cme;
 
+    // Skip dummy frame; see `rb_ec_partial_backtrace_object` for details
+    end_cfp = RUBY_VM_NEXT_CONTROL_FRAME(end_cfp);
+
     for (i=0; i<limit && cfp != end_cfp;) {
         if (VM_FRAME_RUBYFRAME_P(cfp)) {
             if (start > 0) {


### PR DESCRIPTION
The `rb_profile_frames` API did not skip the two dummy frames that each thread has at its beginning. This was unlike `backtrace_each` and `rb_ec_parcial_backtrace_object`, which do skip them.

This does not seem to be a problem for non-main thread frames, because both `VM_FRAME_RUBYFRAME_P(cfp)` and `rb_vm_frame_method_entry(cfp)` are NULL for them.

BUT, on the main thread `VM_FRAME_RUBYFRAME_P(cfp)` was true and thus the dummy thread was still included in the output of `rb_profile_frames`.

I've now made `rb_profile_frames` skip this extra frame (like `backtrace_each` and friends), as well as add a test that asserts the size and contents of `rb_profile_frames`.

Fixes [Bug #18907] (<https://bugs.ruby-lang.org/issues/18907>)