### PR TITLE
No computing embed_capa_max in str_subseq

### DIFF
--- a/array.c
+++ b/array.c
@@ -1194,10 +1194,10 @@ ary_make_partial(VALUE ary, VALUE klass, long offset, long len)
     assert(len >= 0);
     assert(offset+len <= RARRAY_LEN(ary));
 
-    const size_t rarray_embed_capa_max = (sizeof(struct RArray) - offsetof(struct RArray, as.ary)) / sizeof(VALUE);
-
-    if ((size_t)len <= rarray_embed_capa_max && ary_embeddable_p(len)) {
-        VALUE result = ary_alloc_embed(klass, len);
+    VALUE result = ary_alloc_heap(klass);
+    size_t embed_capa = ary_embed_capa(result);
+    if ((size_t)len <= embed_capa) {
+        FL_SET_EMBED(result);
         ary_memcpy(result, 0, len, RARRAY_CONST_PTR(ary) + offset);
         ARY_SET_EMBED_LEN(result, len);
         return result;
@@ -1205,7 +1205,6 @@ ary_make_partial(VALUE ary, VALUE klass, long offset, long len)
     else {
         VALUE shared = ary_make_shared(ary);
 
-        VALUE result = ary_alloc_heap(klass);
         assert(!ARY_EMBED_P(result));
 
         ARY_SET_PTR(result, RARRAY_CONST_PTR(ary));

--- a/array.c
+++ b/array.c
@@ -1194,10 +1194,10 @@ ary_make_partial(VALUE ary, VALUE klass, long offset, long len)
     assert(len >= 0);
     assert(offset+len <= RARRAY_LEN(ary));
 
-    VALUE result = ary_alloc_heap(klass);
-    size_t embed_capa = ary_embed_capa(result);
-    if ((size_t)len <= embed_capa) {
-        FL_SET_EMBED(result);
+    const size_t rarray_embed_capa_max = (sizeof(struct RArray) - offsetof(struct RArray, as.ary)) / sizeof(VALUE);
+
+    if ((size_t)len <= rarray_embed_capa_max && ary_embeddable_p(len)) {
+        VALUE result = ary_alloc_embed(klass, len);
         ary_memcpy(result, 0, len, RARRAY_CONST_PTR(ary) + offset);
         ARY_SET_EMBED_LEN(result, len);
         return result;
@@ -1205,6 +1205,7 @@ ary_make_partial(VALUE ary, VALUE klass, long offset, long len)
     else {
         VALUE shared = ary_make_shared(ary);
 
+        VALUE result = ary_alloc_heap(klass);
         assert(!ARY_EMBED_P(result));
 
         ARY_SET_PTR(result, RARRAY_CONST_PTR(ary));


### PR DESCRIPTION
Fix `str_subseq` so that it does not attempt to predict the size of the object returned by `str_alloc_heap`.

Currently, `str_subseq` tries to predict the embedded capacity of a string allocated by `str_alloc_heap` if the returned heap string is transformed into an embedded instance.  This is intended for avoiding creating shared strings if the sub-sequence is too short.

However, the current algorithm for computing the "embed_capa_max" tries to predict the slot size of the GC.  The following line is taken from `str_subseq`:

```c
// From str_subseq in string.c
const long rstring_embed_capa_max = ((sizeof(struct RString) - offsetof(struct RString, as.embed.ary)) / sizeof(char)) - 1;
```

It assumes the GC slot size of the object allocated by `str_alloc_heap` is `sizeof(struct RString)` which is 40 bytes on x86_64.  Currently, the smallest size class of the GC happens to be 40 bytes as well, for both debug and release build.  Therefore, the code above works well for now.

But this implementation is not robust against changes in the underlying garbage collector.  If, for example, the GC algorithm changed, the slot size may no longer be 40 bytes, or the concept of "size class" may disappear.  If the layout of strings changed (which is possible due to the availability of VWA, and the potential to integrate other garbage collectors into the Ruby runtime), the string created by `str_alloc_heap` may no longer occupy a slot in the 40-byte size class, and the formula above will be inaccurate.

The solution is as follows:
1.  We blindly create a heap string using `str_alloc_heap`.
2.  We see if the subsequence can fit into the (already allocated) heap string.
3.  If yes, we transform that heap string into an embedded string, and copy the content of the sub-sequence into it.
4.  Otherwise, we let the newly created string instance share the buffer of the original string.

In this way, the length threshold to decide whether the result is embedded or heap is decided at step (2) by the *actual* size of the allocated heap string.  It will still work even if the size of the result of `str_alloc_heap` changes.

The above algorithm is already partially implemented in `str_new_shared`:

```c
    // Excerpt from `str_new_shared`
    return str_replace_shared(str_alloc_heap(klass), str);
```

This PR further pushes some of the responsibility of `str_subseq` down to `str_new_shared` so that `str_new_shared` can create a string that only shares a suffix (or a part in the middle if the macro `SHARABLE_SUBSTRING_P` is set to 1) of the original string (see the `str_new_shared_partial` function introduced in this PR).  Now `str_replace_shared_partial_without_enc` is the only function that decides whether the result (which may share the whole or part of the original string) is embedded or heap.  `str_subseq` no longer makes this decision.

A similar function for arrays, namely `ary_make_partial`, has a similar problem.  I created [another PR](https://github.com/ruby/ruby/pull/8164) to fix it using the same solution.