### PR TITLE
Fix the precedence of `--backtrace-limit` option

### DIFF
--- a/ruby.c
+++ b/ruby.c
@@ -897,6 +897,7 @@ moreswitches(const char *s, ruby_cmdline_options_t *opt, int envopt)
     VALUE int_enc_name = opt->intern.enc.name;
     ruby_features_t feat = opt->features;
     ruby_features_t warn = opt->warn;
+    long backtrace_length_limit = opt->backtrace_length_limit;
 
     while (ISSPACE(*s)) s++;
     if (!*s) return;
@@ -947,6 +948,9 @@ moreswitches(const char *s, ruby_cmdline_options_t *opt, int envopt)
     }
     FEATURE_SET_RESTORE(opt->features, feat);
     FEATURE_SET_RESTORE(opt->warn, warn);
+    if (BACKTRACE_LENGTH_LIMIT_VALID_P(backtrace_length_limit)) {
+        opt->backtrace_length_limit = backtrace_length_limit;
+    }
 
     ruby_xfree(ptr);
     /* get rid of GC */
@@ -1453,7 +1457,7 @@ proc_long_options(ruby_cmdline_options_t *opt, const char *s, long argc, char **
         if (errno == ERANGE || !BACKTRACE_LENGTH_LIMIT_VALID_P(n) || *e) {
             rb_raise(rb_eRuntimeError, "wrong limit for backtrace length");
         }
-        else if (!OPT_BACKTRACE_LENGTH_LIMIT_VALID_P(opt)) {
+        else {
             opt->backtrace_length_limit = n;
         }
     }

--- a/test/ruby/test_rubyoptions.rb
+++ b/test/ruby/test_rubyoptions.rb
@@ -89,6 +89,10 @@ class TestRubyOptions < Test::Unit::TestCase
     assert_in_out_err([env], "p Thread::Backtrace.limit", ['5'], [])
     assert_in_out_err([env, "--backtrace-limit=1"], "p Thread::Backtrace.limit", ['1'], [])
     assert_in_out_err([env, "--backtrace-limit=-1"], "p Thread::Backtrace.limit", ['-1'], [])
+    assert_in_out_err([env, "--backtrace-limit=3", "--backtrace-limit=1"],
+                      "p Thread::Backtrace.limit", ['1'], [])
+    assert_in_out_err([{"RUBYOPT" => "--backtrace-limit=5 --backtrace-limit=3"}],
+                      "p Thread::Backtrace.limit", ['3'], [])
     long_max = RbConfig::LIMITS["LONG_MAX"]
     assert_in_out_err(%W(--backtrace-limit=#{long_max}), "p Thread::Backtrace.limit",
                       ["#{long_max}"], [])


### PR DESCRIPTION
In general, if the same option specifying a single value is given multiple times at the same level, the last one overrides the earlier ones, unless prohibited.