### PR TITLE
Separate TS_IVC and TS_ICVARC in is_entries buffers

### DIFF
--- a/iseq.c
+++ b/iseq.c
@@ -274,17 +274,28 @@ rb_iseq_each_value(const rb_iseq_t *iseq, iseq_value_itr_t * func, void *data)
     union iseq_inline_storage_entry *is_entries = body->is_entries;
 
     if (body->is_entries) {
-        // IVC and ICVARC entries
+        // IVC entries
         for (unsigned int i = 0; i < body->ivc_size; i++, is_entries++) {
             IVC ivc = (IVC)is_entries;
             if (ivc->entry) {
-                if (RB_TYPE_P(ivc->entry->class_value, T_NONE)) {
-                    rb_bug("!! %u", ivc->entry->index);
-                }
+                RUBY_ASSERT(!RB_TYPE_P(ivc->entry->class_value, T_NONE));
 
                 VALUE nv = func(data, ivc->entry->class_value);
                 if (ivc->entry->class_value != nv) {
                     ivc->entry->class_value = nv;
+                }
+            }
+        }
+
+        // ICVARC entries
+        for (unsigned int i = 0; i < body->icvarc_size; i++, is_entries++) {
+            ICVARC icvarc = (ICVARC)is_entries;
+            if (icvarc->entry) {
+                RUBY_ASSERT(!RB_TYPE_P(icvarc->entry->class_value, T_NONE));
+
+                VALUE nv = func(data, icvarc->entry->class_value);
+                if (icvarc->entry->class_value != nv) {
+                    icvarc->entry->class_value = nv;
                 }
             }
         }

--- a/tool/ruby_vm/views/_insn_type_chars.erb
+++ b/tool/ruby_vm/views/_insn_type_chars.erb
@@ -20,9 +20,10 @@ ISEQ_IS_ENTRY_START(const struct rb_iseq_constant_body *body, char op_type)
       case TS_IC:
         relative_ic_offset += body->ise_size;
       case TS_ISE:
+        relative_ic_offset += body->icvarc_size;
+      case TS_ICVARC:
         relative_ic_offset += body->ivc_size;
       case TS_IVC:
-      case TS_ICVARC:
         break;
       default:
         rb_bug("Wrong op type");

--- a/vm_core.h
+++ b/vm_core.h
@@ -337,7 +337,7 @@ struct rb_mjit_unit;
 
 typedef uintptr_t iseq_bits_t;
 
-#define ISEQ_IS_SIZE(body) (body->ic_size + body->ivc_size + body->ise_size)
+#define ISEQ_IS_SIZE(body) (body->ic_size + body->ivc_size + body->ise_size + body->icvarc_size)
 
 struct rb_iseq_constant_body {
     enum iseq_type {
@@ -448,7 +448,7 @@ struct rb_iseq_constant_body {
     const struct rb_iseq_struct *parent_iseq;
     struct rb_iseq_struct *local_iseq; /* local_iseq->flip_cnt can be modified */
 
-    union iseq_inline_storage_entry *is_entries; /* [ TS_(ICVARC|IVC) ... | TS_ISE | TS_IC ] */
+    union iseq_inline_storage_entry *is_entries; /* [ TS_IVC | TS_ICVARC | TS_ISE | TS_IC ] */
     struct rb_call_data *call_data; //struct rb_call_data calls[ci_size];
 
     struct {
@@ -460,9 +460,10 @@ struct rb_iseq_constant_body {
     } variable;
 
     unsigned int local_table_size;
-    unsigned int ic_size;  // Number of IC caches
-    unsigned int ise_size; // Number of ISE caches
-    unsigned int ivc_size; // Number of IVC and ICVARC caches
+    unsigned int ic_size;     // Number of IC caches
+    unsigned int ise_size;    // Number of ISE caches
+    unsigned int ivc_size;    // Number of IVC caches
+    unsigned int icvarc_size; // Number of ICVARC caches
     unsigned int ci_size;
     unsigned int stack_max; /* for stack overflow check */
     union {


### PR DESCRIPTION
This allows us to treat cvar caches differently than ivar caches.