### PR TITLE
Ruby 3.0 backport: Merge openssl-2.2.2

### DIFF
--- a/ext/openssl/History.md
+++ b/ext/openssl/History.md
@@ -1,3 +1,9 @@
+Version 2.2.2
+=============
+
+Merged changes in 2.1.4.
+
+
 Version 2.2.1
 =============
 
@@ -90,6 +96,16 @@ Notable changes
   added to `OpenSSL::PKey` classes: `private_to_der`, `private_to_pem`,
   `public_to_der` and `public_to_pem`.
   [[GitHub #297]](https://github.com/ruby/openssl/pull/297)
+
+
+Version 2.1.4
+=============
+
+Bug fixes
+---------
+
+* Do not use pkg-config if --with-openssl-dir option is specified.
+ [[GitHub #486]](https://github.com/ruby/openssl/pull/486)
 
 
 Version 2.1.3

--- a/ext/openssl/extconf.rb
+++ b/ext/openssl/extconf.rb
@@ -13,7 +13,7 @@
 
 require "mkmf"
 
-dir_config("openssl")
+dir_config_given = dir_config("openssl").any?
 dir_config("kerberos")
 
 Logging::message "=== OpenSSL for Ruby configurator ===\n"
@@ -90,7 +90,7 @@ def find_openssl_library
 end
 
 Logging::message "=== Checking for required stuff... ===\n"
-pkg_config_found = pkg_config("openssl") && have_header("openssl/ssl.h")
+pkg_config_found = !dir_config_given && pkg_config("openssl") && have_header("openssl/ssl.h")
 
 if !pkg_config_found && !find_openssl_library
   Logging::message "=== Checking for required stuff failed. ===\n"

--- a/ext/openssl/lib/openssl/version.rb
+++ b/ext/openssl/lib/openssl/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OpenSSL
-  VERSION = "2.2.1"
+  VERSION = "2.2.2"
 end

--- a/ext/openssl/openssl.gemspec
+++ b/ext/openssl/openssl.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "openssl"
-  spec.version       = "2.2.1"
+  spec.version       = "2.2.2"
   spec.authors       = ["Martin Bosslet", "SHIBATA Hiroshi", "Zachary Scott", "Kazuki Yamaguchi"]
   spec.email         = ["ruby-core@ruby-lang.org"]
   spec.summary       = %q{OpenSSL provides SSL, TLS and general purpose cryptography.}
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.3.0"
 
   spec.add_runtime_dependency "ipaddr"
-  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rake", ">= 11.2.0"
   spec.add_development_dependency "rake-compiler"
   spec.add_development_dependency "test-unit", "~> 3.0"
   spec.add_development_dependency "rdoc"


### PR DESCRIPTION
The changes can be found at:

  https://github.com/ruby/openssl/compare/v2.2.1...v2.2.2