### PR TITLE
YJIT: implement codegen for rb_int_lshift

### DIFF
--- a/yjit.rb
+++ b/yjit.rb
@@ -264,6 +264,7 @@ module RubyVM::YJIT
       print_counters(stats, out: out, prefix: 'opt_aref_', prompt: 'opt_aref exit reasons: ')
       print_counters(stats, out: out, prefix: 'opt_aref_with_', prompt: 'opt_aref_with exit reasons: ')
       print_counters(stats, out: out, prefix: 'expandarray_', prompt: 'expandarray exit reasons: ')
+      print_counters(stats, out: out, prefix: 'lshift_', prompt: 'left shift (ltlt) exit reasons: ')
       print_counters(stats, out: out, prefix: 'opt_getconstant_path_', prompt: 'opt_getconstant_path exit reasons: ')
       print_counters(stats, out: out, prefix: 'invalidate_', prompt: 'invalidation reasons: ')
 

--- a/yjit/src/asm/x86_64/mod.rs
+++ b/yjit/src/asm/x86_64/mod.rs
@@ -1277,7 +1277,7 @@ fn write_shift(cb: &mut CodeBlock, op_mem_one_pref: u8, op_mem_cl_pref: u8, op_m
         }
 
         _ => {
-            unreachable!("{:?} {:?}", opnd0, opnd1);
+            unreachable!("unsupported operands: {:?}, {:?}", opnd0, opnd1);
         }
     }
 }

--- a/yjit/src/asm/x86_64/mod.rs
+++ b/yjit/src/asm/x86_64/mod.rs
@@ -1277,7 +1277,7 @@ fn write_shift(cb: &mut CodeBlock, op_mem_one_pref: u8, op_mem_cl_pref: u8, op_m
         }
 
         _ => {
-            unreachable!();
+            unreachable!("{:?} {:?}", opnd0, opnd1);
         }
     }
 }

--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -541,6 +541,7 @@ impl Insn {
             Insn::Jb(target) |
             Insn::Je(target) |
             Insn::Jl(target) |
+            Insn::Jg(target) |
             Insn::Jmp(target) |
             Insn::Jne(target) |
             Insn::Jnz(target) |
@@ -686,6 +687,7 @@ impl Insn {
             Insn::Jb(target) |
             Insn::Je(target) |
             Insn::Jl(target) |
+            Insn::Jg(target) |
             Insn::Jmp(target) |
             Insn::Jne(target) |
             Insn::Jnz(target) |
@@ -1833,6 +1835,10 @@ impl Assembler {
 
     pub fn jl(&mut self, target: Target) {
         self.push_insn(Insn::Jl(target));
+    }
+
+    pub fn jg(&mut self, target: Target) {
+        self.push_insn(Insn::Jg(target));
     }
 
     pub fn jmp(&mut self, target: Target) {

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -347,7 +347,7 @@ make_counters! {
     opt_mod_zero,
     opt_div_zero,
 
-    lshift_range,
+    lshift_amt_changed,
     lshift_overflow,
 
     opt_aref_argc_not_one,


### PR DESCRIPTION
This is an implementation of bitwise left shift for integers, which will hopefully improve YJIT's performance on optcarrot a little bit more 🤞  

This implementation speculates that the shift amount will not change, which is always true on optcarrot (the side-exit is never taken).

The generated code is more compact than with a variable shift amount:
```
  # regenerate_branch
  # Block: foo@test.rb:2 (chain_depth: 1)
  # reg_temps: 00000011
  # Insn: 0004 opt_ltlt (stack_size: 2)
  # call to Integer#<<
  0x10daa0063: cmp rdi, 5
  0x10daa0067: jne 0x10daa2087
  0x10daa006d: mov rax, rsi
  0x10daa0070: sub rax, 1
  0x10daa0074: mov rcx, rax
  0x10daa0077: shl rcx, 2
  0x10daa007b: mov rdx, rcx
  0x10daa007e: sar rdx, 2
  0x10daa0082: cmp rdx, rax
  0x10daa0085: jne 0x10daa2087
  0x10daa008b: add rcx, 1
  0x10daa008f: mov rsi, rcx
```