### PR TITLE
YJIT: Delete stale `frozen_bytes` related code

### DIFF
--- a/yjit/src/asm/mod.rs
+++ b/yjit/src/asm/mod.rs
@@ -611,11 +611,6 @@ impl CodeBlock {
         // This currently patches every ISEQ, which works, but in the future,
         // we could limit that to patch only on-stack ISEQs for optimizing code GC.
         rb_yjit_tracing_invalidate_all();
-        // When code GC runs next time, we could have reused pages in between
-        // invalidated pages. To invalidate them, we skip freezing them here.
-        // We free or not reuse the bytes frozen by any past invalidation, so this
-        // can be safely reset to pass the frozen bytes check on invalidation.
-        CodegenGlobals::set_inline_frozen_bytes(0);
 
         // Assert that all code pages are freeable
         assert_eq!(

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -7662,12 +7662,6 @@ pub struct CodegenGlobals {
     /// For implementing global code invalidation
     global_inval_patches: Vec<CodepagePatch>,
 
-    /// For implementing global code invalidation. The number of bytes counting from the beginning
-    /// of the inline code block that should not be changed. After patching for global invalidation,
-    /// no one should make changes to the invalidated code region anymore. This is used to
-    /// break out of invalidation race when there are multiple ractors.
-    inline_frozen_bytes: usize,
-
     // Methods for generating code for hardcoded (usually C) methods
     method_codegen_table: HashMap<usize, MethodGenFn>,
 
@@ -7766,7 +7760,6 @@ impl CodegenGlobals {
             outline_full_cfunc_return_pos: cfunc_exit_code,
             branch_stub_hit_trampoline,
             global_inval_patches: Vec::new(),
-            inline_frozen_bytes: 0,
             method_codegen_table: HashMap::new(),
             ocb_pages,
             code_gc_count: 0,
@@ -7894,14 +7887,6 @@ impl CodegenGlobals {
     pub fn take_global_inval_patches() -> Vec<CodepagePatch> {
         let globals = CodegenGlobals::get_instance();
         mem::take(&mut globals.global_inval_patches)
-    }
-
-    pub fn get_inline_frozen_bytes() -> usize {
-        CodegenGlobals::get_instance().inline_frozen_bytes
-    }
-
-    pub fn set_inline_frozen_bytes(frozen_bytes: usize) {
-        CodegenGlobals::get_instance().inline_frozen_bytes = frozen_bytes;
     }
 
     pub fn get_outline_full_cfunc_return_pos() -> CodePtr {

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -1820,14 +1820,6 @@ pub fn gen_entry_point(iseq: IseqPtr, ec: EcPtr) -> Option<CodePtr> {
 
 /// Generate code for a branch, possibly rewriting and changing the size of it
 fn regenerate_branch(cb: &mut CodeBlock, branch: &mut Branch) {
-    // FIXME
-    /*
-    if (branch->start_addr < cb_get_ptr(cb, yjit_codepage_frozen_bytes)) {
-        // Generating this branch would modify frozen bytes. Do nothing.
-        return;
-    }
-    */
-
     // Remove old comments
     if let (Some(start_addr), Some(end_addr)) = (branch.start_addr, branch.end_addr) {
         cb.remove_comments(start_addr, end_addr)
@@ -2425,9 +2417,6 @@ pub fn invalidate_block_version(blockref: &BlockRef) {
             // Some blocks exit on entry. Patching a jump to the entry at the
             // entry makes an infinite loop.
         } else {
-            // TODO(alan)
-            // if (block.start_addr >= cb_get_ptr(cb, yjit_codepage_frozen_bytes)) // Don't patch frozen code region
-
             // Patch in a jump to block.entry_exit.
 
             let cur_pos = cb.get_write_ptr();
@@ -2467,12 +2456,6 @@ pub fn invalidate_block_version(blockref: &BlockRef) {
         if let Some(incoming_block) = &incoming_target.get_block() {
             assert_eq!(blockref, incoming_block);
         }
-
-        // TODO(alan):
-        // Don't patch frozen code region
-        // if (branch.start_addr < cb_get_ptr(cb, yjit_codepage_frozen_bytes)) {
-        //     continue;
-        // }
 
         // Create a stub for this branch target or rewire it to a valid block
         set_branch_target(target_idx as u32, block.blockid, &block.ctx, branchref, &mut branch, ocb);

--- a/yjit/src/invariants.rs
+++ b/yjit/src/invariants.rs
@@ -546,17 +546,6 @@ pub extern "C" fn rb_yjit_tracing_invalidate_all() {
         cb.set_pos(old_pos);
         cb.set_dropped_bytes(old_dropped_bytes);
 
-        // Freeze invalidated part of the codepage. We only want to wait for
-        // running instances of the code to exit from now on, so we shouldn't
-        // change the code. There could be other ractors sleeping in
-        // branch_stub_hit(), for example. We could harden this by changing memory
-        // protection on the frozen range.
-        assert!(
-            CodegenGlobals::get_inline_frozen_bytes() <= old_pos,
-            "frozen bytes should increase monotonically"
-        );
-        CodegenGlobals::set_inline_frozen_bytes(old_pos);
-
         CodegenGlobals::get_outlined_cb()
             .unwrap()
             .mark_all_executable();


### PR DESCRIPTION
The code and comments in there have been disabled by comments for a long
time. The issues that the counter used to solve are now solved more
comprehensively by "runningness" [tracking][1] introduced by Code GC
and [delayed deallocation][2].

Having a single counter doesn't fit our current model where code pages
that could be touched or not are interleaved, anyway.

Just delete the code.

[1]: https://github.com/ruby/ruby/commit/e7c71c6c9271b0c29f210769159090e17128e740
[2]: https://github.com/ruby/ruby/commit/a0b0365e905e1ac51998ace7e6fc723406a2f157
