### PR TITLE
Reuse `RB_BIGNUM_TYPE_P` macro

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -203,7 +203,7 @@ obj_any_hash(VALUE obj)
     }
 
     while (!FIXNUM_P(hval)) {
-        if (RB_TYPE_P(hval, T_BIGNUM)) {
+        if (RB_BIGNUM_TYPE_P(hval)) {
             int sign;
             unsigned long ul;
             sign = rb_integer_pack(hval, &ul, 1, sizeof(ul), 0,


### PR DESCRIPTION
`obj_any_hash` function has check type code in `hash.c`.

```c
if (RB_TYPE_P(hval, T_BIGNUM)) {
```

But, using `RB_BIGNUM_TYPE_P` is better and more simpler. I thought.


