### PR TITLE
[Bug #18960] Support `using` at toplevel in wrapped script

### DIFF
--- a/eval.c
+++ b/eval.c
@@ -1792,10 +1792,12 @@ top_include(int argc, VALUE *argv, VALUE self)
 static VALUE
 top_using(VALUE self, VALUE module)
 {
-    const rb_cref_t *cref = rb_vm_cref();
+    const rb_cref_t *cref = CREF_NEXT(rb_vm_cref());;
     rb_control_frame_t *prev_cfp = previous_frame(GET_EC());
+    rb_thread_t *th = GET_THREAD();
 
-    if (CREF_NEXT(cref) || (prev_cfp && rb_vm_frame_method_entry(prev_cfp))) {
+    if ((th->top_wrapper ? CREF_NEXT(cref) : cref) ||
+        (prev_cfp && rb_vm_frame_method_entry(prev_cfp))) {
         rb_raise(rb_eRuntimeError, "main.using is permitted only at toplevel");
     }
     if (rb_block_given_p()) {

--- a/spec/ruby/core/main/fixtures/using.rb
+++ b/spec/ruby/core/main/fixtures/using.rb
@@ -1,0 +1,1 @@
+using Module.new

--- a/spec/ruby/core/main/fixtures/using_in_main.rb
+++ b/spec/ruby/core/main/fixtures/using_in_main.rb
@@ -1,0 +1,5 @@
+MAIN = self
+
+module X
+  MAIN.send(:using, Module.new)
+end

--- a/spec/ruby/core/main/fixtures/using_in_method.rb
+++ b/spec/ruby/core/main/fixtures/using_in_method.rb
@@ -1,0 +1,5 @@
+def foo
+  using Module.new
+end
+
+foo

--- a/spec/ruby/core/main/using_spec.rb
+++ b/spec/ruby/core/main/using_spec.rb
@@ -129,4 +129,24 @@ describe "main.using" do
 
     x.call_bar(cls2.new).should == 'bar'
   end
+
+  it "raises error when called from method in wrapped script" do
+    -> do
+      load File.expand_path('../fixtures/using_in_method.rb', __FILE__), true
+    end.should raise_error(RuntimeError)
+  end
+
+  it "raises error when called on toplevel from module" do
+    -> do
+      load File.expand_path('../fixtures/using_in_main.rb', __FILE__), true
+    end.should raise_error(RuntimeError)
+  end
+
+  ruby_version_is "3.2" do
+    it "does not raise error when wrapped with module" do
+      -> do
+        load File.expand_path('../fixtures/using.rb', __FILE__), true
+      end.should_not raise_error
+    end
+  end
 end


### PR DESCRIPTION
Fixes [Bug [#18960](https://bugs.ruby-lang.org/issues/18960)]

Allow refinements to be used at the toplevel within a script that is loaded under a module.