### PR TITLE
Limit maximum number of IVs on a shape

### DIFF
--- a/shape.c
+++ b/shape.c
@@ -139,7 +139,7 @@ get_next_shape_internal(rb_shape_t * shape, ID id, enum shape_type shape_type, b
 
     *variation_created = false;
 
-    if (new_shapes_allowed) {
+    if (new_shapes_allowed && shape->next_iv_index < SHAPE_MAX_NUM_IVS) {
         RB_VM_LOCK_ENTER();
         {
             bool had_edges = !!shape->edges;

--- a/shape.h
+++ b/shape.h
@@ -31,6 +31,7 @@ typedef uint16_t shape_id_t;
 # define SHAPE_BITMAP_SIZE 16384
 
 # define SHAPE_MAX_VARIATIONS 8
+# define SHAPE_MAX_NUM_IVS 50
 
 # define MAX_SHAPE_ID (SHAPE_MASK - 1)
 # define INVALID_SHAPE_ID SHAPE_MASK


### PR DESCRIPTION
Create SHAPE_MAX_NUM_IVS (currently 50) and limit all shapes to that number of IVs. When a shape has more than 50 IVs, fallback to the obj_too_complex shape which uses hash lookup for IVs.

This is in response to [Bug #19334](https://bugs.ruby-lang.org/issues/19334) and can be backported. 

We can see the time it takes to run the sample script supplied in the bug is significantly less. Here is the script:

```
class C
  eval("def initialize; #{ (0..100000).map { "@x#{ _1 } = 0; " }.join } end")
  attr_reader :x50000
end
p :start
C.new.x50000
```

Timing it on this branch we get:

```
$ time ruby -v test.rb 
ruby 3.3.0dev (2023-01-25T16:50:33Z limit-num-shapes 29c90b22bb) [arm64-darwin22]
:start
ruby -v test.rb  0.13s user 0.03s system 96% cpu 0.159 total
```

And on Ruby 3.1.3:

```
$ time ruby -v test.rb
ruby 3.1.3p185 (2022-11-24 revision 1a6b16756e) [arm64-darwin22]
:start
ruby -v test.rb  0.13s user 0.03s system 97% cpu 0.165 total
```