### PR TITLE
Reduce fork calls in daemon

### DIFF
--- a/process.c
+++ b/process.c
@@ -7109,19 +7109,13 @@ rb_daemon(int nochdir, int noclose)
 #else
     int n;
 
-#define fork_daemon() \
-    switch (rb_fork_ruby(NULL)) { \
-      case -1: return -1; \
-      case 0:  break; \
-      default: _exit(EXIT_SUCCESS); \
+    switch (rb_fork_ruby(NULL)) {
+      case -1: return -1;
+      case 0:  break;
+      default: _exit(EXIT_SUCCESS);
     }
 
-    fork_daemon();
-
     if (setsid() < 0) return -1;
-
-    /* must not be process-leader */
-    fork_daemon();
 
     if (!nochdir)
         err = chdir("/");

--- a/test/ruby/test_process.rb
+++ b/test/ruby/test_process.rb
@@ -1876,6 +1876,26 @@ class TestProcess < Test::Unit::TestCase
       assert_not_equal(cpid, dpid)
     end
 
+    def test_daemon_detached
+      IO.popen("-", "r+") do |f|
+        if f
+          assert_equal(f.pid, Process.wait(f.pid))
+
+          dpid, ppid = Integer(f.gets), Integer(f.gets)
+
+          message = "daemon #{dpid} should be detached"
+          assert_not_equal($$, ppid, message) # would be 1 almost always
+          assert_raise(Errno::ECHILD, message) {Process.wait(dpid)}
+          assert_kind_of(Integer, Process.kill(0, dpid), message)
+
+          break # close f, and let the daemon resume and exit
+        end
+        Process.daemon(false, true)
+        puts $$, Process.ppid
+        $stdin.gets # wait for the above assertions using signals
+      end
+    end
+
     if File.directory?("/proc/self/task") && /netbsd[a-z]*[1-6]/ !~ RUBY_PLATFORM
       def test_daemon_no_threads
         pid, data = IO.popen("-", "r+") do |f|


### PR DESCRIPTION
The forked child process is a grandchild process from the viewpoint of the process which invoked the caller process.
That means the child is detached at that point, and it does not need to fork twice.