### PR TITLE
Define bounds-checking interfaces macro for each file

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2153,9 +2153,6 @@ AC_CHECK_FUNCS(__sinpi)
 AS_IF([test "x$ac_cv_member_struct_statx_stx_btime" = xyes],
     [AC_CHECK_FUNCS(statx)])
 
-AS_CASE(["$ac_cv_func_memset_s:$ac_cv_func_qsort_s"], [*yes*],
-    [RUBY_DEFINE_IF([!defined __STDC_WANT_LIB_EXT1__], [__STDC_WANT_LIB_EXT1__], 1)])
-
 AS_IF([test "$ac_cv_func_getcwd" = yes], [
     AC_CACHE_CHECK(if getcwd allocates buffer if NULL is given, [rb_cv_getcwd_malloc],
 	[AC_RUN_IFELSE([AC_LANG_SOURCE([[

--- a/util.c
+++ b/util.c
@@ -13,6 +13,10 @@
 # define MINGW_HAS_SECURE_API 1
 #endif
 
+#ifndef __STDC_WANT_LIB_EXT1__
+#define __STDC_WANT_LIB_EXT1__ 1
+#endif
+
 #include "ruby/internal/config.h"
 
 #include <ctype.h>


### PR DESCRIPTION
Already `explicit_zero.c` defines it.