### PR TITLE
YJIT: Save PC on rb_str_concat

### DIFF
--- a/test/ruby/test_yjit.rb
+++ b/test/ruby/test_yjit.rb
@@ -1216,6 +1216,25 @@ class TestYJIT < Test::Unit::TestCase
     RUBY
   end
 
+  def test_str_concat_encoding_mismatch
+    assert_compiles(<<~'RUBY', result: "incompatible character encodings: ASCII-8BIT and EUC-JP")
+      def bar(a, b)
+        a << b
+      rescue => e
+        e.message
+      end
+
+      def foo(a, b, h)
+        h[nil]
+        bar(a, b) # Ruby call, not set cfp->pc
+      end
+
+      h = Hash.new { nil }
+      foo("\x80".b, "\xA1A1".force_encoding("EUC-JP"), h)
+      foo("\x80".b, "\xA1A1".force_encoding("EUC-JP"), h)
+    RUBY
+  end
+
   private
 
   def code_gc_helpers

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -4479,8 +4479,10 @@ fn jit_rb_str_concat(
     // Guard that the concat argument is a string
     guard_object_is_string(ctx, asm, ctx.stack_opnd(0), StackOpnd(0), side_exit);
 
-    // Guard buffers from GC since rb_str_buf_append may allocate.
-    gen_save_sp(asm, ctx);
+    // Guard buffers from GC since rb_str_buf_append may allocate. During the VM lock on GC,
+    // other Ractors may trigger global invalidation, so we need ctx.clear_local_types().
+    // PC is used on errors like Encoding::CompatibilityError raised by rb_str_buf_append.
+    jit_prepare_routine_call(jit, ctx, asm);
 
     let concat_arg = ctx.stack_pop(1);
     let recv = ctx.stack_pop(1);


### PR DESCRIPTION
Fix https://github.com/Shopify/ruby/issues/514

[[Bug #19483]](https://bugs.ruby-lang.org/issues/19483)

`make test-all TESTS="test/ruby/test_m17n_comb.rb -n /test_str_concat/" RUN_OPTS="--yjit-call-threshold=1"` crashes without this, and this change fixes it. Also this PR includes a test case that trips assertion on dev build.