### PR TITLE
explicitly build miniruby to resolve symbols when cross-compiling

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3352,6 +3352,10 @@ AS_IF([test x"$cross_compiling" = xyes], [
   AC_SUBST(XRUBY_RUBYLIBDIR)
   AC_SUBST(XRUBY_RUBYHDRDIR)
   PREP='$(arch)-fake.rb'
+  AS_CASE(["$target_os"],[darwin*],[
+    # darwin target requires miniruby for linking ext bundles
+    PREP="$PREP"' miniruby$(EXEEXT)'
+  ])
   RUNRUBY_COMMAND='$(MINIRUBY) -I`cd $(srcdir)/lib; pwd`'
   RUNRUBY='$(RUNRUBY_COMMAND)'
   XRUBY='$(MINIRUBY)'


### PR DESCRIPTION
When cross-compiling Ruby for darwin, the default make target doesn't build miniruby, even though it's needed for symbol resolution since https://github.com/ruby/ruby/commit/50d81bf

https://bugs.ruby-lang.org/issues/19239

cc @XrXr 