### PR TITLE
Supress warning that variable may be used uninitialized  with ripper building

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -11335,7 +11335,7 @@ id_is_var(struct parser_params *p, ID id)
 static VALUE
 new_regexp(struct parser_params *p, VALUE re, VALUE opt, const YYLTYPE *loc)
 {
-    VALUE src = 0, err;
+    VALUE src = 0, err = 0;
     int options = 0;
     if (ripper_is_node_yylval(p, re)) {
         src = RNODE(re)->nd_cval;


### PR DESCRIPTION
I saw these warning when build head ruby.

```bash
extracting ripper.y from ../../../ruby/parse.y
compiling compiler ripper.y
compiling ripper.c
ripper.c: In function ‘ripper_yyparse’:
parse.y:1434:24: warning: ‘err’ may be used uninitialized in this function [-Wmaybe-uninitialized]
parse.y:11336:20: note: ‘err’ was declared here
parse.y: At top level:
cc1: warning: unrecognized command line option ‘-Wno-self-assign’
cc1: warning: unrecognized command line option ‘-Wno-parentheses-equality’
cc1: warning: unrecognized command line option ‘-Wno-constant-logical-operand’
generating ripper_init.c from ../../../ruby/ext/ripper/ripper_init.c.tmpl
compiling ripper_init.c
linking shared-object ripper.so
```

This pull request supress these warning.