### PR TITLE
Directly allocate FrozenCore as an ICLASS

### DIFF
--- a/class.c
+++ b/class.c
@@ -1130,9 +1130,15 @@ rb_define_module_id_under(VALUE outer, ID id)
 }
 
 VALUE
+rb_iclass_alloc(VALUE klass)
+{
+    return class_alloc(T_ICLASS, klass);
+}
+
+VALUE
 rb_include_class_new(VALUE module, VALUE super)
 {
-    VALUE klass = class_alloc(T_ICLASS, rb_cClass);
+    VALUE klass = rb_iclass_alloc(rb_cClass);
 
     RCLASS_M_TBL(klass) = RCLASS_M_TBL(module);
 
@@ -1409,7 +1415,7 @@ ensure_origin(VALUE klass)
 {
     VALUE origin = RCLASS_ORIGIN(klass);
     if (origin == klass) {
-        origin = class_alloc(T_ICLASS, klass);
+        origin = rb_iclass_alloc(klass);
         RCLASS_SET_SUPER(origin, RCLASS_SUPER(klass));
         RCLASS_SET_SUPER(klass, origin);
         RCLASS_SET_ORIGIN(klass, origin);

--- a/internal/class.h
+++ b/internal/class.h
@@ -119,6 +119,7 @@ VALUE rb_module_s_alloc(VALUE klass);
 void rb_module_set_initialized(VALUE module);
 void rb_module_check_initializable(VALUE module);
 VALUE rb_make_metaclass(VALUE, VALUE);
+VALUE rb_iclass_alloc(VALUE klass);
 VALUE rb_include_class_new(VALUE, VALUE);
 void rb_class_foreach_subclass(VALUE klass, void (*f)(VALUE, VALUE), VALUE);
 void rb_class_detach_subclasses(VALUE);
@@ -205,7 +206,7 @@ RCLASS_SET_SUPER(VALUE klass, VALUE super)
 static inline void
 RCLASS_SET_CLASSPATH(VALUE klass, VALUE classpath, bool permanent)
 {
-    assert(BUILTIN_TYPE(klass) == T_CLASS || BUILTIN_TYPE(klass) == T_MODULE);
+    assert(BUILTIN_TYPE(klass) == T_CLASS || BUILTIN_TYPE(klass) == T_MODULE || klass == rb_mRubyVMFrozenCore);
     assert(classpath == 0 || BUILTIN_TYPE(classpath) == T_STRING);
 
     RB_OBJ_WRITE(klass, &(RCLASS_EXT(klass)->classpath), classpath);

--- a/vm.c
+++ b/vm.c
@@ -3638,7 +3638,6 @@ Init_VM(void)
 {
     VALUE opts;
     VALUE klass;
-    VALUE fcore;
 
     /*
      * Document-class: RubyVM
@@ -3664,9 +3663,8 @@ Init_VM(void)
 #endif
 
     /* FrozenCore (hidden) */
-    fcore = rb_class_new(rb_cBasicObject);
+    VALUE fcore = rb_mRubyVMFrozenCore = rb_iclass_alloc(rb_cBasicObject);
     rb_set_class_path(fcore, rb_cRubyVM, "FrozenCore");
-    RBASIC(fcore)->flags = T_ICLASS;
     klass = rb_singleton_class(fcore);
     rb_define_method_id(klass, id_core_set_method_alias, m_core_set_method_alias, 3);
     rb_define_method_id(klass, id_core_set_variable_alias, m_core_set_variable_alias, 2);
@@ -3685,7 +3683,6 @@ Init_VM(void)
     RBASIC_CLEAR_CLASS(klass);
     rb_obj_freeze(klass);
     rb_gc_register_mark_object(fcore);
-    rb_mRubyVMFrozenCore = fcore;
 
     /*
      * Document-class: Thread


### PR DESCRIPTION
It's a bad idea to overwrite the flags as the garbage collector may have set other flags.