### PR TITLE
YJIT: Do not call `mprotect` when `mem_size` is zero

### DIFF
--- a/yjit.c
+++ b/yjit.c
@@ -74,6 +74,11 @@ rb_yjit_mark_writable(void *mem_block, uint32_t mem_size)
 void
 rb_yjit_mark_executable(void *mem_block, uint32_t mem_size)
 {
+    // Do not call mprotect when mem_size is zero. Some platforms may return
+    // an error for it. https://github.com/Shopify/ruby/issues/450
+    if (mem_size == 0) {
+        return;
+    }
     if (mprotect(mem_block, mem_size, PROT_READ | PROT_EXEC)) {
         rb_bug("Couldn't make JIT page (%p, %lu bytes) executable, errno: %s\n",
             mem_block, (unsigned long)mem_size, strerror(errno));


### PR DESCRIPTION
This PR fixes the issue reported by https://github.com/Shopify/ruby/issues/450. When you try to run x86_64 based YJIT on Docker Desktop on macOS (arm64), YJIT will fail as the followings:

```console
$ docker run -it rubylang/ruby:master-debug-nightly-focal ruby --yjit -e 'p 1'
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
ruby: [BUG] Couldn't make JIT page (0x0000ffff9033b000, 0 bytes) executable, errno: Cannot allocate memory

ruby 3.2.0dev (2022-09-26T16:21:58Z master 830b5b5c35) [x86_64-linux]
...
```

## Cause

The issue was caused by a subtle behavior difference in `mprotect` system call between the Linux kernel and `qemu-x86_64` user space emulator. `qemu-x86_64` translates x86_64 based Linux system call to AArch64 based Linux system call, but if `mprotect` is called with `mem_size` of `0`, it returns a different code to Linux kernel. As of QEMU 7.0 and 7.1, `qemu-x86_64` returns `ENOMEM` error, but Linux kernel returns `0` (no error). YJIT does not expect the error so it will crash.

Just FYI, the place that YJIT calls `mprotect` with `mem_size` `0` is here:

`codegen::CodegenGlobals::init` [L6616](https://github.com/ruby/ruby/blob/1acc1a5c6d5d01b2822d7aa4356208095481724b/yjit/src/codegen.rs#L6616)

```rust
6543: impl CodegenGlobals {
6544:     /// Initialize the codegen globals
6545:     pub fn init() {
              ...
6615:         // Mark all code memory as executable
6616:         cb.mark_all_executable();
6617:         ocb.unwrap().mark_all_executable();
```

`cb`, the inline code block, has no machine codes written after initialization, and its `mem_size` is `0`. So calling `mark_all_executable` causes a C function `rb_yjit_mark_executable` to call `mprotect` with `mem_size` of `0`.

`ocb`, the outline code block, has some machine codes written before calling `mark_all_executable`, so its `mem_size` is not `0`.

## Fix

This PR adds a "guard" to `rb_yjit_mark_executable`, which checks if `mem_size` is `0` at the beginning. If so, `rb_yjit_mark_executable` will return without calling `mprotect`.

My friend is also [submitting a patch](https://lists.nongnu.org/archive/html/qemu-trivial/2022-10/msg00012.html) to the QEMU project to correct the behavior of `qemu-x86_64`. But we still want to add the guard to YJIT because the spec of `mprotect` is not clear what it should do when `mem_size` `0` is given. It seems it is OS dependent. So it will be safer not to call `mprotect` in such case.

## Testing

I tested this PR on Docker Desktop on a M1 Mac. I created a Docker image with x86_64 based Ruby YJIT and ran [yjit-bench](https://github.com/Shopify/yjit-bench) on it. I confirmed all 25 benchmarks ran without error:

```console
$ docker run -it --privileged ruby:master-mprotect-amd64 bash
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
root@a5ca84429cee:/# cd
root@a5ca84429cee:~# apt update && apt upgrade
root@a5ca84429cee:~# apt install libsqlite3-dev xz-utils
root@a5ca84429cee:~# tar xf yjit-bench-2022-10-14.txz
root@a5ca84429cee:~# cd yjit-bench
root@a5ca84429cee:~/yjit-bench# ./run_benchmarks.rb
Running benchmark "30k_ifelse" (1/25)
setarch x86_64 -R taskset -c 3 /usr/local/bin/ruby -I ./harness benchmarks/30k_ifelse.rb
...

Total time spent benchmarking: 15743s

end_time: 2022-10-14 18:22:29 UTC (+0000)
interp: ruby 3.2.0dev (2022-10-14T12:08:01Z yjit-mprotect-zero.. 107c6d024c) [x86_64-linux]
yjit: ruby 3.2.0dev (2022-10-14T12:08:01Z yjit-mprotect-zero.. 107c6d024c) +YJIT [x86_64-linux]
...
```

**The Docker version**

```console
$ docker version
Client:
 Cloud integration: v1.0.29
 Version:           20.10.17
 API version:       1.41
 Go version:        go1.17.11
 Git commit:        100c701
 Built:             Mon Jun  6 23:04:45 2022
 OS/Arch:           darwin/arm64
 Context:           default
 Experimental:      true

Server: Docker Desktop 4.12.0 (85629)
 Engine:
  Version:          20.10.17
  API version:      1.41 (minimum version 1.12)
  Go version:       go1.17.11
  Git commit:       a89b842
  Built:            Mon Jun  6 23:01:01 2022
  OS/Arch:          linux/arm64
  Experimental:     false
 containerd:
  Version:          1.6.8
  GitCommit:        9cd3357b7fd7218e4aec3eae239db1f68a5a6ec6
 runc:
  Version:          1.1.4
  GitCommit:        v1.1.4-0-g5fd4c4d
 docker-init:
  Version:          0.19.0
  GitCommit:        de40ad0
```