### PR TITLE
Implement `exception: false` argument for Queue push & pop

### DIFF
--- a/spec/ruby/shared/queue/deque.rb
+++ b/spec/ruby/shared/queue/deque.rb
@@ -55,8 +55,8 @@ describe :queue_deq, shared: true do
     t.join
   end
 
-  describe "with a timeout" do
-    ruby_version_is "3.2" do
+  ruby_version_is "3.2" do
+    describe "with a timeout" do
       it "returns an item if one is available in time" do
         q = @object.call
 
@@ -106,6 +106,31 @@ describe :queue_deq, shared: true do
           ArgumentError,
           "can't set a timeout if non_block is enabled",
         )
+      end
+    end
+
+    describe "with exception: false" do
+      it "raise ArgumentError if exception is anything but true or false" do
+        q = @object.call
+        q << 1 << 2 << 3
+        q.send(@method, exception: true).should == 1
+        q.send(@method, exception: false).should == 2
+
+        -> { q.send(@method, exception: nil) }.should raise_error(
+          ArgumentError,
+          "expected true or false as exception: nil",
+        )
+      end
+
+      it "returns nil if nonblock=true and the queue is empty" do
+        q = @object.call
+        q.send(@method, true, exception: false).should == nil
+      end
+
+      it "returns nil if nonblock=true and the queue is closed and empty" do
+        q = @object.call
+        q.close
+        q.send(@method, true, exception: false).should == nil
       end
     end
   end

--- a/spec/ruby/shared/queue/enque.rb
+++ b/spec/ruby/shared/queue/enque.rb
@@ -8,11 +8,37 @@ describe :queue_enq, shared: true do
     q.size.should == 2
   end
 
+  it "returns self" do
+    q = @object.call
+    q.send(@method, Object.new).should == q
+  end
+
   it "is an error for a closed queue" do
     q = @object.call
     q.close
     -> {
       q.send @method, Object.new
     }.should raise_error(ClosedQueueError)
+  end
+
+  ruby_version_is "3.2" do
+    describe "with exception: false" do
+      it "raise ArgumentError if exception is anything but true or false" do
+        q = @object.call
+        q.send(@method, 1, exception: true).should == q
+        q.send(@method, 2, exception: false).should == q
+
+        -> { q.send(@method, 3, exception: nil) }.should raise_error(
+          ArgumentError,
+          "expected true or false as exception: nil",
+        )
+      end
+
+      it "returns nil for a closed queue" do
+        q = @object.call
+        q.close
+        q.send(@method, Object.new, exception: false).should == nil
+      end
+    end
   end
 end

--- a/spec/ruby/shared/sizedqueue/enque.rb
+++ b/spec/ruby/shared/sizedqueue/enque.rb
@@ -48,8 +48,8 @@ describe :sizedqueue_enq, shared: true do
     q.pop.should == 1
   end
 
-  describe "with a timeout" do
-    ruby_version_is "3.2" do
+  ruby_version_is "3.2" do
+    describe "with a timeout" do
       it "returns self if the item was pushed in time" do
         q = @object.call(1)
         q << 1
@@ -101,6 +101,31 @@ describe :sizedqueue_enq, shared: true do
           ArgumentError,
           "can't set a timeout if non_block is enabled",
         )
+      end
+    end
+
+    describe "with exception: false" do
+      it "raise ArgumentError if exception is anything but true or false" do
+        q = @object.call(10)
+        q.send(@method, 1, exception: true).should == q
+        q.send(@method, 2, exception: false).should == q
+
+        -> { q.send(@method, 3, exception: nil) }.should raise_error(
+          ArgumentError,
+          "expected true or false as exception: nil",
+        )
+      end
+
+      it "returns nil for a closed queue" do
+        q = @object.call(10)
+        q.close
+        q.send(@method, Object.new, exception: false).should == nil
+      end
+
+      it "returns nil for a full queue when not blocking" do
+        q = @object.call(1)
+        q << 1
+        q.send(@method, Object.new, true, exception: false).should == nil
       end
     end
   end

--- a/test/ruby/test_settracefunc.rb
+++ b/test/ruby/test_settracefunc.rb
@@ -2101,14 +2101,15 @@ CODE
     t.join
     assert_equal ["c-return", base_line + 3], events[0]
     assert_equal ["line", base_line + 6],     events[1]
-    assert_equal ["c-call", base_line + 6],   events[2]
-    assert_equal ["c-return", base_line + 6], events[3]
-    assert_equal ["line", base_line + 7],     events[4]
-    assert_equal ["line", base_line + 8],     events[5]
-    assert_equal ["call", base_line + -6],    events[6]
-    assert_equal ["return", base_line + -4],  events[7]
-    assert_equal ["line", base_line + 9],     events[8]
-    assert_equal nil,                         events[9]
+    assert_equal ["call"],                    events[2].first(1) # Queue#push
+    assert_equal ["line"],                    events[3].first(1) # Queue#push
+    assert_equal ["return"],                  events[4].first(1) # Queue#push
+    assert_equal ["line", base_line + 7],     events[5]
+    assert_equal ["line", base_line + 8],     events[6]
+    assert_equal ["call", base_line + -6],    events[7]
+    assert_equal ["return", base_line + -4],  events[8]
+    assert_equal ["line", base_line + 9],     events[9]
+    assert_equal nil,                         events[10]
 
     # other thread
     events = []
@@ -2140,15 +2141,15 @@ CODE
     m2t_q.push 1
     t.join
 
-    assert_equal ["line", base_line + 32],     events[0]
-    assert_equal ["line", base_line + 33],     events[1]
+    assert_equal ["line", base_line + 33],     events[0]
+    assert_equal ["line", base_line + 34],     events[1]
     assert_equal ["call", base_line + -6],     events[2]
     assert_equal ["return", base_line + -4],   events[3]
-    assert_equal ["line", base_line + 34],     events[4]
-    assert_equal ["line", base_line + 35],     events[5]
-    assert_equal ["c-call", base_line + 35],   events[6] # Thread.current
-    assert_equal ["c-return", base_line + 35], events[7] # Thread.current
-    assert_equal ["c-call", base_line + 35],   events[8] # Thread#set_trace_func
+    assert_equal ["line", base_line + 35],     events[4]
+    assert_equal ["line", base_line + 36],     events[5]
+    assert_equal ["c-call", base_line + 36],   events[6] # Thread.current
+    assert_equal ["c-return", base_line + 36], events[7] # Thread.current
+    assert_equal ["c-call", base_line + 36],   events[8] # Thread#set_trace_func
     assert_equal nil,                          events[9]
   end
 

--- a/test/ruby/test_thread_queue.rb
+++ b/test/ruby/test_thread_queue.rb
@@ -135,6 +135,11 @@ class TestThreadQueue < Test::Unit::TestCase
     end
   end
 
+  def test_queue_pop_non_block_no_exception
+    q = Thread::Queue.new
+    assert_nil q.pop(true, exception: false)
+  end
+
   def test_sized_queue_pop_interrupt
     q = Thread::SizedQueue.new(1)
     t1 = Thread.new { q.pop }
@@ -168,6 +173,11 @@ class TestThreadQueue < Test::Unit::TestCase
     end
   end
 
+  def test_sized_queue_pop_non_block_no_exception
+    q = Thread::SizedQueue.new(1)
+    assert_nil q.pop(true, exception: false)
+  end
+
   def test_sized_queue_push_timeout
     q = Thread::SizedQueue.new(1)
 
@@ -192,6 +202,12 @@ class TestThreadQueue < Test::Unit::TestCase
     assert_raise_with_message(ThreadError, /full/) do
       q.push(2, true)
     end
+  end
+
+  def test_sized_queue_push_interrupt_no_exception
+    q = Thread::SizedQueue.new(1)
+    q.push(1)
+    assert_nil q.push(2, true, exception: false)
   end
 
   def test_sized_queue_push_non_block
@@ -452,6 +468,12 @@ class TestThreadQueue < Test::Unit::TestCase
     q = Thread::SizedQueue.new 7
     q.close
     assert_raise_with_message(ClosedQueueError, /queue closed/){q.push(non_block=true)}
+  end
+
+  def test_sized_queue_closed_push_non_blocking_no_exception
+    q = Thread::SizedQueue.new 7
+    q.close
+    assert_nil q.push(non_block=true, exception: false)
   end
 
   def test_blocked_pushers

--- a/thread_sync.rb
+++ b/thread_sync.rb
@@ -1,43 +1,72 @@
 class Thread
   class Queue
     # call-seq:
-    #   pop(non_block=false, timeout: nil)
+    #   pop(non_block=false, timeout: nil, exception: true)
     #
     # Retrieves data from the queue.
     #
-    # If the queue is empty, the calling thread is suspended until data is pushed
-    # onto the queue. If +non_block+ is true, the thread isn't suspended, and
-    # +ThreadError+ is raised.
+    # If the queue is empty, the calling thread is suspended until data
+    # is pushed onto the queue.
     #
-    # If +timeout+ seconds have passed and no data is available +nil+ is
-    # returned.
-    def pop(non_block = false, timeout: nil)
+    # If the queue is both empty and closed, +nil+ is returned.
+    #
+    # If the queue is empty and +non_block+ is true, the thread isn't
+    # suspended, and +ThreadError+ is raised.
+    #
+    # If +exception+ is +false+, instead of raising +ThreadError+
+    # +nil+ is returned.
+    #
+    # If +timeout+ seconds have passed and no data is available,
+    # +nil+ is returned.
+    def pop(non_block = false, timeout: nil, exception: true)
       if non_block && timeout
         raise ArgumentError, "can't set a timeout if non_block is enabled"
       end
-      Primitive.rb_queue_pop(non_block, timeout)
+      Primitive.rb_queue_pop(non_block, timeout, exception)
     end
     alias_method :deq, :pop
     alias_method :shift, :pop
+
+    # call-seq:
+    #   push(object, exception: true)
+    #
+    # Pushes the given +object+ to the queue.
+    #
+    # If the queue is closed, +ClosedQueueError+ is raised.
+    #
+    # If +exception+ is +false+, instead of raising +ClosedQueueError+,
+    # +nil+ is returned.
+    def push(object, exception: true)
+      Primitive.rb_queue_push(object, exception)
+    end
+    alias_method :enq, :push
+    alias_method :<<, :push
   end
 
   class SizedQueue
     # call-seq:
-    #   pop(non_block=false, timeout: nil)
+    #   pop(non_block=false, timeout: nil, exception: true)
     #
     # Retrieves data from the queue.
     #
-    # If the queue is empty, the calling thread is suspended until data is
-    # pushed onto the queue. If +non_block+ is true, the thread isn't
-    # suspended, and +ThreadError+ is raised.
+    # If the queue is empty, the calling thread is suspended until data
+    # is pushed onto the queue.
+    #
+    # If the queue is both empty and closed, +nil+ is returned.
+    #
+    # If the queue is empty and +non_block+ is true, the thread isn't
+    # suspended, and +ThreadError+ is raised. If +exception+
+    #
+    # If +exception+ is +false+, instead of raising +ThreadError+
+    # +nil+ is returned.
     #
     # If +timeout+ seconds have passed and no data is available +nil+ is
     # returned.
-    def pop(non_block = false, timeout: nil)
+    def pop(non_block = false, timeout: nil, exception: true)
       if non_block && timeout
         raise ArgumentError, "can't set a timeout if non_block is enabled"
       end
-      Primitive.rb_szqueue_pop(non_block, timeout)
+      Primitive.rb_szqueue_pop(non_block, timeout, exception)
     end
     alias_method :deq, :pop
     alias_method :shift, :pop
@@ -49,18 +78,26 @@ class Thread
     #
     # Pushes +object+ to the queue.
     #
-    # If there is no space left in the queue, waits until space becomes
-    # available, unless +non_block+ is true.  If +non_block+ is true, the
+    # If there is no space left in the queue, the thread is suspended
+    # until space becomes available, unless +non_block+ is true.
+    #
+    # If +non_block+ is true, the
     # thread isn't suspended, and +ThreadError+ is raised.
+    #
+    # If the queue is closed, +ClosedQueueError+ is raised.
+    #
+    # If +exception+ is +false+, instead of raising +ClosedQueueError+ or
+    # +ThreadError+, +nil+ is returned.
     #
     # If +timeout+ seconds have passed and no space is available +nil+ is
     # returned.
+    #
     # Otherwise it returns +self+.
-    def push(object, non_block = false, timeout: nil)
+    def push(object, non_block = false, timeout: nil, exception: true)
       if non_block && timeout
         raise ArgumentError, "can't set a timeout if non_block is enabled"
       end
-      Primitive.rb_szqueue_push(object, non_block, timeout)
+      Primitive.rb_szqueue_push(object, non_block, timeout, exception)
     end
     alias_method :enq, :push
     alias_method :<<, :push


### PR DESCRIPTION
Ref: https://bugs.ruby-lang.org/issues/18982

[Feature #18982]

In many cases, especially when using the nonblock mode, it's much simpler and more efficient to check the return value rather than to rescue an exception.