### PR TITLE
Ripper does not depend on Bison [ci skip]

### DIFF
--- a/ext/ripper/README
+++ b/ext/ripper/README
@@ -13,7 +13,6 @@ Requirements
 ------------
 
   * ruby 1.9 (support CVS HEAD only)
-  * bison 1.28 or later (Other yaccs do not work)
 
 Usage
 -----


### PR DESCRIPTION
It also uses Lrama then no dependency on Bison.