### PR TITLE
Fix SEGV of ripper_s_allocate

### DIFF
--- a/ext/ripper/ripper_init.c.tmpl
+++ b/ext/ripper/ripper_init.c.tmpl
@@ -109,18 +109,19 @@ static VALUE
 ripper_s_allocate(VALUE klass)
 {
     struct ripper *r;
-
-    VALUE self = TypedData_Make_Struct(klass, struct ripper,
-                                       &parser_data_type, r);
+    struct parser_params* p;
 
 #ifdef UNIVERSAL_PARSER
     rb_parser_config_t *config;
     config = rb_ruby_parser_config_new(ruby_xmalloc);
     rb_parser_config_initialize(config);
-    r->p = rb_ruby_parser_allocate(config);
+    p = rb_ruby_parser_allocate(config);
 #else
-    r->p = rb_ruby_ripper_parser_allocate();
+    p = rb_ruby_ripper_parser_allocate();
 #endif
+    VALUE self = TypedData_Make_Struct(klass, struct ripper,
+                                       &parser_data_type, r);
+    r->p = p;
     rb_ruby_parser_set_value(r->p, self);
     return self;
 }


### PR DESCRIPTION
`rb_ruby_ripper_parser_allocate` calls `ruby_xcalloc` which runs GC. If GC runs inside of `rb_ruby_ripper_parser_allocate`, struct ripper allocated by `TypedData_Make_Struct` is marked even so the struct is not fully initialized. This causes SEGV when `rb_parser_t *p` is marked. Fix the order of allocation so that mark for struct ripper doesn't cause SEGV on `rb_ruby_parser_mark`.

Fix http://ci.rvm.jp/results/trunk-random1@ruby-sp2-docker/4647472