### PR TITLE
Fix compile error on older systems without clock_get*

### DIFF
--- a/process.c
+++ b/process.c
@@ -8216,7 +8216,9 @@ rb_clock_gettime(int argc, VALUE *argv, VALUE _)
 
     VALUE unit = (rb_check_arity(argc, 1, 2) == 2) ? argv[1] : Qnil;
     VALUE clk_id = argv[0];
+#ifdef HAVE_CLOCK_GETTIME
     clockid_t c;
+#endif
 
     if (SYMBOL_P(clk_id)) {
 #ifdef CLOCK_REALTIME
@@ -8444,7 +8446,9 @@ rb_clock_getres(int argc, VALUE *argv, VALUE _)
     timetick_int_t denominators[2];
     int num_numerators = 0;
     int num_denominators = 0;
+#ifdef HAVE_CLOCK_GETRES
     clockid_t c;
+#endif
 
     VALUE unit = (rb_check_arity(argc, 1, 2) == 2) ? argv[1] : Qnil;
     VALUE clk_id = argv[0];


### PR DESCRIPTION
clock_get* calls are already gated in ifdef conditionals here:

https://github.com/ruby/ruby/blob/3c53d31ffa72946f17e662b119fe55b9a3bf31c8/process.c#L8377-L8381

and here:

https://github.com/ruby/ruby/blob/3c53d31ffa72946f17e662b119fe55b9a3bf31c8/process.c#L8556-L8560

as are all other assignments of the variable `c`.

However declaration `clockid_t c;` was not wrapped in an ifdef. Besides being an unused variable, systems that are without `clock_get*` are unlikely to have `clockid_t`, resulting in a compile error. This pull request fixes that.

This regressed in Ruby 3.2.