### PR TITLE
YJIT: Support ifunc on invokeblock

### DIFF
--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -4396,6 +4396,12 @@ vm_yield_with_cfunc(rb_execution_context_t *ec,
     return val;
 }
 
+VALUE
+rb_vm_yield_with_cfunc(rb_execution_context_t *ec, const struct rb_captured_block *captured, int argc, const VALUE *argv)
+{
+    return vm_yield_with_cfunc(ec, captured, captured->self, argc, argv, 0, VM_BLOCK_HANDLER_NONE, NULL);
+}
+
 static VALUE
 vm_yield_with_symbol(rb_execution_context_t *ec,  VALUE symbol, int argc, const VALUE *argv, int kw_splat, VALUE block_handler)
 {

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -248,8 +248,9 @@ make_counters! {
     invokeblock_none,
     invokeblock_iseq_arg0_splat,
     invokeblock_iseq_block_changed,
-    invokeblock_iseq_tag_changed,
-    invokeblock_ifunc,
+    invokeblock_tag_changed,
+    invokeblock_ifunc_args_splat,
+    invokeblock_ifunc_kw_splat,
     invokeblock_proc,
     invokeblock_symbol,
 


### PR DESCRIPTION
This is the `ifunc` support that was skipped in https://github.com/ruby/ruby/pull/6640.

It's not used that much now, but converting `Array#each` to Ruby https://github.com/ruby/ruby/pull/6687 makes it used significantly more often. I'd like to introduce this support first for fair comparison.

https://github.com/ruby/ruby/pull/6687 reduces ratio_in_yjit from 91.7% to 88.8% on railsbench with run_once.sh, but merging this PR to that branch improves it from 88.8% to 89.8%. We also need to support `iseq_arg0_splat` to fully recover it, but it should be done in another PR.

This does help reducing invokeblock exits on a few benchmarks on master as well:

## hexapdf
### Before
```
invokeblock exit reasons:
               ifunc      17053 (46.9%)
                proc      16764 (46.1%)
    iseq_tag_changed       2511 ( 6.9%)
```

### After
```
invokeblock exit reasons:
      proc      16764 (99.5%)
    symbol         83 ( 0.5%)
```

## railsbench
### Before
```
invokeblock exit reasons:
               ifunc       5690 (59.5%)
     iseq_arg0_splat       2000 (20.9%)
                proc       1112 (11.6%)
    iseq_tag_changed        727 ( 7.6%)
              symbol         32 ( 0.3%)
```

### After
```
invokeblock exit reasons:
    iseq_arg0_splat       2000 (51.7%)
               proc       1112 (28.7%)
             symbol        759 (19.6%)
```

## SFR

This might help SFR more than those benchmarks. On Jan 19th, we had:

```
invokeblock exit reasons:
                 ifunc    1811594 (70.8%)
                  proc     401048 (15.7%)
      iseq_tag_changed     288100 (11.3%)
    iseq_block_changed      56844 ( 2.2%)

Top-20 most frequent exit ops (100.0% of exits):
                        ...
               invokeblock:    3918833 (2.2%)
```