### PR TITLE
YJIT: Include actual memory region size in stats

### DIFF
--- a/yjit.rb
+++ b/yjit.rb
@@ -262,6 +262,7 @@ module RubyVM::YJIT
       $stderr.puts "inline_code_size:      " + ("%10d" % stats[:inline_code_size])
       $stderr.puts "outlined_code_size:    " + ("%10d" % stats[:outlined_code_size])
       $stderr.puts "freed_code_size:       " + ("%10d" % stats[:freed_code_size])
+      $stderr.puts "code_region_size:      " + ("%10d" % stats[:code_region_size])
       $stderr.puts "yjit_alloc_size:       " + ("%10d" % stats[:yjit_alloc_size]) if stats.key?(:yjit_alloc_size)
       $stderr.puts "live_page_count:       " + ("%10d" % stats[:live_page_count])
       $stderr.puts "freed_page_count:      " + ("%10d" % stats[:freed_page_count])

--- a/yjit/src/asm/mod.rs
+++ b/yjit/src/asm/mod.rs
@@ -210,12 +210,15 @@ impl CodeBlock {
         self.page_size
     }
 
+    pub fn mapped_region_size(&self) -> usize {
+        self.mem_block.borrow().mapped_region_size()
+    }
+
     /// Return the number of code pages that have been mapped by the VirtualMemory.
     pub fn num_mapped_pages(&self) -> usize {
-        let mapped_region_size = self.mem_block.borrow().mapped_region_size();
         // CodeBlock's page size != VirtualMem's page size on Linux,
         // so mapped_region_size % self.page_size may not be 0
-        ((mapped_region_size - 1) / self.page_size) + 1
+        ((self.mapped_region_size() - 1) / self.page_size) + 1
     }
 
     /// Return the number of code pages that have been reserved by the VirtualMemory.

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -402,6 +402,9 @@ fn rb_yjit_gen_stats_dict() -> VALUE {
         // Code GC count
         hash_aset_usize!(hash, "code_gc_count", CodegenGlobals::get_code_gc_count());
 
+        // Size of memory region allocated for JIT code
+        hash_aset_usize!(hash, "code_region_size", cb.mapped_region_size());
+
         // Rust global allocations in bytes
         #[cfg(feature="stats")]
         hash_aset_usize!(hash, "yjit_alloc_size", global_allocation_size());


### PR DESCRIPTION
I always double `inline_code_size` in my head (as an approximation of `inline_code_size + outlined_code_size`) to compare the total JIT code size against Rust-allocated bytes. I thought it'd be easier to interpret if we just show the total size there.

However, just adding `inline_code_size + outlined_code_size` to stats feels redundant. It seems more interesting to include the actual code region size, which is different information from the number of bytes utilized in the region, so this PR adds that as `code_region_size`.