### PR TITLE
YJIT: Don't side-exit on too-complex shapes

### DIFF
--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -265,7 +265,6 @@ make_counters! {
     getivar_se_self_not_heap,
     getivar_idx_out_of_range,
     getivar_megamorphic,
-    getivar_too_complex,
 
     setivar_se_self_not_heap,
     setivar_idx_out_of_range,
@@ -274,7 +273,6 @@ make_counters! {
     setivar_not_object,
     setivar_frozen,
     setivar_megamorphic,
-    setivar_too_complex,
 
     oaref_argc_not_one,
     oaref_arg_not_fixnum,


### PR DESCRIPTION
related to https://github.com/Shopify/ruby/issues/490

Too-complex shapes are the largest side exit reason on SFR. I'd like to address the situation by using a general C call for that case as a first step. We could then call a C function specific to too-complex shapes to improve it, but I'm assuming the overhead of using this general one is not too significant.

We would also like to add the same thing at the end of megamorphic callsites, but I'd like to do it in a separate PR.