### PR TITLE
Weaken the Class#attached_object reference

### DIFF
--- a/class.c
+++ b/class.c
@@ -1674,7 +1674,12 @@ rb_class_attached_object(VALUE klass)
         rb_raise(rb_eTypeError, "`%"PRIsVALUE"' is not a singleton class", klass);
     }
 
-    return RCLASS_ATTACHED_OBJECT(klass);
+    VALUE attached_object = RCLASS_ATTACHED_OBJECT(klass);
+    if (rb_objspace_garbage_object_p(attached_object)) {
+        return Qnil;
+    }
+
+    return attached_object;
 }
 
 static void

--- a/gc.c
+++ b/gc.c
@@ -7271,6 +7271,13 @@ gc_mark_children(rb_objspace_t *objspace, VALUE obj)
 
     switch (BUILTIN_TYPE(obj)) {
       case T_CLASS:
+        if (FL_TEST(obj, FL_SINGLETON)) {
+            VALUE attached_object = RCLASS_ATTACHED_OBJECT(obj);
+            if (RB_TYPE_P(attached_object, T_CLASS) || RB_TYPE_P(attached_object, T_MODULE)) {
+                gc_mark(objspace, attached_object);
+            }
+        }
+        // Continue to the shared T_CLASS/T_MODULE
       case T_MODULE:
         if (RCLASS_SUPER(obj)) {
             gc_mark(objspace, RCLASS_SUPER(obj));


### PR DESCRIPTION
[[Bug #19436]](https://bugs.ruby-lang.org/issues/19436)

Singleton classes can end up in call caches, and cause very large objects to be retained, effectively causing some form of memory leak, or at least some form of undesirable and uncontrolable memory overhead.

One of the possible solution is to weaken the `attached_object` reference.

The singleton class would still be marked through the call cache, but the attached object wouldn't, allowing it to be freed hence keeping the memory overhead down.