### PR TITLE
YJIT: Distinguish exit and fallback reasons for invokesuper/invokeblock

### DIFF
--- a/yjit.rb
+++ b/yjit.rb
@@ -251,9 +251,11 @@ module RubyVM::YJIT
       out.puts("***YJIT: Printing YJIT statistics on exit***")
 
       print_counters(stats, out: out, prefix: 'send_', prompt: 'method call fallback reasons: ')
+      print_counters(stats, out: out, prefix: 'invokeblock_', prompt: 'invokeblock fallback reasons: ')
+      print_counters(stats, out: out, prefix: 'invokesuper_', prompt: 'invokesuper fallback reasons: ')
       print_counters(stats, out: out, prefix: 'guard_send_', prompt: 'method call exit reasons: ')
-      print_counters(stats, out: out, prefix: 'invokeblock_', prompt: 'invokeblock exit reasons: ')
-      print_counters(stats, out: out, prefix: 'invokesuper_', prompt: 'invokesuper exit reasons: ')
+      print_counters(stats, out: out, prefix: 'guard_invokeblock_', prompt: 'invokeblock exit reasons: ')
+      print_counters(stats, out: out, prefix: 'guard_invokesuper_', prompt: 'invokesuper exit reasons: ')
       print_counters(stats, out: out, prefix: 'leave_', prompt: 'leave exit reasons: ')
       print_counters(stats, out: out, prefix: 'gbpp_', prompt: 'getblockparamproxy exit reasons: ')
       print_counters(stats, out: out, prefix: 'getivar_', prompt: 'getinstancevariable exit reasons:')

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -274,6 +274,26 @@ make_counters! {
     send_bmethod_ractor,
     send_bmethod_block_arg,
 
+    invokesuper_blockarg,
+    invokesuper_defined_class_mismatch,
+    invokesuper_kw_splat,
+    invokesuper_kwarg,
+    invokesuper_no_cme,
+    invokesuper_no_me,
+    invokesuper_not_iseq_or_cfunc,
+    invokesuper_refinement,
+
+    invokeblock_none,
+    invokeblock_iseq_arg0_optional,
+    invokeblock_iseq_arg0_has_kw,
+    invokeblock_iseq_arg0_args_splat,
+    invokeblock_iseq_arg0_not_array,
+    invokeblock_iseq_arg0_wrong_len,
+    invokeblock_ifunc_args_splat,
+    invokeblock_ifunc_kw_splat,
+    invokeblock_proc,
+    invokeblock_symbol,
+
     // Method calls that exit to the interpreter
     guard_send_klass_megamorphic,
     guard_send_se_cf_overflow,
@@ -292,23 +312,13 @@ make_counters! {
     guard_send_not_string,
     guard_send_mid_mismatch,
 
+    guard_invokesuper_me_changed,
+    guard_invokesuper_block_given,
+
+    guard_invokeblock_tag_changed,
+    guard_invokeblock_iseq_block_changed,
+
     traced_cfunc_return,
-
-    invokesuper_me_changed,
-    invokesuper_block,
-
-    invokeblock_none,
-    invokeblock_iseq_arg0_optional,
-    invokeblock_iseq_arg0_has_kw,
-    invokeblock_iseq_arg0_args_splat,
-    invokeblock_iseq_arg0_not_array,
-    invokeblock_iseq_arg0_wrong_len,
-    invokeblock_iseq_block_changed,
-    invokeblock_tag_changed,
-    invokeblock_ifunc_args_splat,
-    invokeblock_ifunc_kw_splat,
-    invokeblock_proc,
-    invokeblock_symbol,
 
     leave_se_interrupt,
     leave_interp_return,


### PR DESCRIPTION
This is the same as https://github.com/ruby/ruby/pull/8159 but for invokesuper and invokeblock. I also added a few missing fallback counters for invokesuper.

## Example
Here's an example output on railsbench:

```
invokeblock fallback reasons:
      proc:      1,863 (93.6%)
    symbol:        127 ( 6.4%)
invokesuper fallback reasons:
    not_iseq_or_cfunc:      8,768 (58.9%)
             kw_splat:      5,934 (39.8%)
             blockarg:        100 ( 0.7%)
                kwarg:         90 ( 0.6%)
```
```
invokeblock exit reasons:
    (all relevant counters are zero)
invokesuper exit reasons:
     me_changed:      4,941 (70.4%)
    block_given:      2,079 (29.6%)
```