### PR TITLE
Generalize cfunc large array splat fix to fix many additional cases raising SystemStackError

### DIFF
--- a/benchmark/vm_call_bmethod.yml
+++ b/benchmark/vm_call_bmethod.yml
@@ -1,0 +1,37 @@
+prelude: |
+  define_method(:a0){}
+  define_method(:a1){|a| a}
+  define_method(:s){|*a| a}
+  define_method(:b){|kw: 1| kw}
+
+  t0 = 0.times.to_a
+  t1 = 1.times.to_a
+  t10 = 10.times.to_a
+  t100 = 100.times.to_a
+  kw = {kw: 2}
+benchmark:
+  bmethod_simple_0: |
+    a0
+  bmethod_simple_1: |
+    a1(1)
+  bmethod_simple_0_splat: |
+    a0(*t0)
+  bmethod_simple_1_splat: |
+    a1(*t1)
+  bmethod_no_splat: |
+    s
+  bmethod_0_splat: |
+    s(*t0)
+  bmethod_1_splat: |
+    s(*t1)
+  bmethod_10_splat: |
+    s(*t10)
+  bmethod_100_splat: |
+    s(*t100)
+  bmethod_kw: |
+    b(kw: 1)
+  bmethod_no_kw: |
+    b
+  bmethod_kw_splat: |
+    b(**kw)
+loop_count: 6000000

--- a/benchmark/vm_call_method_missing.yml
+++ b/benchmark/vm_call_method_missing.yml
@@ -1,0 +1,62 @@
+prelude: |
+  class A0
+    def method_missing(m); m end
+  end
+  class A1
+    def method_missing(m, a) a; end
+  end
+  class S
+    def method_missing(m, *a) a; end
+  end
+  class B
+    def method_missing(m, kw: 1) kw end
+  end
+  class SB
+    def method_missing(m, *a, kw: 1) kw end
+  end
+
+  t0 = 0.times.to_a
+  t1 = 1.times.to_a
+  t10 = 10.times.to_a
+  t200 = 200.times.to_a
+  kw = {kw: 2}
+
+  a0 = A0.new
+  a1 = A1.new
+  s = S.new
+  b = B.new
+  sb = SB.new
+benchmark:
+  method_missing_simple_0: |
+    a0.()
+  method_missing_simple_1: |
+    a1.x(1)
+  method_missing_simple_0_splat: |
+    a0.(*t0)
+  method_missing_simple_1_splat: |
+    a1.(*t1)
+  method_missing_no_splat: |
+    s.()
+  method_missing_0_splat: |
+    s.(*t0)
+  method_missing_1_splat: |
+    s.(*t1)
+  method_missing_10_splat: |
+    s.(*t10)
+  method_missing_200_splat: |
+    s.(*t200)
+  method_missing_kw: |
+    b.(kw: 1)
+  method_missing_no_kw: |
+    b.()
+  method_missing_kw_splat: |
+    b.(**kw)
+  method_missing_0_splat_kw: |
+    sb.(*t0, **kw)
+  method_missing_1_splat_kw: |
+    sb.(*t1, **kw)
+  method_missing_10_splat_kw: |
+    sb.(*t10, **kw)
+  method_missing_200_splat_kw: |
+    sb.(*t200, **kw)
+loop_count: 1000000

--- a/benchmark/vm_call_send_iseq.yml
+++ b/benchmark/vm_call_send_iseq.yml
@@ -1,0 +1,77 @@
+prelude: |
+  def a0; end
+  def a1(a) a; end
+  def s(*a) a; end
+  def b(kw: 1) kw end
+  def sb(*a, kw: 1) kw end
+
+  t0 = 0.times.to_a
+  t1 = 1.times.to_a
+  t10 = 10.times.to_a
+  t200 = 200.times.to_a
+
+  a0_t0 = [:a0, *t0]
+  a1_t1 = [:a1, *t1]
+  s_t0 = [:s, *t0]
+  s_t1 = [:s, *t1]
+  s_t10 = [:s, *t10]
+  s_t200 = [:s, *t200]
+  sb_t0 = [:sb, *t0]
+  sb_t1 = [:sb, *t1]
+  sb_t10 = [:sb, *t10]
+  sb_t200 = [:sb, *t200]
+  kw = {kw: 2}
+benchmark:
+  send_simple_0: |
+    send(:a0)
+  send_simple_1: |
+    send(:a1, 1)
+  send_simple_0_splat: |
+    send(:a0, *t0)
+  send_simple_1_splat: |
+    send(:a1, *t1)
+  send_simple_0_splat_comb: |
+    send(*a0_t0)
+  send_simple_1_splat_comb: |
+    send(*a1_t1)
+  send_no_splat: |
+    send(:s)
+  send_0_splat: |
+    send(:s, *t0)
+  send_1_splat: |
+    send(:s, *t1)
+  send_10_splat: |
+    send(:s, *t10)
+  send_200_splat: |
+    send(:s, *t200)
+  send_0_splat_comb: |
+    send(*s_t0)
+  send_1_splat_comb: |
+    send(*s_t1)
+  send_10_splat_comb: |
+    send(*s_t10)
+  send_200_splat_comb: |
+    send(*s_t200)
+  send_kw: |
+    send(:b, kw: 1)
+  send_no_kw: |
+    send(:b)
+  send_kw_splat: |
+    send(:b, **kw)
+  send_0_splat_kw: |
+    send(:sb, *t0, **kw)
+  send_1_splat_kw: |
+    send(:sb, *t1, **kw)
+  send_10_splat_kw: |
+    send(:sb, *t10, **kw)
+  send_200_splat_kw: |
+    send(:sb, *t200, **kw)
+  send_0_splat_comb_kw: |
+    send(*sb_t0, **kw)
+  send_1_splat_comb_kw: |
+    send(*sb_t1, **kw)
+  send_10_splat_comb_kw: |
+    send(*sb_t10, **kw)
+  send_200_splat_comb_kw: |
+    send(*sb_t200, **kw)
+loop_count: 3000000

--- a/benchmark/vm_call_symproc.yml
+++ b/benchmark/vm_call_symproc.yml
@@ -1,0 +1,83 @@
+prelude: |
+  def self.a0; end
+  def self.a1(a) a; end
+  def self.s(*a) a; end
+  def self.b(kw: 1) kw end
+  def self.sb(*a, kw: 1) kw end
+
+  t0 = 0.times.to_a
+  t1 = 1.times.to_a
+  t10 = 10.times.to_a
+  t200 = 200.times.to_a
+
+  a0_t0 = [self, *t0]
+  a1_t1 = [self, *t1]
+  s_t0 = [self, *t0]
+  s_t1 = [self, *t1]
+  s_t10 = [self, *t10]
+  s_t200 = [self, *t200]
+  sb_t0 = [self, *t0]
+  sb_t1 = [self, *t1]
+  sb_t10 = [self, *t10]
+  sb_t200 = [self, *t200]
+  kw = {kw: 2}
+
+  a0 = :a0.to_proc
+  a1 = :a1.to_proc
+  s = :s.to_proc
+  b = :b.to_proc
+  sb = :sb.to_proc
+benchmark:
+  symproc_simple_0: |
+    a0.(self)
+  symproc_simple_1: |
+    a1.(self, 1)
+  symproc_simple_0_splat: |
+    a0.(self, *t0)
+  symproc_simple_1_splat: |
+    a1.(self, *t1)
+  symproc_simple_0_splat_comb: |
+    a0.(*a0_t0)
+  symproc_simple_1_splat_comb: |
+    a1.(*a1_t1)
+  symproc_no_splat: |
+    s.(self)
+  symproc_0_splat: |
+    s.(self, *t0)
+  symproc_1_splat: |
+    s.(self, *t1)
+  symproc_10_splat: |
+    s.(self, *t10)
+  symproc_200_splat: |
+    s.(self, *t200)
+  symproc_0_splat_comb: |
+    s.(*s_t0)
+  symproc_1_splat_comb: |
+    s.(*s_t1)
+  symproc_10_splat_comb: |
+    s.(*s_t10)
+  symproc_200_splat_comb: |
+    s.(*s_t200)
+  symproc_kw: |
+    b.(self, kw: 1)
+  symproc_no_kw: |
+    b.(self)
+  symproc_kw_splat: |
+    b.(self, **kw)
+  symproc_0_splat_kw: |
+    sb.(self, *t0, **kw)
+  symproc_1_splat_kw: |
+    sb.(self, *t1, **kw)
+  symproc_10_splat_kw: |
+    sb.(self, *t10, **kw)
+  symproc_200_splat_kw: |
+    sb.(self, *t200, **kw)
+  symproc_0_splat_comb_kw: |
+    sb.(*sb_t0, **kw)
+  symproc_1_splat_comb_kw: |
+    sb.(*sb_t1, **kw)
+  symproc_10_splat_comb_kw: |
+    sb.(*sb_t10, **kw)
+  symproc_200_splat_comb_kw: |
+    sb.(*sb_t200, **kw)
+loop_count: 1000000

--- a/benchmark/vm_send_cfunc.yml
+++ b/benchmark/vm_send_cfunc.yml
@@ -1,3 +1,14 @@
+prelude: |
+  ary = []
+  kw = {a: 1}
+  empty_kw = {}
+  kw_ary = [Hash.ruby2_keywords_hash(a: 1)]
+  empty_kw_ary = [Hash.ruby2_keywords_hash({})]
 benchmark:
-  vm_send_cfunc: self.class
-loop_count: 100000000
+  vm_send_cfunc: itself
+  vm_send_cfunc_splat: itself(*ary)
+  vm_send_cfunc_splat_kw_hash: equal?(*kw_ary)
+  vm_send_cfunc_splat_empty_kw_hash: itself(*empty_kw_ary)
+  vm_send_cfunc_splat_kw: equal?(*ary, **kw)
+  vm_send_cfunc_splat_empty_kw: itself(*ary, **empty_kw)
+loop_count: 20000000

--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -3947,3 +3947,19 @@ assert_equal 'true', %q{
 
   calling_my_func
 }
+
+# Fix failed case for large splat
+assert_equal 'true', %q{
+  def d(a, b=:b)
+  end
+
+  def calling_func
+    ary = 1380888.times;
+    d(*ary)
+  end
+  begin
+    calling_func
+  rescue ArgumentError
+    true
+  end
+} unless defined?(RubyVM::RJIT) && RubyVM::RJIT.enabled? # Not yet working on RJIT

--- a/test/ruby/test_call.rb
+++ b/test/ruby/test_call.rb
@@ -100,6 +100,19 @@ class TestCall < Test::Unit::TestCase
     }
   end
 
+  def test_call_bmethod_proc
+    pr = proc{|sym| sym}
+    define_singleton_method(:a, &pr)
+    ary = [10]
+    assert_equal(10, a(*ary))
+
+    pr = proc{|*sym| sym}
+    define_singleton_method(:a, &pr)
+    ary = [10]
+    assert_equal([10], a(*ary))
+    assert_equal([10], a(10))
+  end
+
   def test_call_splat_order
     bug12860 = '[ruby-core:77701] [Bug# 12860]'
     ary = [1, 2]

--- a/test/ruby/test_call.rb
+++ b/test/ruby/test_call.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: false
 require 'test/unit'
+require '-test-/iter'
 
 class TestCall < Test::Unit::TestCase
   def aaa(a, b=100, *rest)
@@ -116,8 +117,11 @@ class TestCall < Test::Unit::TestCase
     assert_equal([0, 1, 2, b], aaa(0, *ary, &ary.pop), bug16504)
   end
 
+  OVER_STACK_LEN = (ENV['RUBY_OVER_STACK_LEN'] || 150).to_i # Greater than VM_ARGC_STACK_MAX
+  OVER_STACK_ARGV = OVER_STACK_LEN.times.to_a.freeze
+
   def test_call_cfunc_splat_large_array_bug_4040
-    a = 1380.times.to_a # Greater than VM_ARGC_STACK_MAX
+    a = OVER_STACK_ARGV
 
     assert_equal(a, [].push(*a))
     assert_equal(a, [].push(a[0], *a[1..]))
@@ -198,5 +202,882 @@ class TestCall < Test::Unit::TestCase
     # Single test with value that would cause SystemStackError.
     # Not all tests use such a large array to reduce testing time.
     assert_equal(1380888, [].push(*1380888.times.to_a).size)
+  end
+
+  def test_call_iseq_large_array_splat_fail
+    def self.a; end
+    def self.b(a=1); end
+    def self.c(k: 1); end
+    def self.d(**kw); end
+    def self.e(k: 1, **kw); end
+    def self.f(a=1, k: 1); end
+    def self.g(a=1, **kw); end
+    def self.h(a=1, k: 1, **kw); end
+
+    (:a..:h).each do |meth|
+      assert_raise_with_message(ArgumentError, /wrong number of arguments \(given #{OVER_STACK_LEN}, expected 0(\.\.[12])?\)/) do
+        instance_eval("#{meth}(*OVER_STACK_ARGV)", __FILE__, __LINE__)
+      end
+    end
+  end
+
+  def test_call_iseq_large_array_splat_pass
+    def self.a(*a); a.length end
+    assert_equal OVER_STACK_LEN, a(*OVER_STACK_ARGV)
+
+    def self.b(_, *a); a.length end
+    assert_equal (OVER_STACK_LEN - 1), b(*OVER_STACK_ARGV)
+
+    def self.c(_, *a, _); a.length end
+    assert_equal (OVER_STACK_LEN - 2), c(*OVER_STACK_ARGV)
+
+    def self.d(b=1, *a); a.length end
+    assert_equal (OVER_STACK_LEN - 1), d(*OVER_STACK_ARGV)
+
+    def self.e(b=1, *a, _); a.length end
+    assert_equal (OVER_STACK_LEN - 2), e(*OVER_STACK_ARGV)
+
+    def self.f(b, *a); a.length end
+    assert_equal (OVER_STACK_LEN - 1), f(*OVER_STACK_ARGV)
+
+    def self.g(*a, k: 1); a.length end
+    assert_equal OVER_STACK_LEN, g(*OVER_STACK_ARGV)
+
+    def self.h(*a, **kw); a.length end
+    assert_equal OVER_STACK_LEN, h(*OVER_STACK_ARGV)
+
+    def self.i(*a, k: 1, **kw); a.length end
+    assert_equal OVER_STACK_LEN, i(*OVER_STACK_ARGV)
+
+    def self.j(b=1, *a, k: 1); a.length end
+    assert_equal (OVER_STACK_LEN - 1), j(*OVER_STACK_ARGV)
+
+    def self.k(b=1, *a, **kw); a.length end
+    assert_equal (OVER_STACK_LEN - 1), k(*OVER_STACK_ARGV)
+
+    def self.l(b=1, *a, k: 1, **kw); a.length end
+    assert_equal (OVER_STACK_LEN - 1), l(*OVER_STACK_ARGV)
+
+    def self.m(b=1, *a, _, k: 1); a.length end
+    assert_equal (OVER_STACK_LEN - 2), m(*OVER_STACK_ARGV)
+
+    def self.n(b=1, *a, _, **kw); a.length end
+    assert_equal (OVER_STACK_LEN - 2), n(*OVER_STACK_ARGV)
+
+    def self.o(b=1, *a, _, k: 1, **kw); a.length end
+    assert_equal (OVER_STACK_LEN - 2), o(*OVER_STACK_ARGV)
+  end
+
+  def test_call_iseq_large_array_splat_with_large_number_of_parameters
+    args = OVER_STACK_ARGV.map{|i| "a#{i}"}.join(',')
+    args1 = (OVER_STACK_LEN-1).times.map{|i| "a#{i}"}.join(',')
+
+    singleton_class.class_eval("def a(#{args}); [#{args}] end")
+    assert_equal OVER_STACK_ARGV, a(*OVER_STACK_ARGV)
+
+    singleton_class.class_eval("def b(#{args}, b=0); [#{args}, b] end")
+    assert_equal(OVER_STACK_ARGV + [0], b(*OVER_STACK_ARGV))
+
+    singleton_class.class_eval("def c(#{args}, *b); [#{args}, b] end")
+    assert_equal(OVER_STACK_ARGV + [[]], c(*OVER_STACK_ARGV))
+
+    singleton_class.class_eval("def d(#{args1}, *b); [#{args1}, b] end")
+    assert_equal(OVER_STACK_ARGV[0...-1] + [[OVER_STACK_ARGV.last]], d(*OVER_STACK_ARGV))
+  end if OVER_STACK_LEN < 200
+
+  def test_call_proc_large_array_splat_pass
+    [
+      proc{0} ,
+      proc{|a=1|a},
+      proc{|k: 1|0},
+      proc{|**kw| 0},
+      proc{|k: 1, **kw| 0},
+      proc{|a=1, k: 1| a},
+      proc{|a=1, **kw| a},
+      proc{|a=1, k: 1, **kw| a},
+    ].each do |l|
+      assert_equal 0, l.call(*OVER_STACK_ARGV)
+    end
+
+    assert_equal OVER_STACK_LEN, proc{|*a| a.length}.(*OVER_STACK_ARGV)
+    assert_equal (OVER_STACK_LEN - 1), proc{|_, *a| a.length}.(*OVER_STACK_ARGV)
+    assert_equal (OVER_STACK_LEN - 2), proc{|_, *a, _| a.length}.(*OVER_STACK_ARGV)
+    assert_equal (OVER_STACK_LEN - 1), proc{|b=1, *a| a.length}.(*OVER_STACK_ARGV)
+    assert_equal (OVER_STACK_LEN - 2), proc{|b=1, *a, _| a.length}.(*OVER_STACK_ARGV)
+    assert_equal (OVER_STACK_LEN - 1), proc{|b=1, *a| a.length}.(*OVER_STACK_ARGV)
+    assert_equal OVER_STACK_LEN, proc{|*a, k: 1| a.length}.(*OVER_STACK_ARGV)
+    assert_equal OVER_STACK_LEN, proc{|*a, **kw| a.length}.(*OVER_STACK_ARGV)
+    assert_equal OVER_STACK_LEN, proc{|*a, k: 1, **kw| a.length}.(*OVER_STACK_ARGV)
+    assert_equal (OVER_STACK_LEN - 1), proc{|b=1, *a, k: 1| a.length}.(*OVER_STACK_ARGV)
+    assert_equal (OVER_STACK_LEN - 1), proc{|b=1, *a, **kw| a.length}.(*OVER_STACK_ARGV)
+    assert_equal (OVER_STACK_LEN - 1), proc{|b=1, *a, k: 1, **kw| a.length}.(*OVER_STACK_ARGV)
+    assert_equal (OVER_STACK_LEN - 2), proc{|b=1, *a, _, k: 1| a.length}.(*OVER_STACK_ARGV)
+    assert_equal (OVER_STACK_LEN - 2), proc{|b=1, *a, _, **kw| a.length}.(*OVER_STACK_ARGV)
+    assert_equal (OVER_STACK_LEN - 2), proc{|b=1, *a, _, k: 1, **kw| a.length}.(*OVER_STACK_ARGV)
+  end
+
+  def test_call_proc_large_array_splat_with_large_number_of_parameters
+    args = OVER_STACK_ARGV.map{|i| "a#{i}"}.join(',')
+    args1 = (OVER_STACK_LEN-1).times.map{|i| "a#{i}"}.join(',')
+
+    l = instance_eval("proc{|#{args}| [#{args}]}")
+    assert_equal OVER_STACK_ARGV, l.(*OVER_STACK_ARGV)
+
+    l = instance_eval("proc{|#{args}, b| [#{args}, b]}")
+    assert_equal(OVER_STACK_ARGV + [nil], l.(*OVER_STACK_ARGV))
+
+    l = instance_eval("proc{|#{args1}| [#{args1}]}")
+    assert_equal(OVER_STACK_ARGV[0...-1], l.(*OVER_STACK_ARGV))
+
+    l = instance_eval("proc{|#{args}, *b| [#{args}, b]}")
+    assert_equal(OVER_STACK_ARGV + [[]], l.(*OVER_STACK_ARGV))
+
+    l = instance_eval("proc{|#{args1}, *b| [#{args1}, b]}")
+    assert_equal(OVER_STACK_ARGV[0...-1] + [[OVER_STACK_ARGV.last]], l.(*OVER_STACK_ARGV))
+
+    l = instance_eval("proc{|#{args}, b, *c| [#{args}, b, c]}")
+    assert_equal(OVER_STACK_ARGV + [nil, []], l.(*OVER_STACK_ARGV))
+
+    l = instance_eval("proc{|#{args}, b, *c, d| [#{args}, b, c, d]}")
+    assert_equal(OVER_STACK_ARGV + [nil, [], nil], l.(*OVER_STACK_ARGV))
+  end if OVER_STACK_LEN < 200
+
+  def test_call_lambda_large_array_splat_fail
+    [
+      ->{} ,
+      ->(a=1){},
+      ->(k: 1){},
+      ->(**kw){},
+      ->(k: 1, **kw){},
+      ->(a=1, k: 1){},
+      ->(a=1, **kw){},
+      ->(a=1, k: 1, **kw){},
+    ].each do |l|
+      assert_raise_with_message(ArgumentError, /wrong number of arguments \(given #{OVER_STACK_LEN}, expected 0(\.\.[12])?\)/) do
+        l.call(*OVER_STACK_ARGV)
+      end
+    end
+  end
+
+  def test_call_lambda_large_array_splat_pass
+    assert_equal OVER_STACK_LEN, ->(*a){a.length}.(*OVER_STACK_ARGV)
+    assert_equal (OVER_STACK_LEN - 1), ->(_, *a){a.length}.(*OVER_STACK_ARGV)
+    assert_equal (OVER_STACK_LEN - 2), ->(_, *a, _){a.length}.(*OVER_STACK_ARGV)
+    assert_equal (OVER_STACK_LEN - 1), ->(b=1, *a){a.length}.(*OVER_STACK_ARGV)
+    assert_equal (OVER_STACK_LEN - 2), ->(b=1, *a, _){a.length}.(*OVER_STACK_ARGV)
+    assert_equal (OVER_STACK_LEN - 1), ->(b, *a){a.length}.(*OVER_STACK_ARGV)
+    assert_equal OVER_STACK_LEN, ->(*a, k: 1){a.length}.(*OVER_STACK_ARGV)
+    assert_equal OVER_STACK_LEN, ->(*a, **kw){a.length}.(*OVER_STACK_ARGV)
+    assert_equal OVER_STACK_LEN, ->(*a, k: 1, **kw){a.length}.(*OVER_STACK_ARGV)
+    assert_equal (OVER_STACK_LEN - 1), ->(b=1, *a, k: 1){a.length}.(*OVER_STACK_ARGV)
+    assert_equal (OVER_STACK_LEN - 1), ->(b=1, *a, **kw){a.length}.(*OVER_STACK_ARGV)
+    assert_equal (OVER_STACK_LEN - 1), ->(b=1, *a, k: 1, **kw){a.length}.(*OVER_STACK_ARGV)
+    assert_equal (OVER_STACK_LEN - 2), ->(b=1, *a, _, k: 1){a.length}.(*OVER_STACK_ARGV)
+    assert_equal (OVER_STACK_LEN - 2), ->(b=1, *a, _, **kw){a.length}.(*OVER_STACK_ARGV)
+    assert_equal (OVER_STACK_LEN - 2), ->(b=1, *a, _, k: 1, **kw){a.length}.(*OVER_STACK_ARGV)
+  end
+
+  def test_call_yield_block_large_array_splat_pass
+    def self.a
+      yield(*OVER_STACK_ARGV)
+    end
+
+    [
+      proc{0} ,
+      proc{|a=1|a},
+      proc{|k: 1|0},
+      proc{|**kw| 0},
+      proc{|k: 1, **kw| 0},
+      proc{|a=1, k: 1| a},
+      proc{|a=1, **kw| a},
+      proc{|a=1, k: 1, **kw| a},
+    ].each do |l|
+      assert_equal 0, a(&l)
+    end
+
+    assert_equal OVER_STACK_LEN, a{|*a| a.length}
+    assert_equal (OVER_STACK_LEN - 1), a{|_, *a| a.length}
+    assert_equal (OVER_STACK_LEN - 2), a{|_, *a, _| a.length}
+    assert_equal (OVER_STACK_LEN - 1), a{|b=1, *a| a.length}
+    assert_equal (OVER_STACK_LEN - 2), a{|b=1, *a, _| a.length}
+    assert_equal (OVER_STACK_LEN - 1), a{|b, *a| a.length}
+    assert_equal OVER_STACK_LEN, a{|*a, k: 1| a.length}
+    assert_equal OVER_STACK_LEN, a{|*a, **kw| a.length}
+    assert_equal OVER_STACK_LEN, a{|*a, k: 1, **kw| a.length}
+    assert_equal (OVER_STACK_LEN - 1), a{|b=1, *a, k: 1| a.length}
+    assert_equal (OVER_STACK_LEN - 1), a{|b=1, *a, **kw| a.length}
+    assert_equal (OVER_STACK_LEN - 1), a{|b=1, *a, k: 1, **kw| a.length}
+    assert_equal (OVER_STACK_LEN - 2), a{|b=1, *a, _, k: 1| a.length}
+    assert_equal (OVER_STACK_LEN - 2), a{|b=1, *a, _, **kw| a.length}
+    assert_equal (OVER_STACK_LEN - 2), a{|b=1, *a, _, k: 1, **kw| a.length}
+  end
+
+  def test_call_yield_large_array_splat_with_large_number_of_parameters
+    def self.a
+      yield(*OVER_STACK_ARGV)
+    end
+
+    args = OVER_STACK_ARGV.map{|i| "a#{i}"}.join(',')
+    args1 = (OVER_STACK_LEN-1).times.map{|i| "a#{i}"}.join(',')
+
+    assert_equal OVER_STACK_ARGV, instance_eval("a{|#{args}| [#{args}]}", __FILE__, __LINE__)
+    assert_equal(OVER_STACK_ARGV + [nil], instance_eval("a{|#{args}, b| [#{args}, b]}", __FILE__, __LINE__))
+    assert_equal(OVER_STACK_ARGV[0...-1], instance_eval("a{|#{args1}| [#{args1}]}", __FILE__, __LINE__))
+    assert_equal(OVER_STACK_ARGV + [[]], instance_eval("a{|#{args}, *b| [#{args}, b]}", __FILE__, __LINE__))
+    assert_equal(OVER_STACK_ARGV[0...-1] + [[OVER_STACK_ARGV.last]], instance_eval("a{|#{args1}, *b| [#{args1}, b]}", __FILE__, __LINE__))
+    assert_equal(OVER_STACK_ARGV + [nil, []], instance_eval("a{|#{args}, b, *c| [#{args}, b, c]}", __FILE__, __LINE__))
+    assert_equal(OVER_STACK_ARGV + [nil, [], nil], instance_eval("a{|#{args}, b, *c, d| [#{args}, b, c, d]}", __FILE__, __LINE__))
+  end if OVER_STACK_LEN < 200
+
+  def test_call_yield_lambda_large_array_splat_fail
+    def self.a
+      yield(*OVER_STACK_ARGV)
+    end
+    [
+      ->{} ,
+      ->(a=1){},
+      ->(k: 1){},
+      ->(**kw){},
+      ->(k: 1, **kw){},
+      ->(a=1, k: 1){},
+      ->(a=1, **kw){},
+      ->(a=1, k: 1, **kw){},
+    ].each do |l|
+      assert_raise_with_message(ArgumentError, /wrong number of arguments \(given #{OVER_STACK_LEN}, expected 0(\.\.[12])?\)/) do
+        a(&l)
+      end
+    end
+  end
+
+  def test_call_yield_lambda_large_array_splat_pass
+    def self.a
+      yield(*OVER_STACK_ARGV)
+    end
+
+    assert_equal OVER_STACK_LEN, a(&->(*a){a.length})
+    assert_equal (OVER_STACK_LEN - 1), a(&->(_, *a){a.length})
+    assert_equal (OVER_STACK_LEN - 2), a(&->(_, *a, _){a.length})
+    assert_equal (OVER_STACK_LEN - 1), a(&->(b=1, *a){a.length})
+    assert_equal (OVER_STACK_LEN - 2), a(&->(b=1, *a, _){a.length})
+    assert_equal (OVER_STACK_LEN - 1), a(&->(b, *a){a.length})
+    assert_equal OVER_STACK_LEN, a(&->(*a, k: 1){a.length})
+    assert_equal OVER_STACK_LEN, a(&->(*a, **kw){a.length})
+    assert_equal OVER_STACK_LEN, a(&->(*a, k: 1, **kw){a.length})
+    assert_equal (OVER_STACK_LEN - 1), a(&->(b=1, *a, k: 1){a.length})
+    assert_equal (OVER_STACK_LEN - 1), a(&->(b=1, *a, **kw){a.length})
+    assert_equal (OVER_STACK_LEN - 1), a(&->(b=1, *a, k: 1, **kw){a.length})
+    assert_equal (OVER_STACK_LEN - 2), a(&->(b=1, *a, _, k: 1){a.length})
+    assert_equal (OVER_STACK_LEN - 2), a(&->(b=1, *a, _, **kw){a.length})
+    assert_equal (OVER_STACK_LEN - 2), a(&->(b=1, *a, _, k: 1, **kw){a.length})
+  end
+
+  def test_call_send_iseq_large_array_splat_fail
+    def self.a; end
+    def self.b(a=1); end
+    def self.c(k: 1); end
+    def self.d(**kw); end
+    def self.e(k: 1, **kw); end
+    def self.f(a=1, k: 1); end
+    def self.g(a=1, **kw); end
+    def self.h(a=1, k: 1, **kw); end
+
+    (:a..:h).each do |meth|
+      assert_raise_with_message(ArgumentError, /wrong number of arguments \(given #{OVER_STACK_LEN}, expected 0(\.\.[12])?\)/) do
+        send(meth, *OVER_STACK_ARGV)
+      end
+    end
+  end
+
+  def test_call_send_iseq_large_array_splat_pass
+    def self.a(*a); a.length end
+    assert_equal OVER_STACK_LEN, send(:a, *OVER_STACK_ARGV)
+
+    def self.b(_, *a); a.length end
+    assert_equal (OVER_STACK_LEN - 1), send(:b, *OVER_STACK_ARGV)
+
+    def self.c(_, *a, _); a.length end
+    assert_equal (OVER_STACK_LEN - 2), send(:c, *OVER_STACK_ARGV)
+
+    def self.d(b=1, *a); a.length end
+    assert_equal (OVER_STACK_LEN - 1), send(:d, *OVER_STACK_ARGV)
+
+    def self.e(b=1, *a, _); a.length end
+    assert_equal (OVER_STACK_LEN - 2), send(:e, *OVER_STACK_ARGV)
+
+    def self.f(b, *a); a.length end
+    assert_equal (OVER_STACK_LEN - 1), send(:f, *OVER_STACK_ARGV)
+
+    def self.g(*a, k: 1); a.length end
+    assert_equal OVER_STACK_LEN, send(:g, *OVER_STACK_ARGV)
+
+    def self.h(*a, **kw); a.length end
+    assert_equal OVER_STACK_LEN, send(:h, *OVER_STACK_ARGV)
+
+    def self.i(*a, k: 1, **kw); a.length end
+    assert_equal OVER_STACK_LEN, send(:i, *OVER_STACK_ARGV)
+
+    def self.j(b=1, *a, k: 1); a.length end
+    assert_equal (OVER_STACK_LEN - 1), send(:j, *OVER_STACK_ARGV)
+
+    def self.k(b=1, *a, **kw); a.length end
+    assert_equal (OVER_STACK_LEN - 1), send(:k, *OVER_STACK_ARGV)
+
+    def self.l(b=1, *a, k: 1, **kw); a.length end
+    assert_equal (OVER_STACK_LEN - 1), send(:l, *OVER_STACK_ARGV)
+
+    def self.m(b=1, *a, _, k: 1); a.length end
+    assert_equal (OVER_STACK_LEN - 2), send(:m, *OVER_STACK_ARGV)
+
+    def self.n(b=1, *a, _, **kw); a.length end
+    assert_equal (OVER_STACK_LEN - 2), send(:n, *OVER_STACK_ARGV)
+
+    def self.o(b=1, *a, _, k: 1, **kw); a.length end
+    assert_equal (OVER_STACK_LEN - 2), send(:o, *OVER_STACK_ARGV)
+  end
+
+  def test_call_send_iseq_large_array_splat_with_large_number_of_parameters
+    args = OVER_STACK_ARGV.map{|i| "a#{i}"}.join(',')
+    args1 = (OVER_STACK_LEN-1).times.map{|i| "a#{i}"}.join(',')
+
+    singleton_class.class_eval("def a(#{args}); [#{args}] end")
+    assert_equal OVER_STACK_ARGV, send(:a, *OVER_STACK_ARGV)
+
+    singleton_class.class_eval("def b(#{args}, b=0); [#{args}, b] end")
+    assert_equal(OVER_STACK_ARGV + [0], send(:b, *OVER_STACK_ARGV))
+
+    singleton_class.class_eval("def c(#{args}, *b); [#{args}, b] end")
+    assert_equal(OVER_STACK_ARGV + [[]], send(:c, *OVER_STACK_ARGV))
+
+    singleton_class.class_eval("def d(#{args1}, *b); [#{args1}, b] end")
+    assert_equal(OVER_STACK_ARGV[0...-1] + [[OVER_STACK_ARGV.last]], send(:d, *OVER_STACK_ARGV))
+  end if OVER_STACK_LEN < 200
+
+  def test_call_send_cfunc_large_array_splat_fail
+    assert_raise_with_message(ArgumentError, "wrong number of arguments (given #{OVER_STACK_LEN}, expected 0)") do
+      send(:object_id, *OVER_STACK_ARGV)
+    end
+  end
+
+  def test_call_send_cfunc_large_array_splat_pass
+    assert_equal OVER_STACK_LEN, [].send(:push, *OVER_STACK_ARGV).length
+  end
+
+  def test_call_attr_reader_large_array_splat_fail
+    singleton_class.send(:attr_reader, :a)
+    assert_raise_with_message(ArgumentError, "wrong number of arguments (given #{OVER_STACK_LEN}, expected 0)") do
+      a(*OVER_STACK_ARGV)
+    end
+    assert_raise_with_message(ArgumentError, "wrong number of arguments (given #{OVER_STACK_LEN}, expected 0)") do
+      send(:a, *OVER_STACK_ARGV)
+    end
+  end
+
+  def test_call_attr_writer_large_array_splat_fail
+    singleton_class.send(:attr_writer, :a)
+    singleton_class.send(:alias_method, :a, :a=)
+
+    assert_raise_with_message(ArgumentError, "wrong number of arguments (given #{OVER_STACK_LEN}, expected 1)") do
+      a(*OVER_STACK_ARGV)
+    end
+    assert_raise_with_message(ArgumentError, "wrong number of arguments (given #{OVER_STACK_LEN}, expected 1)") do
+      send(:a, *OVER_STACK_ARGV)
+    end
+  end
+
+  def test_call_struct_aref_large_array_splat_fail
+    s = Struct.new(:a).new
+    assert_raise_with_message(ArgumentError, "wrong number of arguments (given #{OVER_STACK_LEN}, expected 0)") do
+      s.a(*OVER_STACK_ARGV)
+    end
+    assert_raise_with_message(ArgumentError, "wrong number of arguments (given #{OVER_STACK_LEN}, expected 0)") do
+      s.send(:a, *OVER_STACK_ARGV)
+    end
+  end
+
+  def test_call_struct_aset_large_array_splat_fail
+    s = Struct.new(:a) do
+      alias b a=
+    end.new
+    assert_raise_with_message(ArgumentError, "wrong number of arguments (given #{OVER_STACK_LEN}, expected 1)") do
+      s.b(*OVER_STACK_ARGV)
+    end
+    assert_raise_with_message(ArgumentError, "wrong number of arguments (given #{OVER_STACK_LEN}, expected 1)") do
+      s.send(:b, *OVER_STACK_ARGV)
+    end
+  end
+
+  def test_call_alias_large_array_splat
+    c = Class.new do
+      def a; end
+      def c(*a); a.length end
+      attr_accessor :e
+    end
+    sc = Class.new(c) do
+      alias b a
+      alias d c
+      alias f e
+      alias g e=
+    end
+
+    obj = sc.new
+    assert_raise_with_message(ArgumentError, "wrong number of arguments (given #{OVER_STACK_LEN}, expected 0)") do
+      obj.b(*OVER_STACK_ARGV)
+    end
+    assert_raise_with_message(ArgumentError, "wrong number of arguments (given #{OVER_STACK_LEN}, expected 0)") do
+      obj.f(*OVER_STACK_ARGV)
+    end
+    assert_raise_with_message(ArgumentError, "wrong number of arguments (given #{OVER_STACK_LEN}, expected 1)") do
+      obj.g(*OVER_STACK_ARGV)
+    end
+
+    assert_equal OVER_STACK_LEN, obj.d(*OVER_STACK_ARGV)
+  end
+
+  def test_call_zsuper_large_array_splat
+    c = Class.new do
+      private
+      def a; end
+      def c(*a); a.length end
+      attr_reader :e
+    end
+    sc = Class.new(c) do
+      public :a
+      public :c
+      public :e
+    end
+
+    obj = sc.new
+    assert_raise_with_message(ArgumentError, "wrong number of arguments (given #{OVER_STACK_LEN}, expected 0)") do
+      obj.a(*OVER_STACK_ARGV)
+    end
+    assert_raise_with_message(ArgumentError, "wrong number of arguments (given #{OVER_STACK_LEN}, expected 0)") do
+      obj.e(*OVER_STACK_ARGV)
+    end
+
+    assert_equal OVER_STACK_LEN, obj.c(*OVER_STACK_ARGV)
+  end
+
+  class RefinedModuleLargeArrayTest
+    c = self
+    using(Module.new do
+      refine c do
+        def a; end
+        def c(*a) a.length end
+        attr_reader :e
+      end
+    end)
+
+    def b
+      a(*OVER_STACK_ARGV)
+    end
+
+    def d
+      c(*OVER_STACK_ARGV)
+    end
+
+    def f
+      e(*OVER_STACK_ARGV)
+    end
+  end
+
+  def test_call_refined_large_array_splat_fail
+    assert_raise_with_message(ArgumentError, "wrong number of arguments (given #{OVER_STACK_LEN}, expected 0)") do
+      RefinedModuleLargeArrayTest.new.b
+    end
+
+    assert_raise_with_message(ArgumentError, "wrong number of arguments (given #{OVER_STACK_LEN}, expected 0)") do
+      RefinedModuleLargeArrayTest.new.f
+    end
+  end
+
+  def test_call_refined_large_array_splat_pass
+    assert_equal OVER_STACK_LEN, RefinedModuleLargeArrayTest.new.d
+  end
+
+  def test_call_method_missing_iseq_large_array_splat_fail
+    def self.method_missing(_) end
+    assert_raise_with_message(ArgumentError, "wrong number of arguments (given #{OVER_STACK_LEN+1}, expected 1)") do
+      nonexistent_method(*OVER_STACK_ARGV)
+    end
+
+    assert_raise_with_message(ArgumentError, "wrong number of arguments (given #{OVER_STACK_LEN+1}, expected 1)") do
+      send(:nonexistent_method, *OVER_STACK_ARGV)
+    end
+
+    assert_raise_with_message(ArgumentError, "wrong number of arguments (given #{OVER_STACK_LEN+1}, expected 1)") do
+      send("nonexistent_method123", *OVER_STACK_ARGV)
+    end
+  end
+
+  def test_call_method_missing_iseq_large_array_splat_pass
+    def self.method_missing(m, *a)
+      a.length
+    end
+    assert_equal OVER_STACK_LEN, nonexistent_method(*OVER_STACK_ARGV)
+    assert_equal OVER_STACK_LEN, send(:nonexistent_method, *OVER_STACK_ARGV)
+    assert_equal OVER_STACK_LEN, send("nonexistent_method123", *OVER_STACK_ARGV)
+  end
+
+  def test_call_bmethod_large_array_splat_fail
+    define_singleton_method(:a){}
+    define_singleton_method(:b){|a=1|}
+    define_singleton_method(:c){|k: 1|}
+    define_singleton_method(:d){|**kw|}
+    define_singleton_method(:e){|k: 1, **kw|}
+    define_singleton_method(:f){|a=1, k: 1|}
+    define_singleton_method(:g){|a=1, **kw|}
+    define_singleton_method(:h){|a=1, k: 1, **kw|}
+
+    (:a..:h).each do |meth|
+      assert_raise_with_message(ArgumentError, /wrong number of arguments \(given #{OVER_STACK_LEN}, expected 0(\.\.[12])?\)/) do
+        instance_eval("#{meth}(*OVER_STACK_ARGV)", __FILE__, __LINE__)
+      end
+    end
+  end
+
+  def test_call_bmethod_large_array_splat_pass
+    define_singleton_method(:a){|*a| a.length}
+    assert_equal OVER_STACK_LEN, a(*OVER_STACK_ARGV)
+
+    define_singleton_method(:b){|_, *a| a.length}
+    assert_equal (OVER_STACK_LEN - 1), b(*OVER_STACK_ARGV)
+
+    define_singleton_method(:c){|_, *a, _| a.length}
+    assert_equal (OVER_STACK_LEN - 2), c(*OVER_STACK_ARGV)
+
+    define_singleton_method(:d){|b=1, *a| a.length}
+    assert_equal (OVER_STACK_LEN - 1), d(*OVER_STACK_ARGV)
+
+    define_singleton_method(:e){|b=1, *a, _| a.length}
+    assert_equal (OVER_STACK_LEN - 2), e(*OVER_STACK_ARGV)
+
+    define_singleton_method(:f){|b, *a| a.length}
+    assert_equal (OVER_STACK_LEN - 1), f(*OVER_STACK_ARGV)
+
+    define_singleton_method(:g){|*a, k: 1| a.length}
+    assert_equal OVER_STACK_LEN, g(*OVER_STACK_ARGV)
+
+    define_singleton_method(:h){|*a, **kw| a.length}
+    assert_equal OVER_STACK_LEN, h(*OVER_STACK_ARGV)
+
+    define_singleton_method(:i){|*a, k: 1, **kw| a.length}
+    assert_equal OVER_STACK_LEN, i(*OVER_STACK_ARGV)
+
+    define_singleton_method(:j){|b=1, *a, k: 1| a.length}
+    assert_equal (OVER_STACK_LEN - 1), j(*OVER_STACK_ARGV)
+
+    define_singleton_method(:k){|b=1, *a, **kw| a.length}
+    assert_equal (OVER_STACK_LEN - 1), k(*OVER_STACK_ARGV)
+
+    define_singleton_method(:l){|b=1, *a, k: 1, **kw| a.length}
+    assert_equal (OVER_STACK_LEN - 1), l(*OVER_STACK_ARGV)
+
+    define_singleton_method(:m){|b=1, *a, _, k: 1| a.length}
+    assert_equal (OVER_STACK_LEN - 2), m(*OVER_STACK_ARGV)
+
+    define_singleton_method(:n){|b=1, *a, _, **kw| a.length}
+    assert_equal (OVER_STACK_LEN - 2), n(*OVER_STACK_ARGV)
+
+    define_singleton_method(:o){|b=1, *a, _, k: 1, **kw| a.length}
+    assert_equal (OVER_STACK_LEN - 2), o(*OVER_STACK_ARGV)
+  end
+
+  def test_call_method_missing_bmethod_large_array_splat_fail
+    define_singleton_method(:method_missing){|_|}
+    assert_raise_with_message(ArgumentError, "wrong number of arguments (given #{OVER_STACK_LEN+1}, expected 1)") do
+      nonexistent_method(*OVER_STACK_ARGV)
+    end
+
+    assert_raise_with_message(ArgumentError, "wrong number of arguments (given #{OVER_STACK_LEN+1}, expected 1)") do
+      send(:nonexistent_method, *OVER_STACK_ARGV)
+    end
+
+    assert_raise_with_message(ArgumentError, "wrong number of arguments (given #{OVER_STACK_LEN+1}, expected 1)") do
+      send("nonexistent_method123", *OVER_STACK_ARGV)
+    end
+  end
+
+  def test_call_method_missing_bmethod_large_array_splat_pass
+    define_singleton_method(:method_missing){|_, *a| a.length}
+    assert_equal OVER_STACK_LEN, nonexistent_method(*OVER_STACK_ARGV)
+    assert_equal OVER_STACK_LEN, send(:nonexistent_method, *OVER_STACK_ARGV)
+    assert_equal OVER_STACK_LEN, send("nonexistent_method123", *OVER_STACK_ARGV)
+  end
+
+  def test_call_symproc_large_array_splat_fail
+    define_singleton_method(:a){}
+    define_singleton_method(:b){|a=1|}
+    define_singleton_method(:c){|k: 1|}
+    define_singleton_method(:d){|**kw|}
+    define_singleton_method(:e){|k: 1, **kw|}
+    define_singleton_method(:f){|a=1, k: 1|}
+    define_singleton_method(:g){|a=1, **kw|}
+    define_singleton_method(:h){|a=1, k: 1, **kw|}
+
+    (:a..:h).each do |meth|
+      assert_raise_with_message(ArgumentError, /wrong number of arguments \(given #{OVER_STACK_LEN}, expected 0(\.\.[12])?\)/) do
+        instance_eval(":#{meth}.to_proc.(self, *OVER_STACK_ARGV)", __FILE__, __LINE__)
+      end
+    end
+  end
+
+  def test_call_symproc_large_array_splat_pass
+    define_singleton_method(:a){|*a| a.length}
+    assert_equal OVER_STACK_LEN, :a.to_proc.(self, *OVER_STACK_ARGV)
+
+    define_singleton_method(:b){|_, *a| a.length}
+    assert_equal (OVER_STACK_LEN - 1), :b.to_proc.(self, *OVER_STACK_ARGV)
+
+    define_singleton_method(:c){|_, *a, _| a.length}
+    assert_equal (OVER_STACK_LEN - 2), :c.to_proc.(self, *OVER_STACK_ARGV)
+
+    define_singleton_method(:d){|b=1, *a| a.length}
+    assert_equal (OVER_STACK_LEN - 1), :d.to_proc.(self, *OVER_STACK_ARGV)
+
+    define_singleton_method(:e){|b=1, *a, _| a.length}
+    assert_equal (OVER_STACK_LEN - 2), :e.to_proc.(self, *OVER_STACK_ARGV)
+
+    define_singleton_method(:f){|b, *a| a.length}
+    assert_equal (OVER_STACK_LEN - 1), :f.to_proc.(self, *OVER_STACK_ARGV)
+
+    define_singleton_method(:g){|*a, k: 1| a.length}
+    assert_equal OVER_STACK_LEN, :g.to_proc.(self, *OVER_STACK_ARGV)
+
+    define_singleton_method(:h){|*a, **kw| a.length}
+    assert_equal OVER_STACK_LEN, :h.to_proc.(self, *OVER_STACK_ARGV)
+
+    define_singleton_method(:i){|*a, k: 1, **kw| a.length}
+    assert_equal OVER_STACK_LEN, :i.to_proc.(self, *OVER_STACK_ARGV)
+
+    define_singleton_method(:j){|b=1, *a, k: 1| a.length}
+    assert_equal (OVER_STACK_LEN - 1), :j.to_proc.(self, *OVER_STACK_ARGV)
+
+    define_singleton_method(:k){|b=1, *a, **kw| a.length}
+    assert_equal (OVER_STACK_LEN - 1), :k.to_proc.(self, *OVER_STACK_ARGV)
+
+    define_singleton_method(:l){|b=1, *a, k: 1, **kw| a.length}
+    assert_equal (OVER_STACK_LEN - 1), :l.to_proc.(self, *OVER_STACK_ARGV)
+
+    define_singleton_method(:m){|b=1, *a, _, k: 1| a.length}
+    assert_equal (OVER_STACK_LEN - 2), :m.to_proc.(self, *OVER_STACK_ARGV)
+
+    define_singleton_method(:n){|b=1, *a, _, **kw| a.length}
+    assert_equal (OVER_STACK_LEN - 2), :n.to_proc.(self, *OVER_STACK_ARGV)
+
+    define_singleton_method(:o){|b=1, *a, _, k: 1, **kw| a.length}
+    assert_equal (OVER_STACK_LEN - 2), :o.to_proc.(self, *OVER_STACK_ARGV)
+  end
+
+  def test_call_rb_call_iseq_large_array_splat_fail
+    extend Bug::Iter::Yield
+    l = ->(*a){}
+
+    def self.a; end
+    def self.b(a=1) end
+    def self.c(k: 1) end
+    def self.d(**kw) end
+    def self.e(k: 1, **kw) end
+    def self.f(a=1, k: 1) end
+    def self.g(a=1, **kw) end
+    def self.h(a=1, k: 1, **kw) end
+
+    (:a..:h).each do |meth|
+      assert_raise_with_message(ArgumentError, /wrong number of arguments \(given #{OVER_STACK_LEN}, expected 0(\.\.[12])?\)/) do
+        yield_block(meth, *OVER_STACK_ARGV, &l)
+      end
+    end
+  end
+
+  def test_call_rb_call_iseq_large_array_splat_pass
+    extend Bug::Iter::Yield
+    l = ->(*a){a.length}
+
+    def self.a(*a) a.length end
+    assert_equal OVER_STACK_LEN, yield_block(:a, *OVER_STACK_ARGV, &l)
+
+    def self.b(_, *a) a.length end
+    assert_equal (OVER_STACK_LEN - 1), yield_block(:b, *OVER_STACK_ARGV, &l)
+
+    def self.c(_, *a, _) a.length end
+    assert_equal (OVER_STACK_LEN - 2), yield_block(:c, *OVER_STACK_ARGV, &l)
+
+    def self.d(b=1, *a) a.length end
+    assert_equal (OVER_STACK_LEN - 1), yield_block(:d, *OVER_STACK_ARGV, &l)
+
+    def self.e(b=1, *a, _) a.length end
+    assert_equal (OVER_STACK_LEN - 2), yield_block(:e, *OVER_STACK_ARGV, &l)
+
+    def self.f(b, *a) a.length end
+    assert_equal (OVER_STACK_LEN - 1), yield_block(:f, *OVER_STACK_ARGV, &l)
+
+    def self.g(*a, k: 1) a.length end
+    assert_equal OVER_STACK_LEN, yield_block(:g, *OVER_STACK_ARGV, &l)
+
+    def self.h(*a, **kw) a.length end
+    assert_equal OVER_STACK_LEN, yield_block(:h, *OVER_STACK_ARGV, &l)
+
+    def self.i(*a, k: 1, **kw) a.length end
+    assert_equal OVER_STACK_LEN, yield_block(:h, *OVER_STACK_ARGV, &l)
+
+    def self.j(b=1, *a, k: 1) a.length end
+    assert_equal (OVER_STACK_LEN - 1), yield_block(:j, *OVER_STACK_ARGV, &l)
+
+    def self.k(b=1, *a, **kw) a.length end
+    assert_equal (OVER_STACK_LEN - 1), yield_block(:k, *OVER_STACK_ARGV, &l)
+
+    def self.l(b=1, *a, k: 1, **kw) a.length end
+    assert_equal (OVER_STACK_LEN - 1), yield_block(:l, *OVER_STACK_ARGV, &l)
+
+    def self.m(b=1, *a, _, k: 1) a.length end
+    assert_equal (OVER_STACK_LEN - 2), yield_block(:m, *OVER_STACK_ARGV, &l)
+
+    def self.n(b=1, *a, _, **kw) a.length end
+    assert_equal (OVER_STACK_LEN - 2), yield_block(:n, *OVER_STACK_ARGV, &l)
+
+    def self.o(b=1, *a, _, k: 1, **kw) a.length end
+    assert_equal (OVER_STACK_LEN - 2), yield_block(:o, *OVER_STACK_ARGV, &l)
+  end
+
+  def test_call_rb_call_bmethod_large_array_splat_fail
+    extend Bug::Iter::Yield
+    l = ->(*a){}
+
+    define_singleton_method(:a){||}
+    define_singleton_method(:b){|a=1|}
+    define_singleton_method(:c){|k: 1|}
+    define_singleton_method(:d){|**kw|}
+    define_singleton_method(:e){|k: 1, **kw|}
+    define_singleton_method(:f){|a=1, k: 1|}
+    define_singleton_method(:g){|a=1, **kw|}
+    define_singleton_method(:h){|a=1, k: 1, **kw|}
+
+    (:a..:h).each do |meth|
+      assert_raise_with_message(ArgumentError, /wrong number of arguments \(given #{OVER_STACK_LEN}, expected 0(\.\.[12])?\)/) do
+        yield_block(meth, *OVER_STACK_ARGV, &l)
+      end
+    end
+  end
+
+  def test_call_rb_call_bmethod_large_array_splat_pass
+    extend Bug::Iter::Yield
+    l = ->(*a){a.length}
+
+    define_singleton_method(:a){|*a| a.length}
+    assert_equal OVER_STACK_LEN, yield_block(:a, *OVER_STACK_ARGV, &l)
+
+    define_singleton_method(:b){|_, *a| a.length}
+    assert_equal (OVER_STACK_LEN - 1), yield_block(:b, *OVER_STACK_ARGV, &l)
+
+    define_singleton_method(:c){|_, *a, _| a.length}
+    assert_equal (OVER_STACK_LEN - 2), yield_block(:c, *OVER_STACK_ARGV, &l)
+
+    define_singleton_method(:d){|b=1, *a| a.length}
+    assert_equal (OVER_STACK_LEN - 1), yield_block(:d, *OVER_STACK_ARGV, &l)
+
+    define_singleton_method(:e){|b=1, *a, _| a.length}
+    assert_equal (OVER_STACK_LEN - 2), yield_block(:e, *OVER_STACK_ARGV, &l)
+
+    define_singleton_method(:f){|b, *a| a.length}
+    assert_equal (OVER_STACK_LEN - 1), yield_block(:f, *OVER_STACK_ARGV, &l)
+
+    define_singleton_method(:g){|*a, k: 1| a.length}
+    assert_equal OVER_STACK_LEN, yield_block(:g, *OVER_STACK_ARGV, &l)
+
+    define_singleton_method(:h){|*a, **kw| a.length}
+    assert_equal OVER_STACK_LEN, yield_block(:h, *OVER_STACK_ARGV, &l)
+
+    define_singleton_method(:i){|*a, k: 1, **kw| a.length}
+    assert_equal OVER_STACK_LEN, yield_block(:h, *OVER_STACK_ARGV, &l)
+
+    define_singleton_method(:j){|b=1, *a, k: 1| a.length}
+    assert_equal (OVER_STACK_LEN - 1), yield_block(:j, *OVER_STACK_ARGV, &l)
+
+    define_singleton_method(:k){|b=1, *a, **kw| a.length}
+    assert_equal (OVER_STACK_LEN - 1), yield_block(:k, *OVER_STACK_ARGV, &l)
+
+    define_singleton_method(:l){|b=1, *a, k: 1, **kw| a.length}
+    assert_equal (OVER_STACK_LEN - 1), yield_block(:l, *OVER_STACK_ARGV, &l)
+
+    define_singleton_method(:m){|b=1, *a, _, k: 1| a.length}
+    assert_equal (OVER_STACK_LEN - 2), yield_block(:m, *OVER_STACK_ARGV, &l)
+
+    define_singleton_method(:n){|b=1, *a, _, **kw| a.length}
+    assert_equal (OVER_STACK_LEN - 2), yield_block(:n, *OVER_STACK_ARGV, &l)
+
+    define_singleton_method(:o){|b=1, *a, _, k: 1, **kw| a.length}
+    assert_equal (OVER_STACK_LEN - 2), yield_block(:o, *OVER_STACK_ARGV, &l)
+  end
+
+  def test_call_ifunc_iseq_large_array_splat_fail
+    extend Bug::Iter::Yield
+    def self.a(*a)
+      yield(*a)
+    end
+    [
+      ->(){},
+      ->(a=1){},
+      ->(k: 1){},
+      ->(**kw){},
+      ->(k: 1, **kw){},
+      ->(a=1, k: 1){},
+      ->(a=1, **kw){},
+      ->(a=1, k: 1, **kw){},
+    ].each do |l|
+      assert_raise_with_message(ArgumentError, /wrong number of arguments \(given #{OVER_STACK_LEN}, expected 0(\.\.[12])?\)/) do
+        yield_block(:a, *OVER_STACK_ARGV, &l)
+      end
+    end
+  end
+
+  def test_call_ifunc_iseq_large_array_splat_pass
+    extend Bug::Iter::Yield
+    def self.a(*a)
+      yield(*a)
+    end
+
+    l = ->(*a) do a.length end
+    assert_equal OVER_STACK_LEN, yield_block(:a, *OVER_STACK_ARGV, &l)
+
+    l = ->(_, *a) do a.length end
+    assert_equal (OVER_STACK_LEN - 1), yield_block(:a, *OVER_STACK_ARGV, &l)
+
+    l = ->(_, *a, _) do a.length end
+    assert_equal (OVER_STACK_LEN - 2), yield_block(:a, *OVER_STACK_ARGV, &l)
+
+    l = ->(b=1, *a) do a.length end
+    assert_equal (OVER_STACK_LEN - 1), yield_block(:a, *OVER_STACK_ARGV, &l)
+
+    l = ->(b=1, *a, _) do a.length end
+    assert_equal (OVER_STACK_LEN - 2), yield_block(:a, *OVER_STACK_ARGV, &l)
+
+    l = ->(b, *a) do a.length end
+    assert_equal (OVER_STACK_LEN - 1), yield_block(:a, *OVER_STACK_ARGV, &l)
+
+    l = ->(*a, k: 1) do a.length end
+    assert_equal OVER_STACK_LEN, yield_block(:a, *OVER_STACK_ARGV, &l)
+
+    l = ->(*a, **kw) do a.length end
+    assert_equal OVER_STACK_LEN, yield_block(:a, *OVER_STACK_ARGV, &l)
+
+    l = ->(*a, k: 1, **kw) do a.length end
+    assert_equal OVER_STACK_LEN, yield_block(:a, *OVER_STACK_ARGV, &l)
+
+    l = ->(b=1, *a, k: 1) do a.length end
+    assert_equal (OVER_STACK_LEN - 1), yield_block(:a, *OVER_STACK_ARGV, &l)
+
+    l = ->(b=1, *a, **kw) do a.length end
+    assert_equal (OVER_STACK_LEN - 1), yield_block(:a, *OVER_STACK_ARGV, &l)
+
+    l = ->(b=1, *a, k: 1, **kw) do a.length end
+    assert_equal (OVER_STACK_LEN - 1), yield_block(:a, *OVER_STACK_ARGV, &l)
+
+    l = ->(b=1, *a, _, k: 1) do a.length end
+    assert_equal (OVER_STACK_LEN - 2), yield_block(:a, *OVER_STACK_ARGV, &l)
+
+    l = ->(b=1, *a, _, **kw) do a.length end
+    assert_equal (OVER_STACK_LEN - 2), yield_block(:a, *OVER_STACK_ARGV, &l)
+
+    l = ->(b=1, *a, _, k: 1, **kw) do a.length end
+    assert_equal (OVER_STACK_LEN - 2), yield_block(:a, *OVER_STACK_ARGV, &l)
   end
 end

--- a/vm_core.h
+++ b/vm_core.h
@@ -296,7 +296,14 @@ struct rb_calling_info {
     VALUE recv;
     int argc;
     bool kw_splat;
+    VALUE heap_argv;
 };
+
+#ifndef VM_ARGC_STACK_MAX
+#define VM_ARGC_STACK_MAX 128
+#endif
+
+# define CALLING_ARGC(calling) ((calling)->heap_argv ? RARRAY_LENINT((calling)->heap_argv) : (calling)->argc)
 
 struct rb_execution_context_struct;
 

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -3813,14 +3813,13 @@ vm_call_symbol(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp,
                struct rb_calling_info *calling, const struct rb_callinfo *ci, VALUE symbol, int flags)
 {
     ASSUME(calling->argc >= 0);
-    /* Also assumes CALLER_SETUP_ARG is already done. */
 
     enum method_missing_reason missing_reason = MISSING_NOENTRY;
     int argc = calling->argc;
     VALUE recv = calling->recv;
     VALUE klass = CLASS_OF(recv);
     ID mid = rb_check_id(&symbol);
-    flags |= VM_CALL_OPT_SEND | (calling->kw_splat ? VM_CALL_KW_SPLAT : 0);
+    flags |= VM_CALL_OPT_SEND;
 
     if (UNLIKELY(! mid)) {
         mid = idMethodMissing;
@@ -3910,14 +3909,52 @@ vm_call_symbol(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp,
 }
 
 static VALUE
-vm_call_opt_send(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, struct rb_calling_info *calling)
+vm_call_opt_send0(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, struct rb_calling_info *calling, int flags)
 {
-    RB_DEBUG_COUNTER_INC(ccf_opt_send);
+    const struct rb_callinfo *ci = calling->ci;
+    int i;
+    VALUE sym;
 
-    int i, flags = VM_CALL_FCALL;
-    VALUE sym, argv_ary;
+    i = calling->argc - 1;
 
-    CALLER_SETUP_ARG(reg_cfp, calling, calling->ci, ALLOW_HEAP_ARGV);
+    if (calling->argc == 0) {
+        rb_raise(rb_eArgError, "no method name given");
+    }
+
+    sym = TOPN(i);
+    /* E.g. when i == 2
+     *
+     *   |      |        |      |  TOPN
+     *   +------+        |      |
+     *   | arg1 | ---+   |      |    0
+     *   +------+    |   +------+
+     *   | arg0 | -+ +-> | arg1 |    1
+     *   +------+  |     +------+
+     *   | sym  |  +---> | arg0 |    2
+     *   +------+        +------+
+     *   | recv |        | recv |    3
+     * --+------+--------+------+------
+     */
+    /* shift arguments */
+    if (i > 0) {
+        MEMMOVE(&TOPN(i), &TOPN(i-1), VALUE, i);
+    }
+    calling->argc -= 1;
+    DEC_SP(1);
+
+    return vm_call_symbol(ec, reg_cfp, calling, ci, sym, flags);
+}
+
+static VALUE
+vm_call_opt_send_complex(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, struct rb_calling_info *calling)
+{
+    RB_DEBUG_COUNTER_INC(ccf_opt_send_complex);
+    const struct rb_callinfo *ci = calling->ci;
+    int flags = VM_CALL_FCALL;
+    VALUE sym;
+
+    VALUE argv_ary;
+    CALLER_SETUP_ARG(reg_cfp, calling, ci, ALLOW_HEAP_ARGV);
     if (UNLIKELY(argv_ary = calling->heap_argv)) {
         sym = rb_ary_shift(argv_ary);
         flags |= VM_CALL_ARGS_SPLAT;
@@ -3926,37 +3963,38 @@ vm_call_opt_send(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, struct
             ((struct RHash *)last_hash)->basic.flags |= RHASH_PASS_AS_KEYWORDS;
             calling->kw_splat = 0;
         }
-    }
-    else {
-        i = calling->argc - 1;
-
-        if (calling->argc == 0) {
-            rb_raise(rb_eArgError, "no method name given");
-        }
-
-        sym = TOPN(i);
-        /* E.g. when i == 2
-         *
-         *   |      |        |      |  TOPN
-         *   +------+        |      |
-         *   | arg1 | ---+   |      |    0
-         *   +------+    |   +------+
-         *   | arg0 | -+ +-> | arg1 |    1
-         *   +------+  |     +------+
-         *   | sym  |  +---> | arg0 |    2
-         *   +------+        +------+
-         *   | recv |        | recv |    3
-         * --+------+--------+------+------
-         */
-        /* shift arguments */
-        if (i > 0) {
-            MEMMOVE(&TOPN(i), &TOPN(i-1), VALUE, i);
-        }
-        calling->argc -= 1;
-        DEC_SP(1);
+        return vm_call_symbol(ec, reg_cfp, calling, ci, sym, flags);
     }
 
-    return vm_call_symbol(ec, reg_cfp, calling, calling->ci, sym, flags);
+    if (calling->kw_splat) flags |= VM_CALL_KW_SPLAT;
+    return vm_call_opt_send0(ec, reg_cfp, calling, flags);
+}
+
+static VALUE
+vm_call_opt_send_simple(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, struct rb_calling_info *calling)
+{
+    RB_DEBUG_COUNTER_INC(ccf_opt_send_simple);
+    return vm_call_opt_send0(ec, reg_cfp, calling, vm_ci_flag(calling->ci) | VM_CALL_FCALL);
+}
+
+static VALUE
+vm_call_opt_send(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, struct rb_calling_info *calling)
+{
+    RB_DEBUG_COUNTER_INC(ccf_opt_send);
+
+    const struct rb_callinfo *ci = calling->ci;
+    int flags = vm_ci_flag(ci);
+
+    if (UNLIKELY(!(flags & VM_CALL_ARGS_SIMPLE) &&
+        ((calling->argc == 1 && (flags & (VM_CALL_ARGS_SPLAT | VM_CALL_KW_SPLAT))) ||
+         (calling->argc == 2 && (flags & VM_CALL_ARGS_SPLAT) && (flags & VM_CALL_KW_SPLAT)) ||
+         ((flags & VM_CALL_KWARG) && (vm_ci_kwarg(ci)->keyword_len == calling->argc))))) {
+        CC_SET_FASTPATH(calling->cc, vm_call_opt_send_complex, TRUE);
+        return vm_call_opt_send_complex(ec, reg_cfp, calling);
+    }
+
+    CC_SET_FASTPATH(calling->cc, vm_call_opt_send_simple, TRUE);
+    return vm_call_opt_send_simple(ec, reg_cfp, calling);
 }
 
 static VALUE
@@ -4818,6 +4856,9 @@ vm_invoke_symbol_block(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp,
             rb_raise(rb_eArgError, "no receiver given");
         }
         calling->recv = TOPN(--calling->argc);
+    }
+    if (calling->kw_splat) {
+        flags |= VM_CALL_KW_SPLAT;
     }
     return vm_call_symbol(ec, reg_cfp, calling, ci, symbol, flags);
 }

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -1896,6 +1896,8 @@ pub const SEND_MAX_CHAIN_DEPTH: i32 = 20;
 // up to 20 different offsets for case-when
 pub const CASE_WHEN_MAX_DEPTH: i32 = 20;
 
+pub const MAX_SPLAT_LENGTH: i32 = 127;
+
 // Codegen for setting an instance variable.
 // Preconditions:
 //   - receiver is in REG0
@@ -5875,6 +5877,10 @@ fn gen_send_iseq(
             // all the remaining arguments. In the generated code
             // we test if this is true and if not side exit.
             argc = argc - 1 + array_length as i32 + remaining_opt as i32;
+            if argc + asm.ctx.get_stack_size() as i32 > MAX_SPLAT_LENGTH {
+                gen_counter_incr!(asm, send_splat_too_long);
+                return None;
+            }
             push_splat_args(array_length, asm);
 
             for _ in 0..remaining_opt {

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -261,6 +261,7 @@ make_counters! {
     send_args_splat_cfunc_zuper,
     send_args_splat_cfunc_ruby2_keywords,
     send_iseq_splat_arity_error,
+    send_splat_too_long,
     send_iseq_ruby2_keywords,
     send_send_not_imm,
     send_send_wrong_args,


### PR DESCRIPTION
Originally, when 2e7bceb34ea858649e1f975a934ce1894d1f06a6 fixed cfuncs to no longer use the VM stack for large array splats, it was thought to have fully fixed Bug #4040, since the issue was fixed for methods defined in Ruby (iseqs) back in Ruby 2.2.

After additional research, I determined that same issue affects almost all types of method calls, not just iseq and cfunc calls.  There were two main types of remaining issues, important cases (where large array splat should work) and pedantic cases (where large array splat raised SystemStackError instead of ArgumentError).

Important cases:

```ruby
# bmethod
define_method(:a){|*a|}
a(*1380888.times)

# send
def b(*a); end
send(:b, *1380888.times)

# symproc
:b.to_proc.call(self, *1380888.times)

# method to proc
def d; yield(*1380888.times) end
d(&method(:b))

# method_missing
def self.method_missing(*a); end
not_a_method(*1380888.times)
```

Pedantic cases:

```ruby
# iseq with only required or optional arguments
def a; end
a(*1380888.times)
def b(_); end
b(*1380888.times)
def c(_=nil); end
c(*1380888.times)

# attr reader/writer
c = Class.new do
  attr_accessor :a
  alias b a=
end.new
c.a(*1380888.times)
c.b(*1380888.times)

# Struct aref/aset
c = Struct.new(:a) do
  alias b a=
end.new
c.a(*1380888.times)
c.b(*1380888.times)
```

This patch fixes all usage of CALLER_SETUP_ARG with splatting a large number of arguments, and required similar fixes to use a temporary hidden array in three other cases where the VM would use the VM stack for handling a large number of arguments.  However, it is possible there may be additional cases where splatting a large number of arguments still causes a SystemStackError.

This has a measurable performance impact, as it requires additional checks for a large number of arguments in many additional cases.

This change is fairly invasive, as there were many different VM functions that needed to be modified to support this. To avoid too much API change, I modified struct rb_calling_info to add a heap_argv member for storing the array, so I would not have to thread it through many functions.  This struct is always stack allocated, which helps ensure sure GC doesn't collect it early.

Because of how invasive the changes are, and how rarely large arrays are actually splatted in Ruby code, the existing test/spec suites are not great at testing for correct behavior.  To try to find and fix all issues, I set VM_ARGC_STACK_MAX to -1, ensuring that a temporary array is used for all array splat method calls. This was very helpful in finding breaking cases, especially ones involving flagged keyword hashes.

Fixes [Bug #4040]

Note that this initial commit uses `-1` as `VM_ARGC_STACK_MAX`.  This is for testing, to ensure that a temporary array is used for almost all argument splats.  This makes things significantly slower.  After we get a clean CI run, I'll push another commit that changes `VM_ARGC_STACK_MAX` back to `128`.