### PR TITLE
Fix up test/ruby/test_ast.rb - don't include rubygems tmp files

### DIFF
--- a/test/ruby/test_ast.rb
+++ b/test/ruby/test_ast.rb
@@ -115,6 +115,7 @@ class TestAst < Test::Unit::TestCase
   SRCDIR = File.expand_path("../../..", __FILE__)
 
   Dir.glob("test/**/*.rb", base: SRCDIR).each do |path|
+    next if path.include? 'test/tmp/'
     define_method("test_ranges:#{path}") do
       helper = Helper.new("#{SRCDIR}/#{path}")
       helper.validate_range
@@ -124,6 +125,7 @@ class TestAst < Test::Unit::TestCase
   end
 
   Dir.glob("test/**/*.rb", base: SRCDIR).each do |path|
+    next if path.include? 'test/tmp/'
     define_method("test_not_cared:#{path}") do
       helper = Helper.new("#{SRCDIR}/#{path}")
       helper.validate_not_cared
@@ -133,6 +135,7 @@ class TestAst < Test::Unit::TestCase
   end
 
   Dir.glob("test/**/*.rb", base: SRCDIR).each do |path|
+    next if path.include? 'test/tmp/'
     define_method("test_all_tokens:#{path}") do
       node = RubyVM::AbstractSyntaxTree.parse_file("#{SRCDIR}/#{path}", keep_tokens: true)
       tokens = node.all_tokens.sort_by { [_1.last[0], _1.last[1]] }


### PR DESCRIPTION
RubyGems testing generates ruby files in `test/tmp`.  These files are deleted, but may cause errors when running parallel testing.

Below are a few lines of parallel errors.  One run had 18 lines...
```
TestAst#test_ranges:test/tmp/test_rubygems_20221120-3308-1krcj3/gemhome/gems/c-1.2/lib/code.rb = 0.00 s = E
TestAst#test_ranges:test/tmp/test_rubygems_20221120-3308-1krcj3/gemhome/gems/pl-1-x86-linux/lib/code.rb = 0.00 s = E
TestAst#test_not_cared:test/tmp/test_rubygems_20221120-3308-1krcj3/gemhome/gems/b-2/lib/code.rb = 0.00 s = E
TestAst#test_not_cared:test/tmp/test_rubygems_20221120-3308-1krcj3/gemhome/gems/pl-1-x86-linux/lib/code.rb = 0.00 s = E
TestAst#test_not_cared:test/tmp/test_rubygems_20221120-3308-1krcj3/gemhome/gems/a-1/lib/code.rb = 0.01 s = E

```