### PR TITLE
fix `NameError` message

### DIFF
--- a/test/ruby/test_class.rb
+++ b/test/ruby/test_class.rb
@@ -355,6 +355,17 @@ class TestClass < Test::Unit::TestCase
     assert_equal(42, PrivateClass.new.foo)
   end
 
+  def test_private_const_access
+    assert_raise_with_message NameError, /uninitialized/ do
+      begin
+        eval('class ::TestClass::PrivateClass; end')
+      rescue NameError => e
+      end
+
+      Object.const_get "NOT_AVAILABLE_CONST_NAME_#{__LINE__}"
+    end
+  end
+
   StrClone = String.clone
   Class.new(StrClone)
 

--- a/variable.c
+++ b/variable.c
@@ -2073,11 +2073,12 @@ rb_const_missing(VALUE klass, VALUE name)
 VALUE
 rb_mod_const_missing(VALUE klass, VALUE name)
 {
-    VALUE ref = GET_EC()->private_const_reference;
+    rb_execution_context_t *ec = GET_EC();
+    VALUE ref = ec->private_const_reference;
     rb_vm_pop_cfunc_frame();
     if (ref) {
-        rb_name_err_raise("private constant %2$s::%1$s referenced",
-                          ref, name);
+        ec->private_const_reference = 0;
+        rb_name_err_raise("private constant %2$s::%1$s referenced", ref, name);
     }
     uninitialized_constant(klass, name);
 


### PR DESCRIPTION
The following code produces two NameErrors respectively and they are independent, but the second one can show `private constant` message because of first NameError.

```ruby
class C
  class PrivateClass; end
  private_constant :PrivateClass
end

begin
  eval('class C::PrivateClass; end')
rescue => e
  p e
end

begin
  Object.const_get 'Foo'
rescue => e
  p e
end

  #<NameError: private constant C::PrivateClass referenced>
  #<NameError: private constant C::Foo referenced>
  #=> should be #<NameError: uninitialized constant Foo>
```

It fails the test-all tests with
`make test-all TESTS='ruby/class ruby/parse --seed=58891 -v`.

The reason is clear miss from https://github.com/ruby/ruby/commit/7387c08373a