### PR TITLE
YJIT: Merge lower_stack into the split pass

### DIFF
--- a/yjit/src/backend/arm64/mod.rs
+++ b/yjit/src/backend/arm64/mod.rs
@@ -399,6 +399,9 @@ impl Assembler
                             *opnd = asm.load(*opnd);
                         }
                     },
+                    Opnd::Stack { .. } => {
+                        *opnd = asm.lower_stack_opnd(opnd);
+                    }
                     _ => {}
                 };
             }
@@ -1123,7 +1126,6 @@ impl Assembler
                         nop(cb);
                     }
                 }
-                Insn::SpillTemp(_) => unreachable!("Insn::SpillTemp should have been lowered by lower_stack"),
             };
 
             // On failure, jump to the next page and retry the current insn
@@ -1146,10 +1148,8 @@ impl Assembler
     }
 
     /// Optimize and compile the stored instructions
-    pub fn compile_with_regs(self, cb: &mut CodeBlock, ocb: Option<&mut OutlinedCb>, regs: Vec<Reg>) -> Vec<u32>
-    {
-        let asm = self.lower_stack();
-        let asm = asm.arm64_split();
+    pub fn compile_with_regs(self, cb: &mut CodeBlock, ocb: Option<&mut OutlinedCb>, regs: Vec<Reg>) -> Vec<u32> {
+        let asm = self.arm64_split();
         let mut asm = asm.alloc_regs(regs);
 
         // Create label instances in the code block

--- a/yjit/src/backend/x86_64/mod.rs
+++ b/yjit/src/backend/x86_64/mod.rs
@@ -147,21 +147,23 @@ impl Assembler
             let mut opnd_iter = insn.opnd_iter_mut();
 
             while let Some(opnd) = opnd_iter.next() {
+                if let Opnd::Stack { .. } = opnd {
+                    *opnd = asm.lower_stack_opnd(opnd);
+                }
                 unmapped_opnds.push(*opnd);
 
-                *opnd = if is_load {
-                    iterator.map_opnd(*opnd)
-                } else if let Opnd::Value(value) = opnd {
-                    // Since mov(mem64, imm32) sign extends, as_i64() makes sure
-                    // we split when the extended value is different.
-                    if !value.special_const_p() || imm_num_bits(value.as_i64()) > 32 {
-                        asm.load(iterator.map_opnd(*opnd))
-                    } else {
-                        Opnd::UImm(value.as_u64())
+                *opnd = match opnd {
+                    Opnd::Value(value) if !is_load => {
+                        // Since mov(mem64, imm32) sign extends, as_i64() makes sure
+                        // we split when the extended value is different.
+                        if !value.special_const_p() || imm_num_bits(value.as_i64()) > 32 {
+                            asm.load(iterator.map_opnd(*opnd))
+                        } else {
+                            Opnd::UImm(value.as_u64())
+                        }
                     }
-                } else {
-                    iterator.map_opnd(*opnd)
-                }
+                    _ => iterator.map_opnd(*opnd),
+                };
             }
 
             // We are replacing instructions here so we know they are already
@@ -744,7 +746,6 @@ impl Assembler
                         nop(cb, (cb.jmp_ptr_bytes() - code_size) as u32);
                     }
                 }
-                Insn::SpillTemp(_) => unreachable!("Insn::SpillTemp should have been lowered by lower_stack"),
             };
 
             // On failure, jump to the next page and retry the current insn
@@ -762,8 +763,7 @@ impl Assembler
 
     /// Optimize and compile the stored instructions
     pub fn compile_with_regs(self, cb: &mut CodeBlock, ocb: Option<&mut OutlinedCb>, regs: Vec<Reg>) -> Vec<u32> {
-        let asm = self.lower_stack();
-        let asm = asm.x86_split();
+        let asm = self.x86_split();
         let mut asm = asm.alloc_regs(regs);
 
         // Create label instances in the code block


### PR DESCRIPTION
This PR does a couple of things:

* Remove `Insn::SpillTemp` by using `Insn::Mov` from the beginning. This simplifies the lowering of `Opnd::Stack`.
* Merge the `lower_stack` pass into the `split` pass.

This makes compilation faster.

```
before: ruby 3.3.0dev (2023-04-20T20:08:42Z master 64a25977ed) +YJIT [x86_64-linux]
after: ruby 3.3.0dev (2023-04-20T21:01:43Z yjit-merge-lower fb8143d481) +YJIT [x86_64-linux]
last_commit=YJIT: Merge lower_stack into the split pass

----------  -----------  ----------  ----------  ----------  -------------  ------------
bench       before (ms)  stddev (%)  after (ms)  stddev (%)  after 1st itr  before/after
30k_ifelse  1311.4       0.0         1139.3      0.0         1.15           1.15
----------  -----------  ----------  ----------  ----------  -------------  ------------
```