### PR TITLE
YJIT: Crash with rb_bug() when panicking

### DIFF
--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -88,6 +88,9 @@ fn main() {
         // This function prints info about a value and is useful for debugging
         .allowlist_function("rb_obj_info_dump")
 
+        // For crashing
+        .allowlist_function("rb_bug")
+
         // From shape.h
         .allowlist_function("rb_shape_get_shape_id")
         .allowlist_function("rb_shape_get_shape_by_id")

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -1074,6 +1074,7 @@ extern "C" {
     pub fn rb_singleton_class(obj: VALUE) -> VALUE;
     pub fn rb_get_alloc_func(klass: VALUE) -> rb_alloc_func_t;
     pub fn rb_method_basic_definition_p(klass: VALUE, mid: ID) -> ::std::os::raw::c_int;
+    pub fn rb_bug(fmt: *const ::std::os::raw::c_char, ...) -> !;
     pub fn rb_gc_writebarrier(old: VALUE, young: VALUE);
     pub fn rb_class_get_superclass(klass: VALUE) -> VALUE;
     pub static mut rb_mKernel: VALUE;


### PR DESCRIPTION
Helps with getting good bug reports in the wild. Intended to be
backported to the 3.2.x series.

Tested by applying against `ruby_3_2` and running the Ruby repro for
[[Bug #19385]](https://github.com/ruby/ruby/pull/7227#issuecomment-1413912049)
