### PR TITLE
[DOC] fix formatting - bsearch.rdoc & getoptLong.rb

### DIFF
--- a/doc/bsearch.rdoc
+++ b/doc/bsearch.rdoc
@@ -29,7 +29,7 @@ Find-any mode:: method +bsearch+ some element, if any, for which
 The block should not mix the modes by sometimes returning +true+ or +false+
 and other times returning a numeric value, but this is not checked.
 
-<b>Find-Minimum Mode</b>
+=== Find-Minimum Mode
 
 In find-minimum mode, the block must return +true+ or +false+.
 The further requirement (though not checked) is that
@@ -72,7 +72,7 @@ This would not make sense:
 
   a.map {|x| x == 7 } # => [false, false, true, false, false]
 
-<b>Find-Any Mode</b>
+=== Find-Any Mode
 
 In find-any mode, the block must return a numeric value.
 The further requirement (though not checked) is that

--- a/lib/getoptlong.rb
+++ b/lib/getoptlong.rb
@@ -352,7 +352,7 @@
 #
 # Command line:
 #
-# $ ruby fibonacci.rb --number 6 --verbose yes
+#   $ ruby fibonacci.rb --number 6 --verbose yes
 #
 # Output:
 #


### PR DESCRIPTION
These are intended to be as sub-headings, but as they are, they blend in with the rest of the text.

This change makes them stand out more.

https://docs.ruby-lang.org/en/master/bsearch_rdoc.html