### PR TITLE
YJIT: Merge add/sub/and/or/xor and mov on x86_64

### DIFF
--- a/yjit/src/backend/x86_64/mod.rs
+++ b/yjit/src/backend/x86_64/mod.rs
@@ -166,29 +166,41 @@ impl Assembler
                 Insn::And { left, right, out } |
                 Insn::Or { left, right, out } |
                 Insn::Xor { left, right, out } => {
-                    match (unmapped_opnds[0], unmapped_opnds[1]) {
-                        (Opnd::Mem(_), Opnd::Mem(_)) => {
-                            *left = asm.load(*left);
-                            *right = asm.load(*right);
-                        },
-                        (Opnd::Mem(_), Opnd::UImm(_) | Opnd::Imm(_)) => {
-                            *left = asm.load(*left);
-                        },
-                        // Instruction output whose live range spans beyond this instruction
-                        (Opnd::InsnOut { idx, .. }, _) => {
-                            if live_ranges[idx] > index {
-                                *left = asm.load(*left);
-                            }
-                        },
-                        // We have to load memory operands to avoid corrupting them
-                        (Opnd::Mem(_) | Opnd::Reg(_), _) => {
-                            *left = asm.load(*left);
-                        },
-                        _ => {}
-                    };
+                    match (&left, &right, iterator.peek()) {
+                        // Merge this insn, e.g. `add REG, right -> out`, and `mov REG, out` if possible
+                        (Opnd::Reg(_), Opnd::UImm(value), Some(Insn::Mov { dest, src }))
+                        if out == src && left == dest && live_ranges[index] == index + 1 && uimm_num_bits(*value) <= 32 => {
+                            *out = *dest;
+                            asm.push_insn(insn);
+                            iterator.map_insn_index(&mut asm);
+                            iterator.next_unmapped(); // Pop merged Insn::Mov
+                        }
+                        _ => {
+                            match (unmapped_opnds[0], unmapped_opnds[1]) {
+                                (Opnd::Mem(_), Opnd::Mem(_)) => {
+                                    *left = asm.load(*left);
+                                    *right = asm.load(*right);
+                                },
+                                (Opnd::Mem(_), Opnd::UImm(_) | Opnd::Imm(_)) => {
+                                    *left = asm.load(*left);
+                                },
+                                // Instruction output whose live range spans beyond this instruction
+                                (Opnd::InsnOut { idx, .. }, _) => {
+                                    if live_ranges[idx] > index {
+                                        *left = asm.load(*left);
+                                    }
+                                },
+                                // We have to load memory operands to avoid corrupting them
+                                (Opnd::Mem(_) | Opnd::Reg(_), _) => {
+                                    *left = asm.load(*left);
+                                },
+                                _ => {}
+                            };
 
-                    *out = asm.next_opnd_out(Opnd::match_num_bits(&[*left, *right]));
-                    asm.push_insn(insn);
+                            *out = asm.next_opnd_out(Opnd::match_num_bits(&[*left, *right]));
+                            asm.push_insn(insn);
+                        }
+                    }
                 },
                 Insn::Cmp { left, right } => {
                     // Replace `cmp REG, 0` (4 bytes) with `test REG, REG` (3 bytes)
@@ -952,5 +964,60 @@ mod tests {
         asm.compile_with_num_regs(&mut cb, 2);
 
         assert_eq!(format!("{:x}", cb), "488b43084885c0b814000000b900000000480f45c14889c0");
+    }
+
+    #[test]
+    fn test_merge_add_mov() {
+        let (mut asm, mut cb) = setup_asm();
+
+        let sp = asm.add(CFP, Opnd::UImm(0x40));
+        asm.mov(CFP, sp); // should be merged to add
+        asm.compile_with_num_regs(&mut cb, 1);
+
+        assert_eq!(format!("{:x}", cb), "4983c540");
+    }
+
+    #[test]
+    fn test_merge_sub_mov() {
+        let (mut asm, mut cb) = setup_asm();
+
+        let sp = asm.sub(CFP, Opnd::UImm(0x40));
+        asm.mov(CFP, sp); // should be merged to add
+        asm.compile_with_num_regs(&mut cb, 1);
+
+        assert_eq!(format!("{:x}", cb), "4983ed40");
+    }
+
+    #[test]
+    fn test_merge_and_mov() {
+        let (mut asm, mut cb) = setup_asm();
+
+        let sp = asm.and(CFP, Opnd::UImm(0x40));
+        asm.mov(CFP, sp); // should be merged to add
+        asm.compile_with_num_regs(&mut cb, 1);
+
+        assert_eq!(format!("{:x}", cb), "4983e540");
+    }
+
+    #[test]
+    fn test_merge_or_mov() {
+        let (mut asm, mut cb) = setup_asm();
+
+        let sp = asm.or(CFP, Opnd::UImm(0x40));
+        asm.mov(CFP, sp); // should be merged to add
+        asm.compile_with_num_regs(&mut cb, 1);
+
+        assert_eq!(format!("{:x}", cb), "4983cd40");
+    }
+
+    #[test]
+    fn test_merge_xor_mov() {
+        let (mut asm, mut cb) = setup_asm();
+
+        let sp = asm.xor(CFP, Opnd::UImm(0x40));
+        asm.mov(CFP, sp); // should be merged to add
+        asm.compile_with_num_regs(&mut cb, 1);
+
+        assert_eq!(format!("{:x}", cb), "4983f540");
     }
 }


### PR DESCRIPTION
## Generated code
This PR does the following optimization in the backend.

### Before
```asm
  # pop stack frame
  0x55b7c734e169: mov rax, r13
  0x55b7c734e16c: add rax, 0x40
  0x55b7c734e170: mov r13, rax
```
### After
```asm
  # pop stack frame
  0x559ec891a169: add r13, 0x40
```

## railsbench code size
### Before
```
inline_code_size:          2,169,119
outlined_code_size:        2,167,668
```

### After
```
inline_code_size:          2,143,498
outlined_code_size:        2,141,916
```

## 30k_methods
This seems to speed up 30k_methods a little.

```
before: ruby 3.3.0dev (2023-03-09T21:14:01Z master 9546c70e09) +YJIT [x86_64-linux]
after: ruby 3.3.0dev (2023-03-09T23:49:25Z yjit-lea-args 9ebb3e64a1) +YJIT [x86_64-linux]

-----------  -----------  ----------  ----------  ----------  ------------  -------------
bench        before (ms)  stddev (%)  after (ms)  stddev (%)  before/after  after 1st itr
30k_methods  800.1        0.2         788.2       1.0         1.02          1.00
-----------  -----------  ----------  ----------  ----------  ------------  -------------
```