### PR TITLE
YJIT: Fix incorrect exit in splat

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -3662,3 +3662,18 @@ assert_equal '[1, 2, 3]', %q{
   end
   send(:bar, 1, 2, 3)
 }
+
+# Fix splat block arg bad compilation
+assert_equal "foo", %q{
+  def literal(*args, &block)
+    s = ''.dup
+    literal_append(s, *args, &block)
+    s
+  end
+
+  def literal_append(sql, v)
+    sql << v
+  end
+
+  literal("foo")
+}

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -5708,7 +5708,7 @@ fn gen_send_iseq(
             unsafe { rb_yjit_array_len(array) as u32}
         };
 
-        if opt_num == 0 && required_num != array_length as i32 {
+        if opt_num == 0 && required_num != array_length as i32 + argc - 1 {
             gen_counter_incr!(asm, send_iseq_splat_arity_error);
             return CantCompile;
         }


### PR DESCRIPTION
So by itself, this shouldn't have been a correctness issue, but we also pop the stack for block_args. Doing stack manipulation like that and then side-exiting causes issues. So, while this fixes the immediate failure, we have a bigger issue with block_args popping and then exiting that we need to deal with.