### PR TITLE
Fix Integer#ceildiv to respect #coerce

### DIFF
--- a/numeric.rb
+++ b/numeric.rb
@@ -278,7 +278,7 @@ class Integer
   #
   #    3.ceildiv(1.2) # => 3
   def ceildiv(other)
-    -div(-other)
+    -div(0 - other)
   end
 
   #

--- a/test/ruby/test_integer.rb
+++ b/test/ruby/test_integer.rb
@@ -725,5 +725,9 @@ class TestInteger < Test::Unit::TestCase
 
     assert_equal(10, (10**100-11).ceildiv(10**99-1))
     assert_equal(11, (10**100-9).ceildiv(10**99-1))
+
+    o = Object.new
+    def o.coerce(other); [other, 10]; end
+    assert_equal(124, 1234.ceildiv(o))
   end
 end


### PR DESCRIPTION
Since `Integer#div`, `Integer#fdiv`, etc respect `#coerce`, so should `#ceildiv`.

```Ruby
c = Object.new
def c.coerce(other) = [other, 10]

p 1234 / c          # => 123
p 1234.div(c)       # => 123
p 1234.quo(c)       # => (617/5)
p 1234.fdiv(c)      # => 123.4
p 1234.ceildiv(c)   # => in `ceildiv': undefined method `-@' for #<Object:0x000000010250ad68> (NoMethodError)
```