### PR TITLE
YJIT: Introduce RubyVM::YJIT.stats_string

### DIFF
--- a/yjit.rb
+++ b/yjit.rb
@@ -186,7 +186,7 @@ module RubyVM::YJIT
 
   # Format and print out counters as a String. This returns a non-empty
   # content only when --yjit-stats is enabled.
-  def self.printed_stats
+  def self.stats_string
     # Lazily require StringIO to avoid breaking miniruby
     require 'stringio'
     strio = StringIO.new

--- a/yjit.rb
+++ b/yjit.rb
@@ -191,8 +191,7 @@ module RubyVM::YJIT
     require 'stringio'
     strio = StringIO.new
     _print_stats(out: strio)
-    strio.rewind
-    strio.read
+    strio.string
   end
 
   # Produce disassembly for an iseq


### PR DESCRIPTION
To periodically report production stats output in SFR, we've been using an implementation similar to this. Currently, it requires SFR to modify `$stderr` and call the private method `_print_stats`.

Since it's already proven to be useful, we should make it a public interface to avoid the hacky implementation.