### PR TITLE
Add RARRAY_LITERAL_FLAG for array literals

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -4369,7 +4369,7 @@ compile_array(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, int pop
 
             if ((first_chunk && stack_len == 0 && !node_tmp) || count >= min_tmp_ary_len) {
                 /* The literal contains only optimizable elements, or the subarray is long enough */
-                VALUE ary = rb_ary_tmp_new(count);
+                VALUE ary = rb_ary_literal_new(count);
 
                 /* Create a hidden array */
                 for (; count; count--, node = node->nd_next)
@@ -12349,7 +12349,7 @@ ibf_load_object_array(const struct ibf_load *load, const struct ibf_object_heade
 
     const long len = (long)ibf_load_small_value(load, &reading_pos);
 
-    VALUE ary = rb_ary_new_capa(len);
+    VALUE ary = header->internal ? rb_ary_literal_new(len) : rb_ary_new_capa(len);
     int i;
 
     for (i=0; i<len; i++) {

--- a/internal/array.h
+++ b/internal/array.h
@@ -33,6 +33,7 @@ void rb_ary_cancel_sharing(VALUE ary);
 size_t rb_ary_size_as_embedded(VALUE ary);
 void rb_ary_make_embedded(VALUE ary);
 bool rb_ary_embeddable_p(VALUE ary);
+VALUE rb_ary_literal_new(long capa);
 
 static inline VALUE rb_ary_entry_internal(VALUE ary, long offset);
 static inline bool ARY_PTR_USING_P(VALUE ary);


### PR DESCRIPTION
Array created as literals during iseq compilation don't need a reference count since they can never be modified. The previous implementation would mutate the hidden array's reference count, causing copy-on-write invalidation.

This commit adds a RARRAY_LITERAL_FLAG for arrays created through rb_ary_literal_new. Arrays created with this flag do not have reference count stored and just assume they have infinite number of references.

Co-authored-by: @byroot