### PR TITLE
YJIT: Optimize != for Integers and Strings

### DIFF
--- a/yjit.c
+++ b/yjit.c
@@ -840,6 +840,12 @@ rb_yarv_str_eql_internal(VALUE str1, VALUE str2)
     return rb_str_eql_internal(str1, str2);
 }
 
+VALUE
+rb_str_neq_internal(VALUE str1, VALUE str2)
+{
+    return rb_str_eql_internal(str1, str2) == Qtrue ? Qfalse : Qtrue;
+}
+
 // YJIT needs this function to never allocate and never raise
 VALUE
 rb_yarv_ary_entry_internal(VALUE ary, long offset)

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -402,6 +402,7 @@ fn main() {
         .allowlist_function("rb_get_cikw_keywords_idx")
         .allowlist_function("rb_get_call_data_ci")
         .allowlist_function("rb_yarv_str_eql_internal")
+        .allowlist_function("rb_str_neq_internal")
         .allowlist_function("rb_yarv_ary_entry_internal")
         .allowlist_function("rb_yarv_fix_mod_fix")
         .allowlist_function("rb_FL_TEST")

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -1294,6 +1294,7 @@ extern "C" {
     pub fn rb_get_cfp_ep_level(cfp: *mut rb_control_frame_struct, lv: u32) -> *const VALUE;
     pub fn rb_yarv_class_of(obj: VALUE) -> VALUE;
     pub fn rb_yarv_str_eql_internal(str1: VALUE, str2: VALUE) -> VALUE;
+    pub fn rb_str_neq_internal(str1: VALUE, str2: VALUE) -> VALUE;
     pub fn rb_yarv_ary_entry_internal(ary: VALUE, offset: ::std::os::raw::c_long) -> VALUE;
     pub fn rb_yarv_fix_mod_fix(recv: VALUE, obj: VALUE) -> VALUE;
     pub fn rb_yjit_dump_iseq_loc(iseq: *const rb_iseq_t, insn_idx: u32);


### PR DESCRIPTION
This PR reuses `gen_equality_specialized` for optimizing `!=`. Looking at https://github.com/Shopify/yjit-bench/pull/168, `BasicObject#!=` is called often in mail benchmark, and this PR makes the benchmark stably faster by 3%:

```
before: ruby 3.3.0dev (2023-02-14T17:12:48Z master 55af69b15e) +YJIT [x86_64-linux]
after: ruby 3.3.0dev (2023-02-14T18:42:13Z yjit-opt-neq a676a199eb) +YJIT [x86_64-linux]

-----  -----------  ----------  ----------  ----------  ------------  -------------
bench  before (ms)  stddev (%)  after (ms)  stddev (%)  before/after  after 1st itr
mail   76.0         0.4         73.7        0.3         1.03          1.02
-----  -----------  ----------  ----------  ----------  ------------  -------------
```

`!=` [dispatches](https://github.com/ruby/ruby/blob/f089f2ad909f618efb22aea52cc139e1806efecb/object.c#L225) `==`, so the `BOP_EQ` guard and its optimization for `==` are useful for `!=` too.