### PR TITLE
YJIT: Make dev_nodebug closer to dev

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3800,6 +3800,7 @@ AS_CASE(["${YJIT_SUPPORT}"],
     [dev_nodebug], [
 	rb_rust_target_subdir=dev_nodebug
 	CARGO_BUILD_ARGS='--profile dev_nodebug --features stats,disasm'
+	AC_DEFINE(YJIT_STATS, 1)
     ],
     [stats], [
 	rb_rust_target_subdir=stats

--- a/yjit/Cargo.toml
+++ b/yjit/Cargo.toml
@@ -30,10 +30,11 @@ debug = true
 debug-assertions = true
 overflow-checks = true
 
-[profile.stats]
-inherits = "release"
-
 [profile.dev_nodebug]
+inherits = "dev"
+debug = false
+
+[profile.stats]
 inherits = "release"
 
 [profile.release]


### PR DESCRIPTION
As per https://github.com/ruby/ruby/pull/6105#discussion_r1142478615, this PR makes a couple of changes to `dev_nodebug`, adding more features of `dev` to it:

* Define `YJIT_STATS`: I'd like to use `ratio_in_yjit`.
* Use `opt-level = 0`: I want faster local build like `dev`.