### PR TITLE
YJIT: Avoid creating a vector in get_temp_regs()

### DIFF
--- a/yjit/src/backend/arm64/mod.rs
+++ b/yjit/src/backend/arm64/mod.rs
@@ -184,6 +184,10 @@ fn emit_load_value(cb: &mut CodeBlock, rd: A64Opnd, value: u64) -> usize {
     }
 }
 
+/// List of registers that can be used for stack temps.
+/// These are caller-saved registers.
+pub static TEMP_REGS: [Reg; 5] = [X1_REG, X9_REG, X10_REG, X14_REG, X15_REG];
+
 impl Assembler
 {
     // Special scratch registers for intermediate processing.
@@ -191,10 +195,6 @@ impl Assembler
     pub const SCRATCH_REG: Reg = X16_REG;
     const SCRATCH0: A64Opnd = A64Opnd::Reg(Assembler::SCRATCH_REG);
     const SCRATCH1: A64Opnd = A64Opnd::Reg(X17_REG);
-
-    /// List of registers that can be used for stack temps.
-    /// These are caller-saved registers.
-    pub const TEMP_REGS: [Reg; 5] = [X1_REG, X9_REG, X10_REG, X14_REG, X15_REG];
 
     /// Get the list of registers from which we will allocate on this platform
     /// These are caller-saved registers
@@ -1636,7 +1636,7 @@ mod tests {
     fn test_replace_mov_with_ldur() {
         let (mut asm, mut cb) = setup_asm();
 
-        asm.mov(Opnd::Reg(Assembler::TEMP_REGS[0]), Opnd::mem(64, CFP, 8));
+        asm.mov(Opnd::Reg(TEMP_REGS[0]), Opnd::mem(64, CFP, 8));
         asm.compile_with_num_regs(&mut cb, 1);
 
         assert_disasm!(cb, "618240f8", {"
@@ -1648,8 +1648,8 @@ mod tests {
     fn test_not_split_mov() {
         let (mut asm, mut cb) = setup_asm();
 
-        asm.mov(Opnd::Reg(Assembler::TEMP_REGS[0]), Opnd::UImm(0xffff));
-        asm.mov(Opnd::Reg(Assembler::TEMP_REGS[0]), Opnd::UImm(0x10000));
+        asm.mov(Opnd::Reg(TEMP_REGS[0]), Opnd::UImm(0xffff));
+        asm.mov(Opnd::Reg(TEMP_REGS[0]), Opnd::UImm(0x10000));
         asm.compile_with_num_regs(&mut cb, 1);
 
         assert_disasm!(cb, "e1ff9fd2e10370b2", {"
@@ -1663,7 +1663,7 @@ mod tests {
         let (mut asm, mut cb) = setup_asm();
 
         let out = asm.csel_l(Qtrue.into(), Qfalse.into());
-        asm.mov(Opnd::Reg(Assembler::TEMP_REGS[0]), out);
+        asm.mov(Opnd::Reg(TEMP_REGS[0]), out);
         asm.compile_with_num_regs(&mut cb, 2);
 
         assert_disasm!(cb, "8b0280d20c0080d261b18c9a", {"

--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -2,6 +2,7 @@
 #![allow(unused_variables)]
 #![allow(unused_imports)]
 
+use core::num;
 use std::cell::Cell;
 use std::collections::HashMap;
 use std::fmt;
@@ -16,11 +17,7 @@ use crate::core::{Context, Type, TempMapping, RegTemps, MAX_REG_TEMPS, MAX_TEMP_
 use crate::options::*;
 use crate::stats::*;
 
-#[cfg(target_arch = "x86_64")]
-use crate::backend::x86_64::*;
-
-#[cfg(target_arch = "aarch64")]
-use crate::backend::arm64::*;
+use crate::backend::current::*;
 
 pub const EC: Opnd = _EC;
 pub const CFP: Opnd = _CFP;
@@ -1030,10 +1027,9 @@ impl Assembler
     }
 
     /// Get the list of registers that can be used for stack temps.
-    pub fn get_temp_regs() -> Vec<Reg> {
+    pub fn get_temp_regs() -> &'static [Reg] {
         let num_regs = get_option!(num_temp_regs);
-        let mut regs = Self::TEMP_REGS.to_vec();
-        regs.drain(0..num_regs).collect()
+        &TEMP_REGS[0..num_regs]
     }
 
     /// Set a context for generating side exits

--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -2,7 +2,6 @@
 #![allow(unused_variables)]
 #![allow(unused_imports)]
 
-use core::num;
 use std::cell::Cell;
 use std::collections::HashMap;
 use std::fmt;

--- a/yjit/src/backend/mod.rs
+++ b/yjit/src/backend/mod.rs
@@ -4,5 +4,11 @@ pub mod x86_64;
 #[cfg(target_arch = "aarch64")]
 pub mod arm64;
 
+#[cfg(target_arch = "x86_64")]
+pub use x86_64 as current;
+
+#[cfg(target_arch = "aarch64")]
+pub use arm64 as current;
+
 pub mod ir;
 mod tests;

--- a/yjit/src/backend/x86_64/mod.rs
+++ b/yjit/src/backend/x86_64/mod.rs
@@ -84,6 +84,9 @@ impl From<&Opnd> for X86Opnd {
     }
 }
 
+/// List of registers that can be used for stack temps.
+pub static TEMP_REGS: [Reg; 5] = [RSI_REG, RDI_REG, R8_REG, R9_REG, R10_REG];
+
 impl Assembler
 {
     // A special scratch register for intermediate processing.
@@ -91,8 +94,6 @@ impl Assembler
     pub const SCRATCH_REG: Reg = R11_REG;
     const SCRATCH0: X86Opnd = X86Opnd::Reg(Assembler::SCRATCH_REG);
 
-    /// List of registers that can be used for stack temps.
-    pub const TEMP_REGS: [Reg; 5] = [RSI_REG, RDI_REG, R8_REG, R9_REG, R10_REG];
 
     /// Get the list of registers from which we can allocate on this platform
     pub fn get_alloc_regs() -> Vec<Reg>

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -2694,7 +2694,7 @@ pub fn gen_branch_stub_hit_trampoline(ocb: &mut OutlinedCb) -> CodePtr {
 /// Return registers to be pushed and popped on branch_stub_hit.
 /// The return value may include an extra register for x86 alignment.
 fn caller_saved_temp_regs() -> Vec<Opnd> {
-    let mut regs = Assembler::get_temp_regs();
+    let mut regs = Assembler::get_temp_regs().to_vec();
     if regs.len() % 2 == 1 {
         regs.push(*regs.last().unwrap()); // x86 alignment
     }

--- a/yjit/src/options.rs
+++ b/yjit/src/options.rs
@@ -1,5 +1,5 @@
 use std::ffi::CStr;
-use crate::backend::ir::Assembler;
+use crate::backend::current::TEMP_REGS;
 
 // Command-line options
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -156,7 +156,7 @@ pub fn parse_option(str_ptr: *const std::os::raw::c_char) -> Option<()> {
 
         ("temp-regs", _) => match opt_val.parse() {
             Ok(n) => {
-                assert!(n <= Assembler::TEMP_REGS.len(), "--yjit-temp-regs must be <= {}", Assembler::TEMP_REGS.len());
+                assert!(n <= TEMP_REGS.len(), "--yjit-temp-regs must be <= {}", TEMP_REGS.len());
                 unsafe { OPTIONS.num_temp_regs = n }
             }
             Err(_) => {


### PR DESCRIPTION
`Assembler::get_temp_regs()` is relatively frequently called through `lower_stack_opnd()`, and it allocates a vector. This PR changes it to return a slice to avoid allocations in that case.

The performance impact of this PR is small, but it does seem to exist, and the code seems as maintainable as the current master. So I think it's worth merging it.

```
before: ruby 3.3.0dev (2023-09-14T22:49:40Z master 982d6503b9) +YJIT [x86_64-linux]
after: ruby 3.3.0dev (2023-09-15T01:01:04Z yjit-temp-regs f1bd4f973d) +YJIT [x86_64-linux]

----------  -----------  ----------  ----------  ----------  -------------  ------------
bench       before (ms)  stddev (%)  after (ms)  stddev (%)  after 1st itr  before/after
30k_ifelse  1114.6       0.0         1108.0      0.0         1.01           1.01
----------  -----------  ----------  ----------  ----------  -------------  ------------
```