### PR TITLE
Use VM Lock when mutating waiting threads list

### DIFF
--- a/thread.c
+++ b/thread.c
@@ -4342,7 +4342,11 @@ select_single_cleanup(VALUE ptr)
 {
     struct select_args *args = (struct select_args *)ptr;
 
-    ccan_list_del(&args->wfd.wfd_node);
+    RB_VM_LOCK_ENTER();
+    {
+        ccan_list_del(&args->wfd.wfd_node);
+    }
+    RB_VM_LOCK_LEAVE();
     if (args->read) rb_fd_term(args->read);
     if (args->write) rb_fd_term(args->write);
     if (args->except) rb_fd_term(args->except);


### PR DESCRIPTION
`rb_thread_wait_for_single_fd` needs to mutate the `waiting_fds` list
that is stored on the VM.  We need to delete the FD from the list before
returning, and deleting from the list requires a VM lock (because the
list is a global).

[Bug #18816] [ruby-core:108771]

Co-Authored-By: Alan Wu <alanwu@ruby-lang.org>