### PR TITLE
ObjectSpace::WeakMap: fix compaction support

### DIFF
--- a/test/ruby/test_weakmap.rb
+++ b/test/ruby/test_weakmap.rb
@@ -176,4 +176,12 @@ class TestWeakMap < Test::Unit::TestCase
       end
     end;
   end
+
+  def test_compaction_bug_19529
+    obj = Object.new
+    100.times do |i|
+      GC.compact
+      @wm[i] = obj
+    end
+  end
 end


### PR DESCRIPTION
[[Bug #19529]](https://bugs.ruby-lang.org/issues/19529)

`rb_gc_update_tbl_refs` can't be used on `w->obj2wmap` because it's not a `VALUE -> VALUE` table, but a `VALUE -> VALUE *` table, so we need some dedicated iterator.

NB: I believe `WeakKeyMap` has a similar issue, but I'll fix it in a followup because it was introduced in 3.3, so doesn't have to be backported.

I also think keeping the `size` as first element of a `VALUE *` is not very elegant, I think we could use a proper struct for this, but similarly I'm trying to keep the changes as small as possible to facilitate backporting.