### PR TITLE
Use rb_inspect instead of +PRIsVALUE for Object.inspect

### DIFF
--- a/object.c
+++ b/object.c
@@ -677,8 +677,8 @@ inspect_i(st_data_t k, st_data_t v, st_data_t a)
     else {
         rb_str_cat2(str, ", ");
     }
-    rb_str_catf(str, "%"PRIsVALUE"=%+"PRIsVALUE,
-                rb_id2str(id), value);
+    rb_str_catf(str, "%"PRIsVALUE"=", rb_id2str(id));
+    rb_str_buf_append(str, rb_inspect(value));
 
     return ST_CONTINUE;
 }

--- a/test/ruby/test_object.rb
+++ b/test/ruby/test_object.rb
@@ -853,6 +853,15 @@ class TestObject < Test::Unit::TestCase
     x.instance_variable_set(:@bar, 42)
     assert_match(/\A#<Object:0x\h+ (?:@foo="value", @bar=42|@bar=42, @foo="value")>\z/, x.inspect)
 
+    # Bug: [ruby-core:19167]
+    x = Object.new
+    x.instance_variable_set(:@foo, NilClass)
+    assert_match(/\A#<Object:0x\h+ @foo=NilClass>\z/, x.inspect)
+    x.instance_variable_set(:@foo, TrueClass)
+    assert_match(/\A#<Object:0x\h+ @foo=TrueClass>\z/, x.inspect)
+    x.instance_variable_set(:@foo, FalseClass)
+    assert_match(/\A#<Object:0x\h+ @foo=FalseClass>\z/, x.inspect)
+
     # #inspect does not call #to_s anymore
     feature6130 = '[ruby-core:43238]'
     x = Object.new


### PR DESCRIPTION
In order to preserve the values when TrueClass, FalseClass or NilClass are stored in ivars

[[Bug #19167]](https://bugs.ruby-lang.org/issues/19167)