### PR TITLE
Allow passing a Rust closure to rb_iseq_callback

### DIFF
--- a/cont.c
+++ b/cont.c
@@ -1253,7 +1253,7 @@ jit_cont_free(struct rb_jit_cont *cont)
 
 // Call a given callback against all on-stack ISEQs.
 void
-rb_jit_cont_each_iseq(rb_iseq_callback callback)
+rb_jit_cont_each_iseq(rb_iseq_callback callback, void *data)
 {
     struct rb_jit_cont *cont;
     for (cont = first_jit_cont; cont != NULL; cont = cont->next) {
@@ -1264,7 +1264,7 @@ rb_jit_cont_each_iseq(rb_iseq_callback callback)
         for (cfp = RUBY_VM_END_CONTROL_FRAME(cont->ec) - 1; ; cfp = RUBY_VM_NEXT_CONTROL_FRAME(cfp)) {
             const rb_iseq_t *iseq;
             if (cfp->pc && (iseq = cfp->iseq) != NULL && imemo_type((VALUE)iseq) == imemo_iseq) {
-                callback(iseq);
+                callback(iseq, data);
             }
 
             if (cfp == cont->ec->cfp)

--- a/internal/cont.h
+++ b/internal/cont.h
@@ -19,7 +19,7 @@ struct rb_execution_context_struct; /* in vm_core.c */
 void rb_fiber_reset_root_local_storage(struct rb_thread_struct *);
 void ruby_register_rollback_func_for_ensure(VALUE (*ensure_func)(VALUE), VALUE (*rollback_func)(VALUE));
 void rb_fiber_init_jit_cont(struct rb_fiber_struct *fiber);
-void rb_jit_cont_each_iseq(rb_iseq_callback callback);
+void rb_jit_cont_each_iseq(rb_iseq_callback callback, void *data);
 void rb_jit_cont_finish(void);
 
 VALUE rb_fiberptr_self(struct rb_fiber_struct *fiber);

--- a/iseq.h
+++ b/iseq.h
@@ -31,7 +31,7 @@ RUBY_EXTERN const int ruby_api_version[];
 typedef struct rb_iseq_struct rb_iseq_t;
 #define rb_iseq_t rb_iseq_t
 #endif
-typedef void (*rb_iseq_callback)(const rb_iseq_t *);
+typedef void (*rb_iseq_callback)(const rb_iseq_t *, void *);
 
 extern const ID rb_iseq_shared_exc_local_tbl[];
 

--- a/mjit.c
+++ b/mjit.c
@@ -951,7 +951,7 @@ mjit_capture_cc_entries(const struct rb_iseq_constant_body *compiled_iseq, const
 
 // Set up field `used_code_p` for unit iseqs whose iseq on the stack of ec.
 static void
-mark_iseq_units(const rb_iseq_t *iseq)
+mark_iseq_units(const rb_iseq_t *iseq, void *data)
 {
     if (ISEQ_BODY(iseq)->jit_unit != NULL) {
         ISEQ_BODY(iseq)->jit_unit->used_code_p = true;
@@ -982,7 +982,7 @@ unload_units(void)
     }
     // All threads have a root_fiber which has a mjit_cont. Other normal fibers also
     // have a mjit_cont. Thus we can check ISeqs in use by scanning ec of mjit_conts.
-    rb_jit_cont_each_iseq(mark_iseq_units);
+    rb_jit_cont_each_iseq(mark_iseq_units, NULL);
     // TODO: check stale_units and unload unused ones! (note that the unit is not associated to ISeq anymore)
 
     // Unload units whose total_calls is smaller than any total_calls in unit_queue.

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -527,6 +527,16 @@ fn get_or_create_iseq_payload(iseq: IseqPtr) -> &'static mut IseqPayload {
     unsafe { payload_non_null.as_mut() }.unwrap()
 }
 
+/// Iterate over all existing ISEQs
+pub fn for_each_iseq<F: FnMut(IseqPtr)>(mut callback: F) {
+    unsafe extern "C" fn callback_wrapper(iseq: IseqPtr, data: *mut c_void) {
+        let callback: &mut &mut dyn FnMut(IseqPtr) -> bool = unsafe { std::mem::transmute(data) };
+        callback(iseq);
+    };
+    let mut data: &mut dyn FnMut(IseqPtr) = &mut callback;
+    unsafe { rb_yjit_for_each_iseq(Some(callback_wrapper), (&mut data) as *mut _ as *mut c_void) };
+}
+
 /// Free the per-iseq payload
 #[no_mangle]
 pub extern "C" fn rb_yjit_iseq_free(payload: *mut c_void) {

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -1244,7 +1244,9 @@ pub const YARVINSN_trace_putobject_INT2FIX_0_: ruby_vminsn_type = 200;
 pub const YARVINSN_trace_putobject_INT2FIX_1_: ruby_vminsn_type = 201;
 pub const VM_INSTRUCTION_SIZE: ruby_vminsn_type = 202;
 pub type ruby_vminsn_type = u32;
-pub type rb_iseq_callback = ::std::option::Option<unsafe extern "C" fn(arg1: *const rb_iseq_t)>;
+pub type rb_iseq_callback = ::std::option::Option<
+    unsafe extern "C" fn(arg1: *const rb_iseq_t, arg2: *mut ::std::os::raw::c_void),
+>;
 extern "C" {
     pub fn rb_vm_insn_addr2opcode(addr: *const ::std::os::raw::c_void) -> ::std::os::raw::c_int;
 }
@@ -1540,7 +1542,7 @@ extern "C" {
     pub fn rb_assert_cme_handle(handle: VALUE);
 }
 extern "C" {
-    pub fn rb_yjit_for_each_iseq(callback: rb_iseq_callback);
+    pub fn rb_yjit_for_each_iseq(callback: rb_iseq_callback, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
     pub fn rb_yjit_obj_written(

--- a/yjit/src/invariants.rs
+++ b/yjit/src/invariants.rs
@@ -532,9 +532,7 @@ pub extern "C" fn rb_yjit_tracing_invalidate_all() {
     // Stop other ractors since we are going to patch machine code.
     with_vm_lock(src_loc!(), || {
         // Make it so all live block versions are no longer valid branch targets
-        unsafe { rb_yjit_for_each_iseq(Some(invalidate_all_blocks_for_tracing)) };
-
-        extern "C" fn invalidate_all_blocks_for_tracing(iseq: IseqPtr) {
+        for_each_iseq(|iseq| {
             if let Some(payload) = unsafe { get_iseq_payload(iseq) } {
                 // C comment:
                 //   Leaking the blocks for now since we might have situations where
@@ -554,7 +552,7 @@ pub extern "C" fn rb_yjit_tracing_invalidate_all() {
 
             // Reset output code entry point
             unsafe { rb_iseq_reset_jit_func(iseq) };
-        }
+        });
 
         let cb = CodegenGlobals::get_inline_cb();
 


### PR DESCRIPTION
Rust closures cannot be used as a C callback like `rb_iseq_callback`. You always have to pass a static `extern` function that takes only `IseqPtr`, so you can only modify an ISEQ in the callback.

However, for implementing code GC, I'd like to also modify other function-local states that are not reachable from the ISEQ given to the callback when calling `rb_yjit_for_each_iseq` or `rb_jit_cont_each_iseq`. To do so, `rb_iseq_callback` should have a second `void *` argument so that it can be cast to a Rust closure.

This PR prepares API for passing a Rust closure to it. The new API is also used while it's not strictly required for the current use in `rb_yjit_tracing_invalidate_all`.

ref: [How do I convert a Rust closure to a C-style callback?](https://stackoverflow.com/questions/32270030/how-do-i-convert-a-rust-closure-to-a-c-style-callback)