### PR TITLE
lib/bundled_gems.rb - fixup when rb & so are both loaded

### DIFF
--- a/lib/bundled_gems.rb
+++ b/lib/bundled_gems.rb
@@ -71,7 +71,7 @@ module Gem::BUNDLED_GEMS
     return unless gem = find_gem(path)
     caller, = caller_locations(3, 1)
     return if find_gem(caller&.absolute_path)
-    return if WARNED[name]
+    return if WARNED[name.sub(DLEXT, "")]
     WARNED[name] = true
     if gem == true
       gem = name


### PR DESCRIPTION
Example - big_decimal

See https://bugs.ruby-lang.org/issues/19852