### PR TITLE
CI: Pass -O2 for annocheck

### DIFF
--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -83,12 +83,13 @@ jobs:
             container: gcc-11
             env:
               # Minimal flags to pass the check.
-              default_cc: 'gcc-11 -O2 -fcf-protection -Wa,--generate-missing-build-notes=yes'
+              default_cc: 'gcc-11 -fcf-protection -Wa,--generate-missing-build-notes=yes'
+              optflags: '-O2'
               LDFLAGS: '-Wl,-z,now'
               # FIXME: Drop skipping options
               # https://bugs.ruby-lang.org/issues/18061
               # https://sourceware.org/annobin/annobin.html/Test-pie.html
-              TEST_ANNOCHECK_OPTS: "--skip-pie"
+              TEST_ANNOCHECK_OPTS: "--skip-pie --skip-gaps"
             check: true
           - { name: clang-16,  env: { default_cc: clang-16 } }
           - { name: clang-15,  env: { default_cc: clang-15 } }


### PR DESCRIPTION
Because `optflags` is pasted into the invocation line after `CC`, we were building with -O1 unintentionally. You can see this in the configuration
summary: https://github.com/ruby/ruby/actions/runs/3933391169/jobs/6727044423#step:9:753

---

CC @junaruga 