### PR TITLE
YJIT: Change the default --yjit-call-threshold to 30

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -518,6 +518,8 @@ The following deprecated APIs are removed.
     * Simply run ruby with `--yjit-stats` to compute stats (incurs some run-time overhead).
 * YJIT is now optimized to take advantage of object shapes. [[Feature #18776]]
 * Take advantage of finer-grained constant invalidation to invalidate less code when defining new constants. [[Feature #18589]]
+* The default `--yjit-exec-mem-size` is changed to 128 (MiB).
+* The default `--yjit-call-threshold` is changed to 30.
 
 ### MJIT
 

--- a/yjit/src/options.rs
+++ b/yjit/src/options.rs
@@ -55,7 +55,7 @@ pub struct Options {
 pub static mut OPTIONS: Options = Options {
     exec_mem_size: 128 * 1024 * 1024,
     code_page_size: 16 * 1024,
-    call_threshold: 10,
+    call_threshold: 30,
     greedy_versioning: false,
     no_type_prop: false,
     max_versions: 4,


### PR DESCRIPTION
We've learned that `--yjit-call-threshold=10` and `--yjit-call-threshold=20` compile a lot of transient ISEQs on our tier-1 application while `--yjit-call-threshold=30`, `--yjit-call-threshold=50`, `--yjit-call-threshold=100`, and `--yjit-call-threshold=200` don't.

`30` seems like a better default than `10` for production workloads that are similar to ours.

## Benchmark
I confirmed that this doesn't negatively impact railsbench:

```
before: ruby 3.2.0dev (2022-12-02T00:13:38Z master dcbea7671b) +YJIT [x86_64-linux]
after: ruby 3.2.0dev (2022-12-02T00:41:08Z yjit-call-threshold 8afbdf7228) +YJIT [x86_64-linux]

----------  -----------  ----------  ----------  ----------  ------------  -------------
bench       before (ms)  stddev (%)  after (ms)  stddev (%)  before/after  after 1st itr
railsbench  1096.9       1.9         1093.8      2.3         1.00          0.98
----------  -----------  ----------  ----------  ----------  ------------  -------------
```

<details>

```
$ ./run_benchmarks.rb railsbench -e "before::/opt/rubies/before/bin/ruby --yjit" -e "after::/opt/rubies/after/bin/ruby --yjit"
Running benchmark "railsbench" (1/1)
setarch x86_64 -R taskset -c 7 /opt/rubies/before/bin/ruby --yjit -I ./harness benchmarks/railsbench/benchmark.rb
ruby 3.2.0dev (2022-12-02T00:13:38Z master dcbea7671b) +YJIT [x86_64-linux]
Command: bundle check 2> /dev/null || bundle install
The Gemfile's dependencies are satisfied
Command: bin/rails db:migrate db:seed
Using 100 posts in the database
itr #1: 1233ms
itr #2: 1121ms
itr #3: 1085ms
itr #4: 1120ms
itr #5: 1118ms
itr #6: 1124ms
itr #7: 1084ms
itr #8: 1121ms
itr #9: 1088ms
itr #10: 1124ms
itr #11: 1084ms
itr #12: 1124ms
itr #13: 1083ms
itr #14: 1091ms
itr #15: 1082ms
itr #16: 1094ms
itr #17: 1080ms
itr #18: 1125ms
itr #19: 1079ms
itr #20: 1127ms
itr #21: 1080ms
itr #22: 1129ms
itr #23: 1079ms
itr #24: 1093ms
itr #25: 1079ms
Average of last 10, non-warmup iters: 1096ms
Running benchmark "railsbench" (1/1)
setarch x86_64 -R taskset -c 7 /opt/rubies/after/bin/ruby --yjit -I ./harness benchmarks/railsbench/benchmark.rb
ruby 3.2.0dev (2022-12-02T00:41:08Z yjit-call-threshold 8afbdf7228) +YJIT [x86_64-linux]
Command: bundle check 2> /dev/null || bundle install
The Gemfile's dependencies are satisfied
Command: bin/rails db:migrate db:seed
Using 100 posts in the database
itr #1: 1263ms
itr #2: 1040ms
itr #3: 1119ms
itr #4: 1037ms
itr #5: 1084ms
itr #6: 1072ms
itr #7: 1084ms
itr #8: 1108ms
itr #9: 1077ms
itr #10: 1111ms
itr #11: 1141ms
itr #12: 1080ms
itr #13: 1074ms
itr #14: 1113ms
itr #15: 1074ms
itr #16: 1109ms
itr #17: 1079ms
itr #18: 1080ms
itr #19: 1075ms
itr #20: 1114ms
itr #21: 1077ms
itr #22: 1111ms
itr #23: 1138ms
itr #24: 1048ms
itr #25: 1101ms
Average of last 10, non-warmup iters: 1093ms
Total time spent benchmarking: 59s

before: ruby 3.2.0dev (2022-12-02T00:13:38Z master dcbea7671b) +YJIT [x86_64-linux]
after: ruby 3.2.0dev (2022-12-02T00:41:08Z yjit-call-threshold 8afbdf7228) +YJIT [x86_64-linux]

----------  -----------  ----------  ----------  ----------  ------------  -------------
bench       before (ms)  stddev (%)  after (ms)  stddev (%)  before/after  after 1st itr
railsbench  1096.9       1.9         1093.8      2.3         1.00          0.98
----------  -----------  ----------  ----------  ----------  ------------  -------------
Legend:
- before/after: ratio of before/after time. Higher is better for after. Above 1 represents a speedup.
- after 1st itr: ratio of before/after time for the first benchmarking iteration.
```

</details>

## Code size

This reduces memory consumption on Railsbench:

### Before
```
inline_code_size:         2704209
outlined_code_size:       2703839
freed_code_size:                0
code_region_size:         5419008
```

### After
```
inline_code_size:         2079265
outlined_code_size:       2076643
freed_code_size:                0
code_region_size:         4157440
```