### PR TITLE
YJIT: Stack temp register allocation

### DIFF
--- a/.github/workflows/yjit-ubuntu.yml
+++ b/.github/workflows/yjit-ubuntu.yml
@@ -71,6 +71,10 @@ jobs:
             configure: "--enable-yjit=dev"
             yjit_opts: "--yjit-call-threshold=1 --yjit-verify-ctx"
 
+          - test_task: "check"
+            configure: "--enable-yjit=dev"
+            yjit_opts: "--yjit-call-threshold=1 --yjit-temp-regs=6"
+
           - test_task: "test-all TESTS=--repeat-count=2"
             configure: "--enable-yjit=dev"
 

--- a/yjit.rb
+++ b/yjit.rb
@@ -263,6 +263,9 @@ module RubyVM::YJIT
 
       $stderr.puts "iseq_stack_too_large:  " + format_number(13, stats[:iseq_stack_too_large])
       $stderr.puts "iseq_too_long:         " + format_number(13, stats[:iseq_too_long])
+      $stderr.puts "temp_reg_opnds:        " + format_number(13, stats[:temp_reg_opnds])
+      $stderr.puts "temp_mem_opnds:        " + format_number(13, stats[:temp_mem_opnds])
+      $stderr.puts "temp_spills:           " + format_number(13, stats[:temp_spills])
       $stderr.puts "bindings_allocations:  " + format_number(13, stats[:binding_allocations])
       $stderr.puts "bindings_set:          " + format_number(13, stats[:binding_set])
       $stderr.puts "compilation_failure:   " + format_number(13, compilation_failure) if compilation_failure != 0

--- a/yjit/src/backend/arm64/mod.rs
+++ b/yjit/src/backend/arm64/mod.rs
@@ -171,8 +171,12 @@ impl Assembler
     /// These are caller-saved registers
     /// Note: we intentionally exclude C_RET_REG (X0) from this list
     /// because of the way it's used in gen_leave() and gen_leave_exit()
-    pub fn get_alloc_regs() -> Vec<Reg> {
+    pub fn get_out_regs() -> Vec<Reg> {
         vec![X11_REG, X12_REG, X13_REG]
+    }
+
+    pub fn get_temp_regs() -> Vec<Reg> {
+        vec![] // FIXME: Not using this yet since assigning registers to Store insns doesn't work.
     }
 
     /// Get a list of all of the caller-saved registers
@@ -224,7 +228,7 @@ impl Assembler
                         Opnd::mem(64, base, 0)
                     }
                 },
-                _ => unreachable!("Can only split memory addresses.")
+                _ => unreachable!("Can only split Mem operands, but got {:?}", opnd)
             }
         }
 
@@ -349,7 +353,7 @@ impl Assembler
             }
         }
 
-        let mut asm_local = Assembler::new_with_label_names(std::mem::take(&mut self.label_names));
+        let mut asm_local = Assembler::new_with_label_names(std::mem::take(&mut self.label_names), self.initial_temps);
         let asm = &mut asm_local;
         let mut iterator = self.into_draining_iter();
 
@@ -1047,6 +1051,7 @@ impl Assembler
                     csel(cb, out.into(), truthy.into(), falsy.into(), Condition::GE);
                 }
                 Insn::LiveReg { .. } => (), // just a reg alloc signal, no code
+                Insn::SpillTemps { .. } => unreachable!("SpillTemps was not lowered"),
                 Insn::PadInvalPatch => {
                     while (cb.get_write_pos().saturating_sub(std::cmp::max(start_write_pos, cb.page_start_pos()))) < JMP_PTR_BYTES && !cb.has_dropped_bytes() {
                         nop(cb);
@@ -1074,9 +1079,11 @@ impl Assembler
     }
 
     /// Optimize and compile the stored instructions
-    pub fn compile_with_regs(self, cb: &mut CodeBlock, regs: Vec<Reg>) -> Vec<u32>
+    pub fn compile_with_regs(self, cb: &mut CodeBlock, out_regs: Vec<Reg>, temp_regs: Vec<Reg>) -> Vec<u32>
     {
-        let mut asm = self.lower_stack().arm64_split().alloc_regs(regs);
+        let asm = self.alloc_temp_regs(temp_regs);
+        let asm = asm.arm64_split();
+        let mut asm = asm.alloc_out_regs(out_regs);
 
         // Create label instances in the code block
         for (idx, name) in asm.label_names.iter().enumerate() {
@@ -1130,7 +1137,7 @@ mod tests {
 
         let opnd = asm.add(Opnd::Reg(X0_REG), Opnd::Reg(X1_REG));
         asm.store(Opnd::mem(64, Opnd::Reg(X2_REG), 0), opnd);
-        asm.compile_with_regs(&mut cb, vec![X3_REG]);
+        asm.compile_with_regs(&mut cb, vec![X3_REG], vec![]);
 
         // Assert that only 2 instructions were written.
         assert_eq!(8, cb.get_write_pos());

--- a/yjit/src/backend/tests.rs
+++ b/yjit/src/backend/tests.rs
@@ -36,11 +36,11 @@ fn test_alloc_regs() {
     let _ = asm.add(out3, Opnd::UImm(6));
 
     // Here we're going to allocate the registers.
-    let result = asm.alloc_regs(Assembler::get_alloc_regs());
+    let result = asm.alloc_out_regs(Assembler::get_out_regs());
 
     // Now we're going to verify that the out field has been appropriately
     // updated for each of the instructions that needs it.
-    let regs = Assembler::get_alloc_regs();
+    let regs = Assembler::get_out_regs();
     let reg0 = regs[0];
     let reg1 = regs[1];
 
@@ -72,7 +72,7 @@ fn setup_asm() -> (Assembler, CodeBlock) {
 fn test_compile()
 {
     let (mut asm, mut cb) = setup_asm();
-    let regs = Assembler::get_alloc_regs();
+    let regs = Assembler::get_out_regs();
 
     let out = asm.add(Opnd::Reg(regs[0]), Opnd::UImm(2));
     let out2 = asm.add(out, Opnd::UImm(2));
@@ -199,7 +199,7 @@ fn test_alloc_ccall_regs() {
     let out2 = asm.ccall(0 as *const u8, vec![out1]);
     asm.mov(EC, out2);
     let mut cb = CodeBlock::new_dummy(1024);
-    asm.compile_with_regs(&mut cb, Assembler::get_alloc_regs());
+    asm.compile_with_regs(&mut cb, Assembler::get_out_regs(), vec![]);
 }
 
 #[test]
@@ -324,7 +324,7 @@ fn test_lookback_iterator() {
 #[test]
 fn test_cmp_8_bit() {
     let (mut asm, mut cb) = setup_asm();
-    let reg = Assembler::get_alloc_regs()[0];
+    let reg = Assembler::get_out_regs()[0];
     asm.cmp(Opnd::Reg(reg).with_num_bits(8).unwrap(), Opnd::UImm(RUBY_SYMBOL_FLAG as u64));
 
     asm.compile_with_num_regs(&mut cb, 1);

--- a/yjit/src/backend/x86_64/mod.rs
+++ b/yjit/src/backend/x86_64/mod.rs
@@ -10,6 +10,7 @@ use crate::codegen::{JITState};
 use crate::cruby::*;
 use crate::backend::ir::*;
 use crate::codegen::CodegenGlobals;
+use crate::options::*;
 
 // Use the x86 register type for this platform
 pub type Reg = X86Reg;
@@ -88,13 +89,20 @@ impl Assembler
     const SCRATCH0: X86Opnd = X86Opnd::Reg(R11_REG);
 
     /// Get the list of registers from which we can allocate on this platform
-    pub fn get_alloc_regs() -> Vec<Reg>
+    pub fn get_out_regs() -> Vec<Reg>
     {
         vec![
             RAX_REG,
             RCX_REG,
             RDX_REG,
         ]
+    }
+
+    /// Get the list of registers for stack temps
+    pub fn get_temp_regs() -> Vec<Reg> {
+        let num_regs = get_option!(temp_regs);
+        let mut regs = vec![RSI_REG, RDI_REG, R8_REG, R9_REG, R10_REG, R11_REG];
+        regs.drain(0..num_regs).collect()
     }
 
     /// Get a list of all of the caller-save registers
@@ -110,7 +118,7 @@ impl Assembler
     /// generated code, which is what this pass does.
     fn x86_merge(mut self) -> Assembler {
         let live_ranges: Vec<usize> = take(&mut self.live_ranges);
-        let mut asm = Assembler::new_with_label_names(take(&mut self.label_names));
+        let mut asm = Assembler::new_with_label_names(take(&mut self.label_names), self.initial_temps);
         let mut iterator = self.into_draining_iter();
 
         while let Some((index, mut insn)) = iterator.next_unmapped() {
@@ -139,7 +147,7 @@ impl Assembler
     fn x86_split(mut self) -> Assembler
     {
         let live_ranges: Vec<usize> = take(&mut self.live_ranges);
-        let mut asm = Assembler::new_with_label_names(take(&mut self.label_names));
+        let mut asm = Assembler::new_with_label_names(take(&mut self.label_names), self.initial_temps);
         let mut iterator = self.into_draining_iter();
 
         while let Some((index, mut insn)) = iterator.next_unmapped() {
@@ -716,19 +724,13 @@ impl Assembler
                     emit_csel(cb, *truthy, *falsy, *out, cmovl);
                 }
                 Insn::LiveReg { .. } => (), // just a reg alloc signal, no code
+                Insn::SpillTemps { .. } => unreachable!("SpillTemps was not lowered"),
                 Insn::PadInvalPatch => {
                     let code_size = cb.get_write_pos().saturating_sub(std::cmp::max(start_write_pos, cb.page_start_pos()));
                     if code_size < JMP_PTR_BYTES {
                         nop(cb, (JMP_PTR_BYTES - code_size) as u32);
                     }
                 }
-
-                // We want to keep the panic here because some instructions that
-                // we feed to the backend could get lowered into other
-                // instructions. So it's possible that some of our backend
-                // instructions can never make it to the emit stage.
-                #[allow(unreachable_patterns)]
-                _ => panic!("unsupported instruction passed to x86 backend: {:?}", insn)
             };
 
             // On failure, jump to the next page and retry the current insn
@@ -745,12 +747,12 @@ impl Assembler
     }
 
     /// Optimize and compile the stored instructions
-    pub fn compile_with_regs(self, cb: &mut CodeBlock, regs: Vec<Reg>) -> Vec<u32>
+    pub fn compile_with_regs(self, cb: &mut CodeBlock, out_regs: Vec<Reg>, temp_regs: Vec<Reg>) -> Vec<u32>
     {
-        let asm = self.lower_stack();
+        let asm = self.alloc_temp_regs(temp_regs);
         let asm = asm.x86_split();
         let asm = asm.x86_merge();
-        let mut asm = asm.alloc_regs(regs);
+        let mut asm = asm.alloc_out_regs(out_regs);
 
         // Create label instances in the code block
         for (idx, name) in asm.label_names.iter().enumerate() {

--- a/yjit/src/options.rs
+++ b/yjit/src/options.rs
@@ -22,6 +22,9 @@ pub struct Options {
     // 1 means always create generic versions
     pub max_versions: usize,
 
+    // The number of registers allocated for stack temps
+    pub temp_regs: usize,
+
     // Capture and print out stats
     pub gen_stats: bool,
 
@@ -54,6 +57,7 @@ pub static mut OPTIONS: Options = Options {
     greedy_versioning: false,
     no_type_prop: false,
     max_versions: 4,
+    temp_regs: 0,
     gen_stats: false,
     gen_trace_exits: false,
     dump_insns: false,
@@ -134,6 +138,13 @@ pub fn parse_option(str_ptr: *const std::os::raw::c_char) -> Option<()> {
 
         ("max-versions", _) => match opt_val.parse() {
             Ok(n) => unsafe { OPTIONS.max_versions = n },
+            Err(_) => {
+                return None;
+            }
+        },
+
+        ("temp-regs", _) => match opt_val.parse() {
+            Ok(n) => unsafe { OPTIONS.temp_regs = n },
             Err(_) => {
                 return None;
             }

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -351,6 +351,10 @@ make_counters! {
 
     iseq_stack_too_large,
     iseq_too_long,
+
+    temp_reg_opnds,
+    temp_mem_opnds,
+    temp_spills,
 }
 
 //===========================================================================


### PR DESCRIPTION
## TODO

1. Use `spilled_temps` instead of `spilled_size` in Context
2. Use `u8` instead of `[bool; 8]` for `spilled_temps`
3. Avoid spilling on every block boundary, propagating `spilled_temps` through `Context`.
4. Modify IR to represent immediate stack operands and avoid spilling such stack operands.
5. Share the same set of registers between `alloc_temp_regs` and `alloc_out_regs`