### PR TITLE
YJIT: Check interrupts on frame pop

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -5300,9 +5300,6 @@ fn gen_send_iseq(
     // Number of locals that are not parameters
     let num_locals = unsafe { get_iseq_body_local_table_size(iseq) as i32 } - (num_params as i32);
 
-    // Check for interrupts
-    gen_check_ints(asm, side_exit);
-
     match block_arg_type {
         Some(Type::Nil) => {
             // We have a nil block arg, so let's pop it off the args


### PR DESCRIPTION
On the interpreter, vm_push_frame doesn't check interrupts. Only vm_pop_frame does.