### PR TITLE
Use the development versions of minitest and debug gems

### DIFF
--- a/defs/gmake.mk
+++ b/defs/gmake.mk
@@ -357,7 +357,7 @@ $(srcdir)/gems/$(1)-$(2).gem: $(srcdir)/gems/src/$(1)/$(1).gemspec \
 	$(ECHO) Building $(1)@$(3) to $$(@)
 	$(Q) $(BASERUBY) -C "$(srcdir)" \
 	    -Itool/lib -rbundled_gem \
-	    -e 'BundledGem.build("gems/src/$(1)/$(1).gemspec", "$(2)", "gems")'
+	    -e 'BundledGem.build("gems/src/$(1)/$(1).gemspec", "$(2)", "gems", validation: false)'
 
 endef
 define build-gem-0

--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -5,7 +5,7 @@
 # - repository-url: URL from where clone for test
 # - revision: revision in repository-url to test
 #   if `revision` is not given, "v"+`version` or `version` will be used.
-minitest        5.17.0  https://github.com/seattlerb/minitest
+minitest        5.17.0  https://github.com/seattlerb/minitest d4fc359899f96944be147609e045b9e921881f19
 power_assert    2.0.3   https://github.com/ruby/power_assert
 rake            13.0.6  https://github.com/ruby/rake
 test-unit       3.5.7   https://github.com/test-unit/test-unit
@@ -19,4 +19,4 @@ matrix          0.4.2   https://github.com/ruby/matrix
 prime           0.1.2   https://github.com/ruby/prime
 rbs             2.8.4   https://github.com/ruby/rbs
 typeprof        0.21.4  https://github.com/ruby/typeprof
-debug           1.7.1   https://github.com/ruby/debug
+debug           1.7.1   https://github.com/ruby/debug d7bf3b2e4502eb0f07a67f00e5fce5a0d661189e

--- a/tool/lib/bundled_gem.rb
+++ b/tool/lib/bundled_gem.rb
@@ -18,6 +18,31 @@ module BundledGem
     outdir = File.expand_path(outdir)
     gemdir, gemfile = File.split(gemspec)
     Dir.chdir(gemdir) do
+      if gemspec == "gems/src/minitest/minitest.gemspec" && !File.exist?("minitest.gemspec")
+        # The repository of minitest does not include minitest.gemspec because it uses hoe.
+        # This creates a dummy gemspec.
+        File.write("minitest.gemspec", <<END)
+Gem::Specification.new do |s|
+  s.name = "minitest"
+  s.version = #{ File.read("lib/minitest.rb")[/VERSION = "(.+?)"/, 1].dump }
+
+  s.require_paths = ["lib"]
+  s.authors = ["Ryan Davis"]
+  s.date = "#{ Time.now.strftime("%Y-%m-%d") }"
+  s.description = "(dummy gemspec)"
+  s.email = ["ryand-ruby@zenspider.com"]
+  s.extra_rdoc_files = ["History.rdoc", "Manifest.txt", "README.rdoc"]
+  s.files = [#{ Dir.glob("**/*").reject {|s| File.directory?(s) }.map {|s| s.dump }.join(",") }]
+  s.homepage = "https://github.com/seattlerb/minitest"
+  s.licenses = ["MIT"]
+  s.rdoc_options = ["--main", "README.rdoc"]
+  s.summary = "(dummy gemspec)"
+
+  s.add_development_dependency(%q<rdoc>, [">= 4.0", "< 7"])
+  s.add_development_dependency(%q<hoe>, ["~> 4.0"])
+end
+END
+      end
       spec = Gem::Specification.load(gemfile)
       abort "Failed to load #{gemspec}" unless spec
       abort "Unexpected version #{spec.version}" unless spec.version == Gem::Version.new(version)


### PR DESCRIPTION
This is a preparation for a new message format of NameError.
[Feature #18285]
https://github.com/ruby/ruby/pull/6950