### PR TITLE
YJIT: Lower the required Rust version from 1.58.1 to 1.58.0

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -89,7 +89,7 @@ yjit_task:
     matrix:
       - CC: clang-12
         configure: --enable-yjit=dev
-        rustup_init: --default-toolchain=1.58.1
+        rustup_init: --default-toolchain=1.58.0
       - CC: gcc-11
         configure: --enable-yjit
   id_script: id

--- a/.github/workflows/yjit-ubuntu.yml
+++ b/.github/workflows/yjit-ubuntu.yml
@@ -48,8 +48,8 @@ jobs:
             configure: "--with-gcc=clang-12 --enable-yjit=dev"
 
           - test_task: "check"
-            configure: "--enable-yjit RUSTC='rustc +1.58.1'" # release build
-            rust_version: "1.58.1"
+            configure: "--enable-yjit RUSTC='rustc +1.58.0'" # release build
+            rust_version: "1.58.0"
 
           - test_task: "check"
             configure: "--enable-yjit=dev"

--- a/NEWS.md
+++ b/NEWS.md
@@ -367,7 +367,7 @@ The following deprecated APIs are removed.
 ### YJIT
 
 * Support arm64 / aarch64 on UNIX platforms.
-* Building YJIT requires Rust 1.58.1+. [[Feature #18481]]
+* Building YJIT requires Rust 1.58.0+. [[Feature #18481]]
 * Physical memory for JIT code is lazily allocated. Unlike Ruby 3.1,
   the RSS of a Ruby process is minimized because virtual memory pages
   allocated by `--yjit-exec-mem-size` will not be mapped to physical

--- a/doc/contributing/building_ruby.md
+++ b/doc/contributing/building_ruby.md
@@ -18,7 +18,7 @@
     * libffi
     * libyaml
     * libexecinfo (FreeBSD)
-    * rustc - 1.58.1 or later (if you wish to build [YJIT](/doc/yjit/yjit.md))
+    * rustc - 1.58.0 or later (if you wish to build [YJIT](/doc/yjit/yjit.md))
 
 3. Checkout the CRuby source code:
 

--- a/doc/yjit/yjit.md
+++ b/doc/yjit/yjit.md
@@ -51,7 +51,7 @@ You will need to install:
 - A C compiler such as GCC or Clang
 - GNU Make and Autoconf
 - The Rust compiler `rustc` and Cargo (if you want to build in dev/debug mode)
-  - The Rust version must be [>= 1.58.1](../../yjit/Cargo.toml).
+  - The Rust version must be [>= 1.58.0](../../yjit/Cargo.toml).
 
 To install the Rust build toolchain, we suggest following the [recommended installation method][rust-install]. Rust also provides first class [support][editor-tools] for many source code editors.
 

--- a/yjit/Cargo.toml
+++ b/yjit/Cargo.toml
@@ -6,7 +6,7 @@
 name = "yjit"
 version = "0.1.0"       # YJIT version
 edition = "2021"        # Rust 2021 edition to compile with
-rust-version = "1.58.1" # Minimally supported rust version
+rust-version = "1.58.0" # Minimally supported rust version
 publish = false         # Don't publish to crates.io
 
 [lib]


### PR DESCRIPTION
We've already reached this consensus, but the implementation is not consistent yet.