### PR TITLE
Fix some UBSAN false positives

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -12898,10 +12898,14 @@ regexec.$(OBJEXT): {$(VPATH)}st.h
 regexec.$(OBJEXT): {$(VPATH)}subst.h
 regparse.$(OBJEXT): $(hdrdir)/ruby.h
 regparse.$(OBJEXT): $(hdrdir)/ruby/ruby.h
+regparse.$(OBJEXT): $(top_srcdir)/internal/compilers.h
+regparse.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
+regparse.$(OBJEXT): $(top_srcdir)/internal/warnings.h
 regparse.$(OBJEXT): {$(VPATH)}assert.h
 regparse.$(OBJEXT): {$(VPATH)}backward/2/assume.h
 regparse.$(OBJEXT): {$(VPATH)}backward/2/attributes.h
 regparse.$(OBJEXT): {$(VPATH)}backward/2/bool.h
+regparse.$(OBJEXT): {$(VPATH)}backward/2/gcc_version_since.h
 regparse.$(OBJEXT): {$(VPATH)}backward/2/inttypes.h
 regparse.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 regparse.$(OBJEXT): {$(VPATH)}backward/2/long_long.h

--- a/include/ruby/internal/arithmetic/long.h
+++ b/include/ruby/internal/arithmetic/long.h
@@ -115,7 +115,7 @@ RB_INT2FIX(long i)
     /* :NOTE: VALUE can be wider than long.  As j being unsigned, 2j+1 is fully
      * defined. Also it can be compiled into a single LEA instruction. */
     const unsigned long j = i;
-    const unsigned long k = 2 * j + RUBY_FIXNUM_FLAG;
+    const unsigned long k = (j << 1) + RUBY_FIXNUM_FLAG;
     const long          l = k;
     const SIGNED_VALUE  m = l; /* Sign extend */
     const VALUE         n = m;

--- a/parse.y
+++ b/parse.y
@@ -232,12 +232,12 @@ enum {
 };
 
 #define NUMPARAM_ID_P(id) numparam_id_p(id)
-#define NUMPARAM_ID_TO_IDX(id) (unsigned int)(((id) >> ID_SCOPE_SHIFT) - tNUMPARAM_1 + 1)
-#define NUMPARAM_IDX_TO_ID(idx) TOKEN2LOCALID((tNUMPARAM_1 + (idx) - 1))
+#define NUMPARAM_ID_TO_IDX(id) (unsigned int)(((id) >> ID_SCOPE_SHIFT) - (tNUMPARAM_1 - 1))
+#define NUMPARAM_IDX_TO_ID(idx) TOKEN2LOCALID((tNUMPARAM_1 - 1 + (idx)))
 static int
 numparam_id_p(ID id)
 {
-    if (!is_local_id(id)) return 0;
+    if (!is_local_id(id) || id < (tNUMPARAM_1 << ID_SCOPE_SHIFT)) return 0;
     unsigned int idx = NUMPARAM_ID_TO_IDX(id);
     return idx > 0 && idx <= NUMPARAM_MAX;
 }

--- a/regparse.c
+++ b/regparse.c
@@ -37,6 +37,7 @@
 
 #include "regparse.h"
 #include <stdarg.h>
+#include "internal/sanitizers.h"
 
 #define WARN_BUFSIZE    256
 
@@ -393,6 +394,8 @@ str_end_cmp(st_data_t xp, st_data_t yp)
 
   return 0;
 }
+
+NO_SANITIZE("unsigned-integer-overflow", static st_index_t str_end_hash(st_data_t xp));
 
 static st_index_t
 str_end_hash(st_data_t xp)


### PR DESCRIPTION
I tried building ruby with UBSAN and saw some false-positive results for "unsigned integer overflow". These changes fix the false-positives, without changing the behavior of the code.