### PR TITLE
Add `--enable-devel` configure option

### DIFF
--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -147,6 +147,7 @@ jobs:
           - { name: disable-dln,          env: { append_configure: '--disable-dln' } }
           - { name: enable-mkmf-verbose,  env: { append_configure: '--enable-mkmf-verbose' } }
           - { name: disable-rubygems,     env: { append_configure: '--disable-rubygems' } }
+          - { name: RUBY_DEVEL,           env: { append_configure: '--enable-devel' } }
 
           - { name: OPT_THREADED_CODE=1,            env: { cppflags: '-DOPT_THREADED_CODE=1' } }
           - { name: OPT_THREADED_CODE=2,            env: { cppflags: '-DOPT_THREADED_CODE=2' } }
@@ -154,7 +155,6 @@ jobs:
 
           - { name: NDEBUG,                         env: { cppflags: '-DNDEBUG' } }
           - { name: RUBY_DEBUG,                     env: { cppflags: '-DRUBY_DEBUG' } }
-          - { name: RUBY_DEVEL,                     env: { cppflags: '-DRUBY_DEVEL' } }
 #         - { name: ARRAY_DEBUG,                    env: { cppflags: '-DARRAY_DEBUG' } }
 #         - { name: BIGNUM_DEBUG,                   env: { cppflags: '-DBIGNUM_DEBUG' } }
 #         - { name: CCAN_LIST_DEBUG,                env: { cppflags: '-DCCAN_LIST_DEBUG' } }

--- a/configure.ac
+++ b/configure.ac
@@ -622,8 +622,13 @@ AS_IF([test "$fdeclspec" = yes], [
     RUBY_APPEND_OPTIONS(CXXFLAGS, -fdeclspec)
 ])
 
-AS_IF([test "x$RUBY_DEVEL" != xyes], [RUBY_DEVEL=no])
-particular_werror_flags=$RUBY_DEVEL
+AC_ARG_ENABLE(devel,
+    AS_HELP_STRING([--enable-devel], [enable development build]),
+    [RUBY_DEVEL=$enableval],
+    [AS_IF([test "x${RUBY_DEVEL-no}" != xyes], [RUBY_DEVEL=])]
+)dnl
+AC_SUBST(RUBY_DEVEL)
+particular_werror_flags=${RUBY_DEVEL:-no}
 AC_ARG_ENABLE(werror,
 	AS_HELP_STRING([--disable-werror],
 		       [don't make warnings into errors
@@ -867,7 +872,6 @@ AS_IF([test "$GCC" = yes], [
     test "${debugflags+set}" || {RUBY_TRY_CFLAGS(-g3, [debugflags=-g3])}
 ])
 test $ac_cv_prog_cc_g = yes && : ${debugflags=-g}
-AS_IF([test "x$RUBY_DEVEL" = xyes], [RUBY_APPEND_OPTION(XCFLAGS, -DRUBY_DEVEL=1)])
 
 AS_IF([test "$GCC" = ""], [
     AS_CASE(["$target_os"],[aix*],[warnflags="$warnflags -qinfo=por" rb_cv_warnflags="$rb_cv_warnflags -qinfo=por"])

--- a/template/Makefile.in
+++ b/template/Makefile.in
@@ -89,7 +89,9 @@ optflags = @optflags@
 debugflags = @debugflags@
 warnflags = @warnflags@ @strict_warnflags@
 cppflags = @cppflags@
-XCFLAGS = @XCFLAGS@ $(INCFLAGS)
+RUBY_DEVEL = @RUBY_DEVEL@ # "yes" or empty
+_RUBY_DEVEL_enabled = $(RUBY_DEVEL:no=)
+XCFLAGS = @XCFLAGS@ $(INCFLAGS) $(_RUBY_DEVEL_enabled:yes=-DRUBY_DEVEL=1)
 USE_RUBYGEMS = @USE_RUBYGEMS@
 USE_RUBYGEMS_ = $(USE_RUBYGEMS:yes=)
 CPPFLAGS = @CPPFLAGS@ $(USE_RUBYGEMS_:no=-DDISABLE_RUBYGEMS=1)

--- a/win32/configure.bat
+++ b/win32/configure.bat
@@ -34,6 +34,8 @@ if "%1" == "--enable-install-static-library" goto :enable-lib
 if "%1" == "--disable-install-static-library" goto :disable-lib
 if "%1" == "--enable-debug-env" goto :enable-debug-env
 if "%1" == "--disable-debug-env" goto :disable-debug-env
+if "%1" == "--enable-devel" goto :enable-devel
+if "%1" == "--disable-devel" goto :disable-devel
 if "%1" == "--enable-rubygems" goto :enable-rubygems
 if "%1" == "--disable-rubygems" goto :disable-rubygems
 if "%1" == "--enable-mjit-support" goto :enable-mjit-support
@@ -140,6 +142,16 @@ goto :loop ;
 goto :loop ;
 :disable-debug-env
   echo>> ~tmp~.mak 	"ENABLE_DEBUG_ENV=no" \
+  echo>>confargs.tmp  %1 \
+  shift
+goto :loop ;
+:enable-devel
+  echo>> ~tmp~.mak 	"RUBY_DEVEL=yes" \
+  echo>>confargs.tmp  %1 \
+  shift
+goto :loop ;
+:disable-devel
+  echo>> ~tmp~.mak 	"RUBY_DEVEL=no" \
   echo>>confargs.tmp  %1 \
   shift
 goto :loop ;

--- a/win32/setup.mak
+++ b/win32/setup.mak
@@ -80,6 +80,9 @@ $(BANG)else
 HAVE_BASERUBY = no
 $(BANG)endif
 <<
+!if "$(RUBY_DEVEL)" == "yes"
+	RUBY_DEVEL = yes
+!endif
 !if "$(GIT)" != ""
 	@echo GIT = $(GIT)>> $(MAKEFILE)
 !endif
@@ -197,7 +200,6 @@ echo MINOR = RUBY_VERSION_MINOR
 echo TEENY = RUBY_VERSION_TEENY
 echo ABI_VERSION = RUBY_ABI_VERSION
 #if defined RUBY_PATCHLEVEL && RUBY_PATCHLEVEL < 0
-echo RUBY_DEVEL = yes
 #endif
 set /a MSC_VER = _MSC_VER
 #if _MSC_VER >= 1920


### PR DESCRIPTION
Since `RUBY_DEVEL` in cppflags has no effect in the configure script and makefiles.