### PR TITLE
YJIT: Avoid splitting mov for small values on arm64

### DIFF
--- a/yjit/src/backend/arm64/mod.rs
+++ b/yjit/src/backend/arm64/mod.rs
@@ -963,7 +963,7 @@ impl Assembler
                     // This supports the following two kinds of immediates:
                     //   * The value fits into a single movz instruction
                     //   * It can be encoded with the special bitmask immediate encoding
-                    // arm64_splat should have split other immediates that require multiple instructions.
+                    // arm64_split() should have split other immediates that require multiple instructions.
                     match src {
                         Opnd::UImm(uimm) if *uimm <= 0xffff => {
                             movz(cb, dest.into(), A64Opnd::new_uimm(*uimm), 0);

--- a/yjit/src/backend/arm64/mod.rs
+++ b/yjit/src/backend/arm64/mod.rs
@@ -1608,11 +1608,13 @@ mod tests {
     fn test_not_split_mov() {
         let (mut asm, mut cb) = setup_asm();
 
-        asm.mov(Opnd::Reg(Assembler::TEMP_REGS[0]), Opnd::UImm(5));
+        asm.mov(Opnd::Reg(Assembler::TEMP_REGS[0]), Opnd::UImm(0xffff));
+        asm.mov(Opnd::Reg(Assembler::TEMP_REGS[0]), Opnd::UImm(0x10000));
         asm.compile_with_num_regs(&mut cb, 1);
 
-        assert_disasm!(cb, "a10080d2", {"
-            0x0: mov x1, #5
+        assert_disasm!(cb, "e1ff9fd2e10370b2", {"
+            0x0: mov x1, #0xffff
+            0x4: orr x1, xzr, #0x10000
         "});
     }
 }

--- a/yjit/src/disasm.rs
+++ b/yjit/src/disasm.rs
@@ -207,7 +207,6 @@ pub fn disasm_addr_range(cb: &CodeBlock, start_addr: usize, end_addr: usize) -> 
 #[cfg(test)]
 macro_rules! assert_disasm {
     ($cb:expr, $hex:expr, $disasm:expr) => {
-        assert_eq!(format!("{:x}", $cb), $hex);
         #[cfg(feature = "disasm")]
         {
             let disasm = disasm_addr_range(
@@ -217,6 +216,7 @@ macro_rules! assert_disasm {
             );
             assert_eq!(unindent(&disasm, false), unindent(&$disasm, true));
         }
+        assert_eq!(format!("{:x}", $cb), $hex);
     };
 }
 #[cfg(test)]


### PR DESCRIPTION
When `Mov`'s destination is a register and the source is an immediate which cannot be encoded with a bitmask but is <= `0xffff`, it can be a single `mov` instruction. 

Currently, `split_bitmask_immediate` splits such source operands, which are still necessary for other instructions, so this PR avoids calling it for that case.

While I don't see a significant impact on benchmarks, this should help the performance of stack temp register allocation on arm64 https://github.com/ruby/ruby/pull/7659 a little.

## Example
### before
```asm
  # Insn: 0000 putobject (stack_size: 0)
  # reg_temps: 00000000 -> 00000001
  0x1065d0090: mov x11, #5
  0x1065d0094: mov x1, x11
```

### after
```asm
  # Insn: 0000 putobject (stack_size: 0)
  # reg_temps: 00000000 -> 00000001
  0x103840090: mov x1, #5
```
