### PR TITLE
[Bug #19028] Suppress GCC 12 `-Wuse-after-free` false warning

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -12236,7 +12236,7 @@ objspace_xrealloc(rb_objspace_t *objspace, void *ptr, size_t new_size, size_t ol
 #endif
 
     old_size = objspace_malloc_size(objspace, ptr, old_size);
-    TRY_WITH_GC(new_size, mem = realloc(ptr, new_size));
+    TRY_WITH_GC(new_size, mem = RB_GNUC_EXTENSION_BLOCK(realloc(ptr, new_size)));
     new_size = objspace_malloc_size(objspace, mem, new_size);
 
 #if CALC_EXACT_MALLOC_SIZE


### PR DESCRIPTION
GCC 12 introduced a new warning flag `-Wuse-after-free`, however it has a false positive at `realloc` when optimization is disabled, since the memory requested for reallocation is guaranteed to not be touched. This workaround is very unclear why the false warning is suppressed by a statement-expression GCC extension.