### PR TITLE
Update response.rb

### DIFF
--- a/lib/net/http/response.rb
+++ b/lib/net/http/response.rb
@@ -40,7 +40,7 @@ class Net::HTTPResponse
 
     def read_status_line(sock)
       str = sock.readline
-      m = /\AHTTP(?:\/(\d+\.\d+))?\s+(\d\d\d)(?:\s+(.*))?\z/in.match(str) or
+      m = /\AHTTP(?:\/(\d+\.?\d?))?\s+(\d\d\d)(?:\s+(.*))?\z/in.match(str) or
         raise Net::HTTPBadResponse, "wrong status line: #{str.dump}"
       m.captures
     end


### PR DESCRIPTION
I found an issue with the regex, that validates the response status code of HTTP requests.

The current regex doesn't accept `HTTP/2 200`, but `HTTP/2.0 200`. We should make it less strict to ensure compatibility.