### PR TITLE
Allow changing RUBY_PATCHLEVEL_STR if RUBY_PATCHLEVEL == -1

### DIFF
--- a/version.h
+++ b/version.h
@@ -55,11 +55,13 @@
 #endif
 
 #if RUBY_PATCHLEVEL == -1
-#define RUBY_PATCHLEVEL_STR "dev"
+# ifndef RUBY_PATCHLEVEL_STR
+#  define RUBY_PATCHLEVEL_STR "dev"
+# endif
 #elif defined RUBY_ABI_VERSION
-#error RUBY_ABI_VERSION is defined in non-development branch
+# error RUBY_ABI_VERSION is defined in non-development branch
 #else
-#define RUBY_PATCHLEVEL_STR ""
+# define RUBY_PATCHLEVEL_STR ""
 #endif
 
 #endif /* RUBY_TOPLEVEL_VERSION_H */

--- a/version.h
+++ b/version.h
@@ -55,7 +55,9 @@
 #endif
 
 #if RUBY_PATCHLEVEL == -1
-# ifndef RUBY_PATCHLEVEL_STR
+# ifdef RUBY_PATCHLEVEL_NAME
+#  define RUBY_PATCHLEVEL_STR STRINGIZE(RUBY_PATCHLEVEL_NAME)
+# else
 #  define RUBY_PATCHLEVEL_STR "dev"
 # endif
 #elif defined RUBY_ABI_VERSION


### PR DESCRIPTION
One of Shopify's services uses Ruby 3.3.0-preview2. So we use `ruby ">= 3.3.0.preview2"` in Gemfile. We also want to deploy Ruby master (newer than preview2) to a few instances of that service, but 3.3.0.dev does not satisfy `>= 3.3.0.preview2`.

I want to keep using `>= 3.3.0.preview2` instead of relaxing it to `>= 3.3.0.dev` since I want to use `ruby ">= 3.3.0.preview3"` when I bump it again. To allow installing Ruby master while keeping `ruby ">= 3.3.0.preview2"`, I'd like to change `RUBY_PATCHLEVEL_STR` to something `>= preview2`, e.g. `cppflags=-DRUBY_PATCHLEVEL_STR=pshopify1`.