### PR TITLE
Backport: [ruby/openssl] Relax error message check for OpenSSL 3.1

### DIFF
--- a/test/openssl/test_ssl.rb
+++ b/test/openssl/test_ssl.rb
@@ -1046,9 +1046,7 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
     start_server(ignore_listener_error: true) { |port|
       ctx = OpenSSL::SSL::SSLContext.new
       ctx.set_params
-      # OpenSSL <= 1.1.0: "self signed certificate in certificate chain"
-      # OpenSSL >= 3.0.0: "self-signed certificate in certificate chain"
-      assert_raise_with_message(OpenSSL::SSL::SSLError, /self.signed/) {
+      assert_raise_with_message(OpenSSL::SSL::SSLError, /certificate/) {
         server_connect(port, ctx)
       }
     }


### PR DESCRIPTION
I'm backporting this because on my backport to fix cvar cloning I saw that we were experiencing this error on the `ruby_3_2` branch.

See original commit https://github.com/ruby/ruby/commit/0b303c683007598a31f2cda3d512d981b278f8bd

See build: https://github.com/ruby/ruby/actions/runs/5146819376/jobs/9266401095?pr=7888#logs

Ticket: https://bugs.ruby-lang.org/issues/19707

---

A tentative measures fo https://github.com/ruby/openssl/issues/606.

With OpenSSL 3.1.0, the error message at connection using "self-signed certificate" seems to return `SSL_R_TLSV1_ALERT_UNKNOWN_CA` instead of `SSL_R_CERTIFICATE_VERIFY_FAILED`.

https://github.com/ruby/openssl/commit/fc4629d246