### PR TITLE
tool/merger.rb: Support commit URLs as revisions

### DIFF
--- a/tool/merger.rb
+++ b/tool/merger.rb
@@ -295,7 +295,8 @@ else
     tickets = ''
   end
 
-  revstr = ARGV[0].delete('^, :\-0-9a-fA-F')
+  revstr = ARGV[0].gsub(%r!https://github\.com/ruby/ruby/commit/|https://bugs\.ruby-lang\.org/projects/ruby-master/repository/git/revisions/!, '')
+  revstr = revstr.delete('^, :\-0-9a-fA-F')
   revs = revstr.split(/[,\s]+/)
   commit_message = ''
 


### PR DESCRIPTION
With this PR you can specify commits via URL on GitHub or bugs.r-l.o.

```
./tool/merger.rb https://github.com/ruby/ruby/commit/0123456789abcdef
./tool/merger.rb https://bugs.ruby-lang.org/projects/ruby-master/repository/git/revisions/0123456789abcdef
```