### PR TITLE
YJIT: Avoid checking symbol ID twice on send

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -6379,9 +6379,6 @@ fn gen_send_general(
 
                         asm.comment("chain_guard_send");
                         let chain_exit = counted_exit!(ocb, side_exit, send_send_chain);
-                        asm.cmp(symbol_id_opnd, 0.into());
-                        asm.jbe(chain_exit);
-
                         asm.cmp(symbol_id_opnd, mid.into());
                         jit_chain_guard(
                             JCC_JNE,


### PR DESCRIPTION
If I read this correctly, this place is checking `mid <= 0`, but `ID` is unsigned, and `mid != 0` case seems doubly guarded by the subsequent chain guard because we have `return CantCompile` under `if mid == 0 {`. This doesn't seem necessary.