### PR TITLE
Rewrite Kernel#loop in Ruby

### DIFF
--- a/benchmark/loop_generator.rb
+++ b/benchmark/loop_generator.rb
@@ -1,4 +1,4 @@
-max = 600000
+max = 6000000
 
 if defined? Fiber
   gen = (1..max).each

--- a/kernel.rb
+++ b/kernel.rb
@@ -179,7 +179,7 @@ module Kernel
   #    } #=> :ok
   def loop
     unless Primitive.block_given_p
-      return Primitive.cexpr! 'SIZED_ENUMERATOR(self, 0, 0, rb_f_loop_size)'
+      return enum_for(:loop) { Float::INFINITY }
     end
     while true
       yield

--- a/kernel.rb
+++ b/kernel.rb
@@ -181,11 +181,14 @@ module Kernel
     unless Primitive.block_given_p
       return enum_for(:loop) { Float::INFINITY }
     end
-    while true
-      yield
+
+    begin
+      while true
+        yield
+      end
+    rescue StopIteration => e
+      e.result
     end
-  rescue StopIteration => e
-    e.result
   end
 
   #

--- a/kernel.rb
+++ b/kernel.rb
@@ -150,6 +150,44 @@ module Kernel
 
   module_function
 
+  # call-seq:
+  #    loop { block }
+  #    loop            -> an_enumerator
+  #
+  # Repeatedly executes the block.
+  #
+  # If no block is given, an enumerator is returned instead.
+  #
+  #    loop do
+  #      print "Input: "
+  #      line = gets
+  #      break if !line or line =~ /^q/i
+  #      # ...
+  #    end
+  #
+  # StopIteration raised in the block breaks the loop.  In this case,
+  # loop returns the "result" value stored in the exception.
+  #
+  #    enum = Enumerator.new { |y|
+  #      y << "one"
+  #      y << "two"
+  #      :ok
+  #    }
+  #
+  #    result = loop {
+  #      puts enum.next
+  #    } #=> :ok
+  def loop
+    unless Primitive.block_given_p
+      return Primitive.cexpr! 'SIZED_ENUMERATOR(self, 0, 0, rb_f_loop_size)'
+    end
+    while true
+      yield
+    end
+  rescue StopIteration => e
+    e.result
+  end
+
   #
   #  call-seq:
   #     Float(arg, exception: true)    -> float or nil

--- a/object.c
+++ b/object.c
@@ -3940,12 +3940,6 @@ f_sprintf(int c, const VALUE *v, VALUE _)
     return rb_f_sprintf(c, v);
 }
 
-static VALUE
-rb_f_loop_size(VALUE self, VALUE args, VALUE eobj)
-{
-    return DBL2NUM(HUGE_VAL);
-}
-
 /*
  *  Document-class: Class
  *

--- a/object.c
+++ b/object.c
@@ -3940,6 +3940,12 @@ f_sprintf(int c, const VALUE *v, VALUE _)
     return rb_f_sprintf(c, v);
 }
 
+static VALUE
+rb_f_loop_size(VALUE self, VALUE args, VALUE eobj)
+{
+    return DBL2NUM(HUGE_VAL);
+}
+
 /*
  *  Document-class: Class
  *

--- a/test/ruby/test_settracefunc.rb
+++ b/test/ruby/test_settracefunc.rb
@@ -1668,7 +1668,7 @@ CODE
       Bug10724.new
     }
 
-    assert_equal([:call, :return], evs)
+    assert_equal([:call, :call, :return, :return], evs)
   end
 
   require 'fiber'

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -1440,64 +1440,6 @@ rb_yield_block(RB_BLOCK_CALL_FUNC_ARGLIST(val, arg))
                                rb_keyword_given_p());
 }
 
-static VALUE
-loop_i(VALUE _)
-{
-    for (;;) {
-        rb_yield_0(0, 0);
-    }
-    return Qnil;
-}
-
-static VALUE
-loop_stop(VALUE dummy, VALUE exc)
-{
-    return rb_attr_get(exc, id_result);
-}
-
-static VALUE
-rb_f_loop_size(VALUE self, VALUE args, VALUE eobj)
-{
-    return DBL2NUM(HUGE_VAL);
-}
-
-/*
- *  call-seq:
- *     loop { block }
- *     loop            -> an_enumerator
- *
- *  Repeatedly executes the block.
- *
- *  If no block is given, an enumerator is returned instead.
- *
- *     loop do
- *       print "Input: "
- *       line = gets
- *       break if !line or line =~ /^q/i
- *       # ...
- *     end
- *
- *  StopIteration raised in the block breaks the loop.  In this case,
- *  loop returns the "result" value stored in the exception.
- *
- *     enum = Enumerator.new { |y|
- *       y << "one"
- *       y << "two"
- *       :ok
- *     }
- *
- *     result = loop {
- *       puts enum.next
- *     } #=> :ok
- */
-
-static VALUE
-rb_f_loop(VALUE self)
-{
-    RETURN_SIZED_ENUMERATOR(self, 0, 0, rb_f_loop_size);
-    return rb_rescue2(loop_i, (VALUE)0, loop_stop, (VALUE)0, rb_eStopIteration, (VALUE)0);
-}
-
 #if VMDEBUG
 static const char *
 vm_frametype_name(const rb_control_frame_t *cfp);
@@ -2579,8 +2521,6 @@ Init_vm_eval(void)
 
     rb_define_global_function("catch", rb_f_catch, -1);
     rb_define_global_function("throw", rb_f_throw, -1);
-
-    rb_define_global_function("loop", rb_f_loop, 0);
 
     rb_define_method(rb_cBasicObject, "instance_eval", rb_obj_instance_eval_internal, -1);
     rb_define_method(rb_cBasicObject, "instance_exec", rb_obj_instance_exec_internal, -1);


### PR DESCRIPTION
because Ruby is faster than C ™️

## Interpreter

```
$ benchmark-driver -v --chruby 'before;after' benchmark/loop_generator.rb
before: ruby 3.2.0dev (2022-12-21T15:34:21Z master 398aaed2f0) [arm64-darwin22]
after: ruby 3.2.0dev (2022-12-21T18:57:36Z ruby-loop b860fd41db) [arm64-darwin22]
Calculating -------------------------------------
                         before       after
      loop_generator      0.888       0.943 i/s -       1.000 times in 1.125595s 1.060871s

Comparison:
                   loop_generator
               after:         0.9 i/s
              before:         0.9 i/s - 1.06x  slower
```

## YJIT

```
benchmark-driver -v --chruby 'before::before --yjit-call-threshold=1;after::after --yjit-call-threshold=1' benchmark/loop_generator.rb
before: ruby 3.2.0dev (2022-12-21T15:34:21Z master 398aaed2f0) +YJIT [arm64-darwin22]
after: ruby 3.2.0dev (2022-12-21T18:57:36Z ruby-loop b860fd41db) +YJIT [arm64-darwin22]
Calculating -------------------------------------
                         before       after
      loop_generator      0.962       1.146 i/s -       1.000 times in 1.039119s 0.872700s

Comparison:
                   loop_generator
               after:         1.1 i/s
              before:         1.0 i/s - 1.19x  slower
```