### PR TITLE
YJIT: 32 bit comparison on shape id

### DIFF
--- a/mjit_c.rb
+++ b/mjit_c.rb
@@ -158,10 +158,6 @@ module RubyVM::MJIT
     Primitive.cexpr! %q{ INT2NUM(VM_METHOD_TYPE_ISEQ) }
   end
 
-  def C.SHAPE_BITS
-    Primitive.cexpr! %q{ UINT2NUM(SHAPE_BITS) }
-  end
-
   def C.SHAPE_CAPACITY_CHANGE
     Primitive.cexpr! %q{ UINT2NUM(SHAPE_CAPACITY_CHANGE) }
   end
@@ -172,6 +168,10 @@ module RubyVM::MJIT
 
   def C.SHAPE_FROZEN
     Primitive.cexpr! %q{ UINT2NUM(SHAPE_FROZEN) }
+  end
+
+  def C.SHAPE_ID_NUM_BITS
+    Primitive.cexpr! %q{ UINT2NUM(SHAPE_ID_NUM_BITS) }
   end
 
   def C.SHAPE_INITIAL_CAPACITY

--- a/ractor_core.h
+++ b/ractor_core.h
@@ -290,7 +290,7 @@ rb_ractor_id(const rb_ractor_t *r)
 #if RACTOR_CHECK_MODE > 0
 uint32_t rb_ractor_current_id(void);
 // If ractor check mode is enabled, shape bits needs to be smaller
-STATIC_ASSERT(shape_bits, SHAPE_BITS == 16);
+STATIC_ASSERT(shape_bits, SHAPE_ID_NUM_BITS == 16);
 
 static inline void
 rb_ractor_setup_belonging_to(VALUE obj, uint32_t rid)

--- a/shape.c
+++ b/shape.c
@@ -665,7 +665,7 @@ Init_shape(void)
     rb_define_const(rb_cShape, "SHAPE_T_OBJECT", INT2NUM(SHAPE_T_OBJECT));
     rb_define_const(rb_cShape, "SHAPE_IVAR_UNDEF", INT2NUM(SHAPE_IVAR_UNDEF));
     rb_define_const(rb_cShape, "SHAPE_FROZEN", INT2NUM(SHAPE_FROZEN));
-    rb_define_const(rb_cShape, "SHAPE_BITS", INT2NUM(SHAPE_BITS));
+    rb_define_const(rb_cShape, "SHAPE_ID_NUM_BITS", INT2NUM(SHAPE_ID_NUM_BITS));
     rb_define_const(rb_cShape, "SHAPE_FLAG_SHIFT", INT2NUM(SHAPE_FLAG_SHIFT));
     rb_define_const(rb_cShape, "SPECIAL_CONST_SHAPE_ID", INT2NUM(SPECIAL_CONST_SHAPE_ID));
 

--- a/shape.c
+++ b/shape.c
@@ -325,10 +325,10 @@ rb_shape_set_shape(VALUE obj, rb_shape_t* shape)
     rb_shape_set_shape_id(obj, rb_shape_id(shape));
 }
 
-VALUE
-rb_shape_flags_mask(void)
+uint8_t
+rb_shape_id_num_bits(void)
 {
-    return SHAPE_FLAG_MASK;
+    return SHAPE_ID_NUM_BITS;
 }
 
 rb_shape_t *

--- a/shape.h
+++ b/shape.h
@@ -132,6 +132,7 @@ static inline shape_id_t RCLASS_SHAPE_ID(VALUE obj) {
 
 bool rb_shape_root_shape_p(rb_shape_t* shape);
 rb_shape_t * rb_shape_get_root_shape(void);
+uint8_t rb_shape_id_num_bits(void);
 
 rb_shape_t* rb_shape_get_shape_by_id_without_assertion(shape_id_t shape_id);
 rb_shape_t * rb_shape_get_parent(rb_shape_t * shape);

--- a/shape.h
+++ b/shape.h
@@ -15,25 +15,25 @@ typedef uint16_t attr_index_t;
 #if RUBY_DEBUG || (defined(VM_CHECK_MODE) && VM_CHECK_MODE > 0)
 #  if SIZEOF_SHAPE_T == 4
 typedef uint32_t shape_id_t;
-# define SHAPE_BITS 16
+# define SHAPE_ID_NUM_BITS 16
 #  else
 typedef uint16_t shape_id_t;
-# define SHAPE_BITS 16
+# define SHAPE_ID_NUM_BITS 16
 #  endif
 #else
 #  if SIZEOF_SHAPE_T == 4
 typedef uint32_t shape_id_t;
-# define SHAPE_BITS 32
+# define SHAPE_ID_NUM_BITS 32
 #  else
 typedef uint16_t shape_id_t;
-# define SHAPE_BITS 16
+# define SHAPE_ID_NUM_BITS 16
 #  endif
 #endif
 
-# define SHAPE_MASK (((uintptr_t)1 << SHAPE_BITS) - 1)
-# define SHAPE_FLAG_MASK (((VALUE)-1) >> SHAPE_BITS)
+# define SHAPE_MASK (((uintptr_t)1 << SHAPE_ID_NUM_BITS) - 1)
+# define SHAPE_FLAG_MASK (((VALUE)-1) >> SHAPE_ID_NUM_BITS)
 
-# define SHAPE_FLAG_SHIFT ((SIZEOF_VALUE * 8) - SHAPE_BITS)
+# define SHAPE_FLAG_SHIFT ((SIZEOF_VALUE * 8) - SHAPE_ID_NUM_BITS)
 
 # define SHAPE_BITMAP_SIZE 16384
 

--- a/tool/mjit/bindgen.rb
+++ b/tool/mjit/bindgen.rb
@@ -346,7 +346,7 @@ generator = BindingGenerator.new(
       VM_METHOD_TYPE_ISEQ
     ],
     UINT: %w[
-      SHAPE_BITS
+      SHAPE_ID_NUM_BITS
       SHAPE_CAPACITY_CHANGE
       SHAPE_FLAG_SHIFT
       SHAPE_FROZEN

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -85,7 +85,7 @@ fn main() {
         // From shape.h
         .allowlist_function("rb_shape_get_shape_id")
         .allowlist_function("rb_shape_get_shape_by_id")
-        .allowlist_function("rb_shape_flags_mask")
+        .allowlist_function("rb_shape_id_num_bits")
         .allowlist_function("rb_shape_get_iv_index")
 
         // From ruby/internal/intern/object.h

--- a/yjit/src/asm/arm64/mod.rs
+++ b/yjit/src/asm/arm64/mod.rs
@@ -540,8 +540,6 @@ pub fn ldur(cb: &mut CodeBlock, rt: A64Opnd, rn: A64Opnd) {
 pub fn ldurh(cb: &mut CodeBlock, rt: A64Opnd, rn: A64Opnd) {
     let bytes: [u8; 4] = match (rt, rn) {
         (A64Opnd::Reg(rt), A64Opnd::Mem(rn)) => {
-            assert!(rt.num_bits == 32, "Rt should be a 32 bit register");
-            assert!(rn.num_bits == 64, "Rn should be a 64 bit register");
             assert!(mem_disp_fits_bits(rn.disp), "Expected displacement to be 9 bits or less");
 
             LoadStore::ldurh(rt.reg_no, rn.base_reg_no, rn.disp as i16).into()

--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -109,8 +109,8 @@ impl Opnd
                 })
             },
 
-            Opnd::InsnOut{idx, num_bits } => {
-                assert!(num_bits == 64);
+            Opnd::InsnOut{idx, num_bits: out_num_bits } => {
+                assert!(num_bits <= out_num_bits);
                 Opnd::Mem(Mem {
                     base: MemBase::InsnOut(idx),
                     disp: disp,
@@ -143,7 +143,7 @@ impl Opnd
     }
 
     /// Get the size in bits for this operand if there is one.
-    fn num_bits(&self) -> Option<u8> {
+    pub fn num_bits(&self) -> Option<u8> {
         match *self {
             Opnd::Reg(Reg { num_bits, .. }) => Some(num_bits),
             Opnd::Mem(Mem { num_bits, .. }) => Some(num_bits),

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -425,6 +425,9 @@ pub struct rb_shape {
 }
 pub type rb_shape_t = rb_shape;
 extern "C" {
+    pub fn rb_shape_id_num_bits() -> u8;
+}
+extern "C" {
     pub fn rb_shape_get_shape_by_id(shape_id: shape_id_t) -> *mut rb_shape_t;
 }
 extern "C" {
@@ -432,9 +435,6 @@ extern "C" {
 }
 extern "C" {
     pub fn rb_shape_get_iv_index(shape: *mut rb_shape_t, id: ID, value: *mut attr_index_t) -> bool;
-}
-extern "C" {
-    pub fn rb_shape_flags_mask() -> VALUE;
 }
 pub const idDot2: ruby_method_ids = 128;
 pub const idDot3: ruby_method_ids = 129;


### PR DESCRIPTION
This commit changes the shape id comparisons to use a 32 bit comparison rather than 64 bit.  That means we don't need to load the shape id to a register on x86 machines.

I've also added a guard for "Object" types, and added a way to upgrade the type to an object on the context.

Unfortunately this patch also generates an extra guard for the object type, but that guard can be amortized over many ivar reads.  Once we incorporate T_OBJECT / T_* information in to the shape, we can remove this guard.

Given the following program:

```ruby
class Foo
  def initialize
    @foo = 1
    @bar = 1
  end

  def read
    [@foo, @bar]
  end
end

foo = Foo.new
foo.read
foo.read
foo.read
foo.read
foo.read

puts RubyVM::YJIT.disasm(Foo.instance_method(:read))
```

The machine code we generated _before_ this change is like this:

```
== BLOCK 1/4, ISEQ RANGE [0,3), 65 bytes ======================
  # getinstancevariable
  0x559a18623023: mov rax, qword ptr [r13 + 0x18]
  # guard object is heap
  0x559a18623027: test al, 7
  0x559a1862302a: jne 0x559a1862502d
  0x559a18623030: cmp rax, 4
  0x559a18623034: jbe 0x559a1862502d
  # guard shape, embedded, and T_OBJECT
  0x559a1862303a: mov rcx, qword ptr [rax]
  0x559a1862303d: movabs r11, 0xffff00000000201f
  0x559a18623047: and rcx, r11
  0x559a1862304a: movabs r11, 0xb000000002001
  0x559a18623054: cmp rcx, r11
  0x559a18623057: jne 0x559a18625046
  0x559a1862305d: mov rax, qword ptr [rax + 0x18]
  0x559a18623061: mov qword ptr [rbx], rax

== BLOCK 2/4, ISEQ RANGE [3,6), 0 bytes =======================
== BLOCK 3/4, ISEQ RANGE [3,6), 47 bytes ======================
  # gen_direct_jmp: fallthrough
  # getinstancevariable
  # regenerate_branch
  # getinstancevariable
  # regenerate_branch
  0x559a18623064: mov rax, qword ptr [r13 + 0x18]
  # guard shape, embedded, and T_OBJECT
  0x559a18623068: mov rcx, qword ptr [rax]
  0x559a1862306b: movabs r11, 0xffff00000000201f
  0x559a18623075: and rcx, r11
  0x559a18623078: movabs r11, 0xb000000002001
  0x559a18623082: cmp rcx, r11
  0x559a18623085: jne 0x559a18625099
  0x559a1862308b: mov rax, qword ptr [rax + 0x20]
  0x559a1862308f: mov qword ptr [rbx + 8], rax
```

After this change, it's like this:

```
== BLOCK 1/4, ISEQ RANGE [0,3), 58 bytes ======================
  # getinstancevariable
  0x5608ccada023: mov rax, qword ptr [r13 + 0x18]
  # guard object is heap
  0x5608ccada027: test al, 7
  0x5608ccada02a: jne 0x5608ccadc02d
  0x5608ccada030: cmp rax, 4
  0x5608ccada034: jbe 0x5608ccadc02d
  # guard object is object
  0x5608ccada03a: mov rcx, qword ptr [rax]
  0x5608ccada03d: and rcx, 0x1f
  0x5608ccada041: cmp rcx, 1
  0x5608ccada045: jne 0x5608ccadc02d
  # guard shape
  0x5608ccada04b: cmp word ptr [rax + 6], 0x13
  0x5608ccada050: jne 0x5608ccadc046
  0x5608ccada056: mov rax, qword ptr [rax + 0x10]
  0x5608ccada05a: mov qword ptr [rbx], rax

== BLOCK 2/4, ISEQ RANGE [3,6), 0 bytes =======================
== BLOCK 3/4, ISEQ RANGE [3,6), 23 bytes ======================
  # gen_direct_jmp: fallthrough
  # getinstancevariable
  # regenerate_branch
  # getinstancevariable
  # regenerate_branch
  0x5608ccada05d: mov rax, qword ptr [r13 + 0x18]
  # guard shape
  0x5608ccada061: cmp word ptr [rax + 6], 0x13
  0x5608ccada066: jne 0x5608ccadc099
  0x5608ccada06c: mov rax, qword ptr [rax + 0x18]
  0x5608ccada070: mov qword ptr [rbx + 8], rax
```

The first ivar read is a bit more complex, but the second ivar read is much simpler.  I think eventually we could teach the context about the shape, then emit only one shape guard.