### PR TITLE
Revert "Revert https://github.com/ruby/io-console/pull/43"

### DIFF
--- a/ext/io/console/extconf.rb
+++ b/ext/io/console/extconf.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: false
 require 'mkmf'
 
+have_func("rb_io_path")
+have_func("rb_io_descriptor")
+have_func("rb_io_get_write_io")
+have_func("rb_io_closed_p")
+have_func("rb_io_open_descriptor")
+
 ok = true if RUBY_ENGINE == "ruby" || RUBY_ENGINE == "truffleruby"
 hdr = nil
 case


### PR DESCRIPTION
This restores the changes in `io-console` without breaking backwards compatibility.