### PR TITLE
CodeQL memory size

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -78,6 +78,7 @@ jobs:
           category: '/language:${{ matrix.language }}'
           upload: False
           output: sarif-results
+          ram: 8192
 
       - name: filter-sarif
         uses: advanced-security/filter-sarif@f3b8118a9349d88f7b1c0c488476411145b6270d # v1.0


### PR DESCRIPTION
Query evaluation ran out of Java heap frequently since CodeQL 2.14.3.
