### PR TITLE
math.c: Fix Math.log against huge bignum [Bug #19878]

### DIFF
--- a/math.c
+++ b/math.c
@@ -561,14 +561,14 @@ rb_math_log(int argc, const VALUE *argv)
             return DBL2NUM(-0.0);
         }
         d = log_intermediate(d) / log_intermediate(b);
-        numbits -= numbits_2;
+        d += (numbits - numbits_2) * M_LN2 / log(b);
     }
     else {
         /* check for pole error */
         if (d == 0.0) return DBL2NUM(-HUGE_VAL);
         d = log(d);
+        d += numbits * M_LN2;
     }
-    d += numbits * M_LN2;
     return DBL2NUM(d);
 }
 

--- a/math.c
+++ b/math.c
@@ -538,6 +538,7 @@ math_log_split(VALUE x, size_t *numbits)
 # define log_intermediate log2
 #else
 # define log_intermediate log10
+double log2(double x);
 #endif
 
 VALUE
@@ -561,7 +562,7 @@ rb_math_log(int argc, const VALUE *argv)
             return DBL2NUM(-0.0);
         }
         d = log_intermediate(d) / log_intermediate(b);
-        d += (numbits - numbits_2) * M_LN2 / log(b);
+        d += (numbits - numbits_2) / log2(b);
     }
     else {
         /* check for pole error */

--- a/test/ruby/test_math.rb
+++ b/test/ruby/test_math.rb
@@ -168,6 +168,7 @@ class TestMath < Test::Unit::TestCase
     assert_nothing_raised { assert_nan(Math.log(1.0, Float::NAN)) }
     assert_nothing_raised { assert_infinity(-Math.log(0)) }
     assert_nothing_raised { assert_infinity(-Math.log(0, 2)) }
+    check(307.95368556425274, Math.log(2**1023, 10))
   end
 
   def test_log2


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/19878