### PR TITLE
Fix autosplat conditions to handle ruby2_keywords case

### DIFF
--- a/test/ruby/test_proc.rb
+++ b/test/ruby/test_proc.rb
@@ -1322,14 +1322,29 @@ class TestProc < Test::Unit::TestCase
   end
 
   def test_proc_autosplat_with_multiple_args_with_ruby2_keywords_splat_bug_19759
-    def self.yielder(splat)
+    def self.yielder_ab(splat)
       yield([:a, :b], *splat)
     end
 
-    res = yielder([[:aa, :bb], Hash.ruby2_keywords_hash({k: :k})]) do |a, b, k:|
+    res = yielder_ab([[:aa, :bb], Hash.ruby2_keywords_hash({k: :k})]) do |a, b, k:|
       [a, b, k]
     end
     assert_equal([[:a, :b], [:aa, :bb], :k], res)
+
+    def self.yielder(splat)
+      yield(*splat)
+    end
+    res = yielder([ [:a, :b] ]){|a, b, **| [a, b]}
+    assert_equal([:a, :b], res)
+
+    res = yielder([ [:a, :b], Hash.ruby2_keywords_hash({}) ]){|a, b, **| [a, b]}
+    assert_equal([[:a, :b], nil], res)
+
+    res = yielder([ [:a, :b], Hash.ruby2_keywords_hash({c: 1}) ]){|a, b, **| [a, b]}
+    assert_equal([[:a, :b], nil], res)
+
+    res = yielder([ [:a, :b], Hash.ruby2_keywords_hash({}) ]){|a, b, **nil| [a, b]}
+    assert_equal([[:a, :b], nil], res)
   end
 
   def test_parameters_lambda

--- a/test/ruby/test_proc.rb
+++ b/test/ruby/test_proc.rb
@@ -1321,6 +1321,17 @@ class TestProc < Test::Unit::TestCase
     assert_empty(pr.parameters.map{|_,n|n}.compact)
   end
 
+  def test_proc_autosplat_with_multiple_args_with_ruby2_keywords_splat_bug_19759
+    def self.yielder(splat)
+      yield([:a, :b], *splat)
+    end
+
+    res = yielder([[:aa, :bb], Hash.ruby2_keywords_hash({k: :k})]) do |a, b, k:|
+      [a, b, k]
+    end
+    assert_equal([[:a, :b], [:aa, :bb], :k], res)
+  end
+
   def test_parameters_lambda
     assert_equal([], proc {}.parameters(lambda: true))
     assert_equal([], proc {||}.parameters(lambda: true))

--- a/vm_args.c
+++ b/vm_args.c
@@ -640,7 +640,7 @@ setup_parameters_complex(rb_execution_context_t * const ec, const rb_iseq_t * co
       case arg_setup_method:
         break; /* do nothing special */
       case arg_setup_block:
-        if (given_argc == ((NIL_P(keyword_hash) || !calling->kw_splat) ? 1 : 2) &&
+        if (given_argc == 1 &&
             allow_autosplat &&
             (min_argc > 0 || ISEQ_BODY(iseq)->param.opt_num > 1) &&
             !ISEQ_BODY(iseq)->param.flags.ambiguous_param0 &&

--- a/vm_args.c
+++ b/vm_args.c
@@ -640,7 +640,7 @@ setup_parameters_complex(rb_execution_context_t * const ec, const rb_iseq_t * co
       case arg_setup_method:
         break; /* do nothing special */
       case arg_setup_block:
-        if (given_argc == (NIL_P(keyword_hash) ? 1 : 2) &&
+        if (given_argc == ((NIL_P(keyword_hash) || !calling->kw_splat) ? 1 : 2) &&
             allow_autosplat &&
             (min_argc > 0 || ISEQ_BODY(iseq)->param.opt_num > 1) &&
             !ISEQ_BODY(iseq)->param.flags.ambiguous_param0 &&

--- a/vm_args.c
+++ b/vm_args.c
@@ -642,6 +642,7 @@ setup_parameters_complex(rb_execution_context_t * const ec, const rb_iseq_t * co
       case arg_setup_block:
         if (given_argc == 1 &&
             allow_autosplat &&
+            !splat_flagged_keyword_hash &&
             (min_argc > 0 || ISEQ_BODY(iseq)->param.opt_num > 1) &&
             !ISEQ_BODY(iseq)->param.flags.ambiguous_param0 &&
             !((ISEQ_BODY(iseq)->param.flags.has_kw ||


### PR DESCRIPTION
Autosplat should not occur if there are two arguments but second argument is an array containing a ruby2_keywords splat.

Fixes [Bug #19759]