### PR TITLE
Don't redefine RB_OBJ_WRITE

### DIFF
--- a/internal.h
+++ b/internal.h
@@ -43,7 +43,6 @@
 /* internal/gc.h */
 #undef NEWOBJ_OF
 #undef RB_NEWOBJ_OF
-#undef RB_OBJ_WRITE
 
 /* internal/hash.h */
 #undef RHASH_IFNONE

--- a/internal/class.h
+++ b/internal/class.h
@@ -9,7 +9,6 @@
  * @brief      Internal header for Class.
  */
 #include "id_table.h"           /* for struct rb_id_table */
-#include "internal/gc.h"        /* for RB_OBJ_WRITE */
 #include "internal/serial.h"    /* for rb_serial_t */
 #include "internal/static_assert.h"
 #include "ruby/internal/stdbool.h"     /* for bool */

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -21,7 +21,6 @@ struct rb_objspace; /* in vm_core.h */
 #ifdef NEWOBJ_OF
 # undef NEWOBJ_OF
 # undef RB_NEWOBJ_OF
-# undef RB_OBJ_WRITE
 #endif
 
 #define RVALUE_SIZE (sizeof(struct RBasic) + sizeof(VALUE[RBIMPL_RVALUE_EMBED_LEN_MAX]))
@@ -63,9 +62,6 @@ struct rb_objspace; /* in vm_core.h */
 #endif
 
 #define UNALIGNED_MEMBER_PTR(ptr, mem) UNALIGNED_MEMBER_ACCESS(&(ptr)->mem)
-#define RB_OBJ_WRITE(a, slot, b) \
-    rb_obj_write((VALUE)(a), UNALIGNED_MEMBER_ACCESS((VALUE *)(slot)), \
-                 (VALUE)(b), __FILE__, __LINE__)
 
 // We use SIZE_POOL_COUNT number of shape IDs for transitions out of different size pools
 // The next available shapd ID will be the SPECIAL_CONST_SHAPE_ID

--- a/internal/imemo.h
+++ b/internal/imemo.h
@@ -11,7 +11,6 @@
 #include "ruby/internal/config.h"
 #include <stddef.h>             /* for size_t */
 #include "internal/array.h"     /* for rb_ary_hidden_new_fill */
-#include "internal/gc.h"        /* for RB_OBJ_WRITE */
 #include "ruby/internal/stdbool.h"     /* for bool */
 #include "ruby/ruby.h"          /* for rb_block_call_func_t */
 

--- a/internal/process.h
+++ b/internal/process.h
@@ -20,6 +20,7 @@
 #endif
 
 #include "ruby/ruby.h"          /* for VALUE */
+#include "internal/compilers.h" /* for __has_warning */
 #include "internal/imemo.h"     /* for RB_IMEMO_TMPBUF_PTR */
 #include "internal/warnings.h"  /* for COMPILER_WARNING_PUSH */
 

--- a/internal/rational.h
+++ b/internal/rational.h
@@ -10,7 +10,6 @@
  */
 #include "ruby/internal/config.h"      /* for HAVE_LIBGMP */
 #include "ruby/ruby.h"          /* for struct RBasic */
-#include "internal/gc.h"        /* for RB_OBJ_WRITE */
 #include "internal/numeric.h"   /* for INT_POSITIVE_P */
 #include "ruby_assert.h"        /* for assert */
 

--- a/internal/struct.h
+++ b/internal/struct.h
@@ -9,7 +9,6 @@
  * @brief      Internal header for Struct.
  */
 #include "ruby/internal/stdbool.h"     /* for bool */
-#include "internal/gc.h"        /* for RB_OBJ_WRITE */
 #include "ruby/ruby.h"          /* for struct RBasic */
 
 enum {

--- a/thread_sync.c
+++ b/thread_sync.c
@@ -905,7 +905,7 @@ rb_queue_initialize(int argc, VALUE *argv, VALUE self)
     if ((argc = rb_scan_args(argc, argv, "01", &initial)) == 1) {
         initial = rb_to_array(initial);
     }
-    RB_OBJ_WRITE(self, &q->que, ary_buf_new());
+    RB_OBJ_WRITE(self, UNALIGNED_MEMBER_ACCESS(&q->que), ary_buf_new());
     ccan_list_head_init(queue_waitq(q));
     if (argc == 1) {
         rb_ary_concat(q->que, initial);
@@ -1178,7 +1178,7 @@ rb_szqueue_initialize(VALUE self, VALUE vmax)
         rb_raise(rb_eArgError, "queue size must be positive");
     }
 
-    RB_OBJ_WRITE(self, &sq->q.que, ary_buf_new());
+    RB_OBJ_WRITE(self, UNALIGNED_MEMBER_ACCESS(&sq->q.que), ary_buf_new());
     ccan_list_head_init(szqueue_waitq(sq));
     ccan_list_head_init(szqueue_pushq(sq));
     sq->max = max;


### PR DESCRIPTION
RB_OBJ_WRITE already exists in rgengc.h, so we shouldn't redefine it in gc.h.