### PR TITLE
[Bug #19892] Clean intermediate files regardless `-keep_temp`

### DIFF
--- a/tool/make-snapshot
+++ b/tool/make-snapshot
@@ -384,8 +384,21 @@ def package(vcs, rev, destdir, tmp = nil)
     puts $colorize.fail("patching failed")
     return
   end
-  def (clean = []).add(n) push(n); n end
-  def clean.create(file, content = "") File.binwrite(add(file), content) end
+
+  class << (clean = [])
+    def add(n) push(n)
+      n
+    end
+    def create(file, content = "", &block)
+      add(file)
+      if block
+        File.open(file, "wb", &block)
+      else
+        File.binwrite(file, content)
+      end
+    end
+  end
+
   Dir.chdir(v) do
     unless File.exist?("ChangeLog")
       vcs.export_changelog(url, nil, revision, "ChangeLog")
@@ -406,7 +419,7 @@ def package(vcs, rev, destdir, tmp = nil)
       puts
     end
 
-    File.open(clean.add("cross.rb"), "w") do |f|
+    clean.create("cross.rb") do |f|
       f.puts "Object.__send__(:remove_const, :CROSS_COMPILING) if defined?(CROSS_COMPILING)"
       f.puts "CROSS_COMPILING=true"
       f.puts "Object.__send__(:remove_const, :RUBY_PLATFORM)"

--- a/tool/make-snapshot
+++ b/tool/make-snapshot
@@ -518,8 +518,7 @@ touch-unicode-files:
     end
     vcs.after_export(".") if exported
     clean.concat(Dir.glob("ext/**/autom4te.cache"))
-    FileUtils.rm_rf(clean) unless $keep_temp
-    FileUtils.rm_rf(".downloaded-cache")
+    clean.add(".downloaded-cache")
     if File.exist?("gems/bundled_gems")
       gems = Dir.glob("gems/*.gem")
       gems -= File.readlines("gems/bundled_gems").map {|line|
@@ -527,10 +526,11 @@ touch-unicode-files:
         name, version, _ = line.split(' ')
         "gems/#{name}-#{version}.gem"
       }
-      FileUtils.rm_f(gems)
+      clean.concat(gems)
     else
-      FileUtils.rm_rf("gems")
+      clean.add("gems")
     end
+    FileUtils.rm_rf(clean)
     if modified
       touch_all(modified, "**/*/", 0) do |name, stat|
         stat.mtime > modified


### PR DESCRIPTION
Not to include such files in the result packages.