### PR TITLE
Changes in Array#index Documentation

### DIFF
--- a/array.c
+++ b/array.c
@@ -2199,8 +2199,7 @@ rb_ary_fetch(int argc, VALUE *argv, VALUE ary)
  *
  *  Returns +nil+ if no such element found.
  *
- *  When both argument +object+ and a block are given,
- *  calls the block with each successive element;
+ *  When a block is given, calls the block with each successive element;
  *  returns the index of the first element for which the block returns a truthy value:
  *
  *    a = [:foo, 'bar', 2, 'bar']
@@ -2208,6 +2207,8 @@ rb_ary_fetch(int argc, VALUE *argv, VALUE ary)
  *
  *  Returns +nil+ if the block never returns a truthy value.
  *
+ *  When both an argument and a block is given, issues a warning, ignores the block, 
+ *  and returns the index of the first element +element+ for which <tt>object == element</tt>:
  *  When neither an argument nor a block is given, returns a new Enumerator:
  *
  *    a = [:foo, 'bar', 2]


### PR DESCRIPTION
Changes in Documentation for Array#index and Array#find_index, 
where it claims both argument and block can be passed to Array#index method, 
But, this will result in warning and ignores block.

Made changes to show block only behaviour,
Args and block behaviour which warns and ignores block completely.


IRB Snippet to show the warning if both args and block is passed.
```ruby
3.1.3 :001 > a = [:foo, 'bar', 2, 'bar']
 => [:foo, "bar", 2, "bar"] 
3.1.3 :002 > a.index(2) {|element| element == 'bar' }
(irb):2: warning: given block not used
 => 2 
```

Ruby Version
```sh
$ ruby --version
ruby 3.1.3p185 (2022-11-24 revision 1a6b16756e) [x86_64-linux]
```
