### PR TITLE
Escape non-ascii characters in prelude C comments

### DIFF
--- a/.github/workflows/check_misc.yml
+++ b/.github/workflows/check_misc.yml
@@ -19,6 +19,8 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
       - uses: ./.github/actions/setup/directories
+        with:
+          makeup: true
 
       - name: Check if C-sources are US-ASCII
         run: |

--- a/template/prelude.c.tmpl
+++ b/template/prelude.c.tmpl
@@ -43,7 +43,10 @@ class Prelude
     lineno = 0
     result = [@preludes.size, @vpath.strip(filename), lines, sub]
     @vpath.foreach(filename) do |line|
-      line.force_encoding("ASCII-8BIT") if line.respond_to?(:force_encoding)
+      if line.respond_to?(:force_encoding)
+        enc = line.encoding
+        line.force_encoding("ASCII-8BIT")
+      end
       line.rstrip!
       lineno += 1
       @preludes[filename] ||= result
@@ -71,6 +74,7 @@ class Prelude
           orig
         end
       end
+      comment.force_encoding(enc) if enc and comment
       lines << [line, comment]
     end
     result << (start_line || 1)

--- a/tool/ruby_vm/helpers/c_escape.rb
+++ b/tool/ruby_vm/helpers/c_escape.rb
@@ -17,7 +17,10 @@ module RubyVM::CEscape
 
   # generate comment, with escaps.
   def commentify str
-    return "/* #{str.b.gsub('*/', '*\\/').gsub('/*', '/\\*')} */"
+    unless str = str.dump[/\A"\K.*(?="\z)/]
+      raise Encoding::CompatibilityError, "must be ASCII-compatible (#{str.encoding})"
+    end
+    return "/* #{str.gsub('*/', '*\\/').gsub('/*', '/\\*')} */"
   end
 
   # Mimic gensym of CL.


### PR DESCRIPTION
Non-ASCII code are often warned by localized compilers.