### PR TITLE
Extract `rb_shape_get_parent` helper

### DIFF
--- a/object.c
+++ b/object.c
@@ -284,7 +284,7 @@ rb_obj_copy_ivar(VALUE dest, VALUE obj)
 
     // The copy should be mutable, so we don't want the frozen shape
     if (rb_shape_frozen_shape_p(src_shape)) {
-        shape_to_set_on_dest = rb_shape_get_shape_by_id(src_shape->parent_id);
+        shape_to_set_on_dest = rb_shape_get_parent(src_shape);
     }
 
     src_buf = ROBJECT_IVPTR(obj);

--- a/shape.c
+++ b/shape.c
@@ -51,6 +51,12 @@ rb_shape_get_shape_by_id_without_assertion(shape_id_t shape_id)
     return shape;
 }
 
+rb_shape_t *
+rb_shape_get_parent(rb_shape_t * shape)
+{
+    return rb_shape_get_shape_by_id(shape->parent_id);
+}
+
 #if !SHAPE_IN_BASIC_FLAGS
 shape_id_t
 rb_rclass_shape_id(VALUE obj)
@@ -105,7 +111,7 @@ rb_shape_lookup_id(rb_shape_t* shape, ID id, enum shape_type shape_type)
                 return NULL;
             }
         }
-        shape = rb_shape_get_shape_by_id(shape->parent_id);
+        shape = rb_shape_get_parent(shape);
     }
     return NULL;
 }
@@ -273,7 +279,7 @@ rb_shape_get_iv_index(rb_shape_t * shape, ID id, attr_index_t *value)
                 rb_bug("Ivar should not exist on transition\n");
             }
         }
-        shape = rb_shape_get_shape_by_id(shape->parent_id);
+        shape = rb_shape_get_parent(shape);
     }
     return false;
 }
@@ -338,7 +344,7 @@ rb_shape_rebuild_shape(rb_shape_t * initial_shape, rb_shape_t * dest_shape)
     rb_shape_t * midway_shape;
 
     if (dest_shape->type != SHAPE_ROOT) {
-        midway_shape = rb_shape_rebuild_shape(initial_shape, rb_shape_get_shape_by_id(dest_shape->parent_id));
+        midway_shape = rb_shape_rebuild_shape(initial_shape, rb_shape_get_parent(dest_shape));
     }
     else {
         midway_shape = initial_shape;
@@ -504,7 +510,7 @@ rb_shape_export_depth(VALUE self)
     unsigned int depth = 0;
     while (shape->parent_id != INVALID_SHAPE_ID) {
         depth++;
-        shape = rb_shape_get_shape_by_id(shape->parent_id);
+        shape = rb_shape_get_parent(shape);
     }
     return INT2NUM(depth);
 }
@@ -515,7 +521,7 @@ rb_shape_parent(VALUE self)
     rb_shape_t * shape;
     TypedData_Get_Struct(self, rb_shape_t, &shape_data_type, shape);
     if (shape->parent_id != INVALID_SHAPE_ID) {
-        return rb_shape_t_to_rb_cShape(rb_shape_get_shape_by_id(shape->parent_id));
+        return rb_shape_t_to_rb_cShape(rb_shape_get_parent(shape));
     }
     else {
         return Qnil;

--- a/shape.h
+++ b/shape.h
@@ -133,6 +133,7 @@ bool rb_shape_root_shape_p(rb_shape_t* shape);
 rb_shape_t * rb_shape_get_root_shape(void);
 
 rb_shape_t* rb_shape_get_shape_by_id_without_assertion(shape_id_t shape_id);
+rb_shape_t * rb_shape_get_parent(rb_shape_t * shape);
 
 MJIT_SYMBOL_EXPORT_BEGIN
 rb_shape_t* rb_shape_get_shape_by_id(shape_id_t shape_id);

--- a/variable.c
+++ b/variable.c
@@ -1583,7 +1583,7 @@ iterate_over_shapes_with_callback(rb_shape_t *shape, rb_ivar_foreach_callback_fu
       case SHAPE_ROOT:
         return;
       case SHAPE_IVAR:
-        iterate_over_shapes_with_callback(rb_shape_get_shape_by_id(shape->parent_id), callback, itr_data);
+        iterate_over_shapes_with_callback(rb_shape_get_parent(shape), callback, itr_data);
         VALUE * iv_list;
         switch (BUILTIN_TYPE(itr_data->obj)) {
           case T_OBJECT:
@@ -1606,7 +1606,7 @@ iterate_over_shapes_with_callback(rb_shape_t *shape, rb_ivar_foreach_callback_fu
       case SHAPE_CAPACITY_CHANGE:
       case SHAPE_FROZEN:
       case SHAPE_IVAR_UNDEF:
-        iterate_over_shapes_with_callback(rb_shape_get_shape_by_id(shape->parent_id), callback, itr_data);
+        iterate_over_shapes_with_callback(rb_shape_get_parent(shape), callback, itr_data);
         return;
     }
 }


### PR DESCRIPTION
Extract an `rb_shape_get_parent` method instead of continually calling `rb_shape_get_shape_by_id(shape->parent_id)`