### PR TITLE
Fix files for gemspec files direct-under lib

### DIFF
--- a/tool/rbinstall.rb
+++ b/tool/rbinstall.rb
@@ -773,7 +773,7 @@ module RbInstall
                     remove_prefix(prefix, ruby_source)
                   end
                 else
-                  [File.basename(@gemspec, '.gemspec') + '.rb']
+                  [@gemspec[%r[(?:[^/]+/)?[^/]+(?=\.gemspec\z)]] + '.rb']
                 end
 
         case File.basename(@gemspec, ".gemspec")


### PR DESCRIPTION
Collected `files` lacked `lib` prefix.