### PR TITLE
Move `catch_except_p` to `compile_data`

### DIFF
--- a/iseq.c
+++ b/iseq.c
@@ -2306,7 +2306,6 @@ rb_iseq_disasm_recursive(const rb_iseq_t *iseq, VALUE indent)
     rb_str_cat2(str, "== disasm: ");
 
     rb_str_append(str, iseq_inspect(iseq));
-    rb_str_catf(str, " (catch: %s)", body->catch_except_p ? "true" : "false");
     if ((l = RSTRING_LEN(str) - indent_len) < header_minlen) {
         rb_str_modify_expand(str, header_minlen - l);
         memset(RSTRING_END(str), '=', header_minlen - l);

--- a/iseq.h
+++ b/iseq.h
@@ -126,6 +126,7 @@ struct iseq_compile_data {
     struct rb_id_table *ivar_cache_table;
     const struct rb_builtin_function *builtin_function_table;
     const NODE *root_node;
+    bool catch_except_p; // If a frame of this ISeq may catch exception, set true.
 #if OPT_SUPPORT_JOKE
     st_table *labels_table;
 #endif

--- a/rjit_c.rb
+++ b/rjit_c.rb
@@ -1159,7 +1159,6 @@ module RubyVM::RJIT # :nodoc: all
       icvarc_size: [CType::Immediate.parse("unsigned int"), Primitive.cexpr!("OFFSETOF((*((struct rb_iseq_constant_body *)NULL)), icvarc_size)")],
       ci_size: [CType::Immediate.parse("unsigned int"), Primitive.cexpr!("OFFSETOF((*((struct rb_iseq_constant_body *)NULL)), ci_size)")],
       stack_max: [CType::Immediate.parse("unsigned int"), Primitive.cexpr!("OFFSETOF((*((struct rb_iseq_constant_body *)NULL)), stack_max)")],
-      catch_except_p: [self._Bool, Primitive.cexpr!("OFFSETOF((*((struct rb_iseq_constant_body *)NULL)), catch_except_p)")],
       builtin_attrs: [CType::Immediate.parse("unsigned int"), Primitive.cexpr!("OFFSETOF((*((struct rb_iseq_constant_body *)NULL)), builtin_attrs)")],
       mark_bits: [CType::Union.new(
         "", Primitive.cexpr!("SIZEOF(((struct rb_iseq_constant_body *)NULL)->mark_bits)"),
@@ -1599,10 +1598,6 @@ module RubyVM::RJIT # :nodoc: all
     CType::Stub.new(:rb_snum_t)
   end
 
-  def C._Bool
-    CType::Bool.new
-  end
-
   def C.iseq_bits_t
     CType::Stub.new(:iseq_bits_t)
   end
@@ -1629,6 +1624,10 @@ module RubyVM::RJIT # :nodoc: all
 
   def C.rb_method_refined_t
     CType::Stub.new(:rb_method_refined_t)
+  end
+
+  def C._Bool
+    CType::Bool.new
   end
 
   def C.ccan_list_node

--- a/vm_core.h
+++ b/vm_core.h
@@ -496,7 +496,6 @@ struct rb_iseq_constant_body {
     unsigned int ci_size;
     unsigned int stack_max; /* for stack overflow check */
 
-    bool catch_except_p; // If a frame of this ISeq may catch exception, set true.
     unsigned int builtin_attrs; // Union of rb_builtin_attr
 
     union {


### PR DESCRIPTION
The `catch_except_p` flag is used for communicating between parent and child iseq's that a throw instruction was emitted. So for example if a child iseq has a throw in it and the parent wants to catch the throw, we use this flag to communicate to the parent iseq that a throw instruction was emitted.

This flag is only useful at compile time, it only impacts the compilation process so it seems to be fine to move it from the iseq body to the compile_data struct.

cc/ @tenderlove