### PR TITLE
Fixes ivar benchmarks to not depend on object allocation

### DIFF
--- a/benchmark/vm_ivar_embedded_obj_init.yml
+++ b/benchmark/vm_ivar_embedded_obj_init.yml
@@ -1,12 +1,14 @@
 prelude: |
   class C
-    def initialize
+    def set_ivars
       @a = nil
       @b = nil
       @c = nil
     end
   end
+
+  c = C.new
 benchmark:
   vm_ivar_embedded_obj_init: |
-    C.new
+    c.set_ivars
 loop_count: 30000000

--- a/benchmark/vm_ivar_extended_obj_init.yml
+++ b/benchmark/vm_ivar_extended_obj_init.yml
@@ -1,6 +1,6 @@
 prelude: |
   class C
-    def initialize
+    def set_ivars
       @a = nil
       @b = nil
       @c = nil
@@ -8,7 +8,9 @@ prelude: |
       @e = nil
     end
   end
+
+  c = C.new
 benchmark:
   vm_ivar_extended_obj_init: |
-    C.new
+    c.set_ivars
 loop_count: 30000000

--- a/benchmark/vm_ivar_set_subclass.yml
+++ b/benchmark/vm_ivar_set_subclass.yml
@@ -1,6 +1,6 @@
 prelude: |
   class A
-    def initialize
+    def set_ivars
       @a = nil
       @b = nil
       @c = nil
@@ -10,8 +10,11 @@ prelude: |
   end
   class B < A; end
   class C < A; end
+
+  b = B.new
+  c = C.new
 benchmark:
   vm_ivar_init_subclass: |
-    B.new
-    C.new
+    b.set_ivars
+    c.set_ivars
 loop_count: 3000000


### PR DESCRIPTION
Prior to this change, we were measuring object allocation as well
as setting instance variables within ivar benchmarks. With this
change, we now only measure setting instance variables within
ivar benchmarks.