### PR TITLE
Remove alias macro rb_str_splice

### DIFF
--- a/string.c
+++ b/string.c
@@ -5344,8 +5344,6 @@ rb_str_update(VALUE str, long beg, long len, VALUE val)
         ENC_CODERANGE_SET(str, cr);
 }
 
-#define rb_str_splice(str, beg, len, val) rb_str_update(str, beg, len, val)
-
 static void
 rb_str_subpat_set(VALUE str, VALUE re, VALUE backref, VALUE val)
 {
@@ -5396,7 +5394,7 @@ rb_str_aset(VALUE str, VALUE indx, VALUE val)
             rb_raise(rb_eIndexError, "string not matched");
         }
         beg = rb_str_sublen(str, beg);
-        rb_str_splice(str, beg, str_strlen(indx, NULL), val);
+        rb_str_update(str, beg, str_strlen(indx, NULL), val);
         return val;
 
       default:
@@ -5404,7 +5402,7 @@ rb_str_aset(VALUE str, VALUE indx, VALUE val)
         {
             long beg, len;
             if (rb_range_beg_len(indx, &beg, &len, str_strlen(str, NULL), 2)) {
-                rb_str_splice(str, beg, len, val);
+                rb_str_update(str, beg, len, val);
                 return val;
             }
         }
@@ -5412,7 +5410,7 @@ rb_str_aset(VALUE str, VALUE indx, VALUE val)
 
       case T_FIXNUM:
         idx = NUM2LONG(indx);
-        rb_str_splice(str, idx, 1, val);
+        rb_str_update(str, idx, 1, val);
         return val;
     }
 }
@@ -5454,7 +5452,7 @@ rb_str_aset_m(int argc, VALUE *argv, VALUE str)
             rb_str_subpat_set(str, argv[0], argv[1], argv[2]);
         }
         else {
-            rb_str_splice(str, NUM2LONG(argv[0]), NUM2LONG(argv[1]), argv[2]);
+            rb_str_update(str, NUM2LONG(argv[0]), NUM2LONG(argv[1]), argv[2]);
         }
         return argv[2];
     }
@@ -5491,7 +5489,7 @@ rb_str_insert(VALUE str, VALUE idx, VALUE str2)
     else if (pos < 0) {
         pos++;
     }
-    rb_str_splice(str, pos, 0, str2);
+    rb_str_update(str, pos, 0, str2);
     return str;
 }
 

--- a/string.c
+++ b/string.c
@@ -5257,7 +5257,7 @@ rb_str_drop_bytes(VALUE str, long len)
 }
 
 static void
-rb_str_splice_1(VALUE str, long beg, long len, VALUE val, long vbeg, long vlen)
+rb_str_update_1(VALUE str, long beg, long len, VALUE val, long vbeg, long vlen)
 {
     char *sptr;
     long slen;
@@ -5299,9 +5299,9 @@ rb_str_splice_1(VALUE str, long beg, long len, VALUE val, long vbeg, long vlen)
 }
 
 static inline void
-rb_str_splice_0(VALUE str, long beg, long len, VALUE val)
+rb_str_update_0(VALUE str, long beg, long len, VALUE val)
 {
-    rb_str_splice_1(str, beg, len, val, 0, RSTRING_LEN(val));
+    rb_str_update_1(str, beg, len, val, 0, RSTRING_LEN(val));
 }
 
 void
@@ -5337,7 +5337,7 @@ rb_str_update(VALUE str, long beg, long len, VALUE val)
     /* error check */
     beg = p - RSTRING_PTR(str);	/* physical position */
     len = e - p;		/* physical length */
-    rb_str_splice_0(str, beg, len, val);
+    rb_str_update_0(str, beg, len, val);
     rb_enc_associate(str, enc);
     cr = ENC_CODERANGE_AND(ENC_CODERANGE(str), ENC_CODERANGE(val));
     if (cr != ENC_CODERANGE_BROKEN)
@@ -5374,7 +5374,7 @@ rb_str_subpat_set(VALUE str, VALUE re, VALUE backref, VALUE val)
     len = end - start;
     StringValue(val);
     enc = rb_enc_check_str(str, val);
-    rb_str_splice_0(str, start, len, val);
+    rb_str_update_0(str, start, len, val);
     rb_enc_associate(str, enc);
 }
 
@@ -6368,7 +6368,7 @@ rb_str_bytesplice(int argc, VALUE *argv, VALUE str)
     str_check_beg_len(val, &vbeg, &vlen);
     enc = rb_enc_check(str, val);
     str_modify_keep_cr(str);
-    rb_str_splice_1(str, beg, len, val, vbeg, vlen);
+    rb_str_update_1(str, beg, len, val, vbeg, vlen);
     rb_enc_associate(str, enc);
     cr = ENC_CODERANGE_AND(ENC_CODERANGE(str), ENC_CODERANGE(val));
     if (cr != ENC_CODERANGE_BROKEN)


### PR DESCRIPTION
`rb_str_splice` was renamed to `rb_str_update` nine years ago in [this commit](https://github.com/ruby/ruby/commit/8581ce328d625ca3dadd897fc2e76ed2022fc127) and an alias macro left in it's place

the only callers of `rb_str_splice` are in `string.c` so I think it's safe to remove the alias macro, and just use `rb_str_update` everywhere.

This PR also renames `rb_str_splice_0` and `rb_str_splice_1` to follow the same convention.