### PR TITLE
Remove uneeded int2big property for Universal Parser

### DIFF
--- a/ruby_parser.c
+++ b/ruby_parser.c
@@ -681,7 +681,6 @@ rb_parser_config_initialize(rb_parser_config_t *config)
 
     config->bignum_negate = bignum_negate;
     config->big_norm      = rb_big_norm;
-    config->int2big       = rb_int2big;
     config->cstr_to_inum  = rb_cstr_to_inum;
 
     config->float_new   = rb_float_new;

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -458,7 +458,6 @@ typedef struct rb_parser_config_struct {
     /* Bignum */
     void (*bignum_negate)(VALUE b);
     VALUE (*big_norm)(VALUE x);
-    VALUE (*int2big)(intptr_t n);
     VALUE (*cstr_to_inum)(const char *str, int base, int badcheck);
 
     /* Float */

--- a/universal_parser.c
+++ b/universal_parser.c
@@ -225,7 +225,6 @@ struct rb_imemo_tmpbuf_struct {
 
 #define bignum_negate p->config->bignum_negate
 #define rb_big_norm   p->config->big_norm
-#define rb_int2big    p->config->int2big
 #define rb_cstr_to_inum p->config->cstr_to_inum
 
 #define rb_float_new   p->config->float_new


### PR DESCRIPTION
I was reading Universal Parser and parse.y and it seems that int2big is not used in parse.y.
Therefore, it has been removed.