### PR TITLE
[Bug #19399] Parsing invalid heredoc inside block parameter

### DIFF
--- a/ext/ripper/lib/ripper/lexer.rb
+++ b/ext/ripper/lib/ripper/lexer.rb
@@ -228,7 +228,7 @@ class Ripper
 
     def on_heredoc_end(tok)
       @buf.push Elem.new([lineno(), column()], __callee__, tok, state())
-      @buf = @stack.pop
+      @buf = @stack.pop unless @stack.empty?
     end
 
     def _push_token(tok)

--- a/test/ripper/test_lexer.rb
+++ b/test/ripper/test_lexer.rb
@@ -252,4 +252,16 @@ world"
 ]
     assert_equal(code, Ripper.tokenize(code).join(""), bug)
   end
+
+  def test_heredoc_inside_block_param
+    bug = '[Bug #19399]'
+    code = <<~CODE
+      a do |b
+        <<-C
+        C
+        |
+      end
+    CODE
+    assert_equal(code, Ripper.tokenize(code).join(""), bug)
+  end
 end


### PR DESCRIPTION
Although this is of course invalid as Ruby code, allow to just parse and tokenize.