### PR TITLE
uri/generic: Support comma-delimited rules in no_proxy

### DIFF
--- a/lib/uri/generic.rb
+++ b/lib/uri/generic.rb
@@ -1565,22 +1565,26 @@ module URI
     def self.use_proxy?(hostname, addr, port, no_proxy) # :nodoc:
       hostname = hostname.downcase
       dothostname = ".#{hostname}"
-      no_proxy.scan(/([^:,\s]+)(?::(\d+))?/) {|p_host, p_port|
-        if !p_port || port == p_port.to_i
-          if p_host.start_with?('.')
-            return false if hostname.end_with?(p_host.downcase)
-          else
-            return false if dothostname.end_with?(".#{p_host.downcase}")
-          end
-          if addr
-            begin
-              return false if IPAddr.new(p_host).include?(addr)
-            rescue IPAddr::InvalidAddressError
-              next
+      no_proxy.split(',').each do |name|
+        name.strip!
+
+        name.scan(/([^:,\s]+)(?::(\d+))?/) {|p_host, p_port|
+          if !p_port || port == p_port.to_i
+            if p_host.start_with?('.')
+              return false if hostname.end_with?(p_host.downcase)
+            else
+              return false if dothostname.end_with?(".#{p_host.downcase}")
+            end
+            if addr
+              begin
+                return false if IPAddr.new(p_host).include?(addr)
+              rescue IPAddr::InvalidAddressError
+                next
+              end
             end
           end
-        end
-      }
+        }
+      end
       true
     end
   end

--- a/test/uri/test_generic.rb
+++ b/test/uri/test_generic.rb
@@ -964,6 +964,11 @@ class URI::TestGeneric < Test::Unit::TestCase
       ['127.0.0.1', '127.0.0.1', 80, '10.224.0.0/22', true],
       ['10.224.1.1', '10.224.1.1', 80, '10.224.1.1', false],
       ['10.224.1.1', '10.224.1.1', 80, '10.224.0.0/22', false],
+      ['10.224.1.1', '10.224.1.1', 80, '.example.com,10.224.0.0/22', false],
+      ['127.0.0.1', '127.0.0.1', 80, '.example.com,10.224.0.0/22', true],
+      ['example.com', nil, 80, '10.224.0.0/22,example.com', false],
+      ['foo.example.com', nil, 80, '10.224.0.0/22,.example.com', false],
+      ['xample.com', nil, 80, '10.224.0.0/22,.example.com', true],
     ].each do |hostname, addr, port, no_proxy, expected|
       assert_equal expected, URI::Generic.use_proxy?(hostname, addr, port, no_proxy),
         "use_proxy?('#{hostname}', '#{addr}', #{port}, '#{no_proxy}')"


### PR DESCRIPTION
Previously `URI::Generic.use_proxy?` did not treat the `no_proxy` variable as a comma-delimited string. That means that it's not possible to specify multiple rules, such as:

```
no_proxy=.example.com,192.168.0.0/8
```

While there's no official standard for `no_proxy`, the comma is parsed in other languages such as Python and Go.

https://bugs.ruby-lang.org/issues/19018