### PR TITLE
Incrementally mark even if we have free pages

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -2347,7 +2347,7 @@ gc_continue(rb_objspace_t *objspace, rb_size_pool_t *size_pool, rb_heap_t *heap)
     gc_enter(objspace, gc_enter_event_continue, &lock_lev);
 
     /* Continue marking if in incremental marking. */
-    if (heap->free_pages == NULL && is_incremental_marking(objspace)) {
+    if (is_incremental_marking(objspace)) {
         if (gc_marks_continue(objspace, size_pool, heap)) {
             gc_sweep(objspace);
         }


### PR DESCRIPTION
We move all pooled pages to free pages at the start of incremental marking, so we shouldn't run incremental marking only when we have run out of free pages. This causes incremental marking to always complete in a single step.