### PR TITLE
[Bugfix #19732] Add missing stdint.h header to event.h

### DIFF
--- a/include/ruby/internal/event.h
+++ b/include/ruby/internal/event.h
@@ -23,6 +23,10 @@
 #include "ruby/internal/dllexport.h"
 #include "ruby/internal/value.h"
 
+#ifdef HAVE_STDINT_H
+#include <stdint.h>
+#endif
+
 /* These macros are not enums because they are wider than int.*/
 
 /**


### PR DESCRIPTION
Issue tracker: https://bugs.ruby-lang.org/issues/19732

Ruby's `event.h` (https://github.com/ruby/ruby/blob/813a5f4fc46a24ca1695d23c159250b9e1080ac7/include/ruby/internal/event.h#L103) is using type aliases from `stdint.h`, however it's not directly included.

An example where this causes issues can be seen in the issue linked above: including the `ruby/debug.h` header before `ruby/ruby.h` loads `ruby/internal/event.h`, which fails with:

``` shell
make
compiling debug_inspector.c
In file included from /home/itarato/.rubies/ruby-master/include/ruby-3.3.0+0/ruby/debug.h:16,
                 from debug_inspector.c:12:
/home/itarato/.rubies/ruby-master/include/ruby-3.3.0+0/ruby/internal/event.h:105:9: error: unknown type name ‘uint32_t’
  105 | typedef uint32_t rb_event_flag_t;
      |         ^~~~~~~~
```

I've accidentally bumped into this when `clang-format` auto-sorted my includes, resulting:

```c
#include "ruby/debug.h"
#include "ruby/ruby.h"
```

This is on `ruby/ruby` latest commit (813a5f4fc46a24ca1695d23c159250b9e1080ac7), but also tried on tag 3.2 (same error).

This PR is addressing this issue by including the missing header file.