### PR TITLE
Enable --yjit-stats for release builds

### DIFF
--- a/yjit.rb
+++ b/yjit.rb
@@ -147,7 +147,7 @@ module RubyVM::YJIT
     avg_len_in_yjit = retired_in_yjit.to_f / total_exits
 
     # This only available on yjit stats builds
-    if stats.has_key?(:vm_insns_count)
+    if stats.key?(:vm_insns_count)
       # Proportion of instructions that retire in YJIT
       total_insns_count = retired_in_yjit + stats[:vm_insns_count]
       yjit_ratio_pct = 100.0 * retired_in_yjit.to_f / total_insns_count

--- a/yjit.rb
+++ b/yjit.rb
@@ -146,14 +146,17 @@ module RubyVM::YJIT
     # Average length of instruction sequences executed by YJIT
     avg_len_in_yjit = retired_in_yjit.to_f / total_exits
 
-    # Proportion of instructions that retire in YJIT
-    total_insns_count = retired_in_yjit + stats[:vm_insns_count]
-    yjit_ratio_pct = 100.0 * retired_in_yjit.to_f / total_insns_count
+    # This only available on yjit stats builds
+    if stats.has_key?(:vm_insns_count)
+      # Proportion of instructions that retire in YJIT
+      total_insns_count = retired_in_yjit + stats[:vm_insns_count]
+      yjit_ratio_pct = 100.0 * retired_in_yjit.to_f / total_insns_count
+      stats[:ratio_in_yjit] = yjit_ratio_pct
+    end
 
     # Make those stats available in RubyVM::YJIT.runtime_stats as well
     stats[:side_exit_count]  = side_exits
     stats[:total_exit_count] = total_exits
-    stats[:ratio_in_yjit]    = yjit_ratio_pct
     stats[:avg_len_in_yjit]  = avg_len_in_yjit
 
     stats
@@ -239,13 +242,16 @@ module RubyVM::YJIT
       $stderr.puts "freed_page_count:      " + ("%10d" % stats[:freed_page_count])
       $stderr.puts "code_gc_count:         " + ("%10d" % stats[:code_gc_count])
       $stderr.puts "num_gc_obj_refs:       " + ("%10d" % stats[:num_gc_obj_refs])
-
       $stderr.puts "side_exit_count:       " + ("%10d" % stats[:side_exit_count])
       $stderr.puts "total_exit_count:      " + ("%10d" % stats[:side_exit_count])
       $stderr.puts "total_insns_count:     " + ("%10d" % stats[:total_exit_count])
-      $stderr.puts "vm_insns_count:        " + ("%10d" % stats[:vm_insns_count])
+      if stats.has_key?(:vm_insns_count)
+        $stderr.puts "vm_insns_count:        " + ("%10d" % stats[:vm_insns_count])
+      end
       $stderr.puts "yjit_insns_count:      " + ("%10d" % stats[:exec_instruction])
-      $stderr.puts "ratio_in_yjit:         " + ("%9.1f" % stats[:ratio_in_yjit]) + "%"
+      if stats.has_key?(:ratio_in_yjit)
+        $stderr.puts "ratio_in_yjit:         " + ("%9.1f" % stats[:ratio_in_yjit]) + "%"
+      end
       $stderr.puts "avg_len_in_yjit:       " + ("%10.1f" % stats[:avg_len_in_yjit])
 
       print_sorted_exit_counts(stats, prefix: "exit_")

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -7,7 +7,6 @@ use crate::core::*;
 use crate::cruby::*;
 use crate::invariants::*;
 use crate::options::*;
-#[cfg(feature = "stats")]
 use crate::stats::*;
 use crate::utils::*;
 use CodegenStatus::*;
@@ -181,12 +180,6 @@ fn jit_peek_at_block_handler(jit: &JITState, level: u32) -> VALUE {
     }
 }
 
-/// Increment a profiling counter with counter_name
-#[cfg(not(feature = "stats"))]
-macro_rules! gen_counter_incr {
-    ($asm:tt, $counter_name:ident) => {};
-}
-#[cfg(feature = "stats")]
 macro_rules! gen_counter_incr {
     ($asm:tt, $counter_name:ident) => {
         if (get_option!(gen_stats)) {
@@ -204,15 +197,6 @@ macro_rules! gen_counter_incr {
     };
 }
 
-/// Increment a counter then take an existing side exit
-#[cfg(not(feature = "stats"))]
-macro_rules! counted_exit {
-    ($ocb:tt, $existing_side_exit:tt, $counter_name:ident) => {{
-        let _ = $ocb;
-        $existing_side_exit
-    }};
-}
-#[cfg(feature = "stats")]
 macro_rules! counted_exit {
     ($ocb:tt, $existing_side_exit:tt, $counter_name:ident) => {
         // The counter is only incremented when stats are enabled
@@ -422,7 +406,6 @@ fn gen_exit(exit_pc: *mut VALUE, ctx: &Context, asm: &mut Assembler) {
     );
 
     // Accumulate stats about interpreter exits
-    #[cfg(feature = "stats")]
     if get_option!(gen_stats) {
         asm.ccall(
             rb_yjit_count_side_exit_op as *const u8,

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -289,12 +289,12 @@ make_counters! {
 /// Check if stats generation is enabled
 #[no_mangle]
 pub extern "C" fn rb_yjit_stats_enabled_p(_ec: EcPtr, _ruby_self: VALUE) -> VALUE {
-    #[cfg(feature = "stats")]
+
     if get_option!(gen_stats) {
         return Qtrue;
+    } else {
+        return Qfalse;
     }
-
-    return Qfalse;
 }
 
 /// Primitive called in yjit.rb.
@@ -404,7 +404,7 @@ fn rb_yjit_gen_stats_dict() -> VALUE {
     }
 
     // If the stats feature is enabled
-    #[cfg(feature = "stats")]
+
     unsafe {
         // Indicate that the complete set of stats is available
         rb_hash_aset(hash, rust_str_to_sym("all_stats"), Qtrue);
@@ -414,6 +414,13 @@ fn rb_yjit_gen_stats_dict() -> VALUE {
             // Get the counter value
             let counter_ptr = get_counter_ptr(counter_name);
             let counter_val = *counter_ptr;
+
+            #[cfg(not(feature = "stats"))]
+            if counter_name == &"vm_insns_count" {
+                // If the stats feature is disabled, we don't have vm_insns_count
+                // so we are going to exlcude the key
+                continue;
+            }
 
             // Put counter into hash
             let key = rust_str_to_sym(counter_name);


### PR DESCRIPTION
In order for people in the real world to report information about how their application runs with YJIT, we want to expose stats without requiring rebuilding ruby. We can do this without overhead, with the exception of count ratio in yjit, since this relies on the interpreter also counting instructions.

This change exposes those stats, while not showing ratio in yjit if we are not in a stats build.