### PR TITLE
Revert "Only emit circular dependency warning for owned thread shields"

### DIFF
--- a/internal/thread.h
+++ b/internal/thread.h
@@ -29,7 +29,6 @@ VALUE rb_get_coverages(void);
 int rb_get_coverage_mode(void);
 VALUE rb_default_coverage(int);
 VALUE rb_thread_shield_new(void);
-bool rb_thread_shield_owned(VALUE self);
 VALUE rb_thread_shield_wait(VALUE self);
 VALUE rb_thread_shield_release(VALUE self);
 VALUE rb_thread_shield_destroy(VALUE self);

--- a/load.c
+++ b/load.c
@@ -850,8 +850,7 @@ load_lock(rb_vm_t *vm, const char *ftptr, bool warn)
         st_insert(loading_tbl, (st_data_t)ftptr, data);
         return (char *)ftptr;
     }
-
-    if (warn && rb_thread_shield_owned((VALUE)data)) {
+    if (warn) {
         VALUE warning = rb_warning_string("loading in progress, circular require considered harmful - %s", ftptr);
         rb_backtrace_each(rb_str_append, warning);
         rb_warning("%"PRIsVALUE, warning);

--- a/spec/ruby/core/kernel/shared/require.rb
+++ b/spec/ruby/core/kernel/shared/require.rb
@@ -237,16 +237,6 @@ describe :kernel_require, shared: true do
       }.should complain(/circular require considered harmful/, verbose: true)
       ScratchPad.recorded.should == [:loaded]
     end
-
-    ruby_bug "#17340", ''...'3.3' do
-      it "loads a file concurrently" do
-        path = File.expand_path "concurrent_require_fixture.rb", CODE_LOADING_DIR
-        ScratchPad.record(@object)
-        -> {
-          @object.require(path)
-        }.should_not complain(/circular require considered harmful/, verbose: true)
-      end
-    end
   end
 
   describe "(non-extensioned path)" do

--- a/spec/ruby/fixtures/code/concurrent_require_fixture.rb
+++ b/spec/ruby/fixtures/code/concurrent_require_fixture.rb
@@ -1,1 +1,0 @@
-Thread.new { ScratchPad.recorded.require(__FILE__) }.join(0.1)

--- a/test/ruby/test_require.rb
+++ b/test/ruby/test_require.rb
@@ -562,6 +562,9 @@ class TestRequire < Test::Unit::TestCase
 
       assert_equal(true, (t1_res ^ t2_res), bug5754 + " t1:#{t1_res} t2:#{t2_res}")
       assert_equal([:pre, :post], scratch, bug5754)
+
+      assert_match(/circular require/, output)
+      assert_match(/in #{__method__}'$/o, output)
     }
   ensure
     $VERBOSE = verbose

--- a/thread.c
+++ b/thread.c
@@ -4920,17 +4920,6 @@ rb_thread_shield_new(void)
     return thread_shield;
 }
 
-bool
-rb_thread_shield_owned(VALUE self)
-{
-    VALUE mutex = GetThreadShieldPtr(self);
-    if (!mutex) return false;
-
-    rb_mutex_t *m = mutex_ptr(mutex);
-
-    return m->fiber == GET_EC()->fiber_ptr;
-}
-
 /*
  * Wait a thread shield.
  *


### PR DESCRIPTION
Reverts ruby/ruby#7252

We got some failures on CI.
```
1)
  An exception occurred during: Kernel#require (path resolution) loads a file concurrently
  /__w/ruby/ruby/src/spec/ruby/core/kernel/shared/require.rb:242
  Kernel#require (path resolution) loads a file concurrently ERROR
  LeakError: Leaked thread: #<Thread:0x00007f6994305480 /__w/ruby/ruby/src/spec/ruby/fixtures/code/concurrent_require_fixture.rb:1 sleep_forever>
  /__w/ruby/ruby/src/spec/ruby/core/kernel/require_spec.rb:5:in `<top (required)>'
  
  2)
  An exception occurred during: Kernel#require (non-extensioned path) loads a .rb extensioned file when a C-extension file exists on an earlier load path
  /__w/ruby/ruby/src/spec/ruby/core/kernel/shared/require.rb:259
  Kernel#require (non-extensioned path) loads a .rb extensioned file when a C-extension file exists on an earlier load path ERROR
  LeakError: Finished thread: #<Thread:0x00007f6994305480 /__w/ruby/ruby/src/spec/ruby/fixtures/code/concurrent_require_fixture.rb:1 dead>
  /__w/ruby/ruby/src/spec/ruby/core/kernel/require_spec.rb:5:in `<top (required)>'
  
  3)
  An exception occurred during: Kernel.require (path resolution) loads a file concurrently
  /__w/ruby/ruby/src/spec/ruby/core/kernel/shared/require.rb:2[42](https://github.com/ruby/ruby/actions/runs/4107964103/jobs/7088090413#step:19:43)
  Kernel.require (path resolution) loads a file concurrently ERROR
  LeakError: Leaked thread: #<Thread:0x00007f69908fbaa0 /__w/ruby/ruby/src/spec/ruby/fixtures/code/concurrent_require_fixture.rb:1 sleep_forever>
  /__w/ruby/ruby/src/spec/ruby/core/kernel/require_spec.rb:23:in `<top (required)>'
  
  4)
  An exception occurred during: Kernel.require (non-extensioned path) loads a .rb extensioned file when a C-extension file exists on an earlier load path
  /__w/ruby/ruby/src/spec/ruby/core/kernel/shared/require.rb:259
  Kernel.require (non-extensioned path) loads a .rb extensioned file when a C-extension file exists on an earlier load path ERROR
  LeakError: Finished thread: #<Thread:0x00007f69908fbaa0 /__w/ruby/ruby/src/spec/ruby/fixtures/code/concurrent_require_fixture.rb:1 dead>
  /__w/ruby/ruby/src/spec/ruby/core/kernel/require_spec.rb:23:in `<top (required)>'
```