### PR TITLE
Delay start of the match cache optimization

### DIFF
--- a/regint.h
+++ b/regint.h
@@ -909,7 +909,7 @@ typedef struct {
   uint64_t end_time;
 #endif
 #ifdef USE_MATCH_CACHE
-  int              enable_match_cache;
+  int              match_cache_status;
   long             num_fails;
   long             num_cache_opcodes;
   OnigCacheOpcode* cache_opcodes;
@@ -918,8 +918,13 @@ typedef struct {
 #endif
 } OnigMatchArg;
 
+#define NUM_CACHE_OPCODES_UNINIT      1
 #define NUM_CACHE_OPCODES_IMPOSSIBLE -1
-#define NUM_CACHE_OPCODES_UNINIT     -2
+
+#define MATCH_CACHE_STATUS_UNINIT    1
+#define MATCH_CACHE_STATUS_INIT      2
+#define MATCH_CACHE_STATUS_DISABLED -1
+#define MATCH_CACHE_STATUS_ENABLED   0
 
 #define IS_CODE_SB_WORD(enc,code) \
   (ONIGENC_IS_CODE_ASCII(code) && ONIGENC_IS_CODE_WORD(enc,code))


### PR DESCRIPTION
Fix [Bug #19534]
Close #7737

This is another solution for [Bug #19534].
This fix delays the match cache buffer allocation and a start of the match cache optimization until the number of backtracks exceeds string length × #(cache opcodes).

<details><summary>benchmark script</summary>
<p>

```ruby
require "benchmark"

puts RUBY_DESCRIPTION

Benchmark.bm do |bm|
  3.times do
    keywords = Array.new(5000)
    keywords.each_index do |idx|
      keywords[idx] = (1..20).map {|e| (0x3042+Random.new.rand(0..82)).chr(Encoding::UTF_8)}.join
    end
    regx = ::Regexp.union(keywords)

    text = (1..600).map {|e| (0x3042+Random.new.rand(0..82)).chr(Encoding::UTF_8)}.join

    bm.report { text.scan(regx) }
  end
end
```

</p>
</details>

### 3.1.3

```
ruby 3.1.3p185 (2022-11-24 revision 1a6b16756e) [arm64-darwin22]
       user     system      total        real
   0.016589   0.000130   0.016719 (  0.016727)
   0.015642   0.000100   0.015742 (  0.015748)
   0.015881   0.000147   0.016028 (  0.016116)
```

### 3.2.2

```
ruby 3.2.2 (2023-03-30 revision e51014f9c0) [arm64-darwin22]
       user     system      total        real
   0.109200   0.001246   0.110446 (  0.110620)
   0.108544   0.001107   0.109651 (  0.109735)
   0.107521   0.001229   0.108750 (  0.108805)
```

### HEAD (this fix)

```
ruby 3.3.0dev (2023-04-19T04:08:28Z delay-linear a1c2c274ee) [arm64-darwin22]
       user     system      total        real
   0.018780   0.000031   0.018811 (  0.018819)
   0.018509   0.000016   0.018525 (  0.018528)
   0.018772   0.000026   0.018798 (  0.018808)
```