### PR TITLE
[Bug #19788] Use the result of `tCOLON2` event

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -2045,7 +2045,7 @@ command_asgn	: lhs '=' lex_ctxt command_rhs
                     /*%%%*/
                         $$ = new_attr_op_assign(p, $1, ID2VAL(idCOLON2), $3, $4, $6, &@$);
                     /*% %*/
-                    /*% ripper: opassign!(field!($1, ID2VAL(idCOLON2), $3), $4, $6) %*/
+                    /*% ripper: opassign!(field!($1, $2, $3), $4, $6) %*/
                     }
                 | defn_head f_opt_paren_args '=' endless_command
                     {
@@ -2316,14 +2316,14 @@ command		: fcall command_args       %prec tLOWEST
                     /*%%%*/
                         $$ = new_command_qcall(p, ID2VAL(idCOLON2), $1, $3, $4, Qnull, &@3, &@$);
                     /*% %*/
-                    /*% ripper: command_call!($1, ID2VAL(idCOLON2), $3, $4) %*/
+                    /*% ripper: command_call!($1, $2, $3, $4) %*/
                     }
                 | primary_value tCOLON2 operation2 command_args cmd_brace_block
                     {
                     /*%%%*/
                         $$ = new_command_qcall(p, ID2VAL(idCOLON2), $1, $3, $4, $5, &@3, &@$);
                     /*% %*/
-                    /*% ripper: method_add_block!(command_call!($1, ID2VAL(idCOLON2), $3, $4), $5) %*/
+                    /*% ripper: method_add_block!(command_call!($1, $2, $3, $4), $5) %*/
                    }
                 | keyword_super command_args
                     {
@@ -2599,7 +2599,7 @@ lhs		: user_variable
                     /*%%%*/
                         $$ = attrset(p, $1, idCOLON2, $3, &@$);
                     /*% %*/
-                    /*% ripper: field!($1, ID2VAL(idCOLON2), $3) %*/
+                    /*% ripper: field!($1, $2, $3) %*/
                     }
                 | primary_value call_op tCONSTANT
                     {
@@ -2790,7 +2790,7 @@ arg		: lhs '=' lex_ctxt arg_rhs
                     /*%%%*/
                         $$ = new_attr_op_assign(p, $1, ID2VAL(idCOLON2), $3, $4, $6, &@$);
                     /*% %*/
-                    /*% ripper: opassign!(field!($1, ID2VAL(idCOLON2), $3), $4, $6) %*/
+                    /*% ripper: opassign!(field!($1, $2, $3), $4, $6) %*/
                     }
                 | primary_value tCOLON2 tCONSTANT tOP_ASGN lex_ctxt arg_rhs
                     {
@@ -4351,14 +4351,14 @@ method_call	: fcall paren_args
                         $$ = new_qcall(p, ID2VAL(idCOLON2), $1, $3, $4, &@3, &@$);
                         nd_set_line($$, @3.end_pos.lineno);
                     /*% %*/
-                    /*% ripper: method_add_arg!(call!($1, ID2VAL(idCOLON2), $3), $4) %*/
+                    /*% ripper: method_add_arg!(call!($1, $2, $3), $4) %*/
                     }
                 | primary_value tCOLON2 operation3
                     {
                     /*%%%*/
                         $$ = new_qcall(p, ID2VAL(idCOLON2), $1, $3, Qnull, &@3, &@$);
                     /*% %*/
-                    /*% ripper: call!($1, ID2VAL(idCOLON2), $3) %*/
+                    /*% ripper: call!($1, $2, $3) %*/
                     }
                 | primary_value call_op paren_args
                     {
@@ -4374,7 +4374,7 @@ method_call	: fcall paren_args
                         $$ = new_qcall(p, ID2VAL(idCOLON2), $1, ID2VAL(idCall), $3, &@2, &@$);
                         nd_set_line($$, @2.end_pos.lineno);
                     /*% %*/
-                    /*% ripper: method_add_arg!(call!($1, ID2VAL(idCOLON2), ID2VAL(idCall)), $3) %*/
+                    /*% ripper: method_add_arg!(call!($1, $2, ID2VAL(idCall)), $3) %*/
                     }
                 | keyword_super paren_args
                     {

--- a/test/ripper/test_parser_events.rb
+++ b/test/ripper/test_parser_events.rb
@@ -499,6 +499,23 @@ class TestRipper::ParserEvents < Test::Unit::TestCase
     assert_equal "[call(ref(self),&.,foo,[])]", tree
   end
 
+  def test_call_colon2
+    hook = Module.new do
+      def on_op(op)
+        super("(op: #{op.inspect})")
+      end
+      def on_call(recv, name, *args)
+        super(recv, "(method: #{name})", *args)
+      end
+      def on_ident(name)
+        super("(ident: #{name.inspect})")
+      end
+    end
+
+    parser = DummyParser.new("a::b").extend(hook)
+    assert_equal '[call(vcall((ident: "a")),(method: (op: "::")),(ident: "b"))]', parser.parse.to_s
+  end
+
   def test_excessed_comma
     thru_excessed_comma = false
     parse("proc{|x,|}", :on_excessed_comma) {thru_excessed_comma = true}

--- a/test/ripper/test_scanner_events.rb
+++ b/test/ripper/test_scanner_events.rb
@@ -179,6 +179,11 @@ class TestRipper::ScannerEvents < Test::Unit::TestCase
                  scan('backtick', %q[p `make all`])
   end
 
+  def test_colon2_call
+    assert_equal ["::"],
+                 scan('op', %q[ a::b ])
+  end
+
   def test_comma
     assert_equal [','] * 6,
                  scan('comma', %q[ m(0,1,2,3,4,5,6) ])


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/19788