### PR TITLE
Fix keyword splat in enumerator

### DIFF
--- a/numeric.c
+++ b/numeric.c
@@ -3065,7 +3065,7 @@ num_step(int argc, VALUE *argv, VALUE from)
                                     num_step_size, from, to, step, FALSE);
         }
 
-        return SIZED_ENUMERATOR(from, 2, ((VALUE [2]){to, step}), num_step_size);
+        return SIZED_ENUMERATOR_KW(from, 2, ((VALUE [2]){to, step}), num_step_size, FALSE);
     }
 
     desc = num_step_scan_args(argc, argv, &to, &step, TRUE, FALSE);

--- a/test/ruby/test_numeric.rb
+++ b/test/ruby/test_numeric.rb
@@ -324,6 +324,9 @@ class TestNumeric < Test::Unit::TestCase
     e = 1.step(10, {by: "1"})
     assert_raise(TypeError) {e.next}
     assert_raise(TypeError) {e.size}
+    e = 1.step(to: "10")
+    assert_raise(ArgumentError) {e.next}
+    assert_raise(ArgumentError) {e.size}
 
     assert_equal(bignum*2+1, (-bignum).step(bignum, 1).size)
     assert_equal(bignum*2, (-bignum).step(bignum-1, 1).size)


### PR DESCRIPTION
Extracted arguments do not have keyword hash to splat.