### PR TITLE
Remove macro RHASH_ITER_LEV

### DIFF
--- a/include/ruby/internal/core/rhash.h
+++ b/include/ruby/internal/core/rhash.h
@@ -54,19 +54,6 @@
  *
  * @internal
  *
- * Declaration of rb_hash_iter_lev() is at include/ruby/backward.h.
- */
-#define RHASH_ITER_LEV(h)           rb_hash_iter_lev(h)
-
-/**
- * @private
- *
- * @deprecated  This macro once was a thing in the old days, but makes no sense
- *              any  longer today.   Exists  here  for backwards  compatibility
- *              only.  You can safely forget about it.
- *
- * @internal
- *
  * Declaration of rb_hash_ifnone() is at include/ruby/backward.h.
  */
 #define RHASH_IFNONE(h)             rb_hash_ifnone(h)


### PR DESCRIPTION
The function rb_hash_iter_lev doesn't exist as it was removed.