### PR TITLE
Use `rb_off_t` instead of `off_t`

### DIFF
--- a/file.c
+++ b/file.c
@@ -2517,7 +2517,7 @@ rb_file_birthtime(VALUE obj)
  *
  */
 
-off_t
+rb_off_t
 rb_file_size(VALUE file)
 {
     if (RB_TYPE_P(file, T_FILE)) {
@@ -5089,7 +5089,7 @@ rb_file_s_join(VALUE klass, VALUE args)
 #if defined(HAVE_TRUNCATE)
 struct truncate_arg {
     const char *path;
-    off_t pos;
+    rb_off_t pos;
 };
 
 static void *
@@ -5138,7 +5138,7 @@ rb_file_s_truncate(VALUE klass, VALUE path, VALUE len)
 #if defined(HAVE_FTRUNCATE)
 struct ftruncate_arg {
     int fd;
-    off_t pos;
+    rb_off_t pos;
 };
 
 static VALUE
@@ -6093,7 +6093,7 @@ rb_stat_z(VALUE obj)
 static VALUE
 rb_stat_s(VALUE obj)
 {
-    off_t size = get_stat(obj)->st_size;
+    rb_off_t size = get_stat(obj)->st_size;
 
     if (size == 0) return Qnil;
     return OFFT2NUM(size);

--- a/file.c
+++ b/file.c
@@ -5086,41 +5086,17 @@ rb_file_s_join(VALUE klass, VALUE args)
     return rb_file_join(args);
 }
 
-#if defined(HAVE_TRUNCATE) || defined(HAVE_CHSIZE)
+#if defined(HAVE_TRUNCATE)
 struct truncate_arg {
     const char *path;
-#if defined(HAVE_TRUNCATE)
-#define NUM2POS(n) NUM2OFFT(n)
     off_t pos;
-#else
-#define NUM2POS(n) NUM2LONG(n)
-    long pos;
-#endif
 };
 
 static void *
 nogvl_truncate(void *ptr)
 {
     struct truncate_arg *ta = ptr;
-#ifdef HAVE_TRUNCATE
     return (void *)(VALUE)truncate(ta->path, ta->pos);
-#else /* defined(HAVE_CHSIZE) */
-    {
-        int tmpfd = rb_cloexec_open(ta->path, 0, 0);
-
-        if (tmpfd < 0)
-            return (void *)-1;
-        rb_update_max_fd(tmpfd);
-        if (chsize(tmpfd, ta->pos) < 0) {
-            int e = errno;
-            close(tmpfd);
-            errno = e;
-            return (void *)-1;
-        }
-        close(tmpfd);
-        return 0;
-    }
-#endif
 }
 
 /*
@@ -5144,7 +5120,7 @@ rb_file_s_truncate(VALUE klass, VALUE path, VALUE len)
     struct truncate_arg ta;
     int r;
 
-    ta.pos = NUM2POS(len);
+    ta.pos = NUM2OFFT(len);
     FilePathValue(path);
     path = rb_str_encode_ospath(path);
     ta.path = StringValueCStr(path);
@@ -5154,22 +5130,15 @@ rb_file_s_truncate(VALUE klass, VALUE path, VALUE len)
     if (r < 0)
         rb_sys_fail_path(path);
     return INT2FIX(0);
-#undef NUM2POS
 }
 #else
 #define rb_file_s_truncate rb_f_notimplement
 #endif
 
-#if defined(HAVE_FTRUNCATE) || defined(HAVE_CHSIZE)
+#if defined(HAVE_FTRUNCATE)
 struct ftruncate_arg {
     int fd;
-#if defined(HAVE_FTRUNCATE)
-#define NUM2POS(n) NUM2OFFT(n)
     off_t pos;
-#else
-#define NUM2POS(n) NUM2LONG(n)
-    long pos;
-#endif
 };
 
 static VALUE
@@ -5177,11 +5146,7 @@ nogvl_ftruncate(void *ptr)
 {
     struct ftruncate_arg *fa = ptr;
 
-#ifdef HAVE_FTRUNCATE
     return (VALUE)ftruncate(fa->fd, fa->pos);
-#else /* defined(HAVE_CHSIZE) */
-    return (VALUE)chsize(fa->fd, fa->pos);
-#endif
 }
 
 /*
@@ -5204,7 +5169,7 @@ rb_file_truncate(VALUE obj, VALUE len)
     rb_io_t *fptr;
     struct ftruncate_arg fa;
 
-    fa.pos = NUM2POS(len);
+    fa.pos = NUM2OFFT(len);
     GetOpenFile(obj, fptr);
     if (!(fptr->mode & FMODE_WRITABLE)) {
         rb_raise(rb_eIOError, "not opened for writing");
@@ -5215,7 +5180,6 @@ rb_file_truncate(VALUE obj, VALUE len)
         rb_sys_fail_path(fptr->pathv);
     }
     return INT2FIX(0);
-#undef NUM2POS
 }
 #else
 #define rb_file_truncate rb_f_notimplement

--- a/include/ruby/fiber/scheduler.h
+++ b/include/ruby/fiber/scheduler.h
@@ -276,7 +276,7 @@ VALUE rb_fiber_scheduler_io_write(VALUE scheduler, VALUE io, VALUE buffer, size_
  * @retval      RUBY_Qundef  `scheduler` doesn't have `#io_read`.
  * @return      otherwise    What `scheduler.io_read` returns.
  */
-VALUE rb_fiber_scheduler_io_pread(VALUE scheduler, VALUE io, VALUE buffer, size_t length, off_t offset);
+VALUE rb_fiber_scheduler_io_pread(VALUE scheduler, VALUE io, VALUE buffer, size_t length, rb_off_t offset);
 
 /**
  * Nonblocking write to the passed IO at the specified offset.
@@ -289,7 +289,7 @@ VALUE rb_fiber_scheduler_io_pread(VALUE scheduler, VALUE io, VALUE buffer, size_
  * @retval      RUBY_Qundef  `scheduler` doesn't have `#io_write`.
  * @return      otherwise    What `scheduler.io_write` returns.
  */
-VALUE rb_fiber_scheduler_io_pwrite(VALUE scheduler, VALUE io, VALUE buffer, size_t length, off_t offset);
+VALUE rb_fiber_scheduler_io_pwrite(VALUE scheduler, VALUE io, VALUE buffer, size_t length, rb_off_t offset);
 
 /**
  * Nonblocking read from the passed IO using a native buffer.

--- a/include/ruby/internal/intern/file.h
+++ b/include/ruby/internal/intern/file.h
@@ -206,7 +206,7 @@ int rb_is_absolute_path(const char *path);
  *              unpredictable.  POSIX's `<sys/stat.h>` states  that "the use of
  *              this field is unspecified" then.
  */
-off_t rb_file_size(VALUE file);
+rb_off_t rb_file_size(VALUE file);
 
 RBIMPL_SYMBOL_EXPORT_END()
 

--- a/include/ruby/io/buffer.h
+++ b/include/ruby/io/buffer.h
@@ -65,7 +65,7 @@ enum rb_io_buffer_endian {
 };
 
 VALUE rb_io_buffer_new(void *base, size_t size, enum rb_io_buffer_flags flags);
-VALUE rb_io_buffer_map(VALUE io, size_t size, off_t offset, enum rb_io_buffer_flags flags);
+VALUE rb_io_buffer_map(VALUE io, size_t size, rb_off_t offset, enum rb_io_buffer_flags flags);
 
 VALUE rb_io_buffer_lock(VALUE self);
 VALUE rb_io_buffer_unlock(VALUE self);
@@ -82,9 +82,9 @@ void rb_io_buffer_clear(VALUE self, uint8_t value, size_t offset, size_t length)
 
 // The length is the minimum required length.
 VALUE rb_io_buffer_read(VALUE self, VALUE io, size_t length);
-VALUE rb_io_buffer_pread(VALUE self, VALUE io, size_t length, off_t offset);
+VALUE rb_io_buffer_pread(VALUE self, VALUE io, size_t length, rb_off_t offset);
 VALUE rb_io_buffer_write(VALUE self, VALUE io, size_t length);
-VALUE rb_io_buffer_pwrite(VALUE self, VALUE io, size_t length, off_t offset);
+VALUE rb_io_buffer_pwrite(VALUE self, VALUE io, size_t length, rb_off_t offset);
 
 RBIMPL_SYMBOL_EXPORT_END()
 

--- a/include/ruby/win32.h
+++ b/include/ruby/win32.h
@@ -195,7 +195,6 @@ struct stati128 {
   long st_ctimensec;
 };
 
-#define off_t __int64
 #define stat stati128
 #undef SIZEOF_STRUCT_STAT_ST_INO
 #define SIZEOF_STRUCT_STAT_ST_INO sizeof(unsigned __int64)
@@ -401,9 +400,9 @@ scalb(double a, long b)
 
 #define SUFFIX
 
-extern int rb_w32_ftruncate(int fd, off_t length);
-extern int rb_w32_truncate(const char *path, off_t length);
-extern int rb_w32_utruncate(const char *path, off_t length);
+extern int rb_w32_ftruncate(int fd, rb_off_t length);
+extern int rb_w32_truncate(const char *path, rb_off_t length);
+extern int rb_w32_utruncate(const char *path, rb_off_t length);
 
 #undef HAVE_FTRUNCATE
 #define HAVE_FTRUNCATE 1
@@ -722,7 +721,7 @@ int  rb_w32_fclose(FILE*);
 int  rb_w32_pipe(int[2]);
 ssize_t rb_w32_read(int, void *, size_t);
 ssize_t rb_w32_write(int, const void *, size_t);
-off_t  rb_w32_lseek(int, off_t, int);
+rb_off_t  rb_w32_lseek(int, rb_off_t, int);
 int  rb_w32_uutime(const char *, const struct utimbuf *);
 int  rb_w32_uutimes(const char *, const struct timeval *);
 int  rb_w32_uutimensat(int /* must be AT_FDCWD */, const char *, const struct timespec *, int /* must be 0 */);
@@ -815,7 +814,7 @@ double rb_w32_pow(double x, double y);
 #define MAP_ANON	0x1000
 #define MAP_ANONYMOUS	MAP_ANON
 
-extern void *rb_w32_mmap(void *, size_t, int, int, int, off_t);
+extern void *rb_w32_mmap(void *, size_t, int, int, int, rb_off_t);
 extern int rb_w32_munmap(void *, size_t);
 extern int rb_w32_mprotect(void *, size_t, int);
 

--- a/io_buffer.c
+++ b/io_buffer.c
@@ -64,7 +64,7 @@ io_buffer_map_memory(size_t size)
 }
 
 static void
-io_buffer_map_file(struct rb_io_buffer *data, int descriptor, size_t size, off_t offset, enum rb_io_buffer_flags flags)
+io_buffer_map_file(struct rb_io_buffer *data, int descriptor, size_t size, rb_off_t offset, enum rb_io_buffer_flags flags)
 {
 #if defined(_WIN32)
     HANDLE file = (HANDLE)_get_osfhandle(descriptor);
@@ -409,7 +409,7 @@ rb_io_buffer_new(void *base, size_t size, enum rb_io_buffer_flags flags)
 }
 
 VALUE
-rb_io_buffer_map(VALUE io, size_t size, off_t offset, enum rb_io_buffer_flags flags)
+rb_io_buffer_map(VALUE io, size_t size, rb_off_t offset, enum rb_io_buffer_flags flags)
 {
     io_buffer_experimental();
 
@@ -478,7 +478,7 @@ io_buffer_map(int argc, VALUE *argv, VALUE klass)
         size = RB_NUM2SIZE(argv[1]);
     }
     else {
-        off_t file_size = rb_file_size(io);
+        rb_off_t file_size = rb_file_size(io);
 
         // Compiler can confirm that we handled file_size < 0 case:
         if (file_size < 0) {
@@ -494,7 +494,7 @@ io_buffer_map(int argc, VALUE *argv, VALUE klass)
         }
     }
 
-    off_t offset = 0;
+    rb_off_t offset = 0;
     if (argc >= 3) {
         offset = NUM2OFFT(argv[2]);
     }
@@ -2037,7 +2037,7 @@ io_buffer_read(VALUE self, VALUE io, VALUE length)
 }
 
 VALUE
-rb_io_buffer_pread(VALUE self, VALUE io, size_t length, off_t offset)
+rb_io_buffer_pread(VALUE self, VALUE io, size_t length, rb_off_t offset)
 {
     VALUE scheduler = rb_fiber_scheduler_current();
     if (scheduler != Qnil) {
@@ -2063,16 +2063,16 @@ rb_io_buffer_pread(VALUE self, VALUE io, size_t length, off_t offset)
     ssize_t result = pread(descriptor, base, size, offset);
 #else
     // This emulation is not thread safe, but the GVL means it's unlikely to be a problem.
-    off_t current_offset = lseek(descriptor, 0, SEEK_CUR);
-    if (current_offset == (off_t)-1)
+    rb_off_t current_offset = lseek(descriptor, 0, SEEK_CUR);
+    if (current_offset == (rb_off_t)-1)
         return rb_fiber_scheduler_io_result(-1, errno);
 
-    if (lseek(descriptor, offset, SEEK_SET) == (off_t)-1)
+    if (lseek(descriptor, offset, SEEK_SET) == (rb_off_t)-1)
         return rb_fiber_scheduler_io_result(-1, errno);
 
     ssize_t result = read(descriptor, base, size);
 
-    if (lseek(descriptor, current_offset, SEEK_SET) == (off_t)-1)
+    if (lseek(descriptor, current_offset, SEEK_SET) == (rb_off_t)-1)
         return rb_fiber_scheduler_io_result(-1, errno);
 #endif
 
@@ -2120,7 +2120,7 @@ io_buffer_write(VALUE self, VALUE io, VALUE length)
 }
 
 VALUE
-rb_io_buffer_pwrite(VALUE self, VALUE io, size_t length, off_t offset)
+rb_io_buffer_pwrite(VALUE self, VALUE io, size_t length, rb_off_t offset)
 {
     VALUE scheduler = rb_fiber_scheduler_current();
     if (scheduler != Qnil) {
@@ -2146,16 +2146,16 @@ rb_io_buffer_pwrite(VALUE self, VALUE io, size_t length, off_t offset)
     ssize_t result = pwrite(descriptor, base, length, offset);
 #else
     // This emulation is not thread safe, but the GVL means it's unlikely to be a problem.
-    off_t current_offset = lseek(descriptor, 0, SEEK_CUR);
-    if (current_offset == (off_t)-1)
+    rb_off_t current_offset = lseek(descriptor, 0, SEEK_CUR);
+    if (current_offset == (rb_off_t)-1)
         return rb_fiber_scheduler_io_result(-1, errno);
 
-    if (lseek(descriptor, offset, SEEK_SET) == (off_t)-1)
+    if (lseek(descriptor, offset, SEEK_SET) == (rb_off_t)-1)
         return rb_fiber_scheduler_io_result(-1, errno);
 
     ssize_t result = write(descriptor, base, length);
 
-    if (lseek(descriptor, current_offset, SEEK_SET) == (off_t)-1)
+    if (lseek(descriptor, current_offset, SEEK_SET) == (rb_off_t)-1)
         return rb_fiber_scheduler_io_result(-1, errno);
 #endif
 

--- a/scheduler.c
+++ b/scheduler.c
@@ -242,7 +242,7 @@ rb_fiber_scheduler_io_read(VALUE scheduler, VALUE io, VALUE buffer, size_t lengt
 }
 
 VALUE
-rb_fiber_scheduler_io_pread(VALUE scheduler, VALUE io, VALUE buffer, size_t length, off_t offset)
+rb_fiber_scheduler_io_pread(VALUE scheduler, VALUE io, VALUE buffer, size_t length, rb_off_t offset)
 {
     VALUE arguments[] = {
         io, buffer, SIZET2NUM(length), OFFT2NUM(offset)
@@ -262,7 +262,7 @@ rb_fiber_scheduler_io_write(VALUE scheduler, VALUE io, VALUE buffer, size_t leng
 }
 
 VALUE
-rb_fiber_scheduler_io_pwrite(VALUE scheduler, VALUE io, VALUE buffer, size_t length, off_t offset)
+rb_fiber_scheduler_io_pwrite(VALUE scheduler, VALUE io, VALUE buffer, size_t length, rb_off_t offset)
 {
     VALUE arguments[] = {
         io, buffer, SIZET2NUM(length), OFFT2NUM(offset)

--- a/win32/Makefile.sub
+++ b/win32/Makefile.sub
@@ -622,6 +622,10 @@ $(CONFIG_H): $(MKFILES) $(srcdir)/win32/Makefile.sub $(win_srcdir)/Makefile.sub
 #define ULL_TO_DOUBLE(n) ((double)(unsigned long)((n)>>32) * (1I64 << 32) + (unsigned long)(n))
 !endif
 #define HAVE_OFF_T 1
+#define rb_off_t __int64
+#define SIGNEDNESS_OF_OFF_T -1
+#define OFFT2NUM(v) LL2NUM(v)
+#define NUM2OFFT(v) NUM2LL(v)
 #define SIZEOF_INT 4
 #define SIZEOF_SHORT 2
 #define SIZEOF_LONG 4

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -5899,8 +5899,8 @@ rb_w32_lstati128(const char *path, struct stati128 *st)
 }
 
 /* License: Ruby's */
-off_t
-rb_w32_lseek(int fd, off_t ofs, int whence)
+rb_off_t
+rb_w32_lseek(int fd, rb_off_t ofs, int whence)
 {
     SOCKET sock = TO_SOCKET(fd);
     if (is_socket(sock) || is_pipe(sock)) {
@@ -5941,7 +5941,7 @@ rb_w32_uaccess(const char *path, int mode)
 
 /* License: Ruby's */
 static int
-rb_chsize(HANDLE h, off_t size)
+rb_chsize(HANDLE h, rb_off_t size)
 {
     long upos, lpos, usize, lsize;
     int ret = -1;
@@ -5970,7 +5970,7 @@ rb_chsize(HANDLE h, off_t size)
 
 /* License: Ruby's */
 static int
-w32_truncate(const char *path, off_t length, UINT cp)
+w32_truncate(const char *path, rb_off_t length, UINT cp)
 {
     HANDLE h;
     int ret;
@@ -5992,21 +5992,21 @@ w32_truncate(const char *path, off_t length, UINT cp)
 
 /* License: Ruby's */
 int
-rb_w32_utruncate(const char *path, off_t length)
+rb_w32_utruncate(const char *path, rb_off_t length)
 {
     return w32_truncate(path, length, CP_UTF8);
 }
 
 /* License: Ruby's */
 int
-rb_w32_truncate(const char *path, off_t length)
+rb_w32_truncate(const char *path, rb_off_t length)
 {
     return w32_truncate(path, length, filecp());
 }
 
 /* License: Ruby's */
 int
-rb_w32_ftruncate(int fd, off_t length)
+rb_w32_ftruncate(int fd, rb_off_t length)
 {
     HANDLE h;
 
@@ -8214,7 +8214,7 @@ VALUE (*const rb_f_notimplement_)(int, const VALUE *, VALUE, VALUE) = rb_f_notim
 #endif
 
 void *
-rb_w32_mmap(void *addr, size_t len, int prot, int flags, int fd, off_t offset)
+rb_w32_mmap(void *addr, size_t len, int prot, int flags, int fd, rb_off_t offset)
 {
     void *ptr;
     //DWORD protect = 0;


### PR DESCRIPTION
Get rid of the conflict with system-provided small `off_t`.

[[Bug #5317]](https://bugs.ruby-lang.org/issues/5317)

------------

Should also this be added to include/ruby/subst.h?

```C
#if !defined(HAVE_OFF_T) && !defined(off_t)
# define off_t rb_off_t
#endif
```
