### PR TITLE
Use Thread.pass until thread.stop? to wait for thread to block

### DIFF
--- a/spec/ruby/fixtures/code/concurrent_require_fixture.rb
+++ b/spec/ruby/fixtures/code/concurrent_require_fixture.rb
@@ -1,4 +1,4 @@
 object = ScratchPad.recorded
 thread = Thread.new { object.require(__FILE__) }
-thread.wakeup unless thread.stop?
+Thread.pass until thread.stop?
 ScratchPad.record(thread)


### PR DESCRIPTION
It should be more reliable