### PR TITLE
Fix null pointer access in Ripper#initialize

### DIFF
--- a/ext/ripper/ripper_init.c.tmpl
+++ b/ext/ripper/ripper_init.c.tmpl
@@ -25,14 +25,14 @@ static void
 ripper_parser_mark2(void *ptr)
 {
     struct ripper *r = (struct ripper*)ptr;
-    ripper_parser_mark(r->p);
+    if (r->p) ripper_parser_mark(r->p);
 }
 
 static void
 ripper_parser_free2(void *ptr)
 {
     struct ripper *r = (struct ripper*)ptr;
-    ripper_parser_free(r->p);
+    if (r->p) ripper_parser_free(r->p);
     xfree(r);
 }
 
@@ -40,7 +40,7 @@ static size_t
 ripper_parser_memsize2(const void *ptr)
 {
     struct ripper *r = (struct ripper*)ptr;
-    return ripper_parser_memsize(r->p);
+    return (r->p) ? ripper_parser_memsize(r->p) : 0;
 }
 
 static const rb_data_type_t parser_data_type = {

--- a/test/ripper/test_ripper.rb
+++ b/test/ripper/test_ripper.rb
@@ -14,6 +14,13 @@ class TestRipper::Ripper < Test::Unit::TestCase
     @ripper = Ripper.new '1 + 1'
   end
 
+  def test_new
+    assert_separately(%w[-rripper], "#{<<~"begin;"}\n#{<<~'end;'}")
+    begin;
+      assert_nil EnvUtil.under_gc_stress {Ripper.new("")}.state
+    end;
+  end
+
   def test_column
     assert_nil @ripper.column
   end


### PR DESCRIPTION
In `rb_ruby_ripper_parser_allocate`, `r->p` is NULL between creating `self` and `parser_params` assignment.  As GC can happen there, the typed-data functions for it need to consider the case.