### PR TITLE
Enable write barriers on File::Stat

### DIFF
--- a/file.c
+++ b/file.c
@@ -493,7 +493,7 @@ stat_memsize(const void *p)
 static const rb_data_type_t stat_data_type = {
     "stat",
     {NULL, RUBY_TYPED_DEFAULT_FREE, stat_memsize,},
-    0, 0, RUBY_TYPED_FREE_IMMEDIATELY
+    0, 0, RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED
 };
 
 static VALUE


### PR DESCRIPTION
It holds no reference, so no changes needed.

cc @peterzhu2118 