### PR TITLE
YJIT: Generate direct jump in branch{if,unless,nil} when it can be determined from types

### DIFF
--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -172,7 +172,7 @@ impl Type {
         }
     }
 
-    /// Returns an Option with the exact value if it is known, otherwise None
+    /// Returns an Option boolean representing whether the value is truthy if known, otherwise None
     pub fn known_truthy(&self) -> Option<bool> {
         match self {
             Type::Nil => Some(false),
@@ -180,6 +180,16 @@ impl Type {
             Type::UnknownHeap => Some(true),
             Type::Unknown | Type::UnknownImm => None,
             _ => Some(true)
+        }
+    }
+
+    /// Returns an Option boolean representing whether the value is equal to nil if known, otherwise None
+    pub fn known_nil(&self) -> Option<bool> {
+        match (self, self.known_truthy()) {
+            (Type::Nil, _) => Some(true),
+            (Type::False, _) => Some(false), // Qfalse is not nil
+            (_, Some(true))  => Some(false), // if truthy, can't be nil
+            (_, _) => None // otherwise unknown
         }
     }
 


### PR DESCRIPTION
In branchif/branchunless/branchnil, if we have information about the value we're testing. We can make a direct jump instead of a conditional one.

For example:

```
def foo(bar)
  bar || :default
end

foo(nil)
```

**Before:**

```
== BLOCK 1/2, ISEQ RANGE [0,5), 32 bytes ======================
  # getlocal_WC_0
  0x55acc59a4170: mov rax, qword ptr [r13 + 0x20]
  0x55acc59a4174: mov rax, qword ptr [rax - 0x18]
  0x55acc59a4178: mov qword ptr [rbx], rax
  # dup
  0x55acc59a417b: mov rax, qword ptr [rbx]
  0x55acc59a417e: mov qword ptr [rbx + 8], rax
  # branchif
  0x55acc59a4182: test qword ptr [rbx + 8], -9
  # regenerate_branch
  0x55acc59a418a: jne 0x55accd9a40ee
== BLOCK 2/2, ISEQ RANGE [5,9), 54 bytes ======================
  # pop
  # putobject
  0x55acc59a4190: mov qword ptr [rbx], 0x36810c
  # leave
```

**After:**

```
NUM BLOCK VERSIONS: 2
TOTAL INLINE CODE SIZE: 72 bytes
== BLOCK 1/2, ISEQ RANGE [0,5), 18 bytes ======================
  # getlocal_WC_0
  0x55e31c46d170: mov rax, qword ptr [r13 + 0x20]
  0x55e31c46d174: mov rax, qword ptr [rax - 0x18]
  0x55e31c46d178: mov qword ptr [rbx], rax
  # dup
  0x55e31c46d17b: mov rax, qword ptr [rbx]
  0x55e31c46d17e: mov qword ptr [rbx + 8], rax
== BLOCK 2/2, ISEQ RANGE [5,9), 54 bytes ======================
  # branchif
  # pop
  # putobject
  0x55e31c46d182: mov qword ptr [rbx], 0x36810c
  # leave
```

We completely skip the `test` and `jne` instructions because of type information from the caller.

Unfortunately, this is currently not too common, only about 7.5% of these branches can know their target from type information, and I didn't notice any change in benchmarks. Fortunately, I don't think this adds too much complexity. I think we could make this more impactful in the future by learning type information from integer comparisons and similar.