### PR TITLE
Tell VSCode to debug test.rb by default [ci-skip]

### DIFF
--- a/misc/.vscode/launch.json
+++ b/misc/.vscode/launch.json
@@ -6,7 +6,7 @@
             "name": "Run ruby",
             "request": "launch",
             "program": "${workspaceFolder}/ruby",
-            "args": ["-e", "p 1"],
+            "args": ["test.rb"],
             "preLaunchTask": "${defaultBuildTask}"
         }
     ]


### PR DESCRIPTION
This mirrors the behaviour of `make lldb` and `make gdb` etc.