### PR TITLE
YJIT: Optimize rb_int_equal

### DIFF
--- a/test/ruby/test_yjit.rb
+++ b/test/ruby/test_yjit.rb
@@ -827,6 +827,22 @@ class TestYJIT < Test::Unit::TestCase
     RUBY
   end
 
+  def test_int_equal
+    assert_compiles(<<~'RUBY', exits: :any, result: [true, false, true, false, true, false, true, false])
+      def eq(a, b)
+        a == b
+      end
+
+      def eqq(a, b)
+        a === b
+      end
+
+      big1 = 2 ** 65
+      big2 = big1 + 1
+      [eq(1, 1), eq(1, 2), eq(big1, big1), eq(big1, big2), eqq(1, 1), eqq(1, 2), eqq(big1, big1), eqq(big1, big2)]
+    RUBY
+  end
+
   def test_code_gc
     assert_compiles(code_gc_helpers + <<~'RUBY', exits: :any, result: :ok)
       return :not_paged unless add_pages(100) # prepare freeable pages


### PR DESCRIPTION
This optimizes `mail` bench well since it has a large case-when table with integers. I also attached railsbench results:

```
before: ruby 3.2.0dev (2022-11-30T19:09:10Z master d98d84b75d) +YJIT [arm64-darwin22]
after: ruby 3.2.0dev (2022-11-30T19:57:34Z yjit-int-equal bd8c063e18) +YJIT [arm64-darwin22]

----------  -----------  ----------  ----------  ----------  ------------  -------------
bench       before (ms)  stddev (%)  after (ms)  stddev (%)  before/after  after 1st itr
mail        72.8         1.1         64.6        3.4         1.13          0.97
railsbench  707.0        3.1         694.2       1.4         1.02          1.02
----------  -----------  ----------  ----------  ----------  ------------  -------------
```

<details>

```
$ ./run_benchmarks.rb railsbench mail -e "before::/opt/rubies/yjit-release-before-$arch/bin/ruby --yjit" -e "after::/opt/rubies/yjit-release-after-$arch/bin/ruby --yjit"
Running benchmark "mail" (1/2)
/opt/rubies/yjit-release-before-arm64/bin/ruby --yjit -I ./harness benchmarks/mail/benchmark.rb
ruby 3.2.0dev (2022-11-30T19:09:10Z master d98d84b75d) +YJIT [arm64-darwin22]
Command: bundle check 2> /dev/null || bundle install
The Gemfile's dependencies are satisfied
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
itr #1: 212ms
itr #2: 71ms
itr #3: 71ms
itr #4: 71ms
itr #5: 71ms
itr #6: 71ms
itr #7: 74ms
itr #8: 72ms
itr #9: 71ms
itr #10: 72ms
itr #11: 71ms
itr #12: 71ms
itr #13: 71ms
itr #14: 71ms
itr #15: 71ms
itr #16: 71ms
itr #17: 71ms
itr #18: 72ms
itr #19: 71ms
itr #20: 71ms
itr #21: 71ms
itr #22: 71ms
itr #23: 71ms
itr #24: 72ms
itr #25: 71ms
itr #26: 74ms
itr #27: 71ms
itr #28: 71ms
itr #29: 71ms
itr #30: 74ms
itr #31: 74ms
itr #32: 73ms
itr #33: 73ms
itr #34: 73ms
itr #35: 72ms
itr #36: 72ms
itr #37: 72ms
itr #38: 72ms
itr #39: 72ms
itr #40: 72ms
itr #41: 72ms
itr #42: 72ms
itr #43: 72ms
itr #44: 72ms
itr #45: 72ms
itr #46: 72ms
itr #47: 72ms
itr #48: 72ms
itr #49: 72ms
itr #50: 72ms
itr #51: 72ms
itr #52: 73ms
itr #53: 75ms
itr #54: 73ms
itr #55: 73ms
itr #56: 72ms
itr #57: 72ms
itr #58: 72ms
itr #59: 72ms
itr #60: 72ms
itr #61: 72ms
itr #62: 72ms
itr #63: 72ms
itr #64: 72ms
itr #65: 72ms
itr #66: 72ms
itr #67: 72ms
itr #68: 72ms
itr #69: 73ms
itr #70: 72ms
itr #71: 72ms
itr #72: 72ms
itr #73: 72ms
itr #74: 72ms
itr #75: 72ms
itr #76: 72ms
itr #77: 72ms
itr #78: 72ms
itr #79: 72ms
itr #80: 72ms
itr #81: 75ms
itr #82: 74ms
itr #83: 72ms
itr #84: 72ms
itr #85: 72ms
itr #86: 73ms
itr #87: 72ms
itr #88: 72ms
itr #89: 72ms
itr #90: 72ms
itr #91: 72ms
itr #92: 72ms
itr #93: 73ms
itr #94: 72ms
itr #95: 72ms
itr #96: 72ms
itr #97: 72ms
itr #98: 72ms
itr #99: 72ms
itr #100: 73ms
itr #101: 73ms
itr #102: 73ms
itr #103: 72ms
itr #104: 72ms
itr #105: 72ms
itr #106: 73ms
itr #107: 73ms
itr #108: 76ms
itr #109: 73ms
itr #110: 72ms
itr #111: 73ms
itr #112: 72ms
itr #113: 72ms
itr #114: 72ms
itr #115: 72ms
itr #116: 72ms
itr #117: 72ms
itr #118: 72ms
itr #119: 72ms
itr #120: 73ms
itr #121: 72ms
itr #122: 72ms
itr #123: 72ms
itr #124: 72ms
itr #125: 72ms
itr #126: 72ms
itr #127: 72ms
itr #128: 72ms
itr #129: 72ms
itr #130: 72ms
itr #131: 72ms
itr #132: 72ms
itr #133: 72ms
itr #134: 72ms
itr #135: 72ms
itr #136: 75ms
Average of last 121, non-warmup iters: 72ms
Running benchmark "railsbench" (2/2)
/opt/rubies/yjit-release-before-arm64/bin/ruby --yjit -I ./harness benchmarks/railsbench/benchmark.rb
ruby 3.2.0dev (2022-11-30T19:09:10Z master d98d84b75d) +YJIT [arm64-darwin22]
Command: bundle check 2> /dev/null || bundle install
The Gemfile's dependencies are satisfied
Command: bin/rails db:migrate db:seed
Using 100 posts in the database
itr #1: 881ms
itr #2: 705ms
itr #3: 689ms
itr #4: 700ms
itr #5: 718ms
itr #6: 706ms
itr #7: 719ms
itr #8: 693ms
itr #9: 689ms
itr #10: 702ms
itr #11: 710ms
itr #12: 709ms
itr #13: 692ms
itr #14: 689ms
itr #15: 688ms
itr #16: 717ms
itr #17: 687ms
itr #18: 693ms
itr #19: 691ms
itr #20: 687ms
itr #21: 697ms
itr #22: 687ms
itr #23: 729ms
itr #24: 754ms
itr #25: 723ms
Average of last 10, non-warmup iters: 706ms
Running benchmark "mail" (1/2)
/opt/rubies/yjit-release-after-arm64/bin/ruby --yjit -I ./harness benchmarks/mail/benchmark.rb
ruby 3.2.0dev (2022-11-30T19:57:34Z yjit-int-equal bd8c063e18) +YJIT [arm64-darwin22]
Command: bundle check 2> /dev/null || bundle install
The Gemfile's dependencies are satisfied
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
itr #1: 218ms
itr #2: 73ms
itr #3: 71ms
itr #4: 69ms
itr #5: 64ms
itr #6: 67ms
itr #7: 64ms
itr #8: 67ms
itr #9: 64ms
itr #10: 65ms
itr #11: 67ms
itr #12: 67ms
itr #13: 65ms
itr #14: 64ms
itr #15: 64ms
itr #16: 66ms
itr #17: 65ms
itr #18: 67ms
itr #19: 64ms
itr #20: 64ms
itr #21: 64ms
itr #22: 64ms
itr #23: 64ms
itr #24: 64ms
itr #25: 65ms
itr #26: 64ms
itr #27: 64ms
itr #28: 64ms
itr #29: 64ms
itr #30: 64ms
itr #31: 64ms
itr #32: 64ms
itr #33: 68ms
itr #34: 75ms
itr #35: 75ms
itr #36: 70ms
itr #37: 71ms
itr #38: 70ms
itr #39: 72ms
itr #40: 69ms
itr #41: 65ms
itr #42: 65ms
itr #43: 65ms
itr #44: 65ms
itr #45: 63ms
itr #46: 65ms
itr #47: 68ms
itr #48: 66ms
itr #49: 64ms
itr #50: 63ms
itr #51: 64ms
itr #52: 63ms
itr #53: 63ms
itr #54: 64ms
itr #55: 64ms
itr #56: 63ms
itr #57: 63ms
itr #58: 63ms
itr #59: 63ms
itr #60: 63ms
itr #61: 63ms
itr #62: 63ms
itr #63: 63ms
itr #64: 64ms
itr #65: 64ms
itr #66: 63ms
itr #67: 64ms
itr #68: 63ms
itr #69: 63ms
itr #70: 63ms
itr #71: 63ms
itr #72: 63ms
itr #73: 63ms
itr #74: 63ms
itr #75: 63ms
itr #76: 64ms
itr #77: 63ms
itr #78: 63ms
itr #79: 63ms
itr #80: 64ms
itr #81: 63ms
itr #82: 66ms
itr #83: 64ms
itr #84: 65ms
itr #85: 65ms
itr #86: 65ms
itr #87: 64ms
itr #88: 68ms
itr #89: 65ms
itr #90: 63ms
itr #91: 63ms
itr #92: 66ms
itr #93: 63ms
itr #94: 64ms
itr #95: 63ms
itr #96: 66ms
itr #97: 67ms
itr #98: 67ms
itr #99: 63ms
itr #100: 63ms
itr #101: 63ms
itr #102: 63ms
itr #103: 63ms
itr #104: 63ms
itr #105: 63ms
itr #106: 63ms
itr #107: 63ms
itr #108: 63ms
itr #109: 63ms
itr #110: 63ms
itr #111: 63ms
itr #112: 63ms
itr #113: 63ms
itr #114: 63ms
itr #115: 63ms
itr #116: 63ms
itr #117: 63ms
itr #118: 63ms
itr #119: 63ms
itr #120: 63ms
itr #121: 63ms
itr #122: 63ms
itr #123: 63ms
itr #124: 63ms
itr #125: 63ms
itr #126: 63ms
itr #127: 63ms
itr #128: 63ms
itr #129: 63ms
itr #130: 63ms
itr #131: 63ms
itr #132: 63ms
itr #133: 63ms
itr #134: 63ms
itr #135: 63ms
itr #136: 63ms
itr #137: 63ms
itr #138: 63ms
itr #139: 63ms
itr #140: 63ms
itr #141: 63ms
itr #142: 63ms
itr #143: 63ms
itr #144: 63ms
itr #145: 63ms
itr #146: 63ms
itr #147: 63ms
itr #148: 63ms
itr #149: 63ms
itr #150: 63ms
itr #151: 63ms
itr #152: 63ms
Average of last 137, non-warmup iters: 64ms
Running benchmark "railsbench" (2/2)
/opt/rubies/yjit-release-after-arm64/bin/ruby --yjit -I ./harness benchmarks/railsbench/benchmark.rb
ruby 3.2.0dev (2022-11-30T19:57:34Z yjit-int-equal bd8c063e18) +YJIT [arm64-darwin22]
Command: bundle check 2> /dev/null || bundle install
The Gemfile's dependencies are satisfied
Command: bin/rails db:migrate db:seed
Using 100 posts in the database
itr #1: 867ms
itr #2: 700ms
itr #3: 714ms
itr #4: 728ms
itr #5: 733ms
itr #6: 700ms
itr #7: 690ms
itr #8: 710ms
itr #9: 691ms
itr #10: 702ms
itr #11: 713ms
itr #12: 691ms
itr #13: 715ms
itr #14: 689ms
itr #15: 708ms
itr #16: 693ms
itr #17: 685ms
itr #18: 685ms
itr #19: 705ms
itr #20: 704ms
itr #21: 708ms
itr #22: 705ms
itr #23: 684ms
itr #24: 685ms
itr #25: 683ms
Average of last 10, non-warmup iters: 694ms
Total time spent benchmarking: 63s

before: ruby 3.2.0dev (2022-11-30T19:09:10Z master d98d84b75d) +YJIT [arm64-darwin22]
after: ruby 3.2.0dev (2022-11-30T19:57:34Z yjit-int-equal bd8c063e18) +YJIT [arm64-darwin22]

----------  -----------  ----------  ----------  ----------  ------------  -------------
bench       before (ms)  stddev (%)  after (ms)  stddev (%)  before/after  after 1st itr
mail        72.8         1.1         64.6        3.4         1.13          0.97
railsbench  707.0        3.1         694.2       1.4         1.02          1.02
----------  -----------  ----------  ----------  ----------  ------------  -------------
Legend:
- before/after: ratio of before/after time. Higher is better for after. Above 1 represents a speedup.
- after 1st itr: ratio of before/after time for the first benchmarking iteration.
```

</details>