### PR TITLE
Add tests for variables in `END` block shared with the toplevel

### DIFF
--- a/spec/ruby/language/END_spec.rb
+++ b/spec/ruby/language/END_spec.rb
@@ -12,4 +12,8 @@ describe "The END keyword" do
   it "runs multiple ends in LIFO order" do
     ruby_exe("END { puts 'foo' }; END { puts 'bar' }").should == "bar\nfoo\n"
   end
+
+  it "is affected by the toplevel assignment" do
+    ruby_exe("foo = 'foo'; END { puts foo }").should == "foo\n"
+  end
 end

--- a/test/ruby/test_beginendblock.rb
+++ b/test/ruby/test_beginendblock.rb
@@ -14,6 +14,11 @@ class TestBeginEndBlock < Test::Unit::TestCase
     assert_in_out_err(["-p", "-eBEGIN{p :begin}", "-eEND{p :end}"], "foo\nbar\n", %w(:begin foo bar :end))
   end
 
+  def test_endblock_variable
+    assert_in_out_err(["-n", "-ea = :ok", "-eEND{p a}"], "foo\n", %w(:ok))
+    assert_in_out_err(["-p", "-ea = :ok", "-eEND{p a}"], "foo\n", %w(foo :ok))
+  end
+
   def test_begininmethod
     assert_raise_with_message(SyntaxError, /BEGIN is permitted only at toplevel/) do
       eval("def foo; BEGIN {}; end")


### PR DESCRIPTION
As the following code doesn't raise `NameError` in `END` block, the block shares the scope with the toplevel.
That means the assignment at the toplevel also should be effective as well.

```ruby
a = 1
END {p a}
```