### PR TITLE
cmp_clamp arguments

### DIFF
--- a/compar.c
+++ b/compar.c
@@ -229,7 +229,7 @@ cmp_clamp(int argc, VALUE *argv, VALUE x)
         }
     }
     if (!NIL_P(min) && !NIL_P(max) && cmpint(min, max) > 0) {
-        rb_raise(rb_eArgError, "min argument must be smaller than max argument");
+        rb_raise(rb_eArgError, "min argument must be equal to or smaller than max argument");
     }
 
     if (!NIL_P(min)) {

--- a/compar.c
+++ b/compar.c
@@ -229,7 +229,7 @@ cmp_clamp(int argc, VALUE *argv, VALUE x)
         }
     }
     if (!NIL_P(min) && !NIL_P(max) && cmpint(min, max) > 0) {
-        rb_raise(rb_eArgError, "min argument must be equal to or smaller than max argument");
+        rb_raise(rb_eArgError, "min argument must be less than or equal to max argument");
     }
 
     if (!NIL_P(min)) {

--- a/test/ruby/test_comparable.rb
+++ b/test/ruby/test_comparable.rb
@@ -85,7 +85,7 @@ class TestComparable < Test::Unit::TestCase
     assert_equal(1, @o.clamp(1, 1))
     assert_equal(@o, @o.clamp(0, 0))
 
-    assert_raise_with_message(ArgumentError, 'min argument must be smaller than max argument') {
+    assert_raise_with_message(ArgumentError, 'min argument must be equal to or smaller than max argument') {
       @o.clamp(2, 1)
     }
   end
@@ -115,7 +115,7 @@ class TestComparable < Test::Unit::TestCase
     assert_raise_with_message(*exc) {@o.clamp(-1...0)}
     assert_raise_with_message(*exc) {@o.clamp(...2)}
 
-    assert_raise_with_message(ArgumentError, 'min argument must be smaller than max argument') {
+    assert_raise_with_message(ArgumentError, 'min argument must be equal to or smaller than max argument') {
       @o.clamp(2..1)
     }
   end

--- a/test/ruby/test_comparable.rb
+++ b/test/ruby/test_comparable.rb
@@ -85,7 +85,7 @@ class TestComparable < Test::Unit::TestCase
     assert_equal(1, @o.clamp(1, 1))
     assert_equal(@o, @o.clamp(0, 0))
 
-    assert_raise_with_message(ArgumentError, 'min argument must be equal to or smaller than max argument') {
+    assert_raise_with_message(ArgumentError, 'min argument must be less than or equal to max argument') {
       @o.clamp(2, 1)
     }
   end
@@ -115,7 +115,7 @@ class TestComparable < Test::Unit::TestCase
     assert_raise_with_message(*exc) {@o.clamp(-1...0)}
     assert_raise_with_message(*exc) {@o.clamp(...2)}
 
-    assert_raise_with_message(ArgumentError, 'min argument must be equal to or smaller than max argument') {
+    assert_raise_with_message(ArgumentError, 'min argument must be less than or equal to max argument') {
       @o.clamp(2..1)
     }
   end


### PR DESCRIPTION
If clamp receives min higher than max, it will raise an exception. The message says _min argument must be smaller than max argument_, but min can actually be equal to max too. This patch updates the message to be clearer.

```
[kandy@ ~]$ ruby -ve "0.clamp(1,0)"
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [x86_64-freebsd13.1]
-e:1:in `clamp': min argument must be smaller than max argument (ArgumentError)
        from -e:1:in `<main>'
[kandy@ ~]$ ruby -ve "0.clamp(0,0)"
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [x86_64-freebsd13.1]
```
