### PR TITLE
Fix `retry` in nested `rescue` blocks

### DIFF
--- a/test/ruby/test_ast.rb
+++ b/test/ruby/test_ast.rb
@@ -283,6 +283,27 @@ class TestAst < Test::Unit::TestCase
     assert_parse("begin rescue; ensure; defined? retry; end")
     assert_parse("END {defined? retry}")
     assert_parse("begin rescue; END {defined? retry}; end")
+
+    assert_parse("#{<<-"begin;"}\n#{<<-'end;'}")
+    begin;
+      def foo
+        begin
+          yield
+        rescue StandardError => e
+          begin
+            puts "hi"
+            retry
+          rescue
+            retry unless e
+            raise e
+          else
+            retry
+          ensure
+            retry
+          end
+        end
+      end
+    end;
   end
 
   def test_invalid_yield


### PR DESCRIPTION
Restore `rescue`-context from the outer context.
`retry` targets the next outer block except for between `rescue` and `else` or `ensure`, otherwise, if there is no enclosing block, it should be syntax error.