### PR TITLE
mkmf: Add the extra option `--with-verbose` to enable verbose mode.

### DIFF
--- a/lib/mkmf.rb
+++ b/lib/mkmf.rb
@@ -1965,14 +1965,14 @@ SRC
 
   def configuration(srcdir)
     mk = []
-    CONFIG['MKMF_VERBOSE'] ||= "0"
+    verbose = with_config('verbose') ?  "1" : (CONFIG['MKMF_VERBOSE'] || "0")
     vpath = $VPATH.dup
     CONFIG["hdrdir"] ||= $hdrdir
     mk << %{
 SHELL = /bin/sh
 
 # V=0 quiet, V=1 verbose.  other values don't work.
-V = #{CONFIG['MKMF_VERBOSE']}
+V = #{verbose}
 V0 = $(V:0=)
 Q1 = $(V:1=)
 Q = $(Q1:0=@)

--- a/test/mkmf/base.rb
+++ b/test/mkmf/base.rb
@@ -147,7 +147,10 @@ class TestMkmf < Test::Unit::TestCase
 
   include Base
 
-  def assert_separately(args, src, *rest, **options)
-    super(args + ["-r#{__FILE__}"], "extend TestMkmf::Base; setup\nEND{teardown}\n#{src}", *rest, **options)
+  def assert_separately(args, extra_args, src, *rest, **options)
+    super(args + ["-r#{__FILE__}"] + %w[- --] + extra_args,
+          "extend TestMkmf::Base; setup\nEND{teardown}\n#{src}",
+          *rest,
+          **options)
   end
 end

--- a/test/mkmf/test_config.rb
+++ b/test/mkmf/test_config.rb
@@ -1,15 +1,30 @@
 # frozen_string_literal: false
-$extmk = true
+require_relative 'base'
 
-require 'test/unit'
-require 'mkmf'
-
-class TestMkmfConfig < Test::Unit::TestCase
+class TestMkmfConfig < TestMkmf
   def test_dir_config
     bug8074 = '[Bug #8074]'
     lib = RbConfig.expand(RbConfig::MAKEFILE_CONFIG["libdir"], "exec_prefix"=>"/test/foo")
-    assert_separately %w[-rmkmf - -- --with-foo-dir=/test/foo], %{
+    assert_separately([], %w[--with-foo-dir=/test/foo], <<-"end;")
       assert_equal(%w[/test/foo/include #{lib}], dir_config("foo"), #{bug8074.dump})
-    }
+    end;
+  end
+
+  def test_with_config_with_arg_and_value
+    assert_separately([], %w[--with-foo=bar], <<-'end;')
+      assert_equal("bar", with_config("foo"))
+    end;
+  end
+
+  def test_with_config_with_arg_and_no_value
+    assert_separately([], %w[--with-foo], <<-'end;')
+      assert_equal(true, with_config("foo"))
+    end;
+  end
+
+  def test_with_config_without_arg
+    assert_separately([], %w[--without-foo], <<-'end;')
+      assert_equal(false, with_config("foo"))
+    end;
   end
 end

--- a/test/mkmf/test_configuration.rb
+++ b/test/mkmf/test_configuration.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: false
+require_relative 'base'
+
+class TestMkmfConfiguration < TestMkmf
+  def test_verbose_with_rbconfig_verbose_disabled
+    makefile = mkmf do
+      self.class::CONFIG['MKMF_VERBOSE'] = "0"
+      init_mkmf(self.class::CONFIG)
+      configuration '.'
+    end
+    verbose = makefile.grep(/^V =/).first[/^V = (.)$/, 1]
+
+    assert_equal "0", verbose
+  end
+
+  def test_verbose_with_rbconfig_verbose_enabled
+    makefile = mkmf do
+      self.class::CONFIG['MKMF_VERBOSE'] = "1"
+      init_mkmf(self.class::CONFIG)
+      configuration '.'
+    end
+    verbose = makefile.grep(/^V =/).first[/^V = (.)$/, 1]
+
+    assert_equal "1", verbose
+  end
+
+  def test_verbose_with_arg
+    assert_separately([], %w[--with-verbose], <<-'end;')
+      makefile = mkmf do
+        self.class::CONFIG['MKMF_VERBOSE'] = "0"
+        init_mkmf(self.class::CONFIG)
+        configuration '.'
+      end
+      verbose = makefile.grep(/^V =/).first[/^V = (.)$/, 1]
+
+      assert_equal "1", verbose
+    end;
+  end
+end

--- a/test/mkmf/test_flags.rb
+++ b/test/mkmf/test_flags.rb
@@ -33,21 +33,21 @@ class TestMkmfFlags < TestMkmf
   end
 
   def test_try_ldflag_invalid_opt
-    assert_separately([], <<-'end;') #do
+    assert_separately([], [], <<-'end;') #do
       assert(!try_ldflags("nosuch.c"), TestMkmf::MKMFLOG)
       assert(have_devel?, TestMkmf::MKMFLOG)
     end;
   end
 
   def test_try_cflag_invalid_opt
-    assert_separately([], <<-'end;', timeout: 30) #do
+    assert_separately([], [], <<-'end;', timeout: 30) #do
       assert(!try_cflags("nosuch.c"), TestMkmf::MKMFLOG)
       assert(have_devel?, TestMkmf::MKMFLOG)
     end;
   end
 
   def test_try_cppflag_invalid_opt
-    assert_separately([], <<-'end;') #do
+    assert_separately([], [], <<-'end;') #do
       assert(!try_cppflags("nosuch.c"), TestMkmf::MKMFLOG)
       assert(have_devel?, TestMkmf::MKMFLOG)
     end;


### PR DESCRIPTION
The Ruby ticket is <https://bugs.ruby-lang.org/issues/19695>.

This PR is to add the new extra argument `--with-verbose` to the `mkmf.rb`, and the PR has 3 commits.

1. mkmf: Add the extra option `--with-verbose` to enable verbose mode.
2. mkmf: Add tests for `MakeMakefile#with_config`.
3. mkmf: Add tests to test the verbose mode in MakeMakefile#configuration.

## mkmf: Add the extra option `--with-verbose` to enable verbose mode.

The first commit is the main one of the feature.
    
This commit is to add an extra option to enable verbose mode (V=1) in the generated `Makefile` at runtime of the Ruby to print compiler command lines by the commands below when building native extensions. It's possible to enable the verbose mode by setting the environment variable `MAKEFLAGS="V=1"`[1] implemented in GNU make. However, I wanted to make a consistent user-interface not depending on the specific make's implementation.

```
$ ruby /path/to/extconf.rb -- --with-verbose
```

You can also add the extra option via rake-compiler gem.

```
$ rake compiler -- --with-verbose
```

If the extra option is not given, the value of the `RbConfig::CONFIG["MKMF_VERBOSE"]` enabled by the configure option below is used.

```
$ ./configure --enable-mkmf-verbose
```

[1] https://www.gnu.org/software/make/manual/html_node/Variables_002fRecursion.html

Co-authored-by: Nobuyoshi Nakada <nobu@ruby-lang.org>

## mkmf: Add tests for `MakeMakefile#with_config`.

This second commit is to test the `MakeMakefile#with_config` that is used in the main commit. As I couldn't find the test of the `with_config`, I created it. 

## mkmf: Add tests to test the verbose mode in MakeMakefile#configuration.

The third commit is the tests to test the use cases of the first commit.
