### PR TITLE
YJIT: Generate debug info in release builds

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -10,7 +10,7 @@ env:
 
 task:
   name: Arm64 Graviton2 / $CC
-  skip: "changesIncludeOnly('doc/**', '**.{md,rdoc,ronn,[1-8]}', '.document') || $CIRRUS_CHANGE_TITLE =~ '.*[DOC].*'"
+  skip: "changesIncludeOnly('doc/**', '**.{md,rdoc,ronn,[1-8]}', '.document')"
   arm_container:
     # We use the arm64 images at https://github.com/ruby/ruby-ci-image/pkgs/container/ruby-ci-image .
     image: ghcr.io/ruby/ruby-ci-image:$CC
@@ -66,7 +66,7 @@ task:
 yjit_task:
   name: Arm64 Graviton2 / $CC YJIT
   auto_cancellation: $CIRRUS_BRANCH != 'master'
-  skip: "changesIncludeOnly('doc/**', '**.{md,rdoc,ronn,[1-8]}', '.document') || $CIRRUS_CHANGE_TITLE =~ '.*[DOC].*'"
+  skip: "changesIncludeOnly('doc/**', '**.{md,rdoc,ronn,[1-8]}', '.document')"
   arm_container:
     # We use the arm64 images at https://github.com/ruby/ruby-ci-image/pkgs/container/ruby-ci-image .
     image: ghcr.io/ruby/ruby-ci-image:$CC

--- a/common.mk
+++ b/common.mk
@@ -224,6 +224,7 @@ MAKE_LINK = $(MINIRUBY) -rfileutils -e "include FileUtils::Verbose" \
 YJIT_RUSTC_ARGS = --crate-name=yjit \
 	--crate-type=staticlib \
 	--edition=2021 \
+	-g \
 	-C opt-level=3 \
 	-C overflow-checks=on \
 	'--out-dir=$(CARGO_TARGET_DIR)/release/' \

--- a/yjit/Cargo.toml
+++ b/yjit/Cargo.toml
@@ -43,3 +43,5 @@ opt-level = 3
 # The extra robustness that comes from checking for arithmetic overflow is
 # worth the performance cost for the compiler.
 overflow-checks = true
+# Generate debug info
+debug = true


### PR DESCRIPTION
They are helpful in case we need to do core dump debugging.
