### PR TITLE
YJIT: Use NonNull pointer for CodePtr

### DIFF
--- a/yjit/src/asm/mod.rs
+++ b/yjit/src/asm/mod.rs
@@ -636,12 +636,13 @@ impl CodeBlock {
 impl CodeBlock {
     /// Stubbed CodeBlock for testing. Can't execute generated code.
     pub fn new_dummy(mem_size: usize) -> Self {
+        use std::ptr::NonNull;
         use crate::virtualmem::*;
         use crate::virtualmem::tests::TestingAllocator;
 
         let alloc = TestingAllocator::new(mem_size);
         let mem_start: *const u8 = alloc.mem_start();
-        let virt_mem = VirtualMem::new(alloc, 1, mem_start as *mut u8, mem_size);
+        let virt_mem = VirtualMem::new(alloc, 1, NonNull::new(mem_start as *mut u8).unwrap(), mem_size);
 
         Self::new(Rc::new(RefCell::new(virt_mem)), 16 * 1024, false)
     }

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -6781,11 +6781,12 @@ impl CodegenGlobals {
             assert_eq!(code_page_size % page_size.as_usize(), 0, "code_page_size was not page-aligned");
 
             use crate::virtualmem::*;
+            use std::ptr::NonNull;
 
             let mem_block = VirtualMem::new(
                 SystemAllocator {},
                 page_size,
-                virt_block,
+                NonNull::new(virt_block).unwrap(),
                 mem_size,
             );
             let mem_block = Rc::new(RefCell::new(mem_block));


### PR DESCRIPTION
Use `NonNull` inside `CodePtr` to reduce memory consumption, leveraging the following optimization:

> https://doc.rust-lang.org/stable/std/ptr/struct.NonNull.html
> Unlike *mut T, the pointer must always be non-null, even if the pointer is never dereferenced. This is so that enums may use this forbidden value as a discriminant – Option<NonNull<T>> has the same size as *mut T.

Also fixed a warning on `cargo test` with `MarkUnused`.

## Code Size
`yjit_alloc_size` is reduced from 17.8MB to 17.2MB.

### Before
```
code_region_size:         8830976
yjit_alloc_size:         17815913
```

### After
```
code_region_size:         8814592
yjit_alloc_size:         17228805
```