### PR TITLE
Reuse `yyerror0` macro

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -6589,7 +6589,7 @@ parser_yyerror(struct parser_params *p, const YYLTYPE *yylloc, const char *msg)
 	p->lex.ptok = p->lex.pbeg + yylloc->beg_pos.column;
 	p->lex.pcur = p->lex.pbeg + yylloc->end_pos.column;
     }
-    parser_yyerror0(p, msg);
+    yyerror0(msg);
     if (pcur) {
 	p->lex.ptok = ptok;
 	p->lex.pcur = pcur;


### PR DESCRIPTION
`parser_yyerror` has this code.

```c
parser_yyerror0(p, msg);
```

But, this code repalce to `yyerror0` macro and that more shorter and shimpler. I think.