### PR TITLE
YJIT: Add splat optimized_send

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -4739,11 +4739,6 @@ fn gen_send_cfunc(
         }
     }
 
-    // This is a .send call and we need to adjust the stack
-    if flags & VM_CALL_OPT_SEND != 0 {
-        handle_opt_send_shift_stack(asm, argc, ctx);
-    }
-
     // push_splat_args does stack manipulation so we can no longer side exit
     if flags & VM_CALL_ARGS_SPLAT != 0 {
         let required_args : u32 = (cfunc_argc as u32).saturating_sub(argc as u32 - 1);
@@ -4758,6 +4753,11 @@ fn gen_send_cfunc(
         argc = required_args as i32;
         passed_argc = argc;
         push_splat_args(required_args, ctx, asm, ocb, side_exit)
+    }
+
+    // This is a .send call and we need to adjust the stack
+    if flags & VM_CALL_OPT_SEND != 0 {
+        handle_opt_send_shift_stack(asm, argc, ctx);
     }
 
     // Points to the receiver operand on the stack
@@ -5962,11 +5962,6 @@ fn gen_send_general(
                     return CantCompile;
                 }
 
-                if flags & VM_CALL_ARGS_SPLAT != 0 {
-                    gen_counter_incr!(asm, send_args_splat_optimized);
-                    return CantCompile;
-                }
-
                 let opt_type = unsafe { get_cme_def_body_optimized_type(cme) };
                 match opt_type {
                     OPTIMIZED_METHOD_TYPE_SEND => {
@@ -6086,6 +6081,11 @@ fn gen_send_general(
 
                         if flags & VM_CALL_KWARG != 0 {
                             gen_counter_incr!(asm, send_call_kwarg);
+                            return CantCompile;
+                        }
+
+                        if flags & VM_CALL_ARGS_SPLAT != 0 {
+                            gen_counter_incr!(asm, send_args_splat_opt_call);
                             return CantCompile;
                         }
 

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -218,7 +218,7 @@ make_counters! {
     send_args_splat_bmethod,
     send_args_splat_aref,
     send_args_splat_aset,
-    send_args_splat_optimized,
+    send_args_splat_opt_call,
     send_args_splat_cfunc_var_args,
     send_args_splat_cfunc_zuper,
     send_args_splat_cfunc_ruby2_keywords,


### PR DESCRIPTION
Big change here is in liquid-render where we go from 18978 exits for `args_splat_optimized` to 4219 `iseq_splat_with_opt` exits. Once this is combined with https://github.com/ruby/ruby/pull/7166 those numbers should go down as well.

<details><summary>Before</summary>

```ruby
ruby 3.3.0dev (2023-01-20T21:07:03Z master 887d21613c) +YJIT dev [arm64-darwin22]
***YJIT: Printing YJIT statistics on exit***
method call exit reasons: 
                iseq_has_rest      41227 (66.1%)
         args_splat_optimized      18978 (30.4%)
                    block_arg       1324 ( 2.1%)
                zsuper_method        792 ( 1.3%)
        cfunc_ruby_array_varg         39 ( 0.1%)
     iseq_missing_optional_kw         39 ( 0.1%)
    args_splat_cfunc_var_args         11 ( 0.0%)
              ivar_set_method          1 ( 0.0%)
invokeblock exit reasons: 
                proc         90 (95.7%)
    iseq_tag_changed          4 ( 4.3%)
invokesuper exit reasons: 
    block          5 (100.0%)
leave exit reasons: 
        interp_return     287962 (100.0%)
    start_pc_non_zero        105 ( 0.0%)
         se_interrupt         16 ( 0.0%)
getblockparamproxy exit reasons: 
    (all relevant counters are zero)
getinstancevariable exit reasons:
    megamorphic          8 (100.0%)
setinstancevariable exit reasons:
    (all relevant counters are zero)
opt_aref exit reasons: 
    (all relevant counters are zero)
expandarray exit reasons: 
    (all relevant counters are zero)
opt_getinlinecache exit reasons: 
    (all relevant counters are zero)
invalidation reasons: 
       constant_ic_fill        149 (84.2%)
    constant_state_bump         19 (10.7%)
          method_lookup          9 ( 5.1%)
bindings_allocations:          77
bindings_set:                   0
compiled_iseq_count:          694
compiled_block_count:        5894
compiled_branch_count:       9771
block_next_count:            2019
defer_count:                 1992
freed_iseq_count:             181
invalidation_count:           177
constant_state_bumps:           0
inline_code_size:          920596
outlined_code_size:        918748
freed_code_size:                0
code_region_size:         1851392
yjit_alloc_size:         12031174
live_page_count:              113
freed_page_count:               0
code_gc_count:                  0
num_gc_obj_refs:             3878
object_shape_count:           538
side_exit_count:            84932
total_exit_count:          372894
total_insns_count:       19298312
vm_insns_count:           2599787
yjit_insns_count:        16783457
ratio_in_yjit:              86.5%
avg_len_in_yjit:             44.8
Top-12 most frequent exit ops (100.0% of exits):
    opt_send_without_block:      61372 (72.3%)
                     throw:      21517 (25.3%)
                      send:       1324 (1.6%)
      opt_getconstant_path:        369 (0.4%)
               invokesuper:        126 (0.1%)
               invokeblock:         94 (0.1%)
                    opt_eq:         87 (0.1%)
                     leave:         16 (0.0%)
                      once:         12 (0.0%)
          putspecialobject:         12 (0.0%)
                  opt_ltlt:          2 (0.0%)
                  opt_aref:          1 (0.0%)
itr #1: 562ms

```
</details> 


<details><summary>After</summary>

```ruby

ruby 3.3.0dev (2023-01-20T21:54:19Z yjit-send-splat-init 7a6345afb7) +YJIT dev [arm64-darwin22]
***YJIT: Printing YJIT statistics on exit***
method call exit reasons: 
                iseq_has_rest      41226 (86.5%)
          iseq_splat_with_opt       4219 ( 8.9%)
                    block_arg       1324 ( 2.8%)
                zsuper_method        792 ( 1.7%)
        cfunc_ruby_array_varg         39 ( 0.1%)
     iseq_missing_optional_kw         39 ( 0.1%)
    args_splat_cfunc_var_args         11 ( 0.0%)
              ivar_set_method          1 ( 0.0%)
invokeblock exit reasons: 
                proc         90 (95.7%)
    iseq_tag_changed          4 ( 4.3%)
invokesuper exit reasons: 
    block          5 (100.0%)
leave exit reasons: 
        interp_return     287940 (100.0%)
    start_pc_non_zero        105 ( 0.0%)
         se_interrupt         13 ( 0.0%)
getblockparamproxy exit reasons: 
    (all relevant counters are zero)
getinstancevariable exit reasons:
    megamorphic          8 (100.0%)
setinstancevariable exit reasons:
    (all relevant counters are zero)
opt_aref exit reasons: 
    (all relevant counters are zero)
expandarray exit reasons: 
    (all relevant counters are zero)
opt_getinlinecache exit reasons: 
    (all relevant counters are zero)
invalidation reasons: 
       constant_ic_fill        149 (84.2%)
    constant_state_bump         19 (10.7%)
          method_lookup          9 ( 5.1%)
bindings_allocations:          77
bindings_set:                   0
compiled_iseq_count:          694
compiled_block_count:        5911
compiled_branch_count:       9812
block_next_count:            2033
defer_count:                 1992
freed_iseq_count:             181
invalidation_count:           177
constant_state_bumps:           0
inline_code_size:          929836
outlined_code_size:        927636
freed_code_size:                0
code_region_size:         1867776
yjit_alloc_size:         12134656
live_page_count:              114
freed_page_count:               0
code_gc_count:                  0
num_gc_obj_refs:             3942
object_shape_count:           538
side_exit_count:            70161
total_exit_count:          358101
total_insns_count:       19421037
vm_insns_count:           2541164
yjit_insns_count:        16950034
ratio_in_yjit:              86.9%
avg_len_in_yjit:             47.1
Top-12 most frequent exit ops (100.0% of exits):
    opt_send_without_block:      46604 (66.4%)
                     throw:      21516 (30.7%)
                      send:       1324 (1.9%)
      opt_getconstant_path:        370 (0.5%)
               invokesuper:        126 (0.2%)
               invokeblock:         94 (0.1%)
                    opt_eq:         87 (0.1%)
                     leave:         13 (0.0%)
                      once:         12 (0.0%)
          putspecialobject:         12 (0.0%)
                  opt_ltlt:          2 (0.0%)
                   opt_neq:          1 (0.0%)
itr #1: 569ms


```
</details> 