### PR TITLE
YJIT: Add known_* helpers for Type

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -3399,7 +3399,7 @@ fn jit_guard_known_klass(
 ) {
     let val_type = ctx.get_opnd_type(insn_opnd);
 
-    if val_type.known_class_of() == Some(known_klass) {
+    if val_type.known_class() == Some(known_klass) {
         // We already know from type information that this is a match
         return;
     }

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -2496,7 +2496,7 @@ fn gen_equality_specialized(
 
         // Otherwise guard that b is a T_STRING (from type info) or String (from runtime guard)
         let btype = ctx.get_opnd_type(StackOpnd(0));
-        if btype != Type::TString && btype != Type::CString {
+        if btype.known_value_type() != Some(RUBY_T_STRING) {
             mov(cb, REG0, C_ARG_REGS[1]);
             // Note: any T_STRING is valid here, but we check for a ::String for simplicity
             // To pass a mutable static variable (rb_cString) requires an unsafe block

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -143,7 +143,7 @@ impl Type {
     }
 
     /// Returns an Option with the class if it is known, otherwise None
-    pub fn known_class_of(&self) -> Option<VALUE> {
+    pub fn known_class(&self) -> Option<VALUE> {
         unsafe {
             match self {
                 Type::Nil => Some(rb_cNilClass),

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -126,6 +126,60 @@ impl Type {
         }
     }
 
+    /// Returns an Option with the T_ value type if it is known, otherwise None
+    pub fn known_value_type(&self) -> Option<ruby_value_type> {
+        match self {
+            Type::Nil => Some(RUBY_T_NIL),
+            Type::True => Some(RUBY_T_TRUE),
+            Type::False => Some(RUBY_T_FALSE),
+            Type::Fixnum => Some(RUBY_T_FIXNUM),
+            Type::Flonum => Some(RUBY_T_FLOAT),
+            Type::Array => Some(RUBY_T_ARRAY),
+            Type::Hash => Some(RUBY_T_HASH),
+            Type::ImmSymbol | Type::HeapSymbol => Some(RUBY_T_SYMBOL),
+            Type::TString | Type::CString => Some(RUBY_T_STRING),
+            Type::Unknown | Type::UnknownImm | Type::UnknownHeap => None
+        }
+    }
+
+    /// Returns an Option with the class if it is known, otherwise None
+    pub fn known_class_of(&self) -> Option<VALUE> {
+        unsafe {
+            match self {
+                Type::Nil => Some(rb_cNilClass),
+                Type::True => Some(rb_cTrueClass),
+                Type::False => Some(rb_cFalseClass),
+                Type::Fixnum => Some(rb_cInteger),
+                Type::Flonum => Some(rb_cFloat),
+                Type::ImmSymbol | Type::HeapSymbol => Some(rb_cSymbol),
+                Type::CString => Some(rb_cString),
+                _ => None,
+            }
+        }
+    }
+
+    /// Returns an Option with the exact value if it is known, otherwise None
+    #[allow(unused)] // not yet used
+    pub fn known_exact_value(&self) -> Option<VALUE> {
+        match self {
+            Type::Nil => Some(Qnil),
+            Type::True => Some(Qtrue),
+            Type::False => Some(Qfalse),
+            _ => None,
+        }
+    }
+
+    /// Returns an Option with the exact value if it is known, otherwise None
+    pub fn known_truthy(&self) -> Option<bool> {
+        match self {
+            Type::Nil => Some(false),
+            Type::False => Some(false),
+            Type::UnknownHeap => Some(true),
+            Type::Unknown | Type::UnknownImm => None,
+            _ => Some(true)
+        }
+    }
+
     /// Compute a difference between two value types
     /// Returns 0 if the two are the same
     /// Returns > 0 if different but compatible


### PR DESCRIPTION
This adds a few helpers to Type which all return `Options` representing what is known, from a Ruby perspective, about the type.

This includes:
* known_class_of: If known, the class represented by this type
* known_value_type: If known, the T_ value type
* known_exact_value: If known, the exact VALUE represented by this type (currently this is only available for true/false/nil)
* known_truthy: If known, whether or not this value evaluates as true (not false or nil)

The goal of this is to abstract away the specifics of the mappings between types wherever possible from the codegen. For example previously by introducing `Type::CString` as a more specific version of `Type::TString`, uses of `Type::TString` in codegen needed to be updated to check either case. Now by using known_value_type, at least in theory we can introduce new types with minimal (if any) codegen changes.

I think rust's Option type allows us to represent this uncertainty fairly well, and should help avoid mistakes, and the matching using this turned out pretty cleanly.

This PR includes a commit using each of these helpers as a demonstration (other than `known_exact_value`, which I didn't find a place to use 😅):
* I really like how it removed a bunch of if statements from `jit_guard_known_klass` allowing us to immediately return if a check was not needed.
* I'm also happy with gen_checktype, as it's able to dynamically check against the type it wants.
* The change to `jit_rb_obj_not` is the only place I used `known_truthy`, but in the future I could see it being used by `branchif`/`branchunless`

I didn't make changes to `jit_rb_str_concat` (though I think it would be useful there) to avoid conflicts with #6205 cc @noahgibbs 

I'm interested in making some helpers for Type that go in the other direction: from a class or value type to a `Type`, much like `Type::from` does today, but I'd like feedback on this first. That next step could allow introducing new types and have them used (ex. by `jit_guard_known_klass`) without any changes to codegen.