### PR TITLE
`.NOTPARALLEL` with prerequisites needs recent GNU Make

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1289,7 +1289,6 @@ $(REVISION_H)$(yes_baseruby:yes=~disabled~):
 # $(MKFILES): $(REVISION_H)
 
 ripper_srcs: $(RIPPER_SRCS)
-.NOTPARALLEL: ripper_srcs
 
 $(RIPPER_SRCS): $(srcdir)/parse.y $(srcdir)/defs/id.def
 $(RIPPER_SRCS): $(srcdir)/ext/ripper/tools/preproc.rb $(srcdir)/ext/ripper/tools/dsl.rb

--- a/defs/gmake.mk
+++ b/defs/gmake.mk
@@ -518,7 +518,13 @@ matz: up
 tags:
 	$(MAKE) GIT="$(GIT)" -C "$(srcdir)" -f defs/tags.mk
 
-ifeq ($(DOT_WAIT),)
+
+# ripper_srcs makes all sources at once. invoking this target multiple
+# times in parallel means all sources will be built for the number of
+# sources times respectively.
+ifneq ($(DOT_WAIT),)
+.NOTPARALLEL: ripper_srcs
+else
 ripper_src =
 $(foreach r,$(RIPPER_SRCS),$(eval $(value r): | $(value ripper_src))\
 	$(eval ripper_src := $(value r)))


### PR DESCRIPTION
GNU Make prior to 4.4 just ignores the prerequisites, and runs everything in serial.