### PR TITLE
Removed needless dependency from test-bundled-gems

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1432,7 +1432,7 @@ no-test-bundled-gems-prepare: no-test-bundled-gems-precheck
 yes-test-bundled-gems-prepare: yes-test-bundled-gems-precheck
 	$(ACTIONS_GROUP)
 	$(XRUBY) -C "$(srcdir)" bin/gem install --no-document \
-		--install-dir .bundle --conservative "hoe" "json-schema" "test-unit-rr" "rake-compiler"
+		--install-dir .bundle --conservative "hoe" "json-schema" "test-unit-rr"
 	$(ACTIONS_ENDGROUP)
 
 PREPARE_BUNDLED_GEMS = test-bundled-gems-prepare

--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -20,4 +20,4 @@ prime           0.1.2   https://github.com/ruby/prime
 rbs             3.1.0   https://github.com/ruby/rbs
 typeprof        0.21.7  https://github.com/ruby/typeprof aabc019684d8b4a1ed66c2a1ca48da7bbb18dcc0
 debug           1.8.0   https://github.com/ruby/debug
-racc            1.7.0   https://github.com/ruby/racc
+racc            1.7.1   https://github.com/ruby/racc


### PR DESCRIPTION
We shouldn't install external dependencies for `test-bundled-gems`. I tried to test with https://github.com/ruby/racc/pull/223.

After that, we can remove `rake-compiler` from dependencies installation.