### PR TITLE
YJIT: Optional parameter rework and bugfix

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -1,3 +1,37 @@
+# test splat filling required and feeding rest
+assert_equal '[0, 1, 2, [3, 4]]', %q{
+  public def lead_rest(a, b, *rest)
+    [self, a, b, rest]
+  end
+
+  def call(args) = 0.lead_rest(*args)
+
+  call([1, 2, 3, 4])
+}
+
+# test missing opts are nil initialized
+assert_equal '[[0, 1, nil, 3], [0, 1, nil, 3], [0, 1, nil, 3, []], [0, 1, nil, 3, []]]', %q{
+  public def lead_opts(a, b=binding.local_variable_get(:c), c=3)
+    [self, a, b, c]
+  end
+
+  public def opts_rest(a=raise, b=binding.local_variable_get(:c), c=3, *rest)
+    [self, a, b, c, rest]
+  end
+
+  def call(args)
+    [
+      0.lead_opts(1),
+      0.lead_opts(*args),
+
+      0.opts_rest(1),
+      0.opts_rest(*args),
+    ]
+  end
+
+  call([1])
+}
+
 # test filled optionals with unspecified keyword param
 assert_equal 'ok', %q{
   def opt_rest_opt_kw(_=1, *, k: :ok) = k

--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -1,3 +1,12 @@
+# test filled optionals with unspecified keyword param
+assert_equal 'ok', %q{
+  def opt_rest_opt_kw(_=1, *, k: :ok) = k
+
+  def call = opt_rest_opt_kw(0)
+
+  call
+}
+
 # test splat empty array with rest param
 assert_equal '[0, 1, 2, []]', %q{
   public def foo(a=1, b=2, *rest)

--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -1,3 +1,14 @@
+# test splat empty array with rest param
+assert_equal '[0, 1, 2, []]', %q{
+  public def foo(a=1, b=2, *rest)
+    [self, a, b, rest]
+  end
+
+  def call(args) = 0.foo(*args)
+
+  call([])
+}
+
 # Regression test for yielding with autosplat to block with
 # optional parameters. https://github.com/Shopify/yjit/issues/313
 assert_equal '[:a, :b, :a, :b]', %q{

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -5732,7 +5732,6 @@ fn gen_send_iseq(
     exit_if_has_kwrest(asm, iseq)?;
     exit_if_splat_and_ruby2_keywords(asm, jit, flags)?;
     exit_if_has_rest_and_captured(asm, iseq_has_rest, captured_opnd)?;
-    exit_if_has_rest_and_splat(asm, iseq_has_rest, flags)?;
     exit_if_has_rest_and_supplying_kws(asm, iseq_has_rest, iseq, supplying_kws)?;
     exit_if_supplying_kw_and_has_no_kw(asm, supplying_kws, iseq)?;
     exit_if_supplying_kws_and_accept_no_kwargs(asm, supplying_kws, iseq)?;
@@ -6491,11 +6490,6 @@ fn exit_if_splat_and_ruby2_keywords(asm: &mut Assembler, jit: &mut JITState, fla
 #[must_use]
 fn exit_if_has_rest_and_captured(asm: &mut Assembler, iseq_has_rest: bool, captured_opnd: Option<Opnd>) -> Option<()> {
     exit_if(asm, iseq_has_rest && captured_opnd.is_some(), Counter::send_iseq_has_rest_and_captured)
-}
-
-#[must_use]
-fn exit_if_has_rest_and_splat( asm: &mut Assembler, iseq_has_rest: bool, flags: u32) -> Option<()> {
-    exit_if(asm, iseq_has_rest && flags & VM_CALL_ARGS_SPLAT != 0, Counter::send_iseq_has_rest_and_splat)
 }
 
 #[must_use]

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -5523,6 +5523,11 @@ fn move_rest_args_to_stack(array: Opnd, num_args: u32, asm: &mut Assembler) {
     asm.cmp(array_len_opnd, num_args.into());
     asm.jl(Target::side_exit(Counter::guard_send_iseq_has_rest_and_splat_not_equal));
 
+    // Unused operands cause the backend to panic
+    if num_args == 0 {
+        return;
+    }
+
     asm.comment("Push arguments from array");
 
     // Load the address of the embedded array


### PR DESCRIPTION
See message in each commit.
Other than fixing the opts+rest+keywords bug and accepting to compile more situations, I like the new code because it has fewer `mut` variables than before.

_(Would like to merge without squashing)_