### PR TITLE
Move the PC regardless of the leaf flag

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -10217,12 +10217,6 @@ dump_disasm_list_with_cursor(const LINK_ELEMENT *link, const LINK_ELEMENT *curr,
     fflush(stdout);
 }
 
-bool
-rb_insns_leaf_p(int i)
-{
-    return insn_leaf_p(i);
-}
-
 int
 rb_insn_len(VALUE insn)
 {

--- a/internal/compile.h
+++ b/internal/compile.h
@@ -17,7 +17,6 @@ struct rb_iseq_struct;          /* in vm_core.h */
 /* compile.c */
 int rb_dvar_defined(ID, const struct rb_iseq_struct *);
 int rb_local_defined(ID, const struct rb_iseq_struct *);
-bool rb_insns_leaf_p(int i);
 int rb_insn_len(VALUE insn);
 const char *rb_insns_name(int i);
 VALUE rb_insns_name_array(void);

--- a/test/objspace/test_objspace.rb
+++ b/test/objspace/test_objspace.rb
@@ -225,6 +225,13 @@ class TestObjSpace < Test::Unit::TestCase
       assert_equal(__FILE__, ObjectSpace.allocation_sourcefile(o4))
       assert_equal(line4, ObjectSpace.allocation_sourceline(o4))
 
+      # The line number should be based on newarray instead of getinstancevariable.
+      line5 = __LINE__; o5 = [ # newarray (leaf)
+        @ivar, # getinstancevariable (not leaf)
+      ]
+      assert_equal(__FILE__, ObjectSpace.allocation_sourcefile(o5))
+      assert_equal(line5, ObjectSpace.allocation_sourceline(o5))
+
       # [Bug #19482]
       EnvUtil.under_gc_stress do
         100.times do

--- a/tool/ruby_vm/views/_insn_entry.erb
+++ b/tool/ruby_vm/views/_insn_entry.erb
@@ -24,7 +24,7 @@ INSN_ENTRY(<%= insn.name %>)
     <%= ope[:decl] %> = (<%= ope[:type] %>)GET_OPERAND(<%= i + 1 %>);
 % end
 #   define INSN_ATTR(x) <%= insn.call_attribute(' ## x ## ') %>
-    const bool leaf = INSN_ATTR(leaf);
+    const bool MAYBE_UNUSED(leaf) = INSN_ATTR(leaf);
 % insn.pops.reverse_each.with_index.reverse_each do |pop, i|
     <%= pop[:decl] %> = <%= insn.cast_from_VALUE pop, "TOPN(#{i})"%>;
 % end
@@ -35,7 +35,7 @@ INSN_ENTRY(<%= insn.name %>)
 % end
 
     /* ### Instruction preambles. ### */
-    if (! leaf) ADD_PC(INSN_ATTR(width));
+    ADD_PC(INSN_ATTR(width));
 % if insn.handles_sp?
     POPN(INSN_ATTR(popn));
 % end
@@ -68,7 +68,6 @@ INSN_ENTRY(<%= insn.name %>)
     VM_ASSERT(!RB_TYPE_P(TOPN(<%= i %>), T_MOVED));
 %   end
 % end
-    if (leaf) ADD_PC(INSN_ATTR(width));
 #   undef INSN_ATTR
 
     /* ### Leave the instruction. ### */

--- a/tool/ruby_vm/views/_leaf_helpers.erb
+++ b/tool/ruby_vm/views/_leaf_helpers.erb
@@ -10,31 +10,6 @@
 
 #include "iseq.h"
 
-extern const bool rb_vm_insn_leaf_p[];
-
-#ifdef RUBY_VM_INSNS_INFO
-const bool rb_vm_insn_leaf_p[] = {
-% RubyVM::Instructions.each_slice(20) do |insns|
-    <%= insns.map do |insn|
-        if insn.is_a?(RubyVM::BareInstructions)
-          insn.always_leaf? ? '1' : '0'
-        else
-          '0'
-        end
-      end.join(', ')
-    %>,
-% end
-};
-#endif
-
-CONSTFUNC(MAYBE_UNUSED(static bool insn_leaf_p(VALUE insn)));
-
-bool
-insn_leaf_p(VALUE insn)
-{
-    return rb_vm_insn_leaf_p[insn];
-}
-
 // This is used to tell RJIT that this insn would be leaf if CHECK_INTS didn't exist.
 // It should be used only when RUBY_VM_CHECK_INTS is directly written in insns.def.
 static bool leafness_of_check_ints = false;

--- a/vm_insnhelper.h
+++ b/vm_insnhelper.h
@@ -181,10 +181,8 @@ CC_SET_FASTPATH(const struct rb_callcache *cc, vm_call_handler func, bool enable
 /**********************************************************/
 
 #define CALL_SIMPLE_METHOD() do { \
-    rb_snum_t x = leaf ? INSN_ATTR(width) : 0; \
-    rb_snum_t y = attr_width_opt_send_without_block(0); \
-    rb_snum_t z = x - y; \
-    ADD_PC(z); \
+    rb_snum_t insn_width = attr_width_opt_send_without_block(0); \
+    ADD_PC(-insn_width); \
     DISPATCH_ORIGINAL_INSN(opt_send_without_block); \
 } while (0)
 


### PR DESCRIPTION
This PR fixes https://bugs.ruby-lang.org/issues/19456 for the case that https://github.com/ruby/ruby/pull/7357 did not cover as explained in https://github.com/ruby/ruby/commit/fa1eb31fca. It can't be fixed as long as the PC is conditionally moved. The PC motion needs to be consistent across all instructions.

This change will also help us implement an upcoming PC-related YJIT optimization efficiently. It comes with deoptimization that lazily materializes CFPs in arbitrary C functions (e.g. our current `gc_event_hook_body`). For performance, we want to avoid materialization if possible. It's required when we modify `cfp->pc`.

This PR unfortunately ends up reverting https://github.com/ruby/ruby/commit/9c6bd0d840. We benchmarked it, and we think that the performance impact is not too significant today.

## Benchmarks
This change slows down some benchmarks, but also speeds up some other benchmarks. Looking at Rails application benchmarks like `railsbench` and `lobsters`, it doesn't show any difference. So the performance impact is probably not significant when you look at a whole application.

### yjit-bench
We ran https://github.com/shopify/yjit-bench without JIT.

`psych-load` slows down, but 5 benchmarks show a 2%+ speedup.

```
before: ruby 3.3.0dev (2023-08-16T14:52:04Z master 0d7e847153) [x86_64-linux]
after: ruby 3.3.0dev (2023-08-16T21:54:16Z move-pc-for-leaf 314dcc733d) [x86_64-linux]

--------------  -----------  ----------  ----------  ----------  -------------  ------------
bench           before (ms)  stddev (%)  after (ms)  stddev (%)  after 1st itr  before/after
activerecord    67.9         2.7         67.6        2.8         1.00           1.00
chunky-png      708.5        0.4         697.8       0.3         1.01           1.02
erubi-rails     18.9         18.7        18.8        18.8        0.98           1.00
hexapdf         2323.1       0.7         2282.8      0.6         1.01           1.02
liquid-c        58.2         0.3         56.7        0.4         1.01           1.03
liquid-compile  56.0         0.5         56.0        0.4         0.99           1.00
liquid-render   144.1        0.2         141.2       0.3         1.01           1.02
lobsters        907.3        1.7         907.9       1.4         0.99           1.00
mail            121.1        0.2         120.5       0.3         1.00           1.01
psych-load      1853.9       0.4         1949.7      0.4         0.93           0.95
railsbench      1928.1       0.6         1931.6      0.9         1.00           1.00
ruby-lsp        58.1         5.2         57.2        3.7         1.00           1.02
sequel          67.4         1.3         65.8        1.3         1.03           1.03
--------------  -----------  ----------  ----------  ----------  -------------  ------------
```

### Shootout
We also ran the same set of benchmarks used in the original change https://github.com/ruby/ruby/commit/9c6bd0d840. 

There are 8 benchmarks that show a 2-7% slowdown, and 2 benchmarks that show a 2-3% speedup.

<details>

```
$ benchmark-driver so_ackermann.rb so_concatenate.rb so_fannkuch.rb so_lists.rb so_meteor_contest.rb so_nsieve_bits.rb so_partial_sums.rb so_reverse_complement.yml so_array.rb so_count_words.yml so_fasta.rb so_mandelbrot.rb so_nbody.rb so_nsieve.rb so_pidigits.rb so_sieve.rb so_binary_trees.rb so_exception.rb so_k_nucleotide.yml so_matrix.rb so_nested_loop.rb so_object.rb so_random.rb so_spectralnorm.rb --chruby 'before;after' --output=markdown --output-compare --repeat-count=4 -v
before: ruby 3.3.0dev (2023-08-16T14:52:04Z master 0d7e847153) [x86_64-linux]
after: ruby 3.3.0dev (2023-08-16T21:54:16Z move-pc-for-leaf 314dcc733d) [x86_64-linux]
```

#### Iteration per second (i/s)

|                       |  before|   after|
|:----------------------|-------:|-------:|
|so_ackermann           |   2.392|   2.403|
|                       |       -|   1.00x|
|so_concatenate         |   0.616|   0.619|
|                       |       -|   1.00x|
|so_fannkuch            |   2.067|   2.078|
|                       |       -|   1.01x|
|so_lists               |   3.321|   3.160|
|                       |   1.05x|       -|
|so_meteor_contest      |   0.429|   0.431|
|                       |       -|   1.00x|
|so_nsieve_bits         |   0.762|   0.737|
|                       |   1.03x|       -|
|so_partial_sums        |   0.913|   0.852|
|                       |   1.07x|       -|
|so_reverse_complement  |   1.450|   1.420|
|                       |   1.02x|       -|
|so_array               |   1.683|   1.685|
|                       |       -|   1.00x|
|so_count_words         |  10.468|  10.504|
|                       |       -|   1.00x|
|so_fasta               |   0.722|   0.738|
|                       |       -|   1.02x|
|so_mandelbrot          |   0.644|   0.627|
|                       |   1.03x|       -|
|so_nbody               |   1.078|   1.036|
|                       |   1.04x|       -|
|so_nsieve              |   0.803|   0.814|
|                       |       -|   1.01x|
|so_pidigits            |   1.969|   1.970|
|                       |       -|   1.00x|
|so_sieve               |   2.409|   2.481|
|                       |       -|   1.03x|
|so_binary_trees        |   0.247|   0.246|
|                       |   1.01x|       -|
|so_exception           |   5.221|   5.199|
|                       |   1.00x|       -|
|so_k_nucleotide        |   1.201|   1.204|
|                       |       -|   1.00x|
|so_matrix              |   2.737|   2.736|
|                       |   1.00x|       -|
|so_nested_loop         |   1.426|   1.438|
|                       |       -|   1.01x|
|so_object              |   2.329|   2.264|
|                       |   1.03x|       -|
|so_random              |   2.687|   2.627|
|                       |   1.02x|       -|
|so_spectralnorm        |   0.823|   0.832|
|                       |       -|   1.01x|

</details>