### PR TITLE
[DOC] Add parenthetical to explain what FIFO abbrev means - thread_sync.c

### DIFF
--- a/thread_sync.c
+++ b/thread_sync.c
@@ -846,8 +846,8 @@ queue_closed_result(VALUE self, struct rb_queue *q)
  *  information must be exchanged safely between multiple threads. The
  *  Thread::Queue class implements all the required locking semantics.
  *
- *  The class implements FIFO type of queue. In a FIFO queue, the first
- *  tasks added are the first retrieved.
+ *  The class implements FIFO (first in, first out) type of queue.
+ *  In a FIFO queue, the first tasks added are the first retrieved.
  *
  *  Example:
  *


### PR DESCRIPTION
Whenever I read an acronym/abbreviation/initialism, I always wish that there was an explanation of what the abbreviation means.

This PR adds an explanatory parenthetical to the first mention of `FIFO` in the `Thread::Queue` docs. For clarity and disambiguation. 