### PR TITLE
Clarification for offset and timezone in Time

### DIFF
--- a/doc/time_offsets.rdoc
+++ b/doc/time_offsets.rdoc
@@ -1,12 +1,12 @@
-=== Timezone Specifiers
+=== \Time Offsets
 
-Certain methods in class Time accept arguments that specify timezones:
+Certain methods in class \Time accept arguments that specify time offsets:
 
 - Time.at: keyword argument +in:+.
-- Time.new: positional argument +zone+ or keyword argument +in:+.
+- Time.new: positional argument +offset+ or keyword argument +in:+.
 - Time.now: keyword argument +in:+.
-- Time#getlocal: positional argument +zone+.
-- Time#localtime: positional argument +zone+.
+- Time#getlocal: positional argument +offset+.
+- Time#localtime: positional argument +offset+.
 
 The value given with any of these must be one of the following:
 

--- a/time.c
+++ b/time.c
@@ -3829,7 +3829,7 @@ time_zonelocal(VALUE time, VALUE off)
 /*
  *  call-seq:
  *    localtime -> self or new_time
- *    localtime(zone) -> new_time
+ *    localtime(offset) -> new_time
  *
  *  With no argument given:
  *
@@ -3839,15 +3839,15 @@ time_zonelocal(VALUE time, VALUE off)
  *      t = Time.utc(2000, 1, 1, 20, 15, 1) # => 2000-01-01 20:15:01 UTC
  *      t.localtime                         # => 2000-01-01 14:15:01 -0600
  *
- *  With argument +zone+ given,
+ *  With argument +offset+ given,
  *  returns the new \Time object created by converting
- *  +self+ to the given time zone:
+ *  +self+ to the given time offset:
  *
  *    t = Time.utc(2000, 1, 1, 20, 15, 1) # => 2000-01-01 20:15:01 UTC
  *    t.localtime("-09:00")               # => 2000-01-01 11:15:01 -0900
  *
- *  For forms of argument +zone+, see
- *  {Timezone Specifiers}[rdoc-ref:timezone_specifiers.rdoc].
+ *  For values of argument +offset+, see
+ *  {Time Offsets}[rdoc-ref:time_offsets.rdoc].
  *
  */
 
@@ -3938,18 +3938,18 @@ time_fixoff(VALUE time)
 
 /*
  *  call-seq:
- *    getlocal(zone = nil) -> new_time
+ *    getlocal(offset = nil) -> new_time
  *
  *  Returns a new \Time object representing the value of +self+
- *  converted to a given timezone;
- *  if +zone+ is +nil+, the local timezone is used:
+ *  converted to a given time offset;
+ *  if +offset+ is +nil+, the local time offset is used:
  *
  *    t = Time.utc(2000)                    # => 2000-01-01 00:00:00 UTC
  *    t.getlocal                            # => 1999-12-31 18:00:00 -0600
  *    t.getlocal('+12:00')                  # => 2000-01-01 12:00:00 +1200
  *
- *  For forms of argument +zone+, see
- *  {Timezone Specifiers}[rdoc-ref:timezone_specifiers.rdoc].
+ *  For values of argument +offset+, see
+ *  {Time Offsets}[rdoc-ref:time_offsets.rdoc].
  *
  */
 

--- a/timev.rb
+++ b/timev.rb
@@ -110,9 +110,9 @@
 # === Methods for Creating
 #
 # - ::new: Returns a new time from specified arguments (year, month, etc.),
-#   including an optional timezone value.
+#   including an optional offset value.
 # - ::local (aliased as ::mktime): Same as ::new, except the
-#   timezone is the local timezone.
+#   offset is the local offset.
 # - ::utc (aliased as ::gm): Same as ::new, except the timezone is UTC.
 # - ::at: Returns a new time based on seconds since epoch.
 # - ::now: Returns a new time based on the current system time.
@@ -217,8 +217,8 @@ class Time
   #    Time.now               # => 2009-06-24 12:39:54 +0900
   #    Time.now(in: '+04:00') # => 2009-06-24 07:39:54 +0400
   #
-  # For forms of argument +zone+, see
-  # {Timezone Specifiers}[rdoc-ref:timezone_specifiers.rdoc].
+  # For values of keyword argument +in:+, see
+  # {Time Offsets}[rdoc-ref:time_offsets.rdoc].
   def self.now(in: nil)
     Primitive.time_s_now(Primitive.arg!(:in))
   end
@@ -267,15 +267,14 @@ class Time
   #     Time.at(secs, -1000000000, :nanosecond) # => 2000-12-31 23:59:58 -0600
   #
   #
-  # Optional keyword argument <tt>+in: zone</tt> specifies the timezone
+  # Optional keyword argument +in:+ specifies the offset
   # for the returned time:
   #
   #   Time.at(secs, in: '+12:00') # => 2001-01-01 17:59:59 +1200
   #   Time.at(secs, in: '-12:00') # => 2000-12-31 17:59:59 -1200
   #
-  # For the forms of argument +zone+, see
-  # {Timezone Specifiers}[rdoc-ref:timezone_specifiers.rdoc].
-  #
+  # For values of keyword argument +in:+, see
+  # {Time Offsets}[rdoc-ref:time_offsets.rdoc].
   def self.at(time, subsec = false, unit = :microsecond, in: nil)
     if Primitive.mandatory_only?
       Primitive.time_s_at1(time)
@@ -285,18 +284,18 @@ class Time
   end
 
   # Returns a new \Time object based on the given arguments,
-  # by default in the local timezone.
+  # by default in the local time offset.
   #
   # With no positional arguments, returns the value of Time.now:
   #
   #   Time.new # => 2021-04-24 17:27:46.0512465 -0500
   #
   # With one to six arguments, returns a new \Time object
-  # based on the given arguments, in the local timezone.
+  # based on the given arguments, in the local time offset.
   #
   #   Time.new(2000, 1, 2, 3, 4, 5) # => 2000-01-02 03:04:05 -0600
   #
-  # For the positional arguments (other than +zone+):
+  # For the positional arguments (other than +offset+):
   #
   # - +year+: Year, with no range limits:
   #
@@ -348,10 +347,8 @@ class Time
   #     # => ["0", "1", "1", "0", "0", "0"]
   #     Time.new(*a) # => 0000-01-01 00:00:00 -0600
   #
-  # When positional argument +zone+ or keyword argument +in:+ is given,
-  # the new \Time object is in the specified timezone.
-  # For the forms of argument +zone+, see
-  # {Timezone Specifiers}[rdoc-ref:timezone_specifiers.rdoc]:
+  # When positional argument +offset+ or keyword argument +in:+ is given,
+  # the new \Time object has the specified offset.
   #
   #   Time.new(2000, 1, 1, 0, 0, 0, '+12:00')
   #   # => 2000-01-01 00:00:00 +1200
@@ -360,19 +357,21 @@ class Time
   #   Time.new(in: '-12:00')
   #   # => 2022-08-23 08:49:26.1941467 -1200
   #
-  def initialize(year = (now = true), mon = nil, mday = nil, hour = nil, min = nil, sec = nil, zone = nil, in: nil)
-    if zone
+  # For values of positional argument +offset+ or keyword argument +in:+, see
+  # {Time Offsets}[rdoc-ref:time_offsets.rdoc].
+  def initialize(year = (now = true), mon = nil, mday = nil, hour = nil, min = nil, sec = nil, offset = nil, in: nil)
+    if offset
       if Primitive.arg!(:in)
-        raise ArgumentError, "timezone argument given as positional and keyword arguments"
+        raise ArgumentError, "Positional argument offset and keyword argument in: may not both be given."
       end
     else
-      zone = Primitive.arg!(:in)
+      offset = Primitive.arg!(:in)
     end
 
     if now
-      return Primitive.time_init_now(zone)
+      return Primitive.time_init_now(offset)
     end
 
-    Primitive.time_init_args(year, mon, mday, hour, min, sec, zone)
+    Primitive.time_init_args(year, mon, mday, hour, min, sec, offset)
   end
 end


### PR DESCRIPTION
Distinguishes between time offset and timezone.

This is not a [DOC] PR because it  changes a parameter name in one method.