### PR TITLE
[DOC] Fix links to non-existent pages

### DIFF
--- a/LEGAL
+++ b/LEGAL
@@ -826,7 +826,7 @@ mentioned below.
 
   >>>
     (c) 1995:: Microsoft Corporation. All rights reserved.
-    Developed by ActiveWare Internet Corp., http://www.ActiveWare.com
+    Developed by ActiveWare Internet Corp.
 
     Other modifications Copyright (c) 1997, 1998:: by Gurusamy Sarathy
     <gsar@umich.edu> and Jan Dubois <jan.dubois@ibm.net>

--- a/README.ja.md
+++ b/README.ja.md
@@ -152,7 +152,7 @@ UNIXであれば `configure` がほとんどの差異を吸収してくれるは
 
 ## 配布条件
 
-[COPYING.ja](COPYING.ja) ファイルを参照してください．
+[COPYING.ja](https://docs.ruby-lang.org/en/master/COPYING_ja.html   ) ファイルを参照してください．
 
 ## フィードバック
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ if you are a committer.
 
 ## How to build
 
-see [Building Ruby](doc/contributing/building_ruby.md)
+see [Building Ruby](https://docs.ruby-lang.org/en/master/contributing/building_ruby_md.html)
 
 ## Ruby home page
 

--- a/doc/NEWS/NEWS-1.8.7
+++ b/doc/NEWS/NEWS-1.8.7
@@ -414,16 +414,22 @@ with all sufficient information, see the ChangeLog file.
 
   * added LDAPS scheme.
   * Change for RFC3986:
-    * FTP
-      * URI('ftp://example.com/foo').path #=> 'foo'
-      * URI('ftp://example.com/%2Ffoo').path #=> '/foo'
-      * URI::FTP.build([nil, 'example.com', nil, '/foo', 'i']).to_s #=> 'ftp://example.com/%2Ffoo;type=i'
-    * URI merge
-      * URI('http://a/b/c/d;p?q').merge('?y') == URI('http://a/b/c/d;p?y')
-      * URI('http://a/b/c/d;p?q').merge('/./g') == URI('http://a/g')
-      * URI('http://a/b/c/d;p?q').merge('/../g') == URI('http://a/g')
-      * URI('http://a/b/c/d;p?q').merge('../../../g') == URI('http://a/g')
-      * URI('http://a/b/c/d;p?q').merge('../../../../g') == URI('http://a/g')
+
+    * FTP:
+
+        require 'uri'
+        URI('ftp://example.com/foo').path    # => "foo"
+        URI('ftp://example.com/%2Ffoo').path # => "/foo"
+        URI::FTP.build([nil, 'example.com', nil, '/foo', 'i']).to_s
+        # => "ftp://example.com/%2Ffoo;type=i"
+
+    * URI merge:
+
+        URI('http://a/b/c/d;p?q').merge('?y') == URI('http://a/b/c/d;p?y')    # => true
+        URI('http://a/b/c/d;p?q').merge('/./g') == URI('http://a/g')          # => true
+        URI('http://a/b/c/d;p?q').merge('/../g') == URI('http://a/g')         # => true
+        URI('http://a/b/c/d;p?q').merge('../../../g') == URI('http://a/g')    # => true
+        URI('http://a/b/c/d;p?q').merge('../../../../g') == URI('http://a/g') # => true
 
 * rss
 

--- a/doc/NEWS/NEWS-1.9.3
+++ b/doc/NEWS/NEWS-1.9.3
@@ -282,8 +282,7 @@ with all sufficient information, see the ChangeLog file.
   * Support Ruby native encoding mechanism and iconv dependency is dropped.
 
 * RubyGems
-  * RubyGems has been upgraded to version 1.8.10. For full release notes see
-    http://rubygems.rubyforge.org/rubygems-update/History_txt.html
+  * RubyGems has been upgraded to version 1.8.10.
 
 * stringio
   * extended method:

--- a/doc/NEWS/NEWS-2.0.0
+++ b/doc/NEWS/NEWS-2.0.0
@@ -424,9 +424,6 @@ with all sufficient information, see the ChangeLog file.
     This version is backwards-compatible with previous rake versions and
     contains many bug fixes.
 
-    See
-    http://rake.rubyforge.org/doc/release_notes/rake-0_9_5_rdoc.html for a list
-    of changes in rake 0.9.3, 0.9.4 and 0.9.5.
 
 * RDoc
   * RDoc has been updated to version 4.0

--- a/doc/NEWS/NEWS-2.1.0
+++ b/doc/NEWS/NEWS-2.1.0
@@ -227,12 +227,6 @@ String
     Rake::DSL to hold the rake DSL methods and removal of support for legacy
     rake features.
 
-    For a complete list of changes since rake 0.9.6 see:
-
-    http://rake.rubyforge.org/doc/release_notes/rake-10_1_0_rdoc.html
-
-    http://rake.rubyforge.org/doc/release_notes/rake-10_0_3_rdoc.html
-
 * RbConfig
   * New constants:
     * RbConfig::SIZEOF is added to provide the size of C types.

--- a/doc/NEWS/NEWS-2.2.0
+++ b/doc/NEWS/NEWS-2.2.0
@@ -191,12 +191,12 @@ with all sufficient information, see the ChangeLog file.
 * Rake
   * Updated to Rake 10.4.0.  For full release notes see:
 
-    http://docs.seattlerb.org/rake/History_rdoc.html#label-10.4.0
+    http://docs.seattlerb.org/rake/History_rdoc.html#label-10.4.0+%2F+2014-11-22
 
 * RubyGems
   * Updated to RubyGems 2.4.2.  For full release notes see:
 
-    http://docs.seattlerb.org/rubygems/History_txt.html#label-2.4.2+%2F+2014-10-01
+    http://docs.seattlerb.org/rake/History_rdoc.html#label-10.4.2+%2F+2014-12-02
 
 * TSort
   * TSort.tsort_each, TSort.each_strongly_connected_component and

--- a/doc/contributing/building_ruby.md
+++ b/doc/contributing/building_ruby.md
@@ -25,7 +25,8 @@
     * libffi (to build fiddle)
     * gmp (if you with to accelerate Bignum operations)
     * libexecinfo (FreeBSD)
-    * rustc - 1.58.0 or later (if you wish to build [YJIT](/doc/yjit/yjit.md))
+    * rustc - 1.58.0 or later, if you wish to build
+      [YJIT](https://docs.ruby-lang.org/en/master/RubyVM/YJIT.html).
 
     If you installed the libraries needed for extensions (openssl, readline, libyaml, zlib) into other than the OS default place,
     typically using Homebrew on macOS, add `--with-EXTLIB-dir` options to `CONFIGURE_ARGS` environment variable.


### PR DESCRIPTION
Fixes the links I've found that link to non-existent pages (but not those with incorrect fragments):

- When I could find a useful substitute page, I've changed the link.
- When not, I've removed the link.
- In one file, the links were (I think) unintended;  I've moved that text  (code, actually) into code blocks.