### PR TITLE
YJIT: Chain guard method IDs for respond_to?

### DIFF
--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -310,7 +310,7 @@ make_counters! {
     guard_send_interrupted,
     guard_send_not_fixnums,
     guard_send_not_string,
-    guard_send_mid_mismatch,
+    guard_send_respond_to_mid_mismatch,
 
     guard_invokesuper_me_changed,
     guard_invokesuper_block_given,


### PR DESCRIPTION
`guard_send_mid_mismatch` consists of 10% of all side exits on SFR. This PR changes `respond_to?` to accept multiple method IDs in a single callsite using a chain guard.