### PR TITLE
Update shape capacity when removing ivar and rewriting shape transitions

### DIFF
--- a/shape.c
+++ b/shape.c
@@ -242,9 +242,10 @@ remove_shape_recursive(VALUE obj, ID id, rb_shape_t * shape, VALUE * removed)
             // has the same attributes as this shape.
             if (new_parent) {
                 rb_shape_t * new_child = get_next_shape_internal(new_parent, shape->edge_name, shape->type);
+                new_child->capacity = shape->capacity;
+
                 if (new_child->type == SHAPE_IVAR) {
                     move_iv(obj, id, shape->next_iv_index - 1, new_child->next_iv_index - 1);
-
                 }
 
                 return new_child;

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1416,8 +1416,6 @@ vm_setivar(VALUE obj, ID id, VALUE val, shape_id_t dest_shape_id, attr_index_t i
                 rb_shape_t *dest_shape = rb_shape_get_shape_by_id(dest_shape_id);
                 shape_id_t source_shape_id = dest_shape->parent_id;
 
-                RUBY_ASSERT(dest_shape->type == SHAPE_IVAR);
-
                 if (shape_id == source_shape_id && dest_shape->edge_name == id) {
                     RUBY_ASSERT(dest_shape_id != INVALID_SHAPE_ID && shape_id != INVALID_SHAPE_ID);
 


### PR DESCRIPTION
Since edc7af48acd12666a2945f30901d16b62a39f474, we now no longer have undef ivar transitions. Instead, we rebuild the shapes table. When we do this, we need to ensure that we retain our capacities on shapes.