### PR TITLE
string.c: query the real capacity with malloc_usable_size

### DIFF
--- a/benchmark/string_expand.yml
+++ b/benchmark/string_expand.yml
@@ -1,0 +1,9 @@
+prelude: |
+  START = "a" * 23
+  buffer = ""
+  START.ascii_only?
+  GC.disable
+benchmark:
+  string_expand: |
+    buffer.replace(START)
+    buffer << buffer << buffer << buffer << buffer << buffer << buffer << buffer << buffer << buffer

--- a/string.c
+++ b/string.c
@@ -178,6 +178,7 @@ str_enc_fastpath(VALUE str)
     RESIZE_CAPA_TERM(str,capacity,termlen);\
 } while (0)
 #ifdef HAVE_MALLOC_USABLE_SIZE
+#include <malloc.h>
 #define REAL_CAPA(ptr, capa, termlen) malloc_usable_size(ptr) - termlen
 #else
 #define REAL_CAPA(ptr, capa, termlen) capa


### PR DESCRIPTION
Different allocators will have different slab sizes. Ruby is being quite naive when allocating space for strings, if we were to query the real usable size of string buffers, we may be able to save a few allocations and also report more accurate memory usage.

The concern however is how much of an overhead `malloc_usable_size` is. According to https://lemire.me/blog/2017/09/15/how-fast-are-malloc_size-and-malloc_usable_size-in-c/, it's about 10 CPU cycles on Linux which isn't bad at all. However Linux is kind of a broad term. Different people run different allocators, so millage may vary.