### PR TITLE
[DOC] IO#eof

### DIFF
--- a/io.c
+++ b/io.c
@@ -2484,7 +2484,7 @@ io_fillbuf(rb_io_t *fptr)
  *  IO#sysread may not behave as you intend with IO#eof?, unless you
  *  call IO#rewind first (which is not available for some streams).
  *
- *  I#eof? is an alias for IO#eof.
+ *  IO#eof? is an alias for IO#eof.
  *
  */
 


### PR DESCRIPTION
Use IO#eof? instead of I#eof?