### PR TITLE
Windows: Set nonblock=true on pipes and non-datagram sockets

### DIFF
--- a/ext/socket/init.c
+++ b/ext/socket/init.c
@@ -420,6 +420,9 @@ rsock_socket0(int domain, int type, int proto)
     rb_fd_fix_cloexec(result);
 
 #ifndef SOCK_NONBLOCK
+#ifdef _WIN32
+    if( type != SOCK_DGRAM )
+#endif
     rsock_make_fd_nonblock(result);
 #endif
 
@@ -582,10 +585,6 @@ rsock_connect(int fd, const struct sockaddr *sockaddr, int len, int socks, struc
 void
 rsock_make_fd_nonblock(int fd)
 {
-#ifdef _WIN32
-    return;
-#endif
-
     int flags;
 #ifdef F_GETFL
     flags = fcntl(fd, F_GETFL);

--- a/io.c
+++ b/io.c
@@ -430,10 +430,8 @@ rb_cloexec_pipe(int descriptors[2])
     rb_maygvl_fd_fix_cloexec(descriptors[0]);
     rb_maygvl_fd_fix_cloexec(descriptors[1]);
 
-#ifndef _WIN32
     rb_fd_set_nonblock(descriptors[0]);
     rb_fd_set_nonblock(descriptors[1]);
-#endif
 #endif
 
     return result;

--- a/test/-ext-/thread_fd/test_thread_fd_close.rb
+++ b/test/-ext-/thread_fd/test_thread_fd_close.rb
@@ -6,6 +6,7 @@ require 'io/wait'
 class TestThreadFdClose < Test::Unit::TestCase
 
   def test_thread_fd_close
+    omit "Windows has a different closing behaviour with nonblock=true" if RUBY_PLATFORM=~/mswin|mingw/
     IO.pipe do |r, w|
       th = Thread.new do
         begin

--- a/test/socket/test_socket.rb
+++ b/test/socket/test_socket.rb
@@ -583,7 +583,7 @@ class TestSocket < Test::Unit::TestCase
   ensure
     serv_thread.value.close
     server.close
-  end unless RUBY_PLATFORM.include?("freebsd")
+  end unless RUBY_PLATFORM =~ /freebsd|mswin|mingw/
 
   def test_connect_timeout
     host = "127.0.0.1"


### PR DESCRIPTION
This enables pipes, TCP and UNIXSocket for Fiber.scheduler. Nonblocking UDP doesn't work on Windows and is therefore excluded.

This also adds tests to verify pipe, TCP and UDP messages.