### PR TITLE
YJIT: Use #[cfg] instead of if cfg!

### DIFF
--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -493,7 +493,8 @@ pub extern "C" fn rb_yjit_record_exit_stack(exit_pc: *const VALUE)
     // rb_vm_insn_addr2opcode won't work in cargo test --all-features
     // because it's a C function. Without insn call, this function is useless
     // so wrap the whole thing in a not test check.
-    if cfg!(not(test)) {
+    #[cfg(not(test))]
+    {
         // Get the opcode from the encoded insn handler at this PC
         let insn = unsafe { rb_vm_insn_addr2opcode((*exit_pc).as_ptr()) };
 


### PR DESCRIPTION
This PR intends to fix a `cargo test` failure in `ruby_3_2` branch: https://cirrus-ci.com/task/6281156040065024

```
  = note: /usr/bin/ld: /tmp/cirrus-ci-build/yjit/target/debug/deps/yjit-0044bace7c3a8bfe.5b58a5nco7jhlap8.rcgu.o: in function `rb_yjit_record_exit_stack':
          /tmp/cirrus-ci-build/yjit/src/stats.rs:498: undefined reference to `rb_vm_insn_addr2opcode'
          /usr/bin/ld: /tmp/cirrus-ci-build/yjit/src/stats.rs:514: undefined reference to `rb_profile_frames'
          collect2: error: ld returned 1 exit status
```

I'm not sure why it's working for master, but `if cfg!(not(test))` _seems_ less reliable than `#[cfg(not(test))]` for eliminating the code as early as possible.