### PR TITLE
object.c: rb_eql returns int not VALUE

### DIFF
--- a/include/ruby/internal/intern/object.h
+++ b/include/ruby/internal/intern/object.h
@@ -92,8 +92,8 @@ VALUE rb_class_new_instance_kw(int argc, const VALUE *argv, VALUE klass, int kw_
  *
  * @param[in]  lhs          Comparison left hand side.
  * @param[in]  rhs          Comparison right hand side.
- * @retval     RUBY_Qtrue   They are equal.
- * @retval     RUBY_Qfalse  Otherwise.
+ * @retval     non-zero     They are equal.
+ * @retval     0            Otherwise.
  * @note       This  function  actually  calls `lhs.eql?(rhs)`  so  you  cannot
  *             implement your class' `#eql?` method using it.
  */

--- a/object.c
+++ b/object.c
@@ -134,12 +134,12 @@ rb_eql(VALUE obj1, VALUE obj2)
 {
     VALUE result;
 
-    if (obj1 == obj2) return Qtrue;
+    if (obj1 == obj2) return TRUE;
     result = rb_eql_opt(obj1, obj2);
     if (result == Qundef) {
         result = rb_funcall(obj1, id_eql, 1, obj2);
     }
-    return RBOOL(RTEST(result));
+    return RTEST(result);
 }
 
 /**


### PR DESCRIPTION
It works, but assumes `Qfalse == 0`, which is true today but might not be forever.