### PR TITLE
[DOC] RDoc for Process

### DIFF
--- a/process.c
+++ b/process.c
@@ -3006,7 +3006,6 @@ NORETURN(static VALUE f_exec(int c, const VALUE *a, VALUE _));
 /*
  *  call-seq:
  *    exec([env, ] command_line, options = {})
- *    exec([env, ] exe_path, options  = {})
  *    exec([env, ] exe_path, *args, options  = {})
  *
  *  Replaces the current process by doing one of the following:

--- a/process.c
+++ b/process.c
@@ -8650,8 +8650,7 @@ proc_warmup(VALUE _)
  * Each of these methods creates a process:
  *
  * - Process.exec: Replaces the current process by running a given external command.
- * - Process.spawn: Creates a child process.
- * - Kernel#spawn: Executes the given command and returns its pid without waiting for completion.
+ * - Process.spawn, Kernel#spawn: Executes the given command and returns its pid without waiting for completion.
  * - Kernel#system: Executes the given command in a subshell.
  *
  * Each of these methods accepts:

--- a/process.c
+++ b/process.c
@@ -1538,8 +1538,8 @@ rb_detach_process(rb_pid_t pid)
  *  but it does detach the process so that it does not become a zombie:
  *
  *    pid = Process.spawn('ruby', '-e', 'exit 13') # => 313213
- *    sleep(1)
  *    thread = Process.detach(pid)
+ *    sleep(1)
  *    # => #<Process::Waiter:0x00007f038f48b838 run>
  *    system("ps -ho pid,state -p #{pid}")        # Finds no zombies.
  *

--- a/process.c
+++ b/process.c
@@ -8790,6 +8790,7 @@ proc_warmup(VALUE _)
  * to create a new process group for the new process.
  *
  * ==== Resource Limits
+ *
  * Use execution options to set resource limits.
  *
  * The keys for these options are symbols of the form

--- a/process.c
+++ b/process.c
@@ -1424,7 +1424,7 @@ proc_m_wait(int c, VALUE *v, VALUE _)
  *    Process.wait2(pid = -1, flags = 0) -> [pid, status]
  *
  *  Like Process.waitpid, but returns an array
- *  containing the child process pid and Process::Status status:
+ *  containing the child process +pid+ and Process::Status +status+:
  *
  *    pid = Process.spawn('ruby', '-e', 'exit 13') # => 309581
  *    Process.wait2(pid)

--- a/process.c
+++ b/process.c
@@ -1522,11 +1522,10 @@ rb_detach_process(rb_pid_t pid)
  *  This example does not reap the second child process;
  *  that process appears as a zombie in the process status (+ps+) output:
  *
- *    pid0 = Process.spawn('ruby', '-e', 'exit 13') # => 312691
- *    pid1 = Process.spawn('ruby', '-e', 'exit 14') # => 312716
- *    Process.wait(pid0)                            # => 312691
+ *    pid = Process.spawn('ruby', '-e', 'exit 13') # => 312691
+ *    sleep(1)
  *    # Find zombies.
- *    system("ps -ho pid,state -p #{pid1}")
+ *    system("ps -ho pid,state -p #{pid}")
  *
  *  Output:
  *

--- a/process.c
+++ b/process.c
@@ -1512,7 +1512,7 @@ rb_detach_process(rb_pid_t pid)
 
 /*
  *  call-seq:
- *    Process.detach(pid) -> thread or nil
+ *    Process.detach(pid) -> thread
  *
  *  Avoids the potential for a child process to become a
  *  {zombie process}[https://en.wikipedia.org/wiki/Zombie_process].

--- a/process.c
+++ b/process.c
@@ -3045,11 +3045,9 @@ NORETURN(static VALUE f_exec(int c, const VALUE *a, VALUE _));
  *
  *  Except for the +COMSPEC+ case,
  *  the entire string +command_line+ is passed as an argument
- *  to {shell option -c}[https://www.man7.org/linux/man-pages/man1/bash.1.html#OPTIONS].
+ *  to {shell option -c}[https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/sh.html].
  *
- *  The shell performs normal
- *  {shell expansion}[https://www.man7.org/linux/man-pages/man1/bash.1.html#EXPANSION]
- *  on the command line.
+ *  The shell performs normal shell expansion on the command line.
  *
  *  Raises an exception if the new process fails to execute.
  *

--- a/process.c
+++ b/process.c
@@ -8707,7 +8707,7 @@ proc_warmup(VALUE _)
  *
  * The working directory of the current process is not changed:
  *
- *   Dir .pwd # => "/var"
+ *   Dir.pwd # => "/var"
  *
  * ==== \File Redirection (\File Descriptor)
  *

--- a/process.c
+++ b/process.c
@@ -1516,7 +1516,7 @@ rb_detach_process(rb_pid_t pid)
  *
  *  Avoids the potential for a child process to become a
  *  {zombie process}[https://en.wikipedia.org/wiki/Zombie_process].
- *  Process::detach prevents this by setting up a separate Ruby thread
+ *  Process.detach prevents this by setting up a separate Ruby thread
  *  whose sole job is to reap the status of the process _pid_ when it terminates.
  *
  *  This method is needed only when the parent process will never wait

--- a/process.c
+++ b/process.c
@@ -3034,8 +3034,9 @@ NORETURN(static VALUE f_exec(int c, const VALUE *a, VALUE _));
  *  <b>Argument +command_line+</b>
  *
  *  \String argument +command_line+ is a command line to be passed to a shell;
- *  it must begin with a shell reserved word or special built-in,
- *  and may also contain arguments and options for that command.
+ *  it must begin with a shell reserved word, begin with a special built-in,
+ *  or contain meta characters.
+ *  It may also contain arguments and options for that command.
  *
  *  On a Unix-like system, the shell is <tt>/bin/sh</tt>;
  *  otherwise the shell is determined by environment variable

--- a/process.c
+++ b/process.c
@@ -1544,7 +1544,7 @@ rb_detach_process(rb_pid_t pid)
  *
  *  The waiting thread can return the pid of the detached child process:
  *
- *    thread.join(thread).pid                       # => 313262
+ *    thread.join.pid                       # => 313262
  *
  */
 


### PR DESCRIPTION
Revises doc for a few methods, including exec.  Adds class-doc sections "Execution Environment" and "Execution Options," which exec links to.