### PR TITLE
YJIT: Stack temp register allocation for arm64

### DIFF
--- a/.github/workflows/yjit-ubuntu.yml
+++ b/.github/workflows/yjit-ubuntu.yml
@@ -78,10 +78,6 @@ jobs:
             configure: "--enable-yjit=dev"
             yjit_opts: "--yjit-call-threshold=1 --yjit-verify-ctx"
 
-          - test_task: "check"
-            configure: "--enable-yjit=dev"
-            yjit_opts: "--yjit-call-threshold=1 --yjit-temp-regs=5"
-
           - test_task: "test-all TESTS=--repeat-count=2"
             configure: "--enable-yjit=dev"
 

--- a/yjit/src/backend/arm64/mod.rs
+++ b/yjit/src/backend/arm64/mod.rs
@@ -5,9 +5,11 @@
 use crate::asm::{CodeBlock};
 use crate::asm::arm64::*;
 use crate::codegen::{JITState, CodegenGlobals};
+use crate::core::Context;
 use crate::cruby::*;
 use crate::backend::ir::*;
 use crate::virtualmem::CodePtr;
+use crate::options::*;
 
 // Use the arm64 register type for this platform
 pub type Reg = A64Reg;
@@ -167,6 +169,9 @@ impl Assembler
     const SCRATCH0: A64Opnd = A64Opnd::Reg(X16_REG);
     const SCRATCH1: A64Opnd = A64Opnd::Reg(X17_REG);
 
+    /// List of registers that can be used for stack temps.
+    pub const TEMP_REGS: [Reg; 5] = [X1_REG, X9_REG, X10_REG, X14_REG, X15_REG];
+
     /// Get the list of registers from which we will allocate on this platform
     /// These are caller-saved registers
     /// Note: we intentionally exclude C_RET_REG (X0) from this list
@@ -175,16 +180,9 @@ impl Assembler
         vec![X11_REG, X12_REG, X13_REG]
     }
 
-    /// Get the list of registers that can be used for stack temps.
-    pub fn get_temp_regs() -> Vec<Reg> {
-        // FIXME: arm64 is not supported yet. Insn::Store doesn't support registers
-        // in its dest operand. Currently crashing at split_memory_address.
-        vec![]
-    }
-
     /// Get a list of all of the caller-saved registers
     pub fn get_caller_save_regs() -> Vec<Reg> {
-        vec![X9_REG, X10_REG, X11_REG, X12_REG, X13_REG, X14_REG, X15_REG]
+        vec![X1_REG, X9_REG, X10_REG, X11_REG, X12_REG, X13_REG, X14_REG, X15_REG]
     }
 
     /// Split platform-specific instructions
@@ -595,11 +593,6 @@ impl Assembler
                     asm.not(opnd0);
                 },
                 Insn::Store { dest, src } => {
-                    // The displacement for the STUR instruction can't be more
-                    // than 9 bits long. If it's longer, we need to load the
-                    // memory address into a register first.
-                    let opnd0 = split_memory_address(asm, dest);
-
                     // The value being stored must be in a register, so if it's
                     // not already one we'll load it first.
                     let opnd1 = match src {
@@ -610,7 +603,19 @@ impl Assembler
                         _ => split_load_operand(asm, src)
                     };
 
-                    asm.store(opnd0, opnd1);
+                    match dest {
+                        Opnd::Reg(_) => {
+                            // Store does not support a register as a dest operand.
+                            asm.mov(dest, opnd1);
+                        }
+                        _ => {
+                            // The displacement for the STUR instruction can't be more
+                            // than 9 bits long. If it's longer, we need to load the
+                            // memory address into a register first.
+                            let opnd0 = split_memory_address(asm, dest);
+                            asm.store(opnd0, opnd1);
+                        }
+                    }
                 },
                 Insn::Sub { left, right, .. } => {
                     let opnd0 = split_load_operand(asm, left);
@@ -1085,7 +1090,9 @@ impl Assembler
     /// Optimize and compile the stored instructions
     pub fn compile_with_regs(self, cb: &mut CodeBlock, regs: Vec<Reg>) -> Vec<u32>
     {
-        let mut asm = self.lower_stack().arm64_split().alloc_regs(regs);
+        let asm = self.lower_stack();
+        let asm = asm.arm64_split();
+        let mut asm = asm.alloc_regs(regs);
 
         // Create label instances in the code block
         for (idx, name) in asm.label_names.iter().enumerate() {
@@ -1170,7 +1177,7 @@ mod tests {
     fn test_emit_cpop_all() {
         let (mut asm, mut cb) = setup_asm();
 
-        asm.cpop_all();
+        asm.cpop_all(&Context::default());
         asm.compile_with_num_regs(&mut cb, 0);
     }
 

--- a/yjit/src/backend/arm64/mod.rs
+++ b/yjit/src/backend/arm64/mod.rs
@@ -170,6 +170,7 @@ impl Assembler
     const SCRATCH1: A64Opnd = A64Opnd::Reg(X17_REG);
 
     /// List of registers that can be used for stack temps.
+    /// These are caller-saved registers.
     pub const TEMP_REGS: [Reg; 5] = [X1_REG, X9_REG, X10_REG, X14_REG, X15_REG];
 
     /// Get the list of registers from which we will allocate on this platform

--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -1503,7 +1503,8 @@ impl Assembler {
     pub fn cpop_all(&mut self, ctx: &Context) {
         self.push_insn(Insn::CPopAll);
 
-        // Re-enable ccall's assertion disabled by cpush_all
+        // Re-enable ccall's RegTemps assertion disabled by cpush_all.
+        // cpush_all + cpop_all preserve all stack temp registers, so it's safe.
         self.set_reg_temps(ctx.get_reg_temps());
     }
 
@@ -1518,7 +1519,9 @@ impl Assembler {
     pub fn cpush_all(&mut self) {
         self.push_insn(Insn::CPushAll);
 
-        // Disable ccall's assertion. This will be re-enabled by cpop_all.
+        // Disable ccall's RegTemps assertion. This will be re-enabled by cpop_all.
+        // We assume that cpush_all + cpop_all are used for C functions in utils.rs
+        // that don't require spill_temps for GC.
         self.set_reg_temps(RegTemps::default());
     }
 

--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -1519,7 +1519,8 @@ impl Assembler {
     pub fn cpush_all(&mut self) {
         self.push_insn(Insn::CPushAll);
 
-        // Disable ccall's RegTemps assertion. This will be re-enabled by cpop_all.
+        // Mark all temps as not being in registers.
+        // Temps will be marked back as being in registers by cpop_all.
         // We assume that cpush_all + cpop_all are used for C functions in utils.rs
         // that don't require spill_temps for GC.
         self.set_reg_temps(RegTemps::default());

--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -913,6 +913,13 @@ impl Assembler
         }
     }
 
+    /// Get the list of registers that can be used for stack temps.
+    pub fn get_temp_regs() -> Vec<Reg> {
+        let num_regs = get_option!(num_temp_regs);
+        let mut regs = Self::TEMP_REGS.to_vec();
+        regs.drain(0..num_regs).collect()
+    }
+
     /// Build an Opnd::InsnOut from the current index of the assembler and the
     /// given number of bits.
     pub(super) fn next_opnd_out(&self, num_bits: u8) -> Opnd {
@@ -1493,8 +1500,11 @@ impl Assembler {
         out
     }
 
-    pub fn cpop_all(&mut self) {
+    pub fn cpop_all(&mut self, ctx: &Context) {
         self.push_insn(Insn::CPopAll);
+
+        // Re-enable ccall's assertion disabled by cpush_all
+        self.set_reg_temps(ctx.get_reg_temps());
     }
 
     pub fn cpop_into(&mut self, opnd: Opnd) {
@@ -1507,6 +1517,9 @@ impl Assembler {
 
     pub fn cpush_all(&mut self) {
         self.push_insn(Insn::CPushAll);
+
+        // Disable ccall's assertion. This will be re-enabled by cpop_all.
+        self.set_reg_temps(RegTemps::default());
     }
 
     pub fn cret(&mut self, opnd: Opnd) {

--- a/yjit/src/backend/x86_64/mod.rs
+++ b/yjit/src/backend/x86_64/mod.rs
@@ -88,6 +88,9 @@ impl Assembler
     // a closure and we don't want it to have to capture anything.
     const SCRATCH0: X86Opnd = X86Opnd::Reg(R11_REG);
 
+    /// List of registers that can be used for stack temps.
+    pub const TEMP_REGS: [Reg; 5] = [RSI_REG, RDI_REG, R8_REG, R9_REG, R10_REG];
+
     /// Get the list of registers from which we can allocate on this platform
     pub fn get_alloc_regs() -> Vec<Reg>
     {
@@ -96,13 +99,6 @@ impl Assembler
             RCX_REG,
             RDX_REG,
         ]
-    }
-
-    /// Get the list of registers that can be used for stack temps.
-    pub fn get_temp_regs() -> Vec<Reg> {
-        let num_regs = get_option!(num_temp_regs);
-        let mut regs = vec![RSI_REG, RDI_REG, R8_REG, R9_REG, R10_REG];
-        regs.drain(0..num_regs).collect()
     }
 
     /// Get a list of all of the caller-save registers

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -933,7 +933,7 @@ pub fn gen_single_block(
             // If requested, dump instructions for debugging
             if get_option!(dump_insns) {
                 println!("compiling {}", insn_name(opcode));
-                print_str(&mut asm, &format!("executing {}", insn_name(opcode)));
+                print_str(&mut asm, &ctx, &format!("executing {}", insn_name(opcode)));
             }
 
             // Call the code generation function
@@ -8306,7 +8306,9 @@ mod tests {
         let status = gen_pop(&mut jit, &mut context, &mut asm, &mut ocb);
 
         assert_eq!(status, KeepCompiling);
-        assert_eq!(context.diff(&Context::default()), TypeDiff::Compatible(0));
+        let mut default = Context::default();
+        default.set_reg_temps(context.get_reg_temps());
+        assert_eq!(context.diff(&default), TypeDiff::Compatible(0));
     }
 
     #[test]

--- a/yjit/src/options.rs
+++ b/yjit/src/options.rs
@@ -1,4 +1,5 @@
 use std::ffi::CStr;
+use crate::backend::ir::Assembler;
 
 // Command-line options
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -55,7 +56,7 @@ pub static mut OPTIONS: Options = Options {
     greedy_versioning: false,
     no_type_prop: false,
     max_versions: 4,
-    num_temp_regs: 0,
+    num_temp_regs: 5,
     gen_stats: false,
     gen_trace_exits: false,
     pause: false,
@@ -146,7 +147,10 @@ pub fn parse_option(str_ptr: *const std::os::raw::c_char) -> Option<()> {
         },
 
         ("temp-regs", _) => match opt_val.parse() {
-            Ok(n) => unsafe { OPTIONS.num_temp_regs = n },
+            Ok(n) => {
+                assert!(n <= Assembler::TEMP_REGS.len(), "--yjit-temp-regs must be <= {}", Assembler::TEMP_REGS.len());
+                unsafe { OPTIONS.num_temp_regs = n }
+            }
             Err(_) => {
                 return None;
             }


### PR DESCRIPTION
Following up https://github.com/ruby/ruby/pull/7651, this PR adds arm64 support for stack temp register allocation. Because benchmark results are generally better in both x86_64 and arm64, this PR also changes the default of `--yjit-temp-regs` to `5`.

## Benchmark
The speedups on M1 seem less dramatic compared to my Linux x86_64 environment (maybe because M1 is faster on memory access?). But still benchmark results seem generally better than not enabling it.

```
regs=0: ruby 3.3.0dev (2023-04-04T23:36:32Z yjit-stack-arm64 ca7446cd37) +YJIT [arm64-darwin22]
regs=5: ruby 3.3.0dev (2023-04-04T23:36:32Z yjit-stack-arm64 ca7446cd37) +YJIT [arm64-darwin22]

--------------  -----------  ----------  -----------  ----------  -------------  --------------
bench           regs=0 (ms)  stddev (%)  regs=5 (ms)  stddev (%)  regs=0/regs=5  regs=5 1st itr
activerecord    17.7         2.3         17.5         2.2         1.01           0.89
erubi_rails     6.1          10.6        6.1          9.8         1.00           0.65
hexapdf         922.7        1.9         916.6        2.1         1.01           0.97
liquid-c        24.5         3.6         24.4         3.6         1.01           0.82
liquid-render   49.0         3.3         48.4         3.6         1.01           0.86
mail            57.1         2.2         55.3         1.7         1.03           0.87
psych-load      888.2        0.4         880.4        0.5         1.01           1.01
railsbench      646.9        1.6         647.6        1.7         1.00           0.92
ruby-lsp        32.0         26.4        32.2         34.7        1.00           1.02
sequel          30.3         1.6         30.4         1.4         0.99           1.00
binarytrees     112.4        2.6         110.2        2.6         1.02           1.02
chunky_png      370.1        0.3         362.7        0.4         1.02           1.00
erubi           121.4        1.5         121.8        2.1         1.00           1.00
etanni          210.6        0.9         207.3        0.9         1.02           1.02
fannkuchredux   446.0        0.4         401.5        0.2         1.11           1.00
lee             482.6        0.7         474.6        0.9         1.02           1.48
nbody           41.3         0.7         42.3         0.7         0.98           0.96
optcarrot       1434.6       0.6         1364.9       0.6         1.05           1.03
ruby-json       1496.1       0.4         1506.0       0.4         0.99           0.99
rubykon         3413.4       0.4         3196.5       0.4         1.07           1.03
30k_ifelse      350.3        0.8         368.8        2.2         0.95           0.61
30k_methods     837.5        0.6         836.0        0.9         1.00           0.88
cfunc_itself    20.9         0.9         20.6         1.4         1.02           1.03
fib             34.4         0.6         32.4         1.0         1.06           1.07
getivar         40.3         51.7        27.9         71.4        1.44           1.00
keyword_args    30.4         0.8         27.4         0.9         1.11           1.12
respond_to      19.2         0.9         18.6         0.8         1.03           1.02
setivar         10.4         78.1        8.2          91.6        1.27           1.00
setivar_object  28.7         48.4        27.6         50.8        1.04           0.99
setivar_young   28.8         49.2        27.5         50.0        1.05           1.02
str_concat      23.0         2.9         22.3         3.2         1.03           1.01
throw           11.9         0.9         11.9         1.0         1.00           1.00
--------------  -----------  ----------  -----------  ----------  -------------  --------------
```

## Code size
The following stats are measured on railsbench. Unlike linux-x86_64, `inline_code_size` seems to be increased as well (maybe due to the difference in encoding?). But the total `code_region_size` increase doesn't seem to be too bad.

### Before (--yjit-temp-regs=0)
```
inline_code_size:          4,238,900
outlined_code_size:        2,153,884
code_region_size:          7,667,712
```

### After (--yjit-temp-regs=5)
```
inline_code_size:          4,338,116
outlined_code_size:        3,075,936
code_region_size:          7,684,096
```