### PR TITLE
bignum.c: rb_int_parse_cstr handle `0` strings

### DIFF
--- a/bignum.c
+++ b/bignum.c
@@ -4184,7 +4184,6 @@ rb_int_parse_cstr(const char *str, ssize_t len, char **endp, size_t *ndigits,
         }
         if (!c || ISSPACE(c)) --str;
         if (end) len = end - str;
-        ASSERT_LEN();
     }
     c = *str;
     c = conv_digit(c);

--- a/test/ruby/test_time.rb
+++ b/test/ruby/test_time.rb
@@ -1426,4 +1426,8 @@ class TestTime < Test::Unit::TestCase
       t.deconstruct_keys(%i[year month sec nonexistent])
     )
   end
+
+  def test_parse_zero_bigint
+    assert_equal 0, Time.new("2020-10-28T16:48:07.000Z").nsec, '[Bug #19390]'
+  end
 end


### PR DESCRIPTION
[Bug #19390]

We shouldn't check the string length when skipping zeros, as the string might only contains zero characters, resulting in an empty string.
