### PR TITLE
Return NULL to indicate the next shape isn't found

### DIFF
--- a/shape.c
+++ b/shape.c
@@ -497,6 +497,9 @@ rb_shape_traverse_from_new_root(rb_shape_t *initial_shape, rb_shape_t *dest_shap
             if (child->edge_name == dest_shape->edge_name) {
                 return child;
             }
+            else {
+                return NULL;
+            }
         }
         else {
             if (rb_id_table_lookup(next_shape->edges, dest_shape->edge_name, &lookup_result)) {


### PR DESCRIPTION
During compaction we must fix up shapes on objects who were extended but then became embedded.  `rb_shape_traverse_from_new_root` is supposed to walk shape trees looking for a matching shape.  When a shape has a "single child" we weren't returning NULL when the edge names didn't match.

In the case of a single outgoing edge, this patch returns NULL when the child edge name doesn't match (similar to the case when a shape has a hash of outgoing edges)

cc @k0kubun 