### PR TITLE
YJIT: Skip padding jumps to side exits on Arm

### DIFF
--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -254,9 +254,10 @@ impl From<VALUE> for Opnd {
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Target
 {
-    CodePtr(CodePtr),   // Pointer to a piece of YJIT-generated code (e.g. side-exit)
-    FunPtr(*const u8),  // Pointer to a C function
-    Label(usize),       // A label within the generated code
+    CodePtr(CodePtr),     // Pointer to a piece of YJIT-generated code
+    SideExitPtr(CodePtr), // Pointer to a side exit code
+    FunPtr(*const u8),    // Pointer to a C function
+    Label(usize),         // A label within the generated code
 }
 
 impl Target

--- a/yjit/src/backend/x86_64/mod.rs
+++ b/yjit/src/backend/x86_64/mod.rs
@@ -565,7 +565,7 @@ impl Assembler
                 // Conditional jump to a label
                 Insn::Jmp(target) => {
                     match *target {
-                        Target::CodePtr(code_ptr) => jmp_ptr(cb, code_ptr),
+                        Target::CodePtr(code_ptr) | Target::SideExitPtr(code_ptr) => jmp_ptr(cb, code_ptr),
                         Target::Label(label_idx) => jmp_label(cb, label_idx),
                         _ => unreachable!()
                     }
@@ -573,7 +573,7 @@ impl Assembler
 
                 Insn::Je(target) => {
                     match *target {
-                        Target::CodePtr(code_ptr) => je_ptr(cb, code_ptr),
+                        Target::CodePtr(code_ptr) | Target::SideExitPtr(code_ptr) => je_ptr(cb, code_ptr),
                         Target::Label(label_idx) => je_label(cb, label_idx),
                         _ => unreachable!()
                     }
@@ -581,7 +581,7 @@ impl Assembler
 
                 Insn::Jne(target) => {
                     match *target {
-                        Target::CodePtr(code_ptr) => jne_ptr(cb, code_ptr),
+                        Target::CodePtr(code_ptr) | Target::SideExitPtr(code_ptr) => jne_ptr(cb, code_ptr),
                         Target::Label(label_idx) => jne_label(cb, label_idx),
                         _ => unreachable!()
                     }
@@ -589,7 +589,7 @@ impl Assembler
 
                 Insn::Jl(target) => {
                     match *target {
-                        Target::CodePtr(code_ptr) => jl_ptr(cb, code_ptr),
+                        Target::CodePtr(code_ptr) | Target::SideExitPtr(code_ptr) => jl_ptr(cb, code_ptr),
                         Target::Label(label_idx) => jl_label(cb, label_idx),
                         _ => unreachable!()
                     }
@@ -597,7 +597,7 @@ impl Assembler
 
                 Insn::Jbe(target) => {
                     match *target {
-                        Target::CodePtr(code_ptr) => jbe_ptr(cb, code_ptr),
+                        Target::CodePtr(code_ptr) | Target::SideExitPtr(code_ptr) => jbe_ptr(cb, code_ptr),
                         Target::Label(label_idx) => jbe_label(cb, label_idx),
                         _ => unreachable!()
                     }
@@ -605,7 +605,7 @@ impl Assembler
 
                 Insn::Jz(target) => {
                     match *target {
-                        Target::CodePtr(code_ptr) => jz_ptr(cb, code_ptr),
+                        Target::CodePtr(code_ptr) | Target::SideExitPtr(code_ptr) => jz_ptr(cb, code_ptr),
                         Target::Label(label_idx) => jz_label(cb, label_idx),
                         _ => unreachable!()
                     }
@@ -613,7 +613,7 @@ impl Assembler
 
                 Insn::Jnz(target) => {
                     match *target {
-                        Target::CodePtr(code_ptr) => jnz_ptr(cb, code_ptr),
+                        Target::CodePtr(code_ptr) | Target::SideExitPtr(code_ptr) => jnz_ptr(cb, code_ptr),
                         Target::Label(label_idx) => jnz_label(cb, label_idx),
                         _ => unreachable!()
                     }
@@ -621,7 +621,7 @@ impl Assembler
 
                 Insn::Jo(target) => {
                     match *target {
-                        Target::CodePtr(code_ptr) => jo_ptr(cb, code_ptr),
+                        Target::CodePtr(code_ptr) | Target::SideExitPtr(code_ptr) => jo_ptr(cb, code_ptr),
                         Target::Label(label_idx) => jo_label(cb, label_idx),
                         _ => unreachable!()
                     }

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -2195,7 +2195,7 @@ pub fn invalidate_block_version(blockref: &BlockRef) {
             cb.set_write_ptr(block_start);
 
             let mut asm = Assembler::new();
-            asm.jmp(block_entry_exit.into());
+            asm.jmp(block_entry_exit.as_side_exit());
             cb.set_dropped_bytes(false);
             asm.compile(&mut cb);
 

--- a/yjit/src/invariants.rs
+++ b/yjit/src/invariants.rs
@@ -503,7 +503,7 @@ pub extern "C" fn rb_yjit_tracing_invalidate_all() {
             assert!(last_patch_end <= patch.inline_patch_pos.raw_ptr(), "patches should not overlap");
 
             let mut asm = crate::backend::ir::Assembler::new();
-            asm.jmp(patch.outlined_target_pos.into());
+            asm.jmp(patch.outlined_target_pos.as_side_exit());
 
             cb.set_write_ptr(patch.inline_patch_pos);
             cb.set_dropped_bytes(false);

--- a/yjit/src/virtualmem.rs
+++ b/yjit/src/virtualmem.rs
@@ -3,7 +3,7 @@
 // usize->pointer casts is viable. It seems like a lot of work for us to participate for not much
 // benefit.
 
-use crate::utils::IntoUsize;
+use crate::{utils::IntoUsize, backend::ir::Target};
 
 #[cfg(not(test))]
 pub type VirtualMem = VirtualMemory<sys::SystemAllocator>;
@@ -61,6 +61,12 @@ pub trait Allocator {
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Debug)]
 #[repr(C, packed)]
 pub struct CodePtr(*const u8);
+
+impl CodePtr {
+    pub fn as_side_exit(self) -> Target {
+        Target::SideExitPtr(self)
+    }
+}
 
 /// Errors that can happen when writing to [VirtualMemory]
 #[derive(Debug, PartialEq)]


### PR DESCRIPTION
This PR revisits the idea I shared at https://github.com/ruby/ruby/pull/6757#issuecomment-1319371923.

Jumps to side exits are non-patchable, so we don't need to generate nops for these cases.

## Benchmark
A release build on Arm becomes 1.02x faster.

```
before: ruby 3.2.0dev (2022-11-21T18:52:44Z master cf05c202ce) +YJIT [arm64-darwin22]
after: ruby 3.2.0dev (2022-11-22T19:09:31Z yjit-side-exit-ptr e513fe1ad3) +YJIT [arm64-darwin22]

----------  -----------  ----------  ----------  ----------  ------------  -------------
bench       before (ms)  stddev (%)  after (ms)  stddev (%)  before/after  after 1st itr
railsbench  710.1        2.4         693.6       1.1         1.02          0.99
----------  -----------  ----------  ----------  ----------  ------------  -------------
```

<details>

```
$ ./run_benchmarks.rb railsbench -e "before::/opt/rubies/yjit-release-before-$arch/bin/ruby --yjit" -e "after::/opt/rubies/yjit-release-after-$arch/bin/ruby --yjit"
Running benchmark "railsbench" (1/1)
/opt/rubies/yjit-release-before-arm64/bin/ruby --yjit -I ./harness benchmarks/railsbench/benchmark.rb
ruby 3.2.0dev (2022-11-21T18:52:44Z master cf05c202ce) +YJIT [arm64-darwin22]
Command: bundle check 2> /dev/null || bundle install
The Gemfile's dependencies are satisfied
Command: bin/rails db:migrate db:seed
Deleted all 100 posts
Creating 100 posts....................................................................................................
itr #1: 857ms
itr #2: 730ms
itr #3: 704ms
itr #4: 739ms
itr #5: 723ms
itr #6: 715ms
itr #7: 719ms
itr #8: 699ms
itr #9: 680ms
itr #10: 719ms
itr #11: 698ms
itr #12: 699ms
itr #13: 706ms
itr #14: 718ms
itr #15: 694ms
itr #16: 727ms
itr #17: 705ms
itr #18: 697ms
itr #19: 686ms
itr #20: 715ms
itr #21: 740ms
itr #22: 703ms
itr #23: 694ms
itr #24: 731ms
itr #25: 696ms
Average of last 10, non-warmup iters: 710ms
Running benchmark "railsbench" (1/1)
/opt/rubies/yjit-release-after-arm64/bin/ruby --yjit -I ./harness benchmarks/railsbench/benchmark.rb
ruby 3.2.0dev (2022-11-22T19:09:31Z yjit-side-exit-ptr e513fe1ad3) +YJIT [arm64-darwin22]
Command: bundle check 2> /dev/null || bundle install
The Gemfile's dependencies are satisfied
Command: bin/rails db:migrate db:seed
Deleted all 100 posts
Creating 100 posts....................................................................................................
itr #1: 864ms
itr #2: 706ms
itr #3: 688ms
itr #4: 696ms
itr #5: 690ms
itr #6: 687ms
itr #7: 710ms
itr #8: 706ms
itr #9: 687ms
itr #10: 686ms
itr #11: 685ms
itr #12: 694ms
itr #13: 686ms
itr #14: 685ms
itr #15: 692ms
itr #16: 705ms
itr #17: 685ms
itr #18: 691ms
itr #19: 688ms
itr #20: 687ms
itr #21: 689ms
itr #22: 705ms
itr #23: 704ms
itr #24: 691ms
itr #25: 686ms
Average of last 10, non-warmup iters: 693ms
Total time spent benchmarking: 41s

before: ruby 3.2.0dev (2022-11-21T18:52:44Z master cf05c202ce) +YJIT [arm64-darwin22]
after: ruby 3.2.0dev (2022-11-22T19:09:31Z yjit-side-exit-ptr e513fe1ad3) +YJIT [arm64-darwin22]
end_time: 2022-11-22 11:12:18 PST (-0800)

----------  -----------  ----------  ----------  ----------  ------------  -------------
bench       before (ms)  stddev (%)  after (ms)  stddev (%)  before/after  after 1st itr
railsbench  710.1        2.4         693.6       1.1         1.02          0.99
----------  -----------  ----------  ----------  ----------  ------------  -------------
Legend:
- before/after: ratio of before/after time. Higher is better for after. Above 1 represents a speedup.
- after 1st itr: ratio of before/after time for the first benchmarking iteration.
```

</details>

## Code Size
`inline_code_size` is decreased by 8% with a release build on Arm.

### Before
```
inline_code_size:         4795980
outlined_code_size:       4794088
freed_code_size:                0
code_region_size:         9601024
```

### After
```
inline_code_size:         4415324
outlined_code_size:       4411532
freed_code_size:                0
code_region_size:         8830976
```