### PR TITLE
YJIT: don't show a full crash report if mmap is only out of memory

### DIFF
--- a/yjit.c
+++ b/yjit.c
@@ -307,6 +307,10 @@ rb_yjit_reserve_addr_space(uint32_t mem_size)
     // Check that the memory mapping was successful
     if (mem_block == MAP_FAILED) {
         perror("ruby: yjit: mmap:");
+        if(errno == ENOMEM) {
+            // No crash report if it's only insufficient memory
+            exit(EXIT_FAILURE);
+        }
         rb_bug("mmap failed");
     }
 


### PR DESCRIPTION
Without this we'll print a full crash report even if it's just ENOMEM. I don't don't think this situation should be recoverable, so I'm not throwing an exception, just exiting like ractor.c does if it can't allocate required initial memory.