### PR TITLE
configure.ac: limit miniruby dep to when bundle_loader needs it

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3354,7 +3354,7 @@ AS_IF([test x"$cross_compiling" = xyes], [
   AC_SUBST(XRUBY_RUBYLIBDIR)
   AC_SUBST(XRUBY_RUBYHDRDIR)
   PREP='$(arch)-fake.rb'
-  AS_CASE(["$target_os"],[darwin*],[
+  AS_CASE(["$enable_shared:$EXTSTATIC:$target_os"], [no::darwin*], [
     # darwin target requires miniruby for linking ext bundles
     PREP="$PREP"' miniruby$(EXEEXT)'
   ])


### PR DESCRIPTION
This is an improvement on commit e7bffe0 from #6944 suggested by @nobu at https://github.com/ruby/ruby/pull/6944#issuecomment-1356671939

https://bugs.ruby-lang.org/issues/19239

Co-authored-by: Nobuyoshi Nakada <nobu@ruby-lang.org>
