### PR TITLE
Reuse `ins_methods_type_i` function

### DIFF
--- a/class.c
+++ b/class.c
@@ -1639,10 +1639,7 @@ ins_methods_pub_i(st_data_t name, st_data_t type, st_data_t ary)
 static int
 ins_methods_undef_i(st_data_t name, st_data_t type, st_data_t ary)
 {
-    if ((rb_method_visibility_t)type == METHOD_VISI_UNDEF) {
-        ins_methods_push(name, ary);
-    }
-    return ST_CONTINUE;
+    return ins_methods_type_i(name, type, ary, METHOD_VISI_UNDEF);
 }
 
 struct method_entry_arg {


### PR DESCRIPTION
`ins_methods_undef_i` function has almost same code as `ins_methods_type_i` in `class.c`.
I thought better and more simple code to reuse `ins_methods_type_i` function.