### PR TITLE
mark `cc->cme_` if it is for `super`

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -7030,7 +7030,15 @@ gc_mark_imemo(rb_objspace_t *objspace, VALUE obj)
          * - On the multi-Ractors, cme will be collected with global GC
          *   so that it is safe if GC is not interleaving while accessing
          *   cc and cme.
+         * - However, cc_type_super is not chained from cc so the cc->cme
+         *   should be marked.
          */
+        {
+            const struct rb_callcache *cc = (const struct rb_callcache *)obj;
+            if (vm_cc_super_p(cc)) {
+                gc_mark(objspace, (VALUE)cc->cme_);
+            }
+        }
         return;
       case imemo_constcache:
         {

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -425,7 +425,7 @@ cc_new(VALUE klass, ID mid, int argc, const rb_callable_method_entry_t *cme)
 
         if (cc == NULL) {
             const struct rb_callinfo *ci = vm_ci_new(mid, 0, argc, NULL); // TODO: proper ci
-            cc = vm_cc_new(klass, cme, vm_call_general);
+            cc = vm_cc_new(klass, cme, vm_call_general, cc_type_normal);
             METHOD_ENTRY_CACHED_SET((struct rb_callable_method_entry_struct *)cme);
             vm_ccs_push(klass, ccs, ci, cc);
         }

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -2096,7 +2096,7 @@ vm_search_cc(const VALUE klass, const struct rb_callinfo * const ci)
 
     cme = check_overloaded_cme(cme, ci);
 
-    const struct rb_callcache *cc = vm_cc_new(klass, cme, vm_call_general);
+    const struct rb_callcache *cc = vm_cc_new(klass, cme, vm_call_general, cc_type_normal);
     vm_ccs_push(klass, ccs, ci, cc);
 
     VM_ASSERT(vm_cc_cme(cc) != NULL);
@@ -4630,7 +4630,7 @@ vm_search_super_method(const rb_control_frame_t *reg_cfp, struct rb_call_data *c
 
     if (!klass) {
         /* bound instance method of module */
-        cc = vm_cc_new(klass, NULL, vm_call_method_missing);
+        cc = vm_cc_new(klass, NULL, vm_call_method_missing, cc_type_super);
         RB_OBJ_WRITE(reg_cfp->iseq, &cd->cc, cc);
     }
     else {
@@ -4645,7 +4645,7 @@ vm_search_super_method(const rb_control_frame_t *reg_cfp, struct rb_call_data *c
         else if (cached_cme->called_id != mid) {
             const rb_callable_method_entry_t *cme = rb_callable_method_entry(klass, mid);
             if (cme) {
-                cc = vm_cc_new(klass, cme, vm_call_super_method);
+                cc = vm_cc_new(klass, cme, vm_call_super_method, cc_type_super);
                 RB_OBJ_WRITE(reg_cfp->iseq, &cd->cc, cc);
             }
             else {


### PR DESCRIPTION
`vm_search_super_method()` makes orphan CCs (they are not connected from ccs) and `cc->cme_` can be collected before without marking.