### PR TITLE
Fix reference to proper list type RDoc::MarkupReference

### DIFF
--- a/doc/rdoc/markup_reference.rb
+++ b/doc/rdoc/markup_reference.rb
@@ -346,7 +346,7 @@ require 'rdoc'
 #
 # ===== Lettered Lists
 #
-# A numbered list item begins with a letters and a period.
+# A lettered list item begins with letters and a period.
 #
 # The items are automatically "re-lettered."
 #


### PR DESCRIPTION
The "Lettered List" section referred to the previous "Numbered List" section, so this PR fixes that reference to point instead of lettered lists.