### PR TITLE
YJIT: Add codegen for Array#<<

### DIFF
--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -136,6 +136,7 @@ fn main() {
         .allowlist_function("rb_ary_resurrect")
         .allowlist_function("rb_ary_clear")
         .allowlist_function("rb_ary_dup")
+        .allowlist_function("rb_ary_push")
         .allowlist_function("rb_ary_unshift_m")
         .allowlist_function("rb_yjit_rb_ary_subseq_length")
 

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -1094,6 +1094,7 @@ extern "C" {
     pub fn rb_ary_store(ary: VALUE, key: ::std::os::raw::c_long, val: VALUE);
     pub fn rb_ary_dup(ary: VALUE) -> VALUE;
     pub fn rb_ary_resurrect(ary: VALUE) -> VALUE;
+    pub fn rb_ary_push(ary: VALUE, elem: VALUE) -> VALUE;
     pub fn rb_ary_clear(ary: VALUE) -> VALUE;
     pub fn rb_hash_new() -> VALUE;
     pub fn rb_hash_aref(hash: VALUE, key: VALUE) -> VALUE;


### PR DESCRIPTION
This codegen simply skips pushing a frame when calling `Array#<<`. The interpreter skips it on `opt_ltlt`, so it's fair to do the same thing on YJIT.

Note that we cannot use `Primitive.attr! :leaf` to implement this because BOP methods must be implemented in C at the moment.

### Benchmark
I found this is useful for speeding up Optcarrot when I worked on RJIT. This doesn't speed up headline benchmarks, but this method should be fairly popular in actual real-world applications.

```
before: ruby 3.3.0dev (2023-04-03T15:59:05Z master ba4ff2552e) +YJIT [x86_64-linux]
after: ruby 3.3.0dev (2023-04-03T18:20:37Z yjit-array-push cbf04e0aad) +YJIT [x86_64-linux]

---------  -----------  ----------  ----------  ----------  ------------  -------------
bench      before (ms)  stddev (%)  after (ms)  stddev (%)  before/after  after 1st itr
optcarrot  1823.1       0.8         1757.6      0.7         1.04          1.05
---------  -----------  ----------  ----------  ----------  ------------  -------------
```