### PR TITLE
Add MatchData#deconstruct/deconstruct_keys

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -113,6 +113,8 @@ Note: We're only listing outstanding class updates.
 
 * MatchData
     * MatchData#byteoffset has been added. [[Feature #13110]]
+    * MatchData#deconstruct has been added. [[Feature #18821]]
+    * MatchData#deconstruct_keys has been added. [[Feature #18821]]
 
 * Module
     * Module.used_refinements has been added. [[Feature #14332]]

--- a/test/ruby/test_regexp.rb
+++ b/test/ruby/test_regexp.rb
@@ -608,6 +608,38 @@ class TestRegexp < Test::Unit::TestCase
     assert_equal('#<MatchData "foobarbaz" 1:"foo" 2:"bar" 3:"baz" 4:nil>', m.inspect)
   end
 
+  def test_match_data_deconstruct
+    m = /foo.+/.match("foobarbaz")
+    assert_equal([], m.deconstruct)
+
+    m = /(foo).+(baz)/.match("foobarbaz")
+    assert_equal(["foo", "baz"], m.deconstruct)
+
+    m = /(...)(...)(...)(...)?/.match("foobarbaz")
+    assert_equal(["foo", "bar", "baz", nil], m.deconstruct)
+  end
+
+  def test_match_data_deconstruct_keys
+    m = /foo.+/.match("foobarbaz")
+    assert_equal({}, m.deconstruct_keys([:a]))
+
+    m = /(?<a>foo).+(?<b>baz)/.match("foobarbaz")
+    assert_equal({a: "foo", b: "baz"}, m.deconstruct_keys(nil))
+    assert_equal({a: "foo", b: "baz"}, m.deconstruct_keys([:a, :b]))
+    assert_equal({b: "baz"}, m.deconstruct_keys([:b]))
+    assert_equal({}, m.deconstruct_keys([:c, :a]))
+    assert_equal({a: "foo"}, m.deconstruct_keys([:a, :c]))
+    assert_equal({}, m.deconstruct_keys([:a, :b, :c]))
+
+    assert_raise(TypeError) {
+      m.deconstruct_keys(0)
+    }
+
+    assert_raise(TypeError) {
+      m.deconstruct_keys(["a", "b"])
+    }
+  end
+
   def test_initialize
     assert_raise(ArgumentError) { Regexp.new }
     assert_equal(/foo/, assert_warning(/ignored/) {Regexp.new(/foo/, Regexp::IGNORECASE)})


### PR DESCRIPTION
[Feature #18821](https://bugs.ruby-lang.org/issues/18821)

The `#deconstruct_keys` behaviour is inferred from the `Struct#deconstruct_keys`, in particular:
1) Both Symbols and Strings could be passed as the required keys, the type is preserved.
2) If the number of the passed keys is greater than the number of the named groups, an empty Hash is returned.
3) Collecting the keys stops as soon as an unknown key is encountered; the returned Hash contains all the keys collected so far.

IMO, 1) and 2) are questionable. But since we already do that for Structs, it makes sense to preserve the current behaviors and not introduce a new one. Alternatively, we can re-visit the Struct API (which I [proposed once](https://bugs.ruby-lang.org/issues/16660), but it was rejected).

/cc @baweaver 

