### PR TITLE
YJIT: Properly deal with cfunc splat when no args needed

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -3584,3 +3584,13 @@ assert_equal 'true', %q{
 assert_equal 'true', %q{
   1.send(:==, 1, *[])
 }
+
+# Test send with splat to a cfunc
+assert_equal '2', %q{
+  def foo
+    Integer.sqrt(4, *[])
+  end
+  # call twice to deal with constant exiting
+  foo
+  foo
+}


### PR DESCRIPTION
Related to:
https://github.com/ruby/ruby/pull/7377

Previously it was believed that there was a problem with a combination of cfuncs + splat + send, but it turns out the same issue happened without send. For example `Integer.sqrt(1, *[])`. The issue was happening not because of send, but because of setting the wrong argc when we don't need to splat any args.