### PR TITLE
Make mjit_cont sharable with YJIT

### DIFF
--- a/eval.c
+++ b/eval.c
@@ -21,6 +21,7 @@
 #include "gc.h"
 #include "internal.h"
 #include "internal/class.h"
+#include "internal/cont.h"
 #include "internal/error.h"
 #include "internal/eval.h"
 #include "internal/hash.h"
@@ -251,7 +252,8 @@ rb_ec_cleanup(rb_execution_context_t *ec, int ex0)
         }
     }
 
-    mjit_finish(true); // We still need ISeqs here.
+    mjit_finish(true); // We still need ISeqs here, so it's before rb_ec_finalize().
+    rb_jit_cont_finish();
 
     rb_ec_finalize(ec);
 

--- a/internal/cont.h
+++ b/internal/cont.h
@@ -9,6 +9,7 @@
  * @brief      Internal header for Fiber.
  */
 #include "ruby/ruby.h"          /* for VALUE */
+#include "iseq.h"
 
 struct rb_thread_struct;        /* in vm_core.h */
 struct rb_fiber_struct;         /* in cont.c */
@@ -17,7 +18,9 @@ struct rb_execution_context_struct; /* in vm_core.c */
 /* cont.c */
 void rb_fiber_reset_root_local_storage(struct rb_thread_struct *);
 void ruby_register_rollback_func_for_ensure(VALUE (*ensure_func)(VALUE), VALUE (*rollback_func)(VALUE));
-void rb_fiber_init_mjit_cont(struct rb_fiber_struct *fiber);
+void rb_fiber_init_jit_cont(struct rb_fiber_struct *fiber);
+void rb_jit_cont_each_iseq(rb_iseq_callback callback);
+void rb_jit_cont_finish(void);
 
 VALUE rb_fiberptr_self(struct rb_fiber_struct *fiber);
 unsigned int rb_fiberptr_blocking(struct rb_fiber_struct *fiber);

--- a/iseq.h
+++ b/iseq.h
@@ -31,6 +31,7 @@ RUBY_EXTERN const int ruby_api_version[];
 typedef struct rb_iseq_struct rb_iseq_t;
 #define rb_iseq_t rb_iseq_t
 #endif
+typedef void (*rb_iseq_callback)(const rb_iseq_t *);
 
 extern const ID rb_iseq_shared_exc_local_tbl[];
 

--- a/mjit.h
+++ b/mjit.h
@@ -101,8 +101,6 @@ extern void mjit_init(const struct mjit_options *opts);
 extern void mjit_free_iseq(const rb_iseq_t *iseq);
 extern void mjit_update_references(const rb_iseq_t *iseq);
 extern void mjit_mark(void);
-extern struct mjit_cont *mjit_cont_new(rb_execution_context_t *ec);
-extern void mjit_cont_free(struct mjit_cont *cont);
 extern void mjit_mark_cc_entries(const struct rb_iseq_constant_body *const body);
 extern void mjit_notify_waitpid(int exit_code);
 
@@ -120,8 +118,6 @@ void mjit_finish(bool close_handle_p);
 # else // USE_MJIT
 
 static inline void mjit_cancel_all(const char *reason){}
-static inline struct mjit_cont *mjit_cont_new(rb_execution_context_t *ec){return NULL;}
-static inline void mjit_cont_free(struct mjit_cont *cont){}
 static inline void mjit_free_iseq(const rb_iseq_t *iseq){}
 static inline void mjit_mark(void){}
 static inline VALUE jit_exec(rb_execution_context_t *ec) { return Qundef; /* unreachable */ }

--- a/yjit.c
+++ b/yjit.c
@@ -889,13 +889,11 @@ rb_assert_cme_handle(VALUE handle)
     RUBY_ASSERT_ALWAYS(IMEMO_TYPE_P(handle, imemo_ment));
 }
 
-typedef void (*iseq_callback)(const rb_iseq_t *);
-
 // Heap-walking callback for rb_yjit_for_each_iseq().
 static int
 for_each_iseq_i(void *vstart, void *vend, size_t stride, void *data)
 {
-    const iseq_callback callback = (iseq_callback)data;
+    const rb_iseq_callback callback = (rb_iseq_callback)data;
     VALUE v = (VALUE)vstart;
     for (; v != (VALUE)vend; v += stride) {
         void *ptr = asan_poisoned_object_p(v);
@@ -914,7 +912,7 @@ for_each_iseq_i(void *vstart, void *vend, size_t stride, void *data)
 // Iterate through the whole GC heap and invoke a callback for each iseq.
 // Used for global code invalidation.
 void
-rb_yjit_for_each_iseq(iseq_callback callback)
+rb_yjit_for_each_iseq(rb_iseq_callback callback)
 {
     rb_objspace_each_objects(for_each_iseq_i, (void *)callback);
 }


### PR DESCRIPTION
For YJIT's code GC, we want to enumerate on-stack ISEQs. Because we've implemented that in CRuby for MJIT, I'd like to make the logic sharable with MJIT instead of re-implementing the same thing.

`rb_jit_cont_each_iseq` is the API that can be used by YJIT once you modify `jit_cont_enabled` logic to include `rb_yjit_enabled_p()`.