### PR TITLE
Set default %printer for NODE nterms

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -51,11 +51,12 @@ jobs:
       - name: Install libraries
         run: |
           brew upgrade
-          brew install gmp libffi openssl@1.1 zlib autoconf automake libtool readline
+          brew install gmp libffi openssl@1.1 zlib autoconf automake libtool readline bison
         working-directory: src
       - name: Set ENV
         run: |
           echo "MAKEFLAGS=-j$((1 + $(sysctl -n hw.activecpu)))" >> $GITHUB_ENV
+          echo "PATH="/usr/local/opt/bison/bin:$PATH"" >> $GITHUB_ENV
       - run: ./autogen.sh
         working-directory: src
       - name: Run configure

--- a/ext/ripper/tools/preproc.rb
+++ b/ext/ripper/tools/preproc.rb
@@ -47,7 +47,7 @@ def prelude(f, out)
     when /\A%%/
       out << "%%\n"
       return
-    when /\A%token/
+    when /\A%token/, /\A} <node>/
       out << line.sub(/<\w+>/, '<val>')
     when /\A%type/
       out << line.sub(/<\w+>/, '<val>')

--- a/parse.y
+++ b/parse.y
@@ -1141,6 +1141,14 @@ static int looking_at_eol_p(struct parser_params *p);
 %define parse.error verbose
 %printer {
 #ifndef RIPPER
+    if ($$) {
+	rb_parser_printf(p, "%s", ruby_node_name(nd_type($$)));
+    }
+#else
+#endif
+} <node>
+%printer {
+#ifndef RIPPER
     rb_parser_printf(p, "%"PRIsVALUE, rb_id2str($$));
 #else
     rb_parser_printf(p, "%"PRIsVALUE, RNODE($$)->nd_rval);


### PR DESCRIPTION
Filed https://bugs.ruby-lang.org/issues/19068 because this will change required Bison version for development.

Before:

```
Reducing stack by rule 639 (line 5062):
   $1 = token "integer literal" (1.0-1.1: 1)
-> $$ = nterm simple_numeric (1.0-1.1: )
```

After:

```
Reducing stack by rule 641 (line 5078):
   $1 = token "integer literal" (1.0-1.1: 1)
-> $$ = nterm simple_numeric (1.0-1.1: NODE_LIT)
```

`"<*>"` is supported by Bison 2.3b (2008-05-27) or later. https://git.savannah.gnu.org/cgit/bison.git/commit/?id=12e3584054c16ab255672c07af0ffc7bb220e8bc

Therefore developers need to install Bison 2.3b+ to build ruby from source codes if their Bison is older.