### PR TITLE
Bypass git submodule add/update with protocol.file.allow=always option

### DIFF
--- a/test/rubygems/test_gem_source_git.rb
+++ b/test/rubygems/test_gem_source_git.rb
@@ -63,6 +63,11 @@ class TestGemSourceGit < Gem::TestCase
   end
 
   def test_checkout_submodules
+    # We need to allow to checkout submodules with file:// protocol
+    # CVE-2022-39253
+    # https://lore.kernel.org/lkml/xmqq4jw1uku5.fsf@gitster.g/
+    system(@git, *%W"config --global protocol.file.allow always")
+
     source = Gem::Source::Git.new @name, @repository, "master", true
 
     git_gem "b"


### PR DESCRIPTION
Git 2.38.1+ refuse `submodule add` and `subomodule update` with file protocol by default. I added bypass option for rubygems test. 