### PR TITLE
YJIT: Fix naming for a getblockparamproxy counter

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -7890,7 +7890,7 @@ fn gen_getblockparam(
     asm.test(flags_opnd, VM_ENV_FLAG_WB_REQUIRED.into());
 
     // if (flags & VM_ENV_FLAG_WB_REQUIRED) != 0
-    asm.jnz(Target::side_exit(Counter::gbp_wb_required));
+    asm.jnz(Target::side_exit(Counter::gbpp_wb_required));
 
     // Convert the block handler in to a proc
     // call rb_vm_bh_to_procval(const rb_execution_context_t *ec, VALUE block_handler)

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -355,7 +355,7 @@ make_counters! {
     expandarray_not_array,
     expandarray_rhs_too_small,
 
-    gbp_wb_required,
+    gbpp_wb_required,
     gbpp_not_gc_guarded,
     gbpp_block_param_modified,
     gbpp_block_handler_not_none,


### PR DESCRIPTION
The rest of the counters are prefixed with `gbpp_` and that's what
`yjit.rb` uses when printing the summary. This counter wasn't included
in the summary.
