### PR TITLE
Allow the match cache optimization for atomic groups

### DIFF
--- a/regexec.c
+++ b/regexec.c
@@ -446,8 +446,10 @@ count_num_cache_opcodes(const regex_t* reg, long* num_cache_opcodes_ptr)
       case OP_POP_POS:
       case OP_PUSH_POS_NOT:
       case OP_FAIL_POS:
+	goto impossible;
       case OP_PUSH_STOP_BT:
       case OP_POP_STOP_BT:
+	break;
       case OP_LOOK_BEHIND:
       case OP_PUSH_LOOK_BEHIND_NOT:
       case OP_FAIL_LOOK_BEHIND_NOT:
@@ -709,8 +711,10 @@ init_cache_opcodes(const regex_t* reg, OnigCacheOpcode* cache_opcodes, long* num
       case OP_POP_POS:
       case OP_PUSH_POS_NOT:
       case OP_FAIL_POS:
+	goto unexpected_bytecode_error;
       case OP_PUSH_STOP_BT:
       case OP_POP_STOP_BT:
+	break;
       case OP_LOOK_BEHIND:
       case OP_PUSH_LOOK_BEHIND_NOT:
       case OP_FAIL_LOOK_BEHIND_NOT:

--- a/test/ruby/test_regexp.rb
+++ b/test/ruby/test_regexp.rb
@@ -1760,6 +1760,16 @@ class TestRegexp < Test::Unit::TestCase
     end;
   end
 
+  def test_match_cache_atomic
+    assert_separately([], "#{<<-"begin;"}\n#{<<-'end;'}")
+      timeout = #{ EnvUtil.apply_timeout_scale(10).inspect }
+    begin;
+      Regexp.timeout = timeout
+
+      assert_nil(/^(?>a?a?)(a|a)*$/ =~ "a" * 1000000 + "x")
+    end;
+  end
+
   def test_cache_opcodes_initialize
     str = 'test1-test2-test3-test4-test_5'
     re = '^([0-9a-zA-Z\-/]*){1,256}$'


### PR DESCRIPTION
We can easily support the match cache optimization for atomic groups because atomic groups do not change anything other than backtracking behavior.