### PR TITLE
YJIT: Add compiled_branch_count stats

### DIFF
--- a/yjit.rb
+++ b/yjit.rb
@@ -254,8 +254,9 @@ module RubyVM::YJIT
       $stderr.puts "bindings_allocations:  " + ("%10d" % stats[:binding_allocations])
       $stderr.puts "bindings_set:          " + ("%10d" % stats[:binding_set])
       $stderr.puts "compilation_failure:   " + ("%10d" % compilation_failure) if compilation_failure != 0
-      $stderr.puts "compiled_block_count:  " + ("%10d" % stats[:compiled_block_count])
       $stderr.puts "compiled_iseq_count:   " + ("%10d" % stats[:compiled_iseq_count])
+      $stderr.puts "compiled_block_count:  " + ("%10d" % stats[:compiled_block_count])
+      $stderr.puts "compiled_branch_count: " + ("%10d" % stats[:compiled_branch_count])
       $stderr.puts "freed_iseq_count:      " + ("%10d" % stats[:freed_iseq_count])
       $stderr.puts "invalidation_count:    " + ("%10d" % stats[:invalidation_count])
       $stderr.puts "constant_state_bumps:  " + ("%10d" % stats[:constant_state_bumps])

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -1673,6 +1673,7 @@ fn make_branch_entry(block: &BlockRef, gen_fn: BranchGenFn) -> BranchRef {
     // Add to the list of outgoing branches for the block
     let branchref = Rc::new(RefCell::new(branch));
     block.borrow_mut().push_outgoing(branchref.clone());
+    incr_counter!(compiled_branch_count);
 
     return branchref;
 }

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -267,6 +267,7 @@ make_counters! {
     vm_insns_count,
     compiled_iseq_count,
     compiled_block_count,
+    compiled_branch_count,
     compilation_failure,
     freed_iseq_count,
 


### PR DESCRIPTION
`Branch` allocated by `make_branch_entry` and `Block` allocated by `gen_single_block` are the two biggest memory usages in YJIT. We currently count only the number of blocks, but to investigate memory consumption, it'd be nice to know the number of allocated branches as well.