### PR TITLE
YJIT: Make yjit_alloc_size available by default

### DIFF
--- a/yjit/Cargo.lock
+++ b/yjit/Cargo.lock
@@ -35,15 +35,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21a41fed9d98f27ab1c6d161da622a4fa35e8a54a8adc24bbf3ddd0ef70b0e50"
 
 [[package]]
-name = "stats_alloc"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c0e04424e733e69714ca1bbb9204c1a57f09f5493439520f9f68c132ad25eec"
-
-[[package]]
 name = "yjit"
 version = "0.1.0"
 dependencies = [
  "capstone",
- "stats_alloc",
 ]

--- a/yjit/Cargo.toml
+++ b/yjit/Cargo.toml
@@ -16,13 +16,12 @@ crate-type = ["staticlib"]
 # No required dependencies to simplify build process. TODO: Link to yet to be
 # written rationale. Optional For development and testing purposes
 capstone = { version = "0.10.0", optional = true }
-stats_alloc = { version = "0.1.10", optional = true }
 
 [features]
 # NOTE: Development builds select a set of these via configure.ac
 # For debugging, `make V=1` shows exact cargo invocation.
 disasm = ["capstone"]
-stats = ["stats_alloc"]
+stats = []
 
 [profile.dev]
 opt-level = 0


### PR DESCRIPTION
`yjit_alloc_size` is a very important metric for monitoring YJIT since it's more significant than `code_region_size` in production, but this is available only with `--enable-yjit=stats`. This PR proposes to make it available by default.

The performance impact on the 1st iteration of the following benchmarks doesn't seem too significant:

```
before: ruby 3.3.0dev (2023-09-12T21:45:26Z master 19346c2336) +YJIT [x86_64-linux]
after: ruby 3.3.0dev (2023-09-13T00:43:05Z yjit-stats-alloc af1b1f5d02) +YJIT [x86_64-linux]

-----------  -----------  ----------  ----------  ----------  -------------  ------------
bench        before (ms)  stddev (%)  after (ms)  stddev (%)  after 1st itr  before/after
lobsters     1751.9       0.0         1753.9      0.0         1.00           1.00
railsbench   1503.5       0.0         1492.0      0.0         1.01           1.01
30k_ifelse   1373.7       0.0         1385.9      0.0         0.99           0.99
30k_methods  917.4        0.0         930.3       0.0         0.99           0.99
-----------  -----------  ----------  ----------  ----------  -------------  ------------
```