### PR TITLE
NEWS.md: custom method example for `Data.define`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -177,12 +177,18 @@ Note: We're only listing outstanding class updates.
       lean and strict API. [[Feature #16122]]
 
         ```ruby
-        Measure = Data.define(:amount, :unit)
+        Measure = Data.define(:amount, :unit) do
+          # Custom method to present data
+          def value
+            "#{amount} #{unit}"
+          end
+        end
         distance = Measure.new(100, 'km')            #=> #<data Measure amount=100, unit="km">
         weight = Measure.new(amount: 50, unit: 'kg') #=> #<data Measure amount=50, unit="kg">
         weight.with(amount: 40)                      #=> #<data Measure amount=40, unit="kg">
         weight.amount                                #=> 50
         weight.amount = 40                           #=> NoMethodError: undefined method `amount='
+        weight.value                                 #=> "50 kg"
         ```
 
 * Encoding

--- a/NEWS.md
+++ b/NEWS.md
@@ -178,7 +178,7 @@ Note: We're only listing outstanding class updates.
 
         ```ruby
         Measure = Data.define(:amount, :unit) do
-          # Custom method to present data
+          # Custom method to represent data
           def value
             "#{amount} #{unit}"
           end


### PR DESCRIPTION
When I use the new core class `Data` to define something, I found it could define some custom method by passing a block, So I thought is it could be mentioned in the doc?