### PR TITLE
YJIT: add counters for polymorphic send and send with known class

### DIFF
--- a/yjit/src/asm/x86_64/mod.rs
+++ b/yjit/src/asm/x86_64/mod.rs
@@ -700,13 +700,13 @@ pub fn call_ptr(cb: &mut CodeBlock, scratch_opnd: X86Opnd, dst_ptr: *const u8) {
 
         // If the offset fits in 32-bit
         if rel64 >= i32::MIN.into() && rel64 <= i32::MAX.into() {
-            incr_counter!(x86_call_rel32);
+            incr_counter!(num_send_x86_rel32);
             call_rel32(cb, rel64.try_into().unwrap());
             return;
         }
 
         // Move the pointer into the scratch register and call
-        incr_counter!(x86_call_reg);
+        incr_counter!(num_send_x86_reg);
         mov(cb, scratch_opnd, const_ptr_opnd(dst_ptr));
         call(cb, scratch_opnd);
     } else {

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -318,8 +318,11 @@ make_counters! {
 
     num_gc_obj_refs,
 
-    x86_call_rel32,
-    x86_call_reg,
+    num_send,
+    num_send_known_class,
+    num_send_polymorphic,
+    num_send_x86_rel32,
+    num_send_x86_reg,
 }
 
 //===========================================================================


### PR DESCRIPTION
I wanted to investigate the idea that maybe we could avoid `defer_compilation` when we already know the class of an object, e.g. `CArray`, `CHash` or `CString`, in relation with https://github.com/Shopify/ruby/issues/462

Railsbench:
```
num_send:                13,048,597
num_send_known_class:       420,456 ( 3.2%)
num_send_polymorphic:       963,840 ( 7.4%)
```

Liquid:
```
num_send:                 2,966,224
num_send_known_class:       103,663 ( 3.5%)
num_send_polymorphic:       583,445 (19.7%)
```

At the moment I don't think this is common enough for this change to have a ton of impact, however... If we end up with a more sophisticated context object which makes it easier to track the class of locals without using a ton of memory, then I think this idea could become viable.