### PR TITLE
Add support for anonymous shared IO buffers.

### DIFF
--- a/include/ruby/io/buffer.h
+++ b/include/ruby/io/buffer.h
@@ -37,6 +37,9 @@ enum rb_io_buffer_flags {
     // A non-private mapping is marked as external.
     RB_IO_BUFFER_MAPPED = 4,
 
+    // A mapped buffer that is also shared.
+    RB_IO_BUFFER_SHARED = 8,
+
     // The buffer is locked and cannot be resized.
     // More specifically, it means we can't change the base address or size.
     // A buffer is typically locked before a system call that uses the data.

--- a/io_buffer.c
+++ b/io_buffer.c
@@ -895,7 +895,7 @@ rb_io_buffer_mapped_p(VALUE self)
  *
  *  If the buffer is _shared_, meaning it references memory that can be shared
  *  with other processes (and thus might change without being modified
- *  locally). 
+ *  locally).
  */
 static VALUE
 rb_io_buffer_shared_p(VALUE self)

--- a/io_buffer.c
+++ b/io_buffer.c
@@ -56,9 +56,11 @@ io_buffer_map_memory(size_t size, int flags)
         rb_sys_fail("io_buffer_map_memory:VirtualAlloc");
     }
 #else
-    int mmap_flags = MAP_PRIVATE | MAP_ANON;
+    int mmap_flags = MAP_ANONYMOUS;
     if (flags & RB_IO_BUFFER_SHARED) {
         mmap_flags |= MAP_SHARED;
+    } else {
+        mmap_flags |= MAP_PRIVATE;
     }
 
     void * base = mmap(NULL, size, PROT_READ | PROT_WRITE, mmap_flags, -1, 0);

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -416,6 +416,6 @@ class TestIOBuffer < Test::Unit::TestCase
     string = buffer.get_string(0, message.bytesize)
     assert_equal message, string
   rescue NotImplementedError
-    skip "Fork/shared memory is not supported."
+    omit "Fork/shared memory is not supported."
   end
 end

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -403,4 +403,19 @@ class TestIOBuffer < Test::Unit::TestCase
     assert_equal IO::Buffer.for("\x00\x01\x004\x00\x01\x004\x00\x01"), source.dup.xor!(mask)
     assert_equal IO::Buffer.for("\xce\xcd\xcc\xcb\xce\xcd\xcc\xcb\xce\xcd"), source.dup.not!
   end
+
+  def test_shared
+    message = "Hello World"
+    buffer = IO::Buffer.new(64, IO::Buffer::MAPPED | IO::Buffer::SHARED)
+
+    pid = fork do
+      buffer.set_string(message)
+    end
+
+    Process.wait(pid)
+    string = buffer.get_string(0, message.bytesize)
+    assert_equal message, string
+  rescue NotImplementedError
+    skip "Fork/shared memory is not supported."
+  end
 end


### PR DESCRIPTION
Windows does not support anonymous memory mapped regions, so it needs to use a file instead.

```ruby
#!/usr/bin/env ruby

# file = File.open("buffer.dat", "r+")
# file.truncate(64)
# buffer = IO::Buffer.map(file, 64, 0)
buffer = IO::Buffer.new(64, IO::Buffer::MAPPED | IO::Buffer::SHARED)

begin
  pid = fork do
    while true
      puts buffer
      puts buffer.hexdump
      sleep 1
    end
  end

  while true
    buffer.set_string("The time is: #{Time.now}")
    sleep 1
  end
ensure
  Process.kill("TERM", pid)
end
```

```
#<IO::Buffer 0x00000001051fc000+64 MAPPED SHARED>
0x00000000  54 68 65 20 74 69 6d 65 20 69 73 3a 20 32 30 32 The time is: 202
0x00000010  32 2d 31 30 2d 31 39 20 31 36 3a 34 32 3a 33 36 2-10-19 16:42:36
0x00000020  20 2b 31 33 30 30 00 00 00 00 00 00 00 00 00 00  +1300..........
0x00000030  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
#<IO::Buffer 0x00000001051fc000+64 MAPPED SHARED>
0x00000000  54 68 65 20 74 69 6d 65 20 69 73 3a 20 32 30 32 The time is: 202
0x00000010  32 2d 31 30 2d 31 39 20 31 36 3a 34 32 3a 33 37 2-10-19 16:42:37
0x00000020  20 2b 31 33 30 30 00 00 00 00 00 00 00 00 00 00  +1300..........
0x00000030  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
#<IO::Buffer 0x00000001051fc000+64 MAPPED SHARED>
0x00000000  54 68 65 20 74 69 6d 65 20 69 73 3a 20 32 30 32 The time is: 202
0x00000010  32 2d 31 30 2d 31 39 20 31 36 3a 34 32 3a 33 39 2-10-19 16:42:39
0x00000020  20 2b 31 33 30 30 00 00 00 00 00 00 00 00 00 00  +1300..........
0x00000030  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
#<IO::Buffer 0x00000001051fc000+64 MAPPED SHARED>
0x00000000  54 68 65 20 74 69 6d 65 20 69 73 3a 20 32 30 32 The time is: 202
0x00000010  32 2d 31 30 2d 31 39 20 31 36 3a 34 32 3a 34 30 2-10-19 16:42:40
0x00000020  20 2b 31 33 30 30 00 00 00 00 00 00 00 00 00 00  +1300..........
0x00000030  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
```