### PR TITLE
YJIT: Make compile_time_ns a default counter

### DIFF
--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -167,13 +167,14 @@ macro_rules! make_counters {
 
 /// The list of counters that are available without --yjit-stats.
 /// They are incremented only by `incr_counter!` and don't use `gen_counter_incr`.
-pub const DEFAULT_COUNTERS: [Counter; 6] = [
+pub const DEFAULT_COUNTERS: [Counter; 7] = [
     Counter::code_gc_count,
     Counter::compiled_iseq_entry,
     Counter::compiled_iseq_count,
     Counter::compiled_blockid_count,
     Counter::compiled_block_count,
     Counter::compiled_branch_count,
+    Counter::compile_time_ns,
 ];
 
 /// Macro to increase a counter by name and count
@@ -845,13 +846,9 @@ fn global_allocation_size() -> usize {
 
 /// Measure the time taken by func() and add that to yjit_compile_time.
 pub fn with_compile_time<F, R>(func: F) -> R where F: FnOnce() -> R {
-    if get_option!(gen_stats) {
-        let start = Instant::now();
-        let ret = func();
-        let nanos = Instant::now().duration_since(start).as_nanos();
-        incr_counter_by!(compile_time_ns, nanos);
-        ret
-    } else {
-        func()
-    }
+    let start = Instant::now();
+    let ret = func();
+    let nanos = Instant::now().duration_since(start).as_nanos();
+    incr_counter_by!(compile_time_ns, nanos);
+    ret
 }


### PR DESCRIPTION
This PR proposes to make https://github.com/ruby/ruby/pull/8417 available by default.

We want to know how long we spend in YJIT compilation out of each request, but that request processing is somewhat slower than ideal since you must use `--yjit-stats` for it. Even for non-YJIT-developer users, this seems like a useful metric for APM like NewRelic to show how many % your application spends in YJIT compilation, similar to what they do for GC time.

This doesn't seem to have a significant performance impact on the 1st iteration of the following benchmarks:

```
before: ruby 3.3.0dev (2023-09-12T21:45:26Z master 19346c2336) +YJIT [x86_64-linux]
after: ruby 3.3.0dev (2023-09-12T23:33:25Z yjit-default-time 38d9038633) +YJIT [x86_64-linux]

-----------  -----------  ----------  ----------  ----------  -------------  ------------
bench        before (ms)  stddev (%)  after (ms)  stddev (%)  after 1st itr  before/after
lobsters     1752.5       0.0         1721.9      0.0         1.02           1.02
railsbench   1508.3       0.0         1492.0      0.0         1.01           1.01
30k_ifelse   1339.6       0.0         1343.9      0.0         1.00           1.00
30k_methods  915.8        0.0         909.7       0.0         1.01           1.01
-----------  -----------  ----------  ----------  ----------  -------------  ------------
```