### PR TITLE
memory_view: Avoid using bit field

### DIFF
--- a/include/ruby/memory_view.h
+++ b/include/ruby/memory_view.h
@@ -47,10 +47,10 @@ typedef struct {
     char format;
 
     /** :FIXME: what is a "native" size is unclear. */
-    unsigned native_size_p: 1;
+    bool native_size_p;
 
     /** Endian of the component */
-    unsigned little_endian_p: 1;
+    bool little_endian_p;
 
     /** The component's offset. */
     size_t offset;


### PR DESCRIPTION
Bit field's memory layout is implementation-defined.

See also:
https://wiki.sei.cmu.edu/confluence/display/c/EXP11-C.+Do+not+make+assumptions+regarding+the+layout+of+structures+with+bit-fields

If memory layout is implementation-defined, it's difficult to use from FFI library such as Ruby-FFI.