### PR TITLE
Update SimpleCov version

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -51,12 +51,6 @@ GEM_VENDOR =
 
 BENCHMARK_DRIVER_GIT_URL = https://github.com/benchmark-driver/benchmark-driver
 BENCHMARK_DRIVER_GIT_REF = v0.16.3
-SIMPLECOV_GIT_URL = https://github.com/simplecov-ruby/simplecov.git
-SIMPLECOV_GIT_REF = v0.17.0
-SIMPLECOV_HTML_GIT_URL = https://github.com/simplecov-ruby/simplecov-html.git
-SIMPLECOV_HTML_GIT_REF = v0.10.2
-DOCLIE_GIT_URL = https://github.com/ms-ati/docile.git
-DOCLIE_GIT_REF = v1.3.2
 
 STATIC_RUBY   = static-ruby
 
@@ -1377,6 +1371,10 @@ update-rubyspec:
 update-config_files: PHONY
 	$(Q) $(BASERUBY) -C "$(srcdir)" tool/downloader.rb -d tool --cache-dir=$(CACHE_DIR) -e gnu \
 	    config.guess config.sub
+
+update-coverage: PHONY
+	$(XRUBY) -C "$(srcdir)" bin/gem install --no-document \
+		--install-dir .bundle --conservative "simplecov"
 
 refresh-gems: update-bundled_gems prepare-gems
 prepare-gems: $(HAVE_BASERUBY:yes=update-gems) $(HAVE_BASERUBY:yes=extract-gems)

--- a/common.mk
+++ b/common.mk
@@ -1374,7 +1374,7 @@ update-config_files: PHONY
 
 update-coverage: PHONY
 	$(XRUBY) -C "$(srcdir)" bin/gem install --no-document \
-		--install-dir .bundle --conservative "simplecov"
+		--install-dir .bundle --conservative "simplecov" -v "0.20.0"
 
 refresh-gems: update-bundled_gems prepare-gems
 prepare-gems: $(HAVE_BASERUBY:yes=update-gems) $(HAVE_BASERUBY:yes=extract-gems)

--- a/template/Makefile.in
+++ b/template/Makefile.in
@@ -602,23 +602,6 @@ update-benchmark-driver:
 		--branch $(BENCHMARK_DRIVER_GIT_REF) \
 		$(BENCHMARK_DRIVER_GIT_URL) benchmark-driver $(GIT_OPTS)
 
-update-doclie:
-	$(Q) $(tooldir)/git-refresh -C $(srcdir)/coverage $(Q1:0=-q) \
-		--branch $(DOCLIE_GIT_REF) \
-		$(DOCLIE_GIT_URL) doclie $(GIT_OPTS)
-
-update-simplecov-html:
-	$(Q) $(tooldir)/git-refresh -C $(srcdir)/coverage $(Q1:0=-q) \
-		--branch $(SIMPLECOV_HTML_GIT_REF) \
-		$(SIMPLECOV_HTML_GIT_URL) simplecov-html $(GIT_OPTS)
-
-update-simplecov:
-	$(Q) $(tooldir)/git-refresh -C $(srcdir)/coverage $(Q1:0=-q) \
-		--branch $(SIMPLECOV_GIT_REF)  \
-		$(SIMPLECOV_GIT_URL) simplecov $(GIT_OPTS)
-
-update-coverage: update-simplecov update-simplecov-html update-doclie
-
 update-known-errors:
 	errno --list | cut -d' ' -f1 | sort -u - $(srcdir)/defs/known_errors.def | \
 	$(IFCHANGE) $(srcdir)/defs/known_errors.def -

--- a/tool/test-coverage.rb
+++ b/tool/test-coverage.rb
@@ -62,8 +62,11 @@ def save_coverage_data(res1)
 end
 
 def invoke_simplecov_formatter
-  %w[doclie simplecov-html simplecov].each do |f|
-    $LOAD_PATH.unshift "#{__dir__}/../coverage/#{f}/lib"
+  # XXX docile-x.y.z and simplecov-x.y.z, simplecov-html-x.y.z, simplecov_json_formatter-x.y.z
+  %w[simplecov simplecov-html simplecov_json_formatter docile].each do |f|
+    Dir.glob("#{__dir__}/../.bundle/gems/#{f}-*/lib").each do |d|
+      $LOAD_PATH.unshift d
+    end
   end
 
   require "simplecov"


### PR DESCRIPTION
The current coverage tools are installed by `git clone`. There is no reason we should use `git clone` instead of `gem install` now. 