### PR TITLE
YJIT: Check if the processor supports --yjit-stats

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -209,6 +209,7 @@ macro_rules! gen_counter_incr {
             let ptr = ptr_to_counter!($counter_name);
 
             // Load the pointer into a register
+            $asm.comment(&format!("increment counter {}", stringify!($counter_name)));
             let ptr_reg = $asm.load(Opnd::const_ptr(ptr as *const u8));
             let counter_opnd = Opnd::mem(64, ptr_reg, 0);
 

--- a/yjit/src/options.rs
+++ b/yjit/src/options.rs
@@ -151,7 +151,16 @@ pub fn parse_option(str_ptr: *const std::os::raw::c_char) -> Option<()> {
 
         ("greedy-versioning", "") => unsafe { OPTIONS.greedy_versioning = true },
         ("no-type-prop", "") => unsafe { OPTIONS.no_type_prop = true },
-        ("stats", "") => unsafe { OPTIONS.gen_stats = true },
+        ("stats", "") => {
+            // Insn::IncrCounter uses ldaddal, which works only on ARMv8.1+.
+            #[cfg(target_arch = "aarch64")]
+            if !std::arch::is_aarch64_feature_detected!("lse") {
+                eprintln!("Your processor does not support --yjit-stats. Aborting.");
+                std::process::exit(1);
+            }
+
+            unsafe { OPTIONS.gen_stats = true }
+        },
         ("trace-exits", "") => unsafe { OPTIONS.gen_trace_exits = true; OPTIONS.gen_stats = true },
         ("dump-insns", "") => unsafe { OPTIONS.dump_insns = true },
         ("verify-ctx", "") => unsafe { OPTIONS.verify_ctx = true },


### PR DESCRIPTION
`Insn::IncrCounter` uses `ldaddal`, which works only on ARMv8.1+ and thus results in Illegal instruction on Graviton (Cortex-A72, ARMv8). Until we change the backend implementation, we should not run --yjit-stats on that chip.

This should still work on a newer environment like Graviton2 or Graviton3, so I'm not sure if we want to add complexity to support Graviton.

I also added an `asm.comment` to make `--yjit-dump-disasm` more readable with `--yjit-stats`.