### PR TITLE
Introduce `hash_iter_status_check` function

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -1346,15 +1346,8 @@ struct hash_foreach_arg {
 };
 
 static int
-hash_ar_foreach_iter(st_data_t key, st_data_t value, st_data_t argp, int error)
+hash_iter_status_check(int status)
 {
-    struct hash_foreach_arg *arg = (struct hash_foreach_arg *)argp;
-    int status;
-
-    if (error) return ST_STOP;
-    status = (*arg->func)((VALUE)key, (VALUE)value, arg->arg);
-    /* TODO: rehash check? rb_raise(rb_eRuntimeError, "rehash occurred during iteration"); */
-
     switch (status) {
       case ST_DELETE:
         return ST_DELETE;
@@ -1363,7 +1356,19 @@ hash_ar_foreach_iter(st_data_t key, st_data_t value, st_data_t argp, int error)
       case ST_STOP:
         return ST_STOP;
     }
-    return ST_CHECK;
+    return ST_CHECK;  
+}
+
+static int
+hash_ar_foreach_iter(st_data_t key, st_data_t value, st_data_t argp, int error)
+{
+    struct hash_foreach_arg *arg = (struct hash_foreach_arg *)argp;
+    int status;
+
+    if (error) return ST_STOP;
+    status = (*arg->func)((VALUE)key, (VALUE)value, arg->arg);
+    /* TODO: rehash check? rb_raise(rb_eRuntimeError, "rehash occurred during iteration"); */
+    return hash_iter_status_check(status);
 }
 
 static int
@@ -1379,15 +1384,7 @@ hash_foreach_iter(st_data_t key, st_data_t value, st_data_t argp, int error)
     if (RHASH_ST_TABLE(arg->hash) != tbl) {
     	rb_raise(rb_eRuntimeError, "rehash occurred during iteration");
     }
-    switch (status) {
-      case ST_DELETE:
-        return ST_DELETE;
-      case ST_CONTINUE:
-        break;
-      case ST_STOP:
-        return ST_STOP;
-    }
-    return ST_CHECK;
+    return hash_iter_status_check(status);
 }
 
 static int

--- a/hash.c
+++ b/hash.c
@@ -1356,7 +1356,7 @@ hash_iter_status_check(int status)
       case ST_STOP:
         return ST_STOP;
     }
-    return ST_CHECK;  
+    return ST_CHECK;
 }
 
 static int


### PR DESCRIPTION
`hash_ar_foreach_iter` and `hash_foreach_iter` function has same iterator status check code in `hash.c`.
I thought better to introduce iterator status check function like `hash_iter_status_check` function.