### PR TITLE
YJIT: use Context in guard_object_is methods

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -1291,10 +1291,17 @@ fn gen_newrange(
 }
 
 fn guard_object_is_heap(
+    ctx: &mut Context,
     asm: &mut Assembler,
     object_opnd: Opnd,
+    ir_opnd: YARVOpnd,
     side_exit: CodePtr,
 ) {
+    let ctx_type = ctx.get_opnd_type(ir_opnd);
+    if ctx_type.is_heap() {
+        return;
+    }
+
     asm.comment("guard object is heap");
 
     // Test that the object is not an immediate
@@ -1304,14 +1311,28 @@ fn guard_object_is_heap(
     // Test that the object is not false
     asm.cmp(object_opnd, Qfalse.into());
     asm.je(side_exit.as_side_exit());
+
+    if ctx.get_opnd_type(ir_opnd) == Type::Unknown {
+        ctx.upgrade_opnd_type(ir_opnd, Type::UnknownHeap);
+    }
 }
 
+// Guards that the passed object is a T_ARRAY, a Ruby Array or subclass
 fn guard_object_is_array(
+    ctx: &mut Context,
     asm: &mut Assembler,
     object_opnd: Opnd,
+    ir_opnd: YARVOpnd,
     side_exit: CodePtr,
 ) {
+    let ctx_type = ctx.get_opnd_type(ir_opnd);
+    if ctx_type == Type::Array {
+        return;
+    }
+
     asm.comment("guard object is array");
+
+    guard_object_is_heap(ctx, asm, object_opnd, ir_opnd, side_exit);
 
     // Pull out the type mask
     let flags_opnd = Opnd::mem(
@@ -1324,28 +1345,7 @@ fn guard_object_is_array(
     // Compare the result with T_ARRAY
     asm.cmp(flags_opnd, (RUBY_T_ARRAY as u64).into());
     asm.jne(side_exit.as_side_exit());
-}
-
-fn guard_object_is_string(
-    asm: &mut Assembler,
-    object_reg: Opnd,
-    side_exit: CodePtr,
-) {
-    asm.comment("guard object is string");
-
-    // Pull out the type mask
-    let flags_reg = asm.load(
-        Opnd::mem(
-            8 * SIZEOF_VALUE as u8,
-            object_reg,
-            RUBY_OFFSET_RBASIC_FLAGS,
-        ),
-    );
-    let flags_reg = asm.and(flags_reg, Opnd::UImm(RUBY_T_MASK as u64));
-
-    // Compare the result with T_STRING
-    asm.cmp(flags_reg, Opnd::UImm(RUBY_T_STRING as u64));
-    asm.jne(side_exit.as_side_exit());
+    ctx.upgrade_opnd_type(ir_opnd, Type::Array);
 }
 
 // push enough nils onto the stack to fill out an array
@@ -1374,11 +1374,11 @@ fn gen_expandarray(
     let side_exit = get_side_exit(jit, ocb, ctx);
 
     let array_type = ctx.get_opnd_type(StackOpnd(0));
-    let array_opnd = ctx.stack_pop(1);
 
     // num is the number of requested values. If there aren't enough in the
     // array then we're going to push on nils.
     if matches!(array_type, Type::Nil) {
+        ctx.stack_pop(1);
         // special case for a, b = nil pattern
         // push N nils onto the stack
         for _ in 0..num {
@@ -1388,18 +1388,22 @@ fn gen_expandarray(
         return KeepCompiling;
     }
 
+    if array_type.is_specific() && array_type != Type::Array {
+        return CantCompile;
+    }
+
     // Move the array from the stack and check that it's an array.
+    let array_opnd = ctx.stack_opnd(0);
     let array_reg = asm.load(array_opnd);
-    guard_object_is_heap(
-        asm,
-        array_reg,
-        counted_exit!(ocb, side_exit, expandarray_not_array),
-    );
     guard_object_is_array(
+        ctx,
         asm,
         array_reg,
+        StackOpnd(0),
         counted_exit!(ocb, side_exit, expandarray_not_array),
     );
+
+    ctx.stack_pop(1);
 
     // If we don't actually want any values, then just return.
     if num == 0 {
@@ -2028,22 +2032,12 @@ fn gen_get_ivar(
         }
     };
 
-    // must be before stack_pop
-    let recv_type = ctx.get_opnd_type(recv_opnd);
-
-    // Upgrade type
-    if !recv_type.is_heap() {
-        ctx.upgrade_opnd_type(recv_opnd, Type::UnknownHeap);
-    }
+    // Guard heap object
+    guard_object_is_heap(ctx, asm, recv, recv_opnd, side_exit);
 
     // Pop receiver if it's on the temp stack
     if recv_opnd != SelfOpnd {
         ctx.stack_pop(1);
-    }
-
-    // Guard heap object
-    if !recv_type.is_heap() {
-        guard_object_is_heap(asm, recv, side_exit);
     }
 
     // Compile time self is embedded and the ivar index lands within the object
@@ -2267,7 +2261,7 @@ fn gen_setinstancevariable(
         // Upgrade type
         if !recv_type.is_heap() { // Must be a heap type
             ctx.upgrade_opnd_type(recv_opnd, Type::UnknownHeap);
-            guard_object_is_heap(asm, recv, side_exit);
+            guard_object_is_heap(ctx, asm, recv, recv_opnd, side_exit);
         }
 
         let expected_shape = unsafe { rb_shape_get_shape_id(comptime_receiver) };
@@ -2523,7 +2517,7 @@ fn guard_two_fixnums(
     let arg0_type = ctx.get_opnd_type(StackOpnd(1));
 
     if arg0_type.is_heap() || arg1_type.is_heap() {
-        asm.comment("arg is heap object");
+        asm.comment("arg is heap object, not fixnum");
         asm.jmp(side_exit.as_side_exit());
         return;
     }
@@ -4156,12 +4150,9 @@ fn jit_rb_str_concat(
     // Guard that the argument is of class String at runtime.
     let arg_type = ctx.get_opnd_type(StackOpnd(0));
 
-    let concat_arg = ctx.stack_pop(1);
-    let recv = ctx.stack_pop(1);
-
     // If we're not compile-time certain that this will always be a string, guard at runtime
     if arg_type != Type::CString && arg_type != Type::TString {
-        let arg_opnd = asm.load(concat_arg);
+        let arg_opnd = asm.load(ctx.stack_opnd(0));
         if !arg_type.is_heap() {
             asm.comment("guard arg not immediate");
             asm.test(arg_opnd, (RUBY_IMMEDIATE_MASK as u64).into());
@@ -4169,8 +4160,28 @@ fn jit_rb_str_concat(
             asm.cmp(arg_opnd, Qfalse.into());
             asm.je(side_exit.as_side_exit());
         }
-        guard_object_is_string(asm, arg_opnd, side_exit);
+
+        // We would like to update the type and combine the heap-check, but some of
+        // the code below is dodgy in our backend def'n. We don't allow labels to
+        // re-combine. So changing this code can easily cause a backend panic.
+        // So this method is highly fragile until we find a backend solution.
+        asm.comment("guard object is string");
+        // Pull out the type mask
+        let flags_reg = asm.load(
+            Opnd::mem(
+                8 * SIZEOF_VALUE as u8,
+                arg_opnd,
+                RUBY_OFFSET_RBASIC_FLAGS,
+            ),
+        );
+        let flags_reg = asm.and(flags_reg, Opnd::UImm(RUBY_T_MASK as u64));
+        // Compare the result with T_STRING
+        asm.cmp(flags_reg, Opnd::UImm(RUBY_T_STRING as u64));
+        asm.jne(side_exit.as_side_exit());
     }
+
+    let concat_arg = ctx.stack_pop(1);
+    let recv = ctx.stack_pop(1);
 
     // Test if string encodings differ. If different, use rb_str_append. If the same,
     // use rb_yjit_str_simple_append, which calls rb_str_cat.
@@ -4188,6 +4199,7 @@ fn jit_rb_str_concat(
     asm.test(flags_xor, Opnd::UImm(RUBY_ENCODING_MASK as u64));
 
     // Push once, use the resulting operand in both branches below.
+
     let stack_ret = ctx.stack_push(Type::CString);
 
     let enc_mismatch = asm.new_label("enc_mismatch");
@@ -4790,14 +4802,11 @@ fn push_splat_args(required_args: i32, ctx: &mut Context, asm: &mut Assembler, o
     let array_opnd = ctx.stack_opnd(0);
 
     let array_reg = asm.load(array_opnd);
-    guard_object_is_heap(
-        asm,
-        array_reg,
-        counted_exit!(ocb, side_exit, send_splat_not_array),
-    );
     guard_object_is_array(
+        ctx,
         asm,
         array_reg,
+        StackOpnd(0),
         counted_exit!(ocb, side_exit, send_splat_not_array),
     );
 


### PR DESCRIPTION
For guard_object_is_ methods, use the Context to avoid unneeded checks and upgrade type info.

Do *not* fully upgrade the jit_rb_str_concat code since it relies on a historical accident to generate its conditional code, and the updated guards break it.