### PR TITLE
Remove rb_struct_s_members from the public header files

### DIFF
--- a/include/ruby/internal/intern/struct.h
+++ b/include/ruby/internal/intern/struct.h
@@ -114,23 +114,8 @@ VALUE rb_struct_initialize(VALUE self, VALUE values);
 VALUE rb_struct_getmember(VALUE self, ID key);
 
 /**
- * Queries the list of the names of the fields of the given struct class.
- *
- * @param[in]  klass  A subclass of ::rb_cStruct.
- * @return     The list of the names of the fields of `klass`.
- */
-VALUE rb_struct_s_members(VALUE klass);
-
-/**
  * Queries the list of the names of the fields of the class of the given struct
- * object.  This is  almost the same as calling  rb_struct_s_members() over the
- * class of the receiver.
- *
- * @internal
- *
- * "Almost"?  What exactly is the difference?
- *
- * @endinternal
+ * object.
  *
  * @param[in]  self  An instance of a subclass of ::rb_cStruct.
  * @return     The list of the names of the fields.

--- a/internal/struct.h
+++ b/internal/struct.h
@@ -56,6 +56,7 @@ struct RStruct {
 VALUE rb_struct_init_copy(VALUE copy, VALUE s);
 VALUE rb_struct_lookup(VALUE s, VALUE idx);
 VALUE rb_struct_s_keyword_init(VALUE klass);
+VALUE rb_struct_s_members(VALUE klass);
 static inline const VALUE *rb_struct_const_heap_ptr(VALUE st);
 static inline bool RSTRUCT_TRANSIENT_P(VALUE st);
 static inline void RSTRUCT_TRANSIENT_SET(VALUE st);

--- a/spec/ruby/optional/capi/ext/struct_spec.c
+++ b/spec/ruby/optional/capi/ext/struct_spec.c
@@ -15,10 +15,12 @@ static VALUE struct_spec_rb_struct_getmember(VALUE self, VALUE st, VALUE key) {
   return rb_struct_getmember(st, SYM2ID(key));
 }
 
+#if RUBY_VERSION_MAJOR < 3 || (RUBY_VERSION_MAJOR == 3 && RUBY_VERSION_MINOR < 3)
 static VALUE struct_spec_rb_struct_s_members(VALUE self, VALUE klass)
 {
   return rb_ary_dup(rb_struct_s_members(klass));
 }
+#endif
 
 static VALUE struct_spec_rb_struct_members(VALUE self, VALUE st)
 {
@@ -71,7 +73,9 @@ void Init_struct_spec(void) {
   VALUE cls = rb_define_class("CApiStructSpecs", rb_cObject);
   rb_define_method(cls, "rb_struct_aref", struct_spec_rb_struct_aref, 2);
   rb_define_method(cls, "rb_struct_getmember", struct_spec_rb_struct_getmember, 2);
+#if RUBY_VERSION_MAJOR < 3 || (RUBY_VERSION_MAJOR == 3 && RUBY_VERSION_MINOR < 3)
   rb_define_method(cls, "rb_struct_s_members", struct_spec_rb_struct_s_members, 1);
+#endif
   rb_define_method(cls, "rb_struct_members", struct_spec_rb_struct_members, 1);
   rb_define_method(cls, "rb_struct_aset", struct_spec_rb_struct_aset, 3);
   rb_define_method(cls, "rb_struct_define", struct_spec_struct_define, 4);

--- a/spec/ruby/optional/capi/struct_spec.rb
+++ b/spec/ruby/optional/capi/struct_spec.rb
@@ -151,9 +151,11 @@ describe "C-API Struct function" do
     end
   end
 
-  describe "rb_struct_s_members" do
-    it "returns the struct members as an array of symbols" do
-      @s.rb_struct_s_members(@klass).should == [:a, :b, :c]
+  ruby_version_is ''...'3.3' do
+    describe "rb_struct_s_members" do
+      it "returns the struct members as an array of symbols" do
+        @s.rb_struct_s_members(@klass).should == [:a, :b, :c]
+      end
     end
   end
 


### PR DESCRIPTION
This is still an exported symbol as it is used in marshal.c. Move the prototype from the public header files to the internal header files.

Fixes [Bug #11230]