### PR TITLE
Put `rb_fork` back into process.c

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -13661,7 +13661,6 @@ ruby.$(OBJEXT): $(top_srcdir)/internal/loadpath.h
 ruby.$(OBJEXT): $(top_srcdir)/internal/missing.h
 ruby.$(OBJEXT): $(top_srcdir)/internal/object.h
 ruby.$(OBJEXT): $(top_srcdir)/internal/parse.h
-ruby.$(OBJEXT): $(top_srcdir)/internal/process.h
 ruby.$(OBJEXT): $(top_srcdir)/internal/serial.h
 ruby.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 ruby.$(OBJEXT): $(top_srcdir)/internal/string.h

--- a/internal/process.h
+++ b/internal/process.h
@@ -22,7 +22,6 @@
 #include "ruby/ruby.h"          /* for VALUE */
 #include "internal/compilers.h" /* for __has_warning */
 #include "internal/imemo.h"     /* for RB_IMEMO_TMPBUF_PTR */
-#include "internal/warnings.h"  /* for COMPILER_WARNING_PUSH */
 
 #define RB_MAX_GROUPS (65536)
 
@@ -121,18 +120,5 @@ ARGVSTR2ARGC(VALUE argv_str)
         ;
     return i - 1;
 }
-
-#ifdef HAVE_WORKING_FORK
-COMPILER_WARNING_PUSH
-#if __has_warning("-Wdeprecated-declarations") || RBIMPL_COMPILER_IS(GCC)
-COMPILER_WARNING_IGNORED(-Wdeprecated-declarations)
-#endif
-static inline rb_pid_t
-rb_fork(void)
-{
-    return fork();
-}
-COMPILER_WARNING_POP
-#endif
 
 #endif /* INTERNAL_PROCESS_H */

--- a/process.c
+++ b/process.c
@@ -1573,6 +1573,17 @@ after_fork_ruby(rb_pid_t pid)
 
 #if defined(HAVE_WORKING_FORK)
 
+COMPILER_WARNING_PUSH
+#if __has_warning("-Wdeprecated-declarations") || RBIMPL_COMPILER_IS(GCC)
+COMPILER_WARNING_IGNORED(-Wdeprecated-declarations)
+#endif
+static inline rb_pid_t
+rb_fork(void)
+{
+    return fork();
+}
+COMPILER_WARNING_POP
+
 /* try_with_sh and exec_with_sh should be async-signal-safe. Actually it is.*/
 #define try_with_sh(err, prog, argv, envp) ((err == ENOEXEC) ? exec_with_sh((prog), (argv), (envp)) : (void)0)
 static void

--- a/ruby.c
+++ b/ruby.c
@@ -54,7 +54,6 @@
 #include "internal/missing.h"
 #include "internal/object.h"
 #include "internal/parse.h"
-#include "internal/process.h"
 #include "internal/variable.h"
 #include "ruby/encoding.h"
 #include "ruby/thread.h"


### PR DESCRIPTION
Now, calling `rb_fork` directly breaks the PID cache and the timer thread, so must use `rb_fork_ruby` or similar instead.