### PR TITLE
Remove dead code in rb_obj_copy_ivar

### DIFF
--- a/object.c
+++ b/object.c
@@ -302,20 +302,6 @@ rb_obj_copy_ivar(VALUE dest, VALUE obj)
     if (initial_shape->capacity < shape_to_set_on_dest->capacity) {
         rb_ensure_iv_list_size(dest, initial_shape->capacity, shape_to_set_on_dest->capacity);
         dest_buf = ROBJECT_IVPTR(dest);
-
-        rb_shape_t * initial_shape = rb_shape_get_shape(dest);
-
-        if (initial_shape->size_pool_index != src_shape->size_pool_index) {
-            RUBY_ASSERT(initial_shape->type == SHAPE_T_OBJECT);
-
-            shape_to_set_on_dest = rb_shape_rebuild_shape(initial_shape, src_shape);
-        }
-
-        RUBY_ASSERT(src_num_ivs <= shape_to_set_on_dest->capacity);
-        if (initial_shape->capacity < shape_to_set_on_dest->capacity) {
-            rb_ensure_iv_list_size(dest, initial_shape->capacity, shape_to_set_on_dest->capacity);
-            dest_buf = ROBJECT_IVPTR(dest);
-        }
     }
 
     MEMCPY(dest_buf, src_buf, VALUE, src_num_ivs);


### PR DESCRIPTION
The removed code is a duplicate of the code above.