### PR TITLE
MJIT: Export fewer shape functions

### DIFF
--- a/shape.h
+++ b/shape.h
@@ -136,19 +136,19 @@ rb_shape_t * rb_shape_get_parent(rb_shape_t * shape);
 
 MJIT_SYMBOL_EXPORT_BEGIN
 rb_shape_t* rb_shape_get_shape_by_id(shape_id_t shape_id);
-void rb_shape_set_shape(VALUE obj, rb_shape_t* shape);
 shape_id_t rb_shape_get_shape_id(VALUE obj);
+rb_shape_t * rb_shape_get_next_iv_shape(rb_shape_t * shape, ID id);
+bool rb_shape_get_iv_index(rb_shape_t * shape, ID id, attr_index_t * value);
+bool rb_shape_obj_too_complex(VALUE obj);
+MJIT_SYMBOL_EXPORT_END
+
+void rb_shape_set_shape(VALUE obj, rb_shape_t* shape);
 rb_shape_t* rb_shape_get_shape(VALUE obj);
 int rb_shape_frozen_shape_p(rb_shape_t* shape);
 void rb_shape_transition_shape_frozen(VALUE obj);
 void rb_shape_transition_shape_remove_ivar(VALUE obj, ID id, rb_shape_t *shape, VALUE * removed);
 rb_shape_t * rb_shape_transition_shape_capa(rb_shape_t * shape, uint32_t new_capacity);
-rb_shape_t * rb_shape_get_next_iv_shape(rb_shape_t * shape, ID id);
 rb_shape_t* rb_shape_get_next(rb_shape_t* shape, VALUE obj, ID id);
-bool rb_shape_get_iv_index(rb_shape_t * shape, ID id, attr_index_t * value);
-shape_id_t rb_shape_id(rb_shape_t * shape);
-bool rb_shape_obj_too_complex(VALUE obj);
-MJIT_SYMBOL_EXPORT_END
 
 rb_shape_t * rb_shape_rebuild_shape(rb_shape_t * initial_shape, rb_shape_t * dest_shape);
 
@@ -219,12 +219,14 @@ VALUE rb_obj_debug_shape(VALUE self, VALUE obj);
 VALUE rb_shape_flags_mask(void);
 void rb_shape_set_too_complex(VALUE obj);
 
+// For ext/objspace
 RUBY_SYMBOL_EXPORT_BEGIN
 typedef void each_shape_callback(rb_shape_t * shape, void *data);
 void rb_shape_each_shape(each_shape_callback callback, void *data);
 size_t rb_shape_memsize(rb_shape_t *shape);
 size_t rb_shape_edges_count(rb_shape_t *shape);
 size_t rb_shape_depth(rb_shape_t *shape);
+shape_id_t rb_shape_id(rb_shape_t * shape);
 RUBY_SYMBOL_EXPORT_END
 
 #endif

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -1111,14 +1111,14 @@ extern "C" {
     pub fn rb_shape_id_offset() -> i32;
     pub fn rb_shape_get_shape_by_id(shape_id: shape_id_t) -> *mut rb_shape_t;
     pub fn rb_shape_get_shape_id(obj: VALUE) -> shape_id_t;
+    pub fn rb_shape_get_iv_index(shape: *mut rb_shape_t, id: ID, value: *mut attr_index_t) -> bool;
+    pub fn rb_shape_obj_too_complex(obj: VALUE) -> bool;
     pub fn rb_shape_transition_shape_capa(
         shape: *mut rb_shape_t,
         new_capacity: u32,
     ) -> *mut rb_shape_t;
     pub fn rb_shape_get_next(shape: *mut rb_shape_t, obj: VALUE, id: ID) -> *mut rb_shape_t;
-    pub fn rb_shape_get_iv_index(shape: *mut rb_shape_t, id: ID, value: *mut attr_index_t) -> bool;
     pub fn rb_shape_id(shape: *mut rb_shape_t) -> shape_id_t;
-    pub fn rb_shape_obj_too_complex(obj: VALUE) -> bool;
     pub fn rb_ary_tmp_new_from_values(
         arg1: VALUE,
         arg2: ::std::os::raw::c_long,


### PR DESCRIPTION
I tested not exporting some of the shape-related functions, and I was able to stop exporting some of them while still passing test_mjit. If --mjit-wait CI passes as well, I think it's safe to remove them.