### PR TITLE
Clear gem paths for each test

### DIFF
--- a/tool/lib/test/unit/parallel.rb
+++ b/tool/lib/test/unit/parallel.rb
@@ -87,6 +87,8 @@ module Test
         $stdout = orig_stdout if orig_stdout
         o.close if o && !o.closed?
         i.close if i && !i.closed?
+
+        Gem.clear_paths if defined?(Gem)
       end
 
       def run(args = []) # :nodoc:


### PR DESCRIPTION
So that rubygems can find the bundled rake.

Fixes "Skipping Gem::PackageTask tests.  rake not found." in test/rubygems/test_gem_package_task.rb file.