### PR TITLE
Using `UNDEF_P` macro

### DIFF
--- a/array.c
+++ b/array.c
@@ -4555,7 +4555,7 @@ take_items(VALUE obj, long n)
     if (!NIL_P(result)) return rb_ary_subseq(result, 0, n);
     result = rb_ary_new2(n);
     args[0] = result; args[1] = (VALUE)n;
-    if (rb_check_block_call(obj, idEach, 0, 0, take_i, (VALUE)args) == Qundef)
+    if (UNDEF_P(rb_check_block_call(obj, idEach, 0, 0, take_i, (VALUE)args)))
         rb_raise(rb_eTypeError, "wrong argument type %"PRIsVALUE" (must respond to :each)",
                  rb_obj_class(obj));
     return result;
@@ -5048,7 +5048,7 @@ rb_ary_fill(int argc, VALUE *argv, VALUE ary)
         ARY_SET_LEN(ary, end);
     }
 
-    if (item == Qundef) {
+    if (UNDEF_P(item)) {
         VALUE v;
         long i;
 
@@ -5505,7 +5505,7 @@ rb_ary_cmp(VALUE ary1, VALUE ary2)
     if (NIL_P(ary2)) return Qnil;
     if (ary1 == ary2) return INT2FIX(0);
     v = rb_exec_recursive_paired(recursive_cmp, ary1, ary2, ary2);
-    if (v != Qundef) return v;
+    if (!UNDEF_P(v)) return v;
     len = RARRAY_LEN(ary1) - RARRAY_LEN(ary2);
     if (len == 0) return INT2FIX(0);
     if (len > 0) return INT2FIX(1);
@@ -6068,7 +6068,7 @@ rb_ary_max(int argc, VALUE *argv, VALUE ary)
     if (rb_block_given_p()) {
         for (i = 0; i < RARRAY_LEN(ary); i++) {
            v = RARRAY_AREF(ary, i);
-           if (result == Qundef || rb_cmpint(rb_yield_values(2, v, result), v, result) > 0) {
+           if (UNDEF_P(result) || rb_cmpint(rb_yield_values(2, v, result), v, result) > 0) {
                result = v;
            }
         }
@@ -6090,7 +6090,7 @@ rb_ary_max(int argc, VALUE *argv, VALUE ary)
             }
         }
     }
-    if (result == Qundef) return Qnil;
+    if (UNDEF_P(result)) return Qnil;
     return result;
 }
 
@@ -6237,7 +6237,7 @@ rb_ary_min(int argc, VALUE *argv, VALUE ary)
     if (rb_block_given_p()) {
         for (i = 0; i < RARRAY_LEN(ary); i++) {
            v = RARRAY_AREF(ary, i);
-           if (result == Qundef || rb_cmpint(rb_yield_values(2, v, result), v, result) < 0) {
+           if (UNDEF_P(result) || rb_cmpint(rb_yield_values(2, v, result), v, result) < 0) {
                result = v;
            }
         }
@@ -6259,7 +6259,7 @@ rb_ary_min(int argc, VALUE *argv, VALUE ary)
             }
         }
     }
-    if (result == Qundef) return Qnil;
+    if (UNDEF_P(result)) return Qnil;
     return result;
 }
 
@@ -8148,7 +8148,7 @@ finish_exact_sum(long n, VALUE r, VALUE v, int z)
 {
     if (n != 0)
         v = rb_fix_plus(LONG2FIX(n), v);
-    if (r != Qundef) {
+    if (!UNDEF_P(r)) {
         v = rb_rational_plus(r, v);
     }
     else if (!n && z) {
@@ -8227,7 +8227,7 @@ rb_ary_sum(int argc, VALUE *argv, VALUE ary)
         else if (RB_BIGNUM_TYPE_P(e))
             v = rb_big_plus(e, v);
         else if (RB_TYPE_P(e, T_RATIONAL)) {
-            if (r == Qundef)
+            if (UNDEF_P(r))
                 r = e;
             else
                 r = rb_rational_plus(r, e);

--- a/class.c
+++ b/class.c
@@ -64,7 +64,7 @@ push_subclass_entry_to_list(VALUE super, VALUE klass)
 void
 rb_class_subclass_add(VALUE super, VALUE klass)
 {
-    if (super && super != Qundef) {
+    if (super && !UNDEF_P(super)) {
         rb_subclass_entry_t *entry = push_subclass_entry_to_list(super, klass);
         RCLASS_SUBCLASS_ENTRY(klass) = entry;
     }
@@ -277,7 +277,7 @@ rb_class_update_superclasses(VALUE klass)
     VALUE super = RCLASS_SUPER(klass);
 
     if (!RB_TYPE_P(klass, T_CLASS)) return;
-    if (super == Qundef) return;
+    if (UNDEF_P(super)) return;
 
     // If the superclass array is already built
     if (RCLASS_SUPERCLASSES(klass))
@@ -608,7 +608,7 @@ rb_singleton_class_clone_and_attach(VALUE obj, VALUE attach)
             arg.klass = clone;
             rb_id_table_foreach(RCLASS_CONST_TBL(klass), clone_const_i, &arg);
         }
-        if (attach != Qundef) {
+        if (!UNDEF_P(attach)) {
             rb_singleton_class_attached(clone, attach);
         }
         RCLASS_M_TBL_INIT(clone);

--- a/compar.c
+++ b/compar.c
@@ -50,7 +50,7 @@ VALUE
 rb_invcmp(VALUE x, VALUE y)
 {
     VALUE invcmp = rb_exec_recursive(invcmp_recursive, x, y);
-    if (invcmp == Qundef || NIL_P(invcmp)) {
+    if (UNDEF_P(invcmp) || NIL_P(invcmp)) {
         return Qnil;
     }
     else {

--- a/compile.c
+++ b/compile.c
@@ -4820,7 +4820,7 @@ when_vals(rb_iseq_t *iseq, LINK_ANCHOR *const cond_seq, const NODE *vals,
         const NODE *val = vals->nd_head;
         VALUE lit = rb_node_case_when_optimizable_literal(val);
 
-        if (lit == Qundef) {
+        if (UNDEF_P(lit)) {
             only_special_literals = 0;
         }
         else if (NIL_P(rb_hash_lookup(literals, lit))) {
@@ -7394,7 +7394,7 @@ compile_loop(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, in
     ADD_LABEL(ret, end_label);
     ADD_ADJUST_RESTORE(ret, adjust_label);
 
-    if (node->nd_state == Qundef) {
+    if (UNDEF_P(node->nd_state)) {
         /* ADD_INSN(ret, line_node, putundef); */
         COMPILE_ERROR(ERROR_ARGS "unsupported: putundef");
         return COMPILE_NG;

--- a/complex.c
+++ b/complex.c
@@ -561,7 +561,7 @@ nucomp_f_complex(int argc, VALUE *argv, VALUE klass)
     if (!NIL_P(opts)) {
         raise = rb_opts_exception_p(opts, raise);
     }
-    if (argc > 0 && CLASS_OF(a1) == rb_cComplex && a2 == Qundef) {
+    if (argc > 0 && CLASS_OF(a1) == rb_cComplex && UNDEF_P(a2)) {
         return a1;
     }
     return nucomp_convert(rb_cComplex, a1, a2, raise);
@@ -2107,11 +2107,11 @@ nucomp_convert(VALUE klass, VALUE a1, VALUE a2, int raise)
     }
 
     if (RB_TYPE_P(a1, T_COMPLEX)) {
-        if (a2 == Qundef || (k_exact_zero_p(a2)))
+        if (UNDEF_P(a2) || (k_exact_zero_p(a2)))
             return a1;
     }
 
-    if (a2 == Qundef) {
+    if (UNDEF_P(a2)) {
         if (k_numeric_p(a1) && !f_real_p(a1))
             return a1;
         /* should raise exception for consistency */
@@ -2133,7 +2133,7 @@ nucomp_convert(VALUE klass, VALUE a1, VALUE a2, int raise)
         int argc;
         VALUE argv2[2];
         argv2[0] = a1;
-        if (a2 == Qundef) {
+        if (UNDEF_P(a2)) {
             argv2[1] = Qnil;
             argc = 1;
         }

--- a/cont.c
+++ b/cont.c
@@ -1831,7 +1831,7 @@ rollback_ensure_stack(VALUE self,rb_ensure_list_t *current,rb_ensure_entry_t *ta
     /* push ensure stack */
     for (j = 0; j < i; j++) {
         func = lookup_rollback_func(target[i - j - 1].e_proc);
-        if ((VALUE)func != Qundef) {
+        if (!UNDEF_P((VALUE)func)) {
             (*func)(target[i - j - 1].data2);
         }
     }
@@ -2058,11 +2058,11 @@ rb_fiber_initialize_kw(int argc, VALUE* argv, VALUE self, int kw_splat)
         argc = rb_scan_args_kw(kw_splat, argc, argv, ":", &options);
         rb_get_kwargs(options, fiber_initialize_keywords, 0, 2, arguments);
 
-        if (arguments[0] != Qundef) {
+        if (!UNDEF_P(arguments[0])) {
             blocking = arguments[0];
         }
 
-        if (arguments[1] != Qundef) {
+        if (!UNDEF_P(arguments[1])) {
             pool = arguments[1];
         }
     }

--- a/dir.c
+++ b/dir.c
@@ -2932,7 +2932,7 @@ dir_globs(VALUE args, VALUE base, int flags)
 static VALUE
 dir_glob_option_base(VALUE base)
 {
-    if (base == Qundef || NIL_P(base)) {
+    if (UNDEF_P(base) || NIL_P(base)) {
         return Qnil;
     }
 #if USE_OPENDIR_AT
@@ -3343,7 +3343,7 @@ rb_dir_s_empty_p(VALUE obj, VALUE dirname)
 
     result = (VALUE)rb_thread_call_without_gvl(nogvl_dir_empty_p, (void *)path,
                                             RUBY_UBF_IO, 0);
-    if (result == Qundef) {
+    if (UNDEF_P(result)) {
         rb_sys_fail_path(orig);
     }
     return result;

--- a/enum.c
+++ b/enum.c
@@ -779,7 +779,7 @@ inject_i(RB_BLOCK_CALL_FUNC_ARGLIST(i, p))
 
     ENUM_WANT_SVALUE();
 
-    if (memo->v1 == Qundef) {
+    if (UNDEF_P(memo->v1)) {
         MEMO_V1_SET(memo, i);
     }
     else {
@@ -796,7 +796,7 @@ inject_op_i(RB_BLOCK_CALL_FUNC_ARGLIST(i, p))
 
     ENUM_WANT_SVALUE();
 
-    if (memo->v1 == Qundef) {
+    if (UNDEF_P(memo->v1)) {
         MEMO_V1_SET(memo, i);
     }
     else if (SYMBOL_P(name = memo->u3.value)) {
@@ -820,9 +820,9 @@ ary_inject_op(VALUE ary, VALUE init, VALUE op)
     long i, n;
 
     if (RARRAY_LEN(ary) == 0)
-        return init == Qundef ? Qnil : init;
+        return UNDEF_P(init) ? Qnil : init;
 
-    if (init == Qundef) {
+    if (UNDEF_P(init)) {
         v = RARRAY_AREF(ary, 0);
         i = 1;
         if (RARRAY_LEN(ary) == 1)
@@ -1051,7 +1051,7 @@ enum_inject(int argc, VALUE *argv, VALUE obj)
 
     memo = MEMO_NEW(init, Qnil, op);
     rb_block_call(obj, id_each, 0, 0, iter, (VALUE)memo);
-    if (memo->v1 == Qundef) return Qnil;
+    if (UNDEF_P(memo->v1)) return Qnil;
     return memo->v1;
 }
 
@@ -1677,7 +1677,7 @@ enum_any(int argc, VALUE *argv, VALUE obj)
 DEFINE_ENUMFUNCS(one)
 {
     if (RTEST(result)) {
-        if (memo->v1 == Qundef) {
+        if (UNDEF_P(memo->v1)) {
             MEMO_V1_SET(memo, Qtrue);
         }
         else if (memo->v1 == Qtrue) {
@@ -1827,7 +1827,7 @@ nmin_i(RB_BLOCK_CALL_FUNC_ARGLIST(i, _data))
     else
         cmpv = i;
 
-    if (data->limit != Qundef) {
+    if (!UNDEF_P(data->limit)) {
         int c = data->cmpfunc(&cmpv, &data->limit, data);
         if (data->rev)
             c = -c;
@@ -1962,7 +1962,7 @@ enum_one(int argc, VALUE *argv, VALUE obj)
     WARN_UNUSED_BLOCK(argc);
     rb_block_call(obj, id_each, 0, 0, ENUMFUNC(one), (VALUE)memo);
     result = memo->v1;
-    if (result == Qundef) return Qfalse;
+    if (UNDEF_P(result)) return Qfalse;
     return result;
 }
 
@@ -2037,7 +2037,7 @@ min_i(RB_BLOCK_CALL_FUNC_ARGLIST(i, args))
 
     ENUM_WANT_SVALUE();
 
-    if (memo->min == Qundef) {
+    if (UNDEF_P(memo->min)) {
         memo->min = i;
     }
     else {
@@ -2056,7 +2056,7 @@ min_ii(RB_BLOCK_CALL_FUNC_ARGLIST(i, args))
 
     ENUM_WANT_SVALUE();
 
-    if (memo->min == Qundef) {
+    if (UNDEF_P(memo->min)) {
         memo->min = i;
     }
     else {
@@ -2147,7 +2147,7 @@ enum_min(int argc, VALUE *argv, VALUE obj)
         rb_block_call(obj, id_each, 0, 0, min_i, memo);
     }
     result = m->min;
-    if (result == Qundef) return Qnil;
+    if (UNDEF_P(result)) return Qnil;
     return result;
 }
 
@@ -2163,7 +2163,7 @@ max_i(RB_BLOCK_CALL_FUNC_ARGLIST(i, args))
 
     ENUM_WANT_SVALUE();
 
-    if (memo->max == Qundef) {
+    if (UNDEF_P(memo->max)) {
         memo->max = i;
     }
     else {
@@ -2182,7 +2182,7 @@ max_ii(RB_BLOCK_CALL_FUNC_ARGLIST(i, args))
 
     ENUM_WANT_SVALUE();
 
-    if (memo->max == Qundef) {
+    if (UNDEF_P(memo->max)) {
         memo->max = i;
     }
     else {
@@ -2272,7 +2272,7 @@ enum_max(int argc, VALUE *argv, VALUE obj)
         rb_block_call(obj, id_each, 0, 0, max_i, (VALUE)memo);
     }
     result = m->max;
-    if (result == Qundef) return Qnil;
+    if (UNDEF_P(result)) return Qnil;
     return result;
 }
 
@@ -2288,7 +2288,7 @@ minmax_i_update(VALUE i, VALUE j, struct minmax_t *memo)
 {
     int n;
 
-    if (memo->min == Qundef) {
+    if (UNDEF_P(memo->min)) {
         memo->min = i;
         memo->max = j;
     }
@@ -2313,7 +2313,7 @@ minmax_i(RB_BLOCK_CALL_FUNC_ARGLIST(i, _memo))
 
     ENUM_WANT_SVALUE();
 
-    if (memo->last == Qundef) {
+    if (UNDEF_P(memo->last)) {
         memo->last = i;
         return Qnil;
     }
@@ -2340,7 +2340,7 @@ minmax_ii_update(VALUE i, VALUE j, struct minmax_t *memo)
 {
     int n;
 
-    if (memo->min == Qundef) {
+    if (UNDEF_P(memo->min)) {
         memo->min = i;
         memo->max = j;
     }
@@ -2365,7 +2365,7 @@ minmax_ii(RB_BLOCK_CALL_FUNC_ARGLIST(i, _memo))
 
     ENUM_WANT_SVALUE();
 
-    if (memo->last == Qundef) {
+    if (UNDEF_P(memo->last)) {
         memo->last = i;
         return Qnil;
     }
@@ -2430,15 +2430,15 @@ enum_minmax(VALUE obj)
     m->cmp_opt.opt_inited = 0;
     if (rb_block_given_p()) {
         rb_block_call(obj, id_each, 0, 0, minmax_ii, memo);
-        if (m->last != Qundef)
+        if (!UNDEF_P(m->last))
             minmax_ii_update(m->last, m->last, m);
     }
     else {
         rb_block_call(obj, id_each, 0, 0, minmax_i, memo);
-        if (m->last != Qundef)
+        if (!UNDEF_P(m->last))
             minmax_i_update(m->last, m->last, m);
     }
-    if (m->min != Qundef) {
+    if (!UNDEF_P(m->min)) {
         return rb_assoc_new(m->min, m->max);
     }
     return rb_assoc_new(Qnil, Qnil);
@@ -2454,7 +2454,7 @@ min_by_i(RB_BLOCK_CALL_FUNC_ARGLIST(i, args))
     ENUM_WANT_SVALUE();
 
     v = enum_yield(argc, i);
-    if (memo->v1 == Qundef) {
+    if (UNDEF_P(memo->v1)) {
         MEMO_V1_SET(memo, v);
         MEMO_V2_SET(memo, i);
     }
@@ -2529,7 +2529,7 @@ max_by_i(RB_BLOCK_CALL_FUNC_ARGLIST(i, args))
     ENUM_WANT_SVALUE();
 
     v = enum_yield(argc, i);
-    if (memo->v1 == Qundef) {
+    if (UNDEF_P(memo->v1)) {
         MEMO_V1_SET(memo, v);
         MEMO_V2_SET(memo, i);
     }
@@ -2608,7 +2608,7 @@ minmax_by_i_update(VALUE v1, VALUE v2, VALUE i1, VALUE i2, struct minmax_by_t *m
 {
     struct cmp_opt_data cmp_opt = { 0, 0 };
 
-    if (memo->min_bv == Qundef) {
+    if (UNDEF_P(memo->min_bv)) {
         memo->min_bv = v1;
         memo->max_bv = v2;
         memo->min = i1;
@@ -2638,7 +2638,7 @@ minmax_by_i(RB_BLOCK_CALL_FUNC_ARGLIST(i, _memo))
 
     vi = enum_yield(argc, i);
 
-    if (memo->last_bv == Qundef) {
+    if (UNDEF_P(memo->last_bv)) {
         memo->last_bv = vi;
         memo->last = i;
         return Qnil;
@@ -2705,7 +2705,7 @@ enum_minmax_by(VALUE obj)
     m->last_bv = Qundef;
     m->last = Qundef;
     rb_block_call(obj, id_each, 0, 0, minmax_by_i, memo);
-    if (m->last_bv != Qundef)
+    if (!UNDEF_P(m->last_bv))
         minmax_by_i_update(m->last_bv, m->last_bv, m->last, m->last, m);
     m = MEMO_FOR(struct minmax_by_t, memo);
     return rb_assoc_new(m->min, m->max);
@@ -3185,7 +3185,7 @@ zip_i(RB_BLOCK_CALL_FUNC_ARGLIST(val, memoval))
 
             v[1] = RARRAY_AREF(args, i);
             rb_rescue2(call_next, (VALUE)v, call_stop, (VALUE)v, rb_eStopIteration, (VALUE)0);
-            if (v[0] == Qundef) {
+            if (UNDEF_P(v[0])) {
                 RARRAY_ASET(args, i, Qnil);
                 v[0] = Qnil;
             }
@@ -4155,7 +4155,7 @@ slicewhen_ii(RB_BLOCK_CALL_FUNC_ARGLIST(i, _memo))
 
     ENUM_WANT_SVALUE();
 
-    if (memo->prev_elt == Qundef) {
+    if (UNDEF_P(memo->prev_elt)) {
         /* The first element */
         memo->prev_elt = i;
         memo->prev_elts = rb_ary_new3(1, i);
@@ -4395,7 +4395,7 @@ sum_iter_bignum(VALUE i, struct enum_sum_memo *memo)
 static void
 sum_iter_rational(VALUE i, struct enum_sum_memo *memo)
 {
-    if (memo->r == Qundef) {
+    if (UNDEF_P(memo->r)) {
         memo->r = i;
     }
     else {
@@ -4616,7 +4616,7 @@ enum_sum(int argc, VALUE* argv, VALUE obj)
     else {
         if (memo.n != 0)
             memo.v = rb_fix_plus(LONG2FIX(memo.n), memo.v);
-        if (memo.r != Qundef) {
+        if (!UNDEF_P(memo.r)) {
             memo.v = rb_rational_plus(memo.r, memo.v);
         }
         return memo.v;

--- a/enumerator.c
+++ b/enumerator.c
@@ -260,7 +260,7 @@ enumerator_ptr(VALUE obj)
     struct enumerator *ptr;
 
     TypedData_Get_Struct(obj, struct enumerator, &enumerator_data_type, ptr);
-    if (!ptr || ptr->obj == Qundef) {
+    if (!ptr || UNDEF_P(ptr->obj)) {
         rb_raise(rb_eArgError, "uninitialized enumerator");
     }
     return ptr;
@@ -735,7 +735,7 @@ next_ii(RB_BLOCK_CALL_FUNC_ARGLIST(i, obj))
     VALUE feedvalue = Qnil;
     VALUE args = rb_ary_new4(argc, argv);
     rb_fiber_yield(1, &args);
-    if (e->feedvalue != Qundef) {
+    if (!UNDEF_P(e->feedvalue)) {
         feedvalue = e->feedvalue;
         e->feedvalue = Qundef;
     }
@@ -840,7 +840,7 @@ enumerator_next_values(VALUE obj)
     struct enumerator *e = enumerator_ptr(obj);
     VALUE vs;
 
-    if (e->lookahead != Qundef) {
+    if (!UNDEF_P(e->lookahead)) {
         vs = e->lookahead;
         e->lookahead = Qundef;
         return vs;
@@ -901,7 +901,7 @@ enumerator_peek_values(VALUE obj)
 {
     struct enumerator *e = enumerator_ptr(obj);
 
-    if (e->lookahead == Qundef) {
+    if (UNDEF_P(e->lookahead)) {
         e->lookahead = get_next_values(obj, e);
     }
     return e->lookahead;
@@ -1025,7 +1025,7 @@ enumerator_feed(VALUE obj, VALUE v)
 {
     struct enumerator *e = enumerator_ptr(obj);
 
-    if (e->feedvalue != Qundef) {
+    if (!UNDEF_P(e->feedvalue)) {
         rb_raise(rb_eTypeError, "feed value already set");
     }
     e->feedvalue = v;
@@ -1070,7 +1070,7 @@ inspect_enumerator(VALUE obj, VALUE dummy, int recur)
 
     cname = rb_obj_class(obj);
 
-    if (!e || e->obj == Qundef) {
+    if (!e || UNDEF_P(e->obj)) {
         return rb_sprintf("#<%"PRIsVALUE": uninitialized>", rb_class_path(cname));
     }
 
@@ -1239,7 +1239,7 @@ enumerator_size(VALUE obj)
         argv = RARRAY_CONST_PTR(e->args);
     }
     size = rb_check_funcall_kw(e->size, id_call, argc, argv, e->kw_splat);
-    if (size != Qundef) return size;
+    if (!UNDEF_P(size)) return size;
     return e->size;
 }
 
@@ -1285,7 +1285,7 @@ yielder_ptr(VALUE obj)
     struct yielder *ptr;
 
     TypedData_Get_Struct(obj, struct yielder, &yielder_data_type, ptr);
-    if (!ptr || ptr->proc == Qundef) {
+    if (!ptr || UNDEF_P(ptr->proc)) {
         rb_raise(rb_eArgError, "uninitialized yielder");
     }
     return ptr;
@@ -1425,7 +1425,7 @@ generator_ptr(VALUE obj)
     struct generator *ptr;
 
     TypedData_Get_Struct(obj, struct generator, &generator_data_type, ptr);
-    if (!ptr || ptr->proc == Qundef) {
+    if (!ptr || UNDEF_P(ptr->proc)) {
         rb_raise(rb_eArgError, "uninitialized generator");
     }
     return ptr;
@@ -1529,7 +1529,7 @@ static VALUE
 enum_size(VALUE self)
 {
     VALUE r = rb_check_funcall(self, id_size, 0, 0);
-    return (r == Qundef) ? Qnil : r;
+    return UNDEF_P(r) ? Qnil : r;
 }
 
 static VALUE
@@ -1562,7 +1562,7 @@ lazy_init_iterator(RB_BLOCK_CALL_FUNC_ARGLIST(val, m))
         result = rb_yield_values2(len, nargv);
         ALLOCV_END(args);
     }
-    if (result == Qundef) rb_iter_break();
+    if (UNDEF_P(result)) rb_iter_break();
     return Qnil;
 }
 
@@ -2923,7 +2923,7 @@ producer_ptr(VALUE obj)
     struct producer *ptr;
 
     TypedData_Get_Struct(obj, struct producer, &producer_data_type, ptr);
-    if (!ptr || ptr->proc == Qundef) {
+    if (!ptr || UNDEF_P(ptr->proc)) {
         rb_raise(rb_eArgError, "uninitialized producer");
     }
     return ptr;
@@ -2978,7 +2978,7 @@ producer_each_i(VALUE obj)
     init = ptr->init;
     proc = ptr->proc;
 
-    if (init == Qundef) {
+    if (UNDEF_P(init)) {
         curr = Qnil;
     }
     else {
@@ -3109,7 +3109,7 @@ enum_chain_ptr(VALUE obj)
     struct enum_chain *ptr;
 
     TypedData_Get_Struct(obj, struct enum_chain, &enum_chain_data_type, ptr);
-    if (!ptr || ptr->enums == Qundef) {
+    if (!ptr || UNDEF_P(ptr->enums)) {
         rb_raise(rb_eArgError, "uninitialized chain");
     }
     return ptr;
@@ -3302,7 +3302,7 @@ inspect_enum_chain(VALUE obj, VALUE dummy, int recur)
 
     TypedData_Get_Struct(obj, struct enum_chain, &enum_chain_data_type, ptr);
 
-    if (!ptr || ptr->enums == Qundef) {
+    if (!ptr || UNDEF_P(ptr->enums)) {
         return rb_sprintf("#<%"PRIsVALUE": uninitialized>", rb_class_path(klass));
     }
 
@@ -3431,7 +3431,7 @@ enum_product_ptr(VALUE obj)
     struct enum_product *ptr;
 
     TypedData_Get_Struct(obj, struct enum_product, &enum_product_data_type, ptr);
-    if (!ptr || ptr->enums == Qundef) {
+    if (!ptr || UNDEF_P(ptr->enums)) {
         rb_raise(rb_eArgError, "uninitialized product");
     }
     return ptr;
@@ -3642,7 +3642,7 @@ inspect_enum_product(VALUE obj, VALUE dummy, int recur)
 
     TypedData_Get_Struct(obj, struct enum_product, &enum_product_data_type, ptr);
 
-    if (!ptr || ptr->enums == Qundef) {
+    if (!ptr || UNDEF_P(ptr->enums)) {
         return rb_sprintf("#<%"PRIsVALUE": uninitialized>", rb_class_path(klass));
     }
 

--- a/error.c
+++ b/error.c
@@ -1005,7 +1005,7 @@ rb_check_type(VALUE x, int t)
 {
     int xt;
 
-    if (RB_UNLIKELY(x == Qundef)) {
+    if (RB_UNLIKELY(UNDEF_P(x))) {
         rb_bug(UNDEF_LEAKED);
     }
 
@@ -1026,7 +1026,7 @@ rb_check_type(VALUE x, int t)
 void
 rb_unexpected_type(VALUE x, int t)
 {
-    if (RB_UNLIKELY(x == Qundef)) {
+    if (RB_UNLIKELY(UNDEF_P(x))) {
         rb_bug(UNDEF_LEAKED);
     }
 
@@ -1228,7 +1228,7 @@ VALUE
 rb_get_message(VALUE exc)
 {
     VALUE e = rb_check_funcall(exc, id_message, 0, 0);
-    if (e == Qundef) return Qnil;
+    if (UNDEF_P(e)) return Qnil;
     if (!RB_TYPE_P(e, T_STRING)) e = rb_check_string_type(e);
     return e;
 }
@@ -1243,7 +1243,7 @@ rb_get_detailed_message(VALUE exc, VALUE opt)
     else {
         e = rb_check_funcall_kw(exc, id_detailed_message, 1, &opt, 1);
     }
-    if (e == Qundef) return Qnil;
+    if (UNDEF_P(e)) return Qnil;
     if (!RB_TYPE_P(e, T_STRING)) e = rb_check_string_type(e);
     return e;
 }
@@ -1635,15 +1635,15 @@ exc_equal(VALUE exc, VALUE obj)
         int state;
 
         obj = rb_protect(try_convert_to_exception, obj, &state);
-        if (state || obj == Qundef) {
+        if (state || UNDEF_P(obj)) {
             rb_set_errinfo(Qnil);
             return Qfalse;
         }
         if (rb_obj_class(exc) != rb_obj_class(obj)) return Qfalse;
         mesg = rb_check_funcall(obj, id_message, 0, 0);
-        if (mesg == Qundef) return Qfalse;
+        if (UNDEF_P(mesg)) return Qfalse;
         backtrace = rb_check_funcall(obj, id_backtrace, 0, 0);
-        if (backtrace == Qundef) return Qfalse;
+        if (UNDEF_P(backtrace)) return Qfalse;
     }
     else {
         mesg = rb_attr_get(obj, id_mesg);
@@ -1746,7 +1746,7 @@ exit_success_p(VALUE exc)
 static VALUE
 err_init_recv(VALUE exc, VALUE recv)
 {
-    if (recv != Qundef) rb_ivar_set(exc, id_recv, recv);
+    if (!UNDEF_P(recv)) rb_ivar_set(exc, id_recv, recv);
     return exc;
 }
 
@@ -2090,7 +2090,7 @@ name_err_mesg_to_str(VALUE obj)
             break;
           default:
             d = rb_protect(name_err_mesg_receiver_name, obj, &state);
-            if (state || d == Qundef || NIL_P(d))
+            if (state || UNDEF_P(d) || NIL_P(d))
                 d = rb_protect(rb_inspect, obj, &state);
             if (state) {
                 rb_set_errinfo(Qnil);
@@ -2145,7 +2145,7 @@ name_err_receiver(VALUE self)
     VALUE *ptr, recv, mesg;
 
     recv = rb_ivar_lookup(self, id_recv, Qundef);
-    if (recv != Qundef) return recv;
+    if (!UNDEF_P(recv)) return recv;
 
     mesg = rb_attr_get(self, id_mesg);
     if (!rb_typeddata_is_kind_of(mesg, &name_err_mesg_data_type)) {
@@ -2203,7 +2203,7 @@ key_err_receiver(VALUE self)
     VALUE recv;
 
     recv = rb_ivar_lookup(self, id_receiver, Qundef);
-    if (recv != Qundef) return recv;
+    if (!UNDEF_P(recv)) return recv;
     rb_raise(rb_eArgError, "no receiver is available");
 }
 
@@ -2220,7 +2220,7 @@ key_err_key(VALUE self)
     VALUE key;
 
     key = rb_ivar_lookup(self, id_key, Qundef);
-    if (key != Qundef) return key;
+    if (!UNDEF_P(key)) return key;
     rb_raise(rb_eArgError, "no key is available");
 }
 
@@ -2258,7 +2258,7 @@ key_err_initialize(int argc, VALUE *argv, VALUE self)
         keywords[1] = id_key;
         rb_get_kwargs(options, keywords, 0, numberof(values), values);
         for (i = 0; i < numberof(values); ++i) {
-            if (values[i] != Qundef) {
+            if (!UNDEF_P(values[i])) {
                 rb_ivar_set(self, keywords[i], values[i]);
             }
         }
@@ -2280,7 +2280,7 @@ no_matching_pattern_key_err_matchee(VALUE self)
     VALUE matchee;
 
     matchee = rb_ivar_lookup(self, id_matchee, Qundef);
-    if (matchee != Qundef) return matchee;
+    if (!UNDEF_P(matchee)) return matchee;
     rb_raise(rb_eArgError, "no matchee is available");
 }
 
@@ -2297,7 +2297,7 @@ no_matching_pattern_key_err_key(VALUE self)
     VALUE key;
 
     key = rb_ivar_lookup(self, id_key, Qundef);
-    if (key != Qundef) return key;
+    if (!UNDEF_P(key)) return key;
     rb_raise(rb_eArgError, "no key is available");
 }
 
@@ -2324,7 +2324,7 @@ no_matching_pattern_key_err_initialize(int argc, VALUE *argv, VALUE self)
         keywords[1] = id_key;
         rb_get_kwargs(options, keywords, 0, numberof(values), values);
         for (i = 0; i < numberof(values); ++i) {
-            if (values[i] != Qundef) {
+            if (!UNDEF_P(values[i])) {
                 rb_ivar_set(self, keywords[i], values[i]);
             }
         }

--- a/eval.c
+++ b/eval.c
@@ -514,7 +514,7 @@ exc_setup_message(const rb_execution_context_t *ec, VALUE mesg, VALUE *cause)
         nocause = 0;
         nocircular = 1;
     }
-    if (*cause == Qundef) {
+    if (UNDEF_P(*cause)) {
         if (nocause) {
             *cause = Qnil;
             nocircular = 1;
@@ -530,7 +530,7 @@ exc_setup_message(const rb_execution_context_t *ec, VALUE mesg, VALUE *cause)
         rb_raise(rb_eTypeError, "exception object expected");
     }
 
-    if (!nocircular && !NIL_P(*cause) && *cause != Qundef && *cause != mesg) {
+    if (!nocircular && !NIL_P(*cause) && !UNDEF_P(*cause) && *cause != mesg) {
         VALUE c = *cause;
         while (!NIL_P(c = rb_attr_get(c, id_cause))) {
             if (c == mesg) {
@@ -549,18 +549,18 @@ setup_exception(rb_execution_context_t *ec, int tag, volatile VALUE mesg, VALUE 
     const char *file = rb_source_location_cstr(&line);
     const char *const volatile file0 = file;
 
-    if ((file && !NIL_P(mesg)) || (cause != Qundef))  {
+    if ((file && !NIL_P(mesg)) || !UNDEF_P(cause))  {
         volatile int state = 0;
 
         EC_PUSH_TAG(ec);
         if (EC_EXEC_TAG() == TAG_NONE && !(state = rb_ec_set_raised(ec))) {
             VALUE bt = rb_get_backtrace(mesg);
-            if (!NIL_P(bt) || cause == Qundef) {
+            if (!NIL_P(bt) || UNDEF_P(cause)) {
                 if (OBJ_FROZEN(mesg)) {
                     mesg = rb_obj_dup(mesg);
                 }
             }
-            if (cause != Qundef && !THROW_DATA_P(cause)) {
+            if (!UNDEF_P(cause) && !THROW_DATA_P(cause)) {
                 exc_setup_cause(mesg, cause);
             }
             if (NIL_P(bt)) {
@@ -633,7 +633,7 @@ setup_exception(rb_execution_context_t *ec, int tag, volatile VALUE mesg, VALUE 
 void
 rb_ec_setup_exception(const rb_execution_context_t *ec, VALUE mesg, VALUE cause)
 {
-    if (cause == Qundef) {
+    if (UNDEF_P(cause)) {
         cause = get_ec_errinfo(ec);
     }
     if (cause != mesg) {
@@ -728,7 +728,7 @@ rb_f_raise(int argc, VALUE *argv)
 
     argc = extract_raise_opts(argc, argv, opts);
     if (argc == 0) {
-        if (*cause != Qundef) {
+        if (!UNDEF_P(*cause)) {
             rb_raise(rb_eArgError, "only cause is given with no arguments");
         }
         err = get_errinfo();
@@ -804,7 +804,7 @@ make_exception(int argc, const VALUE *argv, int isstr)
     if (NIL_P(mesg)) {
         mesg = rb_check_funcall(argv[0], idException, argc != 1, &argv[1]);
     }
-    if (mesg == Qundef) {
+    if (UNDEF_P(mesg)) {
         rb_raise(rb_eTypeError, "exception class/object expected");
     }
     if (!rb_obj_is_kind_of(mesg, rb_eException)) {

--- a/eval_error.c
+++ b/eval_error.c
@@ -306,7 +306,7 @@ rb_error_write(VALUE errinfo, VALUE emesg, VALUE errat, VALUE str, VALUE opt, VA
     if (NIL_P(errinfo))
         return;
 
-    if (errat == Qundef) {
+    if (UNDEF_P(errat)) {
         errat = Qnil;
     }
     eclass = CLASS_OF(errinfo);
@@ -358,7 +358,7 @@ rb_ec_error_print(rb_execution_context_t * volatile ec, volatile VALUE errinfo)
     if (EC_EXEC_TAG() == TAG_NONE) {
         errat = rb_get_backtrace(errinfo);
     }
-    if (emesg == Qundef) {
+    if (UNDEF_P(emesg)) {
         emesg = Qnil;
         emesg = rb_get_detailed_message(errinfo, opt);
     }

--- a/gc.c
+++ b/gc.c
@@ -4307,7 +4307,7 @@ run_single_final(VALUE cmd, VALUE objid)
 static void
 warn_exception_in_finalizer(rb_execution_context_t *ec, VALUE final)
 {
-    if (final != Qundef && !NIL_P(ruby_verbose)) {
+    if (!UNDEF_P(final) && !NIL_P(ruby_verbose)) {
         VALUE errinfo = ec->errinfo;
         rb_warn("Exception in finalizer %+"PRIsVALUE, final);
         rb_ec_error_print(ec, errinfo);
@@ -4673,7 +4673,7 @@ id2ref(VALUE objid)
         }
     }
 
-    if ((orig = id2ref_obj_tbl(objspace, objid)) != Qundef &&
+    if (!UNDEF_P(orig = id2ref_obj_tbl(objspace, objid)) &&
         is_live_object(objspace, orig)) {
 
         if (!rb_multi_ractor_p() || rb_ractor_shareable_p(orig)) {
@@ -7379,7 +7379,7 @@ gc_mark_stacked_objects(rb_objspace_t *objspace, int incremental, size_t count)
 #endif
 
     while (pop_mark_stack(mstack, &obj)) {
-        if (obj == Qundef) continue; /* skip */
+        if (UNDEF_P(obj)) continue; /* skip */
 
         if (RGENGC_CHECK_MODE && !RVALUE_MARKED(obj)) {
             rb_bug("gc_mark_stacked_objects: %s is not marked.", obj_info(obj));
@@ -12790,7 +12790,7 @@ wmap_finalize(RB_BLOCK_CALL_FUNC_ARGLIST(objid, self))
 
     TypedData_Get_Struct(self, struct weakmap, &weakmap_type, w);
     /* Get reference from object id. */
-    if ((obj = id2ref_obj_tbl(&rb_objspace, objid)) == Qundef) {
+    if (UNDEF_P(obj = id2ref_obj_tbl(&rb_objspace, objid))) {
         rb_bug("wmap_finalize: objid is not found.");
     }
 
@@ -13081,14 +13081,14 @@ static VALUE
 wmap_aref(VALUE self, VALUE key)
 {
     VALUE obj = wmap_lookup(self, key);
-    return obj != Qundef ? obj : Qnil;
+    return !UNDEF_P(obj) ? obj : Qnil;
 }
 
 /* Returns +true+ if +key+ is registered */
 static VALUE
 wmap_has_key(VALUE self, VALUE key)
 {
-    return RBOOL(wmap_lookup(self, key) != Qundef);
+    return RBOOL(!UNDEF_P(wmap_lookup(self, key)));
 }
 
 /* Returns the number of referenced objects */

--- a/hash.c
+++ b/hash.c
@@ -111,7 +111,7 @@ rb_any_cmp(VALUE a, VALUE b)
         RB_TYPE_P(b, T_STRING) && RBASIC(b)->klass == rb_cString) {
         return rb_str_hash_cmp(a, b);
     }
-    if (a == Qundef || b == Qundef) return -1;
+    if (UNDEF_P(a) || UNDEF_P(b)) return -1;
     if (SYMBOL_P(a) && SYMBOL_P(b)) {
         return a != b;
     }
@@ -195,7 +195,7 @@ obj_any_hash(VALUE obj)
 {
     VALUE hval = rb_check_funcall_basic_kw(obj, id_hash, rb_mKernel, 0, 0, 0);
 
-    if (hval == Qundef) {
+    if (UNDEF_P(hval)) {
         hval = rb_exec_recursive_outer_mid(hash_recursive, obj, 0, id_hash);
     }
 
@@ -437,7 +437,7 @@ ar_cleared_entry(VALUE hash, unsigned int index)
          * so you need to check key == Qundef
          */
         ar_table_pair *pair = RHASH_AR_TABLE_REF(hash, index);
-        return pair->key == Qundef;
+        return UNDEF_P(pair->key);
     }
     else {
         return FALSE;
@@ -517,8 +517,8 @@ hash_verify_(VALUE hash, const char *file, int line)
                 ar_table_pair *pair = RHASH_AR_TABLE_REF(hash, i);
                 k = pair->key;
                 v = pair->val;
-                HASH_ASSERT(k != Qundef);
-                HASH_ASSERT(v != Qundef);
+                HASH_ASSERT(!UNDEF_P(k));
+                HASH_ASSERT(!UNDEF_P(v));
                 n++;
             }
         }
@@ -2076,7 +2076,7 @@ rb_hash_default_value(VALUE hash, VALUE key)
     if (LIKELY(rb_method_basic_definition_p(CLASS_OF(hash), id_default))) {
         VALUE ifnone = RHASH_IFNONE(hash);
         if (!FL_TEST(hash, RHASH_PROC_DEFAULT)) return ifnone;
-        if (key == Qundef) return Qnil;
+        if (UNDEF_P(key)) return Qnil;
         return call_default_proc(ifnone, hash, key);
     }
     else {
@@ -2402,7 +2402,7 @@ rb_hash_delete(VALUE hash, VALUE key)
 {
     VALUE deleted_value = rb_hash_delete_entry(hash, key);
 
-    if (deleted_value != Qundef) { /* likely pass */
+    if (!UNDEF_P(deleted_value)) { /* likely pass */
         return deleted_value;
     }
     else {
@@ -2445,7 +2445,7 @@ rb_hash_delete_m(VALUE hash, VALUE key)
     rb_hash_modify_check(hash);
     val = rb_hash_delete_entry(hash, key);
 
-    if (val != Qundef) {
+    if (!UNDEF_P(val)) {
         return val;
     }
     else {
@@ -2502,7 +2502,7 @@ rb_hash_shift(VALUE hash)
         }
         else {
             rb_hash_foreach(hash, shift_i_safe, (VALUE)&var);
-            if (var.key != Qundef) {
+            if (!UNDEF_P(var.key)) {
                 rb_hash_delete_entry(hash, var.key);
                 return rb_assoc_new(var.key, var.val);
             }
@@ -2517,7 +2517,7 @@ rb_hash_shift(VALUE hash)
         }
         else {
             rb_hash_foreach(hash, shift_i_safe, (VALUE)&var);
-            if (var.key != Qundef) {
+            if (!UNDEF_P(var.key)) {
                 rb_hash_delete_entry(hash, var.key);
                 return rb_assoc_new(var.key, var.val);
             }
@@ -2658,7 +2658,7 @@ rb_hash_slice(int argc, VALUE *argv, VALUE hash)
     for (i = 0; i < argc; i++) {
         key = argv[i];
         value = rb_hash_lookup2(hash, key, Qundef);
-        if (value != Qundef)
+        if (!UNDEF_P(value))
             rb_hash_aset(result, key, value);
     }
 
@@ -3181,7 +3181,7 @@ transform_keys_hash_i(VALUE key, VALUE value, VALUE transarg)
     struct transform_keys_args *p = (void *)transarg;
     VALUE trans = p->trans, result = p->result;
     VALUE new_key = rb_hash_lookup2(trans, key, Qundef);
-    if (new_key == Qundef) {
+    if (UNDEF_P(new_key)) {
         if (p->block_given)
             new_key = rb_yield(key);
         else
@@ -3302,7 +3302,7 @@ rb_hash_transform_keys_bang(int argc, VALUE *argv, VALUE hash)
             if (!trans) {
                 new_key = rb_yield(key);
             }
-            else if ((new_key = rb_hash_lookup2(trans, key, Qundef)) != Qundef) {
+            else if (!UNDEF_P(new_key = rb_hash_lookup2(trans, key, Qundef))) {
                 /* use the transformed key */
             }
             else if (block_given) {
@@ -4195,7 +4195,7 @@ rb_hash_assoc(VALUE hash, VALUE key)
         ensure_arg.hash = hash;
         ensure_arg.orighash = orighash;
         value = rb_ensure(lookup2_call, (VALUE)&args, reset_hash_type, (VALUE)&ensure_arg);
-        if (value != Qundef) return rb_assoc_new(key, value);
+        if (!UNDEF_P(value)) return rb_assoc_new(key, value);
     }
 
     args[0] = key;
@@ -4608,7 +4608,7 @@ hash_le_i(VALUE key, VALUE value, VALUE arg)
 {
     VALUE *args = (VALUE *)arg;
     VALUE v = rb_hash_lookup2(args[0], key, Qundef);
-    if (v != Qundef && rb_equal(value, v)) return ST_CONTINUE;
+    if (!UNDEF_P(v) && rb_equal(value, v)) return ST_CONTINUE;
     args[1] = Qfalse;
     return ST_STOP;
 }

--- a/io_buffer.c
+++ b/io_buffer.c
@@ -2384,7 +2384,7 @@ rb_io_buffer_read(VALUE self, VALUE io, size_t length, size_t offset)
     if (scheduler != Qnil) {
         VALUE result = rb_fiber_scheduler_io_read(scheduler, io, self, SIZET2NUM(length), SIZET2NUM(offset));
 
-        if (result != Qundef) {
+        if (!UNDEF_P(result)) {
             return result;
         }
     }
@@ -2501,7 +2501,7 @@ rb_io_buffer_pread(VALUE self, VALUE io, rb_off_t from, size_t length, size_t of
     if (scheduler != Qnil) {
         VALUE result = rb_fiber_scheduler_io_pread(scheduler, io, OFFT2NUM(from), self, SIZET2NUM(length), SIZET2NUM(offset));
 
-        if (result != Qundef) {
+        if (!UNDEF_P(result)) {
             return result;
         }
     }
@@ -2574,7 +2574,7 @@ rb_io_buffer_write(VALUE self, VALUE io, size_t length, size_t offset)
     if (scheduler != Qnil) {
         VALUE result = rb_fiber_scheduler_io_write(scheduler, io, self, SIZET2NUM(length), SIZET2NUM(offset));
 
-        if (result != Qundef) {
+        if (!UNDEF_P(result)) {
             return result;
         }
     }
@@ -2668,7 +2668,7 @@ rb_io_buffer_pwrite(VALUE self, VALUE io, rb_off_t from, size_t length, size_t o
     if (scheduler != Qnil) {
         VALUE result = rb_fiber_scheduler_io_pwrite(scheduler, io, OFFT2NUM(from), self, SIZET2NUM(length), SIZET2NUM(offset));
 
-        if (result != Qundef) {
+        if (!UNDEF_P(result)) {
             return result;
         }
     }

--- a/iseq.c
+++ b/iseq.c
@@ -331,7 +331,7 @@ rb_iseq_update_references(rb_iseq_t *iseq)
 
             for (j = 0; i < body->param.keyword->num; i++, j++) {
                 VALUE obj = body->param.keyword->default_values[j];
-                if (obj != Qundef) {
+                if (!UNDEF_P(obj)) {
                     body->param.keyword->default_values[j] = rb_gc_location(obj);
                 }
             }
@@ -2916,7 +2916,7 @@ iseq_data_to_ary(const rb_iseq_t *iseq)
             }
             for (j=0; i<keyword->num; i++, j++) {
                 VALUE key = rb_ary_new_from_args(1, ID2SYM(keyword->table[i]));
-                if (keyword->default_values[j] != Qundef) {
+                if (!UNDEF_P(keyword->default_values[j])) {
                     rb_ary_push(key, keyword->default_values[j]);
                 }
                 rb_ary_push(keywords, key);

--- a/marshal.c
+++ b/marshal.c
@@ -743,7 +743,7 @@ w_ivar(st_index_t num, VALUE ivobj, VALUE encname, struct dump_call_arg *arg)
         w_object(Qtrue, arg->arg, limit);
         num--;
     }
-    if (ivobj != Qundef && num) {
+    if (!UNDEF_P(ivobj) && num) {
         w_ivar_each(ivobj, num, arg);
     }
 }
@@ -930,7 +930,7 @@ w_object(VALUE obj, struct dump_arg *arg, int limit)
                     arg->compat_tbl = rb_init_identtable();
                 }
                 st_insert(arg->compat_tbl, (st_data_t)obj, (st_data_t)real_obj);
-                if (obj != real_obj && ivobj == Qundef) hasiv = 0;
+                if (obj != real_obj && UNDEF_P(ivobj)) hasiv = 0;
             }
         }
         if (hasiv) w_byte(TYPE_IVAR, arg);
@@ -2251,7 +2251,7 @@ r_object_for(struct load_arg *arg, bool partial, int *ivp, VALUE extmod, int typ
         break;
     }
 
-    if (v == Qundef) {
+    if (UNDEF_P(v)) {
         rb_raise(rb_eArgError, "dump format error (bad link)");
     }
 

--- a/numeric.c
+++ b/numeric.c
@@ -449,7 +449,7 @@ static int
 do_coerce(VALUE *x, VALUE *y, int err)
 {
     VALUE ary = rb_check_funcall(*y, id_coerce, 1, x);
-    if (ary == Qundef) {
+    if (UNDEF_P(ary)) {
         if (err) {
             coerce_failed(*x, *y);
         }
@@ -1713,7 +1713,7 @@ flo_cmp(VALUE x, VALUE y)
         b = RFLOAT_VALUE(y);
     }
     else {
-        if (isinf(a) && (i = rb_check_funcall(y, rb_intern("infinite?"), 0, 0)) != Qundef) {
+        if (isinf(a) && !UNDEF_P(i = rb_check_funcall(y, rb_intern("infinite?"), 0, 0))) {
             if (RTEST(i)) {
                 int j = rb_cmpint(i, x, y);
                 j = (a > 0.0) ? (j > 0 ? 0 : +1) : (j < 0 ? 0 : -1);
@@ -2858,7 +2858,7 @@ num_step_negative_p(VALUE num)
     }
 
     r = rb_check_funcall(num, '>', 1, &zero);
-    if (r == Qundef) {
+    if (UNDEF_P(r)) {
         coerce_failed(num, INT2FIX(0));
     }
     return !RTEST(r);
@@ -2876,11 +2876,11 @@ num_step_extract_args(int argc, const VALUE *argv, VALUE *to, VALUE *step, VALUE
         keys[0] = id_to;
         keys[1] = id_by;
         rb_get_kwargs(hash, keys, 0, 2, values);
-        if (values[0] != Qundef) {
+        if (!UNDEF_P(values[0])) {
             if (argc > 0) rb_raise(rb_eArgError, "to is given twice");
             *to = values[0];
         }
-        if (values[1] != Qundef) {
+        if (!UNDEF_P(values[1])) {
             if (argc > 1) rb_raise(rb_eArgError, "step is given twice");
             *by = values[1];
         }
@@ -2893,7 +2893,7 @@ static int
 num_step_check_fix_args(int argc, VALUE *to, VALUE *step, VALUE by, int fix_nil, int allow_zero_step)
 {
     int desc;
-    if (by != Qundef) {
+    if (!UNDEF_P(by)) {
         *step = by;
     }
     else {
@@ -3041,7 +3041,7 @@ num_step(int argc, VALUE *argv, VALUE from)
         VALUE by = Qundef;
 
         num_step_extract_args(argc, argv, &to, &step, &by);
-        if (by != Qundef) {
+        if (!UNDEF_P(by)) {
             step = by;
         }
         if (NIL_P(step)) {
@@ -4930,7 +4930,7 @@ rb_num_coerce_bit(VALUE x, VALUE y, ID func)
     do_coerce(&args[1], &args[2], TRUE);
     ret = rb_exec_recursive_paired(num_funcall_bit_1,
                                    args[2], args[1], (VALUE)args);
-    if (ret == Qundef) {
+    if (UNDEF_P(ret)) {
         /* show the original object, not coerced object */
         coerce_failed(x, y);
     }

--- a/object.c
+++ b/object.c
@@ -125,7 +125,7 @@ rb_equal(VALUE obj1, VALUE obj2)
 
     if (obj1 == obj2) return Qtrue;
     result = rb_equal_opt(obj1, obj2);
-    if (result == Qundef) {
+    if (UNDEF_P(result)) {
         result = rb_funcall(obj1, id_eq, 1, obj2);
     }
     return RBOOL(RTEST(result));
@@ -138,7 +138,7 @@ rb_eql(VALUE obj1, VALUE obj2)
 
     if (obj1 == obj2) return TRUE;
     result = rb_eql_opt(obj1, obj2);
-    if (result == Qundef) {
+    if (UNDEF_P(result)) {
         result = rb_funcall(obj1, id_eql, 1, obj2);
     }
     return RTEST(result);
@@ -411,7 +411,7 @@ rb_get_freeze_opt(int argc, VALUE *argv)
     rb_scan_args(argc, argv, "0:", &opt);
     if (!NIL_P(opt)) {
         rb_get_kwargs(opt, keyword_ids, 0, 1, &kwfreeze);
-        if (kwfreeze != Qundef)
+        if (!UNDEF_P(kwfreeze))
             kwfreeze = obj_freeze_opt(kwfreeze);
     }
     return kwfreeze;
@@ -2545,7 +2545,7 @@ rb_mod_const_defined(int argc, VALUE *argv, VALUE mod)
 
 #if 0
         mod = rb_const_search(mod, id, beglen > 0 || !RTEST(recur), RTEST(recur), FALSE);
-        if (mod == Qundef) return Qfalse;
+        if (UNDEF_P(mod)) return Qfalse;
 #else
         if (!RTEST(recur)) {
             if (!rb_const_defined_at(mod, id))
@@ -2975,7 +2975,7 @@ static VALUE
 convert_type_with_id(VALUE val, const char *tname, ID method, int raise, int index)
 {
     VALUE r = rb_check_funcall(val, method, 0, 0);
-    if (r == Qundef) {
+    if (UNDEF_P(r)) {
         if (raise) {
             const char *msg =
                 ((index < 0 ? conv_method_index(rb_id2name(method)) : index)

--- a/parse.y
+++ b/parse.y
@@ -10848,7 +10848,7 @@ check_literal_when(struct parser_params *p, NODE *arg, const YYLTYPE *loc)
     if (!arg || !p->case_labels) return;
 
     lit = rb_node_case_when_optimizable_literal(arg);
-    if (lit == Qundef) return;
+    if (UNDEF_P(lit)) return;
     if (nd_type_p(arg, NODE_STR)) {
 	RB_OBJ_WRITTEN(p->ast, Qnil, arg->nd_lit = lit);
     }
@@ -11501,7 +11501,7 @@ shareable_literal_constant(struct parser_params *p, enum shareability shareable,
 	    }
 	    if (RTEST(lit)) {
 		VALUE e = shareable_literal_value(elt);
-		if (e != Qundef) {
+		if (!UNDEF_P(e)) {
 		    rb_ary_push(lit, e);
 		}
 		else {
@@ -11541,7 +11541,7 @@ shareable_literal_constant(struct parser_params *p, enum shareability shareable,
 	    if (RTEST(lit)) {
 		VALUE k = shareable_literal_value(key);
 		VALUE v = shareable_literal_value(val);
-		if (k != Qundef && v != Qundef) {
+		if (!UNDEF_P(k) && !UNDEF_P(v)) {
 		    rb_hash_aset(lit, k, v);
 		}
 		else {
@@ -13787,7 +13787,7 @@ ripper_validate_object(VALUE self, VALUE x)
     if (x == Qfalse) return x;
     if (x == Qtrue) return x;
     if (NIL_P(x)) return x;
-    if (x == Qundef)
+    if (UNDEF_P(x))
 	rb_raise(rb_eArgError, "Qundef given");
     if (FIXNUM_P(x)) return x;
     if (SYMBOL_P(x)) return x;
@@ -13898,7 +13898,7 @@ static VALUE
 ripper_get_value(VALUE v)
 {
     NODE *nd;
-    if (v == Qundef) return Qnil;
+    if (UNDEF_P(v)) return Qnil;
     if (!RB_TYPE_P(v, T_NODE)) return v;
     nd = (NODE *)v;
     if (!nd_type_p(nd, NODE_RIPPER)) return Qnil;
@@ -14159,7 +14159,7 @@ static VALUE
 ripper_assert_Qundef(VALUE self, VALUE obj, VALUE msg)
 {
     StringValue(msg);
-    if (obj == Qundef) {
+    if (UNDEF_P(obj)) {
         rb_raise(rb_eArgError, "%"PRIsVALUE, msg);
     }
     return Qnil;

--- a/proc.c
+++ b/proc.c
@@ -89,7 +89,7 @@ block_mark(const struct rb_block *block)
             const struct rb_captured_block *captured = &block->as.captured;
             RUBY_MARK_MOVABLE_UNLESS_NULL(captured->self);
             RUBY_MARK_MOVABLE_UNLESS_NULL((VALUE)captured->code.val);
-            if (captured->ep && captured->ep[VM_ENV_DATA_INDEX_ENV] != Qundef /* cfunc_proc_t */) {
+            if (captured->ep && !UNDEF_P(captured->ep[VM_ENV_DATA_INDEX_ENV]) /* cfunc_proc_t */) {
                 rb_gc_mark(VM_ENV_ENVVAL(captured->ep));
             }
         }
@@ -1645,7 +1645,7 @@ respond_to_missing_p(VALUE klass, VALUE obj, VALUE sym, int scope)
     /* TODO: merge with obj_respond_to() */
     ID rmiss = idRespond_to_missing;
 
-    if (obj == Qundef) return 0;
+    if (UNDEF_P(obj)) return 0;
     if (rb_method_basic_definition_p(klass, rmiss)) return 0;
     return RTEST(rb_funcall(obj, rmiss, 2, sym, RBOOL(!scope)));
 }
@@ -1746,7 +1746,7 @@ mnew_callable(VALUE klass, VALUE obj, ID id, VALUE mclass, int scope)
     const rb_method_entry_t *me;
     VALUE iclass = Qnil;
 
-    ASSUME(obj != Qundef);
+    ASSUME(!UNDEF_P(obj));
     me = (rb_method_entry_t *)rb_callable_method_entry_with_refinements(klass, id, &iclass);
     return mnew_from_me(me, klass, iclass, obj, id, mclass, scope);
 }
@@ -1988,7 +1988,7 @@ rb_method_name_error(VALUE klass, VALUE str)
     else if (RB_TYPE_P(c, T_MODULE)) {
         s = MSG(" module");
     }
-    if (s == Qundef) {
+    if (UNDEF_P(s)) {
         s = MSG(" class");
     }
     rb_name_err_raise_str(s, c, str);
@@ -2493,7 +2493,7 @@ rb_method_call_with_block_kw(int argc, const VALUE *argv, VALUE method, VALUE pa
     rb_execution_context_t *ec = GET_EC();
 
     TypedData_Get_Struct(method, struct METHOD, &method_data_type, data);
-    if (data->recv == Qundef) {
+    if (UNDEF_P(data->recv)) {
         rb_raise(rb_eTypeError, "can't call unbound method; bind first");
     }
     return call_method_data(ec, data, argc, argv, passed_procval, kw_splat);
@@ -3142,7 +3142,7 @@ method_inspect(VALUE method)
     if (FL_TEST(mklass, FL_SINGLETON)) {
         VALUE v = rb_ivar_get(mklass, attached);
 
-        if (data->recv == Qundef) {
+        if (UNDEF_P(data->recv)) {
             rb_str_buf_append(str, rb_inspect(mklass));
         }
         else if (data->recv == v) {

--- a/process.c
+++ b/process.c
@@ -1332,7 +1332,7 @@ rb_process_status_wait(rb_pid_t pid, int flags)
     if (!(flags & WNOHANG)) {
         VALUE scheduler = rb_fiber_scheduler_current();
         VALUE result = rb_fiber_scheduler_process_wait(scheduler, pid, flags);
-        if (result != Qundef) return result;
+        if (!UNDEF_P(result)) return result;
     }
 
     struct waitpid_state waitpid_state;

--- a/ractor.c
+++ b/ractor.c
@@ -728,7 +728,7 @@ ractor_receive(rb_execution_context_t *ec, rb_ractor_t *cr)
     VM_ASSERT(cr == rb_ec_ractor_ptr(ec));
     VALUE v;
 
-    while ((v = ractor_try_receive(ec, cr)) == Qundef) {
+    while (UNDEF_P(v = ractor_try_receive(ec, cr))) {
         ractor_receive_wait(ec, cr);
     }
 
@@ -875,7 +875,7 @@ ractor_receive_if(rb_execution_context_t *ec, VALUE crv, VALUE b)
         }
         RACTOR_UNLOCK_SELF(cr);
 
-        if (v != Qundef) {
+        if (!UNDEF_P(v)) {
             struct receive_block_data data = {
                 .cr = cr,
                 .rq = rq,
@@ -887,7 +887,7 @@ ractor_receive_if(rb_execution_context_t *ec, VALUE crv, VALUE b)
             VALUE result = rb_ensure(receive_if_body, (VALUE)&data,
                                      receive_if_ensure, (VALUE)&data);
 
-            if (result != Qundef) return result;
+            if (!UNDEF_P(result)) return result;
             index++;
         }
 
@@ -1095,7 +1095,7 @@ ractor_select(rb_execution_context_t *ec, const VALUE *rs, const int rs_len, VAL
     int i;
     bool interrupted = false;
     enum rb_ractor_wait_status wait_status = 0;
-    bool yield_p = (yielded_value != Qundef) ? true : false;
+    bool yield_p = !UNDEF_P(yielded_value) ? true : false;
     const int alen = rs_len + (yield_p ? 1 : 0);
 
     struct ractor_select_action {
@@ -1152,7 +1152,7 @@ ractor_select(rb_execution_context_t *ec, const VALUE *rs, const int rs_len, VAL
               case ractor_select_action_take:
                 rv = actions[i].v;
                 v = ractor_try_take(ec, RACTOR_PTR(rv));
-                if (v != Qundef) {
+                if (!UNDEF_P(v)) {
                     *ret_r = rv;
                     ret = v;
                     goto cleanup;
@@ -1160,7 +1160,7 @@ ractor_select(rb_execution_context_t *ec, const VALUE *rs, const int rs_len, VAL
                 break;
               case ractor_select_action_receive:
                 v = ractor_try_receive(ec, cr);
-                if (v != Qundef) {
+                if (!UNDEF_P(v)) {
                     *ret_r = ID2SYM(rb_intern("receive"));
                     ret = v;
                     goto cleanup;
@@ -1324,7 +1324,7 @@ ractor_select(rb_execution_context_t *ec, const VALUE *rs, const int rs_len, VAL
         goto restart;
     }
 
-    VM_ASSERT(ret != Qundef);
+    VM_ASSERT(!UNDEF_P(ret));
     return ret;
 }
 
@@ -2289,7 +2289,7 @@ obj_traverse_i(VALUE obj, struct obj_traverse_data *data)
         rb_ivar_generic_ivtbl_lookup(obj, &ivtbl);
         for (uint32_t i = 0; i < ivtbl->numiv; i++) {
             VALUE val = ivtbl->ivptr[i];
-            if (val != Qundef && obj_traverse_i(val, data)) return 1;
+            if (!UNDEF_P(val) && obj_traverse_i(val, data)) return 1;
         }
     }
 
@@ -2311,7 +2311,7 @@ obj_traverse_i(VALUE obj, struct obj_traverse_data *data)
 
             for (uint32_t i=0; i<len; i++) {
                 VALUE val = ptr[i];
-                if (val != Qundef && obj_traverse_i(val, data)) return 1;
+                if (!UNDEF_P(val) && obj_traverse_i(val, data)) return 1;
             }
         }
         break;
@@ -2735,7 +2735,7 @@ obj_traverse_replace_i(VALUE obj, struct obj_traverse_replace_data *data)
         struct gen_ivtbl *ivtbl;
         rb_ivar_generic_ivtbl_lookup(obj, &ivtbl);
         for (uint32_t i = 0; i < ivtbl->numiv; i++) {
-            if (ivtbl->ivptr[i] != Qundef) {
+            if (!UNDEF_P(ivtbl->ivptr[i])) {
                 CHECK_AND_REPLACE(ivtbl->ivptr[i]);
             }
         }
@@ -2764,7 +2764,7 @@ obj_traverse_replace_i(VALUE obj, struct obj_traverse_replace_data *data)
             VALUE *ptr = ROBJECT_IVPTR(obj);
 
             for (uint32_t i=0; i<len; i++) {
-                if (ptr[i] != Qundef) {
+                if (!UNDEF_P(ptr[i])) {
                     CHECK_AND_REPLACE(ptr[i]);
                 }
             }
@@ -2969,7 +2969,7 @@ static VALUE
 ractor_move(VALUE obj)
 {
     VALUE val = rb_obj_traverse_replace(obj, move_enter, move_leave, true);
-    if (val != Qundef) {
+    if (!UNDEF_P(val)) {
         return val;
     }
     else {
@@ -3000,7 +3000,7 @@ static VALUE
 ractor_copy(VALUE obj)
 {
     VALUE val = rb_obj_traverse_replace(obj, copy_enter, copy_leave, false);
-    if (val != Qundef) {
+    if (!UNDEF_P(val)) {
         return val;
     }
     else {
@@ -3132,7 +3132,7 @@ static bool
 ractor_local_ref(rb_ractor_local_key_t key, void **pret)
 {
     if (rb_ractor_main_p()) {
-        if ((VALUE)key->main_cache != Qundef) {
+        if (!UNDEF_P((VALUE)key->main_cache)) {
             *pret = key->main_cache;
             return true;
         }

--- a/range.c
+++ b/range.c
@@ -607,7 +607,7 @@ is_integer_p(VALUE v)
     VALUE is_int;
     CONST_ID(id_integer_p, "integer?");
     is_int = rb_check_funcall(v, id_integer_p, 0, 0);
-    return RTEST(is_int) && is_int != Qundef;
+    return RTEST(is_int) && !UNDEF_P(is_int);
 }
 
 static VALUE
@@ -1505,11 +1505,11 @@ rb_range_values(VALUE range, VALUE *begp, VALUE *endp, int *exclp)
     else {
         VALUE x;
         b = rb_check_funcall(range, id_beg, 0, 0);
-        if (b == Qundef) return (int)Qfalse;
+        if (UNDEF_P(b)) return (int)Qfalse;
         e = rb_check_funcall(range, id_end, 0, 0);
-        if (e == Qundef) return (int)Qfalse;
+        if (UNDEF_P(e)) return (int)Qfalse;
         x = rb_check_funcall(range, rb_intern("exclude_end?"), 0, 0);
-        if (x == Qundef) return (int)Qfalse;
+        if (UNDEF_P(x)) return (int)Qfalse;
         excl = RTEST(x);
     }
     *begp = b;
@@ -1646,7 +1646,7 @@ inspect_range(VALUE range, VALUE dummy, int recur)
     if (NIL_P(RANGE_BEG(range)) || !NIL_P(RANGE_END(range))) {
         str2 = rb_inspect(RANGE_END(range));
     }
-    if (str2 != Qundef) rb_str_append(str, str2);
+    if (!UNDEF_P(str2)) rb_str_append(str, str2);
 
     return str;
 }
@@ -1724,7 +1724,7 @@ static VALUE
 range_eqq(VALUE range, VALUE val)
 {
     VALUE ret = range_include_internal(range, val, 1);
-    if (ret != Qundef) return ret;
+    if (!UNDEF_P(ret)) return ret;
     return r_cover_p(range, RANGE_BEG(range), RANGE_END(range), val);
 }
 
@@ -1764,7 +1764,7 @@ static VALUE
 range_include(VALUE range, VALUE val)
 {
     VALUE ret = range_include_internal(range, val, 0);
-    if (ret != Qundef) return ret;
+    if (!UNDEF_P(ret)) return ret;
     return rb_call_super(1, &val);
 }
 

--- a/rational.c
+++ b/rational.c
@@ -2552,7 +2552,7 @@ nurat_convert(VALUE klass, VALUE numv, VALUE denv, int raise)
     VALUE a1 = numv, a2 = denv;
     int state;
 
-    assert(a1 != Qundef);
+    assert(!UNDEF_P(a1));
 
     if (NIL_P(a1) || NIL_P(a2)) {
         if (!raise) return Qnil;
@@ -2603,7 +2603,7 @@ nurat_convert(VALUE klass, VALUE numv, VALUE denv, int raise)
         a2 = string_to_r_strict(a2, raise);
         if (!raise && NIL_P(a2)) return Qnil;
     }
-    else if (a2 != Qundef && !rb_respond_to(a2, idTo_r)) {
+    else if (!UNDEF_P(a2) && !rb_respond_to(a2, idTo_r)) {
         VALUE tmp = rb_protect(rb_check_to_int, a2, NULL);
         rb_set_errinfo(Qnil);
         if (!NIL_P(tmp)) {
@@ -2612,11 +2612,11 @@ nurat_convert(VALUE klass, VALUE numv, VALUE denv, int raise)
     }
 
     if (RB_TYPE_P(a1, T_RATIONAL)) {
-        if (a2 == Qundef || (k_exact_one_p(a2)))
+        if (UNDEF_P(a2) || (k_exact_one_p(a2)))
             return a1;
     }
 
-    if (a2 == Qundef) {
+    if (UNDEF_P(a2)) {
         if (!RB_INTEGER_TYPE_P(a1)) {
             if (!raise) {
                 VALUE result = rb_protect(to_rational, a1, NULL);
@@ -2666,7 +2666,7 @@ nurat_convert(VALUE klass, VALUE numv, VALUE denv, int raise)
 
     a1 = nurat_int_value(a1);
 
-    if (a2 == Qundef) {
+    if (UNDEF_P(a2)) {
         a2 = ONE;
     }
     else if (!k_integer_p(a2) && !raise) {

--- a/re.c
+++ b/re.c
@@ -3832,14 +3832,14 @@ rb_reg_initialize_m(int argc, VALUE *argv, VALUE self)
         str = RREGEXP_SRC(re);
     }
     else {
-        if (opts != Qundef) {
+        if (!UNDEF_P(opts)) {
             int f;
             if (FIXNUM_P(opts)) flags = FIX2INT(opts);
             else if ((f = str_to_option(opts)) >= 0) flags = f;
             else if (!NIL_P(opts) && rb_bool_expected(opts, "ignorecase", FALSE))
                 flags = ONIG_OPTION_IGNORECASE;
         }
-        if (n_flag != Qundef && !NIL_P(n_flag)) {
+        if (!UNDEF_P(n_flag) && !NIL_P(n_flag)) {
             char *kcode = StringValuePtr(n_flag);
             if (kcode[0] == 'n' || kcode[0] == 'N') {
                 enc = rb_ascii8bit_encoding();

--- a/scheduler.c
+++ b/scheduler.c
@@ -231,10 +231,10 @@ rb_fiber_scheduler_close(VALUE scheduler)
     // would create an infinite loop.
 
     result = rb_check_funcall(scheduler, id_scheduler_close, 0, NULL);
-    if (result != Qundef) return result;
+    if (!UNDEF_P(result)) return result;
 
     result = rb_check_funcall(scheduler, id_close, 0, NULL);
-    if (result != Qundef) return result;
+    if (!UNDEF_P(result)) return result;
 
     return Qnil;
 }

--- a/signal.c
+++ b/signal.c
@@ -1129,7 +1129,7 @@ rb_signal_exec(rb_thread_t *th, int sig)
             break;
         }
     }
-    else if (cmd == Qundef) {
+    else if (UNDEF_P(cmd)) {
         rb_threadptr_signal_exit(th);
     }
     else {

--- a/sprintf.c
+++ b/sprintf.c
@@ -97,7 +97,7 @@ sign_bits(int base, const char *p)
     blen += (l);\
 } while (0)
 
-#define GETARG() (nextvalue != Qundef ? nextvalue : \
+#define GETARG() (!UNDEF_P(nextvalue) ? nextvalue : \
                   GETNEXTARG())
 
 #define GETNEXTARG() ( \
@@ -193,7 +193,7 @@ get_hash(volatile VALUE *hash, int argc, const VALUE *argv)
 {
     VALUE tmp;
 
-    if (*hash != Qundef) return *hash;
+    if (!UNDEF_P(*hash)) return *hash;
     if (argc != 2) {
         rb_raise(rb_eArgError, "one hash required");
     }
@@ -336,7 +336,7 @@ rb_str_format(int argc, const VALUE *argv, VALUE fmt)
             n = 0;
             GETNUM(n, width);
             if (*p == '$') {
-                if (nextvalue != Qundef) {
+                if (!UNDEF_P(nextvalue)) {
                     rb_raise(rb_eArgError, "value given twice - %d$", n);
                 }
                 nextvalue = GETPOSARG(n);
@@ -381,7 +381,7 @@ rb_str_format(int argc, const VALUE *argv, VALUE fmt)
                                            len - 2 /* without parenthesis */,
                                            enc);
                 if (!NIL_P(sym)) nextvalue = rb_hash_lookup2(hash, sym, Qundef);
-                if (nextvalue == Qundef) {
+                if (UNDEF_P(nextvalue)) {
                     if (NIL_P(sym)) {
                         sym = rb_sym_intern(start + 1,
                                             len - 2 /* without parenthesis */,

--- a/string.c
+++ b/string.c
@@ -495,7 +495,7 @@ register_fstring(VALUE str, bool copy)
         do {
             args.fstr = str;
             st_update(frozen_strings, (st_data_t)str, fstr_update_callback, (st_data_t)&args);
-        } while (args.fstr == Qundef);
+        } while (UNDEF_P(args.fstr));
     }
     RB_VM_LOCK_LEAVE();
 
@@ -1873,10 +1873,10 @@ rb_str_init(int argc, VALUE *argv, VALUE str)
         rb_get_kwargs(opt, keyword_ids, 0, 2, kwargs);
         venc = kwargs[0];
         vcapa = kwargs[1];
-        if (venc != Qundef && !NIL_P(venc)) {
+        if (!UNDEF_P(venc) && !NIL_P(venc)) {
             enc = rb_to_encoding(venc);
         }
-        if (vcapa != Qundef && !NIL_P(vcapa)) {
+        if (!UNDEF_P(vcapa) && !NIL_P(vcapa)) {
             long capa = NUM2LONG(vcapa);
             long len = 0;
             int termlen = enc ? rb_enc_mbminlen(enc) : 1;
@@ -8922,7 +8922,7 @@ rb_str_enumerate_lines(int argc, VALUE *argv, VALUE str, VALUE ary)
             keywords[0] = rb_intern_const("chomp");
         }
         rb_get_kwargs(opts, keywords, 0, 1, &chomp);
-        chomp = (chomp != Qundef && RTEST(chomp));
+        chomp = (!UNDEF_P(chomp) && RTEST(chomp));
     }
 
     if (NIL_P(rs)) {

--- a/struct.c
+++ b/struct.c
@@ -650,7 +650,7 @@ rb_struct_s_def(int argc, VALUE *argv, VALUE klass)
             keyword_ids[0] = rb_intern("keyword_init");
         }
         rb_get_kwargs(opt, keyword_ids, 0, 1, &keyword_init);
-        if (keyword_init == Qundef) {
+        if (UNDEF_P(keyword_init)) {
             keyword_init = Qnil;
         }
         else if (RTEST(keyword_init)) {

--- a/thread.c
+++ b/thread.c
@@ -681,7 +681,7 @@ thread_start_func_2(rb_thread_t *th, VALUE *stack_start)
     th->ec->machine.stack_maxsize -= size * sizeof(VALUE);
 
     // Ensure that we are not joinable.
-    VM_ASSERT(th->value == Qundef);
+    VM_ASSERT(UNDEF_P(th->value));
 
     EC_PUSH_TAG(th->ec);
 
@@ -727,7 +727,7 @@ thread_start_func_2(rb_thread_t *th, VALUE *stack_start)
     }
 
     // The thread is effectively finished and can be joined.
-    VM_ASSERT(th->value != Qundef);
+    VM_ASSERT(!UNDEF_P(th->value));
 
     rb_threadptr_join_list_wakeup(th);
     rb_threadptr_unlock_all_locking_mutexes(th);
@@ -1027,7 +1027,7 @@ remove_from_join_list(VALUE arg)
 static int
 thread_finished(rb_thread_t *th)
 {
-    return th->status == THREAD_KILLED || th->value != Qundef;
+    return th->status == THREAD_KILLED || !UNDEF_P(th->value);
 }
 
 static VALUE
@@ -1219,7 +1219,7 @@ thread_value(VALUE self)
 {
     rb_thread_t *th = rb_thread_ptr(self);
     thread_join(th, Qnil, 0);
-    if (th->value == Qundef) {
+    if (UNDEF_P(th->value)) {
         // If the thread is dead because we forked th->value is still Qundef.
         return Qnil;
     }
@@ -2349,7 +2349,7 @@ rb_threadptr_execute_interrupts(rb_thread_t *th, int blocking_timing)
             RUBY_DEBUG_LOG("err:%"PRIdVALUE"\n", err);
             ret = TRUE;
 
-            if (err == Qundef) {
+            if (UNDEF_P(err)) {
                 /* no error */
             }
             else if (err == eKillSignal        /* Thread#kill received */   ||
@@ -5035,7 +5035,7 @@ recursive_check(VALUE list, VALUE obj, VALUE paired_obj_id)
 #endif
 
     VALUE pair_list = rb_hash_lookup2(list, obj, Qundef);
-    if (pair_list == Qundef)
+    if (UNDEF_P(pair_list))
         return Qfalse;
     if (paired_obj_id) {
         if (!RB_TYPE_P(pair_list, T_HASH)) {
@@ -5067,7 +5067,7 @@ recursive_push(VALUE list, VALUE obj, VALUE paired_obj)
     if (!paired_obj) {
         rb_hash_aset(list, obj, Qtrue);
     }
-    else if ((pair_list = rb_hash_lookup2(list, obj, Qundef)) == Qundef) {
+    else if (UNDEF_P(pair_list = rb_hash_lookup2(list, obj, Qundef))) {
         rb_hash_aset(list, obj, paired_obj);
     }
     else {
@@ -5094,7 +5094,7 @@ recursive_pop(VALUE list, VALUE obj, VALUE paired_obj)
 {
     if (paired_obj) {
         VALUE pair_list = rb_hash_lookup2(list, obj, Qundef);
-        if (pair_list == Qundef) {
+        if (UNDEF_P(pair_list)) {
             return 0;
         }
         if (RB_TYPE_P(pair_list, T_HASH)) {

--- a/time.c
+++ b/time.c
@@ -523,7 +523,7 @@ num_exact(VALUE v)
         return rb_rational_canonicalize(v);
 
       default:
-        if ((tmp = rb_check_funcall(v, idTo_r, 0, NULL)) != Qundef) {
+        if (!UNDEF_P(tmp = rb_check_funcall(v, idTo_r, 0, NULL))) {
             /* test to_int method availability to reject non-Numeric
              * objects such as String, Time, etc which have to_r method. */
             if (!rb_respond_to(v, idTo_int)) {
@@ -2277,7 +2277,7 @@ zone_set_dst(VALUE zone, struct time_object *tobj, VALUE tm)
     VALUE dst;
     CONST_ID(id_dst_p, "dst?");
     dst = rb_check_funcall(zone, id_dst_p, 1, &tm);
-    tobj->vtm.isdst = (dst != Qundef && RTEST(dst));
+    tobj->vtm.isdst = (!UNDEF_P(dst) && RTEST(dst));
 }
 
 static int
@@ -2290,7 +2290,7 @@ zone_timelocal(VALUE zone, VALUE time)
     t = rb_time_unmagnify(tobj->timew);
     tm = tm_from_time(rb_cTimeTM, time);
     utc = rb_check_funcall(zone, id_local_to_utc, 1, &tm);
-    if (utc == Qundef) return 0;
+    if (UNDEF_P(utc)) return 0;
 
     s = extract_time(utc);
     zone_set_offset(zone, tobj, t, s);
@@ -2314,7 +2314,7 @@ zone_localtime(VALUE zone, VALUE time)
     tm = tm_from_time(rb_cTimeTM, time);
 
     local = rb_check_funcall(zone, id_utc_to_local, 1, &tm);
-    if (local == Qundef) return 0;
+    if (UNDEF_P(local)) return 0;
 
     s = extract_vtm(local, &tobj->vtm, subsecx);
     tobj->tm_got = 1;
@@ -2616,7 +2616,7 @@ time_timespec(VALUE num, int interval)
     else {
         i = INT2FIX(1);
         ary = rb_check_funcall(num, id_divmod, 1, &i);
-        if (ary != Qundef && !NIL_P(ary = rb_check_array_type(ary))) {
+        if (!UNDEF_P(ary) && !NIL_P(ary = rb_check_array_type(ary))) {
             i = rb_ary_entry(ary, 0);
             f = rb_ary_entry(ary, 1);
             t.tv_sec = NUM2TIMET(i);
@@ -5481,12 +5481,12 @@ rb_time_zone_abbreviation(VALUE zone, VALUE time)
 
     tm = tm_from_time(rb_cTimeTM, time);
     abbr = rb_check_funcall(zone, rb_intern("abbr"), 1, &tm);
-    if (abbr != Qundef) {
+    if (!UNDEF_P(abbr)) {
         goto found;
     }
 #ifdef SUPPORT_TZINFO_ZONE_ABBREVIATION
     abbr = rb_check_funcall(zone, rb_intern("period_for_utc"), 1, &tm);
-    if (abbr != Qundef) {
+    if (!UNDEF_P(abbr)) {
         abbr = rb_funcallv(abbr, rb_intern("abbreviation"), 0, 0);
         goto found;
     }
@@ -5494,7 +5494,7 @@ rb_time_zone_abbreviation(VALUE zone, VALUE time)
     strftime_args[0] = rb_fstring_lit("%Z");
     strftime_args[1] = tm;
     abbr = rb_check_funcall(zone, rb_intern("strftime"), 2, strftime_args);
-    if (abbr != Qundef) {
+    if (!UNDEF_P(abbr)) {
         goto found;
     }
     abbr = rb_check_funcall_default(zone, idName, 0, 0, Qnil);

--- a/transcode.c
+++ b/transcode.c
@@ -2352,7 +2352,7 @@ transcode_loop(const unsigned char **in_pos, unsigned char **out_pos,
                 ec->last_error.error_bytes_len,
                 rb_enc_find(ec->last_error.source_encoding));
         rep = (*fallback_func)(fallback, rep);
-        if (rep != Qundef && !NIL_P(rep)) {
+        if (!UNDEF_P(rep) && !NIL_P(rep)) {
             StringValue(rep);
             ret = rb_econv_insert_output(ec, (const unsigned char *)RSTRING_PTR(rep),
                     RSTRING_LEN(rep), rb_enc_name(rb_enc_get(rep)));

--- a/transient_heap.c
+++ b/transient_heap.c
@@ -169,7 +169,7 @@ ATTRIBUTE_NO_ADDRESS_SAFETY_ANALYSIS(static void transient_heap_ptr_check(struct
 static void
 transient_heap_ptr_check(struct transient_heap *theap, VALUE obj)
 {
-    if (obj != Qundef) {
+    if (!UNDEF_P(obj)) {
         const void *ptr = transient_heap_ptr(obj, FALSE);
         TH_ASSERT(ptr == NULL || transient_header_managed_ptr_p(theap, ptr));
     }

--- a/variable.c
+++ b/variable.c
@@ -281,7 +281,7 @@ rb_path_to_class(VALUE pathname)
             goto undefined_class;
         }
         c = rb_const_search(c, id, TRUE, FALSE, FALSE);
-        if (c == Qundef) goto undefined_class;
+        if (UNDEF_P(c)) goto undefined_class;
         if (!rb_namespace_p(c)) {
             rb_raise(rb_eTypeError, "%"PRIsVALUE" does not refer to class/module",
                      pathname);
@@ -1108,7 +1108,7 @@ gen_ivtbl_count(const struct gen_ivtbl *ivtbl)
     size_t n = 0;
 
     for (i = 0; i < ivtbl->numiv; i++) {
-        if (ivtbl->ivptr[i] != Qundef) {
+        if (!UNDEF_P(ivtbl->ivptr[i])) {
             n++;
         }
     }
@@ -1598,7 +1598,7 @@ iterate_over_shapes_with_callback(rb_shape_t *shape, rb_ivar_foreach_callback_fu
             break;
         }
         VALUE val = iv_list[shape->next_iv_index - 1];
-        if (val != Qundef) {
+        if (!UNDEF_P(val)) {
             callback(shape->edge_name, val, itr_data->arg);
         }
         return;
@@ -1756,7 +1756,7 @@ rb_ivar_count(VALUE obj)
             st_index_t i, count, num = ROBJECT_IV_COUNT(obj);
             const VALUE *const ivptr = ROBJECT_IVPTR(obj);
             for (i = count = 0; i < num; ++i) {
-                if (ivptr[i] != Qundef) {
+                if (!UNDEF_P(ivptr[i])) {
                     count++;
                 }
             }
@@ -1773,7 +1773,7 @@ rb_ivar_count(VALUE obj)
                 st_index_t i, num = rb_shape_get_shape(obj)->next_iv_index;
                 const VALUE *const ivptr = RCLASS_IVPTR(obj);
                 for (i = count = 0; i < num; ++i) {
-                    if (ivptr[i] != Qundef) {
+                    if (!UNDEF_P(ivptr[i])) {
                         count++;
                     }
                 }
@@ -2283,7 +2283,7 @@ autoload_synchronized(VALUE _arguments)
     struct autoload_arguments *arguments = (struct autoload_arguments *)_arguments;
 
     rb_const_entry_t *constant_entry = rb_const_lookup(arguments->module, arguments->name);
-    if (constant_entry && constant_entry->value != Qundef) {
+    if (constant_entry && !UNDEF_P(constant_entry->value)) {
         return Qfalse;
     }
 
@@ -2468,7 +2468,7 @@ autoloading_const_entry(VALUE mod, ID id)
 
     // Check if it's being loaded by the current thread/fiber:
     if (autoload_by_current(ele)) {
-        if (ac->value != Qundef) {
+        if (!UNDEF_P(ac->value)) {
             return ac;
         }
     }
@@ -2482,7 +2482,7 @@ autoload_defined_p(VALUE mod, ID id)
     rb_const_entry_t *ce = rb_const_lookup(mod, id);
 
     // If there is no constant or the constant is not undefined (special marker for autoloading):
-    if (!ce || ce->value != Qundef) {
+    if (!ce || !UNDEF_P(ce->value)) {
         // We are not autoloading:
         return 0;
     }
@@ -2578,7 +2578,7 @@ autoload_apply_constants(VALUE _arguments)
 
     // Iterate over all constants and assign them:
     ccan_list_for_each_safe(&arguments->autoload_data->constants, autoload_const, next, cnode) {
-        if (autoload_const->value != Qundef) {
+        if (!UNDEF_P(autoload_const->value)) {
             autoload_const_set(autoload_const);
         }
     }
@@ -2617,7 +2617,7 @@ autoload_try_load(VALUE _arguments)
     // After we loaded the feature, if the constant is not defined, we remove it completely:
     rb_const_entry_t *ce = rb_const_lookup(arguments->module, arguments->name);
 
-    if (!ce || ce->value == Qundef) {
+    if (!ce || UNDEF_P(ce->value)) {
         result = Qfalse;
 
         rb_const_remove(arguments->module, arguments->name);
@@ -2652,7 +2652,7 @@ rb_autoload_load(VALUE module, ID name)
     rb_const_entry_t *ce = rb_const_lookup(module, name);
 
     // We bail out as early as possible without any synchronisation:
-    if (!ce || ce->value != Qundef) {
+    if (!ce || !UNDEF_P(ce->value)) {
         return Qfalse;
     }
 
@@ -2725,7 +2725,7 @@ static VALUE
 rb_const_get_0(VALUE klass, ID id, int exclude, int recurse, int visibility)
 {
     VALUE c = rb_const_search(klass, id, exclude, recurse, visibility);
-    if (c != Qundef) {
+    if (!UNDEF_P(c)) {
         if (UNLIKELY(!rb_ractor_main_p())) {
             if (!rb_ractor_shareable_p(c)) {
                 rb_raise(rb_eRactorIsolationError, "can not access non-shareable objects in constant %"PRIsVALUE"::%s by non-main Ractor.", rb_class_path(klass), rb_id2name(id));
@@ -2769,7 +2769,7 @@ rb_const_search_from(VALUE klass, ID id, int exclude, int recurse, int visibilit
             }
             rb_const_warn_if_deprecated(ce, tmp, id);
             value = ce->value;
-            if (value == Qundef) {
+            if (UNDEF_P(value)) {
                 struct autoload_const *ac;
                 if (am == tmp) break;
                 am = tmp;
@@ -2798,7 +2798,7 @@ rb_const_search(VALUE klass, ID id, int exclude, int recurse, int visibility)
 
     if (klass == rb_cObject) exclude = FALSE;
     value = rb_const_search_from(klass, id, exclude, recurse, visibility);
-    if (value != Qundef) return value;
+    if (!UNDEF_P(value)) return value;
     if (exclude) return value;
     if (BUILTIN_TYPE(klass) != T_MODULE) return value;
     /* search global const too, if klass is a module */
@@ -2935,7 +2935,7 @@ rb_const_remove(VALUE mod, ID id)
 
     val = ce->value;
 
-    if (val == Qundef) {
+    if (UNDEF_P(val)) {
         autoload_delete(mod, id);
         val = Qnil;
     }
@@ -3092,7 +3092,7 @@ rb_const_defined_0(VALUE klass, ID id, int exclude, int recurse, int visibility)
             if (visibility && RB_CONST_PRIVATE_P(ce)) {
                 return (int)Qfalse;
             }
-            if (ce->value == Qundef && !check_autoload_required(tmp, id, 0) &&
+            if (UNDEF_P(ce->value) && !check_autoload_required(tmp, id, 0) &&
                 !rb_autoloading_value(tmp, id, NULL, NULL))
                 return (int)Qfalse;
 
@@ -3298,7 +3298,7 @@ const_tbl_update(struct autoload_const *ac, int autoload_force)
 
     if (rb_id_table_lookup(tbl, id, &value)) {
         ce = (rb_const_entry_t *)value;
-        if (ce->value == Qundef) {
+        if (UNDEF_P(ce->value)) {
             RUBY_ASSERT_CRITICAL_SECTION_ENTER();
             VALUE file = ac->file;
             int line = ac->line;
@@ -3398,7 +3398,7 @@ set_const_visibility(VALUE mod, int argc, const VALUE *argv,
         if ((ce = rb_const_lookup(mod, id))) {
             ce->flag &= ~mask;
             ce->flag |= flag;
-            if (ce->value == Qundef) {
+            if (UNDEF_P(ce->value)) {
                 struct autoload_data *ele;
 
                 ele = autoload_data_for_named_constant(mod, id, &ac);
@@ -3508,7 +3508,7 @@ cvar_lookup_at(VALUE klass, ID id, st_data_t *v)
     }
 
     VALUE n = rb_ivar_lookup(klass, id, Qundef);
-    if (n == Qundef) return 0;
+    if (UNDEF_P(n)) return 0;
 
     if (v) *v = n;
     return 1;
@@ -3838,7 +3838,7 @@ rb_mod_remove_cvar(VALUE mod, VALUE name)
     }
     rb_check_frozen(mod);
     val = rb_ivar_delete(mod, id, Qundef);
-    if (val != Qundef) {
+    if (!UNDEF_P(val)) {
         return (VALUE)val;
     }
     if (rb_cvar_defined(mod, id)) {

--- a/vm.c
+++ b/vm.c
@@ -172,7 +172,7 @@ vm_ep_in_heap_p_(const rb_execution_context_t *ec, const VALUE *ep)
     if (VM_EP_IN_HEAP_P(ec, ep)) {
         VALUE envval = ep[VM_ENV_DATA_INDEX_ENV]; /* VM_ENV_ENVVAL(ep); */
 
-        if (envval != Qundef) {
+        if (!UNDEF_P(envval)) {
             const rb_env_t *env = (const rb_env_t *)envval;
 
             VM_ASSERT(vm_assert_env(envval));
@@ -1838,7 +1838,7 @@ rb_vm_make_jump_tag_but_local_jump(int state, VALUE val)
       default:
         return Qnil;
     }
-    if (val == Qundef) {
+    if (UNDEF_P(val)) {
         val = GET_EC()->tag->retval;
     }
     return make_localjump_error(mesg, val, state);
@@ -2278,7 +2278,7 @@ vm_exec_enter_vm_loop(rb_execution_context_t *ec, struct rb_vm_exec_context *ctx
 
     ctx->result = ec->errinfo;
     rb_ec_raised_reset(ec, RAISED_STACKOVERFLOW | RAISED_NOMEMORY);
-    while ((ctx->result = vm_exec_handle_exception(ec, ctx->state, ctx->result, &ctx->initial)) == Qundef) {
+    while (UNDEF_P(ctx->result = vm_exec_handle_exception(ec, ctx->state, ctx->result, &ctx->initial))) {
         /* caught a jump, exec the handler */
         ctx->result = vm_exec_core(ec, ctx->initial);
     vm_loop_start:
@@ -2295,7 +2295,7 @@ vm_exec_bottom_main(void *context)
     struct rb_vm_exec_context *ctx = (struct rb_vm_exec_context *)context;
 
     ctx->state = TAG_NONE;
-    if (!ctx->jit_enable_p || (ctx->result = jit_exec(ctx->ec)) == Qundef) {
+    if (!ctx->jit_enable_p || UNDEF_P(ctx->result = jit_exec(ctx->ec))) {
         ctx->result = vm_exec_core(ctx->ec, ctx->initial);
     }
     vm_exec_enter_vm_loop(ctx->ec, ctx, ctx->tag, true);
@@ -2347,7 +2347,7 @@ vm_exec(rb_execution_context_t *ec, bool jit_enable_p)
 
     _tag.retval = Qnil;
     if ((state = EC_EXEC_TAG()) == TAG_NONE) {
-        if (!jit_enable_p || (result = jit_exec(ec)) == Qundef) {
+        if (!jit_enable_p || UNDEF_P(result = jit_exec(ec))) {
             result = vm_exec_core(ec, initial);
         }
         goto vm_loop_start; /* fallback to the VM */
@@ -2355,7 +2355,7 @@ vm_exec(rb_execution_context_t *ec, bool jit_enable_p)
     else {
         result = ec->errinfo;
         rb_ec_raised_reset(ec, RAISED_STACKOVERFLOW | RAISED_NOMEMORY);
-        while ((result = vm_exec_handle_exception(ec, state, result, &initial)) == Qundef) {
+        while (UNDEF_P(result = vm_exec_handle_exception(ec, state, result, &initial))) {
             /* caught a jump, exec the handler */
             result = vm_exec_core(ec, initial);
           vm_loop_start:

--- a/vm_args.c
+++ b/vm_args.c
@@ -283,7 +283,7 @@ make_unknown_kw_hash(const VALUE *passed_keywords, int passed_keyword_len, const
     VALUE obj = rb_ary_hidden_new(1);
 
     for (i=0; i<passed_keyword_len; i++) {
-        if (kw_argv[i] != Qundef) {
+        if (!UNDEF_P(kw_argv[i])) {
             rb_ary_push(obj, passed_keywords[i]);
         }
     }
@@ -297,7 +297,7 @@ make_rest_kw_hash(const VALUE *passed_keywords, int passed_keyword_len, const VA
     VALUE obj = rb_hash_new_with_size(passed_keyword_len);
 
     for (i=0; i<passed_keyword_len; i++) {
-        if (kw_argv[i] != Qundef) {
+        if (!UNDEF_P(kw_argv[i])) {
             rb_hash_aset(obj, passed_keywords[i], kw_argv[i]);
         }
     }
@@ -355,7 +355,7 @@ args_setup_kw_parameters(rb_execution_context_t *const ec, const rb_iseq_t *cons
             found++;
         }
         else {
-            if (default_values[di] == Qundef) {
+            if (UNDEF_P(default_values[di])) {
                 locals[i] = Qnil;
 
                 if (LIKELY(i < KW_SPECIFIED_BITS_MAX)) {

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -621,7 +621,7 @@ check_funcall_missing(rb_execution_context_t *ec, VALUE klass, VALUE recv, ID mi
                                        ID2SYM(mid), Qtrue);
     if (!RTEST(ret)) return def;
     args.respond = respond > 0;
-    args.respond_to_missing = (ret != Qundef);
+    args.respond_to_missing = !UNDEF_P(ret);
     ret = def;
     cme = callable_method_entry(klass, idMethodMissing, &args.defined_class);
 
@@ -684,7 +684,7 @@ rb_check_funcall_default_kw(VALUE recv, ID mid, int argc, const VALUE *argv, VAL
     if (!check_funcall_callable(ec, me)) {
         VALUE ret = check_funcall_missing(ec, klass, recv, mid, argc, argv,
                                           respond, def, kw_splat);
-        if (ret == Qundef) ret = def;
+        if (UNDEF_P(ret)) ret = def;
         return ret;
     }
     stack_check(ec);
@@ -715,7 +715,7 @@ rb_check_funcall_with_hook_kw(VALUE recv, ID mid, int argc, const VALUE *argv,
     if (!check_funcall_callable(ec, me)) {
         VALUE ret = check_funcall_missing(ec, klass, recv, mid, argc, argv,
                                           respond, Qundef, kw_splat);
-        (*hook)(ret != Qundef, recv, mid, argc, argv, arg);
+        (*hook)(!UNDEF_P(ret), recv, mid, argc, argv, arg);
         return ret;
     }
     stack_check(ec);
@@ -846,7 +846,7 @@ rb_method_call_status(rb_execution_context_t *ec, const rb_callable_method_entry
                 defined_class = RBASIC(defined_class)->klass;
             }
 
-            if (self == Qundef || !rb_obj_is_kind_of(self, defined_class)) {
+            if (UNDEF_P(self) || !rb_obj_is_kind_of(self, defined_class)) {
                 return MISSING_PROTECTED;
             }
         }
@@ -1357,7 +1357,7 @@ rb_yield_1(VALUE val)
 VALUE
 rb_yield(VALUE val)
 {
-    if (val == Qundef) {
+    if (UNDEF_P(val)) {
         return rb_yield_0(0, NULL);
     }
     else {
@@ -1698,7 +1698,7 @@ eval_make_iseq(VALUE src, VALUE fname, int line, const rb_binding_t *bind,
         fname = rb_source_location(&line);
     }
 
-    if (fname != Qundef) {
+    if (!UNDEF_P(fname)) {
         if (!NIL_P(fname)) fname = rb_fstring(fname);
     }
     else {

--- a/vm_exec.c
+++ b/vm_exec.c
@@ -183,7 +183,7 @@ vm_exec_core(rb_execution_context_t *ec, VALUE initial)
         }
     }
 
-    if ((th = rb_ec_thread_ptr(ec))->retval != Qundef) {
+    if (!UNDEF_P((th = rb_ec_thread_ptr(ec))->retval)) {
         VALUE ret = th->retval;
         th->retval = Qundef;
         return ret;

--- a/vm_method.c
+++ b/vm_method.c
@@ -2735,7 +2735,7 @@ basic_obj_respond_to(rb_execution_context_t *ec, VALUE obj, ID id, int pub)
       case 0:
         ret = basic_obj_respond_to_missing(ec, klass, obj, ID2SYM(id),
                                            RBOOL(!pub));
-        return RTEST(ret) && ret != Qundef;
+        return RTEST(ret) && !UNDEF_P(ret);
       default:
         return TRUE;
     }
@@ -2847,7 +2847,7 @@ obj_respond_to(int argc, VALUE *argv, VALUE obj)
     if (!(id = rb_check_id(&mid))) {
         VALUE ret = basic_obj_respond_to_missing(ec, CLASS_OF(obj), obj,
                                                  rb_to_symbol(mid), priv);
-        if (ret == Qundef) ret = Qfalse;
+        if (UNDEF_P(ret)) ret = Qfalse;
         return ret;
     }
     return  RBOOL(basic_obj_respond_to(ec, obj, id, !RTEST(priv)));

--- a/vm_trace.c
+++ b/vm_trace.c
@@ -262,7 +262,7 @@ remove_event_hook(const rb_execution_context_t *ec, const rb_thread_t *filter_th
     while (hook) {
         if (func == 0 || hook->func == func) {
             if (hook->filter.th == filter_th || filter_th == MATCH_ANY_FILTER_TH) {
-                if (data == Qundef || hook->data == data) {
+                if (UNDEF_P(data) || hook->data == data) {
                     hook->hook_flags |= RUBY_EVENT_HOOK_FLAG_DELETED;
                     ret+=1;
                     list->need_clean = true;
@@ -857,7 +857,7 @@ rb_tracearg_event(rb_trace_arg_t *trace_arg)
 static void
 fill_path_and_lineno(rb_trace_arg_t *trace_arg)
 {
-    if (trace_arg->path == Qundef) {
+    if (UNDEF_P(trace_arg->path)) {
         get_path_and_lineno(trace_arg->ec, trace_arg->cfp, trace_arg->event, &trace_arg->path, &trace_arg->lineno);
     }
 }
@@ -986,7 +986,7 @@ rb_tracearg_return_value(rb_trace_arg_t *trace_arg)
     else {
         rb_raise(rb_eRuntimeError, "not supported by this event");
     }
-    if (trace_arg->data == Qundef) {
+    if (UNDEF_P(trace_arg->data)) {
         rb_bug("rb_tracearg_return_value: unreachable");
     }
     return trace_arg->data;
@@ -1001,7 +1001,7 @@ rb_tracearg_raised_exception(rb_trace_arg_t *trace_arg)
     else {
         rb_raise(rb_eRuntimeError, "not supported by this event");
     }
-    if (trace_arg->data == Qundef) {
+    if (UNDEF_P(trace_arg->data)) {
         rb_bug("rb_tracearg_raised_exception: unreachable");
     }
     return trace_arg->data;
@@ -1018,7 +1018,7 @@ rb_tracearg_eval_script(rb_trace_arg_t *trace_arg)
     else {
         rb_raise(rb_eRuntimeError, "not supported by this event");
     }
-    if (data == Qundef) {
+    if (UNDEF_P(data)) {
         rb_bug("rb_tracearg_raised_exception: unreachable");
     }
     if (rb_obj_is_iseq(data)) {
@@ -1042,7 +1042,7 @@ rb_tracearg_instruction_sequence(rb_trace_arg_t *trace_arg)
     else {
         rb_raise(rb_eRuntimeError, "not supported by this event");
     }
-    if (data == Qundef) {
+    if (UNDEF_P(data)) {
         rb_bug("rb_tracearg_raised_exception: unreachable");
     }
 
@@ -1067,7 +1067,7 @@ rb_tracearg_object(rb_trace_arg_t *trace_arg)
     else {
         rb_raise(rb_eRuntimeError, "not supported by this event");
     }
-    if (trace_arg->data == Qundef) {
+    if (UNDEF_P(trace_arg->data)) {
         rb_bug("rb_tracearg_object: unreachable");
     }
     return trace_arg->data;


### PR DESCRIPTION
MRI(CRuby) has theese `Qundef` check code.

```c
if (result == Qundef) return Qnil;
```

But, theese check `UNDEF_P` macro already define.
Using and replace theese `Qundef` check code to `UNDEF_P` that is more simple. I think.