### PR TITLE
YJIT: Use general definedivar at the end of chains

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -2417,7 +2417,7 @@ fn gen_definedivar(
     // Specialize base on compile time values
     let comptime_receiver = jit.peek_at_self();
 
-    if comptime_receiver.shape_too_complex() {
+    if comptime_receiver.shape_too_complex() || asm.ctx.get_chain_depth() as i32 >= GET_IVAR_MAX_DEPTH {
         // Fall back to calling rb_ivar_defined
 
         // Save the PC and SP because the callee may allocate


### PR DESCRIPTION
Running https://github.com/ruby/ruby/pull/7755 locally with a bare SFR stats hash, I confirmed definedivar exit reasons consist of:

```
definedivar exit reasons:
    megamorphic: 27,640,363 (100.0%)
```

which makes up 4.3% overall.

Similar to what we do for getivar and setivar, I think we should use a general case at the last chain to avoid side exits.