### PR TITLE
YJIT: Lazily enable YJIT after prelude

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -16771,6 +16771,7 @@ version.$(OBJEXT): $(hdrdir)/ruby.h
 version.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 version.$(OBJEXT): $(hdrdir)/ruby/version.h
 version.$(OBJEXT): $(top_srcdir)/internal/array.h
+version.$(OBJEXT): $(top_srcdir)/internal/cmdlineopt.h
 version.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 version.$(OBJEXT): $(top_srcdir)/internal/gc.h
 version.$(OBJEXT): $(top_srcdir)/internal/imemo.h

--- a/internal/cmdlineopt.h
+++ b/internal/cmdlineopt.h
@@ -26,9 +26,6 @@ typedef struct ruby_cmdline_options {
 #if USE_MJIT
     struct mjit_options mjit;
 #endif
-#if USE_YJIT
-    bool yjit;
-#endif
 
     int sflag, xflag;
     unsigned int warning: 1;
@@ -39,6 +36,9 @@ typedef struct ruby_cmdline_options {
     unsigned int do_split: 1;
     unsigned int do_search: 1;
     unsigned int setids: 2;
+#if USE_YJIT
+    unsigned int yjit: 1;
+#endif
 } ruby_cmdline_options_t;
 
 struct ruby_opt_message {

--- a/internal/cmdlineopt.h
+++ b/internal/cmdlineopt.h
@@ -26,6 +26,9 @@ typedef struct ruby_cmdline_options {
 #if USE_MJIT
     struct mjit_options mjit;
 #endif
+#if USE_YJIT
+    bool yjit;
+#endif
 
     int sflag, xflag;
     unsigned int warning: 1;

--- a/ruby.c
+++ b/ruby.c
@@ -72,7 +72,7 @@ STATIC_ASSERT(Qnil_1bit_from_Qfalse, singlebit_only_p(Qnil^Qfalse));
 # define O_ACCMODE (O_RDONLY | O_WRONLY | O_RDWR)
 #endif
 
-void Init_ruby_description(void);
+void Init_ruby_description(ruby_cmdline_options_t *opt);
 
 #ifndef HAVE_STDLIB_H
 char *getenv();
@@ -1613,13 +1613,8 @@ ruby_opt_init(ruby_cmdline_options_t *opt)
 
 #if USE_MJIT
     // rb_call_builtin_inits depends on RubyVM::MJIT.enabled?
-    if (opt->mjit.on) {
+    if (opt->mjit.on)
         mjit_enabled = true;
-        // rb_threadptr_root_fiber_setup for the initial thread is called before rb_yjit_enabled_p()
-        // or mjit_enabled becomes true, meaning jit_cont_new is skipped for the initial root fiber.
-        // Therefore we need to call this again here to set the initial root fiber's jit_cont.
-        rb_jit_cont_init(); // must be after mjit_enabled = true
-    }
 #endif
 
     Init_ext(); /* load statically linked extensions before rubygems */
@@ -1627,11 +1622,20 @@ ruby_opt_init(ruby_cmdline_options_t *opt)
     rb_call_builtin_inits();
     ruby_init_prelude();
 
+    // Initialize JITs after prelude because JITing prelude is typically not optimal.
 #if USE_MJIT
-    // mjit_init is safe only after rb_call_builtin_inits defines RubyVM::MJIT::Compiler
+    // Also, mjit_init is safe only after rb_call_builtin_inits() defines RubyVM::MJIT::Compiler.
     if (opt->mjit.on)
         mjit_init(&opt->mjit);
 #endif
+#if USE_YJIT
+    if (opt->yjit)
+        rb_yjit_init();
+#endif
+    // rb_threadptr_root_fiber_setup for the initial thread is called before rb_yjit_enabled_p()
+    // or mjit_enabled becomes true, meaning jit_cont_new is skipped for the initial root fiber.
+    // Therefore we need to call this again here to set the initial root fiber's jit_cont.
+    rb_jit_cont_init(); // must be after mjit_enabled = true and rb_yjit_init()
 
     ruby_set_script_name(opt->script_name);
     require_libraries(&opt->req_list);
@@ -1915,22 +1919,15 @@ process_options(int argc, char **argv, ruby_cmdline_options_t *opt)
 
 #if USE_MJIT
     if (FEATURE_SET_P(opt->features, mjit)) {
-        opt->mjit.on = true; // set mjit.on for ruby_show_version() API and check to call mjit_init()
+        opt->mjit.on = true; // set opt->mjit.on for Init_ruby_description() and calling mjit_init()
     }
 #endif
 #if USE_YJIT
     if (FEATURE_SET_P(opt->features, yjit)) {
-        rb_yjit_init();
-        // rb_threadptr_root_fiber_setup for the initial thread is called before rb_yjit_enabled_p()
-        // or mjit_enabled becomes true, meaning jit_cont_new is skipped for the initial root fiber.
-        // Therefore we need to call this again here to set the initial root fiber's jit_cont.
-        rb_jit_cont_init(); // must be after rb_yjit_init(), but before parsing options raises an exception.
+        opt->yjit = true; // set opt->yjit for Init_ruby_description() and calling rb_yjit_init()
     }
 #endif
-#if USE_MJIT
-    mjit_opts.on = opt->mjit.on; /* used by Init_ruby_description(). mjit_init() still can't be called here. */
-#endif
-    Init_ruby_description();
+    Init_ruby_description(opt);
     if (opt->dump & (DUMP_BIT(version) | DUMP_BIT(version_v))) {
         ruby_show_version();
         if (opt->dump & DUMP_BIT(version)) return Qtrue;

--- a/version.c
+++ b/version.c
@@ -9,6 +9,7 @@
 
 **********************************************************************/
 
+#include "internal/cmdlineopt.h"
 #include "ruby/ruby.h"
 #include "version.h"
 #include "vm_core.h"
@@ -121,13 +122,19 @@ Init_version(void)
 }
 
 #if USE_MJIT
-#define MJIT_OPTS_ON mjit_opts.on
+#define MJIT_OPTS_ON opt->mjit.on
 #else
 #define MJIT_OPTS_ON 0
 #endif
 
+#if USE_YJIT
+#define YJIT_OPTS_ON opt->yjit
+#else
+#define YJIT_OPTS_ON 0
+#endif
+
 void
-Init_ruby_description(void)
+Init_ruby_description(ruby_cmdline_options_t *opt)
 {
     VALUE description;
 
@@ -135,7 +142,7 @@ Init_ruby_description(void)
         rb_dynamic_description = ruby_description_with_mjit;
         description = MKSTR(description_with_mjit);
     }
-    else if (rb_yjit_enabled_p()) {
+    else if (YJIT_OPTS_ON) {
         rb_dynamic_description = ruby_description_with_yjit;
         description = MKSTR(description_with_yjit);
     }


### PR DESCRIPTION
Currently, YJIT compiles code for prelude as well. But some code used by prelude may not be used ever again after prelude, which could bring less localized code and unnecessary pressure on code GC.

JITing prelude seems just useless if it doesn't contribute to speeding up prelude. And the cost of JITing prelude seems to outweigh the JITed code's speedup. So I'd like to propose not JITing prelude.

### Before
```
$ time ruby -v --yjit -e ''
ruby 3.2.0dev (2022-10-20T00:45:36Z master 2e3b764ad1) +YJIT [arm64-darwin21]
ruby -v --yjit -e ''  0.05s user 0.02s system 91% cpu 0.071 total
```

### After
```
$ time ruby -v --yjit -e ''
ruby 3.2.0dev (2022-10-20T00:45:54Z yjit-lazy-init f60a1b4ce3) +YJIT [arm64-darwin21]
ruby -v --yjit -e ''  0.04s user 0.01s system 90% cpu 0.058 total
```

I've tried both multiple times, and this PR was reliably faster.