### PR TITLE
Improve performance `Time#localtime` method written by Ruby

### DIFF
--- a/benchmark/time_localtime.yml
+++ b/benchmark/time_localtime.yml
@@ -1,0 +1,8 @@
+prelude: |
+  t = Time.utc(2000, 1, 1, 20, 15, 1)
+benchmark:
+  noarg: |
+    t.localtime 
+  given_zone: |
+    t.localtime("-09:00")  
+loop_count: 20000000

--- a/time.c
+++ b/time.c
@@ -4037,43 +4037,6 @@ time_zonelocal(VALUE time, VALUE off)
 
 /*
  *  call-seq:
- *    localtime -> self or new_time
- *    localtime(zone) -> new_time
- *
- *  With no argument given:
- *
- *  - Returns +self+ if +self+ is a local time.
- *  - Otherwise returns a new \Time in the user's local timezone:
- *
- *      t = Time.utc(2000, 1, 1, 20, 15, 1) # => 2000-01-01 20:15:01 UTC
- *      t.localtime                         # => 2000-01-01 14:15:01 -0600
- *
- *  With argument +zone+ given,
- *  returns the new \Time object created by converting
- *  +self+ to the given time zone:
- *
- *    t = Time.utc(2000, 1, 1, 20, 15, 1) # => 2000-01-01 20:15:01 UTC
- *    t.localtime("-09:00")               # => 2000-01-01 11:15:01 -0900
- *
- *  For forms of argument +zone+, see
- *  {Timezone Specifiers}[rdoc-ref:timezones.rdoc].
- *
- */
-
-static VALUE
-time_localtime_m(int argc, VALUE *argv, VALUE time)
-{
-    VALUE off;
-
-    if (rb_check_arity(argc, 0, 1) && !NIL_P(off = argv[0])) {
-        return time_zonelocal(time, off);
-    }
-
-    return time_localtime(time);
-}
-
-/*
- *  call-seq:
  *    utc -> self
  *
  *  Returns +self+, converted to the UTC timezone:
@@ -5764,7 +5727,6 @@ Init_Time(void)
     rb_define_method(rb_cTime, "hash", time_hash, 0);
     rb_define_method(rb_cTime, "initialize_copy", time_init_copy, 1);
 
-    rb_define_method(rb_cTime, "localtime", time_localtime_m, -1);
     rb_define_method(rb_cTime, "gmtime", time_gmtime, 0);
     rb_define_method(rb_cTime, "utc", time_gmtime, 0);
     rb_define_method(rb_cTime, "getlocal", time_getlocaltime, -1);

--- a/timev.rb
+++ b/timev.rb
@@ -401,4 +401,41 @@ class Time
 
     Primitive.time_init_args(year, mon, mday, hour, min, sec, zone)
   end
+
+  #
+  #  call-seq:
+  #    localtime -> self or new_time
+  #    localtime(zone) -> new_time
+  #
+  #  With no argument given:
+  #
+  #  - Returns +self+ if +self+ is a local time.
+  #  - Otherwise returns a new \Time in the user's local timezone:
+  #
+  #      t = Time.utc(2000, 1, 1, 20, 15, 1) # => 2000-01-01 20:15:01 UTC
+  #      t.localtime                         # => 2000-01-01 14:15:01 -0600
+  #
+  #  With argument +zone+ given,
+  #  returns the new \Time object created by converting
+  #  +self+ to the given time zone:
+  #
+  #    t = Time.utc(2000, 1, 1, 20, 15, 1) # => 2000-01-01 20:15:01 UTC
+  #    t.localtime("-09:00")               # => 2000-01-01 11:15:01 -0900
+  #
+  #  For forms of argument +zone+, see
+  #  {Timezone Specifiers}[rdoc-ref:timezones.rdoc].
+  #
+  #
+  def localtime(zone = unspecified = true)
+    if Primitive.mandatory_only?
+      Primitive.attr! :leaf
+      Primitive.cexpr! %q{ time_localtime(self) }
+    else
+      if unspecified
+        Primitive.cexpr! %q{ time_localtime(self) }
+      else
+        Primitive.cexpr! %q{ time_zonelocal(self, zone) }
+      end
+    end
+  end
 end


### PR DESCRIPTION
Improve performance `Time#localtime` method written by Ruby.

benchmark:
```bash
prelude: |
  t = Time.utc(2000, 1, 1, 20, 15, 1)
benchmark:
  noarg: |
    t.localtime 
  given_zone: |
    t.localtime("-09:00")  
loop_count: 20000000

```

result:
```bash
sh@DESKTOP-L0NI312:~/rubydev/build$ make benchmark/benchmark.yml -e BENCH_RUBY=../install/bin/ruby COMPARE_RUBY=~/.rbenv/shims/ruby
compare-ruby: ruby 3.3.0dev (2023-05-10T14:49:44Z master a19fa9b2bd) [x86_64-linux]
built-ruby: ruby 3.3.0dev (2023-05-11T02:33:23Z improve/time_local.. 2493bda901) [x86_64-linux]
# Iteration per second (i/s)

|            |compare-ruby|built-ruby|
|:-----------|-----------:|---------:|
|noarg       |     71.005M|   99.727M|
|            |           -|     1.40x|
|given_zone  |      2.215M|    2.449M|
|            |           -|     1.11x|
```


`COMPARE_RUBY` is `ruby 3.3.0dev (2023-05-10T14:49:44Z master a19fa9b2bd) [x86_64-linux]`. `BENCH_RUBY` is ahead of `ruby 3.3.0dev (2023-05-10T14:49:44Z master a19fa9b2bd) [x86_64-linux]`.

ref: https://github.com/ruby/ruby/pull/7486