### PR TITLE
Raise ArgumentError in IO#sysread on Windows when given a negative length

### DIFF
--- a/io.c
+++ b/io.c
@@ -3053,7 +3053,8 @@ static int
 io_setstrbuf(VALUE *str, long len)
 {
 #ifdef _WIN32
-    len = (len + 1) & ~1L;	/* round up for wide char */
+    if (len > 0)
+        len = (len + 1) & ~1L;	/* round up for wide char */
 #endif
     if (NIL_P(*str)) {
         *str = rb_str_new(0, len);

--- a/test/ruby/test_io.rb
+++ b/test/ruby/test_io.rb
@@ -2213,6 +2213,14 @@ class TestIO < Test::Unit::TestCase
     end)
   end
 
+  def test_sysread_with_negative_length
+    make_tempfile {|t|
+      open(t.path) do |f|
+        assert_raise(ArgumentError) { f.sysread(-1) }
+      end
+    }
+  end
+
   def test_flag
     make_tempfile {|t|
       assert_raise(ArgumentError) do


### PR DESCRIPTION
Fixes [Bug #18880]