### PR TITLE
[DOC] Fixes for link fragments

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -26,7 +26,7 @@ Rubyはテキスト処理関係の能力などに優れ，Perlと同じくらい
 *   ダイナミックローディング (アーキテクチャによる)
 *   移植性が高い．多くのUnix-like/POSIX互換プラットフォーム上で動くだけでなく，Windows， macOS，
     Haikuなどの上でも動く cf.
-    https://github.com/ruby/ruby/blob/master/doc/contributing.rdoc#platform-maintainers
+    https://docs.ruby-lang.org/en/master/maintainers_md.html
 
 
 ## 入手法

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ It is simple, straightforward, and extensible.
 * Dynamic Loading of Object Files (on some architectures)
 * Highly Portable (works on many Unix-like/POSIX compatible platforms as
   well as Windows, macOS, etc.) cf.
-  https://github.com/ruby/ruby/blob/master/doc/maintainers.md#platform-maintainers
+  https://docs.ruby-lang.org/en/master/maintainers_md.html
 
 ## How to get Ruby
 

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -9,4 +9,4 @@ This guide outlines ways to get started with contributing to Ruby:
   to change Ruby's documentation, code, test suite, or standard libraries
 * [Making changes to Ruby standard libraries](contributing/making_changes_to_stdlibs.md): How to build, test, and contribute to Ruby standard libraries
 * [Making changes to Ruby documentation](contributing/documentation_guide.md): How to make changes to Ruby documentation
-* [Benchmarking Ruby](https://github.com/ruby/ruby/tree/master/benchmark#make-benchmark): How to benchmark Ruby
+* [Benchmarking Ruby](https://github.com/ruby/ruby/tree/master/benchmark#user-content-make-benchmark): How to benchmark Ruby

--- a/doc/contributing/documentation_guide.md
+++ b/doc/contributing/documentation_guide.md
@@ -41,16 +41,17 @@ Use your judgment about what the user needs to know.
 - Write short declarative or imperative sentences.
 - Group sentences into (ideally short) paragraphs,
   each covering a single topic.
-- Organize material with [headers](rdoc-ref:RDoc::Markup@Headers).
+- Organize material with
+  [headings](rdoc-ref:RDoc::MarkupReference@Headings).
 - Refer to authoritative and relevant sources using
-  [links](rdoc-ref:RDoc::Markup@Links).
+  [links](rdoc-ref:RDoc::MarkupReference@Links).
 - Use simple verb tenses: simple present, simple past, simple future.
 - Use simple sentence structure, not compound or complex structure.
 - Avoid:
     - Excessive comma-separated phrases;
-      consider a [list](rdoc-ref:RDoc::Markup@Simple+Lists).
+      consider a [list](rdoc-ref:RDoc::MarkupReference@Lists).
     - Idioms and culture-specific references.
-    - Overuse of headers.
+    - Overuse of headings.
     - Using US-ASCII-incompatible characters in C source files;
       see [Characters](#label-Characters) below.
 
@@ -124,16 +125,16 @@ a.shuffle!    #=> [2, 3, 1]
 a             #=> [2, 3, 1]
 ```
 
-### Headers
+### Headings
 
-Organize a long discussion with [headers](rdoc-ref:RDoc::Markup@Headers).
+Organize a long discussion with [headings](rdoc-ref:RDoc::MarkupReference@Headings).
 
 ### Blank Lines
 
 A blank line begins a new paragraph.
 
-A [code block](rdoc-ref:RDoc::Markup@Paragraphs+and+Verbatim)
-or [list](rdoc-ref:RDoc::Markup@Simple+Lists)
+A [code block](rdoc-ref:RDoc::MarkupReference@Code+Blocks)
+or [list](rdoc-ref:RDoc::MarkupReference@Lists)
 should be preceded by and followed by a blank line.
 This is unnecessary for the HTML output, but helps in the `ri` output.
 
@@ -214,7 +215,7 @@ Guidelines:
 
 - The section title is `What's Here`.
 - Consider listing the parent class and any included modules; consider
-  [links](rdoc-ref:RDoc::Markup@Links)
+  [links](rdoc-ref:RDoc::MarkupReference@Links)
   to their "What's Here" sections if those exist.
 - List methods as a bullet list:
 
@@ -224,9 +225,9 @@ Guidelines:
       (and do not list the aliases separately).
     - Check the rendered documentation to determine whether \RDoc has recognized
       the method and linked to it;  if not, manually insert a
-      [link](rdoc-ref:RDoc::Markup@Links).
+      [link](rdoc-ref:RDoc::MarkupReference@Links).
 
-- If there are numerous entries, consider grouping them into subsections with headers.
+- If there are numerous entries, consider grouping them into subsections with headings.
 - If there are more than a few such subsections,
   consider adding a table of contents just below the main section title.
 
@@ -249,7 +250,7 @@ For methods written in Ruby, \RDoc documents the calling sequence automatically.
 
 For methods written in C, \RDoc cannot determine what arguments
 the method accepts, so those need to be documented using \RDoc directive
-[`call-seq:`](rdoc-ref:RDoc::Markup@Method+arguments).
+[`call-seq:`](rdoc-ref:RDoc::MarkupReference@Directives+for+Method+Documentation).
 
 For a singleton method, use the form:
 
@@ -388,7 +389,7 @@ argument passed if it is not obvious, not explicitly mentioned in the
 details, and not implicitly shown in the examples.
 
 If there is more than one argument or block argument, use a
-[labeled list](rdoc-ref:RDoc::Markup@Labeled+Lists).
+[labeled list](rdoc-ref:RDoc::MarkupReference@Labeled+Lists).
 
 ### Corner Cases and Exceptions
 

--- a/doc/encodings.rdoc
+++ b/doc/encodings.rdoc
@@ -137,15 +137,16 @@ returns the \Encoding of the concatenated string, or +nil+ if incompatible:
 A Ruby String object has an encoding that is an instance of class \Encoding.
 The encoding may be retrieved by method String#encoding.
 
-The default encoding for a string literal is the script encoding
-(see Encoding@Script+encoding):
+The default encoding for a string literal is the script encoding;
+see {Script Encoding}[https://docs.ruby-lang.org/en/master/encodings_rdoc.html#label-Script+Encoding].
 
   's'.encoding # => #<Encoding:UTF-8>
 
 The default encoding for a string created with method String.new is:
 
 - For a \String object argument, the encoding of that string.
-- For a string literal, the script encoding (see Encoding@Script+encoding).
+- For a string literal, the script encoding;
+  see {Script Encoding}[https://docs.ruby-lang.org/en/master/encodings_rdoc.html#label-Script+Encoding].
 
 In either case, any encoding may be specified:
 
@@ -190,7 +191,8 @@ the encoding may be retrieved by method Symbol#encoding or Regexp#encoding.
 The default encoding for these, however, is:
 
 - US-ASCII, if all characters are US-ASCII.
-- The script encoding, otherwise (see Encoding@Script+encoding).
+- The script encoding, otherwise;
+  see {Script Encoding}[https://docs.ruby-lang.org/en/master/encodings_rdoc.html#label-Script+Encoding].
 
 === Filesystem \Encoding
 

--- a/file.c
+++ b/file.c
@@ -7134,7 +7134,6 @@ const char ruby_null_device[] =
  *
  *  Note that file permissions are quite different from the _mode_
  *  of a file stream (\File object).
- *  See IO@Modes.
  *
  *  In a \File object, the permissions are available thus,
  *  where method +mode+, despite its name, returns permissions:
@@ -7190,7 +7189,7 @@ const char ruby_null_device[] =
  *
  *  - Inherits from {class IO}[rdoc-ref:IO@What-27s+Here],
  *    in particular, methods for creating, reading, and writing files
- *  - Includes {module FileTest}[rdoc-ref:FileTest@What-27s+Here].
+ *  - Includes module FileTest.
  *    which provides dozens of additional methods.
  *
  *  Here, class \File provides methods that are useful for:

--- a/io.c
+++ b/io.c
@@ -11995,7 +11995,7 @@ io_s_foreach(VALUE v)
  *
  *  - {Open Options}[rdoc-ref:IO@Open+Options].
  *  - {Encoding options}[rdoc-ref:encodings.rdoc@Encoding+Options].
- *  - {Line Options}[rdoc-ref:IO@Line+Options].
+ *  - {Line Options}[rdoc-ref:IO@Line+IO].
  *
  *  Returns an Enumerator if no block is given.
  *
@@ -12093,7 +12093,7 @@ io_s_readlines(VALUE v)
  *
  *  - {Open Options}[rdoc-ref:IO@Open+Options].
  *  - {Encoding options}[rdoc-ref:encodings.rdoc@Encoding+Options].
- *  - {Line Options}[rdoc-ref:IO@Line+Options].
+ *  - {Line Options}[rdoc-ref:IO@Line+IO].
  *
  */
 

--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -973,7 +973,7 @@ class Binding
   #     Cooked potato: true
   #
   #
-  # See IRB@IRB+Usage for more information.
+  # See IRB@Usage for more information.
   def irb(show_code: true)
     IRB.setup(source_location[0], argv: [])
     workspace = IRB::WorkSpace.new(self)

--- a/numeric.c
+++ b/numeric.c
@@ -948,7 +948,7 @@ num_negative_p(VALUE num)
  *  So you should know its esoteric system. See following:
  *
  *  - https://docs.oracle.com/cd/E19957-01/806-3568/ncg_goldberg.html
- *  - https://github.com/rdp/ruby_tutorials_core/wiki/Ruby-Talk-FAQ#floats_imprecise
+ *  - https://github.com/rdp/ruby_tutorials_core/wiki/Ruby-Talk-FAQ#https://github.com/rdp/ruby_tutorials_core/wiki/Ruby-Talk-FAQ#user-content--why-are-rubys-floats-imprecise
  *  - https://en.wikipedia.org/wiki/Floating_point#Accuracy_problems
  *
  *  You can create a \Float object explicitly with:


### PR DESCRIPTION
These fixes are for links that landed on the target page, but did not scroll to the target fragment.

One exception:  I was surprised to find that some browsers to "soft fragments," where the browser scrolls to a target that's similar to the given fragment.  I'm fixing those by using the full and correct fragment;  we don't know that all browsers and other applications use this soft approach;  certainly, my rdoc_link_checker doesn't.