### PR TITLE
Support `alias $global $global2` in YARP

### DIFF
--- a/test/yarp/compiler_test.rb
+++ b/test/yarp/compiler_test.rb
@@ -242,6 +242,22 @@ module YARP
       assert_equal (1), compile("(1)")
     end
 
+    def test_alias_globals
+      rd, wr = IO.pipe
+      pid = fork {
+        rd.close
+        $foo = 123
+        code = "alias $bar $foo; $bar"
+        wr.write Marshal.dump(RubyVM::InstructionSequence.compile_yarp(code).eval)
+        wr.close
+      }
+      wr.close
+      Process.waitpid pid
+      assert_equal 123, Marshal.load(rd.read)
+    ensure
+      rd.close
+    end
+
     private
 
     def compile(source)


### PR DESCRIPTION
This patch adds alias global support to the YARP compiler.  It only works with normal globals, not special globals like `$1` though.

The test might be a little bit overboard 😅 