### PR TITLE
Expose `enum rb_io_event` flags without `_t` suffix.

### DIFF
--- a/include/ruby/io.h
+++ b/include/ruby/io.h
@@ -78,11 +78,13 @@ RUBY_EXTERN VALUE rb_eIOTimeoutError;
  *
  * This is visible from extension libraries because `io/wait` wants it.
  */
-typedef enum {
+enum rb_io_event {
     RUBY_IO_READABLE = RB_WAITFD_IN,  /**< `IO::READABLE` */
     RUBY_IO_WRITABLE = RB_WAITFD_OUT, /**< `IO::WRITABLE` */
     RUBY_IO_PRIORITY = RB_WAITFD_PRI, /**< `IO::PRIORITY` */
-} rb_io_event_t;
+};
+
+typedef enum rb_io_event rb_io_event_t;
 
 /**
  * IO  buffers.   This  is  an implementation  detail  of  ::rb_io_t::wbuf  and

--- a/io.c
+++ b/io.c
@@ -9785,7 +9785,7 @@ wait_mode_sym(VALUE mode)
     rb_raise(rb_eArgError, "unsupported mode: %"PRIsVALUE, mode);
 }
 
-static inline rb_io_event_t
+static inline enum rb_io_event
 io_event_from_value(VALUE value)
 {
     int events = RB_NUM2INT(value);
@@ -9816,7 +9816,7 @@ static VALUE
 io_wait(int argc, VALUE *argv, VALUE io)
 {
     VALUE timeout = Qundef;
-    rb_io_event_t events = 0;
+    enum rb_io_event events = 0;
     int return_io = 0;
 
     // The documented signature for this method is actually incorrect.


### PR DESCRIPTION
This is an additive change and should not cause any compatibility issue.

This improves consistency with existing definitions in `io.h`.