### PR TITLE
Use CXX14 to allow constexpr with non-return statements

### DIFF
--- a/include/ruby/internal/special_consts.h
+++ b/include/ruby/internal/special_consts.h
@@ -192,7 +192,7 @@ RB_UNDEF_P(VALUE obj)
 }
 
 RBIMPL_ATTR_CONST()
-RBIMPL_ATTR_CONSTEXPR(CXX11)
+RBIMPL_ATTR_CONSTEXPR(CXX14)
 RBIMPL_ATTR_ARTIFICIAL()
 /**
  * Checks if the given object is nil or undef.  Can be used to see if


### PR DESCRIPTION
This broke C extensions which were building with C++11

`/workspace/github/vendor/ruby/bcb72f503c311e214545e77906efbbadd8313068/include/ruby-3.2.0+3/ruby/internal/special_consts.h:232:1:
error: body of constexpr function constexpr bool RB_NIL_OR_UNDEF_P(VALUE) not
a return-statement`