### PR TITLE
Stabilize test_latest_gc_info_need_major_by

### DIFF
--- a/test/ruby/test_gc.rb
+++ b/test/ruby/test_gc.rb
@@ -259,7 +259,7 @@ class TestGc < Test::Unit::TestCase
     # allocate objects until need_major_by is set or major GC happens
     major_count = GC.stat(:major_gc_count)
     objects = []
-    while GC.stat(:major_gc_count) == major_count && GC.latest_gc_info(:need_major_by).nil?
+    while GC.latest_gc_info(:need_major_by).nil?
       objects.append(100.times.map { '*' })
     end
 


### PR DESCRIPTION
Fix:
```
    1) Failure:
  TestGc#test_latest_gc_info_need_major_by [/home/runner/work/ruby/ruby/src/test/ruby/test_gc.rb:266]:
  <nil> expected to not be nil.
```

`GC.stat(:major_gc_count)` can be bumped while `GC.latest_gc_info(:need_major_by)` is still nil.

@ioquatix @peterzhu2118 