### PR TITLE
YJIT: Make case-when optimization respect === redefinition

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -3436,3 +3436,23 @@ assert_equal '1', %q{
 
   foo(1)
 }
+
+# case-when with redefined ===
+assert_equal 'ok', %q{
+  class Symbol
+    def ===(a)
+      true
+    end
+  end
+
+  def cw(arg)
+    case arg
+    when :b
+      :ok
+    when 4
+      :ng
+    end
+  end
+
+  cw(4)
+}

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -100,6 +100,10 @@ fn main() {
         // From internal/hash.h
         .allowlist_function("rb_hash_new_with_size")
         .allowlist_function("rb_hash_resurrect")
+        .allowlist_function("rb_hash_stlike_foreach")
+
+        // From include/ruby/st.h
+        .allowlist_type("st_retval")
 
         // From include/ruby/internal/intern/hash.h
         .allowlist_function("rb_hash_aset")

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -234,6 +234,19 @@ pub const RUBY_FL_SINGLETON: ruby_fl_type = 4096;
 pub type ruby_fl_type = i32;
 pub type st_data_t = ::std::os::raw::c_ulong;
 pub type st_index_t = st_data_t;
+pub const ST_CONTINUE: st_retval = 0;
+pub const ST_STOP: st_retval = 1;
+pub const ST_DELETE: st_retval = 2;
+pub const ST_CHECK: st_retval = 3;
+pub const ST_REPLACE: st_retval = 4;
+pub type st_retval = u32;
+pub type st_foreach_callback_func = ::std::option::Option<
+    unsafe extern "C" fn(
+        arg1: st_data_t,
+        arg2: st_data_t,
+        arg3: st_data_t,
+    ) -> ::std::os::raw::c_int,
+>;
 pub const RARRAY_EMBED_FLAG: ruby_rarray_flags = 8192;
 pub const RARRAY_EMBED_LEN_MASK: ruby_rarray_flags = 4161536;
 pub const RARRAY_TRANSIENT_FLAG: ruby_rarray_flags = 33554432;
@@ -414,6 +427,7 @@ extern "C" {
 pub type attr_index_t = u32;
 pub type shape_id_t = u32;
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct rb_shape {
     pub edges: *mut rb_id_table,
     pub edge_name: ID,
@@ -1022,6 +1036,13 @@ extern "C" {
 }
 extern "C" {
     pub fn rb_ec_str_resurrect(ec: *mut rb_execution_context_struct, str_: VALUE) -> VALUE;
+}
+extern "C" {
+    pub fn rb_hash_stlike_foreach(
+        hash: VALUE,
+        func: st_foreach_callback_func,
+        arg: st_data_t,
+    ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn rb_hash_new_with_size(size: st_index_t) -> VALUE;

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -427,7 +427,6 @@ extern "C" {
 pub type attr_index_t = u32;
 pub type shape_id_t = u32;
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
 pub struct rb_shape {
     pub edges: *mut rb_id_table,
     pub edge_name: ID,


### PR DESCRIPTION
Basically, this is just fixing for people that want to redefine === on String, Integer and such. Sorry for bringing up this frustrating issue 😅. Alternative fix could be to register a bunch of assumptions, or maybe just leave the bug in since it's plausible that no one cares.
 
---

Even when a fixnum key is in the dispatch hash, if there is a case such that its basic operations for === is redefined, we need to fall back to checking each case like the interpreter. Semantically we're always checking each case by calling === in order, it's just that this is not observable when basic operations are intact.

When all the keys are fixnums, though, we can do the optimization we're doing right now. Check for this condition.

---

This narrows the targets for the optimization, but speed on `mail` is untouched.

```
baseline: ruby 3.2.0dev (2022-12-01T16:50:48Z master 9da2a5204f) +YJIT stats [arm64-darwin22]
patched: ruby 3.2.0dev (2022-12-01T22:05:31Z yjit-case-when-nar.. 2ed46e7b30) +YJIT [arm64-darwin22]
last_commit=YJIT: Make case-when optimization respect === redefinition

-----  -------------  ----------  ------------  ----------  ----------------  ---------------
bench  baseline (ms)  stddev (%)  patched (ms)  stddev (%)  baseline/patched  patched 1st itr
mail   63.7           2.7         63.4          1.2         1.01              1.00           
-----  -------------  ----------  ------------  ----------  ----------------  ---------------
```