### PR TITLE
Implement `opt_aref_with` instruction

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -1100,6 +1100,18 @@ assert_equal '[42, :default]', %q{
   ]
 }
 
+# Test default value block for Hash with opt_aref_with
+assert_equal "false", %q{
+  def index_with_string(h)
+    h["foo"]
+  end
+
+  h = Hash.new { |h, k| k.frozen? }
+
+  index_with_string(h)
+  index_with_string(h)
+}
+
 # A regression test for making sure cfp->sp is proper when
 # hitting stubs. See :stub-sp-flush:
 assert_equal 'ok', %q{

--- a/test/ruby/test_yjit.rb
+++ b/test/ruby/test_yjit.rb
@@ -1289,6 +1289,14 @@ class TestYJIT < Test::Unit::TestCase
     RUBY
   end
 
+  def test_opt_aref_with
+    assert_compiles(<<~RUBY, insns: %i[opt_aref_with], result: "bar")
+      h = {"foo" => "bar"}
+
+      h["foo"]
+    RUBY
+  end
+
   private
 
   def code_gc_helpers

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -6259,6 +6259,12 @@ vm_opt_aref_with(VALUE recv, VALUE key)
     }
 }
 
+VALUE
+rb_vm_opt_aref_with(VALUE recv, VALUE key)
+{
+    return vm_opt_aref_with(recv, key);
+}
+
 static VALUE
 vm_opt_aset_with(VALUE recv, VALUE key, VALUE val)
 {

--- a/yjit.rb
+++ b/yjit.rb
@@ -259,6 +259,7 @@ module RubyVM::YJIT
       print_counters(stats, out: out, prefix: 'setivar_', prompt: 'setinstancevariable exit reasons:')
       print_counters(stats, out: out, prefix: 'definedivar_', prompt: 'definedivar exit reasons:')
       print_counters(stats, out: out, prefix: 'opt_aref_', prompt: 'opt_aref exit reasons: ')
+      print_counters(stats, out: out, prefix: 'opt_aref_with_', prompt: 'opt_aref_with exit reasons: ')
       print_counters(stats, out: out, prefix: 'expandarray_', prompt: 'expandarray exit reasons: ')
       print_counters(stats, out: out, prefix: 'opt_getinlinecache_', prompt: 'opt_getinlinecache exit reasons: ')
       print_counters(stats, out: out, prefix: 'invalidate_', prompt: 'invalidation reasons: ')

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -344,6 +344,8 @@ make_counters! {
     opt_aset_not_fixnum,
     opt_aset_not_hash,
 
+    opt_aref_with_qundef,
+
     opt_case_dispatch_megamorphic,
 
     opt_getinlinecache_miss,


### PR DESCRIPTION
This PR implements the `opt_aref_with` instruction. 

`opt_aref_with` is an instruction that appears when accessing a key on a receiver hash, similar to `opt_aref`, but the key is a string value known at compile-time (instead of the key being on the stack). 

example - 

```ruby
animals = {'c' => 'cat'}; 
p animals['c']
```

We implemented the instruction by calling the vm method, and falling back to the interpreter if the vm method returns the qundef value. We implemented the yjit instruction this way because otherwise, we would have to rewrite some non-trivial checks for the runtime, including whether the receiver hash was initialized with a proc, whether the receiver hash has its keys compared by object id, whether the hash's `[]` method was overwritten, etc. The complexity of our implementation is about relative to how much we think the instruction will appear -- since the instruction only appears if the key is a known string value, and will not appear for any code that uses `frozen_string_literal: true` (because strings are not reallocated for code that use `frozen_string_literal: true`, the `opt_aref` instruction will be used instead).  It would be more maintainable for this relatively specific instruction to keep all its checks in the vm method, than reimplementing all the checks.

Even though the implementation just calls the vm method, we think that implementing the `opt_aref_with` instruction for yjit is worth it because it removes a category of exits. We see the unimplemented `opt_aref_with` instruction as a (small percent of) side exit location in pages we have benchmarked for github. The instruction is also a exit location for for the erubi-rails benchmark because of [this line](https://github.com/Shopify/yjit-bench/blob/ba41f5116668ebdc5e9ac66cd1ae351d4886b348/benchmarks/erubi-rails/app/views/fake_discourse/topics_show.html.erb#L57) (~10% of exits running harness/harness-warmup, 7.5% of exits when running harness-perf).

In actually benchmarking erubi-rails, we found that the change doesn't make things significantly faster. (We think it's because there is another exit soon after.) However, because we no longer exit on `opt_aref_with` being unimplemented, we can stay longer in the compiler and get better stats for later exits. 

```
RSS: 160.7MiB
Average of last 401, non-warmup iters: 22ms
Total time spent benchmarking: 30s

control-dev --yjit: ruby 3.3.0dev (2023-07-24T14:41:01Z opt-aref-with 1780ad3748) +YJIT dev [x86_64-darwin22]
test-dev --yjit: ruby 3.3.0dev (2023-07-24T14:58:52Z opt-aref-with 76c7a645fb) +YJIT dev [x86_64-darwin22]

-----------  -----------------------  ----------  --------------------  ----------  -----------------------  ----------------------------------
bench        control-dev --yjit (ms)  stddev (%)  test-dev --yjit (ms)  stddev (%)  test-dev --yjit 1st itr  control-dev --yjit/test-dev --yjit
erubi-rails  23.5                     19.2        22.8                  18.6        1.06                     1.03                              
-----------  -----------------------  ----------  --------------------  ----------  -----------------------  ----------------------------------
Legend:
- test-dev --yjit 1st itr: ratio of control-dev --yjit/test-dev --yjit time for the first benchmarking iteration.
- control-dev --yjit/test-dev --yjit: ratio of control-dev --yjit/test-dev --yjit time. Higher is better for test-dev --yjit. Above 1 represents a speedup.

```

