### PR TITLE
Implement "mutex reservation"

### DIFF
--- a/internal/thread.h
+++ b/internal/thread.h
@@ -50,6 +50,7 @@ void rb_mutex_allow_trap(VALUE self, int val);
 VALUE rb_uninterruptible(VALUE (*b_proc)(VALUE), VALUE data);
 VALUE rb_mutex_owned_p(VALUE self);
 VALUE rb_exec_recursive_outer_mid(VALUE (*f)(VALUE g, VALUE h, int r), VALUE g, VALUE h, ID mid);
+VALUE rb_thread_alive_p(VALUE thread);
 
 int rb_thread_wait_for_single_fd(int fd, int events, struct timeval * timeout);
 

--- a/rjit_c.rb
+++ b/rjit_c.rb
@@ -1514,6 +1514,7 @@ module RubyVM::RJIT # :nodoc: all
       interrupt_lock: [self.rb_nativethread_lock_t, Primitive.cexpr!("OFFSETOF((*((struct rb_thread_struct *)NULL)), interrupt_lock)")],
       unblock: [self.rb_unblock_callback, Primitive.cexpr!("OFFSETOF((*((struct rb_thread_struct *)NULL)), unblock)")],
       locking_mutex: [self.VALUE, Primitive.cexpr!("OFFSETOF((*((struct rb_thread_struct *)NULL)), locking_mutex)")],
+      sleeping_mutex: [self.VALUE, Primitive.cexpr!("OFFSETOF((*((struct rb_thread_struct *)NULL)), sleeping_mutex)")],
       keeping_mutexes: [CType::Pointer.new { self.rb_mutex_struct }, Primitive.cexpr!("OFFSETOF((*((struct rb_thread_struct *)NULL)), keeping_mutexes)")],
       join_list: [CType::Pointer.new { self.rb_waiting_list }, Primitive.cexpr!("OFFSETOF((*((struct rb_thread_struct *)NULL)), join_list)")],
       invoke_arg: [CType::Union.new(

--- a/test/ruby/test_thread_cv.rb
+++ b/test/ruby/test_thread_cv.rb
@@ -243,4 +243,78 @@ INPUT
       thrs.delete_if { |t| t.join(0.01) }
     end
   end if Process.respond_to?(:fork)
+
+  def test_condvar_pingpong
+    resource_pool_klass = Class.new do
+      const_set :PoolTimeoutError, Class.new(StandardError)
+
+      def initialize(resources)
+        @resources = resources
+        @mutex = Thread::Mutex.new
+        @condvar = Thread::ConditionVariable.new
+      end
+
+      def acquire
+        @mutex.synchronize do
+          t_start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          t_deadline = t_start + 1.0
+          loop do
+            return @resources.pop if @resources.any?
+            wait_for = t_deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC)
+            raise self.class::PoolTimeoutError if wait_for <= 0
+            @condvar.wait(@mutex, wait_for)
+          end
+        end
+      end
+
+      def release(resource)
+        @mutex.synchronize do
+          @resources << resource
+          @condvar.signal
+        end
+      end
+    end
+
+    worker_klass = Class.new do
+      def initialize(pool, iterations)
+        @pool = pool
+        @iterations = iterations
+      end
+
+      def start
+        @thread = Thread.new { run }
+      end
+
+      def stop
+        @thread&.kill
+        @thread&.join
+        @thread = nil
+      end
+
+      def join
+        @thread&.join
+        @thread = nil
+      end
+
+      def run
+        @iterations.times do
+          r = @pool.acquire
+          sleep 0.001
+          @pool.release r
+        end
+      end
+    end
+
+    pool = resource_pool_klass.new([Object.new])
+    workers = 3.times.map do
+      worker_klass.new(pool, 1000).tap { _1.start }
+    end
+
+    # No thread should raise a pool timeout.
+    begin
+      workers.each { _1.join }
+    rescue resource_pool_klass::PoolTimeoutError
+      flunk "[Bug #19717] a PoolTimeoutError was raised from a thread being unfairly starved"
+    end
+  end
 end

--- a/thread.c
+++ b/thread.c
@@ -3252,7 +3252,7 @@ rb_thread_status(VALUE thread)
  *  See also #stop? and #status.
  */
 
-static VALUE
+VALUE
 rb_thread_alive_p(VALUE thread)
 {
     return RBOOL(!thread_finished(rb_thread_ptr(thread)));

--- a/vm.c
+++ b/vm.c
@@ -3264,6 +3264,7 @@ thread_mark(void *ptr)
     RUBY_MARK_UNLESS_NULL(th->stat_insn_usage);
     RUBY_MARK_UNLESS_NULL(th->last_status);
     RUBY_MARK_UNLESS_NULL(th->locking_mutex);
+    RUBY_MARK_UNLESS_NULL(th->sleeping_mutex);
     RUBY_MARK_UNLESS_NULL(th->name);
 
     RUBY_MARK_UNLESS_NULL(th->scheduler);

--- a/vm_core.h
+++ b/vm_core.h
@@ -1025,6 +1025,7 @@ typedef struct rb_thread_struct {
     rb_nativethread_lock_t interrupt_lock;
     struct rb_unblock_callback unblock;
     VALUE locking_mutex;
+    VALUE sleeping_mutex;
     struct rb_mutex_struct *keeping_mutexes;
 
     struct rb_waiting_list *join_list;


### PR DESCRIPTION
This implements a solution to Bug #19717, where it's possible for a resource protected by a condition variable & a mutex to ping-ping between two threads, whilst a third thread never gets it. This occurs if the resource is released & re-acquired in the same thread, because a thread which releases a mutex will almost always be able to re-acquire it afterwards unless it does some blocking work in between.

This implements a kind of "reservation" system for mutexes orchestrated with condition variables. A condition variable waiter (or, actually, any caller to Mutex#sleep) records the mutex it's waiting on in a thread variable; when it's woken up by the condition variable signaller, it gets the mutex "reserved" for it. If the waking thread subsequently attempts to reacquire the mutex immediately, it will thus fail because of the reservation and go to sleep.

[Bug #19717]