### PR TITLE
Skip a flaky test on macOS

### DIFF
--- a/test/ruby/test_process.rb
+++ b/test/ruby/test_process.rb
@@ -691,6 +691,7 @@ class TestProcess < Test::Unit::TestCase
   end unless windows? # does not support fifo
 
   def test_execopts_redirect_open_fifo_interrupt_print
+    omit "[Bug #19700]" if /darwin/ =~ RUBY_PLATFORM
     with_tmpchdir {|d|
       begin
         File.mkfifo("fifo")


### PR DESCRIPTION
I believe this is flaky because the operating system is buggy.

https://bugs.ruby-lang.org/issues/19700 - I put the details about my thinking there.