### PR TITLE
[DOC] Document new methods of IO::Buffer and Fiber::Scheduler

### DIFF
--- a/io_buffer.c
+++ b/io_buffer.c
@@ -2639,10 +2639,10 @@ rb_io_buffer_write(VALUE self, VALUE io, size_t length, size_t offset)
  *  If +offset+ is not given, the bytes are taken from the beginning
  *  of the buffer.
  *
- *    out = File.open('buf.txt', 'wb')
+ *    out = File.open('output.txt', 'wb')
  *    IO::Buffer.for('1234567').write(out, 3)
  *
- *  This leads to +123+ being written into <tt>buf.txt</tt>
+ *  This leads to +123+ being written into <tt>output.txt</tt>
  */
 static VALUE
 io_buffer_write(int argc, VALUE *argv, VALUE self)
@@ -2746,11 +2746,11 @@ rb_io_buffer_pwrite(VALUE self, VALUE io, rb_off_t from, size_t length, size_t o
  *  If +offset+ is not given, the bytes are taken from the beginning
  *  of the buffer.
  *
- *    out = File.open('buf.txt', File::RDWR) # open for read/write, no truncation
+ *    out = File.open('output.txt', File::RDWR) # open for read/write, no truncation
  *    IO::Buffer.for('1234567').pwrite(out, 2, 3, 1)
  *
  *  This leads to +234+ (3 bytes, starting from position 1) being written into
- *  <tt>buf.txt</tt>, starting from file position 2.
+ *  <tt>output.txt</tt>, starting from file position 2.
  */
 static VALUE
 io_buffer_pwrite(int argc, VALUE *argv, VALUE self)

--- a/io_buffer.c
+++ b/io_buffer.c
@@ -2413,7 +2413,7 @@ rb_io_buffer_read(VALUE self, VALUE io, size_t length, size_t offset)
 }
 
 /*
- *  call-seq: read(io, [length, [offset]]) -> self
+ *  call-seq: read(io, [length, [offset]]) -> numbytes
  *
  *  Read at most +length+ bytes from +io+ into the buffer, starting at
  *  +offset+.
@@ -2426,14 +2426,17 @@ rb_io_buffer_read(VALUE self, VALUE io, size_t length, size_t offset)
  *
  *  Example:
  *
- *    buffer = IO::Buffer.for('test')
- *    # =>
- *    # <IO::Buffer 0x00007fca40087c38+4 SLICE>
- *    # 0x00000000  74 65 73 74         test
- *    buffer.read(File.open('/dev/urandom', 'rb'), 4)
- *    # =>
- *    # <IO::Buffer 0x00007fca40087c38+4 SLICE>
- *    # 0x00000000  2a 0e 0e 0e         *...
+ *    IO::Buffer.for('test') do |buffer|
+ *      p buffer
+ *      # =>
+ *      # <IO::Buffer 0x00007fca40087c38+4 SLICE>
+ *      # 0x00000000  74 65 73 74         test
+ *      buffer.read(File.open('/dev/urandom', 'rb'), 2)
+ *      p buffer
+ *      # =>
+ *      # <IO::Buffer 0x00007f3bc65f2a58+4 EXTERNAL SLICE>
+ *      # 0x00000000  05 35 73 74         .5st
+ *    end
  */
 static VALUE
 io_buffer_read(int argc, VALUE *argv, VALUE self)
@@ -2528,6 +2531,31 @@ rb_io_buffer_pread(VALUE self, VALUE io, rb_off_t from, size_t length, size_t of
     return rb_thread_io_blocking_region(io_buffer_pread_internal, &argument, descriptor);
 }
 
+/*
+ *  call-seq: pread(io, from, length, [offset]) -> numbytes
+ *
+ *  Read at most +length+ bytes from +io+ into the buffer, starting at
+ *  +from+, and put it in buffer starting from specified +offset+.
+ *
+ *  If +offset+ is not given, put it at the beginning of the buffer.
+ *
+ *  Example:
+ *
+ *    IO::Buffer.for('test') do |buffer|
+ *      p buffer
+ *      # =>
+ *      # <IO::Buffer 0x00007fca40087c38+4 SLICE>
+ *      # 0x00000000  74 65 73 74         test
+ *
+ *      # take 2 bytes from the beginning of urandom,
+ *      # put them in buffer starting from possition 2
+ *      buffer.pread(File.open('/dev/urandom', 'rb'), 0, 2, 2)
+ *      p buffer
+ *      # =>
+ *      # <IO::Buffer 0x00007f3bc65f2a58+4 EXTERNAL SLICE>
+ *      # 0x00000000  05 35 73 74         te.5
+ *    end
+ */
 static VALUE
 io_buffer_pread(int argc, VALUE *argv, VALUE self)
 {
@@ -2602,6 +2630,20 @@ rb_io_buffer_write(VALUE self, VALUE io, size_t length, size_t offset)
     return rb_thread_io_blocking_region(io_buffer_write_internal, &argument, descriptor);
 }
 
+/*
+ *  call-seq: write(io, length, [offset]) -> numbytes
+ *
+ *  Writes +length+ bytes from buffer into +io+, starting at
+ *  +offset+ in the buffer.
+ *
+ *  If +offset+ is not given, the bytes are taken from the beginning
+ *  of the buffer.
+ *
+ *    out = File.open('buf.txt', 'wb')
+ *    IO::Buffer.for('1234567').write(out, 3)
+ *
+ *  This leads to +123+ being written into <tt>buf.txt</tt>
+ */
 static VALUE
 io_buffer_write(int argc, VALUE *argv, VALUE self)
 {
@@ -2695,6 +2737,21 @@ rb_io_buffer_pwrite(VALUE self, VALUE io, rb_off_t from, size_t length, size_t o
     return rb_thread_io_blocking_region(io_buffer_pwrite_internal, &argument, descriptor);
 }
 
+/*
+ *  call-seq: pwrite(io, from, length, [offset]) -> numbytes
+ *
+ *  Writes +length+ bytes from buffer into +io+, starting at
+ *  +offset+ in the buffer.
+ *
+ *  If +offset+ is not given, the bytes are taken from the beginning
+ *  of the buffer.
+ *
+ *    out = File.open('buf.txt', File::RDWR) # open for read/write, no truncation
+ *    IO::Buffer.for('1234567').pwrite(out, 2, 3, 1)
+ *
+ *  This leads to +234+ (3 bytes, starting from position 1) being written into
+ *  <tt>buf.txt</tt>, starting from file position 2.
+ */
 static VALUE
 io_buffer_pwrite(int argc, VALUE *argv, VALUE self)
 {

--- a/io_buffer.c
+++ b/io_buffer.c
@@ -2548,7 +2548,7 @@ rb_io_buffer_pread(VALUE self, VALUE io, rb_off_t from, size_t length, size_t of
  *      # 0x00000000  74 65 73 74         test
  *
  *      # take 2 bytes from the beginning of urandom,
- *      # put them in buffer starting from possition 2
+ *      # put them in buffer starting from position 2
  *      buffer.pread(File.open('/dev/urandom', 'rb'), 0, 2, 2)
  *      p buffer
  *      # =>

--- a/io_buffer.c
+++ b/io_buffer.c
@@ -2416,7 +2416,7 @@ rb_io_buffer_read(VALUE self, VALUE io, size_t length, size_t offset)
  *  call-seq: read(io, [length, [offset]]) -> read length or -errno
  *
  *  Read at most +length+ bytes from +io+ into the buffer, starting at
- *  +offset+.
+ *  +offset+. If an error occurs, return <tt>-errno</tt>.
  *
  *  If +length+ is not given, read until the end of the buffer.
  *
@@ -2536,6 +2536,7 @@ rb_io_buffer_pread(VALUE self, VALUE io, rb_off_t from, size_t length, size_t of
  *
  *  Read at most +length+ bytes from +io+ into the buffer, starting at
  *  +from+, and put it in buffer starting from specified +offset+.
+ *  If an error occurs, return <tt>-errno</tt>.
  *
  *  If +offset+ is not given, put it at the beginning of the buffer.
  *
@@ -2634,7 +2635,7 @@ rb_io_buffer_write(VALUE self, VALUE io, size_t length, size_t offset)
  *  call-seq: write(io, length, [offset]) -> written length or -errno
  *
  *  Writes +length+ bytes from buffer into +io+, starting at
- *  +offset+ in the buffer.
+ *  +offset+ in the buffer. If an error occurs, return <tt>-errno</tt>.
  *
  *  If +offset+ is not given, the bytes are taken from the beginning
  *  of the buffer.
@@ -2741,10 +2742,11 @@ rb_io_buffer_pwrite(VALUE self, VALUE io, rb_off_t from, size_t length, size_t o
  *  call-seq: pwrite(io, from, length, [offset]) -> written length or -errno
  *
  *  Writes +length+ bytes from buffer into +io+, starting at
- *  +offset+ in the buffer.
+ *  +offset+ in the buffer. If an error occurs, return <tt>-errno</tt>.
  *
- *  If +offset+ is not given, the bytes are taken from the beginning
- *  of the buffer.
+ *  If +offset+ is not given, the bytes are taken from the beginning of the
+ *  buffer. If the +offset+ is given and is beyond the end of the file, the
+ *  gap will be filled with null (0 value) bytes.
  *
  *    out = File.open('output.txt', File::RDWR) # open for read/write, no truncation
  *    IO::Buffer.for('1234567').pwrite(out, 2, 3, 1)

--- a/io_buffer.c
+++ b/io_buffer.c
@@ -2413,7 +2413,7 @@ rb_io_buffer_read(VALUE self, VALUE io, size_t length, size_t offset)
 }
 
 /*
- *  call-seq: read(io, [length, [offset]]) -> numbytes
+ *  call-seq: read(io, [length, [offset]]) -> read length or -errno
  *
  *  Read at most +length+ bytes from +io+ into the buffer, starting at
  *  +offset+.
@@ -2532,7 +2532,7 @@ rb_io_buffer_pread(VALUE self, VALUE io, rb_off_t from, size_t length, size_t of
 }
 
 /*
- *  call-seq: pread(io, from, length, [offset]) -> numbytes
+ *  call-seq: pread(io, from, length, [offset]) -> read length or -errno
  *
  *  Read at most +length+ bytes from +io+ into the buffer, starting at
  *  +from+, and put it in buffer starting from specified +offset+.
@@ -2631,7 +2631,7 @@ rb_io_buffer_write(VALUE self, VALUE io, size_t length, size_t offset)
 }
 
 /*
- *  call-seq: write(io, length, [offset]) -> numbytes
+ *  call-seq: write(io, length, [offset]) -> written length or -errno
  *
  *  Writes +length+ bytes from buffer into +io+, starting at
  *  +offset+ in the buffer.
@@ -2738,7 +2738,7 @@ rb_io_buffer_pwrite(VALUE self, VALUE io, rb_off_t from, size_t length, size_t o
 }
 
 /*
- *  call-seq: pwrite(io, from, length, [offset]) -> numbytes
+ *  call-seq: pwrite(io, from, length, [offset]) -> written length or -errno
  *
  *  Writes +length+ bytes from buffer into +io+, starting at
  *  +offset+ in the buffer.

--- a/scheduler.c
+++ b/scheduler.c
@@ -118,6 +118,9 @@ Init_Fiber_Scheduler(void)
     rb_define_method(rb_cFiberScheduler, "io_wait", rb_fiber_scheduler_io_wait, 3);
     rb_define_method(rb_cFiberScheduler, "io_read", rb_fiber_scheduler_io_read, 4);
     rb_define_method(rb_cFiberScheduler, "io_write", rb_fiber_scheduler_io_write, 4);
+    rb_define_method(rb_cFiberScheduler, "io_pread", rb_fiber_scheduler_io_pread, 5);
+    rb_define_method(rb_cFiberScheduler, "io_pwrite", rb_fiber_scheduler_io_pwrite, 5);
+    rb_define_method(rb_cFiberScheduler, "io_select", rb_fiber_scheduler_io_select, 4);
     rb_define_method(rb_cFiberScheduler, "kernel_sleep", rb_fiber_scheduler_kernel_sleep, 1);
     rb_define_method(rb_cFiberScheduler, "address_resolve", rb_fiber_scheduler_address_resolve, 1);
     rb_define_method(rb_cFiberScheduler, "timeout_after", rb_fiber_scheduler_timeout_after, 3);
@@ -490,6 +493,14 @@ rb_fiber_scheduler_io_read(VALUE scheduler, VALUE io, VALUE buffer, size_t lengt
     return rb_check_funcall(scheduler, id_io_read, 4, arguments);
 }
 
+
+/*
+ *  Document-method: Fiber::Scheduler#io_read
+ *  call-seq: io_pread(io, buffer, from, length, offset) -> read length or -errno
+ *
+ *  Invoked by IO::Buffer#pread. See that method for description of arguments.
+ *
+ */
 VALUE
 rb_fiber_scheduler_io_pread(VALUE scheduler, VALUE io, rb_off_t from, VALUE buffer, size_t length, size_t offset)
 {
@@ -537,6 +548,13 @@ rb_fiber_scheduler_io_write(VALUE scheduler, VALUE io, VALUE buffer, size_t leng
     return rb_check_funcall(scheduler, id_io_write, 4, arguments);
 }
 
+/*
+ *  Document-method: Fiber::Scheduler#io_pwrite
+ *  call-seq: io_pwrite(io, buffer, from, length, offset) -> written length or -errno
+ *
+ *  Invoked by IO::Buffer#pwrite. See that method for description of arguments.
+ *
+ */
 VALUE
 rb_fiber_scheduler_io_pwrite(VALUE scheduler, VALUE io, rb_off_t from, VALUE buffer, size_t length, size_t offset)
 {


### PR DESCRIPTION
* `Fiber:Scheduler`: `io_pread`, `io_pwrite`, `io_select` (for the latter, docs were there, just didn't linked to be visible by RDoc)
* `IO::Buffer`: `pread`, `pwrite`, `write` (already existing, but wasn't documented)

Docs are kind of shallows, but better than none at all :(