### PR TITLE
Avoid seeding OpenSSL for SecureRandom

### DIFF
--- a/lib/securerandom.rb
+++ b/lib/securerandom.rb
@@ -47,17 +47,6 @@ module SecureRandom
     private
 
     def gen_random_openssl(n)
-      @pid = 0 unless defined?(@pid)
-      pid = $$
-      unless @pid == pid
-        now = Process.clock_gettime(Process::CLOCK_REALTIME, :nanosecond)
-        OpenSSL::Random.random_add([now, @pid, pid].join(""), 0.0)
-        seed = Random.urandom(16)
-        if (seed)
-          OpenSSL::Random.random_add(seed, 16)
-        end
-        @pid = pid
-      end
       return OpenSSL::Random.random_bytes(n)
     end
 


### PR DESCRIPTION
OpenSSL's man page previously stated that "the application is responsible for seeding the PRNG by calling RAND_add" (see [1]). So we had this code.  However things changed.  They no longer say so, instead "manual (re-)seeding of the default OpenSSL random generator is not necessary" now (see [2]).  It seems all OpenSSL versions that we support now already behaves like this. Let's follow that.

[1]: https://www.openssl.org/docs/man1.0.2/man3/RAND_add.html
[2]: https://www.openssl.org/docs/manmaster/man3/RAND_add.html