### PR TITLE
Remove support for the Regexp.new 3rd argument

### DIFF
--- a/re.c
+++ b/re.c
@@ -3912,10 +3912,10 @@ reg_extract_args(int argc, VALUE *argv, struct reg_init_args *args)
 {
     int flags = 0;
     rb_encoding *enc = 0;
-    VALUE str, src, opts = Qundef, n_flag = Qundef, kwargs;
+    VALUE str, src, opts = Qundef, kwargs;
     VALUE re = Qnil;
 
-    argc = rb_scan_args(argc, argv, "12:", &src, &opts, &n_flag, &kwargs);
+    rb_scan_args(argc, argv, "11:", &src, &opts, &kwargs);
 
     args->timeout = Qnil;
     if (!NIL_P(kwargs)) {
@@ -3924,10 +3924,6 @@ reg_extract_args(int argc, VALUE *argv, struct reg_init_args *args)
             keywords[0] = rb_intern_const("timeout");
         }
         rb_get_kwargs(kwargs, keywords, 0, 1, &args->timeout);
-    }
-
-    if (argc == 3) {
-        rb_warn_deprecated_to_remove("3.3", "3rd argument to Regexp.new", "2nd argument");
     }
 
     if (RB_TYPE_P(src, T_REGEXP)) {
@@ -3947,13 +3943,6 @@ reg_extract_args(int argc, VALUE *argv, struct reg_init_args *args)
             else if ((f = str_to_option(opts)) >= 0) flags = f;
             else if (!NIL_P(opts) && rb_bool_expected(opts, "ignorecase", FALSE))
                 flags = ONIG_OPTION_IGNORECASE;
-        }
-        if (!NIL_OR_UNDEF_P(n_flag)) {
-            char *kcode = StringValuePtr(n_flag);
-            if (kcode[0] == 'n' || kcode[0] == 'N') {
-                enc = rb_ascii8bit_encoding();
-                flags |= ARG_ENCODING_NONE;
-            }
         }
         str = StringValue(src);
     }

--- a/test/ruby/test_regexp.rb
+++ b/test/ruby/test_regexp.rb
@@ -40,19 +40,6 @@ class TestRegexp < Test::Unit::TestCase
     assert_equal("a".gsub(/a\Z/, ""), "")
   end
 
-  def test_yoshidam_net_20041111_1
-    s = "[\xC2\xA0-\xC3\xBE]"
-    r = assert_deprecated_warning(/3\.3/) {Regexp.new(s, nil, "u")}
-    assert_match(r, "\xC3\xBE")
-  end
-
-  def test_yoshidam_net_20041111_2
-    assert_raise(RegexpError) do
-      s = "[\xFF-\xFF]".force_encoding("utf-8")
-      assert_warning(/3\.3/) {Regexp.new(s, nil, "u")}
-    end
-  end
-
   def test_ruby_dev_31309
     assert_equal('Ruby', 'Ruby'.sub(/[^a-z]/i, '-'))
   end
@@ -713,25 +700,6 @@ class TestRegexp < Test::Unit::TestCase
       assert_equal(//n, Regexp.new("", Regexp::NOENCODING, timeout: 1))
 
       assert_equal(arg_encoding_none, Regexp.new("", Regexp::NOENCODING).options)
-    end
-
-    assert_deprecated_warning(/3\.3/) do
-      assert_equal(Encoding.find("US-ASCII"), Regexp.new("b..", nil, "n").encoding)
-    end
-    assert_deprecated_warning(/3\.3/) do
-      assert_equal(Encoding.find("US-ASCII"), Regexp.new("b..", nil, "n", timeout: 1).encoding)
-    end
-    assert_deprecated_warning(/3\.3/) do
-      assert_equal("bar", "foobarbaz"[Regexp.new("b..", nil, "n")])
-    end
-    assert_deprecated_warning(/3\.3/) do
-      assert_equal(//n, Regexp.new("", nil, "n"))
-    end
-    assert_deprecated_warning(/3\.3/) do
-      assert_equal(arg_encoding_none, Regexp.new("", nil, "n").options)
-    end
-    assert_deprecated_warning(/3\.3/) do
-      assert_equal(arg_encoding_none, Regexp.new("", nil, "N").options)
     end
 
     assert_raise(RegexpError) { Regexp.new(")(") }


### PR DESCRIPTION
This was deprecated in Ruby 3.2.

Fixes [Bug #18797]

test-bundled-gems currently fails, it needs https://github.com/ruby/rbs/pull/1190 merged and a new rbs release to pass.