### PR TITLE
Fix handling of 6-byte codepoints in left_adjust_char_head in CESU-8 encoding.

### DIFF
--- a/test/ruby/enc/test_cesu8.rb
+++ b/test/ruby/enc/test_cesu8.rb
@@ -106,4 +106,8 @@ EOT
       assert_equal chr, ord.chr("cesu-8")
     end
   end
+
+  def test_cesu8_left_adjust_char_head
+    assert_equal("", "\u{10000}".encode("cesu-8").chop)
+  end
 end


### PR DESCRIPTION
As far as i know, `left_adjust_char_head` should move the given string cursor left by an entire codepoint.
CESU-8 encodes codepoints greater than `0xffff` as a UTF-16 surrogate pair, where the individual surrogate values are encoded in UTF-8, so they look like two individual UTF-8 codepoints. Since `left_adjust_char_head` currently only moves to the previous UTF-8 codepoint head, it will move into the "middle" of surrogate pairs instead of the beginning of the full codepoint.

This pull request aims to fix that.

https://bugs.ruby-lang.org/issues/19532