### PR TITLE
Introduce recursive_eq macro for refactor

### DIFF
--- a/range.c
+++ b/range.c
@@ -142,7 +142,7 @@ range_exclude_end_p(VALUE range)
         return Qfalse; \
     if (!rb_##name(RANGE_END(range), RANGE_END(obj))) \
         return Qfalse; \
-    return RBOOL(EXCL(range) == EXCL(obj)); 
+    return RBOOL(EXCL(range) == EXCL(obj));
 
 static VALUE
 recursive_equal(VALUE range, VALUE obj, int recur)

--- a/range.c
+++ b/range.c
@@ -136,16 +136,18 @@ range_exclude_end_p(VALUE range)
     return RBOOL(EXCL(range));
 }
 
+#define recursive_eq(name) \
+    if (recur) return Qtrue; /* Subtle! */ \
+    if (!rb_##name(RANGE_BEG(range), RANGE_BEG(obj))) \
+        return Qfalse; \
+    if (!rb_##name(RANGE_END(range), RANGE_END(obj))) \
+        return Qfalse; \
+    return RBOOL(EXCL(range) == EXCL(obj)); 
+
 static VALUE
 recursive_equal(VALUE range, VALUE obj, int recur)
 {
-    if (recur) return Qtrue; /* Subtle! */
-    if (!rb_equal(RANGE_BEG(range), RANGE_BEG(obj)))
-        return Qfalse;
-    if (!rb_equal(RANGE_END(range), RANGE_END(obj)))
-        return Qfalse;
-
-    return RBOOL(EXCL(range) == EXCL(obj));
+    recursive_eq(equal);
 }
 
 
@@ -209,13 +211,7 @@ r_less(VALUE a, VALUE b)
 static VALUE
 recursive_eql(VALUE range, VALUE obj, int recur)
 {
-    if (recur) return Qtrue; /* Subtle! */
-    if (!rb_eql(RANGE_BEG(range), RANGE_BEG(obj)))
-        return Qfalse;
-    if (!rb_eql(RANGE_END(range), RANGE_END(obj)))
-        return Qfalse;
-
-    return RBOOL(EXCL(range) == EXCL(obj));
+    recursive_eq(eql);
 }
 
 /*

--- a/struct.c
+++ b/struct.c
@@ -1361,17 +1361,19 @@ rb_struct_select(int argc, VALUE *argv, VALUE s)
     return result;
 }
 
+#define recursive_eq(name) \
+    long i, len; \
+    if (recur) return Qtrue; /* Subtle! */ \
+    len = RSTRUCT_LEN(s); \
+    for (i=0; i<len; i++) { \
+        if (!rb_##name(RSTRUCT_GET(s, i), RSTRUCT_GET(s2, i))) return Qfalse; \
+    } \
+    return Qtrue; 
+
 static VALUE
 recursive_equal(VALUE s, VALUE s2, int recur)
 {
-    long i, len;
-
-    if (recur) return Qtrue; /* Subtle! */
-    len = RSTRUCT_LEN(s);
-    for (i=0; i<len; i++) {
-        if (!rb_equal(RSTRUCT_GET(s, i), RSTRUCT_GET(s2, i))) return Qfalse;
-    }
-    return Qtrue;
+    recursive_eq(equal);
 }
 
 
@@ -1447,14 +1449,7 @@ rb_struct_hash(VALUE s)
 static VALUE
 recursive_eql(VALUE s, VALUE s2, int recur)
 {
-    long i, len;
-
-    if (recur) return Qtrue; /* Subtle! */
-    len = RSTRUCT_LEN(s);
-    for (i=0; i<len; i++) {
-        if (!rb_eql(RSTRUCT_GET(s, i), RSTRUCT_GET(s2, i))) return Qfalse;
-    }
-    return Qtrue;
+    recursive_eq(eql);
 }
 
 /*

--- a/struct.c
+++ b/struct.c
@@ -1368,7 +1368,7 @@ rb_struct_select(int argc, VALUE *argv, VALUE s)
     for (i=0; i<len; i++) { \
         if (!rb_##name(RSTRUCT_GET(s, i), RSTRUCT_GET(s2, i))) return Qfalse; \
     } \
-    return Qtrue; 
+    return Qtrue;
 
 static VALUE
 recursive_equal(VALUE s, VALUE s2, int recur)


### PR DESCRIPTION
Introduce `recursive_eq` macro to refactor for `recursive_equal` and `recursive_eql` functions.