### PR TITLE
Windows: Fix encoding of Dir.home

### DIFF
--- a/spec/ruby/core/dir/home_spec.rb
+++ b/spec/ruby/core/dir/home_spec.rb
@@ -19,6 +19,17 @@ describe "Dir.home" do
     it "returns a non-frozen string" do
       Dir.home.should_not.frozen?
     end
+
+    platform_is :windows do
+      ruby_version_is "3.0" do
+        it "returns the home directory with forward slashs and as UTF-8" do
+          ENV['HOME'] = "C:\\rubyspäc\\home"
+          home = Dir.home
+          home.should == "C:/rubyspäc/home"
+          home.encoding.should == Encoding::UTF_8
+        end
+      end
+    end
   end
 
   describe "when called with the current user name" do

--- a/win32/file.c
+++ b/win32/file.c
@@ -266,7 +266,8 @@ rb_default_home_dir(VALUE result)
         rb_raise(rb_eArgError, "couldn't find HOME environment -- expanding `~'");
     }
     append_wstr(result, dir, -1,
-                       rb_w32_filecp(), rb_filesystem_encoding());
+                       CP_UTF8, rb_utf8_encoding());
+
     xfree(dir);
     return result;
 }


### PR DESCRIPTION
`Dir.home` returns an UTF-8 string since ruby-3.0, but the actual encoding of the bytes was `CP_ACP` or `CP_OEMCP`. That led to invalid bytes when calling `Dir.home` with an Unicode username.

Splitted out of #6958. Fixes https://bugs.ruby-lang.org/issues/19243

This should be backported to ruby-3.[01].