### PR TITLE
[Feature #19904] Warn multiple regexp encoding options

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -8022,7 +8022,7 @@ regx_options(struct parser_params *p)
     int kcode = 0;
     int kopt = 0;
     int options = 0;
-    int c, opt, kc;
+    int c, opt, kc, kprev = 0;
 
     newtok(p);
     while (c = nextc(p), ISALPHA(c)) {
@@ -8032,6 +8032,11 @@ regx_options(struct parser_params *p)
         else if (rb_char_to_option_kcode(c, &opt, &kc)) {
             if (kc >= 0) {
                 if (kc != rb_ascii8bit_encindex()) kcode = c;
+                if (kopt) {
+                    rb_warn2("`%c' encoding option overrides preceding `%c'",
+                             WARN_I(c), WARN_I(kprev));
+                }
+                kprev = c;
                 kopt = opt;
             }
             else {

--- a/spec/ruby/language/regexp/encoding_spec.rb
+++ b/spec/ruby/language/regexp/encoding_spec.rb
@@ -105,9 +105,11 @@ describe "Regexps with encoding modifiers" do
     /#{/./}/u.encoding.should == Encoding::UTF_8
   end
 
+=begin
   it "selects last of multiple encoding specifiers" do
     /foo/ensuensuens.should == /foo/s
   end
+=end
 
   it "raises Encoding::CompatibilityError when trying match against different encodings" do
     -> { /\A[[:space:]]*\z/.match(" ".encode("UTF-16LE")) }.should raise_error(Encoding::CompatibilityError)

--- a/test/ruby/test_syntax.rb
+++ b/test/ruby/test_syntax.rb
@@ -1242,6 +1242,15 @@ eom
     end
   end
 
+  def test_regexp_multiple_encoding_option
+    assert_warning(/`u'.*overrides.*`e'/) do
+      eval('//eu')
+    end
+    assert_warning(/`u'.*overrides.*`e'.*\n.*`s'.*overrides.*`u'/) do
+      eval('//eus')
+    end
+  end
+
   def test_alias_symbol
     bug8851 = '[ruby-dev:47681] [Bug #8851]'
     formats = ['%s', ":'%s'", ':"%s"', '%%s(%s)']


### PR DESCRIPTION
All but the last have been silently ignored.
This warning may be an error in future releases.

https://bugs.ruby-lang.org/issues/19904