### PR TITLE
YJIT: Use #[cfg] instead of if cfg!

### DIFF
--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -641,7 +641,8 @@ pub extern "C" fn rb_yjit_record_exit_stack(exit_pc: *const VALUE)
     // rb_vm_insn_addr2opcode won't work in cargo test --all-features
     // because it's a C function. Without insn call, this function is useless
     // so wrap the whole thing in a not test check.
-    if cfg!(not(test)) {
+    #[cfg(not(test))]
+    {
         // Get the opcode from the encoded insn handler at this PC
         let insn = unsafe { rb_vm_insn_addr2opcode((*exit_pc).as_ptr()) };
 


### PR DESCRIPTION
Rust 1.70.0 came out and it seems to have [broken our build](https://github.com/ruby/ruby/runs/13959427198). This is the same patch as https://github.com/ruby/ruby/pull/7893 for `ruby_3_2` branch.

```
  = note: /usr/bin/ld: /tmp/cirrus-ci-build/yjit/target/debug/deps/yjit-0044bace7c3a8bfe.5b58a5nco7jhlap8.rcgu.o: in function `rb_yjit_record_exit_stack':
          /tmp/cirrus-ci-build/yjit/src/stats.rs:646: undefined reference to `rb_vm_insn_addr2opcode'
          /usr/bin/ld: /tmp/cirrus-ci-build/yjit/src/stats.rs:662: undefined reference to `rb_profile_frames'
          collect2: error: ld returned 1 exit status
```

`if cfg!` seems not reliable to avoid linking functions in the block, and apparently it stopped working in Rust 1.70.0. `#[cfg]` seems like the proper way to do it, so this PR uses it instead.