### PR TITLE
Deprecate SecurityError

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,10 @@ Note: We're only listing outstanding class updates.
     * `String#unpack` now raises ArgumentError for unknown directives. [[Bug #19150]]
     * `String#bytesplice` now accepts new arguments index/length or range of the source string to be copied.  [[Feature #19314]]
 
+* SecurityError
+
+    * SecurityError is now deprecated.  It will be removed in Ruby 3.4.
+
 ## Stdlib updates
 
 The following default gems are updated.

--- a/error.c
+++ b/error.c
@@ -1097,7 +1097,7 @@ VALUE rb_eNameError;
 VALUE rb_eEncodingError;
 VALUE rb_eEncCompatError;
 VALUE rb_eNoMethodError;
-VALUE rb_eSecurityError;
+VALUE rb__eSecurityError;
 VALUE rb_eNotImpError;
 VALUE rb_eNoMemError;
 VALUE rb_cNameErrorMesg;
@@ -2789,7 +2789,7 @@ syserr_eqq(VALUE self, VALUE exc)
 /*
  *  Document-class: SecurityError
  *
- *  No longer used by internal code.
+ *  Deprecated, no longer used by internal code.
  */
 
 /*
@@ -3062,7 +3062,9 @@ Init_Exception(void)
     rb_eFrozenError = rb_define_class("FrozenError", rb_eRuntimeError);
     rb_define_method(rb_eFrozenError, "initialize", frozen_err_initialize, -1);
     rb_define_method(rb_eFrozenError, "receiver", frozen_err_receiver, 0);
-    rb_eSecurityError = rb_define_class("SecurityError", rb_eException);
+    rb__eSecurityError = rb_define_class("SecurityError", rb_eException);
+    /* Remove SecurityError in Ruby 3.4 */
+    rb_deprecate_constant(rb_cObject, "SecurityError");
     rb_eNoMemError = rb_define_class("NoMemoryError", rb_eException);
     rb_eEncodingError = rb_define_class("EncodingError", rb_eStandardError);
     rb_eEncCompatError = rb_define_class_under(rb_cEncoding, "CompatibilityError", rb_eEncodingError);

--- a/include/ruby/internal/globals.h
+++ b/include/ruby/internal/globals.h
@@ -121,7 +121,12 @@ RUBY_EXTERN VALUE rb_eRangeError;                /**< `RangeError` exception. */
 RUBY_EXTERN VALUE rb_eIOError;                   /**< `IOError` exception. */
 RUBY_EXTERN VALUE rb_eRuntimeError;              /**< `RuntimeError` exception. */
 RUBY_EXTERN VALUE rb_eFrozenError;               /**< `FrozenError` exception. */
-RUBY_EXTERN VALUE rb_eSecurityError;             /**< `SecurityError` exception. */
+RUBY_EXTERN VALUE rb__eSecurityError;            /**< `SecurityError` exception. */
+#ifdef __GNUC__
+#define rb_eSecurityError _Pragma ("GCC warning \"rb_eSecurityError is deprecated\"") rb__eSecurityError;
+#else
+#define rb_eSecurityError rb__eSecurityError;
+#endif
 RUBY_EXTERN VALUE rb_eSystemCallError;           /**< `SystemCallError` exception. */
 RUBY_EXTERN VALUE rb_eThreadError;               /**< `ThreadError` exception. */
 RUBY_EXTERN VALUE rb_eTypeError;                 /**< `TypeError` exception. */

--- a/re.c
+++ b/re.c
@@ -3104,8 +3104,6 @@ rb_reg_initialize(VALUE obj, const char *s, long len, rb_encoding *enc,
     rb_encoding *a_enc = rb_ascii8bit_encoding();
 
     rb_check_frozen(obj);
-    if (FL_TEST(obj, REG_LITERAL))
-        rb_raise(rb_eSecurityError, "can't modify literal regexp");
     if (re->ptr)
         rb_raise(rb_eTypeError, "already initialized regexp");
     re->ptr = 0;

--- a/ruby.c
+++ b/ruby.c
@@ -2627,9 +2627,9 @@ static void
 forbid_setid(const char *s, const ruby_cmdline_options_t *opt)
 {
     if (opt->setids & 1)
-        rb_raise(rb_eSecurityError, "no %s allowed while running setuid", s);
+        rb_raise(rb_eRuntimeError, "no %s allowed while running setuid", s);
     if (opt->setids & 2)
-        rb_raise(rb_eSecurityError, "no %s allowed while running setgid", s);
+        rb_raise(rb_eRuntimeError, "no %s allowed while running setgid", s);
 }
 
 static VALUE

--- a/spec/ruby/core/exception/hierarchy_spec.rb
+++ b/spec/ruby/core/exception/hierarchy_spec.rb
@@ -10,7 +10,6 @@ describe "Exception" do
           NotImplementedError => nil,
           SyntaxError => nil,
         },
-        SecurityError => nil,
         SignalException => {
           Interrupt => nil,
         },
@@ -49,6 +48,7 @@ describe "Exception" do
         SystemStackError => nil,
       },
     }
+    hierarchy[Exception][SecurityError] = nil if RUBY_VERSION < '3.3'
 
     traverse = -> parent_class, parent_subclass_hash {
       parent_subclass_hash.each do |child_class, child_subclass_hash|

--- a/spec/ruby/language/rescue_spec.rb
+++ b/spec/ruby/language/rescue_spec.rb
@@ -350,9 +350,12 @@ describe "The rescue keyword" do
     end
 
     it "will not rescue exceptions except StandardError" do
-      [ Exception.new, NoMemoryError.new, ScriptError.new, SecurityError.new,
+      exceptions = [
+        Exception.new, NoMemoryError.new, ScriptError.new,
         SignalException.new('INT'), SystemExit.new, SystemStackError.new
-      ].each do |exception|
+      ]
+      exceptions << SecurityError.new if RUBY_VERSION < '3.3'
+      exceptions.each do |exception|
         -> {
           begin
             raise exception

--- a/spec/ruby/optional/capi/constants_spec.rb
+++ b/spec/ruby/optional/capi/constants_spec.rb
@@ -271,8 +271,18 @@ describe "C-API exception constant" do
     @s.rb_eScriptError.should == ScriptError
   end
 
-  specify "rb_eSecurityError references the SecurityError class" do
-    @s.rb_eSecurityError.should == SecurityError
+  ruby_version_is '3.3'...'3.4' do
+    specify "rb_eSecurityError references the deprecated SecurityError class" do
+      proc do
+        @s.rb_eSecurityError.should == SecurityError
+      end.should complain(/constant ::SecurityError is deprecated/)
+    end
+  end
+
+  ruby_version_is ''...'3.3' do
+    specify "rb_eSecurityError references the SecurityError class" do
+      @s.rb_eSecurityError.should == SecurityError
+    end
   end
 
   specify "rb_eSignal references the SignalException class" do

--- a/test/ruby/test_process.rb
+++ b/test/ruby/test_process.rb
@@ -2035,7 +2035,7 @@ class TestProcess < Test::Unit::TestCase
           # while other UNIXes do not. (This might be AIX's violation of the POSIX standard.)
           # However, Ruby does not allow a setgid'ed Ruby process to use the -e option.
           # As a result, the Ruby process invoked by "IO.popen([RUBY, "-e", ..." above fails
-          # with a message like "no -e allowed while running setgid (SecurityError)" to stderr,
+          # with a message like "no -e allowed while running setgid (RuntimeError)" to stderr,
           # the exis status is set to 1, and the variable "g" is set to an empty string.
           # To conclude, on AIX, if the "gid" variable is a supplementary group,
           # the assert_equal next can fail, so skip it.


### PR DESCRIPTION
This probably should have been removed when $SAFE was removed, but there are a few places where it was still used.

Deprecate Ruby-level reference to SecurityError using the standard rb_deprecate_constant.  Deprecate C-level reference to rb_eSecurityError by renaming to rb__eSecurityError, and adding a rb_eSecurityError macro that warns on GCC and clang (not sure if the approach used will work on other compilers).

Remove dead code referencing rb_eSecurityError in rb_reg_initialize, since all literal regexps are now frozen.

The only code inside Ruby that was actually using SecurityError was the setuid/setgid checks will processing command line options. Since these exceptions could not be rescued in normal use, switch to RuntimeError, since doing so shouldn't break backwards compatibility.

Fix fallout in specs.

Add note to remove SecurityError in Ruby 3.4.