### PR TITLE
testing_ruby.md: Update `make test-all` tips [ci skip]

### DIFF
--- a/doc/contributing/testing_ruby.md
+++ b/doc/contributing/testing_ruby.md
@@ -70,13 +70,19 @@ We can run any of the make scripts [in parallel](building_ruby.md#label-Running+
     first the file name, and then the test name, prefixed with `--name`. For example:
 
     ```
-    make test-all TESTS="../test/ruby/test_alias.rb --name=/test_alias_with_zsuper_method/"
+    make test-all TESTS="../test/ruby/test_alias.rb --name=TestAlias#test_alias_with_zsuper_method"
     ```
 
     To run these specs with logs, we can use:
 
     ```
     make test-all TESTS=-v
+    ```
+
+    We can display the help of the `TESTS` option:
+
+    ```
+    $ make test-all TESTS=--help
     ```
 
     If we would like to run both the `test/` and `bootstraptest/` test suites, we can run


### PR DESCRIPTION
This PR is to update the document about testing Ruby.

I think to explain the specific test case, the complete matching `--name=TestingClass#test_method` is better than the regular expression matching `--name=/something/`.

And I think the following command is helpful to know the options.

```
$ make test-all TESTS=--help
```

It is explained [in the `common.mk`](https://github.com/ruby/ruby/blob/e87f6c899e55f4d9452ce4d75cf2a725ae736aff/common.mk#L826
) with the `TESTOPTS="--help"`. However, as I see that the `TESTS` is only used in the `test-all` section in the `testing_ruby.md`, I am using `TESTS=--help` to align other parts.


The modified document is [https://github.com/junaruga/ruby/blob/wip/doc-contributing/doc/contributing/testing_ruby.md].


## Debugging the specific test with debug gem

By the way, I wanted to add the way to debug a test with debug gem in the `make test-all` in the `testing_ruby.md`. I see it's useful to debug.

```
$ ./configure

$ make

$ make test-all TESTS="test/ruby/test_alias.rb --name=TestAlias#test_alias_with_zsuper_method" RUN_OPTS=-rdebug/start
[1, 10] in ./test/runner.rb
     1| # frozen_string_literal: true
     2| 
     3| # Should be done in rubygems test files?
=>   4| ENV["GEM_SKIP"] = "".freeze
     5| ENV.delete("RUBY_CODESIGN")
     6| 
     7| Warning[:experimental] = false
     8| 
     9| gem_path = [
    10|   File.realdirpath(".bundle"),
=>#0	<main> at ./test/runner.rb:4
(rdbg) b TestAlias#test_alias_with_zsuper_method    # break command
Unknown constant name: "TestAlias"
#0  BP - Method (pending)  TestAlias#test_alias_with_zsuper_method
(rdbg) c    # continue command
Run options: 
  --seed=9328
  "--ruby=./miniruby -I./lib -I. -I.ext/common  ./tool/runruby.rb --extout=.ext  -- -rdebug/start"
  --excludes-dir=./test/excludes
  --name=!/memory_leak/
  --name=TestAlias#test_alias_with_zsuper_method

# Running tests:

[1/0] TestAlias#test_alias_with_zsuper_method[96, 105] in ~/var/git/ruby/ruby/test/ruby/test_alias.rb
    96|       end
    97|     end
    98|   end
    99| 
   100|   def test_alias_with_zsuper_method
=> 101|     c = Class.new
   102|     c.class_eval do
   103|       def foo
   104|         :ok
   105|       end
=>#0	TestAlias#test_alias_with_zsuper_method at ~/var/git/ruby/ruby/test/ruby/test_alias.rb:101
  #1	Test::Unit::TestCase#run_test(name=:test_alias_with_zsuper_method) at ~/var/git/ruby/ruby/tool/lib/test/unit/testcase.rb:200
  # and 24 frames (use `bt' command for all frames)

Stop by #0  BP - Method  TestAlias#test_alias_with_zsuper_method at /home/jaruga/var/git/ruby/ruby/test/ruby/test_alias.rb:100
(rdbg) 
```

However, maybe this document is written as a prerequisite where the current working directory is in the `build` directory that is written in the [building_ruby.md](https://github.com/junaruga/ruby/blob/wip/doc-contributing/doc/contributing/building_ruby.md). In the case, I couldn't run the specific unit test with debug gem. So, I couldn't write this way to the document.

```
$ mkdir build && cd build

$ ../configure --prefix="${HOME}/.rubies/ruby-master"

$ make

$ make test-all TESTS="../test/ruby/test_alias.rb --name=TestAlias#test_alias_with_zsuper_method" RUN_OPTS=-rdebug/start
../revision.h updated
generating x86_64-linux-fake.rb
x86_64-linux-fake.rb updated
<internal:/home/jaruga/var/git/ruby/ruby2/lib/rubygems/core_ext/kernel_require.rb>:85:in `require': cannot load such file -- debug/start (LoadError)
	from <internal:/home/jaruga/var/git/ruby/ruby2/lib/rubygems/core_ext/kernel_require.rb>:85:in `require'
make: *** [uncommon.mk:831: yes-test-all] Error 1
```
