### PR TITLE
YJIT: Fix edge and total counts in exit_locations

### DIFF
--- a/yjit.rb
+++ b/yjit.rb
@@ -70,6 +70,8 @@ module RubyVM::YJIT
       stack_length = raw_samples[i] + 1
       i += 1 # consume the stack length
 
+      sample_count = raw_samples[i + stack_length]
+
       prev_frame_id = nil
       stack_length.times do |idx|
         idx += i
@@ -78,14 +80,14 @@ module RubyVM::YJIT
         if prev_frame_id
           prev_frame = frames[prev_frame_id]
           prev_frame[:edges][frame_id] ||= 0
-          prev_frame[:edges][frame_id] += 1
+          prev_frame[:edges][frame_id] += sample_count
         end
 
         frame_info = frames[frame_id]
-        frame_info[:total_samples] += 1
+        frame_info[:total_samples] += sample_count
 
         frame_info[:lines][line_samples[idx]] ||= [0, 0]
-        frame_info[:lines][line_samples[idx]][0] += 1
+        frame_info[:lines][line_samples[idx]][0] += sample_count
 
         prev_frame_id = frame_id
       end
@@ -94,8 +96,6 @@ module RubyVM::YJIT
 
       top_frame_id = prev_frame_id
       top_frame_line = 1
-
-      sample_count = raw_samples[i]
 
       frames[top_frame_id][:samples] += sample_count
       frames[top_frame_id][:lines] ||= {}


### PR DESCRIPTION
The stackprof-format raw samples are suffixed with a count (ie. how many times did the previously recorded side-exit repeat). Previously we were correctly using this value to increment the `:samples` count, but not the `:total_samples` count or edges.

This made the stackprof aggregate results incorrect (though any flamegraphs generated should have been correct, since those only rely on raw samples).

test script:
```
def bar(**args)
end

1000.times do
  bar() # side exit
end
```


**Before**

```
$ ./miniruby --yjit-trace-exits test.rb && stackprof yjit_exit_locations.dump --method=opt_send_without_block
opt_send_without_block (nonexistent.def:1)
  samples:   971 self (98.3%)  /      1 total (0.1%)
  callers:
       1  (  100.0%)  block in <main>
  callees (-970 total):
  code:
        SOURCE UNAVAILABLE
```

**After**

```
$ ./miniruby --yjit-trace-exits test.rb && stackprof yjit_exit_locations.dump --method=opt_send_without_block
opt_send_without_block (nonexistent.def:1)
  samples:   971 self (98.3%)  /    971 total (98.3%)
  callers:
     971  (  100.0%)  block in <main>
  callees (0 total):
  code:
        SOURCE UNAVAILABLE
```