### PR TITLE
Enable RGENGC_CHECK_MODE on RUBY_DEBUG

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -421,7 +421,7 @@ int ruby_rgengc_debug;
  * 5: show all references
  */
 #ifndef RGENGC_CHECK_MODE
-#define RGENGC_CHECK_MODE  0
+# define RGENGC_CHECK_MODE RUBY_DEBUG
 #endif
 
 // Note: using RUBY_ASSERT_WHEN() extend a macro in expr (info by nobu).


### PR DESCRIPTION
We should have GC assertions when RUBY_DEBUG=1.