### PR TITLE
[DOC] Improve doc guide compliance

### DIFF
--- a/array.rb
+++ b/array.rb
@@ -81,7 +81,7 @@ class Array
   #
   # If +self+ is empty, returns +nil+.
   #
-  # When non-negative \Integer argument +n+ is given,
+  # When non-negative Integer argument +n+ is given,
   # returns the first +n+ elements in a new \Array:
   #
   #   a = [:foo, 'bar', 2]
@@ -125,7 +125,7 @@ class Array
   #
   # If +self+ is empty, returns +nil+.
   #
-  # When non-negative \Integer argument +n+ is given,
+  # When non-negative Integer argument +n+ is given,
   # returns the last +n+ elements in a new \Array:
   #
   #   a = [:foo, 'bar', 2]

--- a/enum.c
+++ b/enum.c
@@ -354,7 +354,7 @@ find_i(RB_BLOCK_CALL_FUNC_ARGLIST(i, memop))
  *   {foo: 0, bar: 1, baz: 2}.find {|key, value| key.start_with?('b') }            # => [:bar, 1]
  *   {foo: 0, bar: 1, baz: 2}.find(proc {[]}) {|key, value| key.start_with?('c') } # => []
  *
- * With no block given, returns an \Enumerator.
+ * With no block given, returns an Enumerator.
  *
  */
 static VALUE
@@ -424,7 +424,7 @@ find_index_iter_i(RB_BLOCK_CALL_FUNC_ARGLIST(i, memop))
  *   ['a', 'b', 'c', 'b'].find_index {|element| element.start_with?('b') } # => 1
  *   {foo: 0, bar: 1, baz: 2}.find_index {|key, value| value > 1 }         # => 2
  *
- * With no argument and no block given, returns an \Enumerator.
+ * With no argument and no block given, returns an Enumerator.
  *
  */
 
@@ -501,7 +501,7 @@ enum_size_over_p(VALUE obj, long n)
  *   a = {foo: 0, bar: 1, baz: 2}.select {|key, value| key.start_with?('b') }
  *   a # => {:bar=>1, :baz=>2}
  *
- * With no block given, returns an \Enumerator.
+ * With no block given, returns an Enumerator.
  *
  * Related: #reject.
  */
@@ -543,7 +543,7 @@ filter_map_i(RB_BLOCK_CALL_FUNC_ARGLIST(i, ary))
  *   (0..9).filter_map {|i| i * 2 if i.even? }                              # => [0, 4, 8, 12, 16]
  *   {foo: 0, bar: 1, baz: 2}.filter_map {|key, value| key if value.even? } # => [:foo, :baz]
  *
- * When no block given, returns an \Enumerator.
+ * When no block given, returns an Enumerator.
  *
  */
 static VALUE
@@ -584,7 +584,7 @@ reject_i(RB_BLOCK_CALL_FUNC_ARGLIST(i, ary))
  *   (0..9).reject {|i| i * 2 if i.even? }                             # => [1, 3, 5, 7, 9]
  *   {foo: 0, bar: 1, baz: 2}.reject {|key, value| key if value.odd? } # => {:foo=>0, :baz=>2}
  *
- * When no block given, returns an \Enumerator.
+ * When no block given, returns an Enumerator.
  *
  * Related: #select.
  */
@@ -631,7 +631,7 @@ collect_all(RB_BLOCK_CALL_FUNC_ARGLIST(i, ary))
  *   (0..4).map {|i| i*i }                               # => [0, 1, 4, 9, 16]
  *   {foo: 0, bar: 1, baz: 2}.map {|key, value| value*2} # => [0, 2, 4]
  *
- * With no block given, returns an \Enumerator.
+ * With no block given, returns an Enumerator.
  *
  */
 static VALUE
@@ -681,7 +681,7 @@ flat_map_i(RB_BLOCK_CALL_FUNC_ARGLIST(i, ary))
  *   [[0, 1], [2, 3]].flat_map {|e| e + [100] }                     # => [0, 1, 100, 2, 3, 100]
  *   {foo: 0, bar: 1, baz: 2}.flat_map {|key, value| [key, value] } # => [:foo, 0, :bar, 1, :baz, 2]
  *
- * With no block given, returns an \Enumerator.
+ * With no block given, returns an Enumerator.
  *
  * Alias: #collect_concat.
  */
@@ -4905,7 +4905,7 @@ enum_compact(VALUE obj)
  * - #one?: Returns +true+ if exactly one element meets a specified criterion; +false+ otherwise.
  * - #count: Returns the count of elements,
  *   based on an argument or block criterion, if given.
- * - #tally: Returns a new \Hash containing the counts of occurrences of each element.
+ * - #tally: Returns a new Hash containing the counts of occurrences of each element.
  *
  * === Methods for Fetching
  *
@@ -4926,20 +4926,20 @@ enum_compact(VALUE obj)
  *   as determined by <tt><=></tt> or a given block.
  * - #max: Returns the elements whose values are largest among the elements,
  *   as determined by <tt><=></tt> or a given block.
- * - #minmax: Returns a 2-element \Array containing the smallest and largest elements.
+ * - #minmax: Returns a 2-element Array containing the smallest and largest elements.
  * - #min_by: Returns the smallest element, as determined by the given block.
  * - #max_by: Returns the largest element, as determined by the given block.
  * - #minmax_by: Returns the smallest and largest elements, as determined by the given block.
  *
  * <i>Groups, slices, and partitions</i>:
  *
- * - #group_by: Returns a \Hash that partitions the elements into groups.
+ * - #group_by: Returns a Hash that partitions the elements into groups.
  * - #partition: Returns elements partitioned into two new Arrays, as determined by the given block.
- * - #slice_after: Returns a new \Enumerator whose entries are a partition of +self+,
+ * - #slice_after: Returns a new Enumerator whose entries are a partition of +self+,
      based either on a given +object+ or a given block.
- * - #slice_before: Returns a new \Enumerator whose entries are a partition of +self+,
+ * - #slice_before: Returns a new Enumerator whose entries are a partition of +self+,
      based either on a given +object+ or a given block.
- * - #slice_when: Returns a new \Enumerator whose entries are a partition of +self+
+ * - #slice_when: Returns a new Enumerator whose entries are a partition of +self+
      based on the given block.
  * - #chunk: Returns elements organized into chunks as specified by the given block.
  * - #chunk_while: Returns elements organized into chunks as specified by the given block.
@@ -5040,18 +5040,18 @@ enum_compact(VALUE obj)
  *
  * Virtually all methods in \Enumerable call method +#each+ in the including class:
  *
- * - <tt>Hash#each</tt> yields the next key-value pair as a 2-element \Array.
- * - <tt>Struct#each</tt> yields the next name-value pair as a 2-element \Array.
+ * - <tt>Hash#each</tt> yields the next key-value pair as a 2-element Array.
+ * - <tt>Struct#each</tt> yields the next name-value pair as a 2-element Array.
  * - For the other classes above, +#each+ yields the next object from the collection.
  *
  * == About the Examples
  *
  * The example code snippets for the \Enumerable methods:
  *
- * - Always show the use of one or more \Array-like classes (often \Array itself).
- * - Sometimes show the use of a \Hash-like class.
+ * - Always show the use of one or more Array-like classes (often Array itself).
+ * - Sometimes show the use of a Hash-like class.
  *   For some methods, though, the usage would not make sense,
- *   and so it is not shown.  Example: #tally would find exactly one of each \Hash entry.
+ *   and so it is not shown.  Example: #tally would find exactly one of each Hash entry.
  *
  */
 

--- a/object.c
+++ b/object.c
@@ -4145,7 +4145,7 @@ f_sprintf(int c, const VALUE *v, VALUE _)
  *
  *  These are the methods defined for BasicObject:
  *
- *  - ::new: Returns a new BasicObject instance.
+ *  - ::new: Returns a new \BasicObject instance.
  *  - #!: Returns the boolean negation of +self+: +true+ or +false+.
  *  - #!=: Returns whether +self+ and the given object are _not_ equal.
  *  - #==: Returns whether +self+ and the given object are equivalent.

--- a/object.c
+++ b/object.c
@@ -4143,7 +4143,7 @@ f_sprintf(int c, const VALUE *v, VALUE _)
  *
  *  === What's Here
  *
- *  These are the methods defined for BasicObject:
+ *  These are the methods defined for \BasicObject:
  *
  *  - ::new: Returns a new \BasicObject instance.
  *  - #!: Returns the boolean negation of +self+: +true+ or +false+.

--- a/object.c
+++ b/object.c
@@ -4298,7 +4298,7 @@ InitVM_Object(void)
      *
      * == What's Here
      *
-     * \Module Kernel provides methods that are useful for:
+     * \Module \Kernel provides methods that are useful for:
      *
      * - {Converting}[rdoc-ref:Kernel@Converting]
      * - {Querying}[rdoc-ref:Kernel@Querying]

--- a/object.c
+++ b/object.c
@@ -4143,9 +4143,9 @@ f_sprintf(int c, const VALUE *v, VALUE _)
  *
  *  === What's Here
  *
- *  These are the methods defined for \BasicObject:
+ *  These are the methods defined for BasicObject:
  *
- *  - ::new: Returns a new \BasicObject instance.
+ *  - ::new: Returns a new BasicObject instance.
  *  - #!: Returns the boolean negation of +self+: +true+ or +false+.
  *  - #!=: Returns whether +self+ and the given object are _not_ equal.
  *  - #==: Returns whether +self+ and the given object are equivalent.
@@ -4244,7 +4244,7 @@ f_sprintf(int c, const VALUE *v, VALUE _)
  *    and frozen state.
  *  - #define_singleton_method: Defines a singleton method in +self+
  *    for the given symbol method-name and block or proc.
- *  - #display: Prints +self+ to the given \IO stream or <tt>$stdout</tt>.
+ *  - #display: Prints +self+ to the given IO stream or <tt>$stdout</tt>.
  *  - #dup: Returns a shallow unfrozen copy of +self+.
  *  - #enum_for (aliased as #to_enum): Returns an Enumerator for +self+
  *    using the using the given method, arguments, and block.
@@ -4298,7 +4298,7 @@ InitVM_Object(void)
      *
      * == What's Here
      *
-     * \Module \Kernel provides methods that are useful for:
+     * \Module Kernel provides methods that are useful for:
      *
      * - {Converting}[rdoc-ref:Kernel@Converting]
      * - {Querying}[rdoc-ref:Kernel@Querying]

--- a/re.c
+++ b/re.c
@@ -3498,7 +3498,7 @@ match_hash(VALUE match)
  *  call-seq:
  *    matchdata == object -> true or false
  *
- *  Returns +true+ if +object+ is another MatchData object
+ *  Returns +true+ if +object+ is another \MatchData object
  *  whose target string, regexp, match, and captures
  *  are the same as +self+, +false+ otherwise.
  */

--- a/re.c
+++ b/re.c
@@ -3498,7 +3498,7 @@ match_hash(VALUE match)
  *  call-seq:
  *    matchdata == object -> true or false
  *
- *  Returns +true+ if +object+ is another \MatchData object
+ *  Returns +true+ if +object+ is another MatchData object
  *  whose target string, regexp, match, and captures
  *  are the same as +self+, +false+ otherwise.
  */

--- a/string.rb
+++ b/string.rb
@@ -265,7 +265,7 @@
 #
 #  <b><tt>string[regexp, capture = 0]</tt></b>
 #
-#  When the \Regexp argument +regexp+ is given,
+#  When the Regexp argument +regexp+ is given,
 #  and the +capture+ argument is <tt>0</tt>,
 #  the slice is the first matching substring found in +self+:
 #

--- a/struct.c
+++ b/struct.c
@@ -1547,7 +1547,7 @@ rb_struct_dig(int argc, VALUE *argv, VALUE self)
 /*
  *  Document-class: Data
  *
- *  \Class Data provides a convenient way to define simple classes
+ *  \Class \Data provides a convenient way to define simple classes
  *  for value-alike objects.
  *
  *  The simplest example of usage:
@@ -1619,7 +1619,7 @@ rb_struct_dig(int argc, VALUE *argv, VALUE self)
  * call-seq:
  *   define(*symbols) -> class
  *
- *  Defines a new Data class.
+ *  Defines a new \Data class.
  *
  *     measure = Data.define(:amount, :unit)
  *     #=> #<Class:0x00007f70c6868498>
@@ -1634,7 +1634,7 @@ rb_struct_dig(int argc, VALUE *argv, VALUE self)
  *     #=> #<data Measure amount=1, unit="km">
  *
  *
- *  Note that member-less Data is acceptable and might be a useful technique
+ *  Note that member-less \Data is acceptable and might be a useful technique
  *  for defining several homogenous data classes, like
  *
  *     class HTTPFetcher

--- a/struct.c
+++ b/struct.c
@@ -561,7 +561,7 @@ rb_struct_define_under(VALUE outer, const char *name, ...)
  *
  *  <b>Member Names</b>
  *
- *  \Symbol arguments +member_names+
+ *  Symbol arguments +member_names+
  *  determines the members of the new subclass:
  *
  *    Struct.new(:foo, :bar).members        # => [:foo, :bar]
@@ -1547,7 +1547,7 @@ rb_struct_dig(int argc, VALUE *argv, VALUE self)
 /*
  *  Document-class: Data
  *
- *  \Class \Data provides a convenient way to define simple classes
+ *  \Class Data provides a convenient way to define simple classes
  *  for value-alike objects.
  *
  *  The simplest example of usage:
@@ -1619,7 +1619,7 @@ rb_struct_dig(int argc, VALUE *argv, VALUE self)
  * call-seq:
  *   define(*symbols) -> class
  *
- *  Defines a new \Data class.
+ *  Defines a new Data class.
  *
  *     measure = Data.define(:amount, :unit)
  *     #=> #<Class:0x00007f70c6868498>
@@ -1634,7 +1634,7 @@ rb_struct_dig(int argc, VALUE *argv, VALUE self)
  *     #=> #<data Measure amount=1, unit="km">
  *
  *
- *  Note that member-less \Data is acceptable and might be a useful technique
+ *  Note that member-less Data is acceptable and might be a useful technique
  *  for defining several homogenous data classes, like
  *
  *     class HTTPFetcher

--- a/time.c
+++ b/time.c
@@ -3637,7 +3637,7 @@ tmcmp(struct tm *a, struct tm *b)
  *     Time.utc(Float(0.0), Rational(1, 1), 1.0, 0.0, 0.0, 0.0, 0.0)
  *     # => 0000-01-01 00:00:00 UTC
  *
- * - \String integers:
+ * - String integers:
  *
  *     a = %w[0 1 1 0 0 0 0 0]
  *     # => ["0", "1", "1", "0", "0", "0", "0", "0"]

--- a/timev.rb
+++ b/timev.rb
@@ -359,7 +359,7 @@ class Time
   #     Time.new(Float(0.0), Rational(1, 1), 1.0, 0.0, 0.0, 0.0)
   #     # => 0000-01-01 00:00:00 -0600
   #
-  # - \String integers:
+  # - String integers:
   #
   #     a = %w[0 1 1 0 0 0]
   #     # => ["0", "1", "1", "0", "0", "0"]

--- a/weakmap.c
+++ b/weakmap.c
@@ -894,8 +894,8 @@ wkmap_clear(VALUE self)
  *  call-seq:
  *    map.inspect -> new_string
  *
- *  Returns a new \String containing informations about the map:
-
+ *  Returns a new String containing informations about the map:
+ *
  *    m = ObjectSpace::WeakKeyMap.new
  *    m[key] = value
  *    m.inspect # => "#<ObjectSpace::WeakKeyMap:0x00000001028dcba8 size=1>"


### PR DESCRIPTION
Avoid suppressing autolinks to classes and modules.

I think this is the last for ruby/*.{c,rb}.  Everything else is upstream, right?