### PR TITLE
Optimize handle_interrupt(Exception => ..) as a common case

### DIFF
--- a/thread.c
+++ b/thread.c
@@ -1892,6 +1892,23 @@ enum handle_interrupt_timing {
 };
 
 static enum handle_interrupt_timing
+rb_threadptr_pending_interrupt_from_symbol(rb_thread_t *th, VALUE sym)
+{
+    if (sym == sym_immediate) {
+        return INTERRUPT_IMMEDIATE;
+    }
+    else if (sym == sym_on_blocking) {
+        return INTERRUPT_ON_BLOCKING;
+    }
+    else if (sym == sym_never) {
+        return INTERRUPT_NEVER;
+    }
+    else {
+        rb_raise(rb_eThreadError, "unknown mask signature");
+    }
+}
+
+static enum handle_interrupt_timing
 rb_threadptr_pending_interrupt_check_mask(rb_thread_t *th, VALUE err)
 {
     VALUE mask;
@@ -1902,6 +1919,16 @@ rb_threadptr_pending_interrupt_check_mask(rb_thread_t *th, VALUE err)
 
     for (i=0; i<mask_stack_len; i++) {
         mask = mask_stack[mask_stack_len-(i+1)];
+
+        if (SYMBOL_P(mask)) {
+            /* do not match RUBY_FATAL_THREAD_KILLED etc */
+            if (err != rb_cInteger) {
+                return rb_threadptr_pending_interrupt_from_symbol(th, mask);
+            }
+            else {
+                continue;
+            }
+        }
 
         for (mod = err; mod; mod = RCLASS_SUPER(mod)) {
             VALUE klass = mod;
@@ -1915,18 +1942,7 @@ rb_threadptr_pending_interrupt_check_mask(rb_thread_t *th, VALUE err)
             }
 
             if ((sym = rb_hash_aref(mask, klass)) != Qnil) {
-                if (sym == sym_immediate) {
-                    return INTERRUPT_IMMEDIATE;
-                }
-                else if (sym == sym_on_blocking) {
-                    return INTERRUPT_ON_BLOCKING;
-                }
-                else if (sym == sym_never) {
-                    return INTERRUPT_NEVER;
-                }
-                else {
-                    rb_raise(rb_eThreadError, "unknown mask signature");
-                }
+                return rb_threadptr_pending_interrupt_from_symbol(th, sym);
             }
         }
         /* try to next mask */
@@ -2018,11 +2034,23 @@ handle_interrupt_arg_check_i(VALUE key, VALUE val, VALUE args)
         rb_raise(rb_eArgError, "unknown mask signature");
     }
 
-    if (maskp) {
-        if (!*maskp) {
+    if (key == rb_eException && (UNDEF_P(*maskp) || NIL_P(*maskp))) {
+        *maskp = val;
+        return ST_CONTINUE;
+    }
+
+    if (RTEST(*maskp)) {
+        if (!RB_TYPE_P(*maskp, T_HASH)) {
+            VALUE prev = *maskp;
             *maskp = rb_ident_hash_new();
+            if (SYMBOL_P(prev)) {
+                rb_hash_aset(*maskp, rb_eException, prev);
+            }
         }
         rb_hash_aset(*maskp, key, val);
+    }
+    else {
+        *maskp = Qfalse;
     }
 
     return ST_CONTINUE;
@@ -2139,7 +2167,7 @@ handle_interrupt_arg_check_i(VALUE key, VALUE val, VALUE args)
 static VALUE
 rb_thread_s_handle_interrupt(VALUE self, VALUE mask_arg)
 {
-    VALUE mask;
+    VALUE mask = Qundef;
     rb_execution_context_t * volatile ec = GET_EC();
     rb_thread_t * volatile th = rb_ec_thread_ptr(ec);
     volatile VALUE r = Qnil;
@@ -2152,14 +2180,19 @@ rb_thread_s_handle_interrupt(VALUE self, VALUE mask_arg)
     mask_arg = rb_to_hash_type(mask_arg);
 
     if (OBJ_FROZEN(mask_arg) && rb_hash_compare_by_id_p(mask_arg)) {
-        rb_hash_foreach(mask_arg, handle_interrupt_arg_check_i, 0);
+        mask = Qnil;
+    }
+
+    rb_hash_foreach(mask_arg, handle_interrupt_arg_check_i, (VALUE)&mask);
+
+    if (UNDEF_P(mask)) {
+        return rb_yield(Qnil);
+    }
+
+    if (!RTEST(mask)) {
         mask = mask_arg;
-    } else {
-        mask = 0;
-        rb_hash_foreach(mask_arg, handle_interrupt_arg_check_i, (VALUE)&mask);
-        if (!mask) {
-            return rb_yield(Qnil);
-        }
+    }
+    else if (RB_TYPE_P(mask, T_HASH)) {
         OBJ_FREEZE_RAW(mask);
     }
 


### PR DESCRIPTION
When interrupt behaviour is configured for all possible exceptions using `Exception`, there's no need to iterate the pending exception's ancestors for hash lookups.

More significantly, by storing the catch-all timing symbol directly in the mask stack, we can skip allocating the hash we would otherwise need.

---

The shortcut in `rb_threadptr_pending_interrupt_check_mask` is nice as a bonus, but not likely to ever be hot enough to show a difference in a benchmark. At best there _might_ be some situation where it helps speed up re-checks when an pending interrupt is held for a long time.

The more interesting performance difference is in "regular" code that must always protect against the possibility of an interrupt, rather than that rarely-hit code that gets invoked when an interrupt does actually occur.

<details><summary>benchmark script</summary>

```ruby
require "benchmark/ips"

def safely_do_nothing(defer_interrupts, allow_interrupts)
  Thread.handle_interrupt(defer_interrupts) do
    Thread.handle_interrupt(allow_interrupts) do
      nil
    end
  ensure
    begin
      Thread.handle_interrupt(allow_interrupts) do
        nil
      end
    ensure
      nil
    end
  end
end

# Reproduces the same level of block nesting: we don't want to measure
# the cost of method calls
def unsafely_do_nothing
  1.times do
    1.times do
      nil
    end
  ensure
    begin
      1.times do
        nil
      end
    ensure
      nil
    end
  end
end

Benchmark.ips do |x|
  x.report("control") do
    unsafely_do_nothing
  end

  exception_immutable_never = { Exception => :never }.compare_by_identity.freeze
  exception_immutable_immediate = { Exception => :immediate }.compare_by_identity.freeze

  x.report("frozen Exception") do
    safely_do_nothing(exception_immutable_never, exception_immutable_immediate)
  end

  exception_mutable_never = { Exception => :never }
  exception_mutable_immediate = { Exception => :immediate }

  x.report("mutable Exception") do
    safely_do_nothing(exception_mutable_never, exception_mutable_immediate)
  end

  runtimeerror_immutable_never = { RuntimeError => :never }.compare_by_identity.freeze
  runtimeerror_immutable_immediate = { RuntimeError => :immediate }.compare_by_identity.freeze

  x.report("frozen RuntimeError") do
    safely_do_nothing(runtimeerror_immutable_never, runtimeerror_immutable_immediate)
  end

  runtimeerror_mutable_never = { RuntimeError => :never }
  runtimeerror_mutable_immediate = { RuntimeError => :immediate }

  x.report("mutable RuntimeError") do
    safely_do_nothing(runtimeerror_mutable_never, runtimeerror_mutable_immediate)
  end
end
```
</details>

**Before (5b407450f5a28295cdeae8e8bb3ea4591600e395)**

```
             control      3.964M (± 6.9%) i/s -     19.741M in   5.009446s
    frozen Exception      1.078M (± 5.7%) i/s -      5.382M in   5.008824s
   mutable Exception      1.018M (± 9.8%) i/s -      5.043M in   5.013756s
 frozen RuntimeError      1.070M (± 5.9%) i/s -      5.386M in   5.050367s
mutable RuntimeError      1.038M (± 6.2%) i/s -      5.243M in   5.073596s
```

**After (5c16f28680bdf8d9e08602c641f00a6355362c53)**
 
```
             control      3.800M (±12.5%) i/s -     18.844M in   5.059755s
    frozen Exception      2.438M (± 5.1%) i/s -     12.229M in   5.031170s
   mutable Exception      2.225M (± 6.9%) i/s -     11.231M in   5.074758s
 frozen RuntimeError      2.379M (± 4.6%) i/s -     12.075M in   5.087612s
mutable RuntimeError      1.017M (± 5.9%) i/s -      5.078M in   5.010767s
```