### PR TITLE
objspace_dump.c: don't skip object's class in references

### DIFF
--- a/ext/objspace/objspace_dump.c
+++ b/ext/objspace/objspace_dump.c
@@ -313,9 +313,6 @@ reachable_object_i(VALUE ref, void *data)
 {
     struct dump_config *dc = (struct dump_config *)data;
 
-    if (dc->cur_obj_klass == ref)
-        return;
-
     if (dc->cur_obj_references == 0) {
         dump_append(dc, ", \"references\":[");
         dump_append_ref(dc, ref);


### PR DESCRIPTION
**Problem:** when fixing memory leaks, you sometimes need to analyze heap dumps to find a reference chain from a root object to the object that's potentially leaked. However, using just the `references` array as the source of objects that are referenced (and thus retained) is not enough because sometimes object's class is also referenced but it is not put into the `references` array.

**Solution:** do not skip references to object's class in the `references` array. This would simplify heap analysis tools a lot because the tools would no longer need to make guesses if the `class` key needs to be used or not.

Ref https://github.com/zombocom/heapy/pull/33.