### PR TITLE
[DOC] Symbol#end_with? accepts Strings only

### DIFF
--- a/string.c
+++ b/string.c
@@ -11845,7 +11845,7 @@ sym_start_with(int argc, VALUE *argv, VALUE sym)
 
 /*
  *  call-seq:
- *    end_with?(*string_or_regexp) -> true or false
+ *    end_with?(*strings) -> true or false
  *
  *
  *  Equivalent to <tt>self.to_s.end_with?</tt>; see String#end_with?.


### PR DESCRIPTION
Regular expressions are not supported (same as String#end_with?).