### PR TITLE
YJIT: Make compiled_* stats available by default

### DIFF
--- a/yjit/src/asm/mod.rs
+++ b/yjit/src/asm/mod.rs
@@ -6,6 +6,7 @@ use crate::core::IseqPayload;
 use crate::core::for_each_off_stack_iseq_payload;
 use crate::core::for_each_on_stack_iseq_payload;
 use crate::invariants::rb_yjit_tracing_invalidate_all;
+use crate::stats::incr_counter;
 use crate::virtualmem::WriteError;
 
 #[cfg(feature = "disasm")]
@@ -652,7 +653,7 @@ impl CodeBlock {
         ocb.unwrap().freed_pages = new_freed_pages;
         assert_eq!(1, Rc::strong_count(&old_freed_pages)); // will deallocate
 
-        CodegenGlobals::incr_code_gc_count();
+        incr_counter!(code_gc_count);
     }
 
     pub fn inline(&self) -> bool {

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -249,7 +249,7 @@ pub enum JCCKinds {
 
 #[inline(always)]
 fn gen_counter_incr(asm: &mut Assembler, counter: Counter) {
-    // Assert that default counters do not require --yjit-stats
+    // Assert that default counters are not incremented by generated code as this would impact performance
     assert!(!DEFAULT_COUNTERS.contains(&counter), "gen_counter_incr incremented {:?}", counter);
 
     if get_option!(gen_stats) {

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -249,6 +249,9 @@ pub enum JCCKinds {
 
 #[inline(always)]
 fn gen_counter_incr(asm: &mut Assembler, counter: Counter) {
+    // Assert that default counters do not require --yjit-stats
+    assert!(!DEFAULT_COUNTERS.contains(&counter), "gen_counter_incr incremented {:?}", counter);
+
     if get_option!(gen_stats) {
         asm.comment(&format!("increment counter {}", counter.get_name()));
         let ptr = get_counter_ptr(&counter.get_name());
@@ -8581,9 +8584,6 @@ pub struct CodegenGlobals {
 
     /// Page indexes for outlined code that are not associated to any ISEQ.
     ocb_pages: Vec<usize>,
-
-    /// How many times code GC has been executed.
-    code_gc_count: usize,
 }
 
 /// For implementing global code invalidation. A position in the inline
@@ -8679,7 +8679,6 @@ impl CodegenGlobals {
             global_inval_patches: Vec::new(),
             method_codegen_table: HashMap::new(),
             ocb_pages,
-            code_gc_count: 0,
         };
 
         // Register the method codegen functions
@@ -8840,14 +8839,6 @@ impl CodegenGlobals {
 
     pub fn get_ocb_pages() -> &'static Vec<usize> {
         &CodegenGlobals::get_instance().ocb_pages
-    }
-
-    pub fn incr_code_gc_count() {
-        CodegenGlobals::get_instance().code_gc_count += 1;
-    }
-
-    pub fn get_code_gc_count() -> usize {
-        CodegenGlobals::get_instance().code_gc_count
     }
 }
 

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -163,6 +163,17 @@ macro_rules! make_counters {
     }
 }
 
+/// The list of counters that are available without --yjit-stats.
+/// They are incremented only by `incr_counter!` and don't use `gen_counter_incr`.
+pub const DEFAULT_COUNTERS: [Counter; 6] = [
+    Counter::code_gc_count,
+    Counter::compiled_iseq_entry,
+    Counter::compiled_iseq_count,
+    Counter::compiled_blockid_count,
+    Counter::compiled_block_count,
+    Counter::compiled_branch_count,
+];
+
 /// Macro to increase a counter by name and count
 macro_rules! incr_counter_by {
     // Unsafe is ok here because options are initialized
@@ -424,6 +435,8 @@ make_counters! {
     // executable memory, so this should be 0.
     exec_mem_non_bump_alloc,
 
+    code_gc_count,
+
     num_gc_obj_refs,
 
     num_send,
@@ -571,9 +584,6 @@ fn rb_yjit_gen_stats_dict(context: bool) -> VALUE {
         // Live pages
         hash_aset_usize!(hash, "live_page_count", cb.num_mapped_pages() - freed_page_count);
 
-        // Code GC count
-        hash_aset_usize!(hash, "code_gc_count", CodegenGlobals::get_code_gc_count());
-
         // Size of memory region allocated for JIT code
         hash_aset_usize!(hash, "code_region_size", cb.mapped_region_size());
 
@@ -594,13 +604,23 @@ fn rb_yjit_gen_stats_dict(context: bool) -> VALUE {
         hash_aset_usize!(hash, "vm_insns_count", rb_vm_insns_count as usize);
     }
 
-    // If we're not generating stats, the hash is done
+    // If we're not generating stats, put only default counters
     if !get_option!(gen_stats) {
+        for counter in DEFAULT_COUNTERS {
+            // Get the counter value
+            let counter_ptr = get_counter_ptr(&counter.get_name());
+            let counter_val = unsafe { *counter_ptr };
+
+            // Put counter into hash
+            let key = rust_str_to_sym(&counter.get_name());
+            let value = VALUE::fixnum_from_usize(counter_val as usize);
+            unsafe { rb_hash_aset(hash, key, value); }
+        }
+
         return hash;
     }
 
     // If the stats feature is enabled
-
     unsafe {
         // Indicate that the complete set of stats is available
         rb_hash_aset(hash, rust_str_to_sym("all_stats"), Qtrue);


### PR DESCRIPTION
This PR introduces `DEFAULT_COUNTERS` that makes the counters available in `RubyVM::YJIT.runtime_stats` without `--yjit-stats`. I want to monitor `compiled_*` stats among different Ruby revisions, and I don't have enough clusters to accommodate `--yjit-stats` versions besides them. So I want to make them available without `--yjit-stats`.

It also leverages this constant to refactor `code_gc_count` as discussed in https://github.com/ruby/ruby/pull/6665#discussion_r1013224734.