### PR TITLE
YJIT: Add counters for ivar exits

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -1977,6 +1977,7 @@ fn gen_get_ivar(
 ) -> CodegenStatus {
     // If the object has a too complex shape, we exit
     if comptime_receiver.shape_too_complex() {
+        gen_counter_incr!(asm, getivar_too_complex);
         return CantCompile;
     }
 
@@ -2209,8 +2210,13 @@ fn gen_setinstancevariable(
 
     // If the comptime receiver is frozen, writing an IV will raise an exception
     // and we don't want to JIT code to deal with that situation.
+    if comptime_receiver.is_frozen() {
+        gen_counter_incr!(asm, setivar_frozen);
+        return CantCompile;
+    }
     // If the object has a too complex shape, we will also exit
-    if comptime_receiver.is_frozen() || comptime_receiver.shape_too_complex() {
+    if comptime_receiver.shape_too_complex() {
+        gen_counter_incr!(asm, setivar_too_complex);
         return CantCompile;
     }
 

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -264,6 +264,7 @@ make_counters! {
     getivar_se_self_not_heap,
     getivar_idx_out_of_range,
     getivar_megamorphic,
+    getivar_too_complex,
 
     setivar_se_self_not_heap,
     setivar_idx_out_of_range,
@@ -272,6 +273,7 @@ make_counters! {
     setivar_not_object,
     setivar_frozen,
     setivar_megamorphic,
+    setivar_too_complex,
 
     oaref_argc_not_one,
     oaref_arg_not_fixnum,


### PR DESCRIPTION
I'm thinking about just using `asm.ccall` for the too complex case, but I'd like to be able to measure the actual breakdown first.