### PR TITLE
[YARP] Add tests for popped instructions

### DIFF
--- a/test/yarp/compiler_test.rb
+++ b/test/yarp/compiler_test.rb
@@ -225,7 +225,7 @@ module YARP
 
     def test_InterpolatedXStringNode
       test_yarp_eval('`echo #{1}`')
-      test_yarp_eval('`printf "100"`')
+      test_yarp_eval('`printf #{"100"}`')
     end
 
     def test_RegularExpressionNode
@@ -278,11 +278,18 @@ module YARP
 
     private
 
-    def test_yarp_eval(source)
+    def compare_eval(source)
       ruby_eval = RubyVM::InstructionSequence.compile(source).eval
       yarp_eval = RubyVM::InstructionSequence.compile_yarp(source).eval
 
       assert_equal ruby_eval, yarp_eval
+    end
+
+    def test_yarp_eval(source)
+      compare_eval(source)
+
+      # Test "popped" functionality
+      compare_eval("#{source}; 1")
     end
   end
 end

--- a/yarp/yarp_compiler.c
+++ b/yarp/yarp_compiler.c
@@ -1529,12 +1529,14 @@ yp_compile_node(rb_iseq_t *iseq, const yp_node_t *node, LINK_ANCHOR *const ret, 
       }
       case YP_MULTI_WRITE_NODE: {
           yp_multi_write_node_t *multi_write_node = (yp_multi_write_node_t *)node;
-          YP_COMPILE(multi_write_node->value);
+          YP_COMPILE_NOT_POPPED(multi_write_node->value);
 
           // TODO: int flag = 0x02 | (NODE_NAMED_REST_P(restn) ? 0x01 : 0x00);
           int flag = 0x00;
 
-          ADD_INSN(ret, &dummy_line_node, dup);
+          if (!popped) {
+              ADD_INSN(ret, &dummy_line_node, dup);
+          }
           ADD_INSN2(ret, &dummy_line_node, expandarray, INT2FIX(multi_write_node->targets.size), INT2FIX(flag));
           yp_node_list_t node_list = multi_write_node->targets;
 


### PR DESCRIPTION
Prior to this PR, our test suite never tested the "popped" codepath. By adding "; 1" to all existing test cases, we can also test the popped codepath 