### PR TITLE
Move ISASCII defination to parse.y

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -6352,6 +6352,17 @@ ripper_dispatch_delayed_token(struct parser_params *p, enum yytokentype t)
 #endif /* RIPPER */
 
 static inline int
+parse_isascii(int c)
+{
+    return '\0' <= c && c <= '\x7f';
+}
+
+#ifdef ISASCII
+#undef ISASCII
+#define ISASCII parse_isascii
+#endif
+
+static inline int
 is_identchar(struct parser_params *p, const char *ptr, const char *MAYBE_UNUSED(ptr_end), rb_encoding *enc)
 {
     return rb_enc_isalnum((unsigned char)*ptr, enc) || *ptr == '_' || !ISASCII(*ptr);

--- a/ruby_parser.c
+++ b/ruby_parser.c
@@ -791,7 +791,6 @@ rb_parser_config_initialize(rb_parser_config_t *config)
     config->strtod      = ruby_strtod;
 
     config->isspace = rb_isspace;
-    config->isascii = rb_isascii;
     config->iscntrl = rb_iscntrl;
     config->isalpha = rb_isalpha;
     config->isdigit = rb_isdigit;

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -588,7 +588,6 @@ typedef struct rb_parser_config_struct {
 
     /* ctype */
     int (*isspace)(int c);
-    int (*isascii)(int c);
     int (*iscntrl)(int c);
     int (*isalpha)(int c);
     int (*isdigit)(int c);


### PR DESCRIPTION
Move to `ISASCII` defination to parse.y for universal parser.