### PR TITLE
Move allocator callback into RClass

### DIFF
--- a/benchmark/object_allocate.yml
+++ b/benchmark/object_allocate.yml
@@ -18,4 +18,4 @@ benchmark:
   allocate_32_deep: ThirtyTwo.new
   allocate_64_deep: SixtyFour.new
   allocate_128_deep: OneTwentyEight.new
-loop_count: 100000
+loop_count: 1000000

--- a/internal/class.h
+++ b/internal/class.h
@@ -56,7 +56,9 @@ struct rb_classext_struct {
     struct rb_subclass_entry *module_subclass_entry;
     const VALUE origin_;
     const VALUE refined_class;
+#if !USE_RVARGC
     rb_alloc_func_t allocator;
+#endif
     const VALUE includer;
     uint32_t max_iv_count;
 #if !SHAPE_IN_BASIC_FLAGS
@@ -68,7 +70,9 @@ struct RClass {
     struct RBasic basic;
     VALUE super;
     struct rb_id_table *m_tbl;
-#if !USE_RVARGC
+#if USE_RVARGC
+    rb_alloc_func_t allocator;
+#else
     struct rb_classext_struct *ptr;
 #endif
 };
@@ -92,7 +96,11 @@ typedef struct rb_classext_struct rb_classext_t;
 #define RCLASS_INCLUDER(c) (RCLASS_EXT(c)->includer)
 #define RCLASS_SUBCLASS_ENTRY(c) (RCLASS_EXT(c)->subclass_entry)
 #define RCLASS_MODULE_SUBCLASS_ENTRY(c) (RCLASS_EXT(c)->module_subclass_entry)
-#define RCLASS_ALLOCATOR(c) (RCLASS_EXT(c)->allocator)
+#if USE_RVARGC
+  #define RCLASS_ALLOCATOR(c) (RCLASS(c)->allocator)
+#else
+  #define RCLASS_ALLOCATOR(c) (RCLASS_EXT(c)->allocator)
+#endif
 #define RCLASS_SUBCLASSES(c) (RCLASS_EXT(c)->subclasses)
 #define RCLASS_SUPERCLASS_DEPTH(c) (RCLASS_EXT(c)->superclass_depth)
 #define RCLASS_SUPERCLASSES(c) (RCLASS_EXT(c)->superclasses)


### PR DESCRIPTION
When RVARGC is enabled, we have an extra slot in RClass. Moving the
allocator into this slot is likely to improve cache locality on
allocations.

This also reduces the size of rb_classext_struct by 8 bytes.

Co-Authored-By: Aaron Patterson <tenderlove@ruby-lang.org>