### PR TITLE
Ignore failure to set nonblock mode.

### DIFF
--- a/io.c
+++ b/io.c
@@ -3571,7 +3571,7 @@ io_read_nonblock(rb_execution_context_t *ec, VALUE io, VALUE length, VALUE str, 
 
     n = read_buffered_data(RSTRING_PTR(str), len, fptr);
     if (n <= 0) {
-        rb_io_set_nonblock(fptr);
+        rb_fd_set_nonblock(fptr->fd);
         shrinkable |= io_setstrbuf(&str, len);
         iis.fptr = fptr;
         iis.nonblock = 1;
@@ -3618,7 +3618,7 @@ io_write_nonblock(rb_execution_context_t *ec, VALUE io, VALUE str, VALUE ex)
     if (io_fflush(fptr) < 0)
         rb_sys_fail_on_write(fptr);
 
-    rb_io_set_nonblock(fptr);
+    rb_fd_set_nonblock(fptr->fd);
     n = write(fptr->fd, RSTRING_PTR(str), RSTRING_LEN(str));
     RB_GC_GUARD(str);
 

--- a/test/ruby/test_io.rb
+++ b/test/ruby/test_io.rb
@@ -1597,6 +1597,22 @@ class TestIO < Test::Unit::TestCase
     end
   end
 
+  def test_read_nonblock_file
+    make_tempfile do |path|
+      File.open(path, 'r') do |file|
+        file.read_nonblock(4)
+      end
+    end
+  end
+
+  def test_write_nonblock_file
+    make_tempfile do |path|
+      File.open(path, 'w') do |file|
+        file.write_nonblock("Ruby")
+      end
+    end
+  end
+
   def test_write_nonblock_simple_no_exceptions
     pipe(proc do |w|
       w.write_nonblock('1', exception: false)


### PR DESCRIPTION
On Linux, setting `O_NONBLOCK` on files doesn't have any effect, but also doesn't cause an error.

On Windows it can cause a variety of different errors, none of them really helpful. So, let's ignore them.