### PR TITLE
Fix parens on LIKELY in BASIC_OP_UNREDEFINED_P

### DIFF
--- a/internal/basic_operators.h
+++ b/internal/basic_operators.h
@@ -58,6 +58,6 @@ MJIT_SYMBOL_EXPORT_END
 #define FALSE_REDEFINED_OP_FLAG  (1 << 11)
 #define PROC_REDEFINED_OP_FLAG   (1 << 12)
 
-#define BASIC_OP_UNREDEFINED_P(op, klass) (LIKELY(ruby_vm_redefined_flag[(op)]&(klass)) == 0)
+#define BASIC_OP_UNREDEFINED_P(op, klass) (LIKELY((ruby_vm_redefined_flag[(op)]&(klass)) == 0))
 
 #endif


### PR DESCRIPTION
We want to hint to the compiler that it's likely that the BOP is not likely to be redefined (the bit is 0). Previously we were accidentally hinting to the compiler that it was non-zero (it was redefined) due to a misplaced parenthesis. Oops 😅.

This likely (though I'm still not 100% sure) was the cause of an MJIT regression from #6851 on nbody, optcarrot, and similarly math-heavy benchmarks (and it can't have helped the interpreter, though I haven't been able to see evidence of that). It also might depend on the compiler, I was never able to reproduce this on gcc 12.2 on arch linux, but was able to see a difference inside an ubuntu docker container built with gcc 9.4.

I was able to test this most easily by using:

```
time ruby --mjit --mjit-verbose --disable-gems -e 'a=0; 100_000_000.times { a = a+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1 }'
```

cc @k0kubun @composerinteralia 