### PR TITLE
YJIT: Fix autosplat miscomp for blocks with optionals

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -1,3 +1,13 @@
+# Regression test for yielding with autosplat to block with
+# optional parameters. https://github.com/Shopify/yjit/issues/313
+assert_equal '[:a, :b, :a, :b]', %q{
+  def yielder(arg) = yield(arg) + yield(arg)
+
+  yielder([:a, :b]) do |c = :c, d = :d|
+    [c, d]
+  end
+}
+
 # Regression test for GC mishap while doing shape transition
 assert_equal '[:ok]', %q{
   # [Bug #19601]

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -296,6 +296,7 @@ make_counters! {
     invokesuper_block,
 
     invokeblock_none,
+    invokeblock_iseq_arg0_optional,
     invokeblock_iseq_arg0_has_kw,
     invokeblock_iseq_arg0_args_splat,
     invokeblock_iseq_arg0_not_array,


### PR DESCRIPTION
When passing an array as the sole argument to `yield`, and the yieldee
takes more than 1 optional parameter, the array is expanded similar
to `*array` splat calls. This is called "autosplat" in
`setup_parameters_complex()`.

Previously, YJIT did not detect this autosplat condition. It passed the
array without expanding it, deviating from interpreter behavior.
Detect this conditon and refuse to compile it.

Fixes: Shopify/yjit#313

---
The `setup_parameters_complex()` logic, for reference:
https://github.com/ruby/ruby/blob/d49a92d036fb316757d7c4a12a2f9808875f35bf/vm_args.c#L643-L649
