### PR TITLE
Remove reference counting for all frozen arrays

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -4369,7 +4369,7 @@ compile_array(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, int pop
 
             if ((first_chunk && stack_len == 0 && !node_tmp) || count >= min_tmp_ary_len) {
                 /* The literal contains only optimizable elements, or the subarray is long enough */
-                VALUE ary = rb_ary_literal_new(count);
+                VALUE ary = rb_ary_tmp_new(count);
 
                 /* Create a hidden array */
                 for (; count; count--, node = node->nd_next)
@@ -12349,7 +12349,7 @@ ibf_load_object_array(const struct ibf_load *load, const struct ibf_object_heade
 
     const long len = (long)ibf_load_small_value(load, &reading_pos);
 
-    VALUE ary = header->internal ? rb_ary_literal_new(len) : rb_ary_new_capa(len);
+    VALUE ary = header->frozen ? rb_ary_tmp_new(len) : rb_ary_new_capa(len);
     int i;
 
     for (i=0; i<len; i++) {

--- a/internal/array.h
+++ b/internal/array.h
@@ -21,7 +21,6 @@
 #define RARRAY_SHARED_FLAG      ELTS_SHARED
 #define RARRAY_SHARED_ROOT_FLAG FL_USER12
 #define RARRAY_PTR_IN_USE_FLAG  FL_USER14
-#define RARRAY_LITERAL_FLAG     FL_USER15
 
 /* array.c */
 VALUE rb_ary_last(int, const VALUE *, VALUE);
@@ -36,7 +35,6 @@ void rb_ary_cancel_sharing(VALUE ary);
 size_t rb_ary_size_as_embedded(VALUE ary);
 void rb_ary_make_embedded(VALUE ary);
 bool rb_ary_embeddable_p(VALUE ary);
-VALUE rb_ary_literal_new(long capa);
 
 static inline VALUE rb_ary_entry_internal(VALUE ary, long offset);
 static inline bool ARY_PTR_USING_P(VALUE ary);
@@ -118,13 +116,6 @@ ARY_SHARED_ROOT_REFCNT(VALUE ary)
 {
     assert(ARY_SHARED_ROOT_P(ary));
     return RARRAY(ary)->as.heap.aux.capa;
-}
-
-static inline bool
-ARY_LITERAL_P(VALUE ary)
-{
-    assert(RB_TYPE_P(ary, T_ARRAY));
-    return FL_TEST_RAW(ary, RARRAY_LITERAL_FLAG);
 }
 
 static inline void


### PR DESCRIPTION
The `RARRAY_LITERAL_FLAG` was added in commit 5871ecf956711fcacad7c03f2aef95115ed25bc4 to improve CoW performance for array literals by not keeping track of reference counts.

This commit reverts that commit and has an alternate implementation that is more generic for all frozen arrays. Since frozen arrays cannot be modified, we don't need to set the `RARRAY_SHARED_ROOT_FLAG` and we don't need to do reference counting.