### PR TITLE
Remove unneeded `rb_parser_set_yydebug` function declaration

### DIFF
--- a/node.h
+++ b/node.h
@@ -431,7 +431,6 @@ rb_ast_id_table_t *rb_ast_resize_latest_local_table(rb_ast_t*, int);
 VALUE rb_parser_new(void);
 VALUE rb_parser_end_seen_p(VALUE);
 VALUE rb_parser_encoding(VALUE);
-VALUE rb_parser_set_yydebug(VALUE, VALUE);
 VALUE rb_parser_dump_tree(const NODE *node, int comment);
 void rb_parser_set_options(VALUE, int, int, int, int);
 


### PR DESCRIPTION
`rb_parser_set_yydebug` declaration alredy define in `internal/parse.h`, and included in `parse.y` and `ast.c`.
So, remove this declaration in `internal/node.h`.