### PR TITLE
[Bug #19550] Fix memory leak for iclass

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -3677,7 +3677,7 @@ obj_free(rb_objspace_t *objspace, VALUE obj)
         cc_table_free(objspace, obj, FALSE);
         rb_class_remove_from_module_subclasses(obj);
         rb_class_remove_from_super_subclasses(obj);
-#if !USE_RVARGC
+#if !RCLASS_EXT_EMBEDDED
         xfree(RCLASS_EXT(obj));
 #endif
 

--- a/test/ruby/test_module.rb
+++ b/test/ruby/test_module.rb
@@ -3276,6 +3276,21 @@ class TestModule < Test::Unit::TestCase
     assert_match(/::Foo$/, mod.name, '[Bug #14895]')
   end
 
+  def test_iclass_memory_leak
+    # [Bug #19550]
+    assert_no_memory_leak([], <<~PREP, <<~CODE, rss: true)
+      code = proc do
+        mod = Module.new
+        Class.new do
+          include mod
+        end
+      end
+      1_000.times(&code)
+    PREP
+      3_000_000.times(&code)
+    CODE
+  end
+
   private
 
   def assert_top_method_is_private(method)


### PR DESCRIPTION
If !RCLASS_EXT_EMBEDDED (e.g. 32 bit systems) then the rb_classext_t is allocated throug malloc so it must be freed.

The issue can be seen in the following script:

```ruby
20.times do
  100_000.times do
    mod = Module.new
    Class.new do
      include mod
    end
  end

  # Output the Resident Set Size (memory usage, in KB) of the current Ruby process
  puts `ps -o rss= -p #{$$}`
end
```

Before this fix, the max RSS is 280MB, while after this change, it's 30MB.