### PR TITLE
Serially update only the ripper source, even with old GNU make

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1268,8 +1268,7 @@ $(REVISION_H)$(yes_baseruby:yes=~disabled~):
 # uncommon.mk: $(REVISION_H)
 # $(MKFILES): $(REVISION_H)
 
-ripper_srcs: $(RIPPER_SRCS)
-.NOTPARALLEL: ripper_srcs
+$(DOT_WAIT)ripper_srcs: $(RIPPER_SRCS)
 
 $(RIPPER_SRCS): $(srcdir)/parse.y $(srcdir)/defs/id.def
 $(RIPPER_SRCS): $(srcdir)/ext/ripper/tools/preproc.rb $(srcdir)/ext/ripper/tools/dsl.rb

--- a/defs/gmake.mk
+++ b/defs/gmake.mk
@@ -495,3 +495,12 @@ matz: up
 
 tags:
 	$(MAKE) GIT="$(GIT)" -C "$(srcdir)" -f defs/tags.mk
+
+ifneq ($(DOT_WAIT),)
+ripper_srcs: $(addprefix $(DOT_WAIT) ,$(RIPPER_SRCS))
+else
+ripper_src =
+$(foreach r,$(RIPPER_SRCS),$(eval $(value r): | $(value ripper_src))\
+	$(eval ripper_src := $(value r)))
+ripper_srcs: $(ripper_src)
+endif


### PR DESCRIPTION
3cfcd3d1663169ad68e22e5efef35f8057173993 makes all serial with GNU make 4.3 or earlier.