### PR TITLE
Move IO#readline to Ruby

### DIFF
--- a/internal/vm.h
+++ b/internal/vm.h
@@ -58,6 +58,8 @@ VALUE rb_yield_refine_block(VALUE refinement, VALUE refinements);
 VALUE ruby_vm_special_exception_copy(VALUE);
 PUREFUNC(st_table *rb_vm_fstring_table(void));
 
+void rb_lastline_set_up(VALUE val, unsigned int up);
+
 /* vm_eval.c */
 VALUE rb_current_realfilepath(void);
 VALUE rb_check_block_call(VALUE, ID, int, const VALUE *, rb_block_call_func_t, VALUE);

--- a/io.rb
+++ b/io.rb
@@ -120,4 +120,17 @@ class IO
   def write_nonblock(buf, exception: true)
     Primitive.io_write_nonblock(buf, exception)
   end
+
+  # call-seq:
+  #   readline(sep = $/, chomp: false)   -> string
+  #   readline(limit, chomp: false)      -> string
+  #   readline(sep, limit, chomp: false) -> string
+  #
+  # Reads a line as with IO#gets, but raises EOFError if already at end-of-stream.
+  #
+  # Optional keyword argument +chomp+ specifies whether line separators
+  # are to be omitted.
+  def readline(sep = $/, limit = nil, chomp: false)
+    Primitive.io_readline(sep, limit, chomp)
+  end
 end

--- a/vm.c
+++ b/vm.c
@@ -1750,6 +1750,17 @@ rb_lastline_set(VALUE val)
     vm_svar_set(GET_EC(), VM_SVAR_LASTLINE, val);
 }
 
+void
+rb_lastline_set_up(VALUE val, unsigned int up)
+{
+    rb_control_frame_t * cfp = GET_EC()->cfp;
+
+    for(unsigned int i = 0; i < up; i++) {
+        cfp = RUBY_VM_PREVIOUS_CONTROL_FRAME(cfp);
+    }
+    vm_cfp_svar_set(GET_EC(), cfp, VM_SVAR_LASTLINE, val);
+}
+
 /* misc */
 
 const char *


### PR DESCRIPTION
This commit moves IO#readline to Ruby.  In order to call C functions, keyword arguments must be converted to hashes.  Prior to this commit, code like `io.readline(chomp: true)` would allocate a hash.  This commits moves the keyword "denaturing" to Ruby, allowing us to send positional arguments to the C API and avoiding the hash allocation.

Here is an allocation benchmark for the method:

```
x = GC.stat(:total_allocated_objects)
File.open("/usr/share/dict/words") do |f|
  f.readline(chomp: true) until f.eof?
end
p ALLOCATIONS: GC.stat(:total_allocated_objects) - x
```

Before this commit, the output was this:

```
$ make run
./miniruby -I./lib -I. -I.ext/common  -r./arm64-darwin22-fake  ./test.rb
{:ALLOCATIONS=>707939}
```

Now it is this:

```
$ make run
./miniruby -I./lib -I. -I.ext/common  -r./arm64-darwin22-fake  ./test.rb
{:ALLOCATIONS=>471962}
```

[Bug #19890] [ruby-core:114803]