### PR TITLE
YJIT: Colorize outlined code differently on --yjit-dump-disasm

### DIFF
--- a/yjit/src/disasm.rs
+++ b/yjit/src/disasm.rs
@@ -173,22 +173,23 @@ pub fn disasm_addr_range(cb: &CodeBlock, start_addr: usize, end_addr: usize) -> 
     let code_slice = unsafe { std::slice::from_raw_parts(start_addr as _, code_size) };
     let insns = cs.disasm_all(code_slice, start_addr as u64).unwrap();
 
+    // Colorize outlined code in blue
+    if cb.outlined {
+        write!(&mut out, "\x1b[34m").unwrap();
+    }
     // For each instruction in this block
     for insn in insns.as_ref() {
-        // Colorize outlined code in blue
-        let (prefix, suffix) = if cb.outlined {
-            ("\x1b[34m", "\x1b[0m")
-        } else {
-            ("", "")
-        };
-
         // Comments for this block
         if let Some(comment_list) = cb.comments_at(insn.address() as usize) {
             for comment in comment_list {
-                writeln!(&mut out, "  \x1b[1m{prefix}# {comment}{suffix}\x1b[0m").unwrap();
+                writeln!(&mut out, "  \x1b[1m# {comment}\x1b[22m").unwrap(); // Make comments bold
             }
         }
-        writeln!(&mut out, "  {prefix}{insn}{suffix}").unwrap();
+        writeln!(&mut out, "  {insn}").unwrap();
+    }
+    // Disable blue color
+    if cb.outlined {
+        write!(&mut out, "\x1b[0m").unwrap();
     }
 
     return out;

--- a/yjit/src/disasm.rs
+++ b/yjit/src/disasm.rs
@@ -175,13 +175,20 @@ pub fn disasm_addr_range(cb: &CodeBlock, start_addr: usize, end_addr: usize) -> 
 
     // For each instruction in this block
     for insn in insns.as_ref() {
+        // Colorize outlined code in blue
+        let (prefix, suffix) = if cb.outlined {
+            ("\x1b[34m", "\x1b[0m")
+        } else {
+            ("", "")
+        };
+
         // Comments for this block
         if let Some(comment_list) = cb.comments_at(insn.address() as usize) {
             for comment in comment_list {
-                writeln!(&mut out, "  \x1b[1m# {}\x1b[0m", comment).unwrap();
+                writeln!(&mut out, "  \x1b[1m{prefix}# {comment}{suffix}\x1b[0m").unwrap();
             }
         }
-        writeln!(&mut out, "  {}", insn).unwrap();
+        writeln!(&mut out, "  {prefix}{insn}{suffix}").unwrap();
     }
 
     return out;


### PR DESCRIPTION
On --yjit-dump-disasm, I'd like to make it easy to distinguish inline code and outlined code, which I feel makes it more readable. I made outlined code blue because it's a "cold" path, but I'm open to other ways of visualization.

### Before
<img width="614" alt="Screenshot 2023-01-05 at 17 18 16" src="https://user-images.githubusercontent.com/3138447/210910154-5493f53c-beee-4e5c-b085-6c5c8733fd7b.png">

### After
<img width="609" alt="Screenshot 2023-01-05 at 17 18 08" src="https://user-images.githubusercontent.com/3138447/210910167-079efbf3-2e3a-476c-911b-707176db41a7.png">