### PR TITLE
YJIT: Remove unused src_ctx from Block

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -1880,7 +1880,7 @@ fn jit_chain_guard(
             idx: jit.insn_idx,
         };
 
-        gen_branch(jit, ctx, asm, ocb, bid, &deeper, None, None, target0_gen_fn);
+        gen_branch(jit, asm, ocb, bid, &deeper, None, None, target0_gen_fn);
     } else {
         target0_gen_fn(asm, side_exit, None, BranchShape::Default);
     }
@@ -3210,7 +3210,6 @@ fn gen_branchif(
         // Generate the branch instructions
         gen_branch(
             jit,
-            ctx,
             asm,
             ocb,
             jump_block,
@@ -3281,7 +3280,6 @@ fn gen_branchunless(
         // Generate the branch instructions
         gen_branch(
             jit,
-            ctx,
             asm,
             ocb,
             jump_block,
@@ -3349,7 +3347,6 @@ fn gen_branchnil(
         // Generate the branch instructions
         gen_branch(
             jit,
-            ctx,
             asm,
             ocb,
             jump_block,
@@ -5069,7 +5066,6 @@ fn gen_send_iseq(
     // Write the JIT return address on the callee frame
     gen_branch(
         jit,
-        ctx,
         asm,
         ocb,
         return_block,


### PR DESCRIPTION
Pairing with Maxime and Alan, we found that we don't use `src_ctx` and removing this contributes to reducing memory usages. This PR removes the unused field.

With `yjit_alloc_size` implemented in https://github.com/ruby/ruby/pull/6712, I confirmed it has the following memory usage impact on 25 itrs of railsbench:

## Before
```
inline_code_size:         4948216
outlined_code_size:       4947968
freed_code_size:                0
yjit_alloc_size:         25137225
```

JIT code: 9.8MB, payload: 25.1MB

## After
```
inline_code_size:         4852292
outlined_code_size:       4850940
freed_code_size:                0
yjit_alloc_size:         23306197
```

JIT code: 9.7MB, payload: 23.3MB

(`*_code_size` changes would be just an unrelated fluctuation, but I included it for comparison to `yjit_alloc_size`)