### PR TITLE
YJIT: Use rb_ivar_get at the end of ivar chains

### DIFF
--- a/yjit.rb
+++ b/yjit.rb
@@ -272,7 +272,7 @@ module RubyVM::YJIT
       $stderr.puts "freed_iseq_count:      " + format_number(13, stats[:freed_iseq_count])
       $stderr.puts "invalidation_count:    " + format_number(13, stats[:invalidation_count])
       $stderr.puts "constant_state_bumps:  " + format_number(13, stats[:constant_state_bumps])
-      $stderr.puts "ivar_last_chain_count: " + format_number(13, stats[:ivar_last_chain_count])
+      $stderr.puts "get_ivar_max_depth:    " + format_number(13, stats[:get_ivar_max_depth])
       $stderr.puts "inline_code_size:      " + format_number(13, stats[:inline_code_size])
       $stderr.puts "outlined_code_size:    " + format_number(13, stats[:outlined_code_size])
       $stderr.puts "freed_code_size:       " + format_number(13, stats[:freed_code_size])

--- a/yjit.rb
+++ b/yjit.rb
@@ -272,6 +272,7 @@ module RubyVM::YJIT
       $stderr.puts "freed_iseq_count:      " + format_number(13, stats[:freed_iseq_count])
       $stderr.puts "invalidation_count:    " + format_number(13, stats[:invalidation_count])
       $stderr.puts "constant_state_bumps:  " + format_number(13, stats[:constant_state_bumps])
+      $stderr.puts "ivar_last_chain_count: " + format_number(13, stats[:ivar_last_chain_count])
       $stderr.puts "inline_code_size:      " + format_number(13, stats[:inline_code_size])
       $stderr.puts "outlined_code_size:    " + format_number(13, stats[:outlined_code_size])
       $stderr.puts "freed_code_size:       " + format_number(13, stats[:freed_code_size])

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -721,7 +721,8 @@ pub fn gen_single_block(
     #[cfg(feature = "disasm")]
     if get_option_ref!(dump_disasm).is_some() {
         let blockid_idx = blockid.idx;
-        asm.comment(&format!("Block: {} (ISEQ offset: {})", iseq_get_location(blockid.iseq, blockid_idx), blockid_idx));
+        let chain_depth = if ctx.get_chain_depth() > 0 { format!(", chain_depth: {}", ctx.get_chain_depth()) } else { "".to_string() };
+        asm.comment(&format!("Block: {} (ISEQ offset: {}{})", iseq_get_location(blockid.iseq, blockid_idx), blockid_idx, chain_depth));
     }
 
     // For each instruction to compile
@@ -1945,13 +1946,18 @@ fn gen_get_ivar(
 
     // Check if the comptime receiver is a T_OBJECT
     let receiver_t_object = unsafe { RB_TYPE_P(comptime_receiver, RUBY_T_OBJECT) };
+    // Use a general C call at the last chain to avoid exits on megamorphic shapes
+    let last_chain = ctx.get_chain_depth() as i32 == max_chain_depth - 1;
+    if last_chain {
+        gen_counter_incr!(asm, ivar_last_chain_count);
+    }
 
     // If the class uses the default allocator, instances should all be T_OBJECT
     // NOTE: This assumes nobody changes the allocator of the class after allocation.
     //       Eventually, we can encode whether an object is T_OBJECT or not
     //       inside object shapes.
     // too-complex shapes can't use index access, so we use rb_ivar_get for them too.
-    if !receiver_t_object || uses_custom_allocator || comptime_receiver.shape_too_complex() {
+    if !receiver_t_object || uses_custom_allocator || comptime_receiver.shape_too_complex() || last_chain {
         // General case. Call rb_ivar_get().
         // VALUE rb_ivar_get(VALUE obj, ID id)
         asm.comment("call rb_ivar_get()");

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -1949,7 +1949,7 @@ fn gen_get_ivar(
     // Use a general C call at the last chain to avoid exits on megamorphic shapes
     let last_chain = ctx.get_chain_depth() as i32 == max_chain_depth - 1;
     if last_chain {
-        gen_counter_incr!(asm, ivar_last_chain_count);
+        gen_counter_incr!(asm, get_ivar_max_depth);
     }
 
     // If the class uses the default allocator, instances should all be T_OBJECT

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -283,7 +283,8 @@ make_counters! {
     setivar_frozen,
     setivar_megamorphic,
 
-    ivar_last_chain_count,
+    // Not using "getivar_" to exclude this from exit reasons
+    get_ivar_max_depth,
 
     oaref_argc_not_one,
     oaref_arg_not_fixnum,

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -283,6 +283,8 @@ make_counters! {
     setivar_frozen,
     setivar_megamorphic,
 
+    ivar_last_chain_count,
+
     oaref_argc_not_one,
     oaref_arg_not_fixnum,
 


### PR DESCRIPTION
As mentioned in https://github.com/ruby/ruby/pull/7298, this PR adds a `rb_ivar_get` call at the end of a getivar chain. `getivar_megamorphic` is currently the largest exit reason of SFR, and this change should address it.