### PR TITLE
Fix malloc_trim() on wasm32

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -48,7 +48,7 @@
 # endif
 #endif
 
-#ifdef HAVE_MALLOC_USABLE_SIZE
+#if defined(HAVE_MALLOC_USABLE_SIZE) || defined(HAVE_MALLOC_TRIM)
 # ifdef RUBY_ALTERNATIVE_MALLOC_HEADER
 /* Alternative malloc header is included in ruby/missing.h */
 # elif defined(HAVE_MALLOC_H)


### PR DESCRIPTION
```
compiling gc.c
gc.c:9746:5: error: implicit declaration of function 'malloc_trim' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
    malloc_trim(0);
    ^
1 error generated.
```

cc @peterzhu2118 