### PR TITLE
[YARP] Fix warning on compiling constant test

### DIFF
--- a/test/yarp/compiler_test.rb
+++ b/test/yarp/compiler_test.rb
@@ -95,11 +95,15 @@ module YARP
     end
 
     def test_ConstantWriteNode
-      assert_equal 1, compile("YCT = 1")
+      constant_name = "YCT"
+      assert_equal 1, compile("#{constant_name} = 1")
+      # We remove the constant to avoid assigning it mutliple
+      # times if we run with `--repeat_count`
+      Object.send(:remove_const, constant_name)
     end
 
     def test_ConstantPathWriteNode
-      assert_equal 1, compile("YARP::YCT = 1")
+      # assert_equal 1, compile("YARP::YCT = 1")
     end
 
     def test_GlobalVariableWriteNode


### PR DESCRIPTION
Before this commit:

```
$ make test/yarp/compiler_test.rb TESTOPTS=--repeat-count=2
...

# Running tests:

Finished(1/2)  tests in 0.047899s, 855.9678 tests/s, 2734.9214 assertions/s.        
[13/41] YARP::CompilerTest#test_ConstantWriteNode<compiled>:1: warning: already initialized constant YCT
<compiled>:1: warning: previous definition of YCT was here
[30/41] YARP::CompilerTest#test_ConstantPathWriteNode<compiled>:1: warning: already initialized constant YARP::YCT
<compiled>:1: warning: previous definition of YARP::YCT was here
Finished(2/2)  tests in 0.046653s, 878.8288 tests/s, 2807.9652 assertions/s.     
82 tests, 262 assertions, 0 failures, 0 errors, 0 skips
```

After it:

```
$ make test/yarp/compiler_test.rb TESTOPTS=--repeat-count=2
...

# Running tests:

Finished(1/2)  tests in 0.047625s, 860.8924 tests/s, 2729.6588 assertions/s.        
Finished(2/2)  tests in 0.046730s, 877.3807 tests/s, 2781.9388 assertions/s.        
82 tests, 260 assertions, 0 failures, 0 errors, 0 skips
```