### PR TITLE
Consider DATA objects without a mark function as protected

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -3110,7 +3110,7 @@ rb_data_object_wrap(VALUE klass, void *datap, RUBY_DATA_FUNC dmark, RUBY_DATA_FU
 {
     RUBY_ASSERT_ALWAYS(dfree != (RUBY_DATA_FUNC)1);
     if (klass) rb_data_object_check(klass);
-    return newobj_of(klass, T_DATA, (VALUE)dmark, (VALUE)dfree, (VALUE)datap, FALSE, sizeof(struct RTypedData));
+    return newobj_of(klass, T_DATA, (VALUE)dmark, (VALUE)dfree, (VALUE)datap, !dmark, sizeof(struct RTypedData));
 }
 
 VALUE
@@ -3126,7 +3126,8 @@ rb_data_typed_object_wrap(VALUE klass, void *datap, const rb_data_type_t *type)
 {
     RBIMPL_NONNULL_ARG(type);
     if (klass) rb_data_object_check(klass);
-    return newobj_of(klass, T_DATA, (VALUE)type, (VALUE)1, (VALUE)datap, type->flags & RUBY_FL_WB_PROTECTED, sizeof(struct RTypedData));
+    bool wb_protected = (type->flags & RUBY_FL_WB_PROTECTED) || !type->function.dmark;
+    return newobj_of(klass, T_DATA, (VALUE)type, (VALUE)1, (VALUE)datap, wb_protected, sizeof(struct RTypedData));
 }
 
 VALUE

--- a/test/ruby/test_gc.rb
+++ b/test/ruby/test_gc.rb
@@ -335,13 +335,15 @@ class TestGc < Test::Unit::TestCase
     env = {
       "RUBY_GC_HEAP_INIT_SLOTS" => "100000",
       "RUBY_GC_HEAP_FREE_SLOTS" => "10000",
-      "RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR" => "0.9",
+      "RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR" => "0.4",
     }
     assert_normal_exit("exit", "", :child_env => env)
-    assert_in_out_err([env, "-w", "-e", "exit"], "", [], /RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR=0\.9/, "")
+    assert_in_out_err([env, "-w", "-e", "exit"], "", [], /RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR=0\.4/, "")
 
-    # always full GC when RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR < 1.0
-    assert_in_out_err([env, "-e", "1000_000.times{Object.new}; p(GC.stat[:minor_gc_count] < GC.stat[:major_gc_count])"], "", ['true'], //, "") if use_rgengc?
+    if use_rgengc?
+      # always full GC when RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR < 1.0
+      assert_in_out_err([env, "--disable-gems", "-e", "GC.start; 1000_000.times{Object.new}; p(GC.stat[:minor_gc_count] < GC.stat[:major_gc_count])"], "", ['true'], //, "")
+    end
 
     env = {
       "RUBY_GC_MALLOC_LIMIT"               => "60000000",


### PR DESCRIPTION
Reverts ruby/ruby#7262
Ref: https://github.com/ruby/ruby/pull/7255

It's not uncommon for simple binding to wrap structs without any Ruby object references. Hence with no mark function.

Might as well mark them as protected by a write barrier.

Initially reverted because it would fail the Windows CI. Still has to be investigated.

```
    1) Failure:
  TestGc#test_gc_parameter [D:/a/ruby/ruby/src/test/ruby/test_gc.rb:344]:
  pid 13548 exit 0.
  
  1. [1/2] Assertion for "stdout"
     | <["true"]> expected but was
     | <["false"]>.
```
