### PR TITLE
YJIT: Tweak asm comments

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -802,8 +802,9 @@ pub fn gen_single_block(
     #[cfg(feature = "disasm")]
     if get_option_ref!(dump_disasm).is_some() {
         let blockid_idx = blockid.idx;
-        let chain_depth = if asm.ctx.get_chain_depth() > 0 { format!(", chain_depth: {}", asm.ctx.get_chain_depth()) } else { "".to_string() };
-        asm.comment(&format!("Block: {} (ISEQ offset: {}{})", iseq_get_location(blockid.iseq, blockid_idx), blockid_idx, chain_depth));
+        let chain_depth = if asm.ctx.get_chain_depth() > 0 { format!("(chain_depth: {})", asm.ctx.get_chain_depth()) } else { "".to_string() };
+        asm.comment(&format!("Block: {} {}", iseq_get_location(blockid.iseq, blockid_idx), chain_depth));
+        asm.comment(&format!("reg_temps: {:08b}", ctx.get_reg_temps().as_u8()));
     }
 
     // For each instruction to compile
@@ -859,7 +860,7 @@ pub fn gen_single_block(
             gen_counter_incr!(asm, exec_instruction);
 
             // Add a comment for the name of the YARV instruction
-            asm.comment(&format!("Insn: {} (stack_size: {})", insn_name(opcode), asm.ctx.get_stack_size()));
+            asm.comment(&format!("Insn: {:04} {} (stack_size: {})", insn_idx, insn_name(opcode), asm.ctx.get_stack_size()));
 
             // If requested, dump instructions for debugging
             if get_option!(dump_insns) {


### PR DESCRIPTION
This PR does a couple of asm comment changes:

* Move `ISEQ offset` information to each `Insn` comments
* Resurrect `reg_temps` comment at the beginning of each block
  * https://github.com/ruby/ruby/pull/7741 removed `asm.set_reg_temps` that used to put the comment there

## Before
```asm
  # Block: fib@benchmarks/fib.rb:8 (ISEQ offset: 24, chain_depth: 1)
  # Insn: opt_minus (stack_size: 4)
  # guard arg0 fixnum
  0x1188001bc: tst x10, #1
  0x1188001c0: b.eq #0x1188023dc
  0x1188001c4: nop
  0x1188001c8: subs x11, x10, x14
  0x1188001cc: b.vs #0x11880239c
  0x1188001d0: mov x12, #1
  0x1188001d4: adds x11, x11, x12
  0x1188001d8: mov x10, x11
  # Insn: opt_send_without_block (stack_size: 3)
  # defer_compilation
  0x1188001dc: b #0x11880241c
```

## After
```asm
  # Block: fib@benchmarks/fib.rb:8 (chain_depth: 1)
  # reg_temps: 00001110
  # Insn: 0024 opt_minus (stack_size: 4)
  # guard arg0 fixnum
  0x103c401bc: tst x10, #1
  0x103c401c0: b.eq #0x103c423b8
  0x103c401c4: nop
  0x103c401c8: subs x11, x10, x14
  0x103c401cc: b.vs #0x103c42378
  0x103c401d0: mov x12, #1
  0x103c401d4: adds x11, x11, x12
  0x103c401d8: mov x10, x11
  # Insn: 0026 opt_send_without_block (stack_size: 3)
  # defer_compilation
  0x103c401dc: b #0x103c423f8
```

`0024 opt_minus` and `0026 opt_send_without_block` are easier to understand when you compare it with `--dump=insns`:

```
== disasm: #<ISeq:fib@benchmarks/fib.rb:3 (3,0)-(9,3)>
local table (size: 1, argc: 1 [opts: 0, rest: -1, post: 0, block: -1, kw: -1@-1, kwrest: -1])
[ 1] n@0<Arg>
0000 getlocal_WC_0                          n@0                       (   4)[LiCa]
0002 putobject                              2
0004 opt_lt                                 <calldata!mid:<, argc:1, ARGS_SIMPLE>[CcCr]
0006 branchunless                           11
0008 getlocal_WC_0                          n@0                       (   5)[Li]
0010 leave                                  [Re]
0011 putself                                                          (   8)[Li]
0012 getlocal_WC_0                          n@0
0014 putobject_INT2FIX_1_
0015 opt_minus                              <calldata!mid:-, argc:1, ARGS_SIMPLE>[CcCr]
0017 opt_send_without_block                 <calldata!mid:fib, argc:1, FCALL|ARGS_SIMPLE>
0019 putself
0020 getlocal_WC_0                          n@0
0022 putobject                              2
0024 opt_minus                              <calldata!mid:-, argc:1, ARGS_SIMPLE>[CcCr]
0026 opt_send_without_block                 <calldata!mid:fib, argc:1, FCALL|ARGS_SIMPLE>
0028 opt_plus                               <calldata!mid:+, argc:1, ARGS_SIMPLE>[CcCr]
0030 leave                                                            (   9)[Re]
```