### PR TITLE
Fix weak references count test

### DIFF
--- a/test/ruby/test_gc.rb
+++ b/test/ruby/test_gc.rb
@@ -303,7 +303,8 @@ class TestGc < Test::Unit::TestCase
       # Create some objects and place it in a WeakMap
       wmap = ObjectSpace::WeakMap.new
       ary = Array.new(count)
-      count.times do |i|
+      enum = count.times
+      enum.each.with_index do |i|
         obj = Object.new
         ary[i] = obj
         wmap[obj] = nil


### PR DESCRIPTION
This test creates a lot of Objects held in an array, and a set of weak references to them using WeakMap. It then clears the array and frees it and asserts that all the weak references to it are also gone.

This test is failing because one of the dummy objects in our weakmap is ending up on the stack, and so is being marked, even though we thought that we'd removed the only reference to it.

This behaviour has changed since commit: https://github.com/ruby/ruby/commit/5b5ae3d9e064e17e2a7d8d21d739fcc62ae1075c which rewrites `Integer#times` from C into Ruby. This change is somehow causing the last object we append to our array to consistently end up on the stack during GC.

This commit fixes the specific weakmap test by using an enumerator and each, instead of `Integer#times`, and thus avoids having our last object created end up on the stack.