### PR TITLE
Re-add RJIT::Instruction#opes

### DIFF
--- a/tool/ruby_vm/models/attribute.rb
+++ b/tool/ruby_vm/models/attribute.rb
@@ -21,7 +21,7 @@ class RubyVM::Attribute
     @key = opts[:name]
     @expr = RubyVM::CExpr.new location: opts[:location], expr: opts[:expr]
     @type = opts[:type]
-    @ope_decls = @insn.opes.map do |operand|
+    @ope_decls = @insn.operands.map do |operand|
       decl = operand[:decl]
       if @key == 'comptime_sp_inc' && operand[:type] == 'CALL_DATA'
         decl = decl.gsub('CALL_DATA', 'CALL_INFO').gsub('cd', 'ci')

--- a/tool/ruby_vm/models/operands_unifications.rb
+++ b/tool/ruby_vm/models/operands_unifications.rb
@@ -38,8 +38,8 @@ class RubyVM::OperandsUnifications < RubyVM::BareInstructions
   end
 
   def operand_shift_of var
-    before = @original.opes.find_index var
-    after  = @opes.find_index var
+    before = @original.operands.find_index var
+    after  = @operands.find_index var
     raise "no #{var} for #{@name}" unless before and after
     return before - after
   end
@@ -50,7 +50,7 @@ class RubyVM::OperandsUnifications < RubyVM::BareInstructions
       case val when '*' then
         next nil
       else
-        type = @original.opes[i][:type]
+        type = @original.operands[i][:type]
         expr = RubyVM::Typemap.typecast_to_VALUE type, val
         next "#{ptr}[#{i}] == #{expr}"
       end
@@ -85,7 +85,7 @@ class RubyVM::OperandsUnifications < RubyVM::BareInstructions
   def compose location, spec, template
     name    = namegen spec
     *, argv = *spec
-    opes    = @original.opes
+    opes    = @original.operands
     if opes.size != argv.size
       raise sprintf("operand size mismatch for %s (%s's: %d, given: %d)",
                     name, template[:name], opes.size, argv.size)

--- a/tool/ruby_vm/views/_comptime_insn_stack_increase.erb
+++ b/tool/ruby_vm/views/_comptime_insn_stack_increase.erb
@@ -42,7 +42,7 @@ comptime_insn_stack_increase_dispatch(enum ruby_vminsn_type insn, const VALUE *o
 %     end
     case <%= i.bin %>:
         return <%= attr_function %>(<%=
-          i.opes.map.with_index do |v, j|
+          i.operands.map.with_index do |v, j|
             if v[:type] == 'CALL_DATA' && i.has_attribute?('comptime_sp_inc')
               v = v.dup
               v[:type] = 'CALL_INFO'

--- a/tool/ruby_vm/views/_insn_entry.erb
+++ b/tool/ruby_vm/views/_insn_entry.erb
@@ -20,7 +20,7 @@ INSN_ENTRY(<%= insn.name %>)
 <%= render_c_expr konst -%>
 % end
 %
-% insn.opes.each_with_index do |ope, i|
+% insn.operands.each_with_index do |ope, i|
     <%= ope[:decl] %> = (<%= ope[:type] %>)GET_OPERAND(<%= i + 1 %>);
 % end
 #   define INSN_ATTR(x) <%= insn.call_attribute(' ## x ## ') %>
@@ -41,7 +41,7 @@ INSN_ENTRY(<%= insn.name %>)
 % end
 <%= insn.handle_canary "SETUP_CANARY(leaf)" -%>
     COLLECT_USAGE_INSN(INSN_ATTR(bin));
-% insn.opes.each_with_index do |ope, i|
+% insn.operands.each_with_index do |ope, i|
     COLLECT_USAGE_OPERAND(INSN_ATTR(bin), <%= i %>, <%= ope[:name] %>);
 % end
 % unless body.empty?

--- a/tool/ruby_vm/views/lib/ruby_vm/rjit/instruction.rb.erb
+++ b/tool/ruby_vm/views/lib/ruby_vm/rjit/instruction.rb.erb
@@ -7,7 +7,7 @@ module RubyVM::RJIT # :nodoc: all
       name: :<%= insn.name %>,
       bin: <%= i %>, # BIN(<%= insn.name %>)
       len: <%= insn.width %>, # insn_len
-      operands: <%= (insn.opes unless insn.name.start_with?('trace_')).inspect %>,
+      operands: <%= (insn.operands unless insn.name.start_with?('trace_')).inspect %>,
     ),
 % end
   }

--- a/tool/ruby_vm/views/lib/ruby_vm/rjit/instruction.rb.erb
+++ b/tool/ruby_vm/views/lib/ruby_vm/rjit/instruction.rb.erb
@@ -1,5 +1,5 @@
 module RubyVM::RJIT # :nodoc: all
-  Instruction = Data.define(:name, :bin, :len)
+  Instruction = Data.define(:name, :bin, :len, :opes)
 
   INSNS = {
 % RubyVM::Instructions.each_with_index do |insn, i|
@@ -7,6 +7,7 @@ module RubyVM::RJIT # :nodoc: all
       name: :<%= insn.name %>,
       bin: <%= i %>, # BIN(<%= insn.name %>)
       len: <%= insn.width %>, # insn_len
+      opes: <%= (insn.opes unless insn.name.start_with?('trace_')).inspect %>,
     ),
 % end
   }

--- a/tool/ruby_vm/views/lib/ruby_vm/rjit/instruction.rb.erb
+++ b/tool/ruby_vm/views/lib/ruby_vm/rjit/instruction.rb.erb
@@ -1,5 +1,5 @@
 module RubyVM::RJIT # :nodoc: all
-  Instruction = Data.define(:name, :bin, :len, :opes)
+  Instruction = Data.define(:name, :bin, :len, :operands)
 
   INSNS = {
 % RubyVM::Instructions.each_with_index do |insn, i|
@@ -7,7 +7,7 @@ module RubyVM::RJIT # :nodoc: all
       name: :<%= insn.name %>,
       bin: <%= i %>, # BIN(<%= insn.name %>)
       len: <%= insn.width %>, # insn_len
-      opes: <%= (insn.opes unless insn.name.start_with?('trace_')).inspect %>,
+      operands: <%= (insn.opes unless insn.name.start_with?('trace_')).inspect %>,
     ),
 % end
   }

--- a/tool/ruby_vm/views/optinsn.inc.erb
+++ b/tool/ruby_vm/views/optinsn.inc.erb
@@ -29,14 +29,14 @@ insn_operands_unification(INSN *iobj)
 
         /* <%= insn.pretty_name %> */
         if ( <%= insn.condition('op') %> ) {
-%       insn.opes.each_with_index do |o, x|
+%       insn.operands.each_with_index do |o, x|
 %         n = insn.operand_shift_of(o)
 %         if n != 0 then
             op[<%= x %>] = op[<%= x + n %>];
 %         end
 %       end
             iobj->insn_id      = <%= insn.bin %>;
-            iobj->operand_size = <%= insn.opes.size %>;
+            iobj->operand_size = <%= insn.operands.size %>;
             break;
         }
 %   end


### PR DESCRIPTION
Useful for "bring your own JIT" implementations to have type information of arguments

I left it as `nil` for trace instructions.

cc @k0kubun @tenderlove