### PR TITLE
YJIT: shrink stack_size/sp_offet to u8/i8

### DIFF
--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -73,7 +73,7 @@ pub enum Opnd
     InsnOut{ idx: usize, num_bits: u8 },
 
     // Pointer to a slot on the VM stack
-    Stack { idx: i32, sp_offset: i16, num_bits: u8 },
+    Stack { idx: i32, sp_offset: i8, num_bits: u8 },
 
     // Low-level operands, for lowering
     Imm(i64),           // Raw signed immediate

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -319,7 +319,7 @@ fn verify_ctx(jit: &JITState, ctx: &Context) {
     }
 
     // Verify stack operand types
-    let top_idx = cmp::min(ctx.get_stack_size(), MAX_TEMP_TYPES as u16);
+    let top_idx = cmp::min(ctx.get_stack_size(), MAX_TEMP_TYPES as u8);
     for i in 0..top_idx {
         let (learned_mapping, learned_type) = ctx.get_opnd_mapping(StackOpnd(i));
         let stack_val = jit.peek_at_stack(ctx, i as isize);
@@ -5854,7 +5854,7 @@ fn gen_send_iseq(
 
     // Set the argument types in the callee's context
     for arg_idx in 0..argc {
-        let stack_offs: u16 = (argc - arg_idx - 1).try_into().unwrap();
+        let stack_offs: u8 = (argc - arg_idx - 1).try_into().unwrap();
         let arg_type = ctx.get_opnd_type(StackOpnd(stack_offs));
         callee_ctx.set_local_type(arg_idx.try_into().unwrap(), arg_type);
     }

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -340,13 +340,13 @@ pub enum YARVOpnd {
     SelfOpnd,
 
     // Temporary stack operand with stack index
-    StackOpnd(u16),
+    StackOpnd(u8),
 }
 
 impl From<Opnd> for YARVOpnd {
     fn from(value: Opnd) -> Self {
         match value {
-            Opnd::Stack { idx, .. } => StackOpnd(idx as u16),
+            Opnd::Stack { idx, .. } => StackOpnd(idx.try_into().unwrap()),
             _ => unreachable!("{:?} cannot be converted to YARVOpnd", value)
         }
     }
@@ -358,11 +358,11 @@ impl From<Opnd> for YARVOpnd {
 #[derive(Clone, Default, PartialEq, Debug)]
 pub struct Context {
     // Number of values currently on the temporary stack
-    stack_size: u16,
+    stack_size: u8,
 
     // Offset of the JIT SP relative to the interpreter SP
     // This represents how far the JIT's SP is from the "real" SP
-    sp_offset: i16,
+    sp_offset: i8,
 
     // Depth of this block in the sidechain (eg: inline-cache chain)
     chain_depth: u8,
@@ -1265,15 +1265,15 @@ impl Block {
 }
 
 impl Context {
-    pub fn get_stack_size(&self) -> u16 {
+    pub fn get_stack_size(&self) -> u8 {
         self.stack_size
     }
 
-    pub fn get_sp_offset(&self) -> i16 {
+    pub fn get_sp_offset(&self) -> i8 {
         self.sp_offset
     }
 
-    pub fn set_sp_offset(&mut self, offset: i16) {
+    pub fn set_sp_offset(&mut self, offset: i8) {
         self.sp_offset = offset;
     }
 
@@ -1359,8 +1359,8 @@ impl Context {
             }
         }
 
-        self.stack_size -= n as u16;
-        self.sp_offset -= n as i16;
+        self.stack_size -= n as u8;
+        self.sp_offset -= n as i8;
 
         return top;
     }
@@ -1368,7 +1368,7 @@ impl Context {
     pub fn shift_stack(&mut self, argc: usize) {
         assert!(argc < self.stack_size.into());
 
-        let method_name_index = (self.stack_size - argc as u16 - 1) as usize;
+        let method_name_index = (self.stack_size as usize) - (argc as usize) - 1;
 
         for i in method_name_index..(self.stack_size - 1) as usize {
 


### PR DESCRIPTION
Small refactoring to save two bytes on `Context` objects.

The difference is too small to see in the `yjit_alloc_size` metric, falls below the noise threshold, but I figure that if it passes the CI, it might still be good to merge this, because it gives us more flexibility for other context representations as well.