### PR TITLE
[DOC] Add doc for behavior when passing nil to Comparable#clamp(min, max)

### DIFF
--- a/compar.c
+++ b/compar.c
@@ -187,6 +187,12 @@ cmp_between(VALUE x, VALUE min, VALUE max)
  *     'd'.clamp('a', 'f')      #=> 'd'
  *     'z'.clamp('a', 'f')      #=> 'f'
  *
+ * If _min_ is +nil+, it is considered smaller than _obj_,
+ * and if _max_ is +nil+, it is considered greater than _obj_.
+ *
+ *     -20.clamp(0, nil)           #=> 0
+ *     523.clamp(nil, 100)         #=> 100
+ *
  * In <code>(range)</code> form, returns _range.begin_ if _obj_
  * <code><=></code> _range.begin_ is less than zero, _range.end_
  * if _obj_ <code><=></code> _range.end_ is greater than zero, and


### PR DESCRIPTION
Allow `Comparable#clamp(min, max)` to accept nil as a specification.

Please check https://bugs.ruby-lang.org/issues/19588 for detail.