### PR TITLE
Don't allocate a match cache buffer when regex has no loop

### DIFF
--- a/regint.h
+++ b/regint.h
@@ -918,8 +918,9 @@ typedef struct {
 #endif
 } OnigMatchArg;
 
-#define NUM_CACHE_OPCODES_IMPOSSIBLE -1
-#define NUM_CACHE_OPCODES_UNINIT     -2
+#define NUM_CACHE_OPCODES_UNNECESSARY  0
+#define NUM_CACHE_OPCODES_IMPOSSIBLE  -1
+#define NUM_CACHE_OPCODES_UNINIT      -2
 
 #define IS_CODE_SB_WORD(enc,code) \
   (ONIGENC_IS_CODE_ASCII(code) && ONIGENC_IS_CODE_WORD(enc,code))


### PR DESCRIPTION
Fix [[Bug #19534]](https://bugs.ruby-lang.org/issues/19534)

This fix prevents extremely slow matching for large regular expressions without loops.
However, the overhead for the match cache optimization still exists.

<details><summary>benchmark script</summary>
<p>

```
require "benchmark"

puts RUBY_VERSION

Benchmark.bm do |bm|
  3.times do
    keywords = Array.new(5000)
    keywords.each_index do |idx|
      keywords[idx] = (1..20).map {|e| (0x3042+Random.new.rand(0..82)).chr(Encoding::UTF_8)}.join
    end
    regx = ::Regexp.union(keywords)

    text = (1..600).map {|e| (0x3042+Random.new.rand(0..82)).chr(Encoding::UTF_8)}.join

    bm.report { text.scan(regx) }
  end
end
```

</p>
</details>

### 3.1.3

```
3.1.3
       user     system      total        real
   0.015672   0.000009   0.015681 (  0.015689)
   0.015579   0.000008   0.015587 (  0.015603)
   0.015570   0.000079   0.015649 (  0.015647)
```

### 3.2.2

```
3.2.2
       user     system      total        real
   0.107469   0.000409   0.107878 (  0.107889)
   0.108779   0.000572   0.109351 (  0.109383)
   0.107311   0.000295   0.107606 (  0.107621)
```

### HEAD (this fix)

```
3.3.0
       user     system      total        real
   0.020324   0.000063   0.020387 (  0.020399)
   0.020281   0.000107   0.020388 (  0.020404)
   0.019999   0.000009   0.020008 (  0.020015)
```