### PR TITLE
Windows: Simplify ENV code by removing compatibility and duplicated code

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -5102,6 +5102,8 @@ ruby_setenv(const char *name, const char *value)
 
     ENV_LOCK();
     {
+        /* Use _wputenv_s() instead of SetEnvironmentVariableW() to make sure
+         * special variables like "TZ" are interpret by libc. */
         failed = _wputenv_s(wname, wvalue);
     }
     ENV_UNLOCK();
@@ -5111,7 +5113,7 @@ ruby_setenv(const char *name, const char *value)
      * variable from the system area. */
     if (!value || !*value) {
         /* putenv() doesn't handle empty value */
-        if (!SetEnvironmentVariable(name, value) &&
+        if (!SetEnvironmentVariableW(wname, value ? wvalue : NULL) &&
             GetLastError() != ERROR_ENVVAR_NOT_FOUND) goto fail;
     }
     if (failed) {

--- a/hash.c
+++ b/hash.c
@@ -5053,44 +5053,6 @@ envix(const char *nam)
 }
 #endif
 
-#if defined(_WIN32)
-static size_t
-getenvsize(const WCHAR* p)
-{
-    const WCHAR* porg = p;
-    while (*p++) p += lstrlenW(p) + 1;
-    return p - porg + 1;
-}
-
-static size_t
-getenvblocksize(void)
-{
-#ifdef _MAX_ENV
-    return _MAX_ENV;
-#else
-    return 32767;
-#endif
-}
-
-static int
-check_envsize(size_t n)
-{
-    if (_WIN32_WINNT < 0x0600 && rb_w32_osver() < 6) {
-        /* https://msdn.microsoft.com/en-us/library/windows/desktop/ms682653(v=vs.85).aspx */
-        /* Windows Server 2003 and Windows XP: The maximum size of the
-         * environment block for the process is 32,767 characters. */
-        WCHAR* p = GetEnvironmentStringsW();
-        if (!p) return -1; /* never happen */
-        n += getenvsize(p);
-        FreeEnvironmentStringsW(p);
-        if (n >= getenvblocksize()) {
-            return -1;
-        }
-    }
-    return 0;
-}
-#endif
-
 #if defined(_WIN32) || \
   (defined(__sun) && !(defined(HAVE_SETENV) && defined(HAVE_UNSETENV)))
 
@@ -5116,9 +5078,6 @@ void
 ruby_setenv(const char *name, const char *value)
 {
 #if defined(_WIN32)
-# if defined(MINGW_HAS_SECURE_API) || RUBY_MSVCRT_VERSION >= 80
-#   define HAVE__WPUTENV_S 1
-# endif
     VALUE buf;
     WCHAR *wname;
     WCHAR *wvalue = 0;
@@ -5129,34 +5088,21 @@ ruby_setenv(const char *name, const char *value)
     if (value) {
         int len2;
         len2 = MultiByteToWideChar(CP_UTF8, 0, value, -1, NULL, 0);
-        if (check_envsize((size_t)len + len2)) { /* len and len2 include '\0' */
-            goto fail;  /* 2 for '=' & '\0' */
-        }
         wname = ALLOCV_N(WCHAR, buf, len + len2);
         wvalue = wname + len;
         MultiByteToWideChar(CP_UTF8, 0, name, -1, wname, len);
         MultiByteToWideChar(CP_UTF8, 0, value, -1, wvalue, len2);
-#ifndef HAVE__WPUTENV_S
-        wname[len-1] = L'=';
-#endif
     }
     else {
         wname = ALLOCV_N(WCHAR, buf, len + 1);
         MultiByteToWideChar(CP_UTF8, 0, name, -1, wname, len);
         wvalue = wname + len;
         *wvalue = L'\0';
-#ifndef HAVE__WPUTENV_S
-        wname[len-1] = L'=';
-#endif
     }
 
     ENV_LOCK();
     {
-#ifndef HAVE__WPUTENV_S
-        failed = _wputenv(wname);
-#else
         failed = _wputenv_s(wname, wvalue);
-#endif
     }
     ENV_UNLOCK();
 

--- a/test/ruby/test_env.rb
+++ b/test/ruby/test_env.rb
@@ -1485,5 +1485,15 @@ class TestEnv < Test::Unit::TestCase
     ensure
       ENV["test"] = test
     end
+
+    def test_utf8_empty
+      key = "VAR\u{e5 e1 e2 e4 e3 101 3042}"
+      ENV[key] = "x"
+      assert_equal "x", ENV[key]
+      ENV[key] = ""
+      assert_equal "", ENV[key]
+      ENV[key] = nil
+      assert_nil ENV[key]
+    end
   end
 end

--- a/win32/file.c
+++ b/win32/file.c
@@ -332,7 +332,7 @@ rb_file_expand_path_internal(VALUE fname, VALUE dname, int abs_mode, int long_na
 
         if (!IS_ABSOLUTE_PATH_P(whome, whome_len)) {
             free(wpath);
-            xfree(whome);
+            free(whome);
             rb_raise(rb_eArgError, "non-absolute home");
         }
 
@@ -411,7 +411,7 @@ rb_file_expand_path_internal(VALUE fname, VALUE dname, int abs_mode, int long_na
             if (!IS_ABSOLUTE_PATH_P(whome, whome_len)) {
                 free(wpath);
                 free(wdir);
-                xfree(whome);
+                free(whome);
                 rb_raise(rb_eArgError, "non-absolute home");
             }
 
@@ -572,7 +572,7 @@ rb_file_expand_path_internal(VALUE fname, VALUE dname, int abs_mode, int long_na
     xfree(buffer);
     free(wpath);
     free(wdir);
-    xfree(whome);
+    free(whome);
 
     if (wfullpath != wfullpath_buffer)
         xfree(wfullpath);


### PR DESCRIPTION
`_wputenv_s` is available in all supported MSVC versions and in MINGW since years. Dropping support for `_wputenv` without `_s` allows to remove some complexity and duplication, since `rb_w32_home_dir()` is usable in the win32 initialization then.

Also fix a single ANSI call to `SetEnvironmentVariable()` by using the Unicode equivalent. I added a test case for it.
