### PR TITLE
Allocate registers backward

### DIFF
--- a/yjit/src/backend/arm64/mod.rs
+++ b/yjit/src/backend/arm64/mod.rs
@@ -977,7 +977,8 @@ impl Assembler
     /// Optimize and compile the stored instructions
     pub fn compile_with_regs(self, cb: &mut CodeBlock, regs: Vec<Reg>) -> Vec<u32>
     {
-        let mut asm = self.arm64_split().alloc_regs(regs);
+        let mut asm = self.arm64_split();
+        asm.alloc_regs(regs);
 
         // Create label instances in the code block
         for (idx, name) in asm.label_names.iter().enumerate() {

--- a/yjit/src/backend/tests.rs
+++ b/yjit/src/backend/tests.rs
@@ -69,7 +69,7 @@ fn test_alloc_regs() {
     asm.add(out3, Opnd::UImm(6));
 
     // Here we're going to allocate the registers.
-    let result = asm.alloc_regs(Assembler::get_alloc_regs());
+    asm.alloc_regs(Assembler::get_alloc_regs());
 
     // Now we're going to verify that the out field has been appropriately
     // updated for each of the instructions that needs it.
@@ -77,9 +77,9 @@ fn test_alloc_regs() {
     let reg0 = regs[0];
     let reg1 = regs[1];
 
-    assert!(matches!(result.insns[0].out_opnd(), Some(Opnd::Reg(reg0))));
-    assert!(matches!(result.insns[2].out_opnd(), Some(Opnd::Reg(reg1))));
-    assert!(matches!(result.insns[5].out_opnd(), Some(Opnd::Reg(reg0))));
+    assert!(matches!(asm.insns[0].out_opnd(), Some(Opnd::Reg(reg0))));
+    assert!(matches!(asm.insns[2].out_opnd(), Some(Opnd::Reg(reg1))));
+    assert!(matches!(asm.insns[5].out_opnd(), Some(Opnd::Reg(reg0))));
 }
 
 fn setup_asm() -> (Assembler, CodeBlock) {

--- a/yjit/src/backend/x86_64/mod.rs
+++ b/yjit/src/backend/x86_64/mod.rs
@@ -670,7 +670,8 @@ impl Assembler
     /// Optimize and compile the stored instructions
     pub fn compile_with_regs(self, cb: &mut CodeBlock, regs: Vec<Reg>) -> Vec<u32>
     {
-        let mut asm = self.x86_split().alloc_regs(regs);
+        let mut asm = self.x86_split();
+        asm.alloc_regs(regs);
 
         // Create label instances in the code block
         for (idx, name) in asm.label_names.iter().enumerate() {


### PR DESCRIPTION
Setting this up so that we can bias the register allocator toward giving us the registers we want ahead of time to reduce movs later.