### PR TITLE
Avoid SystemStackError when splatting large arrays to cfuncs

### DIFF
--- a/test/ruby/test_call.rb
+++ b/test/ruby/test_call.rb
@@ -115,4 +115,88 @@ class TestCall < Test::Unit::TestCase
     ary = [1, 2, b]
     assert_equal([0, 1, 2, b], aaa(0, *ary, &ary.pop), bug16504)
   end
+
+  def test_call_cfunc_splat_large_array_bug_4040
+    a = 1380.times.to_a # Greater than VM_ARGC_STACK_MAX
+
+    assert_equal(a, [].push(*a))
+    assert_equal(a, [].push(a[0], *a[1..]))
+    assert_equal(a, [].push(a[0], a[1], *a[2..]))
+    assert_equal(a, [].push(*a[0..1], *a[2..]))
+    assert_equal(a, [].push(*a[...-1], a[-1]))
+    assert_equal(a, [].push(a[0], *a[1...-1], a[-1]))
+    assert_equal(a, [].push(a[0], a[1], *a[2...-1], a[-1]))
+    assert_equal(a, [].push(*a[0..1], *a[2...-1], a[-1]))
+    assert_equal(a, [].push(*a[...-2], a[-2], a[-1]))
+    assert_equal(a, [].push(a[0], *a[1...-2], a[-2], a[-1]))
+    assert_equal(a, [].push(a[0], a[1], *a[2...-2], a[-2], a[-1]))
+    assert_equal(a, [].push(*a[0..1], *a[2...-2], a[-2], a[-1]))
+
+    kw = {x: 1}
+    a_kw = a + [kw]
+
+    assert_equal(a_kw, [].push(*a, **kw))
+    assert_equal(a_kw, [].push(a[0], *a[1..], **kw))
+    assert_equal(a_kw, [].push(a[0], a[1], *a[2..], **kw))
+    assert_equal(a_kw, [].push(*a[0..1], *a[2..], **kw))
+    assert_equal(a_kw, [].push(*a[...-1], a[-1], **kw))
+    assert_equal(a_kw, [].push(a[0], *a[1...-1], a[-1], **kw))
+    assert_equal(a_kw, [].push(a[0], a[1], *a[2...-1], a[-1], **kw))
+    assert_equal(a_kw, [].push(*a[0..1], *a[2...-1], a[-1], **kw))
+    assert_equal(a_kw, [].push(*a[...-2], a[-2], a[-1], **kw))
+    assert_equal(a_kw, [].push(a[0], *a[1...-2], a[-2], a[-1], **kw))
+    assert_equal(a_kw, [].push(a[0], a[1], *a[2...-2], a[-2], a[-1], **kw))
+    assert_equal(a_kw, [].push(*a[0..1], *a[2...-2], a[-2], a[-1], **kw))
+
+    assert_equal(a_kw, [].push(*a, x: 1))
+    assert_equal(a_kw, [].push(a[0], *a[1..], x: 1))
+    assert_equal(a_kw, [].push(a[0], a[1], *a[2..], x: 1))
+    assert_equal(a_kw, [].push(*a[0..1], *a[2..], x: 1))
+    assert_equal(a_kw, [].push(*a[...-1], a[-1], x: 1))
+    assert_equal(a_kw, [].push(a[0], *a[1...-1], a[-1], x: 1))
+    assert_equal(a_kw, [].push(a[0], a[1], *a[2...-1], a[-1], x: 1))
+    assert_equal(a_kw, [].push(*a[0..1], *a[2...-1], a[-1], x: 1))
+    assert_equal(a_kw, [].push(*a[...-2], a[-2], a[-1], x: 1))
+    assert_equal(a_kw, [].push(a[0], *a[1...-2], a[-2], a[-1], x: 1))
+    assert_equal(a_kw, [].push(a[0], a[1], *a[2...-2], a[-2], a[-1], x: 1))
+    assert_equal(a_kw, [].push(*a[0..1], *a[2...-2], a[-2], a[-1], x: 1))
+
+    a_kw[-1][:y] = 2
+    kw = {y: 2}
+
+    assert_equal(a_kw, [].push(*a, x: 1, **kw))
+    assert_equal(a_kw, [].push(a[0], *a[1..], x: 1, **kw))
+    assert_equal(a_kw, [].push(a[0], a[1], *a[2..], x: 1, **kw))
+    assert_equal(a_kw, [].push(*a[0..1], *a[2..], x: 1, **kw))
+    assert_equal(a_kw, [].push(*a[...-1], a[-1], x: 1, **kw))
+    assert_equal(a_kw, [].push(a[0], *a[1...-1], a[-1], x: 1, **kw))
+    assert_equal(a_kw, [].push(a[0], a[1], *a[2...-1], a[-1], x: 1, **kw))
+    assert_equal(a_kw, [].push(*a[0..1], *a[2...-1], a[-1], x: 1, **kw))
+    assert_equal(a_kw, [].push(*a[...-2], a[-2], a[-1], x: 1, **kw))
+    assert_equal(a_kw, [].push(a[0], *a[1...-2], a[-2], a[-1], x: 1, **kw))
+    assert_equal(a_kw, [].push(a[0], a[1], *a[2...-2], a[-2], a[-1], x: 1, **kw))
+    assert_equal(a_kw, [].push(*a[0..1], *a[2...-2], a[-2], a[-1], x: 1, **kw))
+
+    kw = {}
+
+    assert_equal(a, [].push(*a, **kw))
+    assert_equal(a, [].push(a[0], *a[1..], **kw))
+    assert_equal(a, [].push(a[0], a[1], *a[2..], **kw))
+    assert_equal(a, [].push(*a[0..1], *a[2..], **kw))
+    assert_equal(a, [].push(*a[...-1], a[-1], **kw))
+    assert_equal(a, [].push(a[0], *a[1...-1], a[-1], **kw))
+    assert_equal(a, [].push(a[0], a[1], *a[2...-1], a[-1], **kw))
+    assert_equal(a, [].push(*a[0..1], *a[2...-1], a[-1], **kw))
+    assert_equal(a, [].push(*a[...-2], a[-2], a[-1], **kw))
+    assert_equal(a, [].push(a[0], *a[1...-2], a[-2], a[-1], **kw))
+    assert_equal(a, [].push(a[0], a[1], *a[2...-2], a[-2], a[-1], **kw))
+    assert_equal(a, [].push(*a[0..1], *a[2...-2], a[-2], a[-1], **kw))
+
+    a_kw = a + [Hash.ruby2_keywords_hash({})]
+    assert_equal(a, [].push(*a_kw))
+
+    # Single test with value that would cause SystemStackError.
+    # Not all tests use such a large array to reduce testing time.
+    assert_equal(1380888, [].push(*1380888.times.to_a).size)
+  end
 end

--- a/vm_core.h
+++ b/vm_core.h
@@ -298,6 +298,17 @@ struct rb_calling_info {
     int kw_splat;
 };
 
+/* Abuse rb_calling_info.kw_splat to hold heap argv flag for
+ * cfunc calls, to avoid performance decrease for other calls.
+ */
+#define RB_CFUNC_KWSPLAT 1
+#define RB_CFUNC_HEAP_ARGV 2
+#define RB_CFUNC_KWSPLAT_P(calling) ((calling)->kw_splat & RB_CFUNC_KWSPLAT)
+#define RB_CFUNC_HEAP_ARGV_P(calling) ((calling)->kw_splat & RB_CFUNC_HEAP_ARGV)
+#define RB_CFUNC_SET_HEAP_ARGV(calling) (calling)->kw_splat |= RB_CFUNC_HEAP_ARGV
+#define RB_CFUNC_SET_KWSPLAT(calling) (calling)->kw_splat |= RB_CFUNC_KWSPLAT
+#define RB_CFUNC_UNSET_KWSPLAT(calling) (calling)->kw_splat &= ~RB_CFUNC_KWSPLAT
+
 struct rb_execution_context_struct;
 
 #if 1
@@ -831,6 +842,13 @@ typedef struct rb_vm_struct {
 
 #ifndef VM_DEBUG_VERIFY_METHOD_CACHE
 #define VM_DEBUG_VERIFY_METHOD_CACHE (VMDEBUG != 0)
+#endif
+
+/* Cfunc calls with more than this many arguments when using a splat use a temporary
+ * array for argv.
+ */
+#ifndef VM_ARGC_STACK_MAX
+#define VM_ARGC_STACK_MAX 1024
 #endif
 
 struct rb_captured_block {


### PR DESCRIPTION
Instead of splatting a large array using separate arguments on the VM stack, store all arguments passed to the cfunc in a temporary hidden array, and pass the array's buffer as the argv for the cfunc.

Add heap_argv to struct rb_calling_info to flag calls where a temporary array is used for argument passing.

Only vm_call_cfunc_with_frame has the logic to extract argv from the single argument.  To ensure no other code uses this feature, add an allow_heap_argv argument to CALLER_SETUP_ARG and
vm_caller_setup_arg_splat, and only enable the code in vm_call_cfunc. If the SystemStackError issue occurs for other types of calls, the related call types could be updated to use the same approach.

Keep calling->argc at 1 when using the temporary array, to ensure it matches the arguments on the stack.  When calling the cfunc, get the actual argc from the size of the temporary array.

The limit for passing arguments on the VM stack is stored in VM_ARGC_STACK_MAX.  It's currently set to 1024, which is much lower than it actually needs to be to avoid SystemStackError in a normal process or thread.  However, fibers often have much smaller stacks, and the low limit may help avoid the issue there. It seems unlikely that there are many callsites with splats that result in passing more than 1024 arguments to C functions, so I think the current limit is fine, but I don't have a problem increasing it.

This also changes CALLER_SETUP_ARG to ignore an empty ruby2_keywords hash, instead of duplicating the empty hash just to have it be removed later by CALLER_REMOVE_EMPTY_KW_SPLAT.

Fixes [Bug #4040]