### PR TITLE
Don't check for STR_NOEMBED in rb_fstring

### DIFF
--- a/string.c
+++ b/string.c
@@ -421,7 +421,8 @@ rb_fstring(VALUE str)
             OBJ_FREEZE_RAW(str);
             return str;
         }
-        if (FL_TEST_RAW(str, STR_NOEMBED|STR_SHARED_ROOT|STR_SHARED) == (STR_NOEMBED|STR_SHARED_ROOT)) {
+
+        if (FL_TEST_RAW(str, STR_SHARED_ROOT | STR_SHARED) == STR_SHARED_ROOT) {
             assert(OBJ_FROZEN(str));
             return str;
         }


### PR DESCRIPTION
We don't need to check for STR_NOEMBED because the check above for STR_EMBED_P means that it can never be false.