### PR TITLE
Remove duplicated code in `str_coderange` function

### DIFF
--- a/re.c
+++ b/re.c
@@ -1548,11 +1548,7 @@ reg_enc_error(VALUE re, VALUE str)
 static inline int
 str_coderange(VALUE str)
 {
-    int cr = ENC_CODERANGE(str);
-    if (cr == ENC_CODERANGE_UNKNOWN) {
-        cr = rb_enc_str_coderange(str);
-    }
-    return cr;
+    return rb_enc_str_coderange(str);
 }
 
 static rb_encoding*


### PR DESCRIPTION
`str_coderange` and `rb_enc_str_coderange` functions has same encoding range get code.

```c
// In re.c

static inline int
str_coderange(VALUE str)
{
    int cr = ENC_CODERANGE(str);
    if (cr == ENC_CODERANGE_UNKNOWN) {
        cr = rb_enc_str_coderange(str);
    }
    return cr;
}

```

```c
// In string.c

int
rb_enc_str_coderange(VALUE str)
{
    int cr = ENC_CODERANGE(str);

    if (cr == ENC_CODERANGE_UNKNOWN) {
        cr = enc_coderange_scan(str, get_encoding(str));
        ENC_CODERANGE_SET(str, cr);
    }
    return cr;
}
```

I thought better and more simply that remove this duplicated code.