### PR TITLE
Remove uneeded fix2int and rational_raw properties for Universal Parser

### DIFF
--- a/ruby_parser.c
+++ b/ruby_parser.c
@@ -686,14 +686,12 @@ rb_parser_config_initialize(rb_parser_config_t *config)
     config->float_new   = rb_float_new;
     config->float_value = rb_float_value;
 
-    config->fix2int          = rb_fix2int;
     config->num2int          = rb_num2int_inline;
     config->int_positive_pow = rb_int_positive_pow;
     config->int2num          = rb_int2num_inline;
     config->fix2long         = rb_fix2long;
 
     config->rational_new     = rb_rational_new;
-    config->rational_raw     = rb_rational_raw;
     config->rational_raw1    = rational_raw1;
     config->rational_set_num = rational_set_num;
     config->rational_get_num = rational_get_num;

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -465,7 +465,6 @@ typedef struct rb_parser_config_struct {
     double (*float_value)(VALUE v);
 
     /* Numeric */
-    long (*fix2int)(VALUE val);
     int (*num2int)(VALUE val);
     VALUE (*int_positive_pow)(long x, unsigned long y);
     VALUE (*int2num)(int v);
@@ -473,7 +472,6 @@ typedef struct rb_parser_config_struct {
 
     /* Rational */
     VALUE (*rational_new)(VALUE x, VALUE y);
-    VALUE (*rational_raw)(VALUE x, VALUE y);
     VALUE (*rational_raw1)(VALUE x);
     void (*rational_set_num)(VALUE r, VALUE n);
     VALUE (*rational_get_num)(VALUE obj);

--- a/universal_parser.c
+++ b/universal_parser.c
@@ -233,7 +233,6 @@ struct rb_imemo_tmpbuf_struct {
 #undef DBL2NUM
 #define DBL2NUM p->config->float_new
 
-#define rb_fix2int          p->config->fix2int
 #undef NUM2INT
 #define NUM2INT             p->config->num2int
 #define rb_int_positive_pow p->config->int_positive_pow
@@ -243,7 +242,6 @@ struct rb_imemo_tmpbuf_struct {
 #define FIX2LONG            p->config->fix2long
 
 #define rb_rational_new  p->config->rational_new
-#define rb_rational_raw  p->config->rational_raw
 #undef rb_rational_raw1
 #define rb_rational_raw1 p->config->rational_raw1
 #define rational_set_num p->config->rational_set_num


### PR DESCRIPTION
I was reading Universal Parser and parse.y and it seems that `fix2int` and `rational_raw` properties are not used in parse.y.
Therefore, it has been removed.