### PR TITLE
Do not hide the IO in rb_f_backquote if a scheduler is registered

### DIFF
--- a/io.c
+++ b/io.c
@@ -10467,7 +10467,11 @@ rb_f_backquote(VALUE obj, VALUE str)
     if (NIL_P(port)) return rb_str_new(0,0);
 
     GetOpenFile(port, fptr);
-    rb_obj_hide(port);
+
+    if (NIL_P(rb_fiber_scheduler_current())) {
+        rb_obj_hide(port);
+    }
+
     result = read_all(fptr, remain_size(fptr), Qnil);
     rb_io_close(port);
     RFILE(port)->fptr = NULL;


### PR DESCRIPTION
Otherwise we end up passing an hidden object to Ruby code which is invalid.

```
NotImplementedError: method `hash' called on hidden T_FILE object (0x0000000119cd5ca0 flags=0xb)
    src/graphql-ruby/spec/support/dummy_scheduler.rb:159:in `io_wait'
```

This `hide` was recently added as a response to https://bugs.ruby-lang.org/issues/19624