### PR TITLE
Handle Array#* raising ArgumentError in test

### DIFF
--- a/test/ruby/test_process.rb
+++ b/test/ruby/test_process.rb
@@ -1799,7 +1799,11 @@ class TestProcess < Test::Unit::TestCase
           loop do
             Process.spawn(cmds.join(sep), opts)
             min = [cmds.size, min].max
-            cmds *= 100
+            begin
+              cmds *= 100
+            rescue ArgumentError
+              raise NoMemoryError
+            end
           end
         rescue NoMemoryError
           size = cmds.size


### PR DESCRIPTION
Treat ArgumentError as NoMemoryError, so it will resize the array and try again.

Fixes [Bug #12500]