### PR TITLE
Add `Range#reverse_each` implementation for performance

### DIFF
--- a/benchmark/range_reverse_each.yml
+++ b/benchmark/range_reverse_each.yml
@@ -1,0 +1,16 @@
+prelude: |
+  rf_1 = 0..1
+  rf_1k = 0..1000
+  rf_1m = 0..1000000
+  big = 2**1000
+  rb_1 = big..big+1
+  rb_1k = big..big+1000
+  rb_1m = big..big+1000000
+
+benchmark:
+  "Fixnum 1": rf_1.reverse_each { _1 }
+  "Fixnum 1K": rf_1k.reverse_each { _1 }
+  "Fixnum 1M": rf_1m.reverse_each { _1 }
+  "Bignum 1": rb_1.reverse_each { _1 }
+  "Bignum 1K": rb_1k.reverse_each { _1 }
+  "Bignum 1M": rb_1m.reverse_each { _1 }

--- a/range.c
+++ b/range.c
@@ -1020,6 +1020,139 @@ range_each(VALUE range)
     return range;
 }
 
+RBIMPL_ATTR_NORETURN()
+static void
+range_reverse_each_bignum_beginless(VALUE end)
+{
+    RUBY_ASSERT(RBIGNUM_NEGATIVE_P(end));
+
+    for (;; end = rb_big_minus(end, INT2FIX(1))) {
+        rb_yield(end);
+    }
+    UNREACHABLE;
+}
+
+static void
+range_reverse_each_bignum(VALUE beg, VALUE end)
+{
+    RUBY_ASSERT(RBIGNUM_POSITIVE_P(beg) == RBIGNUM_POSITIVE_P(end));
+
+    VALUE c;
+    while ((c = rb_big_cmp(beg, end)) != INT2FIX(1)) {
+        rb_yield(end);
+        if (c == INT2FIX(0)) break;
+        end = rb_big_minus(end, INT2FIX(1));
+    }
+}
+
+static void
+range_reverse_each_positive_bignum_section(VALUE beg, VALUE end)
+{
+    RUBY_ASSERT(!NIL_P(end));
+
+    if (FIXNUM_P(end) || RBIGNUM_NEGATIVE_P(end)) return;
+
+    if (NIL_P(beg) || FIXNUM_P(beg) || RBIGNUM_NEGATIVE_P(beg)) {
+        beg = LONG2NUM(FIXNUM_MAX + 1);
+    }
+
+    range_reverse_each_bignum(beg, end);
+}
+
+static void
+range_reverse_each_fixnum_section(VALUE beg, VALUE end)
+{
+    RUBY_ASSERT(!NIL_P(end));
+
+    if (!FIXNUM_P(beg)) {
+        if (!NIL_P(beg) && RBIGNUM_POSITIVE_P(beg)) return;
+
+        beg = LONG2FIX(FIXNUM_MIN);
+    }
+
+    if (!FIXNUM_P(end)) {
+        if (RBIGNUM_NEGATIVE_P(end)) return;
+
+        end = LONG2FIX(FIXNUM_MAX);
+    }
+
+    long b = FIX2LONG(beg);
+    long e = FIX2LONG(end);
+    for (long i = e; i >= b; --i) {
+        rb_yield(LONG2FIX(i));
+    }
+}
+
+static void
+range_reverse_each_negative_bignum_section(VALUE beg, VALUE end)
+{
+    RUBY_ASSERT(!NIL_P(end));
+
+    if (FIXNUM_P(end) || RBIGNUM_POSITIVE_P(end)) {
+        end = LONG2NUM(FIXNUM_MIN - 1);
+    }
+
+    if (NIL_P(beg)) {
+        range_reverse_each_bignum_beginless(end);
+    }
+
+    if (FIXNUM_P(beg) || RBIGNUM_POSITIVE_P(beg)) return;
+
+    range_reverse_each_bignum(beg, end);
+}
+
+/*
+ *  call-seq:
+ *    reverse_each {|element| ... } -> self
+ *    reverse_each                  -> an_enumerator
+ *
+ *  With a block given, passes each element of +self+ to the block in reverse order:
+ *
+ *    a = []
+ *    (1..4).reverse_each {|element| a.push(element) } # => 1..4
+ *    a # => [4, 3, 2, 1]
+ *
+ *    a = []
+ *    (1...4).reverse_each {|element| a.push(element) } # => 1...4
+ *    a # => [3, 2, 1]
+ *
+ *  With no block given, returns an enumerator.
+ *
+ */
+
+static VALUE
+range_reverse_each(VALUE range)
+{
+    RETURN_SIZED_ENUMERATOR(range, 0, 0, range_enum_size);
+
+    VALUE beg = RANGE_BEG(range);
+    VALUE end = RANGE_END(range);
+    int excl = EXCL(range);
+
+    if (FIXNUM_P(beg) && FIXNUM_P(end)) {
+        if (excl) {
+            if (end == LONG2FIX(FIXNUM_MIN)) return range;
+
+            end = rb_int_minus(end, INT2FIX(1));
+        }
+
+        range_reverse_each_fixnum_section(beg, end);
+    }
+    else if ((NIL_P(beg) || RB_INTEGER_TYPE_P(beg)) && RB_INTEGER_TYPE_P(end)) {
+        if (excl) {
+            end = rb_int_minus(end, INT2FIX(1));
+        }
+        range_reverse_each_positive_bignum_section(beg, end);
+        range_reverse_each_fixnum_section(beg, end);
+        range_reverse_each_negative_bignum_section(beg, end);
+    }
+    else {
+        return rb_call_super(0, NULL);
+    }
+
+    return range;
+}
+
 /*
  *  call-seq:
  *    self.begin -> object
@@ -2520,6 +2653,7 @@ Init_Range(void)
     rb_define_method(rb_cRange, "each", range_each, 0);
     rb_define_method(rb_cRange, "step", range_step, -1);
     rb_define_method(rb_cRange, "%", range_percent_step, 1);
+    rb_define_method(rb_cRange, "reverse_each", range_reverse_each, 0);
     rb_define_method(rb_cRange, "bsearch", range_bsearch, 0);
     rb_define_method(rb_cRange, "begin", range_begin, 0);
     rb_define_method(rb_cRange, "end", range_end, 0);

--- a/test/ruby/test_range.rb
+++ b/test/ruby/test_range.rb
@@ -496,6 +496,143 @@ class TestRange < Test::Unit::TestCase
     assert_equal([0, 1, 2, 3, 4], result)
   end
 
+  def test_reverse_each
+    a = []
+    (1..3).reverse_each {|x| a << x }
+    assert_equal([3, 2, 1], a)
+
+    a = []
+    (1...3).reverse_each {|x| a << x }
+    assert_equal([2, 1], a)
+
+    fmax = RbConfig::LIMITS['FIXNUM_MAX']
+    fmin = RbConfig::LIMITS['FIXNUM_MIN']
+
+    a = []
+    (fmax+1..fmax+3).reverse_each {|x| a << x }
+    assert_equal([fmax+3, fmax+2, fmax+1], a)
+
+    a = []
+    (fmax+1...fmax+3).reverse_each {|x| a << x }
+    assert_equal([fmax+2, fmax+1], a)
+
+    a = []
+    (fmax-1..fmax+1).reverse_each {|x| a << x }
+    assert_equal([fmax+1, fmax, fmax-1], a)
+
+    a = []
+    (fmax-1...fmax+1).reverse_each {|x| a << x }
+    assert_equal([fmax, fmax-1], a)
+
+    a = []
+    (fmin-1..fmin+1).reverse_each{|x| a << x }
+    assert_equal([fmin+1, fmin, fmin-1], a)
+
+    a = []
+    (fmin-1...fmin+1).reverse_each{|x| a << x }
+    assert_equal([fmin, fmin-1], a)
+
+    a = []
+    (fmin-3..fmin-1).reverse_each{|x| a << x }
+    assert_equal([fmin-1, fmin-2, fmin-3], a)
+
+    a = []
+    (fmin-3...fmin-1).reverse_each{|x| a << x }
+    assert_equal([fmin-2, fmin-3], a)
+
+    a = []
+    ("a".."c").reverse_each {|x| a << x }
+    assert_equal(["c", "b", "a"], a)
+  end
+
+  def test_reverse_each_for_beginless_range
+    fmax = RbConfig::LIMITS['FIXNUM_MAX']
+    fmin = RbConfig::LIMITS['FIXNUM_MIN']
+
+    a = []
+    (..3).reverse_each {|x| a << x; break if x <= 0 }
+    assert_equal([3, 2, 1, 0], a)
+
+    a = []
+    (...3).reverse_each {|x| a << x; break if x <= 0 }
+    assert_equal([2, 1, 0], a)
+
+    a = []
+    (..fmax+1).reverse_each {|x| a << x; break if x <= fmax-1 }
+    assert_equal([fmax+1, fmax, fmax-1], a)
+
+    a = []
+    (...fmax+1).reverse_each {|x| a << x; break if x <= fmax-1 }
+    assert_equal([fmax, fmax-1], a)
+
+    a = []
+    (..fmin+1).reverse_each {|x| a << x; break if x <= fmin-1 }
+    assert_equal([fmin+1, fmin, fmin-1], a)
+
+    a = []
+    (...fmin+1).reverse_each {|x| a << x; break if x <= fmin-1 }
+    assert_equal([fmin, fmin-1], a)
+
+    a = []
+    (..fmin-1).reverse_each {|x| a << x; break if x <= fmin-3 }
+    assert_equal([fmin-1, fmin-2, fmin-3], a)
+
+    a = []
+    (...fmin-1).reverse_each {|x| a << x; break if x <= fmin-3 }
+    assert_equal([fmin-2, fmin-3], a)
+  end
+
+  def test_reverse_each_for_single_point_range
+    fmin = RbConfig::LIMITS['FIXNUM_MIN']
+    fmax = RbConfig::LIMITS['FIXNUM_MAX']
+
+    values = [fmin*2, fmin-1, fmin, 0, fmax, fmax+1, fmax*2]
+
+    values.each do |b|
+      r = b..b
+      a = []
+      r.reverse_each {|x| a << x }
+      assert_equal([b], a, "failed on #{r}")
+
+      r = b...b+1
+      a = []
+      r.reverse_each {|x| a << x }
+      assert_equal([b], a, "failed on #{r}")
+    end
+  end
+
+  def test_reverse_each_for_empty_range
+    fmin = RbConfig::LIMITS['FIXNUM_MIN']
+    fmax = RbConfig::LIMITS['FIXNUM_MAX']
+
+    values = [fmin*2, fmin-1, fmin, 0, fmax, fmax+1, fmax*2]
+
+    values.each do |b|
+      r = b..b-1
+      a = []
+      r.reverse_each {|x| a << x }
+      assert_equal([], a, "failed on #{r}")
+    end
+
+    values.repeated_permutation(2).to_a.product([true, false]).each do |(b, e), excl|
+      next unless b > e || (b == e && excl)
+
+      r = Range.new(b, e, excl)
+      a = []
+      r.reverse_each {|x| a << x }
+      assert_equal([], a, "failed on #{r}")
+    end
+  end
+
+  def test_reverse_each_with_no_block
+    enum = (1..5).reverse_each
+    assert_equal 5, enum.size
+
+    a = []
+    enum.each {|x| a << x }
+    assert_equal [5, 4, 3, 2, 1], a
+  end
+
   def test_begin_end
     assert_equal(0, (0..1).begin)
     assert_equal(1, (0..1).end)


### PR DESCRIPTION
(This pull request replaces #5489 with simpler implementation.)

The current `Range#reverse_each` uses `Enumerable#reverse_each`, which is implemented using `#to_a`.
This means we require additional memory for `#to_a`, and thus cannot use `#reverse_each` for a very large range, even if only a few elements are actually iterated over.

```ruby
(1..2**100).reverse_each { |x| p x; break if x.odd? }
(..5).reverse_each { |x| p x; break if x == 0 }
(1..2**32).reverse_each.lazy.select { |x| Prime.prime?(x) }.take(3).to_a
```

This patch implements `Range#reverse_each` for `Integer` elements and enables these examples.

## benchmark

```yaml
prelude: |
  rf_1 = 0..1
  rf_1k = 0..1000
  rf_1m = 0..1000000
  big = 2**1000
  rb_1 = big..big+1
  rb_1k = big..big+1000
  rb_1m = big..big+1000000

benchmark:
  "Fixnum 1": rf_1.reverse_each { _1 }
  "Fixnum 1K": rf_1k.reverse_each { _1 }
  "Fixnum 1M": rf_1m.reverse_each { _1 }
  "Bignum 1": rb_1.reverse_each { _1 }
  "Bignum 1K": rb_1k.reverse_each { _1 }
  "Bignum 1M": rb_1m.reverse_each { _1 }
```

As arrays no longer need to be created, huge memory savings are achieved, especially for large `Range`.
Execution speed is also increased.

### Max resident set size (bytes)

|           |master   |PR      |ratio|
|:----------|--------:|-------:|----:|
|Fixnum 1   |  13.910M| 14.877M|1.069|
|Fixnum 1K  |  14.778M| 14.762M|0.998|
|Fixnum 1M  |  28.770M| 14.025M|0.487|
|Bignum 1   |  14.729M| 14.189M|0.963|
|Bignum 1K  |  14.074M| 13.582M|0.965|
|Bignum 1M  | 224.723M| 15.254M|0.067|

### Iteration per second (i/s)

|           |master |PR      |ratio|
|:----------|------:|-------:|----:|
|Fixnum 1   | 6.653M| 14.511M|2.181|
|Fixnum 1K  |27.866k| 45.527k|1.633|
|Fixnum 1M  | 28.659|  45.667|1.593|
|Bignum 1   | 3.534M|  4.635M|1.311|
|Bignum 1K  | 6.790k|  7.693k|1.132|
|Bignum 1M  |  5.720|   7.532|1.316|

ticket: https://bugs.ruby-lang.org/issues/18515