### PR TITLE
Remove deleted function

### DIFF
--- a/vm_eval.c
+++ b/vm_eval.c
@@ -1613,8 +1613,6 @@ rb_each(VALUE obj)
     return rb_call(obj, idEach, 0, 0, CALL_FCALL);
 }
 
-void rb_parser_warn_location(VALUE, int);
-
 static VALUE eval_default_path;
 
 static const rb_iseq_t *


### PR DESCRIPTION
`rb_parser_warn_location` was deleted by 0eeed5bcc5530edb0af2af2ccff09d067c59e8f9.