### PR TITLE
objspace_dump.c: skip dumping method name if not pure ASCII

### DIFF
--- a/ext/objspace/objspace_dump.c
+++ b/ext/objspace/objspace_dump.c
@@ -547,8 +547,10 @@ dump_object(VALUE obj, struct dump_config *dc)
         }
         if (RTEST(ainfo->mid)) {
             VALUE m = rb_sym2str(ainfo->mid);
-            dump_append(dc, ", \"method\":");
-            dump_append_string_value(dc, m);
+            if (dump_string_ascii_only(RSTRING_PTR(m), RSTRING_LEN(m))) {
+                dump_append(dc, ", \"method\":");
+                dump_append_string_value(dc, m);
+            }
         }
         dump_append(dc, ", \"generation\":");
         dump_append_sizet(dc, ainfo->generation);

--- a/test/objspace/test_objspace.rb
+++ b/test/objspace/test_objspace.rb
@@ -725,4 +725,17 @@ class TestObjSpace < Test::Unit::TestCase
       assert_equal '42', out[2]
     end
   end
+
+  def test_utf8_method_names
+    obj = ObjectSpace.trace_object_allocations do
+      utf8_❨╯°□°❩╯︵┻━┻
+    end
+    assert_nil JSON.parse(ObjectSpace.dump(obj))["method"]
+  end
+
+  private
+
+  def utf8_❨╯°□°❩╯︵┻━┻
+    "1" + "2"
+  end
 end


### PR DESCRIPTION
Sidekiq has a method named `❨╯°□°❩╯︵┻━┻` which corrupts heap dumps.

Normally we could just dump is as is since it's valid UTF-8 and need no escaping. But our code to escape control characters isn't UTF-8 aware so it's more complicated than it seems.

Ultimately since the overwhelming majority of method names are pure ASCII, it's not a big loss to just skip it.

cc @vahe 