### PR TITLE
YJIT: x64: Split mem-to-mem Insn::Store like Insn::Mov

### DIFF
--- a/yjit/src/asm/x86_64/mod.rs
+++ b/yjit/src/asm/x86_64/mod.rs
@@ -635,7 +635,7 @@ fn write_rm_multi(cb: &mut CodeBlock, op_mem_reg8: u8, op_mem_reg_pref: u8, op_r
                 panic!("immediate value too large (num_bits={}, num={uimm:?})", num_bits);
             }
         },
-        _ => unreachable!()
+        _ => panic!("unknown encoding combo: {opnd0:?} {opnd1:?}")
     };
 }
 

--- a/yjit/src/backend/x86_64/mod.rs
+++ b/yjit/src/backend/x86_64/mod.rs
@@ -291,7 +291,7 @@ impl Assembler
                     *out = asm.next_opnd_out(Opnd::match_num_bits(&[*truthy, *falsy]));
                     asm.push_insn(insn);
                 },
-                Insn::Mov { dest, src } => {
+                Insn::Mov { dest, src } | Insn::Store { dest, src } => {
                     match (&dest, &src) {
                         (Opnd::Mem(_), Opnd::Mem(_)) => {
                             // We load opnd1 because for mov, opnd0 is the output


### PR DESCRIPTION
The ARM backend allows for this so let's make x64 consistent.
