### PR TITLE
YJIT: Fallback megamorphic super/yield to dynamic dispatch

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -7226,6 +7226,12 @@ fn gen_invokeblock_specialized(
         return Some(EndBlock);
     }
 
+    // Fallback to dynamic dispatch if this callsite is megamorphic
+    if asm.ctx.get_chain_depth() as i32 >= SEND_MAX_CHAIN_DEPTH {
+        gen_counter_incr(asm, Counter::invokeblock_megamorphic);
+        return None;
+    }
+
     // Get call info
     let ci = unsafe { get_call_data_ci(cd) };
     let argc: i32 = unsafe { vm_ci_argc(ci) }.try_into().unwrap();
@@ -7389,6 +7395,12 @@ fn gen_invokesuper_specialized(
         return Some(EndBlock);
     }
 
+    // Fallback to dynamic dispatch if this callsite is megamorphic
+    if asm.ctx.get_chain_depth() as i32 >= SEND_MAX_CHAIN_DEPTH {
+        gen_counter_incr(asm, Counter::invokesuper_megamorphic);
+        return None;
+    }
+
     let me = unsafe { rb_vm_frame_method_entry(jit.get_cfp()) };
     if me.is_null() {
         gen_counter_incr(asm, Counter::invokesuper_no_me);
@@ -7467,7 +7479,14 @@ fn gen_invokesuper_specialized(
 
     let me_as_value = VALUE(me as usize);
     asm.cmp(ep_me_opnd, me_as_value.into());
-    asm.jne(Target::side_exit(Counter::guard_invokesuper_me_changed));
+    jit_chain_guard(
+        JCC_JNE,
+        jit,
+        asm,
+        ocb,
+        SEND_MAX_CHAIN_DEPTH,
+        Counter::guard_invokesuper_me_changed,
+    );
 
     if block.is_none() {
         // Guard no block passed

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -278,11 +278,13 @@ make_counters! {
     invokesuper_defined_class_mismatch,
     invokesuper_kw_splat,
     invokesuper_kwarg,
+    invokesuper_megamorphic,
     invokesuper_no_cme,
     invokesuper_no_me,
     invokesuper_not_iseq_or_cfunc,
     invokesuper_refinement,
 
+    invokeblock_megamorphic,
     invokeblock_none,
     invokeblock_iseq_arg0_optional,
     invokeblock_iseq_arg0_has_kw,


### PR DESCRIPTION
A single `yield` could jump to multiple ISEQ blocks depending on who's calling it. A `super` could call multiple method entries if a module is inherited by multiple classes.

This PR changes `invokeblock` and `invokesuper` to fallback to dynamic dispatch when they end up being megamorphic. `guard_invokeblock_iseq_block_changed` and `guard_invokesuper_me_changed` are one of the top exit reasons on SFR, and this tries to stay in JIT code in such cases.