### PR TITLE
[DOC] Enhanced RDoc for Time

### DIFF
--- a/time.c
+++ b/time.c
@@ -3489,7 +3489,7 @@ time_s_mktime(int argc, VALUE *argv, VALUE klass)
  *
  *  Returns the value of +self+ as integer
  *  {Epoch seconds}[rdoc-ref:Time@Epoch+Seconds];
- *  subseconds are omitted (not rounded):
+ *  subseconds are truncated (not rounded):
  *
  *    Time.utc(1970, 1, 1, 0, 0, 0).to_i         # => 0
  *    Time.utc(1970, 1, 1, 0, 0, 0, 999999).to_i # => 0
@@ -3498,12 +3498,7 @@ time_s_mktime(int argc, VALUE *argv, VALUE klass)
  *
  *  Time#tv_sec is an alias for Time#to_i.
  *
- *  Related:
- *
- *  - Time.to_f: returns Epoch seconds as a Float (may be approximate).
- *  - Time.to_r: returns Epoch seconds as a Rational (exact),
- *  - Time.at: returns the time for a given number of Epoch seconds).
- *
+ *  Related: Time#to_f Time#to_r.
  */
 
 static VALUE
@@ -3532,12 +3527,7 @@ time_to_i(VALUE time)
  *    Time.utc(1950, 1, 1, 0, 0, 0).to_f         # => -631152000.0
  *    Time.utc(1990, 1, 1, 0, 0, 0).to_f         # => 631152000.0
  *
- *  Related:
- *
- *  - Time.to_i: returns Epoch seconds as an integer (subseconds truncated).
- *  - Time.to_r: returns Epoch seconds as a Rational (exact),
- *  - Time.at: returns the time for a given number of Epoch seconds).
- *
+ *  Related: Time#to_i, Time#to_r.
  */
 
 static VALUE
@@ -3558,12 +3548,7 @@ time_to_f(VALUE time)
  *
  *    Time.now.to_r # => (16571402750320203/10000000)
  *
- *  Related:
- *
- *  - Time.to_f: returns Epoch seconds as a Float (may be approximate).
- *  - Time.to_i: returns Epoch seconds as an integer (subseconds truncated).
- *  - Time.at: returns the time for a given number of Epoch seconds).
- *
+ *  Related: Time#to_f, Time#to_i.
  */
 
 static VALUE

--- a/time.c
+++ b/time.c
@@ -3487,18 +3487,23 @@ time_s_mktime(int argc, VALUE *argv, VALUE klass)
  *  call-seq:
  *    to_i -> integer
  *
- *  Returns the number of seconds since the Epoch
- *  for the time represented in +self+:
+ *  Returns the value of +self+ as integer
+ *  {Epoch seconds}[rdoc-ref:Time@Epoch+Seconds];
+ *  subseconds are omitted (not rounded):
  *
- *    Time.utc(1970, 1, 1).to_i # => 0
- *    t = Time.now.to_i         # => 1595263289
- *
- *  Subseconds are omitted:
- *
- *    t = Time.now # => 2022-07-12 09:13:48.5075976 -0500
- *    t.to_i       # => 1657635228
+ *    Time.utc(1970, 1, 1, 0, 0, 0).to_i         # => 0
+ *    Time.utc(1970, 1, 1, 0, 0, 0, 999999).to_i # => 0
+ *    Time.utc(1950, 1, 1, 0, 0, 0).to_i         # => -631152000
+ *    Time.utc(1990, 1, 1, 0, 0, 0).to_i         # => 631152000
  *
  *  Time#tv_sec is an alias for Time#to_i.
+ *
+ *  Related:
+ *
+ *  - Time.to_f: returns Epoch seconds as a Float (may be approximate).
+ *  - Time.to_r: returns Epoch seconds as a Rational (exact),
+ *  - Time.at: returns the time for a given number of Epoch seconds).
+ *
  */
 
 static VALUE
@@ -3514,15 +3519,24 @@ time_to_i(VALUE time)
  *  call-seq:
  *    to_f -> float
  *
- *  Returns the value of +self+ as a Float number of seconds
- *  since the Epoch.
+ *  Returns the value of +self+ as a Float number
+ *  {Epoch seconds}[rdoc-ref:Time@Epoch+Seconds];
+ *  subseconds are included.
+ *
  *  The stored value of +self+ is a
  *  {Rational}[rdoc-ref:Rational@#method-i-to_f],
  *  which means that the returned value may be approximate:
  *
- *    t = Time.now # => 2022-07-07 11:23:18.0784889 -0500
- *    t.to_f       # => 1657210998.0784888
- *    t.to_i       # => 1657210998
+ *    Time.utc(1970, 1, 1, 0, 0, 0).to_f         # => 0.0
+ *    Time.utc(1970, 1, 1, 0, 0, 0, 999999).to_f # => 0.999999
+ *    Time.utc(1950, 1, 1, 0, 0, 0).to_f         # => -631152000.0
+ *    Time.utc(1990, 1, 1, 0, 0, 0).to_f         # => 631152000.0
+ *
+ *  Related:
+ *
+ *  - Time.to_i: returns Epoch seconds as an integer (subseconds truncated).
+ *  - Time.to_r: returns Epoch seconds as a Rational (exact),
+ *  - Time.at: returns the time for a given number of Epoch seconds).
  *
  */
 
@@ -3539,10 +3553,16 @@ time_to_f(VALUE time)
  *  call-seq:
  *    to_r -> rational
  *
- *  Returns the value of +self+ as a Rational number of seconds
- *  since the Epoch, which is exact:
+ *  Returns the value of +self+ as a Rational exact number of
+ *  {Epoch seconds}[rdoc-ref:Time@Epoch+Seconds];
  *
  *    Time.now.to_r # => (16571402750320203/10000000)
+ *
+ *  Related:
+ *
+ *  - Time.to_f: returns Epoch seconds as a Float (may be approximate).
+ *  - Time.to_i: returns Epoch seconds as an integer (subseconds truncated).
+ *  - Time.at: returns the time for a given number of Epoch seconds).
  *
  */
 

--- a/timev.rb
+++ b/timev.rb
@@ -1,19 +1,61 @@
-# Time is an abstraction of dates and times. Time is stored internally as
-# the number of seconds with subsecond since the _Epoch_,
-# 1970-01-01 00:00:00 UTC.
+# A \Time object represents a date and time:
 #
-# The Time class treats GMT
-# (Greenwich Mean Time) and UTC (Coordinated Universal Time) as equivalent.
+#   Time.new(2000, 1, 1, 0, 0, 0) # => 2000-01-01 00:00:00 -0600
+#
+# Although its value is stored internally as a single numeric
+# (see {Epoch Seconds}[rdoc-ref:Time@Epoch+Seconds] below),
+# it can be convenient to deal with the value by parts:
+#
+#   t = Time.new(-2000, 1, 1, 0, 0, 0.0)
+#   # => -2000-01-01 00:00:00 -0600
+#   t.year # => -2000
+#   t.month # => 1
+#   t.mday # => 1
+#   t.hour # => 0
+#   t.min # => 0
+#   t.sec # => 0
+#   t.subsec # => 0
+#
+#   t = Time.new(2000, 12, 31, 23, 59, 59.5)
+#   # => 2000-12-31 23:59:59.5 -0600
+#   t.year # => 2000
+#   t.month # => 12
+#   t.mday # => 31
+#   t.hour # => 23
+#   t.min # => 59
+#   t.sec # => 59
+#   t.subsec # => (1/2)
+#
+# == Epoch Seconds
+#
+# The value of a \Time object is stored internally as a Rational object
+# representing <i>Epoch seconds</i>,
+# which the exact number of seconds (including fractional subseconds)
+# since the Unix Epoch, January 1, 1970.
+#
+# You can retrieve that exact number using method Time.to_r:
+#
+#   Time.at(0).to_r        # => (0/1)
+#   Time.at(0.999999).to_r # => (9007190247541737/9007199254740992)
+#
+# Other retrieval methods such as Time.to_i and Time.to_f
+# may return a value that rounds or truncates subseconds.
+#
+# == \Time Resolution
+#
+# A \Time object derived from the system clock
+# (for example, by method Time.now)
+# has the resolution supported by the system.
+#
+# == GMT and UTC
+#
+# The \Time class treats
+# GMT ({Greenwich Mean Time}[https://en.wikipedia.org/wiki/Greenwich_Mean_Time])
+# and
+# UTC ({Coordinated Universal Time}[https://en.wikipedia.org/wiki/Coordinated_Universal_Time])
+# as equivalent.
 # GMT is the older way of referring to these baseline times but persists in
 # the names of calls on POSIX systems.
-#
-# Note: A \Time object uses the resolution available on your system clock.
-#
-# All times may have subsecond. Be aware of this fact when comparing times
-# with each other -- times that are apparently equal when displayed may be
-# different when compared.
-# (Since Ruby 2.7.0, Time#inspect shows subsecond but
-# Time#to_s still doesn't show subsecond.)
 #
 # == Examples
 #
@@ -229,7 +271,9 @@ class Time
   #
   # - A \Time object, whose value is the basis for the returned time;
   #   also influenced by optional keyword argument +in:+ (see below).
-  # - A numeric number of seconds (since the epoch) for the returned time.
+  # - A numeric number of
+  #   {Epoch seconds}[rdoc-ref:Time@Epoch+Seconds]
+  #   for the returned time.
   #
   # Examples:
   #
@@ -259,7 +303,7 @@ class Time
   #     Time.at(secs, 1000000, :microsecond)  # => 2001-01-01 00:00:00 -0600
   #     Time.at(secs, -1000000, :microsecond) # => 2000-12-31 23:59:58 -0600
   #
-  # - +:nsec+ or +:nanosecond+: +subsec+ in nanoseconds:
+  # - +:nanosecond+ or +:nsec+: +subsec+ in nanoseconds:
   #
   #     Time.at(secs, 0, :nanosecond)           # => 2000-12-31 23:59:59 -0600
   #     Time.at(secs, 500000000, :nanosecond)   # => 2000-12-31 23:59:59.5 -0600
@@ -275,6 +319,12 @@ class Time
   #
   # For the forms of argument +zone+, see
   # {Timezone Specifiers}[rdoc-ref:timezone_specifiers.rdoc].
+  #
+  # Related:
+  #
+  # - Time.to_f: returns Epoch seconds as a Float (may be approximate).
+  # - Time.to_i: returns Epoch seconds as an integer (subseconds truncated).
+  # - Time.to_r: returns Epoch seconds as a Rational (exact),
   #
   def self.at(time, subsec = false, unit = :microsecond, in: nil)
     if Primitive.mandatory_only?

--- a/timev.rb
+++ b/timev.rb
@@ -28,17 +28,15 @@
 #
 # == Epoch Seconds
 #
-# The value of a \Time object is stored internally as a Rational object
-# representing <i>Epoch seconds</i>,
-# which the exact number of seconds (including fractional subseconds)
-# since the Unix Epoch, January 1, 1970.
+<i>Epoch seconds</i> is the exact number of seconds
+(including fractional subseconds) since the Unix Epoch, January 1, 1970.
 #
-# You can retrieve that exact number using method Time.to_r:
+# You can retrieve that value exactly using method Time.to_r:
 #
 #   Time.at(0).to_r        # => (0/1)
 #   Time.at(0.999999).to_r # => (9007190247541737/9007199254740992)
 #
-# Other retrieval methods such as Time.to_i and Time.to_f
+# Other retrieval methods such as Time#to_i and Time#to_f
 # may return a value that rounds or truncates subseconds.
 #
 # == \Time Resolution
@@ -46,16 +44,6 @@
 # A \Time object derived from the system clock
 # (for example, by method Time.now)
 # has the resolution supported by the system.
-#
-# == GMT and UTC
-#
-# The \Time class treats
-# GMT ({Greenwich Mean Time}[https://en.wikipedia.org/wiki/Greenwich_Mean_Time])
-# and
-# UTC ({Coordinated Universal Time}[https://en.wikipedia.org/wiki/Coordinated_Universal_Time])
-# as equivalent.
-# GMT is the older way of referring to these baseline times but persists in
-# the names of calls on POSIX systems.
 #
 # == Examples
 #
@@ -319,12 +307,6 @@ class Time
   #
   # For the forms of argument +zone+, see
   # {Timezone Specifiers}[rdoc-ref:timezone_specifiers.rdoc].
-  #
-  # Related:
-  #
-  # - Time.to_f: returns Epoch seconds as a Float (may be approximate).
-  # - Time.to_i: returns Epoch seconds as an integer (subseconds truncated).
-  # - Time.to_r: returns Epoch seconds as a Rational (exact),
   #
   def self.at(time, subsec = false, unit = :microsecond, in: nil)
     if Primitive.mandatory_only?

--- a/timev.rb
+++ b/timev.rb
@@ -2,7 +2,7 @@
 #
 #   Time.new(2000, 1, 1, 0, 0, 0) # => 2000-01-01 00:00:00 -0600
 #
-# Although its value is stored internally as a single numeric
+# Although its value can be expressed as a single numeric
 # (see {Epoch Seconds}[rdoc-ref:Time@Epoch+Seconds] below),
 # it can be convenient to deal with the value by parts:
 #


### PR DESCRIPTION
Revises the introductory doc for Time, in particular adding a small section "Epoch Seconds" that is now linked to from other parts of the doc.

Adds "Related" remarks to several methods' doc.