### PR TITLE
Use the rb_sys_fail_str macro in signal.c

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -14436,6 +14436,7 @@ signal.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 signal.$(OBJEXT): $(top_srcdir)/internal/array.h
 signal.$(OBJEXT): $(top_srcdir)/internal/basic_operators.h
 signal.$(OBJEXT): $(top_srcdir)/internal/compilers.h
+signal.$(OBJEXT): $(top_srcdir)/internal/error.h
 signal.$(OBJEXT): $(top_srcdir)/internal/eval.h
 signal.$(OBJEXT): $(top_srcdir)/internal/gc.h
 signal.$(OBJEXT): $(top_srcdir)/internal/imemo.h

--- a/signal.c
+++ b/signal.c
@@ -36,6 +36,7 @@
 #include "debug_counter.h"
 #include "eval_intern.h"
 #include "internal.h"
+#include "internal/error.h"
 #include "internal/eval.h"
 #include "internal/sanitizers.h"
 #include "internal/signal.h"


### PR DESCRIPTION
Let signal.c include `"internal/error.h"` explicitly to ensure that the identifier `rb_sys_fail_str` in `signal.c` refers to the macro defined in `"internal/error.h"` instead of the actual function.

That macro reads `errno` before evaluating its argument.  Without this change, the `rb_signo2signm(sig)` expression in the `trap` function in `signal.c` will overwrite the `errno` before the actual `rb_sys_fail_str` function reads the `errno`.

Fixes: https://bugs.ruby-lang.org/issues/19635
