### PR TITLE
YJIT: Reserve C argument registers on register allocation

### DIFF
--- a/yjit/src/backend/arm64/mod.rs
+++ b/yjit/src/backend/arm64/mod.rs
@@ -74,9 +74,10 @@ impl From<Opnd> for A64Opnd {
             Opnd::Mem(Mem { base: MemBase::InsnOut(_), .. }) => {
                 panic!("attempted to lower an Opnd::Mem with a MemBase::InsnOut base")
             },
-            Opnd::InsnOut { .. } => panic!("attempted to lower an Opnd::InsnOut"),
-            Opnd::Value(_) => panic!("attempted to lower an Opnd::Value"),
-            Opnd::Stack { .. } => panic!("attempted to lower an Opnd::Stack"),
+            Opnd::CArg { .. } |
+            Opnd::InsnOut { .. } |
+            Opnd::Value(_) |
+            Opnd::Stack { .. } => panic!("attempted to lower {:?}", opnd),
             Opnd::None => panic!(
                 "Attempted to lower an Opnd::None. This often happens when an out operand was not allocated for an instruction because the output of the instruction was not used. Please ensure you are using the output."
             ),
@@ -280,7 +281,7 @@ impl Assembler
         /// do follow that encoding, and if they don't then we load them first.
         fn split_bitmask_immediate(asm: &mut Assembler, opnd: Opnd, dest_num_bits: u8) -> Opnd {
             match opnd {
-                Opnd::Reg(_) | Opnd::InsnOut { .. } | Opnd::Stack { .. } => opnd,
+                Opnd::Reg(_) | Opnd::CArg(_) | Opnd::InsnOut { .. } | Opnd::Stack { .. } => opnd,
                 Opnd::Mem(_) => split_load_operand(asm, opnd),
                 Opnd::Imm(imm) => {
                     if imm == 0 {
@@ -313,7 +314,7 @@ impl Assembler
         /// a certain size. If they don't then we need to load them first.
         fn split_shifted_immediate(asm: &mut Assembler, opnd: Opnd) -> Opnd {
             match opnd {
-                Opnd::Reg(_) | Opnd::InsnOut { .. } => opnd,
+                Opnd::Reg(_) | Opnd::CArg(_) | Opnd::InsnOut { .. } => opnd,
                 Opnd::Mem(_) => split_load_operand(asm, opnd),
                 Opnd::Imm(_) => asm.load(opnd),
                 Opnd::UImm(uimm) => {
@@ -452,7 +453,7 @@ impl Assembler
                             _ => *opnd
                         };
 
-                        asm.load_into(C_ARG_OPNDS[idx], value);
+                        asm.load_into(Opnd::c_arg(C_ARG_OPNDS[idx]), value);
                     }
 
                     // Now we push the CCall without any arguments so that it
@@ -924,8 +925,8 @@ impl Assembler
                             let ptr_offset: u32 = (cb.get_write_pos() as u32) - (SIZEOF_VALUE as u32);
                             insn_gc_offsets.push(ptr_offset);
                         },
-                        Opnd::Stack { .. } => {
-                            unreachable!("Stack operand was not lowered before arm64_emit");
+                        Opnd::CArg(_) | Opnd::Stack { .. } => {
+                            unreachable!("Attempted to lower {:?}", opnd);
                         }
                         Opnd::None => {
                             unreachable!("Attempted to load from None operand");

--- a/yjit/src/backend/x86_64/mod.rs
+++ b/yjit/src/backend/x86_64/mod.rs
@@ -347,7 +347,7 @@ impl Assembler
                     // Load each operand into the corresponding argument
                     // register.
                     for (idx, opnd) in opnds.into_iter().enumerate() {
-                        asm.load_into(C_ARG_OPNDS[idx], *opnd);
+                        asm.load_into(Opnd::c_arg(C_ARG_OPNDS[idx]), *opnd);
                     }
 
                     // Now we push the CCall without any arguments so that it
@@ -1054,5 +1054,22 @@ mod tests {
         asm.compile_with_num_regs(&mut cb, 1);
 
         assert_eq!(format!("{:x}", cb), "4983f540");
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_c_arg_reg() {
+        let (mut asm, mut cb) = setup_asm();
+
+        let rax = asm.load(Opnd::UImm(1));
+        let rcx = asm.load(Opnd::UImm(2));
+        let rdx = asm.load(Opnd::UImm(3));
+        asm.ccall(0 as _, vec![
+            rax, // -> rdi
+            rcx, // -> rsi
+            rcx, // -> rdx
+            rdx, // -> rcx (rdx has been rewritten to 2)
+        ]);
+        asm.compile_with_num_regs(&mut cb, 3);
     }
 }


### PR DESCRIPTION
This is a revised attempt to fix the issue described in https://github.com/ruby/ruby/pull/7910.

We could reorder instructions and/or use an extra register to support such scenarios, but it seems like we don't need it for the current codegen.rs. So this PR just asserts that we don't have that problem by taking C argument registers from the pool when used.

---

Note: w.r.t. https://github.com/ruby/ruby/pull/7910#discussion_r1219762144, I still intend to implement an algorithm to generate optimal code for C arguments, but it'll be used only for stack temps. I want to reorder instructions in `x86_split` for it, but `InsnOut` is not lowered until `alloc_regs`.