### PR TITLE
[Bug #19624] Hide internal IO for backquote

### DIFF
--- a/io.c
+++ b/io.c
@@ -10497,6 +10497,7 @@ rb_f_backquote(VALUE obj, VALUE str)
     if (NIL_P(port)) return rb_str_new(0,0);
 
     GetOpenFile(port, fptr);
+    rb_obj_hide(port);
     result = read_all(fptr, remain_size(fptr), Qnil);
     rb_io_close(port);
     RFILE(port)->fptr = NULL;

--- a/test/ruby/test_system.rb
+++ b/test/ruby/test_system.rb
@@ -146,6 +146,19 @@ class TestSystem < Test::Unit::TestCase
     end
   end
 
+  def test_system_closed
+    assert_separately([], "#{<<~"begin;"}\n#{<<~'end;'}")
+    begin;
+      ios = []
+      ObjectSpace.each_object(IO) {|io| ios << io}
+      `echo`
+      ObjectSpace.each_object(IO) do |io|
+        next if ios.include?(io)
+        assert_nothing_raised {io.close}
+      end
+    end;
+  end
+
   def test_empty_evstr
     assert_equal("", eval('"#{}"', nil, __FILE__, __LINE__), "[ruby-dev:25113]")
   end


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/19624