### PR TITLE
Enable passing the `target` argument to `Array#bsearch`, `Array#bsearch_index`, and `Range#bsearch`

### DIFF
--- a/array.c
+++ b/array.c
@@ -3573,7 +3573,6 @@ rb_ary_bsearch_index(int argc, VALUE *argv, VALUE ary)
 
     static ID keyword_ids[1];
     VALUE target;
-    ID target_id;
 
     if (!keyword_ids[0]) {
         keyword_ids[0] = rb_intern_const("target");
@@ -3581,21 +3580,16 @@ rb_ary_bsearch_index(int argc, VALUE *argv, VALUE ary)
 
     rb_get_kwargs(opt, keyword_ids, 0, 1, &target);
 
-    if (!SYMBOL_P(target)) {
-        goto invalid_target;
-    }
-
-    target_id = SYM2ID(target);
-
-    if (target_id == rb_intern("first")) {
+    if (target == ID2SYM(rb_intern("first"))) {
         return ary_bsearch_index(ary, true);
     }
-    else if (target_id == rb_intern("last")) {
+    else if (target == ID2SYM(rb_intern("last"))) {
         return ary_bsearch_index(ary, false);
     }
-
-  invalid_target:
-    rb_raise(rb_eArgError, "target must be :first or :last");
+    else {
+        rb_raise(rb_eArgError, "target must be :first or :last");
+        UNREACHABLE_RETURN(Qnil);
+    }
 }
 
 static VALUE

--- a/array.c
+++ b/array.c
@@ -3531,6 +3531,10 @@ static VALUE rb_ary_bsearch_index(int argc, VALUE *argv, VALUE ary);
  *
  *  Returns an element from +self+ selected by a binary search.
  *
+ *    a = [2, 3, 5, 7, 11]
+ *    a.bsearch {|x| x >= 6 } # => 7
+ *    a.bsearch(target: :last) {|x| x <= 6 } # => 5
+ *
  *  See {Binary Searching}[rdoc-ref:bsearch.rdoc].
  */
 

--- a/doc/bsearch.rdoc
+++ b/doc/bsearch.rdoc
@@ -15,42 +15,54 @@ Given a block, each of these methods returns an element (or element index) from 
 as determined by a binary search.
 The search finds an element of +self+ which meets
 the given condition in <tt>O(log n)</tt> operations, where +n+ is the count of elements.
-+self+ should be sorted, but this is not checked.
++self+ must be sorted to get the correct value, but this is not checked.
 
 There are two search modes:
 
-Find-minimum mode:: method +bsearch+ returns the first element for which
-                    the block returns +true+;
-                    the block must return +true+ or +false+.
-Find-any mode:: method +bsearch+ some element, if any, for which
-                the block returns zero.
-                the block must return a numeric value.
+Find-by-boolean mode:: method +bsearch+ returns the first (or last) element
+                       that makes the given block return +true+.
+                       If no elements satisfy the condition, +bsearch+ returns +nil+.
+                       The block must return +true+ or +false+.
+Find-by-number mode:: method +bsearch+ returns the first (or last) element
+                      that makes the given block return zero.
+                      If no elements satisfy the condition, +bsearch+ returns +nil+.
+                      The block must return a numeric value.
 
-The block should not mix the modes by sometimes returning +true+ or +false+
+The block must not mix the modes by sometimes returning +true+ or +false+
 and other times returning a numeric value, but this is not checked.
 
-<b>Find-Minimum Mode</b>
+You can pass the argument <tt>target</tt> to specify whether the method returns the first
+or the last matching element. The possible values are <tt>:first</tt> or <tt>:last</tt>.
 
-In find-minimum mode, the block must return +true+ or +false+.
+<b>Find-by-boolean Mode</b>
+
+In find-by-boolean mode, the block must return +true+ or +false+.
 The further requirement (though not checked) is that
 there are no indexes +i+ and +j+ such that:
 
 - <tt>0 <= i < j <= self.size</tt>.
-- The block returns +true+ for <tt>self[i]</tt> and +false+ for <tt>self[j]</tt>.
+- When <tt>target == :first</tt>, the block returns +true+ for <tt>self[i]</tt> and +false+ for <tt>self[j]</tt>.
+- When <tt>target == :last</tt>, the block returns +false+ for <tt>self[i]</tt> and +true+ for <tt>self[j]</tt>.
 
-Less formally: the block is such that all +false+-evaluating elements
+Less formally: When <tt>target == :first</tt>, the block is such that all +false+-evaluating elements
 precede all +true+-evaluating elements.
+When <tt>target == :last</tt>, the block is such that all +true+-evaluating elements
+precede all +false+-evaluating elements.
 
-In find-minimum mode, method +bsearch+ returns the first element
+In find-by-boolean mode, method +bsearch+ returns the first (or last) element
 for which the block returns +true+.
 
 Examples:
 
   a = [0, 4, 7, 10, 12]
+  # same as bsearch(target: :first)
   a.bsearch {|x| x >= 4 } # => 4
   a.bsearch {|x| x >= 6 } # => 7
   a.bsearch {|x| x >= -1 } # => 0
   a.bsearch {|x| x >= 100 } # => nil
+
+  a.bsearch(target: :last) {|x| x <= 8 } # => 7
+  a.bsearch(target: :last) {|x| x <= -10 } # => nil
 
   r = (0...a.size)
   r.bsearch {|i| a[i] >= 4 } #=> 1
@@ -60,7 +72,7 @@ Examples:
   r = (0.0...Float::INFINITY)
   r.bsearch {|x| Math.log(x) >= 0 } #=> 1.0
 
-These blocks make sense in find-minimum mode:
+These blocks make sense in find-by-boolean mode with <tt>target == :first</tt>:
 
   a = [0, 4, 7, 10, 12]
   a.map {|x| x >= 4 } # => [false, true, true, true, true]
@@ -72,9 +84,21 @@ This would not make sense:
 
   a.map {|x| x == 7 } # => [false, false, true, false, false]
 
-<b>Find-Any Mode</b>
+These blocks make sense in find-by-boolean mode with <tt>target == :last</tt>:
 
-In find-any mode, the block must return a numeric value.
+  a = [0, 4, 7, 10, 12]
+  a.map {|x| x <= 0 } # => [true, false, false, false, false]
+  a.map {|x| x <= 6 } # => [true, true, false, false, false]
+  a.map {|x| x <= 100 } # => [true, true, true, true, true]
+  a.map {|x| x <= -1 } # => [false, false, false, false, false]
+
+This would not make sense:
+
+  a.map {|x| x == 7 } # => [false, false, true, false, false]
+
+<b>Find-by-number Mode</b>
+
+In find-by-number mode, the block must return a numeric value.
 The further requirement (though not checked) is that
 there are no indexes +i+ and +j+ such that:
 
@@ -90,7 +114,7 @@ Less formally: the block is such that:
 - All positive-evaluating elements precede all negative-evaluating elements.
 - All zero-evaluating elements precede all negative-evaluating elements.
 
-In find-any mode, method +bsearch+ returns some element
+In find-by-number mode, method +bsearch+ returns the first (or last) element
 for which the block returns zero, or +nil+ if no such element is found.
 
 Examples:
@@ -100,6 +124,8 @@ Examples:
   a.bsearch {|element| -1 <=> element } # => nil
   a.bsearch {|element| 5 <=> element } # => nil
   a.bsearch {|element| 15 <=> element } # => nil
+  a.bsearch { 0 } # => 0
+  a.bsearch(target: :last) { 0 } # => 12
 
   a = [0, 100, 100, 100, 200]
   r = (0..4)
@@ -107,7 +133,7 @@ Examples:
   r.bsearch {|i| 300 - a[i] } #=> nil
   r.bsearch {|i|  50 - a[i] } #=> nil
 
-These blocks make sense in find-any mode:
+These blocks make sense in find-by-number mode:
 
   a = [0, 4, 7, 10, 12]
   a.map {|element| 7 <=> element } # => [1, 1, 0, -1, -1]

--- a/range.c
+++ b/range.c
@@ -684,9 +684,14 @@ static VALUE bsearch_impl(int argc, VALUE *argv, VALUE range, int is_target_firs
 
 /*
  *  call-seq:
- *     bsearch(target: :first) {|obj| block }  -> value
+ *    bsearch(target: :first) {|obj| block }  -> value
+ *    bsearch(target: :first)                 -> enumerator
  *
  *  Returns an element from +self+ selected by a binary search.
+ *
+ *    r = 1..10
+ *    r.bsearch {|x| x ** 2 >= 10 } # => 4
+ *    r.bsearch(target: :last) {|x| x ** 2 <= 10 } # => 3
  *
  *  See {Binary Searching}[rdoc-ref:bsearch.rdoc].
  *

--- a/range.c
+++ b/range.c
@@ -769,7 +769,7 @@ bsearch_impl(int argc, VALUE *argv, VALUE range, int is_target_first)
         low--; \
         while (low + 1 < high) { \
             mid = ((high < 0) == (low < 0)) ? low + ((high - low) / 2) \
-                : (low < -high) ? -((-1 - low - high)/2 + 1) : (low + high) / 2; \
+                : (low + high) / 2; \
             BSEARCH_CHECK(conv(mid), is_target_first); \
             if (smaller) { \
                 high = mid; \

--- a/range.c
+++ b/range.c
@@ -710,7 +710,6 @@ range_bsearch(int argc, VALUE *argv, VALUE range)
 
     static ID keyword_ids[1];
     VALUE target;
-    ID target_id;
 
     if (!keyword_ids[0]) {
         keyword_ids[0] = rb_intern_const("target");
@@ -718,21 +717,16 @@ range_bsearch(int argc, VALUE *argv, VALUE range)
 
     rb_get_kwargs(opt, keyword_ids, 0, 1, &target);
 
-    if (!SYMBOL_P(target)) {
-        goto invalid_target;
-    }
-
-    target_id = SYM2ID(target);
-
-    if (target_id == rb_intern("first")) {
+    if (target == ID2SYM(rb_intern("first"))) {
         return bsearch_impl(argc, argv, range, true);
     }
-    else if (target_id == rb_intern("last")) {
+    else if (target == ID2SYM(rb_intern("last"))) {
         return bsearch_impl(argc, argv, range, false);
     }
-
-  invalid_target:
-    rb_raise(rb_eArgError, "target must be :first or :last");
+    else {
+        rb_raise(rb_eArgError, "target must be :first or :last");
+        UNREACHABLE_RETURN(Qnil);
+    }
 }
 
 static VALUE

--- a/test/ruby/test_array.rb
+++ b/test/ruby/test_array.rb
@@ -3311,34 +3311,75 @@ class TestArray < Test::Unit::TestCase
     assert_equal [1, 2, 42, 100, 666].bsearch{}, [1, 2, 42, 100, 666].bsearch{false}
   end
 
+  def test_bsearch_target_value
+    assert_nothing_raised do
+      [1, 2, 3].bsearch { true }
+    end
+
+    assert_nothing_raised do
+      [1, 2, 3].bsearch(target: :first) { true }
+    end
+
+    assert_nothing_raised do
+      [1, 2, 3].bsearch(target: :last) { true }
+    end
+
+    assert_raise(ArgumentError) do
+      [1, 2, 3].bsearch(target: nil) { true }
+    end
+
+    assert_raise(ArgumentError) do
+      [1, 2, 3].bsearch(target: 'first') { true }
+    end
+
+    assert_raise(ArgumentError) do
+      [1, 2, 3].bsearch(target: :invalid) { true }
+    end
+  end
+
   def test_bsearch_with_no_block
     enum = [1, 2, 42, 100, 666].bsearch
     assert_nil enum.size
     assert_equal 42, enum.each{|x| x >= 33 }
   end
 
-  def test_bsearch_in_find_minimum_mode
+  def test_bsearch_in_find_by_boolean_mode
     a = [0, 4, 7, 10, 12]
     assert_equal(4, a.bsearch {|x| x >=   4 })
     assert_equal(7, a.bsearch {|x| x >=   6 })
     assert_equal(0, a.bsearch {|x| x >=  -1 })
     assert_equal(nil, a.bsearch {|x| x >= 100 })
+    assert_equal(nil, a.bsearch {|x| nil })
+
+    assert_equal(nil, [].bsearch {|x| x < 0 })
   end
 
-  def test_bsearch_in_find_any_mode
+  def test_bsearch_first_in_find_by_boolean_mode
     a = [0, 4, 7, 10, 12]
-    assert_include([4, 7], a.bsearch {|x| 1 - x / 4 })
+    [-1, 3, 5, 8, 11, 15].each do |search|
+      assert_equal(
+        a.bsearch {|x| x >= search },
+        a.bsearch(target: :first) {|x| x >= search }
+      )
+    end
+  end
+
+  def test_bsearch_in_find_by_number_mode
+    a = [0, 4, 7, 10, 12]
+    assert_equal(4, a.bsearch {|x| 1 - x / 4 })
     assert_equal(nil, a.bsearch {|x| 4 - x / 2 })
     assert_equal(nil, a.bsearch {|x| 1 })
     assert_equal(nil, a.bsearch {|x| -1 })
+    assert_equal(0, a.bsearch{|x| 0 })
 
-    assert_include([4, 7], a.bsearch {|x| (1 - x / 4) * (2**100) })
+    assert_equal(4, a.bsearch {|x| (1 - x / 4) * (2**100) })
     assert_equal(nil, a.bsearch {|x|   1  * (2**100) })
     assert_equal(nil, a.bsearch {|x| (-1) * (2**100) })
 
     assert_equal(4, a.bsearch {|x| (4 - x).to_r })
+    assert_equal(10, a.bsearch {|x| (10 - x).to_r })
 
-    assert_include([4, 7], a.bsearch {|x| (2**100).coerce((1 - x / 4) * (2**100)).first })
+    assert_equal(4, a.bsearch {|x| (2**100).coerce((1 - x / 4) * (2**100)).first })
   end
 
   def test_bsearch_index_typechecks_return_values
@@ -3348,13 +3389,39 @@ class TestArray < Test::Unit::TestCase
     assert_equal [1, 2, 42, 100, 666].bsearch_index {}, [1, 2, 42, 100, 666].bsearch_index {false}
   end
 
+  def test_bsearch_index_target_value
+    assert_nothing_raised do
+      [1, 2, 3].bsearch_index { true }
+    end
+
+    assert_nothing_raised do
+      [1, 2, 3].bsearch_index(target: :first) { true }
+    end
+
+    assert_nothing_raised do
+      [1, 2, 3].bsearch_index(target: :last) { true }
+    end
+
+    assert_raise(ArgumentError) do
+      [1, 2, 3].bsearch_index(target: nil) { true }
+    end
+
+    assert_raise(ArgumentError) do
+      [1, 2, 3].bsearch_index(target: 'first') { true }
+    end
+
+    assert_raise(ArgumentError) do
+      [1, 2, 3].bsearch_index(target: :invalid) { true }
+    end
+  end
+
   def test_bsearch_index_with_no_block
     enum = [1, 2, 42, 100, 666].bsearch_index
     assert_nil enum.size
     assert_equal 2, enum.each{|x| x >= 33 }
   end
 
-  def test_bsearch_index_in_find_minimum_mode
+  def test_bsearch_index_in_find_by_boolean_mode
     a = [0, 4, 7, 10, 12]
     assert_equal(1, a.bsearch_index {|x| x >=   4 })
     assert_equal(2, a.bsearch_index {|x| x >=   6 })
@@ -3362,20 +3429,101 @@ class TestArray < Test::Unit::TestCase
     assert_equal(nil, a.bsearch_index {|x| x >= 100 })
   end
 
-  def test_bsearch_index_in_find_any_mode
+  def test_bsearch_index_in_find_by_number_mode
     a = [0, 4, 7, 10, 12]
-    assert_include([1, 2], a.bsearch_index {|x| 1 - x / 4 })
+    assert_equal(1, a.bsearch_index {|x| 1 - x / 4 })
     assert_equal(nil, a.bsearch_index {|x| 4 - x / 2 })
     assert_equal(nil, a.bsearch_index {|x| 1 })
     assert_equal(nil, a.bsearch_index {|x| -1 })
+    assert_equal(0, a.bsearch_index {|x| 0 })
 
-    assert_include([1, 2], a.bsearch_index {|x| (1 - x / 4) * (2**100) })
+    assert_equal(1, a.bsearch_index {|x| (1 - x / 4) * (2**100) })
     assert_equal(nil, a.bsearch_index {|x|   1  * (2**100) })
     assert_equal(nil, a.bsearch_index {|x| (-1) * (2**100) })
 
     assert_equal(1, a.bsearch_index {|x| (4 - x).to_r })
+    assert_equal(3, a.bsearch_index {|x| (10 - x).to_r })
 
-    assert_include([1, 2], a.bsearch_index {|x| (2**100).coerce((1 - x / 4) * (2**100)).first })
+    assert_equal(1, a.bsearch_index {|x| (2**100).coerce((1 - x / 4) * (2**100)).first })
+  end
+
+  def test_bsearch_index_last_in_find_by_boolean_mode
+    a = [0, 4, 7, 10, 12]
+    assert_equal(nil, a.bsearch_index(target: :last) {|x| x <= -1 })
+    assert_equal(1, a.bsearch_index(target: :last) {|x| x <= 4 })
+    assert_equal(2, a.bsearch_index(target: :last) {|x| x <= 9 })
+    assert_equal(4, a.bsearch_index(target: :last) {|x| x <= 100 })
+
+    assert_equal(nil, [].bsearch_index(target: :last) {|x| false })
+    assert_equal(nil, [].bsearch_index(target: :last) {|x| true })
+    assert_equal(nil, [1].bsearch_index(target: :last) {|x| false })
+    assert_equal(0, [1].bsearch_index(target: :last) {|x| true })
+  end
+
+  def test_bsearch_index_last_in_find_by_number_mode
+    a = [0, 4, 7, 10, 12]
+    assert_equal(2, a.bsearch_index(target: :last) {|x| 1 - x / 4 })
+    assert_equal(nil, a.bsearch_index(target: :last) {|x| 4 - x / 2 })
+    assert_equal(nil, a.bsearch_index(target: :last) {|x| 1 })
+    assert_equal(nil, a.bsearch_index(target: :last) {|x| -1 })
+    assert_equal(4, a.bsearch_index(target: :last) {|x| 0 })
+
+    assert_equal(2, a.bsearch_index(target: :last) {|x| (1 - x / 4) * (2**100) })
+    assert_equal(nil, a.bsearch_index(target: :last) {|x|   1  * (2**100) })
+    assert_equal(nil, a.bsearch_index(target: :last) {|x| (-1) * (2**100) })
+
+    assert_equal(2, a.bsearch_index(target: :last) {|x| (2**100).coerce((1 - x / 4) * (2**100)).first })
+  end
+
+  def test_bsearch_index_last_with_no_block
+    enum = [1, 2, 42, 100, 666].bsearch_index(target: :last)
+    assert_nil enum.size
+    assert_equal 1, enum.each{|x| x <= 33 }
+  end
+
+  def test_bsearch_last_index_typechecks_return_values
+    assert_raise(TypeError) do
+      [1, 2, 42, 100, 666].bsearch_index(target: :last) {"not ok"}
+    end
+    assert_equal [1, 2, 42, 100, 666].bsearch_index(target: :last) {}, [1, 2, 42, 100, 666].bsearch_index(target: :last) {false}
+  end
+
+  def test_bsearch_last_in_find_by_boolean_mode
+    a = [0, 4, 7, 10, 12]
+    assert_equal(nil, a.bsearch(target: :last) {|x| x <= -1 })
+    assert_equal(4, a.bsearch(target: :last) {|x| x <= 4 })
+    assert_equal(7, a.bsearch(target: :last) {|x| x <= 9 })
+    assert_equal(12, a.bsearch(target: :last) {|x| x <= 100 })
+
+    assert_equal(nil, [].bsearch(target: :last) {|x| x < 0 })
+  end
+
+  def test_bsearch_last_in_find_by_number_mode
+    a = [0, 4, 7, 10, 12]
+    assert_equal(7, a.bsearch(target: :last) {|x| 1 - x / 4 })
+    assert_equal(nil, a.bsearch(target: :last) {|x| 4 - x / 2 })
+    assert_equal(nil, a.bsearch(target: :last) {|x| 1 })
+    assert_equal(nil, a.bsearch(target: :last) {|x| -1 })
+    assert_equal(12, a.bsearch(target: :last) {|x| 0 })
+
+    assert_equal(7, a.bsearch(target: :last) {|x| (1 - x / 4) * (2**100) })
+    assert_equal(nil, a.bsearch(target: :last) {|x|   1  * (2**100) })
+    assert_equal(nil, a.bsearch(target: :last) {|x| (-1) * (2**100) })
+
+    assert_equal(7, a.bsearch(target: :last) {|x| (2**100).coerce((1 - x / 4) * (2**100)).first })
+  end
+
+  def test_bsearch_last_with_no_block
+    enum = [1, 10, 42, 100, 666].bsearch(target: :last)
+    assert_nil enum.size
+    assert_equal 10, enum.each{|x| x <= 33 }
+  end
+
+  def test_bsearch_last_typechecks_return_values
+    assert_raise(TypeError) do
+      [1, 2, 42, 100, 666].bsearch(target: :last) {"not ok"}
+    end
+    assert_equal [1, 2, 42, 100, 666].bsearch(target: :last) {}, [1, 2, 42, 100, 666].bsearch(target: :last) {false}
   end
 
   def test_shared_marking


### PR DESCRIPTION
related issue: https://bugs.ruby-lang.org/issues/19075

This pull request implements the option (3) in the above issue.

* `bsearch` and `bsearch_index` take the argument `target`, whose possible values are `:first` or `:last`.
* find-by-number mode (former find-any mode) returns the first (or last) element for which the block returns zero.
* find-any mode has been renamed to find-by-number mode.
* find-minimum mode has been renamed to find-by-boolean mode.

```
a = [2, 3, 5, 7, 11]
a.bsearch {|x| x >= 6 } # => 7
a.bsearch(target: :first) {|x| x >= 6 } # same as a.bsearch { ... }
a.bsearch(target: :last) {|x| x <= 6 } # => 5
a.bsearch(target: :first) {|x| 0 } # => 2
a.bsearch(target: :last) {|x| 0 } # => 11
```
