### PR TITLE
Optimize `Range#bsearch` for beginless/endless ranges within Fixnum

### DIFF
--- a/benchmark/range_bsearch.yml
+++ b/benchmark/range_bsearch.yml
@@ -1,9 +1,21 @@
 prelude: |
-  r = (1..)
+  re = (1..)
+  rb = (..0)
 
 benchmark:
-  '10**1': r.bsearch { |x| x >= 10 }
-  '10**2': r.bsearch { |x| x >= 100 }
-  '10**3': r.bsearch { |x| x >= 1000 }
-  '10**4': r.bsearch { |x| x >= 10000 }
-  '10**5': r.bsearch { |x| x >= 100000 }
+  'endless 10**0': re.bsearch { |x| x >= 1 }
+  'endless 10**1': re.bsearch { |x| x >= 10 }
+  'endless 10**2': re.bsearch { |x| x >= 100 }
+  'endless 10**3': re.bsearch { |x| x >= 1000 }
+  'endless 10**4': re.bsearch { |x| x >= 10000 }
+  'endless 10**5': re.bsearch { |x| x >= 100000 }
+  'endless 10**10': re.bsearch { |x| x >= 10000000000 }
+  'endless 10**100': re.bsearch { |x| x >= 10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 }
+  'beginless -10**0': rb.bsearch { |x| x >= -1 }
+  'beginless -10**1': rb.bsearch { |x| x >= -10 }
+  'beginless -10**2': rb.bsearch { |x| x >= -100 }
+  'beginless -10**3': rb.bsearch { |x| x >= -1000 }
+  'beginless -10**4': rb.bsearch { |x| x >= -10000 }
+  'beginless -10**5': rb.bsearch { |x| x >= -100000 }
+  'beginless -10**10': rb.bsearch { |x| x >= -10000000000 }
+  'beginless -10**100': rb.bsearch { |x| x >= -10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 }

--- a/test/ruby/test_range.rb
+++ b/test/ruby/test_range.rb
@@ -1047,7 +1047,10 @@ class TestRange < Test::Unit::TestCase
     assert_equal(nil, (bignum...bignum+ary.size).bsearch {|i| ary[i - bignum] >= 100 })
     assert_equal(bignum + 0, (bignum...bignum+ary.size).bsearch {|i| true })
     assert_equal(nil, (bignum...bignum+ary.size).bsearch {|i| false })
+
+    assert_equal(bignum * 2 + 1, (0...).bsearch {|i| i > bignum * 2 })
     assert_equal(bignum * 2 + 1, (bignum...).bsearch {|i| i > bignum * 2 })
+    assert_equal(-bignum * 2 + 1, (...0).bsearch {|i| i > -bignum * 2 })
     assert_equal(-bignum * 2 + 1, (...-bignum).bsearch {|i| i > -bignum * 2 })
 
     assert_raise(TypeError) { ("a".."z").bsearch {} }


### PR DESCRIPTION
Let's consider a endless range `n..`.
When performing `bsearch` on this range, we first look for an `m > n` that satisfies the condition, and then carry out a binary search on the interval `[n, m]`.
Currently, `bsearch_integer_range` is used for the binary search on this `[n, m]`.
However, when both `n` and `m` are `Fixnum`, we can use `BSEARCH` instead.

## benchmark

benchmark/range_bsearch.yml (ips)

|                    | master   | PR       | ratio |
|:-------------------|---------:|---------:|------:|
|endless 10**0       |   3.462M |   4.696M | 1.356 |
|endless 10**1       |   1.476M |   2.182M | 1.478 |
|endless 10**2       | 857.339k |   1.366M | 1.593 |
|endless 10**3       | 595.369k |   1.005M | 1.688 |
|endless 10**4       | 436.656k | 735.579k | 1.684 |
|endless 10**5       | 359.428k | 610.058k | 1.697 |
|endless 10**10      | 182.439k | 318.632k | 1.746 |
|endless 10**100     |   4.996k |   4.996k | 1.000 |
|beginless -10**0    |   2.664M |   3.617M | 1.357 |
|beginless -10**1    |   1.520M |   2.288M | 1.505 |
|beginless -10**2    | 864.470k |   1.417M | 1.639 |
|beginless -10**3    | 623.544k |   1.024M | 1.642 |
|beginless -10**4    | 438.421k | 743.375k | 1.695 |
|beginless -10**5    | 361.527k | 611.817k | 1.692 |
|beginless -10**10   | 181.906k | 320.272k | 1.760 |
|beginless -10**100  |   4.296k |   4.214k | 0.980 |
