### PR TITLE
YJIT: call free_block to cleanup block when out of memory

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -884,6 +884,7 @@ pub fn gen_single_block(
 
     // If code for the block doesn't fit, fail
     if cb.has_dropped_bytes() || ocb.unwrap().has_dropped_bytes() {
+        free_block(&blockref);
         return Err(());
     }
 

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -1420,11 +1420,9 @@ fn gen_block_series_body(
         if result.is_err() {
             // Remove previously compiled block
             // versions from the version map
+            mem::drop(last_branch); // end borrow
             for blockref in &batch {
-                // FIXME: should be deallocating resources here too
-                // e.g. invariants, etc.
-                //free_block(blockref)
-
+                free_block(blockref);
                 remove_block_version(blockref);
             }
 
@@ -1991,7 +1989,7 @@ pub fn defer_compilation(
 }
 
 // Remove all references to a block then free it.
-fn free_block(blockref: &BlockRef) {
+pub fn free_block(blockref: &BlockRef) {
     use crate::invariants::*;
 
     block_assumptions_free(blockref);


### PR DESCRIPTION
The commented out instance of free_block() is left over from the port. The addition in gen_single_block() was a place we missed. The new block is allocated in the same function and could have invariants associated with it even though there is no space to hold all the code.

---
@k0kubun and I uncovered these while lowering YJIT's memory limit to test code GC.
Unfortunately, some fixes for OOM from #6460 is also required to test this, but I confirmed that the two changes help with `railsbench` with a 1M limit and `hexapdf` with a 2M limit respectively (yjit-bench workloads).