### PR TITLE
Auto-generate the date on version.h from CommitDate

### DIFF
--- a/tool/lib/vcs.rb
+++ b/tool/lib/vcs.rb
@@ -204,12 +204,13 @@ class VCS
     revision_handler(rev).short_revision(rev)
   end
 
-  def revision_header(last, modified = nil, branch = nil, title = nil, limit: 20)
+  def revision_header(last, modified, branch = nil, title = nil, limit: 20)
     short = short_revision(last)
     if /[^\x00-\x7f]/ =~ title and title.respond_to?(:force_encoding)
       title = title.dup.force_encoding("US-ASCII")
     end
     code = [
+      "#ifndef RUBY_REVISION",
       "#define RUBY_REVISION #{short.inspect}",
     ]
     unless short == last
@@ -225,10 +226,14 @@ class VCS
       title = title.dump.sub(/\\#/, '#')
       code << "#define RUBY_LAST_COMMIT_TITLE #{title}"
     end
-    if modified
-      t = modified.utc
-      code << t.strftime('#define RUBY_RELEASE_DATETIME "%FT%TZ"')
-    end
+    t = modified.utc
+    code << t.strftime('#define RUBY_RELEASE_DATETIME "%FT%TZ"')
+    code << "#endif"
+
+    code << t.strftime('#define RUBY_RELEASE_YEAR %Y')
+    code << t.strftime('#define RUBY_RELEASE_MONTH %-m')
+    code << t.strftime('#define RUBY_RELEASE_DAY %-d')
+
     code
   end
 

--- a/tool/make-snapshot
+++ b/tool/make-snapshot
@@ -292,12 +292,9 @@ def package(vcs, rev, destdir, tmp = nil)
     warn "#{$0}: unknown version - #{rev}"
     return
   end
-  if info = vcs.get_revisions(url)
-    modified = info[2]
-  else
-    modified = Time.now - 10
-  end
-  if !revision and info
+  info = vcs.get_revisions(url)
+  modified = info[2]
+  if !revision
     revision = info
     url ||= vcs.branch(revision[3])
     revision = revision[1]
@@ -347,7 +344,7 @@ def package(vcs, rev, destdir, tmp = nil)
   end
 
   File.open("#{v}/revision.h", "wb") {|f|
-    f.puts vcs.revision_header(revision)
+    f.puts vcs.revision_header(revision, info[2])
   }
   version ||= (versionhdr = IO.read("#{v}/version.h"))[RUBY_VERSION_PATTERN, 1]
   version ||=

--- a/version.h
+++ b/version.h
@@ -13,10 +13,7 @@
 #define RUBY_RELEASE_DATE RUBY_RELEASE_YEAR_STR"-"RUBY_RELEASE_MONTH_STR"-"RUBY_RELEASE_DAY_STR
 #define RUBY_PATCHLEVEL -1
 
-#define RUBY_RELEASE_YEAR 2022
-#define RUBY_RELEASE_MONTH 9
-#define RUBY_RELEASE_DAY 15
-
+#include "revision.h"
 #include "ruby/version.h"
 #include "ruby/internal/abi.h"
 
@@ -59,10 +56,6 @@
 #error RUBY_ABI_VERSION is defined in non-development branch
 #else
 #define RUBY_PATCHLEVEL_STR ""
-#endif
-
-#ifndef RUBY_REVISION
-# include "revision.h"
 #endif
 
 #endif /* RUBY_TOPLEVEL_VERSION_H */


### PR DESCRIPTION
We can gradually stop maintaining update-version.h.rb in ruby-commit-hook.
The commit history will be shorter and cleaner as well.