### PR TITLE
thread_pthread: Grow main_stack if required (fixes tests on HPPA)

### DIFF
--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -777,8 +777,20 @@ size_t pthread_get_stacksize_np(pthread_t);
 #   define MAINSTACKADDR_AVAILABLE 0
 # endif
 #endif
-#if MAINSTACKADDR_AVAILABLE && !defined(get_main_stack)
-# define get_main_stack(addr, size) get_stack(addr, size)
+#if MAINSTACKADDR_AVAILABLE
+static int get_stack(void **, size_t *);
+static int
+get_main_stack(void **addr, size_t *size)
+{
+    int ret = get_stack(addr, size);
+
+    /* On some architectures, the initial stack size may be too small, but fortunately,
+       it's growable. Bump it up to the minimum needed if it is too small. */
+    if (*size < RUBY_VM_THREAD_VM_STACK_SIZE)
+        *size = RUBY_VM_THREAD_VM_STACK_SIZE;
+
+    return ret;
+}
 #endif
 
 #ifdef STACKADDR_AVAILABLE


### PR DESCRIPTION
On HPPA, test_insns.rb fails (along with various Ruby gems) with 'stack level too deep (SystemStackError)'. This turns out to be because HPPA defaults to a small(er) stack.

With this change, Ruby's test suite passes on HPPA.

Thanks to both Dave and Helge for the investigation and coming up with the patch.

Bug: https://bugs.gentoo.org/701494
Bug: https://bugs.debian.org/881773
Bug: https://bugs.debian.org/881772 (for PPC64)
Bug: https://github.com/rack/rack/issues/1640
Thanks-to: John David Anglin <dave.anglin@bell.net>
Thanks-to: Helge Deller <deller@gmx.de>