### PR TITLE
Don't check for null pointer in calls to free

### DIFF
--- a/dln_find.c
+++ b/dln_find.c
@@ -75,7 +75,7 @@ dln_find_exe_r(const char *fname, const char *path, char *buf, size_t size
             ".";
     }
     buf = dln_find_1(fname, path, buf, size, 1 DLN_FIND_EXTRA_ARG);
-    if (envpath) free(envpath);
+    free(envpath);
     return buf;
 }
 

--- a/ext/socket/getaddrinfo.c
+++ b/ext/socket/getaddrinfo.c
@@ -219,8 +219,7 @@ freeaddrinfo(struct addrinfo *ai)
 
         do {
                 next = ai->ai_next;
-                if (ai->ai_canonname)
-                        free(ai->ai_canonname);
+                free(ai->ai_canonname);
                 /* no need to free(ai->ai_addr) */
                 free(ai);
         } while ((ai = next) != NULL);

--- a/ext/socket/socket.c
+++ b/ext/socket/socket.c
@@ -1654,8 +1654,7 @@ socket_s_ip_address_list(VALUE self)
 
   finish:
     save_errno = errno;
-    if (lc.lifc_buf != NULL)
-        xfree(lc.lifc_req);
+    xfree(lc.lifc_req);
     if (fd != -1)
         close(fd);
     errno = save_errno;

--- a/gc.c
+++ b/gc.c
@@ -1854,10 +1854,8 @@ rb_objspace_free(rb_objspace_t *objspace)
     if (is_lazy_sweeping(objspace))
         rb_bug("lazy sweeping underway when freeing object space");
 
-    if (objspace->profile.records) {
-        free(objspace->profile.records);
-        objspace->profile.records = 0;
-    }
+    free(objspace->profile.records);
+    objspace->profile.records = NULL;
 
     if (global_list) {
         struct gc_list *list, *next;
@@ -3555,7 +3553,7 @@ obj_free(rb_objspace_t *objspace, VALUE obj)
         if (RHASH_ST_TABLE_P(obj)) {
             st_table *tab = RHASH_ST_TABLE(obj);
 
-            if (tab->bins != NULL) free(tab->bins);
+            free(tab->bins);
             free(tab->entries);
         }
         break;
@@ -3829,11 +3827,7 @@ objspace_each_objects_ensure(VALUE arg)
 
     for (int i = 0; i < SIZE_POOL_COUNT; i++) {
         struct heap_page **pages = data->pages[i];
-        /* pages could be NULL if an error was raised during setup (e.g.
-         * malloc failed due to out of memory). */
-        if (pages) {
-            free(pages);
-        }
+        free(pages);
     }
 
     return Qnil;
@@ -12981,9 +12975,7 @@ gc_profile_clear(VALUE _)
     objspace->profile.size = 0;
     objspace->profile.next_index = 0;
     objspace->profile.current_record = 0;
-    if (p) {
-        free(p);
-    }
+    free(p);
     return Qnil;
 }
 

--- a/hash.c
+++ b/hash.c
@@ -1165,7 +1165,7 @@ st_free_and_clear_table(VALUE hash)
 
     st_table *tab = RHASH_ST_TABLE(hash);
 
-    if (tab->bins != NULL) free(tab->bins);
+    free(tab->bins);
     free(tab->entries);
 
     RHASH_ST_CLEAR(hash);

--- a/iseq.c
+++ b/iseq.c
@@ -170,9 +170,9 @@ rb_iseq_free(const rb_iseq_t *iseq)
 #endif
         ruby_xfree((void *)body->iseq_encoded);
         ruby_xfree((void *)body->insns_info.body);
-        if (body->insns_info.positions) ruby_xfree((void *)body->insns_info.positions);
+        ruby_xfree((void *)body->insns_info.positions);
 #if VM_INSN_INFO_TABLE_IMPL == 2
-        if (body->insns_info.succ_index_table) ruby_xfree(body->insns_info.succ_index_table);
+        ruby_xfree(body->insns_info.succ_index_table);
 #endif
         if (LIKELY(body->local_table != rb_iseq_shared_exc_local_tbl))
             ruby_xfree((void *)body->local_table);

--- a/parse.y
+++ b/parse.y
@@ -13740,7 +13740,7 @@ rb_ruby_parser_free(void *ptr)
         ruby_sized_xfree(p->tokenbuf, p->toksiz);
     }
     for (local = p->lvtbl; local; local = prev) {
-        if (local->vars) xfree(local->vars);
+        xfree(local->vars);
         prev = local->prev;
         xfree(local);
     }

--- a/regcomp.c
+++ b/regcomp.c
@@ -195,8 +195,7 @@ unset_addr_list_init(UnsetAddrList* uslist, int size)
 static void
 unset_addr_list_end(UnsetAddrList* uslist)
 {
-  if (IS_NOT_NULL(uslist->us))
-    xfree(uslist->us);
+  xfree(uslist->us);
 }
 
 static int
@@ -5649,12 +5648,12 @@ extern void
 onig_free_body(regex_t* reg)
 {
   if (IS_NOT_NULL(reg)) {
-    if (IS_NOT_NULL(reg->p))                xfree(reg->p);
-    if (IS_NOT_NULL(reg->exact))            xfree(reg->exact);
-    if (IS_NOT_NULL(reg->int_map))          xfree(reg->int_map);
-    if (IS_NOT_NULL(reg->int_map_backward)) xfree(reg->int_map_backward);
-    if (IS_NOT_NULL(reg->repeat_range))     xfree(reg->repeat_range);
-    if (IS_NOT_NULL(reg->chain))            onig_free(reg->chain);
+    xfree(reg->p);
+    xfree(reg->exact);
+    xfree(reg->int_map);
+    xfree(reg->int_map_backward);
+    xfree(reg->repeat_range);
+    onig_free(reg->chain);
 
 #ifdef USE_NAMED_GROUP
     onig_names_free(reg);
@@ -6001,8 +6000,8 @@ onig_compile(regex_t* reg, const UChar* pattern, const UChar* pattern_end,
   }
 
   onig_node_free(root);
-  if (IS_NOT_NULL(scan_env.mem_nodes_dynamic))
-      xfree(scan_env.mem_nodes_dynamic);
+  xfree(scan_env.mem_nodes_dynamic);
+
   return r;
 }
 

--- a/regexec.c
+++ b/regexec.c
@@ -886,8 +886,8 @@ onig_region_free(OnigRegion* r, int free_self)
 {
   if (r) {
     if (r->allocated > 0) {
-      if (r->beg) xfree(r->beg);
-      if (r->end) xfree(r->end);
+      xfree(r->beg);
+      xfree(r->end);
       r->allocated = 0;
     }
 #ifdef USE_CAPTURE_HISTORY
@@ -965,8 +965,8 @@ onig_region_copy(OnigRegion* to, const OnigRegion* from)
   (msa).match_cache_buf = (uint8_t*)NULL;\
 } while(0)
 #define MATCH_ARG_FREE_MATCH_CACHE(msa) do {\
-  if ((msa).cache_opcodes != NULL) xfree((msa).cache_opcodes);\
-  if ((msa).match_cache_buf != NULL) xfree((msa).match_cache_buf);\
+  xfree((msa).cache_opcodes);\
+  xfree((msa).match_cache_buf);\
   (msa).cache_opcodes = (OnigCacheOpcode*)NULL;\
   (msa).match_cache_buf = (uint8_t*)NULL;\
 } while(0)
@@ -1031,15 +1031,15 @@ onig_region_copy(OnigRegion* to, const OnigRegion* from)
   } while(0)
 
 # define MATCH_ARG_FREE(msa) do {\
-  if ((msa).stack_p) xfree((msa).stack_p);\
+  xfree((msa).stack_p);\
   if ((msa).state_check_buff_size >= STATE_CHECK_BUFF_MALLOC_THRESHOLD_SIZE) { \
-    if ((msa).state_check_buff) xfree((msa).state_check_buff);\
+    xfree((msa).state_check_buff);\
   }\
   MATCH_ARG_FREE_MATCH_CACHE(msa);\
 } while(0)
 #else /* USE_COMBINATION_EXPLOSION_CHECK */
 # define MATCH_ARG_FREE(msa) do {\
-  if ((msa).stack_p) xfree((msa).stack_p);\
+  xfree((msa).stack_p);\
   MATCH_ARG_FREE_MATCH_CACHE(msa);\
 } while (0)
 #endif /* USE_COMBINATION_EXPLOSION_CHECK */
@@ -1151,7 +1151,7 @@ stack_double(OnigStackType** arg_stk_base, OnigStackType** arg_stk_end,
     int r = stack_double(&stk_base, &stk_end, &stk, stk_alloc, msa);\
     if (r != 0) {\
       STACK_SAVE;\
-      if (xmalloc_base) xfree(xmalloc_base);\
+      xfree(xmalloc_base);\
       return r;\
     }\
   }\
@@ -4044,24 +4044,24 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 
  finish:
   STACK_SAVE;
-  if (xmalloc_base) xfree(xmalloc_base);
+  xfree(xmalloc_base);
   return best_len;
 
 #ifdef ONIG_DEBUG
  stack_error:
   STACK_SAVE;
-  if (xmalloc_base) xfree(xmalloc_base);
+  xfree(xmalloc_base);
   return ONIGERR_STACK_BUG;
 #endif
 
  bytecode_error:
   STACK_SAVE;
-  if (xmalloc_base) xfree(xmalloc_base);
+  xfree(xmalloc_base);
   return ONIGERR_UNDEFINED_BYTECODE;
 
  unexpected_bytecode_error:
   STACK_SAVE;
-  if (xmalloc_base) xfree(xmalloc_base);
+  xfree(xmalloc_base);
   return ONIGERR_UNEXPECTED_BYTECODE;
 }
 

--- a/regparse.c
+++ b/regparse.c
@@ -142,7 +142,7 @@ static void
 bbuf_free(BBuf* bbuf)
 {
   if (IS_NOT_NULL(bbuf)) {
-    if (IS_NOT_NULL(bbuf->p)) xfree(bbuf->p);
+    xfree(bbuf->p);
     xfree(bbuf);
   }
 }
@@ -514,7 +514,7 @@ static int
 i_free_name_entry(UChar* key, NameEntry* e, void* arg ARG_UNUSED)
 {
   xfree(e->name);
-  if (IS_NOT_NULL(e->back_refs)) xfree(e->back_refs);
+  xfree(e->back_refs);
   xfree(key);
   xfree(e);
   return ST_DELETE;
@@ -699,7 +699,7 @@ names_clear(regex_t* reg)
 	e->name_len   = 0;
 	e->back_num   = 0;
 	e->back_alloc = 0;
-	if (IS_NOT_NULL(e->back_refs)) xfree(e->back_refs);
+	xfree(e->back_refs);
 	e->back_refs = (int* )NULL;
       }
     }
@@ -722,7 +722,7 @@ onig_names_free(regex_t* reg)
   if (r) return r;
 
   t = (NameTable* )reg->name_table;
-  if (IS_NOT_NULL(t)) xfree(t);
+  xfree(t);
   reg->name_table = NULL;
   return 0;
 }
@@ -1098,29 +1098,24 @@ onig_node_free(Node* node)
     {
       CClassNode* cc = NCCLASS(node);
 
-      if (cc->mbuf)
-	bbuf_free(cc->mbuf);
+      bbuf_free(cc->mbuf);
     }
     break;
 
   case NT_QTFR:
-    if (NQTFR(node)->target)
-      onig_node_free(NQTFR(node)->target);
+    onig_node_free(NQTFR(node)->target);
     break;
 
   case NT_ENCLOSE:
-    if (NENCLOSE(node)->target)
-      onig_node_free(NENCLOSE(node)->target);
+    onig_node_free(NENCLOSE(node)->target);
     break;
 
   case NT_BREF:
-    if (IS_NOT_NULL(NBREF(node)->back_dynamic))
-      xfree(NBREF(node)->back_dynamic);
+    xfree(NBREF(node)->back_dynamic);
     break;
 
   case NT_ANCHOR:
-    if (NANCHOR(node)->target)
-      onig_node_free(NANCHOR(node)->target);
+    onig_node_free(NANCHOR(node)->target);
     break;
   }
 

--- a/st.c
+++ b/st.c
@@ -657,8 +657,7 @@ st_clear(st_table *tab)
 void
 st_free_table(st_table *tab)
 {
-    if (tab->bins != NULL)
-        free(tab->bins);
+    free(tab->bins);
     free(tab->entries);
     free(tab);
 }
@@ -777,8 +776,7 @@ rebuild_table(st_table *tab)
         tab->entry_power = new_tab->entry_power;
         tab->bin_power = new_tab->bin_power;
         tab->size_ind = new_tab->size_ind;
-        if (tab->bins != NULL)
-            free(tab->bins);
+        free(tab->bins);
         tab->bins = new_tab->bins;
         free(tab->entries);
         tab->entries = new_tab->entries;
@@ -2090,10 +2088,8 @@ st_expand_table(st_table *tab, st_index_t siz)
     n = get_allocated_entries(tab);
     MEMCPY(tmp->entries, tab->entries, st_table_entry, n);
     free(tab->entries);
-    if (tab->bins != NULL)
-        free(tab->bins);
-    if (tmp->bins != NULL)
-        free(tmp->bins);
+    free(tab->bins);
+    free(tmp->bins);
     tab->entry_power = tmp->entry_power;
     tab->bin_power = tmp->bin_power;
     tab->size_ind = tmp->size_ind;
@@ -2111,10 +2107,10 @@ st_rehash_linear(st_table *tab)
     int eq_p, rebuilt_p;
     st_index_t i, j;
     st_table_entry *p, *q;
-    if (tab->bins) {
-        free(tab->bins);
-        tab->bins = NULL;
-    }
+
+    free(tab->bins);
+    tab->bins = NULL;
+
     for (i = tab->entries_start; i < tab->entries_bound; i++) {
         p = &tab->entries[i];
         if (DELETED_ENTRY_P(p))

--- a/thread.c
+++ b/thread.c
@@ -3911,7 +3911,7 @@ rb_fd_init_copy(rb_fdset_t *dst, rb_fdset_t *src)
 void
 rb_fd_term(rb_fdset_t *fds)
 {
-    if (fds->fdset) xfree(fds->fdset);
+    xfree(fds->fdset);
     fds->maxfd = 0;
     fds->fdset = 0;
 }

--- a/transcode.c
+++ b/transcode.c
@@ -1715,8 +1715,7 @@ rb_econv_close(rb_econv_t *ec)
     }
     for (i = 0; i < ec->num_trans; i++) {
         rb_transcoding_close(ec->elems[i].tc);
-        if (ec->elems[i].out_buf_start)
-            xfree(ec->elems[i].out_buf_start);
+        xfree(ec->elems[i].out_buf_start);
     }
     xfree(ec->in_buf_start);
     xfree(ec->elems);

--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -478,7 +478,7 @@ static void
 backtrace_free(void *ptr)
 {
    rb_backtrace_t *bt = (rb_backtrace_t *)ptr;
-   if (bt->backtrace) ruby_xfree(bt->backtrace);
+   ruby_xfree(bt->backtrace);
    ruby_xfree(bt);
 }
 

--- a/win32/file.c
+++ b/win32/file.c
@@ -372,8 +372,7 @@ rb_file_expand_path_internal(VALUE fname, VALUE dname, int abs_mode, int long_na
         result = append_wstr(result, wpath_pos + 1, user_length_in_path(wpath_pos + 1, wpath_len - 1),
                              path_cp, path_encoding);
 
-        if (wpath)
-            free(wpath);
+        free(wpath);
 
         rb_exc_raise(rb_exc_new_str(rb_eArgError, result));
     }
@@ -390,7 +389,7 @@ rb_file_expand_path_internal(VALUE fname, VALUE dname, int abs_mode, int long_na
             const long dir_len = RSTRING_LEN(dir);
 #if SIZEOF_INT < SIZEOF_LONG
             if ((long)(int)dir_len != dir_len) {
-                if (wpath) free(wpath);
+                free(wpath);
                 rb_raise(rb_eRangeError, "base directory (%ld bytes) is too long",
                          dir_len);
             }
@@ -452,11 +451,8 @@ rb_file_expand_path_internal(VALUE fname, VALUE dname, int abs_mode, int long_na
             result = rb_str_new_cstr("can't find user ");
             result = append_wstr(result, wdir_pos + 1, user_length_in_path(wdir_pos + 1, wdir_len - 1),
                                  path_cp, path_encoding);
-            if (wpath)
-                free(wpath);
-
-            if (wdir)
-                free(wdir);
+            free(wpath);
+            free(wdir);
 
             rb_exc_raise(rb_exc_new_str(rb_eArgError, result));
         }
@@ -573,17 +569,10 @@ rb_file_expand_path_internal(VALUE fname, VALUE dname, int abs_mode, int long_na
     result = append_wstr(result, wfullpath, size, path_cp, path_encoding);
 
     /* TODO: better cleanup */
-    if (buffer)
-        xfree(buffer);
-
-    if (wpath)
-        free(wpath);
-
-    if (wdir)
-        free(wdir);
-
-    if (whome)
-        xfree(whome);
+    xfree(buffer);
+    free(wpath);
+    free(wdir);
+    xfree(whome);
 
     if (wfullpath != wfullpath_buffer)
         xfree(wfullpath);

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -2369,10 +2369,8 @@ readdir_internal(DIR *dirp, BOOL (*conv)(const WCHAR *, const WCHAR *, struct di
         //
         // first set up the structure to return
         //
-        if (dirp->dirstr.d_name)
-            free(dirp->dirstr.d_name);
-        if (dirp->dirstr.d_altname)
-            free(dirp->dirstr.d_altname);
+        free(dirp->dirstr.d_name);
+        free(dirp->dirstr.d_altname);
         dirp->dirstr.d_altname = 0;
         dirp->dirstr.d_altlen = 0;
         conv(dirp->curr, dirp->curr + lstrlenW(dirp->curr) + 1, &dirp->dirstr, enc);
@@ -2478,14 +2476,10 @@ void
 rb_w32_closedir(DIR *dirp)
 {
     if (dirp) {
-        if (dirp->dirstr.d_name)
-            free(dirp->dirstr.d_name);
-        if (dirp->dirstr.d_altname)
-            free(dirp->dirstr.d_altname);
-        if (dirp->start)
-            free(dirp->start);
-        if (dirp->bits)
-            free(dirp->bits);
+        free(dirp->dirstr.d_name);
+        free(dirp->dirstr.d_altname);
+        free(dirp->start);
+        free(dirp->bits);
         free(dirp);
     }
 }
@@ -4378,8 +4372,8 @@ freeifaddrs(struct ifaddrs *ifp)
 {
     while (ifp) {
         struct ifaddrs *next = ifp->ifa_next;
-        if (ifp->ifa_addr) ruby_xfree(ifp->ifa_addr);
-        if (ifp->ifa_name) ruby_xfree(ifp->ifa_name);
+        ruby_xfree(ifp->ifa_addr);
+        ruby_xfree(ifp->ifa_name);
         ruby_xfree(ifp);
         ifp = next;
     }
@@ -7593,7 +7587,7 @@ rb_w32_write_console(uintptr_t strarg, int fd)
         }
     }
     RB_GC_GUARD(str);
-    if (wbuffer) free(wbuffer);
+    free(wbuffer);
     return (long)reslen;
 }
 


### PR DESCRIPTION
According to the C99 specification section 7.20.3.2 paragraph 2:

> If ptr is a null pointer, no action occurs.

So we do not need to check that the pointer is a null pointer.