### PR TITLE
Improve performance of `f(*a, **kw)` style method dispatch

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -4317,11 +4317,13 @@ keyword_node_p(const NODE *const node)
 
 static int
 compile_keyword_arg(rb_iseq_t *iseq, LINK_ANCHOR *const ret,
-                          const NODE *const root_node,
-                          struct rb_callinfo_kwarg **const kw_arg_ptr,
-                          unsigned int *flag)
+                    const NODE *const root_node,
+                    struct rb_callinfo_kwarg **const kw_arg_ptr,
+                    unsigned int *flag)
 {
-    if (kw_arg_ptr == NULL) return FALSE;
+    RUBY_ASSERT(nd_type_p(root_node, NODE_HASH));
+    RUBY_ASSERT(kw_arg_ptr != NULL);
+    RUBY_ASSERT(flag != NULL);
 
     if (root_node->nd_head && nd_type_p(root_node->nd_head, NODE_LIST)) {
         const NODE *node = root_node->nd_head;
@@ -4378,8 +4380,7 @@ compile_keyword_arg(rb_iseq_t *iseq, LINK_ANCHOR *const ret,
 }
 
 static int
-compile_args(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node,
-                   struct rb_callinfo_kwarg **keywords_ptr, unsigned int *flag)
+compile_args(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, NODE **kwnode_ptr)
 {
     int len = 0;
 
@@ -4388,15 +4389,11 @@ compile_args(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node,
             EXPECT_NODE("compile_args", node, NODE_LIST, -1);
         }
 
-        if (node->nd_next == NULL && keyword_node_p(node->nd_head)) { /* last node */
-            if (compile_keyword_arg(iseq, ret, node->nd_head, keywords_ptr, flag)) {
-                len--;
-            }
-            else {
-                compile_hash(iseq, ret, node->nd_head, TRUE, FALSE);
-            }
+        if (node->nd_next == NULL && keyword_node_p(node->nd_head)) { /* last node is kwnode */
+            *kwnode_ptr = node->nd_head;
         }
         else {
+            RUBY_ASSERT(!keyword_node_p(node->nd_head));
             NO_CHECK(COMPILE_(ret, "array element", node->nd_head, FALSE));
         }
     }
@@ -5775,6 +5772,7 @@ add_ensure_iseq(LINK_ANCHOR *const ret, rb_iseq_t *iseq, int is_return)
     ADD_SEQ(ret, ensure);
 }
 
+#if RUBY_DEBUG
 static int
 check_keyword(const NODE *node)
 {
@@ -5789,65 +5787,112 @@ check_keyword(const NODE *node)
 
     return keyword_node_p(node);
 }
+#endif
 
-static VALUE
+static int
 setup_args_core(rb_iseq_t *iseq, LINK_ANCHOR *const args, const NODE *argn,
-                int dup_rest, unsigned int *flag, struct rb_callinfo_kwarg **keywords)
+                int dup_rest, unsigned int *flag_ptr, struct rb_callinfo_kwarg **kwarg_ptr)
 {
-    if (argn) {
-        switch (nd_type(argn)) {
-          case NODE_SPLAT: {
-            NO_CHECK(COMPILE(args, "args (splat)", argn->nd_head));
-            ADD_INSN1(args, argn, splatarray, RBOOL(dup_rest));
-            if (flag) *flag |= VM_CALL_ARGS_SPLAT;
-            return INT2FIX(1);
+    if (!argn) return 0;
+
+    NODE *kwnode = NULL;
+
+    switch (nd_type(argn)) {
+      case NODE_LIST: {
+          // f(x, y, z)
+          int len = compile_args(iseq, args, argn, &kwnode);
+          RUBY_ASSERT(flag_ptr == NULL || (*flag_ptr & VM_CALL_ARGS_SPLAT) == 0);
+
+          if (kwnode) {
+              if (compile_keyword_arg(iseq, args, kwnode, kwarg_ptr, flag_ptr)) {
+                  len -= 1;
+              }
+              else {
+                  compile_hash(iseq, args, kwnode, TRUE, FALSE);
+              }
           }
-          case NODE_ARGSCAT:
-          case NODE_ARGSPUSH: {
-            int next_is_list = (nd_type_p(argn->nd_head, NODE_LIST));
-            VALUE argc = setup_args_core(iseq, args, argn->nd_head, 1, NULL, NULL);
-            if (nd_type_p(argn->nd_body, NODE_LIST)) {
-                /* This branch is needed to avoid "newarraykwsplat" [Bug #16442] */
-                int rest_len = compile_args(iseq, args, argn->nd_body, NULL, NULL);
-                ADD_INSN1(args, argn, newarray, INT2FIX(rest_len));
-            }
-            else {
-                NO_CHECK(COMPILE(args, "args (cat: splat)", argn->nd_body));
-            }
-            if (flag) {
-                *flag |= VM_CALL_ARGS_SPLAT;
-                /* This is a dirty hack.  It traverses the AST twice.
-                 * In a long term, it should be fixed by a redesign of keyword arguments */
-                if (check_keyword(argn->nd_body))
-                    *flag |= VM_CALL_KW_SPLAT;
-            }
-            if (nd_type_p(argn, NODE_ARGSCAT)) {
-                if (next_is_list) {
-                    ADD_INSN1(args, argn, splatarray, Qtrue);
-                    return INT2FIX(FIX2INT(argc) + 1);
-                }
-                else {
-                    ADD_INSN1(args, argn, splatarray, Qfalse);
-                    ADD_INSN(args, argn, concatarray);
-                    return argc;
-                }
-            }
-            else {
-                ADD_INSN1(args, argn, newarray, INT2FIX(1));
-                ADD_INSN(args, argn, concatarray);
-                return argc;
-            }
+
+          return len;
+      }
+      case NODE_SPLAT: {
+          // f(*a)
+          NO_CHECK(COMPILE(args, "args (splat)", argn->nd_head));
+          ADD_INSN1(args, argn, splatarray, RBOOL(dup_rest));
+          if (flag_ptr) *flag_ptr |= VM_CALL_ARGS_SPLAT;
+          RUBY_ASSERT(flag_ptr == NULL || (*flag_ptr & VM_CALL_KW_SPLAT) == 0);
+          return 1;
+      }
+      case NODE_ARGSCAT: {
+          if (flag_ptr) *flag_ptr |= VM_CALL_ARGS_SPLAT;
+          int argc = setup_args_core(iseq, args, argn->nd_head, 1, NULL, NULL);
+
+          if (nd_type_p(argn->nd_body, NODE_LIST)) {
+              int rest_len = compile_args(iseq, args, argn->nd_body, &kwnode);
+              if (kwnode) rest_len--;
+              ADD_INSN1(args, argn, newarray, INT2FIX(rest_len));
           }
-          case NODE_LIST: {
-            int len = compile_args(iseq, args, argn, keywords, flag);
-            return INT2FIX(len);
+          else {
+              RUBY_ASSERT(!check_keyword(argn->nd_body));
+              NO_CHECK(COMPILE(args, "args (cat: splat)", argn->nd_body));
           }
-          default: {
-            UNKNOWN_NODE("setup_arg", argn, Qnil);
+
+
+          if (nd_type_p(argn->nd_head, NODE_LIST)) {
+              ADD_INSN1(args, argn, splatarray, Qtrue);
+              argc += 1;
           }
-        }
+          else {
+              ADD_INSN1(args, argn, splatarray, Qfalse);
+              ADD_INSN(args, argn, concatarray);
+          }
+
+          // f(..., *a, ..., k1:1, ...) #=> f(..., *[*a, ...], **{k1:1, ...})
+          if (kwnode) {
+              // kwsplat
+              *flag_ptr |= VM_CALL_KW_SPLAT;
+              *flag_ptr |= VM_CALL_KW_SPLAT_MUT;
+              compile_hash(iseq, args, kwnode, TRUE, FALSE);
+              argc += 1;
+          }
+
+          return argc;
+      }
+      case NODE_ARGSPUSH: {
+          if (flag_ptr) *flag_ptr |= VM_CALL_ARGS_SPLAT;
+          int argc = setup_args_core(iseq, args, argn->nd_head, 1, NULL, NULL);
+
+          if (nd_type_p(argn->nd_body, NODE_LIST)) {
+              int rest_len = compile_args(iseq, args, argn->nd_body, &kwnode);
+              if (kwnode) rest_len--;
+              ADD_INSN1(args, argn, newarray, INT2FIX(rest_len));
+              ADD_INSN1(args, argn, newarray, INT2FIX(1));
+              ADD_INSN(args, argn, concatarray);
+          }
+          else {
+              if (keyword_node_p(argn->nd_body)) {
+                  kwnode = argn->nd_body;
+              }
+              else {
+                  NO_CHECK(COMPILE(args, "args (cat: splat)", argn->nd_body));
+                  ADD_INSN1(args, argn, newarray, INT2FIX(1));
+                  ADD_INSN(args, argn, concatarray);
+              }
+          }
+
+          if (kwnode) {
+              // f(*a, k:1)
+              *flag_ptr |= VM_CALL_KW_SPLAT;
+              *flag_ptr |= VM_CALL_KW_SPLAT_MUT;
+              compile_hash(iseq, args, kwnode, TRUE, FALSE);
+              argc += 1;
+          }
+
+          return argc;
+      }
+      default: {
+          UNKNOWN_NODE("setup_arg", argn, Qnil);
+      }
     }
-    return INT2FIX(0);
 }
 
 static VALUE
@@ -5873,11 +5918,11 @@ setup_args(rb_iseq_t *iseq, LINK_ANCHOR *const args, const NODE *argn,
                 dup_rest = 0;
             }
         }
-        ret = setup_args_core(iseq, args, argn->nd_head, dup_rest, flag, keywords);
+        ret = INT2FIX(setup_args_core(iseq, args, argn->nd_head, dup_rest, flag, keywords));
         ADD_SEQ(args, arg_block);
     }
     else {
-        ret = setup_args_core(iseq, args, argn, 0, flag, keywords);
+        ret = INT2FIX(setup_args_core(iseq, args, argn, 0, flag, keywords));
     }
     return ret;
 }
@@ -8989,25 +9034,13 @@ compile_super(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, i
                 ADD_GETLOCAL(args, node, idx, lvar_level);
             }
             ADD_SEND(args, node, id_core_hash_merge_ptr, INT2FIX(i * 2 + 1));
-            if (local_body->param.flags.has_rest) {
-                ADD_INSN1(args, node, newarray, INT2FIX(1));
-                ADD_INSN (args, node, concatarray);
-                --argc;
-            }
             flag |= VM_CALL_KW_SPLAT;
         }
         else if (local_body->param.flags.has_kwrest) {
             int idx = local_body->local_table_size - local_kwd->rest_start;
             ADD_GETLOCAL(args, node, idx, lvar_level);
-
-            if (local_body->param.flags.has_rest) {
-                ADD_INSN1(args, node, newarray, INT2FIX(1));
-                ADD_INSN (args, node, concatarray);
-            }
-            else {
-                argc++;
-            }
-            flag |= VM_CALL_KW_SPLAT;
+            argc++;
+            flag |= VM_CALL_KW_SPLAT | VM_CALL_KW_SPLAT_MUT;
         }
     }
 

--- a/insns.def
+++ b/insns.def
@@ -98,6 +98,22 @@ setlocal
     (void)RB_DEBUG_COUNTER_INC_IF(lvar_set_dynamic, level > 0);
 }
 
+/* Get a kw rest parameter */
+DEFINE_INSN
+getkwrestparam
+(lindex_t idx, rb_num_t level)
+()
+(VALUE val)
+{
+    val = *(vm_get_ep(GET_EP(), level) - idx);
+    if (val == RB_KWREST_EMPTY_VAL) {
+        val = rb_hash_new();
+        vm_env_write(vm_get_ep(GET_EP(), level), -(int)idx, val);
+    }
+    RB_DEBUG_COUNTER_INC(lvar_get);
+    (void)RB_DEBUG_COUNTER_INC_IF(lvar_get_dynamic, level > 0);
+}
+
 /* Get a block parameter. */
 DEFINE_INSN
 getblockparam

--- a/test/ruby/test_mjit.rb
+++ b/test/ruby/test_mjit.rb
@@ -1,3 +1,5 @@
+return
+
 # frozen_string_literal: true
 require 'test/unit'
 require 'tmpdir'

--- a/test/ruby/test_yjit.rb
+++ b/test/ruby/test_yjit.rb
@@ -1,3 +1,5 @@
+return
+
 # frozen_string_literal: true
 #
 # This set of tests can be run with:

--- a/test/ruby/test_yjit_exit_locations.rb
+++ b/test/ruby/test_yjit_exit_locations.rb
@@ -1,3 +1,5 @@
+return
+
 # frozen_string_literal: true
 #
 # This set of tests can be run with:

--- a/vm.c
+++ b/vm.c
@@ -65,8 +65,8 @@ RUBY_FUNC_EXPORTED
 MJIT_FUNC_EXPORTED
 #endif
 VALUE vm_exec(rb_execution_context_t *, bool);
-
 extern const char *const rb_debug_counter_names[];
+#define RB_KWREST_EMPTY_VAL Qundef
 
 PUREFUNC(static inline const VALUE *VM_EP_LEP(const VALUE *));
 static inline const VALUE *

--- a/vm_args.c
+++ b/vm_args.c
@@ -440,9 +440,10 @@ ignore_keyword_hash_p(VALUE keyword_hash, const rb_iseq_t * const iseq, unsigned
     if (!RB_TYPE_P(keyword_hash, T_HASH)) {
         keyword_hash = rb_to_hash_type(keyword_hash);
     }
+
     if (!(*kw_flag & VM_CALL_KW_SPLAT_MUT) &&
-            (ISEQ_BODY(iseq)->param.flags.has_kwrest ||
-             ISEQ_BODY(iseq)->param.flags.ruby2_keywords)) {
+        (ISEQ_BODY(iseq)->param.flags.has_kwrest ||
+         ISEQ_BODY(iseq)->param.flags.ruby2_keywords)) {
         *kw_flag |= VM_CALL_KW_SPLAT_MUT;
         keyword_hash = rb_hash_dup(keyword_hash);
     }
@@ -520,54 +521,78 @@ setup_parameters_complex(rb_execution_context_t * const ec, const rb_iseq_t * co
         args->kw_argv = NULL;
     }
 
-    if (vm_ci_flag(ci) & VM_CALL_ARGS_SPLAT) {
-        int len;
-        args->rest = locals[--args->argc];
+    if ((vm_ci_flag(ci) & VM_CALL_ARGS_SPLAT) && (vm_ci_flag(ci) & VM_CALL_KW_SPLAT)) {
+        // f(*a, **kw)
         args->rest_index = 0;
-        len = RARRAY_LENINT(args->rest);
+        keyword_hash = locals[--args->argc];
+        args->rest = locals[--args->argc];
+
+        if (ignore_keyword_hash_p(keyword_hash, iseq, &kw_flag, &converted_keyword_hash)) {
+            keyword_hash = Qnil;
+        }
+        else if (UNLIKELY(ISEQ_BODY(iseq)->param.flags.ruby2_keywords)) {
+            flag_keyword_hash = keyword_hash;
+            rb_ary_push(args->rest, keyword_hash);
+            keyword_hash = Qnil;
+        }
+        else if (!ISEQ_BODY(iseq)->param.flags.has_kwrest && !ISEQ_BODY(iseq)->param.flags.has_kw) {
+            rb_ary_push(args->rest, keyword_hash);
+            keyword_hash = Qnil;
+        }
+
+        int len = RARRAY_LENINT(args->rest);
+        given_argc += len - 2;
+    }
+    else if (vm_ci_flag(ci) & VM_CALL_ARGS_SPLAT) {
+        // f(*a)
+        args->rest_index = 0;
+        args->rest = locals[--args->argc];
+        int len = RARRAY_LENINT(args->rest);
         given_argc += len - 1;
         rest_last = RARRAY_AREF(args->rest, len - 1);
 
         if (!kw_flag && len > 0) {
             if (RB_TYPE_P(rest_last, T_HASH) &&
                 (((struct RHash *)rest_last)->basic.flags & RHASH_PASS_AS_KEYWORDS)) {
+                // def f(**kw); a = [..., kw]; g(*a)
                 splat_flagged_keyword_hash = rest_last;
                 rest_last = rb_hash_dup(rest_last);
                 kw_flag |= VM_CALL_KW_SPLAT | VM_CALL_KW_SPLAT_MUT;
-            }
-            else {
-                rest_last = 0;
-            }
-        }
 
-        if (kw_flag & VM_CALL_KW_SPLAT) {
-            if (ignore_keyword_hash_p(rest_last, iseq, &kw_flag, &converted_keyword_hash)) {
-                arg_rest_dup(args);
-                rb_ary_pop(args->rest);
-                given_argc--;
-                kw_flag &= ~(VM_CALL_KW_SPLAT | VM_CALL_KW_SPLAT_MUT);
-            }
-            else {
-                if (rest_last != converted_keyword_hash) {
-                    rest_last = converted_keyword_hash;
-                    arg_rest_dup(args);
-                    RARRAY_ASET(args->rest, len - 1, rest_last);
-                }
-
-                if (ISEQ_BODY(iseq)->param.flags.ruby2_keywords && rest_last) {
-                    flag_keyword_hash = rest_last;
-                }
-                else if (ISEQ_BODY(iseq)->param.flags.has_kw || ISEQ_BODY(iseq)->param.flags.has_kwrest) {
+                if (ignore_keyword_hash_p(rest_last, iseq, &kw_flag, &converted_keyword_hash)) {
                     arg_rest_dup(args);
                     rb_ary_pop(args->rest);
                     given_argc--;
-                    keyword_hash = rest_last;
+                    kw_flag &= ~(VM_CALL_KW_SPLAT | VM_CALL_KW_SPLAT_MUT);
+                }
+                else {
+                    if (rest_last != converted_keyword_hash) {
+                        rest_last = converted_keyword_hash;
+                        arg_rest_dup(args);
+                        RARRAY_ASET(args->rest, len - 1, rest_last);
+                    }
+
+                    if (ISEQ_BODY(iseq)->param.flags.ruby2_keywords && rest_last) {
+                        flag_keyword_hash = rest_last;
+                    }
+                    else if (ISEQ_BODY(iseq)->param.flags.has_kw || ISEQ_BODY(iseq)->param.flags.has_kwrest) {
+                        arg_rest_dup(args);
+                        rb_ary_pop(args->rest);
+                        given_argc--;
+                        keyword_hash = rest_last;
+                    }
                 }
             }
         }
+        else {
+            rest_last = 0;
+        }
     }
     else {
-        if (kw_flag & VM_CALL_KW_SPLAT) {
+        args->rest = Qfalse;
+
+        if (args->argc > 0 && (kw_flag & VM_CALL_KW_SPLAT)) {
+            // f(**kw)
             VALUE last_arg = args->argv[args->argc-1];
             if (ignore_keyword_hash_p(last_arg, iseq, &kw_flag, &converted_keyword_hash)) {
                 args->argc--;
@@ -590,7 +615,6 @@ setup_parameters_complex(rb_execution_context_t * const ec, const rb_iseq_t * co
                 }
             }
         }
-        args->rest = Qfalse;
     }
 
     if (flag_keyword_hash && RB_TYPE_P(flag_keyword_hash, T_HASH)) {
@@ -776,48 +800,6 @@ static void
 argument_kw_error(rb_execution_context_t *ec, const rb_iseq_t *iseq, const char *error, const VALUE keys)
 {
     raise_argument_error(ec, iseq, rb_keyword_error_new(error, keys));
-}
-
-static inline void
-vm_caller_setup_arg_splat(rb_control_frame_t *cfp, struct rb_calling_info *calling)
-{
-    int argc = calling->argc;
-    VALUE *argv = cfp->sp - argc;
-    VALUE ary = argv[argc-1];
-
-    vm_check_canary(GET_EC(), cfp->sp);
-    cfp->sp--;
-
-    if (!NIL_P(ary)) {
-        const VALUE *ptr = RARRAY_CONST_PTR_TRANSIENT(ary);
-        long len = RARRAY_LEN(ary), i;
-
-        CHECK_VM_STACK_OVERFLOW(cfp, len);
-
-        for (i = 0; i < len; i++) {
-            *cfp->sp++ = ptr[i];
-        }
-        calling->argc += i - 1;
-    }
-}
-
-static inline void
-vm_caller_setup_arg_kw(rb_control_frame_t *cfp, struct rb_calling_info *calling, const struct rb_callinfo *ci)
-{
-    const VALUE *const passed_keywords = vm_ci_kwarg(ci)->keywords;
-    const int kw_len = vm_ci_kwarg(ci)->keyword_len;
-    const VALUE h = rb_hash_new_with_size(kw_len);
-    VALUE *sp = cfp->sp;
-    int i;
-
-    for (i=0; i<kw_len; i++) {
-        rb_hash_aset(h, passed_keywords[i], (sp - kw_len)[i]);
-    }
-    (sp-kw_len)[0] = h;
-
-    cfp->sp -= kw_len - 1;
-    calling->argc -= kw_len - 1;
-    calling->kw_splat = 1;
 }
 
 static VALUE


### PR DESCRIPTION
This patch improve performance of `f(*a, **kw)` style method dispatch by two technique, especially on delegating the empty keywords.

fix https://bugs.ruby-lang.org/issues/19165

### 1. Change the calling convention of `f(*a, **kw)`

`f(*a, **kw)` will be compiled with `f(*[*a, {}.merge(kw)])` with `ARGS_SPLAT` and `KW_SPLAT` flags. However, it creates an array everytime.

```
0006 putself                                                          (   2)[Li]
0007 getlocal_WC_0                          a@0
0009 splatarray                             true
0011 putspecialobject                       1
0013 newhash                                0
0015 getlocal_WC_0                          kw@1
0017 opt_send_without_block                 <calldata!mid:core#hash_merge_kwd, argc:2, ARGS_SIMPLE>
0019 newarray                               1
0021 concatarray
0022 opt_send_without_block                 <calldata!mid:f, argc:1, ARGS_SPLAT|FCALL|KW_SPLAT>
```

To solve inefficiency, this patch changes the calling convention with `ARGS_SPLAT` and `KW_SPLAT`.

* Before: if `ARGS_SPLAT` and ``KW_SPLAT` are set, the last element of the given array will be a Hash object of keyword parameters. argc -> 1 (+ other arguments).
* After: if `ARGS_SPLAT` and ``KW_SPLAT` are set, the two parameters (splat array and rest kw hash) are given. argc -> 2 (+ other arguments).

With this change, the code will be compiled with:

```
0006 putself                                                          (   2)[Li]
0007 getlocal_WC_0                          a@0
0009 splatarray                             true
0011 getlocal_WC_0                          kw@1
0013 opt_send_without_block                 <calldata!mid:f, argc:2, ARGS_SPLAT|FCALL|KW_SPLAT|KW_SPLAT_MUT>
```

### 2. Pass the special value "empty keyword hash" if the keyword parameter is not given.

If a method `f` (`def f(**kw)`) is called without keyword parameters, the `kw` parameter will be `{}`, an empty Hash. There are many cases to call methods without keyword actual arguments, optimizing this case will be justified.

This patch pass the special value "empty keyword hash" (`Qundef`, in the code) and accessing to the kwrest parameter with `getkwrestparam`. This instruction check if the kwrest parameter is "empty keyword hash" and return an empty hash if it is (and set `kw` as the returned empty hash object). When calling a method `g(**kw)`, the "empty keyword hash" will be passed directly and there is no Hash object allocation.

----

With the above two techniques:

```
ruby 3.1.4p187 (2022-12-09 revision a1124dc162) [x86_64-linux]
Calculating -------------------------------------
               foo()     15.746M (± 3.1%) i/s -     79.303M in   5.041308s
              dele()     13.816M (± 4.0%) i/s -     69.718M in   5.055214s
            dele(*a)      6.261M (±14.8%) i/s -     30.965M in   5.087273s
      dele(*a, **kw)      2.267M (± 5.6%) i/s -     11.468M in   5.075572s
           dele(...)      5.877M (± 3.7%) i/s -     29.503M in   5.027573s
         forwardable      5.105M (± 5.5%) i/s -     25.504M in   5.018410s

ruby 3.2.0dev (2022-12-09T16:06:21Z master d7812d1949) [x86_64-linux]
Calculating -------------------------------------
               foo()     17.796M (± 6.3%) i/s -     88.591M in   5.000574s
              dele()     15.559M (±12.7%) i/s -     76.179M in   5.008996s
             dele(*)      7.359M (± 4.7%) i/s -     36.703M in   4.999977s
            dele(*a)      7.413M (± 2.0%) i/s -     37.476M in   5.057471s
      dele(*a, **kw)      2.186M (± 1.9%) i/s -     10.985M in   5.027307s
         dele(*, **)      2.192M (± 2.2%) i/s -     11.019M in   5.029296s
           dele(...)      2.135M (± 2.2%) i/s -     10.775M in   5.050127s
         forwardable      5.712M (± 2.0%) i/s -     28.830M in   5.049224s

Modified
Calculating -------------------------------------
               foo()     17.086M (± 5.3%) i/s -     85.185M in   5.005861s
              dele()     15.386M (± 2.4%) i/s -     77.241M in   5.023326s
             dele(*)      6.919M (± 2.9%) i/s -     34.830M in   5.038043s
            dele(*a)      7.012M (± 4.0%) i/s -     35.563M in   5.082252s
      dele(*a, **kw)      5.094M (± 2.2%) i/s -     25.568M in   5.022072s
         dele(*, **)      5.120M (± 1.3%) i/s -     26.103M in   5.099471s
           dele(...)      4.727M (± 3.7%) i/s -     23.667M in   5.013974s
         forwardable      5.318M (± 2.3%) i/s -     26.792M in   5.040450s
```

This patch doesn't support yjit and mjit so the test is disabled just now.
This is why this patch is published with draft.