### PR TITLE
Fix Object#freeze also freezing part of the class

### DIFF
--- a/test/ruby/test_class.rb
+++ b/test/ruby/test_class.rb
@@ -809,4 +809,13 @@ PREP
 3_000_000.times(&code)
 CODE
   end
+
+  def test_instance_freeze_dont_freeze_the_class_bug_19164
+    klass = Class.new
+    klass.prepend(Module.new)
+
+    klass.new.freeze
+    klass.define_method(:bar) {}
+    assert_equal klass, klass.remove_method(:bar), '[Bug #19164]'
+  end
 end

--- a/test/ruby/test_module.rb
+++ b/test/ruby/test_module.rb
@@ -2350,6 +2350,18 @@ class TestModule < Test::Unit::TestCase
     assert_equal(:foo, removed)
   end
 
+  def test_frozen_prepend_remove_method
+    [Module, Class].each do |klass|
+      mod = klass.new do
+        prepend(Module.new)
+        def foo; end
+      end
+      mod.freeze
+      assert_raise(FrozenError, '[Bug #19166]') { mod.send(:remove_method, :foo) }
+      assert_equal([:foo], mod.instance_methods(false))
+    end
+  end
+
   def test_prepend_class_ancestors
     bug6658 = '[ruby-core:45919]'
     m = labeled_module("m")

--- a/vm_method.c
+++ b/vm_method.c
@@ -1541,8 +1541,8 @@ remove_method(VALUE klass, ID mid)
     rb_method_entry_t *me = 0;
     VALUE self = klass;
 
-    klass = RCLASS_ORIGIN(klass);
     rb_class_modify_check(klass);
+    klass = RCLASS_ORIGIN(klass);
     if (mid == object_id || mid == id__send__ || mid == idInitialize) {
         rb_warn("removing `%s' may cause serious problems", rb_id2name(mid));
     }


### PR DESCRIPTION
[[Bug #19164]](https://bugs.ruby-lang.org/issues/19164)

The bug was introduced in 8a13a2e8d1361bdab5d4bc1d75cf07b804a982c0 / https://github.com/ruby/ruby/pull/5955

NB: This is just the failing case for now.