### PR TITLE
[YARP] Implement Compiling for And / Or / Operator Write Nodes

### DIFF
--- a/test/yarp/compiler_test.rb
+++ b/test/yarp/compiler_test.rb
@@ -81,6 +81,19 @@ module YARP
       assert_equal 1, compile("class YARP::CompilerTest; @@yct = 1; end")
     end
 
+    def test_ClassVariableAndWriteNode
+      assert_equal 1, compile("class YARP::CompilerTest; @@yct = 0; @@yct &&= 1; end")
+    end
+
+    def test_ClassVariableOrWriteNode
+      assert_equal 1, compile("class YARP::CompilerTest; @@yct = 1; @@yct ||= 0; end")
+      assert_equal 1, compile("class YARP::CompilerTest; @@yct = nil; @@yct ||= 1; end")
+    end
+
+    def test_ClassVariableOperatorWriteNode
+      assert_equal 1, compile("class YARP::CompilerTest; @@yct = 0; @@yct += 1; end")
+    end
+
     def test_ConstantWriteNode
       assert_equal 1, compile("YCT = 1")
     end
@@ -93,12 +106,48 @@ module YARP
       assert_equal 1, compile("$yct = 1")
     end
 
+    def test_GlobalVariableAndWriteNode
+      assert_equal 1, compile("$yct = 0; $yct &&= 1")
+    end
+
+    def test_GlobalVariableOrWriteNode
+      assert_equal 1, compile("$yct ||= 1")
+    end
+
+    def test_GlobalVariableOperatorWriteNode
+      assert_equal 1, compile("$yct = 0; $yct += 1")
+    end
+
     def test_InstanceVariableWriteNode
       assert_equal 1, compile("class YARP::CompilerTest; @yct = 1; end")
     end
 
+    def test_InstanceVariableAndWriteNode
+      assert_equal 1, compile("@yct = 0; @yct &&= 1")
+    end
+
+    def test_InstanceVariableOrWriteNode
+      assert_equal 1, compile("@yct ||= 1")
+    end
+
+    def test_InstanceVariableOperatorWriteNode
+      assert_equal 1, compile("@yct = 0; @yct += 1")
+    end
+
     def test_LocalVariableWriteNode
       assert_equal 1, compile("yct = 1")
+    end
+
+    def test_LocalVariableAndWriteNode
+      assert_equal 1, compile("yct = 0; yct &&= 1")
+    end
+
+    def test_LocalVariableOrWriteNode
+      assert_equal 1, compile("yct ||= 1")
+    end
+
+    def test_LocalVariableOperatorWriteNode
+      assert_equal 1, compile("yct = 0; yct += 1")
     end
 
     ############################################################################

--- a/yarp/yarp_compiler.c
+++ b/yarp/yarp_compiler.c
@@ -614,7 +614,6 @@ yp_compile_node(rb_iseq_t *iseq, const yp_node_t *node, LINK_ANCHOR *const ret, 
       case YP_NODE_CLASS_VARIABLE_AND_WRITE_NODE: {
           yp_class_variable_and_write_node_t *class_variable_and_write_node = (yp_class_variable_and_write_node_t*) node;
 
-          LABEL *set_label= NEW_LABEL(lineno);
           LABEL *end_label = NEW_LABEL(lineno);
 
           ID class_variable_name_id = compile_context->constants[class_variable_and_write_node->name - 1];
@@ -634,7 +633,6 @@ yp_compile_node(rb_iseq_t *iseq, const yp_node_t *node, LINK_ANCHOR *const ret, 
               ADD_INSN(ret, &dummy_line_node, pop);
           }
 
-          ADD_LABEL(ret, set_label);
           yp_compile_node(iseq, class_variable_and_write_node->value, ret, src, false, compile_context);
 
           if (!popped) {
@@ -872,7 +870,6 @@ yp_compile_node(rb_iseq_t *iseq, const yp_node_t *node, LINK_ANCHOR *const ret, 
       case YP_NODE_GLOBAL_VARIABLE_AND_WRITE_NODE: {
           yp_global_variable_and_write_node_t *global_variable_and_write_node = (yp_global_variable_and_write_node_t*) node;
 
-          LABEL *set_label= NEW_LABEL(lineno);
           LABEL *end_label = NEW_LABEL(lineno);
 
           VALUE global_variable_name = ID2SYM(parse_location_symbol(&global_variable_and_write_node->name_loc));
@@ -888,7 +885,6 @@ yp_compile_node(rb_iseq_t *iseq, const yp_node_t *node, LINK_ANCHOR *const ret, 
               ADD_INSN(ret, &dummy_line_node, pop);
           }
 
-          ADD_LABEL(ret, set_label);
           yp_compile_node(iseq, global_variable_and_write_node->value, ret, src, false, compile_context);
 
           if (!popped) {
@@ -1022,7 +1018,6 @@ yp_compile_node(rb_iseq_t *iseq, const yp_node_t *node, LINK_ANCHOR *const ret, 
       case YP_NODE_INSTANCE_VARIABLE_AND_WRITE_NODE: {
           yp_instance_variable_and_write_node_t *instance_variable_and_write_node = (yp_instance_variable_and_write_node_t*) node;
 
-          LABEL *set_label= NEW_LABEL(lineno);
           LABEL *end_label = NEW_LABEL(lineno);
 
           ID instance_variable_name_id = compile_context->constants[instance_variable_and_write_node->name - 1];
@@ -1042,7 +1037,6 @@ yp_compile_node(rb_iseq_t *iseq, const yp_node_t *node, LINK_ANCHOR *const ret, 
               ADD_INSN(ret, &dummy_line_node, pop);
           }
 
-          ADD_LABEL(ret, set_label);
           yp_compile_node(iseq, instance_variable_and_write_node->value, ret, src, false, compile_context);
 
           if (!popped) {
@@ -1237,7 +1231,6 @@ yp_compile_node(rb_iseq_t *iseq, const yp_node_t *node, LINK_ANCHOR *const ret, 
       case YP_NODE_LOCAL_VARIABLE_AND_WRITE_NODE: {
           yp_local_variable_and_write_node_t *local_variable_and_write_node = (yp_local_variable_and_write_node_t*) node;
 
-          LABEL *set_label= NEW_LABEL(lineno);
           LABEL *end_label = NEW_LABEL(lineno);
 
           yp_constant_id_t constant_id = local_variable_and_write_node->name;
@@ -1255,7 +1248,6 @@ yp_compile_node(rb_iseq_t *iseq, const yp_node_t *node, LINK_ANCHOR *const ret, 
               ADD_INSN(ret, &dummy_line_node, pop);
           }
 
-          ADD_LABEL(ret, set_label);
           yp_compile_node(iseq, local_variable_and_write_node->value, ret, src, false, compile_context);
 
           if (!popped) {

--- a/yarp/yarp_compiler.c
+++ b/yarp/yarp_compiler.c
@@ -986,8 +986,8 @@ yp_compile_node(rb_iseq_t *iseq, const yp_node_t *node, LINK_ANCHOR *const ret, 
       case YP_NODE_LOCAL_VARIABLE_READ_NODE: {
           yp_local_variable_read_node_t *local_read_node = (yp_local_variable_read_node_t *) node;
 
-          int index = yp_lookup_local_index(iseq, compile_context, local_read_node->name);
           if (!popped) {
+              int index = yp_lookup_local_index(iseq, compile_context, local_read_node->name);
               ADD_GETLOCAL(ret, &dummy_line_node, index, local_read_node->depth);
           }
           return;

--- a/yarp/yarp_compiler.c
+++ b/yarp/yarp_compiler.c
@@ -875,8 +875,8 @@ yp_compile_node(rb_iseq_t *iseq, const yp_node_t *node, LINK_ANCHOR *const ret, 
           LABEL *set_label= NEW_LABEL(lineno);
           LABEL *end_label = NEW_LABEL(lineno);
 
-          ID global_variable_name = parse_location_symbol(&global_variable_and_write_node->name_loc);
-          ADD_INSN1(ret, &dummy_line_node, getglobal, ID2SYM(global_variable_name));
+          VALUE global_variable_name = ID2SYM(parse_location_symbol(&global_variable_and_write_node->name_loc));
+          ADD_INSN1(ret, &dummy_line_node, getglobal, global_variable_name);
 
           if (!popped) {
               ADD_INSN(ret, &dummy_line_node, dup);
@@ -895,7 +895,7 @@ yp_compile_node(rb_iseq_t *iseq, const yp_node_t *node, LINK_ANCHOR *const ret, 
               ADD_INSN(ret, &dummy_line_node, dup);
           }
 
-          ADD_INSN1(ret, &dummy_line_node, setglobal, ID2SYM(global_variable_name));
+          ADD_INSN1(ret, &dummy_line_node, setglobal, global_variable_name);
           ADD_LABEL(ret, end_label);
 
           return;


### PR DESCRIPTION
This PR implements compilation for the following nodes:
- ClassVariableAndWriteNode
- ClassVariableOperatorWriteNode
- ClassVariableOrWriteNode
- GlobalVariableAndWriteNode
- GlobalVariableOperatorWriteNode
- GlobalVariableOrWriteNode
- InstanceVariableAndWriteNode
- InstanceVariableOperatorWriteNode
- InstanceVariableOrWriteNode
- LocalVariableAndWriteNode
- LocalVariableOperatorWriteNode
- LocalVariableOrWriteNode