### PR TITLE
 Inherit max_iv_count from superclass 

### DIFF
--- a/class.c
+++ b/class.c
@@ -326,7 +326,13 @@ rb_class_new(VALUE super)
 {
     Check_Type(super, T_CLASS);
     rb_check_inheritable(super);
-    return rb_class_boot(super);
+    VALUE klass = rb_class_boot(super);
+
+    if (super != rb_cObject && super != rb_cBasicObject) {
+        RCLASS_EXT(klass)->max_iv_count = RCLASS_EXT(super)->max_iv_count;
+    }
+
+    return klass;
 }
 
 VALUE

--- a/shape.c
+++ b/shape.c
@@ -7,6 +7,10 @@
 #include "internal/variable.h"
 #include <stdbool.h>
 
+#ifndef SHAPE_DEBUG
+#define SHAPE_DEBUG (VM_CHECK_MODE > 0)
+#endif
+
 static ID id_frozen;
 static ID id_t_object;
 static ID size_pool_edge_names[SIZE_POOL_COUNT];
@@ -339,7 +343,7 @@ rb_shape_rebuild_shape(rb_shape_t * initial_shape, rb_shape_t * dest_shape)
     return midway_shape;
 }
 
-#if VM_CHECK_MODE > 0
+#if SHAPE_DEBUG
 VALUE rb_cShape;
 
 /*
@@ -617,7 +621,7 @@ Init_default_shapes(void)
 void
 Init_shape(void)
 {
-#if VM_CHECK_MODE > 0
+#if SHAPE_DEBUG
     rb_cShape = rb_define_class_under(rb_cRubyVM, "Shape", rb_cObject);
     rb_undef_alloc_func(rb_cShape);
 


### PR DESCRIPTION
In https://github.com/ruby/ruby/commit/274870bd5434ab64ac3a3c9db9aa27d262c1d6d6 we gained the ability to make an educated guess at the max_iv_count of a class based on its initialize method 🎉. This PR makes subclasses inherit their super's max_iv_count, which makes the estimate work in cases that the subclass does not have an initialize method.

This may also pull in a max_iv_count we've learned from a parent class (ie from an instance growing). Though that feels like something we shouldn't count on, and it's more likely we'll use the estimate.

I made this ignore `rb_cObject` and `rb_cBasicObject`, just to avoid having a large single instance of those affecting every class in the application.

cc @jemmaissroff @tenderlove 