### PR TITLE
[DOC] Correction for doc guide + TOC fix in File

### DIFF
--- a/doc/contributing/documentation_guide.md
+++ b/doc/contributing/documentation_guide.md
@@ -216,14 +216,12 @@ may not render them properly.
 In particular, avoid building tables with HTML tags
 (<tt><table></tt>, etc.).
 
-Alternatives are:
-
-- The GFM (GitHub Flavored Markdown) table extension,
-  which is enabled by default. See
-  {GFM tables extension}[https://github.github.com/gfm/#tables-extension-].
+An alternative is:
 
 - A {verbatim text block}[rdoc-ref:RDoc::MarkupReference@Verbatim+Text+Blocks],
   using spaces and punctuation to format the text.
+  See {examples}[rdoc-ref:File@Read-2FWrite+Mode].
+
   Note that {text markup}[rdoc-ref:RDoc::MarkupReference@Text+Markup]
   will not be honored.
 

--- a/file.c
+++ b/file.c
@@ -6531,7 +6531,7 @@ const char ruby_null_device[] =
  *  \Class \File extends module FileTest, supporting such singleton methods
  *  as <tt>File.exist?</tt>.
  *
- *  === About the Examples
+ *  == About the Examples
  *
  *  Many examples here use these variables:
  *


### PR DESCRIPTION
The doc guide is corrected to omit reference to GFM tables, which RDoc does not support.

In linking to verbatim example, I discovered an TOC jump-level that caused most of the headings in File doc to be omitted from the doc's left-TOC for the class.  Now corrected.