### PR TITLE
Disallow forking inside a ractor

### DIFF
--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -231,6 +231,24 @@ assert_equal 'ok', %q{
   end.take
 }
 
+# fork marks other ractors as terminated in forked process
+assert_equal 'ok', %q{
+  if Process.respond_to?(:fork)
+    ractor = Ractor.new do
+      sleep 10
+    end
+    r, w = IO.pipe
+    if Process.fork
+      r.read(2)
+    else
+      w.write(ractor.inspect.include?("terminated") ? 'ok' : 'ba')
+      w.close
+    end
+  else
+    :ok
+  end
+}
+
 ###
 ###
 # Ractor still has several memory corruption so skip huge number of tests

--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -222,6 +222,15 @@ assert_equal 'ok', %q{
   r.take
 }
 
+# fork not allowed inside ractor
+assert_equal 'ok', %q{
+  Ractor.new do
+    Process.fork
+  rescue RuntimeError, NotImplementedError => e
+    :ok
+  end.take
+}
+
 ###
 ###
 # Ractor still has several memory corruption so skip huge number of tests

--- a/common.mk
+++ b/common.mk
@@ -13436,6 +13436,7 @@ process.$(OBJEXT): {$(VPATH)}onigmo.h
 process.$(OBJEXT): {$(VPATH)}oniguruma.h
 process.$(OBJEXT): {$(VPATH)}process.c
 process.$(OBJEXT): {$(VPATH)}ractor.h
+process.$(OBJEXT): {$(VPATH)}ractor_core.h
 process.$(OBJEXT): {$(VPATH)}rjit.h
 process.$(OBJEXT): {$(VPATH)}ruby_assert.h
 process.$(OBJEXT): {$(VPATH)}ruby_atomic.h

--- a/process.c
+++ b/process.c
@@ -111,6 +111,7 @@ int initgroups(const char *, rb_gid_t);
 #include "internal/variable.h"
 #include "internal/warnings.h"
 #include "rjit.h"
+#include "ractor_core.h"
 #include "ruby/io.h"
 #include "ruby/st.h"
 #include "ruby/thread.h"
@@ -4371,6 +4372,10 @@ rb_proc__fork(VALUE _obj)
 static VALUE
 rb_f_fork(VALUE obj)
 {
+    if (!rb_ractor_main_p()) {
+        rb_raise(rb_eRuntimeError, "cannot fork from inside ractor");
+    }
+
     rb_pid_t pid;
 
     pid = rb_call_proc__fork();

--- a/thread.c
+++ b/thread.c
@@ -4691,6 +4691,9 @@ rb_thread_atfork_internal(rb_thread_t *th, void (*atfork)(rb_thread_t *, const r
 
     // OK. Only this thread accesses:
     ccan_list_for_each(&vm->ractor.set, r, vmlr_node) {
+        if (r != vm->ractor.main_ractor) {
+            r->status_ = ractor_terminated;
+        }
         ccan_list_for_each(&r->threads.set, i, lt_node) {
             atfork(i, th);
         }


### PR DESCRIPTION
Previously, forking inside a ractor segfaulted.

Fixes [Bug #17516]