### PR TITLE
YJIT: Remove old comments for regenerated branches

### DIFF
--- a/yjit/src/asm/mod.rs
+++ b/yjit/src/asm/mod.rs
@@ -356,6 +356,13 @@ impl CodeBlock {
         self.asm_comments.get(&pos)
     }
 
+    pub fn remove_comments(&mut self, start_addr: CodePtr, end_addr: CodePtr) {
+        #[cfg(feature = "disasm")]
+        for addr in start_addr.into_usize()..end_addr.into_usize() {
+            self.asm_comments.remove(&addr);
+        }
+    }
+
     pub fn clear_comments(&mut self) {
         #[cfg(feature = "disasm")]
         self.asm_comments.clear();

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -1609,6 +1609,11 @@ fn regenerate_branch(cb: &mut CodeBlock, branch: &mut Branch) {
     }
     */
 
+    // Remove old comments
+    if let (Some(start_addr), Some(end_addr)) = (branch.start_addr, branch.end_addr) {
+        cb.remove_comments(start_addr, end_addr)
+    }
+
     let mut block = branch.block.borrow_mut();
     let branch_terminates_block = branch.end_addr == block.end_addr;
 


### PR DESCRIPTION
I see some comment duplication when the same address is compiled twice. It seems useful to not see the same comment twice.

### Before
```asm
  # opt_plus
  # regenerate_branch
  # Block: a@/home/k0kubun/tmp/comments.rb:2 (ISEQ offset: 3)
  # opt_plus
  0x55d91c106068: mov rax, qword ptr [rbx]
```

### After
```asm
  # regenerate_branch
  # Block: a@/home/k0kubun/tmp/comments.rb:2 (ISEQ offset: 3)
  # opt_plus
  0x55f04c985068: mov rax, qword ptr [rbx]
```