### PR TITLE
Update dln.c to fix error output from dln_open()

### DIFF
--- a/dln.c
+++ b/dln.c
@@ -385,10 +385,10 @@ dln_open(const char *file)
         const char *libruby_name = NULL;
         if (dln_incompatible_library_p(handle, &libruby_name)) {
             if (dln_disable_dlclose()) {
+                /* dlclose() segfaults */
                 if (libruby_name) {
                     dln_fatalerror("linked to incompatible %s - %s", libruby_name, file);
                 }
-                /* dlclose(handle) segfaults */
                 dln_fatalerror("%s - %s", incompatible, file);
             }
             else {

--- a/dln.c
+++ b/dln.c
@@ -385,17 +385,17 @@ dln_open(const char *file)
         const char *libruby_name = NULL;
         if (dln_incompatible_library_p(handle, &libruby_name)) {
             if (dln_disable_dlclose()) {
-                /* dlclose() segfaults */
                 if (libruby_name) {
                     dln_fatalerror("linked to incompatible %s - %s", libruby_name, file);
                 }
+                /* dlclose(handle) segfaults */
                 dln_fatalerror("%s - %s", incompatible, file);
             }
             else {
-                dlclose(handle);
                 if (libruby_name) {
                     dln_loaderror("linked to incompatible %s - %s", libruby_name, file);
                 }
+                dlclose(handle);
                 error = incompatible;
                 goto failed;
             }

--- a/dln.c
+++ b/dln.c
@@ -393,9 +393,17 @@ dln_open(const char *file)
             }
             else {
                 if (libruby_name) {
-                    dln_loaderror("linked to incompatible %s - %s", libruby_name, file);
+                    const size_t len = strlen(libruby_name);
+                    char *const tmp = ALLOCA_N(char, len + 1);
+                    if (tmp) {
+                        memcpy(tmp, libruby_name, len + 1);
+                        libruby_name = tmp;
+                    }
                 }
                 dlclose(handle);
+                if (libruby_name) {
+                    dln_loaderror("linked to incompatible %s - %s", libruby_name, file);
+                }
                 error = incompatible;
                 goto failed;
             }

--- a/dln.c
+++ b/dln.c
@@ -395,10 +395,8 @@ dln_open(const char *file)
                 if (libruby_name) {
                     const size_t len = strlen(libruby_name);
                     char *const tmp = ALLOCA_N(char, len + 1);
-                    if (tmp) {
-                        memcpy(tmp, libruby_name, len + 1);
-                        libruby_name = tmp;
-                    }
+                    if (tmp) memcpy(tmp, libruby_name, len + 1);
+                    libruby_name = tmp;
                 }
                 dlclose(handle);
                 if (libruby_name) {


### PR DESCRIPTION
On CentOS7 when using Phusion-Passenger via RPM from the official Phusion-Passenger RPM repo I am seeing the following problem.  Passenger tries to 

`require '/usr/lib64/ruby/vendor_ruby/passenger_native_support.so'`

but this is correctly linked to the ruby-2.0 libraries so ruby-3.2.1 raises a LoadError :

(simulated with `ruby32 -e "require '/usr/lib64/ruby/vendor_ruby/passenger_native_support.so'"`)

```
<internal:/usr/lib64/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:88:in `require': linked to incompatible @b? - /usr/lib64/ruby/vendor_ruby/passenger_native_support.so (LoadError)
	from <internal:/usr/lib64/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:88:in `require'
	from -:1:in `<main>'
```

It looks to me like `dlclose(handle)` in `dln_open` is trashing `libruby_name` (originally from line 280: `*libname = dli.dli_fname;`)

Moving the `dlclose(handle)` to after the error output fixes the problem :

```
LD_PRELOAD=./libruby32.so.3.2 ./ruby32 -e "require '/usr/lib64/ruby/vendor_ruby/passenger_native_support.so'"
<internal:/usr/lib64/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:88:in `require': linked to incompatible /lib64/libruby.so.2.0 - /usr/lib64/ruby/vendor_ruby/passenger_native_support.so (LoadError)
	from <internal:/usr/lib64/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:88:in `require'
	from -e:1:in `<main>'
```