### PR TITLE
Rename ENCINDEX_ASCII to ENCINDEX_ASCII_8BIT

### DIFF
--- a/dir.c
+++ b/dir.c
@@ -709,7 +709,7 @@ static int
 fundamental_encoding_p(rb_encoding *enc)
 {
     switch (rb_enc_to_index(enc)) {
-      case ENCINDEX_ASCII:
+      case ENCINDEX_ASCII_8BIT:
       case ENCINDEX_US_ASCII:
       case ENCINDEX_UTF_8:
 	return TRUE;
@@ -1131,8 +1131,8 @@ rb_dir_getwd(void)
 
     switch (fsenc) {
       case ENCINDEX_US_ASCII:
-	fsenc = ENCINDEX_ASCII;
-      case ENCINDEX_ASCII:
+	fsenc = ENCINDEX_ASCII_8BIT;
+      case ENCINDEX_ASCII_8BIT:
 	break;
 #if defined _WIN32 || defined __APPLE__
       default:

--- a/enc/ascii.c
+++ b/enc/ascii.c
@@ -33,8 +33,8 @@
 # include "encindex.h"
 #endif
 
-#ifndef ENCINDEX_ASCII
-# define ENCINDEX_ASCII 0
+#ifndef ENCINDEX_ASCII_8BIT
+# define ENCINDEX_ASCII_8BIT 0
 #endif
 
 OnigEncodingDefine(ascii, ASCII) = {
@@ -55,7 +55,7 @@ OnigEncodingDefine(ascii, ASCII) = {
   onigenc_single_byte_left_adjust_char_head,
   onigenc_always_true_is_allowed_reverse_match,
   onigenc_single_byte_ascii_only_case_map,
-  ENCINDEX_ASCII,
+  ENCINDEX_ASCII_8BIT,
   ONIGENC_FLAG_NONE,
 };
 ENC_ALIAS("BINARY", "ASCII-8BIT")

--- a/encindex.h
+++ b/encindex.h
@@ -20,7 +20,7 @@ extern "C" {
 #endif
 
 enum ruby_preserved_encindex {
-    RUBY_ENCINDEX_ASCII,
+    RUBY_ENCINDEX_ASCII_8BIT,
     RUBY_ENCINDEX_UTF_8,
     RUBY_ENCINDEX_US_ASCII,
 
@@ -40,7 +40,7 @@ enum ruby_preserved_encindex {
     RUBY_ENCINDEX_BUILTIN_MAX
 };
 
-#define ENCINDEX_ASCII       RUBY_ENCINDEX_ASCII
+#define ENCINDEX_ASCII_8BIT  RUBY_ENCINDEX_ASCII_8BIT
 #define ENCINDEX_UTF_8       RUBY_ENCINDEX_UTF_8
 #define ENCINDEX_US_ASCII    RUBY_ENCINDEX_US_ASCII
 #define ENCINDEX_UTF_16BE    RUBY_ENCINDEX_UTF_16BE
@@ -54,7 +54,7 @@ enum ruby_preserved_encindex {
 #define ENCINDEX_Windows_31J RUBY_ENCINDEX_Windows_31J
 #define ENCINDEX_BUILTIN_MAX RUBY_ENCINDEX_BUILTIN_MAX
 
-#define rb_ascii8bit_encindex() RUBY_ENCINDEX_ASCII
+#define rb_ascii8bit_encindex() RUBY_ENCINDEX_ASCII_8BIT
 #define rb_utf8_encindex()      RUBY_ENCINDEX_UTF_8
 #define rb_usascii_encindex()   RUBY_ENCINDEX_US_ASCII
 

--- a/encoding.c
+++ b/encoding.c
@@ -416,7 +416,7 @@ rb_enc_from_index(int index)
     rb_encoding *enc;
 
     switch (index) {
-      case ENCINDEX_ASCII:    return global_enc_ascii;
+      case ENCINDEX_ASCII_8BIT:    return global_enc_ascii;
       case ENCINDEX_UTF_8:    return global_enc_utf_8;
       case ENCINDEX_US_ASCII: return global_enc_us_ascii;
       default:
@@ -771,14 +771,16 @@ rb_enc_init(struct enc_table *enc_table)
     if (!enc_table->names) {
 	enc_table->names = st_init_strcasetable();
     }
+#define OnigEncodingASCII_8BIT OnigEncodingASCII
 #define ENC_REGISTER(enc) enc_register_at(enc_table, ENCINDEX_##enc, rb_enc_name(&OnigEncoding##enc), &OnigEncoding##enc)
-    ENC_REGISTER(ASCII);
+    ENC_REGISTER(ASCII_8BIT);
     ENC_REGISTER(UTF_8);
     ENC_REGISTER(US_ASCII);
-    global_enc_ascii = enc_table->list[ENCINDEX_ASCII].enc;
+    global_enc_ascii = enc_table->list[ENCINDEX_ASCII_8BIT].enc;
     global_enc_utf_8 = enc_table->list[ENCINDEX_UTF_8].enc;
     global_enc_us_ascii = enc_table->list[ENCINDEX_US_ASCII].enc;
 #undef ENC_REGISTER
+#undef OnigEncodingASCII_8BIT
 #define ENCDB_REGISTER(name, enc) enc_register_at(enc_table, ENCINDEX_##enc, name, NULL)
     ENCDB_REGISTER("UTF-16BE", UTF_16BE);
     ENCDB_REGISTER("UTF-16LE", UTF_16LE);
@@ -969,7 +971,7 @@ enc_get_index_str(VALUE str)
          * all instance variables are removed in `obj_free`.
          */
         iv = rb_attr_get(str, rb_id_encoding());
-        i = NIL_P(iv) ? ENCINDEX_ASCII : NUM2INT(iv);
+        i = NIL_P(iv) ? ENCINDEX_ASCII_8BIT : NUM2INT(iv);
 #endif
     }
     return i;
@@ -1520,7 +1522,7 @@ rb_ascii8bit_encoding(void)
 int
 rb_ascii8bit_encindex(void)
 {
-    return ENCINDEX_ASCII;
+    return ENCINDEX_ASCII_8BIT;
 }
 
 rb_encoding *
@@ -1584,7 +1586,7 @@ rb_filesystem_encindex(void)
                           idx = enc_registered(enc_table, "filesystem"));
 
     if (idx < 0)
-	idx = ENCINDEX_ASCII;
+	idx = ENCINDEX_ASCII_8BIT;
     return idx;
 }
 

--- a/file.c
+++ b/file.c
@@ -182,7 +182,7 @@ file_path_convert(VALUE name)
     int fname_encidx = ENCODING_GET(name);
     int fs_encidx;
     if (ENCINDEX_US_ASCII != fname_encidx &&
-	ENCINDEX_ASCII != fname_encidx &&
+	ENCINDEX_ASCII_8BIT != fname_encidx &&
 	(fs_encidx = rb_filesystem_encindex()) != fname_encidx &&
 	rb_default_internal_encoding() &&
 	!rb_enc_str_asciionly_p(name)) {
@@ -253,11 +253,11 @@ rb_str_encode_ospath(VALUE path)
 #if USE_OSPATH
     int encidx = ENCODING_GET(path);
 #if 0 && defined _WIN32
-    if (encidx == ENCINDEX_ASCII) {
+    if (encidx == ENCINDEX_ASCII_8BIT) {
 	encidx = rb_filesystem_encindex();
     }
 #endif
-    if (encidx != ENCINDEX_ASCII && encidx != ENCINDEX_UTF_8) {
+    if (encidx != ENCINDEX_ASCII_8BIT && encidx != ENCINDEX_UTF_8) {
 	rb_encoding *enc = rb_enc_from_index(encidx);
 	rb_encoding *utf8 = rb_utf8_encoding();
 	path = rb_str_conv_enc(path, enc, utf8);
@@ -4396,7 +4396,7 @@ rb_check_realpath_emulate(VALUE basedir, VALUE path, rb_encoding *origenc, enum 
 #endif
 
     switch (rb_enc_to_index(enc)) {
-      case ENCINDEX_ASCII:
+      case ENCINDEX_ASCII_8BIT:
       case ENCINDEX_US_ASCII:
 	rb_enc_associate_index(resolved, rb_filesystem_encindex());
     }
@@ -6425,7 +6425,7 @@ static VALUE
 copy_path_class(VALUE path, VALUE orig)
 {
     int encidx = rb_enc_get_index(orig);
-    if (encidx == ENCINDEX_ASCII || encidx == ENCINDEX_US_ASCII)
+    if (encidx == ENCINDEX_ASCII_8BIT || encidx == ENCINDEX_US_ASCII)
         encidx = rb_filesystem_encindex();
     rb_enc_associate_index(path, encidx);
     str_shrink(path);

--- a/localeinit.c
+++ b/localeinit.c
@@ -128,7 +128,7 @@ Init_enc_set_filesystem_encoding(void)
     /* for debugging */
     CP_FORMAT(cp, codepage);
     idx = rb_enc_find_index(cp);
-    if (idx < 0) idx = ENCINDEX_ASCII;
+    if (idx < 0) idx = ENCINDEX_ASCII_8BIT;
 #elif defined __CYGWIN__
     idx = ENCINDEX_UTF_8;
 #else

--- a/string.c
+++ b/string.c
@@ -3441,7 +3441,7 @@ rb_str_concat(VALUE str1, VALUE str2)
     }
 
     encidx = rb_enc_to_index(enc);
-    if (encidx == ENCINDEX_ASCII || encidx == ENCINDEX_US_ASCII) {
+    if (encidx == ENCINDEX_ASCII_8BIT || encidx == ENCINDEX_US_ASCII) {
 	/* US-ASCII automatically extended to ASCII-8BIT */
 	char buf[1];
 	buf[0] = (char)code;
@@ -3450,7 +3450,7 @@ rb_str_concat(VALUE str1, VALUE str2)
 	}
 	rb_str_cat(str1, buf, 1);
 	if (encidx == ENCINDEX_US_ASCII && code > 127) {
-	    rb_enc_associate_index(str1, ENCINDEX_ASCII);
+	    rb_enc_associate_index(str1, ENCINDEX_ASCII_8BIT);
 	    ENC_CODERANGE_SET(str1, ENC_CODERANGE_VALID);
 	}
     }

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -2310,7 +2310,7 @@ rb_w32_conv_from_wchar(const WCHAR *wstr, rb_encoding *enc)
 	WideCharToMultiByte(CP_UTF8, 0, wstr, clen, RSTRING_PTR(src), len, NULL, NULL);
     }
     switch (encindex) {
-      case ENCINDEX_ASCII:
+      case ENCINDEX_ASCII_8BIT:
       case ENCINDEX_US_ASCII:
 	/* assume UTF-8 */
       case ENCINDEX_UTF_8:
@@ -2402,7 +2402,7 @@ struct direct  *
 rb_w32_readdir(DIR *dirp, rb_encoding *enc)
 {
     int idx = rb_enc_to_index(enc);
-    if (idx == ENCINDEX_ASCII) {
+    if (idx == ENCINDEX_ASCII_8BIT) {
 	const UINT cp = filecp();
 	return readdir_internal(dirp, win32_direct_conv, &cp);
     }
@@ -7355,7 +7355,7 @@ rb_w32_write_console(uintptr_t strarg, int fd)
 				   ECONV_INVALID_REPLACE|ECONV_UNDEF_REPLACE, Qnil);
 	/* fall through */
       case ENCINDEX_US_ASCII:
-      case ENCINDEX_ASCII:
+      case ENCINDEX_ASCII_8BIT:
 	/* assume UTF-8 */
       case ENCINDEX_UTF_8:
 	ptr = wbuffer = mbstr_to_wstr(CP_UTF8, RSTRING_PTR(str), RSTRING_LEN(str), &len);


### PR DESCRIPTION
Otherwise it's way too easy to confuse it with US_ASCII.


cc @duerst 
