### PR TITLE
YJIT: Initialize Vec with capacity for iterators

### DIFF
--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -1568,7 +1568,7 @@ impl AssemblerDrainingIterator {
         Self {
             insns: asm.insns.into_iter().peekable(),
             index: 0,
-            indices: Vec::default()
+            indices: Vec::with_capacity(ASSEMBLER_INSNS_CAPACITY),
         }
     }
 


### PR DESCRIPTION
`AssemblerDrainingIterator::indices` is a vector parallel to `insns`. This PR applies the same optimization as https://github.com/ruby/ruby/pull/8437 to it.

This seems to have a positive impact on the 1st itr performance.

```
before: ruby 3.3.0dev (2023-09-14T15:11:32Z master 6df0927be2) +YJIT [x86_64-linux]
after: ruby 3.3.0dev (2023-09-14T16:22:29Z yjit-indices-cap 2cee09f07a) +YJIT [x86_64-linux]

-----------  -----------  ----------  ---------  ----------  ----------  ---------  -------------  ------------
bench        before (ms)  stddev (%)  RSS (MiB)  after (ms)  stddev (%)  RSS (MiB)  after 1st itr  before/after
lobsters     1666.2       0.0         313.6      1615.4      0.0         316.1      1.03           1.03
ruby-lsp     1313.8       0.0         106.6      1293.1      0.0         106.8      1.02           1.02
30k_ifelse   1246.4       0.0         98.8       1209.0      0.0         98.8       1.03           1.03
30k_methods  838.2        0.0         65.0       829.3       0.0         65.0       1.01           1.01
-----------  -----------  ----------  ---------  ----------  ----------  ---------  -------------  ------------
```