### PR TITLE
YJIT: use u16 for insn_idx instead of u32

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -16,7 +16,7 @@ use std::cmp;
 use std::collections::HashMap;
 use std::ffi::CStr;
 use std::mem::{self, size_of};
-use std::os::raw::{c_int, c_uint};
+use std::os::raw::{c_int};
 use std::ptr;
 use std::slice;
 
@@ -48,7 +48,7 @@ pub struct JITState {
     iseq: IseqPtr,
 
     // Index of the current instruction being compiled
-    insn_idx: u32,
+    insn_idx: u16,
 
     // Opcode for the instruction being compiled
     opcode: usize,
@@ -94,7 +94,7 @@ impl JITState {
         self.block.clone()
     }
 
-    pub fn get_insn_idx(&self) -> u32 {
+    pub fn get_insn_idx(&self) -> u16 {
         self.insn_idx
     }
 
@@ -118,8 +118,8 @@ impl JITState {
     }
 
     // Get the index of the next instruction
-    fn next_insn_idx(&self) -> u32 {
-        self.insn_idx + insn_len(self.get_opcode())
+    fn next_insn_idx(&self) -> u16 {
+        self.insn_idx + insn_len(self.get_opcode()) as u16
     }
 
     // Check if we are compiling the instruction at the stub PC
@@ -512,7 +512,7 @@ pub fn jit_ensure_block_entry_exit(jit: &mut JITState, ocb: &mut OutlinedCb) {
         // Generate the exit with the cache in jitstate.
         block.entry_exit = Some(get_side_exit(jit, ocb, &block_ctx).unwrap_code_ptr());
     } else {
-        let block_entry_pc = unsafe { rb_iseq_pc_at_idx(blockid.iseq, blockid.idx) };
+        let block_entry_pc = unsafe { rb_iseq_pc_at_idx(blockid.iseq, blockid.idx.into()) };
         block.entry_exit = Some(gen_outlined_exit(block_entry_pc, &block_ctx, ocb));
     }
 }
@@ -582,9 +582,9 @@ fn gen_leave_exit(ocb: &mut OutlinedCb) -> CodePtr {
 // This is to handle the situation of optional parameters.
 // When a function with optional parameters is called, the entry
 // PC for the method isn't necessarily 0.
-fn gen_pc_guard(asm: &mut Assembler, iseq: IseqPtr, insn_idx: u32) {
+fn gen_pc_guard(asm: &mut Assembler, iseq: IseqPtr, insn_idx: u16) {
     let pc_opnd = Opnd::mem(64, CFP, RUBY_OFFSET_CFP_PC);
-    let expected_pc = unsafe { rb_iseq_pc_at_idx(iseq, insn_idx) };
+    let expected_pc = unsafe { rb_iseq_pc_at_idx(iseq, insn_idx.into()) };
     let expected_pc_opnd = Opnd::const_ptr(expected_pc as *const u8);
 
     asm.cmp(pc_opnd, expected_pc_opnd);
@@ -609,7 +609,7 @@ fn gen_pc_guard(asm: &mut Assembler, iseq: IseqPtr, insn_idx: u32) {
 
 /// Compile an interpreter entry block to be inserted into an iseq
 /// Returns None if compilation fails.
-pub fn gen_entry_prologue(cb: &mut CodeBlock, iseq: IseqPtr, insn_idx: u32) -> Option<CodePtr> {
+pub fn gen_entry_prologue(cb: &mut CodeBlock, iseq: IseqPtr, insn_idx: u16) -> Option<CodePtr> {
     let code_ptr = cb.get_write_ptr();
 
     let mut asm = Assembler::new();
@@ -728,7 +728,8 @@ pub fn gen_single_block(
     // Instruction sequence to compile
     let iseq = blockid.iseq;
     let iseq_size = unsafe { get_iseq_encoded_size(iseq) };
-    let mut insn_idx: c_uint = blockid.idx;
+    let iseq_size: u16 = iseq_size.try_into().unwrap();
+    let mut insn_idx: u16 = blockid.idx;
     let starting_insn_idx = insn_idx;
 
     // Allocate the new block
@@ -752,7 +753,7 @@ pub fn gen_single_block(
     // NOTE: could rewrite this loop with a std::iter::Iterator
     while insn_idx < iseq_size {
         // Get the current pc and opcode
-        let pc = unsafe { rb_iseq_pc_at_idx(iseq, insn_idx) };
+        let pc = unsafe { rb_iseq_pc_at_idx(iseq, insn_idx.into()) };
         // try_into() call below is unfortunate. Maybe pick i32 instead of usize for opcodes.
         let opcode: usize = unsafe { rb_iseq_opcode_at_pc(iseq, pc) }
             .try_into()
@@ -834,7 +835,7 @@ pub fn gen_single_block(
         ctx.reset_chain_depth();
 
         // Move to the next instruction to compile
-        insn_idx += insn_len(opcode);
+        insn_idx += insn_len(opcode) as u16;
 
         // If the instruction terminates this block
         if status == EndBlock {
@@ -3536,7 +3537,8 @@ fn gen_opt_case_dispatch(
         };
 
         // Jump to the offset of case or else
-        let jump_block = BlockId { iseq: jit.iseq, idx: jit.next_insn_idx() + jump_offset };
+        let jump_idx = jit.next_insn_idx() as u32 + jump_offset;
+        let jump_block = BlockId { iseq: jit.iseq, idx: jump_idx.try_into().unwrap() };
         gen_direct_jump(jit, &ctx, jump_block, asm);
         EndBlock
     } else {
@@ -3567,7 +3569,7 @@ fn gen_branchif(
     };
     let jump_block = BlockId {
         iseq: jit.iseq,
-        idx: jump_idx as u32,
+        idx: jump_idx.try_into().unwrap(),
     };
 
     // Test if any bit (outside of the Qnil bit) is on
@@ -3751,10 +3753,10 @@ fn gen_jump(
     }
 
     // Get the branch target instruction offsets
-    let jump_idx = (jit.next_insn_idx() as i32) + jump_offset;
+    let jump_idx = jit.next_insn_idx() as i32 + jump_offset;
     let jump_block = BlockId {
         iseq: jit.iseq,
-        idx: jump_idx as u32,
+        idx: jump_idx.try_into().unwrap(),
     };
 
     // Generate the jump instruction
@@ -5426,7 +5428,7 @@ fn gen_send_iseq(
         return CantCompile;
     }
 
-    let mut start_pc_offset = 0;
+    let mut start_pc_offset: u16 = 0;
     let required_num = unsafe { get_iseq_body_param_lead_num(iseq) };
 
     // This struct represents the metadata about the caller-specified
@@ -5498,7 +5500,7 @@ fn gen_send_iseq(
         num_params -= opts_missing as u32;
         unsafe {
             let opt_table = get_iseq_body_param_opt_table(iseq);
-            start_pc_offset = (*opt_table.offset(opts_filled as isize)).as_u32();
+            start_pc_offset = (*opt_table.offset(opts_filled as isize)).try_into().unwrap();
         }
     }
 
@@ -5685,7 +5687,7 @@ fn gen_send_iseq(
             unsafe {
                 let opt_table = get_iseq_body_param_opt_table(iseq);
                 let offset = (opt_num - remaining_opt as i32) as isize;
-                start_pc_offset = (*opt_table.offset(offset)).as_u32();
+                start_pc_offset = (*opt_table.offset(offset)).try_into().unwrap();
             };
         }
         // We are going to assume that the splat fills

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -399,7 +399,7 @@ pub struct BlockId {
     pub iseq: IseqPtr,
 
     /// Index in the iseq where the block starts
-    pub idx: u32,
+    pub idx: u16,
 }
 
 /// Branch code shape enumeration
@@ -618,7 +618,7 @@ pub struct Block {
     blockid: BlockId,
 
     // Index one past the last instruction for this block in the iseq
-    end_idx: u32,
+    end_idx: u16,
 
     // Context at the start of the block
     // This should never be mutated
@@ -1210,7 +1210,7 @@ impl Block {
         self.blockid
     }
 
-    pub fn get_end_idx(&self) -> u32 {
+    pub fn get_end_idx(&self) -> u16 {
         self.end_idx
     }
 
@@ -1250,7 +1250,7 @@ impl Block {
 
     /// Set the index of the last instruction in the block
     /// This can be done only once for a block
-    pub fn set_end_idx(&mut self, end_idx: u32) {
+    pub fn set_end_idx(&mut self, end_idx: u16) {
         assert!(self.end_idx == 0);
         self.end_idx = end_idx;
     }
@@ -1669,7 +1669,7 @@ impl BlockId {
     #[cfg(debug_assertions)]
     #[allow(dead_code)]
     pub fn dump_src_loc(&self) {
-        unsafe { rb_yjit_dump_iseq_loc(self.iseq, self.idx) }
+        unsafe { rb_yjit_dump_iseq_loc(self.iseq, self.idx as u32) }
     }
 }
 
@@ -1794,7 +1794,7 @@ fn gen_block_series_body(
 /// NOTE: this function assumes that the VM lock has been taken
 pub fn gen_entry_point(iseq: IseqPtr, ec: EcPtr) -> Option<CodePtr> {
     // Compute the current instruction index based on the current PC
-    let insn_idx: u32 = unsafe {
+    let insn_idx: u16 = unsafe {
         let pc_zero = rb_iseq_pc_at_idx(iseq, 0);
         let ec_pc = get_cfp_pc(get_ec_cfp(ec));
         ec_pc.offset_from(pc_zero).try_into().ok()?
@@ -1975,7 +1975,7 @@ fn branch_stub_hit_body(branch_ptr: *const c_void, target_idx: u32, ec: EcPtr) -
         let original_interp_sp = get_cfp_sp(cfp);
 
         let running_iseq = rb_cfp_get_iseq(cfp);
-        let reconned_pc = rb_iseq_pc_at_idx(running_iseq, target_blockid.idx);
+        let reconned_pc = rb_iseq_pc_at_idx(running_iseq, target_blockid.idx.into());
         let reconned_sp = original_interp_sp.offset(target_ctx.sp_offset.into());
 
         assert_eq!(running_iseq, target_blockid.iseq as _, "each stub expects a particular iseq");
@@ -2385,7 +2385,7 @@ pub fn free_block(blockref: &BlockRef) {
 pub fn verify_blockid(blockid: BlockId) {
     unsafe {
         assert!(rb_IMEMO_TYPE_P(blockid.iseq.into(), imemo_iseq) != 0);
-        assert!(blockid.idx < get_iseq_encoded_size(blockid.iseq));
+        assert!(u32::from(blockid.idx) < get_iseq_encoded_size(blockid.iseq));
     }
 }
 

--- a/yjit/src/disasm.rs
+++ b/yjit/src/disasm.rs
@@ -44,7 +44,7 @@ pub extern "C" fn rb_yjit_disasm_iseq(_ec: EcPtr, _ruby_self: VALUE, iseqw: VALU
 }
 
 #[cfg(feature = "disasm")]
-pub fn disasm_iseq_insn_range(iseq: IseqPtr, start_idx: u32, end_idx: u32) -> String {
+pub fn disasm_iseq_insn_range(iseq: IseqPtr, start_idx: u16, end_idx: u16) -> String {
     let mut out = String::from("");
 
     // Get a list of block versions generated for this iseq
@@ -310,7 +310,7 @@ pub extern "C" fn rb_yjit_insns_compiled(_ec: EcPtr, _ruby_self: VALUE, iseqw: V
     }
 }
 
-fn insns_compiled(iseq: IseqPtr) -> Vec<(String, u32)> {
+fn insns_compiled(iseq: IseqPtr) -> Vec<(String, u16)> {
     let mut insn_vec = Vec::new();
 
     // Get a list of block versions generated for this iseq
@@ -321,13 +321,13 @@ fn insns_compiled(iseq: IseqPtr) -> Vec<(String, u32)> {
         let block = blockref.borrow();
         let start_idx = block.get_blockid().idx;
         let end_idx = block.get_end_idx();
-        assert!(end_idx <= unsafe { get_iseq_encoded_size(iseq) });
+        assert!(u32::from(end_idx) <= unsafe { get_iseq_encoded_size(iseq) });
 
         // For each YARV instruction in the block
         let mut insn_idx = start_idx;
         while insn_idx < end_idx {
             // Get the current pc and opcode
-            let pc = unsafe { rb_iseq_pc_at_idx(iseq, insn_idx) };
+            let pc = unsafe { rb_iseq_pc_at_idx(iseq, insn_idx.into()) };
             // try_into() call below is unfortunate. Maybe pick i32 instead of usize for opcodes.
             let opcode: usize = unsafe { rb_iseq_opcode_at_pc(iseq, pc) }
                 .try_into()
@@ -340,7 +340,7 @@ fn insns_compiled(iseq: IseqPtr) -> Vec<(String, u32)> {
             insn_vec.push((op_name, insn_idx));
 
             // Move to the next instruction
-            insn_idx += insn_len(opcode);
+            insn_idx += insn_len(opcode) as u16;
         }
     }
 

--- a/yjit/src/invariants.rs
+++ b/yjit/src/invariants.rs
@@ -415,7 +415,7 @@ pub fn block_assumptions_free(blockref: &BlockRef) {
 /// Invalidate the block for the matching opt_getinlinecache so it could regenerate code
 /// using the new value in the constant cache.
 #[no_mangle]
-pub extern "C" fn rb_yjit_constant_ic_update(iseq: *const rb_iseq_t, ic: IC, insn_idx: u32) {
+pub extern "C" fn rb_yjit_constant_ic_update(iseq: *const rb_iseq_t, ic: IC, insn_idx: u16) {
     // If YJIT isn't enabled, do nothing
     if !yjit_enabled_p() {
         return;
@@ -433,7 +433,7 @@ pub extern "C" fn rb_yjit_constant_ic_update(iseq: *const rb_iseq_t, ic: IC, ins
         // This should come from a running iseq, so direct threading translation
         // should have been done
         assert!(unsafe { FL_TEST(iseq.into(), VALUE(ISEQ_TRANSLATED)) } != VALUE(0));
-        assert!(insn_idx < unsafe { get_iseq_encoded_size(iseq) });
+        assert!(u32::from(insn_idx) < unsafe { get_iseq_encoded_size(iseq) });
 
         // Ensure that the instruction the insn_idx is pointing to is in
         // fact a opt_getconstant_path instruction.

--- a/yjit/src/utils.rs
+++ b/yjit/src/utils.rs
@@ -86,7 +86,7 @@ fn ruby_str_to_rust(v: VALUE) -> String {
 // Location is the file defining the method, colon, method name.
 // Filenames are sometimes internal strings supplied to eval,
 // so be careful with them.
-pub fn iseq_get_location(iseq: IseqPtr, pos: u32) -> String {
+pub fn iseq_get_location(iseq: IseqPtr, pos: u16) -> String {
     let iseq_label = unsafe { rb_iseq_label(iseq) };
     let iseq_path = unsafe { rb_iseq_path(iseq) };
     let iseq_lineno = unsafe { rb_iseq_line_no(iseq, pos as usize) };


### PR DESCRIPTION
Resurrecting this PR. At the moment it doesn't seem to make a significant difference, but we've already validated that limiting YJIT to ISEQs with size less than 64K doesn't affect performance on SFR or on benchmarks, and I figure every little bit of size optimization counts.