### PR TITLE
YJIT: Enable debug symbols in dev_nodebug

### DIFF
--- a/yjit/Cargo.toml
+++ b/yjit/Cargo.toml
@@ -32,7 +32,6 @@ overflow-checks = true
 
 [profile.dev_nodebug]
 inherits = "dev"
-debug = false
 
 [profile.stats]
 inherits = "release"


### PR DESCRIPTION
`debug`  flag in cargo is enabled even for release build. I think it's more useful to keep it in `dev_nodebug` as well.

The main motivation of `dev_nodebug` in https://github.com/ruby/ruby/pull/7570 was to turn off `RUBY_DEBUG` macro in C to make the interpreter faster. We don't need to change anything in the cargo side for it.