### PR TITLE
hash.c: fix typo in `#<=>` docs

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -7061,7 +7061,7 @@ static const rb_data_type_t env_data_type = {
  *  - #<=: Returns whether +self+ is a subset of a given object.
  *  - #==: Returns whether a given object is equal to +self+.
  *  - #>: Returns whether +self+ is a proper superset of a given object
- *  - #>=: Returns whether +self+ is a proper superset of a given object.
+ *  - #>=: Returns whether +self+ is a superset of a given object.
  *
  *  ==== Methods for Fetching
  *


### PR DESCRIPTION
The docs for `Hash#>=` say it’s a predicate for the receiver being a _strict_ superset of the argument, but it’s a predicate for being a _non-strict_ superset (I assume this snuck in due to copying-and-pasting the line above, documenting the strict `Hash#>`).