### PR TITLE
YJIT: Use dynamic dispatch for megamorphic send

### DIFF
--- a/yjit.rb
+++ b/yjit.rb
@@ -270,11 +270,14 @@ module RubyVM::YJIT
       out.puts "num_send:              " + format_number(13, stats[:num_send])
       out.puts "num_send_known_class:  " + format_number_pct(13, stats[:num_send_known_class], stats[:num_send])
       out.puts "num_send_polymorphic:  " + format_number_pct(13, stats[:num_send_polymorphic], stats[:num_send])
+      out.puts "num_send_megamorphic:  " + format_number_pct(13, stats[:num_send_megamorphic], stats[:num_send])
       out.puts "num_send_dynamic:      " + format_number_pct(13, stats[:num_send_dynamic], stats[:num_send])
       if stats[:num_send_x86_rel32] != 0 || stats[:num_send_x86_reg] != 0
         out.puts "num_send_x86_rel32:    " + format_number(13,  stats[:num_send_x86_rel32])
         out.puts "num_send_x86_reg:      " + format_number(13, stats[:num_send_x86_reg])
       end
+      out.puts "num_getivar_megamorphic: " + format_number(13, stats[:num_getivar_megamorphic])
+      out.puts "num_setivar_megamorphic: " + format_number(13, stats[:num_setivar_megamorphic])
 
       out.puts "iseq_stack_too_large:  " + format_number(13, stats[:iseq_stack_too_large])
       out.puts "iseq_too_long:         " + format_number(13, stats[:iseq_too_long])
@@ -302,7 +305,6 @@ module RubyVM::YJIT
       out.puts "freed_iseq_count:      " + format_number(13, stats[:freed_iseq_count])
       out.puts "invalidation_count:    " + format_number(13, stats[:invalidation_count])
       out.puts "constant_state_bumps:  " + format_number(13, stats[:constant_state_bumps])
-      out.puts "get_ivar_max_depth:    " + format_number(13, stats[:get_ivar_max_depth])
       out.puts "inline_code_size:      " + format_number(13, stats[:inline_code_size])
       out.puts "outlined_code_size:    " + format_number(13, stats[:outlined_code_size])
       out.puts "code_region_size:      " + format_number(13, stats[:code_region_size])

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -396,9 +396,6 @@ make_counters! {
 
     constant_state_bumps,
 
-    // Not using "getivar_" to exclude this from exit reasons
-    get_ivar_max_depth,
-
     // Currently, it's out of the ordinary (might be impossible) for YJIT to leave gaps in
     // executable memory, so this should be 0.
     exec_mem_non_bump_alloc,
@@ -407,10 +404,14 @@ make_counters! {
 
     num_send,
     num_send_known_class,
+    num_send_megamorphic,
     num_send_polymorphic,
     num_send_x86_rel32,
     num_send_x86_reg,
     num_send_dynamic,
+
+    num_getivar_megamorphic,
+    num_setivar_megamorphic,
 
     iseq_stack_too_large,
     iseq_too_long,


### PR DESCRIPTION
This PR generates the dynamic send dispatch https://github.com/ruby/ruby/pull/8106 when a callsite becomes megamorphic for receiver classes. It's currently the top exit reason on SFR.

In addition to generating that code, this PR adds another counter, `num_send_megamorphic`, which counts the number of such calls. For consistency, I renamed `get_ivar_max_depth` to `num_getivar_megamorphic`, and introduced `num_setivar_megamorphic` as well.