### PR TITLE
Adjust SHAPE_BUFFER_SIZE with shape_id_t

### DIFF
--- a/shape.h
+++ b/shape.h
@@ -3,7 +3,7 @@
 
 #include "internal/gc.h"
 
-#if (SIZEOF_UINT64_T == SIZEOF_VALUE)
+#if (SIZEOF_UINT64_T <= SIZEOF_VALUE)
 #define SIZEOF_SHAPE_T 4
 #define SHAPE_IN_BASIC_FLAGS 1
 typedef uint32_t attr_index_t;
@@ -18,17 +18,17 @@ typedef uint16_t attr_index_t;
 #if SIZEOF_SHAPE_T == 4
 typedef uint32_t shape_id_t;
 # define SHAPE_ID_NUM_BITS 32
+# define SHAPE_BUFFER_SIZE 0x80000
 #else
 typedef uint16_t shape_id_t;
 # define SHAPE_ID_NUM_BITS 16
+# define SHAPE_BUFFER_SIZE 0x8000
 #endif
 
 # define SHAPE_MASK (((uintptr_t)1 << SHAPE_ID_NUM_BITS) - 1)
 # define SHAPE_FLAG_MASK (((VALUE)-1) >> SHAPE_ID_NUM_BITS)
 
 # define SHAPE_FLAG_SHIFT ((SIZEOF_VALUE * 8) - SHAPE_ID_NUM_BITS)
-
-# define SHAPE_BUFFER_SIZE 0x80000
 
 # define SHAPE_MAX_VARIATIONS 8
 # define SHAPE_MAX_NUM_IVS 80


### PR DESCRIPTION
On platforms where `shape_id_t` is 16-bits, 0x80000 is out of range of this type.

https://github.com/ruby/ruby/actions/runs/4508538084/jobs/7937330984#step:13:89
```
../src/shape.c: In function ‘shape_alloc’:
../src/shape.c:129:18: warning: comparison is always false due to limited range of data type [-Wtype-limits]
  129 |     if (shape_id == MAX_SHAPE_ID) {
      |                  ^~
```