### PR TITLE
Introduce `Fiber.blocking{}` for bypassing the fiber scheduler.

### DIFF
--- a/spec/ruby/core/fiber/blocking_spec.rb
+++ b/spec/ruby/core/fiber/blocking_spec.rb
@@ -59,4 +59,19 @@ ruby_version_is "3.0" do
       end
     end
   end
+
+  describe "Fiber.blocking" do
+    context "when fiber is non-blocking" do
+      it "can become blocking" do
+        fiber = Fiber.new(blocking: false) do
+          Fiber.blocking do |fiber|
+            fiber.blocking? ? :blocking : :non_blocking
+          end
+        end
+
+        blocking = fiber.resume
+        blocking.should == :blocking
+      end
+    end
+  end
 end

--- a/spec/ruby/core/fiber/blocking_spec.rb
+++ b/spec/ruby/core/fiber/blocking_spec.rb
@@ -59,7 +59,9 @@ ruby_version_is "3.0" do
       end
     end
   end
+end
 
+ruby_version_is "3.2" do
   describe "Fiber.blocking" do
     context "when fiber is non-blocking" do
       it "can become blocking" do

--- a/test/fiber/test_scheduler.rb
+++ b/test/fiber/test_scheduler.rb
@@ -27,6 +27,17 @@ class TestFiberScheduler < Test::Unit::TestCase
     refute f.blocking?
   end
 
+  def test_fiber_blocking
+    f = Fiber.new(blocking: false) do
+      fiber = Fiber.current
+      refute fiber.blocking?
+      Fiber.blocking do |_fiber|
+        assert_equal fiber, _fiber
+        assert fiber.blocking?
+      end
+    end
+  end
+
   def test_closed_at_thread_exit
     scheduler = Scheduler.new
 


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/18411