### PR TITLE
YJIT: format numbers in stats printouts with comma separators

### DIFF
--- a/yjit.rb
+++ b/yjit.rb
@@ -254,38 +254,38 @@ module RubyVM::YJIT
       compilation_failure = stats[:compilation_failure]
 
       if stats[:x86_call_rel32] != 0 || stats[:x86_call_reg] != 0
-        $stderr.puts "x86_call_rel32:        " + ("%10d" % stats[:x86_call_rel32])
-        $stderr.puts "x86_call_reg:          " + ("%10d" % stats[:x86_call_reg])
+        $stderr.puts "x86_call_rel32:        " + format_number(10,  stats[:x86_call_rel32])
+        $stderr.puts "x86_call_reg:          " + format_number(10, stats[:x86_call_reg])
       end
 
-      $stderr.puts "bindings_allocations:  " + ("%10d" % stats[:binding_allocations])
-      $stderr.puts "bindings_set:          " + ("%10d" % stats[:binding_set])
-      $stderr.puts "compilation_failure:   " + ("%10d" % compilation_failure) if compilation_failure != 0
-      $stderr.puts "compiled_iseq_count:   " + ("%10d" % stats[:compiled_iseq_count])
-      $stderr.puts "compiled_block_count:  " + ("%10d" % stats[:compiled_block_count])
-      $stderr.puts "compiled_branch_count: " + ("%10d" % stats[:compiled_branch_count])
-      $stderr.puts "block_next_count:      " + ("%10d" % stats[:block_next_count])
-      $stderr.puts "defer_count:           " + ("%10d" % stats[:defer_count])
-      $stderr.puts "freed_iseq_count:      " + ("%10d" % stats[:freed_iseq_count])
-      $stderr.puts "invalidation_count:    " + ("%10d" % stats[:invalidation_count])
-      $stderr.puts "constant_state_bumps:  " + ("%10d" % stats[:constant_state_bumps])
-      $stderr.puts "inline_code_size:      " + ("%10d" % stats[:inline_code_size])
-      $stderr.puts "outlined_code_size:    " + ("%10d" % stats[:outlined_code_size])
-      $stderr.puts "freed_code_size:       " + ("%10d" % stats[:freed_code_size])
-      $stderr.puts "code_region_size:      " + ("%10d" % stats[:code_region_size])
-      $stderr.puts "yjit_alloc_size:       " + ("%10d" % stats[:yjit_alloc_size]) if stats.key?(:yjit_alloc_size)
-      $stderr.puts "live_page_count:       " + ("%10d" % stats[:live_page_count])
-      $stderr.puts "freed_page_count:      " + ("%10d" % stats[:freed_page_count])
-      $stderr.puts "code_gc_count:         " + ("%10d" % stats[:code_gc_count])
-      $stderr.puts "num_gc_obj_refs:       " + ("%10d" % stats[:num_gc_obj_refs])
-      $stderr.puts "object_shape_count:    " + ("%10d" % stats[:object_shape_count])
-      $stderr.puts "side_exit_count:       " + ("%10d" % stats[:side_exit_count])
-      $stderr.puts "total_exit_count:      " + ("%10d" % stats[:total_exit_count])
-      $stderr.puts "total_insns_count:     " + ("%10d" % stats[:total_insns_count]) if stats.key?(:total_insns_count)
+      $stderr.puts "bindings_allocations:  " + format_number(10, stats[:binding_allocations])
+      $stderr.puts "bindings_set:          " + format_number(10, stats[:binding_set])
+      $stderr.puts "compilation_failure:   " + format_number(10, compilation_failure) if compilation_failure != 0
+      $stderr.puts "compiled_iseq_count:   " + format_number(10, stats[:compiled_iseq_count])
+      $stderr.puts "compiled_block_count:  " + format_number(10, stats[:compiled_block_count])
+      $stderr.puts "compiled_branch_count: " + format_number(10, stats[:compiled_branch_count])
+      $stderr.puts "block_next_count:      " + format_number(10, stats[:block_next_count])
+      $stderr.puts "defer_count:           " + format_number(10, stats[:defer_count])
+      $stderr.puts "freed_iseq_count:      " + format_number(10, stats[:freed_iseq_count])
+      $stderr.puts "invalidation_count:    " + format_number(10, stats[:invalidation_count])
+      $stderr.puts "constant_state_bumps:  " + format_number(10, stats[:constant_state_bumps])
+      $stderr.puts "inline_code_size:      " + format_number(10, stats[:inline_code_size])
+      $stderr.puts "outlined_code_size:    " + format_number(10, stats[:outlined_code_size])
+      $stderr.puts "freed_code_size:       " + format_number(10, stats[:freed_code_size])
+      $stderr.puts "code_region_size:      " + format_number(10, stats[:code_region_size])
+      $stderr.puts "yjit_alloc_size:       " + format_number(10, stats[:yjit_alloc_size]) if stats.key?(:yjit_alloc_size)
+      $stderr.puts "live_page_count:       " + format_number(10, stats[:live_page_count])
+      $stderr.puts "freed_page_count:      " + format_number(10, stats[:freed_page_count])
+      $stderr.puts "code_gc_count:         " + format_number(10, stats[:code_gc_count])
+      $stderr.puts "num_gc_obj_refs:       " + format_number(10, stats[:num_gc_obj_refs])
+      $stderr.puts "object_shape_count:    " + format_number(10, stats[:object_shape_count])
+      $stderr.puts "side_exit_count:       " + format_number(10, stats[:side_exit_count])
+      $stderr.puts "total_exit_count:      " + format_number(10, stats[:total_exit_count])
+      $stderr.puts "total_insns_count:     " + format_number(10, stats[:total_insns_count]) if stats.key?(:total_insns_count)
       if stats.key?(:vm_insns_count)
-        $stderr.puts "vm_insns_count:        " + ("%10d" % stats[:vm_insns_count])
+        $stderr.puts "vm_insns_count:        " + format_number(10, stats[:vm_insns_count])
       end
-      $stderr.puts "yjit_insns_count:      " + ("%10d" % stats[:exec_instruction])
+      $stderr.puts "yjit_insns_count:      " + format_number(10, stats[:exec_instruction])
       if stats.key?(:ratio_in_yjit)
         $stderr.puts "ratio_in_yjit:         " + ("%9.1f" % stats[:ratio_in_yjit]) + "%"
       end
@@ -315,13 +315,13 @@ module RubyVM::YJIT
         exits.each do |name, count|
           padding = longest_insn_name_len + left_pad
           padded_name = "%#{padding}s" % name
-          padded_count = "%10d" % count
+          padded_count = format_number(10, count)
           percent = 100.0 * count / total_exits
           formatted_percent = "%.1f" % percent
           $stderr.puts("#{padded_name}: #{padded_count} (#{formatted_percent}%)" )
         end
       else
-        $stderr.puts "total_exits:           " + ("%10d" % total_exits)
+        $stderr.puts "total_exits:           " + format_number(10, total_exits)
       end
     end
 
@@ -351,8 +351,20 @@ module RubyVM::YJIT
 
       counters.reverse_each do |(name, value)|
         percentage = value.fdiv(total) * 100
-        $stderr.printf("    %*s %10d (%4.1f%%)\n", longest_name_length, name, value, percentage);
+        padded_name = name.rjust(longest_name_length, ' ')
+        padded_count = format_number(10, value)
+        formatted_pct = "%4.1f%%" % percentage
+        $stderr.puts("    #{padded_name}: #{padded_count} (#{formatted_pct})")
       end
+    end
+
+    # Format large numbers with comma separators for readability
+    def format_number(pad, number)
+      integer, decimal = number.to_s.split(".")
+      d_groups = integer.chars.to_a.reverse.each_slice(3)
+      with_commas = d_groups.map(&:join).join(',').reverse
+      formatted = [with_commas, decimal].compact.join(".")
+      formatted.rjust(pad, ' ')
     end
   end
 end


### PR DESCRIPTION
This is my attempt to make the stats more readable:

```
***YJIT: Printing YJIT statistics on exit***
method call exit reasons: 
                      iseq_has_rest:    115,117 (33.1%)
                          block_arg:     63,342 (18.2%)
                        iseq_zsuper:     45,902 (13.2%)
                   iseq_arity_error:     30,523 ( 8.8%)
                iseq_ruby2_keywords:     24,632 ( 7.1%)
                     iseq_has_no_kw:     17,853 ( 5.1%)
          args_splat_cfunc_var_args:     15,946 ( 4.6%)
                           kw_splat:     12,611 ( 3.6%)
                  klass_megamorphic:      7,787 ( 2.2%)
                    iseq_has_kwrest:      5,200 ( 1.5%)
           iseq_missing_optional_kw:      3,942 ( 1.1%)
             args_splat_cfunc_zuper:      1,972 ( 0.6%)
                      iseq_has_post:      1,958 ( 0.6%)
                     refined_method:        797 ( 0.2%)
              cfunc_ruby_array_varg:        469 ( 0.1%)
                           keywords:         90 ( 0.0%)
    args_splat_cfunc_ruby2_keywords:         33 ( 0.0%)
                      zsuper_method:          5 ( 0.0%)
invokeblock exit reasons: 
      proc:      1,859 (94.5%)
    symbol:        109 ( 5.5%)
invokesuper exit reasons: 
    me_changed:      4,630 (96.3%)
         block:        176 ( 3.7%)
leave exit reasons: 
        interp_return:  1,697,530 (98.1%)
    start_pc_non_zero:     33,363 ( 1.9%)
         se_interrupt:         27 ( 0.0%)
getblockparamproxy exit reasons: 
    block_param_modified:         77 (100.0%)
getinstancevariable exit reasons:
    too_complex:          8 (100.0%)
setinstancevariable exit reasons:
    (all relevant counters are zero)
opt_aref exit reasons: 
    (all relevant counters are zero)
expandarray exit reasons: 
            splat:      9,945 (99.9%)
    rhs_too_small:          5 ( 0.1%)
opt_getinlinecache exit reasons: 
    miss:          2 (100.0%)
invalidation reasons: 
          method_lookup:        312 (60.0%)
    constant_state_bump:        150 (28.8%)
       constant_ic_fill:         58 (11.2%)
x86_call_rel32:            19,268
x86_call_reg:                   0
bindings_allocations:         155
bindings_set:                   0
compiled_iseq_count:        2,170
compiled_block_count:      19,987
compiled_branch_count:     34,914
block_next_count:           7,089
defer_count:                6,581
freed_iseq_count:              35
invalidation_count:           520
constant_state_bumps:           0
inline_code_size:       1,971,872
outlined_code_size:     1,970,384
freed_code_size:                0
code_region_size:       3,948,544
yjit_alloc_size:       41,197,784
live_page_count:              241
freed_page_count:               0
code_gc_count:                  0
num_gc_obj_refs:           15,719
object_shape_count:         2,392
side_exit_count:          409,429
total_exit_count:       2,106,959
total_insns_count:     88,133,207
vm_insns_count:         7,235,966
yjit_insns_count:      81,306,670
ratio_in_yjit:              91.8%
avg_len_in_yjit:             38.4
Top-20 most frequent exit ops (100.0% of exits):
    opt_send_without_block:    116,906 (28.6%)
               invokesuper:    111,565 (27.2%)
                      send:     99,750 (24.4%)
               invokeblock:     30,520 (7.5%)
                  opt_aref:     14,025 (3.4%)
                     throw:     10,460 (2.6%)
               expandarray:      9,950 (2.4%)
             setlocal_WC_0:      8,149 (2.0%)
                    opt_eq:      4,966 (1.2%)
        getblockparamproxy:      2,217 (0.5%)
                 opt_nil_p:        325 (0.1%)
               objtostring:        286 (0.1%)
                checkmatch:        155 (0.0%)
      opt_getconstant_path:         63 (0.0%)
                      once:         58 (0.0%)
                     leave:         27 (0.0%)
       getinstancevariable:          2 (0.0%)
               opt_empty_p:          2 (0.0%)
                    opt_or:          1 (0.0%)
                   opt_mod:          1 (0.0%)
```

Might not seem like it makes much of a difference, but I feel like it makes things like numbers of bytes a lot easier to parse.