### PR TITLE
Update IO::Buffer#get_value benchmark

### DIFF
--- a/benchmark/buffer_get.yml
+++ b/benchmark/buffer_get.yml
@@ -1,9 +1,10 @@
+prelude: |
+  # frozen_string_literal: true
+  Warning[:experimental] = false
+  buffer = IO::Buffer.new(32, IO::Buffer::MAPPED)
+  string = "\0" * 32
 benchmark:
-  - name: buffer.get
-    prelude: buffer = IO::Buffer.new(32, IO::Buffer::MAPPED)
-    script: buffer.get(:U32, 0)
-    loop_count: 20000000
-  - name: string.unpack
-    prelude: string = "\0" * 32
-    script: string.unpack("C")
-    loop_count: 20000000
+  buffer.get_value: |
+    buffer.get_value(:U32, 0)
+  string.unpack1: |
+    string.unpack1("N")


### PR DESCRIPTION
- The method was renamed from `get` to `get_value`
- Comparing to `String#unpack` isn't quite equivalent, `unpack1` is closer.
- Use frozen_string_literal to avoid allocating a format string every time.
- Use `N` format which is equivalent to `:U32` (`uint_32_t` big-endian).
- Disable experimental warnings to not mess up the output.
    