### PR TITLE
[Bug #19398] Memory leak in WeakMap

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -12870,6 +12870,7 @@ wmap_free(void *ptr)
     st_foreach(w->obj2wmap, wmap_free_map, 0);
     st_free_table(w->obj2wmap);
     st_free_table(w->wmap2obj);
+    xfree(w);
 }
 
 static int

--- a/test/ruby/test_weakmap.rb
+++ b/test/ruby/test_weakmap.rb
@@ -167,4 +167,13 @@ class TestWeakMap < Test::Unit::TestCase
     assert_nothing_raised(FrozenError) {@wm[o] = 'foo'}
     assert_nothing_raised(FrozenError) {@wm['foo'] = o}
   end
+
+  def test_no_memory_leak
+    assert_no_memory_leak([], '', "#{<<~"begin;"}\n#{<<~'end;'}", "[Bug #19398]", rss: true, limit: 1.5, timeout: 60)
+    begin;
+      1_000_000.times do
+        ObjectSpace::WeakMap.new
+      end
+    end;
+  end
 end


### PR DESCRIPTION
There's a memory leak in ObjectSpace::WeakMap due to not freeing the `struct weakmap`. It can be seen in the following script:

```ruby
100.times do
  10000.times do
    ObjectSpace::WeakMap.new
  end

  # Output the Resident Set Size (memory usage, in KB) of the current Ruby process
  puts `ps -o rss= -p #{$$}`
end
```

This is the memory usage graph before and after the patch:

![chart](https://user-images.githubusercontent.com/15860699/216066158-8e353760-247a-495e-bfde-f54fa38b9f76.png)
