### PR TITLE
YJIT: Add RubyVM::YJIT.code_gc

### DIFF
--- a/yjit.c
+++ b/yjit.c
@@ -1053,6 +1053,7 @@ VALUE rb_yjit_get_stats(rb_execution_context_t *ec, VALUE self);
 VALUE rb_yjit_reset_stats_bang(rb_execution_context_t *ec, VALUE self);
 VALUE rb_yjit_disasm_iseq(rb_execution_context_t *ec, VALUE self, VALUE iseq);
 VALUE rb_yjit_insns_compiled(rb_execution_context_t *ec, VALUE self, VALUE iseq);
+VALUE rb_yjit_code_gc(rb_execution_context_t *ec, VALUE self);
 VALUE rb_yjit_simulate_oom_bang(rb_execution_context_t *ec, VALUE self);
 VALUE rb_yjit_get_exit_locations(rb_execution_context_t *ec, VALUE self);
 

--- a/yjit.rb
+++ b/yjit.rb
@@ -219,14 +219,14 @@ module RubyVM::YJIT
       $stderr.puts "compilation_failure:   " + ("%10d" % compilation_failure) if compilation_failure != 0
       $stderr.puts "compiled_block_count:  " + ("%10d" % stats[:compiled_block_count])
       $stderr.puts "compiled_iseq_count:   " + ("%10d" % stats[:compiled_iseq_count])
-      $stderr.puts "compiled_page_count:   " + ("%10d" % stats[:compiled_page_count])
       $stderr.puts "freed_iseq_count:      " + ("%10d" % stats[:freed_iseq_count])
-      $stderr.puts "freed_page_count:      " + ("%10d" % stats[:freed_page_count])
       $stderr.puts "invalidation_count:    " + ("%10d" % stats[:invalidation_count])
       $stderr.puts "constant_state_bumps:  " + ("%10d" % stats[:constant_state_bumps])
       $stderr.puts "inline_code_size:      " + ("%10d" % stats[:inline_code_size])
       $stderr.puts "outlined_code_size:    " + ("%10d" % stats[:outlined_code_size])
       $stderr.puts "freed_code_size:       " + ("%10d" % stats[:freed_code_size])
+      $stderr.puts "live_page_count:       " + ("%10d" % stats[:live_page_count])
+      $stderr.puts "freed_page_count:      " + ("%10d" % stats[:freed_page_count])
       $stderr.puts "code_gc_count:         " + ("%10d" % stats[:code_gc_count])
       $stderr.puts "num_gc_obj_refs:       " + ("%10d" % stats[:num_gc_obj_refs])
 

--- a/yjit.rb
+++ b/yjit.rb
@@ -162,6 +162,11 @@ module RubyVM::YJIT
     end
   end
 
+  # Free and recompile all existing JIT code
+  def self.code_gc
+    Primitive.rb_yjit_code_gc
+  end
+
   def self.simulate_oom!
     Primitive.rb_yjit_simulate_oom_bang
   end

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -381,8 +381,8 @@ fn rb_yjit_gen_stats_dict() -> VALUE {
         // GCed code size
         hash_aset_usize!(hash, "freed_code_size", freed_page_count * cb.page_size());
 
-        // Compiled pages
-        hash_aset_usize!(hash, "compiled_page_count", cb.num_mapped_pages() - freed_page_count);
+        // Live pages
+        hash_aset_usize!(hash, "live_page_count", cb.num_mapped_pages() - freed_page_count);
     }
 
     // If we're not generating stats, the hash is done

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -382,7 +382,7 @@ fn rb_yjit_gen_stats_dict() -> VALUE {
         hash_aset_usize!(hash, "freed_code_size", freed_page_count * cb.page_size());
 
         // Compiled pages
-        hash_aset_usize!(hash, "compiled_page_count", cb.num_pages() - freed_page_count);
+        hash_aset_usize!(hash, "compiled_page_count", cb.num_mapped_pages() - freed_page_count);
     }
 
     // If we're not generating stats, the hash is done

--- a/yjit/src/yjit.rs
+++ b/yjit/src/yjit.rs
@@ -79,6 +79,18 @@ pub extern "C" fn rb_yjit_iseq_gen_entry_point(iseq: IseqPtr, ec: EcPtr) -> *con
     }
 }
 
+/// Free and recompile all existing JIT code
+#[no_mangle]
+pub extern "C" fn rb_yjit_code_gc(_ec: EcPtr, _ruby_self: VALUE) -> VALUE {
+    if !yjit_enabled_p() {
+        return Qnil;
+    }
+
+    let cb = CodegenGlobals::get_inline_cb();
+    cb.code_gc();
+    Qnil
+}
+
 /// Simulate a situation where we are out of executable memory
 #[no_mangle]
 pub extern "C" fn rb_yjit_simulate_oom_bang(_ec: EcPtr, _ruby_self: VALUE) -> VALUE {


### PR DESCRIPTION
This could be useful when triggering this at the end of initialization is efficient enough and it's more time-consuming to find a good `--yjit-exec-mem-size` that stabilizes Code GC.

## Railsbench stats
I checked the impact of calling the `RubyVM::YJIT.code_gc` at `config/initializers/yjit_code_gc.rb` (last initializer):

| mem size (MiB) | Call `YJIT.code_gc` | code_gc_count | live_page_count | freed_page_count |
|:--|:---|:--|:--|:--|
| 9 | No | 0 | 575 | 0 |
| 9 | Yes | 1 | 436 | 0 |
| 8 | No | 1 | 263 | 249 |
| 8 | Yes | 1 | 437 | 0 |

It seems like `config/initializers` is still too early for Code GC, but it's still better than never triggering Code GC.

P.S. Looks like now `--yjit-exec-mem-size=9` is needed to fit all code today (it was 6 in https://github.com/ruby/ruby/pull/6406), maybe due to the reduced # of size exits (which is a good thing).