### PR TITLE
Validate gemspec version more strictly

### DIFF
--- a/defs/gmake.mk
+++ b/defs/gmake.mk
@@ -354,7 +354,7 @@ $(srcdir)/.bundle/.timestamp/$(1).revision: \
 
 # The repository of minitest does not include minitest.gemspec because it uses hoe.
 # This creates a dummy gemspec.
-$(srcdir)/gems/src/$(1)/$(1).gemspec: \
+$(srcdir)/gems/src/$(1)/$(1).gemspec: $(srcdir)/.bundle/.timestamp/$(1).revision \
 	| $(srcdir)/gems/src/$(1)/.git
 	$(Q) $(BASERUBY) -I$(tooldir)/lib -rbundled_gem -e 'BundledGem.dummy_gemspec(*ARGV)' $$(@)
 

--- a/tool/fetch-bundled_gems.rb
+++ b/tool/fetch-bundled_gems.rb
@@ -23,6 +23,15 @@ end
 if r
   puts "fetching #{r} ..."
   system("git", "fetch", "origin", r, chdir: n) or abort
+
+  unless File.exist? "#{n}/#{n}.gemspec"
+    require_relative "lib/bundled_gem"
+    BundledGem.dummy_gemspec("#{n}/#{n}.gemspec")
+  end
+
+  # Check bundled_gems version and gemspec version same as BundledGem.build
+  spec = Gem::Specification.load("#{n}/#{n}.gemspec")
+  abort "Unexpected version #{spec.version}" unless spec.version == Gem::Version.new(v)
 end
 c = r || "v#{v}"
 checkout = %w"git -c advice.detachedHead=false checkout"

--- a/tool/fetch-bundled_gems.rb
+++ b/tool/fetch-bundled_gems.rb
@@ -31,7 +31,7 @@ if r
 
   # Check bundled_gems version and gemspec version same as BundledGem.build
   spec = Gem::Specification.load("#{n}/#{n}.gemspec")
-  abort "Unexpected version #{spec.version}" unless spec.version == Gem::Version.new(v)
+  abort "Unexpected versions between bundled_gems:#{v} and gemspec:#{spec.version}" unless spec.version == Gem::Version.new(v)
 end
 c = r || "v#{v}"
 checkout = %w"git -c advice.detachedHead=false checkout"

--- a/tool/fetch-bundled_gems.rb
+++ b/tool/fetch-bundled_gems.rb
@@ -30,6 +30,7 @@ if r
   end
 
   # Check bundled_gems version and gemspec version same as BundledGem.build
+  require "rubygems"
   spec = Gem::Specification.load("#{n}/#{n}.gemspec")
   abort "Unexpected versions between bundled_gems:#{v} and gemspec:#{spec.version}" unless spec.version == Gem::Version.new(v)
 end

--- a/tool/lib/bundled_gem.rb
+++ b/tool/lib/bundled_gem.rb
@@ -20,7 +20,9 @@ module BundledGem
     Dir.chdir(gemdir) do
       spec = Gem::Specification.load(gemfile)
       abort "Failed to load #{gemspec}" unless spec
-      abort "Unexpected versions between bundled_gems:#{version} and gemspec:#{spec.version}" unless spec.version == Gem::Version.new(version)
+      unless spec.version == Gem::Version.new(version)
+        abort "Unexpected versions between bundled_gems:#{version} and gemspec:#{spec.version}"
+      end
       output = File.join(outdir, spec.file_name)
       FileUtils.rm_rf(output)
       package = Gem::Package.new(output)

--- a/tool/lib/bundled_gem.rb
+++ b/tool/lib/bundled_gem.rb
@@ -20,7 +20,7 @@ module BundledGem
     Dir.chdir(gemdir) do
       spec = Gem::Specification.load(gemfile)
       abort "Failed to load #{gemspec}" unless spec
-      abort "Unexpected version #{spec.version}" unless spec.version == Gem::Version.new(version)
+      abort "Unexpected versions between bundled_gems:#{version} and gemspec:#{spec.version}" unless spec.version == Gem::Version.new(version)
       output = File.join(outdir, spec.file_name)
       FileUtils.rm_rf(output)
       package = Gem::Package.new(output)


### PR DESCRIPTION
The current bundled gems task couldn't handle the following cases:

* When `minitest` or other repos that don't have `gemspec` are updated the new version, `make install` is always fail because version mismatch. 
* When A version number or revision are changed unintentionally, `test-bundled-gems` skip to validate gemspec version. We only detect this version mismatch at `make install`.

I added to care above cases.