### PR TITLE
YJIT: Build on BSD platforms with GNU make

### DIFF
--- a/yjit/yjit.mk
+++ b/yjit/yjit.mk
@@ -42,11 +42,10 @@ endif
 
 yjit-libobj: $(YJIT_LIBOBJ)
 
-# Note, BSD handling is in yjit/not_gmake.mk
 YJIT_LIB_SYMBOLS = $(YJIT_LIBS:.a=).symbols
 $(YJIT_LIBOBJ): $(YJIT_LIBS)
 	$(ECHO) 'partial linking $(YJIT_LIBS) into $@'
-ifneq ($(findstring linux,$(target_os)),)
+ifneq ($(or $(findstring linux,$(target_os)),$(findstring bsd,$(target_os))),$(findstring dragonfly,$(target_os))),)
 	$(Q) $(LD) -r -o $@ --whole-archive $(YJIT_LIBS)
 	-$(Q) $(OBJCOPY) --wildcard --keep-global-symbol='$(SYMBOL_PREFIX)rb_*' $(@)
 else ifneq ($(findstring darwin,$(target_os)),)


### PR DESCRIPTION
A note in yjit.mk states "BSD handling is in yjit/not_gmake.mk", which appears to just replicate the Linux branch of the gmake version.

This patch expands that branch to cover the BSDs so either option can be used, and has been lightly tested across FreeBSD, OpenBSD, NetBSD, and DragonFly BSD.