### PR TITLE
IO::Buffer#resize: Free internal buffer if new size is zero

### DIFF
--- a/io_buffer.c
+++ b/io_buffer.c
@@ -1422,6 +1422,11 @@ rb_io_buffer_resize(VALUE self, size_t size)
 #endif
 
     if (data->flags & RB_IO_BUFFER_INTERNAL) {
+        if (size == 0) {
+            io_buffer_free(data);
+            return;
+        }
+
         void *base = realloc(data->base, size);
 
         if (!base) {

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -158,9 +158,12 @@ class TestIOBuffer < Test::Unit::TestCase
 
   def test_resize_zero_internal
     buffer = IO::Buffer.new(1)
-    buffer.resize(0)
 
+    buffer.resize(0)
     assert_equal 0, buffer.size
+
+    buffer.resize(1)
+    assert_equal 1, buffer.size
   end
 
   def test_resize_zero_external

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -156,6 +156,21 @@ class TestIOBuffer < Test::Unit::TestCase
     assert_equal message, buffer.get_string(0, message.bytesize)
   end
 
+  def test_resize_zero_internal
+    buffer = IO::Buffer.new(1)
+    buffer.resize(0)
+
+    assert_equal 0, buffer.size
+  end
+
+  def test_resize_zero_external
+    buffer = IO::Buffer.for('1')
+
+    assert_raise IO::Buffer::AccessError do
+      buffer.resize(0)
+    end
+  end
+
   def test_compare_same_size
     buffer1 = IO::Buffer.new(1)
     assert_equal buffer1, buffer1


### PR DESCRIPTION
Fixes: https://bugs.ruby-lang.org/issues/19543

`#resize(0)` on an IO::Buffer with internal buffer allocated will result in calling `realloc(data->base, 0)`. The behavior of `realloc` with size = 0 is implementation-defined (glibc frees the object and returns NULL, while BSDs return an inaccessible object). And thus such usage is deprecated in standard C (upcoming C23 will make it UB).

To avoid this problem, just `free`s the memory when the new size is zero.