### PR TITLE
Fix indirect counter increment

### DIFF
--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -1494,8 +1494,9 @@ assert_equal "#{n}#{n}", %Q{
 
 # NameError
 assert_equal "ok", %q{
+  obj = "".freeze # NameError refers the receiver indirectly
   begin
-    bar
+    obj.bar
   rescue => err
   end
   begin

--- a/ractor.c
+++ b/ractor.c
@@ -3127,7 +3127,7 @@ obj_refer_only_shareables_p_i(VALUE obj, void *ptr)
     int *pcnt = (int *)ptr;
 
     if (!rb_ractor_shareable_p(obj)) {
-        *pcnt++;
+        ++*pcnt;
     }
 }
 


### PR DESCRIPTION
`*pcnt++` just dereferences `pcnt` then increments the local variable, but has no side effect.
