### PR TITLE
YJIT: Show side_exit count in stats as well

### DIFF
--- a/yjit.rb
+++ b/yjit.rb
@@ -231,6 +231,7 @@ module RubyVM::YJIT
       $stderr.puts "code_gc_count:         " + ("%10d" % stats[:code_gc_count])
       $stderr.puts "num_gc_obj_refs:       " + ("%10d" % stats[:num_gc_obj_refs])
 
+      $stderr.puts "side_exit_count:       " + ("%10d" % side_exits)
       $stderr.puts "total_exit_count:      " + ("%10d" % total_exits)
       $stderr.puts "total_insns_count:     " + ("%10d" % total_insns_count)
       $stderr.puts "vm_insns_count:        " + ("%10d" % stats[:vm_insns_count])


### PR DESCRIPTION
When we look at the numbers under "Top-20 most frequent exit ops", it's nice to have a number we can compare them with to understand the actual gap. Because `total_exit_count` includes leave's `interp_return`, which is not a side exit, you need to manually subtract it from `total_exit_count` to see the number of side exits. I thought it'd be more useful to directly see the number here. 

`side_exit_count` should be 0 while `total_exit_count` basically can't be 0. In that sense, this seems like an interesting number to look at.