### PR TITLE
Rewrite Symbol#to_sym and #intern in Ruby

### DIFF
--- a/.document
+++ b/.document
@@ -23,6 +23,7 @@ nilclass.rb
 pack.rb
 ractor.rb
 string.rb
+symbol.rb
 timev.rb
 thread_sync.rb
 trace_point.rb

--- a/common.mk
+++ b/common.mk
@@ -1104,6 +1104,7 @@ BUILTIN_RB_SRCS = \
 		$(srcdir)/array.rb \
 		$(srcdir)/kernel.rb \
 		$(srcdir)/ractor.rb \
+		$(srcdir)/symbol.rb \
 		$(srcdir)/timev.rb \
 		$(srcdir)/thread_sync.rb \
 		$(srcdir)/nilclass.rb \
@@ -9600,6 +9601,7 @@ miniinit.$(OBJEXT): {$(VPATH)}ruby_atomic.h
 miniinit.$(OBJEXT): {$(VPATH)}shape.h
 miniinit.$(OBJEXT): {$(VPATH)}st.h
 miniinit.$(OBJEXT): {$(VPATH)}subst.h
+miniinit.$(OBJEXT): {$(VPATH)}symbol.rb
 miniinit.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).h
 miniinit.$(OBJEXT): {$(VPATH)}thread_native.h
 miniinit.$(OBJEXT): {$(VPATH)}thread_sync.rb
@@ -15425,6 +15427,7 @@ symbol.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 symbol.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
 symbol.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 symbol.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
+symbol.$(OBJEXT): {$(VPATH)}builtin.h
 symbol.$(OBJEXT): {$(VPATH)}config.h
 symbol.$(OBJEXT): {$(VPATH)}constant.h
 symbol.$(OBJEXT): {$(VPATH)}debug_counter.h
@@ -15597,6 +15600,8 @@ symbol.$(OBJEXT): {$(VPATH)}st.h
 symbol.$(OBJEXT): {$(VPATH)}subst.h
 symbol.$(OBJEXT): {$(VPATH)}symbol.c
 symbol.$(OBJEXT): {$(VPATH)}symbol.h
+symbol.$(OBJEXT): {$(VPATH)}symbol.rb
+symbol.$(OBJEXT): {$(VPATH)}symbol.rbinc
 symbol.$(OBJEXT): {$(VPATH)}vm_debug.h
 symbol.$(OBJEXT): {$(VPATH)}vm_sync.h
 thread.$(OBJEXT): $(CCAN_DIR)/check_type/check_type.h

--- a/inits.c
+++ b/inits.c
@@ -99,6 +99,7 @@ rb_call_builtin_inits(void)
     BUILTIN(warning);
     BUILTIN(array);
     BUILTIN(kernel);
+    BUILTIN(symbol);
     BUILTIN(timev);
     BUILTIN(thread_sync);
     BUILTIN(yjit);

--- a/string.c
+++ b/string.c
@@ -11524,23 +11524,6 @@ rb_sym_to_s(VALUE sym)
     return str_new_shared(rb_cString, rb_sym2str(sym));
 }
 
-/*
- *  call-seq:
- *    to_sym -> self
- *
- *  Returns +self+.
- *
- *  Symbol#intern is an alias for Symbol#to_sym.
- *
- *  Related: String#to_sym.
- */
-
-static VALUE
-sym_to_sym(VALUE sym)
-{
-    return sym;
-}
-
 MJIT_FUNC_EXPORTED VALUE
 rb_sym_proc_call(ID mid, int argc, const VALUE *argv, int kw_splat, VALUE passed_proc)
 {
@@ -12107,8 +12090,6 @@ Init_String(void)
     rb_define_method(rb_cSymbol, "to_s", rb_sym_to_s, 0);
     rb_define_method(rb_cSymbol, "id2name", rb_sym_to_s, 0);
     rb_define_method(rb_cSymbol, "name", rb_sym2str, 0); /* in symbol.c */
-    rb_define_method(rb_cSymbol, "intern", sym_to_sym, 0);
-    rb_define_method(rb_cSymbol, "to_sym", sym_to_sym, 0);
     rb_define_method(rb_cSymbol, "to_proc", rb_sym_to_proc, 0); /* in proc.c */
     rb_define_method(rb_cSymbol, "succ", sym_succ, 0);
     rb_define_method(rb_cSymbol, "next", sym_succ, 0);

--- a/symbol.c
+++ b/symbol.c
@@ -22,6 +22,7 @@
 #include "ruby/st.h"
 #include "symbol.h"
 #include "vm_sync.h"
+#include "builtin.h"
 
 #ifndef USE_SYMBOL_GC
 # define USE_SYMBOL_GC 1
@@ -1262,3 +1263,4 @@ rb_is_local_name(VALUE name)
 }
 
 #include "id_table.c"
+#include "symbol.rbinc"

--- a/symbol.rb
+++ b/symbol.rb
@@ -1,0 +1,15 @@
+class Symbol
+  # call-seq:
+  #   to_sym -> self
+  #
+  # Returns +self+.
+  #
+  # Symbol#intern is an alias for Symbol#to_sym.
+  #
+  # Related: String#to_sym.
+  def to_sym
+    self
+  end
+
+  alias intern to_sym
+end


### PR DESCRIPTION
## Benchmark
### VM
It doesn't slow down the interpreter:

```
$ benchmark-driver -v --chruby 'before;after' ':sym.to_sym'
before: ruby 3.2.0dev (2022-11-15T08:34:00Z master 1a9e87fe3a) [x86_64-linux]
after: ruby 3.2.0dev (2022-11-15T08:38:30Z builtin-sym-to-sym 43fb0e94cb) [x86_64-linux]
Warming up --------------------------------------
         :sym.to_sym    42.107M i/s -     42.341M times in 1.005555s (23.75ns/i, 68clocks/i)
Calculating -------------------------------------
                         before       after
         :sym.to_sym    60.844M     69.503M i/s -    126.321M times in 2.076139s 1.817497s

Comparison:
                      :sym.to_sym
               after:  69502715.5 i/s
              before:  60844185.9 i/s - 1.14x  slower
```

### MJIT
MJIT has method inlining, so calling this method becomes faster. (Using `--runner=block` because MJIT doesn't compile top-level ISeqs. So the i/s numbers can't be compared with other results)

```
$ benchmark-driver -v --runner=block --chruby 'before --mjit;after --mjit' ':sym.to_sym'
before --mjit: ruby 3.2.0dev (2022-11-15T08:34:00Z master 1a9e87fe3a) +MJIT [x86_64-linux]
after --mjit: ruby 3.2.0dev (2022-11-15T08:38:30Z builtin-sym-to-sym 43fb0e94cb) +MJIT [x86_64-linux]
Warming up --------------------------------------
         :sym.to_sym       29.554M i/s -     29.941M times in 1.013091s (33.84ns/i, 126clocks/i)
Calculating -------------------------------------
                     before --mjit  after --mjit
         :sym.to_sym       37.037M       47.251M i/s -     88.661M times in 2.393876s 1.876395s

Comparison:
                      :sym.to_sym
        after --mjit:  47250836.8 i/s
       before --mjit:  37036677.0 i/s - 1.28x  slower
```

### YJIT
YJIT doesn't have method inlining yet, but this PR doesn't make YJIT slower.

```
$ benchmark-driver -v --chruby 'before --yjit;after --yjit' ':sym.to_sym'
before --yjit: ruby 3.2.0dev (2022-11-15T08:34:00Z master 1a9e87fe3a) +YJIT [x86_64-linux]
after --yjit: ruby 3.2.0dev (2022-11-15T08:38:30Z builtin-sym-to-sym 43fb0e94cb) +YJIT [x86_64-linux]
Warming up --------------------------------------
         :sym.to_sym       44.355M i/s -     44.893M times in 1.012133s (22.55ns/i, 85clocks/i)
Calculating -------------------------------------
                     before --yjit  after --yjit
         :sym.to_sym       60.814M       67.980M i/s -    133.066M times in 2.188084s 1.957411s

Comparison:
                      :sym.to_sym
        after --yjit:  67980378.9 i/s
       before --yjit:  60813714.4 i/s - 1.12x  slower
```