### PR TITLE
Remove special handling of `SIGCHLD`.

### DIFF
--- a/signal.c
+++ b/signal.c
@@ -508,9 +508,6 @@ static struct {
     rb_atomic_t cnt[RUBY_NSIG];
     rb_atomic_t size;
 } signal_buff;
-#if RUBY_SIGCHLD
-volatile unsigned int ruby_nocldwait;
-#endif
 
 #define sighandler_t ruby_sighandler_t
 
@@ -608,27 +605,6 @@ ruby_signal(int signum, sighandler_t handler)
 #endif
 
     switch (signum) {
-#if RUBY_SIGCHLD
-      case RUBY_SIGCHLD:
-        if (handler == SIG_IGN) {
-            ruby_nocldwait = 1;
-# ifdef USE_SIGALTSTACK
-            if (sigact.sa_flags & SA_SIGINFO) {
-                sigact.sa_sigaction = (ruby_sigaction_t*)sighandler;
-            }
-            else {
-                sigact.sa_handler = sighandler;
-            }
-# else
-            sigact.sa_handler = handler;
-            sigact.sa_flags = 0;
-# endif
-        }
-        else {
-            ruby_nocldwait = 0;
-        }
-        break;
-#endif
 #if defined(SA_ONSTACK) && defined(USE_SIGALTSTACK)
       case SIGSEGV:
 #ifdef SIGBUS
@@ -707,35 +683,14 @@ signal_enque(int sig)
     ATOMIC_INC(signal_buff.size);
 }
 
-#if RUBY_SIGCHLD
-static rb_atomic_t sigchld_hit;
-/* destructive getter than simple predicate */
-# define GET_SIGCHLD_HIT() ATOMIC_EXCHANGE(sigchld_hit, 0)
-#else
-# define GET_SIGCHLD_HIT() 0
-#endif
-
 static void
 sighandler(int sig)
 {
     int old_errnum = errno;
 
-    /* the VM always needs to handle SIGCHLD for rb_waitpid */
-    if (sig == RUBY_SIGCHLD) {
-#if RUBY_SIGCHLD
-        rb_vm_t *vm = GET_VM();
-        ATOMIC_EXCHANGE(sigchld_hit, 1);
-
-        /* avoid spurious wakeup in main thread if and only if nobody uses trap(:CHLD) */
-        if (vm && ACCESS_ONCE(VALUE, vm->trap_list.cmd[sig])) {
-            signal_enque(sig);
-        }
-#endif
-    }
-    else {
-        signal_enque(sig);
-    }
+    signal_enque(sig);
     rb_thread_wakeup_timer_thread(sig);
+
 #if !defined(BSD_SIGNAL) && !defined(POSIX_SIGNAL)
     ruby_signal(sig, sighandler);
 #endif
@@ -1152,9 +1107,6 @@ default_handler(int sig)
 #ifdef SIGUSR2
       case SIGUSR2:
 #endif
-#if RUBY_SIGCHLD
-      case RUBY_SIGCHLD:
-#endif
         func = sighandler;
         break;
 #ifdef SIGBUS
@@ -1220,9 +1172,6 @@ trap_handler(VALUE *cmd, int sig)
                 break;
               case 14:
                 if (memcmp(cptr, "SYSTEM_DEFAULT", 14) == 0) {
-                    if (sig == RUBY_SIGCHLD) {
-                        goto sig_dfl;
-                    }
                     func = SIG_DFL;
                     *cmd = 0;
                 }


### PR DESCRIPTION
Previously, `waitpid` depended on specific behaviour for `SIGCHLD`, because that implementation is removed, we can simplify `signal.c`.

This is a follow up from <https://github.com/ruby/ruby/pull/7476>.