### PR TITLE
YJIT: Always encode Opnd::Value in 64 bits on x86_64 for GC offsets

### DIFF
--- a/yjit/src/asm/x86_64/mod.rs
+++ b/yjit/src/asm/x86_64/mod.rs
@@ -1038,18 +1038,13 @@ pub fn mov(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) {
 pub fn movabs(cb: &mut CodeBlock, dst: X86Opnd, value: u64) {
     match dst {
         X86Opnd::Reg(reg) => {
-            if reg.num_bits == 16 {
-                cb.write_byte(0x66);
-            }
+            assert_eq!(reg.num_bits, 64);
+            write_rex(cb, true, 0, 0, reg.reg_no);
 
-            if dst.rex_needed() || reg.num_bits == 64 {
-                write_rex(cb, reg.num_bits == 64, 0, 0, reg.reg_no);
-            }
-
-            write_opcode(cb, if reg.num_bits == 8 { 0xb0 } else { 0xb8 }, reg);
-            cb.write_int(value, reg.num_bits.into());
+            write_opcode(cb, 0xb8, reg);
+            cb.write_int(value, 64);
         },
-        _ => unreachable!(),
+        _ => unreachable!()
     }
 }
 

--- a/yjit/src/asm/x86_64/mod.rs
+++ b/yjit/src/asm/x86_64/mod.rs
@@ -972,7 +972,16 @@ pub fn mov(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) {
                 write_opcode(cb, 0xB8, reg);
                 cb.write_int(uimm.value, 32);
             } else {
-                movabs(cb, dst, uimm.value);
+                if reg.num_bits == 16 {
+                    cb.write_byte(0x66);
+                }
+
+                if dst.rex_needed() || reg.num_bits == 64 {
+                    write_rex(cb, reg.num_bits == 64, 0, 0, reg.reg_no);
+                }
+
+                write_opcode(cb, if reg.num_bits == 8 { 0xb0 } else { 0xb8 }, reg);
+                cb.write_int(uimm.value, reg.num_bits.into());
             }
         },
         // M + Imm

--- a/yjit/src/asm/x86_64/mod.rs
+++ b/yjit/src/asm/x86_64/mod.rs
@@ -972,16 +972,7 @@ pub fn mov(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) {
                 write_opcode(cb, 0xB8, reg);
                 cb.write_int(uimm.value, 32);
             } else {
-                if reg.num_bits == 16 {
-                    cb.write_byte(0x66);
-                }
-
-                if dst.rex_needed() || reg.num_bits == 64 {
-                    write_rex(cb, reg.num_bits == 64, 0, 0, reg.reg_no);
-                }
-
-                write_opcode(cb, if reg.num_bits == 8 { 0xb0 } else { 0xb8 }, reg);
-                cb.write_int(uimm.value, reg.num_bits.into());
+                movabs(cb, dst, uimm.value);
             }
         },
         // M + Imm
@@ -1032,6 +1023,25 @@ pub fn mov(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) {
             );
         }
     };
+}
+
+/// A variant of mov used for always writing the value in 64 bits for GC offsets.
+pub fn movabs(cb: &mut CodeBlock, dst: X86Opnd, value: u64) {
+    match dst {
+        X86Opnd::Reg(reg) => {
+            if reg.num_bits == 16 {
+                cb.write_byte(0x66);
+            }
+
+            if dst.rex_needed() || reg.num_bits == 64 {
+                write_rex(cb, reg.num_bits == 64, 0, 0, reg.reg_no);
+            }
+
+            write_opcode(cb, if reg.num_bits == 8 { 0xb0 } else { 0xb8 }, reg);
+            cb.write_int(value, reg.num_bits.into());
+        },
+        _ => unreachable!(),
+    }
 }
 
 /// movsx - Move with sign extension (signed integers)

--- a/yjit/src/asm/x86_64/tests.rs
+++ b/yjit/src/asm/x86_64/tests.rs
@@ -189,6 +189,12 @@ fn test_mov() {
 }
 
 #[test]
+fn test_movabs() {
+    check_bytes("49b83400000000000000", |cb| movabs(cb, R8, 0x34));
+    check_bytes("49b80000008000000000", |cb| movabs(cb, R8, 0x80000000));
+}
+
+#[test]
 fn test_mov_unsigned() {
     // MOV AL, imm8
     check_bytes("b001", |cb| mov(cb, AL, uimm_opnd(1)));

--- a/yjit/src/backend/x86_64/mod.rs
+++ b/yjit/src/backend/x86_64/mod.rs
@@ -466,8 +466,7 @@ impl Assembler
                 Insn::Load { opnd, out } |
                 Insn::LoadInto { dest: out, opnd } => {
                     match opnd {
-                        // If the value being loaded is a heap object
-                        Opnd::Value(val) if !val.special_const_p() => {
+                        Opnd::Value(val) if val.heap_object_p() => {
                             // Using movabs because mov might write value in 32 bits
                             movabs(cb, out.into(), val.0 as _);
                             // The pointer immediate is encoded as the last part of the mov written out

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -333,6 +333,11 @@ impl VALUE {
         self.immediate_p() || !self.test()
     }
 
+    /// Return true if the value is a heap object
+    pub fn heap_object_p(self) -> bool {
+        !self.special_const_p()
+    }
+
     /// Return true if the value is a Ruby Fixnum (immediate-size integer)
     pub fn fixnum_p(self) -> bool {
         let VALUE(cval) = self;


### PR DESCRIPTION
When `asm.load` takes `Opnd::Value` that fits in 32 bits, our x86_64 `mov` assembler optimizes the encoding and writes the value in 32 bits, which crashes reading GC offsets as a 64-bit value. To avoid that, I added a `movabs` helper that always writes the immediate in 64 bits and used that when a GC offset is needed.

Note that this issue has been reproducible only with Valgrind that uses smaller addresses.