### PR TITLE
Indicate if a shape is too_complex in ObjectSpace#dump

### DIFF
--- a/ext/objspace/objspace_dump.c
+++ b/ext/objspace/objspace_dump.c
@@ -406,10 +406,8 @@ dump_object(VALUE obj, struct dump_config *dc)
     dump_append(dc, "\"");
 
     size_t shape_id = rb_shape_get_shape_id(obj);
-    if (shape_id) {
-        dump_append(dc, ", \"shape_id\":");
-        dump_append_sizet(dc, shape_id);
-    }
+    dump_append(dc, ", \"shape_id\":");
+    dump_append_sizet(dc, shape_id);
 
     dump_append(dc, ", \"slot_size\":");
     dump_append_sizet(dc, dc->cur_page_slot_size);
@@ -548,6 +546,9 @@ dump_object(VALUE obj, struct dump_config *dc)
       case T_OBJECT:
         dump_append(dc, ", \"ivars\":");
         dump_append_lu(dc, ROBJECT_IV_COUNT(obj));
+        if (rb_shape_obj_too_complex(obj)) {
+            dump_append(dc, ", \"too_complex_shape\":true");
+        }
         break;
 
       case T_FILE:

--- a/test/objspace/test_objspace.rb
+++ b/test/objspace/test_objspace.rb
@@ -272,6 +272,35 @@ class TestObjSpace < Test::Unit::TestCase
     JSON.parse(info) if defined?(JSON)
   end
 
+  def test_dump_too_complex_shape
+    if defined?(RubyVM::Shape)
+      RubyVM::Shape::SHAPE_MAX_VARIATIONS.times do
+        Object.new.instance_variable_set(:"@a#{_1}", 1)
+      end
+
+      tc = Object.new
+      tc.instance_variable_set(:@new_ivar, 1)
+      info = ObjectSpace.dump(tc)
+      assert_match(/"too_complex_shape":true/, info)
+      if defined?(JSON)
+        assert_true(JSON.parse(info)["too_complex_shape"])
+      end
+    end
+  end
+
+  class NotTooComplex ; end
+
+  def test_dump_not_too_complex_shape
+    tc = NotTooComplex.new
+    tc.instance_variable_set(:@new_ivar, 1)
+    info = ObjectSpace.dump(tc)
+
+    assert_not_match(/"too_complex_shape"/, info)
+    if defined?(JSON)
+      assert_nil(JSON.parse(info)["too_complex_shape"])
+    end
+  end
+
   def test_dump_to_default
     line = nil
     info = nil


### PR DESCRIPTION
I was going back and forth on whether, for objects that aren't too complex, we should still include the field as false, or leave it off entirely. 

Let me know your thoughts!