### PR TITLE
Introduce encoding check macro

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -10820,6 +10820,7 @@ parse.$(OBJEXT): $(top_srcdir)/internal/bits.h
 parse.$(OBJEXT): $(top_srcdir)/internal/compile.h
 parse.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 parse.$(OBJEXT): $(top_srcdir)/internal/complex.h
+parse.$(OBJEXT): $(top_srcdir)/internal/encoding.h
 parse.$(OBJEXT): $(top_srcdir)/internal/error.h
 parse.$(OBJEXT): $(top_srcdir)/internal/fixnum.h
 parse.$(OBJEXT): $(top_srcdir)/internal/gc.h
@@ -12234,6 +12235,7 @@ re.$(OBJEXT): $(top_srcdir)/internal/array.h
 re.$(OBJEXT): $(top_srcdir)/internal/bits.h
 re.$(OBJEXT): $(top_srcdir)/internal/class.h
 re.$(OBJEXT): $(top_srcdir)/internal/compilers.h
+re.$(OBJEXT): $(top_srcdir)/internal/encoding.h
 re.$(OBJEXT): $(top_srcdir)/internal/gc.h
 re.$(OBJEXT): $(top_srcdir)/internal/hash.h
 re.$(OBJEXT): $(top_srcdir)/internal/imemo.h
@@ -14768,6 +14770,7 @@ st.$(OBJEXT): {$(VPATH)}st.h
 st.$(OBJEXT): {$(VPATH)}subst.h
 strftime.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 strftime.$(OBJEXT): $(top_srcdir)/internal/compilers.h
+strftime.$(OBJEXT): $(top_srcdir)/internal/encoding.h
 strftime.$(OBJEXT): $(top_srcdir)/internal/serial.h
 strftime.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 strftime.$(OBJEXT): $(top_srcdir)/internal/string.h

--- a/ext/ripper/depend
+++ b/ext/ripper/depend
@@ -231,6 +231,7 @@ ripper.o: $(top_srcdir)/internal/bits.h
 ripper.o: $(top_srcdir)/internal/compile.h
 ripper.o: $(top_srcdir)/internal/compilers.h
 ripper.o: $(top_srcdir)/internal/complex.h
+ripper.o: $(top_srcdir)/internal/encoding.h
 ripper.o: $(top_srcdir)/internal/error.h
 ripper.o: $(top_srcdir)/internal/fixnum.h
 ripper.o: $(top_srcdir)/internal/gc.h

--- a/internal/encoding.h
+++ b/internal/encoding.h
@@ -12,9 +12,9 @@
 #include "ruby/encoding.h"      /* for rb_encoding */
 
 #define rb_enc_autoload_p(enc) (!rb_enc_mbmaxlen(enc))
-#define rb_is_usascii_enc(enc) (enc) == rb_usascii_encoding()
-#define rb_is_ascii8bit_enc(enc) (enc) == rb_ascii8bit_encoding()
-#define rb_is_locale_enc(enc) (enc) == rb_locale_encoding()
+#define rb_is_usascii_enc(enc) ((enc) == rb_usascii_encoding())
+#define rb_is_ascii8bit_enc(enc) ((enc) == rb_ascii8bit_encoding())
+#define rb_is_locale_enc(enc) ((enc) == rb_locale_encoding())
 
 /* encoding.c */
 ID rb_id_encoding(void);

--- a/internal/encoding.h
+++ b/internal/encoding.h
@@ -12,6 +12,9 @@
 #include "ruby/encoding.h"      /* for rb_encoding */
 
 #define rb_enc_autoload_p(enc) (!rb_enc_mbmaxlen(enc))
+#define rb_is_usascii_enc(enc) (enc) == rb_usascii_encoding()
+#define rb_is_ascii8bit_enc(enc) (enc) == rb_ascii8bit_encoding()
+#define rb_is_locale_enc(enc) (enc) == rb_locale_encoding()
 
 /* encoding.c */
 ID rb_id_encoding(void);

--- a/io.c
+++ b/io.c
@@ -1646,7 +1646,7 @@ make_writeconv(rb_io_t *fptr)
         ecflags = fptr->encs.ecflags & ~ECONV_NEWLINE_DECORATOR_READ_MASK;
         ecopts = fptr->encs.ecopts;
 
-        if (!fptr->encs.enc || (fptr->encs.enc == rb_ascii8bit_encoding() && !fptr->encs.enc2)) {
+        if (!fptr->encs.enc || (rb_is_ascii8bit_enc(fptr->encs.enc) && !fptr->encs.enc2)) {
             /* no encoding conversion */
             fptr->writeconv_pre_ecflags = 0;
             fptr->writeconv_pre_ecopts = Qnil;
@@ -6514,7 +6514,7 @@ rb_io_ext_int_to_encs(rb_encoding *ext, rb_encoding *intern, rb_encoding **enc, 
         ext = rb_default_external_encoding();
         default_ext = 1;
     }
-    if (ext == rb_ascii8bit_encoding()) {
+    if (rb_is_ascii8bit_enc(ext)) {
         /* If external is ASCII-8BIT, no transcoding */
         intern = NULL;
     }

--- a/parse.y
+++ b/parse.y
@@ -34,6 +34,7 @@ struct lex_context;
 #include "internal/compile.h"
 #include "internal/compilers.h"
 #include "internal/complex.h"
+#include "internal/encoding.h"
 #include "internal/error.h"
 #include "internal/hash.h"
 #include "internal/imemo.h"
@@ -6992,7 +6993,7 @@ parser_str_new(const char *ptr, long len, rb_encoding *enc, int func, rb_encodin
     if (!(func & STR_FUNC_REGEXP) && rb_enc_asciicompat(enc)) {
 	if (is_ascii_string(str)) {
 	}
-	else if (enc0 == rb_usascii_encoding() && enc != rb_utf8_encoding()) {
+	else if (rb_is_usascii_enc(enc0) && enc != rb_utf8_encoding()) {
 	    rb_enc_associate(str, rb_ascii8bit_encoding());
 	}
     }
@@ -8353,7 +8354,7 @@ here_document(struct parser_params *p, rb_strterm_heredoc_t *here)
 		    int cr = ENC_CODERANGE_UNKNOWN;
 		    rb_str_coderange_scan_restartable(p->lex.ptok, p->lex.pcur, enc, &cr);
 		    if (cr != ENC_CODERANGE_7BIT &&
-			p->enc == rb_usascii_encoding() &&
+			rb_is_usascii_enc(p->enc) &&
 			enc != rb_utf8_encoding()) {
 			enc = rb_ascii8bit_encoding();
 		    }
@@ -13478,7 +13479,7 @@ rb_reg_fragment_setenc(struct parser_params* p, VALUE str, int options)
         }
 	rb_enc_associate(str, rb_ascii8bit_encoding());
     }
-    else if (p->enc == rb_usascii_encoding()) {
+    else if (rb_is_usascii_enc(p->enc)) {
 	if (!is_ascii_string(str)) {
 	    /* raise in re.c */
 	    rb_enc_associate(str, rb_usascii_encoding());

--- a/re.c
+++ b/re.c
@@ -16,6 +16,7 @@
 #include "encindex.h"
 #include "hrtime.h"
 #include "internal.h"
+#include "internal/encoding.h"
 #include "internal/hash.h"
 #include "internal/imemo.h"
 #include "internal/re.h"
@@ -2859,7 +2860,7 @@ unescape_nonascii(const char *p, const char *end, rb_encoding *enc,
               case 'C': /* \C-X, \C-\M-X */
               case 'M': /* \M-X, \M-\C-X, \M-\cX */
                 p = p-2;
-                if (enc == rb_usascii_encoding()) {
+                if (rb_is_usascii_enc(enc)) {
                     const char *pbeg = p;
                     int byte = read_escaped_byte(&p, end, err);
                     if (byte == -1) return -1;

--- a/strftime.c
+++ b/strftime.c
@@ -66,6 +66,7 @@
 #include <math.h>
 
 #include "internal.h"
+#include "internal/encoding.h"
 #include "internal/string.h"
 #include "internal/vm.h"
 #include "ruby/encoding.h"
@@ -270,9 +271,9 @@ rb_strftime_with_timespec(VALUE ftime, const char *format, size_t format_len,
 	}
 
 	if (enc &&
-	    (enc == rb_usascii_encoding() ||
-	     enc == rb_ascii8bit_encoding() ||
-	     enc == rb_locale_encoding())) {
+	    (rb_is_usascii_enc(enc) ||
+	     rb_is_ascii8bit_enc(enc) ||
+	     rb_is_locale_enc(enc))) {
 		enc = NULL;
 	}
 

--- a/string.c
+++ b/string.c
@@ -1096,7 +1096,7 @@ rb_str_conv_enc_opts(VALUE str, rb_encoding *from, rb_encoding *to, int ecflags,
     if (!from) from = rb_enc_get(str);
     if (from == to) return str;
     if ((rb_enc_asciicompat(to) && is_enc_ascii_string(str, from)) ||
-        to == rb_ascii8bit_encoding()) {
+        rb_is_ascii8bit_enc(to)) {
         if (STR_ENC_GET(str) != to) {
             str = rb_str_dup(str);
             rb_enc_associate(str, to);


### PR DESCRIPTION
Some code has encoding check that using `rb_usascii_encoding`, `rb_ascii8bit_encoding` and `rb_locale_encoding` functions.
But, bit longer I thought.

So, I thought better to introduce encoding check macro like a `is_ascii_string` function to more shorter and simpler.

