### PR TITLE
Check only symbol flag bits

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -3454,7 +3454,8 @@ fn jit_guard_known_klass(
 
             asm.comment("guard object is static symbol");
             assert!(RUBY_SPECIAL_SHIFT == 8);
-            asm.cmp(obj_opnd, Opnd::UImm(RUBY_SYMBOL_FLAG as u64));
+            let flag_bits = asm.and(obj_opnd, Opnd::UImm(RUBY_SYMBOL_FLAG as u64));
+            asm.cmp(flag_bits, Opnd::UImm(RUBY_SYMBOL_FLAG as u64));
             jit_chain_guard(JCC_JNE, jit, ctx, asm, ocb, max_chain_depth, side_exit);
             ctx.upgrade_opnd_type(insn_opnd, Type::ImmSymbol);
         }


### PR DESCRIPTION
This place was originally checking only 8bits https://github.com/ruby/ruby/blob/4ee1a687768338a1928014fc6042c320a1a1af3e/yjit/src/codegen.rs#L3477 but that was changed to compare 64bits in the backend migration. 

## Before
```
  # opt_eq
  # guard object is static symbol
  0x10eda006c: mov rax, qword ptr [rbx]
  0x10eda006f: cmp rax, 0xc
  0x10eda0073: jne 0x116da009d
```

## After
```
  # opt_eq
  # guard object is static symbol
  0x10e51006c: mov rax, qword ptr [rbx]
  0x10e51006f: and rax, 0xc
  0x10e510073: cmp rax, 0xc
  0x10e510077: jne 0x11651009d
```

Originally it was generating `cmp al, 0xc`, but I couldn't figure out how to generate it. Maybe we could do it with a peephole optimization later?

This seems to reduce the number of `opt_eq` side exits on rubykon.

cc: @noahgibbs @kddnewton 