### PR TITLE
Remove unused ISASCII definition

### DIFF
--- a/universal_parser.c
+++ b/universal_parser.c
@@ -345,8 +345,6 @@ struct rb_imemo_tmpbuf_struct {
 
 #undef ISSPACE
 #define ISSPACE(c)  ((p->config->isspace)(c))
-#undef ISASCII
-#define ISASCII(c)  ((p->config->isascii)(c))
 #undef ISCNTRL
 #define ISCNTRL(c)  ((p->config->iscntrl)(c))
 #undef ISALPHA


### PR DESCRIPTION
- Removed ISASCII definition from universal_parser.c
- The ISASCII definition was moved to parse.y, but the old definition wasn't removed.
    - https://github.com/ruby/ruby/pull/8029