### PR TITLE
rbconfig, mkmf: call foreign pkg-config when cross compiling

### DIFF
--- a/lib/mkmf.rb
+++ b/lib/mkmf.rb
@@ -1866,7 +1866,7 @@ SRC
     if pkgconfig = with_config("#{pkg}-config") and find_executable0(pkgconfig)
       # if and only if package specific config command is given
     elsif ($PKGCONFIG ||=
-           (pkgconfig = with_config("pkg-config", ("pkg-config" unless CROSS_COMPILING))) &&
+           (pkgconfig = with_config("pkg-config", CROSS_COMPILING ? RbConfig::CONFIG["CC"].sub(/-gcc$/, "-pkg-config"): "pkg-config")) &&
            find_executable0(pkgconfig) && pkgconfig) and
         xsystem([*envs, $PKGCONFIG, "--exists", pkg])
       # default to pkg-config command

--- a/tool/mkconfig.rb
+++ b/tool/mkconfig.rb
@@ -383,7 +383,7 @@ print <<EOS
     )
   end
 end
-CROSS_COMPILING = nil unless defined? CROSS_COMPILING
+CROSS_COMPILING = (RbConfig::CONFIG["arch"] != RUBY_PLATFORM) unless defined? CROSS_COMPILING
 EOS
 
 # vi:set sw=2:


### PR DESCRIPTION
When cross compiling packages that use pkg-config on Debian, one can use ${DEB_HOST_GNU_TYPE}-pkg-config to find library configuration for the architecture we are compiling for. For example,
i686-linux-gnu-pkg-config on i386, or aarch64-linux-gnu-pkg-config for arm64.

For this to work, in Debian we set RUBYLIB to include a directory containing the foreign rbconfig.rb for the architecture we are building for, e.g.

$ find /usr/lib/aarch64-linux-gnu/ruby-crossbuild -not -type d /usr/lib/aarch64-linux-gnu/ruby-crossbuild/3.0.0/rbconfig.rb

So when cross compiling, Ruby will load the rbconfig.rb for the architecture we are compiling for, which is the same mechanism used when we are cross compiling Ruby itself.

Link: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1018230

----

This patch has been tested on Debian, and allows to cross compile Ruby extensions that use pkg-config.
Of course this has a few limitations (e.g. assuming the compiler is gcc and ruby has been compiled with multiarch support), and that the cross-pkg-config binaries are available at all, but AFAICT it won't break any cases that currently work, since cross compilation was basically ignored before this.