### PR TITLE
[Bug #19281] Allow semicolon in parenthesis at the first argument of command call

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -3348,14 +3348,7 @@ primary		: literal
                     /*% %*/
                     /*% ripper: begin!($3) %*/
                     }
-                | tLPAREN_ARG {SET_LEX_STATE(EXPR_ENDARG);} rparen
-                    {
-                    /*%%%*/
-                        $$ = NEW_BEGIN(0, &@$);
-                    /*% %*/
-                    /*% ripper: paren!(0) %*/
-                    }
-                | tLPAREN_ARG stmt {SET_LEX_STATE(EXPR_ENDARG);} rparen
+                | tLPAREN_ARG compstmt {SET_LEX_STATE(EXPR_ENDARG);} ')'
                     {
                     /*%%%*/
                         if (nd_type_p($2, NODE_SELF)) $2->nd_state = 0;

--- a/test/ruby/test_syntax.rb
+++ b/test/ruby/test_syntax.rb
@@ -1642,6 +1642,21 @@ eom
     assert_valid_syntax('obj::foo (1) {}')
   end
 
+  def test_command_newline_in_tlparen_args
+    assert_valid_syntax("p (1\n2\n),(3),(4)")
+    assert_valid_syntax("p (\n),(),()")
+    assert_valid_syntax("a.b (1\n2\n),(3),(4)")
+    assert_valid_syntax("a.b (\n),(),()")
+  end
+
+  def test_command_semicolon_in_tlparen_at_the_first_arg
+    bug19281 = '[ruby-core:111499] [Bug #19281]'
+    assert_valid_syntax('p (1;2),(3),(4)', bug19281)
+    assert_valid_syntax('p (;),(),()', bug19281)
+    assert_valid_syntax('a.b (1;2),(3),(4)', bug19281)
+    assert_valid_syntax('a.b (;),(),()', bug19281)
+  end
+
   def test_numbered_parameter
     assert_valid_syntax('proc {_1}')
     assert_equal(3, eval('[1,2].then {_1+_2}'))


### PR DESCRIPTION
Allow compstmt in the first argument of command call wrapped with parenthesis like following arguments with parenthesis.

https://bugs.ruby-lang.org/issues/19281