### PR TITLE
Expand the test directory to real path

### DIFF
--- a/tool/test/runner.rb
+++ b/tool/test/runner.rb
@@ -18,6 +18,6 @@ when __FILE__
 when "-e"
   # No default directory
 else
-  dir = File.expand_path("..", $0)
+  dir = File.realdirpath("..", $0)
 end
 exit Test::Unit::AutoRunner.run(true, dir)


### PR DESCRIPTION
When the test source directory path contains symbolic links, that directory might be placed earlier in the result of `IRB::InputCompletor.retrieve_gem_and_system_load_path`, than other directories in the source tree that are expanded to the real path.  In that case, the test file in "csv" under the test directory of csv gem instead of the library path will be the first candidate, in `TestIRB::TestCompletion#test_complete_require_library_name_first`.

```
<"'csv"> expected but was
<"'csv/helper">.
```