### PR TITLE
Add Missing Counters to `rb_debug_counter_type` enum

### DIFF
--- a/debug_counter.h
+++ b/debug_counter.h
@@ -100,6 +100,13 @@ RB_DEBUG_COUNTER(ccf_opt_block_call)
 RB_DEBUG_COUNTER(ccf_opt_struct_aref)
 RB_DEBUG_COUNTER(ccf_opt_struct_aset)
 RB_DEBUG_COUNTER(ccf_super_method)
+RB_DEBUG_COUNTER(ccf_cfunc_other)
+RB_DEBUG_COUNTER(ccf_cfunc_only_splat)
+RB_DEBUG_COUNTER(ccf_cfunc_only_splat_kw)
+RB_DEBUG_COUNTER(ccf_iseq_bmethod)
+RB_DEBUG_COUNTER(ccf_noniseq_bmethod)
+RB_DEBUG_COUNTER(ccf_opt_send_complex)
+RB_DEBUG_COUNTER(ccf_opt_send_simple)
 
 /*
  * control frame push counts.


### PR DESCRIPTION
On master we have calls to the `RB_DEBUG_COUNTER_INC` macro for counters that are not getting defined in the
`rb_debug_counter_type` enum. This causes compilation to fail with undeclared identifiers if you try to compile with `-DUSE_RUBY_DEBUG_LOG`:
```
../configure optflags="-DUSE_DEBUG_COUNTER"

[...]

make -j4

[...]

compiling yarp/token_type.c
compiling ../yjit.c
generating encdb.h
In file included from ../vm.c:470:
../vm_insnhelper.c:3509:5: error: use of undeclared identifier 'RB_DEBUG_COUNTER_ccf_cfunc_other'; did you mean 'RB_DEBUG_COUNTER_ccf_cfunc'?
    RB_DEBUG_COUNTER_INC(ccf_cfunc_other);
    ^
./../debug_counter.h:392:72: note: expanded from macro 'RB_DEBUG_COUNTER_INC'
#define RB_DEBUG_COUNTER_INC(type)                rb_debug_counter_add(RB_DEBUG_COUNTER_##type, 1, 1)

[...]
```


This commit adds those that are missing. Compilation passes locally and the debug logging prints as expected.