### PR TITLE
Add all-ruby-quine as a sample code

### DIFF
--- a/sample/all-ruby-quine.rb
+++ b/sample/all-ruby-quine.rb
@@ -1,0 +1,24 @@
+          eval($s=("t='eval($s=('+d=34.chr;s=3
+        2.chr+$s*i=8;v=$VERSION||eval('begin;v=V
+      ERSION;rescue;v||RUBY_VERSION;end');f=('?'*8
+    +'A|'+'?'*20+'G?c'+'?'*15+'A@CXx@~@_`OpGxCxp@~pO
+  xS|O~G?c?q?xC`AP|q?x_|C_xC_xO@H@cG?G?qA|_|_`GCpOxC|H
+NFccqq@`_|OF@`?q?x_@x_x_`GB`O``O~G?C@qCxCxP@D@|G~C?pO|C?
+  pO|C?AP|A~HNN`ccxC|Q@L@B"+"GpGpc@p?x_`GB`???_@FO|OB@
+     xC|P`@?c?q?HPx@~@_`G@`????@L^`?q?x?xq@|_|O~GC`
+        xA~@_@GBD').unpack('c*');w=4+v.length*u=
+           15;r=10.chr;j=0;while-24+w*u>i=1+i
+              ;x=i%w;x>0||t=t+d+'+'+r+d;k=
+                 i/w%12>2&&x%u>3&&x%u+i
+                    /w*11-34+('-._'.
+                       index(c=v[
+                         x/u,1]
+                )||c.hex        +3)*99|
+               |0;    k=f     [k/6   ][k%
+                       6];    t=t     +s[
+                      k*j     =k+     j,1
+                 ]end;pr      int     (t+
+                      d+'     ).s     pli
+                       t.j    oin     [0,
+               609    ])#     Y.E.   '+r)
+                ").split        .join)#

--- a/test/test_trick.rb
+++ b/test/test_trick.rb
@@ -1,6 +1,7 @@
 require "test/unit"
 require "ripper"
 require "envutil"
+require "stringio"
 
 # This is a test suite for TRICK entries, joke Ruby program contest.
 # The programs are very unusual, and not practical.
@@ -210,5 +211,36 @@ class TestTRICK2022 < Test::Unit::TestCase
 
     # TODO
     assert_in_out_err(["-W0", "-c", src], "", ["Syntax OK"])
+  end
+end
+
+# https://github.com/mame/all-ruby-quine
+class TestAllRubyQuine < Test::Unit::TestCase
+  def test_all_ruby_quine
+    stdout_bak = $stdout
+    $stdout = StringIO.new
+    src = File.read(File.join(__dir__, "../sample/all-ruby-quine.rb"))
+
+    eval(src)
+
+    out = $stdout.string.lines(chomp: true)
+    $stdout = stdout_bak
+
+    # cheat OCR
+    font = {
+      "-" => 0x7ffffffffffe03fffffffffff, "." => 0x7fffffffffffffffffffc7f8f, "_" => 0x7fffffffffffffffffffff800,
+      "0" => 0x6030e03e07c0f81f03e038603, "1" => 0x70fc1f23fc7f8ff1fe3fc7c01, "2" => 0x4011f1fe3fc7e1f0f87c3f800,
+      "3" => 0x4031e3fe3f8e03fe3fe078c03, "4" => 0x783e0788e318e31c6003f1fe3, "5" => 0x0001fe3fc7f801fe1fe078401,
+      "6" => 0x78083e3fc7f8011e03e038401, "7" => 0x000fe1fc3f0fc3f0fc3f0fc3f, "8" => 0x4011f03e238e038e23e07c401,
+      "9" => 0x4010e03e03c400ff1fe078401, "a" => 0x7fffff00c787f88003e078408, "b" => 0x0ff1fe3fc408701f03e078001,
+      "c" => 0x7fffff8063c0ff1fe3fe3c601, "d" => 0x7f8ff1fe3004781f03e038408,
+    }.invert
+    out = (0...out.first.size / 15).map do |i|
+      font[(3..11).map {|j| out[j][i * 15 + 5, 11] }.join.gsub(/\S/, "#").tr("# ", "10").to_i(2)]
+    end.join
+
+    assert_equal(RUBY_VERSION, out)
+  ensure
+    $stdout = stdout_bak
   end
 end


### PR DESCRIPTION
This sample code works on all release versions of Ruby, from Ruby 0.49.