### PR TITLE
variable.c: Set the autoload ivar to Qfalse rather than delete it

### DIFF
--- a/variable.c
+++ b/variable.c
@@ -2432,9 +2432,9 @@ autoload_delete(VALUE module, ID name)
                 rb_hash_delete(autoload_features, autoload_data->feature);
             }
 
-            // If the autoload table is empty, we can delete it.
+            // If the autoload table is empty, we can remove the reference.
             if (table->num_entries == 0) {
-                rb_attr_delete(module, autoload);
+                rb_class_ivar_set(module, autoload, Qfalse);
             }
         }
     }


### PR DESCRIPTION
This avoid changing the shape of the module.

@tenderlove not sure how big a deal this is, but I noticed this when working on https://github.com/ruby/ruby/pull/7402