### PR TITLE
Add `String#getbyte` YJIT implementation

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -1832,6 +1832,24 @@ assert_equal 'true', %q{
   jittable_method
 }
 
+# test getbyte on string class
+assert_equal '[97, :nil, 97, :nil, :raised]', %q{
+  def getbyte(s, i)
+   byte = begin
+    s.getbyte(i)
+   rescue TypeError
+    :raised
+   end
+
+   byte || :nil
+  end
+
+  getbyte("a", 0)
+  getbyte("a", 0)
+
+  [getbyte("a", 0), getbyte("a", 1), getbyte("a", -1), getbyte("a", -2), getbyte("a", "a")]
+}
+
 # Test << operator on string subclass
 assert_equal 'abab', %q{
   class MyString < String; end

--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -1848,7 +1848,7 @@ assert_equal '[97, :nil, 97, :nil, :raised]', %q{
   getbyte("a", 0)
 
   [getbyte("a", 0), getbyte("a", 1), getbyte("a", -1), getbyte("a", -2), getbyte("a", "a")]
-}
+} unless defined?(RubyVM::RJIT) && RubyVM::RJIT.enabled? # Not yet working on RJIT
 
 # Test << operator on string subclass
 assert_equal 'abab', %q{


### PR DESCRIPTION
Adds an implementation for `String#getbyte` for YJIT, along with a bootstrap test. This should be helpful for pure Ruby implementations and to avoid unneeded allocations.

See the following benchmark for comparison. The benchmark is loosely based on an example from TinyGraphql - see this [blog post](https://tenderlovemaking.com/2023/09/02/fast-tokenizers-with-stringscanner.html) and [code snippet](https://github.com/tenderlove/tinygql/blob/3fc680c73cf16bfb2c7b57ecb07e8721e67d384c/lib/tinygql/lexer.rb#L116-L126).

```ruby
require 'benchmark'

def get_key(str, pos)
    key = (str.getbyte(pos + 2) << 8) | str.getbyte(pos + 1)
end

def get_keys
    str = "one string" * 10_000
    0.upto(str.length - 10).each do |i|
        get_key(str , i)
    end
end

Benchmark.bm do |x|
  x.report('ruby-yjit') { 100.times { get_keys } }
end
```

```
user               system     total      real
ruby-control       1.213070   0.000037   1.213107 (  1.215320)
ruby-yjit-control  0.517514   0.007920   0.525434 (  0.569921)
ruby-yjit-getbyte  0.424347   0.003604   0.427951 (  0.428764)

ruby-control: ruby 3.3.0dev (2023-08-31T18:31:18Z master 945945dad4)
ruby-yjit-control: ruby 3.3.0dev (2023-08-31T18:31:18Z master 945945dad4) --yjit
ruby-yjit-getbyte: ruby 3.3.0dev (2023-09-06T23:49:59Z yjit_str_getbyte 76251be9e2) [x86_64-linux] --yjit
```