### PR TITLE
thread_sync.c: pass proper argument to queue_sleep in rb_szqueue_push

### DIFF
--- a/thread_sync.c
+++ b/thread_sync.c
@@ -1277,7 +1277,13 @@ rb_szqueue_push(int argc, VALUE *argv, VALUE self)
             ccan_list_add_tail(pushq, &queue_waiter.w.node);
             sq->num_waiting_push++;
 
-            rb_ensure(queue_sleep, self, szqueue_sleep_done, (VALUE)&queue_waiter);
+            struct queue_sleep_arg queue_sleep_arg = {
+                .self = self,
+                .timeout = Qnil,
+                .end = 0
+            };
+
+            rb_ensure(queue_sleep, (VALUE)&queue_sleep_arg, szqueue_sleep_done, (VALUE)&queue_waiter);
         }
     }
 


### PR DESCRIPTION
Fix: https://github.com/ruby/ruby/pull/6185

When I removed the SizeQueue#push timeout from my PR, I forgot to update the `queue_sleep` parameters to be a `queue_sleep_arg`.

Somehow this worked on most archs, but on Solaris/Sparc it would legitimately crash when trying to access the `timeout` and `end` members of the struct.

