### PR TITLE
[Bug #19831] Remove duplicate library options

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3061,8 +3061,7 @@ AC_SUBST(EXTOBJS)
 			: ${LIBPATHENV=DYLD_FALLBACK_LIBRARY_PATH}
 			: ${PRELOADENV=DYLD_INSERT_LIBRARIES}
                         AS_IF([test x"$enable_shared" = xyes], [
-                            # Resolve symbols from libruby.dylib when --enable-shared
-                            EXTDLDFLAGS='$(LIBRUBYARG_SHARED)'
+                            # Resolve symbols from libruby.dylib in $(LIBS) when --enable-shared
                         ], [test "x$EXTSTATIC" = x], [
                             # When building exts as bundles, a mach-o bundle needs to know its loader
                             # program to bind symbols from the ruby executable


### PR DESCRIPTION
`$(LIBRUBYARG_SHARED)` is included in `$(LIBS)` in extension libraries.