### PR TITLE
YJIT: Fix Kernel#respond_to? handling of rb_f_notimplement

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -4898,7 +4898,7 @@ fn jit_obj_respond_to(
             // Method exists and has acceptable visibility
             if cme_def_type == VM_METHOD_TYPE_NOTIMPLEMENTED {
                 // C method with rb_f_notimplement(). `respond_to?` returns false
-                // without consulting `respond_to_missing?`.
+                // without consulting `respond_to_missing?`. See also: rb_add_method_cfunc()
                 Qfalse
             } else {
                 Qtrue


### PR DESCRIPTION
We should return false for this type of special methods but wasn't
previously. Was reproducible with:

    make test-all TESTS=../test/-ext-/test_notimplement.rb RUN_OPTS='--yjit-call-threshold=1'
