### PR TITLE
Rename rb_ary_tmp_new to rb_ary_hidden_new

### DIFF
--- a/array.c
+++ b/array.c
@@ -1025,14 +1025,6 @@ rb_ary_memsize(VALUE ary)
     }
 }
 
-static inline void
-ary_discard(VALUE ary)
-{
-    rb_ary_free(ary);
-    RBASIC(ary)->flags |= RARRAY_EMBED_FLAG;
-    RBASIC(ary)->flags &= ~(RARRAY_EMBED_LEN_MASK | RARRAY_TRANSIENT_FLAG);
-}
-
 static VALUE
 ary_make_shared(VALUE ary)
 {
@@ -6938,7 +6930,6 @@ rb_ary_cycle(int argc, VALUE *argv, VALUE ary)
 }
 
 #define tmpary(n) rb_ary_tmp_new(n)
-#define tmpary_discard(a) (ary_discard(a), RBASIC_SET_CLASS_RAW(a, rb_cArray))
 
 /*
  * Build a ruby array of the corresponding values and yield it to the
@@ -7711,8 +7702,8 @@ rb_ary_product(int argc, VALUE *argv, VALUE ary)
             counters[m]++;
         }
     }
+
 done:
-    tmpary_discard(t0);
     ALLOCV_END(t1);
 
     return NIL_P(result) ? ary : result;

--- a/array.c
+++ b/array.c
@@ -977,10 +977,9 @@ rb_ary_hidden_new(long capa)
 VALUE
 rb_ary_hidden_new_fill(long capa)
 {
-    VALUE ary = ary_new(0, capa);
+    VALUE ary = rb_ary_hidden_new(capa);
     ary_memfill(ary, 0, capa, Qnil);
     ARY_SET_LEN(ary, capa);
-    rb_ary_transient_heap_evacuate(ary, TRUE);
     return ary;
 }
 

--- a/array.c
+++ b/array.c
@@ -967,7 +967,7 @@ rb_ec_ary_new_from_values(rb_execution_context_t *ec, long n, const VALUE *elts)
 }
 
 VALUE
-rb_ary_tmp_new(long capa)
+rb_ary_hidden_new(long capa)
 {
     VALUE ary = ary_new(0, capa);
     rb_ary_transient_heap_evacuate(ary, TRUE);
@@ -975,7 +975,7 @@ rb_ary_tmp_new(long capa)
 }
 
 VALUE
-rb_ary_tmp_new_fill(long capa)
+rb_ary_hidden_new_fill(long capa)
 {
     VALUE ary = ary_new(0, capa);
     ary_memfill(ary, 0, capa, Qnil);
@@ -5101,7 +5101,7 @@ rb_ary_concat_multi(int argc, VALUE *argv, VALUE ary)
     }
     else if (argc > 1) {
         int i;
-        VALUE args = rb_ary_tmp_new(argc);
+        VALUE args = rb_ary_hidden_new(argc);
         for (i = 0; i < argc; i++) {
             rb_ary_concat(args, argv[i]);
         }
@@ -6929,8 +6929,6 @@ rb_ary_cycle(int argc, VALUE *argv, VALUE ary)
     return Qnil;
 }
 
-#define tmpary(n) rb_ary_tmp_new(n)
-
 /*
  * Build a ruby array of the corresponding values and yield it to the
  * associated block.
@@ -7625,7 +7623,7 @@ static VALUE
 rb_ary_product(int argc, VALUE *argv, VALUE ary)
 {
     int n = argc+1;    /* How many arrays we're operating on */
-    volatile VALUE t0 = tmpary(n);
+    volatile VALUE t0 = rb_ary_hidden_new(n);
     volatile VALUE t1 = Qundef;
     VALUE *arrays = RARRAY_PTR(t0); /* The arrays we're computing the product of */
     int *counters = ALLOCV_N(int, t1, n); /* The current position in each one */

--- a/class.c
+++ b/class.c
@@ -507,7 +507,7 @@ rb_mod_init_copy(VALUE clone, VALUE orig)
         VALUE p = RCLASS_SUPER(orig);
         VALUE orig_origin = RCLASS_ORIGIN(orig);
         VALUE prev_clone_p = clone;
-        VALUE origin_stack = rb_ary_tmp_new(2);
+        VALUE origin_stack = rb_ary_hidden_new(2);
         VALUE origin[2];
         VALUE clone_p = 0;
         long origin_len;
@@ -1250,7 +1250,7 @@ do_include_modules_at(const VALUE klass, VALUE c, VALUE module, int search_super
         RCLASS_SET_INCLUDER(iclass, klass);
         add_subclass = TRUE;
         if (module != RCLASS_ORIGIN(module)) {
-            if (!origin_stack) origin_stack = rb_ary_tmp_new(2);
+            if (!origin_stack) origin_stack = rb_ary_hidden_new(2);
             VALUE origin[2] = {iclass, RCLASS_ORIGIN(module)};
             rb_ary_cat(origin_stack, origin, 2);
         }
@@ -2310,7 +2310,7 @@ rb_get_kwargs(VALUE keyword_hash, const ID *table, int required, int optional, V
                     continue;
                 }
             }
-            if (NIL_P(missing)) missing = rb_ary_tmp_new(1);
+            if (NIL_P(missing)) missing = rb_ary_hidden_new(1);
             rb_ary_push(missing, keyword);
         }
         if (!NIL_P(missing)) {

--- a/compile.c
+++ b/compile.c
@@ -313,7 +313,7 @@ static void iseq_add_setlocal(rb_iseq_t *iseq, LINK_ANCHOR *const seq, const NOD
     LABEL_REF(le);								\
     LABEL_REF(lc);								\
     if (NIL_P(ISEQ_COMPILE_DATA(iseq)->catch_table_ary)) \
-        RB_OBJ_WRITE(iseq, &ISEQ_COMPILE_DATA(iseq)->catch_table_ary, rb_ary_tmp_new(3)); \
+        RB_OBJ_WRITE(iseq, &ISEQ_COMPILE_DATA(iseq)->catch_table_ary, rb_ary_hidden_new(3)); \
     rb_ary_push(ISEQ_COMPILE_DATA(iseq)->catch_table_ary, freeze_hide_obj(_e));	\
 } while (0)
 
@@ -627,7 +627,7 @@ decl_branch_base(rb_iseq_t *iseq, const NODE *node, const char *type)
     VALUE branches;
 
     if (NIL_P(branch_base)) {
-        branch_base = rb_ary_tmp_new(6);
+        branch_base = rb_ary_hidden_new(6);
         rb_hash_aset(structure, key, branch_base);
         rb_ary_push(branch_base, ID2SYM(rb_intern(type)));
         rb_ary_push(branch_base, INT2FIX(first_lineno));
@@ -675,7 +675,7 @@ add_trace_branch_coverage(rb_iseq_t *iseq, LINK_ANCHOR *const seq, const NODE *n
     long counter_idx;
 
     if (NIL_P(branch)) {
-        branch = rb_ary_tmp_new(6);
+        branch = rb_ary_hidden_new(6);
         rb_hash_aset(branches, key, branch);
         rb_ary_push(branch, ID2SYM(rb_intern(type)));
         rb_ary_push(branch, INT2FIX(first_lineno));
@@ -1743,7 +1743,7 @@ iseq_set_arguments_keywords(rb_iseq_t *iseq, LINK_ANCHOR *const optargs,
     const NODE *node = args->kw_args;
     struct rb_iseq_constant_body *const body = ISEQ_BODY(iseq);
     struct rb_iseq_param_keyword *keyword;
-    const VALUE default_values = rb_ary_tmp_new(1);
+    const VALUE default_values = rb_ary_hidden_new(1);
     const VALUE complex_mark = rb_str_tmp_new(0);
     int kw = 0, rkw = 0, di = 0, i;
 
@@ -1847,7 +1847,7 @@ iseq_set_arguments(rb_iseq_t *iseq, LINK_ANCHOR *const optargs, const NODE *cons
         if (args->opt_args) {
             const NODE *node = args->opt_args;
             LABEL *label;
-            VALUE labels = rb_ary_tmp_new(1);
+            VALUE labels = rb_ary_hidden_new(1);
             VALUE *opt_table;
             int i = 0, j;
 
@@ -4369,7 +4369,7 @@ compile_array(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, int pop
 
             if ((first_chunk && stack_len == 0 && !node_tmp) || count >= min_tmp_ary_len) {
                 /* The literal contains only optimizable elements, or the subarray is long enough */
-                VALUE ary = rb_ary_tmp_new(count);
+                VALUE ary = rb_ary_hidden_new(count);
 
                 /* Create a hidden array */
                 for (; count; count--, node = node->nd_next)
@@ -4420,7 +4420,7 @@ static int
 compile_array_1(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node)
 {
     if (static_literal_node_p(node, iseq)) {
-        VALUE ary = rb_ary_tmp_new(1);
+        VALUE ary = rb_ary_hidden_new(1);
         rb_ary_push(ary, static_literal_value(node, iseq));
         OBJ_FREEZE(ary);
 
@@ -4517,7 +4517,7 @@ compile_hash(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, int meth
 
             if ((first_chunk && stack_len == 0 && !node_tmp) || count >= min_tmp_hash_len) {
                 /* The literal contains only optimizable elements, or the subsequence is long enough */
-                VALUE ary = rb_ary_tmp_new(count);
+                VALUE ary = rb_ary_hidden_new(count);
 
                 /* Create a hidden hash */
                 for (; count; count--, node = node->nd_next->nd_next) {
@@ -12077,7 +12077,7 @@ ibf_dump_iseq_list_i(st_data_t key, st_data_t val, st_data_t ptr)
 static void
 ibf_dump_iseq_list(struct ibf_dump *dump, struct ibf_header *header)
 {
-    VALUE offset_list = rb_ary_tmp_new(dump->iseq_table->num_entries);
+    VALUE offset_list = rb_ary_hidden_new(dump->iseq_table->num_entries);
 
     struct ibf_dump_iseq_list_arg args;
     args.dump = dump;
@@ -12349,7 +12349,7 @@ ibf_load_object_array(const struct ibf_load *load, const struct ibf_object_heade
 
     const long len = (long)ibf_load_small_value(load, &reading_pos);
 
-    VALUE ary = header->internal ? rb_ary_tmp_new(len) : rb_ary_new_capa(len);
+    VALUE ary = header->internal ? rb_ary_hidden_new(len) : rb_ary_new_capa(len);
     int i;
 
     for (i=0; i<len; i++) {
@@ -12744,7 +12744,7 @@ static void
 ibf_dump_object_list(struct ibf_dump *dump, ibf_offset_t *obj_list_offset, unsigned int *obj_list_size)
 {
     st_table *obj_table = dump->current_buffer->obj_table;
-    VALUE offset_list = rb_ary_tmp_new(obj_table->num_entries);
+    VALUE offset_list = rb_ary_hidden_new(obj_table->num_entries);
 
     struct ibf_dump_object_list_arg args;
     args.dump = dump;

--- a/cont.c
+++ b/cont.c
@@ -1316,7 +1316,7 @@ cont_capture(volatile int *volatile stat)
         entry = cont->ensure_array = ALLOC_N(rb_ensure_entry_t,size+1);
         for (p=th->ec->ensure_list; p; p=p->next) {
             if (!p->entry.marker)
-                p->entry.marker = rb_ary_tmp_new(0); /* dummy object */
+                p->entry.marker = rb_ary_hidden_new(0); /* dummy object */
             *entry++ = p->entry;
         }
         entry->marker = 0;

--- a/enum.c
+++ b/enum.c
@@ -1487,7 +1487,7 @@ enum_sort_by(VALUE obj)
         ary = rb_ary_new();
     }
     RBASIC_CLEAR_CLASS(ary);
-    buf = rb_ary_tmp_new(SORT_BY_BUFSIZE*2);
+    buf = rb_ary_hidden_new(SORT_BY_BUFSIZE*2);
     rb_ary_store(buf, SORT_BY_BUFSIZE*2-1, Qnil);
     memo = MEMO_NEW(0, 0, 0);
     data = (struct sort_by_data *)&memo->v1;
@@ -1863,7 +1863,7 @@ rb_nmin_run(VALUE obj, VALUE num, int by, int rev, int ary)
         rb_raise(rb_eArgError, "too big size");
     data.bufmax = data.n * 4;
     data.curlen = 0;
-    data.buf = rb_ary_tmp_new(data.bufmax * (by ? 2 : 1));
+    data.buf = rb_ary_hidden_new(data.bufmax * (by ? 2 : 1));
     data.limit = Qundef;
     data.cmpfunc = by ? nmin_cmp :
                    rb_block_given_p() ? nmin_block_cmp :

--- a/ext/fiddle/closure.c
+++ b/ext/fiddle/closure.c
@@ -74,7 +74,7 @@ with_gvl_callback(void *ptr)
     VALUE rbargs    = rb_iv_get(self, "@args");
     VALUE ctype     = rb_iv_get(self, "@ctype");
     int argc        = RARRAY_LENINT(rbargs);
-    VALUE params    = rb_ary_tmp_new(argc);
+    VALUE params    = rb_ary_hidden_new(argc);
     VALUE ret;
     VALUE cPointer;
     int i, type;

--- a/ext/openssl/ossl_pkey_ec.c
+++ b/ext/openssl/ossl_pkey_ec.c
@@ -1462,7 +1462,7 @@ static VALUE ossl_ec_point_mul(int argc, VALUE *argv, VALUE self)
                    "use #mul(bn) form instead");
 
 	num = RARRAY_LEN(arg1);
-	bns_tmp = rb_ary_tmp_new(num);
+	bns_tmp = rb_ary_hidden_new(num);
 	bignums = ALLOCV_N(const BIGNUM *, tmp_b, num);
 	for (i = 0; i < num; i++) {
 	    VALUE item = RARRAY_AREF(arg1, i);

--- a/gc.c
+++ b/gc.c
@@ -9135,7 +9135,7 @@ rb_gc_register_mark_object(VALUE obj)
         VALUE ary = rb_ary_last(0, 0, ary_ary);
 
         if (NIL_P(ary) || RARRAY_LEN(ary) >= MARK_OBJECT_ARY_BUCKET_SIZE) {
-            ary = rb_ary_tmp_new(MARK_OBJECT_ARY_BUCKET_SIZE);
+            ary = rb_ary_hidden_new(MARK_OBJECT_ARY_BUCKET_SIZE);
             rb_ary_push(ary_ary, ary);
         }
 
@@ -14193,7 +14193,7 @@ rb_gcdebug_add_stress_to_class(int argc, VALUE *argv, VALUE self)
     rb_objspace_t *objspace = &rb_objspace;
 
     if (!stress_to_class) {
-        stress_to_class = rb_ary_tmp_new(argc);
+        stress_to_class = rb_ary_hidden_new(argc);
     }
     rb_ary_cat(stress_to_class, argv, argc);
     return self;

--- a/hash.c
+++ b/hash.c
@@ -3294,7 +3294,7 @@ rb_hash_transform_keys_bang(int argc, VALUE *argv, VALUE hash)
     if (!RHASH_TABLE_EMPTY_P(hash)) {
         long i;
         VALUE new_keys = hash_alloc(0);
-        VALUE pairs = rb_ary_tmp_new(RHASH_SIZE(hash) * 2);
+        VALUE pairs = rb_ary_hidden_new(RHASH_SIZE(hash) * 2);
         rb_hash_foreach(hash, flatten_i, pairs);
         for (i = 0; i < RARRAY_LEN(pairs); i += 2) {
             VALUE key = RARRAY_AREF(pairs, i), new_key, val;

--- a/include/ruby/internal/intern/array.h
+++ b/include/ruby/internal/intern/array.h
@@ -107,14 +107,14 @@ VALUE rb_ary_new_from_args(long n, ...);
 VALUE rb_ary_new_from_values(long n, const VALUE *elts);
 
 /**
- * Allocates a  "temporary" array.   This is  a hidden  empty array.   Handy on
- * occasions.
+ * Allocates a hidden (no class) empty array.
  *
  * @param[in]  capa  Designed capacity of the array.
  * @return     A hidden, empty array.
  * @see        rb_obj_hide()
  */
-VALUE rb_ary_tmp_new(long capa);
+VALUE rb_ary_hidden_new(long capa);
+#define rb_ary_tmp_new rb_ary_hidden_new
 
 /**
  * Destroys the given array for no reason.

--- a/internal/array.h
+++ b/internal/array.h
@@ -26,7 +26,7 @@
 VALUE rb_ary_last(int, const VALUE *, VALUE);
 void rb_ary_set_len(VALUE, long);
 void rb_ary_delete_same(VALUE, VALUE);
-VALUE rb_ary_tmp_new_fill(long capa);
+VALUE rb_ary_hidden_new_fill(long capa);
 VALUE rb_ary_at(VALUE, VALUE);
 size_t rb_ary_memsize(VALUE);
 VALUE rb_to_array_type(VALUE obj);

--- a/internal/imemo.h
+++ b/internal/imemo.h
@@ -10,7 +10,7 @@
  */
 #include "ruby/internal/config.h"
 #include <stddef.h>             /* for size_t */
-#include "internal/array.h"     /* for rb_ary_tmp_new_fill */
+#include "internal/array.h"     /* for rb_ary_hidden_new_fill */
 #include "internal/gc.h"        /* for RB_OBJ_WRITE */
 #include "ruby/internal/stdbool.h"     /* for bool */
 #include "ruby/ruby.h"          /* for rb_block_call_func_t */
@@ -121,9 +121,9 @@ struct MEMO {
 #define MEMO_NEW(a, b, c) ((struct MEMO *)rb_imemo_new(imemo_memo, (VALUE)(a), (VALUE)(b), (VALUE)(c), 0))
 #define MEMO_FOR(type, value) ((type *)RARRAY_PTR(value))
 #define NEW_MEMO_FOR(type, value) \
-  ((value) = rb_ary_tmp_new_fill(type_roomof(type, VALUE)), MEMO_FOR(type, value))
+  ((value) = rb_ary_hidden_new_fill(type_roomof(type, VALUE)), MEMO_FOR(type, value))
 #define NEW_PARTIAL_MEMO_FOR(type, value, member) \
-  ((value) = rb_ary_tmp_new_fill(type_roomof(type, VALUE)), \
+  ((value) = rb_ary_hidden_new_fill(type_roomof(type, VALUE)), \
    rb_ary_set_len((value), offsetof(type, member) / sizeof(VALUE)), \
    MEMO_FOR(type, value))
 

--- a/iseq.c
+++ b/iseq.c
@@ -773,7 +773,7 @@ prepare_iseq_build(rb_iseq_t *iseq,
     }
     ISEQ_COVERAGE_SET(iseq, coverage);
     if (coverage && ISEQ_BRANCH_COVERAGE(iseq))
-        ISEQ_PC2BRANCHINDEX_SET(iseq, rb_ary_tmp_new(0));
+        ISEQ_PC2BRANCHINDEX_SET(iseq, rb_ary_hidden_new(0));
 
     return Qtrue;
 }
@@ -2391,7 +2391,7 @@ rb_iseq_disasm_recursive(const rb_iseq_t *iseq, VALUE indent)
     const struct rb_iseq_constant_body *const body = ISEQ_BODY(iseq);
     VALUE *code;
     VALUE str = rb_str_new(0, 0);
-    VALUE child = rb_ary_tmp_new(3);
+    VALUE child = rb_ary_hidden_new(3);
     unsigned int size;
     unsigned int i;
     long l;

--- a/load.c
+++ b/load.c
@@ -54,7 +54,7 @@ rb_construct_expanded_load_path(rb_vm_t *vm, enum expand_type type, int *has_rel
     VALUE ary;
     long i;
 
-    ary = rb_ary_tmp_new(RARRAY_LEN(load_path));
+    ary = rb_ary_hidden_new(RARRAY_LEN(load_path));
     for (i = 0; i < RARRAY_LEN(load_path); ++i) {
         VALUE path, as_str, expanded_path;
         int is_string, non_cache;
@@ -1427,15 +1427,15 @@ Init_load(void)
     rb_alias_variable(rb_intern_const("$-I"), id_load_path);
     rb_alias_variable(rb_intern_const("$LOAD_PATH"), id_load_path);
     vm->load_path = rb_ary_new();
-    vm->expanded_load_path = rb_ary_tmp_new(0);
-    vm->load_path_snapshot = rb_ary_tmp_new(0);
+    vm->expanded_load_path = rb_ary_hidden_new(0);
+    vm->load_path_snapshot = rb_ary_hidden_new(0);
     vm->load_path_check_cache = 0;
     rb_define_singleton_method(vm->load_path, "resolve_feature_path", rb_resolve_feature_path, 1);
 
     rb_define_virtual_variable("$\"", get_LOADED_FEATURES, 0);
     rb_define_virtual_variable("$LOADED_FEATURES", get_LOADED_FEATURES, 0);
     vm->loaded_features = rb_ary_new();
-    vm->loaded_features_snapshot = rb_ary_tmp_new(0);
+    vm->loaded_features_snapshot = rb_ary_hidden_new(0);
     vm->loaded_features_index = st_init_numtable();
     vm->loaded_features_realpaths = rb_hash_new();
     rb_obj_hide(vm->loaded_features_realpaths);
@@ -1448,6 +1448,6 @@ Init_load(void)
     rb_define_global_function("autoload", rb_f_autoload, 2);
     rb_define_global_function("autoload?", rb_f_autoload_p, -1);
 
-    ruby_dln_librefs = rb_ary_tmp_new(0);
+    ruby_dln_librefs = rb_ary_hidden_new(0);
     rb_gc_register_mark_object(ruby_dln_librefs);
 }

--- a/marshal.c
+++ b/marshal.c
@@ -1763,7 +1763,7 @@ r_object_for(struct load_arg *arg, bool partial, int *ivp, VALUE extmod, int typ
         {
             VALUE path = r_unique(arg);
             VALUE m = rb_path_to_class(path);
-            if (NIL_P(extmod)) extmod = rb_ary_tmp_new(0);
+            if (NIL_P(extmod)) extmod = rb_ary_hidden_new(0);
 
             if (RB_TYPE_P(m, T_CLASS)) { /* prepended */
                 VALUE c;

--- a/proc.c
+++ b/proc.c
@@ -1491,7 +1491,7 @@ rb_sym_to_proc(VALUE sym)
     ID id;
 
     if (!sym_proc_cache) {
-        sym_proc_cache = rb_ary_tmp_new(SYM_PROC_CACHE_SIZE * 2);
+        sym_proc_cache = rb_ary_hidden_new(SYM_PROC_CACHE_SIZE * 2);
         rb_gc_register_mark_object(sym_proc_cache);
         rb_ary_store(sym_proc_cache, SYM_PROC_CACHE_SIZE*2 - 1, Qnil);
     }

--- a/ruby.c
+++ b/ruby.c
@@ -725,7 +725,7 @@ add_modules(VALUE *req_list, const char *mod)
     VALUE feature;
 
     if (!list) {
-        *req_list = list = rb_ary_tmp_new(0);
+        *req_list = list = rb_ary_hidden_new(0);
     }
     feature = rb_str_cat_cstr(rb_str_tmp_new(0), mod);
     rb_ary_push(list, feature);

--- a/struct.c
+++ b/struct.c
@@ -115,7 +115,7 @@ struct_set_members(VALUE klass, VALUE /* frozen hidden array */ members)
 
         while (mask < members_length * AREF_HASH_UNIT) mask *= 2;
 
-        back = rb_ary_tmp_new(mask + 1);
+        back = rb_ary_hidden_new(mask + 1);
         rb_ary_store(back, mask, INT2FIX(members_length));
         mask -= 2;			  /* mask = (2**k-1)*2 */
 
@@ -810,7 +810,7 @@ rb_struct_new(VALUE klass, ...)
 
     size = rb_long2int(num_members(klass));
     if (size > numberof(tmpargs)) {
-        tmpargs[0] = rb_ary_tmp_new(size);
+        tmpargs[0] = rb_ary_hidden_new(size);
         mem = RARRAY_PTR(tmpargs[0]);
     }
     va_start(args, klass);

--- a/symbol.c
+++ b/symbol.c
@@ -91,7 +91,7 @@ Init_sym(void)
     rb_obj_hide(dsym_fstrs);
 
     symbols->str_sym = st_init_table_with_size(&symhash, 1000);
-    symbols->ids = rb_ary_tmp_new(0);
+    symbols->ids = rb_ary_hidden_new(0);
     rb_gc_register_mark_object(symbols->ids);
 
     Init_op_tbl();
@@ -426,7 +426,7 @@ set_id_entry(rb_symbols_t *symbols, rb_id_serial_t num, VALUE str, VALUE sym)
 
     VALUE ary, ids = symbols->ids;
     if (idx >= (size_t)RARRAY_LEN(ids) || NIL_P(ary = rb_ary_entry(ids, (long)idx))) {
-        ary = rb_ary_tmp_new(ID_ENTRY_UNIT * ID_ENTRY_SIZE);
+        ary = rb_ary_hidden_new(ID_ENTRY_UNIT * ID_ENTRY_SIZE);
         rb_ary_store(ids, (long)idx, ary);
     }
     idx = (num % ID_ENTRY_UNIT) * ID_ENTRY_SIZE;

--- a/thread.c
+++ b/thread.c
@@ -843,7 +843,7 @@ thread_create_core(VALUE thval, struct thread_create_params *params)
     th->priority = current_th->priority;
     th->thgroup = current_th->thgroup;
 
-    th->pending_interrupt_queue = rb_ary_tmp_new(0);
+    th->pending_interrupt_queue = rb_ary_hidden_new(0);
     th->pending_interrupt_queue_checked = 0;
     th->pending_interrupt_mask_stack = rb_ary_dup(current_th->pending_interrupt_mask_stack);
     RBASIC_CLEAR_CLASS(th->pending_interrupt_mask_stack);
@@ -5352,9 +5352,9 @@ Init_Thread(void)
             struct rb_thread_sched *sched = TH_SCHED(th);
             thread_sched_to_running(sched, th);
 
-            th->pending_interrupt_queue = rb_ary_tmp_new(0);
+            th->pending_interrupt_queue = rb_ary_hidden_new(0);
             th->pending_interrupt_queue_checked = 0;
-            th->pending_interrupt_mask_stack = rb_ary_tmp_new(0);
+            th->pending_interrupt_mask_stack = rb_ary_hidden_new(0);
         }
     }
 
@@ -5651,17 +5651,17 @@ rb_reset_coverages(void)
 VALUE
 rb_default_coverage(int n)
 {
-    VALUE coverage = rb_ary_tmp_new_fill(3);
+    VALUE coverage = rb_ary_hidden_new_fill(3);
     VALUE lines = Qfalse, branches = Qfalse;
     int mode = GET_VM()->coverage_mode;
 
     if (mode & COVERAGE_TARGET_LINES) {
-        lines = n > 0 ? rb_ary_tmp_new_fill(n) : rb_ary_tmp_new(0);
+        lines = n > 0 ? rb_ary_hidden_new_fill(n) : rb_ary_hidden_new(0);
     }
     RARRAY_ASET(coverage, COVERAGE_INDEX_LINES, lines);
 
     if (mode & COVERAGE_TARGET_BRANCHES) {
-        branches = rb_ary_tmp_new_fill(2);
+        branches = rb_ary_hidden_new_fill(2);
         /* internal data structures for branch coverage:
          *
          * { branch base node =>
@@ -5687,7 +5687,7 @@ rb_default_coverage(int n)
         rb_obj_hide(structure);
         RARRAY_ASET(branches, 0, structure);
         /* branch execution counters */
-        RARRAY_ASET(branches, 1, rb_ary_tmp_new(0));
+        RARRAY_ASET(branches, 1, rb_ary_hidden_new(0));
     }
     RARRAY_ASET(coverage, COVERAGE_INDEX_BRANCHES, branches);
 

--- a/thread_sync.c
+++ b/thread_sync.c
@@ -754,7 +754,7 @@ szqueue_ptr(VALUE obj)
 static VALUE
 ary_buf_new(void)
 {
-    return rb_ary_tmp_new(1);
+    return rb_ary_hidden_new(1);
 }
 
 static VALUE

--- a/vm.c
+++ b/vm.c
@@ -3932,7 +3932,7 @@ Init_vm_objects(void)
     vm->defined_module_hash = st_init_numtable();
 
     /* initialize mark object array, hash */
-    vm->mark_object_ary = rb_ary_tmp_new(128);
+    vm->mark_object_ary = rb_ary_hidden_new(128);
     vm->loading_table = st_init_strtable();
     vm->frozen_strings = st_init_table_with_size(&rb_fstring_hash_type, 10000);
 }

--- a/vm_args.c
+++ b/vm_args.c
@@ -280,7 +280,7 @@ static VALUE
 make_unknown_kw_hash(const VALUE *passed_keywords, int passed_keyword_len, const VALUE *kw_argv)
 {
     int i;
-    VALUE obj = rb_ary_tmp_new(1);
+    VALUE obj = rb_ary_hidden_new(1);
 
     for (i=0; i<passed_keyword_len; i++) {
         if (kw_argv[i] != Qundef) {
@@ -343,7 +343,7 @@ args_setup_kw_parameters(rb_execution_context_t *const ec, const rb_iseq_t *cons
             found++;
         }
         else {
-            if (!missing) missing = rb_ary_tmp_new(1);
+            if (!missing) missing = rb_ary_hidden_new(1);
             rb_ary_push(missing, ID2SYM(key));
         }
     }
@@ -907,7 +907,7 @@ vm_caller_setup_arg_block(const rb_execution_context_t *ec, rb_control_frame_t *
                 VALUE func = rb_hash_lookup(ref, block_code);
                 if (NIL_P(func)) {
                     /* TODO: limit cached funcs */
-                    VALUE callback_arg = rb_ary_tmp_new(2);
+                    VALUE callback_arg = rb_ary_hidden_new(2);
                     rb_ary_push(callback_arg, block_code);
                     rb_ary_push(callback_arg, ref);
                     OBJ_FREEZE_RAW(callback_arg);


### PR DESCRIPTION
`rb_ary_tmp_new` suggests that the array is temporary in some way, but that's not true, it just creates an array that's hidden and not on the transient heap. This commit renames it to `rb_ary_hidden_new`.