### PR TITLE
Add rb_no_keywords_accepted to C-API

### DIFF
--- a/enumerator.c
+++ b/enumerator.c
@@ -3510,7 +3510,7 @@ enum_product_initialize(int argc, VALUE *argv, VALUE obj)
     rb_scan_args(argc, argv, "*:", &enums, &options);
 
     if (!NIL_P(options) && !RHASH_EMPTY_P(options)) {
-        rb_exc_raise(rb_keyword_error_new("unknown", rb_hash_keys(options)));
+        rb_no_keywords_accepted();
     }
 
     rb_check_frozen(obj);
@@ -3736,7 +3736,7 @@ enumerator_s_product(int argc, VALUE *argv, VALUE klass)
     rb_scan_args(argc, argv, "*:&", &enums, &options, &block);
 
     if (!NIL_P(options) && !RHASH_EMPTY_P(options)) {
-        rb_exc_raise(rb_keyword_error_new("unknown", rb_hash_keys(options)));
+        rb_no_keywords_accepted();
     }
 
     VALUE obj = enum_product_initialize(argc, argv, enum_product_allocate(rb_cEnumProduct));

--- a/error.c
+++ b/error.c
@@ -3240,6 +3240,12 @@ rb_loaderror_with_path(VALUE path, const char *fmt, ...)
 }
 
 void
+rb_no_keywords_accepted(void)
+{
+    rb_raise(rb_eArgError, "no keywords accepted");
+}
+
+void
 rb_notimplement(void)
 {
     rb_raise(rb_eNotImpError,

--- a/include/ruby/internal/error.h
+++ b/include/ruby/internal/error.h
@@ -326,6 +326,16 @@ RBIMPL_ATTR_NORETURN()
  */
 void rb_notimplement(void);
 
+RBIMPL_ATTR_NORETURN()
+/**
+ * Raises an ArgumentError stating no keywords accepted. Should be used for
+ * C functions that want to implement the equivalent of **nil syntax.
+ *
+ * @exception  rb_eArgError
+ * @note       It never returns.
+ */
+void rb_no_keywords_accepted(void);
+
 /**
  * Creates an exception object that represents the given C errno.
  *

--- a/spec/ruby/core/enumerator/product_spec.rb
+++ b/spec/ruby/core/enumerator/product_spec.rb
@@ -47,7 +47,7 @@ ruby_version_is "3.2" do
     it "reject keyword arguments" do
       -> {
         Enumerator.product(1..3, foo: 1, bar: 2)
-      }.should raise_error(ArgumentError, "unknown keywords: :foo, :bar")
+      }.should raise_error(ArgumentError)
     end
 
     it "calls only #each_entry method on arguments" do

--- a/test/ruby/test_enumerator.rb
+++ b/test/ruby/test_enumerator.rb
@@ -969,7 +969,7 @@ class TestEnumerator < Test::Unit::TestCase
     assert_equal [1, 1, 2, 2, 3, 3], heads
 
     # Reject keyword arguments
-    assert_raise(ArgumentError) {
+    assert_raise(ArgumentError, "no keywords accepted") {
       Enumerator::Product.new(1..3, foo: 1, bar: 2)
     }
 
@@ -1004,7 +1004,7 @@ class TestEnumerator < Test::Unit::TestCase
     assert_equal [[1, "a"], [1, "b"], [2, "a"], [2, "b"]], e.take(4)
 
     # Reject keyword arguments
-    assert_raise(ArgumentError) {
+    assert_raise(ArgumentError, "no keywords accepted") {
       Enumerator.product(1..3, foo: 1, bar: 2)
     }
   end

--- a/vm_args.c
+++ b/vm_args.c
@@ -629,7 +629,7 @@ setup_parameters_complex(rb_execution_context_t * const ec, const rb_iseq_t * co
     }
 
     if (kw_flag && ISEQ_BODY(iseq)->param.flags.accepts_no_kwarg) {
-        rb_raise(rb_eArgError, "no keywords accepted");
+        rb_no_keywords_accepted();
     }
 
     switch (arg_setup_type) {


### PR DESCRIPTION
This can be used by extensions for C functions that want to implement the equivalent of **nil syntax.

Extract this function from vm_args.c.

Update Enumerator::Product.new and Enumerator.product to use this function.

Loosen spec to pass with both the previous and new message.

Fixes [Bug #19829]