### PR TITLE
YJIT: Fix assertion for partially mapped last pages

### DIFF
--- a/test/ruby/test_yjit.rb
+++ b/test/ruby/test_yjit.rb
@@ -974,6 +974,25 @@ class TestYJIT < Test::Unit::TestCase
     RUBY
   end
 
+  def test_code_gc_partial_last_page
+    # call_threshold: 2 to avoid JIT-ing code_gc itself. If code_gc were JITed right before
+    # code_gc is called, the last page would be on stack.
+    assert_compiles(<<~'RUBY', exits: :any, result: :ok, call_threshold: 2)
+      # Leave a bunch of off-stack pages
+      i = 0
+      while i < 1000
+        eval("x = proc { 1.to_s }; x.call; x.call")
+        i += 1
+      end
+
+      # On Linux, memory page size != code page size. So the last code page could be partially
+      # mapped. This call tests that assertions and other things work fine under the situation.
+      RubyVM::YJIT.code_gc
+
+      :ok
+    RUBY
+  end
+
   def test_trace_script_compiled # not ISEQ_TRACE_EVENTS
     assert_compiles(<<~'RUBY', exits: :any, result: :ok)
       @eval_counter = 0

--- a/yjit/src/asm/mod.rs
+++ b/yjit/src/asm/mod.rs
@@ -423,7 +423,7 @@ impl CodeBlock {
     /// Convert an address range to memory page indexes against a num_pages()-sized array.
     pub fn addrs_to_pages(&self, start_addr: CodePtr, end_addr: CodePtr) -> Vec<usize> {
         let mem_start = self.mem_block.borrow().start_ptr().into_usize();
-        let mem_end = self.mem_block.borrow().end_ptr().into_usize();
+        let mem_end = self.mem_block.borrow().mapped_end_ptr().into_usize();
         assert!(mem_start <= start_addr.into_usize());
         assert!(start_addr.into_usize() <= end_addr.into_usize());
         assert!(end_addr.into_usize() <= mem_end);


### PR DESCRIPTION
This fixes a panic that was observed at https://github.com/ruby/ruby/actions/runs/4207413772/jobs/7302174299.

On Linux, a code page consists of two inline memory pages and two outlined memory pages. When a last code page is not on stack and code_gc decides to free the region of the last code page, the range could contain an unmapped outlined memory page. The situation trips this assertion.

One way to fix this is to shrink the argument range in the first place, but specifying unmapped regions could happen for non-last pages as well, so fixing the argument only for the last page seems strange. As long as it's inside the virtual region, `mark_unused` should be safe.