### PR TITLE
Make sure TestDefaultGems#test_validate_gemspec runs even when Dir.pwd != srcdir

### DIFF
--- a/test/ruby/test_default_gems.rb
+++ b/test/ruby/test_default_gems.rb
@@ -4,13 +4,20 @@ require 'rubygems'
 class TestDefaultGems < Test::Unit::TestCase
 
   def test_validate_gemspec
-    omit "git not found" unless system("git", "rev-parse", %i[out err]=>IO::NULL)
     srcdir = File.expand_path('../../..', __FILE__)
-    Dir.glob("#{srcdir}/{lib,ext}/**/*.gemspec").map do |src|
-      assert_nothing_raised do
-        raise("invalid spec in #{src}") unless Gem::Specification.load(src)
+    specs = 0
+    Dir.chdir(srcdir) do
+      unless system("git", "rev-parse", %i[out err]=>IO::NULL)
+        omit "git not found"
+      end
+      Dir.glob("#{srcdir}/{lib,ext}/**/*.gemspec").map do |src|
+        specs += 1
+        assert_nothing_raised do
+          raise("invalid spec in #{src}") unless Gem::Specification.load(src)
+        end
       end
     end
+    assert specs > 0, "gemspecs not found"
   end
 
 end


### PR DESCRIPTION
This test was omitted if git rev-parse wasn't valid in current directory.
For instance, when running tests in build directory like:

$ make test-all TESTOPTS="../ruby/test"