### PR TITLE
Remove usage of $SAFE in debug.rb

### DIFF
--- a/lib/debug.rb
+++ b/lib/debug.rb
@@ -3,11 +3,6 @@
 # Copyright (C) 2000  Information-technology Promotion Agency, Japan
 # Copyright (C) 2000-2003  NAKAMURA, Hiroshi  <nahi@ruby-lang.org>
 
-if $SAFE > 0
-  STDERR.print "-r debug.rb is not available in safe mode\n"
-  exit 1
-end
-
 require 'tracer'
 require 'pp'
 


### PR DESCRIPTION
$SAFE was removed in Ruby 3.0, so debug.rb is basically broken without this change.

Fixes [Bug #19049]