### PR TITLE
Windows: Fix encoding of `Dir.home` and prefer `USERPROFILE` over `HOMEPATH`

### DIFF
--- a/spec/ruby/core/dir/home_spec.rb
+++ b/spec/ruby/core/dir/home_spec.rb
@@ -19,7 +19,40 @@ describe "Dir.home" do
     it "returns a non-frozen string" do
       Dir.home.should_not.frozen?
     end
+
+    platform_is :windows do
+      ruby_version_is "3.0" do
+        it "returns the current user's home directory from USERPROFILE as UTF-8" do
+          old_dir = ENV['USERPROFILE']
+          ENV.delete 'HOME'
+          ENV['USERPROFILE'] = "C:\\rubyspäc\\home"
+          home = Dir.home
+          home.should == "C:/rubyspäc/home"
+          home.encoding.should == Encoding::UTF_8
+        ensure
+          ENV['USERPROFILE'] = old_dir
+        end
+
+        it "returns the current user's home directory from HOMEDRIVE + HOMEPATH as UTF-8" do
+          old_dir = ENV['USERPROFILE']
+          old_drive = ENV['HOMEDRIVE']
+          old_path = ENV['HOMEPATH']
+          ENV.delete 'HOME'
+          ENV.delete 'USERPROFILE'
+          ENV['HOMEDRIVE'] = "C:"
+          ENV['HOMEPATH'] = "\\rubysp€c\\home"
+          home = Dir.home
+          home.should == "C:/rubysp€c/home"
+          home.encoding.should == Encoding::UTF_8
+        ensure
+          ENV['USERPROFILE'] = old_dir
+          ENV['HOMEDRIVE'] = old_drive
+          ENV['HOMEPATH'] = old_path
+        end
+      end
+    end
   end
+
 
   describe "when called with the current user name" do
     platform_is :solaris do

--- a/win32/file.c
+++ b/win32/file.c
@@ -266,7 +266,8 @@ rb_default_home_dir(VALUE result)
         rb_raise(rb_eArgError, "couldn't find HOME environment -- expanding `~'");
     }
     append_wstr(result, dir, -1,
-                       rb_w32_filecp(), rb_filesystem_encoding());
+                       CP_UTF8, rb_utf8_encoding());
+
     xfree(dir);
     return result;
 }

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -544,7 +544,7 @@ rb_w32_system_tmpdir(WCHAR *path, UINT len)
   afterwards with xfree.
 
   Try:
-  HOME, HOMEDRIVE + HOMEPATH and USERPROFILE environment variables
+  HOME, USERPROFILE, HOMEDRIVE + HOMEPATH environment variables
   Special Folders - Profile and Personal
 */
 WCHAR *
@@ -553,12 +553,16 @@ rb_w32_home_dir(void)
     WCHAR *buffer = NULL;
     size_t buffer_len = MAX_PATH, len = 0;
     enum {
-        HOME_NONE, ENV_HOME, ENV_DRIVEPATH, ENV_USERPROFILE
+        HOME_NONE, ENV_HOME, ENV_USERPROFILE, ENV_DRIVEPATH
     } home_type = HOME_NONE;
 
     if ((len = GetEnvironmentVariableW(L"HOME", NULL, 0)) != 0) {
         buffer_len = len;
         home_type = ENV_HOME;
+    }
+    else if ((len = GetEnvironmentVariableW(L"USERPROFILE", NULL, 0)) != 0) {
+        buffer_len = len;
+        home_type = ENV_USERPROFILE;
     }
     else if ((len = GetEnvironmentVariableW(L"HOMEDRIVE", NULL, 0)) != 0) {
         buffer_len = len;
@@ -566,10 +570,6 @@ rb_w32_home_dir(void)
             buffer_len += len;
             home_type = ENV_DRIVEPATH;
         }
-    }
-    else if ((len = GetEnvironmentVariableW(L"USERPROFILE", NULL, 0)) != 0) {
-        buffer_len = len;
-        home_type = ENV_USERPROFILE;
     }
 
     /* allocate buffer */
@@ -579,12 +579,12 @@ rb_w32_home_dir(void)
       case ENV_HOME:
         GetEnvironmentVariableW(L"HOME", buffer, buffer_len);
         break;
+      case ENV_USERPROFILE:
+        GetEnvironmentVariableW(L"USERPROFILE", buffer, buffer_len);
+        break;
       case ENV_DRIVEPATH:
         len = GetEnvironmentVariableW(L"HOMEDRIVE", buffer, buffer_len);
         GetEnvironmentVariableW(L"HOMEPATH", buffer + len, buffer_len - len);
-        break;
-      case ENV_USERPROFILE:
-        GetEnvironmentVariableW(L"USERPROFILE", buffer, buffer_len);
         break;
       default:
         if (!get_special_folder(CSIDL_PROFILE, buffer, buffer_len) &&


### PR DESCRIPTION
`Dir.home` returns an UTF-8 string since ruby-3.0, but the actual encoding of the bytes was `CP_ACP` or `CP_OEMCP`. That led to invalid bytes when calling `Dir.home` with an Unicode username.

`HOMEPATH` is set to `\WINDOWS\system32` when running per `runas` session. This directory is not writable by ordinary users, leading to errors with many ruby tools. Also config files in the home directory are not recognized.

Still keeping `HOME` at first, which is not used by native Windows, but by ruby specs and by MSYS2 environment.

This might be backported to ruby-3.[01].
