### PR TITLE
Array#pack: document silent truncation

### DIFF
--- a/doc/packed_data.rdoc
+++ b/doc/packed_data.rdoc
@@ -60,6 +60,10 @@ Any directive may be followed by either of these modifiers:
   Note: Directives in <tt>%w[A a Z m]</tt> use +count+ differently;
   see {String Directives}[rdoc-ref:packed_data.rdoc@String+Directives].
 
+If elements don't fit the provided directive, only least significant bits are encoded:
+
+    [257].pack("C").unpack("C") # => [1]
+
 === Packing \Method
 
 \Method Array#pack accepts optional keyword argument


### PR DESCRIPTION
Ref: [Feature #19245]

At the very least this behavior should be documented.