### PR TITLE
compile.c: eliminate getinstancevariable -> pop sequences

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -3319,7 +3319,7 @@ iseq_peephole_optimize(rb_iseq_t *iseq, LINK_ELEMENT *list, const int do_tailcal
                 previ == BIN(getlocal) ||
                 previ == BIN(getblockparam) ||
                 previ == BIN(getblockparamproxy) ||
-                /* getinstancevariable may issue a warning */
+                previ == BIN(getinstancevariable) ||
                 previ == BIN(duparray)) {
                 /* just push operand or static value and pop soon, no
                  * side effects */


### PR DESCRIPTION
This case wasn't eliminated before because `getinstancevariable` could emit a warning, but that's no longer the case since Ruby 3.0.

(I noticed this while looking at something else).