### PR TITLE
Skip DW_FORM_GNU_* forms in addr2line.c

### DIFF
--- a/addr2line.c
+++ b/addr2line.c
@@ -840,7 +840,11 @@ enum
     DW_FORM_addrx1 = 0x29,
     DW_FORM_addrx2 = 0x2a,
     DW_FORM_addrx3 = 0x2b,
-    DW_FORM_addrx4 = 0x2c
+    DW_FORM_addrx4 = 0x2c,
+
+    /* GNU extensions for referring to .gnu_debugaltlink dwz-compressed info */
+    DW_FORM_GNU_ref_alt = 0x1f20,
+    DW_FORM_GNU_strp_alt = 0x1f21
 };
 
 /* Range list entry encodings */
@@ -1314,6 +1318,14 @@ debug_info_reader_read_value(DebugInfoReader *reader, uint64_t form, DebugInfoVa
         break;
       case DW_FORM_addrx4:
         set_addr_idx_value(v, read_uint32(&reader->p));
+        break;
+      /* we have no support for actually reading the real values of these refs out
+       * of the .gnu_debugaltlink dwz-compressed debuginfo at the moment, but "read"
+       * them anyway so that we advance the reader by the right amount. */
+      case DW_FORM_GNU_ref_alt:
+      case DW_FORM_GNU_strp_alt:
+        read_uint(reader);
+        set_uint_value(v, 0);
         break;
       case 0:
         goto fail;


### PR DESCRIPTION
DW_FORM_GNU_ref_alt and DW_FORM_GNU_strp_alt refer to data stored in an external ELF file specified by a .gnu_debugaltlink attribute. These attributes are generated by dwz(1), which extracts DWARF data common amongst several files and stores it in a single, new file. It leaves behind these two forms in the original file to point at the new, common data.

We don't support actually reading the .gnu_debugaltlink file in addr2line.c (and maybe we don't really need to), but we do need to know how to read the actual value of these forms so we can skip over the right number of bytes and not lose track of where we are in the CU.

Closes https://bugs.ruby-lang.org/issues/19606