### PR TITLE
Fix Enumerator::Lazy#take(0)

### DIFF
--- a/enumerator.c
+++ b/enumerator.c
@@ -127,8 +127,8 @@ VALUE rb_cEnumerator;
 static VALUE rb_cLazy;
 static ID id_rewind, id_new, id_to_enum, id_each_entry;
 static ID id_next, id_result, id_receiver, id_arguments, id_memo, id_method, id_force;
-static ID id_begin, id_end, id_step, id_exclude_end;
-static VALUE sym_each, sym_cycle, sym_yield;
+static ID id_begin, id_end, id_step, id_exclude_end, id_cycle;
+static VALUE sym_each, sym_yield;
 
 static VALUE lazy_use_super_method;
 
@@ -2467,9 +2467,7 @@ lazy_take(VALUE obj, VALUE n)
     }
 
     if (len == 0) {
-       argv[0] = sym_cycle;
-       argv[1] = INT2NUM(0);
-       argc = 2;
+       obj = rb_funcall(obj, id_cycle, 1, INT2NUM(0));
     }
 
     return lazy_add_method(obj, argc, argv, n, rb_ary_new3(1, n), &lazy_take_funcs);
@@ -4620,8 +4618,8 @@ Init_Enumerator(void)
     id_end = rb_intern_const("end");
     id_step = rb_intern_const("step");
     id_exclude_end = rb_intern_const("exclude_end");
+    id_cycle = rb_intern_const("cycle");
     sym_each = ID2SYM(id_each);
-    sym_cycle = ID2SYM(rb_intern_const("cycle"));
     sym_yield = ID2SYM(rb_intern_const("yield"));
 
     InitVM(Enumerator);

--- a/test/ruby/test_lazy_enumerator.rb
+++ b/test/ruby/test_lazy_enumerator.rb
@@ -295,6 +295,21 @@ class TestLazyEnumerator < Test::Unit::TestCase
     assert_equal(nil, a.current)
   end
 
+  def test_take_0_bug_18971
+    assert_equal([], (2..10).lazy.take(0).map(&:itself).to_a)
+    assert_equal([], (2..10).lazy.take(0).select(&:even?).to_a)
+    assert_equal([], (2..10).lazy.take(0).select(&:odd?).to_a)
+    assert_equal([], (2..10).lazy.take(0).reject(&:even?).to_a)
+    assert_equal([], (2..10).lazy.take(0).reject(&:odd?).to_a)
+    assert_equal([], (2..10).lazy.take(0).take(1).to_a)
+    assert_equal([], (2..10).lazy.take(0).take(0).take(1).to_a)
+    assert_equal([], (2..10).lazy.take(0).drop(0).to_a)
+    assert_equal([], (2..10).lazy.take(0).find_all {|_| true}.to_a)
+    assert_equal([], (2..10).lazy.take(0).zip((12..20)).to_a)
+    assert_equal([], (2..10).lazy.take(0).uniq.to_a)
+    assert_equal([], (2..10).lazy.take(0).sort.to_a)
+  end
+
   def test_take_bad_arg
     a = Step.new(1..10)
     assert_raise(ArgumentError) { a.lazy.take(-1) }
@@ -438,8 +453,8 @@ class TestLazyEnumerator < Test::Unit::TestCase
                  "foo".each_char.lazy.inspect)
     assert_equal("#<Enumerator::Lazy: #<Enumerator::Lazy: 1..10>:map>",
                  (1..10).lazy.map {}.inspect)
-    assert_equal("#<Enumerator::Lazy: #<Enumerator::Lazy: 1..10>:take(0)>",
-                 (1..10).lazy.take(0).inspect)
+    assert_equal("#<Enumerator::Lazy: #<Enumerator::Lazy: 1..10>:take(1)>",
+                 (1..10).lazy.take(1).inspect)
     assert_equal("#<Enumerator::Lazy: #<Enumerator::Lazy: 1..10>:take(3)>",
                  (1..10).lazy.take(3).inspect)
     assert_equal('#<Enumerator::Lazy: #<Enumerator::Lazy: "a".."c">:grep(/b/)>',


### PR DESCRIPTION
With some usage of take(0), the first element is taken.

This implementation approach probably is suboptimal, it uses an
intermediate cycle(0) enumerator which does not appear to have this
problem.

Fixes [Bug #18971]