### PR TITLE
Remove `rb_sigwait_fd_*` and related internal implementation.

### DIFF
--- a/process.c
+++ b/process.c
@@ -1072,10 +1072,6 @@ struct waitpid_state {
     int errnum;
 };
 
-int rb_sigwait_fd_get(const rb_thread_t *);
-void rb_sigwait_sleep(const rb_thread_t *, int fd, const rb_hrtime_t *);
-void rb_sigwait_fd_put(const rb_thread_t *, int fd);
-
 static void
 waitpid_state_init(struct waitpid_state *w, rb_pid_t pid, int options)
 {

--- a/test.rb
+++ b/test.rb
@@ -1,0 +1,12 @@
+1000.times do |i|
+	$stderr.puts i
+	queue = Thread::Queue.new
+	r, w = IO.pipe
+	th = Thread.start do
+		queue.push(nil)
+		r.read 1
+	end
+	queue.pop
+	th.kill
+	th.join
+end


### PR DESCRIPTION
This code path adds a lot of complexity but does not serve any purpose after MJIT was removed. It was primarily used for handling SIGCHLD. It should be more efficient to handle signals directly.