### PR TITLE
YJIT: use `u16` for insn_idx instead of `u32`

### DIFF
--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -389,7 +389,7 @@ pub struct BlockId {
     pub iseq: IseqPtr,
 
     /// Index in the iseq where the block starts
-    pub idx: u32,
+    pub idx: u16,
 }
 
 /// Branch code shape enumeration
@@ -608,7 +608,7 @@ pub struct Block {
     blockid: BlockId,
 
     // Index one past the last instruction for this block in the iseq
-    end_idx: u32,
+    end_idx: u16,
 
     // Context at the start of the block
     // This should never be mutated
@@ -1188,7 +1188,7 @@ impl Block {
         self.blockid
     }
 
-    pub fn get_end_idx(&self) -> u32 {
+    pub fn get_end_idx(&self) -> u16 {
         self.end_idx
     }
 
@@ -1228,7 +1228,7 @@ impl Block {
 
     /// Set the index of the last instruction in the block
     /// This can be done only once for a block
-    pub fn set_end_idx(&mut self, end_idx: u32) {
+    pub fn set_end_idx(&mut self, end_idx: u16) {
         assert!(self.end_idx == 0);
         self.end_idx = end_idx;
     }
@@ -1649,7 +1649,7 @@ impl BlockId {
     #[cfg(debug_assertions)]
     #[allow(dead_code)]
     pub fn dump_src_loc(&self) {
-        unsafe { rb_yjit_dump_iseq_loc(self.iseq, self.idx) }
+        unsafe { rb_yjit_dump_iseq_loc(self.iseq, self.idx as u32) }
     }
 }
 
@@ -1774,7 +1774,7 @@ fn gen_block_series_body(
 /// NOTE: this function assumes that the VM lock has been taken
 pub fn gen_entry_point(iseq: IseqPtr, ec: EcPtr) -> Option<CodePtr> {
     // Compute the current instruction index based on the current PC
-    let insn_idx: u32 = unsafe {
+    let insn_idx: u16 = unsafe {
         let pc_zero = rb_iseq_pc_at_idx(iseq, 0);
         let ec_pc = get_cfp_pc(get_ec_cfp(ec));
         ec_pc.offset_from(pc_zero).try_into().ok()?
@@ -1963,7 +1963,7 @@ fn branch_stub_hit_body(branch_ptr: *const c_void, target_idx: u32, ec: EcPtr) -
         let original_interp_sp = get_cfp_sp(cfp);
 
         let running_iseq = rb_cfp_get_iseq(cfp);
-        let reconned_pc = rb_iseq_pc_at_idx(running_iseq, target_blockid.idx);
+        let reconned_pc = rb_iseq_pc_at_idx(running_iseq, target_blockid.idx.into());
         let reconned_sp = original_interp_sp.offset(target_ctx.sp_offset.into());
 
         assert_eq!(running_iseq, target_blockid.iseq as _, "each stub expects a particular iseq");
@@ -2373,7 +2373,7 @@ pub fn free_block(blockref: &BlockRef) {
 pub fn verify_blockid(blockid: BlockId) {
     unsafe {
         assert!(rb_IMEMO_TYPE_P(blockid.iseq.into(), imemo_iseq) != 0);
-        assert!(blockid.idx < get_iseq_encoded_size(blockid.iseq));
+        assert!(u32::from(blockid.idx) < get_iseq_encoded_size(blockid.iseq));
     }
 }
 

--- a/yjit/src/invariants.rs
+++ b/yjit/src/invariants.rs
@@ -417,7 +417,7 @@ pub fn block_assumptions_free(blockref: &BlockRef) {
 /// Invalidate the block for the matching opt_getinlinecache so it could regenerate code
 /// using the new value in the constant cache.
 #[no_mangle]
-pub extern "C" fn rb_yjit_constant_ic_update(iseq: *const rb_iseq_t, ic: IC, insn_idx: u32) {
+pub extern "C" fn rb_yjit_constant_ic_update(iseq: *const rb_iseq_t, ic: IC, insn_idx: u16) {
     // If YJIT isn't enabled, do nothing
     if !yjit_enabled_p() {
         return;
@@ -435,7 +435,7 @@ pub extern "C" fn rb_yjit_constant_ic_update(iseq: *const rb_iseq_t, ic: IC, ins
         // This should come from a running iseq, so direct threading translation
         // should have been done
         assert!(unsafe { FL_TEST(iseq.into(), VALUE(ISEQ_TRANSLATED)) } != VALUE(0));
-        assert!(insn_idx < unsafe { get_iseq_encoded_size(iseq) });
+        assert!(u32::from(insn_idx) < unsafe { get_iseq_encoded_size(iseq) });
 
         // Ensure that the instruction the insn_idx is pointing to is in
         // fact a opt_getconstant_path instruction.

--- a/yjit/src/utils.rs
+++ b/yjit/src/utils.rs
@@ -86,7 +86,7 @@ fn ruby_str_to_rust(v: VALUE) -> String {
 // Location is the file defining the method, colon, method name.
 // Filenames are sometimes internal strings supplied to eval,
 // so be careful with them.
-pub fn iseq_get_location(iseq: IseqPtr, pos: u32) -> String {
+pub fn iseq_get_location(iseq: IseqPtr, pos: u16) -> String {
     let iseq_label = unsafe { rb_iseq_label(iseq) };
     let iseq_path = unsafe { rb_iseq_path(iseq) };
     let iseq_lineno = unsafe { rb_iseq_line_no(iseq, pos as usize) };


### PR DESCRIPTION
An experiment to see if we can save a bit of memory by using `u16` for instruction indices in an ISEQ instead of `u32`. Done by rejecting ISEQs that are more than 64K YARV instruction slots (which we probably shouldn't be wasting time compiling anyways).

Check if the CI doesn't explode 💥 

@k0kubun how do you usually go about measuring memory usage? I assume you're not using a dev build and the rust alloc size?