### PR TITLE
Broken encoding prefix

### DIFF
--- a/file.c
+++ b/file.c
@@ -4610,7 +4610,7 @@ rmext(const char *p, long l0, long l1, const char *e, long l2, rb_encoding *enc)
     if (l1 < l2) return l1;
 
     s = p+l1-l2;
-    if (rb_enc_left_char_head(p, s, p+l1, enc) != s) return 0;
+    if (!at_char_boundary(p, s, p+l1, enc)) return 0;
 #if CASEFOLD_FILESYSTEM
 #define fncomp strncasecmp
 #else

--- a/internal/string.h
+++ b/internal/string.h
@@ -119,6 +119,12 @@ is_broken_string(VALUE str)
     return rb_enc_str_coderange(str) == ENC_CODERANGE_BROKEN;
 }
 
+static inline bool
+at_char_boundary(const char *s, const char *p, const char *e, rb_encoding *enc)
+{
+    return rb_enc_left_char_head(s, p, e, enc) == p;
+}
+
 /* expect tail call optimization */
 // YJIT needs this function to never allocate and never raise
 static inline VALUE

--- a/io.c
+++ b/io.c
@@ -4144,8 +4144,7 @@ rb_io_getline_0(VALUE rs, long limit, int chomp, rb_io_t *fptr)
                 s = RSTRING_PTR(str);
                 e = RSTRING_END(str);
                 p = e - rslen;
-                pp = rb_enc_left_char_head(s, p, e, enc);
-                if (pp != p) continue;
+                if (!at_char_boundary(s, p, e, enc)) continue;
                 if (!rspara) rscheck(rsptr, rslen, rs);
                 if (memcmp(p, rsptr, rslen) == 0) {
                     if (chomp) {

--- a/spec/ruby/core/string/start_with_spec.rb
+++ b/spec/ruby/core/string/start_with_spec.rb
@@ -7,12 +7,14 @@ describe "String#start_with?" do
   it_behaves_like :start_with, :to_s
 
   # Here and not in the shared examples because this is invalid as a Symbol
-  it "does not check that we are not starting to match at the head of a character" do
+  it "matches part of a character with the same part" do
     "\xA9".should.start_with?("\xA9") # A9 is not a character head for UTF-8
   end
 
-  it "does not check we are matching only part of a character" do
-    "\xe3\x81\x82".size.should == 1
-    "\xe3\x81\x82".should.start_with?("\xe3")
+  ruby_bug "#19784", ""..."3.3" do
+    it "checks we are matching only part of a character" do
+      "\xe3\x81\x82".size.should == 1
+      "\xe3\x81\x82".should_not.start_with?("\xe3")
+    end
   end
 end

--- a/spec/ruby/shared/string/start_with.rb
+++ b/spec/ruby/shared/string/start_with.rb
@@ -70,7 +70,9 @@ describe :start_with, shared: true do
     $1.should be_nil
   end
 
-  it "does not check that we are not matching part of a character" do
-    "\xC3\xA9".send(@method).should.start_with?("\xC3")
+  ruby_bug "#19784", ""..."3.3" do
+    it "checks that we are not matching part of a character" do
+      "\xC3\xA9".send(@method).should_not.start_with?("\xC3")
+    end
   end
 end

--- a/string.c
+++ b/string.c
@@ -3930,8 +3930,7 @@ str_ensure_byte_pos(VALUE str, long pos)
     const char *s = RSTRING_PTR(str);
     const char *e = RSTRING_END(str);
     const char *p = s + pos;
-    const char *pp = rb_enc_left_char_head(s, p, e, rb_enc_get(str));
-    if (p != pp) {
+    if (!at_char_boundary(s, p, e, rb_enc_get(str))) {
         rb_raise(rb_eIndexError,
                  "offset %ld does not land on character boundary", pos);
     }
@@ -9521,7 +9520,7 @@ chompped_length(VALUE str, VALUE rs)
     if (p[len-1] == newline &&
         (rslen <= 1 ||
          memcmp(rsptr, pp, rslen) == 0)) {
-        if (rb_enc_left_char_head(p, pp, e, enc) == pp)
+        if (at_char_boundary(p, pp, e, enc))
             return len - rslen;
         RB_GC_GUARD(rs);
     }
@@ -10497,7 +10496,7 @@ rb_str_end_with(int argc, VALUE *argv, VALUE str)
         p = RSTRING_PTR(str);
         e = p + slen;
         s = e - tlen;
-        if (rb_enc_left_char_head(p, s, e, enc) != s)
+        if (!at_char_boundary(p, s, e, enc))
             continue;
         if (memcmp(s, RSTRING_PTR(tmp), RSTRING_LEN(tmp)) == 0)
             return Qtrue;
@@ -10605,7 +10604,7 @@ deleted_suffix_length(VALUE str, VALUE suffix)
     suffixptr = RSTRING_PTR(suffix);
     s = strptr + olen - suffixlen;
     if (memcmp(s, suffixptr, suffixlen) != 0) return 0;
-    if (rb_enc_left_char_head(strptr, s, strptr + olen, enc) != s) return 0;
+    if (!at_char_boundary(strptr, s, strptr + olen, enc)) return 0;
 
     return suffixlen;
 }

--- a/test/ruby/test_string.rb
+++ b/test/ruby/test_string.rb
@@ -1938,6 +1938,8 @@ CODE
     assert_send([S("hello"), :start_with?, S("hel")])
     assert_not_send([S("hello"), :start_with?, S("el")])
     assert_send([S("hello"), :start_with?, S("el"), S("he")])
+    assert_send([S("\xFF\xFE"), :start_with?, S("\xFF")])
+    assert_not_send([S("\u{c4}"), :start_with?, S("\xC3")])
 
     bug5536 = '[ruby-core:40623]'
     assert_raise(TypeError, bug5536) {S("str").start_with? :not_convertible_to_string}
@@ -2930,6 +2932,7 @@ CODE
     assert_equal("\x95\x5c".force_encoding("Shift_JIS"), s.delete_prefix("\x95"))
     assert_equal("\x95\x5c".force_encoding("Shift_JIS"), s)
 
+    assert_equal("\xFE", S("\xFF\xFE").delete_prefix("\xFF"))
   end
 
   def test_delete_prefix_clear_coderange
@@ -2978,6 +2981,9 @@ CODE
     assert_equal(nil, s.delete_prefix!("\xe3"))
     assert_equal("\xe3\x81\x82", s)
 
+    s = S("\xFF\xFE")
+    assert_equal("\xFE", s.delete_prefix!("\xFF"))
+    assert_equal("\xFE", s)
   end
 
   def test_delete_prefix_bang_clear_coderange

--- a/test/ruby/test_string.rb
+++ b/test/ruby/test_string.rb
@@ -1941,7 +1941,9 @@ CODE
 
     bug5536 = '[ruby-core:40623]'
     assert_raise(TypeError, bug5536) {S("str").start_with? :not_convertible_to_string}
+  end
 
+  def test_start_with_regexp
     assert_equal(true, S("hello").start_with?(/hel/))
     assert_equal("hel", $&)
     assert_equal(false, S("hello").start_with?(/el/))
@@ -2891,11 +2893,13 @@ CODE
 
   end
 
-  def test_delete_prefix
+  def test_delete_prefix_type_error
     assert_raise(TypeError) { S('hello').delete_prefix(nil) }
     assert_raise(TypeError) { S('hello').delete_prefix(1) }
     assert_raise(TypeError) { S('hello').delete_prefix(/hel/) }
+  end
 
+  def test_delete_prefix
     s = S("hello")
     assert_equal("lo", s.delete_prefix('hel'))
     assert_equal("hello", s)
@@ -2915,8 +2919,9 @@ CODE
     s = S("hello")
     assert_equal("hello", s.delete_prefix("\u{3053 3093}"))
     assert_equal("hello", s)
+  end
 
-    # skip if argument is a broken string
+  def test_delete_prefix_broken_encoding
     s = S("\xe3\x81\x82")
     assert_equal("\xe3\x81\x82", s.delete_prefix("\xe3"))
     assert_equal("\xe3\x81\x82", s)
@@ -2925,23 +2930,28 @@ CODE
     assert_equal("\x95\x5c".force_encoding("Shift_JIS"), s.delete_prefix("\x95"))
     assert_equal("\x95\x5c".force_encoding("Shift_JIS"), s)
 
-    # clear coderange
+  end
+
+  def test_delete_prefix_clear_coderange
     s = S("\u{3053 3093}hello")
     assert_not_predicate(s, :ascii_only?)
     assert_predicate(s.delete_prefix("\u{3053 3093}"), :ascii_only?)
+  end
 
-    # argument should be converted to String
+  def test_delete_prefix_argument_conversion
     klass = Class.new { def to_str; 'a'; end }
     s = S("abba")
     assert_equal("bba", s.delete_prefix(klass.new))
     assert_equal("abba", s)
   end
 
-  def test_delete_prefix_bang
+  def test_delete_prefix_bang_type_error
     assert_raise(TypeError) { S('hello').delete_prefix!(nil) }
     assert_raise(TypeError) { S('hello').delete_prefix!(1) }
     assert_raise(TypeError) { S('hello').delete_prefix!(/hel/) }
+  end
 
+  def test_delete_prefix_bang
     s = S("hello")
     assert_equal("lo", s.delete_prefix!('hel'))
     assert_equal("lo", s)
@@ -2961,23 +2971,29 @@ CODE
     s = S("hello")
     assert_equal(nil, s.delete_prefix!("\u{3053 3093}"))
     assert_equal("hello", s)
+  end
 
-    # skip if argument is a broken string
+  def test_delete_prefix_bang_broken_encoding
     s = S("\xe3\x81\x82")
     assert_equal(nil, s.delete_prefix!("\xe3"))
     assert_equal("\xe3\x81\x82", s)
 
-    # clear coderange
+  end
+
+  def test_delete_prefix_bang_clear_coderange
     s = S("\u{3053 3093}hello")
     assert_not_predicate(s, :ascii_only?)
     assert_predicate(s.delete_prefix!("\u{3053 3093}"), :ascii_only?)
+  end
 
-    # argument should be converted to String
+  def test_delete_prefix_bang_argument_conversion
     klass = Class.new { def to_str; 'a'; end }
     s = S("abba")
     assert_equal("bba", s.delete_prefix!(klass.new))
     assert_equal("bba", s)
+  end
 
+  def test_delete_prefix_bang_frozen_error
     s = S("ax").freeze
     assert_raise_with_message(FrozenError, /frozen/) {s.delete_prefix!("a")}
 
@@ -2990,11 +3006,13 @@ CODE
     assert_raise_with_message(FrozenError, /frozen/) {s.delete_prefix!(o)}
   end
 
-  def test_delete_suffix
+  def test_delete_suffix_type_error
     assert_raise(TypeError) { S('hello').delete_suffix(nil) }
     assert_raise(TypeError) { S('hello').delete_suffix(1) }
     assert_raise(TypeError) { S('hello').delete_suffix(/hel/) }
+  end
 
+  def test_delete_suffix
     s = S("hello")
     assert_equal("hel", s.delete_suffix('lo'))
     assert_equal("hello", s)
@@ -3014,23 +3032,28 @@ CODE
     s = S("hello")
     assert_equal("hello", s.delete_suffix("\u{3061 306f}"))
     assert_equal("hello", s)
+  end
 
-    # skip if argument is a broken string
+  def test_delete_suffix_broken_encoding
     s = S("\xe3\x81\x82")
     assert_equal("\xe3\x81\x82", s.delete_suffix("\x82"))
     assert_equal("\xe3\x81\x82", s)
+  end
 
-    # clear coderange
+  def test_delete_suffix_clear_coderange
     s = S("hello\u{3053 3093}")
     assert_not_predicate(s, :ascii_only?)
     assert_predicate(s.delete_suffix("\u{3053 3093}"), :ascii_only?)
+  end
 
-    # argument should be converted to String
+  def test_delete_suffix_argument_conversion
     klass = Class.new { def to_str; 'a'; end }
     s = S("abba")
     assert_equal("abb", s.delete_suffix(klass.new))
     assert_equal("abba", s)
+  end
 
+  def test_delete_suffix_newline
     # chomp removes any of "\n", "\r\n", "\r" when "\n" is specified,
     # but delete_suffix does not
     s = "foo\n"
@@ -3041,11 +3064,13 @@ CODE
     assert_equal("foo\r", s.delete_suffix("\n"))
   end
 
-  def test_delete_suffix_bang
+  def test_delete_suffix_bang_type_error
     assert_raise(TypeError) { S('hello').delete_suffix!(nil) }
     assert_raise(TypeError) { S('hello').delete_suffix!(1) }
     assert_raise(TypeError) { S('hello').delete_suffix!(/hel/) }
+  end
 
+  def test_delete_suffix_bang_frozen_error
     s = S("hello").freeze
     assert_raise_with_message(FrozenError, /frozen/) {s.delete_suffix!('lo')}
 
@@ -3056,7 +3081,9 @@ CODE
       "x"
     end
     assert_raise_with_message(FrozenError, /frozen/) {s.delete_suffix!(o)}
+  end
 
+  def test_delete_suffix_bang
     s = S("hello")
     assert_equal("hel", s.delete_suffix!('lo'))
     assert_equal("hel", s)
@@ -3076,8 +3103,9 @@ CODE
     s = S("hello")
     assert_equal(nil, s.delete_suffix!("\u{3061 306f}"))
     assert_equal("hello", s)
+  end
 
-    # skip if argument is a broken string
+  def test_delete_suffix_bang_broken_encoding
     s = S("\xe3\x81\x82")
     assert_equal(nil, s.delete_suffix!("\x82"))
     assert_equal("\xe3\x81\x82", s)
@@ -3085,18 +3113,22 @@ CODE
     s = S("\x95\x5c").force_encoding("Shift_JIS")
     assert_equal(nil, s.delete_suffix!("\x5c"))
     assert_equal("\x95\x5c".force_encoding("Shift_JIS"), s)
+  end
 
-    # clear coderange
+  def test_delete_suffix_bang_clear_coderange
     s = S("hello\u{3053 3093}")
     assert_not_predicate(s, :ascii_only?)
     assert_predicate(s.delete_suffix!("\u{3053 3093}"), :ascii_only?)
+  end
 
-    # argument should be converted to String
+  def test_delete_suffix_bang_argument_conversion
     klass = Class.new { def to_str; 'a'; end }
     s = S("abba")
     assert_equal("abb", s.delete_suffix!(klass.new))
     assert_equal("abb", s)
+  end
 
+  def test_delete_suffix_bang_newline
     # chomp removes any of "\n", "\r\n", "\r" when "\n" is specified,
     # but delete_suffix does not
     s = "foo\n"


### PR DESCRIPTION
[Bug #19784](https://bugs.ruby-lang.org/issues/19784)