### PR TITLE
Removed unused false-branch of always-true conditional in version.c

### DIFF
--- a/version.c
+++ b/version.c
@@ -121,7 +121,7 @@ Init_version(void)
     /*
      * The version of the engine or interpreter this ruby uses.
      */
-    rb_define_global_const("RUBY_ENGINE_VERSION", (1 ? version : MKSTR(version)));
+    rb_define_global_const("RUBY_ENGINE_VERSION", version);
 
     rb_provide("ruby2_keywords.rb");
 }


### PR DESCRIPTION
This removes dead code that was added [8 years ago](https://github.com/ruby/ruby/commit/c5634371dcd1e49501989f3c713f1fd1f76c572e).