### PR TITLE
YJIT: Show --yjit-stats of railsbench on CI

### DIFF
--- a/.github/workflows/yjit-ubuntu.yml
+++ b/.github/workflows/yjit-ubuntu.yml
@@ -117,12 +117,19 @@ jobs:
         if: ${{ matrix.test_task == 'check' }}
       - name: Enable YJIT through ENV
         run: echo "RUBY_YJIT_ENABLE=1" >> $GITHUB_ENV
-      - run: make -s -j ${{ matrix.test_task }} RUN_OPTS="$RUN_OPTS" YJIT_BENCH_OPTS="$YJIT_BENCH_OPTS"
+      - name: make ${{ matrix.test_task }}
+        run: make -s -j ${{ matrix.test_task }} RUN_OPTS="$RUN_OPTS" YJIT_BENCH_OPTS="$YJIT_BENCH_OPTS"
         timeout-minutes: 60
         env:
           RUBY_TESTOPTS: "-q --tty=no"
           TEST_BUNDLED_GEMS_ALLOW_FAILURES: ""
           PRECHECK_BUNDLED_GEMS: "no"
+      - name: Show ${{ github.event.pull_request.base.ref }} GitHub URL for yjit-bench comparison
+        run: echo "https://github.com/${BASE_REPO}/commit/${BASE_SHA}"
+        env:
+          BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        if: ${{ matrix.test_task == 'yjit-bench' && startsWith(github.event_name, 'pull') }}
       - uses: k0kubun/action-slack@v2.0.0
         with:
           payload: |

--- a/.github/workflows/yjit-ubuntu.yml
+++ b/.github/workflows/yjit-ubuntu.yml
@@ -59,10 +59,16 @@ jobs:
 
           - test_task: "test-bundled-gems"
             configure: "--enable-yjit=dev"
+
+          - test_task: "yjit-bench"
+            configure: "--enable-yjit=dev_nodebug"
+            yjit_bench_opts: "--yjit-stats"
     env:
       GITPULLOPTIONS: --no-tags origin ${{github.ref}}
       RUN_OPTS: ${{ matrix.yjit_opts }}
+      YJIT_BENCH_OPTS: ${{ matrix.yjit_bench_opts }}
       RUBY_DEBUG: ci
+      BUNDLE_JOBS: 8 # for yjit-bench
     runs-on: ubuntu-20.04
     if: ${{ !contains(github.event.head_commit.message, '[DOC]') && !contains(github.event.pull_request.labels.*.name, 'Documentation') }}
     steps:
@@ -98,7 +104,7 @@ jobs:
       - run: ./autogen.sh
         working-directory: src
       - name: Run configure
-        run: ../src/configure -C --disable-install-doc ${{ matrix.configure }}
+        run: ../src/configure -C --disable-install-doc --prefix=$(pwd)/install ${{ matrix.configure }}
       - run: make incs
       - run: make prepare-gems
         if: ${{ matrix.test_task == 'test-bundled-gems' }}
@@ -111,7 +117,7 @@ jobs:
         if: ${{ matrix.test_task == 'check' }}
       - name: Enable YJIT through ENV
         run: echo "RUBY_YJIT_ENABLE=1" >> $GITHUB_ENV
-      - run: make -s ${{ matrix.test_task }} RUN_OPTS="$RUN_OPTS"
+      - run: make -s -j ${{ matrix.test_task }} RUN_OPTS="$RUN_OPTS" YJIT_BENCH_OPTS="$YJIT_BENCH_OPTS"
         timeout-minutes: 60
         env:
           RUBY_TESTOPTS: "-q --tty=no"

--- a/.github/workflows/yjit-ubuntu.yml
+++ b/.github/workflows/yjit-ubuntu.yml
@@ -124,6 +124,7 @@ jobs:
           RUBY_TESTOPTS: "-q --tty=no"
           TEST_BUNDLED_GEMS_ALLOW_FAILURES: ""
           PRECHECK_BUNDLED_GEMS: "no"
+        continue-on-error: ${{ matrix.test_task == 'yjit-bench' }}
       - name: Show ${{ github.event.pull_request.base.ref }} GitHub URL for yjit-bench comparison
         run: echo "https://github.com/${BASE_REPO}/commit/${BASE_SHA}"
         env:

--- a/.github/workflows/yjit-ubuntu.yml
+++ b/.github/workflows/yjit-ubuntu.yml
@@ -61,7 +61,7 @@ jobs:
             configure: "--enable-yjit=dev"
 
           - test_task: "yjit-bench"
-            configure: "--enable-yjit=dev_nodebug"
+            configure: "--enable-yjit=dev"
             yjit_bench_opts: "--yjit-stats"
     env:
       GITPULLOPTIONS: --no-tags origin ${{github.ref}}

--- a/.gitignore
+++ b/.gitignore
@@ -238,5 +238,8 @@ lcov*.info
 /include/ruby-*/*/rb_mjit_min_header-*.h
 /lib/mjit/instruction.rb
 
+# YJIT
+/yjit-bench
+
 # /wasm/
 /wasm/tests/*.wasm

--- a/yjit/yjit.mk
+++ b/yjit/yjit.mk
@@ -51,6 +51,19 @@ endif
 # TODO: might need to move for BSD Make support
 miniruby$(EXEEXT): $(YJIT_LIBS)
 
+# By using YJIT_BENCH_OPTS instead of RUN_OPTS, you can skip passing the options to `make install`
+YJIT_BENCH_OPTS = $(RUN_OPTS) --enable-gems
+YJIT_BENCH = benchmarks/railsbench/benchmark.rb
+
+# Run yjit-bench's ./run_once.sh for CI
+yjit-bench: install update-yjit-bench PHONY
+	$(Q) cd $(srcdir)/yjit-bench && PATH=$(prefix)/bin:$$PATH \
+		./run_once.sh $(YJIT_BENCH_OPTS) $(YJIT_BENCH)
+
+update-yjit-bench:
+	$(Q) $(tooldir)/git-refresh -C $(srcdir) --branch main \
+		https://github.com/Shopify/yjit-bench yjit-bench $(GIT_OPTS)
+
 # Generate Rust bindings. See source for details.
 # Needs `./configure --enable-yjit=dev` and Clang.
 ifneq ($(strip $(CARGO)),) # if configure found Cargo


### PR DESCRIPTION
Currently, while we can see the after-merge stats of some revisions on https://speed.yjit.org, it's harder to see the before-merge stats of pull requests. As a result, we sometimes realize stats changes after merging PRs, e.g. https://github.com/Shopify/ruby/issues/445.

If we can confirm the metrics of railsbench on pull requests by just looking at CI, we could probably reduce the possibility of such commits. Assuming railsbench is the benchmark we're currently the most interested in, this PR automatically checks --yjit-stats of railsbench.

You'll be able to compare the yjit-bench CI results of the master branch and your pull request.