### PR TITLE
YJIT: Bump SEND_MAX_DEPTH to 20

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -353,9 +353,10 @@ fn verify_ctx(jit: &JITState, ctx: &Context) {
         // If the actual type differs from the learned type
         if val_type.diff(learned_type) == TypeDiff::Incompatible {
             panic!(
-                "verify_ctx: ctx type ({:?}) incompatible with actual value on stack: {}",
+                "verify_ctx: ctx type ({:?}) incompatible with actual value on stack: {} ({:?})",
                 learned_type,
-                obj_info_str(stack_val)
+                obj_info_str(stack_val),
+                val_type,
             );
         }
     }

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -1867,7 +1867,7 @@ pub const SET_IVAR_MAX_DEPTH: i32 = 10;
 pub const OPT_AREF_MAX_CHAIN_DEPTH: i32 = 2;
 
 // up to 10 different classes
-pub const SEND_MAX_DEPTH: i32 = 10;
+pub const SEND_MAX_DEPTH: i32 = 20;
 
 // up to 20 different methods for send
 pub const SEND_MAX_CHAIN_DEPTH: i32 = 20;

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -141,6 +141,7 @@ impl Type {
             Type::HeapSymbol => true,
             Type::TString => true,
             Type::CString => true,
+            Type::BlockParamProxy => true,
             _ => false,
         }
     }


### PR DESCRIPTION
This reduced `send_klass_megamorphic / side_exit_count` from 15.0% to 8.0% on SFR.

I needed to fix `Type::BlockParamProxy` to be `is_heap() => true` (indeed it is. it's a special "object") to pass test_objectspace.rb with `--yjit-verify-ctx` and this threshold.