### PR TITLE
Use tools appropriate with CC

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -233,6 +233,11 @@ AS_CASE(["${build_os}"],
 ],
 [aix*], [
     AC_PATH_TOOL([NM], [nm], [/usr/ccs/bin/nm], [/usr/ccs/bin:$PATH])
+],
+[darwin*], [
+    ac_cv_prog_ac_ct_AR=`$CC -print-prog-name=ar`
+    ac_cv_prog_ac_ct_LD=`$CC -print-prog-name=ld`
+    ac_cv_prog_ac_ct_NM=`$CC -print-prog-name=nm`
 ])
 AS_CASE(["${target_os}"],
 [cygwin*|msys*|mingw*|darwin*], [

--- a/configure.ac
+++ b/configure.ac
@@ -235,6 +235,7 @@ AS_CASE(["${build_os}"],
     AC_PATH_TOOL([NM], [nm], [/usr/ccs/bin/nm], [/usr/ccs/bin:$PATH])
 ],
 [darwin*], [
+    # For Apple clang version 14.0.3 (clang-1403.0.22.14.1)
     ac_cv_prog_ac_ct_AR=`$CC -print-prog-name=ar`
     ac_cv_prog_ac_ct_LD=`$CC -print-prog-name=ld`
     ac_cv_prog_ac_ct_NM=`$CC -print-prog-name=nm`


### PR DESCRIPTION
To get rid of mysterious errors such as:

```
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/nm: error: libruby.3.3-static.a(/): The end of the file was unexpectedly encountered
```

and

```
ld: warning: ignoring file ../../libruby.3.3-static.a, building for macOS-x86_64 but attempting to link with file built for macOS-x86_64
Undefined symbols for architecture x86_64:
  "_rb_rational_num", referenced from:
```