### PR TITLE
YJIT: Fix String#<< return type

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -1,3 +1,12 @@
+# regression test for return type of String#<<
+assert_equal 'Sub', %q{
+  def call(sub) = (sub << sub).itself
+
+  class Sub < String; end
+
+  call(Sub.new('o')).class
+}
+
 # test splat filling required and feeding rest
 assert_equal '[0, 1, 2, [3, 4]]', %q{
   public def lead_rest(a, b, *rest)

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -4764,7 +4764,7 @@ fn jit_rb_str_concat(
     asm.spill_temps(); // for ccall
     let ret_opnd = asm.ccall(rb_yjit_str_simple_append as *const u8, vec![recv, concat_arg]);
     let ret_label = asm.new_label("func_return");
-    let stack_ret = asm.stack_push(Type::CString);
+    let stack_ret = asm.stack_push(Type::TString);
     asm.mov(stack_ret, ret_opnd);
     asm.stack_pop(1); // forget stack_ret to re-push after ccall
     asm.jmp(ret_label);
@@ -4773,7 +4773,7 @@ fn jit_rb_str_concat(
     asm.write_label(enc_mismatch);
     asm.spill_temps(); // for ccall
     let ret_opnd = asm.ccall(rb_str_buf_append as *const u8, vec![recv, concat_arg]);
-    let stack_ret = asm.stack_push(Type::CString);
+    let stack_ret = asm.stack_push(Type::TString);
     asm.mov(stack_ret, ret_opnd);
     // Drop through to return
 


### PR DESCRIPTION
We previously falsely asserted that String#<< always returns a ::String
instance. Issue was discovered on CI with `--yjit-verify-ctx`.

https://github.com/ruby/ruby/actions/runs/5893760435/job/15986002531
