### PR TITLE
Fix `PLATFORM_GET_INC`

### DIFF
--- a/regexec.c
+++ b/regexec.c
@@ -3464,7 +3464,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 	if (ischanged && msa->enable_cache_match_opt) {
 	  RelAddrType rel;
 	  OnigUChar *addr;
-	  int mem;
+	  MemNumType mem;
 	  UChar* tmp = p;
 	  switch (*tmp++) {
 	  case OP_JUMP:

--- a/regint.h
+++ b/regint.h
@@ -319,9 +319,13 @@ RUBY_SYMBOL_EXPORT_BEGIN
 
 #define ONIG_LAST_CODE_POINT    (~((OnigCodePoint )0))
 
+#define PLATFORM_GET_INC_ARGUMENTS_ASSERT(val, type) \
+  ((void)sizeof(char[2 * (sizeof(val) == sizeof(type)) - 1]))
+
 #ifdef PLATFORM_UNALIGNED_WORD_ACCESS
 
 # define PLATFORM_GET_INC(val,p,type) do{\
+  PLATFORM_GET_INC_ARGUMENTS_ASSERT(val, type);\
   val  = *(type* )p;\
   (p) += sizeof(type);\
 } while(0)
@@ -329,7 +333,10 @@ RUBY_SYMBOL_EXPORT_BEGIN
 #else
 
 # define PLATFORM_GET_INC(val,p,type) do{\
-  xmemcpy(&val, (p), sizeof(type));\
+  PLATFORM_GET_INC_ARGUMENTS_ASSERT(val, type);\
+  type platform_get_value;\
+  xmemcpy(&platform_get_value, (p), sizeof(type));\
+  val = platform_get_value;\
   (p) += sizeof(type);\
 } while(0)
 


### PR DESCRIPTION
On platforms where unaligned word access is not allowed, and if `sizeof(val)` and `sizeof(type)` differ:

- `val` > `type`, `val` will be a garbage.
- `val` < `type`, outside `val` will be clobbered.

Fixes segmentation faults on SPARC Solaris and s390x.