### PR TITLE
Reuse `RBASIC_CLASS` macro

### DIFF
--- a/array.c
+++ b/array.c
@@ -3461,7 +3461,7 @@ struct ary_sort_data {
 static VALUE
 sort_reentered(VALUE ary)
 {
-    if (RBASIC(ary)->klass) {
+    if (RBASIC_CLASS(ary)) {
         rb_raise(rb_eRuntimeError, "sort reentered");
     }
     return Qnil;
@@ -6558,7 +6558,7 @@ flatten(VALUE ary, int level)
                 continue;
             }
             tmp = rb_check_array_type(elt);
-            if (RBASIC(result)->klass) {
+            if (RBASIC_CLASS(result)) {
                 if (memo) {
                     RB_GC_GUARD(vmemo);
                     st_clear(memo);
@@ -6963,7 +6963,7 @@ yield_indexed_values(const VALUE values, const long r, const long *const p)
     for (i = 0; i < r; i++) ARY_SET(result, i, RARRAY_AREF(values, p[i]));
     ARY_SET_LEN(result, r);
     rb_yield(result);
-    return !RBASIC(values)->klass;
+    return !RBASIC_CLASS(values);
 }
 
 /*

--- a/class.c
+++ b/class.c
@@ -32,7 +32,7 @@
 
 #define id_attached id__attached__
 
-#define METACLASS_OF(k) RBASIC(k)->klass
+#define METACLASS_OF(k) RBASIC_CLASS(k)
 #define SET_METACLASS_OF(k, cls) RBASIC_SET_CLASS(k, cls)
 
 RUBY_EXTERN rb_serial_t ruby_vm_global_cvar_state;

--- a/enum.c
+++ b/enum.c
@@ -1353,7 +1353,7 @@ sort_by_i(RB_BLOCK_CALL_FUNC_ARGLIST(i, _data))
 
     v = enum_yield(argc, i);
 
-    if (RBASIC(ary)->klass) {
+    if (RBASIC_CLASS(ary)) {
         rb_raise(rb_eRuntimeError, "sort_by reentered");
     }
     if (RARRAY_LEN(data->buf) != SORT_BY_BUFSIZE*2) {
@@ -1377,7 +1377,7 @@ sort_by_cmp(const void *ap, const void *bp, void *data)
     VALUE b;
     VALUE ary = (VALUE)data;
 
-    if (RBASIC(ary)->klass) {
+    if (RBASIC_CLASS(ary)) {
         rb_raise(rb_eRuntimeError, "sort_by reentered");
     }
 
@@ -1505,7 +1505,7 @@ enum_sort_by(VALUE obj)
                        ruby_qsort(ptr, RARRAY_LEN(ary)/2, 2*sizeof(VALUE),
                                   sort_by_cmp, (void *)ary));
     }
-    if (RBASIC(ary)->klass) {
+    if (RBASIC_CLASS(ary)) {
         rb_raise(rb_eRuntimeError, "sort_by reentered");
     }
     for (i=1; i<RARRAY_LEN(ary); i+=2) {
@@ -1701,7 +1701,7 @@ struct nmin_data {
 static VALUE
 cmpint_reenter_check(struct nmin_data *data, VALUE val)
 {
-    if (RBASIC(data->buf)->klass) {
+    if (RBASIC_CLASS(data->buf)) {
         rb_raise(rb_eRuntimeError, "%s%s reentered",
                  data->rev ? "max" : "min",
                  data->by ? "_by" : "");

--- a/eval.c
+++ b/eval.c
@@ -1269,7 +1269,7 @@ rb_using_refinement(rb_cref_t *cref, VALUE klass, VALUE module)
         if (!NIL_P(c = rb_hash_lookup(CREF_REFINEMENTS(cref), klass))) {
             superclass = c;
             while (c && RB_TYPE_P(c, T_ICLASS)) {
-                if (RBASIC(c)->klass == module) {
+                if (RBASIC_CLASS(c) == module) {
                     /* already used refinement */
                     return;
                 }
@@ -1317,7 +1317,7 @@ using_module_recursive(const rb_cref_t *cref, VALUE klass)
         break;
 
       case T_ICLASS:
-        module = RBASIC(klass)->klass;
+        module = RBASIC_CLASS(klass);
         break;
 
       default:
@@ -1366,7 +1366,7 @@ add_activated_refinement(VALUE activated_refinements,
     if (!NIL_P(c = rb_hash_lookup(activated_refinements, klass))) {
         superclass = c;
         while (c && RB_TYPE_P(c, T_ICLASS)) {
-            if (RBASIC(c)->klass == refinement) {
+            if (RBASIC_CLASS(c) == refinement) {
                 /* already used refinement */
                 return;
             }

--- a/gc.c
+++ b/gc.c
@@ -14001,11 +14001,11 @@ rb_raw_obj_info_common(char *const buff, const size_t buff_size, const VALUE obj
         if (internal_object_p(obj)) {
             /* ignore */
         }
-        else if (RBASIC(obj)->klass == 0) {
+        else if (RBASIC_CLASS(obj) == 0) {
             APPEND_S("(temporary internal)");
         }
-        else if (RTEST(RBASIC(obj)->klass)) {
-            VALUE class_path = rb_class_path_cached(RBASIC(obj)->klass);
+        else if (RTEST(RBASIC_CLASS(obj))) {
+            VALUE class_path = rb_class_path_cached(RBASIC_CLASS(obj));
             if (!NIL_P(class_path)) {
                 APPEND_F("(%s)", RSTRING_PTR(class_path));
             }

--- a/hash.c
+++ b/hash.c
@@ -110,8 +110,8 @@ static int
 rb_any_cmp(VALUE a, VALUE b)
 {
     if (a == b) return 0;
-    if (RB_TYPE_P(a, T_STRING) && RBASIC(a)->klass == rb_cString &&
-        RB_TYPE_P(b, T_STRING) && RBASIC(b)->klass == rb_cString) {
+    if (RB_TYPE_P(a, T_STRING) && RBASIC_CLASS(a) == rb_cString &&
+        RB_TYPE_P(b, T_STRING) && RBASIC_CLASS(b) == rb_cString) {
         return rb_str_hash_cmp(a, b);
     }
     if (UNDEF_P(a) || UNDEF_P(b)) return -1;

--- a/iseq.c
+++ b/iseq.c
@@ -54,7 +54,7 @@ static unsigned int *succ_index_table_invert(int max_pos, struct succ_index_tabl
 static int succ_index_lookup(const struct succ_index_table *sd, int x);
 #endif
 
-#define hidden_obj_p(obj) (!SPECIAL_CONST_P(obj) && !RBASIC(obj)->klass)
+#define hidden_obj_p(obj) (!SPECIAL_CONST_P(obj) && !RBASIC_CLASS(obj))
 
 static inline VALUE
 obj_resurrect(VALUE obj)

--- a/marshal.c
+++ b/marshal.c
@@ -538,8 +538,8 @@ w_extended(VALUE klass, struct dump_arg *arg, int check)
     }
     while (BUILTIN_TYPE(klass) == T_ICLASS) {
         if (!FL_TEST(klass, RICLASS_IS_ORIGIN) ||
-                BUILTIN_TYPE(RBASIC(klass)->klass) != T_MODULE) {
-            VALUE path = rb_class_name(RBASIC(klass)->klass);
+                BUILTIN_TYPE(RBASIC_CLASS(klass)) != T_MODULE) {
+            VALUE path = rb_class_name(RBASIC_CLASS(klass));
             w_byte(TYPE_EXTENDED, arg);
             w_unique(path, arg);
         }
@@ -929,7 +929,7 @@ w_object(VALUE obj, struct dump_arg *arg, int limit)
         hasiv = has_ivars(obj, (encname = encoding_name(obj, arg)), &ivobj);
         {
             st_data_t compat_data;
-            rb_alloc_func_t allocator = rb_get_alloc_func(RBASIC(obj)->klass);
+            rb_alloc_func_t allocator = rb_get_alloc_func(RBASIC_CLASS(obj));
             if (st_lookup(compat_allocator_tbl,
                           (st_data_t)allocator,
                           &compat_data)) {
@@ -1886,7 +1886,7 @@ r_object_for(struct load_arg *arg, bool partial, int *ivp, VALUE extmod, int typ
             if (rb_special_const_p(v) || RB_TYPE_P(v, T_OBJECT) || RB_TYPE_P(v, T_CLASS)) {
                 goto format_error;
             }
-            if (RB_TYPE_P(v, T_MODULE) || !RTEST(rb_class_inherited_p(c, RBASIC(v)->klass))) {
+            if (RB_TYPE_P(v, T_MODULE) || !RTEST(rb_class_inherited_p(c, RBASIC_CLASS(v)))) {
                 VALUE tmp = rb_obj_alloc(c);
 
                 if (TYPE(v) != TYPE(tmp)) goto format_error;

--- a/object.c
+++ b/object.c
@@ -1903,7 +1903,7 @@ rb_class_initialize(int argc, VALUE *argv, VALUE klass)
         }
     }
     RCLASS_SET_SUPER(klass, super);
-    rb_make_metaclass(klass, RBASIC(super)->klass);
+    rb_make_metaclass(klass, RBASIC_CLASS(super));
     rb_class_inherited(super, klass);
     rb_mod_initialize_exec(klass);
 

--- a/range.c
+++ b/range.c
@@ -2048,7 +2048,7 @@ range_loader(VALUE range, VALUE obj)
 {
     VALUE beg, end, excl;
 
-    if (!RB_TYPE_P(obj, T_OBJECT) || RBASIC(obj)->klass != rb_cObject) {
+    if (!RB_TYPE_P(obj, T_OBJECT) || RBASIC_CLASS(obj) != rb_cObject) {
         rb_raise(rb_eTypeError, "not a dumped range object");
     }
 

--- a/sprintf.c
+++ b/sprintf.c
@@ -1070,7 +1070,7 @@ ruby__sfvwrite(register rb_printf_buffer *fp, register struct __suio *uio)
     long len, n;
     long blen = buf - RSTRING_PTR(result), bsiz = fp->_w;
 
-    if (RBASIC(result)->klass) {
+    if (RBASIC_CLASS(result)) {
         rb_raise(rb_eRuntimeError, "rb_vsprintf reentered");
     }
     if (uio->uio_resid == 0)
@@ -1102,7 +1102,7 @@ ruby__sfvextra(rb_printf_buffer *fp, size_t valsize, void *valp, long *sz, int s
 
     if (valsize != sizeof(VALUE)) return 0;
     value = *(VALUE *)valp;
-    if (RBASIC(result)->klass) {
+    if (RBASIC_CLASS(result)) {
         rb_raise(rb_eRuntimeError, "rb_vsprintf reentered");
     }
     if (sign == '+') {
@@ -1150,7 +1150,7 @@ ruby_vsprintf0(VALUE result, char *p, const char *fmt, va_list ap)
 {
     rb_printf_buffer_extra buffer;
 #define f buffer.base
-    VALUE klass = RBASIC(result)->klass;
+    VALUE klass = RBASIC_CLASS(result);
     int coderange = ENC_CODERANGE(result);
     long scanned = 0;
 

--- a/string.c
+++ b/string.c
@@ -1475,7 +1475,7 @@ str_new_frozen_buffer(VALUE klass, VALUE orig, int copy_encoding)
             assert(OBJ_FROZEN(shared));
 
             if ((ofs > 0) || (rest > 0) ||
-                (klass != RBASIC(shared)->klass) ||
+                (klass != RBASIC_CLASS(shared)) ||
                 ENCODING_GET(shared) != ENCODING_GET(orig)) {
                 str = str_new_shared(klass, shared);
                 assert(!STR_EMBED_P(str));

--- a/struct.c
+++ b/struct.c
@@ -254,7 +254,7 @@ anonymous_struct(VALUE klass)
     VALUE nstr;
 
     nstr = rb_class_new(klass);
-    rb_make_metaclass(nstr, RBASIC(klass)->klass);
+    rb_make_metaclass(nstr, RBASIC_CLASS(klass));
     rb_class_inherited(klass, nstr);
     return nstr;
 }

--- a/thread.c
+++ b/thread.c
@@ -1886,7 +1886,7 @@ rb_threadptr_pending_interrupt_check_mask(rb_thread_t *th, VALUE err)
             VALUE sym;
 
             if (BUILTIN_TYPE(mod) == T_ICLASS) {
-                klass = RBASIC(mod)->klass;
+                klass = RBASIC_CLASS(mod);
             }
             else if (mod != RCLASS_ORIGIN(mod)) {
                 continue;

--- a/variable.c
+++ b/variable.c
@@ -173,7 +173,7 @@ rb_tmp_class_path(VALUE klass, int *permanent, fallback_func fallback)
             }
             else {
                 int perm;
-                path = rb_tmp_class_path(RBASIC(klass)->klass, &perm, fallback);
+                path = rb_tmp_class_path(RBASIC_CLASS(klass), &perm, fallback);
             }
         }
         *permanent = 0;
@@ -2124,7 +2124,7 @@ autoload_data(VALUE mod, ID id)
             return 0;
         }
         else {
-            mod = RBASIC(mod)->klass;
+            mod = RBASIC_CLASS(mod);
         }
     }
 
@@ -2824,7 +2824,7 @@ rb_const_search_from(VALUE klass, ID id, int exclude, int recurse, int visibilit
         // Do lookup in original class or module in case we are at an origin
         // iclass in the chain.
         tmp = current;
-        if (BUILTIN_TYPE(tmp) == T_ICLASS) tmp = RBASIC(tmp)->klass;
+        if (BUILTIN_TYPE(tmp) == T_ICLASS) tmp = RBASIC_CLASS(tmp);
 
         // Do the lookup. Loop in case of autoload.
         while ((ce = rb_const_lookup(tmp, id))) {
@@ -3555,7 +3555,7 @@ static VALUE
 original_module(VALUE c)
 {
     if (RB_TYPE_P(c, T_ICLASS))
-        return RBASIC(c)->klass;
+        return RBASIC_CLASS(c);
     return c;
 }
 
@@ -3568,7 +3568,7 @@ cvar_lookup_at(VALUE klass, ID id, st_data_t *v)
         }
         else {
             // check the original module
-            klass = RBASIC(klass)->klass;
+            klass = RBASIC_CLASS(klass);
         }
     }
 
@@ -3672,7 +3672,7 @@ rb_cvar_set(VALUE klass, ID id, VALUE val)
     }
 
     if (RB_TYPE_P(target, T_ICLASS)) {
-        target = RBASIC(target)->klass;
+        target = RBASIC_CLASS(target);
     }
     check_before_mod_set(target, id, val, "class variable");
 

--- a/vm.c
+++ b/vm.c
@@ -539,7 +539,7 @@ rb_dtrace_setup(rb_execution_context_t *ec, VALUE klass, ID id,
             return FALSE;
     }
     if (RB_TYPE_P(klass, T_ICLASS)) {
-        klass = RBASIC(klass)->klass;
+        klass = RBASIC_CLASS(klass);
     }
     else if (FL_TEST(klass, FL_SINGLETON)) {
         klass = rb_attr_get(klass, id__attached__);
@@ -2122,7 +2122,7 @@ static void
 hook_before_rewind(rb_execution_context_t *ec, const rb_control_frame_t *cfp,
                    bool cfp_returning_with_value, int state, struct vm_throw_data *err)
 {
-    if (state == TAG_RAISE && RBASIC(err)->klass == rb_eSysStackError) {
+    if (state == TAG_RAISE && RBASIC_CLASS(err) == rb_eSysStackError) {
         return;
     }
     else {

--- a/vm.c
+++ b/vm.c
@@ -2122,7 +2122,7 @@ static void
 hook_before_rewind(rb_execution_context_t *ec, const rb_control_frame_t *cfp,
                    bool cfp_returning_with_value, int state, struct vm_throw_data *err)
 {
-    if (state == TAG_RAISE && RBASIC_CLASS(err) == rb_eSysStackError) {
+    if (state == TAG_RAISE && RBASIC(err)->klass == rb_eSysStackError) {
         return;
     }
     else {

--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -1395,7 +1395,7 @@ get_klass(const rb_control_frame_t *cfp)
     VALUE klass;
     if (rb_vm_control_frame_id_and_class(cfp, 0, 0, &klass)) {
         if (RB_TYPE_P(klass, T_ICLASS)) {
-            return RBASIC(klass)->klass;
+            return RBASIC_CLASS(klass);
         }
         else {
             return klass;
@@ -1733,7 +1733,7 @@ rb_profile_frame_classpath(VALUE frame)
 
     if (klass && !NIL_P(klass)) {
         if (RB_TYPE_P(klass, T_ICLASS)) {
-            klass = RBASIC(klass)->klass;
+            klass = RBASIC_CLASS(klass);
         }
         else if (FL_TEST(klass, FL_SINGLETON)) {
             klass = rb_ivar_get(klass, id__attached__);

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -843,7 +843,7 @@ rb_method_call_status(rb_execution_context_t *ec, const rb_callable_method_entry
 
             VALUE defined_class = me->owner;
             if (RB_TYPE_P(defined_class, T_ICLASS)) {
-                defined_class = RBASIC(defined_class)->klass;
+                defined_class = RBASIC_CLASS(defined_class);
             }
 
             if (UNDEF_P(self) || !rb_obj_is_kind_of(self, defined_class)) {

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1479,7 +1479,7 @@ update_classvariable_cache(const rb_iseq_t *iseq, VALUE klass, ID id, ICVARC ic)
     VALUE cvar_value = rb_cvar_find(klass, id, &defined_class);
 
     if (RB_TYPE_P(defined_class, T_ICLASS)) {
-        defined_class = RBASIC(defined_class)->klass;
+        defined_class = RBASIC_CLASS(defined_class);
     }
 
     struct rb_id_table *rb_cvc_tbl = RCLASS_CVC_TBL(defined_class);
@@ -4102,9 +4102,9 @@ static inline VALUE
 vm_search_normal_superclass(VALUE klass)
 {
     if (BUILTIN_TYPE(klass) == T_ICLASS &&
-            RB_TYPE_P(RBASIC(klass)->klass, T_MODULE) &&
-        FL_TEST_RAW(RBASIC(klass)->klass, RMODULE_IS_REFINEMENT)) {
-        klass = RBASIC(klass)->klass;
+            RB_TYPE_P(RBASIC_CLASS(klass), T_MODULE) &&
+        FL_TEST_RAW(RBASIC_CLASS(klass), RMODULE_IS_REFINEMENT)) {
+        klass = RBASIC_CLASS(klass);
     }
     klass = RCLASS_ORIGIN(klass);
     return RCLASS_SUPER(klass);

--- a/vm_method.c
+++ b/vm_method.c
@@ -336,7 +336,7 @@ rb_method_table_insert(VALUE klass, struct rb_id_table *table, ID method_id, con
 {
     VALUE table_owner = klass;
     if (RB_TYPE_P(klass, T_ICLASS) && !RICLASS_OWNS_M_TBL_P(klass)) {
-        table_owner = RBASIC(table_owner)->klass;
+        table_owner = RBASIC_CLASS(table_owner);
     }
     VM_ASSERT(RB_TYPE_P(table_owner, T_CLASS) || RB_TYPE_P(table_owner, T_ICLASS) || RB_TYPE_P(table_owner, T_MODULE));
     VM_ASSERT(table == RCLASS_M_TBL(table_owner));

--- a/vm_trace.c
+++ b/vm_trace.c
@@ -715,7 +715,7 @@ call_trace_func(rb_event_flag_t event, VALUE proc, VALUE self, ID id, VALUE klas
 
     if (klass) {
         if (RB_TYPE_P(klass, T_ICLASS)) {
-            klass = RBASIC(klass)->klass;
+            klass = RBASIC_CLASS(klass);
         }
         else if (FL_TEST(klass, FL_SINGLETON)) {
             klass = rb_ivar_get(klass, id__attached__);
@@ -885,7 +885,7 @@ fill_id_and_klass(rb_trace_arg_t *trace_arg)
 
         if (trace_arg->klass) {
             if (RB_TYPE_P(trace_arg->klass, T_ICLASS)) {
-                trace_arg->klass = RBASIC(trace_arg->klass)->klass;
+                trace_arg->klass = RBASIC_CLASS(trace_arg->klass);
             }
         }
         else {


### PR DESCRIPTION
Some code has get to `klass` like this.

```c
RBASIC(ary)->klass
```

But, already defined `RBASIC_CLASS` macro to get `klass`.
I thought better and more shorter code to use `RBASIC_CLASS` macro.