### PR TITLE
Reuse `RBOOL` macro in `rb_ivar_defined` function

### DIFF
--- a/variable.c
+++ b/variable.c
@@ -1594,12 +1594,7 @@ rb_ivar_defined(VALUE obj, ID id)
     switch (BUILTIN_TYPE(obj)) {
       case T_CLASS:
       case T_MODULE:
-        if (RCLASS_IV_TBL(obj) && lock_st_is_member(RCLASS_IV_TBL(obj), (st_data_t)id)) {
-            return Qtrue;
-        }
-        else {
-            return Qfalse;
-        }
+        return RBOOL(RCLASS_IV_TBL(obj) && lock_st_is_member(RCLASS_IV_TBL(obj), (st_data_t)id));
       default:
         return RBOOL(rb_shape_get_iv_index(rb_shape_get_shape(obj), id, &index));
     }


### PR DESCRIPTION
In `rb_ivar_defined` function can reuse `RBOOL` macro.
I thought better and more simple that reuse `RBOOL` macro.