### PR TITLE
Use shorter path as rubyspec temporary directory

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -873,7 +873,8 @@ test-spec: $(TEST_RUNNABLE)-test-spec
 yes-test-spec: test-spec-precheck
 	$(ACTIONS_GROUP)
 	$(gnumake_recursive)$(Q) \
-	$(RUNRUBY) -r./$(arch)-fake $(srcdir)/spec/mspec/bin/mspec run -B $(srcdir)/spec/default.mspec $(MSPECOPT) $(SPECOPTS)
+	$(RUNRUBY) -r./$(arch)-fake -r$(tooldir)/rubyspec_temp \
+		$(srcdir)/spec/mspec/bin/mspec run -B $(srcdir)/spec/default.mspec $(MSPECOPT) $(SPECOPTS)
 	$(ACTIONS_ENDGROUP)
 no-test-spec:
 

--- a/spec/ruby/library/socket/fixtures/classes.rb
+++ b/spec/ruby/library/socket/fixtures/classes.rb
@@ -37,7 +37,9 @@ module SocketSpecs
     # Check for too long unix socket path (max 104 bytes on macOS)
     # Note that Linux accepts not null-terminated paths but the man page advises against it.
     if path.bytesize > 104
-      path = "/tmp/unix_server_spec.socket"
+      # rm_r in spec/mspec/lib/mspec/helpers/fs.rb fails against
+      # "/tmp/unix_server_spec.socket"
+      skip "too long unix socket path: #{path}"
     end
     rm_socket(path)
     path

--- a/tool/rubyspec_temp.rb
+++ b/tool/rubyspec_temp.rb
@@ -1,0 +1,13 @@
+require "tmpdir"
+require "fileutils"
+
+if (tmpdir = Dir.mktmpdir("rubyspec_temp.")).size > 80
+  # On macOS, the default TMPDIR is very long, inspite of UNIX socket
+  # path length is limited.
+  Dir.rmdir(tmpdir)
+  tmpdir = Dir.mktmpdir("rubyspec_temp.", "/tmp")
+end
+# warn "tmpdir(#{tmpdir.size}) = #{tmpdir}"
+END {FileUtils.rm_rf(tmpdir)}
+
+ENV["TMPDIR"] = ENV["SPEC_TEMP_DIR"] = tmpdir


### PR DESCRIPTION
* [Skip when unix socket path is too long](https://github.com/ruby/ruby/commit/e956052fa953d7e312a2f524127b2ac6ae1b0da2) 
Eventually the path directly under "/tmp" is complained by `rm_r` in spec/mspec/lib/mspec/helpers/fs.rb.
* [Use shorter path as SPEC_TEMP_DIR](https://github.com/ruby/ruby/commit/de5cd5a635e3b975ca7acc5caf0363f2811abd95) 
The temporary directory under the build directory may be too long as a UNIX socket path.  On macOS, the default `TMPDIR` per user is also very long.