### PR TITLE
Improve the match cache optimization to support look-around and atomic groups

### DIFF
--- a/regcomp.c
+++ b/regcomp.c
@@ -1273,6 +1273,10 @@ compile_length_enclose_node(EncloseNode* node, regex_t* reg)
     break;
 
   case ENCLOSE_STOP_BACKTRACK:
+    /* Disable POP_STOP_BT optimization for simple repeat under the match cache */
+    /* optimization because the match cache optimization pushes an extra item to */
+    /* the stack and it breaks the assumption for this optimization. */
+#ifndef USE_MATCH_CACHE
     if (IS_ENCLOSE_STOP_BT_SIMPLE_REPEAT(node)) {
       QtfrNode* qn = NQTFR(node->target);
       tlen = compile_length_tree(qn->target, reg);
@@ -1282,8 +1286,11 @@ compile_length_enclose_node(EncloseNode* node, regex_t* reg)
 	  + SIZE_OP_PUSH + tlen + SIZE_OP_POP + SIZE_OP_JUMP;
     }
     else {
+#endif
       len = SIZE_OP_PUSH_STOP_BT + tlen + SIZE_OP_POP_STOP_BT;
+#ifndef USE_MATCH_CACHE
     }
+#endif
     break;
 
   case ENCLOSE_CONDITION:
@@ -1395,6 +1402,10 @@ compile_enclose_node(EncloseNode* node, regex_t* reg)
     break;
 
   case ENCLOSE_STOP_BACKTRACK:
+    /* Disable POP_STOP_BT optimization for simple repeat under the match cache */
+    /* optimization because the match cache optimization pushes an extra item to */
+    /* the stack and it breaks the assumption for this optimization. */
+#ifndef USE_MATCH_CACHE
     if (IS_ENCLOSE_STOP_BT_SIMPLE_REPEAT(node)) {
       QtfrNode* qn = NQTFR(node->target);
       r = compile_tree_n_times(qn->target, qn->lower, reg);
@@ -1413,12 +1424,15 @@ compile_enclose_node(EncloseNode* node, regex_t* reg)
 	 -((int )SIZE_OP_PUSH + len + (int )SIZE_OP_POP + (int )SIZE_OP_JUMP));
     }
     else {
+#endif
       r = add_opcode(reg, OP_PUSH_STOP_BT);
       if (r) return r;
       r = compile_tree(node->target, reg);
       if (r) return r;
       r = add_opcode(reg, OP_POP_STOP_BT);
+#ifndef USE_MATCH_CACHE
     }
+#endif
     break;
 
   case ENCLOSE_CONDITION:

--- a/regexec.c
+++ b/regexec.c
@@ -437,17 +437,23 @@ count_num_cache_opcodes(const regex_t* reg, long* num_cache_opcodes_ptr)
 	p += SIZE_RELADDR;
 	lookaround_nesting++;
 	break;
+      case OP_PUSH_LOOK_BEHIND_NOT:
+	p += SIZE_RELADDR;
+	p += SIZE_LENGTH;
+	lookaround_nesting++;
+	break;
       case OP_POP_POS:
       case OP_FAIL_POS:
+      case OP_FAIL_LOOK_BEHIND_NOT:
 	lookaround_nesting--;
 	break;
       case OP_PUSH_STOP_BT:
       case OP_POP_STOP_BT:
 	break;
-
       case OP_LOOK_BEHIND:
-      case OP_PUSH_LOOK_BEHIND_NOT:
-      case OP_FAIL_LOOK_BEHIND_NOT:
+	p += SIZE_LENGTH;
+	break;
+
       case OP_PUSH_ABSENT_POS:
       case OP_ABSENT_END:
       case OP_ABSENT:
@@ -708,17 +714,23 @@ init_cache_opcodes(const regex_t* reg, OnigCacheOpcode* cache_opcodes, long* num
 	p += SIZE_RELADDR;
 	INC_LOOKAROUND_NESTING;
 	break;
+      case OP_PUSH_LOOK_BEHIND_NOT:
+	p += SIZE_RELADDR;
+	p += SIZE_LENGTH;
+	INC_LOOKAROUND_NESTING;
+	break;
       case OP_POP_POS:
       case OP_FAIL_POS:
+      case OP_FAIL_LOOK_BEHIND_NOT:
 	DEC_LOOKAROUND_NESTING;
 	break;
       case OP_PUSH_STOP_BT:
       case OP_POP_STOP_BT:
 	break;
       case OP_LOOK_BEHIND:
-      case OP_PUSH_LOOK_BEHIND_NOT:
-      case OP_FAIL_LOOK_BEHIND_NOT:
-      case OP_PUSH_ABSENT_POS:
+	p += SIZE_LENGTH;
+        break;
+
       case OP_ABSENT_END:
       case OP_ABSENT:
 	goto unexpected_bytecode_error;

--- a/regint.h
+++ b/regint.h
@@ -875,8 +875,8 @@ typedef struct _OnigStackType {
     } absent_pos;
 #ifdef USE_MATCH_CACHE
     struct {
-      long index;
-      uint8_t mask;
+      long    index;      /* index of the match cache buffer */
+      uint8_t mask;       /* bit-mask for the match cache buffer */
     } match_cache_point;
 #endif
   } u;
@@ -889,6 +889,8 @@ typedef struct {
   int outer_repeat_mem;
   long num_cache_points_at_outer_repeat;
   long num_cache_points_in_outer_repeat;
+  int atomic_nesting;
+  UChar *match_addr;
 } OnigCacheOpcode;
 #endif
 

--- a/regint.h
+++ b/regint.h
@@ -889,7 +889,7 @@ typedef struct {
   int outer_repeat_mem;
   long num_cache_points_at_outer_repeat;
   long num_cache_points_in_outer_repeat;
-  int atomic_nesting;
+  int lookaround_nesting;
   UChar *match_addr;
 } OnigCacheOpcode;
 #endif

--- a/regint.h
+++ b/regint.h
@@ -873,6 +873,12 @@ typedef struct _OnigStackType {
       UChar *abs_pstr;        /* absent start position */
       const UChar *end_pstr;  /* end position */
     } absent_pos;
+#ifdef USE_MATCH_CACHE
+    struct {
+      long index;
+      uint8_t mask;
+    } match_cache_point;
+#endif
   } u;
 } OnigStackType;
 

--- a/test/ruby/test_regexp.rb
+++ b/test/ruby/test_regexp.rb
@@ -1848,6 +1848,15 @@ class TestRegexp < Test::Unit::TestCase
     end;
   end
 
+  def test_match_cache_atomic_complex
+    assert_separately([], "#{<<-"begin;"}\n#{<<-'end;'}")
+      timeout = #{ EnvUtil.apply_timeout_scale(10).inspect }
+    begin;
+      Regexp.timeout = timeout
+      assert_nil(/a*(?>a*)ab/ =~ "a" * 1000000 + "b")
+    end;
+  end
+    
   def test_match_cache_positive_look_ahead
     assert_separately([], "#{<<-"begin;"}\n#{<<-'end;'}")
       timeout = #{ EnvUtil.apply_timeout_scale(10).inspect }
@@ -1857,6 +1866,15 @@ class TestRegexp < Test::Unit::TestCase
     end;
   end
 
+  def test_match_cache_positive_look_ahead_complex
+    assert_separately([], "#{<<-"begin;"}\n#{<<-'end;'}")
+      timeout = #{ EnvUtil.apply_timeout_scale(10).inspect }
+    begin;
+       Regexp.timeout = timeout
+       assert_equal(/(?:(?=a*)a)*/ =~ "a" * 1000000, 0)
+    end;
+  end
+    
   def test_match_cache_negative_look_ahead
     assert_separately([], "#{<<-"begin;"}\n#{<<-'end;'}")
       timeout = #{ EnvUtil.apply_timeout_scale(10).inspect }
@@ -1897,7 +1915,7 @@ class TestRegexp < Test::Unit::TestCase
     assert_equal("10:0:0".match(pattern)[0], "10:0:0")
   end
 
-  def test_bug_19467
+  def test_bug_19467 # [Bug #19467]
     assert_separately([], "#{<<-"begin;"}\n#{<<-'end;'}")
       timeout = #{ EnvUtil.apply_timeout_scale(10).inspect }
     begin;
@@ -1912,7 +1930,7 @@ class TestRegexp < Test::Unit::TestCase
     assert_equal("123456789".match(/(?:x?\dx?){2,}/)[0], "123456789")
   end
 
-  def test_bug_19537
+  def test_bug_19537 # [Bug #19537]
     str = 'aac'
     re = '^([ab]{1,3})(a?)*$'
     100.times do

--- a/test/ruby/test_regexp.rb
+++ b/test/ruby/test_regexp.rb
@@ -1856,7 +1856,7 @@ class TestRegexp < Test::Unit::TestCase
       assert_nil(/a*(?>a*)ab/ =~ "a" * 1000000 + "b")
     end;
   end
-    
+
   def test_match_cache_positive_look_ahead
     assert_separately([], "#{<<-"begin;"}\n#{<<-'end;'}")
       timeout = #{ EnvUtil.apply_timeout_scale(10).inspect }
@@ -1874,7 +1874,7 @@ class TestRegexp < Test::Unit::TestCase
        assert_equal(/(?:(?=a*)a)*/ =~ "a" * 1000000, 0)
     end;
   end
-    
+
   def test_match_cache_negative_look_ahead
     assert_separately([], "#{<<-"begin;"}\n#{<<-'end;'}")
       timeout = #{ EnvUtil.apply_timeout_scale(10).inspect }

--- a/test/ruby/test_regexp.rb
+++ b/test/ruby/test_regexp.rb
@@ -1826,7 +1826,6 @@ class TestRegexp < Test::Unit::TestCase
       timeout = #{ EnvUtil.apply_timeout_scale(10).inspect }
     begin;
       Regexp.timeout = timeout
-
       assert_nil(/^(a*)*$/ =~ "a" * 1000000 + "x")
     end;
   end
@@ -1836,7 +1835,6 @@ class TestRegexp < Test::Unit::TestCase
       timeout = #{ EnvUtil.apply_timeout_scale(10).inspect }
     begin;
       Regexp.timeout = timeout
-
       assert_nil(/^a*b?a*$/ =~ "a" * 1000000 + "x")
     end;
   end
@@ -1846,8 +1844,25 @@ class TestRegexp < Test::Unit::TestCase
       timeout = #{ EnvUtil.apply_timeout_scale(10).inspect }
     begin;
       Regexp.timeout = timeout
+      assert_nil(/^a*?(?>a*a*)$/ =~ "a" * 1000000 + "x")
+    end;
+  end
 
-      assert_nil(/^(?>a?a?)(a|a)*$/ =~ "a" * 1000000 + "x")
+  def test_match_cache_positive_look_ahead
+    assert_separately([], "#{<<-"begin;"}\n#{<<-'end;'}")
+      timeout = #{ EnvUtil.apply_timeout_scale(10).inspect }
+    begin;
+       Regexp.timeout = timeout
+       assert_nil(/^a*?(?=a*a*)$/ =~ "a" * 1000000 + "x")
+    end;
+  end
+
+  def test_match_cache_negative_look_ahead
+    assert_separately([], "#{<<-"begin;"}\n#{<<-'end;'}")
+      timeout = #{ EnvUtil.apply_timeout_scale(10).inspect }
+    begin;
+      Regexp.timeout = timeout
+      assert_nil(/^a*?(?!a*a*)$/ =~ "a" * 1000000 + "x")
     end;
   end
 
@@ -1893,6 +1908,9 @@ class TestRegexp < Test::Unit::TestCase
     assert_send [Regexp, :linear_time?, 'a', Regexp::IGNORECASE]
     assert_not_send [Regexp, :linear_time?, /(a)\1/]
     assert_not_send [Regexp, :linear_time?, "(a)\\1"]
+
+    assert_not_send [Regexp, :linear_time?, /(?=(a))/]
+    assert_not_send [Regexp, :linear_time?, /(?>(a))/]
 
     assert_raise(TypeError) {Regexp.linear_time?(nil)}
     assert_raise(TypeError) {Regexp.linear_time?(Regexp.allocate)}

--- a/test/ruby/test_regexp.rb
+++ b/test/ruby/test_regexp.rb
@@ -1866,6 +1866,24 @@ class TestRegexp < Test::Unit::TestCase
     end;
   end
 
+  def test_match_cache_positive_look_behind
+    assert_separately([], "#{<<-"begin;"}\n#{<<-'end;'}")
+      timeout = #{ EnvUtil.apply_timeout_scale(10).inspect }
+    begin;
+      Regexp.timeout = timeout
+      assert_nil(/(?<=abc|def)(a|a)*$/ =~ "abc" + "a" * 1000000 + "x")
+    end;
+  end
+
+  def test_match_cache_negative_look_behind
+    assert_separately([], "#{<<-"begin;"}\n#{<<-'end;'}")
+    timeout = #{ EnvUtil.apply_timeout_scale(10).inspect }
+    begin;
+      Regexp.timeout = timeout
+      assert_nil(/(?<!x)(a|a)*$/ =~ "a" * 1000000 + "x")
+    end;
+  end
+
   def test_cache_opcodes_initialize
     str = 'test1-test2-test3-test4-test_5'
     re = '^([0-9a-zA-Z\-/]*){1,256}$'
@@ -1910,7 +1928,7 @@ class TestRegexp < Test::Unit::TestCase
     assert_not_send [Regexp, :linear_time?, "(a)\\1"]
 
     assert_not_send [Regexp, :linear_time?, /(?=(a))/]
-    assert_not_send [Regexp, :linear_time?, /(?>(a))/]
+    assert_not_send [Regexp, :linear_time?, /(?!(a))/]
 
     assert_raise(TypeError) {Regexp.linear_time?(nil)}
     assert_raise(TypeError) {Regexp.linear_time?(Regexp.allocate)}


### PR DESCRIPTION
Close [Feature #19725].

https://bugs.ruby-lang.org/issues/19725