### PR TITLE
Bump SHAPE_MAX_NUM_IVS to 80

### DIFF
--- a/shape.h
+++ b/shape.h
@@ -31,7 +31,7 @@ typedef uint16_t shape_id_t;
 # define SHAPE_BITMAP_SIZE 16384
 
 # define SHAPE_MAX_VARIATIONS 8
-# define SHAPE_MAX_NUM_IVS 50
+# define SHAPE_MAX_NUM_IVS 80
 
 # define MAX_SHAPE_ID (SHAPE_MASK - 1)
 # define INVALID_SHAPE_ID SHAPE_MASK


### PR DESCRIPTION
A quick fix to https://github.com/ruby/ruby/pull/7188#issuecomment-1422087741. I know we'll have a long-term solution shortly, but it wouldn't hurt to normalize yjit-bench sooner.

71 seems to be the minimum number that fixes the immediate problem, but I wanted to use a somewhat round number, while still not encouraging to use an infinite number of ivars.

```
before: ruby 3.3.0dev (2023-02-21T04:46:11Z master 6384f7981c) +YJIT [x86_64-linux]
after: ruby 3.3.0dev (2023-02-21T07:15:39Z shape-num-iv 6dc96a29f7) +YJIT [x86_64-linux]

---------  -----------  ----------  ----------  ----------  ------------  -------------
bench      before (ms)  stddev (%)  after (ms)  stddev (%)  before/after  after 1st itr
optcarrot  3287.2       0.4         1453.8      0.8         2.26          2.22
---------  -----------  ----------  ----------  ----------  ------------  -------------
```

cc: @jemmaissroff @tenderlove @ruby/yjit 