### PR TITLE
Fix write barrier order for `klass` to `cme` edge

### DIFF
--- a/vm_eval.c
+++ b/vm_eval.c
@@ -396,8 +396,7 @@ cc_new(VALUE klass, ID mid, int argc, const rb_callable_method_entry_t *cme)
             ccs = (struct rb_class_cc_entries *)ccs_data;
         }
         else {
-            ccs = vm_ccs_create(klass, cme);
-            rb_id_table_insert(cc_tbl, mid, (VALUE)ccs);
+            ccs = vm_ccs_create(klass, cc_tbl, mid, cme);
         }
 
         for (int i=0; i<ccs->len; i++) {

--- a/vm_method.c
+++ b/vm_method.c
@@ -1330,8 +1330,7 @@ cache_callable_method_entry(VALUE klass, ID mid, const rb_callable_method_entry_
         VM_ASSERT(ccs->cme == cme);
     }
     else {
-        ccs = vm_ccs_create(klass, cme);
-        rb_id_table_insert(cc_tbl, mid, (VALUE)ccs);
+        ccs = vm_ccs_create(klass, cc_tbl, mid, cme);
     }
 }
 


### PR DESCRIPTION
Previously, the following crashes with
`CFLAGS=-DRGENGC_CHECK_MODE=2 -DRUBY_DEBUG=1 -fno-inline`:

    $ ./miniruby -e 'GC.stress = true; Marshal.dump({})'

It crashes with a write barrier (WB) miss assertion on an edge from the
`Hash` class object to a newly allocated negative method entry.

This is due to usages of vm_ccs_create() running the WB too early,
before the method entry is inserted into the cc table, so before the
reference edge is established. The insertion can trigger GC and promote
the class object, so running the WB after the insertion is necessary.
Move the insertion into vm_ccs_create() and run the WB after the
insertion.

Discovered on CI:
http://ci.rvm.jp/results/trunk-asserts@ruby-sp2-docker/4391770
