### PR TITLE
YJIT: Allow --yjit-dump-disasm to dump into a file

### DIFF
--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -4,8 +4,6 @@
 
 use std::cell::Cell;
 use std::fmt;
-use std::fs::File;
-use std::io::Write;
 use std::convert::From;
 use std::mem::take;
 use crate::cruby::{VALUE};
@@ -1102,18 +1100,9 @@ impl Assembler
 
         #[cfg(feature = "disasm")]
         if let Some(dump_disasm) = get_option_ref!(dump_disasm) {
-            use crate::disasm::disasm_addr_range;
-            let last_ptr = cb.get_write_ptr();
-            let disasm = disasm_addr_range(cb, start_addr, last_ptr.raw_ptr() as usize - start_addr as usize);
-            if disasm.len() > 0 {
-                match dump_disasm {
-                    DumpDisasm::Stdout => println!("{disasm}"),
-                    DumpDisasm::File(path) => {
-                        let mut f = File::options().append(true).create(true).open(path).unwrap();
-                        f.write_all(disasm.as_bytes()).unwrap();
-                    }
-                };
-            }
+            use crate::disasm::dump_disasm_addr_range;
+            let end_ptr = cb.get_write_ptr();
+            dump_disasm_addr_range(cb, start_addr, end_ptr.raw_ptr() as usize - start_addr as usize, dump_disasm)
         }
         gc_offsets
     }

--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -1101,8 +1101,8 @@ impl Assembler
         #[cfg(feature = "disasm")]
         if let Some(dump_disasm) = get_option_ref!(dump_disasm) {
             use crate::disasm::dump_disasm_addr_range;
-            let end_ptr = cb.get_write_ptr();
-            dump_disasm_addr_range(cb, start_addr, end_ptr.raw_ptr() as usize - start_addr as usize, dump_disasm)
+            let end_addr = cb.get_write_ptr().raw_ptr();
+            dump_disasm_addr_range(cb, start_addr, end_addr, dump_disasm)
         }
         gc_offsets
     }

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -622,7 +622,7 @@ pub fn gen_entry_prologue(cb: &mut CodeBlock, iseq: IseqPtr, insn_idx: u32) -> O
     let code_ptr = cb.get_write_ptr();
 
     let mut asm = Assembler::new();
-    if get_option!(dump_disasm).is_enabled() {
+    if get_option_ref!(dump_disasm).is_some() {
         asm.comment(&format!("YJIT entry: {}", iseq_get_location(iseq)));
     } else {
         asm.comment("YJIT entry");
@@ -751,7 +751,7 @@ pub fn gen_single_block(
     let mut asm = Assembler::new();
 
     #[cfg(feature = "disasm")]
-    if get_option!(dump_disasm).is_enabled() {
+    if get_option_ref!(dump_disasm).is_some() {
         asm.comment(&format!("Block: {} (ISEQ offset: {})", iseq_get_location(blockid.iseq), blockid.idx));
     }
 

--- a/yjit/src/disasm.rs
+++ b/yjit/src/disasm.rs
@@ -2,6 +2,7 @@ use crate::core::*;
 use crate::cruby::*;
 use crate::yjit::yjit_enabled_p;
 use crate::asm::CodeBlock;
+use crate::options::DumpDisasm;
 
 use std::fmt::Write;
 
@@ -115,6 +116,22 @@ pub fn disasm_iseq_insn_range(iseq: IseqPtr, start_idx: u32, end_idx: u32) -> St
     return out;
 }
 
+#[cfg(feature = "disasm")]
+pub fn dump_disasm_addr_range(cb: &CodeBlock, start_addr: *const u8, code_size: usize, dump_disasm: &DumpDisasm) {
+    use std::fs::File;
+    use std::io::Write;
+
+    let disasm = disasm_addr_range(cb, start_addr, code_size);
+    if disasm.len() > 0 {
+        match dump_disasm {
+            DumpDisasm::Stdout => println!("{disasm}"),
+            DumpDisasm::File(path) => {
+                let mut f = File::options().append(true).create(true).open(path).unwrap();
+                f.write_all(disasm.as_bytes()).unwrap();
+            }
+        };
+    }
+}
 
 #[cfg(feature = "disasm")]
 pub fn disasm_addr_range(cb: &CodeBlock, start_addr: *const u8, code_size: usize) -> String {


### PR DESCRIPTION
## Before
Currently, `--yjit-dump-disasm` is behaving like:

* `--yjit-dump-disasm`: Dump only inline code to stdout
* `--yjit-dump-disasm=all`: Dump both inline and outlined code to stdout

## After
This PR changes that to:

* `--yjit-dump-disasm`: Dump both inline and outlined code to stdout
* `--yjit-dump-disasm=[directory]`: Dump both inline and outlined code to `{directory}/yjit_{pid}.log` file

because it's too slow to dump disasm to stdout with large scripts like test-all while it's still useful to dump things to stdout in smaller scripts.

I noticed that I don't really use the previous `--yjit-dump-disasm` these days, so that version is probably not needed anymore. Alternatively, you could still use `--yjit-dump-iseq-disasm` when you're only interested in ISEQ's inline code.