### PR TITLE
YJIT: Count all opt_getconstant_path exit reasons

### DIFF
--- a/yjit.rb
+++ b/yjit.rb
@@ -262,7 +262,7 @@ module RubyVM::YJIT
       print_counters(stats, out: out, prefix: 'opt_aref_', prompt: 'opt_aref exit reasons: ')
       print_counters(stats, out: out, prefix: 'opt_aref_with_', prompt: 'opt_aref_with exit reasons: ')
       print_counters(stats, out: out, prefix: 'expandarray_', prompt: 'expandarray exit reasons: ')
-      print_counters(stats, out: out, prefix: 'opt_getinlinecache_', prompt: 'opt_getinlinecache exit reasons: ')
+      print_counters(stats, out: out, prefix: 'opt_getconstant_path_', prompt: 'opt_getconstant_path exit reasons: ')
       print_counters(stats, out: out, prefix: 'invalidate_', prompt: 'invalidation reasons: ')
 
       # Number of failed compiler invocations

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -353,7 +353,9 @@ make_counters! {
 
     opt_case_dispatch_megamorphic,
 
-    opt_getinlinecache_miss,
+    opt_getconstant_path_ic_miss,
+    opt_getconstant_path_no_ic_entry,
+    opt_getconstant_path_multi_ractor,
 
     expandarray_splat,
     expandarray_postarg,


### PR DESCRIPTION
This new `opt_getconstant_path_no_ic_entry` was not counted, but it was the top exit reason on `lobsters` benchmark.