### PR TITLE
Set max_iv_count (used for object shapes) based on inline caches

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -2461,7 +2461,17 @@ iseq_set_sequence(rb_iseq_t *iseq, LINK_ANCHOR *const anchor)
                       case TS_IVC: /* inline ivar cache */
                         {
                             unsigned int ic_index = FIX2UINT(operands[j]);
-                            vm_ic_attr_index_initialize(((IVC)&body->is_entries[ic_index]), INVALID_SHAPE_ID);
+
+                            IVC cache = ((IVC)&body->is_entries[ic_index]);
+
+                            if (insn == BIN(setinstancevariable)) {
+                                cache->iv_set_name = SYM2ID(operands[j - 1]);
+                            }
+                            else {
+                                cache->iv_set_name = 0;
+                            }
+
+                            vm_ic_attr_index_initialize(cache, INVALID_SHAPE_ID);
                         }
                       case TS_ISE: /* inline storage entry: `once` insn */
                       case TS_ICVARC: /* inline cvar cache */
@@ -11529,7 +11539,17 @@ ibf_load_code(const struct ibf_load *load, rb_iseq_t *iseq, ibf_offset_t bytecod
                     code[code_index] = (VALUE)ic;
 
                     if (operand_type == TS_IVC) {
-                        vm_ic_attr_index_initialize(((IVC)code[code_index]), INVALID_SHAPE_ID);
+                        IVC cache = (IVC)ic;
+
+                        if (insn == BIN(setinstancevariable)) {
+                            ID iv_name = (ID)code[code_index - 1];
+                            cache->iv_set_name = iv_name;
+                        }
+                        else {
+                            cache->iv_set_name = 0;
+                        }
+
+                        vm_ic_attr_index_initialize(cache, INVALID_SHAPE_ID);
                     }
 
                 }

--- a/mjit_c.rb
+++ b/mjit_c.rb
@@ -310,6 +310,7 @@ module RubyVM::MJIT
     @iseq_inline_iv_cache_entry ||= CType::Struct.new(
       "iseq_inline_iv_cache_entry", Primitive.cexpr!("SIZEOF(struct iseq_inline_iv_cache_entry)"),
       value: [CType::Immediate.parse("uintptr_t"), Primitive.cexpr!("OFFSETOF((*((struct iseq_inline_iv_cache_entry *)NULL)), value)")],
+      iv_set_name: [self.ID, Primitive.cexpr!("OFFSETOF((*((struct iseq_inline_iv_cache_entry *)NULL)), iv_set_name)")],
     )
   end
 

--- a/vm_core.h
+++ b/vm_core.h
@@ -274,6 +274,7 @@ struct iseq_inline_constant_cache {
 
 struct iseq_inline_iv_cache_entry {
     uintptr_t value; // attr_index in lower bits, dest_shape_id in upper bits
+    ID iv_set_name;
 };
 
 struct iseq_inline_cvar_cache_entry {

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -821,6 +821,7 @@ pub struct iseq_inline_constant_cache {
 #[derive(Debug, Copy, Clone)]
 pub struct iseq_inline_iv_cache_entry {
     pub value: usize,
+    pub iv_set_name: ID,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]


### PR DESCRIPTION
With this change, we're storing the iv name on an inline cache on setinstancevariable instructions. This allows us to check the inline cache to count instance variables set in initialize and give us an estimate of iv capacity for an object.

For the purpose of estimating the number of instance variables required for an object, we're assuming that all initialize methods will call `super`.

This change allows us to estimate the number of instance variables required without disassembling instruction sequences.

Co-Authored-By: Aaron Patterson <tenderlove@ruby-lang.org>