### PR TITLE
Pass -Werror=lto-type-mismatch for GCC LTO jobs

### DIFF
--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -78,10 +78,10 @@ jobs:
           - { name: gcc-9,     env: { default_cc: gcc-9 } }
           - { name: gcc-8,     env: { default_cc: gcc-8 } }
           - { name: gcc-7,     env: { default_cc: gcc-7 } }
-          - name: 'gcc-11 LTO'
-            container: gcc-11
+          - name: 'gcc-13 LTO'
+            container: gcc-13
             env:
-              default_cc: 'gcc-11 -flto=auto -ffat-lto-objects -Werror=lto-type-mismatch'
+              default_cc: 'gcc-13 -flto=auto -ffat-lto-objects -Werror=lto-type-mismatch'
               optflags: '-O2'
             shared: disable
             # check: true

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -97,10 +97,10 @@ jobs:
           - { name: clang-8,   env: { default_cc: clang-8 } }
           - { name: clang-7,   env: { default_cc: clang-7 } }
           - { name: clang-6.0, env: { default_cc: clang-6.0 } }
-          - name: 'clang-14 LTO'
-            container: clang-14
+          - name: 'clang-16 LTO'
+            container: clang-16
             env:
-              default_cc: 'clang-14 -flto=auto'
+              default_cc: 'clang-16 -flto=auto'
               optflags: '-O2'
             shared: disable
             # check: true

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -81,7 +81,7 @@ jobs:
           - name: 'gcc-11 LTO'
             container: gcc-11
             env:
-              default_cc: 'gcc-11 -flto=auto -ffat-lto-objects'
+              default_cc: 'gcc-11 -flto=auto -ffat-lto-objects -Werror=lto-type-mismatch'
               optflags: '-O2'
             shared: disable
             # check: true


### PR DESCRIPTION
This helps to find possible LTO miscompilations earlier. See also https://github.com/ruby/ruby/pull/7695.