### PR TITLE
Fix typo in anonymous class string

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -13441,7 +13441,7 @@ rb_raw_obj_info_buitin_type(char *const buff, const size_t buff_size, const VALU
                     APPEND_F("%s", RSTRING_PTR(class_path));
                 }
                 else {
-                    APPEND_S("(annon)");
+                    APPEND_S("(anon)");
                 }
                 break;
             }


### PR DESCRIPTION
If anonymous was shorted it should be `anon` not `annon`. Fixes typo in APPEND_S for anonymous classes.

cc/ @tenderlove 