### PR TITLE
Suppress "comparison of unsigned expression < 0 is always false"

### DIFF
--- a/shape.c
+++ b/shape.c
@@ -491,7 +491,7 @@ static VALUE
 rb_shape_find_by_id(VALUE mod, VALUE id)
 {
     shape_id_t shape_id = NUM2INT(id);
-    if (shape_id < 0 || shape_id >= GET_VM()->next_shape_id) {
+    if (shape_id != INVALID_SHAPE_ID && shape_id >= GET_VM()->next_shape_id) {
         rb_raise(rb_eArgError, "Shape ID %d is out of bounds\n", shape_id);
     }
     return rb_shape_t_to_rb_cShape(rb_shape_get_shape_by_id(shape_id));


### PR DESCRIPTION
```
shape.c: In function 'rb_shape_find_by_id':
shape.c:494:18: warning: comparison of unsigned expression < 0 is always false [-Wtype-limits]
  494 |     if (shape_id < 0 || shape_id >= GET_VM()->next_shape_id) {
      |                  ^
```