### PR TITLE
[Bug #19335] `Integer#remainder` should respect `#coerce`

### DIFF
--- a/spec/ruby/core/numeric/remainder_spec.rb
+++ b/spec/ruby/core/numeric/remainder_spec.rb
@@ -6,6 +6,9 @@ describe "Numeric#remainder" do
     @obj    = NumericSpecs::Subclass.new
     @result = mock("Numeric#% result")
     @other  = mock("Passed Object")
+    ruby_version_is "3.3" do
+      @other.should_receive(:coerce).with(@obj).and_return([@obj, @other])
+    end
   end
 
   it "returns the result of calling self#% with other if self is 0" do

--- a/test/ruby/test_float.rb
+++ b/test/ruby/test_float.rb
@@ -227,6 +227,12 @@ class TestFloat < Test::Unit::TestCase
     assert_equal(-3.5, (-11.5).remainder(-4))
     assert_predicate(Float::NAN.remainder(4), :nan?)
     assert_predicate(4.remainder(Float::NAN), :nan?)
+
+    ten = Object.new
+    def ten.coerce(other)
+      [other, 10]
+    end
+    assert_equal(4, 14.0.remainder(ten))
   end
 
   def test_to_s


### PR DESCRIPTION
Also `Numeric#remainder` should.