### PR TITLE
Add Regexp#timeout= setter

### DIFF
--- a/test/ruby/test_regexp.rb
+++ b/test/ruby/test_regexp.rb
@@ -1813,4 +1813,16 @@ class TestRegexp < Test::Unit::TestCase
       re =~ s
     end
   end
+
+  def test_timeout_setter
+    re = /(a)\1{100000}/.dup
+    re.timeout = 0.1
+    assert_equal(0.1, re.timeout)
+    assert_raise(Regexp::TimeoutError) {re.match? "a"* 100000}
+  end
+
+  def test_timeout_setter_frozen
+    re = /(a)\1{100000}/
+    assert_raise(FrozenError) {re.timeout = 0.1}
+  end
 end


### PR DESCRIPTION
This makes it possible to set a custom timeout value for Regexp instances after initialization, or to be able to set a timeout for regexes that weren’t initialized using Regexp.new, like regex literals (though they're frozen and you'd need to `dup` them first to be able to do so).

