### PR TITLE
YJIT: Implement opt_newarray_max instruction

### DIFF
--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -5198,6 +5198,12 @@ vm_opt_newarray_max(rb_execution_context_t *ec, rb_num_t num, const VALUE *ptr)
     }
 }
 
+VALUE
+rb_vm_opt_newarray_max(rb_execution_context_t *ec, rb_num_t num, const VALUE *ptr)
+{
+    return vm_opt_newarray_max(ec, num, ptr);
+}
+
 static VALUE
 vm_opt_newarray_min(rb_execution_context_t *ec, rb_num_t num, const VALUE *ptr)
 {

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -3304,6 +3304,41 @@ fn gen_opt_str_uminus(
     KeepCompiling
 }
 
+fn gen_opt_newarray_max(
+    jit: &mut JITState,
+    ctx: &mut Context,
+    asm: &mut Assembler,
+    _ocb: &mut OutlinedCb,
+) -> CodegenStatus {
+    let num = jit_get_arg(jit, 0).as_u32();
+
+    // Save the PC and SP because we may allocate
+    jit_prepare_routine_call(jit, ctx, asm);
+
+    extern "C" {
+        fn rb_vm_opt_newarray_max(ec: EcPtr, num: u32, elts: *const VALUE) -> VALUE;
+    }
+
+    let offset_magnitude = (SIZEOF_VALUE as u32) * num;
+    let values_opnd = ctx.sp_opnd(-(offset_magnitude as isize));
+    let values_ptr = asm.lea(values_opnd);
+
+    let val_opnd = asm.ccall(
+        rb_vm_opt_newarray_max as *const u8,
+        vec![
+            EC,
+            num.into(),
+            values_ptr
+        ],
+    );
+
+    ctx.stack_pop(num.as_usize());
+    let stack_ret = ctx.stack_push(Type::Unknown);
+    asm.mov(stack_ret, val_opnd);
+
+    KeepCompiling
+}
+
 fn gen_opt_newarray_min(
     jit: &mut JITState,
     ctx: &mut Context,
@@ -7002,6 +7037,7 @@ fn get_gen_fn(opcode: VALUE) -> Option<InsnGenFn> {
         YARVINSN_opt_mod => Some(gen_opt_mod),
         YARVINSN_opt_str_freeze => Some(gen_opt_str_freeze),
         YARVINSN_opt_str_uminus => Some(gen_opt_str_uminus),
+        YARVINSN_opt_newarray_max => Some(gen_opt_newarray_max),
         YARVINSN_opt_newarray_min => Some(gen_opt_newarray_min),
         YARVINSN_splatarray => Some(gen_splatarray),
         YARVINSN_concatarray => Some(gen_concatarray),


### PR DESCRIPTION
Almost the same thing as https://github.com/ruby/ruby/pull/6888.

Prior to this PR, some benchmarks were exiting on `opt_newarray_max`:

| benchmark | ratio_in_yjit | opt_newarray_max: exit reasons % |
|:----------|:--------------|:-------------------|
| activerecord | 88.8% | 0 |
| hexapdf | 82.9% | 17.3% |
| liquid-render | 86.8% | 0 |
| mail | 98.9% | 4% |
| psych-load | 100% | 0 |
| railsbench | 92.9% | 0.0% |
| ruby-lsp | 68.7% | 0.8% |

This does seem to help the hexapdf benchmark a little:

```
before: ruby 3.2.0dev (2022-12-09T22:12:15Z master daa893db41) +YJIT [x86_64-linux]
after: ruby 3.2.0dev (2022-12-09T22:18:52Z yjit-newarray-max 356e80da95) +YJIT [x86_64-linux]

-------  -----------  ----------  ----------  ----------  ------------  -------------
bench    before (ms)  stddev (%)  after (ms)  stddev (%)  before/after  after 1st itr
hexapdf  1231.9       0.7         1190.7      1.0         1.03          1.03
-------  -----------  ----------  ----------  ----------  ------------  -------------
```