### PR TITLE
Support `--backtrace-limit` in RUBYOPT, allow -1 as value, and add it to man page

### DIFF
--- a/man/ruby.1
+++ b/man/ruby.1
@@ -271,6 +271,11 @@ In auto-split mode, Ruby executes
 .Dl $F = $_.split
 at beginning of each loop.
 .Pp
+.It Fl -backtrace-limit Ns = Ns Ar num
+Limits the maximum length of backtraces to
+.Ar num
+lines (default -1, meaning no limit).
+.Pp
 .It Fl c
 Causes Ruby to check the syntax of the script and exit without
 executing. If there are no syntax errors, Ruby will print

--- a/ruby.c
+++ b/ruby.c
@@ -1446,7 +1446,7 @@ proc_long_options(ruby_cmdline_options_t *opt, const char *s, long argc, char **
         opt->dump |= DUMP_BIT(help);
         return 0;
     }
-    else if (is_option_with_arg("backtrace-limit", Qfalse, Qfalse)) {
+    else if (is_option_with_arg("backtrace-limit", Qfalse, Qtrue)) {
         char *e;
         long n = strtol(s, &e, 10);
         if (errno == ERANGE || n < 0 || *e) rb_raise(rb_eRuntimeError, "wrong limit for backtrace length");

--- a/ruby.c
+++ b/ruby.c
@@ -1449,7 +1449,7 @@ proc_long_options(ruby_cmdline_options_t *opt, const char *s, long argc, char **
     else if (is_option_with_arg("backtrace-limit", Qfalse, Qtrue)) {
         char *e;
         long n = strtol(s, &e, 10);
-        if (errno == ERANGE || n < 0 || *e) rb_raise(rb_eRuntimeError, "wrong limit for backtrace length");
+        if (errno == ERANGE || n < -1 || *e) rb_raise(rb_eRuntimeError, "wrong limit for backtrace length");
         opt->backtrace_length_limit = (int)n;
     }
     else {

--- a/test/ruby/test_rubyoptions.rb
+++ b/test/ruby/test_rubyoptions.rb
@@ -74,7 +74,7 @@ class TestRubyOptions < Test::Unit::TestCase
   def test_backtrace_limit
     assert_in_out_err(%w(--backtrace-limit), "", [], /missing argument for --backtrace-limit/)
     assert_in_out_err(%w(--backtrace-limit= 1), "", [], /missing argument for --backtrace-limit/)
-    assert_in_out_err(%w(--backtrace-limit=-1), "", [], /wrong limit for backtrace length/)
+    assert_in_out_err(%w(--backtrace-limit=-2), "", [], /wrong limit for backtrace length/)
     code = 'def f(n);n > 0 ? f(n-1) : raise;end;f(5)'
     assert_in_out_err(%w(--backtrace-limit=1), code, [],
                       [/.*unhandled exception\n/, /^\tfrom .*\n/,

--- a/test/ruby/test_rubyoptions.rb
+++ b/test/ruby/test_rubyoptions.rb
@@ -84,6 +84,9 @@ class TestRubyOptions < Test::Unit::TestCase
                        /^\t \.{3} \d+ levels\.{3}\n/])
     assert_kind_of(Integer, Thread::Backtrace.limit)
     assert_in_out_err(%w(--backtrace-limit=1), "p Thread::Backtrace.limit", ['1'], [])
+    env = {"RUBYOPT" => "--backtrace-limit=5"}
+    assert_in_out_err([env], "p Thread::Backtrace.limit", ['5'], [])
+    assert_in_out_err([env, "--backtrace-limit=1"], "p Thread::Backtrace.limit", ['1'], [])
   end
 
   def test_warning


### PR DESCRIPTION
The `--backtrace-limit` option is not currently allowed to appear in the `RUBYOPT` environment variable, but that appears to be a mistake. Unlike other long options which are not allowed in `RUBYOPT` (e.g. `--copyright`, `--version`, `--dump` and `--help`) it does not cause the interpreter to terminate, and cannot cause harm if read from the environment. During the initial discussion about the `--backtrace-limit` feature, Matz [suggested](https://bugs.ruby-lang.org/issues/8661#note-27) that he expected `RUBYOPT` to allow this option.

The `--backtrace-limit` option should also allow a value of -1 since that is legitimate (and the default), and be documented on Ruby’s `man` page.