### PR TITLE
TestSocket_UNIXSocket: stop testing empty packets

### DIFF
--- a/test/socket/test_unix.rb
+++ b/test/socket/test_unix.rb
@@ -488,9 +488,7 @@ class TestSocket_UNIXSocket < Test::Unit::TestCase
       assert_kind_of(IO::WaitReadable, e)
     end
 
-    s2.send("", 0)
     s2.send("haha", 0)
-    assert_equal(nil, s1.recv(10)) # no way to distinguish empty packet from EOF with SOCK_SEQPACKET
     assert_equal("haha", s1.recv(10))
     assert_raise(IO::EWOULDBLOCKWaitReadable) { s1.recv_nonblock(10) }
 


### PR DESCRIPTION
Followup: https://github.com/ruby/ruby/pull/6407
[[Bug #19012]](https://bugs.ruby-lang.org/issues/19012)

OpenBSD and Solaris behave differently here.

Linux does deliver the empty packet, which is questionable as it's undistinguishable from a closed connection.

It seems that OpenBSD and Solaris simply drop it.

We could test the platform before doing the assertion, but it would likely be fragile, and the entire web recommend to not ever send an empty packet, so the value of this assertion is low.