### PR TITLE
Lazily allocate pages at boot

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -3713,10 +3713,8 @@ Init_heap(void)
     objspace->rgengc.oldmalloc_increase_limit = gc_params.oldmalloc_limit_min;
 #endif
 
-    heap_add_pages(objspace, &size_pools[0], SIZE_POOL_EDEN_HEAP(&size_pools[0]), gc_params.heap_init_slots / HEAP_PAGE_OBJ_LIMIT);
-
-    /* Give other size pools allocatable pages. */
-    for (int i = 1; i < SIZE_POOL_COUNT; i++) {
+    /* Set size pools allocatable pages. */
+    for (int i = 0; i < SIZE_POOL_COUNT; i++) {
         rb_size_pool_t *size_pool = &size_pools[i];
         int multiple = size_pool->slot_size / BASE_SLOT_SIZE;
         size_pool->allocatable_pages = gc_params.heap_init_slots * multiple / HEAP_PAGE_OBJ_LIMIT;

--- a/test/objspace/test_objspace.rb
+++ b/test/objspace/test_objspace.rb
@@ -632,7 +632,13 @@ class TestObjSpace < Test::Unit::TestCase
       end
     end
 
-    entry_hash = JSON.parse(test_string_in_dump_all[1])
+    strs = test_string_in_dump_all.reject do |s|
+      s.include?("fstring")
+    end
+
+    assert_equal(1, strs.length)
+
+    entry_hash = JSON.parse(strs[0])
 
     assert_equal(5, entry_hash["bytesize"], "bytesize is wrong")
     assert_equal("TEST2", entry_hash["value"], "value is wrong")


### PR DESCRIPTION
We can just set alloctable pages for the first size pool rather than eagerly allocating pages.