### PR TITLE
Skip drb tests on mswin

### DIFF
--- a/test/drb/test_drbssl.rb
+++ b/test/drb/test_drbssl.rb
@@ -63,6 +63,10 @@ end
 class TestDRbSSLAry < Test::Unit::TestCase
   include DRbAry
   def setup
+    if RUBY_PLATFORM.match?(/mswin/)
+      @omitted = true
+      omit 'This test seems to randomly hang on GitHub Actions mswin'
+    end
     LeakChecker.skip if defined?(LeakChecker)
     @drb_service = DRbSSLService.new
     super

--- a/test/drb/test_drbssl.rb
+++ b/test/drb/test_drbssl.rb
@@ -41,9 +41,9 @@ end
 class TestDRbSSLCore < Test::Unit::TestCase
   include DRbCore
   def setup
-    if RUBY_PLATFORM.match?(/mingw/)
+    if RUBY_PLATFORM.match?(/mswin|mingw/)
       @omitted = true
-      omit 'This test seems to randomly hang on GitHub Actions MinGW'
+      omit 'This test seems to randomly hang on Windows'
     end
     @drb_service = DRbSSLService.new
     super
@@ -63,9 +63,9 @@ end
 class TestDRbSSLAry < Test::Unit::TestCase
   include DRbAry
   def setup
-    if RUBY_PLATFORM.match?(/mswin/)
+    if RUBY_PLATFORM.match?(/mswin|mingw/)
       @omitted = true
-      omit 'This test seems to randomly hang on GitHub Actions mswin'
+      omit 'This test seems to randomly hang on Windows'
     end
     LeakChecker.skip if defined?(LeakChecker)
     @drb_service = DRbSSLService.new


### PR DESCRIPTION
It fails with "D:/a/actions/actions/snapshot-ruby_3_1/tool/lib/test/unit.rb:740:in `const_get': uninitialized constant DRbTests::TestDRbSSLCore (NameError)"
https://github.com/ruby/actions/actions/runs/4896468736/jobs/8743421205