### PR TITLE
YJIT: Handle splat with opt more fully

### DIFF
--- a/yjit.c
+++ b/yjit.c
@@ -103,6 +103,12 @@ rb_yjit_mark_unused(void *mem_block, uint32_t mem_size)
     return mprotect(mem_block, mem_size, PROT_NONE) == 0;
 }
 
+long
+rb_yjit_array_len(VALUE a)
+{
+    return rb_array_len(a);
+}
+
 // `start` is inclusive and `end` is exclusive.
 void
 rb_yjit_icache_invalidate(void *start, void *end)

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -410,6 +410,7 @@ fn main() {
         .allowlist_function("rb_METHOD_ENTRY_VISI")
         .allowlist_function("rb_RCLASS_ORIGIN")
         .allowlist_function("rb_method_basic_definition_p")
+        .allowlist_function("rb_yjit_array_len")
 
         // We define VALUE manually, don't import it
         .blocklist_type("VALUE")

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -5351,8 +5351,6 @@ fn gen_send_iseq(
     asm.cmp(CFP, stack_limit);
     asm.jbe(counted_exit!(ocb, side_exit, send_se_cf_overflow));
 
-
-
     // push_splat_args does stack manipulation so we can no longer side exit
     if flags & VM_CALL_ARGS_SPLAT != 0 {
 

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -5192,24 +5192,14 @@ fn gen_send_iseq(
         return CantCompile;
     }
 
+    // We will handle splat case later
     if opt_num > 0 && flags & VM_CALL_ARGS_SPLAT == 0 {
         num_params -= opts_missing as u32;
         unsafe {
             let opt_table = get_iseq_body_param_opt_table(iseq);
             start_pc_offset = (*opt_table.offset(opts_filled as isize)).as_u32();
         }
-    } else if opt_num > 0 && flags & VM_CALL_ARGS_SPLAT != 0 {
-        // We are going to assume that args_splat fills all of the optional arguments.
-        // We should actually get the array length instead at compile time.
-        // We don't set num_params here because we use it for the splat.
-        // If our assumption is wrong, we will exit early in the splat code.
-        // We could do that a bit smarter and not exit but instead change
-        // the offset we jump to. But we aren't currently doing that.
-        unsafe {
-            let opt_table = get_iseq_body_param_opt_table(iseq);
-            start_pc_offset = (*opt_table.offset(opt_num as isize)).as_u32();
-        };
-    };
+    }
 
     if doing_kw_call {
         // Here we're calling a method with keyword arguments and specifying
@@ -5361,14 +5351,46 @@ fn gen_send_iseq(
     asm.cmp(CFP, stack_limit);
     asm.jbe(counted_exit!(ocb, side_exit, send_se_cf_overflow));
 
+
+
     // push_splat_args does stack manipulation so we can no longer side exit
     if flags & VM_CALL_ARGS_SPLAT != 0 {
-        let required_args = num_params - (argc as u32 - 1);
+
+        let array = jit_peek_at_stack(jit, ctx, if block_arg { 1 } else { 0 }) ;
+        let array_length = if array == Qnil {
+            0
+        } else {
+            unsafe { rb_yjit_array_len(array) as u32}
+        };
+
+        if opt_num == 0 && required_num != array_length as i32 {
+            gen_counter_incr!(asm, send_iseq_splat_arity_error);
+            return CantCompile;
+        }
+
+        let remaining_opt = (opt_num as u32 + required_num as u32).saturating_sub(array_length + (argc as u32 - 1));
+
+        if opt_num > 0 {
+
+            // We are going to jump to the correct offset based on how many optional
+            // params are remaining.
+            unsafe {
+                let opt_table = get_iseq_body_param_opt_table(iseq);
+                let offset = (opt_num - remaining_opt as i32) as isize;
+                start_pc_offset = (*opt_table.offset(offset)).as_u32();
+            };
+        }
         // We are going to assume that the splat fills
         // all the remaining arguments. In the generated code
         // we test if this is true and if not side exit.
-        argc = num_params as i32;
-        push_splat_args(required_args, ctx, asm, ocb, side_exit)
+        argc = argc - 1 + array_length as i32 + remaining_opt as i32;
+        push_splat_args(array_length, ctx, asm, ocb, side_exit);
+
+        for _ in 0..remaining_opt as u32 {
+            // We need to push nil for the optional arguments
+            let stack_ret = ctx.stack_push(Type::Unknown);
+            asm.mov(stack_ret, Qnil.into());
+        }
     }
 
     // This is a .send call and we need to adjust the stack

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -1194,6 +1194,7 @@ extern "C" {
     pub fn rb_yjit_mark_writable(mem_block: *mut ::std::os::raw::c_void, mem_size: u32) -> bool;
     pub fn rb_yjit_mark_executable(mem_block: *mut ::std::os::raw::c_void, mem_size: u32);
     pub fn rb_yjit_mark_unused(mem_block: *mut ::std::os::raw::c_void, mem_size: u32) -> bool;
+    pub fn rb_yjit_array_len(a: VALUE) -> ::std::os::raw::c_long;
     pub fn rb_yjit_icache_invalidate(
         start: *mut ::std::os::raw::c_void,
         end: *mut ::std::os::raw::c_void,

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -222,6 +222,7 @@ make_counters! {
     send_args_splat_cfunc_var_args,
     send_args_splat_cfunc_zuper,
     send_args_splat_cfunc_ruby2_keywords,
+    send_iseq_splat_arity_error,
     send_iseq_ruby2_keywords,
     send_send_not_imm,
     send_send_wrong_args,


### PR DESCRIPTION
 
Here are the stats of railsbench and liquid-render before and after these changes

Highlights:

Rails bench:
```
Before:
splatarray_length_not_equal       2029 ( 0.6%)

After:
splatarray_length_not_equal          2 ( 0.0%)
```

Liquid render:
```
Before:
splatarray_length_not_equal       2979 ( 6.4%)
After:
None
```
        
<summary>Rails Bench Before</summary>
<details>

```ruby
         ***YJIT: Printing YJIT statistics on exit***
method call exit reasons: 
                      iseq_has_rest     110946 (33.8%)
                          block_arg      64643 (19.7%)
                        iseq_zsuper      46081 (14.0%)
                iseq_ruby2_keywords      24994 ( 7.6%)
                   iseq_arity_error      19401 ( 5.9%)
          args_splat_cfunc_var_args      16250 ( 4.9%)
                     iseq_has_no_kw      15970 ( 4.9%)
                           kw_splat      12995 ( 4.0%)
                    iseq_has_kwrest       5294 ( 1.6%)
           iseq_missing_optional_kw       4054 ( 1.2%)
        splatarray_length_not_equal       2029 ( 0.6%)
             args_splat_cfunc_zuper       2002 ( 0.6%)
                      iseq_has_post       1987 ( 0.6%)
                     refined_method        891 ( 0.3%)
              cfunc_ruby_array_varg        653 ( 0.2%)
                           keywords        102 ( 0.0%)
    args_splat_cfunc_ruby2_keywords         62 ( 0.0%)
                    args_splat_ivar         49 ( 0.0%)
                        send_getter         12 ( 0.0%)
                      zsuper_method          9 ( 0.0%)
                args_splat_opt_call          5 ( 0.0%)
                  bmethod_block_arg          2 ( 0.0%)
                    ivar_set_method          1 ( 0.0%)
invokeblock exit reasons: 
                  proc     115212 (90.9%)
                 ifunc       5897 ( 4.7%)
    iseq_block_changed       2463 ( 1.9%)
       iseq_arg0_splat       2000 ( 1.6%)
      iseq_tag_changed       1153 ( 0.9%)
                symbol         68 ( 0.1%)
invokesuper exit reasons: 
         block       4850 (98.4%)
    me_changed         80 ( 1.6%)
leave exit reasons: 
        interp_return    1837165 (97.7%)
    start_pc_non_zero      43883 ( 2.3%)
         se_interrupt         32 ( 0.0%)
getblockparamproxy exit reasons: 
    block_param_modified          3 (100.0%)
getinstancevariable exit reasons:
    megamorphic      10302 (100.0%)
setinstancevariable exit reasons:
    (all relevant counters are zero)
opt_aref exit reasons: 
    (all relevant counters are zero)
expandarray exit reasons: 
            splat       9974 (99.8%)
    rhs_too_small         22 ( 0.2%)
opt_getinlinecache exit reasons: 
    miss         11 (100.0%)
invalidation reasons: 
       constant_ic_fill       2011 (59.2%)
          method_lookup       1045 (30.8%)
    constant_state_bump        339 (10.0%)
bindings_allocations:         184
bindings_set:                   0
compiled_iseq_count:         9291
compiled_block_count:       51556
compiled_branch_count:      81930
block_next_count:           14966
defer_count:                16167
freed_iseq_count:            4064
invalidation_count:          3395
constant_state_bumps:           0
inline_code_size:         8761368
outlined_code_size:       8760932
freed_code_size:                0
code_region_size:        17580032
yjit_alloc_size:         97526573
live_page_count:             1073
freed_page_count:               0
code_gc_count:                  0
num_gc_obj_refs:            41145
object_shape_count:          2397
side_exit_count:           616130
total_exit_count:         2453295
total_insns_count:       95024544
vm_insns_count:          11833218
yjit_insns_count:        83807456
ratio_in_yjit:              87.5%
avg_len_in_yjit:             33.9
Top-20 most frequent exit ops (100.0% of exits):
    opt_send_without_block:     144864 (23.5%)
               invokeblock:     144171 (23.4%)
               invokesuper:     117072 (19.0%)
                      send:     104047 (16.9%)
      opt_getconstant_path:      53736 (8.7%)
                  opt_aref:      14088 (2.3%)
                     throw:      10587 (1.7%)
               expandarray:       9996 (1.6%)
             setlocal_WC_0:       8357 (1.4%)
                    opt_eq:       5009 (0.8%)
        getblockparamproxy:       2271 (0.4%)
               objtostring:        448 (0.1%)
          putspecialobject:        386 (0.1%)
                 opt_nil_p:        327 (0.1%)
             definesmethod:        240 (0.0%)
                checkmatch:        204 (0.0%)
                      once:        104 (0.0%)
       getinstancevariable:        102 (0.0%)
                     leave:         33 (0.0%)
               opt_empty_p:         32 (0.0%)

```
</details>
    
        
<summary>Rails Bench After</summary>
<details>

```ruby
         ***YJIT: Printing YJIT statistics on exit***
method call exit reasons: 
                      iseq_has_rest     110946 (34.0%)
                          block_arg      64645 (19.8%)
                        iseq_zsuper      46081 (14.1%)
                iseq_ruby2_keywords      24994 ( 7.7%)
                   iseq_arity_error      19401 ( 5.9%)
          args_splat_cfunc_var_args      16251 ( 5.0%)
                     iseq_has_no_kw      15971 ( 4.9%)
                           kw_splat      12995 ( 4.0%)
                    iseq_has_kwrest       5294 ( 1.6%)
           iseq_missing_optional_kw       4054 ( 1.2%)
             args_splat_cfunc_zuper       2002 ( 0.6%)
                      iseq_has_post       1987 ( 0.6%)
                     refined_method        891 ( 0.3%)
              cfunc_ruby_array_varg        653 ( 0.2%)
                           keywords        102 ( 0.0%)
    args_splat_cfunc_ruby2_keywords         62 ( 0.0%)
                    args_splat_ivar         49 ( 0.0%)
                        send_getter         12 ( 0.0%)
                      zsuper_method          9 ( 0.0%)
                args_splat_opt_call          5 ( 0.0%)
        splatarray_length_not_equal          2 ( 0.0%)
                  bmethod_block_arg          2 ( 0.0%)
                    ivar_set_method          1 ( 0.0%)
invokeblock exit reasons: 
                  proc     115214 (90.9%)
                 ifunc       5896 ( 4.6%)
    iseq_block_changed       2463 ( 1.9%)
       iseq_arg0_splat       2000 ( 1.6%)
      iseq_tag_changed       1155 ( 0.9%)
                symbol         68 ( 0.1%)
invokesuper exit reasons: 
         block       4850 (98.4%)
    me_changed         80 ( 1.6%)
leave exit reasons: 
        interp_return    1832617 (97.7%)
    start_pc_non_zero      43882 ( 2.3%)
         se_interrupt         31 ( 0.0%)
getblockparamproxy exit reasons: 
    block_param_modified          3 (100.0%)
getinstancevariable exit reasons:
    megamorphic      10302 (100.0%)
setinstancevariable exit reasons:
    (all relevant counters are zero)
opt_aref exit reasons: 
    (all relevant counters are zero)
expandarray exit reasons: 
            splat       9974 (99.8%)
    rhs_too_small         22 ( 0.2%)
opt_getinlinecache exit reasons: 
    miss         11 (100.0%)
invalidation reasons: 
       constant_ic_fill       2008 (59.2%)
          method_lookup       1045 (30.8%)
    constant_state_bump        341 (10.0%)
bindings_allocations:         184
bindings_set:                   0
compiled_iseq_count:         9291
compiled_block_count:       51521
compiled_branch_count:      81854
block_next_count:           14958
defer_count:                16151
freed_iseq_count:            4064
invalidation_count:          3394
constant_state_bumps:           0
inline_code_size:         8767716
outlined_code_size:       8764516
freed_code_size:                0
code_region_size:        17580032
yjit_alloc_size:         97597423
live_page_count:             1073
freed_page_count:               0
code_gc_count:                  0
num_gc_obj_refs:            41221
object_shape_count:          2396
side_exit_count:           614120
total_exit_count:         2446737
total_insns_count:       95010644
vm_insns_count:          11815839
yjit_insns_count:        83808925
ratio_in_yjit:              87.6%
avg_len_in_yjit:             34.0
Top-20 most frequent exit ops (100.0% of exits):
    opt_send_without_block:     144844 (23.6%)
               invokeblock:     144173 (23.5%)
               invokesuper:     117058 (19.1%)
                      send:     102048 (16.6%)
      opt_getconstant_path:      53763 (8.8%)
                  opt_aref:      14089 (2.3%)
                     throw:      10587 (1.7%)
               expandarray:       9996 (1.6%)
             setlocal_WC_0:       8358 (1.4%)
                    opt_eq:       5009 (0.8%)
        getblockparamproxy:       2271 (0.4%)
               objtostring:        449 (0.1%)
          putspecialobject:        386 (0.1%)
                 opt_nil_p:        327 (0.1%)
             definesmethod:        240 (0.0%)
                checkmatch:        204 (0.0%)
                      once:        104 (0.0%)
       getinstancevariable:        102 (0.0%)
                     leave:         32 (0.0%)
               opt_empty_p:         32 (0.0%)

```
</details>
    
        
<summary>Liquid Render Before</summary>
<details>

```ruby
         ***YJIT: Printing YJIT statistics on exit***
method call exit reasons: 
                  iseq_has_rest      41227 (88.8%)
    splatarray_length_not_equal       2979 ( 6.4%)
                      block_arg       1323 ( 2.9%)
                  zsuper_method        792 ( 1.7%)
       iseq_missing_optional_kw         39 ( 0.1%)
          cfunc_ruby_array_varg         39 ( 0.1%)
      args_splat_cfunc_var_args         11 ( 0.0%)
invokeblock exit reasons: 
    iseq_block_changed      26318 (94.7%)
      iseq_tag_changed       1366 ( 4.9%)
                  proc         90 ( 0.3%)
                 ifunc         10 ( 0.0%)
invokesuper exit reasons: 
    block          5 (100.0%)
leave exit reasons: 
        interp_return     329111 (100.0%)
    start_pc_non_zero        105 ( 0.0%)
         se_interrupt         13 ( 0.0%)
getblockparamproxy exit reasons: 
    (all relevant counters are zero)
getinstancevariable exit reasons:
    megamorphic          8 (100.0%)
setinstancevariable exit reasons:
    (all relevant counters are zero)
opt_aref exit reasons: 
    (all relevant counters are zero)
expandarray exit reasons: 
    (all relevant counters are zero)
opt_getinlinecache exit reasons: 
    (all relevant counters are zero)
invalidation reasons: 
       constant_ic_fill        149 (83.2%)
    constant_state_bump         20 (11.2%)
          method_lookup         10 ( 5.6%)
bindings_allocations:          77
bindings_set:                   0
compiled_iseq_count:          695
compiled_block_count:        5923
compiled_branch_count:       9897
block_next_count:            2048
defer_count:                 1990
freed_iseq_count:             173
invalidation_count:           179
constant_state_bumps:           0
inline_code_size:          937356
outlined_code_size:        934812
freed_code_size:                0
code_region_size:         1884160
yjit_alloc_size:         12276093
live_page_count:              115
freed_page_count:               0
code_gc_count:                  0
num_gc_obj_refs:             4016
object_shape_count:           539
side_exit_count:            96193
total_exit_count:          425304
total_insns_count:       22130540
vm_insns_count:           4087260
yjit_insns_count:        18139473
ratio_in_yjit:              81.5%
avg_len_in_yjit:             42.4
Top-12 most frequent exit ops (100.0% of exits):
    opt_send_without_block:      45343 (47.1%)
               invokeblock:      27784 (28.9%)
                     throw:      21115 (22.0%)
                      send:       1325 (1.4%)
      opt_getconstant_path:        372 (0.4%)
               invokesuper:        125 (0.1%)
                    opt_eq:         87 (0.1%)
                     leave:         13 (0.0%)
                      once:         12 (0.0%)
          putspecialobject:         12 (0.0%)
                  opt_ltlt:          3 (0.0%)
                opt_length:          2 (0.0%)

```
</details>
    
        
<summary>Liquid Render After</summary>
<details>

```ruby
         ***YJIT: Printing YJIT statistics on exit***
method call exit reasons: 
                iseq_has_rest      41226 (94.9%)
                    block_arg       1324 ( 3.0%)
                zsuper_method        792 ( 1.8%)
     iseq_missing_optional_kw         39 ( 0.1%)
        cfunc_ruby_array_varg         39 ( 0.1%)
    args_splat_cfunc_var_args         11 ( 0.0%)
invokeblock exit reasons: 
    iseq_block_changed      26318 (94.7%)
      iseq_tag_changed       1367 ( 4.9%)
                  proc         90 ( 0.3%)
                 ifunc         10 ( 0.0%)
invokesuper exit reasons: 
    block          5 (100.0%)
leave exit reasons: 
        interp_return     329117 (100.0%)
    start_pc_non_zero        105 ( 0.0%)
         se_interrupt         16 ( 0.0%)
getblockparamproxy exit reasons: 
    (all relevant counters are zero)
getinstancevariable exit reasons:
    megamorphic          8 (100.0%)
setinstancevariable exit reasons:
    (all relevant counters are zero)
opt_aref exit reasons: 
    (all relevant counters are zero)
expandarray exit reasons: 
    (all relevant counters are zero)
opt_getinlinecache exit reasons: 
    (all relevant counters are zero)
invalidation reasons: 
       constant_ic_fill        149 (83.2%)
    constant_state_bump         20 (11.2%)
          method_lookup         10 ( 5.6%)
bindings_allocations:          77
bindings_set:                   0
compiled_iseq_count:          696
compiled_block_count:        5907
compiled_branch_count:       9893
block_next_count:            2044
defer_count:                 1983
freed_iseq_count:             173
invalidation_count:           179
constant_state_bumps:           0
inline_code_size:          935820
outlined_code_size:        934264
freed_code_size:                0
code_region_size:         1884160
yjit_alloc_size:         12257324
live_page_count:              115
freed_page_count:               0
code_gc_count:                  0
num_gc_obj_refs:             4006
object_shape_count:           538
side_exit_count:            93216
total_exit_count:          422333
total_insns_count:       22111919
vm_insns_count:           4075284
yjit_insns_count:        18129851
ratio_in_yjit:              81.6%
avg_len_in_yjit:             42.7
Top-13 most frequent exit ops (100.0% of exits):
    opt_send_without_block:      42362 (45.4%)
               invokeblock:      27785 (29.8%)
                     throw:      21115 (22.7%)
                      send:       1325 (1.4%)
      opt_getconstant_path:        372 (0.4%)
               invokesuper:        125 (0.1%)
                    opt_eq:         87 (0.1%)
                     leave:         16 (0.0%)
                      once:         12 (0.0%)
          putspecialobject:         12 (0.0%)
                  opt_ltlt:          3 (0.0%)
                   opt_div:          1 (0.0%)
                  opt_aref:          1 (0.0%)

```
</details>
    
    

