### PR TITLE
YJIT: Shrink the vectors of Block after mutation

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -829,9 +829,7 @@ pub fn gen_single_block(
         let gc_offsets = asm.compile(cb);
 
         // Add the GC offsets to the block
-        for offset in gc_offsets {
-            block.add_gc_obj_offset(offset)
-        }
+        block.add_gc_obj_offsets(gc_offsets);
 
         // Mark the end position of the block
         block.set_end_addr(cb.get_write_ptr());


### PR DESCRIPTION
> https://doc.rust-lang.org/std/vec/struct.Vec.html
> Vec will never automatically shrink itself, even if completely empty. This ensures no unnecessary allocations or deallocations occur. Emptying a Vec and then filling it back up to the same [len](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.len) should incur no calls to the allocator. If you wish to free up unused memory, use [shrink_to_fit](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.shrink_to_fit) or [shrink_to](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.shrink_to).

This PR uses `shrink_to_fit` to save some space of vectors after use: 22.2MB -> 20.9MB (railsbench)

### Before
```
code_region_size:         9715712
yjit_alloc_size:         22258669
```

### After
```
code_region_size:         9682944
yjit_alloc_size:         20912761
```