### PR TITLE
Introduce class and module tye check macro

### DIFF
--- a/class.c
+++ b/class.c
@@ -276,7 +276,7 @@ rb_class_update_superclasses(VALUE klass)
 {
     VALUE super = RCLASS_SUPER(klass);
 
-    if (!RB_TYPE_P(klass, T_CLASS)) return;
+    if (!RB_CLASS_TYPE_P(klass)) return;
     if (UNDEF_P(super)) return;
 
     // If the superclass array is already built
@@ -284,7 +284,7 @@ rb_class_update_superclasses(VALUE klass)
         return;
 
     // find the proper superclass
-    while (super != Qfalse && !RB_TYPE_P(super, T_CLASS)) {
+    while (super != Qfalse && !RB_CLASS_TYPE_P(super)) {
         super = RCLASS_SUPER(super);
     }
 
@@ -309,7 +309,7 @@ rb_class_update_superclasses(VALUE klass)
 void
 rb_check_inheritable(VALUE super)
 {
-    if (!RB_TYPE_P(super, T_CLASS)) {
+    if (!RB_CLASS_TYPE_P(super)) {
         rb_raise(rb_eTypeError, "superclass must be an instance of Class (given an instance of %"PRIsVALUE")",
                  rb_obj_class(super));
     }
@@ -412,7 +412,7 @@ copy_tables(VALUE clone, VALUE orig)
         RCLASS_CONST_TBL(clone) = 0;
     }
     RCLASS_M_TBL(clone) = 0;
-    if (!RB_TYPE_P(clone, T_ICLASS)) {
+    if (!RB_ICLASS_TYPE_P(clone)) {
         st_data_t id;
 
         rb_iv_tbl_copy(clone, orig);
@@ -522,7 +522,7 @@ rb_mod_init_copy(VALUE clone, VALUE orig)
             RCLASS_M_TBL(clone_p) = RCLASS_M_TBL(p);
             RCLASS_CONST_TBL(clone_p) = RCLASS_CONST_TBL(p);
             RCLASS_ALLOCATOR(clone_p) = RCLASS_ALLOCATOR(p);
-            if (RB_TYPE_P(clone, T_CLASS)) {
+            if (RB_CLASS_TYPE_P(clone)) {
                 RCLASS_SET_INCLUDER(clone_p, clone);
             }
             add_subclass = TRUE;
@@ -657,7 +657,7 @@ rb_singleton_class_has_metaclass_p(VALUE sklass)
 int
 rb_singleton_class_internal_p(VALUE sklass)
 {
-    return (RB_TYPE_P(rb_attr_get(sklass, id_attached), T_CLASS) &&
+    return (RB_CLASS_TYPE_P(rb_attr_get(sklass, id_attached)) &&
             !rb_singleton_class_has_metaclass_p(sklass));
 }
 
@@ -710,7 +710,7 @@ make_metaclass(VALUE klass)
     }
 
     super = RCLASS_SUPER(klass);
-    while (RB_TYPE_P(super, T_ICLASS)) super = RCLASS_SUPER(super);
+    while (RB_ICLASS_TYPE_P(super)) super = RCLASS_SUPER(super);
     RCLASS_SET_SUPER(metaclass, super ? ENSURE_EIGENCLASS(super) : rb_cClass);
 
     // Full class ancestry may not have been filled until we reach here.
@@ -914,7 +914,7 @@ rb_define_class(const char *name, VALUE super)
     id = rb_intern(name);
     if (rb_const_defined(rb_cObject, id)) {
         klass = rb_const_get(rb_cObject, id);
-        if (!RB_TYPE_P(klass, T_CLASS)) {
+        if (!RB_CLASS_TYPE_P(klass)) {
             rb_raise(rb_eTypeError, "%s is not a class (%"PRIsVALUE")",
                      name, rb_obj_class(klass));
         }
@@ -950,7 +950,7 @@ rb_define_class_id_under(VALUE outer, ID id, VALUE super)
 
     if (rb_const_defined_at(outer, id)) {
         klass = rb_const_get_at(outer, id);
-        if (!RB_TYPE_P(klass, T_CLASS)) {
+        if (!RB_CLASS_TYPE_P(klass)) {
             rb_raise(rb_eTypeError, "%"PRIsVALUE"::%"PRIsVALUE" is not a class"
                      " (%"PRIsVALUE")",
                      outer, rb_id2str(id), rb_obj_class(klass));
@@ -1024,7 +1024,7 @@ rb_define_module(const char *name)
     id = rb_intern(name);
     if (rb_const_defined(rb_cObject, id)) {
         module = rb_const_get(rb_cObject, id);
-        if (!RB_TYPE_P(module, T_MODULE)) {
+        if (!RB_MODULE_TYPE_P(module)) {
             rb_raise(rb_eTypeError, "%s is not a module (%"PRIsVALUE")",
                      name, rb_obj_class(module));
         }
@@ -1052,7 +1052,7 @@ rb_define_module_id_under(VALUE outer, ID id)
 
     if (rb_const_defined_at(outer, id)) {
         module = rb_const_get_at(outer, id);
-        if (!RB_TYPE_P(module, T_MODULE)) {
+        if (!RB_MODULE_TYPE_P(module)) {
             rb_raise(rb_eTypeError, "%"PRIsVALUE"::%"PRIsVALUE" is not a module"
                      " (%"PRIsVALUE")",
                      outer, rb_id2str(id), rb_obj_class(module));
@@ -1080,7 +1080,7 @@ rb_include_class_new(VALUE module, VALUE super)
     if (BUILTIN_TYPE(module) == T_ICLASS) {
         module = METACLASS_OF(module);
     }
-    RUBY_ASSERT(!RB_TYPE_P(module, T_ICLASS));
+    RUBY_ASSERT(!RB_ICLASS_TYPE_P(module));
     if (!RCLASS_CONST_TBL(module)) {
         RCLASS_CONST_TBL(module) = rb_id_table_create(0);
     }
@@ -1118,7 +1118,7 @@ rb_include_module(VALUE klass, VALUE module)
     if (changed < 0)
         rb_raise(rb_eArgError, "cyclic include detected");
 
-    if (RB_TYPE_P(klass, T_MODULE)) {
+    if (RB_MODULE_TYPE_P(klass)) {
         rb_subclass_entry_t *iclass = RCLASS_SUBCLASSES(klass);
         // skip the placeholder subclass entry at the head of the list
         if (iclass) {
@@ -1135,7 +1135,7 @@ rb_include_module(VALUE klass, VALUE module)
                 while (check_class) {
                     RUBY_ASSERT(!rb_objspace_garbage_object_p(check_class));
 
-                    if (RB_TYPE_P(check_class, T_ICLASS) &&
+                    if (RB_ICLASS_TYPE_P(check_class) &&
                             (METACLASS_OF(check_class) == module)) {
                         do_include = 0;
                     }
@@ -1242,12 +1242,12 @@ do_include_modules_at(const VALUE klass, VALUE c, VALUE module, int search_super
         tbl = RCLASS_M_TBL(module);
         if (tbl && rb_id_table_size(tbl)) {
             if (search_super) { // include
-                if (super_class && !RB_TYPE_P(super_class, T_MODULE)) {
+                if (super_class && !RB_MODULE_TYPE_P(super_class)) {
                     rb_id_table_foreach(tbl, clear_module_cache_i, (void *)super_class);
                 }
             }
             else { // prepend
-                if (!RB_TYPE_P(original_klass, T_MODULE)) {
+                if (!RB_MODULE_TYPE_P(original_klass)) {
                     rb_id_table_foreach(tbl, clear_module_cache_i, (void *)original_klass);
                 }
             }
@@ -1378,7 +1378,7 @@ rb_prepend_module(VALUE klass, VALUE module)
     if (changed) {
         rb_vm_check_redefinition_by_prepend(klass);
     }
-    if (RB_TYPE_P(klass, T_MODULE)) {
+    if (RB_MODULE_TYPE_P(klass)) {
         rb_subclass_entry_t *iclass = RCLASS_SUBCLASSES(klass);
         // skip the placeholder subclass entry at the head of the list if it exists
         if (iclass) {
@@ -1444,7 +1444,7 @@ rb_mod_included_modules(VALUE mod)
     for (p = RCLASS_SUPER(mod); p; p = RCLASS_SUPER(p)) {
         if (p != origin && RCLASS_ORIGIN(p) == p && BUILTIN_TYPE(p) == T_ICLASS) {
             VALUE m = METACLASS_OF(p);
-            if (RB_TYPE_P(m, T_MODULE))
+            if (RB_MODULE_TYPE_P(m))
                 rb_ary_push(ary, m);
         }
     }
@@ -2022,7 +2022,7 @@ rb_obj_singleton_methods(int argc, const VALUE *argv, VALUE obj)
     int recur = TRUE;
 
     if (rb_check_arity(argc, 0, 1)) recur = RTEST(argv[0]);
-    if (RB_TYPE_P(obj, T_CLASS) && FL_TEST(obj, FL_SINGLETON)) {
+    if (RB_CLASS_TYPE_P(obj) && FL_TEST(obj, FL_SINGLETON)) {
         rb_singleton_class(obj);
     }
     klass = CLASS_OF(obj);
@@ -2034,7 +2034,7 @@ rb_obj_singleton_methods(int argc, const VALUE *argv, VALUE obj)
         klass = RCLASS_SUPER(klass);
     }
     if (recur) {
-        while (klass && (FL_TEST(klass, FL_SINGLETON) || RB_TYPE_P(klass, T_ICLASS))) {
+        while (klass && (FL_TEST(klass, FL_SINGLETON) || RB_ICLASS_TYPE_P(klass))) {
             if (klass != origin && (mtbl = RCLASS_M_TBL(klass)) != 0) rb_id_table_foreach(mtbl, method_entry_i, &me_arg);
             klass = RCLASS_SUPER(klass);
         }
@@ -2224,7 +2224,7 @@ rb_singleton_class(VALUE obj)
     VALUE klass = singleton_class_of(obj);
 
     /* ensures an exposed class belongs to its own eigenclass */
-    if (RB_TYPE_P(obj, T_CLASS)) (void)ENSURE_EIGENCLASS(klass);
+    if (RB_CLASS_TYPE_P(obj)) (void)ENSURE_EIGENCLASS(klass);
 
     return klass;
 }

--- a/error.c
+++ b/error.c
@@ -2971,7 +2971,7 @@ exception_loader(VALUE exc, VALUE obj)
     // argument is a class object (see TYPE_USERDEF case in r_object0).
     // We want to copy all instance variables (but "bt_locations") from obj to exc.
     // But we do not want to do so in the second case, so the following branch is for that.
-    if (RB_TYPE_P(exc, T_CLASS)) return obj; // maybe called from Marshal's TYPE_USERDEF
+    if (RB_CLASS_TYPE_P(exc)) return obj; // maybe called from Marshal's TYPE_USERDEF
 
     rb_ivar_foreach(obj, ivar_copy_i, exc);
 

--- a/eval.c
+++ b/eval.c
@@ -433,7 +433,7 @@ rb_class_modify_check(VALUE klass)
     if (SPECIAL_CONST_P(klass)) {
         Check_Type(klass, T_CLASS);
     }
-    if (RB_TYPE_P(klass, T_MODULE)) {
+    if (RB_MODULE_TYPE_P(klass)) {
         rb_module_set_initialized(klass);
     }
     if (OBJ_FROZEN(klass)) {
@@ -1220,7 +1220,7 @@ rb_mod_prepend(int argc, VALUE *argv, VALUE module)
 static void
 ensure_class_or_module(VALUE obj)
 {
-    if (!RB_TYPE_P(obj, T_CLASS) && !RB_TYPE_P(obj, T_MODULE)) {
+    if (!RB_CLASS_TYPE_P(obj) && !RB_MODULE_TYPE_P(obj)) {
         rb_raise(rb_eTypeError,
                  "wrong argument type %"PRIsVALUE" (expected Class or Module)",
                  rb_obj_class(obj));
@@ -1239,7 +1239,7 @@ hidden_identity_hash_new(void)
 static VALUE
 refinement_superclass(VALUE superclass)
 {
-    if (RB_TYPE_P(superclass, T_MODULE)) {
+    if (RB_MODULE_TYPE_P(superclass)) {
         /* FIXME: Should ancestors of superclass be used here? */
         return rb_include_class_new(RCLASS_ORIGIN(superclass), rb_cBasicObject);
     }
@@ -1268,7 +1268,7 @@ rb_using_refinement(rb_cref_t *cref, VALUE klass, VALUE module)
         }
         if (!NIL_P(c = rb_hash_lookup(CREF_REFINEMENTS(cref), klass))) {
             superclass = c;
-            while (c && RB_TYPE_P(c, T_ICLASS)) {
+            while (c && RB_ICLASS_TYPE_P(c)) {
                 if (RBASIC(c)->klass == module) {
                     /* already used refinement */
                     return;
@@ -1365,7 +1365,7 @@ add_activated_refinement(VALUE activated_refinements,
 
     if (!NIL_P(c = rb_hash_lookup(activated_refinements, klass))) {
         superclass = c;
-        while (c && RB_TYPE_P(c, T_ICLASS)) {
+        while (c && RB_ICLASS_TYPE_P(c)) {
             if (RBASIC(c)->klass == refinement) {
                 /* already used refinement */
                 return;

--- a/eval_error.c
+++ b/eval_error.c
@@ -393,7 +393,7 @@ rb_ec_error_print(rb_execution_context_t *volatile ec, volatile VALUE errinfo)
 void
 rb_print_undef(VALUE klass, ID id, rb_method_visibility_t visi)
 {
-    const int is_mod = RB_TYPE_P(klass, T_MODULE);
+    const int is_mod = RB_MODULE_TYPE_P(klass);
     VALUE mesg;
     switch (visi & METHOD_VISI_MASK) {
       case METHOD_VISI_UNDEF:
@@ -408,7 +408,7 @@ rb_print_undef(VALUE klass, ID id, rb_method_visibility_t visi)
 void
 rb_print_undef_str(VALUE klass, VALUE name)
 {
-    const int is_mod = RB_TYPE_P(klass, T_MODULE);
+    const int is_mod = RB_MODULE_TYPE_P(klass);
     rb_name_err_raise_str(undef_mesg(""), klass, name);
 }
 
@@ -421,7 +421,7 @@ rb_print_undef_str(VALUE klass, VALUE name)
 void
 rb_print_inaccessible(VALUE klass, ID id, rb_method_visibility_t visi)
 {
-    const int is_mod = RB_TYPE_P(klass, T_MODULE);
+    const int is_mod = RB_MODULE_TYPE_P(klass);
     VALUE mesg;
     switch (visi & METHOD_VISI_MASK) {
       case METHOD_VISI_UNDEF:

--- a/internal.h
+++ b/internal.h
@@ -104,6 +104,9 @@ RUBY_SYMBOL_EXPORT_END
 
 #define RBOOL(v) ((v) ? Qtrue : Qfalse)
 #define RB_BIGNUM_TYPE_P(x) RB_TYPE_P((x), T_BIGNUM)
+#define RB_CLASS_TYPE_P(x) RB_TYPE_P((x), T_CLASS)
+#define RB_MODULE_TYPE_P(x) RB_TYPE_P((x), T_MODULE)
+#define RB_ICLASS_TYPE_P(x) RB_TYPE_P((x), T_ICLASS)
 
 #ifndef __MINGW32__
 #undef memcpy

--- a/load.c
+++ b/load.c
@@ -749,7 +749,7 @@ rb_load_internal(VALUE fname, VALUE wrap)
     rb_execution_context_t *ec = GET_EC();
     enum ruby_tag_type state = TAG_NONE;
     if (RTEST(wrap)) {
-        if (!RB_TYPE_P(wrap, T_MODULE)) {
+        if (!RB_MODULE_TYPE_P(wrap)) {
             wrap = rb_module_new();
         }
         state = load_wrapping(ec, fname, wrap);

--- a/marshal.c
+++ b/marshal.c
@@ -265,7 +265,7 @@ class2path(VALUE klass)
 {
     VALUE path = rb_class_path(klass);
 
-    must_not_be_anonymous((RB_TYPE_P(klass, T_CLASS) ? "class" : "module"), path);
+    must_not_be_anonymous((RB_CLASS_TYPE_P(klass) ? "class" : "module"), path);
     if (rb_path_to_class(path) != rb_class_real(klass)) {
         rb_raise(rb_eTypeError, "% "PRIsVALUE" can't be referred to", path);
     }
@@ -1657,7 +1657,7 @@ r_leave(VALUE v, struct load_arg *arg, bool partial)
         st_data_t key = (st_data_t)v;
         st_delete(arg->partial_objects, &key, &data);
         if (arg->freeze) {
-            if (RB_TYPE_P(v, T_MODULE) || RB_TYPE_P(v, T_CLASS)) {
+            if (RB_MODULE_TYPE_P(v) || RB_CLASS_TYPE_P(v)) {
                 // noop
             }
             else if (RB_TYPE_P(v, T_STRING)) {
@@ -1730,7 +1730,7 @@ path2class(VALUE path)
 {
     VALUE v = rb_path_to_class(path);
 
-    if (!RB_TYPE_P(v, T_CLASS)) {
+    if (!RB_CLASS_TYPE_P(v)) {
         rb_raise(rb_eArgError, "%"PRIsVALUE" does not refer to class", path);
     }
     return v;
@@ -1741,7 +1741,7 @@ path2class(VALUE path)
 static VALUE
 must_be_module(VALUE v, VALUE path)
 {
-    if (!RB_TYPE_P(v, T_MODULE)) {
+    if (!RB_MODULE_TYPE_P(v)) {
         rb_raise(rb_eArgError, "%"PRIsVALUE" does not refer to module", path);
     }
     return v;
@@ -1839,7 +1839,7 @@ r_object_for(struct load_arg *arg, bool partial, int *ivp, VALUE extmod, int typ
             VALUE m = rb_path_to_class(path);
             if (NIL_P(extmod)) extmod = rb_ary_hidden_new(0);
 
-            if (RB_TYPE_P(m, T_CLASS)) { /* prepended */
+            if (RB_CLASS_TYPE_P(m)) { /* prepended */
                 VALUE c;
 
                 v = r_object0(arg, true, 0, Qnil);
@@ -1883,10 +1883,10 @@ r_object_for(struct load_arg *arg, bool partial, int *ivp, VALUE extmod, int typ
                 goto type_hash;
             }
             v = r_object_for(arg, partial, 0, extmod, type);
-            if (rb_special_const_p(v) || RB_TYPE_P(v, T_OBJECT) || RB_TYPE_P(v, T_CLASS)) {
+            if (rb_special_const_p(v) || RB_TYPE_P(v, T_OBJECT) || RB_CLASS_TYPE_P(v)) {
                 goto format_error;
             }
-            if (RB_TYPE_P(v, T_MODULE) || !RTEST(rb_class_inherited_p(c, RBASIC(v)->klass))) {
+            if (RB_MODULE_TYPE_P(v) || !RTEST(rb_class_inherited_p(c, RBASIC(v)->klass))) {
                 VALUE tmp = rb_obj_alloc(c);
 
                 if (TYPE(v) != TYPE(tmp)) goto format_error;

--- a/proc.c
+++ b/proc.c
@@ -2007,7 +2007,7 @@ rb_method_name_error(VALUE klass, VALUE str)
             break;
         }
     }
-    else if (RB_TYPE_P(c, T_MODULE)) {
+    else if (RB_MODULE_TYPE_P(c)) {
         s = MSG(" module");
     }
     if (UNDEF_P(s)) {
@@ -2243,7 +2243,7 @@ rb_mod_define_method_with_visibility(int argc, VALUE *argv, VALUE mod, const str
 
     if (is_method) {
         struct METHOD *method = (struct METHOD *)DATA_PTR(body);
-        if (method->me->owner != mod && !RB_TYPE_P(method->me->owner, T_MODULE) &&
+        if (method->me->owner != mod && !RB_MODULE_TYPE_P(method->me->owner) &&
             !RTEST(rb_class_inherited_p(mod, method->me->owner))) {
             if (FL_TEST(method->me->owner, FL_SINGLETON)) {
                 rb_raise(rb_eTypeError,
@@ -2589,11 +2589,11 @@ convert_umethod_to_method_components(const struct METHOD *data, VALUE recv, VALU
     VALUE iclass = data->me->defined_class;
     VALUE klass = CLASS_OF(recv);
 
-    if (RB_TYPE_P(methclass, T_MODULE)) {
+    if (RB_MODULE_TYPE_P(methclass)) {
         VALUE refined_class = rb_refinement_module_get_refined_class(methclass);
         if (!NIL_P(refined_class)) methclass = refined_class;
     }
-    if (!RB_TYPE_P(methclass, T_MODULE) && !RTEST(rb_obj_is_kind_of(recv, methclass))) {
+    if (!RB_MODULE_TYPE_P(methclass) && !RTEST(rb_obj_is_kind_of(recv, methclass))) {
         if (FL_TEST(methclass, FL_SINGLETON)) {
             rb_raise(rb_eTypeError,
                      "singleton method called for a different object");
@@ -2612,7 +2612,7 @@ convert_umethod_to_method_components(const struct METHOD *data, VALUE recv, VALU
         me = data->me;
     }
 
-    if (RB_TYPE_P(me->owner, T_MODULE)) {
+    if (RB_MODULE_TYPE_P(me->owner)) {
         if (!clone) {
             // if we didn't previously clone the method entry, then we need to clone it now
             // because this branch manipulates it in rb_method_entry_complement_defined_class
@@ -3142,7 +3142,7 @@ method_inspect(VALUE method)
     mklass = data->iclass;
     if (!mklass) mklass = data->klass;
 
-    if (RB_TYPE_P(mklass, T_ICLASS)) {
+    if (RB_ICLASS_TYPE_P(mklass)) {
         /* TODO: I'm not sure why mklass is T_ICLASS.
          * UnboundMethod#bind() can set it as T_ICLASS at convert_umethod_to_method_components()
          * but not sure it is needed.
@@ -3157,7 +3157,7 @@ method_inspect(VALUE method)
         defined_class = method_entry_defined_class(data->me);
     }
 
-    if (RB_TYPE_P(defined_class, T_ICLASS)) {
+    if (RB_ICLASS_TYPE_P(defined_class)) {
         defined_class = RBASIC_CLASS(defined_class);
     }
 
@@ -3187,10 +3187,10 @@ method_inspect(VALUE method)
         mklass = data->klass;
         if (FL_TEST(mklass, FL_SINGLETON)) {
             VALUE v = rb_ivar_get(mklass, attached);
-            if (!(RB_TYPE_P(v, T_CLASS) || RB_TYPE_P(v, T_MODULE))) {
+            if (!(RB_CLASS_TYPE_P(v) || RB_MODULE_TYPE_P(v))) {
                 do {
                    mklass = RCLASS_SUPER(mklass);
-                } while (RB_TYPE_P(mklass, T_ICLASS));
+                } while (RB_ICLASS_TYPE_P(mklass));
             }
         }
         rb_str_buf_append(str, rb_inspect(mklass));

--- a/ractor.c
+++ b/ractor.c
@@ -2562,9 +2562,9 @@ shareable_p_enter(VALUE obj)
     if (RB_OBJ_SHAREABLE_P(obj)) {
         return traverse_skip;
     }
-    else if (RB_TYPE_P(obj, T_CLASS)  ||
-             RB_TYPE_P(obj, T_MODULE) ||
-             RB_TYPE_P(obj, T_ICLASS)) {
+    else if (RB_CLASS_TYPE_P(obj)  ||
+             RB_MODULE_TYPE_P(obj) ||
+             RB_ICLASS_TYPE_P(obj)) {
         // TODO: remove it
         mark_shareable(obj);
         return traverse_skip;

--- a/shape.c
+++ b/shape.c
@@ -80,7 +80,7 @@ rb_shape_get_parent(rb_shape_t * shape)
 shape_id_t
 rb_rclass_shape_id(VALUE obj)
 {
-    RUBY_ASSERT(RB_TYPE_P(obj, T_CLASS) || RB_TYPE_P(obj, T_MODULE));
+    RUBY_ASSERT(RB_CLASS_TYPE_P(obj) || RB_MODULE_TYPE_P(obj));
     return RCLASS_EXT(obj)->shape_id;
 }
 

--- a/struct.c
+++ b/struct.c
@@ -50,7 +50,7 @@ struct_ivar_get(VALUE c, ID id)
         c = rb_class_superclass(c);
         if (c == rb_cStruct || c == rb_cData || !RTEST(c))
             return Qnil;
-        RUBY_ASSERT(RB_TYPE_P(c, T_CLASS));
+        RUBY_ASSERT(RB_CLASS_TYPE_P(c));
         ivar = rb_attr_get(c, id);
         if (!NIL_P(ivar)) {
             return rb_ivar_set(orig, id, ivar);

--- a/variable.c
+++ b/variable.c
@@ -161,7 +161,7 @@ rb_tmp_class_path(VALUE klass, bool *permanent, fallback_func fallback)
         return path;
     }
     else {
-        if (RB_TYPE_P(klass, T_MODULE)) {
+        if (RB_MODULE_TYPE_P(klass)) {
             if (rb_obj_class(klass) == rb_cModule) {
                 path = Qfalse;
             }
@@ -935,7 +935,7 @@ gen_ivtbl_get_unlocked(VALUE obj, ID id, struct gen_ivtbl **ivtbl)
 MJIT_FUNC_EXPORTED int
 rb_gen_ivtbl_get(VALUE obj, ID id, struct gen_ivtbl **ivtbl)
 {
-    RUBY_ASSERT(!RB_TYPE_P(obj, T_ICLASS));
+    RUBY_ASSERT(!RB_ICLASS_TYPE_P(obj));
 
     st_data_t data;
     int r = 0;
@@ -1705,7 +1705,7 @@ gen_ivar_each(VALUE obj, rb_ivar_foreach_callback_func *func, st_data_t arg)
 static void
 class_ivar_each(VALUE obj, rb_ivar_foreach_callback_func *func, st_data_t arg)
 {
-    RUBY_ASSERT(RB_TYPE_P(obj, T_CLASS) || RB_TYPE_P(obj, T_MODULE));
+    RUBY_ASSERT(RB_CLASS_TYPE_P(obj) || RB_MODULE_TYPE_P(obj));
 
     rb_shape_t* shape = rb_shape_get_shape(obj);
     struct iv_itr_data itr_data;
@@ -2113,7 +2113,7 @@ autoload_data(VALUE mod, ID id)
 
     // If we are called with a non-origin ICLASS, fetch the autoload data from
     // the original module.
-    if (RB_TYPE_P(mod, T_ICLASS)) {
+    if (RB_ICLASS_TYPE_P(mod)) {
         if (FL_TEST_RAW(mod, RICLASS_IS_ORIGIN)) {
             return 0;
         }
@@ -2122,7 +2122,7 @@ autoload_data(VALUE mod, ID id)
         }
     }
 
-    RUBY_ASSERT(RB_TYPE_P(mod, T_CLASS) || RB_TYPE_P(mod, T_MODULE));
+    RUBY_ASSERT(RB_CLASS_TYPE_P(mod) || RB_MODULE_TYPE_P(mod));
 
     // Look up the instance variable table for `autoload`, then index into that table with the given constant name `id`.
 
@@ -2404,7 +2404,7 @@ autoload_delete(VALUE module, ID name)
 
     st_data_t load = 0, key = name;
 
-    RUBY_ASSERT(RB_TYPE_P(module, T_CLASS) || RB_TYPE_P(module, T_MODULE));
+    RUBY_ASSERT(RB_CLASS_TYPE_P(module) || RB_MODULE_TYPE_P(module));
 
     VALUE table_value = rb_ivar_lookup(module, autoload, 0);
     if (table_value) {
@@ -3553,7 +3553,7 @@ rb_mod_deprecate_constant(int argc, const VALUE *argv, VALUE obj)
 static VALUE
 original_module(VALUE c)
 {
-    if (RB_TYPE_P(c, T_ICLASS))
+    if (RB_ICLASS_TYPE_P(c))
         return RBASIC(c)->klass;
     return c;
 }
@@ -3561,7 +3561,7 @@ original_module(VALUE c)
 static int
 cvar_lookup_at(VALUE klass, ID id, st_data_t *v)
 {
-    if (RB_TYPE_P(klass, T_ICLASS)) {
+    if (RB_ICLASS_TYPE_P(klass)) {
         if (FL_TEST_RAW(klass, RICLASS_IS_ORIGIN)) {
             return 0;
         }
@@ -3647,7 +3647,7 @@ static void
 check_for_cvar_table(VALUE subclass, VALUE key)
 {
     // Must not check ivar on ICLASS
-    if (!RB_TYPE_P(subclass, T_ICLASS) && RTEST(rb_ivar_defined(subclass, key))) {
+    if (!RB_ICLASS_TYPE_P(subclass) && RTEST(rb_ivar_defined(subclass, key))) {
         RB_DEBUG_COUNTER_INC(cvar_class_invalidate);
         ruby_vm_global_cvar_state++;
         return;
@@ -3670,7 +3670,7 @@ rb_cvar_set(VALUE klass, ID id, VALUE val)
         target = tmp;
     }
 
-    if (RB_TYPE_P(target, T_ICLASS)) {
+    if (RB_ICLASS_TYPE_P(target)) {
         target = RBASIC(target)->klass;
     }
     check_before_mod_set(target, id, val, "class variable");
@@ -3702,7 +3702,7 @@ rb_cvar_set(VALUE klass, ID id, VALUE val)
     // and target is a module or a subclass with the same
     // cvar in this lookup.
     if (result == 0) {
-        if (RB_TYPE_P(target, T_CLASS)) {
+        if (RB_CLASS_TYPE_P(target)) {
             if (RCLASS_SUBCLASSES(target)) {
                 rb_class_foreach_subclass(target, check_for_cvar_table, id);
             }
@@ -3937,7 +3937,7 @@ rb_iv_set(VALUE obj, const char *name, VALUE val)
 int
 rb_class_ivar_set(VALUE obj, ID key, VALUE value)
 {
-    RUBY_ASSERT(RB_TYPE_P(obj, T_CLASS) || RB_TYPE_P(obj, T_MODULE));
+    RUBY_ASSERT(RB_CLASS_TYPE_P(obj) || RB_MODULE_TYPE_P(obj));
     int found;
     rb_check_frozen(obj);
 
@@ -3991,7 +3991,7 @@ void
 rb_iv_tbl_copy(VALUE dst, VALUE src)
 {
     RUBY_ASSERT(rb_type(dst) == rb_type(src));
-    RUBY_ASSERT(RB_TYPE_P(dst, T_CLASS) || RB_TYPE_P(dst, T_MODULE));
+    RUBY_ASSERT(RB_CLASS_TYPE_P(dst) || RB_MODULE_TYPE_P(dst));
 
     RUBY_ASSERT(RCLASS_SHAPE_ID(dst) == ROOT_SHAPE_ID || rb_shape_get_shape_by_id(RCLASS_SHAPE_ID(dst))->type == SHAPE_INITIAL_CAPACITY);
     RUBY_ASSERT(!RCLASS_IVPTR(dst));

--- a/vm.c
+++ b/vm.c
@@ -538,7 +538,7 @@ rb_dtrace_setup(rb_execution_context_t *ec, VALUE klass, ID id,
         if (!rb_ec_frame_method_id_and_class(ec, &id, 0, &klass) || !klass)
             return FALSE;
     }
-    if (RB_TYPE_P(klass, T_ICLASS)) {
+    if (RB_ICLASS_TYPE_P(klass)) {
         klass = RBASIC(klass)->klass;
     }
     else if (FL_TEST(klass, FL_SINGLETON)) {
@@ -1966,8 +1966,8 @@ static void
 rb_vm_check_redefinition_opt_method(const rb_method_entry_t *me, VALUE klass)
 {
     st_data_t bop;
-    if (RB_TYPE_P(klass, T_ICLASS) && FL_TEST(klass, RICLASS_IS_ORIGIN) &&
-            RB_TYPE_P(RBASIC_CLASS(klass), T_CLASS)) {
+    if (RB_ICLASS_TYPE_P(klass) && FL_TEST(klass, RICLASS_IS_ORIGIN) &&
+            RB_CLASS_TYPE_P(RBASIC_CLASS(klass))) {
        klass = RBASIC_CLASS(klass);
     }
     if (vm_redefinition_check_method_type(me)) {

--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -1394,7 +1394,7 @@ get_klass(const rb_control_frame_t *cfp)
 {
     VALUE klass;
     if (rb_vm_control_frame_id_and_class(cfp, 0, 0, &klass)) {
-        if (RB_TYPE_P(klass, T_ICLASS)) {
+        if (RB_ICLASS_TYPE_P(klass)) {
             return RBASIC(klass)->klass;
         }
         else {
@@ -1741,12 +1741,12 @@ rb_profile_frame_classpath(VALUE frame)
     VALUE klass = frame2klass(frame);
 
     if (klass && !NIL_P(klass)) {
-        if (RB_TYPE_P(klass, T_ICLASS)) {
+        if (RB_ICLASS_TYPE_P(klass)) {
             klass = RBASIC(klass)->klass;
         }
         else if (FL_TEST(klass, FL_SINGLETON)) {
             klass = rb_ivar_get(klass, id__attached__);
-            if (!RB_TYPE_P(klass, T_CLASS) && !RB_TYPE_P(klass, T_MODULE))
+            if (!RB_CLASS_TYPE_P(klass) && !RB_MODULE_TYPE_P(klass))
                 return rb_sprintf("#<%s:%p>", rb_class2name(rb_obj_class(klass)), (void*)klass);
         }
         return rb_class_path(klass);

--- a/vm_dump.c
+++ b/vm_dump.c
@@ -1109,8 +1109,8 @@ rb_vm_bugreport(const void *ctx)
                     fprintf(stderr, " %4d %.*s\n", i,
                             LIMITED_NAME_LENGTH(name), RSTRING_PTR(name));
                 }
-                else if (RB_TYPE_P(name, T_CLASS) || RB_TYPE_P(name, T_MODULE)) {
-                    const char *const type = RB_TYPE_P(name, T_CLASS) ?
+                else if (RB_CLASS_TYPE_P(name) || RB_MODULE_TYPE_P(name)) {
+                    const char *const type = RB_CLASS_TYPE_P(name) ?
                         "class" : "module";
                     name = rb_search_class_path(rb_class_real(name));
                     if (!RB_TYPE_P(name, T_STRING)) {

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -841,7 +841,7 @@ rb_method_call_status(rb_execution_context_t *ec, const rb_callable_method_entry
                  scope == CALL_PUBLIC) {
 
             VALUE defined_class = me->owner;
-            if (RB_TYPE_P(defined_class, T_ICLASS)) {
+            if (RB_ICLASS_TYPE_P(defined_class)) {
                 defined_class = RBASIC(defined_class)->klass;
             }
 
@@ -1918,7 +1918,7 @@ yield_under(VALUE self, int singleton, int argc, const VALUE *argv, int kw_splat
         VM_FORCE_WRITE_SPECIAL_CONST(&VM_CF_LEP(ec->cfp)[VM_ENV_DATA_INDEX_SPECVAL], new_block_handler);
     }
 
-    VM_ASSERT(singleton || RB_TYPE_P(self, T_MODULE) || RB_TYPE_P(self, T_CLASS));
+    VM_ASSERT(singleton || RB_MODULE_TYPE_P(self) || RB_CLASS_TYPE_P(self));
     cref = vm_cref_push(ec, self, ep, TRUE, singleton);
 
     return vm_yield_with_cref(ec, argc, argv, kw_splat, cref, is_lambda);

--- a/vm_trace.c
+++ b/vm_trace.c
@@ -720,7 +720,7 @@ call_trace_func(rb_event_flag_t event, VALUE proc, VALUE self, ID id, VALUE klas
     }
 
     if (klass) {
-        if (RB_TYPE_P(klass, T_ICLASS)) {
+        if (RB_ICLASS_TYPE_P(klass)) {
             klass = RBASIC(klass)->klass;
         }
         else if (FL_TEST(klass, FL_SINGLETON)) {
@@ -890,7 +890,7 @@ fill_id_and_klass(rb_trace_arg_t *trace_arg)
         }
 
         if (trace_arg->klass) {
-            if (RB_TYPE_P(trace_arg->klass, T_ICLASS)) {
+            if (RB_ICLASS_TYPE_P(trace_arg->klass)) {
                 trace_arg->klass = RBASIC(trace_arg->klass)->klass;
             }
         }


### PR DESCRIPTION
Some codes check to Class(IClass) or Module type in Ruby.

```c
(!RB_TYPE_P(obj, T_CLASS) && !RB_TYPE_P(obj, T_MODULE))
```

But, I though better and more shoter to using these type check macro.

```c
#define RB_CLASS_TYPE_P(x) RB_TYPE_P((x), T_CLASS)
#define RB_MODULE_TYPE_P(x) RB_TYPE_P((x), T_MODULE)
#define RB_ICLASS_TYPE_P(x) RB_TYPE_P((x), T_ICLASS)
```
