### PR TITLE
YJIT: Avoid using a register for unspecified_bits

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -3822,3 +3822,22 @@ assert_equal '[true, true, true, true]', %q{
 assert_equal '0', %q{
   3[0, 0]
 }
+
+# unspecified_bits + checkkeyword
+assert_equal '2', %q{
+  def callee = 1
+
+  # checkkeyword should see unspecified_bits=0 (use bar), not Integer 1 (set bar = foo).
+  def foo(foo, bar: foo) = bar
+
+  def entry(&block)
+    # write 1 at stack[3]. Calling #callee spills stack[3].
+    1 + (1 + (1 + (1 + callee)))
+    # &block is written to a register instead of stack[3]. When &block is popped and
+    # unspecified_bits is pushed, it must be written to stack[3], not to a register.
+    foo(1, bar: 2, &block)
+  end
+
+  entry # call branch_stub_hit (spill temps)
+  entry # doesn't call branch_stub_hit (not spill temps)
+}

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -6172,6 +6172,7 @@ fn gen_send_iseq(
         // pushed onto the stack that represents the parameters that weren't
         // explicitly given a value and have a non-constant default.
         let unspec_opnd = VALUE::fixnum_from_usize(unspecified_bits).as_u64();
+        asm.spill_temps(ctx); // avoid using a register for unspecified_bits
         asm.mov(ctx.stack_opnd(-1), unspec_opnd.into());
     }
 


### PR DESCRIPTION
Fix [[Bug #19586]](https://bugs.ruby-lang.org/issues/19586)

Because `unspec_opnd` uses a slot above the stack top, calling `ctx.spill_temps` later did not spill `unspec_opnd` as expected. This PR makes sure the register bit for `unspec_opnd` is unset by this `ctx.spill_temps`.