### PR TITLE
YJIT: log the names of methods we call to in disasm

### DIFF
--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -77,6 +77,9 @@ fn main() {
         // From encindex.h
         .allowlist_type("ruby_preserved_encindex")
 
+        // From include/ruby/ruby.h
+        .allowlist_function("rb_class2name")
+
         // This struct is public to Ruby C extensions
         // From include/ruby/internal/core/rbasic.h
         .allowlist_type("RBasic")
@@ -199,6 +202,7 @@ fn main() {
         // From include/ruby/internal/symbol.h
         .allowlist_function("rb_intern")
         .allowlist_function("rb_id2sym")
+        .allowlist_function("rb_id2name")
         .allowlist_function("rb_sym2id")
         .allowlist_function("rb_str_intern")
 

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -5833,7 +5833,12 @@ fn gen_send_general(
     {
         let class_name = unsafe { cstr_to_rust_string(rb_class2name(comptime_recv_klass)) };
         let method_name = unsafe { cstr_to_rust_string(rb_id2name(mid)) };
-        asm.comment(&format!("call to {}#{}", class_name, method_name));
+        match (class_name, method_name) {
+            (Some(class_name), Some(method_name)) => {
+                asm.comment(&format!("call to {}#{}", class_name, method_name))
+            }
+            _ => {}
+        }
     }
 
     // Guard that the receiver has the same class as the one from compile time

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -5668,9 +5668,6 @@ fn gen_send_iseq(
         },
     );
 
-    //print_str(cb, "calling Ruby func:");
-    //print_str(cb, rb_id2name(vm_ci_mid(ci)));
-
     // Directly jump to the entry point of the callee
     gen_direct_jump(
         jit,
@@ -5830,6 +5827,14 @@ fn gen_send_general(
 
     let comptime_recv = jit_peek_at_stack(jit, ctx, recv_idx as isize);
     let comptime_recv_klass = comptime_recv.class_of();
+
+    // Log the name of the method we're calling to
+    #[cfg(feature = "disasm")]
+    {
+        let class_name = unsafe { cstr_to_rust_string(rb_class2name(comptime_recv_klass)) };
+        let method_name = unsafe { cstr_to_rust_string(rb_id2name(mid)) };
+        asm.comment(&format!("call to {}#{}", class_name, method_name));
+    }
 
     // Guard that the receiver has the same class as the one from compile time
     let side_exit = get_side_exit(jit, ocb, ctx);

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -568,6 +568,14 @@ pub fn rust_str_to_sym(str: &str) -> VALUE {
     unsafe { rb_id2sym(rb_intern(c_ptr)) }
 }
 
+/// Produce an owned Rust String from a C char pointer
+#[cfg(feature = "disasm")]
+pub fn cstr_to_rust_string(c_char_ptr: *const c_char) -> String {
+    use std::ffi::CStr;
+    let c_str: &CStr = unsafe { CStr::from_ptr(c_char_ptr) };
+    c_str.to_str().unwrap().to_string()
+}
+
 /// A location in Rust code for integrating with debugging facilities defined in C.
 /// Use the [src_loc!] macro to crate an instance.
 pub struct SourceLocation {

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -564,15 +564,17 @@ pub fn rust_str_to_ruby(str: &str) -> VALUE {
 pub fn rust_str_to_sym(str: &str) -> VALUE {
     let c_str = CString::new(str).unwrap();
     let c_ptr: *const c_char = c_str.as_ptr();
-
     unsafe { rb_id2sym(rb_intern(c_ptr)) }
 }
 
 /// Produce an owned Rust String from a C char pointer
 #[cfg(feature = "disasm")]
 pub fn cstr_to_rust_string(c_char_ptr: *const c_char) -> String {
+    assert!(c_char_ptr != std::ptr::null());
+
     use std::ffi::CStr;
     let c_str: &CStr = unsafe { CStr::from_ptr(c_char_ptr) };
+
     c_str.to_str().unwrap().to_string()
 }
 

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -569,13 +569,16 @@ pub fn rust_str_to_sym(str: &str) -> VALUE {
 
 /// Produce an owned Rust String from a C char pointer
 #[cfg(feature = "disasm")]
-pub fn cstr_to_rust_string(c_char_ptr: *const c_char) -> String {
+pub fn cstr_to_rust_string(c_char_ptr: *const c_char) -> Option<String> {
     assert!(c_char_ptr != std::ptr::null());
 
     use std::ffi::CStr;
     let c_str: &CStr = unsafe { CStr::from_ptr(c_char_ptr) };
 
-    c_str.to_str().unwrap().to_string()
+    match c_str.to_str() {
+        Ok(rust_str) => Some(rust_str.to_string()),
+        Err(_) => None
+    }
 }
 
 /// A location in Rust code for integrating with debugging facilities defined in C.

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -1100,6 +1100,8 @@ extern "C" {
     pub fn rb_sym2id(obj: VALUE) -> ID;
     pub fn rb_id2sym(id: ID) -> VALUE;
     pub fn rb_intern(name: *const ::std::os::raw::c_char) -> ID;
+    pub fn rb_id2name(id: ID) -> *const ::std::os::raw::c_char;
+    pub fn rb_class2name(klass: VALUE) -> *const ::std::os::raw::c_char;
     pub fn rb_gc_mark(obj: VALUE);
     pub fn rb_gc_mark_movable(obj: VALUE);
     pub fn rb_gc_location(obj: VALUE) -> VALUE;


### PR DESCRIPTION
Makes it easier to make sense of disasm and spot optimization opportunities. Could also help with debugging.