### PR TITLE
Dump non-ASCII char as unsigned

### DIFF
--- a/ext/objspace/objspace_dump.c
+++ b/ext/objspace/objspace_dump.c
@@ -141,7 +141,7 @@ dump_append_sizet(struct dump_config *dc, const size_t number)
 }
 
 static void
-dump_append_c(struct dump_config *dc, char c)
+dump_append_c(struct dump_config *dc, unsigned char c)
 {
     if (c <= 0x1f) {
         const int width = (sizeof(c) * CHAR_BIT / 4) + 5;

--- a/test/objspace/test_objspace.rb
+++ b/test/objspace/test_objspace.rb
@@ -604,4 +604,19 @@ class TestObjSpace < Test::Unit::TestCase
     assert_not_include ObjectSpace.dump(Class.new), '"name"'
     assert_not_include ObjectSpace.dump(Module.new), '"name"'
   end
+
+  def test_utf8_method_names
+    name = "utf8_❨╯°□°❩╯︵┻━┻"
+    obj = ObjectSpace.trace_object_allocations do
+      __send__(name)
+    end
+    dump = ObjectSpace.dump(obj)
+    assert_equal name, JSON.parse(dump)["method"], dump
+  end
+
+  private
+
+  def utf8_❨╯°□°❩╯︵┻━┻
+    "1#{2}"
+  end
 end


### PR DESCRIPTION
Non-ASCII code may be negative on platforms plain char is signed.

```bash
$ make test/objspace/test_objspace.rb
generating vm_call_iseq_optimized.inc
vm_call_iseq_optimized.inc unchanged
generating known_errors.inc
known_errors.inc unchanged
Run options: 
  --seed=95914
  "--ruby=./miniruby -I./lib -I. -I.ext/common  ./tool/runruby.rb --extout=.ext  -- --disable-gems"
  --excludes-dir=./test/excludes
  --name=!/memory_leak/
  --

# Running tests:

Finished tests in 0.803674s, 49.7714 tests/s, 375.7743 assertions/s.                          
40 tests, 302 assertions, 0 failures, 0 errors, 0 skips

ruby -v: ruby 3.0.5p211 (2022-09-20 revision 92acef2a97) [arm64-darwin21]
```

cc @nagachika 