### PR TITLE
common.mk: Do not invoke outdate-bundled-gems by default

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1375,7 +1375,6 @@ update-config_files: PHONY
 
 refresh-gems: update-bundled_gems prepare-gems
 prepare-gems: $(HAVE_BASERUBY:yes=update-gems) $(HAVE_BASERUBY:yes=extract-gems)
-prepare-gems: $(DOT_WAIT) $(HAVE_BASERUBY:yes=outdate-bundled-gems)
 extract-gems: $(HAVE_BASERUBY:yes=update-gems)
 
 update-gems$(gnumake:yes=-sequential): PHONY


### PR DESCRIPTION
If baseruby is available (and its version is different from one being built) when compiling ruby, tool/outdate-bundled-gems.rb (which is invoked by `make install`) wrongly deletes debug.so and rbs_extension.so in .bundle/extension/*.

This leads to a broken installation of ruby which lacks the libraries, which may make rubygems show the following warnings (in some additional complex conditions):

```
$ irb
Ignoring debug-1.7.1 because its extensions are not built. Try: gem pristine debug --version 1.7.1
Ignoring rbs-2.8.2 because its extensions are not built. Try: gem pristine rbs --version 2.8.2
irb(main):001:0>
```

According to some committers, tool/outdate-bundled-gems.rb is introduced for fixing a build issue, but the detail is not recorded. The issue seems to occur only when debug gem or rbs gem is updated, so it is difficult to fix the script so soon.

Tentatively, this change stops invoking the script by default. This should be backported to ruby_3_2.

Fixes [Bug #19271]