### PR TITLE
Do not chomp trailing line separator IO#each with nil separator and chomp

### DIFF
--- a/io.c
+++ b/io.c
@@ -3875,7 +3875,6 @@ rb_io_getline_0(VALUE rs, long limit, int chomp, rb_io_t *fptr)
     if (NIL_P(rs) && limit < 0) {
         str = read_all(fptr, 0, Qnil);
         if (RSTRING_LEN(str) == 0) return Qnil;
-        if (chomp) rb_str_chomp_string(str, rb_default_rs);
     }
     else if (limit == 0) {
         return rb_enc_str_new(0, 0, io_read_encoding(fptr));

--- a/spec/ruby/core/io/shared/each.rb
+++ b/spec/ruby/core/io/shared/each.rb
@@ -190,10 +190,20 @@ describe :io_each, shared: true do
   end
 
   describe "when passed chomp and nil as a separator" do
-    it "yields self's content without trailing new line character" do
-      @io.pos = 100
-      @io.send(@method, nil, chomp: true) { |s| ScratchPad << s }
-      ScratchPad.recorded.should == ["qui a linha cinco.\nHere is line six."]
+    ruby_version_is "3.2" do
+      it "yields self's content" do
+        @io.pos = 100
+        @io.send(@method, nil, chomp: true) { |s| ScratchPad << s }
+        ScratchPad.recorded.should == ["qui a linha cinco.\nHere is line six.\n"]
+      end
+    end
+
+    ruby_version_is ""..."3.2" do
+      it "yields self's content without trailing new line character" do
+        @io.pos = 100
+        @io.send(@method, nil, chomp: true) { |s| ScratchPad << s }
+        ScratchPad.recorded.should == ["qui a linha cinco.\nHere is line six."]
+      end
     end
   end
 

--- a/test/ruby/test_io.rb
+++ b/test/ruby/test_io.rb
@@ -312,7 +312,7 @@ class TestIO < Test::Unit::TestCase
       w.print "a\n\nb\n\n"
       w.close
     end, proc do |r|
-      assert_equal "a\n\nb\n", r.gets(nil, chomp: true)
+      assert_equal("a\n\nb\n\n", r.gets(nil, chomp: true), "[Bug #18770]")
       assert_nil r.gets("")
       r.close
     end)
@@ -1893,6 +1893,20 @@ class TestIO < Test::Unit::TestCase
       assert_equal("bar\n", e.next)
       assert_equal("baz\n", e.next)
       assert_raise(StopIteration) { e.next }
+    end)
+
+    pipe(proc do |w|
+      w.write "foo\n"
+      w.close
+    end, proc do |r|
+      assert_equal(["foo\n"], r.each_line(nil, chomp: true).to_a, "[Bug #18770]")
+    end)
+
+    pipe(proc do |w|
+      w.write "foo\n"
+      w.close
+    end, proc do |r|
+      assert_equal(["fo", "o\n"], r.each_line(nil, 2, chomp: true).to_a, "[Bug #18770]")
     end)
   end
 


### PR DESCRIPTION
nil separator means no sepator, so chomp should not remove a line
separator.

Partially Fixes [Bug #18770]