### PR TITLE
Implement Write Barrier for Backtrace::Location

### DIFF
--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -165,7 +165,7 @@ location_memsize(const void *ptr)
 static const rb_data_type_t location_data_type = {
     "frame_info",
     {location_mark, RUBY_TYPED_DEFAULT_FREE, location_memsize,},
-    0, 0, RUBY_TYPED_FREE_IMMEDIATELY
+    0, 0, RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED
 };
 
 int
@@ -757,7 +757,7 @@ location_create(rb_backtrace_location_t *srcloc, void *btobj)
     obj = TypedData_Make_Struct(rb_cBacktraceLocation, struct valued_frame_info, &location_data_type, vloc);
 
     vloc->loc = srcloc;
-    vloc->btobj = (VALUE)btobj;
+    RB_OBJ_WRITE(obj, &vloc->btobj, (VALUE)btobj);
 
     return obj;
 }


### PR DESCRIPTION
It only has a single reference, set in a single place.

NB: The reference in question is a ref to the `Backtrace` object, but I can't see it used anywhere, which makes me wonder if it's even needed in the first place?

cc @peterzhu2118 