### PR TITLE
[Bug #19051] Update the global_cc_cache_table when compacting

### DIFF
--- a/vm.c
+++ b/vm.c
@@ -2727,6 +2727,14 @@ rb_vm_update_references(void *ptr)
             vm->coverages = rb_gc_location(vm->coverages);
             vm->me2counter = rb_gc_location(vm->me2counter);
         }
+
+        for (int i=0; i<VM_GLOBAL_CC_CACHE_TABLE_SIZE; i++) {
+            const struct rb_callcache *cc = vm->global_cc_cache_table[i];
+
+            if (RB_TYPE_P((VALUE)cc, T_MOVED)) {
+                vm->global_cc_cache_table[i] = (const struct rb_callcache *)rb_gc_location((VALUE)cc);
+            }
+         }
     }
 }
 


### PR DESCRIPTION
During compaction, T_IMEMO objects get moved around the heap. vm->The global_cc_cache_table is an array of pointers to callcache objects, stored as T_IMEMO's of type callcache on the GC heap. These pointers are never updated during the update references step of compaction. If the T_IMEMO object gets moved and another object allocated in the same slot, then the contents of the global_cc_cache_table will be incorrect, resulting in a crash when attempting to access it.

An example of this is during the mark phase when we attempt to check the validity of the callcache entry before marking it, but the object is not actually a callcache.

This PR checks the pointers in the `global_cc_cache_table` during the VM's update references step and updates them if appropriate