### PR TITLE
Silent backtrace from cve_2019_8325_spec.rb

### DIFF
--- a/spec/ruby/security/cve_2019_8325_spec.rb
+++ b/spec/ruby/security/cve_2019_8325_spec.rb
@@ -5,8 +5,16 @@ require 'rubygems/command_manager'
 
 describe "CVE-2019-8325 is resisted by" do
   describe "sanitising error message components" do
+    silent_ui = Module.new do
+      attr_accessor :ui
+      def self.extended(obj)
+        obj.ui = Gem::SilentUI.new
+      end
+    end
+
     it "for the 'while executing' message" do
       manager = Gem::CommandManager.new
+      manager.extend(silent_ui)
       def manager.process_args(args, build_args)
         raise StandardError, "\e]2;nyan\a"
       end
@@ -26,6 +34,7 @@ describe "CVE-2019-8325 is resisted by" do
 
     it "for the 'loading command' message" do
       manager = Gem::CommandManager.new
+      manager.extend(silent_ui)
       def manager.require(x)
         raise 'foo'
       end


### PR DESCRIPTION
By the change at f310ac1cb2964f635f582862763b2155aacf2c12, spec/ruby/security/cve_2019_8325_spec.rb started to show the backtraces.
As the backtraces are not the subject of this test, silence them by using Gem::SilentUI.

https://github.com/ruby/ruby/runs/7687115678?check_suite_focus=true#step:16:167
```
ruby 3.2.0dev (2022-08-05T07:37:03Z master f310ac1cb2) [i686-linux-gnu]
	/home/runner/work/ruby/ruby/src/spec/ruby/security/cve_2019_8325_spec.rb:11:in `process_args'
	/home/runner/work/ruby/ruby/src/lib/rubygems/command_manager.rb:149:in `run'
	/home/runner/work/ruby/ruby/src/spec/ruby/security/cve_2019_8325_spec.rb:16:in `block (3 levels) in <top (required)>'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/runner/mspec.rb:116:in `instance_exec'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/runner/mspec.rb:116:in `protect'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/runner/context.rb:176:in `block in protect'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/runner/context.rb:176:in `all?'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/runner/context.rb:176:in `protect'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/runner/context.rb:212:in `block (2 levels) in process'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/runner/mspec.rb:284:in `repeat'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/runner/context.rb:204:in `block in process'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/runner/context.rb:203:in `each'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/runner/context.rb:203:in `process'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/runner/context.rb:235:in `block in process'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/runner/context.rb:235:in `each'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/runner/context.rb:235:in `process'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/runner/mspec.rb:55:in `describe'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/runner/object.rb:11:in `describe'
	/home/runner/work/ruby/ruby/src/spec/ruby/security/cve_2019_8325_spec.rb:6:in `<top (required)>'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/runner/mspec.rb:99:in `load'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/runner/mspec.rb:99:in `block (2 levels) in files'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/runner/mspec.rb:116:in `instance_exec'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/runner/mspec.rb:116:in `protect'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/runner/mspec.rb:99:in `block in files'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/runner/mspec.rb:76:in `each_file'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/runner/mspec.rb:95:in `files'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/runner/mspec.rb:63:in `process'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/commands/mspec-run.rb:84:in `run'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/utils/script.rb:292:in `main'
	/home/runner/work/ruby/ruby/src/spec/mspec/bin/mspec-run:7:in `<main>'
	/home/runner/work/ruby/ruby/src/spec/ruby/security/cve_2019_8325_spec.rb:30:in `require'
	/home/runner/work/ruby/ruby/src/lib/rubygems/command_manager.rb:228:in `load_and_instantiate'
	/home/runner/work/ruby/ruby/src/spec/ruby/security/cve_2019_8325_spec.rb:33:in `block (3 levels) in <top (required)>'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/runner/mspec.rb:116:in `instance_exec'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/runner/mspec.rb:116:in `protect'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/runner/context.rb:176:in `block in protect'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/runner/context.rb:176:in `all?'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/runner/context.rb:176:in `protect'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/runner/context.rb:212:in `block (2 levels) in process'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/runner/mspec.rb:284:in `repeat'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/runner/context.rb:204:in `block in process'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/runner/context.rb:203:in `each'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/runner/context.rb:203:in `process'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/runner/context.rb:235:in `block in process'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/runner/context.rb:235:in `each'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/runner/context.rb:235:in `process'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/runner/mspec.rb:55:in `describe'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/runner/object.rb:11:in `describe'
	/home/runner/work/ruby/ruby/src/spec/ruby/security/cve_2019_8325_spec.rb:6:in `<top (required)>'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/runner/mspec.rb:99:in `load'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/runner/mspec.rb:99:in `block (2 levels) in files'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/runner/mspec.rb:116:in `instance_exec'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/runner/mspec.rb:116:in `protect'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/runner/mspec.rb:99:in `block in files'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/runner/mspec.rb:76:in `each_file'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/runner/mspec.rb:95:in `files'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/runner/mspec.rb:63:in `process'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/commands/mspec-run.rb:84:in `run'
	/home/runner/work/ruby/ruby/src/spec/mspec/lib/mspec/utils/script.rb:292:in `main'
	/home/runner/work/ruby/ruby/src/spec/mspec/bin/mspec-run:7:in `<main>'
```