### PR TITLE
[Feature #19790] Crash report

### DIFF
--- a/addr2line.c
+++ b/addr2line.c
@@ -144,7 +144,7 @@ void *alloca();
 #define DW_LNE_define_file              0x03
 #define DW_LNE_set_discriminator        0x04  /* DWARF4 */
 
-#define kprintf(...) fprintf(stderr, "" __VA_ARGS__)
+#define kprintf(...) fprintf(errout, "" __VA_ARGS__)
 
 typedef struct line_info {
     const char *dirname;
@@ -254,7 +254,7 @@ sleb128(const char **p)
 }
 
 static const char *
-get_nth_dirname(unsigned long dir, const char *p)
+get_nth_dirname(unsigned long dir, const char *p, FILE *errout)
 {
     if (!dir--) {
 	return "";
@@ -271,10 +271,14 @@ get_nth_dirname(unsigned long dir, const char *p)
     return p;
 }
 
-static const char *parse_ver5_debug_line_header(const char *p, int idx, uint8_t format, obj_info_t *obj, const char **out_path, uint64_t *out_directory_index);
+static const char *parse_ver5_debug_line_header(
+    const char *p, int idx, uint8_t format,
+    obj_info_t *obj, const char **out_path,
+    uint64_t *out_directory_index, FILE *errout);
 
 static void
-fill_filename(int file, uint8_t format, uint16_t version, const char *include_directories, const char *filenames, line_info_t *line, obj_info_t *obj)
+fill_filename(int file, uint8_t format, uint16_t version, const char *include_directories,
+              const char *filenames, line_info_t *line, obj_info_t *obj, FILE *errout)
 {
     int i;
     const char *p = filenames;
@@ -283,9 +287,9 @@ fill_filename(int file, uint8_t format, uint16_t version, const char *include_di
     if (version >= 5) {
         const char *path;
         uint64_t directory_index = -1;
-        parse_ver5_debug_line_header(filenames, file, format, obj, &path, &directory_index);
+        parse_ver5_debug_line_header(filenames, file, format, obj, &path, &directory_index, errout);
         line->filename = path;
-        parse_ver5_debug_line_header(include_directories, (int)directory_index, format, obj, &path, NULL);
+        parse_ver5_debug_line_header(include_directories, (int)directory_index, format, obj, &path, NULL, errout);
         line->dirname = path;
     }
     else {
@@ -307,7 +311,7 @@ fill_filename(int file, uint8_t format, uint16_t version, const char *include_di
 
             if (i == file) {
                 line->filename = filename;
-                line->dirname = get_nth_dirname(dir, include_directories);
+                line->dirname = get_nth_dirname(dir, include_directories, errout);
             }
         }
     }
@@ -316,7 +320,7 @@ fill_filename(int file, uint8_t format, uint16_t version, const char *include_di
 static void
 fill_line(int num_traces, void **traces, uintptr_t addr, int file, int line,
 	  uint8_t format, uint16_t version, const char *include_directories, const char *filenames,
-	  obj_info_t *obj, line_info_t *lines, int offset)
+	  obj_info_t *obj, line_info_t *lines, int offset, FILE *errout)
 {
     int i;
     addr += obj->base_addr - obj->vmaddr;
@@ -325,7 +329,7 @@ fill_line(int num_traces, void **traces, uintptr_t addr, int file, int line,
 	/* We assume one line code doesn't result >100 bytes of native code.
        We may want more reliable way eventually... */
 	if (addr < a && a < addr + 100) {
-	    fill_filename(file, format, version, include_directories, filenames, &lines[i], obj);
+	    fill_filename(file, format, version, include_directories, filenames, &lines[i], obj, errout);
 	    lines[i].line = line;
 	}
     }
@@ -350,7 +354,7 @@ struct LineNumberProgramHeader {
 };
 
 static int
-parse_debug_line_header(obj_info_t *obj, const char **pp, struct LineNumberProgramHeader *header)
+parse_debug_line_header(obj_info_t *obj, const char **pp, struct LineNumberProgramHeader *header, FILE *errout)
 {
     const char *p = *pp;
     header->unit_length = *(uint32_t *)p;
@@ -396,7 +400,7 @@ parse_debug_line_header(obj_info_t *obj, const char **pp, struct LineNumberProgr
 
     if (header->version >= 5) {
         header->include_directories = p;
-        p = parse_ver5_debug_line_header(p, -1, header->format, obj, NULL, NULL);
+        p = parse_ver5_debug_line_header(p, -1, header->format, obj, NULL, NULL, errout);
         header->filenames = p;
     }
     else {
@@ -423,7 +427,7 @@ parse_debug_line_header(obj_info_t *obj, const char **pp, struct LineNumberProgr
 
 static int
 parse_debug_line_cu(int num_traces, void **traces, const char **debug_line,
-		obj_info_t *obj, line_info_t *lines, int offset)
+		obj_info_t *obj, line_info_t *lines, int offset, FILE *errout)
 {
     const char *p = (const char *)*debug_line;
     struct LineNumberProgramHeader header;
@@ -440,7 +444,7 @@ parse_debug_line_cu(int num_traces, void **traces, const char **debug_line,
     /* int epilogue_begin = 0; */
     /* unsigned int isa = 0; */
 
-    if (parse_debug_line_header(obj, &p, &header))
+    if (parse_debug_line_header(obj, &p, &header, errout))
         return -1;
     is_stmt = header.default_is_stmt;
 
@@ -451,7 +455,7 @@ parse_debug_line_cu(int num_traces, void **traces, const char **debug_line,
                   header.version,                                   \
                   header.include_directories,                       \
                   header.filenames,                                 \
-		  obj, lines, offset);				    \
+		  obj, lines, offset, errout);                      \
 	/*basic_block = prologue_end = epilogue_begin = 0;*/	    \
     } while (0)
 
@@ -551,11 +555,11 @@ parse_debug_line_cu(int num_traces, void **traces, const char **debug_line,
 static int
 parse_debug_line(int num_traces, void **traces,
 		 const char *debug_line, unsigned long size,
-		 obj_info_t *obj, line_info_t *lines, int offset)
+		 obj_info_t *obj, line_info_t *lines, int offset, FILE *errout)
 {
     const char *debug_line_end = debug_line + size;
     while (debug_line < debug_line_end) {
-	if (parse_debug_line_cu(num_traces, traces, &debug_line, obj, lines, offset))
+	if (parse_debug_line_cu(num_traces, traces, &debug_line, obj, lines, offset, errout))
 	    return -1;
     }
     if (debug_line != debug_line_end) {
@@ -568,7 +572,7 @@ parse_debug_line(int num_traces, void **traces,
 /* read file and fill lines */
 static uintptr_t
 fill_lines(int num_traces, void **traces, int check_debuglink,
-	   obj_info_t **objp, line_info_t *lines, int offset);
+	   obj_info_t **objp, line_info_t *lines, int offset, FILE *errout);
 
 static void
 append_obj(obj_info_t **objp)
@@ -596,7 +600,7 @@ append_obj(obj_info_t **objp)
 // check the path pattern of "/usr/lib/debug/usr/bin/ruby.debug"
 static void
 follow_debuglink(const char *debuglink, int num_traces, void **traces,
-		 obj_info_t **objp, line_info_t *lines, int offset)
+		 obj_info_t **objp, line_info_t *lines, int offset, FILE *errout)
 {
     static const char global_debug_dir[] = "/usr/lib/debug";
     const size_t global_debug_dir_len = sizeof(global_debug_dir) - 1;
@@ -622,13 +626,13 @@ follow_debuglink(const char *debuglink, int num_traces, void **traces,
     o2 = *objp;
     o2->base_addr = o1->base_addr;
     o2->path = o1->path;
-    fill_lines(num_traces, traces, 0, objp, lines, offset);
+    fill_lines(num_traces, traces, 0, objp, lines, offset, errout);
 }
 
 // check the path pattern of "/usr/lib/debug/.build-id/ab/cdef1234.debug"
 static void
 follow_debuglink_build_id(const char *build_id, size_t build_id_size, int num_traces, void **traces,
-                          obj_info_t **objp, line_info_t *lines, int offset)
+                          obj_info_t **objp, line_info_t *lines, int offset, FILE *errout)
 {
     static const char global_debug_dir[] = "/usr/lib/debug/.build-id/";
     const size_t global_debug_dir_len = sizeof(global_debug_dir) - 1;
@@ -653,7 +657,7 @@ follow_debuglink_build_id(const char *build_id, size_t build_id_size, int num_tr
     o2 = *objp;
     o2->base_addr = o1->base_addr;
     o2->path = o1->path;
-    fill_lines(num_traces, traces, 0, objp, lines, offset);
+    fill_lines(num_traces, traces, 0, objp, lines, offset, errout);
 }
 #endif
 
@@ -1079,13 +1083,13 @@ di_read_debug_abbrev_cu(DebugInfoReader *reader)
 }
 
 static int
-di_read_debug_line_cu(DebugInfoReader *reader)
+di_read_debug_line_cu(DebugInfoReader *reader, FILE *errout)
 {
     const char *p;
     struct LineNumberProgramHeader header;
 
     p = (const char *)reader->debug_line_cu_end;
-    if (parse_debug_line_header(reader->obj, &p, &header))
+    if (parse_debug_line_header(reader->obj, &p, &header, errout))
         return -1;
 
     reader->debug_line_cu_end = (char *)header.cu_end;
@@ -1186,7 +1190,7 @@ debug_info_reader_read_addr_value_member(DebugInfoReader *reader, DebugInfoValue
 
 
 static bool
-debug_info_reader_read_value(DebugInfoReader *reader, uint64_t form, DebugInfoValue *v)
+debug_info_reader_read_value(DebugInfoReader *reader, uint64_t form, DebugInfoValue *v, FILE *errout)
 {
     switch (form) {
       case DW_FORM_addr:
@@ -1369,7 +1373,7 @@ debug_info_reader_read_value(DebugInfoReader *reader, uint64_t form, DebugInfoVa
 
 /* find abbrev in current compilation unit */
 static const char *
-di_find_abbrev(DebugInfoReader *reader, uint64_t abbrev_number)
+di_find_abbrev(DebugInfoReader *reader, uint64_t abbrev_number, FILE *errout)
 {
     const char *p;
     if (abbrev_number < ABBREV_TABLE_SIZE) {
@@ -1394,7 +1398,7 @@ di_find_abbrev(DebugInfoReader *reader, uint64_t abbrev_number)
 
 #if 0
 static void
-hexdump0(const unsigned char *p, size_t n)
+hexdump0(const unsigned char *p, size_t n, FILE *errout)
 {
     size_t i;
     kprintf("     0  1  2  3  4  5  6  7  8  9  A  B  C  D  E  F\n");
@@ -1415,10 +1419,10 @@ hexdump0(const unsigned char *p, size_t n)
         kprintf("\n");
     }
 }
-#define hexdump(p,n) hexdump0((const unsigned char *)p, n)
+#define hexdump(p,n,e) hexdump0((const unsigned char *)p, n, e)
 
 static void
-div_inspect(DebugInfoValue *v)
+div_inspect(DebugInfoValue *v, FILE *errout)
 {
     switch (v->type) {
       case VAL_uint:
@@ -1432,14 +1436,14 @@ div_inspect(DebugInfoValue *v)
         break;
       case VAL_data:
         kprintf("%d: type:%d size:%" PRIxSIZE " v:\n",__LINE__,v->type,v->size);
-        hexdump(v->as.ptr, 16);
+        hexdump(v->as.ptr, 16, errout);
         break;
     }
 }
 #endif
 
 static DIE *
-di_read_die(DebugInfoReader *reader, DIE *die)
+di_read_die(DebugInfoReader *reader, DIE *die, FILE *errout)
 {
     uint64_t abbrev_number = uleb128(&reader->p);
     if (abbrev_number == 0) {
@@ -1447,7 +1451,7 @@ di_read_die(DebugInfoReader *reader, DIE *die)
         return NULL;
     }
 
-    if (!(reader->q = di_find_abbrev(reader, abbrev_number))) return NULL;
+    if (!(reader->q = di_find_abbrev(reader, abbrev_number, errout))) return NULL;
 
     die->pos = reader->p - reader->obj->debug_info.ptr - 1;
     die->tag = (int)uleb128(&reader->q); /* tag */
@@ -1459,26 +1463,26 @@ di_read_die(DebugInfoReader *reader, DIE *die)
 }
 
 static DebugInfoValue *
-di_read_record(DebugInfoReader *reader, DebugInfoValue *vp)
+di_read_record(DebugInfoReader *reader, DebugInfoValue *vp, FILE *errout)
 {
     uint64_t at = uleb128(&reader->q);
     uint64_t form = uleb128(&reader->q);
     if (!at || !form) return NULL;
     vp->at = at;
     vp->form = form;
-    if (!debug_info_reader_read_value(reader, form, vp)) return NULL;
+    if (!debug_info_reader_read_value(reader, form, vp, errout)) return NULL;
     return vp;
 }
 
 static bool
-di_skip_records(DebugInfoReader *reader)
+di_skip_records(DebugInfoReader *reader, FILE *errout)
 {
     for (;;) {
         DebugInfoValue v = {{0}};
         uint64_t at = uleb128(&reader->q);
         uint64_t form = uleb128(&reader->q);
         if (!at || !form) return true;
-        if (!debug_info_reader_read_value(reader, form, &v)) return false;
+        if (!debug_info_reader_read_value(reader, form, &v, errout)) return false;
     }
 }
 
@@ -1491,7 +1495,8 @@ typedef struct addr_header {
 } addr_header_t;
 
 static bool
-addr_header_init(obj_info_t *obj, addr_header_t *header) {
+addr_header_init(obj_info_t *obj, addr_header_t *header, FILE *errout)
+{
     const char *p = obj->debug_addr.ptr;
 
     header->ptr = p;
@@ -1536,7 +1541,8 @@ typedef struct rnglists_header {
 } rnglists_header_t;
 
 static bool
-rnglists_header_init(obj_info_t *obj, rnglists_header_t *header) {
+rnglists_header_init(obj_info_t *obj, rnglists_header_t *header, FILE *errout)
+{
     const char *p = obj->debug_rnglists.ptr;
 
     if (!p) return true;
@@ -1603,7 +1609,7 @@ ranges_set(ranges_t *ptr, DebugInfoValue *v, addr_header_t *addr_header, uint64_
 }
 
 static uint64_t
-read_dw_form_addr(DebugInfoReader *reader, const char **ptr)
+read_dw_form_addr(DebugInfoReader *reader, const char **ptr, FILE *errout)
 {
     const char *p = *ptr;
     *ptr = p + reader->address_size;
@@ -1615,7 +1621,7 @@ read_dw_form_addr(DebugInfoReader *reader, const char **ptr)
 }
 
 static uintptr_t
-ranges_include(DebugInfoReader *reader, ranges_t *ptr, uint64_t addr, rnglists_header_t *rnglists_header)
+ranges_include(DebugInfoReader *reader, ranges_t *ptr, uint64_t addr, rnglists_header_t *rnglists_header, FILE *errout)
 {
     if (ptr->high_pc_set) {
         if (ptr->ranges_set || !ptr->low_pc_set) {
@@ -1668,15 +1674,15 @@ ranges_include(DebugInfoReader *reader, ranges_t *ptr, uint64_t addr, rnglists_h
                     to = (uintptr_t)base + uleb128(&p);
                     break;
                   case DW_RLE_base_address:
-                    base = read_dw_form_addr(reader, &p);
+                    base = read_dw_form_addr(reader, &p, errout);
                     base_valid = true;
                     break;
                   case DW_RLE_start_end:
-                    from = (uintptr_t)read_dw_form_addr(reader, &p);
-                    to = (uintptr_t)read_dw_form_addr(reader, &p);
+                    from = (uintptr_t)read_dw_form_addr(reader, &p, errout);
+                    to = (uintptr_t)read_dw_form_addr(reader, &p, errout);
                     break;
                   case DW_RLE_start_length:
-                    from = (uintptr_t)read_dw_form_addr(reader, &p);
+                    from = (uintptr_t)read_dw_form_addr(reader, &p, errout);
                     to = from + uleb128(&p);
                     break;
                 }
@@ -1710,7 +1716,7 @@ ranges_include(DebugInfoReader *reader, ranges_t *ptr, uint64_t addr, rnglists_h
 
 #if 0
 static void
-ranges_inspect(DebugInfoReader *reader, ranges_t *ptr)
+ranges_inspect(DebugInfoReader *reader, ranges_t *ptr, FILE *errout)
 {
     if (ptr->high_pc_set) {
         if (ptr->ranges_set || !ptr->low_pc_set) {
@@ -1740,7 +1746,7 @@ ranges_inspect(DebugInfoReader *reader, ranges_t *ptr)
 #endif
 
 static int
-di_read_cu(DebugInfoReader *reader)
+di_read_cu(DebugInfoReader *reader, FILE *errout)
 {
     uint64_t unit_length;
     uint16_t version;
@@ -1775,15 +1781,15 @@ di_read_cu(DebugInfoReader *reader)
 
     reader->level = 0;
     di_read_debug_abbrev_cu(reader);
-    if (di_read_debug_line_cu(reader)) return -1;
+    if (di_read_debug_line_cu(reader, errout)) return -1;
 
     do {
         DIE die;
 
-        if (!di_read_die(reader, &die)) continue;
+        if (!di_read_die(reader, &die, errout)) continue;
 
         if (die.tag != DW_TAG_compile_unit) {
-            if (!di_skip_records(reader)) return -1;
+            if (!di_skip_records(reader, errout)) return -1;
             break;
         }
 
@@ -1795,7 +1801,7 @@ di_read_cu(DebugInfoReader *reader)
         /* enumerate abbrev */
         for (;;) {
             DebugInfoValue v = {{0}};
-            if (!di_read_record(reader, &v)) break;
+            if (!di_read_record(reader, &v, errout)) break;
             switch (v.at) {
               case DW_AT_low_pc:
                 // clang may output DW_AT_addr_base after DW_AT_low_pc.
@@ -1821,7 +1827,7 @@ di_read_cu(DebugInfoReader *reader)
             case VAL_addr:
                 {
                     addr_header_t header = {0};
-                    if (!addr_header_init(reader->obj, &header)) return -1;
+                    if (!addr_header_init(reader->obj, &header, errout)) return -1;
                     reader->current_low_pc = read_addr(&header, reader->current_addr_base, low_pc.as.addr_idx);
                 }
                 break;
@@ -1832,7 +1838,7 @@ di_read_cu(DebugInfoReader *reader)
 }
 
 static void
-read_abstract_origin(DebugInfoReader *reader, uint64_t form, uint64_t abstract_origin, line_info_t *line)
+read_abstract_origin(DebugInfoReader *reader, uint64_t form, uint64_t abstract_origin, line_info_t *line, FILE *errout)
 {
     const char *p = reader->p;
     const char *q = reader->q;
@@ -1857,12 +1863,12 @@ read_abstract_origin(DebugInfoReader *reader, uint64_t form, uint64_t abstract_o
       default:
         goto finish;
     }
-    if (!di_read_die(reader, &die)) goto finish;
+    if (!di_read_die(reader, &die, errout)) goto finish;
 
     /* enumerate abbrev */
     for (;;) {
         DebugInfoValue v = {{0}};
-        if (!di_read_record(reader, &v)) break;
+        if (!di_read_record(reader, &v, errout)) break;
         switch (v.at) {
           case DW_AT_name:
             line->sname = get_cstr_value(&v);
@@ -1878,25 +1884,26 @@ read_abstract_origin(DebugInfoReader *reader, uint64_t form, uint64_t abstract_o
 
 static bool
 debug_info_read(DebugInfoReader *reader, int num_traces, void **traces,
-         line_info_t *lines, int offset) {
+                line_info_t *lines, int offset, FILE *errout)
+{
 
     addr_header_t addr_header = {0};
-    if (!addr_header_init(reader->obj, &addr_header)) return false;
+    if (!addr_header_init(reader->obj, &addr_header, errout)) return false;
 
     rnglists_header_t rnglists_header = {0};
-    if (!rnglists_header_init(reader->obj, &rnglists_header)) return false;
+    if (!rnglists_header_init(reader->obj, &rnglists_header, errout)) return false;
 
     while (reader->p < reader->cu_end) {
         DIE die;
         ranges_t ranges = {0};
         line_info_t line = {0};
 
-        if (!di_read_die(reader, &die)) continue;
+        if (!di_read_die(reader, &die, errout)) continue;
         /* kprintf("%d:%tx: <%d>\n",__LINE__,die.pos,reader->level,die.tag); */
 
         if (die.tag != DW_TAG_subprogram && die.tag != DW_TAG_inlined_subroutine) {
           skip_die:
-            if (!di_skip_records(reader)) return false;
+            if (!di_skip_records(reader, errout)) return false;
             continue;
         }
 
@@ -1904,15 +1911,15 @@ debug_info_read(DebugInfoReader *reader, int num_traces, void **traces,
         for (;;) {
             DebugInfoValue v = {{0}};
             /* ptrdiff_t pos = reader->p - reader->p0; */
-            if (!di_read_record(reader, &v)) break;
+            if (!di_read_record(reader, &v, errout)) break;
             /* kprintf("\n%d:%tx: AT:%lx FORM:%lx\n",__LINE__,pos,v.at,v.form); */
-            /* div_inspect(&v); */
+            /* div_inspect(&v, errout); */
             switch (v.at) {
               case DW_AT_name:
                 line.sname = get_cstr_value(&v);
                 break;
               case DW_AT_call_file:
-                fill_filename((int)v.as.uint64, reader->debug_line_format, reader->debug_line_version, reader->debug_line_directories, reader->debug_line_files, &line, reader->obj);
+                fill_filename((int)v.as.uint64, reader->debug_line_format, reader->debug_line_version, reader->debug_line_directories, reader->debug_line_files, &line, reader->obj, errout);
                 break;
               case DW_AT_call_line:
                 line.line = (int)v.as.uint64;
@@ -1928,16 +1935,16 @@ debug_info_read(DebugInfoReader *reader, int num_traces, void **traces,
                 /* 1 or 3 */
                 break; /* goto skip_die; */
               case DW_AT_abstract_origin:
-                read_abstract_origin(reader, v.form, v.as.uint64, &line);
+                read_abstract_origin(reader, v.form, v.as.uint64, &line, errout);
                 break; /* goto skip_die; */
             }
         }
-        /* ranges_inspect(reader, &ranges); */
+        /* ranges_inspect(reader, &ranges, errout); */
         /* kprintf("%d:%tx: %x ",__LINE__,diepos,die.tag); */
         for (int i=offset; i < num_traces; i++) {
             uintptr_t addr = (uintptr_t)traces[i];
             uintptr_t offset = addr - reader->obj->base_addr + reader->obj->vmaddr;
-            uintptr_t saddr = ranges_include(reader, &ranges, offset, &rnglists_header);
+            uintptr_t saddr = ranges_include(reader, &ranges, offset, &rnglists_header, errout);
             if (saddr == UINTPTR_MAX) return false;
             if (saddr) {
                 /* kprintf("%d:%tx: %d %lx->%lx %x %s: %s/%s %d %s %s %s\n",__LINE__,die.pos, i,addr,offset, die.tag,line.sname,line.dirname,line.filename,line.line,reader->obj->path,line.sname,lines[i].sname); */
@@ -1976,7 +1983,10 @@ debug_info_read(DebugInfoReader *reader, int num_traces, void **traces,
 //
 // It records DW_LNCT_path and DW_LNCT_directory_index at the index "idx".
 static const char *
-parse_ver5_debug_line_header(const char *p, int idx, uint8_t format, obj_info_t *obj, const char **out_path, uint64_t *out_directory_index) {
+parse_ver5_debug_line_header(const char *p, int idx, uint8_t format,
+                             obj_info_t *obj, const char **out_path,
+                             uint64_t *out_directory_index, FILE *errout)
+{
     int i, j;
     int entry_format_count = *(uint8_t *)p++;
     const char *entry_format = p;
@@ -1996,7 +2006,7 @@ parse_ver5_debug_line_header(const char *p, int idx, uint8_t format, obj_info_t 
             DebugInfoValue v = {{0}};
             unsigned long dw_lnct = uleb128(&format);
             unsigned long dw_form = uleb128(&format);
-            if (!debug_info_reader_read_value(&reader, dw_form, &v)) return 0;
+            if (!debug_info_reader_read_value(&reader, dw_form, &v, errout)) return 0;
             if (dw_lnct == 1 /* DW_LNCT_path */ && v.type == VAL_cstr && out_path)
                 *out_path = v.as.ptr + v.off;
             if (dw_lnct == 2 /* DW_LNCT_directory_index */ && v.type == VAL_uint && out_directory_index)
@@ -2041,7 +2051,7 @@ fail:
 /* read file and fill lines */
 static uintptr_t
 fill_lines(int num_traces, void **traces, int check_debuglink,
-	   obj_info_t **objp, line_info_t *lines, int offset)
+	   obj_info_t **objp, line_info_t *lines, int offset, FILE *errout)
 {
     int i, j;
     char *shstr;
@@ -2202,8 +2212,8 @@ fill_lines(int num_traces, void **traces, int check_debuglink,
         i = 0;
         while (reader.p < reader.pend) {
             /* kprintf("%d:%tx: CU[%d]\n", __LINE__, reader.p - reader.obj->debug_info.ptr, i++); */
-            if (di_read_cu(&reader)) goto use_symtab;
-            if (!debug_info_read(&reader, num_traces, traces, lines, offset))
+            if (di_read_cu(&reader, errout)) goto use_symtab;
+            if (!debug_info_read(&reader, num_traces, traces, lines, offset, errout))
                 goto use_symtab;
         }
     }
@@ -2244,14 +2254,14 @@ use_symtab:
 	if (gnu_debuglink_shdr && check_debuglink) {
 	    follow_debuglink(file + gnu_debuglink_shdr->sh_offset,
 			     num_traces, traces,
-			     objp, lines, offset);
+			     objp, lines, offset, errout);
 	}
         if (note_gnu_build_id && check_debuglink) {
             ElfW(Nhdr) *nhdr = (ElfW(Nhdr)*) (file + note_gnu_build_id->sh_offset);
             const char *build_id = (char *)(nhdr + 1) + nhdr->n_namesz;
             follow_debuglink_build_id(build_id, nhdr->n_descsz,
 			       num_traces, traces,
-			       objp, lines, offset);
+                               objp, lines, offset, errout);
         }
 	goto finish;
     }
@@ -2259,7 +2269,7 @@ use_symtab:
     if (parse_debug_line(num_traces, traces,
             obj->debug_line.ptr,
             obj->debug_line.size,
-            obj, lines, offset) == -1)
+            obj, lines, offset, errout) == -1)
         goto fail;
 
 finish:
@@ -2271,7 +2281,7 @@ fail:
 /* read file and fill lines */
 static uintptr_t
 fill_lines(int num_traces, void **traces, int check_debuglink,
-        obj_info_t **objp, line_info_t *lines, int offset)
+        obj_info_t **objp, line_info_t *lines, int offset, FILE *errout)
 {
 # ifdef __LP64__
 #  define LP(x) x##_64
@@ -2472,8 +2482,8 @@ found_mach_header:
         DebugInfoReader reader;
         debug_info_reader_init(&reader, obj);
         while (reader.p < reader.pend) {
-            if (di_read_cu(&reader)) goto fail;
-            if (!debug_info_read(&reader, num_traces, traces, lines, offset))
+            if (di_read_cu(&reader, errout)) goto fail;
+            if (!debug_info_read(&reader, num_traces, traces, lines, offset, errout))
                 goto fail;
         }
     }
@@ -2481,7 +2491,7 @@ found_mach_header:
     if (parse_debug_line(num_traces, traces,
             obj->debug_line.ptr,
             obj->debug_line.size,
-            obj, lines, offset) == -1)
+            obj, lines, offset, errout) == -1)
         goto fail;
 
     return dladdr_fbase;
@@ -2542,7 +2552,7 @@ main_exe_path(void)
 #endif
 
 static void
-print_line0(line_info_t *line, void *address)
+print_line0(line_info_t *line, void *address, FILE *errout)
 {
     uintptr_t addr = (uintptr_t)address;
     uintptr_t d = addr - line->saddr;
@@ -2583,16 +2593,16 @@ print_line0(line_info_t *line, void *address)
 }
 
 static void
-print_line(line_info_t *line, void *address)
+print_line(line_info_t *line, void *address, FILE *errout)
 {
-    print_line0(line, address);
+    print_line0(line, address, errout);
     if (line->next) {
-        print_line(line->next, NULL);
+        print_line(line->next, NULL, errout);
     }
 }
 
 void
-rb_dump_backtrace_with_lines(int num_traces, void **traces)
+rb_dump_backtrace_with_lines(int num_traces, void **traces, FILE *errout)
 {
     int i;
     /* async-signal unsafe */
@@ -2611,7 +2621,7 @@ rb_dump_backtrace_with_lines(int num_traces, void **traces)
 	    memcpy(main_path, binary_filename, len+1);
 	    append_obj(&obj);
 	    obj->path = main_path;
-	    addr = fill_lines(num_traces, traces, 1, &obj, lines, -1);
+	    addr = fill_lines(num_traces, traces, 1, &obj, lines, -1, errout);
 	    if (addr != (uintptr_t)-1) {
 		dladdr_fbases[0] = (void *)addr;
 	    }
@@ -2648,7 +2658,7 @@ rb_dump_backtrace_with_lines(int num_traces, void **traces)
                 lines[i].saddr = (uintptr_t)info.dli_saddr;
             }
 	    strlcpy(binary_filename, path, PATH_MAX);
-	    if (fill_lines(num_traces, traces, 1, &obj, lines, i) == (uintptr_t)-1)
+	    if (fill_lines(num_traces, traces, 1, &obj, lines, i, errout) == (uintptr_t)-1)
 		break;
 	}
 next_line:
@@ -2657,7 +2667,7 @@ next_line:
 
     /* output */
     for (i = 0; i < num_traces; i++) {
-        print_line(&lines[i], traces[i]);
+        print_line(&lines[i], traces[i], errout);
 
 	/* FreeBSD's backtrace may show _start and so on */
 	if (lines[i].sname && strcmp("main", lines[i].sname) == 0)

--- a/addr2line.h
+++ b/addr2line.h
@@ -12,8 +12,10 @@
 
 #if (defined(USE_ELF) || defined(HAVE_MACH_O_LOADER_H))
 
+#include <stdio.h>
+
 void
-rb_dump_backtrace_with_lines(int num_traces, void **traces);
+rb_dump_backtrace_with_lines(int num_traces, void **traces, FILE *errout);
 
 #endif /* USE_ELF */
 

--- a/common.mk
+++ b/common.mk
@@ -6324,6 +6324,7 @@ error.$(OBJEXT): $(top_srcdir)/internal/imemo.h
 error.$(OBJEXT): $(top_srcdir)/internal/io.h
 error.$(OBJEXT): $(top_srcdir)/internal/load.h
 error.$(OBJEXT): $(top_srcdir)/internal/object.h
+error.$(OBJEXT): $(top_srcdir)/internal/process.h
 error.$(OBJEXT): $(top_srcdir)/internal/serial.h
 error.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 error.$(OBJEXT): $(top_srcdir)/internal/string.h
@@ -6516,6 +6517,7 @@ error.$(OBJEXT): {$(VPATH)}st.h
 error.$(OBJEXT): {$(VPATH)}subst.h
 error.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).h
 error.$(OBJEXT): {$(VPATH)}thread_native.h
+error.$(OBJEXT): {$(VPATH)}util.h
 error.$(OBJEXT): {$(VPATH)}vm_core.h
 error.$(OBJEXT): {$(VPATH)}vm_opts.h
 error.$(OBJEXT): {$(VPATH)}warning.rbinc

--- a/error.c
+++ b/error.c
@@ -1000,12 +1000,13 @@ bug_report_end(FILE *out, rb_pid_t pid)
 void
 ruby_test_bug_report(const char *template)
 {
+    rb_pid_t pid = -1;
     char buf[REPORT_BUG_BUFSIZ];
-    FILE *out = open_report_path(template, buf, sizeof(buf));
+    FILE *out = open_report_path(template, buf, sizeof(buf), &pid);
     if (out) {
         time_t t = time(NULL);
         fprintf(out, "ruby_test_bug_report: %s", ctime(&t));
-        finish_report(out);
+        finish_report(out, pid);
     }
 }
 

--- a/error.c
+++ b/error.c
@@ -757,7 +757,7 @@ bug_report_end(FILE *out)
     FILE *out = bug_report_file(file, line); \
     if (out) { \
         bug_report_begin(out, fmt); \
-        rb_vm_bugreport(ctx); \
+        rb_vm_bugreport(ctx, out); \
         bug_report_end(out); \
     } \
 } while (0) \
@@ -766,7 +766,7 @@ bug_report_end(FILE *out)
     FILE *out = bug_report_file(file, line); \
     if (out) { \
         bug_report_begin_valist(out, fmt, args); \
-        rb_vm_bugreport(ctx); \
+        rb_vm_bugreport(ctx, out); \
         bug_report_end(out); \
     } \
 } while (0) \
@@ -881,7 +881,7 @@ rb_assert_failure(const char *file, int line, const char *name, const char *expr
     if (name) fprintf(out, "%s:", name);
     fprintf(out, "%s\n%s\n\n", expr, rb_dynamic_description);
     preface_dump(out);
-    rb_vm_bugreport(NULL);
+    rb_vm_bugreport(NULL, out);
     bug_report_end(out);
     die();
 }
@@ -3256,7 +3256,7 @@ rb_fatal(const char *fmt, ...)
         /* The thread has no GVL.  Object allocation impossible (cant run GC),
          * thus no message can be printed out. */
         fprintf(stderr, "[FATAL] rb_fatal() outside of GVL\n");
-        rb_print_backtrace();
+        rb_print_backtrace(stderr);
         die();
     }
 

--- a/error.c
+++ b/error.c
@@ -737,7 +737,7 @@ struct report_expansion {
 };
 
 /*
- * Open a bug report file to write.  The `RUBY_BUGREPORT_PATH`
+ * Open a bug report file to write.  The `RUBY_CRASH_REPORT`
  * environment variable can be set to define a template that is used
  * to name bug report files.  The template can contain % specifiers
  * which are substituted by the following values when a bug report
@@ -817,7 +817,7 @@ open_report_path(const char *template, char *buf, size_t size, rb_pid_t *pid)
     struct report_expansion values = {{0}};
 
     if (!template) return NULL;
-    if (0) fprintf(stderr, "RUBY_BUGREPORT_PATH=%s\n", buf);
+    if (0) fprintf(stderr, "RUBY_CRASH_REPORT=%s\n", buf);
     if (*template == '|') {
         char *argv[16], *bufend = buf + size, *p;
         int argc;
@@ -839,7 +839,7 @@ open_report_path(const char *template, char *buf, size_t size, rb_pid_t *pid)
     return NULL;
 }
 
-static const char *bugreport_path;
+static const char *crash_report;
 
 /* SIGSEGV handler might have a very small stack. Thus we need to use it carefully. */
 #define REPORT_BUG_BUFSIZ 256
@@ -847,8 +847,8 @@ static FILE *
 bug_report_file(const char *file, int line, rb_pid_t *pid)
 {
     char buf[REPORT_BUG_BUFSIZ];
-    const char *report = bugreport_path;
-    if (!report) report = getenv("RUBY_BUGREPORT_PATH");
+    const char *report = crash_report;
+    if (!report) report = getenv("RUBY_CRASH_REPORT");
     FILE *out = open_report_path(report, buf, sizeof(buf), pid);
     int len = err_position_0(buf, sizeof(buf), file, line);
 
@@ -1002,9 +1002,9 @@ bug_report_end(FILE *out, rb_pid_t pid)
 } while (0) \
 
 void
-ruby_set_bug_report(const char *template)
+ruby_set_crash_report(const char *template)
 {
-    bugreport_path = template;
+    crash_report = template;
 #if RUBY_DEBUG
     rb_pid_t pid = -1;
     char buf[REPORT_BUG_BUFSIZ];

--- a/error.c
+++ b/error.c
@@ -958,6 +958,18 @@ bug_report_end(FILE *out)
     } \
 } while (0) \
 
+void
+ruby_test_bug_report(const char *template)
+{
+    char buf[REPORT_BUG_BUFSIZ];
+    FILE *out = open_report_path(template, buf, sizeof(buf));
+    if (out) {
+        time_t t = time(NULL);
+        fprintf(out, "ruby_test_bug_report: %s", ctime(&t));
+        finish_report(out);
+    }
+}
+
 NORETURN(static void die(void));
 static void
 die(void)

--- a/gc.c
+++ b/gc.c
@@ -7803,7 +7803,7 @@ check_children_i(const VALUE child, void *ptr)
     if (check_rvalue_consistency_force(child, FALSE) != 0) {
         fprintf(stderr, "check_children_i: %s has error (referenced from %s)",
                 obj_info(child), obj_info(data->parent));
-        rb_print_backtrace(); /* C backtrace will help to debug */
+        rb_print_backtrace(stderr); /* C backtrace will help to debug */
 
         data->err_count++;
     }
@@ -9123,7 +9123,7 @@ rb_gc_register_address(VALUE *addr)
     if (0 && !SPECIAL_CONST_P(obj)) {
         rb_warn("Object is assigned to registering address already: %"PRIsVALUE,
                 rb_obj_class(obj));
-        rb_print_backtrace();
+        rb_print_backtrace(stderr);
     }
 }
 

--- a/internal/cmdlineopt.h
+++ b/internal/cmdlineopt.h
@@ -28,7 +28,7 @@ typedef struct ruby_cmdline_options {
     struct rb_rjit_options rjit;
 #endif
 
-    const char *bugreport_path;
+    const char *crash_report;
 
     signed int sflag: 2;
     unsigned int xflag: 1;

--- a/internal/cmdlineopt.h
+++ b/internal/cmdlineopt.h
@@ -28,6 +28,8 @@ typedef struct ruby_cmdline_options {
     struct rb_rjit_options rjit;
 #endif
 
+    const char *bugreport_path;
+
     signed int sflag: 2;
     unsigned int xflag: 1;
     unsigned int warning: 1;

--- a/internal/vm.h
+++ b/internal/vm.h
@@ -95,7 +95,7 @@ int rb_ec_obj_respond_to(struct rb_execution_context_struct *ec, VALUE obj, ID i
 void rb_clear_constant_cache(void);
 
 /* vm_dump.c */
-void rb_print_backtrace(void);
+void rb_print_backtrace(FILE *);
 
 /* vm_backtrace.c */
 VALUE rb_vm_thread_backtrace(int argc, const VALUE *argv, VALUE thval);
@@ -103,7 +103,7 @@ VALUE rb_vm_thread_backtrace_locations(int argc, const VALUE *argv, VALUE thval)
 VALUE rb_vm_backtrace(int argc, const VALUE * argv, struct rb_execution_context_struct * ec);
 VALUE rb_vm_backtrace_locations(int argc, const VALUE * argv, struct rb_execution_context_struct * ec);
 VALUE rb_make_backtrace(void);
-void rb_backtrace_print_as_bugreport(void);
+void rb_backtrace_print_as_bugreport(FILE*);
 int rb_backtrace_p(VALUE obj);
 VALUE rb_backtrace_to_str_ary(VALUE obj);
 VALUE rb_backtrace_to_location_ary(VALUE obj);

--- a/man/ruby.1
+++ b/man/ruby.1
@@ -669,6 +669,8 @@ PID of dumped process.
 .It %t
 Time of dump, expressed as seconds since the
 Epoch, 1970-01-01 00:00:00 +0000 (UTC).
+.It %NNN
+A character code in octal.
 .El
 .Pp
 A single % at the end of the template is dropped from the
@@ -678,6 +680,13 @@ All other characters in the template become a literal
 part of the core filename.
 The template may include \(aq/\(aq characters, which are interpreted
 as delimiters for directory names.
+.Ss Piping bug reports to a program
+If the first character of this file is a pipe symbol (\fB|\fP),
+then the remainder of the line is interpreted as the command-line for
+a program (or script) that is to be executed.
+.Pp
+The pipe template is split on spaces into an argument list before the
+template parameters are expanded.
 .Sh SEE ALSO
 .Bl -hang -compact -width "https://www.ruby-toolbox.com/"
 .It Lk https://www.ruby-lang.org/

--- a/man/ruby.1
+++ b/man/ruby.1
@@ -645,6 +645,39 @@ Machine stack size used at fiber creation.
 default: 262144 or 524288
 .Pp
 .El
+.Sh BUG REPORT ENVIRONMENT
+.Pp
+.Bl -tag -compact -width "RUBY_BUGREPORT_PATH"
+.It Ev RUBY_BUGREPORT_PATH
+The template of path name to save bug report.
+default: none
+.El
+.Ss Naming bug report files
+The template can contain % specifiers which are substituted
+by the following values when a bug report file is created:
+.Pp
+.Bl -hang -compact -width "%NNN"
+.It %%
+A single % character.
+.It %e
+Basename of executable.
+.It %E
+Pathname of executable,
+with slashes (\fB/\fP) replaced by exclamation marks (\fB!\fP).
+.It %p
+PID of dumped process.
+.It %t
+Time of dump, expressed as seconds since the
+Epoch, 1970-01-01 00:00:00 +0000 (UTC).
+.El
+.Pp
+A single % at the end of the template is dropped from the
+core filename, as is the combination of a % followed by any
+character other than those listed above.
+All other characters in the template become a literal
+part of the core filename.
+The template may include \(aq/\(aq characters, which are interpreted
+as delimiters for directory names.
 .Sh SEE ALSO
 .Bl -hang -compact -width "https://www.ruby-toolbox.com/"
 .It Lk https://www.ruby-lang.org/

--- a/man/ruby.1
+++ b/man/ruby.1
@@ -25,6 +25,7 @@
 .Op Fl - Ns Bro Cm enable Ns | Ns Cm disable Brc Ns - Ns Ar FEATURE
 .Op Fl -dump Ns = Ns Ar target
 .Op Fl -verbose
+.Op Fl -bugreport-path Ns = Ns Ar template
 .Op Fl -
 .Op Ar program_file
 .Op Ar argument ...
@@ -469,6 +470,12 @@ variable to true.
 If this switch is given, and no script arguments (script file or
 .Fl e
 options) are present, Ruby quits immediately.
+.Pp
+.It Fl -bugreport-path Ns = Ns Ar template
+Sets the template of path name to save bug report.
+See
+.Ev RUBY_BUGREPORT_PATH
+environment variable for details.
 .El
 .Pp
 .Sh ENVIRONMENT

--- a/man/ruby.1
+++ b/man/ruby.1
@@ -25,7 +25,7 @@
 .Op Fl - Ns Bro Cm enable Ns | Ns Cm disable Brc Ns - Ns Ar FEATURE
 .Op Fl -dump Ns = Ns Ar target
 .Op Fl -verbose
-.Op Fl -bugreport-path Ns = Ns Ar template
+.Op Fl -crash-report Ns = Ns Ar template
 .Op Fl -
 .Op Ar program_file
 .Op Ar argument ...
@@ -471,10 +471,10 @@ If this switch is given, and no script arguments (script file or
 .Fl e
 options) are present, Ruby quits immediately.
 .Pp
-.It Fl -bugreport-path Ns = Ns Ar template
+.It Fl -crash-report Ns = Ns Ar template
 Sets the template of path name to save bug report.
 See
-.Ev RUBY_BUGREPORT_PATH
+.Ev RUBY_CRASH_REPORT
 environment variable for details.
 .El
 .Pp
@@ -654,8 +654,8 @@ default: 262144 or 524288
 .El
 .Sh BUG REPORT ENVIRONMENT
 .Pp
-.Bl -tag -compact -width "RUBY_BUGREPORT_PATH"
-.It Ev RUBY_BUGREPORT_PATH
+.Bl -tag -compact -width "RUBY_CRASH_REPORT"
+.It Ev RUBY_CRASH_REPORT
 The template of path name to save bug report.
 default: none
 .El

--- a/ruby.c
+++ b/ruby.c
@@ -337,6 +337,7 @@ usage(const char *name, int help, int highlight, int columns)
         M("--backtrace-limit=num",                  "", "limit the maximum length of backtrace"),
         M("--verbose",                              "", "turn on verbose mode and disable script from stdin"),
         M("--version",                              "", "print the version number, then exit"),
+        M("--bugreport-path=TEMPLATE",              "", "template of bug report files"),
         M("-y",                          ", --yydebug", "print log of parser. Backward compatibility is not guaranteed"),
         M("--help",			            "", "show this message, -h for short message"),
     };
@@ -1352,8 +1353,6 @@ proc_encoding_option(ruby_cmdline_options_t *opt, const char *s, const char *opt
     UNREACHABLE;
 }
 
-static const char *test_bug_report_template;
-
 static long
 proc_long_options(ruby_cmdline_options_t *opt, const char *s, long argc, char **argv, int envopt)
 {
@@ -1464,8 +1463,10 @@ proc_long_options(ruby_cmdline_options_t *opt, const char *s, long argc, char **
             opt->backtrace_length_limit = n;
         }
     }
-    else if (is_option_with_arg("test-bugreport", true, false)) {
-        test_bug_report_template = s;
+    else if (is_option_with_arg("bugreport-path", true, true)) {
+        if (!opt->bugreport_path) {
+            opt->bugreport_path = s;
+        }
     }
     else {
         rb_raise(rb_eRuntimeError,
@@ -2916,9 +2917,9 @@ ruby_process_options(int argc, char **argv)
 
     iseq = process_options(argc, argv, cmdline_options_init(&opt));
 
-    if (test_bug_report_template) {
-        void ruby_test_bug_report(const char *template);
-        ruby_test_bug_report(test_bug_report_template);
+    if (opt.bugreport_path && *opt.bugreport_path) {
+        void ruby_set_bug_report(const char *template);
+        ruby_set_bug_report(opt.bugreport_path);
     }
     return (void*)(struct RData*)iseq;
 }

--- a/ruby.c
+++ b/ruby.c
@@ -1352,6 +1352,8 @@ proc_encoding_option(ruby_cmdline_options_t *opt, const char *s, const char *opt
     UNREACHABLE;
 }
 
+static const char *test_bug_report_template;
+
 static long
 proc_long_options(ruby_cmdline_options_t *opt, const char *s, long argc, char **argv, int envopt)
 {
@@ -1461,6 +1463,9 @@ proc_long_options(ruby_cmdline_options_t *opt, const char *s, long argc, char **
         else {
             opt->backtrace_length_limit = n;
         }
+    }
+    else if (is_option_with_arg("test-bugreport", true, false)) {
+        test_bug_report_template = s;
     }
     else {
         rb_raise(rb_eRuntimeError,
@@ -2911,6 +2916,10 @@ ruby_process_options(int argc, char **argv)
 
     iseq = process_options(argc, argv, cmdline_options_init(&opt));
 
+    if (test_bug_report_template) {
+        void ruby_test_bug_report(const char *template);
+        ruby_test_bug_report(test_bug_report_template);
+    }
     return (void*)(struct RData*)iseq;
 }
 

--- a/ruby.c
+++ b/ruby.c
@@ -899,6 +899,7 @@ moreswitches(const char *s, ruby_cmdline_options_t *opt, int envopt)
     ruby_features_t feat = opt->features;
     ruby_features_t warn = opt->warn;
     long backtrace_length_limit = opt->backtrace_length_limit;
+    const char *bugreport_path = opt->bugreport_path;
 
     while (ISSPACE(*s)) s++;
     if (!*s) return;
@@ -952,6 +953,9 @@ moreswitches(const char *s, ruby_cmdline_options_t *opt, int envopt)
     FEATURE_SET_RESTORE(opt->warn, warn);
     if (BACKTRACE_LENGTH_LIMIT_VALID_P(backtrace_length_limit)) {
         opt->backtrace_length_limit = backtrace_length_limit;
+    }
+    if (bugreport_path) {
+        opt->bugreport_path = bugreport_path;
     }
 
     ruby_xfree(ptr);
@@ -1464,9 +1468,7 @@ proc_long_options(ruby_cmdline_options_t *opt, const char *s, long argc, char **
         }
     }
     else if (is_option_with_arg("bugreport-path", true, true)) {
-        if (!opt->bugreport_path) {
-            opt->bugreport_path = s;
-        }
+        opt->bugreport_path = s;
     }
     else {
         rb_raise(rb_eRuntimeError,

--- a/ruby.c
+++ b/ruby.c
@@ -337,7 +337,7 @@ usage(const char *name, int help, int highlight, int columns)
         M("--backtrace-limit=num",                  "", "limit the maximum length of backtrace"),
         M("--verbose",                              "", "turn on verbose mode and disable script from stdin"),
         M("--version",                              "", "print the version number, then exit"),
-        M("--bugreport-path=TEMPLATE",              "", "template of bug report files"),
+        M("--crash-report=TEMPLATE",                "", "template of crash report files"),
         M("-y",                          ", --yydebug", "print log of parser. Backward compatibility is not guaranteed"),
         M("--help",			            "", "show this message, -h for short message"),
     };
@@ -899,7 +899,7 @@ moreswitches(const char *s, ruby_cmdline_options_t *opt, int envopt)
     ruby_features_t feat = opt->features;
     ruby_features_t warn = opt->warn;
     long backtrace_length_limit = opt->backtrace_length_limit;
-    const char *bugreport_path = opt->bugreport_path;
+    const char *crash_report = opt->crash_report;
 
     while (ISSPACE(*s)) s++;
     if (!*s) return;
@@ -954,8 +954,8 @@ moreswitches(const char *s, ruby_cmdline_options_t *opt, int envopt)
     if (BACKTRACE_LENGTH_LIMIT_VALID_P(backtrace_length_limit)) {
         opt->backtrace_length_limit = backtrace_length_limit;
     }
-    if (bugreport_path) {
-        opt->bugreport_path = bugreport_path;
+    if (crash_report) {
+        opt->crash_report = crash_report;
     }
 
     ruby_xfree(ptr);
@@ -1467,8 +1467,8 @@ proc_long_options(ruby_cmdline_options_t *opt, const char *s, long argc, char **
             opt->backtrace_length_limit = n;
         }
     }
-    else if (is_option_with_arg("bugreport-path", true, true)) {
-        opt->bugreport_path = s;
+    else if (is_option_with_arg("crash-report", true, true)) {
+        opt->crash_report = s;
     }
     else {
         rb_raise(rb_eRuntimeError,
@@ -2919,9 +2919,9 @@ ruby_process_options(int argc, char **argv)
 
     iseq = process_options(argc, argv, cmdline_options_init(&opt));
 
-    if (opt.bugreport_path && *opt.bugreport_path) {
-        void ruby_set_bug_report(const char *template);
-        ruby_set_bug_report(opt.bugreport_path);
+    if (opt.crash_report && *opt.crash_report) {
+        void ruby_set_crash_report(const char *template);
+        ruby_set_crash_report(opt.crash_report);
     }
     return (void*)(struct RData*)iseq;
 }

--- a/test/ruby/test_rubyoptions.rb
+++ b/test/ruby/test_rubyoptions.rb
@@ -880,6 +880,21 @@ class TestRubyOptions < Test::Unit::TestCase
     end
   end
 
+  def test_bugreport_path_pipe
+    if File.executable?(echo = "/bin/echo")
+    elsif /mswin|ming/ =~ RUBY_PLATFORM
+      echo = "echo"
+    else
+      omit "/bin/echo not found"
+    end
+    assert_in_out_err([{"RUBY_BUGREPORT_PATH"=>"| #{echo} %e:%f:%p"}], SEGVTest::KILL_SELF,
+                      encoding: "ASCII-8BIT",
+                      **SEGVTest::ExecOptions) do |stdout, stderr, status|
+      assert_empty(stderr)
+      assert_equal(["#{File.basename(EnvUtil.rubybin)}:-:#{status.pid}"], stdout)
+    end
+  end
+
   def test_DATA
     Tempfile.create(["test_ruby_test_rubyoption", ".rb"]) {|t|
       t.puts "puts DATA.read.inspect"

--- a/test/ruby/test_rubyoptions.rb
+++ b/test/ruby/test_rubyoptions.rb
@@ -836,8 +836,8 @@ class TestRubyOptions < Test::Unit::TestCase
     }
   end
 
-  def assert_bugreport_path(path, cmd = nil)
-    Dir.mktmpdir("ruby_bugreport") do |dir|
+  def assert_crash_report(path, cmd = nil)
+    Dir.mktmpdir("ruby_crash_report") do |dir|
       list = SEGVTest::ExpectedStderrList
       if cmd
         FileUtils.mkpath(File.join(dir, File.dirname(cmd)))
@@ -847,7 +847,7 @@ class TestRubyOptions < Test::Unit::TestCase
       else
         cmd = ['-e', SEGVTest::KILL_SELF]
       end
-      status = assert_segv([{"RUBY_BUGREPORT_PATH"=>path}, *cmd], list: [], chdir: dir)
+      status = assert_segv([{"RUBY_CRASH_REPORT"=>path}, *cmd], list: [], chdir: dir)
       reports = Dir.glob("*.log", File::FNM_DOTMATCH, base: dir)
       assert_equal(1, reports.size)
       assert_pattern_list(list, File.read(File.join(dir, reports.first)))
@@ -855,39 +855,39 @@ class TestRubyOptions < Test::Unit::TestCase
     end
   end
 
-  def test_bugreport_path
-    assert_bugreport_path("%e.%f.%p.log") do |status, report|
+  def test_crash_report
+    assert_crash_report("%e.%f.%p.log") do |status, report|
       assert_equal("#{File.basename(EnvUtil.rubybin)}.-e.#{status.pid}.log", report)
     end
   end
 
-  def test_bugreport_path_script
-    assert_bugreport_path("%e.%f.%p.log", "bug.rb") do |status, report|
+  def test_crash_report_script
+    assert_crash_report("%e.%f.%p.log", "bug.rb") do |status, report|
       assert_equal("#{File.basename(EnvUtil.rubybin)}.bug.rb.#{status.pid}.log", report)
     end
   end
 
-  def test_bugreport_path_executable_path
+  def test_crash_report_executable_path
     omit if EnvUtil.rubybin.size > 245
-    assert_bugreport_path("%E.%p.log") do |status, report|
+    assert_crash_report("%E.%p.log") do |status, report|
       assert_equal("#{EnvUtil.rubybin.tr('/', '!')}.#{status.pid}.log", report)
     end
   end
 
-  def test_bugreport_path_script_path
-    assert_bugreport_path("%F.%p.log", "test/bug.rb") do |status, report|
+  def test_crash_report_script_path
+    assert_crash_report("%F.%p.log", "test/bug.rb") do |status, report|
       assert_equal("test!bug.rb.#{status.pid}.log", report)
     end
   end
 
-  def test_bugreport_path_pipe
+  def test_crash_report_pipe
     if File.executable?(echo = "/bin/echo")
     elsif /mswin|ming/ =~ RUBY_PLATFORM
       echo = "echo"
     else
       omit "/bin/echo not found"
     end
-    assert_in_out_err([{"RUBY_BUGREPORT_PATH"=>"| #{echo} %e:%f:%p"}], SEGVTest::KILL_SELF,
+    assert_in_out_err([{"RUBY_CRASH_REPORT"=>"| #{echo} %e:%f:%p"}], SEGVTest::KILL_SELF,
                       encoding: "ASCII-8BIT",
                       **SEGVTest::ExecOptions) do |stdout, stderr, status|
       assert_empty(stderr)

--- a/test/ruby/test_rubyoptions.rb
+++ b/test/ruby/test_rubyoptions.rb
@@ -793,29 +793,32 @@ class TestRubyOptions < Test::Unit::TestCase
         )?
       )x,
     ]
+
+    KILL_SELF = "Process.kill :SEGV, $$"
   end
 
-  def assert_segv(args, message=nil)
+  def assert_segv(args, message=nil, list: SEGVTest::ExpectedStderrList, **opt)
     # We want YJIT to be enabled in the subprocess if it's enabled for us
     # so that the Ruby description matches.
+    env = Hash === args.first ? args.shift : {}
     args.unshift("--yjit") if self.class.yjit_enabled?
-    args.unshift({'RUBY_ON_BUG' => nil})
+    env.update({'RUBY_ON_BUG' => nil})
+    args.unshift(env)
 
     test_stdin = ""
-    opt = SEGVTest::ExecOptions.dup
-    list = SEGVTest::ExpectedStderrList
 
-    assert_in_out_err(args, test_stdin, //, list, encoding: "ASCII-8BIT", **opt)
+    assert_in_out_err(args, test_stdin, //, list, encoding: "ASCII-8BIT",
+                      **SEGVTest::ExecOptions, **opt)
   end
 
   def test_segv_test
-    assert_segv(["--disable-gems", "-e", "Process.kill :SEGV, $$"])
+    assert_segv(["--disable-gems", "-e", SEGVTest::KILL_SELF])
   end
 
   def test_segv_loaded_features
     bug7402 = '[ruby-core:49573]'
 
-    status = assert_segv(['-e', 'END {Process.kill :SEGV, $$}',
+    status = assert_segv(['-e', "END {#{SEGVTest::KILL_SELF}}",
                           '-e', 'class Bogus; def to_str; exit true; end; end',
                           '-e', '$".clear',
                           '-e', '$".unshift Bogus.new',
@@ -829,8 +832,52 @@ class TestRubyOptions < Test::Unit::TestCase
     Tempfile.create(["test_ruby_test_bug7597", ".rb"]) {|t|
       t.write "f" * 100
       t.flush
-      assert_segv(["--disable-gems", "-e", "$0=ARGV[0]; Process.kill :SEGV, $$", t.path], bug7597)
+      assert_segv(["--disable-gems", "-e", "$0=ARGV[0]; #{SEGVTest::KILL_SELF}", t.path], bug7597)
     }
+  end
+
+  def assert_bugreport_path(path, cmd = nil)
+    Dir.mktmpdir("ruby_bugreport") do |dir|
+      list = SEGVTest::ExpectedStderrList
+      if cmd
+        FileUtils.mkpath(File.join(dir, File.dirname(cmd)))
+        File.write(File.join(dir, cmd), SEGVTest::KILL_SELF+"\n")
+        c = Regexp.quote(cmd)
+        list = list.map {|re| Regexp.new(re.source.gsub(/-e/) {c}, re.options)}
+      else
+        cmd = ['-e', SEGVTest::KILL_SELF]
+      end
+      status = assert_segv([{"RUBY_BUGREPORT_PATH"=>path}, *cmd], list: [], chdir: dir)
+      reports = Dir.glob("*.log", File::FNM_DOTMATCH, base: dir)
+      assert_equal(1, reports.size)
+      assert_pattern_list(list, File.read(File.join(dir, reports.first)))
+      break status, reports.first
+    end
+  end
+
+  def test_bugreport_path
+    assert_bugreport_path("%e.%f.%p.log") do |status, report|
+      assert_equal("#{File.basename(EnvUtil.rubybin)}.-e.#{status.pid}.log", report)
+    end
+  end
+
+  def test_bugreport_path_script
+    assert_bugreport_path("%e.%f.%p.log", "bug.rb") do |status, report|
+      assert_equal("#{File.basename(EnvUtil.rubybin)}.bug.rb.#{status.pid}.log", report)
+    end
+  end
+
+  def test_bugreport_path_executable_path
+    omit if EnvUtil.rubybin.size > 245
+    assert_bugreport_path("%E.%p.log") do |status, report|
+      assert_equal("#{EnvUtil.rubybin.tr('/', '!')}.#{status.pid}.log", report)
+    end
+  end
+
+  def test_bugreport_path_script_path
+    assert_bugreport_path("%F.%p.log", "test/bug.rb") do |status, report|
+      assert_equal("test!bug.rb.#{status.pid}.log", report)
+    end
   end
 
   def test_DATA

--- a/vm.c
+++ b/vm.c
@@ -3542,7 +3542,7 @@ extern size_t rb_gc_stack_maxsize;
 static VALUE
 sdr(VALUE self)
 {
-    rb_vm_bugreport(NULL);
+    rb_vm_bugreport(NULL, stderr);
     return Qnil;
 }
 

--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -71,7 +71,7 @@ calc_pos(const rb_iseq_t *iseq, const VALUE *pc, int *lineno, int *node_id)
 #if VMDEBUG && defined(HAVE_BUILTIN___BUILTIN_TRAP)
         else {
             /* SDR() is not possible; that causes infinite loop. */
-            rb_print_backtrace();
+            rb_print_backtrace(stderr);
             __builtin_trap();
         }
 #endif
@@ -1003,31 +1003,38 @@ vm_backtrace_print(FILE *fp)
                    &arg);
 }
 
+struct oldbt_bugreport_arg {
+    FILE *fp;
+    int count;
+};
+
 static void
 oldbt_bugreport(void *arg, VALUE file, int line, VALUE method)
 {
+    struct oldbt_bugreport_arg *p = arg;
+    FILE *fp = p->fp;
     const char *filename = NIL_P(file) ? "ruby" : RSTRING_PTR(file);
-    if (!*(int *)arg) {
-        fprintf(stderr, "-- Ruby level backtrace information "
+    if (!p->count) {
+        fprintf(fp, "-- Ruby level backtrace information "
                 "----------------------------------------\n");
-        *(int *)arg = 1;
+        p->count = 1;
     }
     if (NIL_P(method)) {
-        fprintf(stderr, "%s:%d:in unknown method\n", filename, line);
+        fprintf(fp, "%s:%d:in unknown method\n", filename, line);
     }
     else {
-        fprintf(stderr, "%s:%d:in `%s'\n", filename, line, RSTRING_PTR(method));
+        fprintf(fp, "%s:%d:in `%s'\n", filename, line, RSTRING_PTR(method));
     }
 }
 
 void
-rb_backtrace_print_as_bugreport(void)
+rb_backtrace_print_as_bugreport(FILE *fp)
 {
     struct oldbt_arg arg;
-    int i = 0;
+    struct oldbt_bugreport_arg barg = {fp, 0};
 
     arg.func = oldbt_bugreport;
-    arg.data = (int *)&i;
+    arg.data = &barg;
 
     backtrace_each(GET_EC(),
                    oldbt_init,

--- a/vm_core.h
+++ b/vm_core.h
@@ -1678,13 +1678,13 @@ VALUE rb_proc_alloc(VALUE klass);
 VALUE rb_proc_dup(VALUE self);
 
 /* for debug */
-extern void rb_vmdebug_stack_dump_raw(const rb_execution_context_t *ec, const rb_control_frame_t *cfp);
-extern void rb_vmdebug_debug_print_pre(const rb_execution_context_t *ec, const rb_control_frame_t *cfp, const VALUE *_pc);
-extern void rb_vmdebug_debug_print_post(const rb_execution_context_t *ec, const rb_control_frame_t *cfp);
+extern void rb_vmdebug_stack_dump_raw(const rb_execution_context_t *ec, const rb_control_frame_t *cfp, FILE *);
+extern void rb_vmdebug_debug_print_pre(const rb_execution_context_t *ec, const rb_control_frame_t *cfp, const VALUE *_pc, FILE *);
+extern void rb_vmdebug_debug_print_post(const rb_execution_context_t *ec, const rb_control_frame_t *cfp, FILE *);
 
-#define SDR() rb_vmdebug_stack_dump_raw(GET_EC(), GET_EC()->cfp)
-#define SDR2(cfp) rb_vmdebug_stack_dump_raw(GET_EC(), (cfp))
-void rb_vm_bugreport(const void *);
+#define SDR() rb_vmdebug_stack_dump_raw(GET_EC(), GET_EC()->cfp, stderr)
+#define SDR2(cfp) rb_vmdebug_stack_dump_raw(GET_EC(), (cfp), stderr)
+void rb_vm_bugreport(const void *, FILE *);
 typedef void (*ruby_sighandler_t)(int);
 RBIMPL_ATTR_FORMAT(RBIMPL_PRINTF_FORMAT, 4, 5)
 NORETURN(void rb_bug_for_fatal_signal(ruby_sighandler_t default_sighandler, int sig, const void *, const char *fmt, ...));

--- a/vm_core.h
+++ b/vm_core.h
@@ -1678,13 +1678,13 @@ VALUE rb_proc_alloc(VALUE klass);
 VALUE rb_proc_dup(VALUE self);
 
 /* for debug */
-extern void rb_vmdebug_stack_dump_raw(const rb_execution_context_t *ec, const rb_control_frame_t *cfp, FILE *);
-extern void rb_vmdebug_debug_print_pre(const rb_execution_context_t *ec, const rb_control_frame_t *cfp, const VALUE *_pc, FILE *);
-extern void rb_vmdebug_debug_print_post(const rb_execution_context_t *ec, const rb_control_frame_t *cfp, FILE *);
+extern bool rb_vmdebug_stack_dump_raw(const rb_execution_context_t *ec, const rb_control_frame_t *cfp, FILE *);
+extern bool rb_vmdebug_debug_print_pre(const rb_execution_context_t *ec, const rb_control_frame_t *cfp, const VALUE *_pc, FILE *);
+extern bool rb_vmdebug_debug_print_post(const rb_execution_context_t *ec, const rb_control_frame_t *cfp, FILE *);
 
 #define SDR() rb_vmdebug_stack_dump_raw(GET_EC(), GET_EC()->cfp, stderr)
 #define SDR2(cfp) rb_vmdebug_stack_dump_raw(GET_EC(), (cfp), stderr)
-void rb_vm_bugreport(const void *, FILE *);
+bool rb_vm_bugreport(const void *, FILE *);
 typedef void (*ruby_sighandler_t)(int);
 RBIMPL_ATTR_FORMAT(RBIMPL_PRINTF_FORMAT, 4, 5)
 NORETURN(void rb_bug_for_fatal_signal(ruby_sighandler_t default_sighandler, int sig, const void *, const char *fmt, ...));

--- a/vm_dump.c
+++ b/vm_dump.c
@@ -46,7 +46,10 @@
 const char *rb_method_type_name(rb_method_type_t type);
 int ruby_on_ci;
 
-static void
+#define kprintf(...) if (fprintf(errout, __VA_ARGS__) < 0) goto error
+#define kputs(s) if (fputs(s, errout) < 0) goto error
+
+static bool
 control_frame_dump(const rb_execution_context_t *ec, const rb_control_frame_t *cfp, FILE *errout)
 {
     ptrdiff_t pc = -1;
@@ -140,30 +143,30 @@ control_frame_dump(const rb_execution_context_t *ec, const rb_control_frame_t *c
         line = -1;
     }
 
-    fprintf(errout, "c:%04"PRIdPTRDIFF" ",
+    kprintf("c:%04"PRIdPTRDIFF" ",
             ((rb_control_frame_t *)(ec->vm_stack + ec->vm_stack_size) - cfp));
     if (pc == -1) {
-        fprintf(errout, "p:---- ");
+        kprintf("p:---- ");
     }
     else {
-        fprintf(errout, "p:%04"PRIdPTRDIFF" ", pc);
+        kprintf("p:%04"PRIdPTRDIFF" ", pc);
     }
-    fprintf(errout, "s:%04"PRIdPTRDIFF" ", cfp->sp - ec->vm_stack);
-    fprintf(errout, ep_in_heap == ' ' ? "e:%06"PRIdPTRDIFF" " : "E:%06"PRIxPTRDIFF" ", ep % 10000);
-    fprintf(errout, "%-6s", magic);
+    kprintf("s:%04"PRIdPTRDIFF" ", cfp->sp - ec->vm_stack);
+    kprintf(ep_in_heap == ' ' ? "e:%06"PRIdPTRDIFF" " : "E:%06"PRIxPTRDIFF" ", ep % 10000);
+    kprintf("%-6s", magic);
     if (line) {
-        fprintf(errout, " %s", posbuf);
+        kprintf(" %s", posbuf);
     }
     if (VM_FRAME_FINISHED_P(cfp)) {
-        fprintf(errout, " [FINISH]");
+        kprintf(" [FINISH]");
     }
     if (0) {
-        fprintf(errout, "              \t");
-        fprintf(errout, "iseq: %-24s ", iseq_name);
-        fprintf(errout, "self: %-24s ", selfstr);
-        fprintf(errout, "%-1s ", biseq_name);
+        kprintf("              \t");
+        kprintf("iseq: %-24s ", iseq_name);
+        kprintf("self: %-24s ", selfstr);
+        kprintf("%-1s ", biseq_name);
     }
-    fprintf(errout, "\n");
+    kprintf("\n");
 
     // additional information for CI machines
     if (ruby_on_ci) {
@@ -171,35 +174,38 @@ control_frame_dump(const rb_execution_context_t *ec, const rb_control_frame_t *c
 
         if (me) {
             if (IMEMO_TYPE_P(me, imemo_ment)) {
-                fprintf(errout, "  me:\n");
-                fprintf(errout, "    called_id: %s, type: %s\n", rb_id2name(me->called_id), rb_method_type_name(me->def->type));
-                fprintf(errout, "    owner class: %s\n", rb_raw_obj_info(buff, 0x100, me->owner));
+                kprintf("  me:\n");
+                kprintf("    called_id: %s, type: %s\n", rb_id2name(me->called_id), rb_method_type_name(me->def->type));
+                kprintf("    owner class: %s\n", rb_raw_obj_info(buff, 0x100, me->owner));
                 if (me->owner != me->defined_class) {
-                    fprintf(errout, "    defined_class: %s\n", rb_raw_obj_info(buff, 0x100, me->defined_class));
+                    kprintf("    defined_class: %s\n", rb_raw_obj_info(buff, 0x100, me->defined_class));
                 }
             }
             else {
-                fprintf(errout, " me is corrupted (%s)\n", rb_raw_obj_info(buff, 0x100, (VALUE)me));
+                kprintf(" me is corrupted (%s)\n", rb_raw_obj_info(buff, 0x100, (VALUE)me));
             }
         }
 
-        fprintf(errout, "  self: %s\n", rb_raw_obj_info(buff, 0x100, cfp->self));
+        kprintf("  self: %s\n", rb_raw_obj_info(buff, 0x100, cfp->self));
 
         if (iseq) {
             if (ISEQ_BODY(iseq)->local_table_size > 0) {
-                fprintf(errout, "  lvars:\n");
+                kprintf("  lvars:\n");
                 for (unsigned int i=0; i<ISEQ_BODY(iseq)->local_table_size; i++) {
                     const VALUE *argv = cfp->ep - ISEQ_BODY(cfp->iseq)->local_table_size - VM_ENV_DATA_SIZE + 1;
-                    fprintf(errout, "    %s: %s\n",
+                    kprintf("    %s: %s\n",
                             rb_id2name(ISEQ_BODY(iseq)->local_table[i]),
                             rb_raw_obj_info(buff, 0x100, argv[i]));
                 }
             }
         }
     }
+    return true;
+  error:
+    return false;
 }
 
-void
+bool
 rb_vmdebug_stack_dump_raw(const rb_execution_context_t *ec, const rb_control_frame_t *cfp, FILE *errout)
 {
 #if 0
@@ -207,58 +213,66 @@ rb_vmdebug_stack_dump_raw(const rb_execution_context_t *ec, const rb_control_fra
     const VALUE *ep = cfp->ep;
     VALUE *p, *st, *t;
 
-    fprintf(errout, "-- stack frame ------------\n");
+    kprintf("-- stack frame ------------\n");
     for (p = st = ec->vm_stack; p < sp; p++) {
-        fprintf(errout, "%04ld (%p): %08"PRIxVALUE, (long)(p - st), p, *p);
+        kprintf("%04ld (%p): %08"PRIxVALUE, (long)(p - st), p, *p);
 
         t = (VALUE *)*p;
         if (ec->vm_stack <= t && t < sp) {
-            fprintf(errout, " (= %ld)", (long)((VALUE *)GC_GUARDED_PTR_REF((VALUE)t) - ec->vm_stack));
+            kprintf(" (= %ld)", (long)((VALUE *)GC_GUARDED_PTR_REF((VALUE)t) - ec->vm_stack));
         }
 
         if (p == ep)
-            fprintf(errout, " <- ep");
+            kprintf(" <- ep");
 
-        fprintf(errout, "\n");
+        kprintf("\n");
     }
 #endif
 
-    fprintf(errout, "-- Control frame information "
+    kprintf("-- Control frame information "
             "-----------------------------------------------\n");
     while ((void *)cfp < (void *)(ec->vm_stack + ec->vm_stack_size)) {
         control_frame_dump(ec, cfp, errout);
         cfp++;
     }
-    fprintf(errout, "\n");
+    kprintf("\n");
+    return true;
+
+  error:
+    return false;
 }
 
-void
+bool
 rb_vmdebug_stack_dump_raw_current(void)
 {
     const rb_execution_context_t *ec = GET_EC();
-    rb_vmdebug_stack_dump_raw(ec, ec->cfp, stderr);
+    return rb_vmdebug_stack_dump_raw(ec, ec->cfp, stderr);
 }
 
-void
+bool
 rb_vmdebug_env_dump_raw(const rb_env_t *env, const VALUE *ep, FILE *errout)
 {
     unsigned int i;
-    fprintf(errout, "-- env --------------------\n");
+    kprintf("-- env --------------------\n");
 
     while (env) {
-        fprintf(errout, "--\n");
+        kprintf("--\n");
         for (i = 0; i < env->env_size; i++) {
-            fprintf(errout, "%04d: %08"PRIxVALUE" (%p)", i, env->env[i], (void *)&env->env[i]);
-            if (&env->env[i] == ep) fprintf(errout, " <- ep");
-            fprintf(errout, "\n");
+            kprintf("%04d: %08"PRIxVALUE" (%p)", i, env->env[i], (void *)&env->env[i]);
+            if (&env->env[i] == ep) kprintf(" <- ep");
+            kprintf("\n");
         }
 
         env = rb_vm_env_prev_env(env);
     }
-    fprintf(errout, "---------------------------\n");
+    kprintf("---------------------------\n");
+    return true;
+
+  error:
+    return false;
 }
 
-void
+bool
 rb_vmdebug_proc_dump_raw(rb_proc_t *proc, FILE *errout)
 {
     const rb_env_t *env;
@@ -266,17 +280,21 @@ rb_vmdebug_proc_dump_raw(rb_proc_t *proc, FILE *errout)
     VALUE val = rb_inspect(vm_block_self(&proc->block));
     selfstr = StringValueCStr(val);
 
-    fprintf(errout, "-- proc -------------------\n");
-    fprintf(errout, "self: %s\n", selfstr);
+    kprintf("-- proc -------------------\n");
+    kprintf("self: %s\n", selfstr);
     env = VM_ENV_ENVVAL_PTR(vm_block_ep(&proc->block));
     rb_vmdebug_env_dump_raw(env, vm_block_ep(&proc->block), errout);
+    return true;
+
+  error:
+    return false;
 }
 
-void
+bool
 rb_vmdebug_stack_dump_th(VALUE thval, FILE *errout)
 {
     rb_thread_t *target_th = rb_thread_ptr(thval);
-    rb_vmdebug_stack_dump_raw(target_th->ec, target_th->ec->cfp, errout);
+    return rb_vmdebug_stack_dump_raw(target_th->ec, target_th->ec->cfp, errout);
 }
 
 #if VMDEBUG > 2
@@ -325,12 +343,12 @@ vm_stack_dump_each(const rb_execution_context_t *ec, const rb_control_frame_t *c
 
         for (i = 0; i < argc; i++) {
             rstr = rb_inspect(*ptr);
-            fprintf(errout, "  arg   %2d: %8s (%p)\n", i, StringValueCStr(rstr),
+            kprintf("  arg   %2d: %8s (%p)\n", i, StringValueCStr(rstr),
                     (void *)ptr++);
         }
         for (; i < local_table_size - 1; i++) {
             rstr = rb_inspect(*ptr);
-            fprintf(errout, "  local %2d: %8s (%p)\n", i, StringValueCStr(rstr),
+            kprintf("  local %2d: %8s (%p)\n", i, StringValueCStr(rstr),
                     (void *)ptr++);
         }
 
@@ -347,7 +365,7 @@ vm_stack_dump_each(const rb_execution_context_t *ec, const rb_control_frame_t *c
                 rstr = rb_inspect(*ptr);
                 break;
             }
-            fprintf(errout, "  stack %2d: %8s (%"PRIdPTRDIFF")\n", i, StringValueCStr(rstr),
+            kprintf("  stack %2d: %8s (%"PRIdPTRDIFF")\n", i, StringValueCStr(rstr),
                     (ptr - ec->vm_stack));
         }
     }
@@ -365,7 +383,7 @@ vm_stack_dump_each(const rb_execution_context_t *ec, const rb_control_frame_t *c
 }
 #endif
 
-void
+bool
 rb_vmdebug_debug_print_register(const rb_execution_context_t *ec, FILE *errout)
 {
     rb_control_frame_t *cfp = ec->cfp;
@@ -382,17 +400,21 @@ rb_vmdebug_debug_print_register(const rb_execution_context_t *ec, FILE *errout)
     }
 
     cfpi = ((rb_control_frame_t *)(ec->vm_stack + ec->vm_stack_size)) - cfp;
-    fprintf(errout, "  [PC] %04"PRIdPTRDIFF", [SP] %04"PRIdPTRDIFF", [EP] %04"PRIdPTRDIFF", [CFP] %04"PRIdPTRDIFF"\n",
+    kprintf("  [PC] %04"PRIdPTRDIFF", [SP] %04"PRIdPTRDIFF", [EP] %04"PRIdPTRDIFF", [CFP] %04"PRIdPTRDIFF"\n",
             pc, (cfp->sp - ec->vm_stack), ep, cfpi);
+    return true;
+
+  error:
+    return false;
 }
 
-void
+bool
 rb_vmdebug_thread_dump_regs(VALUE thval, FILE *errout)
 {
-    rb_vmdebug_debug_print_register(rb_thread_ptr(thval)->ec, errout);
+    return rb_vmdebug_debug_print_register(rb_thread_ptr(thval)->ec, errout);
 }
 
-void
+bool
 rb_vmdebug_debug_print_pre(const rb_execution_context_t *ec, const rb_control_frame_t *cfp, const VALUE *_pc, FILE *errout)
 {
     const rb_iseq_t *iseq = cfp->iseq;
@@ -402,10 +424,10 @@ rb_vmdebug_debug_print_pre(const rb_execution_context_t *ec, const rb_control_fr
         int i;
 
         for (i=0; i<(int)VM_CFP_CNT(ec, cfp); i++) {
-            printf(" ");
+            kprintf(" ");
         }
-        printf("| ");
-        if(0)printf("[%03ld] ", (long)(cfp->sp - ec->vm_stack));
+        kprintf("| ");
+        if(0) kprintf("[%03ld] ", (long)(cfp->sp - ec->vm_stack));
 
         /* printf("%3"PRIdPTRDIFF" ", VM_CFP_CNT(ec, cfp)); */
         if (pc >= 0) {
@@ -416,20 +438,24 @@ rb_vmdebug_debug_print_pre(const rb_execution_context_t *ec, const rb_control_fr
     }
 
 #if VMDEBUG > 3
-    fprintf(errout, "        (1)");
+    kprintf("        (1)");
     rb_vmdebug_debug_print_register(errout, ec);
 #endif
+    return true;
+
+  error:
+    return false;
 }
 
-void
+bool
 rb_vmdebug_debug_print_post(const rb_execution_context_t *ec, const rb_control_frame_t *cfp, FILE *errout)
 {
 #if VMDEBUG > 9
-    rb_vmdebug_stack_dump_raw(ec, cfp, errout);
+    if (!rb_vmdebug_stack_dump_raw(ec, cfp, errout)) goto errout;
 #endif
 
 #if VMDEBUG > 3
-    fprintf(errout, "        (2)");
+    kprintf("        (2)");
     rb_vmdebug_debug_print_register(errout, ec);
 #endif
     /* stack_dump_raw(ec, cfp); */
@@ -438,8 +464,14 @@ rb_vmdebug_debug_print_post(const rb_execution_context_t *ec, const rb_control_f
     /* stack_dump_thobj(ec); */
     vm_stack_dump_each(ec, ec->cfp, errout);
 
-    printf
+    kprintf
         ("--------------------------------------------------------------\n");
+#endif
+    return true;
+
+#if VMDEBUG > 2
+  error:
+    return false;
 #endif
 }
 
@@ -449,10 +481,11 @@ rb_vmdebug_thread_dump_state(FILE *errout, VALUE self)
     rb_thread_t *th = rb_thread_ptr(self);
     rb_control_frame_t *cfp = th->ec->cfp;
 
-    fprintf(errout, "Thread state dump:\n");
-    fprintf(errout, "pc : %p, sp : %p\n", (void *)cfp->pc, (void *)cfp->sp);
-    fprintf(errout, "cfp: %p, ep : %p\n", (void *)cfp, (void *)cfp->ep);
+    kprintf("Thread state dump:\n");
+    kprintf("pc : %p, sp : %p\n", (void *)cfp->pc, (void *)cfp->sp);
+    kprintf("cfp: %p, ep : %p\n", (void *)cfp, (void *)cfp->ep);
 
+  error:
     return Qnil;
 }
 
@@ -746,19 +779,20 @@ dump_thread(void *arg)
                         info->MaxNameLen = MAX_SYM_NAME;
                         if (pSymFromAddr(ph, addr, &displacement, info)) {
                             if (GetModuleFileName((HANDLE)(uintptr_t)pSymGetModuleBase64(ph, addr), libpath, sizeof(libpath)))
-                                fprintf(errout, "%s", libpath);
-                            fprintf(errout, "(%s+0x%"PRI_64_PREFIX"x)",
+                                kprintf("%s", libpath);
+                            kprintf("(%s+0x%"PRI_64_PREFIX"x)",
                                     info->Name, displacement);
                         }
-                        fprintf(errout, " [0x%p]", (void *)(VALUE)addr);
+                        kprintf(" [0x%p]", (void *)(VALUE)addr);
                         memset(&line, 0, sizeof(line));
                         line.SizeOfStruct = sizeof(line);
                         if (pSymGetLineFromAddr64(ph, addr, &tmp, &line))
-                            fprintf(errout, " %s:%lu", line.FileName, line.LineNumber);
-                        fprintf(errout, "\n");
+                            kprintf(" %s:%lu", line.FileName, line.LineNumber);
+                        kprintf("\n");
                     }
                 }
 
+              error:
                 ResumeThread(th);
             }
             CloseHandle(th);
@@ -783,7 +817,7 @@ rb_print_backtrace(FILE *errout)
     if (syms) {
         int i;
         for (i=0; i<n; i++) {
-            fprintf(errout, "%s\n", syms[i]);
+            kprintf("%s\n", syms[i]);
         }
         free(syms);
     }
@@ -827,21 +861,24 @@ print_machine_register(FILE *errout, size_t reg, const char *reg_name, int col_c
 
     ret = snprintf(buf, sizeof(buf), " %3.3s: 0x%.*" PRIxSIZE, reg_name, size_width, reg);
     if (col_count + ret > max_col) {
-        fputs("\n", errout);
+        kputs("\n");
         col_count = 0;
     }
     col_count += ret;
-    fputs(buf, errout);
+    kputs(buf);
     return col_count;
+
+  error:
+    return -1;
 }
 
-static void
+static bool
 rb_dump_machine_register(FILE *errout, const ucontext_t *ctx)
 {
     int col_count = 0;
-    if (!ctx) return;
+    if (!ctx) return true;
 
-    fprintf(errout, "-- Machine register context "
+    kprintf("-- Machine register context "
             "------------------------------------------------\n");
 
 # if defined __linux__
@@ -1034,13 +1071,17 @@ rb_dump_machine_register(FILE *errout, const ucontext_t *ctx)
 #   endif
     }
 # endif
-    fprintf(errout, "\n\n");
+    kprintf("\n\n");
+    return true;
+
+  error:
+    return false;
 }
 #else
 # define rb_dump_machine_register(errout, ctx) ((void)0)
 #endif /* dump_machine_register */
 
-void
+bool
 rb_vm_bugreport(const void *ctx, FILE *errout)
 {
     const char *cmd = getenv("RUBY_ON_BUG");
@@ -1058,8 +1099,8 @@ rb_vm_bugreport(const void *ctx, FILE *errout)
     {
         static bool crashing = false;
         if (crashing) {
-            fprintf(errout, "Crashed while printing bug report\n");
-            return;
+            kprintf("Crashed while printing bug report\n");
+            return true;
         }
         crashing = true;
     }
@@ -1082,26 +1123,26 @@ rb_vm_bugreport(const void *ctx, FILE *errout)
         // If we get here, hopefully things are intact enough that
         // we can read these two numbers. It is an estimate because
         // we are reading without synchronization.
-        fprintf(errout, "-- Threading information "
+        kprintf("-- Threading information "
                 "---------------------------------------------------\n");
-        fprintf(errout, "Total ractor count: %u\n", vm->ractor.cnt);
-        fprintf(errout, "Ruby thread count for this ractor: %u\n", rb_ec_ractor_ptr(ec)->threads.cnt);
+        kprintf("Total ractor count: %u\n", vm->ractor.cnt);
+        kprintf("Ruby thread count for this ractor: %u\n", rb_ec_ractor_ptr(ec)->threads.cnt);
         fputs("\n", errout);
     }
 
     rb_dump_machine_register(errout, ctx);
 
 #if USE_BACKTRACE || defined(_WIN32)
-    fprintf(errout, "-- C level backtrace information "
+    kprintf("-- C level backtrace information "
             "-------------------------------------------\n");
     rb_print_backtrace(errout);
 
 
-    fprintf(errout, "\n");
+    kprintf("\n");
 #endif /* USE_BACKTRACE */
 
     if (other_runtime_info || vm) {
-        fprintf(errout, "-- Other runtime information "
+        kprintf("-- Other runtime information "
                 "-----------------------------------------------\n\n");
     }
     if (vm && !rb_during_gc()) {
@@ -1114,16 +1155,16 @@ rb_vm_bugreport(const void *ctx, FILE *errout)
 
         name = vm->progname;
         if (name) {
-            fprintf(errout, "* Loaded script: %.*s\n",
+            kprintf("* Loaded script: %.*s\n",
                     LIMITED_NAME_LENGTH(name), RSTRING_PTR(name));
-            fprintf(errout, "\n");
+            kprintf("\n");
         }
         if (vm->loaded_features) {
-            fprintf(errout, "* Loaded features:\n\n");
+            kprintf("* Loaded features:\n\n");
             for (i=0; i<RARRAY_LEN(vm->loaded_features); i++) {
                 name = RARRAY_AREF(vm->loaded_features, i);
                 if (RB_TYPE_P(name, T_STRING)) {
-                    fprintf(errout, " %4d %.*s\n", i,
+                    kprintf(" %4d %.*s\n", i,
                             LIMITED_NAME_LENGTH(name), RSTRING_PTR(name));
                 }
                 else if (RB_TYPE_P(name, T_CLASS) || RB_TYPE_P(name, T_MODULE)) {
@@ -1131,26 +1172,26 @@ rb_vm_bugreport(const void *ctx, FILE *errout)
                         "class" : "module";
                     name = rb_search_class_path(rb_class_real(name));
                     if (!RB_TYPE_P(name, T_STRING)) {
-                        fprintf(errout, " %4d %s:<unnamed>\n", i, type);
+                        kprintf(" %4d %s:<unnamed>\n", i, type);
                         continue;
                     }
-                    fprintf(errout, " %4d %s:%.*s\n", i, type,
+                    kprintf(" %4d %s:%.*s\n", i, type,
                             LIMITED_NAME_LENGTH(name), RSTRING_PTR(name));
                 }
                 else {
                     VALUE klass = rb_search_class_path(rb_obj_class(name));
                     if (!RB_TYPE_P(klass, T_STRING)) {
-                        fprintf(errout, " %4d #<%p:%p>\n", i,
+                        kprintf(" %4d #<%p:%p>\n", i,
                                 (void *)CLASS_OF(name), (void *)name);
                         continue;
                     }
-                    fprintf(errout, " %4d #<%.*s:%p>\n", i,
+                    kprintf(" %4d #<%.*s:%p>\n", i,
                             LIMITED_NAME_LENGTH(klass), RSTRING_PTR(klass),
                             (void *)name);
                 }
             }
         }
-        fprintf(errout, "\n");
+        kprintf("\n");
     }
 
     {
@@ -1158,7 +1199,7 @@ rb_vm_bugreport(const void *ctx, FILE *errout)
         {
             FILE *fp = fopen(PROC_MAPS_NAME, "r");
             if (fp) {
-                fprintf(errout, "* Process memory map:\n\n");
+                kprintf("* Process memory map:\n\n");
 
                 while (!feof(fp)) {
                     char buff[0x100];
@@ -1168,7 +1209,7 @@ rb_vm_bugreport(const void *ctx, FILE *errout)
                 }
 
                 fclose(fp);
-                fprintf(errout, "\n\n");
+                kprintf("\n\n");
             }
         }
 #endif /* __linux__ */
@@ -1182,14 +1223,14 @@ rb_vm_bugreport(const void *ctx, FILE *errout)
         mib[2] = KERN_PROC_PID;
         mib[3] = getpid();
         if (sysctl(mib, MIB_KERN_PROC_PID_LEN, &kp, &len, NULL, 0) == -1) {
-            fprintf(errout, "sysctl: %s\n", strerror(errno));
+            kprintf("sysctl: %s\n", strerror(errno));
         }
         else {
             struct procstat *prstat = procstat_open_sysctl();
-            fprintf(errout, "* Process memory map:\n\n");
+            kprintf("* Process memory map:\n\n");
             procstat_vm(prstat, &kp);
             procstat_close(prstat);
-            fprintf(errout, "\n");
+            kprintf("\n");
         }
 #endif /* __FreeBSD__ */
 #ifdef __APPLE__
@@ -1199,7 +1240,7 @@ rb_vm_bugreport(const void *ctx, FILE *errout)
         mach_msg_type_number_t count = VM_REGION_SUBMAP_INFO_COUNT;
         natural_t depth = 0;
 
-        fprintf(errout, "* Process memory map:\n\n");
+        kprintf("* Process memory map:\n\n");
         while (1) {
             if (vm_region_recurse(mach_task_self(), &addr, &size, &depth,
                         (vm_region_recurse_info_t)&map, &count) != KERN_SUCCESS) {
@@ -1211,17 +1252,17 @@ rb_vm_bugreport(const void *ctx, FILE *errout)
                 depth++;
             }
             else {
-                fprintf(errout, "%lx-%lx %s%s%s", addr, (addr+size),
+                kprintf("%lx-%lx %s%s%s", addr, (addr+size),
                         ((map.protection & VM_PROT_READ) != 0 ? "r" : "-"),
                         ((map.protection & VM_PROT_WRITE) != 0 ? "w" : "-"),
                     ((map.protection & VM_PROT_EXECUTE) != 0 ? "x" : "-"));
 #ifdef HAVE_LIBPROC_H
                 char buff[PATH_MAX];
                 if (proc_regionfilename(getpid(), addr, buff, sizeof(buff)) > 0) {
-                    fprintf(errout, " %s", buff);
+                    kprintf(" %s", buff);
                 }
 #endif
-                fprintf(errout, "\n");
+                kprintf("\n");
             }
 
             addr += size;
@@ -1229,9 +1270,13 @@ rb_vm_bugreport(const void *ctx, FILE *errout)
         }
 #endif
     }
+    return true;
+
+  error:
+    return false;
 }
 
-void
+bool
 rb_vmdebug_stack_dump_all_threads(void)
 {
     rb_thread_t *th = NULL;
@@ -1241,10 +1286,14 @@ rb_vmdebug_stack_dump_all_threads(void)
     // TODO: now it only shows current ractor
     ccan_list_for_each(&r->threads.set, th, lt_node) {
 #ifdef NON_SCALAR_THREAD_ID
-        fprintf(errout, "th: %p, native_id: N/A\n", th);
+        kprintf("th: %p, native_id: N/A\n", th);
 #else
-        fprintf(errout, "th: %p, native_id: %p\n", (void *)th, (void *)(uintptr_t)th->nt->thread_id);
+        kprintf("th: %p, native_id: %p\n", (void *)th, (void *)(uintptr_t)th->nt->thread_id);
 #endif
-        rb_vmdebug_stack_dump_raw(th->ec, th->ec->cfp, errout);
+        if (!rb_vmdebug_stack_dump_raw(th->ec, th->ec->cfp, errout)) goto error;
     }
+    return true;
+
+  error:
+    return false;
 }

--- a/vm_dump.c
+++ b/vm_dump.c
@@ -47,7 +47,7 @@ const char *rb_method_type_name(rb_method_type_t type);
 int ruby_on_ci;
 
 static void
-control_frame_dump(const rb_execution_context_t *ec, const rb_control_frame_t *cfp)
+control_frame_dump(const rb_execution_context_t *ec, const rb_control_frame_t *cfp, FILE *errout)
 {
     ptrdiff_t pc = -1;
     ptrdiff_t ep = cfp->ep - ec->vm_stack;
@@ -140,30 +140,30 @@ control_frame_dump(const rb_execution_context_t *ec, const rb_control_frame_t *c
         line = -1;
     }
 
-    fprintf(stderr, "c:%04"PRIdPTRDIFF" ",
+    fprintf(errout, "c:%04"PRIdPTRDIFF" ",
             ((rb_control_frame_t *)(ec->vm_stack + ec->vm_stack_size) - cfp));
     if (pc == -1) {
-        fprintf(stderr, "p:---- ");
+        fprintf(errout, "p:---- ");
     }
     else {
-        fprintf(stderr, "p:%04"PRIdPTRDIFF" ", pc);
+        fprintf(errout, "p:%04"PRIdPTRDIFF" ", pc);
     }
-    fprintf(stderr, "s:%04"PRIdPTRDIFF" ", cfp->sp - ec->vm_stack);
-    fprintf(stderr, ep_in_heap == ' ' ? "e:%06"PRIdPTRDIFF" " : "E:%06"PRIxPTRDIFF" ", ep % 10000);
-    fprintf(stderr, "%-6s", magic);
+    fprintf(errout, "s:%04"PRIdPTRDIFF" ", cfp->sp - ec->vm_stack);
+    fprintf(errout, ep_in_heap == ' ' ? "e:%06"PRIdPTRDIFF" " : "E:%06"PRIxPTRDIFF" ", ep % 10000);
+    fprintf(errout, "%-6s", magic);
     if (line) {
-        fprintf(stderr, " %s", posbuf);
+        fprintf(errout, " %s", posbuf);
     }
     if (VM_FRAME_FINISHED_P(cfp)) {
-        fprintf(stderr, " [FINISH]");
+        fprintf(errout, " [FINISH]");
     }
     if (0) {
-        fprintf(stderr, "              \t");
-        fprintf(stderr, "iseq: %-24s ", iseq_name);
-        fprintf(stderr, "self: %-24s ", selfstr);
-        fprintf(stderr, "%-1s ", biseq_name);
+        fprintf(errout, "              \t");
+        fprintf(errout, "iseq: %-24s ", iseq_name);
+        fprintf(errout, "self: %-24s ", selfstr);
+        fprintf(errout, "%-1s ", biseq_name);
     }
-    fprintf(stderr, "\n");
+    fprintf(errout, "\n");
 
     // additional information for CI machines
     if (ruby_on_ci) {
@@ -171,26 +171,26 @@ control_frame_dump(const rb_execution_context_t *ec, const rb_control_frame_t *c
 
         if (me) {
             if (IMEMO_TYPE_P(me, imemo_ment)) {
-                fprintf(stderr, "  me:\n");
-                fprintf(stderr, "    called_id: %s, type: %s\n", rb_id2name(me->called_id), rb_method_type_name(me->def->type));
-                fprintf(stderr, "    owner class: %s\n", rb_raw_obj_info(buff, 0x100, me->owner));
+                fprintf(errout, "  me:\n");
+                fprintf(errout, "    called_id: %s, type: %s\n", rb_id2name(me->called_id), rb_method_type_name(me->def->type));
+                fprintf(errout, "    owner class: %s\n", rb_raw_obj_info(buff, 0x100, me->owner));
                 if (me->owner != me->defined_class) {
-                    fprintf(stderr, "    defined_class: %s\n", rb_raw_obj_info(buff, 0x100, me->defined_class));
+                    fprintf(errout, "    defined_class: %s\n", rb_raw_obj_info(buff, 0x100, me->defined_class));
                 }
             }
             else {
-                fprintf(stderr, " me is corrupted (%s)\n", rb_raw_obj_info(buff, 0x100, (VALUE)me));
+                fprintf(errout, " me is corrupted (%s)\n", rb_raw_obj_info(buff, 0x100, (VALUE)me));
             }
         }
 
-        fprintf(stderr, "  self: %s\n", rb_raw_obj_info(buff, 0x100, cfp->self));
+        fprintf(errout, "  self: %s\n", rb_raw_obj_info(buff, 0x100, cfp->self));
 
         if (iseq) {
             if (ISEQ_BODY(iseq)->local_table_size > 0) {
-                fprintf(stderr, "  lvars:\n");
+                fprintf(errout, "  lvars:\n");
                 for (unsigned int i=0; i<ISEQ_BODY(iseq)->local_table_size; i++) {
                     const VALUE *argv = cfp->ep - ISEQ_BODY(cfp->iseq)->local_table_size - VM_ENV_DATA_SIZE + 1;
-                    fprintf(stderr, "    %s: %s\n",
+                    fprintf(errout, "    %s: %s\n",
                             rb_id2name(ISEQ_BODY(iseq)->local_table[i]),
                             rb_raw_obj_info(buff, 0x100, argv[i]));
                 }
@@ -200,83 +200,83 @@ control_frame_dump(const rb_execution_context_t *ec, const rb_control_frame_t *c
 }
 
 void
-rb_vmdebug_stack_dump_raw(const rb_execution_context_t *ec, const rb_control_frame_t *cfp)
+rb_vmdebug_stack_dump_raw(const rb_execution_context_t *ec, const rb_control_frame_t *cfp, FILE *errout)
 {
 #if 0
     VALUE *sp = cfp->sp;
     const VALUE *ep = cfp->ep;
     VALUE *p, *st, *t;
 
-    fprintf(stderr, "-- stack frame ------------\n");
+    fprintf(errout, "-- stack frame ------------\n");
     for (p = st = ec->vm_stack; p < sp; p++) {
-        fprintf(stderr, "%04ld (%p): %08"PRIxVALUE, (long)(p - st), p, *p);
+        fprintf(errout, "%04ld (%p): %08"PRIxVALUE, (long)(p - st), p, *p);
 
         t = (VALUE *)*p;
         if (ec->vm_stack <= t && t < sp) {
-            fprintf(stderr, " (= %ld)", (long)((VALUE *)GC_GUARDED_PTR_REF((VALUE)t) - ec->vm_stack));
+            fprintf(errout, " (= %ld)", (long)((VALUE *)GC_GUARDED_PTR_REF((VALUE)t) - ec->vm_stack));
         }
 
         if (p == ep)
-            fprintf(stderr, " <- ep");
+            fprintf(errout, " <- ep");
 
-        fprintf(stderr, "\n");
+        fprintf(errout, "\n");
     }
 #endif
 
-    fprintf(stderr, "-- Control frame information "
+    fprintf(errout, "-- Control frame information "
             "-----------------------------------------------\n");
     while ((void *)cfp < (void *)(ec->vm_stack + ec->vm_stack_size)) {
-        control_frame_dump(ec, cfp);
+        control_frame_dump(ec, cfp, errout);
         cfp++;
     }
-    fprintf(stderr, "\n");
+    fprintf(errout, "\n");
 }
 
 void
 rb_vmdebug_stack_dump_raw_current(void)
 {
     const rb_execution_context_t *ec = GET_EC();
-    rb_vmdebug_stack_dump_raw(ec, ec->cfp);
+    rb_vmdebug_stack_dump_raw(ec, ec->cfp, stderr);
 }
 
 void
-rb_vmdebug_env_dump_raw(const rb_env_t *env, const VALUE *ep)
+rb_vmdebug_env_dump_raw(const rb_env_t *env, const VALUE *ep, FILE *errout)
 {
     unsigned int i;
-    fprintf(stderr, "-- env --------------------\n");
+    fprintf(errout, "-- env --------------------\n");
 
     while (env) {
-        fprintf(stderr, "--\n");
+        fprintf(errout, "--\n");
         for (i = 0; i < env->env_size; i++) {
-            fprintf(stderr, "%04d: %08"PRIxVALUE" (%p)", i, env->env[i], (void *)&env->env[i]);
-            if (&env->env[i] == ep) fprintf(stderr, " <- ep");
-            fprintf(stderr, "\n");
+            fprintf(errout, "%04d: %08"PRIxVALUE" (%p)", i, env->env[i], (void *)&env->env[i]);
+            if (&env->env[i] == ep) fprintf(errout, " <- ep");
+            fprintf(errout, "\n");
         }
 
         env = rb_vm_env_prev_env(env);
     }
-    fprintf(stderr, "---------------------------\n");
+    fprintf(errout, "---------------------------\n");
 }
 
 void
-rb_vmdebug_proc_dump_raw(rb_proc_t *proc)
+rb_vmdebug_proc_dump_raw(rb_proc_t *proc, FILE *errout)
 {
     const rb_env_t *env;
     char *selfstr;
     VALUE val = rb_inspect(vm_block_self(&proc->block));
     selfstr = StringValueCStr(val);
 
-    fprintf(stderr, "-- proc -------------------\n");
-    fprintf(stderr, "self: %s\n", selfstr);
+    fprintf(errout, "-- proc -------------------\n");
+    fprintf(errout, "self: %s\n", selfstr);
     env = VM_ENV_ENVVAL_PTR(vm_block_ep(&proc->block));
-    rb_vmdebug_env_dump_raw(env, vm_block_ep(&proc->block));
+    rb_vmdebug_env_dump_raw(env, vm_block_ep(&proc->block), errout);
 }
 
 void
-rb_vmdebug_stack_dump_th(VALUE thval)
+rb_vmdebug_stack_dump_th(VALUE thval, FILE *errout)
 {
     rb_thread_t *target_th = rb_thread_ptr(thval);
-    rb_vmdebug_stack_dump_raw(target_th->ec, target_th->ec->cfp);
+    rb_vmdebug_stack_dump_raw(target_th->ec, target_th->ec->cfp, errout);
 }
 
 #if VMDEBUG > 2
@@ -295,7 +295,7 @@ vm_base_ptr(const rb_control_frame_t *cfp)
 }
 
 static void
-vm_stack_dump_each(const rb_execution_context_t *ec, const rb_control_frame_t *cfp)
+vm_stack_dump_each(const rb_execution_context_t *ec, const rb_control_frame_t *cfp, FILE *errout)
 {
     int i, argc = 0, local_table_size = 0;
     VALUE rstr;
@@ -321,17 +321,17 @@ vm_stack_dump_each(const rb_execution_context_t *ec, const rb_control_frame_t *c
     {
         const VALUE *ptr = ep - local_table_size;
 
-        control_frame_dump(ec, cfp);
+        control_frame_dump(ec, cfp, errout);
 
         for (i = 0; i < argc; i++) {
             rstr = rb_inspect(*ptr);
-            fprintf(stderr, "  arg   %2d: %8s (%p)\n", i, StringValueCStr(rstr),
-                   (void *)ptr++);
+            fprintf(errout, "  arg   %2d: %8s (%p)\n", i, StringValueCStr(rstr),
+                    (void *)ptr++);
         }
         for (; i < local_table_size - 1; i++) {
             rstr = rb_inspect(*ptr);
-            fprintf(stderr, "  local %2d: %8s (%p)\n", i, StringValueCStr(rstr),
-                   (void *)ptr++);
+            fprintf(errout, "  local %2d: %8s (%p)\n", i, StringValueCStr(rstr),
+                    (void *)ptr++);
         }
 
         ptr = vm_base_ptr(cfp);
@@ -347,13 +347,13 @@ vm_stack_dump_each(const rb_execution_context_t *ec, const rb_control_frame_t *c
                 rstr = rb_inspect(*ptr);
                 break;
             }
-            fprintf(stderr, "  stack %2d: %8s (%"PRIdPTRDIFF")\n", i, StringValueCStr(rstr),
+            fprintf(errout, "  stack %2d: %8s (%"PRIdPTRDIFF")\n", i, StringValueCStr(rstr),
                     (ptr - ec->vm_stack));
         }
     }
     else if (VM_FRAME_FINISHED_P(cfp)) {
         if (ec->vm_stack + ec->vm_stack_size > (VALUE *)(cfp + 1)) {
-            vm_stack_dump_each(ec, cfp + 1);
+            vm_stack_dump_each(ec, cfp + 1, errout);
         }
         else {
             /* SDR(); */
@@ -366,7 +366,7 @@ vm_stack_dump_each(const rb_execution_context_t *ec, const rb_control_frame_t *c
 #endif
 
 void
-rb_vmdebug_debug_print_register(const rb_execution_context_t *ec)
+rb_vmdebug_debug_print_register(const rb_execution_context_t *ec, FILE *errout)
 {
     rb_control_frame_t *cfp = ec->cfp;
     ptrdiff_t pc = -1;
@@ -382,18 +382,18 @@ rb_vmdebug_debug_print_register(const rb_execution_context_t *ec)
     }
 
     cfpi = ((rb_control_frame_t *)(ec->vm_stack + ec->vm_stack_size)) - cfp;
-    fprintf(stderr, "  [PC] %04"PRIdPTRDIFF", [SP] %04"PRIdPTRDIFF", [EP] %04"PRIdPTRDIFF", [CFP] %04"PRIdPTRDIFF"\n",
+    fprintf(errout, "  [PC] %04"PRIdPTRDIFF", [SP] %04"PRIdPTRDIFF", [EP] %04"PRIdPTRDIFF", [CFP] %04"PRIdPTRDIFF"\n",
             pc, (cfp->sp - ec->vm_stack), ep, cfpi);
 }
 
 void
-rb_vmdebug_thread_dump_regs(VALUE thval)
+rb_vmdebug_thread_dump_regs(VALUE thval, FILE *errout)
 {
-    rb_vmdebug_debug_print_register(rb_thread_ptr(thval)->ec);
+    rb_vmdebug_debug_print_register(rb_thread_ptr(thval)->ec, errout);
 }
 
 void
-rb_vmdebug_debug_print_pre(const rb_execution_context_t *ec, const rb_control_frame_t *cfp, const VALUE *_pc)
+rb_vmdebug_debug_print_pre(const rb_execution_context_t *ec, const rb_control_frame_t *cfp, const VALUE *_pc, FILE *errout)
 {
     const rb_iseq_t *iseq = cfp->iseq;
 
@@ -416,27 +416,27 @@ rb_vmdebug_debug_print_pre(const rb_execution_context_t *ec, const rb_control_fr
     }
 
 #if VMDEBUG > 3
-    fprintf(stderr, "        (1)");
-    rb_vmdebug_debug_print_register(ec);
+    fprintf(errout, "        (1)");
+    rb_vmdebug_debug_print_register(errout, ec);
 #endif
 }
 
 void
-rb_vmdebug_debug_print_post(const rb_execution_context_t *ec, const rb_control_frame_t *cfp)
+rb_vmdebug_debug_print_post(const rb_execution_context_t *ec, const rb_control_frame_t *cfp, FILE *errout)
 {
 #if VMDEBUG > 9
-    SDR2(cfp);
+    rb_vmdebug_stack_dump_raw(ec, cfp, errout);
 #endif
 
 #if VMDEBUG > 3
-    fprintf(stderr, "        (2)");
-    rb_vmdebug_debug_print_register(ec);
+    fprintf(errout, "        (2)");
+    rb_vmdebug_debug_print_register(errout, ec);
 #endif
     /* stack_dump_raw(ec, cfp); */
 
 #if VMDEBUG > 2
     /* stack_dump_thobj(ec); */
-    vm_stack_dump_each(ec, ec->cfp);
+    vm_stack_dump_each(ec, ec->cfp, errout);
 
     printf
         ("--------------------------------------------------------------\n");
@@ -444,14 +444,14 @@ rb_vmdebug_debug_print_post(const rb_execution_context_t *ec, const rb_control_f
 }
 
 VALUE
-rb_vmdebug_thread_dump_state(VALUE self)
+rb_vmdebug_thread_dump_state(FILE *errout, VALUE self)
 {
     rb_thread_t *th = rb_thread_ptr(self);
     rb_control_frame_t *cfp = th->ec->cfp;
 
-    fprintf(stderr, "Thread state dump:\n");
-    fprintf(stderr, "pc : %p, sp : %p\n", (void *)cfp->pc, (void *)cfp->sp);
-    fprintf(stderr, "cfp: %p, ep : %p\n", (void *)cfp, (void *)cfp->ep);
+    fprintf(errout, "Thread state dump:\n");
+    fprintf(errout, "pc : %p, sp : %p\n", (void *)cfp->pc, (void *)cfp->sp);
+    fprintf(errout, "cfp: %p, ep : %p\n", (void *)cfp, (void *)cfp->ep);
 
     return Qnil;
 }
@@ -664,6 +664,11 @@ typedef void *PGET_MODULE_BASE_ROUTINE64;
 typedef void *PTRANSLATE_ADDRESS_ROUTINE64;
 # endif
 
+struct dump_thead_arg {
+    DWORD tid;
+    FILE *errout;
+};
+
 static void
 dump_thread(void *arg)
 {
@@ -675,7 +680,8 @@ dump_thread(void *arg)
     BOOL (WINAPI *pSymFromAddr)(HANDLE, DWORD64, DWORD64 *, SYMBOL_INFO *);
     BOOL (WINAPI *pSymGetLineFromAddr64)(HANDLE, DWORD64, DWORD *, IMAGEHLP_LINE64 *);
     HANDLE (WINAPI *pOpenThread)(DWORD, BOOL, DWORD);
-    DWORD tid = *(DWORD *)arg;
+    DWORD tid = ((struct dump_thead_arg *)arg)->tid;
+    FILE *errout = ((struct dump_thead_arg *)arg)->errout;
     HANDLE ph;
     HANDLE th;
 
@@ -740,16 +746,16 @@ dump_thread(void *arg)
                         info->MaxNameLen = MAX_SYM_NAME;
                         if (pSymFromAddr(ph, addr, &displacement, info)) {
                             if (GetModuleFileName((HANDLE)(uintptr_t)pSymGetModuleBase64(ph, addr), libpath, sizeof(libpath)))
-                                fprintf(stderr, "%s", libpath);
-                            fprintf(stderr, "(%s+0x%"PRI_64_PREFIX"x)",
+                                fprintf(errout, "%s", libpath);
+                            fprintf(errout, "(%s+0x%"PRI_64_PREFIX"x)",
                                     info->Name, displacement);
                         }
-                        fprintf(stderr, " [0x%p]", (void *)(VALUE)addr);
+                        fprintf(errout, " [0x%p]", (void *)(VALUE)addr);
                         memset(&line, 0, sizeof(line));
                         line.SizeOfStruct = sizeof(line);
                         if (pSymGetLineFromAddr64(ph, addr, &tmp, &line))
-                            fprintf(stderr, " %s:%lu", line.FileName, line.LineNumber);
-                        fprintf(stderr, "\n");
+                            fprintf(errout, " %s:%lu", line.FileName, line.LineNumber);
+                        fprintf(errout, "\n");
                     }
                 }
 
@@ -764,27 +770,30 @@ dump_thread(void *arg)
 #endif
 
 void
-rb_print_backtrace(void)
+rb_print_backtrace(FILE *errout)
 {
 #if USE_BACKTRACE
 #define MAX_NATIVE_TRACE 1024
     static void *trace[MAX_NATIVE_TRACE];
     int n = (int)backtrace(trace, MAX_NATIVE_TRACE);
 #if (defined(USE_ELF) || defined(HAVE_MACH_O_LOADER_H)) && defined(HAVE_DLADDR) && !defined(__sparc)
-    rb_dump_backtrace_with_lines(n, trace);
+    rb_dump_backtrace_with_lines(n, trace, errout);
 #else
     char **syms = backtrace_symbols(trace, n);
     if (syms) {
         int i;
         for (i=0; i<n; i++) {
-            fprintf(stderr, "%s\n", syms[i]);
+            fprintf(errout, "%s\n", syms[i]);
         }
         free(syms);
     }
 #endif
 #elif defined(_WIN32)
-    DWORD tid = GetCurrentThreadId();
-    HANDLE th = (HANDLE)_beginthread(dump_thread, 0, &tid);
+    struct dump_thead_arg arg = {
+        .tid = GetCurrentThreadId(),
+        .errout = errout,
+    };
+    HANDLE th = (HANDLE)_beginthread(dump_thread, 0, &arg);
     if (th != (HANDLE)-1)
         WaitForSingleObject(th, INFINITE);
 #endif
@@ -796,21 +805,21 @@ rb_print_backtrace(void)
 
 #if defined __linux__
 # if defined(__x86_64__) || defined(__i386__)
-#   define dump_machine_register(reg) (col_count = print_machine_register(mctx->gregs[REG_##reg], #reg, col_count, 80))
+#   define dump_machine_register(reg) (col_count = print_machine_register(errout, mctx->gregs[REG_##reg], #reg, col_count, 80))
 # elif defined(__aarch64__) || defined(__arm__) || defined(__riscv) || defined(__loongarch64)
-#   define dump_machine_register(reg, regstr) (col_count = print_machine_register(reg, regstr, col_count, 80))
+#   define dump_machine_register(reg, regstr) (col_count = print_machine_register(errout, reg, regstr, col_count, 80))
 # endif
 #elif defined __APPLE__
 # if defined(__aarch64__)
-#   define dump_machine_register(reg, regstr) (col_count = print_machine_register(mctx->MCTX_SS_REG(reg), regstr, col_count, 80))
+#   define dump_machine_register(reg, regstr) (col_count = print_machine_register(errout, mctx->MCTX_SS_REG(reg), regstr, col_count, 80))
 # else
-#   define dump_machine_register(reg) (col_count = print_machine_register(mctx->MCTX_SS_REG(reg), #reg, col_count, 80))
+#   define dump_machine_register(reg) (col_count = print_machine_register(errout, mctx->MCTX_SS_REG(reg), #reg, col_count, 80))
 # endif
 #endif
 
 #ifdef dump_machine_register
 static int
-print_machine_register(size_t reg, const char *reg_name, int col_count, int max_col)
+print_machine_register(FILE *errout, size_t reg, const char *reg_name, int col_count, int max_col)
 {
     int ret;
     char buf[64];
@@ -818,21 +827,21 @@ print_machine_register(size_t reg, const char *reg_name, int col_count, int max_
 
     ret = snprintf(buf, sizeof(buf), " %3.3s: 0x%.*" PRIxSIZE, reg_name, size_width, reg);
     if (col_count + ret > max_col) {
-        fputs("\n", stderr);
+        fputs("\n", errout);
         col_count = 0;
     }
     col_count += ret;
-    fputs(buf, stderr);
+    fputs(buf, errout);
     return col_count;
 }
 
 static void
-rb_dump_machine_register(const ucontext_t *ctx)
+rb_dump_machine_register(FILE *errout, const ucontext_t *ctx)
 {
     int col_count = 0;
     if (!ctx) return;
 
-    fprintf(stderr, "-- Machine register context "
+    fprintf(errout, "-- Machine register context "
             "------------------------------------------------\n");
 
 # if defined __linux__
@@ -1025,14 +1034,14 @@ rb_dump_machine_register(const ucontext_t *ctx)
 #   endif
     }
 # endif
-    fprintf(stderr, "\n\n");
+    fprintf(errout, "\n\n");
 }
 #else
-# define rb_dump_machine_register(ctx) ((void)0)
+# define rb_dump_machine_register(errout, ctx) ((void)0)
 #endif /* dump_machine_register */
 
 void
-rb_vm_bugreport(const void *ctx)
+rb_vm_bugreport(const void *ctx, FILE *errout)
 {
     const char *cmd = getenv("RUBY_ON_BUG");
     if (cmd) {
@@ -1049,7 +1058,7 @@ rb_vm_bugreport(const void *ctx)
     {
         static bool crashing = false;
         if (crashing) {
-            fprintf(stderr, "Crashed while printing bug report\n");
+            fprintf(errout, "Crashed while printing bug report\n");
             return;
         }
         crashing = true;
@@ -1067,32 +1076,32 @@ rb_vm_bugreport(const void *ctx)
     const rb_execution_context_t *ec = rb_current_execution_context(false);
 
     if (vm && ec) {
-        SDR();
-        rb_backtrace_print_as_bugreport();
-        fputs("\n", stderr);
+        rb_vmdebug_stack_dump_raw(ec, ec->cfp, errout);
+        rb_backtrace_print_as_bugreport(errout);
+        fputs("\n", errout);
         // If we get here, hopefully things are intact enough that
         // we can read these two numbers. It is an estimate because
         // we are reading without synchronization.
-        fprintf(stderr, "-- Threading information "
+        fprintf(errout, "-- Threading information "
                 "---------------------------------------------------\n");
-        fprintf(stderr, "Total ractor count: %u\n", vm->ractor.cnt);
-        fprintf(stderr, "Ruby thread count for this ractor: %u\n", rb_ec_ractor_ptr(ec)->threads.cnt);
-        fputs("\n", stderr);
+        fprintf(errout, "Total ractor count: %u\n", vm->ractor.cnt);
+        fprintf(errout, "Ruby thread count for this ractor: %u\n", rb_ec_ractor_ptr(ec)->threads.cnt);
+        fputs("\n", errout);
     }
 
-    rb_dump_machine_register(ctx);
+    rb_dump_machine_register(errout, ctx);
 
 #if USE_BACKTRACE || defined(_WIN32)
-    fprintf(stderr, "-- C level backtrace information "
+    fprintf(errout, "-- C level backtrace information "
             "-------------------------------------------\n");
-    rb_print_backtrace();
+    rb_print_backtrace(errout);
 
 
-    fprintf(stderr, "\n");
+    fprintf(errout, "\n");
 #endif /* USE_BACKTRACE */
 
     if (other_runtime_info || vm) {
-        fprintf(stderr, "-- Other runtime information "
+        fprintf(errout, "-- Other runtime information "
                 "-----------------------------------------------\n\n");
     }
     if (vm && !rb_during_gc()) {
@@ -1105,16 +1114,16 @@ rb_vm_bugreport(const void *ctx)
 
         name = vm->progname;
         if (name) {
-            fprintf(stderr, "* Loaded script: %.*s\n",
+            fprintf(errout, "* Loaded script: %.*s\n",
                     LIMITED_NAME_LENGTH(name), RSTRING_PTR(name));
-            fprintf(stderr, "\n");
+            fprintf(errout, "\n");
         }
         if (vm->loaded_features) {
-            fprintf(stderr, "* Loaded features:\n\n");
+            fprintf(errout, "* Loaded features:\n\n");
             for (i=0; i<RARRAY_LEN(vm->loaded_features); i++) {
                 name = RARRAY_AREF(vm->loaded_features, i);
                 if (RB_TYPE_P(name, T_STRING)) {
-                    fprintf(stderr, " %4d %.*s\n", i,
+                    fprintf(errout, " %4d %.*s\n", i,
                             LIMITED_NAME_LENGTH(name), RSTRING_PTR(name));
                 }
                 else if (RB_TYPE_P(name, T_CLASS) || RB_TYPE_P(name, T_MODULE)) {
@@ -1122,26 +1131,26 @@ rb_vm_bugreport(const void *ctx)
                         "class" : "module";
                     name = rb_search_class_path(rb_class_real(name));
                     if (!RB_TYPE_P(name, T_STRING)) {
-                        fprintf(stderr, " %4d %s:<unnamed>\n", i, type);
+                        fprintf(errout, " %4d %s:<unnamed>\n", i, type);
                         continue;
                     }
-                    fprintf(stderr, " %4d %s:%.*s\n", i, type,
+                    fprintf(errout, " %4d %s:%.*s\n", i, type,
                             LIMITED_NAME_LENGTH(name), RSTRING_PTR(name));
                 }
                 else {
                     VALUE klass = rb_search_class_path(rb_obj_class(name));
                     if (!RB_TYPE_P(klass, T_STRING)) {
-                        fprintf(stderr, " %4d #<%p:%p>\n", i,
+                        fprintf(errout, " %4d #<%p:%p>\n", i,
                                 (void *)CLASS_OF(name), (void *)name);
                         continue;
                     }
-                    fprintf(stderr, " %4d #<%.*s:%p>\n", i,
+                    fprintf(errout, " %4d #<%.*s:%p>\n", i,
                             LIMITED_NAME_LENGTH(klass), RSTRING_PTR(klass),
                             (void *)name);
                 }
             }
         }
-        fprintf(stderr, "\n");
+        fprintf(errout, "\n");
     }
 
     {
@@ -1149,17 +1158,17 @@ rb_vm_bugreport(const void *ctx)
         {
             FILE *fp = fopen(PROC_MAPS_NAME, "r");
             if (fp) {
-                fprintf(stderr, "* Process memory map:\n\n");
+                fprintf(errout, "* Process memory map:\n\n");
 
                 while (!feof(fp)) {
                     char buff[0x100];
                     size_t rn = fread(buff, 1, 0x100, fp);
-                    if (fwrite(buff, 1, rn, stderr) != rn)
+                    if (fwrite(buff, 1, rn, errout) != rn)
                         break;
                 }
 
                 fclose(fp);
-                fprintf(stderr, "\n\n");
+                fprintf(errout, "\n\n");
             }
         }
 #endif /* __linux__ */
@@ -1173,14 +1182,14 @@ rb_vm_bugreport(const void *ctx)
         mib[2] = KERN_PROC_PID;
         mib[3] = getpid();
         if (sysctl(mib, MIB_KERN_PROC_PID_LEN, &kp, &len, NULL, 0) == -1) {
-            perror("sysctl");
+            fprintf(errout, "sysctl: %s\n", strerror(errno));
         }
         else {
             struct procstat *prstat = procstat_open_sysctl();
-            fprintf(stderr, "* Process memory map:\n\n");
+            fprintf(errout, "* Process memory map:\n\n");
             procstat_vm(prstat, &kp);
             procstat_close(prstat);
-            fprintf(stderr, "\n");
+            fprintf(errout, "\n");
         }
 #endif /* __FreeBSD__ */
 #ifdef __APPLE__
@@ -1190,7 +1199,7 @@ rb_vm_bugreport(const void *ctx)
         mach_msg_type_number_t count = VM_REGION_SUBMAP_INFO_COUNT;
         natural_t depth = 0;
 
-        fprintf(stderr, "* Process memory map:\n\n");
+        fprintf(errout, "* Process memory map:\n\n");
         while (1) {
             if (vm_region_recurse(mach_task_self(), &addr, &size, &depth,
                         (vm_region_recurse_info_t)&map, &count) != KERN_SUCCESS) {
@@ -1202,17 +1211,17 @@ rb_vm_bugreport(const void *ctx)
                 depth++;
             }
             else {
-                fprintf(stderr, "%lx-%lx %s%s%s", addr, (addr+size),
+                fprintf(errout, "%lx-%lx %s%s%s", addr, (addr+size),
                         ((map.protection & VM_PROT_READ) != 0 ? "r" : "-"),
                         ((map.protection & VM_PROT_WRITE) != 0 ? "w" : "-"),
                     ((map.protection & VM_PROT_EXECUTE) != 0 ? "x" : "-"));
 #ifdef HAVE_LIBPROC_H
                 char buff[PATH_MAX];
                 if (proc_regionfilename(getpid(), addr, buff, sizeof(buff)) > 0) {
-                    fprintf(stderr, " %s", buff);
+                    fprintf(errout, " %s", buff);
                 }
 #endif
-                fprintf(stderr, "\n");
+                fprintf(errout, "\n");
             }
 
             addr += size;
@@ -1227,14 +1236,15 @@ rb_vmdebug_stack_dump_all_threads(void)
 {
     rb_thread_t *th = NULL;
     rb_ractor_t *r = GET_RACTOR();
+    FILE *errout = stderr;
 
     // TODO: now it only shows current ractor
     ccan_list_for_each(&r->threads.set, th, lt_node) {
 #ifdef NON_SCALAR_THREAD_ID
-        fprintf(stderr, "th: %p, native_id: N/A\n", th);
+        fprintf(errout, "th: %p, native_id: N/A\n", th);
 #else
-        fprintf(stderr, "th: %p, native_id: %p\n", (void *)th, (void *)(uintptr_t)th->nt->thread_id);
+        fprintf(errout, "th: %p, native_id: %p\n", (void *)th, (void *)(uintptr_t)th->nt->thread_id);
 #endif
-        rb_vmdebug_stack_dump_raw(th->ec, th->ec->cfp);
+        rb_vmdebug_stack_dump_raw(th->ec, th->ec->cfp, errout);
     }
 }

--- a/win32/file.h
+++ b/win32/file.h
@@ -47,4 +47,7 @@ int fchmod(int fd, int mode);
 UINT rb_w32_filecp(void);
 WCHAR *rb_w32_home_dir(void);
 
+rb_pid_t rb_w32_uspawn_process(int mode, const char *prog, char *const *argv,
+                               int in_fd, int out_fd, int err_fd, DWORD flags);
+
 #endif	/* RUBY_WIN32_FILE_H */


### PR DESCRIPTION
[[Feature #19790]](https://bugs.ruby-lang.org/issues/19790)
Optionally write Ruby crash reports into a file rather than STDERR.
