### PR TITLE
sendmsg with string array

### DIFF
--- a/ext/socket/lib/socket.rb
+++ b/ext/socket/lib/socket.rb
@@ -280,7 +280,7 @@ class BasicSocket < IO
   #
   # sendmsg sends a message using sendmsg(2) system call in blocking manner.
   #
-  # _mesg_ is a string to send.
+  # _mesg_ is a string or an array of strings to send.
   #
   # _flags_ is bitwise OR of MSG_* constants such as Socket::MSG_OOB.
   #

--- a/test/socket/test_basicsocket.rb
+++ b/test/socket/test_basicsocket.rb
@@ -225,4 +225,17 @@ class TestSocket_BasicSocket < Test::Unit::TestCase
       assert_equal "hello", csock.read(5)
     end
   end
+
+  def test_sendmsg
+    socks do |sserv, ssock, csock|
+      # string message
+      ssock.sendmsg("hello")
+      assert_equal "hello", csock.read(5)
+
+      # multi string message
+      ssock.sendmsg(["hello,", " world!"])
+      assert_equal "hello, world!", csock.read(13)
+      ssock.close
+    end
+  end
 end if defined?(BasicSocket)


### PR DESCRIPTION
- [rubygems/rubygems] Fix a typo
- Fix integer underflow when using HEAP_INIT_SLOTS
- Fix test when Ruby is verbose
- [DOC] [Bug #19290] fix formatting
- [Bug #19292] Re-initialize tm when wday or yday is not set
- [ruby/net-http] Enhanced RDoc for HTTPHeader
- [rubygems/rubygems] Remove stray word in bundle config man page.
- Make IO#set_encoding with binary external encoding use nil internal encoding
- Update bundled gems list at 2023-01-02
- Adjut indent [ci skip]
- [Bug #19291] Rewind to the previous line
- Add missing assertion
- [Bug #19296] Precheck bits of time components
- [ruby/irb] Fix prompt and code mismatch (https://github.com/ruby/irb/pull/386)
- Remove lib/mjit/instruction.rb
- Update bundled gems list at 2bbf63dd867fe3d349b1758805ad44 [ci skip]
- NEWS.md: remove a redundant bundled gems entry. [ci skip]
- Fix Error in GC Compaction specs
- [ruby/uri] [DOC] Enhanced RDoc for common methods (https://github.com/ruby/uri/pull/48)
- [DOC] Move the internal document for `Init_class_hierarchy`
- [ci skip] Remove trailing semicolon in gc.c
- Bump actions/cache from 3.2.0 to 3.2.2
- YJIT: Fix `yield` into block with >=30 locals on ARM
- YJIT: Dump spill error to stderr [ci skip]
- Bump ruby/setup-ruby from 1.128.0 to 1.133.0
- Pin octokit/request-action@v2.1.7
- [ruby/reline] correct Win32API capitalization for JRuby
- [ruby/irb] workspace.rb cleanup (https://github.com/ruby/irb/pull/489)
- [rubygems/rubygems] Enhance bundle open with --path option
- [rubygems/rubygems] Raise invalid option when bundle open --path is called without a value
- Allow malloc during gc when GC has been disabled
- Fix crash in tracing object allocations
- [ruby/uri] [DOC] Common methods rdoc (https://github.com/ruby/uri/pull/49)
- Fix crash in TracePoint c_call for removed method
- [ruby/openssl] Stop AutoRunner with test-unit
- Skip Test::Unit::AutoRunner logic in ruby/ruby repository
- Extract only one revision in header [ci skip]
- common.mk: Do not invoke outdate-bundled-gems by default
- [ruby/irb] Group command test cases with class (https://github.com/ruby/irb/pull/491)
- [DOC] Fix formatting for GC.stat
- Raise an ArgumentError for unknown pack/unpack directive
- Update to ruby/mspec@fef9b81
- Update to ruby/spec@9d69b95
- * remove trailing spaces, append newline at EOF. [ci skip]
- Fix undefined behavior in shape.c
- Skip reviews for cruby_bindings-only PRs [ci skip] (#7004)
- Update to ruby/spec@7e680fa
- Add RBIMPL_ATTR_NORETURN to unknown_directive
- Update to ruby/spec@5e48206
- Add embedded status to dumps of T_OBJECT
- Check if the argument is Thread::Backtrace::Location object
- Use a different name for megamorphic setivar exits
- Ensure newline at EOF [ci skip]
- [ruby/psych] Add msys2 dependencies for windows
- [ruby/psych] Strip trailing spaces [ci skip]
- Update bundled gems list at 2023-01-06
- Fix typos [ci skip]
- Pass options for extensions via `CONFIGURE_ARGS`
- mkmf.rb: Refactor splitting configure_args and remove duplicate code
- [DOC] Specify `shell` format to shell commands
- [DOC] Mention `configure` options earlier, not after failure
- [Bug #19312] Return end-of-input at `__END__`
- [ruby/uri] [DOC] Enhanced RDoc for common methods (https://github.com/ruby/uri/pull/50)
- Add bug number
- [Bug #19319] Fix crash in rb_str_casemap
- Remove unused function `rb_shape_flags_mask`
- YJIT: Colorize outlined code differently on --yjit-dump-disasm (#7073)
- YJIT: Make iseq_get_location consistent with iseq.c (#7074)
- Fix format specifiers for pointer differences
- [ruby/bigdecimal] Fix format specifiers for `size_t`
- [ruby/syntax_suggest] Run with the given ruby command
- [ruby/did_you_mean] Keep the deprecated API for another year in case this could break 'bundle install'
- Fix Integer#{<<,>>} specs with large shift width
- Only RangeError on CRuby for shift width >= 2**67
- Socket#sendmsg with string array
