### PR TITLE
Backport Keep GC disabled until VM bootstrap has done [Bug #17583] for Ruby 3.0

### DIFF
--- a/test/ruby/test_thread.rb
+++ b/test/ruby/test_thread.rb
@@ -1146,7 +1146,9 @@ q.pop
     env = {}
     env['RUBY_THREAD_VM_STACK_SIZE'] = vm_stack_size.to_s if vm_stack_size
     env['RUBY_THREAD_MACHINE_STACK_SIZE'] = machine_stack_size.to_s if machine_stack_size
-    out, = EnvUtil.invoke_ruby([env, '-e', script], '', true, true)
+    out, err, status = EnvUtil.invoke_ruby([env, '-e', script], '', true, true)
+    assert_not_predicate(status, :signaled?, err)
+
     use_length ? out.length : out
   end
 

--- a/vm.c
+++ b/vm.c
@@ -3671,6 +3671,8 @@ Init_VM(void)
 	 * The Binding of the top level scope
 	 */
 	rb_define_global_const("TOPLEVEL_BINDING", rb_binding_new());
+
+        rb_objspace_gc_enable(vm->objspace);
     }
     vm_init_redefined_flag();
 
@@ -3736,8 +3738,6 @@ Init_vm_objects(void)
     vm->mark_object_ary = rb_ary_tmp_new(128);
     vm->loading_table = st_init_strtable();
     vm->frozen_strings = st_init_table_with_size(&rb_fstring_hash_type, 10000);
-
-    rb_objspace_gc_enable(vm->objspace);
 }
 
 /* top self */


### PR DESCRIPTION
https://github.com/ruby/ruby/pull/4617 at https://bugs.ruby-lang.org/issues/17583

It's very helpful to be able to set `RUBY_THREAD_VM_STACK_SIZE` higher than 16MB even in ruby 3.0.x.
Confirmed that `make test` has passed on this branch.

```
$ env RUBY_THREAD_VM_STACK_SIZE=134217728 ruby -ve 'p 1'
ruby 3.0.5p211 (2022-10-01 revision 7941ac286f) [x86_64-linux]
1
```
^ no segmentation fault

(Thanks @mopp for finding the issue and the patch for the master branch.)