### PR TITLE
Refactor RB_SPECIAL_CONST_P

### DIFF
--- a/include/ruby/internal/special_consts.h
+++ b/include/ruby/internal/special_consts.h
@@ -326,7 +326,7 @@ RBIMPL_ATTR_ARTIFICIAL()
 static inline bool
 RB_SPECIAL_CONST_P(VALUE obj)
 {
-    return RB_IMMEDIATE_P(obj) || ! RB_TEST(obj);
+    return RB_IMMEDIATE_P(obj) || obj == RUBY_Qfalse;
 }
 
 RBIMPL_ATTR_CONST()


### PR DESCRIPTION
Since https://github.com/ruby/ruby/pull/6599, RUBY_IMMEDIATE_MASK also overlaps RUBY_Qnil. Now RB_SPECIAL_CONST_P seems confusing since both RB_IMMEDIATE_P and RB_TEST check for RUBY_Qnil. I'd like to make this change to make it less confusing.

I confirmed that this doesn't change the number of instructions used for the RUBY_Qfalse check on Linux x86_64 and macOS arm64.