### PR TITLE
Revert "Re-apply "Ruby 3.2 - Speed up rebuilding the loaded feature index and realpath cache (#8023)""

### DIFF
--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -139,11 +139,12 @@ jobs:
         run: |
           make test
         if: ${{matrix.test_task == 'check' || matrix.test_task == 'test'}}
-        shell: cmd
 
       - name: test-all
         timeout-minutes: 45
         run: |
+          # Actions uses UTF8, causes test failures, similar to normal OS setup
+          chcp.com 437
           make ${{ StartsWith(matrix.test_task, 'test/') && matrix.test_task || 'test-all' }}
         env:
           RUBY_TESTOPTS: >-
@@ -151,7 +152,6 @@ jobs:
             ${{ matrix.test-all-opts }}
           BUNDLER_VERSION:
         if: ${{matrix.test_task == 'check' || matrix.test_task == 'test-all' || StartsWith(matrix.test_task, 'test/')}}
-        shell: cmd
 
       - name: test-spec
         timeout-minutes: 10

--- a/test/excludes/TestReadline.rb
+++ b/test/excludes/TestReadline.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: false
-if /mingw/i.match?(RUBY_PLATFORM)
-  exclude(:test_input_metachar_multibyte, "failed with readline.so on MiNGW")
-end

--- a/vm.c
+++ b/vm.c
@@ -2703,7 +2703,6 @@ rb_vm_update_references(void *ptr)
         vm->loaded_features = rb_gc_location(vm->loaded_features);
         vm->loaded_features_snapshot = rb_gc_location(vm->loaded_features_snapshot);
         vm->loaded_features_realpaths = rb_gc_location(vm->loaded_features_realpaths);
-        vm->loaded_features_realpath_map = rb_gc_location(vm->loaded_features_realpath_map);
         vm->top_self = rb_gc_location(vm->top_self);
         vm->orig_progname = rb_gc_location(vm->orig_progname);
 
@@ -2795,7 +2794,6 @@ rb_vm_mark(void *ptr)
         rb_gc_mark_movable(vm->loaded_features);
         rb_gc_mark_movable(vm->loaded_features_snapshot);
         rb_gc_mark_movable(vm->loaded_features_realpaths);
-        rb_gc_mark_movable(vm->loaded_features_realpath_map);
         rb_gc_mark_movable(vm->top_self);
         rb_gc_mark_movable(vm->orig_progname);
         RUBY_MARK_MOVABLE_UNLESS_NULL(vm->coverages);

--- a/vm_core.h
+++ b/vm_core.h
@@ -680,7 +680,6 @@ typedef struct rb_vm_struct {
     VALUE loaded_features;
     VALUE loaded_features_snapshot;
     VALUE loaded_features_realpaths;
-    VALUE loaded_features_realpath_map;
     struct st_table *loaded_features_index;
     struct st_table *loading_table;
 #if EXTSTATIC


### PR DESCRIPTION
Reverts ruby/ruby#8252

I suspect that #8252 could introduce a `[BUG] object allocation during garbage collection phase` error.

https://github.com/ruby/actions/actions/runs/5942679604/job/16116356743
https://github.com/ruby/actions/actions/runs/5955117204/job/16153242195
https://github.com/ruby/ruby/actions/runs/5932543614/job/16086524440

Let's consider reverting it and observe the results for a while.
