### PR TITLE
Introduce BOP_CMP for optimized comparisons

### DIFF
--- a/array.c
+++ b/array.c
@@ -3456,7 +3456,6 @@ rb_ary_rotate_m(int argc, VALUE *argv, VALUE ary)
 struct ary_sort_data {
     VALUE ary;
     VALUE receiver;
-    struct cmp_opt_data cmp_opt;
 };
 
 static VALUE
@@ -3502,15 +3501,15 @@ sort_2(const void *ap, const void *bp, void *dummy)
     VALUE a = *(const VALUE *)ap, b = *(const VALUE *)bp;
     int n;
 
-    if (FIXNUM_P(a) && FIXNUM_P(b) && CMP_OPTIMIZABLE(data->cmp_opt, Integer)) {
+    if (FIXNUM_P(a) && FIXNUM_P(b) && CMP_OPTIMIZABLE(INTEGER)) {
         if ((long)a > (long)b) return 1;
         if ((long)a < (long)b) return -1;
         return 0;
     }
-    if (STRING_P(a) && STRING_P(b) && CMP_OPTIMIZABLE(data->cmp_opt, String)) {
+    if (STRING_P(a) && STRING_P(b) && CMP_OPTIMIZABLE(STRING)) {
         return rb_str_cmp(a, b);
     }
-    if (RB_FLOAT_TYPE_P(a) && CMP_OPTIMIZABLE(data->cmp_opt, Float)) {
+    if (RB_FLOAT_TYPE_P(a) && CMP_OPTIMIZABLE(FLOAT)) {
         return rb_float_cmp(a, b);
     }
 
@@ -3574,8 +3573,6 @@ rb_ary_sort_bang(VALUE ary)
         RBASIC_CLEAR_CLASS(tmp);
         data.ary = tmp;
         data.receiver = ary;
-        data.cmp_opt.opt_methods = 0;
-        data.cmp_opt.opt_inited = 0;
         RARRAY_PTR_USE(tmp, ptr, {
             ruby_qsort(ptr, len, sizeof(VALUE),
                        rb_block_given_p()?sort_1:sort_2, &data);
@@ -6056,7 +6053,6 @@ ary_max_opt_string(VALUE ary, long i, VALUE vmax)
 static VALUE
 rb_ary_max(int argc, VALUE *argv, VALUE ary)
 {
-    struct cmp_opt_data cmp_opt = { 0, 0 };
     VALUE result = Qundef, v;
     VALUE num;
     long i;
@@ -6076,13 +6072,13 @@ rb_ary_max(int argc, VALUE *argv, VALUE ary)
     else if (n > 0) {
         result = RARRAY_AREF(ary, 0);
         if (n > 1) {
-            if (FIXNUM_P(result) && CMP_OPTIMIZABLE(cmp_opt, Integer)) {
+            if (FIXNUM_P(result) && CMP_OPTIMIZABLE(INTEGER)) {
                 return ary_max_opt_fixnum(ary, 1, result);
             }
-            else if (STRING_P(result) && CMP_OPTIMIZABLE(cmp_opt, String)) {
+            else if (STRING_P(result) && CMP_OPTIMIZABLE(STRING)) {
                 return ary_max_opt_string(ary, 1, result);
             }
-            else if (RB_FLOAT_TYPE_P(result) && CMP_OPTIMIZABLE(cmp_opt, Float)) {
+            else if (RB_FLOAT_TYPE_P(result) && CMP_OPTIMIZABLE(FLOAT)) {
                 return ary_max_opt_float(ary, 1, result);
             }
             else {
@@ -6225,7 +6221,6 @@ ary_min_opt_string(VALUE ary, long i, VALUE vmin)
 static VALUE
 rb_ary_min(int argc, VALUE *argv, VALUE ary)
 {
-    struct cmp_opt_data cmp_opt = { 0, 0 };
     VALUE result = Qundef, v;
     VALUE num;
     long i;
@@ -6245,13 +6240,13 @@ rb_ary_min(int argc, VALUE *argv, VALUE ary)
     else if (n > 0) {
         result = RARRAY_AREF(ary, 0);
         if (n > 1) {
-            if (FIXNUM_P(result) && CMP_OPTIMIZABLE(cmp_opt, Integer)) {
+            if (FIXNUM_P(result) && CMP_OPTIMIZABLE(INTEGER)) {
                 return ary_min_opt_fixnum(ary, 1, result);
             }
-            else if (STRING_P(result) && CMP_OPTIMIZABLE(cmp_opt, String)) {
+            else if (STRING_P(result) && CMP_OPTIMIZABLE(STRING)) {
                 return ary_min_opt_string(ary, 1, result);
             }
-            else if (RB_FLOAT_TYPE_P(result) && CMP_OPTIMIZABLE(cmp_opt, Float)) {
+            else if (RB_FLOAT_TYPE_P(result) && CMP_OPTIMIZABLE(FLOAT)) {
                 return ary_min_opt_float(ary, 1, result);
             }
             else {

--- a/benchmark/array_sort_int.yml
+++ b/benchmark/array_sort_int.yml
@@ -1,0 +1,15 @@
+prelude: |
+  ary2 = 2.times.to_a.shuffle
+  ary10 = 10.times.to_a.shuffle
+  ary100 = 100.times.to_a.shuffle
+  ary1000 = 1000.times.to_a.shuffle
+  ary10000 = 10000.times.to_a.shuffle
+
+benchmark:
+  ary2.sort: ary2.sort
+  ary10.sort: ary10.sort
+  ary100.sort: ary100.sort
+  ary1000.sort: ary1000.sort
+  ary10000.sort: ary10000.sort
+
+loop_count: 10000

--- a/benchmark/enum_minmax.yml
+++ b/benchmark/enum_minmax.yml
@@ -1,0 +1,25 @@
+prelude: |
+  set2 = 2.times.to_a.shuffle.to_set
+  set10 = 10.times.to_a.shuffle.to_set
+  set100 = 100.times.to_a.shuffle.to_set
+  set1000 = 1000.times.to_a.shuffle.to_set
+  set10000 = 10000.times.to_a.shuffle.to_set
+
+benchmark:
+  set2.min: set2.min
+  set10.min: set10.min
+  set100.min: set100.min
+  set1000.min: set1000.min
+  set10000.min: set10000.min
+  set2.max: set2.max
+  set10.max: set10.max
+  set100.max: set100.max
+  set1000.max: set1000.max
+  set10000.max: set10000.max
+  set2.minmax: set2.minmax
+  set10.minmax: set10.minmax
+  set100.minmax: set100.minmax
+  set1000.minmax: set1000.minmax
+  set10000.minmax: set10000.minmax
+
+loop_count: 10000

--- a/benchmark/enum_sort.yml
+++ b/benchmark/enum_sort.yml
@@ -1,0 +1,15 @@
+prelude: |
+  set2 = 2.times.to_a.shuffle.to_set
+  set10 = 10.times.to_a.shuffle.to_set
+  set100 = 100.times.to_a.shuffle.to_set
+  set1000 = 1000.times.to_a.shuffle.to_set
+  set10000 = 10000.times.to_a.shuffle.to_set
+
+benchmark:
+  set2.sort_by: set2.sort_by { 0 }
+  set10.sort_by: set10.sort_by { 0 }
+  set100.sort_by: set100.sort_by { 0 }
+  set1000.sort_by: set1000.sort_by { 0 }
+  set10000.sort_by: set10000.sort_by { 0 }
+
+loop_count: 10000

--- a/benchmark/range_min.yml
+++ b/benchmark/range_min.yml
@@ -1,0 +1,2 @@
+benchmark:
+  - (1..10).min

--- a/common.mk
+++ b/common.mk
@@ -1813,6 +1813,7 @@ addr2line.$(OBJEXT): {$(VPATH)}internal/xmalloc.h
 addr2line.$(OBJEXT): {$(VPATH)}missing.h
 array.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 array.$(OBJEXT): $(top_srcdir)/internal/array.h
+array.$(OBJEXT): $(top_srcdir)/internal/basic_operators.h
 array.$(OBJEXT): $(top_srcdir)/internal/bignum.h
 array.$(OBJEXT): $(top_srcdir)/internal/bits.h
 array.$(OBJEXT): $(top_srcdir)/internal/class.h
@@ -2020,6 +2021,7 @@ ast.$(OBJEXT): $(CCAN_DIR)/str/str.h
 ast.$(OBJEXT): $(hdrdir)/ruby.h
 ast.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 ast.$(OBJEXT): $(top_srcdir)/internal/array.h
+ast.$(OBJEXT): $(top_srcdir)/internal/basic_operators.h
 ast.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 ast.$(OBJEXT): $(top_srcdir)/internal/gc.h
 ast.$(OBJEXT): $(top_srcdir)/internal/imemo.h
@@ -2404,6 +2406,7 @@ builtin.$(OBJEXT): $(CCAN_DIR)/list/list.h
 builtin.$(OBJEXT): $(CCAN_DIR)/str/str.h
 builtin.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 builtin.$(OBJEXT): $(top_srcdir)/internal/array.h
+builtin.$(OBJEXT): $(top_srcdir)/internal/basic_operators.h
 builtin.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 builtin.$(OBJEXT): $(top_srcdir)/internal/gc.h
 builtin.$(OBJEXT): $(top_srcdir)/internal/imemo.h
@@ -2592,6 +2595,7 @@ class.$(OBJEXT): $(CCAN_DIR)/list/list.h
 class.$(OBJEXT): $(CCAN_DIR)/str/str.h
 class.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 class.$(OBJEXT): $(top_srcdir)/internal/array.h
+class.$(OBJEXT): $(top_srcdir)/internal/basic_operators.h
 class.$(OBJEXT): $(top_srcdir)/internal/class.h
 class.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 class.$(OBJEXT): $(top_srcdir)/internal/eval.h
@@ -2790,6 +2794,7 @@ class.$(OBJEXT): {$(VPATH)}thread_native.h
 class.$(OBJEXT): {$(VPATH)}vm_core.h
 class.$(OBJEXT): {$(VPATH)}vm_opts.h
 compar.$(OBJEXT): $(hdrdir)/ruby/ruby.h
+compar.$(OBJEXT): $(top_srcdir)/internal/basic_operators.h
 compar.$(OBJEXT): $(top_srcdir)/internal/compar.h
 compar.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 compar.$(OBJEXT): $(top_srcdir)/internal/error.h
@@ -2974,6 +2979,7 @@ compile.$(OBJEXT): $(CCAN_DIR)/list/list.h
 compile.$(OBJEXT): $(CCAN_DIR)/str/str.h
 compile.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 compile.$(OBJEXT): $(top_srcdir)/internal/array.h
+compile.$(OBJEXT): $(top_srcdir)/internal/basic_operators.h
 compile.$(OBJEXT): $(top_srcdir)/internal/bignum.h
 compile.$(OBJEXT): $(top_srcdir)/internal/bits.h
 compile.$(OBJEXT): $(top_srcdir)/internal/class.h
@@ -3384,6 +3390,7 @@ cont.$(OBJEXT): $(CCAN_DIR)/str/str.h
 cont.$(OBJEXT): $(hdrdir)/ruby.h
 cont.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 cont.$(OBJEXT): $(top_srcdir)/internal/array.h
+cont.$(OBJEXT): $(top_srcdir)/internal/basic_operators.h
 cont.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 cont.$(OBJEXT): $(top_srcdir)/internal/cont.h
 cont.$(OBJEXT): $(top_srcdir)/internal/gc.h
@@ -3584,6 +3591,7 @@ debug.$(OBJEXT): $(CCAN_DIR)/list/list.h
 debug.$(OBJEXT): $(CCAN_DIR)/str/str.h
 debug.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 debug.$(OBJEXT): $(top_srcdir)/internal/array.h
+debug.$(OBJEXT): $(top_srcdir)/internal/basic_operators.h
 debug.$(OBJEXT): $(top_srcdir)/internal/class.h
 debug.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 debug.$(OBJEXT): $(top_srcdir)/internal/gc.h
@@ -5651,6 +5659,7 @@ encoding.$(OBJEXT): {$(VPATH)}vm_debug.h
 encoding.$(OBJEXT): {$(VPATH)}vm_sync.h
 enum.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 enum.$(OBJEXT): $(top_srcdir)/internal/array.h
+enum.$(OBJEXT): $(top_srcdir)/internal/basic_operators.h
 enum.$(OBJEXT): $(top_srcdir)/internal/bignum.h
 enum.$(OBJEXT): $(top_srcdir)/internal/bits.h
 enum.$(OBJEXT): $(top_srcdir)/internal/class.h
@@ -6047,6 +6056,7 @@ error.$(OBJEXT): $(CCAN_DIR)/list/list.h
 error.$(OBJEXT): $(CCAN_DIR)/str/str.h
 error.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 error.$(OBJEXT): $(top_srcdir)/internal/array.h
+error.$(OBJEXT): $(top_srcdir)/internal/basic_operators.h
 error.$(OBJEXT): $(top_srcdir)/internal/class.h
 error.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 error.$(OBJEXT): $(top_srcdir)/internal/error.h
@@ -6259,6 +6269,7 @@ eval.$(OBJEXT): $(CCAN_DIR)/str/str.h
 eval.$(OBJEXT): $(hdrdir)/ruby.h
 eval.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 eval.$(OBJEXT): $(top_srcdir)/internal/array.h
+eval.$(OBJEXT): $(top_srcdir)/internal/basic_operators.h
 eval.$(OBJEXT): $(top_srcdir)/internal/class.h
 eval.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 eval.$(OBJEXT): $(top_srcdir)/internal/cont.h
@@ -6697,6 +6708,7 @@ gc.$(OBJEXT): $(CCAN_DIR)/str/str.h
 gc.$(OBJEXT): $(hdrdir)/ruby.h
 gc.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 gc.$(OBJEXT): $(top_srcdir)/internal/array.h
+gc.$(OBJEXT): $(top_srcdir)/internal/basic_operators.h
 gc.$(OBJEXT): $(top_srcdir)/internal/bignum.h
 gc.$(OBJEXT): $(top_srcdir)/internal/bits.h
 gc.$(OBJEXT): $(top_srcdir)/internal/class.h
@@ -6939,6 +6951,7 @@ goruby.$(OBJEXT): $(CCAN_DIR)/str/str.h
 goruby.$(OBJEXT): $(hdrdir)/ruby.h
 goruby.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 goruby.$(OBJEXT): $(top_srcdir)/internal/array.h
+goruby.$(OBJEXT): $(top_srcdir)/internal/basic_operators.h
 goruby.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 goruby.$(OBJEXT): $(top_srcdir)/internal/gc.h
 goruby.$(OBJEXT): $(top_srcdir)/internal/imemo.h
@@ -7129,6 +7142,7 @@ hash.$(OBJEXT): $(CCAN_DIR)/list/list.h
 hash.$(OBJEXT): $(CCAN_DIR)/str/str.h
 hash.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 hash.$(OBJEXT): $(top_srcdir)/internal/array.h
+hash.$(OBJEXT): $(top_srcdir)/internal/basic_operators.h
 hash.$(OBJEXT): $(top_srcdir)/internal/bignum.h
 hash.$(OBJEXT): $(top_srcdir)/internal/bits.h
 hash.$(OBJEXT): $(top_srcdir)/internal/class.h
@@ -7512,6 +7526,7 @@ io.$(OBJEXT): $(CCAN_DIR)/list/list.h
 io.$(OBJEXT): $(CCAN_DIR)/str/str.h
 io.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 io.$(OBJEXT): $(top_srcdir)/internal/array.h
+io.$(OBJEXT): $(top_srcdir)/internal/basic_operators.h
 io.$(OBJEXT): $(top_srcdir)/internal/bignum.h
 io.$(OBJEXT): $(top_srcdir)/internal/bits.h
 io.$(OBJEXT): $(top_srcdir)/internal/class.h
@@ -7920,6 +7935,7 @@ iseq.$(OBJEXT): $(CCAN_DIR)/str/str.h
 iseq.$(OBJEXT): $(hdrdir)/ruby.h
 iseq.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 iseq.$(OBJEXT): $(top_srcdir)/internal/array.h
+iseq.$(OBJEXT): $(top_srcdir)/internal/basic_operators.h
 iseq.$(OBJEXT): $(top_srcdir)/internal/bits.h
 iseq.$(OBJEXT): $(top_srcdir)/internal/class.h
 iseq.$(OBJEXT): $(top_srcdir)/internal/compile.h
@@ -8142,6 +8158,7 @@ load.$(OBJEXT): $(CCAN_DIR)/list/list.h
 load.$(OBJEXT): $(CCAN_DIR)/str/str.h
 load.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 load.$(OBJEXT): $(top_srcdir)/internal/array.h
+load.$(OBJEXT): $(top_srcdir)/internal/basic_operators.h
 load.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 load.$(OBJEXT): $(top_srcdir)/internal/dir.h
 load.$(OBJEXT): $(top_srcdir)/internal/error.h
@@ -9388,6 +9405,7 @@ miniinit.$(OBJEXT): $(CCAN_DIR)/str/str.h
 miniinit.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 miniinit.$(OBJEXT): $(srcdir)/mjit_c.rb
 miniinit.$(OBJEXT): $(top_srcdir)/internal/array.h
+miniinit.$(OBJEXT): $(top_srcdir)/internal/basic_operators.h
 miniinit.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 miniinit.$(OBJEXT): $(top_srcdir)/internal/gc.h
 miniinit.$(OBJEXT): $(top_srcdir)/internal/imemo.h
@@ -9612,6 +9630,7 @@ mjit.$(OBJEXT): $(hdrdir)/ruby.h
 mjit.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 mjit.$(OBJEXT): $(hdrdir)/ruby/version.h
 mjit.$(OBJEXT): $(top_srcdir)/internal/array.h
+mjit.$(OBJEXT): $(top_srcdir)/internal/basic_operators.h
 mjit.$(OBJEXT): $(top_srcdir)/internal/class.h
 mjit.$(OBJEXT): $(top_srcdir)/internal/cmdlineopt.h
 mjit.$(OBJEXT): $(top_srcdir)/internal/compile.h
@@ -9839,6 +9858,7 @@ mjit_c.$(OBJEXT): $(hdrdir)/ruby.h
 mjit_c.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 mjit_c.$(OBJEXT): $(srcdir)/mjit_c.rb
 mjit_c.$(OBJEXT): $(top_srcdir)/internal/array.h
+mjit_c.$(OBJEXT): $(top_srcdir)/internal/basic_operators.h
 mjit_c.$(OBJEXT): $(top_srcdir)/internal/class.h
 mjit_c.$(OBJEXT): $(top_srcdir)/internal/compile.h
 mjit_c.$(OBJEXT): $(top_srcdir)/internal/compilers.h
@@ -10043,6 +10063,7 @@ node.$(OBJEXT): $(CCAN_DIR)/list/list.h
 node.$(OBJEXT): $(CCAN_DIR)/str/str.h
 node.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 node.$(OBJEXT): $(top_srcdir)/internal/array.h
+node.$(OBJEXT): $(top_srcdir)/internal/basic_operators.h
 node.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 node.$(OBJEXT): $(top_srcdir)/internal/gc.h
 node.$(OBJEXT): $(top_srcdir)/internal/hash.h
@@ -11030,6 +11051,7 @@ proc.$(OBJEXT): $(CCAN_DIR)/list/list.h
 proc.$(OBJEXT): $(CCAN_DIR)/str/str.h
 proc.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 proc.$(OBJEXT): $(top_srcdir)/internal/array.h
+proc.$(OBJEXT): $(top_srcdir)/internal/basic_operators.h
 proc.$(OBJEXT): $(top_srcdir)/internal/class.h
 proc.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 proc.$(OBJEXT): $(top_srcdir)/internal/error.h
@@ -11239,6 +11261,7 @@ process.$(OBJEXT): $(CCAN_DIR)/str/str.h
 process.$(OBJEXT): $(hdrdir)/ruby.h
 process.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 process.$(OBJEXT): $(top_srcdir)/internal/array.h
+process.$(OBJEXT): $(top_srcdir)/internal/basic_operators.h
 process.$(OBJEXT): $(top_srcdir)/internal/bignum.h
 process.$(OBJEXT): $(top_srcdir)/internal/bits.h
 process.$(OBJEXT): $(top_srcdir)/internal/class.h
@@ -11459,6 +11482,7 @@ ractor.$(OBJEXT): $(CCAN_DIR)/list/list.h
 ractor.$(OBJEXT): $(CCAN_DIR)/str/str.h
 ractor.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 ractor.$(OBJEXT): $(top_srcdir)/internal/array.h
+ractor.$(OBJEXT): $(top_srcdir)/internal/basic_operators.h
 ractor.$(OBJEXT): $(top_srcdir)/internal/bignum.h
 ractor.$(OBJEXT): $(top_srcdir)/internal/bits.h
 ractor.$(OBJEXT): $(top_srcdir)/internal/compilers.h
@@ -11857,6 +11881,7 @@ random.$(OBJEXT): {$(VPATH)}st.h
 random.$(OBJEXT): {$(VPATH)}subst.h
 range.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 range.$(OBJEXT): $(top_srcdir)/internal/array.h
+range.$(OBJEXT): $(top_srcdir)/internal/basic_operators.h
 range.$(OBJEXT): $(top_srcdir)/internal/bignum.h
 range.$(OBJEXT): $(top_srcdir)/internal/bits.h
 range.$(OBJEXT): $(top_srcdir)/internal/compar.h
@@ -13418,6 +13443,7 @@ ruby.$(OBJEXT): $(hdrdir)/ruby.h
 ruby.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 ruby.$(OBJEXT): $(hdrdir)/ruby/version.h
 ruby.$(OBJEXT): $(top_srcdir)/internal/array.h
+ruby.$(OBJEXT): $(top_srcdir)/internal/basic_operators.h
 ruby.$(OBJEXT): $(top_srcdir)/internal/class.h
 ruby.$(OBJEXT): $(top_srcdir)/internal/cmdlineopt.h
 ruby.$(OBJEXT): $(top_srcdir)/internal/compilers.h
@@ -13638,6 +13664,7 @@ scheduler.$(OBJEXT): $(CCAN_DIR)/list/list.h
 scheduler.$(OBJEXT): $(CCAN_DIR)/str/str.h
 scheduler.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 scheduler.$(OBJEXT): $(top_srcdir)/internal/array.h
+scheduler.$(OBJEXT): $(top_srcdir)/internal/basic_operators.h
 scheduler.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 scheduler.$(OBJEXT): $(top_srcdir)/internal/gc.h
 scheduler.$(OBJEXT): $(top_srcdir)/internal/imemo.h
@@ -13998,6 +14025,7 @@ shape.$(OBJEXT): $(CCAN_DIR)/list/list.h
 shape.$(OBJEXT): $(CCAN_DIR)/str/str.h
 shape.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 shape.$(OBJEXT): $(top_srcdir)/internal/array.h
+shape.$(OBJEXT): $(top_srcdir)/internal/basic_operators.h
 shape.$(OBJEXT): $(top_srcdir)/internal/class.h
 shape.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 shape.$(OBJEXT): $(top_srcdir)/internal/gc.h
@@ -14201,6 +14229,7 @@ signal.$(OBJEXT): $(CCAN_DIR)/list/list.h
 signal.$(OBJEXT): $(CCAN_DIR)/str/str.h
 signal.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 signal.$(OBJEXT): $(top_srcdir)/internal/array.h
+signal.$(OBJEXT): $(top_srcdir)/internal/basic_operators.h
 signal.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 signal.$(OBJEXT): $(top_srcdir)/internal/eval.h
 signal.$(OBJEXT): $(top_srcdir)/internal/gc.h
@@ -14946,6 +14975,7 @@ strftime.$(OBJEXT): {$(VPATH)}timev.h
 strftime.$(OBJEXT): {$(VPATH)}util.h
 string.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 string.$(OBJEXT): $(top_srcdir)/internal/array.h
+string.$(OBJEXT): $(top_srcdir)/internal/basic_operators.h
 string.$(OBJEXT): $(top_srcdir)/internal/bignum.h
 string.$(OBJEXT): $(top_srcdir)/internal/bits.h
 string.$(OBJEXT): $(top_srcdir)/internal/class.h
@@ -15191,6 +15221,7 @@ struct.$(OBJEXT): $(CCAN_DIR)/list/list.h
 struct.$(OBJEXT): $(CCAN_DIR)/str/str.h
 struct.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 struct.$(OBJEXT): $(top_srcdir)/internal/array.h
+struct.$(OBJEXT): $(top_srcdir)/internal/basic_operators.h
 struct.$(OBJEXT): $(top_srcdir)/internal/class.h
 struct.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 struct.$(OBJEXT): $(top_srcdir)/internal/error.h
@@ -15600,6 +15631,7 @@ thread.$(OBJEXT): $(CCAN_DIR)/str/str.h
 thread.$(OBJEXT): $(hdrdir)/ruby.h
 thread.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 thread.$(OBJEXT): $(top_srcdir)/internal/array.h
+thread.$(OBJEXT): $(top_srcdir)/internal/basic_operators.h
 thread.$(OBJEXT): $(top_srcdir)/internal/bits.h
 thread.$(OBJEXT): $(top_srcdir)/internal/class.h
 thread.$(OBJEXT): $(top_srcdir)/internal/compilers.h
@@ -15824,6 +15856,7 @@ thread.$(OBJEXT): {$(VPATH)}vm_opts.h
 thread.$(OBJEXT): {$(VPATH)}vm_sync.h
 time.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 time.$(OBJEXT): $(top_srcdir)/internal/array.h
+time.$(OBJEXT): $(top_srcdir)/internal/basic_operators.h
 time.$(OBJEXT): $(top_srcdir)/internal/bignum.h
 time.$(OBJEXT): $(top_srcdir)/internal/bits.h
 time.$(OBJEXT): $(top_srcdir)/internal/compar.h
@@ -16557,6 +16590,7 @@ variable.$(OBJEXT): $(CCAN_DIR)/list/list.h
 variable.$(OBJEXT): $(CCAN_DIR)/str/str.h
 variable.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 variable.$(OBJEXT): $(top_srcdir)/internal/array.h
+variable.$(OBJEXT): $(top_srcdir)/internal/basic_operators.h
 variable.$(OBJEXT): $(top_srcdir)/internal/class.h
 variable.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 variable.$(OBJEXT): $(top_srcdir)/internal/error.h
@@ -16773,6 +16807,7 @@ version.$(OBJEXT): $(hdrdir)/ruby.h
 version.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 version.$(OBJEXT): $(hdrdir)/ruby/version.h
 version.$(OBJEXT): $(top_srcdir)/internal/array.h
+version.$(OBJEXT): $(top_srcdir)/internal/basic_operators.h
 version.$(OBJEXT): $(top_srcdir)/internal/cmdlineopt.h
 version.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 version.$(OBJEXT): $(top_srcdir)/internal/gc.h
@@ -16965,6 +17000,7 @@ vm.$(OBJEXT): $(CCAN_DIR)/str/str.h
 vm.$(OBJEXT): $(hdrdir)/ruby.h
 vm.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 vm.$(OBJEXT): $(top_srcdir)/internal/array.h
+vm.$(OBJEXT): $(top_srcdir)/internal/basic_operators.h
 vm.$(OBJEXT): $(top_srcdir)/internal/bignum.h
 vm.$(OBJEXT): $(top_srcdir)/internal/bits.h
 vm.$(OBJEXT): $(top_srcdir)/internal/class.h
@@ -17215,6 +17251,7 @@ vm_backtrace.$(OBJEXT): $(CCAN_DIR)/list/list.h
 vm_backtrace.$(OBJEXT): $(CCAN_DIR)/str/str.h
 vm_backtrace.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 vm_backtrace.$(OBJEXT): $(top_srcdir)/internal/array.h
+vm_backtrace.$(OBJEXT): $(top_srcdir)/internal/basic_operators.h
 vm_backtrace.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 vm_backtrace.$(OBJEXT): $(top_srcdir)/internal/error.h
 vm_backtrace.$(OBJEXT): $(top_srcdir)/internal/gc.h
@@ -17417,6 +17454,7 @@ vm_dump.$(OBJEXT): $(CCAN_DIR)/list/list.h
 vm_dump.$(OBJEXT): $(CCAN_DIR)/str/str.h
 vm_dump.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 vm_dump.$(OBJEXT): $(top_srcdir)/internal/array.h
+vm_dump.$(OBJEXT): $(top_srcdir)/internal/basic_operators.h
 vm_dump.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 vm_dump.$(OBJEXT): $(top_srcdir)/internal/gc.h
 vm_dump.$(OBJEXT): $(top_srcdir)/internal/imemo.h
@@ -17609,6 +17647,7 @@ vm_sync.$(OBJEXT): $(CCAN_DIR)/list/list.h
 vm_sync.$(OBJEXT): $(CCAN_DIR)/str/str.h
 vm_sync.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 vm_sync.$(OBJEXT): $(top_srcdir)/internal/array.h
+vm_sync.$(OBJEXT): $(top_srcdir)/internal/basic_operators.h
 vm_sync.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 vm_sync.$(OBJEXT): $(top_srcdir)/internal/gc.h
 vm_sync.$(OBJEXT): $(top_srcdir)/internal/imemo.h
@@ -17801,6 +17840,7 @@ vm_trace.$(OBJEXT): $(CCAN_DIR)/str/str.h
 vm_trace.$(OBJEXT): $(hdrdir)/ruby.h
 vm_trace.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 vm_trace.$(OBJEXT): $(top_srcdir)/internal/array.h
+vm_trace.$(OBJEXT): $(top_srcdir)/internal/basic_operators.h
 vm_trace.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 vm_trace.$(OBJEXT): $(top_srcdir)/internal/gc.h
 vm_trace.$(OBJEXT): $(top_srcdir)/internal/hash.h
@@ -18009,6 +18049,7 @@ yjit.$(OBJEXT): $(CCAN_DIR)/list/list.h
 yjit.$(OBJEXT): $(CCAN_DIR)/str/str.h
 yjit.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 yjit.$(OBJEXT): $(top_srcdir)/internal/array.h
+yjit.$(OBJEXT): $(top_srcdir)/internal/basic_operators.h
 yjit.$(OBJEXT): $(top_srcdir)/internal/class.h
 yjit.$(OBJEXT): $(top_srcdir)/internal/compile.h
 yjit.$(OBJEXT): $(top_srcdir)/internal/compilers.h

--- a/ext/coverage/depend
+++ b/ext/coverage/depend
@@ -170,6 +170,7 @@ coverage.o: $(top_srcdir)/gc.h
 coverage.o: $(top_srcdir)/id_table.h
 coverage.o: $(top_srcdir)/internal.h
 coverage.o: $(top_srcdir)/internal/array.h
+coverage.o: $(top_srcdir)/internal/basic_operators.h
 coverage.o: $(top_srcdir)/internal/compilers.h
 coverage.o: $(top_srcdir)/internal/gc.h
 coverage.o: $(top_srcdir)/internal/hash.h

--- a/ext/objspace/depend
+++ b/ext/objspace/depend
@@ -539,6 +539,7 @@ objspace_dump.o: $(top_srcdir)/gc.h
 objspace_dump.o: $(top_srcdir)/id_table.h
 objspace_dump.o: $(top_srcdir)/internal.h
 objspace_dump.o: $(top_srcdir)/internal/array.h
+objspace_dump.o: $(top_srcdir)/internal/basic_operators.h
 objspace_dump.o: $(top_srcdir)/internal/compilers.h
 objspace_dump.o: $(top_srcdir)/internal/gc.h
 objspace_dump.o: $(top_srcdir)/internal/hash.h

--- a/internal/basic_operators.h
+++ b/internal/basic_operators.h
@@ -1,0 +1,62 @@
+#ifndef INTERNAL_BOP_H                                /*-*-C-*-vi:se ft=c:*/
+#define INTERNAL_BOP_H
+
+#include "internal.h"
+#include "ruby/internal/dllexport.h"
+
+enum ruby_basic_operators {
+    BOP_PLUS,
+    BOP_MINUS,
+    BOP_MULT,
+    BOP_DIV,
+    BOP_MOD,
+    BOP_EQ,
+    BOP_EQQ,
+    BOP_LT,
+    BOP_LE,
+    BOP_LTLT,
+    BOP_AREF,
+    BOP_ASET,
+    BOP_LENGTH,
+    BOP_SIZE,
+    BOP_EMPTY_P,
+    BOP_NIL_P,
+    BOP_SUCC,
+    BOP_GT,
+    BOP_GE,
+    BOP_NOT,
+    BOP_NEQ,
+    BOP_MATCH,
+    BOP_FREEZE,
+    BOP_UMINUS,
+    BOP_MAX,
+    BOP_MIN,
+    BOP_CALL,
+    BOP_AND,
+    BOP_OR,
+
+    BOP_LAST_
+};
+
+MJIT_SYMBOL_EXPORT_BEGIN
+RUBY_EXTERN short ruby_vm_redefined_flag[BOP_LAST_];
+MJIT_SYMBOL_EXPORT_END
+
+/* optimize insn */
+#define INTEGER_REDEFINED_OP_FLAG (1 << 0)
+#define FLOAT_REDEFINED_OP_FLAG  (1 << 1)
+#define STRING_REDEFINED_OP_FLAG (1 << 2)
+#define ARRAY_REDEFINED_OP_FLAG  (1 << 3)
+#define HASH_REDEFINED_OP_FLAG   (1 << 4)
+/* #define BIGNUM_REDEFINED_OP_FLAG (1 << 5) */
+#define SYMBOL_REDEFINED_OP_FLAG (1 << 6)
+#define TIME_REDEFINED_OP_FLAG   (1 << 7)
+#define REGEXP_REDEFINED_OP_FLAG (1 << 8)
+#define NIL_REDEFINED_OP_FLAG    (1 << 9)
+#define TRUE_REDEFINED_OP_FLAG   (1 << 10)
+#define FALSE_REDEFINED_OP_FLAG  (1 << 11)
+#define PROC_REDEFINED_OP_FLAG   (1 << 12)
+
+#define BASIC_OP_UNREDEFINED_P(op, klass) (LIKELY(ruby_vm_redefined_flag[(op)]&(klass)) == 0)
+
+#endif

--- a/internal/basic_operators.h
+++ b/internal/basic_operators.h
@@ -34,6 +34,7 @@ enum ruby_basic_operators {
     BOP_CALL,
     BOP_AND,
     BOP_OR,
+    BOP_CMP,
 
     BOP_LAST_
 };

--- a/internal/compar.h
+++ b/internal/compar.h
@@ -8,38 +8,18 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      Internal header for Comparable.
  */
-#include "internal/vm.h"        /* for rb_method_basic_definition_p */
+#include "internal/basic_operators.h"
 
 #define STRING_P(s) (RB_TYPE_P((s), T_STRING) && CLASS_OF(s) == rb_cString)
 
-enum {
-    cmp_opt_Integer,
-    cmp_opt_String,
-    cmp_opt_Float,
-    cmp_optimizable_count
-};
+#define CMP_OPTIMIZABLE(type) BASIC_OP_UNREDEFINED_P(BOP_CMP, type##_REDEFINED_OP_FLAG)
 
-struct cmp_opt_data {
-    unsigned int opt_methods;
-    unsigned int opt_inited;
-};
-
-#define NEW_CMP_OPT_MEMO(type, value) \
-    NEW_PARTIAL_MEMO_FOR(type, value, cmp_opt)
-#define CMP_OPTIMIZABLE_BIT(type) (1U << TOKEN_PASTE(cmp_opt_,type))
-#define CMP_OPTIMIZABLE(data, type) \
-    (((data).opt_inited & CMP_OPTIMIZABLE_BIT(type)) ? \
-     ((data).opt_methods & CMP_OPTIMIZABLE_BIT(type)) : \
-     (((data).opt_inited |= CMP_OPTIMIZABLE_BIT(type)), \
-      rb_method_basic_definition_p(TOKEN_PASTE(rb_c,type), id_cmp) && \
-      ((data).opt_methods |= CMP_OPTIMIZABLE_BIT(type))))
-
-#define OPTIMIZED_CMP(a, b, data) \
-    ((FIXNUM_P(a) && FIXNUM_P(b) && CMP_OPTIMIZABLE(data, Integer)) ? \
+#define OPTIMIZED_CMP(a, b) \
+    ((FIXNUM_P(a) && FIXNUM_P(b) && CMP_OPTIMIZABLE(INTEGER)) ? \
      (((long)a > (long)b) ? 1 : ((long)a < (long)b) ? -1 : 0) : \
-     (STRING_P(a) && STRING_P(b) && CMP_OPTIMIZABLE(data, String)) ? \
+     (STRING_P(a) && STRING_P(b) && CMP_OPTIMIZABLE(STRING)) ? \
      rb_str_cmp(a, b) : \
-     (RB_FLOAT_TYPE_P(a) && RB_FLOAT_TYPE_P(b) && CMP_OPTIMIZABLE(data, Float)) ? \
+     (RB_FLOAT_TYPE_P(a) && RB_FLOAT_TYPE_P(b) && CMP_OPTIMIZABLE(FLOAT)) ? \
      rb_float_cmp(a, b) : \
      rb_cmpint(rb_funcallv(a, id_cmp, 1, &b), a, b))
 

--- a/range.c
+++ b/range.c
@@ -1297,10 +1297,9 @@ range_min(int argc, VALUE *argv, VALUE range)
         return range_first(argc, argv, range);
     }
     else {
-        struct cmp_opt_data cmp_opt = { 0, 0 };
         VALUE b = RANGE_BEG(range);
         VALUE e = RANGE_END(range);
-        int c = NIL_P(e) ? -1 : OPTIMIZED_CMP(b, e, cmp_opt);
+        int c = NIL_P(e) ? -1 : OPTIMIZED_CMP(b, e);
 
         if (c > 0 || (c == 0 && EXCL(range)))
             return Qnil;
@@ -1408,8 +1407,7 @@ range_max(int argc, VALUE *argv, VALUE range)
         return rb_call_super(argc, argv);
     }
     else {
-        struct cmp_opt_data cmp_opt = { 0, 0 };
-        int c = NIL_P(b) ? -1 : OPTIMIZED_CMP(b, e, cmp_opt);
+        int c = NIL_P(b) ? -1 : OPTIMIZED_CMP(b, e);
 
         if (c > 0)
             return Qnil;

--- a/vm.c
+++ b/vm.c
@@ -2035,6 +2035,7 @@ vm_init_redefined_flag(void)
     OP(And, AND), (C(Integer));
     OP(Or, OR), (C(Integer));
     OP(NilP, NIL_P), (C(NilClass));
+    OP(Cmp, CMP), (C(Integer), C(Float), C(String));
 #undef C
 #undef OP
 }

--- a/vm.c
+++ b/vm.c
@@ -466,7 +466,6 @@ VALUE rb_cThread;
 VALUE rb_mRubyVMFrozenCore;
 VALUE rb_block_param_proxy;
 
-#define ruby_vm_redefined_flag GET_VM()->redefined_flag
 VALUE ruby_vm_const_missing_count = 0;
 rb_vm_t *ruby_current_vm_ptr = NULL;
 rb_ractor_t *ruby_single_main_ractor;
@@ -1894,6 +1893,7 @@ rb_iter_break_value(VALUE val)
 
 /* optimization: redefine management */
 
+short ruby_vm_redefined_flag[BOP_LAST_];
 static st_table *vm_opt_method_def_table = 0;
 static st_table *vm_opt_mid_table = 0;
 

--- a/vm_core.h
+++ b/vm_core.h
@@ -91,6 +91,7 @@ extern int ruby_assert_critical_section_entered;
 #include "id.h"
 #include "internal.h"
 #include "internal/array.h"
+#include "internal/basic_operators.h"
 #include "internal/serial.h"
 #include "internal/vm.h"
 #include "method.h"
@@ -582,40 +583,6 @@ enum ruby_special_exceptions {
     ruby_special_error_count
 };
 
-enum ruby_basic_operators {
-    BOP_PLUS,
-    BOP_MINUS,
-    BOP_MULT,
-    BOP_DIV,
-    BOP_MOD,
-    BOP_EQ,
-    BOP_EQQ,
-    BOP_LT,
-    BOP_LE,
-    BOP_LTLT,
-    BOP_AREF,
-    BOP_ASET,
-    BOP_LENGTH,
-    BOP_SIZE,
-    BOP_EMPTY_P,
-    BOP_NIL_P,
-    BOP_SUCC,
-    BOP_GT,
-    BOP_GE,
-    BOP_NOT,
-    BOP_NEQ,
-    BOP_MATCH,
-    BOP_FREEZE,
-    BOP_UMINUS,
-    BOP_MAX,
-    BOP_MIN,
-    BOP_CALL,
-    BOP_AND,
-    BOP_OR,
-
-    BOP_LAST_
-};
-
 #define GetVMPtr(obj, ptr) \
   GetCoreDataFromValue((obj), rb_vm_t, (ptr))
 
@@ -775,7 +742,6 @@ typedef struct rb_vm_struct {
         size_t fiber_machine_stack_size;
     } default_params;
 
-    short redefined_flag[BOP_LAST_];
 } rb_vm_t;
 
 /* default values */
@@ -807,23 +773,6 @@ typedef struct rb_vm_struct {
 #undef  RUBY_VM_FIBER_MACHINE_STACK_SIZE_MIN
 #define RUBY_VM_FIBER_MACHINE_STACK_SIZE_MIN  ( 128 * 1024 * sizeof(VALUE))
 #endif
-
-/* optimize insn */
-#define INTEGER_REDEFINED_OP_FLAG (1 << 0)
-#define FLOAT_REDEFINED_OP_FLAG  (1 << 1)
-#define STRING_REDEFINED_OP_FLAG (1 << 2)
-#define ARRAY_REDEFINED_OP_FLAG  (1 << 3)
-#define HASH_REDEFINED_OP_FLAG   (1 << 4)
-/* #define BIGNUM_REDEFINED_OP_FLAG (1 << 5) */
-#define SYMBOL_REDEFINED_OP_FLAG (1 << 6)
-#define TIME_REDEFINED_OP_FLAG   (1 << 7)
-#define REGEXP_REDEFINED_OP_FLAG (1 << 8)
-#define NIL_REDEFINED_OP_FLAG    (1 << 9)
-#define TRUE_REDEFINED_OP_FLAG   (1 << 10)
-#define FALSE_REDEFINED_OP_FLAG  (1 << 11)
-#define PROC_REDEFINED_OP_FLAG   (1 << 12)
-
-#define BASIC_OP_UNREDEFINED_P(op, klass) (LIKELY((GET_VM()->redefined_flag[(op)]&(klass)) == 0))
 
 #ifndef VM_DEBUG_BP_CHECK
 #define VM_DEBUG_BP_CHECK 0

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -5176,12 +5176,11 @@ vm_opt_newarray_max(rb_execution_context_t *ec, rb_num_t num, const VALUE *ptr)
             return Qnil;
         }
         else {
-            struct cmp_opt_data cmp_opt = { 0, 0 };
             VALUE result = *ptr;
             rb_snum_t i = num - 1;
             while (i-- > 0) {
                 const VALUE v = *++ptr;
-                if (OPTIMIZED_CMP(v, result, cmp_opt) > 0) {
+                if (OPTIMIZED_CMP(v, result) > 0) {
                     result = v;
                 }
             }
@@ -5201,12 +5200,11 @@ vm_opt_newarray_min(rb_execution_context_t *ec, rb_num_t num, const VALUE *ptr)
             return Qnil;
         }
         else {
-            struct cmp_opt_data cmp_opt = { 0, 0 };
             VALUE result = *ptr;
             rb_snum_t i = num - 1;
             while (i-- > 0) {
                 const VALUE v = *++ptr;
-                if (OPTIMIZED_CMP(v, result, cmp_opt) < 0) {
+                if (OPTIMIZED_CMP(v, result) < 0) {
                     result = v;
                 }
             }

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -701,7 +701,8 @@ pub const BOP_MIN: ruby_basic_operators = 25;
 pub const BOP_CALL: ruby_basic_operators = 26;
 pub const BOP_AND: ruby_basic_operators = 27;
 pub const BOP_OR: ruby_basic_operators = 28;
-pub const BOP_LAST_: ruby_basic_operators = 29;
+pub const BOP_CMP: ruby_basic_operators = 29;
+pub const BOP_LAST_: ruby_basic_operators = 30;
 pub type ruby_basic_operators = u32;
 pub type rb_serial_t = ::std::os::raw::c_ulonglong;
 extern "C" {

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -672,6 +672,37 @@ extern "C" {
         elts: *const VALUE,
     ) -> VALUE;
 }
+pub const BOP_PLUS: ruby_basic_operators = 0;
+pub const BOP_MINUS: ruby_basic_operators = 1;
+pub const BOP_MULT: ruby_basic_operators = 2;
+pub const BOP_DIV: ruby_basic_operators = 3;
+pub const BOP_MOD: ruby_basic_operators = 4;
+pub const BOP_EQ: ruby_basic_operators = 5;
+pub const BOP_EQQ: ruby_basic_operators = 6;
+pub const BOP_LT: ruby_basic_operators = 7;
+pub const BOP_LE: ruby_basic_operators = 8;
+pub const BOP_LTLT: ruby_basic_operators = 9;
+pub const BOP_AREF: ruby_basic_operators = 10;
+pub const BOP_ASET: ruby_basic_operators = 11;
+pub const BOP_LENGTH: ruby_basic_operators = 12;
+pub const BOP_SIZE: ruby_basic_operators = 13;
+pub const BOP_EMPTY_P: ruby_basic_operators = 14;
+pub const BOP_NIL_P: ruby_basic_operators = 15;
+pub const BOP_SUCC: ruby_basic_operators = 16;
+pub const BOP_GT: ruby_basic_operators = 17;
+pub const BOP_GE: ruby_basic_operators = 18;
+pub const BOP_NOT: ruby_basic_operators = 19;
+pub const BOP_NEQ: ruby_basic_operators = 20;
+pub const BOP_MATCH: ruby_basic_operators = 21;
+pub const BOP_FREEZE: ruby_basic_operators = 22;
+pub const BOP_UMINUS: ruby_basic_operators = 23;
+pub const BOP_MAX: ruby_basic_operators = 24;
+pub const BOP_MIN: ruby_basic_operators = 25;
+pub const BOP_CALL: ruby_basic_operators = 26;
+pub const BOP_AND: ruby_basic_operators = 27;
+pub const BOP_OR: ruby_basic_operators = 28;
+pub const BOP_LAST_: ruby_basic_operators = 29;
+pub type ruby_basic_operators = u32;
 pub type rb_serial_t = ::std::os::raw::c_ulonglong;
 extern "C" {
     pub fn rb_class_allocate_instance(klass: VALUE) -> VALUE;
@@ -818,37 +849,6 @@ pub struct rb_iseq_constant_body__bindgen_ty_1_rb_iseq_param_keyword {
     pub table: *const ID,
     pub default_values: *mut VALUE,
 }
-pub const BOP_PLUS: ruby_basic_operators = 0;
-pub const BOP_MINUS: ruby_basic_operators = 1;
-pub const BOP_MULT: ruby_basic_operators = 2;
-pub const BOP_DIV: ruby_basic_operators = 3;
-pub const BOP_MOD: ruby_basic_operators = 4;
-pub const BOP_EQ: ruby_basic_operators = 5;
-pub const BOP_EQQ: ruby_basic_operators = 6;
-pub const BOP_LT: ruby_basic_operators = 7;
-pub const BOP_LE: ruby_basic_operators = 8;
-pub const BOP_LTLT: ruby_basic_operators = 9;
-pub const BOP_AREF: ruby_basic_operators = 10;
-pub const BOP_ASET: ruby_basic_operators = 11;
-pub const BOP_LENGTH: ruby_basic_operators = 12;
-pub const BOP_SIZE: ruby_basic_operators = 13;
-pub const BOP_EMPTY_P: ruby_basic_operators = 14;
-pub const BOP_NIL_P: ruby_basic_operators = 15;
-pub const BOP_SUCC: ruby_basic_operators = 16;
-pub const BOP_GT: ruby_basic_operators = 17;
-pub const BOP_GE: ruby_basic_operators = 18;
-pub const BOP_NOT: ruby_basic_operators = 19;
-pub const BOP_NEQ: ruby_basic_operators = 20;
-pub const BOP_MATCH: ruby_basic_operators = 21;
-pub const BOP_FREEZE: ruby_basic_operators = 22;
-pub const BOP_UMINUS: ruby_basic_operators = 23;
-pub const BOP_MAX: ruby_basic_operators = 24;
-pub const BOP_MIN: ruby_basic_operators = 25;
-pub const BOP_CALL: ruby_basic_operators = 26;
-pub const BOP_AND: ruby_basic_operators = 27;
-pub const BOP_OR: ruby_basic_operators = 28;
-pub const BOP_LAST_: ruby_basic_operators = 29;
-pub type ruby_basic_operators = u32;
 #[repr(C)]
 pub struct rb_captured_block {
     pub self_: VALUE,


### PR DESCRIPTION
This PR introduces a new basic operator, BOP_CMP, so we can quickly check whether `<=>` has been redefined when doing optimized comparisons.

The PR is in two commits (plus one more to update the deps), which could be reviewed separtely:

Move BOP macros to separate file
---

This first commit moves `ruby_basic_operators` and the `UNREDEFINED` macros out of
vm_core.h and into basic_operators.h so that we can use them in internal/compar.h, as well as more broadly in places where we currently do a method look up via `rb_method_basic_definition_p` (e.g. object.c, numeric.c, complex.c, enum.c, and a number of other places if we introduce more BOPs).

The most controversial part of this first commit is probably moving `redefined_flag` out of `rb_vm_t`. Neither [vm_opt_method_def_table or vm_opt_mid_table](https://github.com/ruby/ruby/blob/9da2a5204f32a4f2ce135fddde2abb6e07d647e9/vm.c) are part of rb_vm_t either, and I do think `redefined_flag` fits well with those. But more significantly it seems to result in one fewer instruction. For example:

Before:

```
(lldb) disassemble -n vm_opt_str_freeze
miniruby`vm_exec_core:
miniruby[0x10028233e] <+14558>: movq   0x11a86b(%rip), %rax      ; ruby_current_vm_ptr
miniruby[0x100282345] <+14565>: testb  $0x4, 0x242c(%rax)
```

After:

```
(lldb) disassemble -n vm_opt_str_freeze
ruby`vm_exec_core:
ruby[0x100280ebe] <+14510>: testb  $0x4, 0x120147(%rip)      ; ruby_vm_redefined_flag + 43
```

Introduce BOP_CMP for optimized comparison
---

Prior to this commit the `OPTIMIZED_CMP` macro relied on a method lookup to determine whether `<=>` was overridden. The result of the lookup was cached, but only for the duration of the specific method that initialized the cmp_opt_data cache structure.

With this method lookup, `[x,y].max` is slower than doing `x > y ? x : y` even though there's an optimized instruction for "new array max". (John noticed somebody a proposed micro-optimization based on this fact in https://github.com/mastodon/mastodon/pull/19903.)

```rb
a, b = 1, 2
Benchmark.ips do |bm|
  bm.report('conditional') { a > b ? a : b }
  bm.report('method') { [a, b].max }
  bm.compare!
end
```

Before:

```
Comparison:
         conditional: 22603733.2 i/s
              method: 19820412.7 i/s - 1.14x  (± 0.00) slower
```

This commit replaces the method lookup with a new CMP basic op, which gives the examples above equivalent performance.

After:

```
Comparison:
              method: 24022466.5 i/s
         conditional: 23851094.2 i/s - same-ish: difference falls within error
```

Relevant benchmarks show an improvement to Array#max and Array#min when not using the optimized newarray_max instruction as well. They are noticeably faster for small arrays with the relevant types, and the same or maybe a touch faster on larger arrays.

<details>

<summary>Benchmark output comparing master@5958c305 against these changes</summary>

* array_max_int

  ```
  |                |compare-ruby|built-ruby|
  |:---------------|-----------:|---------:|
  |ary2.max        |     31.546M|   45.045M|
  |                |           -|     1.43x|
  |ary10.max       |     25.907M|   37.594M|
  |                |           -|     1.45x|
  |ary100.max      |     12.092M|   13.123M|
  |                |           -|     1.09x|
  |ary500.max      |      3.775M|    3.964M|
  |                |           -|     1.05x|
  |ary1000.max     |      2.053M|    2.058M|
  |                |           -|     1.00x|
  |ary2000.max     |    713.012k|  813.339k|
  |                |           -|     1.14x|
  |ary3000.max     |    848.320k|  856.825k|
  |                |           -|     1.01x|
  |ary5000.max     |    403.161k|  412.116k|
  |                |           -|     1.02x|
  |ary10000.max    |    208.381k|  209.780k|
  |                |           -|     1.01x|
  |ary20000.max    |    106.438k|  107.331k|
  |                |           -|     1.01x|
  |ary50000.max    |     42.102k|   41.743k|
  |                |       1.01x|         -|
  |ary100000.max   |     21.131k|   21.069k|
  |                |       1.00x|         -|
  |ary1000000.max  |      2.052k|    2.013k|
  |                |       1.02x|         -|
  ```

* array_max_float

  ```
  |               |compare-ruby|built-ruby|
  |:--------------|-----------:|---------:|
  |ary2.max       |     26.882M|   34.843M|
  |               |           -|     1.30x|
  |ary10.max      |     10.299M|   12.453M|
  |               |           -|     1.21x|
  |ary100.max     |      1.321M|    1.286M|
  |               |       1.03x|         -|
  |ary500.max     |    269.818k|  290.909k|
  |               |           -|     1.08x|
  |ary1000.max    |    136.947k|  152.849k|
  |               |           -|     1.12x|
  |ary2000.max    |     56.819k|   57.943k|
  |               |           -|     1.02x|
  |ary3000.max    |     56.480k|   60.751k|
  |               |           -|     1.08x|
  |ary5000.max    |     28.669k|   30.332k|
  |               |           -|     1.06x|
  |ary10000.max   |     14.247k|   15.255k|
  |               |           -|     1.07x|
  |ary20000.max   |      7.037k|    7.691k|
  |               |           -|     1.09x|
  |ary50000.max   |      2.841k|    3.076k|
  |               |           -|     1.08x|
  |ary100000.max  |      1.442k|    1.523k|
  |               |           -|     1.06x|
  ```

* array_max_str

  ```
  |               |compare-ruby|built-ruby|
  |:--------------|-----------:|---------:|
  |ary2.max       |     21.882M|   35.461M|
  |               |           -|     1.62x|
  |ary10.max      |     11.834M|   13.228M|
  |               |           -|     1.12x|
  |ary100.max     |      1.398M|    1.410M|
  |               |           -|     1.01x|
  |ary500.max     |    309.885k|  304.284k|
  |               |       1.02x|         -|
  |ary1000.max    |    138.160k|  138.101k|
  |               |       1.00x|         -|
  |ary2000.max    |     57.870k|   61.428k|
  |               |           -|     1.06x|
  |ary3000.max    |     58.945k|   59.989k|
  |               |           -|     1.02x|
  |ary5000.max    |     30.331k|   31.941k|
  |               |           -|     1.05x|
  |ary10000.max   |     12.037k|   12.395k|
  |               |           -|     1.03x|
  |ary20000.max   |      6.169k|    6.258k|
  |               |           -|     1.01x|
  |ary50000.max   |      2.459k|    2.506k|
  |               |           -|     1.02x|
  |ary100000.max  |      1.023k|    1.035k|
  |               |           -|     1.01x|
  ```

* array_min

  ```
  |                |compare-ruby|built-ruby|
  |:---------------|-----------:|---------:|
  |ary2.min        |     27.778M|   45.249M|
  |                |           -|     1.63x|
  |ary10.min       |     26.667M|   37.313M|
  |                |           -|     1.40x|
  |ary100.min      |     12.346M|   12.970M|
  |                |           -|     1.05x|
  |ary500.min      |      3.413M|    4.088M|
  |                |           -|     1.20x|
  |ary1000.min     |      2.049M|    2.081M|
  |                |           -|     1.02x|
  |ary2000.min     |    847.027k|  823.113k|
  |                |       1.03x|         -|
  |ary3000.min     |    788.830k|  857.045k|
  |                |           -|     1.09x|
  |ary5000.min     |    400.064k|  413.223k|
  |                |           -|     1.03x|
  |ary10000.min    |    205.225k|  209.661k|
  |                |           -|     1.02x|
  |ary20000.min    |    106.158k|  106.014k|
  |                |       1.00x|         -|
  |ary50000.min    |     41.978k|   41.151k|
  |                |       1.02x|         -|
  |ary100000.min   |     20.452k|   20.793k|
  |                |           -|     1.02x|
  |ary1000000.min  |      1.970k|    2.015k|
  |                |           -|     1.02x|
  ```

* array_sort_int

  ```
  |               |compare-ruby|built-ruby|
  |:--------------|-----------:|---------:|
  |ary2.sort      |      4.476M|    4.566M|
  |               |           -|     1.02x|
  |ary10.sort     |      1.883M|    1.952M|
  |               |           -|     1.04x|
  |ary100.sort    |    188.740k|  208.212k|
  |               |           -|     1.10x|
  |ary1000.sort   |     11.633k|   12.404k|
  |               |           -|     1.07x|
  |ary10000.sort  |     870.835|   901.142|
  |               |           -|     1.03x|

* range_min

  ```
  |             |compare-ruby|built-ruby|
  |:------------|-----------:|---------:|
  |(1..10).min  |     35.793M|   45.426M|
  |             |           -|     1.27x|
  ```
  ```
* enum_minmax

  ```
  |                 |compare-ruby|built-ruby|
  |:----------------|-----------:|---------:|
  |set2.min         |      1.966M|    2.267M|
  |                 |           -|     1.15x|
  |set10.min        |      1.340M|    1.479M|
  |                 |           -|     1.10x|
  |set100.min       |    383.083k|  363.135k|
  |                 |       1.05x|         -|
  |set1000.min      |     48.824k|   49.068k|
  |                 |           -|     1.00x|
  |set10000.min     |      5.084k|    5.107k|
  |                 |           -|     1.00x|
  |set2.max         |      1.979M|    2.536M|
  |                 |           -|     1.28x|
  |set10.max        |      1.400M|    1.656M|
  |                 |           -|     1.18x|
  |set100.max       |    381.185k|  368.094k|
  |                 |       1.04x|         -|
  |set1000.max      |     48.235k|   48.075k|
  |                 |       1.00x|         -|
  |set10000.max     |      4.971k|    4.841k|
  |                 |       1.03x|         -|
  |set2.minmax      |      2.278M|    2.352M|
  |                 |           -|     1.03x|
  |set10.minmax     |      1.558M|    1.429M|
  |                 |       1.09x|         -|
  |set100.minmax    |    310.299k|  298.998k|
  |                 |       1.04x|         -|
  |set1000.minmax   |     40.261k|   41.033k|
  |                 |           -|     1.02x|
  |set10000.minmax  |      4.126k|    4.217k|
  |                 |           -|     1.02x|
  ```

* enum_sort

  ```
  |                  |compare-ruby|built-ruby|
  |:-----------------|-----------:|---------:|
  |set2.sort_by      |      1.100M|    1.188M|
  |                  |           -|     1.08x|
  |set10.sort_by     |    558.534k|  608.643k|
  |                  |           -|     1.09x|
  |set100.sort_by    |    107.417k|  116.046k|
  |                  |           -|     1.08x|
  |set1000.sort_by   |     13.077k|   13.804k|
  |                  |           -|     1.06x|
  |set10000.sort_by  |      1.279k|    1.327k|
  |                  |           -|     1.04x|
  ```

</details>