### PR TITLE
Introduce `gc_mark_table` macro

### DIFF
--- a/variable.c
+++ b/variable.c
@@ -501,12 +501,13 @@ mark_global_entry(VALUE v, void *ignored)
     return ID_TABLE_CONTINUE;
 }
 
+#define gc_mark_table(task) \
+    if (rb_global_tbl) { rb_id_table_foreach_values(rb_global_tbl, task##_global_entry, 0); }
+
 void
 rb_gc_mark_global_tbl(void)
 {
-    if (rb_global_tbl) {
-        rb_id_table_foreach_values(rb_global_tbl, mark_global_entry, 0);
-    }
+    gc_mark_table(mark);
 }
 
 static enum rb_id_table_iterator_result
@@ -522,9 +523,7 @@ update_global_entry(VALUE v, void *ignored)
 void
 rb_gc_update_global_tbl(void)
 {
-    if (rb_global_tbl) {
-        rb_id_table_foreach_values(rb_global_tbl, update_global_entry, 0);
-    }
+    gc_mark_table(update);
 }
 
 static ID


### PR DESCRIPTION
Introduce `gc_mark_table` macro to refactor `rb_gc_mark_global_tbl` and `rb_gc_update_global_tbl` functions.