### PR TITLE
YJIT: Chain guard classes on instance_of

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -4264,7 +4264,7 @@ fn jit_rb_kernel_is_a(
 fn jit_rb_kernel_instance_of(
     jit: &mut JITState,
     asm: &mut Assembler,
-    _ocb: &mut OutlinedCb,
+    ocb: &mut OutlinedCb,
     _ci: *const rb_callinfo,
     _cme: *const rb_callable_method_entry_t,
     _block: Option<BlockHandler>,
@@ -4305,7 +4305,14 @@ fn jit_rb_kernel_instance_of(
 
     asm.comment("Kernel#instance_of?");
     asm.cmp(asm.stack_opnd(0), sample_rhs.into());
-    asm.jne(Target::side_exit(Counter::guard_send_instance_of_class_mismatch));
+    jit_chain_guard(
+        JCC_JNE,
+        jit,
+        asm,
+        ocb,
+        SEND_MAX_CHAIN_DEPTH,
+        Counter::guard_send_instance_of_class_mismatch,
+    );
 
     asm.stack_pop(2);
 


### PR DESCRIPTION
`guard_send_instance_of_class_mismatch` is the top method call exit reason on SFR:

```
method call exit reasons: 
     instance_of_class_mismatch:    177,776 (40.2%)
          send_chain_not_string:    119,495 (27.0%)
            is_a_class_mismatch:     65,474 (14.8%)
                    interrupted:     46,571 (10.5%)
                    not_fixnums:     32,070 ( 7.3%)
    splatarray_length_not_equal:        656 ( 0.1%)
```

I'd like to see if a chain guard helps the situation.