### PR TITLE
Remove USE_RGENGC_LOGGING_WB_UNPROTECT

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -9124,49 +9124,6 @@ rb_gc_writebarrier_remember(VALUE obj)
     }
 }
 
-static st_table *rgengc_unprotect_logging_table;
-
-static int
-rgengc_unprotect_logging_exit_func_i(st_data_t key, st_data_t val, st_data_t arg)
-{
-    fprintf(stderr, "%s\t%"PRIuVALUE"\n", (char *)key, (VALUE)val);
-    return ST_CONTINUE;
-}
-
-static void
-rgengc_unprotect_logging_exit_func(void)
-{
-    st_foreach(rgengc_unprotect_logging_table, rgengc_unprotect_logging_exit_func_i, 0);
-}
-
-void
-rb_gc_unprotect_logging(void *objptr, const char *filename, int line)
-{
-    VALUE obj = (VALUE)objptr;
-
-    if (rgengc_unprotect_logging_table == 0) {
-        rgengc_unprotect_logging_table = st_init_strtable();
-        atexit(rgengc_unprotect_logging_exit_func);
-    }
-
-    if (RVALUE_WB_UNPROTECTED(obj) == 0) {
-        char buff[0x100];
-        st_data_t cnt = 1;
-        char *ptr = buff;
-
-        snprintf(ptr, 0x100 - 1, "%s|%s:%d", obj_info(obj), filename, line);
-
-        if (st_lookup(rgengc_unprotect_logging_table, (st_data_t)ptr, &cnt)) {
-            cnt++;
-        }
-        else {
-            ptr = (strdup)(buff);
-            if (!ptr) rb_memerror();
-        }
-        st_insert(rgengc_unprotect_logging_table, (st_data_t)ptr, cnt);
-    }
-}
-
 void
 rb_copy_wb_protected_attribute(VALUE dest, VALUE obj)
 {

--- a/include/ruby/internal/rgengc.h
+++ b/include/ruby/internal/rgengc.h
@@ -56,14 +56,6 @@
 #endif
 
 /**
- * @deprecated  This macro seems  broken.  Setting this to  anything other than
- *              zero just doesn't compile.  We need to KonMari.
- */
-#ifndef USE_RGENGC_LOGGING_WB_UNPROTECT
-# define USE_RGENGC_LOGGING_WB_UNPROTECT 0
-#endif
-
-/**
  * @private
  *
  * This  is   a  compile-time   flag  to   enable/disable  write   barrier  for
@@ -302,22 +294,6 @@ void rb_gc_writebarrier(VALUE old, VALUE young);
  */
 void rb_gc_writebarrier_unprotect(VALUE obj);
 
-#if USE_RGENGC_LOGGING_WB_UNPROTECT
-/**
- * @private
- *
- * This  is  the   implementation  of  #RGENGC_LOGGING_WB_UNPROTECT().   People
- * don't use it directly.
- *
- * @param[in]  objptr    Don't  know why  this  is  a pointer  to  void but  in
- *                       reality this is  a pointer to an object  that is about
- *                       to be un-protected.
- * @param[in]  filename  Pass C's `__FILE__` here.
- * @param[in]  line      Pass C's `__LINE__` here.
- */
-void rb_gc_unprotect_logging(void *objptr, const char *filename, int line);
-#endif
-
 RBIMPL_SYMBOL_EXPORT_END()
 
 RBIMPL_ATTR_PURE_UNLESS_DEBUG()
@@ -378,12 +354,11 @@ rb_obj_wb_unprotect(
     RBIMPL_ATTR_MAYBE_UNUSED()
     int line)
 {
-#if USE_RGENGC_LOGGING_WB_UNPROTECT
-    RGENGC_LOGGING_WB_UNPROTECT(RBIMPL_CAST((void *)x), filename, line);
-#endif
     rb_gc_writebarrier_unprotect(x);
     return x;
 }
+
+#define RGENGC_LOGGING_OBJ_WRITTEN rb_gc_obj_written_logging
 
 /**
  * @private
@@ -409,10 +384,6 @@ rb_obj_written(
     RBIMPL_ATTR_MAYBE_UNUSED()
     int line)
 {
-#if USE_RGENGC_LOGGING_WB_UNPROTECT
-    RGENGC_LOGGING_OBJ_WRITTEN(a, oldv, b, filename, line);
-#endif
-
     if (!RB_SPECIAL_CONST_P(b)) {
         rb_gc_writebarrier(a, b);
     }


### PR DESCRIPTION
This macro is broken when set to anything other than 0. And has had a comment saying that it's broken for 3 years.

This commit deletes it and the associated logging code. It's clearly not being used.