### PR TITLE
[For ruby_3_2] Fix unused_mut Rust warnings

### DIFF
--- a/yjit/src/asm/mod.rs
+++ b/yjit/src/asm/mod.rs
@@ -624,12 +624,12 @@ impl CodeBlock {
         freed_pages.append(&mut virtual_pages);
 
         if let Some(&first_page) = freed_pages.first() {
-            let mut cb = CodegenGlobals::get_inline_cb();
+            let cb = CodegenGlobals::get_inline_cb();
             cb.write_pos = cb.get_page_pos(first_page);
             cb.dropped_bytes = false;
             cb.clear_comments();
 
-            let mut ocb = CodegenGlobals::get_outlined_cb().unwrap();
+            let ocb = CodegenGlobals::get_outlined_cb().unwrap();
             ocb.write_pos = ocb.get_page_pos(first_page);
             ocb.dropped_bytes = false;
             ocb.clear_comments();

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -1484,7 +1484,7 @@ fn gen_block_series_body(
 
         // gen_direct_jump() can request a block to be placed immediately after by
         // leaving a single target that has a `None` address.
-        let mut last_target = match &mut last_branch.targets {
+        let last_target = match &mut last_branch.targets {
             [Some(last_target), None] if last_target.address.is_none() => last_target,
             _ => break
         };


### PR DESCRIPTION
*For YJIT members: please don't merge and let the branch maintainer decide what to do.*

Rust version 1.71.0 and up issue these warnings. On GitHub CI, the
warnings were previously seen in -DYJIT_FORCE_ENABLE runs.

Not a backport, and these code don't exist on the master branch anymore.
Discovered thanks to @nirvdrum.
