### PR TITLE
YJIT: Stop passing target1 to gen_return_branch

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -5067,8 +5067,8 @@ fn gen_send_iseq(
         ocb,
         return_block,
         &return_ctx,
-        Some(return_block),
-        Some(&return_ctx),
+        None,
+        None,
         gen_return_branch,
     );
 


### PR DESCRIPTION
`gen_return_branch` doesn't use `target1`. I got confused when I saw this code was passing the same thing to two targets.