### PR TITLE
YJIT: Implement throw instruction

### DIFF
--- a/insns.def
+++ b/insns.def
@@ -814,6 +814,11 @@ send
     VALUE bh = vm_caller_setup_arg_block(ec, GET_CFP(), cd->ci, blockiseq, false);
     val = vm_sendish(ec, GET_CFP(), cd, bh, mexp_search_method);
 
+    jit_func_t func;
+    if (val == Qundef && (func = jit_compile(ec))) {
+        val = func(ec, ec->cfp);
+    }
+
     if (val == Qundef) {
         RESTORE_REGS();
         NEXT_INSN();
@@ -832,6 +837,11 @@ opt_send_without_block
 {
     VALUE bh = VM_BLOCK_HANDLER_NONE;
     val = vm_sendish(ec, GET_CFP(), cd, bh, mexp_search_method);
+
+    jit_func_t func;
+    if (val == Qundef && (func = jit_compile(ec))) {
+        val = func(ec, ec->cfp);
+    }
 
     if (val == Qundef) {
         RESTORE_REGS();
@@ -935,6 +945,11 @@ invokesuper
     VALUE bh = vm_caller_setup_arg_block(ec, GET_CFP(), cd->ci, blockiseq, true);
     val = vm_sendish(ec, GET_CFP(), cd, bh, mexp_search_super);
 
+    jit_func_t func;
+    if (val == Qundef && (func = jit_compile(ec))) {
+        val = func(ec, ec->cfp);
+    }
+
     if (val == Qundef) {
         RESTORE_REGS();
         NEXT_INSN();
@@ -953,6 +968,11 @@ invokeblock
 {
     VALUE bh = VM_BLOCK_HANDLER_NONE;
     val = vm_sendish(ec, GET_CFP(), cd, bh, mexp_search_invokeblock);
+
+    jit_func_t func;
+    if (val == Qundef && (func = jit_compile(ec))) {
+        val = func(ec, ec->cfp);
+    }
 
     if (val == Qundef) {
         RESTORE_REGS();

--- a/insns.def
+++ b/insns.def
@@ -817,6 +817,7 @@ send
     jit_func_t func;
     if (val == Qundef && (func = jit_compile(ec))) {
         val = func(ec, ec->cfp);
+        if (ec->tag->state) THROW_EXCEPTION(val);
     }
 
     if (val == Qundef) {
@@ -841,6 +842,7 @@ opt_send_without_block
     jit_func_t func;
     if (val == Qundef && (func = jit_compile(ec))) {
         val = func(ec, ec->cfp);
+        if (ec->tag->state) THROW_EXCEPTION(val);
     }
 
     if (val == Qundef) {
@@ -948,6 +950,7 @@ invokesuper
     jit_func_t func;
     if (val == Qundef && (func = jit_compile(ec))) {
         val = func(ec, ec->cfp);
+        if (ec->tag->state) THROW_EXCEPTION(val);
     }
 
     if (val == Qundef) {
@@ -972,6 +975,7 @@ invokeblock
     jit_func_t func;
     if (val == Qundef && (func = jit_compile(ec))) {
         val = func(ec, ec->cfp);
+        if (ec->tag->state) THROW_EXCEPTION(val);
     }
 
     if (val == Qundef) {

--- a/vm.c
+++ b/vm.c
@@ -369,11 +369,9 @@ extern VALUE rb_vm_invoke_bmethod(rb_execution_context_t *ec, rb_proc_t *proc, V
 static VALUE vm_invoke_proc(rb_execution_context_t *ec, rb_proc_t *proc, VALUE self, int argc, const VALUE *argv, int kw_splat, VALUE block_handler);
 
 #if USE_RJIT || USE_YJIT
-// Try to execute the current iseq in ec.  Use JIT code if it is ready.
-// If it is not, add ISEQ to the compilation queue and return Qundef for RJIT.
-// YJIT compiles on the thread running the iseq.
-static inline VALUE
-jit_exec(rb_execution_context_t *ec)
+// Try to compile the current ISeq in ec. Return 0 if not compiled.
+static inline jit_func_t
+jit_compile(rb_execution_context_t *ec)
 {
     // Increment the ISEQ's call counter
     const rb_iseq_t *iseq = ec->cfp->iseq;
@@ -383,43 +381,42 @@ jit_exec(rb_execution_context_t *ec)
         body->total_calls++;
     }
     else {
-        return Qundef;
+        return 0;
     }
 
     // Trigger JIT compilation as needed
-    jit_func_t func;
     if (yjit_enabled) {
         if (body->total_calls == rb_yjit_call_threshold())  {
-            // If we couldn't generate any code for this iseq, then return
-            // Qundef so the interpreter will handle the call.
-            if (!rb_yjit_compile_iseq(iseq, ec)) {
-                return Qundef;
-            }
-        }
-        // YJIT tried compiling this function once before and couldn't do
-        // it, so return Qundef so the interpreter handles it.
-        if ((func = body->jit_func) == 0) {
-            return Qundef;
+            rb_yjit_compile_iseq(iseq, ec);
         }
     }
     else { // rb_rjit_call_p
         if (body->total_calls == rb_rjit_call_threshold()) {
             rb_rjit_compile(iseq);
         }
-        if ((func = body->jit_func) == 0) {
-            return Qundef;
-        }
     }
 
-    // Call the JIT code
-    return func(ec, ec->cfp); // SystemV x64 calling convention: ec -> RDI, cfp -> RSI
+    return body->jit_func;
 }
-#else
+
+// Try to execute the current iseq in ec.  Use JIT code if it is ready.
+// If it is not, add ISEQ to the compilation queue and return Qundef for RJIT.
+// YJIT compiles on the thread running the iseq.
 static inline VALUE
 jit_exec(rb_execution_context_t *ec)
 {
-    return Qundef;
+    jit_func_t func = jit_compile(ec);
+    if (func) {
+        // Call the JIT code
+        return func(ec, ec->cfp);
+    }
+    else {
+        return Qundef;
+    }
 }
+#else
+static inline jit_func_t jit_compile(rb_execution_context_t *ec) { return 0; }
+static inline VALUE jit_exec(rb_execution_context_t *ec) { return Qundef; }
 #endif
 
 #include "vm_insnhelper.c"

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1823,6 +1823,12 @@ vm_throw(const rb_execution_context_t *ec, rb_control_frame_t *reg_cfp,
     }
 }
 
+VALUE
+rb_vm_throw(const rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, rb_num_t throw_state, VALUE throwobj)
+{
+    return vm_throw(ec, reg_cfp, throw_state, throwobj);
+}
+
 static inline void
 vm_expandarray(VALUE *sp, VALUE ary, rb_num_t num, int flag)
 {

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -5211,15 +5211,7 @@ vm_sendish(
         val = vm_invokeblock_i(ec, GET_CFP(), &calling);
         break;
     }
-
-    if (!UNDEF_P(val)) {
-        return val;             /* CFUNC normal return */
-    }
-    else {
-        RESTORE_REGS();         /* CFP pushed in cc->call() */
-    }
-
-    return jit_exec(ec);
+    return val;
 }
 
 /* object.c */

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -3714,6 +3714,9 @@ fn gen_throw(
     jit_save_pc(jit, asm);
     gen_save_sp(asm, ctx);
 
+    // rb_vm_throw verifies it's a valid throw, sets ec->tag->state, and returns throw
+    // data, which is throwobj or a vm_throw_data wrapping it. When ec->tag->state is
+    // set, JIT code callers will handle the throw with vm_exec_handle_exception.
     extern "C" {
         fn rb_vm_throw(ec: EcPtr, reg_cfp: CfpPtr, throw_state: u32, throwobj: VALUE) -> VALUE;
     }


### PR DESCRIPTION
This PR does:

* Break up `jit_exec` from `vm_sendish`
  * We need this to have `THROW_INSTRUCTION` (`return`) directly in insns.def
* Implement a general path for `throw` insn on YJIT
  * This saves one instruction dispatch compared to a side exit.
  * In another PR, we should add a Ruby-to-Ruby jump as a fast path.

## Benchmark
### Interpreter
```
before: ruby 3.3.0dev (2023-03-14T17:26:05Z master 76f2031884) [x86_64-linux]
after: ruby 3.3.0dev (2023-03-14T18:13:45Z yjit-throw-inline 152ccbe859) [x86_64-linux]

-------------  -----------  ----------  ----------  ----------  ------------  -------------
bench          before (ms)  stddev (%)  after (ms)  stddev (%)  before/after  after 1st itr
liquid-render  116.3        1.6         109.0       1.3         1.07          1.07
railsbench     1554.1       0.7         1521.1      0.9         1.02          1.01
-------------  -----------  ----------  ----------  ----------  ------------  -------------
```

### YJIT
```
before: ruby 3.3.0dev (2023-03-14T17:26:05Z master 76f2031884) +YJIT [x86_64-linux]
after: ruby 3.3.0dev (2023-03-14T18:13:45Z yjit-throw-inline 152ccbe859) +YJIT [x86_64-linux]

-------------  -----------  ----------  ----------  ----------  ------------  -------------
bench          before (ms)  stddev (%)  after (ms)  stddev (%)  before/after  after 1st itr
liquid-render  59.9         3.0         58.2        2.7         1.03          1.01
railsbench     1002.9       1.9         998.1       1.8         1.00          1.00
-------------  -----------  ----------  ----------  ----------  ------------  -------------
```