### PR TITLE
YJIT: fold the "asm_comments" feature into "disasm"

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3751,12 +3751,12 @@ AS_CASE(["${YJIT_SUPPORT}"],
     ],
     [dev], [
 	rb_rust_target_subdir=debug
-	CARGO_BUILD_ARGS='--features stats,disasm,asm_comments'
+	CARGO_BUILD_ARGS='--features stats,disasm'
 	AC_DEFINE(RUBY_DEBUG, 1)
     ],
     [dev_nodebug], [
 	rb_rust_target_subdir=dev_nodebug
-	CARGO_BUILD_ARGS='--profile dev_nodebug --features stats,disasm,asm_comments'
+	CARGO_BUILD_ARGS='--profile dev_nodebug --features stats,disasm'
     ],
     [stats], [
 	rb_rust_target_subdir=stats

--- a/yjit/Cargo.toml
+++ b/yjit/Cargo.toml
@@ -22,7 +22,6 @@ capstone = { version = "0.10.0", optional = true }
 # For debugging, `make V=1` shows exact cargo invocation.
 disasm = ["capstone"]
 stats = []
-asm_comments = []
 
 [profile.dev]
 opt-level = 0

--- a/yjit/src/asm/mod.rs
+++ b/yjit/src/asm/mod.rs
@@ -11,7 +11,7 @@ use crate::backend::ir::Assembler;
 use crate::backend::ir::Target;
 use crate::virtualmem::WriteError;
 
-#[cfg(feature = "asm_comments")]
+#[cfg(feature = "disasm")]
 use std::collections::BTreeMap;
 
 use crate::codegen::CodegenGlobals;
@@ -72,7 +72,7 @@ pub struct CodeBlock {
     label_refs: Vec<LabelRef>,
 
     // Comments for assembly instructions, if that feature is enabled
-    #[cfg(feature = "asm_comments")]
+    #[cfg(feature = "disasm")]
     asm_comments: BTreeMap<usize, Vec<String>>,
 
     // True for OutlinedCb
@@ -104,7 +104,7 @@ impl CodeBlock {
             label_addrs: Vec::new(),
             label_names: Vec::new(),
             label_refs: Vec::new(),
-            #[cfg(feature = "asm_comments")]
+            #[cfg(feature = "disasm")]
             asm_comments: BTreeMap::new(),
             outlined,
             dropped_bytes: false,
@@ -240,7 +240,7 @@ impl CodeBlock {
 
     /// Add an assembly comment if the feature is on.
     /// If not, this becomes an inline no-op.
-    #[cfg(feature = "asm_comments")]
+    #[cfg(feature = "disasm")]
     pub fn add_comment(&mut self, comment: &str) {
         let cur_ptr = self.get_write_ptr().into_usize();
 
@@ -252,11 +252,11 @@ impl CodeBlock {
             this_line_comments.push(comment.to_string());
         }
     }
-    #[cfg(not(feature = "asm_comments"))]
+    #[cfg(not(feature = "disasm"))]
     #[inline]
     pub fn add_comment(&mut self, _: &str) {}
 
-    #[cfg(feature = "asm_comments")]
+    #[cfg(feature = "disasm")]
     pub fn comments_at(&self, pos: usize) -> Option<&Vec<String>> {
         self.asm_comments.get(&pos)
     }

--- a/yjit/src/asm/x86_64/tests.rs
+++ b/yjit/src/asm/x86_64/tests.rs
@@ -413,7 +413,7 @@ fn basic_capstone_usage() -> std::result::Result<(), capstone::Error> {
 }
 
 #[test]
-#[cfg(feature = "asm_comments")]
+#[cfg(feature = "disasm")]
 fn block_comments() {
     let mut cb = super::CodeBlock::new_dummy(4096);
 

--- a/yjit/src/backend/arm64/mod.rs
+++ b/yjit/src/backend/arm64/mod.rs
@@ -724,7 +724,7 @@ impl Assembler
 
             match insn {
                 Insn::Comment(text) => {
-                    if cfg!(feature = "asm_comments") {
+                    if cfg!(feature = "disasm") {
                         cb.add_comment(text);
                     }
                 },

--- a/yjit/src/backend/x86_64/mod.rs
+++ b/yjit/src/backend/x86_64/mod.rs
@@ -388,7 +388,7 @@ impl Assembler
 
             match insn {
                 Insn::Comment(text) => {
-                    if cfg!(feature = "asm_comments") {
+                    if cfg!(feature = "disasm") {
                         cb.add_comment(text);
                     }
                 },

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -510,7 +510,7 @@ impl From<VALUE> for u16 {
 }
 
 /// Produce a Ruby string from a Rust string slice
-#[cfg(feature = "asm_comments")]
+#[cfg(feature = "disasm")]
 pub fn rust_str_to_ruby(str: &str) -> VALUE {
     unsafe { rb_utf8_str_new(str.as_ptr() as *const _, str.len() as i64) }
 }


### PR DESCRIPTION
Previously, enabling only "disasm" didn't actually build. Since these two features are closely related and we don't really use one without the other, let's simplify and merge the two features together.