### PR TITLE
Ensure SIGCHLD always uses a signal handler.

### DIFF
--- a/signal.c
+++ b/signal.c
@@ -1108,6 +1108,9 @@ default_handler(int sig)
 #ifdef SIGUSR2
       case SIGUSR2:
 #endif
+#ifdef RUBY_SIGCHLD
+      case RUBY_SIGCHLD:
+#endif
         func = sighandler;
         break;
 #ifdef SIGBUS


### PR DESCRIPTION
This should hopefully fix the BSD test suite failures introduced by https://github.com/ruby/ruby/pull/7816.