### PR TITLE
Re-enable example for Europe/Amsterdam pre-1970 time for Ruby 3.0

### DIFF
--- a/spec/ruby/core/time/shared/local.rb
+++ b/spec/ruby/core/time/shared/local.rb
@@ -6,18 +6,16 @@ describe :time_local, shared: true do
     end
   end
 
-=begin
   platform_is_not :windows do
     describe "timezone changes" do
-      it "correctly adjusts the timezone change to 'CEST' on 'Europe/Amsterdam'" do
+      it "correctly adjusts the timezone change to 'CET' on 'Europe/Amsterdam'" do
         with_timezone("Europe/Amsterdam") do
-          Time.send(@method, 1940, 5, 16).to_a.should ==
-            [0, 40, 1, 16, 5, 1940, 4, 137, true, "CEST"]
+          Time.send(@method, 1970, 5, 16).to_a.should ==
+            [0, 0, 0, 16, 5, 1970, 6, 136, false, "CET"]
         end
       end
     end
   end
-=end
 end
 
 describe :time_local_10_arg, shared: true do


### PR DESCRIPTION
Same as https://github.com/ruby/ruby/pull/6468

* https://github.com/ruby/spec/pull/939
* https://github.com/ruby/ruby/pull/6393