### PR TITLE
Fix detection of compiler_wd in tool/update-deps

### DIFF
--- a/tool/update-deps
+++ b/tool/update-deps
@@ -334,24 +334,25 @@ end
 #  raise ArgumentError, "can not find #{filename} (hint: #{hint0})"
 #end
 
-def read_single_cc_deps(path_i, cwd)
+def read_single_cc_deps(path_i, cwd, fn_o)
   files = {}
   compiler_wd = nil
   path_i.each_line {|line|
     next if /\A\# \d+ "(.*)"/ !~ line
     dep = $1
+
     next if %r{\A<.*>\z} =~ dep # omit <command-line>, etc.
     next if /\.e?rb\z/ =~ dep
-    compiler_wd ||= dep
+    # gcc emits {# 1 "/absolute/directory/of/the/source/file//"} at 2nd line.
+    if /\/\/\z/ =~ dep
+      compiler_wd = Pathname(dep.sub(%r{//\z}, ''))
+      next
+    end
+
     files[dep] = true
   }
-  # gcc emits {# 1 "/absolute/directory/of/the/source/file//"} at 2nd line.
-  if %r{\A/.*//\z} =~ compiler_wd
-    files.delete compiler_wd
-    compiler_wd = Pathname(compiler_wd.sub(%r{//\z}, ''))
-  elsif !(compiler_wd = yield)
-    raise "compiler working directory not found: #{path_i}"
-  end
+  compiler_wd ||= fn_o.to_s.start_with?("enc/") ? cwd : path_i.parent
+
   deps = []
   files.each_key {|dep|
     dep = Pathname(dep)
@@ -383,13 +384,7 @@ def read_cc_deps(cwd)
     end
     path_o = cwd + fn_o
     path_i = cwd + fn_i
-    deps[path_o] = read_single_cc_deps(path_i, cwd) do
-      if fn_o.to_s.start_with?("enc/")
-        cwd
-      else
-        path_i.parent
-      end
-    end
+    deps[path_o] = read_single_cc_deps(path_i, cwd, fn_o)
   }
   deps
 end


### PR DESCRIPTION
This fixes the large list of warnings at the top of the Check Dependencies CI run that look like this:

```
warning: file not found: /home/runner/work/ruby/ruby//
warning: file not found: /home/runner/work/ruby/ruby//
warning: file not found: /home/runner/work/ruby/ruby//
warning: file not found: /home/runner/work/ruby/ruby//
warning: file not found: /home/runner/work/ruby/ruby//
warning: file not found: /home/runner/work/ruby/ruby//
warning: file not found: /home/runner/work/ruby/ruby//
warning: file not found: /home/runner/work/ruby/ruby//
warning: file not found: /home/runner/work/ruby/ruby//
warning: file not found: /home/runner/work/ruby/ruby//
warning: file not found: /home/runner/work/ruby/ruby//
warning: file not found: /home/runner/work/ruby/ruby//
warning: file not found: /home/runner/work/ruby/ruby//
warning: file not found: /home/runner/work/ruby/ruby//
warning: file not found: /home/runner/work/ruby/ruby//
```

These warnings are being caused because `gcc` always outputs 

```
# 1 "/home/runner/work/ruby/ruby//"
```

as the second line of the `*.i` file. There is already code in `update-deps` with the intention of removing this line from the dependencies array, however it is not working as intended 

This is because when it loops through all the lines in the `*.i` files, it sets `dep` each time, and sets `compiler_wd ||= dep`. The use of `||=` here means that the `compiler_wd` is always set to the _first_ line in the file, rather than the second. Therefore the regex used to detect and remove the `//` and set the `compile_wd` correctly is never matching.