### PR TITLE
Reuse `new_find_pattern` function

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -12754,8 +12754,7 @@ new_find_pattern_tail(struct parser_params *p, ID pre_rest_arg, NODE *args, ID p
 static NODE*
 new_hash_pattern(struct parser_params *p, NODE *constant, NODE *hshptn, const YYLTYPE *loc)
 {
-    hshptn->nd_pconst = constant;
-    return hshptn;
+    return new_find_pattern(p, constant, hshptn, loc);
 }
 
 static NODE*


### PR DESCRIPTION
`new_hash_pattern` and `new_find_pattern` functions has same code(in `parse.y`)

I thought better and more simple to reuse `new_find_pattern` function in `new_hash_pattern` function.