### PR TITLE
Reuse `NIL_OR_UNDEF_P` macro

### DIFF
--- a/compar.c
+++ b/compar.c
@@ -50,7 +50,7 @@ VALUE
 rb_invcmp(VALUE x, VALUE y)
 {
     VALUE invcmp = rb_exec_recursive(invcmp_recursive, x, y);
-    if (UNDEF_P(invcmp) || NIL_P(invcmp)) {
+    if (NIL_OR_UNDEF_P(invcmp)) {
         return Qnil;
     }
     else {

--- a/dir.c
+++ b/dir.c
@@ -2932,7 +2932,7 @@ dir_globs(VALUE args, VALUE base, int flags)
 static VALUE
 dir_glob_option_base(VALUE base)
 {
-    if (UNDEF_P(base) || NIL_P(base)) {
+    if (NIL_OR_UNDEF_P(base)) {
         return Qnil;
     }
 #if USE_OPENDIR_AT

--- a/error.c
+++ b/error.c
@@ -2090,7 +2090,7 @@ name_err_mesg_to_str(VALUE obj)
             break;
           default:
             d = rb_protect(name_err_mesg_receiver_name, obj, &state);
-            if (state || UNDEF_P(d) || NIL_P(d))
+            if (state || NIL_OR_UNDEF_P(d))
                 d = rb_protect(rb_inspect, obj, &state);
             if (state) {
                 rb_set_errinfo(Qnil);

--- a/io.c
+++ b/io.c
@@ -1424,7 +1424,7 @@ rb_io_wait(VALUE io, VALUE events, VALUE timeout)
     struct timeval tv_storage;
     struct timeval *tv = NULL;
 
-    if (timeout == Qnil || UNDEF_P(timeout)) {
+    if (NIL_OR_UNDEF_P(timeout)) {
         timeout = fptr->timeout;
     }
 


### PR DESCRIPTION
Some code has theese `Qnil` or `Qundef` check.

```c
if (UNDEF_P(invcmp) || NIL_P(invcmp)) {
    return Qnil;
}
```

But, already defined `NIL_OR_UNDEF_P` macro.
Reuse `NIL_OR_UNDEF_P` macro more better. I think.