### PR TITLE
YJIT: Skip checking interrupt_mask

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -642,12 +642,10 @@ fn gen_check_ints(asm: &mut Assembler, side_exit: CodePtr) {
     // see RUBY_VM_CHECK_INTS(ec) macro
     asm.comment("RUBY_VM_CHECK_INTS(ec)");
 
-    let not_mask = asm.not(Opnd::mem(32, EC, RUBY_OFFSET_EC_INTERRUPT_MASK));
-
-    asm.test(
-        Opnd::mem(32, EC, RUBY_OFFSET_EC_INTERRUPT_FLAG),
-        not_mask,
-    );
+    // Not checking interrupt_mask since it's zero outside finalize_deferred_heap_pages,
+    // signal_exec, or rb_postponed_job_flush.
+    let interrupt_flag = asm.load(Opnd::mem(32, EC, RUBY_OFFSET_EC_INTERRUPT_FLAG));
+    asm.test(interrupt_flag, interrupt_flag);
 
     asm.jnz(Target::SideExitPtr(side_exit));
 }


### PR DESCRIPTION
`ec->interrupt_flag` seems to be not utilized in normal paths, so we could skip checking it, leaving the task to side exits.

`ec->interrupt_mask` and `ec->interrupt_flag` would be on the same cacheline, so I didn't observe a speed-up (or slowdown) on railsbench, but it reduces the code size by 2% without increasing the number of side exits.

## Code size on railsbench
### Before
```
inline_code_size:         2753638
outlined_code_size:       2753220
freed_code_size:                0
code_region_size:         5517312
```

### After
```
inline_code_size:         2705017
outlined_code_size:       2704737
freed_code_size:                0
code_region_size:         5419008
```