### PR TITLE
Disable Ractor check on 32bit architectures

### DIFF
--- a/ractor.c
+++ b/ractor.c
@@ -74,7 +74,9 @@ static void
 ractor_lock_self(rb_ractor_t *cr, const char *file, int line)
 {
     VM_ASSERT(cr == GET_RACTOR());
+#if RACTOR_CHECK_MODE > 0
     VM_ASSERT(cr->sync.locked_by != cr->pub.self);
+#endif
     ractor_lock(cr, file, line);
 }
 
@@ -94,7 +96,9 @@ static void
 ractor_unlock_self(rb_ractor_t *cr, const char *file, int line)
 {
     VM_ASSERT(cr == GET_RACTOR());
+#if RACTOR_CHECK_MODE > 0
     VM_ASSERT(cr->sync.locked_by == cr->pub.self);
+#endif
     ractor_unlock(cr, file, line);
 }
 

--- a/ractor_core.h
+++ b/ractor_core.h
@@ -5,7 +5,7 @@
 #include "vm_debug.h"
 
 #ifndef RACTOR_CHECK_MODE
-#define RACTOR_CHECK_MODE (0 || VM_CHECK_MODE || RUBY_DEBUG)
+#define RACTOR_CHECK_MODE (VM_CHECK_MODE || RUBY_DEBUG) && (SIZEOF_UINT64_T == SIZEOF_VALUE)
 #endif
 
 enum rb_ractor_basket_type {


### PR DESCRIPTION
Ractor verification requires storing the ractor id in the top 32 bits of
the object header.  Unfortunately 32 bit machines only have 32 bits in
the object header.  The verification code has a 32 bit left shift which
doesn't work on i686 and will clobber existing flags.

This commit disables the verification code on i686 since i686 will crash
if it's enabled.

Co-Authored-By: John Hawthorn <john@hawthorn.email>
Co-Authored-By: Jemma Issroff <jemmaissroff@gmail.com>