### PR TITLE
Stop using receiver#inspect for "undefined method" errors

### DIFF
--- a/error.c
+++ b/error.c
@@ -2116,12 +2116,14 @@ name_err_mesg_to_str(VALUE obj)
 object:
                 klass = CLASS_OF(obj);
                 if (RB_TYPE_P(klass, T_CLASS) && FL_TEST(klass, FL_SINGLETON)) {
-                    s = FAKE_CSTR(&s_str, "extended object ");
+                    s = FAKE_CSTR(&s_str, "");
+                    c = rb_any_to_s(obj);
+                    break;
                 }
                 else {
-                    s = FAKE_CSTR(&s_str, "object ");
+                    s = FAKE_CSTR(&s_str, "an instance of ");
+                    c = rb_class_real(klass);
                 }
-                c = rb_class_real(klass);
             }
             c2 = rb_protect(name_err_mesg_receiver_name, c, &state);
             if (state || NIL_OR_UNDEF_P(c2))

--- a/error.c
+++ b/error.c
@@ -2066,42 +2066,75 @@ name_err_mesg_to_str(VALUE obj)
     if (NIL_P(mesg)) return Qnil;
     else {
         struct RString s_str, d_str;
-        VALUE c, s, d = 0, args[4];
-        int state = 0, singleton = 0;
+        VALUE c, s, d = 0, args[4], c2;
+        int state = 0;
         rb_encoding *usascii = rb_usascii_encoding();
 
 #define FAKE_CSTR(v, str) rb_setup_fake_str((v), (str), rb_strlen_lit(str), usascii)
+        c = s = FAKE_CSTR(&s_str, "");
         obj = ptr[NAME_ERR_MESG__RECV];
         switch (obj) {
           case Qnil:
-            d = FAKE_CSTR(&d_str, "nil");
+            c = d = FAKE_CSTR(&d_str, "nil");
             break;
           case Qtrue:
-            d = FAKE_CSTR(&d_str, "true");
+            c = d = FAKE_CSTR(&d_str, "true");
             break;
           case Qfalse:
-            d = FAKE_CSTR(&d_str, "false");
+            c = d = FAKE_CSTR(&d_str, "false");
             break;
           default:
-            d = rb_protect(name_err_mesg_receiver_name, obj, &state);
-            if (state || NIL_OR_UNDEF_P(d))
-                d = rb_protect(rb_inspect, obj, &state);
+            if (strstr(RSTRING_PTR(mesg), "%2$s")) {
+                d = rb_protect(name_err_mesg_receiver_name, obj, &state);
+                if (state || NIL_OR_UNDEF_P(d))
+                    d = rb_protect(rb_inspect, obj, &state);
+                if (state) {
+                    rb_set_errinfo(Qnil);
+                }
+                d = rb_check_string_type(d);
+                if (NIL_P(d)) {
+                    d = rb_any_to_s(obj);
+                }
+            }
+
+            if (!RB_SPECIAL_CONST_P(obj)) {
+                switch (RB_BUILTIN_TYPE(obj)) {
+                    case T_MODULE:
+                        s = FAKE_CSTR(&s_str, "module ");
+                        c = obj;
+                        break;
+                    case T_CLASS:
+                        s = FAKE_CSTR(&s_str, "class ");
+                        c = obj;
+                        break;
+                    default:
+                        goto object;
+                }
+            }
+            else {
+                VALUE klass;
+object:
+                klass = CLASS_OF(obj);
+                if (RB_TYPE_P(klass, T_CLASS) && FL_TEST(klass, FL_SINGLETON)) {
+                    s = FAKE_CSTR(&s_str, "extended object ");
+                }
+                else {
+                    s = FAKE_CSTR(&s_str, "object ");
+                }
+                c = rb_class_real(klass);
+            }
+            c2 = rb_protect(name_err_mesg_receiver_name, c, &state);
+            if (state || NIL_OR_UNDEF_P(c2))
+                c2 = rb_protect(rb_inspect, c, &state);
             if (state) {
                 rb_set_errinfo(Qnil);
             }
-            d = rb_check_string_type(d);
-            if (NIL_P(d)) {
-                d = rb_any_to_s(obj);
+            c2 = rb_check_string_type(c2);
+            if (NIL_P(c2)) {
+                c2 = rb_any_to_s(c);
             }
-            singleton = (RSTRING_LEN(d) > 0 && RSTRING_PTR(d)[0] == '#');
+            c = c2;
             break;
-        }
-        if (!singleton) {
-            s = FAKE_CSTR(&s_str, ":");
-            c = rb_class_name(CLASS_OF(obj));
-        }
-        else {
-            c = s = FAKE_CSTR(&s_str, "");
         }
         args[0] = rb_obj_as_string(ptr[NAME_ERR_MESG__NAME]);
         args[1] = d;

--- a/error.c
+++ b/error.c
@@ -2065,7 +2065,7 @@ name_err_mesg_to_str(VALUE obj)
     mesg = ptr[NAME_ERR_MESG__MESG];
     if (NIL_P(mesg)) return Qnil;
     else {
-        struct RString s_str, d_str;
+        struct RString s_str, c_str, d_str;
         VALUE c, s, d = 0, args[4], c2;
         int state = 0;
         rb_encoding *usascii = rb_usascii_encoding();
@@ -2117,7 +2117,12 @@ object:
                 klass = CLASS_OF(obj);
                 if (RB_TYPE_P(klass, T_CLASS) && FL_TEST(klass, FL_SINGLETON)) {
                     s = FAKE_CSTR(&s_str, "");
-                    c = rb_any_to_s(obj);
+                    if (obj == rb_vm_top_self()) {
+                        c = FAKE_CSTR(&c_str, "main");
+                    }
+                    else {
+                        c = rb_any_to_s(obj);
+                    }
                     break;
                 }
                 else {

--- a/spec/ruby/core/exception/no_method_error_spec.rb
+++ b/spec/ruby/core/exception/no_method_error_spec.rb
@@ -62,26 +62,49 @@ describe "NoMethodError#message" do
       NoMethodErrorSpecs::NoMethodErrorC.new.a_private_method
     rescue Exception => e
       e.should be_kind_of(NoMethodError)
-      e.message.lines[0].should =~ /private method `a_private_method' called for #<NoMethodErrorSpecs::NoMethodErrorC:0x[\h]+>/
+      e.message.lines[0].should =~ /private method `a_private_method' called for /
     end
   end
 
-  it "calls receiver.inspect only when calling Exception#message" do
-    ScratchPad.record []
-    test_class = Class.new do
-      def inspect
-        ScratchPad << :inspect_called
-        "<inspect>"
+  ruby_version_is ""..."3.3" do
+    it "calls receiver.inspect only when calling Exception#message" do
+      ScratchPad.record []
+      test_class = Class.new do
+        def inspect
+          ScratchPad << :inspect_called
+          "<inspect>"
+        end
+      end
+      instance = test_class.new
+      begin
+        instance.bar
+      rescue Exception => e
+        e.name.should == :bar
+        ScratchPad.recorded.should == []
+        e.message.should =~ /undefined method.+\bbar\b/
+        ScratchPad.recorded.should == [:inspect_called]
       end
     end
-    instance = test_class.new
-    begin
-      instance.bar
-    rescue Exception => e
-      e.name.should == :bar
-      ScratchPad.recorded.should == []
-      e.message.should =~ /undefined method.+\bbar\b/
-      ScratchPad.recorded.should == [:inspect_called]
+  end
+
+  ruby_version_is "3.3" do
+    it "does not call receiver.inspect even when calling Exception#message" do
+      ScratchPad.record []
+      test_class = Class.new do
+        def inspect
+          ScratchPad << :inspect_called
+          "<inspect>"
+        end
+      end
+      instance = test_class.new
+      begin
+        instance.bar
+      rescue Exception => e
+        e.name.should == :bar
+        ScratchPad.recorded.should == []
+        e.message.should =~ /undefined method.+\bbar\b/
+        ScratchPad.recorded.should == []
+      end
     end
   end
 
@@ -108,14 +131,14 @@ describe "NoMethodError#message" do
       begin
         klass.foo
       rescue NoMethodError => error
-        error.message.lines.first.chomp.should == "undefined method `foo' for MyClass:Class"
+        error.message.lines.first.chomp.should =~ /^undefined method `foo' for /
       end
 
       mod = Module.new { def self.name; "MyModule"; end }
       begin
         mod.foo
       rescue NoMethodError => error
-        error.message.lines.first.chomp.should == "undefined method `foo' for MyModule:Module"
+        error.message.lines.first.chomp.should =~ /^undefined method `foo' for /
       end
     end
   end

--- a/test/ruby/test_module.rb
+++ b/test/ruby/test_module.rb
@@ -3281,7 +3281,7 @@ class TestModule < Test::Unit::TestCase
       methods = singleton_class.private_instance_methods(false)
       assert_include(methods, :#{method}, ":#{method} should be private")
 
-      assert_raise_with_message(NoMethodError, "private method `#{method}' called for main:Object") {
+      assert_raise_with_message(NoMethodError, /^private method `#{method}' called for /) {
         recv = self
         recv.#{method}
       }

--- a/test/ruby/test_nomethod_error.rb
+++ b/test/ruby/test_nomethod_error.rb
@@ -85,7 +85,7 @@ class TestNoMethodError < Test::Unit::TestCase
     bug3237 = '[ruby-core:29948]'
     str = "\u2600"
     id = :"\u2604"
-    msg = "undefined method `#{id}' for \"#{str}\":String"
+    msg = "undefined method `#{id}' for an instance of String"
     assert_raise_with_message(NoMethodError, Regexp.compile(Regexp.quote(msg)), bug3237) do
       str.__send__(id)
     end

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -933,7 +933,7 @@ rb_make_no_method_exception(VALUE exc, VALUE format, VALUE obj,
     VALUE name = argv[0];
 
     if (!format) {
-        format = rb_fstring_lit("undefined method `%s' for %s%s%s");
+        format = rb_fstring_lit("undefined method `%1$s' for %3$s%4$s");
     }
     if (exc == rb_eNoMethodError) {
         VALUE args = rb_ary_new4(argc - 1, argv + 1);
@@ -965,17 +965,17 @@ raise_method_missing(rb_execution_context_t *ec, int argc, const VALUE *argv, VA
     stack_check(ec);
 
     if (last_call_status & MISSING_PRIVATE) {
-        format = rb_fstring_lit("private method `%s' called for %s%s%s");
+        format = rb_fstring_lit("private method `%1$s' called for %3$s%4$s");
     }
     else if (last_call_status & MISSING_PROTECTED) {
-        format = rb_fstring_lit("protected method `%s' called for %s%s%s");
+        format = rb_fstring_lit("protected method `%1$s' called for %3$s%4$s");
     }
     else if (last_call_status & MISSING_VCALL) {
-        format = rb_fstring_lit("undefined local variable or method `%s' for %s%s%s");
+        format = rb_fstring_lit("undefined local variable or method `%1$s' for %3$s%4$s");
         exc = rb_eNameError;
     }
     else if (last_call_status & MISSING_SUPER) {
-        format = rb_fstring_lit("super: no superclass method `%s' for %s%s%s");
+        format = rb_fstring_lit("super: no superclass method `%1$s' for %3$s%4$s");
     }
 
     {


### PR DESCRIPTION
```
42.time    #=> undefined method `time' for object Integer (NoMethodError)

class Foo
  privatee #=> undefined local variable or method 'privatee' for class Foo (NoMethodError)
end

s = ""
def s.foo = nil
s.bar      #=> undefined method `bar' for extended object String (NoMethodError)
```

[Feature #18285]