### PR TITLE
[ruby/net-http] Use nonblocking IO to detect eof

### DIFF
--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -2467,7 +2467,7 @@ module Net   #:nodoc:
           debug 'Conn close because of keep_alive_timeout'
           @socket.close
           connect
-        elsif @socket.io.to_io.wait_readable(0) && @socket.eof?
+        elsif eof?
           debug "Conn close because of EOF"
           @socket.close
           connect
@@ -2480,6 +2480,14 @@ module Net   #:nodoc:
 
       req.update_uri address, port, use_ssl?
       req['host'] ||= addr_port()
+    end
+
+    def eof?
+      if defined?(OpenSSL::SSL) && @socket.io.is_a?(OpenSSL::SSL::SSLSocket)
+        @socket.io.read_nonblock(0, exception: false).nil?
+      else
+        @socket.io.to_io.wait_readable(0) && @socket.eof?
+      end
     end
 
     def end_transport(req, res)


### PR DESCRIPTION
The call to `@socket.eof?` can block when attempting to reuse a persistent connection and there are SSL Handshake messages ready to be read, but no Application Data, such as when the server sends an updated NewSessionTicket in TLS 1.3.

Instead call `OpenSSL::SSL::SSLSocket#read_nonblocking`, which will read and process the SSL Handshake message, but return `nil` on EOF or an empty string if no data is available. It may also return `:wait_readable` or `:wait_writable` which indicates the socket is reusable.

Filed as https://bugs.ruby-lang.org/issues/19017