### PR TITLE
tool test/unit/testcase: rename vars @passed, @@current

### DIFF
--- a/tool/lib/test/unit/testcase.rb
+++ b/tool/lib/test/unit/testcase.rb
@@ -144,8 +144,7 @@ module Test
       # Runs the tests reporting the status to +runner+
 
       def run runner
-        @options = runner.options
-
+        @__runner_options__ = runner.options
         trap "INFO" do
           runner.report.each_with_index do |msg, i|
             warn "\n%3d) %s" % [i + 1, msg]
@@ -161,7 +160,7 @@ module Test
         result = ""
 
         begin
-          @passed = nil
+          @__passed__ = nil
           self.before_setup
           self.setup
           self.after_setup
@@ -169,11 +168,11 @@ module Test
           result = "." unless io?
           time = Time.now - start_time
           runner.record self.class, self.__name__, self._assertions, time, nil
-          @passed = true
+          @__passed__ = true
         rescue *PASSTHROUGH_EXCEPTIONS
           raise
         rescue Exception => e
-          @passed = Test::Unit::PendedError === e
+          @__passed__ = Test::Unit::PendedError === e
           time = Time.now - start_time
           runner.record self.class, self.__name__, self._assertions, time, e
           result = runner.puke self.class, self.__name__, e
@@ -184,7 +183,7 @@ module Test
             rescue *PASSTHROUGH_EXCEPTIONS
               raise
             rescue Exception => e
-              @passed = false
+              @__passed__ = false
               runner.record self.class, self.__name__, self._assertions, time, e
               result = runner.puke self.class, self.__name__, e
             end
@@ -206,12 +205,12 @@ module Test
       def initialize name # :nodoc:
         @__name__ = name
         @__io__ = nil
-        @passed = nil
-        @@current = self # FIX: make thread local
+        @__passed__ = nil
+        @@__current__ = self # FIX: make thread local
       end
 
       def self.current # :nodoc:
-        @@current # FIX: make thread local
+        @@__current__ # FIX: make thread local
       end
 
       ##
@@ -263,7 +262,7 @@ module Test
       # Returns true if the test passed.
 
       def passed?
-        @passed
+        @__passed__
       end
 
       ##

--- a/tool/test/testunit/test_hideskip.rb
+++ b/tool/test/testunit/test_hideskip.rb
@@ -13,7 +13,7 @@ class TestHideSkip < Test::Unit::TestCase
   private
 
   def hideskip(*args)
-    IO.popen([*@options[:ruby], "#{File.dirname(__FILE__)}/test4test_hideskip.rb",
+    IO.popen([*@__runner_options__[:ruby], "#{File.dirname(__FILE__)}/test4test_hideskip.rb",
                        "--verbose", *args], err: [:child, :out]) {|f|
       f.read
     }

--- a/tool/test/testunit/test_load_failure.rb
+++ b/tool/test/testunit/test_load_failure.rb
@@ -13,7 +13,7 @@ class TestLoadFailure < Test::Unit::TestCase
   private
 
   def load_failure(*args)
-    IO.popen([*@options[:ruby], "#{__dir__}/../runner.rb",
+    IO.popen([*@__runner_options__[:ruby], "#{__dir__}/../runner.rb",
               "#{__dir__}/test4test_load_failure.rb",
               "--verbose", *args], err: [:child, :out]) {|f|
       assert_include(f.read, "test4test_load_failure.rb")

--- a/tool/test/testunit/test_parallel.rb
+++ b/tool/test/testunit/test_parallel.rb
@@ -12,8 +12,8 @@ module TestParallel
     def setup
       i, @worker_in = IO.pipe
       @worker_out, o = IO.pipe
-      @worker_pid = spawn(*@options[:ruby], PARALLEL_RB,
-                          "--ruby", @options[:ruby].join(" "),
+      @worker_pid = spawn(*@__runner_options__[:ruby], PARALLEL_RB,
+                          "--ruby", @__runner_options__[:ruby].join(" "),
                           "-j", "t1", "-v", out: o, in: i)
       [i,o].each(&:close)
     end
@@ -145,8 +145,8 @@ module TestParallel
   class TestParallel < Test::Unit::TestCase
     def spawn_runner(*opt_args, jobs: "t1")
       @test_out, o = IO.pipe
-      @test_pid = spawn(*@options[:ruby], TESTS+"/runner.rb",
-                        "--ruby", @options[:ruby].join(" "),
+      @test_pid = spawn(*@__runner_options__[:ruby], TESTS+"/runner.rb",
+                        "--ruby", @__runner_options__[:ruby].join(" "),
                         "-j", jobs, *opt_args, out: o, err: o)
       o.close
     end

--- a/tool/test/testunit/test_sorting.rb
+++ b/tool/test/testunit/test_sorting.rb
@@ -10,7 +10,7 @@ class TestTestUnitSorting < Test::Unit::TestCase
   end
 
   def sorting(*args)
-    IO.popen([*@options[:ruby], "#{File.dirname(__FILE__)}/test4test_sorting.rb",
+    IO.popen([*@__runner_options__[:ruby], "#{File.dirname(__FILE__)}/test4test_sorting.rb",
               "--verbose", *args], err: [:child, :out]) {|f|
       f.read
     }

--- a/tool/test/testunit/test_timeout.rb
+++ b/tool/test/testunit/test_timeout.rb
@@ -3,7 +3,7 @@ require 'test/unit'
 
 class TestTiemout < Test::Unit::TestCase
   def test_timeout
-    cmd = [*@options[:ruby], "#{File.dirname(__FILE__)}/test4test_timeout.rb"]
+    cmd = [*@__runner_options__[:ruby], "#{File.dirname(__FILE__)}/test4test_timeout.rb"]
     result = IO.popen(cmd, err: [:child, :out], &:read)
     assert_not_match(/^T{10}$/, result)
   end


### PR DESCRIPTION
to `@__passed__`, `@@__current__`.
`@passed` is redefined accidentally in a few test suites, and this could lead to bugs.

Also rename `@options` (Runner#options) to `@__runner_options__`