### PR TITLE
[Bug #19563] Yield words separators per lines

### DIFF
--- a/test/ripper/test_scanner_events.rb
+++ b/test/ripper/test_scanner_events.rb
@@ -712,7 +712,7 @@ class TestRipper::ScannerEvents < Test::Unit::TestCase
                  scan('words_sep', '%w( w w w )')
     assert_equal [' ', "\n", ' ', ' '],
                  scan('words_sep', "%w( w\nw w )")
-    assert_equal ["\n\n", "\n ", ' ', ' '],
+    assert_equal ["\n", "\n", "\n", ' ', ' ', ' '],
                  scan('words_sep', "%w(\n\nw\n w w )")
   end
 


### PR DESCRIPTION
So that newlines across a here-doc terminator will be separated tokens.

https://bugs.ruby-lang.org/issues/19563
https://github.com/ruby/irb/pull/558