### PR TITLE
YJIT: Consolidate jit methods in JITState impl

### DIFF
--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -1504,9 +1504,9 @@ impl Context {
     }
 
     pub fn two_fixnums_on_stack(&self, jit: &mut JITState) -> Option<bool> {
-        if jit_at_current_insn(jit) {
-            let comptime_recv = jit_peek_at_stack(jit, self, 1);
-            let comptime_arg = jit_peek_at_stack(jit, self, 0);
+        if jit.at_current_insn() {
+            let comptime_recv = jit.peek_at_stack( self, 1);
+            let comptime_arg = jit.peek_at_stack(self, 0);
             return Some(comptime_recv.fixnum_p() && comptime_arg.fixnum_p());
         }
 


### PR DESCRIPTION
These jit_* methods don't jit code, but instead check things on the JITState. We had other methods that did the same thing that were just added on the impl JITState. For consistency I added these methods there.

(It looks like github is doing a really bad job rendering the diff here. I just moved the methods and changed their arguments. Locally if I do a `git diff HEAD~1` locally, the diff is much clearer. I didn't mess with JCCKinds at all, unlike what the github diff implies)