### PR TITLE
[Feature #19579] Remove !USE_RVARGC code

### DIFF
--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -175,8 +175,6 @@ jobs:
 #         - { name: USE_THREAD_CACHE=0,             env: { cppflags: '-DUSE_THREAD_CACHE=0' } }
 #         - { name: USE_TRANSIENT_HEAP=0,           env: { cppflags: '-DUSE_TRANSIENT_HEAP=0' } }
           - { name: USE_RUBY_DEBUG_LOG=1,           env: { cppflags: '-DUSE_RUBY_DEBUG_LOG=1' } }
-          - { name: USE_RVARGC=0,                   env: { cppflags: '-DUSE_RVARGC=0' } }
-#         - { name: USE_RVARGC=1,                   env: { cppflags: '-DUSE_RVARGC=1' } }
 #         - { name: USE_DEBUG_COUNTER,              env: { cppflags: '-DUSE_DEBUG_COUNTER=1', RUBY_DEBUG_COUNTER_DISABLE: '1' } }
 
           - { name: DEBUG_FIND_TIME_NUMGUESS,       env: { cppflags: '-DDEBUG_FIND_TIME_NUMGUESS' } }

--- a/debug.c
+++ b/debug.c
@@ -53,14 +53,8 @@ const union {
     rb_econv_result_t           econv_result;
     enum ruby_preserved_encindex encoding_index;
     enum ruby_robject_flags     robject_flags;
-#if !USE_RVARGC
-    enum ruby_robject_consts    robject_consts;
-#endif
     enum ruby_rmodule_flags     rmodule_flags;
     enum ruby_rstring_flags     rstring_flags;
-#if !USE_RVARGC
-    enum ruby_rstring_consts    rstring_consts;
-#endif
     enum ruby_rarray_flags      rarray_flags;
     enum ruby_rarray_consts     rarray_consts;
     enum {

--- a/ext/-test-/string/cstr.c
+++ b/ext/-test-/string/cstr.c
@@ -62,12 +62,7 @@ bug_str_unterminated_substring(VALUE str, VALUE vbeg, VALUE vlen)
     if (RSTRING_LEN(str) < beg + len) rb_raise(rb_eIndexError, "end: %ld", beg + len);
     str = rb_str_new_shared(str);
     if (STR_EMBED_P(str)) {
-#if USE_RVARGC
         RSTRING(str)->as.embed.len = (short)len;
-#else
-        RSTRING(str)->basic.flags &= ~RSTRING_EMBED_LEN_MASK;
-        RSTRING(str)->basic.flags |= len << RSTRING_EMBED_LEN_SHIFT;
-#endif
         memmove(RSTRING(str)->as.embed.ary, RSTRING(str)->as.embed.ary + beg, len);
     }
     else {
@@ -116,11 +111,7 @@ bug_str_s_cstr_noembed(VALUE self, VALUE str)
     Check_Type(str, T_STRING);
     FL_SET((str2), STR_NOEMBED);
     memcpy(buf, RSTRING_PTR(str), capacity);
-#if USE_RVARGC
     RBASIC(str2)->flags &= ~(STR_SHARED | FL_USER5 | FL_USER6);
-#else
-    RBASIC(str2)->flags &= ~RSTRING_EMBED_LEN_MASK;
-#endif
     RSTRING(str2)->as.heap.aux.capa = capacity;
     RSTRING(str2)->as.heap.ptr = buf;
     RSTRING(str2)->as.heap.len = RSTRING_LEN(str);

--- a/include/ruby/internal/config.h
+++ b/include/ruby/internal/config.h
@@ -148,8 +148,4 @@
 # undef RBIMPL_TEST3
 #endif /* HAVE_VA_ARGS_MACRO */
 
-#ifndef USE_RVARGC
-# define USE_RVARGC 1
-#endif
-
 #endif /* RBIMPL_CONFIG_H */

--- a/include/ruby/internal/core/rarray.h
+++ b/include/ruby/internal/core/rarray.h
@@ -130,12 +130,8 @@ enum ruby_rarray_flags {
      * 3rd parties must  not be aware that  there even is more than  one way to
      * store array elements.  It was a bad idea to expose this to them.
      */
-#if USE_RVARGC
     RARRAY_EMBED_LEN_MASK  = RUBY_FL_USER9 | RUBY_FL_USER8 | RUBY_FL_USER7 | RUBY_FL_USER6 |
                                  RUBY_FL_USER5 | RUBY_FL_USER4 | RUBY_FL_USER3
-#else
-    RARRAY_EMBED_LEN_MASK  = RUBY_FL_USER4 | RUBY_FL_USER3
-#endif
 
 #if USE_TRANSIENT_HEAP
     ,
@@ -163,13 +159,6 @@ enum ruby_rarray_flags {
 enum ruby_rarray_consts {
     /** Where ::RARRAY_EMBED_LEN_MASK resides. */
     RARRAY_EMBED_LEN_SHIFT = RUBY_FL_USHIFT + 3
-
-#if !USE_RVARGC
-    ,
-
-    /** Max possible number elements that can be embedded. */
-    RARRAY_EMBED_LEN_MAX   = RBIMPL_EMBED_LEN_MAX_OF(VALUE)
-#endif
 };
 
 /** Ruby's array. */
@@ -228,16 +217,12 @@ struct RArray {
          * to store its elements.  In this  case the length is encoded into the
          * flags.
          */
-#if USE_RVARGC
         /* This is a length 1 array because:
          *   1. GCC has a bug that does not optimize C flexible array members
          *      (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=102452)
          *   2. Zero length arrays are not supported by all compilers
          */
         const VALUE ary[1];
-#else
-        const VALUE ary[RARRAY_EMBED_LEN_MAX];
-#endif
     } as;
 };
 

--- a/include/ruby/internal/core/robject.h
+++ b/include/ruby/internal/core/robject.h
@@ -74,17 +74,6 @@ enum ruby_robject_flags {
     ROBJECT_EMBED = RUBY_FL_USER1
 };
 
-#if !USE_RVARGC
-/**
- * This is an enum because GDB wants it (rather than a macro).  People need not
- * bother.
- */
-enum ruby_robject_consts {
-    /** Max possible number of instance variables that can be embedded. */
-    ROBJECT_EMBED_LEN_MAX = RBIMPL_EMBED_LEN_MAX_OF(VALUE)
-};
-#endif
-
 struct st_table;
 
 /**
@@ -118,7 +107,6 @@ struct RObject {
             struct rb_id_table *iv_index_tbl;
         } heap;
 
-#if USE_RVARGC
         /* Embedded instance variables. When an object is small enough, it
          * uses this area to store the instance variables.
          *
@@ -128,13 +116,6 @@ struct RObject {
          *   2. Zero length arrays are not supported by all compilers
          */
         VALUE ary[1];
-#else
-        /**
-        * Embedded instance  variables.  When  an object  is small  enough, it
-        * uses this area to store the instance variables.
-        */
-        VALUE ary[ROBJECT_EMBED_LEN_MAX];
-#endif
     } as;
 };
 

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -190,7 +190,7 @@ struct rb_objspace; /* in vm_core.h */
 // We use SIZE_POOL_COUNT number of shape IDs for transitions out of different size pools
 // The next available shape ID will be the SPECIAL_CONST_SHAPE_ID
 #ifndef SIZE_POOL_COUNT
-# if USE_RVARGC && (SIZEOF_UINT64_T == SIZEOF_VALUE)
+# if (SIZEOF_UINT64_T == SIZEOF_VALUE)
 #  define SIZE_POOL_COUNT 5
 # else
 #  define SIZE_POOL_COUNT 1

--- a/lib/ruby_vm/rjit/insn_compiler.rb
+++ b/lib/ruby_vm/rjit/insn_compiler.rb
@@ -2938,7 +2938,6 @@ module RubyVM::RJIT
     def jit_rb_str_empty_p(jit, ctx, asm, argc, known_recv_class)
       # Assume same offset to len embedded or not so we can use one code path to read the length
       #assert_equal(C.RString.offsetof(:as, :heap, :len), C.RString.offsetof(:as, :embed, :len))
-      # `C.RString.offsetof(:as, :embed, :len)` doesn't work because of USE_RVARGC=0 CI
 
       recv_opnd = ctx.stack_pop(1)
       out_opnd = ctx.stack_push(Type::UnknownImm)

--- a/rjit_c.rb
+++ b/rjit_c.rb
@@ -857,6 +857,11 @@ module RubyVM::RJIT # :nodoc: all
             shared: self.VALUE,
           ), Primitive.cexpr!("OFFSETOF(((struct RString *)NULL)->as.heap, aux)")],
         ),
+        embed: CType::Struct.new(
+          "", Primitive.cexpr!("SIZEOF(((struct RString *)NULL)->as.embed)"),
+          len: [CType::Immediate.parse("long"), Primitive.cexpr!("OFFSETOF(((struct RString *)NULL)->as.embed, len)")],
+          ary: [CType::Pointer.new { CType::Immediate.parse("char") }, Primitive.cexpr!("OFFSETOF(((struct RString *)NULL)->as.embed, ary)")],
+        ),
       ), Primitive.cexpr!("OFFSETOF((*((struct RString *)NULL)), as)")],
     )
   end

--- a/ruby.c
+++ b/ruby.c
@@ -549,12 +549,8 @@ static VALUE
 runtime_libruby_path(void)
 {
 #if defined _WIN32 || defined __CYGWIN__
-    DWORD len, ret;
-#if USE_RVARGC
-    len = 32;
-#else
-    len = RSTRING_EMBED_LEN_MAX;
-#endif
+    DWORD ret;
+    DWORD len = 32;
     VALUE path;
     VALUE wsopath = rb_str_new(0, len*sizeof(WCHAR));
     WCHAR *wlibpath;

--- a/string.c
+++ b/string.c
@@ -108,26 +108,13 @@ VALUE rb_cSymbol;
 
 #define STR_SET_NOEMBED(str) do {\
     FL_SET((str), STR_NOEMBED);\
-    if (USE_RVARGC) {\
-        FL_UNSET((str), STR_SHARED | STR_SHARED_ROOT | STR_BORROWED);\
-    }\
-    else {\
-        STR_SET_EMBED_LEN((str), 0);\
-    }\
+    FL_UNSET((str), STR_SHARED | STR_SHARED_ROOT | STR_BORROWED);\
 } while (0)
 #define STR_SET_EMBED(str) FL_UNSET((str), (STR_NOEMBED|STR_NOFREE))
-#if USE_RVARGC
 # define STR_SET_EMBED_LEN(str, n) do { \
     assert(str_embed_capa(str) > (n));\
     RSTRING(str)->as.embed.len = (n);\
 } while (0)
-#else
-# define STR_SET_EMBED_LEN(str, n) do { \
-    long tmp_n = (n);\
-    RBASIC(str)->flags &= ~RSTRING_EMBED_LEN_MASK;\
-    RBASIC(str)->flags |= (tmp_n) << RSTRING_EMBED_LEN_SHIFT;\
-} while (0)
-#endif
 
 #define STR_SET_LEN(str, n) do { \
     if (STR_EMBED_P(str)) {\
@@ -227,11 +214,7 @@ str_enc_fastpath(VALUE str)
 static inline long
 str_embed_capa(VALUE str)
 {
-#if USE_RVARGC
     return rb_gc_obj_slot_size(str) - offsetof(struct RString, as.embed.ary);
-#else
-    return RSTRING_EMBED_LEN_MAX + 1;
-#endif
 }
 
 bool
@@ -250,7 +233,6 @@ size_t
 rb_str_size_as_embedded(VALUE str)
 {
     size_t real_size;
-#if USE_RVARGC
     if (STR_EMBED_P(str)) {
         real_size = rb_str_embed_size(RSTRING(str)->as.embed.len) + TERM_LEN(str);
     }
@@ -260,22 +242,15 @@ rb_str_size_as_embedded(VALUE str)
         real_size = rb_str_embed_size(RSTRING(str)->as.heap.aux.capa) + TERM_LEN(str);
     }
     else {
-#endif
         real_size = sizeof(struct RString);
-#if USE_RVARGC
     }
-#endif
     return real_size;
 }
 
 static inline bool
 STR_EMBEDDABLE_P(long len, long termlen)
 {
-#if USE_RVARGC
     return rb_gc_size_allocatable_p(rb_str_embed_size(len + termlen));
-#else
-    return len <= RSTRING_EMBED_LEN_MAX + 1 - termlen;
-#endif
 }
 
 static VALUE str_replace_shared_without_enc(VALUE str2, VALUE str);
@@ -866,11 +841,7 @@ static size_t
 str_capacity(VALUE str, const int termlen)
 {
     if (STR_EMBED_P(str)) {
-#if USE_RVARGC
         return str_embed_capa(str) - termlen;
-#else
-        return (RSTRING_EMBED_LEN_MAX + 1 - termlen);
-#endif
     }
     else if (FL_TEST(str, STR_SHARED|STR_NOFREE)) {
         return RSTRING(str)->as.heap.len;
@@ -900,9 +871,6 @@ str_alloc_embed(VALUE klass, size_t capa)
     size_t size = rb_str_embed_size(capa);
     assert(size > 0);
     assert(rb_gc_size_allocatable_p(size));
-#if !USE_RVARGC
-    assert(size <= sizeof(struct RString));
-#endif
 
     RVARGC_NEWOBJ_OF(str, struct RString, klass,
                      T_STRING | (RGENGC_WB_PROTECTED_STRING ? FL_WB_PROTECTED : 0), size);
@@ -1486,9 +1454,6 @@ str_new_frozen_buffer(VALUE klass, VALUE orig, int copy_encoding)
             assert(ofs >= 0);
             assert(rest >= 0);
             assert(ofs + rest <= RSTRING_LEN(shared));
-#if !USE_RVARGC
-            assert(!STR_EMBED_P(shared));
-#endif
             assert(OBJ_FROZEN(shared));
 
             if ((ofs > 0) || (rest > 0) ||
@@ -1537,9 +1502,6 @@ str_new_empty_String(VALUE str)
 }
 
 #define STR_BUF_MIN_SIZE 63
-#if !USE_RVARGC
-STATIC_ASSERT(STR_BUF_MIN_SIZE, STR_BUF_MIN_SIZE > RSTRING_EMBED_LEN_MAX);
-#endif
 
 VALUE
 rb_str_buf_new(long capa)
@@ -1550,11 +1512,6 @@ rb_str_buf_new(long capa)
 
     VALUE str = str_alloc_heap(rb_cString);
 
-#if !USE_RVARGC
-    if (capa < STR_BUF_MIN_SIZE) {
-        capa = STR_BUF_MIN_SIZE;
-    }
-#endif
     RSTRING(str)->as.heap.aux.capa = capa;
     RSTRING(str)->as.heap.ptr = ALLOC_N(char, (size_t)capa + 1);
     RSTRING(str)->as.heap.ptr[0] = '\0';
@@ -1654,7 +1611,6 @@ str_shared_replace(VALUE str, VALUE str2)
         ENC_CODERANGE_SET(str, cr);
     }
     else {
-#if USE_RVARGC
         if (STR_EMBED_P(str2)) {
             assert(!FL_TEST(str2, STR_SHARED));
             long len = RSTRING(str2)->as.embed.len;
@@ -1667,7 +1623,6 @@ str_shared_replace(VALUE str, VALUE str2)
             RSTRING(str2)->as.heap.aux.capa = len;
             STR_SET_NOEMBED(str2);
         }
-#endif
 
         STR_SET_NOEMBED(str);
         FL_UNSET(str, STR_SHARED);
@@ -1739,9 +1694,6 @@ ec_str_alloc_embed(struct rb_execution_context_struct *ec, VALUE klass, size_t c
     size_t size = rb_str_embed_size(capa);
     assert(size > 0);
     assert(rb_gc_size_allocatable_p(size));
-#if !USE_RVARGC
-    assert(size <= sizeof(struct RString));
-#endif
 
     RB_RVARGC_EC_NEWOBJ_OF(ec, str, struct RString, klass,
                            T_STRING | (RGENGC_WB_PROTECTED_STRING ? FL_WB_PROTECTED : 0), size);
@@ -1762,9 +1714,6 @@ static inline VALUE
 str_duplicate_setup(VALUE klass, VALUE str, VALUE dup)
 {
     const VALUE flag_mask =
-#if !USE_RVARGC
-        RSTRING_NOEMBED | RSTRING_EMBED_LEN_MASK |
-#endif
         ENC_CODERANGE_MASK | ENCODING_MASK |
         FL_FREEZE
         ;
@@ -1789,21 +1738,12 @@ str_duplicate_setup(VALUE klass, VALUE str, VALUE dup)
         }
         assert(!STR_SHARED_P(root));
         assert(RB_OBJ_FROZEN_RAW(root));
-        if (0) {}
-#if !USE_RVARGC
-        else if (STR_EMBED_P(root)) {
-            MEMCPY(RSTRING(dup)->as.embed.ary, RSTRING(root)->as.embed.ary,
-                   char, RSTRING_EMBED_LEN_MAX + 1);
-            FL_UNSET(dup, STR_NOEMBED);
-        }
-#endif
-        else {
-            RSTRING(dup)->as.heap.len = RSTRING_LEN(str);
-            RSTRING(dup)->as.heap.ptr = RSTRING_PTR(str);
-            FL_SET(root, STR_SHARED_ROOT);
-            RB_OBJ_WRITE(dup, &RSTRING(dup)->as.heap.aux.shared, root);
-            flags |= RSTRING_NOEMBED | STR_SHARED;
-        }
+
+        RSTRING(dup)->as.heap.len = RSTRING_LEN(str);
+        RSTRING(dup)->as.heap.ptr = RSTRING_PTR(str);
+        FL_SET(root, STR_SHARED_ROOT);
+        RB_OBJ_WRITE(dup, &RSTRING(dup)->as.heap.aux.shared, root);
+        flags |= RSTRING_NOEMBED | STR_SHARED;
     }
 
     if ((flags & ENCODING_MASK) == (ENCODING_INLINE_MAX<<ENCODING_SHIFT)) {
@@ -1913,12 +1853,8 @@ rb_str_init(int argc, VALUE *argv, VALUE str)
             str_modifiable(str);
             if (STR_EMBED_P(str)) { /* make noembed always */
                 char *new_ptr = ALLOC_N(char, (size_t)capa + termlen);
-#if USE_RVARGC
                 assert(RSTRING(str)->as.embed.len + 1 <= str_embed_capa(str));
                 memcpy(new_ptr, RSTRING(str)->as.embed.ary, RSTRING(str)->as.embed.len + 1);
-#else
-                memcpy(new_ptr, RSTRING(str)->as.embed.ary, RSTRING_EMBED_LEN_MAX + 1);
-#endif
                 RSTRING(str)->as.heap.ptr = new_ptr;
             }
             else if (FL_TEST(str, STR_SHARED|STR_NOFREE)) {
@@ -3124,9 +3060,6 @@ str_buf_cat4(VALUE str, const char *ptr, long len, bool keep_cr)
     long capa, total, olen, off = -1;
     char *sptr;
     const int termlen = TERM_LEN(str);
-#if !USE_RVARGC
-    assert(termlen < RSTRING_EMBED_LEN_MAX + 1); /* < (LONG_MAX/2) */
-#endif
 
     RSTRING_GETMEM(str, sptr, olen);
     if (ptr >= sptr && ptr <= sptr + olen) {

--- a/test/-ext-/string/test_capacity.rb
+++ b/test/-ext-/string/test_capacity.rb
@@ -66,11 +66,7 @@ class Test_StringCapacity < Test::Unit::TestCase
   end
 
   def embed_header_size
-    if GC.using_rvargc?
-      2 * RbConfig::SIZEOF['void*'] + RbConfig::SIZEOF['long']
-    else
-      2 * RbConfig::SIZEOF['void*']
-    end
+    2 * RbConfig::SIZEOF['void*'] + RbConfig::SIZEOF['long']
   end
 
   def max_embed_len

--- a/tool/rjit/bindgen.rb
+++ b/tool/rjit/bindgen.rb
@@ -633,7 +633,6 @@ generator = BindingGenerator.new(
   ],
   skip_fields: {
     'rb_execution_context_struct.machine': %w[regs], # differs between macOS and Linux
-    'RString.as': %w[embed], # doesn't compile on USE_RVARGC=0 CI
     rb_execution_context_struct: %w[method_missing_reason], # non-leading bit fields not supported
     rb_iseq_constant_body: %w[yjit_payload], # conditionally defined
     rb_thread_struct: %w[status has_dedicated_nt to_kill abort_on_exception report_on_exception pending_interrupt_queue_checked],

--- a/transcode.c
+++ b/transcode.c
@@ -3768,11 +3768,8 @@ econv_primitive_convert(int argc, VALUE *argv, VALUE self)
     rb_str_modify(output);
 
     if (NIL_P(output_bytesize_v)) {
-#if USE_RVARGC
         output_bytesize = rb_str_capacity(output);
-#else
-        output_bytesize = RSTRING_EMBED_LEN_MAX;
-#endif
+
         if (!NIL_P(input) && output_bytesize < RSTRING_LEN(input))
             output_bytesize = RSTRING_LEN(input);
     }

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -178,7 +178,6 @@ fn main() {
 
         // From include/ruby/internal/core/robject.h
         .allowlist_type("ruby_robject_flags")
-        // .allowlist_type("ruby_robject_consts") // Removed when USE_RVARGC
         .allowlist_var("ROBJECT_OFFSET_.*")
 
         // From include/ruby/internal/core/rarray.h


### PR DESCRIPTION
The Variable Width Allocation feature was turned on by default in Ruby 3.2. Since then, we haven't received bug reports or backports to the non-Variable Width Allocation code paths, so we assume that nobody is using it. We also don't plan on maintaining the non-Variable Width Allocation code, so we would like to remove it.