### PR TITLE
YJIT doesn't need rb_obj_ensure_iv_index_mapping

### DIFF
--- a/internal/variable.h
+++ b/internal/variable.h
@@ -35,7 +35,6 @@ void rb_gvar_ractor_local(const char *name);
 static inline bool ROBJ_TRANSIENT_P(VALUE obj);
 static inline void ROBJ_TRANSIENT_SET(VALUE obj);
 static inline void ROBJ_TRANSIENT_UNSET(VALUE obj);
-uint32_t rb_obj_ensure_iv_index_mapping(VALUE obj, ID id);
 
 struct gen_ivtbl;
 int rb_gen_ivtbl_get(VALUE obj, ID id, struct gen_ivtbl **ivtbl);

--- a/variable.c
+++ b/variable.c
@@ -1449,7 +1449,7 @@ rb_init_iv_list(VALUE obj)
 // @note May raise when there are too many instance variables.
 // @note YJIT uses this function at compile time to simplify the work needed to
 //       access the variable at runtime.
-uint32_t
+static uint32_t
 rb_obj_ensure_iv_index_mapping(VALUE obj, ID id)
 {
     RUBY_ASSERT(RB_TYPE_P(obj, T_OBJECT));

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -304,7 +304,6 @@ fn main() {
 
         // From internal/variable.h
         .allowlist_function("rb_gvar_(get|set)")
-        .allowlist_function("rb_obj_ensure_iv_index_mapping")
 
         // From include/ruby/internal/intern/variable.h
         .allowlist_function("rb_attr_get")

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -1016,9 +1016,6 @@ extern "C" {
     pub fn rb_hash_resurrect(hash: VALUE) -> VALUE;
 }
 extern "C" {
-    pub fn rb_obj_ensure_iv_index_mapping(obj: VALUE, id: ID) -> u32;
-}
-extern "C" {
     pub fn rb_gvar_get(arg1: ID) -> VALUE;
 }
 extern "C" {


### PR DESCRIPTION
We should make this function static and remove it from YJIT bindings.