### PR TITLE
Fix removing ivars from classes and modules

### DIFF
--- a/shape.c
+++ b/shape.c
@@ -238,7 +238,9 @@ remove_shape_recursive(VALUE obj, ID id, rb_shape_t * shape, VALUE * removed)
             // has the same attributes as this shape.
             if (new_parent) {
                 bool dont_care;
-                rb_shape_t * new_child = get_next_shape_internal(new_parent, shape->edge_name, shape->type, &dont_care, true, false);
+                enum ruby_value_type type = BUILTIN_TYPE(obj);
+                bool new_shape_necessary = type == T_CLASS || type == T_MODULE;
+                rb_shape_t * new_child = get_next_shape_internal(new_parent, shape->edge_name, shape->type, &dont_care, true, new_shape_necessary);
                 new_child->capacity = shape->capacity;
                 if (new_child->type == SHAPE_IVAR) {
                     move_iv(obj, id, shape->next_iv_index - 1, new_child->next_iv_index - 1);

--- a/shape.c
+++ b/shape.c
@@ -239,7 +239,7 @@ remove_shape_recursive(VALUE obj, ID id, rb_shape_t * shape, VALUE * removed)
             if (new_parent) {
                 bool dont_care;
                 enum ruby_value_type type = BUILTIN_TYPE(obj);
-                bool new_shape_necessary = type == T_CLASS || type == T_MODULE;
+                bool new_shape_necessary = type != T_OBJECT;
                 rb_shape_t * new_child = get_next_shape_internal(new_parent, shape->edge_name, shape->type, &dont_care, true, new_shape_necessary);
                 new_child->capacity = shape->capacity;
                 if (new_child->type == SHAPE_IVAR) {

--- a/test/ruby/test_shapes.rb
+++ b/test/ruby/test_shapes.rb
@@ -108,6 +108,32 @@ class TestShapes < Test::Unit::TestCase
     assert_false RubyVM::Shape.of(obj).too_complex?
   end
 
+  def test_removing_when_too_many_ivs_on_class
+    obj = Class.new
+
+    (RubyVM::Shape::SHAPE_MAX_NUM_IVS + 2).times do
+      obj.instance_variable_set(:"@a#{_1}", 1)
+    end
+    (RubyVM::Shape::SHAPE_MAX_NUM_IVS + 2).times do
+      obj.remove_instance_variable(:"@a#{_1}")
+    end
+
+    assert_empty obj.instance_variables
+  end
+
+  def test_removing_when_too_many_ivs_on_module
+    obj = Module.new
+
+    (RubyVM::Shape::SHAPE_MAX_NUM_IVS + 2).times do
+      obj.instance_variable_set(:"@a#{_1}", 1)
+    end
+    (RubyVM::Shape::SHAPE_MAX_NUM_IVS + 2).times do
+      obj.remove_instance_variable(:"@a#{_1}")
+    end
+
+    assert_empty obj.instance_variables
+  end
+
   def test_too_complex_ractor
     assert_separately([], "#{<<~"begin;"}\n#{<<~'end;'}")
     begin;


### PR DESCRIPTION
We have figured out that removing an ivar from a module or a class object which has more than `50` ivars is creating a segmentation fault. This PR fixes it.

Example code to reproduce the crash:

```ruby
class Foo; end
LIMIT = 51
(0..LIMIT).each do |n|
  Foo.instance_variable_set("@a#{n}".to_sym, n)
end
Foo.remove_instance_variable(:@a0)
```

Co-authored-by: Adam Hess <hparker@github.com>