### PR TITLE
Allow strings in `assert_pattern_list`

### DIFF
--- a/tool/lib/core_assertions.rb
+++ b/tool/lib/core_assertions.rb
@@ -548,11 +548,13 @@ eom
             anchored = false
           else
             if anchored
-              match = /\A#{pattern}/.match(rest)
+              match = rest.rindex(pattern, 0)
             else
-              match = pattern.match(rest)
+              match = rest.index(pattern)
             end
-            unless match
+            if match
+              post_match = $~ ? $~.post_match : rest[match+pattern.size..-1]
+            else
               msg = message(msg) {
                 expect_msg = "Expected #{mu_pp pattern}\n"
                 if /\n[^\n]/ =~ rest
@@ -569,7 +571,7 @@ eom
               }
               assert false, msg
             end
-            rest = match.post_match
+            rest = post_match
             anchored = true
           end
         }

--- a/tool/test/testunit/test_assertion.rb
+++ b/tool/test/testunit/test_assertion.rb
@@ -35,6 +35,14 @@ class TestAssertion < Test::Unit::TestCase
     assert_pattern_list([:*, /foo?/], "afoo")
     assert_not_pattern_list([:*, /foo?/], "afoo?")
     assert_pattern_list([/foo?/, :*], "foo?")
+
+    assert_not_pattern_list(["foo?"], "foo")
+    assert_not_pattern_list(["foo?"], "afoo")
+    assert_pattern_list(["foo?"], "foo?")
+    assert_not_pattern_list([:*, "foo?", :*], "foo")
+    assert_not_pattern_list([:*, "foo?"], "afoo")
+    assert_pattern_list([:*, "foo?"], "afoo?")
+    assert_pattern_list(["foo?", :*], "foo?")
   end
 
   def assert_not_pattern_list(pattern_list, actual, message=nil)


### PR DESCRIPTION
Also `assert_in_out_err`.
Only I found is `TestErbCommand#test_deprecated_option` in test/erb/test_erb_command.rb.