### PR TITLE
Check if the argument is Thread::Backtrace::Location object

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -202,6 +202,11 @@ static VALUE
 node_id_for_backtrace_location(rb_execution_context_t *ec, VALUE module, VALUE location)
 {
     int node_id;
+
+    if (!rb_frame_info_p(location)) {
+        rb_raise(rb_eTypeError, "Thread::Backtrace::Location object expected");
+    }
+
     node_id = rb_get_node_id_from_frame_info(location);
     if (node_id == -1) {
         return Qnil;

--- a/test/ruby/test_ast.rb
+++ b/test/ruby/test_ast.rb
@@ -227,6 +227,12 @@ class TestAst < Test::Unit::TestCase
     assert_equal node.node_id, node_id
   end
 
+  def test_node_id_for_backtrace_location_raises_argument_error
+    bug19262 = '[ruby-core:111435]'
+
+    assert_raise(TypeError, bug19262) { RubyVM::AbstractSyntaxTree.node_id_for_backtrace_location(1) }
+  end
+
   def test_of_proc_and_method
     proc = Proc.new { 1 + 2 }
     method = self.method(__method__)


### PR DESCRIPTION
[Bug #19262]