### PR TITLE
Split a workflow for annocheck

### DIFF
--- a/.github/workflows/annocheck.yml
+++ b/.github/workflows/annocheck.yml
@@ -1,0 +1,152 @@
+name: Annocheck
+
+on:
+  push:
+    paths-ignore:
+      - 'doc/**'
+      - '**/man'
+      - '**.md'
+      - '**.rdoc'
+      - '**/.document'
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
+      - '**/man'
+      - '**.rdoc'
+      - '**/.document'
+
+concurrency:
+  group: ${{ github.workflow }} / ${{ startsWith(github.event_name, 'pull') && github.ref_name || github.sha }}
+  cancel-in-progress: ${{ startsWith(github.event_name, 'pull') }}
+
+# GitHub actions does not support YAML anchors.  This creative use of
+# environment variables (plus the "echo $GITHUB_ENV" hack) is to reroute that
+# restriction.
+env:
+  default_cc: clang-15
+  append_cc: ''
+
+  # -O1 is faster than -O3 in our tests... Majority of time are consumed trying
+  # to optimize binaries.  Also GitHub Actions run on relatively modern CPUs
+  # compared to, say, GCC 4 or Clang 3.  We don't specify `-march=native`
+  # because compilers tend not understand what the CPU is.
+  optflags: '-O1'
+
+  # -g0 disables backtraces when SEGV.  Do not set that.
+  debugflags: '-ggdb3'
+
+  default_configure: >-
+    --enable-debug-env
+    --disable-install-doc
+    --with-ext=-test-/cxxanyargs,+
+  append_configure: >-
+    --without-valgrind
+    --without-jemalloc
+    --without-gmp
+
+  CONFIGURE_TTY: never
+  GITPULLOPTIONS: --no-tags origin ${{github.ref}}
+  RUBY_DEBUG: ci rgengc
+  RUBY_TESTOPTS: >-
+    -q
+    --color=always
+    --tty=no
+
+permissions:
+  contents: read
+
+jobs:
+  compile:
+    strategy:
+      fail-fast: false
+      matrix:
+        env:
+          - {}
+        entry:
+          - name: 'gcc-11 annocheck'
+            container: gcc-11
+            env:
+              # Minimal flags to pass the check.
+              default_cc: 'gcc-11 -fcf-protection -Wa,--generate-missing-build-notes=yes'
+              optflags: '-O2'
+              LDFLAGS: '-Wl,-z,now'
+              # FIXME: Drop skipping options
+              # https://bugs.ruby-lang.org/issues/18061
+              # https://sourceware.org/annobin/annobin.html/Test-pie.html
+              TEST_ANNOCHECK_OPTS: "--skip-pie --skip-gaps"
+            check: true
+
+    name: ${{ matrix.entry.name }}
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/ruby/ruby-ci-image:${{ matrix.entry.container || matrix.entry.env.default_cc || 'clang-15' }}
+      options: --user root
+    if: ${{ !contains(github.event.head_commit.message, '[DOC]') && !contains(github.event.pull_request.labels.*.name, 'Documentation') }}
+    env: ${{ matrix.entry.env || matrix.env }}
+    steps:
+      - run: id
+        working-directory:
+      - run: mkdir build
+        working-directory:
+      - name: setenv
+        run: |
+          echo "GNUMAKEFLAGS=-sj$((1 + $(nproc --all)))" >> $GITHUB_ENV
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        with:
+          path: src
+      - uses: actions/cache@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0 # v3.2.6
+        with:
+          path: src/.downloaded-cache
+          key: downloaded-cache
+      - name: autogen
+        run: |
+          if [ ! -f ./autogen.sh ]; then
+            ls -la
+          fi
+          ./autogen.sh
+        working-directory: src
+      - name: Run configure
+        run: >
+          ../src/configure -C ${default_configure} ${append_configure}
+          --${{
+            matrix.entry.crosshost && 'host' || 'with-gcc'
+          }}=${{
+            matrix.entry.crosshost || '"${default_cc}${append_cc:+ $append_cc}"'
+          }}
+          --${{ matrix.entry.shared || 'enable' }}-shared
+      - run: make extract-extlibs
+      - run: make incs
+      - run: make showflags
+      - run: make
+      - run: make leaked-globals
+      - run: make test
+      - run: make install
+        if: ${{ matrix.entry.check }}
+      - run: make test-tool
+        if: ${{ matrix.entry.check }}
+      - run: make test-all TESTS='-- ruby -ext-'
+        if: ${{ matrix.entry.check }}
+      - run: make test-spec
+        env:
+          CHECK_LEAKS: true
+        if: ${{ matrix.entry.check }}
+      - run: make test-annocheck
+        if: ${{ matrix.entry.check && endsWith(matrix.entry.name, 'annocheck') }}
+
+      - uses: ruby/action-slack@b6882ea6ef8f556f9f9af9ec1220d3f1ced74acf # v3.0.0
+        with:
+          payload: |
+            {
+              "ci": "GitHub Actions",
+              "env": "${{ github.workflow }} / ${{ matrix.entry.name }}",
+              "url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+              "commit": "${{ github.sha }}",
+              "branch": "${{ github.ref_name }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SIMPLER_ALERTS_URL }} # ruby-lang slack: ruby/simpler-alerts-bot
+        if: ${{ failure() && github.event_name == 'push' }}
+
+defaults:
+  run:
+    working-directory: build

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -79,18 +79,6 @@ jobs:
               optflags: '-O2'
             shared: disable
             # check: true
-          - name: 'gcc-11 annocheck'
-            container: gcc-11
-            env:
-              # Minimal flags to pass the check.
-              default_cc: 'gcc-11 -fcf-protection -Wa,--generate-missing-build-notes=yes'
-              optflags: '-O2'
-              LDFLAGS: '-Wl,-z,now'
-              # FIXME: Drop skipping options
-              # https://bugs.ruby-lang.org/issues/18061
-              # https://sourceware.org/annobin/annobin.html/Test-pie.html
-              TEST_ANNOCHECK_OPTS: "--skip-pie --skip-gaps"
-            check: true
           - { name: clang-16,  env: { default_cc: clang-16 } }
           - { name: clang-15,  env: { default_cc: clang-15 } }
           - { name: clang-14,  env: { default_cc: clang-14 } }


### PR DESCRIPTION
It's not really about different compilers. It seems confusing to have this in compilers.yml.

This change only forks the entire workflow and modifies only matrix entries. If this doesn't work, it did not work before either.

ref: https://github.com/ruby/ruby/pull/5900