### PR TITLE
YJIT: Rename exec_instruction to yjit_insns_count

### DIFF
--- a/doc/yjit/yjit.md
+++ b/doc/yjit/yjit.md
@@ -216,7 +216,7 @@ irb(main):001:0> RubyVM::YJIT.runtime_stats
 {:inline_code_size=>340745,
  :outlined_code_size=>297664,
  :all_stats=>true,
- :exec_instruction=>1547816,
+ :yjit_insns_count=>1547816,
  :send_callsite_not_simple=>7267,
  :send_kw_splat=>7,
  :send_ivar_set_method=>72,
@@ -225,7 +225,7 @@ irb(main):001:0> RubyVM::YJIT.runtime_stats
 
 Some of the counters include:
 
-:exec_instruction - how many Ruby bytecode instructions have been executed
+:yjit_insns_count - how many Ruby bytecode instructions have been executed
 :binding_allocations - number of bindings allocated
 :binding_set - number of variables set via a binding
 :code_gc_count - number of garbage collections of compiled code since process start

--- a/yjit.rb
+++ b/yjit.rb
@@ -162,7 +162,7 @@ module RubyVM::YJIT
 
     # Number of instructions that finish executing in YJIT.
     # See :count-placement: about the subtraction.
-    retired_in_yjit = stats[:exec_instruction] - side_exits
+    retired_in_yjit = stats[:yjit_insns_count] - side_exits
 
     # Average length of instruction sequences executed by YJIT
     avg_len_in_yjit = total_exits > 0 ? retired_in_yjit.to_f / total_exits : 0
@@ -317,7 +317,7 @@ module RubyVM::YJIT
       out.puts "total_exit_count:      " + format_number(13, stats[:total_exit_count])
       out.puts "total_insns_count:     " + format_number(13, stats[:total_insns_count])
       out.puts "vm_insns_count:        " + format_number(13, stats[:vm_insns_count])
-      out.puts "exec_instruction:      " + format_number(13, stats[:exec_instruction])
+      out.puts "yjit_insns_count:      " + format_number(13, stats[:yjit_insns_count])
       out.puts "ratio_in_yjit:         " + ("%12.1f" % stats[:ratio_in_yjit]) + "%"
       out.puts "avg_len_in_yjit:       " + ("%13.1f" % stats[:avg_len_in_yjit])
 

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -850,7 +850,7 @@ pub fn gen_single_block(
         // :count-placement:
         // Count bytecode instructions that execute in generated code.
         // Note that the increment happens even when the output takes side exit.
-        gen_counter_incr(&mut asm, Counter::exec_instruction);
+        gen_counter_incr(&mut asm, Counter::yjit_insns_count);
 
         // Lookup the codegen function for this instruction
         let mut status = None;

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -202,7 +202,7 @@ pub(crate) use ptr_to_counter;
 
 // Declare all the counters we track
 make_counters! {
-    exec_instruction,
+    yjit_insns_count,
 
     send_keywords,
     send_klass_megamorphic,


### PR DESCRIPTION
It seems more consistent with `vm_insns_count`. 