### PR TITLE
[DOC] Process._fork does not get called by Process.daemon

### DIFF
--- a/process.c
+++ b/process.c
@@ -4354,8 +4354,8 @@ rb_call_proc__fork(void)
  *  libraries. You can add custom code before and after fork events
  *  by overriding this method.
  *
- *  Note: Process.daemon may be implemented using fork(2) in Linux and
- *  macOS (and possibly others) BUT does not go through this method.
+ *  Note: Process.daemon may be implemented using fork(2) in glibc (Linux),
+ *  libSystem (macOS), and possibly others BUT does not go through this method.
  *  Thus, depending on your reason to hook into this method, you
  *  may also want to hook into that one.
  *  See {this issue}[https://bugs.ruby-lang.org/issues/18911] for a

--- a/process.c
+++ b/process.c
@@ -4354,8 +4354,8 @@ rb_call_proc__fork(void)
  *  libraries. You can add custom code before and after fork events
  *  by overriding this method.
  *
- *  Note: Process.daemon may be implemented using fork(2) in glibc (Linux),
- *  libSystem (macOS), and possibly others BUT does not go through this method.
+ *  Note: Process.daemon may be implemented using fork(2) BUT does not go
+ *  through this method.
  *  Thus, depending on your reason to hook into this method, you
  *  may also want to hook into that one.
  *  See {this issue}[https://bugs.ruby-lang.org/issues/18911] for a

--- a/process.c
+++ b/process.c
@@ -4353,6 +4353,12 @@ rb_call_proc__fork(void)
  *  This method is not for casual code but for application monitoring
  *  libraries. You can add custom code before and after fork events
  *  by overriding this method.
+ *
+ *  Note: Process.daemon may be implemented using fork(2) in Linux and
+ *  macOS (and possibly others) BUT does not go through this method.
+ *  Thus, depending on your reason to hook into this method, you
+ *  may also want to hook into that one. See #18911 for a more
+ *  detailed discussion of this.
  */
 VALUE
 rb_proc__fork(VALUE _obj)

--- a/process.c
+++ b/process.c
@@ -4357,8 +4357,9 @@ rb_call_proc__fork(void)
  *  Note: Process.daemon may be implemented using fork(2) in Linux and
  *  macOS (and possibly others) BUT does not go through this method.
  *  Thus, depending on your reason to hook into this method, you
- *  may also want to hook into that one. See #18911 for a more
- *  detailed discussion of this.
+ *  may also want to hook into that one.
+ *  See {this issue}[https://bugs.ruby-lang.org/issues/18911] for a
+ *  more detailed discussion of this.
  */
 VALUE
 rb_proc__fork(VALUE _obj)


### PR DESCRIPTION
As discussed in #18911, I'm adding some documentation to `Process._fork` to clarify that it is not expected to cover calls to `Process.daemon`.

Issue [#18911](https://bugs.ruby-lang.org/issues/18911)