### PR TITLE
core_assertions.rb: Relax `assert_linear_performance`

### DIFF
--- a/test/ruby/test_regexp.rb
+++ b/test/ruby/test_regexp.rb
@@ -1783,7 +1783,7 @@ class TestRegexp < Test::Unit::TestCase
 
   def test_linear_performance
     pre = ->(n) {[Regexp.new("a?" * n + "a" * n), "a" * n]}
-    assert_linear_performance(factor: 29, first: 10, max: 1, pre: pre) do |re, s|
+    assert_linear_performance([10, 29], pre: pre) do |re, s|
       re =~ s
     end
   end


### PR DESCRIPTION
* Use an `Enumerable` as factors, instead of three arguments.

* Include `assert_operator` time in rehearsal time.

* Round up max expected time.