### PR TITLE
Assert possible hash functions in RHASH_ST_TABLE

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -2110,6 +2110,10 @@ hash_stlike_lookup(VALUE hash, st_data_t key, st_data_t *pval)
         return ar_lookup(hash, key, pval);
     }
     else {
+        extern st_index_t rb_iseq_cdhash_hash(VALUE);
+        RUBY_ASSERT(RHASH_ST_TABLE(hash)->type->hash == rb_any_hash ||
+                    RHASH_ST_TABLE(hash)->type->hash == rb_ident_hash ||
+                    RHASH_ST_TABLE(hash)->type->hash == rb_iseq_cdhash_hash);
         return st_lookup(RHASH_ST_TABLE(hash), key, pval);
     }
 }


### PR DESCRIPTION
Because of the function pointer, it's hard to figure out what hash functions could be used in Hash objects when st_lookup is used.

Having this assertion makes it easier to understand what hash_stlike_lookup could possibly do. (AR uses only rb_any_hash)

For example, this clarifies that hash_stlike_lookup never calls a #hash method when a key is T_STRING or T_SYMBOL.