### PR TITLE
Reduce number of iterations in `TestFiberScheduler#test_autoload`.

### DIFF
--- a/test/fiber/test_scheduler.rb
+++ b/test/fiber/test_scheduler.rb
@@ -118,7 +118,7 @@ class TestFiberScheduler < Test::Unit::TestCase
   end
 
   def test_autoload
-    100.times do
+    10.times do
       Object.autoload(:TestFiberSchedulerAutoload, File.expand_path("autoload.rb", __dir__))
 
       thread = Thread.new do


### PR DESCRIPTION
`ppc64le` appears to be struggling with this test due to timeout. Let's see if reducing the number of iterations can help improve the test performance.