### PR TITLE
Mark "mapping_buffer" as write barrier protected

### DIFF
--- a/string.c
+++ b/string.c
@@ -7314,7 +7314,8 @@ mapping_buffer_free(void *p)
 
 static const rb_data_type_t mapping_buffer_type = {
     "mapping_buffer",
-    {0, mapping_buffer_free,}
+    {0, mapping_buffer_free,},
+    0, 0, RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED
 };
 
 static VALUE


### PR DESCRIPTION
It doesn't have any reference so it can be marked as protected.

cc @peterzhu2118 