### PR TITLE
YJIT: Eanble `unsafe_op_in_unsafe_fn` on crate::core (and 2 other things!)

### DIFF
--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -1,4 +1,8 @@
 //! Code versioning, retained live control flow graph mutations, type tracking, etc.
+
+// So we can comment on individual uses of `unsafe` in `unsafe` functions
+#![warn(unsafe_op_in_unsafe_fn)]
+
 use crate::asm::*;
 use crate::backend::ir::*;
 use crate::codegen::*;
@@ -1007,7 +1011,8 @@ pub fn get_or_create_iseq_payload(iseq: IseqPtr) -> &'static mut IseqPayload {
 /// Iterate over all existing ISEQs
 pub fn for_each_iseq<F: FnMut(IseqPtr)>(mut callback: F) {
     unsafe extern "C" fn callback_wrapper(iseq: IseqPtr, data: *mut c_void) {
-        let callback: &mut &mut dyn FnMut(IseqPtr) -> bool = std::mem::transmute(&mut *data);
+        // SAFETY: points to the local below
+        let callback: &mut &mut dyn FnMut(IseqPtr) -> bool = unsafe { std::mem::transmute(&mut *data) };
         callback(iseq);
     }
     let mut data: &mut dyn FnMut(IseqPtr) = &mut callback;
@@ -1026,7 +1031,8 @@ pub fn for_each_iseq_payload<F: FnMut(&IseqPayload)>(mut callback: F) {
 /// Iterate over all on-stack ISEQs
 pub fn for_each_on_stack_iseq<F: FnMut(IseqPtr)>(mut callback: F) {
     unsafe extern "C" fn callback_wrapper(iseq: IseqPtr, data: *mut c_void) {
-        let callback: &mut &mut dyn FnMut(IseqPtr) -> bool = std::mem::transmute(&mut *data);
+        // SAFETY: points to the local below
+        let callback: &mut &mut dyn FnMut(IseqPtr) -> bool = unsafe { std::mem::transmute(&mut *data) };
         callback(iseq);
     }
     let mut data: &mut dyn FnMut(IseqPtr) = &mut callback;

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -1409,7 +1409,7 @@ pub fn limit_block_versions(blockid: BlockId, ctx: &Context) -> Context {
 /// the potential to run blocks which are not ready.
 unsafe fn add_block_version(blockref: BlockRef, cb: &CodeBlock) {
     // SAFETY: caller ensures initialization
-    let block = blockref.as_ref();
+    let block = unsafe { blockref.as_ref() };
 
     // Function entry blocks must have stack size 0
     assert!(!(block.iseq_range.start == 0 && block.ctx.stack_size > 0));
@@ -1432,7 +1432,7 @@ unsafe fn add_block_version(blockref: BlockRef, cb: &CodeBlock) {
         // Creating an unaligned pointer is well defined unlike in C.
         let value_address: *const VALUE = value_address.cast();
 
-        let object = value_address.read_unaligned();
+        let object = unsafe { value_address.read_unaligned() };
         obj_written!(iseq, object);
     }
 
@@ -2790,17 +2790,17 @@ pub fn defer_compilation(
 /// Block must be initialized and incoming/outgoing edges
 /// must also point to initialized blocks.
 unsafe fn remove_from_graph(blockref: BlockRef) {
-    let block = blockref.as_ref();
+    let block = unsafe { blockref.as_ref() };
 
     // Remove this block from the predecessor's targets
     for pred_branchref in block.incoming.0.take().iter() {
         // Branch from the predecessor to us
-        let pred_branch = pred_branchref.as_ref();
+        let pred_branch = unsafe { pred_branchref.as_ref() };
 
         // If this is us, nullify the target block
         for target_idx in 0..pred_branch.targets.len() {
             // SAFETY: no mutation inside unsafe
-            let target_is_us = {
+            let target_is_us = unsafe {
                 pred_branch.targets[target_idx]
                     .ref_unchecked()
                     .as_ref()
@@ -2817,18 +2817,18 @@ unsafe fn remove_from_graph(blockref: BlockRef) {
 
     // For each outgoing branch
     for out_branchref in block.outgoing.iter() {
-        let out_branch = out_branchref.as_ref();
+        let out_branch = unsafe { out_branchref.as_ref() };
         // For each successor block
         for out_target in out_branch.targets.iter() {
             // SAFETY: copying out an Option<BlockRef>. No mutation.
-            let succ_block: Option<BlockRef> = {
+            let succ_block: Option<BlockRef> = unsafe {
                 out_target.ref_unchecked().as_ref().and_then(|target| target.get_block())
             };
 
             if let Some(succ_block) = succ_block {
                 // Remove outgoing branch from the successor's incoming list
                 // SAFETY: caller promises the block has valid outgoing edges.
-                let succ_block = succ_block.as_ref();
+                let succ_block = unsafe { succ_block.as_ref() };
                 // Temporarily move out of succ_block.incoming.
                 let succ_incoming = succ_block.incoming.0.take();
                 let mut succ_incoming = succ_incoming.into_vec();
@@ -2854,7 +2854,7 @@ unsafe fn remove_from_graph(blockref: BlockRef) {
 pub unsafe fn free_block(blockref: BlockRef, graph_intact: bool) {
     // Careful with order here.
     // First, remove all pointers to the referent block
-    {
+    unsafe {
         block_assumptions_free(blockref);
 
         if graph_intact {
@@ -2863,13 +2863,13 @@ pub unsafe fn free_block(blockref: BlockRef, graph_intact: bool) {
     }
 
     // SAFETY: we should now have a unique pointer to the block
-    dealloc_block(blockref)
+    unsafe { dealloc_block(blockref) }
 }
 
 /// Deallocate a block and its outgoing branches. Blocks own their outgoing branches.
 /// Caller must ensure that we have unique ownership for the referent block
 unsafe fn dealloc_block(blockref: BlockRef) {
-    {
+    unsafe {
         for outgoing in blockref.as_ref().outgoing.iter() {
             // this Box::from_raw matches the Box::into_raw from PendingBranch::into_branch
             mem::drop(Box::from_raw(outgoing.as_ptr()));
@@ -2877,7 +2877,7 @@ unsafe fn dealloc_block(blockref: BlockRef) {
     }
 
     // Deallocate the referent Block
-    {
+    unsafe {
         // this Box::from_raw matches the Box::into_raw from JITState::into_block
         mem::drop(Box::from_raw(blockref.as_ptr()));
     }
@@ -3102,7 +3102,7 @@ impl<T> RefUnchecked for Cell<T> {
         // SAFETY: pointer is dereferenceable because it's from a &Cell.
         // It's up to the caller to follow aliasing rules with the output
         // reference.
-        self.as_ptr().as_ref().unwrap()
+        unsafe { self.as_ptr().as_ref().unwrap() }
     }
 }
 

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -614,7 +614,7 @@ macro_rules! obj_written {
     ($old: expr, $young: expr) => {
         let (old, young): (VALUE, VALUE) = ($old, $young);
         let src_loc = $crate::cruby::src_loc!();
-        rb_yjit_obj_written(old, young, src_loc.file.as_ptr(), src_loc.line);
+        unsafe { rb_yjit_obj_written(old, young, src_loc.file.as_ptr(), src_loc.line) };
     };
 }
 pub(crate) use obj_written;

--- a/yjit/yjit.mk
+++ b/yjit/yjit.mk
@@ -90,7 +90,7 @@ update-yjit-bench:
 .PHONY: yjit-smoke-test
 yjit-smoke-test:
 ifneq ($(strip $(CARGO)),)
-	$(CARGO) test --all-features -q --manifest-path='$(top_srcdir)/yjit/Cargo.toml'
+	$(CARGO) +1.58.0 test --all-features -q --manifest-path='$(top_srcdir)/yjit/Cargo.toml'
 endif
 	$(MAKE) btest RUN_OPTS='--yjit-call-threshold=1' BTESTS=-j
 	$(MAKE) test-all TESTS='$(top_srcdir)/test/ruby/test_yjit.rb'


### PR DESCRIPTION
Lore: https://github.com/ruby/ruby/pull/7634#issuecomment-1492066729 

- Revert "YJIT: Suppress unnecessary `unsafe` block (GH-7634)"
- YJIT: Eanble `unsafe_op_in_unsafe_fn` on crate::core
- YJIT: Smoke test on Rust 1.58.0
