### PR TITLE
rb_str_modify_expand: clear the string coderange

### DIFF
--- a/string.c
+++ b/string.c
@@ -2473,6 +2473,7 @@ rb_str_modify_expand(VALUE str, long expand)
     else if (expand > 0) {
         RESIZE_CAPA_TERM(str, len + expand, termlen);
     }
+    ENC_CODERANGE_CLEAR(str);
 }
 
 /* As rb_str_modify(), but don't clear coderange */


### PR DESCRIPTION
[[Bug #19468]](https://bugs.ruby-lang.org/issues/19468)

b0b9f7201acab05c2a3ad92c3043a1f01df3e17f erroneously stopped clearing the coderange.

Since `rb_str_modify` clears it, `rb_str_modify_expand` should too.

