### PR TITLE
Fix misfire of compaction read barrier

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -8519,7 +8519,7 @@ gc_compact_move(rb_objspace_t *objspace, rb_heap_t *heap, rb_size_pool_t *size_p
 
         dheap->sweeping_page = ccan_list_next(&dheap->pages, dheap->sweeping_page, page_node);
         if (gc_compact_heap_cursors_met_p(dheap)) {
-            return false;
+            return dheap != heap;
         }
     }
 


### PR DESCRIPTION
gc_compact_move incorrectly returns false when destination heap is full after sweeping. It returns false even if destination heap is different than source heap (returning false means that the source heap has finished compacting). This causes the source page to get locked, which causes a read barrier fire when we try to compact the source heap again.