### PR TITLE
Reuse `memfill` function

### DIFF
--- a/array.c
+++ b/array.c
@@ -317,12 +317,12 @@ rb_ary_ptr_use_end(VALUE ary)
 #endif
 }
 
+static inline void memfill(register VALUE *mem, register long size, register VALUE val);
+
 void
 rb_mem_clear(VALUE *mem, long size)
 {
-    while (size--) {
-        *mem++ = Qnil;
-    }
+    memfill(mem, size, Qnil);
 }
 
 static void


### PR DESCRIPTION
`rb_mem_clear` and `memfill` has almost same code in `array.c`

```c
void
rb_mem_clear(VALUE *mem, long size)
{
    while (size--) {
        *mem++ = Qnil;
    }
}

static inline void
memfill(register VALUE *mem, register long size, register VALUE val)
{
    while (size--) {
        *mem++ = val;
    }
}
```

I thought better to reuse `memfill` that more simple.
