### PR TITLE
Fix support for dynamic keys.

### DIFF
--- a/cont.c
+++ b/cont.c
@@ -2118,7 +2118,7 @@ rb_fiber_storage_get(VALUE self)
 static int
 fiber_storage_validate_each(VALUE key, VALUE value, VALUE _argument)
 {
-    rb_check_id(&key);
+    Check_Type(key, T_SYMBOL);
 
     return ST_CONTINUE;
 }
@@ -2190,8 +2190,7 @@ rb_fiber_storage_set(VALUE self, VALUE value)
 static VALUE
 rb_fiber_storage_aref(VALUE class, VALUE key)
 {
-    ID id = rb_check_id(&key);
-    if (!id) return Qnil;
+    Check_Type(key, T_SYMBOL);
 
     VALUE storage = fiber_storage_get(fiber_current(), FALSE);
     if (storage == Qnil) return Qnil;
@@ -2212,8 +2211,7 @@ rb_fiber_storage_aref(VALUE class, VALUE key)
 static VALUE
 rb_fiber_storage_aset(VALUE class, VALUE key, VALUE value)
 {
-    ID id = rb_check_id(&key);
-    if (!id) return Qnil;
+    Check_Type(key, T_SYMBOL);
 
     VALUE storage = fiber_storage_get(fiber_current(), value != Qnil);
     if (storage == Qnil) return Qnil;

--- a/spec/ruby/core/fiber/storage_spec.rb
+++ b/spec/ruby/core/fiber/storage_spec.rb
@@ -80,8 +80,10 @@ describe "Fiber.[]" do
     end
 
     it "can't use invalid keys" do
-      key = Object.new
-      -> { Fiber[key] }.should raise_error(TypeError)
+      invalid_keys = [Object.new, "Foo", 12]
+      invalid_keys.each do |key|
+        -> { Fiber[key] }.should raise_error(TypeError)
+      end
     end
   end
 end

--- a/spec/ruby/core/fiber/storage_spec.rb
+++ b/spec/ruby/core/fiber/storage_spec.rb
@@ -73,7 +73,9 @@ describe "Fiber.[]" do
     it "returns nil if the current fiber has no storage" do
       Fiber.new { Fiber[:life] }.resume.should be_nil
     end
+  end
 
+  ruby_version_is "3.2.3" do
     it "can use dynamically defined keys" do
       key = :"#{self.class.name}#.#{self.object_id}"
       Fiber.new { Fiber[key] = 42; Fiber[key] }.resume.should == 42

--- a/spec/ruby/core/fiber/storage_spec.rb
+++ b/spec/ruby/core/fiber/storage_spec.rb
@@ -73,6 +73,16 @@ describe "Fiber.[]" do
     it "returns nil if the current fiber has no storage" do
       Fiber.new { Fiber[:life] }.resume.should be_nil
     end
+
+    it "can use dynamically defined keys" do
+      key = :"#{self.class.name}#.#{self.object_id}"
+      Fiber.new { Fiber[key] = 42; Fiber[key] }.resume.should == 42
+    end
+
+    it "can't use invalid keys" do
+      key = Object.new
+      -> { Fiber[key] }.should raise_error(TypeError)
+    end
   end
 end
 

--- a/tool/rbs_skip_tests
+++ b/tool/rbs_skip_tests
@@ -25,6 +25,8 @@ test_subtract(RBS::CliTest) running tests without Bundler
 test_subtract_several_subtrahends(RBS::CliTest) running tests without Bundler
 test_subtract_write(RBS::CliTest) running tests without Bundler
 
+test_aref(FiberSingletonTest) the method should not accept String keys
+
 NetSingletonTest depending on external resources
 NetInstanceTest depending on external resources
 TestHTTPRequest depending on external resources


### PR DESCRIPTION
Unfortunately there is a bug in `Fiber[key] = value` when key is dynamically defined. I didn't fully understand the implementation of `rb_check_id`.

https://bugs.ruby-lang.org/issues/19845