### PR TITLE
Allow cvc table entries to move during GC compact

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -10271,12 +10271,13 @@ update_cvc_tbl(rb_objspace_t *objspace, VALUE klass)
 static enum rb_id_table_iterator_result
 mark_cvc_tbl_i(VALUE cvc_entry, void *data)
 {
+    rb_objspace_t *objspace = (rb_objspace_t *)data;
     struct rb_cvar_class_tbl_entry *entry;
 
     entry = (struct rb_cvar_class_tbl_entry *)cvc_entry;
 
     RUBY_ASSERT(entry->cref == 0 || (BUILTIN_TYPE((VALUE)entry->cref) == T_IMEMO && IMEMO_TYPE_P(entry->cref, imemo_cref)));
-    rb_gc_mark((VALUE) entry->cref);
+    gc_mark(objspace, (VALUE) entry->cref);
 
     return ID_TABLE_CONTINUE;
 }


### PR DESCRIPTION
This commit changes `mark_cvc_tbl_i` to not pin the `cref` reference in the `rb_cvar_class_tbl_entry`, which allows them to move during GC compaction.

This has been verified by running `yjit-bench`'s headline benchmarks with `GC.auto_compact` enabled. and caused no crashes and no performance changes.

```
master: ruby 3.3.0dev (2023-07-19T20:15:01Z master 84b5274143) [arm64-darwin22]
mvh-move-cvc-entries: ruby 3.3.0dev (2023-07-19T20:59:17Z mvh-move-cvc-entries f8ffe7996f) [arm64-darwin22]

--------------  -----------  ----------  -------------------------  ----------  ----------------------------  ---------------------------
bench           master (ms)  stddev (%)  mvh-move-cvc-entries (ms)  stddev (%)  mvh-move-cvc-entries 1st itr  master/mvh-move-cvc-entries
activerecord    38.0         5.5         38.6                       6.4         1.00                          0.98
chunky-png      794.7        2.2         795.7                      1.6         1.00                          1.00
erubi-rails     13.3         23.3        13.3                       23.6        1.28                          1.01
hexapdf         1842.9       1.8         1838.7                     1.2         1.00                          1.00
liquid-c        38.4         6.4         38.3                       5.7         1.02                          1.00
liquid-compile  44.9         8.6         45.6                       5.5         1.01                          0.98
liquid-render   109.8        5.4         109.5                      4.6         1.00                          1.00
mail            98.2         7.0         96.6                       1.4         1.12                          1.02
psych-load      2152.5       1.4         1651.0                     0.9         1.28                          1.30
railsbench      1278.8       1.8         1302.2                     1.7         1.01                          0.98
ruby-lsp        50.5         7.4         50.4                       11.0        1.14                          1.00
sequel          41.9         7.2         42.6                       6.2         1.07                          0.98
--------------  -----------  ----------  -------------------------  ----------  ----------------------------  ---------------------------
```