### PR TITLE
Avoid bash specific variable substitution

### DIFF
--- a/.github/workflows/check_misc.yml
+++ b/.github/workflows/check_misc.yml
@@ -17,10 +17,13 @@ jobs:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
       - name: Check if C-sources are US-ASCII
         run: |
-          ! grep -r -n '[^	 -~]' *.[chy] include internal win32/*.[ch]
+          ! grep -r -n '[^	 -~]' -- *.[chy] include internal win32/*.[ch]
       - name: Check for trailing spaces
         run: |
-          ! git grep -n '[	 ]$' '*.rb' '*.[chy]'
+          ! git grep -n '[	 ]$' -- '*.rb' '*.[chy]'
+      - name: Check for bash specific substitution in configure.ac
+        run: |
+          ! git grep -n '\${[A-Za-z_0-9]*/' -- configure.ac
       - name: Check for header macros
         run: |
           ! for header in ruby/*.h; do \

--- a/configure.ac
+++ b/configure.ac
@@ -133,9 +133,12 @@ AC_CANONICAL_TARGET
 AS_CASE(["$target_cpu-$target_os"],
     [aarch64-darwin*], [
         target_cpu=arm64
-        AS_CASE(["$target_vendor"], [unknown], [target_vendor=apple target=${target/-unknown-/-apple-}])
-        target="${target/aarch64/arm64}"
-        target_alias="${target_alias/aarch64/arm64}"
+        AS_CASE(["$target_vendor"], [unknown], [
+            target_vendor=apple
+            target=${target%%-unknown-*}-apple-${target@%:@*-unknown-}
+        ])
+        target="arm64-${target@%:@aarch64-}"
+        target_alias="arm64-${target_alias@%:@aarch64-}"
     ])
 
 AC_ARG_PROGRAM
@@ -3104,7 +3107,7 @@ AS_IF([test "$rb_cv_dlopen" = yes], [
 
             AC_MSG_CHECKING([whether $flag is accepted for bundle])
             : > conftest.c
-            AS_IF([${LDSHARED/'$(CC)'/$CC} -o conftest.bundle $flag conftest.c >/dev/null 2>conftest.err &&
+            AS_IF([${LDSHARED%%'$(CC)'*}$CC${LDSHARED@%:@*'$(CC)'} -o conftest.bundle $flag conftest.c >/dev/null 2>conftest.err &&
                 test ! -s conftest.err], [
                 AC_MSG_RESULT([yes])
                 RUBY_APPEND_OPTIONS(DLDFLAGS, [$flag])


### PR DESCRIPTION
It may cause parse errors in some other sh even in never executed parts.