### PR TITLE
[Feature #19785] Deprecate RUBY_GC_HEAP_INIT_SLOTS

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@ Note that each entry is kept to a minimum, see links for details.
 * A new `performance` warning category was introduced.
   They are not displayed by default even in verbose mode.
   Turn them on with `-W:performance` or `Warning[:performance] = true`. [[Feature #19538]]
+* The `RUBY_GC_HEAP_INIT_SLOTS` environment variable has been deprecated and removed. Environment variables `RUBY_GC_HEAP_INIT_SIZE_%d_SLOTS` should be used instead. [[Feature #19785]]
 
 ## Core classes updates
 
@@ -158,3 +159,4 @@ changelog for details of the default gems or bundled gems.
 [Feature #19538]: https://bugs.ruby-lang.org/issues/19538
 [Feature #19591]: https://bugs.ruby-lang.org/issues/19591
 [Feature #19714]: https://bugs.ruby-lang.org/issues/19714
+[Feature #19785]: https://bugs.ruby-lang.org/issues/19785

--- a/gc.c
+++ b/gc.c
@@ -11548,8 +11548,6 @@ gc_set_initial_pages(rb_objspace_t *objspace)
 /*
  * GC tuning environment variables
  *
- * * RUBY_GC_HEAP_INIT_SLOTS
- *   - Initial allocation slots.
  * * RUBY_GC_HEAP_FREE_SLOTS
  *   - Prepare at least this amount of slots after GC.
  *   - Allocate slots if there are not enough slots.
@@ -11596,13 +11594,6 @@ ruby_gc_set_params(void)
         /* ok */
     }
 
-    /* RUBY_GC_HEAP_INIT_SLOTS */
-    size_t global_init_slots = GC_HEAP_INIT_SLOTS;
-    if (get_envparam_size("RUBY_GC_HEAP_INIT_SLOTS", &global_init_slots, 0)) {
-        for (int i = 0; i < SIZE_POOL_COUNT; i++) {
-            gc_params.size_pool_init_slots[i] = global_init_slots;
-        }
-    }
     gc_set_initial_pages(objspace);
 
     get_envparam_double("RUBY_GC_HEAP_GROWTH_FACTOR", &gc_params.growth_factor, 1.0, 0.0, FALSE);

--- a/ruby.c
+++ b/ruby.c
@@ -1738,6 +1738,13 @@ ruby_opt_init(ruby_cmdline_options_t *opt)
 
     rb_warning_category_update(opt->warn.mask, opt->warn.set);
 
+    /* [Feature #19785] Warning for removed GC environment variable.
+     * Remove this in Ruby 3.4. */
+    if (getenv("RUBY_GC_HEAP_INIT_SLOTS")) {
+        rb_warn_deprecated("The environment variable RUBY_GC_HEAP_INIT_SLOTS",
+                           "environment variables RUBY_GC_HEAP_INIT_SIZE_%d_SLOTS");
+    }
+
 #if USE_RJIT
     // rb_call_builtin_inits depends on RubyVM::RJIT.enabled?
     if (opt->rjit.on)


### PR DESCRIPTION
This environment variable is replaced by `RUBY_GC_HEAP_INIT_SIZE_%d_SLOTS`, so it doesn't make sense to keep it.