### PR TITLE
Fix crash in TracePoint c_call for removed method

### DIFF
--- a/vm_trace.c
+++ b/vm_trace.c
@@ -915,7 +915,7 @@ rb_tracearg_parameters(rb_trace_arg_t *trace_arg)
         if (trace_arg->klass && trace_arg->id) {
             const rb_method_entry_t *me;
             VALUE iclass = Qnil;
-            me = rb_method_entry_without_refinements(trace_arg->klass, trace_arg->id, &iclass);
+            me = rb_method_entry_without_refinements(trace_arg->klass, trace_arg->called_id, &iclass);
             return rb_unnamed_parameters(rb_method_entry_arity(me));
         }
         break;


### PR DESCRIPTION
trace_arg->id is the ID of the original method of an aliased method. If the original method is removed, then the lookup will fail. We should use trace_arg->called_id instead, which is the ID of the aliased method.

Fixes [Bug #19305]