### PR TITLE
YJIT: Skip Insn::Comment and format! if disasm is disabled

### DIFF
--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -1724,7 +1724,9 @@ impl Assembler {
     }
 
     pub fn comment(&mut self, text: &str) {
-        self.push_insn(Insn::Comment(text.to_string()));
+        if cfg!(feature = "disasm") {
+            self.push_insn(Insn::Comment(text.to_string()));
+        }
     }
 
     #[must_use]
@@ -2001,6 +2003,16 @@ impl Assembler {
         out
     }
 }
+
+/// Macro to use format! for asm.comment, which skips a format! call
+/// when disasm is not supported.
+macro_rules! asm_comment {
+    ($asm:expr, $($fmt:tt)*) => {
+        #[cfg(feature = "disasm")]
+        $asm.comment(&format!($($fmt)*));
+    };
+}
+pub(crate) use asm_comment;
 
 #[cfg(test)]
 mod tests {

--- a/yjit/src/backend/tests.rs
+++ b/yjit/src/backend/tests.rs
@@ -87,7 +87,7 @@ fn test_mov_mem2mem()
 {
     let (mut asm, mut cb) = setup_asm();
 
-    asm.comment("check that comments work too");
+    asm_comment!(asm, "check that comments work too");
     asm.mov(Opnd::mem(64, SP, 0), Opnd::mem(64, SP, 8));
 
     asm.compile_with_num_regs(&mut cb, 1);

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -253,7 +253,7 @@ fn gen_counter_incr(asm: &mut Assembler, counter: Counter) {
     assert!(!DEFAULT_COUNTERS.contains(&counter), "gen_counter_incr incremented {:?}", counter);
 
     if get_option!(gen_stats) {
-        asm.comment(&format!("increment counter {}", counter.get_name()));
+        asm_comment!(asm, "increment counter {}", counter.get_name());
         let ptr = get_counter_ptr(&counter.get_name());
         let ptr_reg = asm.load(Opnd::const_ptr(ptr as *const u8));
         let counter_opnd = Opnd::mem(64, ptr_reg, 0);
@@ -436,7 +436,7 @@ fn gen_exit(exit_pc: *mut VALUE, asm: &mut Assembler) {
     #[cfg(all(feature = "disasm", not(test)))]
     {
         let opcode = unsafe { rb_vm_insn_addr2opcode((*exit_pc).as_ptr()) };
-        asm.comment(&format!("exit to interpreter on {}", insn_name(opcode as usize)));
+        asm_comment!(asm, "exit to interpreter on {}", insn_name(opcode as usize));
     }
 
     // Spill stack temps before returning to the interpreter
@@ -527,7 +527,7 @@ pub fn gen_counted_exit(side_exit: CodePtr, ocb: &mut OutlinedCb, counter: Optio
     let mut asm = Assembler::new();
 
     // Load the pointer into a register
-    asm.comment(&format!("increment counter {}", counter.get_name()));
+    asm_comment!(asm, "increment counter {}", counter.get_name());
     let ptr_reg = asm.load(Opnd::const_ptr(get_counter_ptr(&counter.get_name()) as *const u8));
     let counter_opnd = Opnd::mem(64, ptr_reg, 0);
 
@@ -697,7 +697,7 @@ pub fn gen_entry_prologue(
 
     let mut asm = Assembler::new();
     if get_option_ref!(dump_disasm).is_some() {
-        asm.comment(&format!("YJIT entry point: {}", iseq_get_location(iseq, 0)));
+        asm_comment!(asm, "YJIT entry point: {}", iseq_get_location(iseq, 0));
     } else {
         asm.comment("YJIT entry");
     }
@@ -863,8 +863,8 @@ pub fn gen_single_block(
     if get_option_ref!(dump_disasm).is_some() {
         let blockid_idx = blockid.idx;
         let chain_depth = if asm.ctx.get_chain_depth() > 0 { format!("(chain_depth: {})", asm.ctx.get_chain_depth()) } else { "".to_string() };
-        asm.comment(&format!("Block: {} {}", iseq_get_location(blockid.iseq, blockid_idx), chain_depth));
-        asm.comment(&format!("reg_temps: {:08b}", asm.ctx.get_reg_temps().as_u8()));
+        asm_comment!(asm, "Block: {} {}", iseq_get_location(blockid.iseq, blockid_idx), chain_depth);
+        asm_comment!(asm, "reg_temps: {:08b}", asm.ctx.get_reg_temps().as_u8());
     }
 
     // For each instruction to compile
@@ -920,7 +920,7 @@ pub fn gen_single_block(
         let mut status = None;
         if let Some(gen_fn) = get_gen_fn(VALUE(opcode)) {
             // Add a comment for the name of the YARV instruction
-            asm.comment(&format!("Insn: {:04} {} (stack_size: {})", insn_idx, insn_name(opcode), asm.ctx.get_stack_size()));
+            asm_comment!(asm, "Insn: {:04} {} (stack_size: {})", insn_idx, insn_name(opcode), asm.ctx.get_stack_size());
 
             // If requested, dump instructions for debugging
             if get_option!(dump_insns) {
@@ -1600,7 +1600,7 @@ fn gen_expandarray(
 
     // Guard on the comptime/expected array length
     if comptime_len >= num {
-        asm.comment(&format!("guard array length >= {}", num));
+        asm_comment!(asm, "guard array length >= {}", num);
         asm.cmp(array_len_opnd, num.into());
         jit_chain_guard(
             JCC_JB,
@@ -1612,7 +1612,7 @@ fn gen_expandarray(
         );
 
     } else {
-        asm.comment(&format!("guard array length == {}", comptime_len));
+        asm_comment!(asm, "guard array length == {}", comptime_len);
         asm.cmp(array_len_opnd, comptime_len.into());
         jit_chain_guard(
             JCC_JNE,
@@ -1640,7 +1640,7 @@ fn gen_expandarray(
         let offset = i32::try_from(i * (SIZEOF_VALUE as u32)).unwrap();
 
         // Missing elements are Qnil
-        asm.comment(&format!("load array[{}]", i));
+        asm_comment!(asm, "load array[{}]", i);
         let elem_opnd = if i < comptime_len { Opnd::mem(64, ary_opnd.unwrap(), offset) } else { Qnil.into() };
         asm.mov(top, elem_opnd);
     }
@@ -6935,7 +6935,7 @@ fn gen_send_general(
         let method_name = unsafe { cstr_to_rust_string(rb_id2name(mid)) };
         match (class_name, method_name) {
             (Some(class_name), Some(method_name)) => {
-                asm.comment(&format!("call to {}#{}", class_name, method_name))
+                asm_comment!(asm, "call to {}#{}", class_name, method_name);
             }
             _ => {}
         }


### PR DESCRIPTION
`format!` is taking some time even on release build. We should skip the call when `disasm` is not supported.

```
before: ruby 3.3.0dev (2023-09-14T18:16:21Z master 533c4072a9) +YJIT [x86_64-linux]
after: ruby 3.3.0dev (2023-09-14T20:14:08Z yjit-comment b9cbeee272) +YJIT [x86_64-linux]

----------  -----------  ----------  ---------  ----------  ----------  ---------  -------------  ------------
bench       before (ms)  stddev (%)  RSS (MiB)  after (ms)  stddev (%)  RSS (MiB)  after 1st itr  before/after
30k_ifelse  1225.0       0.0         98.8       1118.6      0.0         98.6       1.10           1.10
----------  -----------  ----------  ---------  ----------  ----------  ---------  -------------  ------------
```