### PR TITLE
do not clear cme but invalidate cc

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -10131,15 +10131,12 @@ gc_ref_update_imemo(rb_objspace_t *objspace, VALUE obj)
             if (cc->klass) {
                 UPDATE_IF_MOVED(objspace, cc->klass);
                 if (!is_live_object(objspace, cc->klass)) {
-                    *((VALUE *)(&cc->klass)) = (VALUE)0;
+                    vm_cc_invalidate(cc);
                 }
-
-                // cc->cme_ is available if cc->klass is given
-
-                if (cc->cme_) {
+                else if (cc->cme_) { // cc->cme_ is available if cc->klass is given
                     TYPED_UPDATE_IF_MOVED(objspace, struct rb_callable_method_entry_struct *, cc->cme_);
                     if (!is_live_object(objspace, (VALUE)cc->cme_)) {
-                        *((struct rb_callable_method_entry_struct **)(&cc->cme_)) = (struct rb_callable_method_entry_struct *)0;
+                        vm_cc_invalidate(cc);
                     }
                 }
             }


### PR DESCRIPTION
To invalidate a cc, we need to clear cc->klass by `vm_cc_invalidate()`. I hope this patch fix the CI failures.