### PR TITLE
Fix -Wclobbered warning from gcc 12 with -O2 or more

### DIFF
--- a/ractor.c
+++ b/ractor.c
@@ -887,7 +887,7 @@ static VALUE ractor_move(VALUE obj); // in this file
 static VALUE ractor_copy(VALUE obj); // in this file
 
 static void
-ractor_basket_prepare_contents(VALUE obj, VALUE move, VALUE *pobj, enum rb_ractor_basket_type *ptype)
+ractor_basket_prepare_contents(VALUE obj, VALUE move, volatile VALUE *pobj, enum rb_ractor_basket_type *ptype)
 {
     VALUE v;
     enum rb_ractor_basket_type type;
@@ -1248,7 +1248,7 @@ ractor_deq_take_basket(rb_ractor_t *cr, struct rb_ractor_queue *rs, struct rb_ra
 }
 
 static bool
-ractor_try_yield(rb_execution_context_t *ec, rb_ractor_t *cr, struct rb_ractor_queue *ts, VALUE obj, VALUE move, bool exc, bool is_will)
+ractor_try_yield(rb_execution_context_t *ec, rb_ractor_t *cr, struct rb_ractor_queue *ts, volatile VALUE obj, VALUE move, bool exc, bool is_will)
 {
     ASSERT_ractor_unlocking(cr);
 


### PR DESCRIPTION
A variable modified in `EXEC_TAG` block should be `volatile`.

```
ractor.c: In function 'ractor_try_yield':
ractor.c:1251:97: warning: argument 'obj' might be clobbered by 'longjmp' or 'vfork' [-Wclobbered]
 1251 | ractor_try_yield(rb_execution_context_t *ec, rb_ractor_t *cr, struct rb_ractor_queue *ts, VALUE obj, VALUE move, bool exc, bool is_will)
      |                                                                                           ~~~~~~^~~
```