### PR TITLE
Reuse string encoding check function

### DIFF
--- a/string.c
+++ b/string.c
@@ -10847,9 +10847,7 @@ rb_str_b(VALUE str)
 static VALUE
 rb_str_valid_encoding_p(VALUE str)
 {
-    int cr = rb_enc_str_coderange(str);
-
-    return RBOOL(cr != ENC_CODERANGE_BROKEN);
+    return RBOOL(!is_broken_string(str));
 }
 
 /*
@@ -10867,9 +10865,7 @@ rb_str_valid_encoding_p(VALUE str)
 static VALUE
 rb_str_is_ascii_only_p(VALUE str)
 {
-    int cr = rb_enc_str_coderange(str);
-
-    return RBOOL(cr == ENC_CODERANGE_7BIT);
+    return RBOOL(is_ascii_string(str));
 }
 
 VALUE


### PR DESCRIPTION
`rb_str_valid_encoding_p` and `rb_str_is_ascii_only_p` functions has encoding check code.

```c
int cr = rb_enc_str_coderange(str);

return RBOOL(cr == ENC_CODERANGE_7BIT);

```

But, these encoding check was alredy defined `is_broken_string` and `is_ascii_string` functions.

```c
static inline _Bool
is_ascii_string(VALUE str)
{
    return rb_enc_str_coderange(str) == RUBY_ENC_CODERANGE_7BIT;
}

```

I thought better and simple to reuse `is_broken_string` and `is_ascii_string` functions