### PR TITLE
Fix memory leak in Ripper

### DIFF
--- a/ext/ripper/ripper_init.c.tmpl
+++ b/ext/ripper/ripper_init.c.tmpl
@@ -33,6 +33,7 @@ ripper_parser_free2(void *ptr)
 {
     struct ripper *r = (struct ripper*)ptr;
     ripper_parser_free(r->p);
+    xfree(r);
 }
 
 static size_t

--- a/test/ripper/test_ripper.rb
+++ b/test/ripper/test_ripper.rb
@@ -141,6 +141,14 @@ end
     assert_nothing_raised { Ripper.lex src }
   end
 
+  def test_no_memory_leak
+    assert_no_memory_leak(%w(-rripper), "", "#{<<~'end;'}", rss: true)
+      10_000_000.times do
+        Ripper.parse("")
+      end
+    end;
+  end
+
   class TestInput < self
     Input = Struct.new(:lines) do
       def gets


### PR DESCRIPTION
The following script leaks memory in Ripper:

```ruby
require "ripper"

20.times do
  100_000.times do
    Ripper.parse("")
  end

  puts `ps -o rss= -p #{$$}`
end
```