### PR TITLE
YJIT: Fix --yjit-dump-disasm coloring on less(1)

### DIFF
--- a/yjit/src/disasm.rs
+++ b/yjit/src/disasm.rs
@@ -180,23 +180,24 @@ pub fn disasm_addr_range(cb: &CodeBlock, start_addr: usize, end_addr: usize) -> 
     let start_addr = 0;
     let insns = cs.disasm_all(code_slice, start_addr as u64).unwrap();
 
-    // Colorize outlined code in blue
-    if cb.outlined {
-        write!(&mut out, "\x1b[34m").unwrap();
-    }
     // For each instruction in this block
     for insn in insns.as_ref() {
         // Comments for this block
         if let Some(comment_list) = cb.comments_at(insn.address() as usize) {
             for comment in comment_list {
+                if cb.outlined {
+                    write!(&mut out, "\x1b[34m").unwrap(); // Make outlined code blue
+                }
                 writeln!(&mut out, "  \x1b[1m# {comment}\x1b[22m").unwrap(); // Make comments bold
             }
         }
+        if cb.outlined {
+            write!(&mut out, "\x1b[34m").unwrap(); // Make outlined code blue
+        }
         writeln!(&mut out, "  {insn}").unwrap();
-    }
-    // Disable blue color
-    if cb.outlined {
-        write!(&mut out, "\x1b[0m").unwrap();
+        if cb.outlined {
+            write!(&mut out, "\x1b[0m").unwrap(); // Disable blue
+        }
     }
 
     return out;


### PR DESCRIPTION
`less` command does not carry over escape sequences across different lines. Because of that, when you dump disasm into a file with `--yjit-dump-disasm=/tmp` and read it with `less`, the output is wrongly colored.

This PR changes the coloring logic to include every escape sequence that needs to exists in the same line for `less`.

## Before
<img width="277" alt="Screenshot 2023-08-01 at 14 53 01" src="https://github.com/ruby/ruby/assets/3138447/580760b8-84aa-423c-9473-778276c64b8b">

## After
<img width="271" alt="Screenshot 2023-08-01 at 14 56 26" src="https://github.com/ruby/ruby/assets/3138447/76866de7-8aea-4f46-96eb-ec33f7826b7e">