### PR TITLE
Fix Ripper::Lexer::State#[] incompatibility

### DIFF
--- a/ext/ripper/lib/ripper/lexer.rb
+++ b/ext/ripper/lib/ripper/lexer.rb
@@ -67,7 +67,7 @@ class Ripper
         when 0, :to_int
           @to_int
         when 1, :to_s
-          @event
+          @to_s
         else
           nil
         end

--- a/test/ripper/test_lexer.rb
+++ b/test/ripper/test_lexer.rb
@@ -252,4 +252,12 @@ world"
 ]
     assert_equal(code, Ripper.tokenize(code).join(""), bug)
   end
+
+  def test_lexer_state_bracket
+    state = Ripper.lex("1 + 2").last.last
+    assert_equal(state[0], 2)
+    assert_equal(state[:to_int], 2)
+    assert_equal(state[1], "END")
+    assert_equal(state[:to_s], "END")
+  end
 end


### PR DESCRIPTION
I was reading the Ripper's code and found a part of the code where the behavior has changed since v3.1.0.

From the following point in time, the behavior has changed to always return `nil`.

https://github.com/ruby/ruby/pull/5093/files#diff-00cab56d5cd91c959d4b06968b45aa010de48631b54a18593aabca9c261d075eR72

```
$ docker run -it --rm rubylang/all-ruby ./all-ruby -r ripper -e 'p Ripper::Lexer::State.new(1)[:to_s]'
(snip)
ruby-2.5.0-rc1        "EXPR_BEG"
...
ruby-2.7.0-preview1   "EXPR_BEG"
ruby-2.7.0-preview2   "BEG"
...
ruby-3.1.0-preview1   "BEG"
ruby-3.1.0            nil
...
ruby-3.2.0            nil
```

I think it is correct to return `@to_s` since it was originally Struct.