### PR TITLE
Introduce `Fiber#storage` for inheritable fiber-scoped variables.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -102,6 +102,45 @@ Note that each entry is kept to a minimum, see links for details.
 
 Note: We're only listing outstanding class updates.
 
+* Fiber
+
+    * Introduce `Fiber.[]` and `Fiber.[]=` for inheritable fiber storage.
+      Introduce `Fiber#storage` and `Fiber#storage=` (experimental) for getting
+      and resetting the current storage. Introduce `Fiber.new(storage:)` for
+      setting the storage when creating a fiber. [[Feature #19078]]
+
+      Existing Thread and Fiber local variables can be tricky to use. Thread
+      local variables are shared between all fibers, making it hard to isolate,
+      while Fiber local variables can be hard to share. It is often desirable
+      to define unit of execution ("execution context") such that some state
+      is shared between all fibers and threads created in that context. This is
+      what Fiber storage provides.
+
+      ```ruby
+      def log(message)
+        puts "#{Fiber[:request_id]}: #{message}"
+      end
+      
+      def handle_requests
+        while request = read_request
+          Fiber.schedule do
+            Fiber[:request_id] = SecureRandom.uuid
+
+            request.messages.each do |message|
+              Fiber.schedule do
+                log("Handling #{message}") # Log includes inherited request_id.
+              end
+            end
+          end
+        end
+      end
+      ```
+
+      You should generally consider Fiber storage for any state which you want
+      to be shared implicitly between all fibers and threads created in a given
+      context, e.g. a connection pool, a request id, a logger level,
+      environment variables, configuration, etc.
+
 * Fiber::Scheduler
 
     * Introduce `Fiber::Scheduler#io_select` for non-blocking IO.select.
@@ -555,3 +594,4 @@ The following deprecated APIs are removed.
 [Bug #19100]:     https://bugs.ruby-lang.org/issues/19100
 [Feature #19135]: https://bugs.ruby-lang.org/issues/19135
 [Feature #19138]: https://bugs.ruby-lang.org/issues/19138
+[Feature #19078]: https://bugs.ruby-lang.org/issues/19078

--- a/cont.c
+++ b/cont.c
@@ -2104,6 +2104,9 @@ rb_fiber_storage_set(VALUE self, VALUE value)
  *
  *  Returns the value of the fiber-local variable identified by +key+.
  *
+ *  The +key+ must be a symbol, and the value is set by Fiber#[]= or
+ *  Fiber#store.
+ *
  *  See also Fiber[]=.
  */
 static VALUE
@@ -2112,6 +2115,10 @@ rb_fiber_storage_aref(VALUE class, VALUE key)
     VALUE storage = fiber_storage_get(fiber_current());
 
     if (storage == Qnil) return Qnil;
+
+    if (!RB_TYPE_P(key, T_SYMBOL)) {
+        rb_raise(rb_eTypeError, "The given key must be a Symbol!");
+    }
 
     if (RB_TYPE_P(storage, T_HASH)) {
         return rb_hash_aref(storage, key);
@@ -2126,12 +2133,18 @@ rb_fiber_storage_aref(VALUE class, VALUE key)
  *  Assign +value+ to the fiber-local variable identified by +key+.
  *  The variable is created if it doesn't exist.
  *
+ *  +key+ must be a Symbol, otherwise a TypeError is raised.
+ *
  *  See also Fiber[].
  */
 static VALUE
 rb_fiber_storage_aset(VALUE class, VALUE key, VALUE value)
 {
     VALUE storage = fiber_storage_get(fiber_current());
+
+    if (!RB_TYPE_P(key, T_SYMBOL)) {
+        rb_raise(rb_eTypeError, "The given key must be a Symbol!");
+    }
 
     if (RB_TYPE_P(storage, T_HASH)) {
         return rb_hash_aset(storage, key, value);

--- a/cont.c
+++ b/cont.c
@@ -2333,7 +2333,7 @@ rb_fiber_new_storage(rb_block_call_func_t func, VALUE obj, VALUE storage)
 VALUE
 rb_fiber_new(rb_block_call_func_t func, VALUE obj)
 {
-    return rb_fiber_new_storage(func, obj, inherit_fiber_storage());
+    return rb_fiber_new_storage(func, obj, Qtrue);
 }
 
 static VALUE

--- a/enumerator.c
+++ b/enumerator.c
@@ -766,7 +766,8 @@ next_init(VALUE obj, struct enumerator *e)
 {
     VALUE curr = rb_fiber_current();
     e->dst = curr;
-    e->fib = rb_fiber_new(next_i, obj);
+    // We inherit the fiber storage by reference, not by copy, by specifying Qfalse here.
+    e->fib = rb_fiber_new_storage(next_i, obj, Qfalse);
     e->lookahead = Qundef;
 }
 

--- a/include/ruby/internal/intern/cont.h
+++ b/include/ruby/internal/intern/cont.h
@@ -41,7 +41,16 @@ VALUE rb_fiber_new(rb_block_call_func_t func, VALUE callback_obj);
 /**
  * Creates a Fiber instance from a C-backended block with the specified storage.
  *
- * If the given storage is nil, this function is equivalent to rb_fiber_new().
+ * If the given storage is Qundef, this function is equivalent to
+ * rb_fiber_new() which inherits storage from the current fiber.
+ *
+ * If the given storage is Qfalse, this function uses the current fiber's
+ * storage by reference.
+ *
+ * If the given storage is Qnil, this function will lazy initialize the
+ * internal storage which starts of empty (without any inheritance).
+ *
+ * Otherwise, the given storage is used as the internal storage.
  *
  * @param[in]  func          A function, to become the fiber's body.
  * @param[in]  callback_obj  Passed as-is to `func`.

--- a/include/ruby/internal/intern/cont.h
+++ b/include/ruby/internal/intern/cont.h
@@ -39,6 +39,18 @@ RBIMPL_SYMBOL_EXPORT_BEGIN()
 VALUE rb_fiber_new(rb_block_call_func_t func, VALUE callback_obj);
 
 /**
+ * Creates a Fiber instance from a C-backended block with the specified storage.
+ *
+ * If the given storage is nil, this function is equivalent to rb_fiber_new().
+ *
+ * @param[in]  func          A function, to become the fiber's body.
+ * @param[in]  callback_obj  Passed as-is to `func`.
+ * @return     An allocated  new instance  of rb_cFiber, which  is ready  to be
+ *             "resume"d.
+ */
+VALUE rb_fiber_new_storage(rb_block_call_func_t func, VALUE callback_obj, VALUE storage);
+
+/**
  * Queries  the fiber  which  is  calling this  function.   Any ruby  execution
  * context has its fiber, either explicitly or implicitly.
  *

--- a/internal/cont.h
+++ b/internal/cont.h
@@ -22,6 +22,9 @@ void rb_jit_cont_init(void);
 void rb_jit_cont_each_iseq(rb_iseq_callback callback, void *data);
 void rb_jit_cont_finish(void);
 
+// Copy locals from the current execution to the specified fiber.
+VALUE rb_fiber_inherit_storage(struct rb_execution_context_struct *ec, struct rb_fiber_struct *fiber);
+
 VALUE rb_fiberptr_self(struct rb_fiber_struct *fiber);
 unsigned int rb_fiberptr_blocking(struct rb_fiber_struct *fiber);
 struct rb_execution_context_struct * rb_fiberptr_get_ec(struct rb_fiber_struct *fiber);

--- a/mjit_c.rb
+++ b/mjit_c.rb
@@ -442,6 +442,7 @@ module RubyVM::MJIT
       local_storage: [CType::Pointer.new { self.rb_id_table }, Primitive.cexpr!("OFFSETOF((*((struct rb_execution_context_struct *)NULL)), local_storage)")],
       local_storage_recursive_hash: [self.VALUE, Primitive.cexpr!("OFFSETOF((*((struct rb_execution_context_struct *)NULL)), local_storage_recursive_hash)")],
       local_storage_recursive_hash_for_trace: [self.VALUE, Primitive.cexpr!("OFFSETOF((*((struct rb_execution_context_struct *)NULL)), local_storage_recursive_hash_for_trace)")],
+      storage: [self.VALUE, Primitive.cexpr!("OFFSETOF((*((struct rb_execution_context_struct *)NULL)), storage)")],
       root_lep: [CType::Pointer.new { self.VALUE }, Primitive.cexpr!("OFFSETOF((*((struct rb_execution_context_struct *)NULL)), root_lep)")],
       root_svar: [self.VALUE, Primitive.cexpr!("OFFSETOF((*((struct rb_execution_context_struct *)NULL)), root_svar)")],
       ensure_list: [CType::Pointer.new { self.rb_ensure_list_t }, Primitive.cexpr!("OFFSETOF((*((struct rb_execution_context_struct *)NULL)), ensure_list)")],

--- a/test/fiber/test_storage.rb
+++ b/test/fiber/test_storage.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+require 'test/unit'
+
+class TestFiberStorage < Test::Unit::TestCase
+  def test_storage
+    Fiber.new do
+      Fiber[:x] = 10
+      assert_kind_of Hash, Fiber.current.storage
+      assert_predicate Fiber.current.storage, :any?
+    end.resume
+  end
+
+  def test_storage_inherited
+    Fiber.new do
+      Fiber[:foo] = :bar
+
+      Fiber.new do
+        assert_equal :bar, Fiber[:foo]
+        Fiber[:bar] = :baz
+      end.resume
+
+      assert_nil Fiber[:bar]
+    end.resume
+  end
+
+  def test_variable_assignment
+    Fiber.new do
+      Fiber[:foo] = :bar
+      assert_equal :bar, Fiber[:foo]
+    end.resume
+  end
+
+  def test_storage_assignment
+    Fiber.new do
+      Fiber.current.storage = {foo: :bar}
+      assert_equal :bar, Fiber[:foo]
+    end.resume
+  end
+
+  def test_inherited_storage
+    Fiber.new do
+      Fiber.current.storage = {foo: :bar}
+      f = Fiber.new do
+        assert_equal :bar, Fiber[:foo]
+      end
+      f.resume
+    end.resume
+  end
+
+  def test_enumerator_inherited_storage
+    Fiber.new do
+      Fiber[:item] = "Hello World"
+
+      enumerator = Enumerator.new do |out|
+        out << Fiber.current
+        out << Fiber[:item]
+      end
+
+      # The fiber within the enumerator is not equal to the current...
+      assert_not_equal Fiber.current, enumerator.next
+
+      # But it inherited the storage from the current fiber:
+      assert_equal "Hello World", enumerator.next
+    end.resume
+  end
+
+  def test_thread_inherited_storage
+    Fiber.new do
+      Fiber[:x] = 10
+
+      x = Thread.new do
+        Fiber[:y] = 20
+        Fiber[:x]
+      end.value
+
+      assert_equal 10, x
+      assert_equal nil, Fiber[:y]
+    end.resume
+  end
+
+  def test_enumerator_count
+    Fiber.new do
+      Fiber[:count] = 0
+
+      enumerator = Enumerator.new do |y|
+        # Since the fiber is implementation detail, the storage are shared with the parent:
+        Fiber[:count] += 1
+        y << Fiber[:count]
+      end
+
+      assert_equal 1, enumerator.next
+      assert_equal 1, Fiber[:count]
+    end.resume
+  end
+end

--- a/test/fiber/test_storage.rb
+++ b/test/fiber/test_storage.rb
@@ -92,4 +92,10 @@ class TestFiberStorage < Test::Unit::TestCase
       assert_equal 1, Fiber[:count]
     end.resume
   end
+
+  def test_storage_assignment_type_error
+    assert_raise(TypeError) do
+      Fiber.new(storage: {"foo" => "bar"}) {}
+    end
+  end
 end

--- a/test/fiber/test_storage.rb
+++ b/test/fiber/test_storage.rb
@@ -95,7 +95,7 @@ class TestFiberStorage < Test::Unit::TestCase
 
   def test_storage_assignment_type_error
     assert_raise(TypeError) do
-      Fiber.new(storage: {"foo" => "bar"}) {}
+      Fiber.new(storage: {Object.new => "bar"}) {}
     end
   end
 end

--- a/thread.c
+++ b/thread.c
@@ -813,6 +813,8 @@ thread_create_core(VALUE thval, struct thread_create_params *params)
                  "can't start a new thread (frozen ThreadGroup)");
     }
 
+    rb_fiber_inherit_storage(ec, th->ec->fiber_ptr);
+
     switch (params->type) {
       case thread_invoke_type_proc:
         th->invoke_type = thread_invoke_type_proc;

--- a/vm.c
+++ b/vm.c
@@ -3047,7 +3047,7 @@ vm_init2(rb_vm_t *vm)
 }
 
 void
-rb_execution_context_update(const rb_execution_context_t *ec)
+rb_execution_context_update(rb_execution_context_t *ec)
 {
     /* update VM stack */
     if (ec->vm_stack) {
@@ -3087,6 +3087,8 @@ rb_execution_context_update(const rb_execution_context_t *ec)
             cfp = RUBY_VM_PREVIOUS_CONTROL_FRAME(cfp);
         }
     }
+
+    ec->storage = rb_gc_location(ec->storage);
 }
 
 static enum rb_id_table_iterator_result
@@ -3154,6 +3156,8 @@ rb_execution_context_mark(const rb_execution_context_t *ec)
     RUBY_MARK_UNLESS_NULL(ec->local_storage_recursive_hash);
     RUBY_MARK_UNLESS_NULL(ec->local_storage_recursive_hash_for_trace);
     RUBY_MARK_UNLESS_NULL(ec->private_const_reference);
+
+    RUBY_MARK_MOVABLE_UNLESS_NULL(ec->storage);
 }
 
 void rb_fiber_mark_self(rb_fiber_t *fib);
@@ -3343,6 +3347,8 @@ th_init(rb_thread_t *th, VALUE self, rb_vm_t *vm)
     th->ec->root_svar = Qfalse;
     th->ec->local_storage_recursive_hash = Qnil;
     th->ec->local_storage_recursive_hash_for_trace = Qnil;
+
+    th->ec->storage = Qnil;
 
 #if OPT_CALL_THREADED_CODE
     th->retval = Qundef;

--- a/vm_core.h
+++ b/vm_core.h
@@ -968,6 +968,9 @@ struct rb_execution_context_struct {
     VALUE local_storage_recursive_hash;
     VALUE local_storage_recursive_hash_for_trace;
 
+    /* Inheritable fiber storage. */
+    VALUE storage;
+
     /* eval env */
     const VALUE *root_lep;
     VALUE root_svar;
@@ -2010,7 +2013,7 @@ void rb_threadptr_pending_interrupt_clear(rb_thread_t *th);
 void rb_threadptr_pending_interrupt_enque(rb_thread_t *th, VALUE v);
 VALUE rb_ec_get_errinfo(const rb_execution_context_t *ec);
 void rb_ec_error_print(rb_execution_context_t * volatile ec, volatile VALUE errinfo);
-void rb_execution_context_update(const rb_execution_context_t *ec);
+void rb_execution_context_update(rb_execution_context_t *ec);
 void rb_execution_context_mark(const rb_execution_context_t *ec);
 void rb_fiber_close(rb_fiber_t *fib);
 void Init_native_thread(rb_thread_t *th);


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/19078