### PR TITLE
Added vm setivar benchmark from yjit-bench

### DIFF
--- a/benchmark/vm_ivar_set_on_instance.yml
+++ b/benchmark/vm_ivar_set_on_instance.yml
@@ -1,0 +1,35 @@
+prelude: |
+    class TheClass
+        def initialize
+            @v0 = 1
+            @v1 = 2
+            @v3 = 3
+            @levar = 1
+        end
+
+        def set_value_loop
+            # 1M
+            i = 0
+            while i < 1000000
+                # 10 times to de-emphasize loop overhead
+                @levar = i
+                @levar = i
+                @levar = i
+                @levar = i
+                @levar = i
+                @levar = i
+                @levar = i
+                @levar = i
+                @levar = i
+                @levar = i
+                i += 1
+            end
+        end
+    end
+
+    obj = TheClass.new
+
+benchmark:
+  vm_ivar_set_on_instance: |
+    obj.set_value_loop
+loop_count: 100


### PR DESCRIPTION
Copied over [this benchmark](https://github.com/Shopify/yjit-bench/blob/main/benchmarks/setivar.rb) on setting ivars