### PR TITLE
Remove unused class serial

### DIFF
--- a/class.c
+++ b/class.c
@@ -208,9 +208,6 @@ class_alloc(VALUE flags, VALUE klass)
 
 #if USE_RVARGC
     memset(RCLASS_EXT(obj), 0, sizeof(rb_classext_t));
-# if SIZEOF_SERIAL_T != SIZEOF_VALUE
-    RCLASS(obj)->class_serial_ptr = ZALLOC(rb_serial_t);
-# endif
 #else
     obj->ptr = ZALLOC(rb_classext_t);
 #endif
@@ -226,7 +223,6 @@ class_alloc(VALUE flags, VALUE klass)
       RCLASS_MODULE_SUBCLASSES(obj) = NULL;
      */
     RCLASS_SET_ORIGIN((VALUE)obj, (VALUE)obj);
-    RCLASS_SERIAL(obj) = rb_next_class_serial();
     RB_OBJ_WRITE(obj, &RCLASS_REFINED_CLASS(obj), Qnil);
     RCLASS_ALLOCATOR(obj) = 0;
 
@@ -2143,9 +2139,7 @@ singleton_class_of(VALUE obj)
     klass = METACLASS_OF(obj);
     if (!(FL_TEST(klass, FL_SINGLETON) &&
           rb_attr_get(klass, id_attached) == obj)) {
-        rb_serial_t serial = RCLASS_SERIAL(klass);
         klass = rb_make_metaclass(obj, klass);
-        RCLASS_SERIAL(klass) = serial;
     }
 
     RB_FL_SET_RAW(klass, RB_OBJ_FROZEN_RAW(obj));

--- a/gc.c
+++ b/gc.c
@@ -3463,9 +3463,6 @@ obj_free(rb_objspace_t *objspace, VALUE obj)
         if (FL_TEST_RAW(obj, RCLASS_SUPERCLASSES_INCLUDE_SELF)) {
             xfree(RCLASS_SUPERCLASSES(obj));
         }
-#if SIZEOF_SERIAL_T != SIZEOF_VALUE && USE_RVARGC
-        xfree(RCLASS(obj)->class_serial_ptr);
-#endif
 
 #if !USE_RVARGC
         if (RCLASS_EXT(obj))

--- a/internal/class.h
+++ b/internal/class.h
@@ -40,9 +40,6 @@ struct rb_cvar_class_tbl_entry {
 
 struct rb_classext_struct {
     struct st_table *iv_tbl;
-#if SIZEOF_SERIAL_T == SIZEOF_VALUE /* otherwise m_tbl is in struct RClass */
-    struct rb_id_table *m_tbl;
-#endif
     struct rb_id_table *const_tbl;
     struct rb_id_table *callable_m_tbl;
     struct rb_id_table *cc_tbl; /* ID -> [[ci, cc1], cc2, ...] */
@@ -57,9 +54,6 @@ struct rb_classext_struct {
      * included. Hopefully that makes sense.
      */
     struct rb_subclass_entry *module_subclass_entry;
-#if SIZEOF_SERIAL_T != SIZEOF_VALUE && !USE_RVARGC /* otherwise class_serial is in struct RClass */
-    rb_serial_t class_serial;
-#endif
     const VALUE origin_;
     const VALUE refined_class;
     rb_alloc_func_t allocator;
@@ -73,18 +67,9 @@ struct rb_classext_struct {
 struct RClass {
     struct RBasic basic;
     VALUE super;
+    struct rb_id_table *m_tbl;
 #if !USE_RVARGC
     struct rb_classext_struct *ptr;
-#endif
-#if SIZEOF_SERIAL_T == SIZEOF_VALUE
-    /* Class serial is as wide as VALUE.  Place it here. */
-    rb_serial_t class_serial;
-#else
-    /* Class serial does not fit into struct RClass. Place m_tbl instead. */
-    struct rb_id_table *m_tbl;
-# if USE_RVARGC
-    rb_serial_t *class_serial_ptr;
-# endif
 #endif
 };
 
@@ -98,25 +83,12 @@ typedef struct rb_classext_struct rb_classext_t;
 #endif
 #define RCLASS_IV_TBL(c) (RCLASS_EXT(c)->iv_tbl)
 #define RCLASS_CONST_TBL(c) (RCLASS_EXT(c)->const_tbl)
-#if SIZEOF_SERIAL_T == SIZEOF_VALUE
-# define RCLASS_M_TBL(c) (RCLASS_EXT(c)->m_tbl)
-#else
-# define RCLASS_M_TBL(c) (RCLASS(c)->m_tbl)
-#endif
+#define RCLASS_M_TBL(c) (RCLASS(c)->m_tbl)
 #define RCLASS_CALLABLE_M_TBL(c) (RCLASS_EXT(c)->callable_m_tbl)
 #define RCLASS_CC_TBL(c) (RCLASS_EXT(c)->cc_tbl)
 #define RCLASS_CVC_TBL(c) (RCLASS_EXT(c)->cvc_tbl)
 #define RCLASS_ORIGIN(c) (RCLASS_EXT(c)->origin_)
 #define RCLASS_REFINED_CLASS(c) (RCLASS_EXT(c)->refined_class)
-#if SIZEOF_SERIAL_T == SIZEOF_VALUE
-# define RCLASS_SERIAL(c) (RCLASS(c)->class_serial)
-#else
-# if USE_RVARGC
-#  define RCLASS_SERIAL(c) (*RCLASS(c)->class_serial_ptr)
-# else
-#  define RCLASS_SERIAL(c) (RCLASS_EXT(c)->class_serial)
-# endif
-#endif
 #define RCLASS_INCLUDER(c) (RCLASS_EXT(c)->includer)
 #define RCLASS_SUBCLASS_ENTRY(c) (RCLASS_EXT(c)->subclass_entry)
 #define RCLASS_MODULE_SUBCLASS_ENTRY(c) (RCLASS_EXT(c)->module_subclass_entry)

--- a/internal/vm.h
+++ b/internal/vm.h
@@ -40,7 +40,6 @@ enum method_missing_reason {
 };
 
 /* vm_insnhelper.h */
-rb_serial_t rb_next_class_serial(void);
 VALUE rb_vm_push_frame_fname(struct rb_execution_context_struct *ec, VALUE fname);
 
 /* vm.c */

--- a/test/ruby/test_rubyvm.rb
+++ b/test/ruby/test_rubyvm.rb
@@ -4,11 +4,9 @@ require 'test/unit'
 class TestRubyVM < Test::Unit::TestCase
   def test_stat
     assert_kind_of Hash, RubyVM.stat
-    assert_kind_of Integer, RubyVM.stat[:class_serial]
 
     RubyVM.stat(stat = {})
     assert_not_empty stat
-    assert_equal stat[:class_serial], RubyVM.stat(:class_serial)
   end
 
   def test_stat_unknown

--- a/vm.c
+++ b/vm.c
@@ -488,13 +488,6 @@ jit_exec(rb_execution_context_t *ec)
 
 #define PROCDEBUG 0
 
-rb_serial_t
-rb_next_class_serial(void)
-{
-    rb_serial_t class_serial = NEXT_CLASS_SERIAL();
-    return class_serial;
-}
-
 VALUE rb_cRubyVM;
 VALUE rb_cThread;
 VALUE rb_mRubyVMFrozenCore;
@@ -532,7 +525,6 @@ unsigned int    ruby_vm_event_local_num;
 
 rb_serial_t ruby_vm_constant_cache_invalidations = 0;
 rb_serial_t ruby_vm_constant_cache_misses = 0;
-rb_serial_t ruby_vm_class_serial = 1;
 rb_serial_t ruby_vm_global_cvar_state = 1;
 
 static const struct rb_callcache vm_empty_cc = {
@@ -612,7 +604,6 @@ rb_dtrace_setup(rb_execution_context_t *ec, VALUE klass, ID id,
  *    {
  *      :constant_cache_invalidations=>2,
  *      :constant_cache_misses=>14,
- *      :class_serial=>546,
  *      :global_cvar_state=>27
  *    }
  *
@@ -624,7 +615,7 @@ rb_dtrace_setup(rb_execution_context_t *ec, VALUE klass, ID id,
 static VALUE
 vm_stat(int argc, VALUE *argv, VALUE self)
 {
-    static VALUE sym_constant_cache_invalidations, sym_constant_cache_misses, sym_class_serial, sym_global_cvar_state;
+    static VALUE sym_constant_cache_invalidations, sym_constant_cache_misses, sym_global_cvar_state;
     VALUE arg = Qnil;
     VALUE hash = Qnil, key = Qnil;
 
@@ -644,7 +635,6 @@ vm_stat(int argc, VALUE *argv, VALUE self)
 #define S(s) sym_##s = ID2SYM(rb_intern_const(#s))
     S(constant_cache_invalidations);
     S(constant_cache_misses);
-        S(class_serial);
         S(global_cvar_state);
 #undef S
 
@@ -656,7 +646,6 @@ vm_stat(int argc, VALUE *argv, VALUE self)
 
     SET(constant_cache_invalidations, ruby_vm_constant_cache_invalidations);
     SET(constant_cache_misses, ruby_vm_constant_cache_misses);
-    SET(class_serial, ruby_vm_class_serial);
     SET(global_cvar_state, ruby_vm_global_cvar_state);
 #undef SET
 

--- a/vm_insnhelper.h
+++ b/vm_insnhelper.h
@@ -16,7 +16,6 @@ MJIT_SYMBOL_EXPORT_BEGIN
 RUBY_EXTERN VALUE ruby_vm_const_missing_count;
 RUBY_EXTERN rb_serial_t ruby_vm_constant_cache_invalidations;
 RUBY_EXTERN rb_serial_t ruby_vm_constant_cache_misses;
-RUBY_EXTERN rb_serial_t ruby_vm_class_serial;
 RUBY_EXTERN rb_serial_t ruby_vm_global_cvar_state;
 
 MJIT_SYMBOL_EXPORT_END
@@ -182,8 +181,6 @@ CC_SET_FASTPATH(const struct rb_callcache *cc, vm_call_handler func, bool enable
 } while (0)
 #endif
 
-#define PREV_CLASS_SERIAL() (ruby_vm_class_serial)
-#define NEXT_CLASS_SERIAL() (++ruby_vm_class_serial)
 #define GET_GLOBAL_CVAR_STATE() (ruby_vm_global_cvar_state)
 #define INC_GLOBAL_CVAR_STATE() (++ruby_vm_global_cvar_state)
 


### PR DESCRIPTION
Before object shapes, we were using class serial to invalidate inline caches. Now that we use shape_id for inline cache keys, the class serial is unnecessary.

Co-Authored-By: Aaron Patterson <tenderlove@ruby-lang.org>