### PR TITLE
YJIT: Add a few asm comments

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -387,7 +387,8 @@ fn gen_code_for_exit_from_stub(ocb: &mut OutlinedCb) -> CodePtr {
 
 /// Generate an exit to return to the interpreter
 fn gen_exit(exit_pc: *mut VALUE, ctx: &Context, asm: &mut Assembler) {
-    if cfg!(feature = "disasm") {
+    #[cfg(all(feature = "disasm", not(test)))]
+    {
         let opcode = unsafe { rb_vm_insn_addr2opcode((*exit_pc).as_ptr()) };
         asm.comment(&format!("exit to interpreter on {}", insn_name(opcode as usize)));
     }

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -769,7 +769,7 @@ pub fn gen_single_block(
             gen_counter_incr!(asm, exec_instruction);
 
             // Add a comment for the name of the YARV instruction
-            asm.comment(&insn_name(opcode));
+            asm.comment(&format!("Insn: {}", insn_name(opcode)));
 
             // If requested, dump instructions for debugging
             if get_option!(dump_insns) {
@@ -4774,6 +4774,7 @@ fn gen_return_branch(
     match shape {
         BranchShape::Next0 | BranchShape::Next1 => unreachable!(),
         BranchShape::Default => {
+            asm.comment("update cfp->jit_return");
             asm.mov(Opnd::mem(64, CFP, RUBY_OFFSET_CFP_JIT_RETURN), Opnd::const_ptr(target0.raw_ptr()));
         }
     }

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -387,7 +387,10 @@ fn gen_code_for_exit_from_stub(ocb: &mut OutlinedCb) -> CodePtr {
 
 /// Generate an exit to return to the interpreter
 fn gen_exit(exit_pc: *mut VALUE, ctx: &Context, asm: &mut Assembler) {
-    asm.comment("exit to interpreter");
+    if cfg!(feature = "disasm") {
+        let opcode = unsafe { rb_vm_insn_addr2opcode((*exit_pc).as_ptr()) };
+        asm.comment(&format!("exit to interpreter on {}", insn_name(opcode as usize)));
+    }
 
     // Generate the code to exit to the interpreters
     // Write the adjusted SP back into the CFP

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -2114,6 +2114,7 @@ pub fn defer_compilation(
     set_branch_target(0, blockid, &next_ctx, &branch_rc, &mut branch, ocb);
 
     // Call the branch generation function
+    asm.comment("defer_compilation");
     asm.mark_branch_start(&branch_rc);
     if let Some(dst_addr) = branch.get_target_address(0) {
         gen_jump_branch(asm, dst_addr, None, BranchShape::Default);


### PR DESCRIPTION
I carved out a few asm comments from https://github.com/ruby/ruby/pull/7097 that I found helpful when developing that branch.

* Prefix instruction names with `Insn:` so that it will stand out more than random comments for that insn.
  * I'm intentionally not choosing `Instruction:` to make it look less significant / shorter than `Block:`.
* Add `defer_compilation` and `update cfp->jit_return`, which weren't obvious from the current disasm.