### PR TITLE
YJIT: Support nil and blockparamproxy as blockarg in send

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -3337,3 +3337,46 @@ assert_equal '[[1, nil, 2]]', %q{
 
   5.times.map { opt_and_kwargs(1, c: 2) }.uniq
 }
+
+# bmethod with forwarded block
+assert_equal '2', %q{
+  define_method(:foo) do |&block|
+    block.call
+  end
+
+  def bar(&block)
+    foo(&block)
+  end
+
+  bar { 1 }
+  bar { 2 }
+}
+
+# bmethod with forwarded block and arguments
+assert_equal '5', %q{
+  define_method(:foo) do |n, &block|
+    n + block.call
+  end
+
+  def bar(n, &block)
+    foo(n, &block)
+  end
+
+  bar(0) { 1 }
+  bar(3) { 2 }
+}
+
+# bmethod with forwarded unwanted block
+assert_equal '1', %q{
+  one = 1
+  define_method(:foo) do
+    one
+  end
+
+  def bar(&block)
+    foo(&block)
+  end
+
+  bar { }
+  bar { }
+}

--- a/test/ruby/test_yjit.rb
+++ b/test/ruby/test_yjit.rb
@@ -513,9 +513,8 @@ class TestYJIT < Test::Unit::TestCase
     RUBY
   end
 
-  def test_getblockparamproxy_with_no_block
-    # Currently side exits on the send
-    assert_compiles(<<~'RUBY', insns: [:getblockparamproxy], exits: { send: 2 })
+  def test_send_blockarg
+    assert_compiles(<<~'RUBY', insns: [:getblockparamproxy, :send], exits: {})
       def bar
       end
 
@@ -526,6 +525,9 @@ class TestYJIT < Test::Unit::TestCase
 
       foo
       foo
+
+      foo { }
+      foo { }
     RUBY
   end
 

--- a/yjit.c
+++ b/yjit.c
@@ -592,6 +592,12 @@ rb_get_iseq_body_local_iseq(const rb_iseq_t *iseq)
     return iseq->body->local_iseq;
 }
 
+const rb_iseq_t *
+rb_get_iseq_body_parent_iseq(const rb_iseq_t *iseq)
+{
+    return iseq->body->parent_iseq;
+}
+
 unsigned int
 rb_get_iseq_body_local_table_size(const rb_iseq_t *iseq)
 {

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -350,6 +350,7 @@ fn main() {
         .allowlist_function("rb_get_def_bmethod_proc")
         .allowlist_function("rb_iseq_encoded_size")
         .allowlist_function("rb_get_iseq_body_local_iseq")
+        .allowlist_function("rb_get_iseq_body_parent_iseq")
         .allowlist_function("rb_get_iseq_body_iseq_encoded")
         .allowlist_function("rb_get_iseq_body_stack_max")
         .allowlist_function("rb_get_iseq_flags_has_opt")

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -1419,6 +1419,9 @@ extern "C" {
     pub fn rb_get_iseq_body_local_iseq(iseq: *const rb_iseq_t) -> *const rb_iseq_t;
 }
 extern "C" {
+    pub fn rb_get_iseq_body_parent_iseq(iseq: *const rb_iseq_t) -> *const rb_iseq_t;
+}
+extern "C" {
     pub fn rb_get_iseq_body_local_table_size(iseq: *const rb_iseq_t) -> ::std::os::raw::c_uint;
 }
 extern "C" {


### PR DESCRIPTION
Here, @jhawthorn and I have implemented support for the simple but common cases of supplying a block to send via a blockparamproxy (or a nil). Because the blockparamproxy only appears in controlled circumstances, we are able to rely entirely on the type system to recognise this case, without runtime checks.

To support that, we've added a new `Type::BlockParamProxy`. It mostly fits in there with the other singleton types like `Type::True`, though it's unique in that it's not accessible from Ruby code (despite being a real VALUE object).

We've also moved some logic into `gen_push_frame`, turning `CurrentFrame` into a parameterized `BlockISeq(IseqPtr)`. In the process, we've folded in `PrevEP`, renaming the enum from `BlockHandler` to `SpecVal`. They're mutually exclusive (they both end up storing their value in the same place), so this allows the type system to enforce that.