### PR TITLE
[Bug #19584] Fix crash in rb_gc_register_address

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -9202,10 +9202,17 @@ rb_gc_register_address(VALUE *addr)
     rb_objspace_t *objspace = &rb_objspace;
     struct gc_list *tmp;
 
+    VALUE obj = *addr;
+
     tmp = ALLOC(struct gc_list);
     tmp->next = global_list;
     tmp->varptr = addr;
     global_list = tmp;
+
+    /* obj has to be guarded here because the allocation above could trigger a
+     * GC. However, C extensions could pass a pointer to a global variable
+     * which does not exist on the stack and thus could get swept. */
+    RB_GC_GUARD(obj);
 }
 
 void


### PR DESCRIPTION
Some C extensions pass a pointer to a global variable to rb_gc_register_address. However, if a GC is triggered inside of rb_gc_register_address, then the object could get swept since it does not exist on the stack.