### PR TITLE
Always issue deprecation warning when calling Regexp.new with 3rd positional argument

### DIFF
--- a/lib/racc/statetransitiontable.rb
+++ b/lib/racc/statetransitiontable.rb
@@ -216,7 +216,7 @@ module Racc
         end
         i = ii
       end
-      Regexp.compile(map, nil, 'n')
+      Regexp.compile(map, Regexp::NOENCODING)
     end
 
     def set_table(entries, dummy, tbl, chk, ptr)

--- a/spec/ruby/core/regexp/shared/new.rb
+++ b/spec/ruby/core/regexp/shared/new.rb
@@ -197,48 +197,50 @@ describe :regexp_new_string, shared: true do
     end
   end
 
-  it "ignores the third argument if it is 'e' or 'euc' (case-insensitive)" do
-    -> {
-      Regexp.send(@method, 'Hi', nil, 'e').encoding.should == Encoding::US_ASCII
-      Regexp.send(@method, 'Hi', nil, 'euc').encoding.should == Encoding::US_ASCII
-      Regexp.send(@method, 'Hi', nil, 'E').encoding.should == Encoding::US_ASCII
-      Regexp.send(@method, 'Hi', nil, 'EUC').encoding.should == Encoding::US_ASCII
-    }.should complain(/encoding option is ignored/)
-  end
+  ruby_version_is ""..."3.2" do
+    it "ignores the third argument if it is 'e' or 'euc' (case-insensitive)" do
+      -> {
+        Regexp.send(@method, 'Hi', nil, 'e').encoding.should == Encoding::US_ASCII
+        Regexp.send(@method, 'Hi', nil, 'euc').encoding.should == Encoding::US_ASCII
+        Regexp.send(@method, 'Hi', nil, 'E').encoding.should == Encoding::US_ASCII
+        Regexp.send(@method, 'Hi', nil, 'EUC').encoding.should == Encoding::US_ASCII
+      }.should complain(/encoding option is ignored/)
+    end
 
-  it "ignores the third argument if it is 's' or 'sjis' (case-insensitive)" do
-    -> {
-      Regexp.send(@method, 'Hi', nil, 's').encoding.should == Encoding::US_ASCII
-      Regexp.send(@method, 'Hi', nil, 'sjis').encoding.should == Encoding::US_ASCII
-      Regexp.send(@method, 'Hi', nil, 'S').encoding.should == Encoding::US_ASCII
-      Regexp.send(@method, 'Hi', nil, 'SJIS').encoding.should == Encoding::US_ASCII
-    }.should complain(/encoding option is ignored/)
-  end
+    it "ignores the third argument if it is 's' or 'sjis' (case-insensitive)" do
+      -> {
+        Regexp.send(@method, 'Hi', nil, 's').encoding.should == Encoding::US_ASCII
+        Regexp.send(@method, 'Hi', nil, 'sjis').encoding.should == Encoding::US_ASCII
+        Regexp.send(@method, 'Hi', nil, 'S').encoding.should == Encoding::US_ASCII
+        Regexp.send(@method, 'Hi', nil, 'SJIS').encoding.should == Encoding::US_ASCII
+      }.should complain(/encoding option is ignored/)
+    end
 
-  it "ignores the third argument if it is 'u' or 'utf8' (case-insensitive)" do
-    -> {
-      Regexp.send(@method, 'Hi', nil, 'u').encoding.should == Encoding::US_ASCII
-      Regexp.send(@method, 'Hi', nil, 'utf8').encoding.should == Encoding::US_ASCII
-      Regexp.send(@method, 'Hi', nil, 'U').encoding.should == Encoding::US_ASCII
-      Regexp.send(@method, 'Hi', nil, 'UTF8').encoding.should == Encoding::US_ASCII
-    }.should complain(/encoding option is ignored/)
-  end
+    it "ignores the third argument if it is 'u' or 'utf8' (case-insensitive)" do
+      -> {
+        Regexp.send(@method, 'Hi', nil, 'u').encoding.should == Encoding::US_ASCII
+        Regexp.send(@method, 'Hi', nil, 'utf8').encoding.should == Encoding::US_ASCII
+        Regexp.send(@method, 'Hi', nil, 'U').encoding.should == Encoding::US_ASCII
+        Regexp.send(@method, 'Hi', nil, 'UTF8').encoding.should == Encoding::US_ASCII
+      }.should complain(/encoding option is ignored/)
+    end
 
-  it "uses US_ASCII encoding if third argument is 'n' or 'none' (case insensitive) and only ascii characters" do
-    Regexp.send(@method, 'Hi', nil, 'n').encoding.should == Encoding::US_ASCII
-    Regexp.send(@method, 'Hi', nil, 'none').encoding.should == Encoding::US_ASCII
-    Regexp.send(@method, 'Hi', nil, 'N').encoding.should == Encoding::US_ASCII
-    Regexp.send(@method, 'Hi', nil, 'NONE').encoding.should == Encoding::US_ASCII
-  end
+    it "uses US_ASCII encoding if third argument is 'n' or 'none' (case insensitive) and only ascii characters" do
+      Regexp.send(@method, 'Hi', nil, 'n').encoding.should == Encoding::US_ASCII
+      Regexp.send(@method, 'Hi', nil, 'none').encoding.should == Encoding::US_ASCII
+      Regexp.send(@method, 'Hi', nil, 'N').encoding.should == Encoding::US_ASCII
+      Regexp.send(@method, 'Hi', nil, 'NONE').encoding.should == Encoding::US_ASCII
+    end
 
-  it "uses ASCII_8BIT encoding if third argument is 'n' or 'none' (case insensitive) and non-ascii characters" do
-    a = "(?:[\x8E\xA1-\xFE])"
-    str = "\A(?:#{a}|x*)\z"
+    it "uses ASCII_8BIT encoding if third argument is 'n' or 'none' (case insensitive) and non-ascii characters" do
+      a = "(?:[\x8E\xA1-\xFE])"
+      str = "\A(?:#{a}|x*)\z"
 
-    Regexp.send(@method, str, nil, 'N').encoding.should == Encoding::BINARY
-    Regexp.send(@method, str, nil, 'n').encoding.should == Encoding::BINARY
-    Regexp.send(@method, str, nil, 'none').encoding.should == Encoding::BINARY
-    Regexp.send(@method, str, nil, 'NONE').encoding.should == Encoding::BINARY
+      Regexp.send(@method, str, nil, 'N').encoding.should == Encoding::BINARY
+      Regexp.send(@method, str, nil, 'n').encoding.should == Encoding::BINARY
+      Regexp.send(@method, str, nil, 'none').encoding.should == Encoding::BINARY
+      Regexp.send(@method, str, nil, 'NONE').encoding.should == Encoding::BINARY
+    end
   end
 
   describe "with escaped characters" do
@@ -598,8 +600,10 @@ describe :regexp_new_regexp, shared: true do
       Regexp.send(@method, /Hi/n).encoding.should == Encoding::US_ASCII
     end
 
-    it "sets the encoding to source String's encoding if the Regexp literal has the 'n' option and the source String is not ASCII only" do
-      Regexp.send(@method, Regexp.new("\\xff", nil, 'n')).encoding.should == Encoding::BINARY
+    ruby_version_is ''...'3.2' do
+      it "sets the encoding to source String's encoding if the Regexp literal has the 'n' option and the source String is not ASCII only" do
+        Regexp.send(@method, Regexp.new("\\xff", nil, 'n')).encoding.should == Encoding::BINARY
+      end
     end
   end
 end

--- a/test/psych/test_yaml.rb
+++ b/test/psych/test_yaml.rb
@@ -34,7 +34,7 @@ class Psych_Unit_Tests < Psych::TestCase
 
     # [ruby-core:34969]
     def test_regexp_with_n
-        assert_cycle(Regexp.new('',0,'n'))
+        assert_cycle(Regexp.new('',Regexp::NOENCODING))
     end
 	#
 	# Tests modified from 00basic.t in Psych.pm

--- a/test/ruby/test_regexp.rb
+++ b/test/ruby/test_regexp.rb
@@ -42,14 +42,14 @@ class TestRegexp < Test::Unit::TestCase
 
   def test_yoshidam_net_20041111_1
     s = "[\xC2\xA0-\xC3\xBE]"
-    r = assert_deprecated_warning(/ignored/) {Regexp.new(s, nil, "u")}
+    r = assert_deprecated_warning(/3\.3/) {Regexp.new(s, nil, "u")}
     assert_match(r, "\xC3\xBE")
   end
 
   def test_yoshidam_net_20041111_2
     assert_raise(RegexpError) do
       s = "[\xFF-\xFF]".force_encoding("utf-8")
-      assert_warning(/ignored/) {Regexp.new(s, nil, "u")}
+      assert_warning(/3\.3/) {Regexp.new(s, nil, "u")}
     end
   end
 
@@ -646,13 +646,37 @@ class TestRegexp < Test::Unit::TestCase
     assert_equal(/foo/, assert_no_warning(/ignored/) {Regexp.new(/foo/)})
     assert_equal(/foo/, assert_no_warning(/ignored/) {Regexp.new(/foo/, timeout: nil)})
 
-    assert_equal(Encoding.find("US-ASCII"), Regexp.new("b..", nil, "n").encoding)
-    assert_equal("bar", "foobarbaz"[Regexp.new("b..", nil, "n")])
-    assert_equal(//n, Regexp.new("", nil, "n"))
+    arg_encoding_none = //n.options # ARG_ENCODING_NONE is implementation defined value
 
-    arg_encoding_none = 32 # ARG_ENCODING_NONE is implementation defined value
-    assert_equal(arg_encoding_none, Regexp.new("", nil, "n").options)
-    assert_equal(arg_encoding_none, Regexp.new("", nil, "N").options)
+    assert_deprecated_warning('') do
+      assert_equal(Encoding.find("US-ASCII"), Regexp.new("b..", Regexp::NOENCODING).encoding)
+      assert_equal("bar", "foobarbaz"[Regexp.new("b..", Regexp::NOENCODING)])
+      assert_equal(//, Regexp.new(""))
+      assert_equal(//, Regexp.new("", timeout: 1))
+      assert_equal(//n, Regexp.new("", Regexp::NOENCODING))
+      assert_equal(//n, Regexp.new("", Regexp::NOENCODING, timeout: 1))
+
+      assert_equal(arg_encoding_none, Regexp.new("", Regexp::NOENCODING).options)
+    end
+
+    assert_deprecated_warning(/3\.3/) do
+      assert_equal(Encoding.find("US-ASCII"), Regexp.new("b..", nil, "n").encoding)
+    end
+    assert_deprecated_warning(/3\.3/) do
+      assert_equal(Encoding.find("US-ASCII"), Regexp.new("b..", nil, "n", timeout: 1).encoding)
+    end
+    assert_deprecated_warning(/3\.3/) do
+      assert_equal("bar", "foobarbaz"[Regexp.new("b..", nil, "n")])
+    end
+    assert_deprecated_warning(/3\.3/) do
+      assert_equal(//n, Regexp.new("", nil, "n"))
+    end
+    assert_deprecated_warning(/3\.3/) do
+      assert_equal(arg_encoding_none, Regexp.new("", nil, "n").options)
+    end
+    assert_deprecated_warning(/3\.3/) do
+      assert_equal(arg_encoding_none, Regexp.new("", nil, "N").options)
+    end
 
     assert_raise(RegexpError) { Regexp.new(")(") }
     assert_raise(RegexpError) { Regexp.new('[\\40000000000') }


### PR DESCRIPTION
Previously, only certain values of the 3rd argument triggered a deprecation warning.

First step for fix for bug #18797.  Support for the 3rd argument will be removed after the release of Ruby 3.2.

Fix minor fallout discovered by the tests.