### PR TITLE
Update yjit docs

### DIFF
--- a/doc/yjit/yjit.md
+++ b/doc/yjit/yjit.md
@@ -13,8 +13,7 @@ YJIT - Yet Another Ruby JIT
 YJIT is a lightweight, minimalistic Ruby JIT built inside CRuby.
 It lazily compiles code using a Basic Block Versioning (BBV) architecture. The target use case is that of servers running
 Ruby on Rails, an area where MJIT has not yet managed to deliver speedups.
-To simplify development, we currently support only macOS and Linux on x86-64, but an ARM64 backend
-is part of future plans.
+YJIT is currently supported for macOS and Linux on x86-64 and arm64/aarch64 CPUs.
 This project is open source and falls under the same license as CRuby.
 
 If you wish to learn more about the approach taken, here are some conference talks and publications:
@@ -105,10 +104,12 @@ make -j install
 ```
 
 Typically configure will choose the default C compiler. To specify the C compiler, use
+
 ```
 # Choosing a specific c compiler
 export CC=/path/to/my/chosen/c/compiler
 ```
+
 before running `./configure`.
 
 You can test that YJIT works correctly by running:
@@ -141,15 +142,15 @@ You can dump statistics about compilation and execution by running YJIT with the
 
 The machine code generated for a given method can be printed by adding `puts RubyVM::YJIT.disasm(method(:method_name))` to a Ruby script. Note that no code will be generated if the method is not compiled.
 
-
 ### Command-Line Options
 
 YJIT supports all command-line options supported by upstream CRuby, but also adds a few YJIT-specific options:
 
 - `--yjit`: enable YJIT (disabled by default)
-- `--yjit-call-threshold=N`: number of calls after which YJIT begins to compile a function (default 2)
+- `--yjit-call-threshold=N`: number of calls after which YJIT begins to compile a function (default 10)
 - `--yjit-exec-mem-size=N`: size of the executable memory block to allocate, in MiB (default 256 MiB)
 - `--yjit-stats`: produce statistics after the execution of a program (must compile with `cppflags=-DRUBY_DEBUG` to use this)
+- `--yjit-trace-exits`: produce a Marshal dump of backtraces from specific exits. Automatically enables `--yjit-stats` (must compile with `cppflags=-DRUBY_DEBUG` to use this)
 - `--yjit-max-versions=N`: maximum number of versions to generate per basic block (default 4)
 - `--yjit-greedy-versioning`: greedy versioning mode (disabled by default, may increase code size)
 
@@ -176,7 +177,7 @@ You can also compile YJIT in debug mode and use the `--yjit-stats` command-line 
 
 ### Memory Statistics
 
-YJIT, including in production configuration, keeps track of the size of generated code. If you check YJIT.runtime_stats you can see them:
+YJIT, including in production configuration, keeps track of the size of generated code. If you check `YJIT.runtime_stats` you can see them:
 
 ```
 $ RUBYOPT="--yjit" irb
@@ -188,11 +189,11 @@ These are the size in bytes of generated inlined code and generated outlined cod
 
 ### Other Statistics
 
-If you compile Ruby with RUBY_DEBUG and/or YJIT_STATS defined and run with "--yjit --yjit-stats", YJIT will track and return performance statistics in RubyVM::YJIT.runtime_stats.
+If you compile Ruby with `RUBY_DEBUG` and/or `YJIT_STATS` defined and run with `--yjit --yjit-stats`, YJIT will track and return performance statistics in `RubyVM::YJIT.runtime_stats`.
 
 ```
 $ RUBYOPT="--yjit --yjit-stats" irb
-irb(main):001:0> YJIT.runtime_stats
+irb(main):001:0> RubyVM::YJIT.runtime_stats
 =>
 {:inline_code_size=>340745,
  :outlined_code_size=>297664,


### PR DESCRIPTION
* The list of supported architectures was updated in https://github.com/ruby/ruby/commit/5ef048e5b1c3dd61adf782ace570bb0a1f9bb12f but the first paragraph wasn't updated.
* `--yjit-trace-exits` was missing from the command-line options
* Fixes some spacing issues
* Updates call threshold default to 10, verified in the code that's correct.
* Add code ticks around method names.
* Fix namespace of stats example