### PR TITLE
Allocate Ripper struct before use

### DIFF
--- a/ext/ripper/ripper_init.c.tmpl
+++ b/ext/ripper/ripper_init.c.tmpl
@@ -108,10 +108,7 @@ ripper_lex_io_get(struct parser_params *p, VALUE src)
 static VALUE
 ripper_s_allocate(VALUE klass)
 {
-    struct ripper *r;
-
-    VALUE self = TypedData_Make_Struct(klass, struct ripper,
-                                       &parser_data_type, r);
+    struct ripper *r = (struct ripper *)ruby_xcalloc(1, sizeof(struct ripper));
 
 #ifdef UNIVERSAL_PARSER
     rb_parser_config_t *config;
@@ -121,6 +118,8 @@ ripper_s_allocate(VALUE klass)
 #else
     r->p = rb_ruby_ripper_parser_allocate();
 #endif
+    VALUE self = TypedData_Wrap_Struct(klass, &parser_data_type, r);
+
     rb_ruby_parser_set_value(r->p, self);
     return self;
 }


### PR DESCRIPTION
Ruby CI failing build: [4643684](http://ci.rvm.jp/results/trunk-random2@ruby-sp2-docker/4643684)

We need to allocate the ripper struct before we assign a pointer to it inside the T_DATA object. This is because
`rb_ruby_ripper_parse_allocate` can trigger GC, via `ruby_xcalloc`. If GC is triggered before the r->p pointer has been set, we will attempt to mark a `NULL` reference.

This bug can be replicated using the following test script.

```
require "ripper"
GC.stress = true
Ripper.new("foobar")
```