### PR TITLE
Specify int bitfield as signed int bitfield

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -441,8 +441,8 @@ struct parser_params {
     rb_parser_config_t *config;
 #endif
     /* compile_option */
-    int frozen_string_literal:2; /* -1: not specified, 0: false, 1: true */
-    int coverage_enabled:2; /* -1: not specified, 0: false, 1: true */
+    signed int frozen_string_literal:2; /* -1: not specified, 0: false, 1: true */
+    signed int coverage_enabled:2; /* -1: not specified, 0: false, 1: true */
 
     unsigned int command_start:1;
     unsigned int eofp: 1;

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -313,8 +313,8 @@ typedef struct rb_ast_body_struct {
     // script_lines is either:
     // - a Fixnum that represents the line count of the original source, or
     // - an Array that contains the lines of the original source
-    int frozen_string_literal:2; /* -1: not specified, 0: false, 1: true */
-    int coverage_enabled:2; /* -1: not specified, 0: false, 1: true */
+    signed int frozen_string_literal:2; /* -1: not specified, 0: false, 1: true */
+    signed int coverage_enabled:2; /* -1: not specified, 0: false, 1: true */
 } rb_ast_body_t;
 typedef struct rb_ast_struct {
     VALUE flags;


### PR DESCRIPTION
sunc treats int bitfield as unsigned int.
This commit will fix build failure on sunc.

* http://rubyci.s3.amazonaws.com/solaris10-sunc/ruby-master/log/20230617T100003Z.fail.html.gz
* http://rubyci.s3.amazonaws.com/solaris11-sunc/ruby-master/log/20230617T090011Z.fail.html.gz