### PR TITLE
YJIT: Fix cfp inconsistency on tailcall

### DIFF
--- a/test/ruby/test_optimization.rb
+++ b/test/ruby/test_optimization.rb
@@ -437,6 +437,20 @@ class TestRubyOptimization < Test::Unit::TestCase
                  message(bug12565) {disasm(:add_one_and_two)})
   end
 
+  def test_c_func_with_sp_offset_under_tailcall
+    tailcall("#{<<-"begin;"}\n#{<<~"end;"}")
+    begin;
+      def calc_one_plus_two
+        1 + 2.abs
+      end
+
+      def one_plus_two
+        calc_one_plus_two
+      end
+    end;
+    assert_equal(3, one_plus_two)
+  end
+
   def test_tailcall_interrupted_by_sigint
     bug12576 = 'ruby-core:76327'
     script = "#{<<-"begin;"}\n#{<<~'end;'}"

--- a/vm_exec.h
+++ b/vm_exec.h
@@ -173,6 +173,7 @@ default:                        \
     rb_jit_func_t func; \
     if (val == Qundef && (func = jit_compile(ec))) { \
         val = func(ec, ec->cfp); \
+        RESTORE_REGS(); /* fix cfp for tailcall */ \
         if (ec->tag->state) THROW_EXCEPTION(val); \
     } \
 } while (0)


### PR DESCRIPTION
[[Bug #19781]](https://bugs.ruby-lang.org/issues/19781)

This test has been broken since the first release of YJIT. The callee ISEQ (`calc_one_plus_two`) has no indication of tailcall in the ISEQ's metadata, but this does get called by the caller (`one_plus_two`) with tailcall (the caller has tailcall flag in the callsite). The callee ISEQ pops a frame on `leave`, but because it goes back to interpreting `one_plus_two` instead of the top-level frame, it executes another `leave` that would have been skipped in the interpreter.

In order to skip executing duplicated `leave` that is in the outdated frame, the interpreter must call `RESTORE_REGS()` to correct the frame after JIT code exits. 

Fortunately, this fix doesn't seem to have a significant performance impact.

```
before: ruby 3.3.0dev (2023-07-21T19:44:24Z master 11deab7906) +YJIT [x86_64-linux]
after: ruby 3.3.0dev (2023-07-22T03:44:30Z yjit-tailcall 8d43e6b7bd) +YJIT [x86_64-linux]

----------  -----------  ----------  ----------  ----------  -------------  ------------
bench       before (ms)  stddev (%)  after (ms)  stddev (%)  after 1st itr  before/after
railsbench  1235.5       1.1         1227.4      1.2         1.00           1.01        
----------  -----------  ----------  ----------  ----------  -------------  ------------
```