### PR TITLE
Fix incorrect size of WeakMap buffer

### DIFF
--- a/weakmap.c
+++ b/weakmap.c
@@ -163,8 +163,8 @@ wmap_final_func(st_data_t *key, st_data_t *value, st_data_t arg, int existing)
         return ST_DELETE;
     }
     if (j < i) {
-        SIZED_REALLOC_N(ptr, VALUE, j + 1, i);
-        ptr[0] = j;
+        SIZED_REALLOC_N(ptr, VALUE, j, i);
+        ptr[0] = j - 1;
         *value = (st_data_t)ptr;
     }
     return ST_CONTINUE;


### PR DESCRIPTION
In wmap_final_func, j is the number of elements + 1 (since j also includes the length at the 0th index), so we should resize the buffer to size j and the new length is j - 1.