### PR TITLE
Enable code-coverage result for test-spec

### DIFF
--- a/spec/default.mspec
+++ b/spec/default.mspec
@@ -4,6 +4,7 @@ if (opt = ENV["RUBYOPT"]) and (opt = opt.dup).sub!(/(?:\A|\s)-w(?=\z|\s)/, '')
   ENV["RUBYOPT"] = opt
 end
 require "./rbconfig" unless defined?(RbConfig)
+require_relative "../tool/test-coverage" if ENV.key?("COVERAGE")
 load File.dirname(__FILE__) + '/ruby/default.mspec'
 OBJDIR = File.expand_path("spec/ruby/optional/capi/ext")
 class MSpecScript
@@ -24,6 +25,10 @@ class MSpecScript
       #{srcdir}/tool/runruby.rb --archdir=#{builddir} --extout=#{config['EXTOUT']}
       --
     ]
+  end
+
+  if ENV.key?("COVERAGE")
+    set :excludes, ["Coverage"]
   end
 end
 


### PR DESCRIPTION
Try to enable coverage measurement with `make test-spec`. But when coverage enabled, expectation is different number only excluding `Coverage` examples.

```
$ make test-spec
revision.h updated
$ /Users/hsbt/Documents/github.com/ruby/ruby/miniruby -I/Users/hsbt/Documents/github.com/ruby/ruby/lib /Users/hsbt/Documents/github.com/ruby/ruby/tool/runruby.rb --archdir=/Users/hsbt/Documents/github.com/ruby/ruby --extout=.ext -- /Users/hsbt/Documents/github.com/ruby/ruby/spec/mspec/bin/mspec-run -B ./spec/default.mspec
ruby 3.3.0dev (2023-01-26T04:52:20Z enable-code-covera.. 6608d47bed) [arm64-darwin22]
[\ | ==================100%================== | 00:00:00]      0F      0E

Finished in 53.628479 seconds

3835 files, 31673 examples, 263963 expectations, 0 failures, 0 errors, 0 tagged
```

```
$ COVERAGE=1 make test-spec
$ /Users/hsbt/Documents/github.com/ruby/ruby/miniruby -I/Users/hsbt/Documents/github.com/ruby/ruby/lib /Users/hsbt/Documents/github.com/ruby/ruby/tool/runruby.rb --archdir=/Users/hsbt/Documents/github.com/ruby/ruby --extout=.ext -- /Users/hsbt/Documents/github.com/ruby/ruby/spec/mspec/bin/mspec-run -B ./spec/default.mspec
ruby 3.3.0dev (2023-01-26T05:05:01Z enable-code-covera.. 2d98127131) [arm64-darwin22]
[/ | ==================100%================== | 00:00:00]      0F      0E

Finished in 54.983961 seconds

3835 files, 31673 examples, 203888 expectations, 0 failures, 0 errors, 18 tagged
Coverage report generated for Ruby's `make test-all` to /Users/hsbt/Documents/github.com/ruby/ruby/coverage. 8047 / 13816 LOC (58.24%) covered.
```

🤔 