### PR TITLE
Let --yjit-dump-disasm=all dump ocb code as well

### DIFF
--- a/yjit/src/asm/mod.rs
+++ b/yjit/src/asm/mod.rs
@@ -275,6 +275,10 @@ impl CodeBlock {
     pub fn mark_all_executable(&mut self) {
         self.mem_block.mark_all_executable();
     }
+
+    pub fn inline(&self) -> bool {
+        !self.outlined
+    }
 }
 
 #[cfg(test)]

--- a/yjit/src/asm/mod.rs
+++ b/yjit/src/asm/mod.rs
@@ -276,6 +276,7 @@ impl CodeBlock {
         self.mem_block.mark_all_executable();
     }
 
+    #[cfg(feature = "disasm")]
     pub fn inline(&self) -> bool {
         !self.outlined
     }

--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -1084,7 +1084,7 @@ impl Assembler
 
         #[cfg(feature = "disasm")]
         match get_option!(dump_disasm) {
-            DumpDisasm::All | DumpDisasm::Inlined if cb.inline() => {
+            DumpDisasm::All | DumpDisasm::Inline if cb.inline() => {
                 use crate::disasm::disasm_addr_range;
                 let last_ptr = cb.get_write_ptr();
                 let disasm = disasm_addr_range(cb, start_addr, last_ptr.raw_ptr() as usize - start_addr as usize);

--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -1083,8 +1083,8 @@ impl Assembler
         let gc_offsets = self.compile_with_regs(cb, alloc_regs);
 
         #[cfg(feature = "disasm")]
-        if let Some(target) = get_option!(dump_disasm) {
-            if target == DumpDisasm::All || !cb.outlined {
+        match get_option!(dump_disasm) {
+            DumpDisasm::All | DumpDisasm::Inlined if cb.inlined() => {
                 use crate::disasm::disasm_addr_range;
                 let last_ptr = cb.get_write_ptr();
                 let disasm = disasm_addr_range(cb, start_addr, last_ptr.raw_ptr() as usize - start_addr as usize);
@@ -1092,6 +1092,7 @@ impl Assembler
                     println!("{disasm}");
                 }
             }
+            _ => {}
         }
         gc_offsets
     }

--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -1083,12 +1083,14 @@ impl Assembler
         let gc_offsets = self.compile_with_regs(cb, alloc_regs);
 
         #[cfg(feature = "disasm")]
-        if get_option!(dump_disasm) && !cb.outlined {
-            use crate::disasm::disasm_addr_range;
-            let last_ptr = cb.get_write_ptr();
-            let disasm = disasm_addr_range(cb, start_addr, last_ptr.raw_ptr() as usize - start_addr as usize);
-            if disasm.len() > 0 {
-                println!("{disasm}");
+        if let Some(dump_all) = get_option!(dump_disasm) {
+            if dump_all || !cb.outlined {
+                use crate::disasm::disasm_addr_range;
+                let last_ptr = cb.get_write_ptr();
+                let disasm = disasm_addr_range(cb, start_addr, last_ptr.raw_ptr() as usize - start_addr as usize);
+                if disasm.len() > 0 {
+                    println!("{disasm}");
+                }
             }
         }
         gc_offsets

--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -1083,16 +1083,13 @@ impl Assembler
         let gc_offsets = self.compile_with_regs(cb, alloc_regs);
 
         #[cfg(feature = "disasm")]
-        match get_option!(dump_disasm) {
-            DumpDisasm::All | DumpDisasm::Inline if cb.inline() => {
-                use crate::disasm::disasm_addr_range;
-                let last_ptr = cb.get_write_ptr();
-                let disasm = disasm_addr_range(cb, start_addr, last_ptr.raw_ptr() as usize - start_addr as usize);
-                if disasm.len() > 0 {
-                    println!("{disasm}");
-                }
+        if get_option!(dump_disasm) == DumpDisasm::All || (get_option!(dump_disasm) == DumpDisasm::Inline && cb.inline()) {
+            use crate::disasm::disasm_addr_range;
+            let last_ptr = cb.get_write_ptr();
+            let disasm = disasm_addr_range(cb, start_addr, last_ptr.raw_ptr() as usize - start_addr as usize);
+            if disasm.len() > 0 {
+                println!("{disasm}");
             }
-            _ => {}
         }
         gc_offsets
     }

--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -1084,7 +1084,7 @@ impl Assembler
 
         #[cfg(feature = "disasm")]
         match get_option!(dump_disasm) {
-            DumpDisasm::All | DumpDisasm::Inlined if cb.inlined() => {
+            DumpDisasm::All | DumpDisasm::Inlined if cb.inline() => {
                 use crate::disasm::disasm_addr_range;
                 let last_ptr = cb.get_write_ptr();
                 let disasm = disasm_addr_range(cb, start_addr, last_ptr.raw_ptr() as usize - start_addr as usize);

--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -1083,8 +1083,8 @@ impl Assembler
         let gc_offsets = self.compile_with_regs(cb, alloc_regs);
 
         #[cfg(feature = "disasm")]
-        if let Some(dump_all) = get_option!(dump_disasm) {
-            if dump_all || !cb.outlined {
+        if let Some(target) = get_option!(dump_disasm) {
+            if target == DumpDisasm::All || !cb.outlined {
                 use crate::disasm::disasm_addr_range;
                 let last_ptr = cb.get_write_ptr();
                 let disasm = disasm_addr_range(cb, start_addr, last_ptr.raw_ptr() as usize - start_addr as usize);

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -398,6 +398,7 @@ fn gen_code_for_exit_from_stub(ocb: &mut OutlinedCb) -> CodePtr {
 
     gen_counter_incr!(asm, exit_from_branch_stub);
 
+    asm.comment("exit from branch stub");
     asm.cpop_into(SP);
     asm.cpop_into(EC);
     asm.cpop_into(CFP);
@@ -525,7 +526,7 @@ fn gen_full_cfunc_return(ocb: &mut OutlinedCb) -> CodePtr {
     // This chunk of code expects REG_EC to be filled properly and
     // RAX to contain the return value of the C method.
 
-    // Call full_cfunc_return()
+    asm.comment("full cfunc return");
     asm.ccall(
         rb_full_cfunc_return as *const u8,
         vec![EC, C_RET_OPND]
@@ -562,6 +563,7 @@ fn gen_leave_exit(ocb: &mut OutlinedCb) -> CodePtr {
     // Every exit to the interpreter should be counted
     gen_counter_incr!(asm, leave_interp_return);
 
+    asm.comment("exit from leave");
     asm.cpop_into(SP);
     asm.cpop_into(EC);
     asm.cpop_into(CFP);
@@ -624,7 +626,7 @@ pub fn gen_entry_prologue(cb: &mut CodeBlock, iseq: IseqPtr, insn_idx: u32) -> O
     let code_ptr = cb.get_write_ptr();
 
     let mut asm = Assembler::new();
-    if get_option!(dump_disasm) {
+    if get_option!(dump_disasm).is_some() {
         asm.comment(&format!("YJIT entry: {}", iseq_get_location(iseq)));
     } else {
         asm.comment("YJIT entry");
@@ -753,7 +755,7 @@ pub fn gen_single_block(
     let mut asm = Assembler::new();
 
     #[cfg(feature = "disasm")]
-    if get_option!(dump_disasm) {
+    if get_option!(dump_disasm).is_some() {
         asm.comment(&format!("Block: {} (ISEQ offset: {})", iseq_get_location(blockid.iseq), blockid.idx));
     }
 

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -626,7 +626,7 @@ pub fn gen_entry_prologue(cb: &mut CodeBlock, iseq: IseqPtr, insn_idx: u32) -> O
     let code_ptr = cb.get_write_ptr();
 
     let mut asm = Assembler::new();
-    if get_option!(dump_disasm).is_some() {
+    if get_option!(dump_disasm).is_enabled() {
         asm.comment(&format!("YJIT entry: {}", iseq_get_location(iseq)));
     } else {
         asm.comment("YJIT entry");
@@ -755,7 +755,7 @@ pub fn gen_single_block(
     let mut asm = Assembler::new();
 
     #[cfg(feature = "disasm")]
-    if get_option!(dump_disasm).is_some() {
+    if get_option!(dump_disasm).is_enabled() {
         asm.comment(&format!("Block: {} (ISEQ offset: {})", iseq_get_location(blockid.iseq), blockid.idx));
     }
 

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -1779,6 +1779,7 @@ fn get_branch_target(
     let branch_ptr: *const RefCell<Branch> = BranchRef::into_raw(branchref.clone());
 
     let mut asm = Assembler::new();
+    asm.comment("branch stub hit");
 
     // Call branch_stub_hit(branch_ptr, target_idx, ec)
     let jump_addr = asm.ccall(

--- a/yjit/src/options.rs
+++ b/yjit/src/options.rs
@@ -64,9 +64,9 @@ pub static mut OPTIONS: Options = Options {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum DumpDisasm {
-    // Dump only inlined cb
-    Inlined,
-    // Dump both inlined and outlined cbs
+    // Dump only inline cb
+    Inline,
+    // Dump both inline and outlined cbs
     All,
     // Dont dump anything
     None,
@@ -75,7 +75,7 @@ pub enum DumpDisasm {
 impl DumpDisasm {
     pub fn is_enabled(&self) -> bool {
         match self {
-            DumpDisasm::Inlined => true,
+            DumpDisasm::Inline => true,
             DumpDisasm::All => true,
             DumpDisasm::None => false,
         }
@@ -145,7 +145,7 @@ pub fn parse_option(str_ptr: *const std::os::raw::c_char) -> Option<()> {
 
         ("dump-disasm", _) => match opt_val.to_string().as_str() {
             "all" => unsafe { OPTIONS.dump_disasm = DumpDisasm::All },
-            "" => unsafe { OPTIONS.dump_disasm = DumpDisasm::Inlined },
+            "" => unsafe { OPTIONS.dump_disasm = DumpDisasm::Inline },
             _ => return None,
          },
 

--- a/yjit/src/options.rs
+++ b/yjit/src/options.rs
@@ -30,8 +30,9 @@ pub struct Options {
     /// Dump compiled and executed instructions for debugging
     pub dump_insns: bool,
 
-    /// Dump all compiled instructions in inlined CodeBlock
-    pub dump_disasm: bool,
+    /// Dump all compiled instructions. Some(false) dumps only inlined cb,
+    /// and Some(true) dumps both inlined and outlined cbs.
+    pub dump_disasm: Option<bool>,
 
     /// Print when specific ISEQ items are compiled or invalidated
     pub dump_iseq_disasm: Option<String>,
@@ -56,7 +57,7 @@ pub static mut OPTIONS: Options = Options {
     gen_stats: false,
     gen_trace_exits: false,
     dump_insns: false,
-    dump_disasm: false,
+    dump_disasm: None,
     verify_ctx: false,
     global_constant_state: false,
     dump_iseq_disasm: None,
@@ -123,6 +124,12 @@ pub fn parse_option(str_ptr: *const std::os::raw::c_char) -> Option<()> {
             }
         },
 
+        ("dump-disasm", _) => match opt_val.to_string().as_str() {
+            "all" => unsafe { OPTIONS.dump_disasm = Some(true) },
+            "" => unsafe { OPTIONS.dump_disasm = Some(false) },
+            _ => return None,
+         },
+
         ("dump-iseq-disasm", _) => unsafe {
             OPTIONS.dump_iseq_disasm = Some(opt_val.to_string());
         },
@@ -132,7 +139,6 @@ pub fn parse_option(str_ptr: *const std::os::raw::c_char) -> Option<()> {
         ("stats", "") => unsafe { OPTIONS.gen_stats = true },
         ("trace-exits", "") => unsafe { OPTIONS.gen_trace_exits = true; OPTIONS.gen_stats = true },
         ("dump-insns", "") => unsafe { OPTIONS.dump_insns = true },
-        ("dump-disasm", "") => unsafe { OPTIONS.dump_disasm = true },
         ("verify-ctx", "") => unsafe { OPTIONS.verify_ctx = true },
         ("global-constant-state", "") => unsafe { OPTIONS.global_constant_state = true },
 

--- a/yjit/src/options.rs
+++ b/yjit/src/options.rs
@@ -31,7 +31,7 @@ pub struct Options {
     pub dump_insns: bool,
 
     /// Dump all compiled instructions of target cbs.
-    pub dump_disasm: Option<DumpDisasm>,
+    pub dump_disasm: DumpDisasm,
 
     /// Print when specific ISEQ items are compiled or invalidated
     pub dump_iseq_disasm: Option<String>,
@@ -56,7 +56,7 @@ pub static mut OPTIONS: Options = Options {
     gen_stats: false,
     gen_trace_exits: false,
     dump_insns: false,
-    dump_disasm: None,
+    dump_disasm: DumpDisasm::None,
     verify_ctx: false,
     global_constant_state: false,
     dump_iseq_disasm: None,
@@ -68,6 +68,18 @@ pub enum DumpDisasm {
     Inlined,
     // Dump both inlined and outlined cbs
     All,
+    // Dont dump anything
+    None,
+}
+
+impl DumpDisasm {
+    pub fn is_enabled(&self) -> bool {
+        match self {
+            DumpDisasm::Inlined => true,
+            DumpDisasm::All => true,
+            DumpDisasm::None => false,
+        }
+    }
 }
 
 /// Macro to get an option value by name
@@ -132,8 +144,8 @@ pub fn parse_option(str_ptr: *const std::os::raw::c_char) -> Option<()> {
         },
 
         ("dump-disasm", _) => match opt_val.to_string().as_str() {
-            "all" => unsafe { OPTIONS.dump_disasm = Some(DumpDisasm::All) },
-            "" => unsafe { OPTIONS.dump_disasm = Some(DumpDisasm::Inlined) },
+            "all" => unsafe { OPTIONS.dump_disasm = DumpDisasm::All },
+            "" => unsafe { OPTIONS.dump_disasm = DumpDisasm::Inlined },
             _ => return None,
          },
 

--- a/yjit/src/options.rs
+++ b/yjit/src/options.rs
@@ -30,9 +30,8 @@ pub struct Options {
     /// Dump compiled and executed instructions for debugging
     pub dump_insns: bool,
 
-    /// Dump all compiled instructions. Some(false) dumps only inlined cb,
-    /// and Some(true) dumps both inlined and outlined cbs.
-    pub dump_disasm: Option<bool>,
+    /// Dump all compiled instructions of target cbs.
+    pub dump_disasm: Option<DumpDisasm>,
 
     /// Print when specific ISEQ items are compiled or invalidated
     pub dump_iseq_disasm: Option<String>,
@@ -62,6 +61,14 @@ pub static mut OPTIONS: Options = Options {
     global_constant_state: false,
     dump_iseq_disasm: None,
 };
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum DumpDisasm {
+    // Dump only inlined cb
+    Inlined,
+    // Dump both inlined and outlined cbs
+    All,
+}
 
 /// Macro to get an option value by name
 macro_rules! get_option {
@@ -125,8 +132,8 @@ pub fn parse_option(str_ptr: *const std::os::raw::c_char) -> Option<()> {
         },
 
         ("dump-disasm", _) => match opt_val.to_string().as_str() {
-            "all" => unsafe { OPTIONS.dump_disasm = Some(true) },
-            "" => unsafe { OPTIONS.dump_disasm = Some(false) },
+            "all" => unsafe { OPTIONS.dump_disasm = Some(DumpDisasm::All) },
+            "" => unsafe { OPTIONS.dump_disasm = Some(DumpDisasm::Inlined) },
             _ => return None,
          },
 

--- a/yjit/src/options.rs
+++ b/yjit/src/options.rs
@@ -74,11 +74,7 @@ pub enum DumpDisasm {
 
 impl DumpDisasm {
     pub fn is_enabled(&self) -> bool {
-        match self {
-            DumpDisasm::Inline => true,
-            DumpDisasm::All => true,
-            DumpDisasm::None => false,
-        }
+        *self != DumpDisasm::None
     }
 }
 


### PR DESCRIPTION
I'm debugging a SEGV that seems to be caused inside an outlined cb. For that, I thought it'd be useful to have an option that dumps outlined cb code as well. It works as follows:

* `--yjit-dump-disasm`: Dump only inlined cb
* `--yjit-dump-disasm=all`: Dump both inlined and outlined cbs

cc: @jimmyhmiller