### PR TITLE
YJIT: Reorder branches for Fixnum opt_case_dispatch

### DIFF
--- a/test/ruby/test_yjit.rb
+++ b/test/ruby/test_yjit.rb
@@ -843,6 +843,23 @@ class TestYJIT < Test::Unit::TestCase
     RUBY
   end
 
+  def test_opt_case_dispatch
+    assert_compiles(<<~'RUBY', exits: :any, result: [:"1", "2", 3])
+      def case_dispatch(val)
+        case val
+        when 1
+          :"#{val}"
+        when 2
+          "#{val}"
+        else
+          val
+        end
+      end
+
+      [case_dispatch(1), case_dispatch(2), case_dispatch(3)]
+    RUBY
+  end
+
   def test_code_gc
     assert_compiles(code_gc_helpers + <<~'RUBY', exits: :any, result: :ok)
       return :not_paged unless add_pages(100) # prepare freeable pages

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -105,6 +105,7 @@ fn main() {
         .allowlist_function("rb_hash_aset")
         .allowlist_function("rb_hash_aref")
         .allowlist_function("rb_hash_bulk_insert")
+        .allowlist_function("rb_hash_stlike_lookup")
 
         // From include/ruby/internal/intern/array.h
         .allowlist_function("rb_ary_new_capa")

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -3154,7 +3154,7 @@ fn gen_opt_case_dispatch(
     // Supporting only Fixnum for now so that the implementation can be an equality check.
     let key_opnd = ctx.stack_pop(1);
     let comptime_key = jit_peek_at_stack(jit, ctx, 0);
-    if comptime_key.fixnum_p() {
+    if comptime_key.fixnum_p() && comptime_key.0 <= u32::MAX.as_usize() {
         if !assume_bop_not_redefined(jit, ocb, INTEGER_REDEFINED_OP_FLAG, BOP_EQQ) {
             return CantCompile;
         }

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -1895,6 +1895,9 @@ pub const SEND_MAX_DEPTH: i32 = 5;
 // up to 20 different methods for send
 pub const SEND_MAX_CHAIN_DEPTH: i32 = 20;
 
+// up to 20 different offsets for case-when
+pub const CASE_WHEN_MAX_DEPTH: i32 = 20;
+
 // Codegen for setting an instance variable.
 // Preconditions:
 //   - receiver is in REG0
@@ -3126,10 +3129,10 @@ fn gen_opt_regexpmatch2(
 }
 
 fn gen_opt_case_dispatch(
-    _jit: &mut JITState,
+    jit: &mut JITState,
     ctx: &mut Context,
-    _asm: &mut Assembler,
-    _ocb: &mut OutlinedCb,
+    asm: &mut Assembler,
+    ocb: &mut OutlinedCb,
 ) -> CodegenStatus {
     // Normally this instruction would lookup the key in a hash and jump to an
     // offset based on that.
@@ -3138,10 +3141,54 @@ fn gen_opt_case_dispatch(
     // We'd hope that our jitted code will be sufficiently fast without the
     // hash lookup, at least for small hashes, but it's worth revisiting this
     // assumption in the future.
+    if !jit_at_current_insn(jit) {
+        defer_compilation(jit, ctx, asm, ocb);
+        return EndBlock;
+    }
+    let starting_context = *ctx;
 
-    ctx.stack_pop(1);
+    let case_hash = jit_get_arg(jit, 0);
+    let else_offset = jit_get_arg(jit, 1).as_u32();
 
-    KeepCompiling // continue with the next instruction
+    // Try to reorder case/else branches so that ones that are actually used come first.
+    // Supporting only Fixnum for now so that the implementation can be an equality check.
+    let key_opnd = ctx.stack_pop(1);
+    let comptime_key = jit_peek_at_stack(jit, ctx, 0);
+    if comptime_key.fixnum_p() {
+        if !assume_bop_not_redefined(jit, ocb, INTEGER_REDEFINED_OP_FLAG, BOP_EQQ) {
+            return CantCompile;
+        }
+
+        // Check if the key is the same value
+        asm.cmp(key_opnd, comptime_key.into());
+        let side_exit = get_side_exit(jit, ocb, &starting_context);
+        jit_chain_guard(
+            JCC_JNE,
+            jit,
+            &starting_context,
+            asm,
+            ocb,
+            CASE_WHEN_MAX_DEPTH as i32,
+            side_exit,
+        );
+
+        // Get the offset for the compile-time key
+        let mut offset = 0;
+        unsafe { rb_hash_stlike_lookup(case_hash, comptime_key.0 as _, &mut offset) };
+        let jump_offset = if offset == 0 {
+            // NOTE: If we hit the else branch with various values, it could negatively impact the performance.
+            else_offset
+        } else {
+            (offset as u32) >> 1 // FIX2LONG
+        };
+
+        // Jump to the offset of case or else
+        let jump_block = BlockId { iseq: jit.iseq, idx: jit_next_insn_idx(jit) + jump_offset };
+        gen_direct_jump(jit, &ctx, jump_block, asm);
+        EndBlock
+    } else {
+        KeepCompiling // continue with === branches
+    }
 }
 
 fn gen_branchif_branch(

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -1030,6 +1030,13 @@ extern "C" {
     pub fn rb_hash_resurrect(hash: VALUE) -> VALUE;
 }
 extern "C" {
+    pub fn rb_hash_stlike_lookup(
+        hash: VALUE,
+        key: st_data_t,
+        pval: *mut st_data_t,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
     pub fn rb_gvar_get(arg1: ID) -> VALUE;
 }
 extern "C" {


### PR DESCRIPTION
Following up https://github.com/ruby/ruby/pull/6838, this optimizes `mail` bench further by reordering case-when branches since it has a case-when table with 100+ branches and the chain depth goes only up to 17. Railsbench doesn't seem to have a significant impact.

## Benchmark

```
before: ruby 3.2.0dev (2022-11-30T21:27:39Z master 5752d11f1f) +YJIT [arm64-darwin22]
after: ruby 3.2.0dev (2022-11-30T23:41:13Z yjit-case-reorder 9538b52253) +YJIT [arm64-darwin22]

----------  -----------  ----------  ----------  ----------  ------------  -------------
bench       before (ms)  stddev (%)  after (ms)  stddev (%)  before/after  after 1st itr
mail        64.7         1.7         61.4        1.3         1.05          1.07
railsbench  699.0        1.8         701.3       1.7         1.00          1.02
----------  -----------  ----------  ----------  ----------  ------------  -------------
```

<details>

```
$ ./run_benchmarks.rb railsbench mail -e "before::/opt/rubies/yjit-release-before-$arch/bin/ruby --yjit" -e "after::/opt/rubies/yjit-release-after-$arch/bin/ruby --yjit"
Running benchmark "mail" (1/2)
/opt/rubies/yjit-release-before-arm64/bin/ruby --yjit -I ./harness benchmarks/mail/benchmark.rb
ruby 3.2.0dev (2022-11-30T21:27:39Z master 5752d11f1f) +YJIT [arm64-darwin22]
Command: bundle check 2> /dev/null || bundle install
The Gemfile's dependencies are satisfied
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
itr #1: 205ms
itr #2: 65ms
itr #3: 65ms
itr #4: 64ms
itr #5: 64ms
itr #6: 64ms
itr #7: 64ms
itr #8: 65ms
itr #9: 65ms
itr #10: 64ms
itr #11: 64ms
itr #12: 63ms
itr #13: 63ms
itr #14: 64ms
itr #15: 64ms
itr #16: 64ms
itr #17: 63ms
itr #18: 66ms
itr #19: 63ms
itr #20: 63ms
itr #21: 63ms
itr #22: 64ms
itr #23: 63ms
itr #24: 64ms
itr #25: 64ms
itr #26: 64ms
itr #27: 63ms
itr #28: 63ms
itr #29: 67ms
itr #30: 65ms
itr #31: 64ms
itr #32: 69ms
itr #33: 65ms
itr #34: 65ms
itr #35: 64ms
itr #36: 65ms
itr #37: 65ms
itr #38: 65ms
itr #39: 67ms
itr #40: 65ms
itr #41: 65ms
itr #42: 65ms
itr #43: 65ms
itr #44: 65ms
itr #45: 66ms
itr #46: 65ms
itr #47: 65ms
itr #48: 66ms
itr #49: 65ms
itr #50: 65ms
itr #51: 64ms
itr #52: 64ms
itr #53: 65ms
itr #54: 64ms
itr #55: 65ms
itr #56: 65ms
itr #57: 64ms
itr #58: 64ms
itr #59: 64ms
itr #60: 65ms
itr #61: 64ms
itr #62: 64ms
itr #63: 66ms
itr #64: 67ms
itr #65: 64ms
itr #66: 65ms
itr #67: 64ms
itr #68: 64ms
itr #69: 66ms
itr #70: 67ms
itr #71: 65ms
itr #72: 66ms
itr #73: 65ms
itr #74: 64ms
itr #75: 64ms
itr #76: 67ms
itr #77: 63ms
itr #78: 63ms
itr #79: 63ms
itr #80: 63ms
itr #81: 63ms
itr #82: 63ms
itr #83: 64ms
itr #84: 64ms
itr #85: 63ms
itr #86: 63ms
itr #87: 63ms
itr #88: 63ms
itr #89: 63ms
itr #90: 63ms
itr #91: 63ms
itr #92: 63ms
itr #93: 63ms
itr #94: 63ms
itr #95: 65ms
itr #96: 63ms
itr #97: 66ms
itr #98: 63ms
itr #99: 63ms
itr #100: 64ms
itr #101: 65ms
itr #102: 63ms
itr #103: 63ms
itr #104: 64ms
itr #105: 64ms
itr #106: 64ms
itr #107: 64ms
itr #108: 69ms
itr #109: 63ms
itr #110: 64ms
itr #111: 65ms
itr #112: 64ms
itr #113: 63ms
itr #114: 63ms
itr #115: 64ms
itr #116: 63ms
itr #117: 63ms
itr #118: 63ms
itr #119: 63ms
itr #120: 63ms
itr #121: 63ms
itr #122: 63ms
itr #123: 64ms
itr #124: 64ms
itr #125: 63ms
itr #126: 64ms
itr #127: 64ms
itr #128: 63ms
itr #129: 63ms
itr #130: 64ms
itr #131: 63ms
itr #132: 65ms
itr #133: 64ms
itr #134: 64ms
itr #135: 64ms
itr #136: 63ms
itr #137: 63ms
itr #138: 64ms
itr #139: 64ms
itr #140: 63ms
itr #141: 63ms
itr #142: 65ms
itr #143: 64ms
itr #144: 64ms
itr #145: 64ms
itr #146: 64ms
itr #147: 63ms
itr #148: 64ms
itr #149: 63ms
itr #150: 64ms
itr #151: 64ms
itr #152: 63ms
itr #153: 63ms
Average of last 138, non-warmup iters: 64ms
Running benchmark "railsbench" (2/2)
/opt/rubies/yjit-release-before-arm64/bin/ruby --yjit -I ./harness benchmarks/railsbench/benchmark.rb
ruby 3.2.0dev (2022-11-30T21:27:39Z master 5752d11f1f) +YJIT [arm64-darwin22]
Command: bundle check 2> /dev/null || bundle install
The Gemfile's dependencies are satisfied
Command: bin/rails db:migrate db:seed
Using 100 posts in the database
itr #1: 875ms
itr #2: 709ms
itr #3: 700ms
itr #4: 689ms
itr #5: 701ms
itr #6: 693ms
itr #7: 709ms
itr #8: 694ms
itr #9: 691ms
itr #10: 717ms
itr #11: 669ms
itr #12: 705ms
itr #13: 688ms
itr #14: 717ms
itr #15: 688ms
itr #16: 701ms
itr #17: 717ms
itr #18: 676ms
itr #19: 716ms
itr #20: 694ms
itr #21: 712ms
itr #22: 694ms
itr #23: 697ms
itr #24: 685ms
itr #25: 693ms
Average of last 10, non-warmup iters: 698ms
Running benchmark "mail" (1/2)
/opt/rubies/yjit-release-after-arm64/bin/ruby --yjit -I ./harness benchmarks/mail/benchmark.rb
ruby 3.2.0dev (2022-11-30T23:41:13Z yjit-case-reorder 9538b52253) +YJIT [arm64-darwin22]
Command: bundle check 2> /dev/null || bundle install
The Gemfile's dependencies are satisfied
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
itr #1: 192ms
itr #2: 61ms
itr #3: 61ms
itr #4: 62ms
itr #5: 61ms
itr #6: 63ms
itr #7: 62ms
itr #8: 61ms
itr #9: 61ms
itr #10: 61ms
itr #11: 61ms
itr #12: 61ms
itr #13: 61ms
itr #14: 61ms
itr #15: 62ms
itr #16: 61ms
itr #17: 61ms
itr #18: 61ms
itr #19: 61ms
itr #20: 61ms
itr #21: 61ms
itr #22: 64ms
itr #23: 62ms
itr #24: 61ms
itr #25: 61ms
itr #26: 61ms
itr #27: 61ms
itr #28: 61ms
itr #29: 61ms
itr #30: 61ms
itr #31: 62ms
itr #32: 61ms
itr #33: 61ms
itr #34: 61ms
itr #35: 61ms
itr #36: 61ms
itr #37: 61ms
itr #38: 62ms
itr #39: 61ms
itr #40: 61ms
itr #41: 61ms
itr #42: 61ms
itr #43: 61ms
itr #44: 61ms
itr #45: 61ms
itr #46: 61ms
itr #47: 62ms
itr #48: 61ms
itr #49: 61ms
itr #50: 61ms
itr #51: 61ms
itr #52: 61ms
itr #53: 61ms
itr #54: 62ms
itr #55: 63ms
itr #56: 61ms
itr #57: 62ms
itr #58: 61ms
itr #59: 61ms
itr #60: 61ms
itr #61: 64ms
itr #62: 61ms
itr #63: 63ms
itr #64: 61ms
itr #65: 61ms
itr #66: 61ms
itr #67: 61ms
itr #68: 62ms
itr #69: 62ms
itr #70: 62ms
itr #71: 62ms
itr #72: 62ms
itr #73: 61ms
itr #74: 61ms
itr #75: 61ms
itr #76: 61ms
itr #77: 62ms
itr #78: 61ms
itr #79: 61ms
itr #80: 62ms
itr #81: 61ms
itr #82: 61ms
itr #83: 62ms
itr #84: 61ms
itr #85: 62ms
itr #86: 62ms
itr #87: 63ms
itr #88: 62ms
itr #89: 61ms
itr #90: 61ms
itr #91: 61ms
itr #92: 62ms
itr #93: 61ms
itr #94: 62ms
itr #95: 60ms
itr #96: 60ms
itr #97: 60ms
itr #98: 60ms
itr #99: 61ms
itr #100: 62ms
itr #101: 61ms
itr #102: 60ms
itr #103: 60ms
itr #104: 60ms
itr #105: 60ms
itr #106: 60ms
itr #107: 60ms
itr #108: 60ms
itr #109: 60ms
itr #110: 60ms
itr #111: 60ms
itr #112: 60ms
itr #113: 60ms
itr #114: 60ms
itr #115: 60ms
itr #116: 60ms
itr #117: 60ms
itr #118: 60ms
itr #119: 61ms
itr #120: 61ms
itr #121: 60ms
itr #122: 60ms
itr #123: 60ms
itr #124: 60ms
itr #125: 60ms
itr #126: 60ms
itr #127: 60ms
itr #128: 60ms
itr #129: 60ms
itr #130: 60ms
itr #131: 60ms
itr #132: 60ms
itr #133: 60ms
itr #134: 60ms
itr #135: 60ms
itr #136: 60ms
itr #137: 60ms
itr #138: 60ms
itr #139: 60ms
itr #140: 60ms
itr #141: 60ms
itr #142: 60ms
itr #143: 60ms
itr #144: 60ms
itr #145: 60ms
itr #146: 60ms
itr #147: 60ms
itr #148: 60ms
itr #149: 60ms
itr #150: 60ms
itr #151: 62ms
itr #152: 62ms
itr #153: 61ms
itr #154: 60ms
itr #155: 60ms
itr #156: 61ms
itr #157: 60ms
itr #158: 60ms
itr #159: 63ms
itr #160: 60ms
itr #161: 60ms
Average of last 146, non-warmup iters: 61ms
Running benchmark "railsbench" (2/2)
/opt/rubies/yjit-release-after-arm64/bin/ruby --yjit -I ./harness benchmarks/railsbench/benchmark.rb
ruby 3.2.0dev (2022-11-30T23:41:13Z yjit-case-reorder 9538b52253) +YJIT [arm64-darwin22]
Command: bundle check 2> /dev/null || bundle install
The Gemfile's dependencies are satisfied
Command: bin/rails db:migrate db:seed
Using 100 posts in the database
itr #1: 862ms
itr #2: 699ms
itr #3: 711ms
itr #4: 700ms
itr #5: 693ms
itr #6: 697ms
itr #7: 695ms
itr #8: 715ms
itr #9: 691ms
itr #10: 698ms
itr #11: 692ms
itr #12: 715ms
itr #13: 698ms
itr #14: 717ms
itr #15: 694ms
itr #16: 728ms
itr #17: 691ms
itr #18: 695ms
itr #19: 693ms
itr #20: 714ms
itr #21: 701ms
itr #22: 692ms
itr #23: 689ms
itr #24: 696ms
itr #25: 708ms
Average of last 10, non-warmup iters: 701ms
Total time spent benchmarking: 62s

before: ruby 3.2.0dev (2022-11-30T21:27:39Z master 5752d11f1f) +YJIT [arm64-darwin22]
after: ruby 3.2.0dev (2022-11-30T23:41:13Z yjit-case-reorder 9538b52253) +YJIT [arm64-darwin22]

----------  -----------  ----------  ----------  ----------  ------------  -------------
bench       before (ms)  stddev (%)  after (ms)  stddev (%)  before/after  after 1st itr
mail        64.7         1.7         61.4        1.3         1.05          1.07
railsbench  699.0        1.8         701.3       1.7         1.00          1.02
----------  -----------  ----------  ----------  ----------  ------------  -------------
Legend:
- before/after: ratio of before/after time. Higher is better for after. Above 1 represents a speedup.
- after 1st itr: ratio of before/after time for the first benchmarking iteration.
```

</details>

### optcarrot --opt
It doesn't matter, but these changes have made `optcarrot --opt` faster (no change without `--opt` or on yjit-bench)

```bash
# master before rb_int_equal optimization
$ ruby -v --yjit bin/optcarrot-bench --opt
ruby 3.2.0dev (2022-11-30T19:09:10Z master d98d84b75d) +YJIT [arm64-darwin22]
fps: 25.343688580425802

# master after rb_int_equal optimization
$ ruby -v --yjit bin/optcarrot-bench --opt
ruby 3.2.0dev (2022-11-30T21:27:39Z master 5752d11f1f) +YJIT [arm64-darwin22]
fps: 72.50521634549449

# This PR
$ ruby -v --yjit bin/optcarrot-bench --opt
ruby 3.2.0dev (2022-11-30T23:41:13Z yjit-case-reorder 9538b52253) +YJIT [arm64-darwin22]
fps: 117.25467725545384
```