### PR TITLE
Ignore excessive precisions

### DIFF
--- a/spec/ruby/core/file/atime_spec.rb
+++ b/spec/ruby/core/file/atime_spec.rb
@@ -19,7 +19,7 @@ describe "File.atime" do
     platform_is_not :"powerpc64le-linux" do # https://bugs.ruby-lang.org/issues/17926
       ## NOTE also that some Linux systems disable atime (e.g. via mount params) for better filesystem speed.
       it "returns the last access time for the named file with microseconds" do
-        supports_subseconds = Integer(`stat -c%x '#{__FILE__}'`[/\.(\d+)/, 1], 10)
+        supports_subseconds = Integer(`stat -c%x '#{__FILE__}'`[/\.(\d{1,6})/, 1], 10)
         if supports_subseconds != 0
           expected_time = Time.at(Time.now.to_i + 0.123456)
           File.utime expected_time, 0, @file

--- a/spec/ruby/core/file/ctime_spec.rb
+++ b/spec/ruby/core/file/ctime_spec.rb
@@ -16,7 +16,7 @@ describe "File.ctime" do
 
   platform_is :linux, :windows do
     it "returns the change time for the named file (the time at which directory information about the file was changed, not the file itself) with microseconds." do
-      supports_subseconds = Integer(`stat -c%z '#{__FILE__}'`[/\.(\d+)/, 1], 10)
+      supports_subseconds = Integer(`stat -c%z '#{__FILE__}'`[/\.(\d{1,6})/, 1], 10)
       if supports_subseconds != 0
         File.ctime(__FILE__).usec.should > 0
       else

--- a/spec/ruby/core/file/mtime_spec.rb
+++ b/spec/ruby/core/file/mtime_spec.rb
@@ -17,7 +17,7 @@ describe "File.mtime" do
 
   platform_is :linux, :windows do
     it "returns the modification Time of the file with microseconds" do
-      supports_subseconds = Integer(`stat -c%y '#{__FILE__}'`[/\.(\d+)/, 1], 10)
+      supports_subseconds = Integer(`stat -c%y '#{__FILE__}'`[/\.(\d{1,6})/, 1], 10)
       if supports_subseconds != 0
         expected_time = Time.at(Time.now.to_i + 0.123456)
         File.utime 0, expected_time, @filename


### PR DESCRIPTION
On filesystems where have precisions more than microseconds, even when
the whole fractional part is not zero, the microsecond can be zero in
about 1/1,000,000 probabilities.
