### PR TITLE
Reuse rb_ractor_make_shareable function for rb_ractor_make_shareable_copy function

### DIFF
--- a/ractor.c
+++ b/ractor.c
@@ -2925,10 +2925,7 @@ VALUE
 rb_ractor_make_shareable_copy(VALUE obj)
 {
     VALUE copy = ractor_copy(obj);
-    rb_obj_traverse(copy,
-                    make_shareable_check_shareable,
-                    null_leave, mark_shareable);
-    return copy;
+    return rb_ractor_make_shareable(copy);
 }
 
 VALUE


### PR DESCRIPTION
`rb_ractor_make_shareable_copy` function has almost same code as `rb_ractor_make_shareable`.
I thoght better to reuse `rb_ractor_make_shareable` function in `rb_ractor_make_shareable_copy` that more simply.