### PR TITLE
addr2line.c: Don't special-case DWARF 5 parsing with GCC

### DIFF
--- a/addr2line.c
+++ b/addr2line.c
@@ -1725,10 +1725,6 @@ di_read_cu(DebugInfoReader *reader)
     di_read_debug_abbrev_cu(reader);
     if (di_read_debug_line_cu(reader)) return -1;
 
-#if defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER_BUILD_DATE)
-    /* Though DWARF specifies "the applicable base address defaults to the base
-       address of the compilation unit", but GCC seems to use zero as default */
-#else
     do {
         DIE die;
 
@@ -1779,7 +1775,7 @@ di_read_cu(DebugInfoReader *reader)
                 break;
         }
     } while (0);
-#endif
+
     return 0;
 }
 


### PR DESCRIPTION
I’m trying to fix YJIT’s symbol hygiene issue over at GH-7115 and found
that addr2line.c’s DWARF 5 handling is half-disabled when building with
GCC. Rust’s output contains some DW_AT_rnglists_base records, which the
disabled code reads. Without DW_AT_rnglists_base, it crashes when
generating a backtrace.

I think it’s reasonable to remove this special casing when building with
GCC since we might need to parse DWARF 5 of of C extensions built by
Clang at runtime. This can happen even when building without YJIT.
Rust extensions can also have DWARF 5 that require the disabled code
to read properly.

---

CC @mame @nurse
