### PR TITLE
Reduce dependencies from test-bundled-gems

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1429,7 +1429,7 @@ no-test-bundled-gems-prepare: no-test-bundled-gems-precheck
 yes-test-bundled-gems-prepare: yes-test-bundled-gems-precheck
 	$(ACTIONS_GROUP)
 	$(XRUBY) -C "$(srcdir)" bin/gem install --no-document \
-		--install-dir .bundle --conservative "bundler" "minitest:~> 5" "test-unit" "rake" "hoe" "yard" "pry" "packnga" "rexml" "json-schema" "test-unit-rr" "rake-compiler"
+		--install-dir .bundle --conservative "bundler" "minitest:~> 5" "test-unit" "rake" "hoe" "yard" "packnga" "rexml" "json-schema" "test-unit-rr" "rake-compiler"
 	$(ACTIONS_ENDGROUP)
 
 PREPARE_BUNDLED_GEMS = test-bundled-gems-prepare

--- a/common.mk
+++ b/common.mk
@@ -1429,7 +1429,7 @@ no-test-bundled-gems-prepare: no-test-bundled-gems-precheck
 yes-test-bundled-gems-prepare: yes-test-bundled-gems-precheck
 	$(ACTIONS_GROUP)
 	$(XRUBY) -C "$(srcdir)" bin/gem install --no-document \
-		--install-dir .bundle --conservative "bundler" "minitest:~> 5" "test-unit" "rake" "hoe" "yard" "packnga" "rexml" "json-schema" "test-unit-rr" "rake-compiler"
+		--install-dir .bundle --conservative "bundler" "minitest:~> 5" "test-unit" "rake" "hoe" "rexml" "json-schema" "test-unit-rr" "rake-compiler"
 	$(ACTIONS_ENDGROUP)
 
 PREPARE_BUNDLED_GEMS = test-bundled-gems-prepare

--- a/tool/test-bundled-gems.rb
+++ b/tool/test-bundled-gems.rb
@@ -34,6 +34,16 @@ File.foreach("#{gem_dir}/bundled_gems") do |line|
   when "typeprof"
 
   when "rbs"
+    # TODO: We should skip test file instead of test class/methods
+    skip_test_files = %w[
+      test/stdlib/Prime_test.rb
+    ]
+
+    skip_test_files.each do |file|
+      path = "#{gem_dir}/src/#{gem}/#{file}"
+      File.unlink(path) if File.exist?(path)
+    end
+
     test_command << " stdlib_test validate RBS_SKIP_TESTS=#{__dir__}/rbs_skip_tests SKIP_RBS_VALIDATION=true"
     first_timeout *= 3
 

--- a/tool/test-bundled-gems.rb
+++ b/tool/test-bundled-gems.rb
@@ -43,6 +43,9 @@ File.foreach("#{gem_dir}/bundled_gems") do |line|
     # environment variable.
     load_path = true
 
+  when "test-unit"
+    test_command = "#{ruby} -C #{gem_dir}/src/#{gem} test/run-test.rb"
+
   when /\Anet-/
     toplib = gem.tr("-", "/")
 


### PR DESCRIPTION
We should ignore `racc` dependency by `pry` for `test-bundled-gems` target.