### PR TITLE
Raise ArgumentError when attempting to create a named Struct without members

### DIFF
--- a/bootstraptest/test_struct.rb
+++ b/bootstraptest/test_struct.rb
@@ -1,5 +1,5 @@
 assert_equal 'Struct::Foo', %q{
   Struct.instance_eval { const_set(:Foo, nil) }
-  Struct.new("Foo")
+  Struct.new("Foo", :a)
   Struct::Foo
 }

--- a/spec/ruby/core/marshal/dump_spec.rb
+++ b/spec/ruby/core/marshal/dump_spec.rb
@@ -385,7 +385,7 @@ describe "Marshal.dump" do
 
   describe "with a Struct" do
     it "dumps a Struct" do
-      Marshal.dump(Struct::Pyramid.new).should == "\004\bS:\024Struct::Pyramid\000"
+      Marshal.dump(Struct::Pyramid.new).should == "\004\bS:\024Struct::Pyramid\006:\006a0"
     end
 
     it "dumps a Struct" do
@@ -393,9 +393,9 @@ describe "Marshal.dump" do
     end
 
     it "dumps a Struct with instance variables" do
-      st = Struct.new("Thick").new
+      st = Struct.new("Thick", :a).new
       st.instance_variable_set(:@ivar, 1)
-      Marshal.dump(st).should == "\004\bIS:\022Struct::Thick\000\006:\n@ivari\006"
+      Marshal.dump(st).should == "\004\bIS:\022Struct::Thick\006:\006a0\006:\n@ivari\006"
       Struct.send(:remove_const, :Thick)
     end
 

--- a/spec/ruby/core/marshal/fixtures/marshal_data.rb
+++ b/spec/ruby/core/marshal/fixtures/marshal_data.rb
@@ -154,7 +154,7 @@ module MethsMore
   def meths_more_method() end
 end
 
-Struct.new "Pyramid"
+Struct.new "Pyramid", :a
 Struct.new "Useful", :a, :b
 
 module MarshalSpec
@@ -297,7 +297,7 @@ module MarshalSpec
     "Array subclass" => [UserArray.new,
                      "\004\bC:\016UserArray[\000"],
     "Struct Pyramid" => [Struct::Pyramid.new,
-                 "\004\bS:\024Struct::Pyramid\000"],
+                 "\004\bS:\024Struct::Pyramid\006:\006a0"],
   }
   DATA_19 = {
     "nil" => [nil, "\004\b0"],
@@ -395,7 +395,7 @@ module MarshalSpec
     "Array subclass" => [UserArray.new,
                      "\004\bC:\016UserArray[\000"],
     "Struct Pyramid" => [Struct::Pyramid.new,
-                 "\004\bS:\024Struct::Pyramid\000"],
+                 "\004\bS:\024Struct::Pyramid\006:\006a0"],
     "Random" => random_data,
   }
 end

--- a/spec/ruby/core/marshal/shared/load.rb
+++ b/spec/ruby/core/marshal/shared/load.rb
@@ -334,8 +334,11 @@ describe :marshal_load, shared: true do
              :go, c, nil, Struct::Pyramid.new, f, :go, :no, s, b, r,
              :so, 'huh', o1, true, b, b, 99, r, b, s, :so, f, c, :no, o1, d]
 
-      Marshal.send(@method, "\004\b[*:\aso\"\nhelloii;\000;\000[\t\"\ahi:\ano\"\aoh:\ago;\000U:\020UserMarshal\"\nstuff;\000;\006@\n;\ac\vString0S:\024Struct::Pyramid\000f\0061;\a;\006@\t@\b/\000\000;\000\"\bhuhU:\030UserMarshalWithIvar[\006\"\fmy dataT@\b@\bih@\017@\b@\t;\000@\016@\f;\006@\021@\a").should ==
-        obj
+      loaded = Marshal.send(@method, "\004\b[*:\aso\"\nhelloii;\000;\000[\t\"\ahi:\ano\"\aoh:\ago;\000U:\020UserMarshal\"\nstuff;\000;\006@\n;\ac\vString0S:\024Struct::Pyramid\006:\006a0f\0061;\a;\006@\t@\b/\000\000;\000\"\bhuhU:\030UserMarshalWithIvar[\006\"\fmy dataT@\b@\bih@\017@\b@\t;\000@\016@\f;\006@\021@\a")
+      def (loaded[14]).==(other) 
+        other.is_a?(self.class) && other.a == a
+      end
+      loaded.should == obj
     end
 
     it "loads an array having ivar" do
@@ -533,9 +536,9 @@ describe :marshal_load, shared: true do
     end
 
     it "loads a struct having ivar" do
-      obj = Struct.new("Thick").new
+      obj = Struct.new("Thick", :a).new
       obj.instance_variable_set(:@foo, 5)
-      reloaded = Marshal.send(@method, "\004\bIS:\022Struct::Thick\000\006:\t@fooi\n")
+      reloaded = Marshal.send(@method, "\004\bIS:\022Struct::Thick\006:\006a0\006:\t@fooi\n")
       reloaded.should == obj
       reloaded.instance_variable_get(:@foo).should == 5
       Struct.send(:remove_const, :Thick)

--- a/spec/ruby/core/struct/new_spec.rb
+++ b/spec/ruby/core/struct/new_spec.rb
@@ -24,7 +24,7 @@ describe "Struct.new" do
   it "calls to_str on its first argument (constant name)" do
     obj = mock('Foo')
     def obj.to_str() "Foo" end
-    struct = Struct.new(obj)
+    struct = Struct.new(obj, :a)
     struct.should == Struct::Foo
     struct.name.should == "Struct::Foo"
   end

--- a/struct.c
+++ b/struct.c
@@ -688,6 +688,9 @@ rb_struct_s_def(int argc, VALUE *argv, VALUE klass)
         st = anonymous_struct(klass);
     }
     else {
+        if (argc == 0) {
+            rb_raise(rb_eArgError, "cannot created named struct without members");
+        }
         st = new_struct(name, klass);
     }
     setup_struct(st, rest);

--- a/test/-ext-/symbol/test_inadvertent_creation.rb
+++ b/test/-ext-/symbol/test_inadvertent_creation.rb
@@ -293,7 +293,7 @@ module Test_Symbol
 
     def test_struct_new
       name = noninterned_name
-      assert_raise(NameError) {Struct.new(name)}
+      assert_raise(NameError) {Struct.new(name, :a)}
       assert_not_interned(name)
     end
 

--- a/test/ruby/test_struct.rb
+++ b/test/ruby/test_struct.rb
@@ -29,6 +29,12 @@ module TestStruct
     end
   end
 
+  def test_memberless_struct_error
+    assert_raise(ArgumentError) { @Struct.new }
+    assert_raise(ArgumentError) { @Struct.new("Test") }
+    assert_raise(NameError) { @Struct::Test }
+  end
+
   # [ruby-dev:26247] more than 10 struct members causes segmentation fault
   def test_morethan10members
     list = %w( a b c d  e f g h  i j k l  m n o p )
@@ -91,8 +97,8 @@ module TestStruct
   end
 
   def test_struct_new
-    assert_raise(NameError) { @Struct.new("foo") }
-    assert_nothing_raised { @Struct.new("Foo") }
+    assert_raise(NameError) { @Struct.new("foo", :a) }
+    assert_nothing_raised { @Struct.new("Foo", :a) }
     @Struct.instance_eval { remove_const(:Foo) }
     assert_nothing_raised { @Struct.new(:a) { } }
     assert_raise(RuntimeError) { @Struct.new(:a) { raise } }
@@ -345,15 +351,15 @@ module TestStruct
   end
 
   def test_error
-    assert_raise(TypeError){
+    assert_raise(ArgumentError){
       @Struct.new(0)
     }
   end
 
   def test_redefinition_warning
-    @Struct.new(name = "RedefinitionWarning")
+    @Struct.new(name = "RedefinitionWarning", :a)
     e = EnvUtil.verbose_warning do
-      @Struct.new("RedefinitionWarning")
+      @Struct.new("RedefinitionWarning", :a)
     end
     assert_match(/redefining constant #@Struct::RedefinitionWarning/, e)
 


### PR DESCRIPTION
Anonymous structs without members are not allowed, and it seems like an oversight that named structs without members are allowed.

Fixes [Bug #19416]

This currently fails bundled gems test as it the `debug` gem uses a named struct with members.  I submitted https://github.com/ruby/debug/pull/895 to fix that.