### PR TITLE
respect current frame of `rb_eval_string`

### DIFF
--- a/ext/-test-/eval/eval.c
+++ b/ext/-test-/eval/eval.c
@@ -1,0 +1,13 @@
+#include "ruby/ruby.h"
+
+static VALUE
+eval_string(VALUE self, VALUE str)
+{
+    return rb_eval_string(StringValueCStr(str));
+}
+
+void
+Init_eval(void)
+{
+    rb_define_global_function("rb_eval_string", eval_string, 1);
+}

--- a/ext/-test-/eval/extconf.rb
+++ b/ext/-test-/eval/extconf.rb
@@ -1,0 +1,2 @@
+require 'mkmf'
+create_makefile('-test-/eval')

--- a/test/-ext-/eval/test_eval.rb
+++ b/test/-ext-/eval/test_eval.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: false
+require 'test/unit'
+require "-test-/eval"
+
+class  EvalTest < Test::Unit::TestCase
+  def test_rb_eval_string
+    a = 1
+    assert_equal [self, 1, __method__], rb_eval_string(%q{
+      [self, a, __method__]
+    })
+  end
+end

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -1828,7 +1828,10 @@ VALUE
 ruby_eval_string_from_file(const char *str, const char *filename)
 {
     VALUE file = filename ? rb_str_new_cstr(filename) : 0;
-    return eval_string_with_cref(rb_vm_top_self(), rb_str_new2(str), NULL, file, 1);
+    rb_execution_context_t *ec = GET_EC();
+    rb_control_frame_t *cfp = ec ? rb_vm_get_ruby_level_next_cfp(ec, ec->cfp) : NULL;
+    VALUE self = cfp ? cfp->self : rb_vm_top_self();
+    return eval_string_with_cref(self, rb_str_new2(str), NULL, file, 1);
 }
 
 VALUE


### PR DESCRIPTION
`self` is nearest Ruby method's `self`.
If there is no ruby frame, use toplevel `self` (`main`).

https://bugs.ruby-lang.org/issues/18780