### PR TITLE
Using `is_broken_string` function

### DIFF
--- a/file.c
+++ b/file.c
@@ -4500,9 +4500,9 @@ rb_check_realpath_internal(VALUE basedir, VALUE path, rb_encoding *origenc, enum
         rb_enc_associate(resolved, origenc);
     }
 
-    if (rb_enc_str_coderange(resolved) == ENC_CODERANGE_BROKEN) {
+    if (is_broken_string(resolved)) {
         rb_enc_associate(resolved, rb_filesystem_encoding());
-        if (rb_enc_str_coderange(resolved) == ENC_CODERANGE_BROKEN) {
+        if (is_broken_string(resolved)) {
             rb_enc_associate(resolved, rb_ascii8bit_encoding());
         }
     }

--- a/marshal.c
+++ b/marshal.c
@@ -1554,7 +1554,7 @@ r_symreal(struct load_arg *arg, int ivar)
     }
     if (idx > 0) {
         rb_enc_associate_index(s, idx);
-        if (rb_enc_str_coderange(s) == ENC_CODERANGE_BROKEN) {
+        if (is_broken_string(s)) {
             rb_raise(rb_eArgError, "invalid byte sequence in %s: %+"PRIsVALUE,
                      rb_enc_name(rb_enc_from_index(idx)), s);
         }

--- a/transcode.c
+++ b/transcode.c
@@ -2590,7 +2590,7 @@ rb_econv_prepare_options(VALUE opthash, VALUE *opts, int ecflags)
     v = rb_hash_aref(opthash, sym_replace);
     if (!NIL_P(v)) {
         StringValue(v);
-        if (rb_enc_str_coderange(v) == ENC_CODERANGE_BROKEN) {
+        if (is_broken_string(v)) {
             VALUE dumped = rb_str_dump(v);
             rb_raise(rb_eArgError, "replacement string is broken: %s as %s",
                      StringValueCStr(dumped),


### PR DESCRIPTION
Some code has this code to check encoding is broken.

```c
rb_enc_str_coderange(str) == ENC_CODERANGE_BROKEN
```

But, already implemented `is_broken_string` function that check broken encoding in `internal/string.h.`

```c
static inline bool
is_broken_string(VALUE str)
{
    return rb_enc_str_coderange(str) == ENC_CODERANGE_BROKEN;
}

```

I thought better to these check code replace and using `is_broken_string` function.