### PR TITLE
Coverage.supported? recognizes oneshot_lines mode

### DIFF
--- a/ext/coverage/coverage.c
+++ b/ext/coverage/coverage.c
@@ -29,7 +29,7 @@ static VALUE me2counter = Qnil;
  *  Returns true if coverage measurement is supported for the given mode.
  *
  *  The mode should be one of the following symbols:
- *  +:lines+, +:branches+, +:methods+, +:eval+.
+ *  +:lines+, +:oneshot_lines+, +:branches+, +:methods+, +:eval+.
  *
  *  Example:
  *
@@ -43,6 +43,7 @@ rb_coverage_supported(VALUE self, VALUE _mode)
 
     return RBOOL(
         mode == rb_intern("lines") ||
+        mode == rb_intern("oneshot_lines") ||
         mode == rb_intern("branches") ||
         mode == rb_intern("methods") ||
         mode == rb_intern("eval")

--- a/test/coverage/test_coverage.rb
+++ b/test/coverage/test_coverage.rb
@@ -174,6 +174,7 @@ class TestCoverage < Test::Unit::TestCase
 
   def test_coverage_supported
     assert Coverage.supported?(:lines)
+    assert Coverage.supported?(:oneshot_lines)
     assert Coverage.supported?(:branches)
     assert Coverage.supported?(:methods)
     assert Coverage.supported?(:eval)


### PR DESCRIPTION
This adds oneshot_lines as a mode of coverage that is supported.