### PR TITLE
Make accessing ar and st table pointers more consistent

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -3522,7 +3522,7 @@ obj_free(rb_objspace_t *objspace, VALUE obj)
         }
 #endif
         if (/* RHASH_AR_TABLE_P(obj) */ !FL_TEST_RAW(obj, RHASH_ST_TABLE_FLAG)) {
-            struct ar_table_struct *tab = RHASH(obj)->as.ar;
+            struct ar_table_struct *tab = RHASH_AR_TABLE(obj);
 
             if (tab) {
                 if (RHASH_TRANSIENT_P(obj)) {

--- a/gc.c
+++ b/gc.c
@@ -3535,7 +3535,7 @@ obj_free(rb_objspace_t *objspace, VALUE obj)
         }
         else {
             GC_ASSERT(RHASH_ST_TABLE_P(obj));
-            st_free_table(RHASH(obj)->as.st);
+            st_free_table(RHASH_ST_TABLE(obj));
         }
         break;
       case T_REGEXP:

--- a/hash.c
+++ b/hash.c
@@ -48,10 +48,6 @@
 #include "ruby/ractor.h"
 #include "vm_sync.h"
 
-#ifndef HASH_DEBUG
-#define HASH_DEBUG 0
-#endif
-
 #if HASH_DEBUG
 #include "gc.h"
 #endif
@@ -466,8 +462,6 @@ ar_set_entry(VALUE hash, unsigned int index, st_data_t key, st_data_t val, st_ha
 #define RHASH_ST_TABLE_SET(h, s)  rb_hash_st_table_set(h, s)
 #define RHASH_TYPE(hash) (RHASH_AR_TABLE_P(hash) ? &objhash : RHASH_ST_TABLE(hash)->type)
 
-#define HASH_ASSERT(expr) RUBY_ASSERT_MESG_WHEN(HASH_DEBUG, expr, #expr)
-
 #if HASH_DEBUG
 #define hash_verify(hash) hash_verify_(hash, __FILE__, __LINE__)
 
@@ -549,7 +543,7 @@ hash_verify_(VALUE hash, const char *file, int line)
 static inline int
 RHASH_TABLE_NULL_P(VALUE hash)
 {
-    if (RHASH(hash)->as.ar == NULL) {
+    if (RHASH_AR_TABLE(hash) == NULL) {
         HASH_ASSERT(RHASH_AR_TABLE_P(hash));
         return TRUE;
     }
@@ -568,19 +562,12 @@ int
 rb_hash_ar_table_p(VALUE hash)
 {
     if (FL_TEST_RAW((hash), RHASH_ST_TABLE_FLAG)) {
-        HASH_ASSERT(RHASH(hash)->as.st != NULL);
+        HASH_ASSERT(RHASH_AR_TABLE(hash) != NULL);
         return FALSE;
     }
     else {
         return TRUE;
     }
-}
-
-ar_table *
-rb_hash_ar_table(VALUE hash)
-{
-    HASH_ASSERT(RHASH_AR_TABLE_P(hash));
-    return RHASH(hash)->as.ar;
 }
 
 st_table *
@@ -603,7 +590,7 @@ hash_ar_table_set(VALUE hash, ar_table *ar)
 {
     HASH_ASSERT(RHASH_AR_TABLE_P(hash));
     HASH_ASSERT((RHASH_TRANSIENT_P(hash) && ar == NULL) ? FALSE : TRUE);
-    RHASH(hash)->as.ar = ar;
+    RHASH_AR_TABLE_SET(hash, ar);
     hash_verify(hash);
 }
 

--- a/internal/hash.h
+++ b/internal/hash.h
@@ -142,10 +142,11 @@ RHASH_AR_TABLE(VALUE h)
     return RHASH(h)->as.ar;
 }
 
-static inline st_table *
+static inline struct st_table *
 RHASH_ST_TABLE(VALUE h)
 {
-    return rb_hash_st_table(h)
+    HASH_ASSERT(!RHASH_AR_TABLE_P(h));
+    return RHASH(h)->as.st;
 }
 
 #else
@@ -174,6 +175,12 @@ static inline void
 RHASH_AR_TABLE_SET(VALUE h, struct ar_table_struct *tab)
 {
     RHASH(h)->as.ar = tab;
+}
+
+static inline void
+RHASH_ST_TABLE_SET(VALUE h, st_table *tab)
+{
+    RHASH(h)->as.st = tab;
 }
 
 static inline VALUE

--- a/internal/hash.h
+++ b/internal/hash.h
@@ -16,6 +16,12 @@
 
 #define RHASH_AR_TABLE_MAX_SIZE SIZEOF_VALUE
 
+#ifndef HASH_DEBUG
+#define HASH_DEBUG 0
+#endif
+
+#define HASH_ASSERT(expr) RUBY_ASSERT_MESG_WHEN(HASH_DEBUG, expr, #expr)
+
 struct ar_table_struct;
 typedef unsigned char ar_hint_t;
 
@@ -132,8 +138,8 @@ RHASH_AR_TABLE_P(VALUE h)
 static inline struct ar_table_struct *
 RHASH_AR_TABLE(VALUE h)
 {
-    extern struct ar_table_struct *rb_hash_ar_table(VALUE hash);
-    return rb_hash_ar_table(h)
+    HASH_ASSERT(RHASH_AR_TABLE_P(h));
+    return RHASH(h)->as.ar;
 }
 
 static inline st_table *
@@ -163,6 +169,12 @@ RHASH_ST_TABLE(VALUE h)
 }
 
 #endif
+
+static inline void
+RHASH_AR_TABLE_SET(VALUE h, struct ar_table_struct *tab)
+{
+    RHASH(h)->as.ar = tab;
+}
 
 static inline VALUE
 RHASH_IFNONE(VALUE h)

--- a/ractor.c
+++ b/ractor.c
@@ -2269,7 +2269,7 @@ obj_traverse_rec(struct obj_traverse_data *data)
 {
     if (UNLIKELY(!data->rec)) {
         data->rec_hash = rb_ident_hash_new();
-        data->rec = rb_hash_st_table(data->rec_hash);
+        data->rec = RHASH_ST_TABLE(data->rec_hash);
     }
     return data->rec;
 }
@@ -2667,7 +2667,7 @@ obj_traverse_replace_rec(struct obj_traverse_replace_data *data)
 {
     if (UNLIKELY(!data->rec)) {
         data->rec_hash = rb_ident_hash_new();
-        data->rec = rb_hash_st_table(data->rec_hash);
+        data->rec = RHASH_ST_TABLE(data->rec_hash);
     }
     return data->rec;
 }

--- a/transient_heap.c
+++ b/transient_heap.c
@@ -610,7 +610,7 @@ transient_heap_ptr(VALUE obj, int error)
       case T_HASH:
         if (RHASH_TRANSIENT_P(obj)) {
             TH_ASSERT(RHASH_AR_TABLE_P(obj));
-            ptr = (VALUE *)(RHASH(obj)->as.ar);
+            ptr = (VALUE *)(RHASH_AR_TABLE(obj));
         }
         else {
             ptr = NULL;


### PR DESCRIPTION
There are multiple different ways being used to get access to the ar/st table pointers from a hash. This PR makes them more consistent and hides them behind an (inline) function call: `RHASH_{AR,ST}_TABLE`.

It also does the same for setting the pointers: `RHASH_{AR,ST}_TABLE_SET`. These are defined in `internal/hash.h` and are the only places that remain that access the `->as.ar` and `->as.st` tables directly.

