### PR TITLE
YJIT: invokesuper: Remove cme mid matching check

### DIFF
--- a/test/ruby/test_yjit.rb
+++ b/test/ruby/test_yjit.rb
@@ -777,6 +777,25 @@ class TestYJIT < Test::Unit::TestCase
     RUBY
   end
 
+  def test_super_with_alias
+    assert_compiles(<<~'RUBY', insns: %i[invokesuper opt_plus opt_mult], result: 15)
+      class A
+        def foo = 1 + 2
+      end
+
+      module M
+        def foo = super() * 5
+        alias bar foo
+
+        def foo = :bad
+      end
+
+      A.prepend M
+
+      A.new.bar
+    RUBY
+  end
+
   def test_super_cfunc
     assert_compiles(<<~'RUBY', insns: %i[invokesuper], result: "Hello")
       class Gnirts < String

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -7034,13 +7034,6 @@ fn gen_invokesuper(
     let current_defined_class = unsafe { (*me).defined_class };
     let mid = unsafe { get_def_original_id((*me).def) };
 
-    if me != unsafe { rb_callable_method_entry(current_defined_class, (*me).called_id) } {
-        // Though we likely could generate this call, as we are only concerned
-        // with the method entry remaining valid, assume_method_lookup_stable
-        // below requires that the method lookup matches as well
-        return None;
-    }
-
     // vm_search_normal_superclass
     let rbasic_ptr: *const RBasic = current_defined_class.as_ptr();
     if current_defined_class.builtin_type() == RUBY_T_ICLASS


### PR DESCRIPTION
This check was introduced to match an assertion in the C YJIT when this was originally introduced. I don't believe it's necessary for correctness of the generated code.

In a test page on GitHub we found that [this invokesuper call in Rails](https://github.com/rails/rails/blob/076003d8e66ba2ad7f8350742675c6bfaaa493ba/activesupport/lib/active_support/core_ext/erb/util.rb#L15) was responsible for over 15% of our side-exits. So I think we should find a way to make it work. We won't see this in Railsbench because it uses an old version of Rails.

cc @XrXr I know we discussed this a bit when initially introduced. Per the comment I don't believe this ever actually needed that method lookup to hit, and the invalidation I think is just so we don't leak the object if it is invalidated (the correctness in invokesuper comes from checking the comptime cfp's ME against the runtime ME).