### PR TITLE
Windows: Readlink improvements

### DIFF
--- a/file.c
+++ b/file.c
@@ -115,6 +115,8 @@ int flock(int, int);
 # define link(f, t)      rb_w32_ulink((f), (t))
 # undef unlink
 # define unlink(p)       rb_w32_uunlink(p)
+# undef readlink
+# define readlink(f, t, l)    rb_w32_ureadlink((f), (t), (l))
 # undef rename
 # define rename(f, t)    rb_w32_urename((f), (t))
 # undef symlink
@@ -3152,7 +3154,6 @@ rb_file_s_readlink(VALUE klass, VALUE path)
     return rb_readlink(path, rb_filesystem_encoding());
 }
 
-#ifndef _WIN32
 struct readlink_arg {
     const char *path;
     char *buf;
@@ -3208,7 +3209,6 @@ rb_readlink(VALUE path, rb_encoding *enc)
 
     return v;
 }
-#endif
 #else
 #define rb_file_s_readlink rb_f_notimplement
 #endif

--- a/include/ruby/win32.h
+++ b/include/ruby/win32.h
@@ -302,7 +302,6 @@ extern DWORD  rb_w32_osver(void);
 extern int rb_w32_uchown(const char *, int, int);
 extern int rb_w32_ulink(const char *, const char *);
 extern ssize_t rb_w32_ureadlink(const char *, char *, size_t);
-extern ssize_t rb_w32_wreadlink(const WCHAR *, WCHAR *, size_t);
 extern int rb_w32_usymlink(const char *src, const char *link);
 extern int gettimeofday(struct timeval *, struct timezone *);
 extern int clock_gettime(clockid_t, struct timespec *);

--- a/win32/file.h
+++ b/win32/file.h
@@ -1,10 +1,8 @@
 #ifndef RUBY_WIN32_FILE_H
 #define RUBY_WIN32_FILE_H
 
-#define MAX_REPARSE_PATH_LEN 4092
-
 enum {
-    MINIMUM_REPARSE_BUFFER_PATH_LEN = 4
+    MINIMUM_REPARSE_BUFFER_PATH_LEN = 100
 };
 /* License: Ruby's */
 typedef struct {
@@ -18,14 +16,14 @@ typedef struct {
             USHORT PrintNameOffset;
             USHORT PrintNameLength;
             ULONG  Flags;
-            WCHAR  PathBuffer[4];
+            WCHAR  PathBuffer[MINIMUM_REPARSE_BUFFER_PATH_LEN];
         } SymbolicLinkReparseBuffer;
         struct {
             USHORT SubstituteNameOffset;
             USHORT SubstituteNameLength;
             USHORT PrintNameOffset;
             USHORT PrintNameLength;
-            WCHAR  PathBuffer[4];
+            WCHAR  PathBuffer[MINIMUM_REPARSE_BUFFER_PATH_LEN];
         } MountPointReparseBuffer;
     };
 } rb_w32_reparse_buffer_t;


### PR DESCRIPTION
While working on #6513 I noticed that the Windows emulation `w32_readlink()` of POSIX `readline()` is broken and not used any longer in ruby-core (but still provided to extensions). So I fixed `w32_readlink`.

Then I removed the custom `rb_readlink` implementation in favour of the POSIX emulation `w32_readlink()`. This has the advantage of releasing the GVL and reduced complexity due to removal of `rb_readlink`.

The dedicated `rb_readlink` for Windows was introduced in commit https://github.com/ruby/ruby/commit/2ffb87995a33cdc7ba609a4b867f03f18da0c3b3 in order to improve encoding and buffer allocation. However the encoding issues are solved since ruby-3.0 switched to UTF-8 and the buffer allocation is now not worse than in the custom `rb_readlink` implementation.

This PR also increases the default buffer size for reparse point info, since previously nearly all queries of reparse points needed two attempts to get enough buffer space.

The last commit removes `rb_w32_wreadlink` declaration, which is no longer present.