### PR TITLE
YJIT: Do not refer to an undefined constant

### DIFF
--- a/yjit.rb
+++ b/yjit.rb
@@ -195,14 +195,11 @@ module RubyVM::YJIT
 
   # Produce a list of instructions compiled by YJIT for an iseq
   def self.insns_compiled(iseq)
+    return nil unless self.enabled?
+
     # If a method or proc is passed in, get its iseq
     iseq = RubyVM::InstructionSequence.of(iseq)
-
-    if self.enabled?
-      Primitive.rb_yjit_insns_compiled(iseq)
-    else
-      Qnil
-    end
+    Primitive.rb_yjit_insns_compiled(iseq)
   end
 
   # Free and recompile all existing JIT code


### PR DESCRIPTION
`Qnil` is not defined under `RubyVM::YJIT`. It was introduced in https://github.com/ruby/ruby/commit/f90549cd38518231a6a74432fe1168c943a7cc18, but it seems not intentional. I guess you didn't mean `Fiddle::Qnil` either. You probably wanted to do `Primitive.cexpr! 'Qnil'`, but `nil` is enough if that's the case.