### PR TITLE
Do not depend on `REVISION_H`

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1225,8 +1225,8 @@ $(REVISION_H)$(no_baseruby:no=~disabled~):
 $(REVISION_H)$(yes_baseruby:yes=~disabled~):
 	$(Q) exit > $@
 
-uncommon.mk: $(REVISION_H)
-$(MKFILES): $(REVISION_H)
+# uncommon.mk: $(REVISION_H)
+# $(MKFILES): $(REVISION_H)
 
 $(srcdir)/ext/ripper/ripper.c: $(srcdir)/ext/ripper/tools/preproc.rb $(srcdir)/parse.y $(srcdir)/defs/id.def $(srcdir)/ext/ripper/depend
 	$(ECHO) generating $@


### PR DESCRIPTION
Disable for now, since this seems causing infinite rebuilding.