### PR TITLE
YJIT: Use SCRATCH0 for IncrCounter

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -279,13 +279,9 @@ macro_rules! gen_counter_incr {
             // Get a pointer to the counter variable
             let ptr = ptr_to_counter!($counter_name);
 
-            // Load the pointer into a register
+            // Load and increment the pointer
             $asm.comment(&format!("increment counter {}", stringify!($counter_name)));
-            let ptr_reg = $asm.load(Opnd::const_ptr(ptr as *const u8));
-            let counter_opnd = Opnd::mem(64, ptr_reg, 0);
-
-            // Increment and store the updated value
-            $asm.incr_counter(counter_opnd, Opnd::UImm(1));
+            $asm.incr_counter(Opnd::const_ptr(ptr as *const u8), Opnd::UImm(1));
         }
     };
 }
@@ -572,13 +568,9 @@ fn counted_exit(jit: &mut JITState, ctx: &Context, ocb: &mut OutlinedCb, counter
 
     let mut asm = Assembler::new();
 
-    // Load the pointer into a register
+    // Load and increment the pointer
     asm.comment(&format!("increment counter {}", counter.name));
-    let ptr_reg = asm.load(Opnd::const_ptr(counter.ptr));
-    let counter_opnd = Opnd::mem(64, ptr_reg, 0);
-
-    // Increment and store the updated value
-    asm.incr_counter(counter_opnd, Opnd::UImm(1));
+    asm.incr_counter(Opnd::const_ptr(counter.ptr), Opnd::UImm(1));
 
     // Jump to the existing side exit
     asm.jmp(side_exit);


### PR DESCRIPTION
I'm trying to count the number of stack operand accesses in my stack temp register allocation branch. However, it pressures the `InsnOut` register allocator a lot, and an extra `InsnOut` register used by `IncrCounter` causes spill.

Regardless of my branch, I think it's nice to avoid consuming an extra `InsnOut` register when `--yjit-stats` is enabled. This PR splits `IncrCounter` and uses the `SCRATCH0` register in the backend to load the pointer.