### PR TITLE
YJIT: Use 4 trampolines for branch_stub_hit

### DIFF
--- a/yjit.rb
+++ b/yjit.rb
@@ -292,6 +292,7 @@ module RubyVM::YJIT
       $stderr.puts "invalidation_count:    " + format_number(13, stats[:invalidation_count])
       $stderr.puts "constant_state_bumps:  " + format_number(13, stats[:constant_state_bumps])
       $stderr.puts "get_ivar_max_depth:    " + format_number(13, stats[:get_ivar_max_depth])
+      $stderr.puts "outlined_page_jump:    " + format_number(13, stats[:outlined_page_jump])
       $stderr.puts "inline_code_size:      " + format_number(13, stats[:inline_code_size])
       $stderr.puts "outlined_code_size:    " + format_number(13, stats[:outlined_code_size])
       $stderr.puts "code_region_size:      " + format_number(13, stats[:code_region_size])

--- a/yjit/src/asm/mod.rs
+++ b/yjit/src/asm/mod.rs
@@ -6,6 +6,7 @@ use crate::core::IseqPayload;
 use crate::core::for_each_off_stack_iseq_payload;
 use crate::core::for_each_on_stack_iseq_payload;
 use crate::invariants::rb_yjit_tracing_invalidate_all;
+use crate::stats::incr_counter;
 use crate::virtualmem::WriteError;
 
 #[cfg(feature = "disasm")]
@@ -152,6 +153,9 @@ impl CodeBlock {
         if next_page_idx.is_none() || !self.set_page(next_page_idx.unwrap(), &jmp_ptr) {
             self.set_write_ptr(old_write_ptr); // rollback if there are no more pages
             return false;
+        }
+        if self.outlined {
+            incr_counter!(outlined_page_jump);
         }
 
         // Move the other CodeBlock to the same page if it's on the furthest page

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -365,6 +365,8 @@ make_counters! {
     // executable memory, so this should be 0.
     exec_mem_non_bump_alloc,
 
+    outlined_page_jump,
+
     num_gc_obj_refs,
 
     num_send,


### PR DESCRIPTION
The idea of this PR is to use 4 different trampolines for different sets of stack temp registers to be spilled:

* No register: []
* 2 registers: [rsi, rdi]
* 4 registers: [rsi, rdi, r8, r9]
* 6 registers: [rsi, rdi, r8, r9, r10, r10]

Note that these numbers are all even for x86 alignment.

The current master always pushes 6 registers. So if you can use other no/2/4-register trampolines, you can reduce the number of `push` instructions.

## railsbench stats
This PR reduces `outlined_code_size` by 11%.

This PR also introduces and reduces `outlined_page_jump`. It counts the number of page jumps that are triggered by an outlined page reaching its page end. Such jumps cause inline code to have gaps, so it's better to have lower `outlined_page_jump` for inline code even if the number of its actually-written bytes (`inline_code_size`) isn't changed.

### before
```
outlined_page_jump:               24
inline_code_size:          2,428,907
outlined_code_size:        1,965,416
code_region_size:          4,632,576
```

### after
```
outlined_page_jump:                2
inline_code_size:          2,412,536
outlined_code_size:        1,747,173
code_region_size:          4,616,192
```