### PR TITLE
Add anonymous module name spec.

### DIFF
--- a/spec/ruby/core/module/new_spec.rb
+++ b/spec/ruby/core/module/new_spec.rb
@@ -6,6 +6,10 @@ describe "Module.new" do
     Module.new.is_a?(Module).should == true
   end
 
+  it "creates a module without a name" do
+    Module.new.name.should be_nil
+  end
+
   it "creates a new Module and passes it to the provided block" do
     test_mod = nil
     m = Module.new do |mod|


### PR DESCRIPTION
This exists for class but not for module.

https://bugs.ruby-lang.org/issues/19742