### PR TITLE
YJIT: Bump SEND_MAX_DEPTH to 10

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -1866,8 +1866,8 @@ pub const SET_IVAR_MAX_DEPTH: i32 = 10;
 // hashes and arrays
 pub const OPT_AREF_MAX_CHAIN_DEPTH: i32 = 2;
 
-// up to 5 different classes
-pub const SEND_MAX_DEPTH: i32 = 5;
+// up to 10 different classes
+pub const SEND_MAX_DEPTH: i32 = 10;
 
 // up to 20 different methods for send
 pub const SEND_MAX_CHAIN_DEPTH: i32 = 20;


### PR DESCRIPTION
On SFR, this reduced `send_klass_megamorphic / side_exit_count` from 20.5% to 15.0%. 

`send_klass_megamorphic` is not that common on railsbench, so it had no significant impact there.