### PR TITLE
Rewrite Array#each in Ruby

### DIFF
--- a/array.c
+++ b/array.c
@@ -8643,7 +8643,6 @@ Init_Array(void)
     rb_define_method(rb_cArray, "unshift", rb_ary_unshift_m, -1);
     rb_define_alias(rb_cArray,  "prepend", "unshift");
     rb_define_method(rb_cArray, "insert", rb_ary_insert, -1);
-    rb_define_method(rb_cArray, "each", rb_ary_each, 0);
     rb_define_method(rb_cArray, "each_index", rb_ary_each_index, 0);
     rb_define_method(rb_cArray, "reverse_each", rb_ary_reverse_each, 0);
     rb_define_method(rb_cArray, "length", rb_ary_length, 0);

--- a/array.rb
+++ b/array.rb
@@ -1,5 +1,59 @@
 class Array
   # call-seq:
+  #   array.each {|element| ... } -> self
+  #   array.each -> Enumerator
+  #
+  # Iterates over array elements.
+  #
+  # When a block given, passes each successive array element to the block;
+  # returns +self+:
+  #
+  #   a = [:foo, 'bar', 2]
+  #   a.each {|element|  puts "#{element.class} #{element}" }
+  #
+  # Output:
+  #
+  #   Symbol foo
+  #   String bar
+  #   Integer 2
+  #
+  # Allows the array to be modified during iteration:
+  #
+  #   a = [:foo, 'bar', 2]
+  #   a.each {|element| puts element; a.clear if element.to_s.start_with?('b') }
+  #
+  # Output:
+  #
+  #   foo
+  #   bar
+  #
+  # When no block given, returns a new Enumerator:
+  #   a = [:foo, 'bar', 2]
+  #
+  #   e = a.each
+  #   e # => #<Enumerator: [:foo, "bar", 2]:each>
+  #   a1 = e.each {|element|  puts "#{element.class} #{element}" }
+  #
+  # Output:
+  #
+  #   Symbol foo
+  #   String bar
+  #   Integer 2
+  #
+  # Related: #each_index, #reverse_each.
+  def each
+    unless block_given?
+      return to_enum(:each) { self.length }
+    end
+    i = 0
+    while i < self.length
+      yield self[i]
+      i = i.succ
+    end
+    self
+  end
+
+  # call-seq:
   #    array.shuffle!(random: Random) -> array
   #
   # Shuffles the elements of +self+ in place.

--- a/benchmark/loop_each.yml
+++ b/benchmark/loop_each.yml
@@ -1,0 +1,4 @@
+prelude: |
+  arr = [nil] * 30_000_000
+benchmark:
+  loop_each: arr.each{|e|}

--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -4347,3 +4347,8 @@ assert_equal '0', %q{
 
   entry
 }
+
+# Integer succ and overflow
+assert_equal '[2, 4611686018427387904]', %q{
+  [1.succ, 4611686018427387903.succ]
+}

--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -19,6 +19,6 @@ matrix          0.4.2   https://github.com/ruby/matrix
 prime           0.1.2   https://github.com/ruby/prime
 rbs             3.4.1   https://github.com/ruby/rbs
 typeprof        0.21.9  https://github.com/ruby/typeprof
-debug           1.9.1   https://github.com/ruby/debug
+debug           1.9.1   https://github.com/ruby/debug 19b91b14ce814a0eb615abb8d2bef0594c61c5c8
 racc            1.7.3   https://github.com/ruby/racc
 mutex_m         0.2.0   https://github.com/ruby/mutex_m

--- a/test/ruby/test_gc_compact.rb
+++ b/test/ruby/test_gc_compact.rb
@@ -373,7 +373,7 @@ class TestGCCompact < Test::Unit::TestCase
 
       Fiber.new {
         $ary = OBJ_COUNT.times.map { Foo.new }
-        $ary.each(&:add_ivars)
+        $ary.reverse_each(&:add_ivars)
 
         GC.start
         Foo.new.add_ivars

--- a/test/ruby/test_settracefunc.rb
+++ b/test/ruby/test_settracefunc.rb
@@ -504,7 +504,7 @@ class TestSetTraceFunc < Test::Unit::TestCase
     1: trace = TracePoint.trace(*trace_events){|tp| next if !target_thread?
     2:   events << [tp.event, tp.lineno, tp.path, _defined_class.(tp), tp.method_id, tp.self, tp.binding&.eval("_local_var"), _get_data.(tp)] if tp.path == 'xyzzy'
     3: }
-    4: [1].each{|;_local_var| _local_var = :inner
+    4: [1].reverse_each{|;_local_var| _local_var = :inner
     5:   tap{}
     6: }
     7: class XYZZY
@@ -531,10 +531,10 @@ class TestSetTraceFunc < Test::Unit::TestCase
     answer_events = [
      #
      [:line,     4, 'xyzzy', self.class,  method,           self,        :outer, :nothing],
-     [:c_call,   4, 'xyzzy', Array,       :each,            [1],         nil,    :nothing],
+     [:c_call,   4, 'xyzzy', Array,       :reverse_each,    [1],         nil,    :nothing],
      [:line,     4, 'xyzzy', self.class,  method,           self,        nil,    :nothing],
      [:line,     5, 'xyzzy', self.class,  method,           self,        :inner, :nothing],
-     [:c_return, 4, "xyzzy", Array,       :each,            [1],         nil, [1]],
+     [:c_return, 4, "xyzzy", Array,       :reverse_each,    [1],         nil, [1]],
      [:line,     7, 'xyzzy', self.class,  method,           self,        :outer, :nothing],
      [:c_call,   7, "xyzzy", Module,      :const_added,     TestSetTraceFunc, nil, :nothing],
      [:c_return, 7, "xyzzy", Module,      :const_added,     TestSetTraceFunc, nil, nil],

--- a/yjit.rb
+++ b/yjit.rb
@@ -284,6 +284,7 @@ module RubyVM::YJIT
         opt_mod
         opt_mult
         opt_plus
+        opt_succ
         setlocal
       ].each do |insn|
         print_counters(stats, out: out, prefix: "#{insn}_", prompt: "#{insn} exit reasons:", optional: true)

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -444,6 +444,9 @@ make_counters! {
     opt_minus_overflow,
     opt_mult_overflow,
 
+    opt_succ_not_fixnum,
+    opt_succ_overflow,
+
     opt_mod_zero,
     opt_div_zero,
 


### PR DESCRIPTION
Similarly to `Integer#times` https://github.com/ruby/ruby/pull/8388, this PR rewrites `Array#each` in Ruby.

## microbenchmark
### Interpreter
It's a bit slower than the original C method.

```
$ benchmark-driver benchmark/loop_each.yml -v --chruby 'before;after'
before: ruby 3.4.0dev (2024-01-13T00:28:26Z master f7178045bb) [x86_64-linux]
after: ruby 3.4.0dev (2024-01-13T04:31:50Z builtin-array-each 18c9a45314) [x86_64-linux]
Warming up --------------------------------------
           loop_each      2.129 i/s -       3.000 times in 1.408852s (469.62ms/i)
Calculating -------------------------------------
                         before       after
           loop_each      2.103       1.545 i/s -       6.000 times in 2.852494s 3.882698s

Comparison:
                        loop_each
              before:         2.1 i/s
               after:         1.5 i/s - 1.36x  slower
```

### YJIT

It's 5.3x faster.

```
$ benchmark-driver benchmark/loop_each.yml -v --chruby 'before::before --yjit-call-threshold=1;after::after --yjit-call-threshold=1'
before: ruby 3.4.0dev (2024-01-13T00:28:26Z master f7178045bb) +YJIT [x86_64-linux]
after: ruby 3.4.0dev (2024-01-13T04:31:50Z builtin-array-each 18c9a45314) +YJIT [x86_64-linux]
Warming up --------------------------------------
           loop_each      2.451 i/s -       3.000 times in 1.223915s (407.97ms/i)
Calculating -------------------------------------
                         before       after
           loop_each      2.456      13.074 i/s -       7.000 times in 2.850521s 0.535404s

Comparison:
                        loop_each
               after:        13.1 i/s
              before:         2.5 i/s - 5.32x  slower
```
```