### PR TITLE
Fix GC.stress= segfaulting on non-bool/integers

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -7460,6 +7460,7 @@ gc_mark_roots(rb_objspace_t *objspace, const char **categoryp)
     rb_gc_mark(objspace->next_object_id);
     mark_tbl_no_pin(objspace, objspace->obj_to_id_tbl); /* Only mark ids */
 
+    rb_gc_mark(ruby_gc_stress_mode);
     if (stress_to_class) rb_gc_mark(stress_to_class);
 
     MARK_CHECKPOINT("finish");
@@ -11460,6 +11461,10 @@ gc_stress_get(rb_execution_context_t *ec, VALUE self)
 static void
 gc_stress_set(rb_objspace_t *objspace, VALUE flag)
 {
+    if (flag != Qtrue && flag != Qfalse) {
+        flag = rb_to_int(flag);
+    }
+
     objspace->flags.gc_stressful = RTEST(flag);
     objspace->gc_stress_mode = flag;
 }

--- a/spec/ruby/core/gc/stress_spec.rb
+++ b/spec/ruby/core/gc/stress_spec.rb
@@ -20,8 +20,26 @@ describe "GC.stress=" do
     GC.stress = false
   end
 
-  it "sets the stress mode" do
+  it "accepts true, false, and integers" do
     GC.stress = true
     GC.stress.should be_true
+    GC.stress = false
+    GC.stress.should be_false
+    GC.stress = 4
+    GC.stress.should equal 4
+  end
+
+  it "tries to convert non-boolean argument to an integer using to_int" do
+    a = mock('4')
+    a.should_receive(:to_int).and_return(4)
+
+    GC.stress = a
+    GC.stress.should equal 4
+  end
+
+  it "raises TypeError for non-boolean and `to_int` types" do
+    -> { GC.stress = nil }.should raise_error(TypeError)
+    -> { GC.stress = Object.new }.should raise_error(TypeError)
+    -> { GC.stress = :hello }.should raise_error(TypeError)
   end
 end


### PR DESCRIPTION
## Issue
Whilst updating the RBS type definitions for `GC`, I came across a segfault in `GC.stress=`: If you pass it a non-immediate type, accessing any method on `GC.stress` will segfault.

## How to Reproduce
```ruby
GC.stress = "hello world" # or any allocated object.
GC.stress.class
```

## Cause
The segfault is caused by a use-after-free, as `gc_mark_roots()` doesn't mark `objspace->gc_stress_mode`. I suspect it was never marked because the documentation says that it only accepts `true`, `false`, or a bitwise OR of `0x1` `0x2` and `0x4`, all of which are immediate values.

## The Fix
This PR adds a single line, `rb_gc_mark(ruby_gc_stress_mode);`, to `gc_mark_roots()`. This ensures that the stress mode is always marked, and thus won't be erroneously freed. While I was here, I also updated `GC.stress=` as well to only accept `true`, `false`, and types that define `.to_int`, as the documentation describes. 