### PR TITLE
Fix `#line` directive filename of ripper.c

### DIFF
--- a/ext/ripper/depend
+++ b/ext/ripper/depend
@@ -12,7 +12,7 @@ ripper.o: ripper.c
 
 .y.c:
 	$(ECHO) compiling compiler $<
-	$(Q) $(BISON) -t -v -o$@ -h$*.h - parse.y < $<
+	$(Q) $(BISON) -t -v -o$@ -h$*.h - $< < $<
 
 all: check
 static: check


### PR DESCRIPTION
Before:

```c
/* First part of user prologue.  */
#line 14 "parse.y"
```

After:

```c
/* First part of user prologue.  */
#line 14 "ripper.y"
```