### PR TITLE
[Feature #19839] Fix `Range#overlap?` for empty ranges

### DIFF
--- a/benchmark/range_overlap.yml
+++ b/benchmark/range_overlap.yml
@@ -1,0 +1,19 @@
+prelude: |
+  class Range
+    unless method_defined?(:overlap?)
+      def overlap?(other)
+        other.begin == self.begin || cover?(other.begin) || other.cover?(self.begin)
+      end
+    end
+  end
+
+benchmark:
+  - (2..3).overlap?(1..1)
+  - (2..3).overlap?(2..4)
+  - (2..3).overlap?(4..5)
+  - (2..3).overlap?(2..1)
+  - (2..3).overlap?(0..1)
+  - (2..3).overlap?(...1)
+  - (2...3).overlap?(..2)
+  - (2...3).overlap?(3...)
+  - (2..3).overlap?('a'..'d')

--- a/test/ruby/test_range.rb
+++ b/test/ruby/test_range.rb
@@ -1076,7 +1076,42 @@ class TestRange < Test::Unit::TestCase
     assert_operator(0.., :overlap?, 1..2)
     assert_operator(0.., :overlap?, 1..)
 
+    assert_not_operator((1..3), :overlap?, ('a'..'d'))
+
     assert_raise(TypeError) { (0..).overlap?(1) }
     assert_raise(TypeError) { (0..).overlap?(nil) }
+
+    assert_operator((1..3), :overlap?, (2..4))
+    assert_operator((1...3), :overlap?, (2..3))
+    assert_operator((2..3), :overlap?, (1..2))
+    assert_operator((..3), :overlap?, (3..))
+    assert_operator((nil..nil), :overlap?, (3..))
+    assert_operator((nil...nil), :overlap?, (nil..))
+
+    assert_raise(TypeError) { (1..3).overlap?(1) }
+
+    assert_not_operator((1..2), :overlap?, (2...2))
+    assert_not_operator((2...2), :overlap?, (1..2))
+
+    assert_not_operator((4..1), :overlap?, (2..3))
+    assert_not_operator((4..1), :overlap?, (..3))
+    assert_not_operator((4..1), :overlap?, (2..))
+
+    assert_not_operator((1..4), :overlap?, (3..2))
+    assert_not_operator((..4), :overlap?, (3..2))
+    assert_not_operator((1..), :overlap?, (3..2))
+
+    assert_not_operator((4..5), :overlap?, (2..3))
+    assert_not_operator((4..5), :overlap?, (2...4))
+
+    assert_not_operator((1..2), :overlap?, (3..4))
+    assert_not_operator((1...3), :overlap?, (3..4))
+
+    assert_not_operator((4..5), :overlap?, (2..3))
+    assert_not_operator((4..5), :overlap?, (2...4))
+
+    assert_not_operator((1..2), :overlap?, (3..4))
+    assert_not_operator((1...3), :overlap?, (3..4))
+    assert_not_operator((...3), :overlap?, (3..))
   end
 end


### PR DESCRIPTION
Empty ranges do not overlap with any range.

Regarding benchmarks, #8242 is significantly faster in some cases, but one of these two cases is a wrong result.

|                           |ActiveSupport| PR#8242|built-ruby|
|:--------------------------|------------:|-------:|---------:|
|(2..3).overlap?(1..1)      |       7.761M| 15.053M|   32.368M|
|                           |            -|   1.94x|     4.17x|
|(2..3).overlap?(2..4)      |      25.720M| 55.070M|   21.981M|
|                           |        1.17x|   2.51x|         -|
|(2..3).overlap?(4..5)      |       7.616M| 15.048M|   21.730M|
|                           |            -|   1.98x|     2.85x|
|(2..3).overlap?(2..1)      |      25.585M| 56.545M|   32.786M|
|                           |            -|   2.21x|     1.28x|
|(2..3).overlap?(0..1)      |       7.554M| 14.755M|   32.545M|
|                           |            -|   1.95x|     4.31x|
|(2..3).overlap?(...1)      |       6.681M|  5.843M|   32.255M|
|                           |        1.14x|       -|     5.52x|
|(2...3).overlap?(..2)      |       6.676M|  5.817M|   21.572M|
|                           |        1.15x|       -|     3.71x|
|(2...3).overlap?(3...)     |       7.392M| 14.755M|   31.805M|
|                           |            -|   2.00x|     4.30x|
|(2..3).overlap?('a'..'d')  |       3.675M|  3.482M|   17.009M|
|                           |        1.06x|       -|     4.89x|