### PR TITLE
[DOC] Enhanced RDOc for IO

### DIFF
--- a/doc/io_streams.rdoc
+++ b/doc/io_streams.rdoc
@@ -189,14 +189,13 @@ The relevant methods:
 
 A new \IO stream may be open for reading, open for writing, or both.
 
-You can close a stream using these methods:
+A stream is automatically closed when claimed by the garbage collector.
+
+Attempted reading or writing on a closed stream raises an exception.
 
 - IO#close: Closes the stream for both reading and writing.
-- IO#close_read (not in \ARGF): Closes the stream for reading.
-- IO#close_write (not in \ARGF): Closes the stream for writing.
-
-You can query whether a stream is closed using this method:
-
+- IO#close_read: Closes the stream for reading; not in ARGF.
+- IO#close_write: Closes the stream for writing; not in ARGF.
 - IO#closed?: Returns whether the stream is closed.
 
 ==== End-of-Stream

--- a/io.c
+++ b/io.c
@@ -5649,10 +5649,10 @@ rb_io_close(VALUE io)
  *  Example:
  *
  *    IO.popen('ruby', 'r+') do |pipe|
- *      STDOUT.puts pipe.closed?
+ *      puts pipe.closed?
  *      pipe.close
- *      STDOUT.puts $?
- *      STDOUT.puts pipe.closed?
+ *      puts $?
+ *      puts pipe.closed?
  *    end
  *
  *  Output:
@@ -5713,11 +5713,11 @@ io_close(VALUE io)
  *  +false+ otherwise:
  *
  *    IO.popen('ruby', 'r+') do |pipe|
- *      STDOUT.puts pipe.closed?
+ *      puts pipe.closed?
  *      pipe.close_read
- *      STDOUT.puts pipe.closed?
+ *      puts pipe.closed?
  *      pipe.close_write
- *      STDOUT.puts pipe.closed?
+ *      puts pipe.closed?
  *    end
  *
  *  Output:
@@ -5764,12 +5764,12 @@ rb_io_closed(VALUE io)
  *  Example:
  *
  *    IO.popen('ruby', 'r+') do |pipe|
- *      STDOUT.puts pipe.closed?
+ *      puts pipe.closed?
  *      pipe.close_write
- *      STDOUT.puts pipe.closed?
+ *      puts pipe.closed?
  *      pipe.close_read
- *      STDOUT.puts $?
- *      STDOUT.puts pipe.closed?
+ *      puts $?
+ *      puts pipe.closed?
  *    end
  *
  *  Output:
@@ -5838,12 +5838,12 @@ rb_io_close_read(VALUE io)
  *  sets global variable <tt>$?</tt> (child exit status).
  *
  *    IO.popen('ruby', 'r+') do |pipe|
- *      STDOUT.puts pipe.closed?
+ *      puts pipe.closed?
  *      pipe.close_read
- *      STDOUT.puts pipe.closed?
+ *      puts pipe.closed?
  *      pipe.close_write
- *      STDOUT.puts $?
- *      STDOUT.puts pipe.closed?
+ *      puts $?
+ *      puts pipe.closed?
  *    end
  *
  *  Output:


### PR DESCRIPTION
In io.c treats:
- #close
- #close_read
- #close_write
- #closed
Examples for these methods can now run on any platform.

In doc/io_streams.rdoc, merely points to these methods in io.c.