### PR TITLE
Minor mistake change - replacing "method" by "variable"

### DIFF
--- a/doc/syntax/assignment.rdoc
+++ b/doc/syntax/assignment.rdoc
@@ -107,7 +107,7 @@ Rather than printing "true" you receive a NameError, "undefined local variable
 or method `a'".  Since ruby parses the bare +a+ left of the +if+ first and has
 not yet seen an assignment to +a+ it assumes you wish to call a method.  Ruby
 then sees the assignment to +a+ and will assume you are referencing a local
-method.
+variable.
 
 The confusion comes from the out-of-order execution of the expression.  First
 the local variable is assigned-to then you attempt to call a nonexistent


### PR DESCRIPTION
After reading through the docs [Syntax -> Assignment -> Local Variables and Methods](https://docs.ruby-lang.org/en/master/syntax/assignment_rdoc.html#label-Local+Variables+and+Methods) I was confused by the usage of `local method` in that place.

After reading I found that the same phrase was used in the [Syntax -> Control Expression -> Modifier if and unless](https://docs.ruby-lang.org/en/master/syntax/control_expressions_rdoc.html#label-Modifier+if+and+unless), but it used the correct word `variable` instead of `method`. Thus opening this PR to fix the issue.