### PR TITLE
YJIT: add chain guards in `guard_two_fixnums`

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -2493,64 +2493,7 @@ fn gen_equality_specialized(
     let a_opnd = ctx.stack_opnd(1);
     let b_opnd = ctx.stack_opnd(0);
 
-    // Get the stack operand types
-    let a_type = ctx.get_opnd_type(StackOpnd(1));
-    let b_type = ctx.get_opnd_type(StackOpnd(0));
-
-    if comptime_a.static_sym_p() && comptime_b.static_sym_p() {
-        if !assume_bop_not_redefined(jit, ocb, SYMBOL_REDEFINED_OP_FLAG, BOP_EQ) {
-            // if overridden, emit the generic version
-            return false;
-        }
-
-        // If not symbols, fall back
-        if a_type != Type::ImmSymbol {
-            asm.comment("guard arg0 symbol");
-            let low_bits = asm.and(a_opnd, Opnd::UImm(0xff));
-            asm.cmp(low_bits, Opnd::UImm(RUBY_SYMBOL_FLAG as u64));
-
-            jit_chain_guard(
-                JCC_JNE,
-                jit,
-                &ctx,
-                asm,
-                ocb,
-                SEND_MAX_DEPTH,
-                side_exit,
-            );
-        }
-        if b_type != Type::ImmSymbol {
-            asm.comment("guard arg1 symbol");
-            let low_bits = asm.and(b_opnd, Opnd::UImm(0xff));
-            asm.cmp(low_bits, Opnd::UImm(RUBY_SYMBOL_FLAG as u64));
-
-            jit_chain_guard(
-                JCC_JNE,
-                jit,
-                &ctx,
-                asm,
-                ocb,
-                SEND_MAX_DEPTH,
-                side_exit,
-            );
-        }
-
-        // Set stack types in context
-        ctx.upgrade_opnd_type(StackOpnd(0), Type::ImmSymbol);
-        ctx.upgrade_opnd_type(StackOpnd(1), Type::ImmSymbol);
-
-        // Compare the symbols
-        asm.cmp(a_opnd, b_opnd);
-        let val = asm.csel_ne(Qfalse.into(), Qtrue.into());
-
-        // Push the output on the stack
-        ctx.stack_pop(2);
-        let dst = ctx.stack_push(Type::UnknownImm);
-        asm.mov(dst, val);
-
-        return true
-
-    } else if comptime_a.fixnum_p() && comptime_b.fixnum_p() {
+    if comptime_a.fixnum_p() && comptime_b.fixnum_p() {
         if !assume_bop_not_redefined(jit, ocb, INTEGER_REDEFINED_OP_FLAG, BOP_EQ) {
             // if overridden, emit the generic version
             return false;


### PR DESCRIPTION
This was motivated by stats from the Rubykon benchmark showing a number of side-exits on `opt_eq` which is used in a highly polymorphic way in that benchmark.