### PR TITLE
[DOC] IO#read doesn't always read in binary mode

### DIFF
--- a/io.c
+++ b/io.c
@@ -3679,13 +3679,11 @@ io_write_nonblock(rb_execution_context_t *ec, VALUE io, VALUE str, VALUE ex)
  *  call-seq:
  *    read(maxlen = nil, out_string = nil) -> new_string, out_string, or nil
  *
- *  Reads bytes from the stream, (in binary mode);
- *  the stream must be opened for reading
+ *  Reads bytes from the stream; the stream must be opened for reading
  *  (see {Access Modes}[rdoc-ref:File@Access+Modes]):
  *
- *  - If +maxlen+ is +nil+, reads all bytes.
- *  - Otherwise reads +maxlen+ bytes, if available.
- *  - Otherwise reads all bytes.
+ *  - If +maxlen+ is +nil+, reads all bytes using the stream's data mode.
+ *  - Otherwise reads up to +maxlen+ bytes in binary mode.
  *
  *  Returns a string (either a new string or the given +out_string+)
  *  containing the bytes read.


### PR DESCRIPTION
When `maxlen` is `nil`, it uses the data mode of the stream. For example in the following:

```ruby
File.binwrite("a.txt", "\r\n\r")
p File.open("a.txt", "rt").read    # "\n\n"
p File.open("a.txt", "rt").read(3) # "\r\n\r"
```

Note, this is _not_ specific to Windows.