### PR TITLE
[Bug#19161] Detect thread local storage specifier

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -385,13 +385,6 @@ AS_IF([test "$GCC" = yes], [
     AS_IF([test "$gcc_major" -lt 4], [
         AC_MSG_ERROR([too old GCC: $gcc_major.$gcc_minor])
     ])
-
-    AC_CACHE_CHECK([if thread-local storage is supported], [rb_cv_tls_supported],
-        [AC_LINK_IFELSE([AC_LANG_PROGRAM([[int __thread conftest;]])],
-            [rb_cv_tls_supported=yes],
-            [rb_cv_tls_supported=no])])
-    AS_IF([test x"$rb_cv_tls_supported" != xyes],
-        [AC_DEFINE(RB_THREAD_LOCAL_SPECIFIER_IS_UNSUPPORTED)])
 ], [
     linker_flag=
 ])
@@ -2750,6 +2743,22 @@ AS_IF([test "$THREAD_MODEL" = pthread], [
 		AC_DEFINE_UNQUOTED(SET_ANOTHER_THREAD_NAME(thid,name), $set_another_thread_name)
 	    ])
     ])
+
+    AC_CACHE_CHECK([for thread-local storage sepcifier], [rb_cv_tls_specifier],
+        rb_cv_tls_specifier=none
+        RUBY_WERROR_FLAG([
+            for attr in \
+                _Thread_local \
+                __thread \
+                ; do
+                AC_LINK_IFELSE([AC_LANG_PROGRAM([[$attr int conftest;]])],
+                    [rb_cv_tls_specifier=$attr; break])
+            done
+        ])
+    )
+    AS_IF([test x"${rb_cv_tls_specifier}" != xnone],
+        [AC_DEFINE_UNQUOTED(RB_THREAD_LOCAL_SPECIFIER, ${rb_cv_tls_specifier})]
+    )
 ])
 
 AS_IF([test x"$ac_cv_header_ucontext_h" = xno], [

--- a/ext/-test-/thread/instrumentation/instrumentation.c
+++ b/ext/-test-/thread/instrumentation/instrumentation.c
@@ -8,13 +8,8 @@ static rb_atomic_t resumed_count = 0;
 static rb_atomic_t suspended_count = 0;
 static rb_atomic_t exited_count = 0;
 
-#if __STDC_VERSION__ >= 201112
-  #define RB_THREAD_LOCAL_SPECIFIER _Thread_local
-#elif defined(__GNUC__) && !defined(RB_THREAD_LOCAL_SPECIFIER_IS_UNSUPPORTED)
-  /* note that ICC (linux) and Clang are covered by __GNUC__ */
-  #define RB_THREAD_LOCAL_SPECIFIER __thread
-#else
-  #define RB_THREAD_LOCAL_SPECIFIER
+#ifndef RB_THREAD_LOCAL_SPECIFIER
+#  define RB_THREAD_LOCAL_SPECIFIER
 #endif
 
 static RB_THREAD_LOCAL_SPECIFIER unsigned int local_ready_count = 0;

--- a/thread_pthread.h
+++ b/thread_pthread.h
@@ -90,15 +90,6 @@ struct rb_thread_sched {
     int wait_yield;
 };
 
-#ifndef RB_THREAD_LOCAL_SPECIFIER_IS_UNSUPPORTED
-# if __STDC_VERSION__ >= 201112
-#   define RB_THREAD_LOCAL_SPECIFIER _Thread_local
-# elif defined(__GNUC__)
-  /* note that ICC (linux) and Clang are covered by __GNUC__ */
-#   define RB_THREAD_LOCAL_SPECIFIER __thread
-# endif
-#endif
-
 RUBY_SYMBOL_EXPORT_BEGIN
 #ifdef RB_THREAD_LOCAL_SPECIFIER
   # ifdef __APPLE__


### PR DESCRIPTION
Checking by `__STDC_VERSION__` is unreliable because old gcc 4.8 supports `-std=gnu11` option but does not implement `_Thread_local`.
Check the implementation directly instead.