### PR TITLE
 thread/test_instrumentation_api: cleanup all existing threads in setup

### DIFF
--- a/test/-ext-/thread/test_instrumentation_api.rb
+++ b/test/-ext-/thread/test_instrumentation_api.rb
@@ -6,6 +6,15 @@ class TestThreadInstrumentation < Test::Unit::TestCase
     pend("No windows support") if /mswin|mingw|bccwin/ =~ RUBY_PLATFORM
 
     require '-test-/thread/instrumentation'
+
+    Thread.list.each do |thread|
+      if thread != Thread.current
+        thread.kill
+        thread.join rescue nil
+      end
+    end
+    assert_equal [Thread.current], Thread.list
+
     Bug::ThreadInstrumentation.reset_counters
     Bug::ThreadInstrumentation::register_callback
   end


### PR DESCRIPTION
We saw the following failure:

```
TestThreadInstrumentation#test_thread_instrumentation [/tmp/ruby/v3/src/trunk-random3/test/-ext-/thread/test_instrumentation_api.rb:25]:
Expected 0..3 to include 4.
```

Which shouldn't happen unless somehow there was a leaked thread.
