### PR TITLE
Fix private methods reported as protected when called via Symbol#to_proc

### DIFF
--- a/spec/ruby/core/symbol/to_proc_spec.rb
+++ b/spec/ruby/core/symbol/to_proc_spec.rb
@@ -58,8 +58,8 @@ describe "Symbol#to_proc" do
       @a = []
       singleton_class.class_eval(&body)
       tap(&:pub)
-      proc{tap(&:pro)}.should raise_error(NoMethodError)
-      proc{tap(&:pri)}.should raise_error(NoMethodError)
+      proc{tap(&:pro)}.should raise_error(NoMethodError, /protected method `pro' called/)
+      proc{tap(&:pri)}.should raise_error(NoMethodError, /private method `pri' called/)
       @a.should == [:pub]
 
       @a = []
@@ -67,8 +67,8 @@ describe "Symbol#to_proc" do
       o = c.new
       o.instance_variable_set(:@a, [])
       o.tap(&:pub)
-      proc{tap(&:pro)}.should raise_error(NoMethodError)
-      proc{o.tap(&:pri)}.should raise_error(NoMethodError)
+      proc{tap(&:pro)}.should raise_error(NoMethodError, /protected method `pro' called/)
+      proc{o.tap(&:pri)}.should raise_error(NoMethodError, /private method `pri' called/)
       o.a.should == [:pub]
     end
   end

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -3256,6 +3256,7 @@ vm_call_symbol(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp,
             return vm_call_method_each_type(ec, reg_cfp, calling);
           case METHOD_VISI_PRIVATE:
             vm_cc_method_missing_reason_set(cc, MISSING_PRIVATE);
+            break;
           case METHOD_VISI_PROTECTED:
             vm_cc_method_missing_reason_set(cc, MISSING_PROTECTED);
             break;


### PR DESCRIPTION
Ref: bfa6a8ddc84fffe0aef5a0f91b417167e124dbbf
Ref: https://github.com/ruby/ruby/pull/6018
Ref: [Bug #18826]

I noticed this while fixing some code relying on the old behavior in our app.