### PR TITLE
Fix build when enable_shared is on

### DIFF
--- a/tool/outdate-bundled-gems.rb
+++ b/tool/outdate-bundled-gems.rb
@@ -111,7 +111,7 @@ end
 
 version = RbConfig::CONFIG['ruby_version']
 curdir.glob(".bundle/{extensions,.timestamp}/#{platform}/*/") do |dir|
-  unless File.basename(dir) == version
+  unless File.basename(dir).start_with?(version)
     curdir.rmdir(dir)
   end
 end


### PR DESCRIPTION
Before this change, if enable_shared was true, the directory would have a suffix of -static and be deleted on each make install. This would cause a second make install to fail.