### PR TITLE
YJIT: implement side chain fallback for setlocal to avoid exiting

### DIFF
--- a/test/ruby/test_yjit.rb
+++ b/test/ruby/test_yjit.rb
@@ -661,7 +661,7 @@ class TestYJIT < Test::Unit::TestCase
 
   def test_send_block
     # Setlocal_wc_0 sometimes side-exits on write barrier
-    assert_compiles(<<~'RUBY', result: "b:n/b:y/b:y/b:n", exits: { :setlocal_WC_0 => 0..1 })
+    assert_compiles(<<~'RUBY', result: "b:n/b:y/b:y/b:n")
       def internal_method(&b)
         "b:#{block_given? ? "y" : "n"}"
       end

--- a/vm_core.h
+++ b/vm_core.h
@@ -1758,6 +1758,7 @@ rb_thread_t * ruby_thread_from_native(void);
 int ruby_thread_set_native(rb_thread_t *th);
 int rb_vm_control_frame_id_and_class(const rb_control_frame_t *cfp, ID *idp, ID *called_idp, VALUE *klassp);
 void rb_vm_rewind_cfp(rb_execution_context_t *ec, rb_control_frame_t *cfp);
+void rb_vm_env_write(const VALUE *ep, int index, VALUE v);
 VALUE rb_vm_bh_to_procval(const rb_execution_context_t *ec, VALUE block_handler);
 
 void rb_vm_register_special_exception_str(enum ruby_special_exceptions sp, VALUE exception_class, VALUE mesg);

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -505,6 +505,12 @@ vm_env_write(const VALUE *ep, int index, VALUE v)
     }
 }
 
+void
+rb_vm_env_write(const VALUE *ep, int index, VALUE v)
+{
+    vm_env_write(ep, index, v);
+}
+
 VALUE
 rb_vm_bh_to_procval(const rb_execution_context_t *ec, VALUE block_handler)
 {

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -283,6 +283,7 @@ fn main() {
         .blocklist_type("rb_control_frame_struct")
         .opaque_type("rb_control_frame_struct")
         .allowlist_function("rb_vm_bh_to_procval")
+        .allowlist_function("rb_vm_env_write")
         .allowlist_function("rb_vm_ep_local_ep")
         .allowlist_type("vm_special_object_type")
         .allowlist_var("VM_ENV_DATA_INDEX_SPECVAL")

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -1773,9 +1773,8 @@ fn gen_setlocal_generic(
     // Fallback because of write barrier
     if asm.ctx.get_chain_depth() > 0
     {
-        // Max says: I don't think that this is needed here?
-        // Save the PC and SP because we are allocating
-        //jit_prepare_routine_call(jit, asm);
+        // Save the PC and SP because it runs GC
+        jit_prepare_routine_call(jit, asm);
 
         // Pop the value to write from the stack
         let value_opnd = asm.stack_pop(1);

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -1166,6 +1166,7 @@ extern "C" {
     pub static mut rb_block_param_proxy: VALUE;
     pub fn rb_vm_ep_local_ep(ep: *const VALUE) -> *const VALUE;
     pub fn rb_iseq_path(iseq: *const rb_iseq_t) -> VALUE;
+    pub fn rb_vm_env_write(ep: *const VALUE, index: ::std::os::raw::c_int, v: VALUE);
     pub fn rb_vm_bh_to_procval(ec: *const rb_execution_context_t, block_handler: VALUE) -> VALUE;
     pub fn rb_vm_frame_method_entry(
         cfp: *const rb_control_frame_t,


### PR DESCRIPTION
Railsbench before:
```
ratio_in_yjit:                 97.4%
avg_len_in_yjit:                49.9
Top-12 most frequent exit ops (100.0% of exits):
             setlocal_WC_0:     12,252 (41.4%)
               expandarray:      9,945 (33.6%)
                    opt_eq:      4,966 (16.8%)
        getblockparamproxy:      2,090 ( 7.1%)
      opt_getconstant_path:        243 ( 0.8%)
```

Railsbench after:
```
ratio_in_yjit:                 98.2%
avg_len_in_yjit:                51.8
Top-11 most frequent exit ops (100.0% of exits):
               expandarray:      9,945 (57.3%)
                    opt_eq:      4,966 (28.6%)
        getblockparamproxy:      2,090 (12.0%)
      opt_getconstant_path:        243 ( 1.4%)
                      once:         58 ( 0.3%)
```