### PR TITLE
YJIT: Protect strings from GC on String#<<

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -4288,6 +4288,9 @@ fn jit_rb_str_concat(
     // Guard that the argument is of class String at runtime.
     let arg_type = ctx.get_opnd_type(StackOpnd(0));
 
+    // Guard buffers from GC since rb_str_buf_append may allocate.
+    gen_save_sp(asm, ctx);
+
     let concat_arg = ctx.stack_pop(1);
     let recv = ctx.stack_pop(1);
 


### PR DESCRIPTION
Fix https://github.com/Shopify/yjit/issues/310

[[Bug #19483]](https://bugs.ruby-lang.org/issues/19483)

`rb_str_buf_append` may allocate when a buffer needs to be reallocated. At that point, string objects could be freed and random bytes could be written to the string content. We need `gen_save_sp` to let GC scan and mark those objects.