### PR TITLE
Work around a hang in fork(2) on FreeBSD making tests fail

### DIFF
--- a/tool/runruby.rb
+++ b/tool/runruby.rb
@@ -134,6 +134,9 @@ if File.file?(libruby_so)
     env[e] = [abs_archdir, ENV[e]].compact.join(File::PATH_SEPARATOR)
   end
 end
+# Work around a bug in FreeBSD 13.2 which can cause fork(2) to hang
+# See: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=271490
+env['LD_BIND_NOW'] = 'yes' if /freebsd/ =~ RUBY_PLATFORM
 
 ENV.update env
 


### PR DESCRIPTION
See bug https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=271490

On FreeBSDk, it's possible for fork(2) in a multithreaded process to hang because of a bug in the lock handling of the dynamic linker. This is now fixed on FreeBSD master, but it would be good if we could work around it for Ruby CI which is running 13.1.

Setting LD_BIND_NOW seems to work around the problem (probably because the dynamic linker doesn't then need to resolve anything through the PLT when it's first called).