### PR TITLE
Revert "Skip calling jit_exec on Wasm"

### DIFF
--- a/vm.c
+++ b/vm.c
@@ -2336,7 +2336,9 @@ vm_exec_bottom_main(void *context)
     struct rb_vm_exec_context *ctx = (struct rb_vm_exec_context *)context;
 
     ctx->state = TAG_NONE;
-    ctx->result = vm_exec_core(ctx->ec);
+    if (UNDEF_P(ctx->result = jit_exec(ctx->ec))) {
+        ctx->result = vm_exec_core(ctx->ec);
+    }
     vm_exec_enter_vm_loop(ctx->ec, ctx, ctx->tag, true);
 }
 


### PR DESCRIPTION
This reverts commit e80752f9bbc5228dba3066cd95a81e2e496bd9d7.

RJIT and YJIT are never enabled on Wasm.
When both are disabled, `jit_exec` is defined to return `Qundef` constantly, and is optimized away.