### PR TITLE
[Bug #19482] Fix crash when allocating classes with newobj hook

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -2834,6 +2834,12 @@ newobj_alloc(rb_objspace_t *objspace, rb_ractor_t *cr, size_t size_pool_idx, boo
     return obj;
 }
 
+static void
+newobj_zero_slot(VALUE obj)
+{
+    memset((char *)obj + sizeof(struct RBasic), 0, rb_gc_obj_slot_size(obj) - sizeof(struct RBasic));
+}
+
 ALWAYS_INLINE(static VALUE newobj_slowpath(VALUE klass, VALUE flags, rb_objspace_t *objspace, rb_ractor_t *cr, int wb_protected, size_t size_pool_idx));
 
 static inline VALUE
@@ -2864,7 +2870,7 @@ newobj_slowpath(VALUE klass, VALUE flags, rb_objspace_t *objspace, rb_ractor_t *
 #endif
         newobj_init(klass, flags, wb_protected, objspace, obj);
 
-        gc_event_hook_prep(objspace, RUBY_INTERNAL_EVENT_NEWOBJ, obj, newobj_fill(obj, 0, 0, 0));
+        gc_event_hook_prep(objspace, RUBY_INTERNAL_EVENT_NEWOBJ, obj, newobj_zero_slot(obj));
     }
     RB_VM_LOCK_LEAVE_CR_LEV(cr, &lev);
 

--- a/test/objspace/test_objspace.rb
+++ b/test/objspace/test_objspace.rb
@@ -224,6 +224,13 @@ class TestObjSpace < Test::Unit::TestCase
         1.0 / 0.0; line4 = __LINE__; c4 = GC.count
       assert_equal(__FILE__, ObjectSpace.allocation_sourcefile(o4))
       assert_equal(line4, ObjectSpace.allocation_sourceline(o4))
+
+      # [Bug #19482]
+      EnvUtil.under_gc_stress do
+        100.times do
+          Class.new
+        end
+      end
     }
   end
 


### PR DESCRIPTION
We need to zero out the whole slot when running the newobj hook for a newly allocated class because the slot could be filled with garbage, which would cause a crash if a GC runs inside of the newobj hook.

For example, the following script crashes:

```ruby
require "objspace"

GC.stress = true

ObjectSpace.trace_object_allocations {
  100.times do
    Class.new
  end
}
```