### PR TITLE
Fix per-instance Regexp timeout

### DIFF
--- a/hrtime.h
+++ b/hrtime.h
@@ -206,6 +206,7 @@ double2hrtime(rb_hrtime_t *hrt, double d)
     const double TIMESPEC_SEC_MAX_PLUS_ONE = 2.0 * (TIMESPEC_SEC_MAX_as_double / 2.0 + 1.0);
 
     if (TIMESPEC_SEC_MAX_PLUS_ONE <= d) {
+        *hrt = RB_HRTIME_MAX;
         return NULL;
     }
     else if (d <= 0) {

--- a/re.c
+++ b/re.c
@@ -3772,6 +3772,8 @@ str_to_option(VALUE str)
  *  If optional keyword argument +timeout+ is given,
  *  its float value overrides the timeout interval for the class,
  *  Regexp.timeout.
+ *  If +nil+ is passed as +timeout, it uses the timeout interval
+ *  for the class, Regexp.timeout.
  *
  *  With argument +regexp+ given, returns a new regexp. The source,
  *  options, timeout are the same as +regexp+. +options+ and +n_flag+
@@ -3847,7 +3849,9 @@ rb_reg_initialize_m(int argc, VALUE *argv, VALUE self)
 
     {
         double limit = NIL_P(timeout) ? 0.0 : NUM2DBL(timeout);
-        if (limit < 0) limit = 0;
+        if (!NIL_P(timeout) && limit <= 0) {
+            rb_raise(rb_eArgError, "invalid timeout: %"PRIsVALUE, timeout);
+        }
         double2hrtime(&reg->timelimit, limit);
     }
 
@@ -4478,7 +4482,9 @@ rb_reg_s_timeout_set(VALUE dummy, VALUE limit)
 
     rb_ractor_ensure_main_ractor("can not access Regexp.timeout from non-main Ractors");
 
-    if (timeout < 0) timeout = 0;
+    if (!NIL_P(limit) && timeout <= 0) {
+        rb_raise(rb_eArgError, "invalid timeout: %"PRIsVALUE, limit);
+    }
     double2hrtime(&rb_reg_match_time_limit, timeout);
 
     return limit;


### PR DESCRIPTION
This makes it follow what was decided in [Bug #19055]:

* `Regexp.new(str, timeout: nil)` should respect the global timeout
* `Regexp.new(str, timeout: huge_val)` should use the maximum value that can be represented in the internal representation
* `Regexp.new(str, timeout: 0 or negative value)` should raise an error