### PR TITLE
ObjectSpace::WeakMap: clean inverse reference when an entry is re-assigned

### DIFF
--- a/test/ruby/test_weakmap.rb
+++ b/test/ruby/test_weakmap.rb
@@ -194,4 +194,21 @@ class TestWeakMap < Test::Unit::TestCase
       GC.compact
     end;
   end
+
+  def test_replaced_values_bug_19531
+    a = "A".dup
+    b = "B".dup
+
+    @wm[1] = a
+    @wm[1] = a
+    @wm[1] = a
+
+    @wm[1] = b
+    assert_equal b, @wm[1]
+
+    a = nil
+    GC.start
+
+    assert_equal b, @wm[1]
+  end
 end


### PR DESCRIPTION
[Bug #19531]

```ruby
wmap[1] = "A"
wmap[1] = "B"
```

In the example above, we need to remove the `"A" => 1` inverse reference so that when `"A"` is GCed the `1` key isn't deleted.

@peterzhu2118 