### PR TITLE
Dump non-ASCII char as unsigned

### DIFF
--- a/ext/objspace/objspace_dump.c
+++ b/ext/objspace/objspace_dump.c
@@ -142,7 +142,7 @@ dump_append_sizet(struct dump_config *dc, const size_t number)
 }
 
 static void
-dump_append_c(struct dump_config *dc, char c)
+dump_append_c(struct dump_config *dc, unsigned char c)
 {
     if (c <= 0x1f) {
         const unsigned int width = (sizeof(c) * CHAR_BIT / 4) + 5;

--- a/ext/objspace/objspace_dump.c
+++ b/ext/objspace/objspace_dump.c
@@ -145,7 +145,7 @@ static void
 dump_append_c(struct dump_config *dc, unsigned char c)
 {
     if (c <= 0x1f) {
-        const unsigned int width = (sizeof(c) * CHAR_BIT / 4) + 5;
+        const unsigned int width = rb_strlen_lit("\\u0000") + 1;
         buffer_ensure_capa(dc, width);
         unsigned long required = snprintf(dc->buffer + dc->buffer_len, width, "\\u00%02x", c);
         RUBY_ASSERT(required <= width);
@@ -163,7 +163,7 @@ dump_append_ref(struct dump_config *dc, VALUE ref)
 {
     RUBY_ASSERT(ref > 0);
 
-    char buffer[((sizeof(VALUE) * CHAR_BIT + 3) / 4) + 4];
+    char buffer[roomof(sizeof(VALUE) * CHAR_BIT, 4) + rb_strlen_lit("\"0x\"")];
     char *buffer_start, *buffer_end;
 
     buffer_start = buffer_end = &buffer[sizeof(buffer)];
@@ -481,7 +481,8 @@ dump_object(VALUE obj, struct dump_config *dc)
                 dump_append(dc, ", \"name\":\"");
                 dump_append(dc, RSTRING_PTR(mod_name));
                 dump_append(dc, "\"");
-            } else {
+            }
+            else {
                 VALUE real_mod_name = rb_mod_name(rb_class_real(obj));
                 if (RTEST(real_mod_name)) {
                     dump_append(dc, ", \"real_class_name\":\"");
@@ -625,7 +626,8 @@ dump_output(struct dump_config *dc, VALUE output, VALUE full, VALUE since)
     if (TYPE(output) == T_STRING) {
         dc->stream = Qfalse;
         dc->string = output;
-    } else {
+    }
+    else {
         dc->stream = output;
         dc->string = Qfalse;
     }
@@ -637,7 +639,8 @@ dump_output(struct dump_config *dc, VALUE output, VALUE full, VALUE since)
     if (RTEST(since)) {
         dc->partial_dump = 1;
         dc->since = NUM2SIZET(since);
-    } else {
+    }
+    else {
         dc->partial_dump = 0;
     }
 }
@@ -649,7 +652,8 @@ dump_result(struct dump_config *dc)
 
     if (dc->string) {
         return dc->string;
-    } else {
+    }
+    else {
         rb_io_flush(dc->stream);
         return dc->stream;
     }

--- a/test/objspace/test_objspace.rb
+++ b/test/objspace/test_objspace.rb
@@ -725,4 +725,19 @@ class TestObjSpace < Test::Unit::TestCase
       assert_equal '42', out[2]
     end
   end
+
+  def test_utf8_method_names
+    name = "utf8_❨╯°□°❩╯︵┻━┻"
+    obj = ObjectSpace.trace_object_allocations do
+      __send__(name)
+    end
+    dump = ObjectSpace.dump(obj)
+    assert_equal name, JSON.parse(dump)["method"], dump
+  end
+
+  private
+
+  def utf8_❨╯°□°❩╯︵┻━┻
+    "1#{2}"
+  end
 end


### PR DESCRIPTION
Non-ASCII code may be negative on platforms plain char is signed.