### PR TITLE
YJIT: Use a boxed slice for gc_obj_offsets

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -831,7 +831,7 @@ pub fn gen_single_block(
         let gc_offsets = asm.compile(cb);
 
         // Add the GC offsets to the block
-        block.add_gc_obj_offsets(gc_offsets);
+        block.set_gc_obj_offsets(gc_offsets);
 
         // Mark the end position of the block
         block.set_end_addr(cb.get_write_ptr());

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -544,7 +544,7 @@ pub struct Block {
 
     // FIXME: should these be code pointers instead?
     // Offsets for GC managed objects in the mainline code block
-    gc_obj_offsets: Vec<u32>,
+    gc_obj_offsets: Option<Box<[u32]>>,
 
     // CME dependencies of this block, to help to remove all pointers to this
     // block in the system.
@@ -796,16 +796,18 @@ pub extern "C" fn rb_yjit_iseq_mark(payload: *mut c_void) {
             }
 
             // Walk over references to objects in generated code.
-            for offset in &block.gc_obj_offsets {
-                let value_address: *const u8 = cb.get_ptr(offset.as_usize()).raw_ptr();
-                // Creating an unaligned pointer is well defined unlike in C.
-                let value_address = value_address as *const VALUE;
+            if let Some(gc_obj_offsets) = &block.gc_obj_offsets {
+                for offset in gc_obj_offsets.iter() {
+                    let value_address: *const u8 = cb.get_ptr(offset.as_usize()).raw_ptr();
+                    // Creating an unaligned pointer is well defined unlike in C.
+                    let value_address = value_address as *const VALUE;
 
-                // SAFETY: these point to YJIT's code buffer
-                unsafe {
-                    let object = value_address.read_unaligned();
-                    rb_gc_mark_movable(object);
-                };
+                    // SAFETY: these point to YJIT's code buffer
+                    unsafe {
+                        let object = value_address.read_unaligned();
+                        rb_gc_mark_movable(object);
+                    };
+                }
             }
         }
     }
@@ -843,23 +845,25 @@ pub extern "C" fn rb_yjit_iseq_update_references(payload: *mut c_void) {
             }
 
             // Walk over references to objects in generated code.
-            for offset in &block.gc_obj_offsets {
-                let offset_to_value = offset.as_usize();
-                let value_code_ptr = cb.get_ptr(offset_to_value);
-                let value_ptr: *const u8 = value_code_ptr.raw_ptr();
-                // Creating an unaligned pointer is well defined unlike in C.
-                let value_ptr = value_ptr as *mut VALUE;
+            if let Some(gc_obj_offsets) = &block.gc_obj_offsets {
+                for offset in gc_obj_offsets.iter() {
+                    let offset_to_value = offset.as_usize();
+                    let value_code_ptr = cb.get_ptr(offset_to_value);
+                    let value_ptr: *const u8 = value_code_ptr.raw_ptr();
+                    // Creating an unaligned pointer is well defined unlike in C.
+                    let value_ptr = value_ptr as *mut VALUE;
 
-                // SAFETY: these point to YJIT's code buffer
-                let object = unsafe { value_ptr.read_unaligned() };
-                let new_addr = unsafe { rb_gc_location(object) };
+                    // SAFETY: these point to YJIT's code buffer
+                    let object = unsafe { value_ptr.read_unaligned() };
+                    let new_addr = unsafe { rb_gc_location(object) };
 
-                // Only write when the VALUE moves, to be copy-on-write friendly.
-                if new_addr != object {
-                    for (byte_idx, &byte) in new_addr.as_u64().to_le_bytes().iter().enumerate() {
-                        let byte_code_ptr = value_code_ptr.add_bytes(byte_idx);
-                        cb.write_mem(byte_code_ptr, byte)
-                            .expect("patching existing code should be within bounds");
+                    // Only write when the VALUE moves, to be copy-on-write friendly.
+                    if new_addr != object {
+                        for (byte_idx, &byte) in new_addr.as_u64().to_le_bytes().iter().enumerate() {
+                            let byte_code_ptr = value_code_ptr.add_bytes(byte_idx);
+                            cb.write_mem(byte_code_ptr, byte)
+                                .expect("patching existing code should be within bounds");
+                        }
                     }
                 }
             }
@@ -1043,13 +1047,15 @@ fn add_block_version(blockref: &BlockRef, cb: &CodeBlock) {
     }
 
     // Run write barriers for all objects in generated code.
-    for offset in &block.gc_obj_offsets {
-        let value_address: *const u8 = cb.get_ptr(offset.as_usize()).raw_ptr();
-        // Creating an unaligned pointer is well defined unlike in C.
-        let value_address: *const VALUE = value_address.cast();
+    if let Some(gc_obj_offsets) = &block.gc_obj_offsets {
+        for offset in gc_obj_offsets.iter() {
+            let value_address: *const u8 = cb.get_ptr(offset.as_usize()).raw_ptr();
+            // Creating an unaligned pointer is well defined unlike in C.
+            let value_address: *const VALUE = value_address.cast();
 
-        let object = unsafe { value_address.read_unaligned() };
-        obj_written!(iseq, object);
+            let object = unsafe { value_address.read_unaligned() };
+            obj_written!(iseq, object);
+        }
     }
 
     incr_counter!(compiled_block_count);
@@ -1088,7 +1094,7 @@ impl Block {
             end_addr: None,
             incoming: Vec::new(),
             outgoing: Vec::new(),
-            gc_obj_offsets: Vec::new(),
+            gc_obj_offsets: None,
             cme_dependencies: Vec::new(),
             entry_exit: None,
         };
@@ -1147,12 +1153,12 @@ impl Block {
         self.end_idx = end_idx;
     }
 
-    pub fn add_gc_obj_offsets(self: &mut Block, gc_offsets: Vec<u32>) {
-        for offset in gc_offsets {
-            self.gc_obj_offsets.push(offset);
-            incr_counter!(num_gc_obj_refs);
+    pub fn set_gc_obj_offsets(self: &mut Block, gc_offsets: Vec<u32>) {
+        assert_eq!(self.gc_obj_offsets, None);
+        if !gc_offsets.is_empty() {
+            add_counter!(num_gc_obj_refs, gc_offsets.len());
+            self.gc_obj_offsets = Some(gc_offsets.into_boxed_slice());
         }
-        self.gc_obj_offsets.shrink_to_fit();
     }
 
     /// Instantiate a new CmeDependency struct and add it to the list of

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -1150,7 +1150,7 @@ impl Block {
     pub fn set_gc_obj_offsets(self: &mut Block, gc_offsets: Vec<u32>) {
         assert_eq!(self.gc_obj_offsets.len(), 0);
         if !gc_offsets.is_empty() {
-            add_counter!(num_gc_obj_refs, gc_offsets.len());
+            incr_counter_by!(num_gc_obj_refs, gc_offsets.len());
             self.gc_obj_offsets = gc_offsets.into_boxed_slice();
         }
     }

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -141,6 +141,19 @@ macro_rules! make_counters {
     }
 }
 
+/// Macro to increase a counter by name and count
+macro_rules! add_counter {
+    // Unsafe is ok here because options are initialized
+    // once before any Ruby code executes
+    ($counter_name:ident, $count:expr) => {
+        #[allow(unused_unsafe)]
+        {
+            unsafe { $crate::stats::COUNTERS.$counter_name += $count as u64 }
+        }
+    };
+}
+pub(crate) use add_counter;
+
 /// Macro to increment a counter by name
 macro_rules! incr_counter {
     // Unsafe is ok here because options are initialized

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -142,7 +142,7 @@ macro_rules! make_counters {
 }
 
 /// Macro to increase a counter by name and count
-macro_rules! add_counter {
+macro_rules! incr_counter_by {
     // Unsafe is ok here because options are initialized
     // once before any Ruby code executes
     ($counter_name:ident, $count:expr) => {
@@ -152,7 +152,7 @@ macro_rules! add_counter {
         }
     };
 }
-pub(crate) use add_counter;
+pub(crate) use incr_counter_by;
 
 /// Macro to increment a counter by name
 macro_rules! incr_counter {


### PR DESCRIPTION
This reduces `yjit_alloc_size` by 0.15MB (1.7%) on 25 itrs of railsbench with arm64-darwin22 stats build. Not a huge impact, but this field is immutable and it seems like a simple and straightforward improvement.

## Before
```
yjit_alloc_size:           9,045,001
```

## After
```
yjit_alloc_size:           8,894,479
```