### PR TITLE
String#slice! should clear the coderange when truncating

### DIFF
--- a/string.c
+++ b/string.c
@@ -5435,6 +5435,7 @@ rb_str_slice_bang(int argc, VALUE *argv, VALUE str)
 	    slen -= len;
 	    STR_SET_LEN(str, slen);
 	    TERM_FILL(&sptr[slen], TERM_LEN(str));
+	    ENC_CODERANGE_CLEAR(str);
 	}
     }
     return result;

--- a/test/ruby/test_string.rb
+++ b/test/ruby/test_string.rb
@@ -3232,6 +3232,12 @@ CODE
     assert_not_predicate(data, :valid_encoding?)
     assert_predicate(data[100..-1], :valid_encoding?)
   end
+
+  def test_slice_bang_code_range
+    str = "[Bug #19739] ABC OÜ"
+    str.slice!(/ oü$/i)
+    assert_predicate str, :ascii_only?
+  end
 end
 
 class TestString2 < TestString


### PR DESCRIPTION
[[Bug #19739]](https://bugs.ruby-lang.org/issues/19739)

This bug was incidentally fixed in Ruby 3.2 via b0b9f7201acab05c2a3ad92c3043a1f01df3e17f but remains on 3.1 and older.

Ref: https://github.com/ruby/ruby/pull/6178