### PR TITLE
Account for `Qnil` returned by `rb_class_superclass` in `struct_ivar_get`

### DIFF
--- a/struct.c
+++ b/struct.c
@@ -48,7 +48,7 @@ struct_ivar_get(VALUE c, ID id)
 
     for (;;) {
         c = rb_class_superclass(c);
-        if (c == 0 || c == rb_cStruct || c == rb_cData || c == Qnil)
+        if (c == rb_cStruct || c == rb_cData || !RTEST(c))
             return Qnil;
         RUBY_ASSERT(RB_TYPE_P(c, T_CLASS));
         ivar = rb_attr_get(c, id);

--- a/struct.c
+++ b/struct.c
@@ -48,7 +48,7 @@ struct_ivar_get(VALUE c, ID id)
 
     for (;;) {
         c = rb_class_superclass(c);
-        if (c == 0 || c == rb_cStruct || c == rb_cData)
+        if (c == 0 || c == rb_cStruct || c == rb_cData || c == Qnil)
             return Qnil;
         RUBY_ASSERT(RB_TYPE_P(c, T_CLASS));
         ivar = rb_attr_get(c, id);

--- a/test/ruby/test_marshal.rb
+++ b/test/ruby/test_marshal.rb
@@ -92,6 +92,14 @@ class TestMarshal < Test::Unit::TestCase
     TestMarshal.instance_eval { remove_const :StructInvalidMembers }
   end
 
+  def test_load_range_as_struct
+    assert_raise(TypeError, 'GH-6832') do
+      # Can be obtained with:
+      #  $ ruby -e 'Range = Struct.new(:a, :b, :c); p Marshal.dump(Range.new(nil, nil, nil))'
+      Marshal.load("\x04\bS:\nRange\b:\x06a0:\x06b0:\x06c0")
+    end
+  end
+
   class C
     def initialize(str)
       @str = str


### PR DESCRIPTION
👋  Recently found a crashing case  in `Marshal.load` on `ruby 3.2.0dev (2022-11-29T15:09:32Z master 3e4d1a1dd1)` with a coverage guided fuzzing harness I'm working on for cRuby. 

In commit https://github.com/ruby/ruby/commit/adc709adb8c7fbe83a20b7c9b554856c98346a4b we optimized ivar reads in `struct_ivar_get` by resolving super with `rb_class_superclass` instead of `RCLASS_SUPER`.

My understanding from debugging is that by replacing `RCLASS_SUPER` with `rb_class_superclass`, we added another possible case that needs to be accounted for in the following conditional given that `rb_class_superclass` seems to return `Qnil` instead of `0` when none is present.
https://github.com/ruby/ruby/blob/612b528c8a5376a46e185bc812b2b86799b87ade/struct.c#L49-L52

Without this change, `ruby 3.2.0dev (3e4d1a1dd1)` crashes with the attached sample and the following test (stacktrace below):
```
root@fuzzify-prototype:/fuzzify/clean_ruby_versions/ruby# cat test.rb

Marshal.load(File.binread("crash_1"))
```

The seg fault appears to be raised due to our attempt to dereference an offset on `0x4` (`Qnil`) on the `cmp` instruction. That coupled with the fact that this does not crash on `ruby-3.1.3` from my testing made this seem safe for the public issue tracker:
```
Program received signal SIGSEGV, Segmentation fault.
[----------------------------------registers-----------------------------------]
RAX: 0x4
[...]
RDI: 0x4
RBP: 0x4
RSP: 0x7fffffffe068 --> 0x555555719d1b (<rb_struct_s_keyword_init+91>:  mov    rbp,rax)
RIP: 0x55555563c590 (<rb_class_superclass>: cmp    QWORD PTR [rdi+0x10],0x0)
[...]
EFLAGS: 0x10246 (carry PARITY adjust ZERO sign trap INTERRUPT direction overflow)
[-------------------------------------code-------------------------------------]
   0x55555563c582 <class_or_module_required+18>:    xor    eax,eax
   0x55555563c584 <class_or_module_required+20>:    call   0x555555847fc0 <rb_raise>
   0x55555563c589:  nop    DWORD PTR [rax+0x0]
=> 0x55555563c590 <rb_class_superclass>:    cmp    QWORD PTR [rdi+0x10],0x0
```

With the proposed change applied I get the expected `TypeError` raised from Marshal:
```
root@fuzzify-prototype:/fuzzify/clean_ruby_versions/ruby# ./ruby test.rb
`RubyGems' were not loaded.
`error_highlight' was not loaded.
`did_you_mean' was not loaded.
`syntax_suggest' was not loaded.
<internal:marshal>:34:in `load': struct Range not compatible (:exclT: (TypeError)
 for :begin)
	from test.rb:1:in `<main>'
```

## sample

[marshal_input.tar.gz](https://github.com/ruby/ruby/files/10116998/marshal_input.tar.gz)



## stacktrace



```
root@fuzzify-prototype:/fuzzify/clean_ruby_versions/ruby# ./ruby test.rb
`RubyGems' were not loaded.
`error_highlight' was not loaded.
`did_you_mean' was not loaded.
`syntax_suggest' was not loaded.
<internal:marshal>:34: [BUG] Segmentation fault at 0x0000000000000014
ruby 3.2.0dev (2022-11-28T18:45:17Z master 612b528c8a) [x86_64-linux]

-- Control frame information -----------------------------------------------
c:0003 p:0006 s:0015 e:000014 METHOD <internal:marshal>:34
c:0002 p:0014 s:0007 E:001718 EVAL   test.rb:2 [FINISH]
c:0001 p:0000 s:0003 E:0014d0 DUMMY  [FINISH]

-- Ruby level backtrace information ----------------------------------------
test.rb:2:in `<main>'
<internal:marshal>:34:in `load'

-- Machine register context ------------------------------------------------
 RIP: 0x0000558959595550 RBP: 0x0000000000000004 RSP: 0x00007fff2edb26a8
 RAX: 0x0000000000000004 RBX: 0x0000000000000000 RCX: 0x000055895b573d50
 RDX: 0x00007fff2edb2670 RDI: 0x0000000000000004 RSI: 0x0000000000003921
  R8: 0x00007fff2edb2670  R9: 0x00007fff2edb2630 R10: 0x00005589597e6668
 R11: 0x0000000000000000 R12: 0x0000000000003921 R13: 0x0000000000000004
 R14: 0x00007f29118401e8 R15: 0x00007f29148eb720 EFL: 0x0000000000010246

-- C level backtrace information -------------------------------------------
/fuzzify/clean_ruby_versions/ruby/ruby(rb_print_backtrace+0x11) [0x5589596f2238] vm_dump.c:770
/fuzzify/clean_ruby_versions/ruby/ruby(rb_vm_bugreport) vm_dump.c:1065
/fuzzify/clean_ruby_versions/ruby/ruby(rb_bug_for_fatal_signal+0xe8) [0x55895979f848] error.c:819
/fuzzify/clean_ruby_versions/ruby/ruby(sigsegv+0x49) [0x5589596407d9] signal.c:964
/lib/x86_64-linux-gnu/libpthread.so.0(__restore_rt+0x0) [0x7f2914c26140] ../sysdeps/pthread/funlockfile.c:28
/fuzzify/clean_ruby_versions/ruby/ruby(RCLASS_SUPER+0x0) [0x558959595550] object.c:753
/fuzzify/clean_ruby_versions/ruby/ruby(rb_class_superclass) object.c:2064
/fuzzify/clean_ruby_versions/ruby/ruby(struct_ivar_get+0xe) [0x558959672cdb] struct.c:50
/fuzzify/clean_ruby_versions/ruby/ruby(struct_ivar_get) struct.c:41
/fuzzify/clean_ruby_versions/ruby/ruby(rb_struct_s_keyword_init) struct.c:64
/fuzzify/clean_ruby_versions/ruby/ruby(RB_TEST+0x0) [0x55895955e600] marshal.c:2080
/fuzzify/clean_ruby_versions/ruby/ruby(r_object_for) marshal.c:2080
/fuzzify/clean_ruby_versions/ruby/ruby(r_object0+0x0) [0x55895955d38c] marshal.c:1793
/fuzzify/clean_ruby_versions/ruby/ruby(r_object) marshal.c:2264
/fuzzify/clean_ruby_versions/ruby/ruby(r_object_for) marshal.c:2044
/fuzzify/clean_ruby_versions/ruby/ruby(r_object_for+0x67c) [0x55895955d8fc] marshal.c:1793
/fuzzify/clean_ruby_versions/ruby/ruby(r_object_for+0x67c) [0x55895955d8fc] marshal.c:1793
/fuzzify/clean_ruby_versions/ruby/ruby(r_object_for+0x67c) [0x55895955d8fc] marshal.c:1793
/fuzzify/clean_ruby_versions/ruby/ruby(r_object0+0x0) [0x55895955d38c] marshal.c:1793
/fuzzify/clean_ruby_versions/ruby/ruby(r_object) marshal.c:2264
/fuzzify/clean_ruby_versions/ruby/ruby(r_object_for) marshal.c:2044
/fuzzify/clean_ruby_versions/ruby/ruby(clear_load_arg+0x0) [0x55895955fcfa] marshal.c:1793
/fuzzify/clean_ruby_versions/ruby/ruby(rb_marshal_load_with_proc) marshal.c:2340
/fuzzify/clean_ruby_versions/ruby/ruby(invoke_bf+0xe) [0x5589596e780d] vm_insnhelper.c:6259
/fuzzify/clean_ruby_versions/ruby/ruby(vm_invoke_builtin_delegate) vm_insnhelper.c:6286
/fuzzify/clean_ruby_versions/ruby/ruby(vm_exec_core) insns.def:1512
/fuzzify/clean_ruby_versions/ruby/ruby(rb_vm_exec+0x17f) [0x5589596d56ef] vm.c:2353
/fuzzify/clean_ruby_versions/ruby/ruby(rb_ec_exec_node+0xa8) [0x5589594e17e8] eval.c:289
/fuzzify/clean_ruby_versions/ruby/ruby(ruby_run_node+0x49) [0x5589594e6709] eval.c:330
/fuzzify/clean_ruby_versions/ruby/ruby(rb_main+0x21) [0x5589594e15b3] ./main.c:38
/fuzzify/clean_ruby_versions/ruby/ruby(main) ./main.c:57
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xea) [0x7f2914a61d0a] ../csu/libc-start.c:308
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main) (null):0
[0x5589594e15fa]

[ ... ]
```
