### PR TITLE
[Feature #19787] Add `Enumerable#uniq_map`, `Enumerable::Lazy#uniq_map`, `Array#uniq_map` and `Array#uniq_map!`

### DIFF
--- a/benchmark/array_uniq_map.yml
+++ b/benchmark/array_uniq_map.yml
@@ -1,0 +1,6 @@
+prelude: a = Array.new(100) { |i| i % 2 }
+benchmark:
+  a.map { ... }.uniq: a.map { |i| i * 2 }.uniq
+  a.uniq_map { ... }: a.uniq_map { |i| i * 2 }
+  a.map! { ... }.uniq!: a.map! { |i| i * 2 }.uniq!
+  a.uniq_map! { ... }: a.uniq_map! { |i| i * 2 }

--- a/benchmark/enum_uniq_map.yml
+++ b/benchmark/enum_uniq_map.yml
@@ -1,0 +1,4 @@
+prelude: e = Array.new(100) { |i| i % 2 }.to_enum
+benchmark:
+  e.map { ... }.uniq: e.map { |i| i * 2 }.uniq
+  e.uniq_map { ... }: e.uniq_map { |i| i * 2 }

--- a/spec/ruby/core/array/shared/collect.rb
+++ b/spec/ruby/core/array/shared/collect.rb
@@ -90,6 +90,10 @@ describe :array_collect_b, shared: true do
       -> { ArraySpecs.frozen_array.send(@method) {} }.should raise_error(FrozenError)
     end
 
+    it "doesn't yield to the block on a frozen array" do
+      -> { ArraySpecs.frozen_array.send(@method) {raise RangeError, "shouldn't yield" } }.should raise_error(FrozenError)
+    end
+
     it "raises a FrozenError when empty" do
       -> { ArraySpecs.empty_frozen_array.send(@method) {} }.should raise_error(FrozenError)
     end

--- a/spec/ruby/core/array/shared/uniq_map.rb
+++ b/spec/ruby/core/array/shared/uniq_map.rb
@@ -1,0 +1,118 @@
+require_relative '../../../spec_helper'
+require_relative '../fixtures/classes'
+require_relative 'collect'
+
+ruby_version_is "3.4" do
+  describe :array_uniq_map, shared: true do
+    it "compares elements returned by the block" do
+      a = [1, 2, 3, 4]
+      a.send(@method) { |x| x >= 3 ? x : 0 }.should == [0, 3, 4]
+    end
+
+    it "yields items in order" do
+      a = [1, 2, 3]
+      yielded = []
+      a.send(@method) { |i| yielded << i; i }
+      yielded.should == a
+    end
+
+    it "properly handles recursive arrays" do
+      empty = ArraySpecs.empty_recursive_array
+      empty.send(@method) { |i| i }.should == [empty]
+
+      array = ArraySpecs.recursive_array
+      array.send(@method) { |i| i }.should == [1, 'two', 3.0, array]
+    end
+
+    it "handles nil and false like any other values" do
+      [nil, false, 42].send(@method) { |i| i }.should == [nil, false, 42]
+      [false, nil, 42].send(@method) { |i| i }.should == [false, nil, 42]
+    end
+
+    it "uses eql? semantics" do
+      [1.0, 1].send(@method) { |i| i }.should == [1.0, 1]
+    end
+
+    it "compares elements first with hash" do
+      x = mock('0')
+      x.should_receive(:hash).at_least(1).and_return(0)
+      y = mock('0')
+      y.should_receive(:hash).at_least(1).and_return(0)
+
+      [x, y].send(@method) { |i| i }.should == [x, y]
+    end
+
+    it "does not compare elements with different hash codes via eql?" do
+      x = mock('0')
+      x.should_not_receive(:eql?)
+      y = mock('1')
+      y.should_not_receive(:eql?)
+
+      x.should_receive(:hash).at_least(1).and_return(0)
+      y.should_receive(:hash).at_least(1).and_return(1)
+
+      [x, y].send(@method) { |i| i }.should == [x, y]
+    end
+
+    it "compares elements with matching hash codes with #eql?" do
+      a = Array.new(2) do
+        obj = mock('0')
+        obj.should_receive(:hash).at_least(1).and_return(0)
+
+        def obj.eql?(o)
+          false
+        end
+
+        obj
+      end
+
+      a.send(@method) { |i| i }.should == a
+
+      a = Array.new(2) do
+        obj = mock('0')
+        obj.should_receive(:hash).at_least(1).and_return(0)
+
+        def obj.eql?(o)
+          true
+        end
+
+        obj
+      end
+
+      a.send(@method) { |i| i }.size.should == 1
+    end
+
+    it "properly handles an identical item even when its #eql? isn't reflexive" do
+      x = mock('x')
+      x.should_receive(:hash).at_least(1).and_return(42)
+      x.stub!(:eql?).and_return(false)
+
+      [x, x].send(@method) { |i| i }.should == [x]
+    end
+
+
+    describe "given an array of BasicObject subclasses that define ==, eql?, and hash" do
+      it "filters equivalent elements using those definitions" do
+        basic = Class.new(BasicObject) do
+          attr_reader :x
+
+          def initialize(x)
+            @x = x
+          end
+
+          def ==(rhs)
+            @x == rhs.x
+          end
+          alias_method :eql?, :==
+
+          def hash
+            @x.hash
+          end
+        end
+
+        a = [basic.new(3), basic.new(2), basic.new(1), basic.new(4), basic.new(1), basic.new(2), basic.new(3)]
+        a.send(@method) { |i| i }.should == [basic.new(3), basic.new(2), basic.new(1), basic.new(4)]
+      end
+    end
+  end
+end

--- a/spec/ruby/core/array/uniq_map_spec.rb
+++ b/spec/ruby/core/array/uniq_map_spec.rb
@@ -1,0 +1,40 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+require_relative 'shared/uniq_map'
+
+ruby_version_is "3.4" do
+  describe "Array#uniq_map" do
+    @method = :uniq_map
+    @value_to_return = -> e { e }
+    it_behaves_like :array_uniq_map, :uniq_map
+    it_behaves_like :array_collect, :uniq_map
+
+    it "returns an array with no duplicates" do
+      ["a", "a", "b", "b", "c"].uniq_map { |i| i }.should == ["a", "b", "c"]
+      ["a", "a", "b", "b", "c"].uniq_map { |i| i * 2 }.should == ["aa", "bb", "cc"]
+    end
+  end
+
+  describe "Array#uniq_map!" do
+    @method = :uniq_map!
+    @value_to_return = -> e { e }
+    it_behaves_like :array_uniq_map, :uniq_map!
+    it_behaves_like :array_collect_b, :uniq_map!
+
+    it "modifies the array in place with no duplicates" do
+      a = [ "a", "a", "b", "b", "c" ]
+      b = a.dup
+
+      a.uniq_map! { |i| i }
+      a.should == ["a", "b", "c"]
+
+      b.uniq_map! { |i| i * 2 }
+      b.should == ["aa", "bb", "cc"]
+    end
+
+    it "returns self" do
+      a = [ "a", "a", "b", "b", "c" ]
+      a.should equal(a.uniq_map! { |i| i })
+    end
+  end
+end

--- a/spec/ruby/core/enumerable/uniq_map_spec.rb
+++ b/spec/ruby/core/enumerable/uniq_map_spec.rb
@@ -1,0 +1,102 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+ruby_version_is "3.4" do
+  describe 'Enumerable#uniq_map' do
+    it 'returns an enumerator when no block given' do
+      EnumerableSpecs::Empty.new.uniq_map.should be_an_instance_of(Enumerator)
+    end
+
+    it 'returns an empty array if there are no elements' do
+      EnumerableSpecs::Empty.new.uniq_map { true }.should == []
+    end
+
+    it 'returns an array that contains only unique elements' do
+      [0, 1, 1].to_enum.uniq_map { |i| i }.should == [0, 1]
+      [0, 1, 1].to_enum.uniq_map(&:to_s).should == ['0', '1']
+      [0, 1, 1].to_enum.uniq_map { |i| i * 2 }.should == [0, 2]
+      (0..5).uniq_map { |i| i.odd? ? i * 2 : i }.should == [0, 2, 6, 4, 10]
+      {foo: 0, bar: 1, baz: 1}.uniq_map { |_key, value| value * 2 }.should == [0, 2]
+    end
+
+    it 'returns the same result as calling #uniq on #map' do
+      a_map_uniq = [0, 1, 1].to_enum.map { |i| i * 2 }.uniq
+      a_uniq_map = [0, 1, 1].to_enum.uniq_map { |i| i * 2 }
+      a_map_uniq.should == a_uniq_map
+
+      h_map_uniq = {foo: 0, bar: 1, baz: 1}.map { |_key, value| value * 2 }.uniq
+      h_uniq_map = {foo: 0, bar: 1, baz: 1}.uniq_map { |_key, value| value * 2 }
+      h_map_uniq.should == h_uniq_map
+    end
+
+    it "uses eql? semantics" do
+      [1.0, 1].to_enum.uniq_map { |i| i }.should == [1.0, 1]
+    end
+
+    it "compares elements first with hash" do
+      x = mock('0')
+      x.should_receive(:hash).at_least(1).and_return(0)
+      y = mock('0')
+      y.should_receive(:hash).at_least(1).and_return(0)
+
+      [x, y].to_enum.uniq_map { |i| i }.should == [x, y]
+    end
+
+    it "does not compare elements with different hash codes via eql?" do
+      x = mock('0')
+      x.should_not_receive(:eql?)
+      y = mock('1')
+      y.should_not_receive(:eql?)
+
+      x.should_receive(:hash).at_least(1).and_return(0)
+      y.should_receive(:hash).at_least(1).and_return(1)
+
+      [x, y].to_enum.uniq_map { |i| i }.should == [x, y]
+    end
+
+    it "compares elements with matching hash codes with #eql?" do
+      a = Array.new(2) do
+        obj = mock('0')
+        obj.should_receive(:hash).at_least(1).and_return(0)
+
+        def obj.eql?(o)
+          false
+        end
+
+        obj
+      end
+
+      a.uniq_map { |i| i }.should == a
+
+      a = Array.new(2) do
+        obj = mock('0')
+        obj.should_receive(:hash).at_least(1).and_return(0)
+
+        def obj.eql?(o)
+          true
+        end
+
+        obj
+      end
+
+      a.to_enum.uniq_map { |i| i }.size.should == 1
+    end
+
+    context 'when yielded with multiple arguments' do
+      before :each do
+        @enum = Object.new.to_enum
+        class << @enum
+          def each
+            yield 0, 'foo'
+            yield 1, 'FOO'
+            yield 2, 'bar'
+          end
+        end
+      end
+
+      it 'returns all yield arguments as an array' do
+        @enum.uniq_map { |_, label| label.downcase }.should == ['foo', 'bar']
+      end
+    end
+  end
+end

--- a/spec/ruby/core/enumerator/lazy/lazy_spec.rb
+++ b/spec/ruby/core/enumerator/lazy/lazy_spec.rb
@@ -20,6 +20,10 @@ describe "Enumerator::Lazy" do
       lazy_methods += [:compact]
     end
 
+    ruby_version_is '3.4' do
+      lazy_methods += [:uniq_map]
+    end
+
     Enumerator::Lazy.instance_methods(false).should include(*lazy_methods)
   end
 end

--- a/spec/ruby/core/enumerator/lazy/uniq_map_spec.rb
+++ b/spec/ruby/core/enumerator/lazy/uniq_map_spec.rb
@@ -1,0 +1,44 @@
+require_relative '../../../spec_helper'
+require_relative 'fixtures/classes'
+
+ruby_version_is "3.4" do
+  describe 'Enumerator::Lazy#uniq_map' do
+    context 'when yielded with an argument' do
+      before :each do
+        @lazy = [0, 1, 0, 1].to_enum.lazy.uniq_map { |i| (i * 2).to_s }
+      end
+
+      it 'returns a lazy enumerator' do
+        @lazy.should be_an_instance_of(Enumerator::Lazy)
+        @lazy.force.should == ["0", "2"]
+      end
+
+      it 'sets the size to nil' do
+        @lazy.size.should == nil
+      end
+    end
+
+    context 'when yielded with multiple arguments' do
+      before :each do
+        enum = Object.new.to_enum
+        class << enum
+          def each
+            yield 0, 'foo'
+            yield 1, 'FOO'
+            yield 2, 'bar'
+          end
+        end
+        @lazy = enum.lazy
+      end
+
+      it 'returns all yield arguments as an array' do
+        @lazy.uniq_map { |_, label| label.downcase }.force.should == ['foo', 'bar']
+      end
+    end
+
+    it "works with an infinite enumerable" do
+      s = 0..Float::INFINITY
+      s.lazy.uniq_map { |i| i }.first(100).should == s.first(100).uniq_map { |i| i }
+    end
+  end
+end

--- a/test/ruby/test_array.rb
+++ b/test/ruby/test_array.rb
@@ -2276,6 +2276,74 @@ class TestArray < Test::Unit::TestCase
     assert_equal(orig, ary, "must not be modified once frozen")
   end
 
+  if RUBY_VERSION >= "3.4"
+    def test_uniq_map
+      a = []
+      b = a.uniq_map { |v| v * 2 }
+      assert_equal([], a)
+      assert_equal([], b)
+      assert_not_same(a, b)
+
+      a = [1]
+      b = a.uniq_map { |v| v * 2 }
+      assert_equal([1], a)
+      assert_equal([2], b)
+      assert_not_same(a, b)
+
+      a = [1, 1, 2]
+      b = a.uniq_map { |v| v * 2 }
+      assert_equal([1, 1, 2], a)
+      assert_equal([2, 4], b)
+      assert_not_same(a, b)
+
+      a = [{ a: 1 }, { a: 2 }, { a: 1 }]
+      b = a.uniq_map { |h| { b: h[:a] * 2 } }
+      assert_equal([{ a: 1 }, { a: 2 }, { a: 1 }], a)
+      assert_equal([{ b: 2 }, { b: 4 }], b)
+      assert_not_same(a, b)
+
+      a = %w(a a)
+      b = a.uniq_map { |v| v }
+      assert_equal(%w(a a), a)
+      assert(a.none?(&:frozen?))
+      assert_equal(%w(a), b)
+      assert(b.none?(&:frozen?))
+    end
+
+    def test_uniq_map_bang
+      a = []
+      b = a.uniq_map! { |v| v * 2 }
+      assert_equal([], a)
+      assert_equal([], b)
+      assert_same(a, b)
+
+      a = [1]
+      b = a.uniq_map! { |v| v * 2 }
+      assert_equal([2], a)
+      assert_equal([2], b)
+      assert_same(a, b)
+
+      a = [1, 1, 2]
+      b = a.uniq_map! { |v| v * 2 }
+      assert_equal([2, 4], a)
+      assert_equal([2, 4], b)
+      assert_same(a, b)
+
+      a = [ { a: 1 }, { a: 2 }, { a: 1 }]
+      b = a.uniq_map! { |h| { b: h[:a] * 2 } }
+      assert_equal([{ b: 2 }, { b: 4 }], a)
+      assert_equal([{ b: 2 }, { b: 4 }], b)
+      assert_same(a, b)
+
+      a = %w(a a)
+      b = a.uniq_map! { |v| v }
+      assert_equal(%w(a), a)
+      assert(a.none?(&:frozen?))
+      assert_equal(%w(a), b)
+      assert(b.none?(&:frozen?))
+    end
+  end
+
   def test_unshift
     a = @cls[]
     assert_equal(@cls['cat'], a.unshift('cat'))

--- a/test/ruby/test_enum.rb
+++ b/test/ruby/test_enum.rb
@@ -1297,6 +1297,28 @@ class TestEnumerable < Test::Unit::TestCase
     assert_equal([1, [1, 2]], Foo.new.to_enum.uniq)
   end
 
+  if RUBY_VERSION >= "3.4"
+    def test_uniq_map
+      arr = [1, 1, 1, 1, 2, 2, 3, 4, 5, 6]
+      assert_equal([2, 4, 6, 8, 10, 12], arr.uniq_map { |i| i * 2 })
+
+      hash = {
+        1   => 'One',
+        1.0 => 'One',
+        2   => 'Two',
+        3   => 'Three',
+        4   => 'Four',
+      }
+      assert_equal(['One', 'Two', 'Three', 'Four'], hash.uniq_map { |_k, v| v })
+
+      range = 1..100
+      assert_equal([1, 0], range.uniq_map { |i| i % 2 })
+
+      enum = Foo.new.to_enum
+      assert_equal([1], enum.uniq_map { |i| i })
+    end
+  end
+
   def test_compact
     class << (enum = Object.new)
       include Enumerable

--- a/test/ruby/test_enumerator.rb
+++ b/test/ruby/test_enumerator.rb
@@ -569,15 +569,19 @@ class TestEnumerator < Test::Unit::TestCase
 
   def test_size_for_enum_created_from_array
     arr = %w[hello world]
-    %i[each each_with_index reverse_each sort_by! sort_by map map!
-      keep_if reject! reject select! select filter! filter delete_if].each do |method|
+    methods = %i[each each_with_index reverse_each sort_by! sort_by map map!
+      keep_if reject! reject select! select filter! filter delete_if]
+    methods += %i[uniq_map] if RUBY_VERSION >= "3.4"
+    methods.each do |method|
       assert_equal arr.size, arr.send(method).size
     end
   end
 
   def test_size_for_enum_created_from_enumerable
-    %i[find_all reject map flat_map partition group_by sort_by min_by max_by
-      minmax_by each_with_index reverse_each each_entry filter_map].each do |method|
+    methods = %i[find_all reject map flat_map partition group_by sort_by min_by max_by
+      minmax_by each_with_index reverse_each each_entry filter_map]
+    methods += %i[uniq_map] if RUBY_VERSION >= "3.4"
+    methods.each do |method|
       assert_equal nil, @obj.send(method).size
       assert_equal 42, @sized.send(method).size
     end
@@ -597,14 +601,18 @@ class TestEnumerator < Test::Unit::TestCase
   end
 
   def test_size_for_enum_created_from_env
-    %i[each_pair reject! delete_if select select! filter filter! keep_if].each do |method|
+    methods = %i[each_pair reject! delete_if select select! filter filter! keep_if]
+    methods += %i[uniq_map] if RUBY_VERSION >= "3.4"
+    methods.each do |method|
       assert_equal ENV.size, ENV.send(method).size
     end
   end
 
   def test_size_for_enum_created_from_struct
     s = Struct.new(:foo, :bar, :baz).new(1, 2)
-    %i[each each_pair select].each do |method|
+    methods = %i[each each_pair select]
+    methods += %i[uniq_map] if RUBY_VERSION >= "3.4"
+    methods.each do |method|
       assert_equal 3, s.send(method).size
     end
   end


### PR DESCRIPTION
## Description

Implements https://bugs.ruby-lang.org/issues/19787

## Benchmarks

**[Enumerable](https://github.com/joshuay03/ruby/blob/feature/%23uniq_map/benchmark/enum_uniq_map.yml)**

```ruby
./build/ruby: ruby 3.4.0dev (2024-03-16T01:29:18Z feature/#uniq_map 3580e39ed3) [arm64-darwin23]
warming up..
# Iteration per second (i/s)

|                    |./build/ruby|
|:-------------------|-----------:|
|e.map { ... }.uniq  |    145.732k|
|e.uniq_map { ... }  |    190.970k|
```

**[Array](https://github.com/joshuay03/ruby/blob/feature/%23uniq_map/benchmark/array_uniq_map.yml)**

```ruby
./build/ruby: ruby 3.4.0dev (2024-03-16T01:29:18Z feature/#uniq_map 3580e39ed3) [arm64-darwin23]
warming up....
# Iteration per second (i/s)

|                      |./build/ruby|
|:---------------------|-----------:|
|a.map { ... }.uniq    |    202.570k|
|a.uniq_map { ... }    |    242.139k|
|a.map! { ... }.uniq!  |    110.230k|
|a.uniq_map! { ... }   |    111.476k|
```