### PR TITLE
YJIT: Stop wrapping CmePtr with CmeDependency

### DIFF
--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -369,8 +369,7 @@ impl Branch {
     }
 }
 
-// In case this block is invalidated, these two pieces of info
-// help to remove all pointers to this block in the system.
+// In case a block is invalidated, this helps to remove all pointers to the block.
 pub type CmePtr = *const rb_callable_method_entry_t;
 
 /// Basic block version

--- a/yjit/src/invariants.rs
+++ b/yjit/src/invariants.rs
@@ -355,7 +355,7 @@ pub fn block_assumptions_free(blockref: &BlockRef) {
         // For each method lookup dependency
         for dep in block.iter_cme_deps() {
             // Remove tracking for cme validity
-            if let Some(blockset) = invariants.cme_validity.get_mut(&dep.callee_cme) {
+            if let Some(blockset) = invariants.cme_validity.get_mut(dep) {
                 blockset.remove(blockref);
             }
         }


### PR DESCRIPTION
A follow-up refactoring after https://github.com/ruby/ruby/pull/6734. This reduces memory consumption by only 0.1MB, so I wasn't sure if I should file this, but I filed this anyway because the code becomes slightly simpler.