### PR TITLE
fix test/rubygems/test_gem_package_task.rb when in -j mode

### DIFF
--- a/test/rubygems/test_gem_bundler_version_finder.rb
+++ b/test/rubygems/test_gem_bundler_version_finder.rb
@@ -4,10 +4,10 @@ require "rubygems/bundler_version_finder"
 
 class TestGemBundlerVersionFinder < Gem::TestCase
   def setup
-    super
-
     @argv = ARGV.dup
     @dollar_0 = $0
+    super
+
     without_any_upwards_gemfiles
   end
 

--- a/test/rubygems/test_gem_commands_exec_command.rb
+++ b/test/rubygems/test_gem_commands_exec_command.rb
@@ -4,14 +4,14 @@ require "rubygems/commands/exec_command"
 
 class TestGemCommandsExecCommand < Gem::TestCase
   def setup
+    @orig_args = Gem::Command.build_args
+    @orig_specific_extra_args = Gem::Command.specific_extra_args_hash.dup
+    @orig_extra_args = Gem::Command.extra_args.dup
+
     super
     common_installer_setup
 
     @cmd = Gem::Commands::ExecCommand.new
-
-    @orig_args = Gem::Command.build_args
-    @orig_specific_extra_args = Gem::Command.specific_extra_args_hash.dup
-    @orig_extra_args = Gem::Command.extra_args.dup
 
     @gem_home = Gem.dir
     @gem_path = Gem.path

--- a/test/rubygems/test_gem_commands_install_command.rb
+++ b/test/rubygems/test_gem_commands_install_command.rb
@@ -7,6 +7,7 @@ require "rubygems/rdoc"
 
 class TestGemCommandsInstallCommand < Gem::TestCase
   def setup
+    @orig_args = Gem::Command.build_args
     super
     common_installer_setup
 
@@ -14,7 +15,6 @@ class TestGemCommandsInstallCommand < Gem::TestCase
     @cmd.options[:document] = []
 
     @gemdeps = "tmp_install_gemdeps"
-    @orig_args = Gem::Command.build_args
 
     common_installer_setup
   end

--- a/test/rubygems/test_gem_ext_builder.rb
+++ b/test/rubygems/test_gem_ext_builder.rb
@@ -5,6 +5,8 @@ require "rubygems/installer"
 
 class TestGemExtBuilder < Gem::TestCase
   def setup
+    @orig_DESTDIR = ENV["DESTDIR"]
+    @orig_make = ENV["make"]
     super
 
     @ext = File.join @tempdir, "ext"
@@ -13,19 +15,15 @@ class TestGemExtBuilder < Gem::TestCase
     FileUtils.mkdir_p @ext
     FileUtils.mkdir_p @dest_path
 
-    @orig_DESTDIR = ENV["DESTDIR"]
-    @orig_make = ENV["make"]
-
     @spec = util_spec "a"
 
     @builder = Gem::Ext::Builder.new @spec, ""
   end
 
   def teardown
+    super
     ENV["DESTDIR"] = @orig_DESTDIR
     ENV["make"] = @orig_make
-
-    super
   end
 
   def test_class_make

--- a/test/rubygems/test_gem_gem_runner.rb
+++ b/test/rubygems/test_gem_gem_runner.rb
@@ -3,12 +3,12 @@ require_relative "helper"
 
 class TestGemGemRunner < Gem::TestCase
   def setup
-    super
-
     require "rubygems/command"
     @orig_args = Gem::Command.build_args
     @orig_specific_extra_args = Gem::Command.specific_extra_args_hash.dup
     @orig_extra_args = Gem::Command.extra_args.dup
+
+    super
 
     require "rubygems/gem_runner"
     @runner = Gem::GemRunner.new

--- a/test/rubygems/test_kernel.rb
+++ b/test/rubygems/test_kernel.rb
@@ -5,17 +5,9 @@ class TestKernel < Gem::TestCase
   def setup
     super
 
-    @old_path = $:.dup
-
     util_make_gems
 
     without_any_upwards_gemfiles
-  end
-
-  def teardown
-    super
-
-    $:.replace @old_path
   end
 
   def test_gem

--- a/tool/lib/test/unit/parallel.rb
+++ b/tool/lib/test/unit/parallel.rb
@@ -208,5 +208,9 @@ if $0 == __FILE__
     end
   end
   require 'rubygems'
+  begin
+    require 'rake'
+  rescue LoadError
+  end
   Test::Unit::Worker.new.run(ARGV)
 end


### PR DESCRIPTION
This test skipped sometimes due to failure to load 'rake/packagetask'. This is due to manipulation of $LOAD_PATH by other rubygems tests. If rake is loaded before any rubygems tests run, then it works fine.

To reproduce the skipping behavior:
  $ make test-all TESTOPTS="-j6 --test-order=sorted test/rubygems/test_*.rb"