### PR TITLE
Ignore .o.tmp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 *.inc
 *.log
 *.o
+*.o.tmp
 *.obj
 *.old
 *.orig


### PR DESCRIPTION
I see these jumping in my editor file tree when I compile ruby.