### PR TITLE
mutex: Raise a ThreadError when detecting a fiber deadlock

### DIFF
--- a/thread_sync.c
+++ b/thread_sync.c
@@ -327,6 +327,10 @@ do_mutex_lock(VALUE self, int interruptible_p)
                 }
             }
             else {
+                if (!th->vm->thread_ignore_deadlock && rb_fiber_threadptr(mutex->fiber) == th) {
+                    rb_raise(rb_eThreadError, "deadlock; lock already owned by another fiber belonging to the same thread");
+                }
+
                 enum rb_thread_status prev_status = th->status;
                 rb_hrtime_t *timeout = 0;
                 rb_hrtime_t rel = rb_msec2hrtime(100);


### PR DESCRIPTION
[[Bug #19105]](https://bugs.ruby-lang.org/issues/19105)

If no fiber scheduler is registered and the fiber that owns the lock and the one that try to acquire it
both belong to the same thread, we're in a deadlock case.

Ref: https://bugs.ruby-lang.org/issues/17827#note-10

cc @eregon @ioquatix WDYT?