### PR TITLE
[Feature #19013] Error Tolerant Parser

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -648,6 +648,8 @@ node_children(rb_ast_t *ast, const NODE *node)
                                         NEW_CHILD(ast, node->nd_pkwargs),
                                         kwrest);
         }
+      case NODE_ERROR:
+        return rb_ary_new_from_node_args(ast, 0);
       case NODE_ARGS_AUX:
       case NODE_LAST:
         break;

--- a/ast.c
+++ b/ast.c
@@ -64,8 +64,8 @@ ast_new_internal(rb_ast_t *ast, const NODE *node)
     return obj;
 }
 
-static VALUE rb_ast_parse_str(VALUE str, VALUE keep_script_lines);
-static VALUE rb_ast_parse_file(VALUE path, VALUE keep_script_lines);
+static VALUE rb_ast_parse_str(VALUE str, VALUE keep_script_lines, VALUE error_tolerant);
+static VALUE rb_ast_parse_file(VALUE path, VALUE keep_script_lines, VALUE error_tolerant);
 
 static VALUE
 ast_parse_new(void)
@@ -85,31 +85,32 @@ ast_parse_done(rb_ast_t *ast)
 }
 
 static VALUE
-ast_s_parse(rb_execution_context_t *ec, VALUE module, VALUE str, VALUE keep_script_lines)
+ast_s_parse(rb_execution_context_t *ec, VALUE module, VALUE str, VALUE keep_script_lines, VALUE error_tolerant)
 {
-    return rb_ast_parse_str(str, keep_script_lines);
+    return rb_ast_parse_str(str, keep_script_lines, error_tolerant);
 }
 
 static VALUE
-rb_ast_parse_str(VALUE str, VALUE keep_script_lines)
+rb_ast_parse_str(VALUE str, VALUE keep_script_lines, VALUE error_tolerant)
 {
     rb_ast_t *ast = 0;
 
     StringValue(str);
     VALUE vparser = ast_parse_new();
     if (RTEST(keep_script_lines)) rb_parser_keep_script_lines(vparser);
+    if (RTEST(error_tolerant)) rb_parser_error_tolerant(vparser);
     ast = rb_parser_compile_string_path(vparser, Qnil, str, 1);
     return ast_parse_done(ast);
 }
 
 static VALUE
-ast_s_parse_file(rb_execution_context_t *ec, VALUE module, VALUE path, VALUE keep_script_lines)
+ast_s_parse_file(rb_execution_context_t *ec, VALUE module, VALUE path, VALUE keep_script_lines, VALUE error_tolerant)
 {
-    return rb_ast_parse_file(path, keep_script_lines);
+    return rb_ast_parse_file(path, keep_script_lines, error_tolerant);
 }
 
 static VALUE
-rb_ast_parse_file(VALUE path, VALUE keep_script_lines)
+rb_ast_parse_file(VALUE path, VALUE keep_script_lines, VALUE error_tolerant)
 {
     VALUE f;
     rb_ast_t *ast = 0;
@@ -120,6 +121,7 @@ rb_ast_parse_file(VALUE path, VALUE keep_script_lines)
     rb_funcall(f, rb_intern("set_encoding"), 2, rb_enc_from_encoding(enc), rb_str_new_cstr("-"));
     VALUE vparser = ast_parse_new();
     if (RTEST(keep_script_lines)) rb_parser_keep_script_lines(vparser);
+    if (RTEST(error_tolerant))  rb_parser_error_tolerant(vparser);
     ast = rb_parser_compile_file_path(vparser, Qnil, f, 1);
     rb_io_close(f);
     return ast_parse_done(ast);
@@ -139,13 +141,14 @@ lex_array(VALUE array, int index)
 }
 
 static VALUE
-rb_ast_parse_array(VALUE array, VALUE keep_script_lines)
+rb_ast_parse_array(VALUE array, VALUE keep_script_lines, VALUE error_tolerant)
 {
     rb_ast_t *ast = 0;
 
     array = rb_check_array_type(array);
     VALUE vparser = ast_parse_new();
     if (RTEST(keep_script_lines)) rb_parser_keep_script_lines(vparser);
+    if (RTEST(error_tolerant)) rb_parser_error_tolerant(vparser);
     ast = rb_parser_compile_generic(vparser, lex_array, Qnil, array, 1);
     return ast_parse_done(ast);
 }
@@ -193,7 +196,7 @@ script_lines(VALUE path)
 }
 
 static VALUE
-ast_s_of(rb_execution_context_t *ec, VALUE module, VALUE body, VALUE keep_script_lines)
+ast_s_of(rb_execution_context_t *ec, VALUE module, VALUE body, VALUE keep_script_lines, VALUE error_tolerant)
 {
     VALUE node, lines = Qnil;
     const rb_iseq_t *iseq;
@@ -232,13 +235,13 @@ ast_s_of(rb_execution_context_t *ec, VALUE module, VALUE body, VALUE keep_script
     }
 
     if (!NIL_P(lines) || !NIL_P(lines = script_lines(path))) {
-        node = rb_ast_parse_array(lines, keep_script_lines);
+        node = rb_ast_parse_array(lines, keep_script_lines, error_tolerant);
     }
     else if (e_option) {
-        node = rb_ast_parse_str(rb_e_script, keep_script_lines);
+        node = rb_ast_parse_str(rb_e_script, keep_script_lines, error_tolerant);
     }
     else {
-        node = rb_ast_parse_file(path, keep_script_lines);
+        node = rb_ast_parse_file(path, keep_script_lines, error_tolerant);
     }
 
     return node_find(node, node_id);

--- a/ast.rb
+++ b/ast.rb
@@ -29,8 +29,8 @@ module RubyVM::AbstractSyntaxTree
   #
   #    RubyVM::AbstractSyntaxTree.parse("x = 1 + 2")
   #    # => #<RubyVM::AbstractSyntaxTree::Node:SCOPE@1:0-1:9>
-  def self.parse string, keep_script_lines: false
-    Primitive.ast_s_parse string, keep_script_lines
+  def self.parse string, keep_script_lines: false, error_tolerant: false
+    Primitive.ast_s_parse string, keep_script_lines, error_tolerant
   end
 
   #  call-seq:
@@ -44,8 +44,8 @@ module RubyVM::AbstractSyntaxTree
   #
   #     RubyVM::AbstractSyntaxTree.parse_file("my-app/app.rb")
   #     # => #<RubyVM::AbstractSyntaxTree::Node:SCOPE@1:0-31:3>
-  def self.parse_file pathname, keep_script_lines: false
-    Primitive.ast_s_parse_file pathname, keep_script_lines
+  def self.parse_file pathname, keep_script_lines: false, error_tolerant: false
+    Primitive.ast_s_parse_file pathname, keep_script_lines, error_tolerant
   end
 
   #  call-seq:
@@ -63,8 +63,8 @@ module RubyVM::AbstractSyntaxTree
   #
   #     RubyVM::AbstractSyntaxTree.of(method(:hello))
   #     # => #<RubyVM::AbstractSyntaxTree::Node:SCOPE@1:0-3:3>
-  def self.of body, keep_script_lines: false
-    Primitive.ast_s_of body, keep_script_lines
+  def self.of body, keep_script_lines: false, error_tolerant: false
+    Primitive.ast_s_of body, keep_script_lines, error_tolerant
   end
 
   # RubyVM::AbstractSyntaxTree::Node instances are created by parse methods in

--- a/ext/objspace/objspace.c
+++ b/ext/objspace/objspace.c
@@ -493,6 +493,7 @@ count_nodes(int argc, VALUE *argv, VALUE os)
                 COUNT_NODE(NODE_ARYPTN);
                 COUNT_NODE(NODE_FNDPTN);
                 COUNT_NODE(NODE_HSHPTN);
+                COUNT_NODE(NODE_ERROR);
 #undef COUNT_NODE
               case NODE_LAST: break;
             }

--- a/internal/parse.h
+++ b/internal/parse.h
@@ -15,6 +15,7 @@ struct rb_iseq_struct;          /* in vm_core.h */
 VALUE rb_parser_set_yydebug(VALUE, VALUE);
 void *rb_parser_load_file(VALUE parser, VALUE name);
 void rb_parser_keep_script_lines(VALUE vparser);
+void rb_parser_error_tolerant(VALUE vparser);
 
 RUBY_SYMBOL_EXPORT_BEGIN
 VALUE rb_parser_set_context(VALUE, const struct rb_iseq_struct *, int);

--- a/node.c
+++ b/node.c
@@ -1098,6 +1098,9 @@ dump_node(VALUE buf, VALUE indent, int comment, const NODE * node)
             F_NODE(nd_pkwrestarg, "keyword rest argument");
         }
         return;
+      case NODE_ERROR:
+        ANN("Broken input recovered by Error Tolerant mode");
+        return;
 
       case NODE_ARGS_AUX:
       case NODE_LAST:

--- a/node.h
+++ b/node.h
@@ -125,6 +125,7 @@ enum node_type {
     NODE_ARYPTN,
     NODE_HSHPTN,
     NODE_FNDPTN,
+    NODE_ERROR,
     NODE_LAST
 };
 
@@ -386,6 +387,7 @@ typedef struct RNode {
 #define NEW_PREEXE(b,loc) NEW_SCOPE(b,loc)
 #define NEW_POSTEXE(b,loc) NEW_NODE(NODE_POSTEXE,0,b,0,loc)
 #define NEW_ATTRASGN(r,m,a,loc) NEW_NODE(NODE_ATTRASGN,r,m,a,loc)
+#define NEW_ERROR(loc) NEW_NODE(NODE_ERROR,0,0,0,loc)
 
 #define NODE_SPECIAL_REQUIRED_KEYWORD ((NODE *)-1)
 #define NODE_REQUIRED_KEYWORD_P(node) ((node)->nd_value == NODE_SPECIAL_REQUIRED_KEYWORD)

--- a/parse.y
+++ b/parse.y
@@ -1901,6 +1901,12 @@ expr_value	: expr
 			value_expr($1);
 			$$ = $1;
 		    }
+		| error
+		    {
+		    /*%%%*/
+			$$ = NEW_ERROR(&@$);
+		    /*% %*/
+		    }
 		;
 
 expr_value_do	: {COND_PUSH(1);} expr_value do {COND_POP();}

--- a/parse.y
+++ b/parse.y
@@ -348,6 +348,7 @@ struct parser_params {
     unsigned int do_chomp: 1;
     unsigned int do_split: 1;
     unsigned int keep_script_lines: 1;
+    unsigned int error_tolerant: 1;
 
     NODE *eval_tree_begin;
     NODE *eval_tree;
@@ -6384,7 +6385,9 @@ yycompile0(VALUE arg)
 	    mesg = rb_class_new_instance(0, 0, rb_eSyntaxError);
 	}
 	rb_set_errinfo(mesg);
-	return FALSE;
+	if (!p->error_tolerant) {
+	    return FALSE;
+	}
     }
     tree = p->eval_tree;
     if (!tree) {
@@ -13313,6 +13316,16 @@ rb_parser_keep_script_lines(VALUE vparser)
     TypedData_Get_Struct(vparser, struct parser_params, &parser_data_type, p);
     p->keep_script_lines = 1;
 }
+
+void
+rb_parser_error_tolerant(VALUE vparser)
+{
+    struct parser_params *p;
+
+    TypedData_Get_Struct(vparser, struct parser_params, &parser_data_type, p);
+    p->error_tolerant = 1;
+}
+
 #endif
 
 #ifdef RIPPER

--- a/parse.y
+++ b/parse.y
@@ -1430,10 +1430,6 @@ top_stmts	: none
 		    /*% %*/
 		    /*% ripper: stmts_add!($1, $3) %*/
 		    }
-		| error top_stmt
-		    {
-			$$ = remove_begin($2);
-		    }
 		;
 
 top_stmt	: stmt
@@ -1502,10 +1498,6 @@ stmts		: none
 			$$ = block_append(p, $1, newline_node($3));
 		    /*% %*/
 		    /*% ripper: stmts_add!($1, $3) %*/
-		    }
-		| error stmt
-		    {
-			$$ = remove_begin($2);
 		    }
 		;
 
@@ -1659,6 +1651,12 @@ stmt		: keyword_alias fitem {SET_LEX_STATE(EXPR_FNAME|EXPR_FITEM);} fitem
 		    /*% ripper: massign!($1, $4) %*/
 		    }
 		| expr
+		| error
+		    {
+		    /*%%%*/
+			$$ = NEW_ERROR(&@$);
+		    /*% %*/
+		    }
 		;
 
 command_asgn	: lhs '=' lex_ctxt command_rhs

--- a/test/irb/test_color.rb
+++ b/test/irb/test_color.rb
@@ -114,6 +114,11 @@ module TestIRB
           "class bad; end" => "#{GREEN}class#{CLEAR} #{RED}#{REVERSE}bad#{CLEAR}; #{GREEN}end#{CLEAR}",
           "def req(@a) end" => "#{GREEN}def#{CLEAR} #{BLUE}#{BOLD}req#{CLEAR}(#{RED}#{REVERSE}@a#{CLEAR}) #{GREEN}end#{CLEAR}",
         })
+        if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.2.0')
+          tests.merge!({
+            "def req(true) end" => "#{GREEN}def#{CLEAR} #{BLUE}#{BOLD}req#{CLEAR}(#{RED}#{REVERSE}true#{CLEAR}#{RED}#{REVERSE})#{CLEAR} #{RED}#{REVERSE}end#{CLEAR}",
+          })
+        end
       else
         if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0')
           tests.merge!({

--- a/test/ruby/test_ast.rb
+++ b/test/ruby/test_ast.rb
@@ -1007,4 +1007,39 @@ dummy
                       body: nil))))))
     EXP
   end
+
+  def test_error_tolerant_expr_value_can_be_error
+    node = RubyVM::AbstractSyntaxTree.parse(<<~STR, error_tolerant: true)
+      def m
+        if
+      end
+    STR
+
+    str = ""
+    PP.pp(node, str)
+    assert_equal(<<~EXP, str)
+      (SCOPE@1:0-3:3
+       tbl: []
+       args: nil
+       body:
+         (DEFN@1:0-3:3
+          mid: :m
+          body:
+            (SCOPE@1:0-3:3
+             tbl: []
+             args:
+               (ARGS@1:5-1:5
+                pre_num: 0
+                pre_init: nil
+                opt: nil
+                first_post: nil
+                post_num: 0
+                post_init: nil
+                rest: nil
+                kw: nil
+                kwrest: nil
+                block: nil)
+             body: (IF@2:2-3:3 (ERROR@3:0-3:3) nil nil))))
+    EXP
+  end
 end

--- a/test/ruby/test_ast.rb
+++ b/test/ruby/test_ast.rb
@@ -565,4 +565,17 @@ dummy
     assert_in_out_err(["-e", "def foo; end; pp RubyVM::AbstractSyntaxTree.of(method(:foo)).type"],
                       "", [":SCOPE"], [])
   end
+
+  def test_error_tolerant
+    node = RubyVM::AbstractSyntaxTree.parse(<<~STR, error_tolerant: true)
+      class A
+        def m
+          if;
+          a = 10
+        end
+      end
+    STR
+
+    assert_equal(:SCOPE, node.type)
+  end
 end

--- a/test/ruby/test_ast.rb
+++ b/test/ruby/test_ast.rb
@@ -956,4 +956,55 @@ dummy
              body: (VCALL@2:2-2:3 :a))))
     EXP
   end
+
+  def test_error_tolerant_treat_end_as_keyword_based_on_indent
+    node = RubyVM::AbstractSyntaxTree.parse(<<~STR, error_tolerant: true)
+      module Z
+        class Foo
+          foo.
+        end
+
+        def bar
+        end
+      end
+    STR
+
+    str = ""
+    PP.pp(node, str)
+    assert_equal(<<~EXP, str)
+      (SCOPE@1:0-8:3
+       tbl: []
+       args: nil
+       body:
+         (MODULE@1:0-8:3 (COLON2@1:7-1:8 nil :Z)
+            (SCOPE@1:0-8:3
+             tbl: []
+             args: nil
+             body:
+               (BLOCK@1:8-8:3 (BEGIN@1:8-1:8 nil)
+                  (CLASS@2:2-8:3 (COLON2@2:8-2:11 nil :Foo) nil
+                     (SCOPE@2:2-8:3
+                      tbl: []
+                      args: nil
+                      body:
+                        (DEFN@6:2-7:5
+                         mid: :bar
+                         body:
+                           (SCOPE@6:2-7:5
+                            tbl: []
+                            args:
+                              (ARGS@6:9-6:9
+                               pre_num: 0
+                               pre_init: nil
+                               opt: nil
+                               first_post: nil
+                               post_num: 0
+                               post_init: nil
+                               rest: nil
+                               kw: nil
+                               kwrest: nil
+                               block: nil)
+                            body: nil))))))))
+    EXP
+  end
 end

--- a/test/ruby/test_ast.rb
+++ b/test/ruby/test_ast.rb
@@ -981,30 +981,30 @@ dummy
              tbl: []
              args: nil
              body:
-               (BLOCK@1:8-8:3 (BEGIN@1:8-1:8 nil)
-                  (CLASS@2:2-8:3 (COLON2@2:8-2:11 nil :Foo) nil
-                     (SCOPE@2:2-8:3
+               (BLOCK@1:8-7:5 (BEGIN@1:8-1:8 nil)
+                  (CLASS@2:2-4:5 (COLON2@2:8-2:11 nil :Foo) nil
+                     (SCOPE@2:2-4:5
                       tbl: []
                       args: nil
-                      body:
-                        (DEFN@6:2-7:5
-                         mid: :bar
-                         body:
-                           (SCOPE@6:2-7:5
-                            tbl: []
-                            args:
-                              (ARGS@6:9-6:9
-                               pre_num: 0
-                               pre_init: nil
-                               opt: nil
-                               first_post: nil
-                               post_num: 0
-                               post_init: nil
-                               rest: nil
-                               kw: nil
-                               kwrest: nil
-                               block: nil)
-                            body: nil))))))))
+                      body: (BLOCK@2:11-4:5 (BEGIN@2:11-2:11 nil) (ERROR@3:4-4:5))))
+                  (DEFN@6:2-7:5
+                   mid: :bar
+                   body:
+                     (SCOPE@6:2-7:5
+                      tbl: []
+                      args:
+                        (ARGS@6:9-6:9
+                         pre_num: 0
+                         pre_init: nil
+                         opt: nil
+                         first_post: nil
+                         post_num: 0
+                         post_init: nil
+                         rest: nil
+                         kw: nil
+                         kwrest: nil
+                         block: nil)
+                      body: nil))))))
     EXP
   end
 end


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/19013

* Add error_tolerant option to RubyVM::AbstractSyntaxTree
* Support "+error-tolerant" as ruby option
* Error Tolerant mode includes
  * Generates "end" tokens if parser hits end of input but "end" tokens are needed for correct language
  * Treat "end" as reserved word with consideration of indent
* Change the locations of error terms