### PR TITLE
Dump non-ASCII char as unsigned

### DIFF
--- a/ext/objspace/objspace_dump.c
+++ b/ext/objspace/objspace_dump.c
@@ -141,7 +141,7 @@ dump_append_sizet(struct dump_config *dc, const size_t number)
 }
 
 static void
-dump_append_c(struct dump_config *dc, char c)
+dump_append_c(struct dump_config *dc, unsigned char c)
 {
     if (c <= 0x1f) {
         const unsigned int width = (sizeof(c) * CHAR_BIT / 4) + 5;

--- a/test/objspace/test_objspace.rb
+++ b/test/objspace/test_objspace.rb
@@ -632,4 +632,19 @@ class TestObjSpace < Test::Unit::TestCase
       assert_equal '42', out[2]
     end
   end
+
+  def test_utf8_method_names
+    name = "utf8_❨╯°□°❩╯︵┻━┻"
+    obj = ObjectSpace.trace_object_allocations do
+      __send__(name)
+    end
+    dump = ObjectSpace.dump(obj)
+    assert_equal name, JSON.parse(dump)["method"], dump
+  end
+
+  private
+
+  def utf8_❨╯°□°❩╯︵┻━┻
+    "1#{2}"
+  end
 end


### PR DESCRIPTION
Non-ASCII code may be negative on platforms plain char is signed.

```
$ make test/objspace/test_objspace.rb
generating vm_call_iseq_optimized.inc
vm_call_iseq_optimized.inc unchanged
generating known_errors.inc
known_errors.inc unchanged
making mjit_build_dir.dylib
generating arm64-darwin21-fake.rb
arm64-darwin21-fake.rb updated
Run options: 
  --seed=28060
  "--ruby=./miniruby -I./lib -I. -I.ext/common  ./tool/runruby.rb --extout=.ext  -- --disable-gems"
  --excludes-dir=./test/excludes
  --name=!/memory_leak/
  --

# Running tests:

Finished tests in 0.751264s, 55.9058 tests/s, 60211.8563 assertions/s.                        
42 tests, 45235 assertions, 0 failures, 0 errors, 0 skips

ruby -v: ruby 3.1.3p63 (2022-09-25 revision 161e49affe) [arm64-darwin21]
```

cc @nagachika 