### PR TITLE
For YJIT Actions, don't filter test-spec backtraces

### DIFF
--- a/.github/workflows/yjit-ubuntu.yml
+++ b/.github/workflows/yjit-ubuntu.yml
@@ -158,7 +158,7 @@ jobs:
         run: ./miniruby --yjit -v | grep "+YJIT"
 
       - name: make ${{ matrix.test_task }}
-        run: make -s -j ${{ matrix.test_task }} RUN_OPTS="$RUN_OPTS" YJIT_BENCH_OPTS="$YJIT_BENCH_OPTS" YJIT_BINDGEN_DIFF_OPTS="$YJIT_BINDGEN_DIFF_OPTS"
+        run: make -s -j ${{ matrix.test_task }} RUN_OPTS="$RUN_OPTS" MSPECOPT=--debug YJIT_BENCH_OPTS="$YJIT_BENCH_OPTS" YJIT_BINDGEN_DIFF_OPTS="$YJIT_BINDGEN_DIFF_OPTS"
         timeout-minutes: 60
         env:
           RUBY_TESTOPTS: '-q --tty=no'


### PR DESCRIPTION
I'm trying to debug a flaky `RuntimeError: nested #it` failure in
ruby/spec. Hopefully the full backtrace will give some clues.

Last occurence:
https://github.com/ruby/ruby/actions/runs/6172578817/job/16753137038
