### PR TITLE
Fix crash in tracing object allocations 

### DIFF
--- a/ext/objspace/depend
+++ b/ext/objspace/depend
@@ -158,6 +158,7 @@ object_tracing.o: $(hdrdir)/ruby/missing.h
 object_tracing.o: $(hdrdir)/ruby/ruby.h
 object_tracing.o: $(hdrdir)/ruby/st.h
 object_tracing.o: $(hdrdir)/ruby/subst.h
+object_tracing.o: $(top_srcdir)/gc.h
 object_tracing.o: $(top_srcdir)/internal.h
 object_tracing.o: object_tracing.c
 object_tracing.o: objspace.h

--- a/gc.c
+++ b/gc.c
@@ -9913,10 +9913,8 @@ gc_is_moveable_obj(rb_objspace_t *objspace, VALUE obj)
 #define COULD_MALLOC_REGION_START() \
     GC_ASSERT(during_gc); \
     VALUE _already_disabled = rb_gc_disable_no_rest(); \
-    during_gc = false;
 
 #define COULD_MALLOC_REGION_END() \
-    during_gc = true; \
     if (_already_disabled == Qfalse) rb_objspace_gc_enable(objspace);
 
 static VALUE
@@ -12216,7 +12214,7 @@ malloc_during_gc_p(rb_objspace_t *objspace)
      * (since ractors can run while another thread is sweeping) and when we
      * have the GVL (since if we don't have the GVL, we'll try to acquire the
      * GVL which will block and ensure the other thread finishes GC). */
-    return during_gc && !rb_multi_ractor_p() && ruby_thread_has_gvl_p();
+    return during_gc && !dont_gc_val() && !rb_multi_ractor_p() && ruby_thread_has_gvl_p();
 }
 
 static inline void *

--- a/gc.h
+++ b/gc.h
@@ -116,8 +116,6 @@ int ruby_get_stack_grow_direction(volatile VALUE *addr);
 const char *rb_obj_info(VALUE obj);
 const char *rb_raw_obj_info(char *const buff, const size_t buff_size, VALUE obj);
 
-VALUE rb_gc_disable_no_rest(void);
-
 struct rb_thread_struct;
 
 size_t rb_size_pool_slot_size(unsigned char pool_id);
@@ -141,6 +139,8 @@ void rb_objspace_each_objects_without_setup(
     void *data);
 
 size_t rb_gc_obj_slot_size(VALUE obj);
+
+VALUE rb_gc_disable_no_rest(void);
 
 RUBY_SYMBOL_EXPORT_END
 


### PR DESCRIPTION
ObjectSpace.trace_object_allocations_start could crash since it adds a TracePoint for when objects are freed. However, TracePoint could crash since it modifies st tables while inside the GC that is trying to free the object. This could cause a memory allocation to happen which would crash if it triggers another GC.

See a crash log: http://ci.rvm.jp/results/trunk@ruby-sp1/4373707