### PR TITLE
Refactor at match defined

### DIFF
--- a/include/ruby/internal/intern/re.h
+++ b/include/ruby/internal/intern/re.h
@@ -87,11 +87,6 @@ void rb_match_busy(VALUE md);
  * @retval     RUBY_Qfalse    There is a `n`-th capture and is empty.
  * @retval     RUBY_Qtrue     There is a `n`-th capture that has something.
  *
- * @internal
- *
- * @shyouhei   wonders:  why   there   are   both  rb_reg_match_defined()   and
- * rb_match_nth_defined, which  are largely the  same things, but do  not share
- * their implementations at all?
  */
 VALUE rb_reg_nth_defined(int n, VALUE md);
 

--- a/internal/re.h
+++ b/internal/re.h
@@ -22,7 +22,6 @@ VALUE rb_reg_equal(VALUE re1, VALUE re2);
 void rb_backref_set_string(VALUE string, long pos, long len);
 void rb_match_unbusy(VALUE);
 int rb_match_count(VALUE match);
-int rb_match_nth_defined(int nth, VALUE match);
 VALUE rb_reg_new_ary(VALUE ary, int options);
 
 #endif /* INTERNAL_RE_H */

--- a/internal/re.h
+++ b/internal/re.h
@@ -23,5 +23,6 @@ void rb_backref_set_string(VALUE string, long pos, long len);
 void rb_match_unbusy(VALUE);
 int rb_match_count(VALUE match);
 VALUE rb_reg_new_ary(VALUE ary, int options);
+VALUE rb_reg_last_defined(VALUE match);
 
 #endif /* INTERNAL_RE_H */

--- a/re.c
+++ b/re.c
@@ -1935,21 +1935,37 @@ rb_reg_match_post(VALUE match)
     return str;
 }
 
-VALUE
-rb_reg_match_last(VALUE match)
+static int
+match_last_index(VALUE match)
 {
     int i;
     struct re_registers *regs;
 
-    if (NIL_P(match)) return Qnil;
+    if (NIL_P(match)) return -1;
     match_check(match);
     regs = RMATCH_REGS(match);
-    if (BEG(0) == -1) return Qnil;
+    if (BEG(0) == -1) return -1;
 
     for (i=regs->num_regs-1; BEG(i) == -1 && i > 0; i--)
         ;
-    if (i == 0) return Qnil;
-    return rb_reg_nth_match(i, match);
+    return i;
+}
+
+VALUE
+rb_reg_match_last(VALUE match)
+{
+    int i = match_last_index(match);
+    if (i <= 0) return Qnil;
+    struct re_registers *regs = RMATCH_REGS(match);
+    return rb_str_subseq(RMATCH(match)->str, BEG(i), END(i) - BEG(i));
+}
+
+VALUE
+rb_reg_last_defined(VALUE match)
+{
+    int i = match_last_index(match);
+    if (i < 0) return Qnil;
+    return RBOOL(i);
 }
 
 static VALUE

--- a/re.c
+++ b/re.c
@@ -1450,23 +1450,6 @@ rb_match_count(VALUE match)
     return regs->num_regs;
 }
 
-int
-rb_match_nth_defined(int nth, VALUE match)
-{
-    struct re_registers *regs;
-    if (NIL_P(match)) return FALSE;
-    regs = RMATCH_REGS(match);
-    if (!regs) return FALSE;
-    if (nth >= regs->num_regs) {
-        return FALSE;
-    }
-    if (nth < 0) {
-        nth += regs->num_regs;
-        if (nth <= 0) return FALSE;
-    }
-    return (BEG(nth) != -1);
-}
-
 static void
 match_set_string(VALUE m, VALUE string, long pos, long len)
 {

--- a/variable.c
+++ b/variable.c
@@ -902,7 +902,7 @@ rb_f_global_variables(void)
         int i, nmatch = rb_match_count(backref);
         buf[0] = '$';
         for (i = 1; i <= nmatch; ++i) {
-            if (!rb_match_nth_defined(i, backref)) continue;
+            if (!RTEST(rb_reg_nth_defined(i, backref))) continue;
             if (i < 10) {
                 /* probably reused, make static ID */
                 buf[1] = (char)(i + '0');


### PR DESCRIPTION
- Remove almost duplicate implementation.
- Stop allocating unused backref strings at `defined?`