### PR TITLE
YJIT: Show definedivar exit reasons

### DIFF
--- a/yjit.rb
+++ b/yjit.rb
@@ -250,6 +250,7 @@ module RubyVM::YJIT
       print_counters(stats, prefix: 'gbpp_', prompt: 'getblockparamproxy exit reasons: ')
       print_counters(stats, prefix: 'getivar_', prompt: 'getinstancevariable exit reasons:')
       print_counters(stats, prefix: 'setivar_', prompt: 'setinstancevariable exit reasons:')
+      print_counters(stats, prefix: 'definedivar_', prompt: 'definedivar exit reasons:')
       print_counters(stats, prefix: 'opt_aref_', prompt: 'opt_aref exit reasons: ')
       print_counters(stats, prefix: 'expandarray_', prompt: 'expandarray exit reasons: ')
       print_counters(stats, prefix: 'opt_getinlinecache_', prompt: 'opt_getinlinecache exit reasons: ')


### PR DESCRIPTION
`definedivar` makes up 4.3% of exit reasons on SFR. It'd be nice to show a breakdown of it. 

I bet it's mostly `definedivar_megamorphic` and we want to put a general case at the end of chains, but I want to double-check it first.