### PR TITLE
Fix `Gem::BUNDLED_GEMS.find_gem` return value

### DIFF
--- a/lib/bundled_gems.rb
+++ b/lib/bundled_gems.rb
@@ -59,7 +59,7 @@ module Gem::BUNDLED_GEMS
     else
       return
     end
-    EXACT[n] or PREFIXED[n[%r[\A[^/]+(?=/)]]]
+    EXACT[n] or PREFIXED[n = n[%r[\A[^/]+(?=/)]]] && n
   end
 
   def self.warning?(name)


### PR DESCRIPTION
If the required name is different from the found gem name, return the gem name, instead of true that means the required name is an exact gem name.