### PR TITLE
YJIT: Add `--yjit-pause` and `RubyVM::YJIT.resume`

### DIFF
--- a/vm.c
+++ b/vm.c
@@ -376,7 +376,7 @@ jit_compile(rb_execution_context_t *ec)
     // Increment the ISEQ's call counter
     const rb_iseq_t *iseq = ec->cfp->iseq;
     struct rb_iseq_constant_body *body = ISEQ_BODY(iseq);
-    bool yjit_enabled = rb_yjit_enabled_p();
+    bool yjit_enabled = rb_yjit_compile_new_iseqs();
     if (yjit_enabled || rb_rjit_call_p) {
         body->total_calls++;
     }

--- a/yjit.c
+++ b/yjit.c
@@ -1114,6 +1114,7 @@ VALUE rb_yjit_insns_compiled(rb_execution_context_t *ec, VALUE self, VALUE iseq)
 VALUE rb_yjit_code_gc(rb_execution_context_t *ec, VALUE self);
 VALUE rb_yjit_simulate_oom_bang(rb_execution_context_t *ec, VALUE self);
 VALUE rb_yjit_get_exit_locations(rb_execution_context_t *ec, VALUE self);
+VALUE rb_yjit_resume(rb_execution_context_t *ec, VALUE self);
 
 // Preprocessed yjit.rb generated during build
 #include "yjit.rbinc"

--- a/yjit.h
+++ b/yjit.h
@@ -26,6 +26,7 @@
 
 // Expose these as declarations since we are building YJIT.
 bool rb_yjit_enabled_p(void);
+bool rb_yjit_compile_new_iseqs(void);
 unsigned rb_yjit_call_threshold(void);
 void rb_yjit_invalidate_all_method_lookup_assumptions(void);
 void rb_yjit_cme_invalidate(rb_callable_method_entry_t *cme);
@@ -48,6 +49,7 @@ void rb_yjit_tracing_invalidate_all(void);
 // In these builds, YJIT could never be turned on. Provide dummy implementations.
 
 static inline bool rb_yjit_enabled_p(void) { return false; }
+static inline bool rb_yjit_compile_new_iseqs(void) { return false; }
 static inline unsigned rb_yjit_call_threshold(void) { return UINT_MAX; }
 static inline void rb_yjit_invalidate_all_method_lookup_assumptions(void) {}
 static inline void rb_yjit_cme_invalidate(rb_callable_method_entry_t *cme) {}

--- a/yjit.rb
+++ b/yjit.rb
@@ -29,6 +29,10 @@ module RubyVM::YJIT
     Primitive.rb_yjit_reset_stats_bang
   end
 
+  def self.resume
+    Primitive.rb_yjit_resume
+  end
+
   # If --yjit-trace-exits is enabled parse the hashes from
   # Primitive.rb_yjit_get_exit_locations into a format readable
   # by Stackprof. This will allow us to find the exact location of a

--- a/yjit.rb
+++ b/yjit.rb
@@ -29,6 +29,7 @@ module RubyVM::YJIT
     Primitive.rb_yjit_reset_stats_bang
   end
 
+  # Resume YJIT compilation after paused on startup with --yjit-pause
   def self.resume
     Primitive.rb_yjit_resume
   end

--- a/yjit/src/options.rs
+++ b/yjit/src/options.rs
@@ -28,6 +28,10 @@ pub struct Options {
     // Trace locations of exits
     pub gen_trace_exits: bool,
 
+    // Whether to start YJIT in paused state (initialize YJIT but don't
+    // compile anything)
+    pub pause: bool,
+
     /// Dump compiled and executed instructions for debugging
     pub dump_insns: bool,
 
@@ -50,6 +54,7 @@ pub static mut OPTIONS: Options = Options {
     max_versions: 4,
     gen_stats: false,
     gen_trace_exits: false,
+    pause: false,
     dump_insns: false,
     dump_disasm: None,
     verify_ctx: false,
@@ -130,6 +135,10 @@ pub fn parse_option(str_ptr: *const std::os::raw::c_char) -> Option<()> {
             Err(_) => {
                 return None;
             }
+        },
+
+        ("pause", "") => unsafe {
+            OPTIONS.pause = true;
         },
 
         ("dump-disasm", _) => match opt_val.to_string().as_str() {

--- a/yjit/src/yjit.rs
+++ b/yjit/src/yjit.rs
@@ -15,6 +15,9 @@ use std::sync::atomic::{AtomicBool, Ordering};
 /// See [rb_yjit_enabled_p]
 static YJIT_ENABLED: AtomicBool = AtomicBool::new(false);
 
+/// When false, we don't compile new iseqs, but might still service existing branch stubs.
+static COMPILE_NEW_ISEQS: AtomicBool = AtomicBool::new(false);
+
 /// Parse one command-line option.
 /// This is called from ruby.c
 #[no_mangle]
@@ -30,6 +33,11 @@ pub extern "C" fn rb_yjit_enabled_p() -> raw::c_int {
     // Note that we might want to call this function from signal handlers so
     // might need to ensure signal-safety(7).
     YJIT_ENABLED.load(Ordering::Acquire).into()
+}
+
+#[no_mangle]
+pub extern "C" fn rb_yjit_compile_new_iseqs() -> bool {
+    COMPILE_NEW_ISEQS.load(Ordering::Acquire).into()
 }
 
 /// Like rb_yjit_enabled_p, but for Rust code.
@@ -60,6 +68,8 @@ pub extern "C" fn rb_yjit_init_rust() {
 
         // YJIT enabled and initialized successfully
         YJIT_ENABLED.store(true, Ordering::Release);
+
+        COMPILE_NEW_ISEQS.store(!get_option!(pause), Ordering::Release);
     });
 
     if let Err(_) = result {
@@ -131,6 +141,15 @@ pub extern "C" fn rb_yjit_code_gc(_ec: EcPtr, _ruby_self: VALUE) -> VALUE {
 
     let cb = CodegenGlobals::get_inline_cb();
     cb.code_gc();
+    Qnil
+}
+
+#[no_mangle]
+pub extern "C" fn rb_yjit_resume(_ec: EcPtr, _ruby_self: VALUE) -> VALUE {
+    if yjit_enabled_p() {
+        COMPILE_NEW_ISEQS.store(true, Ordering::Release);
+    }
+
     Qnil
 }
 


### PR DESCRIPTION
This allows booting YJIT in a suspended state. We chose to add a new command line option as opposed to simply allowing YJIT.resume to work without any command line option because it allows for combining with YJIT tuning command line options. It also simpifies implementation.

Co-authored by Alan, Kokubun & Maxime

----

Benchmark results (locally on M1/Rosetta):
```
./run_benchmarks.rb -e "normal::ruby --yjit" -e "paused::ruby --yjit-pause" --rss liquid-render railsbench hexapdf liquid-c activerecord mail psych-load ruby-lsp sequel

normal: ruby 3.3.0dev (2023-03-28T16:04:45Z runtime-enable-yjit bee3d1410a) +YJIT dev [x86_64-darwin22]
paused: ruby 3.3.0dev (2023-03-28T16:04:45Z runtime-enable-yjit bee3d1410a) +YJIT dev [x86_64-darwin22]

-------------  -----------  ----------  ---------  -----------  ----------  ---------  -------------  --------------
bench          normal (ms)  stddev (%)  RSS (MiB)  paused (ms)  stddev (%)  RSS (MiB)  normal/paused  paused 1st itr
activerecord   47.4         1.8         82.8       44.8         1.8         60.8       1.06           0.44          
hexapdf        2485.5       3.9         840.1      2483.7       1.9         862.6      1.00           1.01          
liquid-c       63.6         3.4         66.3       63.1         2.5         55.4       1.01           1.08          
liquid-render  137.4        3.4         60.6       136.3        2.2         48.6       1.01           0.95          
mail           120.8        1.9         103.0      118.7        1.3         89.6       1.02           1.03          
psych-load     1956.3       0.2         46.5       1982.8       0.5         43.0       0.99           0.99          
railsbench     1679.0       1.3         213.1      1653.4       1.2         169.8      1.02           1.17          
ruby-lsp       142.0        63.6        296.6      130.5        77.1        279.0      1.09           1.08          
sequel         71.0         1.5         64.9       68.4         1.2         45.2       1.04           0.41          
-------------  -----------  ----------  ---------  -----------  ----------  ---------  -------------  --------------
```

Seems worth upstreaming as this will facilitate further testing (e.g. on SFR) and this change is not hard to revert. The RSS seems to be almost always significantly less, and performance a little bit better. We should ignore the ruby-lsp performance data point since this benchmark is so noisy.