### PR TITLE
Fix false LocalJumpError when branch coverage is enabled

### DIFF
--- a/test/coverage/test_coverage.rb
+++ b/test/coverage/test_coverage.rb
@@ -964,4 +964,18 @@ class TestCoverage < Test::Unit::TestCase
       p :NG
     end;
   end
+
+  def test_tag_break_with_branch_coverage
+    result = {
+      :branches => {
+        [:"&.", 0, 1, 0, 1, 6] => {
+          [:then, 1, 1, 0, 1, 6] => 1,
+          [:else, 2, 1, 0, 1, 6] => 0,
+        },
+      },
+    }
+    assert_coverage(<<~"end;", { branches: true }, result)
+      1&.tap do break end
+    end;
+  end
 end


### PR DESCRIPTION
`throw TAG_BREAK` instruction makes a jump only if the continuation of catch of TAG_BREAK exactly matches the instruction immediately following the "send" instruction that is currently being executed. Otherwise, it seems to determine break from proc-closure.

Branch coverage may insert some recording instructions after "send" instruction, which broke the conditions for TAG_BREAK to work properly.

This change forces to set the continuation of catch of TAG_BREAK immediately after "send" (or "invokesuper") instruction.

[Bug #18991]