### PR TITLE
YJIT: guard for array_len >= num in expandarray

### DIFF
--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -538,6 +538,7 @@ impl Insn {
     pub(super) fn target_mut(&mut self) -> Option<&mut Target> {
         match self {
             Insn::Jbe(target) |
+            Insn::Jb(target) |
             Insn::Je(target) |
             Insn::Jl(target) |
             Insn::Jmp(target) |
@@ -682,6 +683,7 @@ impl Insn {
     pub fn target(&self) -> Option<&Target> {
         match self {
             Insn::Jbe(target) |
+            Insn::Jb(target) |
             Insn::Je(target) |
             Insn::Jl(target) |
             Insn::Jmp(target) |
@@ -1819,6 +1821,10 @@ impl Assembler {
 
     pub fn jbe(&mut self, target: Target) {
         self.push_insn(Insn::Jbe(target));
+    }
+
+    pub fn jb(&mut self, target: Target) {
+        self.push_insn(Insn::Jb(target));
     }
 
     pub fn je(&mut self, target: Target) {

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -474,6 +474,7 @@ pub enum BranchGenFn {
     JNZToTarget0,
     JZToTarget0,
     JBEToTarget0,
+    JBToTarget0,
     JITReturn,
 }
 
@@ -527,6 +528,9 @@ impl BranchGenFn {
             BranchGenFn::JBEToTarget0 => {
                 asm.jbe(target0)
             }
+            BranchGenFn::JBToTarget0 => {
+                asm.jb(target0)
+            }
             BranchGenFn::JITReturn => {
                 asm.comment("update cfp->jit_return");
                 asm.mov(Opnd::mem(64, CFP, RUBY_OFFSET_CFP_JIT_RETURN), Opnd::const_ptr(target0.unwrap_code_ptr().raw_ptr()));
@@ -543,6 +547,7 @@ impl BranchGenFn {
             BranchGenFn::JNZToTarget0 |
             BranchGenFn::JZToTarget0 |
             BranchGenFn::JBEToTarget0 |
+            BranchGenFn::JBToTarget0 |
             BranchGenFn::JITReturn => BranchShape::Default,
         }
     }
@@ -563,6 +568,7 @@ impl BranchGenFn {
             BranchGenFn::JNZToTarget0 |
             BranchGenFn::JZToTarget0 |
             BranchGenFn::JBEToTarget0 |
+            BranchGenFn::JBToTarget0 |
             BranchGenFn::JITReturn => {
                 assert_eq!(new_shape, BranchShape::Default);
             }


### PR DESCRIPTION
Avoid generating long dispatch chains for all array lengths seen.