### PR TITLE
Ensure symlinks to bundled gem with exts have parent dir

### DIFF
--- a/ext/extmk.rb
+++ b/ext/extmk.rb
@@ -603,6 +603,7 @@ if @gemname
       puts "using #{gemlib}"
     else
       begin
+        FileUtils.mkdir_p(File.dirname(gemlib))
         File.symlink(relative_from(src_gemlib, ".."), gemlib)
         puts "linked #{gemlib}"
       rescue NotImplementedError, Errno::EPERM


### PR DESCRIPTION
When configuring with `--disable-rpath` and `--static-linked-ext` (e.g.
building for WASI), `extmk.rb` doesn't build exts under bundled gems,
and `.bundle/gems/#{gemname}-#{ver}` are not created due to no call of
`extmake`.
b2491783986084770f6f97552f27b868622730cf starts creating symlink at
`.bundle/gems/#{gemname}-#{ver}/lib`, but the parent dir is not created,
so configuration aginst debug and rbs gems were failed.

Failure log https://github.com/ruby/ruby.wasm/runs/7342868710?check_suite_focus=true#step:6:3265