### PR TITLE
[Bug #19081] Show the caller location in warning for Ractor

### DIFF
--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -1618,4 +1618,10 @@ assert_equal "ok", %q{
   "ok"
 }
 
+assert_match /\Atest_ractor\.rb:1:\s+warning:\s+Ractor is experimental/, %q{
+  Warning[:experimental] = $VERBOSE = true
+  STDERR.reopen(STDOUT)
+  eval("Ractor.new{}.take", nil, "test_ractor.rb", 1)
+}
+
 end # if !ENV['GITHUB_WORKFLOW']

--- a/ractor.c
+++ b/ractor.c
@@ -1438,12 +1438,6 @@ cancel_single_ractor_mode(void)
     }
 
     ruby_single_main_ractor = NULL;
-
-    if (rb_warning_category_enabled_p(RB_WARN_CATEGORY_EXPERIMENTAL)) {
-        rb_category_warn(RB_WARN_CATEGORY_EXPERIMENTAL,
-                         "Ractor is experimental, and the behavior may change in future versions of Ruby! "
-                         "Also there are many implementation issues.");
-    }
 }
 
 static void

--- a/ractor.rb
+++ b/ractor.rb
@@ -262,6 +262,10 @@ class Ractor
   def self.new(*args, name: nil, &block)
     b = block # TODO: builtin bug
     raise ArgumentError, "must be called with a block" unless block
+    if __builtin_cexpr!("RBOOL(ruby_single_main_ractor)")
+      warn("Ractor is experimental, and the behavior may change in future versions of Ruby! " \
+           "Also there are many implementation issues.", uplevel: 0, category: :experimental)
+    end
     loc = caller_locations(1, 1).first
     loc = "#{loc.path}:#{loc.lineno}"
     __builtin_ractor_create(loc, name, args, b)


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/19081

The internal location in ractor.rb is not usefull at all.
```sh-session
$ ruby -e 'Ractor.new {}'
<internal:ractor>:267: warning: Ractor is experimental, ...
```