### PR TITLE
Add RB_WARN_CATEGORY_DEFAULT_BITS

### DIFF
--- a/error.c
+++ b/error.c
@@ -150,7 +150,7 @@ rb_syntax_error_append(VALUE exc, VALUE file, int line, int column,
 
 static unsigned int warning_disabled_categories = (
     (1U << RB_WARN_CATEGORY_DEPRECATED) |
-    ~RB_WARN_CATEGORY_ALL_BITS);
+    ~RB_WARN_CATEGORY_DEFAULT_BITS);
 
 static unsigned int
 rb_warning_category_mask(VALUE category)

--- a/include/ruby/internal/error.h
+++ b/include/ruby/internal/error.h
@@ -53,9 +53,15 @@ typedef enum {
     /** Warning is for performance issues (not enabled by -w). */
     RB_WARN_CATEGORY_PERFORMANCE,
 
+    RB_WARN_CATEGORY_DEFAULT_BITS = (
+        (1U << RB_WARN_CATEGORY_DEPRECATED) |
+        (1U << RB_WARN_CATEGORY_EXPERIMENTAL) |
+        0),
+
     RB_WARN_CATEGORY_ALL_BITS = (
         (1U << RB_WARN_CATEGORY_DEPRECATED) |
         (1U << RB_WARN_CATEGORY_EXPERIMENTAL) |
+        (1U << RB_WARN_CATEGORY_PERFORMANCE) |
         0)
 } rb_warning_category_t;
 

--- a/ruby.c
+++ b/ruby.c
@@ -1174,7 +1174,7 @@ proc_options(long argc, char **argv, ruby_cmdline_options_t *opt, int envopt)
                 warning = 1;
                 ruby_verbose = Qtrue;
             }
-            FEATURE_SET(opt->warn, RB_WARN_CATEGORY_ALL_BITS);
+            FEATURE_SET(opt->warn, RB_WARN_CATEGORY_DEFAULT_BITS);
             s++;
             goto reswitch;
 
@@ -1226,13 +1226,13 @@ proc_options(long argc, char **argv, ruby_cmdline_options_t *opt, int envopt)
                 warning = 1;
                 switch (v) {
                   case 0:
-                    FEATURE_SET_TO(opt->warn, RB_WARN_CATEGORY_ALL_BITS, 0);
+                    FEATURE_SET_TO(opt->warn, RB_WARN_CATEGORY_DEFAULT_BITS, 0);
                     break;
                   case 1:
                     FEATURE_SET_TO(opt->warn, 1U << RB_WARN_CATEGORY_DEPRECATED, 0);
                     break;
                   default:
-                    FEATURE_SET(opt->warn, RB_WARN_CATEGORY_ALL_BITS);
+                    FEATURE_SET(opt->warn, RB_WARN_CATEGORY_DEFAULT_BITS);
                     break;
                 }
             }


### PR DESCRIPTION
Followup: ac123f167a364c3d7a43eca78d564e41f6dbb91e

RB_WARN_CATEGORY_ALL_BITS is exposed in a public header, so it makes sense for it to be updated to contain all valid bits.

Instead we introduce RB_WARN_CATEGORY_DEFAULT_BITS to list the categories that are enabled by default.