### PR TITLE
Skip reviews for cruby_bindings-only PRs [ci skip]

### DIFF
--- a/.github/auto_request_review.yml
+++ b/.github/auto_request_review.yml
@@ -1,9 +1,11 @@
 files:
   'yjit*': [team:yjit]
   'yjit/**/*': [team:yjit]
+  'yjit/src/cruby_bindings.inc.rs': []
   'doc/yjit/*': [team:yjit]
   'bootstraptest/test_yjit*': [team:yjit]
   'test/ruby/test_yjit*': [team:yjit]
   '.github/workflows/yjit*': [team:yjit]
 options:
   ignore_draft: true
+  last_files_match_only: true


### PR DESCRIPTION
YJIT team was asked to review https://github.com/ruby/ruby/pull/6851 because `yjit/src/cruby_bindings.inc.rs` is modified. However, it only added a new constant `BOP_CMP` that's not used by YJIT. Given that it's an auto-generated code, it doesn't seem necessary to trigger YJIT team reviews when it's `yjit/src/cruby_bindings.inc.rs`-only changes.