### PR TITLE
Fixes hidden OPENSSL_LIBRARY_VERSION description fix

### DIFF
--- a/ext/openssl/ossl.c
+++ b/ext/openssl/ossl.c
@@ -1179,12 +1179,15 @@ Init_openssl(void)
      */
     rb_define_const(mOSSL, "OPENSSL_VERSION", rb_str_new2(OPENSSL_VERSION_TEXT));
 
+#if !defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x10100000
     /*
      * Version of OpenSSL the ruby OpenSSL extension is running with
      */
-#if !defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x10100000
     rb_define_const(mOSSL, "OPENSSL_LIBRARY_VERSION", rb_str_new2(OpenSSL_version(OPENSSL_VERSION)));
 #else
+    /*
+     * Version of OpenSSL the ruby OpenSSL extension is running with
+     */
     rb_define_const(mOSSL, "OPENSSL_LIBRARY_VERSION", rb_str_new2(SSLeay_version(SSLEAY_VERSION)));
 #endif
 


### PR DESCRIPTION
Adds back missing constant description on the documentation

Currently:
<img width="587" alt="image" src="https://user-images.githubusercontent.com/15916283/200743892-51738382-9603-4272-9510-f1d314e2a5c6.png">

After fix:
<img width="605" alt="image" src="https://user-images.githubusercontent.com/15916283/200743987-6f57e21e-d862-4326-bfbf-54ee1abaf0f9.png">


Thanks @schneems for pointing out the problem