### PR TITLE
skip if `DidYouMean.formatter=` is not defined

### DIFF
--- a/test/ruby/test_pattern_matching.rb
+++ b/test/ruby/test_pattern_matching.rb
@@ -9,14 +9,14 @@ class TestPatternMatching < Test::Unit::TestCase
   end
 
   def setup
-    if defined?(DidYouMean)
+    if defined?(DidYouMean.formatter=nil)
       @original_formatter = DidYouMean.formatter
       DidYouMean.formatter = NullFormatter.new
     end
   end
 
   def teardown
-    if defined?(DidYouMean)
+    if defined?(DidYouMean.formatter=nil)
       DidYouMean.formatter = @original_formatter
     end
   end


### PR DESCRIPTION
ruby/test_default_gems.rb can define empty `DidYouMean` module because of the following line (second require) in the `lib/did_you_mean/did_you_mean.gemspec`:

```ruby
begin
  require_relative "lib/did_you_mean/version"
rescue LoadError # Fallback to load version file in ruby core repository
  require_relative "version"
end
```

It defines only `::DidYouMean::VERSION`.

However, in the `test/ruby/test_patten_matching.rb` assumes that if `defined?(DidYouMean)` is true, then there is a method `DidYouMean.formatter=` and this assumption fails all tests in `test/ruby/test_patten_matching.rb` if there is only a `::DidYouMean::VERSION`.

To reproduce the failures, we need to repeat the following command:

`make test-all TESTS='-v ruby/test_default_gems.rb ruby/pattern_matching'`

(because the ruby/test_default_gems.rb should be run before the ruby/pattern_matching`)

This patch introduces more strict gurds.