### PR TITLE
YJIT: Change the default mem size to 64MiB

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -602,7 +602,7 @@ The following deprecated APIs are removed.
     * Simply run ruby with `--yjit-stats` to compute and dump stats (incurs some run-time overhead).
 * YJIT is now optimized to take advantage of object shapes. [[Feature #18776]]
 * Take advantage of finer-grained constant invalidation to invalidate less code when defining new constants. [[Feature #18589]]
-* The default `--yjit-exec-mem-size` is changed to 128 (MiB).
+* The default `--yjit-exec-mem-size` is changed to 64 (MiB).
 * The default `--yjit-call-threshold` is changed to 30.
 
 ### MJIT

--- a/ruby.c
+++ b/ruby.c
@@ -340,7 +340,7 @@ usage(const char *name, int help, int highlight, int columns)
 #if YJIT_STATS
         M("--yjit-stats",              "", "Enable collecting YJIT statistics"),
 #endif
-        M("--yjit-exec-mem-size=num",  "", "Size of executable memory block in MiB (default: 256)"),
+        M("--yjit-exec-mem-size=num",  "", "Size of executable memory block in MiB (default: 64)"),
         M("--yjit-call-threshold=num", "", "Number of calls to trigger JIT (default: 10)"),
         M("--yjit-max-versions=num",   "", "Maximum number of versions per basic block (default: 4)"),
         M("--yjit-greedy-versioning",  "", "Greedy versioning mode (default: disabled)"),

--- a/yjit/src/options.rs
+++ b/yjit/src/options.rs
@@ -49,7 +49,7 @@ pub struct Options {
 
 // Initialize the options to default values
 pub static mut OPTIONS: Options = Options {
-    exec_mem_size: 128 * 1024 * 1024,
+    exec_mem_size: 64 * 1024 * 1024,
     call_threshold: 30,
     greedy_versioning: false,
     no_type_prop: false,


### PR DESCRIPTION
In our production workload, YJIT's code region size is stabilized at 34MiB or so over the weekend. 64MiB seems enough, and even if it reaches 64MiB once, the code generated next time could be much smaller than 64MiB when initialization code is no longer compiled, which would actually give a better peak performance thanks to more compact code.

Given that Rust also uses 3x more memory than JIT code itself, 128MiB for JIT code could be a bit too large when you use multi-process workers (4 * 128MiB = 512MiB). Until we save more memory used by Rust, this would guarantee a nice smaller number in the memory usage per process (4 * 64MiB = 256MiB).