### PR TITLE
Reuse `nonlocal_var` pattern

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -5071,10 +5071,8 @@ nonlocal_var    : tIVAR
 		;
 
 user_variable	: tIDENTIFIER
-		| tIVAR
-		| tGVAR
+		| nonlocal_var
 		| tCONSTANT
-		| tCVAR
 		;
 
 keyword_variable: keyword_nil {$$ = KWD2EID(nil, $1);}

--- a/parse.y
+++ b/parse.y
@@ -5071,8 +5071,8 @@ nonlocal_var    : tIVAR
 		;
 
 user_variable	: tIDENTIFIER
-		| nonlocal_var
 		| tCONSTANT
+		| nonlocal_var
 		;
 
 keyword_variable: keyword_nil {$$ = KWD2EID(nil, $1);}

--- a/parse.y
+++ b/parse.y
@@ -5035,9 +5035,7 @@ ssym		: tSYMBEG sym
 		;
 
 sym		: fname
-		| tIVAR
-		| tGVAR
-		| tCVAR
+		| nonlocal_var
 		;
 
 dsym		: tSYMBEG string_contents tSTRING_END


### PR DESCRIPTION
`sym` and `nonlocal_var` pattern using same pattern in `parse.y`.

```y
sym		: fname
		| tIVAR
		| tGVAR
		| tCVAR
		;
```

```y
nonlocal_var    : tIVAR
		| tGVAR
		| tCVAR
		;
```

I thought better and more simpler to reuse `nonlocal_var` pattern.
