### PR TITLE
Fix [Bug 19273], set correct value to `outer_repeat` on `OP_REPEAT`

### DIFF
--- a/regexec.c
+++ b/regexec.c
@@ -615,7 +615,7 @@ init_cache_index_table(regex_t* reg, OnigCacheIndex *table)
 	if (reg->repeat_range[mem].lower == 0) {
 	  table->addr = pbegin;
 	  table->num = num - current_mem_num;
-	  table->outer_repeat = mem;
+	  table->outer_repeat = -1;
 	  num++;
 	  table++;
 	}

--- a/test/ruby/test_regexp.rb
+++ b/test/ruby/test_regexp.rb
@@ -1721,6 +1721,11 @@ class TestRegexp < Test::Unit::TestCase
     end;
   end
 
+  def test_bug_19273 # [Bug #19273]
+    pattern = /(?:(?:-?b)|(?:-?(?:1_?(?:0_?)*)?0))(?::(?:(?:-?b)|(?:-?(?:1_?(?:0_?)*)?0))){0,3}/
+    assert_equal("10:0:0".match(pattern)[0], "10:0:0")
+  end
+
   def test_linear_time_p
     assert_send [Regexp, :linear_time?, /a/]
     assert_send [Regexp, :linear_time?, 'a']


### PR DESCRIPTION
This PR fixes [\[Bug 19273\]](https://bugs.ruby-lang.org/issues/19273). The bug is caused by incorrectly treating the outer repeats as inner ones.

Thank you.