### PR TITLE
Remove --disable-gems for assert_separately

### DIFF
--- a/test/-ext-/string/test_too_many_dummy_encodings.rb
+++ b/test/-ext-/string/test_too_many_dummy_encodings.rb
@@ -4,7 +4,7 @@ require "-test-/string"
 
 class Test_TooManyDummyEncodings < Test::Unit::TestCase
   def test_exceed_encoding_table_size
-    assert_separately(%w[--disable=gems], "#{<<~"begin;"}\n#{<<~'end;'}")
+    assert_separately([], "#{<<~"begin;"}\n#{<<~'end;'}")
     begin;
       require "-test-/string"
       assert_raise_with_message(EncodingError, /too many encoding/) do

--- a/test/ripper/assert_parse_files.rb
+++ b/test/ripper/assert_parse_files.rb
@@ -7,7 +7,7 @@ class TestRipper::Generic < Test::Unit::TestCase
 
   def assert_parse_files(dir, pattern = "**/*.rb", exclude: nil, gc_stress: GC.stress, test_ratio: nil)
     test_ratio ||= ENV["TEST_RIPPER_RATIO"]&.tap {|s|break s.to_f} || 0.05 # testing all files needs too long time...
-    assert_separately(%W[--disable-gem -rripper - #{SRCDIR}/#{dir} #{pattern}],
+    assert_separately(%W[-rripper - #{SRCDIR}/#{dir} #{pattern}],
                       __FILE__, __LINE__, "#{<<-"begin;"}\n#{<<-'end;'}", timeout: Float::INFINITY)
     GC.stress = false
     pattern = "#{pattern}"

--- a/test/ruby/test_econv.rb
+++ b/test/ruby/test_econv.rb
@@ -931,7 +931,7 @@ class TestEncodingConverter < Test::Unit::TestCase
 
   def test_default_external
     Encoding.list.grep(->(enc) {/\AISO-8859-\d+\z/i =~ enc.name}) do |enc|
-      assert_separately(%W[--disable=gems -d - #{enc.name}], <<-EOS, ignore_stderr: true)
+      assert_separately(%W[-d - #{enc.name}], <<-EOS, ignore_stderr: true)
     Encoding.default_external = ext = ARGV[0]
     Encoding.default_internal = int ='utf-8'
     assert_nothing_raised do

--- a/test/ruby/test_encoding.rb
+++ b/test/ruby/test_encoding.rb
@@ -106,7 +106,7 @@ class TestEncoding < Test::Unit::TestCase
   end
 
   def test_errinfo_after_autoload
-    assert_separately(%w[--disable=gems], "#{<<~"begin;"}\n#{<<~'end;'}")
+    assert_separately([], "#{<<~"begin;"}\n#{<<~'end;'}")
     bug9038 = '[ruby-core:57949] [Bug #9038]'
     begin;
       e = assert_raise_with_message(SyntaxError, /unknown regexp option - Q/, bug9038) {

--- a/test/ruby/test_exception.rb
+++ b/test/ruby/test_exception.rb
@@ -685,7 +685,7 @@ end.join
 
   def test_machine_stackoverflow
     bug9109 = '[ruby-dev:47804] [Bug #9109]'
-    assert_separately(%w[--disable-gem], <<-SRC)
+    assert_separately([], <<-SRC)
     assert_raise(SystemStackError, #{bug9109.dump}) {
       h = {a: ->{h[:a].call}}
       h[:a].call
@@ -696,7 +696,7 @@ end.join
 
   def test_machine_stackoverflow_by_define_method
     bug9454 = '[ruby-core:60113] [Bug #9454]'
-    assert_separately(%w[--disable-gem], <<-SRC)
+    assert_separately([], <<-SRC)
     assert_raise(SystemStackError, #{bug9454.dump}) {
       define_method(:foo) {self.foo}
       self.foo

--- a/test/ruby/test_gc.rb
+++ b/test/ruby/test_gc.rb
@@ -402,7 +402,7 @@ class TestGc < Test::Unit::TestCase
   end
 
   def test_gc_parameter_init_slots
-    assert_separately(["--disable-gems"], __FILE__, __LINE__, <<~RUBY)
+    assert_separately([], __FILE__, __LINE__, <<~RUBY)
       # Constant from gc.c.
       GC_HEAP_INIT_SLOTS = 10_000
       GC.stat_heap.each do |_, s|
@@ -421,7 +421,7 @@ class TestGc < Test::Unit::TestCase
     GC.stat_heap.each do |i, s|
       env["RUBY_GC_HEAP_INIT_SIZE_#{s[:slot_size]}_SLOTS"] = sizes[i].to_s
     end
-    assert_separately([env, "-W0", "--disable-gems"], __FILE__, __LINE__, <<~RUBY)
+    assert_separately([env, "-W0"], __FILE__, __LINE__, <<~RUBY)
       SIZES = #{sizes}
       GC.stat_heap.each do |i, s|
         # Sometimes pages will have 1 less slot due to alignment, so always increase slots_per_page by 1.
@@ -432,7 +432,7 @@ class TestGc < Test::Unit::TestCase
     RUBY
 
     # Check that the configured sizes are "remembered" across GC invocations.
-    assert_separately([env, "-W0", "--disable-gems"], __FILE__, __LINE__, <<~RUBY)
+    assert_separately([env, "-W0"], __FILE__, __LINE__, <<~RUBY)
       SIZES = #{sizes}
 
       # Fill size pool 0 with transient objects.

--- a/test/ruby/test_method.rb
+++ b/test/ruby/test_method.rb
@@ -1458,7 +1458,7 @@ class TestMethod < Test::Unit::TestCase
   end
 
   def test_zsuper_private_override_instance_method
-    assert_separately(%w(--disable-gems), <<-'end;', timeout: 30)
+    assert_separately([], <<-'end;', timeout: 30)
       # Bug #16942 [ruby-core:98691]
       module M
         def x
@@ -1479,7 +1479,7 @@ class TestMethod < Test::Unit::TestCase
   end
 
   def test_override_optimized_method_on_class_using_prepend
-    assert_separately(%w(--disable-gems), <<-'end;', timeout: 30)
+    assert_separately([], <<-'end;', timeout: 30)
       # Bug #17725 [ruby-core:102884]
       $VERBOSE = nil
       String.prepend(Module.new)

--- a/test/ruby/test_process.rb
+++ b/test/ruby/test_process.rb
@@ -2355,7 +2355,7 @@ EOS
   end
 
   def test_deadlock_by_signal_at_forking
-    assert_separately(%W(--disable=gems - #{RUBY}), <<-INPUT, timeout: 100)
+    assert_separately(%W(- #{RUBY}), <<-INPUT, timeout: 100)
       ruby = ARGV.shift
       GC.start # reduce garbage
       GC.disable # avoid triggering CoW after forks

--- a/test/ruby/test_require_lib.rb
+++ b/test/ruby/test_require_lib.rb
@@ -12,7 +12,7 @@ class TestRequireLib < Test::Unit::TestCase
     # skip many files that almost use no threads
     next if TEST_RATIO < rand(0.0..1.0)
     define_method "test_thread_size:#{lib}" do
-      assert_separately(['--disable-gems', '-W0'], "#{<<~"begin;"}\n#{<<~"end;"}")
+      assert_separately(['-W0'], "#{<<~"begin;"}\n#{<<~"end;"}")
       begin;
         n = Thread.list.size
         begin

--- a/test/ruby/test_syntax.rb
+++ b/test/ruby/test_syntax.rb
@@ -13,8 +13,7 @@ class TestSyntax < Test::Unit::TestCase
   def assert_syntax_files(test)
     srcdir = File.expand_path("../../..", __FILE__)
     srcdir = File.join(srcdir, test)
-    assert_separately(%W[--disable-gem - #{srcdir}],
-                      __FILE__, __LINE__, <<-'eom', timeout: Float::INFINITY)
+    assert_separately(%W[- #{srcdir}], __FILE__, __LINE__, <<-'eom', timeout: Float::INFINITY)
       dir = ARGV.shift
       for script in Dir["#{dir}/**/*.rb"].sort
         assert_valid_syntax(IO::read(script), script)

--- a/test/ruby/test_time.rb
+++ b/test/ruby/test_time.rb
@@ -438,7 +438,7 @@ class TestTime < Test::Unit::TestCase
   end
 
   def test_marshal_zone_gc
-    assert_separately(%w(--disable-gems), <<-'end;', timeout: 30)
+    assert_separately([], <<-'end;', timeout: 30)
       ENV["TZ"] = "JST-9"
       s = Marshal.dump(Time.now)
       t = Marshal.load(s)

--- a/test/ruby/test_weakmap.rb
+++ b/test/ruby/test_weakmap.rb
@@ -202,7 +202,7 @@ class TestWeakMap < Test::Unit::TestCase
       @wm[i] = obj
     end
 
-    assert_separately(%w(--disable-gems), <<-'end;')
+    assert_separately([], <<-'end;')
       wm = ObjectSpace::WeakMap.new
       obj = Object.new
       100.times do


### PR DESCRIPTION
assert_separately adds --disable=gems so we don't need to add --disable-gems when calling assert_separately.