### PR TITLE
Fix small issues concerning namespacing in test-all suite

### DIFF
--- a/test/-ext-/iseq_load/test_iseq_load.rb
+++ b/test/-ext-/iseq_load/test_iseq_load.rb
@@ -123,6 +123,8 @@ class TestIseqLoad < Test::Unit::TestCase
     assert_equal false, test_break_ensure_def_method
     omit "failing due to exception entry sp mismatch"
     assert_iseq_roundtrip(src)
+  ensure
+    Object.undef_method(:test_break_ensure_def_method) rescue nil
   end
 
   def test_kwarg

--- a/test/ruby/test_eval.rb
+++ b/test/ruby/test_eval.rb
@@ -488,6 +488,9 @@ class TestEval < Test::Unit::TestCase
       end
     end
     assert_equal(feature6609, feature6609_method)
+  ensure
+    Object.undef_method(:feature6609_block) rescue nil
+    Object.undef_method(:feature6609_method) rescue nil
   end
 
   def test_eval_using_integer_as_binding

--- a/test/ruby/test_iseq.rb
+++ b/test/ruby/test_iseq.rb
@@ -637,6 +637,8 @@ class TestISeq < Test::Unit::TestCase
     }
 
     lines
+  ensure
+    Object.send(:remove_const, :A) rescue nil
   end
 
   def test_to_binary_line_tracepoint

--- a/test/ruby/test_module.rb
+++ b/test/ruby/test_module.rb
@@ -1728,6 +1728,8 @@ class TestModule < Test::Unit::TestCase
     assert_equal("TestModule::C\u{df}", c.name, '[ruby-core:24600]')
     c = Module.new.module_eval("class X\u{df} < Module; self; end")
     assert_match(/::X\u{df}:/, c.new.to_s)
+  ensure
+    Object.send(:remove_const, "C\u{df}")
   end
 
 

--- a/test/ruby/test_require.rb
+++ b/test/ruby/test_require.rb
@@ -210,6 +210,7 @@ class TestRequire < Test::Unit::TestCase
       assert_not_nil(bt = e.backtrace, "no backtrace")
       assert_not_empty(bt.find_all {|b| b.start_with? __FILE__}, proc {bt.inspect})
     end
+  ensure
     $LOADED_FEATURES.replace loaded_features
   end
 


### PR DESCRIPTION
Fix temporary methods on Object leaking across test cases.