### PR TITLE
Mark "method" objects as protected by write barrier

### DIFF
--- a/proc.c
+++ b/proc.c
@@ -1630,7 +1630,7 @@ static const rb_data_type_t method_data_type = {
         bm_memsize,
         bm_compact,
     },
-    0, 0, RUBY_TYPED_FREE_IMMEDIATELY
+    0, 0, RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED
 };
 
 VALUE


### PR DESCRIPTION
All its reference are set with RB_OBJ_WRITE, so they can be marked as WB protected.