### PR TITLE
Remove reference to __classid__

### DIFF
--- a/class.c
+++ b/class.c
@@ -423,8 +423,6 @@ copy_tables(VALUE clone, VALUE orig)
         st_delete(RCLASS_IV_TBL(clone), &id, 0);
         CONST_ID(id, "__classpath__");
         st_delete(RCLASS_IV_TBL(clone), &id, 0);
-        CONST_ID(id, "__classid__");
-        st_delete(RCLASS_IV_TBL(clone), &id, 0);
     }
     if (RCLASS_CONST_TBL(orig)) {
         struct clone_const_arg arg;


### PR DESCRIPTION
This used to be used for module names but its uses were removed in b00f280d4b9569e7153365d7e1c522b3d6b3c6cf.