### PR TITLE
Rename and move RB_GC_SAVE_MACHINE_CONTEXT

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -17621,6 +17621,7 @@ vm_sync.$(OBJEXT): $(top_srcdir)/internal/gc.h
 vm_sync.$(OBJEXT): $(top_srcdir)/internal/imemo.h
 vm_sync.$(OBJEXT): $(top_srcdir)/internal/serial.h
 vm_sync.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
+vm_sync.$(OBJEXT): $(top_srcdir)/internal/thread.h
 vm_sync.$(OBJEXT): $(top_srcdir)/internal/variable.h
 vm_sync.$(OBJEXT): $(top_srcdir)/internal/vm.h
 vm_sync.$(OBJEXT): $(top_srcdir)/internal/warnings.h

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -33,13 +33,6 @@ NOINLINE(void rb_gc_set_stack_end(VALUE **stack_end_p));
 #define USE_CONSERVATIVE_STACK_END
 #endif
 
-#define RB_GC_SAVE_MACHINE_CONTEXT(th)				\
-    do {							\
-        FLUSH_REGISTER_WINDOWS;					\
-        setjmp((th)->ec->machine.regs);				\
-        SET_MACHINE_STACK_END(&(th)->ec->machine.stack_end);	\
-    } while (0)
-
 /* for GC debug */
 
 #ifndef RUBY_MARK_FREE_DEBUG

--- a/internal/thread.h
+++ b/internal/thread.h
@@ -13,6 +13,13 @@
 
 struct rb_thread_struct;        /* in vm_core.h */
 
+#define RB_VM_SAVE_MACHINE_CONTEXT(th)				\
+    do {							\
+        FLUSH_REGISTER_WINDOWS;					\
+        setjmp((th)->ec->machine.regs);				\
+        SET_MACHINE_STACK_END(&(th)->ec->machine.stack_end);	\
+    } while (0)
+
 /* thread.c */
 #define COVERAGE_INDEX_LINES    0
 #define COVERAGE_INDEX_BRANCHES 1

--- a/thread.c
+++ b/thread.c
@@ -173,7 +173,7 @@ static inline void blocking_region_end(rb_thread_t *th, struct rb_blocking_regio
 
 #define THREAD_BLOCKING_BEGIN(th) do { \
   struct rb_thread_sched * const sched = TH_SCHED(th); \
-  RB_GC_SAVE_MACHINE_CONTEXT(th); \
+  RB_VM_SAVE_MACHINE_CONTEXT(th); \
   thread_sched_to_waiting(sched);
 
 #define THREAD_BLOCKING_END(th) \
@@ -1439,7 +1439,7 @@ rb_thread_schedule_limits(uint32_t limits_us)
         if (th->running_time_us >= limits_us) {
             RUBY_DEBUG_LOG("switch %s", "start");
 
-            RB_GC_SAVE_MACHINE_CONTEXT(th);
+            RB_VM_SAVE_MACHINE_CONTEXT(th);
             thread_sched_yield(TH_SCHED(th), th);
             rb_ractor_thread_switch(th->ractor, th);
 
@@ -1474,7 +1474,7 @@ blocking_region_begin(rb_thread_t *th, struct rb_blocking_region_buffer *region,
 
         RUBY_DEBUG_LOG("");
 
-        RB_GC_SAVE_MACHINE_CONTEXT(th);
+        RB_VM_SAVE_MACHINE_CONTEXT(th);
         thread_sched_to_waiting(TH_SCHED(th));
         return TRUE;
     }

--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -2282,7 +2282,7 @@ ubf_ppoll_sleep(void *ignore)
 #define THREAD_BLOCKING_YIELD(th) do { \
     const rb_thread_t *next; \
     struct rb_thread_sched *sched = TH_SCHED(th); \
-    RB_GC_SAVE_MACHINE_CONTEXT(th); \
+    RB_VM_SAVE_MACHINE_CONTEXT(th); \
     rb_native_mutex_lock(&sched->lock); \
     next = thread_sched_to_waiting_common(sched); \
     rb_native_mutex_unlock(&sched->lock); \

--- a/vm_core.h
+++ b/vm_core.h
@@ -1819,6 +1819,13 @@ RUBY_EXTERN unsigned int    ruby_vm_event_local_num;
 #define GET_THREAD() rb_current_thread()
 #define GET_EC()     rb_current_execution_context(true)
 
+#define RB_GC_SAVE_MACHINE_CONTEXT(th)				\
+    do {							\
+        FLUSH_REGISTER_WINDOWS;					\
+        setjmp((th)->ec->machine.regs);				\
+        SET_MACHINE_STACK_END(&(th)->ec->machine.stack_end);	\
+    } while (0)
+
 static inline rb_thread_t *
 rb_ec_thread_ptr(const rb_execution_context_t *ec)
 {

--- a/vm_core.h
+++ b/vm_core.h
@@ -1819,13 +1819,6 @@ RUBY_EXTERN unsigned int    ruby_vm_event_local_num;
 #define GET_THREAD() rb_current_thread()
 #define GET_EC()     rb_current_execution_context(true)
 
-#define RB_VM_SAVE_MACHINE_CONTEXT(th)				\
-    do {							\
-        FLUSH_REGISTER_WINDOWS;					\
-        setjmp((th)->ec->machine.regs);				\
-        SET_MACHINE_STACK_END(&(th)->ec->machine.stack_end);	\
-    } while (0)
-
 static inline rb_thread_t *
 rb_ec_thread_ptr(const rb_execution_context_t *ec)
 {

--- a/vm_core.h
+++ b/vm_core.h
@@ -1819,7 +1819,7 @@ RUBY_EXTERN unsigned int    ruby_vm_event_local_num;
 #define GET_THREAD() rb_current_thread()
 #define GET_EC()     rb_current_execution_context(true)
 
-#define RB_GC_SAVE_MACHINE_CONTEXT(th)				\
+#define RB_VM_SAVE_MACHINE_CONTEXT(th)				\
     do {							\
         FLUSH_REGISTER_WINDOWS;					\
         setjmp((th)->ec->machine.regs);				\

--- a/vm_sync.c
+++ b/vm_sync.c
@@ -64,7 +64,7 @@ vm_lock_enter(rb_ractor_t *cr, rb_vm_t *vm, bool locked, bool no_barrier, unsign
                 rb_thread_t *th = GET_THREAD();
                 bool running;
 
-                RB_GC_SAVE_MACHINE_CONTEXT(th);
+                RB_VM_SAVE_MACHINE_CONTEXT(th);
 
                 if (rb_ractor_status_p(cr, ractor_running)) {
                     rb_vm_ractor_blocking_cnt_inc(vm, cr, __FILE__, __LINE__);

--- a/vm_sync.c
+++ b/vm_sync.c
@@ -1,4 +1,5 @@
 #include "internal/gc.h"
+#include "internal/thread.h"
 #include "vm_core.h"
 #include "vm_sync.h"
 #include "ractor_core.h"


### PR DESCRIPTION
This macro was originally a wrapper around `rb_gc_save_machine_context`, a function in `thread.c`, but that function doesn't exist anymore and now this macro doesn't do anything GC specific.

Because it's now being used from the context of the VM, or a thread. I've renamed it to `RB_VM_SAVE_MACHINE_CONTEXT` and moved it into `thread.h`. 