### PR TITLE
YJIT: Invalidate i-cache for the other cb on next_page

### DIFF
--- a/yjit/src/asm/mod.rs
+++ b/yjit/src/asm/mod.rs
@@ -134,15 +134,7 @@ impl CodeBlock {
         }
 
         // Move the other CodeBlock to the same page if it'S on the furthest page
-        self.other_cb().unwrap().set_page(next_page_idx.unwrap(), &|other_cb, dst_ptr| {
-            // compile_with_regs will not invalidate i-cache for other_cb. Doing it there could
-            // result in invalidating a lot more than necessary when other_cb jumps from a
-            // position early in the page, which cannot be filtered by writable_addrs well.
-            // So invalidating it here is more efficient than that.
-            other_cb.with_icache_invalidation(|other_cb| {
-                jmp_ptr(other_cb, dst_ptr);
-            });
-        });
+        self.other_cb().unwrap().set_page(next_page_idx.unwrap(), &jmp_ptr);
 
         return !self.dropped_bytes;
     }
@@ -268,18 +260,6 @@ impl CodeBlock {
             self.page_size
         };
         page_end - self.page_end_reserve // reserve space to jump to the next page
-    }
-
-    fn with_icache_invalidation<F: Fn(&mut Self)>(&mut self, block: F) {
-        #[cfg(all(not(test), target_arch = "aarch64"))]
-        let start = self.get_write_ptr();
-        block(self);
-        #[cfg(all(not(test), target_arch = "aarch64"))]
-        {
-            let end = self.get_write_ptr();
-            use crate::cruby::rb_yjit_icache_invalidate;
-            unsafe { rb_yjit_icache_invalidate(start.raw_ptr() as _, end.raw_ptr() as _) };
-        }
     }
 
     /// Call a given function with page_end_reserve = 0

--- a/yjit/src/backend/arm64/mod.rs
+++ b/yjit/src/backend/arm64/mod.rs
@@ -708,6 +708,23 @@ impl Assembler
             }
         }
 
+        /// Call emit_jmp_ptr and immediately invalidate the written range.
+        /// This is needed when next_page also moves other_cb that is not invalidated
+        /// by compile_with_regs. Doing it here allows you to avoid invalidating a lot
+        /// more than necessary when other_cb jumps from a position early in the page.
+        /// This invalidates a small range of cb twice, but we accept the small cost.
+        fn emit_jmp_ptr_with_invalidation(cb: &mut CodeBlock, dst_ptr: CodePtr) {
+            #[cfg(not(test))]
+            let start = cb.get_write_ptr();
+            emit_jmp_ptr(cb, dst_ptr);
+            #[cfg(not(test))]
+            {
+                let end = cb.get_write_ptr();
+                use crate::cruby::rb_yjit_icache_invalidate;
+                unsafe { rb_yjit_icache_invalidate(start.raw_ptr() as _, end.raw_ptr() as _) };
+            }
+        }
+
         // dbg!(&self.insns);
 
         // List of GC offsets
@@ -1018,7 +1035,7 @@ impl Assembler
             };
 
             // On failure, jump to the next page and retry the current insn
-            if !had_dropped_bytes && cb.has_dropped_bytes() && cb.next_page(src_ptr, emit_jmp_ptr) {
+            if !had_dropped_bytes && cb.has_dropped_bytes() && cb.next_page(src_ptr, emit_jmp_ptr_with_invalidation) {
                 // Reset cb states before retrying the current Insn
                 cb.set_label_state(old_label_state);
             } else {
@@ -1042,7 +1059,6 @@ impl Assembler
         }
 
         let start_ptr = cb.get_write_ptr();
-        let other_start_ptr = cb.other_cb().map(|other_cb| other_cb.get_write_ptr());
         let gc_offsets = asm.arm64_emit(cb);
 
         if cb.has_dropped_bytes() {

--- a/yjit/src/backend/arm64/mod.rs
+++ b/yjit/src/backend/arm64/mod.rs
@@ -1059,16 +1059,6 @@ impl Assembler
                     unsafe { rb_yjit_icache_invalidate(start as _, end as _) };
                 }
             });
-
-            // CodeBlock#next_page could generate code for the other cb as well
-            #[cfg(not(test))]
-            if other_start_ptr != cb.other_cb().map(|other_cb| other_cb.get_write_ptr()) {
-                cb.other_cb().unwrap().without_page_end_reserve(|other_cb| {
-                    for (start, end) in other_cb.writable_addrs(other_start_ptr.unwrap(), other_cb.get_write_ptr()) {
-                        unsafe { rb_yjit_icache_invalidate(start as _, end as _) };
-                    }
-                });
-            }
         }
 
         gc_offsets

--- a/yjit/src/backend/arm64/mod.rs
+++ b/yjit/src/backend/arm64/mod.rs
@@ -1042,6 +1042,7 @@ impl Assembler
         }
 
         let start_ptr = cb.get_write_ptr();
+        let other_start_ptr = cb.other_cb().map(|other_cb| other_cb.get_write_ptr());
         let gc_offsets = asm.arm64_emit(cb);
 
         if cb.has_dropped_bytes() {
@@ -1058,6 +1059,16 @@ impl Assembler
                     unsafe { rb_yjit_icache_invalidate(start as _, end as _) };
                 }
             });
+
+            // CodeBlock#next_page could generate code for the other cb as well
+            #[cfg(not(test))]
+            if other_start_ptr != cb.other_cb().map(|other_cb| other_cb.get_write_ptr()) {
+                cb.other_cb().unwrap().without_page_end_reserve(|other_cb| {
+                    for (start, end) in other_cb.writable_addrs(other_start_ptr.unwrap(), other_cb.get_write_ptr()) {
+                        unsafe { rb_yjit_icache_invalidate(start as _, end as _) };
+                    }
+                });
+            }
         }
 
         gc_offsets


### PR DESCRIPTION
Follows up https://github.com/ruby/ruby/pull/6460.

`cb.next_page()` could also write some code on `cb.other_cb()`, and we currently don't invalidate its i-cache on Arm. This PR fixes that problem to avoid Illegal instruction crashes. I confirmed that running yjit-bench's optcarrot on lldb stops reproducing the problem with this patch.