### PR TITLE
Reuse `with_warning_string_from` macro

### DIFF
--- a/error.c
+++ b/error.c
@@ -511,12 +511,9 @@ rb_warn_deprecated(const char *fmt, const char *suggest, ...)
 {
     if (!deprecation_warning_enabled()) return;
 
-    va_list args;
-    va_start(args, suggest);
-    VALUE mesg = warning_string(0, fmt, args);
-    va_end(args);
-
-    warn_deprecated(mesg, NULL, suggest);
+    with_warning_string(mesg, 0, suggest) {
+        warn_deprecated(mesg, NULL, suggest);
+    }
 }
 
 void

--- a/error.c
+++ b/error.c
@@ -511,12 +511,9 @@ rb_warn_deprecated(const char *fmt, const char *suggest, ...)
 {
     if (!deprecation_warning_enabled()) return;
 
-    va_list args;
-    va_start(args, suggest);
-    VALUE mesg = warning_string(0, fmt, args);
-    va_end(args);
-
-    warn_deprecated(mesg, NULL, suggest);
+    with_warning_string(mesg, 0, fmt) {
+        warn_deprecated(mesg, NULL, suggest);
+    }
 }
 
 void
@@ -524,12 +521,9 @@ rb_warn_deprecated_to_remove(const char *removal, const char *fmt, const char *s
 {
     if (!deprecation_warning_enabled()) return;
 
-    va_list args;
-    va_start(args, suggest);
-    VALUE mesg = warning_string(0, fmt, args);
-    va_end(args);
-
-    warn_deprecated(mesg, removal, suggest);
+    with_warning_string(mesg, 0, fmt) {
+        warn_deprecated(mesg, removal, suggest);
+    }
 }
 
 static inline int

--- a/error.c
+++ b/error.c
@@ -511,7 +511,7 @@ rb_warn_deprecated(const char *fmt, const char *suggest, ...)
 {
     if (!deprecation_warning_enabled()) return;
 
-    with_warning_string(mesg, 0, fmt) {
+    with_warning_string_from(mesg, 0, fmt, suggest) {
         warn_deprecated(mesg, NULL, suggest);
     }
 }
@@ -521,7 +521,7 @@ rb_warn_deprecated_to_remove(const char *removal, const char *fmt, const char *s
 {
     if (!deprecation_warning_enabled()) return;
 
-    with_warning_string(mesg, 0, fmt) {
+    with_warning_string_from(mesg, 0, fmt, suggest) {
         warn_deprecated(mesg, removal, suggest);
     }
 }

--- a/error.c
+++ b/error.c
@@ -511,12 +511,9 @@ rb_warn_deprecated(const char *fmt, const char *suggest, ...)
 {
     if (!deprecation_warning_enabled()) return;
 
-    va_list args;
-    va_start(args, suggest);
-    VALUE mesg = warning_string(0, fmt, args);
-    va_end(args);
-
-    warn_deprecated(mesg, NULL, suggest);
+    with_warning_string(mesg, 0, fmt) {
+        warn_deprecated(mesg, NULL, suggest);
+    }
 }
 
 void
@@ -524,7 +521,7 @@ rb_warn_deprecated_to_remove(const char *removal, const char *fmt, const char *s
 {
     if (!deprecation_warning_enabled()) return;
 
-    with_warning_string(mesg, 0, suggest) {
+    with_warning_string(mesg, 0, fmt) {
         warn_deprecated(mesg, removal, suggest);
     }
 }

--- a/error.c
+++ b/error.c
@@ -511,9 +511,12 @@ rb_warn_deprecated(const char *fmt, const char *suggest, ...)
 {
     if (!deprecation_warning_enabled()) return;
 
-    with_warning_string(mesg, 0, fmt) {
-        warn_deprecated(mesg, NULL, suggest);
-    }
+    va_list args;
+    va_start(args, suggest);
+    VALUE mesg = warning_string(0, fmt, args);
+    va_end(args);
+
+    warn_deprecated(mesg, NULL, suggest);
 }
 
 void

--- a/error.c
+++ b/error.c
@@ -511,9 +511,12 @@ rb_warn_deprecated(const char *fmt, const char *suggest, ...)
 {
     if (!deprecation_warning_enabled()) return;
 
-    with_warning_string(mesg, 0, suggest) {
-        warn_deprecated(mesg, NULL, suggest);
-    }
+    va_list args;
+    va_start(args, suggest);
+    VALUE mesg = warning_string(0, fmt, args);
+    va_end(args);
+
+    warn_deprecated(mesg, NULL, suggest);
 }
 
 void

--- a/error.c
+++ b/error.c
@@ -524,7 +524,7 @@ rb_warn_deprecated_to_remove(const char *removal, const char *fmt, const char *s
 {
     if (!deprecation_warning_enabled()) return;
 
-    with_warning_string(mesg, 0, fmt) {
+    with_warning_string(mesg, 0, suggest) {
         warn_deprecated(mesg, removal, suggest);
     }
 }


### PR DESCRIPTION
`rb_warn_deprecated_to_remove` function has same code that `with_warning_string` macro.

I thought better and more simple code to reuse `with_warning_string`.