### PR TITLE
Upgrade zlib_version on AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,7 +18,7 @@ skip_commits:
     - '**/*.rdoc'
 environment:
   ruby_version: "24-%Platform%"
-  zlib_version: "1.2.12"
+  zlib_version: "1.2.13"
   matrix:
     - build: vs
       vs: 120


### PR DESCRIPTION
They removed https://zlib.net/zlib1212.zip because https://zlib.net/zlib1213.zip was released :thinking_face:

Fix CI failures like:
https://ci.appveyor.com/project/ruby/ruby/builds/45064876/job/bb9biogolh0u2595