### PR TITLE
Use `rb_fork_ruby` for `--help` pager

### DIFF
--- a/ruby.c
+++ b/ruby.c
@@ -1824,6 +1824,8 @@ env_var_truthy(const char *name)
 }
 #endif
 
+rb_pid_t rb_fork_ruby(int *status);
+
 static VALUE
 process_options(int argc, char **argv, ruby_cmdline_options_t *opt)
 {
@@ -1860,7 +1862,7 @@ process_options(int argc, char **argv, ruby_cmdline_options_t *opt)
 #ifdef HAVE_WORKING_FORK
                 int fds[2];
                 if (rb_pipe(fds) == 0) {
-                    rb_pid_t pid = rb_fork();
+                    rb_pid_t pid = rb_fork_ruby(NULL);
                     if (pid > 0) {
                         /* exec PAGER with reading from child */
                         dup2(fds[0], 0);


### PR DESCRIPTION
Instead of `rb_fork`, to update `current_fork_gen` which has been introduced at 3563e1383fe4ce13168cd3b9f4d5222d69d00061.

Otherwise, the forked process attempts to stop the timer thread, but raises an exception because the thread is not alive in the child and dies because already no tag is present at that time.