### PR TITLE
Restore `HAVE_RB_IO_T` macro for compatibility with `kgio`, `unicorn`, etc.

### DIFF
--- a/include/ruby/io.h
+++ b/include/ruby/io.h
@@ -138,6 +138,7 @@ struct rb_io_encoding {
 };
 
 #ifndef HAVE_RB_IO_T
+#define HAVE_RB_IO_T 1
 /** Ruby's IO, metadata and buffers. */
 struct rb_io {
     /** The IO's Ruby level counterpart. */


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/19057