### PR TITLE
YJIT: Implement VM_CALL_ARGS_BLOCKARG with Proc for ISeq calls

### DIFF
--- a/test/ruby/test_yjit.rb
+++ b/test/ruby/test_yjit.rb
@@ -1320,6 +1320,16 @@ class TestYJIT < Test::Unit::TestCase
     RUBY
   end
 
+  def test_proc_block_arg
+    assert_compiles(<<~RUBY, result: [:proc, :no_block])
+      def yield_if_given = block_given? ? yield : :no_block
+
+      def call(block_arg = nil) = yield_if_given(&block_arg)
+
+      [call(-> { :proc }), call]
+    RUBY
+  end
+
   private
 
   def code_gc_helpers

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -59,6 +59,8 @@ pub enum Type {
     TArray, // An object with the T_ARRAY flag set, possibly an rb_cArray
     CArray, // An un-subclassed string of type rb_cArray (can have instance vars in some cases)
 
+    TProc, // A proc object. Could be an instance of a subclass of ::rb_cProc
+
     BlockParamProxy, // A special sentinel value indicating the block parameter should be read from
                      // the current surrounding cfp
 }
@@ -110,6 +112,8 @@ impl Type {
                 RUBY_T_ARRAY => Type::TArray,
                 RUBY_T_HASH => Type::Hash,
                 RUBY_T_STRING => Type::TString,
+                #[cfg(not(test))]
+                RUBY_T_DATA if unsafe { rb_obj_is_proc(val).test() } => Type::TProc,
                 _ => Type::UnknownHeap,
             }
         }
@@ -155,6 +159,7 @@ impl Type {
             Type::TString => true,
             Type::CString => true,
             Type::BlockParamProxy => true,
+            Type::TProc => true,
             _ => false,
         }
     }
@@ -189,6 +194,7 @@ impl Type {
             Type::Hash => Some(RUBY_T_HASH),
             Type::ImmSymbol | Type::HeapSymbol => Some(RUBY_T_SYMBOL),
             Type::TString | Type::CString => Some(RUBY_T_STRING),
+            Type::TProc => Some(RUBY_T_DATA),
             Type::Unknown | Type::UnknownImm | Type::UnknownHeap => None,
             Type::BlockParamProxy => None,
         }

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -296,6 +296,7 @@ make_counters! {
     invokeblock_symbol,
 
     // Method calls that exit to the interpreter
+    guard_send_block_arg_type,
     guard_send_klass_megamorphic,
     guard_send_se_cf_overflow,
     guard_send_se_protected_check_failed,


### PR DESCRIPTION
Rack uses this. Guard that the `obj` in `the_call(&obj)` is always going
to be a Proc if the compile time sample is a Proc.
