### PR TITLE
Try default `gcc` 9.4.0 to see if it exhibits the same compiler bugs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,12 +82,12 @@ env:
   - &ppc64le-linux
     name: ppc64le-linux
     arch: ppc64le
-    <<: *gcc-10
+    compiler: gcc
 
   - &s390x-linux
     name: s390x-linux
     arch: s390x
-    <<: *gcc-10
+    compiler: gcc
 
   - &arm32-linux
     name: arm32-linux

--- a/thread_sync.c
+++ b/thread_sync.c
@@ -290,28 +290,6 @@ delete_from_waitq(VALUE value)
     return Qnil;
 }
 
-static void
-do_mutex_lock_check_interrupts(int interruptible_p, rb_fiber_t *fiber, rb_mutex_t *mutex, rb_thread_t *thread)
-{
-    // We extracted this function because we suspect there can be a codegen bug
-    // on ppc64le and moving this code to a separate function seems to fix the
-    // problem, at least in my tests.
-    if (interruptible_p) {
-        /* release mutex before checking for interrupts...as interrupt checking
-         * code might call rb_raise() */
-        if (mutex->fiber == fiber) {
-            mutex->fiber = 0;
-        }
-
-        RUBY_VM_CHECK_INTS_BLOCKING(thread->ec); /* may release mutex */
-
-        if (!mutex->fiber) {
-            mutex->fiber = fiber;
-        }
-    }
-}
-
-
 static VALUE
 do_mutex_lock(VALUE self, int interruptible_p)
 {
@@ -400,7 +378,15 @@ do_mutex_lock(VALUE self, int interruptible_p)
                 rb_ractor_sleeper_threads_dec(th->ractor);
             }
 
-            do_mutex_lock_check_interrupts(interruptible_p, fiber, mutex, th);
+            if (interruptible_p) {
+                /* release mutex before checking for interrupts...as interrupt checking
+                 * code might call rb_raise() */
+                if (mutex->fiber == fiber) mutex->fiber = 0;
+                RUBY_VM_CHECK_INTS_BLOCKING(th->ec); /* may release mutex */
+                if (!mutex->fiber) {
+                    mutex->fiber = fiber;
+                }
+            }
         }
 
         if (mutex->fiber == fiber) mutex_locked(th, self);


### PR DESCRIPTION
If https://github.com/ruby/ruby/pull/8393 works, let's try `gcc-9` to see if that mitigates the issue too. Perhaps this was a bug introduced in `gcc-10`.