### PR TITLE
More precisely iterate over Object instance variables

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -7270,7 +7270,7 @@ gc_mark_children(rb_objspace_t *objspace, VALUE obj)
         {
             const VALUE * const ptr = ROBJECT_IVPTR(obj);
 
-            uint32_t i, len = ROBJECT_NUMIV(obj);
+            uint32_t i, len = ROBJECT_IV_COUNT(obj);
             for (i  = 0; i < len; i++) {
                 gc_mark(objspace, ptr[i]);
             }
@@ -10019,7 +10019,7 @@ gc_ref_update_object(rb_objspace_t *objspace, VALUE v)
     }
 #endif
 
-    for (uint32_t i = 0; i < numiv; i++) {
+    for (uint32_t i = 0; i < ROBJECT_IV_COUNT(v); i++) {
         UPDATE_IF_MOVED(objspace, ptr[i]);
     }
 }

--- a/ractor.c
+++ b/ractor.c
@@ -2312,7 +2312,7 @@ obj_traverse_i(VALUE obj, struct obj_traverse_data *data)
 
       case T_OBJECT:
         {
-            uint32_t len = ROBJECT_NUMIV(obj);
+            uint32_t len = ROBJECT_IV_COUNT(obj);
             VALUE *ptr = ROBJECT_IVPTR(obj);
 
             for (uint32_t i=0; i<len; i++) {
@@ -2766,7 +2766,7 @@ obj_traverse_replace_i(VALUE obj, struct obj_traverse_replace_data *data)
             if (data->move) rb_obj_transient_heap_evacuate(obj, TRUE);
 #endif
 
-            uint32_t len = ROBJECT_NUMIV(obj);
+            uint32_t len = ROBJECT_IV_COUNT(obj);
             VALUE *ptr = ROBJECT_IVPTR(obj);
 
             for (uint32_t i=0; i<len; i++) {

--- a/shape.h
+++ b/shape.h
@@ -125,6 +125,15 @@ bool rb_shape_get_iv_index(rb_shape_t * shape, ID id, attr_index_t * value);
 shape_id_t rb_shape_id(rb_shape_t * shape);
 MJIT_SYMBOL_EXPORT_END
 
+static inline uint32_t
+ROBJECT_IV_COUNT(VALUE obj)
+{
+    RBIMPL_ASSERT_TYPE(obj, RUBY_T_OBJECT);
+    uint32_t ivc = rb_shape_get_shape_by_id(ROBJECT_SHAPE_ID(obj))->iv_count;
+    RUBY_ASSERT(ivc <= ROBJECT_NUMIV(obj));
+    return ivc;
+}
+
 rb_shape_t * rb_shape_alloc(ID edge_name, rb_shape_t * parent);
 rb_shape_t * rb_shape_alloc_with_parent_id(ID edge_name, shape_id_t parent_id);
 

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1268,8 +1268,7 @@ vm_setivar_slowpath(VALUE obj, ID id, VALUE val, const rb_iseq_t *iseq, IVC ic, 
 
             if (shape != next_shape) {
                 RUBY_ASSERT(next_shape->parent_id == rb_shape_id(shape));
-                rb_shape_set_shape(obj, next_shape);
-                next_shape_id = ROBJECT_SHAPE_ID(obj);
+                next_shape_id = rb_shape_id(next_shape);
             }
 
             if (rb_shape_get_iv_index(next_shape, id, &index)) { // based off the hash stored in the transition tree
@@ -1289,6 +1288,9 @@ vm_setivar_slowpath(VALUE obj, ID id, VALUE val, const rb_iseq_t *iseq, IVC ic, 
                 rb_init_iv_list(obj);
             }
 
+            if (shape != next_shape) {
+                rb_shape_set_shape(obj, next_shape);
+            }
             VALUE *ptr = ROBJECT_IVPTR(obj);
             RB_OBJ_WRITE(obj, &ptr[index], val);
             RB_DEBUG_COUNTER_INC(ivar_set_ic_miss_iv_hit);


### PR DESCRIPTION
Shapes provides us with an (almost) exact count of instance variables. We only need to check for Qundef when an IV has been "undefined" Prefer to use ROBJECT_IV_COUNT when iterating IVs