### PR TITLE
Fix parallel build on MINGW

### DIFF
--- a/cygwin/GNUmakefile.in
+++ b/cygwin/GNUmakefile.in
@@ -52,7 +52,7 @@ $(RUBY_EXP) $(LIBRUBY_SO): $(DLL_BASE_NAME).res.$(OBJEXT)
 	$(ECHO) compiling $@
 	$(Q) $(WINDRES) --include-dir . --include-dir $(<D) --include-dir $(srcdir)/win32 $< $@
 
-%.rc: $(RBCONFIG) $(srcdir)/revision.h $(srcdir)/win32/resource.rb
+%.rc: $(BOOTSTRAPRUBY_FAKE) $(RBCONFIG) $(srcdir)/revision.h $(srcdir)/win32/resource.rb
 	$(ECHO) generating $@
 	$(Q) $(BOOTSTRAPRUBY_COMMAND) $(srcdir)/win32/resource.rb \
 	  -ruby_name=$(RUBY_INSTALL_NAME) -rubyw_name=$(RUBYW_INSTALL_NAME) \
@@ -94,7 +94,7 @@ endif
 
 $(LIBRUBY_SO): $(RUBYDEF)
 
-$(RUBYDEF): $(LIBRUBY_A) $(PREP) $(RBCONFIG)
+$(RUBYDEF): $(LIBRUBY_A) $(PREP) $(BOOTSTRAPRUBY_FAKE) $(RBCONFIG)
 	$(ECHO) generating $@
 	$(Q) $(BOOTSTRAPRUBY_COMMAND) $(srcdir)/win32/mkexports.rb -output=$@ $(LIBRUBY_A)
 

--- a/template/Makefile.in
+++ b/template/Makefile.in
@@ -170,6 +170,7 @@ yes_baseruby = $(HAVE_BASERUBY:no=)
 no_baseruby = $(HAVE_BASERUBY:yes=)
 BOOTSTRAPRUBY = $(yes_baseruby:yes=$(BASERUBY)) $(no_baseruby:no=$(MINIRUBY))
 BOOTSTRAPRUBY_OPT = $(yes_baseruby:yes=-r./$(arch)-fake)
+BOOTSTRAPRUBY_FAKE = $(yes_baseruby:yes=$(arch)-fake.rb)
 
 COROUTINE_H = @X_COROUTINE_H@
 COROUTINE_OBJ = $(COROUTINE_H:.h=.$(OBJEXT))


### PR DESCRIPTION
When the build is running with a base ruby then generating `x64-ucrt-ruby320.rc` could fail due to a missing dependency to `x64-mingw-ucrt-fake.rb`. This commit adds this dependency.

A failing build looks like so:
```
generating x64-mingw-ucrt-fake.rb
generating x64-ucrt-ruby320.rc
../snapshot-master/win32/resource.rb:in `require': cannot load such file -- ./x64-mingw-ucrt-fake (LoadError)
make: *** [GNUmakefile:57: x64-ucrt-ruby320.rc] Error 1
make: *** Waiting for unfinished jobs....
linking miniruby.exe
x64-mingw-ucrt-fake.rb updated
```

I fails since 2022-09-05 like here: https://github.com/oneclick/rubyinstaller2-packages/runs/8195238345?check_suite_focus=true#step:8:961