### PR TITLE
[wasm] Scan machine stack based on `ec->machine.stack_{start,end}`

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -6756,8 +6756,10 @@ mark_current_machine_context(rb_objspace_t *objspace, rb_execution_context_t *ec
 static void
 mark_current_machine_context(rb_objspace_t *objspace, rb_execution_context_t *ec)
 {
-    rb_wasm_scan_stack(rb_mark_locations);
-    each_stack_location(objspace, ec, rb_stack_range_tmp[0], rb_stack_range_tmp[1], gc_mark_maybe);
+    VALUE *stack_start, *stack_end;
+    SET_STACK_END;
+    GET_STACK_BOUNDS(stack_start, stack_end, 1);
+    each_stack_location(objspace, ec, stack_start, stack_end, gc_mark_maybe);
 
     rb_wasm_scan_locals(rb_mark_locations);
     each_stack_location(objspace, ec, rb_stack_range_tmp[0], rb_stack_range_tmp[1], gc_mark_maybe);

--- a/thread_none.c
+++ b/thread_none.c
@@ -15,6 +15,10 @@
 
 #include <time.h>
 
+#if defined(__wasm__) && !defined(__EMSCRIPTEN__)
+# include "wasm/machine.h"
+#endif
+
 #define TIME_QUANTUM_MSEC (100)
 #define TIME_QUANTUM_USEC (TIME_QUANTUM_MSEC * 1000)
 #define TIME_QUANTUM_NSEC (TIME_QUANTUM_USEC * 1000)
@@ -143,6 +147,9 @@ ruby_init_stack(volatile VALUE *addr)
 static int
 native_thread_init_stack(rb_thread_t *th)
 {
+#if defined(__wasm__) && !defined(__EMSCRIPTEN__)
+    th->ec->machine.stack_start = (VALUE *)rb_wasm_stack_get_base();
+#endif
     return 0; // success
 }
 

--- a/wasm/machine.c
+++ b/wasm/machine.c
@@ -49,10 +49,10 @@ rb_wasm_record_stack_base(void)
     return 0;
 }
 
-void
-_rb_wasm_scan_stack(rb_wasm_scan_func scan, void *current)
+void *
+rb_wasm_stack_get_base(void)
 {
-    scan(current, rb_wasm_stack_base);
+    return rb_wasm_stack_base;
 }
 
 void *

--- a/wasm/machine.h
+++ b/wasm/machine.h
@@ -8,9 +8,8 @@ typedef void (*rb_wasm_scan_func)(void*, void*);
 // Used by conservative GC
 void rb_wasm_scan_locals(rb_wasm_scan_func scan);
 
-// Scan userland C-stack memory space in WebAssembly. Used by conservative GC
-#define rb_wasm_scan_stack(scan) _rb_wasm_scan_stack((scan), rb_wasm_get_stack_pointer())
-void _rb_wasm_scan_stack(rb_wasm_scan_func scan, void *current);
+// Get base address of userland C-stack memory space in WebAssembly. Used by conservative GC
+void *rb_wasm_stack_get_base(void);
 
 
 // Get the current stack pointer


### PR DESCRIPTION
fiber machine stack is placed outside of C stack allocated by wasm-ld, so highest stack address recorded by `rb_wasm_record_stack_base` is invalid when running on non-main fiber.
Therefore, we should scan `stack_{start,end}` which always point a valid stack range in any context.