### PR TITLE
Remove unused FILE from cruby.rs

### DIFF
--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -378,13 +378,6 @@ pub struct rb_method_cfunc_t {
     _marker: core::marker::PhantomData<(*mut u8, core::marker::PhantomPinned)>,
 }
 
-/// Opaque FILE type from the C standard library
-#[repr(C)]
-pub struct FILE {
-    _data: [u8; 0],
-    _marker: core::marker::PhantomData<(*mut u8, core::marker::PhantomPinned)>,
-}
-
 /// Opaque call-cache type from vm_callinfo.h
 #[repr(C)]
 pub struct rb_callcache {


### PR DESCRIPTION
Suppressing the following warning:

```
building Rust YJIT (dev_nodebug mode)
warning: struct `FILE` is never constructed
   --> src/cruby.rs:383:12
    |
383 | pub struct FILE {
    |            ^^^^
    |
    = note: `#[warn(dead_code)]` on by default
```