### PR TITLE
YJIT: Pack BlockId and CodePtr

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -721,7 +721,8 @@ pub fn gen_single_block(
 
     #[cfg(feature = "disasm")]
     if get_option_ref!(dump_disasm).is_some() {
-        asm.comment(&format!("Block: {} (ISEQ offset: {})", iseq_get_location(blockid.iseq), blockid.idx));
+        let blockid_idx = blockid.idx;
+        asm.comment(&format!("Block: {} (ISEQ offset: {})", iseq_get_location(blockid.iseq), blockid_idx));
     }
 
     // For each instruction to compile

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -304,6 +304,7 @@ pub struct Context {
 /// Tuple of (iseq, idx) used to identify basic blocks
 /// There are a lot of blockid objects so we try to keep the size small.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[repr(packed)]
 pub struct BlockId {
     /// Instruction sequence
     pub iseq: IseqPtr,
@@ -1530,7 +1531,8 @@ fn gen_block_series_body(
             let iseq_location = iseq_get_location(blockid.iseq);
             if iseq_location.contains(substr) {
                 let last_block = last_blockref.borrow();
-                println!("Compiling {} block(s) for {}, ISEQ offsets [{}, {})", batch.len(), iseq_location, blockid.idx, last_block.end_idx);
+                let blockid_idx = blockid.idx;
+                println!("Compiling {} block(s) for {}, ISEQ offsets [{}, {})", batch.len(), iseq_location, blockid_idx, last_block.end_idx);
                 print!("{}", disasm_iseq_insn_range(blockid.iseq, blockid.idx, last_block.end_idx));
             }
         }
@@ -2151,7 +2153,8 @@ pub fn invalidate_block_version(blockref: &BlockRef) {
         if let Some(substr) = get_option_ref!(dump_iseq_disasm).as_ref() {
             let iseq_location = iseq_get_location(block.blockid.iseq);
             if iseq_location.contains(substr) {
-                println!("Invalidating block from {}, ISEQ offsets [{}, {})", iseq_location, block.blockid.idx, block.end_idx);
+                let blockid_idx = block.blockid.idx;
+                println!("Invalidating block from {}, ISEQ offsets [{}, {})", iseq_location, blockid_idx, block.end_idx);
             }
         }
     }

--- a/yjit/src/disasm.rs
+++ b/yjit/src/disasm.rs
@@ -90,11 +90,12 @@ pub fn disasm_iseq_insn_range(iseq: IseqPtr, start_idx: u32, end_idx: u32) -> St
             let code_size = block.code_size();
 
             // Write some info about the current block
+            let blockid_idx = blockid.idx;
             let block_ident = format!(
                 "BLOCK {}/{}, ISEQ RANGE [{},{}), {} bytes ",
                 block_idx + 1,
                 block_list.len(),
-                blockid.idx,
+                blockid_idx,
                 end_idx,
                 code_size
             );

--- a/yjit/src/virtualmem.rs
+++ b/yjit/src/virtualmem.rs
@@ -59,7 +59,7 @@ pub trait Allocator {
 /// We may later change this to wrap an u32.
 /// Note: there is no NULL constant for CodePtr. You should use Option<CodePtr> instead.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Debug)]
-#[repr(C)]
+#[repr(C, packed)]
 pub struct CodePtr(*const u8);
 
 /// Errors that can happen when writing to [VirtualMemory]


### PR DESCRIPTION
This reduces memory usage on railsbench from 20.9MB to 18.2MB.

## Before
```
code_region_size:         9895936
yjit_alloc_size:         20964221
```

## After
```
code_region_size:         9732096
yjit_alloc_size:         18216757
```