### PR TITLE
Expose the address of MJIT Pointers

### DIFF
--- a/lib/ruby_vm/mjit/c_pointer.rb
+++ b/lib/ruby_vm/mjit/c_pointer.rb
@@ -253,6 +253,11 @@ module RubyVM::MJIT # :nodoc: all
           [value.to_i].pack(Fiddle::PackInfo::PACK_MAP[Fiddle::TYPE_VOIDP])
       end
 
+      # Get a raw address
+      def to_i
+        @addr
+      end
+
       private
 
       def dest_addr


### PR DESCRIPTION
This way we can manually dereference pointers with Fiddle.

Background: I'm trying to access the local table array on instruction sequence bodies.  I guess we can't unwrap them because it's a `ID *` and the length of the array is unknown?  I'm not sure that's just my guess.  Anyway, this adds a reader to `Pointer` so we can manually de-reference the list.

Here's sample code to show how I'm using it (btw, `hacks` comes from [here](https://github.com/tenderlove/hacks)):

```ruby
require "hacks" # to get RTypedData layout
require "fiddle"

module Fiddle
  def self.read_ptr ptr, offset
    Fiddle::Pointer.new(ptr)[offset, Fiddle::SIZEOF_VOIDP].unpack1("l!")
  end

  class CArray # :nodoc:
    def self.unpack ptr, len, type
      size = Fiddle::PackInfo::SIZE_MAP[type]
      bytesize = size * len
      ptr[0, bytesize].unpack("#{Fiddle::PackInfo::PACK_MAP[type]}#{len}")
    end
  end
end

C = RubyVM::MJIT.const_get(:C)

# Convert a Method object in to an rb_iseq_t from MJIT
def method_to_iseq_t method
  rb_iseq = RubyVM::InstructionSequence.of(method)
  addr = Fiddle.dlwrap(rb_iseq)
  offset = Hacks::STRUCTS["RTypedData"]["data"][0]
  addr = Fiddle.read_ptr addr, offset

  C.rb_iseq_t.new addr
end

class Foo
  def foo a, b
    a + b
  end
end

rb_iseq = method_to_iseq_t(Foo.instance_method(:foo))

# Accessing the local table doesn't work
begin
  rb_iseq.body.local_table
rescue NoMethodError
end

# I want the address of the pointer so I can dereference it myself
addr = Fiddle.read_ptr rb_iseq.body[:local_table].addr, 0

# Unpack the local table array
list = Fiddle::CArray.unpack(Fiddle::Pointer.new(addr),
                             rb_iseq.body.local_table_size,
                             Fiddle::TYPE_UINTPTR_T)

p list.map { Hacks.rb_id2sym _1 } # => [:a, :b]
```

I need the `addr` method so the above code can work.  Thanks!