### PR TITLE
YJIT: Leave cfp->pc uninitialized for VM_FRAME_MAGIC_CFUNC

### DIFF
--- a/vm.c
+++ b/vm.c
@@ -1609,7 +1609,7 @@ rb_vm_invoke_proc_with_self(rb_execution_context_t *ec, rb_proc_t *proc, VALUE s
 VALUE *
 rb_vm_svar_lep(const rb_execution_context_t *ec, const rb_control_frame_t *cfp)
 {
-    while (cfp->pc == 0) {
+    while (cfp->pc == 0 || cfp->iseq == 0) {
         if (VM_FRAME_TYPE(cfp) ==  VM_FRAME_MAGIC_IFUNC) {
             struct vm_ifunc *ifunc = (struct vm_ifunc *)cfp->iseq;
             return ifunc->svar_lep;

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -5095,7 +5095,11 @@ fn gen_send_cfunc(
         cme,
         recv,
         sp,
-        pc: Some(0),
+        pc: if cfg!(debug_assertions) {
+            Some(!0) // Poison value. Helps to fast fast.
+        } else {
+            None     // Leave PC uninitialized as cfuncs shouldn't read it
+        },
         iseq: None,
         local_size: 0,
     });

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -5096,7 +5096,7 @@ fn gen_send_cfunc(
         recv,
         sp,
         pc: if cfg!(debug_assertions) {
-            Some(!0) // Poison value. Helps to fast fast.
+            Some(!0) // Poison value. Helps to fail fast.
         } else {
             None     // Leave PC uninitialized as cfuncs shouldn't read it
         },


### PR DESCRIPTION
C function frames don't need to use the VM-specific pc field to run
properly. When pushing a control frame from output code, save one
instruction by leaving the field uninitialized.

Fix-up rb_vm_svar_lep(), which is used while setting local variables via
Regexp#=~. Use cfp->iseq as a secondary signal so it can stop assuming
that all CFUNC frames always have zero pc's.
