### PR TITLE
YJIT: Fallback setivar if the next shape is too complex

### DIFF
--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -323,7 +323,6 @@ make_counters! {
     setivar_not_heap,
     setivar_frozen,
     setivar_megamorphic,
-    setivar_too_complex,
 
     definedivar_not_heap,
     definedivar_megamorphic,


### PR DESCRIPTION
Currently, `setivar_too_complex` is one of the most frequent exit ops on SFR (e.g. 21.7% overall). This exit happens when it needs to transition to a too-complex shape.

This PR hoists out the logic to get the `new_shape_id` (as well as other information that is used to get `new_shape_id` and reused later) and check if it's `OBJ_TOO_COMPLEX_SHAPE_ID` before generating any code. If it is, it fallbacks to the generic setivar C call.