### PR TITLE
YJIT: Filter out 0-exit ops from Top-20 exit ops

### DIFF
--- a/yjit.rb
+++ b/yjit.rb
@@ -299,14 +299,14 @@ module RubyVM::YJIT
         end
       end
 
-      exits = exits.sort_by { |name, count| -count }[0...how_many]
+      exits = exits.select { |_name, count| count > 0 }.sort_by { |_name, count| -count }.first(how_many)
       total_exits = total_exit_count(stats)
 
       if total_exits > 0
         top_n_total = exits.map { |name, count| count }.sum
         top_n_exit_pct = 100.0 * top_n_total / total_exits
 
-        $stderr.puts "Top-#{how_many} most frequent exit ops (#{"%.1f" % top_n_exit_pct}% of exits):"
+        $stderr.puts "Top-#{exits.size} most frequent exit ops (#{"%.1f" % top_n_exit_pct}% of exits):"
 
         longest_insn_name_len = exits.map { |name, count| name.length }.max
         exits.each do |name, count|


### PR DESCRIPTION
This always shows 20 entries, but we don't need to show zeros.

## Example: psych-load
### Before
```
Top-20 most frequent exit ops (100.0% of exits):
                      send:      15274 (37.9%)
               invokesuper:       7666 (19.0%)
    opt_send_without_block:       7620 (18.9%)
                     throw:       7493 (18.6%)
                     leave:       1677 (4.2%)
               invokeblock:        527 (1.3%)
                      once:          7 (0.0%)
      opt_getconstant_path:          6 (0.0%)
             setlocal_WC_0:          1 (0.0%)
                opt_length:          1 (0.0%)
       setinstancevariable:          0 (0.0%)
          getclassvariable:          0 (0.0%)
          setclassvariable:          0 (0.0%)
               getconstant:          0 (0.0%)
               setconstant:          0 (0.0%)
                 getglobal:          0 (0.0%)
                 setglobal:          0 (0.0%)
                    putnil:          0 (0.0%)
                   putself:          0 (0.0%)
                 putobject:          0 (0.0%)
```

### After
```
Top-9 most frequent exit ops (100.0% of exits):
                      send:      15274 (37.9%)
               invokesuper:       7666 (19.0%)
    opt_send_without_block:       7617 (18.9%)
                     throw:       7493 (18.6%)
                     leave:       1677 (4.2%)
               invokeblock:        527 (1.3%)
                      once:          7 (0.0%)
      opt_getconstant_path:          6 (0.0%)
             setlocal_WC_0:          1 (0.0%)
```