### PR TITLE
[win32] Only include base windows types

### DIFF
--- a/win32/dir.h
+++ b/win32/dir.h
@@ -1,7 +1,7 @@
 #ifndef RUBY_WIN32_DIR_H
 #define RUBY_WIN32_DIR_H
 #include <stdint.h>             /* for uint8_t */
-#include <esent.h>              /* for WCHAR */
+#include <basetsd.h>            /* for WCHAR */
 #include "ruby/encoding.h"      /* for rb_encoding */
 
 #define DT_UNKNOWN 0


### PR DESCRIPTION
esent.h is the header for MS essential storage engine (JET) which is not needed in ruby. basetsd.h has existed since _MSC_VER >= 1200 (VS 6.0) and is the preferred header to use for WCHAR.