### PR TITLE
[Bug #18956] Negative codepoints are invalid characters

### DIFF
--- a/sprintf.c
+++ b/sprintf.c
@@ -448,8 +448,8 @@ rb_str_format(int argc, const VALUE *argv, VALUE fmt)
                     RB_GC_GUARD(tmp);
                 }
                 else {
-                    c = NUM2INT(val);
-                    n = rb_enc_codelen(c, enc);
+                    n = NUM2INT(val);
+                    if (n >= 0) n = rb_enc_codelen((c = n), enc);
                 }
                 if (n <= 0) {
                     rb_raise(rb_eArgError, "invalid character");

--- a/test/ruby/test_sprintf.rb
+++ b/test/ruby/test_sprintf.rb
@@ -367,6 +367,7 @@ class TestSprintf < Test::Unit::TestCase
     assert_equal(" " * (BSIZ - 1) + "a", sprintf(" " * (BSIZ - 1) + "%-1c", ?a))
     assert_equal(" " * BSIZ + "a", sprintf("%#{ BSIZ + 1 }c", ?a))
     assert_equal("a" + " " * BSIZ, sprintf("%-#{ BSIZ + 1 }c", ?a))
+    assert_raise(ArgumentError) { sprintf("%c", -1) }
   end
 
   def test_string


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/18956