### PR TITLE
YJIT: Respect destination num_bits on STUR

### DIFF
--- a/yjit/src/asm/arm64/mod.rs
+++ b/yjit/src/asm/arm64/mod.rs
@@ -906,7 +906,7 @@ pub fn stur(cb: &mut CodeBlock, rt: A64Opnd, rn: A64Opnd) {
             assert!(rn.num_bits == 32 || rn.num_bits == 64);
             assert!(mem_disp_fits_bits(rn.disp), "Expected displacement to be 9 bits or less");
 
-            LoadStore::stur(rt.reg_no, rn.base_reg_no, rn.disp as i16, rt.num_bits).into()
+            LoadStore::stur(rt.reg_no, rn.base_reg_no, rn.disp as i16, rn.num_bits).into()
         },
         _ => panic!("Invalid operand combination to stur instruction.")
     };
@@ -1499,8 +1499,13 @@ mod tests {
     }
 
     #[test]
-    fn test_stur() {
+    fn test_stur_64_bits() {
         check_bytes("6a0108f8", |cb| stur(cb, X10, A64Opnd::new_mem(64, X11, 128)));
+    }
+
+    #[test]
+    fn test_stur_32_bits() {
+        check_bytes("6a0108b8", |cb| stur(cb, X10, A64Opnd::new_mem(32, X11, 128)));
     }
 
     #[test]


### PR DESCRIPTION
A fix needed to make https://github.com/ruby/ruby/pull/6839 (and https://github.com/ruby/ruby/pull/6767) work, following up https://github.com/ruby/ruby/pull/6840. On `stur`, `rn` is the destination address, not `rt`. When writing to a memory operand with 32 bits, we want to write only 32 bits. 