### PR TITLE
Move classpath to rb_classext_t 

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -7259,6 +7259,8 @@ gc_mark_children(rb_objspace_t *objspace, VALUE obj)
             gc_mark(objspace, RCLASS_IVPTR(obj)[i]);
         }
         mark_const_tbl(objspace, RCLASS_CONST_TBL(obj));
+
+        gc_mark(objspace, RCLASS_EXT(obj)->classpath);
         break;
 
       case T_ICLASS:
@@ -10559,6 +10561,8 @@ gc_update_object_references(rb_objspace_t *objspace, VALUE obj)
 
         update_class_ext(objspace, RCLASS_EXT(obj));
         update_const_tbl(objspace, RCLASS_CONST_TBL(obj));
+
+        UPDATE_IF_MOVED(objspace, RCLASS_EXT(obj)->classpath);
         break;
 
       case T_ICLASS:

--- a/internal/class.h
+++ b/internal/class.h
@@ -59,6 +59,8 @@ struct rb_classext_struct {
 #endif
     uint32_t max_iv_count;
     unsigned char variation_count;
+    bool permanent_classpath;
+    VALUE classpath;
 };
 typedef struct rb_classext_struct rb_classext_t;
 
@@ -73,8 +75,10 @@ struct RClass {
 #endif
 };
 
-typedef struct rb_subclass_entry rb_subclass_entry_t;
-typedef struct rb_classext_struct rb_classext_t;
+#if RCLASS_EXT_EMBEDDED
+// Assert that classes can be embedded in size_pools[2] (which has 160B slot size)
+STATIC_ASSERT(sizeof_rb_classext_t, sizeof(struct RClass) + sizeof(rb_classext_t) <= 4 * RVALUE_SIZE);
+#endif
 
 #if RCLASS_EXT_EMBEDDED
 #  define RCLASS_EXT(c) ((rb_classext_t *)((char *)(c) + sizeof(struct RClass)))
@@ -182,6 +186,16 @@ RCLASS_SET_SUPER(VALUE klass, VALUE super)
     RB_OBJ_WRITE(klass, &RCLASS(klass)->super, super);
     rb_class_update_superclasses(klass);
     return super;
+}
+
+static inline void
+RCLASS_SET_CLASSPATH(VALUE klass, VALUE classpath, bool permanent)
+{
+    assert(BUILTIN_TYPE(klass) == T_CLASS || BUILTIN_TYPE(klass) == T_MODULE);
+    assert(classpath == 0 || BUILTIN_TYPE(classpath) == T_STRING);
+
+    RB_OBJ_WRITE(klass, &(RCLASS_EXT(klass)->classpath), classpath);
+    RCLASS_EXT(klass)->permanent_classpath = permanent;
 }
 
 #endif /* INTERNAL_CLASS_H */

--- a/internal/class.h
+++ b/internal/class.h
@@ -11,6 +11,7 @@
 #include "id_table.h"           /* for struct rb_id_table */
 #include "internal/gc.h"        /* for RB_OBJ_WRITE */
 #include "internal/serial.h"    /* for rb_serial_t */
+#include "internal/static_assert.h"
 #include "ruby/internal/stdbool.h"     /* for bool */
 #include "ruby/intern.h"        /* for rb_alloc_func_t */
 #include "ruby/ruby.h"          /* for struct RBasic */
@@ -25,6 +26,7 @@ struct rb_subclass_entry {
     struct rb_subclass_entry *next;
     struct rb_subclass_entry *prev;
 };
+typedef struct rb_subclass_entry rb_subclass_entry_t;
 
 struct rb_cvar_class_tbl_entry {
     uint32_t index;
@@ -52,12 +54,15 @@ struct rb_classext_struct {
     const VALUE refined_class;
     rb_alloc_func_t allocator;
     const VALUE includer;
-    uint32_t max_iv_count;
-    uint32_t variation_count;
 #if !SHAPE_IN_BASIC_FLAGS
     shape_id_t shape_id;
 #endif
+    uint32_t max_iv_count;
+    unsigned char variation_count;
 };
+typedef struct rb_classext_struct rb_classext_t;
+
+STATIC_ASSERT(shape_max_variations, SHAPE_MAX_VARIATIONS < (1 << (sizeof(((rb_classext_t *)0)->variation_count) * CHAR_BIT)));
 
 struct RClass {
     struct RBasic basic;

--- a/spec/ruby/optional/capi/object_spec.rb
+++ b/spec/ruby/optional/capi/object_spec.rb
@@ -993,13 +993,19 @@ describe "CApiObject" do
       end
 
       it "calls the callback function for each cvar and ivar on a class" do
+        exp = [:@@cvar, :foo, :@@cvar2, :bar, :@ivar, :baz]
+        exp.unshift(:__classpath__, 'CApiObjectSpecs::CVars') if RUBY_VERSION < "3.3"
+
         ary = @o.rb_ivar_foreach(CApiObjectSpecs::CVars)
-        ary.should == [:__classpath__, 'CApiObjectSpecs::CVars', :@@cvar, :foo, :@@cvar2, :bar, :@ivar, :baz]
+        ary.should == exp
       end
 
       it "calls the callback function for each cvar and ivar on a module" do
+        exp = [:@@mvar, :foo, :@@mvar2, :bar, :@ivar, :baz]
+        exp.unshift(:__classpath__, 'CApiObjectSpecs::MVars') if RUBY_VERSION < "3.3"
+
         ary = @o.rb_ivar_foreach(CApiObjectSpecs::MVars)
-        ary.should == [:__classpath__, 'CApiObjectSpecs::MVars', :@@mvar, :foo, :@@mvar2, :bar, :@ivar, :baz]
+        ary.should == exp
       end
 
     end


### PR DESCRIPTION
This commit moves the classpath (and tmp_classpath) from instance variables to the rb_classext_t. This improves performance as we no longer need to set an instance variable when assigning a classpath to a class.

I benchmarked with the following script:

```ruby
name = :MyClass

puts(Benchmark.measure do
  10_000_000.times do |i|
    Object.const_set(name, Class.new)
    Object.send(:remove_const, name)
  end
end)
```

Before this patch:

```
  5.440119   0.025264   5.465383 (  5.467105)
```

After this patch:

```
  4.889646   0.028325   4.917971 (  4.942678)
```