### PR TITLE
Remove description and codes of experimental warnings related pattern matching from documentation and test

### DIFF
--- a/doc/syntax.rdoc
+++ b/doc/syntax.rdoc
@@ -12,7 +12,7 @@ Assignment[rdoc-ref:syntax/assignment.rdoc] ::
   +if+, +unless+, +while+, +until+, +for+, +break+, +next+, +redo+
 
 {Pattern matching}[rdoc-ref:syntax/pattern_matching.rdoc] ::
-  Experimental structural pattern matching and variable binding syntax
+  Structural pattern matching and variable binding syntax
 
 Methods[rdoc-ref:syntax/methods.rdoc] ::
   Method and method argument syntax

--- a/doc/syntax/control_expressions.rdoc
+++ b/doc/syntax/control_expressions.rdoc
@@ -255,7 +255,7 @@ Again, the +then+ and +else+ are optional.
 The result value of a +case+ expression is the last value executed in the
 expression.
 
-Since Ruby 2.7, +case+ expressions also provide a more powerful experimental
+Since Ruby 2.7, +case+ expressions also provide a more powerful
 pattern matching feature via the +in+ keyword:
 
   case {a: 1, b: 2, c: 3}

--- a/error.c
+++ b/error.c
@@ -217,7 +217,6 @@ rb_warning_category_enabled_p(rb_warning_category_t category)
  *
  * +:experimental+ ::
  *   experimental features
- *   * Pattern matching
  *
  * +:performance+ ::
  *   performance hints


### PR DESCRIPTION
Ruby 3.2.0 has been released and all experimental warnings about pattern matching have been removed.
Experimental warnings about pattern matching are no longer output, so I remove description about it from documentation and codes using it on test.

cf. https://bugs.ruby-lang.org/issues/18585
cf. https://github.com/ruby/ruby/commit/db6b23c76cbc7888cd9a9912790c2068703afdd0
cf. https://twitter.com/k_tsj/status/1606956336037900289?s=20&t=-_PSYLhYPtYsB9FZhtXl5A