### PR TITLE
YJIT: Fix false object collection when setting ivar

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -1,3 +1,23 @@
+# Regression test for GC mishap while doing shape transition
+assert_equal '[:ok]', %q{
+  # [Bug #19601]
+  class RegressionTest
+    def initialize
+      @a = @b = @fourth_ivar_does_shape_transition = nil
+    end
+
+    def extender
+      @first_extended_ivar = [:ok]
+    end
+  end
+
+  GC.stress = true
+
+  # Used to crash due to GC run in rb_ensure_iv_list_size()
+  # not marking the newly allocated [:ok].
+  RegressionTest.new.extender.itself
+}
+
 assert_equal 'true', %q{
   # regression test for tracking type of locals for too long
   def local_setting_cmp(five)

--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -16,7 +16,7 @@ assert_equal '[:ok]', %q{
   # Used to crash due to GC run in rb_ensure_iv_list_size()
   # not marking the newly allocated [:ok].
   RegressionTest.new.extender.itself
-}
+} unless RUBY_DESCRIPTION.include?('+RJIT') # Skip on RJIT since this uncovers a crash
 
 assert_equal 'true', %q{
   # regression test for tracking type of locals for too long

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -2290,6 +2290,11 @@ fn gen_setinstancevariable(
                 if needs_extension {
                     // Generate the C call so that runtime code will increase
                     // the capacity and set the buffer.
+                    asm.comment("call rb_ensure_iv_list_size");
+
+                    // It allocates so can trigger GC, which takes the VM lock
+                    // so could yield to a different ractor.
+                    jit_prepare_routine_call(jit, asm);
                     asm.spill_temps(); // for ccall
                     asm.ccall(rb_ensure_iv_list_size as *const u8,
                               vec![

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -2295,7 +2295,6 @@ fn gen_setinstancevariable(
                     // It allocates so can trigger GC, which takes the VM lock
                     // so could yield to a different ractor.
                     jit_prepare_routine_call(jit, asm);
-                    asm.spill_temps(); // for ccall
                     asm.ccall(rb_ensure_iv_list_size as *const u8,
                               vec![
                                   recv,


### PR DESCRIPTION
Previously, setinstancevariable could generate code that calls
`rb_ensure_iv_list_size()` without first updating `cfp->sp`. This means
in the event that a GC start from within said routine the top few
objects would not be marked, causing them to be falsly collected.

Call `jit_prepare_routine_call()` first.

[[Bug #19601]](https://bugs.ruby-lang.org/issues/19601)
