### PR TITLE
Implement Write Barrier for RMatch objects

### DIFF
--- a/include/ruby/internal/rgengc.h
+++ b/include/ruby/internal/rgengc.h
@@ -133,6 +133,17 @@
  * @private
  *
  * This  is   a  compile-time   flag  to   enable/disable  write   barrier  for
+ * struct ::RMatch.  It has to be set at the time ruby itself compiles.  Makes
+ * no sense for 3rd parties.
+ */
+#ifndef RGENGC_WB_PROTECTED_MATCH
+# define RGENGC_WB_PROTECTED_MATCH 1
+#endif
+
+/**
+ * @private
+ *
+ * This  is   a  compile-time   flag  to   enable/disable  write   barrier  for
  * struct ::RClass.  It has to be set  at the time ruby itself compiles.  Makes
  * no sense for 3rd parties.
  */


### PR DESCRIPTION
They only have two references.

cc @peterzhu2118 