### PR TITLE
Remove --disable-gems in assert_in_out_err

### DIFF
--- a/test/-ext-/bug_reporter/test_bug_reporter.rb
+++ b/test/-ext-/bug_reporter/test_bug_reporter.rb
@@ -22,8 +22,7 @@ class TestBugReporter < Test::Unit::TestCase
     tmpdir = Dir.mktmpdir
 
     no_core = "Process.setrlimit(Process::RLIMIT_CORE, 0); " if defined?(Process.setrlimit) && defined?(Process::RLIMIT_CORE)
-    args = ["--disable-gems", "-r-test-/bug_reporter",
-            "-C", tmpdir]
+    args = ["-r-test-/bug_reporter", "-C", tmpdir]
     args.push("--yjit") if yjit_enabled? # We want the printed description to match this process's RUBY_DESCRIPTION
     args.unshift({"RUBY_ON_BUG" => nil})
     stdin = "#{no_core}register_sample_bug_reporter(12345); Process.kill :SEGV, $$"

--- a/test/json/json_generator_test.rb
+++ b/test/json/json_generator_test.rb
@@ -233,7 +233,7 @@ EOT
 
   def test_gc
     if respond_to?(:assert_in_out_err) && !(RUBY_PLATFORM =~ /java/)
-      assert_in_out_err(%w[-rjson --disable-gems], <<-EOS, [], [])
+      assert_in_out_err(%w[-rjson], <<-EOS, [], [])
         bignum_too_long_to_embed_as_string = 1234567890123456789012345
         expect = bignum_too_long_to_embed_as_string.to_s
         GC.stress = true

--- a/test/ruby/test_require.rb
+++ b/test/ruby/test_require.rb
@@ -193,7 +193,7 @@ class TestRequire < Test::Unit::TestCase
       File.write(req, "p :ok\n")
       assert_file.exist?(req)
       req[/.rb$/i] = ""
-      assert_in_out_err(['--disable-gems'], <<-INPUT, %w(:ok), [])
+      assert_in_out_err([], <<-INPUT, %w(:ok), [])
         require "#{req}"
         require "#{req}"
       INPUT
@@ -681,7 +681,7 @@ class TestRequire < Test::Unit::TestCase
     Dir.mktmpdir {|tmp|
       Dir.chdir(tmp) {
         open("foo.rb", "w") {}
-        assert_in_out_err([{"RUBYOPT"=>nil}, '--disable-gems'], "#{<<~"begin;"}\n#{<<~"end;"}", %w(:ok), [], bug7158)
+        assert_in_out_err([{"RUBYOPT"=>nil}], "#{<<~"begin;"}\n#{<<~"end;"}", %w(:ok), [], bug7158)
         begin;
           $:.replace([IO::NULL])
           a = Object.new
@@ -709,7 +709,7 @@ class TestRequire < Test::Unit::TestCase
     Dir.mktmpdir {|tmp|
       Dir.chdir(tmp) {
         open("foo.rb", "w") {}
-        assert_in_out_err([{"RUBYOPT"=>nil}, '--disable-gems'], "#{<<~"begin;"}\n#{<<~"end;"}", %w(:ok), [], bug7158)
+        assert_in_out_err([{"RUBYOPT"=>nil}], "#{<<~"begin;"}\n#{<<~"end;"}", %w(:ok), [], bug7158)
         begin;
           $:.replace([IO::NULL])
           a = Object.new
@@ -739,7 +739,7 @@ class TestRequire < Test::Unit::TestCase
         open("foo.rb", "w") {}
         Dir.mkdir("a")
         open(File.join("a", "bar.rb"), "w") {}
-        assert_in_out_err(['--disable-gems'], "#{<<~"begin;"}\n#{<<~"end;"}", %w(:ok), [], bug7383)
+        assert_in_out_err([], "#{<<~"begin;"}\n#{<<~"end;"}", %w(:ok), [], bug7383)
         begin;
           $:.replace([IO::NULL])
           $:.#{add} "#{tmp}"
@@ -963,7 +963,7 @@ class TestRequire < Test::Unit::TestCase
 
   def test_require_with_public_method_missing
     # [Bug #19793]
-    assert_separately(["-W0", "--disable-gems", "-rtempfile"], __FILE__, __LINE__, <<~RUBY)
+    assert_separately(["-W0", "-rtempfile"], __FILE__, __LINE__, <<~RUBY)
       GC.stress = true
 
       class Object

--- a/test/ruby/test_rubyoptions.rb
+++ b/test/ruby/test_rubyoptions.rb
@@ -135,12 +135,12 @@ class TestRubyOptions < Test::Unit::TestCase
   end
 
   def test_debug
-    assert_in_out_err(["--disable-gems", "-de", "p $DEBUG"], "", %w(true), [])
+    assert_in_out_err(["-de", "p $DEBUG"], "", %w(true), [])
 
-    assert_in_out_err(["--disable-gems", "--debug", "-e", "p $DEBUG"],
+    assert_in_out_err(["--debug", "-e", "p $DEBUG"],
                       "", %w(true), [])
 
-    assert_in_out_err(["--disable-gems", "--debug-", "-e", "p $DEBUG"], "", %w(), /invalid option --debug-/)
+    assert_in_out_err(["--debug-", "-e", "p $DEBUG"], "", %w(), /invalid option --debug-/)
   end
 
   q = Regexp.method(:quote)
@@ -211,9 +211,9 @@ class TestRubyOptions < Test::Unit::TestCase
     assert_in_out_err(%w(--disable foobarbazqux -e) + [""], "", [],
                       /unknown argument for --disable: `foobarbazqux'/)
     assert_in_out_err(%w(--disable), "", [], /missing argument for --disable/)
-    assert_in_out_err(%w(--disable-gems -e) + ['p defined? Gem'], "", ["nil"], [])
+    assert_in_out_err(%w(-e) + ['p defined? Gem'], "", ["nil"], [])
     assert_in_out_err(%w(--disable-did_you_mean -e) + ['p defined? DidYouMean'], "", ["nil"], [])
-    assert_in_out_err(%w(--disable-gems -e) + ['p defined? DidYouMean'], "", ["nil"], [])
+    assert_in_out_err(%w(-e) + ['p defined? DidYouMean'], "", ["nil"], [])
   end
 
   def test_kanji

--- a/test/ruby/test_thread.rb
+++ b/test/ruby/test_thread.rb
@@ -395,7 +395,7 @@ class TestThread < Test::Unit::TestCase
       end
     INPUT
 
-    assert_in_out_err(%w(--disable-gems -d), <<-INPUT, %w(false 2), %r".+")
+    assert_in_out_err(%w(-d), <<-INPUT, %w(false 2), %r".+")
       p Thread.abort_on_exception
       begin
         t = Thread.new { raise }

--- a/test/test_tempfile.rb
+++ b/test/test_tempfile.rb
@@ -209,8 +209,7 @@ puts Tempfile.new('foo').path
 
   def test_tempfile_finalizer_does_not_run_if_unlinked
     bug8768 = '[ruby-core:56521] [Bug #8768]'
-    args = %w(--disable-gems -rtempfile)
-    assert_in_out_err(args, <<-'EOS') do |(filename), (error)|
+    assert_in_out_err(%w(-rtempfile), <<-'EOS') do |(filename), (error)|
       tmp = Tempfile.new('foo')
       puts tmp.path
       tmp.close


### PR DESCRIPTION
assert_in_out_err adds --disable=gems so we don't need to add --disable-gems in the args list.