### PR TITLE
YJIT: Handle splat+rest for args pass greater than required

### DIFF
--- a/array.c
+++ b/array.c
@@ -1802,6 +1802,12 @@ rb_ary_unshift_m(int argc, VALUE *argv, VALUE ary)
     return ary;
 }
 
+/* non-static for yjit */
+VALUE
+rb_yjit_rb_ary_unshift_m(int argc, VALUE *argv, VALUE ary) {
+    return rb_ary_unshift_m(argc, argv, ary);
+}
+
 VALUE
 rb_ary_unshift(VALUE ary, VALUE item)
 {

--- a/yjit.c
+++ b/yjit.c
@@ -848,6 +848,9 @@ rb_yarv_ary_entry_internal(VALUE ary, long offset)
 }
 
 VALUE
+rb_yjit_rb_ary_unshift_m(int argc, VALUE *argv, VALUE ary);
+
+VALUE
 rb_yarv_fix_mod_fix(VALUE recv, VALUE obj)
 {
     return rb_fix_mod_fix(recv, obj);

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -136,6 +136,7 @@ fn main() {
         .allowlist_function("rb_ary_resurrect")
         .allowlist_function("rb_ary_clear")
         .allowlist_function("rb_ary_dup")
+        .allowlist_function("rb_yjit_rb_ary_unshift_m")
 
         // From internal/array.h
         .allowlist_function("rb_ec_ary_new_from_values")

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -1297,6 +1297,11 @@ extern "C" {
     pub fn rb_yarv_str_eql_internal(str1: VALUE, str2: VALUE) -> VALUE;
     pub fn rb_str_neq_internal(str1: VALUE, str2: VALUE) -> VALUE;
     pub fn rb_yarv_ary_entry_internal(ary: VALUE, offset: ::std::os::raw::c_long) -> VALUE;
+    pub fn rb_yjit_rb_ary_unshift_m(
+        argc: ::std::os::raw::c_int,
+        argv: *mut VALUE,
+        ary: VALUE,
+    ) -> VALUE;
     pub fn rb_yarv_fix_mod_fix(recv: VALUE, obj: VALUE) -> VALUE;
     pub fn rb_yjit_dump_iseq_loc(iseq: *const rb_iseq_t, insn_idx: u32);
     pub fn rb_FL_TEST(obj: VALUE, flags: VALUE) -> VALUE;

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -253,7 +253,7 @@ make_counters! {
     send_send_getter,
     send_send_builtin,
     send_iseq_has_rest_and_captured,
-    send_iseq_has_rest_and_splat_not_equal,
+    send_iseq_has_rest_and_splat_fewer,
     send_iseq_has_rest_and_send,
     send_iseq_has_rest_and_block,
     send_iseq_has_rest_and_kw,


### PR DESCRIPTION
For example:

```ruby
def my_func(x, y, *rest)
    p [x, y, rest]
end

my_func(1, 2, 3, *[4, 5])
```