### PR TITLE
Add embedded status to dumps of T_OBJECT

### DIFF
--- a/ext/objspace/objspace_dump.c
+++ b/ext/objspace/objspace_dump.c
@@ -544,6 +544,10 @@ dump_object(VALUE obj, struct dump_config *dc)
         break;
 
       case T_OBJECT:
+        if (FL_TEST(obj, ROBJECT_EMBED)) {
+            dump_append(dc, ", \"embedded\":true");
+        }
+
         dump_append(dc, ", \"ivars\":");
         dump_append_lu(dc, ROBJECT_IV_COUNT(obj));
         if (rb_shape_obj_too_complex(obj)) {

--- a/test/objspace/test_objspace.rb
+++ b/test/objspace/test_objspace.rb
@@ -358,6 +358,22 @@ class TestObjSpace < Test::Unit::TestCase
     assert_not_include(info, '"embedded":true')
   end
 
+  def test_dump_object
+    klass = Class.new
+
+    # Empty object
+    info = ObjectSpace.dump(klass.new)
+    assert_include(info, '"embedded":true')
+    assert_include(info, '"ivars":0')
+
+    # Non-embed object
+    obj = klass.new
+    5.times { |i| obj.instance_variable_set("@ivar#{i}", 0) }
+    info = ObjectSpace.dump(obj)
+    assert_not_include(info, '"embedded":true')
+    assert_include(info, '"ivars":5')
+  end
+
   def test_dump_control_char
     assert_include(ObjectSpace.dump("\x0f"), '"value":"\u000f"')
     assert_include(ObjectSpace.dump("\C-?"), '"value":"\u007f"')


### PR DESCRIPTION
This commit adds `"embedded":true` in ObjectSpace.dump for T_OBJECTs that are embedded.