### PR TITLE
Define YJIT_STATS on --enable-yjit=stats

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3806,6 +3806,7 @@ AS_CASE(["${YJIT_SUPPORT}"],
     [stats], [
 	rb_rust_target_subdir=stats
 	CARGO_BUILD_ARGS='--profile stats --features stats'
+	AC_DEFINE(YJIT_STATS, 1)
     ])
 
     AS_IF([test -n "${CARGO_BUILD_ARGS}"], [


### PR DESCRIPTION
The current master seems just wrong. Currently, `--enable-yjit=stats` always shows `ratio_in_yjit: 100%` because the missing `YJIT_STATS` leaves `vm_insns_count` 0, but given what we did at https://github.com/ruby/ruby/pull/6694, it seems that `YJIT_STATS` is supposed to be defined whenever cargo's `stats` feature is used.