### PR TITLE
YJIT: add `defer_empty_count` stat

### DIFF
--- a/yjit.rb
+++ b/yjit.rb
@@ -269,6 +269,7 @@ module RubyVM::YJIT
       $stderr.puts "compiled_branch_count: " + format_number(13, stats[:compiled_branch_count])
       $stderr.puts "block_next_count:      " + format_number(13, stats[:block_next_count])
       $stderr.puts "defer_count:           " + format_number(13, stats[:defer_count])
+      $stderr.puts "defer_empty_count:     " + format_number(13, stats[:defer_empty_count])
       $stderr.puts "freed_iseq_count:      " + format_number(13, stats[:freed_iseq_count])
       $stderr.puts "invalidation_count:    " + format_number(13, stats[:invalidation_count])
       $stderr.puts "constant_state_bumps:  " + format_number(13, stats[:constant_state_bumps])

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -2244,6 +2244,11 @@ pub fn defer_compilation(
     }
     asm.mark_branch_end(&branch_rc);
 
+    // If the block we're deferring from is empty
+    if jit.get_block().borrow().get_blockid().idx == jit.get_insn_idx() {
+        incr_counter!(defer_empty_count);
+    }
+
     incr_counter!(defer_count);
 }
 

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -310,6 +310,7 @@ make_counters! {
     compilation_failure,
     block_next_count,
     defer_count,
+    defer_empty_count,
     freed_iseq_count,
 
     exit_from_branch_stub,


### PR DESCRIPTION
Count how often we defer from a block that is empty.

On railsbench, the results are:
```
compiled_block_count:         20,472
compiled_branch_count:        35,805
defer_count:                   6,720
defer_empty_count:             1,391
```