### PR TITLE
For YJIT stats, set avg_len_in_yjit to 0 if denominator would be 0

### DIFF
--- a/yjit.rb
+++ b/yjit.rb
@@ -165,7 +165,7 @@ module RubyVM::YJIT
     retired_in_yjit = stats[:exec_instruction] - side_exits
 
     # Average length of instruction sequences executed by YJIT
-    avg_len_in_yjit = retired_in_yjit.to_f / total_exits
+    avg_len_in_yjit = total_exits > 0 ? retired_in_yjit.to_f / total_exits : 0
 
     # This only available on yjit stats builds
     if stats.key?(:vm_insns_count)


### PR DESCRIPTION
This field is only compiled for yjit-stats builds.

Currently the result is NaN if the total exit is 0, which is inconvenient. This should only occur if YJIT has not yet executed any compiled methods.