### PR TITLE
YJIT: Add object shape count to stats

### DIFF
--- a/yjit.c
+++ b/yjit.c
@@ -1071,6 +1071,14 @@ rb_yjit_invalidate_all_method_lookup_assumptions(void)
     // method caches, so we do nothing here for now.
 }
 
+// Number of object shapes, which might be useful for investigating YJIT exit reasons.
+static VALUE
+object_shape_count(rb_execution_context_t *ec, VALUE self)
+{
+    // next_shape_id starts from 0, so it's the same as the count
+    return ULONG2NUM((unsigned long)GET_VM()->next_shape_id);
+}
+
 // Primitives used by yjit.rb
 VALUE rb_yjit_stats_enabled_p(rb_execution_context_t *ec, VALUE self);
 VALUE rb_yjit_trace_exit_locations_enabled_p(rb_execution_context_t *ec, VALUE self);

--- a/yjit.rb
+++ b/yjit.rb
@@ -146,7 +146,10 @@ module RubyVM::YJIT
   # Return nil when option is not passed or unavailable.
   def self.runtime_stats
     stats = Primitive.rb_yjit_get_stats
-    return stats if stats.nil? || !Primitive.rb_yjit_stats_enabled_p
+    return stats if stats.nil?
+
+    stats[:object_shape_count] = Primitive.object_shape_count
+    return stats unless Primitive.rb_yjit_stats_enabled_p
 
     side_exits = total_exit_count(stats)
     total_exits = side_exits + stats[:leave_interp_return]
@@ -270,6 +273,7 @@ module RubyVM::YJIT
       $stderr.puts "freed_page_count:      " + ("%10d" % stats[:freed_page_count])
       $stderr.puts "code_gc_count:         " + ("%10d" % stats[:code_gc_count])
       $stderr.puts "num_gc_obj_refs:       " + ("%10d" % stats[:num_gc_obj_refs])
+      $stderr.puts "object_shape_count:    " + ("%10d" % stats[:object_shape_count])
       $stderr.puts "side_exit_count:       " + ("%10d" % stats[:side_exit_count])
       $stderr.puts "total_exit_count:      " + ("%10d" % stats[:total_exit_count])
       $stderr.puts "total_insns_count:     " + ("%10d" % stats[:total_insns_count]) if stats.key?(:total_insns_count)


### PR DESCRIPTION
This PR adds `object_shape_count` to stats for having insight into exit reasons due to shape transitions.

We might want to add this to `GC.stat`, but I assume `GC.stat` is supposed to be a little bit stable interface compared to `RubyVM::YJIT.runtime_stats`, and I think it's useful to see this on `_print_stats` anyway.