### PR TITLE
Change max_iv_count to type attr_index_t

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -7351,7 +7351,7 @@ gc_mark_children(rb_objspace_t *objspace, VALUE obj)
                 VALUE klass = RBASIC_CLASS(obj);
 
                 // Increment max_iv_count if applicable, used to determine size pool allocation
-                uint32_t num_of_ivs = shape->next_iv_index;
+                attr_index_t num_of_ivs = shape->next_iv_index;
                 if (RCLASS_EXT(klass)->max_iv_count < num_of_ivs) {
                     RCLASS_EXT(klass)->max_iv_count = num_of_ivs;
                 }

--- a/internal/class.h
+++ b/internal/class.h
@@ -65,7 +65,7 @@ struct rb_classext_struct {
 #if !SHAPE_IN_BASIC_FLAGS
     shape_id_t shape_id;
 #endif
-    uint32_t max_iv_count;
+    attr_index_t max_iv_count;
     unsigned char variation_count;
     bool permanent_classpath;
     VALUE classpath;


### PR DESCRIPTION
max_iv_count is calculated from next_iv_index of the shape, which is of type attr_index_t, so we can also make max_iv_count of type attr_index_t.

cc. @jemmaissroff 