### PR TITLE
YJIT: Use --yjit-exec-mem-size=128 by default

### DIFF
--- a/ruby.c
+++ b/ruby.c
@@ -366,7 +366,7 @@ usage(const char *name, int help, int highlight, int columns)
         M("--yjit-stats",                    "", "Enable collecting YJIT statistics"),
         M("--yjit-trace-exits",              "", "Record Ruby source location when exiting from generated code"),
         M("--yjit-trace-exits-sample-rate",  "", "Trace exit locations only every Nth occurrence"),
-        M("--yjit-exec-mem-size=num",        "", "Size of executable memory block in MiB (default: 64)"),
+        M("--yjit-exec-mem-size=num",        "", "Size of executable memory block in MiB (default: 128)"),
         M("--yjit-call-threshold=num",       "", "Number of calls to trigger JIT (default: 30)"),
         M("--yjit-max-versions=num",         "", "Maximum number of versions per basic block (default: 4)"),
         M("--yjit-greedy-versioning",        "", "Greedy versioning mode (default: disabled)"),

--- a/yjit/src/options.rs
+++ b/yjit/src/options.rs
@@ -54,7 +54,7 @@ pub struct Options {
 
 // Initialize the options to default values
 pub static mut OPTIONS: Options = Options {
-    exec_mem_size: 64 * 1024 * 1024,
+    exec_mem_size: 128 * 1024 * 1024,
     call_threshold: 30,
     greedy_versioning: false,
     no_type_prop: false,


### PR DESCRIPTION
discussion: https://github.com/Shopify/ruby/issues/520#issuecomment-1622278658

64MiB was a fair size for SFR on Ruby 3.2 and it's more than enough for SFR on Ruby 3.3. However, as of Ruby 3.2, Core currently needs 256MiB. It'd be nice to bump the default a little bit for applications larger than SFR. The 128MiB default is still compatible with https://github.com/ruby/ruby/pull/7671 for arm64.