### PR TITLE
YJIT: Quiet mode when running with `--yjit-stats`

### DIFF
--- a/yjit.c
+++ b/yjit.c
@@ -1169,6 +1169,7 @@ rb_yjit_set_exception_return(rb_control_frame_t *cfp, void *leave_exit, void *le
 
 // Primitives used by yjit.rb
 VALUE rb_yjit_stats_enabled_p(rb_execution_context_t *ec, VALUE self);
+VALUE rb_yjit_print_stats_p(rb_execution_context_t *ec, VALUE self);
 VALUE rb_yjit_trace_exit_locations_enabled_p(rb_execution_context_t *ec, VALUE self);
 VALUE rb_yjit_get_stats(rb_execution_context_t *ec, VALUE self, VALUE context);
 VALUE rb_yjit_reset_stats_bang(rb_execution_context_t *ec, VALUE self);

--- a/yjit.rb
+++ b/yjit.rb
@@ -226,7 +226,9 @@ module RubyVM::YJIT
   # Avoid calling a method here to not interfere with compilation tests
   if Primitive.rb_yjit_stats_enabled_p
     at_exit do
-      _print_stats
+      if Primitive.rb_yjit_print_stats_p
+        _print_stats
+      end
       _dump_locations
     end
   end

--- a/yjit/src/options.rs
+++ b/yjit/src/options.rs
@@ -26,8 +26,11 @@ pub struct Options {
     // The number of registers allocated for stack temps
     pub num_temp_regs: usize,
 
-    // Capture and print out stats
+    // Capture stats
     pub gen_stats: bool,
+
+    // Print stats on exit (when gen_stats is also true)
+    pub print_stats: bool,
 
     // Trace locations of exits
     pub gen_trace_exits: bool,
@@ -62,6 +65,7 @@ pub static mut OPTIONS: Options = Options {
     num_temp_regs: 5,
     gen_stats: false,
     gen_trace_exits: false,
+    print_stats: true,
     trace_exits_sample_rate: 0,
     pause: false,
     dump_insns: false,
@@ -176,7 +180,16 @@ pub fn parse_option(str_ptr: *const std::os::raw::c_char) -> Option<()> {
 
         ("greedy-versioning", "") => unsafe { OPTIONS.greedy_versioning = true },
         ("no-type-prop", "") => unsafe { OPTIONS.no_type_prop = true },
-        ("stats", "") => unsafe { OPTIONS.gen_stats = true },
+        ("stats", _) => match opt_val.to_string().as_str() {
+            "" => unsafe { OPTIONS.gen_stats = true },
+            "quiet" => {
+                unsafe { OPTIONS.gen_stats = true }
+                unsafe { OPTIONS.print_stats = false }
+            },
+            _ => {
+                return None;
+            }
+        },
         ("trace-exits", "") => unsafe { OPTIONS.gen_trace_exits = true; OPTIONS.gen_stats = true; OPTIONS.trace_exits_sample_rate = 0 },
         ("trace-exits-sample-rate", sample_rate) => unsafe { OPTIONS.gen_trace_exits = true; OPTIONS.gen_stats = true; OPTIONS.trace_exits_sample_rate = sample_rate.parse().unwrap(); },
         ("dump-insns", "") => unsafe { OPTIONS.dump_insns = true },

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -463,6 +463,17 @@ pub extern "C" fn rb_yjit_stats_enabled_p(_ec: EcPtr, _ruby_self: VALUE) -> VALU
     }
 }
 
+/// Primitive called in yjit.rb
+/// Check if stats generation should print at exit
+#[no_mangle]
+pub extern "C" fn rb_yjit_print_stats_p(_ec: EcPtr, _ruby_self: VALUE) -> VALUE {
+    if get_option!(print_stats) {
+        return Qtrue;
+    } else {
+        return Qfalse;
+    }
+}
+
 /// Primitive called in yjit.rb.
 /// Export all YJIT statistics as a Ruby hash.
 #[no_mangle]


### PR DESCRIPTION
This PR adds a the `--yjit-stats=quiet` option while running with YJIT in stats mode. 

Currently, when running with `--yjit-stats`, stats are always printed on exit. With this change, `--yjit-stats=quiet` will give us the option to collect the stats-mode runtime stats without needing to print them. Passing in an invalid option to `--yjit-stats` will return an error message, which was the case for passing anything to `--yjit-stats` before the changes in this PR. Running with `--yjit-stats` will still print the stats on exit by default.

This option would be useful in cases where we would like to collect stats without printing them, e.g. if also running tests that compare what gets printed with test expectations.