### PR TITLE
mkconfig: Map `includedir` only for system ruby

### DIFF
--- a/test/mkmf/test_config.rb
+++ b/test/mkmf/test_config.rb
@@ -7,9 +7,9 @@ require 'mkmf'
 class TestMkmfConfig < Test::Unit::TestCase
   def test_dir_config
     bug8074 = '[Bug #8074]'
-    lib = RbConfig.expand(RbConfig::MAKEFILE_CONFIG["libdir"], "exec_prefix"=>"")
+    lib = RbConfig.expand(RbConfig::MAKEFILE_CONFIG["libdir"], "exec_prefix"=>"/test/foo")
     assert_separately %w[-rmkmf - -- --with-foo-dir=/test/foo], %{
-      assert_equal(%w[/test/foo/include /test/foo#{lib}], dir_config("foo"), #{bug8074.dump})
+      assert_equal(%w[/test/foo/include #{lib}], dir_config("foo"), #{bug8074.dump})
     }
   end
 end

--- a/test/test_rbconfig.rb
+++ b/test/test_rbconfig.rb
@@ -51,13 +51,4 @@ class TestRbConfig < Test::Unit::TestCase
       assert_match(/\$\(sitearch|\$\(rubysitearchprefix\)/, val, "#{key} #{bug7823}")
     end
   end
-
-  if /darwin/ =~ RUBY_PLATFORM
-    def test_sdkroot
-      assert_separately([{"SDKROOT" => "$(prefix)/SDKRoot"}], "#{<<~"begin;"}\n#{<<~'end;'}")
-      begin;
-        assert_equal RbConfig::CONFIG["prefix"]+"/SDKRoot", RbConfig::CONFIG["SDKROOT"]
-      end;
-    end
-  end
 end

--- a/tool/mkconfig.rb
+++ b/tool/mkconfig.rb
@@ -278,7 +278,7 @@ EOS
 print <<EOS if $unicode_emoji_version
   CONFIG["UNICODE_EMOJI_VERSION"] = #{$unicode_emoji_version.dump}
 EOS
-print <<EOS if /darwin/ =~ arch
+print prefix.start_with?("/System/") ? <<EOS : <<EOS if /darwin/ =~ arch
   if sdkroot = ENV["SDKROOT"]
     sdkroot = sdkroot.dup
   elsif File.exist?(File.join(CONFIG["prefix"], "include")) ||
@@ -288,6 +288,8 @@ print <<EOS if /darwin/ =~ arch
     sdkroot.chomp!
   end
   CONFIG["SDKROOT"] = sdkroot
+EOS
+  CONFIG["SDKROOT"] = ""
 EOS
 print <<EOS
   CONFIG["platform"] = #{platform || '"$(arch)"'}


### PR DESCRIPTION
Only when installing to the system path on macOS, prepend '$(SDKROOT)' and remap `includedir`.
Fix https://github.com/rbenv/ruby-build/discussions/2123