### PR TITLE
Merge `T_OBJECT` case in `rb_ivar_delete` function

### DIFF
--- a/variable.c
+++ b/variable.c
@@ -1239,11 +1239,6 @@ rb_ivar_delete(VALUE obj, ID id, VALUE undef)
         RB_VM_LOCK_LEAVE();
 
         break;
-      case T_OBJECT: {
-        rb_shape_transition_shape_remove_ivar(obj, id, shape, &val);
-
-        break;
-      }
       default: {
         rb_shape_transition_shape_remove_ivar(obj, id, shape, &val);
 


### PR DESCRIPTION
In `rb_ivar_delete` function has same case.

```c
      case T_OBJECT: {
        rb_shape_transition_shape_remove_ivar(obj, id, shape, &val);

        break;
      }
      default: {
        rb_shape_transition_shape_remove_ivar(obj, id, shape, &val);

        break;
      }
```

I thought to better to merge these case, If there is no particular reason.