### PR TITLE
Fix crash when replacing ST hash with AR hash

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -2933,11 +2933,6 @@ rb_hash_replace(VALUE hash, VALUE hash2)
         rb_gc_writebarrier_remember(hash);
     }
 
-    if (RHASH_EMPTY_P(hash2) && RHASH_ST_TABLE_P(hash2)) {
-        /* ident hash */
-        hash_st_table_init(hash, RHASH_TYPE(hash2), 0);
-    }
-
     return hash;
 }
 

--- a/internal/hash.h
+++ b/internal/hash.h
@@ -179,7 +179,6 @@ static inline void
 RHASH_ST_CLEAR(VALUE h)
 {
     memset(RHASH_ST_TABLE(h), 0, sizeof(st_table));
-    FL_UNSET_RAW(h, RHASH_ST_TABLE_FLAG);
 }
 
 static inline unsigned

--- a/test/ruby/test_hash.rb
+++ b/test/ruby/test_hash.rb
@@ -850,6 +850,16 @@ class TestHash < Test::Unit::TestCase
     assert(true)
   end
 
+  def test_replace_st_with_ar
+    # ST hash
+    h1 = { a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8, i: 9 }
+    # AR hash
+    h2 = { a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7 }
+    # Replace ST hash with AR hash
+    h1.replace(h2)
+    assert_equal(h2, h1)
+  end
+
   def test_shift
     h = @h.dup
 


### PR DESCRIPTION
With VWA, AR hashes are much larger than ST hashes. Hash#replace attempts to directly copy the contents of AR hashes into ST hashes so there will be memory corruption caused by writing past the end of memory.

This commit changes it so that if a ST hash is being replaced with an AR hash it will insert each element into the ST hash.