### PR TITLE
Implement object shapes for T_CLASS and T_MODULE

### DIFF
--- a/class.c
+++ b/class.c
@@ -213,7 +213,6 @@ class_alloc(VALUE flags, VALUE klass)
 #endif
 
     /* ZALLOC
-      RCLASS_IV_TBL(obj) = 0;
       RCLASS_CONST_TBL(obj) = 0;
       RCLASS_M_TBL(obj) = 0;
       RCLASS_IV_INDEX_TBL(obj) = 0;
@@ -402,16 +401,12 @@ class_init_copy_check(VALUE clone, VALUE orig)
 static void
 copy_tables(VALUE clone, VALUE orig)
 {
-    if (RCLASS_IV_TBL(clone)) {
-        st_free_table(RCLASS_IV_TBL(clone));
-        RCLASS_IV_TBL(clone) = 0;
-    }
     if (RCLASS_CONST_TBL(clone)) {
         rb_free_const_table(RCLASS_CONST_TBL(clone));
         RCLASS_CONST_TBL(clone) = 0;
     }
     RCLASS_M_TBL(clone) = 0;
-    if (RCLASS_IV_TBL(orig)) {
+    {
         st_data_t id;
 
         rb_iv_tbl_copy(clone, orig);
@@ -520,7 +515,6 @@ rb_mod_init_copy(VALUE clone, VALUE orig)
             prev_clone_p = clone_p;
             RCLASS_M_TBL(clone_p) = RCLASS_M_TBL(p);
             RCLASS_CONST_TBL(clone_p) = RCLASS_CONST_TBL(p);
-            RCLASS_IV_TBL(clone_p) = RCLASS_IV_TBL(p);
             RCLASS_ALLOCATOR(clone_p) = RCLASS_ALLOCATOR(p);
             if (RB_TYPE_P(clone, T_CLASS)) {
                 RCLASS_SET_INCLUDER(clone_p, clone);
@@ -607,9 +601,7 @@ rb_singleton_class_clone_and_attach(VALUE obj, VALUE attach)
 
         RCLASS_SET_SUPER(clone, RCLASS_SUPER(klass));
         RCLASS_ALLOCATOR(clone) = RCLASS_ALLOCATOR(klass);
-        if (RCLASS_IV_TBL(klass)) {
-            rb_iv_tbl_copy(clone, klass);
-        }
+        rb_iv_tbl_copy(clone, klass);
         if (RCLASS_CONST_TBL(klass)) {
             struct clone_const_arg arg;
             arg.tbl = RCLASS_CONST_TBL(clone) = rb_id_table_create(0);
@@ -1062,13 +1054,10 @@ rb_include_class_new(VALUE module, VALUE super)
         module = METACLASS_OF(module);
     }
     RUBY_ASSERT(!RB_TYPE_P(module, T_ICLASS));
-    if (!RCLASS_IV_TBL(module)) {
-        RCLASS_IV_TBL(module) = st_init_numtable();
-    }
     if (!RCLASS_CONST_TBL(module)) {
         RCLASS_CONST_TBL(module) = rb_id_table_create(0);
     }
-    RCLASS_IV_TBL(klass) = RCLASS_IV_TBL(module);
+
     RCLASS_CVC_TBL(klass) = RCLASS_CVC_TBL(module);
     RCLASS_CONST_TBL(klass) = RCLASS_CONST_TBL(module);
 

--- a/class.c
+++ b/class.c
@@ -406,7 +406,7 @@ copy_tables(VALUE clone, VALUE orig)
         RCLASS_CONST_TBL(clone) = 0;
     }
     RCLASS_M_TBL(clone) = 0;
-    {
+    if (!RB_TYPE_P(clone, T_ICLASS)) {
         st_data_t id;
 
         rb_iv_tbl_copy(clone, orig);

--- a/class.c
+++ b/class.c
@@ -416,9 +416,9 @@ copy_tables(VALUE clone, VALUE orig)
 
         rb_iv_tbl_copy(clone, orig);
         CONST_ID(id, "__tmp_classpath__");
-        st_delete(RCLASS_IV_TBL(clone), &id, 0);
+        rb_attr_delete(clone, id);
         CONST_ID(id, "__classpath__");
-        st_delete(RCLASS_IV_TBL(clone), &id, 0);
+        rb_attr_delete(clone, id);
     }
     if (RCLASS_CONST_TBL(orig)) {
         struct clone_const_arg arg;

--- a/internal/class.h
+++ b/internal/class.h
@@ -33,7 +33,7 @@ struct rb_cvar_class_tbl_entry {
 };
 
 struct rb_classext_struct {
-    struct st_table *iv_tbl;
+    VALUE *iv_ptr;
     struct rb_id_table *const_tbl;
     struct rb_id_table *callable_m_tbl;
     struct rb_id_table *cc_tbl; /* ID -> [[ci, cc1], cc2, ...] */
@@ -75,9 +75,9 @@ typedef struct rb_classext_struct rb_classext_t;
 #else
 #  define RCLASS_EXT(c) (RCLASS(c)->ptr)
 #endif
-#define RCLASS_IV_TBL(c) (RCLASS_EXT(c)->iv_tbl)
 #define RCLASS_CONST_TBL(c) (RCLASS_EXT(c)->const_tbl)
 #define RCLASS_M_TBL(c) (RCLASS(c)->m_tbl)
+#define RCLASS_IVPTR(c) (RCLASS_EXT(c)->iv_ptr)
 #define RCLASS_CALLABLE_M_TBL(c) (RCLASS_EXT(c)->callable_m_tbl)
 #define RCLASS_CC_TBL(c) (RCLASS_EXT(c)->cc_tbl)
 #define RCLASS_CVC_TBL(c) (RCLASS_EXT(c)->cvc_tbl)

--- a/internal/variable.h
+++ b/internal/variable.h
@@ -24,7 +24,6 @@ void rb_gc_update_global_tbl(void);
 size_t rb_generic_ivar_memsize(VALUE);
 VALUE rb_search_class_path(VALUE);
 VALUE rb_attr_delete(VALUE, ID);
-VALUE rb_ivar_lookup(VALUE obj, ID id, VALUE undef);
 void rb_autoload_str(VALUE mod, ID id, VALUE file);
 VALUE rb_autoload_at_p(VALUE, ID, int);
 NORETURN(VALUE rb_mod_const_missing(VALUE,VALUE));
@@ -49,6 +48,7 @@ void rb_iv_tbl_copy(VALUE dst, VALUE src);
 RUBY_SYMBOL_EXPORT_END
 
 MJIT_SYMBOL_EXPORT_BEGIN
+VALUE rb_ivar_lookup(VALUE obj, ID id, VALUE undef);
 VALUE rb_gvar_get(ID);
 VALUE rb_gvar_set(ID, VALUE);
 VALUE rb_gvar_defined(ID);

--- a/marshal.c
+++ b/marshal.c
@@ -523,7 +523,7 @@ hash_each(VALUE key, VALUE value, VALUE v)
 
 #define SINGLETON_DUMP_UNABLE_P(klass) \
     (rb_id_table_size(RCLASS_M_TBL(klass)) > 0 || \
-     (RCLASS_IV_TBL(klass) && RCLASS_IV_TBL(klass)->num_entries > 1))
+     rb_ivar_count(klass) > 1)
 
 static void
 w_extended(VALUE klass, struct dump_arg *arg, int check)

--- a/object.c
+++ b/object.c
@@ -298,20 +298,22 @@ init_copy(VALUE dest, VALUE obj)
     rb_copy_generic_ivar(dest, obj);
     rb_gc_copy_finalizer(dest, obj);
 
-    rb_shape_t *shape_to_set = rb_shape_get_shape(obj);
+    if (!RB_TYPE_P(obj, T_CLASS) && !RB_TYPE_P(obj, T_MODULE)) {
+        rb_shape_t *shape_to_set = rb_shape_get_shape(obj);
 
-    // If the object is frozen, the "dup"'d object will *not* be frozen,
-    // so we need to copy the frozen shape's parent to the new object.
-    if (rb_shape_frozen_shape_p(shape_to_set)) {
-        shape_to_set = rb_shape_get_shape_by_id(shape_to_set->parent_id);
+        // If the object is frozen, the "dup"'d object will *not* be frozen,
+        // so we need to copy the frozen shape's parent to the new object.
+        if (rb_shape_frozen_shape_p(shape_to_set)) {
+            shape_to_set = rb_shape_get_shape_by_id(shape_to_set->parent_id);
+        }
+
+        // shape ids are different
+        rb_shape_set_shape(dest, shape_to_set);
     }
 
     if (RB_TYPE_P(obj, T_OBJECT)) {
         rb_obj_copy_ivar(dest, obj);
     }
-
-    // shape ids are different
-    rb_shape_set_shape(dest, shape_to_set);
 }
 
 static VALUE immutable_obj_clone(VALUE obj, VALUE kwfreeze);

--- a/shape.c
+++ b/shape.c
@@ -54,9 +54,10 @@ rb_shape_get_shape_by_id_without_assertion(shape_id_t shape_id)
 }
 
 #if !SHAPE_IN_BASIC_FLAGS
-static inline shape_id_t
-RCLASS_SHAPE_ID(VALUE obj)
+shape_id_t
+rb_rclass_shape_id(VALUE obj)
 {
+    RUBY_ASSERT(RB_TYPE_P(obj, T_CLASS) || RB_TYPE_P(obj, T_MODULE));
     return RCLASS_EXT(obj)->shape_id;
 }
 
@@ -115,7 +116,9 @@ static rb_shape_t*
 get_next_shape_internal(rb_shape_t* shape, ID id, VALUE obj, enum shape_type shape_type)
 {
     rb_shape_t *res = NULL;
-    RUBY_ASSERT(SHAPE_FROZEN != (enum shape_type)shape->type);
+
+    RUBY_ASSERT(SHAPE_FROZEN != (enum shape_type)shape->type || RB_TYPE_P(obj, T_MODULE) || RB_TYPE_P(obj, T_CLASS));
+
     RB_VM_LOCK_ENTER();
     {
         if (rb_shape_lookup_id(shape, id, shape_type)) {

--- a/shape.h
+++ b/shape.h
@@ -90,6 +90,13 @@ ROBJECT_SET_SHAPE_ID(VALUE obj, shape_id_t shape_id)
     RBASIC_SET_SHAPE_ID(obj, shape_id);
 }
 
+static inline shape_id_t
+RCLASS_SHAPE_ID(VALUE obj)
+{
+    RUBY_ASSERT(RB_TYPE_P(obj, T_CLASS) || RB_TYPE_P(obj, T_MODULE));
+    return RBASIC_SHAPE_ID(obj);
+}
+
 #else
 
 static inline shape_id_t
@@ -105,6 +112,15 @@ ROBJECT_SET_SHAPE_ID(VALUE obj, shape_id_t shape_id)
     RBASIC(obj)->flags &= SHAPE_FLAG_MASK;
     RBASIC(obj)->flags |= ((VALUE)(shape_id) << SHAPE_FLAG_SHIFT);
 }
+
+MJIT_SYMBOL_EXPORT_BEGIN
+shape_id_t rb_rclass_shape_id(VALUE obj);
+MJIT_SYMBOL_EXPORT_END
+
+static inline shape_id_t RCLASS_SHAPE_ID(VALUE obj) {
+    return rb_rclass_shape_id(obj);
+}
+
 #endif
 
 bool rb_shape_root_shape_p(rb_shape_t* shape);
@@ -131,6 +147,14 @@ ROBJECT_IV_COUNT(VALUE obj)
     RBIMPL_ASSERT_TYPE(obj, RUBY_T_OBJECT);
     uint32_t ivc = rb_shape_get_shape_by_id(ROBJECT_SHAPE_ID(obj))->next_iv_index;
     RUBY_ASSERT(ivc <= ROBJECT_NUMIV(obj));
+    return ivc;
+}
+
+static inline uint32_t
+RCLASS_IV_COUNT(VALUE obj)
+{
+    RUBY_ASSERT(RB_TYPE_P(obj, RUBY_T_CLASS) || RB_TYPE_P(obj, RUBY_T_MODULE));
+    uint32_t ivc = rb_shape_get_shape_by_id(RCLASS_SHAPE_ID(obj))->next_iv_index;
     return ivc;
 }
 

--- a/variable.c
+++ b/variable.c
@@ -3869,8 +3869,12 @@ void
 rb_iv_tbl_copy(VALUE dst, VALUE src)
 {
     st_table *orig_tbl = RCLASS_IV_TBL(src);
+    if (!orig_tbl) return;
+
     st_table *new_tbl = st_copy(orig_tbl);
     st_foreach(new_tbl, tbl_copy_i, (st_data_t)dst);
+
+    RUBY_ASSERT(!RCLASS_IV_TBL(dst));
     RCLASS_IV_TBL(dst) = new_tbl;
 }
 

--- a/variable.c
+++ b/variable.c
@@ -111,18 +111,16 @@ rb_namespace_p(VALUE obj)
 static VALUE
 classname(VALUE klass, int *permanent)
 {
-    st_table *ivtbl;
-    st_data_t n;
-
     *permanent = 0;
     if (!RCLASS_EXT(klass)) return Qnil;
-    if (!(ivtbl = RCLASS_IV_TBL(klass))) return Qnil;
-    if (st_lookup(ivtbl, (st_data_t)classpath, &n)) {
+
+    VALUE classpathv = rb_ivar_lookup(klass, classpath, Qnil);
+    if (RTEST(classpathv)) {
         *permanent = 1;
-        return (VALUE)n;
+        return classpathv;
     }
-    if (st_lookup(ivtbl, (st_data_t)tmp_classpath, &n)) return (VALUE)n;
-    return Qnil;
+
+    return rb_ivar_lookup(klass, tmp_classpath, Qnil);;
 }
 
 /*

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1507,15 +1507,13 @@ vm_getclassvariable(const rb_iseq_t *iseq, const rb_control_frame_t *reg_cfp, ID
 {
     const rb_cref_t *cref;
 
-    if (ic->entry && ic->entry->global_cvar_state == GET_GLOBAL_CVAR_STATE()) {
-        VALUE v = Qundef;
+    if (ic->entry && ic->entry->global_cvar_state == GET_GLOBAL_CVAR_STATE() && LIKELY(rb_ractor_main_p())) {
         RB_DEBUG_COUNTER_INC(cvar_read_inline_hit);
 
-        if (st_lookup(RCLASS_IV_TBL(ic->entry->class_value), (st_data_t)id, &v) &&
-            LIKELY(rb_ractor_main_p())) {
+        VALUE v = rb_ivar_lookup(ic->entry->class_value, id, Qundef);
+        RUBY_ASSERT(v != Qundef);
 
-            return v;
-        }
+        return v;
     }
 
     cref = vm_get_cref(GET_EP());


### PR DESCRIPTION
Object Shapes were introduced in #6386 for T_OBJECT and "extended ivars" with the plan to later implement it for Classes and Modules, which previously were using an `st_table`. This is that change 😁

This brings a number of advantages over the previous approach, where each class/module had its own st_table: First it requires less storage, as we now store the values of the ivars in a flat array. This works particularly well with shapes because the shape can be reused between classes with the same ivar keys, which is very common (many classes only use the hidden `__classpath__` and `__autoload__` keys). Next, this unifies behaviour between all types of object which can hold ivars as everything now uses shapes (though there are small differences). Finally, this change allows using inline caches to fetch class instance variables.

One challenge while implementing this is that previously the same `st_table *iv_tbl` was shared between T_MODULE and the T_ICLASS representing that modules inheritance. This was convenient for class-variables (N.B. not class-instance-variables), but was incompatible with having IVs in an array (it previously relied on two levels of indirection because we may `realloc` storage when introducing new IVs). The first few commits of this PR remove this technique, and instead in the cases we needed the behaviour we look though the original module. (T_ICLASS never supported proper instance variables, only explicit access via the st_table). 

### RActor notes

One quirk of IVar access for RActors is that when on a non-main RActor we must guard that the result we receive is shareable. For this reason (and due to locking requirements described below) we don't attempt to use inline caches on other RActors, and simply fall back to the generic safe/locking implementation (which should already have similar or better performance to today).

Previously thread safety was provided using `lock_st_lookup`, `lock_st_is_member`, `lock_st_insert`, `lock_st_delete`, which hold the VM lock when performing their operation. Similarly most operations now use `RB_VM_LOCK_ENTER`/`RB_VM_LOCK_LEAVE` around their access of the iv storage. With two exceptions:
* `rb_ivar_defined` does not need to perform any locking as all information is encoded in the immutable shape
* When we read an instance variable using the inline cache from the main RActor, we do not perform locking, instead relying on the assumption that only main RActors are allowed to modify class ivars. (Non-main ractors aren't able to use inline caches per above)

It feels like in the future even more of these accesses could be made in a more lock-free way. Since shapes themselves are immutable, and we never shrink the IV storage in most cases it should be safe to access storage without locking (other than maybe removed ivars, which could be worked around), and likely could also be safe to set variables when it didn't require a shape transition (which would require some form of locking, but possibly much lighter or more granular), so long as `free` (specifically the free from `realloc`) was deferred until GC or some other safepoint. However none of this was explored or attempted because RActor's current use and the relative rarity of class instance variable usage didn't justify the complexity or risk of this approach.

Because of the locking requirement on class instance variable sets, this doesn't attempt use inline caches in that case (the inline cache is only used for read). If this ends up being common we could revisit this.

## Benchmark

```
$ ruby --disable=gems -rrubygems -I./benchmark/lib ./benchmark/benchmark-driver/exe/benchmark-driver \
            --executables="ruby-3.1.2::/home/jhawthorn/.rubies/ruby-3.1.2/bin/ruby -I.ext/common --disable-gem" \
            --executables="ruby-trunk::/home/jhawthorn/.rubies/ruby-trunk/bin/ruby -I.ext/common --disable-gem" \
            --executables="built-ruby::./miniruby -I./lib -I. -I.ext/common  ./tool/runruby.rb --extout=.ext  -- --disable-gems --disable-gem" \
            --output=markdown --output-compare -v $(find ./benchmark -maxdepth 1 -name 'vm_ivar_of_class' -o -name '*vm_ivar_of_class*.yml' -o -name '*vm_ivar_of_class*.rb' | sort)
ruby-3.1.2: ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [x86_64-linux]
ruby-trunk: ruby 3.2.0dev (2022-10-26T05:49:35Z master df43611021) [x86_64-linux]
built-ruby: ruby 3.2.0dev (2022-10-26T05:56:39Z object-shapes-clas.. 84f88cbd9e) [x86_64-linux]
# Iteration per second (i/s)

|                      |ruby-3.1.2|ruby-trunk|built-ruby|
|:---------------------|---------:|---------:|---------:|
|vm_ivar_of_class_set  |    8.738M|    9.788M|   10.216M|
|                      |         -|     1.12x|     1.17x|
|vm_ivar_of_class      |    7.703M|    8.008M|   16.433M|
|                      |         -|     1.04x|     2.13x|
```

As expected we see a significant ~2x speedup from using inline caching.

cc @jemmaissroff @tenderlove 