### PR TITLE
YJIT: Use ThinLTO for Rust parts in release mode

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -225,6 +225,7 @@ YJIT_RUSTC_ARGS = --crate-name=yjit \
 	--crate-type=staticlib \
 	--edition=2021 \
 	-g \
+	-C lto=thin \
 	-C opt-level=3 \
 	-C overflow-checks=on \
 	'--out-dir=$(CARGO_TARGET_DIR)/release/' \

--- a/yjit/Cargo.toml
+++ b/yjit/Cargo.toml
@@ -45,3 +45,5 @@ opt-level = 3
 overflow-checks = true
 # Generate debug info
 debug = true
+# Use ThinLTO. Much smaller output for a small amount of build time increase.
+lto = "thin"


### PR DESCRIPTION
This reduces the code size of libyjit.a by a lot. On darwin it went from
23 MiB to 12 MiB for me. I chose ThinLTO over fat LTO for the relatively
fast build time; in case we need to debug release-build-only problems
it won't be painful.

---

The size reduction will become more important on GNU/Linux when we start glomming libyjit.a to mitigate symbol leakage issues: #7115. ThinLTO seems to work pretty well. It was added into LLVM by Google and there is a talk about it done by one of the maintainers: https://youtu.be/p9nH2vZ2mNo. (It's available in Rust 1.58.0, our minimum Rust version)