### PR TITLE
Remove unneeded allocation and assignment

### DIFF
--- a/vm_eval.c
+++ b/vm_eval.c
@@ -1655,7 +1655,6 @@ eval_make_iseq(VALUE src, VALUE fname, int line, const rb_binding_t *bind,
         if (!NIL_P(fname)) fname = rb_fstring(fname);
     }
     else {
-        fname = rb_fstring_lit("(eval)");
         if (!eval_default_path) {
             eval_default_path = rb_fstring_lit("(eval)");
             rb_gc_register_mark_object(eval_default_path);


### PR DESCRIPTION
fname is set to eval_default_path unconditionally shortly after this.