### PR TITLE
ext/pty/extconf.rb: Try libutil only on OpenBSD

### DIFF
--- a/ext/pty/extconf.rb
+++ b/ext/pty/extconf.rb
@@ -7,10 +7,12 @@ if /mswin|mingw|bccwin/ !~ RUBY_PLATFORM
   have_header("sys/stropts.h")
   have_func("setresuid")
   have_header("libutil.h")
-  have_header("util.h") # OpenBSD openpty
   have_header("pty.h")
   have_header("pwd.h")
-  util = have_library("util", "openpty")
+  if /openbsd/ =~ RUBY_PLATFORM
+    have_header("util.h") # OpenBSD openpty
+    util = have_library("util", "openpty")
+  end
   if have_func("posix_openpt") or
       (util or have_func("openpty")) or
       have_func("_getpty") or


### PR DESCRIPTION
icc now seems to provide libutil.so that is not related to pty.
This extconf.rb wrongly finds it and adds `-lutil`, but `ruby -rpty`
fails because it cannot find libutil.so on the runtime.

http://rubyci.s3.amazonaws.com/icc-x64/ruby-master/log/20220815T210005Z.fail.html.gz
```
Exception raised:
<#<LoadError: libutil.so: cannot open shared object file: No such file or directory - /home/chkbuild/chkbuild/tmp/build/20220815T210005Z/ruby/.ext/x86_64-linux/pty.so>>
```

This change makes extconf.rb check libutil only on OpenBSD.