### PR TITLE
Disable chained fixups on macOS to fix M1 build errors with C extensions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3102,9 +3102,16 @@ AS_IF([test "$rb_cv_dlopen" = yes], [
     AS_CASE(["$target_os"],
     [darwin*], [
         AC_SUBST(ADDITIONAL_DLDFLAGS, "")
+        # Xcode 14+ will warn if -undefined dynamic_lookup is used without disabling chained fixups.
+        # Older linkers may not support the -no_fixup_chains flag.
+        dynamic_lookup_flag="-undefined dynamic_lookup"
+        flag="-no_fixup_chains"
+        test "x${linker_flag}" = x || flag="${linker_flag}`echo ${flag} | tr ' ' ,`"
+        RUBY_TRY_LDFLAGS([$flag], [dynamic_lookup_flag="-no_fixup_chains $dynamic_lookup_flag"])
+
 	for flag in \
 	  "-multiply_defined suppress" \
-	  "-undefined dynamic_lookup" \
+	  "$dynamic_lookup_flag" \
 	  ; do
             test "x${linker_flag}" = x || flag="${linker_flag}`echo ${flag} | tr ' ' ,`"
             RUBY_TRY_LDFLAGS([$flag], [], [flag=])


### PR DESCRIPTION
With XCode 14, building with `-undefined dynamic_lookup` results in this warning message:

```
ld: warning: -undefined dynamic_lookup may not work with chained fixups
```

This warning causes the `configure` script to believe that `-undefined dynamic_lookup` is not available on the system since stderr is not empty. However, omitting this flag breaks some gems with C extensions that are not ready for this change.

Relates to https://bugs.ruby-lang.org/issues/19005