### PR TITLE
Avoid unnecessary copying when removing the leading part of a string

### DIFF
--- a/string.c
+++ b/string.c
@@ -5359,7 +5359,6 @@ rb_str_update(VALUE str, long beg, long len, VALUE val)
     if (len > slen - beg) {
         len = slen - beg;
     }
-    str_modify_keep_cr(str);
     p = str_nth(RSTRING_PTR(str), RSTRING_END(str), beg, enc, singlebyte);
     if (!p) p = RSTRING_END(str);
     e = str_nth(p, RSTRING_END(str), len, enc, singlebyte);


### PR DESCRIPTION
Remove the superfluous str_modify_keep_cr() call from rb_str_update(). It ends up calling either rb_str_drop_bytes() or rb_str_splice_0(), which already does checks if necessary.

The extra call makes the string "independent". This is not always wanted, in other words, it can keep the same shared root when merely removing the leading part of a shared string.

A quick test shows the reduction in the peak RSS:

```
$ /usr/bin/time ./miniruby-master -e'GC.disable' -e's="1"*10*1024*1024; s[0,1024*16]=""until s.empty?'
0.67user 0.86system 0:01.54elapsed 100%CPU (0avgtext+0avgdata 3296700maxresident)k
0inputs+0outputs (0major+822917minor)pagefaults 0swaps

$ /usr/bin/time ./miniruby -e'GC.disable' -e's="1"*10*1024*1024; s[0,1024*16]=""until s.empty?' 
0.22user 0.00system 0:00.23elapsed 100%CPU (0avgtext+0avgdata 23100maxresident)k
0inputs+0outputs (0major+4497minor)pagefaults 0swaps
```