### PR TITLE
Remove `require 'io/wait'` as it's no longer necessary.

### DIFF
--- a/ext/socket/lib/socket.rb
+++ b/ext/socket/lib/socket.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 require 'socket.so'
-require 'io/wait' unless ::IO.method_defined?(:wait_readable, false)
+
+unless IO.method_defined?(:wait_writable, false)
+  # It's only required on older Rubies < v3.2:
+  require 'io/wait'
+end
 
 class Addrinfo
   # creates an Addrinfo object from the arguments.

--- a/spec/ruby/library/io-wait/wait_readable_spec.rb
+++ b/spec/ruby/library/io-wait/wait_readable_spec.rb
@@ -1,6 +1,8 @@
 require_relative '../../spec_helper'
 
-require 'io/wait'
+ruby_version_is ''...'3.2' do
+  require 'io/wait'
+end
 
 describe "IO#wait_readable" do
   before :each do

--- a/spec/ruby/library/io-wait/wait_writable_spec.rb
+++ b/spec/ruby/library/io-wait/wait_writable_spec.rb
@@ -1,6 +1,8 @@
 require_relative '../../spec_helper'
 
-require 'io/wait'
+ruby_version_is ''...'3.2' do
+  require 'io/wait'
+end
 
 describe "IO#wait_writable" do
   it "waits for the IO to become writable with no timeout" do

--- a/test/-ext-/thread_fd/test_thread_fd_close.rb
+++ b/test/-ext-/thread_fd/test_thread_fd_close.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 require 'test/unit'
 require '-test-/thread_fd'
-require 'io/wait'
 
 class TestThreadFdClose < Test::Unit::TestCase
 

--- a/test/io/wait/test_io_wait.rb
+++ b/test/io/wait/test_io_wait.rb
@@ -3,10 +3,6 @@
 require 'test/unit'
 require 'timeout'
 require 'socket'
-begin
-  require 'io/wait'
-rescue LoadError
-end
 
 class TestIOWait < Test::Unit::TestCase
 

--- a/test/io/wait/test_io_wait.rb
+++ b/test/io/wait/test_io_wait.rb
@@ -4,6 +4,9 @@ require 'test/unit'
 require 'timeout'
 require 'socket'
 
+# For `IO#ready?` and `IO#nread`:
+require 'io/wait'
+
 class TestIOWait < Test::Unit::TestCase
 
   def setup

--- a/test/io/wait/test_io_wait_uncommon.rb
+++ b/test/io/wait/test_io_wait_uncommon.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'test/unit'
-require 'io/wait'
 
 # test uncommon device types to check portability problems
 # We may optimize IO#wait_*able for non-Linux kernels in the future

--- a/test/io/wait/test_ractor.rb
+++ b/test/io/wait/test_ractor.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 require 'test/unit'
 require 'rbconfig'
-require 'io/wait'
 
 class TestIOWaitInRactor < Test::Unit::TestCase
   def test_ractor

--- a/test/ruby/test_process.rb
+++ b/test/ruby/test_process.rb
@@ -3,7 +3,6 @@
 require 'test/unit'
 require 'tempfile'
 require 'timeout'
-require 'io/wait'
 require 'rbconfig'
 
 class TestProcess < Test::Unit::TestCase

--- a/tool/lib/webrick/httpserver.rb
+++ b/tool/lib/webrick/httpserver.rb
@@ -9,7 +9,6 @@
 #
 # $IPR: httpserver.rb,v 1.63 2002/10/01 17:16:32 gotoyuzo Exp $
 
-require 'io/wait'
 require_relative 'server'
 require_relative 'httputils'
 require_relative 'httpstatus'


### PR DESCRIPTION
Follow up to <https://github.com/ruby/ruby/pull/6922>.