### PR TITLE
ruby_3_2 backport for #8006

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -1,3 +1,13 @@
+# Regression test for yielding with autosplat to block with
+# optional parameters. https://github.com/Shopify/yjit/issues/313
+assert_equal '[:a, :b, :a, :b]', %q{
+  def yielder(arg) = yield(arg) + yield(arg)
+
+  yielder([:a, :b]) do |c = :c, d = :d|
+    [c, d]
+  end
+}
+
 assert_equal 'true', %q{
   # regression test for tracking type of locals for too long
   def local_setting_cmp(five)

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -6117,7 +6117,9 @@ fn gen_invokeblock(
         // Not supporting vm_callee_setup_block_arg_arg0_splat for now
         let comptime_captured = unsafe { ((comptime_handler.0 & !0x3) as *const rb_captured_block).as_ref().unwrap() };
         let comptime_iseq = unsafe { *comptime_captured.code.iseq.as_ref() };
-        if argc == 1 && unsafe { get_iseq_flags_has_lead(comptime_iseq) && !get_iseq_flags_ambiguous_param0(comptime_iseq) } {
+        if argc == 1 && unsafe {
+                (get_iseq_flags_has_lead(comptime_iseq) || get_iseq_body_param_opt_num(comptime_iseq) > 1) &&
+                !get_iseq_flags_ambiguous_param0(comptime_iseq) } {
             gen_counter_incr!(asm, invokeblock_iseq_arg0_splat);
             return CantCompile;
         }


### PR DESCRIPTION
This is a backported version of https://github.com/ruby/ruby/pull/8006
The patch is different because the two branches have diverged.

Original bug report: https://github.com/Shopify/yjit/issues/313

---

YJIT: Fix autosplat miscomp for blocks with optionals

When passing an array as the sole argument to `yield`, and the yieldee takes more than 1 optional parameter, the array is expanded similar to `*array` splat calls. This is called "autosplat" in `setup_parameters_complex()`.

Previously, YJIT did not detect this autosplat condition. It passed the array without expanding it, deviating from interpreter behavior. Detect this conditon and refuse to compile it.

