### PR TITLE
Add RVALUE_OVERHEAD and move ractor_belonging_id

### DIFF
--- a/ractor_core.h
+++ b/ractor_core.h
@@ -291,8 +291,6 @@ rb_ractor_id(const rb_ractor_t *r)
 # define RACTOR_BELONGING_ID(obj) (*(uint32_t *)(((uintptr_t)(obj)) + rb_gc_obj_slot_size(obj)))
 
 uint32_t rb_ractor_current_id(void);
-// If ractor check mode is enabled, shape bits needs to be smaller
-STATIC_ASSERT(shape_bits, SHAPE_ID_NUM_BITS == 16);
 
 static inline void
 rb_ractor_setup_belonging_to(VALUE obj, uint32_t rid)

--- a/ractor_core.h
+++ b/ractor_core.h
@@ -288,6 +288,8 @@ rb_ractor_id(const rb_ractor_t *r)
 }
 
 #if RACTOR_CHECK_MODE > 0
+# define RACTOR_BELONGING_ID(obj) (*(uint32_t *)(((uintptr_t)(obj)) + rb_gc_obj_slot_size(obj)))
+
 uint32_t rb_ractor_current_id(void);
 // If ractor check mode is enabled, shape bits needs to be smaller
 STATIC_ASSERT(shape_bits, SHAPE_ID_NUM_BITS == 16);
@@ -295,8 +297,7 @@ STATIC_ASSERT(shape_bits, SHAPE_ID_NUM_BITS == 16);
 static inline void
 rb_ractor_setup_belonging_to(VALUE obj, uint32_t rid)
 {
-    VALUE flags = RBASIC(obj)->flags & 0xffff0000ffffffff; // 4B
-    RBASIC(obj)->flags = flags | ((VALUE)rid << 32);
+    RACTOR_BELONGING_ID(obj) = rid;
 }
 
 static inline void
@@ -312,7 +313,7 @@ rb_ractor_belonging(VALUE obj)
         return 0;
     }
     else {
-        return RBASIC(obj)->flags >> 32 & 0xFFFF;
+        return RACTOR_BELONGING_ID(obj);
     }
 }
 

--- a/shape.h
+++ b/shape.h
@@ -12,22 +12,12 @@ typedef uint16_t attr_index_t;
 
 #define MAX_IVARS (attr_index_t)(-1)
 
-#if RUBY_DEBUG || (defined(VM_CHECK_MODE) && VM_CHECK_MODE > 0)
-#  if SIZEOF_SHAPE_T == 4
-typedef uint32_t shape_id_t;
-# define SHAPE_ID_NUM_BITS 16
-#  else
-typedef uint16_t shape_id_t;
-# define SHAPE_ID_NUM_BITS 16
-#  endif
-#else
-#  if SIZEOF_SHAPE_T == 4
+#if SIZEOF_SHAPE_T == 4
 typedef uint32_t shape_id_t;
 # define SHAPE_ID_NUM_BITS 32
-#  else
+#else
 typedef uint16_t shape_id_t;
 # define SHAPE_ID_NUM_BITS 16
-#  endif
 #endif
 
 # define SHAPE_MASK (((uintptr_t)1 << SHAPE_ID_NUM_BITS) - 1)

--- a/test/objspace/test_objspace.rb
+++ b/test/objspace/test_objspace.rb
@@ -480,8 +480,8 @@ class TestObjSpace < Test::Unit::TestCase
         obj = JSON.parse(l)
         next if obj["type"] == "ROOT"
 
-        assert(obj["slot_size"] != nil)
-        assert(obj["slot_size"] % GC::INTERNAL_CONSTANTS[:BASE_SLOT_SIZE] == 0)
+        assert_not_nil obj["slot_size"]
+        assert_equal 0, obj["slot_size"] % GC::INTERNAL_CONSTANTS[:RVALUE_SIZE]
       }
     end
   end

--- a/test/ruby/test_gc.rb
+++ b/test/ruby/test_gc.rb
@@ -152,7 +152,7 @@ class TestGc < Test::Unit::TestCase
       GC.stat_heap(i, stat_heap)
       GC.stat(stat)
 
-      assert_equal GC::INTERNAL_CONSTANTS[:BASE_SLOT_SIZE] * (2**i), stat_heap[:slot_size]
+      assert_equal GC::INTERNAL_CONSTANTS[:RVALUE_SIZE] * (2**i), stat_heap[:slot_size]
       assert_operator stat_heap[:heap_allocatable_pages], :<=, stat[:heap_allocatable_pages]
       assert_operator stat_heap[:heap_eden_pages], :<=, stat[:heap_eden_pages]
       assert_operator stat_heap[:heap_eden_slots], :>=, 0

--- a/test/ruby/test_objectspace.rb
+++ b/test/ruby/test_objectspace.rb
@@ -67,7 +67,7 @@ End
 
   def test_id2ref_invalid_symbol_id
     msg = /is not symbol id value/
-    assert_raise_with_message(RangeError, msg) { ObjectSpace._id2ref(:a.object_id + 40) }
+    assert_raise_with_message(RangeError, msg) { ObjectSpace._id2ref(:a.object_id + GC::INTERNAL_CONSTANTS[:RVALUE_SIZE]) }
   end
 
   def test_count_objects


### PR DESCRIPTION
This PR adds RVALUE_OVERHEAD for storing metadata at the end of the slot. This commit moves the ractor_belonging_id in debug builds from the flags to RVALUE_OVERHEAD which frees the 16 bits in the headers for object shapes.