### PR TITLE
YJIT: Allow VM_CALL_ARGS_BLOCKARG on invokesuper

### DIFF
--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -274,7 +274,6 @@ make_counters! {
     send_bmethod_ractor,
     send_bmethod_block_arg,
 
-    invokesuper_blockarg,
     invokesuper_defined_class_mismatch,
     invokesuper_kw_splat,
     invokesuper_kwarg,
@@ -313,7 +312,7 @@ make_counters! {
     guard_send_respond_to_mid_mismatch,
 
     guard_invokesuper_me_changed,
-    guard_invokesuper_block_given,
+    guard_invokesuper_block_handler,
 
     guard_invokeblock_tag_changed,
     guard_invokeblock_iseq_block_changed,


### PR DESCRIPTION
`invokesuper` exits on `VM_CALL_ARGS_BLOCKARG`, but because `gen_send_iseq` and `gen_send_cfunc` handle that flag (compile `nil`/`blockparamproxy` or give up), we could let `invokesuper` delegate that case to those functions.