### PR TITLE
`nt->serial` for `RUBY_DEBUG_LOG`

### DIFF
--- a/debug.c
+++ b/debug.c
@@ -533,7 +533,9 @@ ruby_debug_log(const char *file, int line, const char *func_name, const char *fm
         len += r;
     }
 
-    if (rb_current_execution_context(false)) {
+    rb_execution_context_t *ec = rb_current_execution_context(false);
+
+    if (ec) {
         // Ruby location
         int ruby_line;
         const char *ruby_file = rb_source_location_cstr(&ruby_line);
@@ -547,22 +549,46 @@ ruby_debug_log(const char *file, int line, const char *func_name, const char *fm
             if (r < 0) rb_bug("ruby_debug_log returns %d\n", r);
             len += r;
         }
+    }
+
+#ifdef RUBY_NT_SERIAL
+    // native thread information
+    if (len < MAX_DEBUG_LOG_MESSAGE_LEN) {
+        r = snprintf(buff + len, MAX_DEBUG_LOG_MESSAGE_LEN - len, "\tnt:%d", ruby_nt_serial);
+        if (r < 0) rb_bug("ruby_debug_log returns %d\n", r);
+        len += r;
+    }
+#endif
+
+    if (ec) {
+        rb_thread_t *th = ec ? rb_ec_thread_ptr(ec) : NULL;
 
         // ractor information
         if (ruby_single_main_ractor == NULL) {
-            rb_ractor_t *cr = GET_RACTOR();
+            rb_ractor_t *cr = th ? th->ractor : NULL;
+
             if (r && len < MAX_DEBUG_LOG_MESSAGE_LEN) {
-                r = snprintf(buff + len, MAX_DEBUG_LOG_MESSAGE_LEN - len, "\tr:#%u/%u",
-                             (unsigned int)rb_ractor_id(cr), GET_VM()->ractor.cnt);
+                r = snprintf(buff + len, MAX_DEBUG_LOG_MESSAGE_LEN - len, "\tr:#%d/%u",
+                             cr ? (int)rb_ractor_id(cr) : -1, GET_VM()->ractor.cnt);
+
                 if (r < 0) rb_bug("ruby_debug_log returns %d\n", r);
                 len += r;
             }
         }
 
         // thread information
-        const rb_thread_t *th = GET_THREAD();
-        if (r && len < MAX_DEBUG_LOG_MESSAGE_LEN) {
-            r = snprintf(buff + len, MAX_DEBUG_LOG_MESSAGE_LEN - len, "\tth:%u", rb_th_serial(th));
+        if (th && r && len < MAX_DEBUG_LOG_MESSAGE_LEN) {
+            rb_execution_context_t *rec = th->ractor ? th->ractor->threads.running_ec : NULL;
+            const rb_thread_t *rth = rec ? rec->thread_ptr : NULL;
+            const rb_thread_t *sth = th->ractor ? th->ractor->threads.sched.running : NULL;
+
+            if (rth != th || sth != th) {
+                r = snprintf(buff + len, MAX_DEBUG_LOG_MESSAGE_LEN - len, "\tth:%u (rth:%d,sth:%d)",
+                             rb_th_serial(th), rth ? (int)rb_th_serial(rth) : -1, sth ? (int)rb_th_serial(sth) : -1);
+            }
+            else {
+                r = snprintf(buff + len, MAX_DEBUG_LOG_MESSAGE_LEN - len, "\tth:%u", rb_th_serial(th));
+            }
             if (r < 0) rb_bug("ruby_debug_log returns %d\n", r);
             len += r;
         }

--- a/thread_pthread.h
+++ b/thread_pthread.h
@@ -26,7 +26,7 @@ struct rb_thread_sched_item {
 };
 
 struct rb_native_thread {
-    int id;
+    rb_atomic_t serial;
 
     rb_nativethread_id_t thread_id;
 
@@ -101,13 +101,17 @@ struct rb_thread_sched {
 
 RUBY_SYMBOL_EXPORT_BEGIN
 #ifdef RB_THREAD_LOCAL_SPECIFIER
-# ifdef __APPLE__
-// on Darwin, TLS can not be accessed across .so
-struct rb_execution_context_struct *rb_current_ec(void);
-void rb_current_ec_set(struct rb_execution_context_struct *);
-# else
-RUBY_EXTERN RB_THREAD_LOCAL_SPECIFIER struct rb_execution_context_struct *ruby_current_ec;
-# endif
+  # ifdef __APPLE__
+    // on Darwin, TLS can not be accessed across .so
+    struct rb_execution_context_struct *rb_current_ec(void);
+    void rb_current_ec_set(struct rb_execution_context_struct *);
+  # else
+    RUBY_EXTERN RB_THREAD_LOCAL_SPECIFIER struct rb_execution_context_struct *ruby_current_ec;
+
+    // for RUBY_DEBUG_LOG()
+    RUBY_EXTERN RB_THREAD_LOCAL_SPECIFIER rb_atomic_t ruby_nt_serial;
+    #define RUBY_NT_SERIAL 1
+  # endif
 #else
 typedef pthread_key_t native_tls_key_t;
 

--- a/vm.c
+++ b/vm.c
@@ -440,6 +440,9 @@ bool ruby_vm_keep_script_lines;
 
 #ifdef RB_THREAD_LOCAL_SPECIFIER
 RB_THREAD_LOCAL_SPECIFIER rb_execution_context_t *ruby_current_ec;
+#ifdef RUBY_NT_SERIAL
+RB_THREAD_LOCAL_SPECIFIER rb_atomic_t ruby_nt_serial;
+#endif
 
 #ifdef __APPLE__
   rb_execution_context_t *


### PR DESCRIPTION
Show native thread's serial on `RUBY_DEBUG_LOG`.
`nt->serial` is also stored into `ruby_nt_serial` if the compiler supports `RB_THREAD_LOCAL_SPECIFIER`.