### PR TITLE
Don't filter backtrace in make test-spec

### DIFF
--- a/defs/gmake.mk
+++ b/defs/gmake.mk
@@ -4,7 +4,7 @@ reconfig config.status: export MAKE:=$(MAKE)
 export BASERUBY:=$(BASERUBY)
 override gnumake_recursive := $(if $(findstring n,$(firstword $(MFLAGS))),,+)
 override mflags := $(filter-out -j%,$(MFLAGS))
-MSPECOPT += $(if $(filter -j%,$(MFLAGS)),-j)
+MSPECOPT += --debug $(if $(filter -j%,$(MFLAGS)),-j)
 nproc = $(subst -j,,$(filter -j%,$(MFLAGS)))
 
 ifeq ($(GITHUB_ACTIONS),true)


### PR DESCRIPTION
Especially on CI, the backtrace is very valuable for debugging.
