### PR TITLE
objspace_dump.c: dump the capacity field for INITIAL_CAPACITY shapes

### DIFF
--- a/ext/objspace/objspace_dump.c
+++ b/ext/objspace/objspace_dump.c
@@ -747,6 +747,8 @@ shape_i(rb_shape_t *shape, void *data)
         break;
       case SHAPE_INITIAL_CAPACITY:
         dump_append(dc, "\"INITIAL_CAPACITY\"");
+        dump_append(dc, ", \"capacity\":");
+        dump_append_sizet(dc, shape->capacity);
         break;
       case SHAPE_T_OBJECT:
         dump_append(dc, "\"T_OBJECT\"");


### PR DESCRIPTION
We forgot about that one, it's quite useful to see which capacity we started from.

Followup: https://github.com/ruby/ruby/pull/6868

FYI @jemmaissroff @tenderlove @k0kubun @jhawthorn @composerinteralia 