### PR TITLE
Allow --enable-yjit on OpenBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3767,6 +3767,10 @@ AS_CASE(["${YJIT_SUPPORT}"],
              ]))
 
     YJIT_LIBS="yjit/target/${rb_rust_target_subdir}/libyjit.a"
+    AS_CASE(["$target_os"],[openbsd*],[
+        # Link libc++abi (which requires libpthread) for _Unwind_* functions needed by yjit
+        LDFLAGS="$LDFLAGS -lpthread -lc++abi"
+    ])
     YJIT_OBJ='yjit.$(OBJEXT)'
     AC_DEFINE(USE_YJIT, 1)
 ], [AC_DEFINE(USE_YJIT, 0)])


### PR DESCRIPTION
yjit uses `_Unwind_*` functions from libunwind.  On OpenBSD, these are available in libexecinfo, but only in the static library (they are local/non-external functions in the shared library). Handle this by adding the static libexecinfo library to YJIT_LIBS.

This exposed a problem with the code to merge libyjit.a with libruby_static.a, which was expecting only a single entry in YJIT_LIBS (despite YJIT_LIBS being plural).  Handle this by adding YJIT_LIB, which contains only the static library, and not other libraries that may be needed.

I used this to test yjit is working on OpenBSD, showing a nice 4x speedup:

```
$ time ruby -e "def b(a); a = 1; a += 1 while a < 300000; a end; a = 0; 1000.times{a = b(a)}"
    0m08.16s real     0m08.14s user     0m00.03s system
$ time ruby --yjit -e "def b(a); a = 1; a += 1 while a < 300000; a end; a = 0; 1000.times{a = b(a)}"
    0m01.90s real     0m01.55s user     0m00.29s system
```