### PR TITLE
YJIT: Avoid reloading InsnOut operands

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -1375,7 +1375,7 @@ fn guard_object_is_array(
     }
 
     let object_reg = match object {
-        Opnd::Reg(_) => object,
+        Opnd::InsnOut { .. } => object,
         _ => asm.load(object),
     };
     guard_object_is_heap(asm, object_reg, object_opnd, counter);
@@ -1407,7 +1407,7 @@ fn guard_object_is_string(
     }
 
     let object_reg = match object {
-        Opnd::Reg(_) => object,
+        Opnd::InsnOut { .. } => object,
         _ => asm.load(object),
     };
     guard_object_is_heap(asm, object_reg, object_opnd, counter);
@@ -1954,7 +1954,7 @@ fn gen_get_ivar(
 
     // If recv isn't already a register, load it.
     let recv = match recv {
-        Opnd::Reg(_) => recv,
+        Opnd::InsnOut { .. } => recv,
         _ => asm.load(recv),
     };
 
@@ -3910,7 +3910,7 @@ fn jit_guard_known_klass(
 
         // If obj_opnd isn't already a register, load it.
         let obj_opnd = match obj_opnd {
-            Opnd::Reg(_) => obj_opnd,
+            Opnd::InsnOut { .. } => obj_opnd,
             _ => asm.load(obj_opnd),
         };
         let klass_opnd = Opnd::mem(64, obj_opnd, RUBY_OFFSET_RBASIC_KLASS);
@@ -5209,7 +5209,7 @@ fn get_array_len(asm: &mut Assembler, array_opnd: Opnd) -> Opnd {
 
     // Pull out the embed flag to check if it's an embedded array.
     let array_reg = match array_opnd {
-        Opnd::Reg(_) => array_opnd,
+        Opnd::InsnOut { .. } => array_opnd,
         _ => asm.load(array_opnd),
     };
     let flags_opnd = Opnd::mem(VALUE_BITS, array_reg, RUBY_OFFSET_RBASIC_FLAGS);
@@ -5223,7 +5223,7 @@ fn get_array_len(asm: &mut Assembler, array_opnd: Opnd) -> Opnd {
     asm.test(flags_opnd, (RARRAY_EMBED_FLAG as u64).into());
 
     let array_reg = match array_opnd {
-        Opnd::Reg(_) => array_opnd,
+        Opnd::InsnOut { .. } => array_opnd,
         _ => asm.load(array_opnd),
     };
     let array_len_opnd = Opnd::mem(


### PR DESCRIPTION
There's this idiom in codegen.rs:

```rs
let object_reg = match object {
    Opnd::Reg(_) => object,
    _ => asm.load(object),
};
```

but `Opnd::Reg` doesn't seem to be really used in those places. When an argument operand is loaded into a register with `asm.load`, it's actually `Opnd::InsnOut`. So this PR fixes the condition to use `Opnd::InsnOut` instead.

I noticed this when I looked at generated code that contained an identical move `mov rax, rax` on expandarray. This PR removes such instructions.