### PR TITLE
remove strange line event

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -12360,6 +12360,7 @@ reduce_nodes(struct parser_params *p, NODE **body)
             if (!subnodes(nd_head, nd_resq)) goto end;
             break;
           case NODE_RESCUE:
+            newline = 0; // RESBODY should not be a NEWLINE
             if (node->nd_else) {
                 body = &node->nd_resq;
                 break;

--- a/test/ruby/test_settracefunc.rb
+++ b/test/ruby/test_settracefunc.rb
@@ -2725,4 +2725,28 @@ CODE
       Foo.foo
     RUBY
   end
+
+  def helper_cant_rescue
+    begin
+      raise SyntaxError
+    rescue
+      cant_rescue
+    end
+  end
+
+  def test_tp_rescue
+    lines = []
+    TracePoint.new(:line){|tp|
+      next unless target_thread?
+      lines << tp.lineno
+    }.enable{
+      begin
+        helper_cant_rescue
+      rescue SyntaxError
+      end
+    }
+    call_line = lines.shift
+    raise_line = lines.shift
+    assert_equal [], lines
+  end
 end


### PR DESCRIPTION
```ruby
  def helper_cant_rescue
    begin
      raise SyntaxError
    rescue
      cant_rescue # here
    end
  end
```

on this case, a line event is reported on `cant_rescue` line because of node structure. it should not be reported.