### PR TITLE
Remove get_actual_encoding() and the dynamic endian detection for dummy UTF-16/UTF-32

### DIFF
--- a/enc/encdb.c
+++ b/enc/encdb.c
@@ -17,7 +17,7 @@
 #define ENC_DEFINE(name) rb_encdb_declare(name)
 #define ENC_SET_BASE(name, orig) rb_enc_set_base((name), (orig))
 #define ENC_SET_DUMMY(name, orig) rb_enc_set_dummy(name)
-#define ENC_DUMMY_UNICODE(name) rb_encdb_set_unicode(rb_enc_set_dummy(ENC_REPLICATE((name), name "BE")))
+#define ENC_DUMMY_UNICODE(name) ENC_DUMMY(name)
 
 void
 Init_encdb(void)

--- a/enc/utf_16_32.h
+++ b/enc/utf_16_32.h
@@ -1,5 +1,5 @@
 #include "regenc.h"
 /* dummy for unsupported, stateful encoding */
-#define ENC_DUMMY_UNICODE(name) ENC_REPLICATE(name, name "BE")
+#define ENC_DUMMY_UNICODE(name) ENC_DUMMY(name)
 ENC_DUMMY_UNICODE("UTF-16");
 ENC_DUMMY_UNICODE("UTF-32");

--- a/encoding.c
+++ b/encoding.c
@@ -50,7 +50,6 @@ void rb_encdb_declare(const char *name);
 int rb_encdb_replicate(const char *name, const char *orig);
 int rb_encdb_dummy(const char *name);
 int rb_encdb_alias(const char *alias, const char *orig);
-void rb_encdb_set_unicode(int index);
 #pragma GCC visibility pop
 #endif
 
@@ -758,14 +757,6 @@ rb_encdb_alias(const char *alias, const char *orig)
     GLOBAL_ENC_TABLE_LEAVE();
 
     return r;
-}
-
-void
-rb_encdb_set_unicode(int index)
-{
-    rb_raw_encoding *enc = (rb_raw_encoding *)rb_enc_from_index(index);
-    ASSUME(enc);
-    enc->flags |= ONIGENC_FLAG_UNICODE;
 }
 
 static void

--- a/internal/encoding.h
+++ b/internal/encoding.h
@@ -24,7 +24,6 @@ int rb_encdb_dummy(const char *name);
 void rb_encdb_declare(const char *name);
 void rb_enc_set_base(const char *name, const char *orig);
 int rb_enc_set_dummy(int index);
-void rb_encdb_set_unicode(int index);
 PUREFUNC(int rb_data_is_encoding(VALUE obj));
 
 #endif /* INTERNAL_ENCODING_H */

--- a/test/ruby/test_m17n.rb
+++ b/test/ruby/test_m17n.rb
@@ -226,38 +226,16 @@ class TestM17N < Test::Unit::TestCase
     end
   end
 
-  STR_WITHOUT_BOM = "\u3042".freeze
-  STR_WITH_BOM = "\uFEFF\u3042".freeze
-  bug8940 = '[ruby-core:59757] [Bug #8940]'
-  bug9415 = '[ruby-dev:47895] [Bug #9415]'
-  %w/UTF-16 UTF-32/.each do |enc|
-    %w/BE LE/.each do |endian|
-      bom = "\uFEFF".encode("#{enc}#{endian}").force_encoding(enc)
+  def test_utf_dummy_are_like_regular_dummy_encodings
+    [Encoding::UTF_16, Encoding::UTF_32].each do |enc|
+      s = "\u3042".encode("UTF-32BE")
+      assert_equal(s.dup.force_encoding("ISO-2022-JP").inspect, s.dup.force_encoding(enc).inspect)
+      s = "\x00\x00\xFE\xFF"
+      assert_equal(s.dup.force_encoding("ISO-2022-JP").inspect, s.dup.force_encoding(enc).inspect)
 
-      define_method("test_utf_16_32_inspect(#{enc}#{endian})") do
-        s = STR_WITHOUT_BOM.encode(enc + endian)
-        # When a UTF-16/32 string doesn't have a BOM,
-        # inspect as a dummy encoding string.
-        assert_equal(s.dup.force_encoding("ISO-2022-JP").inspect,
-                     s.dup.force_encoding(enc).inspect)
-        assert_normal_exit("#{bom.b.dump}.force_encoding('#{enc}').inspect", bug8940)
-      end
-
-      define_method("test_utf_16_32_codepoints(#{enc}#{endian})") do
-        assert_equal([0xFEFF], bom.codepoints, bug9415)
-      end
-
-      define_method("test_utf_16_32_ord(#{enc}#{endian})") do
-        assert_equal(0xFEFF, bom.ord, bug9415)
-      end
-
-      define_method("test_utf_16_32_inspect(#{enc}#{endian}-BOM)") do
-        s = STR_WITH_BOM.encode(enc + endian)
-        # When a UTF-16/32 string has a BOM,
-        # inspect as a particular encoding string.
-        assert_equal(s.inspect,
-                     s.dup.force_encoding(enc).inspect)
-      end
+      assert_equal [0, 0, 254, 255], "\x00\x00\xFE\xFF".force_encoding(enc).codepoints
+      assert_equal 0, "\x00\x00\xFE\xFF".force_encoding(enc).ord
+      assert_equal 255, "\xFF\xFE\x00\x00".force_encoding(enc).ord
     end
   end
 

--- a/test/ruby/test_transcode.rb
+++ b/test/ruby/test_transcode.rb
@@ -2232,12 +2232,12 @@ class TestTranscode < Test::Unit::TestCase
     assert_equal("U+3042", "\u{3042}".encode("US-ASCII", fallback: fallback))
   end
 
-  bug8940 = '[ruby-core:57318] [Bug #8940]'
-  %w[UTF-32 UTF-16].each do |enc|
-    define_method("test_pseudo_encoding_inspect(#{enc})") do
-      assert_normal_exit("'aaa'.encode('#{enc}').inspect", bug8940)
-      assert_equal(4, 'aaa'.encode(enc).length, "should count in #{enc} with BOM")
-    end
+  def test_pseudo_encoding_inspect
+    s = 'aaa'.encode "UTF-16"
+    assert_equal '"\xFE\xFF\x00\x61\x00\x61\x00\x61"', s.inspect
+
+    s = 'aaa'.encode "UTF-32"
+    assert_equal '"\x00\x00\xFE\xFF\x00\x00\x00\x61\x00\x00\x00\x61\x00\x00\x00\x61"', s.inspect
   end
 
   def test_encode_with_invalid_chars


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/18949#note-29