### PR TITLE
Redo fix for 19379

### DIFF
--- a/class.c
+++ b/class.c
@@ -446,8 +446,11 @@ cvc_table_copy(ID id, VALUE val, void *data)
 
     ent = ALLOC(struct rb_cvar_class_tbl_entry);
     ent->class_value = ctx->clone;
+    ent->cref = orig_entry->cref;
     ent->global_cvar_state = orig_entry->global_cvar_state;
     rb_id_table_insert(ctx->new_table, id, (VALUE)ent);
+
+    RB_OBJ_WRITTEN(ctx->clone, Qundef, ent->cref);
 
     return ID_TABLE_CONTINUE;
 }

--- a/ext/objspace/depend
+++ b/ext/objspace/depend
@@ -365,6 +365,11 @@ objspace.o: $(top_srcdir)/ccan/container_of/container_of.h
 objspace.o: $(top_srcdir)/ccan/list/list.h
 objspace.o: $(top_srcdir)/ccan/str/str.h
 objspace.o: $(top_srcdir)/constant.h
+objspace.o: $(hdrdir)/ruby/thread_native.h
+objspace.o: $(top_srcdir)/ccan/check_type/check_type.h
+objspace.o: $(top_srcdir)/ccan/container_of/container_of.h
+objspace.o: $(top_srcdir)/ccan/list/list.h
+objspace.o: $(top_srcdir)/ccan/str/str.h
 objspace.o: $(top_srcdir)/id_table.h
 objspace.o: $(top_srcdir)/internal.h
 objspace.o: $(top_srcdir)/internal/array.h

--- a/gc.c
+++ b/gc.c
@@ -7138,6 +7138,8 @@ gc_ref_update_from_offset(rb_objspace_t *objspace, VALUE obj)
     }
 }
 
+static void mark_cvc_tbl(rb_objspace_t *objspace, VALUE klass);
+
 static void
 gc_mark_children(rb_objspace_t *objspace, VALUE obj)
 {
@@ -7188,6 +7190,7 @@ gc_mark_children(rb_objspace_t *objspace, VALUE obj)
         if (!RCLASS_EXT(obj)) break;
 
         mark_m_tbl(objspace, RCLASS_M_TBL(obj));
+        mark_cvc_tbl(objspace, obj);
         cc_table_mark(objspace, obj);
         for (attr_index_t i = 0; i < RCLASS_IV_COUNT(obj); i++) {
             gc_mark(objspace, RCLASS_IVPTR(obj)[i]);
@@ -10325,8 +10328,13 @@ static enum rb_id_table_iterator_result
 update_cvc_tbl_i(VALUE cvc_entry, void *data)
 {
     struct rb_cvar_class_tbl_entry *entry;
+    rb_objspace_t * objspace = (rb_objspace_t *)data;
 
     entry = (struct rb_cvar_class_tbl_entry *)cvc_entry;
+
+    if (entry->cref) {
+        TYPED_UPDATE_IF_MOVED(objspace, rb_cref_t *, entry->cref);
+    }
 
     entry->class_value = rb_gc_location(entry->class_value);
 
@@ -10339,6 +10347,28 @@ update_cvc_tbl(rb_objspace_t *objspace, VALUE klass)
     struct rb_id_table *tbl = RCLASS_CVC_TBL(klass);
     if (tbl) {
         rb_id_table_foreach_values(tbl, update_cvc_tbl_i, objspace);
+    }
+}
+
+static enum rb_id_table_iterator_result
+mark_cvc_tbl_i(VALUE cvc_entry, void *data)
+{
+    struct rb_cvar_class_tbl_entry *entry;
+
+    entry = (struct rb_cvar_class_tbl_entry *)cvc_entry;
+
+    RUBY_ASSERT(entry->cref == 0 || (BUILTIN_TYPE((VALUE)entry->cref) == T_IMEMO && IMEMO_TYPE_P(entry->cref, imemo_cref)));
+    rb_gc_mark((VALUE) entry->cref);
+
+    return ID_TABLE_CONTINUE;
+}
+
+static void
+mark_cvc_tbl(rb_objspace_t *objspace, VALUE klass)
+{
+    struct rb_id_table *tbl = RCLASS_CVC_TBL(klass);
+    if (tbl) {
+        rb_id_table_foreach_values(tbl, mark_cvc_tbl_i, objspace);
     }
 }
 

--- a/internal/class.h
+++ b/internal/class.h
@@ -17,6 +17,9 @@
 #include "ruby/intern.h"        /* for rb_alloc_func_t */
 #include "ruby/ruby.h"          /* for struct RBasic */
 #include "shape.h"
+#include "ruby_assert.h"
+#include "vm_core.h"
+#include "method.h"             /* for rb_cref_t */
 
 #ifdef RCLASS_SUPER
 # undef RCLASS_SUPER
@@ -32,6 +35,7 @@ typedef struct rb_subclass_entry rb_subclass_entry_t;
 struct rb_cvar_class_tbl_entry {
     uint32_t index;
     rb_serial_t global_cvar_state;
+    const rb_cref_t * cref;
     VALUE class_value;
 };
 

--- a/test/ruby/test_variable.rb
+++ b/test/ruby/test_variable.rb
@@ -49,6 +49,19 @@ class TestVariable < Test::Unit::TestCase
     assert_equal(1, c.class_variable_get(:@@foo))
   end
 
+  Zeus = Gods.clone
+
+  def test_cloned_allows_setting_cvar
+    Zeus.class_variable_set(:@@rule, "Athena")
+
+    god = Gods.new.ruler0
+    zeus = Zeus.new.ruler0
+
+    assert_equal "Cronus", god
+    assert_equal "Athena", zeus
+    assert_not_equal god.object_id, zeus.object_id
+  end
+
   def test_singleton_class_included_class_variable
     c = Class.new
     c.extend(Olympians)

--- a/variable.c
+++ b/variable.c
@@ -3693,6 +3693,7 @@ rb_cvar_set(VALUE klass, ID id, VALUE val)
         ent = ALLOC(struct rb_cvar_class_tbl_entry);
         ent->class_value = target;
         ent->global_cvar_state = GET_GLOBAL_CVAR_STATE();
+        ent->cref = 0;
         rb_id_table_insert(rb_cvc_tbl, id, (VALUE)ent);
         RB_DEBUG_COUNTER_INC(cvar_inline_miss);
     }

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1519,6 +1519,7 @@ update_classvariable_cache(const rb_iseq_t *iseq, VALUE klass, ID id, const rb_c
     RUBY_ASSERT(BUILTIN_TYPE((VALUE)cref) == T_IMEMO && IMEMO_TYPE_P(cref, imemo_cref));
     RB_OBJ_WRITTEN(iseq, Qundef, ent->cref);
     RB_OBJ_WRITTEN(iseq, Qundef, ent->class_value);
+    RB_OBJ_WRITTEN(ent->class_value, Qundef, ent->cref);
 
     return cvar_value;
 }

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -806,6 +806,7 @@ pub type rb_shape_t = rb_shape;
 pub struct rb_cvar_class_tbl_entry {
     pub index: u32,
     pub global_cvar_state: rb_serial_t,
+    pub cref: *const rb_cref_t,
     pub class_value: VALUE,
 }
 pub const VM_CALL_ARGS_SPLAT_bit: vm_call_flag_bits = 0;


### PR DESCRIPTION
Unreverts #7265 and adds missing write barrier. Should fix the failures we saw in http://ci.rvm.jp/logfiles/brlog.trunk-gc-asserts.20230601-165052 (we were able to reproduce on Aaron's linux machine).

cc/ @tenderlove 