### PR TITLE
[DOC] Add spaces to fix formatting in example - getoptlong.rb

### DIFF
--- a/lib/getoptlong.rb
+++ b/lib/getoptlong.rb
@@ -352,7 +352,7 @@
 #
 # Command line:
 #
-# $ ruby fibonacci.rb --number 6 --verbose yes
+#   $ ruby fibonacci.rb --number 6 --verbose yes
 #
 # Output:
 #


### PR DESCRIPTION
The very last example on the page here, under "Command line:":

https://docs.ruby-lang.org/en/master/GetoptLong.html

the example doesn't show the code properly formatted, so I added two spaces to match the other examples