### PR TITLE
YJIT: Fix a cargo test warning on x86_64

### DIFF
--- a/yjit/src/asm/mod.rs
+++ b/yjit/src/asm/mod.rs
@@ -687,6 +687,7 @@ impl CodeBlock {
     }
 
     /// Stubbed CodeBlock for testing conditions that can arise due to code GC. Can't execute generated code.
+    #[cfg(target_arch = "aarch64")]
     pub fn new_dummy_with_freed_pages(mut freed_pages: Vec<usize>) -> Self {
         use std::ptr::NonNull;
         use crate::virtualmem::*;


### PR DESCRIPTION
This fixes:
```
$ cargo test
   Compiling yjit v0.1.0 (/home/k0kubun/src/github.com/ruby/ruby/yjit)
warning: associated function `new_dummy_with_freed_pages` is never used
   --> src/asm/mod.rs:690:12
    |
690 |     pub fn new_dummy_with_freed_pages(mut freed_pages: Vec<usize>) -> Self {
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(dead_code)]` on by default
```

on x86_64.