### PR TITLE
Auto-merge feature for dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,4 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'monthly'
+      interval: 'daily'

--- a/.github/workflows/dependabot_automerge.yml
+++ b/.github/workflows/dependabot_automerge.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           repo-token: ${{ secrets.MATZBOT_GITHUB_TOKEN }}
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          check-regexp: "^Ubuntu / make (check,*"
+          check-regexp: "^Ubuntu"
           wait-interval: 30
       - name: Auto-merge for Dependabot PRs
         if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'}}

--- a/.github/workflows/dependabot_automerge.yml
+++ b/.github/workflows/dependabot_automerge.yml
@@ -1,0 +1,26 @@
+# from https://github.com/gofiber/swagger/blob/main/.github/workflows/dependabot_automerge.yml
+name: Dependabot auto-merge
+on:
+  pull_request_target:
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        uses: dependabot/fetch-metadata@v1
+        id: metadata
+      - name: Wait for status checks
+        uses: lewagon/wait-on-check-action@v1.2.0
+        with:
+          repo-token: ${{ secrets.MATZBOT_GITHUB_TOKEN }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          check-regexp: test*
+          wait-interval: 30
+      - name: Auto-merge for Dependabot PRs
+        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{ secrets.MATZBOT_GITHUB_TOKEN }}

--- a/.github/workflows/dependabot_automerge.yml
+++ b/.github/workflows/dependabot_automerge.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           repo-token: ${{ secrets.MATZBOT_GITHUB_TOKEN }}
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          check-regexp: test*
+          check-regexp: "^Ubuntu / make (check,*"
           wait-interval: 30
       - name: Auto-merge for Dependabot PRs
         if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'}}

--- a/.github/workflows/dependabot_automerge.yml
+++ b/.github/workflows/dependabot_automerge.yml
@@ -20,7 +20,7 @@ jobs:
           wait-interval: 30
       - name: Auto-merge for Dependabot PRs
         if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --auto --rebase "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{ secrets.MATZBOT_GITHUB_TOKEN }}


### PR DESCRIPTION
We have many of PRs every month like https://github.com/ruby/ruby/pulls?q=is%3Apr+author%3Aapp%2Fdependabot

I'd like to merge them automatically when Ubuntu CI are passed every week. With monthly period, We may get a lot of dependabot updates and CI stuck. We should reduce this stuck with auto-update with every day and merge them after all jobs of Ubuntu.