### PR TITLE
Match +YJIT in Ruby desc when testing segv

### DIFF
--- a/test/-ext-/bug_reporter/test_bug_reporter.rb
+++ b/test/-ext-/bug_reporter/test_bug_reporter.rb
@@ -4,6 +4,10 @@ require 'tmpdir'
 require_relative '../../lib/jit_support'
 
 class TestBugReporter < Test::Unit::TestCase
+  def yjit_enabled?
+    defined?(RubyVM::YJIT.enabled?) && RubyVM::YJIT.enabled?
+  end
+
   def test_bug_reporter_add
     omit if ENV['RUBY_ON_BUG']
 
@@ -22,6 +26,7 @@ class TestBugReporter < Test::Unit::TestCase
     no_core = "Process.setrlimit(Process::RLIMIT_CORE, 0); " if defined?(Process.setrlimit) && defined?(Process::RLIMIT_CORE)
     args = ["--disable-gems", "-r-test-/bug_reporter",
             "-C", tmpdir]
+    args.push("--yjit") if yjit_enabled? # We want the printed description to match this process's RUBY_DESCRIPTION
     stdin = "#{no_core}register_sample_bug_reporter(12345); Process.kill :SEGV, $$"
     assert_in_out_err(args, stdin, [], expected_stderr, encoding: "ASCII-8BIT")
   ensure

--- a/test/ruby/test_rubyoptions.rb
+++ b/test/ruby/test_rubyoptions.rb
@@ -778,6 +778,10 @@ class TestRubyOptions < Test::Unit::TestCase
   def assert_segv(args, message=nil)
     omit if ENV['RUBY_ON_BUG']
 
+    # We want YJIT to be enabled in the subprocess if it's enabled for us
+    # so that the Ruby description matches.
+    args.unshift("--yjit") if self.class.yjit_enabled?
+
     test_stdin = ""
     opt = SEGVTest::ExecOptions.dup
     list = SEGVTest::ExpectedStderrList


### PR DESCRIPTION
In test_bug_reporter and test_rubyoptions we intentionally test child processes that cause SEGV. We run them with YJIT
if the parent uses YJIT so that the text description matches the parent RUBY_DESCRIPTION.

I kept hitting test failures in these tests in certain configurations while working on YJIT.