### PR TITLE
Prevent the stack from being marked twice

### DIFF
--- a/cont.c
+++ b/cont.c
@@ -1194,6 +1194,12 @@ cont_init_mjit_cont(rb_context_t *cont)
     }
 }
 
+struct rb_execution_context_struct *
+rb_fiberptr_get_ec(struct rb_fiber_struct *fiber)
+{
+    return &fiber->cont.saved_ec;
+}
+
 static void
 cont_init(rb_context_t *cont, rb_thread_t *th)
 {

--- a/internal/cont.h
+++ b/internal/cont.h
@@ -12,6 +12,7 @@
 
 struct rb_thread_struct;        /* in vm_core.h */
 struct rb_fiber_struct;         /* in cont.c */
+struct rb_execution_context_struct; /* in vm_core.c */
 
 /* cont.c */
 void rb_fiber_reset_root_local_storage(struct rb_thread_struct *);
@@ -20,5 +21,6 @@ void rb_fiber_init_mjit_cont(struct rb_fiber_struct *fiber);
 
 VALUE rb_fiberptr_self(struct rb_fiber_struct *fiber);
 unsigned int rb_fiberptr_blocking(struct rb_fiber_struct *fiber);
+struct rb_execution_context_struct * rb_fiberptr_get_ec(struct rb_fiber_struct *fiber);
 
 #endif /* INTERNAL_CONT_H */

--- a/vm.c
+++ b/vm.c
@@ -3138,8 +3138,7 @@ thread_mark(void *ptr)
     RUBY_MARK_UNLESS_NULL(th->top_wrapper);
     if (th->root_fiber) rb_fiber_mark_self(th->root_fiber);
 
-    /* Ensure EC stack objects are pinned */
-    rb_execution_context_mark(th->ec);
+    RUBY_ASSERT(th->ec == rb_fiberptr_get_ec(th->ec->fiber_ptr));
     RUBY_MARK_UNLESS_NULL(th->stat_insn_usage);
     RUBY_MARK_UNLESS_NULL(th->last_status);
     RUBY_MARK_UNLESS_NULL(th->locking_mutex);


### PR DESCRIPTION
This commit prevents the stack from being marked twice: once via the
Fiber, and once via the Thread.  It introduces an assertion to assert
that the ec on the thread is the same as the ec on the Fiber being
marked via the thread.