### PR TITLE
YJIT: Skip dumping code for the other cb on --yjit-dump-disasm

### DIFF
--- a/yjit/src/asm/mod.rs
+++ b/yjit/src/asm/mod.rs
@@ -213,9 +213,8 @@ impl CodeBlock {
         self.page_end_reserve = old_page_end_reserve;
     }
 
-    #[cfg(target_arch = "aarch64")]
-    #[cfg(not(test))]
     /// Return the address ranges of a given address range that this CodeBlock can write.
+    #[cfg(any(feature = "disasm", target_arch = "aarch64"))]
     pub fn writable_addrs(&self, start_ptr: CodePtr, end_ptr: CodePtr) -> Vec<(usize, usize)> {
         let mut addrs = vec![];
         let mut start = start_ptr.raw_ptr() as usize;

--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -1094,7 +1094,7 @@ impl Assembler
     pub fn compile(self, cb: &mut CodeBlock) -> Vec<u32>
     {
         #[cfg(feature = "disasm")]
-        let start_addr = cb.get_write_ptr().raw_ptr();
+        let start_addr = cb.get_write_ptr();
 
         let alloc_regs = Self::get_alloc_regs();
         let gc_offsets = self.compile_with_regs(cb, alloc_regs);
@@ -1102,7 +1102,7 @@ impl Assembler
         #[cfg(feature = "disasm")]
         if let Some(dump_disasm) = get_option_ref!(dump_disasm) {
             use crate::disasm::dump_disasm_addr_range;
-            let end_addr = cb.get_write_ptr().raw_ptr();
+            let end_addr = cb.get_write_ptr();
             dump_disasm_addr_range(cb, start_addr, end_addr, dump_disasm)
         }
         gc_offsets


### PR DESCRIPTION
Following up https://github.com/ruby/ruby/pull/6460.

`dump_disasm_addr_range` currently dumps page-jump gaps between code blocks for the current cb, but it should be skipped for better readability of `--yjit-dump-disasm`.