### PR TITLE
Make the maximum shapes variation warning non-verbose

### DIFF
--- a/shape.c
+++ b/shape.c
@@ -403,7 +403,7 @@ rb_shape_get_next(rb_shape_t* shape, VALUE obj, ID id)
             RCLASS_EXT(klass)->variation_count++;
             if (rb_warning_category_enabled_p(RB_WARN_CATEGORY_PERFORMANCE)) {
                 if (RCLASS_EXT(klass)->variation_count >= SHAPE_MAX_VARIATIONS) {
-                    rb_category_warning(
+                    rb_category_warn(
                         RB_WARN_CATEGORY_PERFORMANCE,
                         "Maximum shapes variations (%d) reached by %"PRIsVALUE", instance variables accesses will be slower.",
                         SHAPE_MAX_VARIATIONS,

--- a/test/ruby/test_object.rb
+++ b/test/ruby/test_object.rb
@@ -424,7 +424,7 @@ class TestObject < Test::Unit::TestCase
 
   def test_max_shape_variation_with_performance_warnings
     assert_in_out_err([], <<-INPUT, %w(), /Maximum shapes variations \(8\) reached by Foo, instance variables accesses will be slower\.$/)
-      $VERBOSE = true
+      $VERBOSE = false
       Warning[:performance] = true
 
       class Foo; end


### PR DESCRIPTION
[Feature #19538]

Since that category is not enabled by default, making it a verbose warning is redundant. Enabling performance warning should work with the default verbosity level.

Ref: https://github.com/ruby/ruby/pull/7715#discussion_r1169777099

cc @eregon @mame 