### PR TITLE
Add support for LoongArch

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2623,6 +2623,9 @@ AS_CASE([$coroutine_type], [yes|''], [
         [riscv64-linux*], [
             coroutine_type=riscv64
         ],
+        [loongarch64-linux*], [
+            coroutine_type=loongarch64
+        ],
         [x86_64-freebsd*], [
             coroutine_type=amd64
         ],

--- a/coroutine/loongarch64/Context.S
+++ b/coroutine/loongarch64/Context.S
@@ -1,0 +1,73 @@
+#define TOKEN_PASTE(x,y) x##y
+#define PREFIXED_SYMBOL(prefix,name) TOKEN_PASTE(prefix,name)
+
+.text
+.align 2
+
+.global PREFIXED_SYMBOL(SYMBOL_PREFIX,coroutine_transfer)
+PREFIXED_SYMBOL(SYMBOL_PREFIX,coroutine_transfer):
+
+	# Make space on the stack for caller registers
+	addi.d $sp, $sp, -0xa0
+
+	# Save caller registers
+	st.d $s0, $sp, 0x00
+	st.d $s1, $sp, 0x08
+	st.d $s2, $sp, 0x10
+	st.d $s3, $sp, 0x18
+	st.d $s4, $sp, 0x20
+	st.d $s5, $sp, 0x28
+	st.d $s6, $sp, 0x30
+	st.d $s7, $sp, 0x38
+	st.d $s8, $sp, 0x40
+	st.d $fp, $sp, 0x48
+	fst.d $fs0, $sp, 0x50
+	fst.d $fs1, $sp, 0x58
+	fst.d $fs2, $sp, 0x60
+	fst.d $fs3, $sp, 0x68
+	fst.d $fs4, $sp, 0x70
+	fst.d $fs5, $sp, 0x78
+	fst.d $fs6, $sp, 0x80
+	fst.d $fs7, $sp, 0x88
+
+	# Save return address
+	st.d $ra, $sp, 0x90
+
+	# Save stack pointer to a0 (first argument)
+	st.d $sp, $a0, 0x00
+
+	# Load stack pointer from a1 (second argument)
+	ld.d $sp, $a1, 0x00
+
+	# Restore caller registers
+	ld.d $s0, $sp, 0x00
+	ld.d $s1, $sp, 0x08
+	ld.d $s2, $sp, 0x10
+	ld.d $s3, $sp, 0x18
+	ld.d $s4, $sp, 0x20
+	ld.d $s5, $sp, 0x28
+	ld.d $s6, $sp, 0x30
+	ld.d $s7, $sp, 0x38
+	ld.d $s8, $sp, 0x40
+	ld.d $fp, $sp, 0x48
+	fld.d $fs0, $sp, 0x50
+	fld.d $fs1, $sp, 0x58
+	fld.d $fs2, $sp, 0x60
+	fld.d $fs3, $sp, 0x68
+	fld.d $fs4, $sp, 0x70
+	fld.d $fs5, $sp, 0x78
+	fld.d $fs6, $sp, 0x80
+	fld.d $fs7, $sp, 0x88
+
+	# Load return address
+	ld.d $ra, $sp, 0x90
+
+	# Pop stack frame
+	addi.d $sp, $sp, 0xa0	
+
+	# Jump to return address
+	jr $ra
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/coroutine/loongarch64/Context.h
+++ b/coroutine/loongarch64/Context.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <assert.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#define COROUTINE __attribute__((noreturn)) void
+
+enum {COROUTINE_REGISTERS = 0xa0 / 8};
+
+struct coroutine_context
+{
+    void **stack_pointer;
+    void *argument;
+};
+
+typedef COROUTINE(* coroutine_start)(struct coroutine_context *from, struct coroutine_context *self);
+
+static inline void coroutine_initialize_main(struct coroutine_context * context) {
+    context->stack_pointer = NULL;
+}
+
+static inline void coroutine_initialize(
+    struct coroutine_context *context,
+    coroutine_start start,
+    void *stack,
+    size_t size
+) {
+    assert(start && stack && size >= 1024);
+
+    // Stack grows down. Force 16-byte alignment.
+    char * top = (char*)stack + size;
+    context->stack_pointer = (void**)((uintptr_t)top & ~0xF);
+
+    context->stack_pointer -= COROUTINE_REGISTERS;
+    memset(context->stack_pointer, 0, sizeof(void*) * COROUTINE_REGISTERS);
+
+    context->stack_pointer[0x90 / 8] = (void*)start;
+}
+
+struct coroutine_context * coroutine_transfer(struct coroutine_context * current, struct coroutine_context * target);
+
+static inline void coroutine_destroy(struct coroutine_context * context)
+{
+}

--- a/vm_dump.c
+++ b/vm_dump.c
@@ -808,7 +808,7 @@ rb_print_backtrace(void)
 #endif
 
 #if defined __linux__
-# if defined __x86_64__ || defined __i386__ || defined __aarch64__ || defined __arm__ || defined __riscv
+# if defined __x86_64__ || defined __i386__ || defined __aarch64__ || defined __arm__ || defined __riscv || defined __loongarch64
 #  define HAVE_PRINT_MACHINE_REGISTERS 1
 # endif
 #elif defined __APPLE__
@@ -837,7 +837,7 @@ print_machine_register(size_t reg, const char *reg_name, int col_count, int max_
 # ifdef __linux__
 #   if defined(__x86_64__) || defined(__i386__)
 #       define dump_machine_register(reg) (col_count = print_machine_register(mctx->gregs[REG_##reg], #reg, col_count, 80))
-#   elif defined(__aarch64__) || defined(__arm__) || defined(__riscv)
+#   elif defined(__aarch64__) || defined(__arm__) || defined(__riscv) || defined(__loongarch64)
 #       define dump_machine_register(reg, regstr) (col_count = print_machine_register(reg, regstr, col_count, 80))
 #   endif
 # elif defined __APPLE__
@@ -958,6 +958,28 @@ rb_dump_machine_register(const ucontext_t *ctx)
         dump_machine_register(mctx->__gregs[REG_S2+7], "s9");
         dump_machine_register(mctx->__gregs[REG_S2+8], "s10");
         dump_machine_register(mctx->__gregs[REG_S2+9], "s11");
+#   elif defined __loongarch64
+        dump_machine_register(mctx->__gregs[LARCH_REG_SP], "sp");
+        dump_machine_register(mctx->__gregs[LARCH_REG_S0], "s0");
+        dump_machine_register(mctx->__gregs[LARCH_REG_S1], "s1");
+        dump_machine_register(mctx->__gregs[LARCH_REG_A0], "a0");
+        dump_machine_register(mctx->__gregs[LARCH_REG_A0+1], "a1");
+        dump_machine_register(mctx->__gregs[LARCH_REG_A0+2], "a2");
+        dump_machine_register(mctx->__gregs[LARCH_REG_A0+3], "a3");
+        dump_machine_register(mctx->__gregs[LARCH_REG_A0+4], "a4");
+        dump_machine_register(mctx->__gregs[LARCH_REG_A0+5], "a5");
+        dump_machine_register(mctx->__gregs[LARCH_REG_A0+6], "a6");
+        dump_machine_register(mctx->__gregs[LARCH_REG_A0+7], "a7");
+        dump_machine_register(mctx->__gregs[LARCH_REG_A0+7], "a7");
+        dump_machine_register(mctx->__gregs[LARCH_REG_S0], "s0");
+        dump_machine_register(mctx->__gregs[LARCH_REG_S0+1], "s1");
+        dump_machine_register(mctx->__gregs[LARCH_REG_S0+2], "s2");
+        dump_machine_register(mctx->__gregs[LARCH_REG_S0+3], "s3");
+        dump_machine_register(mctx->__gregs[LARCH_REG_S0+4], "s4");
+        dump_machine_register(mctx->__gregs[LARCH_REG_S0+5], "s5");
+        dump_machine_register(mctx->__gregs[LARCH_REG_S0+6], "s6");
+        dump_machine_register(mctx->__gregs[LARCH_REG_S0+7], "s7");
+        dump_machine_register(mctx->__gregs[LARCH_REG_S0+8], "s8");
 #   endif
     }
 # elif defined __APPLE__


### PR DESCRIPTION
LoongArch is a new architecture that is already supported by linux-6.1, gcc-12, and I want to add LoongArch support for ruby.