### PR TITLE
Dump name of method for imemo callinfo

### DIFF
--- a/ext/objspace/depend
+++ b/ext/objspace/depend
@@ -585,6 +585,7 @@ objspace_dump.o: $(top_srcdir)/ccan/container_of/container_of.h
 objspace_dump.o: $(top_srcdir)/ccan/list/list.h
 objspace_dump.o: $(top_srcdir)/ccan/str/str.h
 objspace_dump.o: $(top_srcdir)/constant.h
+objspace_dump.o: $(top_srcdir)/debug_counter.h
 objspace_dump.o: $(top_srcdir)/id_table.h
 objspace_dump.o: $(top_srcdir)/internal.h
 objspace_dump.o: $(top_srcdir)/internal/array.h
@@ -610,6 +611,7 @@ objspace_dump.o: $(top_srcdir)/rubyparser.h
 objspace_dump.o: $(top_srcdir)/shape.h
 objspace_dump.o: $(top_srcdir)/symbol.h
 objspace_dump.o: $(top_srcdir)/thread_pthread.h
+objspace_dump.o: $(top_srcdir)/vm_callinfo.h
 objspace_dump.o: $(top_srcdir)/vm_core.h
 objspace_dump.o: $(top_srcdir)/vm_opts.h
 objspace_dump.o: objspace.h

--- a/ext/objspace/objspace_dump.c
+++ b/ext/objspace/objspace_dump.c
@@ -28,6 +28,7 @@
 #include "ruby/debug.h"
 #include "ruby/util.h"
 #include "ruby/io.h"
+#include "vm_callinfo.h"
 #include "vm_core.h"
 
 RUBY_EXTERN const char ruby_hexdigits[];
@@ -429,6 +430,17 @@ dump_object(VALUE obj, struct dump_config *dc)
         dump_append(dc, ", \"imemo_type\":\"");
         dump_append(dc, rb_imemo_name(imemo_type(obj)));
         dump_append(dc, "\"");
+
+        switch (imemo_type(obj)) {
+          case imemo_callinfo:
+            dump_append(dc, ", \"mid\":\"");
+            dump_append(dc, RSTRING_PTR(rb_id2str(vm_ci_mid((const struct rb_callinfo *)obj))));
+            dump_append(dc, "\"");
+            break;
+
+          default:
+            break;
+        }
         break;
 
       case T_SYMBOL:


### PR DESCRIPTION
This commit dumps the `mid` of the imemo callinfo when calling `ObjectSpace.dump_all`.