### PR TITLE
Expose need_major_gc via GC.latest_gc_info

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -10955,7 +10955,7 @@ gc_count(rb_execution_context_t *ec, VALUE self)
 static VALUE
 gc_info_decode(rb_objspace_t *objspace, const VALUE hash_or_key, const unsigned int orig_flags)
 {
-    static VALUE sym_major_by = Qnil, sym_gc_by, sym_immediate_sweep, sym_have_finalizer, sym_state;
+    static VALUE sym_major_by = Qnil, sym_gc_by, sym_immediate_sweep, sym_have_finalizer, sym_state, sym_need_major_by;
     static VALUE sym_nofree, sym_oldgen, sym_shady, sym_force, sym_stress;
 #if RGENGC_ESTIMATE_OLDMALLOC
     static VALUE sym_oldmalloc;
@@ -10963,7 +10963,7 @@ gc_info_decode(rb_objspace_t *objspace, const VALUE hash_or_key, const unsigned 
     static VALUE sym_newobj, sym_malloc, sym_method, sym_capi;
     static VALUE sym_none, sym_marking, sym_sweeping;
     VALUE hash = Qnil, key = Qnil;
-    VALUE major_by;
+    VALUE major_by, need_major_by;
     unsigned int flags = orig_flags ? orig_flags : objspace->profile.latest_gc_info;
 
     if (SYMBOL_P(hash_or_key)) {
@@ -10983,6 +10983,7 @@ gc_info_decode(rb_objspace_t *objspace, const VALUE hash_or_key, const unsigned 
         S(immediate_sweep);
         S(have_finalizer);
         S(state);
+        S(need_major_by);
 
         S(stress);
         S(nofree);
@@ -11019,6 +11020,20 @@ gc_info_decode(rb_objspace_t *objspace, const VALUE hash_or_key, const unsigned 
 #endif
       Qnil;
     SET(major_by, major_by);
+
+    if (orig_flags == 0) { /* set need_major_by only if flags not set explicitly */
+        unsigned int need_major_flags = objspace->rgengc.need_major_gc;
+        need_major_by =
+            (need_major_flags & GPR_FLAG_MAJOR_BY_NOFREE) ? sym_nofree :
+            (need_major_flags & GPR_FLAG_MAJOR_BY_OLDGEN) ? sym_oldgen :
+            (need_major_flags & GPR_FLAG_MAJOR_BY_SHADY)  ? sym_shady :
+            (need_major_flags & GPR_FLAG_MAJOR_BY_FORCE)  ? sym_force :
+#if RGENGC_ESTIMATE_OLDMALLOC
+            (need_major_flags & GPR_FLAG_MAJOR_BY_OLDMALLOC) ? sym_oldmalloc :
+#endif
+            Qnil;
+        SET(need_major_by, need_major_by);
+    }
 
     SET(gc_by,
         (flags & GPR_FLAG_NEWOBJ) ? sym_newobj :


### PR DESCRIPTION
We trigger GC out-of-band to reduce latency impact on synchronous request processing. It’s not perfect, but it works. One thing we _really_ want to avoid is major GC during request processing - so we don’t want to start request processing in a state where `need_major_gc` is set. If there is a risk of major GC, we prefer to run it out-of-band, where it doesn't matter for request latency. 

Unfortunately, this state is currently not exposed - so we can’t know whether the next GC is set to be major or not. As a workaround, we trigger minor GC twice in a row - if a major GC threshold is hit during the first GC, the second GC is upgraded to major and there is no immediate risk of another major GC. This mostly works, but it's not great and it's not efficient (the second GC is not cheap and it's unnecessary in most cases); this PR makes it possible to do that in a better way by exposing `need_major_gc`.

It may seem strange to expose it under `GC.latest_gc_info` but I think it’s a reasonable place because the decision was made during the latest GC.