### PR TITLE
Re-enable TZ test missed due to merge conflict.

### DIFF
--- a/spec/ruby/core/time/shared/local.rb
+++ b/spec/ruby/core/time/shared/local.rb
@@ -6,7 +6,6 @@ describe :time_local, shared: true do
     end
   end
 
-=begin
   platform_is_not :windows do
     describe "timezone changes" do
       it "correctly adjusts the timezone change to 'CET' on 'Europe/Amsterdam'" do
@@ -17,7 +16,6 @@ describe :time_local, shared: true do
       end
     end
   end
-=end
 end
 
 describe :time_local_10_arg, shared: true do


### PR DESCRIPTION
This was disabled by b7577b4d9e, while properly fixed upstream by:

https://github.com/ruby/spec/pull/939

@eregon PTAL, the current status seems to be just wrongly resolved merge conflict.