### PR TITLE
YJIT: Fallback send instructions to vm_sendish

### DIFF
--- a/test/ruby/test_yjit.rb
+++ b/test/ruby/test_yjit.rb
@@ -548,7 +548,7 @@ class TestYJIT < Test::Unit::TestCase
 
   def test_getblockparamproxy
     # Currently two side exits as OPTIMIZED_METHOD_TYPE_CALL is unimplemented
-    assert_compiles(<<~'RUBY', insns: [:getblockparamproxy], exits: { opt_send_without_block: 2 })
+    assert_compiles(<<~'RUBY', insns: [:getblockparamproxy])
       def foo &blk
         p blk.call
         p blk.call
@@ -607,7 +607,7 @@ class TestYJIT < Test::Unit::TestCase
 
   def test_send_kwargs
     # For now, this side-exits when calls include keyword args
-    assert_compiles(<<~'RUBY', result: "2#a:1,b:2/A", exits: {opt_send_without_block: 1})
+    assert_compiles(<<~'RUBY', result: "2#a:1,b:2/A")
       def internal_method(**kw)
         "#{kw.size}##{kw.keys.map { |k| "#{k}:#{kw[k]}" }.join(",")}"
       end
@@ -647,7 +647,7 @@ class TestYJIT < Test::Unit::TestCase
 
   def test_send_kwargs_splat
     # For now, this side-exits when calling with a splat
-    assert_compiles(<<~'RUBY', result: "2#a:1,b:2/B", exits: {opt_send_without_block: 1})
+    assert_compiles(<<~'RUBY', result: "2#a:1,b:2/B")
       def internal_method(**kw)
         "#{kw.size}##{kw.keys.map { |k| "#{k}:#{kw[k]}" }.join(",")}"
       end

--- a/vm_exec.h
+++ b/vm_exec.h
@@ -169,7 +169,7 @@ default:                        \
 #define THROW_EXCEPTION(exc) return (VALUE)(exc)
 #endif
 
-// Run the interpreter on JIT
+// Run the interpreter from the JIT
 #define VM_EXEC(ec, val) do { \
     if (val == Qundef) { \
         VM_ENV_FLAGS_SET(ec->cfp->ep, VM_FRAME_FLAG_FINISH); \
@@ -177,7 +177,7 @@ default:                        \
     } \
 } while (0)
 
-// Run JIT on the interpreter
+// Run the JIT from the interpreter
 #define JIT_EXEC(ec, val) do { \
     rb_jit_func_t func; \
     if (val == Qundef && (func = jit_compile(ec))) { \

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -5528,6 +5528,42 @@ vm_sendish(
     return val;
 }
 
+VALUE
+rb_vm_send(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, CALL_DATA cd, ISEQ blockiseq)
+{
+    VALUE bh = vm_caller_setup_arg_block(ec, GET_CFP(), cd->ci, blockiseq, false);
+    VALUE val = vm_sendish(ec, GET_CFP(), cd, bh, mexp_search_method);
+    VM_EXEC(ec, val);
+    return val;
+}
+
+VALUE
+rb_vm_opt_send_without_block(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, CALL_DATA cd)
+{
+    VALUE bh = VM_BLOCK_HANDLER_NONE;
+    VALUE val = vm_sendish(ec, GET_CFP(), cd, bh, mexp_search_method);
+    VM_EXEC(ec, val);
+    return val;
+}
+
+VALUE
+rb_vm_invokesuper(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, CALL_DATA cd, ISEQ blockiseq)
+{
+    VALUE bh = vm_caller_setup_arg_block(ec, GET_CFP(), cd->ci, blockiseq, true);
+    VALUE val = vm_sendish(ec, GET_CFP(), cd, bh, mexp_search_super);
+    VM_EXEC(ec, val);
+    return val;
+}
+
+VALUE
+rb_vm_invokeblock(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, CALL_DATA cd)
+{
+    VALUE bh = VM_BLOCK_HANDLER_NONE;
+    VALUE val = vm_sendish(ec, GET_CFP(), cd, bh, mexp_search_invokeblock);
+    VM_EXEC(ec, val);
+    return val;
+}
+
 /* object.c */
 VALUE rb_nil_to_s(VALUE);
 VALUE rb_true_to_s(VALUE);

--- a/yjit.c
+++ b/yjit.c
@@ -1122,6 +1122,20 @@ rb_yjit_assert_holding_vm_lock(void)
     ASSERT_vm_locking();
 }
 
+// The number of stack slots that vm_sendish() pops for send and invokesuper.
+size_t
+rb_yjit_sendish_sp_pops(const struct rb_callinfo *ci)
+{
+    return 1 - sp_inc_of_sendish(ci); // + 1 to ignore return value push
+}
+
+// The number of stack slots that vm_sendish() pops for invokeblock.
+size_t
+rb_yjit_invokeblock_sp_pops(const struct rb_callinfo *ci)
+{
+    return 1 - sp_inc_of_invokeblock(ci); // + 1 to ignore return value push
+}
+
 // Primitives used by yjit.rb
 VALUE rb_yjit_stats_enabled_p(rb_execution_context_t *ec, VALUE self);
 VALUE rb_yjit_trace_exit_locations_enabled_p(rb_execution_context_t *ec, VALUE self);

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -325,6 +325,8 @@ fn main() {
         .allowlist_function("rb_yjit_icache_invalidate")
         .allowlist_function("rb_optimized_call")
         .allowlist_function("rb_yjit_assert_holding_vm_lock")
+        .allowlist_function("rb_yjit_sendish_sp_pops")
+        .allowlist_function("rb_yjit_invokeblock_sp_pops")
 
         // from vm_sync.h
         .allowlist_function("rb_vm_barrier")

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -6947,7 +6947,7 @@ fn gen_opt_send_without_block(
         return Some(status);
     }
 
-    // Otherwise, fallback to dynamic dispatch
+    // Otherwise, fallback to dynamic dispatch using the interpreter's implementation of send
     gen_send_dynamic(jit, asm, cd, unsafe { rb_yjit_sendish_sp_pops((*cd).ci) }, |asm| {
         extern "C" {
             fn rb_vm_opt_send_without_block(ec: EcPtr, cfp: CfpPtr, cd: VALUE) -> VALUE;
@@ -6971,7 +6971,7 @@ fn gen_send(
         return Some(status);
     }
 
-    // Otherwise, fallback to dynamic dispatch
+    // Otherwise, fallback to dynamic dispatch using the interpreter's implementation of send
     let blockiseq = jit.get_arg(1).as_iseq();
     gen_send_dynamic(jit, asm, cd, unsafe { rb_yjit_sendish_sp_pops((*cd).ci) }, |asm| {
         extern "C" {
@@ -6995,7 +6995,7 @@ fn gen_invokeblock(
         return Some(status);
     }
 
-    // Otherwise, fallback to dynamic dispatch
+    // Otherwise, fallback to dynamic dispatch using the interpreter's implementation of send
     gen_send_dynamic(jit, asm, cd, unsafe { rb_yjit_invokeblock_sp_pops((*cd).ci) }, |asm| {
         extern "C" {
             fn rb_vm_invokeblock(ec: EcPtr, cfp: CfpPtr, cd: VALUE) -> VALUE;
@@ -7154,7 +7154,7 @@ fn gen_invokesuper(
         return Some(status);
     }
 
-    // Otherwise, fallback to dynamic dispatch
+    // Otherwise, fallback to dynamic dispatch using the interpreter's implementation of send
     let blockiseq = jit.get_arg(1).as_iseq();
     gen_send_dynamic(jit, asm, cd, unsafe { rb_yjit_sendish_sp_pops((*cd).ci) }, |asm| {
         extern "C" {

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -6428,6 +6428,38 @@ fn gen_struct_aset(
     Some(EndBlock)
 }
 
+// Generate code that calls a method with dynamic dispatch
+fn gen_send_dynamic<F: Fn(&mut Assembler) -> Opnd>(
+    jit: &mut JITState,
+    asm: &mut Assembler,
+    cd: *const rb_call_data,
+    sp_pops: usize,
+    vm_sendish: F,
+) -> Option<CodegenStatus> {
+    // Our frame handling is not compatible with tailcall
+    if unsafe { vm_ci_flag((*cd).ci) } & VM_CALL_TAILCALL != 0 {
+        return None;
+    }
+
+    // Save PC and SP to prepare for dynamic dispatch
+    jit_prepare_routine_call(jit, asm);
+
+    // Pop arguments and a receiver
+    asm.stack_pop(sp_pops);
+
+    // Dispatch a method
+    let ret = vm_sendish(asm);
+
+    // Push the return value
+    let stack_ret = asm.stack_push(Type::Unknown);
+    asm.mov(stack_ret, ret);
+
+    // Fix the interpreter SP deviated by vm_sendish
+    asm.mov(Opnd::mem(64, CFP, RUBY_OFFSET_CFP_SP), SP);
+
+    Some(KeepCompiling)
+}
+
 fn gen_send_general(
     jit: &mut JITState,
     asm: &mut Assembler,
@@ -6909,9 +6941,22 @@ fn gen_opt_send_without_block(
     asm: &mut Assembler,
     ocb: &mut OutlinedCb,
 ) -> Option<CodegenStatus> {
+    // Generate specialized code if possible
     let cd = jit.get_arg(0).as_ptr();
+    if let Some(status) = gen_send_general(jit, asm, ocb, cd, None) {
+        return Some(status);
+    }
 
-    gen_send_general(jit, asm, ocb, cd, None)
+    // Otherwise, fallback to dynamic dispatch
+    gen_send_dynamic(jit, asm, cd, unsafe { rb_yjit_sendish_sp_pops((*cd).ci) }, |asm| {
+        extern "C" {
+            fn rb_vm_opt_send_without_block(ec: EcPtr, cfp: CfpPtr, cd: VALUE) -> VALUE;
+        }
+        asm.ccall(
+            rb_vm_opt_send_without_block as *const u8,
+            vec![EC, CFP, (cd as usize).into()],
+        )
+    })
 }
 
 fn gen_send(
@@ -6919,9 +6964,24 @@ fn gen_send(
     asm: &mut Assembler,
     ocb: &mut OutlinedCb,
 ) -> Option<CodegenStatus> {
+    // Generate specialized code if possible
     let cd = jit.get_arg(0).as_ptr();
     let block = jit.get_arg(1).as_optional_ptr();
-    return gen_send_general(jit, asm, ocb, cd, block);
+    if let Some(status) = gen_send_general(jit, asm, ocb, cd, block) {
+        return Some(status);
+    }
+
+    // Otherwise, fallback to dynamic dispatch
+    let blockiseq = jit.get_arg(1).as_iseq();
+    gen_send_dynamic(jit, asm, cd, unsafe { rb_yjit_sendish_sp_pops((*cd).ci) }, |asm| {
+        extern "C" {
+            fn rb_vm_send(ec: EcPtr, cfp: CfpPtr, cd: VALUE, blockiseq: IseqPtr) -> VALUE;
+        }
+        asm.ccall(
+            rb_vm_send as *const u8,
+            vec![EC, CFP, (cd as usize).into(), VALUE(blockiseq as usize).into()],
+        )
+    })
 }
 
 fn gen_invokeblock(
@@ -6929,13 +6989,36 @@ fn gen_invokeblock(
     asm: &mut Assembler,
     ocb: &mut OutlinedCb,
 ) -> Option<CodegenStatus> {
+    // Generate specialized code if possible
+    let cd = jit.get_arg(0).as_ptr();
+    if let Some(status) = gen_invokeblock_specialized(jit, asm, ocb, cd) {
+        return Some(status);
+    }
+
+    // Otherwise, fallback to dynamic dispatch
+    gen_send_dynamic(jit, asm, cd, unsafe { rb_yjit_invokeblock_sp_pops((*cd).ci) }, |asm| {
+        extern "C" {
+            fn rb_vm_invokeblock(ec: EcPtr, cfp: CfpPtr, cd: VALUE) -> VALUE;
+        }
+        asm.ccall(
+            rb_vm_invokeblock as *const u8,
+            vec![EC, CFP, (cd as usize).into()],
+        )
+    })
+}
+
+fn gen_invokeblock_specialized(
+    jit: &mut JITState,
+    asm: &mut Assembler,
+    ocb: &mut OutlinedCb,
+    cd: *const rb_call_data,
+) -> Option<CodegenStatus> {
     if !jit.at_current_insn() {
         defer_compilation(jit, asm, ocb);
         return Some(EndBlock);
     }
 
     // Get call info
-    let cd = jit.get_arg(0).as_ptr();
     let ci = unsafe { get_call_data_ci(cd) };
     let argc: i32 = unsafe { vm_ci_argc(ci) }.try_into().unwrap();
     let flags = unsafe { vm_ci_flag(ci) };
@@ -7065,7 +7148,31 @@ fn gen_invokesuper(
     asm: &mut Assembler,
     ocb: &mut OutlinedCb,
 ) -> Option<CodegenStatus> {
-    let cd: *const rb_call_data = jit.get_arg(0).as_ptr();
+    // Generate specialized code if possible
+    let cd = jit.get_arg(0).as_ptr();
+    if let Some(status) = gen_invokesuper_specialized(jit, asm, ocb, cd) {
+        return Some(status);
+    }
+
+    // Otherwise, fallback to dynamic dispatch
+    let blockiseq = jit.get_arg(1).as_iseq();
+    gen_send_dynamic(jit, asm, cd, unsafe { rb_yjit_sendish_sp_pops((*cd).ci) }, |asm| {
+        extern "C" {
+            fn rb_vm_invokesuper(ec: EcPtr, cfp: CfpPtr, cd: VALUE, blockiseq: IseqPtr) -> VALUE;
+        }
+        asm.ccall(
+            rb_vm_invokesuper as *const u8,
+            vec![EC, CFP, (cd as usize).into(), VALUE(blockiseq as usize).into()],
+        )
+    })
+}
+
+fn gen_invokesuper_specialized(
+    jit: &mut JITState,
+    asm: &mut Assembler,
+    ocb: &mut OutlinedCb,
+    cd: *const rb_call_data,
+) -> Option<CodegenStatus> {
     let block: Option<IseqPtr> = jit.get_arg(1).as_optional_ptr();
 
     // Defer compilation so we can specialize on class of receiver

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -1336,4 +1336,6 @@ extern "C" {
         line: ::std::os::raw::c_int,
     );
     pub fn rb_yjit_assert_holding_vm_lock();
+    pub fn rb_yjit_sendish_sp_pops(ci: *const rb_callinfo) -> usize;
+    pub fn rb_yjit_invokeblock_sp_pops(ci: *const rb_callinfo) -> usize;
 }


### PR DESCRIPTION
`send`, `opt_send_without_block`, `invokesuper`, and `invokeblock` instructions are currently the top exit reasons for most benchmarks and production applications. It's because they side-exit when YJIT doesn't know how to optimize them.

This PR changes YJIT to call the implementation of the interpreter in such scenarios so that the execution stays in JIT code as long as possible.

## Ratio in YJIT
It improves `ratio_in_yjit` from 92.6% to 97.1% on railsbench.

### Before
<details>

```
***YJIT: Printing YJIT statistics on exit***
method call exit reasons:
                          block_arg:     63,519 (20.5%)
             iseq_has_rest_and_send:     51,188 (16.5%)
                        iseq_zsuper:     45,901 (14.8%)
                   iseq_arity_error:     30,517 ( 9.9%)
                iseq_ruby2_keywords:     24,696 ( 8.0%)
                     iseq_has_no_kw:     21,095 ( 6.8%)
          args_splat_cfunc_var_args:     16,018 ( 5.2%)
            iseq_materialized_block:     15,942 ( 5.2%)
                           kw_splat:     12,611 ( 4.1%)
                    iseq_has_kwrest:      7,172 ( 2.3%)
                        not_fixnums:      4,968 ( 1.6%)
                  klass_megamorphic:      4,286 ( 1.4%)
           iseq_missing_optional_kw:      3,942 ( 1.3%)
             args_splat_cfunc_zuper:      1,972 ( 0.6%)
        iseq_has_rest_opt_and_block:      1,959 ( 0.6%)
                      iseq_has_post:      1,958 ( 0.6%)
              cfunc_ruby_array_varg:      1,118 ( 0.4%)
                       mid_mismatch:        389 ( 0.1%)
                           keywords:         90 ( 0.0%)
    args_splat_cfunc_ruby2_keywords:         33 ( 0.0%)
                        interrupted:         17 ( 0.0%)
                      zsuper_method:         15 ( 0.0%)
invokeblock exit reasons:
      proc:      1,807 (93.5%)
    symbol:        126 ( 6.5%)
invokesuper exit reasons:
    me_changed:      4,676 (69.2%)
         block:      2,081 (30.8%)
leave exit reasons:
    interp_return:  1,678,795 (100.0%)
     se_interrupt:         17 ( 0.0%)
getblockparamproxy exit reasons:
    block_param_modified:         77 (96.2%)
          not_gc_guarded:          3 ( 3.8%)
getinstancevariable exit reasons:
    (all relevant counters are zero)
setinstancevariable exit reasons:
    (all relevant counters are zero)
definedivar exit reasons:
    (all relevant counters are zero)
opt_aref exit reasons:
    (all relevant counters are zero)
expandarray exit reasons:
            splat:      9,945 (99.9%)
    rhs_too_small:          5 ( 0.1%)
opt_getinlinecache exit reasons:
    miss:          3 (100.0%)
invalidation reasons:
          method_lookup:        378 (68.6%)
    constant_state_bump:        121 (22.0%)
       constant_ic_fill:         52 ( 9.4%)
num_send:                 13,176,721
num_send_known_class:        471,932 ( 3.6%)
num_send_polymorphic:        999,997 ( 7.6%)
num_send_x86_rel32:           19,700
num_send_x86_reg:                 38
iseq_stack_too_large:              0
iseq_too_long:                     0
temp_reg_opnd:               108,435
temp_mem_opnd:                78,766
temp_spill:                   69,350
bindings_allocations:              0
bindings_set:                      0
compiled_iseq_entry:           1,214
compiled_iseq_count:           2,153
compiled_blockid_count:       16,690
compiled_block_count:         20,987
versions_per_block:            1.257
compiled_branch_count:        37,360
block_next_count:             18,924
defer_count:                   6,589
defer_empty_count:             1,355
branch_insn_count:             1,785
branch_known_count:              324 (18.2%)
freed_iseq_count:                 33
invalidation_count:              551
constant_state_bumps:              0
get_ivar_max_depth:               20
inline_code_size:          2,248,796
outlined_code_size:        1,992,972
code_region_size:          4,403,200
freed_code_size:                   0
live_context_size:           778,969
live_context_count:           26,861
live_page_count:                 269
freed_page_count:                  0
code_gc_count:                     0
num_gc_obj_refs:              17,701
object_shape_count:            2,326
side_exit_count:             349,584
total_exit_count:          2,028,379
total_insns_count:        87,371,151
vm_insns_count:            6,511,097
yjit_insns_count:         81,209,638
ratio_in_yjit:                 92.5%
avg_len_in_yjit:                39.9
Top-18 most frequent exit ops (100.0% of exits):
               invokesuper:    102,325 (29.3%)
                      send:     97,831 (28.0%)
    opt_send_without_block:     78,965 (22.6%)
               invokeblock:     30,479 ( 8.7%)
                  opt_aref:     13,971 ( 4.0%)
               expandarray:      9,950 ( 2.8%)
             setlocal_WC_0:      8,140 ( 2.3%)
                    opt_eq:      4,968 ( 1.4%)
        getblockparamproxy:      2,260 ( 0.6%)
                 opt_nil_p:        244 ( 0.1%)
      opt_getconstant_path:        211 ( 0.1%)
                checkmatch:        144 ( 0.0%)
                      once:         58 ( 0.0%)
                     leave:         17 ( 0.0%)
               objtostring:         17 ( 0.0%)
                  opt_plus:          2 ( 0.0%)
                  opt_size:          1 ( 0.0%)
                  branchif:          1 ( 0.0%)
Total time spent benchmarking: 4s

before: ruby 3.3.0dev (2023-07-22T04:07:04Z master dd04def10f) +YJIT [x86_64-linux]

----------  -----------  ----------
bench       before (ms)  stddev (%)
railsbench  1670.5       0.0
----------  -----------  ----------
```

</details>

### After
<details>

```
***YJIT: Printing YJIT statistics on exit***
method call exit reasons:
                          block_arg:     63,795 (19.4%)
             iseq_has_rest_and_send:     53,159 (16.1%)
                        iseq_zsuper:     45,901 (13.9%)
                   iseq_arity_error:     32,488 ( 9.9%)
                     iseq_has_no_kw:     25,011 ( 7.6%)
                iseq_ruby2_keywords:     24,756 ( 7.5%)
          args_splat_cfunc_var_args:     16,019 ( 4.9%)
            iseq_materialized_block:     15,942 ( 4.8%)
                           kw_splat:     14,624 ( 4.4%)
                    iseq_has_kwrest:     11,118 ( 3.4%)
                        not_fixnums:      4,968 ( 1.5%)
                  klass_megamorphic:      4,291 ( 1.3%)
           iseq_missing_optional_kw:      3,943 ( 1.2%)
                 args_splat_bmethod:      3,399 ( 1.0%)
        iseq_has_rest_opt_and_block:      1,981 ( 0.6%)
             args_splat_cfunc_zuper:      1,972 ( 0.6%)
         iseq_has_rest_and_captured:      1,958 ( 0.6%)
                      iseq_has_post:      1,958 ( 0.6%)
              cfunc_ruby_array_varg:      1,760 ( 0.5%)
                       mid_mismatch:        389 ( 0.1%)
                           keywords:         90 ( 0.0%)
    args_splat_cfunc_ruby2_keywords:         34 ( 0.0%)
                        interrupted:         20 ( 0.0%)
                      zsuper_method:         15 ( 0.0%)
invokeblock exit reasons:
      proc:      1,807 (93.5%)
    symbol:        126 ( 6.5%)
invokesuper exit reasons:
    me_changed:      4,676 (69.2%)
         block:      2,081 (30.8%)
leave exit reasons:
    interp_return:  1,708,600 (100.0%)
     se_interrupt:         17 ( 0.0%)
getblockparamproxy exit reasons:
    block_param_modified:         77 (96.2%)
          not_gc_guarded:          3 ( 3.8%)
getinstancevariable exit reasons:
    (all relevant counters are zero)
setinstancevariable exit reasons:
    (all relevant counters are zero)
definedivar exit reasons:
    (all relevant counters are zero)
opt_aref exit reasons:
    (all relevant counters are zero)
expandarray exit reasons:
            splat:      9,945 (99.9%)
    rhs_too_small:          5 ( 0.1%)
opt_getinlinecache exit reasons:
    miss:          3 (100.0%)
invalidation reasons:
          method_lookup:        382 (68.0%)
    constant_state_bump:        125 (22.2%)
       constant_ic_fill:         55 ( 9.8%)
num_send:                 13,794,298
num_send_known_class:        493,928 ( 3.6%)
num_send_polymorphic:      1,008,032 ( 7.3%)
num_send_x86_rel32:           21,667
num_send_x86_reg:                 46
iseq_stack_too_large:              0
iseq_too_long:                     0
temp_reg_opnd:               116,936
temp_mem_opnd:                85,539
temp_spill:                   74,846
bindings_allocations:              0
bindings_set:                      0
compiled_iseq_entry:           1,124
compiled_iseq_count:           2,159
compiled_blockid_count:       17,999
compiled_block_count:         22,616
versions_per_block:            1.257
compiled_branch_count:        40,252
block_next_count:             20,337
defer_count:                   7,182
defer_empty_count:             1,486
branch_insn_count:             1,912
branch_known_count:              334 (17.5%)
freed_iseq_count:                 33
invalidation_count:              562
constant_state_bumps:              0
get_ivar_max_depth:               20
inline_code_size:          2,400,539
outlined_code_size:        2,172,050
code_region_size:          4,763,648
freed_code_size:                   0
live_context_size:           844,915
live_context_count:           29,135
live_page_count:                 291
freed_page_count:                  0
code_gc_count:                     0
num_gc_obj_refs:              19,076
object_shape_count:            2,326
side_exit_count:              39,258
total_exit_count:          1,747,858
total_insns_count:        88,293,673
vm_insns_count:            2,521,541
yjit_insns_count:         85,811,390
ratio_in_yjit:                 97.1%
avg_len_in_yjit:                49.1
Top-14 most frequent exit ops (100.0% of exits):
             setlocal_WC_0:     10,186 (25.9%)
               expandarray:      9,950 (25.3%)
               invokesuper:      6,758 (17.2%)
                    opt_eq:      4,968 (12.7%)
    opt_send_without_block:      4,181 (10.7%)
        getblockparamproxy:      2,260 ( 5.8%)
                      send:        255 ( 0.6%)
                 opt_nil_p:        244 ( 0.6%)
      opt_getconstant_path:        214 ( 0.5%)
                checkmatch:        144 ( 0.4%)
                      once:         58 ( 0.1%)
                     leave:         21 ( 0.1%)
               objtostring:         18 ( 0.0%)
                opt_length:          1 ( 0.0%)
Total time spent benchmarking: 4s

after: ruby 3.3.0dev (2023-07-22T04:07:50Z yjit-send-fallback 39eeab23c6) +YJIT [x86_64-linux]

----------  ----------  ----------
bench       after (ms)  stddev (%)
railsbench  1619.2      0.0
----------  ----------  ----------
```

</details>

## Benchmarks
The following benchmarks get 5%+ speedup.

```
before: ruby 3.3.0dev (2023-07-22T04:07:04Z master dd04def10f) +YJIT [x86_64-linux]
after: ruby 3.3.0dev (2023-07-22T04:07:50Z yjit-send-fallback 39eeab23c6) +YJIT [x86_64-linux]

------------  -----------  ----------  ----------  ----------  -------------  ------------
bench         before (ms)  stddev (%)  after (ms)  stddev (%)  after 1st itr  before/after
activerecord  32.6         5.1         29.8        5.1         1.01           1.10 
erubi-rails   11.5         25.5        10.9        32.9        1.04           1.05
hexapdf       1401.9       1.2         1341.4      1.1         1.04           1.05  
railsbench    1232.5       1.2         1149.2      1.2         1.03           1.07
ruby-lsp      38.7         19.2        36.2        21.8        0.96           1.07
------------  -----------  ----------  ----------  ----------  -------------  ------------
```