### PR TITLE
YJIT: add new counters for deferred compilation and queued blocks

### DIFF
--- a/yjit.rb
+++ b/yjit.rb
@@ -261,6 +261,8 @@ module RubyVM::YJIT
       $stderr.puts "compiled_iseq_count:   " + ("%10d" % stats[:compiled_iseq_count])
       $stderr.puts "compiled_block_count:  " + ("%10d" % stats[:compiled_block_count])
       $stderr.puts "compiled_branch_count: " + ("%10d" % stats[:compiled_branch_count])
+      $stderr.puts "block_next_count:      " + ("%10d" % stats[:block_next_count])
+      $stderr.puts "defer_count:           " + ("%10d" % stats[:defer_count])
       $stderr.puts "freed_iseq_count:      " + ("%10d" % stats[:freed_iseq_count])
       $stderr.puts "invalidation_count:    " + ("%10d" % stats[:invalidation_count])
       $stderr.puts "constant_state_bumps:  " + ("%10d" % stats[:constant_state_bumps])

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -1487,6 +1487,8 @@ fn gen_block_series_body(
             _ => break
         };
 
+        incr_counter!(block_next_count);
+
         // Get id and context for the new block
         let requested_id = last_target.id;
         let requested_ctx = &last_target.ctx;
@@ -2085,6 +2087,8 @@ pub fn defer_compilation(
         gen_jump_branch(asm, dst_addr, None, BranchShape::Default);
     }
     asm.mark_branch_end(&branch_rc);
+
+    incr_counter!(defer_count);
 }
 
 // Remove all references to a block then free it.

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -269,6 +269,8 @@ make_counters! {
     compiled_block_count,
     compiled_branch_count,
     compilation_failure,
+    block_next_count,
+    defer_count,
     freed_iseq_count,
 
     exit_from_branch_stub,


### PR DESCRIPTION
I added these counters with the goal of understanding how often we compile multiple blocks in a row in `gen_block_series` and finding out how frequently we use `defer_compilation`.

Potentially, we could save some memory by reusing blocks when we do `defer_compilation` (seems likely).

We may also be able to merge blocks together when they are queued as multiple blocks in a row (not sure if this is a good/bad idea yet).

On railsbench:
```
compiled_iseq_count:         2686
compiled_block_count:       25202
compiled_branch_count:      43956
block_next_count:            8960
defer_count:                 7903
```