### PR TITLE
YJIT: Rest and block_arg support

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -3779,3 +3779,24 @@ assert_equal "ArgumentError", %q{
     "ArgumentError"
   end
 }
+
+# Rest with block
+# Simplified code from railsbench
+assert_equal '[{"/a"=>"b", :as=>:c, :via=>:post}, [], nil]', %q{
+  def match(path, *rest, &block)
+    [path, rest, block]
+  end
+
+  def map_method(method, args, &block)
+    options = args.last
+    args.pop
+    options[:via] = method
+    match(*args, options, &block)
+  end
+
+  def post(*args, &block)
+    map_method(:post, args, &block)
+  end
+
+  post "/a" => "b", as: :c
+}

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -5240,9 +5240,9 @@ fn move_rest_args_to_stack(array: Opnd, num_args: u32, ctx: &mut Context, asm: &
 
     let array_len_opnd = get_array_len(asm, array);
 
-    asm.comment("Side exit if length doesn't not equal remaining args");
+    asm.comment("Side exit if length is less than required");
     asm.cmp(array_len_opnd, num_args.into());
-    asm.jbe(counted_exit!(ocb, side_exit, send_splatarray_length_not_equal));
+    asm.jl(counted_exit!(ocb, side_exit, send_iseq_has_rest_and_splat_not_equal));
 
     asm.comment("Push arguments from array");
 
@@ -5469,11 +5469,6 @@ fn gen_send_iseq(
     let iseq_has_rest = unsafe { get_iseq_flags_has_rest(iseq) };
     if iseq_has_rest && captured_opnd.is_some() {
         gen_counter_incr!(asm, send_iseq_has_rest_and_captured);
-        return CantCompile;
-    }
-
-    if iseq_has_rest && unsafe { get_iseq_flags_has_block(iseq) } {
-        gen_counter_incr!(asm, send_iseq_has_rest_and_block);
         return CantCompile;
     }
 

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -253,11 +253,10 @@ make_counters! {
     send_send_getter,
     send_send_builtin,
     send_iseq_has_rest_and_captured,
-    send_iseq_has_rest_and_splat_fewer,
     send_iseq_has_rest_and_send,
-    send_iseq_has_rest_and_block,
     send_iseq_has_rest_and_kw,
     send_iseq_has_rest_and_optional,
+    send_iseq_has_rest_and_splat_not_equal,
     send_is_a_class_mismatch,
     send_instance_of_class_mismatch,
 


### PR DESCRIPTION
This reverts commit 30e7561d1d21844bd6fc7a2ced12cd08cf3ea5ea.

https://github.com/ruby/ruby/pull/7557 was originally reverted because it was believed to be the cause of the sequel benchmark failing. The underlying issue was actually fixed in https://github.com/ruby/ruby/pull/7575