### PR TITLE
Avoid marking CC->klass through the method_entry

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -7208,9 +7208,10 @@ gc_mark_imemo(rb_objspace_t *objspace, VALUE obj)
         return;
       case imemo_callcache:
         {
-            const struct rb_callcache *cc = (const struct rb_callcache *)obj;
+            // const struct rb_callcache *cc = (const struct rb_callcache *)obj;
             // should not mark klass here
-            gc_mark(objspace, (VALUE)vm_cc_cme(cc));
+            // The method_entry owner match class so we shouldn't mark it either.
+            // gc_mark(objspace, (VALUE)vm_cc_cme(cc));
         }
         return;
       case imemo_constcache:

--- a/vm_callinfo.h
+++ b/vm_callinfo.h
@@ -352,9 +352,9 @@ static inline const struct rb_callable_method_entry_struct *
 vm_cc_cme(const struct rb_callcache *cc)
 {
     VM_ASSERT(IMEMO_TYPE_P(cc, imemo_callcache));
-    VM_ASSERT(cc->call_ == NULL   || // not initialized yet
-              !vm_cc_markable(cc) ||
-              cc->cme_ != NULL);
+    // VM_ASSERT(cc->call_ == NULL   || // not initialized yet
+    //           !vm_cc_markable(cc) ||
+    //           cc->cme_ != NULL);
 
     return cc->cme_;
 }

--- a/vm_callinfo.h
+++ b/vm_callinfo.h
@@ -352,9 +352,10 @@ static inline const struct rb_callable_method_entry_struct *
 vm_cc_cme(const struct rb_callcache *cc)
 {
     VM_ASSERT(IMEMO_TYPE_P(cc, imemo_callcache));
-    // VM_ASSERT(cc->call_ == NULL   || // not initialized yet
-    //           !vm_cc_markable(cc) ||
-    //           cc->cme_ != NULL);
+    VM_ASSERT(cc->call_ == NULL   || // not initialized yet
+              cc->klass == NULL || // invalidated
+              !vm_cc_markable(cc) ||
+              cc->cme_ != NULL);
 
     return cc->cme_;
 }


### PR DESCRIPTION
Test script:

```ruby
require 'objspace'
ObjectSpace.trace_object_allocations_start
GC.start
gen = GC.count

module Foo
  def bar
  end
end

def call_bar(obj)
  # Here the call cache we'll keep a ref on the method_entry
  # which then keep a ref on the singleton_class, making that
  # instance immortal until the method is called again with
  # another instance.

  # The reference chain is IMEMO(callcache) -> IMEMO(ment) -> ICLASS -> CLASS(singleton) -> OBJECT
  obj.bar
end

obj = Object.new
obj.extend(Foo)

call_bar(obj)

id = obj.object_id
obj = nil

4.times { GC.start }
p ObjectSpace._id2ref(id)

puts ObjectSpace.dump(ObjectSpace._id2ref(id))
puts ObjectSpace.dump(ObjectSpace._id2ref(id).singleton_class)
puts '-' * 40
ObjectSpace.dump_all(output: STDOUT)
```

Just curious how much will break on CI