### PR TITLE
Revert "Use the dedicated method to convert file path" partially

### DIFF
--- a/lib/rubygems/core_ext/kernel_require.rb
+++ b/lib/rubygems/core_ext/kernel_require.rb
@@ -37,7 +37,8 @@ module Kernel
     return gem_original_require(path) unless Gem.discover_gems_on_require
 
     RUBYGEMS_ACTIVATION_MONITOR.synchronize do
-      path = File.path(path)
+      path = path.to_path if path.respond_to? :to_path
+      path = String.try_convert(path) || path
 
       if spec = Gem.find_unresolved_default_spec(path)
         # Ensure -I beats a default gem


### PR DESCRIPTION
This reverts commit 0d86cc4caf1495507b2937654d3ed868278b9ddc. `File.path` is affected by `Encoding.default_internal`, and `require` needs the original encoding for the `LoadError` message.