### PR TITLE
Reduce dependency to is_notop_id for Universal Parser

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -284,6 +284,9 @@ parse_isxdigit(int c)
 #undef STRNCASECMP
 #define STRNCASECMP rb_parser_st_locale_insensitive_strncasecmp
 
+#undef is_notop_id
+#define is_notop_id(id) ((id)>tLAST_OP_ID)
+
 #ifdef RIPPER
 #include "ripper_init.h"
 #endif

--- a/ruby_parser.c
+++ b/ruby_parser.c
@@ -179,12 +179,6 @@ is_attrset_id2(ID id)
     return is_attrset_id(id);
 }
 
-static int
-is_notop_id2(ID id)
-{
-    return is_notop_id(id);
-}
-
 static VALUE
 enc_str_new(const char *ptr, long len, void *enc)
 {
@@ -636,7 +630,6 @@ rb_parser_config_initialize(rb_parser_config_t *config)
     config->intern2               = rb_intern2;
     config->intern3               = intern3;
     config->intern_str            = rb_intern_str;
-    config->is_notop_id           = is_notop_id2;
     config->enc_symname_type      = enc_symname_type;
     config->str_intern            = rb_str_intern;
     config->id2name               = rb_id2name;

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -409,7 +409,6 @@ typedef struct rb_parser_config_struct {
     ID (*intern2)(const char *name, long len);
     ID (*intern3)(const char *name, long len, rb_encoding *enc);
     ID (*intern_str)(VALUE str);
-    int (*is_notop_id)(ID);
     int (*enc_symname_type)(const char *name, long len, rb_encoding *enc, unsigned int allowed_attrset);
     VALUE (*str_intern)(VALUE str);
     const char *(*id2name)(ID id);

--- a/universal_parser.c
+++ b/universal_parser.c
@@ -166,7 +166,6 @@ struct rb_imemo_tmpbuf_struct {
 #define rb_intern2               p->config->intern2
 #define rb_intern3               p->config->intern3
 #define rb_intern_str            p->config->intern_str
-#define is_notop_id              p->config->is_notop_id
 #define rb_enc_symname_type      p->config->enc_symname_type
 #define rb_str_intern            p->config->str_intern
 #define rb_id2name               p->config->id2name


### PR DESCRIPTION
Add `is_notop_id` macro defination in parse.y that reduce dependency C API for Universal Parser.