### PR TITLE
[Bug #19902] Update the coderange regarding the changed region

### DIFF
--- a/ext/-test-/string/set_len.c
+++ b/ext/-test-/string/set_len.c
@@ -7,8 +7,18 @@ bug_str_set_len(VALUE str, VALUE len)
     return str;
 }
 
+static VALUE
+bug_str_append(VALUE str, VALUE addendum)
+{
+    StringValue(addendum);
+    rb_str_modify_expand(str, RSTRING_LEN(addendum));
+    memcpy(RSTRING_END(str), RSTRING_PTR(addendum), RSTRING_LEN(addendum));
+    return str;
+}
+
 void
 Init_string_set_len(VALUE klass)
 {
     rb_define_method(klass, "set_len", bug_str_set_len, 1);
+    rb_define_method(klass, "append", bug_str_append, 1);
 }

--- a/test/-ext-/string/test_set_len.rb
+++ b/test/-ext-/string/test_set_len.rb
@@ -34,4 +34,33 @@ class Test_StrSetLen < Test::Unit::TestCase
     assert_equal 128, Bug::String.capacity(str)
     assert_equal 127, str.set_len(127).bytesize, bug12757
   end
+
+  def test_coderange_after_append
+    u = -"\u3042"
+    str = Bug::String.new(encoding: Encoding::UTF_8)
+    bsize = u.bytesize
+    str.append(u)
+    assert_equal 0, str.bytesize
+    str.set_len(bsize)
+    assert_equal bsize, str.bytesize
+    assert_predicate str, :valid_encoding?
+    assert_not_predicate str, :ascii_only?
+    assert_equal u, str
+  end
+
+  def test_coderange_after_trunc
+    u = -"\u3042"
+    bsize = u.bytesize
+    str = Bug::String.new(u)
+    str.set_len(bsize - 1)
+    assert_equal bsize - 1, str.bytesize
+    assert_not_predicate str, :valid_encoding?
+    assert_not_predicate str, :ascii_only?
+    str.append(u.byteslice(-1))
+    str.set_len(bsize)
+    assert_equal bsize, str.bytesize
+    assert_predicate str, :valid_encoding?
+    assert_not_predicate str, :ascii_only?
+    assert_equal u, str
+  end
 end


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/19902