### PR TITLE
Move some macro for universal parser 

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -201,6 +201,87 @@ new_strterm(VALUE v1, VALUE v2, VALUE v3, VALUE v0, int heredoc)
 }
 #endif /* !UNIVERSAL_PARSER */
 
+static inline int
+parse_isascii(int c)
+{
+    return '\0' <= c && c <= '\x7f';
+}
+
+#undef ISASCII
+#define ISASCII parse_isascii
+
+static inline int
+parse_isspace(int c)
+{
+    return c == ' ' || ('\t' <= c && c <= '\r');
+}
+
+#undef ISSPACE
+#define ISSPACE parse_isspace
+
+static inline int
+parse_iscntrl(int c)
+{
+    return ('\0' <= c && c < ' ') || c == '\x7f';
+}
+
+#undef ISCNTRL
+#define ISCNTRL(c) parse_iscntrl(c)
+
+static inline int
+parse_isupper(int c)
+{
+    return 'A' <= c && c <= 'Z';
+}
+
+static inline int
+parse_islower(int c)
+{
+    return 'a' <= c && c <= 'z';
+}
+
+static inline int
+parse_isalpha(int c)
+{
+    return parse_isupper(c) || parse_islower(c);
+}
+
+#undef ISALPHA
+#define ISALPHA(c) parse_isalpha(c)
+
+static inline int
+parse_isdigit(int c)
+{
+    return '0' <= c && c <= '9';
+}
+
+#undef ISDIGIT
+#define ISDIGIT(c) parse_isdigit(c)
+
+static inline int
+parse_isalnum(int c)
+{
+    return parse_isalpha(c) || parse_isdigit(c);
+}
+
+#undef ISALNUM
+#define ISALNUM(c) parse_isalnum(c)
+
+static inline int
+parse_isxdigit(int c)
+{
+    return parse_isdigit(c) || ('A' <= c && c <= 'F') || ('a' <= c && c <= 'f');
+}
+
+#undef ISXDIGIT
+#define ISXDIGIT(c) parse_isxdigit(c)
+
+#undef STRCASECMP
+#define STRCASECMP st_locale_insensitive_strcasecmp
+
+#undef STRNCASECMP
+#define STRNCASECMP st_locale_insensitive_strncasecmp
+
 #ifdef RIPPER
 #include "ripper_init.h"
 #endif
@@ -6350,17 +6431,6 @@ ripper_dispatch_delayed_token(struct parser_params *p, enum yytokentype t)
 }
 #define dispatch_delayed_token(p, t) ripper_dispatch_delayed_token(p, t)
 #endif /* RIPPER */
-
-static inline int
-parse_isascii(int c)
-{
-    return '\0' <= c && c <= '\x7f';
-}
-
-#ifdef ISASCII
-#undef ISASCII
-#define ISASCII parse_isascii
-#endif
 
 static inline int
 is_identchar(struct parser_params *p, const char *ptr, const char *MAYBE_UNUSED(ptr_end), rb_encoding *enc)

--- a/ruby_parser.c
+++ b/ruby_parser.c
@@ -790,15 +790,6 @@ rb_parser_config_initialize(rb_parser_config_t *config)
     config->scan_digits = ruby_scan_digits;
     config->strtod      = ruby_strtod;
 
-    config->isspace = rb_isspace;
-    config->iscntrl = rb_iscntrl;
-    config->isalpha = rb_isalpha;
-    config->isdigit = rb_isdigit;
-    config->isalnum = rb_isalnum;
-    config->isxdigit = rb_isxdigit;
-    config->strcasecmp = st_locale_insensitive_strcasecmp;
-    config->strncasecmp = st_locale_insensitive_strncasecmp;
-
     config->rbool = rbool;
     config->undef_p = undef_p;
     config->rtest = rtest;

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -586,16 +586,6 @@ typedef struct rb_parser_config_struct {
     unsigned long (*scan_digits)(const char *str, ssize_t len, int base, size_t *retlen, int *overflow);
     double (*strtod)(const char *s00, char **se);
 
-    /* ctype */
-    int (*isspace)(int c);
-    int (*iscntrl)(int c);
-    int (*isalpha)(int c);
-    int (*isdigit)(int c);
-    int (*isalnum)(int c);
-    int (*isxdigit)(int c);
-    int (*strcasecmp)(const char *s1, const char *s2);
-    int (*strncasecmp)(const char *s1, const char *s2, size_t n);
-
     /* Misc */
     VALUE (*rbool)(VALUE);
     int (*undef_p)(VALUE);

--- a/universal_parser.c
+++ b/universal_parser.c
@@ -343,23 +343,6 @@ struct rb_imemo_tmpbuf_struct {
 #define ruby_scan_digits p->config->scan_digits
 #define strtod           p->config->strtod
 
-#undef ISSPACE
-#define ISSPACE(c)  ((p->config->isspace)(c))
-#undef ISCNTRL
-#define ISCNTRL(c)  ((p->config->iscntrl)(c))
-#undef ISALPHA
-#define ISALPHA(c)  ((p->config->isalpha)(c))
-#undef ISDIGIT
-#define ISDIGIT(c)  ((p->config->isdigit)(c))
-#undef ISALNUM
-#define ISALNUM(c)  ((p->config->isalnum)(c))
-#undef ISXDIGIT
-#define ISXDIGIT(c) ((p->config->isxdigit)(c))
-#undef STRCASECMP
-#define STRCASECMP p->config->strcasecmp
-#undef STRNCASECMP
-#define STRNCASECMP p->config->strncasecmp
-
 #undef RBOOL
 #define RBOOL p->config->rbool
 #undef UNDEF_P


### PR DESCRIPTION
Move some macro that defined in ``internal/ctype.h`` to `parse.y` .
