### PR TITLE
[Bug #19685]: Add `-y` and `--yydebug` document to `--help`

### DIFF
--- a/man/ruby.1
+++ b/man/ruby.1
@@ -388,7 +388,7 @@ before executing script.
 .Pp
 .It Fl y
 .It Fl -yydebug
-DO NOT USE.
+This option is not guaranteed to be compatible.
 .Pp
 Turns on compiler debug mode.  Ruby will print a bunch of internal
 state messages during compilation.  Only specify this switch you are going to

--- a/ruby.c
+++ b/ruby.c
@@ -284,7 +284,7 @@ usage(const char *name, int help, int highlight, int columns)
         M("-w",		   "",			   "turn warnings on for your script"),
         M("-W[level=2|:category]",   "",	   "set warning level; 0=silence, 1=medium, 2=verbose"),
         M("-x[directory]", "",			   "strip off text before #!ruby line and perhaps cd to directory"),
-        M("",              "-y, --yydebug",        "yydebug of yacc parser generator. This option is not guaranteed to be compatible"),
+        M("",              "-y, --yydebug",        "print log of parser. Backward compatibility is not guaranteed"),
         M("--jit",         "",                     "enable JIT for the platform, same as " PLATFORM_JIT_OPTION),
 #if USE_YJIT
         M("--yjit",        "",                     "enable in-process JIT compiler"),

--- a/ruby.c
+++ b/ruby.c
@@ -284,6 +284,7 @@ usage(const char *name, int help, int highlight, int columns)
         M("-w",		   "",			   "turn warnings on for your script"),
         M("-W[level=2|:category]",   "",	   "set warning level; 0=silence, 1=medium, 2=verbose"),
         M("-x[directory]", "",			   "strip off text before #!ruby line and perhaps cd to directory"),
+        M("",              "-y, --yydebug",        "yydebug of yacc parser generator. This option is not guaranteed to be compatible"),
         M("--jit",         "",                     "enable JIT for the platform, same as " PLATFORM_JIT_OPTION),
 #if USE_YJIT
         M("--yjit",        "",                     "enable in-process JIT compiler"),

--- a/ruby.c
+++ b/ruby.c
@@ -304,7 +304,7 @@ usage(const char *name, int help, int highlight, int columns)
         M("--backtrace-limit=num",                  "", "limit the maximum length of backtrace"),
         M("--verbose",                              "", "turn on verbose mode and disable script from stdin"),
         M("--version",                              "", "print the version number, then exit"),
-        M("-y, --yydebug",                          "", "print log of parser. Backward compatibility is not guaranteed"),
+        M("-y",                          ", --yydebug", "print log of parser. Backward compatibility is not guaranteed"),
         M("--help",			            "", "show this message, -h for short message"),
     };
     static const struct ruby_opt_message dumps[] = {

--- a/ruby.c
+++ b/ruby.c
@@ -284,7 +284,6 @@ usage(const char *name, int help, int highlight, int columns)
         M("-w",		   "",			   "turn warnings on for your script"),
         M("-W[level=2|:category]",   "",	   "set warning level; 0=silence, 1=medium, 2=verbose"),
         M("-x[directory]", "",			   "strip off text before #!ruby line and perhaps cd to directory"),
-        M("",              "-y, --yydebug",        "print log of parser. Backward compatibility is not guaranteed"),
         M("--jit",         "",                     "enable JIT for the platform, same as " PLATFORM_JIT_OPTION),
 #if USE_YJIT
         M("--yjit",        "",                     "enable in-process JIT compiler"),
@@ -305,6 +304,7 @@ usage(const char *name, int help, int highlight, int columns)
         M("--backtrace-limit=num",                  "", "limit the maximum length of backtrace"),
         M("--verbose",                              "", "turn on verbose mode and disable script from stdin"),
         M("--version",                              "", "print the version number, then exit"),
+        M("-y, --yydebug",                          "", "print log of parser. Backward compatibility is not guaranteed"),
         M("--help",			            "", "show this message, -h for short message"),
     };
     static const struct ruby_opt_message dumps[] = {


### PR DESCRIPTION
I added `-y` and `--debug` option to `--help`
It is clearly stated that compatibility is not guaranteed.

Implements: [Bug #19685](https://bugs.ruby-lang.org/issues/19685)