### PR TITLE
Raise ArgumentError when passing Integer >= 128 for %c for US-ASCII

### DIFF
--- a/sprintf.c
+++ b/sprintf.c
@@ -449,6 +449,9 @@ rb_str_format(int argc, const VALUE *argv, VALUE fmt)
                 }
                 else {
                     n = NUM2INT(val);
+                    if (n >= 128 && enc == rb_usascii_encoding()) {
+                        rb_raise(rb_eArgError, "invalid character");
+                    }
                     if (n >= 0) n = rb_enc_codelen((c = n), enc);
                 }
                 if (n <= 0) {

--- a/test/ruby/test_sprintf.rb
+++ b/test/ruby/test_sprintf.rb
@@ -369,6 +369,7 @@ class TestSprintf < Test::Unit::TestCase
     assert_equal(" " * BSIZ + "a", sprintf("%#{ BSIZ + 1 }c", ?a))
     assert_equal("a" + " " * BSIZ, sprintf("%-#{ BSIZ + 1 }c", ?a))
     assert_raise(ArgumentError) { sprintf("%c", -1) }
+    assert_raise(ArgumentError) { sprintf("%c".encode('US-ASCII'), 128) }
   end
 
   def test_string


### PR DESCRIPTION
US-ASCII only supports characters 0-127, so allowing >=128 previously
resulted in the returnined string not having a valid encoding.

Fixes [Bug #18973]