### PR TITLE
Mark Encoding as Write Barrier protected

### DIFF
--- a/encoding.c
+++ b/encoding.c
@@ -102,7 +102,7 @@ static rb_encoding *global_enc_ascii,
 static const rb_data_type_t encoding_data_type = {
     "encoding",
     {0, 0, 0,},
-    0, 0, RUBY_TYPED_FREE_IMMEDIATELY
+    0, 0, RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED
 };
 
 #define is_data_encoding(obj) (RTYPEDDATA_P(obj) && RTYPEDDATA_TYPE(obj) == &encoding_data_type)


### PR DESCRIPTION
It doesn't even have a mark function.
It's only about a hundred objects, but not reason
to scan them every time.

cc @peterzhu2118 @jhawthorn @HParker 