### PR TITLE
Freeze singleton class, not its origin

### DIFF
--- a/class.c
+++ b/class.c
@@ -2148,7 +2148,7 @@ rb_freeze_singleton_class(VALUE x)
     /* should not propagate to meta-meta-class, and so on */
     if (!(RBASIC(x)->flags & FL_SINGLETON)) {
         VALUE klass = RBASIC_CLASS(x);
-        if (klass && (klass = RCLASS_ORIGIN(klass)) != 0 &&
+        if (klass && // no class when hidden from ObjectSpace
             FL_TEST(klass, (FL_SINGLETON|FL_FREEZE)) == FL_SINGLETON) {
             OBJ_FREEZE_RAW(klass);
         }

--- a/test/ruby/test_object.rb
+++ b/test/ruby/test_object.rb
@@ -925,6 +925,19 @@ class TestObject < Test::Unit::TestCase
     end
   end
 
+  def test_singleton_class_freeze
+    x = Object.new
+    xs = x.singleton_class
+    x.freeze
+    assert_predicate(xs, :frozen?)
+
+    y = Object.new
+    ys = y.singleton_class
+    ys.prepend(Module.new)
+    y.freeze
+    assert_predicate(ys, :frozen?, '[Bug #19169]')
+  end
+
   def test_redef_method_missing
     bug5473 = '[ruby-core:40287]'
     ['ArgumentError.new("bug5473")', 'ArgumentError, "bug5473"', '"bug5473"'].each do |code|


### PR DESCRIPTION
Previously, when we froze an object, we froze
`RCLASS_ORIGIN(object.singleton_class)`, which didn't freeze
`object.singleton_class` when it has some prepended modules.
This was a weird inconsistency because we _did_ freeze the
singleton class when it has no prepended modules.

Origin iclasses are internal objects and users can't interact with
them through Kernel#freeze?, Kernel#freeze, or any mutation method
that checks the frozen status. So we shouldn't touch the origin
iclasses when the frozen status should be visible.

[[Bug #19169]](https://bugs.ruby-lang.org/issues/19169)
