### PR TITLE
YJIT: Inline basic Ruby methods

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -3456,3 +3456,30 @@ assert_equal 'ok', %q{
 
   cw(4)
 }
+
+# inlined method calls
+assert_equal 'nil', %q{
+  def inlined = nil
+  def foo = inlined
+  foo.inspect
+}
+assert_equal '1', %q{
+  def inlined = 1
+  def foo = inlined
+  foo
+}
+assert_equal '1', %q{
+  def inlined(_unused_arg1) = 1
+  def foo = inlined(nil)
+  foo
+}
+assert_equal 'main', %q{
+  def inlined = self
+  def foo = inlined
+  foo
+}
+assert_equal 'main', %q{
+  def inlined(_unused_arg) = self
+  def foo = inlined(nil)
+  foo
+}

--- a/yjit.rb
+++ b/yjit.rb
@@ -262,6 +262,7 @@ module RubyVM::YJIT
       $stderr.puts "compiled_iseq_count:   " + ("%10d" % stats[:compiled_iseq_count])
       $stderr.puts "compiled_block_count:  " + ("%10d" % stats[:compiled_block_count])
       $stderr.puts "compiled_branch_count: " + ("%10d" % stats[:compiled_branch_count])
+      $stderr.puts "inlined_block_count:   " + ("%10d" % stats[:inlined_block_count])
       $stderr.puts "block_next_count:      " + ("%10d" % stats[:block_next_count])
       $stderr.puts "defer_count:           " + ("%10d" % stats[:defer_count])
       $stderr.puts "freed_iseq_count:      " + ("%10d" % stats[:freed_iseq_count])

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -5178,7 +5178,9 @@ fn gen_send_iseq(
 
     // Inline ISEQ if possible. Captured operands are not supported yet, which require ep.
     let inline_method = captured_opnd.is_none() && can_inline_iseq(iseq);
-    incr_counter!(inlined_block_count);
+    if inline_method {
+        incr_counter!(inlined_block_count);
+    }
 
     if !inline_method {
         // Check for interrupts

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -278,6 +278,7 @@ make_counters! {
     compiled_iseq_count,
     compiled_block_count,
     compiled_branch_count,
+    inlined_block_count,
     compilation_failure,
     block_next_count,
     defer_count,


### PR DESCRIPTION
## Changes
This PR inlines method calls of ISEQs that have only: `putnil`, `putobject`, `putself`, or `leave`.

## Background
Sometimes such simple methods are called. `Symbol#to_sym` is one of such examples, which consists of 1% of all Ruby calls in railsbench https://github.com/Shopify/yjit-bench/pull/163. Such small ISEQs are faster in Ruby than in C on the interpreter, so we generally rewrite them to Ruby https://github.com/ruby/ruby/pull/6683 (more examples are in `ruby/ruby/*.rb`). Unlike MJIT, YJIT currently doesn't have a way to inline such Ruby methods, and this PR implements that.

Another way to implement this would be to convert such Ruby methods to C and use cfunc specialized codegen. But the downside is that it would slow down the interpreter and we can't do that for methods defined in the Rails side, such as `Object#html_safe?` and `Object#present?`.

## Design
* `putnil`, `putobject`, `putself`, or `leave` are the targets because:
  * They never side-exist (besides check ints on leave) and they're "leaf" (i.e. they don't call arbitrary methods).
  * We could include some other insns as well, but I assume most methods using such insns would involve other insns that may side-exit.
* On `opt_send_without_block`, jump to the callee block while keeping the receiver and the arguments on the stack.
  * The receiver is kept for `putself`. We could eliminate a few instructions if we write the return value there if `putself` is not used, but I made the implementation simple, assuming the benefit of that optimization would be trivial.
  * Arguments are kept on the stack so that we could use them for `getlocal_WC_0` later. Out of scope in this PR.
* The callee jumps back to the caller. Normally, both jumps are optimized away by patching on `gen_direct_jmp`.
* Always inline such ISEQs since they're fairly small. Ignore such inlined contexts from the versioning limit.

## Example
```rb
def symbol(sym)
  sym.to_sym
end
symbol(:sym)
```

### Before
<details>

```asm
  # ...
  # Block: symbol@/home/k0kubun/tmp/a.rb:2 (ISEQ offset: 0)
  # Insn: getlocal_WC_0
  0x5575c4639059: mov rax, qword ptr [r13 + 0x20]
  0x5575c463905d: mov rax, qword ptr [rax - 0x18]
  0x5575c4639061: mov qword ptr [rbx], rax
  # regenerate_branch
  # Block: symbol@/home/k0kubun/tmp/a.rb:2 (ISEQ offset: 2)
  # Insn: opt_send_without_block
  # guard object is static symbol
  0x5575c4639064: cmp byte ptr [rbx], 0xc
  0x5575c4639067: jne 0x5575c463b072
  # RUBY_VM_CHECK_INTS(ec)
  0x5575c463906d: mov eax, dword ptr [r12 + 0x20]
  0x5575c4639072: test eax, eax
  0x5575c4639074: jne 0x5575c463b051
  # stack overflow check
  0x5575c463907a: lea rax, [rbx + 0x90]
  0x5575c4639081: cmp r13, rax
  0x5575c4639084: jbe 0x5575c463b051
  # store caller sp
  0x5575c463908a: lea rax, [rbx]
  0x5575c463908d: mov qword ptr [r13 + 8], rax
  # save PC to CFP
  0x5575c4639091: movabs rax, 0x5575c428cec0
  0x5575c463909b: mov qword ptr [r13], rax
  0x5575c463909f: lea rax, [rbx + 0x20]
  # push cme, specval, frame type
  0x5575c46390a3: movabs rcx, 0x7f42c162abe0
  0x5575c46390ad: mov qword ptr [rax - 0x18], rcx
  0x5575c46390b1: mov qword ptr [rax - 0x10], 0
  0x5575c46390b9: mov qword ptr [rax - 8], 0x11110003
  # push callee control frame
  0x5575c46390c1: mov qword ptr [r13 - 0x10], rax
  0x5575c46390c5: mov qword ptr [r13 - 0x38], rax
  0x5575c46390c9: movabs rcx, 0x7f42c162aca0
  0x5575c46390d3: mov qword ptr [r13 - 0x30], rcx
  0x5575c46390d7: mov rcx, qword ptr [rbx]
  0x5575c46390da: mov qword ptr [r13 - 0x28], rcx
  0x5575c46390de: mov qword ptr [r13 - 0x18], 0
  0x5575c46390e6: mov rbx, rax
  0x5575c46390e9: sub rax, 8
  0x5575c46390ed: mov qword ptr [r13 - 0x20], rax
  # switch to new CFP
  0x5575c46390f1: lea rax, [r13 - 0x40]
  0x5575c46390f5: mov r13, rax
  0x5575c46390f8: mov qword ptr [r12 + 0x10], r13
  # regenerate_branch
  # update cfp->jit_return
  0x5575c46390fd: movabs rax, 0x5575c463913c
  0x5575c4639107: mov qword ptr [r13 + 0x38], rax
  # gen_direct_jmp: fallthrough
  # Block: to_sym@<internal:symbol>:11 (ISEQ offset: 0)
  # Insn: putself
  0x5575c463910b: mov rax, qword ptr [r13 + 0x18]
  0x5575c463910f: mov qword ptr [rbx], rax
  # Insn: leave
  # RUBY_VM_CHECK_INTS(ec)
  0x5575c4639112: mov eax, dword ptr [r12 + 0x20]
  0x5575c4639117: test eax, eax
  0x5575c4639119: jne 0x5575c463b09a
  # pop stack frame
  0x5575c463911f: mov rax, r13
  0x5575c4639122: add rax, 0x40
  0x5575c4639126: mov r13, rax
  0x5575c4639129: mov qword ptr [r12 + 0x10], r13
  0x5575c463912e: mov rax, qword ptr [rbx]
  0x5575c4639131: mov rbx, qword ptr [r13 + 8]
  0x5575c4639135: mov qword ptr [rbx], rax
  0x5575c4639138: jmp qword ptr [r13 - 8]
  # Block: symbol@/home/k0kubun/tmp/a.rb:3 (ISEQ offset: 4)
  # Insn: leave
  # RUBY_VM_CHECK_INTS(ec)
  0x5575c463913c: mov eax, dword ptr [r12 + 0x20]
  # ...
```

</details>

### After
<details>

```asm
  # ...
  # Block: symbol@/home/k0kubun/tmp/a.rb:2 (ISEQ offset: 0)
  # Insn: getlocal_WC_0
  0x5627b8cf3059: mov rax, qword ptr [r13 + 0x20]
  0x5627b8cf305d: mov rax, qword ptr [rax - 0x18]
  0x5627b8cf3061: mov qword ptr [rbx], rax
  # regenerate_branch
  # Block: symbol@/home/k0kubun/tmp/a.rb:2 (ISEQ offset: 2)
  # Insn: opt_send_without_block
  # guard object is static symbol
  0x5627b8cf3064: cmp byte ptr [rbx], 0xc
  0x5627b8cf3067: jne 0x5627b8cf5072
  # gen_direct_jmp: fallthrough
  # Block: to_sym@<internal:symbol>:11 (ISEQ offset: 0)
  # Insn: putself
  0x5627b8cf306d: mov rax, qword ptr [rbx]
  0x5627b8cf3070: mov qword ptr [rbx + 8], rax
  # Insn: leave
  0x5627b8cf3074: mov rax, qword ptr [rbx + 8]
  0x5627b8cf3078: mov qword ptr [rbx], rax
  # jump to inlining caller
  # gen_direct_jmp: fallthrough
  # Block: symbol@/home/k0kubun/tmp/a.rb:3 (ISEQ offset: 4)
  # Insn: leave
  # RUBY_VM_CHECK_INTS(ec)
  0x5627b8cf307b: mov eax, dword ptr [r12 + 0x20]
  # ...
```

</details>

## Benchmark
### microbenchmark
```yml
prelude: |
  def inlined = nil
  def bench = inlined
  bench
benchmark: bench
```

```
$ benchmark-driver -v --chruby 'before::before --yjit-call-threshold=1' --chruby 'after::after --yjit-call-threshold=1' /tmp/a.yml
before: ruby 3.3.0dev (2023-01-10T16:11:10Z master aeddc19340) +YJIT [x86_64-linux]
after: ruby 3.3.0dev (2023-01-10T22:00:18Z yjit-inline-method 80865eb089) +YJIT [x86_64-linux]
Warming up --------------------------------------
               bench    39.937M i/s -     40.052M times in 1.002889s (25.04ns/i, 55clocks/i)
Calculating -------------------------------------
                         before       after
               bench    50.615M     59.804M i/s -    119.811M times in 2.367111s 2.003390s

Comparison:
                            bench
               after:  59804022.4 i/s
              before:  50614759.9 i/s - 1.18x  slower
```

### railsbench
It unfortunately doesn't make a significant impact overall:

```
before: ruby 3.3.0dev (2023-01-10T16:11:10Z master aeddc19340) +YJIT [x86_64-linux]
after: ruby 3.3.0dev (2023-01-10T22:00:18Z yjit-inline-method 80865eb089) +YJIT [x86_64-linux]

----------  -----------  ----------  ----------  ----------  ------------  -------------
bench       before (ms)  stddev (%)  after (ms)  stddev (%)  before/after  after 1st itr
railsbench  1037.1       0.8         1033.2      0.2         1.00          1.00
----------  -----------  ----------  ----------  ----------  ------------  -------------
```

So merging this alone isn't really useful. I'm okay even if we decide to not merge this yet. However, I assume that part of this implementation could be useful when we support more complicated ISEQs. If so, we could incrementally work on it from here.

## Stats
`run_once.sh` on railsbench with --yjit-stats:

### Before
```
compiled_iseq_count:         2189
compiled_block_count:       20143
compiled_branch_count:      35198

inline_code_size:         2029628
outlined_code_size:       2027410
freed_code_size:                0
code_region_size:         4063232

ratio_in_yjit:              91.7%
```

### After
```
compiled_iseq_count:         2189
compiled_block_count:       20232
compiled_branch_count:      35216
inlined_block_count:         2552

inline_code_size:         2019186
outlined_code_size:       2017520
freed_code_size:                0
code_region_size:         4042752

ratio_in_yjit:              91.7%
```