### PR TITLE
Don't break if `IO` has been finalised and `io.closed?` is called.

### DIFF
--- a/io.c
+++ b/io.c
@@ -5715,6 +5715,9 @@ rb_io_closed(VALUE io)
     VALUE write_io;
     rb_io_t *write_fptr;
 
+    // If someone has called `rb_io_fptr_finalize`, then the fptr is already NULL.
+    if (RFILE(io)->fptr == NULL) return Qtrue;
+
     write_io = GetWriteIO(io);
     if (io != write_io) {
         write_fptr = RFILE(write_io)->fptr;


### PR DESCRIPTION
```ruby
require "objspace"

before = []
ObjectSpace.each_object(IO) do |io|
  before << io
end

ok = `echo OK`

after = []
ObjectSpace.each_object(IO) do |io|
  after << io
end

created = after - before

created.each do |io|
  p io
  p io.closed?
end
```

The last `io.closed?` raises an exception. But it should probably just return `true`.