### PR TITLE
YJIT: Shrink version lists after mutation

### DIFF
--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -878,6 +878,7 @@ fn add_block_version(blockref: &BlockRef, cb: &CodeBlock) {
     let version_list = get_or_create_version_list(block.blockid);
 
     version_list.push(blockref.clone());
+    version_list.shrink_to_fit();
 
     // By writing the new block to the iseq, the iseq now
     // contains new references to Ruby objects. Run write barriers.


### PR DESCRIPTION
Not a big deal (18.1MB -> 17.8MB), but not too complicated to do this either.

## Before
```
code_region_size:         9699328
yjit_alloc_size:         18155581
```

## After
```
code_region_size:         9715712
yjit_alloc_size:         17863209
```