### PR TITLE
POC of unwind info generation for YJIT

### DIFF
--- a/doc/yjit/unwinding.md
+++ b/doc/yjit/unwinding.md
@@ -1,0 +1,266 @@
+# Stack unwinding with YJIT
+
+Ruby generates C-language backtraces by default when certain fatal signals or other bugs are encountered. These are often useful for identifying the source of a problem inside a C extension, or in the Ruby interpreter itself. In order to generate these, it calls the `backtrace(3)` C standard library function (see vm_dump.c).
+
+YJIT-generated machine code might also be on the stack when a backtrace is generated. Because this code is generated dynamically at run-time, YJIT needs to take some specific steps to make sure that the unwinder in `backtrace(3)` can understand this code and incorporate it in the generated stack trace. This would normally be transparently handled by the compiler for regular code.
+
+## Stack unwinding - a primer.
+
+Distilled down to its essence, stack unwinding is the mechanics of solving the following problem: given the current state of the CPU's registers and the stack, what piece of code is currently running right now? What piece of code called that one? And so on for each previous call, up to the entry point of the program (i.e. `main`).
+
+The answer to "what piece of code is currently running" is normally fairly trivial; every mainstream CPU architecture has an "instruction pointer" register (ip), which points at the currently-executing instruction.
+
+The tricky thing to find out is what the _previous_ value of the ip was, when the call to this function was made. This information must be present somewhere, because the function needs to know where to return control to when it's finished (i.e. - it needs to know the return address). So, how does the `backtrace(3)` function work this out?
+
+There are (at least!) two ways in which this can be done.
+
+### Frame pointer chains
+
+The traditional way this worked is by using frame pointers. The precise scheme is actually CPU/platform dependent, however in general one CPU register is designated as the "frame pointer" (fp). The compiler inserts a prologue at the beginning of every function which saves the previous frame pointer to the stack, and then sets the fp register to point at the bottom of the stack. The compiler also inserts an epilogue which restores the previous value of the fp register on return.
+
+To make things more concrete, this is what the standard prologue/epilogue look like on Linux aarch64. On this architecture, x29 is the frame pointer register, and x30 contains the return address (the "link register").
+
+```assembly
+# Pushes the previous frame pointer (x29) and the return address (x30) onto the stack,
+# decrementing the stack pointer by 0x10 (two 8-byte registers).
+stp x29, x30, [sp, #-0x10]!
+# Copies the stack pointer to x29, the frame pointer register.
+mov x29, sp
+
+# function body
+# Maybe sp is decremented further to make room for local variables.
+sub sp, sp, 0xF0
+# ...
+add sp, sp, 0xF0
+
+# Restore 
+ldp x29, x30, [sp], #0x10
+# Return to the return address address that's now in x30 again.
+ret
+```
+
+This means that, during the "function body" part of this function, the stack might look something like the following (n.b. - remember that on most mainstream CPU architectures, including aarch64, the stack grows downwards):
+
+       |--------------------------------|       |-- x29 register (fp): 0xFEF0
+0xFFFF |                                |       |    sp register (sp): 0xFE00
+  .... | Previous frame return address  |       |
+0x0FF8 |                                |       |
+       |--------------------------------|       |
+0xFFF7 |                                |       |
+  .... | Previous previous frame fp     |<-|    |
+0xFFF0 |                                |  |    |
+       |--------------------------------|  |    |
+0xFFEF |                                |  |    |
+  .... | Previous frame's local vars    |  |    |
+0xFF00 |                                |  |    |
+       |--------------------------------|  |    |
+0xFEFF |                                |  |    |
+  .... | Saved x30 (return address)     |  |    |
+0xFEF8 |                                |  |    |
+       |--------------------------------|  |    |
+0xFEF7 |                                |--|    |
+  .... | Saved x29 (frame pointer)      |       |
+0xFEF0 |      (value: 0xFEF0)           |<------|
+  .... |--------------------------------|
+0xFEEF |                                |
+  .... | This frame's local vars        |
+0xFE00 |                                |
+  .... |--------------------------------|            
+
+This simple example elides a bunch of complexity, but I found [Raymond Chen](https://devblogs.microsoft.com/oldnewthing/20220824-00/?p=107043) to be a good resource (it actually works the same on aarch64 Windows as well as Linux).
+
+Anyway, with our frame pointer register, and the saved return address that we _know_ sits below it on the stack, we can answer the original question ("how can I know of the address of the thing that called me?") with a simple pair of rules
+
+* `*(fp + 8)` --> ip in previous frame
+* `*fp`       --> fp in previous frame
+
+Or, in words, we know that the fp register (x29) points to the previous value of the fp register, and the previous fp/ip are always stored on the stack in pairs.
+
+Starting from the initial values of the CPU registers & the contents of the stack, repeated application of these rules gets us the ip in successively deeper call frames, yielding a chain of code addresses that caused execution to reach where it has; a stack trace.
+
+### Unwind info
+
+Depending on flags, the OS & CPU architecture, compilers often do not actually generate the prologue/epilogue described in the previous section. The frame pointer is not actually needed for the execution of the code, and compilers might be able to generate faster code if they re-use the frame pointer register as a general purpose register instead. This was historically especially true on architectures with small numbers of registers, like 32-bit x86.
+
+Instead, the compiler can generate an "unwind table". The idea behind the unwind table is that the compiler actually knows at every point in the function what it's done with the stack pointer and where it saved registers. The function _must_ have the return address available somewhere (either on the stack or in a register) so it can actually return there; likewise, the compiler knows how much it's incremented the stack pointer in a function, and thus what the previous value of the stack pointer must have been.
+
+Recall that with frame-pointer based unwinding, we had a pair of rules, that given the state of the fp & ip registers in one frame, could recover the fp & ip registers in the previous frame. The compiler actually has enough information to generate rules to do this unwinding, even without a frame pointer - however, the rules actually _change_ depending on the ip. This set of rules is called "Call Frame Information" (CFI).
+
+For example, here's a (very silly and contrived) aarch64 function that _doesn't_ save a frame pointer _or_ the return address to the stack, along with the unwinding rules the compiler would generate for each code location.
+
+```assembly
+# By default, the rules are:
+#     x30 --> ip in previous frame (this is where aarch64 call instruction puts the return value)
+#      sp --> sp in previous frame (we haven't changed it at all)
+
+# Reserve 16 bytes of stack space for this function:
+sub sp, sp, 16
+# Now, the rules are:
+#    x30 --> ip in previous frame
+#  sp+16 --> sp in previous frame (we've added 16 to it!)
+
+# Save the callee-saved register x19 to the stack
+str x19, [sp, #-0x8]
+# This doesn't change the rules.
+
+# Save x30 in x19
+mov x19, x30
+# Now, the rules are:
+#    x19 --> ip in previous frame (we moved the value here)
+#  sp+16 --> sp in previous frame
+
+
+# Call some other function
+bl some_other_function
+# This doesn't change the rules; the bl instruction clobbers x30 (the return address),
+# but we already updated the rules to look in x19 instead.
+
+# Put the stack pointer back how we found it
+add sp, sp, 16
+# Now, the rules are
+#    x19 --> ip in previous frame
+#     sp --> sp in previous frame (it's back how it was)
+
+# Restore the previous value of x30
+mov x30, x19
+# Now, the rules are back how they started
+#    x30 --> ip in previous frame
+#     sp --> sp in previous frame
+
+ret
+```
+
+The compiler can emit these CFI rules into a table. Then, instead of using the static rules of frame-pointer based unwinding, the unwinding code in `backtrace(3)` can read that table and and apply the dynamic rules instead. It generates a stack trace by starting with the current set of registers & stack, looking up the appropriate rules based on the ip, applying those rules to discover the ip & sp (and potentially other register values!) in the previous frame, and repeating.
+
+## Unwinding implementation details
+
+There is a lot of platform specific machinery that goes into actually _implementing_ this idea of dynamic, per-location unwinding rules, and in how tools can make use of it to actually perform unwinding.
+
+### Unwinding on Linux.
+
+On Linux, the per-location unwinding rules table is encoded in a format defined by the [DWARF Call Frame Information standard](https://dwarfstd.org/) (see section 6.4). The DWARF CFI standard defines the concept of a FDE (Frame Debug Entry) and CIE (Common Information Entry). A single FDE defines unwinding rules for a particular function, and a CIE defines effectively snippets of rules which are common between functions (for example, many functions might share an identical prologue).
+
+The compiler generates FDEs and CIEs for the code it generates, and saves them in a section of the binary called `.eh_frame`. The format of the `.eh_frame` section containing the FDEs/CIEs is itself defined by the [Linux Standard Base (LSB)](https://refspecs.linuxfoundation.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/ehframechpt.html).
+
+(Note - the compiler might _also_ generate a similar section called `.debug_frame`; this can contain similar but more detailed information which is of particular use to debuggers. However, everything we discuss in this document is focused on `.eh_frame`.)
+
+This CFI information then has various uses:
+
+* The main use of it is actually to support C++ exceptions, which need to bubble up through the call stack; however, this is of course not relevant for Ruby or YJIT.
+* The `backtrace(3)` function from glibc, which Ruby uses as part of `rb_print_backtrace` in vm_dump.c, (indirectly) uses the CFI information. Actually, the libc function is a thin wrapper around libgcc_s's `_Unwind_Backtrace` function. The libgcc_s library, and [its unwinding support routines](https://refspecs.linuxbase.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/libgcc-sman.html), is defined as being a part of the LSB specification, and so must be present on any LSB-compliant Linux system. Even if an application is not compiled with gcc, routines in libgcc_s are still linked in and used as part of stack unwinding when requested.
+* GDB (and other debuggers) will look at `.eh_frame` information if present, to support getting the backtraces of running threads.
+
+Importantly, the `.eh_frame` section _MUST_ be present for any of this to work. Neither libgcc's `_Unwind_Backtrace`, nor GDB, will fall back to frame-pointer based unwinding under any circumstances.
+
+However, there are other tools which _only_ use frame-pointer based unwinding. The `perf(1)` tool, as well as eBPF-based programs, can collect stack traces of running programs from _inside_ the kernel. However, the kernel has no facility itself to perform DWARF CFI-based unwinding, and of course can't call out to libgcc_s. Therefore, userspace stacks are collected from the kernel _only_ by frame-pointer unwinding.
+
+Thus, for stack unwinding to work reliably in all circumstances on Linux, an application (and all libraries it uses) needs to be compiled with both full unwind tables (the `-fasynchronous-unwind-tables` gcc flag) and also frame pointers (the `-fno-omit-frame-pointer` gcc flag).
+
+## Unwinding through JIT'd code
+
+At runtime, YJIT allocates fresh pages, writes machine code into them, marks them executable, and jumps into the generated code. None of this freshly generated code is mentioned in the unwinding information stored in the Ruby binary, of course, so by default, the `backtrace(3)` function would not know how to unwind through it. That means that, when unwinding reached a piece of dynamically-generated YJIT code, it would stop, and would not be able to see any frames underneath that.
+
+For example, if YJIT did not generate any unwinding information, a backtrace due to a fatal signal might look something like this:
+
+```
+/ruby/miniruby(rb_print_backtrace+0xc) [0xaaaad0276884] /ruby/vm_dump.c:785
+/ruby/miniruby(rb_vm_bugreport) /ruby/vm_dump.c:1093
+/ruby/miniruby(rb_bug_for_fatal_signal+0xd0) [0xaaaad0075580] /ruby/error.c:813
+/ruby/miniruby(sigsegv+0x5c) [0xaaaad01bedac] /ruby/signal.c:919
+linux-vdso.so.1(__kernel_rt_sigreturn+0x0) [0xffff91a3e8bc]
+/ruby/miniruby(map<(usize, yjit::backend::ir::Insn), (usize, yjit::backend::ir::Insn), yjit::backend::ir::{impl#17}::next_mapped::{closure_env#0}>+0x8c) [0xaaaad03b8b00] /rustc/897e37553bba8b42751c67658967889d11ecd120/library/core/src/option.rs:929
+/ruby/miniruby(next_mapped+0x3c) [0xaaaad0291dc0] src/backend/ir.rs:1225
+/ruby/miniruby(arm64_split+0x114) [0xaaaad0287744] src/backend/arm64/mod.rs:359
+/ruby/miniruby(compile_with_regs+0x80) [0xaaaad028bf84] src/backend/arm64/mod.rs:1106
+/ruby/miniruby(compile+0xc4) [0xaaaad0291ae0] src/backend/ir.rs:1158
+/ruby/miniruby(gen_single_block+0xe44) [0xaaaad02b1f88] src/codegen.rs:854
+/ruby/miniruby(gen_block_series_body+0x9c) [0xaaaad03b0250] src/core.rs:1698
+/ruby/miniruby(gen_block_series+0x50) [0xaaaad03b0100] src/core.rs:1676
+/ruby/miniruby(branch_stub_hit_body+0x80c) [0xaaaad03b1f68] src/core.rs:2021
+/ruby/miniruby({closure#0}+0x28) [0xaaaad02eb86c] src/core.rs:1924
+/ruby/miniruby(do_call<yjit::core::branch_stub_hit::{closure_env#0}, *const u8>+0x98) [0xaaaad035ba3c] /rustc/897e37553bba8b42751c67658967889d11ecd120/library/std/src/panicking.rs:492
+[0xaaaad035c9b4]
+```
+
+The backtrace does not show anything underneath `[0xaaaad035c9b4]` (which is YJIT generated code), because the unwinder (i.e. libgcc_s's `_Unwind_Backtrace` function on Linux) doesn't know how to unwind through it. What we would rather see, is something like this:
+
+```
+/ruby/miniruby(rb_print_backtrace+0xc) [0xaaaad0276884] /ruby/vm_dump.c:785
+/ruby/miniruby(rb_vm_bugreport) /ruby/vm_dump.c:1093
+/ruby/miniruby(rb_bug_for_fatal_signal+0xd0) [0xaaaad0075580] /ruby/error.c:813
+/ruby/miniruby(sigsegv+0x5c) [0xaaaad01bedac] /ruby/signal.c:919
+linux-vdso.so.1(__kernel_rt_sigreturn+0x0) [0xffff91a3e8bc]
+/ruby/miniruby(map<(usize, yjit::backend::ir::Insn), (usize, yjit::backend::ir::Insn), yjit::backend::ir::{impl#17}::next_mapped::{closure_env#0}>+0x8c) [0xaaaad03b8b00] /rustc/897e37553bba8b42751c67658967889d11ecd120/library/core/src/option.rs:929
+/ruby/miniruby(next_mapped+0x3c) [0xaaaad0291dc0] src/backend/ir.rs:1225
+/ruby/miniruby(arm64_split+0x114) [0xaaaad0287744] src/backend/arm64/mod.rs:359
+/ruby/miniruby(compile_with_regs+0x80) [0xaaaad028bf84] src/backend/arm64/mod.rs:1106
+/ruby/miniruby(compile+0xc4) [0xaaaad0291ae0] src/backend/ir.rs:1158
+/ruby/miniruby(gen_single_block+0xe44) [0xaaaad02b1f88] src/codegen.rs:854
+/ruby/miniruby(gen_block_series_body+0x9c) [0xaaaad03b0250] src/core.rs:1698
+/ruby/miniruby(gen_block_series+0x50) [0xaaaad03b0100] src/core.rs:1676
+/ruby/miniruby(branch_stub_hit_body+0x80c) [0xaaaad03b1f68] src/core.rs:2021
+/ruby/miniruby({closure#0}+0x28) [0xaaaad02eb86c] src/core.rs:1924
+/ruby/miniruby(do_call<yjit::core::branch_stub_hit::{closure_env#0}, *const u8>+0x98) [0xaaaad035ba3c] /rustc/897e37553bba8b42751c67658967889d11ecd120/library/std/src/panicking.rs:492
+[0xaaaad035c9b4]
+/ruby/miniruby(try<*const u8, yjit::core::branch_stub_hit::{closure_env#0}>+0x6c) [0xaaaad035b004] /rustc/897e37553bba8b42751c67658967889d11ecd120/library/std/src/panicking.rs:456
+/ruby/miniruby(catch_unwind<yjit::core::branch_stub_hit::{closure_env#0}, *const u8>+0x24) [0xaaaad03a1b28] /rustc/897e37553bba8b42751c67658967889d11ecd120/library/std/src/panic.rs:137
+/ruby/miniruby(with_vm_lock<yjit::core::branch_stub_hit::{closure_env#0}, *const u8>+0xac) [0xaaaad02a71a8] src/cruby.rs:630
+/ruby/miniruby(branch_stub_hit+0xd4) [0xaaaad03b77ac] src/core.rs:1923
+[0xaaaad128205c]
+/ruby/miniruby(jit_exec+0x5c) [0xaaaad024c3e4] /ruby/vm.c:415
+/ruby/miniruby(vm_sendish) /ruby/vm_insnhelper.c:5222
+/ruby/miniruby(vm_exec_core+0xb0) [0xaaaad0266290] /ruby/insns.def:834
+/ruby/miniruby(rb_vm_exec+0xd0) [0xaaaad0256af0] /ruby/vm.c:2383
+/ruby/miniruby(rb_f_eval+0x208) [0xaaaad0257e4c] /ruby/vm_eval.c:1763
+[0xaaaad12844ac]
+/ruby/miniruby(jit_exec+0xa8) [0xaaaad0256e50] /ruby/vm.c:415
+/ruby/miniruby(rb_vm_exec) /ruby/vm.c:2373
+/ruby/miniruby(rb_yield_1+0x230) [0xaaaad025cd90] /ruby/vm.c:1387
+/ruby/miniruby(int_dotimes+0x1d0) [0xaaaad0110000] /ruby/numeric.c:5697
+/ruby/miniruby(vm_call_cfunc_with_frame_+0x120) [0xaaaad0253390] /ruby/vm_insnhelper.c:3329
+/ruby/miniruby(vm_sendish+0x15c) [0xaaaad024c37c] /ruby/vm_insnhelper.c:5203
+/ruby/miniruby(vm_exec_core+0xc30) [0xaaaad0266e10] /ruby/insns.def:815
+/ruby/miniruby(rb_vm_exec+0xd0) [0xaaaad0256af0] /ruby/vm.c:2383
+/ruby/miniruby(rb_ec_exec_node+0xc8) [0xaaaad007baec] /ruby/eval.c:287
+/ruby/miniruby(ruby_run_node+0x60) [0xaaaad00812c4] /ruby/eval.c:328
+/ruby/miniruby(main+0x6c) [0xaaaacffe5c9c] ./main.c:39
+```
+
+When YJIT generates the correct unwind info, the crash backtrace can show the complete sequence of calls all the way into `main`.
+
+## YJIT's unwind info support
+
+Enabling unwinding through JIT-generated code requires doing two things:
+
+* Generating the unwinding info for the code that is generated (this is reasonably platform agnostic)
+* Registering that unwinding info so that `backtrace(3)`, `gdb`, etc can find it (this is very platform specific).
+
+### Generating unwind info
+
+YJIT splits up generated functions into multiple blocks, and generates code for those blocks separately, connected by appropriate jump instructions. This means that a single "function" (from the point of view of the platform's ABI Calling convention) actually spans multiple blocks of potentially non-contiguous code; a YJIT function might well return from a different block than the original target of the call. Each block needs to have its own independent unwind info, which knows how to recover the return address & previous stack pointer value.
+
+To achieve this, each block YJIT generates has an associated "stack rule". The stack rule describes the assumptions that the generated code makes about the state of the stack when it's executed. In practice, currently, YJIT's stack manipulations are quite simple, and there are only two stack rules:
+
+* `CalledFromC` - this rule is for the YJIT entry prologue; the stack looks liike it does at the beginning of any function call on this platform.
+* `NormalJumpFromJITCode` - this rule is for all other YJIT blocks; the block expects the stack to have already been set up by the entry prologue, and the return address & previous stack pointer value are recoverable by undoing the effects of the entry prologue.
+
+If YJIT ever does more complex stack manipulations that span blocks, the unwinder will need to be taught about these as well.
+
+The machine-specific code generators in YJIT use this knowledge of the initial state of the stack to generate unwinding rules as they generate code. Essentially, they generate unwinding rules every time they manipulate the stack, which mirror their effect. In the current implementation, these rules )(`enum CFIDirective` in unwind.rs) simply mirror the [DWARF CFI annotations](https://sourceware.org/binutils/docs/as/CFI-directives.html#g_t_002ecfi_005fstartproc-_005bsimple_005d) provided by the GNU assembler, however as platform support for YJIT expands these rules could be more generic if required.
+
+Once the code for a block is generated, these rules are passed to the `UnwindInfoManager` implementation in unwind.rs, where the platform-specific parts of the process take place.
+
+### Registering unwind info (Linux)
+
+Frustratingly, on Linux, there are _two_ different interfaces that need to be used to register dynamic unwind information.
+
+* libgcc provides a [`__register_frame`](https://gcc.gnu.org/git/?p=gcc.git;a=blob;f=libgcc/unwind-dw2-fde.c;h=7b74c391ced1b70990736161a22c9adcea524a04;hb=HEAD#l148) function which adds dynamically-generated unwinding info in a place that `_Unwind_Backtrace` (and hence `backtrace(3)`) can find it. This function expects a pointer to a block of memory which contains the contents of a complete, valid `.eh_frame` section - which is to say, it contains a byte buffer containing CIEs and FDEs, terminating in a zero-length FDE.
+* gdb defines a [JIT interface](https://sourceware.org/gdb/onlinedocs/gdb/JIT-Interface.html) which JIT compilers can use to add dynamically-generated unwinding info. This requires the application to maintain a linked list of `struct jit_code_entry` objects, each of which have a field `symfile_addr` pointing at the unwind info. However, gdb does not simply expect the contents of an `.eh_frame` section; rather, it expects a complete, valid ELF file laid out in memory, which _contains_ an `.eh_frame` section. This interface is also used by `lldb`.
+
+In order to make unwinding work both with crashdumps and debuggers, YJIT needs to implement _both_ of these interfaces. Maintaining the complete object file expected by GDB is quite tricky, because an ELF file cannot really be appended to, and we'd rather not have to copy around unwind information for the whole process every time we generate a single new small block. However, it's also impractical to generate a complete object file for every code block (this would be both memory inefficient and make the unwinding very slow!). Furthermore, any growth scheme is complicated by the fact that it is unsafe to modify the unwind info while it's registered.
+
+The `UnwindInfoManager` implementation squares this circle by maintaining a _pair_ of object files, with an `.eh_frame` section containing empty space for expansion. At any given time, one is "active" (and registered with libgcc/gdb), and one is "standby".
+
+When a new block of code is generated, and the assembler passes the `enum CFIDirective` rules to the `UnwindInfoManager`, the manager converts those into a real DWARF CFI FDE structure, and then attempts to append it to the "standby" object's `.eh_frame` section. If it doesn't fit, a new standby object is created with a bigger section. Then, the standby info is registered, the active info is de-registered, and the standby object is copied to the active one. This avoids the need for copying large amounts of unwind info around on a regular basis.
+
+As a side note - it's important that `.eh_frame` sections passed to libgcc's `__register_frame` do _NOT_ describe interleaving regions of memory; each section must describe a single contiguous address range (not all of which needs to actually have code) which does not overlap with the range of any other `.eh_frame` section.

--- a/yjit/Cargo.lock
+++ b/yjit/Cargo.lock
@@ -3,6 +3,29 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
 name = "capstone"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -29,10 +52,116 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 
 [[package]]
-name = "libc"
-version = "0.2.124"
+name = "cfg-if"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a41fed9d98f27ab1c6d161da622a4fa35e8a54a8adc24bbf3ddd0ef70b0e50"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "flate2"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "gimli"
+version = "0.27.2"
+source = "git+https://github.com/KJTsanaktsidis/gimli#90c9721ed6eaa62fc1a74fe3415625e39e9b016e"
+dependencies = [
+ "fallible-iterator",
+ "indexmap",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.139"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+
+[[package]]
+name = "memchr"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "object"
+version = "0.30.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "hashbrown 0.13.2",
+ "indexmap",
+ "memchr",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "stats_alloc"
@@ -41,9 +170,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c0e04424e733e69714ca1bbb9204c1a57f09f5493439520f9f68c132ad25eec"
 
 [[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
 name = "yjit"
 version = "0.1.0"
 dependencies = [
  "capstone",
+ "gimli",
+ "object",
  "stats_alloc",
 ]

--- a/yjit/Cargo.toml
+++ b/yjit/Cargo.toml
@@ -15,8 +15,13 @@ crate-type = ["staticlib"]
 [dependencies]
 # No required dependencies to simplify build process. TODO: Link to yet to be
 # written rationale. Optional For development and testing purposes
+object = { version = "0.30.3", features = ["read", "write"] }
+gimli = { version = "0.27.2", features = ["read", "write"] }
 capstone = { version = "0.10.0", optional = true }
 stats_alloc = { version = "0.1.10", optional = true }
+
+[patch.crates-io]
+gimli = { git = "https://github.com/KJTsanaktsidis/gimli" }
 
 [features]
 # NOTE: Development builds select a set of these via configure.ac

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -319,6 +319,8 @@ fn main() {
         .allowlist_function("rb_yjit_exit_locations_dict")
         .allowlist_function("rb_yjit_icache_invalidate")
         .allowlist_function("rb_optimized_call")
+        .allowlist_function("rb_yjit_register_unwind_info")
+        .allowlist_function("rb_yjit_deregister_unwind_info")
         // from vm_sync.h
         .allowlist_function("rb_vm_barrier")
 

--- a/yjit/src/backend/mod.rs
+++ b/yjit/src/backend/mod.rs
@@ -6,3 +6,4 @@ pub mod arm64;
 
 pub mod ir;
 mod tests;
+pub mod unwind;

--- a/yjit/src/backend/unwind.rs
+++ b/yjit/src/backend/unwind.rs
@@ -1,0 +1,603 @@
+extern crate gimli;
+extern crate object;
+
+use gimli::write::Writer;
+use crate::codegen::CodePtr;
+use crate::cruby::{rb_yjit_register_unwind_info, rb_yjit_deregister_unwind_info};
+use std::collections::HashMap;
+use std::rc::Rc;
+use std::cell::RefCell;
+use std::ops::Range;
+
+/// CStackSetupRule defines the expectations a block of YJIT code makes about
+/// the state of the C stack when it's called.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub enum CStackSetupRule {
+    /// Blocks that have the CalledFromC CIE are YJIT entry points; they are called
+    /// directly from the CRuby code. That means the stack will be set up as per the
+    /// normal platform ABI for function entry.
+    CalledFromC,
+
+    /// Blocks that have the NormalJumpFromJITCode CIE are targets of jumps from YJIT
+    /// generated code; the C-stack setup has already been done by an entry point. That
+    /// means the stack has been set up by gen_entry_prologue, including the frame setup
+    /// and the saving of the callee-saved registers used for CFP, EP, and SP.
+    NormalJumpFromJITCode,
+
+    /// Don't generate any CFI
+    None,
+}
+
+/// A CFIDirective represents the effect an instruction has on the rules used to unwind
+/// the stack.
+/// Mirrors https://sourceware.org/binutils/docs/as/CFI-directives.html#g_t_002ecfi_005fstartproc-_005bsimple_005d
+#[derive(Copy, Clone, Debug)]
+#[allow(dead_code)]
+pub enum CFIDirective {
+    /// .cfi_startproc - marks the beginning of a block of code with unwind rules
+    StartProc(CStackSetupRule),
+
+    /// .cfi_endproc - marks the end of a block of code with unwind rules
+    EndProc(),
+
+    /// .cfi_def_cfa - defines the CFA (canonical frame address) as *reg + offset
+    DefCFA(platform::Reg, i32),
+
+    /// .cfi_def_cfa_register - changes the CFA register, keeping the same offset
+    DefCFARegister(platform::Reg),
+
+    /// .cfi_def_cfa_offset - changes the CFA offset, keeping the same register
+    DefCFAOffset(i32),
+
+    /// .cfi_adjust_cfa_offset - adds to the current CFA offset
+    AdjustCFAOffset(i32),
+
+    /// .cfi_offset - the value of reg in the previous frame can be found at CFA + i32
+    Offset(platform::Reg, i32),
+
+    ///.cfi_rel_offset - the value of reg in the previous frame can be found at *(CFA register) + i32
+    RelOffset(platform::Reg, i32),
+
+    /// .cfi_restore - reset the rule for reg to what it was when .cfi_startproc was used
+    Restore(platform::Reg),
+
+    // This is not a real CFI directive that GNU assembler supports,
+    // but rather a signal that this "FDE" is actually split across pages
+    // and needs to be two FDE's. The DWARF standard specifies that FDE's
+    // must be contiguous, but YJIT can generate blocks that span two pages
+    // with a jump instruction connecting them. 
+    Split(CodePtr)
+}
+
+/// A CFIDirective for an instruction at a particular address
+#[derive(Copy, Clone, Debug)]
+pub struct CFIDirectiveWithAddr {
+    /// The address being annotated
+    pub addr: CodePtr,
+
+    /// The CFI directive
+    pub directive: CFIDirective,
+}
+
+/// An UnwindInfoManager which looks after the unwind info for the all the YJIT
+/// generated code in the proces. It's a singleton registered on the CodegenGlobals.
+pub struct UnwindInfoManager {
+    /// A list of all DWARF CIEs for this architecture, one per stack rule.
+    /// This is set up at boot and never changed.
+    cies: HashMap<CStackSetupRule, gimli::write::CieId>,
+
+    /// The frame table holds all of the DWARF CIEs and FDEs we generate
+    frame_table: gimli::write::FrameTable,
+
+    /// This is the index of the first entry in the frame table that we have _NOT_
+    /// yet emitted to the .eh_frame section in active_object/standby_object.
+    next_fde_ix: usize,
+
+    /// The raw bytes of a real ELF/MachO/etc object containing the .eh_frame
+    /// section which has the unwind info for this process. The active_object is
+    /// currently registered with the runtime as providing the info.
+    active_object: Vec<u8>,
+
+    /// The standby_object is where we build up an appropriate ELF/MachO/etc object
+    /// before promoting it to the active_object.
+    standby_object: Vec<u8>,
+
+    /// This is the range of bytes inside the standby_object that contains the
+    /// .eh_frame section data
+    unwind_info_section_range: Range<usize>,
+
+    /// This is the range of bytes inside the standby_object that contains the
+    /// free space at the end of the .eh_frame section data. This "free space"
+    /// includes the terminating zero-length FDE
+    unwind_info_section_free_space_range: Range<usize>,
+
+    /// Whether or not we have actually registered active_object with the runtime
+    handler_registered: bool,
+
+    /// When this flag is set, we will stop attempting to write FDEs into the empty
+    /// space inside the standby_object's .eh_frame section, and instead regenerate
+    /// an entirely new object. This gets set when code objects are freed, since
+    /// we have no other way to remove their unwind info.
+    object_invalidated: bool,
+}
+
+/// An implementation of Gimli's EndianWriter interface which can append to a slice.
+struct DwarfSliceWriter<'a, TEndian: gimli::Endianity> {
+    buf: &'a mut[u8],
+    endian: TEndian,
+    ix: usize,
+}
+
+impl<'a, TEndian> DwarfSliceWriter<'a, TEndian>
+where
+    TEndian: gimli::Endianity
+{
+    fn new(buf: &'a mut[u8], endian: TEndian) -> Self {
+        Self { buf, endian, ix: 0 }
+    }
+}
+
+impl<'a, TEndian> gimli::write::Writer for DwarfSliceWriter<'a, TEndian>
+where
+    TEndian: gimli::Endianity,
+{
+    type Endian = TEndian;
+
+    fn endian(&self) -> Self::Endian {
+        self.endian
+    }
+
+    fn len(&self) -> usize {
+        self.ix
+    }
+
+    fn write(&mut self, bytes: &[u8]) -> gimli::write::Result<()> {
+        let target_slice = &mut self.buf[self.ix..];
+        if target_slice.len() < bytes.len() {
+            return Err(gimli::write::Error::LengthOutOfBounds);
+        }
+        target_slice[..bytes.len()].copy_from_slice(bytes);
+        self.ix += bytes.len();
+        Ok(())
+    }
+
+    fn write_at(&mut self, offset: usize, bytes: &[u8]) -> gimli::write::Result<()> {
+        let target_slice = &mut self.buf[offset..];
+        if offset > target_slice.len() {
+            return Err(gimli::write::Error::OffsetOutOfBounds);
+        }
+        if target_slice.len() < bytes.len() {
+            return Err(gimli::write::Error::LengthOutOfBounds);
+        }
+        target_slice[..bytes.len()].copy_from_slice(bytes);
+        Ok(())
+    }
+
+}
+
+impl UnwindInfoManager {
+    /// Constructs a new unwind info manager
+    pub fn new() -> Self {
+        let mut frame_table = gimli::write::FrameTable::default();
+        let mut cies = HashMap::<CStackSetupRule, gimli::write::CieId>::new();
+        for (stack_rule, cie) in platform::cies_for_all_stack_rules().into_iter() {
+            cies.insert(stack_rule, frame_table.add_cie(cie));
+        }
+
+        Self {
+            cies,
+            frame_table,
+            next_fde_ix: 0,
+            active_object: Vec::new(),
+            standby_object: Vec::new(),
+            unwind_info_section_range: 0..0,
+            unwind_info_section_free_space_range: 0..0,
+            handler_registered: false,
+            object_invalidated: true,
+        }
+    }
+
+    /// Called with a slice of CFIDirectiveWithAddr to add unwind info for newly-generated
+    /// blocks to the standby_object. The directives list can actually refer to multiple blocks,
+    /// with matching StartProc/EndProc directives.
+    pub fn add_unwind_info(&mut self, directives: &[CFIDirectiveWithAddr]) {
+        struct FDEState {
+            start_addr: CodePtr,
+            end_addr: Option<CodePtr>,
+            stack_rule: CStackSetupRule,
+            current_cfa_offset: i32,
+            insns: Vec::<(CodePtr, gimli::write::CallFrameInstruction)>,
+        }
+
+        fn new_fde_state(stack_rule: CStackSetupRule, start_addr: CodePtr) -> Rc<RefCell<FDEState>> {
+            Rc::new(RefCell::new(FDEState {
+                start_addr,
+                end_addr: None,
+                stack_rule,
+                current_cfa_offset: 0,
+                insns: Vec::new(),
+            }))
+        }
+
+        // There may be more than one FDE generated, either because there are multiple blocks
+        // described in directives, or because this block is split across pages.
+        let mut fde_vec = Vec::<Rc<RefCell<FDEState>>>::new();
+        let mut current_fde = Option::<Rc<RefCell<FDEState>>>::None;
+
+        for i in directives.iter() {
+            match i.directive {
+                CFIDirective::StartProc(stack_rule) => {
+                    if current_fde.is_some() {
+                        panic!("CFI StartProc called twice")
+                    }
+                    let state = new_fde_state(stack_rule, i.addr);
+                    fde_vec.push(state.clone());
+                    current_fde.replace(state);
+                },
+                CFIDirective::EndProc() => {
+                    let mut state = current_fde.as_mut().take().expect("CFI StartProc not called").borrow_mut();
+                    state.end_addr.replace(i.addr);
+                },
+                CFIDirective::DefCFA(reg, cfa_offset) => {
+                    let mut state = current_fde.as_mut().expect("CFI StartProc not called").borrow_mut();
+                    state.insns.push((i.addr, gimli::write::CallFrameInstruction::Cfa(
+                        gimli::Register(reg.reg_no.into()), cfa_offset,
+                    )));
+                    state.current_cfa_offset = cfa_offset;
+                },
+                CFIDirective::DefCFAOffset(cfa_offset) => {
+                    let mut state = current_fde.as_mut().expect("CFI StartProc not called").borrow_mut();
+                    state.insns.push((i.addr, gimli::write::CallFrameInstruction::CfaOffset(
+                        cfa_offset,
+                    )));
+                    state.current_cfa_offset = cfa_offset;
+                },
+                CFIDirective::DefCFARegister(reg) => {
+                    let mut state = current_fde.as_mut().expect("CFI StartProc not called").borrow_mut();
+                    state.insns.push((i.addr, gimli::write::CallFrameInstruction::CfaRegister(
+                        gimli::Register(reg.reg_no.into())
+                    )));
+                },
+                CFIDirective::AdjustCFAOffset(cfa_offset_adj) => {
+                    let mut state = current_fde.as_mut().expect("CFI StartProc not called").borrow_mut();
+                    state.current_cfa_offset += cfa_offset_adj;
+                    let o = state.current_cfa_offset;
+                    state.insns.push((i.addr, gimli::write::CallFrameInstruction::CfaOffset(o)));
+                },
+                CFIDirective::Offset(reg, cfa_offset) => {
+                    let mut state = current_fde.as_mut().expect("CFI StartProc not called").borrow_mut();
+                    state.insns.push((i.addr, gimli::write::CallFrameInstruction::Offset(
+                        gimli::Register(reg.reg_no.into()), cfa_offset,
+                    )));
+                },
+                CFIDirective::RelOffset(reg, cfa_offset_rel) => {
+                    let mut state = current_fde.as_mut().expect("CFI StartProc not called").borrow_mut();
+                    let o = state.current_cfa_offset + cfa_offset_rel;
+                    state.insns.push((i.addr, gimli::write::CallFrameInstruction::Offset(
+                        gimli::Register(reg.reg_no.into()), o,
+                    )));
+                }
+                CFIDirective::Restore(reg) => {
+                    let mut state = current_fde.as_mut().expect("CFI StartProc not called").borrow_mut();
+                    state.insns.push((i.addr, gimli::write::CallFrameInstruction::Restore(
+                        gimli::Register(reg.reg_no.into())
+                    )));
+                }
+                CFIDirective::Split(from) => {
+                    let mut old_state = current_fde.as_mut().take().expect("CFI StartProc not called").borrow_mut();
+                    // Mark old state as finished at the given address
+                    old_state.end_addr.replace(from);
+                    // Create a new state for the new page.
+                    // Give it the same stack rule as the original, because we're _also_ going to copy the instructions over...
+                    // That way, we don't need to worry if we've split a cpush/cpop pair across a page boundary, for example.
+                    let new_state = new_fde_state(old_state.stack_rule, i.addr);
+                    for (_, insn) in old_state.insns.iter() {
+                        new_state.borrow_mut().insns.push((i.addr, insn.clone()));
+                    }
+                    new_state.borrow_mut().current_cfa_offset = old_state.current_cfa_offset;
+
+                    std::mem::drop(old_state);
+                    fde_vec.push(new_state.clone());
+                    current_fde.replace(new_state);
+                }
+            };
+        }
+        
+        for state_ref in fde_vec.into_iter() {
+            let state = state_ref.borrow();
+
+            if state.stack_rule == CStackSetupRule::None {
+                continue;
+            }
+
+            let start_addr_num = state.start_addr.into_u64();
+            let end_addr_num = state.end_addr.expect("CFI EndProc not used").into_u64();
+            let length = (end_addr_num - start_addr_num) as u32;
+            if length == 0 {
+                // Don't generate a FDE for an empty block
+                continue;
+            }
+
+            let mut fde = gimli::write::FrameDescriptionEntry::new(
+                gimli::write::Address::Constant(state.start_addr.into_u64()), length
+            );
+            for (addr, insn) in state.insns.iter() {
+                fde.add_instruction((addr.into_u64() - start_addr_num) as u32, insn.clone())
+            }
+            let cie_ix = self.cies.get(&state.stack_rule).expect("CIE table not filled!").clone();
+            self.frame_table.add_fde(cie_ix, fde);
+        }
+    }
+
+    /// Sets standby_object to a new object containing all .eh_frame data in the frame table
+    fn flush_to_new_object(&mut self) {
+        let mut obj = object::write::Object::new(
+            platform::OBJECT_FORMAT,
+            platform::OBJECT_ARCHITECTURE,
+            platform::OBJECT_ENDIANNESS,
+        );
+        let eh_frame_section_id = obj.add_section(
+            "".as_bytes().to_vec(),
+            platform::UNWIND_SECTION_NAME.as_bytes().to_vec(),
+            object::SectionKind::ReadOnlyData,
+        );
+
+        let mut eh_frame_section = gimli::write::EhFrame(
+            gimli::write::EndianVec::new(platform::DwarfEndianness::default())
+        );
+        self.next_fde_ix = self.frame_table.write_eh_frame_from(&mut eh_frame_section, 0).unwrap();
+
+        obj.section_mut(eh_frame_section_id).append_data(eh_frame_section.slice(), 8);
+        // _also_ append this-much-again empty data, for growth. Also the first zero is the "empty FDE"
+        // at the end of the eh_frame section, which signals its termination.
+        let grow_by = std::cmp::max(eh_frame_section.len(), 2048);
+        obj.section_mut(eh_frame_section_id).append_data(vec![0; grow_by].as_slice(), 1);
+
+        self.standby_object = obj.write().unwrap();
+
+        // Where is the eh_frame in this final data, and where does it end?
+        let reparsed_object = object::File::parse(self.standby_object.as_slice()).unwrap();
+        let reparsed_object_section = object::read::Object::section_by_name(
+            &reparsed_object, platform::UNWIND_SECTION_NAME
+        ).unwrap();
+        let eh_frame_range = object::read::ObjectSection::file_range(&reparsed_object_section).unwrap();
+        self.unwind_info_section_range = Range {
+            start: (eh_frame_range.0) as usize,
+            end: (eh_frame_range.0 as usize) + (eh_frame_range.1 as usize),
+        };
+        self.unwind_info_section_free_space_range = Range {
+            start: (eh_frame_range.0 as usize) + eh_frame_section.len(),
+            // chomp off one u32 at the end of this "free" space range, which is thus a terminator.
+            end: (eh_frame_range.0 as usize) + (eh_frame_range.1 as usize) - std::mem::size_of::<u32>(),
+        };
+        self.object_invalidated = false;
+    }
+
+    /// Attempts to append new FDEs from the frame table to the existing .eh_frame section
+    /// in the standby object, if they fit.
+    fn flush_into_existing_object(&mut self) -> Result<Range<usize>, ()> {
+        // If we haven't got an existing object, make this fail. Note that even if we're writing zero FDE's, we want
+        // to make sure the object exists so we have something valid to register.
+        if self.standby_object.len() == 0 || self.object_invalidated {
+            return Err(())
+        }
+
+        let initial_free_space_start = self.unwind_info_section_free_space_range.start;
+        let eh_frame_slice = &mut self.standby_object[self.unwind_info_section_free_space_range.clone()];
+        let mut eh_frame_section = gimli::write::EhFrame(
+            DwarfSliceWriter::new(eh_frame_slice, platform::DwarfEndianness::default())
+        );
+        let next_ix = self.frame_table.write_eh_frame_from(&mut eh_frame_section, self.next_fde_ix);
+        match next_ix {
+            Ok(ix) => {
+                self.next_fde_ix = ix;
+                self.unwind_info_section_free_space_range.start += eh_frame_section.0.ix;
+                Ok(initial_free_space_start..self.unwind_info_section_free_space_range.start)
+            }
+            Err(_) => {
+                // Means it didn't fit - we'll need to construct a new object.
+                Err(())
+            }
+        }
+    }
+
+    /// Swaps the active and standby objects, registering the new unwind info added
+    /// through add_unwind_info with the runtime.
+    pub fn flush_and_register(&mut self) {
+        // Save this so we can find the right offset to deregister the currently-active eh_frame section.
+        let original_unwind_info_section_range = self.unwind_info_section_range.clone();
+
+        // Write new FDE's into the standby object (possibly re-creating it if it needed
+        // to be grown)
+        let range_to_copy =  match self.flush_into_existing_object() {
+            Ok(invalidate_range) => {
+                // It fit - we'll copy the given range into the other buffer.
+                Option::Some(invalidate_range)
+            }
+            Err(()) => {
+                // It did not fit - generate a whole new object, and copy it _all_ over.
+                self.flush_to_new_object();
+                Option::<Range<usize>>::None
+            }
+        };
+
+        // Register the _new_ copy.
+        unsafe {
+            // Saftey: these two pointers alias each other, but the C side does not actually
+            // write to them.
+            let obj_ptr = self.standby_object.as_mut_ptr();
+            let obj_size = self.standby_object.len() as u64;
+            let eh_frame_ptr = self.standby_object[self.unwind_info_section_range.clone()].as_mut_ptr();
+            rb_yjit_register_unwind_info(obj_ptr, obj_size, eh_frame_ptr);
+        }
+
+        // FROM THIS MOMENT - the meaning of active/standby is flipped.
+        std::mem::swap(&mut self.active_object, &mut self.standby_object);
+
+        // and un-register the _old_ copy
+        if self.handler_registered {
+            unsafe {
+                let obj_ptr = self.standby_object.as_mut_ptr();
+                let obj_size = self.standby_object.len() as u64;
+                let eh_frame_ptr = self.standby_object[original_unwind_info_section_range].as_mut_ptr();
+                rb_yjit_deregister_unwind_info(obj_ptr, obj_size, eh_frame_ptr);
+            }
+        }
+
+        // Copy from new -> old now.
+        match range_to_copy {
+            Some(range) => {
+                self.standby_object[range.clone()].copy_from_slice(&self.active_object[range]);
+            }
+            None => {
+                self.standby_object = self.active_object.clone();
+            }
+        };
+
+        self.handler_registered = true;
+    }
+
+    /// Remove all unwind info for blocks that overlap the provided range; called to remove
+    /// blocks from the unwind info during code GC.
+    pub fn free_info_for_range(&mut self, free_range: Range<CodePtr>) {
+        let free_range_u64 = free_range.start.into_u64()..free_range.end.into_u64();
+        self.frame_table.retain_fdes(|_, fde| {
+            if let gimli::write::Address::Constant(fde_addr) = fde.address() {
+                let fde_addr_range = fde_addr..(fde_addr + (fde.length() as u64));
+                // Does fde_addr_range NOT overlap with the free_range?
+                !(fde_addr_range.start <= free_range_u64.end && fde_addr_range.end >= free_range_u64.start)
+            } else {
+                // We don't use non-constant addresses at all.
+                unreachable!();
+            }
+        });
+        // We'll definitely need to make a new object.
+        self.next_fde_ix = 0;
+        self.object_invalidated = true;
+    }
+}
+
+
+// Platform-specific parts of the unwinder
+#[cfg(target_arch = "aarch64")]
+mod arm64 {
+    use super::*;
+
+    pub type Reg = crate::backend::arm64::Reg;
+    pub type DwarfEndianness = gimli::LittleEndian;
+    pub const OBJECT_ARCHITECTURE : object::Architecture = object::Architecture::Aarch64;
+    pub const OBJECT_ENDIANNESS : object::Endianness = object::Endianness::Little;
+
+    pub fn cies_for_all_stack_rules() -> HashMap<CStackSetupRule, gimli::write::CommonInformationEntry> {
+        let mut r = HashMap::<CStackSetupRule, gimli::write::CommonInformationEntry>::new();
+
+        let encoding = gimli::Encoding {
+            address_size: 8,
+            format: gimli::Format::Dwarf32,
+            version: 1,
+        };
+        let code_alignment_factor = 4;
+        let data_alignment_factor = -8;
+        let return_address_register = gimli::Register(30);
+
+        let mut cie_called_from_c = gimli::write::CommonInformationEntry::new(
+            encoding, code_alignment_factor, data_alignment_factor, return_address_register,
+        );
+        cie_called_from_c.fde_address_encoding = gimli::DW_EH_PE_absptr;
+        cie_called_from_c.add_instruction(
+            gimli::write::CallFrameInstruction::Cfa(
+                gimli::Register(31), initial_cfa_offset_for_rule(CStackSetupRule::CalledFromC)
+            )
+        );
+        cie_called_from_c.add_instruction(
+            gimli::write::CallFrameInstruction::SameValue(gimli::Register(29))
+        );
+        cie_called_from_c.add_instruction(
+            gimli::write::CallFrameInstruction::SameValue(gimli::Register(30))
+        );
+
+        let mut cie_normal_jump_from_yjit = gimli::write::CommonInformationEntry::new(
+            encoding, code_alignment_factor, data_alignment_factor, return_address_register,
+        );
+        cie_normal_jump_from_yjit.fde_address_encoding = gimli::DW_EH_PE_absptr;
+        cie_normal_jump_from_yjit.add_instruction(
+            gimli::write::CallFrameInstruction::Cfa(
+                gimli::Register(31), initial_cfa_offset_for_rule(CStackSetupRule::NormalJumpFromJITCode)
+            )
+        );
+        cie_normal_jump_from_yjit.add_instruction(
+            gimli::write::CallFrameInstruction::Offset(
+                gimli::Register(29), -16
+            )
+        );
+        cie_normal_jump_from_yjit.add_instruction(
+            gimli::write::CallFrameInstruction::Offset(
+                gimli::Register(30), -8
+            )
+        );
+
+        r.insert(CStackSetupRule::CalledFromC, cie_called_from_c);
+        r.insert(CStackSetupRule::NormalJumpFromJITCode, cie_normal_jump_from_yjit);
+        r
+    }
+
+    pub fn initial_cfa_offset_for_rule(rule: CStackSetupRule) -> i32 {
+        match rule {
+            CStackSetupRule::CalledFromC => 0,
+            // Entry prologue code looks like this on aarch64:
+            // stp x29, x30, [sp, #-0x10]!
+            // mov x29, sp
+            // str x19, [sp, #-0x10]!
+            // str x20, [sp, #-0x10]!
+            // str x21, [sp, #-0x10]!
+            // Yes, we use 16 bytes of stack space each to store the 8-byte registers
+            // x19, x20, and x21.
+            CStackSetupRule::NormalJumpFromJITCode => 64,
+            CStackSetupRule::None => 0,
+        }
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+mod x86_64 {
+    use super::*;
+
+    pub type Reg = crate::backend::x86_64::Reg;
+    pub type DwarfEndianness = gimli::LittleEndian;
+    pub const OBJECT_ARCHITECTURE : object::Architecture = object::Architecture::X86_64;
+    pub const OBJECT_ENDIANNESS : object::Endianness = object::Endianness::Little;
+
+    pub fn cies_for_all_stack_rules() -> HashMap<CStackSetupRule, gimli::write::CommonInformationEntry> {
+        panic!("implement me");
+    }
+
+    pub fn initial_cfa_offset_for_rule(rule: CStackSetupRule) -> i32 {
+        panic!("implement me");
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))]
+mod elf {
+    pub const OBJECT_FORMAT : object::BinaryFormat = object::BinaryFormat::Elf;
+    pub const UNWIND_SECTION_NAME : &str = ".eh_frame";
+}
+
+#[cfg(target_os = "macos")]
+mod macho {
+    pub const OBJECT_FORMAT : object::BinaryFormat = object::BinaryFormat::MachO;
+    pub const UNWIND_SECTION_NAME : &str = "__eh_frame";
+}
+
+mod platform {
+    #[cfg(target_arch = "aarch64")]
+    pub use super::arm64::*;
+
+    #[cfg(target_arch = "x86_64")]
+    pub use super::x86_64::*;
+
+    #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))]
+    pub use super::elf::*;
+
+    #[cfg(target_os = "macos")]
+    pub use super::macho::*;
+}

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -6960,11 +6960,9 @@ fn gen_leave(
 
     // Create a side-exit to fall back to the interpreter
     let side_exit = get_side_exit(jit, ocb, ctx);
-    let ocb_asm = Assembler::new();
 
     // Check for interrupts
     gen_check_ints(asm, counted_exit!(ocb, side_exit, leave_se_interrupt));
-    ocb_asm.compile(ocb.unwrap());
 
     // Pop the current frame (ec->cfp++)
     // Note: the return PC is already in the previous CFP

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -1330,4 +1330,14 @@ extern "C" {
         file: *const ::std::os::raw::c_char,
         line: ::std::os::raw::c_int,
     );
+    pub fn rb_yjit_register_unwind_info(
+        object_file: *mut ::std::os::raw::c_uchar,
+        object_file_size: u64,
+        eh_frame: *mut ::std::os::raw::c_uchar,
+    );
+    pub fn rb_yjit_deregister_unwind_info(
+        object_file: *mut ::std::os::raw::c_uchar,
+        object_file_size: u64,
+        eh_frame: *mut ::std::os::raw::c_uchar,
+    );
 }

--- a/yjit/src/invariants.rs
+++ b/yjit/src/invariants.rs
@@ -546,6 +546,9 @@ pub extern "C" fn rb_yjit_tracing_invalidate_all() {
         cb.set_pos(old_pos);
         cb.set_dropped_bytes(old_dropped_bytes);
 
+        CodegenGlobals::get_unwind_info_manager()
+            .borrow_mut()
+            .flush_and_register();
         CodegenGlobals::get_outlined_cb()
             .unwrap()
             .mark_all_executable();

--- a/yjit/src/virtualmem.rs
+++ b/yjit/src/virtualmem.rs
@@ -244,7 +244,6 @@ impl CodePtr {
         ptr.as_ptr() as i64
     }
 
-    #[cfg(target_arch = "aarch64")]
     pub fn into_u64(self) -> u64 {
         let CodePtr(ptr) = self;
         ptr.as_ptr() as u64


### PR DESCRIPTION
Currently, when the ruby interpreter crashes, and there is YJIT-generated code in the call stack, unwinding can't progress past that and so the stack trace from `rb_print_backtrace()` gets truncated at that point. Likewise, when attaching gdb to a Ruby interpreter, it's not possible to get a thread backtrace past yjit-generated code.

To resolve this, yjit needs to generate unwinding information for the code it generates, and register it in a way that both the `backtrace(3)` library function and gdb can find it.

This PR is a POC which generates DWARF CFI on Linux aarch64, and registers it using both `__register_frame` (for `backtrace(3)`'s benefit), and the GDB JIT interface (for GDB's benefit). For more details about the platform-specific unwind info/registration, see the `unwinding.md` document in this PR.

Ticket: https://bugs.ruby-lang.org/issues/19541

(note - this will fail CI because of the external crates in use; I described the issue here in the associated ticket).
