### PR TITLE
Add `yjit.rb` to `.document`

### DIFF
--- a/.document
+++ b/.document
@@ -27,6 +27,7 @@ timev.rb
 thread_sync.rb
 trace_point.rb
 warning.rb
+yjit.rb
 
 # the lib/ directory (which has its own .document file)
 lib


### PR DESCRIPTION
There was no rdoc that comments in `yjit.rb` in the built ruby.
So, I added `yjit.rb` to the `.document` that to generate yjit rdoc