### PR TITLE
Define UNDEF_P and NIL_OR_UNDEF_P [EXPERIMENTAL]

### DIFF
--- a/include/ruby/internal/abi.h
+++ b/include/ruby/internal/abi.h
@@ -24,7 +24,7 @@
  * In released versions of Ruby, this number is not defined since teeny
  * versions of Ruby should guarantee ABI compatibility.
  */
-#define RUBY_ABI_VERSION 2
+#define RUBY_ABI_VERSION 3
 
 /* Windows does not support weak symbols so ruby_abi_version will not exist
  * in the shared library. */

--- a/include/ruby/internal/special_consts.h
+++ b/include/ruby/internal/special_consts.h
@@ -94,9 +94,9 @@ ruby_special_consts {
     RUBY_SYMBOL_FLAG,           /**< Flag to denote a static symbol. */
 #elif USE_FLONUM
     RUBY_Qfalse         = 0x00, /* ...0000 0000 */
+    RUBY_Qnil           = 0x04, /* ...0000 0100 */
     RUBY_Qtrue          = 0x14, /* ...0001 0100 */
-    RUBY_Qnil           = 0x08, /* ...0000 1000 */
-    RUBY_Qundef         = 0x34, /* ...0011 0100 */
+    RUBY_Qundef         = 0x24, /* ...0010 0100 */
     RUBY_IMMEDIATE_MASK = 0x07, /* ...0000 0111 */
     RUBY_FIXNUM_FLAG    = 0x01, /* ...xxxx xxx1 */
     RUBY_FLONUM_MASK    = 0x03, /* ...0000 0011 */
@@ -104,9 +104,9 @@ ruby_special_consts {
     RUBY_SYMBOL_FLAG    = 0x0c, /* ...xxxx 1100 */
 #else
     RUBY_Qfalse         = 0x00, /* ...0000 0000 */
-    RUBY_Qtrue          = 0x02, /* ...0000 0010 */
-    RUBY_Qnil           = 0x04, /* ...0000 0100 */
-    RUBY_Qundef         = 0x06, /* ...0000 0110 */
+    RUBY_Qnil           = 0x02, /* ...0000 0010 */
+    RUBY_Qtrue          = 0x06, /* ...0000 0110 */
+    RUBY_Qundef         = 0x0a, /* ...0000 1010 */
     RUBY_IMMEDIATE_MASK = 0x03, /* ...0000 0011 */
     RUBY_FIXNUM_FLAG    = 0x01, /* ...xxxx xxx1 */
     RUBY_FLONUM_MASK    = 0x00, /* any values ANDed with FLONUM_MASK cannot be FLONUM_FLAG */
@@ -138,19 +138,19 @@ RB_TEST(VALUE obj)
     /*
      * if USE_FLONUM
      *  Qfalse:  ....0000 0000
-     *  Qnil:    ....0000 1000
-     * ~Qnil:    ....1111 0111
-     *  v        ....xxxx xxxx
-     * ----------------------------
-     *  RTEST(v) ....xxxx 0xxx
-     *
-     * if ! USE_FLONUM
-     *  Qfalse:  ....0000 0000
      *  Qnil:    ....0000 0100
      * ~Qnil:    ....1111 1011
      *  v        ....xxxx xxxx
      * ----------------------------
      *  RTEST(v) ....xxxx x0xx
+     *
+     * if ! USE_FLONUM
+     *  Qfalse:  ....0000 0000
+     *  Qnil:    ....0000 0010
+     * ~Qnil:    ....1111 1101
+     *  v        ....xxxx xxxx
+     * ----------------------------
+     *  RTEST(v) ....xxxx xx0x
      *
      *  RTEST(v) can be 0 if and only if (v == Qfalse || v == Qnil).
      */

--- a/internal.h
+++ b/internal.h
@@ -25,6 +25,9 @@
 /* Prevent compiler from reordering access */
 #define ACCESS_ONCE(type,x) (*((volatile type *)&(x)))
 
+#define UNDEF_P         RB_UNDEF_P
+#define NIL_OR_UNDEF_P  RB_NIL_OR_UNDEF_P
+
 #include "ruby/ruby.h"
 
 /* Following macros were formerly defined in this header but moved to somewhere

--- a/ruby.c
+++ b/ruby.c
@@ -64,6 +64,7 @@
 
 #define singlebit_only_p(x) !((x) & ((x)-1))
 STATIC_ASSERT(Qnil_1bit_from_Qfalse, singlebit_only_p(Qnil^Qfalse));
+STATIC_ASSERT(Qundef_1bit_from_Qnil, singlebit_only_p(Qundef^Qnil));
 
 #ifndef MAXPATHLEN
 # define MAXPATHLEN 1024

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -3219,8 +3219,7 @@ fn gen_branchif(
     };
 
     // Test if any bit (outside of the Qnil bit) is on
-    // RUBY_Qfalse  /* ...0000 0000 */
-    // RUBY_Qnil    /* ...0000 1000 */
+    // See RB_TEST()
     let val_type = ctx.get_opnd_type(StackOpnd(0));
     let val_opnd = ctx.stack_pop(1);
 

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -597,11 +597,11 @@ where
 #[allow(non_upper_case_globals)]
 pub const Qfalse: VALUE = VALUE(0);
 #[allow(non_upper_case_globals)]
-pub const Qnil: VALUE = VALUE(8);
+pub const Qnil: VALUE = VALUE(4);
 #[allow(non_upper_case_globals)]
 pub const Qtrue: VALUE = VALUE(20);
 #[allow(non_upper_case_globals)]
-pub const Qundef: VALUE = VALUE(52);
+pub const Qundef: VALUE = VALUE(0x24);
 
 #[allow(unused)]
 mod manual_defs {


### PR DESCRIPTION
`NIL_OR_UNDEF_P` could be used to see if a keyword argument is not given or given `nil`.