### PR TITLE
Introduce recursive_eq function for refactor

### DIFF
--- a/range.c
+++ b/range.c
@@ -136,15 +136,21 @@ range_exclude_end_p(VALUE range)
 }
 
 static VALUE
-recursive_equal(VALUE range, VALUE obj, int recur)
+recursive_eq(VALUE range, VALUE obj, int recur, VALUE (*func)(VALUE, VALUE))
 {
     if (recur) return Qtrue; /* Subtle! */
-    if (!rb_equal(RANGE_BEG(range), RANGE_BEG(obj)))
+    if (!func(RANGE_BEG(range), RANGE_BEG(obj)))
         return Qfalse;
-    if (!rb_equal(RANGE_END(range), RANGE_END(obj)))
+    if (!func(RANGE_END(range), RANGE_END(obj)))
         return Qfalse;
 
     return RBOOL(EXCL(range) == EXCL(obj));
+}
+
+static VALUE
+recursive_equal(VALUE range, VALUE obj, int recur)
+{
+    return recursive_eq(range, obj, recur, rb_equal);
 }
 
 
@@ -208,13 +214,7 @@ r_less(VALUE a, VALUE b)
 static VALUE
 recursive_eql(VALUE range, VALUE obj, int recur)
 {
-    if (recur) return Qtrue; /* Subtle! */
-    if (!rb_eql(RANGE_BEG(range), RANGE_BEG(obj)))
-        return Qfalse;
-    if (!rb_eql(RANGE_END(range), RANGE_END(obj)))
-        return Qfalse;
-
-    return RBOOL(EXCL(range) == EXCL(obj));
+    return recursive_eq(range, obj, recur, rb_eql);
 }
 
 /*

--- a/struct.c
+++ b/struct.c
@@ -1357,16 +1357,22 @@ rb_struct_select(int argc, VALUE *argv, VALUE s)
 }
 
 static VALUE
-recursive_equal(VALUE s, VALUE s2, int recur)
+recursive_eq(VALUE s, VALUE s2, int recur, VALUE (*func)(VALUE, VALUE))
 {
     long i, len;
 
     if (recur) return Qtrue; /* Subtle! */
     len = RSTRUCT_LEN(s);
     for (i=0; i<len; i++) {
-        if (!rb_equal(RSTRUCT_GET(s, i), RSTRUCT_GET(s2, i))) return Qfalse;
+        if (!func(RSTRUCT_GET(s, i), RSTRUCT_GET(s2, i))) return Qfalse;
     }
     return Qtrue;
+}
+
+static VALUE
+recursive_equal(VALUE s, VALUE s2, int recur)
+{
+    return recursive_eq(s, s2, recur, rb_equal);
 }
 
 
@@ -1442,14 +1448,7 @@ rb_struct_hash(VALUE s)
 static VALUE
 recursive_eql(VALUE s, VALUE s2, int recur)
 {
-    long i, len;
-
-    if (recur) return Qtrue; /* Subtle! */
-    len = RSTRUCT_LEN(s);
-    for (i=0; i<len; i++) {
-        if (!rb_eql(RSTRUCT_GET(s, i), RSTRUCT_GET(s2, i))) return Qfalse;
-    }
-    return Qtrue;
+    return recursive_eq(s, s2, recur, rb_eql);
 }
 
 /*


### PR DESCRIPTION
Introduce `recursive_eq` function to refactor for `recursive_equal` and `recursive_eql` functions.