### PR TITLE
wasm/README.md: Add a note about the Ruby built for wasm. [ci skip]

### DIFF
--- a/wasm/README.md
+++ b/wasm/README.md
@@ -54,6 +54,16 @@ $ wasmtime ruby-wasm32-wasi/usr/local/bin/ruby --mapdir /::./ruby-wasm32-wasi/ -
 wasm32-wasi
 ```
 
+Note: you cannot run the built ruby without a WebAssembly runtime, because of the difference of the binary file type.
+
+```
+$ ruby-wasm32-wasi/usr/local/bin/ruby -e 'puts "a"'
+bash: ruby-wasm32-wasi/usr/local/bin/ruby: cannot execute binary file: Exec format error
+
+$ file ruby-wasm32-wasi/usr/local/bin/ruby
+ruby-wasm32-wasi/usr/local/bin/ruby: WebAssembly (wasm) binary module version 0x1 (MVP)
+```
+
 ## Current Limitation
 
 - No `Thread` support for now.


### PR DESCRIPTION
Hello,
I would like to update the current document about wasm, WebAssembly. Because I needed extra info to explain to other people that "the WASI feature only works with the WebAssembly runtime, but can't be used like normal Ruby without the WebAssembly runtime" .

The modified `README.md` is [here](https://github.com/junaruga/ruby/blob/wip/wasm-doc/wasm/README.md).

The Ruby built for wasm cannot be executed without a WebAssembly runtime.

```
$ ruby-wasm32-wasi/usr/local/bin/ruby -e 'puts "a"'
bash: ruby-wasm32-wasi/usr/local/bin/ruby: cannot execute binary file: Exec format error
```

Because the Ruby's file type is different from the one built normally, that is the `/usr/local/ruby-3.2.0-preview2/bin/ruby` below.

```
$ file ruby-wasm32-wasi/usr/local/bin/ruby
ruby-wasm32-wasi/usr/local/bin/ruby: WebAssembly (wasm) binary module version 0x1 (MVP)

$ file /usr/local/ruby-3.2.0-preview2/bin/ruby
/usr/local/ruby-3.2.0-preview2/bin/ruby: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, BuildID[sha1]=a37822085e285c0971159982e7642dda88cea606, for GNU/Linux 3.2.0, with debug_info, not stripped
```

Though perhaps this might be for another PR, I think another possible improvement is the following part in the current document - Steps. I have no idea what the `--with-ext=ripper,monitor` is dong.

```
$ ./configure LDFLAGS="-Xlinker -zstack-size=16777216" \
  --host wasm32-unknown-wasi \
  --with-destdir=./ruby-wasm32-wasi \
  --with-static-linked-ext \
  --with-ext=ripper,monitor
```

I did see the explanation.

```
$ ./configure --help
...
  --with-ext=EXTS         pass to --with-ext option of extmk.rb
...
```

I think adding one more `configure` script example as a typically used command example with the minimal `configure` options in the document is helpful for users. This could be like this?

```
$ ./configure LDFLAGS="-Xlinker -zstack-size=16777216" \
  --prefix=/path/to/ruby-wasi \
  --host wasm32-unknown-wasi \
  --with-static-linked-ext \
```

I just checked the current CI for wasm, and the `--with-ext` is not used.
https://github.com/ruby/ruby/blob/b7e8876704648cee6866591ac1aca7a54faff742/.github/workflows/wasm.yml#L88-L97

So, what do you think?
