### PR TITLE
YJIT: Stack temp register allocation

### DIFF
--- a/.github/workflows/yjit-ubuntu.yml
+++ b/.github/workflows/yjit-ubuntu.yml
@@ -78,6 +78,10 @@ jobs:
             configure: "--enable-yjit=dev"
             yjit_opts: "--yjit-call-threshold=1 --yjit-verify-ctx"
 
+          - test_task: "check"
+            configure: "--enable-yjit=dev"
+            yjit_opts: "--yjit-call-threshold=1 --yjit-temp-regs=5"
+
           - test_task: "test-all TESTS=--repeat-count=2"
             configure: "--enable-yjit=dev"
 

--- a/yjit.rb
+++ b/yjit.rb
@@ -268,6 +268,9 @@ module RubyVM::YJIT
 
       $stderr.puts "iseq_stack_too_large:  " + format_number(13, stats[:iseq_stack_too_large])
       $stderr.puts "iseq_too_long:         " + format_number(13, stats[:iseq_too_long])
+      $stderr.puts "temp_reg_opnd:         " + format_number(13, stats[:temp_reg_opnd])
+      $stderr.puts "temp_mem_opnd:         " + format_number(13, stats[:temp_mem_opnd])
+      $stderr.puts "temp_spill:            " + format_number(13, stats[:temp_spill])
       $stderr.puts "bindings_allocations:  " + format_number(13, stats[:binding_allocations])
       $stderr.puts "bindings_set:          " + format_number(13, stats[:binding_set])
       $stderr.puts "compilation_failure:   " + format_number(13, compilation_failure) if compilation_failure != 0

--- a/yjit/src/backend/arm64/mod.rs
+++ b/yjit/src/backend/arm64/mod.rs
@@ -175,6 +175,13 @@ impl Assembler
         vec![X11_REG, X12_REG, X13_REG]
     }
 
+    /// Get the list of registers that can be used for stack temps.
+    pub fn get_temp_regs() -> Vec<Reg> {
+        // FIXME: arm64 is not supported yet. Insn::Store doesn't support registers
+        // in its dest operand. Currently crashing at split_memory_address.
+        vec![]
+    }
+
     /// Get a list of all of the caller-saved registers
     pub fn get_caller_save_regs() -> Vec<Reg> {
         vec![X9_REG, X10_REG, X11_REG, X12_REG, X13_REG, X14_REG, X15_REG]
@@ -1046,7 +1053,9 @@ impl Assembler
                 Insn::CSelGE { truthy, falsy, out } => {
                     csel(cb, out.into(), truthy.into(), falsy.into(), Condition::GE);
                 }
-                Insn::LiveReg { .. } => (), // just a reg alloc signal, no code
+                Insn::LiveReg { .. } |
+                Insn::RegTemps(_) |
+                Insn::SpillTemp(_) => (), // just a reg alloc signal, no code
                 Insn::PadInvalPatch => {
                     while (cb.get_write_pos().saturating_sub(std::cmp::max(start_write_pos, cb.page_start_pos()))) < JMP_PTR_BYTES && !cb.has_dropped_bytes() {
                         nop(cb);

--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -10,8 +10,9 @@ use std::mem::take;
 use crate::cruby::{VALUE, SIZEOF_VALUE_I32};
 use crate::virtualmem::{CodePtr};
 use crate::asm::{CodeBlock, uimm_num_bits, imm_num_bits};
-use crate::core::{Context, Type, TempMapping};
+use crate::core::{Context, Type, TempMapping, RegTemps, MAX_REG_TEMPS, MAX_TEMP_TYPES};
 use crate::options::*;
+use crate::stats::*;
 
 #[cfg(target_arch = "x86_64")]
 use crate::backend::x86_64::*;
@@ -73,7 +74,7 @@ pub enum Opnd
     InsnOut{ idx: usize, num_bits: u8 },
 
     // Pointer to a slot on the VM stack
-    Stack { idx: i32, sp_offset: i8, num_bits: u8 },
+    Stack { idx: i32, stack_size: u8, sp_offset: i8, num_bits: u8 },
 
     // Low-level operands, for lowering
     Imm(i64),           // Raw signed immediate
@@ -162,7 +163,7 @@ impl Opnd
             Opnd::Reg(reg) => Some(Opnd::Reg(reg.with_num_bits(num_bits))),
             Opnd::Mem(Mem { base, disp, .. }) => Some(Opnd::Mem(Mem { base, disp, num_bits })),
             Opnd::InsnOut { idx, .. } => Some(Opnd::InsnOut { idx, num_bits }),
-            Opnd::Stack { idx, sp_offset, .. } => Some(Opnd::Stack { idx, sp_offset, num_bits }),
+            Opnd::Stack { idx, stack_size, sp_offset, .. } => Some(Opnd::Stack { idx, stack_size, sp_offset, num_bits }),
             _ => None,
         }
     }
@@ -215,6 +216,26 @@ impl Opnd
     /// them are different sizes this will panic.
     pub fn match_num_bits(opnds: &[Opnd]) -> u8 {
         Self::match_num_bits_iter(opnds.iter())
+    }
+
+    /// Calculate Opnd::Stack's index from the stack bottom.
+    pub fn stack_idx(&self) -> u8 {
+        match self {
+            Opnd::Stack { idx, stack_size, .. } => {
+                (*stack_size as isize - *idx as isize - 1) as u8
+            },
+            _ => unreachable!(),
+        }
+    }
+
+    /// Get the index for stack temp registers.
+    pub fn reg_idx(&self) -> usize {
+        match self {
+            Opnd::Stack { .. } => {
+                self.stack_idx() as usize % get_option!(num_temp_regs)
+            },
+            _ => unreachable!(),
+        }
     }
 }
 
@@ -408,6 +429,9 @@ pub enum Insn {
     /// Take a specific register. Signal the register allocator to not use it.
     LiveReg { opnd: Opnd, out: Opnd },
 
+    /// Update live stack temps without spill
+    RegTemps(RegTemps),
+
     // A low-level instruction that loads a value into a register.
     Load { opnd: Opnd, out: Opnd },
 
@@ -442,6 +466,9 @@ pub enum Insn {
 
     /// Shift a value right by a certain amount (signed).
     RShift { opnd: Opnd, shift: Opnd, out: Opnd },
+
+    /// Spill a stack temp from a register into memory
+    SpillTemp(Opnd),
 
     // Low-level instruction to store a value to memory.
     Store { dest: Opnd, src: Opnd },
@@ -514,6 +541,7 @@ impl Insn {
             Insn::LeaLabel { .. } => "LeaLabel",
             Insn::Lea { .. } => "Lea",
             Insn::LiveReg { .. } => "LiveReg",
+            Insn::RegTemps(_) => "RegTemps",
             Insn::Load { .. } => "Load",
             Insn::LoadInto { .. } => "LoadInto",
             Insn::LoadSExt { .. } => "LoadSExt",
@@ -524,6 +552,7 @@ impl Insn {
             Insn::PadInvalPatch => "PadEntryExit",
             Insn::PosMarker(_) => "PosMarker",
             Insn::RShift { .. } => "RShift",
+            Insn::SpillTemp(_) => "SpillTemp",
             Insn::Store { .. } => "Store",
             Insn::Sub { .. } => "Sub",
             Insn::Test { .. } => "Test",
@@ -658,6 +687,7 @@ impl<'a> Iterator for InsnOpndIterator<'a> {
             Insn::Jz(_) |
             Insn::Label(_) |
             Insn::LeaLabel { .. } |
+            Insn::RegTemps(_) |
             Insn::PadInvalPatch |
             Insn::PosMarker(_) => None,
             Insn::CPopInto(opnd) |
@@ -668,7 +698,8 @@ impl<'a> Iterator for InsnOpndIterator<'a> {
             Insn::LiveReg { opnd, .. } |
             Insn::Load { opnd, .. } |
             Insn::LoadSExt { opnd, .. } |
-            Insn::Not { opnd, .. } => {
+            Insn::Not { opnd, .. } |
+            Insn::SpillTemp(opnd) => {
                 match self.idx {
                     0 => {
                         self.idx += 1;
@@ -755,6 +786,7 @@ impl<'a> InsnOpndMutIterator<'a> {
             Insn::Jz(_) |
             Insn::Label(_) |
             Insn::LeaLabel { .. } |
+            Insn::RegTemps(_) |
             Insn::PadInvalPatch |
             Insn::PosMarker(_) => None,
             Insn::CPopInto(opnd) |
@@ -765,7 +797,8 @@ impl<'a> InsnOpndMutIterator<'a> {
             Insn::LiveReg { opnd, .. } |
             Insn::Load { opnd, .. } |
             Insn::LoadSExt { opnd, .. } |
-            Insn::Not { opnd, .. } => {
+            Insn::Not { opnd, .. } |
+            Insn::SpillTemp(opnd) => {
                 match self.idx {
                     0 => {
                         self.idx += 1;
@@ -857,6 +890,10 @@ pub struct Assembler
     /// Index of the last insn using the output of this insn
     pub(super) live_ranges: Vec<usize>,
 
+    /// Parallel vec with insns
+    /// Bitmap of which temps are in a register for this insn
+    pub(super) reg_temps: Vec<RegTemps>,
+
     /// Names of labels
     pub(super) label_names: Vec<String>,
 }
@@ -871,6 +908,7 @@ impl Assembler
         Self {
             insns: Vec::default(),
             live_ranges: Vec::default(),
+            reg_temps: Vec::default(),
             label_names
         }
     }
@@ -905,8 +943,33 @@ impl Assembler
             }
         }
 
+        // Update live stack temps for this instruction
+        let mut reg_temps = self.get_reg_temps();
+        match insn {
+            Insn::RegTemps(next_temps) => {
+                reg_temps = next_temps;
+            }
+            Insn::SpillTemp(opnd) => {
+                assert_eq!(reg_temps.get(opnd.stack_idx()), true);
+                reg_temps.set(opnd.stack_idx(), false);
+            }
+            _ => {}
+        }
+        // Assert no conflict
+        for stack_idx in 0..MAX_REG_TEMPS {
+            if reg_temps.get(stack_idx) {
+                assert!(!reg_temps.conflicts_with(stack_idx));
+            }
+        }
+
         self.insns.push(insn);
         self.live_ranges.push(insn_idx);
+        self.reg_temps.push(reg_temps);
+    }
+
+    /// Get stack temps that are currently in a register
+    pub fn get_reg_temps(&self) -> RegTemps {
+        *self.reg_temps.last().unwrap_or(&RegTemps::default())
     }
 
     /// Create a new label instance that we can jump to
@@ -922,20 +985,111 @@ impl Assembler
     /// Convert Stack operands to memory operands
     pub fn lower_stack(mut self) -> Assembler
     {
+        // Convert Opnd::Stack to Opnd::Mem
+        fn mem_opnd(opnd: &Opnd) -> Opnd {
+            if let Opnd::Stack { idx, sp_offset, num_bits, .. } = *opnd {
+                incr_counter!(temp_mem_opnd);
+                Opnd::mem(num_bits, SP, (sp_offset as i32 - idx - 1) * SIZEOF_VALUE_I32)
+            } else {
+                unreachable!()
+            }
+        }
+
+        // Convert Opnd::Stack to Opnd::Reg
+        fn reg_opnd(opnd: &Opnd, regs: &Vec<Reg>) -> Opnd {
+            if let Opnd::Stack { num_bits, .. } = *opnd {
+                incr_counter!(temp_reg_opnd);
+                Opnd::Reg(regs[opnd.reg_idx()]).with_num_bits(num_bits).unwrap()
+            } else {
+                unreachable!()
+            }
+        }
+
         let mut asm = Assembler::new_with_label_names(take(&mut self.label_names));
+        let regs = Assembler::get_temp_regs();
+        let reg_temps = take(&mut self.reg_temps);
         let mut iterator = self.into_draining_iter();
 
-        while let Some((index, mut insn)) = iterator.next_unmapped() {
-            let mut opnd_iter = insn.opnd_iter_mut();
-            while let Some(opnd) = opnd_iter.next() {
-                if let Opnd::Stack { idx, sp_offset, num_bits } = *opnd {
-                    *opnd = Opnd::mem(num_bits, SP, (sp_offset as i32 - idx - 1) * SIZEOF_VALUE_I32);
+        while let Some((index, mut insn)) = iterator.next_mapped() {
+            match &insn {
+                // The original insn is pushed to the new asm to satisfy ccall's reg_temps assertion.
+                Insn::RegTemps(_) => {} // noop
+                Insn::SpillTemp(opnd) => {
+                    incr_counter!(temp_spill);
+                    asm.mov(mem_opnd(opnd), reg_opnd(opnd, &regs));
+                }
+                _ => {
+                    // next_mapped() doesn't map out_opnd. So we need to map it here.
+                    if insn.out_opnd().is_some() {
+                        let out_num_bits = Opnd::match_num_bits_iter(insn.opnd_iter());
+                        let out = insn.out_opnd_mut().unwrap();
+                        *out = asm.next_opnd_out(out_num_bits);
+                    }
+
+                    // Lower Opnd::Stack to Opnd::Reg or Opnd::Mem
+                    let mut opnd_iter = insn.opnd_iter_mut();
+                    while let Some(opnd) = opnd_iter.next() {
+                        if let Opnd::Stack { idx, stack_size, sp_offset, num_bits } = *opnd {
+                            *opnd = if opnd.stack_idx() < MAX_REG_TEMPS && reg_temps[index].get(opnd.stack_idx()) {
+                                reg_opnd(opnd, &regs)
+                            } else {
+                                mem_opnd(opnd)
+                            };
+                        }
+                    }
                 }
             }
             asm.push_insn(insn);
+            iterator.map_insn_index(&mut asm);
         }
 
         asm
+    }
+
+    /// Allocate a register to a stack temp if available.
+    pub fn alloc_temp_reg(&mut self, ctx: &mut Context, stack_idx: u8) {
+        if get_option!(num_temp_regs) == 0 {
+            return;
+        }
+
+        assert_eq!(self.get_reg_temps(), ctx.get_reg_temps());
+        let mut reg_temps = self.get_reg_temps();
+
+        // Allocate a register if there's no conflict.
+        if reg_temps.conflicts_with(stack_idx) {
+            assert!(!reg_temps.get(stack_idx));
+        } else {
+            reg_temps.set(stack_idx, true);
+            self.set_reg_temps(reg_temps);
+            ctx.set_reg_temps(reg_temps);
+        }
+    }
+
+    /// Spill all live stack temps from registers to the stack
+    pub fn spill_temps(&mut self, ctx: &mut Context) {
+        assert_eq!(self.get_reg_temps(), ctx.get_reg_temps());
+
+        // Forget registers above the stack top
+        let mut reg_temps = self.get_reg_temps();
+        for stack_idx in ctx.get_stack_size()..MAX_REG_TEMPS {
+            reg_temps.set(stack_idx, false);
+        }
+        self.set_reg_temps(reg_temps);
+
+        // Spill live stack temps
+        if self.get_reg_temps() != RegTemps::default() {
+            self.comment(&format!("spill_temps: {:08b} -> {:08b}", self.get_reg_temps().as_u8(), RegTemps::default().as_u8()));
+            for stack_idx in 0..u8::min(MAX_REG_TEMPS, ctx.get_stack_size()) {
+                if self.get_reg_temps().get(stack_idx) {
+                    let idx = ctx.get_stack_size() - 1 - stack_idx;
+                    self.spill_temp(ctx.stack_opnd(idx.into()));
+                }
+            }
+        }
+
+        // Every stack temp should have been spilled
+        assert_eq!(self.get_reg_temps(), RegTemps::default());
+        ctx.set_reg_temps(self.get_reg_temps());
     }
 
     /// Sets the out field on the various instructions that require allocated
@@ -1318,6 +1472,7 @@ impl Assembler {
     }
 
     pub fn ccall(&mut self, fptr: *const u8, opnds: Vec<Opnd>) -> Opnd {
+        assert_eq!(self.get_reg_temps(), RegTemps::default(), "temps must be spilled before ccall");
         let out = self.next_opnd_out(Opnd::match_num_bits(&opnds));
         self.push_insn(Insn::CCall { fptr, opnds, out });
         out
@@ -1543,6 +1698,20 @@ impl Assembler {
         let out = self.next_opnd_out(Opnd::match_num_bits(&[opnd, shift]));
         self.push_insn(Insn::RShift { opnd, shift, out });
         out
+    }
+
+    /// Update which stack temps are in a register
+    pub fn set_reg_temps(&mut self, reg_temps: RegTemps) {
+        if self.get_reg_temps() != reg_temps {
+            self.comment(&format!("reg_temps: {:08b} -> {:08b}", self.get_reg_temps().as_u8(), reg_temps.as_u8()));
+            self.push_insn(Insn::RegTemps(reg_temps));
+        }
+    }
+
+    /// Spill a stack temp from a register to the stack
+    pub fn spill_temp(&mut self, opnd: Opnd) {
+        assert!(self.get_reg_temps().get(opnd.stack_idx()));
+        self.push_insn(Insn::SpillTemp(opnd));
     }
 
     pub fn store(&mut self, dest: Opnd, src: Opnd) {

--- a/yjit/src/options.rs
+++ b/yjit/src/options.rs
@@ -22,6 +22,9 @@ pub struct Options {
     // 1 means always create generic versions
     pub max_versions: usize,
 
+    // The number of registers allocated for stack temps
+    pub num_temp_regs: usize,
+
     // Capture and print out stats
     pub gen_stats: bool,
 
@@ -52,6 +55,7 @@ pub static mut OPTIONS: Options = Options {
     greedy_versioning: false,
     no_type_prop: false,
     max_versions: 4,
+    num_temp_regs: 0,
     gen_stats: false,
     gen_trace_exits: false,
     pause: false,
@@ -139,6 +143,13 @@ pub fn parse_option(str_ptr: *const std::os::raw::c_char) -> Option<()> {
 
         ("pause", "") => unsafe {
             OPTIONS.pause = true;
+        },
+
+        ("temp-regs", _) => match opt_val.parse() {
+            Ok(n) => unsafe { OPTIONS.num_temp_regs = n },
+            Err(_) => {
+                return None;
+            }
         },
 
         ("dump-disasm", _) => match opt_val.to_string().as_str() {

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -352,6 +352,11 @@ make_counters! {
 
     iseq_stack_too_large,
     iseq_too_long,
+
+    temp_reg_opnd,
+    temp_mem_opnd,
+    temp_spill,
+    temp_reload,
 }
 
 //===========================================================================

--- a/yjit/yjit.mk
+++ b/yjit/yjit.mk
@@ -92,8 +92,7 @@ yjit-smoke-test:
 ifneq ($(strip $(CARGO)),)
 	$(CARGO) test --all-features -q --manifest-path='$(top_srcdir)/yjit/Cargo.toml'
 endif
-	$(MAKE) btest RUN_OPTS='--yjit-call-threshold=1' BTESTS=-j
-	$(MAKE) test-all TESTS='$(top_srcdir)/test/ruby/test_yjit.rb'
+	$(MAKE) btest RUN_OPTS='--yjit-call-threshold=1 --yjit-temp-regs=5' BTESTS=-j
 
 # Generate Rust bindings. See source for details.
 # Needs `./configure --enable-yjit=dev` and Clang.


### PR DESCRIPTION
This PR implements register allocation for stack temps. It currently works only on x86_64 and I'm working on arm64 support, but I'm filing this now to reduce the risks of conflict first.

# Design
* Use 5 caller-saved registers for stack temps on x86_64.
  * They are used only for stack temps for now, but we could share it with `Opnd::InsnOut` in the future.
  * They conflict with registers used for C call arguments, so `asm.ccall` asserts that no register is allocated to stack temps at the time.
* Share the 5 registers among 8 stack temps, assigned by modulo
  * `reg_idx = stack_idx % num_regs`. So, given 5 registers, `stack[0]` and `stack[5]` share the same register.
  * If a register is already allocated to a conflicting stack temp, simply skip allocating a register to a new stack temp.
* Spill registers before C calls, method calls, and side exits.
  * C calls: Argument registers conflict, and we need values on stack for GC. This also covers the case that an argument is a `VALUE *` pointing to the stack.
  * Method calls: It doesn't perform cross-method register allocation. A caller and the caller want to use the same register for stack temp 0, for example.
  * Side exits: Values must be on stack before returning to the interpreter.
* Branch stubs spill registers only in the branch stub code and preserve register mapping.
  * We push/pop registers for calling branch_stub_hit. In a branch stub, registers are spilled for `jit.peek_at_stack`, but they're reloaded by pop instructions and the next block can use registers again.
* `--yjit-temp-regs` to control the number of assigned registers
  * You can use `--yjit-temp-regs=5` to enable this feature, and `--yjit-temp-regs=0` to disable this feature.
  * Using `--yjit-temp-regs=0` by default at least until we implement arm64 support.

# Benchmark
Here's the current performance:

## Headline

```

regs=0: ruby 3.3.0dev (2023-04-04T16:27:22Z yjit-stack-temps 0fa81a7fe6) +YJIT [x86_64-linux]
regs=5: ruby 3.3.0dev (2023-04-04T16:27:22Z yjit-stack-temps 0fa81a7fe6) +YJIT [x86_64-linux]

-------------  -----------  ----------  -----------  ----------  -------------  --------------
bench          regs=0 (ms)  stddev (%)  regs=5 (ms)  stddev (%)  regs=0/regs=5  regs=5 1st itr
activerecord   34.0         0.5         32.5         0.5         1.05           0.94
erubi_rails    11.2         15.6        11.1         11.6        1.01           0.72
hexapdf        1391.7       1.2         1332.0       1.9         1.04           0.97
liquid-c       40.8         2.5         39.8         2.6         1.03           0.85
liquid-render  74.7         2.2         71.9         2.4         1.04           0.88
mail           91.5         0.3         88.3         0.6         1.04           0.87
psych-load     1227.2       0.1         1209.7       0.2         1.01           1.01
railsbench     1240.9       1.5         1232.5       1.6         1.01           0.94
ruby-lsp       41.3         26.6        40.8         32.4        1.01           0.84
sequel         50.9         0.3         51.1         0.3         0.99           0.98
-------------  -----------  ----------  -----------  ----------  -------------  --------------
```

## Other

```
regs=0: ruby 3.3.0dev (2023-04-04T16:27:22Z yjit-stack-temps 0fa81a7fe6) +YJIT [x86_64-linux]
regs=5: ruby 3.3.0dev (2023-04-04T16:27:22Z yjit-stack-temps 0fa81a7fe6) +YJIT [x86_64-linux]

-------------  -----------  ----------  -----------  ----------  -------------  --------------
bench          regs=0 (ms)  stddev (%)  regs=5 (ms)  stddev (%)  regs=0/regs=5  regs=5 1st itr
binarytrees    150.9        0.3         135.8        0.5         1.11           1.10
chunky_png     399.4        0.1         367.6        0.1         1.09           1.05
erubi          158.1        1.0         158.1        1.2         1.00           1.00
etanni         253.5        0.8         253.7        0.8         1.00           1.01
fannkuchredux  612.8        0.2         471.5        0.4         1.30           1.00
lee            556.3        1.1         527.6        1.3         1.05           1.04
nbody          46.0         0.4         43.5         0.3         1.06           1.03
optcarrot      1764.7       0.8         1545.5       0.5         1.14           1.11
ruby-json      2462.0       0.1         2459.4       0.0         1.00           1.00
rubykon        4834.7       0.3         4472.3       0.4         1.08           1.08
-------------  -----------  ----------  -----------  ----------  -------------  --------------
```

## Micro
```
regs=0: ruby 3.3.0dev (2023-04-04T16:27:22Z yjit-stack-temps 0fa81a7fe6) +YJIT [x86_64-linux]
regs=5: ruby 3.3.0dev (2023-04-04T16:27:22Z yjit-stack-temps 0fa81a7fe6) +YJIT [x86_64-linux]

--------------  -----------  ----------  -----------  ----------  -------------  --------------
bench           regs=0 (ms)  stddev (%)  regs=5 (ms)  stddev (%)  regs=0/regs=5  regs=5 1st itr
30k_ifelse      265.8        0.1         240.3        0.3         1.11           0.77
30k_methods     535.9        0.1         535.1        0.1         1.00           0.90
cfunc_itself    23.0         1.9         23.1         2.1         1.00           1.11
fib             50.4         0.4         31.2         2.5         1.61           1.66
getivar         60.8         12.6        10.2         93.7        5.97           1.00
keyword_args    39.1         0.5         43.0         0.8         0.91           0.90
respond_to      20.2         0.6         14.1         0.9         1.43           1.29
setivar         10.5         47.3        8.9          52.7        1.19           0.90
setivar_object  36.5         16.3        34.7         17.7        1.05           1.07
setivar_young   36.8         21.0        35.1         21.8        1.05           1.08
str_concat      25.9         1.3         24.1         1.4         1.07           1.07
throw           14.7         0.2         14.6         0.3         1.01           1.00
--------------  -----------  ----------  -----------  ----------  -------------  --------------
```

<details>
<summary>Code size stats on railsbench and liquid-c</summary>

## railsbench
### before (regs=0)
```
inline_code_size:          2,272,690
outlined_code_size:        2,271,540
code_region_size:          4,550,656
```

### after (regs=5)
```
inline_code_size:          2,276,717
outlined_code_size:        2,276,130
code_region_size:          4,554,752
```

## liquid-c
### before (regs=0)
```
inline_code_size:            400,811
outlined_code_size:          398,227
code_region_size:            802,816
```

### after (regs=5)
```
inline_code_size:            403,570
outlined_code_size:          403,624
code_region_size:            815,104
```

</details>