### PR TITLE
Only assert ractor_shareable is consistent on ivar_set for T_OBJECT

### DIFF
--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1173,7 +1173,7 @@ vm_getivar(VALUE obj, ID id, const rb_iseq_t *iseq, IVC ic, const struct rb_call
         }
 
         val = ivar_list[index];
-        VM_ASSERT(rb_ractor_shareable_p(obj) ? rb_ractor_shareable_p(val) : true);
+        VM_ASSERT(BUILTIN_TYPE(obj) == T_OBJECT && rb_ractor_shareable_p(obj) ? rb_ractor_shareable_p(val) : true);
     }
     else { // cache miss case
 #if RUBY_DEBUG


### PR DESCRIPTION
Before d594a5a8bd0756f65c078fcf5ce0098250cba141, we were only asserting that the value on an ivar_get was ractor_shareable if the object was a T_OBJECT and also ractor shareable. We should still be doing this check only if the object is a T_OBJECT and ractor shareable.

(See [this](https://github.com/ruby/ruby/blob/a05b2614645594df896aaf44a2e5701ee7fb5fec/vm_insnhelper.c#L1162) for what the assertion previously looked like)
