### PR TITLE
Add a realpath cache to reduce number of syscalls.

### DIFF
--- a/load.c
+++ b/load.c
@@ -689,6 +689,19 @@ rb_provide(const char *feature)
 
 NORETURN(static void load_failed(VALUE));
 
+static inline VALUE
+realpath_internal_cached(VALUE hash, VALUE path)
+{
+    VALUE ret = rb_hash_aref(hash, path);
+    if(RTEST(ret)) {
+        return ret;
+    }
+
+    VALUE realpath = rb_realpath_internal(Qnil, path, 1);
+    rb_hash_aset(hash, rb_fstring(path), rb_fstring(realpath));
+    return realpath;
+}
+
 static inline void
 load_iseq_eval(rb_execution_context_t *ec, VALUE fname)
 {
@@ -701,8 +714,12 @@ load_iseq_eval(rb_execution_context_t *ec, VALUE fname)
         VALUE parser = rb_parser_new();
         rb_parser_set_context(parser, NULL, FALSE);
         ast = (rb_ast_t *)rb_parser_load_file(parser, fname);
+
+        rb_thread_t *th = rb_ec_thread_ptr(ec);
+        VALUE realpath_map = get_loaded_features_realpath_map(th->vm);
+
         iseq = rb_iseq_new_top(&ast->body, rb_fstring_lit("<top (required)>"),
-                               fname, rb_realpath_internal(Qnil, fname, 1), NULL);
+                               fname, realpath_internal_cached(realpath_map, fname), NULL);
         rb_ast_dispose(ast);
         rb_vm_pop_frame(ec);
         RB_GC_GUARD(v);
@@ -1208,7 +1225,7 @@ require_internal(rb_execution_context_t *ec, VALUE fname, int exception, bool wa
                 result = TAG_RETURN;
             }
             else if (RTEST(rb_hash_aref(realpaths,
-                                        realpath = rb_realpath_internal(Qnil, path, 1)))) {
+                                        realpath = realpath_internal_cached(realpath_map, path)))) {
                 result = 0;
             }
             else {
@@ -1268,7 +1285,6 @@ require_internal(rb_execution_context_t *ec, VALUE fname, int exception, bool wa
         if (real) {
             real = rb_fstring(real);
             rb_hash_aset(realpaths, real, Qtrue);
-            rb_hash_aset(realpath_map, path, real);
         }
     }
     ec->errinfo = saved.errinfo;


### PR DESCRIPTION
Number of lstat and stat syscalls for each 'require'd file is doubled, because rb_realpath_internal is called from two places with the same arguments in require_internal; once for checking the realpaths cache, and once in load_iseq_eval when iseq is not found.

Introduce rb_realpath_internal_cached function to reuse the realpath_map cache which memoizes rb_realpath_internal function, leading to less syscalls and increased startup performance depending on the cost of the syscalls in a particular environment.

---

I have discovered that Ruby 3.2.0 is slower to load an empty ruby file w.r.t. 2.7.8.

This made me suspicious and I checked the number of syscalls made for `ruby empty.rb` and `ruby require_100_empty_rbs.rb`.

While loading an empty file may not be a realistic use case, I have found that ruby makes ~double the amount of `lstat` and `stat` syscalls for `require`’d files. In environments where syscalls are slower, this has a larger impact.

Top 6 file-related syscalls made for loading the empty file for 2.7.8, 3.2.0 and master as of writing (af9eeb19d8b73a951776ea91901618d6e038d030):

```
strace -fcw ruby-2.7.8 empty.rb
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
 68.31    0.035562         167       212           read
  8.94    0.004654           8       529           lstat
  6.29    0.003275           8       367       220 openat
  2.76    0.001436        1436         1           execve
  2.08    0.001085           8       122        15 stat
  2.06    0.001071           7       150           close
  1.89    0.000984           6       153           fstat
  ...
  
  Total calls: 2120
```

```
strace -fcw ruby-3.2.0 empty.rb
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
 38.83    0.008490           7      1133         6 lstat
 10.61    0.002320           7       300       112 openat
  8.16    0.001784           6       269           read
  7.55    0.001650           7       219        21 stat
  5.51    0.001204           6       191           close
  5.20    0.001137           5       192           fstat
  ...
  
  Total calls: 3100
```

```
strace -fcw ruby-master empty.rb
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
 37.89    0.008473           7      1109         3 lstat
 11.02    0.002465           8       296       113 openat
  8.56    0.001915           7       263           read
  7.76    0.001736           8       210        18 stat
  5.72    0.001280           6       186           close
  5.17    0.001157           6       187           fstat
  ...
  
  Total calls: 3030
```

### Root cause

Ruby 3.2.0 is making ~double file-related (mostly `lstat` and `stat`) syscalls w.r.t. Ruby 2.7.8, while requiring .rb files, now that is a *clue*. `gdb` revealed that most `lstat` calls originate from `rb_check_realpath_internal`, which is called via [`load_iseq_eval`](https://github.com/ruby/ruby/blob/af9eeb19d8b73a951776ea91901618d6e038d030/load.c#L693) and [`require_internal`](https://github.com/ruby/ruby/blob/af9eeb19d8b73a951776ea91901618d6e038d030/load.c#L1164) in `load.c`.

Bisecting between 2.7.8 and 3.2.0 revealed that https://github.com/ruby/ruby/commit/79a4484a072e9769b603e7b4fbdb15b1d7eccb15 introduced the extra syscalls while implementing an optimization around loading the same file twice, which is included since 3.1.0-preview1. This commit introduces another `rb_check_realpath` in the load/require path. This agrees with the results from the `gdb` investigation (omitted in the PR for brevity).

### The patch

I hereby propose a patch that will reduce the number of syscalls made while loading ruby files by ~half, by memoizing the invocations of `rb_realpath_internal` from `load.c`, reusing the `realpath_map` cache introduced in https://github.com/ruby/ruby/commit/1f115f141dd17f75049a5e17107906c5bcc372e1 which also focuses on load time performance optimization.

With the patch, w.r.t. master, number of total syscalls is reduced by 470, `lstat` calls reduced by 429.

```
strace -fcw ruby-master-patched empty.rb
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
 26.81    0.004502           6       680         3 lstat
 13.25    0.002226           7       296       113 openat
  9.96    0.001672           6       263           read
  7.17    0.001204           7       168        18 stat
  6.61    0.001111           5       186           close
  6.36    0.001067           5       187           fstat
  ...
  
  Total calls: 2560
```

### Requiring 100 files

For a file that requires 100 different empty files, number of syscalls is reduced by 1076, lstat calls reduced by 929:

```
strace -fcw ruby-master require_100_empty_rbs.rb
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
 39.49    0.015040           7      2109         3 lstat
 10.17    0.003872           7       496       113 openat
  8.37    0.003186           7       410        18 stat
  6.32    0.002406           6       386           close
  6.18    0.002353           6       387           fstat
  6.06    0.002307           6       363           read
  ...
  
  Total calls: 5541
```

and with the patch:

```
strace -fcw ruby-master-patched require_100_empty_rbs.rb
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
 28.32    0.008822           7      1180         3 lstat
 12.77    0.003979           8       496       113 openat
  7.86    0.002448           6       386           close
  7.71    0.002401           6       387           fstat
  7.63    0.002376           6       363           read
  6.73    0.002097           7       268        18 stat
  ...
  
  Total calls: 4465
```

**require_100_empty_rbs.rb**:
```
require_relative “empty_001.rb”
require_relative “empty_002.rb”
...
require_relative “empty_100.rb”
```
where `empty_*.rb` are 0 byte files.