### PR TITLE
YJIT: check that we correctly auto-enable YJIT on Linux

### DIFF
--- a/.github/workflows/yjit-ubuntu.yml
+++ b/.github/workflows/yjit-ubuntu.yml
@@ -51,7 +51,7 @@ jobs:
             configure: "--with-gcc=clang-12 --enable-yjit=dev"
 
           - test_task: "check"
-            # YJIT should be automatically built in release mode
+            # YJIT should be automatically built in release mode on x86-64 Linux with rustc present
             #configure: "--enable-yjit RUSTC='rustc +1.58.0'"
             configure: "RUSTC='rustc +1.58.0'"
             rust_version: "1.58.0"
@@ -128,7 +128,7 @@ jobs:
         run: echo "RUBY_YJIT_ENABLE=1" >> $GITHUB_ENV
       # Check that the binary was built with YJIT
       - name: Check YJIT enabled
-        run: ruby --yjit -v | grep "+YJIT"
+        run: ./miniruby --yjit -v | grep "+YJIT"
       - name: make ${{ matrix.test_task }}
         run: make -s -j ${{ matrix.test_task }} RUN_OPTS="$RUN_OPTS" YJIT_BENCH_OPTS="$YJIT_BENCH_OPTS"
         timeout-minutes: 60

--- a/.github/workflows/yjit-ubuntu.yml
+++ b/.github/workflows/yjit-ubuntu.yml
@@ -51,7 +51,9 @@ jobs:
             configure: "--with-gcc=clang-12 --enable-yjit=dev"
 
           - test_task: "check"
-            configure: "--enable-yjit RUSTC='rustc +1.58.0'" # release build
+            # YJIT should be automatically built in release mode
+            #configure: "--enable-yjit RUSTC='rustc +1.58.0'"
+            configure: "RUSTC='rustc +1.58.0'"
             rust_version: "1.58.0"
 
           - test_task: "check"
@@ -124,6 +126,9 @@ jobs:
         if: ${{ matrix.test_task == 'check' }}
       - name: Enable YJIT through ENV
         run: echo "RUBY_YJIT_ENABLE=1" >> $GITHUB_ENV
+      # Check that the binary was built with YJIT
+      - name: Check YJIT enabled
+        run: ruby --yjit -v | grep "+YJIT"
       - name: make ${{ matrix.test_task }}
         run: make -s -j ${{ matrix.test_task }} RUN_OPTS="$RUN_OPTS" YJIT_BENCH_OPTS="$YJIT_BENCH_OPTS"
         timeout-minutes: 60


### PR DESCRIPTION
YJIT should be automatically built on Linux x86-64 when rustc is present, and we should see +YJIT in the version string.

This will address https://github.com/Shopify/ruby/issues/461