### PR TITLE
use inline cache for refinements

### DIFF
--- a/eval.c
+++ b/eval.c
@@ -1341,7 +1341,7 @@ rb_using_module(const rb_cref_t *cref, VALUE module)
 {
     Check_Type(module, T_MODULE);
     using_module_recursive(cref, module);
-    rb_clear_method_cache_all();
+    rb_clear_all_refinement_method_cache();
 }
 
 /*

--- a/gc.c
+++ b/gc.c
@@ -3187,6 +3187,8 @@ vm_ccs_free(struct rb_class_cc_entries *ccs, int alive, rb_objspace_t *objspace,
                     asan_poison_object((VALUE)cc);
                 }
             }
+
+            VM_ASSERT(!vm_cc_super_p(cc) && !vm_cc_refinement_p(cc));
             vm_cc_invalidate(cc);
         }
         ruby_xfree(ccs->entries);

--- a/method.h
+++ b/method.h
@@ -249,6 +249,6 @@ void rb_scope_visibility_set(rb_method_visibility_t);
 VALUE rb_unnamed_parameters(int arity);
 
 void rb_clear_method_cache(VALUE klass_or_module, ID mid);
-void rb_clear_method_cache_all(void);
+void rb_clear_all_refinement_method_cache(void);
 
 #endif /* RUBY_METHOD_H */

--- a/test/ruby/test_refinement.rb
+++ b/test/ruby/test_refinement.rb
@@ -2626,6 +2626,24 @@ class TestRefinement < Test::Unit::TestCase
     assert_equal([], Refinement.used_modules)
   end
 
+  def test_inlinecache
+    assert_separately([], <<-"end;")
+      module R
+        refine String do
+          def to_s = :R
+        end
+      end
+
+      2.times{|i|
+        s = ''.to_s
+        assert_equal '', s if i == 0
+        assert_equal :R, s if i == 1
+        using R            if i == 0
+        assert_equal :R, ''.to_s
+      }
+    end;
+  end
+
   private
 
   def eval_using(mod, s)

--- a/vm_callinfo.h
+++ b/vm_callinfo.h
@@ -296,13 +296,15 @@ struct rb_callcache {
 #define VM_CALLCACHE_UNMARKABLE FL_FREEZE
 #define VM_CALLCACHE_ON_STACK   FL_EXIVAR
 
-#define VM_CALLCACHE_IVAR  IMEMO_FL_USER0
-#define VM_CALLCACHE_BF    IMEMO_FL_USER1
-#define VM_CALLCACHE_SUPER IMEMO_FL_USER2
+#define VM_CALLCACHE_IVAR       IMEMO_FL_USER0
+#define VM_CALLCACHE_BF         IMEMO_FL_USER1
+#define VM_CALLCACHE_SUPER      IMEMO_FL_USER2
+#define VM_CALLCACHE_REFINEMENT IMEMO_FL_USER3
 
 enum vm_cc_type {
     cc_type_normal, // chained from ccs
     cc_type_super,
+    cc_type_refinement,
 };
 
 extern const struct rb_callcache *rb_vm_empty_cc(void);
@@ -332,6 +334,9 @@ vm_cc_new(VALUE klass,
       case cc_type_super:
         *(VALUE *)&cc->flags |= VM_CALLCACHE_SUPER;
         break;
+      case cc_type_refinement:
+        *(VALUE *)&cc->flags |= VM_CALLCACHE_REFINEMENT;
+        break;
     }
 
     vm_cc_attr_index_initialize(cc, INVALID_SHAPE_ID);
@@ -343,6 +348,12 @@ static inline bool
 vm_cc_super_p(const struct rb_callcache *cc)
 {
     return (cc->flags & VM_CALLCACHE_SUPER) != 0;
+}
+
+static inline bool
+vm_cc_refinement_p(const struct rb_callcache *cc)
+{
+    return (cc->flags & VM_CALLCACHE_REFINEMENT) != 0;
 }
 
 #define VM_CC_ON_STACK(clazz, call, aux, cme) \

--- a/vm_core.h
+++ b/vm_core.h
@@ -278,7 +278,7 @@ union iseq_inline_storage_entry {
 };
 
 struct rb_calling_info {
-    const struct rb_callinfo *ci;
+    const struct rb_call_data *cd;
     const struct rb_callcache *cc;
     VALUE block_handler;
     VALUE recv;

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -96,7 +96,10 @@ vm_call0_cc(rb_execution_context_t *ec, VALUE recv, ID id, int argc, const VALUE
     }
 
     struct rb_calling_info calling = {
-        .ci = &VM_CI_ON_STACK(id, flags, argc, NULL),
+        .cd = &(struct rb_call_data) {
+            .ci = &VM_CI_ON_STACK(id, flags, argc, NULL),
+            .cc = NULL,
+        },
         .cc = cc,
         .block_handler = vm_passed_block_handler(ec),
         .recv = recv,
@@ -117,7 +120,7 @@ vm_call0_cme(rb_execution_context_t *ec, struct rb_calling_info *calling, const 
 static VALUE
 vm_call0_super(rb_execution_context_t *ec, struct rb_calling_info *calling, const VALUE *argv, VALUE klass, enum method_missing_reason ex)
 {
-    ID mid = vm_ci_mid(calling->ci);
+    ID mid = vm_ci_mid(calling->cd->ci);
     klass = RCLASS_SUPER(klass);
 
     if (klass) {
@@ -136,7 +139,7 @@ vm_call0_super(rb_execution_context_t *ec, struct rb_calling_info *calling, cons
 static VALUE
 vm_call0_cfunc_with_frame(rb_execution_context_t* ec, struct rb_calling_info *calling, const VALUE *argv)
 {
-    const struct rb_callinfo *ci = calling->ci;
+    const struct rb_callinfo *ci = calling->cd->ci;
     VALUE val;
     const rb_callable_method_entry_t *me = vm_cc_cme(calling->cc);
     const rb_method_cfunc_t *cfunc = UNALIGNED_MEMBER_PTR(me->def, body.cfunc);
@@ -201,7 +204,7 @@ vm_call_check_arity(struct rb_calling_info *calling, int argc, const VALUE *argv
 static VALUE
 vm_call0_body(rb_execution_context_t *ec, struct rb_calling_info *calling, const VALUE *argv)
 {
-    const struct rb_callinfo *ci = calling->ci;
+    const struct rb_callinfo *ci = calling->cd->ci;
     const struct rb_callcache *cc = calling->cc;
     VALUE ret;
 

--- a/vm_method.c
+++ b/vm_method.c
@@ -322,6 +322,7 @@ invalidate_all_cc(void *vstart, void *vend, size_t stride, void *data)
                 RCLASS_CC_TBL(v) = NULL;
             }
         }
+
         if (ptr) {
             asan_poison_object(v);
         }

--- a/vm_method.c
+++ b/vm_method.c
@@ -307,19 +307,19 @@ rb_clear_method_cache(VALUE klass_or_module, ID mid)
 void rb_cc_table_free(VALUE klass);
 
 static int
-invalidate_all_cc(void *vstart, void *vend, size_t stride, void *data)
+invalidate_all_refinement_cc(void *vstart, void *vend, size_t stride, void *data)
 {
     VALUE v = (VALUE)vstart;
     for (; v != (VALUE)vend; v += stride) {
         void *ptr = asan_poisoned_object_p(v);
         asan_unpoison_object(v, false);
+
         if (RBASIC(v)->flags) { // liveness check
-            if (RB_TYPE_P(v, T_CLASS) ||
-                RB_TYPE_P(v, T_ICLASS)) {
-                if (RCLASS_CC_TBL(v)) {
-                    rb_cc_table_free(v);
+            if (imemo_type_p(v, imemo_callcache)) {
+                const struct rb_callcache *cc = (const struct rb_callcache *)v;
+                if (vm_cc_refinement_p(cc) && cc->klass) {
+                    vm_cc_invalidate(cc);
                 }
-                RCLASS_CC_TBL(v) = NULL;
             }
         }
 
@@ -331,10 +331,9 @@ invalidate_all_cc(void *vstart, void *vend, size_t stride, void *data)
 }
 
 void
-rb_clear_method_cache_all(void)
+rb_clear_all_refinement_method_cache(void)
 {
-    rb_objspace_each_objects(invalidate_all_cc, NULL);
-
+    rb_objspace_each_objects(invalidate_all_refinement_cc, NULL);
     rb_yjit_invalidate_all_method_lookup_assumptions();
 }
 


### PR DESCRIPTION
From Ruby 3.0, refined method invocations are slow because resolved methods are not cached by inline cache because of conservertive strategy. However, `using` clears all caches so that it seems safe to cache resolved method entries.

This patch caches resolved method entries in inline cache and clear all of inline method caches when `using` is called.

This patch also introduced the following techniques.

`VM_CALLCACHE_ORPHAN` means the callcache is not belonging to a specific class and can not be invalidated with `rb_cc_table_free()`.

`struct rb_calling_info::cd` is introduced and `rb_calling_info::ci` is replaced with it to manipulate the inline cache of iseq from `vm_call_refined()`. So that `ci` can be acessed with `calling->cd->ci`. It adds one indirection but it can be justified by the following points:

1) `vm_search_method_fastpath()` doesn't need `ci` and also `vm_call_iseq_setup_normal()` doesn't need `ci`. It means reducing `cd->ci` access in `vm_sendish()` can make it faster.

2) most of method types need to access `ci` once in theory so that 1 additional indirection doesn't matter.

fix [Bug #18572]

```ruby
 # without refinements

class C
  def foo = :C
end

N = 1_000_000

obj = C.new
require 'benchmark'
Benchmark.bm{|x|
  x.report{N.times{
    obj.foo; obj.foo; obj.foo; obj.foo; obj.foo;
    obj.foo; obj.foo; obj.foo; obj.foo; obj.foo;
    obj.foo; obj.foo; obj.foo; obj.foo; obj.foo;
    obj.foo; obj.foo; obj.foo; obj.foo; obj.foo;
  }}
}

_END__
              user     system      total        real
master    0.362859   0.002544   0.365403 (  0.365424)
modified  0.357251   0.000000   0.357251 (  0.357258)
```

```ruby
 # with refinment but without using

class C
  def foo = :C
end

module R
  refine C do
    def foo = :R
  end
end

N = 1_000_000

obj = C.new
require 'benchmark'
Benchmark.bm{|x|
  x.report{N.times{
    obj.foo; obj.foo; obj.foo; obj.foo; obj.foo;
    obj.foo; obj.foo; obj.foo; obj.foo; obj.foo;
    obj.foo; obj.foo; obj.foo; obj.foo; obj.foo;
    obj.foo; obj.foo; obj.foo; obj.foo; obj.foo;
  }}
}
__END__
               user     system      total        real
master     0.957182   0.000000   0.957182 (  0.957212)
modified   0.359228   0.000000   0.359228 (  0.359238)
```

```ruby
 # with using

class C
  def foo = :C
end

module R
  refine C do
    def foo = :R
  end
end

N = 1_000_000

using R

obj = C.new
require 'benchmark'
Benchmark.bm{|x|
  x.report{N.times{
    obj.foo; obj.foo; obj.foo; obj.foo; obj.foo;
    obj.foo; obj.foo; obj.foo; obj.foo; obj.foo;
    obj.foo; obj.foo; obj.foo; obj.foo; obj.foo;
    obj.foo; obj.foo; obj.foo; obj.foo; obj.foo;
  }}
}

__END__
               user     system      total        real
master     1.362208   0.000000   1.362208 (  1.362243)
modified   0.356346   0.000609   0.356955 (  0.356961)
```