### PR TITLE
Allow anonymous keyword rest parameter with other keyword parameters

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -5612,7 +5612,7 @@ f_kwrest	: kwrest_mark tIDENTIFIER
 		    {
 			arg_var(p, ANON_KEYWORD_REST_ID);
 		    /*%%%*/
-			$$ = internal_id(p);
+			$$ = ANON_KEYWORD_REST_ID;
 		    /*% %*/
 		    /*% ripper: kwrest_param!(Qnil) %*/
 		    }

--- a/test/ruby/test_ast.rb
+++ b/test/ruby/test_ast.rb
@@ -469,7 +469,7 @@ class TestAst < Test::Unit::TestCase
     end
 
     assert_equal(nil, kwrest.call(''))
-    assert_equal([nil], kwrest.call('**'))
+    assert_equal([:**], kwrest.call('**'))
     assert_equal(false, kwrest.call('**nil'))
     assert_equal([:a], kwrest.call('**a'))
   end

--- a/test/ruby/test_syntax.rb
+++ b/test/ruby/test_syntax.rb
@@ -163,9 +163,11 @@ class TestSyntax < Test::Unit::TestCase
         def c(**kw); kw end
         def d(**); b(k: 1, **) end
         def e(**); b(**, k: 1) end
+        def f(a: nil, **); b(**) end
         assert_equal({a: 1, k: 3}, b(a: 1, k: 3))
         assert_equal({a: 1, k: 3}, d(a: 1, k: 3))
         assert_equal({a: 1, k: 1}, e(a: 1, k: 3))
+        assert_equal({k: 3}, f(a: 1, k: 3))
     end;
   end
 


### PR DESCRIPTION
Fixes [Bug #19132]