### PR TITLE
[DOC] The Document-method hint is needed only in C files

### DIFF
--- a/numeric.rb
+++ b/numeric.rb
@@ -210,8 +210,6 @@ class Integer
     self
   end
 
-  #
-  #  Document-method: Integer#size
   #  call-seq:
   #     int.size  ->  int
   #


### PR DESCRIPTION
'Document-method' string in C file has a special treatment. In Ruby source file, however, it is considered to be part of the documentation.

Note Numeric#size was migrated from C to Ruby, in 3208a5df2dfb429752a130a36274464e9924cf44

See also: https://ruby-doc.org/3.2.1/Integer.html#method-i-size

![scrot](https://user-images.githubusercontent.com/6666052/230876526-ced9ccbe-5451-4c62-aa42-475856589040.jpg)
