### PR TITLE
Bump the required BASERUBY version to 2.5

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,7 +20,7 @@ skip_commits:
     - '**/*.[1-8]'
     - '**/*.ronn'
 environment:
-  ruby_version: "24-%Platform%"
+  ruby_version: "25-%Platform%"
   matrix:
     # Test only the oldest supported version because AppVeyor is unstable, its concurrency
     # is limited, and compatibility issues that happen only in newer versions are rare.

--- a/.github/workflows/baseruby.yml
+++ b/.github/workflows/baseruby.yml
@@ -31,10 +31,7 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - ruby-2.2
-#         - ruby-2.3
-#         - ruby-2.4
-#         - ruby-2.5
+          - ruby-2.5
 #         - ruby-2.6
 #         - ruby-2.7
           - ruby-3.0

--- a/configure.ac
+++ b/configure.ac
@@ -64,8 +64,8 @@ AC_ARG_WITH(baseruby,
 	[
 		AC_PATH_PROG([BASERUBY], [ruby], [false])
 	])
-# BASERUBY must be >= 2.2.0. Note that `"2.2.0" > "2.2"` is true.
-AS_IF([test "$HAVE_BASERUBY" != no -a "`RUBYOPT=- $BASERUBY --disable=gems -e 'print 42 if RUBY_VERSION > "2.2"' 2>/dev/null`" = 42], [
+# BASERUBY must be >= 2.5.0. Note that `"2.5.0" > "2.5"` is true.
+AS_IF([test "$HAVE_BASERUBY" != no -a "`RUBYOPT=- $BASERUBY --disable=gems -e 'print 42 if RUBY_VERSION > "2.5"' 2>/dev/null`" = 42], [
     AS_CASE(["$build_os"], [mingw*], [
         # Can MSys shell run a command with a drive letter?
         RUBYOPT=- `cygpath -ma "$BASERUBY"` --disable=gems -e exit 2>/dev/null || HAVE_BASERUBY=no

--- a/doc/contributing/building_ruby.md
+++ b/doc/contributing/building_ruby.md
@@ -18,7 +18,7 @@
     * bison - 3.0 or later
     * gperf - 3.1 or later
         * Usually unneeded; only if you edit some source files using gperf
-    * ruby - 2.2 or later
+    * ruby - 2.5 or later
         * We can upgrade this version to system ruby version of the latest Ubuntu LTS.
 
 2. Install optional, recommended dependencies:


### PR DESCRIPTION
[Misc #16671]

I'd like to bump it to 2.7 to use pattern matching in tool/mk_builtin_loader.rb.

However, I experienced a few blockers. 2.5 seems like the closest version that is easy enough to use on CIs, so let me bump the version to it as an intermediate step for it. I want to use &. and <<~ in 2.3 too.

Known blockers:
* AppVeyor Visual Studio 2015 doesn't have Ruby 2.7. You'd need to bump the version to Visual Studio 2019.
* GitHub Actions windows-2019 doesn't have Ruby 2.7 either. You can use ruby/setup-ruby, but configure doesn't seem to work with it.
* For ruby/ruby-ci-imaage, bionic doesn't have Ruby 2.7. I tried using ruby-build to build Ruby 2.7 from package, but the build on its CI seems to somehow loop forever when I do that. So I gave it up for now. We might want to wait until bionic becomes EOL.

Note:
* AppVeyor Visual Studio 2015 has Ruby <= 2.6.3 https://www.appveyor.com/docs/windows-images-software/#ruby
* GitHub Actions windows-2019 uses Ruby 2.5.9 https://github.com/actions/runner-images/blob/main/images/win/Windows2019-Readme.md