### PR TITLE
Make it so YJIT is no longer marked as experimental

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -581,6 +581,8 @@ The following deprecated APIs are removed.
 
 ### YJIT
 
+* YJIT is no longer experimental
+    * Has been tested on production workloads for over a year and proven to be quite stable.
 * YJIT now supports both x86-64 and arm64/aarch64 CPUs on Linux, MacOS, BSD and other UNIX platforms.
     * This release brings support for Mac M1/M2, AWS Graviton and Raspberry Pi 4.
 * Building YJIT now requires Rust 1.58.0+. [[Feature #18481]]

--- a/configure.ac
+++ b/configure.ac
@@ -3785,7 +3785,7 @@ AS_IF([test "$cross_compiling" = no],
 dnl build YJIT in release mode if rustc >= 1.58.0 is present and we are on a supported platform
 AC_ARG_ENABLE(yjit,
     AS_HELP_STRING([--enable-yjit],
-    [enable experimental in-process JIT compiler that requires Rust build tools [default=no]]),
+    [enable in-process JIT compiler that requires Rust build tools [default=no]]),
     [YJIT_SUPPORT=$enableval],
     [AS_CASE(["$enable_jit_support:$YJIT_TARGET_OK:$YJIT_RUSTC_OK"],
         [yes:yes:yes|:yes:yes], [

--- a/ruby.c
+++ b/ruby.c
@@ -262,7 +262,7 @@ usage(const char *name, int help, int highlight, int columns)
 #if USE_YJIT
 # define PLATFORM_JIT_OPTION "--yjit"
 #else
-# define PLATFORM_JIT_OPTION "--mjit"
+# define PLATFORM_JIT_OPTION "--mjit (experimental)"
 #endif
     static const struct ruby_opt_message usage_msg[] = {
         M("-0[octal]",	   "",			   "specify record separator (\\0, if no argument)"),
@@ -285,12 +285,12 @@ usage(const char *name, int help, int highlight, int columns)
         M("-w",		   "",			   "turn warnings on for your script"),
         M("-W[level=2|:category]",   "",	   "set warning level; 0=silence, 1=medium, 2=verbose"),
         M("-x[directory]", "",			   "strip off text before #!ruby line and perhaps cd to directory"),
-        M("--jit",         "",                     "enable JIT for the platform, same as " PLATFORM_JIT_OPTION " (experimental)"),
+        M("--jit",         "",                     "enable JIT for the platform, same as " PLATFORM_JIT_OPTION),
 #if USE_MJIT
         M("--mjit",        "",                     "enable C compiler-based JIT compiler (experimental)"),
 #endif
 #if USE_YJIT
-        M("--yjit",        "",                     "enable in-process JIT compiler (experimental)"),
+        M("--yjit",        "",                     "enable in-process JIT compiler"),
 #endif
         M("-h",		   "",			   "show this message, --help for more info"),
     };
@@ -378,7 +378,7 @@ usage(const char *name, int help, int highlight, int columns)
         SHOW(mjit_option_messages[i]);
 #endif
 #if USE_YJIT
-    printf("%s""YJIT options (experimental):%s\n", sb, se);
+    printf("%s""YJIT options:%s\n", sb, se);
     for (i = 0; i < numberof(yjit_options); ++i)
         SHOW(yjit_options[i]);
 #endif

--- a/yjit.rb
+++ b/yjit.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# This module allows for introspection of YJIT, CRuby's experimental in-process
+# This module allows for introspection of YJIT, CRuby's in-process
 # just-in-time compiler. This module exists only to help develop YJIT, as such,
 # everything in the module is highly implementation specific and comes with no
 # API stability guarantee whatsoever.


### PR DESCRIPTION
Tested on production workloads at Shopify for > 1 year and proven to be quite stable. Enabling YJIT at run-time is still guarded behind the --yjit command-line option for now.