### PR TITLE
[Bug #18958] printf format string must be ASCII compatible

### DIFF
--- a/sprintf.c
+++ b/sprintf.c
@@ -250,6 +250,7 @@ rb_str_format(int argc, const VALUE *argv, VALUE fmt)
     --argv;
     StringValue(fmt);
     enc = rb_enc_get(fmt);
+    rb_must_asciicompat(fmt);
     orig = fmt;
     fmt = rb_str_tmp_frozen_acquire(fmt);
     p = RSTRING_PTR(fmt);

--- a/string.c
+++ b/string.c
@@ -2526,6 +2526,9 @@ void
 rb_must_asciicompat(VALUE str)
 {
     rb_encoding *enc = rb_enc_get(str);
+    if (!enc) {
+        rb_raise(rb_eTypeError, "not encoding capable object");
+    }
     if (!rb_enc_asciicompat(enc)) {
         rb_raise(rb_eEncCompatError, "ASCII incompatible encoding: %s", rb_enc_name(enc));
     }

--- a/test/ruby/test_m17n.rb
+++ b/test/ruby/test_m17n.rb
@@ -896,6 +896,16 @@ class TestM17N < Test::Unit::TestCase
 
   def test_sprintf_p
     Encoding.list.each do |e|
+      unless e.ascii_compatible?
+        format = e.dummy? ? "%p".force_encoding(e) : "%p".encode(e)
+        assert_raise(Encoding::CompatibilityError) do
+          sprintf(format, nil)
+        end
+        assert_raise(Encoding::CompatibilityError) do
+          format % nil
+        end
+        next
+      end
       format = "%p".force_encoding(e)
       ['', 'a', "\xC2\xA1", "\x00"].each do |s|
         s.force_encoding(e)


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/18958