### PR TITLE
Introduce `Fiber#locals` for storing shared fiber-local variables.

### DIFF
--- a/enumerator.c
+++ b/enumerator.c
@@ -760,7 +760,7 @@ next_init(VALUE obj, struct enumerator *e)
 {
     VALUE curr = rb_fiber_current();
     e->dst = curr;
-    e->fib = rb_fiber_new(next_i, obj);
+    e->fib = rb_fiber_new2(next_i, obj, rb_fiber_locals());
     e->lookahead = Qundef;
 }
 

--- a/include/ruby/internal/intern/cont.h
+++ b/include/ruby/internal/intern/cont.h
@@ -39,12 +39,31 @@ RBIMPL_SYMBOL_EXPORT_BEGIN()
 VALUE rb_fiber_new(rb_block_call_func_t func, VALUE callback_obj);
 
 /**
+ * Creates a Fiber instance from a C-backended block with the specified locals.
+ *
+ * If the given locals are nil, this function is equivalent to rb_fiber_new().
+ *
+ * @param[in]  func          A function, to become the fiber's body.
+ * @param[in]  callback_obj  Passed as-is to `func`.
+ * @return     An allocated  new instance  of rb_cFiber, which  is ready  to be
+ *             "resume"d.
+ */
+VALUE rb_fiber_new2(rb_block_call_func_t func, VALUE callback_obj, VALUE locals);
+
+/**
  * Queries  the fiber  which  is  calling this  function.   Any ruby  execution
  * context has its fiber, either explicitly or implicitly.
  *
  * @return  The current fiber.
  */
 VALUE rb_fiber_current(void);
+
+/**
+ * Current fiber locals.
+ *
+ * @return  The locals of the current fiber.
+ */
+VALUE rb_fiber_locals(void);
 
 /**
  * Queries the  liveness of the  passed fiber.   "Alive" in this  context means

--- a/internal/cont.h
+++ b/internal/cont.h
@@ -22,6 +22,9 @@ void rb_jit_cont_init(void);
 void rb_jit_cont_each_iseq(rb_iseq_callback callback, void *data);
 void rb_jit_cont_finish(void);
 
+// Copy locals from the current execution to the specified fiber.
+VALUE rb_fiber_inherit_locals(struct rb_execution_context_struct *ec, struct rb_fiber_struct *fiber);
+
 VALUE rb_fiberptr_self(struct rb_fiber_struct *fiber);
 unsigned int rb_fiberptr_blocking(struct rb_fiber_struct *fiber);
 struct rb_execution_context_struct * rb_fiberptr_get_ec(struct rb_fiber_struct *fiber);

--- a/mjit_c.rb
+++ b/mjit_c.rb
@@ -398,6 +398,7 @@ module RubyVM::MJIT
       local_storage: [CType::Pointer.new { self.rb_id_table }, Primitive.cexpr!("OFFSETOF((*((struct rb_execution_context_struct *)NULL)), local_storage)")],
       local_storage_recursive_hash: [self.VALUE, Primitive.cexpr!("OFFSETOF((*((struct rb_execution_context_struct *)NULL)), local_storage_recursive_hash)")],
       local_storage_recursive_hash_for_trace: [self.VALUE, Primitive.cexpr!("OFFSETOF((*((struct rb_execution_context_struct *)NULL)), local_storage_recursive_hash_for_trace)")],
+      locals: [self.VALUE, Primitive.cexpr!("OFFSETOF((*((struct rb_execution_context_struct *)NULL)), locals)")],
       root_lep: [CType::Pointer.new { self.VALUE }, Primitive.cexpr!("OFFSETOF((*((struct rb_execution_context_struct *)NULL)), root_lep)")],
       root_svar: [self.VALUE, Primitive.cexpr!("OFFSETOF((*((struct rb_execution_context_struct *)NULL)), root_svar)")],
       ensure_list: [CType::Pointer.new { self.rb_ensure_list_t }, Primitive.cexpr!("OFFSETOF((*((struct rb_execution_context_struct *)NULL)), ensure_list)")],

--- a/test/fiber/test_locals.rb
+++ b/test/fiber/test_locals.rb
@@ -3,15 +3,19 @@ require 'test/unit'
 
 class TestFiberLocals < Test::Unit::TestCase
   def test_locals
+    Fiber[:x] = 10
     assert_kind_of Hash, Fiber.current.locals
-    assert_predicate Fiber.current.locals, :empty?
+    assert_predicate Fiber.current.locals, :any?
   end
 
   def test_locals_inherited
     locals = Fiber.current.locals
+    locals[:foo] = :bar
 
     Fiber.new do
       assert_equal locals, Fiber.current.locals
+      Fiber[:bar] = :baz
+      assert_not_equal locals, Fiber.current.locals
     end.resume
   end
 
@@ -39,8 +43,9 @@ class TestFiberLocals < Test::Unit::TestCase
     Fiber.current.locals.clear
   end
 
-  def test_enumerator
-    Fiber.current.locals = {item: "Hello World"}
+  def test_enumerator_inherited_locals
+    Fiber[:item] = "Hello World"
+
     enumerator = Enumerator.new do |out|
       out << Fiber.current
       out << Fiber[:item]
@@ -51,6 +56,35 @@ class TestFiberLocals < Test::Unit::TestCase
 
     # But it inherited the locals from the current fiber:
     assert_equal "Hello World", enumerator.next
+  ensure
+    Fiber.current.locals.clear
+  end
+
+  def test_thread_inherited_locals
+    Fiber[:x] = 10
+
+    x = Thread.new do
+      Fiber[:y] = 20
+      Fiber[:x]
+    end.value
+
+    assert_equal 10, x
+    assert_equal nil, Fiber[:y]
+  ensure
+    Fiber.current.locals.clear
+  end
+
+  def test_enumerator_count
+    Fiber[:count] = 0
+
+    enumerator = Enumerator.new do |y|
+      # Since the fiber is implementation detail, the locals are shared with the parent:
+      Fiber[:count] += 1
+      y << Fiber[:count]
+    end
+
+    assert_equal 1, enumerator.next
+    assert_equal 1, Fiber[:count]
   ensure
     Fiber.current.locals.clear
   end

--- a/test/fiber/test_locals.rb
+++ b/test/fiber/test_locals.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+require 'test/unit'
+
+class TestFiberLocals < Test::Unit::TestCase
+  def test_locals
+    assert_kind_of Hash, Fiber.current.locals
+    assert_predicate Fiber.current.locals, :empty?
+  end
+
+  def test_locals_inherited
+    locals = Fiber.current.locals
+
+    Fiber.new do
+      assert_equal locals, Fiber.current.locals
+    end.resume
+  end
+
+  def test_variable_assignment
+    Fiber[:foo] = :bar
+    assert_equal :bar, Fiber[:foo]
+  ensure
+    Fiber.current.locals.clear
+  end
+
+  def test_locals_assignment
+    Fiber.current.locals = {foo: :bar}
+    assert_equal :bar, Fiber[:foo]
+  ensure
+    Fiber.current.locals.clear
+  end
+
+  def test_inherited_locals
+    Fiber.current.locals = {foo: :bar}
+    f = Fiber.new do
+      assert_equal :bar, Fiber[:foo]
+    end
+    f.resume
+  ensure
+    Fiber.current.locals.clear
+  end
+
+  def test_enumerator
+    Fiber.current.locals = {item: "Hello World"}
+    enumerator = Enumerator.new do |out|
+      out << Fiber.current
+      out << Fiber[:item]
+    end
+
+    # The fiber within the enumerator is not equal to the current...
+    assert_not_equal Fiber.current, enumerator.next
+
+    # But it inherited the locals from the current fiber:
+    assert_equal "Hello World", enumerator.next
+  ensure
+    Fiber.current.locals.clear
+  end
+end

--- a/thread.c
+++ b/thread.c
@@ -813,6 +813,8 @@ thread_create_core(VALUE thval, struct thread_create_params *params)
                  "can't start a new thread (frozen ThreadGroup)");
     }
 
+    rb_fiber_inherit_locals(ec, th->ec->fiber_ptr);
+
     switch (params->type) {
       case thread_invoke_type_proc:
         th->invoke_type = thread_invoke_type_proc;

--- a/vm.c
+++ b/vm.c
@@ -3189,6 +3189,7 @@ rb_execution_context_mark(const rb_execution_context_t *ec)
     }
     RUBY_MARK_UNLESS_NULL(ec->local_storage_recursive_hash);
     RUBY_MARK_UNLESS_NULL(ec->local_storage_recursive_hash_for_trace);
+    RUBY_MARK_UNLESS_NULL(ec->locals);
     RUBY_MARK_UNLESS_NULL(ec->private_const_reference);
 }
 
@@ -3379,6 +3380,8 @@ th_init(rb_thread_t *th, VALUE self, rb_vm_t *vm)
     th->ec->root_svar = Qfalse;
     th->ec->local_storage_recursive_hash = Qnil;
     th->ec->local_storage_recursive_hash_for_trace = Qnil;
+
+    th->ec->locals = Qnil;
 
 #if OPT_CALL_THREADED_CODE
     th->retval = Qundef;

--- a/vm_core.h
+++ b/vm_core.h
@@ -960,6 +960,9 @@ struct rb_execution_context_struct {
     VALUE local_storage_recursive_hash;
     VALUE local_storage_recursive_hash_for_trace;
 
+    /* Fiber locals. */
+    VALUE locals;
+
     /* eval env */
     const VALUE *root_lep;
     VALUE root_svar;


### PR DESCRIPTION
Fiber locals are inherited child fibers spawned from the current fiber. This is useful for storing per-request state in a web server, for example.

https://bugs.ruby-lang.org/issues/19062