### PR TITLE
[doc] Clarify how to build OpenSSL on macOS

### DIFF
--- a/doc/contributing/building_ruby.md
+++ b/doc/contributing/building_ruby.md
@@ -69,11 +69,7 @@
             Check ext/openssl/mkmf.log for more details.
         ```
 
-        Running the following command may solve the issue:
-
-        ```
-        brew link openssl --force
-        ```
+        Adding `--with-openssl-dir=$(brew --prefix openssl)` to the list of options passed to configure may solve the issue.
 
         Remember to delete your `build` directory and start again from the configure step.
 


### PR DESCRIPTION
We should explain how to use `--with-openssl-dir` before `brew link --force` as that's what the error message recommends, and it doesn't require the user to make system modifications.