### PR TITLE
YJIT: Make --yjit-stats always visible on --help

### DIFF
--- a/ruby.c
+++ b/ruby.c
@@ -337,9 +337,7 @@ usage(const char *name, int help, int highlight, int columns)
 #endif
 #if USE_YJIT
     static const struct ruby_opt_message yjit_options[] = {
-#if YJIT_STATS
         M("--yjit-stats",              "", "Enable collecting YJIT statistics"),
-#endif
         M("--yjit-exec-mem-size=num",  "", "Size of executable memory block in MiB (default: 64)"),
         M("--yjit-call-threshold=num", "", "Number of calls to trigger JIT (default: 10)"),
         M("--yjit-max-versions=num",   "", "Maximum number of versions per basic block (default: 4)"),


### PR DESCRIPTION
It's been available on release builds too since https://github.com/ruby/ruby/pull/6694. It's useful for showing Code GC metrics as well.