### PR TITLE
YJIT: Count the number of dynamic send dispatches

### DIFF
--- a/yjit.rb
+++ b/yjit.rb
@@ -270,6 +270,7 @@ module RubyVM::YJIT
       out.puts "num_send:              " + format_number(13, stats[:num_send])
       out.puts "num_send_known_class:  " + format_number_pct(13, stats[:num_send_known_class], stats[:num_send])
       out.puts "num_send_polymorphic:  " + format_number_pct(13, stats[:num_send_polymorphic], stats[:num_send])
+      out.puts "num_send_dynamic:      " + format_number_pct(13, stats[:num_send_dynamic], stats[:num_send])
       if stats[:num_send_x86_rel32] != 0 || stats[:num_send_x86_reg] != 0
         out.puts "num_send_x86_rel32:    " + format_number(13,  stats[:num_send_x86_rel32])
         out.puts "num_send_x86_reg:      " + format_number(13, stats[:num_send_x86_reg])

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -6488,6 +6488,7 @@ fn gen_send_dynamic<F: Fn(&mut Assembler) -> Opnd>(
     // Fix the interpreter SP deviated by vm_sendish
     asm.mov(Opnd::mem(64, CFP, RUBY_OFFSET_CFP_SP), SP);
 
+    gen_counter_incr(asm, Counter::num_send_dynamic);
     Some(KeepCompiling)
 }
 

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -410,6 +410,7 @@ make_counters! {
     num_send_polymorphic,
     num_send_x86_rel32,
     num_send_x86_reg,
+    num_send_dynamic,
 
     iseq_stack_too_large,
     iseq_too_long,


### PR DESCRIPTION
This counter checks the utilization of https://github.com/ruby/ruby/pull/8106. Decreasing this counter should generally contribute to performance even if it doesn't change `ratio_in_yjit`.