### PR TITLE
addr2line.c: Support DWARF 5

### DIFF
--- a/addr2line.c
+++ b/addr2line.c
@@ -863,6 +863,7 @@ enum {
 typedef struct {
     obj_info_t *obj;
     const char *file;
+    uint8_t current_version;
     const char *current_cu;
     uint64_t current_low_pc;
     const char *debug_line_cu_end;
@@ -1472,7 +1473,7 @@ ranges_include(DebugInfoReader *reader, ranges_t *ptr, uint64_t addr)
         const char *p;
         uint64_t base = ptr->low_pc_set ? ptr->low_pc : reader->current_low_pc;
         bool base_valid = true;
-        if (reader->obj->debug_rnglists.ptr) {
+        if (reader->current_version >= 5) {
             p = reader->obj->debug_rnglists.ptr + ptr->ranges;
             for (;;) {
                 uint8_t rle = read_uint8(&p);
@@ -1583,6 +1584,7 @@ di_read_cu(DebugInfoReader *reader)
     }
     reader->cu_end = reader->p + unit_length;
     version = read_uint16(&reader->p);
+    reader->current_version = version;
     if (version > 5) {
         return -1;
     }

--- a/addr2line.c
+++ b/addr2line.c
@@ -161,10 +161,11 @@ typedef struct obj_info {
     struct dwarf_section debug_ranges;
     struct dwarf_section debug_rnglists;
     struct dwarf_section debug_str;
+    struct dwarf_section debug_line_str;
     struct obj_info *next;
 } obj_info_t;
 
-#define DWARF_SECTION_COUNT 6
+#define DWARF_SECTION_COUNT 7
 
 static struct dwarf_section *
 obj_dwarf_section_at(obj_info_t *obj, int n)
@@ -175,7 +176,8 @@ obj_dwarf_section_at(obj_info_t *obj, int n)
         &obj->debug_line,
         &obj->debug_ranges,
         &obj->debug_rnglists,
-        &obj->debug_str
+        &obj->debug_str,
+        &obj->debug_line_str
     };
     if (n < 0 || DWARF_SECTION_COUNT <= n) {
         abort();
@@ -1208,8 +1210,7 @@ debug_info_reader_read_value(DebugInfoReader *reader, uint64_t form, DebugInfoVa
         reader->p += v->size;
         break;
       case DW_FORM_line_strp:
-        set_uint_value(v, read_uint(reader));
-        /* *p = reader->file + reader->line->sh_offset + ret; */
+        set_cstrp_value(v, reader->obj->debug_line_str.ptr, read_uint(reader));
         break;
       case DW_FORM_ref_sig8:
         set_uint_value(v, read_uint64(&reader->p));
@@ -1847,7 +1848,8 @@ fill_lines(int num_traces, void **traces, int check_debuglink,
                     ".debug_line",
                     ".debug_ranges",
                     ".debug_rnglists",
-                    ".debug_str"
+                    ".debug_str",
+                    ".debug_line_str"
                 };
 
                 for (j=0; j < DWARF_SECTION_COUNT; j++) {
@@ -2104,7 +2106,8 @@ found_mach_header:
                     "__debug_line",
                     "__debug_ranges",
                     "__debug_rnglists",
-                    "__debug_str"
+                    "__debug_str",
+                    "__debug_line_str",
                 };
                 struct LP(segment_command) *scmd = (struct LP(segment_command) *)lcmd;
                 if (strcmp(scmd->segname, "__TEXT") == 0) {


### PR DESCRIPTION
Because the newer GCC generates DWARF 5, vm_dump trace show no source file names and line numbers.

```
$ ruby -e 'Process.kill(:SEGV, $$)'
-e:1: [BUG] Segmentation fault at 0x000003e8001a5f09
...
-- C level backtrace information -------------------------------------------
ruby(0x24a000) [0x5581d4cb9000]
/home/mame/.rbenv/versions/3.1.3/bin/ruby(rb_bug_for_fatal_signal+0xec) [0x5581d4d7efac]
/home/mame/.rbenv/versions/3.1.3/bin/ruby(sigsegv+0x4f) [0x5581d4c0a53f]
```

This change tries to (partially) support DWARF 5 for GCC.

```
$ ./local/bin/ruby -e 'Process.kill(:SEGV, $$)'
-e:1: [BUG] Segmentation fault at 0x000003e8001c229e
ruby 3.2.0dev (2022-12-21T15:52:20Z support-dwarf5 aaf628ce33) [x86_64-linux]
...
-- C level backtrace information -------------------------------------------
/home/mame/work/ruby-build-gcc-12/local/bin/ruby(rb_print_backtrace+0x14) [0x55e18fc6d2df] /home/mame/work/ruby-build-gcc-12/vm_dump.c:770
/home/mame/work/ruby-build-gcc-12/local/bin/ruby(rb_vm_bugreport) /home/mame/work/ruby-build-gcc-12/vm_dump.c:1065
/home/mame/work/ruby-build-gcc-12/local/bin/ruby(rb_bug_for_fatal_signal+0xec) [0x55e482125fec] /home/mame/work/ruby-build-gcc-12/error.c:813
/home/mame/work/ruby-build-gcc-12/local/bin/ruby(sigsegv+0x4f) [0x55e481f5587f] /home/mame/work/ruby-build-gcc-12/signal.c:964
...
```