### PR TITLE
Free all empty heap pages in Process.warmup

### DIFF
--- a/process.c
+++ b/process.c
@@ -8648,10 +8648,12 @@ static VALUE rb_mProcID_Syscall;
  *
  *  On CRuby, +Process.warmup+:
  *
- *  * Perform a major GC.
+ *  * Performs a major GC.
  *  * Compacts the heap.
  *  * Promotes all surviving objects to the old generation.
- *  * Precompute the coderange of all strings.
+ *  * Precomputes the coderange of all strings.
+ *  * Frees all empty heap pages and increments the allocatable pages counter
+ *    by the number of pages freed.
  */
 
 static VALUE

--- a/test/ruby/test_process.rb
+++ b/test/ruby/test_process.rb
@@ -2721,4 +2721,26 @@ EOS
       assert_include(ObjectSpace.dump(obj), '"coderange":"7bit"')
     end;
   end
+
+  def test_warmup_frees_pages
+    assert_separately([{"RUBY_GC_HEAP_FREE_SLOTS_MAX_RATIO" => "1.0"}, "-W0"], "#{<<~"begin;"}\n#{<<~'end;'}")
+    begin;
+      TIMES = 10_000
+      ary = Array.new(TIMES)
+      TIMES.times do |i|
+        ary[i] = Object.new
+      end
+      ary.clear
+      ary = nil
+
+      total_pages_before = GC.stat(:heap_eden_pages) + GC.stat(:heap_allocatable_pages)
+
+      Process.warmup
+
+      # Number of pages freed should cause equal increase in number of allocatable pages.
+      assert_equal(total_pages_before, GC.stat(:heap_eden_pages) + GC.stat(:heap_allocatable_pages))
+      assert_equal(0, GC.stat(:heap_tomb_pages))
+      assert_operator(GC.stat(:total_freed_pages), :>, 0)
+    end;
+  end
 end


### PR DESCRIPTION
This commit adds `free_empty_pages` which frees all empty heap pages and moves the number of pages freed to the allocatable pages counter. This is used in Process.warmup to improve performance because page invalidation from copy-on-write is slower than allocating a new page.