### PR TITLE
windows console input sometimes drop leading charactors.

### DIFF
--- a/win32/win32.c
+++ b/win32/win32.c
@@ -3105,6 +3105,11 @@ is_readable_console(SOCKET sock) /* call this for console only */
                 ir.Event.KeyEvent.uChar.UnicodeChar) {
                 ret = 1;
             }
+            else if (ir.EventType == KEY_EVENT && !ir.Event.KeyEvent.bKeyDown &&
+                ir.Event.KeyEvent.wVirtualKeyCode == 18 /* VK_MENU */ &&
+                ir.Event.KeyEvent.uChar.UnicodeChar) {
+                ret = 1;
+            }
             else {
                 ReadConsoleInputW((HANDLE)sock, &ir, 1, &n);
             }

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -3106,7 +3106,7 @@ is_readable_console(SOCKET sock) /* call this for console only */
                 ret = 1;
             }
             else if (ir.EventType == KEY_EVENT && !ir.Event.KeyEvent.bKeyDown &&
-                ir.Event.KeyEvent.wVirtualKeyCode == 18 /* VK_MENU */ &&
+                ir.Event.KeyEvent.wVirtualKeyCode == VK_MENU /* ALT key */ &&
                 ir.Event.KeyEvent.uChar.UnicodeChar) {
                 ret = 1;
             }

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -3102,7 +3102,7 @@ is_readable_console(SOCKET sock) /* call this for console only */
     RUBY_CRITICAL {
         if (PeekConsoleInputW((HANDLE)sock, &ir, 1, &n) && n > 0) {
             if (ir.EventType == KEY_EVENT && ir.Event.KeyEvent.bKeyDown &&
-                ir.Event.KeyEvent.uChar.AsciiChar) {
+                ir.Event.KeyEvent.uChar.UnicodeChar) {
                 ret = 1;
             }
             else {


### PR DESCRIPTION
In win32.c, is_readable_console() drops some kind of valid input character.
As a result, the first character(s) of STDIN.gets can be lost.

1. codepoint(in unicode) lower bytes has 0x00. \u0100,\u0400,\u2200, CJK charactors, etc.
2. ALT+NUMPAD sequence, via classic console(conhost.exe). They generates VK_ALT, key_up, UnicodeChar != 0.

This fixes both situations.
