### PR TITLE
Fix String interpolation optimisation for VWA

### DIFF
--- a/benchmark/string_concat.yml
+++ b/benchmark/string_concat.yml
@@ -1,6 +1,8 @@
 prelude: |
   CHUNK = "a" * 64
   UCHUNK = "é" * 32
+  SHORT = "a" * (GC::INTERNAL_CONSTANTS[:BASE_SLOT_SIZE] / 2)
+  LONG = "a" * (GC::INTERNAL_CONSTANTS[:BASE_SLOT_SIZE] * 2)
   GC.disable # GC causes a lot of variance
 benchmark:
   binary_concat_7bit: |
@@ -43,3 +45,7 @@ benchmark:
       "#{CHUNK}#{CHUNK}#{CHUNK}#{CHUNK}#{CHUNK}#{CHUNK}#{CHUNK}#{CHUNK}#{CHUNK}#{CHUNK}" \
       "#{CHUNK}#{CHUNK}#{CHUNK}#{CHUNK}#{CHUNK}#{CHUNK}#{CHUNK}#{CHUNK}#{CHUNK}#{CHUNK}" \
       "#{CHUNK}#{CHUNK}#{CHUNK}#{CHUNK}#{CHUNK}#{CHUNK}#{CHUNK}#{CHUNK}#{CHUNK}"
+  interpolation_same_size_pool: |
+    buffer = "#{SHORT}#{SHORT}"
+  interpolation_switching_size_pools: |
+    buffer = "#{SHORT}#{LONG}"

--- a/string.c
+++ b/string.c
@@ -3352,7 +3352,7 @@ rb_str_concat_literals(size_t num, const VALUE *strary)
 
     for (i = 0; i < num; ++i) { len += RSTRING_LEN(strary[i]); }
     str = rb_str_buf_new(len);
-    str_enc_copy(str, strary[0]);
+    str_enc_copy_direct(str, strary[0]);
 
     for (i = s; i < num; ++i) {
         const VALUE v = strary[i];

--- a/string.c
+++ b/string.c
@@ -3340,28 +3340,19 @@ rb_str_append(VALUE str, VALUE str2)
     return rb_str_buf_append(str, str2);
 }
 
-#define MIN_PRE_ALLOC_SIZE 48
-
 MJIT_FUNC_EXPORTED VALUE
 rb_str_concat_literals(size_t num, const VALUE *strary)
 {
     VALUE str;
-    size_t i, s;
-    long len = 1;
+    size_t i, s = 0;
+    unsigned long len = 1;
 
     if (UNLIKELY(!num)) return rb_str_new(0, 0);
     if (UNLIKELY(num == 1)) return rb_str_resurrect(strary[0]);
 
     for (i = 0; i < num; ++i) { len += RSTRING_LEN(strary[i]); }
-    if (LIKELY(len < MIN_PRE_ALLOC_SIZE)) {
-        str = rb_str_resurrect(strary[0]);
-        s = 1;
-    }
-    else {
-        str = rb_str_buf_new(len);
-        rb_enc_copy(str, strary[0]);
-        s = 0;
-    }
+    str = rb_str_buf_new(len);
+    str_enc_copy(str, strary[0]);
 
     for (i = s; i < num; ++i) {
         const VALUE v = strary[i];


### PR DESCRIPTION
When string interpolation is used, after some pre-processing, `rb_str_concat_literals` gets called, with an array containing `T_STRING` objects for each piece of the final interpolated string. The first string is used as a base, and all the remaining strings are appended to it.

There was an optimisation here. If the final length of the interpolated string is larger than the value of `MIN_PRE_ALLOC_SIZE` (48 bytes), then we pre-allocate a new string of the correct size in order to avoid unnecessary capacity resizing of the first strings underlying buffer.

NOTE: the original value for `MIN_PRE_ALLOC_SIZE` of 48, was chosen by experimentation when this optimisation was initially implemented in 2017.

With VWA enabled, this can cause us to see unexpected behaviour - where strings are created as extended strings in a small size pool, when they would adequately fit into a larger size pool and be able to remain embedded.

This can be seen by running the following test code:

```ruby
require 'objspace'

short_a = "Hello"
long_a = "a" * 20

mixed_res = "#{short}, #{long_b}"

puts mixed_res.size
puts ObjectSpace.dump(mixed_res)
```

This outputs the following on master

```
{"address":"0x10768b7f0", "type":"STRING", "shape_id":0,"slot_size":40, "class":"0x105f2eda0", "bytesize":27, "capacity":31, "value":"Hello, bbbbbbbbbbbbbbbbbbbb", "encoding":"UTF-8", "coderange":"7bit", "memsize":72, "flags":{"wb_protected":true}}
```

Where we can see that this string is in the 40 byte size pool, and is not embedded (ObjectSpace dumps will contain `embedded: true` for embedded objects), and the bytesize of the string is 27, this is larger than the space available in the 40 byte pool.

This is happening because if a string interpolation is used where the first "chunk" of the string is in the smallest size pool, but the combined final length would put it in a larger size pool (but still less than `MIN_PRE_ALLOC_SIZE` bytes), then the initial 40 byte string gets used as the base, and as the string grows the buffer ends up being evacuated out to the heap and that string loses it's embedded status.

This PR changes this behaviour so that the original `rb_str_resurrect` path will be used whenever the final interpolated string will still fit into the same size pool as the first "chunk" of the string.

If the final string and the initial "chunk" are going to be in different size pools, then we do a pre-allocation of a new empty string, in the correct size pool for the interpolated string to be embedded.

This fixes the observable behaviour above. Running the test script now outputs the following:

```
{"address":"0x107e433a8", "type":"STRING", "shape_id":1, "slot_size":80, "class":"0x1067eeda0", "embedded":true, "bytesize":27, "value":"Hello, bbbbbbbbbbbbbbbbbbbb", "encoding":"UTF-8", "coderange":"7bit", "memsize":80, "flags":{"wb_protected":true}}
```

Where we can see that the final string has now been embedded into the 80 byte pool.

There are some implications of this approach:

* We could actually have slightly worse memory usage in some cases. Where  strings are being interpolated such that the final string crosses a size pool boundary by only a few bytes (as in the case above), then the unused space in the slot will require more memory than if the object was extended. However in this case I'd expect performance to be faster owing to better spatial locality.
* We'll be doing more allocations for workloads that create strings that are slightly longer than 24 bytes but shorter than `MIN_PRE_ALLOC_SIZE`. This is because these strings will require a size pool change and will be pre-allocated now where in the past they were not. In this case I'd expect to see a slight performance degradation paired with better memory usage
* The removal of the `MIN_PRE_ALLOC_SIZE` constraint will now mean that we can use the `rb_str_resurrect` fast path for strings in all size pools, not just the smallest, as long as the final interpolated string will remain in the same pool as the first "chunk"

## Alternative approaches

Initially, We tried removing the `rb_str_resurrect` branch of this conditional entirely, and always pre-allocating a new object in the correct size pool. This fixes the immediate issue, but regresses the original performance optimisation benchmark seen in [the original commit](https://github.com/shopify/ruby/commit/80c50308f9db813e999367ec5d116e2d2be9f840). This is due to the increased overhead setting up the correct encoding on the new string.

We tried implementing another optimisation to make the encoding copy faster, and allow us to pre-allocate everything. Ultimately we discarded this idea as it increases the complexity of the implementation, for only a small performance improvement for small strings (but was slower than our chosen implementation for larger string interpolations).

Here is the [original code](https://github.com/shopify/ruby/commit/80c50308f9db813e999367ec5d116e2d2be9f840) used for benchmarking:

```ruby
require 'benchmark/ips'

Benchmark.ips do |x|
  x.report "Large string interpolation" do |t|
    a = "Hellooooooooooooooooooooooooooooooooooooooooooooooooooo"
    b = "Wooooooooooooooooooooooooooooooooooooooooooooooooooorld"

    t.times do
      "#{a}, #{b}!"
    end
  end

  x.report "Small string interpolation" do |t|
    a = "Hello"
    b = "World"

    t.times do
      "#{a}, #{b}!"
    end
  end
end
```

### Results

Benchmarks were run for the default 5 seconds, values are the benchmark runs only, excluding the warm-up numbers.

The final solution we chose is in **bold**

| branch                               | Large string interpolation (i/s) | Small string interpolation (i/s) |
| ------------------------------------ | -------------------------- | -------------------------- |
| master                               | 42.890M                    | 49.089M                    |
| Always pre-alloc                     | 41.740M                    | 45.420M                    |
| Always pre-alloc (with-encoding fix) | 45.538M                    | 48.853M                    |
| **Pre-alloc on size pool change**    | **42.176M**                | **50.412M**                |

## Further benchmarks

We measured performance using `yjit-bench` and saw the following results:

```
master: ruby 3.3.0dev (2023-01-10T14:31:04Z master be1db1ca5c) [x86_64-linux]
last_commit=Just ignore empty lines in bundled_gems file [ci skip]
mvh-string-interpolate-correct-pool: ruby 3.3.0dev (2023-01-11T17:27:59Z mvh-string-interpo.. 089a05ec11) [x86_64-linux]

--------------  -----------  ----------  ---------  ----------------------------------------  ----------  ---------  ------------------------------------------  -------------------------------------------
bench           master (ms)  stddev (%)  RSS (MiB)  mvh-string-interpolate-correct-pool (ms)  stddev (%)  RSS (MiB)  master/mvh-string-interpolate-correct-pool  mvh-string-interpolate-correct-pool 1st itr
activerecord    136.3        0.2         45.5       138.5                                     0.8         45.7       0.98                                        1.00
hexapdf         2273.9       0.3         285.5      2261.7                                    0.2         214.2      1.01                                        1.01
liquid-render   149.3        0.7         22.2       148.1                                     0.7         22.3       1.01                                        1.00
mail            122.5        0.1         42.4       122.9                                     0.1         42.1       1.00                                        1.02
psych-load      1847.6       0.1         29.4       1882.4                                    0.1         29.4       0.98                                        0.98
railsbench      1813.0       0.6         92.5       1822.2                                    0.7         92.8       0.99                                        0.98
ruby-lsp        62.3         8.8         88.0       61.5                                      8.2         88.4       1.01                                        1.00
sequel          111.9        1.3         34.4       112.9                                     1.4         34.4       0.99                                        0.99
binarytrees     302.5        0.8         22.3       303.9                                     0.8         22.7       1.00                                        1.02
chunky_png      757.3        0.4         30.9       764.6                                     0.4         31.0       0.99                                        0.99
erubi           253.3        0.7         80.1       229.8                                     0.7         77.0       1.10                                        1.10
erubi_rails     18.5         1.5         92.3       18.4                                      1.6         91.6       1.00                                        0.89
etanni          342.9        0.5         88.7       307.4                                     0.6         89.6       1.12                                        1.12
fannkuchredux   1804.0       0.5         16.4       1813.2                                    0.4         16.6       0.99                                        0.99
lee             939.7        0.8         25.3       941.4                                     1.0         25.9       1.00                                        0.99
nbody           97.0         0.6         16.5       96.2                                      0.9         16.5       1.01                                        1.03
optcarrot       4792.4       1.2         50.7       4652.0                                    0.7         50.9       1.03                                        1.01
rubykon         9640.7       0.3         50.4       9330.0                                    0.8         51.1       1.03                                        1.01
30k_ifelse      1614.1       0.1         59.5       1605.3                                    0.0         59.5       1.01                                        1.01
30k_methods     4032.2       0.0         49.6       4028.9                                    0.3         49.6       1.00                                        1.00
cfunc_itself    75.5         0.3         16.4       75.0                                      1.1         16.5       1.01                                        1.01
fib             165.4        1.4         16.4       163.0                                     1.7         16.4       1.01                                        1.05
getivar         91.6         0.9         16.4       92.1                                      0.5         16.5       0.99                                        0.99
keyword_args    219.4        0.4         16.4       198.1                                     1.4         16.5       1.11                                        1.12
respond_to      205.5        0.2         16.4       204.8                                     0.4         16.5       1.00                                        1.00
setivar         51.1         2.6         16.4       56.8                                      2.8         16.5       0.90                                        0.90
setivar_object  79.2         5.6         16.4       75.2                                      3.8         16.5       1.05                                        1.10
str_concat      62.1         1.4         82.1       61.8                                      1.7         82.1       1.01                                        0.98
--------------  -----------  ----------  ---------  ----------------------------------------  ----------  ---------  ------------------------------------------  -------------------------------------------
Legend:
- master/mvh-string-interpolate-correct-pool: ratio of master/mvh-string-interpolate-correct-pool time. Higher is better for mvh-string-interpolate-correct-pool. Above 1 represents a speedup.
- mvh-string-interpolate-correct-pool 1st itr: ratio of master/mvh-string-interpolate-correct-pool time for the first benchmarking iteration.
```

This shows that performance overall has mostly been maintained compared to the original optimisation, but has improved by ~12% for some specific workloads, as well as improving memory usage on these workloads. This could be explained by the first implication above. We're using slightly more memory to embed strings that would previously have been extended.

We have also seen a significant drop in RSS in `hexapdf`. This could be explained by the last implication above. We're now able to use the fast path for more strings, in different pools, reducing the number of allocations required overall.

The RSS results can be seen in this chart.

<img width="1659" alt="Screenshot 2023-01-11 at 18 19 45" src="https://user-images.githubusercontent.com/31869/211886601-dcfae88d-1699-441e-8bb8-f134e8526e5e.png">

