### PR TITLE
YJIT: Use a boxed slice for outgoing branches and cme dependencies

### DIFF
--- a/yjit/src/invariants.rs
+++ b/yjit/src/invariants.rs
@@ -123,9 +123,7 @@ pub fn assume_method_lookup_stable(
     jit_ensure_block_entry_exit(jit, ocb);
 
     let block = jit.get_block();
-    block
-        .borrow_mut()
-        .add_cme_dependency(callee_cme);
+    jit.push_cme_dependency(callee_cme);
 
     Invariants::get_instance()
         .cme_validity


### PR DESCRIPTION
`outgoing` and `cme_dependencies` are extended only when code is being generated. If we build a vector in `JITState` and set them as a boxed slice at the end, we don't need to use a vector, saving some space and obviating `shrink_to_fit` calls.

This reduces yjit_alloc_size by 0.23MB (2.3%) on 25 itrs of railsbench with arm64-darwin22 stats build.

## Before
```
yjit_alloc_size:           8,683,949
```

## After
```
yjit_alloc_size:           8,458,747
```