### PR TITLE
Fix test fails with Aracritty and macOS

### DIFF
--- a/lib/reline/general_io.rb
+++ b/lib/reline/general_io.rb
@@ -57,6 +57,12 @@ class Reline::GeneralIO
     Reline::CursorPos.new(1, 1)
   end
 
+  def self.hide_cursor
+  end
+
+  def self.show_cursor
+  end
+
   def self.move_cursor_column(val)
   end
 

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -655,7 +655,10 @@ class Reline::LineEditor
   end
 
   private def padding_space_with_escape_sequences(str, width)
-    str + (' ' * (width - calculate_width(str, true)))
+    padding_width = width - calculate_width(str, true)
+    # padding_width should be only positive value. But macOS and Aracritty returns negative value.
+    padding_width = 0 if padding_width < 0
+    str + (' ' * padding_width)
   end
 
   private def render_each_dialog(dialog, cursor_column)


### PR DESCRIPTION
I'm not sure why these are failed caused by reline.

```
./miniruby -I./lib -I. -I.ext/common  ./tool/runruby.rb --extout=.ext  -- --disable-gems -C . -Ispec/bundler .bundle/bin/rspec \
        --require spec_helper  spec/bundler/commands/platform_spec.rb:952
Run options:
  include {:locations=>{"./spec/bundler/commands/platform_spec.rb"=>[952]}}
  exclude {:man=>false, :truffleruby_only=>true, :jruby_only=>true, :readline=>false, :permissions=>false, :no_color_tty=>false, :ruby_repo=>true, :rubygems=>"!= 3.4.0.dev", :bundler=>"!= 2", :git=>"!= 2.37.3", :realworld=>true, :sudo=>true}

Randomized with seed 57510
F

Failures:

  1) bundle platform bundle console starts IRB with the default group loaded when ruby version matches
     Failure/Error:
               raise <<~ERROR

                 Invoking `#{cmd}` failed with output:
                 ----------------------------------------------------------------------
                 #{command_execution.stdboth}
                 ----------------------------------------------------------------------
               ERROR

     RuntimeError:


       Commands:
       $ /Users/hsbt/Documents/github.com/ruby/ruby/exe/ruby -I/Users/hsbt/Documents/github.com/ruby/ruby/spec/bundler -r/Users/hsbt/Documents/github.com/ruby/ruby/spec/bundler/support/artifice/fail.rb -r/Users/hsbt/Documents/github.com/ruby/ruby/spec/bundler/support/hax.rb /Users/hsbt/Documents/github.com/ruby/ruby/tmp/1/gems/system/bin/bundle install
       Fetching source index from file:///Users/hsbt/Documents/github.com/ruby/ruby/tmp/1/gems/remote1/
       Resolving dependencies...
       Using bundler 2.4.0.dev
       Fetching activesupport 2.3.5
       Fetching rack 0.9.1
       Installing rack 0.9.1
       Installing activesupport 2.3.5
       Fetching rack_middleware 1.0
       Installing rack_middleware 1.0
       Bundle complete! 3 Gemfile dependencies, 4 gems now installed.
       Use `bundle info [gemname]` to see where a bundled gem is installed.
       Post-install message from rack:
       Rack's post install message
       # $? => 0

       Invoking `/Users/hsbt/Documents/github.com/ruby/ruby/exe/ruby -I/Users/hsbt/Documents/github.com/ruby/ruby/spec/bundler -r/Users/hsbt/Documents/github.com/ruby/ruby/spec/bundler/support/artifice/fail.rb -r/Users/hsbt/Documents/github.com/ruby/ruby/spec/bundler/support/hax.rb /Users/hsbt/Documents/github.com/ruby/ruby/tmp/1/gems/system/bin/bundle console` failed with output:
       ----------------------------------------------------------------------
       [DEPRECATED] bundle console will be replaced by `bin/console` generated by `bundle gem <name>`
       --- ERROR REPORT TEMPLATE -------------------------------------------------------

       ```
       NoMethodError: undefined method `hide_cursor' for Reline::GeneralIO:Class
         /Users/hsbt/Documents/github.com/ruby/ruby/lib/reline/line_editor.rb:736:in `render_each_dialog'
         /Users/hsbt/Documents/github.com/ruby/ruby/lib/reline/line_editor.rb:653:in `block in render_dialog'
         /Users/hsbt/Documents/github.com/ruby/ruby/lib/reline/line_editor.rb:652:in `each'
         /Users/hsbt/Documents/github.com/ruby/ruby/lib/reline/line_editor.rb:652:in `render_dialog'
         /Users/hsbt/Documents/github.com/ruby/ruby/lib/reline/line_editor.rb:512:in `rerender'
         /Users/hsbt/Documents/github.com/ruby/ruby/lib/reline.rb:363:in `block (3 levels) in inner_readline'
         /Users/hsbt/Documents/github.com/ruby/ruby/lib/reline.rb:361:in `each'
         /Users/hsbt/Documents/github.com/ruby/ruby/lib/reline.rb:361:in `block (2 levels) in inner_readline'
         /Users/hsbt/Documents/github.com/ruby/ruby/lib/reline.rb:436:in `block in read_io'
         /Users/hsbt/Documents/github.com/ruby/ruby/lib/reline.rb:406:in `loop'
         /Users/hsbt/Documents/github.com/ruby/ruby/lib/reline.rb:406:in `read_io'
         /Users/hsbt/Documents/github.com/ruby/ruby/lib/reline.rb:359:in `block in inner_readline'
         /Users/hsbt/Documents/github.com/ruby/ruby/lib/reline.rb:357:in `loop'
         /Users/hsbt/Documents/github.com/ruby/ruby/lib/reline.rb:357:in `inner_readline'
         /Users/hsbt/Documents/github.com/ruby/ruby/lib/reline.rb:287:in `readmultiline'
         /Users/hsbt/Documents/github.com/ruby/ruby/lib/forwardable.rb:238:in `readmultiline'
         /Users/hsbt/Documents/github.com/ruby/ruby/lib/forwardable.rb:238:in `readmultiline'
         /Users/hsbt/Documents/github.com/ruby/ruby/lib/irb/input-method.rb:421:in `gets'
         /Users/hsbt/Documents/github.com/ruby/ruby/lib/irb.rb:495:in `block (2 levels) in eval_input'
         /Users/hsbt/Documents/github.com/ruby/ruby/lib/irb.rb:726:in `signal_status'
         /Users/hsbt/Documents/github.com/ruby/ruby/lib/irb.rb:494:in `block in eval_input'
         /Users/hsbt/Documents/github.com/ruby/ruby/lib/irb/ruby-lex.rb:284:in `lex'
         /Users/hsbt/Documents/github.com/ruby/ruby/lib/irb/ruby-lex.rb:253:in `block (2 levels) in each_top_level_statement'
         /Users/hsbt/Documents/github.com/ruby/ruby/lib/irb/ruby-lex.rb:250:in `loop'
         /Users/hsbt/Documents/github.com/ruby/ruby/lib/irb/ruby-lex.rb:250:in `block in each_top_level_statement'
         /Users/hsbt/Documents/github.com/ruby/ruby/lib/irb/ruby-lex.rb:249:in `catch'
         /Users/hsbt/Documents/github.com/ruby/ruby/lib/irb/ruby-lex.rb:249:in `each_top_level_statement'
         /Users/hsbt/Documents/github.com/ruby/ruby/lib/irb.rb:513:in `eval_input'
         /Users/hsbt/Documents/github.com/ruby/ruby/lib/irb.rb:447:in `block in run'
         /Users/hsbt/Documents/github.com/ruby/ruby/lib/irb.rb:446:in `catch'
         /Users/hsbt/Documents/github.com/ruby/ruby/lib/irb.rb:446:in `run'
         /Users/hsbt/Documents/github.com/ruby/ruby/lib/irb.rb:375:in `start'
         /Users/hsbt/Documents/github.com/ruby/ruby/tmp/1/gems/system/gems/bundler-2.4.0.dev/lib/bundler/cli/console.rb:19:in `run'
         /Users/hsbt/Documents/github.com/ruby/ruby/tmp/1/gems/system/gems/bundler-2.4.0.dev/lib/bundler/cli.rb:515:in `console'
         /Users/hsbt/Documents/github.com/ruby/ruby/tmp/1/gems/system/gems/bundler-2.4.0.dev/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
         /Users/hsbt/Documents/github.com/ruby/ruby/tmp/1/gems/system/gems/bundler-2.4.0.dev/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
         /Users/hsbt/Documents/github.com/ruby/ruby/tmp/1/gems/system/gems/bundler-2.4.0.dev/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
         /Users/hsbt/Documents/github.com/ruby/ruby/tmp/1/gems/system/gems/bundler-2.4.0.dev/lib/bundler/cli.rb:31:in `dispatch'
         /Users/hsbt/Documents/github.com/ruby/ruby/tmp/1/gems/system/gems/bundler-2.4.0.dev/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
         /Users/hsbt/Documents/github.com/ruby/ruby/tmp/1/gems/system/gems/bundler-2.4.0.dev/lib/bundler/cli.rb:25:in `start'
         /Users/hsbt/Documents/github.com/ruby/ruby/tmp/1/gems/system/gems/bundler-2.4.0.dev/libexec/bundle:48:in `block in <top (required)>'
         /Users/hsbt/Documents/github.com/ruby/ruby/tmp/1/gems/system/gems/bundler-2.4.0.dev/lib/bundler/friendly_errors.rb:120:in `with_friendly_errors'
         /Users/hsbt/Documents/github.com/ruby/ruby/tmp/1/gems/system/gems/bundler-2.4.0.dev/libexec/bundle:36:in `<top (required)>'
         /Users/hsbt/Documents/github.com/ruby/ruby/tmp/1/gems/system/bin/bundle:25:in `load'
         /Users/hsbt/Documents/github.com/ruby/ruby/tmp/1/gems/system/bin/bundle:25:in `<main>'

       ```

       ## Environment

       ```
       Bundler       2.4.0.dev
         Platforms   ruby, arm64-darwin-22
       Ruby          3.2.0p-1 (2022-09-02 revision e896b338605914df70c1c34274f5147dff6f71a3) [arm64-darwin-22]
         Full Path   /Users/hsbt/Documents/github.com/ruby/ruby/exe/ruby
         Config Dir  /Users/hsbt/.local/share/rbenv/versions/master/etc
       RubyGems      3.4.0.dev
         Gem Home    /Users/hsbt/Documents/github.com/ruby/ruby/tmp/1/gems/system
         Gem Path    /Users/hsbt/Documents/github.com/ruby/ruby/tmp/1/gems/system
         User Home   /Users/hsbt/Documents/github.com/ruby/ruby/tmp/1/home
         User Path   /Users/hsbt/.local/share/gem/ruby/3.2.0+2
         Bin Dir     /Users/hsbt/Documents/github.com/ruby/ruby/tmp/1/gems/system/bin
       OpenSSL
         Compiled    OpenSSL 3.0.5 5 Jul 2022
         Loaded      OpenSSL 3.0.5 5 Jul 2022
         Cert File   /opt/homebrew/etc/openssl@3/cert.pem
         Cert Dir    /opt/homebrew/etc/openssl@3/certs
       Tools
         Git         2.37.3
         RVM         not installed
         rbenv       rbenv 1.2.0-16-gc4395e5
         chruby      not installed
       ```

       ## Bundler Build Metadata

       ```
       Built At          2022-09-02
       Git SHA           e896b338605
       Released Version  true
       ```

       ## Gemfile

       ### Gemfile

       ```ruby
       source "file:///Users/hsbt/Documents/github.com/ruby/ruby/tmp/1/gems/remote1"
       gem "rack"
       gem "activesupport", :group => :test
       gem "rack_middleware", :group => :development

       ruby "3.2.0.dev", :engine => "ruby", :engine_version => "3.2.0.dev"
       ```

       ### Gemfile.lock

       ```
       GEM
         remote: file:///Users/hsbt/Documents/github.com/ruby/ruby/tmp/1/gems/remote1/
         specs:
           activesupport (2.3.5)
           rack (0.9.1)
           rack_middleware (1.0)
             rack (= 0.9.1)

       PLATFORMS
         arm64-darwin-22

       DEPENDENCIES
         activesupport
         rack
         rack_middleware

       BUNDLED WITH
          2.4.0.dev
       ```

       --- TEMPLATE END ----------------------------------------------------------------

       Unfortunately, an unexpected error occurred, and Bundler cannot continue.

       First, try this link to see if there are any existing issue reports for this error:
       https://github.com/rubygems/rubygems/search?q=undefined+method+%60hide_cursor%27+for+Reline++GeneralIO+Class&type=Issues

       If there aren't any reports for this error yet, please fill in the new issue form located at https://github.com/rubygems/rubygems/issues/new?labels=Bundler&template=bundler-related-issue.md, and copy and paste the report template above in there.
       Resolving dependencies...
       Switch to inspect mode.
       >> >> p
       ----------------------------------------------------------------------
     # ./spec/bundler/support/helpers.rb:207:in `sys_exec'
     # ./spec/bundler/support/helpers.rb:124:in `bundle'
     # ./spec/bundler/commands/platform_spec.rb:962:in `block (3 levels) in <top (required)>'
     # ./spec/bundler/spec_helper.rb:103:in `block (4 levels) in <top (required)>'
     # ./spec/bundler/spec_helper.rb:103:in `block (3 levels) in <top (required)>'
     # ./spec/bundler/support/helpers.rb:350:in `block in with_gem_path_as'
     # ./spec/bundler/support/helpers.rb:364:in `without_env_side_effects'
     # ./spec/bundler/support/helpers.rb:345:in `with_gem_path_as'
     # ./spec/bundler/spec_helper.rb:102:in `block (2 levels) in <top (required)>'

Finished in 1.24 seconds (files took 0.1246 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/bundler/commands/platform_spec.rb:952 # bundle platform bundle console starts IRB with the default group loaded when ruby version matches
```