### PR TITLE
Change heap init environment variable names

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,7 +13,7 @@ Note that each entry is kept to a minimum, see links for details.
   They are not displayed by default even in verbose mode.
   Turn them on with `-W:performance` or `Warning[:performance] = true`. [[Feature #19538]]
 * The `RUBY_GC_HEAP_INIT_SLOTS` environment variable has been deprecated and
-  removed. Environment variables `RUBY_GC_HEAP_INIT_SIZE_%d_SLOTS` should be
+  removed. Environment variables `RUBY_GC_HEAP_%d_INIT_SLOTS` should be
   used instead.  [[Feature #19785]]
 
 ## Core classes updates

--- a/gc.c
+++ b/gc.c
@@ -11633,8 +11633,8 @@ gc_set_initial_pages(rb_objspace_t *objspace)
 
     for (int i = 0; i < SIZE_POOL_COUNT; i++) {
         rb_size_pool_t *size_pool = &size_pools[i];
-        char env_key[sizeof("RUBY_GC_HEAP_INIT_SIZE_" "_SLOTS") + DECIMAL_SIZE_OF_BITS(sizeof(size_pool->slot_size) * CHAR_BIT)];
-        snprintf(env_key, sizeof(env_key), "RUBY_GC_HEAP_INIT_SIZE_%d_SLOTS", size_pool->slot_size);
+        char env_key[sizeof("RUBY_GC_HEAP_" "_INIT_SLOTS") + DECIMAL_SIZE_OF_BITS(sizeof(int) * CHAR_BIT)];
+        snprintf(env_key, sizeof(env_key), "RUBY_GC_HEAP_%d_INIT_SLOTS", i);
 
         size_t size_pool_init_slots = gc_params.size_pool_init_slots[i];
         if (get_envparam_size(env_key, &size_pool_init_slots, 0)) {

--- a/man/ruby.1
+++ b/man/ruby.1
@@ -557,9 +557,9 @@ the following 11 environment variables:
 .It Ev RUBY_GC_HEAP_INIT_SLOTS
 Initial allocation slots. Applies to all slot sizes.  Introduced in Ruby 2.1, default: 10000.
 .Pp
-.It Ev RUBY_GC_HEAP_INIT_SIZE_%d_SLOTS
-Initial allocation of slots in a specific size pool.
-The available size pools can be found in `GC.stat_heap`.
+.It Ev RUBY_GC_HEAP_%d_INIT_SLOTS
+Initial allocation of slots in a specific heap.
+The available heaps can be found in the keys of `GC.stat_heap`.
 Introduced in Ruby 3.3.
 .Pp
 .It Ev RUBY_GC_HEAP_FREE_SLOTS

--- a/ruby.c
+++ b/ruby.c
@@ -1742,7 +1742,7 @@ ruby_opt_init(ruby_cmdline_options_t *opt)
      * Remove this in Ruby 3.4. */
     if (getenv("RUBY_GC_HEAP_INIT_SLOTS")) {
         rb_warn_deprecated("The environment variable RUBY_GC_HEAP_INIT_SLOTS",
-                           "environment variables RUBY_GC_HEAP_INIT_SIZE_%d_SLOTS");
+                           "environment variables RUBY_GC_HEAP_%d_INIT_SLOTS");
     }
 
 #if USE_RJIT

--- a/test/ruby/test_gc.rb
+++ b/test/ruby/test_gc.rb
@@ -377,17 +377,17 @@ class TestGc < Test::Unit::TestCase
     }
     assert_in_out_err([env, "-W0", "-e", "exit"], "", [], [])
     assert_in_out_err([env, "-W:deprecated", "-e", "exit"], "", [],
-                       /The environment variable RUBY_GC_HEAP_INIT_SLOTS is deprecated; use environment variables RUBY_GC_HEAP_INIT_SIZE_%d_SLOTS instead/)
+                       /The environment variable RUBY_GC_HEAP_INIT_SLOTS is deprecated; use environment variables RUBY_GC_HEAP_%d_INIT_SLOTS instead/)
 
     env = {}
-    GC.stat_heap.each do |_, s|
-      env["RUBY_GC_HEAP_INIT_SIZE_#{s[:slot_size]}_SLOTS"] = "200000"
+    GC.stat_heap.keys.each do |heap|
+      env["RUBY_GC_HEAP_#{heap}_INIT_SLOTS"] = "200000"
     end
     assert_normal_exit("exit", "", :child_env => env)
 
     env = {}
-    GC.stat_heap.each do |_, s|
-      env["RUBY_GC_HEAP_INIT_SIZE_#{s[:slot_size]}_SLOTS"] = "0"
+    GC.stat_heap.keys.each do |heap|
+      env["RUBY_GC_HEAP_#{heap}_INIT_SLOTS"] = "0"
     end
     assert_normal_exit("exit", "", :child_env => env)
 
@@ -456,8 +456,8 @@ class TestGc < Test::Unit::TestCase
     env = {}
     # Make the heap big enough to ensure the heap never needs to grow.
     sizes = GC.stat_heap.keys.reverse.map { |i| (i + 1) * 100_000 }
-    GC.stat_heap.each do |i, s|
-      env["RUBY_GC_HEAP_INIT_SIZE_#{s[:slot_size]}_SLOTS"] = sizes[i].to_s
+    GC.stat_heap.keys.each do |heap|
+      env["RUBY_GC_HEAP_#{heap}_INIT_SLOTS"] = sizes[heap].to_s
     end
     assert_separately([env, "-W0"], __FILE__, __LINE__, <<~RUBY)
       SIZES = #{sizes}


### PR DESCRIPTION
This commit changes `RUBY_GC_HEAP_INIT_SIZE_{40,80,160,320,640}_SLOTS` to `RUBY_GC_HEAP_{0,1,2,3,4}_INIT_SLOTS`. This is easier to use because the user does not need to determine the slot sizes (which can vary between 32 and 64 bit systems). They now just use the heap names (`GC.stat_heap.keys`).

cc. @byroot 