### PR TITLE
Suppress warning for fgrep

### DIFF
--- a/template/Makefile.in
+++ b/template/Makefile.in
@@ -399,7 +399,7 @@ uncommon.mk: $(srcdir)/common.mk
 .PHONY: reconfig
 reconfig-args = $(srcdir)/$(CONFIGURE) $(yes_silence:yes=--silent) $(configure_args)
 config.status-args = ./config.status $(yes_silence:yes=--silent) --recheck
-reconfig-exec-0 = test -t 1 && { : $${CONFIGURE_TTY=yes}; export CONFIGURE_TTY; }; exec 3>&1; exit `exec 4>&1; { "$$@" 3>&- 4>&-; echo $$? 1>&4; } | fgrep -v '(cached)' 1>&3 3>&- 4>&-`
+reconfig-exec-0 = test -t 1 && { : $${CONFIGURE_TTY=yes}; export CONFIGURE_TTY; }; exec 3>&1; exit `exec 4>&1; { "$$@" 3>&- 4>&-; echo $$? 1>&4; } | grep -F -v '(cached)' 1>&3 3>&- 4>&-`
 reconfig-exec-1 = set -x; exec "$$@"
 reconfig-exec-yes = $(reconfig-exec-1)
 


### PR DESCRIPTION
```
fgrep: warning: fgrep is obsolescent; using ggrep -F
```

I'm not sure `grep -F` is the correct solution in the all of supported platforms.