### PR TITLE
[DOC] Surface existing MonitorMixin documentation

### DIFF
--- a/ext/monitor/lib/monitor.rb
+++ b/ext/monitor/lib/monitor.rb
@@ -7,17 +7,19 @@
 # You can freely distribute/modify this library.
 #
 
+require 'monitor.so'
+
 #
 # In concurrent programming, a monitor is an object or module intended to be
-# used safely by more than one thread.  The defining characteristic of a
-# monitor is that its methods are executed with mutual exclusion.  That is, at
+# used safely by more than one thread. The defining characteristic of a
+# monitor is that its methods are executed with mutual exclusion. That is, at
 # each point in time, at most one thread may be executing any of its methods.
 # This mutual exclusion greatly simplifies reasoning about the implementation
 # of monitors compared to reasoning about parallel code that updates a data
 # structure.
 #
 # You can read more about the general principles on the Wikipedia page for
-# Monitors[https://en.wikipedia.org/wiki/Monitor_%28synchronization%29]
+# Monitors[https://en.wikipedia.org/wiki/Monitor_%28synchronization%29].
 #
 # == Examples
 #
@@ -48,7 +50,7 @@
 #   end
 #
 # The consumer thread waits for the producer thread to push a line to buf
-# while <tt>buf.empty?</tt>.  The producer thread (main thread) reads a
+# while <tt>buf.empty?</tt>. The producer thread (main thread) reads a
 # line from ARGF and pushes it into buf then calls <tt>empty_cond.signal</tt>
 # to notify the consumer thread of new data.
 #
@@ -86,9 +88,6 @@
 # This Class is implemented as subclass of Array which includes the
 # MonitorMixin module.
 #
-
-require 'monitor.so'
-
 module MonitorMixin
   #
   # FIXME: This isn't documented in Nutshell.


### PR DESCRIPTION
The documentation for the mixin `MonitorMixin` already existed, but didn't get compiled into the documentation pages because it was not positioned directly above `module MonitorMixin`.

This PR moves the block two lines down, making it correctly render.