### PR TITLE
Handle `\0`, `^D` and `^Z` correctly in Ripper.lex

### DIFF
--- a/ext/ripper/lib/ripper/lexer.rb
+++ b/ext/ripper/lib/ripper/lexer.rb
@@ -178,9 +178,13 @@ class Ripper
       if raise_errors and !@errors.empty?
         raise SyntaxError, @errors.map(&:message).join(' ;')
       end
-      @buf.flatten!
-      unless (result = @buf).empty?
-        result.concat(@buf) until (@buf = []; super(); @buf.flatten!; @buf.empty?)
+      result = @buf.flatten
+      prev_errors_size = 0
+      until @errors.size == prev_errors_size
+        prev_errors_size = @errors.size
+        @buf = []
+        super()
+        result.concat(@buf.flatten)
       end
       result
     end

--- a/test/ripper/test_lexer.rb
+++ b/test/ripper/test_lexer.rb
@@ -100,6 +100,12 @@ class TestRipper::Lexer < Test::Unit::TestCase
     assert_equal expect, Ripper.lex(src).map {|e| e[1]}
   end
 
+  def test_end_of_script_char
+    ["a\0b", "a\4b", "a\32b"].each do |src|
+      assert_equal [:on_ident], Ripper.lex(src).map {|e| e[1]}
+    end
+  end
+
   def test_slice
     assert_equal "string\#{nil}\n",
       Ripper.slice(%(<<HERE\nstring\#{nil}\nHERE), "heredoc_beg .*? nl $(.*?) heredoc_end", 1)


### PR DESCRIPTION
Ripper.lex does not handle `\0`, `^D` and `^Z` correctly.
```ruby
require 'ripper'
p Ripper.lex("hello\0\0world").map{_3} #=> ["hello"]
p Ripper.lex("hello\0world").map{_3}   #=> ["hello", "\u0000world"]
p Ripper.lex("hello\0@world").map{_3}  #=> ["hello", "@world"]
p Ripper.lex("hello\0:world").map{_3}  #=> ["hello", "\u0000:", "world"]
p Ripper.lex("hello\0))").map{_3}      #=> ["hello", "\u0000)", ")"]
# expect all to be ["hello"]
```

Lexer tries to parse several times to fully parse all tokens in syntax invalid code.
It also parses again when it is syntax ok which means already parsed all tokens or reached `\0`, `^D` or `^Z`.
I changed it to parse again only if there are new errors.

```ruby
require 'ripper'
p Ripper.lex("hello\0\0world").map{_3} #=> ["hello"]
p Ripper.lex("hello\0world").map{_3}   #=> ["hello"]
p Ripper.lex("hello\0@world").map{_3}  #=> ["hello"]
p Ripper.lex("hello\0:world").map{_3}  #=> ["hello"]
p Ripper.lex("hello\0))").map{_3}      #=> ["hello"]

# This pull request does not solve problems for syntax invalid code
p Ripper.lex("end\0*").map{[_2,_3]} # => [[:on_kw, "end"], [:on_op, "\u0000*"]]
# expect [[:on_kw, "end"], [:on_op, "*"]] or [[:on_kw, "end"]]
```
