### PR TITLE
YJIT: Remove duplicated information in BranchTarget

### DIFF
--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -1775,7 +1775,7 @@ fn branch_stub_hit_body(branch_ptr: *const c_void, target_idx: u32, ec: EcPtr) -
     let target_idx: usize = target_idx.as_usize();
     let target = branch.targets[target_idx].as_ref().unwrap();
     let target_id = target.get_id();
-    let target_ctx = target.get_ctx().clone();
+    let target_ctx = target.get_ctx();
 
     let target_branch_shape = match target_idx {
         0 => BranchShape::Next0,


### PR DESCRIPTION
In `BranchTarget`, you only need `id`/`ctx` or `block.blockid`/`block.ctx` at a time. If you encode that constraint in the type, we can save some space by eliminating the duplication.

## Impact
With macOS stats build on railsbench, `yjit_alloc_size` is reduced from 9.9MB to 9.0MB.

### Before
```
yjit_alloc_size:          9927949
```

### After
```
yjit_alloc_size:          8986243
```