### PR TITLE
YJIT: Fix a warning on cargo test

### DIFF
--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -612,7 +612,7 @@ fn get_live_context_count() -> usize {
 /// and line samples. Their length should be the same, however the data stored in
 /// them is different.
 #[no_mangle]
-pub extern "C" fn rb_yjit_record_exit_stack(exit_pc: *const VALUE)
+pub extern "C" fn rb_yjit_record_exit_stack(_exit_pc: *const VALUE)
 {
     // Return if YJIT is not enabled
     if !yjit_enabled_p() {
@@ -644,7 +644,7 @@ pub extern "C" fn rb_yjit_record_exit_stack(exit_pc: *const VALUE)
     #[cfg(not(test))]
     {
         // Get the opcode from the encoded insn handler at this PC
-        let insn = unsafe { rb_vm_insn_addr2opcode((*exit_pc).as_ptr()) };
+        let insn = unsafe { rb_vm_insn_addr2opcode((*_exit_pc).as_ptr()) };
 
         // Use the same buffer size as Stackprof.
         const BUFF_LEN: usize = 2048;


### PR DESCRIPTION
This PR fixes the following warning:

```
$ cargo test --all-features
   Compiling yjit v0.1.0 (/home/k0kubun/src/github.com/ruby/ruby/yjit)
warning: unused variable: `exit_pc`
   --> src/stats.rs:615:45
    |
615 | pub extern "C" fn rb_yjit_record_exit_stack(exit_pc: *const VALUE)
    |                                             ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_exit_pc`
    |
    = note: `#[warn(unused_variables)]` on by default
```

It's conditionally used for `#[cfg(not(test))]`, so it currently becomes a warning on `cargo test`.