### PR TITLE
Avoid overwriting revision.h when .git doesn't exist

### DIFF
--- a/tool/file2lastrev.rb
+++ b/tool/file2lastrev.rb
@@ -25,6 +25,7 @@ end
 
 time_format = '%Y-%m-%dT%H:%M:%S%z'
 vcs = nil
+create_only = false
 OptionParser.new {|opts|
   opts.banner << " paths..."
   vcs_options = VCS.define_options(opts)
@@ -62,6 +63,9 @@ OptionParser.new {|opts|
     abort "#{File.basename(Program)}: #{e.message}" unless @suppress_not_found
     opts.remove
     (vcs = VCS::Null.new(nil)).set_options(vcs_options)
+    if @format == :revision_h
+      create_only = true # don't overwrite existing revision.h when .git doesn't exist
+    end
   end
 }
 
@@ -92,7 +96,7 @@ ok = true
   begin
     data = formatter[*vcs.get_revisions(arg)]
     data.sub!(/(?<!\A|\n)\z/, "\n")
-    @output.write(data, overwrite: true)
+    @output.write(data, overwrite: true, create_only: create_only)
   rescue => e
     warn "#{File.basename(Program)}: #{e.message}"
     ok = false

--- a/tool/lib/output.rb
+++ b/tool/lib/output.rb
@@ -29,7 +29,7 @@ class Output
     outpath = nil
 
     if (@ifchange or overwrite or create_only) and
-      (@vpath.open(@path, "rb") {|f| outpath = f.path; (@ifchange and f.read == data) or create_only} rescue false)
+      (@vpath.open(@path, "rb") {|f| outpath = f.path; (@ifchange and f.read == data) or (create_only and !f.read.empty?)} rescue false)
       puts "#{outpath} #{unchanged}"
       written = false
     else

--- a/tool/lib/output.rb
+++ b/tool/lib/output.rb
@@ -18,7 +18,7 @@ class Output
     @vpath.def_options(opt)
   end
 
-  def write(data, overwrite: false)
+  def write(data, overwrite: false, create_only: false)
     unless @path
       $stdout.print data
       return true
@@ -28,8 +28,8 @@ class Output
     updated = color.fail("updated")
     outpath = nil
 
-    if (@ifchange or overwrite) and
-      (@vpath.open(@path, "rb") {|f| outpath = f.path; f.read == data if @ifchange} rescue false)
+    if (@ifchange or overwrite or create_only) and
+      (@vpath.open(@path, "rb") {|f| outpath = f.path; (@ifchange and f.read == data) or create_only} rescue false)
       puts "#{outpath} #{unchanged}"
       written = false
     else


### PR DESCRIPTION
When a source directory has `revision.h` but doesn't have `.git`, there should be no motivation to update `revision.h`. However, it currently overwrites `revision.h` as long as baseruby exists, even in a package built by `make-snapshot`.

This PR changes it to avoid overwriting existing `revision.h` when `.git` doesn't exist.