### PR TITLE
Windows: Prefer USERPROFILE over HOMEPATH on startup as well

### DIFF
--- a/test/ruby/test_dir.rb
+++ b/test/ruby/test_dir.rb
@@ -578,6 +578,40 @@ class TestDir < Test::Unit::TestCase
       ENV.delete('USERPROFILE')
       assert_equal("C:/ruby/homepath", Dir.home)
     end
+
+    def test_home_at_startup_windows
+      env = {'HOME' => "C:\\ruby\\home"}
+      args = [env]
+      assert_separately(args, "#{<<~"begin;"}\n#{<<~'end;'}")
+      begin;
+        assert_equal("C:/ruby/home", Dir.home)
+      end;
+
+      env['USERPROFILE'] = "C:\\ruby\\userprofile"
+      assert_separately(args, "#{<<~"begin;"}\n#{<<~'end;'}")
+      begin;
+        assert_equal("C:/ruby/home", Dir.home)
+      end;
+
+      env['HOME'] = nil
+      assert_separately(args, "#{<<~"begin;"}\n#{<<~'end;'}")
+      begin;
+        assert_equal("C:/ruby/userprofile", Dir.home)
+      end;
+
+      env['HOMEDRIVE'] = "C:"
+      env['HOMEPATH'] = "\\ruby\\homepath"
+      assert_separately(args, "#{<<~"begin;"}\n#{<<~'end;'}")
+      begin;
+        assert_equal("C:/ruby/userprofile", Dir.home)
+      end;
+
+      env['USERPROFILE'] = nil
+      assert_separately(args, "#{<<~"begin;"}\n#{<<~'end;'}")
+      begin;
+        assert_equal("C:/ruby/homepath", Dir.home)
+      end;
+    end
   end
 
   def test_home

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -622,21 +622,24 @@ init_env(void)
 
     if (!GetEnvironmentVariableW(L"HOME", env, numberof(env))) {
         f = FALSE;
-        if (GetEnvironmentVariableW(L"HOMEDRIVE", env, numberof(env)))
-            len = lstrlenW(env);
-        else
-            len = 0;
-        if (GetEnvironmentVariableW(L"HOMEPATH", env + len, numberof(env) - len) || len) {
+        if (GetEnvironmentVariableW(L"USERPROFILE", env, numberof(env))) {
             f = TRUE;
         }
-        else if (GetEnvironmentVariableW(L"USERPROFILE", env, numberof(env))) {
-            f = TRUE;
-        }
-        else if (get_special_folder(CSIDL_PROFILE, env, numberof(env))) {
-            f = TRUE;
-        }
-        else if (get_special_folder(CSIDL_PERSONAL, env, numberof(env))) {
-            f = TRUE;
+        else {
+            if (GetEnvironmentVariableW(L"HOMEDRIVE", env, numberof(env)))
+                len = lstrlenW(env);
+            else
+                len = 0;
+
+            if (GetEnvironmentVariableW(L"HOMEPATH", env + len, numberof(env) - len) || len) {
+                f = TRUE;
+            }
+            else if (get_special_folder(CSIDL_PROFILE, env, numberof(env))) {
+                f = TRUE;
+            }
+            else if (get_special_folder(CSIDL_PERSONAL, env, numberof(env))) {
+                f = TRUE;
+            }
         }
         if (f) {
             regulate_path(env);


### PR DESCRIPTION
This is a fix-up of commit https://github.com/ruby/ruby/commit/d0f5dc9eac78ecade459b740ed08795c8df6d129 .

Unfortunately the original intention to allow the use of ruby in a `runas` environment wasn't fixed by the above commit.  This is because the win32 initialization sets the `HOME` environment variable based on a separate evaluation of `USERPROFILE`, `HOMEDRIVE` and `HOMEPATH`. And the `HOME` variable is preferred by `Dir.home`. I'm sorry I didn't know about this initialization, so that I missed to adjust this code part properly. This is now fixed.

Fixes https://bugs.ruby-lang.org/issues/19244