### PR TITLE
[DOC] Add an example of the splat operator with a non-array object

### DIFF
--- a/doc/syntax/assignment.rdoc
+++ b/doc/syntax/assignment.rdoc
@@ -403,6 +403,10 @@ assigning.  This is similar to multiple assignment:
 
   p a # prints [1, 2, 3]
 
+  b = *1
+
+  p b # prints [1]
+
 You can splat anywhere in the right-hand side of the assignment:
 
   a = 1, *[2, 3]


### PR DESCRIPTION
On assignment, we can use the splat operator with a non-array object.
This behavior seems not to be documented. So I think an example should be added.
