### PR TITLE
Improve performance some `Integer` and `Float` methods [Feature #19085]

### DIFF
--- a/benchmark/numeric_methods.yml
+++ b/benchmark/numeric_methods.yml
@@ -10,4 +10,20 @@ benchmark:
     int.finite?
   infinite?: |
     int.infinite?
+  integer_real: |
+    int.real
+  float_real: |
+    flo.real
+  integr_imag: |
+    int.imag
+  float_imag: |
+    flo.imag
+  integer_conj: |
+    int.conj
+  float_conj: |
+    flo.conj
+  integer_numerator: |
+    int.numerator
+  integer_denominator: |
+    int.denominator
 loop_count: 20000000

--- a/complex.c
+++ b/complex.c
@@ -2161,31 +2161,6 @@ nucomp_s_convert(int argc, VALUE *argv, VALUE klass)
 
 /*
  * call-seq:
- *    num.real  ->  self
- *
- * Returns self.
- */
-static VALUE
-numeric_real(VALUE self)
-{
-    return self;
-}
-
-/*
- * call-seq:
- *    num.imag       ->  0
- *    num.imaginary  ->  0
- *
- * Returns zero.
- */
-static VALUE
-numeric_imag(VALUE self)
-{
-    return INT2FIX(0);
-}
-
-/*
- * call-seq:
  *    num.abs2  ->  real
  *
  * Returns square of self.
@@ -2253,19 +2228,6 @@ numeric_polar(VALUE self)
         arg = f_arg(self);
     }
     return rb_assoc_new(abs, arg);
-}
-
-/*
- * call-seq:
- *    num.conj       ->  self
- *    num.conjugate  ->  self
- *
- * Returns self.
- */
-static VALUE
-numeric_conj(VALUE self)
-{
-    return self;
 }
 
 /*
@@ -2433,9 +2395,6 @@ Init_Complex(void)
 
     rb_define_private_method(CLASS_OF(rb_cComplex), "convert", nucomp_s_convert, -1);
 
-    rb_define_method(rb_cNumeric, "real", numeric_real, 0);
-    rb_define_method(rb_cNumeric, "imaginary", numeric_imag, 0);
-    rb_define_method(rb_cNumeric, "imag", numeric_imag, 0);
     rb_define_method(rb_cNumeric, "abs2", numeric_abs2, 0);
     rb_define_method(rb_cNumeric, "arg", numeric_arg, 0);
     rb_define_method(rb_cNumeric, "angle", numeric_arg, 0);
@@ -2443,8 +2402,6 @@ Init_Complex(void)
     rb_define_method(rb_cNumeric, "rectangular", numeric_rect, 0);
     rb_define_method(rb_cNumeric, "rect", numeric_rect, 0);
     rb_define_method(rb_cNumeric, "polar", numeric_polar, 0);
-    rb_define_method(rb_cNumeric, "conjugate", numeric_conj, 0);
-    rb_define_method(rb_cNumeric, "conj", numeric_conj, 0);
 
     rb_define_method(rb_cFloat, "arg", float_arg, 0);
     rb_define_method(rb_cFloat, "angle", float_arg, 0);

--- a/numeric.rb
+++ b/numeric.rb
@@ -6,7 +6,7 @@ class Numeric
   #  Returns +true+ if +num+ is a real number (i.e. not Complex).
   #
   def real?
-    return true
+    true
   end
 
   #
@@ -16,7 +16,7 @@ class Numeric
   # Returns self.
   #
   def real
-    return self
+    self
   end
 
   #
@@ -29,7 +29,7 @@ class Numeric
   #      1.integer?     #=> true
   #
   def integer?
-    return false
+    false
   end
 
   #
@@ -39,7 +39,7 @@ class Numeric
   #  Returns +true+ if +num+ is a finite number, otherwise returns +false+.
   #
   def finite?
-    return true
+    true
   end
 
   #
@@ -50,7 +50,7 @@ class Numeric
   #  finite, <code>-Infinity</code>, or <code>+Infinity</code>.
   #
   def infinite?
-    return nil
+    nil
   end
 
   #
@@ -61,12 +61,15 @@ class Numeric
   # Returns zero.
   #
   def imaginary
-    return 0;
+    0
   end
 
+  alias imag imaginary
+=begin
   def imag
-    return 0;
+    0
   end
+=end
 
   #
   # call-seq:
@@ -76,12 +79,15 @@ class Numeric
   # Returns self.
   #
   def conjugate
-    return self
+    self
   end
 
+  alias conj conjugate
+=begin
   def conj
-    return self
+    self
   end
+=end
 end
 
 class Integer
@@ -186,7 +192,7 @@ class Integer
   #
   #  Since +int+ is already an Integer, this always returns +true+.
   def integer?
-    return true
+    true
   end
 
   alias magnitude abs
@@ -218,7 +224,7 @@ class Integer
   #
   #  For example, <code>?a.ord</code> returns 97 both in 1.8 and 1.9.
   def ord
-    return self
+    self
   end
 
   #
@@ -248,7 +254,7 @@ class Integer
   #
   #  #to_int is an alias for #to_i.
   def to_i
-    return self
+    self
   end
 
   #  call-seq:
@@ -256,7 +262,7 @@ class Integer
   #
   #  Since +int+ is already an Integer, returns +self+.
   def to_int
-    return self
+    self
   end
 
   # call-seq:
@@ -292,7 +298,7 @@ class Integer
   # Returns self.
   #
   def numerator
-    return self
+    self
   end
 
   #
@@ -302,7 +308,7 @@ class Integer
   # Returns 1.
   #
   def denominator
-    return 1
+    1
   end
 end
 
@@ -336,7 +342,7 @@ class Float
   # Since +float+ is already a Float, returns +self+.
   #
   def to_f
-    return self
+    self
   end
 
   #

--- a/numeric.rb
+++ b/numeric.rb
@@ -10,6 +10,16 @@ class Numeric
   end
 
   #
+  # call-seq:
+  #    num.real  ->  self
+  #
+  # Returns self.
+  #
+  def real
+    return self
+  end
+
+  #
   #  call-seq:
   #     num.integer?  ->  true or false
   #
@@ -41,6 +51,36 @@ class Numeric
   #
   def infinite?
     return nil
+  end
+
+  #
+  # call-seq:
+  #    num.imag       ->  0
+  #    num.imaginary  ->  0
+  #
+  # Returns zero.
+  #
+  def imaginary
+    return 0;
+  end
+
+  def imag
+    return 0;
+  end
+
+  #
+  # call-seq:
+  #    num.conj       ->  self
+  #    num.conjugate  ->  self
+  #
+  # Returns self.
+  #
+  def conjugate
+    return self
+  end
+
+  def conj
+    return self
   end
 end
 
@@ -243,6 +283,26 @@ class Integer
   #    3.ceildiv(1.2) # => 3
   def ceildiv(other)
     -div(-other)
+  end
+
+  #
+  # call-seq:
+  #    int.numerator  ->  self
+  #
+  # Returns self.
+  #
+  def numerator
+    return self
+  end
+
+  #
+  # call-seq:
+  #    int.denominator  ->  1
+  #
+  # Returns 1.
+  #
+  def denominator
+    return 1
   end
 end
 

--- a/numeric.rb
+++ b/numeric.rb
@@ -65,11 +65,6 @@ class Numeric
   end
 
   alias imag imaginary
-=begin
-  def imag
-    0
-  end
-=end
 
   #
   # call-seq:
@@ -83,11 +78,6 @@ class Numeric
   end
 
   alias conj conjugate
-=begin
-  def conj
-    self
-  end
-=end
 end
 
 class Integer

--- a/rational.c
+++ b/rational.c
@@ -2061,30 +2061,6 @@ rb_rational_canonicalize(VALUE x)
 
 /*
  * call-seq:
- *    int.numerator  ->  self
- *
- * Returns self.
- */
-static VALUE
-integer_numerator(VALUE self)
-{
-    return self;
-}
-
-/*
- * call-seq:
- *    int.denominator  ->  1
- *
- * Returns 1.
- */
-static VALUE
-integer_denominator(VALUE self)
-{
-    return INT2FIX(1);
-}
-
-/*
- * call-seq:
  *    flo.numerator  ->  integer
  *
  * Returns the numerator.  The result is machine dependent.
@@ -2831,9 +2807,6 @@ Init_Rational(void)
     rb_define_method(rb_cNumeric, "numerator", numeric_numerator, 0);
     rb_define_method(rb_cNumeric, "denominator", numeric_denominator, 0);
     rb_define_method(rb_cNumeric, "quo", rb_numeric_quo, 1);
-
-    rb_define_method(rb_cInteger, "numerator", integer_numerator, 0);
-    rb_define_method(rb_cInteger, "denominator", integer_denominator, 0);
 
     rb_define_method(rb_cFloat, "numerator", rb_float_numerator, 0);
     rb_define_method(rb_cFloat, "denominator", rb_float_denominator, 0);


### PR DESCRIPTION
Improve performance some `Integer` and `Float` methods written by Ruby.

benchmark:

```yml
prelude: |
  int_num = 42
  flo_num = 4.2
benchmark:
  integer_real: |
    int_num.real
  float_real: |
    flo_num.real
  integr_imag: |
    int_num.imag
  float_imag: |
    flo_num.imag
  integer_conj: |
    int_num.conj
  float_conj: |
    flo_num.conj
  integer_numerator: |
    int_num.numerator
  integer_denominator: |
    int_num.denominator
loop_count: 20000000

```

result:

```bash
sh@DESKTOP-L0NI312:~/rubydev/build$ make benchmark/benchmark.yml -e BENCH_RUBY=../install/bin/ruby -e COMPARE_RUBY=~/.rbenv/shims/ruby
../ruby/revision.h unchanged
compare-ruby: ruby 3.2.0dev (2022-10-26T06:02:04Z master 94f3aa2126) [x86_64-linux]
built-ruby: ruby 3.2.0dev (2022-10-26T12:38:10Z improve_integer_an.. 2044b65fb2) [x86_64-linux]
# Iteration per second (i/s)

|                     |compare-ruby|built-ruby|
|:--------------------|-----------:|---------:|
|integer_real         |     79.510M|   82.640M|
|                     |           -|     1.04x|
|float_real           |     80.673M|   83.534M|
|                     |           -|     1.04x|
|integr_imag          |     81.043M|   86.709M|
|                     |           -|     1.07x|
|float_imag           |     80.303M|   80.680M|
|                     |           -|     1.00x|
|integer_conj         |     78.219M|   85.795M|
|                     |           -|     1.10x|
|float_conj           |     75.137M|   84.604M|
|                     |           -|     1.13x|
|integer_numerator    |     78.194M|   79.461M|
|                     |           -|     1.02x|
|integer_denominator  |     73.674M|   87.035M|
|                     |           -|     1.18x|
```

`COMPARE_RUBY` is `ruby 3.2.0dev (2022-10-26T06:02:04Z master 94f3aa2126) [x86_64-linux]`. `BENCH_RUBY` is ahead of `ruby 3.2.0dev (2022-10-26T06:02:04Z master 94f3aa2126) [x86_64-linux]`.

ticket: https://bugs.ruby-lang.org/issues/19085