### PR TITLE
Raise ArgumentError if IO.read is provided negative offset

### DIFF
--- a/io.c
+++ b/io.c
@@ -12125,9 +12125,13 @@ static VALUE
 rb_io_s_read(int argc, VALUE *argv, VALUE io)
 {
     VALUE opt, offset;
+    long off;
     struct foreach_arg arg;
 
     argc = rb_scan_args(argc, argv, "13:", NULL, NULL, &offset, NULL, &opt);
+    if (!NIL_P(offset) && (off = NUM2LONG(offset)) < 0) {
+        rb_raise(rb_eArgError, "negative offset %ld given", off);
+    }
     open_key_args(io, argc, argv, opt, &arg);
     if (NIL_P(arg.io)) return Qnil;
     if (!NIL_P(offset)) {

--- a/spec/ruby/core/io/read_spec.rb
+++ b/spec/ruby/core/io/read_spec.rb
@@ -128,9 +128,18 @@ describe "IO.read" do
     -> { IO.read @fname, -1 }.should raise_error(ArgumentError)
   end
 
-  it "raises an Errno::EINVAL when not passed a valid offset" do
-    -> { IO.read @fname, 0, -1  }.should raise_error(Errno::EINVAL)
-    -> { IO.read @fname, -1, -1 }.should raise_error(Errno::EINVAL)
+  ruby_version_is ''...'3.3' do
+    it "raises an Errno::EINVAL when not passed a valid offset" do
+      -> { IO.read @fname, 0, -1  }.should raise_error(Errno::EINVAL)
+      -> { IO.read @fname, -1, -1 }.should raise_error(Errno::EINVAL)
+    end
+  end
+
+  ruby_version_is '3.3' do
+    it "raises an ArgumentError when not passed a valid offset" do
+      -> { IO.read @fname, 0, -1  }.should raise_error(ArgumentError)
+      -> { IO.read @fname, -1, -1 }.should raise_error(ArgumentError)
+    end
   end
 
   it "uses the external encoding specified via the :external_encoding option" do

--- a/test/ruby/test_io.rb
+++ b/test/ruby/test_io.rb
@@ -2866,6 +2866,9 @@ class TestIO < Test::Unit::TestCase
       assert_equal("foo\nbar\nbaz\n", File.read(t.path))
       assert_equal("foo\nba", File.read(t.path, 6))
       assert_equal("bar\n", File.read(t.path, 4, 4))
+
+      assert_raise(ArgumentError) { File.read(t.path, -1) }
+      assert_raise(ArgumentError) { File.read(t.path, 1, -1) }
     }
   end
 


### PR DESCRIPTION
Fixes [Bug #19380]