### PR TITLE
[DOC] encodings.rdoc: universal_newline reacts to \r

### DIFF
--- a/doc/encodings.rdoc
+++ b/doc/encodings.rdoc
@@ -467,12 +467,13 @@ These keyword-value pairs specify encoding options:
     with a carriage-return character (<tt>"\r"</tt>).
   - <tt>:crlf_newline: true</tt>: Replace each line-feed character (<tt>"\n"</tt>)
     with a carriage-return/line-feed string (<tt>"\r\n"</tt>).
-  - <tt>:universal_newline: true</tt>: Replace each carriage-return/line-feed string
+  - <tt>:universal_newline: true</tt>: Replace each carriage-return
+    character (<tt>"\r"</tt>) and each carriage-return/line-feed string
     (<tt>"\r\n"</tt>) with a line-feed character (<tt>"\n"</tt>).
 
   Examples:
 
-    s = "\n \r\n"                              # => "\n \r\n"
-    s.encode('ASCII', cr_newline: true)        # => "\r \r\r"
-    s.encode('ASCII', crlf_newline: true)      # => "\r\n \r\r\n"
-    s.encode('ASCII', universal_newline: true) # => "\n \n"
+    s = "\n \r \r\n"                           # => "\n \r \r\n"
+    s.encode('ASCII', cr_newline: true)        # => "\r \r \r\r"
+    s.encode('ASCII', crlf_newline: true)      # => "\r\n \r \r\r\n"
+    s.encode('ASCII', universal_newline: true) # => "\n \n \n"


### PR DESCRIPTION
It wasn't clear that the mode also translates "\r" to "\n".
<img width="1120" alt="Screenshot 2022-12-21 at 12 38 10 PM" src="https://user-images.githubusercontent.com/6457510/208969033-5bc8492c-3cb9-4511-a2cc-2e1650a07a0d.png">
