### PR TITLE
Windows: Prefer USERPROFILE over HOMEPATH

### DIFF
--- a/spec/ruby/core/dir/home_spec.rb
+++ b/spec/ruby/core/dir/home_spec.rb
@@ -21,6 +21,23 @@ describe "Dir.home" do
     end
   end
 
+  platform_is :windows do
+    it "retrieves the directory from HOME, USERPROFILE, HOMEDRIVE/HOMEPATH and the WinAPI in that order" do
+      old_dirs = [ENV.delete('HOME'), ENV.delete('USERPROFILE'), ENV.delete('HOMEDRIVE'), ENV.delete('HOMEPATH')]
+
+      Dir.home.should == old_dirs[1].gsub("\\", "/")
+      ENV['HOMEDRIVE'] = "C:"
+      ENV['HOMEPATH'] = "\\rubyspec\\home1"
+      Dir.home.should == "C:/rubyspec/home1"
+      ENV['USERPROFILE'] = "C:\\rubyspec\\home2"
+      Dir.home.should == "C:/rubyspec/home2"
+      ENV['HOME'] = "C:\\rubyspec\\home3"
+      Dir.home.should == "C:/rubyspec/home3"
+    ensure
+      ENV['HOME'], ENV['USERPROFILE'], ENV['HOMEDRIVE'], ENV['HOMEPATH'] = *old_dirs
+    end
+  end
+
   describe "when called with the current user name" do
     platform_is :solaris do
       it "returns the named user's home directory from the user database" do

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -544,7 +544,7 @@ rb_w32_system_tmpdir(WCHAR *path, UINT len)
   afterwards with xfree.
 
   Try:
-  HOME, HOMEDRIVE + HOMEPATH and USERPROFILE environment variables
+  HOME, USERPROFILE, HOMEDRIVE + HOMEPATH environment variables
   Special Folders - Profile and Personal
 */
 WCHAR *
@@ -553,12 +553,16 @@ rb_w32_home_dir(void)
     WCHAR *buffer = NULL;
     size_t buffer_len = MAX_PATH, len = 0;
     enum {
-        HOME_NONE, ENV_HOME, ENV_DRIVEPATH, ENV_USERPROFILE
+        HOME_NONE, ENV_HOME, ENV_USERPROFILE, ENV_DRIVEPATH
     } home_type = HOME_NONE;
 
     if ((len = GetEnvironmentVariableW(L"HOME", NULL, 0)) != 0) {
         buffer_len = len;
         home_type = ENV_HOME;
+    }
+    else if ((len = GetEnvironmentVariableW(L"USERPROFILE", NULL, 0)) != 0) {
+        buffer_len = len;
+        home_type = ENV_USERPROFILE;
     }
     else if ((len = GetEnvironmentVariableW(L"HOMEDRIVE", NULL, 0)) != 0) {
         buffer_len = len;
@@ -566,10 +570,6 @@ rb_w32_home_dir(void)
             buffer_len += len;
             home_type = ENV_DRIVEPATH;
         }
-    }
-    else if ((len = GetEnvironmentVariableW(L"USERPROFILE", NULL, 0)) != 0) {
-        buffer_len = len;
-        home_type = ENV_USERPROFILE;
     }
 
     /* allocate buffer */
@@ -579,12 +579,12 @@ rb_w32_home_dir(void)
       case ENV_HOME:
         GetEnvironmentVariableW(L"HOME", buffer, buffer_len);
         break;
+      case ENV_USERPROFILE:
+        GetEnvironmentVariableW(L"USERPROFILE", buffer, buffer_len);
+        break;
       case ENV_DRIVEPATH:
         len = GetEnvironmentVariableW(L"HOMEDRIVE", buffer, buffer_len);
         GetEnvironmentVariableW(L"HOMEPATH", buffer + len, buffer_len - len);
-        break;
-      case ENV_USERPROFILE:
-        GetEnvironmentVariableW(L"USERPROFILE", buffer, buffer_len);
         break;
       default:
         if (!get_special_folder(CSIDL_PROFILE, buffer, buffer_len) &&


### PR DESCRIPTION
`HOMEPATH` is set to `\WINDOWS\system32` when running per `runas` session. This directory is not writable by ordinary users, leading to errors with many ruby tools. Also config files in the home directory are not recognized.

Still keeping `HOME` at first, which is not used by native Windows, but by ruby specs and by MSYS2 environment.

This might be backported.

Splitted out of #6958. Fixes https://bugs.ruby-lang.org/issues/19244
