### PR TITLE
Remove macOS 10.15 from CI

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,7 +21,6 @@ jobs:
       matrix:
         test_task: ["check"] # "test-bundler-parallel", "test-bundled-gems"
         os:
-          - macos-10.15
           - macos-11
           - macos-12
       fail-fast: false


### PR DESCRIPTION
macOS 10.15 is deprecated on GitHub Actions and will have periodic brownouts. See actions/virtual-environments#5583.