### PR TITLE
YJIT: Stop incrementing write_pos if cb.has_dropped_bytes

### DIFF
--- a/yjit/src/backend/arm64/mod.rs
+++ b/yjit/src/backend/arm64/mod.rs
@@ -1028,7 +1028,7 @@ impl Assembler
                 }
                 Insn::LiveReg { .. } => (), // just a reg alloc signal, no code
                 Insn::PadInvalPatch => {
-                    while (cb.get_write_pos().saturating_sub(std::cmp::max(start_write_pos, cb.page_start_pos()))) < JMP_PTR_BYTES {
+                    while (cb.get_write_pos().saturating_sub(std::cmp::max(start_write_pos, cb.page_start_pos()))) < JMP_PTR_BYTES && !cb.has_dropped_bytes() {
                         nop(cb);
                     }
                 }


### PR DESCRIPTION
Fixes https://github.com/Shopify/ruby/issues/455

## Background

Before Code GC is introduced, we started incrementing `write_pos` even when it runs out of memory and `write_byte` fails as a workaround to avoid an infinite loop for Arm64 PadInvalPatch. However, when Code GC leaves only a page in the middle of a YJIT memory region and then the next Code GC leaves no page, failed `write_byte` will start entering invalid `write_pos` where existing valid code resides, which could also flip the result of the `capacity` check at some point, and any attempts of writing new JIT code could overwrite that position (and then notice `dropped_bytes` is true and stop compilation after writing a single `Insn`).

The infinite increment workaround was fine when there was no Code GC because it just points to an address after the YJIT memory region, which could never overwrite existing JIT code. However, with Code GC, the infinite increment could point to existing code inside the region. 

## Changes
Stop incrementing `write_pos` when it fails to write code, removing the previous workaround for Arm64 PadInvalPatch. To avoid the infinite loop for Arm64PadInvalPatch, this PR just checks `cb.has_dropped_bytes()` instead.