### PR TITLE
Split cmp operations that aren't 32/64 bit for arm

### DIFF
--- a/yjit/src/backend/tests.rs
+++ b/yjit/src/backend/tests.rs
@@ -341,3 +341,12 @@ fn test_lookback_iterator() {
         }
     }
 }
+
+#[test]
+fn test_cmp_8_bit() {
+    let (mut asm, mut cb) = setup_asm();
+    let reg = Assembler::get_alloc_regs()[0];
+    asm.cmp(Opnd::Reg(reg).with_num_bits(8).unwrap(), Opnd::UImm(RUBY_SYMBOL_FLAG as u64));
+
+    asm.compile_with_num_regs(&mut cb, 1);
+}


### PR DESCRIPTION
This is very targeted just at the use case in guard_known_klass for symbol. There are tons of ways make arm registers with `num_bits=8` that will break. Maybe that is okay? Maybe it isn't? But as I looked at it, it seemed to unclear the right place/way to deal with that issue right now. Instead, I just targeted comparisons. I added a test that crashes on arm before this change. I also tried out guard_known_class for symbols on my optimize_send branch and everything worked as intended.