### PR TITLE
Fix range of `--backtrace-limit`

### DIFF
--- a/internal/cmdlineopt.h
+++ b/internal/cmdlineopt.h
@@ -23,7 +23,7 @@ typedef struct ruby_cmdline_options {
     ruby_features_t features;
     ruby_features_t warn;
     unsigned int dump;
-    int backtrace_length_limit;
+    long backtrace_length_limit;
 #if USE_RJIT
     struct rb_rjit_options rjit;
 #endif

--- a/test/ruby/test_rubyoptions.rb
+++ b/test/ruby/test_rubyoptions.rb
@@ -84,9 +84,14 @@ class TestRubyOptions < Test::Unit::TestCase
                        /^\t \.{3} \d+ levels\.{3}\n/])
     assert_kind_of(Integer, Thread::Backtrace.limit)
     assert_in_out_err(%w(--backtrace-limit=1), "p Thread::Backtrace.limit", ['1'], [])
+    assert_in_out_err(%w(--backtrace-limit 1), "p Thread::Backtrace.limit", ['1'], [])
     env = {"RUBYOPT" => "--backtrace-limit=5"}
     assert_in_out_err([env], "p Thread::Backtrace.limit", ['5'], [])
     assert_in_out_err([env, "--backtrace-limit=1"], "p Thread::Backtrace.limit", ['1'], [])
+    assert_in_out_err([env, "--backtrace-limit=-1"], "p Thread::Backtrace.limit", ['-1'], [])
+    long_max = RbConfig::LIMITS["LONG_MAX"]
+    assert_in_out_err(%W(--backtrace-limit=#{long_max}), "p Thread::Backtrace.limit",
+                      ["#{long_max}"], [])
   end
 
   def test_warning


### PR DESCRIPTION
Also an option command line should have precedence over `RUBYOPT`.