### PR TITLE
YJIT: Skip defer_compilation for fixnums if possible

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -1093,15 +1093,15 @@ fn gen_opt_plus(
     asm: &mut Assembler,
     ocb: &mut OutlinedCb,
 ) -> CodegenStatus {
-    if !jit_at_current_insn(jit) {
-        defer_compilation(jit, ctx, asm, ocb);
-        return EndBlock;
-    }
+    let two_fixnums = match two_fixnums_on_stack(jit, ctx) {
+        Some(two_fixnums) => two_fixnums,
+        None => {
+            defer_compilation(jit, ctx, asm, ocb);
+            return EndBlock;
+        }
+    };
 
-    let comptime_a = jit_peek_at_stack(jit, ctx, 1);
-    let comptime_b = jit_peek_at_stack(jit, ctx, 0);
-
-    if comptime_a.fixnum_p() && comptime_b.fixnum_p() {
+    if two_fixnums {
         // Create a side-exit to fall back to the interpreter
         // Note: we generate the side-exit before popping operands from the stack
         let side_exit = get_side_exit(jit, ocb, ctx);
@@ -2539,6 +2539,24 @@ fn gen_concatstrings(
     KeepCompiling
 }
 
+// Return Some if whether stack-top objects are fixnums or not at least at compile
+// time is known, otherwise None.
+fn two_fixnums_on_stack(jit: &mut JITState, ctx: &mut Context) -> Option<bool> {
+    if jit_at_current_insn(jit) {
+        let comptime_recv = jit_peek_at_stack(jit, ctx, 1);
+        let comptime_arg = jit_peek_at_stack(jit, ctx, 0);
+        return Some(comptime_recv.fixnum_p() && comptime_arg.fixnum_p());
+    }
+
+    let recv_type = ctx.get_opnd_type(StackOpnd(1));
+    let arg_type = ctx.get_opnd_type(StackOpnd(0));
+    match (recv_type, arg_type) {
+        (Type::Fixnum, Type::Fixnum) => Some(true),
+        (Type::Unknown | Type::UnknownImm, Type::Unknown | Type::UnknownImm) => None,
+        _ => Some(false),
+    }
+}
+
 fn guard_two_fixnums(
     jit: &mut JITState,
     ctx: &mut Context,
@@ -2622,16 +2640,16 @@ fn gen_fixnum_cmp(
     ocb: &mut OutlinedCb,
     cmov_op: CmovFn,
 ) -> CodegenStatus {
-    // Defer compilation so we can specialize base on a runtime receiver
-    if !jit_at_current_insn(jit) {
-        defer_compilation(jit, ctx, asm, ocb);
-        return EndBlock;
-    }
+    let two_fixnums = match two_fixnums_on_stack(jit, ctx) {
+        Some(two_fixnums) => two_fixnums,
+        None => {
+            // Defer compilation so we can specialize based on a runtime receiver
+            defer_compilation(jit, ctx, asm, ocb);
+            return EndBlock;
+        }
+    };
 
-    let comptime_a = jit_peek_at_stack(jit, ctx, 1);
-    let comptime_b = jit_peek_at_stack(jit, ctx, 0);
-
-    if comptime_a.fixnum_p() && comptime_b.fixnum_p() {
+    if two_fixnums {
         // Create a side-exit to fall back to the interpreter
         // Note: we generate the side-exit before popping operands from the stack
         let side_exit = get_side_exit(jit, ocb, ctx);
@@ -2698,24 +2716,29 @@ fn gen_opt_gt(
 }
 
 // Implements specialized equality for either two fixnum or two strings
-// Returns true if code was generated, otherwise false
+// Returns None if enough type information isn't available, Some(true)
+// if code was generated, otherwise false.
 fn gen_equality_specialized(
     jit: &mut JITState,
     ctx: &mut Context,
     asm: &mut Assembler,
     ocb: &mut OutlinedCb,
-    side_exit: Target,
-) -> bool {
-    let comptime_a = jit_peek_at_stack(jit, ctx, 1);
-    let comptime_b = jit_peek_at_stack(jit, ctx, 0);
+) -> Option<bool> {
+    // Create a side-exit to fall back to the interpreter
+    let side_exit = get_side_exit(jit, ocb, ctx);
 
     let a_opnd = ctx.stack_opnd(1);
     let b_opnd = ctx.stack_opnd(0);
 
-    if comptime_a.fixnum_p() && comptime_b.fixnum_p() {
+    let two_fixnums = match two_fixnums_on_stack(jit, ctx) {
+        Some(two_fixnums) => two_fixnums,
+        None => return None,
+    };
+
+    if two_fixnums {
         if !assume_bop_not_redefined(jit, ocb, INTEGER_REDEFINED_OP_FLAG, BOP_EQ) {
             // if overridden, emit the generic version
-            return false;
+            return Some(false);
         }
 
         guard_two_fixnums(jit, ctx, asm, ocb, side_exit);
@@ -2729,13 +2752,19 @@ fn gen_equality_specialized(
         let dst = ctx.stack_push(Type::UnknownImm);
         asm.mov(dst, val);
 
-        true
+        return Some(true);
     }
-    else if unsafe { comptime_a.class_of() == rb_cString && comptime_b.class_of() == rb_cString }
-    {
+
+    if !jit_at_current_insn(jit) {
+        return None;
+    }
+    let comptime_a = jit_peek_at_stack(jit, ctx, 1);
+    let comptime_b = jit_peek_at_stack(jit, ctx, 0);
+
+    if unsafe { comptime_a.class_of() == rb_cString && comptime_b.class_of() == rb_cString } {
         if !assume_bop_not_redefined(jit, ocb, STRING_REDEFINED_OP_FLAG, BOP_EQ) {
             // if overridden, emit the generic version
-            return false;
+            return Some(false);
         }
 
         // Guard that a is a String
@@ -2792,9 +2821,9 @@ fn gen_equality_specialized(
 
         asm.write_label(ret);
 
-        true
+        Some(true)
     } else {
-        false
+        Some(false)
     }
 }
 
@@ -2804,16 +2833,16 @@ fn gen_opt_eq(
     asm: &mut Assembler,
     ocb: &mut OutlinedCb,
 ) -> CodegenStatus {
-    // Defer compilation so we can specialize base on a runtime receiver
-    if !jit_at_current_insn(jit) {
-        defer_compilation(jit, ctx, asm, ocb);
-        return EndBlock;
-    }
+    let specialized = match gen_equality_specialized(jit, ctx, asm, ocb) {
+        Some(specialized) => specialized,
+        None => {
+            // Defer compilation so we can specialize base on a runtime receiver
+            defer_compilation(jit, ctx, asm, ocb);
+            return EndBlock;
+        }
+    };
 
-    // Create a side-exit to fall back to the interpreter
-    let side_exit = get_side_exit(jit, ocb, ctx);
-
-    if gen_equality_specialized(jit, ctx, asm, ocb, side_exit) {
+    if specialized {
         jump_to_next_insn(jit, ctx, asm, ocb);
         EndBlock
     } else {
@@ -3068,16 +3097,16 @@ fn gen_opt_and(
     asm: &mut Assembler,
     ocb: &mut OutlinedCb,
 ) -> CodegenStatus {
-    // Defer compilation so we can specialize on a runtime `self`
-    if !jit_at_current_insn(jit) {
-        defer_compilation(jit, ctx, asm, ocb);
-        return EndBlock;
-    }
+    let two_fixnums = match two_fixnums_on_stack(jit, ctx) {
+        Some(two_fixnums) => two_fixnums,
+        None => {
+            // Defer compilation so we can specialize on a runtime `self`
+            defer_compilation(jit, ctx, asm, ocb);
+            return EndBlock;
+        }
+    };
 
-    let comptime_a = jit_peek_at_stack(jit, ctx, 1);
-    let comptime_b = jit_peek_at_stack(jit, ctx, 0);
-
-    if comptime_a.fixnum_p() && comptime_b.fixnum_p() {
+    if two_fixnums {
         // Create a side-exit to fall back to the interpreter
         // Note: we generate the side-exit before popping operands from the stack
         let side_exit = get_side_exit(jit, ocb, ctx);
@@ -3113,16 +3142,16 @@ fn gen_opt_or(
     asm: &mut Assembler,
     ocb: &mut OutlinedCb,
 ) -> CodegenStatus {
-    // Defer compilation so we can specialize on a runtime `self`
-    if !jit_at_current_insn(jit) {
-        defer_compilation(jit, ctx, asm, ocb);
-        return EndBlock;
-    }
+    let two_fixnums = match two_fixnums_on_stack(jit, ctx) {
+        Some(two_fixnums) => two_fixnums,
+        None => {
+            // Defer compilation so we can specialize on a runtime `self`
+            defer_compilation(jit, ctx, asm, ocb);
+            return EndBlock;
+        }
+    };
 
-    let comptime_a = jit_peek_at_stack(jit, ctx, 1);
-    let comptime_b = jit_peek_at_stack(jit, ctx, 0);
-
-    if comptime_a.fixnum_p() && comptime_b.fixnum_p() {
+    if two_fixnums {
         // Create a side-exit to fall back to the interpreter
         // Note: we generate the side-exit before popping operands from the stack
         let side_exit = get_side_exit(jit, ocb, ctx);
@@ -3158,16 +3187,16 @@ fn gen_opt_minus(
     asm: &mut Assembler,
     ocb: &mut OutlinedCb,
 ) -> CodegenStatus {
-    // Defer compilation so we can specialize on a runtime `self`
-    if !jit_at_current_insn(jit) {
-        defer_compilation(jit, ctx, asm, ocb);
-        return EndBlock;
-    }
+    let two_fixnums = match two_fixnums_on_stack(jit, ctx) {
+        Some(two_fixnums) => two_fixnums,
+        None => {
+            // Defer compilation so we can specialize on a runtime `self`
+            defer_compilation(jit, ctx, asm, ocb);
+            return EndBlock;
+        }
+    };
 
-    let comptime_a = jit_peek_at_stack(jit, ctx, 1);
-    let comptime_b = jit_peek_at_stack(jit, ctx, 0);
-
-    if comptime_a.fixnum_p() && comptime_b.fixnum_p() {
+    if two_fixnums {
         // Create a side-exit to fall back to the interpreter
         // Note: we generate the side-exit before popping operands from the stack
         let side_exit = get_side_exit(jit, ocb, ctx);
@@ -3225,16 +3254,16 @@ fn gen_opt_mod(
     asm: &mut Assembler,
     ocb: &mut OutlinedCb,
 ) -> CodegenStatus {
-    // Defer compilation so we can specialize on a runtime `self`
-    if !jit_at_current_insn(jit) {
-        defer_compilation(jit, ctx, asm, ocb);
-        return EndBlock;
-    }
+    let two_fixnums = match two_fixnums_on_stack(jit, ctx) {
+        Some(two_fixnums) => two_fixnums,
+        None => {
+            // Defer compilation so we can specialize on a runtime `self`
+            defer_compilation(jit, ctx, asm, ocb);
+            return EndBlock;
+        }
+    };
 
-    let comptime_a = jit_peek_at_stack(jit, ctx, 1);
-    let comptime_b = jit_peek_at_stack(jit, ctx, 0);
-
-    if comptime_a.fixnum_p() && comptime_b.fixnum_p() {
+    if two_fixnums {
         // Create a side-exit to fall back to the interpreter
         // Note: we generate the side-exit before popping operands from the stack
         let side_exit = get_side_exit(jit, ocb, ctx);

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -2717,7 +2717,7 @@ fn gen_opt_gt(
 
 // Implements specialized equality for either two fixnum or two strings
 // Returns None if enough type information isn't available, Some(true)
-// if code was generated, otherwise false.
+// if code was generated, otherwise Some(false).
 fn gen_equality_specialized(
     jit: &mut JITState,
     ctx: &mut Context,

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -1474,6 +1474,22 @@ impl Context {
 
         return diff;
     }
+
+    pub fn two_fixnums_on_stack(&self, jit: &mut JITState) -> Option<bool> {
+        if jit_at_current_insn(jit) {
+            let comptime_recv = jit_peek_at_stack(jit, self, 1);
+            let comptime_arg = jit_peek_at_stack(jit, self, 0);
+            return Some(comptime_recv.fixnum_p() && comptime_arg.fixnum_p());
+        }
+
+        let recv_type = self.get_opnd_type(StackOpnd(1));
+        let arg_type = self.get_opnd_type(StackOpnd(0));
+        match (recv_type, arg_type) {
+            (Type::Fixnum, Type::Fixnum) => Some(true),
+            (Type::Unknown | Type::UnknownImm, Type::Unknown | Type::UnknownImm) => None,
+            _ => Some(false),
+        }
+    }
 }
 
 impl BlockId {


### PR DESCRIPTION
This partly addresses https://github.com/Shopify/ruby/issues/462.

When "compile-time stack-top values are fixnums?" can be answered from the type info in `ctx`, this PR skips `defer_compilation`.

As investigated in https://github.com/Shopify/ruby/issues/462#issuecomment-1344604539, it's not supposed to have a huge impact on the number of blocks. However, as I started experimenting with register allocation, targeting only intra-block allocation as a first step, I noticed even very simple blocks are split now. Supporting this is useful for that first milestone and I figured the implementation is not that complicated.

## Impact
It does have a small impact though. It eliminates some unneeded blocks on railsbench, reducing Rust memory consumption from 9.01MB to 9.00MB.

### Before
```
compiled_block_count:       20739
defer_count:                 6871
code_region_size:         6733824
yjit_alloc_size:          9010417
```

### After
```
compiled_block_count:       20699
defer_count:                 6836
code_region_size:         6733824
yjit_alloc_size:          9000787
```