### PR TITLE
[DOC] Fix example code indentation from 3 to 2 spaces - thread_sync.c

### DIFF
--- a/thread_sync.c
+++ b/thread_sync.c
@@ -855,17 +855,17 @@ queue_closed_result(VALUE self, struct rb_queue *q)
  *
  *	producer = Thread.new do
  *	  5.times do |i|
- *	     sleep rand(i) # simulate expense
- *	     queue << i
- *	     puts "#{i} produced"
+ *	    sleep rand(i) # simulate expense
+ *	    queue << i
+ *	    puts "#{i} produced"
  *	  end
  *	end
  *
  *	consumer = Thread.new do
  *	  5.times do |i|
- *	     value = queue.pop
- *	     sleep rand(i/2) # simulate expense
- *	     puts "consumed #{value}"
+ *	    value = queue.pop
+ *	    sleep rand(i/2) # simulate expense
+ *	    puts "consumed #{value}"
  *	  end
  *	end
  *


### PR DESCRIPTION
The first code example in `Thread::Queue` docs has three spaces for indentation on a few lines, instead of two. This PR outdents those lines back to two spaces.

<img width="611" alt="Screenshot 2023-07-12 at 5 12 21 PM" src="https://github.com/ruby/ruby/assets/4361/d19a9119-f728-4cfd-a0b2-aad764a8e02a">
