### PR TITLE
Add RUBY_GC_HEAP_INIT_SIZE_%d_SLOTS to pre-init pools granularly

### DIFF
--- a/man/ruby.1
+++ b/man/ruby.1
@@ -550,7 +550,12 @@ There are currently 4 possible areas where the GC may be tuned by
 the following 11 environment variables:
 .Bl -hang -compact -width "RUBY_GC_OLDMALLOC_LIMIT_GROWTH_FACTOR"
 .It Ev RUBY_GC_HEAP_INIT_SLOTS
-Initial allocation slots.  Introduced in Ruby 2.1, default: 10000.
+Initial allocation slots. Applies to all slot sizes.  Introduced in Ruby 2.1, default: 10000.
+.Pp
+.It Ev RUBY_GC_HEAP_INIT_SIZE_%d_SLOTS
+Initial allocation of slots in a specific size pool.
+The available size pools can be found in `GC.stat_heap`.
+Introduced in Ruby 3.3.
 .Pp
 .It Ev RUBY_GC_HEAP_FREE_SLOTS
 Prepare at least this amount of slots after GC.

--- a/test/ruby/test_gc.rb
+++ b/test/ruby/test_gc.rb
@@ -315,6 +315,21 @@ class TestGc < Test::Unit::TestCase
     }
     assert_normal_exit("exit", "[ruby-core:39777]", :child_env => env)
 
+    env = {}
+    GC.stat_heap.each do |_, s|
+      env["RUBY_GC_HEAP_INIT_SIZE_#{s[:slot_size]}_SLOTS"] = "200000"
+    end
+    assert_normal_exit("exit", "", :child_env => env)
+
+    env["RUBY_GC_HEAP_INIT_SLOTS"] = "100000"
+    assert_normal_exit("exit", "", :child_env => env)
+
+    env = {}
+    GC.stat_heap.each do |_, s|
+      env["RUBY_GC_HEAP_INIT_SIZE_#{s[:slot_size]}_SLOTS"] = "0"
+    end
+    assert_normal_exit("exit", "", :child_env => env)
+
     env = {
       "RUBYOPT" => "",
       "RUBY_GC_HEAP_INIT_SLOTS" => "100000"


### PR DESCRIPTION
The old RUBY_GC_HEAP_INIT_SLOTS isn't really usable anymore as it initialize all the pools by the same factor, but it's unlikely that pools will need similar sizes.

In production our 40B pool is 5 to 6 times bigger than our 80B pool.

cc @peterzhu2118 @eightbitraptor @jasonhl