### PR TITLE
Allow classes and modules to become too complex

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -3512,7 +3512,11 @@ obj_free(rb_objspace_t *objspace, VALUE obj)
       case T_CLASS:
         rb_id_table_free(RCLASS_M_TBL(obj));
         cc_table_free(objspace, obj, FALSE);
-        if (RCLASS_IVPTR(obj)) {
+        if (rb_shape_obj_too_complex(obj)) {
+            RB_DEBUG_COUNTER_INC(obj_obj_too_complex);
+            rb_id_table_free(RCLASS_TABLE_IVPTR(obj));
+        }
+        else if (RCLASS_IVPTR(obj)) {
             xfree(RCLASS_IVPTR(obj));
         }
         if (RCLASS_CONST_TBL(obj)) {

--- a/internal/class.h
+++ b/internal/class.h
@@ -96,6 +96,7 @@ STATIC_ASSERT(sizeof_rb_classext_t, sizeof(struct RClass) + sizeof(rb_classext_t
 #define RCLASS_CONST_TBL(c) (RCLASS_EXT(c)->const_tbl)
 #define RCLASS_M_TBL(c) (RCLASS(c)->m_tbl)
 #define RCLASS_IVPTR(c) (RCLASS_EXT(c)->iv_ptr)
+#define RCLASS_TABLE_IVPTR(c) (struct rb_id_table *)(RCLASS_EXT(c)->iv_ptr)
 #define RCLASS_CALLABLE_M_TBL(c) (RCLASS_EXT(c)->callable_m_tbl)
 #define RCLASS_CC_TBL(c) (RCLASS_EXT(c)->cc_tbl)
 #define RCLASS_CVC_TBL(c) (RCLASS_EXT(c)->cvc_tbl)

--- a/test/ruby/test_shapes.rb
+++ b/test/ruby/test_shapes.rb
@@ -105,7 +105,27 @@ class TestShapes < Test::Unit::TestCase
       obj.instance_variable_set(:"@a#{_1}", 1)
     end
 
-    assert_false RubyVM::Shape.of(obj).too_complex?
+    assert_predicate RubyVM::Shape.of(obj), :too_complex?
+  end
+
+  def test_too_many_ivs_on_module
+    obj = Module.new
+
+    (RubyVM::Shape::SHAPE_MAX_NUM_IVS + 1).times do
+      obj.instance_variable_set(:"@a#{_1}", 1)
+    end
+
+    assert_predicate RubyVM::Shape.of(obj), :too_complex?
+  end
+
+  def test_too_many_ivs_on_builtin
+    obj = "string"
+
+    (RubyVM::Shape::SHAPE_MAX_NUM_IVS + 1).times do
+      obj.instance_variable_set(:"@a#{_1}", 1)
+    end
+
+    refute RubyVM::Shape.of(obj).too_complex?
   end
 
   def test_removing_when_too_many_ivs_on_class


### PR DESCRIPTION
This makes the behavior of classes and modules when there are too many instance variables match the behavior of objects with too many instance variables.

At GitHub we have a lot of edges from class instance variables, so limiting them somewhat should result in a much more manageable shape tree.

cc: @jemmaissroff and @tenderlove 