### PR TITLE
Fixup spec/ruby/optional/capi/rbasic_spec.rb for mswin

### DIFF
--- a/spec/ruby/optional/capi/rbasic_spec.rb
+++ b/spec/ruby/optional/capi/rbasic_spec.rb
@@ -1,7 +1,6 @@
 require_relative 'spec_helper'
 require_relative 'shared/rbasic'
 load_extension("rbasic")
-return if /mswin/ =~ RUBY_PLATFORM && ENV.key?('GITHUB_ACTIONS') # not working from the beginning
 load_extension("data")
 load_extension("array")
 

--- a/spec/ruby/optional/capi/spec_helper.rb
+++ b/spec/ruby/optional/capi/spec_helper.rb
@@ -34,7 +34,8 @@ def compile_extension(name)
   abi_header = "#{rubyhdrdir}/ruby/internal/abi.h"
 
   if RbConfig::CONFIG["ENABLE_SHARED"] == "yes"
-    libdirname = RbConfig::CONFIG['libdirname'] # defined since 2.1
+    # below is defined since 2.1, except for mswin, and maybe other platforms
+    libdirname = RbConfig::CONFIG.fetch 'libdirname', 'libdir'
     libruby = "#{RbConfig::CONFIG[libdirname]}/#{RbConfig::CONFIG['LIBRUBY']}"
   end
 


### PR DESCRIPTION
`RbConfig::CONFIG['libdirname']` is not defined in Windows mswin Rubies, use default of 'libdir'.

See https://bugs.ruby-lang.org/issues/19133