### PR TITLE
Use a different name for megamorphic setivar exits

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -2276,7 +2276,7 @@ fn gen_setinstancevariable(
 
         asm.comment("guard shape");
         asm.cmp(shape_opnd, Opnd::UImm(expected_shape as u64));
-        let megamorphic_side_exit = counted_exit!(ocb, side_exit, getivar_megamorphic).into();
+        let megamorphic_side_exit = counted_exit!(ocb, side_exit, setivar_megamorphic).into();
         jit_chain_guard(
             JCC_JNE,
             jit,

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -256,6 +256,7 @@ make_counters! {
     setivar_name_not_mapped,
     setivar_not_object,
     setivar_frozen,
+    setivar_megamorphic,
 
     oaref_argc_not_one,
     oaref_arg_not_fixnum,


### PR DESCRIPTION
We should differentiate between set and get for megamorphic exits.  This patch fixes the megamorphic exit name in gen_setinstancevariable so that we can tell the difference between megamorphic get / set sites