### PR TITLE
YJIT: Implement codegen for Kernel#block_given?

### DIFF
--- a/kernel.rb
+++ b/kernel.rb
@@ -118,7 +118,7 @@ module Kernel
   #     2.then.detect(&:odd?)            # => nil
   #
   def then
-    unless Primitive.block_given_p
+    unless block_given?
       return Primitive.cexpr! 'SIZED_ENUMERATOR(self, 0, 0, rb_obj_size)'
     end
     yield(self)
@@ -142,7 +142,7 @@ module Kernel
   #       then {|response| JSON.parse(response) }
   #
   def yield_self
-    unless Primitive.block_given_p
+    unless block_given?
       return Primitive.cexpr! 'SIZED_ENUMERATOR(self, 0, 0, rb_obj_size)'
     end
     yield(self)
@@ -178,7 +178,7 @@ module Kernel
   #      puts enum.next
   #    } #=> :ok
   def loop
-    unless Primitive.block_given_p
+    unless block_given?
       return enum_for(:loop) { Float::INFINITY }
     end
 

--- a/object.c
+++ b/object.c
@@ -569,12 +569,6 @@ rb_obj_size(VALUE self, VALUE args, VALUE obj)
     return LONG2FIX(1);
 }
 
-static VALUE
-block_given_p(rb_execution_context_t *ec, VALUE self)
-{
-    return RBOOL(rb_block_given_p());
-}
-
 /**
  * :nodoc:
  *--


### PR DESCRIPTION
As we plan to convert loop methods to Ruby (e.g. https://github.com/ruby/ruby/pull/6687 and https://github.com/ruby/ruby/pull/3656), we'll need to introduce an extra Ruby method call on `block_given?` or work around it with `Primitive.block_given_p` for such methods.

Since `Kernel#block_given?` is called almost as frequently as `Kernel#respond_to?` (see "railsbench" in https://github.com/Shopify/yjit-bench/pull/168), which we already have codegen for, I thought it's probably not a bad idea to just optimize it everywhere.

I also considered using `Primitive.attr! 'inline'` for this, but the fact that it's CFP-dependent makes it rather complicated to skip pushing a frame. So I feel this is the simplest approach to optimize `Kernel#block_given?`.

## Benchmark
### microbenchmark
```yml
prelude: |
  def block_given
    block_given?
  end
benchmark:
  - block_given
  - block_given {}
```

```
$ benchmark-driver -v ~/tmp/a.yml --chruby 'before::before --yjit;after::after --yjit'
before: ruby 3.3.0dev (2023-01-30T23:43:40Z master 7439ccf0ed) +YJIT [x86_64-linux]
after: ruby 3.3.0dev (2023-01-30T23:59:31Z yjit-block-given-p c93c350a9b) +YJIT [x86_64-linux]
Warming up --------------------------------------
         block_given    37.831M i/s -     38.332M times in 1.013220s (26.43ns/i, 58clocks/i)
      block_given {}    35.519M i/s -     35.813M times in 1.008285s (28.15ns/i, 106clocks/i)
Calculating -------------------------------------
                         before       after
         block_given    44.561M     67.404M i/s -    113.494M times in 2.546934s 1.683793s
      block_given {}    44.189M     56.191M i/s -    106.557M times in 2.411368s 1.896333s

Comparison:
                      block_given
               after:  67403965.4 i/s
              before:  44561158.5 i/s - 1.51x  slower

                   block_given {}
               after:  56191030.5 i/s
              before:  44189397.7 i/s - 1.27x  slower
```

### railsbench

```
before: ruby 3.3.0dev (2023-01-30T23:43:40Z master 7439ccf0ed) +YJIT [x86_64-linux]
after: ruby 3.3.0dev (2023-01-30T23:59:31Z yjit-block-given-p c93c350a9b) +YJIT [x86_64-linux]

----------  -----------  ----------  ----------  ----------  ------------  -------------
bench       before (ms)  stddev (%)  after (ms)  stddev (%)  before/after  after 1st itr
railsbench  1068.9       0.8         1066.6      1.8         1.00          1.00
----------  -----------  ----------  ----------  ----------  ------------  -------------
```