### PR TITLE
Use `uint_least32_t`

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -7864,7 +7864,7 @@ flush_string_content(struct parser_params *p, rb_encoding *enc)
 }
 #endif
 
-RUBY_FUNC_EXPORTED const unsigned int ruby_global_name_punct_bits[(0x7e - 0x20 + 31) / 32];
+RUBY_FUNC_EXPORTED const uint_least32_t ruby_global_name_punct_bits[(0x7e - 0x20 + 31) / 32];
 /* this can be shared with ripper, since it's independent from struct
  * parser_params. */
 #ifndef RIPPER
@@ -7876,7 +7876,7 @@ RUBY_FUNC_EXPORTED const unsigned int ruby_global_name_punct_bits[(0x7e - 0x20 +
         BIT(':', idx) | BIT('<', idx) | BIT('>', idx) | BIT('\"', idx) | \
         BIT('&', idx) | BIT('`', idx) | BIT('\'', idx) | BIT('+', idx) | \
         BIT('0', idx))
-const unsigned int ruby_global_name_punct_bits[] = {
+const uint_least32_t ruby_global_name_punct_bits[] = {
     SPECIAL_PUNCT(0),
     SPECIAL_PUNCT(1),
     SPECIAL_PUNCT(2),

--- a/symbol.h
+++ b/symbol.h
@@ -100,7 +100,7 @@ sym_type(VALUE sym)
 #define is_class_sym(sym) (sym_type(sym)==ID_CLASS)
 #define is_junk_sym(sym) (sym_type(sym)==ID_JUNK)
 
-RUBY_FUNC_EXPORTED const unsigned int ruby_global_name_punct_bits[(0x7e - 0x20 + 31) / 32];
+RUBY_FUNC_EXPORTED const uint_least32_t ruby_global_name_punct_bits[(0x7e - 0x20 + 31) / 32];
 
 static inline int
 is_global_name_punct(const int c)


### PR DESCRIPTION
The elements of `ruby_global_name_punct_bits` table are 32-bit masks.