### PR TITLE
Fix autoconf RUBY_STACK_GROW_DIRECTION on ARM devices

### DIFF
--- a/tool/m4/ruby_stack_grow_direction.m4
+++ b/tool/m4/ruby_stack_grow_direction.m4
@@ -3,7 +3,7 @@ AC_DEFUN([RUBY_STACK_GROW_DIRECTION], [
     AS_VAR_PUSHDEF([stack_grow_dir], [rb_cv_stack_grow_dir_$1])
     AC_CACHE_CHECK(stack growing direction on $1, stack_grow_dir, [
 AS_CASE(["$1"],
-[m68*|x86*|x64|i?86|ppc*|sparc*|alpha*], [ $2=-1],
+[m68*|x86*|x64|i?86|ppc*|sparc*|alpha*|arm*|aarch*], [ $2=-1],
 [hppa*], [ $2=+1],
 [
   AC_RUN_IFELSE([AC_LANG_SOURCE([[


### PR DESCRIPTION
The logic in `tool/m4/ruby_stack_grow_direction.m4` has a list of hard-coded architecture stack directions, as well as a fallback for when the architecture is unknown:

https://github.com/ruby/ruby/blob/f471f46184c1faffe29e8a5df36407fbd5fbce8d/tool/m4/ruby_stack_grow_direction.m4#L6

However, ARM (`arm*` / `aarch*`) is not currently in the hard-coded list. ARM (32-bit and 64-bit) use the same stack direction (growing up, e.g. towards smaller addresses) as Intel:

https://community.arm.com/arm-community-blogs/b/architectures-and-processors-blog/posts/using-the-stack-in-aarch32-and-aarch64

Evidently the fallback is not reliable; on at least one macOS x86_64 host building for universal x86_64 + arm64, it's detecting the arm64 stack direction as growing *down* (e.g., towards larger directions):

```
| #if defined __x86_64__
| #define STACK_GROW_DIRECTION -1
| #endif /* defined __x86_64__ */
| #if defined __arm64__
| #define STACK_GROW_DIRECTION +1

(snip)

rb_cv_stack_grow_dir_arm64=+1
rb_cv_stack_grow_dir_x86_64=-1
```

When the stack direction is incorrectly detected, we get the startup crash on arm64 in https://bugs.ruby-lang.org/issues/18286 .

This fixes the issue by always using `-1` for the stack direction when targeting `arm*` and `aarch*` architectures. (Fixing the fallback test in the file is something I'd rather leave for a separate PR).

Fixes [Bug #18286]