### PR TITLE
Avoid dup and pop in conditional assignments

### DIFF
--- a/benchmark/vm_lvar_cond_set.yml
+++ b/benchmark/vm_lvar_cond_set.yml
@@ -1,0 +1,8 @@
+benchmark:
+  vm_lvar_cond_set: |
+    a ||= 1
+    b ||= 1
+    c ||= 1
+    d ||= 1
+    nil
+loop_count: 30000000

--- a/compile.c
+++ b/compile.c
@@ -8831,7 +8831,10 @@ compile_op_log(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, 
     }
 
     CHECK(COMPILE(ret, "NODE_OP_ASGN_AND/OR#nd_head", node->nd_head));
-    ADD_INSN(ret, node, dup);
+
+    if (!popped) {
+        ADD_INSN(ret, node, dup);
+    }
 
     if (type == NODE_OP_ASGN_AND) {
         ADD_INSNL(ret, node, branchunless, lfin);
@@ -8840,15 +8843,15 @@ compile_op_log(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, 
         ADD_INSNL(ret, node, branchif, lfin);
     }
 
-    ADD_INSN(ret, node, pop);
-    ADD_LABEL(ret, lassign);
-    CHECK(COMPILE(ret, "NODE_OP_ASGN_AND/OR#nd_value", node->nd_value));
-    ADD_LABEL(ret, lfin);
-
-    if (popped) {
-        /* we can apply more optimize */
+    if (!popped) {
         ADD_INSN(ret, node, pop);
     }
+
+    ADD_LABEL(ret, lassign);
+
+    CHECK(COMPILE_(ret, "NODE_OP_ASGN_AND/OR#nd_value", node->nd_value, popped));
+
+    ADD_LABEL(ret, lfin);
     return COMPILE_OK;
 }
 


### PR DESCRIPTION
Remove some extra dup and pop generated in `||=` and `&&=`

`ruby --dump=insns -e 'x ||= 1; nil' `

before:

```
== disasm: #<ISeq:<main>@-e:1 (1,0)-(1,12)> (catch: FALSE)
local table (size: 1, argc: 0 [opts: 0, rest: -1, post: 0, block: -1, kw: -1@-1, kwrest: -1])
[ 1] x@0
0000 getlocal_WC_0                          x@0                       (   1)[Li]
0002 dup
0003 branchif                               10
0005 pop
0006 putobject_INT2FIX_1_
0007 dup
0008 setlocal_WC_0                          x@0
0010 pop
0011 putnil
0012 leave
```

after:

```
== disasm: #<ISeq:<main>@-e:1 (1,0)-(1,12)> (catch: false)
local table (size: 1, argc: 0 [opts: 0, rest: -1, post: 0, block: -1, kw: -1@-1, kwrest: -1])
[ 1] x@0
0000 getlocal_WC_0                          x@0                       (   1)[Li]
0002 branchif                               7
0004 putobject_INT2FIX_1_
0005 setlocal_WC_0                          x@0
0007 putnil
0008 leave
```

`ruby --dump=insns -e 'x.y ||= 1; nil'`

before:

```
== disasm: #<ISeq:<main>@-e:1 (1,0)-(1,14)> (catch: FALSE)
0000 putself                                                          (   1)[Li]
0001 opt_send_without_block                 <calldata!mid:x, argc:0, FCALL|VCALL|ARGS_SIMPLE>
0003 dup
0004 opt_send_without_block                 <calldata!mid:y, argc:0, ARGS_SIMPLE>
0006 dup
0007 branchif                               18
0009 pop
0010 putobject_INT2FIX_1_
0011 swap
0012 topn                                   1
0014 opt_send_without_block                 <calldata!mid:y=, argc:1, ARGS_SIMPLE>
0016 jump                                   19
0018 swap
0019 pop
0020 pop
0021 putnil
0022 leave
```

after:

```
== disasm: #<ISeq:<main>@-e:1 (1,0)-(1,14)> (catch: false)
0000 putself                                                          (   1)[Li]
0001 opt_send_without_block                 <calldata!mid:x, argc:0, FCALL|VCALL|ARGS_SIMPLE>
0003 dup
0004 opt_send_without_block                 <calldata!mid:y, argc:0, ARGS_SIMPLE>
0006 branchif                               11
0008 putobject_INT2FIX_1_
0009 opt_send_without_block                 <calldata!mid:y=, argc:1, ARGS_SIMPLE>
0011 pop
0012 putnil
0013 leave
```

```
compare-ruby: ruby 3.2.0dev (2022-04-04T13:27:14Z master ea9c09a92c) [x86_64-darwin21]
built-ruby: ruby 3.2.0dev (2022-09-21T21:12:45Z avoid-dup-and-pop-.. da183a284c) [x86_64-darwin21]
# Iteration per second (i/s)

|                  |compare-ruby|built-ruby|
|:-----------------|-----------:|---------:|
|vm_lvar_cond_set  |     63.841M|  109.491M|
|                  |           -|     1.72x|
```