### PR TITLE
Write keyword arguments directly

### DIFF
--- a/test/ruby/test_thread_queue.rb
+++ b/test/ruby/test_thread_queue.rb
@@ -211,9 +211,9 @@ class TestThreadQueue < Test::Unit::TestCase
       timeout = EnvUtil.apply_timeout_scale(60)
       total_count = 250
       begin
-        assert_normal_exit(<<-"_eom", bug5343, **{:timeout => timeout, :chdir=>d})
+        assert_normal_exit(<<-"_eom", bug5343, timeout: timeout, chdir: d)
           #{total_count}.times do |i|
-            open("test_thr_kill_count", "w") {|f| f.puts i }
+            File.open("test_thr_kill_count", "w") {|f| f.puts i }
             queue = Thread::Queue.new
             r, w = IO.pipe
             th = Thread.start {


### PR DESCRIPTION
`assert_normal_exit` uses keyword arguments since 2013, commit 05dd6b194cc29961a7cecfd5c3852f06dd56a871.