### PR TITLE
Unify error messages of rb_num2ulong and rb_num2ull

### DIFF
--- a/numeric.c
+++ b/numeric.c
@@ -3165,7 +3165,7 @@ rb_num2ulong_internal(VALUE val, int *wrap_p)
 {
   again:
     if (NIL_P(val)) {
-       rb_raise(rb_eTypeError, "no implicit conversion from nil to integer");
+       rb_raise(rb_eTypeError, "no implicit conversion of nil into Integer");
     }
 
     if (FIXNUM_P(val)) {
@@ -3440,7 +3440,7 @@ unsigned LONG_LONG
 rb_num2ull(VALUE val)
 {
     if (NIL_P(val)) {
-        rb_raise(rb_eTypeError, "no implicit conversion from nil");
+        rb_raise(rb_eTypeError, "no implicit conversion of nil into Integer");
     }
     else if (FIXNUM_P(val)) {
         return (LONG_LONG)FIX2LONG(val); /* this is FIX2LONG, intended */
@@ -3459,15 +3459,10 @@ rb_num2ull(VALUE val)
     else if (RB_BIGNUM_TYPE_P(val)) {
         return rb_big2ull(val);
     }
-    else if (RB_TYPE_P(val, T_STRING)) {
-        rb_raise(rb_eTypeError, "no implicit conversion from string");
+    else {
+        val = rb_to_int(val);
+        return NUM2ULL(val);
     }
-    else if (RB_TYPE_P(val, T_TRUE) || RB_TYPE_P(val, T_FALSE)) {
-        rb_raise(rb_eTypeError, "no implicit conversion from boolean");
-    }
-
-    val = rb_to_int(val);
-    return NUM2ULL(val);
 }
 
 #endif  /* HAVE_LONG_LONG */

--- a/spec/ruby/core/time/new_spec.rb
+++ b/spec/ruby/core/time/new_spec.rb
@@ -523,9 +523,16 @@ describe "Time.new with a timezone argument" do
       end
 
       it "raise TypeError is can't convert precision keyword argument into Integer" do
+        error_msg =
+          if "3.3" <= RUBY_VERSION
+            "no implicit conversion of String into Integer"
+          else
+            "no implicit conversion from string"
+          end
+
         -> {
           Time.new("2021-12-25 00:00:00.123456789876 +09:00", precision: "")
-        }.should raise_error(TypeError, "no implicit conversion from string")
+        }.should raise_error(TypeError, error_msg)
       end
 
       it "raises ArgumentError if part of time string is missing" do


### PR DESCRIPTION
The error messages were slightly different due, which causes different behaviour on 32-bit and 64-bit systems.