### PR TITLE
YJIT: reduce default `--yjit-exec-mem-size` to 128MiB instead of 256

### DIFF
--- a/yjit/src/options.rs
+++ b/yjit/src/options.rs
@@ -53,7 +53,7 @@ pub struct Options {
 
 // Initialize the options to default values
 pub static mut OPTIONS: Options = Options {
-    exec_mem_size: 256 * 1024 * 1024,
+    exec_mem_size: 128 * 1024 * 1024,
     code_page_size: 16 * 1024,
     call_threshold: 10,
     greedy_versioning: false,


### PR DESCRIPTION
Reduce to 128 now so we can do some testing with this value. We can also re-adjust the final number based on the data we get from SFR.