### PR TITLE
`vm_call_single_noarg_inline_builtin`

### DIFF
--- a/array.c
+++ b/array.c
@@ -1428,20 +1428,11 @@ enum ary_take_pos_flags
 };
 
 static VALUE
-ary_take_first_or_last(int argc, const VALUE *argv, VALUE ary, enum ary_take_pos_flags last)
+ary_take_first_or_last_n(VALUE ary, long n, enum ary_take_pos_flags last)
 {
-    long n;
-    long len;
+    long len = RARRAY_LEN(ary);
     long offset = 0;
 
-    argc = rb_check_arity(argc, 0, 1);
-    /* the case optional argument is omitted should be handled in
-     * callers of this function.  if another arity case is added,
-     * this arity check needs to rewrite. */
-    RUBY_ASSERT_ALWAYS(argc == 1);
-
-    n = NUM2LONG(argv[0]);
-    len = RARRAY_LEN(ary);
     if (n > len) {
         n = len;
     }
@@ -1452,6 +1443,17 @@ ary_take_first_or_last(int argc, const VALUE *argv, VALUE ary, enum ary_take_pos
         offset = len - n;
     }
     return ary_make_partial(ary, rb_cArray, offset, n);
+}
+
+static VALUE
+ary_take_first_or_last(int argc, const VALUE *argv, VALUE ary, enum ary_take_pos_flags last)
+{
+    argc = rb_check_arity(argc, 0, 1);
+    /* the case optional argument is omitted should be handled in
+     * callers of this function.  if another arity case is added,
+     * this arity check needs to rewrite. */
+    RUBY_ASSERT_ALWAYS(argc == 1);
+    return ary_take_first_or_last_n(ary, NUM2LONG(argv[0]), last);
 }
 
 /*
@@ -2027,6 +2029,7 @@ rb_ary_at(VALUE ary, VALUE pos)
     return rb_ary_entry(ary, NUM2LONG(pos));
 }
 
+#if 0
 /*
  *  call-seq:
  *    array.first -> object or nil
@@ -2071,6 +2074,20 @@ rb_ary_first(int argc, VALUE *argv, VALUE ary)
         return ary_take_first_or_last(argc, argv, ary, ARY_TAKE_FIRST);
     }
 }
+#endif
+
+static VALUE
+ary_first(VALUE self)
+{
+    return (RARRAY_LEN(self) == 0) ? Qnil : RARRAY_AREF(self, 0);
+}
+
+static VALUE
+ary_last(VALUE self)
+{
+    long len = RARRAY_LEN(self);
+    return (len == 0) ? Qnil : RARRAY_AREF(self, len-1);
+}
 
 /*
  *  call-seq:
@@ -2107,12 +2124,10 @@ rb_ary_first(int argc, VALUE *argv, VALUE ary)
  */
 
 VALUE
-rb_ary_last(int argc, const VALUE *argv, VALUE ary)
+rb_ary_last(int argc, const VALUE *argv, VALUE ary) // used by parse.y
 {
     if (argc == 0) {
-        long len = RARRAY_LEN(ary);
-        if (len == 0) return Qnil;
-        return RARRAY_AREF(ary, len-1);
+        return ary_last(ary);
     }
     else {
         return ary_take_first_or_last(argc, argv, ary, ARY_TAKE_LAST);
@@ -8809,8 +8824,6 @@ Init_Array(void)
     rb_define_method(rb_cArray, "[]=", rb_ary_aset, -1);
     rb_define_method(rb_cArray, "at", rb_ary_at, 1);
     rb_define_method(rb_cArray, "fetch", rb_ary_fetch, -1);
-    rb_define_method(rb_cArray, "first", rb_ary_first, -1);
-    rb_define_method(rb_cArray, "last", rb_ary_last, -1);
     rb_define_method(rb_cArray, "concat", rb_ary_concat_multi, -1);
     rb_define_method(rb_cArray, "union", rb_ary_union_multi, -1);
     rb_define_method(rb_cArray, "difference", rb_ary_difference_multi, -1);

--- a/array.rb
+++ b/array.rb
@@ -66,4 +66,30 @@ class Array
       Primitive.ary_sample(random, n, ary)
     end
   end
+
+  def first n = unspecified = true
+    if Primitive.mandatory_only?
+      Primitive.attr! :leaf
+      Primitive.cexpr! %q{ ary_first(self) }
+    else
+      if unspecified
+        Primitive.cexpr! %q{ ary_first(self) }
+      else
+        Primitive.cexpr! %q{  ary_take_first_or_last_n(self, NUM2LONG(n), ARY_TAKE_FIRST) }
+      end
+    end
+  end
+
+  def last n = unspecified = true
+    if Primitive.mandatory_only?
+      Primitive.attr! :leaf
+      Primitive.cexpr! %q{ ary_last(self) }
+    else
+      if unspecified
+        Primitive.cexpr! %q{ ary_last(self) }
+      else
+        Primitive.cexpr! %q{ ary_take_first_or_last_n(self, NUM2LONG(n), ARY_TAKE_LAST) }
+      end
+    end
+  end
 end

--- a/compile.c
+++ b/compile.c
@@ -8348,15 +8348,12 @@ compile_builtin_mandatory_only_method(rb_iseq_t *iseq, const NODE *node, const N
         .script_lines = ISEQ_BODY(iseq)->variable.script_lines,
     };
 
-    int prev_inline_index = GET_VM()->builtin_inline_index;
-
     ISEQ_BODY(iseq)->mandatory_only_iseq =
       rb_iseq_new_with_opt(&ast, rb_iseq_base_label(iseq),
                            rb_iseq_path(iseq), rb_iseq_realpath(iseq),
                            nd_line(line_node), NULL, 0,
                            ISEQ_TYPE_METHOD, ISEQ_COMPILE_DATA(iseq)->option);
 
-    GET_VM()->builtin_inline_index = prev_inline_index;
     ALLOCV_END(idtmp);
     return COMPILE_OK;
 }

--- a/compile.c
+++ b/compile.c
@@ -3646,6 +3646,10 @@ iseq_peephole_optimize(rb_iseq_t *iseq, LINK_ELEMENT *list, const int do_tailcal
         if (IS_TRACE(iobj->link.next)) {
             if (IS_NEXT_INSN_ID(iobj->link.next, leave)) {
                 iobj->insn_id = BIN(opt_invokebuiltin_delegate_leave);
+                const struct rb_builtin_function *bf = (const struct rb_builtin_function *)iobj->operands[0];
+                if (iobj == (INSN *)list && bf->argc == 0 && (iseq->body->builtin_attrs & BUILTIN_ATTR_LEAF)) {
+                    iseq->body->builtin_attrs |= BUILTIN_ATTR_SINGLE_NOARG_INLINE;
+                }
             }
         }
     }

--- a/iseq.c
+++ b/iseq.c
@@ -3550,8 +3550,31 @@ rb_iseq_trace_set(const rb_iseq_t *iseq, rb_event_flag_t turnon_events)
     }
 }
 
-bool rb_vm_call_ivar_attrset_p(const vm_call_handler ch);
 void rb_vm_cc_general(const struct rb_callcache *cc);
+
+static bool
+clear_attr_cc(VALUE v)
+{
+    if (imemo_type_p(v, imemo_callcache) && vm_cc_ivar_p((const struct rb_callcache *)v)) {
+        rb_vm_cc_general((struct rb_callcache *)v);
+        return true;
+    }
+    else {
+        return false;
+    }
+}
+
+static bool
+clear_bf_cc(VALUE v)
+{
+    if (imemo_type_p(v, imemo_callcache) && vm_cc_bf_p((const struct rb_callcache *)v)) {
+        rb_vm_cc_general((struct rb_callcache *)v);
+        return true;
+    }
+    else {
+        return false;
+    }
+}
 
 static int
 clear_attr_ccs_i(void *vstart, void *vend, size_t stride, void *data)
@@ -3560,11 +3583,7 @@ clear_attr_ccs_i(void *vstart, void *vend, size_t stride, void *data)
     for (; v != (VALUE)vend; v += stride) {
         void *ptr = asan_poisoned_object_p(v);
         asan_unpoison_object(v, false);
-
-        if (imemo_type_p(v, imemo_callcache) && rb_vm_call_ivar_attrset_p(((const struct rb_callcache *)v)->call_)) {
-            rb_vm_cc_general((struct rb_callcache *)v);
-        }
-
+        clear_attr_cc(v);
         asan_poison_object_if(ptr, v);
     }
     return 0;
@@ -3574,6 +3593,25 @@ void
 rb_clear_attr_ccs(void)
 {
     rb_objspace_each_objects(clear_attr_ccs_i, NULL);
+}
+
+static int
+clear_bf_ccs_i(void *vstart, void *vend, size_t stride, void *data)
+{
+    VALUE v = (VALUE)vstart;
+    for (; v != (VALUE)vend; v += stride) {
+        void *ptr = asan_poisoned_object_p(v);
+        asan_unpoison_object(v, false);
+        clear_bf_cc(v);
+        asan_poison_object_if(ptr, v);
+    }
+    return 0;
+}
+
+void
+rb_clear_bf_ccs(void)
+{
+    rb_objspace_each_objects(clear_bf_ccs_i, NULL);
 }
 
 static int
@@ -3589,8 +3627,9 @@ trace_set_i(void *vstart, void *vend, size_t stride, void *data)
         if (rb_obj_is_iseq(v)) {
             rb_iseq_trace_set(rb_iseq_check((rb_iseq_t *)v), turnon_events);
         }
-        else if (imemo_type_p(v, imemo_callcache) && rb_vm_call_ivar_attrset_p(((const struct rb_callcache *)v)->call_)) {
-            rb_vm_cc_general((struct rb_callcache *)v);
+        else if (clear_attr_cc(v)) {
+        }
+        else if (clear_bf_cc(v)) {
         }
 
         asan_poison_object_if(ptr, v);

--- a/rjit_c.rb
+++ b/rjit_c.rb
@@ -952,6 +952,7 @@ module RubyVM::RJIT # :nodoc: all
         ),
         method_missing_reason: self.method_missing_reason,
         v: self.VALUE,
+        bf: CType::Pointer.new { self.rb_builtin_function },
       ), Primitive.cexpr!("OFFSETOF((*((struct rb_callcache *)NULL)), aux_)")],
     )
   end

--- a/vm_callinfo.h
+++ b/vm_callinfo.h
@@ -290,6 +290,7 @@ struct rb_callcache {
         } attr;
         const enum method_missing_reason method_missing_reason; /* used by method_missing */
         VALUE v;
+        const struct rb_builtin_function *bf;
     } aux_;
 };
 
@@ -439,6 +440,9 @@ vm_cc_valid_p(const struct rb_callcache *cc, const rb_callable_method_entry_t *c
 
 /* callcache: mutate */
 
+#define VM_CALLCACH_IVAR IMEMO_FL_USER0
+#define VM_CALLCACH_BF IMEMO_FL_USER1
+
 static inline void
 vm_cc_call_set(const struct rb_callcache *cc, vm_call_handler call)
 {
@@ -458,6 +462,13 @@ vm_cc_attr_index_set(const struct rb_callcache *cc, attr_index_t index, shape_id
     VM_ASSERT(IMEMO_TYPE_P(cc, imemo_callcache));
     VM_ASSERT(cc != vm_cc_empty());
     *attr_value = (attr_index_t)(index + 1) | ((uintptr_t)(dest_shape_id) << SHAPE_FLAG_SHIFT);
+    *(VALUE *)&cc->flags |= VM_CALLCACH_IVAR;
+}
+
+static inline bool
+vm_cc_ivar_p(const struct rb_callcache *cc)
+{
+    return (cc->flags & VM_CALLCACH_IVAR) != 0;
 }
 
 static inline void
@@ -478,6 +489,21 @@ vm_cc_method_missing_reason_set(const struct rb_callcache *cc, enum method_missi
     VM_ASSERT(IMEMO_TYPE_P(cc, imemo_callcache));
     VM_ASSERT(cc != vm_cc_empty());
     *(enum method_missing_reason *)&cc->aux_.method_missing_reason = reason;
+}
+
+static inline void
+vm_cc_bf_set(const struct rb_callcache *cc, const struct rb_builtin_function *bf)
+{
+    VM_ASSERT(IMEMO_TYPE_P(cc, imemo_callcache));
+    VM_ASSERT(cc != vm_cc_empty());
+    *(const struct rb_builtin_function **)&cc->aux_.bf = bf;
+    *(VALUE *)&cc->flags |= VM_CALLCACH_BF;
+}
+
+static inline bool
+vm_cc_bf_p(const struct rb_callcache *cc)
+{
+    return (cc->flags & VM_CALLCACH_BF) != 0;
 }
 
 static inline void

--- a/vm_core.h
+++ b/vm_core.h
@@ -371,6 +371,8 @@ enum rb_builtin_attr {
     BUILTIN_ATTR_LEAF = 0x01,
     // The iseq does not allocate objects.
     BUILTIN_ATTR_NO_GC = 0x02,
+    // This iseq only contains single `opt_invokebuiltin_delegate_leave` instruction with 0 arguments.
+    BUILTIN_ATTR_SINGLE_NOARG_INLINE = 0x04,
 };
 
 typedef VALUE (*rb_jit_func_t)(struct rb_execution_context_struct *, struct rb_control_frame_struct *);

--- a/vm_trace.c
+++ b/vm_trace.c
@@ -93,6 +93,7 @@ rb_hook_list_free(rb_hook_list_t *hooks)
 /* ruby_vm_event_flags management */
 
 void rb_clear_attr_ccs(void);
+void rb_clear_bf_ccs(void);
 
 static void
 update_global_event_hook(rb_event_flag_t prev_events, rb_event_flag_t new_events)
@@ -102,6 +103,8 @@ update_global_event_hook(rb_event_flag_t prev_events, rb_event_flag_t new_events
     bool first_time_iseq_events_p = new_iseq_events & ~enabled_iseq_events;
     bool enable_c_call   = (prev_events & RUBY_EVENT_C_CALL)   == 0 && (new_events & RUBY_EVENT_C_CALL);
     bool enable_c_return = (prev_events & RUBY_EVENT_C_RETURN) == 0 && (new_events & RUBY_EVENT_C_RETURN);
+    bool enable_call     = (prev_events & RUBY_EVENT_CALL)     == 0 && (new_events & RUBY_EVENT_CALL);
+    bool enable_return   = (prev_events & RUBY_EVENT_RETURN)   == 0 && (new_events & RUBY_EVENT_RETURN);
 
     // Modify ISEQs or CCs to enable tracing
     if (first_time_iseq_events_p) {
@@ -111,6 +114,9 @@ update_global_event_hook(rb_event_flag_t prev_events, rb_event_flag_t new_events
     // if c_call or c_return is activated
     else if (enable_c_call || enable_c_return) {
         rb_clear_attr_ccs();
+    }
+    else if (enable_call || enable_return) {
+        rb_clear_bf_ccs();
     }
 
     ruby_vm_event_flags = new_events;
@@ -1258,6 +1264,10 @@ rb_tracepoint_enable_for_target(VALUE tpval, VALUE target, VALUE target_line)
     n += rb_iseq_add_local_tracepoint_recursively(iseq, tp->events, tpval, line, target_bmethod);
     rb_hash_aset(tp->local_target_set, (VALUE)iseq, Qtrue);
 
+    if ((tp->events & (RUBY_EVENT_CALL | RUBY_EVENT_RETURN)) &&
+        iseq->body->builtin_attrs & BUILTIN_ATTR_SINGLE_NOARG_INLINE) {
+        rb_clear_bf_ccs();
+    }
 
     if (n == 0) {
         rb_raise(rb_eArgError, "can not enable any hooks");

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -664,6 +664,7 @@ pub struct iseq_inline_cvar_cache_entry {
 }
 pub const BUILTIN_ATTR_LEAF: rb_builtin_attr = 1;
 pub const BUILTIN_ATTR_NO_GC: rb_builtin_attr = 2;
+pub const BUILTIN_ATTR_SINGLE_NOARG_INLINE: rb_builtin_attr = 4;
 pub type rb_builtin_attr = u32;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]


### PR DESCRIPTION
    If the iseq only contains `opt_invokebuiltin_delegate_leave` insn and
    the builtin-function (bf) is inline-able, the caller doesn't need to
    build a method frame.

    `vm_call_single_noarg_inline_builtin` is fast path for such cases.
