### PR TITLE
YJIT: add an assert for branch_stub_hit()

### DIFF
--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -1647,8 +1647,11 @@ fn branch_stub_hit_body(branch_ptr: *const c_void, target_idx: u32, ec: EcPtr) -
         let cfp = get_ec_cfp(ec);
         let original_interp_sp = get_cfp_sp(cfp);
 
-        let reconned_pc = rb_iseq_pc_at_idx(rb_cfp_get_iseq(cfp), target.idx);
+        let running_iseq = rb_cfp_get_iseq(cfp);
+        let reconned_pc = rb_iseq_pc_at_idx(running_iseq, target.idx);
         let reconned_sp = original_interp_sp.offset(target_ctx.sp_offset.into());
+
+        assert_eq!(running_iseq, target.iseq as _, "each stub expects a particular iseq");
 
         // Update the PC in the current CFP, because it may be out of sync in JITted code
         rb_set_cfp_pc(cfp, reconned_pc);


### PR DESCRIPTION
We set the PC in branch_stub_hit(), which only makes sense if we're running with the intended iseq for the stub. We ran into an issue caught by this while tweaking code layout.