### PR TITLE
Revert "defs/gmake.mk: no _FORTIFY_SOURCE unless optimization"

### DIFF
--- a/defs/gmake.mk
+++ b/defs/gmake.mk
@@ -44,10 +44,6 @@ TEST_DEPENDS += $(if $(filter great exam love check,$(MAKECMDGOALS)),all exts)
 
 in-srcdir := $(if $(filter-out .,$(srcdir)),$(CHDIR) $(srcdir) &&)
 
-ifneq ($(filter -O0 -Od,$(optflags)),)
-override XCFLAGS := $(filter-out -D_FORTIFY_SOURCE=%,$(XCFLAGS))
-endif
-
 ifeq ($(if $(filter all main exts enc trans libencs libenc libtrans \
 		    prog program ruby ruby$(EXEEXT) \
 		    wprogram rubyw rubyw$(EXEEXT) \


### PR DESCRIPTION
This reverts commit b8c376cb9d91854fd40f6e06f07773404899b54f, as it seems no longer needed probably.