### PR TITLE
Optimize `Range#bsearch` for beginless/endless ranges

### DIFF
--- a/benchmark/range_bsearch.yml
+++ b/benchmark/range_bsearch.yml
@@ -1,0 +1,9 @@
+prelude: |
+  r = (1..)
+
+benchmark:
+  '10**1': r.bsearch { |x| x >= 10 }
+  '10**2': r.bsearch { |x| x >= 100 }
+  '10**3': r.bsearch { |x| x >= 1000 }
+  '10**4': r.bsearch { |x| x >= 10000 }
+  '10**5': r.bsearch { |x| x >= 100000 }

--- a/range.c
+++ b/range.c
@@ -758,6 +758,7 @@ range_bsearch(VALUE range)
                 return bsearch_integer_range(beg, mid, 0);
             }
             diff = rb_funcall(diff, '*', 1, LONG2FIX(2));
+            beg = mid;
         }
     }
     else if (NIL_P(beg) && is_integer_p(end)) {
@@ -770,6 +771,7 @@ range_bsearch(VALUE range)
                 return bsearch_integer_range(mid, end, 0);
             }
             diff = rb_funcall(diff, '*', 1, LONG2FIX(2));
+            end = mid;
         }
     }
     else {


### PR DESCRIPTION
In `Range#bsearch` for endless ranges, we try positions at `begin + 2**i` (i = 0, 1, 2, ...) to find a point that satisfies a given condition. Subsequently, we perform binary searching with the interval `[begin, begin + 2**n]`.

However, the interval `[begin + 2**(n-1), begin + 2**n]` is sufficient for binary search because `begin + 2**(n-1)` does not satisfy the condition.

The same applies to beginless ranges.

## benchmark

```ruby
require 'benchmark/ips'

Benchmark.ips do |x|
  r = (1..)

  1.upto(5) do |i|
    x.report("10**#{i}") do
      100.times do
        search = 10**i
        r.bsearch { |x| x >= search }
      end
    end
  end
end
```

before: ruby 3.3.0dev (2023-09-14T01:09:33Z master e50fcca9a7) [arm64-darwin22]

```
% ~/tmp/r/bin/ruby ~/bm.rb
Warming up --------------------------------------
               10**1     1.148k i/100ms
               10**2   723.000  i/100ms
               10**3   522.000  i/100ms
               10**4   393.000  i/100ms
               10**5   327.000  i/100ms
Calculating -------------------------------------
               10**1     11.455k (± 0.8%) i/s -     57.400k in   5.011444s
               10**2      7.245k (± 0.7%) i/s -     36.873k in   5.089349s
               10**3      5.248k (± 0.7%) i/s -     26.622k in   5.072963s
               10**4      3.997k (± 0.8%) i/s -     20.043k in   5.014992s
               10**5      3.317k (± 0.8%) i/s -     16.677k in   5.028277s
```

after

```
% ~/tmp/r/bin/ruby ~/bm.rb
Warming up --------------------------------------
               10**1     1.147k i/100ms
               10**2   794.000  i/100ms
               10**3   551.000  i/100ms
               10**4   409.000  i/100ms
               10**5   342.000  i/100ms
Calculating -------------------------------------
               10**1     11.517k (± 0.6%) i/s -     58.497k in   5.079274s
               10**2      7.913k (± 0.7%) i/s -     39.700k in   5.017003s
               10**3      5.529k (± 0.5%) i/s -     28.101k in   5.082603s
               10**4      4.099k (± 0.6%) i/s -     20.859k in   5.089185s
               10**5      3.411k (± 0.6%) i/s -     17.100k in   5.014102s
```