### PR TITLE
`%c` conversion promotes US-ASCII to ASCII-8BIT

### DIFF
--- a/internal/string.h
+++ b/internal/string.h
@@ -43,6 +43,7 @@ char *rb_str_to_cstr(VALUE str);
 const char *ruby_escaped_char(int c);
 void rb_str_make_independent(VALUE str);
 int rb_enc_str_coderange_scan(VALUE str, rb_encoding *enc);
+int rb_ascii8bit_appendable_encoding_index(rb_encoding *enc, unsigned int code);
 
 static inline bool STR_EMBED_P(VALUE str);
 static inline bool STR_SHARED_P(VALUE str);

--- a/sprintf.c
+++ b/sprintf.c
@@ -454,12 +454,17 @@ rb_str_format(int argc, const VALUE *argv, VALUE fmt)
                     str = tmp;
                     goto format_s1;
                 }
-                else {
-                    n = NUM2INT(val);
-                    if (n >= 0) n = rb_enc_codelen((c = n), enc);
-                }
+                n = NUM2INT(val);
+                if (n >= 0) n = rb_enc_codelen((c = n), enc);
                 if (n <= 0) {
                     rb_raise(rb_eArgError, "invalid character");
+                }
+                int encidx = rb_ascii8bit_appendable_encoding_index(enc, c);
+                if (encidx >= 0 && encidx != rb_enc_to_index(enc)) {
+                    /* special case */
+                    rb_enc_associate_index(result, encidx);
+                    enc = rb_enc_from_index(encidx);
+                    coderange = ENC_CODERANGE_VALID;
                 }
                 if (!(flags & FWIDTH)) {
                     CHECK(n);

--- a/test/ruby/test_sprintf.rb
+++ b/test/ruby/test_sprintf.rb
@@ -369,6 +369,9 @@ class TestSprintf < Test::Unit::TestCase
     assert_equal(" " * BSIZ + "a", sprintf("%#{ BSIZ + 1 }c", ?a))
     assert_equal("a" + " " * BSIZ, sprintf("%-#{ BSIZ + 1 }c", ?a))
     assert_raise(ArgumentError) { sprintf("%c", -1) }
+    s = sprintf("%c".encode(Encoding::US_ASCII), 0x80)
+    assert_equal("\x80".b, s)
+    assert_predicate(s, :valid_encoding?)
   end
 
   def test_string


### PR DESCRIPTION
[Bug #18973](https://bugs.ruby-lang.org/issues/18973)