### PR TITLE
Expose `rb_process_status_wait` and hide `rb_process_status_waitv`.

### DIFF
--- a/include/ruby/internal/intern/process.h
+++ b/include/ruby/internal/intern/process.h
@@ -31,6 +31,15 @@ RBIMPL_SYMBOL_EXPORT_BEGIN()
 /* process.c */
 
 /**
+ * Wait for the specified process to terminate, reap it, and return its status.
+ *
+ * @param[in] pid The process ID to wait for.
+ * @param[in] flags The flags to pass to waitpid(2).
+ * @return VALUE An instance of Process::Status.
+ */
+VALUE rb_process_status_wait(rb_pid_t pid, int flags);
+
+/**
  * Sets the "last status", or the `$?`.
  *
  * @param[in]  status  The termination status, as defined in `waitpid(3posix)`.

--- a/process.c
+++ b/process.c
@@ -1197,7 +1197,7 @@ rb_process_status_wait(rb_pid_t pid, int flags)
  *  This is an EXPERIMENTAL FEATURE.
  */
 
-VALUE
+static VALUE
 rb_process_status_waitv(int argc, VALUE *argv, VALUE _)
 {
     rb_check_arity(argc, 0, 2);


### PR DESCRIPTION
For background, see <https://github.com/ruby/ruby/pull/4563> and <https://github.com/ruby/ruby/pull/8315>.