### PR TITLE
Add NEWS entries about YJIT [ci skip]

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -324,6 +324,12 @@ The following deprecated APIs are removed.
 
 * Support arm64 / aarch64 on UNIX platforms.
 * Building YJIT requires Rust 1.58.1+. [[Feature #18481]]
+* Physical memory for JIT code is lazily allocated. Unlike Ruby 3.1,
+  the RSS of a Ruby process is minimized because virtual memory pages
+  allocated by `--yjit-exec-mem-size` will not be mapped to physical
+  memory pages until actually utilized by JIT code.
+* Introduce Code GC that frees all code pages when the memory consumption
+  by JIT code reaches `--yjit-exec-mem-size`.
 
 ### MJIT
 


### PR DESCRIPTION
Added entries about https://github.com/ruby/ruby/pull/5944 and https://github.com/ruby/ruby/pull/6406.