### PR TITLE
YJIT: Merge lea and mov on x86_64 when possible

### DIFF
--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -1230,6 +1230,7 @@ impl AssemblerDrainingIterator {
         self.insns.next().map(|insn| (index, insn))
     }
 
+    /// Returns the next instruction without incrementing the iterator's index.
     pub fn peek(&mut self) -> Option<&Insn> {
         self.insns.peek()
     }

--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -1179,7 +1179,7 @@ impl Assembler
 /// A struct that allows iterating through an assembler's instructions and
 /// consuming them as it iterates.
 pub struct AssemblerDrainingIterator {
-    insns: std::vec::IntoIter<Insn>,
+    insns: std::iter::Peekable<std::vec::IntoIter<Insn>>,
     index: usize,
     indices: Vec<usize>
 }
@@ -1187,7 +1187,7 @@ pub struct AssemblerDrainingIterator {
 impl AssemblerDrainingIterator {
     fn new(asm: Assembler) -> Self {
         Self {
-            insns: asm.insns.into_iter(),
+            insns: asm.insns.into_iter().peekable(),
             index: 0,
             indices: Vec::default()
         }
@@ -1228,6 +1228,10 @@ impl AssemblerDrainingIterator {
         let index = self.index;
         self.index += 1;
         self.insns.next().map(|insn| (index, insn))
+    }
+
+    pub fn peek(&mut self) -> Option<&Insn> {
+        self.insns.peek()
     }
 }
 

--- a/yjit/src/backend/x86_64/mod.rs
+++ b/yjit/src/backend/x86_64/mod.rs
@@ -105,6 +105,9 @@ impl Assembler
     // These are the callee-saved registers in the x86-64 SysV ABI
     // RBX, RSP, RBP, and R12–R15
 
+    /// Merge IR instructions for the x86 platform. As of x86_split, all `out` operands
+    /// are Opnd::Out, but you sometimes want to use Opnd::Reg for example to shorten the
+    /// generated code, which is what this pass does.
     fn x86_merge(mut self) -> Assembler {
         let live_ranges: Vec<usize> = take(&mut self.live_ranges);
         let mut asm = Assembler::new_with_label_names(take(&mut self.label_names));


### PR DESCRIPTION
I started to look into adding optimization passes to the backend. This was one of the inefficient code I was aware of, so I worked on this first. My plan is to add more peephole optimizations to `x86_merge` over time.

## Generated code
### Before
```asm
  # save SP to CFP
  0x564019e65142: lea rcx, [rbx - 0x10]
  0x564019e65146: mov rbx, rcx
  0x564019e65149: mov qword ptr [r13 + 8], rbx
```

### After
```asm
  # save SP to CFP
  0x5634800c413f: lea rbx, [rbx - 0x10]
  0x5634800c4143: mov qword ptr [r13 + 8], rbx
```

## Code size stats
On railsbench, inline code size went down by 0.4%. I see no significant impact on its speed.

### Before

```
inline_code_size:          2,073,884
outlined_code_size:        2,073,528
```

### After

```
inline_code_size:          2,065,752
outlined_code_size:        2,065,384
```