### PR TITLE
Increase memory leak test timeout

### DIFF
--- a/test/ripper/test_ripper.rb
+++ b/test/ripper/test_ripper.rb
@@ -143,7 +143,7 @@ end
 
   def test_no_memory_leak
     assert_no_memory_leak(%w(-rripper), "", "#{<<~'end;'}", rss: true)
-      10_000_000.times do
+      2_000_000.times do
         Ripper.parse("")
       end
     end;


### PR DESCRIPTION
The test times out on some platforms, so increase the timeout.