### PR TITLE
Don't define ruby_qsort when POSIX qsort_r is available.

### DIFF
--- a/util.c
+++ b/util.c
@@ -218,6 +218,7 @@ ruby_strtoul(const char *str, char **endptr, int base)
 
 typedef int (cmpfunc_t)(const void*, const void*, void*);
 
+#if !defined HAVE_GNU_QSORT_R
 #if defined HAVE_QSORT_S && defined RUBY_MSVCRT_VERSION
 /* In contrast to its name, Visual Studio qsort_s is incompatible with
  * C11 in the order of the comparison function's arguments, and same
@@ -263,7 +264,7 @@ ruby_qsort(void* base, const size_t nel, const size_t size, cmpfunc_t *cmp, void
     qsort_s(base, nel, size, cmp, d);
 }
 # define HAVE_GNU_QSORT_R 1
-#elif !defined HAVE_GNU_QSORT_R
+#else
 /* mm.c */
 
 #define mmtype long
@@ -530,7 +531,8 @@ ruby_qsort(void* base, const size_t nel, const size_t size, cmpfunc_t *cmp, void
     else goto nxt;                         /* need not to sort both sides */
   }
 }
-#endif /* HAVE_GNU_QSORT_R */
+#endif
+#endif /* !HAVE_GNU_QSORT_R */
 
 char *
 ruby_strdup(const char *str)


### PR DESCRIPTION
The current code would define `ruby_qsort` as a wrapper of `qsort_s` when it is available. When both `qsort_s` and POSIX (GNU) `qsort_r` are available, we should call `qsort_r` directly instead, and the `qsort_s` wrapper is redundant.

This fixes ruby build on FreeBSD with `qsort_r` interface modified to match POSIX one (more information at https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=266227 and http://gohan05.nyi.freebsd.org/data/mainamd64PR266227-default/2022-09-06_09h13m56s/logs/errors/ruby32-3.2.0.p1_2,1.log ).