### PR TITLE
fix leak in module clone

### DIFF
--- a/class.c
+++ b/class.c
@@ -471,6 +471,7 @@ copy_tables(VALUE clone, VALUE orig)
         rb_id_table_foreach(rb_cvc_tbl, cvc_table_copy, &ctx);
         RCLASS_CVC_TBL(clone) = rb_cvc_tbl_dup;
     }
+    rb_id_table_free(RCLASS_M_TBL(clone));
     RCLASS_M_TBL(clone) = 0;
     if (!RB_TYPE_P(clone, T_ICLASS)) {
         st_data_t id;

--- a/test/ruby/test_module.rb
+++ b/test/ruby/test_module.rb
@@ -3321,6 +3321,18 @@ class TestModule < Test::Unit::TestCase
     CODE
   end
 
+  def test_module_clone_memory_leak
+    # [Bug #19901]
+    assert_no_memory_leak([], <<~PREP, <<~CODE, rss: true)
+      code = proc do
+        Module.new.clone
+      end
+      1_000.times(&code)
+    PREP
+      1_000_000.times(&code)
+    CODE
+  end
+
   private
 
   def assert_top_method_is_private(method)


### PR DESCRIPTION
issue: https://bugs.ruby-lang.org/issues/19901

reproduction:

```ruby
m = Module.new

20.times do
  100_000.times do
    m.clone
  end

  puts `ps -o rss= -p #{$$}`
end
```

before:

```
21544
24708
27860
31024
33928
37360
40264
43432
46600
49768
52936
55840
59008
62176
65344
68512
71680
74584
77752
80920
```

after:

```
18808
18808
18872
18872
18872
18872
18872
18872
18872
18872
18872
18872
18872
18872
18872
18872
18872
18872
18872
18872
```