### PR TITLE
Remove check for RCLASS_EXT in variable.c

### DIFF
--- a/variable.c
+++ b/variable.c
@@ -112,7 +112,6 @@ static VALUE
 classname(VALUE klass, int *permanent)
 {
     *permanent = 0;
-    if (!RCLASS_EXT(klass)) return Qnil;
 
     VALUE classpathv = rb_ivar_lookup(klass, classpath, Qnil);
     if (RTEST(classpathv)) {


### PR DESCRIPTION
A class/module should always have a RCLASS_EXT, so we shouldn't need to check that it exists.