### PR TITLE
Harden Queue#pop timeout tests

### DIFF
--- a/test/ruby/test_thread_queue.rb
+++ b/test/ruby/test_thread_queue.rb
@@ -121,11 +121,11 @@ class TestThreadQueue < Test::Unit::TestCase
     assert_nil t1.value
 
     t2 = Thread.new { q.pop(timeout: 0.1) }
-    assert_equal t2, t2.join(0.2)
+    assert_equal t2, t2.join(1)
     assert_nil t2.value
   ensure
-    t1&.kill
-    t2&.kill
+    t1&.kill&.join
+    t2&.kill&.join
   end
 
   def test_queue_pop_non_block
@@ -154,11 +154,11 @@ class TestThreadQueue < Test::Unit::TestCase
     assert_nil t1.value
 
     t2 = Thread.new { q.pop(timeout: 0.1) }
-    assert_equal t2, t2.join(0.2)
+    assert_equal t2, t2.join(1)
     assert_nil t2.value
   ensure
-    t1&.kill
-    t2&.kill
+    t1&.kill&.join
+    t2&.kill&.join
   end
 
   def test_sized_queue_pop_non_block


### PR DESCRIPTION
They occasionaly fail with;

```
  FLeaked thread: TestThreadQueue#test_queue_pop_timeout: #<Thread:0x0000000108e38e48 /Users/runner/work/ruby/ruby/src/test/ruby/test_thread_queue.rb:123 sleep>
  .Finished thread: TestThreadQueue#test_deny_pushers: #<Thread:0x0000000108e38e48 /Users/runner/work/ruby/ruby/src/test/ruby/test_thread_queue.rb:123 dead>
  ...
  Retrying...

    1) Failure:
  TestThreadQueue#test_sized_queue_pop_timeout [/Users/runner/work/ruby/ruby/src/test/ruby/test_thread_queue.rb:157]:
  <#<Thread:0x00000001084bc7e8 /Users/runner/work/ruby/ruby/src/test/ruby/test_thread_queue.rb:156 sleep>> expected but was
  <nil>.

    2) Failure:
  TestThreadQueue#test_queue_pop_timeout [/Users/runner/work/ruby/ruby/src/test/ruby/test_thread_queue.rb:124]:
  <#<Thread:0x00000001083ff058 /Users/runner/work/ruby/ruby/src/test/ruby/test_thread_queue.rb:123 sleep>> expected but was
  <nil>.
```

I'm hoping joining for longer should help avoid this.