### PR TITLE
Make gc_mark_ptr have a single responsibility

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -11643,7 +11643,12 @@ static void
 reachable_objects_from_callback(VALUE obj)
 {
     rb_ractor_t *cr = GET_RACTOR();
-    cr->mfd.mark_func(obj, cr->mfd.data);
+    if (LIKELY(!cr->mfd.mark_func)) {
+        gc_mark_ptr(obj, (void *)&rb_objspace);
+    }
+    else {
+        cr->mfd.mark_func(obj, cr->mfd.data);
+    }
 }
 
 void
@@ -13745,8 +13750,8 @@ rb_gcdebug_remove_stress_to_class(int argc, VALUE *argv, VALUE self)
 void
 rb_ractor_init_mfd(rb_ractor_t *r)
 {
-    r->mfd.mark_func = gc_mark_ptr;
-    r->mfd.data = (void *)&rb_objspace;
+    r->mfd.mark_func = NULL;
+    r->mfd.data = NULL;
 }
 
 /*

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -125,6 +125,13 @@ const char *rb_raw_obj_info(char *const buff, const size_t buff_size, VALUE obj)
 
 size_t rb_size_pool_slot_size(unsigned char pool_id);
 
+typedef void (*rb_ractor_value_visitor_func)(VALUE v, void *data);
+
+struct gc_mark_func_data_struct {
+    void *data;
+    rb_ractor_value_visitor_func mark_func;
+};
+
 struct rb_execution_context_struct; /* in vm_core.h */
 struct rb_objspace; /* in vm_core.h */
 
@@ -234,6 +241,7 @@ VALUE rb_gc_id2ref_obj_tbl(VALUE objid);
 VALUE rb_define_finalizer_no_check(VALUE obj, VALUE block);
 
 void rb_gc_mark_and_move(VALUE *ptr);
+void rb_ractor_init_mfd(rb_ractor_t *r);
 
 #define rb_gc_mark_and_move_ptr(ptr) do { \
     VALUE _obj = (VALUE)*(ptr); \

--- a/ractor.c
+++ b/ractor.c
@@ -1903,6 +1903,7 @@ ractor_alloc(VALUE klass)
     VALUE rv = TypedData_Make_Struct(klass, rb_ractor_t, &ractor_data_type, r);
     FL_SET_RAW(rv, RUBY_FL_SHAREABLE);
     r->pub.self = rv;
+    rb_ractor_init_mfd(r);
     VM_ASSERT(ractor_status_p(r, ractor_created));
     return rv;
 }
@@ -1921,7 +1922,7 @@ rb_ractor_main_alloc(void)
     r->name = Qnil;
     r->pub.self = Qnil;
     ruby_single_main_ractor = r;
-
+    rb_ractor_init_mfd(r);
     return r;
 }
 

--- a/ractor_core.h
+++ b/ractor_core.h
@@ -186,10 +186,7 @@ struct rb_ractor_struct {
     rb_ractor_newobj_cache_t newobj_cache;
 
     // gc.c rb_objspace_reachable_objects_from
-    struct gc_mark_func_data_struct {
-        void *data;
-        void (*mark_func)(VALUE v, void *data);
-    } *mfd;
+    struct gc_mark_func_data_struct mfd;
 }; // rb_ractor_t is defined in vm_core.h
 
 


### PR DESCRIPTION
Currently the GC's marking functions functions (`gc_mark`, `gc_mark_ptr`, `gc_mark_children`) are responsible for both marking and object tracing. This becomes awkward when we need to use object tracing for non-GC related purposes (such as dumping the heap).

The current implementation relies on `gc_mark_ptr` having multiple responsibilites depending on whether it's being called during GC or during mutator work - it switches based on `objspace->flags.during_gc`.

If that flag is set it runs marking, and if not it passes the pointer in question to `reachable_objects_from_callback`, which then looks at the current ractor for a function pointer to execute with the pointer as an argument.

This PR removes the conditional from `gc_mark_ptr`. Making it unconditionally mark the pointer.

It then replaces previous calls to `gc_mark_ptr` with calls to `reachable_objects_from_callback`, which will use the ractors mark function callback if it's set, and call `gc_mark_ptr` directly if it's not - This essentially inverts the relationship between gc_marking and object tracing. Implenting marking on top of object tracing, instead of implementing object tracing on top of marking.

So to trace the object graph now, we need to:

1. make sure there is a function pointer attached to the ractor, that will run on each valid pointer.
2. use the iterator function `reachable_objects_from_callback`

One of the challenges involved in walking the object graph, is that we cannot change the api for marking T_DATA objects. The nice thing about the original approach, is that we didn't have to - all marking callbacks in C extension objects will eventually use gc_mark_ptr - because it's used by `rb_gc_mark` which is part of the public API.

This new approach also doesn't require changing the public API. We implement `rb_gc_mark` on top of `reachable_objects_from_callback` and no user facing changes have to be made to any code in C extensions.

This new approach is the first step in separating gc marking from object graph traversal. This is necessary for us to start implementing alternate GC's so that we can implement custom marking and tracing functions independently.

## Benchmarking
### Yjit-bench headline benchmarks

Initial benchmarks show no performance impact in using the function pointer in all cases. 

```
master: ruby 3.3.0dev (2023-07-24T06:08:54Z master 14d16bdb1a) [x86_64-linux]
mvh-refactor-gc-mark-ptr: ruby 3.3.0dev (2023-08-07T21:09:44Z mvh-refactor-gc-ma.. ecf2a2d689) [x86_64-linux]
last_commit=fix

--------------  -----------  ----------  -----------------------------  ----------  --------------------------------  -------------------------------
bench           master (ms)  stddev (%)  mvh-refactor-gc-mark-ptr (ms)  stddev (%)  mvh-refactor-gc-mark-ptr 1st itr  master/mvh-refactor-gc-mark-ptr
activerecord    75.0         2.2         76.7                           2.2         0.99                              0.98
chunky-png      915.0        0.4         937.6                          0.2         0.98                              0.98
erubi-rails     22.1         12.7        22.2                           12.9        1.00                              1.00
hexapdf         2719.7       0.4         2710.9                         0.5         1.00                              1.00
liquid-c        69.3         0.4         71.2                           2.2         0.95                              0.97
liquid-compile  65.7         0.4         72.1                           4.0         0.96                              0.91
liquid-render   176.0        1.0         175.0                          2.1         1.03                              1.01
mail            139.6        0.1         140.9                          2.1         0.97                              0.99
psych-load      2230.3       0.1         2214.8                         0.8         1.00                              1.01
railsbench      2135.9       0.4         2131.3                         0.5         1.01                              1.00
ruby-lsp        69.6         3.1         69.5                           3.4         0.90                              1.00
sequel          76.3         1.0         74.9                           0.9         1.01                              1.02
binarytrees     386.1        0.3         375.9                          0.4         1.01                              1.03
erubi           281.2        0.2         278.1                          0.4         1.03                              1.01
etanni          358.9        0.3         358.1                          0.2         1.02                              1.00
fannkuchredux   1903.9       0.2         1857.3                         0.1         1.03                              1.03
fluentd         2292.0       0.5         2321.8                         0.4         0.97                              0.99
lee             1229.0       0.6         1215.7                         0.5         1.03                              1.01
nbody           116.0        1.6         116.3                          3.0         1.01                              1.00
optcarrot       5189.7       0.9         5567.9                         1.1         0.94                              0.93
rack            104.6        1.0         108.4                          2.4         0.98                              0.97
ruby-json       3532.6       0.2         3781.1                         0.1         0.94                              0.93
rubykon         11778.9      0.4         11429.8                        0.4         0.98                              1.03
30k_ifelse      1935.9       0.1         1966.7                         0.1         0.99                              0.98
30k_methods     5293.7       0.0         5290.4                         0.1         1.00                              1.00
cfunc_itself    93.1         0.5         95.0                           1.2         0.98                              0.98
fib             212.5        0.5         214.3                          1.0         1.00                              0.99
getivar         110.0        0.7         111.7                          0.8         0.99                              0.98
keyword_args    264.3        0.4         249.3                          1.0         1.06                              1.06
respond_to      226.7        1.6         222.3                          0.4         1.01                              1.02
setivar         61.0         2.5         59.4                           1.0         1.00                              1.03
setivar_object  99.4         5.8         105.0                          3.0         0.92                              0.95
setivar_young   92.8         3.1         100.6                          2.9         0.92                              0.92
str_concat      75.8         1.4         71.9                           1.5         1.05                              1.05
throw           24.5         0.8         26.8                           0.5         0.96                              0.91
--------------  -----------  ----------  -----------------------------  ----------  --------------------------------  -------------------------------
Legend:
- mvh-refactor-gc-mark-ptr 1st itr: ratio of master/mvh-refactor-gc-mark-ptr time for the first benchmarking iteration.
- master/mvh-refactor-gc-mark-ptr: ratio of master/mvh-refactor-gc-mark-ptr
  time. Higher is better for mvh-refactor-gc-mark-ptr. Above 1 represents a
  speedup.
```

### gcbench

Using the [gcbench micro-benchmark](https://github.com/Shopify/ruby-mmtk-builder/blob/main/gcbench.rb) (originally authored by John Ellis et al, and ported to Ruby by Noel Padavan and Chris Seaton)  we can see that there is no difference between this branch and master

```
❯ benchmark-driver --chruby="mvh-refactor-gc-mark-ptr;master" --repeat-count=5 ~/git/ruby-mmtk-builder/gcbench.rb
Calculating -------------------------------------
                     mvh-refactor-gc-mark-ptr      master
             gcbench                    0.358       0.358 i/s -       1.000 times in 2.791722s 2.792682s

Comparison:
                          gcbench
mvh-refactor-gc-mark-ptr:         0.4 i/s
              master:         0.4 i/s - 1.00x  slower
```

### major GC micro-benchmark

Finally, by running `GC.start` 4 times in a loop we can see that, this benchmark is showing a slight (2%) performance increase when compared to master, however given given the previous benchmarks, I suspect this is a statistical anomaly. 

It does however confirm that there is no performance degradation with this work.

```
❯ benchmark-driver --chruby="mvh-refactor-gc-mark-ptr;master" --repeat-count=200 test.rb
Calculating -------------------------------------
                     mvh-refactor-gc-mark-ptr      master
                test                  358.482     351.692 i/s -       1.000 times in 0.002790s 0.002843s

Comparison:
                             test
mvh-refactor-gc-mark-ptr:       358.5 i/s
              master:       351.7 i/s - 1.02x  slower
```
