### PR TITLE
Support clang's DWARF

### DIFF
--- a/addr2line.c
+++ b/addr2line.c
@@ -159,13 +159,15 @@ typedef struct obj_info {
     struct dwarf_section debug_info;
     struct dwarf_section debug_line;
     struct dwarf_section debug_ranges;
+    struct dwarf_section debug_str_offsets;
+    struct dwarf_section debug_addr;
     struct dwarf_section debug_rnglists;
     struct dwarf_section debug_str;
     struct dwarf_section debug_line_str;
     struct obj_info *next;
 } obj_info_t;
 
-#define DWARF_SECTION_COUNT 7
+#define DWARF_SECTION_COUNT 9
 
 static struct dwarf_section *
 obj_dwarf_section_at(obj_info_t *obj, int n)
@@ -175,6 +177,8 @@ obj_dwarf_section_at(obj_info_t *obj, int n)
         &obj->debug_info,
         &obj->debug_line,
         &obj->debug_ranges,
+        &obj->debug_str_offsets,
+        &obj->debug_addr,
         &obj->debug_rnglists,
         &obj->debug_str,
         &obj->debug_line_str
@@ -1928,6 +1932,8 @@ fill_lines(int num_traces, void **traces, int check_debuglink,
                     ".debug_info",
                     ".debug_line",
                     ".debug_ranges",
+                    ".debug_str_offsets",
+                    ".debug_addr",
                     ".debug_rnglists",
                     ".debug_str",
                     ".debug_line_str"
@@ -2186,6 +2192,8 @@ found_mach_header:
                     "__debug_info",
                     "__debug_line",
                     "__debug_ranges",
+                    "__debug_str_offsets",
+                    "__debug_addr",
                     "__debug_rnglists",
                     "__debug_str",
                     "__debug_line_str",

--- a/addr2line.c
+++ b/addr2line.c
@@ -1124,6 +1124,20 @@ get_cstr_value(DebugInfoValue *v)
     }
 }
 
+static const char *
+resolve_strx(DebugInfoReader *reader, uint64_t idx)
+{
+    const char *p = reader->obj->debug_str_offsets.ptr + reader->current_str_offsets_base;
+    uint64_t off;
+    if (reader->format == 4) {
+        off = ((uint32_t *)p)[idx];
+    }
+    else {
+        off = ((uint64_t *)p)[idx];
+    }
+    return reader->obj->debug_str.ptr + off;
+}
+
 static void
 debug_info_reader_read_value(DebugInfoReader *reader, uint64_t form, DebugInfoValue *v)
 {
@@ -1236,7 +1250,7 @@ debug_info_reader_read_value(DebugInfoReader *reader, uint64_t form, DebugInfoVa
         set_uint_value(v, 1);
         break;
       case DW_FORM_strx:
-        set_uint_value(v, uleb128(&reader->p));
+        set_cstr_value(v, resolve_strx(reader, uleb128(&reader->p)));
         break;
       case DW_FORM_addrx:
         set_addr_idx_value(v, uleb128(&reader->p));
@@ -1272,16 +1286,16 @@ debug_info_reader_read_value(DebugInfoReader *reader, uint64_t form, DebugInfoVa
         set_uint_value(v, read_uint64(&reader->p));
         break;
       case DW_FORM_strx1:
-        set_uint_value(v, read_uint8(&reader->p));
+        set_cstr_value(v, resolve_strx(reader, read_uint8(&reader->p)));
         break;
       case DW_FORM_strx2:
-        set_uint_value(v, read_uint16(&reader->p));
+        set_cstr_value(v, resolve_strx(reader, read_uint16(&reader->p)));
         break;
       case DW_FORM_strx3:
-        set_uint_value(v, read_uint24(&reader->p));
+        set_cstr_value(v, resolve_strx(reader, read_uint24(&reader->p)));
         break;
       case DW_FORM_strx4:
-        set_uint_value(v, read_uint32(&reader->p));
+        set_cstr_value(v, resolve_strx(reader, read_uint32(&reader->p)));
         break;
       case DW_FORM_addrx1:
         set_addr_idx_value(v, read_uint8(&reader->p));


### PR DESCRIPTION
```
$ ./miniruby -e 'Process.kill(:SEGV, $$)'
-e:1: [BUG] Segmentation fault at 0x000003e80000fa2d
ruby 3.2.0dev (2022-12-22T11:37:40Z support-clang-dwarf d1d61cabbc) [x86_64-linux]

...

-- C level backtrace information -------------------------------------------
/home/mame/work/ruby-build-clang-15/miniruby(rb_print_backtrace+0x14) [0x562b9062c4f5] /home/mame/work/ruby-build-clang-15/../ruby/vm_dump.c:770
/home/mame/work/ruby-build-clang-15/miniruby(rb_vm_bugreport) /home/mame/work/ruby-build-clang-15/../ruby/vm_dump.c:1065
/home/mame/work/ruby-build-clang-15/miniruby(bug_report_end+0x0) [0x562b9045ee0d] /home/mame/work/ruby-build-clang-15/../ruby/error.c:813
/home/mame/work/ruby-build-clang-15/miniruby(rb_bug_for_fatal_signal) /home/mame/work/ruby-build-clang-15/../ruby/error.c:813
/home/mame/work/ruby-build-clang-15/miniruby(sigsegv+0x51) [0x562b9058d521] /home/mame/work/ruby-build-clang-15/../ruby/signal.c:964
/lib/x86_64-linux-gnu/libc.so.6(0x7fd9f8e3bcf0) [0x7fd9f8e3bcf0]
/lib/x86_64-linux-gnu/libc.so.6(__GI_kill+0xb) [0x7fd9f8e3bf2b] ../sysdeps/unix/syscall-template.S:120
/lib/x86_64-linux-gnu/libc.so.6(kill) (null):0
/lib/x86_64-linux-gnu/libc.so.6(__GI___kill) (null):0
/lib/x86_64-linux-gnu/libc.so.6(__kill) (null):0
/lib/x86_64-linux-gnu/libc.so.6(kill) (null):0
/home/mame/work/ruby-build-clang-15/miniruby(rb_f_kill+0x1cb) [0x562b9058b7fb] /home/mame/work/ruby-build-clang-15/../ruby/signal.c:481
/home/mame/work/ruby-build-clang-15/miniruby(vm_call_cfunc_with_frame+0x11e) [0x562b90620d9e] ../ruby/vm_insnhelper.c:3252
/home/mame/work/ruby-build-clang-15/miniruby(vm_call_cfunc+0x2e) [0x562b9061b177] ../ruby/vm_insnhelper.c:3273
/home/mame/work/ruby-build-clang-15/miniruby(vm_call_method_each_type) ../ruby/vm_insnhelper.c:3904
./miniruby(vm_call_method+0x16b) [0x562b9061aebb]
/home/mame/work/ruby-build-clang-15/miniruby(vm_sendish+0x510) [0x562b90623410] ../ruby/vm_insnhelper.c:5064
/home/mame/work/ruby-build-clang-15/miniruby(vm_exec_core+0x2923) [0x562b90604453] ../ruby/insns.def:820
./miniruby(rb_vm_exec+0x938) [0x562b90616ee8]
/home/mame/work/ruby-build-clang-15/miniruby(rb_ec_exec_node+0x139) [0x562b9046b1a9] /home/mame/work/ruby-build-clang-15/../ruby/eval.c:289
/home/mame/work/ruby-build-clang-15/miniruby(ruby_run_node+0x5b) [0x562b9046b01b] /home/mame/work/ruby-build-clang-15/../ruby/eval.c:330
/home/mame/work/ruby-build-clang-15/miniruby(rb_main+0x1c) [0x562b903c5be5] /home/mame/work/ruby-build-clang-15/../ruby/main.c:38
/home/mame/work/ruby-build-clang-15/miniruby(main) /home/mame/work/ruby-build-clang-15/../ruby/main.c:57
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_call_main+0x80) [0x7fd9f8e23510] ../sysdeps/nptl/libc_start_call_main.h:58
/lib/x86_64-linux-gnu/libc.so.6(call_init+0x0) [0x7fd9f8e235c9] ../csu/libc-start.c:381
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main_impl) ../csu/libc-start.c:368
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main) (null):0
[0x562b903c5aa5]
```