### PR TITLE
Yarp test

### DIFF
--- a/yarp/extension.c
+++ b/yarp/extension.c
@@ -72,6 +72,7 @@ source_file_load(source_t *source, VALUE filepath) {
 
 #ifdef HAVE_MMAP
     if (!source->size) {
+        close(fd);
         source->source = "";
         return 0;
     }


### PR DESCRIPTION
https://github.com/ruby/ruby/actions/runs/5339360166/jobs/9677973026#step:15:100
> Leaked file descriptor: ParseTest#test_filepath_/home/runner/work/ruby/ruby/src/test/yarp/fixtures/unparser/corpus/literal/empty.txt: 9 #<File::Stat dev=0x811, ino=551796, mode=0100644, nlink=1, uid=1001, gid=122, rdev=0x0, size=0, blksize=4096, blocks=0, atime=2023-06-21 22:13:49.74535057 +0000, mtime=2023-06-21 22:05:55.97600362 +0000, ctime=2023-06-21 22:05:55.97600362 +0000>