### PR TITLE
[DOC] socket: fix wrong sample addresses

### DIFF
--- a/ext/socket/raddrinfo.c
+++ b/ext/socket/raddrinfo.c
@@ -2192,7 +2192,7 @@ addrinfo_ipv6_multicast_p(VALUE self)
 }
 
 /*
- * Returns true for IPv6 link local address (ff80::/10).
+ * Returns true for IPv6 link local address (fe80::/10).
  * It returns false otherwise.
  */
 static VALUE
@@ -2204,7 +2204,7 @@ addrinfo_ipv6_linklocal_p(VALUE self)
 }
 
 /*
- * Returns true for IPv6 site local address (ffc0::/10).
+ * Returns true for IPv6 site local address (fec0::/10).
  * It returns false otherwise.
  */
 static VALUE


### PR DESCRIPTION
IPv6 link local address is fe80::/10 not ff80::/10:

https://www.rfc-editor.org/rfc/rfc4291.html

    Link-Local unicast   1111111010           FE80::/10       2.5.6

IPv6 (deprecated) site local address is fec0::/10 not ffc0::/10:

https://www.rfc-editor.org/rfc/rfc3513.html

    Site-local unicast   1111111011           FEC0::/10       2.5.6