### PR TITLE
GitHub Actions: fix ENOENT for jobs running in forks

### DIFF
--- a/.github/actions/setup/directories/action.yml
+++ b/.github/actions/setup/directories/action.yml
@@ -42,6 +42,7 @@ runs:
       run: |
         mkdir -p ${{ inputs.srcdir }}
         mkdir -p ${{ inputs.builddir }}
+        mkdir -p ${{ inputs.srcdir }}/.downloaded-cache
 
     # Did you know that actions/checkout works without git(1)?  We are
     # checking that here.


### PR DESCRIPTION
https://github.com/peterzhu2118/ruby/actions/runs/5649652235/job/15304434412
> Errno::ENOENT: No such file or directory @ rb_sysopen - ./.downloaded-cache/config.guess: https://raw.githubusercontent.com/gcc-mirror/gcc/master/config.guess

Maybe the issue only happens when running with a cold cache.