### PR TITLE
Make racc test more flexible (for JRuby).

### DIFF
--- a/test/racc/case.rb
+++ b/test/racc/case.rb
@@ -17,6 +17,8 @@ module Racc
     TEST_DIR = test_dir
     racc = File.join(PROJECT_DIR, 'bin', 'racc')
     racc = File.join(PROJECT_DIR, '..', 'libexec', 'racc') unless File.exist?(racc)
+    racc = 'racc' unless File.exist?(racc)
+
     RACC = racc
     ASSET_DIR = File.join(TEST_DIR, 'assets') # test grammars
     REGRESS_DIR  = File.join(TEST_DIR, 'regress') # known-good generated outputs


### PR DESCRIPTION
JRuby uses these same files for testing racc.  The existing logic will not find 'racc' in a JRuby project checkout.  This change allows it to work by just assuming 'ruby -S racc' when running tests.  This will not change C Ruby's detection.

This PR does not change C Ruby behavior in any way so I did not open an issue on ruby-lang.