### PR TITLE
Remove function call for String#bytesize

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -4697,10 +4697,21 @@ fn jit_rb_str_bytesize(
     asm.comment("String#bytesize");
 
     let recv = asm.stack_pop(1);
-    let ret_opnd = asm.ccall(rb_str_bytesize as *const u8, vec![recv]);
+
+    asm.comment("get string length");
+    let str_len_opnd = Opnd::mem(
+        std::os::raw::c_long::BITS as u8,
+        asm.load(recv),
+        RUBY_OFFSET_RSTRING_LEN as i32,
+    );
+
+    let len = asm.load(str_len_opnd);
+    let shifted_val = asm.lshift(len, Opnd::UImm(1 as u64));
+    let out_val = asm.or(shifted_val, Opnd::UImm(RUBY_FIXNUM_FLAG as u64));
 
     let out_opnd = asm.stack_push(Type::Fixnum);
-    asm.mov(out_opnd, ret_opnd);
+
+    asm.mov(out_opnd, out_val);
 
     true
 }

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -4706,7 +4706,7 @@ fn jit_rb_str_bytesize(
     );
 
     let len = asm.load(str_len_opnd);
-    let shifted_val = asm.lshift(len, Opnd::UImm(1 as u64));
+    let shifted_val = asm.lshift(len, Opnd::UImm(1));
     let out_val = asm.or(shifted_val, Opnd::UImm(RUBY_FIXNUM_FLAG as u64));
 
     let out_opnd = asm.stack_push(Type::Fixnum);

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -135,7 +135,6 @@ extern "C" {
         ic: ICVARC,
     ) -> VALUE;
     pub fn rb_vm_ic_hit_p(ic: IC, reg_ep: *const VALUE) -> bool;
-    pub fn rb_str_bytesize(str: VALUE) -> VALUE;
 }
 
 // Renames


### PR DESCRIPTION
String size is stored in a consistent location, so we can eliminate the function call.