### PR TITLE
test_default_gems.rb: Stop using `git ls-files`

### DIFF
--- a/test/ruby/test_default_gems.rb
+++ b/test/ruby/test_default_gems.rb
@@ -2,22 +2,26 @@
 require 'rubygems'
 
 class TestDefaultGems < Test::Unit::TestCase
+  def self.load(file)
+    code = File.read(file, mode: "r:UTF-8:-", &:read)
+
+    # - `git ls-files` is useless under ruby's repository
+    # - `2>/dev/null` works only on Unix-like platforms
+    code.gsub!(/`git.*?`/, '""')
+
+    eval(code, binding, file)
+  end
 
   def test_validate_gemspec
     srcdir = File.expand_path('../../..', __FILE__)
     specs = 0
     Dir.chdir(srcdir) do
-      unless system("git", "rev-parse", %i[out err]=>IO::NULL)
-        omit "git not found"
-      end
       Dir.glob("#{srcdir}/{lib,ext}/**/*.gemspec").map do |src|
         specs += 1
-        assert_nothing_raised do
-          raise("invalid spec in #{src}") unless Gem::Specification.load(src)
-        end
+        assert_kind_of(Gem::Specification, self.class.load(src), "invalid spec in #{src}")
       end
     end
-    assert specs > 0, "gemspecs not found"
+    assert_operator specs, :>, 0, "gemspecs not found"
   end
 
 end


### PR DESCRIPTION
Just validate syntax and the result class instead.

Not only `git ls-files` doesn't make sence under ruby's repository, some gemspec files hardcode `2>/dev/null`, which doesn't work of course on other than Unix-like platforms.