### PR TITLE
Fix memory leak in the parser

### DIFF
--- a/node.c
+++ b/node.c
@@ -154,6 +154,10 @@ node_buffer_list_free(rb_ast_t *ast, node_buffer_list_t * nb)
         nbe = nbe->next;
         xfree(buf);
     }
+
+    /* The last node_buffer_elem_t is allocated in the node_buffer_t, so we
+     * only need to free the nodes. */
+    xfree(nbe->nodes);
 }
 
 struct rb_ast_local_table_link {


### PR DESCRIPTION
Reproduction script:

```
require "ripper"

10.times do
  20_000.times do
    Ripper.parse("")
  end

  puts `ps -o rss= -p #{$$}`
end
```

Before:

```
28032
34432
40704
47232
53632
60032
66432
72832
79232
85632
```

After:

```
21760
21760
21760
21760
21760
21760
21760
21760
21760
21760
```