### PR TITLE
YJIT: Fix object movement bug in iseq guard for invokeblock

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -1,3 +1,15 @@
+# regression test for invokeblock iseq guard
+assert_equal 'ok', %q{
+  return :ok unless defined?(GC.compact)
+  def foo = yield
+  10.times do |i|
+    ret = eval("foo { #{i} }")
+    raise "failed at #{i}" unless ret == i
+    GC.compact
+  end
+  :ok
+} unless defined?(RubyVM::RJIT) && RubyVM::RJIT.enabled? # Not yet working on RJIT
+
 # regression test for overly generous guard elision
 assert_equal '[0, :sum, 0, :sum]', %q{
   # In faulty versions, the following happens:

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -7494,7 +7494,7 @@ fn gen_invokeblock_specialized(
         asm_comment!(asm, "guard known ISEQ");
         let captured_opnd = asm.and(block_handler_opnd, Opnd::Imm(!0x3));
         let iseq_opnd = asm.load(Opnd::mem(64, captured_opnd, SIZEOF_VALUE_I32 * 2));
-        asm.cmp(iseq_opnd, (comptime_iseq as usize).into());
+        asm.cmp(iseq_opnd, VALUE::from(comptime_iseq).into());
         jit_chain_guard(
             JCC_JNE,
             jit,


### PR DESCRIPTION
Since the compile time iseq used in the guard was not marked and updated
during compaction, a runtime value reusing an address could falsly pass
the guard.

Should hopefully fix flaky NoMethodError failures like <http://ci.rvm.jp/results/trunk-yjit@ruby-sp2-docker/4712036>, where it is calling the wrong block.