### PR TITLE
Fixup lib/bundled_gems.rb

### DIFF
--- a/lib/bundled_gems.rb
+++ b/lib/bundled_gems.rb
@@ -67,6 +67,7 @@ module Gem::BUNDLED_GEMS
     return unless gem = find_gem(path)
     caller, = caller_locations(3, 1)
     return if find_gem(caller&.absolute_path)
+    name = name[%r[\A[^/]+]]
     return if WARNED[name]
     WARNED[name] = true
     if gem == true


### PR DESCRIPTION
Current master builds throw an error when a file like `drb/drb` is required.  Error similar to:
```
/usr/local/lib/ruby/3.3.0+0/bundled_gems.rb:80:in `<': comparison of String with nil failed (ArgumentError)
```
One way to test this is to copy the current lib/bundled_gems.rb file into a recent master build, then run
```
ruby -rdrb -e "puts 'Throws error'"
```

First, all ruby-loco builds failed.  Then I did the above with recent master builds on both Windows & Ubuntu.  the above command line failed.