### PR TITLE
Avoid missed wakeup with fiber scheduler and Fiber.blocking.

### DIFF
--- a/test/fiber/scheduler.rb
+++ b/test/fiber/scheduler.rb
@@ -353,6 +353,7 @@ end
 
 class SleepingBlockingScheduler < Scheduler
   def kernel_sleep(duration = nil)
+    # Deliberaly sleep in a blocking state which can trigger a deadlock if the implementation is not correct.
     Fiber.blocking{sleep 0.0001}
 
     self.block(:sleep, duration)

--- a/test/fiber/scheduler.rb
+++ b/test/fiber/scheduler.rb
@@ -350,3 +350,13 @@ class SleepingUnblockScheduler < Scheduler
     sleep(0.1)
   end
 end
+
+class SleepingBlockingScheduler < Scheduler
+  def kernel_sleep(duration = nil)
+    Fiber.blocking{sleep 0.0001}
+
+    self.block(:sleep, duration)
+
+    return true
+  end
+end

--- a/thread.c
+++ b/thread.c
@@ -404,7 +404,7 @@ rb_threadptr_join_list_wakeup(rb_thread_t *thread)
 
         rb_thread_t *target_thread = join_list->thread;
 
-        if (target_thread->scheduler != Qnil && rb_fiberptr_blocking(join_list->fiber) == 0) {
+        if (target_thread->scheduler != Qnil && join_list->fiber) {
             rb_fiber_scheduler_unblock(target_thread->scheduler, target_thread->self, rb_fiberptr_self(join_list->fiber));
         }
         else {
@@ -1091,7 +1091,7 @@ thread_join(rb_thread_t *target_th, VALUE timeout, rb_hrtime_t *limit)
         struct rb_waiting_list waiter;
         waiter.next = target_th->join_list;
         waiter.thread = th;
-        waiter.fiber = fiber;
+        waiter.fiber = rb_fiberptr_blocking(fiber) ? NULL : fiber;
         target_th->join_list = &waiter;
 
         struct join_arg arg;

--- a/thread_sync.c
+++ b/thread_sync.c
@@ -446,7 +446,7 @@ rb_mutex_unlock_th(rb_mutex_t *mutex, rb_thread_t *th, rb_fiber_t *fiber)
         ccan_list_for_each_safe(&mutex->waitq, cur, next, node) {
             ccan_list_del_init(&cur->node);
 
-            if (cur->th->scheduler != Qnil && rb_fiberptr_blocking(cur->fiber) == 0) {
+            if (cur->th->scheduler != Qnil && cur->fiber) {
                 rb_fiber_scheduler_unblock(cur->th->scheduler, cur->self, rb_fiberptr_self(cur->fiber));
                 goto found;
             }


### PR DESCRIPTION
When we enter a sync wakeup, ensure that the fiber is only captured if it's non-blocking at the time of entry, rather than at the time of wakeup. Otherwise, if you inadvertently try to wake up a fiber which has invoked `Fiber.blocking`, you may deadlock. This only happens in very rare situations, the only reproduction I could make was blocking in `Scheduler#kernel_sleep`.