### PR TITLE
YJIT: Show Context stats on exit

### DIFF
--- a/yjit.c
+++ b/yjit.c
@@ -1100,7 +1100,7 @@ object_shape_count(rb_execution_context_t *ec, VALUE self)
 // Primitives used by yjit.rb
 VALUE rb_yjit_stats_enabled_p(rb_execution_context_t *ec, VALUE self);
 VALUE rb_yjit_trace_exit_locations_enabled_p(rb_execution_context_t *ec, VALUE self);
-VALUE rb_yjit_get_stats(rb_execution_context_t *ec, VALUE self);
+VALUE rb_yjit_get_stats(rb_execution_context_t *ec, VALUE self, VALUE context);
 VALUE rb_yjit_reset_stats_bang(rb_execution_context_t *ec, VALUE self);
 VALUE rb_yjit_disasm_iseq(rb_execution_context_t *ec, VALUE self, VALUE iseq);
 VALUE rb_yjit_insns_compiled(rb_execution_context_t *ec, VALUE self, VALUE iseq);

--- a/yjit.rb
+++ b/yjit.rb
@@ -145,8 +145,8 @@ module RubyVM::YJIT
 
   # Return a hash for statistics generated for the --yjit-stats command line option.
   # Return nil when option is not passed or unavailable.
-  def self.runtime_stats
-    stats = Primitive.rb_yjit_get_stats
+  def self.runtime_stats(context: false)
+    stats = Primitive.rb_yjit_get_stats(context)
     return stats if stats.nil?
 
     stats[:object_shape_count] = Primitive.object_shape_count
@@ -233,7 +233,7 @@ module RubyVM::YJIT
 
     # Format and print out counters
     def _print_stats # :nodoc:
-      stats = runtime_stats
+      stats = runtime_stats(context: true)
       return unless stats
 
       $stderr.puts("***YJIT: Printing YJIT statistics on exit***")
@@ -277,6 +277,8 @@ module RubyVM::YJIT
       $stderr.puts "freed_code_size:       " + format_number(13, stats[:freed_code_size])
       $stderr.puts "code_region_size:      " + format_number(13, stats[:code_region_size])
       $stderr.puts "yjit_alloc_size:       " + format_number(13, stats[:yjit_alloc_size]) if stats.key?(:yjit_alloc_size)
+      $stderr.puts "live_context_size:     " + format_number(13, stats[:live_context_size])
+      $stderr.puts "live_context_count:    " + format_number(13, stats[:live_context_count])
       $stderr.puts "live_page_count:       " + format_number(13, stats[:live_page_count])
       $stderr.puts "freed_page_count:      " + format_number(13, stats[:freed_page_count])
       $stderr.puts "code_gc_count:         " + format_number(13, stats[:code_gc_count])

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -440,6 +440,18 @@ impl Branch {
     fn get_target_address(&self, target_idx: usize) -> Option<CodePtr> {
         self.targets[target_idx].as_ref().and_then(|target| target.get_address())
     }
+
+    fn get_stub_count(&self) -> usize {
+        let mut count = 0;
+        for target in self.targets.iter() {
+            if let Some(target) = target {
+                if let BranchTarget::Stub(_) = target.as_ref() {
+                    count += 1;
+                }
+            }
+        }
+        count
+    }
 }
 
 // In case a block is invalidated, this helps to remove all pointers to the block.
@@ -551,7 +563,7 @@ impl Eq for BlockRef {}
 #[derive(Default)]
 pub struct IseqPayload {
     // Basic block versions
-    version_map: VersionMap,
+    pub version_map: VersionMap,
 
     // Indexes of code pages used by this this ISEQ
     pub pages: HashSet<usize>,
@@ -619,6 +631,15 @@ pub fn for_each_iseq<F: FnMut(IseqPtr)>(mut callback: F) {
     }
     let mut data: &mut dyn FnMut(IseqPtr) = &mut callback;
     unsafe { rb_yjit_for_each_iseq(Some(callback_wrapper), (&mut data) as *mut _ as *mut c_void) };
+}
+
+/// Iterate over all ISEQ payloads
+pub fn for_each_iseq_payload<F: FnMut(&IseqPayload)>(mut callback: F) {
+    for_each_iseq(|iseq| {
+        if let Some(iseq_payload) = get_iseq_payload(iseq) {
+            callback(iseq_payload);
+        }
+    });
 }
 
 /// Iterate over all on-stack ISEQs
@@ -1030,6 +1051,14 @@ impl Block {
 
     pub fn get_ctx(&self) -> Context {
         self.ctx.clone()
+    }
+
+    pub fn get_ctx_count(&self) -> usize {
+        let mut count = 1; // block.ctx
+        for branch in self.outgoing.iter() {
+            count += branch.borrow().get_stub_count();
+        }
+        count
     }
 
     #[allow(unused)]


### PR DESCRIPTION
As we started to discuss how we compress `Context`, I'd like to add stats about its size. 

Through these metrics, I'd like to remind us that memory consumed by `Context` is currently not that dominant, but these stats will also be useful to notice it's getting more important as we add more fields to it.

## Current stats

Current YJIT stats with stats build on railsbench 25 itrs:

```
compiled_iseq_count:           2,200
compiled_block_count:         20,675
compiled_branch_count:        36,009
...
code_region_size:          4,259,840
yjit_alloc_size:           9,159,933
live_context_size:         1,021,516
live_context_count:           26,882
```

## Implementation design

I considered incrementing or decrementing the counter as it gets allocated or deallocated, but it seemed rather complicated. Scanning all at the end seems to make the implementation simple and precise. However, because it comes at the cost of scanning all payloads, these metrics are available only at exit by default.