### PR TITLE
YJIT: Decrease IVAR_MAX_DEPTH to 8

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -2035,11 +2035,11 @@ fn jit_chain_guard(
     }
 }
 
-// up to 10 different classes, and embedded or not for each
-pub const GET_IVAR_MAX_DEPTH: i32 = 10;
+// up to 8 different shapes for each
+pub const GET_IVAR_MAX_DEPTH: i32 = 8;
 
-// up to 10 different classes, and embedded or not for each
-pub const SET_IVAR_MAX_DEPTH: i32 = 10;
+// up to 8 different shapes for each
+pub const SET_IVAR_MAX_DEPTH: i32 = 8;
 
 // hashes and arrays
 pub const OPT_AREF_MAX_CHAIN_DEPTH: i32 = 2;


### PR DESCRIPTION
I tested 5, 8, and 10 as `GET_IVAR_MAX_DEPTH` and `SET_IVAR_MAX_DEPTH` on SFR. depth=8 showed the best latency, and it had almost the same max code size as depth=5, which is 1.6% smaller than depth=10's.