### PR TITLE
Add thread and ractor counts to bug reports

### DIFF
--- a/test/ruby/test_rubyoptions.rb
+++ b/test/ruby/test_rubyoptions.rb
@@ -755,6 +755,9 @@ class TestRubyOptions < Test::Unit::TestCase
         )?
       )x,
       %r(
+        (?:--\sThreading(?:.+\n)*\n)?
+      )x,
+      %r(
         (?:--\sMachine(?:.+\n)*\n)?
       )x,
       %r(

--- a/vm_dump.c
+++ b/vm_dump.c
@@ -1083,6 +1083,14 @@ rb_vm_bugreport(const void *ctx)
         SDR();
         rb_backtrace_print_as_bugreport();
         fputs("\n", stderr);
+        // If we get here, hopefully things are intact enough that
+        // we can read these two numbers. It is an estimate because
+        // we are reading without synchronization.
+        fprintf(stderr, "-- Threading information "
+                "---------------------------------------------------\n");
+        fprintf(stderr, "Total ractor count: %u\n", vm->ractor.cnt);
+        fprintf(stderr, "Ruby thread count for this ractor: %u\n", rb_ec_ractor_ptr(ec)->threads.cnt);
+        fputs("\n", stderr);
     }
 
     rb_dump_machine_register(ctx);


### PR DESCRIPTION
This is useful for crash triaging. It also helps to hint extension
developers about the misuse of `rb_thread_call_without_gvl()`.

Example:

    $ ./miniruby -e 'Ractor.new{Ractor.receive};
        Thread.new{sleep}; Process.kill:SEGV,Process.pid'
    <snip>
    -- Threading information ---------------------------------------------------
    Total ractor count: 2
    Ruby thread count for this ractor: 2
