### PR TITLE
YJIT: Handle special case of splat and rest lining up

### DIFF
--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -253,7 +253,7 @@ make_counters! {
     send_send_getter,
     send_send_builtin,
     send_iseq_has_rest_and_captured,
-    send_iseq_has_rest_and_splat,
+    send_iseq_has_rest_and_splat_not_equal,
     send_iseq_has_rest_and_send,
     send_iseq_has_rest_and_block,
     send_iseq_has_rest_and_kw,


### PR DESCRIPTION
If you have a method that takes rest arguments and a splat call that happens to line up perfectly with that rest, you don't need to do anything. This is true because the array is already copied before we get to the splat, so we don't need to worry about mutability.

Example:

```ruby
def foo(a, b, *rest)
end

foo(1, 2, *[3, 4])
```



Here are the stats of railsbench and liquid-render before and after these changes.
Biggest change here is ratio in yjit

Railsbench
```
Before:
ratio_in_yjit:              90.2%
After:
ratio_in_yjit:              90.9%
```
        
LiquidRender
```
Before:
ratio_in_yjit:              87.8%
After:
ratio_in_yjit:              88.1%
```
        
<summary>Rails Bench Before</summary>
<details>

```ruby
         ***YJIT: Printing YJIT statistics on exit***
method call exit reasons: 
                      iseq_has_rest     108010 (32.3%)
                          block_arg      64821 (19.4%)
                        iseq_zsuper      46081 (13.8%)
                   iseq_arity_error      28684 ( 8.6%)
                iseq_ruby2_keywords      24995 ( 7.5%)
          args_splat_cfunc_var_args      16250 ( 4.9%)
                     iseq_has_no_kw      15977 ( 4.8%)
                           kw_splat      12994 ( 3.9%)
                    iseq_has_kwrest       5294 ( 1.6%)
           iseq_missing_optional_kw       4054 ( 1.2%)
        splatarray_length_not_equal       2029 ( 0.6%)
             args_splat_cfunc_zuper       2002 ( 0.6%)
                      iseq_has_post       1987 ( 0.6%)
              cfunc_ruby_array_varg       1364 ( 0.4%)
                           keywords        102 ( 0.0%)
    args_splat_cfunc_ruby2_keywords         62 ( 0.0%)
                    args_splat_ivar         49 ( 0.0%)
                        send_getter         12 ( 0.0%)
                      zsuper_method          9 ( 0.0%)
                args_splat_opt_call          5 ( 0.0%)
                    ivar_set_method          2 ( 0.0%)
                  bmethod_block_arg          2 ( 0.0%)
invokeblock exit reasons: 
               ifunc       5797 (56.2%)
                proc       2332 (22.6%)
     iseq_arg0_splat       2000 (19.4%)
    iseq_tag_changed        114 ( 1.1%)
              symbol         68 ( 0.7%)
invokesuper exit reasons: 
         block       4795 (98.3%)
    me_changed         84 ( 1.7%)
leave exit reasons: 
        interp_return    1853011 (97.7%)
    start_pc_non_zero      43884 ( 2.3%)
         se_interrupt         24 ( 0.0%)
getblockparamproxy exit reasons: 
    block_param_modified          3 (100.0%)
getinstancevariable exit reasons:
    megamorphic      13685 (100.0%)
setinstancevariable exit reasons:
    (all relevant counters are zero)
opt_aref exit reasons: 
    (all relevant counters are zero)
expandarray exit reasons: 
            splat       9974 (99.8%)
    rhs_too_small         23 ( 0.2%)
opt_getinlinecache exit reasons: 
    miss         11 (100.0%)
invalidation reasons: 
       constant_ic_fill       2037 (59.3%)
          method_lookup       1062 (30.9%)
    constant_state_bump        338 ( 9.8%)
bindings_allocations:         192
bindings_set:                   0
compiled_iseq_count:         9310
compiled_block_count:       52088
compiled_branch_count:      82580
block_next_count:           15260
defer_count:                16345
freed_iseq_count:            4077
invalidation_count:          3437
constant_state_bumps:           0
inline_code_size:         8856060
outlined_code_size:       8854160
freed_code_size:                0
code_region_size:        17760256
yjit_alloc_size:         98380224
live_page_count:             1084
freed_page_count:               0
code_gc_count:                  0
num_gc_obj_refs:            41430
object_shape_count:          2421
side_exit_count:           509465
total_exit_count:         2362476
total_insns_count:       88829417
vm_insns_count:           8743970
yjit_insns_count:        80594912
ratio_in_yjit:              90.2%
avg_len_in_yjit:             33.9
Top-20 most frequent exit ops (100.0% of exits):
    opt_send_without_block:     141825 (27.8%)
               invokesuper:     117069 (23.0%)
                      send:     104185 (20.4%)
      opt_getconstant_path:      53691 (10.5%)
               invokeblock:      36995 (7.3%)
                  opt_aref:      14090 (2.8%)
                     throw:      10655 (2.1%)
               expandarray:       9997 (2.0%)
             setlocal_WC_0:       8359 (1.6%)
                    opt_eq:       5011 (1.0%)
       getinstancevariable:       3485 (0.7%)
        getblockparamproxy:       2270 (0.4%)
               objtostring:        451 (0.1%)
          putspecialobject:        401 (0.1%)
                 opt_nil_p:        327 (0.1%)
             definesmethod:        237 (0.0%)
                checkmatch:        205 (0.0%)
                      once:        104 (0.0%)
               opt_empty_p:         30 (0.0%)
             setblockparam:         25 (0.0%)

```
</details>
    
        
<summary>Rails Bench After</summary>
<details>

```ruby
         ***YJIT: Printing YJIT statistics on exit***
method call exit reasons: 
                            block_arg:     64,834 (19.0%)
                          iseq_zsuper:     60,078 (17.6%)
              iseq_has_rest_and_block:     54,347 (15.9%)
                     iseq_arity_error:     30,684 ( 9.0%)
                    klass_megamorphic:     27,879 ( 8.2%)
                  iseq_ruby2_keywords:     25,024 ( 7.3%)
                       iseq_has_no_kw:     17,298 ( 5.1%)
            args_splat_cfunc_var_args:     16,251 ( 4.8%)
                             kw_splat:     12,993 ( 3.8%)
    iseq_has_rest_and_splat_not_equal:     12,611 ( 3.7%)
                      iseq_has_kwrest:      7,320 ( 2.1%)
             iseq_missing_optional_kw:      4,054 ( 1.2%)
                 iseq_has_rest_and_kw:      2,173 ( 0.6%)
               args_splat_cfunc_zuper:      2,002 ( 0.6%)
                        iseq_has_post:      1,988 ( 0.6%)
                cfunc_ruby_array_varg:      1,364 ( 0.4%)
                             keywords:        102 ( 0.0%)
      args_splat_cfunc_ruby2_keywords:         62 ( 0.0%)
                      args_splat_ivar:         49 ( 0.0%)
           iseq_has_rest_and_optional:         15 ( 0.0%)
                          send_getter:         12 ( 0.0%)
                        zsuper_method:          9 ( 0.0%)
                  args_splat_opt_call:          5 ( 0.0%)
          splatarray_length_not_equal:          2 ( 0.0%)
                      ivar_set_method:          2 ( 0.0%)
                    bmethod_block_arg:          2 ( 0.0%)
invokeblock exit reasons: 
      proc:      2,332 (92.8%)
    symbol:        182 ( 7.2%)
invokesuper exit reasons: 
    me_changed:      4,790 (96.0%)
         block:        201 ( 4.0%)
leave exit reasons: 
        interp_return:  1,795,066 (97.6%)
    start_pc_non_zero:     43,885 ( 2.4%)
         se_interrupt:         33 ( 0.0%)
getblockparamproxy exit reasons: 
    block_param_modified:          3 (100.0%)
getinstancevariable exit reasons:
    (all relevant counters are zero)
setinstancevariable exit reasons:
    (all relevant counters are zero)
opt_aref exit reasons: 
    (all relevant counters are zero)
expandarray exit reasons: 
            splat:      9,974 (99.8%)
    rhs_too_small:         23 ( 0.2%)
opt_getinlinecache exit reasons: 
    miss:         11 (100.0%)
invalidation reasons: 
       constant_ic_fill:      2,068 (59.5%)
          method_lookup:      1,067 (30.7%)
    constant_state_bump:        340 ( 9.8%)
num_send:                 13,420,111
num_send_known_class:        489,811 ( 3.6%)
num_send_polymorphic:      1,495,022 (11.1%)
bindings_allocations:            192
bindings_set:                      0
compiled_iseq_count:           9,312
compiled_block_count:         54,532
compiled_branch_count:        87,266
block_next_count:             15,310
defer_count:                  17,222
freed_iseq_count:              4,076
invalidation_count:            3,475
constant_state_bumps:              0
get_ivar_max_depth:           41,620
inline_code_size:          9,942,928
outlined_code_size:        9,941,148
freed_code_size:                   0
code_region_size:         19,890,176
yjit_alloc_size:          17,219,579
live_context_size:         1,572,210
live_context_count:           52,407
live_page_count:               1,214
freed_page_count:                  0
code_gc_count:                     0
num_gc_obj_refs:              44,927
object_shape_count:            2,454
side_exit_count:             451,747
total_exit_count:          2,246,813
total_insns_count:        89,179,825
vm_insns_count:            8,138,076
yjit_insns_count:         81,493,496
ratio_in_yjit:                 90.9%
avg_len_in_yjit:                36.1
Top-20 most frequent exit ops (100.0% of exits):
    opt_send_without_block:    112,493 (24.9%)
               invokesuper:    103,407 (22.9%)
                      send:     98,195 (21.7%)
      opt_getconstant_path:     53,881 (11.9%)
               invokeblock:     31,198 ( 6.9%)
                  opt_aref:     14,087 ( 3.1%)
                     throw:     10,655 ( 2.4%)
               expandarray:      9,997 ( 2.2%)
             setlocal_WC_0:      8,383 ( 1.9%)
                    opt_eq:      5,012 ( 1.1%)
        getblockparamproxy:      2,271 ( 0.5%)
          putspecialobject:        727 ( 0.2%)
               objtostring:        451 ( 0.1%)
                 opt_nil_p:        327 ( 0.1%)
             definesmethod:        237 ( 0.1%)
                checkmatch:        204 ( 0.0%)
                      once:        104 ( 0.0%)
                     leave:         34 ( 0.0%)
               opt_empty_p:         30 ( 0.0%)
             setblockparam:         25 ( 0.0%)

```
</details>
    
        
<summary>Liquid Render Before</summary>
<details>

```ruby
         ***YJIT: Printing YJIT statistics on exit***
method call exit reasons: 
                  iseq_has_rest      41423 (88.7%)
    splatarray_length_not_equal       2979 ( 6.4%)
                      block_arg       1466 ( 3.1%)
                  zsuper_method        792 ( 1.7%)
          cfunc_ruby_array_varg         33 ( 0.1%)
                    send_getter         12 ( 0.0%)
       iseq_missing_optional_kw          9 ( 0.0%)
      args_splat_cfunc_var_args          8 ( 0.0%)
                       kw_splat          3 ( 0.0%)
                ivar_set_method          1 ( 0.0%)
invokeblock exit reasons: 
                proc        342 (80.9%)
    iseq_tag_changed         81 (19.1%)
invokesuper exit reasons: 
    block         83 (100.0%)
leave exit reasons: 
        interp_return     297885 (100.0%)
    start_pc_non_zero        111 ( 0.0%)
         se_interrupt          9 ( 0.0%)
getblockparamproxy exit reasons: 
    (all relevant counters are zero)
getinstancevariable exit reasons:
    megamorphic         11 (100.0%)
setinstancevariable exit reasons:
    (all relevant counters are zero)
opt_aref exit reasons: 
    (all relevant counters are zero)
expandarray exit reasons: 
    rhs_too_small         10 (100.0%)
opt_getinlinecache exit reasons: 
    (all relevant counters are zero)
invalidation reasons: 
       constant_ic_fill        579 (81.4%)
    constant_state_bump         89 (12.5%)
          method_lookup         43 ( 6.0%)
bindings_allocations:         154
bindings_set:                   0
compiled_iseq_count:         1681
compiled_block_count:       11674
compiled_branch_count:      19164
block_next_count:            4058
defer_count:                 3825
freed_iseq_count:             560
invalidation_count:           711
constant_state_bumps:           0
inline_code_size:         1849912
outlined_code_size:       1848476
freed_code_size:                0
code_region_size:         3719168
yjit_alloc_size:         23190656
live_page_count:              227
freed_page_count:               0
code_gc_count:                  0
num_gc_obj_refs:             7854
object_shape_count:           766
side_exit_count:            67762
total_exit_count:          365647
total_insns_count:       20374226
vm_insns_count:           2484644
yjit_insns_count:        17957344
ratio_in_yjit:              87.8%
avg_len_in_yjit:             48.9
Top-17 most frequent exit ops (100.0% of exits):
    opt_send_without_block:      45516 (67.2%)
                     throw:      19100 (28.2%)
                      send:       1502 (2.2%)
      opt_getconstant_path:        751 (1.1%)
               invokeblock:        423 (0.6%)
               invokesuper:        206 (0.3%)
                    opt_eq:         90 (0.1%)
                      once:         87 (0.1%)
          putspecialobject:         36 (0.1%)
                  opt_aref:         10 (0.0%)
               expandarray:         10 (0.0%)
        getblockparamproxy:          9 (0.0%)
                     leave:          9 (0.0%)
             setlocal_WC_0:          7 (0.0%)
                  opt_ltlt:          3 (0.0%)
                checkmatch:          2 (0.0%)
                   opt_mod:          1 (0.0%)

```
</details>
    
        
<summary>Liquid Render After</summary>
<details>

```ruby
         ***YJIT: Printing YJIT statistics on exit***
method call exit reasons: 
    iseq_has_rest_and_splat_not_equal:     19,699 (88.3%)
                            block_arg:      1,467 ( 6.6%)
                        zsuper_method:        792 ( 3.6%)
                    klass_megamorphic:        260 ( 1.2%)
                cfunc_ruby_array_varg:         33 ( 0.1%)
                 iseq_has_rest_and_kw:         14 ( 0.1%)
                          send_getter:         12 ( 0.1%)
             iseq_missing_optional_kw:          9 ( 0.0%)
            args_splat_cfunc_var_args:          8 ( 0.0%)
                             kw_splat:          3 ( 0.0%)
                      ivar_set_method:          1 ( 0.0%)
              iseq_has_rest_and_block:          1 ( 0.0%)
invokeblock exit reasons: 
      proc:        342 (80.9%)
    symbol:         81 (19.1%)
invokesuper exit reasons: 
    block:         83 (100.0%)
leave exit reasons: 
        interp_return:    278,208 (100.0%)
    start_pc_non_zero:        111 ( 0.0%)
         se_interrupt:         13 ( 0.0%)
getblockparamproxy exit reasons: 
    (all relevant counters are zero)
getinstancevariable exit reasons:
    megamorphic:          5 (100.0%)
setinstancevariable exit reasons:
    (all relevant counters are zero)
opt_aref exit reasons: 
    (all relevant counters are zero)
expandarray exit reasons: 
    rhs_too_small:         10 (100.0%)
opt_getinlinecache exit reasons: 
    (all relevant counters are zero)
invalidation reasons: 
       constant_ic_fill:        583 (81.3%)
    constant_state_bump:         91 (12.7%)
          method_lookup:         43 ( 6.0%)
num_send:                  3,017,232
num_send_known_class:        135,739 ( 4.5%)
num_send_polymorphic:        582,852 (19.3%)
bindings_allocations:            154
bindings_set:                      0
compiled_iseq_count:           1,682
compiled_block_count:         11,963
compiled_branch_count:        19,758
block_next_count:              4,242
defer_count:                   3,919
freed_iseq_count:                560
invalidation_count:              717
constant_state_bumps:              0
get_ivar_max_depth:              443
inline_code_size:          1,998,732
outlined_code_size:        1,996,440
freed_code_size:                   0
code_region_size:          3,997,696
yjit_alloc_size:           5,901,691
live_context_size:           551,340
live_context_count:           18,378
live_page_count:                 244
freed_page_count:                  0
code_gc_count:                     0
num_gc_obj_refs:               7,942
object_shape_count:              768
side_exit_count:              42,931
total_exit_count:            321,139
total_insns_count:        20,325,641
vm_insns_count:            2,408,753
yjit_insns_count:         17,959,819
ratio_in_yjit:                 88.1%
avg_len_in_yjit:                55.8
Top-16 most frequent exit ops (100.0% of exits):
    opt_send_without_block:     20,804 (48.5%)
                     throw:     19,105 (44.5%)
                      send:      1,495 ( 3.5%)
      opt_getconstant_path:        753 ( 1.8%)
               invokeblock:        423 ( 1.0%)
                    opt_eq:         90 ( 0.2%)
                      once:         87 ( 0.2%)
               invokesuper:         84 ( 0.2%)
          putspecialobject:         36 ( 0.1%)
                     leave:         13 ( 0.0%)
                  opt_aref:         11 ( 0.0%)
               expandarray:         10 ( 0.0%)
        getblockparamproxy:          9 ( 0.0%)
             setlocal_WC_0:          7 ( 0.0%)
                  opt_ltlt:          2 ( 0.0%)
                checkmatch:          2 ( 0.0%)

```
</details>








