### PR TITLE
Hotfix disable yjit for non-flonum

### DIFF
--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -93,10 +93,10 @@ jobs:
           - { name: clang-12,  env: { default_cc: clang-12 } }
           - { name: clang-11,  env: { default_cc: clang-11 } }
           - { name: clang-10,  env: { default_cc: clang-10 } }
-          - { name: clang-9,   env: { default_cc: clang-9 } }
-          - { name: clang-8,   env: { default_cc: clang-8 } }
-          - { name: clang-7,   env: { default_cc: clang-7 } }
-          - { name: clang-6.0, env: { default_cc: clang-6.0 } }
+          - { name: clang-9,   env: { default_cc: clang-9,   append_configure: '--disable-yjit' } }
+          - { name: clang-8,   env: { default_cc: clang-8,   append_configure: '--disable-yjit' } }
+          - { name: clang-7,   env: { default_cc: clang-7,   append_configure: '--disable-yjit' } }
+          - { name: clang-6.0, env: { default_cc: clang-6.0, append_configure: '--disable-yjit' } }
           - name: 'clang-16 LTO'
             container: clang-16
             env:

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -168,7 +168,7 @@ jobs:
 #         - { name: VM_CHECK_MODE,                  env: { cppflags: '-DVM_CHECK_MODE' } }
 
 #         - { name: USE_EMBED_CI=0,                 env: { cppflags: '-DUSE_EMBED_CI=0' } }
-          - { name: USE_FLONUM=0,                   env: { cppflags: '-DUSE_FLONUM=0' } }
+          - { name: USE_FLONUM=0,                   env: { cppflags: '-DUSE_FLONUM=0', append_configure: '--disable-yjit' } }
 #         - { name: USE_GC_MALLOC_OBJ_INFO_DETAILS, env: { cppflags: '-DUSE_GC_MALLOC_OBJ_INFO_DETAILS' } }
 #         - { name: USE_LAZY_LOAD,                  env: { cppflags: '-DUSE_LAZY_LOAD' } }
 #         - { name: USE_SYMBOL_GC=0,                env: { cppflags: '-DUSE_SYMBOL_GC=0' } }


### PR DESCRIPTION
I'm aware I broke our CI.  This is because the container image now includes `rustc`, which is detected by our `configure`, which doesn't interface well with `-DUSE_FLONUM=0`.

This should fix (I don't think it's a wise idea to rely on `rustc`'s being absent).