### PR TITLE
YJIT: Fix raw sample stack lengths in exit traces

### DIFF
--- a/yjit.c
+++ b/yjit.c
@@ -186,8 +186,9 @@ rb_yjit_exit_locations_dict(VALUE *yjit_raw_samples, int *yjit_line_samples, int
         int line_num = (int)yjit_line_samples[idx];
         idx++;
 
-        rb_ary_push(raw_samples, SIZET2NUM(num));
-        rb_ary_push(line_samples, INT2NUM(line_num));
+        // + 1 as we append an additional sample for the insn
+        rb_ary_push(raw_samples, SIZET2NUM(num + 1));
+        rb_ary_push(line_samples, INT2NUM(line_num + 1));
 
         // Loop through the length of samples_len and add data to the
         // frames hash. Also push the current value onto the raw_samples

--- a/yjit.rb
+++ b/yjit.rb
@@ -67,7 +67,7 @@ module RubyVM::YJIT
     # [ length, line_1, line_2, line_n, ..., dummy value, count
     i = 0
     while i < raw_samples.length
-      stack_length = raw_samples[i] + 1
+      stack_length = raw_samples[i]
       i += 1 # consume the stack length
 
       sample_count = raw_samples[i + stack_length]

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -691,10 +691,8 @@ pub extern "C" fn rb_yjit_record_exit_stack(exit_pc: *const VALUE)
         // Push the insn value into the yjit_raw_samples Vec.
         yjit_raw_samples.push(VALUE(insn as usize));
 
-        // Push the current line onto the yjit_line_samples Vec. This
-        // points to the line in insns.def.
-        let line = yjit_line_samples.len() - 1;
-        yjit_line_samples.push(line as i32);
+        // We don't know the line
+        yjit_line_samples.push(0);
 
         // Push number of times seen onto the stack, which is 1
         // because it's the first time we've seen it.


### PR DESCRIPTION
Sorry. Didn't spot this additional issue when doing https://github.com/ruby/ruby/pull/7702

yjit-trace-exits appends a synthetic sample for the instruction being exited, but we didn't increment the size of the stack. It wasn't clear where best to fix this, we did so here because it required the fewest changes.

I also replaced the line number for instructions with 0, as I don't think the previous value had meaning.

---

With this change we can successfully generate flamegraphs from exit locations.

With the stackprof default viewer

```
stackprof --flamegraph yjit_exit_locations.dump > yjit_exit_locations.flamegraph.js
stackprof --flamegraph-viewer yjit_exit_locations.flamegraph.js
```

in speedscope (there's a hack in here because speedscope makes some poor assumptions so we need to pretend to be an object flamegraph. I hope to send a patch upstream)

```
stackprof --json yjit_exit_locations.dump | sed 's/{/{"mode":"object",/' > yjit_exit_locations.stackprof.json
# Drag output file into https://www.speedscope.app/
```