### PR TITLE
YJIT: Introduce Opnd::Stack

### DIFF
--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -7,7 +7,7 @@ use std::fmt;
 use std::convert::From;
 use std::io::Write;
 use std::mem::take;
-use crate::cruby::{VALUE};
+use crate::cruby::{VALUE, SIZEOF_VALUE_I32};
 use crate::virtualmem::{CodePtr};
 use crate::asm::{CodeBlock, uimm_num_bits, imm_num_bits};
 use crate::core::{Context, Type, TempMapping};
@@ -72,6 +72,9 @@ pub enum Opnd
     // Output of a preceding instruction in this block
     InsnOut{ idx: usize, num_bits: u8 },
 
+    // Pointer to a slot on the VM stack
+    Stack { idx: i32, sp_offset: i16, num_bits: u8 },
+
     // Low-level operands, for lowering
     Imm(i64),           // Raw signed immediate
     UImm(u64),          // Raw unsigned immediate
@@ -85,6 +88,7 @@ impl fmt::Debug for Opnd {
         match self {
             Self::None => write!(fmt, "None"),
             Value(val) => write!(fmt, "Value({val:?})"),
+            Stack { idx, sp_offset, .. } => write!(fmt, "SP[{}]", *sp_offset as i32 - idx - 1),
             InsnOut { idx, num_bits } => write!(fmt, "Out{num_bits}({idx})"),
             Imm(signed) => write!(fmt, "{signed:x}_i64"),
             UImm(unsigned) => write!(fmt, "{unsigned:x}_u64"),
@@ -158,6 +162,7 @@ impl Opnd
             Opnd::Reg(reg) => Some(Opnd::Reg(reg.with_num_bits(num_bits))),
             Opnd::Mem(Mem { base, disp, .. }) => Some(Opnd::Mem(Mem { base, disp, num_bits })),
             Opnd::InsnOut { idx, .. } => Some(Opnd::InsnOut { idx, num_bits }),
+            Opnd::Stack { idx, sp_offset, .. } => Some(Opnd::Stack { idx, sp_offset, num_bits }),
             _ => None,
         }
     }
@@ -912,6 +917,25 @@ impl Assembler
         let label_idx = self.label_names.len();
         self.label_names.push(name.to_string());
         Target::Label(label_idx)
+    }
+
+    /// Convert Stack operands to memory operands
+    pub fn lower_stack(mut self) -> Assembler
+    {
+        let mut asm = Assembler::new_with_label_names(take(&mut self.label_names));
+        let mut iterator = self.into_draining_iter();
+
+        while let Some((index, mut insn)) = iterator.next_unmapped() {
+            let mut opnd_iter = insn.opnd_iter_mut();
+            while let Some(opnd) = opnd_iter.next() {
+                if let Opnd::Stack { idx, sp_offset, num_bits } = *opnd {
+                    *opnd = Opnd::mem(num_bits, SP, (sp_offset as i32 - idx - 1) * SIZEOF_VALUE_I32);
+                }
+            }
+            asm.push_insn(insn);
+        }
+
+        asm
     }
 
     /// Sets the out field on the various instructions that require allocated

--- a/yjit/src/backend/x86_64/mod.rs
+++ b/yjit/src/backend/x86_64/mod.rs
@@ -701,7 +701,7 @@ impl Assembler
     /// Optimize and compile the stored instructions
     pub fn compile_with_regs(self, cb: &mut CodeBlock, regs: Vec<Reg>) -> Vec<u32>
     {
-        let mut asm = self.x86_split().alloc_regs(regs);
+        let mut asm = self.lower_stack().x86_split().alloc_regs(regs);
 
         // Create label instances in the code block
         for (idx, name) in asm.label_names.iter().enumerate() {


### PR DESCRIPTION
As I'm working on register allocation for stack temps, it's getting obvious that we need to distinguish stack operands from normal memory operands. In this PR, I introduced `Opnd::Stack` for it and let `lower_stack` convert it to memory operands, which we could replace with stack temp register allocator.

While working on this, I also noticed that we could stop copy-pasting the stack index between `ctx.stack_opnd(n)` and `StackOpnd(n)` once we have this operand. I thought this refactoring alone is useful for readability, so I filed this first.