### PR TITLE
Revert "objspace_dump.c: skip dumping method name if not pure ASCII"

### DIFF
--- a/ext/objspace/objspace_dump.c
+++ b/ext/objspace/objspace_dump.c
@@ -547,10 +547,8 @@ dump_object(VALUE obj, struct dump_config *dc)
         }
         if (RTEST(ainfo->mid)) {
             VALUE m = rb_sym2str(ainfo->mid);
-            if (dump_string_ascii_only(RSTRING_PTR(m), RSTRING_LEN(m))) {
-                dump_append(dc, ", \"method\":");
-                dump_append_string_value(dc, m);
-            }
+            dump_append(dc, ", \"method\":");
+            dump_append_string_value(dc, m);
         }
         dump_append(dc, ", \"generation\":");
         dump_append_sizet(dc, ainfo->generation);

--- a/test/objspace/test_objspace.rb
+++ b/test/objspace/test_objspace.rb
@@ -725,17 +725,4 @@ class TestObjSpace < Test::Unit::TestCase
       assert_equal '42', out[2]
     end
   end
-
-  def test_utf8_method_names
-    obj = ObjectSpace.trace_object_allocations do
-      utf8_❨╯°□°❩╯︵┻━┻
-    end
-    assert_nil JSON.parse(ObjectSpace.dump(obj))["method"]
-  end
-
-  private
-
-  def utf8_❨╯°□°❩╯︵┻━┻
-    "1" + "2"
-  end
 end


### PR DESCRIPTION
Reverts ruby/ruby#6161

The test seem to have flaked on CI, I will look at it next week but in the meantime I'd rather not add to the CI flakiness.

http://ci.rvm.jp/logfiles/brlog.trunk-random1.20220721-164728