### PR TITLE
YJIT: Some context related refactoring

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -5049,7 +5049,7 @@ fn gen_send_iseq(
     };
 
     // Create a context for the callee
-    let mut callee_ctx = Context::new(); // Was DEFAULT_CTX
+    let mut callee_ctx = Context::default();
 
     // Set the argument types in the callee's context
     for arg_idx in 0..argc {
@@ -6870,7 +6870,7 @@ mod tests {
 
         return (
             JITState::new(&block),
-            Context::new(),
+            Context::default(),
             Assembler::new(),
             CodeBlock::new_dummy(256 * 1024),
             OutlinedCb::wrap(CodeBlock::new_dummy(256 * 1024)),
@@ -6913,18 +6913,19 @@ mod tests {
         asm.compile(&mut cb);
 
         assert_eq!(status, KeepCompiling);
-        assert_eq!(context.diff(&Context::new()), 0);
+        assert_eq!(context.diff(&Context::default()), 0);
         assert_eq!(cb.get_write_pos(), 0);
     }
 
     #[test]
     fn test_gen_pop() {
         let (mut jit, _, mut asm, _cb, mut ocb) = setup_codegen();
-        let mut context = Context::new_with_stack_size(1);
+        let mut context = Context::default();
+        context.stack_push(Type::Fixnum);
         let status = gen_pop(&mut jit, &mut context, &mut asm, &mut ocb);
 
         assert_eq!(status, KeepCompiling);
-        assert_eq!(context.diff(&Context::new()), 0);
+        assert_eq!(context.diff(&Context::default()), 0);
     }
 
     #[test]

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -1005,22 +1005,6 @@ impl Block {
 }
 
 impl Context {
-    pub fn new_with_stack_size(size: i16) -> Self {
-        return Context {
-            stack_size: size as u16,
-            sp_offset: size,
-            chain_depth: 0,
-            local_types: [Type::Unknown; MAX_LOCAL_TYPES],
-            temp_types: [Type::Unknown; MAX_TEMP_TYPES],
-            self_type: Type::Unknown,
-            temp_mapping: [MapToStack; MAX_TEMP_TYPES],
-        };
-    }
-
-    pub fn new() -> Self {
-        return Self::new_with_stack_size(0);
-    }
-
     pub fn get_stack_size(&self) -> u16 {
         self.stack_size
     }

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -846,7 +846,12 @@ pub fn limit_block_versions(blockid: BlockId, ctx: &Context) -> Context {
         generic_ctx.stack_size = ctx.stack_size;
         generic_ctx.sp_offset = ctx.sp_offset;
 
-        // Mutate the incoming context
+        debug_assert_ne!(
+            usize::MAX,
+            ctx.diff(&generic_ctx),
+            "should substitute a compatible context",
+        );
+
         return generic_ctx;
     }
 


### PR DESCRIPTION
    YJIT: Add an assert to help with Context changes
    
    While experimenting I found that it's easy to change Context and forget
    to also change the copying operation in limit_block_versions(). Add an
    assert to make sure we substitute a compatible generic context when
    limiting the number of versions.

---
    YJIT: Delete redundant ways to make Context
    
    Context::new() is the same as Context::default() and
    Context::new_with_stack_size() was only used in tests.
