### PR TITLE
Fix exit locations dump

### DIFF
--- a/yjit.rb
+++ b/yjit.rb
@@ -112,13 +112,25 @@ module RubyVM::YJIT
   #
   # Usage:
   #
+  # If `--yjit-exit-locations` is passed, a file named
+  # "yjit_exit_locations.dump" will automatically be generated.
+  #
+  # If you want to collect traces manually, call `dump_exit_locations`
+  # directly.
+  #
+  # Note that calling this in a script will generate stats after the
+  # dump is created, so the stats data may include exits from the
+  # dump itself.
+  #
   # In a script call:
   #
-  #   RubyVM::YJIT.dump_exit_locations("my_file.dump")
+  #   at_exit do
+  #     RubyVM::YJIT.dump_exit_locations("my_file.dump")
+  #   end
   #
   # Then run the file with the following options:
   #
-  #   ruby --yjit --yjit-stats --yjit-trace-exits test.rb
+  #   ruby --yjit --yjit-trace-exits test.rb
   #
   # Once the code is done running, use Stackprof to read the dump file.
   # See Stackprof documentation for options.
@@ -168,11 +180,23 @@ module RubyVM::YJIT
 
   # Avoid calling a method here to not interfere with compilation tests
   if Primitive.rb_yjit_stats_enabled_p
-    at_exit { _print_stats }
+    at_exit do
+      _print_stats
+      _dump_locations
+    end
   end
 
   class << self
     private
+
+    def _dump_locations
+      return unless trace_exit_locations_enabled?
+
+      filename = "yjit_exit_locations.dump"
+      dump_exit_locations(filename)
+
+      $stderr.puts("YJIT exit locations dumped to `#{filename}`.")
+    end
 
     # Format and print out counters
     def _print_stats


### PR DESCRIPTION
While I was working on my RubyConf talk for tracing yjit exit locations I realized that there were exits from the dump code included in the stats data. For example I saw 224 interp leave exits for a simple script that should have had 1 or 2. I realized that the dump code needs to be called _after_ the stats are generated, otherwise the dump code will be counted in the stats exits.

I've added a `_dump_locations` method to the `at_exit` for stats generation to ensure that it runs last. I've updated the documentation to add a note that if you call `dump_exit_locations` directly, your stats will include the dump code exits as well.