### PR TITLE
Make `rb_str_rindex` return byte index

### DIFF
--- a/benchmark/string_rpartition.yml
+++ b/benchmark/string_rpartition.yml
@@ -1,0 +1,18 @@
+prelude: |
+  str1 = [*"a".."z",*"0".."9"].join("")
+  str10 = str1 * 10 + ":"
+  str100 = str1 * 100 + ":"
+  str1000 = str1 * 1000 + ":"
+  nonascii1 = [*"\u{e0}".."\u{ff}"].join("")
+  nonascii10 = nonascii1 * 10 + ":"
+  nonascii100 = nonascii1 * 100 + ":"
+  nonascii1000 = nonascii1 * 1000 + ":"
+benchmark:
+  rpartition-1: str1.rpartition(":")
+  rpartition-10: str10.rpartition(":")
+  rpartition-100: str100.rpartition(":")
+  rpartition-1000: str1000.rpartition(":")
+  rpartition-nonascii1: nonascii1.rpartition(":")
+  rpartition-nonascii10: nonascii10.rpartition(":")
+  rpartition-nonascii100: nonascii100.rpartition(":")
+  rpartition-nonascii1000: nonascii1000.rpartition(":")

--- a/string.c
+++ b/string.c
@@ -3809,6 +3809,7 @@ strseq_core(const char *str_ptr, const char *str_ptr_end, long str_len,
 
 /* found index in byte */
 #define rb_str_index(str, sub, offset) rb_strseq_index(str, sub, offset, 0)
+#define rb_str_byteindex(str, sub, offset) rb_strseq_index(str, sub, offset, 1)
 
 static long
 rb_strseq_index(VALUE str, VALUE sub, long offset, int in_byte)
@@ -3866,33 +3867,24 @@ rb_str_index_m(int argc, VALUE *argv, VALUE str)
     long pos;
 
     if (rb_scan_args(argc, argv, "11", &sub, &initpos) == 2) {
+        long slen = str_strlen(str, enc); /* str's enc */
         pos = NUM2LONG(initpos);
-    }
-    else {
-        pos = 0;
-    }
-    if (pos < 0) {
-        pos += str_strlen(str, NULL);
-        if (pos < 0) {
+        if (pos < 0 ? (pos += slen) < 0 : pos > slen) {
             if (RB_TYPE_P(sub, T_REGEXP)) {
                 rb_backref_set(Qnil);
             }
             return Qnil;
         }
     }
+    else {
+        pos = 0;
+    }
 
     if (RB_TYPE_P(sub, T_REGEXP)) {
-        if (pos > str_strlen(str, NULL)) {
-            rb_backref_set(Qnil);
-            return Qnil;
-        }
         pos = str_offset(RSTRING_PTR(str), RSTRING_END(str), pos,
                          enc, single_byte_optimizable(str));
 
-        if (rb_reg_search(sub, str, pos, 0) < 0) {
-            return Qnil;
-        }
-        else {
+        if (rb_reg_search(sub, str, pos, 0) >= 0) {
             VALUE match = rb_backref_get();
             struct re_registers *regs = RMATCH_REGS(match);
             pos = rb_str_sublen(str, BEG(0));
@@ -3902,11 +3894,12 @@ rb_str_index_m(int argc, VALUE *argv, VALUE str)
     else {
         StringValue(sub);
         pos = rb_str_index(str, sub, pos);
-        pos = rb_str_sublen(str, pos);
+        if (pos >= 0) {
+            pos = rb_str_sublen(str, pos);
+            return LONG2NUM(pos);
+        }
     }
-
-    if (pos == -1) return Qnil;
-    return LONG2NUM(pos);
+    return Qnil;
 }
 
 /* Ensure that the given pos is a valid character boundary.
@@ -3977,10 +3970,7 @@ rb_str_byteindex_m(int argc, VALUE *argv, VALUE str)
     if (rb_scan_args(argc, argv, "11", &sub, &initpos) == 2) {
         long slen = RSTRING_LEN(str);
         pos = NUM2LONG(initpos);
-        if (pos < 0) {
-            pos += slen;
-        }
-        if (pos < 0 || pos > slen) {
+        if (pos < 0 ? (pos += slen) < 0 : pos > slen) {
             if (RB_TYPE_P(sub, T_REGEXP)) {
                 rb_backref_set(Qnil);
             }
@@ -3994,10 +3984,7 @@ rb_str_byteindex_m(int argc, VALUE *argv, VALUE str)
     str_ensure_byte_pos(str, pos);
 
     if (RB_TYPE_P(sub, T_REGEXP)) {
-        if (rb_reg_search(sub, str, pos, 0) < 0) {
-            return Qnil;
-        }
-        else {
+        if (rb_reg_search(sub, str, pos, 0) >= 0) {
             VALUE match = rb_backref_get();
             struct re_registers *regs = RMATCH_REGS(match);
             pos = BEG(0);
@@ -4006,11 +3993,10 @@ rb_str_byteindex_m(int argc, VALUE *argv, VALUE str)
     }
     else {
         StringValue(sub);
-        pos = rb_strseq_index(str, sub, pos, 1);
+        pos = rb_str_byteindex(str, sub, pos);
+        if (pos >= 0) return LONG2NUM(pos);
     }
-
-    if (pos == -1) return Qnil;
-    return LONG2NUM(pos);
+    return Qnil;
 }
 
 #ifdef HAVE_MEMRCHR
@@ -4163,20 +4149,17 @@ static VALUE
 rb_str_rindex_m(int argc, VALUE *argv, VALUE str)
 {
     VALUE sub;
-    VALUE vpos;
+    VALUE initpos;
     rb_encoding *enc = STR_ENC_GET(str);
     long pos, len = str_strlen(str, enc); /* str's enc */
 
-    if (rb_scan_args(argc, argv, "11", &sub, &vpos) == 2) {
-        pos = NUM2LONG(vpos);
-        if (pos < 0) {
-            pos += len;
-            if (pos < 0) {
-                if (RB_TYPE_P(sub, T_REGEXP)) {
-                    rb_backref_set(Qnil);
-                }
-                return Qnil;
+    if (rb_scan_args(argc, argv, "11", &sub, &initpos) == 2) {
+        pos = NUM2LONG(initpos);
+        if (pos < 0 && (pos += len) < 0) {
+            if (RB_TYPE_P(sub, T_REGEXP)) {
+                rb_backref_set(Qnil);
             }
+            return Qnil;
         }
         if (pos > len) pos = len;
     }
@@ -4302,19 +4285,16 @@ static VALUE
 rb_str_byterindex_m(int argc, VALUE *argv, VALUE str)
 {
     VALUE sub;
-    VALUE vpos;
+    VALUE initpos;
     long pos, len = RSTRING_LEN(str);
 
-    if (rb_scan_args(argc, argv, "11", &sub, &vpos) == 2) {
-        pos = NUM2LONG(vpos);
-        if (pos < 0) {
-            pos += len;
-            if (pos < 0) {
-                if (RB_TYPE_P(sub, T_REGEXP)) {
-                    rb_backref_set(Qnil);
-                }
-                return Qnil;
+    if (rb_scan_args(argc, argv, "11", &sub, &initpos) == 2) {
+        pos = NUM2LONG(initpos);
+        if (pos < 0 && (pos += len) < 0) {
+            if (RB_TYPE_P(sub, T_REGEXP)) {
+                rb_backref_set(Qnil);
             }
+            return Qnil;
         }
         if (pos > len) pos = len;
     }
@@ -5570,7 +5550,7 @@ static long
 rb_pat_search(VALUE pat, VALUE str, long pos, int set_backref_str)
 {
     if (BUILTIN_TYPE(pat) == T_STRING) {
-        pos = rb_strseq_index(str, pat, pos, 1);
+        pos = rb_str_byteindex(str, pat, pos);
         if (set_backref_str) {
             if (pos >= 0) {
                 str = rb_str_new_frozen_String(str);

--- a/string.c
+++ b/string.c
@@ -3807,6 +3807,7 @@ strseq_core(const char *str_ptr, const char *str_ptr_end, long str_len,
     return pos + offset;
 }
 
+/* found index in byte */
 #define rb_str_index(str, sub, offset) rb_strseq_index(str, sub, offset, 0)
 
 static long
@@ -4068,6 +4069,7 @@ str_rindex(VALUE str, VALUE sub, const char *s, rb_encoding *enc)
 }
 #endif
 
+/* found index in byte */
 static long
 rb_str_rindex(VALUE str, VALUE sub, long pos)
 {
@@ -4097,7 +4099,7 @@ rb_str_rindex(VALUE str, VALUE sub, long pos)
     }
 
     s = str_nth(sbeg, RSTRING_END(str), pos, enc, singlebyte);
-    return rb_str_sublen(str, str_rindex(str, sub, s, enc));
+    return str_rindex(str, sub, s, enc);
 }
 
 /*
@@ -4197,7 +4199,10 @@ rb_str_rindex_m(int argc, VALUE *argv, VALUE str)
     else {
         StringValue(sub);
         pos = rb_str_rindex(str, sub, pos);
-        if (pos >= 0) return LONG2NUM(pos);
+        if (pos >= 0) {
+            pos = rb_str_sublen(str, pos);
+            return LONG2NUM(pos);
+        }
     }
     return Qnil;
 }
@@ -10425,7 +10430,6 @@ rb_str_rpartition(VALUE str, VALUE sep)
         if (pos < 0) {
             goto failed;
         }
-        pos = rb_str_offset(str, pos);
     }
 
     return rb_ary_new3(3, rb_str_subseq(str, 0, pos),


### PR DESCRIPTION
Leave callers to convert byte index to char index, as well as `rb_str_index`, so that `rb_str_rpartition` does not need to re-convert char index to byte index.

Trivial benchmark against 5f915108da.

|                         |compare-ruby|built-ruby|
|:------------------------|-----------:|---------:|
|rpartition-1             |      2.318M|    2.442M|
|                         |           -|     1.05x|
|rpartition-10            |      4.444M|    4.624M|
|                         |           -|     1.04x|
|rpartition-100           |    980.295k|  927.214k|
|                         |       1.06x|         -|
|rpartition-1000          |     94.950k|   96.553k|
|                         |           -|     1.02x|
|rpartition-nonascii1     |      1.425M|    1.470M|
|                         |           -|     1.03x|
|rpartition-nonascii10    |    225.196k|  377.620k|
|                         |           -|     1.68x|
|rpartition-nonascii100   |     23.752k|   43.870k|
|                         |           -|     1.85x|
|rpartition-nonascii1000  |      2.320k|    4.296k|
|                         |           -|     1.85x|
