### PR TITLE
Make {Nil,True,False}Class#singleton_method always raise NameError

### DIFF
--- a/proc.c
+++ b/proc.c
@@ -2096,10 +2096,9 @@ rb_obj_singleton_method(VALUE obj, VALUE vid)
     VALUE klass = rb_singleton_class_get(obj);
     ID id = rb_check_id(&vid);
 
-    if (NIL_P(klass)) {
-        /* goto undef; */
-    }
-    else if (NIL_P(klass = RCLASS_ORIGIN(klass))) {
+    if (NIL_P(klass) ||
+        NIL_P(klass = RCLASS_ORIGIN(klass)) ||
+        !NIL_P(rb_special_singleton_class(obj))) {
         /* goto undef; */
     }
     else if (! id) {

--- a/spec/ruby/core/false/singleton_method_spec.rb
+++ b/spec/ruby/core/false/singleton_method_spec.rb
@@ -1,0 +1,15 @@
+require_relative '../../spec_helper'
+
+describe "FalseClass#singleton_method" do
+  ruby_version_is '3.3' do
+    it "raises regardless of whether FalseClass defines the method" do
+      proc{false.singleton_method(:foo)}.should raise_error(NameError)
+      begin
+        def false.foo; end
+        proc{false.singleton_method(:foo)}.should raise_error(NameError)
+      ensure
+        FalseClass.send(:remove_method, :foo)
+      end
+    end
+  end
+end

--- a/spec/ruby/core/nil/singleton_method_spec.rb
+++ b/spec/ruby/core/nil/singleton_method_spec.rb
@@ -1,0 +1,15 @@
+require_relative '../../spec_helper'
+
+describe "NilClass#singleton_method" do
+  ruby_version_is '3.3' do
+    it "raises regardless of whether NilClass defines the method" do
+      proc{nil.singleton_method(:foo)}.should raise_error(NameError)
+      begin
+        def nil.foo; end
+        proc{nil.singleton_method(:foo)}.should raise_error(NameError)
+      ensure
+        NilClass.send(:remove_method, :foo)
+      end
+    end
+  end
+end

--- a/spec/ruby/core/true/singleton_method_spec.rb
+++ b/spec/ruby/core/true/singleton_method_spec.rb
@@ -1,0 +1,15 @@
+require_relative '../../spec_helper'
+
+describe "TrueClass#singleton_method" do
+  ruby_version_is '3.3' do
+    it "raises regardless of whether TrueClass defines the method" do
+      proc{true.singleton_method(:foo)}.should raise_error(NameError)
+      begin
+        def true.foo; end
+        proc{true.singleton_method(:foo)}.should raise_error(NameError)
+      ensure
+        TrueClass.send(:remove_method, :foo)
+      end
+    end
+  end
+end


### PR DESCRIPTION
{Nil,True,False}Class#singleton_methods always returns [] indicating that there are no singleton methods defined, so #singleton_method should be consistent with that.

Fixes [Bug #11064]