### PR TITLE
Implement Process.warmup

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -49,6 +49,13 @@ Note: We're only listing outstanding class updates.
 
     * `Module#set_temporary_name` added for setting a temporary name for a module. [[Feature #19521]]
 
+* Process.warmup
+
+    * Notify the Ruby virtual machine that the boot sequence is finished,
+      and that now is a good time to optimize the application. This is useful
+      for long running applications. The actual optimizations performed are entirely
+      implementation specific and may change in the future without notice. [[Feature #18885]
+
 ## Stdlib updates
 
 The following default gems are updated.

--- a/common.mk
+++ b/common.mk
@@ -11649,7 +11649,9 @@ process.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).h
 process.$(OBJEXT): {$(VPATH)}thread_native.h
 process.$(OBJEXT): {$(VPATH)}util.h
 process.$(OBJEXT): {$(VPATH)}vm_core.h
+process.$(OBJEXT): {$(VPATH)}vm_debug.h
 process.$(OBJEXT): {$(VPATH)}vm_opts.h
+process.$(OBJEXT): {$(VPATH)}vm_sync.h
 ractor.$(OBJEXT): $(CCAN_DIR)/check_type/check_type.h
 ractor.$(OBJEXT): $(CCAN_DIR)/container_of/container_of.h
 ractor.$(OBJEXT): $(CCAN_DIR)/list/list.h

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -204,6 +204,7 @@ extern VALUE *ruby_initial_gc_stress_ptr;
 extern int ruby_disable_gc;
 RUBY_ATTR_MALLOC void *ruby_mimmalloc(size_t size);
 void ruby_mimfree(void *ptr);
+void rb_gc_prepare_heap(void);
 void rb_objspace_set_event_hook(const rb_event_flag_t event);
 VALUE rb_objspace_gc_enable(struct rb_objspace *);
 VALUE rb_objspace_gc_disable(struct rb_objspace *);

--- a/spec/ruby/core/process/warmup_spec.rb
+++ b/spec/ruby/core/process/warmup_spec.rb
@@ -1,0 +1,11 @@
+require_relative '../../spec_helper'
+
+describe "Process.warmup" do
+  ruby_version_is "3.3" do
+    # The behavior is entirely implementation specific.
+    # Other implementations are free to just make it a noop
+    it "is implemented" do
+      Process.warmup.should == true
+    end
+  end
+end


### PR DESCRIPTION
[[Feature #18885]](https://bugs.ruby-lang.org/issues/18885)

For now, the optimizations performed are:

  - Run a major GC
  - Compact the heap
  - Promote all surviving objects to oldgen

Other optimizations may follow.

https://github.com/ruby/ruby/pull/7346 had to be reverted because of CI failures (cc @tenderlove)