### PR TITLE
Make absent operator work at the end of the input string

### DIFF
--- a/regexec.c
+++ b/regexec.c
@@ -3774,6 +3774,11 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 	  DATA_ENSURE(0);
 	  p += addr;
 	}
+	else if (s == end) {
+	  /* At the end of the string, just match with it */
+	  DATA_ENSURE(0);
+	  p += addr;
+	}
 	else {
 	  STACK_PUSH_ALT(p + addr, s, sprev, pkeep); /* Push possible point. */
 	  n = enclen(encode, s, end);

--- a/test/ruby/test_regexp.rb
+++ b/test/ruby/test_regexp.rb
@@ -1525,6 +1525,9 @@ class TestRegexp < Test::Unit::TestCase
 
     assert_equal(0, /(?~(a)c)/ =~ "abb")
     assert_nil($1)
+
+    assert_equal(0, /(?~(a))/ =~ "")
+    assert_nil($1)
   end
 
   def test_backref_overrun


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/19104#change-100542