### PR TITLE
Rewrite Integer#times in Ruby

### DIFF
--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -19,5 +19,5 @@ matrix          0.4.2   https://github.com/ruby/matrix
 prime           0.1.2   https://github.com/ruby/prime
 rbs             3.2.1   https://github.com/ruby/rbs
 typeprof        0.21.8  https://github.com/ruby/typeprof
-debug           1.8.0   https://github.com/ruby/debug
+debug           1.8.0   https://github.com/ruby/debug 927587afb6aac69b358b86a01f602d207053e8d2
 racc            1.7.1   https://github.com/ruby/racc

--- a/numeric.c
+++ b/numeric.c
@@ -5652,58 +5652,6 @@ int_downto(VALUE from, VALUE to)
     return from;
 }
 
-static VALUE
-int_dotimes_size(VALUE num, VALUE args, VALUE eobj)
-{
-    if (FIXNUM_P(num)) {
-        if (NUM2LONG(num) <= 0) return INT2FIX(0);
-    }
-    else {
-        if (RTEST(rb_funcall(num, '<', 1, INT2FIX(0)))) return INT2FIX(0);
-    }
-    return num;
-}
-
-/*
- *  call-seq:
- *    times {|i| ... } -> self
- *    times            -> enumerator
- *
- *  Calls the given block +self+ times with each integer in <tt>(0..self-1)</tt>:
- *
- *    a = []
- *    5.times {|i| a.push(i) } # => 5
- *    a                        # => [0, 1, 2, 3, 4]
- *
- *  With no block given, returns an Enumerator.
- *
- */
-
-static VALUE
-int_dotimes(VALUE num)
-{
-    RETURN_SIZED_ENUMERATOR(num, 0, 0, int_dotimes_size);
-
-    if (FIXNUM_P(num)) {
-        long i, end;
-
-        end = FIX2LONG(num);
-        for (i=0; i<end; i++) {
-            rb_yield_1(LONG2FIX(i));
-        }
-    }
-    else {
-        VALUE i = INT2FIX(0);
-
-        for (;;) {
-            if (!RTEST(int_le(i, num))) break;
-            rb_yield(i);
-            i = rb_int_plus(i, INT2FIX(1));
-        }
-    }
-    return num;
-}
-
 /*
  *  call-seq:
  *    round(ndigits= 0, half: :up) -> integer
@@ -6243,7 +6191,6 @@ Init_Numeric(void)
     rb_define_method(rb_cInteger, "nobits?", int_nobits_p, 1);
     rb_define_method(rb_cInteger, "upto", int_upto, 1);
     rb_define_method(rb_cInteger, "downto", int_downto, 1);
-    rb_define_method(rb_cInteger, "times", int_dotimes, 0);
     rb_define_method(rb_cInteger, "succ", int_succ, 0);
     rb_define_method(rb_cInteger, "next", int_succ, 0);
     rb_define_method(rb_cInteger, "pred", int_pred, 0);

--- a/numeric.rb
+++ b/numeric.rb
@@ -217,6 +217,29 @@ class Integer
     Primitive.cexpr! 'rb_int_size(self)'
   end
 
+  # call-seq:
+  #   times {|i| ... } -> self
+  #   times            -> enumerator
+  #
+  # Calls the given block +self+ times with each integer in <tt>(0..self-1)</tt>:
+  #
+  #   a = []
+  #   5.times {|i| a.push(i) } # => 5
+  #   a                        # => [0, 1, 2, 3, 4]
+  #
+  # With no block given, returns an Enumerator.
+  def times
+    unless block_given?
+      return to_enum(:times) { self < 0 ? 0 : self }
+    end
+    i = 0
+    while i < self
+      yield i
+      i = i.succ
+    end
+    self
+  end
+
   #  call-seq:
   #    to_i -> self
   #

--- a/test/ruby/test_backtrace.rb
+++ b/test/ruby/test_backtrace.rb
@@ -215,15 +215,15 @@ class TestBacktrace < Test::Unit::TestCase
       @res = caller_locations(2, 1).inspect
     end
     @line = __LINE__ + 1
-    1.times.map { 1.times.map { foo } }
-    assert_equal("[\"#{__FILE__}:#{@line}:in `times'\"]", @res)
+    [1].map.map { [1].map.map { foo } }
+    assert_equal("[\"#{__FILE__}:#{@line}:in `map'\"]", @res)
   end
 
   def test_caller_location_path_cfunc_iseq_no_pc
     def self.foo
       @res = caller_locations(2, 1)[0].path
     end
-    1.times.map { 1.times.map { foo } }
+    [1].map.map { [1].map.map { foo } }
     assert_equal(__FILE__, @res)
   end
 

--- a/test/ruby/test_integer.rb
+++ b/test/ruby/test_integer.rb
@@ -321,23 +321,34 @@ class TestInteger < Test::Unit::TestCase
     begin;
       called = false
       Integer.class_eval do
-        alias old_plus +
-        undef +
-        define_method(:+){|x| called = true; 1}
+        alias old_succ succ
+        undef succ
+        define_method(:succ){|x| called = true; x+1}
         alias old_lt <
         undef <
         define_method(:<){|x| called = true}
       end
+
+      fix = 1
+      fix.times{break 0}
+      fix_called = called
+
+      called = false
+
       big = 2**65
       big.times{break 0}
+      big_called = called
+
       Integer.class_eval do
-        undef +
-        alias + old_plus
+        undef succ
+        alias succ old_succ
         undef <
         alias < old_lt
       end
+
+      # Asssert that Fixnum and Bignum behave consistently
       bug18377 = "[ruby-core:106361]"
-      assert_equal(false, called, bug18377)
+      assert_equal(fix_called, big_called, bug18377)
     end;
   end
 

--- a/test/ruby/test_settracefunc.rb
+++ b/test/ruby/test_settracefunc.rb
@@ -504,7 +504,7 @@ class TestSetTraceFunc < Test::Unit::TestCase
     1: trace = TracePoint.trace(*trace_events){|tp| next if !target_thread?
     2:   events << [tp.event, tp.lineno, tp.path, _defined_class.(tp), tp.method_id, tp.self, tp.binding&.eval("_local_var"), _get_data.(tp)] if tp.path == 'xyzzy'
     3: }
-    4: 1.times{|;_local_var| _local_var = :inner
+    4: [1].each{|;_local_var| _local_var = :inner
     5:   tap{}
     6: }
     7: class XYZZY
@@ -531,10 +531,10 @@ class TestSetTraceFunc < Test::Unit::TestCase
     answer_events = [
      #
      [:line,     4, 'xyzzy', self.class,  method,           self,        :outer, :nothing],
-     [:c_call,   4, 'xyzzy', Integer,     :times,           1,           nil, :nothing],
+     [:c_call,   4, 'xyzzy', Array,       :each,            [1],         nil,    :nothing],
      [:line,     4, 'xyzzy', self.class,  method,           self,        nil,    :nothing],
      [:line,     5, 'xyzzy', self.class,  method,           self,        :inner, :nothing],
-     [:c_return, 4, "xyzzy", Integer,     :times,           1,           nil, 1],
+     [:c_return, 4, "xyzzy", Array,       :each,            [1],         nil, [1]],
      [:line,     7, 'xyzzy', self.class,  method,           self,        :outer, :nothing],
      [:c_call,   7, "xyzzy", Module,      :const_added,     TestSetTraceFunc, nil, :nothing],
      [:c_return, 7, "xyzzy", Module,      :const_added,     TestSetTraceFunc, nil, nil],
@@ -639,7 +639,7 @@ CODE
     1: set_trace_func(lambda{|event, file, line, id, binding, klass|
     2:   events << [event, line, file, klass, id, binding&.eval('self'), binding&.eval("_local_var")] if file == 'xyzzy'
     3: })
-    4: 1.times{|;_local_var| _local_var = :inner
+    4: [1].map{|;_local_var| _local_var = :inner
     5:   tap{}
     6: }
     7: class XYZZY
@@ -994,7 +994,7 @@ CODE
         /return/ =~ tp.event ? tp.return_value : nil
       ]
     }.enable{
-      1.times{
+      [1].map{
         3
       }
       method_for_test_tracepoint_block{
@@ -1004,10 +1004,10 @@ CODE
     # pp events
     # expected_events =
     [[:b_call, :test_tracepoint_block, TestSetTraceFunc, TestSetTraceFunc, nil],
-     [:c_call, :times, Integer, Integer, nil],
+     [:c_call, :map, Array, Array, nil],
      [:b_call, :test_tracepoint_block, TestSetTraceFunc, TestSetTraceFunc, nil],
      [:b_return, :test_tracepoint_block, TestSetTraceFunc, TestSetTraceFunc, 3],
-     [:c_return, :times, Integer, Integer, 1],
+     [:c_return, :map, Array, Array, [3]],
      [:call, :method_for_test_tracepoint_block, TestSetTraceFunc, TestSetTraceFunc, nil],
      [:b_call, :test_tracepoint_block, TestSetTraceFunc, TestSetTraceFunc, nil],
      [:b_return, :test_tracepoint_block, TestSetTraceFunc, TestSetTraceFunc, 4],
@@ -1310,7 +1310,7 @@ CODE
       next if !target_thread?
       events << tp.event
     }.enable{
-      1.times{
+      [1].map{
         3
       }
       method_for_test_tracepoint_block{
@@ -1332,7 +1332,7 @@ CODE
       next if !target_thread?
       events << tp.event
     }.enable{
-      1.times{
+      [1].map{
         3
       }
       method_for_test_tracepoint_block{


### PR DESCRIPTION
## railsbench
I benchmarked this with railsbench, which does call `Integer#times` a little (https://github.com/Shopify/yjit-bench/pull/168).

### Interpreter
It doesn't seem to have a significant impact on the interpreter.

```
before: ruby 3.3.0dev (2023-09-06T19:50:21Z master acd626a583) [x86_64-linux]
after: ruby 3.3.0dev (2023-09-06T22:03:28Z builtin-times 74e1bd7243) [x86_64-linux]

----------  -----------  ----------  ----------  ----------  -------------  ------------
bench       before (ms)  stddev (%)  after (ms)  stddev (%)  after 1st itr  before/after
railsbench  2018.9       0.8         2015.0      0.9         1.01           1.00
----------  -----------  ----------  ----------  ----------  -------------  ------------
```

### YJIT
It decreases `interp_return`, increases `avg_len_in_yjit`, and speeds up the benchmark a little.

```
before: ruby 3.3.0dev (2023-09-06T19:50:21Z master acd626a583) +YJIT [x86_64-linux]
after: ruby 3.3.0dev (2023-09-06T22:03:28Z builtin-times 74e1bd7243) +YJIT [x86_64-linux]

----------  -----------  ----------  ----------  ----------  -------------  ------------
bench       before (ms)  stddev (%)  after (ms)  stddev (%)  after 1st itr  before/after
railsbench  1155.4       1.4         1137.3      1.3         1.01           1.02
----------  -----------  ----------  ----------  ----------  -------------  ------------
```

## microbenchmark
### Interpreter
It slows down the interpreter a little, but it doesn't seem too significant. In fact, railsbench did not slow down.

```
$ benchmark-driver benchmark/loop_times.rb -v --chruby 'before;after'
before: ruby 3.3.0dev (2023-09-06T19:50:21Z master acd626a583) [x86_64-linux]
after: ruby 3.3.0dev (2023-09-06T22:03:28Z builtin-times 74e1bd7243) [x86_64-linux]
Calculating -------------------------------------
                         before       after
          loop_times      1.290       1.071 i/s -       1.000 times in 0.774922s 0.933629s

Comparison:
                       loop_times
              before:         1.3 i/s
               after:         1.1 i/s - 1.20x  slower
```

## YJIT
Ruby outperforms C.

```
$ benchmark-driver benchmark/loop_times.rb --chruby 'before::before --yjit-call-threshold=1;after::after --yjit-call-threshold=1' -v
before: ruby 3.3.0dev (2023-09-06T19:50:21Z master acd626a583) +YJIT [x86_64-linux]
after: ruby 3.3.0dev (2023-09-06T22:03:28Z builtin-times 74e1bd7243) +YJIT [x86_64-linux]
Calculating -------------------------------------
                         before       after
          loop_times      1.490       5.229 i/s -       1.000 times in 0.670956s 0.191239s

Comparison:
                       loop_times
               after:         5.2 i/s
              before:         1.5 i/s - 3.51x  slower
```