### PR TITLE
[Bug #19887] RUBYOPT should work without leading `-`

### DIFF
--- a/ruby.c
+++ b/ruby.c
@@ -904,12 +904,13 @@ moreswitches(const char *s, ruby_cmdline_options_t *opt, int envopt)
 
     opt->src.enc.name = opt->ext.enc.name = opt->intern.enc.name = 0;
 
-    argstr = rb_str_tmp_new((len = strlen(s)) + (envopt!=0));
+    const int hyphen = *s != '-';
+    argstr = rb_str_tmp_new((len = strlen(s)) + hyphen);
     argary = rb_str_tmp_new(0);
 
     p = RSTRING_PTR(argstr);
-    if (envopt) *p++ = ' ';
-    memcpy(p, s, len + 1);
+    if (hyphen) *p = '-';
+    memcpy(p + hyphen, s, len + 1);
     ap = 0;
     rb_str_cat(argary, (char *)&ap, sizeof(ap));
     while (*p) {

--- a/test/ruby/test_rubyoptions.rb
+++ b/test/ruby/test_rubyoptions.rb
@@ -416,6 +416,9 @@ class TestRubyOptions < Test::Unit::TestCase
     assert_in_out_err(%w(), "p Warning[:experimental]", ["false"])
     ENV['RUBYOPT'] = '-W:qux'
     assert_in_out_err(%w(), "", [], /unknown warning category: `qux'/)
+
+    ENV['RUBYOPT'] = 'w'
+    assert_in_out_err(%w(), "p $VERBOSE", ["true"])
   ensure
     ENV['RUBYOPT'] = rubyopt_orig
   end

--- a/test/ruby/test_rubyoptions.rb
+++ b/test/ruby/test_rubyoptions.rb
@@ -99,8 +99,7 @@ class TestRubyOptions < Test::Unit::TestCase
   end
 
   def test_warning
-    save_rubyopt = ENV['RUBYOPT']
-    ENV['RUBYOPT'] = nil
+    save_rubyopt = ENV.delete('RUBYOPT')
     assert_in_out_err(%w(-W0 -e) + ['p $-W'], "", %w(0), [])
     assert_in_out_err(%w(-W1 -e) + ['p $-W'], "", %w(1), [])
     assert_in_out_err(%w(-Wx -e) + ['p $-W'], "", %w(2), [])
@@ -418,11 +417,7 @@ class TestRubyOptions < Test::Unit::TestCase
     ENV['RUBYOPT'] = '-W:qux'
     assert_in_out_err(%w(), "", [], /unknown warning category: `qux'/)
   ensure
-    if rubyopt_orig
-      ENV['RUBYOPT'] = rubyopt_orig
-    else
-      ENV.delete('RUBYOPT')
-    end
+    ENV['RUBYOPT'] = rubyopt_orig
   end
 
   def test_search


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/19887