### PR TITLE
Stop zeroing memory on allocation / copy

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -2898,40 +2898,28 @@ rb_class_instance_allocate_internal(VALUE klass, VALUE flags, bool wb_protected)
     uint32_t index_tbl_num_entries = RCLASS_EXT(klass)->max_iv_count;
 
     size_t size;
-    bool embed = true;
 #if USE_RVARGC
     size = rb_obj_embedded_size(index_tbl_num_entries);
     if (!rb_gc_size_allocatable_p(size)) {
         size = sizeof(struct RObject);
-        embed = false;
     }
 #else
     size = sizeof(struct RObject);
-    if (index_tbl_num_entries > ROBJECT_EMBED_LEN_MAX) {
-        embed = false;
-    }
 #endif
 
-#if USE_RVARGC
     VALUE obj = newobj_of(klass, flags, 0, 0, 0, wb_protected, size);
-#else
-    VALUE obj = newobj_of(klass, flags, Qundef, Qundef, Qundef, wb_protected, size);
-#endif
 
-    if (embed) {
 #if USE_RVARGC
-        uint32_t capa = (uint32_t)((rb_gc_obj_slot_size(obj) - offsetof(struct RObject, as.ary)) / sizeof(VALUE));
-        GC_ASSERT(capa >= index_tbl_num_entries);
-
-        ROBJECT(obj)->numiv = capa;
-        for (size_t i = 0; i < capa; i++) {
-            ROBJECT(obj)->as.ary[i] = Qundef;
-        }
+    uint32_t capa = (uint32_t)((rb_gc_obj_slot_size(obj) - offsetof(struct RObject, as.ary)) / sizeof(VALUE));
+    ROBJECT(obj)->numiv = capa;
 #endif
+
+#if RUBY_DEBUG
+    VALUE *ptr = ROBJECT_IVPTR(obj);
+    for (size_t i = 0; i < ROBJECT_NUMIV(obj); i++) {
+        ptr[i] = Qundef;
     }
-    else {
-        rb_ensure_iv_list_size(obj, 0, index_tbl_num_entries);
-    }
+#endif
 
     return obj;
 }
@@ -10011,11 +9999,6 @@ gc_ref_update_object(rb_objspace_t *objspace, VALUE v)
 
         uint32_t capa = (uint32_t)((slot_size - offsetof(struct RObject, as.ary)) / sizeof(VALUE));
         ROBJECT(v)->numiv = capa;
-
-        // Fill end with Qundef
-        for (uint32_t i = numiv; i < capa; i++) {
-            ptr[i] = Qundef;
-        }
     }
 #endif
 

--- a/variable.c
+++ b/variable.c
@@ -1404,9 +1404,6 @@ rb_ensure_iv_list_size(VALUE obj, uint32_t len, uint32_t newsize)
         newptr = obj_ivar_heap_realloc(obj, len, newsize);
     }
 
-    for (; len < newsize; len++) {
-        newptr[len] = Qundef;
-    }
 #if USE_RVARGC
     ROBJECT(obj)->numiv = newsize;
 #else


### PR DESCRIPTION
Shapes gives us an almost exact count of instance variables on an object.  Since we know the number of instance variables that have been set, we will never access slots that haven't been initialized with an IV.