### PR TITLE
Fix calls to require_internal in multi-ractor mode

### DIFF
--- a/ractor.c
+++ b/ractor.c
@@ -2341,13 +2341,12 @@ ractor_check_blocking(rb_ractor_t *cr, unsigned int remained_thread_cnt, const c
         cr->threads.cnt == cr->threads.blocking_cnt + 1) {
         // change ractor status: running -> blocking
         rb_vm_t *vm = GET_VM();
-        ASSERT_vm_unlocking();
 
-        RB_VM_LOCK();
+        RB_VM_LOCK_ENTER();
         {
             rb_vm_ractor_blocking_cnt_inc(vm, cr, file, line);
         }
-        RB_VM_UNLOCK();
+        RB_VM_LOCK_LEAVE();
     }
 }
 

--- a/test/ruby/test_encoding.rb
+++ b/test/ruby/test_encoding.rb
@@ -126,4 +126,14 @@ class TestEncoding < Test::Unit::TestCase
       end
     end;
   end
+
+  def test_ractor_load_encoding
+    assert_ractor("#{<<~"begin;"}\n#{<<~'end;'}")
+    begin;
+      Ractor.new{}.take
+      $-w = nil
+      Encoding.default_external = Encoding::ISO8859_2
+      assert "[Bug #19562]"
+    end;
+  end
 end


### PR DESCRIPTION
After a ractor is started (multi-ractor mode), any calls to require_internal will hang the process due to deadlock. For example, loading a new encoding will deadlock after a ractor starts.

Fixes [Bug #19562]