### PR TITLE
YJIT: add code_region_overhead stat output

### DIFF
--- a/yjit.rb
+++ b/yjit.rb
@@ -273,6 +273,8 @@ module RubyVM::YJIT
       # Number of failed compiler invocations
       compilation_failure = stats[:compilation_failure]
 
+      code_region_overhead = stats[:code_region_size] - (stats[:inline_code_size] + stats[:outlined_code_size])
+
       out.puts "num_send:              " + format_number(13, stats[:num_send])
       out.puts "num_send_known_class:  " + format_number_pct(13, stats[:num_send_known_class], stats[:num_send])
       out.puts "num_send_polymorphic:  " + format_number_pct(13, stats[:num_send_polymorphic], stats[:num_send])
@@ -318,6 +320,8 @@ module RubyVM::YJIT
       out.puts "inline_code_size:      " + format_number(13, stats[:inline_code_size])
       out.puts "outlined_code_size:    " + format_number(13, stats[:outlined_code_size])
       out.puts "code_region_size:      " + format_number(13, stats[:code_region_size])
+      out.puts "code_region_overhead:  " + format_number_pct(13, code_region_overhead, stats[:code_region_size])
+
       out.puts "freed_code_size:       " + format_number(13, stats[:freed_code_size])
       out.puts "yjit_alloc_size:       " + format_number(13, stats[:yjit_alloc_size]) if stats.key?(:yjit_alloc_size)
       out.puts "live_context_size:     " + format_number(13, stats[:live_context_size])


### PR DESCRIPTION
Investigating for https://github.com/Shopify/ruby/issues/529, I thought it would be interesting to compute how many bytes in the code region are being unused, and to report what percentage of the total code region size this represents.

railsbench:
```
inline_code_size:          5,146,888
outlined_code_size:        3,766,480
code_region_size:          9,207,808
code_region_overhead:        294,440 ( 3.2%)
```

lobsters:
```
inline_code_size:         14,101,872
outlined_code_size:       10,151,248
code_region_size:         25,870,336
code_region_overhead:      1,617,216 ( 6.3%)
```

Some potential savings there, though it's not as bad as I thought. I'm actually surprised we're wasting this little space. I'm assuming here that the code region size is the total amount of space (pages) we've allocated for machine code.