### PR TITLE
Fix broken wiki links

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -1279,7 +1279,7 @@ document rb_count_objects
   Counts all objects grouped by type.
 end
 
-# Details: https://bugs.ruby-lang.org/projects/ruby-master/wiki/MachineInstructionsTraceWithGDB
+# Details: https://github.com/ruby/ruby/wiki/Machine-Instructions-Trace-with-GDB
 define trace_machine_instructions
   set logging enabled
   set height 0

--- a/common.mk
+++ b/common.mk
@@ -1841,7 +1841,7 @@ help: PHONY
 	"  golf:                  build goruby for golfers" \
 	$(HELP_EXTRA_TASKS) \
 	"see DeveloperHowto for more detail: " \
-	"  https://bugs.ruby-lang.org/projects/ruby/wiki/DeveloperHowto" \
+	"  https://github.com/ruby/ruby/wiki/Developer-How-To" \
 	$(MESSAGE_END)
 
 $(CROSS_COMPILING:yes=)builtin.$(OBJEXT): {$(VPATH)}mini_builtin.c

--- a/doc/syntax/refinements.rdoc
+++ b/doc/syntax/refinements.rdoc
@@ -279,6 +279,6 @@ Refinements in descendants have higher precedence than those of ancestors.
 
 == Further Reading
 
-See https://bugs.ruby-lang.org/projects/ruby-master/wiki/RefinementsSpec for the
+See https://github.com/ruby/ruby/wiki/Refinements-Spec for the
 current specification for implementing refinements.  The specification also
 contains more details.

--- a/man/ruby.1
+++ b/man/ruby.1
@@ -667,5 +667,5 @@ Ruby is designed and implemented by
 .An Yukihiro Matsumoto Aq matz@netlab.jp .
 .Pp
 See
-.Aq Lk https://bugs.ruby-lang.org/projects/ruby/wiki/Contributors
+.Aq Lk https://github.com/ruby/ruby/graphs/contributors
 for contributors to Ruby.


### PR DESCRIPTION
Since [Misc #19679] migrated the wiki, these links should be updated to their new locations.