### PR TITLE
Two YJIT aesthetic refactorings

### DIFF
--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -654,6 +654,7 @@ mod manual_defs {
 
     pub const SIZEOF_VALUE: usize = 8;
     pub const SIZEOF_VALUE_I32: i32 = SIZEOF_VALUE as i32;
+    pub const VALUE_BITS: u8 = 8 * SIZEOF_VALUE as u8;
 
     pub const RUBY_LONG_MIN: isize = std::os::raw::c_long::MIN as isize;
     pub const RUBY_LONG_MAX: isize = std::os::raw::c_long::MAX as isize;


### PR DESCRIPTION
- YJIT: Factor out VALUE_BITS = (8 * SIZE_OF_VALUE as u8)
- YJIT: Use SIZEOF_VALUE_I32 instead of `... as i32`
