### PR TITLE
YJIT: Fix return type of Integer#/ with T_FIXNUM inputs

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -1,3 +1,13 @@
+# regression test for return type of Integer#/
+# It can return a T_BIGNUM when inputs are T_FIXNUM.
+assert_equal 0x3fffffffffffffff.to_s, %q{
+  def call(fixnum_min)
+    (fixnum_min / -1) - 1
+  end
+
+  call(-(2**62))
+}
+
 # regression test for return type of String#<<
 assert_equal 'Sub', %q{
   def call(sub) = (sub << sub).itself

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -4531,6 +4531,9 @@ fn jit_rb_int_div(
     }
     guard_two_fixnums(jit, asm, ocb);
 
+    // rb_fix_div_fix may GC-allocate for Bignum
+    jit_prepare_routine_call(jit, asm);
+
     asm.comment("Integer#/");
     let obj = asm.stack_pop(1);
     let recv = asm.stack_pop(1);
@@ -4541,7 +4544,7 @@ fn jit_rb_int_div(
 
     let ret = asm.ccall(rb_fix_div_fix as *const u8, vec![recv, obj]);
 
-    let ret_opnd = asm.stack_push(Type::Fixnum);
+    let ret_opnd = asm.stack_push(Type::Unknown);
     asm.mov(ret_opnd, ret);
     true
 }


### PR DESCRIPTION
Issue found by running ruby/spec with `--yjit-verify-ctx`. Thanks!
