### PR TITLE
Keep shared arrays WB protected

### DIFF
--- a/array.c
+++ b/array.c
@@ -1065,14 +1065,14 @@ ary_make_shared(VALUE ary)
              * on the transient heap. */
             VALUE *ptr = ALLOC_N(VALUE, capa);
             ARY_SET_PTR(shared, ptr);
-            ary_memcpy(shared, 0, len, RARRAY_PTR(ary));
+            ary_memcpy(shared, 0, len, RARRAY_CONST_PTR(ary));
 
             FL_UNSET_EMBED(ary);
             ARY_SET_HEAP_LEN(ary, len);
             ARY_SET_PTR(ary, ptr);
         }
         else {
-            ARY_SET_PTR(shared, RARRAY_PTR(ary));
+            ARY_SET_PTR(shared, RARRAY_CONST_PTR(ary));
         }
 
         ARY_SET_LEN(shared, capa);


### PR DESCRIPTION
Sharing an array will cause it to be WB unprotected due to the use of `RARRAY_PTR`. We don't need to WB unprotect the array because we're not writing to the buffer of the array.

The following script demonstrates this issue:

```
ary = [1] * 1000
shared = ary[10..20]
puts ObjectSpace.dump(ary)
```