### PR TITLE
YJIT: Instrument global allocations on stats build

### DIFF
--- a/yjit.rb
+++ b/yjit.rb
@@ -262,6 +262,7 @@ module RubyVM::YJIT
       $stderr.puts "inline_code_size:      " + ("%10d" % stats[:inline_code_size])
       $stderr.puts "outlined_code_size:    " + ("%10d" % stats[:outlined_code_size])
       $stderr.puts "freed_code_size:       " + ("%10d" % stats[:freed_code_size])
+      $stderr.puts "yjit_alloc_size:       " + ("%10d" % stats[:yjit_alloc_size]) if stats.key?(:yjit_alloc_size)
       $stderr.puts "live_page_count:       " + ("%10d" % stats[:live_page_count])
       $stderr.puts "freed_page_count:      " + ("%10d" % stats[:freed_page_count])
       $stderr.puts "code_gc_count:         " + ("%10d" % stats[:code_gc_count])

--- a/yjit/Cargo.lock
+++ b/yjit/Cargo.lock
@@ -35,8 +35,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21a41fed9d98f27ab1c6d161da622a4fa35e8a54a8adc24bbf3ddd0ef70b0e50"
 
 [[package]]
+name = "stats_alloc"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0e04424e733e69714ca1bbb9204c1a57f09f5493439520f9f68c132ad25eec"
+
+[[package]]
 name = "yjit"
 version = "0.1.0"
 dependencies = [
  "capstone",
+ "stats_alloc",
 ]

--- a/yjit/Cargo.toml
+++ b/yjit/Cargo.toml
@@ -16,12 +16,13 @@ crate-type = ["staticlib"]
 # No required dependencies to simplify build process. TODO: Link to yet to be
 # written rationale. Optional For development and testing purposes
 capstone = { version = "0.10.0", optional = true }
+stats_alloc = { version = "0.1.10", optional = true }
 
 [features]
 # NOTE: Development builds select a set of these via configure.ac
 # For debugging, `make V=1` shows exact cargo invocation.
 disasm = ["capstone"]
-stats = []
+stats = ["stats_alloc"]
 
 [profile.dev]
 opt-level = 0

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -8,6 +8,14 @@ use crate::cruby::*;
 use crate::options::*;
 use crate::yjit::yjit_enabled_p;
 
+// stats_alloc is a middleware to instrument global allocations in Rust.
+#[cfg(feature="stats")]
+#[global_allocator]
+static GLOBAL_ALLOCATOR: &stats_alloc::StatsAlloc<std::alloc::System> = &stats_alloc::INSTRUMENTED_SYSTEM;
+
+#[cfg(feature="stats")]
+static mut GLOBAL_REGION: Option<stats_alloc::Region<std::alloc::System>> = None;
+
 // YJIT exit counts for each instruction type
 const VM_INSTRUCTION_SIZE_USIZE:usize = VM_INSTRUCTION_SIZE as usize;
 static mut EXIT_OP_COUNT: [u64; VM_INSTRUCTION_SIZE_USIZE] = [0; VM_INSTRUCTION_SIZE_USIZE];
@@ -396,6 +404,12 @@ fn rb_yjit_gen_stats_dict() -> VALUE {
 
         // Code GC count
         hash_aset_usize!(hash, "code_gc_count", CodegenGlobals::get_code_gc_count());
+
+        // Rust global allocations in bytes
+        #[cfg(feature="stats")]
+        if let Some(size) = global_allocation_size() {
+            hash_aset_usize!(hash, "yjit_alloc_size", size);
+        }
     }
 
     // If we're not generating stats, the hash is done
@@ -605,4 +619,22 @@ pub extern "C" fn rb_yjit_count_side_exit_op(exit_pc: *const VALUE) -> *const VA
 
     // This function must return exit_pc!
     return exit_pc;
+}
+
+// Enable instrumenting global allocations in Rust.
+pub fn init_global_allocator() {
+    #[cfg(feature="stats")]
+    unsafe { GLOBAL_REGION = Some(stats_alloc::Region::new(GLOBAL_ALLOCATOR)) };
+}
+
+// Get the size of global allocations in Rust.
+fn global_allocation_size() -> Option<usize> {
+    #[cfg(feature="stats")]
+    unsafe {
+        if let Some(region) = GLOBAL_REGION.as_mut() {
+            let stats = region.change();
+            return Some(stats.bytes_allocated.saturating_sub(stats.bytes_deallocated));
+        }
+    }
+    None
 }

--- a/yjit/src/yjit.rs
+++ b/yjit/src/yjit.rs
@@ -4,7 +4,6 @@ use crate::cruby::*;
 use crate::invariants::*;
 use crate::options::*;
 use crate::stats::YjitExitLocations;
-use crate::stats::init_global_allocator;
 
 use std::os::raw;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -48,8 +47,6 @@ pub extern "C" fn rb_yjit_call_threshold() -> raw::c_uint {
 pub extern "C" fn rb_yjit_init_rust() {
     // TODO: need to make sure that command-line options have been
     // initialized by CRuby
-
-    init_global_allocator();
 
     // Catch panics to avoid UB for unwinding into C frames.
     // See https://doc.rust-lang.org/nomicon/exception-safety.html

--- a/yjit/src/yjit.rs
+++ b/yjit/src/yjit.rs
@@ -4,6 +4,7 @@ use crate::cruby::*;
 use crate::invariants::*;
 use crate::options::*;
 use crate::stats::YjitExitLocations;
+use crate::stats::init_global_allocator;
 
 use std::os::raw;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -47,6 +48,8 @@ pub extern "C" fn rb_yjit_call_threshold() -> raw::c_uint {
 pub extern "C" fn rb_yjit_init_rust() {
     // TODO: need to make sure that command-line options have been
     // initialized by CRuby
+
+    init_global_allocator();
 
     // Catch panics to avoid UB for unwinding into C frames.
     // See https://doc.rust-lang.org/nomicon/exception-safety.html


### PR DESCRIPTION
For stats build, this PR allows you to measure how much memory YJIT uses in Rust.

Enabling YJIT currently consumes a lot more memory than what's used for code pages. I think it's nice to monitor changes in allocated bytes before attempting to reduce it because some changes could come at the cost of implementation complexity and we shouldn't do it when it's not really effective.

## Example
The current state of 25 itrs on railsbench:

```
inline_code_size:         4855668
outlined_code_size:       4852936
freed_code_size:                0
yjit_alloc_size:         25114317
```

When 9.7MB is used for JIT code, 25.1MB is used for Rust's global allocations.

## Benchmark
Its performance impact on stats build seems negligible. Here's the yjit-bench result on railsbench.

### Before
```
itr #1: 1503ms
itr #2: 1164ms
itr #3: 1148ms
itr #4: 1179ms
itr #5: 1114ms
itr #6: 1173ms
itr #7: 1165ms
itr #8: 1153ms
itr #9: 1173ms
itr #10: 1152ms
itr #11: 1149ms
itr #12: 1180ms
itr #13: 1166ms
itr #14: 1138ms
itr #15: 1179ms
itr #16: 1149ms
itr #17: 1163ms
itr #18: 1173ms
itr #19: 1144ms
itr #20: 1166ms
itr #21: 1171ms
itr #22: 1169ms
itr #23: 1149ms
itr #24: 1146ms
itr #25: 1174ms
```

### After
```
itr #1: 1443ms
itr #2: 1135ms
itr #3: 1131ms
itr #4: 1149ms
itr #5: 1143ms
itr #6: 1130ms
itr #7: 1136ms
itr #8: 1150ms
itr #9: 1164ms
itr #10: 1134ms
itr #11: 1134ms
itr #12: 1178ms
itr #13: 1127ms
itr #14: 1134ms
itr #15: 1109ms
itr #16: 1110ms
itr #17: 1155ms
itr #18: 1140ms
itr #19: 1130ms
itr #20: 1150ms
itr #21: 1163ms
itr #22: 1155ms
itr #23: 1144ms
itr #24: 1165ms
itr #25: 1130ms
```