### PR TITLE
Move enum definitions out of struct definition

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -1320,7 +1320,7 @@ new_insn_send(rb_iseq_t *iseq, const NODE *const line_node, ID id, VALUE argc, c
 
 static rb_iseq_t *
 new_child_iseq(rb_iseq_t *iseq, const NODE *const node,
-               VALUE name, const rb_iseq_t *parent, enum iseq_type type, int line_no)
+               VALUE name, const rb_iseq_t *parent, enum rb_iseq_type type, int line_no)
 {
     rb_iseq_t *ret_iseq;
     rb_ast_body_t ast;
@@ -1342,7 +1342,7 @@ new_child_iseq(rb_iseq_t *iseq, const NODE *const node,
 
 static rb_iseq_t *
 new_child_iseq_with_callback(rb_iseq_t *iseq, const struct rb_iseq_new_with_callback_callback_func *ifunc,
-                     VALUE name, const rb_iseq_t *parent, enum iseq_type type, int line_no)
+                     VALUE name, const rb_iseq_t *parent, enum rb_iseq_type type, int line_no)
 {
     rb_iseq_t *ret_iseq;
 
@@ -1418,7 +1418,7 @@ iseq_insert_nop_between_end_and_cont(rb_iseq_t *iseq)
         LINK_ELEMENT *cont = (LINK_ELEMENT *)(ptr[4] & ~1);
         LINK_ELEMENT *e;
 
-        enum catch_type ct = (enum catch_type)(ptr[0] & 0xffff);
+        enum rb_catch_type ct = (enum rb_catch_type)(ptr[0] & 0xffff);
 
         if (ct != CATCH_TYPE_BREAK
             && ct != CATCH_TYPE_NEXT
@@ -2607,7 +2607,7 @@ iseq_set_exception_table(rb_iseq_t *iseq)
         for (i = 0; i < table->size; i++) {
             ptr = RARRAY_CONST_PTR_TRANSIENT(tptr[i]);
             entry = UNALIGNED_MEMBER_PTR(table, entries[i]);
-            entry->type = (enum catch_type)(ptr[0] & 0xffff);
+            entry->type = (enum rb_catch_type)(ptr[0] & 0xffff);
             entry->start = label_get_position((LABEL *)(ptr[1] & ~1));
             entry->end = label_get_position((LABEL *)(ptr[2] & ~1));
             entry->iseq = (rb_iseq_t *)ptr[3];
@@ -7692,9 +7692,9 @@ compile_return(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, 
     const NODE *line_node = node;
 
     if (iseq) {
-        enum iseq_type type = ISEQ_BODY(iseq)->type;
+        enum rb_iseq_type type = ISEQ_BODY(iseq)->type;
         const rb_iseq_t *is = iseq;
-        enum iseq_type t = type;
+        enum rb_iseq_type t = type;
         const NODE *retval = node->nd_stts;
         LABEL *splabel = 0;
 
@@ -11575,7 +11575,7 @@ ibf_load_catch_table(const struct ibf_load *load, ibf_offset_t catch_table_offse
         unsigned int i;
         for (i=0; i<table->size; i++) {
             int iseq_index = (int)ibf_load_small_value(load, &reading_pos);
-            table->entries[i].type = (enum catch_type)ibf_load_small_value(load, &reading_pos);
+            table->entries[i].type = (enum rb_catch_type)ibf_load_small_value(load, &reading_pos);
             table->entries[i].start = (unsigned int)ibf_load_small_value(load, &reading_pos);
             table->entries[i].end = (unsigned int)ibf_load_small_value(load, &reading_pos);
             table->entries[i].cont = (unsigned int)ibf_load_small_value(load, &reading_pos);

--- a/include/ruby/io.h
+++ b/include/ruby/io.h
@@ -98,6 +98,34 @@ PACKED_STRUCT_UNALIGNED(struct rb_io_buffer_t {
 /** @alias{rb_io_buffer_t} */
 typedef struct rb_io_buffer_t rb_io_buffer_t;
 
+/** Decomposed encoding flags (e.g. `"enc:enc2""`). */
+/*
+ * enc  enc2 read action                      write action
+ * NULL NULL force_encoding(default_external) write the byte sequence of str
+ * e1   NULL force_encoding(e1)               convert str.encoding to e1
+ * e1   e2   convert from e2 to e1            convert str.encoding to e2
+ */
+struct rb_io_enc_t {
+    /** Internal encoding. */
+    rb_encoding *enc;
+    /** External encoding. */
+    rb_encoding *enc2;
+    /**
+     * Flags.
+     *
+     * @see enum ::ruby_econv_flag_type
+     */
+    int ecflags;
+    /**
+     * Flags as Ruby hash.
+     *
+     * @internal
+     *
+     * This is set.  But used from nowhere maybe?
+     */
+    VALUE ecopts;
+};
+
 /** Ruby's IO, metadata and buffers. */
 typedef struct rb_io_t {
 
@@ -141,36 +169,7 @@ typedef struct rb_io_t {
      */
     VALUE tied_io_for_writing;
 
-    /** Decomposed encoding flags (e.g. `"enc:enc2""`). */
-    /*
-     * enc  enc2 read action                      write action
-     * NULL NULL force_encoding(default_external) write the byte sequence of str
-     * e1   NULL force_encoding(e1)               convert str.encoding to e1
-     * e1   e2   convert from e2 to e1            convert str.encoding to e2
-     */
-    struct rb_io_enc_t {
-        /** Internal encoding. */
-        rb_encoding *enc;
-
-        /** External encoding. */
-        rb_encoding *enc2;
-
-        /**
-         * Flags.
-         *
-         * @see enum ::ruby_econv_flag_type
-         */
-        int ecflags;
-
-        /**
-         * Flags as Ruby hash.
-         *
-         * @internal
-         *
-         * This is set.  But used from nowhere maybe?
-         */
-        VALUE ecopts;
-    } encs; /**< Decomposed encoding flags. */
+    struct rb_io_enc_t encs; /**< Decomposed encoding flags. */
 
     /** Encoding converter used when reading from this IO. */
     rb_econv_t *readconv;

--- a/iseq.c
+++ b/iseq.c
@@ -723,7 +723,7 @@ new_arena(void)
 static VALUE
 prepare_iseq_build(rb_iseq_t *iseq,
                    VALUE name, VALUE path, VALUE realpath, VALUE first_lineno, const rb_code_location_t *code_location, const int node_id,
-                   const rb_iseq_t *parent, int isolated_depth, enum iseq_type type,
+                   const rb_iseq_t *parent, int isolated_depth, enum rb_iseq_type type,
                    VALUE script_lines, const rb_compile_option_t *option)
 {
     VALUE coverage = Qfalse;
@@ -947,7 +947,7 @@ make_compile_option_value(rb_compile_option_t *option)
 
 rb_iseq_t *
 rb_iseq_new(const rb_ast_body_t *ast, VALUE name, VALUE path, VALUE realpath,
-            const rb_iseq_t *parent, enum iseq_type type)
+            const rb_iseq_t *parent, enum rb_iseq_type type)
 {
     return rb_iseq_new_with_opt(ast, name, path, realpath, INT2FIX(0), parent,
                                 0, type, &COMPILE_OPTION_DEFAULT);
@@ -1015,7 +1015,7 @@ iseq_translate(rb_iseq_t *iseq)
 rb_iseq_t *
 rb_iseq_new_with_opt(const rb_ast_body_t *ast, VALUE name, VALUE path, VALUE realpath,
                      VALUE first_lineno, const rb_iseq_t *parent, int isolated_depth,
-                     enum iseq_type type, const rb_compile_option_t *option)
+                     enum rb_iseq_type type, const rb_compile_option_t *option)
 {
     const NODE *node = ast ? ast->root : 0;
     /* TODO: argument check */
@@ -1053,7 +1053,7 @@ rb_iseq_new_with_callback(
     const struct rb_iseq_new_with_callback_callback_func * ifunc,
     VALUE name, VALUE path, VALUE realpath,
     VALUE first_lineno, const rb_iseq_t *parent,
-    enum iseq_type type, const rb_compile_option_t *option)
+    enum rb_iseq_type type, const rb_compile_option_t *option)
 {
     /* TODO: argument check */
     rb_iseq_t *iseq = iseq_alloc();
@@ -1085,7 +1085,7 @@ rb_iseq_load_iseq(VALUE fname)
 #define CHECK_SYMBOL(v)  rb_to_symbol_type(v)
 static inline VALUE CHECK_INTEGER(VALUE v) {(void)NUM2LONG(v); return v;}
 
-static enum iseq_type
+static enum rb_iseq_type
 iseq_type_from_sym(VALUE type)
 {
     const ID id_top = rb_intern("top");
@@ -1109,7 +1109,7 @@ iseq_type_from_sym(VALUE type)
     if (typeid == id_eval) return ISEQ_TYPE_EVAL;
     if (typeid == id_main) return ISEQ_TYPE_MAIN;
     if (typeid == id_plain) return ISEQ_TYPE_PLAIN;
-    return (enum iseq_type)-1;
+    return (enum rb_iseq_type)-1;
 }
 
 static VALUE
@@ -1155,7 +1155,7 @@ iseq_load(VALUE data, const rb_iseq_t *parent, VALUE opt)
     ISEQ_BODY(iseq)->local_iseq = iseq;
 
     iseq_type = iseq_type_from_sym(type);
-    if (iseq_type == (enum iseq_type)-1) {
+    if (iseq_type == (enum rb_iseq_type)-1) {
         rb_raise(rb_eTypeError, "unsupported type: :%"PRIsVALUE, rb_sym2str(type));
     }
 
@@ -1172,7 +1172,7 @@ iseq_load(VALUE data, const rb_iseq_t *parent, VALUE opt)
     make_compile_option(&option, opt);
     option.peephole_optimization = FALSE; /* because peephole optimization can modify original iseq */
     prepare_iseq_build(iseq, name, path, realpath, first_lineno, &tmp_loc, NUM2INT(node_id),
-                       parent, 0, (enum iseq_type)iseq_type, Qnil, &option);
+                       parent, 0, (enum rb_iseq_type)iseq_type, Qnil, &option);
 
     rb_iseq_build_from_ary(iseq, misc, locals, params, exception, body);
 
@@ -1311,7 +1311,7 @@ rb_iseq_code_location(const rb_iseq_t *iseq, int *beg_pos_lineno, int *beg_pos_c
     if (end_pos_column) *end_pos_column = loc->end_pos.column;
 }
 
-static ID iseq_type_id(enum iseq_type type);
+static ID iseq_type_id(enum rb_iseq_type type);
 
 VALUE
 rb_iseq_type(const rb_iseq_t *iseq)
@@ -2839,7 +2839,7 @@ static const rb_data_type_t label_wrapper = {
   id_##name = rb_intern(#name)
 
 static VALUE
-iseq_type_id(enum iseq_type type)
+iseq_type_id(enum rb_iseq_type type)
 {
     DECL_ID(top);
     DECL_ID(method);

--- a/iseq.h
+++ b/iseq.h
@@ -253,7 +253,7 @@ struct iseq_insn_info_entry {
  *   CATCH_TYPE_REDO, CATCH_TYPE_NEXT:
  *     NULL.
  */
-enum catch_type {
+enum rb_catch_type {
     CATCH_TYPE_RESCUE = INT2FIX(1),
     CATCH_TYPE_ENSURE = INT2FIX(2),
     CATCH_TYPE_RETRY  = INT2FIX(3),
@@ -263,7 +263,7 @@ enum catch_type {
 };
 
 struct iseq_catch_table_entry {
-    enum catch_type type;
+    enum rb_catch_type type;
     rb_iseq_t *iseq;
 
     unsigned int start;

--- a/iseq.h
+++ b/iseq.h
@@ -241,28 +241,29 @@ struct iseq_insn_info_entry {
     rb_event_flag_t events;
 };
 
-struct iseq_catch_table_entry {
-    enum catch_type {
-        CATCH_TYPE_RESCUE = INT2FIX(1),
-        CATCH_TYPE_ENSURE = INT2FIX(2),
-        CATCH_TYPE_RETRY  = INT2FIX(3),
-        CATCH_TYPE_BREAK  = INT2FIX(4),
-        CATCH_TYPE_REDO   = INT2FIX(5),
-        CATCH_TYPE_NEXT   = INT2FIX(6)
-    } type;
+/*
+ * iseq type:
+ *   CATCH_TYPE_RESCUE, CATCH_TYPE_ENSURE:
+ *     use iseq as continuation.
+ *
+ *   CATCH_TYPE_BREAK (iter):
+ *     use iseq as key.
+ *
+ *   CATCH_TYPE_BREAK (while), CATCH_TYPE_RETRY,
+ *   CATCH_TYPE_REDO, CATCH_TYPE_NEXT:
+ *     NULL.
+ */
+enum catch_type {
+    CATCH_TYPE_RESCUE = INT2FIX(1),
+    CATCH_TYPE_ENSURE = INT2FIX(2),
+    CATCH_TYPE_RETRY  = INT2FIX(3),
+    CATCH_TYPE_BREAK  = INT2FIX(4),
+    CATCH_TYPE_REDO   = INT2FIX(5),
+    CATCH_TYPE_NEXT   = INT2FIX(6)
+};
 
-    /*
-     * iseq type:
-     *   CATCH_TYPE_RESCUE, CATCH_TYPE_ENSURE:
-     *     use iseq as continuation.
-     *
-     *   CATCH_TYPE_BREAK (iter):
-     *     use iseq as key.
-     *
-     *   CATCH_TYPE_BREAK (while), CATCH_TYPE_RETRY,
-     *   CATCH_TYPE_REDO, CATCH_TYPE_NEXT:
-     *     NULL.
-     */
+struct iseq_catch_table_entry {
+    enum catch_type type;
     rb_iseq_t *iseq;
 
     unsigned int start;

--- a/ractor.c
+++ b/ractor.c
@@ -493,13 +493,13 @@ ractor_try_receive(rb_execution_context_t *ec, rb_ractor_t *r)
 }
 
 static bool
-ractor_sleeping_by(const rb_ractor_t *r, enum ractor_wait_status wait_status)
+ractor_sleeping_by(const rb_ractor_t *r, enum rb_ractor_wait_status wait_status)
 {
     return (r->sync.wait.status & wait_status) && r->sync.wait.wakeup_status == wakeup_none;
 }
 
 static bool
-ractor_wakeup(rb_ractor_t *r, enum ractor_wait_status wait_status, enum ractor_wakeup_status wakeup_status)
+ractor_wakeup(rb_ractor_t *r, enum rb_ractor_wait_status wait_status, enum rb_ractor_wakeup_status wakeup_status)
 {
     ASSERT_ractor_locking(r);
 
@@ -547,7 +547,7 @@ ractor_sleep_interrupt(void *ptr)
 
 #if USE_RUBY_DEBUG_LOG
 static const char *
-wait_status_str(enum ractor_wait_status wait_status)
+wait_status_str(enum rb_ractor_wait_status wait_status)
 {
     switch ((int)wait_status) {
       case wait_none: return "none";
@@ -563,7 +563,7 @@ wait_status_str(enum ractor_wait_status wait_status)
 }
 
 static const char *
-wakeup_status_str(enum ractor_wakeup_status wakeup_status)
+wakeup_status_str(enum rb_ractor_wakeup_status wakeup_status)
 {
     switch (wakeup_status) {
       case wakeup_none: return "none";
@@ -1035,7 +1035,7 @@ ractor_try_yield(rb_execution_context_t *ec, rb_ractor_t *cr, struct rb_ractor_b
                 VM_ASSERT(r->sync.wait.taken_basket.type == basket_type_none);
 
                 if (basket->type == basket_type_move) {
-                    enum ractor_wait_status prev_wait_status = r->sync.wait.status;
+                    enum rb_ractor_wait_status prev_wait_status = r->sync.wait.status;
                     r->sync.wait.status = wait_moving;
 
                     RACTOR_UNLOCK(r);
@@ -1090,7 +1090,7 @@ ractor_select(rb_execution_context_t *ec, const VALUE *rs, const int rs_len, VAL
     VALUE ret = Qundef;
     int i;
     bool interrupted = false;
-    enum ractor_wait_status wait_status = 0;
+    enum rb_ractor_wait_status wait_status = 0;
     bool yield_p = (yielded_value != Qundef) ? true : false;
     const int alen = rs_len + (yield_p ? 1 : 0);
 
@@ -1264,7 +1264,7 @@ ractor_select(rb_execution_context_t *ec, const VALUE *rs, const int rs_len, VAL
         }
 
         // check results
-        enum ractor_wakeup_status wakeup_status = cr->sync.wait.wakeup_status;
+        enum rb_ractor_wakeup_status wakeup_status = cr->sync.wait.wakeup_status;
         cr->sync.wait.wakeup_status = wakeup_none;
 
         switch (wakeup_status) {

--- a/ractor_core.h
+++ b/ractor_core.h
@@ -40,7 +40,7 @@ struct rb_ractor_waiting_list {
     rb_ractor_t **ractors;
 };
 
-enum ractor_wait_status {
+enum rb_ractor_wait_status {
     wait_none      = 0x00,
     wait_receiving = 0x01,
     wait_taking    = 0x02,
@@ -48,7 +48,7 @@ enum ractor_wait_status {
     wait_moving    = 0x08,
 };
 
-enum ractor_wakeup_status {
+enum rb_ractor_wakeup_status {
     wakeup_none,
     wakeup_by_send,
     wakeup_by_yield,
@@ -74,8 +74,8 @@ struct rb_ractor_sync {
     bool outgoing_port_closed;
 
     struct ractor_wait {
-        enum ractor_wait_status status;
-        enum ractor_wakeup_status wakeup_status;
+        enum rb_ractor_wait_status status;
+        enum rb_ractor_wakeup_status wakeup_status;
         struct rb_ractor_basket yielded_basket;
         struct rb_ractor_basket taken_basket;
     } wait;

--- a/ractor_core.h
+++ b/ractor_core.h
@@ -40,6 +40,24 @@ struct rb_ractor_waiting_list {
     rb_ractor_t **ractors;
 };
 
+enum ractor_wait_status {
+    wait_none      = 0x00,
+    wait_receiving = 0x01,
+    wait_taking    = 0x02,
+    wait_yielding  = 0x04,
+    wait_moving    = 0x08,
+};
+
+enum ractor_wakeup_status {
+    wakeup_none,
+    wakeup_by_send,
+    wakeup_by_yield,
+    wakeup_by_take,
+    wakeup_by_close,
+    wakeup_by_interrupt,
+    wakeup_by_retry,
+};
+
 struct rb_ractor_sync {
     // ractor lock
     rb_nativethread_lock_t lock;
@@ -56,27 +74,32 @@ struct rb_ractor_sync {
     bool outgoing_port_closed;
 
     struct ractor_wait {
-        enum ractor_wait_status {
-            wait_none      = 0x00,
-            wait_receiving = 0x01,
-            wait_taking    = 0x02,
-            wait_yielding  = 0x04,
-            wait_moving    = 0x08,
-        } status;
-
-        enum ractor_wakeup_status {
-            wakeup_none,
-            wakeup_by_send,
-            wakeup_by_yield,
-            wakeup_by_take,
-            wakeup_by_close,
-            wakeup_by_interrupt,
-            wakeup_by_retry,
-        } wakeup_status;
-
+        enum ractor_wait_status status;
+        enum ractor_wakeup_status wakeup_status;
         struct rb_ractor_basket yielded_basket;
         struct rb_ractor_basket taken_basket;
     } wait;
+};
+
+// created
+//   | ready to run
+// ====================== inserted to vm->ractor
+//   v
+// blocking <---+ all threads are blocking
+//   |          |
+//   v          |
+// running -----+
+//   | all threads are terminated.
+// ====================== removed from vm->ractor
+//   v
+// terminated
+//
+// status is protected by VM lock (global state)
+enum ractor_status {
+    ractor_created,
+    ractor_running,
+    ractor_blocking,
+    ractor_terminated,
 };
 
 struct rb_ractor_struct {
@@ -104,27 +127,7 @@ struct rb_ractor_struct {
     VALUE name;
     VALUE loc;
 
-    // created
-    //   | ready to run
-    // ====================== inserted to vm->ractor
-    //   v
-    // blocking <---+ all threads are blocking
-    //   |          |
-    //   v          |
-    // running -----+
-    //   | all threads are terminated.
-    // ====================== removed from vm->ractor
-    //   v
-    // terminated
-    //
-    // status is protected by VM lock (global state)
-
-    enum ractor_status {
-        ractor_created,
-        ractor_running,
-        ractor_blocking,
-        ractor_terminated,
-    } status_;
+    enum ractor_status status_;
 
     struct ccan_list_node vmlr_node;
 

--- a/vm.c
+++ b/vm.c
@@ -2435,7 +2435,7 @@ vm_exec_handle_exception(rb_execution_context_t *ec, enum ruby_tag_type state,
         else if ((state == TAG_BREAK && !escape_cfp) ||
                  (state == TAG_REDO) ||
                  (state == TAG_NEXT)) {
-            type = (const enum catch_type[TAG_MASK]) {
+            type = (const enum rb_catch_type[TAG_MASK]) {
                 [TAG_BREAK]  = CATCH_TYPE_BREAK,
                 [TAG_NEXT]   = CATCH_TYPE_NEXT,
                 [TAG_REDO]   = CATCH_TYPE_REDO,

--- a/vm_core.h
+++ b/vm_core.h
@@ -339,18 +339,21 @@ typedef uintptr_t iseq_bits_t;
 
 #define ISEQ_IS_SIZE(body) (body->ic_size + body->ivc_size + body->ise_size + body->icvarc_size)
 
+/* instruction sequence type */
+enum iseq_type {
+    ISEQ_TYPE_TOP,
+    ISEQ_TYPE_METHOD,
+    ISEQ_TYPE_BLOCK,
+    ISEQ_TYPE_CLASS,
+    ISEQ_TYPE_RESCUE,
+    ISEQ_TYPE_ENSURE,
+    ISEQ_TYPE_EVAL,
+    ISEQ_TYPE_MAIN,
+    ISEQ_TYPE_PLAIN
+};
+
 struct rb_iseq_constant_body {
-    enum iseq_type {
-        ISEQ_TYPE_TOP,
-        ISEQ_TYPE_METHOD,
-        ISEQ_TYPE_BLOCK,
-        ISEQ_TYPE_CLASS,
-        ISEQ_TYPE_RESCUE,
-        ISEQ_TYPE_ENSURE,
-        ISEQ_TYPE_EVAL,
-        ISEQ_TYPE_MAIN,
-        ISEQ_TYPE_PLAIN
-    } type;              /* instruction sequence type */
+    enum iseq_type type;
 
     unsigned int iseq_size;
     VALUE *iseq_encoded; /* encoded iseq (insn addr and operands) */

--- a/vm_core.h
+++ b/vm_core.h
@@ -340,7 +340,7 @@ typedef uintptr_t iseq_bits_t;
 #define ISEQ_IS_SIZE(body) (body->ic_size + body->ivc_size + body->ise_size + body->icvarc_size)
 
 /* instruction sequence type */
-enum iseq_type {
+enum rb_iseq_type {
     ISEQ_TYPE_TOP,
     ISEQ_TYPE_METHOD,
     ISEQ_TYPE_BLOCK,
@@ -353,7 +353,7 @@ enum iseq_type {
 };
 
 struct rb_iseq_constant_body {
-    enum iseq_type type;
+    enum rb_iseq_type type;
 
     unsigned int iseq_size;
     VALUE *iseq_encoded; /* encoded iseq (insn addr and operands) */
@@ -1113,12 +1113,12 @@ typedef enum {
 RUBY_SYMBOL_EXPORT_BEGIN
 
 /* node -> iseq */
-rb_iseq_t *rb_iseq_new         (const rb_ast_body_t *ast, VALUE name, VALUE path, VALUE realpath,                     const rb_iseq_t *parent, enum iseq_type);
+rb_iseq_t *rb_iseq_new         (const rb_ast_body_t *ast, VALUE name, VALUE path, VALUE realpath,                     const rb_iseq_t *parent, enum rb_iseq_type);
 rb_iseq_t *rb_iseq_new_top     (const rb_ast_body_t *ast, VALUE name, VALUE path, VALUE realpath,                     const rb_iseq_t *parent);
 rb_iseq_t *rb_iseq_new_main    (const rb_ast_body_t *ast,             VALUE path, VALUE realpath,                     const rb_iseq_t *parent, int opt);
 rb_iseq_t *rb_iseq_new_eval    (const rb_ast_body_t *ast, VALUE name, VALUE path, VALUE realpath, VALUE first_lineno, const rb_iseq_t *parent, int isolated_depth);
 rb_iseq_t *rb_iseq_new_with_opt(const rb_ast_body_t *ast, VALUE name, VALUE path, VALUE realpath, VALUE first_lineno, const rb_iseq_t *parent, int isolated_depth,
-                                enum iseq_type, const rb_compile_option_t*);
+                                enum rb_iseq_type, const rb_compile_option_t*);
 
 struct iseq_link_anchor;
 struct rb_iseq_new_with_callback_callback_func {
@@ -1136,7 +1136,7 @@ rb_iseq_new_with_callback_new_callback(
 }
 rb_iseq_t *rb_iseq_new_with_callback(const struct rb_iseq_new_with_callback_callback_func * ifunc,
     VALUE name, VALUE path, VALUE realpath, VALUE first_lineno,
-    const rb_iseq_t *parent, enum iseq_type, const rb_compile_option_t*);
+    const rb_iseq_t *parent, enum rb_iseq_type, const rb_compile_option_t*);
 
 VALUE rb_iseq_disasm(const rb_iseq_t *iseq);
 int rb_iseq_disasm_insn(VALUE str, const VALUE *iseqval, size_t pos, const rb_iseq_t *iseq, VALUE child);


### PR DESCRIPTION
```
struct rb_iseq_constant_body {
    enum iseq_type {
        ISEQ_TYPE_TOP,
        ISEQ_TYPE_METHOD,
        ISEQ_TYPE_BLOCK,
        ISEQ_TYPE_CLASS,
        ISEQ_TYPE_RESCUE,
        ISEQ_TYPE_ENSURE,
        ISEQ_TYPE_EVAL,
        ISEQ_TYPE_MAIN,
        ISEQ_TYPE_PLAIN
    } type;              /* instruction sequence type */

    ...
```

Unfortunately, [vscode-cpptools cannot detect this defintion style](https://github.com/microsoft/vscode-cpptools/issues/4831). This changeset moves the enum definitions to the toplevel, and adds `rb_` prefixes to the type name.