### PR TITLE
YJIT: Implement fast Module#===

### DIFF
--- a/yjit.c
+++ b/yjit.c
@@ -937,6 +937,12 @@ struct iseq_callback_data {
     void *data;
 };
 
+int
+rb_RCLASS_SUPERCLASS_DEPTH(VALUE c)
+{
+    return RCLASS_SUPERCLASS_DEPTH(c);
+}
+
 // Heap-walking callback for rb_yjit_for_each_iseq().
 static int
 for_each_iseq_i(void *vstart, void *vend, size_t stride, void *data)

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -39,6 +39,7 @@ fn main() {
         .header("encindex.h")
         .header("internal.h")
         .header("internal/re.h")
+        .header("internal/object.h")
         .header("include/ruby/ruby.h")
         .header("shape.h")
         .header("vm_core.h")
@@ -94,6 +95,9 @@ fn main() {
         // From ruby/internal/intern/object.h
         .allowlist_function("rb_obj_is_kind_of")
 
+        // From internal/object.h
+        .allowlist_function("rb_class_search_ancestor")
+
         // From ruby/internal/encoding/encoding.h
         .allowlist_type("ruby_encoding_consts")
 
@@ -144,6 +148,9 @@ fn main() {
         .allowlist_var("rb_cThread")
         .allowlist_var("rb_cArray")
         .allowlist_var("rb_cHash")
+        .allowlist_var("rb_cObject")
+        .allowlist_var("rb_cClass")
+        .allowlist_var("rb_cNumeric")
 
         // From include/ruby/internal/fl_type.h
         .allowlist_type("ruby_fl_type")
@@ -286,6 +293,7 @@ fn main() {
         .allowlist_function("rb_RSTRING_LEN")
         .allowlist_function("rb_ENCODING_GET")
         .allowlist_function("rb_yjit_get_proc_ptr")
+        .allowlist_function("rb_RCLASS_SUPERCLASS_DEPTH")
         .allowlist_function("rb_yjit_exit_locations_dict")
         .allowlist_function("rb_yjit_icache_invalidate")
 

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -1326,6 +1326,38 @@ fn guard_object_is_heap(
     asm.jbe(side_exit.into());
 }
 
+fn chain_guard_object_is_heap(
+    jit: &JITState,
+    ctx: &mut Context,
+    asm: &mut Assembler,
+    ocb: &mut OutlinedCb,
+    object_opnd: Opnd,
+    insn_opnd: InsnOpnd,
+    depth_limit: i32,
+    side_exit: CodePtr,
+) {
+    let val_type = ctx.get_opnd_type(insn_opnd);
+
+    assert!(!val_type.is_imm());
+
+    if !val_type.is_heap() {
+        asm.comment("guard object is heap");
+
+        let mut ctx_imm = *ctx;
+        ctx_imm.upgrade_opnd_type(insn_opnd, Type::UnknownImm);
+
+        // Test that the object is not an immediate
+        asm.test(object_opnd, (RUBY_IMMEDIATE_MASK as u64).into());
+        jit_chain_guard(JCC_JNZ, jit, &ctx_imm, asm, ocb, depth_limit, side_exit);
+
+        // Test that the object is not false or nil
+        asm.cmp(object_opnd, Qnil.into());
+        jit_chain_guard(JCC_JBE, jit, &ctx_imm, asm, ocb, depth_limit, side_exit);
+
+        ctx.upgrade_opnd_type(insn_opnd, Type::UnknownHeap);
+    }
+}
+
 fn guard_object_is_array(
     asm: &mut Assembler,
     object_opnd: Opnd,
@@ -3528,17 +3560,16 @@ fn jit_guard_known_klass(
         assert!(!val_type.is_imm());
 
         // Check that the receiver is a heap object
-        // Note: if we get here, the class doesn't have immediate instances.
-        if !val_type.is_heap() {
-            asm.comment("guard not immediate");
-            assert!(Qfalse.as_i32() < Qnil.as_i32());
-            asm.test(obj_opnd, Opnd::Imm(RUBY_IMMEDIATE_MASK as i64));
-            jit_chain_guard(JCC_JNZ, jit, ctx, asm, ocb, max_chain_depth, side_exit);
-            asm.cmp(obj_opnd, Qnil.into());
-            jit_chain_guard(JCC_JBE, jit, ctx, asm, ocb, max_chain_depth, side_exit);
-
-            ctx.upgrade_opnd_type(insn_opnd, Type::UnknownHeap);
-        }
+        chain_guard_object_is_heap(
+            jit,
+            ctx,
+            asm,
+            ocb,
+            obj_opnd,
+            insn_opnd,
+            SEND_MAX_DEPTH,
+            side_exit
+            );
 
         // If obj_opnd isn't already a register, load it.
         let obj_opnd = match obj_opnd {
@@ -3969,6 +4000,191 @@ fn jit_thread_s_current(
     let stack_ret = ctx.stack_push(Type::UnknownHeap);
     asm.mov(stack_ret, thread_self);
     true
+}
+
+/// Returns whether any instance of this class or any of its subclasses can be an immediate special
+/// constant.
+fn class_or_subclass_can_be_immediate(klass: VALUE) -> bool {
+    assert!(unsafe { RB_TYPE_P(klass, RUBY_T_CLASS) });
+
+    return unsafe {
+        klass == rb_cInteger ||    // FIXNUM
+            klass == rb_cFloat ||      // FLONUM
+            klass == rb_cNumeric ||    // FIXNUM/FLONUM
+            klass == rb_cSymbol ||     // static symbol
+            klass == rb_cTrueClass ||  // Qtrue
+            klass == rb_cFalseClass || // Qfalse
+            klass == rb_cNilClass ||   // Qnil
+            klass == rb_cObject ||     // All of the above inherit Object
+            klass == rb_cBasicObject   // Everything inherits BasicObject
+    };
+}
+
+fn gen_branch_direct(
+    asm: &mut Assembler,
+    target0: CodePtr,
+    target1: Option<CodePtr>,
+    shape: BranchShape,
+) {
+    assert!(target1 == None);
+    match shape {
+        BranchShape::Default => {
+            asm.jmp(target0.into());
+        }
+        _ => unreachable!()
+    }
+}
+
+// Codegen for Module#===
+fn jit_rb_mod_eqq(
+    jit: &mut JITState,
+    ctx: &mut Context,
+    asm: &mut Assembler,
+    ocb: &mut OutlinedCb,
+    _ci: *const rb_callinfo,
+    _cme: *const rb_callable_method_entry_t,
+    _block: Option<IseqPtr>,
+    _argc: i32,
+    known_recv_class: *const VALUE,
+) -> bool {
+    asm.comment("Module#===");
+
+    // If we're here from invokesuper, we didn't guard on the class so don't actually know the
+    // class we're checking against. Use the generic implementation.
+    if known_recv_class.is_null() {
+        return false;
+    }
+
+    let comptime_arg = jit_peek_at_stack(jit, ctx, 0);
+    let comptime_arg_klass = comptime_arg.class_of();
+    let arg_type = ctx.get_opnd_type(StackOpnd(0));
+
+    let klass = unsafe { rb_attr_get(*known_recv_class, id__attached__ as ID) };
+
+    // Fast ancestry checks only exist between classes. If we're checking against a module use the
+    // fallback generic implementation.
+    if !klass.test() || !unsafe { RB_TYPE_P(klass, RUBY_T_CLASS) } {
+        return false;
+    }
+
+    let side_exit = get_side_exit(jit, ocb, ctx);
+
+    // If the class of the arg is known via ctx type information, we can just push the result.
+    // observed at compile time.
+    let known_result =
+        if let Some(known_klass) = arg_type.known_class() {
+            Some(unsafe { rb_class_search_ancestor(known_klass, klass) })
+        } else if arg_type.is_imm() && !class_or_subclass_can_be_immediate(klass) {
+            Some(Qfalse)
+        } else {
+            None
+        };
+
+    if known_result.is_some() {
+        let result = if known_result.unwrap().test() { Qtrue } else { Qfalse };
+        ctx.stack_pop(2);
+        jit_putobject(jit, ctx, asm, result);
+        return true;
+    }
+
+    if comptime_arg.special_const_p() {
+        // For immediate values, first we guard on the type of immediate we see at compile time and
+        // then push a constant result based on that.
+
+        jit_guard_known_klass(
+            jit,
+            ctx,
+            asm,
+            ocb,
+            comptime_arg_klass,
+            ctx.stack_opnd(0),
+            StackOpnd(0),
+            comptime_arg,
+            SEND_MAX_DEPTH,
+            side_exit,
+            );
+
+        let result = unsafe { rb_class_search_ancestor(comptime_arg_klass, klass) };
+        let result = if result.test() { Qtrue } else { Qfalse };
+        ctx.stack_pop(2);
+        jit_putobject(jit, ctx, asm, result);
+        return true;
+    } else {
+        chain_guard_object_is_heap(
+            jit,
+            ctx,
+            asm,
+            ocb,
+            ctx.stack_opnd(0),
+            StackOpnd(0),
+            SEND_MAX_DEPTH,
+            side_exit
+            );
+
+        let arg = ctx.stack_pop(1);
+        let _recv = ctx.stack_pop(1);
+
+        let return_true  = asm.new_label("return_true");
+        let return_false = asm.new_label("return_false");
+
+        let arg_val = asm.load(arg);
+
+        // For heap objects we use the superclasses array to determine whether the given class is
+        // in the class heirarchy of the given object. From here this always finds us an exact
+        // result without additional chain guards or side exits.
+        // See class_search_class_ancestor in object.c
+
+        // First we check for an exact match
+        asm.comment("return true if cl == c");
+        let klass_opnd = asm.load(Opnd::mem(64, arg_val, RUBY_OFFSET_RBASIC_KLASS));
+        asm.cmp(klass_opnd, klass.into());
+        asm.je(return_true);
+
+        // Next we do a bounds check on the superclass array. If the given class depth is outside
+        // the object's class's depth, we know it is not inherited.
+        asm.comment("return false if cl.depth <= c.depth");
+        let klass_depth = unsafe { rb_RCLASS_SUPERCLASS_DEPTH(klass) };
+        let depth_opnd = Opnd::mem(64, klass_opnd, RUBY_OFFSET_RCLASS_SUPERCLASS_DEPTH);
+        asm.cmp(depth_opnd, klass_depth.into());
+        asm.jbe(return_false);
+
+        // Finally check for the class in the superclass array at the expected index.
+        asm.comment("return cl.superclasses[c.depth] == c");
+        let superclasses_opnd = asm.load(Opnd::mem(64, klass_opnd, RUBY_OFFSET_RCLASS_SUPERCLASSES));
+        let superclasses_off = Opnd::mem(64, superclasses_opnd, klass_depth * SIZEOF_VALUE as i32);
+        asm.cmp(superclasses_off, klass.into());
+        asm.jne(return_false);
+
+        // fall through to return true
+        let stack_ret = ctx.stack_push(Type::UnknownImm);
+
+        {
+            asm.write_label(return_true);
+
+            // Create a new context where the pushed value is of type true
+            let mut true_ctx = *ctx;
+            true_ctx.reset_chain_depth();
+            true_ctx.upgrade_opnd_type(StackOpnd(0), Type::True);
+
+            asm.mov(stack_ret, Qtrue.into());
+            let next_block = BlockId {
+                iseq: jit.iseq,
+                idx: jit_next_insn_idx(jit),
+            };
+            gen_branch(jit, ctx, asm, ocb, next_block, &true_ctx, None, None, gen_branch_direct);
+        }
+
+        {
+            asm.write_label(return_false);
+
+            ctx.upgrade_opnd_type(StackOpnd(0), Type::False);
+            asm.mov(stack_ret, Qfalse.into());
+
+            // fall through
+        }
+
+        true
+    }
 }
 
 // Check if we know how to codegen for a particular cfunc method
@@ -6881,6 +7097,8 @@ impl CodegenGlobals {
             self.yjit_reg_method(rb_cString, "+@", jit_rb_str_uplus);
 
             self.yjit_reg_method(rb_mKernel, "respond_to?", jit_obj_respond_to);
+
+            self.yjit_reg_method(rb_cModule, "===", jit_rb_mod_eqq);
 
             // Thread.current
             self.yjit_reg_method(

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -112,6 +112,8 @@ pub use autogened::*;
 // Use bindgen for functions that are defined in headers or in yjit.c.
 #[cfg_attr(test, allow(unused))] // We don't link against C code when testing
 extern "C" {
+    // Ruby only defines these in vm_insnhelper.c, not in any header.
+    // Parsing it would result in a lot of duplicate definitions.
     pub fn rb_vm_splat_array(flag: VALUE, ary: VALUE) -> VALUE;
     pub fn rb_vm_concat_array(ary1: VALUE, ary2st: VALUE) -> VALUE;
     pub fn rb_vm_defined(
@@ -687,5 +689,9 @@ mod manual_defs {
     // Constants from iseq_inline_constant_cache (IC) and iseq_inline_constant_cache_entry (ICE) in vm_core.h
     pub const RUBY_OFFSET_IC_ENTRY: i32 = 0;
     pub const RUBY_OFFSET_ICE_VALUE: i32 = 8;
+
+    // From internal/class.h
+    pub const RUBY_OFFSET_RCLASS_SUPERCLASS_DEPTH: i32 = 32 + 40;
+    pub const RUBY_OFFSET_RCLASS_SUPERCLASSES: i32 = 32 + 48;
 }
 pub use manual_defs::*;

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -246,6 +246,9 @@ pub type ruby_rmodule_flags = u32;
 extern "C" {
     pub fn rb_class_get_superclass(klass: VALUE) -> VALUE;
 }
+extern "C" {
+    pub static mut rb_cObject: VALUE;
+}
 pub const ROBJECT_EMBED: ruby_robject_flags = 8192;
 pub type ruby_robject_flags = u32;
 pub const ROBJECT_OFFSET_NUMIV: i32 = 16;
@@ -260,6 +263,9 @@ extern "C" {
 }
 extern "C" {
     pub static mut rb_cArray: VALUE;
+}
+extern "C" {
+    pub static mut rb_cClass: VALUE;
 }
 extern "C" {
     pub static mut rb_cFalseClass: VALUE;
@@ -278,6 +284,9 @@ extern "C" {
 }
 extern "C" {
     pub static mut rb_cNilClass: VALUE;
+}
+extern "C" {
+    pub static mut rb_cNumeric: VALUE;
 }
 extern "C" {
     pub static mut rb_cString: VALUE;
@@ -412,6 +421,9 @@ extern "C" {
 }
 extern "C" {
     pub fn rb_reg_new_ary(ary: VALUE, options: ::std::os::raw::c_int) -> VALUE;
+}
+extern "C" {
+    pub fn rb_class_search_ancestor(klass: VALUE, super_: VALUE) -> VALUE;
 }
 pub type attr_index_t = u32;
 pub type shape_id_t = u32;
@@ -1569,6 +1581,9 @@ extern "C" {
 }
 extern "C" {
     pub fn rb_assert_cme_handle(handle: VALUE);
+}
+extern "C" {
+    pub fn rb_RCLASS_SUPERCLASS_DEPTH(c: VALUE) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn rb_yjit_for_each_iseq(callback: rb_iseq_callback, data: *mut ::std::os::raw::c_void);


### PR DESCRIPTION
This implements the fast class inheritance check algorithm described in https://github.com/ruby/ruby/pull/5568 for `Module#===` under YJIT.

When we have a heap object, this is done with three comparisons:
* First we check for an exact match (ie: same class without inheritance)
* Next we do a bounds check on the superclass array's depth
* Finally we check a single location superclassess array to get a result for the check

When we see an immediate object we use `jit_guard_known_klass` in order to use that logic for guarding the specific type of immediate we're seeing, and then pushing a constant true/false result.

Chain guards are very helpful for this because even the classes which usually are immediates (Integer, Float, Symbol) also appear as heap objects (bignums, heap floats, and heap symbols) so they likely need to be checked as both paths.

If we have enough information to return true/false just from the context type information, we do that. Wherever possible we learn more information to the ctx when branching/guarding.

### Example output

```
== BLOCK 363/401, ISEQ RANGE [1084,1086), 100 bytes ===========
  # opt_send_without_block
  # regenerate_branch
  # opt_send_without_block
  # guard known object with singleton class
  # regenerate_branch
  0x5621bc564f23: movabs rax, 0x7fc446f5b740
  0x5621bc564f2d: cmp qword ptr [rbx], rax
  0x5621bc564f30: jne 0x5621bc567002
  # Module#===
  0x5621bc564f36: mov rax, qword ptr [rbx + 8]
  # return true if cl == c
  0x5621bc564f3a: mov rax, qword ptr [rax + 8]
  0x5621bc564f3e: movabs rcx, 0x7fc446f5b740
  0x5621bc564f48: cmp rax, rcx
  0x5621bc564f4b: je 0x5621bc564f74
  # return false if cl.depth <= c.depth
  0x5621bc564f51: cmp qword ptr [rax + 0x48], 1
  0x5621bc564f56: jbe 0x5621bc564f80
  # return cl.superclasses[c.depth] == c
  0x5621bc564f5c: mov rax, qword ptr [rax + 0x50]
  0x5621bc564f60: movabs rcx, 0x7fc446f5b740
  0x5621bc564f6a: cmp qword ptr [rax + 8], rcx
  0x5621bc564f6e: jne 0x5621bc564f80
  0x5621bc564f74: mov qword ptr [rbx], 0x14
  0x5621bc564f7b: jmp 0x5621bc56701b
  0x5621bc564f80: mov qword ptr [rbx], 0
```

### Benchmark

This is a semi-realistic benchmark based on https://github.com/rails/rails/blob/main/activesupport/lib/active_support/json/encoding.rb#L92-L109 (this is the heaviest user of `Module#===` based on Railsbench)

```
def jsonify(value)
  case value
  when String
    value
  when Numeric, NilClass, TrueClass, FalseClass
    value
  when Hash
    value.each do |k, v|
      jsonify(k)
      jsonify(v)
    end
  when Array
    value.each { |v| jsonify(v) }
  when Symbol
    value.name
  else
    raise
  end
end

data = {:_rails=>{:message=>"test", :exp=>nil, :pur=>"test"}}
5_000_000.times { jsonify(data) }
```

**Ruby 3.1**
```
ruby --disable-gems --yjit-call-threshold=2 benchmark_jsonify.rb  3.22s user 0.09s system 99% cpu 3.311 total
```

**Ruby trunk (a923203811)**
```
ruby --disable-gems --yjit-call-threshold=2 benchmark_jsonify.rb  2.89s user 0.00s system 99% cpu 2.894 total
```

**This branch**
```
./ruby --disable-gems --yjit-call-threshold=2 benchmark_jsonify.rb  1.64s user 0.01s system 99% cpu 1.643 total
```

In micro benchmarks this is more than 2x faster.