### PR TITLE
Speed up IV writes

### DIFF
--- a/shape.c
+++ b/shape.c
@@ -306,6 +306,12 @@ rb_shape_id_num_bits(void)
     return SHAPE_ID_NUM_BITS;
 }
 
+int32_t
+rb_shape_id_offset(void)
+{
+    return 8 - rb_shape_id_num_bits() / 8;
+}
+
 uint8_t
 rb_shape_flag_shift(void)
 {

--- a/shape.c
+++ b/shape.c
@@ -306,6 +306,18 @@ rb_shape_id_num_bits(void)
     return SHAPE_ID_NUM_BITS;
 }
 
+uint8_t
+rb_shape_flag_shift(void)
+{
+    return SHAPE_FLAG_SHIFT;
+}
+
+uint64_t
+rb_shape_flag_mask(void)
+{
+    return SHAPE_FLAG_MASK;
+}
+
 rb_shape_t *
 rb_shape_rebuild_shape(rb_shape_t * initial_shape, rb_shape_t * dest_shape)
 {

--- a/shape.c
+++ b/shape.c
@@ -312,18 +312,6 @@ rb_shape_id_offset(void)
     return 8 - rb_shape_id_num_bits() / 8;
 }
 
-uint8_t
-rb_shape_flag_shift(void)
-{
-    return SHAPE_FLAG_SHIFT;
-}
-
-uint64_t
-rb_shape_flag_mask(void)
-{
-    return SHAPE_FLAG_MASK;
-}
-
 rb_shape_t *
 rb_shape_rebuild_shape(rb_shape_t * initial_shape, rb_shape_t * dest_shape)
 {

--- a/shape.h
+++ b/shape.h
@@ -124,6 +124,8 @@ static inline shape_id_t RCLASS_SHAPE_ID(VALUE obj)
 bool rb_shape_root_shape_p(rb_shape_t* shape);
 rb_shape_t * rb_shape_get_root_shape(void);
 uint8_t rb_shape_id_num_bits(void);
+uint64_t rb_shape_flag_mask(void);
+uint8_t rb_shape_flag_shift(void);
 
 rb_shape_t* rb_shape_get_shape_by_id_without_assertion(shape_id_t shape_id);
 rb_shape_t * rb_shape_get_parent(rb_shape_t * shape);

--- a/shape.h
+++ b/shape.h
@@ -124,6 +124,7 @@ static inline shape_id_t RCLASS_SHAPE_ID(VALUE obj)
 bool rb_shape_root_shape_p(rb_shape_t* shape);
 rb_shape_t * rb_shape_get_root_shape(void);
 uint8_t rb_shape_id_num_bits(void);
+int32_t rb_shape_id_offset(void);
 uint64_t rb_shape_flag_mask(void);
 uint8_t rb_shape_flag_shift(void);
 

--- a/shape.h
+++ b/shape.h
@@ -125,8 +125,6 @@ bool rb_shape_root_shape_p(rb_shape_t* shape);
 rb_shape_t * rb_shape_get_root_shape(void);
 uint8_t rb_shape_id_num_bits(void);
 int32_t rb_shape_id_offset(void);
-uint64_t rb_shape_flag_mask(void);
-uint8_t rb_shape_flag_shift(void);
 
 rb_shape_t* rb_shape_get_shape_by_id_without_assertion(shape_id_t shape_id);
 rb_shape_t * rb_shape_get_parent(rb_shape_t * shape);

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -90,8 +90,6 @@ fn main() {
         .allowlist_function("rb_shape_get_iv_index")
         .allowlist_function("rb_shape_get_next")
         .allowlist_function("rb_shape_id")
-        .allowlist_function("rb_shape_flag_mask")
-        .allowlist_function("rb_shape_flag_shift")
         .allowlist_function("rb_shape_transition_shape_capa")
 
         // From ruby/internal/intern/object.h

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -86,6 +86,7 @@ fn main() {
         .allowlist_function("rb_shape_get_shape_id")
         .allowlist_function("rb_shape_get_shape_by_id")
         .allowlist_function("rb_shape_id_num_bits")
+        .allowlist_function("rb_shape_id_offset")
         .allowlist_function("rb_shape_get_iv_index")
         .allowlist_function("rb_shape_get_next")
         .allowlist_function("rb_shape_id")

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -87,6 +87,11 @@ fn main() {
         .allowlist_function("rb_shape_get_shape_by_id")
         .allowlist_function("rb_shape_id_num_bits")
         .allowlist_function("rb_shape_get_iv_index")
+        .allowlist_function("rb_shape_get_next")
+        .allowlist_function("rb_shape_id")
+        .allowlist_function("rb_shape_flag_mask")
+        .allowlist_function("rb_shape_flag_shift")
+        .allowlist_function("rb_shape_transition_shape_capa")
 
         // From ruby/internal/intern/object.h
         .allowlist_function("rb_obj_is_kind_of")
@@ -131,6 +136,7 @@ fn main() {
         .allowlist_function("rb_gc_mark")
         .allowlist_function("rb_gc_mark_movable")
         .allowlist_function("rb_gc_location")
+        .allowlist_function("rb_gc_writebarrier")
 
         // VALUE variables for Ruby class objects
         // From include/ruby/internal/globals.h
@@ -314,6 +320,7 @@ fn main() {
 
         // From internal/variable.h
         .allowlist_function("rb_gvar_(get|set)")
+        .allowlist_function("rb_ensure_iv_list_size")
 
         // From include/ruby/internal/intern/variable.h
         .allowlist_function("rb_attr_get")

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -95,6 +95,7 @@ fn main() {
 
         // From ruby/internal/intern/object.h
         .allowlist_function("rb_obj_is_kind_of")
+        .allowlist_function("rb_obj_frozen_p")
 
         // From ruby/internal/encoding/encoding.h
         .allowlist_type("ruby_encoding_consts")

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -2046,8 +2046,8 @@ fn gen_get_ivar(
 
     let expected_shape = unsafe { rb_shape_get_shape_id(comptime_receiver) };
     let shape_bit_size = unsafe { rb_shape_id_num_bits() }; // either 16 or 32 depending on RUBY_DEBUG
-    let shape_byte_size = shape_bit_size / 8;
-    let shape_opnd = Opnd::mem(shape_bit_size, recv, RUBY_OFFSET_RBASIC_FLAGS + (8 - shape_byte_size as i32));
+    let shape_id_offset = unsafe { rb_shape_id_offset() };
+    let shape_opnd = Opnd::mem(shape_bit_size, recv, shape_id_offset);
 
     asm.comment("guard shape");
     asm.cmp(shape_opnd, Opnd::UImm(expected_shape as u64));
@@ -2270,8 +2270,8 @@ fn gen_setinstancevariable(
 
         let expected_shape = unsafe { rb_shape_get_shape_id(comptime_receiver) };
         let shape_bit_size = unsafe { rb_shape_id_num_bits() }; // either 16 or 32 depending on RUBY_DEBUG
-        let shape_byte_size = shape_bit_size / 8;
-        let shape_opnd = Opnd::mem(shape_bit_size, recv, RUBY_OFFSET_RBASIC_FLAGS + (8 - shape_byte_size as i32));
+        let shape_id_offset = unsafe { rb_shape_id_offset() };
+        let shape_opnd = Opnd::mem(shape_bit_size, recv, shape_id_offset);
 
         asm.comment("guard shape");
         asm.cmp(shape_opnd, Opnd::UImm(expected_shape as u64));
@@ -2335,8 +2335,8 @@ fn gen_setinstancevariable(
                 asm.comment("write shape");
 
                 let shape_bit_size = unsafe { rb_shape_id_num_bits() }; // either 16 or 32 depending on RUBY_DEBUG
-                let shape_byte_size = shape_bit_size / 8;
-                let shape_opnd = Opnd::mem(shape_bit_size, recv, RUBY_OFFSET_RBASIC_FLAGS + (8 - shape_byte_size as i32));
+                let shape_id_offset = unsafe { rb_shape_id_offset() };
+                let shape_opnd = Opnd::mem(shape_bit_size, recv, shape_id_offset);
 
                 // Store the new shape
                 asm.store(shape_opnd, Opnd::UImm(new_shape_id as u64));

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -2191,6 +2191,12 @@ fn gen_setinstancevariable(
     let comptime_receiver = jit_peek_at_self(jit);
     let comptime_val_klass = comptime_receiver.class_of();
 
+    // If the comptime receiver is frozen, writing an IV will raise an exception
+    // and we don't want to JIT code to deal with that situation.
+    if comptime_receiver.is_frozen() {
+        return CantCompile;
+    }
+
     // Check if the comptime class uses a custom allocator
     let custom_allocator = unsafe { rb_get_alloc_func(comptime_val_klass) };
     let uses_custom_allocator = match custom_allocator {

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -2339,7 +2339,6 @@ fn gen_setinstancevariable(
                 let shape_opnd = Opnd::mem(shape_bit_size, recv, RUBY_OFFSET_RBASIC_FLAGS + (8 - shape_byte_size as i32));
 
                 // Store the new shape
-                asm.store(shape_opnd, Opnd::UImm(0 as u64));
                 asm.store(shape_opnd, Opnd::UImm(new_shape_id as u64));
             },
 

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -394,8 +394,26 @@ impl VALUE {
         unsafe { CLASS_OF(self) }
     }
 
-    pub fn shape_of(self) -> u32 {
+    pub fn shape_id_of(self) -> u32 {
         unsafe { rb_shape_get_shape_id(self) }
+    }
+
+    pub fn shape_of(self) -> *mut rb_shape {
+        unsafe {
+            let shape = rb_shape_get_shape_by_id(self.shape_id_of());
+
+            if shape.is_null() {
+                panic!("Shape should not be null");
+            } else {
+                shape
+            }
+        }
+    }
+
+    pub fn embedded_p(self) -> bool {
+        unsafe {
+            FL_TEST_RAW(self, VALUE(ROBJECT_EMBED as usize)) != VALUE(0)
+        }
     }
 
     pub fn as_isize(self) -> isize {

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -394,6 +394,10 @@ impl VALUE {
         unsafe { CLASS_OF(self) }
     }
 
+    pub fn is_frozen(self) -> bool {
+        unsafe { rb_obj_frozen_p(self) != VALUE(0) }
+    }
+
     pub fn shape_id_of(self) -> u32 {
         unsafe { rb_shape_get_shape_id(self) }
     }

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -450,12 +450,6 @@ extern "C" {
     pub fn rb_shape_id_offset() -> i32;
 }
 extern "C" {
-    pub fn rb_shape_flag_mask() -> u64;
-}
-extern "C" {
-    pub fn rb_shape_flag_shift() -> u8;
-}
-extern "C" {
     pub fn rb_shape_get_shape_by_id(shape_id: shape_id_t) -> *mut rb_shape_t;
 }
 extern "C" {

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -441,13 +441,31 @@ extern "C" {
     pub fn rb_shape_id_num_bits() -> u8;
 }
 extern "C" {
+    pub fn rb_shape_flag_mask() -> u64;
+}
+extern "C" {
+    pub fn rb_shape_flag_shift() -> u8;
+}
+extern "C" {
     pub fn rb_shape_get_shape_by_id(shape_id: shape_id_t) -> *mut rb_shape_t;
 }
 extern "C" {
     pub fn rb_shape_get_shape_id(obj: VALUE) -> shape_id_t;
 }
 extern "C" {
+    pub fn rb_shape_transition_shape_capa(
+        shape: *mut rb_shape_t,
+        new_capacity: u32,
+    ) -> *mut rb_shape_t;
+}
+extern "C" {
+    pub fn rb_shape_get_next(shape: *mut rb_shape_t, obj: VALUE, id: ID) -> *mut rb_shape_t;
+}
+extern "C" {
     pub fn rb_shape_get_iv_index(shape: *mut rb_shape_t, id: ID, value: *mut attr_index_t) -> bool;
+}
+extern "C" {
+    pub fn rb_shape_id(shape: *mut rb_shape_t) -> shape_id_t;
 }
 pub const idDot2: ruby_method_ids = 128;
 pub const idDot3: ruby_method_ids = 129;
@@ -1061,6 +1079,9 @@ extern "C" {
 }
 extern "C" {
     pub fn rb_gvar_set(arg1: ID, arg2: VALUE) -> VALUE;
+}
+extern "C" {
+    pub fn rb_ensure_iv_list_size(obj: VALUE, len: u32, newsize: u32);
 }
 extern "C" {
     pub fn rb_vm_insn_decode(encoded: VALUE) -> ::std::os::raw::c_int;

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -444,6 +444,9 @@ extern "C" {
     pub fn rb_shape_id_num_bits() -> u8;
 }
 extern "C" {
+    pub fn rb_shape_id_offset() -> i32;
+}
+extern "C" {
     pub fn rb_shape_flag_mask() -> u64;
 }
 extern "C" {

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -358,6 +358,9 @@ extern "C" {
     pub fn rb_obj_is_kind_of(obj: VALUE, klass: VALUE) -> VALUE;
 }
 extern "C" {
+    pub fn rb_obj_frozen_p(obj: VALUE) -> VALUE;
+}
+extern "C" {
     pub fn rb_backref_get() -> VALUE;
 }
 extern "C" {

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -247,6 +247,9 @@ pub type st_foreach_callback_func = ::std::option::Option<
         arg3: st_data_t,
     ) -> ::std::os::raw::c_int,
 >;
+extern "C" {
+    pub fn rb_gc_writebarrier(old: VALUE, young: VALUE);
+}
 pub const RARRAY_EMBED_FLAG: ruby_rarray_flags = 8192;
 pub const RARRAY_EMBED_LEN_MASK: ruby_rarray_flags = 4161536;
 pub const RARRAY_TRANSIENT_FLAG: ruby_rarray_flags = 33554432;


### PR DESCRIPTION
This PR takes advantage of shapes in the set instance variable instruction.

It handles a few different cases:

|          | Shape Transitions | No Transition |
| - | - | - |
| Needs to allocate IV buffer |  ✅ | ✅ |
| No Allocation | ✅ | ✅ |

For the time being, we still fire a write barrier in many cases.  We never need to fire a write barrier when the object we reference is an immediate.  If we know from the virtual stack that the object we're writing is an immediate, we will not generate WB code.  If we don't know what type it is, then we do a runtime check and only fire the WB if it's a heap object.

Ideally we could fire the WB even less frequently.  The generational algorithm only wants the WB so that we can know old to young references.  Unfortunately, the GC _also_ implements an incremental marking algorithm.  If the GC is doing incremental marking, then it relies on the WB for executing any black / white / grey transitions.

In other words, object age is not the only factor for deciding whether or not the WB should execute, we also have to take in to account whether or not the GC is currently doing incremental marking.

There must be something clever we can do to handle the above situation, I'm just not sure about it right now.

Benchmarks look like this:

```
before: ruby 3.2.0dev (2022-11-18T20:04:10Z master 9e067df76b) +YJIT [x86_64-linux]
after: ruby 3.2.0dev (2022-11-18T21:13:32Z iv-write 6f7f05fb68) +YJIT [x86_64-linux]

--------------  -----------  ----------  ----------  ----------  ------------  -------------
bench           before (ms)  stddev (%)  after (ms)  stddev (%)  before/after  after 1st itr
30k_ifelse      233.7        0.0         227.4       0.1         1.03          1.00         
30k_methods     557.3        0.1         543.9       0.1         1.02          1.04         
activerecord    72.8         0.2         68.0        1.2         1.07          1.03         
binarytrees     139.8        1.7         136.0       0.8         1.03          1.02         
cfunc_itself    30.5         0.1         30.3        0.1         1.01          1.02         
chunky_png      436.1        0.4         455.3       0.3         0.96          0.96         
erubi           198.8        0.7         201.6       0.8         0.99          0.99         
erubi_rails     12.2         8.2         12.2        8.0         1.00          0.97         
etanni          334.6        0.3         337.2       0.4         0.99          1.00         
fannkuchredux   1398.2       0.2         1396.6      0.2         1.00          1.00         
fib             41.4         0.1         41.5        0.7         1.00          1.00         
getivar         24.5         0.1         24.5        0.1         1.00          1.03         
hexapdf         1441.0       1.6         1410.9      2.1         1.02          1.01         
keyword_args    38.3         0.2         36.8        0.1         1.04          1.06         
lee             628.6        0.8         641.8       1.1         0.98          0.98         
liquid-render   76.4         1.7         75.8        1.6         1.01          1.00         
mail            105.3        0.1         104.4       0.1         1.01          0.98         
nbody           64.9         0.4         55.8        0.7         1.16          1.12         
optcarrot       2276.9       0.5         1762.3      0.4         1.29          1.28         
psych-load      1358.3       0.1         1309.7      0.0         1.04          1.03         
railsbench      1284.0       2.2         1280.2      2.0         1.00          1.00         
respond_to      21.9         0.6         17.9        0.4         1.23          1.27         
ruby-lsp        50.5         19.5        50.1        20.4        1.01          0.99         
rubykon         4851.4       0.5         4642.6      2.6         1.04          1.03         
setivar         30.2         1.7         10.3        0.2         2.93          1.03         
setivar_object  50.4         0.2         32.0        0.3         1.57          1.03         
str_concat      26.4         1.7         26.3        3.2         1.00          1.02         
--------------  -----------  ----------  ----------  ----------  ------------  -------------
Legend:
- before/after: ratio of before/after time. Higher is better for after. Above 1 represents a speedup.
- after 1st itr: ratio of before/after time for the first benchmarking iteration.
```

I really really need to study the `respond_to` benchmark.  I don't see _any_ instance variables in that benchmark and yet this patch makes it faster.