### PR TITLE
[Bug #19754] Make `IO::Buffer#get_string` check `offset` range

### DIFF
--- a/io_buffer.c
+++ b/io_buffer.c
@@ -1156,6 +1156,9 @@ VALUE rb_io_buffer_free_locked(VALUE self)
 static inline void
 io_buffer_validate_range(struct rb_io_buffer *buffer, size_t offset, size_t length)
 {
+    if (offset > buffer->size) {
+        rb_raise(rb_eArgError, "Specified offset exceeds buffer size!");
+    }
     if (offset + length > buffer->size) {
         rb_raise(rb_eArgError, "Specified offset+length exceeds buffer size!");
     }

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -251,6 +251,14 @@ class TestIOBuffer < Test::Unit::TestCase
 
     chunk = buffer.get_string(0, message.bytesize, Encoding::BINARY)
     assert_equal Encoding::BINARY, chunk.encoding
+
+    assert_raise_with_message(ArgumentError, /exceeds buffer size/) do
+      buffer.get_string(0, 129)
+    end
+
+    assert_raise_with_message(ArgumentError, /exceeds buffer size/) do
+      buffer.get_string(129)
+    end
   end
 
   # We check that values are correctly round tripped.


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/19754