### PR TITLE
YJIT: Implement concatarray in yjit

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -3066,3 +3066,13 @@ assert_equal '10', %q{
 
   a.length
 }
+
+assert_equal '[1, 2]', %q{
+  def foo
+    x = [2]
+    [1, *x]
+  end
+
+  foo
+  foo
+}

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -4379,6 +4379,12 @@ vm_concat_array(VALUE ary1, VALUE ary2st)
     return rb_ary_concat(tmp1, tmp2);
 }
 
+VALUE
+rb_vm_concat_array(VALUE ary1, VALUE ary2st)
+{
+    return vm_concat_array(ary1, ary2st);
+}
+
 static VALUE
 vm_splat_array(VALUE flag, VALUE ary)
 {

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -5986,6 +5986,7 @@ fn get_gen_fn(opcode: VALUE) -> Option<InsnGenFn> {
         YARVINSN_opt_str_freeze => Some(gen_opt_str_freeze),
         YARVINSN_opt_str_uminus => Some(gen_opt_str_uminus),
         YARVINSN_splatarray => Some(gen_splatarray),
+        YARVINSN_concatarray => Some(gen_concatarray),
         YARVINSN_newrange => Some(gen_newrange),
         YARVINSN_putstring => Some(gen_putstring),
         YARVINSN_expandarray => Some(gen_expandarray),

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -262,6 +262,7 @@ extern "C" {
     // Ruby only defines these in vm_insnhelper.c, not in any header.
     // Parsing it would result in a lot of duplicate definitions.
     pub fn rb_vm_splat_array(flag: VALUE, ary: VALUE) -> VALUE;
+    pub fn rb_vm_concat_array(ary1: VALUE, ary2st: VALUE) -> VALUE;
     pub fn rb_vm_defined(
         ec: EcPtr,
         reg_cfp: CfpPtr,


### PR DESCRIPTION
Paired with @jhawthorn on this 🎉 

# Changes 
Implement `concatarray` in YJIT so it doesn't cause any side exits. 

It's currently just calling the C function `vm_concat_array` but there's potential to use `guard_object_is_array` in the future to save on the `is_a` check. 

