### PR TITLE
[Bug #19848] Flush BOM

### DIFF
--- a/lib/yarp/lex_compat.rb
+++ b/lib/yarp/lex_compat.rb
@@ -588,6 +588,7 @@ module YARP
         if bom && lineno == 1
           column -= 3
 
+=begin
           if index == 0 && column == 0
             flushed =
               case token.type
@@ -608,6 +609,7 @@ module YARP
               value.prepend(String.new("\xEF\xBB\xBF", encoding: value.encoding))
             end
           end
+=end
         end
 
         event = RIPPER.fetch(token.type)

--- a/parse.y
+++ b/parse.y
@@ -9059,6 +9059,7 @@ parser_prepare(struct parser_params *p)
             }
 #endif
             p->lex.pbeg = p->lex.pcur;
+            token_flush(p);
             return;
         }
         break;

--- a/test/ruby/test_ast.rb
+++ b/test/ruby/test_ast.rb
@@ -1082,6 +1082,12 @@ dummy
     assert_equal([[0, :backslash, "\\", [1, 0, 1, 1]]], node.children.last.tokens)
   end
 
+  def test_with_bom
+    assert_error_tolerant("\u{feff}nil", <<~EXP)
+      (SCOPE@1:0-1:3 tbl: [] args: nil body: (NIL@1:0-1:3))
+    EXP
+  end
+
   def assert_error_tolerant(src, expected, keep_tokens: false)
     begin
       verbose_bak, $VERBOSE = $VERBOSE, false


### PR DESCRIPTION
The token just after BOM needs to position at column 0, so that the indentation matches closing line.