### PR TITLE
Fix use of the rb_profile_frames start parameter

### DIFF
--- a/test/-ext-/debug/test_profile_frames.rb
+++ b/test/-ext-/debug/test_profile_frames.rb
@@ -236,4 +236,8 @@ class TestProfileFrames < Test::Unit::TestCase
       a
     end;
   end
+
+  def test_start
+    assert_equal Bug::Debug.profile_frames(0, 10).tap(&:shift), Bug::Debug.profile_frames(1, 9)
+  end
 end

--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -1593,7 +1593,7 @@ thread_profile_frames(rb_execution_context_t *ec, int start, int limit, VALUE *b
     // Skip dummy frame; see `rb_ec_partial_backtrace_object` for details
     end_cfp = RUBY_VM_NEXT_CONTROL_FRAME(end_cfp);
 
-    for (i=0; i<limit && cfp != end_cfp;) {
+    for (i=0; i<limit && cfp != end_cfp; cfp = RUBY_VM_PREVIOUS_CONTROL_FRAME(cfp)) {
         if (VM_FRAME_RUBYFRAME_P(cfp) && cfp->pc != 0) {
             if (start > 0) {
                 start--;
@@ -1627,12 +1627,15 @@ thread_profile_frames(rb_execution_context_t *ec, int start, int limit, VALUE *b
         else {
             cme = rb_vm_frame_method_entry(cfp);
             if (cme && cme->def->type == VM_METHOD_TYPE_CFUNC) {
+                if (start > 0) {
+                    start--;
+                    continue;
+                }
                 buff[i] = (VALUE)cme;
                 if (lines) lines[i] = 0;
                 i++;
             }
         }
-        cfp = RUBY_VM_PREVIOUS_CONTROL_FRAME(cfp);
     }
 
     return i;


### PR DESCRIPTION
Previously, it was decrementing the start argument until it reached zero without actually changing the control frame pointer.

This is the same as #2713, just rebased against master.

[Bug #14607]