### PR TITLE
YJIT: Fix BorrowMutError on BOP invalidation

### DIFF
--- a/test/ruby/test_yjit.rb
+++ b/test/ruby/test_yjit.rb
@@ -1074,6 +1074,24 @@ class TestYJIT < Test::Unit::TestCase
     RUBY
   end
 
+  def test_invalidate_cyclic_branch
+    assert_compiles(<<~'RUBY', result: 2)
+      def foo
+        i = 0
+        while i < 2
+          i += 1
+        end
+        i
+      end
+
+      foo
+      class Integer
+        def +(x) = self - -x
+      end
+      foo
+    RUBY
+  end
+
   private
 
   def code_gc_helpers

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -439,7 +439,7 @@ pub type CmePtr = *const rb_callable_method_entry_t;
 /// Basic block version
 /// Represents a portion of an iseq compiled with a given context
 /// Note: care must be taken to minimize the size of block_t objects
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Block {
     // Bytecode sequence (iseq, idx) this is a version of
     blockid: BlockId,
@@ -2318,6 +2318,8 @@ pub fn invalidate_block_version(blockref: &BlockRef) {
     }
 
     // For each incoming branch
+    mem::drop(block); // end borrow: regenerate_branch might mut borrow this
+    let block = blockref.borrow().clone();
     for branchref in &block.incoming {
         let mut branch = branchref.borrow_mut();
         let target_idx = if branch.get_target_address(0) == block_start {


### PR DESCRIPTION
This fixes:

```
thread '<unnamed>' panicked at 'already borrowed: BorrowMutError', src/core.rs:509:16
stack backtrace:
   0: rust_begin_unwind
             at /rustc/02072b482a8b5357f7fb5e5637444ae30e423c40/library/std/src/panicking.rs:498:5
   1: core::panicking::panic_fmt
             at /rustc/02072b482a8b5357f7fb5e5637444ae30e423c40/library/core/src/panicking.rs:107:14
   2: core::result::unwrap_failed
             at /rustc/02072b482a8b5357f7fb5e5637444ae30e423c40/library/core/src/result.rs:1613:5
   3: core::result::Result<T,E>::expect
             at /rustc/02072b482a8b5357f7fb5e5637444ae30e423c40/library/core/src/result.rs:1255:23
   4: core::cell::RefCell<T>::borrow_mut
             at /rustc/02072b482a8b5357f7fb5e5637444ae30e423c40/library/core/src/cell.rs:946:9
   5: yjit::core::BlockRef::borrow_mut
             at ./yjit/src/core.rs:509:9
   6: yjit::core::regenerate_branch
             at ./yjit/src/core.rs:1708:21
   7: yjit::core::invalidate_block_version
             at ./yjit/src/core.rs:2370:9
   8: yjit::invariants::rb_yjit_bop_redefined::{{closure}}
             at ./yjit/src/invariants.rs:229:17
   9: std::panicking::try::do_call
             at /rustc/02072b482a8b5357f7fb5e5637444ae30e423c40/library/std/src/panicking.rs:406:40
  10: __rust_try
  11: std::panicking::try
             at /rustc/02072b482a8b5357f7fb5e5637444ae30e423c40/library/std/src/panicking.rs:370:19
  12: std::panic::catch_unwind
             at /rustc/02072b482a8b5357f7fb5e5637444ae30e423c40/library/std/src/panic.rs:133:14
  13: yjit::cruby::with_vm_lock
             at ./yjit/src/cruby.rs:617:21
  14: rb_yjit_bop_redefined
             at ./yjit/src/invariants.rs:221:5
```

https://cirrus-ci.com/task/6461636395925504?logs=make_test_all