### PR TITLE
YJIT should die if we compile on Aarch64 with no instruction cache clear available

### DIFF
--- a/yjit.c
+++ b/yjit.c
@@ -89,6 +89,8 @@ rb_yjit_icache_invalidate(void *start, void *end)
     // On Darwin it's the same as calling sys_icache_invalidate().
 #ifdef __GNUC__
     __builtin___clear_cache(start, end);
+#elif defined(__aarch64__)
+#error No instruction cache clear available with this compiler on Aarch64!
 #endif
 }
 


### PR DESCRIPTION
From pairing session with @maximecb and @kddnewton.
