### PR TITLE
clippy: disable `` warning once

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -5305,6 +5305,7 @@ fn gen_send_general(
                 );
             }
             VM_METHOD_TYPE_ATTRSET => {
+                #[allow(clippy::if_same_then_else)]
                 if flags & VM_CALL_KWARG != 0 {
                     gen_counter_incr!(asm, send_attrset_kwargs);
                     return CantCompile;


### PR DESCRIPTION
Version: `rustc 1.64.0 (a55dd71d5 2022-09-19)`

Clippy raises an `if-same-then-else` warning on the lines below, but it seems inappropriate:
 https://github.com/ruby/ruby/blob/ba9c0d0b9fe7ce61fa1162011ced8dbe3e9716c7/yjit/src/codegen.rs#L5308-L5322

Warning output:
```
    Checking yjit v0.1.0 (/home/thd/dev/public/ruby/yjit)
error: this `if` has identical blocks
    --> src/codegen.rs:5308:47
     |
5308 |                   if flags & VM_CALL_KWARG != 0 {
     |  _______________________________________________^
5309 | |                     gen_counter_incr!(asm, send_attrset_kwargs);
5310 | |                     return CantCompile;
5311 | |                 } else if argc != 1 || unsafe { !RB_TYPE_P(comptime_recv, RUBY_T_OBJECT) } {
     | |_________________^
     |
     = note: `#[deny(clippy::if_same_then_else)]` on by default
note: same as this
    --> src/codegen.rs:5311:92
     |
5311 |                   } else if argc != 1 || unsafe { !RB_TYPE_P(comptime_recv, RUBY_T_OBJECT) } {
     |  ____________________________________________________________________________________________^
5312 | |                     gen_counter_incr!(asm, send_ivar_set_method);
5313 | |                     return CantCompile;
5314 | |                 } else if c_method_tracing_currently_enabled(jit) {
     | |_________________^
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#if_same_then_else

error: this `if` has identical blocks
    --> src/codegen.rs:5311:92
     |
5311 |                   } else if argc != 1 || unsafe { !RB_TYPE_P(comptime_recv, RUBY_T_OBJECT) } {
     |  ____________________________________________________________________________________________^
5312 | |                     gen_counter_incr!(asm, send_ivar_set_method);
5313 | |                     return CantCompile;
5314 | |                 } else if c_method_tracing_currently_enabled(jit) {
     | |_________________^
     |
note: same as this
    --> src/codegen.rs:5314:67
     |
5314 |                   } else if c_method_tracing_currently_enabled(jit) {
     |  ___________________________________________________________________^
5315 | |                     // Can't generate code for firing c_call and c_return events
5316 | |                     // See :attr-tracing:
5317 | |                     gen_counter_incr!(asm, send_cfunc_tracing);
5318 | |                     return CantCompile;
5319 | |                 } else {
     | |_________________^
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#if_same_then_else

error: could not compile `yjit` due to 2 previous errors

```

Disabling this rule on the mentioned block solves the problem, but I'm not sure if it's the best solution, would love some feedback. Thank you!