### PR TITLE
YJIT: Test --yjit-verify-ctx on GitHub Actions as well

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -129,5 +129,5 @@ yjit_task:
   full_build_script: source $HOME/.cargo/env && make
   cargo_test_script: source $HOME/.cargo/env && cd yjit && cargo test
   make_test_script: source $HOME/.cargo/env && make test RUN_OPTS="--yjit-call-threshold=1 --yjit-verify-ctx"
-  make_test_all_script: source $HOME/.cargo/env && make test-all RUN_OPTS="--yjit-call-threshold=1" TESTOPTS="$RUBY_TESTOPTS"
-  make_test_spec_script: source $HOME/.cargo/env && make test-spec RUN_OPTS="--yjit-call-threshold=1"
+  make_test_all_script: source $HOME/.cargo/env && make test-all RUN_OPTS="--yjit-call-threshold=1 --yjit-verify-ctx" TESTOPTS="$RUBY_TESTOPTS"
+  make_test_spec_script: source $HOME/.cargo/env && make test-spec RUN_OPTS="--yjit-call-threshold=1 --yjit-verify-ctx"

--- a/.github/workflows/yjit-ubuntu.yml
+++ b/.github/workflows/yjit-ubuntu.yml
@@ -56,7 +56,7 @@ jobs:
 
           - test_task: "check"
             configure: "--enable-yjit=dev"
-            yjit_opts: "--yjit-call-threshold=1"
+            yjit_opts: "--yjit-call-threshold=1 --yjit-verify-ctx"
 
           - test_task: "test-all TESTS=--repeat-count=2"
             configure: "--enable-yjit=dev"


### PR DESCRIPTION
When `--yjit-verify-ctx` has an issue, only Cirrus could fail, so we may get a wrong impression that it's specific to Arm even if it's not. It'd be nice to have at least one failure on Linux with it.

I also made it consistent across different test tasks on Cirrus as well.