### PR TITLE
tool/runruby.rb: remove LD_PRELOAD-like env-var options from runruby.rb

### DIFF
--- a/tool/runruby.rb
+++ b/tool/runruby.rb
@@ -133,15 +133,6 @@ if File.file?(libruby_so)
   if e = config['LIBPATHENV'] and !e.empty?
     env[e] = [abs_archdir, ENV[e]].compact.join(File::PATH_SEPARATOR)
   end
-  unless runner
-    if e = config['PRELOADENV']
-      e = nil if e.empty?
-      e ||= "LD_PRELOAD" if /linux/ =~ RUBY_PLATFORM
-    end
-    if e
-      env[e] = [libruby_so, ENV[e]].compact.join(File::PATH_SEPARATOR)
-    end
-  end
 end
 
 ENV.update env


### PR DESCRIPTION
LD_PRELOAD sometimes forces loading libraries into incompatible executables. For example, macOS on recent Apple Silicon can execute arm64 and arm64e binaries by default, and /usr/bin/clang is built as arm64e. If Ruby is built as arm64, and mkmf launched through runruby.rb spawns /usr/bin/clang, dynamic loader tries to load libruby (arm64e) into clang (arm64). This force-load causes library load failure. In theory, we don't need both LD_PRELOAD and LD_LIBRARY_PATH at the same time, because executables requiring libruby already have libruby dependency, so LD_LIBRARY_PATH is enough for this case.