### PR TITLE
Implement embedded TypedData objects 

### DIFF
--- a/error.c
+++ b/error.c
@@ -1322,7 +1322,7 @@ rb_check_typeddata(VALUE obj, const rb_data_type_t *data_type)
         actual = rb_str_new_cstr(name); /* or rb_fstring_cstr? not sure... */
     }
     else {
-        return DATA_PTR(obj);
+        return RTYPEDDATA_GET_DATA(obj);
     }
 
     const char *expected = data_type->wrap_struct_name;

--- a/include/ruby/internal/core/rtypeddata.h
+++ b/include/ruby/internal/core/rtypeddata.h
@@ -114,6 +114,8 @@
 #define RUBY_TYPED_PROMOTED1         RUBY_TYPED_PROMOTED1
 /** @endcond */
 
+#define TYPED_DATA_EMBEDDED 2
+
 /**
  * @private
  *
@@ -136,6 +138,8 @@ rbimpl_typeddata_flags {
      * would better leave it unspecified.
      */
     RUBY_TYPED_FREE_IMMEDIATELY = 1,
+
+    RUBY_TYPED_EMBEDDABLE = 2,
 
     /**
      * This flag has something to do with Ractor.  Multiple Ractors run without
@@ -460,7 +464,7 @@ RBIMPL_SYMBOL_EXPORT_END()
  */
 #define TypedData_Make_Struct0(result, klass, type, size, data_type, sval) \
     VALUE result = rb_data_typed_object_zalloc(klass, size, data_type);    \
-    (sval) = RBIMPL_CAST((type *)RTYPEDDATA_DATA(result));                  \
+    (sval) = RTYPEDDATA_GET_DATA(result); \
     RBIMPL_CAST(/*suppress unused variable warnings*/(void)(sval))
 
 /**
@@ -511,6 +515,36 @@ RBIMPL_SYMBOL_EXPORT_END()
 #define TypedData_Get_Struct(obj,type,data_type,sval) \
     ((sval) = RBIMPL_CAST((type *)rb_check_typeddata((obj), (data_type))))
 
+static inline bool
+RTYPEDDATA_EMBEDDED_P(VALUE obj)
+{
+#if RUBY_DEBUG
+    if (RB_UNLIKELY(!RB_TYPE_P(obj, RUBY_T_DATA))) {
+        Check_Type(obj, RUBY_T_DATA);
+        RBIMPL_UNREACHABLE_RETURN(false);
+    }
+#endif
+
+    return RTYPEDDATA(obj)->typed_flag & TYPED_DATA_EMBEDDED;
+}
+
+static inline void *
+RTYPEDDATA_GET_DATA(VALUE obj)
+{
+#if RUBY_DEBUG
+    if (RB_UNLIKELY(!RB_TYPE_P(obj, RUBY_T_DATA))) {
+        Check_Type(obj, RUBY_T_DATA);
+        RBIMPL_UNREACHABLE_RETURN(false);
+    }
+#endif
+
+    /* We reuse the data pointer in embedded TypedData. We can't use offsetof
+     * since RTypedData a non-POD type in C++. */
+    const size_t embedded_typed_data_size = sizeof(struct RTypedData) - sizeof(void *);
+
+    return RTYPEDDATA_EMBEDDED_P(obj) ? (char *)obj + embedded_typed_data_size : RTYPEDDATA(obj)->data;
+}
+
 RBIMPL_ATTR_PURE()
 RBIMPL_ATTR_ARTIFICIAL()
 /**
@@ -527,7 +561,8 @@ RBIMPL_ATTR_ARTIFICIAL()
 static inline bool
 rbimpl_rtypeddata_p(VALUE obj)
 {
-    return RTYPEDDATA(obj)->typed_flag == 1;
+    VALUE typed_flag = RTYPEDDATA(obj)->typed_flag;
+    return typed_flag != 0 && typed_flag <= 3;
 }
 
 RBIMPL_ATTR_PURE_UNLESS_DEBUG()


### PR DESCRIPTION
This PR adds a new flag RUBY_TYPED_EMBEDDABLE that allows the data of a TypedData object to be embedded after the object itself. This will improve cache locality and allow us to save the 8 byte data pointer.

This PR also implements this feature on Time objects, which drops the total size of a Time object from 86 bytes to 80 bytes.

This PR is based on top of #7438.

Co-Authored-By: @byroot
