### PR TITLE
Unskip the test skipped in #4173

### DIFF
--- a/test/ruby/test_process.rb
+++ b/test/ruby/test_process.rb
@@ -1702,11 +1702,6 @@ class TestProcess < Test::Unit::TestCase
   end
 
   def test_wait_and_sigchild
-    if /freebsd|openbsd/ =~ RUBY_PLATFORM
-      # this relates #4173
-      # When ruby can use 2 cores, signal and wait4 may miss the signal.
-      omit "this fails on FreeBSD and OpenBSD on multithreaded environment"
-    end
     signal_received = []
     IO.pipe do |sig_r, sig_w|
       Signal.trap(:CHLD) do


### PR DESCRIPTION
This test was skipped 12 years ago because it was flaky on FreeBSD and OpenBSD. Since then, Ruby's SIGCHLD handling has been substantially re-written (mostly by Eric Wong @normalperson in 44fc3d08).

These tests now in fact pass reliably on Ruby master on FreeBSD 13.2 and OpenBSD 7.3. I stress-tested the test_wait_and_sigchild test on my laptop by running four copies of the test in a loop on a 8-core VM; both by itself and also as part of the whole test_process.rb file. I did not see any failures.

Let's unskip the test and close [#4173] out. I'll keep an eye out on Ruby CI for any flakes in this file on BSD after this gets merged, but if we don't see any I'm going to assume 44fc3d08 or related changes around that time accidently fixed this bug.

It's also probably important to unskip this test so that if another attempt at removing the special SIGCHLD handling is made (like was reverted in https://github.com/ruby/ruby/pull/7517), we get signal if that breaks on FreeBSD/OpenBSD.

[Fixes #4173]