### PR TITLE
Remove ruby2_keywords related to args forwarding

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -1832,7 +1832,6 @@ iseq_set_arguments(rb_iseq_t *iseq, LINK_ANCHOR *const optargs, const NODE *cons
 
         EXPECT_NODE("iseq_set_arguments", node_args, NODE_ARGS, COMPILE_NG);
 
-        body->param.flags.ruby2_keywords = args->ruby2_keywords;
         body->param.lead_num = arg_size = (int)args->pre_args_num;
         if (body->param.lead_num > 0) body->param.flags.has_lead = TRUE;
         debugs("  - argc: %d\n", body->param.lead_num);

--- a/node.h
+++ b/node.h
@@ -462,7 +462,6 @@ struct rb_args_info {
 
     NODE *opt_args;
     unsigned int no_kwarg: 1;
-    unsigned int ruby2_keywords: 1;
     unsigned int forwarding: 1;
 
     VALUE imemo;

--- a/parse.y
+++ b/parse.y
@@ -12573,8 +12573,6 @@ new_args(struct parser_params *p, NODE *pre_args, NODE *opt_args, ID rest_arg, N
 
     args->opt_args       = opt_args;
 
-    args->ruby2_keywords = 0;
-
     p->ruby_sourceline = saved_line;
     nd_set_loc(tail, loc);
 


### PR DESCRIPTION
This was introduced by b609bdeb5307e280137b4b2838af0fe4e4b46f1c to suppress warnings. However these warngins were deleted by beae6cbf0fd8b6619e5212552de98022d4c4d4d4. Therefore these codes are not needed anymore.