### PR TITLE
header typos

### DIFF
--- a/include/ruby/assert.h
+++ b/include/ruby/assert.h
@@ -103,7 +103,7 @@
 # /* keep NDEBUG undefined */
 
 #elif (RBIMPL_NDEBUG == 0) && (RBIMPL_RUBY_DEBUG == 0)
-# /* The (*1) situation in avobe diagram. */
+# /* The (*1) situation in above diagram. */
 # define RUBY_DEBUG 0
 # define RUBY_NDEBUG 1
 # define NDEBUG

--- a/include/ruby/internal/arithmetic.h
+++ b/include/ruby/internal/arithmetic.h
@@ -18,7 +18,8 @@
  *             Do not  expect for  instance `__VA_ARGS__` is  always available.
  *             We assume C99  for ruby itself but we don't  assume languages of
  *             extension libraries.  They could be written in C++98.
- * @brief      Conversion between C's arithmtic types and Ruby's numeric types.
+ * @brief      Conversion between C's arithmetic types and Ruby's numeric types
+ *             .
  */
 #include "ruby/internal/arithmetic/char.h"
 #include "ruby/internal/arithmetic/double.h"

--- a/include/ruby/internal/attr/nodiscard.h
+++ b/include/ruby/internal/attr/nodiscard.h
@@ -26,7 +26,7 @@
 
 /**
  * Wraps  (or simulates)  `[[nodiscard]]`.  In  C++  (at least  since C++20)  a
- * nodiscard attribute can  have a message why the result  shall not be ignoed.
+ * nodiscard attribute can  have a message why the result shall not be ignored.
  * However GCC attribute and SAL annotation cannot take them.
  */
 #if RBIMPL_HAS_CPP_ATTRIBUTE(nodiscard)

--- a/include/ruby/internal/intern/select/posix.h
+++ b/include/ruby/internal/intern/select/posix.h
@@ -136,7 +136,7 @@ rb_fd_max(const rb_fdset_t *f)
 }
 
 /** @cond INTERNAL_MACRO */
-/* :FIXME: What are these?  They don't exist for shibling implementations. */
+/* :FIXME: What are these?  They don't exist for sibling implementations. */
 #define rb_fd_init_copy(d, s) (*(d) = *(s))
 #define rb_fd_term(f)   ((void)(f))
 /** @endcond */


### PR DESCRIPTION
@k0kubun per your request

include/ruby/assert.h
include/ruby/internal/arithmetic.h
include/ruby/internal/attr/nodiscard.h
include/ruby/internal/intern/select/posix.h

this only affects .h files installed on a system