### PR TITLE
Disable msystem: MINGW64 job on GitHub Actions

### DIFF
--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -37,10 +37,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - msystem: "MINGW64"
-            base_ruby: 2.6
-            test_task: "check"
-            test-all-opts: "--name=!/TestObjSpace#test_reachable_objects_during_iteration/"
+          # To mitigate flakiness of MinGW CI, we test only one runtime that newer MSYS2 uses.
           - msystem: "UCRT64"
             base_ruby: head
             test_task: "check"


### PR DESCRIPTION
MinGW CI jobs take the longest amount of time among all jobs and cause the largest number of random false positives. While we double the inconvenience by testing two runtimes since https://github.com/ruby/ruby/pull/4599, I haven't seen any moment when testing both seemed useful. The downside seems to outweigh the benefit if it ever existed.

So I'd like to test only what's more important than the other to at least halve the problem of MinGW CI. According to https://bugs.ruby-lang.org/issues/17845, it seems like the newer MSYS2 switched to UCRT. I believe it became less important to test MinGW with MSVCRT.