### PR TITLE
Fixes [Bug #19004]: `Complex.polar` handles complex singular `abs` argument

### DIFF
--- a/complex.c
+++ b/complex.c
@@ -704,15 +704,12 @@ nucomp_s_polar(int argc, VALUE *argv, VALUE klass)
 {
     VALUE abs, arg;
 
-    switch (rb_scan_args(argc, argv, "11", &abs, &arg)) {
-      case 1:
-        nucomp_real_check(abs);
-        return nucomp_s_new_internal(klass, abs, ZERO);
-      default:
-        nucomp_real_check(abs);
+    if (rb_scan_args(argc, argv, "11", &abs, &arg) == 1) {
+        arg = ZERO;
+    } else {
         nucomp_real_check(arg);
-        break;
     }
+    nucomp_real_check(abs);
     return f_complex_polar(klass, abs, arg);
 }
 

--- a/complex.c
+++ b/complex.c
@@ -704,12 +704,14 @@ nucomp_s_polar(int argc, VALUE *argv, VALUE klass)
 {
     VALUE abs, arg;
 
-    if (rb_scan_args(argc, argv, "11", &abs, &arg) == 1) {
-        arg = ZERO;
-    } else {
+    argc = rb_scan_args(argc, argv, "11", &abs, &arg);
+    nucomp_real_check(abs);
+    if (argc == 2) {
         nucomp_real_check(arg);
     }
-    nucomp_real_check(abs);
+    else {
+        arg = ZERO;
+    }
     return f_complex_polar(klass, abs, arg);
 }
 

--- a/spec/ruby/core/complex/polar_spec.rb
+++ b/spec/ruby/core/complex/polar_spec.rb
@@ -10,6 +10,20 @@ describe "Complex.polar" do
     ->{ Complex.polar(nil)      }.should raise_error(TypeError)
     ->{ Complex.polar(nil, nil) }.should raise_error(TypeError)
   end
+
+  it "computes the real values of the real & imaginary parts from the polar form" do
+    a = Complex.polar(1.0+0.0i, Math::PI/2+0.0i)
+    a.real.should be_close(0.0, TOLERANCE)
+    a.imag.should be_close(1.0, TOLERANCE)
+    a.real.real?.should be_true
+    a.imag.real?.should be_true
+
+    b = Complex.polar(1+0.0i)
+    b.real.should be_close(1.0, TOLERANCE)
+    b.imag.should be_close(0.0, TOLERANCE)
+    b.real.real?.should be_true
+    b.imag.real?.should be_true
+  end
 end
 
 describe "Complex#polar" do

--- a/spec/ruby/core/complex/polar_spec.rb
+++ b/spec/ruby/core/complex/polar_spec.rb
@@ -11,18 +11,20 @@ describe "Complex.polar" do
     ->{ Complex.polar(nil, nil) }.should raise_error(TypeError)
   end
 
-  it "computes the real values of the real & imaginary parts from the polar form" do
-    a = Complex.polar(1.0+0.0i, Math::PI/2+0.0i)
-    a.real.should be_close(0.0, TOLERANCE)
-    a.imag.should be_close(1.0, TOLERANCE)
-    a.real.real?.should be_true
-    a.imag.real?.should be_true
+  ruby_version_is "3.2" do
+    it "computes the real values of the real & imaginary parts from the polar form" do
+      a = Complex.polar(1.0+0.0i, Math::PI/2+0.0i)
+      a.real.should be_close(0.0, TOLERANCE)
+      a.imag.should be_close(1.0, TOLERANCE)
+      a.real.real?.should be_true
+      a.imag.real?.should be_true
 
-    b = Complex.polar(1+0.0i)
-    b.real.should be_close(1.0, TOLERANCE)
-    b.imag.should be_close(0.0, TOLERANCE)
-    b.real.real?.should be_true
-    b.imag.real?.should be_true
+      b = Complex.polar(1+0.0i)
+      b.real.should be_close(1.0, TOLERANCE)
+      b.imag.should be_close(0.0, TOLERANCE)
+      b.real.real?.should be_true
+      b.imag.real?.should be_true
+    end
   end
 end
 

--- a/spec/ruby/core/complex/polar_spec.rb
+++ b/spec/ruby/core/complex/polar_spec.rb
@@ -11,7 +11,7 @@ describe "Complex.polar" do
     ->{ Complex.polar(nil, nil) }.should raise_error(TypeError)
   end
 
-  ruby_version_is "3.2" do
+  ruby_bug "#19004", ""..."3.2" do
     it "computes the real values of the real & imaginary parts from the polar form" do
       a = Complex.polar(1.0+0.0i, Math::PI/2+0.0i)
       a.real.should be_close(0.0, TOLERANCE)


### PR DESCRIPTION
Fixes [Bug #19004] [ruby-core:109879]

Link to issue https://bugs.ruby-lang.org/issues/19004

### The issue

`Complex.polar` accepts Complex values as arguments for the polar form (abs, arg), as long as the value of the complex has no imaginary part (ie it is 'real' in a mathematical sense, and according to `nucomp_real_p`, but not necessarily real in the Ruby Numeric sense of `#real?`). Eg:

```
> Complex.polar(1+0.0i, 1+0.0i).real == Complex.polar(1, 1).real
=> true
```

In `f_complex_polar` this is handled by [extracting the real part of the arguments](https://github.com/ruby/ruby/blob/master/complex.c#L616). 

However, in the case `Complex.polar` is called with only a single argument (ie the absolute value is given only):

```
> Complex.polar(1+0.0i).real
=> (1+0.0i)
```

The Complex is created directly without applying a check or attempting to extract the real part of abs. Thus it is possible to create a Complex where the real part is itself an instance of a Complex. 


### Reproduction

```
> Complex.polar(1+0.0i).real
=> (1+0.0i)
```

compare it to:

```
> Complex.polar(1 + 0.0i, 0.0).real
=> 1
```

### Proposed fix

The proposed change removes the short circuit for the single argument case, meaning the real part extraction is performed by `f_complex_polar` as in the 2 argument case. The fact the polar argument is zero is then handled early on [here in `f_complex_polar`](https://github.com/ruby/ruby/blob/master/complex.c#L625) anyway.

Also the switch/case is removed as it seems in other situations of a 2 argument method with optional second argument, mostly a conditional is simply used.

### The spec example

Added a spec to `spec/ruby/core/complex/polar_spec.rb` which exposes the issue and validates the fix. 

The spec aims to more generically test the specified behaviour of Complex rather than checking its internal form, hence the test creates a Complex with `Complex.polar` using complex arguments & then validates that the computed parts of the resulting complex number are `#real?`


----
As my first contribution please let me know if something needs changes or improvement. 

Thanks for Ruby & everything you have all put into it ❤️ 
