### PR TITLE
Avoid memory dependency between instructions.

### DIFF
--- a/coroutine/amd64/Context.S
+++ b/coroutine/amd64/Context.S
@@ -13,29 +13,35 @@
 .globl PREFIXED_SYMBOL(SYMBOL_PREFIX,coroutine_transfer)
 PREFIXED_SYMBOL(SYMBOL_PREFIX,coroutine_transfer):
 
-	# Save caller state
-	pushq %rbp
-	pushq %rbx
-	pushq %r12
-	pushq %r13
-	pushq %r14
-	pushq %r15
+	# Make space on the stack for 6 registers:
+	subq $48, %rsp
 
-	# Save caller stack pointer
+	# Save caller state:
+	movq %rbp, 40(%rsp)
+	movq %rbx, 32(%rsp)
+	movq %r12, 24(%rsp)
+	movq %r13, 16(%rsp)
+	movq %r14, 8(%rsp)
+	movq %r15, (%rsp)
+
+	# Save caller stack pointer:
 	movq %rsp, (%rdi)
 
-	# Restore callee stack pointer
+	# Restore callee stack pointer:
 	movq (%rsi), %rsp
 
 	# Restore callee state
-	popq %r15
-	popq %r14
-	popq %r13
-	popq %r12
-	popq %rbx
-	popq %rbp
+	movq 40(%rsp), %rbp
+	movq 32(%rsp), %rbx
+	movq 24(%rsp), %r12
+	movq 16(%rsp), %r13
+	movq 8(%rsp), %r14
+	movq (%rsp), %r15
 
-	# Put the first argument into the return value
+	# Adjust stack pointer back:
+	addq $48, %rsp
+
+	# Put the first argument into the return value:
 	movq %rdi, %rax
 
 	# We pop the return address and jump to it


### PR DESCRIPTION
See https://bugs.ruby-lang.org/issues/17263 for more context.

Test program:

```ruby
#!/usr/bin/env ruby

require 'fiber'

# This program shows how the performance of Fiber.transfer degrades as the fiber
# count increases

def run(num_fibers = 100, repeats = 100000000)
	count = 0

	GC.start
	GC.disable

	fibers = []
	num_fibers.times do
		fibers << Fiber.new { loop { Fiber.yield } }
	end

	# Warmup:
	fibers.each do |f|
		f.resume
	end

	t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)

	while count < repeats
		fibers.each do |f|
			count += 1
			f.resume
		end
	end

	elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - t0

	puts "fibers: #{num_fibers.to_s.ljust(10)} count: #{count.to_s.ljust(10)} rate: #{(count / elapsed).round(2).to_s.ljust(10)}"
rescue Exception => e
	puts "Stopped at #{count} fibers"
	p e
end

run(*ARGV.map(&:to_i))
```

It seems to be between 0-5% faster.