### PR TITLE
No computing embed_capa_max in str_subseq

### DIFF
--- a/string.c
+++ b/string.c
@@ -2732,15 +2732,30 @@ str_subseq(VALUE str, long beg, long len)
 {
     VALUE str2;
 
-    const long rstring_embed_capa_max = ((sizeof(struct RString) - offsetof(struct RString, as.embed.ary)) / sizeof(char)) - 1;
+    assert(beg >= 0);
+    assert(len >= 0);
+    assert(beg+len <= RSTRING_LEN(str));
 
-    if (!SHARABLE_SUBSTRING_P(beg, len, RSTRING_LEN(str)) ||
-            len <= rstring_embed_capa_max) {
+    const int termlen = TERM_LEN(str);
+    if (!SHARABLE_SUBSTRING_P(beg, len, RSTRING_LEN(str))) {
         str2 = rb_str_new(RSTRING_PTR(str) + beg, len);
+        RB_GC_GUARD(str);
+        return str2;
+    }
+
+    str2 = str_alloc_heap(rb_cString);
+    if (str_embed_capa(str2) >= len + termlen) {
+        char *ptr2 = RSTRING(str2)->as.embed.ary;
+        STR_SET_EMBED(str2);
+        memcpy(ptr2, RSTRING_PTR(str) + beg, len);
+        TERM_FILL(ptr2+len, termlen);
+
+        STR_SET_LEN(str2, len);
         RB_GC_GUARD(str);
     }
     else {
-        str2 = str_new_shared(rb_cString, str);
+        str_replace_shared(str2, str);
+        assert(!STR_EMBED_P(str2));
         ENC_CODERANGE_CLEAR(str2);
         RSTRING(str2)->as.heap.ptr += beg;
         if (RSTRING_LEN(str2) > len) {


### PR DESCRIPTION
Fix str_subseq so that it does not attempt to predict the size of the object returned by str_alloc_heap.

This is an alternative approach for https://github.com/ruby/ruby/pull/8151  This PR is simpler in the sense that it changes only one function, `str_subseq`.  It duplicates some of the code in `str_replace_shared_without_enc`.  `str_subseq` now uses the same if-condition as `str_replace_shared_without_enc`, namely `str_embed_capa(str2) >= len + termlen`, so the two functions should always make the same decision about whether to return an embedded string or heap string.