### PR TITLE
lib/mkmf.rb: retry FileUtils.rm_rf/rm_f up to three times

### DIFF
--- a/lib/mkmf.rb
+++ b/lib/mkmf.rb
@@ -257,13 +257,35 @@ MESSAGE
 
   def rm_f(*files)
     opt = (Hash === files.last ? [files.pop] : [])
-    FileUtils.rm_f(Dir[*files.flatten], *opt)
+    files = Dir[*files.flatten]
+    try_count = 0
+    begin
+      FileUtils.rm_f(files, *opt)
+    rescue SystemCallError
+      try_count += 1
+      if try_count < 3
+        sleep 1
+        retry
+      end
+      # Failed to delete the file; should we report it? How?
+    end
   end
   module_function :rm_f
 
   def rm_rf(*files)
     opt = (Hash === files.last ? [files.pop] : [])
-    FileUtils.rm_rf(Dir[*files.flatten], *opt)
+    files = Dir[*files.flatten]
+    try_count = 0
+    begin
+      FileUtils.rm_rf(files, *opt)
+    rescue SystemCallError
+      try_count += 1
+      if try_count < 3
+        sleep 1
+        retry
+      end
+      # Failed to delete the file; should we report it? How?
+    end
   end
   module_function :rm_rf
 

--- a/test/mkmf/test_constant.rb
+++ b/test/mkmf/test_constant.rb
@@ -2,14 +2,6 @@
 require_relative 'base'
 
 class TestMkmfTryConstant < TestMkmf
-  def setup
-    if ENV.key?('APPVEYOR')
-      @omitted = true
-      omit 'This test fails too often on AppVeyor'
-    end
-    super
-  end
-
   def test_simple
     assert_equal( 0, mkmf {try_constant("0")}, MKMFLOG)
     assert_equal( 1, mkmf {try_constant("1")}, MKMFLOG)


### PR DESCRIPTION
On Appveyor, it often fails to delete conftest.exe.
I'm unsure how the file is locked.

I cannot reproduce the issue on my Windows, so let me try this on CI.