### PR TITLE
YJIT: Delete --yjit-global-constant-state

### DIFF
--- a/yjit/src/options.rs
+++ b/yjit/src/options.rs
@@ -39,12 +39,6 @@ pub struct Options {
 
     /// Verify context objects (debug mode only)
     pub verify_ctx: bool,
-
-    /// Whether or not to assume a global constant state (and therefore
-    /// invalidating code whenever any constant changes) versus assuming
-    /// constant name components (and therefore invalidating code whenever a
-    /// matching name component changes)
-    pub global_constant_state: bool,
 }
 
 // Initialize the options to default values
@@ -59,7 +53,6 @@ pub static mut OPTIONS: Options = Options {
     dump_insns: false,
     dump_disasm: None,
     verify_ctx: false,
-    global_constant_state: false,
     dump_iseq_disasm: None,
 };
 
@@ -159,7 +152,6 @@ pub fn parse_option(str_ptr: *const std::os::raw::c_char) -> Option<()> {
         ("trace-exits", "") => unsafe { OPTIONS.gen_trace_exits = true; OPTIONS.gen_stats = true },
         ("dump-insns", "") => unsafe { OPTIONS.dump_insns = true },
         ("verify-ctx", "") => unsafe { OPTIONS.verify_ctx = true },
-        ("global-constant-state", "") => unsafe { OPTIONS.global_constant_state = true },
 
         // Option name not recognized
         _ => {


### PR DESCRIPTION
It was useful for evaluating 6068da8937d7e4358943f95e7450dae7179a7763
but I think we should remove it now to make the logic around
invalidation more straight forward.
