### PR TITLE
Add `Regexp.linear_time?`

### DIFF
--- a/include/ruby/onigmo.h
+++ b/include/ruby/onigmo.h
@@ -854,6 +854,8 @@ OnigPosition onig_search_gpos(OnigRegex, const OnigUChar* str, const OnigUChar* 
 ONIG_EXTERN
 OnigPosition onig_match(OnigRegex, const OnigUChar* str, const OnigUChar* end, const OnigUChar* at, OnigRegion* region, OnigOptionType option);
 ONIG_EXTERN
+int onig_check_redos_safe(OnigRegex reg);
+ONIG_EXTERN
 OnigRegion* onig_region_new(void);
 ONIG_EXTERN
 void onig_region_init(OnigRegion* region);

--- a/include/ruby/onigmo.h
+++ b/include/ruby/onigmo.h
@@ -854,7 +854,7 @@ OnigPosition onig_search_gpos(OnigRegex, const OnigUChar* str, const OnigUChar* 
 ONIG_EXTERN
 OnigPosition onig_match(OnigRegex, const OnigUChar* str, const OnigUChar* end, const OnigUChar* at, OnigRegion* region, OnigOptionType option);
 ONIG_EXTERN
-int onig_check_redos_safe(OnigRegex reg);
+int onig_check_linear_time(OnigRegex reg);
 ONIG_EXTERN
 OnigRegion* onig_region_new(void);
 ONIG_EXTERN

--- a/re.c
+++ b/re.c
@@ -4206,7 +4206,8 @@ rb_reg_s_union_m(VALUE self, VALUE args)
  *
  */
 static VALUE
-rb_reg_s_linear_time_p(int argc, VALUE *argv, VALUE self) {
+rb_reg_s_linear_time_p(int argc, VALUE *argv, VALUE self)
+{
     VALUE re;
     VALUE src, opts = Qundef, n_flag = Qundef, kwargs;
 

--- a/re.c
+++ b/re.c
@@ -4196,21 +4196,34 @@ rb_reg_s_union_m(VALUE self, VALUE args)
 
 /*
  *  call-seq:
- *    Regexp.redos_safe?(re)
+ *    Regexp.linear_time?(re)
+ *    Regexp.linear_time?(string, options = 0)
  *
- *  Returns +true+ if <tt>re</tt> is a ReDoS safe; that is,
- *  matching against <tt>re</tt> can be done in linear time to the input string.
+ *  Returns +true+ if matching against <tt>re</tt> can be
+ *  done in linear time to the input string.
  *
- *    Regexp.redos_safe?(/re/) # => true
+ *    Regexp.linear_time?(/re/) # => true
  *
  */
 static VALUE
-rb_reg_s_redos_safe_p(VALUE self, VALUE re) {
-    if (!RB_TYPE_P(re, T_REGEXP)) {
-        rb_raise(rb_eTypeError, "uninitialized Regexp");
+rb_reg_s_linear_time_p(int argc, VALUE *argv, VALUE self) {
+    VALUE re;
+    VALUE src, opts = Qundef, n_flag = Qundef, kwargs;
+
+    rb_scan_args(argc, argv, "12:", &src, &opts, &n_flag, &kwargs);
+
+    if (RB_TYPE_P(src, T_REGEXP)) {
+        re = src;
+        if (opts != Qnil) {
+            rb_warn("flags ignored");
+        }
     }
+    else {
+        re = rb_class_new_instance(argc, argv, rb_cRegexp);
+    }
+
     rb_reg_check(re);
-    return RBOOL(onig_check_redos_safe(RREGEXP_PTR(re)));
+    return RBOOL(onig_check_linear_time(RREGEXP_PTR(re)));
 }
 
 /* :nodoc: */
@@ -4590,7 +4603,7 @@ Init_Regexp(void)
     rb_define_singleton_method(rb_cRegexp, "union", rb_reg_s_union_m, -2);
     rb_define_singleton_method(rb_cRegexp, "last_match", rb_reg_s_last_match, -1);
     rb_define_singleton_method(rb_cRegexp, "try_convert", rb_reg_s_try_convert, 1);
-    rb_define_singleton_method(rb_cRegexp, "redos_safe?", rb_reg_s_redos_safe_p, 1);
+    rb_define_singleton_method(rb_cRegexp, "linear_time?", rb_reg_s_linear_time_p, -1);
 
     rb_define_method(rb_cRegexp, "initialize", rb_reg_initialize_m, -1);
     rb_define_method(rb_cRegexp, "initialize_copy", rb_reg_init_copy, 1);

--- a/re.c
+++ b/re.c
@@ -4194,6 +4194,25 @@ rb_reg_s_union_m(VALUE self, VALUE args)
     return rb_reg_s_union(self, args);
 }
 
+/*
+ *  call-seq:
+ *    Regexp.redos_safe?(re)
+ *
+ *  Returns +true+ if <tt>re</tt> is a ReDoS safe; that is,
+ *  matching against <tt>re</tt> can be done in linear time to the input string.
+ *
+ *    Regexp.redos_safe?(/re/) # => true
+ *
+ */
+static VALUE
+rb_reg_s_redos_safe_p(VALUE self, VALUE re) {
+    if (!RB_TYPE_P(re, T_REGEXP)) {
+        rb_raise(rb_eTypeError, "uninitialized Regexp");
+    }
+    rb_reg_check(re);
+    return RBOOL(onig_check_redos_safe(RREGEXP_PTR(re)));
+}
+
 /* :nodoc: */
 static VALUE
 rb_reg_init_copy(VALUE copy, VALUE re)
@@ -4571,6 +4590,7 @@ Init_Regexp(void)
     rb_define_singleton_method(rb_cRegexp, "union", rb_reg_s_union_m, -2);
     rb_define_singleton_method(rb_cRegexp, "last_match", rb_reg_s_last_match, -1);
     rb_define_singleton_method(rb_cRegexp, "try_convert", rb_reg_s_try_convert, 1);
+    rb_define_singleton_method(rb_cRegexp, "redos_safe?", rb_reg_s_redos_safe_p, 1);
 
     rb_define_method(rb_cRegexp, "initialize", rb_reg_initialize_m, -1);
     rb_define_method(rb_cRegexp, "initialize_copy", rb_reg_init_copy, 1);

--- a/regexec.c
+++ b/regexec.c
@@ -695,14 +695,16 @@ bytecode_error:
   return ONIGERR_UNDEFINED_BYTECODE;
 }
 #else /* USE_MATCH_CACHE */
-static OnigPosition count_num_cache_opcode(regex_t* reg, long* num, long* table_size) {
+static OnigPosition count_num_cache_opcode(regex_t* reg, long* num, long* table_size)
+{
   *num = NUM_CACHE_OPCODE_FAIL;
   return 0;
 }
 #endif
 
 extern int
-onig_check_linear_time(OnigRegexType* reg) {
+onig_check_linear_time(OnigRegexType* reg)
+{
   long num = 0, table_size = 0;
   count_num_cache_opcode(reg, &num, &table_size);
   return num != NUM_CACHE_OPCODE_FAIL;

--- a/regexec.c
+++ b/regexec.c
@@ -702,7 +702,7 @@ static OnigPosition count_num_cache_opcode(regex_t* reg, long* num, long* table_
 #endif
 
 extern int
-onig_check_redos_safe(OnigRegexType* reg) {
+onig_check_linear_time(OnigRegexType* reg) {
   long num = 0, table_size = 0;
   count_num_cache_opcode(reg, &num, &table_size);
   return num != NUM_CACHE_OPCODE_FAIL;

--- a/regexec.c
+++ b/regexec.c
@@ -694,7 +694,19 @@ unexpected_bytecode_error:
 bytecode_error:
   return ONIGERR_UNDEFINED_BYTECODE;
 }
-#endif /* USE_MATCH_CACHE */
+#else /* USE_MATCH_CACHE */
+static OnigPosition count_num_cache_opcode(regex_t* reg, long* num, long* table_size) {
+  *num = NUM_CACHE_OPCODE_FAIL;
+  return 0;
+}
+#endif
+
+extern int
+onig_check_redos_safe(OnigRegexType* reg) {
+  int num, table_size;
+  count_num_cache_opcode(reg, &num, &table_size);
+  return num != NUM_CACHE_OPCODE_FAIL;
+}
 
 extern void
 onig_region_clear(OnigRegion* region)

--- a/regexec.c
+++ b/regexec.c
@@ -703,7 +703,7 @@ static OnigPosition count_num_cache_opcode(regex_t* reg, long* num, long* table_
 
 extern int
 onig_check_redos_safe(OnigRegexType* reg) {
-  int num, table_size;
+  long num = 0, table_size = 0;
   count_num_cache_opcode(reg, &num, &table_size);
   return num != NUM_CACHE_OPCODE_FAIL;
 }

--- a/test/ruby/test_regexp.rb
+++ b/test/ruby/test_regexp.rb
@@ -1695,10 +1695,10 @@ class TestRegexp < Test::Unit::TestCase
   end
 
   def test_linear_time_p
-    assert Regexp.linear_time?(/a/)
-    assert Regexp.linear_time?('a')
-    assert Regexp.linear_time?('a', Regexp::IGNORECASE)
-    assert !Regexp.linear_time?(/(a)\1/)
-    assert !Regexp.linear_time?("(a)\\1")
+    assert_send [Regexp, :linear_time?, /a/]
+    assert_send [Regexp, :linear_time?, 'a']
+    assert_send [Regexp, :linear_time?, 'a', Regexp::IGNORECASE]
+    assert_not_send [Regexp, :linear_time?, /(a)\1/]
+    assert_not_send [Regexp, :linear_time?, "(a)\\1"]
   end
 end

--- a/test/ruby/test_regexp.rb
+++ b/test/ruby/test_regexp.rb
@@ -1693,4 +1693,12 @@ class TestRegexp < Test::Unit::TestCase
       assert_nil(/^a*b?a*$/ =~ "a" * 1000000 + "x")
     end;
   end
+
+  def test_linear_time_p
+    assert Regexp.linear_time?(/a/)
+    assert Regexp.linear_time?('a')
+    assert Regexp.linear_time?('a', Regexp::IGNORECASE)
+    assert !Regexp.linear_time?(/(a)\1/)
+    assert !Regexp.linear_time?("(a)\\1")
+  end
 end


### PR DESCRIPTION
Add a new method `Regexp.linear_time?` to check if matching against a given regexp can be completed in linear time by the optimization introduced in #6486.
