### PR TITLE
Fix small documentation problems

### DIFF
--- a/cont.c
+++ b/cont.c
@@ -1959,7 +1959,7 @@ rb_cont_call(int argc, VALUE *argv, VALUE contval)
  *  the current thread, blocking and non-blocking fibers' behavior is identical.
  *
  *  Ruby doesn't provide a scheduler class: it is expected to be implemented by
- *  the user and correspond to Fiber::SchedulerInterface.
+ *  the user and correspond to Fiber::Scheduler.
  *
  *  There is also Fiber.schedule method, which is expected to immediately perform
  *  the given block in a non-blocking manner. Its actual implementation is up to
@@ -2080,9 +2080,10 @@ storage_access_must_be_from_same_fiber(VALUE self)
 }
 
 /**
- *  call-seq: Fiber.current.storage -> hash (dup)
+ *  call-seq: fiber.storage -> hash (dup)
  *
- *  Returns a copy of the storage hash for the current fiber.
+ *  Returns a copy of the storage hash for the fiber. The method can only be called on the
+ *  Fiber.current.
  */
 static VALUE
 rb_fiber_storage_get(VALUE self)
@@ -2117,16 +2118,17 @@ fiber_storage_validate(VALUE value)
 }
 
 /**
- *  call-seq: Fiber.current.storage = hash
+ *  call-seq: fiber.storage = hash
  *
- *  Sets the storage hash for the current fiber. This feature is experimental
- *  and may change in the future.
+ *  Sets the storage hash for the fiber. This feature is experimental
+ *  and may change in the future. The method can only be called on the
+ *  Fiber.current.
  *
  *  You should be careful about using this method as you may inadvertently clear
  *  important fiber-storage state. You should mostly prefer to assign specific
- *  keys in the storage using Fiber#[]=.
+ *  keys in the storage using Fiber::[]=.
  *
- *  You can also use Fiber.new(storage: nil) to create a fiber with an empty
+ *  You can also use <tt>Fiber.new(storage: nil)</tt> to create a fiber with an empty
  *  storage.
  *
  *  Example:
@@ -2160,7 +2162,7 @@ rb_fiber_storage_set(VALUE self, VALUE value)
  *  The +key+ must be a symbol, and the value is set by Fiber#[]= or
  *  Fiber#store.
  *
- *  See also Fiber[]=.
+ *  See also Fiber::[]=.
  */
 static VALUE
 rb_fiber_storage_aref(VALUE class, VALUE key)
@@ -2183,7 +2185,7 @@ rb_fiber_storage_aref(VALUE class, VALUE key)
  *
  *  +key+ must be a Symbol, otherwise a TypeError is raised.
  *
- *  See also Fiber[].
+ *  See also Fiber::[].
  */
 static VALUE
 rb_fiber_storage_aset(VALUE class, VALUE key, VALUE value)
@@ -2397,7 +2399,7 @@ rb_fiber_s_schedule_kw(int argc, VALUE* argv, int kw_splat)
  *
  *  Note that the behavior described above is how the method is <em>expected</em>
  *  to behave, actual behavior is up to the current scheduler's implementation of
- *  Fiber::SchedulerInterface#fiber method. Ruby doesn't enforce this method to
+ *  Fiber::Scheduler#fiber method. Ruby doesn't enforce this method to
  *  behave in any particular way.
  *
  *  If the scheduler is not set, the method raises
@@ -2416,7 +2418,7 @@ rb_fiber_s_schedule(int argc, VALUE *argv, VALUE obj)
  *
  *  Returns the Fiber scheduler, that was last set for the current thread with Fiber.set_scheduler.
  *  Returns +nil+ if no scheduler is set (which is the default), and non-blocking fibers'
- #  behavior is the same as blocking.
+ *  behavior is the same as blocking.
  *  (see "Non-blocking fibers" section in class docs for details about the scheduler concept).
  *
  */
@@ -2450,7 +2452,7 @@ rb_fiber_current_scheduler(VALUE klass)
  *  thread will call scheduler's +close+ method on finalization (allowing the scheduler to
  *  properly manage all non-finished fibers).
  *
- *  +scheduler+ can be an object of any class corresponding to Fiber::SchedulerInterface. Its
+ *  +scheduler+ can be an object of any class corresponding to Fiber::Scheduler. Its
  *  implementation is up to the user.
  *
  *  See also the "Non-blocking fibers" section in class docs.

--- a/error.c
+++ b/error.c
@@ -3028,12 +3028,16 @@ Init_Exception(void)
     rb_eSyntaxError = rb_define_class("SyntaxError", rb_eScriptError);
     rb_define_method(rb_eSyntaxError, "initialize", syntax_error_initialize, -1);
 
+    /* RDoc will use literal name value while parsing rb_attr,
+    *  and will render `idPath` as an attribute name without this trick */
+    ID path = idPath;
+
     /* the path failed to parse */
-    rb_attr(rb_eSyntaxError, idPath, TRUE, FALSE, FALSE);
+    rb_attr(rb_eSyntaxError, path, TRUE, FALSE, FALSE);
 
     rb_eLoadError   = rb_define_class("LoadError", rb_eScriptError);
     /* the path failed to load */
-    rb_attr(rb_eLoadError, idPath, TRUE, FALSE, FALSE);
+    rb_attr(rb_eLoadError, path, TRUE, FALSE, FALSE);
 
     rb_eNotImpError = rb_define_class("NotImplementedError", rb_eScriptError);
 

--- a/gc.rb
+++ b/gc.rb
@@ -218,7 +218,7 @@ module GC
     Primitive.gc_stat_heap heap_name, hash_or_key
   end
 
-  #  call-seq:
+  # call-seq:
   #     GC.latest_gc_info -> hash
   #     GC.latest_gc_info(hash) -> hash
   #     GC.latest_gc_info(:major_by) -> :malloc

--- a/io.c
+++ b/io.c
@@ -14777,6 +14777,8 @@ set_LAST_READ_LINE(VALUE val, ID _x, VALUE *_y)
  *  - +:binmode+: If a truthy value, specifies the mode as binary, text-only otherwise.
  *  - +:autoclose+: If a truthy value, specifies that the +fd+ will close
  *    when the stream closes; otherwise it remains open.
+ *  - +:path:+ If a string value is provided, it is used in #inspect and is available as
+ *    #path method.
  *
  *  Also available are the options offered in String#encode,
  *  which may control conversion between external internal encoding.

--- a/proc.c
+++ b/proc.c
@@ -1842,6 +1842,22 @@ method_eq(VALUE method, VALUE other)
 
 /*
  * call-seq:
+ *   meth.eql?(other_meth)  -> true or false
+ *   meth == other_meth  -> true or false
+ *
+ * Two unbound method objects are equal if they refer to the same
+ * method definition.
+ *
+ *    Array.instance_method(:each_slice) == Enumerable.instance_method(:each_slice)
+ *    #=> true
+ *
+ *    Array.instance_method(:sum) == Enumerable.instance_method(:sum)
+ *    #=> false, Array redefines the method for efficiency
+ */
+#define unbound_method_eq method_eq
+
+/*
+ * call-seq:
  *    meth.hash   -> integer
  *
  * Returns a hash value corresponding to the method object.
@@ -4334,8 +4350,8 @@ Init_Proc(void)
     rb_cUnboundMethod = rb_define_class("UnboundMethod", rb_cObject);
     rb_undef_alloc_func(rb_cUnboundMethod);
     rb_undef_method(CLASS_OF(rb_cUnboundMethod), "new");
-    rb_define_method(rb_cUnboundMethod, "==", method_eq, 1);
-    rb_define_method(rb_cUnboundMethod, "eql?", method_eq, 1);
+    rb_define_method(rb_cUnboundMethod, "==", unbound_method_eq, 1);
+    rb_define_method(rb_cUnboundMethod, "eql?", unbound_method_eq, 1);
     rb_define_method(rb_cUnboundMethod, "hash", method_hash, 0);
     rb_define_method(rb_cUnboundMethod, "clone", method_clone, 0);
     rb_define_method(rb_cUnboundMethod, "arity", method_arity_m, 0);


### PR DESCRIPTION
Fix part of the problems described in [#19247](https://bugs.ruby-lang.org/issues/19247):
* rendering of `SyntaxError#path` (and `LoadError#path`);
* Update `Struct` docs about keyword initialization
* ~~Add list of keys to `Time#deconstruct_keys`~~ fixed by @k-tsj https://github.com/ruby/ruby/commit/b7bb14b96e7e1923d91787fa5a9ca2e4053431b1
* Separate documentation for `UnboundMethod#==` from `Method#==` (behavior is different)
* Fix small glitch in GC docs (wrong rendering of mid-doc indent)
* `path:` option for `IO.new`
* Fix problems with `Fiber`'s docs
    * References to `Scheduler` (was outdated to `SchedulerInterface`)
    * References between new methods (`storage`, `[]`, `[]=`)
    * `storage` call-sequence (rendered confusingly)