### PR TITLE
Enable deprecation warnings for test-all

### DIFF
--- a/test/ruby/test_exception.rb
+++ b/test/ruby/test_exception.rb
@@ -1053,7 +1053,7 @@ $stderr = $stdout; raise "\x82\xa0"') do |outs, errs, status|
           warning << [str, category]
         end
       else
-        define_method(:warn) do |str|
+        define_method(:warn) do |str, category: nil|
           warning << str
         end
       end

--- a/tool/lib/test/unit.rb
+++ b/tool/lib/test/unit.rb
@@ -1,5 +1,20 @@
 # frozen_string_literal: true
 
+# Enable deprecation warnings for test-all, so deprecated methods/constants/functions are dealt with early.
+Warning[:deprecated] = true
+
+if ENV['BACKTRACE_FOR_DEPRECATION_WARNINGS']
+  Warning.extend Module.new {
+    def warn(message, category: nil, **kwargs)
+      if category == :deprecated and $stderr.respond_to?(:puts)
+        $stderr.puts nil, message, caller, nil
+      else
+        super
+      end
+    end
+  }
+end
+
 require_relative '../envutil'
 require_relative '../colorize'
 require_relative '../leakchecker'


### PR DESCRIPTION
* So deprecated methods/constants/functions are dealt with early,
  instead of many tests breaking suddenly when removing a deprecated
  method/constant/function.
* Follows https://bugs.ruby-lang.org/issues/17591