### PR TITLE
Don't check stack for moved after compaction

### DIFF
--- a/test/ruby/test_gc_compact.rb
+++ b/test/ruby/test_gc_compact.rb
@@ -310,7 +310,6 @@ class TestGCCompact < Test::Unit::TestCase
 
   def test_moving_arrays_down_size_pools
     omit if GC::INTERNAL_CONSTANTS[:SIZE_POOL_COUNT] == 1
-    pend "Flaky on some platforms" if /solaris|mswin/i =~ RUBY_PLATFORM
 
     assert_separately(%w[-robjspace], "#{<<~"begin;"}\n#{<<~"end;"}", timeout: 10, signal: :SEGV)
     begin;
@@ -331,7 +330,6 @@ class TestGCCompact < Test::Unit::TestCase
 
   def test_moving_arrays_up_size_pools
     omit if GC::INTERNAL_CONSTANTS[:SIZE_POOL_COUNT] == 1
-    pend "Flaky on some platforms" if /solaris|mswin/i =~ RUBY_PLATFORM
 
     assert_separately(%w[-robjspace], "#{<<~"begin;"}\n#{<<~"end;"}", timeout: 10, signal: :SEGV)
     begin;
@@ -354,7 +352,7 @@ class TestGCCompact < Test::Unit::TestCase
 
   def test_moving_objects_between_size_pools
     omit if GC::INTERNAL_CONSTANTS[:SIZE_POOL_COUNT] == 1
-    pend "Flaky on some platforms" if /solaris|mswin/i =~ RUBY_PLATFORM
+    omit "Flaky on Solaris" if /solaris/i =~ RUBY_PLATFORM
 
     assert_separately(%w[-robjspace], "#{<<~"begin;"}\n#{<<~"end;"}", timeout: 10, signal: :SEGV)
     begin;
@@ -385,7 +383,6 @@ class TestGCCompact < Test::Unit::TestCase
 
   def test_moving_strings_up_size_pools
     omit if GC::INTERNAL_CONSTANTS[:SIZE_POOL_COUNT] == 1
-    pend "Flaky on some platforms" if /solaris|mswin/i =~ RUBY_PLATFORM
 
     assert_separately(%w[-robjspace], "#{<<~"begin;"}\n#{<<~"end;"}", timeout: 10, signal: :SEGV)
     begin;
@@ -405,7 +402,6 @@ class TestGCCompact < Test::Unit::TestCase
 
   def test_moving_strings_down_size_pools
     omit if GC::INTERNAL_CONSTANTS[:SIZE_POOL_COUNT] == 1
-    pend "Flaky on some platforms" if /solaris|mswin/i =~ RUBY_PLATFORM
 
     assert_separately(%w[-robjspace], "#{<<~"begin;"}\n#{<<~"end;"}", timeout: 10, signal: :SEGV)
     begin;
@@ -429,7 +425,7 @@ class TestGCCompact < Test::Unit::TestCase
     # This test fails on Solaris SPARC with the following error and I can't figure out why:
     #   TestGCCompact#test_moving_hashes_down_size_pools
     #   Expected 499 to be >= 500.
-    pend "Flaky on some platforms" if /solaris|mswin/i =~ RUBY_PLATFORM
+    omit if /sparc-solaris/ =~ RUBY_PLATFORM
 
     assert_separately(%w[-robjspace], "#{<<~"begin;"}\n#{<<~"end;"}", timeout: 10, signal: :SEGV)
     begin;


### PR DESCRIPTION
We don't need to check stack for moved objects after compaction because the mutator cannot run between marking the stack and the end of compaction. However, the stack may have moved objects leftover from marking and sweeping phases. This means that their pages will be invalidated and all objects moved back. We don't need to move these objects back.

This also fixes the issue on Windows where some compaction tests sometimes fail due to the page of the object being invalidated.

cc. @tenderlove 