### PR TITLE
Update web link URLs in documentation

### DIFF
--- a/lib/drb/drb.rb
+++ b/lib/drb/drb.rb
@@ -35,7 +35,7 @@
 # [http://www2a.biglobe.ne.jp/~seki/ruby/druby.en.html]
 #    The English version of the dRuby home page.
 #
-# [http://pragprog.com/book/sidruby/the-druby-book]
+# [https://www.druby.org/sidruby/the-druby-book.html]
 #    The dRuby Book: Distributed and Parallel Computing with Ruby
 #    by Masatoshi Seki and Makoto Inoue
 #

--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -291,7 +291,7 @@ module Net   #:nodoc:
   # == Basic Authentication
   #
   # Basic authentication is performed according to
-  # {RFC2617}[http://www.ietf.org/rfc/rfc2617.txt]:
+  # {RFC2617}[https://www.ietf.org/rfc/rfc2617.txt]:
   #
   #   req = Net::HTTP::Get.new(uri)
   #   req.basic_auth('user', 'pass')

--- a/lib/net/http/header.rb
+++ b/lib/net/http/header.rb
@@ -513,9 +513,9 @@ module Net::HTTPHeader
     # byte-range-set = *( "," OWS ) ( byte-range-spec / suffix-byte-range-spec )
     #   *( OWS "," [ OWS ( byte-range-spec / suffix-byte-range-spec ) ] )
     # corrected collected ABNF
-    # http://tools.ietf.org/html/draft-ietf-httpbis-p5-range-19#section-5.4.1
-    # http://tools.ietf.org/html/draft-ietf-httpbis-p5-range-19#appendix-C
-    # http://tools.ietf.org/html/draft-ietf-httpbis-p1-messaging-19#section-3.2.5
+    # https://tools.ietf.org/html/draft-ietf-httpbis-p5-range-19#section-5.4.1
+    # https://tools.ietf.org/html/draft-ietf-httpbis-p5-range-19#appendix-C
+    # https://tools.ietf.org/html/draft-ietf-httpbis-p1-messaging-19#section-3.2.5
     unless /\Abytes=((?:,[ \t]*)*(?:\d+-\d*|-\d+)(?:[ \t]*,(?:[ \t]*\d+-\d*|-\d+)?)*)\z/ =~ value
       raise Net::HTTPHeaderSyntaxError, "invalid syntax for byte-ranges-specifier: '#{value}'"
     end

--- a/lib/net/http/response.rb
+++ b/lib/net/http/response.rb
@@ -432,7 +432,7 @@ class Net::HTTPResponse
   # :nodoc:
   def sniff_encoding(str, encoding=nil)
     # the encoding sniffing algorithm
-    # http://www.w3.org/TR/html5/parsing.html#determining-the-character-encoding
+    # https://www.w3.org/TR/html5/parsing.html#determining-the-character-encoding
     if enc = scanning_meta(str)
       enc
     # 6. last visited page or something
@@ -537,7 +537,7 @@ class Net::HTTPResponse
   end
 
   def extracting_encodings_from_meta_elements(value)
-    # http://dev.w3.org/html5/spec/fetching-resources.html#algorithm-for-extracting-an-encoding-from-a-meta-element
+    # https://dev.w3.org/html5/spec/fetching-resources.html#algorithm-for-extracting-an-encoding-from-a-meta-element
     if /charset[\t\n\f\r ]*=(?:"([^"]*)"|'([^']*)'|["']|\z|([^\t\n\f\r ;]+))/i =~ value
       return $1 || $2 || $3
     end

--- a/lib/rdoc/i18n/locale.rb
+++ b/lib/rdoc/i18n/locale.rb
@@ -37,7 +37,7 @@ class RDoc::I18n::Locale
   # +[language[_territory][.codeset][@modifier]]+.
   #
   # See also {BCP 47 - Tags for Identifying
-  # Languages}[http://tools.ietf.org/rfc/bcp/bcp47.txt].
+  # Languages}[https://tools.ietf.org/html/bcp47].
 
   attr_reader :name
 

--- a/lib/rdoc/parser/changelog.rb
+++ b/lib/rdoc/parser/changelog.rb
@@ -9,7 +9,7 @@
 #
 # This parser is meant to parse the MRI ChangeLog, but can be used to parse any
 # {GNU style Change
-# Log}[http://www.gnu.org/prep/standards/html_node/Style-of-Change-Logs.html].
+# Log}[https://www.gnu.org/prep/standards/html_node/Style-of-Change-Logs.html].
 
 class RDoc::Parser::ChangeLog < RDoc::Parser
 

--- a/lib/shellwords.rb
+++ b/lib/shellwords.rb
@@ -65,7 +65,7 @@
 #
 # === Resources
 #
-# 1: {IEEE Std 1003.1-2008, 2016 Edition, the Shell & Utilities volume}[http://pubs.opengroup.org/onlinepubs/9699919799/utilities/contents.html]
+# 1: {IEEE Std 1003.1-2008, 2016 Edition, the Shell & Utilities volume}[https://pubs.opengroup.org/onlinepubs/9699919799/utilities/contents.html]
 
 module Shellwords
   # Splits a string into an array of tokens in the same way the UNIX

--- a/lib/time.rb
+++ b/lib/time.rb
@@ -15,10 +15,10 @@ require 'date'
 # This library extends the Time class with the following conversions between
 # date strings and Time objects:
 #
-# * date-time defined by {RFC 2822}[http://www.ietf.org/rfc/rfc2822.txt]
-# * HTTP-date defined by {RFC 2616}[http://www.ietf.org/rfc/rfc2616.txt]
+# * date-time defined by {RFC 2822}[https://www.ietf.org/rfc/rfc2822.txt]
+# * HTTP-date defined by {RFC 2616}[https://www.ietf.org/rfc/rfc2616.txt]
 # * dateTime defined by XML Schema Part 2: Datatypes ({ISO
-#   8601}[http://www.iso.org/iso/date_and_time_format])
+#   8601}[https://www.iso.org/iso/date_and_time_format])
 # * various formats handled by Date._parse
 # * custom formats handled by Date._strptime
 

--- a/lib/uri.rb
+++ b/lib/uri.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: false
 # URI is a module providing classes to handle Uniform Resource Identifiers
-# (RFC2396[http://tools.ietf.org/html/rfc2396]).
+# (RFC2396[https://tools.ietf.org/html/rfc2396]).
 #
 # == Features
 #
@@ -44,17 +44,17 @@
 #
 # == RFC References
 #
-# A good place to view an RFC spec is http://www.ietf.org/rfc.html.
+# A good place to view an RFC spec is https://www.rfc-editor.org/.
 #
 # Here is a list of all related RFC's:
-# - RFC822[http://tools.ietf.org/html/rfc822]
-# - RFC1738[http://tools.ietf.org/html/rfc1738]
-# - RFC2255[http://tools.ietf.org/html/rfc2255]
-# - RFC2368[http://tools.ietf.org/html/rfc2368]
-# - RFC2373[http://tools.ietf.org/html/rfc2373]
-# - RFC2396[http://tools.ietf.org/html/rfc2396]
-# - RFC2732[http://tools.ietf.org/html/rfc2732]
-# - RFC3986[http://tools.ietf.org/html/rfc3986]
+# - RFC822[https://www.rfc-editor.org/rfc/rfc822]
+#  RFC1738[https://www.rfc-editor.org/rfc/rfc1738]
+#  RFC2255[https://www.rfc-editor.org/rfc/rfc2255]
+#  RFC2368[https://www.rfc-editor.org/rfc/rfc2368]
+#  RFC2373[https://www.rfc-editor.org/rfc/rfc2373]
+#  RFC2396[https://www.rfc-editor.org/rfc/rfc2396]
+#  RFC2732[https://www.rfc-editor.org/rfc/rfc2732]
+#  RFC3986[https://www.rfc-editor.org/rfc/rfc3986]
 #
 # == Class tree
 #

--- a/lib/uri.rb
+++ b/lib/uri.rb
@@ -48,13 +48,13 @@
 #
 # Here is a list of all related RFC's:
 # - RFC822[https://www.rfc-editor.org/rfc/rfc822]
-#  RFC1738[https://www.rfc-editor.org/rfc/rfc1738]
-#  RFC2255[https://www.rfc-editor.org/rfc/rfc2255]
-#  RFC2368[https://www.rfc-editor.org/rfc/rfc2368]
-#  RFC2373[https://www.rfc-editor.org/rfc/rfc2373]
-#  RFC2396[https://www.rfc-editor.org/rfc/rfc2396]
-#  RFC2732[https://www.rfc-editor.org/rfc/rfc2732]
-#  RFC3986[https://www.rfc-editor.org/rfc/rfc3986]
+# - RFC1738[https://www.rfc-editor.org/rfc/rfc1738]
+# - RFC2255[https://www.rfc-editor.org/rfc/rfc2255]
+# - RFC2368[https://www.rfc-editor.org/rfc/rfc2368]
+# - RFC2373[https://www.rfc-editor.org/rfc/rfc2373]
+# - RFC2396[https://www.rfc-editor.org/rfc/rfc2396]
+# - RFC2732[https://www.rfc-editor.org/rfc/rfc2732]
+# - RFC3986[https://www.rfc-editor.org/rfc/rfc3986]
 #
 # == Class tree
 #


### PR DESCRIPTION
Updates URLs in documentation to their current location. Stumbled across a couple of these as I was reading through the source and figured I'd update them.

The following applies to the URLs in this PR. I'm sure there are many I didn't see and I didn't touch URLs in comments that didn't look like they were being used as documentation.
 * Any urls that auto redirect from `http` to `https` have been changed to `https`.
 * Dead links have been changed to an up to date location.
 * Urls have been checked for validity

Happy to add / remove / or change anything to how folks see fit! Happy to close this PR if it's not needed/wanted!