### PR TITLE
Fix Process.times spec

### DIFF
--- a/spec/ruby/core/process/times_spec.rb
+++ b/spec/ruby/core/process/times_spec.rb
@@ -30,7 +30,7 @@ describe "Process.times" do
 
       found = (max * 100).times.find do
         time = Process.times.utime
-        ('%.6f' % time).end_with?('000')
+        !('%.6f' % time).end_with?('000')
       end
 
       found.should_not == nil

--- a/spec/ruby/core/process/times_spec.rb
+++ b/spec/ruby/core/process/times_spec.rb
@@ -17,16 +17,13 @@ describe "Process.times" do
     end
   end
 
-  platform_is_not :windows do
+  guard -> do
+    Process.clock_gettime(:GETRUSAGE_BASED_CLOCK_PROCESS_CPUTIME_ID)
+  rescue Errno::EINVAL
+    false
+  end do
     it "uses getrusage when available to improve precision beyond milliseconds" do
       max = 10_000
-      has_getrusage = max.times.find do
-        time = Process.clock_gettime(:GETRUSAGE_BASED_CLOCK_PROCESS_CPUTIME_ID)
-        ('%.6f' % time).end_with?('000')
-      end
-      unless has_getrusage
-        skip "getrusage is not supported on this environment"
-      end
 
       found = (max * 100).times.find do
         time = Process.times.utime


### PR DESCRIPTION
* [Fix an example of Process.times](https://github.com/ruby/ruby/commit/a91a28be0eecbb1794ec00e273ff96c488941dc0) 
Prior to commit https://github.com/ruby/ruby/commit/5806c54447439f2ba22892e4045e78dd80f96f0c, it was "at least one result with precision beyond milliseconds (with none-zero microseconds) should exist"; after this commit, "at least one result should have zero microseconds".
This chance is lower than the previous condition.
* [Fix a guard of Process.times](https://github.com/ruby/ruby/commit/80c9786eb83e3d4dd6aa9ad6f5028069b0bafc93) 
`GETRUSAGE_BASED_CLOCK_PROCESS_CPUTIME_ID` clock uses `getrusage` always if available as the name states.  That is if it is implemented `getrusage` is available, regardless microseconds in its results.