### PR TITLE
Directly free structure managed by imemo tmpbuf

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -12721,13 +12721,9 @@ static NODE*
 new_args_tail(struct parser_params *p, NODE *kw_args, ID kw_rest_arg, ID block, const YYLTYPE *kw_rest_loc)
 {
     int saved_line = p->ruby_sourceline;
-    NODE *node;
-    VALUE tmpbuf = rb_imemo_tmpbuf_auto_free_pointer();
+    NODE *node = NEW_NODE(NODE_ARGS, 0, 0, 0, &NULL_LOC);
     struct rb_args_info *args = ZALLOC(struct rb_args_info);
-    rb_imemo_tmpbuf_set_ptr(tmpbuf, args);
-    args->imemo = tmpbuf;
-    node = NEW_NODE(NODE_ARGS, 0, 0, args, &NULL_LOC);
-    RB_OBJ_WRITTEN(p->ast, Qnil, tmpbuf);
+    node->nd_ainfo = args;
     if (p->error_p) return node;
 
     args->block_arg      = block;
@@ -12818,12 +12814,9 @@ static NODE*
 new_array_pattern_tail(struct parser_params *p, NODE *pre_args, int has_rest, NODE *rest_arg, NODE *post_args, const YYLTYPE *loc)
 {
     int saved_line = p->ruby_sourceline;
-    NODE *node;
-    VALUE tmpbuf = rb_imemo_tmpbuf_auto_free_pointer();
+    NODE *node = NEW_NODE(NODE_ARYPTN, 0, 0, 0, loc);
     struct rb_ary_pattern_info *apinfo = ZALLOC(struct rb_ary_pattern_info);
-    rb_imemo_tmpbuf_set_ptr(tmpbuf, apinfo);
-    node = NEW_NODE(NODE_ARYPTN, 0, tmpbuf, apinfo, loc);
-    RB_OBJ_WRITTEN(p->ast, Qnil, tmpbuf);
+    node->nd_apinfo = apinfo;
 
     apinfo->pre_args = pre_args;
 
@@ -12852,12 +12845,9 @@ static NODE*
 new_find_pattern_tail(struct parser_params *p, NODE *pre_rest_arg, NODE *args, NODE *post_rest_arg, const YYLTYPE *loc)
 {
     int saved_line = p->ruby_sourceline;
-    NODE *node;
-    VALUE tmpbuf = rb_imemo_tmpbuf_auto_free_pointer();
+    NODE *node = NEW_NODE(NODE_FNDPTN, 0, 0, 0, loc);
     struct rb_fnd_pattern_info *fpinfo = ZALLOC(struct rb_fnd_pattern_info);
-    rb_imemo_tmpbuf_set_ptr(tmpbuf, fpinfo);
-    node = NEW_NODE(NODE_FNDPTN, 0, tmpbuf, fpinfo, loc);
-    RB_OBJ_WRITTEN(p->ast, Qnil, tmpbuf);
+    node->nd_fpinfo = fpinfo;
 
     fpinfo->pre_rest_arg = pre_rest_arg ? pre_rest_arg : NODE_SPECIAL_NO_NAME_REST;
     fpinfo->args = args;

--- a/ruby_parser.c
+++ b/ruby_parser.c
@@ -566,8 +566,6 @@ rb_parser_config_initialize(rb_parser_config_t *config)
 
     config->new_strterm = new_strterm;
     config->strterm_is_heredoc = strterm_is_heredoc;
-    config->tmpbuf_auto_free_pointer = rb_imemo_tmpbuf_auto_free_pointer;
-    config->tmpbuf_set_ptr = rb_imemo_tmpbuf_set_ptr;
     config->tmpbuf_parser_heap = tmpbuf_parser_heap;
     config->ast_new = ast_new;
 

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -292,8 +292,6 @@ struct rb_args_info {
     unsigned int no_kwarg: 1;
     unsigned int ruby2_keywords: 1;
     unsigned int forwarding: 1;
-
-    VALUE imemo;
 };
 
 struct rb_ary_pattern_info {
@@ -364,8 +362,6 @@ typedef struct rb_parser_config_struct {
     // TODO: Should it return `rb_strterm_t *'?
     VALUE (*new_strterm)(VALUE v1, VALUE v2, VALUE v3, VALUE v0, int heredoc);
     int (*strterm_is_heredoc)(VALUE strterm);
-    VALUE (*tmpbuf_auto_free_pointer)(void);
-    void *(*tmpbuf_set_ptr)(VALUE v, void *ptr);
     rb_imemo_tmpbuf_t *(*tmpbuf_parser_heap)(void *buf, rb_imemo_tmpbuf_t *old_heap, size_t cnt);
     rb_ast_t *(*ast_new)(VALUE nb);
 

--- a/universal_parser.c
+++ b/universal_parser.c
@@ -113,8 +113,6 @@ struct rb_imemo_tmpbuf_struct {
 
 #define new_strterm p->config->new_strterm
 #define strterm_is_heredoc p->config->strterm_is_heredoc
-#define rb_imemo_tmpbuf_auto_free_pointer p->config->tmpbuf_auto_free_pointer
-#define rb_imemo_tmpbuf_set_ptr p->config->tmpbuf_set_ptr
 #define rb_imemo_tmpbuf_parser_heap p->config->tmpbuf_parser_heap
 
 #define compile_callback         p->config->compile_callback


### PR DESCRIPTION
NODE_ARGS, NODE_ARYPTN, NODE_FNDPTN manage memory of their structure by imemo tmpbuf Object.
However rb_ast_struct has reference to NODE. Then these memory can be freed directly when rb_ast_struct is freed.

This commit reduces parser's dependency on CRuby functions.