### PR TITLE
Move iseq.variable.flip_count to iseq_compile_data

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -4210,7 +4210,7 @@ compile_flip_flop(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const nod
 {
     const int line = nd_line(node);
     LABEL *lend = NEW_LABEL(line);
-    rb_num_t cnt = ISEQ_FLIP_CNT_INCREMENT(ISEQ_BODY(iseq)->local_iseq)
+    rb_num_t cnt = ISEQ_COMPILE_DATA(iseq)->flip_count++
         + VM_SVAR_FLIPFLOP_START;
     VALUE key = INT2FIX(cnt);
 
@@ -12070,7 +12070,6 @@ ibf_dump_iseq_each(struct ibf_dump *dump, const rb_iseq_t *iseq)
     ibf_dump_write_small_value(dump, mandatory_only_iseq_index);
     ibf_dump_write_small_value(dump, IBF_BODY_OFFSET(ci_entries_offset));
     ibf_dump_write_small_value(dump, IBF_BODY_OFFSET(outer_variables_offset));
-    ibf_dump_write_small_value(dump, body->variable.flip_count);
     ibf_dump_write_small_value(dump, body->local_table_size);
     ibf_dump_write_small_value(dump, body->ivc_size);
     ibf_dump_write_small_value(dump, body->icvarc_size);
@@ -12181,7 +12180,6 @@ ibf_load_iseq_each(struct ibf_load *load, rb_iseq_t *iseq, ibf_offset_t offset)
     const int mandatory_only_iseq_index = (int)ibf_load_small_value(load, &reading_pos);
     const ibf_offset_t ci_entries_offset = (ibf_offset_t)IBF_BODY_OFFSET(ibf_load_small_value(load, &reading_pos));
     const ibf_offset_t outer_variables_offset = (ibf_offset_t)IBF_BODY_OFFSET(ibf_load_small_value(load, &reading_pos));
-    const rb_snum_t variable_flip_count = (rb_snum_t)ibf_load_small_value(load, &reading_pos);
     const unsigned int local_table_size = (unsigned int)ibf_load_small_value(load, &reading_pos);
 
     const unsigned int ivc_size = (unsigned int)ibf_load_small_value(load, &reading_pos);
@@ -12255,7 +12253,6 @@ ibf_load_iseq_each(struct ibf_load *load, rb_iseq_t *iseq, ibf_offset_t offset)
 
     ISEQ_COVERAGE_SET(iseq, Qnil);
     ISEQ_ORIGINAL_ISEQ_CLEAR(iseq);
-    load_body->variable.flip_count = variable_flip_count;
     load_body->variable.script_lines = Qnil;
 
     load_body->location.first_lineno = location_first_lineno;

--- a/iseq.c
+++ b/iseq.c
@@ -596,7 +596,6 @@ prepare_iseq_build(rb_iseq_t *iseq,
     }
     ISEQ_COVERAGE_SET(iseq, Qnil);
     ISEQ_ORIGINAL_ISEQ_CLEAR(iseq);
-    body->variable.flip_count = 0;
 
     if (NIL_P(script_lines)) {
         RB_OBJ_WRITE(iseq, &body->variable.script_lines, Qnil);

--- a/iseq.h
+++ b/iseq.h
@@ -43,16 +43,6 @@ extern const ID rb_iseq_shared_exc_local_tbl[];
 #define ISEQ_PC2BRANCHINDEX(iseq)         ISEQ_BODY(iseq)->variable.pc2branchindex
 #define ISEQ_PC2BRANCHINDEX_SET(iseq, h)  RB_OBJ_WRITE(iseq, &ISEQ_BODY(iseq)->variable.pc2branchindex, h)
 
-#define ISEQ_FLIP_CNT(iseq) ISEQ_BODY(iseq)->variable.flip_count
-
-static inline rb_snum_t
-ISEQ_FLIP_CNT_INCREMENT(const rb_iseq_t *iseq)
-{
-    rb_snum_t cnt = ISEQ_BODY(iseq)->variable.flip_count;
-    ISEQ_BODY(iseq)->variable.flip_count += 1;
-    return cnt;
-}
-
 static inline VALUE *
 ISEQ_ORIGINAL_ISEQ(const rb_iseq_t *iseq)
 {
@@ -121,6 +111,7 @@ struct iseq_compile_data {
     int isolated_depth;
     unsigned int ci_index;
     unsigned int ic_index;
+    unsigned int flip_count;
     const rb_compile_option_t *option;
     struct rb_id_table *ivar_cache_table;
     const struct rb_builtin_function *builtin_function_table;

--- a/mjit_c.rb
+++ b/mjit_c.rb
@@ -513,7 +513,6 @@ module RubyVM::MJIT # :nodoc: all
       call_data: [CType::Pointer.new { self.rb_call_data }, Primitive.cexpr!("OFFSETOF((*((struct rb_iseq_constant_body *)NULL)), call_data)")],
       variable: [CType::Struct.new(
         "", Primitive.cexpr!("SIZEOF(((struct rb_iseq_constant_body *)NULL)->variable)"),
-        flip_count: [self.rb_snum_t, Primitive.cexpr!("OFFSETOF(((struct rb_iseq_constant_body *)NULL)->variable, flip_count)")],
         script_lines: [self.VALUE, Primitive.cexpr!("OFFSETOF(((struct rb_iseq_constant_body *)NULL)->variable, script_lines)")],
         coverage: [self.VALUE, Primitive.cexpr!("OFFSETOF(((struct rb_iseq_constant_body *)NULL)->variable, coverage)")],
         pc2branchindex: [self.VALUE, Primitive.cexpr!("OFFSETOF(((struct rb_iseq_constant_body *)NULL)->variable, pc2branchindex)")],

--- a/vm_core.h
+++ b/vm_core.h
@@ -471,7 +471,6 @@ struct rb_iseq_constant_body {
     struct rb_call_data *call_data; //struct rb_call_data calls[ci_size];
 
     struct {
-        rb_snum_t flip_count;
         VALUE script_lines;
         VALUE coverage;
         VALUE pc2branchindex;


### PR DESCRIPTION
This was only used at compile time. Saves 8 bytes in rb_iseq_constant_body. We probably won't see any difference in this because malloc likely rounds up (size was 320 now 312 bytes).