### PR TITLE
 Ensure the VM is alive before accessing objspace in C API (Feature #19627)

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -1007,11 +1007,11 @@ asan_unlock_freelist(struct heap_page *page)
 /* Aliases */
 #define rb_objspace (*rb_objspace_of(GET_VM()))
 #define rb_objspace_of(vm) ((vm)->objspace)
-#define rb_objspace_ptr() \
-  ({ \
-    rb_vm_t *rb_objspace_ptr_vm = GET_VM(); \
-    (UNLIKELY(rb_objspace_ptr_vm == NULL)) ? NULL : ((rb_objspace_ptr_vm)->objspace); \
-  })
+#define unless_objspace(objspace) \
+    rb_objspace_t *objspace; \
+    rb_vm_t *unless_objspace_vm = GET_VM(); \
+    if (unless_objspace_vm) objspace = unless_objspace_vm->objspace; \
+    else /* return; or objspace will be warned uninitialized */
 
 #define ruby_initial_gc_stress	gc_params.gc_stress
 
@@ -10919,7 +10919,7 @@ rb_gc_start(void)
 void
 rb_gc(void)
 {
-    rb_objspace_t *objspace = rb_objspace_ptr();
+    unless_objspace(objspace) { return; }
     if (!objspace) return;
     unsigned int reason = GPR_DEFAULT_REASON;
     garbage_collect(objspace, reason);
@@ -10928,8 +10928,7 @@ rb_gc(void)
 int
 rb_during_gc(void)
 {
-    rb_objspace_t *objspace = rb_objspace_ptr();
-    if (!objspace) return FALSE;
+    unless_objspace(objspace) { return FALSE; }
     return during_gc;
 }
 
@@ -12747,8 +12746,7 @@ gc_malloc_allocations(VALUE self)
 void
 rb_gc_adjust_memory_usage(ssize_t diff)
 {
-    rb_objspace_t *objspace = rb_objspace_ptr();
-    if (objspace == NULL) return;
+    unless_objspace(objspace) { return; }
 
     if (diff > 0) {
         objspace_malloc_increase(objspace, 0, diff, 0, MEMOP_TYPE_REALLOC);

--- a/gc.c
+++ b/gc.c
@@ -10920,7 +10920,6 @@ void
 rb_gc(void)
 {
     unless_objspace(objspace) { return; }
-    if (!objspace) return;
     unsigned int reason = GPR_DEFAULT_REASON;
     garbage_collect(objspace, reason);
 }


### PR DESCRIPTION
It is not possible to ensure the Ruby VM is accessible in certain scenarios, such as [thread local destructors](https://github.com/bytecodealliance/wasmtime-rb/actions/runs/4867822840/jobs/8680761059) and [async signal handlers](https://github.com/tmm1/stackprof/pull/200). 

Previously, it was possible to workaround this by probing the hidden `ruby_current_vm_ptr` symbol. But as of https://github.com/ruby/ruby/pull/7459, those symbols are no longer visible.

To remedy this, this patch adds some null checks when accessing `objspace` to eliminate known safety issues in the public C API (`rb_during_gc`, `rb_gc` and `rb_gc_adjust_memory_usage`).

prior art: https://github.com/ruby/ruby/pull/7663
issue tracker: https://bugs.ruby-lang.org/issues/19627