### PR TITLE
Fix memory leak when copying ST tables

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -1482,7 +1482,9 @@ hash_copy(VALUE ret, VALUE hash)
     else {
         HASH_ASSERT(sizeof(st_table) <= sizeof(ar_table));
 
-        RHASH_ST_TABLE_SET(ret, st_copy(RHASH_ST_TABLE(hash)));
+        RHASH_SET_ST_FLAG(ret);
+        st_replace(RHASH_ST_TABLE(ret), RHASH_ST_TABLE(hash));
+
         rb_gc_writebarrier_remember(ret);
     }
     return ret;
@@ -1776,7 +1778,8 @@ rb_hash_s_create(int argc, VALUE *argv, VALUE klass)
             }
             else {
                 hash = hash_alloc(klass);
-                hash_copy(hash, tmp);
+                if (!RHASH_EMPTY_P(tmp))
+                    hash_copy(hash, tmp);
                 return hash;
             }
         }

--- a/include/ruby/st.h
+++ b/include/ruby/st.h
@@ -162,6 +162,8 @@ void rb_st_cleanup_safe(st_table *, st_data_t);
 #define st_cleanup_safe rb_st_cleanup_safe
 void rb_st_clear(st_table *);
 #define st_clear rb_st_clear
+st_table *rb_st_replace(st_table *new_tab, st_table *old_tab);
+#define st_replace rb_st_replace
 st_table *rb_st_copy(st_table *);
 #define st_copy rb_st_copy
 CONSTFUNC(int rb_st_numcmp(st_data_t, st_data_t));

--- a/parser_st.c
+++ b/parser_st.c
@@ -109,6 +109,8 @@ nonempty_memcpy(void *dest, const void *src, size_t n)
 #define st_add_direct rb_parser_st_add_direct
 #undef st_insert2
 #define st_insert2 rb_parser_st_insert2
+#undef st_replace
+#define st_replace rb_parser_st_replace
 #undef st_copy
 #define st_copy rb_parser_st_copy
 #undef st_delete_safe

--- a/parser_st.h
+++ b/parser_st.h
@@ -137,6 +137,7 @@ void rb_parser_st_add_direct(parser_st_table *, parser_st_data_t, parser_st_data
 void rb_parser_st_free_table(parser_st_table *);
 void rb_parser_st_cleanup_safe(parser_st_table *, parser_st_data_t);
 void rb_parser_st_clear(parser_st_table *);
+parser_st_table *rb_parser_st_replace(parser_st_table *, parser_st_table *);
 parser_st_table *rb_parser_st_copy(parser_st_table *);
 CONSTFUNC(int rb_parser_st_numcmp(parser_st_data_t, parser_st_data_t));
 CONSTFUNC(parser_st_index_t rb_parser_st_numhash(parser_st_data_t));


### PR DESCRIPTION
st_copy allocates a st_table, which is not needed for hashes since it is allocated by VWA and embedded, so this causes a memory leak.

The following script demonstrates the issue:

```ruby
20.times do
  100_000.times do
    {a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8, i: 9}
  end

  puts `ps -o rss= -p #{$$}`
end
```