### PR TITLE
YJIT: Count setivar too-complex exits

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -2287,6 +2287,7 @@ fn gen_setinstancevariable(
                 let new_shape_id = unsafe { rb_shape_id(dest_shape) };
 
                 if new_shape_id == OBJ_TOO_COMPLEX_SHAPE_ID {
+                    gen_counter_incr(asm, Counter::setivar_too_complex);
                     return None;
                 }
 

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -323,6 +323,7 @@ make_counters! {
     setivar_not_heap,
     setivar_frozen,
     setivar_megamorphic,
+    setivar_too_complex,
 
     definedivar_not_heap,
     definedivar_megamorphic,


### PR DESCRIPTION
`setinstancevariable` became the top exit reason on SFR, but `(all relevant counters are zero)`. This seems like a case that is missing a counter, so this PR adds a counter for it.