### PR TITLE
Fix YJIT args for rb_vm_set_ivar_idx

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -1945,7 +1945,7 @@ fn gen_set_ivar(
         rb_vm_set_ivar_idx as *const u8,
         vec![
             recv_opnd,
-            Opnd::UImm(ivar_name),
+            ivar_index.into(),
             val_opnd,
         ],
     );


### PR DESCRIPTION
This was broken accidentally with the revert of shapes (it conflicted with some unrelated cleanup).

I am using a PR this time to verify that it's fixed before causing more noise in the git history 😳