### PR TITLE
Don't pin the VM's signal trap list

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -6331,16 +6331,6 @@ rb_gc_mark_locations(const VALUE *start, const VALUE *end)
     gc_mark_locations(&rb_objspace, start, end, gc_mark_maybe);
 }
 
-static void
-gc_mark_values(rb_objspace_t *objspace, long n, const VALUE *values)
-{
-    long i;
-
-    for (i=0; i<n; i++) {
-        gc_mark(objspace, values[i]);
-    }
-}
-
 void
 rb_gc_mark_values(long n, const VALUE *values)
 {
@@ -6953,7 +6943,7 @@ gc_mark_imemo(rb_objspace_t *objspace, VALUE obj)
                 // just after newobj() can be NULL here.
                 GC_ASSERT(env->ep[VM_ENV_DATA_INDEX_ENV] == obj);
                 GC_ASSERT(VM_ENV_ESCAPED_P(env->ep));
-                gc_mark_values(objspace, (long)env->env_size, env->env);
+                rb_gc_mark_values((long)env->env_size, env->env);
                 VM_ENV_FLAGS_SET(env->ep, VM_ENV_FLAG_WB_REQUIRED);
                 gc_mark(objspace, (VALUE)rb_vm_env_prev_env(env));
                 gc_mark(objspace, (VALUE)env->iseq);

--- a/gc.c
+++ b/gc.c
@@ -6348,7 +6348,7 @@ rb_gc_mark_values(long n, const VALUE *values)
     rb_objspace_t *objspace = &rb_objspace;
 
     for (i=0; i<n; i++) {
-        gc_mark_and_pin(objspace, values[i]);
+        gc_mark(objspace, values[i]);
     }
 }
 
@@ -10133,6 +10133,12 @@ gc_update_values(rb_objspace_t *objspace, long n, VALUE *values)
     for (i=0; i<n; i++) {
         UPDATE_IF_MOVED(objspace, values[i]);
     }
+}
+
+void
+rb_gc_update_values(long n, VALUE *values)
+{
+    gc_update_values(&rb_objspace, n, values);
 }
 
 static bool

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -274,6 +274,7 @@ void rb_gc_verify_internal_consistency(void);
 size_t rb_obj_gc_flags(VALUE, ID[], size_t);
 void rb_gc_mark_values(long n, const VALUE *values);
 void rb_gc_mark_vm_stack_values(long n, const VALUE *values);
+void rb_gc_update_values(long n, VALUE *values);
 void *ruby_sized_xrealloc(void *ptr, size_t new_size, size_t old_size) RUBY_ATTR_RETURNS_NONNULL RUBY_ATTR_ALLOC_SIZE((2));
 void *ruby_sized_xrealloc2(void *ptr, size_t new_count, size_t element_size, size_t old_count) RUBY_ATTR_RETURNS_NONNULL RUBY_ATTR_ALLOC_SIZE((2, 3));
 void ruby_sized_xfree(void *x, size_t size);

--- a/vm.c
+++ b/vm.c
@@ -2743,6 +2743,8 @@ rb_vm_update_references(void *ptr)
 
         rb_gc_update_tbl_refs(vm->overloaded_cme_table);
 
+        rb_gc_update_values(RUBY_NSIG, vm->trap_list.cmd);
+
         if (vm->coverages) {
             vm->coverages = rb_gc_location(vm->coverages);
             vm->me2counter = rb_gc_location(vm->me2counter);


### PR DESCRIPTION
Previously there existed two functions

- `void rb_gc_mark_values`
- `static void gc_mark_values`

The difference between them was that `rb_gc_mark_values` pinned each value and `gc_mark_values` did not.

`rb_gc_mark_values` was used inside `rb_vm_mark` to mark and pin the list of code to run when trapping various signals. This is why it was not declared `static`, as it has to be used from `vm.c`.

There is no obvious reason why the `trap_list.cmd` array needs it's entries pinned. So this commit introduces `rb_gc_update_values` alongside `rb_gc_mark_values` so that we can update the `trap_list` references. This change allows us to refactor `rb_gc_mark_values` so that it no longer pins the values.

This refactor means that `rb_gc_mark_values` and `gc_mark_values` become identical. So we can delete `gc_mark_values`