### PR TITLE
[win32/registry] Fallback to UTF-8 for unknown codepages

### DIFF
--- a/ext/win32/lib/win32/registry.rb
+++ b/ext/win32/lib/win32/registry.rb
@@ -69,7 +69,11 @@ For detail, see the MSDN[http://msdn.microsoft.com/library/en-us/sysinfo/base/pr
   WCHAR_NUL = "\0".encode(WCHAR).freeze
   WCHAR_CR = "\r".encode(WCHAR).freeze
   WCHAR_SIZE = WCHAR_NUL.bytesize
-  LOCALE = Encoding.find(Encoding.locale_charmap)
+  begin
+    LOCALE = Encoding.find(Encoding.locale_charmap)
+  rescue ArgumentError
+    LOCALE = Encoding::UTF_8
+  end
 
   class Registry
 


### PR DESCRIPTION
There are some codepages like cp708 for which no ruby encoding exists:

    $ ruby -e "Encoding.find('cp708')"
    Traceback (most recent call last):
    	1: from -e:1:in `<main>'
    -e:1:in `find': unknown encoding name - cp708 (ArgumentError)

win32/registry uses ENCODING to transcode error messages and expand environment variables from UTF-16LE, so using UTF-8 seems like the best choice and is better than a hard failure.

This should resolve [Bug #13831]