### PR TITLE
YJIT: Rest and keyword (non-supplying)

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -3800,3 +3800,18 @@ assert_equal '[{"/a"=>"b", :as=>:c, :via=>:post}, [], nil]', %q{
 
   post "/a" => "b", as: :c
 }
+
+# Test rest and kw_args
+assert_equal '[[["test"], nil, true], [["test"], :base, true]]', %q{
+  def my_func(*args, base: nil, sort: true)
+    [args, base, sort]
+  end
+
+  def calling_my_func
+    result = []
+    result << my_func("test")
+    result << my_func("test", base: :base)
+  end
+
+  calling_my_func
+}

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -5468,8 +5468,8 @@ fn gen_send_iseq(
         return CantCompile;
     }
 
-    if iseq_has_rest && unsafe { get_iseq_flags_has_kw(iseq) } {
-        gen_counter_incr!(asm, send_iseq_has_rest_and_kw);
+    if iseq_has_rest && unsafe { get_iseq_flags_has_kw(iseq) } && supplying_kws {
+        gen_counter_incr!(asm, send_iseq_has_rest_and_kw_supplying);
         return CantCompile;
     }
 
@@ -5800,6 +5800,93 @@ fn gen_send_iseq(
         handle_opt_send_shift_stack(asm, argc, ctx);
     }
 
+    if iseq_has_rest {
+
+        // We are going to allocate so setting pc and sp.
+        jit_save_pc(jit, asm);
+        gen_save_sp(asm, ctx);
+
+        if flags & VM_CALL_ARGS_SPLAT != 0 {
+            let non_rest_arg_count = argc - 1;
+            // We start by dupping the array because someone else might have
+            // a reference to it.
+            let array = ctx.stack_pop(1);
+            let array = asm.ccall(
+                rb_ary_dup as *const u8,
+                vec![array],
+            );
+            if non_rest_arg_count > required_num {
+                // If we have more arguments than required, we need to prepend
+                // the items from the stack onto the array.
+                let diff = (non_rest_arg_count - required_num) as u32;
+
+                // diff is >0 so no need to worry about null pointer
+                asm.comment("load pointer to array elements");
+                let offset_magnitude = SIZEOF_VALUE as u32 * diff;
+                let values_opnd = ctx.sp_opnd(-(offset_magnitude as isize));
+                let values_ptr = asm.lea(values_opnd);
+
+                asm.comment("prepend stack values to rest array");
+                let array = asm.ccall(
+                    rb_yjit_rb_ary_unshift_m as *const u8,
+                    vec![Opnd::UImm(diff as u64), values_ptr, array],
+                );
+                ctx.stack_pop(diff as usize);
+
+                let stack_ret = ctx.stack_push(Type::TArray);
+                asm.mov(stack_ret, array);
+                // We now should have the required arguments
+                // and an array of all the rest arguments
+                argc = required_num + 1;
+            } else if non_rest_arg_count < required_num {
+                // If we have fewer arguments than required, we need to take some
+                // from the array and move them to the stack.
+                let diff = (required_num - non_rest_arg_count) as u32;
+                // This moves the arguments onto the stack. But it doesn't modify the array.
+                move_rest_args_to_stack(array, diff, ctx, asm, ocb, side_exit);
+
+                // We will now slice the array to give us a new array of the correct size
+                let ret = asm.ccall(rb_yjit_rb_ary_subseq_length as *const u8, vec![array, Opnd::UImm(diff as u64)]);
+                let stack_ret = ctx.stack_push(Type::TArray);
+                asm.mov(stack_ret, ret);
+
+                // We now should have the required arguments
+                // and an array of all the rest arguments
+                argc = required_num + 1;
+            } else {
+                // The arguments are equal so we can just push to the stack
+                assert!(non_rest_arg_count == required_num);
+                let stack_ret = ctx.stack_push(Type::TArray);
+                asm.mov(stack_ret, array);
+            }
+        } else {
+            assert!(argc >= required_num);
+            let n = (argc - required_num) as u32;
+            argc = required_num + 1;
+            // If n is 0, then elts is never going to be read, so we can just pass null
+            let values_ptr = if n == 0 {
+                Opnd::UImm(0)
+            } else {
+                asm.comment("load pointer to array elements");
+                let offset_magnitude = SIZEOF_VALUE as u32 * n;
+                let values_opnd = ctx.sp_opnd(-(offset_magnitude as isize));
+                asm.lea(values_opnd)
+            };
+
+            let new_ary = asm.ccall(
+                rb_ec_ary_new_from_values as *const u8,
+                vec![
+                    EC,
+                    Opnd::UImm(n.into()),
+                    values_ptr
+                ]
+            );
+            ctx.stack_pop(n.as_usize());
+            let stack_ret = ctx.stack_push(Type::CArray);
+            asm.mov(stack_ret, new_ary);
+        }
+    }
+
     if doing_kw_call {
         // Here we're calling a method with keyword arguments and specifying
         // keyword arguments at this call site.
@@ -5966,93 +6053,7 @@ fn gen_send_iseq(
         argc = lead_num;
     }
 
-    if iseq_has_rest {
 
-        // We are going to allocate so setting pc and sp.
-        jit_save_pc(jit, asm);
-        gen_save_sp(asm, ctx);
-
-        if flags & VM_CALL_ARGS_SPLAT != 0 {
-            let non_rest_arg_count = argc - 1;
-            // We start by dupping the array because someone else might have
-            // a reference to it.
-            let array = ctx.stack_pop(1);
-            let array = asm.ccall(
-                rb_ary_dup as *const u8,
-                vec![array],
-            );
-            if non_rest_arg_count > required_num {
-                // If we have more arguments than required, we need to prepend
-                // the items from the stack onto the array.
-                let diff = (non_rest_arg_count - required_num) as u32;
-
-                // diff is >0 so no need to worry about null pointer
-                asm.comment("load pointer to array elements");
-                let offset_magnitude = SIZEOF_VALUE as u32 * diff;
-                let values_opnd = ctx.sp_opnd(-(offset_magnitude as isize));
-                let values_ptr = asm.lea(values_opnd);
-
-                asm.comment("prepend stack values to rest array");
-                let array = asm.ccall(
-                    rb_yjit_rb_ary_unshift_m as *const u8,
-                    vec![Opnd::UImm(diff as u64), values_ptr, array],
-                );
-                ctx.stack_pop(diff as usize);
-
-                let stack_ret = ctx.stack_push(Type::TArray);
-                asm.mov(stack_ret, array);
-                // We now should have the required arguments
-                // and an array of all the rest arguments
-                argc = required_num + 1;
-            } else if non_rest_arg_count < required_num {
-                // If we have fewer arguments than required, we need to take some
-                // from the array and move them to the stack.
-                let diff = (required_num - non_rest_arg_count) as u32;
-                // This moves the arguments onto the stack. But it doesn't modify the array.
-                move_rest_args_to_stack(array, diff, ctx, asm, ocb, side_exit);
-
-                // We will now slice the array to give us a new array of the correct size
-                let ret = asm.ccall(rb_yjit_rb_ary_subseq_length as *const u8, vec![array, Opnd::UImm(diff as u64)]);
-                let stack_ret = ctx.stack_push(Type::TArray);
-                asm.mov(stack_ret, ret);
-
-                // We now should have the required arguments
-                // and an array of all the rest arguments
-                argc = required_num + 1;
-            } else {
-                // The arguments are equal so we can just push to the stack
-                assert!(non_rest_arg_count == required_num);
-                let stack_ret = ctx.stack_push(Type::TArray);
-                asm.mov(stack_ret, array);
-            }
-        } else {
-            assert!(argc >= required_num);
-            let n = (argc - required_num) as u32;
-            argc = required_num + 1;
-            // If n is 0, then elts is never going to be read, so we can just pass null
-            let values_ptr = if n == 0 {
-                Opnd::UImm(0)
-            } else {
-                asm.comment("load pointer to array elements");
-                let offset_magnitude = SIZEOF_VALUE as u32 * n;
-                let values_opnd = ctx.sp_opnd(-(offset_magnitude as isize));
-                asm.lea(values_opnd)
-            };
-
-            let new_ary = asm.ccall(
-                rb_ec_ary_new_from_values as *const u8,
-                vec![
-                    EC,
-                    Opnd::UImm(n.into()),
-                    values_ptr
-                ]
-            );
-
-            ctx.stack_pop(n.as_usize());
-            let stack_ret = ctx.stack_push(Type::CArray);
-            asm.mov(stack_ret, new_ary);
-        }
-    }
 
     // Points to the receiver operand on the stack unless a captured environment is used
     let recv = match captured_opnd {

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -5801,7 +5801,6 @@ fn gen_send_iseq(
     }
 
     if iseq_has_rest {
-
         // We are going to allocate so setting pc and sp.
         jit_save_pc(jit, asm);
         gen_save_sp(asm, ctx);

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -254,7 +254,7 @@ make_counters! {
     send_send_builtin,
     send_iseq_has_rest_and_captured,
     send_iseq_has_rest_and_send,
-    send_iseq_has_rest_and_kw,
+    send_iseq_has_rest_and_kw_supplying,
     send_iseq_has_rest_and_optional,
     send_iseq_has_rest_and_splat_not_equal,
     send_is_a_class_mismatch,


### PR DESCRIPTION

Here are the stats of railsbench and liquid-render before and after these changes
        
Highlight:
```
Railsbench Before:
iseq_has_rest_and_kw:                   2,207 ( 0.8%)

After:
iseq_has_rest_and_kw_supplying:         71 ( 0.0%)
```



<summary>Rails Bench Before</summary>
<details>

```ruby
         ***YJIT: Printing YJIT statistics on exit***
method call exit reasons: 
                          block_arg:     64,944 (22.7%)
                        iseq_zsuper:     63,380 (22.2%)
                   iseq_arity_error:     30,686 (10.7%)
                iseq_ruby2_keywords:     25,095 ( 8.8%)
                     iseq_has_no_kw:     19,407 ( 6.8%)
          args_splat_cfunc_var_args:     16,341 ( 5.7%)
            iseq_materialized_block:     16,002 ( 5.6%)
                           kw_splat:     12,997 ( 4.5%)
         iseq_has_rest_and_optional:     12,620 ( 4.4%)
                    iseq_has_kwrest:      7,320 ( 2.6%)
                  klass_megamorphic:      5,025 ( 1.8%)
           iseq_missing_optional_kw:      4,054 ( 1.4%)
               iseq_has_rest_and_kw:      2,207 ( 0.8%)
             args_splat_cfunc_zuper:      2,002 ( 0.7%)
                      iseq_has_post:      1,988 ( 0.7%)
              cfunc_ruby_array_varg:      1,368 ( 0.5%)
                           keywords:        102 ( 0.0%)
    args_splat_cfunc_ruby2_keywords:         62 ( 0.0%)
                    args_splat_ivar:         50 ( 0.0%)
                      zsuper_method:         23 ( 0.0%)
                        send_getter:         12 ( 0.0%)
                args_splat_opt_call:          5 ( 0.0%)
                    ivar_set_method:          2 ( 0.0%)
        splatarray_length_not_equal:          2 ( 0.0%)
                  bmethod_block_arg:          2 ( 0.0%)
                         send_chain:          1 ( 0.0%)
invokeblock exit reasons: 
      proc:      2,400 (92.7%)
    symbol:        188 ( 7.3%)
invokesuper exit reasons: 
    me_changed:      4,819 (68.6%)
         block:      2,207 (31.4%)
leave exit reasons: 
    interp_return:  1,770,365 (100.0%)
     se_interrupt:         35 ( 0.0%)
getblockparamproxy exit reasons: 
    block_param_modified:          3 (100.0%)
getinstancevariable exit reasons:
    megamorphic:      6,330 (100.0%)
setinstancevariable exit reasons:
    (all relevant counters are zero)
opt_aref exit reasons: 
    (all relevant counters are zero)
expandarray exit reasons: 
            splat:      9,973 (99.8%)
    rhs_too_small:         23 ( 0.2%)
opt_getinlinecache exit reasons: 
    miss:         11 (100.0%)
invalidation reasons: 
       constant_ic_fill:      2,092 (57.5%)
          method_lookup:      1,197 (32.9%)
    constant_state_bump:        347 ( 9.5%)
num_send:                 13,992,130
num_send_known_class:        509,509 ( 3.6%)
num_send_polymorphic:      1,930,428 (13.8%)
iseq_stack_too_large:              0
iseq_too_long:                     0
bindings_allocations:            198
bindings_set:                      0
compiled_iseq_count:           9,329
compiled_block_count:         57,993
compiled_branch_count:        95,197
block_next_count:             48,112
defer_count:                  17,572
defer_empty_count:             2,898
branch_insn_count:             3,884
branch_known_count:              836 (21.5%)
freed_iseq_count:              4,084
invalidation_count:            3,636
constant_state_bumps:              0
get_ivar_max_depth:           10,047
inline_code_size:         10,872,076
outlined_code_size:       10,871,520
freed_code_size:                   0
code_region_size:         21,757,952
yjit_alloc_size:          14,415,489
live_context_size:         1,543,612
live_context_count:           55,129
live_page_count:               1,328
freed_page_count:                  0
code_gc_count:                     0
num_gc_obj_refs:              51,368
object_shape_count:            2,449
side_exit_count:             392,364
total_exit_count:          2,162,729
total_insns_count:        90,592,320
vm_insns_count:            7,223,313
yjit_insns_count:         83,761,371
ratio_in_yjit:                 92.0%
avg_len_in_yjit:                38.5
Top-20 most frequent exit ops (100.0% of exits):
               invokesuper:    103,459 (26.4%)
                      send:     96,235 (24.5%)
    opt_send_without_block:     61,372 (15.6%)
      opt_getconstant_path:     51,967 (13.2%)
               invokeblock:     31,272 ( 8.0%)
                  opt_aref:     14,086 ( 3.6%)
               expandarray:      9,996 ( 2.5%)
             setlocal_WC_0:      8,422 ( 2.1%)
               definedivar:      6,330 ( 1.6%)
                    opt_eq:      4,983 ( 1.3%)
        getblockparamproxy:      2,360 ( 0.6%)
          putspecialobject:        733 ( 0.2%)
                 opt_nil_p:        301 ( 0.1%)
             definesmethod:        237 ( 0.1%)
                checkmatch:        205 ( 0.1%)
               objtostring:        194 ( 0.0%)
                      once:        104 ( 0.0%)
                     leave:         36 ( 0.0%)
             setblockparam:         25 ( 0.0%)
              definemethod:         21 ( 0.0%)

```
</details>
    
        
<summary>Rails Bench After</summary>
<details>

```ruby
         ***YJIT: Printing YJIT statistics on exit***
method call exit reasons: 
                          block_arg:     64,948 (22.7%)
                        iseq_zsuper:     63,380 (22.2%)
                   iseq_arity_error:     30,686 (10.7%)
                iseq_ruby2_keywords:     25,096 ( 8.8%)
                     iseq_has_no_kw:     19,407 ( 6.8%)
          args_splat_cfunc_var_args:     16,341 ( 5.7%)
            iseq_materialized_block:     16,002 ( 5.6%)
                           kw_splat:     12,996 ( 4.6%)
         iseq_has_rest_and_optional:     12,619 ( 4.4%)
                    iseq_has_kwrest:      7,319 ( 2.6%)
                  klass_megamorphic:      5,027 ( 1.8%)
           iseq_missing_optional_kw:      4,054 ( 1.4%)
                 iseq_splat_with_kw:      2,004 ( 0.7%)
             args_splat_cfunc_zuper:      2,002 ( 0.7%)
                      iseq_has_post:      1,988 ( 0.7%)
              cfunc_ruby_array_varg:      1,368 ( 0.5%)
                           keywords:        102 ( 0.0%)
     iseq_has_rest_and_kw_supplying:         71 ( 0.0%)
    args_splat_cfunc_ruby2_keywords:         62 ( 0.0%)
                    args_splat_ivar:         50 ( 0.0%)
                      zsuper_method:         23 ( 0.0%)
                        send_getter:         12 ( 0.0%)
                args_splat_opt_call:          5 ( 0.0%)
                    ivar_set_method:          2 ( 0.0%)
        splatarray_length_not_equal:          2 ( 0.0%)
                  bmethod_block_arg:          2 ( 0.0%)
                         send_chain:          1 ( 0.0%)
invokeblock exit reasons: 
      proc:      2,400 (92.7%)
    symbol:        188 ( 7.3%)
invokesuper exit reasons: 
    me_changed:      4,819 (68.6%)
         block:      2,207 (31.4%)
leave exit reasons: 
    interp_return:  1,770,333 (100.0%)
     se_interrupt:         39 ( 0.0%)
getblockparamproxy exit reasons: 
    block_param_modified:          3 (100.0%)
getinstancevariable exit reasons:
    megamorphic:      6,330 (100.0%)
setinstancevariable exit reasons:
    (all relevant counters are zero)
opt_aref exit reasons: 
    (all relevant counters are zero)
expandarray exit reasons: 
            splat:      9,974 (99.8%)
    rhs_too_small:         23 ( 0.2%)
opt_getinlinecache exit reasons: 
    miss:         11 (100.0%)
invalidation reasons: 
       constant_ic_fill:      2,094 (57.6%)
          method_lookup:      1,198 (32.9%)
    constant_state_bump:        346 ( 9.5%)
num_send:                 13,992,525
num_send_known_class:        509,537 ( 3.6%)
num_send_polymorphic:      1,930,711 (13.8%)
iseq_stack_too_large:              0
iseq_too_long:                     0
bindings_allocations:            198
bindings_set:                      0
compiled_iseq_count:           9,329
compiled_block_count:         58,103
compiled_branch_count:        95,515
block_next_count:             48,208
defer_count:                  17,590
defer_empty_count:             2,903
branch_insn_count:             3,891
branch_known_count:              835 (21.5%)
freed_iseq_count:              4,084
invalidation_count:            3,638
constant_state_bumps:              0
get_ivar_max_depth:           10,046
inline_code_size:         10,904,904
outlined_code_size:       10,904,288
freed_code_size:                   0
code_region_size:         21,823,488
yjit_alloc_size:          14,467,917
live_context_size:         1,549,548
live_context_count:           55,341
live_page_count:               1,332
freed_page_count:                  0
code_gc_count:                     0
num_gc_obj_refs:              51,599
object_shape_count:            2,449
side_exit_count:             392,237
total_exit_count:          2,162,570
total_insns_count:        90,592,483
vm_insns_count:            7,222,597
yjit_insns_count:         83,762,123
ratio_in_yjit:                 92.0%
avg_len_in_yjit:                38.6
Top-20 most frequent exit ops (100.0% of exits):
               invokesuper:    103,454 (26.4%)
                      send:     96,238 (24.5%)
    opt_send_without_block:     61,332 (15.6%)
      opt_getconstant_path:     51,966 (13.2%)
               invokeblock:     31,272 ( 8.0%)
                  opt_aref:     14,001 ( 3.6%)
               expandarray:      9,997 ( 2.5%)
             setlocal_WC_0:      8,422 ( 2.1%)
               definedivar:      6,330 ( 1.6%)
                    opt_eq:      4,983 ( 1.3%)
        getblockparamproxy:      2,360 ( 0.6%)
          putspecialobject:        733 ( 0.2%)
                 opt_nil_p:        301 ( 0.1%)
             definesmethod:        237 ( 0.1%)
                checkmatch:        205 ( 0.1%)
               objtostring:        193 ( 0.0%)
                      once:        104 ( 0.0%)
                     leave:         40 ( 0.0%)
             setblockparam:         25 ( 0.0%)
              definemethod:         21 ( 0.0%)

```
</details>
    
        
<summary>Liquid Render Before</summary>
<details>

```ruby
         ***YJIT: Printing YJIT statistics on exit***
method call exit reasons: 
                    block_arg:      1,475 (61.5%)
                zsuper_method:        832 (34.7%)
        cfunc_ruby_array_varg:         33 ( 1.4%)
         iseq_has_rest_and_kw:         14 ( 0.6%)
            klass_megamorphic:         13 ( 0.5%)
                  send_getter:         12 ( 0.5%)
     iseq_missing_optional_kw:          9 ( 0.4%)
    args_splat_cfunc_var_args:          8 ( 0.3%)
                     kw_splat:          3 ( 0.1%)
              ivar_set_method:          1 ( 0.0%)
invokeblock exit reasons: 
      proc:        349 (80.8%)
    symbol:         83 (19.2%)
invokesuper exit reasons: 
    block:         86 (100.0%)
leave exit reasons: 
    interp_return:    274,357 (100.0%)
     se_interrupt:         13 ( 0.0%)
getblockparamproxy exit reasons: 
    (all relevant counters are zero)
getinstancevariable exit reasons:
    (all relevant counters are zero)
setinstancevariable exit reasons:
    (all relevant counters are zero)
opt_aref exit reasons: 
    (all relevant counters are zero)
expandarray exit reasons: 
    rhs_too_small:         10 (100.0%)
opt_getinlinecache exit reasons: 
    (all relevant counters are zero)
invalidation reasons: 
       constant_ic_fill:        597 (81.4%)
    constant_state_bump:         93 (12.7%)
          method_lookup:         43 ( 5.9%)
num_send:                  3,040,387
num_send_known_class:        135,946 ( 4.5%)
num_send_polymorphic:        600,065 (19.7%)
iseq_stack_too_large:              1
iseq_too_long:                     0
bindings_allocations:            156
bindings_set:                      0
compiled_iseq_count:           1,691
compiled_block_count:         12,105
compiled_branch_count:        20,067
block_next_count:             10,364
defer_count:                   3,935
defer_empty_count:               760
branch_insn_count:             1,059
branch_known_count:              308 (29.1%)
freed_iseq_count:                563
invalidation_count:              733
constant_state_bumps:              0
get_ivar_max_depth:               10
inline_code_size:          2,032,516
outlined_code_size:        2,032,012
freed_code_size:                   0
code_region_size:          4,079,616
yjit_alloc_size:           4,701,545
live_context_size:           518,112
live_context_count:           18,504
live_page_count:                 249
freed_page_count:                  0
code_gc_count:                     0
num_gc_obj_refs:               8,137
object_shape_count:              766
side_exit_count:               4,020
total_exit_count:            278,377
total_insns_count:        20,424,374
vm_insns_count:            2,280,456
yjit_insns_count:         18,147,938
ratio_in_yjit:                 88.8%
avg_len_in_yjit:                65.2
Top-15 most frequent exit ops (100.0% of exits):
                      send:      1,490 (37.1%)
    opt_send_without_block:        916 (22.8%)
      opt_getconstant_path:        799 (19.9%)
               invokeblock:        432 (10.7%)
                      once:         96 ( 2.4%)
                    opt_eq:         91 ( 2.3%)
               invokesuper:         87 ( 2.2%)
          putspecialobject:         41 ( 1.0%)
             setlocal_WC_0:         22 ( 0.5%)
                     leave:         13 ( 0.3%)
               expandarray:         10 ( 0.2%)
                  opt_aref:         10 ( 0.2%)
        getblockparamproxy:          9 ( 0.2%)
                  opt_ltlt:          2 ( 0.0%)
                checkmatch:          2 ( 0.0%)

```
</details>
    
        
<summary>Liquid Render After</summary>
<details>

```ruby
         ***YJIT: Printing YJIT statistics on exit***
method call exit reasons: 
                    block_arg:      1,476 (61.7%)
                zsuper_method:        832 (34.8%)
        cfunc_ruby_array_varg:         33 ( 1.4%)
            klass_megamorphic:         13 ( 0.5%)
                  send_getter:         12 ( 0.5%)
     iseq_missing_optional_kw:          9 ( 0.4%)
    args_splat_cfunc_var_args:          8 ( 0.3%)
           iseq_splat_with_kw:          4 ( 0.2%)
                     kw_splat:          3 ( 0.1%)
              ivar_set_method:          1 ( 0.0%)
invokeblock exit reasons: 
      proc:        349 (80.8%)
    symbol:         83 (19.2%)
invokesuper exit reasons: 
    block:         86 (100.0%)
leave exit reasons: 
    interp_return:    274,280 (100.0%)
     se_interrupt:         12 ( 0.0%)
getblockparamproxy exit reasons: 
    (all relevant counters are zero)
getinstancevariable exit reasons:
    (all relevant counters are zero)
setinstancevariable exit reasons:
    (all relevant counters are zero)
opt_aref exit reasons: 
    (all relevant counters are zero)
expandarray exit reasons: 
    rhs_too_small:         10 (100.0%)
opt_getinlinecache exit reasons: 
    (all relevant counters are zero)
invalidation reasons: 
       constant_ic_fill:        597 (81.4%)
    constant_state_bump:         93 (12.7%)
          method_lookup:         43 ( 5.9%)
num_send:                  3,025,697
num_send_known_class:        135,993 ( 4.5%)
num_send_polymorphic:        585,049 (19.3%)
iseq_stack_too_large:              1
iseq_too_long:                     0
bindings_allocations:            156
bindings_set:                      0
compiled_iseq_count:           1,691
compiled_block_count:         12,141
compiled_branch_count:        20,131
block_next_count:             10,396
defer_count:                   3,948
defer_empty_count:               761
branch_insn_count:             1,063
branch_known_count:              309 (29.1%)
freed_iseq_count:                563
invalidation_count:              733
constant_state_bumps:              0
get_ivar_max_depth:               10
inline_code_size:          2,037,852
outlined_code_size:        2,035,476
freed_code_size:                   0
code_region_size:          4,079,616
yjit_alloc_size:           4,713,777
live_context_size:           519,988
live_context_count:           18,571
live_page_count:                 249
freed_page_count:                  0
code_gc_count:                     0
num_gc_obj_refs:               8,160
object_shape_count:              766
side_exit_count:               4,005
total_exit_count:            278,285
total_insns_count:        20,403,442
vm_insns_count:            2,279,060
yjit_insns_count:         18,128,387
ratio_in_yjit:                 88.8%
avg_len_in_yjit:                65.1
Top-16 most frequent exit ops (100.0% of exits):
                      send:      1,489 (37.2%)
    opt_send_without_block:        910 (22.7%)
      opt_getconstant_path:        799 (20.0%)
               invokeblock:        432 (10.8%)
                      once:         96 ( 2.4%)
                    opt_eq:         91 ( 2.3%)
               invokesuper:         87 ( 2.2%)
          putspecialobject:         41 ( 1.0%)
             setlocal_WC_0:         22 ( 0.5%)
                     leave:         12 ( 0.3%)
               expandarray:         10 ( 0.2%)
        getblockparamproxy:          9 ( 0.2%)
                  opt_ltlt:          3 ( 0.1%)
                checkmatch:          2 ( 0.0%)
                   opt_div:          1 ( 0.0%)
                opt_length:          1 ( 0.0%)

```
</details>
    
    

