### PR TITLE
Stop exporting symbols for MJIT

### DIFF
--- a/array.c
+++ b/array.c
@@ -881,7 +881,7 @@ VALUE
     return ary;
 }
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_ary_tmp_new_from_values(VALUE klass, long n, const VALUE *elts)
 {
     VALUE ary;
@@ -1123,7 +1123,7 @@ rb_check_array_type(VALUE ary)
     return rb_check_convert_type_with_id(ary, T_ARRAY, "Array", idTo_ary);
 }
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_check_to_array(VALUE ary)
 {
     return rb_check_convert_type_with_id(ary, T_ARRAY, "Array", idTo_a);
@@ -1655,7 +1655,7 @@ rb_ary_shift_m(int argc, VALUE *argv, VALUE ary)
     return result;
 }
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_ary_behead(VALUE ary, long n)
 {
     if (n <= 0) {
@@ -1981,7 +1981,7 @@ rb_ary_aref2(VALUE ary, VALUE b, VALUE e)
     return rb_ary_subseq(ary, beg, len);
 }
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_ary_aref1(VALUE ary, VALUE arg)
 {
     long beg, len, step;

--- a/bignum.c
+++ b/bignum.c
@@ -4541,7 +4541,7 @@ rb_uint128t2big(uint128_t n)
     return big;
 }
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_int128t2big(int128_t n)
 {
     int neg = 0;

--- a/class.c
+++ b/class.c
@@ -924,7 +924,7 @@ rb_define_class_id(ID id, VALUE super)
  * \return the value \c Class#inherited's returns
  * \pre Each of \a super and \a klass must be a \c Class object.
  */
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_class_inherited(VALUE super, VALUE klass)
 {
     ID inherited;
@@ -2306,7 +2306,7 @@ rb_define_attr(VALUE klass, const char *name, int read, int write)
     rb_attr(klass, rb_intern(name), read, write, FALSE);
 }
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_keyword_error_new(const char *error, VALUE keys)
 {
     long i = 0, len = RARRAY_LEN(keys);

--- a/compile.c
+++ b/compile.c
@@ -13194,7 +13194,7 @@ rb_ibf_load_iseq_complete(rb_iseq_t *iseq)
 }
 
 #if USE_LAZY_LOAD
-MJIT_FUNC_EXPORTED const rb_iseq_t *
+const rb_iseq_t *
 rb_iseq_complete(const rb_iseq_t *iseq)
 {
     rb_ibf_load_iseq_complete((rb_iseq_t *)iseq);

--- a/constant.h
+++ b/constant.h
@@ -43,13 +43,11 @@ VALUE rb_mod_deprecate_constant(int argc, const VALUE *argv, VALUE obj);
 void rb_free_const_table(struct rb_id_table *tbl);
 VALUE rb_const_source_location(VALUE, ID);
 
-MJIT_SYMBOL_EXPORT_BEGIN
 int rb_autoloading_value(VALUE mod, ID id, VALUE *value, rb_const_flag_t *flag);
 rb_const_entry_t *rb_const_lookup(VALUE klass, ID id);
 VALUE rb_public_const_get_at(VALUE klass, ID id);
 VALUE rb_public_const_get_from(VALUE klass, ID id);
 int rb_public_const_defined_from(VALUE klass, ID id);
 VALUE rb_const_source_location_at(VALUE, ID);
-MJIT_SYMBOL_EXPORT_END
 
 #endif /* CONSTANT_H */

--- a/debug_counter.c
+++ b/debug_counter.c
@@ -25,10 +25,8 @@ const char *const rb_debug_counter_names[] = {
 #undef RB_DEBUG_COUNTER
 };
 
-MJIT_SYMBOL_EXPORT_BEGIN
 size_t rb_debug_counter[numberof(rb_debug_counter_names)];
 void rb_debug_counter_add_atomic(enum rb_debug_counter_type type, int add);
-MJIT_SYMBOL_EXPORT_END
 
 static rb_nativethread_lock_t debug_counter_lock;
 

--- a/error.c
+++ b/error.c
@@ -187,7 +187,7 @@ rb_warning_category_update(unsigned int mask, unsigned int bits)
     warning_disabled_categories |= mask & ~bits;
 }
 
-MJIT_FUNC_EXPORTED bool
+bool
 rb_warning_category_enabled_p(rb_warning_category_t category)
 {
     return !(warning_disabled_categories & (1U << category));
@@ -867,7 +867,7 @@ rb_report_bug_valist(VALUE file, int line, const char *fmt, va_list args)
     report_bug_valist(RSTRING_PTR(file), line, fmt, NULL, args);
 }
 
-MJIT_FUNC_EXPORTED void
+void
 rb_assert_failure(const char *file, int line, const char *name, const char *expr)
 {
     FILE *out = stderr;
@@ -1582,7 +1582,7 @@ exc_set_backtrace(VALUE exc, VALUE bt)
     return rb_ivar_set(exc, id_bt, rb_check_backtrace(bt));
 }
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_exc_set_backtrace(VALUE exc, VALUE bt)
 {
     return exc_set_backtrace(exc, bt);

--- a/gc.c
+++ b/gc.c
@@ -3129,7 +3129,7 @@ rb_imemo_new_debug(enum imemo_type type, VALUE v1, VALUE v2, VALUE v3, VALUE v0,
 }
 #endif
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_class_allocate_instance(VALUE klass)
 {
     return rb_class_instance_allocate_internal(klass, T_OBJECT | ROBJECT_EMBED, RGENGC_WB_PROTECTED_OBJECT);
@@ -6526,7 +6526,7 @@ stack_check(rb_execution_context_t *ec, int water_mark)
 
 #define STACKFRAME_FOR_CALL_CFUNC 2048
 
-MJIT_FUNC_EXPORTED int
+int
 rb_ec_stack_check(rb_execution_context_t *ec)
 {
     return stack_check(ec, STACKFRAME_FOR_CALL_CFUNC);
@@ -9167,7 +9167,7 @@ rb_gc_writebarrier_unprotect(VALUE obj)
 /*
  * remember `obj' if needed.
  */
-MJIT_FUNC_EXPORTED void
+void
 rb_gc_writebarrier_remember(VALUE obj)
 {
     rb_objspace_t *objspace = &rb_objspace;
@@ -14661,7 +14661,7 @@ obj_info(VALUE obj)
 }
 #endif
 
-MJIT_FUNC_EXPORTED const char *
+const char *
 rb_obj_info(VALUE obj)
 {
     return obj_info(obj);
@@ -14674,7 +14674,7 @@ rb_obj_info_dump(VALUE obj)
     fprintf(stderr, "rb_obj_info_dump: %s\n", rb_raw_obj_info(buff, 0x100, obj));
 }
 
-MJIT_FUNC_EXPORTED void
+void
 rb_obj_info_dump_loc(VALUE obj, const char *file, int line, const char *func)
 {
     char buff[0x100];

--- a/hash.c
+++ b/hash.c
@@ -1534,7 +1534,7 @@ copy_compare_by_id(VALUE hash, VALUE basis)
     return hash;
 }
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_hash_new_with_size(st_index_t size)
 {
     VALUE ret = rb_hash_new();
@@ -1594,7 +1594,7 @@ rb_hash_dup(VALUE hash)
     return ret;
 }
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_hash_resurrect(VALUE hash)
 {
     VALUE ret = hash_dup(hash, rb_cHash, 0);
@@ -1607,7 +1607,7 @@ rb_hash_modify_check(VALUE hash)
     rb_check_frozen(hash);
 }
 
-MJIT_FUNC_EXPORTED struct st_table *
+struct st_table *
 rb_hash_tbl_raw(VALUE hash, const char *file, int line)
 {
     return ar_force_convert_table(hash, file, line);
@@ -1887,7 +1887,7 @@ rb_hash_s_create(int argc, VALUE *argv, VALUE klass)
     return hash;
 }
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_to_hash_type(VALUE hash)
 {
     return rb_convert_type_with_id(hash, T_HASH, "Hash", idTo_hash);
@@ -2078,7 +2078,7 @@ hash_stlike_lookup(VALUE hash, st_data_t key, st_data_t *pval)
     }
 }
 
-MJIT_FUNC_EXPORTED int
+int
 rb_hash_stlike_lookup(VALUE hash, st_data_t key, st_data_t *pval)
 {
     return hash_stlike_lookup(hash, key, pval);
@@ -3550,7 +3550,7 @@ keys_i(VALUE key, VALUE value, VALUE ary)
  *    h.keys # => [:foo, :bar, :baz]
  */
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_hash_keys(VALUE hash)
 {
     st_index_t size = RHASH_SIZE(hash);
@@ -3637,7 +3637,7 @@ rb_hash_values(VALUE hash)
  *  Returns +true+ if +key+ is a key in +self+, otherwise +false+.
  */
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_hash_has_key(VALUE hash, VALUE key)
 {
     return RBOOL(hash_stlike_lookup(hash, key, NULL));
@@ -4406,7 +4406,7 @@ rb_hash_compare_by_id(VALUE hash)
  *  Returns +true+ if #compare_by_identity has been called, +false+ otherwise.
  */
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_hash_compare_by_id_p(VALUE hash)
 {
     return RBOOL(RHASH_ST_TABLE_P(hash) && RHASH_ST_TABLE(hash)->type == &identhash);

--- a/hash.c
+++ b/hash.c
@@ -1607,7 +1607,7 @@ rb_hash_modify_check(VALUE hash)
     rb_check_frozen(hash);
 }
 
-struct st_table *
+RUBY_FUNC_EXPORTED struct st_table *
 rb_hash_tbl_raw(VALUE hash, const char *file, int line)
 {
     return ar_force_convert_table(hash, file, line);

--- a/id_table.c
+++ b/id_table.c
@@ -92,7 +92,7 @@ rb_id_table_init(struct rb_id_table *tbl, int capa)
     return tbl;
 }
 
-MJIT_FUNC_EXPORTED struct rb_id_table *
+struct rb_id_table *
 rb_id_table_create(size_t capa)
 {
     struct rb_id_table *tbl = ALLOC(struct rb_id_table);
@@ -223,7 +223,7 @@ hash_table_show(struct rb_id_table *tbl)
 }
 #endif
 
-MJIT_FUNC_EXPORTED int
+int
 rb_id_table_lookup(struct rb_id_table *tbl, ID id, VALUE *valp)
 {
     id_key_t key = id2key(id);
@@ -253,7 +253,7 @@ rb_id_table_insert_key(struct rb_id_table *tbl, const id_key_t key, const VALUE 
     return TRUE;
 }
 
-MJIT_FUNC_EXPORTED int
+int
 rb_id_table_insert(struct rb_id_table *tbl, ID id, VALUE val)
 {
     return rb_id_table_insert_key(tbl, id2key(id), val);

--- a/include/ruby/internal/dllexport.h
+++ b/include/ruby/internal/dllexport.h
@@ -69,17 +69,6 @@
 /* These macros are used for functions which are exported only for MJIT
    and NOT ensured to be exported in future versions. */
 
-#if ! defined(MJIT_HEADER)
-# define MJIT_FUNC_EXPORTED RUBY_FUNC_EXPORTED
-#elif ! RBIMPL_COMPILER_IS(MSVC)
-# define MJIT_FUNC_EXPORTED RUBY_FUNC_EXPORTED
-#else
-# define MJIT_FUNC_EXPORTED static
-#endif
-
-#define MJIT_SYMBOL_EXPORT_BEGIN RUBY_SYMBOL_EXPORT_BEGIN
-#define MJIT_SYMBOL_EXPORT_END   RUBY_SYMBOL_EXPORT_END
-
 /* On mswin, MJIT header transformation can't be used since cl.exe can't output
    preprocessed output preserving macros. So this `MJIT_STATIC` is needed
    to force non-static function to static on MJIT header to avoid symbol conflict. */

--- a/internal/array.h
+++ b/internal/array.h
@@ -42,7 +42,6 @@ static inline bool ARY_PTR_USING_P(VALUE ary);
 static inline void RARY_TRANSIENT_SET(VALUE ary);
 static inline void RARY_TRANSIENT_UNSET(VALUE ary);
 
-MJIT_SYMBOL_EXPORT_BEGIN
 VALUE rb_ary_tmp_new_from_values(VALUE, long, const VALUE *);
 VALUE rb_check_to_array(VALUE ary);
 VALUE rb_ary_behead(VALUE, long);
@@ -50,7 +49,6 @@ VALUE rb_ary_aref1(VALUE ary, VALUE i);
 
 struct rb_execution_context_struct;
 VALUE rb_ec_ary_new_from_values(struct rb_execution_context_struct *ec, long n, const VALUE *elts);
-MJIT_SYMBOL_EXPORT_END
 
 // YJIT needs this function to never allocate and never raise
 static inline VALUE

--- a/internal/basic_operators.h
+++ b/internal/basic_operators.h
@@ -40,9 +40,7 @@ enum ruby_basic_operators {
     BOP_LAST_
 };
 
-MJIT_SYMBOL_EXPORT_BEGIN
 RUBY_EXTERN short ruby_vm_redefined_flag[BOP_LAST_];
-MJIT_SYMBOL_EXPORT_END
 
 /* optimize insn */
 #define INTEGER_REDEFINED_OP_FLAG (1 << 0)

--- a/internal/bignum.h
+++ b/internal/bignum.h
@@ -163,11 +163,9 @@ VALUE rb_str2big_gmp(VALUE arg, int base, int badcheck);
 VALUE rb_int_parse_cstr(const char *str, ssize_t len, char **endp, size_t *ndigits, int base, int flags);
 RUBY_SYMBOL_EXPORT_END
 
-MJIT_SYMBOL_EXPORT_BEGIN
 #if defined(HAVE_INT128_T)
 VALUE rb_int128t2big(int128_t n);
 #endif
-MJIT_SYMBOL_EXPORT_END
 
 /* sign: positive:1, negative:0 */
 static inline bool

--- a/internal/class.h
+++ b/internal/class.h
@@ -148,10 +148,8 @@ static inline VALUE RCLASS_SUPER(VALUE klass);
 static inline VALUE RCLASS_SET_SUPER(VALUE klass, VALUE super);
 static inline void RCLASS_SET_INCLUDER(VALUE iclass, VALUE klass);
 
-MJIT_SYMBOL_EXPORT_BEGIN
 VALUE rb_class_inherited(VALUE, VALUE);
 VALUE rb_keyword_error_new(const char *, VALUE);
-MJIT_SYMBOL_EXPORT_END
 
 static inline rb_alloc_func_t
 RCLASS_ALLOCATOR(VALUE klass)

--- a/internal/compile.h
+++ b/internal/compile.h
@@ -29,9 +29,7 @@ int rb_vm_insn_addr2insn(const void *);
 int rb_vm_insn_decode(const VALUE encoded);
 extern bool ruby_vm_keep_script_lines;
 
-MJIT_SYMBOL_EXPORT_BEGIN
 /* iseq.c (export) */
 rb_event_flag_t rb_iseq_event_flags(const struct rb_iseq_struct *iseq, size_t pos);
-MJIT_SYMBOL_EXPORT_END
 
 #endif /* INTERNAL_COMPILE_H */

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -291,11 +291,9 @@ void *ruby_sized_xrealloc2(void *ptr, size_t new_count, size_t element_size, siz
 void ruby_sized_xfree(void *x, size_t size);
 RUBY_SYMBOL_EXPORT_END
 
-MJIT_SYMBOL_EXPORT_BEGIN
 int rb_ec_stack_check(struct rb_execution_context_struct *ec);
 void rb_gc_writebarrier_remember(VALUE obj);
 const char *rb_obj_info(VALUE obj);
-MJIT_SYMBOL_EXPORT_END
 
 #if defined(HAVE_MALLOC_USABLE_SIZE) || defined(HAVE_MALLOC_SIZE) || defined(_WIN32)
 

--- a/internal/hash.h
+++ b/internal/hash.h
@@ -107,7 +107,6 @@ VALUE rb_ident_hash_new(void);
 int rb_hash_stlike_foreach(VALUE hash, st_foreach_callback_func *func, st_data_t arg);
 RUBY_SYMBOL_EXPORT_END
 
-MJIT_SYMBOL_EXPORT_BEGIN
 VALUE rb_hash_new_with_size(st_index_t size);
 VALUE rb_hash_resurrect(VALUE hash);
 int rb_hash_stlike_lookup(VALUE hash, st_data_t key, st_data_t *pval);
@@ -117,7 +116,6 @@ VALUE rb_hash_compare_by_id_p(VALUE hash);
 
 st_table *rb_hash_tbl_raw(VALUE hash, const char *file, int line);
 #define RHASH_TBL_RAW(h) rb_hash_tbl_raw(h, __FILE__, __LINE__)
-MJIT_SYMBOL_EXPORT_END
 
 VALUE rb_hash_compare_by_id(VALUE hash);
 

--- a/internal/numeric.h
+++ b/internal/numeric.h
@@ -111,7 +111,6 @@ RUBY_SYMBOL_EXPORT_BEGIN
 /* numeric.c (export) */
 RUBY_SYMBOL_EXPORT_END
 
-MJIT_SYMBOL_EXPORT_BEGIN
 VALUE rb_flo_div_flo(VALUE x, VALUE y);
 double ruby_float_mod(double x, double y);
 VALUE rb_float_equal(VALUE x, VALUE y);
@@ -125,7 +124,6 @@ VALUE rb_int_abs(VALUE num);
 VALUE rb_int_bit_length(VALUE num);
 VALUE rb_int_uminus(VALUE num);
 VALUE rb_int_comp(VALUE num);
-MJIT_SYMBOL_EXPORT_END
 
 static inline bool
 INT_POSITIVE_P(VALUE num)

--- a/internal/object.h
+++ b/internal/object.h
@@ -27,7 +27,6 @@ RUBY_SYMBOL_EXPORT_BEGIN
 int rb_opts_exception_p(VALUE opts, int default_value);
 RUBY_SYMBOL_EXPORT_END
 
-MJIT_SYMBOL_EXPORT_BEGIN
 CONSTFUNC(VALUE rb_obj_equal(VALUE obj1, VALUE obj2));
 CONSTFUNC(VALUE rb_obj_not(VALUE obj));
 VALUE rb_obj_not_equal(VALUE obj1, VALUE obj2);
@@ -36,7 +35,6 @@ VALUE rb_false(VALUE obj);
 VALUE rb_convert_type_with_id(VALUE v, int t, const char* nam, ID mid);
 VALUE rb_obj_size(VALUE self, VALUE args, VALUE obj);
 VALUE rb_get_freeze_opt(int argc, VALUE *argv);
-MJIT_SYMBOL_EXPORT_END
 
 static inline void
 RBASIC_SET_CLASS_RAW(VALUE obj, VALUE klass)

--- a/internal/proc.h
+++ b/internal/proc.h
@@ -22,11 +22,9 @@ int rb_block_min_max_arity(int *max);
 VALUE rb_block_to_s(VALUE self, const struct rb_block *block, const char *additional_info);
 VALUE rb_callable_receiver(VALUE);
 
-MJIT_SYMBOL_EXPORT_BEGIN
 VALUE rb_func_proc_new(rb_block_call_func_t func, VALUE val);
 VALUE rb_func_lambda_new(rb_block_call_func_t func, VALUE val, int min_argc, int max_argc);
 VALUE rb_iseq_location(const struct rb_iseq_struct *iseq);
 VALUE rb_sym_to_proc(VALUE sym);
-MJIT_SYMBOL_EXPORT_END
 
 #endif /* INTERNAL_PROC_H */

--- a/internal/re.h
+++ b/internal/re.h
@@ -23,8 +23,6 @@ void rb_backref_set_string(VALUE string, long pos, long len);
 void rb_match_unbusy(VALUE);
 int rb_match_count(VALUE match);
 int rb_match_nth_defined(int nth, VALUE match);
-MJIT_SYMBOL_EXPORT_BEGIN
 VALUE rb_reg_new_ary(VALUE ary, int options);
-MJIT_SYMBOL_EXPORT_END
 
 #endif /* INTERNAL_RE_H */

--- a/internal/string.h
+++ b/internal/string.h
@@ -67,7 +67,6 @@ bool rb_str_reembeddable_p(VALUE);
 void rb_str_update_shared_ary(VALUE str, VALUE old_root, VALUE new_root);
 RUBY_SYMBOL_EXPORT_END
 
-MJIT_SYMBOL_EXPORT_BEGIN
 VALUE rb_fstring_new(const char *ptr, long len);
 VALUE rb_obj_as_string_result(VALUE str, VALUE obj);
 VALUE rb_str_opt_plus(VALUE x, VALUE y);
@@ -78,7 +77,6 @@ VALUE rb_sym_proc_call(ID mid, int argc, const VALUE *argv, int kw_splat, VALUE 
 
 struct rb_execution_context_struct;
 VALUE rb_ec_str_resurrect(struct rb_execution_context_struct *ec, VALUE str);
-MJIT_SYMBOL_EXPORT_END
 
 #define rb_fstring_lit(str) rb_fstring_new((str), rb_strlen_lit(str))
 #define rb_fstring_literal(str) rb_fstring_lit(str)

--- a/internal/thread.h
+++ b/internal/thread.h
@@ -49,8 +49,6 @@ VALUE rb_thread_io_blocking_region(rb_blocking_function_t *func, void *data1, in
 int ruby_thread_has_gvl_p(void); /* for ext/fiddle/closure.c */
 RUBY_SYMBOL_EXPORT_END
 
-MJIT_SYMBOL_EXPORT_BEGIN
 int rb_threadptr_execute_interrupts(struct rb_thread_struct *th, int blocking_timing);
-MJIT_SYMBOL_EXPORT_END
 
 #endif /* INTERNAL_THREAD_H */

--- a/internal/variable.h
+++ b/internal/variable.h
@@ -49,7 +49,6 @@ int rb_class_ivar_set(VALUE klass, ID vid, VALUE value);
 void rb_iv_tbl_copy(VALUE dst, VALUE src);
 RUBY_SYMBOL_EXPORT_END
 
-MJIT_SYMBOL_EXPORT_BEGIN
 VALUE rb_ivar_lookup(VALUE obj, ID id, VALUE undef);
 VALUE rb_gvar_get(ID);
 VALUE rb_gvar_set(ID, VALUE);
@@ -59,7 +58,6 @@ rb_shape_t * rb_grow_iv_list(VALUE obj);
 void rb_ensure_iv_list_size(VALUE obj, uint32_t len, uint32_t newsize);
 struct gen_ivtbl *rb_ensure_generic_iv_list_size(VALUE obj, rb_shape_t *shape, uint32_t newsize);
 attr_index_t rb_obj_ivar_set(VALUE obj, ID id, VALUE val);
-MJIT_SYMBOL_EXPORT_END
 
 static inline bool
 ROBJ_TRANSIENT_P(VALUE obj)

--- a/internal/vm.h
+++ b/internal/vm.h
@@ -58,9 +58,7 @@ VALUE rb_yield_refine_block(VALUE refinement, VALUE refinements);
 MJIT_STATIC VALUE ruby_vm_special_exception_copy(VALUE);
 PUREFUNC(st_table *rb_vm_fstring_table(void));
 
-MJIT_SYMBOL_EXPORT_BEGIN
 VALUE vm_exec(struct rb_execution_context_struct *, bool); /* used in JIT-ed code */
-MJIT_SYMBOL_EXPORT_END
 
 /* vm_eval.c */
 VALUE rb_current_realfilepath(void);
@@ -85,15 +83,11 @@ VALUE rb_equal_opt(VALUE obj1, VALUE obj2);
 VALUE rb_eql_opt(VALUE obj1, VALUE obj2);
 
 struct rb_iseq_struct;
-MJIT_SYMBOL_EXPORT_BEGIN
 const struct rb_callcache *rb_vm_search_method_slowpath(const struct rb_callinfo *ci, VALUE klass);
-MJIT_SYMBOL_EXPORT_END
 
 /* vm_method.c */
 struct rb_execution_context_struct;
-MJIT_SYMBOL_EXPORT_BEGIN
 int rb_ec_obj_respond_to(struct rb_execution_context_struct *ec, VALUE obj, ID id, int priv);
-MJIT_SYMBOL_EXPORT_END
 
 void rb_clear_constant_cache(void);
 
@@ -115,10 +109,8 @@ int rb_frame_info_p(VALUE obj);
 int rb_get_node_id_from_frame_info(VALUE obj);
 const struct rb_iseq_struct *rb_get_iseq_from_frame_info(VALUE obj);
 
-MJIT_SYMBOL_EXPORT_BEGIN
 VALUE rb_ec_backtrace_object(const struct rb_execution_context_struct *ec);
 void rb_backtrace_use_iseq_first_lineno_for_last_location(VALUE self);
-MJIT_SYMBOL_EXPORT_END
 
 #define RUBY_DTRACE_CREATE_HOOK(name, arg) \
     RUBY_DTRACE_HOOK(name##_CREATE, arg)

--- a/iseq.c
+++ b/iseq.c
@@ -1908,7 +1908,7 @@ rb_iseq_node_id(const rb_iseq_t *iseq, size_t pos)
 }
 #endif
 
-MJIT_FUNC_EXPORTED rb_event_flag_t
+rb_event_flag_t
 rb_iseq_event_flags(const rb_iseq_t *iseq, size_t pos)
 {
     const struct iseq_insn_info_entry *entry = get_insn_info(iseq, pos);

--- a/numeric.c
+++ b/numeric.c
@@ -1152,7 +1152,7 @@ flo_coerce(VALUE x, VALUE y)
     return rb_assoc_new(rb_Float(y), x);
 }
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_float_uminus(VALUE flt)
 {
     return DBL2NUM(-RFLOAT_VALUE(flt));
@@ -1265,7 +1265,7 @@ double_div_double(double x, double y)
     }
 }
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_flo_div_flo(VALUE x, VALUE y)
 {
     double num = RFLOAT_VALUE(x);
@@ -1375,7 +1375,7 @@ flodivmod(double x, double y, double *divp, double *modp)
  * An error will be raised if y == 0.
  */
 
-MJIT_FUNC_EXPORTED double
+double
 ruby_float_mod(double x, double y)
 {
     double mod;
@@ -1610,7 +1610,7 @@ num_equal(VALUE x, VALUE y)
  *
  */
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_float_equal(VALUE x, VALUE y)
 {
     volatile double a, b;
@@ -1728,7 +1728,7 @@ flo_cmp(VALUE x, VALUE y)
     return rb_dbl_cmp(a, b);
 }
 
-MJIT_FUNC_EXPORTED int
+int
 rb_float_cmp(VALUE x, VALUE y)
 {
     return NUM2INT(ensure_cmp(flo_cmp(x, y), x, y));
@@ -1922,7 +1922,7 @@ flo_le(VALUE x, VALUE y)
  *  Related: Float#== (performs type conversions).
  */
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_float_eql(VALUE x, VALUE y)
 {
     if (RB_FLOAT_TYPE_P(y)) {
@@ -1938,7 +1938,7 @@ rb_float_eql(VALUE x, VALUE y)
 
 #define flo_eql rb_float_eql
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_float_abs(VALUE flt)
 {
     double val = fabs(RFLOAT_VALUE(flt));
@@ -3891,7 +3891,7 @@ rb_fix2str(VALUE x, int base)
 
 static VALUE rb_fix_to_s_static[10];
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_fix_to_s(VALUE x)
 {
     long i = FIX2LONG(x);
@@ -3919,7 +3919,7 @@ rb_fix_to_s(VALUE x)
  *  Raises an exception if +base+ is out of range.
  */
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_int_to_s(int argc, VALUE *argv, VALUE x)
 {
     int base;
@@ -5174,7 +5174,7 @@ rb_int_rshift(VALUE x, VALUE y)
     return Qnil;
 }
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_fix_aref(VALUE fix, VALUE idx)
 {
     long val = FIX2LONG(fix);
@@ -5398,7 +5398,7 @@ fix_size(VALUE fix)
     return INT2FIX(sizeof(long));
 }
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_int_size(VALUE num)
 {
     if (FIXNUM_P(num)) {

--- a/object.c
+++ b/object.c
@@ -185,7 +185,7 @@ rb_eql(VALUE obj1, VALUE obj2)
  * \private
  *++
  */
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_obj_equal(VALUE obj1, VALUE obj2)
 {
     return RBOOL(obj1 == obj2);
@@ -203,7 +203,7 @@ VALUE rb_obj_hash(VALUE obj);
  *++
  */
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_obj_not(VALUE obj)
 {
     return RBOOL(!RTEST(obj));
@@ -219,7 +219,7 @@ rb_obj_not(VALUE obj)
  *++
  */
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_obj_not_equal(VALUE obj1, VALUE obj2)
 {
     VALUE result = rb_funcall(obj1, id_eq, 1, obj2);
@@ -266,7 +266,7 @@ rb_obj_singleton_class(VALUE obj)
 }
 
 /*! \private */
-MJIT_FUNC_EXPORTED void
+void
 rb_obj_copy_ivar(VALUE dest, VALUE obj)
 {
     RUBY_ASSERT(!RB_TYPE_P(obj, T_CLASS) && !RB_TYPE_P(obj, T_MODULE));
@@ -1261,7 +1261,7 @@ rb_obj_frozen_p(VALUE obj)
  *  Always returns the empty string.
  */
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_nil_to_s(VALUE obj)
 {
     return rb_cNilClass_to_s;
@@ -1346,7 +1346,7 @@ nil_match(VALUE obj1, VALUE obj2)
  * The string representation of <code>true</code> is "true".
  */
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_true_to_s(VALUE obj)
 {
     return rb_cTrueClass_to_s;
@@ -1423,7 +1423,7 @@ true_xor(VALUE obj, VALUE obj2)
  * The string representation of <code>false</code> is "false".
  */
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_false_to_s(VALUE obj)
 {
     return rb_cFalseClass_to_s;
@@ -1494,7 +1494,7 @@ rb_true(VALUE obj)
  */
 
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_false(VALUE obj)
 {
     return Qfalse;
@@ -1579,7 +1579,7 @@ rb_obj_cmp(VALUE obj1, VALUE obj2)
  * show information on the thing we're attached to as well.
  */
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_mod_to_s(VALUE klass)
 {
     ID id_defined_at;
@@ -3049,7 +3049,7 @@ rb_check_convert_type(VALUE val, int type, const char *tname, const char *method
 }
 
 /*! \private */
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_check_convert_type_with_id(VALUE val, int type, const char *tname, ID method)
 {
     VALUE v;

--- a/probes_helper.h
+++ b/probes_helper.h
@@ -12,9 +12,7 @@ struct ruby_dtrace_method_hook_args {
     volatile VALUE name;
 };
 
-MJIT_SYMBOL_EXPORT_BEGIN
 NOINLINE(int rb_dtrace_setup(rb_execution_context_t *, VALUE, ID, struct ruby_dtrace_method_hook_args *));
-MJIT_SYMBOL_EXPORT_END
 
 #define RUBY_DTRACE_METHOD_HOOK(name, ec, klazz, id) \
 do { \

--- a/proc.c
+++ b/proc.c
@@ -743,14 +743,14 @@ rb_vm_ifunc_new(rb_block_call_func_t func, const void *data, int min_argc, int m
     return (struct vm_ifunc *)ret;
 }
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_func_proc_new(rb_block_call_func_t func, VALUE val)
 {
     struct vm_ifunc *ifunc = rb_vm_ifunc_proc_new(func, (void *)val);
     return cfunc_proc_new(rb_cProc, (VALUE)ifunc);
 }
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_func_lambda_new(rb_block_call_func_t func, VALUE val, int min_argc, int max_argc)
 {
     struct vm_ifunc *ifunc = rb_vm_ifunc_new(func, (void *)val, min_argc, max_argc);
@@ -1359,7 +1359,7 @@ iseq_location(const rb_iseq_t *iseq)
     return rb_ary_new4(2, loc);
 }
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_iseq_location(const rb_iseq_t *iseq)
 {
     return iseq_location(iseq);
@@ -1471,7 +1471,7 @@ rb_hash_proc(st_index_t hash, VALUE prc)
  *
  */
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_sym_to_proc(VALUE sym)
 {
     static VALUE sym_proc_cache = Qfalse;

--- a/ractor.c
+++ b/ractor.c
@@ -301,7 +301,7 @@ RACTOR_PTR(VALUE self)
 static rb_atomic_t ractor_last_id;
 
 #if RACTOR_CHECK_MODE > 0
-MJIT_FUNC_EXPORTED uint32_t
+uint32_t
 rb_ractor_current_id(void)
 {
     if (GET_THREAD()->ractor == NULL) {
@@ -2097,7 +2097,7 @@ rb_ractor_send_parameters(rb_execution_context_t *ec, rb_ractor_t *r, VALUE args
     }
 }
 
-MJIT_FUNC_EXPORTED bool
+bool
 rb_ractor_main_p_(void)
 {
     VM_ASSERT(rb_multi_ractor_p());
@@ -2976,7 +2976,7 @@ shareable_p_enter(VALUE obj)
     return traverse_stop; // fail
 }
 
-MJIT_FUNC_EXPORTED bool
+bool
 rb_ractor_shareable_p_continue(VALUE obj)
 {
     if (rb_obj_traverse(obj,

--- a/re.c
+++ b/re.c
@@ -3317,7 +3317,7 @@ rb_reg_init_str_enc(VALUE re, VALUE s, rb_encoding *enc, int options)
     return re;
 }
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_reg_new_ary(VALUE ary, int opt)
 {
     VALUE re = rb_reg_new_str(rb_reg_preprocess_dregexp(ary, opt), opt);

--- a/shape.c
+++ b/shape.c
@@ -44,7 +44,7 @@ rb_shape_each_shape(each_shape_callback callback, void *data)
     }
 }
 
-rb_shape_t*
+RUBY_FUNC_EXPORTED rb_shape_t*
 rb_shape_get_shape_by_id(shape_id_t shape_id)
 {
     RUBY_ASSERT(shape_id != INVALID_SHAPE_ID);
@@ -71,7 +71,7 @@ rb_rclass_shape_id(VALUE obj)
 shape_id_t rb_generic_shape_id(VALUE obj);
 #endif
 
-shape_id_t
+RUBY_FUNC_EXPORTED shape_id_t
 rb_shape_get_shape_id(VALUE obj)
 {
     if (RB_SPECIAL_CONST_P(obj)) {
@@ -514,7 +514,7 @@ rb_shape_rebuild_shape(rb_shape_t * initial_shape, rb_shape_t * dest_shape)
     return midway_shape;
 }
 
-bool
+RUBY_FUNC_EXPORTED bool
 rb_shape_obj_too_complex(VALUE obj)
 {
     return rb_shape_get_shape_id(obj) == OBJ_TOO_COMPLEX_SHAPE_ID;

--- a/shape.c
+++ b/shape.c
@@ -172,7 +172,7 @@ get_next_shape_internal(rb_shape_t * shape, ID id, enum shape_type shape_type, b
     return res;
 }
 
-MJIT_FUNC_EXPORTED int
+int
 rb_shape_frozen_shape_p(rb_shape_t* shape)
 {
     return SHAPE_FROZEN == (enum shape_type)shape->type;
@@ -424,7 +424,7 @@ rb_shape_alloc(ID edge_name, rb_shape_t * parent)
     return rb_shape_alloc_with_size_pool_index(edge_name, parent, parent->size_pool_index);
 }
 
-MJIT_FUNC_EXPORTED void
+void
 rb_shape_set_shape(VALUE obj, rb_shape_t* shape)
 {
     rb_shape_set_shape_id(obj, rb_shape_id(shape));

--- a/shape.h
+++ b/shape.h
@@ -116,9 +116,7 @@ ROBJECT_SET_SHAPE_ID(VALUE obj, shape_id_t shape_id)
     RBASIC(obj)->flags |= ((VALUE)(shape_id) << SHAPE_FLAG_SHIFT);
 }
 
-MJIT_SYMBOL_EXPORT_BEGIN
 shape_id_t rb_rclass_shape_id(VALUE obj);
-MJIT_SYMBOL_EXPORT_END
 
 static inline shape_id_t RCLASS_SHAPE_ID(VALUE obj)
 {
@@ -132,13 +130,11 @@ int32_t rb_shape_id_offset(void);
 
 rb_shape_t * rb_shape_get_parent(rb_shape_t * shape);
 
-MJIT_SYMBOL_EXPORT_BEGIN
 rb_shape_t* rb_shape_get_shape_by_id(shape_id_t shape_id);
 shape_id_t rb_shape_get_shape_id(VALUE obj);
 rb_shape_t * rb_shape_get_next_iv_shape(rb_shape_t * shape, ID id);
 bool rb_shape_get_iv_index(rb_shape_t * shape, ID id, attr_index_t * value);
 bool rb_shape_obj_too_complex(VALUE obj);
-MJIT_SYMBOL_EXPORT_END
 
 void rb_shape_set_shape(VALUE obj, rb_shape_t* shape);
 rb_shape_t* rb_shape_get_shape(VALUE obj);

--- a/string.c
+++ b/string.c
@@ -543,7 +543,7 @@ rb_setup_fake_str(struct RString *fake_str, const char *name, long len, rb_encod
  * shared string which refers a static string literal.  `ptr` must
  * point a constant string.
  */
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_fstring_new(const char *ptr, long len)
 {
     struct RString fake_str;
@@ -1703,7 +1703,7 @@ rb_obj_as_string(VALUE obj)
     return rb_obj_as_string_result(str, obj);
 }
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_obj_as_string_result(VALUE str, VALUE obj)
 {
     if (!RB_TYPE_P(str, T_STRING))
@@ -2251,7 +2251,7 @@ rb_str_plus(VALUE str1, VALUE str2)
 }
 
 /* A variant of rb_str_plus that does not raise but return Qundef instead. */
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_str_opt_plus(VALUE str1, VALUE str2)
 {
     assert(RBASIC_CLASS(str1) == rb_cString);
@@ -3351,7 +3351,7 @@ rb_str_append(VALUE str, VALUE str2)
     return rb_str_buf_append(str, str2);
 }
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_str_concat_literals(size_t num, const VALUE *strary)
 {
     VALUE str;
@@ -3692,7 +3692,7 @@ rb_str_equal(VALUE str1, VALUE str2)
  *
  */
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_str_eql(VALUE str1, VALUE str2)
 {
     if (str1 == str2) return Qtrue;
@@ -11516,7 +11516,7 @@ rb_str_quote_unprintable(VALUE str)
     return str;
 }
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_id_quote_unprintable(ID id)
 {
     VALUE str = rb_id2str(id);
@@ -11581,7 +11581,7 @@ rb_sym_to_s(VALUE sym)
     return str_new_shared(rb_cString, rb_sym2str(sym));
 }
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_sym_proc_call(ID mid, int argc, const VALUE *argv, int kw_splat, VALUE passed_proc)
 {
     VALUE obj;

--- a/thread.c
+++ b/thread.c
@@ -2286,7 +2286,7 @@ extern bool mjit_waitpid_finished;
 extern int mjit_waitpid_status;
 #endif
 
-MJIT_FUNC_EXPORTED int
+int
 rb_threadptr_execute_interrupts(rb_thread_t *th, int blocking_timing)
 {
     rb_atomic_t interrupt;

--- a/variable.c
+++ b/variable.c
@@ -785,7 +785,7 @@ rb_gv_get(const char *name)
     return rb_gvar_get(id);
 }
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_gvar_defined(ID id)
 {
     struct rb_global_entry *entry = rb_global_entry(id);
@@ -935,7 +935,7 @@ gen_ivtbl_get_unlocked(VALUE obj, ID id, struct gen_ivtbl **ivtbl)
     return 0;
 }
 
-MJIT_FUNC_EXPORTED int
+int
 rb_gen_ivtbl_get(VALUE obj, ID id, struct gen_ivtbl **ivtbl)
 {
     RUBY_ASSERT(!RB_TYPE_P(obj, T_ICLASS));
@@ -955,7 +955,7 @@ rb_gen_ivtbl_get(VALUE obj, ID id, struct gen_ivtbl **ivtbl)
     return r;
 }
 
-MJIT_FUNC_EXPORTED int
+int
 rb_ivar_generic_ivtbl_lookup(VALUE obj, struct gen_ivtbl **ivtbl)
 {
     return rb_gen_ivtbl_get(obj, 0, ivtbl);
@@ -1072,7 +1072,7 @@ rb_generic_ivar_memsize(VALUE obj)
 }
 
 #if !SHAPE_IN_BASIC_FLAGS
-MJIT_FUNC_EXPORTED shape_id_t
+shape_id_t
 rb_generic_shape_id(VALUE obj)
 {
     struct gen_ivtbl *ivtbl = 0;
@@ -2504,7 +2504,7 @@ check_autoload_required(VALUE mod, ID id, const char **loadingpath)
 
 static struct autoload_const *autoloading_const_entry(VALUE mod, ID id);
 
-MJIT_FUNC_EXPORTED int
+int
 rb_autoloading_value(VALUE mod, ID id, VALUE* value, rb_const_flag_t *flag)
 {
     struct autoload_const *ac = autoloading_const_entry(mod, id);
@@ -2783,7 +2783,7 @@ rb_autoload_at_p(VALUE mod, ID id, int recur)
     return (ele = get_autoload_data(load, 0)) ? ele->feature : Qnil;
 }
 
-MJIT_FUNC_EXPORTED void
+void
 rb_const_warn_if_deprecated(const rb_const_entry_t *ce, VALUE klass, ID id)
 {
     if (RB_CONST_DEPRECATED_P(ce) &&
@@ -2900,13 +2900,13 @@ rb_const_get_at(VALUE klass, ID id)
     return rb_const_get_0(klass, id, TRUE, FALSE, FALSE);
 }
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_public_const_get_from(VALUE klass, ID id)
 {
     return rb_const_get_0(klass, id, TRUE, TRUE, TRUE);
 }
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_public_const_get_at(VALUE klass, ID id)
 {
     return rb_const_get_0(klass, id, TRUE, FALSE, TRUE);
@@ -2964,7 +2964,7 @@ rb_const_source_location(VALUE klass, ID id)
     return rb_const_location(klass, id, FALSE, TRUE, FALSE);
 }
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_const_source_location_at(VALUE klass, ID id)
 {
     return rb_const_location(klass, id, TRUE, FALSE, FALSE);
@@ -3208,7 +3208,7 @@ rb_const_defined_at(VALUE klass, ID id)
     return rb_const_defined_0(klass, id, TRUE, FALSE, FALSE);
 }
 
-MJIT_FUNC_EXPORTED int
+int
 rb_public_const_defined_from(VALUE klass, ID id)
 {
     return rb_const_defined_0(klass, id, TRUE, TRUE, TRUE);
@@ -4017,7 +4017,7 @@ rb_iv_tbl_copy(VALUE dst, VALUE src)
     rb_ivar_foreach(src, tbl_copy_i, dst);
 }
 
-MJIT_FUNC_EXPORTED rb_const_entry_t *
+rb_const_entry_t *
 rb_const_lookup(VALUE klass, ID id)
 {
     struct rb_id_table *tbl = RCLASS_CONST_TBL(klass);

--- a/vm.c
+++ b/vm.c
@@ -56,15 +56,6 @@ int ruby_assert_critical_section_entered = 0;
 
 VALUE rb_str_concat_literals(size_t, const VALUE*);
 
-/* :FIXME: This #ifdef is because we build pch in case of mswin and
- * not in case of other situations.  That distinction might change in
- * a future.  We would better make it detectable in something better
- * than just _MSC_VER. */
-#ifdef _MSC_VER
-RUBY_FUNC_EXPORTED
-#else
-MJIT_FUNC_EXPORTED
-#endif
 VALUE vm_exec(rb_execution_context_t *, bool);
 
 extern const char *const rb_debug_counter_names[];
@@ -508,7 +499,7 @@ rb_vm_inc_const_missing_count(void)
     ruby_vm_const_missing_count +=1;
 }
 
-MJIT_FUNC_EXPORTED int
+int
 rb_dtrace_setup(rb_execution_context_t *ec, VALUE klass, ID id,
                 struct ruby_dtrace_method_hook_args *args)
 {
@@ -685,7 +676,7 @@ rb_vm_get_binding_creatable_next_cfp(const rb_execution_context_t *ec, const rb_
     return 0;
 }
 
-MJIT_FUNC_EXPORTED rb_control_frame_t *
+rb_control_frame_t *
 rb_vm_get_ruby_level_next_cfp(const rb_execution_context_t *ec, const rb_control_frame_t *cfp)
 {
     while (!RUBY_VM_CONTROL_FRAME_STACK_OVERFLOW_P(ec, cfp)) {
@@ -1267,7 +1258,7 @@ rb_proc_ractor_make_shareable(VALUE self)
     return self;
 }
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_vm_make_proc_lambda(const rb_execution_context_t *ec, const struct rb_captured_block *captured, VALUE klass, int8_t is_lambda)
 {
     VALUE procval;
@@ -1586,14 +1577,14 @@ vm_invoke_proc(rb_execution_context_t *ec, rb_proc_t *proc, VALUE self,
     return invoke_block_from_c_proc(ec, proc, self, argc, argv, kw_splat, passed_block_handler, proc->is_lambda, NULL);
 }
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_vm_invoke_bmethod(rb_execution_context_t *ec, rb_proc_t *proc, VALUE self,
                      int argc, const VALUE *argv, int kw_splat, VALUE block_handler, const rb_callable_method_entry_t *me)
 {
     return invoke_block_from_c_proc(ec, proc, self, argc, argv, kw_splat, block_handler, TRUE, me);
 }
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_vm_invoke_proc(rb_execution_context_t *ec, rb_proc_t *proc,
                   int argc, const VALUE *argv, int kw_splat, VALUE passed_block_handler)
 {
@@ -1743,7 +1734,7 @@ rb_source_location(int *pline)
     }
 }
 
-MJIT_FUNC_EXPORTED const char *
+const char *
 rb_source_location_cstr(int *pline)
 {
     VALUE path = rb_source_location(pline);
@@ -1839,7 +1830,7 @@ make_localjump_error(const char *mesg, VALUE value, int reason)
     return exc;
 }
 
-MJIT_FUNC_EXPORTED void
+void
 rb_vm_localjump_error(const char *mesg, VALUE value, int reason)
 {
     VALUE exc = make_localjump_error(mesg, value, reason);
@@ -4421,13 +4412,13 @@ vm_collect_usage_register(int reg, int isset)
 }
 #endif
 
-MJIT_FUNC_EXPORTED const struct rb_callcache *
+const struct rb_callcache *
 rb_vm_empty_cc(void)
 {
     return &vm_empty_cc;
 }
 
-MJIT_FUNC_EXPORTED const struct rb_callcache *
+const struct rb_callcache *
 rb_vm_empty_cc_for_super(void)
 {
     return &vm_empty_cc_for_super;

--- a/vm_args.c
+++ b/vm_args.c
@@ -14,9 +14,6 @@ NORETURN(static void argument_kw_error(rb_execution_context_t *ec, const rb_iseq
 VALUE rb_keyword_error_new(const char *error, VALUE keys); /* class.c */
 static VALUE method_missing(rb_execution_context_t *ec, VALUE obj, ID id, int argc, const VALUE *argv,
                             enum method_missing_reason call_status, int kw_splat);
-#if !defined(_MSC_VER) || !defined(MJIT_HEADER)
-MJIT_FUNC_EXPORTED
-#endif
 const rb_callable_method_entry_t *rb_resolve_refined_method_callable(VALUE refinements, const rb_callable_method_entry_t *me);
 
 struct args_info {

--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -684,7 +684,7 @@ rb_ec_partial_backtrace_object(const rb_execution_context_t *ec, long start_fram
     return btobj;
 }
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_ec_backtrace_object(const rb_execution_context_t *ec)
 {
     return rb_ec_partial_backtrace_object(ec, BACKTRACE_START, ALL_BACKTRACE_LINES, NULL, FALSE, FALSE);
@@ -735,7 +735,7 @@ rb_backtrace_to_str_ary(VALUE self)
     return bt->strary;
 }
 
-MJIT_FUNC_EXPORTED void
+void
 rb_backtrace_use_iseq_first_lineno_for_last_location(VALUE self)
 {
     const rb_backtrace_t *bt;

--- a/vm_core.h
+++ b/vm_core.h
@@ -1810,15 +1810,12 @@ rb_execution_context_t *rb_vm_main_ractor_ec(rb_vm_t *vm); // ractor.c
 /* for thread */
 
 #if RUBY_VM_THREAD_MODEL == 2
-MJIT_SYMBOL_EXPORT_BEGIN
 
 RUBY_EXTERN struct rb_ractor_struct *ruby_single_main_ractor; // ractor.c
 RUBY_EXTERN rb_vm_t *ruby_current_vm_ptr;
 RUBY_EXTERN rb_event_flag_t ruby_vm_event_flags;
 RUBY_EXTERN rb_event_flag_t ruby_vm_event_enabled_global_flags;
 RUBY_EXTERN unsigned int    ruby_vm_event_local_num;
-
-MJIT_SYMBOL_EXPORT_END
 
 #define GET_VM()     rb_current_vm()
 #define GET_RACTOR() rb_current_ractor()

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -43,7 +43,7 @@ static VALUE vm_call0_body(rb_execution_context_t* ec, struct rb_calling_info *c
 
 #ifndef MJIT_HEADER
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_vm_call0(rb_execution_context_t *ec, VALUE recv, ID id, int argc, const VALUE *argv, const rb_callable_method_entry_t *cme, int kw_splat)
 {
     struct rb_calling_info calling = {
@@ -58,7 +58,7 @@ rb_vm_call0(rb_execution_context_t *ec, VALUE recv, ID id, int argc, const VALUE
     return vm_call0_body(ec, &calling, argv);
 }
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_vm_call_with_refinements(rb_execution_context_t *ec, VALUE recv, ID id, int argc, const VALUE *argv, int kw_splat)
 {
     const rb_callable_method_entry_t *me =
@@ -297,7 +297,7 @@ vm_call0_body(rb_execution_context_t *ec, struct rb_calling_info *calling, const
     return ret;
 }
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_vm_call_kw(rb_execution_context_t *ec, VALUE recv, VALUE id, int argc, const VALUE *argv, const rb_callable_method_entry_t *me, int kw_splat)
 {
     return rb_vm_call0(ec, recv, id, argc, argv, me, kw_splat);
@@ -926,7 +926,7 @@ rb_method_missing(int argc, const VALUE *argv, VALUE obj)
     UNREACHABLE_RETURN(Qnil);
 }
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_make_no_method_exception(VALUE exc, VALUE format, VALUE obj,
                             int argc, const VALUE *argv, int priv)
 {

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -240,7 +240,7 @@ static VALUE vm_stack_canary; /* Initialized later */
 static bool vm_stack_canary_was_born = false;
 
 #ifndef MJIT_HEADER
-MJIT_FUNC_EXPORTED void
+void
 rb_vm_check_canary(const rb_execution_context_t *ec, VALUE *sp)
 {
     const struct rb_control_frame_struct *reg_cfp = ec->cfp;
@@ -2081,7 +2081,7 @@ vm_search_cc(const VALUE klass, const struct rb_callinfo * const ci)
     return cc;
 }
 
-MJIT_FUNC_EXPORTED const struct rb_callcache *
+const struct rb_callcache *
 rb_vm_search_method_slowpath(const struct rb_callinfo *ci, VALUE klass)
 {
     const struct rb_callcache *cc;
@@ -2517,7 +2517,7 @@ rb_simple_iseq_p(const rb_iseq_t *iseq)
            ISEQ_BODY(iseq)->param.flags.has_block == FALSE;
 }
 
-MJIT_FUNC_EXPORTED bool
+bool
 rb_iseq_only_optparam_p(const rb_iseq_t *iseq)
 {
     return ISEQ_BODY(iseq)->param.flags.has_opt == TRUE &&
@@ -2529,7 +2529,7 @@ rb_iseq_only_optparam_p(const rb_iseq_t *iseq)
            ISEQ_BODY(iseq)->param.flags.has_block == FALSE;
 }
 
-MJIT_FUNC_EXPORTED bool
+bool
 rb_iseq_only_kwparam_p(const rb_iseq_t *iseq)
 {
     return ISEQ_BODY(iseq)->param.flags.has_opt == FALSE &&
@@ -3567,7 +3567,7 @@ vm_call_bmethod(rb_execution_context_t *ec, rb_control_frame_t *cfp, struct rb_c
     return vm_call_bmethod_body(ec, calling, argv);
 }
 
-MJIT_FUNC_EXPORTED VALUE
+VALUE
 rb_find_defined_class_by_owner(VALUE current_class, VALUE target_owner)
 {
     VALUE klass = current_class;
@@ -6299,7 +6299,7 @@ Init_vm_stack_canary(void)
 }
 
 #ifndef MJIT_HEADER
-MJIT_FUNC_EXPORTED void
+void
 rb_vm_canary_is_found_dead(enum ruby_vminsn_type i, VALUE c)
 {
     /* Because a method has already been called, why not call

--- a/vm_insnhelper.h
+++ b/vm_insnhelper.h
@@ -11,14 +11,10 @@
 
 **********************************************************************/
 
-MJIT_SYMBOL_EXPORT_BEGIN
-
 RUBY_EXTERN VALUE ruby_vm_const_missing_count;
 RUBY_EXTERN rb_serial_t ruby_vm_constant_cache_invalidations;
 RUBY_EXTERN rb_serial_t ruby_vm_constant_cache_misses;
 RUBY_EXTERN rb_serial_t ruby_vm_global_cvar_state;
-
-MJIT_SYMBOL_EXPORT_END
 
 #ifndef MJIT_STATS
 # define MJIT_STATS RUBY_DEBUG

--- a/vm_method.c
+++ b/vm_method.c
@@ -509,7 +509,7 @@ setup_method_cfunc_struct(rb_method_cfunc_t *cfunc, VALUE (*func)(ANYARGS), int 
     cfunc->invoker = call_cfunc_invoker_func(argc);
 }
 
-MJIT_FUNC_EXPORTED void
+void
 rb_method_definition_set(const rb_method_entry_t *me, rb_method_definition_t *def, void *opts)
 {
     *(rb_method_definition_t **)&me->def = def;
@@ -630,7 +630,7 @@ method_definition_reset(const rb_method_entry_t *me)
     }
 }
 
-MJIT_FUNC_EXPORTED rb_method_definition_t *
+rb_method_definition_t *
 rb_method_definition_create(rb_method_type_t type, ID mid)
 {
     rb_method_definition_t *def;
@@ -703,7 +703,7 @@ rb_method_entry_clone(const rb_method_entry_t *src_me)
     return me;
 }
 
-MJIT_FUNC_EXPORTED const rb_callable_method_entry_t *
+const rb_callable_method_entry_t *
 rb_method_entry_complement_defined_class(const rb_method_entry_t *src_me, ID called_id, VALUE defined_class)
 {
     rb_method_definition_t *def = src_me->def;
@@ -1023,7 +1023,7 @@ lookup_overloaded_cme(const rb_callable_method_entry_t *cme)
 }
 
 #if VM_CHECK_MODE > 0
-MJIT_FUNC_EXPORTED const rb_callable_method_entry_t *
+const rb_callable_method_entry_t *
 rb_vm_lookup_overloaded_cme(const rb_callable_method_entry_t *cme)
 {
     return lookup_overloaded_cme(cme);
@@ -1111,7 +1111,7 @@ rb_add_method(VALUE klass, ID mid, rb_method_type_t type, void *opts, rb_method_
     }
 }
 
-MJIT_FUNC_EXPORTED void
+void
 rb_add_method_iseq(VALUE klass, ID mid, const rb_iseq_t *iseq, rb_cref_t *cref, rb_method_visibility_t visi)
 {
     struct { /* should be same fields with rb_method_iseq_struct */
@@ -1228,7 +1228,7 @@ search_method_protect(VALUE klass, ID id, VALUE *defined_class_ptr)
     }
 }
 
-MJIT_FUNC_EXPORTED const rb_method_entry_t *
+const rb_method_entry_t *
 rb_method_entry(VALUE klass, ID id)
 {
     return search_method_protect(klass, id, NULL);
@@ -1407,7 +1407,7 @@ callable_method_entry(VALUE klass, ID mid, VALUE *defined_class_ptr)
     return !UNDEFINED_METHOD_ENTRY_P(cme) ? cme : NULL;
 }
 
-MJIT_FUNC_EXPORTED const rb_callable_method_entry_t *
+const rb_callable_method_entry_t *
 rb_callable_method_entry(VALUE klass, ID mid)
 {
     return callable_method_entry(klass, mid, NULL);
@@ -1438,7 +1438,7 @@ method_entry_resolve_refinement(VALUE klass, ID id, int with_refinement, VALUE *
     return me;
 }
 
-MJIT_FUNC_EXPORTED const rb_method_entry_t *
+const rb_method_entry_t *
 rb_method_entry_with_refinements(VALUE klass, ID id, VALUE *defined_class_ptr)
 {
     return method_entry_resolve_refinement(klass, id, TRUE, defined_class_ptr);
@@ -1465,7 +1465,7 @@ callable_method_entry_refinements(VALUE klass, ID id, VALUE *defined_class_ptr, 
     return callable_method_entry_refeinements0(klass, id, defined_class_ptr, with_refinements, cme);
 }
 
-MJIT_FUNC_EXPORTED const rb_callable_method_entry_t *
+const rb_callable_method_entry_t *
 rb_callable_method_entry_with_refinements(VALUE klass, ID id, VALUE *defined_class_ptr)
 {
     return callable_method_entry_refinements(klass, id, defined_class_ptr, true);
@@ -1483,7 +1483,7 @@ rb_method_entry_without_refinements(VALUE klass, ID id, VALUE *defined_class_ptr
     return method_entry_resolve_refinement(klass, id, FALSE, defined_class_ptr);
 }
 
-MJIT_FUNC_EXPORTED const rb_callable_method_entry_t *
+const rb_callable_method_entry_t *
 rb_callable_method_entry_without_refinements(VALUE klass, ID id, VALUE *defined_class_ptr)
 {
     VALUE defined_class, *dcp = defined_class_ptr ? defined_class_ptr : &defined_class;
@@ -1530,7 +1530,6 @@ rb_resolve_refined_method(VALUE refinements, const rb_method_entry_t *me)
     return resolve_refined_method(refinements, me, NULL);
 }
 
-MJIT_FUNC_EXPORTED
 const rb_callable_method_entry_t *
 rb_resolve_refined_method_callable(VALUE refinements, const rb_callable_method_entry_t *me)
 {
@@ -2079,7 +2078,7 @@ original_method_definition(const rb_method_definition_t *def)
     return def;
 }
 
-MJIT_FUNC_EXPORTED int
+int
 rb_method_definition_eq(const rb_method_definition_t *d1, const rb_method_definition_t *d2)
 {
     d1 = original_method_definition(d1);

--- a/vm_sync.c
+++ b/vm_sync.c
@@ -129,7 +129,7 @@ vm_lock_leave(rb_vm_t *vm, unsigned int *lev APPEND_LOCATION_ARGS)
     }
 }
 
-MJIT_FUNC_EXPORTED void
+void
 rb_vm_lock_enter_body(unsigned int *lev APPEND_LOCATION_ARGS)
 {
     rb_vm_t *vm = GET_VM();
@@ -141,7 +141,7 @@ rb_vm_lock_enter_body(unsigned int *lev APPEND_LOCATION_ARGS)
     }
 }
 
-MJIT_FUNC_EXPORTED void
+void
 rb_vm_lock_enter_body_nb(unsigned int *lev APPEND_LOCATION_ARGS)
 {
     rb_vm_t *vm = GET_VM();
@@ -153,14 +153,14 @@ rb_vm_lock_enter_body_nb(unsigned int *lev APPEND_LOCATION_ARGS)
     }
 }
 
-MJIT_FUNC_EXPORTED void
+void
 rb_vm_lock_enter_body_cr(rb_ractor_t *cr, unsigned int *lev APPEND_LOCATION_ARGS)
 {
     rb_vm_t *vm = GET_VM();
     vm_lock_enter(cr, vm, vm_locked(vm), false, lev APPEND_LOCATION_PARAMS);
 }
 
-MJIT_FUNC_EXPORTED void
+void
 rb_vm_lock_leave_body(unsigned int *lev APPEND_LOCATION_ARGS)
 {
     vm_lock_leave(GET_VM(), lev APPEND_LOCATION_PARAMS);

--- a/vm_trace.c
+++ b/vm_trace.c
@@ -402,7 +402,7 @@ exec_hooks_protected(rb_execution_context_t *ec, rb_hook_list_t *list, const rb_
 }
 
 // pop_p: Whether to pop the frame for the TracePoint when it throws.
-MJIT_FUNC_EXPORTED void
+void
 rb_exec_event_hooks(rb_trace_arg_t *trace_arg, rb_hook_list_t *hooks, int pop_p)
 {
     rb_execution_context_t *ec = trace_arg->ec;

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -1352,7 +1352,7 @@ is_batch(const char *cmd)
 #define wstr_to_utf8(str, plen) wstr_to_mbstr(CP_UTF8, str, -1, plen)
 
 /* License: Ruby's */
-MJIT_FUNC_EXPORTED HANDLE
+HANDLE
 rb_w32_start_process(const char *abspath, char *const *argv, int out_fd)
 {
     /* NOTE: This function is used by MJIT worker, so it can be used parallelly with


### PR DESCRIPTION
RJIT doesn't need C functions to be exported.