### PR TITLE
Add Time#deconstruct_keys

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -225,6 +225,10 @@ Note: We're only listing outstanding class updates.
     * A Struct class can also be initialized with keyword arguments
       without `keyword_init: true` on `Struct.new` [[Feature #16806]]
 
+* Time
+    * `Time#deconstruct_keys` is added, allowing to use `Time` instances
+      in pattern-matching expressions [[Feature #19071]]
+
 * TracePoint
     * TracePoint#binding now returns `nil` for `c_call`/`c_return` TracePoints.
       [[Bug #18487]]
@@ -448,3 +452,4 @@ The following deprecated APIs are removed.
 [Feature #19070]: https://bugs.ruby-lang.org/issues/19070
 [Bug #19100]:     https://bugs.ruby-lang.org/issues/19100
 [Feature #19135]: https://bugs.ruby-lang.org/issues/19135
+[Feature #19071]: https://bugs.ruby-lang.org/issues/19071

--- a/common.mk
+++ b/common.mk
@@ -15833,6 +15833,7 @@ time.$(OBJEXT): $(top_srcdir)/internal/compar.h
 time.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 time.$(OBJEXT): $(top_srcdir)/internal/fixnum.h
 time.$(OBJEXT): $(top_srcdir)/internal/gc.h
+time.$(OBJEXT): $(top_srcdir)/internal/hash.h
 time.$(OBJEXT): $(top_srcdir)/internal/numeric.h
 time.$(OBJEXT): $(top_srcdir)/internal/rational.h
 time.$(OBJEXT): $(top_srcdir)/internal/serial.h

--- a/test/ruby/test_time.rb
+++ b/test/ruby/test_time.rb
@@ -1329,4 +1329,18 @@ class TestTime < Test::Unit::TestCase
   rescue LoadError => e
     omit "failed to load objspace: #{e.message}"
   end
+
+  def test_deconstruct_keys
+    t = in_timezone('JST-9') { Time.local(2022, 10, 16, 14, 1, 30, 500) }
+    assert_equal(
+      {year: 2022, month: 10, day: 16, wday: 0, yday: 289,
+        hour: 14, min: 1, sec: 30, subsec: 1/2000r, dst: false, zone: 'JST'},
+      t.deconstruct_keys(nil)
+    )
+
+    assert_equal(
+      {year: 2022, month: 10, sec: 30},
+      t.deconstruct_keys(%i[year month sec nonexistent])
+    )
+  end
 end

--- a/timev.rb
+++ b/timev.rb
@@ -201,6 +201,7 @@
 # - #getlocal: Returns a new time converted to local time.
 # - #utc (aliased as #gmtime): Converts time to UTC in place.
 # - #localtime: Converts time to local time in place.
+# - #deconstruct_keys: Returns a hash of time components used in pattern-matching.
 #
 # === Methods for Rounding
 #


### PR DESCRIPTION
I believe that `Time` being suitable for pattern-matching is a reasonable feature with many possible usages, which will increase usability of `Time` and would be a good show case for pattern matching.

**Implementation decisions**

**UPD:** As per [Matz's decision](https://bugs.ruby-lang.org/issues/19071#note-2), only `#deconstruct_keys` is implemented now.

`Time#deconstruct_keys`: 
* chosen keys: `[:year, :month, :day, :yday, :wday, :hour, :min, :sec, :subsec, :dst, :zone]` 
* I am open to discussing whether we should include other subsecond units (or any whatsoever)
* It might be useful (but too loose interface) to support `mon` as a synonym for `month`?.. But might be confusing if somebody will unpack the `**rest`
* `day`, not `mday`, seems most reasonable

Possible usages:
```ruby
case t
in year: ...2022
  puts "too old"
in month: ..9
  puts "quarter 1-3"
in wday: 1..5, month:
  puts "working day in month #{month}"
end

if t in Time(wday: 3, day: ..7)
  puts "first Wednesday of the month"
end
```

~~`Time#to_h`: added on a "why not" basis :) As we already have "convert to hash" in the form of `deconstruct_keys(nil)`, having a canonic form seems harmless. Open for discussion.~~
~~`Time#deconstruct`: returns time components in order `[year, month, mday, hour, min, sec, subsec]`~~