### PR TITLE
Don't leave backup file around

### DIFF
--- a/tool/sync_default_gems.rb
+++ b/tool/sync_default_gems.rb
@@ -118,7 +118,6 @@ module SyncDefaultGems
       "rdoc-ref:#{mod || name.chomp("_rdoc") + ".rdoc"}#{scope}#{label}"
     end
     changed or return false
-    File.rename(file, file + "~")
     File.binwrite(file, src)
     return true
   end


### PR DESCRIPTION
I suspect this was for debugging? If not, these days we have source control tools, so this wouldn't seem necessary?