### PR TITLE
YJIT: 2 __send__ miscompilations

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -3579,3 +3579,8 @@ assert_equal 'true', %q{
   def a.test = :test
   a.is_a?(a.singleton_class)
 }
+
+# Test send with splat to a cfunc
+assert_equal 'true', %q{
+  1.send(:==, 1, *[])
+}

--- a/test/ruby/test_yjit.rb
+++ b/test/ruby/test_yjit.rb
@@ -1196,6 +1196,26 @@ class TestYJIT < Test::Unit::TestCase
     RUBY
   end
 
+  def test_nested_send
+    #[Bug #19464]
+    assert_compiles(<<~RUBY, result: [:ok, :ok])
+      klass = Class.new do
+        class << self
+          alias_method :my_send, :send
+
+          def bar = :ok
+
+          def foo = bar
+        end
+      end
+
+      with_break = -> { break klass.send(:my_send, :foo) }
+      wo_break = -> { klass.send(:my_send, :foo) }
+
+      [with_break[], wo_break[]]
+    RUBY
+  end
+
   private
 
   def code_gc_helpers

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -4929,6 +4929,12 @@ fn gen_send_cfunc(
 
     // push_splat_args does stack manipulation so we can no longer side exit
     if flags & VM_CALL_ARGS_SPLAT != 0 {
+        if flags & VM_CALL_OPT_SEND != 0 {
+            // FIXME: This combination is buggy.
+            // For example `1.send(:==, 1, *[])` fails to adjust the stack properly
+            gen_counter_incr!(asm, send_cfunc_splat_send);
+            return CantCompile;
+        }
         let required_args : u32 = (cfunc_argc as u32).saturating_sub(argc as u32 - 1);
         // + 1 because we pass self
         if required_args + 1 >= C_ARG_OPNDS.len() as u32 {

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -192,6 +192,7 @@ make_counters! {
     send_cfunc_tracing,
     send_cfunc_kwargs,
     send_cfunc_splat_with_kw,
+    send_cfunc_splat_send,
     send_attrset_kwargs,
     send_iseq_tailcall,
     send_iseq_arity_error,


### PR DESCRIPTION
Please merge with rebase and **_do not squash_**.
Only the second commit needs to be backported. Need both commits to pass CI on the master branch, though.

---

- YJIT: Reject __send__ with splat to cfunc for now
- YJIT: Detect and reject `send(:alias_for_send, :foo)` (https://bugs.ruby-lang.org/issues/19464)

---

- [ ] Ask people in https://github.com/Shopify/yjit/issues/306 to try the fix. `rbenv`(`ruby-build`) and `ruby-install` both support building with patches.