### PR TITLE
Handle unterminated unicode escapes in regexps

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -7318,7 +7318,7 @@ tokadd_utf8(struct parser_params *p, rb_encoding **encp,
                     tokadd(p, c);
                     c = *++p->lex.pcur;
                 }
-                tokadd(p, c);
+                tokadd_mbchar(p, c);
             }
         }
         else {

--- a/parse.y
+++ b/parse.y
@@ -7279,6 +7279,8 @@ tokadd_codepoint(struct parser_params *p, rb_encoding **encp,
     return TRUE;
 }
 
+static int tokadd_mbchar(struct parser_params *p, int c);
+
 /* return value is for ?\u3042 */
 static void
 tokadd_utf8(struct parser_params *p, rb_encoding **encp,

--- a/test/ruby/test_parse.rb
+++ b/test/ruby/test_parse.rb
@@ -1052,6 +1052,22 @@ x = __ENCODING__
     assert_syntax_error("    0b\n", /\^/)
   end
 
+  def test_unclosed_unicode_escape_at_eol_bug_19750
+    assert_separately([], "#{<<-"begin;"}\n#{<<~"end;"}")
+    begin;
+      assert_syntax_error("\\/\\\\u", /too short escape sequence/)
+      assert_syntax_error("\\/\\\\u{", /unterminated regexp meets end of file/)
+      assert_syntax_error("\\/\\\\u{\\\\n", /invalid Unicode list/)
+      assert_syntax_error("\\/a#\\\\u{\\\\n/", /invalid Unicode list/)
+      re = eval("\\/a#\\\\u{\\n$/x")
+      assert_match(re, 'a')
+      assert_not_match(re, 'a#')
+      re = eval("\\/a#\\\\u\\n$/x")
+      assert_match(re, 'a')
+      assert_not_match(re, 'a#')
+    end;
+  end
+
   def test_error_def_in_argument
     assert_separately([], "#{<<-"begin;"}\n#{<<~"end;"}")
     begin;

--- a/test/ruby/test_parse.rb
+++ b/test/ruby/test_parse.rb
@@ -1053,16 +1053,16 @@ x = __ENCODING__
   end
 
   def test_unclosed_unicode_escape_at_eol_bug_19750
-    assert_separately([], "#{<<-"begin;"}\n#{<<~"end;"}")
+    assert_separately([], "#{<<-"begin;"}\n#{<<~'end;'}")
     begin;
-      assert_syntax_error("\\/\\\\u", /too short escape sequence/)
-      assert_syntax_error("\\/\\\\u{", /unterminated regexp meets end of file/)
-      assert_syntax_error("\\/\\\\u{\\\\n", /invalid Unicode list/)
-      assert_syntax_error("\\/a#\\\\u{\\\\n/", /invalid Unicode list/)
-      re = eval("\\/a#\\\\u{\\n$/x")
+      assert_syntax_error("/\\u", /too short escape sequence/)
+      assert_syntax_error("/\\u{", /unterminated regexp meets end of file/)
+      assert_syntax_error("/\\u{\\n", /invalid Unicode list/)
+      assert_syntax_error("/a#\\u{\\n/", /invalid Unicode list/)
+      re = eval("/a#\\u{\n$/x")
       assert_match(re, 'a')
       assert_not_match(re, 'a#')
-      re = eval("\\/a#\\\\u\\n$/x")
+      re = eval("/a#\\u\n$/x")
       assert_match(re, 'a')
       assert_not_match(re, 'a#')
     end;


### PR DESCRIPTION
This fixes an infinite loop possible after ec3542229b29ec93062e9d90e877ea29d3c19472. For \u{} escapes in regexps, skip validation in the parser, and rely on the regexp code to handle validation. This is necessary so that invalid unicode escapes in comments in extended regexps are allowed.

Fixes [Bug #19750]