### PR TITLE
[DOC] Specify the unit of return value for `Time#-`

### DIFF
--- a/ext/date/date_core.c
+++ b/ext/date/date_core.c
@@ -6332,9 +6332,11 @@ minus_dd(VALUE self, VALUE other)
  * call-seq:
  *    d - other  ->  date or rational
  *
- * Returns the difference between the two dates if the other is a date
- * object.  If the other is a numeric value, returns a date object
- * pointing +other+ days before self.  If the other is a fractional number,
+ * If the other is a date object, returns a Rational
+ * whose value is the difference between the two dates in days.
+ * If the other is a numeric value, returns a date object
+ * pointing +other+ days before self.
+ * If the other is a fractional number,
  * assumes its precision is at most nanosecond.
  *
  *     Date.new(2001,2,3) - 1	#=> #<Date: 2001-02-02 ...>

--- a/ext/date/date_core.c
+++ b/ext/date/date_core.c
@@ -6332,11 +6332,9 @@ minus_dd(VALUE self, VALUE other)
  * call-seq:
  *    d - other  ->  date or rational
  *
- * If the other is a date object, returns a Rational
- * whose value is the difference between the two dates in days.
- * If the other is a numeric value, returns a date object
- * pointing +other+ days before self.
- * If the other is a fractional number,
+ * Returns the difference between the two dates if the other is a date
+ * object.  If the other is a numeric value, returns a date object
+ * pointing +other+ days before self.  If the other is a fractional number,
  * assumes its precision is at most nanosecond.
  *
  *     Date.new(2001,2,3) - 1	#=> #<Date: 2001-02-02 ...>

--- a/time.c
+++ b/time.c
@@ -4410,7 +4410,7 @@ time_plus(VALUE time1, VALUE time2)
  *
  *  When +other_time+ is given,
  *  returns a Float whose value is the difference
- *  of the numeric values of +self+ and +other_time+:
+ *  of the numeric values of +self+ and +other_time+ in seconds:
  *
  *    t - t # => 0.0
  *


### PR DESCRIPTION
* Added the unit of return value in the description for `Time#-`
* cf: https://github.com/ruby/date/pull/97