### PR TITLE
[Bug #19868] `Process::Status` compatibility with `Fixnum`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -38,6 +38,10 @@ Note: We're only listing outstanding class updates.
     * MatchData#named_captures now accepts optional `symbolize_names`
       keyword. [[Feature #19591]]
 
+* Process::Status
+
+    * Process::Status#& and Process::Status#>> are deprecated. [[Bug #19868]]
+
 * String
 
     * String#unpack now raises ArgumentError for unknown directives. [[Bug #19150]]
@@ -182,3 +186,4 @@ changelog for details of the default gems or bundled gems.
 [Feature #19776]: https://bugs.ruby-lang.org/issues/19776
 [Feature #19785]: https://bugs.ruby-lang.org/issues/19785
 [Feature #19843]: https://bugs.ruby-lang.org/issues/19843
+[Bug #19868]:     https://bugs.ruby-lang.org/issues/19868

--- a/process.c
+++ b/process.c
@@ -870,7 +870,7 @@ pst_equal(VALUE st1, VALUE st2)
  *  call-seq:
  *    stat & mask -> integer
  *
- *  The use of this method is discouraged; use other attribute methods.
+ *  This method is deprecated; use other attribute methods.
  *
  *  Returns the logical AND of the value of #to_i with +mask+:
  *
@@ -891,7 +891,9 @@ pst_bitand(VALUE st1, VALUE st2)
     if (mask < 0) {
         rb_raise(rb_eArgError, "negative mask value: %d", mask);
     }
-#define WARN_SUGGEST(suggest) rb_warn("Use " suggest " instead of Process::Status#&")
+#define WARN_SUGGEST(suggest) \
+    rb_warn_deprecated_to_remove_at(3.4, "Process::Status#&", suggest)
+
     switch (mask) {
       case 0x80:
         WARN_SUGGEST("Process::Status#coredump?");
@@ -920,7 +922,7 @@ pst_bitand(VALUE st1, VALUE st2)
  *  call-seq:
  *    stat >> places -> integer
  *
- *  The use of this method is discouraged; use other predicate methods.
+ *  This method is deprecated; use other predicate methods.
  *
  *  Returns the value of #to_i, shifted +places+ to the right:
  *
@@ -942,7 +944,9 @@ pst_rshift(VALUE st1, VALUE st2)
     if (places < 0) {
         rb_raise(rb_eArgError, "negative shift value: %d", places);
     }
-#define WARN_SUGGEST(suggest) rb_warn("Use " suggest " instead of Process::Status#>>")
+#define WARN_SUGGEST(suggest) \
+    rb_warn_deprecated_to_remove_at(3.4, "Process::Status#>>", suggest)
+
     switch (places) {
       case 7:
         WARN_SUGGEST("Process::Status#coredump?");

--- a/process.c
+++ b/process.c
@@ -877,12 +877,19 @@ pst_equal(VALUE st1, VALUE st2)
  *    sprintf('%x', stat.to_i)  # => "100"
  *    stat & 0x00               # => 0
  *
+ *  ArgumentError is raised if +mask+ is negative.
  */
 
 static VALUE
 pst_bitand(VALUE st1, VALUE st2)
 {
-    int status = PST2INT(st1) & NUM2INT(st2);
+    int status = PST2INT(st1);
+    int mask = NUM2INT(st2);
+
+    if (mask < 0) {
+        rb_raise(rb_eArgError, "negative mask value: %d", mask);
+    }
+    status &= mask;
 
     return INT2NUM(status);
 }
@@ -900,13 +907,19 @@ pst_bitand(VALUE st1, VALUE st2)
  *     stat >> 1                 # => 128
  *     stat >> 2                 # => 64
  *
- *  The behavior is unspecified if +places+ is negative.
+ *  ArgumentError is raised if +places+ is negative.
  */
 
 static VALUE
 pst_rshift(VALUE st1, VALUE st2)
 {
-    int status = PST2INT(st1) >> NUM2INT(st2);
+    int status = PST2INT(st1);
+    int places = NUM2INT(st2);
+
+    if (places < 0) {
+        rb_raise(rb_eArgError, "negative shift value: %d", places);
+    }
+    status >>= places;
 
     return INT2NUM(status);
 }

--- a/process.c
+++ b/process.c
@@ -870,6 +870,8 @@ pst_equal(VALUE st1, VALUE st2)
  *  call-seq:
  *    stat & mask -> integer
  *
+ *  The use of this method is discouraged; use other attribute methods.
+ *
  *  Returns the logical AND of the value of #to_i with +mask+:
  *
  *    `cat /nop`
@@ -889,6 +891,25 @@ pst_bitand(VALUE st1, VALUE st2)
     if (mask < 0) {
         rb_raise(rb_eArgError, "negative mask value: %d", mask);
     }
+#define WARN_SUGGEST(suggest) rb_warn("Use " suggest " instead of Process::Status#&")
+    switch (mask) {
+      case 0x80:
+        WARN_SUGGEST("Process::Status#coredump?");
+        break;
+      case 0x7f:
+        WARN_SUGGEST("Process::Status#signaled? or Process::Status#termsig");
+        break;
+      case 0xff:
+        WARN_SUGGEST("Process::Status#exited?, Process::Status#stopped? or Process::Status#coredump?");
+        break;
+      case 0xff00:
+        WARN_SUGGEST("Process::Status#exitstatus or Process::Status#stopsig");
+        break;
+      default:
+        WARN_SUGGEST("other Process::Status predicates");
+        break;
+    }
+#undef WARN_SUGGEST
     status &= mask;
 
     return INT2NUM(status);
@@ -898,6 +919,8 @@ pst_bitand(VALUE st1, VALUE st2)
 /*
  *  call-seq:
  *    stat >> places -> integer
+ *
+ *  The use of this method is discouraged; use other predicate methods.
  *
  *  Returns the value of #to_i, shifted +places+ to the right:
  *
@@ -919,6 +942,19 @@ pst_rshift(VALUE st1, VALUE st2)
     if (places < 0) {
         rb_raise(rb_eArgError, "negative shift value: %d", places);
     }
+#define WARN_SUGGEST(suggest) rb_warn("Use " suggest " instead of Process::Status#>>")
+    switch (places) {
+      case 7:
+        WARN_SUGGEST("Process::Status#coredump?");
+        break;
+      case 8:
+        WARN_SUGGEST("Process::Status#exitstatus or Process::Status#stopsig");
+        break;
+      default:
+        WARN_SUGGEST("other Process::Status attributes");
+        break;
+    }
+#undef WARN_SUGGEST
     status >>= places;
 
     return INT2NUM(status);

--- a/test/ruby/test_process.rb
+++ b/test/ruby/test_process.rb
@@ -1451,10 +1451,10 @@ class TestProcess < Test::Unit::TestCase
       assert_equal(s, s)
       assert_equal(s, s.to_i)
 
-      assert_warn(/\bUse .*Process::Status/) do
+      assert_deprecated_warn(/\buse .*Process::Status/) do
         assert_equal(s.to_i & 0x55555555, s & 0x55555555)
       end
-      assert_warn(/\bUse .*Process::Status/) do
+      assert_deprecated_warn(/\buse .*Process::Status/) do
         assert_equal(s.to_i >> 1, s >> 1)
       end
       assert_raise(ArgumentError) do

--- a/test/ruby/test_process.rb
+++ b/test/ruby/test_process.rb
@@ -1451,8 +1451,12 @@ class TestProcess < Test::Unit::TestCase
       assert_equal(s, s)
       assert_equal(s, s.to_i)
 
-      assert_equal(s.to_i & 0x55555555, s & 0x55555555)
-      assert_equal(s.to_i >> 1, s >> 1)
+      assert_warn(/\bUse .*Process::Status/) do
+        assert_equal(s.to_i & 0x55555555, s & 0x55555555)
+      end
+      assert_warn(/\bUse .*Process::Status/) do
+        assert_equal(s.to_i >> 1, s >> 1)
+      end
       assert_raise(ArgumentError) do
         s >> -1
       end

--- a/test/ruby/test_process.rb
+++ b/test/ruby/test_process.rb
@@ -1453,6 +1453,9 @@ class TestProcess < Test::Unit::TestCase
 
       assert_equal(s.to_i & 0x55555555, s & 0x55555555)
       assert_equal(s.to_i >> 1, s >> 1)
+      assert_raise(ArgumentError) do
+        s >> -1
+      end
       assert_equal(false, s.stopped?)
       assert_equal(nil, s.stopsig)
 


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/19868