### PR TITLE
Implement ObjectSpace::WeakMap#delete and ObjectSpace::WeakKeyMap#delete

### DIFF
--- a/spec/ruby/core/objectspace/weakkeymap/delete_spec.rb
+++ b/spec/ruby/core/objectspace/weakkeymap/delete_spec.rb
@@ -1,0 +1,40 @@
+require_relative '../../../spec_helper'
+
+ruby_version_is '3.3' do
+  describe "ObjectSpace::WeakKeyMap#delete" do
+    it "removes the entry and returns the deleted value" do
+      m = ObjectSpace::WeakKeyMap.new
+      key = Object.new
+      value = Object.new
+      m[key] = value
+
+      m.delete(key).should == value
+      m.key?(key).should == false
+    end
+
+    it "uses equality semantic" do
+      m = ObjectSpace::WeakKeyMap.new
+      key = "foo".upcase
+      value = Object.new
+      m[key] = value
+
+      m.delete("foo".upcase).should == value
+      m.key?(key).should == false
+    end
+
+    it "calls supplied block if the key is not found" do
+      key = Object.new
+      m = ObjectSpace::WeakKeyMap.new
+      return_value = m.delete(key) do |yielded_key|
+        yielded_key.should == key
+        5
+      end
+      return_value.should == 5
+    end
+
+    it "returns nil if the key is not found when no block is given" do
+      m = ObjectSpace::WeakMap.new
+      m.delete(Object.new).should == nil
+    end
+  end
+end

--- a/spec/ruby/core/objectspace/weakmap/delete_spec.rb
+++ b/spec/ruby/core/objectspace/weakmap/delete_spec.rb
@@ -1,0 +1,30 @@
+require_relative '../../../spec_helper'
+
+ruby_version_is '3.3' do
+  describe "ObjectSpace::WeakMap#delete" do
+    it "removes the entry and returns the deleted value" do
+      m = ObjectSpace::WeakMap.new
+      key = Object.new
+      value = Object.new
+      m[key] = value
+
+      m.delete(key).should == value
+      m.key?(key).should == false
+    end
+
+    it "calls supplied block if the key is not found" do
+      key = Object.new
+      m = ObjectSpace::WeakMap.new
+      return_value = m.delete(key) do |yielded_key|
+        yielded_key.should == key
+        5
+      end
+      return_value.should == 5
+    end
+
+    it "returns nil if the key is not found when no block is given" do
+      m = ObjectSpace::WeakMap.new
+      m.delete(Object.new).should == nil
+    end
+  end
+end

--- a/test/ruby/test_weakkeymap.rb
+++ b/test/ruby/test_weakkeymap.rb
@@ -33,11 +33,24 @@ class TestWeakKeyMap < Test::Unit::TestCase
   end
 
   def test_key?
-    1.times do
-      assert_weak_include(:key?, "foo")
+    assert_weak_include(:key?, "foo")
+    assert_not_send([@wm, :key?, "bar"])
+  end
+
+  def test_delete
+    k1 = "foo"
+    x1 = Object.new
+    @wm[k1] = x1
+    assert_equal x1, @wm[k1]
+    assert_equal x1, @wm.delete(k1)
+    assert_nil @wm[k1]
+    assert_nil @wm.delete(k1)
+
+    fallback =  @wm.delete(k1) do |key|
+      assert_equal k1, key
+      42
     end
-    GC.start
-    assert_not_send([@wm, :key?, "FOO".downcase])
+    assert_equal 42, fallback
   end
 
   def test_clear

--- a/test/ruby/test_weakmap.rb
+++ b/test/ruby/test_weakmap.rb
@@ -82,6 +82,22 @@ class TestWeakMap < Test::Unit::TestCase
                  @wm.inspect)
   end
 
+  def test_delete
+    k1 = "foo"
+    x1 = Object.new
+    @wm[k1] = x1
+    assert_equal x1, @wm[k1]
+    assert_equal x1, @wm.delete(k1)
+    assert_nil @wm[k1]
+    assert_nil @wm.delete(k1)
+
+    fallback =  @wm.delete(k1) do |key|
+      assert_equal k1, key
+      42
+    end
+    assert_equal 42, fallback
+  end
+
   def test_each
     m = __callee__[/test_(.*)/, 1]
     x1 = Object.new


### PR DESCRIPTION
[[Feature #19561]](https://bugs.ruby-lang.org/issues/19561)

It's useful to be able to remove references from weak maps.

~~Note to self: we don't have specs for `WeakKeyMap`, I need to add some in another PR, then add a spec for `WeakKeyMap#delete` here.~~