### PR TITLE
Ractor.make_shareable(proc_obj) makes inner structure shareable

### DIFF
--- a/vm.c
+++ b/vm.c
@@ -1284,6 +1284,7 @@ rb_proc_ractor_make_shareable(VALUE self)
     }
 
     FL_SET_RAW(self, RUBY_FL_SHAREABLE);
+    rb_obj_freeze(self);
     return self;
 }
 


### PR DESCRIPTION
Proc objects are now traversed like other objects when making them shareable.

Fixes [Bug #19372]

https://bugs.ruby-lang.org/issues/19372