### PR TITLE
[Bug #19362] Call `#initialize_dup` hook at `Proc#dup`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -49,6 +49,10 @@ Note: We're only listing outstanding class updates.
       The class use equality semantic to lookup keys like a regular hash,
       but it doesn't hold strong references on the keys. [[Feature #18498]]
 
+* Proc
+    * Now Proc#dup and Proc#clone call `#initialize_dup` and `#initialize_clone`
+      hooks respectively.  [[Feature #19362]]
+
 * Process.warmup
 
     * Notify the Ruby virtual machine that the boot sequence is finished,
@@ -220,6 +224,7 @@ changelog for details of the default gems or bundled gems.
 [Feature #19314]: https://bugs.ruby-lang.org/issues/19314
 [Feature #19347]: https://bugs.ruby-lang.org/issues/19347
 [Feature #19351]: https://bugs.ruby-lang.org/issues/19351
+[Feature #19362]: https://bugs.ruby-lang.org/issues/19362
 [Feature #19521]: https://bugs.ruby-lang.org/issues/19521
 [Feature #19538]: https://bugs.ruby-lang.org/issues/19538
 [Feature #19591]: https://bugs.ruby-lang.org/issues/19591

--- a/proc.c
+++ b/proc.c
@@ -152,6 +152,16 @@ proc_clone(VALUE self)
 {
     VALUE procval = rb_proc_dup(self);
     CLONESETUP(procval, self);
+    rb_check_funcall(procval, idInitialize_clone, 1, &self);
+    return procval;
+}
+
+/* :nodoc: */
+static VALUE
+proc_dup(VALUE self)
+{
+    VALUE procval = rb_proc_dup(self);
+    rb_check_funcall(procval, idInitialize_dup, 1, &self);
     return procval;
 }
 
@@ -4258,7 +4268,7 @@ Init_Proc(void)
     rb_define_method(rb_cProc, "to_proc", proc_to_proc, 0);
     rb_define_method(rb_cProc, "arity", proc_arity, 0);
     rb_define_method(rb_cProc, "clone", proc_clone, 0);
-    rb_define_method(rb_cProc, "dup", rb_proc_dup, 0);
+    rb_define_method(rb_cProc, "dup", proc_dup, 0);
     rb_define_method(rb_cProc, "hash", proc_hash, 0);
     rb_define_method(rb_cProc, "to_s", proc_to_s, 0);
     rb_define_alias(rb_cProc, "inspect", "to_s");

--- a/test/ruby/test_proc.rb
+++ b/test/ruby/test_proc.rb
@@ -388,6 +388,15 @@ class TestProc < Test::Unit::TestCase
   def test_dup_subclass
     c1 = Class.new(Proc)
     assert_equal c1, c1.new{}.dup.class, '[Bug #17545]'
+    c1 = Class.new(Proc) {def initialize_dup(*) throw :initialize_dup; end}
+    assert_throw(:initialize_dup) {c1.new{}.dup}
+  end
+
+  def test_clone_subclass
+    c1 = Class.new(Proc)
+    assert_equal c1, c1.new{}.clone.class, '[Bug #17545]'
+    c1 = Class.new(Proc) {def initialize_clone(*) throw :initialize_clone; end}
+    assert_throw(:initialize_clone) {c1.new{}.clone}
   end
 
   def test_binding


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/19362