### PR TITLE
Optimize Marshal dump/load for large (> 31-bit) FIXNUM

### DIFF
--- a/benchmark/marshal_dump_load_integer.yml
+++ b/benchmark/marshal_dump_load_integer.yml
@@ -1,0 +1,22 @@
+prelude: |
+  smallint_array = 1000.times.map { |x| x }
+  bigint32_array = 1000.times.map { |x| x + 2**32 }
+  bigint64_array = 1000.times.map { |x| x + 2**64 }
+
+  smallint_dump = Marshal.dump(smallint_array)
+  bigint32_dump = Marshal.dump(bigint32_array)
+  bigint64_dump = Marshal.dump(bigint64_array)
+benchmark:
+  marshal_dump_integer_small: |
+    Marshal.dump(smallint_array)
+  marshal_dump_integer_over_32_bit: |
+    Marshal.dump(bigint32_array)
+  marshal_dump_integer_over_64_bit: |
+    Marshal.dump(bigint64_array)
+  marshal_load_integer_small: |
+    Marshal.load(smallint_dump)
+  marshal_load_integer_over_32_bit: |
+    Marshal.load(bigint32_dump)
+  marshal_load_integer_over_64_bit: |
+    Marshal.load(bigint64_dump)
+loop_count: 4000

--- a/common.mk
+++ b/common.mk
@@ -8715,12 +8715,15 @@ main.$(OBJEXT): {$(VPATH)}vm_debug.h
 marshal.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 marshal.$(OBJEXT): $(top_srcdir)/internal/array.h
 marshal.$(OBJEXT): $(top_srcdir)/internal/bignum.h
+marshal.$(OBJEXT): $(top_srcdir)/internal/bits.h
 marshal.$(OBJEXT): $(top_srcdir)/internal/class.h
 marshal.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 marshal.$(OBJEXT): $(top_srcdir)/internal/encoding.h
 marshal.$(OBJEXT): $(top_srcdir)/internal/error.h
+marshal.$(OBJEXT): $(top_srcdir)/internal/fixnum.h
 marshal.$(OBJEXT): $(top_srcdir)/internal/gc.h
 marshal.$(OBJEXT): $(top_srcdir)/internal/hash.h
+marshal.$(OBJEXT): $(top_srcdir)/internal/numeric.h
 marshal.$(OBJEXT): $(top_srcdir)/internal/object.h
 marshal.$(OBJEXT): $(top_srcdir)/internal/serial.h
 marshal.$(OBJEXT): $(top_srcdir)/internal/static_assert.h

--- a/test/ruby/test_marshal.rb
+++ b/test/ruby/test_marshal.rb
@@ -33,7 +33,7 @@ class TestMarshal < Test::Unit::TestCase
   end
 
   def test_marshal
-    a = [1, 2, 3, [4,5,"foo"], {1=>"bar"}, 2.5, fact(30)]
+    a = [1, 2, 3, 2**32, 2**64, [4,5,"foo"], {1=>"bar"}, 2.5, fact(30)]
     assert_equal a, Marshal.load(Marshal.dump(a))
 
     [[1,2,3,4], [81, 2, 118, 3146]].each { |w,x,y,z|
@@ -45,6 +45,26 @@ class TestMarshal < Test::Unit::TestCase
     [1.0, 10.0, 100.0, 110.0].each {|x|
       assert_equal(x, Marshal.load(Marshal.dump(x)), bug3659)
     }
+  end
+
+  def test_marshal_integers
+    a = []
+    [-2, -1, 0, 1, 2].each do |i|
+      0.upto(65).map do |exp|
+        a << 2**exp + i
+      end
+    end
+    assert_equal a, Marshal.load(Marshal.dump(a))
+
+    a = [2**32, []]*2
+    assert_equal a, Marshal.load(Marshal.dump(a))
+
+    a = [2**32, 2**32, []]*2
+    assert_equal a, Marshal.load(Marshal.dump(a))
+  end
+
+  def test_marshal_small_bignum_backref
+    assert_equal [2**32, 2**32], Marshal.load("\x04\b[\al+\b\x00\x00\x00\x00\x01\x00@\x06")
   end
 
   StrClone = String.clone


### PR DESCRIPTION
Marshal is mostly a 32-bit format (presumably matching the 32-bit Ruby it was originally implemented for). This means that large FIXNUMs (> 31 bit) on 64-bit platforms still need to be encoded as BIGNUM within Marshal.

This PR keeps the identical serialization format, they are still encoded as TYPE_BIGNUM, but adds special cases for these "big fixnums" for both dumping and loading, so that we don't need to actually allocate an intermediate T_BIGNUM but write the same bytes as though we did.

```
$ make benchmark ITEM=marshal_dump_load_integer
generating vm_call_iseq_optimized.inc
vm_call_iseq_optimized.inc unchanged
building Rust YJIT (dev_nodebug mode)
/home/jhawthorn/.rubies/ruby-3.1.0/bin/ruby --disable=gems -rrubygems -I./benchmark/lib ./benchmark/benchmark-driver/exe/benchmark-driver \
            --executables="compare-ruby::/home/jhawthorn/.rubies/ruby-3.1.0/bin/ruby --disable=gems -I.ext/common --disable-gem" \
            --executables="built-ruby::./miniruby -I./lib -I. -I.ext/common  ./tool/runruby.rb --extout=.ext  -- --disable-gems --disable-gem" \
            --output=markdown --output-compare -v $(find ./benchmark -maxdepth 1 -name 'marshal_dump_load_integer' -o -name '*marshal_dump_load_integer*.yml' -o -name '*marshal_dump_load_integer*.rb' | sort)
compare-ruby: ruby 3.1.0p0 (2021-12-25 revision fb4df44d16) [x86_64-linux]
built-ruby: ruby 3.2.0dev (2022-08-10T17:46:44Z marshal_fast_integer b170d740ed) [x86_64-linux]
# Iteration per second (i/s)

|                                  |compare-ruby|built-ruby|
|:---------------------------------|-----------:|---------:|
|marshal_dump_integer_small        |     20.472k|   36.771k|
|                                  |           -|     1.80x|
|marshal_dump_integer_over_32_bit  |      3.520k|   11.453k|
|                                  |           -|     3.25x|
|marshal_dump_integer_over_64_bit  |      3.319k|    3.983k|
|                                  |           -|     1.20x|
|marshal_load_integer_small        |     30.446k|   26.358k|
|                                  |       1.16x|         -|
|marshal_load_integer_over_32_bit  |      7.603k|   10.278k|
|                                  |           -|     1.35x|
|marshal_load_integer_over_64_bit  |      5.820k|    6.228k|
|                                  |           -|     1.07x|
```

This also happens to make dumping of other "immediate" types (like small fixnums) faster by avoiding an `st_lookup` which never hit.

One common use case for serialization of large-fixnums is stackprof, which dumps a large array of memory locations. There are likely others.