### PR TITLE
Remove "unused parameter" warnings on include of ruby.h

### DIFF
--- a/include/ruby/internal/fl_type.h
+++ b/include/ruby/internal/fl_type.h
@@ -787,6 +787,7 @@ RBIMPL_ATTR_DEPRECATED(("taintedness turned out to be a wrong idea."))
 static inline bool
 RB_OBJ_TAINTABLE(VALUE obj)
 {
+    (void)obj;
     return false;
 }
 
@@ -804,6 +805,7 @@ RBIMPL_ATTR_DEPRECATED(("taintedness turned out to be a wrong idea."))
 static inline VALUE
 RB_OBJ_TAINTED_RAW(VALUE obj)
 {
+    (void)obj;
     return false;
 }
 
@@ -821,6 +823,7 @@ RBIMPL_ATTR_DEPRECATED(("taintedness turned out to be a wrong idea."))
 static inline bool
 RB_OBJ_TAINTED(VALUE obj)
 {
+    (void)obj;
     return false;
 }
 
@@ -836,6 +839,7 @@ RBIMPL_ATTR_DEPRECATED(("taintedness turned out to be a wrong idea."))
 static inline void
 RB_OBJ_TAINT_RAW(VALUE obj)
 {
+    (void)obj;
     return;
 }
 
@@ -851,6 +855,7 @@ RBIMPL_ATTR_DEPRECATED(("taintedness turned out to be a wrong idea."))
 static inline void
 RB_OBJ_TAINT(VALUE obj)
 {
+    (void)obj;
     return;
 }
 
@@ -867,6 +872,8 @@ RBIMPL_ATTR_DEPRECATED(("taintedness turned out to be a wrong idea."))
 static inline void
 RB_OBJ_INFECT_RAW(VALUE dst, VALUE src)
 {
+    (void)dst;
+    (void)src;
     return;
 }
 
@@ -883,6 +890,8 @@ RBIMPL_ATTR_DEPRECATED(("taintedness turned out to be a wrong idea."))
 static inline void
 RB_OBJ_INFECT(VALUE dst, VALUE src)
 {
+    (void)dst;
+    (void)src;
     return;
 }
 

--- a/include/ruby/internal/newobj.h
+++ b/include/ruby/internal/newobj.h
@@ -172,6 +172,8 @@ RBIMPL_ATTR_DEPRECATED(("This is no longer how Object#clone works."))
 static inline void
 rb_clone_setup(VALUE clone, VALUE obj)
 {
+    (void)clone;
+    (void)obj;
     return;
 }
 
@@ -189,6 +191,8 @@ RBIMPL_ATTR_DEPRECATED(("This is no longer how Object#dup works."))
 static inline void
 rb_dup_setup(VALUE dup, VALUE obj)
 {
+    (void)dup;
+    (void)obj;
     return;
 }
 


### PR DESCRIPTION
This pull request removes "unused parameter" warnings when compiling with flag `-Wunused-parameter` (or with `-Wall -Wextra`).

The fix consists in fooling the compiler by adding a no-op instruction using the argument, like:

```C
    (void)obj;
```

## Steps to reproduce

1. Create a C source called `test_ruby.c`, with this content:

```C
#include <ruby.h>

int main()
{
    return 0;
}
```

2. Compile the program with this command (using Ruby 3.1.0, but I'm pretty sure the problem is still there with latest versions):

```
gcc -Wunused-parameter -o test_ruby $(pkg-config --cflags ruby-3.1) $(pkg-config --libs ruby-3.1) test_ruby.c
```

## Actual result

```
$ gcc -Wunused-parameter -o test_ruby $(pkg-config --cflags ruby-3.1) $(pkg-config --libs ruby-3.1) test_ruby.c 
In file included from /usr/include/ruby-3.1.0/ruby/internal/core/rstring.h:30,
                 from /usr/include/ruby-3.1.0/ruby/internal/arithmetic/char.h:29,
                 from /usr/include/ruby-3.1.0/ruby/internal/arithmetic.h:23,
                 from /usr/include/ruby-3.1.0/ruby/ruby.h:27,
                 from /usr/include/ruby-3.1.0/ruby.h:38,
                 from test_ruby.c:1:
/usr/include/ruby-3.1.0/ruby/internal/fl_type.h: In function ‘RB_OBJ_TAINTABLE’:
/usr/include/ruby-3.1.0/ruby/internal/fl_type.h:794:24: warning: unused parameter ‘obj’ [-Wunused-parameter]
  794 | RB_OBJ_TAINTABLE(VALUE obj)
      |                  ~~~~~~^~~
/usr/include/ruby-3.1.0/ruby/internal/fl_type.h: In function ‘RB_OBJ_TAINTED_RAW’:
/usr/include/ruby-3.1.0/ruby/internal/fl_type.h:811:26: warning: unused parameter ‘obj’ [-Wunused-parameter]
  811 | RB_OBJ_TAINTED_RAW(VALUE obj)
      |                    ~~~~~~^~~
/usr/include/ruby-3.1.0/ruby/internal/fl_type.h: In function ‘RB_OBJ_TAINTED’:
/usr/include/ruby-3.1.0/ruby/internal/fl_type.h:828:22: warning: unused parameter ‘obj’ [-Wunused-parameter]
  828 | RB_OBJ_TAINTED(VALUE obj)
      |                ~~~~~~^~~
/usr/include/ruby-3.1.0/ruby/internal/fl_type.h: In function ‘RB_OBJ_TAINT_RAW’:
/usr/include/ruby-3.1.0/ruby/internal/fl_type.h:843:24: warning: unused parameter ‘obj’ [-Wunused-parameter]
  843 | RB_OBJ_TAINT_RAW(VALUE obj)
      |                  ~~~~~~^~~
/usr/include/ruby-3.1.0/ruby/internal/fl_type.h: In function ‘RB_OBJ_TAINT’:
/usr/include/ruby-3.1.0/ruby/internal/fl_type.h:858:20: warning: unused parameter ‘obj’ [-Wunused-parameter]
  858 | RB_OBJ_TAINT(VALUE obj)
      |              ~~~~~~^~~
/usr/include/ruby-3.1.0/ruby/internal/fl_type.h: In function ‘RB_OBJ_INFECT_RAW’:
/usr/include/ruby-3.1.0/ruby/internal/fl_type.h:874:25: warning: unused parameter ‘dst’ [-Wunused-parameter]
  874 | RB_OBJ_INFECT_RAW(VALUE dst, VALUE src)
      |                   ~~~~~~^~~
/usr/include/ruby-3.1.0/ruby/internal/fl_type.h:874:36: warning: unused parameter ‘src’ [-Wunused-parameter]
  874 | RB_OBJ_INFECT_RAW(VALUE dst, VALUE src)
      |                              ~~~~~~^~~
/usr/include/ruby-3.1.0/ruby/internal/fl_type.h: In function ‘RB_OBJ_INFECT’:
/usr/include/ruby-3.1.0/ruby/internal/fl_type.h:890:21: warning: unused parameter ‘dst’ [-Wunused-parameter]
  890 | RB_OBJ_INFECT(VALUE dst, VALUE src)
      |               ~~~~~~^~~
/usr/include/ruby-3.1.0/ruby/internal/fl_type.h:890:32: warning: unused parameter ‘src’ [-Wunused-parameter]
  890 | RB_OBJ_INFECT(VALUE dst, VALUE src)
      |                          ~~~~~~^~~
In file included from /usr/include/ruby-3.1.0/ruby/ruby.h:44:
/usr/include/ruby-3.1.0/ruby/internal/newobj.h: In function ‘rb_clone_setup’:
/usr/include/ruby-3.1.0/ruby/internal/newobj.h:173:22: warning: unused parameter ‘clone’ [-Wunused-parameter]
  173 | rb_clone_setup(VALUE clone, VALUE obj)
      |                ~~~~~~^~~~~
/usr/include/ruby-3.1.0/ruby/internal/newobj.h:173:35: warning: unused parameter ‘obj’ [-Wunused-parameter]
  173 | rb_clone_setup(VALUE clone, VALUE obj)
      |                             ~~~~~~^~~
/usr/include/ruby-3.1.0/ruby/internal/newobj.h: In function ‘rb_dup_setup’:
/usr/include/ruby-3.1.0/ruby/internal/newobj.h:190:20: warning: unused parameter ‘dup’ [-Wunused-parameter]
  190 | rb_dup_setup(VALUE dup, VALUE obj)
      |              ~~~~~~^~~
/usr/include/ruby-3.1.0/ruby/internal/newobj.h:190:31: warning: unused parameter ‘obj’ [-Wunused-parameter]
  190 | rb_dup_setup(VALUE dup, VALUE obj)
      |                         ~~~~~~^~~
```

## Expected result

No warnings at all.

## Additional info

This was caused by commit 0300dec32b5a25b409dc5dfa59b81f4e39fab501 and affects versions 3.1.0 and above.

The fix has been tested with gcc and clang versions on Debian unstable:

```
$ gcc --version
gcc (Debian 12.2.0-13) 12.2.0
Copyright (C) 2022 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

$ clang --version
Debian clang version 14.0.6
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
```

The fix has **NOT** been tested with Ruby version > 3.1.0; other functions may be affected by the similar warning in newer releases (I did not fully check).