### PR TITLE
YJIT: Implement checkmatch instruction

### DIFF
--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -5233,6 +5233,12 @@ vm_check_match(rb_execution_context_t *ec, VALUE target, VALUE pattern, rb_num_t
     }
 }
 
+VALUE
+rb_vm_check_match(rb_execution_context_t *ec, VALUE target, VALUE pattern, rb_num_t flag)
+{
+    return vm_check_match(ec, target, pattern, flag);
+}
+
 static VALUE
 vm_check_keyword(lindex_t bits, lindex_t idx, const VALUE *ep)
 {

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -292,6 +292,7 @@ fn main() {
         .allowlist_type("rb_builtin_attr")
         .allowlist_type("ruby_tag_type")
         .allowlist_type("ruby_vm_throw_flags")
+        .allowlist_type("vm_check_match_type")
 
         // From yjit.c
         .allowlist_function("rb_iseq_(get|set)_yjit_payload")

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -768,6 +768,10 @@ impl rb_proc_t {
         __bindgen_bitfield_unit
     }
 }
+pub const VM_CHECKMATCH_TYPE_WHEN: vm_check_match_type = 1;
+pub const VM_CHECKMATCH_TYPE_CASE: vm_check_match_type = 2;
+pub const VM_CHECKMATCH_TYPE_RESCUE: vm_check_match_type = 3;
+pub type vm_check_match_type = u32;
 pub const VM_SPECIAL_OBJECT_VMCORE: vm_special_object_type = 1;
 pub const VM_SPECIAL_OBJECT_CBASE: vm_special_object_type = 2;
 pub const VM_SPECIAL_OBJECT_CONST_BASE: vm_special_object_type = 3;


### PR DESCRIPTION
`checkmatch` instruction is the top exit reason on SFR (35% of all exits). This PR calls the interpreter's C implementation to just stay in JIT code.