### PR TITLE
Fix crash when defining ivars on special constants

### DIFF
--- a/test/ruby/test_variable.rb
+++ b/test/ruby/test_variable.rb
@@ -261,6 +261,12 @@ class TestVariable < Test::Unit::TestCase
         v.instance_variable_set(:@foo, :bar)
       end
 
+      assert_raise_with_message(FrozenError, msg, "[Bug #19339]") do
+        v.instance_eval do
+          @a = 1
+        end
+      end
+
       assert_nil EnvUtil.suppress_warning {v.instance_variable_get(:@foo)}
       assert_not_send([v, :instance_variable_defined?, :@foo])
 

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1562,6 +1562,11 @@ vm_getinstancevariable(const rb_iseq_t *iseq, VALUE obj, ID id, IVC ic)
 static inline void
 vm_setinstancevariable(const rb_iseq_t *iseq, VALUE obj, ID id, VALUE val, IVC ic)
 {
+    if (RB_SPECIAL_CONST_P(obj)) {
+        rb_error_frozen_object(obj);
+        return;
+    }
+
     shape_id_t dest_shape_id;
     attr_index_t index;
     vm_ic_atomic_shape_and_index(ic, &dest_shape_id, &index);


### PR DESCRIPTION
[Bug #19339]