### PR TITLE
YJIT: Fix missing argc check in known cfuncs

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -1227,6 +1227,38 @@ assert_equal '42', %q{
   run
 }
 
+# splatting an empty array on a specialized method
+assert_equal 'ok', %q{
+  def run
+    "ok".to_s(*[])
+  end
+
+  run
+  run
+}
+
+# splatting an single element array on a specialized method
+assert_equal '[1]', %q{
+  def run
+    [].<<(*[1])
+  end
+
+  run
+  run
+}
+
+# specialized method with wrong args
+assert_equal 'ok', %q{
+  def run(x)
+    "bad".to_s(123) if x
+  rescue
+    :ok
+  end
+
+  run(false)
+  run(true)
+}
+
 # getinstancevariable on Symbol
 assert_equal '[nil, nil]', %q{
   # @foo to exercise the getinstancevariable instruction

--- a/lib/ruby_vm/rjit/insn_compiler.rb
+++ b/lib/ruby_vm/rjit/insn_compiler.rb
@@ -4937,7 +4937,7 @@ module RubyVM::RJIT
       end
 
       # Delegate to codegen for C methods if we have it.
-      if kw_arg.nil? && flags & C::VM_CALL_OPT_SEND == 0
+      if kw_arg.nil? && flags & C::VM_CALL_OPT_SEND == 0 && flags & C::VM_CALL_ARGS_SPLAT == 0 && (cfunc_argc == -1 || argc == cfunc_argc)
         known_cfunc_codegen = lookup_cfunc_codegen(cme.def)
         if known_cfunc_codegen&.call(jit, ctx, asm, argc, known_recv_class)
           # cfunc codegen generated code. Terminate the block so

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -4987,10 +4987,12 @@ fn gen_send_cfunc(
     }
 
     // Delegate to codegen for C methods if we have it.
-    if kw_arg.is_null() && flags & VM_CALL_OPT_SEND == 0 {
+    if kw_arg.is_null() && flags & VM_CALL_OPT_SEND == 0 && flags & VM_CALL_ARGS_SPLAT == 0 && (cfunc_argc == -1 || argc == cfunc_argc) {
         let codegen_p = lookup_cfunc_codegen(unsafe { (*cme).def });
+        let expected_stack_after = asm.ctx.get_stack_size() as i32 - argc;
         if let Some(known_cfunc_codegen) = codegen_p {
             if known_cfunc_codegen(jit, asm, ocb, ci, cme, block, argc, recv_known_klass) {
+                assert_eq!(expected_stack_after, asm.ctx.get_stack_size() as i32);
                 // cfunc codegen generated code. Terminate the block so
                 // there isn't multiple calls in the same block.
                 jump_to_next_insn(jit, asm, ocb);


### PR DESCRIPTION
Previously we were missing a compile-time check that the known cfuncs receive the correct number of arguments.

```
$ ruby --yjit-call-threshold=1 -e '"foo".to_s(*[])'
ruby: YJIT has panicked. More info to follow...
thread '<unnamed>' panicked at 'assertion failed: `(left == right)`
  left: `1`,
 right: `2`', ./yjit/src/codegen.rs:7225:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-e:1: [BUG] YJIT panicked
ruby 3.3.0dev (2023-04-08T18:54:01Z master 671cfc2000) +YJIT [x86_64-linux]
```

We noticed this because in particular when using ARGS_SPLAT, which also wasn't checked, YJIT would crash on code which was otherwise correct (didn't raise exceptions in the VM).

This still supports vararg (argc == -1) cfuncs. I added an additional assertion that when we use the specialized codegen for one of these known functions that the argc are popped off the stack correctly, which should help ensure they're implemented correctly (previously the crash was usually observed on a future `leave` insn).

We should backport this to Ruby 3.2 as well as it seems affected by the non-splat case (it's a little harder to make happen since the code would normally raise an exception on the VM). ex. `ruby --yjit-call-threshold=1 -e '"foo".to_s(1)'`

Ruby 3.1 doesn't seem to have this issue because at that time we [checked argc early enough](https://github.com/ruby/ruby/blob/ruby_3_1/yjit_codegen.c#L3232-L3236).