### PR TITLE
Initialize shape attr index also in non-markable CC

### DIFF
--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1096,9 +1096,7 @@ static inline void
 fill_ivar_cache(const rb_iseq_t *iseq, IVC ic, const struct rb_callcache *cc, int is_attr, attr_index_t index, shape_id_t shape_id)
 {
     if (is_attr) {
-        if (vm_cc_markable(cc)) {
-            vm_cc_attr_index_set(cc, index, shape_id);
-        }
+        vm_cc_attr_index_set(cc, index, shape_id);
     }
     else {
         vm_ic_attr_index_set(iseq, ic, index, shape_id);
@@ -1160,13 +1158,7 @@ vm_getivar(VALUE obj, ID id, const rb_iseq_t *iseq, IVC ic, const struct rb_call
     attr_index_t index;
 
     if (is_attr) {
-        if (vm_cc_markable(cc)) {
-            vm_cc_atomic_shape_and_index(cc, &cached_id, &index);
-        }
-        else {
-            cached_id = INVALID_SHAPE_ID;
-            index = ATTR_INDEX_NOT_SET;
-        }
+        vm_cc_atomic_shape_and_index(cc, &cached_id, &index);
     }
     else {
         vm_ic_atomic_shape_and_index(ic, &cached_id, &index);
@@ -1211,9 +1203,7 @@ vm_getivar(VALUE obj, ID id, const rb_iseq_t *iseq, IVC ic, const struct rb_call
         }
         else {
             if (is_attr) {
-                if (vm_cc_markable(cc)) {
-                    vm_cc_attr_index_initialize(cc, shape_id);
-                }
+                vm_cc_attr_index_initialize(cc, shape_id);
             }
             else {
                 vm_ic_attr_index_initialize(ic, shape_id);
@@ -1245,9 +1235,7 @@ populate_cache(attr_index_t index, shape_id_t next_shape_id, ID id, const rb_ise
 {
     // Cache population code
     if (is_attr) {
-        if (vm_cc_markable(cc)) {
-            vm_cc_attr_index_set(cc, index, next_shape_id);
-        }
+        vm_cc_attr_index_set(cc, index, next_shape_id);
     }
     else {
         vm_ic_attr_index_set(iseq, ic, index, next_shape_id);
@@ -3922,9 +3910,7 @@ vm_call_method_each_type(rb_execution_context_t *ec, rb_control_frame_t *cfp, st
         CALLER_SETUP_ARG(cfp, calling, ci);
         CALLER_REMOVE_EMPTY_KW_SPLAT(cfp, calling, ci);
         rb_check_arity(calling->argc, 0, 0);
-        if (vm_cc_markable(cc)) {
-            vm_cc_attr_index_initialize(cc, INVALID_SHAPE_ID);
-        }
+        vm_cc_attr_index_initialize(cc, INVALID_SHAPE_ID);
         const unsigned int ivar_mask = (VM_CALL_ARGS_SPLAT | VM_CALL_KW_SPLAT);
         VM_CALL_METHOD_ATTR(v,
                             vm_call_ivar(ec, cfp, calling),


### PR DESCRIPTION
Accessing uninitialized attr index resulted in indeterminate index, and failed to find the instance variable.
This caused build errors on FreeBSD12.
http://rubyci.s3.amazonaws.com/freebsd12/ruby-master/log/20221011T163003Z.fail.html.gz
```
/usr/home/chkbuild/chkbuild/tmp/build/20221011T163003Z/ruby/lib/optparse.rb:924:in `complete': undefined method `complete' for nil:NilClass (NoMethodError)
	from /usr/home/chkbuild/chkbuild/tmp/build/20221011T163003Z/ruby/lib/optparse.rb:1816:in `block in visit'
	from /usr/home/chkbuild/chkbuild/tmp/build/20221011T163003Z/ruby/lib/optparse.rb:1815:in `reverse_each'
	from /usr/home/chkbuild/chkbuild/tmp/build/20221011T163003Z/ruby/lib/optparse.rb:1815:in `visit'
	from /usr/home/chkbuild/chkbuild/tmp/build/20221011T163003Z/ruby/lib/optparse.rb:1847:in `block in complete'
	from /usr/home/chkbuild/chkbuild/tmp/build/20221011T163003Z/ruby/lib/optparse.rb:1846:in `catch'
	from /usr/home/chkbuild/chkbuild/tmp/build/20221011T163003Z/ruby/lib/optparse.rb:1846:in `complete'
	from /usr/home/chkbuild/chkbuild/tmp/build/20221011T163003Z/ruby/lib/optparse.rb:1640:in `block in parse_in_order'
	from /usr/home/chkbuild/chkbuild/tmp/build/20221011T163003Z/ruby/lib/optparse.rb:1632:in `catch'
	from /usr/home/chkbuild/chkbuild/tmp/build/20221011T163003Z/ruby/lib/optparse.rb:1632:in `parse_in_order'
	from /usr/home/chkbuild/chkbuild/tmp/build/20221011T163003Z/ruby/lib/optparse.rb:1626:in `order!'
	from /usr/home/chkbuild/chkbuild/tmp/build/20221011T163003Z/ruby/lib/optparse.rb:1732:in `permute!'
	from /usr/home/chkbuild/chkbuild/tmp/build/20221011T163003Z/ruby/lib/optparse.rb:1757:in `parse!'
	from ./ext/extmk.rb:359:in `parse_args'
	from ./ext/extmk.rb:396:in `<main>'
```