### PR TITLE
YJIT: Rest and block_arg support

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -3662,3 +3662,25 @@ assert_equal '[1, 2, 3]', %q{
   end
   send(:bar, 1, 2, 3)
 }
+
+# Rest with block
+# Simplified code from railsbench
+assert_equal '[{"/a"=>"b", :as=>:c, :via=>:post}, [], nil]', %q{
+
+  def match(path, *rest, &block)
+    [path, rest, block]
+  end
+
+  def map_method(method, args, &block)
+    options = args.last
+    args.pop
+    options[:via] = method
+    match(*args, options, &block)
+  end
+
+  def post(*args, &block)
+    map_method(:post, args, &block)
+  end
+
+  post "/a" => "b", as: :c
+}

--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -3666,7 +3666,6 @@ assert_equal '[1, 2, 3]', %q{
 # Rest with block
 # Simplified code from railsbench
 assert_equal '[{"/a"=>"b", :as=>:c, :via=>:post}, [], nil]', %q{
-
   def match(path, *rest, &block)
     [path, rest, block]
   end

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -5172,9 +5172,9 @@ fn move_rest_args_to_stack(array: Opnd, num_args: u32, ctx: &mut Context, asm: &
 
     let array_len_opnd = get_array_len(asm, array);
 
-    asm.comment("Side exit if length doesn't not equal remaining args");
+    asm.comment("Side exit if length is less than required");
     asm.cmp(array_len_opnd, num_args.into());
-    asm.jbe(counted_exit!(ocb, side_exit, send_splatarray_length_not_equal));
+    asm.jl(counted_exit!(ocb, side_exit, send_iseq_has_rest_and_splat_not_equal));
 
     asm.comment("Push arguments from array");
 
@@ -5401,11 +5401,6 @@ fn gen_send_iseq(
     let iseq_has_rest = unsafe { get_iseq_flags_has_rest(iseq) };
     if iseq_has_rest && captured_opnd.is_some() {
         gen_counter_incr!(asm, send_iseq_has_rest_and_captured);
-        return CantCompile;
-    }
-
-    if iseq_has_rest && unsafe { get_iseq_flags_has_block(iseq) } {
-        gen_counter_incr!(asm, send_iseq_has_rest_and_block);
         return CantCompile;
     }
 

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -253,11 +253,10 @@ make_counters! {
     send_send_getter,
     send_send_builtin,
     send_iseq_has_rest_and_captured,
-    send_iseq_has_rest_and_splat_fewer,
     send_iseq_has_rest_and_send,
-    send_iseq_has_rest_and_block,
     send_iseq_has_rest_and_kw,
     send_iseq_has_rest_and_optional,
+    send_iseq_has_rest_and_splat_not_equal,
     send_is_a_class_mismatch,
     send_instance_of_class_mismatch,
 


### PR DESCRIPTION

Here are the stats of railsbench and liquid-render before and after these changes
        
Highlight:
```
Before:
    iseq_has_rest_and_block:     54,480 (17.2%)
After:
    N/a
```

<summary>Rails Bench Before</summary>
<details>

```ruby
         ***YJIT: Printing YJIT statistics on exit***
method call exit reasons: 
                          block_arg:     64,963 (20.5%)
                        iseq_zsuper:     60,079 (19.0%)
            iseq_has_rest_and_block:     54,480 (17.2%)
                   iseq_arity_error:     30,686 ( 9.7%)
                iseq_ruby2_keywords:     25,096 ( 7.9%)
                     iseq_has_no_kw:     17,298 ( 5.5%)
          args_splat_cfunc_var_args:     16,341 ( 5.2%)
                           kw_splat:     12,996 ( 4.1%)
         iseq_has_rest_and_optional:     10,627 ( 3.4%)
                    iseq_has_kwrest:      7,319 ( 2.3%)
                  klass_megamorphic:      4,979 ( 1.6%)
           iseq_missing_optional_kw:      4,054 ( 1.3%)
               iseq_has_rest_and_kw:      2,193 ( 0.7%)
             args_splat_cfunc_zuper:      2,002 ( 0.6%)
                      iseq_has_post:      1,988 ( 0.6%)
              cfunc_ruby_array_varg:      1,368 ( 0.4%)
                           keywords:        102 ( 0.0%)
    args_splat_cfunc_ruby2_keywords:         62 ( 0.0%)
                    args_splat_ivar:         50 ( 0.0%)
                      zsuper_method:         23 ( 0.0%)
                        send_getter:         12 ( 0.0%)
                args_splat_opt_call:          5 ( 0.0%)
        splatarray_length_not_equal:          2 ( 0.0%)
                    ivar_set_method:          2 ( 0.0%)
                  bmethod_block_arg:          2 ( 0.0%)
                         send_chain:          1 ( 0.0%)
invokeblock exit reasons: 
      proc:      2,398 (92.7%)
    symbol:        188 ( 7.3%)
invokesuper exit reasons: 
    me_changed:      4,795 (68.5%)
         block:      2,206 (31.5%)
leave exit reasons: 
        interp_return:  1,757,526 (97.6%)
    start_pc_non_zero:     43,884 ( 2.4%)
         se_interrupt:         32 ( 0.0%)
getblockparamproxy exit reasons: 
    block_param_modified:          3 (100.0%)
getinstancevariable exit reasons:
    (all relevant counters are zero)
setinstancevariable exit reasons:
    (all relevant counters are zero)
opt_aref exit reasons: 
    (all relevant counters are zero)
expandarray exit reasons: 
            splat:      9,974 (99.8%)
    rhs_too_small:         23 ( 0.2%)
opt_getinlinecache exit reasons: 
    miss:         11 (100.0%)
invalidation reasons: 
       constant_ic_fill:      2,086 (57.7%)
          method_lookup:      1,192 (33.0%)
    constant_state_bump:        338 ( 9.3%)
num_send:                 13,907,946
num_send_known_class:        493,581 ( 3.5%)
num_send_polymorphic:      1,884,834 (13.6%)
iseq_stack_too_large:              0
iseq_too_long:                     0
bindings_allocations:            198
bindings_set:                      0
compiled_iseq_count:           9,320
compiled_block_count:         57,186
compiled_branch_count:        93,482
block_next_count:             47,355
defer_count:                  17,388
defer_empty_count:             2,834
branch_insn_count:             3,823
branch_known_count:              738 (19.3%)
freed_iseq_count:              4,083
invalidation_count:            3,616
constant_state_bumps:              0
get_ivar_max_depth:           10,069
inline_code_size:         10,744,184
outlined_code_size:       10,742,656
freed_code_size:                   0
code_region_size:         21,495,808
yjit_alloc_size:          14,134,241
live_context_size:         1,527,932
live_context_count:           54,569
live_page_count:               1,312
freed_page_count:                  0
code_gc_count:                     0
num_gc_obj_refs:              50,425
object_shape_count:            2,452
side_exit_count:             418,915
total_exit_count:          2,176,441
total_insns_count:        89,547,734
vm_insns_count:            7,705,727
yjit_insns_count:         82,260,922
ratio_in_yjit:                 91.4%
avg_len_in_yjit:                37.6
Top-20 most frequent exit ops (100.0% of exits):
               invokesuper:    105,455 (25.2%)
                      send:     98,208 (23.4%)
    opt_send_without_block:     88,374 (21.1%)
      opt_getconstant_path:     53,944 (12.9%)
               invokeblock:     31,270 ( 7.5%)
                  opt_aref:     14,087 ( 3.4%)
               expandarray:      9,997 ( 2.4%)
             setlocal_WC_0:      8,422 ( 2.0%)
                    opt_eq:      4,983 ( 1.2%)
        getblockparamproxy:      2,271 ( 0.5%)
          putspecialobject:        734 ( 0.2%)
                 opt_nil_p:        300 ( 0.1%)
             definesmethod:        237 ( 0.1%)
                checkmatch:        205 ( 0.0%)
               objtostring:        193 ( 0.0%)
                      once:        104 ( 0.0%)
                     leave:         33 ( 0.0%)
               opt_empty_p:         30 ( 0.0%)
             setblockparam:         25 ( 0.0%)
              definemethod:         21 ( 0.0%)

```
</details>
    
        
<summary>Rails Bench After</summary>
<details>

```ruby
         ***YJIT: Printing YJIT statistics on exit***
method call exit reasons: 
                          block_arg:     64,974 (22.8%)
                        iseq_zsuper:     63,380 (22.2%)
                   iseq_arity_error:     30,686 (10.7%)
                iseq_ruby2_keywords:     25,096 ( 8.8%)
                     iseq_has_no_kw:     19,300 ( 6.8%)
          args_splat_cfunc_var_args:     16,341 ( 5.7%)
            iseq_materialized_block:     16,002 ( 5.6%)
                           kw_splat:     12,997 ( 4.6%)
         iseq_has_rest_and_optional:     12,620 ( 4.4%)
                    iseq_has_kwrest:      7,320 ( 2.6%)
                  klass_megamorphic:      4,960 ( 1.7%)
           iseq_missing_optional_kw:      4,054 ( 1.4%)
               iseq_has_rest_and_kw:      2,205 ( 0.8%)
             args_splat_cfunc_zuper:      2,002 ( 0.7%)
                      iseq_has_post:      1,988 ( 0.7%)
              cfunc_ruby_array_varg:      1,367 ( 0.5%)
                           keywords:        102 ( 0.0%)
    args_splat_cfunc_ruby2_keywords:         62 ( 0.0%)
                    args_splat_ivar:         50 ( 0.0%)
                      zsuper_method:         23 ( 0.0%)
                        send_getter:         12 ( 0.0%)
                args_splat_opt_call:          5 ( 0.0%)
                    ivar_set_method:          2 ( 0.0%)
        splatarray_length_not_equal:          2 ( 0.0%)
                  bmethod_block_arg:          2 ( 0.0%)
                         send_chain:          1 ( 0.0%)
invokeblock exit reasons: 
      proc:      2,398 (92.7%)
    symbol:        188 ( 7.3%)
invokesuper exit reasons: 
    me_changed:      4,794 (68.5%)
         block:      2,206 (31.5%)
leave exit reasons: 
        interp_return:  1,755,453 (97.6%)
    start_pc_non_zero:     43,885 ( 2.4%)
         se_interrupt:         34 ( 0.0%)
getblockparamproxy exit reasons: 
    block_param_modified:          3 (100.0%)
getinstancevariable exit reasons:
    (all relevant counters are zero)
setinstancevariable exit reasons:
    (all relevant counters are zero)
opt_aref exit reasons: 
    (all relevant counters are zero)
expandarray exit reasons: 
            splat:      9,974 (99.8%)
    rhs_too_small:         23 ( 0.2%)
opt_getinlinecache exit reasons: 
    miss:         11 (100.0%)
invalidation reasons: 
       constant_ic_fill:      2,082 (57.6%)
          method_lookup:      1,190 (32.9%)
    constant_state_bump:        341 ( 9.4%)
num_send:                 13,910,539
num_send_known_class:        493,593 ( 3.5%)
num_send_polymorphic:      1,884,879 (13.6%)
iseq_stack_too_large:              0
iseq_too_long:                     0
bindings_allocations:            198
bindings_set:                      0
compiled_iseq_count:           9,322
compiled_block_count:         57,298
compiled_branch_count:        93,922
block_next_count:             15,472
defer_count:                  17,426
defer_empty_count:             2,849
freed_iseq_count:              4,082
invalidation_count:            3,613
constant_state_bumps:              0
get_ivar_max_depth:           10,069
inline_code_size:         11,040,900
outlined_code_size:       11,039,044
freed_code_size:                   0
code_region_size:         22,085,632
yjit_alloc_size:          16,585,927
live_context_size:         1,530,872
live_context_count:           54,674
live_page_count:               1,348
freed_page_count:                  0
code_gc_count:                     0
num_gc_obj_refs:              50,805
object_shape_count:            2,452
side_exit_count:             387,734
total_exit_count:          2,143,187
total_insns_count:        89,558,453
vm_insns_count:            7,666,687
yjit_insns_count:         82,279,500
ratio_in_yjit:                 91.4%
avg_len_in_yjit:                38.2
Top-20 most frequent exit ops (100.0% of exits):
               invokesuper:    103,452 (26.7%)
                      send:     96,129 (24.8%)
    opt_send_without_block:     61,310 (15.8%)
      opt_getconstant_path:     53,940 (13.9%)
               invokeblock:     31,270 ( 8.1%)
                  opt_aref:     14,087 ( 3.6%)
               expandarray:      9,997 ( 2.6%)
             setlocal_WC_0:      8,421 ( 2.2%)
                    opt_eq:      4,983 ( 1.3%)
        getblockparamproxy:      2,271 ( 0.6%)
          putspecialobject:        729 ( 0.2%)
                 opt_nil_p:        300 ( 0.1%)
             definesmethod:        237 ( 0.1%)
                checkmatch:        205 ( 0.1%)
               objtostring:        196 ( 0.1%)
                      once:        104 ( 0.0%)
                     leave:         35 ( 0.0%)
             setblockparam:         25 ( 0.0%)
              definemethod:         21 ( 0.0%)
               defineclass:         19 ( 0.0%)

```
</details>
    
        
<summary>Liquid Render Before</summary>
<details>

```ruby
         ***YJIT: Printing YJIT statistics on exit***
method call exit reasons: 
                    block_arg:      1,475 (61.5%)
                zsuper_method:        832 (34.7%)
        cfunc_ruby_array_varg:         32 ( 1.3%)
         iseq_has_rest_and_kw:         14 ( 0.6%)
            klass_megamorphic:         13 ( 0.5%)
                  send_getter:         12 ( 0.5%)
     iseq_missing_optional_kw:          9 ( 0.4%)
    args_splat_cfunc_var_args:          8 ( 0.3%)
                     kw_splat:          3 ( 0.1%)
      iseq_has_rest_and_block:          1 ( 0.0%)
              ivar_set_method:          1 ( 0.0%)
invokeblock exit reasons: 
      proc:        349 (80.8%)
    symbol:         83 (19.2%)
invokesuper exit reasons: 
    block:         85 (100.0%)
leave exit reasons: 
        interp_return:    276,037 (100.0%)
    start_pc_non_zero:        111 ( 0.0%)
         se_interrupt:         10 ( 0.0%)
getblockparamproxy exit reasons: 
    (all relevant counters are zero)
getinstancevariable exit reasons:
    (all relevant counters are zero)
setinstancevariable exit reasons:
    (all relevant counters are zero)
opt_aref exit reasons: 
    (all relevant counters are zero)
expandarray exit reasons: 
    rhs_too_small:         10 (100.0%)
opt_getinlinecache exit reasons: 
    (all relevant counters are zero)
invalidation reasons: 
       constant_ic_fill:        591 (81.2%)
    constant_state_bump:         94 (12.9%)
          method_lookup:         43 ( 5.9%)
num_send:                  3,025,555
num_send_known_class:        135,961 ( 4.5%)
num_send_polymorphic:        585,176 (19.3%)
iseq_stack_too_large:              1
iseq_too_long:                     0
bindings_allocations:            156
bindings_set:                      0
compiled_iseq_count:           1,682
compiled_block_count:         12,045
compiled_branch_count:        19,951
block_next_count:             10,314
defer_count:                   3,918
defer_empty_count:               763
branch_insn_count:             1,048
branch_known_count:              292 (27.9%)
freed_iseq_count:                563
invalidation_count:              728
constant_state_bumps:              0
get_ivar_max_depth:               10
inline_code_size:          2,023,492
outlined_code_size:        2,023,424
freed_code_size:                   0
code_region_size:          4,063,232
yjit_alloc_size:           4,647,493
live_context_size:           515,508
live_context_count:           18,411
live_page_count:                 248
freed_page_count:                  0
code_gc_count:                     0
num_gc_obj_refs:               8,089
object_shape_count:              766
side_exit_count:               3,965
total_exit_count:            280,002
total_insns_count:        20,362,198
vm_insns_count:            2,280,744
yjit_insns_count:         18,085,419
ratio_in_yjit:                 88.8%
avg_len_in_yjit:                64.6
Top-15 most frequent exit ops (100.0% of exits):
                      send:      1,489 (37.6%)
    opt_send_without_block:        915 (23.1%)
      opt_getconstant_path:        759 (19.1%)
               invokeblock:        432 (10.9%)
                    opt_eq:         91 ( 2.3%)
                      once:         87 ( 2.2%)
               invokesuper:         86 ( 2.2%)
          putspecialobject:         41 ( 1.0%)
             setlocal_WC_0:         22 ( 0.6%)
               expandarray:         10 ( 0.3%)
                  opt_aref:         10 ( 0.3%)
                     leave:         10 ( 0.3%)
        getblockparamproxy:          9 ( 0.2%)
                  opt_ltlt:          2 ( 0.1%)
                checkmatch:          2 ( 0.1%)

```
</details>
    
        
<summary>Liquid Render After</summary>
<details>

```ruby
         ***YJIT: Printing YJIT statistics on exit***
method call exit reasons: 
                    block_arg:      1,474 (61.4%)
                zsuper_method:        832 (34.7%)
        cfunc_ruby_array_varg:         33 ( 1.4%)
         iseq_has_rest_and_kw:         14 ( 0.6%)
            klass_megamorphic:         13 ( 0.5%)
                  send_getter:         12 ( 0.5%)
     iseq_missing_optional_kw:          9 ( 0.4%)
    args_splat_cfunc_var_args:          8 ( 0.3%)
                     kw_splat:          3 ( 0.1%)
              ivar_set_method:          1 ( 0.0%)
invokeblock exit reasons: 
      proc:        349 (80.8%)
    symbol:         83 (19.2%)
invokesuper exit reasons: 
    block:         85 (100.0%)
leave exit reasons: 
        interp_return:    276,005 (100.0%)
    start_pc_non_zero:        111 ( 0.0%)
         se_interrupt:         13 ( 0.0%)
getblockparamproxy exit reasons: 
    (all relevant counters are zero)
getinstancevariable exit reasons:
    (all relevant counters are zero)
setinstancevariable exit reasons:
    (all relevant counters are zero)
opt_aref exit reasons: 
    (all relevant counters are zero)
expandarray exit reasons: 
    rhs_too_small:         10 (100.0%)
opt_getinlinecache exit reasons: 
    (all relevant counters are zero)
invalidation reasons: 
       constant_ic_fill:        586 (81.2%)
    constant_state_bump:         93 (12.9%)
          method_lookup:         43 ( 6.0%)
num_send:                  3,025,703
num_send_known_class:        135,971 ( 4.5%)
num_send_polymorphic:        585,177 (19.3%)
iseq_stack_too_large:              1
iseq_too_long:                     0
bindings_allocations:            156
bindings_set:                      0
compiled_iseq_count:           1,685
compiled_block_count:         12,073
compiled_branch_count:        20,004
block_next_count:              4,250
defer_count:                   3,928
defer_empty_count:               769
freed_iseq_count:                563
invalidation_count:              722
constant_state_bumps:              0
get_ivar_max_depth:               10
inline_code_size:          2,028,472
outlined_code_size:        2,026,520
freed_code_size:                   0
code_region_size:          4,063,232
yjit_alloc_size:           5,442,245
live_context_size:           518,784
live_context_count:           18,528
live_page_count:                 248
freed_page_count:                  0
code_gc_count:                     0
num_gc_obj_refs:               8,098
object_shape_count:              766
side_exit_count:               3,952
total_exit_count:            279,957
total_insns_count:        20,363,462
vm_insns_count:            2,281,261
yjit_insns_count:         18,086,153
ratio_in_yjit:                 88.8%
avg_len_in_yjit:                64.6
Top-16 most frequent exit ops (100.0% of exits):
                      send:      1,486 (37.6%)
    opt_send_without_block:        911 (23.1%)
      opt_getconstant_path:        754 (19.1%)
               invokeblock:        432 (10.9%)
                    opt_eq:         91 ( 2.3%)
                      once:         87 ( 2.2%)
               invokesuper:         86 ( 2.2%)
          putspecialobject:         36 ( 0.9%)
             setlocal_WC_0:         22 ( 0.6%)
                     leave:         13 ( 0.3%)
               expandarray:         10 ( 0.3%)
                  opt_aref:         10 ( 0.3%)
        getblockparamproxy:          9 ( 0.2%)
                checkmatch:          2 ( 0.1%)
                  opt_ltlt:          2 ( 0.1%)
                   opt_mod:          1 ( 0.0%)

```
</details>
    
    

