### PR TITLE
YJIT: Eliminate unnecessary mov for trampolines

### DIFF
--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -1491,7 +1491,10 @@ impl Assembler {
     }
 
     pub fn load_into(&mut self, dest: Opnd, opnd: Opnd) {
-        self.push_insn(Insn::LoadInto { dest, opnd });
+        match (dest, opnd) {
+            (Opnd::Reg(dest), Opnd::Reg(opnd)) if dest == opnd => {}, // skip if noop
+            _ => self.push_insn(Insn::LoadInto { dest, opnd }),
+        }
     }
 
     #[must_use]


### PR DESCRIPTION
Maybe not a big deal in practice, but this annoyed me because I needed to generate similar code for https://github.com/ruby/ruby/pull/7535.

## before
```asm
  # branch_stub_hit() trampoline
  0x557a17a3e017: mov rdi, rdi
  0x557a17a3e01a: mov rsi, rsi
  0x557a17a3e01d: mov rdx, r12
  0x557a17a3e020: call 0x557a14f43e40
  0x557a17a3e025: jmp rax
```

## after
```asm
  # branch_stub_hit() trampoline
  0x56455af9a017: mov rdx, r12
  0x56455af9a01a: call 0x56455989fe00
  0x56455af9a01f: jmp rax
```