### PR TITLE
YJIT: Move help descriptions to options.rs

### DIFF
--- a/ruby.c
+++ b/ruby.c
@@ -391,18 +391,6 @@ usage(const char *name, int help, int highlight, int columns)
         M("experimental", "",     "experimental features"),
         M("performance", "",      "performance issues"),
     };
-#if USE_YJIT
-    static const struct ruby_opt_message yjit_options[] = {
-        M("--yjit-stats",                    "", "Enable collecting YJIT statistics"),
-        M("--yjit-trace-exits",              "", "Record Ruby source location when exiting from generated code"),
-        M("--yjit-trace-exits-sample-rate",  "", "Trace exit locations only every Nth occurrence"),
-        M("--yjit-exec-mem-size=num",        "", "Size of executable memory block in MiB (default: 128)"),
-        M("--yjit-call-threshold=num",       "", "Number of calls to trigger JIT (default: 30)"),
-        M("--yjit-cold-threshold=num",       "", "Global call after which ISEQs not compiled (default: 200K)"),
-        M("--yjit-max-versions=num",         "", "Maximum number of versions per basic block (default: 4)"),
-        M("--yjit-greedy-versioning",        "", "Greedy versioning mode (default: disabled)"),
-    };
-#endif
 #if USE_RJIT
     extern const struct ruby_opt_message rb_rjit_option_messages[];
 #endif
@@ -434,8 +422,7 @@ usage(const char *name, int help, int highlight, int columns)
         SHOW(warn_categories[i]);
 #if USE_YJIT
     printf("%s""YJIT options:%s\n", sb, se);
-    for (i = 0; i < numberof(yjit_options); ++i)
-        SHOW(yjit_options[i]);
+    rb_yjit_print_options(help, highlight, w, columns);
 #endif
 #if USE_RJIT
     printf("%s""RJIT options (experimental):%s\n", sb, se);

--- a/ruby.c
+++ b/ruby.c
@@ -422,7 +422,7 @@ usage(const char *name, int help, int highlight, int columns)
         SHOW(warn_categories[i]);
 #if USE_YJIT
     printf("%s""YJIT options:%s\n", sb, se);
-    rb_yjit_print_options(help, highlight, w, columns);
+    rb_yjit_show_usage(help, highlight, w, columns);
 #endif
 #if USE_RJIT
     printf("%s""RJIT options (experimental):%s\n", sb, se);

--- a/ruby.c
+++ b/ruby.c
@@ -296,12 +296,12 @@ show_usage_line(const struct ruby_opt_message *m,
 
 void
 ruby_show_usage_line(const char *name, const char *secondary, const char *description,
-                     int help, int highlight, unsigned int w, int columns)
+                     int help, int highlight, unsigned int width, int columns)
 {
     unsigned int namelen = (unsigned int)strlen(name);
     unsigned int secondlen = (secondary ? (unsigned int)strlen(secondary) : 0);
     show_usage_part(name, namelen, secondary, secondlen,
-                    description, help, highlight, w, columns);
+                    description, help, highlight, width, columns);
 }
 
 static void

--- a/ruby.c
+++ b/ruby.c
@@ -244,14 +244,12 @@ static const char esc_none[] = "";
 #define USAGE_INDENT "  "       /* macro for concatenation */
 
 static void
-show_usage_line(const struct ruby_opt_message *m,
+show_usage_part(const char *str, const unsigned int namelen,
+                const char *str2, const unsigned int secondlen,
+                const char *desc,
                 int help, int highlight, unsigned int w, int columns)
 {
     static const int indent_width = (int)rb_strlen_lit(USAGE_INDENT);
-    const char *str = m->str;
-    const char *str2 = str + m->namelen;
-    const char *desc = str + m->namelen + m->secondlen;
-    const unsigned int namelen = m->namelen - 1, secondlen = m->secondlen - 1;
     const char *sb = highlight ? esc_bold : esc_none;
     const char *se = highlight ? esc_reset : esc_none;
     unsigned int desclen = (unsigned int)strcspn(desc, "\n");
@@ -283,6 +281,27 @@ show_usage_line(const struct ruby_opt_message *m,
             printf("%-*s%.*s\n", w + indent_width, USAGE_INDENT, desclen, desc);
         }
     }
+}
+
+static void
+show_usage_line(const struct ruby_opt_message *m,
+                int help, int highlight, unsigned int w, int columns)
+{
+    const char *str = m->str;
+    const unsigned int namelen = m->namelen, secondlen = m->secondlen;
+    const char *desc = str + namelen + secondlen;
+    show_usage_part(str, namelen - 1, str + namelen, secondlen - 1, desc,
+                    help, highlight, w, columns);
+}
+
+void
+ruby_show_usage_line(const char *name, const char *secondary, const char *description,
+                     int help, int highlight, unsigned int w, int columns)
+{
+    unsigned int namelen = (unsigned int)strlen(name);
+    unsigned int secondlen = (secondary ? (unsigned int)strlen(secondary) : 0);
+    show_usage_part(name, namelen, secondary, secondlen,
+                    description, help, highlight, w, columns);
 }
 
 static void

--- a/yjit.h
+++ b/yjit.h
@@ -43,6 +43,7 @@ void rb_yjit_iseq_free(void *payload);
 void rb_yjit_before_ractor_spawn(void);
 void rb_yjit_constant_ic_update(const rb_iseq_t *const iseq, IC ic, unsigned insn_idx);
 void rb_yjit_tracing_invalidate_all(void);
+void rb_yjit_print_options(int help, int highlight, unsigned int w, int columns);
 
 #else
 // !USE_YJIT

--- a/yjit.h
+++ b/yjit.h
@@ -43,7 +43,7 @@ void rb_yjit_iseq_free(void *payload);
 void rb_yjit_before_ractor_spawn(void);
 void rb_yjit_constant_ic_update(const rb_iseq_t *const iseq, IC ic, unsigned insn_idx);
 void rb_yjit_tracing_invalidate_all(void);
-void rb_yjit_show_usage(int help, int highlight, unsigned int w, int columns);
+void rb_yjit_show_usage(int help, int highlight, unsigned int width, int columns);
 
 #else
 // !USE_YJIT

--- a/yjit.h
+++ b/yjit.h
@@ -43,7 +43,7 @@ void rb_yjit_iseq_free(void *payload);
 void rb_yjit_before_ractor_spawn(void);
 void rb_yjit_constant_ic_update(const rb_iseq_t *const iseq, IC ic, unsigned insn_idx);
 void rb_yjit_tracing_invalidate_all(void);
-void rb_yjit_print_options(int help, int highlight, unsigned int w, int columns);
+void rb_yjit_show_usage(int help, int highlight, unsigned int w, int columns);
 
 #else
 // !USE_YJIT

--- a/yjit/src/options.rs
+++ b/yjit/src/options.rs
@@ -244,16 +244,17 @@ pub fn parse_option(str_ptr: *const std::os::raw::c_char) -> Option<()> {
     return Some(());
 }
 
-/// Print YJIT options for `ruby --help`.
+/// Print YJIT options for `ruby --help`. `width` is width of option parts, and
+/// `columns` is indent width of descriptions.
 #[no_mangle]
-pub extern "C" fn rb_yjit_show_usage(help: c_int, highlight: c_int, w: c_uint, columns: c_int) {
+pub extern "C" fn rb_yjit_show_usage(help: c_int, highlight: c_int, width: c_uint, columns: c_int) {
     for &(name, description) in YJIT_OPTIONS.iter() {
         extern "C" {
             fn ruby_show_usage_line(name: *const c_char, secondary: *const c_char, description: *const c_char,
-                                    help: c_int, highlight: c_int, w: c_uint, columns: c_int);
+                                    help: c_int, highlight: c_int, width: c_uint, columns: c_int);
         }
         let name = CString::new(name).unwrap();
         let description = CString::new(description).unwrap();
-        unsafe { ruby_show_usage_line(name.as_ptr(), null(), description.as_ptr(), help, highlight, w, columns) }
+        unsafe { ruby_show_usage_line(name.as_ptr(), null(), description.as_ptr(), help, highlight, width, columns) }
     }
 }

--- a/yjit/src/options.rs
+++ b/yjit/src/options.rs
@@ -246,7 +246,7 @@ pub fn parse_option(str_ptr: *const std::os::raw::c_char) -> Option<()> {
 
 /// Print YJIT options for `ruby --help`.
 #[no_mangle]
-pub extern "C" fn rb_yjit_print_options(help: c_int, highlight: c_int, w: c_uint, columns: c_int) {
+pub extern "C" fn rb_yjit_show_usage(help: c_int, highlight: c_int, w: c_uint, columns: c_int) {
     for &(name, description) in YJIT_OPTIONS.iter() {
         extern "C" {
             fn ruby_show_usage_line(name: *const c_char, secondary: *const c_char, description: *const c_char,


### PR DESCRIPTION
We sometimes forget adding entries to `yjit_options` or update defaults in it. To prevent that, this PR moves it to options.rs and puts it near `OPTIONS`.