### PR TITLE
[Feature #19610] Implement GC.delay_promotion

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -745,6 +745,7 @@ typedef struct rb_objspace {
         unsigned int during_minor_gc : 1;
         unsigned int during_incremental_marking : 1;
         unsigned int measure_gc : 1;
+        unsigned int delay_promotion : 1;
     } flags;
 
     rb_event_flag_t hook_events;
@@ -958,6 +959,8 @@ struct heap_page {
     bits_t mark_bits[HEAP_PAGE_BITMAP_LIMIT];
     bits_t uncollectible_bits[HEAP_PAGE_BITMAP_LIMIT];
     bits_t marking_bits[HEAP_PAGE_BITMAP_LIMIT];
+
+    bits_t remembered_bits[HEAP_PAGE_BITMAP_LIMIT];
 
     /* If set, the object is not movable */
     bits_t pinned_bits[HEAP_PAGE_BITMAP_LIMIT];
@@ -1523,7 +1526,8 @@ check_rvalue_consistency_force(const VALUE obj, int terminate)
             const int wb_unprotected_bit = RVALUE_WB_UNPROTECTED_BITMAP(obj) != 0;
             const int uncollectible_bit = RVALUE_UNCOLLECTIBLE_BITMAP(obj) != 0;
             const int mark_bit = RVALUE_MARK_BITMAP(obj) != 0;
-            const int marking_bit = RVALUE_MARKING_BITMAP(obj) != 0, remembered_bit = marking_bit;
+            const int marking_bit = RVALUE_MARKING_BITMAP(obj) != 0;
+            const int remembered_bit = MARKED_IN_BITMAP(GET_HEAP_PAGE(obj)->remembered_bits, obj) != 0;
             const int age = RVALUE_FLAGS_AGE(RBASIC(obj)->flags);
 
             if (GET_HEAP_PAGE(obj)->flags.in_tomb) {
@@ -1657,7 +1661,7 @@ static inline int
 RVALUE_REMEMBERED(VALUE obj)
 {
     check_rvalue_consistency(obj);
-    return RVALUE_MARKING_BITMAP(obj) != 0;
+    return MARKED_IN_BITMAP(GET_HEAP_PAGE(obj)->remembered_bits, obj) != 0;
 }
 
 static inline int
@@ -1777,7 +1781,7 @@ RVALUE_DEMOTE(rb_objspace_t *objspace, VALUE obj)
     GC_ASSERT(RVALUE_OLD_P(obj));
 
     if (!is_incremental_marking(objspace) && RVALUE_REMEMBERED(obj)) {
-        CLEAR_IN_BITMAP(GET_HEAP_MARKING_BITS(obj), obj);
+        CLEAR_IN_BITMAP(GET_HEAP_PAGE(obj)->remembered_bits, obj);
     }
 
     RVALUE_DEMOTE_RAW(objspace, obj);
@@ -6902,28 +6906,41 @@ rgengc_check_relation(rb_objspace_t *objspace, VALUE obj)
 
     if (old_parent) { /* parent object is old */
         if (RVALUE_WB_UNPROTECTED(obj)) {
-            if (gc_remember_unprotected(objspace, obj)) {
-                gc_report(2, objspace, "relation: (O->S) %s -> %s\n", obj_info(old_parent), obj_info(obj));
+            if (UNLIKELY(objspace->flags.delay_promotion)) {
+                rgengc_remember(objspace, old_parent);
+            }
+            else {
+                if (gc_remember_unprotected(objspace, obj)) {
+                    gc_report(2, objspace, "relation: (O->S) %s -> %s\n", obj_info(old_parent), obj_info(obj));
+                }
             }
         }
         else {
             if (!RVALUE_OLD_P(obj)) {
-                if (RVALUE_MARKED(obj)) {
-                    /* An object pointed from an OLD object should be OLD. */
-                    gc_report(2, objspace, "relation: (O->unmarked Y) %s -> %s\n", obj_info(old_parent), obj_info(obj));
-                    RVALUE_AGE_SET_OLD(objspace, obj);
-                    if (is_incremental_marking(objspace)) {
-                        if (!RVALUE_MARKING(obj)) {
-                            gc_grey(objspace, obj);
+                if (UNLIKELY(objspace->flags.delay_promotion)) {
+                    /* We need to place the parent on the rememberset so
+                     * that next time we run minor GC, this parent will be
+                     * marked again. */
+                    rgengc_remember(objspace, old_parent);
+                }
+                else {
+                    if (RVALUE_MARKED(obj)) {
+                        /* An object pointed from an OLD object should be OLD. */
+                        gc_report(2, objspace, "relation: (O->unmarked Y) %s -> %s\n", obj_info(old_parent), obj_info(obj));
+                        RVALUE_AGE_SET_OLD(objspace, obj);
+                        if (is_incremental_marking(objspace)) {
+                            if (!RVALUE_MARKING(obj)) {
+                                gc_grey(objspace, obj);
+                            }
+                        }
+                        else {
+                            rgengc_remember(objspace, obj);
                         }
                     }
                     else {
-                        rgengc_remember(objspace, obj);
+                        gc_report(2, objspace, "relation: (O->Y) %s -> %s\n", obj_info(old_parent), obj_info(obj));
+                        RVALUE_AGE_SET_CANDIDATE(objspace, obj);
                     }
-                }
-                else {
-                    gc_report(2, objspace, "relation: (O->Y) %s -> %s\n", obj_info(old_parent), obj_info(obj));
-                    RVALUE_AGE_SET_CANDIDATE(objspace, obj);
                 }
             }
         }
@@ -8742,9 +8759,7 @@ static int
 rgengc_remembersetbits_set(rb_objspace_t *objspace, VALUE obj)
 {
     struct heap_page *page = GET_HEAP_PAGE(obj);
-    bits_t *bits = &page->marking_bits[0];
-
-    GC_ASSERT(!is_incremental_marking(objspace));
+    bits_t *bits = &page->remembered_bits[0];
 
     if (MARKED_IN_BITMAP(bits, obj)) {
         return FALSE;
@@ -8837,7 +8852,7 @@ rgengc_rememberset_mark(rb_objspace_t *objspace, rb_heap_t *heap)
         if (page->flags.has_remembered_objects | page->flags.has_uncollectible_shady_objects) {
             uintptr_t p = page->start;
             bits_t bitset, bits[HEAP_PAGE_BITMAP_LIMIT];
-            bits_t *marking_bits = page->marking_bits;
+            bits_t *remembered_bits = page->remembered_bits;
             bits_t *uncollectible_bits = page->uncollectible_bits;
             bits_t *wb_unprotected_bits = page->wb_unprotected_bits;
 #if PROFILE_REMEMBERSET_MARK
@@ -8846,8 +8861,8 @@ rgengc_rememberset_mark(rb_objspace_t *objspace, rb_heap_t *heap)
             else if (page->flags.has_uncollectible_shady_objects) has_shady++;
 #endif
             for (j=0; j<HEAP_PAGE_BITMAP_LIMIT; j++) {
-                bits[j] = marking_bits[j] | (uncollectible_bits[j] & wb_unprotected_bits[j]);
-                marking_bits[j] = 0;
+                bits[j] = remembered_bits[j] | (uncollectible_bits[j] & wb_unprotected_bits[j]);
+                remembered_bits[j] = 0;
             }
             page->flags.has_remembered_objects = FALSE;
 
@@ -8884,6 +8899,7 @@ rgengc_mark_and_rememberset_clear(rb_objspace_t *objspace, rb_heap_t *heap)
         memset(&page->mark_bits[0],       0, HEAP_PAGE_BITMAP_SIZE);
         memset(&page->uncollectible_bits[0], 0, HEAP_PAGE_BITMAP_SIZE);
         memset(&page->marking_bits[0],    0, HEAP_PAGE_BITMAP_SIZE);
+        memset(&page->remembered_bits[0], 0, HEAP_PAGE_BITMAP_SIZE);
         memset(&page->pinned_bits[0],     0, HEAP_PAGE_BITMAP_SIZE);
         page->flags.has_uncollectible_shady_objects = FALSE;
         page->flags.has_remembered_objects = FALSE;
@@ -8957,16 +8973,26 @@ gc_writebarrier_incremental(VALUE a, VALUE b, rb_objspace_t *objspace)
         }
         else if (RVALUE_OLD_P(a) && !RVALUE_OLD_P(b)) {
             if (!RVALUE_WB_UNPROTECTED(b)) {
-                gc_report(1, objspace, "gc_writebarrier_incremental: [GN] %p -> %s\n", (void *)a, obj_info(b));
-                RVALUE_AGE_SET_OLD(objspace, b);
+                if (UNLIKELY(objspace->flags.delay_promotion)) {
+                    rgengc_remember(objspace, a);
+                }
+                else {
+                    gc_report(1, objspace, "gc_writebarrier_incremental: [GN] %p -> %s\n", (void *)a, obj_info(b));
+                    RVALUE_AGE_SET_OLD(objspace, b);
 
-                if (RVALUE_BLACK_P(b)) {
-                    gc_grey(objspace, b);
+                    if (RVALUE_BLACK_P(b)) {
+                        gc_grey(objspace, b);
+                    }
                 }
             }
             else {
                 gc_report(1, objspace, "gc_writebarrier_incremental: [LL] %p -> %s\n", (void *)a, obj_info(b));
-                gc_remember_unprotected(objspace, b);
+                if (UNLIKELY(objspace->flags.delay_promotion)) {
+                    rgengc_remember(objspace, a);
+                }
+                else {
+                    gc_remember_unprotected(objspace, b);
+                }
             }
         }
 
@@ -9854,7 +9880,6 @@ gc_move(rb_objspace_t *objspace, VALUE scan, VALUE free, size_t src_slot_size, s
     int marked;
     int wb_unprotected;
     int uncollectible;
-    int marking;
     RVALUE *dest = (RVALUE *)free;
     RVALUE *src = (RVALUE *)scan;
 
@@ -9863,17 +9888,19 @@ gc_move(rb_objspace_t *objspace, VALUE scan, VALUE free, size_t src_slot_size, s
     GC_ASSERT(BUILTIN_TYPE(scan) != T_NONE);
     GC_ASSERT(!MARKED_IN_BITMAP(GET_HEAP_MARK_BITS(free), free));
 
+    GC_ASSERT(!RVALUE_MARKING((VALUE)src));
+
     /* Save off bits for current object. */
     marked = rb_objspace_marked_object_p((VALUE)src);
     wb_unprotected = RVALUE_WB_UNPROTECTED((VALUE)src);
     uncollectible = RVALUE_UNCOLLECTIBLE((VALUE)src);
-    marking = RVALUE_MARKING((VALUE)src);
+    bool remembered = RVALUE_REMEMBERED((VALUE)src);
 
     /* Clear bits for eventual T_MOVED */
     CLEAR_IN_BITMAP(GET_HEAP_MARK_BITS((VALUE)src), (VALUE)src);
     CLEAR_IN_BITMAP(GET_HEAP_WB_UNPROTECTED_BITS((VALUE)src), (VALUE)src);
     CLEAR_IN_BITMAP(GET_HEAP_UNCOLLECTIBLE_BITS((VALUE)src), (VALUE)src);
-    CLEAR_IN_BITMAP(GET_HEAP_MARKING_BITS((VALUE)src), (VALUE)src);
+    CLEAR_IN_BITMAP(GET_HEAP_PAGE((VALUE)src)->remembered_bits, (VALUE)src);
 
     if (FL_TEST((VALUE)src, FL_EXIVAR)) {
         /* Resizing the st table could cause a malloc */
@@ -9912,11 +9939,11 @@ gc_move(rb_objspace_t *objspace, VALUE scan, VALUE free, size_t src_slot_size, s
     memset(src, 0, src_slot_size);
 
     /* Set bits for object in new location */
-    if (marking) {
-        MARK_IN_BITMAP(GET_HEAP_MARKING_BITS((VALUE)dest), (VALUE)dest);
+    if (remembered) {
+        MARK_IN_BITMAP(GET_HEAP_PAGE(dest)->remembered_bits, (VALUE)dest);
     }
     else {
-        CLEAR_IN_BITMAP(GET_HEAP_MARKING_BITS((VALUE)dest), (VALUE)dest);
+        CLEAR_IN_BITMAP(GET_HEAP_PAGE(dest)->remembered_bits, (VALUE)dest);
     }
 
     if (marked) {
@@ -10657,7 +10684,7 @@ gc_ref_update(void *vstart, void *vend, size_t stride, rb_objspace_t * objspace,
             if (RVALUE_WB_UNPROTECTED(v)) {
                 page->flags.has_uncollectible_shady_objects = TRUE;
             }
-            if (RVALUE_PAGE_MARKING(page, v)) {
+            if (RVALUE_REMEMBERED(v)) {
                 page->flags.has_remembered_objects = TRUE;
             }
             if (page->flags.before_sweep) {
@@ -11518,6 +11545,52 @@ static VALUE
 gc_disable(rb_execution_context_t *ec, VALUE _)
 {
     return rb_gc_disable();
+}
+
+/*
+ * call-seq:
+ *     GC.delay_promotion = enabled
+ *
+ * Configures the object ageing behavior.
+ *
+ * When set to +false+, references from an old object to a write barrier
+ * protected young object will immediately promote the young object.
+ * References from an old object to a write barrier unprotected object will
+ * place the write barrier unprotected object in the remember set for marking
+ * during minor collections.
+ *
+ * When set to +true+, references from an old object to a write barrier
+ * protected young object will not immediately promote the young object.
+ * Instead, the young object will age just like any other object, meaning that
+ * it has to survive three collections before being promoted to the old
+ * generation.
+ * References from an old object to a write barrier unprotected object will
+ * place the parent object in the remember set for marking during minor
+ * collections. This allows the child object to be reclaimed in minor
+ * collections at the cost of increased time for minor collections.
+ *
+ * This method is only expected to work on CRuby.
+ */
+static VALUE
+gc_set_delay_promotion(VALUE _, VALUE v)
+{
+    rb_objspace_t *objspace = &rb_objspace;
+    gc_rest(objspace);
+    objspace->flags.delay_promotion = RTEST(v);
+    return v;
+}
+
+/*
+ * call-seq:
+ *     GC.delay_promotion -> true or false
+ *
+ * Returns the value set in #delay_promotion=. Defaults to +false+.
+ */
+static VALUE
+gc_get_delay_promotion(VALUE _)
+{
+    rb_objspace_t *objspace = &rb_objspace;
+    return objspace->flags.delay_promotion ? Qtrue : Qfalse;
 }
 
 #if GC_CAN_COMPILE_COMPACTION
@@ -13997,6 +14070,9 @@ Init_GC(void)
     rb_define_singleton_method(rb_mGC, "malloc_allocated_size", gc_malloc_allocated_size, 0);
     rb_define_singleton_method(rb_mGC, "malloc_allocations", gc_malloc_allocations, 0);
 #endif
+
+    rb_define_singleton_method(rb_mGC, "delay_promotion=", gc_set_delay_promotion, 1);
+    rb_define_singleton_method(rb_mGC, "delay_promotion", gc_get_delay_promotion, 0);
 
     if (GC_COMPACTION_SUPPORTED) {
         rb_define_singleton_method(rb_mGC, "compact", gc_compact, 0);

--- a/test/ruby/test_gc.rb
+++ b/test/ruby/test_gc.rb
@@ -643,4 +643,58 @@ class TestGc < Test::Unit::TestCase
     Module.new.class_eval( (["# shareable_constant_value: literal"] +
                             (0..100000).map {|i| "M#{ i } = {}" }).join("\n"))
   end
+
+  def test_delay_promotion_enable
+    original_delay_promotion = GC.delay_promotion
+    original_gc_disabled = GC.disable
+
+    require "objspace"
+
+    GC.delay_promotion = true
+
+    old_obj = Object.new
+    4.times { GC.start }
+
+    assert_include ObjectSpace.dump(old_obj), '"old":true'
+
+    young_obj = Object.new
+    old_obj.instance_variable_set(:@test, young_obj)
+
+    # Not immediately promoted to old generation
+    3.times do
+      assert_not_include ObjectSpace.dump(young_obj), '"old":true'
+      GC.start
+    end
+
+    # Takes 4 GC to promote to old generation
+    GC.start
+    assert_include ObjectSpace.dump(young_obj), '"old":true'
+  ensure
+    GC.delay_promotion = original_delay_promotion
+    GC.enable if !original_gc_disabled
+  end
+
+  def test_delay_promotion_disable
+    original_delay_promotion = GC.delay_promotion
+    original_gc_disabled = GC.disable
+
+    require "objspace"
+
+    GC.delay_promotion = false
+
+    old_obj = Object.new
+    4.times { GC.start }
+
+    assert_include ObjectSpace.dump(old_obj), '"old":true'
+
+    young_obj = Object.new
+    old_obj.instance_variable_set(:@test, young_obj)
+
+    # Immediately promoted to old generation
+    GC.start
+    assert_include ObjectSpace.dump(young_obj), '"old":true'
+  ensure
+    GC.delay_promotion = original_delay_promotion
+    GC.enable if !original_gc_disabled
+  end
 end


### PR DESCRIPTION
I'm proposing `GC.delay_promotion`, which is a feature that changes characteristics of the garbage collector.

When set to `false` (the default value), the GC keeps the original behavior. This means that references from an old object to a write barrier protected young object will immediately promote the young object. References from an old object to a write barrier unprotected object will place the write barrier unprotected object in the remember set for marking during minor collections.

When set to `true`, references from an old object to a write barrier protected young object will not immediately promote the young object. Instead, the young object will age just like any other object, meaning that it has to survive three collections before being promoted to the old generation. References from an old object to a write barrier unprotected object will place the parent object in the remember set for marking during minor collections. This allows the child object to be reclaimed in minor collections at the cost of increased time for minor collections.

On one of [Shopify's highest traffic Ruby apps, Storefront Renderer](https://shopify.engineering/how-shopify-reduced-storefront-response-times-rewrite), we saw significant improvements after deploying this feature in production. In the graphs below, we compare the GC time and response time of web workers that have `GC.delay_promotion = false` (non-experimental group) and `GC.delay_promotion = true` (experimental group). We see that with this feature we spend significantly less time in the GC, 0.81x on average, 0.88x on p99, and 0.45x on p99.9.

<img width="1974" alt="Screenshot 2023-04-20 at 11 49 12 AM" src="https://user-images.githubusercontent.com/15860699/233419676-bf227834-d4e4-429f-ac07-78566ee519b4.png">

This translates to improvements in average response time (0.96x) and p99 response time (0.92x).

<img width="1962" alt="Screenshot 2023-04-20 at 11 49 26 AM" src="https://user-images.githubusercontent.com/15860699/233419727-c9884f32-f152-4b3e-abe5-3f9d8bc222f4.png">

In benchmarks, this feature performs better in some scenarios and worse in others. However, these benchmarks are usually not a good indicator as there are few old objects and major collections are not a significant bottleneck.

```
--------------  -----------  ----------  ---------  -----------  ----------  ---------  --------------  -------------
bench           master (ms)  stddev (%)  RSS (MiB)  branch (ms)  stddev (%)  RSS (MiB)  branch 1st itr  master/branch
activerecord    70.7         0.2         54.4       70.5         0.3         54.7       1.01            1.00
erubi_rails     20.5         2.0         103.0      20.7         2.2         102.2      0.94            0.99
hexapdf         2470.1       0.3         275.6      2475.4       0.7         215.9      1.03            1.00
liquid-c        65.2         1.4         39.8       65.4         0.3         39.7       1.05            1.00
liquid-compile  59.5         3.4         38.9       57.5         3.0         38.3       0.99            1.04
liquid-render   164.3        1.1         36.1       159.8        0.2         35.5       1.02            1.03
mail            135.7        0.2         50.2       135.3        0.1         50.0       1.00            1.00
psych-load      2053.0       0.0         36.4       2003.3       0.1         35.3       1.03            1.02
railsbench      2001.8       0.7         107.1      1965.1       0.0         107.3      1.00            1.02
ruby-lsp        67.1         8.7         94.6       65.1         0.8         92.8       0.97            1.03
sequel          72.4         0.2         40.4       71.3         0.2         40.4       1.01            1.02
--------------  -----------  ----------  ---------  -----------  ----------  ---------  --------------  -------------
```