### PR TITLE
YJIT: increase max chain depth for expandarray

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -1603,7 +1603,7 @@ fn gen_expandarray(
             jit,
             asm,
             ocb,
-            OPT_AREF_MAX_CHAIN_DEPTH,
+            EXPANDARRAY_MAX_CHAIN_DEPTH,
             Counter::expandarray_chain_max_depth,
         );
 
@@ -1615,7 +1615,7 @@ fn gen_expandarray(
             jit,
             asm,
             ocb,
-            OPT_AREF_MAX_CHAIN_DEPTH,
+            EXPANDARRAY_MAX_CHAIN_DEPTH,
             Counter::expandarray_chain_max_depth,
         );
     }
@@ -2007,6 +2007,9 @@ pub const SET_IVAR_MAX_DEPTH: i32 = 10;
 
 // hashes and arrays
 pub const OPT_AREF_MAX_CHAIN_DEPTH: i32 = 2;
+
+// expandarray
+pub const EXPANDARRAY_MAX_CHAIN_DEPTH: i32 = 4;
 
 // up to 10 different classes
 pub const SEND_MAX_DEPTH: i32 = 20;


### PR DESCRIPTION
Expand the chain depth from 2 to 4 since this gets tripped some percentage of the time on SFR:
```
expandarray exit reasons: 
       chain_max_depth:  1,345,017 (85.0%)
                 splat:    181,665 (11.5%)
             not_array:     54,494 ( 3.4%)
    comptime_not_array:        507 ( 0.0%)

...

Top-20 most frequent exit ops (100.0% of exits):
                    checkmatch:  8,593,546 (36.0%)
                   invokesuper:  4,080,558 (17.1%)
                 setlocal_WC_0:  3,828,583 (16.1%)
            getblockparamproxy:  1,778,545 ( 7.5%)
                   expandarray:  1,581,683 ( 6.6%)
        opt_send_without_block:  1,366,974 ( 5.7%)
          opt_getconstant_path:  1,328,064 ( 5.6%)
                 opt_aset_with:    362,129 ( 1.5%)
                      opt_aref:    352,641 ( 1.5%)
```