### PR TITLE
Fold test-spec dots

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -103,7 +103,7 @@ for:
     # separately execute tests without -j which may crash worker with -j.
     - >-
       nmake -l
-      "TESTOPTS=-v --timeout-scale=3.0 --excludes=../test/excludes/_appveyor"
+      "TESTOPTS=--timeout-scale=3.0 --excludes=../test/excludes/_appveyor"
       TESTS="
       ../test/win32ole
       ../test/ruby/test_bignum.rb
@@ -111,7 +111,7 @@ for:
       ../test/open-uri/test_open-uri.rb
       ../test/rubygems/test_bundled_ca.rb
       " test-all
-    - nmake -l test-spec MSPECOPT=-fs # not using `-j` because sometimes `mspec -j` silently dies on Windows
+    - nmake -l test-spec # not using `-j` because sometimes `mspec -j` silently dies on Windows
 notifications:
   - provider: Webhook
     method: POST

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -129,8 +129,10 @@ jobs:
           :vcset
           set | C:\msys64\usr\bin\sort > old.env
           call %VCVARS%
+          nmake -f nul
           set TMP=%USERPROFILE%\AppData\Local\Temp
           set TEMP=%USERPROFILE%\AppData\Local\Temp
+          set MAKEFLAGS=l
           set /a TEST_JOBS=(15 * %NUMBER_OF_PROCESSORS% / 10) > nul
           set | C:\msys64\usr\bin\sort > new.env
           C:\msys64\usr\bin\comm -13 old.env new.env >> %GITHUB_ENV%
@@ -162,7 +164,7 @@ jobs:
       - run: nmake test
         timeout-minutes: 5
 
-      - run: nmake test-spec MSPECOPT="-V -fspec"
+      - run: nmake test-spec
         timeout-minutes: 10
 
       - run: nmake test-all

--- a/.travis.yml
+++ b/.travis.yml
@@ -209,7 +209,7 @@ script:
     if [ -n "${TEST_ALL_OPTS_SEPARATED}" ]; then
       $SETARCH make -s test-all -o exts TESTOPTS="$JOBS -v --tty=no ${TEST_ALL_OPTS_SEPARATED}" RUBYOPT="-w" || :
     fi
-  - $SETARCH make -s test-spec MSPECOPT=-ff # not using `-j` because sometimes `mspec -j` silently dies
+  - $SETARCH make -s test-spec # not using `-j` because sometimes `mspec -j` silently dies
   - $SETARCH make -s -o showflags leaked-globals
 
 # We enable Travis on the specific branches or forked repositories here.

--- a/doc/contributing/testing_ruby.md
+++ b/doc/contributing/testing_ruby.md
@@ -99,28 +99,28 @@ We can run any of the make scripts [in parallel](building_ruby.md#label-Running+
     make test-spec
     ```
 
-    To run a specific directory, we can use `MSPECOPT` to specify the directory:
+    To run a specific directory, we can use `SPECOPTS` to specify the directory:
 
     ```
-    make test-spec MSPECOPT=spec/ruby/core/array
+    make test-spec SPECOPTS=spec/ruby/core/array
     ```
 
-    To run a specific file, we can also use `MSPECOPT` to specify the file:
+    To run a specific file, we can also use `SPECOPTS` to specify the file:
 
     ```
-    make test-spec MSPECOPT=spec/ruby/core/array/any_spec.rb
+    make test-spec SPECOPTS=spec/ruby/core/array/any_spec.rb
     ```
 
     To run a specific test, we can use the `--example` flag to match against the test name:
 
     ```
-    make test-spec MSPECOPT="../spec/ruby/core/array/any_spec.rb --example='is false if the array is empty'"
+    make test-spec SPECOPTS="../spec/ruby/core/array/any_spec.rb --example='is false if the array is empty'"
     ```
 
     To run these specs with logs, we can use:
 
     ```
-    make test-spec MSPECOPT=-Vfs
+    make test-spec SPECOPTS=-Vfs
     ```
 
     To run a ruby-spec file or directory with GNU make, we can use

--- a/spec/README.md
+++ b/spec/README.md
@@ -91,24 +91,24 @@ To run all specs:
 make test-spec
 ```
 
-Extra arguments can be added via `MSPECOPT`.
+Extra arguments can be added via `SPECOPTS`.
 For instance, to show the help:
 
 ```bash
-make test-spec MSPECOPT=-h
+make test-spec SPECOPTS=-h
 ```
 
 You can also run the specs in parallel, which is currently experimental.
 It takes around 10s instead of 60s on a quad-core laptop.
 
 ```bash
-make test-spec MSPECOPT=-j
+make test-spec SPECOPTS=-j
 ```
 
 To run a specific test, add its path to the command:
 
 ```bash
-make test-spec MSPECOPT=spec/ruby/language/for_spec.rb
+make test-spec SPECOPTS=spec/ruby/language/for_spec.rb
 ```
 
 If ruby trunk is your current `ruby` in `$PATH`, you can also run `mspec` directly:

--- a/spec/default.mspec
+++ b/spec/default.mspec
@@ -70,3 +70,51 @@ end
 class MSpecScript
   prepend JobServer
 end
+
+
+require 'mspec/runner/formatters/dotted'
+
+class DottedFormatter
+  prepend Module.new {
+    BASE = __dir__ + "/ruby/"
+
+    def initialize(out = nil)
+      super
+      if out
+        @columns = nil
+      else
+        columns = ENV["COLUMNS"]
+        @columns = columns ? columns.to_i : 80
+      end
+      @dotted = 0
+      @loaded = false
+    end
+
+    def register
+      super
+      MSpec.register :load, self
+      MSpec.register :unload, self
+    end
+
+    def after(*)
+      super
+      if !@loaded and @columns and (@dotted += 1) >= @columns
+        print "\n"
+        @dotted = 0
+      end
+    end
+
+    def load(*)
+      print "#{MSpec.file.delete_prefix(BASE)}: "
+      @loaded = true
+    end
+
+    def unload
+      super
+      if @loaded
+        print "\n"
+        @dotted = 0
+      end
+    end
+  }
+end

--- a/spec/default.mspec
+++ b/spec/default.mspec
@@ -105,7 +105,8 @@ class DottedFormatter
     end
 
     def load(*)
-      print "#{MSpec.file.delete_prefix(BASE)}: "
+      file = MSpec.file || MSpec.files_array.first
+      print "#{file.delete_prefix(BASE)}: "
       @loaded = true
     end
 


### PR DESCRIPTION
In GitHub Actions, outputs are displayed line by line.
That means `-fdotted` output from `test-spec` does not work as "progress-bar", but all dots are displayed after everything finished at once.
This PR folds dot lines by `COLUMNS` width.