### PR TITLE
Fix Array#bsearch when block returns a non-integer numeric value

### DIFF
--- a/array.c
+++ b/array.c
@@ -3522,8 +3522,8 @@ rb_ary_bsearch_index(VALUE ary)
             const VALUE zero = INT2FIX(0);
             switch (rb_cmpint(rb_funcallv(v, id_cmp, 1, &zero), v, zero)) {
               case 0: return INT2FIX(mid);
-              case 1: smaller = 1; break;
-              case -1: smaller = 0;
+              case 1: smaller = 0; break;
+              case -1: smaller = 1;
             }
         }
         else {

--- a/test/ruby/test_array.rb
+++ b/test/ruby/test_array.rb
@@ -3336,6 +3336,8 @@ class TestArray < Test::Unit::TestCase
     assert_equal(nil, a.bsearch {|x|   1  * (2**100) })
     assert_equal(nil, a.bsearch {|x| (-1) * (2**100) })
 
+    assert_equal(4, a.bsearch {|x| (4 - x).to_r })
+
     assert_include([4, 7], a.bsearch {|x| (2**100).coerce((1 - x / 4) * (2**100)).first })
   end
 
@@ -3370,6 +3372,8 @@ class TestArray < Test::Unit::TestCase
     assert_include([1, 2], a.bsearch_index {|x| (1 - x / 4) * (2**100) })
     assert_equal(nil, a.bsearch_index {|x|   1  * (2**100) })
     assert_equal(nil, a.bsearch_index {|x| (-1) * (2**100) })
+
+    assert_equal(1, a.bsearch_index {|x| (4 - x).to_r })
 
     assert_include([1, 2], a.bsearch_index {|x| (2**100).coerce((1 - x / 4) * (2**100)).first })
   end


### PR DESCRIPTION
`Array#bsearch` gets wrong result when its block returns a non-integer numeric value.

```
% ruby -e 'p [0, 4, 7, 10, 12].bsearch { |x| (4 - x) }'
4
% ruby -e 'p [0, 4, 7, 10, 12].bsearch { |x| (4 - x).to_r }'
nil
```