### PR TITLE
Fix uninit constant in ENV leakchecker

### DIFF
--- a/tool/lib/leakchecker.rb
+++ b/tool/lib/leakchecker.rb
@@ -235,7 +235,8 @@ class LeakChecker
     return false if old_env == new_env
     (old_env.keys | new_env.keys).sort.each {|k|
       # Don't report changed environment variables caused by Bundler's backups
-      next if k.start_with?(Bundler::EnvironmentPreserver::BUNDLER_PREFIX)
+      next if defined?(Bundler::EnvironmentPreserver::BUNDLER_PREFIX) &&
+              k.start_with?(Bundler::EnvironmentPreserver::BUNDLER_PREFIX)
 
       if old_env.has_key?(k)
         if new_env.has_key?(k)


### PR DESCRIPTION
Bundler is not require'd in "make test-all", so that the leak check didn't report correctly but failed with:
```
  D:/a/ruby/ruby/src/tool/lib/leakchecker.rb:238:in `block in check_env': uninitialized constant Bundler::EnvironmentPreserver (NameError)

        next if k.start_with?(Bundler::EnvironmentPreserver::BUNDLER_PREFIX)
                                                           ^^^^^^^^^^^^^^^^
```