### PR TITLE
Allow anonymous memberless Struct

### DIFF
--- a/spec/ruby/core/struct/new_spec.rb
+++ b/spec/ruby/core/struct/new_spec.rb
@@ -78,6 +78,20 @@ describe "Struct.new" do
     end
   end
 
+  ruby_version_is ""..."3.3" do
+    it "raises ArgumentError if not provided any arguments" do
+      -> { Struct.new }.should raise_error(ArgumentError)
+    end
+  end
+
+  ruby_version_is "3.3" do
+    it "works when not provided any arguments" do
+      c = Struct.new
+      c.should be_kind_of(Class)
+      c.superclass.should == Struct
+    end
+  end
+
   it "raises ArgumentError when there is a duplicate member" do
     -> { Struct.new(:foo, :foo) }.should raise_error(ArgumentError, "duplicate member: foo")
   end

--- a/struct.c
+++ b/struct.c
@@ -637,17 +637,14 @@ rb_struct_define_under(VALUE outer, const char *name, ...)
 static VALUE
 rb_struct_s_def(int argc, VALUE *argv, VALUE klass)
 {
-    VALUE name, rest, keyword_init = Qnil;
+    VALUE name = Qnil, rest, keyword_init = Qnil;
     long i;
     VALUE st;
     VALUE opt;
 
-    argc = rb_scan_args(argc, argv, "1*:", NULL, NULL, &opt);
-    name = argv[0];
-    if (SYMBOL_P(name)) {
-        name = Qnil;
-    }
-    else {
+    argc = rb_scan_args(argc, argv, "0*:", NULL, &opt);
+    if (argc >= 1 && !SYMBOL_P(argv[0])) {
+        name = argv[0];
         --argc;
         ++argv;
     }

--- a/test/ruby/test_arity.rb
+++ b/test/ruby/test_arity.rb
@@ -65,6 +65,5 @@ class TestArity < Test::Unit::TestCase
     assert_arity(%w[1 2])     { "".sub!(//) }
     assert_arity(%w[0 1..2])  { "".sub!{} }
     assert_arity(%w[0 1+])    { exec }
-    assert_arity(%w[0 1+])    { Struct.new }
   end
 end


### PR DESCRIPTION
Previously, named memberless Structs were allowed, but anonymous memberless Structs were not.

Fixes [Bug #19416]