### PR TITLE
Prevent segfault when calling `defined?(super)` in `BasicObject`

### DIFF
--- a/test/ruby/test_defined.rb
+++ b/test/ruby/test_defined.rb
@@ -311,9 +311,9 @@ class TestDefined < Test::Unit::TestCase
     end
 
     assert_nil(a)
-
+  ensure
     BasicObject.class_eval do
-      undef_method :a
+      undef_method :a if defined?(a)
     end
   end
 

--- a/test/ruby/test_defined.rb
+++ b/test/ruby/test_defined.rb
@@ -303,6 +303,20 @@ class TestDefined < Test::Unit::TestCase
     assert_equal("super", o.x, bug8367)
   end
 
+  def test_super_in_basic_object
+    BasicObject.class_eval do
+      def a
+        defined?(super)
+      end
+    end
+
+    assert_nil(a)
+
+    BasicObject.class_eval do
+      undef_method :a
+    end
+  end
+
   def test_super_toplevel
     assert_separately([], "assert_nil(defined?(super))")
   end

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -4791,7 +4791,7 @@ vm_defined(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, rb_num_t op_
 
             if (me) {
                 VALUE klass = vm_search_normal_superclass(me->defined_class);
-                if (klass == (VALUE)NULL) return false;
+                if (!klass) return false;
 
                 ID id = me->def->original_id;
 

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -4791,6 +4791,8 @@ vm_defined(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, rb_num_t op_
 
             if (me) {
                 VALUE klass = vm_search_normal_superclass(me->defined_class);
+                if (klass == (VALUE)NULL) return false;
+
                 ID id = me->def->original_id;
 
                 return rb_method_boundp(klass, id, 0);


### PR DESCRIPTION
Prior to this commit, a segmentation fault occurred in `vm_defined`'s `zsuper` implementation after NULL is returned as `BasicObject`'s superclass. This fix returns false from `vm_defined` if the superclass is NULL.

For example, the following code resulted in a segfault.
```ruby
class BasicObject
  def seg_fault
    defined?(super)
  end
end

seg_fault
```

### Intended behavior
`defined?(super)` and the `seg_fault` method returns `nil`.

<br/>
I've also added a test for this:

```sh
$ make test-all TESTS="ruby/test_defined.rb --name=/test_super_in_basic_object/ -v"
```

---

Special thanks to @rafaelfranca and @matthewd who helped me debug this!