### PR TITLE
GVL Instrumentation: pass thread_id as part of event data

### DIFF
--- a/include/ruby/thread.h
+++ b/include/ruby/thread.h
@@ -197,7 +197,9 @@ void *rb_nogvl(void *(*func)(void *), void *data1,
 #define RUBY_INTERNAL_THREAD_EVENT_EXITED     1 << 4 /** thread terminated */
 #define RUBY_INTERNAL_THREAD_EVENT_MASK       0xff /** All Thread events */
 
-typedef void rb_internal_thread_event_data_t; // for future extension.
+typedef struct rb_internal_thread_event_data {
+    unsigned int thread_id;
+} rb_internal_thread_event_data_t;
 
 typedef void (*rb_internal_thread_event_callback)(rb_event_flag_t event,
               const rb_internal_thread_event_data_t *event_data,

--- a/thread.c
+++ b/thread.c
@@ -171,7 +171,7 @@ static inline void blocking_region_end(rb_thread_t *th, struct rb_blocking_regio
 #define THREAD_BLOCKING_BEGIN(th) do { \
   struct rb_thread_sched * const sched = TH_SCHED(th); \
   RB_GC_SAVE_MACHINE_CONTEXT(th); \
-  thread_sched_to_waiting(sched);
+  thread_sched_to_waiting(sched, th);
 
 #define THREAD_BLOCKING_END(th) \
   thread_sched_to_running(sched, th); \
@@ -772,12 +772,12 @@ thread_start_func_2(rb_thread_t *th, VALUE *stack_start)
         // after rb_ractor_living_threads_remove()
         // GC will happen anytime and this ractor can be collected (and destroy GVL).
         // So gvl_release() should be before it.
-        thread_sched_to_dead(TH_SCHED(th));
+        thread_sched_to_dead(TH_SCHED(th), th);
         rb_ractor_living_threads_remove(th->ractor, th);
     }
     else {
         rb_ractor_living_threads_remove(th->ractor, th);
-        thread_sched_to_dead(TH_SCHED(th));
+        thread_sched_to_dead(TH_SCHED(th), th);
     }
 
     return 0;
@@ -1457,7 +1457,7 @@ blocking_region_begin(rb_thread_t *th, struct rb_blocking_region_buffer *region,
         RUBY_DEBUG_LOG("%s", "");
 
         RB_GC_SAVE_MACHINE_CONTEXT(th);
-        thread_sched_to_waiting(TH_SCHED(th));
+        thread_sched_to_waiting(TH_SCHED(th), th);
         return TRUE;
     }
     else {

--- a/thread_none.c
+++ b/thread_none.c
@@ -26,7 +26,7 @@ thread_sched_to_running(struct rb_thread_sched *sched, rb_thread_t *th)
 }
 
 static void
-thread_sched_to_waiting(struct rb_thread_sched *sched)
+thread_sched_to_waiting(struct rb_thread_sched *sched, rb_thread_t *th)
 {
 }
 

--- a/thread_win32.c
+++ b/thread_win32.c
@@ -132,7 +132,7 @@ thread_sched_to_running(struct rb_thread_sched *sched, rb_thread_t *th)
 }
 
 static void
-thread_sched_to_waiting(struct rb_thread_sched *sched)
+thread_sched_to_waiting(struct rb_thread_sched *sched, rb_thread_t *th)
 {
     ReleaseMutex(sched->lock);
 }
@@ -140,7 +140,7 @@ thread_sched_to_waiting(struct rb_thread_sched *sched)
 static void
 thread_sched_yield(struct rb_thread_sched *sched, rb_thread_t *th)
 {
-    thread_sched_to_waiting(sched);
+    thread_sched_to_waiting(sched, th);
     native_thread_yield();
     thread_sched_to_running(sched, th);
 }

--- a/vm.c
+++ b/vm.c
@@ -3286,10 +3286,8 @@ th_init(rb_thread_t *th, VALUE self, rb_vm_t *vm)
     th->report_on_exception = vm->thread_report_on_exception;
     th->ext_config.ractor_safe = true;
 
-#if USE_RUBY_DEBUG_LOG
     static rb_atomic_t thread_serial = 0;
     th->serial = RUBY_ATOMIC_FETCH_ADD(thread_serial, 1);
-#endif
 }
 
 VALUE

--- a/vm_core.h
+++ b/vm_core.h
@@ -1009,7 +1009,7 @@ typedef struct rb_thread_struct {
     rb_execution_context_t *ec;
 
     struct rb_thread_sched_item sched;
-    rb_atomic_t serial; // only for RUBY_DEBUG_LOG()
+    rb_atomic_t serial;
 
     VALUE last_status; /* $? */
 


### PR DESCRIPTION
Context: https://github.com/ivoanjo/gvl-tracing/pull/4

Some hooks may want to collect data on a per thread basis. Right now the only way to identified the concerned thread is to
use `rb_nativethread_self()` or similar, but even then because of the thread cache, two distinct Ruby thread may report the same native thread id.

This patch pass a `thread_id` as part of the `event_data` struct. It's a serial id generated when the thread is created.

cc @ivoanjo 

@ko1 what do you think? Would this be acceptable? There is an atomic operation an overhead even if the API is not in use, but that's on thread creation, I assume it's minor compared to the overall thread creation cost?