### PR TITLE
[Bug #19619] Preserve numbered parameters context

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -695,6 +695,11 @@ static NODE* node_newnode_with_locals(struct parser_params *, enum node_type, VA
 static NODE* node_newnode(struct parser_params *, enum node_type, VALUE, VALUE, VALUE, const rb_code_location_t*);
 #define rb_node_newnode(type, a1, a2, a3, loc) node_newnode(p, (type), (a1), (a2), (a3), (loc))
 
+/* Make a new temporal node, which should not be appeared in the
+ * result AST and does not have node_id and location. */
+static NODE* node_new_temporal(struct parser_params *p, enum node_type type, VALUE a0, VALUE a1, VALUE a2);
+#define NODE_NEW_TEMPORAL(t,a0,a1,a2) node_new_temporal(p, (t),(VALUE)(a0),(VALUE)(a1),(VALUE)(a2))
+
 static NODE *nd_set_loc(NODE *nd, const YYLTYPE *loc);
 
 static int
@@ -1208,10 +1213,13 @@ rescued_expr(struct parser_params *p, NODE *arg, NODE *rescue,
 static void
 restore_defun(struct parser_params *p, NODE *name)
 {
-    YYSTYPE c = {.val = name->nd_cval};
+    NODE *save = name->nd_next;
+    YYSTYPE c = {.val = save->nd_cval};
     p->cur_arg = name->nd_vid;
     p->ctxt.in_def = c.ctxt.in_def;
     p->ctxt.shareable_constant_value = c.ctxt.shareable_constant_value;
+    p->max_numparam = (int)save->nd_nth;
+    numparam_pop(p, save->nd_head);
 }
 
 static void
@@ -2037,10 +2045,15 @@ def_name	: fname
                         ID cur_arg = p->cur_arg;
                         YYSTYPE c = {.ctxt = p->ctxt};
                         numparam_name(p, fname);
+                        NODE *save =
+                            NODE_NEW_TEMPORAL(NODE_SELF,
+                                              /*head*/numparam_push(p),
+                                              /*nth*/p->max_numparam,
+                                              /*cval*/c.val);
                         local_push(p, 0);
                         p->cur_arg = 0;
                         p->ctxt.in_def = 1;
-                        $<node>$ = NEW_NODE(NODE_SELF, /*vid*/cur_arg, /*mid*/fname, /*cval*/c.val, &@$);
+                        $<node>$ = NEW_NODE(NODE_SELF, /*vid*/cur_arg, /*mid*/fname, /*args*/save, &@$);
                     /*%%%*/
                     /*%
                         $$ = NEW_RIPPER(fname, get_value($1), $$, &NULL_LOC);
@@ -10490,11 +10503,18 @@ yylex(YYSTYPE *lval, YYLTYPE *yylloc, struct parser_params *p)
 #define LVAR_USED ((ID)1 << (sizeof(ID) * CHAR_BIT - 1))
 
 static NODE*
-node_newnode(struct parser_params *p, enum node_type type, VALUE a0, VALUE a1, VALUE a2, const rb_code_location_t *loc)
+node_new_temporal(struct parser_params *p, enum node_type type, VALUE a0, VALUE a1, VALUE a2)
 {
     NODE *n = rb_ast_newnode(p->ast, type);
 
     rb_node_init(n, type, a0, a1, a2);
+    return n;
+}
+
+static NODE*
+node_newnode(struct parser_params *p, enum node_type type, VALUE a0, VALUE a1, VALUE a2, const rb_code_location_t *loc)
+{
+    NODE *n = node_new_temporal(p, type, a0, a1, a2);
 
     nd_set_loc(n, loc);
     nd_set_node_id(n, parser_get_node_id(p));

--- a/test/ruby/test_syntax.rb
+++ b/test/ruby/test_syntax.rb
@@ -1670,6 +1670,8 @@ eom
         assert_raise(NameError) {eval("_1")},
       ]
     }
+
+    assert_valid_syntax("proc {def foo(_);end;_1}")
   end
 
   def test_value_expr_in_condition


### PR DESCRIPTION
Preserve numbered parameters context across method definitions