### PR TITLE
Fixup #7108 633fde41527bb000cd incorrect rbs version

### DIFF
--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -17,6 +17,6 @@ net-pop         0.1.2   https://github.com/ruby/net-pop
 net-smtp        0.3.3   https://github.com/ruby/net-smtp
 matrix          0.4.2   https://github.com/ruby/matrix
 prime           0.1.2   https://github.com/ruby/prime
-rbs             2.8.3   https://github.com/ruby/rbs eab5367add3469b3f614e663ba43a3debc62420a
+rbs             3.0.0.dev.1   https://github.com/ruby/rbs eab5367add3469b3f614e663ba43a3debc62420a
 typeprof        0.21.4  https://github.com/ruby/typeprof
 debug           1.7.1   https://github.com/ruby/debug


### PR DESCRIPTION
Current version in repo is `3.0.0.dev.1`

PR fixes `make install` failure