### PR TITLE
Suppress warnings on MinGW

### DIFF
--- a/dir.c
+++ b/dir.c
@@ -1277,9 +1277,8 @@ dir_chdir(VALUE dir)
 #if defined(HAVE_FCHDIR) && defined(HAVE_DIRFD) && HAVE_FCHDIR && HAVE_DIRFD
     dir_s_fchdir(rb_cDir, dir_fileno(dir));
 #else
-    struct dir_data *dirp;
-    dirp = dir_get(dir);
-    dir_s_chdir(1, &dirp->path, rb_cDir);
+    VALUE path = dir_get(dir)->path;
+    dir_s_chdir(1, &path, rb_cDir);
 #endif
 
     return Qnil;

--- a/process.c
+++ b/process.c
@@ -506,11 +506,13 @@ get_pid(void)
     return PIDT2NUM(cached_pid);
 }
 
+#if defined HAVE_WORKING_FORK || defined HAVE_DAEMON
 static void
 clear_pid_cache(void)
 {
     cached_pid = 0;
 }
+#endif
 
 /*
  *  call-seq:


### PR DESCRIPTION
```
../src/dir.c: In function 'dir_chdir':
../src/dir.c:1282:20: warning: passing argument 2 of 'dir_s_chdir' discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]        
 1282 |     dir_s_chdir(1, &dirp->path, rb_cDir);
      |                    ^~~~~~~~~~~
../src/dir.c:1093:30: note: expected 'VALUE *' {aka 'long long unsigned int *'} but argument is of type 'const VALUE *' {aka 'const long long unsigned int *'}
 1093 | dir_s_chdir(int argc, VALUE *argv, VALUE obj)
      |                       ~~~~~~~^~~~
```
```
../src/process.c:510:1: warning: 'clear_pid_cache' defined but not used [-Wunused-function]
  510 | clear_pid_cache(void)
      | ^~~~~~~~~~~~~~~
```