### PR TITLE
Preserve the original name of modules when making classpath permanent

### DIFF
--- a/spec/ruby/core/module/name_spec.rb
+++ b/spec/ruby/core/module/name_spec.rb
@@ -53,6 +53,24 @@ describe "Module#name" do
     end
   end
 
+  ruby_bug("#19681", ""..."3.3") do
+    it "keeps the very first name it was assigned" do
+      module ModuleSpecs
+        m = Module.new
+
+        class m::C; end
+        m::C.name.should =~ /\A#<Module:0x\h+>::C\z/
+
+        m::D = m::C
+        m::D.name.should =~ /\A#<Module:0x\h+>::C\z/
+
+        M = m
+        M::C.name.should == "ModuleSpecs::M::C"
+        M::D.name.should == "ModuleSpecs::M::C"
+      end
+    end
+  end
+
   it "is set after it is removed from a constant under an anonymous module" do
     m = Module.new
     module m::Child; end

--- a/variable.c
+++ b/variable.c
@@ -221,6 +221,20 @@ build_const_path(VALUE head, ID tail)
     return build_const_pathname(head, rb_id2str(tail));
 }
 
+static VALUE
+build_permanent_const_path(VALUE head, VALUE temporary_classpath)
+{
+    char *name = RSTRING_PTR(temporary_classpath);
+    char *next = name;
+    while ((next = strstr(next + 1, "::"))) {
+        name = next;
+    }
+
+    VALUE path = rb_str_dup(head);
+    rb_str_cat2(path, name);
+    return rb_fstring(path);
+}
+
 void
 rb_set_class_path_string(VALUE klass, VALUE under, VALUE name)
 {
@@ -3228,11 +3242,11 @@ set_namespace_path_i(ID id, VALUE v, void *payload)
     }
 
     bool has_permanent_classpath;
-    classname(value, &has_permanent_classpath);
+    VALUE temporary_classpath = classname(value, &has_permanent_classpath);
     if (has_permanent_classpath) {
         return ID_TABLE_CONTINUE;
     }
-    set_namespace_path(value, build_const_path(parental_path, id));
+    set_namespace_path(value, build_permanent_const_path(parental_path, temporary_classpath));
 
     if (!RCLASS_EXT(value)->permanent_classpath) {
         RCLASS_SET_CLASSPATH(value, 0, false);


### PR DESCRIPTION
[[Bug #19681]](https://bugs.ruby-lang.org/issues/19681)

Discovered by @fxn:

```ruby
m = Module.new

class m::C; end
p m::C.name # => "#<Module:0x000000010789fbe0>::C"

m::D = m::C
p m::D.name # => "#<Module:0x000000010789fbe0>::C"

M = m
p M::C.name # => "#<M::D"
```

The reason is that we use the keys from the parent const table to build the permanent name. But const tables are backed by `id_table` which isn't ordered, so we have no guarantee that the first match will be the original name and not an alias.

A solution is to instead extract the original name from the temporary classpath. It's a bit inelegant as it requires searching into a string, but it works quite well.