### PR TITLE
YJIT: Fix a compilation warning with release build

### DIFF
--- a/yjit/src/asm/mod.rs
+++ b/yjit/src/asm/mod.rs
@@ -356,12 +356,15 @@ impl CodeBlock {
         self.asm_comments.get(&pos)
     }
 
+    #[cfg(feature = "disasm")]
     pub fn remove_comments(&mut self, start_addr: CodePtr, end_addr: CodePtr) {
-        #[cfg(feature = "disasm")]
         for addr in start_addr.into_usize()..end_addr.into_usize() {
             self.asm_comments.remove(&addr);
         }
     }
+    #[cfg(not(feature = "disasm"))]
+    #[inline]
+    pub fn remove_comments(&mut self, _: CodePtr, _: CodePtr) {}
 
     pub fn clear_comments(&mut self) {
         #[cfg(feature = "disasm")]


### PR DESCRIPTION
```
warning: unused variable: `start_addr`
   --> ../yjit/src/asm/mod.rs:359:39
    |
359 |     pub fn remove_comments(&mut self, start_addr: CodePtr, end_addr: CodePtr) {
    |                                       ^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_start_addr`
    |
    = note: `#[warn(unused_variables)]` on by default

warning: unused variable: `end_addr`
   --> ../yjit/src/asm/mod.rs:359:60
    |
359 |     pub fn remove_comments(&mut self, start_addr: CodePtr, end_addr: CodePtr) {
    |
```