### PR TITLE
Rework `first_lineno` to be `int`.

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -1333,7 +1333,7 @@ new_child_iseq(rb_iseq_t *iseq, const NODE *const node,
     int isolated_depth = ISEQ_COMPILE_DATA(iseq)->isolated_depth;
     ret_iseq = rb_iseq_new_with_opt(&ast, name,
                                     rb_iseq_path(iseq), rb_iseq_realpath(iseq),
-                                    INT2FIX(line_no), parent,
+                                    line_no, parent,
                                     isolated_depth ? isolated_depth + 1 : 0,
                                     type, ISEQ_COMPILE_DATA(iseq)->option);
     debugs("[new_child_iseq]< ---------------------------------------\n");
@@ -1349,7 +1349,7 @@ new_child_iseq_with_callback(rb_iseq_t *iseq, const struct rb_iseq_new_with_call
     debugs("[new_child_iseq_with_callback]> ---------------------------------------\n");
     ret_iseq = rb_iseq_new_with_callback(ifunc, name,
                                  rb_iseq_path(iseq), rb_iseq_realpath(iseq),
-                                 INT2FIX(line_no), parent, type, ISEQ_COMPILE_DATA(iseq)->option);
+                                 line_no, parent, type, ISEQ_COMPILE_DATA(iseq)->option);
     debugs("[new_child_iseq_with_callback]< ---------------------------------------\n");
     return ret_iseq;
 }
@@ -8231,7 +8231,7 @@ compile_builtin_mandatory_only_method(rb_iseq_t *iseq, const NODE *node, const N
     ISEQ_BODY(iseq)->mandatory_only_iseq =
       rb_iseq_new_with_opt(&ast, rb_iseq_base_label(iseq),
                            rb_iseq_path(iseq), rb_iseq_realpath(iseq),
-                           INT2FIX(nd_line(line_node)), NULL, 0,
+                           nd_line(line_node), NULL, 0,
                            ISEQ_TYPE_METHOD, ISEQ_COMPILE_DATA(iseq)->option);
 
     GET_VM()->builtin_inline_index = prev_inline_index;

--- a/compile.c
+++ b/compile.c
@@ -12024,7 +12024,7 @@ ibf_dump_iseq_each(struct ibf_dump *dump, const rb_iseq_t *iseq)
     ibf_dump_write_small_value(dump, location_pathobj_index);
     ibf_dump_write_small_value(dump, location_base_label_index);
     ibf_dump_write_small_value(dump, location_label_index);
-    ibf_dump_write_small_value(dump, RB_INT2NUM(body->location.first_lineno));
+    ibf_dump_write_small_value(dump, body->location.first_lineno);
     ibf_dump_write_small_value(dump, body->location.node_id);
     ibf_dump_write_small_value(dump, body->location.code_location.beg_pos.lineno);
     ibf_dump_write_small_value(dump, body->location.code_location.beg_pos.column);
@@ -12135,7 +12135,7 @@ ibf_load_iseq_each(struct ibf_load *load, rb_iseq_t *iseq, ibf_offset_t offset)
     const VALUE location_pathobj_index = ibf_load_small_value(load, &reading_pos);
     const VALUE location_base_label_index = ibf_load_small_value(load, &reading_pos);
     const VALUE location_label_index = ibf_load_small_value(load, &reading_pos);
-    const VALUE location_first_lineno = ibf_load_small_value(load, &reading_pos);
+    const int location_first_lineno = (int)ibf_load_small_value(load, &reading_pos);
     const int location_node_id = (int)ibf_load_small_value(load, &reading_pos);
     const int location_code_location_beg_pos_lineno = (int)ibf_load_small_value(load, &reading_pos);
     const int location_code_location_beg_pos_column = (int)ibf_load_small_value(load, &reading_pos);
@@ -12195,7 +12195,7 @@ ibf_load_iseq_each(struct ibf_load *load, rb_iseq_t *iseq, ibf_offset_t offset)
     load_body->variable.flip_count = variable_flip_count;
     load_body->variable.script_lines = Qnil;
 
-    load_body->location.first_lineno = RB_NUM2INT(location_first_lineno);
+    load_body->location.first_lineno = location_first_lineno;
     load_body->location.node_id = location_node_id;
     load_body->location.code_location.beg_pos.lineno = location_code_location_beg_pos_lineno;
     load_body->location.code_location.beg_pos.column = location_code_location_beg_pos_column;

--- a/compile.c
+++ b/compile.c
@@ -766,7 +766,7 @@ rb_iseq_compile_node(rb_iseq_t *iseq, const NODE *node)
                 end->rescued = LABEL_RESCUE_END;
 
                 ADD_TRACE(ret, RUBY_EVENT_B_CALL);
-                NODE dummy_line_node = generate_dummy_line_node(FIX2INT(ISEQ_BODY(iseq)->location.first_lineno), -1);
+                NODE dummy_line_node = generate_dummy_line_node(ISEQ_BODY(iseq)->location.first_lineno, -1);
                 ADD_INSN (ret, &dummy_line_node, nop);
                 ADD_LABEL(ret, start);
                 CHECK(COMPILE(ret, "block body", node->nd_body));
@@ -12024,7 +12024,7 @@ ibf_dump_iseq_each(struct ibf_dump *dump, const rb_iseq_t *iseq)
     ibf_dump_write_small_value(dump, location_pathobj_index);
     ibf_dump_write_small_value(dump, location_base_label_index);
     ibf_dump_write_small_value(dump, location_label_index);
-    ibf_dump_write_small_value(dump, body->location.first_lineno);
+    ibf_dump_write_small_value(dump, RB_INT2NUM(body->location.first_lineno));
     ibf_dump_write_small_value(dump, body->location.node_id);
     ibf_dump_write_small_value(dump, body->location.code_location.beg_pos.lineno);
     ibf_dump_write_small_value(dump, body->location.code_location.beg_pos.column);
@@ -12195,7 +12195,7 @@ ibf_load_iseq_each(struct ibf_load *load, rb_iseq_t *iseq, ibf_offset_t offset)
     load_body->variable.flip_count = variable_flip_count;
     load_body->variable.script_lines = Qnil;
 
-    load_body->location.first_lineno = location_first_lineno;
+    load_body->location.first_lineno = RB_NUM2INT(location_first_lineno);
     load_body->location.node_id = location_node_id;
     load_body->location.code_location.beg_pos.lineno = location_code_location_beg_pos_lineno;
     load_body->location.code_location.beg_pos.column = location_code_location_beg_pos_column;

--- a/gc.c
+++ b/gc.c
@@ -13804,11 +13804,10 @@ rb_raw_iseq_info(char *const buff, const size_t buff_size, const rb_iseq_t *iseq
 {
     if (buff_size > 0 && ISEQ_BODY(iseq) && ISEQ_BODY(iseq)->location.label && !RB_TYPE_P(ISEQ_BODY(iseq)->location.pathobj, T_MOVED)) {
         VALUE path = rb_iseq_path(iseq);
-        VALUE n = ISEQ_BODY(iseq)->location.first_lineno;
+        int n = ISEQ_BODY(iseq)->location.first_lineno;
         snprintf(buff, buff_size, " %s@%s:%d",
                  RSTRING_PTR(ISEQ_BODY(iseq)->location.label),
-                 RSTRING_PTR(path),
-                 n ? FIX2INT(n) : 0 );
+                 RSTRING_PTR(path), n);
     }
 }
 

--- a/iseq.c
+++ b/iseq.c
@@ -598,7 +598,7 @@ iseq_location_setup(rb_iseq_t *iseq, VALUE name, VALUE path, VALUE realpath, int
     rb_iseq_pathobj_set(iseq, path, realpath);
     RB_OBJ_WRITE(iseq, &loc->label, name);
     RB_OBJ_WRITE(iseq, &loc->base_label, name);
-    loc->first_lineno = RB_INT2NUM(first_lineno);
+    loc->first_lineno = first_lineno;
     if (code_location) {
         loc->node_id = node_id;
         loc->code_location = *code_location;
@@ -1235,7 +1235,7 @@ rb_iseq_base_label(const rb_iseq_t *iseq)
 VALUE
 rb_iseq_first_lineno(const rb_iseq_t *iseq)
 {
-    return ISEQ_BODY(iseq)->location.first_lineno;
+    return RB_INT2NUM(ISEQ_BODY(iseq)->location.first_lineno);
 }
 
 VALUE
@@ -3164,7 +3164,7 @@ iseq_data_to_ary(const rb_iseq_t *iseq)
     rb_ary_push(val, iseq_body->location.label);
     rb_ary_push(val, rb_iseq_path(iseq));
     rb_ary_push(val, rb_iseq_realpath(iseq));
-    rb_ary_push(val, iseq_body->location.first_lineno);
+    rb_ary_push(val, RB_INT2NUM(iseq_body->location.first_lineno));
     rb_ary_push(val, ID2SYM(type));
     rb_ary_push(val, locals);
     rb_ary_push(val, params);

--- a/lib/mjit/compiler.rb
+++ b/lib/mjit/compiler.rb
@@ -785,8 +785,8 @@ module RubyVM::MJIT
 
             if C.mjit_opts.verbose >= 1 # print beforehand because ISeq may be GCed during copy job.
               child_location = child_iseq.body.location
-              $stderr.puts "JIT inline: #{child_location.label}@#{C.rb_iseq_path(child_iseq)}:#{child_location.first_lineno} " \
-                "=> #{iseq.body.location.label}@#{C.rb_iseq_path(iseq)}:#{iseq.body.location.first_lineno}"
+              $stderr.puts "JIT inline: #{child_location.label}@#{C.rb_iseq_path(child_iseq)}:#{C.rb_iseq_first_lineno(child_iseq)} " \
+                "=> #{iseq.body.location.label}@#{C.rb_iseq_path(iseq)}:#{C.rb_iseq_first_lineno(iseq)}"
             end
             if !precompile_inlinable_child_iseq(f, child_iseq, status, ci, cc, pos)
               return false

--- a/mini_builtin.c
+++ b/mini_builtin.c
@@ -36,7 +36,7 @@ builtin_iseq_load(const char *feature_name, const struct rb_builtin_function *ta
         FALSE, /* unsigned int coverage_enabled; */
         0, /* int debug_level; */
     };
-    const rb_iseq_t *iseq = rb_iseq_new_with_opt(&ast->body, name_str, name_str, Qnil, INT2FIX(0), NULL, 0, ISEQ_TYPE_TOP, &optimization);
+    const rb_iseq_t *iseq = rb_iseq_new_with_opt(&ast->body, name_str, name_str, Qnil, 0, NULL, 0, ISEQ_TYPE_TOP, &optimization);
     GET_VM()->builtin_function_table = NULL;
 
     rb_ast_dispose(ast);

--- a/mjit_c.rb
+++ b/mjit_c.rb
@@ -32,6 +32,11 @@ module RubyVM::MJIT
       Primitive.cexpr! 'rb_iseq_path((rb_iseq_t *)NUM2PTR(_iseq_addr))'
     end
 
+    def rb_iseq_first_lineno(iseq)
+      _iseq_addr = iseq.to_i
+      Primitive.cexpr! 'rb_iseq_first_lineno((rb_iseq_t *)NUM2PTR(_iseq_addr))'
+    end
+
     def vm_ci_argc(ci)
       _ci_addr = ci.to_i
       Primitive.cexpr! 'UINT2NUM(vm_ci_argc((CALL_INFO)NUM2PTR(_ci_addr)))'
@@ -461,7 +466,7 @@ module RubyVM::MJIT
       pathobj: [self.VALUE, Primitive.cexpr!("OFFSETOF((*((struct rb_iseq_location_struct *)NULL)), pathobj)"), true],
       base_label: [self.VALUE, Primitive.cexpr!("OFFSETOF((*((struct rb_iseq_location_struct *)NULL)), base_label)"), true],
       label: [self.VALUE, Primitive.cexpr!("OFFSETOF((*((struct rb_iseq_location_struct *)NULL)), label)"), true],
-      first_lineno: [self.VALUE, Primitive.cexpr!("OFFSETOF((*((struct rb_iseq_location_struct *)NULL)), first_lineno)"), true],
+      first_lineno: [CType::Immediate.parse("int"), Primitive.cexpr!("OFFSETOF((*((struct rb_iseq_location_struct *)NULL)), first_lineno)"), true],
       node_id: [CType::Immediate.parse("int"), Primitive.cexpr!("OFFSETOF((*((struct rb_iseq_location_struct *)NULL)), node_id)")],
       code_location: [self.rb_code_location_t, Primitive.cexpr!("OFFSETOF((*((struct rb_iseq_location_struct *)NULL)), code_location)")],
     )

--- a/proc.c
+++ b/proc.c
@@ -1363,7 +1363,7 @@ iseq_location(const rb_iseq_t *iseq)
     if (!iseq) return Qnil;
     rb_iseq_check(iseq);
     loc[0] = rb_iseq_path(iseq);
-    loc[1] = ISEQ_BODY(iseq)->location.first_lineno;
+    loc[1] = RB_INT2NUM(ISEQ_BODY(iseq)->location.first_lineno);
 
     return rb_ary_new4(2, loc);
 }
@@ -1544,7 +1544,7 @@ rb_block_to_s(VALUE self, const struct rb_block *block, const char *additional_i
             const rb_iseq_t *iseq = rb_iseq_check(block->as.captured.code.iseq);
             rb_str_catf(str, "%p %"PRIsVALUE":%d", (void *)self,
                         rb_iseq_path(iseq),
-                        FIX2INT(ISEQ_BODY(iseq)->location.first_lineno));
+                        ISEQ_BODY(iseq)->location.first_lineno);
         }
         break;
       case block_type_symbol:
@@ -3506,7 +3506,7 @@ proc_binding(VALUE self)
     if (iseq) {
         rb_iseq_check(iseq);
         RB_OBJ_WRITE(bindval, &bind->pathobj, ISEQ_BODY(iseq)->location.pathobj);
-        bind->first_lineno = FIX2INT(rb_iseq_first_lineno(iseq));
+        bind->first_lineno = ISEQ_BODY(iseq)->location.first_lineno;
     }
     else {
         RB_OBJ_WRITE(bindval, &bind->pathobj,

--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -46,7 +46,7 @@ calc_pos(const rb_iseq_t *iseq, const VALUE *pc, int *lineno, int *node_id)
             VM_ASSERT(! ISEQ_BODY(iseq)->local_table_size);
             return 0;
         }
-        if (lineno) *lineno = FIX2INT(ISEQ_BODY(iseq)->location.first_lineno);
+        if (lineno) *lineno = ISEQ_BODY(iseq)->location.first_lineno;
 #ifdef USE_ISEQ_NODE_ID
         if (node_id) *node_id = -1;
 #endif
@@ -105,7 +105,7 @@ rb_vm_get_sourceline(const rb_control_frame_t *cfp)
             return line;
         }
         else {
-            return FIX2INT(rb_iseq_first_lineno(iseq));
+            return ISEQ_BODY(iseq)->location.first_lineno;
         }
     }
     else {

--- a/vm_core.h
+++ b/vm_core.h
@@ -310,7 +310,7 @@ typedef struct rb_iseq_location_struct {
     VALUE pathobj;      /* String (path) or Array [path, realpath]. Frozen. */
     VALUE base_label;   /* String */
     VALUE label;        /* String */
-    VALUE first_lineno;
+    int first_lineno;
     int node_id;
     rb_code_location_t code_location;
 } rb_iseq_location_t;
@@ -1193,7 +1193,7 @@ extern const rb_data_type_t ruby_binding_data_type;
 typedef struct {
     const struct rb_block block;
     const VALUE pathobj;
-    unsigned short first_lineno;
+    int first_lineno;
 } rb_binding_t;
 
 /* used by compile time and send insn */

--- a/vm_core.h
+++ b/vm_core.h
@@ -310,7 +310,7 @@ typedef struct rb_iseq_location_struct {
     VALUE pathobj;      /* String (path) or Array [path, realpath]. Frozen. */
     VALUE base_label;   /* String */
     VALUE label;        /* String */
-    VALUE first_lineno; /* TODO: may be unsigned short */
+    VALUE first_lineno;
     int node_id;
     rb_code_location_t code_location;
 } rb_iseq_location_t;
@@ -1128,8 +1128,8 @@ RUBY_SYMBOL_EXPORT_BEGIN
 rb_iseq_t *rb_iseq_new         (const rb_ast_body_t *ast, VALUE name, VALUE path, VALUE realpath,                     const rb_iseq_t *parent, enum rb_iseq_type);
 rb_iseq_t *rb_iseq_new_top     (const rb_ast_body_t *ast, VALUE name, VALUE path, VALUE realpath,                     const rb_iseq_t *parent);
 rb_iseq_t *rb_iseq_new_main    (const rb_ast_body_t *ast,             VALUE path, VALUE realpath,                     const rb_iseq_t *parent, int opt);
-rb_iseq_t *rb_iseq_new_eval    (const rb_ast_body_t *ast, VALUE name, VALUE path, VALUE realpath, VALUE first_lineno, const rb_iseq_t *parent, int isolated_depth);
-rb_iseq_t *rb_iseq_new_with_opt(const rb_ast_body_t *ast, VALUE name, VALUE path, VALUE realpath, VALUE first_lineno, const rb_iseq_t *parent, int isolated_depth,
+rb_iseq_t *rb_iseq_new_eval    (const rb_ast_body_t *ast, VALUE name, VALUE path, VALUE realpath, int first_lineno, const rb_iseq_t *parent, int isolated_depth);
+rb_iseq_t *rb_iseq_new_with_opt(const rb_ast_body_t *ast, VALUE name, VALUE path, VALUE realpath, int first_lineno, const rb_iseq_t *parent, int isolated_depth,
                                 enum rb_iseq_type, const rb_compile_option_t*);
 
 struct iseq_link_anchor;
@@ -1147,7 +1147,7 @@ rb_iseq_new_with_callback_new_callback(
     return (struct rb_iseq_new_with_callback_callback_func *)memo;
 }
 rb_iseq_t *rb_iseq_new_with_callback(const struct rb_iseq_new_with_callback_callback_func * ifunc,
-    VALUE name, VALUE path, VALUE realpath, VALUE first_lineno,
+    VALUE name, VALUE path, VALUE realpath, int first_lineno,
     const rb_iseq_t *parent, enum rb_iseq_type, const rb_compile_option_t*);
 
 VALUE rb_iseq_disasm(const rb_iseq_t *iseq);

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -1718,7 +1718,7 @@ eval_make_iseq(VALUE src, VALUE fname, int line, const rb_binding_t *bind,
 
         iseq = rb_iseq_new_eval(&ast->body,
                                 ISEQ_BODY(parent)->location.label,
-                                fname, Qnil, INT2FIX(line),
+                                fname, Qnil, line,
                                 parent, isolated_depth);
     }
     rb_ast_dispose(ast);

--- a/vm_method.c
+++ b/vm_method.c
@@ -909,7 +909,7 @@ rb_method_entry_make(VALUE klass, ID mid, VALUE defined_class, rb_method_visibil
             }
             if (iseq) {
                 rb_compile_warning(RSTRING_PTR(rb_iseq_path(iseq)),
-                                   FIX2INT(ISEQ_BODY(iseq)->location.first_lineno),
+                                   ISEQ_BODY(iseq)->location.first_lineno,
                                    "previous definition of %"PRIsVALUE" was here",
                                    rb_id2str(old_def->original_id));
             }


### PR DESCRIPTION
It seems there is a lot of "flip flop" between VALUE and int, when most of the time it is expected to be int, which is more predictable (do we expect any VALUE as `first_lineno`???).