### PR TITLE
sync_default_gems: Fix the case of file to be ignored with to be removed

### DIFF
--- a/tool/sync_default_gems.rb
+++ b/tool/sync_default_gems.rb
@@ -596,7 +596,7 @@ module SyncDefaultGems
     unless ignore.empty?
       puts "Reset ignored files: #{ignore.join(', ')}"
       system(*%W"git rm -r --", *ignore)
-      system(*%W"git checkout -f", base, "--", *ignore)
+      ignore.each {|f| system(*%W"git checkout -f", base, "--", f)}
     end
 
     if changed.empty?


### PR DESCRIPTION
The case of https://github.com/ruby/ruby/commit/7fc73ab5f6fbe46655855079954b26dcc14576b3, which modified `.gitignore` and `.github/workflows/main.yml`.
Both files need to be rejected and restored, but since the latter file was not there before, `git checkout` failed and the former file could not be restored along with it.
To fix this failure, restore the ignored files one by one.