### PR TITLE
Fix declaration of `rb_rjit_entry_stub_hit` in rjit_c.c

### DIFF
--- a/rjit_c.c
+++ b/rjit_c.c
@@ -531,7 +531,7 @@ extern const rb_callable_method_entry_t *rb_callable_method_entry_or_negative(VA
 extern VALUE rb_vm_yield_with_cfunc(rb_execution_context_t *ec, const struct rb_captured_block *captured, int argc, const VALUE *argv);
 extern VALUE rb_vm_set_ivar_id(VALUE obj, ID id, VALUE val);
 extern VALUE rb_ary_unshift_m(int argc, VALUE *argv, VALUE ary);
-extern void* rb_rjit_entry_stub_hit(VALUE branch_stub, int sp_offset, int target0_p);
+extern void* rb_rjit_entry_stub_hit(VALUE branch_stub);
 extern void* rb_rjit_branch_stub_hit(VALUE branch_stub, int sp_offset, int target0_p);
 
 #include "rjit_c.rbinc"


### PR DESCRIPTION
https://github.com/ruby/ruby/actions/runs/4591157404/jobs/8107135563#step:14:185
```
linking miniruby
../src/rjit_c.c:533:14: warning: type of 'rb_rjit_entry_stub_hit' does not match original declaration [-Wlto-type-mismatch]
  533 | extern void* rb_rjit_entry_stub_hit(VALUE branch_stub, int sp_offset, int target0_p);
      |              ^
../src/rjit.c:364:1: note: type mismatch in parameter 2
  364 | rb_rjit_entry_stub_hit(VALUE branch_stub)
      | ^
../src/rjit.c:364:1: note: type 'void' should match type 'int'
../src/rjit.c:364:1: note: 'rb_rjit_entry_stub_hit' was previously declared here
```
