### PR TITLE
Proof of concept: shape iv ancestor search

### DIFF
--- a/shape.h
+++ b/shape.h
@@ -137,6 +137,7 @@ rb_shape_t* rb_shape_get_shape_by_id(shape_id_t shape_id);
 shape_id_t rb_shape_get_shape_id(VALUE obj);
 rb_shape_t * rb_shape_get_next_iv_shape(rb_shape_t * shape, ID id);
 bool rb_shape_get_iv_index(rb_shape_t * shape, ID id, attr_index_t * value);
+bool rb_shape_get_iv_index_with_hint(rb_shape_t * shape, ID id, attr_index_t * value, shape_id_t shape_id_hint, attr_index_t index_hint);
 bool rb_shape_obj_too_complex(VALUE obj);
 MJIT_SYMBOL_EXPORT_END
 

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1273,7 +1273,9 @@ vm_getivar(VALUE obj, ID id, const rb_iseq_t *iseq, IVC ic, const struct rb_call
             }
         }
         else {
-            if (rb_shape_get_iv_index(shape, id, &index)) {
+            //fprintf(stderr, "searching for shape %i prev: %i\n", shape_id, cached_id);
+            //if (rb_shape_get_iv_index(shape, id, &index)) {
+            if (rb_shape_get_iv_index_with_hint(shape, id, &index, cached_id, index)) {
                 // This fills in the cache with the shared cache object.
                 // "ent" is the shared cache object
                 fill_ivar_cache(iseq, ic, cc, is_attr, index, shape_id);


### PR DESCRIPTION
_Opening this as draft because I'm not sure of the idea, but wanted to share it early. I haven't benchmarked realistic code or profiled or optimized yet._

This implements `rb_shape_get_iv_index_with_hint`: a version of rb_shape_get_iv_index which uses a previous shape with a valid index for the given IV in order to speed up searches on a IV inline cache miss.

This works by walking up both the hint shape's and current shape's tree branches in parallel until they meet at a common ancestor. If the common ancestor is deeper than the edge name we're looking for we can skip the remainder of the search. We also check for the edge name as we search.

The thinking behind this is that in many cases we have different, but very similar shapes, who share the common ancestor defining the IV we're looking for. This should also work well for a frozen version of a shape.

This is significantly faster when the divergence between the current and hint shape is shallow, but when it is not (there is no relation between the two shapes) it still resorts to a linear scan. The full scan is slower with this, as more work is being done, but I believe not 2x slower (the LL means we'll be stalling all the time on memory so walking two lists in parallel isn't _so_ bad).

Benchmark: https://gist.github.com/jhawthorn/e9db7a1443eaa957cef772dccdc14d9a

With a shallow tree divergence

before: `ruby --disable-gems test_shape_search.rb  1.64s user 0.00s system 99% cpu 1.648 total`
after: `./miniruby test_shape_search.rb  0.67s user 0.00s system 99% cpu 0.666 total`

With a deep tree divergence (worse, assumed uncommon)

before: `ruby --disable-gems test_shape_search_deep.rb  1.64s user 0.00s system 99% cpu 1.643 total`
after: `./miniruby test_shape_search_deep.rb  1.88s user 0.01s system 99% cpu 1.889 total`


cc @tenderlove @jemmaissroff 