### PR TITLE
Remove unused counter for heap_page->pinned_slots

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -945,7 +945,6 @@ struct heap_page {
     short slot_size;
     short total_slots;
     short free_slots;
-    short pinned_slots;
     short final_slots;
     struct {
         unsigned int before_sweep : 1;


### PR DESCRIPTION
usage of this field was removed in 67b2c21c327c96d80b8a0fe02a96d417e85293e8 when auto_compact was introduced.