### PR TITLE
Suppressing pending messages with RSpec

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1469,8 +1469,8 @@ SYNTAX_SUGGEST_SPECS =
 PREPARE_SYNTAX_SUGGEST = test-syntax-suggest-prepare
 test-syntax-suggest: $(TEST_RUNNABLE)-test-syntax-suggest
 yes-test-syntax-suggest: yes-$(PREPARE_SYNTAX_SUGGEST)
-	$(XRUBY) -C $(srcdir) -Ispec/syntax_suggest .bundle/bin/rspec \
-		--require spec_helper $(RSPECOPTS) spec/syntax_suggest/$(SYNTAX_SUGGEST_SPECS)
+	$(XRUBY) -C $(srcdir) -Ispec/syntax_suggest:spec/lib .bundle/bin/rspec \
+		--require spec_helper --require formatter_overrides $(RSPECOPTS) spec/syntax_suggest/$(SYNTAX_SUGGEST_SPECS)
 no-test-syntax-suggest:
 
 check: $(DOT_WAIT) $(TEST_RUNNABLE)-$(PREPARE_SYNTAX_SUGGEST) test-syntax-suggest
@@ -1498,8 +1498,8 @@ yes-test-bundler: $(PREPARE_BUNDLER)
 	$(gnumake_recursive)$(XRUBY) \
 		-r./$(arch)-fake \
 		-e "exec(*ARGV)" -- \
-		$(XRUBY) -C $(srcdir) -Ispec/bundler .bundle/bin/rspec \
-		--require spec_helper $(RSPECOPTS) spec/bundler/$(BUNDLER_SPECS)
+		$(XRUBY) -C $(srcdir) -Ispec/bundler:spec/lib .bundle/bin/rspec \
+		--require spec_helper --require formatter_overrides $(RSPECOPTS) spec/bundler/$(BUNDLER_SPECS)
 no-test-bundler:
 
 PARALLELRSPECOPTS = --runtime-log $(srcdir)/tmp/parallel_runtime_rspec.log
@@ -1512,9 +1512,9 @@ yes-test-bundler-parallel: $(PREPARE_BUNDLER)
 		$(XRUBY) -I$(srcdir)/spec/bundler \
 		-e "ENV['PARALLEL_TESTS_EXECUTABLE'] = ARGV.shift" \
 		-e "load ARGV.shift" \
-		"$(XRUBY) -C $(srcdir) -Ispec/bundler .bundle/bin/rspec" \
+		"$(XRUBY) -C $(srcdir) -Ispec/bundler:spec/lib .bundle/bin/rspec" \
 		$(srcdir)/.bundle/bin/parallel_rspec \
-		-o "--require spec_helper" \
+		-o "--require spec_helper --require formatter_overrides" \
 		$(PARALLELRSPECOPTS) $(srcdir)/spec/bundler/$(BUNDLER_SPECS)
 no-test-bundler-parallel:
 

--- a/spec/lib/formatter_overrides.rb
+++ b/spec/lib/formatter_overrides.rb
@@ -1,0 +1,6 @@
+module FormatterOverrides
+  def example_pending(_); end
+  def dump_pending(_); end
+end
+
+RSpec::Core::Formatters::ProgressFormatter.prepend FormatterOverrides


### PR DESCRIPTION
Before:

```
(snip)
Finished in 5 minutes 12 seconds (files took 0.27403 seconds to load)
198 examples, 0 failures

.....*........................................................

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) bundle exec with default gems when not specified in Gemfile uses version provided by ruby
     # irb isn't a default gem
     # ./spec/bundler/commands/exec_spec.rb:223

  2) bundle exec with default gems when specified in Gemfile directly uses version specified
     # irb isn't a default gem
     # ./spec/bundler/commands/exec_spec.rb:248

  3) bundle exec with default gems when specified in Gemfile indirectly uses resolved version
     # irb isn't a default gem
     # ./spec/bundler/commands/exec_spec.rb:280

  4) bundle exec `load`ing a ruby file instead of `exec`ing regarding $0 and __FILE__ when the path is relative with a leading ./ relative paths with ./ have absolute __FILE__
     # Not yet implemented
     # ./spec/bundler/commands/exec_spec.rb:984

  5) bundle exec nested bundle exec with a system gem that shadows a default gem only leaves the default gem in the stdlib available
     # openssl isn't a default gem
     # ./spec/bundler/commands/exec_spec.rb:1165


Finished in 5 minutes 21 seconds (files took 0.32771 seconds to load)
351 examples, 0 failures, 5 pending

............

Finished in 5 minutes 23 seconds (files took 0.35749 seconds to load)
249 examples, 0 failures
(snip)
```

After:

```
(snip)
Finished in 4 minutes 40.7 seconds (files took 0.31219 seconds to load)
280 examples, 0 failures

.............................................................................................

Finished in 4 minutes 51.8 seconds (files took 0.31548 seconds to load)
305 examples, 0 failures

......

Finished in 5 minutes 11 seconds (files took 0.34363 seconds to load)
294 examples, 0 failures

...............................................................................................

Finished in 5 minutes 27 seconds (files took 0.34284 seconds to load)
351 examples, 0 failures, 5 pending

..........................................................................................................................................................................................................

Finished in 6 minutes 16 seconds (files took 0.29954 seconds to load)
275 examples, 0 failures
(snip)
```