### PR TITLE
Fix bug in array pack with shared strings

### DIFF
--- a/pack.c
+++ b/pack.c
@@ -217,6 +217,7 @@ pack_pack(rb_execution_context_t *ec, VALUE ary, VALUE fmt, VALUE buffer)
     else {
         if (!RB_TYPE_P(buffer, T_STRING))
             rb_raise(rb_eTypeError, "buffer must be String, not %s", rb_obj_classname(buffer));
+        rb_str_modify(buffer);
         res = buffer;
     }
 

--- a/test/ruby/test_array.rb
+++ b/test/ruby/test_array.rb
@@ -1294,6 +1294,12 @@ class TestArray < Test::Unit::TestCase
 =end
   end
 
+  def test_pack_with_buffer
+    n = [ 65, 66, 67 ]
+    str = "a" * 100
+    assert_equal("aaaABC", n.pack("@3ccc", buffer: str.dup), "[Bug #19116]")
+  end
+
   def test_pop
     a = @cls[ 'cat', 'dog' ]
     assert_equal('dog', a.pop)


### PR DESCRIPTION
If string literals are long and they become shared, we need to make them independent before we can write to them. [Bug #19116]

Confirmed that the test added was previously failing, and is now passing.