### PR TITLE
Rename `rb_node_name` to the original name

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -279,7 +279,7 @@ rb_ast_node_alloc(VALUE klass)
 static const char*
 node_type_to_str(const NODE *node)
 {
-    return (rb_node_name(nd_type(node)) + rb_strlen_lit("NODE_"));
+    return (ruby_node_name(nd_type(node)) + rb_strlen_lit("NODE_"));
 }
 
 static VALUE
@@ -675,7 +675,7 @@ node_children(rb_ast_t *ast, const NODE *node)
         break;
     }
 
-    rb_bug("node_children: unknown node: %s", rb_node_name(type));
+    rb_bug("node_children: unknown node: %s", ruby_node_name(type));
 }
 
 static VALUE

--- a/compile.c
+++ b/compile.c
@@ -404,7 +404,7 @@ do { \
     if (error_type != (ndtype)) { \
         COMPILE_ERROR(ERROR_ARGS_AT(error_node) \
                       prefix ": " #ndtype " is expected, but %s", \
-                      rb_node_name(error_type)); \
+                      ruby_node_name(error_type)); \
         return errval; \
     } \
 } while (0)
@@ -420,7 +420,7 @@ do { \
 do { \
     const NODE *error_node = (node); \
     COMPILE_ERROR(ERROR_ARGS_AT(error_node) prefix ": unknown node (%s)", \
-                  rb_node_name(nd_type(error_node))); \
+                  ruby_node_name(nd_type(error_node))); \
     return errval; \
 } while (0)
 
@@ -4302,12 +4302,12 @@ compile_branch_condition(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *co
       case NODE_STR:
       case NODE_ZLIST:
       case NODE_LAMBDA:
-        /* printf("useless condition eliminate (%s)\n",  rb_node_name(nd_type(cond))); */
+        /* printf("useless condition eliminate (%s)\n",  ruby_node_name(nd_type(cond))); */
         ADD_INSNL(ret, cond, jump, then_label);
         return COMPILE_OK;
       case NODE_FALSE:
       case NODE_NIL:
-        /* printf("useless condition eliminate (%s)\n", rb_node_name(nd_type(cond))); */
+        /* printf("useless condition eliminate (%s)\n", ruby_node_name(nd_type(cond))); */
         ADD_INSNL(ret, cond, jump, else_label);
         return COMPILE_OK;
       case NODE_LIST:
@@ -8910,7 +8910,7 @@ compile_op_cdecl(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node
         break;
       default:
         COMPILE_ERROR(ERROR_ARGS "%s: invalid node in NODE_OP_CDECL",
-                      rb_node_name(nd_type(node->nd_head)));
+                      ruby_node_name(nd_type(node->nd_head)));
         return COMPILE_NG;
     }
     mid = node->nd_head->nd_mid;

--- a/debug.c
+++ b/debug.c
@@ -148,7 +148,7 @@ ruby_debug_print_node(int level, int debug_level, const char *header, const NODE
 {
     if (level < debug_level) {
         fprintf(stderr, "DBG> %s: %s (%u)\n", header,
-                rb_node_name(nd_type(node)), nd_line(node));
+                ruby_node_name(nd_type(node)), nd_line(node));
     }
     return (NODE *)node;
 }

--- a/node.c
+++ b/node.c
@@ -29,7 +29,7 @@
 #define A_LIT(lit) AR(rb_dump_literal(lit))
 #define A_NODE_HEADER(node, term) \
     rb_str_catf(buf, "@ %s (id: %d, line: %d, location: (%d,%d)-(%d,%d))%s"term, \
-                rb_node_name(nd_type(node)), nd_node_id(node), nd_line(node), \
+                ruby_node_name(nd_type(node)), nd_node_id(node), nd_line(node), \
                 nd_first_lineno(node), nd_first_column(node), \
                 nd_last_lineno(node), nd_last_column(node), \
                 (node->flags & NODE_FL_NEWLINE ? "*" : ""))
@@ -1107,7 +1107,7 @@ dump_node(VALUE buf, VALUE indent, int comment, const NODE * node)
         break;
     }
 
-    rb_bug("dump_node: unknown node: %s", rb_node_name(nd_type(node)));
+    rb_bug("dump_node: unknown node: %s", ruby_node_name(nd_type(node)));
 }
 
 VALUE
@@ -1145,7 +1145,7 @@ rb_node_init(NODE *n, enum node_type type, VALUE a0, VALUE a1, VALUE a2)
 }
 
 const char *
-rb_node_name(int node)
+ruby_node_name(int node)
 {
     switch (node) {
 #include "node_name.inc"
@@ -1295,7 +1295,7 @@ rb_ast_node_type_change(NODE *n, enum node_type type)
     enum node_type old_type = nd_type(n);
     if (nodetype_markable_p(old_type) != nodetype_markable_p(type)) {
         rb_bug("node type changed: %s -> %s",
-               rb_node_name(old_type), rb_node_name(type));
+               ruby_node_name(old_type), ruby_node_name(type));
     }
 }
 
@@ -1390,7 +1390,7 @@ mark_ast_value(void *ctx, NODE * node)
         rb_gc_mark_movable(node->nd_rval);
         break;
       default:
-        rb_bug("unreachable node %s", rb_node_name(nd_type(node)));
+        rb_bug("unreachable node %s", ruby_node_name(nd_type(node)));
     }
 }
 

--- a/node.h
+++ b/node.h
@@ -441,7 +441,7 @@ rb_ast_t *rb_parser_compile_file_path(VALUE vparser, VALUE fname, VALUE input, i
 rb_ast_t *rb_parser_compile_generic(VALUE vparser, VALUE (*lex_gets)(VALUE, int), VALUE fname, VALUE input, int line);
 
 void rb_node_init(NODE *n, enum node_type type, VALUE a0, VALUE a1, VALUE a2);
-const char *rb_node_name(int node);
+const char *ruby_node_name(int node);
 
 const struct kwtable *rb_reserved_word(const char *, unsigned int);
 

--- a/parse.y
+++ b/parse.y
@@ -1340,7 +1340,7 @@ static int looking_at_eol_p(struct parser_params *p);
 %printer {
 #ifndef RIPPER
     if ($$) {
-        rb_parser_printf(p, "%s", rb_node_name(nd_type($$)));
+        rb_parser_printf(p, "%s", ruby_node_name(nd_type($$)));
     }
 #else
 #endif
@@ -11078,7 +11078,7 @@ symbol_append(struct parser_params *p, NODE *symbols, NODE *symbol)
         RB_OBJ_WRITTEN(p->ast, Qnil, symbol->nd_lit = rb_str_intern(symbol->nd_lit));
         break;
       default:
-        compile_error(p, "unexpected node as symbol: %s", rb_node_name(type));
+        compile_error(p, "unexpected node as symbol: %s", ruby_node_name(type));
     }
     return list_append(p, symbols, symbol);
 }


### PR DESCRIPTION
98637d421dbe8bcf86cc2effae5e26bb96a6a4da changes the name of the function. However this function is exported as global, then change the name to origin one for keeping compatibility.