### PR TITLE
Make "make exts" build only gems listed in gems/bundled_gems

### DIFF
--- a/template/exts.mk.tmpl
+++ b/template/exts.mk.tmpl
@@ -26,10 +26,18 @@ macros["old_extensions"] = []
 contpat = /(?>(?>[^\\\n]|\\.)*\\\n)*(?>[^\\\n]|\\.)*/
 bundled_gems_to_build = {}
 File.foreach(File.join(__dir__, "../gems/bundled_gems")) do |line|
-  bundled_gem_name, bundled_gem_version = line.split
+  bundled_gem_name, bundled_gem_version, _, bundled_gem_rev = line.split
   next unless bundled_gem_name
   next if bundled_gem_name.start_with?("#")
   bundled_gems_to_build[bundled_gem_name + "-" + bundled_gem_version] = true
+  if bundled_gem_rev
+    ver_file = File.join(__dir__, "../gems/src/#{ bundled_gem_name }/lib/#{ bundled_gem_name }/version.rb")
+    if File.readable?(ver_file) && File.read(ver_file) =~ /VERSION\s*=\s*["'](.+?)["']/
+      bundled_gems_to_build[bundled_gem_name + "-" + $1] = true
+    else
+      warn "#$0: failed to read: #{ ver_file }"
+    end
+  end
 end
 Dir.glob("{ext,.bundle/gems}/*/exts.mk") do |e|
   gem = e.start_with?(".bundle/gems/")

--- a/template/exts.mk.tmpl
+++ b/template/exts.mk.tmpl
@@ -24,8 +24,16 @@ confexts ||= []
 macros["old_extensions"] = []
 
 contpat = /(?>(?>[^\\\n]|\\.)*\\\n)*(?>[^\\\n]|\\.)*/
+bundled_gems_to_build = {}
+File.foreach(File.join(__dir__, "../gems/bundled_gems")) do |line|
+  bundled_gem_name, bundled_gem_version = line.split
+  next unless bundled_gem_name
+  next if bundled_gem_name.start_with?("#")
+  bundled_gems_to_build[bundled_gem_name + "-" + bundled_gem_version] = true
+end
 Dir.glob("{ext,.bundle/gems}/*/exts.mk") do |e|
   gem = e.start_with?(".bundle/gems/")
+  next if gem && !bundled_gems_to_build[File.basename(File.dirname(e))]
   s = File.read(e)
   s.scan(/^(extensions|SUBMAKEOPTS|EXT[A-Z]+|MFLAGS|NOTE_[A-Z]+)[ \t]*=[ \t]*(#{contpat})$/o) do |n, v|
     v.gsub!(/\\\n[ \t]*/, ' ')


### PR DESCRIPTION
template/exts.mk.tmpl includes older directories such as debug-1.5.0, which leads to a failure of "make".

```
make[2]: ディレクトリ '/home/mame/work/ruby/.bundle/gems/debug-1.5.0/ext/debug' に入ります
make[2]: *** '../../../../../.bundle/specifications/debug-1.5.0.gemspec' に必要なターゲット '../../../../.././.bundle/gems/debug-1.5.0/.bundled.debug-1.5.0.gemspec' を make するルールがありません.  中止.
```

We should ignore older source directories in .bundle/gems. If you want to remove them, use "make outdate-bundled-gems".