### PR TITLE
Remove unnecessary set of INVALID_SHAPE_ID in rb_callcache

### DIFF
--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -3922,7 +3922,6 @@ vm_call_method_each_type(rb_execution_context_t *ec, rb_control_frame_t *cfp, st
                 .flags = T_IMEMO |
                     (imemo_callcache << FL_USHIFT) |
                     VM_CALLCACHE_UNMARKABLE |
-                    ((VALUE)INVALID_SHAPE_ID << SHAPE_FLAG_SHIFT) |
                     VM_CALLCACHE_ON_STACK,
                     .klass = cc->klass,
                     .cme_  = cc->cme_,


### PR DESCRIPTION
We don't use this value, so there's no need to set it.