### PR TITLE
[DOC] A bunch of small post-3.2 documentation improvements

### DIFF
--- a/doc/syntax/pattern_matching.rdoc
+++ b/doc/syntax/pattern_matching.rdoc
@@ -415,6 +415,11 @@ Additionally, when matching custom classes, the expected class can be specified 
   end
   #=> "matched: 1"
 
+These core and library classes implement deconstruction:
+
+* MatchData#deconstruct and MatchData#deconstruct_keys;
+* Time#deconstruct_keys, Date#deconstruct_keys, DateTime#deconstruct_keys.
+
 == Guard clauses
 
 +if+ can be used to attach an additional condition (guard clause) when the pattern matches. This condition may use bound variables:
@@ -444,29 +449,6 @@ Additionally, when matching custom classes, the expected class can be specified 
     "not matched"
   end
   #=> "matched"
-
-== Current feature status
-
-As of Ruby 3.1, find patterns are considered _experimental_: its syntax can change in the future. Every time you use these features in code, a warning will be printed:
-
-  [0] => [*, 0, *]
-  # warning: Find pattern is experimental, and the behavior may change in future versions of Ruby!
-  # warning: One-line pattern matching is experimental, and the behavior may change in future versions of Ruby!
-
-To suppress this warning, one may use the Warning::[]= method:
-
-  Warning[:experimental] = false
-  eval('[0] => [*, 0, *]')
-  # ...no warning printed...
-
-Note that pattern-matching warnings are raised at compile time, so this will not suppress the warning:
-
-  Warning[:experimental] = false # At the time this line is evaluated, the parsing happened and warning emitted
-  [0] => [*, 0, *]
-
-So, only subsequently loaded files or `eval`-ed code is affected by switching the flag.
-
-Alternatively, the command line option <code>-W:no-experimental</code> can be used to turn off "experimental" feature warnings.
 
 == Appendix A. Pattern syntax
 

--- a/enum.c
+++ b/enum.c
@@ -700,7 +700,7 @@ enum_flat_map(VALUE obj)
 
 /*
  *  call-seq:
- *    to_a -> array
+ *    to_a(*args) -> array
  *
  *  Returns an array containing the items in +self+:
  *
@@ -746,8 +746,8 @@ enum_to_h_ii(RB_BLOCK_CALL_FUNC_ARGLIST(i, hash))
 
 /*
  *  call-seq:
- *    to_h -> hash
- *    to_h {|element| ... }  -> hash
+ *    to_h(*args) -> hash
+ *    to_h(*args) {|element| ... }  -> hash
  *
  *  When +self+ consists of 2-element arrays,
  *  returns a hash each of whose entries is the key-value pair

--- a/ext/objspace/lib/objspace.rb
+++ b/ext/objspace/lib/objspace.rb
@@ -11,12 +11,15 @@ module ObjectSpace
 
   module_function
 
-  # call-seq:
-  #   ObjectSpace.dump(obj[, output: :string]) -> "{ ... }"
-  #   ObjectSpace.dump(obj, output: :file) -> #<File:/tmp/rubyobj20131125-88733-1xkfmpv.json>
-  #   ObjectSpace.dump(obj, output: :stdout) -> nil
-  #
   # Dump the contents of a ruby object as JSON.
+  #
+  # _output_ can be one of: +:stdout+, +:file+, +:string+, or IO object.
+  #
+  # * +:file+ means dumping to a tempfile and returning corresponding File object;
+  # * +:stdout+ means printing the dump and returning +nil+;
+  # * +:string+ means returning a string with the dump;
+  # * if an instance of IO object is provided, the output goes there, and the object
+  #   is returned.
   #
   # This method is only expected to work with C Ruby.
   # This is an experimental method and is subject to change.
@@ -43,16 +46,11 @@ module ObjectSpace
   end
 
 
-  # call-seq:
-  #   ObjectSpace.dump_all([output: :file]) -> #<File:/tmp/rubyheap20131125-88469-laoj3v.json>
-  #   ObjectSpace.dump_all(output: :stdout) -> nil
-  #   ObjectSpace.dump_all(output: :string) -> "{...}\n{...}\n..."
-  #   ObjectSpace.dump_all(output: File.open('heap.json','w')) -> #<File:heap.json>
-  #   ObjectSpace.dump_all(output: :string, since: 42) -> "{...}\n{...}\n..."
-  #
   # Dump the contents of the ruby heap as JSON.
   #
-  # _full_ must be a boolean. If true all heap slots are dumped including the empty ones (T_NONE).
+  # _output_ argument is the same as for #dump.
+  #
+  # _full_ must be a boolean. If true, all heap slots are dumped including the empty ones (+T_NONE+).
   #
   # _since_ must be a non-negative integer or +nil+.
   #
@@ -104,16 +102,11 @@ module ObjectSpace
     ret
   end
 
-  #  call-seq:
-  #    ObjectSpace.dump_shapes([output: :file]) -> #<File:/tmp/rubyshapes20131125-88469-laoj3v.json>
-  #    ObjectSpace.dump_shapes(output: :stdout) -> nil
-  #    ObjectSpace.dump_shapes(output: :string) -> "{...}\n{...}\n..."
-  #    ObjectSpace.dump_shapes(output: File.open('shapes.json','w')) -> #<File:shapes.json>
-  #    ObjectSpace.dump_all(output: :string, since: 42) -> "{...}\n{...}\n..."
-  #
   #  Dump the contents of the ruby shape tree as JSON.
   #
-  #  If _shapes_ is a positive integer, only shapes newer than the provided
+  #  _output_ argument is the same as for #dump.
+  #
+  #  If _since_ is a positive integer, only shapes newer than the provided
   #  shape id are dumped. The current shape_id can be accessed using <tt>RubyVM.stat(:next_shape_id)</tt>.
   #
   #  This method is only expected to work with C Ruby.

--- a/io.c
+++ b/io.c
@@ -852,8 +852,11 @@ rb_io_timeout(VALUE self)
  *    timeout = duration -> duration
  *    timeout = nil -> nil
  *
- *  Set the internal timeout to the specified duration or nil. The timeout
+ *  \Set the internal timeout to the specified duration or nil. The timeout
  *  applies to all blocking operations where possible.
+ *
+ *  When the operation performs longer than the timeout set, IO::TimeoutError
+ *  is raised.
  *
  *  This affects the following methods (but is not limited to): #gets, #puts,
  *  #read, #write, #wait_readable and #wait_writable. This also affects
@@ -15316,6 +15319,7 @@ Init_IO(void)
     rb_cIO = rb_define_class("IO", rb_cObject);
     rb_include_module(rb_cIO, rb_mEnumerable);
 
+    /* Can be raised by IO operations when IO#timeout= is set. */
     rb_eIOTimeoutError = rb_define_class_under(rb_cIO, "TimeoutError", rb_eIOError);
 
     rb_define_const(rb_cIO, "READABLE", INT2NUM(RUBY_IO_READABLE));

--- a/proc.c
+++ b/proc.c
@@ -350,16 +350,44 @@ rb_binding_new(void)
  *  call-seq:
  *     binding -> a_binding
  *
- *  Returns a +Binding+ object, describing the variable and
+ *  Returns a Binding object, describing the variable and
  *  method bindings at the point of call. This object can be used when
- *  calling +eval+ to execute the evaluated command in this
- *  environment. See also the description of class +Binding+.
+ *  calling Binding#eval to execute the evaluated command in this
+ *  environment, or extracting its local variables.
  *
- *     def get_binding(param)
- *       binding
+ *     class User
+ *       def initialize(name, position)
+ *         @name = name
+ *         @position = position
+ *       end
+ *
+ *       def get_binding
+ *         binding
+ *       end
  *     end
- *     b = get_binding("hello")
- *     eval("param", b)   #=> "hello"
+ *
+ *     user = User.new('Joan', 'manager')
+ *     template = '{name: @name, position: @position}'
+ *
+ *     # evaluate template in context of the object
+ *     eval(template, user.get_binding)
+ *     #=> {:name=>"Joan", :position=>"manager"}
+ *
+ *  Binding#local_variable_get can be used to access the variables
+ *  whose names are reserved Ruby keywords:
+ *
+ *     # This is valid parameter declaration, but `if` parameter can't
+ *     # be accessed by name, because it is a reserved word.
+ *     def validate(field, validation, if: nil)
+ *       condition = binding.local_variable_get('if')
+ *       return unless condition
+ *
+ *       # ...Some implementation ...
+ *     end
+ *
+ *     validate(:name, :empty?, if: false) # skips validation
+ *     validate(:name, :empty?, if: true) # performs validation
+ *
  */
 
 static VALUE

--- a/process.c
+++ b/process.c
@@ -494,24 +494,6 @@ parent_redirect_close(int fd)
 #define parent_redirect_close(fd) close_unless_reserved(fd)
 #endif
 
-/*
- * Document-module: Process
- *
- * The module contains several groups of functionality for handling OS processes:
- *
- * * Low-level property introspection and management of the current process, like
- *   Process.argv0, Process.pid;
- * * Low-level introspection of other processes, like Process.getpgid, Process.getpriority;
- * * Management of the current process: Process.abort, Process.exit, Process.daemon, etc.
- *   (for convenience, most of those are also available as global functions
- *   and module functions of Kernel);
- * * Creation and management of child processes: Process.fork, Process.spawn, and
- *   related methods;
- * * Management of low-level system clock: Process.times and Process.clock_gettime,
- *   which could be important for proper benchmarking and other elapsed
- *   time measurement tasks.
- */
-
 static VALUE
 get_pid(void)
 {
@@ -8774,8 +8756,21 @@ static VALUE rb_mProcID_Syscall;
 
 
 /*
- *  The Process module is a collection of methods used to
- *  manipulate processes.
+ * Document-module: Process
+ *
+ *   The module contains several groups of functionality for handling OS processes:
+ *
+ *   * Low-level property introspection and management of the current process, like
+ *     Process.argv0, Process.pid;
+ *   * Low-level introspection of other processes, like Process.getpgid, Process.getpriority;
+ *   * Management of the current process: Process.abort, Process.exit, Process.daemon, etc.
+ *     (for convenience, most of those are also available as global functions
+ *     and module functions of Kernel);
+ *   * Creation and management of child processes: Process.fork, Process.spawn, and
+ *     related methods;
+ *   * Management of low-level system clock: Process.times and Process.clock_gettime,
+ *     which could be important for proper benchmarking and other elapsed
+ *     time measurement tasks.
  */
 
 void

--- a/string.c
+++ b/string.c
@@ -2950,6 +2950,7 @@ str_substr(VALUE str, long beg, long len, int empty)
     return str2;
 }
 
+/* :nodoc: */
 VALUE
 rb_str_freeze(VALUE str)
 {
@@ -2981,13 +2982,24 @@ str_uplus(VALUE str)
 /*
  * call-seq:
  *   -string -> frozen_string
+ *   dedup -> frozen_string
  *
  * Returns a frozen, possibly pre-existing copy of the string.
  *
  * The returned \String will be deduplicated as long as it does not have
  * any instance variables set on it and is not a String subclass.
  *
- * String#dedup is an alias for String#-@.
+ * Note that <tt>-string</tt> variant is more convenient for defining
+ * constants:
+ *
+ *    FILENAME = -'config/database.yml'
+ *
+ * while +dedup+ is better suitable for using the method in chains
+ * of calculations:
+ *
+ *
+ *    @url_list.concat(urls.map(&:dedup))
+ *
  */
 static VALUE
 str_uminus(VALUE str)

--- a/trace_point.rb
+++ b/trace_point.rb
@@ -377,9 +377,8 @@ class TracePoint
 
   # Return the generated binding object from event.
   #
-  # Note that for +c_call+ and +c_return+ events, the binding returned is the
-  # binding of the nearest Ruby method calling the C method, since C methods
-  # themselves do not have bindings.
+  # Note that for +c_call+ and +c_return+ events, the method will return
+  # +nil+, since C methods themselves do not have bindings.
   def binding
     Primitive.tracepoint_attr_binding
   end


### PR DESCRIPTION
Changes (each in its own commit):

* Update pattern matching docs for 3.2
  * Remove the section about the experimental status
  * Add references to core objects that can deconstruct
* Document `IO::Timeout` exception and mention it in `IO#timeout=`
* Improve `ObjectSpace#dump_XXX` method docs
  * remove false call-seq (output from Ruby parsing is cleaner)
  * explain `output:` argument in plain words
  * change parameter name in docs of `#dump_shapes` (typo)
* Improve `Kernel#binding` docs
  * Add links to `Binding` class
  * Make examples practical
  * Extend possible usages description
* Small adjustment for `String` method docs
  * Hide `freeze` method (no useful docs, same as `Object#freeze`)
  * Add `dedup` to call-seq of `str_uminus`
* Update `TracePoint#binding` docs for 3.2 behavior
* Restore Process module doc lost due to RDoc update
UPD 2023-02-18:
* Fix call-sequences for two Enumerable methods (`#to_a` and `#to_h`), that last `*args` in [this PR](https://github.com/ruby/ruby/pull/4808)