### PR TITLE
Allow specifying (non-permanent) module and class names.

### DIFF
--- a/object.c
+++ b/object.c
@@ -1795,12 +1795,13 @@ static VALUE rb_mod_initialize_exec(VALUE module);
 
 /*
  *  call-seq:
- *    Module.new                  -> mod
- *    Module.new {|mod| block }   -> mod
+ *    Module.new([name]) -> mod
+ *    Module.new([name]) {|mod| block } -> mod
  *
  *  Creates a new anonymous module. If a block is given, it is passed
  *  the module object, and the block is evaluated in the context of this
- *  module like #module_eval.
+ *  module like #module_eval. You can give a module a name by assigning
+ *  the module object to a constant or passing the optional name parameter.
  *
  *     fred = Module.new do
  *       def meth1
@@ -1856,12 +1857,13 @@ rb_mod_initialize_clone(int argc, VALUE* argv, VALUE clone)
 
 /*
  *  call-seq:
- *     Class.new(super_class=Object)               -> a_class
- *     Class.new(super_class=Object) { |mod| ... } -> a_class
+ *     Class.new(super_class=Object, [name]) -> a_class
+ *     Class.new(super_class=Object, [name]) { |mod| ... } -> a_class
  *
- *  Creates a new anonymous (unnamed) class with the given superclass
+ *  Creates a new anonymous class with the given superclass
  *  (or Object if no parameter is given). You can give a
- *  class a name by assigning the class object to a constant.
+ *  class a name by assigning the class object to a constant or
+ *  passing the optional name parameter.
  *
  *  If a block is given, it is passed the class object, and the block
  *  is evaluated in the context of this class like

--- a/spec/ruby/core/class/new_spec.rb
+++ b/spec/ruby/core/class/new_spec.rb
@@ -152,4 +152,19 @@ describe "Class#new" do
 
     klass.new { break 42 }.should == 42
   end
+
+  ruby_version_is "3.3" do
+    it "can provide an explicit name" do
+      klass = Class.new(Object, "fake")
+      klass.name.should == "fake"
+    end
+
+    it "can override explicit name" do
+      klass = Class.new(Object, "fake")
+      ::Fake = klass
+      klass.name.should == "Fake"
+    ensure
+      ::Object.__send__(:remove_const, "Fake")
+    end
+  end
 end

--- a/spec/ruby/core/module/new_spec.rb
+++ b/spec/ruby/core/module/new_spec.rb
@@ -28,4 +28,19 @@ describe "Module.new" do
     o.hello.should == "hello"
     o.bye.should == "bye"
   end
+
+  ruby_version_is "3.3" do
+    it "can provide an explicit name" do
+      mod = Module.new("fake")
+      mod.name.should == "fake"
+    end
+
+    it "can override explicit name" do
+      mod = Module.new("fake")
+      ::Fake = mod
+      mod.name.should == "Fake"
+    ensure
+      ::Object.__send__(:remove_const, "Fake")
+    end
+  end
 end

--- a/tool/lib/envutil.rb
+++ b/tool/lib/envutil.rb
@@ -263,9 +263,7 @@ module EnvUtil
   module_function :with_default_internal
 
   def labeled_module(name, &block)
-    Module.new(name) do
-      class_eval(&block) if block
-    end
+    Module.new(name, &block)
   end
   module_function :labeled_module
 

--- a/tool/lib/envutil.rb
+++ b/tool/lib/envutil.rb
@@ -263,26 +263,14 @@ module EnvUtil
   module_function :with_default_internal
 
   def labeled_module(name, &block)
-    Module.new do
-      singleton_class.class_eval {
-        define_method(:to_s) {name}
-        alias inspect to_s
-        alias name to_s
-      }
+    Module.new(name) do
       class_eval(&block) if block
     end
   end
   module_function :labeled_module
 
   def labeled_class(name, superclass = Object, &block)
-    Class.new(superclass) do
-      singleton_class.class_eval {
-        define_method(:to_s) {name}
-        alias inspect to_s
-        alias name to_s
-      }
-      class_eval(&block) if block
-    end
+    Class.new(superclass, name, &block)
   end
   module_function :labeled_class
 


### PR DESCRIPTION
Enables:

- `Class.new(superclass, name)`
- `Module.new(name)`

such that #name returns the given name UNTIL it's assigned to a constant.

https://bugs.ruby-lang.org/issues/19450