### PR TITLE
YJIT: Add Opnd#with_num_bits to use only 8 bits

### DIFF
--- a/yjit/src/asm/arm64/inst/load_store.rs
+++ b/yjit/src/asm/arm64/inst/load_store.rs
@@ -2,6 +2,7 @@ use super::super::arg::truncate_imm;
 
 /// The size of the operands being operated on.
 enum Size {
+    Size8 = 0b00,
     Size32 = 0b10,
     Size64 = 0b11,
 }
@@ -81,6 +82,12 @@ impl LoadStore {
         Self { rt, rn, idx: Index::None, imm9, opc: Opc::LDR, size: num_bits.into() }
     }
 
+    /// LDURB (load register, byte, unscaled)
+    /// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/LDURB--Load-Register-Byte--unscaled--?lang=en
+    pub fn ldurb(rt: u8, rn: u8, imm9: i16) -> Self {
+        Self { rt, rn, idx: Index::None, imm9, opc: Opc::LDR, size: Size::Size8 }
+    }
+
     /// LDURSW (load register, unscaled, signed)
     /// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/LDURSW--Load-Register-Signed-Word--unscaled--?lang=en
     pub fn ldursw(rt: u8, rn: u8, imm9: i16) -> Self {
@@ -155,6 +162,13 @@ mod tests {
         let inst = LoadStore::ldur(0, 1, 0, 64);
         let result: u32 = inst.into();
         assert_eq!(0xf8400020, result);
+    }
+
+    #[test]
+    fn test_ldurb() {
+        let inst = LoadStore::ldurb(0, 1, 0);
+        let result: u32 = inst.into();
+        assert_eq!(0x38400020, result);
     }
 
     #[test]

--- a/yjit/src/asm/arm64/mod.rs
+++ b/yjit/src/asm/arm64/mod.rs
@@ -267,12 +267,7 @@ pub fn cmp(cb: &mut CodeBlock, rn: A64Opnd, rm: A64Opnd) {
             DataReg::cmp(rn.reg_no, rm.reg_no, rn.num_bits).into()
         },
         (A64Opnd::Reg(rn), A64Opnd::UImm(imm12)) => {
-            let num_bits = if (rn.num_bits == 8) {
-                32 // size can't be 8. assume the remaining 24 bits are zero-extended.
-            } else {
-                rn.num_bits
-            };
-            DataImm::cmp(rn.reg_no, imm12.try_into().unwrap(), num_bits).into()
+            DataImm::cmp(rn.reg_no, imm12.try_into().unwrap(), rn.num_bits).into()
         },
         _ => panic!("Invalid operand combination to cmp instruction."),
     };

--- a/yjit/src/asm/arm64/opnd.rs
+++ b/yjit/src/asm/arm64/opnd.rs
@@ -12,11 +12,6 @@ pub struct A64Reg
 }
 
 impl A64Reg {
-    pub fn sub_reg(&self, num_bits: u8) -> Self {
-        assert!(num_bits <= self.num_bits);
-        self.with_num_bits(num_bits)
-    }
-
     pub fn with_num_bits(&self, num_bits: u8) -> Self {
         assert!(num_bits == 8 || num_bits == 16 || num_bits == 32 || num_bits == 64);
         Self { num_bits, reg_no: self.reg_no }

--- a/yjit/src/asm/arm64/opnd.rs
+++ b/yjit/src/asm/arm64/opnd.rs
@@ -13,7 +13,7 @@ pub struct A64Reg
 
 impl A64Reg {
     pub fn sub_reg(&self, num_bits: u8) -> Self {
-        assert!(num_bits == 32 || num_bits == 64);
+        assert!(num_bits == 8 || num_bits == 32 || num_bits == 64);
         assert!(num_bits <= self.num_bits);
 
         Self { num_bits, reg_no: self.reg_no }

--- a/yjit/src/asm/arm64/opnd.rs
+++ b/yjit/src/asm/arm64/opnd.rs
@@ -13,9 +13,12 @@ pub struct A64Reg
 
 impl A64Reg {
     pub fn sub_reg(&self, num_bits: u8) -> Self {
-        assert!(num_bits == 8 || num_bits == 32 || num_bits == 64);
         assert!(num_bits <= self.num_bits);
+        self.with_num_bits(num_bits)
+    }
 
+    pub fn with_num_bits(&self, num_bits: u8) -> Self {
+        assert!(num_bits == 8 || num_bits == 16 || num_bits == 32 || num_bits == 64);
         Self { num_bits, reg_no: self.reg_no }
     }
 }

--- a/yjit/src/asm/x86_64/mod.rs
+++ b/yjit/src/asm/x86_64/mod.rs
@@ -90,15 +90,17 @@ pub enum X86Opnd
 
 impl X86Reg {
     pub fn sub_reg(&self, num_bits: u8) -> Self {
+        assert!(num_bits <= self.num_bits);
+        self.with_num_bits(num_bits)
+    }
+
+    pub fn with_num_bits(&self, num_bits: u8) -> Self {
         assert!(
             num_bits == 8 ||
             num_bits == 16 ||
             num_bits == 32 ||
             num_bits == 64
         );
-
-        assert!(num_bits <= self.num_bits);
-
         Self {
             num_bits,
             reg_type: self.reg_type,

--- a/yjit/src/asm/x86_64/mod.rs
+++ b/yjit/src/asm/x86_64/mod.rs
@@ -89,11 +89,6 @@ pub enum X86Opnd
 }
 
 impl X86Reg {
-    pub fn sub_reg(&self, num_bits: u8) -> Self {
-        assert!(num_bits <= self.num_bits);
-        self.with_num_bits(num_bits)
-    }
-
     pub fn with_num_bits(&self, num_bits: u8) -> Self {
         assert!(
             num_bits == 8 ||

--- a/yjit/src/backend/arm64/mod.rs
+++ b/yjit/src/backend/arm64/mod.rs
@@ -747,7 +747,11 @@ impl Assembler
                             emit_load_value(cb, out.into(), imm as u64);
                         },
                         Opnd::Mem(_) => {
-                            ldur(cb, out.into(), opnd.into());
+                            match opnd.rm_num_bits() {
+                                64 | 32 => ldur(cb, out.into(), opnd.into()),
+                                8 => ldurb(cb, out.into(), opnd.into()),
+                                num_bits => panic!("unexpected num_bits: {}", num_bits)
+                            };
                         },
                         Opnd::Value(value) => {
                             // We dont need to check if it's a special const

--- a/yjit/src/backend/arm64/mod.rs
+++ b/yjit/src/backend/arm64/mod.rs
@@ -140,7 +140,14 @@ impl Assembler
                 Opnd::Reg(_) | Opnd::InsnOut { .. } => opnd,
                 Opnd::Mem(_) => {
                     let split_opnd = split_memory_address(asm, opnd);
-                    asm.load(split_opnd)
+                    let out_opnd = asm.load(split_opnd);
+                    // Many Arm insns support only 32-bit or 64-bit operands. asm.load with fewer
+                    // bits zero-extends the value, so it's safe to recognize it as a 32-bit value.
+                    if out_opnd.rm_num_bits() < 32 {
+                        out_opnd.with_num_bits(32).unwrap()
+                    } else {
+                        out_opnd
+                    }
                 },
                 _ => asm.load(opnd)
             }

--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -157,6 +157,7 @@ impl Opnd
     }
 
     pub fn with_num_bits(&self, num_bits: u8) -> Option<Opnd> {
+        assert!(num_bits == 8 || num_bits == 16 || num_bits == 32 || num_bits == 64);
         match *self {
             Opnd::Reg(reg) => Some(Opnd::Reg(reg.with_num_bits(num_bits))),
             Opnd::Mem(Mem { base, disp, .. }) => Some(Opnd::Mem(Mem { base, disp, num_bits })),

--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -151,11 +151,6 @@ impl Opnd
         }
     }
 
-    pub fn sub_opnd(&self, num_bits: u8) -> Option<Opnd> {
-        assert!(num_bits <= self.rm_num_bits());
-        self.with_num_bits(num_bits)
-    }
-
     pub fn with_num_bits(&self, num_bits: u8) -> Option<Opnd> {
         assert!(num_bits == 8 || num_bits == 16 || num_bits == 32 || num_bits == 64);
         match *self {

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -3477,7 +3477,7 @@ fn jit_guard_known_klass(
 
             asm.comment("guard object is static symbol");
             assert!(RUBY_SPECIAL_SHIFT == 8);
-            asm.cmp(obj_opnd.sub_opnd(8).unwrap(), Opnd::UImm(RUBY_SYMBOL_FLAG as u64));
+            asm.cmp(obj_opnd.with_num_bits(8).unwrap(), Opnd::UImm(RUBY_SYMBOL_FLAG as u64));
             jit_chain_guard(JCC_JNE, jit, ctx, asm, ocb, max_chain_depth, side_exit);
             ctx.upgrade_opnd_type(insn_opnd, Type::ImmSymbol);
         }

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -3477,8 +3477,7 @@ fn jit_guard_known_klass(
 
             asm.comment("guard object is static symbol");
             assert!(RUBY_SPECIAL_SHIFT == 8);
-            let flag_bits = asm.and(obj_opnd, Opnd::UImm(0xf));
-            asm.cmp(flag_bits, Opnd::UImm(RUBY_SYMBOL_FLAG as u64));
+            asm.cmp(obj_opnd.sub_opnd(8).unwrap(), Opnd::UImm(RUBY_SYMBOL_FLAG as u64));
             jit_chain_guard(JCC_JNE, jit, ctx, asm, ocb, max_chain_depth, side_exit);
             ctx.upgrade_opnd_type(insn_opnd, Type::ImmSymbol);
         }


### PR DESCRIPTION
addresses https://github.com/ruby/ruby/pull/6301#issuecomment-1230855536

This PR optimizes code like this:

```rb
def test(sym)
  sym == :a
end
test(:a)
```

## x86_64
### before
```nasm
  # guard object is static symbol
  0x10e230030: mov rax, qword ptr [rbx]
  0x10e230033: and rax, 0xf
  0x10e230037: cmp rax, 0xc
```

### after
```nasm
  # guard object is static symbol
  0x110b70030: cmp byte ptr [rbx], 0xc
```

## arm64
### before
```nasm
  # guard object is static symbol
  0x10374004c: ldur x11, [x21]
  0x103740050: and x11, x11, #0xf
  0x103740054: cmp x11, #0xc
```

### after
```nasm
  # guard object is static symbol
  0x106de004c: ldurb w11, [x21]
  0x106de0050: cmp w11, #0xc
```