### PR TITLE
YJIT: Initialize Assembler vectors with capacity

### DIFF
--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -983,6 +983,9 @@ impl SideExitContext {
     }
 }
 
+/// Initial capacity for asm.insns vector
+const ASSEMBLER_INSNS_CAPACITY: usize = 256;
+
 /// Object into which we assemble instructions to be
 /// optimized and lowered
 pub struct Assembler {
@@ -1016,8 +1019,8 @@ impl Assembler
 
     pub fn new_with_label_names(label_names: Vec<String>, side_exits: HashMap<SideExitContext, CodePtr>) -> Self {
         Self {
-            insns: Vec::default(),
-            live_ranges: Vec::default(),
+            insns: Vec::with_capacity(ASSEMBLER_INSNS_CAPACITY),
+            live_ranges: Vec::with_capacity(ASSEMBLER_INSNS_CAPACITY),
             label_names,
             ctx: Context::default(),
             side_exits,


### PR DESCRIPTION
Looking at perf profiling results on 30k_ifelse, I noticed `x86_split` and `alloc_regs` spend a considerable amount of time in `push_insn`, which spends majority of time in `Vec::push`.

To make these `Vec::push` calls faster, this PR sets initial capacity to the vectors modified by `push_insn`. 

## Size of asm.insns
I checked the max `asm.insns.len()` in the following benchmarks:

| benchmark | max `asm.insns.len()` |
|:------------|:----------------------|
| lobsters | 131 |
| railsbench | 131 |
| ruby-lsp | 190 |
| 30k_ifelse | 65 |
| 30k_methods | 65 |

To accommodate `Insn`s for these benchmarks, I chose 256. `size_of::<Insn>()` is 80, so each vector has 80 * 256 = 20KiB. Having up to four of such vectors at a time would consume 80KiB extra memory, but it doesn't seem significant compared to what the interpreter uses, and these vectors are transient anyway.

## Benchmarks: 1st itr
This speeds up the 1st itr of `30k_ifelse` by 7%. It also speeds up `lobsters`, `ruby-lsp`, and `30k_methods`. It doesn't seem to have a significant impact on RSS.

```
-----------  -----------  ----------  ---------  ----------  ----------  ---------  -------------  ------------
bench        before (ms)  stddev (%)  RSS (MiB)  after (ms)  stddev (%)  RSS (MiB)  after 1st itr  before/after
lobsters     1766.1       0.0         314.0      1659.5      0.0         317.1      1.06           1.06
railsbench   1512.9       0.0         103.5      1515.6      0.0         102.1      1.00           1.00
ruby-lsp     1526.7       0.0         106.8      1338.5      0.0         106.9      1.14           1.14
30k_ifelse   1378.1       0.0         98.9       1285.5      0.0         98.9       1.07           1.07
30k_methods  920.4        0.0         65.0       885.0       0.0         65.1       1.04           1.04
-----------  -----------  ----------  ---------  ----------  ----------  ---------  -------------  ------------
```