### PR TITLE
Add `offsetof` so we can get the offset of members

### DIFF
--- a/lib/ruby_vm/mjit/c_pointer.rb
+++ b/lib/ruby_vm/mjit/c_pointer.rb
@@ -54,6 +54,12 @@ module RubyVM::MJIT # :nodoc: all
           # Return the size of this type
           define_singleton_method(:sizeof) { sizeof }
 
+          # Get the offset of a member named +name+
+          define_singleton_method(:offsetof) { |name|
+            _, offset = members.fetch(name)
+            offset / 8
+          }
+
           define_method(:initialize) do |addr = nil|
             if addr.nil? # TODO: get rid of this feature later
               addr = Fiddle.malloc(sizeof)


### PR DESCRIPTION
I want to get the offset of fields inside structs, but I don't want to instantiate the struct.  I need to embed the offsets inside machine code, and I can't get the offsets without calling `new` on the struct.

This commit adds an `offset` method so you can get the offset of a member without instantiating anything.  You can do:

```ruby
C.rb_control_frame_t.offsetof(:sp) #=> 8
```

I don't think this implementation is perfect, you can only get immediate fields.  But it is better than nothing!

Btw, Fiddle [implements `offsetof`](https://github.com/ruby/fiddle/blob/36b24325754880266bacf49690e09826b30ad30b/test/fiddle/test_c_struct_builder.rb#L34-L40), but I'm not sure how much code we can share.