### PR TITLE
YJIT: Replace Mov with LoadInto on arm64

### DIFF
--- a/yjit/src/backend/arm64/mod.rs
+++ b/yjit/src/backend/arm64/mod.rs
@@ -597,7 +597,7 @@ impl Assembler
                             let opnd0 = split_memory_address(asm, dest);
                             asm.store(opnd0, value);
                         },
-                        // If we're load a memory operand into a register, then
+                        // If we're loading a memory operand into a register, then
                         // we'll switch over to the load instruction.
                         (Opnd::Reg(_), Opnd::Mem(_)) => {
                             let value = split_memory_address(asm, src);
@@ -1575,5 +1575,17 @@ mod tests {
                 "expected to disassemble to movk",
             )),
         }
+    }
+
+    #[test]
+    fn test_replace_mov_with_ldur() {
+        let (mut asm, mut cb) = setup_asm();
+
+        asm.mov(Opnd::Reg(Assembler::TEMP_REGS[0]), Opnd::mem(64, CFP, 8));
+        asm.compile_with_num_regs(&mut cb, 1);
+
+        assert_disasm!(cb, "618240f8", {"
+            0x0: ldur x1, [x19, #8]
+        "});
     }
 }


### PR DESCRIPTION
On arm64, when `Mov`'s destination is a register and the source is memory, this PR attempts to replace it with a single `LoadInto` (`ldur`). This would be useful for maximizing the performance of stack temp register allocation https://github.com/ruby/ruby/pull/7659.

## Example
For example, `getlocal` generates one less instruction. It loads memory into a stack temp register directly without using an insn out register.

### before
```asm
  # Insn: getlocal_WC_0 (stack_size: 0)
  0x108730098: ldur x11, [x19, #0x20]
  # reg_temps: 00000000 -> 00000001
  0x10873009c: ldur x11, [x11, #-0x18]
  0x1087300a0: mov x1, x11
```

### after
```asm
  # Insn: getlocal_WC_0 (stack_size: 0)
  0x103930090: ldur x11, [x19, #0x20]
  # reg_temps: 00000000 -> 00000001
  0x103930094: ldur x1, [x11, #-0x18]
```

## Code size
On railsbench, it reduces `inline_code_size` by 2%.

### before
```
inline_code_size:          3,571,000
outlined_code_size:        2,433,256
code_region_size:          7,127,040
```

### after
```
inline_code_size:          3,499,320
outlined_code_size:        2,151,744
code_region_size:          7,061,504
```

## Benchmark
Some benchmarks show a speedup. Others don't seem to have a significant impact.

```
before: ruby 3.3.0dev (2023-04-19T20:08:35Z master 2531bb0b66) +YJIT [arm64-darwin22]
after: ruby 3.3.0dev (2023-04-19T22:29:01Z yjit-arm64-load 6a952471ed) +YJIT [arm64-darwin22]

-------------  -----------  ----------  ----------  ----------  -------------  ------------
bench          before (ms)  stddev (%)  after (ms)  stddev (%)  after 1st itr  before/after
fannkuchredux  366.2        0.3         355.9       0.2         1.00           1.03
30k_ifelse     338.8        2.9         319.3       1.4         1.04           1.06
fib            26.9         0.6         25.8        0.5         1.08           1.05
-------------  -----------  ----------  ----------  ----------  -------------  ------------
```