### PR TITLE
Fix frozen object inspect

### DIFF
--- a/shape.c
+++ b/shape.c
@@ -149,12 +149,11 @@ get_next_shape_internal(rb_shape_t* shape, ID id, VALUE obj, enum shape_type sha
                         }
                         break;
                     case SHAPE_IVAR_UNDEF:
+                    case SHAPE_FROZEN:
                         new_shape->iv_count = new_shape->parent->iv_count;
                         break;
                     case SHAPE_ROOT:
                         rb_bug("Unreachable");
-                        break;
-                    case SHAPE_FROZEN:
                         break;
                 }
 

--- a/test/ruby/test_object.rb
+++ b/test/ruby/test_object.rb
@@ -993,4 +993,13 @@ class TestObject < Test::Unit::TestCase
       end
     EOS
   end
+
+  def test_frozen_inspect
+    obj = Object.new
+    obj.instance_variable_set(:@a, "a")
+    ins = obj.inspect
+    obj.freeze
+
+    assert_equal(ins, obj.inspect)
+  end
 end


### PR DESCRIPTION
In the rails/rails CI build for Ruby master we found that some tests were failing due to inspect on a frozen object being incorrect.

An object's instance variable count was incorrect when frozen causing the object's inspect to not splat out the object.

This fixes the issue and adds a test for inspecting frozen objects.

Co-Authored-By: Jemma Issroff <jemmaissroff@gmail.com>
Co-Authored-By: Aaron Patterson <tenderlove@ruby-lang.org>