### PR TITLE
[Bug #19851] Ripper: Hide internal block argument ID

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -1145,6 +1145,11 @@ static void numparam_pop(struct parser_params *p, NODE *prev_inner);
 #define idFWD_KWREST idPow /* Use simple "**", as tDSTAR is "**arg" */
 #define idFWD_BLOCK  '&'
 #define idFWD_ALL    idDot3
+#ifdef RIPPER
+#define arg_FWD_BLOCK Qnone
+#else
+#define arg_FWD_BLOCK idFWD_BLOCK
+#endif
 #define FORWARD_ARGS_WITH_RUBY2_KEYWORDS
 
 #define RE_OPTION_ONCE (1<<16)
@@ -5628,7 +5633,7 @@ args_tail	: f_kwarg ',' f_kwrest opt_f_block_arg
                 | args_forward
                     {
                         add_forwarding_args(p);
-                        $$ = new_args_tail(p, Qnone, $1, ID2VAL(idFWD_BLOCK), &@1);
+                        $$ = new_args_tail(p, Qnone, $1, arg_FWD_BLOCK, &@1);
                     /*%%%*/
                         ($$->nd_ainfo)->forwarding = 1;
                     /*% %*/

--- a/test/ripper/test_parser_events.rb
+++ b/test/ripper/test_parser_events.rb
@@ -152,6 +152,7 @@ class TestRipper::ParserEvents < Test::Unit::TestCase
       thru_args_forward = false
       parse(code, :on_args_forward) {thru_args_forward = true}
       assert_equal true, thru_args_forward, "no args_forward for: #{code}"
+      parse(code, :on_params) {|*, block| assert_nil(block)}
     end
   end
 


### PR DESCRIPTION
[Bug #19851](https://bugs.ruby-lang.org/issues/19851)