### PR TITLE
[DOC] Change to handling of aliases

### DIFF
--- a/doc/contributing/documentation_guide.md
+++ b/doc/contributing/documentation_guide.md
@@ -241,7 +241,6 @@ The general structure of the method documentation should be:
 - Details and examples.
 - Argument description (if necessary).
 - Corner cases and exceptions.
-- Aliases.
 - Related methods (optional).
 
 ### Calling Sequence (for methods written in C)
@@ -328,7 +327,7 @@ Return types:
 
 Aliases:
 
-- Omit aliases from the `call-seq`, but mention them near the end (see below).
+- Omit aliases from the `call-seq`.
 
 ### Synopsis
 
@@ -397,14 +396,6 @@ if you have stated earlier than an argument type must be an integer,
 you do not need to document that a `TypeError` is raised if a non-integer
 is passed.  Do not provide examples of exceptions being raised unless
 that is a common case, such as `Hash#fetch` raising a `KeyError`.
-
-### Aliases
-
-Mention aliases in the form
-
-```
-// Array#find_index is an alias for Array#index.
-```
 
 ### Related Methods (optional)
 


### PR DESCRIPTION
RDoc now automatically mentions aliases, so no need to mention explicitly.