### PR TITLE
Reduce duplication in pack by sharing code for some cases

### DIFF
--- a/pack.c
+++ b/pack.c
@@ -476,40 +476,24 @@ pack_pack(rb_execution_context_t *ec, VALUE ary, VALUE fmt, VALUE buffer)
             goto pack_integer;
 
           case 's':		/* s for int16_t, s! for signed short */
-            integer_size = NATINT_LEN(short, 2);
-            bigendian_p = BIGENDIAN_P();
-            goto pack_integer;
-
           case 'S':		/* S for uint16_t, S! for unsigned short */
             integer_size = NATINT_LEN(short, 2);
             bigendian_p = BIGENDIAN_P();
             goto pack_integer;
 
           case 'i':		/* i and i! for signed int */
-            integer_size = (int)sizeof(int);
-            bigendian_p = BIGENDIAN_P();
-            goto pack_integer;
-
           case 'I':		/* I and I! for unsigned int */
             integer_size = (int)sizeof(int);
             bigendian_p = BIGENDIAN_P();
             goto pack_integer;
 
           case 'l':		/* l for int32_t, l! for signed long */
-            integer_size = NATINT_LEN(long, 4);
-            bigendian_p = BIGENDIAN_P();
-            goto pack_integer;
-
           case 'L':		/* L for uint32_t, L! for unsigned long */
             integer_size = NATINT_LEN(long, 4);
             bigendian_p = BIGENDIAN_P();
             goto pack_integer;
 
           case 'q':		/* q for int64_t, q! for signed long long */
-            integer_size = NATINT_LEN_Q;
-            bigendian_p = BIGENDIAN_P();
-            goto pack_integer;
-
           case 'Q':		/* Q for uint64_t, Q! for unsigned long long */
             integer_size = NATINT_LEN_Q;
             bigendian_p = BIGENDIAN_P();


### PR DESCRIPTION
s/S, i/I, l/L, and q/Q had the same code in both cases, so combine the cases.

Alternatively, we could actually use the size of the unsigned type, but I doubt there are any platforms where the unsigned type is a different size than the signed type.