### PR TITLE
YJIT: Mark ocb pages on invalidate_block_version

### DIFF
--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -1924,7 +1924,7 @@ fn set_branch_target(
     // branch_stub_hit call
     asm.jmp_opnd(jump_addr);
 
-    asm.compile(ocb);
+    asm.compile_with_iseq(ocb, branch.block.borrow().blockid.iseq);
 
     if ocb.has_dropped_bytes() {
         // No space


### PR DESCRIPTION
[Bug #19234]

On the CI of Shopify's main app, we observed crashes right after Code GC. When Alan investigated it, he was able to confirm that Code GC was freeing the live page, the frame that was calling branch_stub_hit that triggered Code GC. It means that some outlined code that calls branch_stub_hit is generated outside marked `pages`.

After we came up with and verified multiple theories, Alan noticed that the `pages` tracking can break naturally with `invalidate_block_version` because it generates fresh stubs in ocb and only existing code is modified in cb.

He has a branch that fixes the problem by adding a stub trampoline for that invalidation and he's running CI. While he was working on it, in case it hits some issues, I worked on a backup plan that is a more ad-hoc fix on the immediate problem, which is this PR; just mark the fresh stubs in `pages`. It didn't crash on the Intel CI, so I filed this PR. I'm checking Arm CI now (edit: It didn't crash either).

If Alan's patch passes CI and we think it's more efficient in some ways, it's okay to just close this and merge his work.