### PR TITLE
Try to fix flaky GC test

### DIFF
--- a/test/ruby/test_gc.rb
+++ b/test/ruby/test_gc.rb
@@ -262,9 +262,12 @@ class TestGc < Test::Unit::TestCase
       objects.append(100.times.map { '*' })
     end
 
-    assert_not_nil GC.latest_gc_info(:need_major_by)
+    need_major_by = GC.latest_gc_info(:need_major_by)
     GC.start(full_mark: false) # should be upgraded to major
-    assert_not_nil GC.latest_gc_info(:major_by)
+    major_by = GC.latest_gc_info(:major_by)
+
+    assert_not_nil(need_major_by)
+    assert_not_nil(major_by)
   end
 
   def test_stress_compile_send


### PR DESCRIPTION
assert_not_nil could allocate objects which may trigger the major GC, so don't run the assertions until the major GC has been ran.