### PR TITLE
Fix off-by-one error in rb_vm_each_stack_value

### DIFF
--- a/vm.c
+++ b/vm.c
@@ -2732,7 +2732,7 @@ rb_vm_each_stack_value(void *ptr, void (*cb)(VALUE, void*), void *ctx)
                     if (ec->vm_stack) {
                         VALUE *p = ec->vm_stack;
                         VALUE *sp = ec->cfp->sp;
-                        while (p <= sp) {
+                        while (p < sp) {
                             if (!rb_special_const_p(*p)) {
                                 cb(*p, ctx);
                             }


### PR DESCRIPTION
Applying the following patch to test/erb/test_erb.rb and running that file will cause Ruby to crash on my machine (macOS 13.1 on M1 Pro):

```diff
--- a/test/erb/test_erb.rb
+++ b/test/erb/test_erb.rb
@@ -7,6 +7,12 @@
 class TestERB < Test::Unit::TestCase
   class MyError < RuntimeError ; end

+  def setup
+    GC.auto_compact = true
+    GC.stress = true
+    GC.verify_compaction_references(expand_heap: true, toward: :empty)
+  end
+
```

It crashes with the following log:

```
/Users/peter/src/ruby/lib/erb/compiler.rb:276: [BUG] Segmentation fault at 0x00000001083a8690
...
-- C level backtrace information -------------------------------------------
...
/Users/peter/src/ruby/build/ruby(rb_vm_each_stack_value+0xa8) [0x104cc3a44] ../vm.c:2737
/Users/peter/src/ruby/build/ruby(rb_vm_each_stack_value+0xa8) [0x104cc3a44] ../vm.c:2737
/Users/peter/src/ruby/build/ruby(check_stack_for_moved+0x2c) [0x104b272a4] ../gc.c:5512
/Users/peter/src/ruby/build/ruby(gc_compact_finish) ../gc.c:5534
/Users/peter/src/ruby/build/ruby(gc_sweep_compact) ../gc.c:8653
/Users/peter/src/ruby/build/ruby(gc_sweep) ../gc.c:6196
/Users/peter/src/ruby/build/ruby(has_sweeping_pages+0x0) [0x104b19c54] ../gc.c:9568
/Users/peter/src/ruby/build/ruby(gc_rest) ../gc.c:9570
```

This crash happens because it's reading the VALUE at sp. But since sp points to the top of the stack, it's reading the VALUE above the top of the stack, which is causing this segfault.

Fixes [Bug #19320]