### PR TITLE
Fix infinite loop in peephole optimizer doing useless jump elimination

### DIFF
--- a/test/ruby/test_syntax.rb
+++ b/test/ruby/test_syntax.rb
@@ -1949,6 +1949,16 @@ eom
     RUBY
   end
 
+  def test_infinite_jump_jump_elimination
+    # Assert that this doesn't loop infinitely doing jump-jump elimination.
+    assert_separately([], <<-RUBY)
+      def bug_19611
+        while true && true
+        end
+      end
+    RUBY
+  end
+
   private
 
   def not_label(x) @result = x; @not_label ||= nil end


### PR DESCRIPTION
If you have a pair of jumps which point at each other, preceeded by a jump which points at one of them too, iseq_peephole_optimize can loop forever switching the target of the first jump alternately between the other two.

Fixes [Bug #19611]