### PR TITLE
[DOC] Fix call-seq for Data.define

### DIFF
--- a/struct.c
+++ b/struct.c
@@ -1662,11 +1662,9 @@ rb_struct_dig(int argc, VALUE *argv, VALUE self)
 
 /*
  * call-seq:
- *   define(name, *symbols) -> class
  *   define(*symbols) -> class
  *
- *  Defines a new \Data class. If the first argument is a string, the class
- *  is stored in <tt>Data::<name></tt> constant.
+ *  Defines a new \Data class.
  *
  *     measure = Data.define(:amount, :unit)
  *     #=> #<Class:0x00007f70c6868498>


### PR DESCRIPTION
Unlike `Struct`, `Data` does not take an argument for its class name.

```
% ruby -e 'p Struct.new("Cat", :name).new(name: "Tama")'
#<struct Struct::Cat name="Tama">
```

```
% ruby -e 'p Data.define("Cat", :name).new(name: "Tama")'
-e:1:in `initialize': missing keyword: :Cat (ArgumentError)

p Data.define("Cat", :name).new(name: "Tama")
                                ^^^^^^^^^^^^
        from -e:1:in `new'
        from -e:1:in `<main>'
```