### PR TITLE
Skip running brew upgrade

### DIFF
--- a/.github/actions/setup/macos/action.yml
+++ b/.github/actions/setup/macos/action.yml
@@ -13,7 +13,6 @@ runs:
     - name: brew
       shell: bash
       run: |
-        brew upgrade --quiet
         brew install --quiet gmp libffi openssl@1.1 zlib autoconf automake libtool readline
 
     - name: Set ENV


### PR DESCRIPTION
This has been unstable:
https://github.com/ruby/ruby/actions/runs/5797755676/job/15713988590

and I'm not sure if we need that in the first place, assuming the OS image itself is maintained by GitHub.