### PR TITLE
Make classes embedded on 32 bit 

### DIFF
--- a/class.c
+++ b/class.c
@@ -193,22 +193,14 @@ rb_class_detach_module_subclasses(VALUE klass)
 static VALUE
 class_alloc(VALUE flags, VALUE klass)
 {
-    size_t alloc_size = sizeof(struct RClass);
-
-#if RCLASS_EXT_EMBEDDED
-    alloc_size += sizeof(rb_classext_t);
-#endif
+    size_t alloc_size = sizeof(struct RClass) + sizeof(rb_classext_t);
 
     flags &= T_MASK;
     flags |= FL_PROMOTED1 /* start from age == 2 */;
     if (RGENGC_WB_PROTECTED_CLASS) flags |= FL_WB_PROTECTED;
     NEWOBJ_OF(obj, struct RClass, klass, flags, alloc_size, 0);
 
-#if RCLASS_EXT_EMBEDDED
     memset(RCLASS_EXT(obj), 0, sizeof(rb_classext_t));
-#else
-    obj->ptr = ZALLOC(rb_classext_t);
-#endif
 
     /* ZALLOC
       RCLASS_CONST_TBL(obj) = 0;

--- a/class.c
+++ b/class.c
@@ -508,8 +508,8 @@ rb_mod_init_copy(VALUE clone, VALUE orig)
     /* cloned flag is refer at constant inline cache
      * see vm_get_const_key_cref() in vm_insnhelper.c
      */
-    FL_SET(clone, RCLASS_CLONED);
-    FL_SET(orig , RCLASS_CLONED);
+    RCLASS_EXT(clone)->cloned = true;
+    RCLASS_EXT(orig)->cloned = true;
 
     if (!FL_TEST(CLASS_OF(clone), FL_SINGLETON)) {
         RBASIC_SET_CLASS(clone, rb_singleton_class_clone(orig));

--- a/class.c
+++ b/class.c
@@ -465,7 +465,7 @@ static bool ensure_origin(VALUE klass);
 /**
  * If this flag is set, that module is allocated but not initialized yet.
  */
-enum {RMODULE_ALLOCATED_BUT_NOT_INITIALIZED = RUBY_FL_USER5};
+enum {RMODULE_ALLOCATED_BUT_NOT_INITIALIZED = RUBY_FL_USER1};
 
 static inline bool
 RMODULE_UNINITIALIZED(VALUE module)

--- a/gc.c
+++ b/gc.c
@@ -3513,11 +3513,6 @@ obj_free(rb_objspace_t *objspace, VALUE obj)
             xfree(RCLASS_SUPERCLASSES(obj));
         }
 
-#if !RCLASS_EXT_EMBEDDED
-        if (RCLASS_EXT(obj))
-            xfree(RCLASS_EXT(obj));
-#endif
-
         (void)RB_DEBUG_COUNTER_INC_IF(obj_module_ptr, BUILTIN_TYPE(obj) == T_MODULE);
         (void)RB_DEBUG_COUNTER_INC_IF(obj_class_ptr, BUILTIN_TYPE(obj) == T_CLASS);
         break;
@@ -3644,9 +3639,6 @@ obj_free(rb_objspace_t *objspace, VALUE obj)
         cc_table_free(objspace, obj, FALSE);
         rb_class_remove_from_module_subclasses(obj);
         rb_class_remove_from_super_subclasses(obj);
-#if !RCLASS_EXT_EMBEDDED
-        xfree(RCLASS_EXT(obj));
-#endif
 
         RB_DEBUG_COUNTER_INC(obj_iclass_ptr);
         break;
@@ -4903,9 +4895,6 @@ obj_memsize_of(VALUE obj, int use_all_types)
             if (FL_TEST_RAW(obj, RCLASS_SUPERCLASSES_INCLUDE_SELF)) {
                 size += (RCLASS_SUPERCLASS_DEPTH(obj) + 1) * sizeof(VALUE);
             }
-#if !RCLASS_EXT_EMBEDDED
-            size += sizeof(rb_classext_t);
-#endif
         }
         break;
       case T_ICLASS:

--- a/internal/class.h
+++ b/internal/class.h
@@ -62,9 +62,6 @@ struct rb_classext_struct {
         } singleton_class;
     } as;
     const VALUE includer;
-#if !SHAPE_IN_BASIC_FLAGS
-    shape_id_t shape_id;
-#endif
     attr_index_t max_iv_count;
     unsigned char variation_count;
     bool permanent_classpath : 1;

--- a/internal/class.h
+++ b/internal/class.h
@@ -76,21 +76,12 @@ struct RClass {
     struct RBasic basic;
     VALUE super;
     struct rb_id_table *m_tbl;
-#if !RCLASS_EXT_EMBEDDED
-    struct rb_classext_struct *ptr;
-#endif
 };
 
-#if RCLASS_EXT_EMBEDDED
 // Assert that classes can be embedded in size_pools[2] (which has 160B slot size)
 STATIC_ASSERT(sizeof_rb_classext_t, sizeof(struct RClass) + sizeof(rb_classext_t) <= 4 * RVALUE_SIZE);
-#endif
 
-#if RCLASS_EXT_EMBEDDED
-#  define RCLASS_EXT(c) ((rb_classext_t *)((char *)(c) + sizeof(struct RClass)))
-#else
-#  define RCLASS_EXT(c) (RCLASS(c)->ptr)
-#endif
+#define RCLASS_EXT(c) ((rb_classext_t *)((char *)(c) + sizeof(struct RClass)))
 #define RCLASS_CONST_TBL(c) (RCLASS_EXT(c)->const_tbl)
 #define RCLASS_M_TBL(c) (RCLASS(c)->m_tbl)
 #define RCLASS_IVPTR(c) (RCLASS_EXT(c)->iv_ptr)

--- a/internal/class.h
+++ b/internal/class.h
@@ -67,7 +67,8 @@ struct rb_classext_struct {
 #endif
     attr_index_t max_iv_count;
     unsigned char variation_count;
-    bool permanent_classpath;
+    bool permanent_classpath : 1;
+    bool cloned : 1;
     VALUE classpath;
 };
 typedef struct rb_classext_struct rb_classext_t;
@@ -110,7 +111,6 @@ STATIC_ASSERT(sizeof_rb_classext_t, sizeof(struct RClass) + sizeof(rb_classext_t
 #define RCLASS_ATTACHED_OBJECT(c) (RCLASS_EXT(c)->as.singleton_class.attached_object)
 
 #define RICLASS_IS_ORIGIN FL_USER0
-#define RCLASS_CLONED     FL_USER1
 #define RCLASS_SUPERCLASSES_INCLUDE_SELF FL_USER2
 #define RICLASS_ORIGIN_SHARED_MTBL FL_USER3
 

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -189,9 +189,6 @@ struct rb_objspace; /* in vm_core.h */
 # define SIZE_POOL_COUNT 5
 #endif
 
-// TODO: Make rb_classext_t small enough to fit in 80 bytes on 32 bit
-#define RCLASS_EXT_EMBEDDED (SIZEOF_UINT64_T == SIZEOF_VALUE)
-
 typedef struct ractor_newobj_size_pool_cache {
     struct RVALUE *freelist;
     struct heap_page *using_page;

--- a/shape.c
+++ b/shape.c
@@ -69,13 +69,6 @@ rb_shape_get_parent(rb_shape_t * shape)
 }
 
 #if !SHAPE_IN_BASIC_FLAGS
-shape_id_t
-rb_rclass_shape_id(VALUE obj)
-{
-    RUBY_ASSERT(RB_TYPE_P(obj, T_CLASS) || RB_TYPE_P(obj, T_MODULE));
-    return RCLASS_EXT(obj)->shape_id;
-}
-
 shape_id_t rb_generic_shape_id(VALUE obj);
 #endif
 

--- a/variable.c
+++ b/variable.c
@@ -1527,7 +1527,7 @@ rb_shape_set_shape_id(VALUE obj, shape_id_t shape_id)
         break;
       case T_CLASS:
       case T_MODULE:
-        RCLASS_EXT(obj)->shape_id = shape_id;
+        RCLASS_SET_SHAPE_ID(obj, shape_id);
         break;
       default:
         if (shape_id != SPECIAL_CONST_SHAPE_ID) {

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -895,7 +895,7 @@ vm_get_const_key_cref(const VALUE *ep)
 
     while (cref) {
         if (FL_TEST(CREF_CLASS(cref), FL_SINGLETON) ||
-            FL_TEST(CREF_CLASS(cref), RCLASS_CLONED)) {
+                RCLASS_EXT(CREF_CLASS(cref))->cloned) {
             return key_cref;
         }
         cref = CREF_NEXT(cref);


### PR DESCRIPTION
Classes are now exactly 80 bytes when embedded, which perfectly fits the 3rd size pool on 32 bit systems.