### PR TITLE
Convert Error to Failure in GC Compaction tests

### DIFF
--- a/test/ruby/test_gc_compact.rb
+++ b/test/ruby/test_gc_compact.rb
@@ -223,7 +223,7 @@ class TestGCCompact < Test::Unit::TestCase
       end
 
       stats = GC.verify_compaction_references(expand_heap: true, toward: :empty)
-      assert_operator(stats.dig(:moved_down, :T_ARRAY), :>=, ARY_COUNT)
+      assert_operator(stats.dig(:moved_down, :T_ARRAY) || 0, :>=, ARY_COUNT)
       assert(arys) # warning: assigned but unused variable - arys
     end;
   end
@@ -245,7 +245,7 @@ class TestGCCompact < Test::Unit::TestCase
       end
 
       stats = GC.verify_compaction_references(expand_heap: true, toward: :empty)
-      assert_operator(stats.dig(:moved_up, :T_ARRAY), :>=, ARY_COUNT)
+      assert_operator(stats.dig(:moved_up, :T_ARRAY) || 0, :>=, ARY_COUNT)
       assert(arys) # warning: assigned but unused variable - arys
     end;
   end
@@ -275,7 +275,7 @@ class TestGCCompact < Test::Unit::TestCase
 
       stats = GC.verify_compaction_references(expand_heap: true, toward: :empty)
 
-      assert_operator(stats[:moved_up][:T_OBJECT], :>=, OBJ_COUNT)
+      assert_operator(stats.dig(:moved_up, :T_OBJECT) || 0, :>=, OBJ_COUNT)
     end;
   end
 


### PR DESCRIPTION
Previously if any of the tests that move objects between size pools failed to move anything, then the call to stats.dig would return `nil` which would then cause assert_operator to error.

This should be a test Failure, rather than an Error so this commit uses a default value of 0 if stats.dig fails to find a key.

Also refactor object movement tests to use stats.dig, rather than :[]