### PR TITLE
Trigger RUBY_INTERNAL_THREAD_EVENT_EXITED before next thread scheduling

### DIFF
--- a/thread.c
+++ b/thread.c
@@ -635,7 +635,6 @@ thread_do_start(rb_thread_t *th)
 }
 
 void rb_ec_clear_current_thread_trace_func(const rb_execution_context_t *ec);
-#define thread_sched_to_dead thread_sched_to_waiting
 
 static int
 thread_start_func_2(rb_thread_t *th, VALUE *stack_start)

--- a/thread_none.c
+++ b/thread_none.c
@@ -34,6 +34,8 @@ thread_sched_to_waiting(struct rb_thread_sched *sched)
 {
 }
 
+#define thread_sched_to_dead thread_sched_to_waiting
+
 static void
 thread_sched_yield(struct rb_thread_sched *sched, rb_thread_t *th)
 {

--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -450,6 +450,13 @@ thread_sched_to_waiting(struct rb_thread_sched *sched)
 }
 
 static void
+thread_sched_to_dead(struct rb_thread_sched *sched)
+{
+    RB_INTERNAL_THREAD_HOOK(RUBY_INTERNAL_THREAD_EVENT_EXITED);
+    thread_sched_to_waiting(sched);
+}
+
+static void
 thread_sched_yield(struct rb_thread_sched *sched, rb_thread_t *th)
 {
     rb_thread_t *next;
@@ -1171,8 +1178,6 @@ thread_start_func_1(void *th_ptr)
 #else
         thread_start_func_2(th, &stack_start);
 #endif
-
-        RB_INTERNAL_THREAD_HOOK(RUBY_INTERNAL_THREAD_EVENT_EXITED);
     }
 #if USE_THREAD_CACHE
     /* cache thread */

--- a/thread_win32.c
+++ b/thread_win32.c
@@ -131,6 +131,8 @@ thread_sched_to_running(struct rb_thread_sched *sched, rb_thread_t *th)
     if (GVL_DEBUG) fprintf(stderr, "gvl acquire (%p): acquire\n", th);
 }
 
+#define thread_sched_to_dead thread_sched_to_waiting
+
 static void
 thread_sched_to_waiting(struct rb_thread_sched *sched)
 {


### PR DESCRIPTION
```
  1) Failure:
TestThreadInstrumentation#test_thread_instrumentation [/tmp/ruby/src/trunk-repeat20-asserts/test/-ext-/thread/test_instrumentation_api.rb:33]:
Call counters[4]: [3, 4, 4, 4, 0].
Expected 0 to be > 0.
```

We fire the EXIT hook after the call to `thread_sched_to_dead` which mean another thread might be running before the `EXIT` hook have been executed.