### PR TITLE
Simplify around `USE_YJIT` macro

### DIFF
--- a/iseq.c
+++ b/iseq.c
@@ -175,7 +175,7 @@ rb_iseq_free(const rb_iseq_t *iseq)
         iseq_clear_ic_references(iseq);
         struct rb_iseq_constant_body *const body = ISEQ_BODY(iseq);
         mjit_free_iseq(iseq); /* Notify MJIT */
-#if YJIT_BUILD
+#if USE_YJIT
         rb_yjit_iseq_free(body->yjit_payload);
 #endif
         ruby_xfree((void *)body->iseq_encoded);
@@ -438,7 +438,7 @@ rb_iseq_update_references(rb_iseq_t *iseq)
 #if USE_MJIT
         mjit_update_references(iseq);
 #endif
-#if YJIT_BUILD
+#if USE_YJIT
         rb_yjit_iseq_update_references(body->yjit_payload);
 #endif
     }
@@ -526,7 +526,7 @@ rb_iseq_mark(const rb_iseq_t *iseq)
 #if USE_MJIT
         mjit_mark_cc_entries(body);
 #endif
-#if YJIT_BUILD
+#if USE_YJIT
         rb_yjit_iseq_mark(body->yjit_payload);
 #endif
     }

--- a/ruby.c
+++ b/ruby.c
@@ -111,7 +111,7 @@ void rb_warning_category_update(unsigned int mask, unsigned int bits);
 enum feature_flag_bits {
     EACH_FEATURES(DEFINE_FEATURE, COMMA),
     feature_debug_flag_first,
-#if defined(MJIT_FORCE_ENABLE) || !YJIT_BUILD
+#if defined(MJIT_FORCE_ENABLE) || !USE_YJIT
     DEFINE_FEATURE(jit) = feature_mjit,
 #else
     DEFINE_FEATURE(jit) = feature_yjit,
@@ -248,7 +248,7 @@ usage(const char *name, int help, int highlight, int columns)
 
 #define M(shortopt, longopt, desc) RUBY_OPT_MESSAGE(shortopt, longopt, desc)
 
-#if YJIT_BUILD
+#if USE_YJIT
 # define PLATFORM_JIT_OPTION "--yjit"
 #else
 # define PLATFORM_JIT_OPTION "--mjit"
@@ -278,7 +278,7 @@ usage(const char *name, int help, int highlight, int columns)
 #if USE_MJIT
         M("--mjit",        "",                     "enable C compiler-based JIT compiler (experimental)"),
 #endif
-#if YJIT_BUILD
+#if USE_YJIT
         M("--yjit",        "",                     "enable in-process JIT compiler (experimental)"),
 #endif
         M("-h",		   "",			   "show this message, --help for more info"),
@@ -312,7 +312,7 @@ usage(const char *name, int help, int highlight, int columns)
 #if USE_MJIT
         M("mjit", "",           "C compiler-based JIT compiler (default: disabled)"),
 #endif
-#if YJIT_BUILD
+#if USE_YJIT
         M("yjit", "",           "in-process JIT compiler (default: disabled)"),
 #endif
     };
@@ -323,7 +323,7 @@ usage(const char *name, int help, int highlight, int columns)
 #if USE_MJIT
     extern const struct ruby_opt_message mjit_option_messages[];
 #endif
-#if YJIT_BUILD
+#if USE_YJIT
     static const struct ruby_opt_message yjit_options[] = {
 #if YJIT_STATS
         M("--yjit-stats",              "", "Enable collecting YJIT statistics"),
@@ -365,7 +365,7 @@ usage(const char *name, int help, int highlight, int columns)
     for (i = 0; mjit_option_messages[i].str; ++i)
         SHOW(mjit_option_messages[i]);
 #endif
-#if YJIT_BUILD
+#if USE_YJIT
     printf("%s""YJIT options (experimental):%s\n", sb, se);
     for (i = 0; i < numberof(yjit_options); ++i)
         SHOW(yjit_options[i]);
@@ -1047,7 +1047,7 @@ set_option_encoding_once(const char *type, VALUE *name, const char *e, long elen
 #define yjit_opt_match_arg(s, l, name) \
     opt_match(s, l, name) && (*(s) && *(s+1) ? 1 : (rb_raise(rb_eRuntimeError, "--yjit-" name " needs an argument"), 0))
 
-#if YJIT_BUILD
+#if USE_YJIT
 static bool
 setup_yjit_options(const char *s)
 {
@@ -1452,7 +1452,7 @@ proc_options(long argc, char **argv, ruby_cmdline_options_t *opt, int envopt)
 #endif
             }
             else if (is_option_with_optarg("yjit", '-', true, false, false)) {
-#if YJIT_BUILD
+#if USE_YJIT
                 FEATURE_SET(opt->features, FEATURE_BIT(yjit));
                 setup_yjit_options(s);
 #else
@@ -1831,7 +1831,7 @@ process_options(int argc, char **argv, ruby_cmdline_options_t *opt)
         rb_warning("-K is specified; it is for 1.8 compatibility and may cause odd behavior");
 
     if (!(FEATURE_SET_BITS(opt->features) & feature_jit_mask)) {
-#if YJIT_BUILD
+#if USE_YJIT
         if (!FEATURE_USED_P(opt->features, yjit) && getenv("RUBY_YJIT_ENABLE")) {
             FEATURE_SET(opt->features, FEATURE_BIT(yjit));
         }
@@ -1847,7 +1847,7 @@ process_options(int argc, char **argv, ruby_cmdline_options_t *opt)
         opt->mjit.on = TRUE; /* set mjit.on for ruby_show_version() API and check to call mjit_init() */
     }
 #endif
-#if YJIT_BUILD
+#if USE_YJIT
     if (FEATURE_SET_P(opt->features, yjit)) {
         rb_yjit_init();
     }

--- a/vm.c
+++ b/vm.c
@@ -3938,7 +3938,7 @@ Init_vm_objects(void)
 }
 
 /* Stub for builtin function when not building YJIT units*/
-#if !YJIT_BUILD
+#if !USE_YJIT
 void Init_builtin_yjit(void) {}
 #endif
 

--- a/vm_core.h
+++ b/vm_core.h
@@ -495,7 +495,6 @@ struct rb_iseq_constant_body {
 
 #if USE_YJIT
     // YJIT stores some data on each iseq.
-    // Note: Cannot use YJIT_BUILD here since yjit.h includes this header.
     void *yjit_payload;
 #endif
 };

--- a/yjit.h
+++ b/yjit.h
@@ -15,23 +15,19 @@
 # define YJIT_STATS RUBY_DEBUG
 #endif
 
+#if USE_YJIT
+
 // We generate x86 assembly
 #if (defined(__x86_64__) && !defined(_WIN32)) || (defined(_WIN32) && defined(_M_AMD64)) // x64 platforms without mingw/msys
-# define YJIT_SUPPORTED_P 1
+// YJIT-supported platforms
 #else
-# define YJIT_SUPPORTED_P 0
+// Unsupported platforms
+# undef USE_YJIT
+# define USE_YJIT 0
+#endif
 #endif
 
-// Is the output binary going to include YJIT?
-#if USE_MJIT && USE_YJIT && YJIT_SUPPORTED_P
-# define YJIT_BUILD 1
-#else
-# define YJIT_BUILD 0
-#endif
-
-#undef YJIT_SUPPORTED_P
-
-#if YJIT_BUILD
+#if USE_YJIT
 
 // Expose these as declarations since we are building YJIT.
 bool rb_yjit_enabled_p(void);
@@ -54,7 +50,7 @@ void rb_yjit_constant_ic_update(const rb_iseq_t *const iseq, IC ic);
 void rb_yjit_tracing_invalidate_all(void);
 
 #else
-// !YJIT_BUILD
+// !USE_YJIT
 // In these builds, YJIT could never be turned on. Provide dummy implementations.
 
 static inline bool rb_yjit_enabled_p(void) { return false; }
@@ -76,6 +72,6 @@ static inline void rb_yjit_before_ractor_spawn(void) {}
 static inline void rb_yjit_constant_ic_update(const rb_iseq_t *const iseq, IC ic) {}
 static inline void rb_yjit_tracing_invalidate_all(void) {}
 
-#endif // #if YJIT_BUILD
+#endif // #if USE_YJIT
 
 #endif // #ifndef YJIT_H

--- a/yjit.h
+++ b/yjit.h
@@ -18,16 +18,11 @@
 #if USE_YJIT
 
 // We generate x86 assembly
-#if (defined(__x86_64__) && !defined(_WIN32)) || (defined(_WIN32) && defined(_M_AMD64)) // x64 platforms without mingw/msys
-// YJIT-supported platforms
+#if defined(_WIN32) ? defined(_M_AMD64) : defined(__x86_64__)
+// x86_64 platforms without mingw/msys or x64-mswin
 #else
-// Unsupported platforms
-# undef USE_YJIT
-# define USE_YJIT 0
+# error YJIT unsupported platform
 #endif
-#endif
-
-#if USE_YJIT
 
 // Expose these as declarations since we are building YJIT.
 bool rb_yjit_enabled_p(void);


### PR DESCRIPTION
There are also `YJIT_SUPPORTED_P` and `YJIT_BUILD`, and seem over complicated.