### PR TITLE
Refactor internal nodes

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -678,7 +678,6 @@ node_children(rb_ast_t *ast, const NODE *node)
       case NODE_ERROR:
         return rb_ary_new_from_node_args(ast, 0);
       case NODE_ARGS_AUX:
-      case NODE_DEF_TEMP:
       case NODE_RIPPER:
       case NODE_RIPPER_VALUES:
       case NODE_LAST:

--- a/ast.c
+++ b/ast.c
@@ -416,9 +416,11 @@ node_children(rb_ast_t *ast, const NODE *node)
       case NODE_FOR_MASGN:
         return rb_ary_new_from_node_args(ast, 1, RNODE_FOR_MASGN(node)->nd_var);
       case NODE_BREAK:
-      case NODE_NEXT:
-      case NODE_RETURN:
         return rb_ary_new_from_node_args(ast, 1, RNODE_BREAK(node)->nd_stts);
+      case NODE_NEXT:
+        return rb_ary_new_from_node_args(ast, 1, RNODE_NEXT(node)->nd_stts);
+      case NODE_RETURN:
+        return rb_ary_new_from_node_args(ast, 1, RNODE_RETURN(node)->nd_stts);
       case NODE_REDO:
         return rb_ary_new_from_node_args(ast, 0);
       case NODE_RETRY:

--- a/ext/objspace/objspace.c
+++ b/ext/objspace/objspace.c
@@ -493,7 +493,6 @@ count_nodes(int argc, VALUE *argv, VALUE os)
                 COUNT_NODE(NODE_ARYPTN);
                 COUNT_NODE(NODE_FNDPTN);
                 COUNT_NODE(NODE_HSHPTN);
-                COUNT_NODE(NODE_DEF_TEMP);
                 COUNT_NODE(NODE_RIPPER);
                 COUNT_NODE(NODE_RIPPER_VALUES);
                 COUNT_NODE(NODE_ERROR);

--- a/node_dump.c
+++ b/node_dump.c
@@ -294,19 +294,22 @@ dump_node(VALUE buf, VALUE indent, int comment, const NODE * node)
         ANN("break statement");
         ANN("format: break [nd_stts]");
         ANN("example: break 1");
-        goto jump;
+        LAST_NODE;
+        F_NODE(nd_stts, RNODE_BREAK, "value");
+        return;
       case NODE_NEXT:
         ANN("next statement");
         ANN("format: next [nd_stts]");
         ANN("example: next 1");
-        goto jump;
+        LAST_NODE;
+        F_NODE(nd_stts, RNODE_NEXT, "value");
+        return;
       case NODE_RETURN:
         ANN("return statement");
         ANN("format: return [nd_stts]");
         ANN("example: return 1");
-      jump:
         LAST_NODE;
-        F_NODE(nd_stts, RNODE_BREAK, "value");
+        F_NODE(nd_stts, RNODE_RETURN, "value");
         return;
 
       case NODE_REDO:

--- a/node_dump.c
+++ b/node_dump.c
@@ -1104,7 +1104,6 @@ dump_node(VALUE buf, VALUE indent, int comment, const NODE * node)
         return;
 
       case NODE_ARGS_AUX:
-      case NODE_DEF_TEMP:
       case NODE_RIPPER:
       case NODE_RIPPER_VALUES:
       case NODE_LAST:

--- a/parse.y
+++ b/parse.y
@@ -11152,9 +11152,6 @@ static rb_node_retry_t *
 rb_node_retry_new(struct parser_params *p, const YYLTYPE *loc)
 {
     rb_node_retry_t *n = NODE_NEWNODE(NODE_RETRY, rb_node_retry_t, loc);
-    n->not_used = 0;
-    n->not_used2 = 0;
-    n->not_used3 = 0;
 
     return n;
 }
@@ -11226,9 +11223,6 @@ rb_node_return_new(struct parser_params *p, NODE *nd_stts, const YYLTYPE *loc)
 {
     rb_node_return_t *n = NODE_NEWNODE(NODE_RETURN, rb_node_return_t, loc);
     n->nd_stts = nd_stts;
-    n->not_used = 0;
-    n->not_used2 = 0;
-
     return n;
 }
 

--- a/parse.y
+++ b/parse.y
@@ -1718,7 +1718,7 @@ add_block_exit(struct parser_params *p, NODE *node)
       case NODE_BREAK: case NODE_NEXT: case NODE_REDO: break;
       default:
         compile_error(p, "unexpected node: %s", ruby_node_name(nd_type(node)));
-        break;
+        return node;
     }
     if (!p->ctxt.in_defined) {
         NODE *exits = p->exits;

--- a/parse.y
+++ b/parse.y
@@ -1080,6 +1080,12 @@ static rb_node_error_t *rb_node_error_new(struct parser_params *p, const YYLTYPE
 
 #endif
 
+enum internal_node_type {
+    NODE_INTERNAL_ONLY = NODE_LAST,
+    NODE_DEF_TEMP,
+    NODE_INTERNAL_LAST
+};
+
 /* This node is parse.y internal */
 typedef struct RNode_DEF_TEMP {
     NODE node;
@@ -12160,7 +12166,7 @@ rb_node_redo_new(struct parser_params *p, const YYLTYPE *loc)
 static rb_node_def_temp_t *
 rb_node_def_temp_new(struct parser_params *p, ID nd_vid, ID nd_mid, NODE *nd_head, long nd_nth, struct lex_context ctxt, const YYLTYPE *loc)
 {
-    rb_node_def_temp_t *n = NODE_NEWNODE(NODE_DEF_TEMP, rb_node_def_temp_t, loc);
+    rb_node_def_temp_t *n = NODE_NEWNODE((enum node_type)NODE_DEF_TEMP, rb_node_def_temp_t, loc);
     n->nd_vid = nd_vid;
     n->nd_mid = nd_mid;
     n->nd_head = nd_head;

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -281,25 +281,21 @@ typedef struct RNode_FOR_MASGN {
 typedef struct RNode_BREAK {
     NODE node;
 
-    VALUE not_used;
+    struct RNode *nd_chain;
     struct RNode *nd_stts;
-    VALUE not_used2;
 } rb_node_break_t;
 
 typedef struct RNode_NEXT {
     NODE node;
 
-    VALUE not_used;
+    struct RNode *nd_chain;
     struct RNode *nd_stts;
-    VALUE not_used2;
 } rb_node_next_t;
 
 typedef struct RNode_REDO {
     NODE node;
 
-    VALUE not_used;
-    VALUE not_used2;
-    VALUE not_used3;
+    struct RNode *nd_chain;
 } rb_node_redo_t;
 
 typedef struct RNode_RETRY {

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -281,16 +281,16 @@ typedef struct RNode_FOR_MASGN {
 typedef struct RNode_BREAK {
     NODE node;
 
-    struct RNode *nd_stts;
     VALUE not_used;
+    struct RNode *nd_stts;
     VALUE not_used2;
 } rb_node_break_t;
 
 typedef struct RNode_NEXT {
     NODE node;
 
-    struct RNode *nd_stts;
     VALUE not_used;
+    struct RNode *nd_stts;
     VALUE not_used2;
 } rb_node_next_t;
 

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -304,10 +304,6 @@ typedef struct RNode_REDO {
 
 typedef struct RNode_RETRY {
     NODE node;
-
-    VALUE not_used;
-    VALUE not_used2;
-    VALUE not_used3;
 } rb_node_retry_t;
 
 typedef struct RNode_BEGIN {
@@ -549,8 +545,6 @@ typedef struct RNode_RETURN {
     NODE node;
 
     struct RNode *nd_stts;
-    VALUE not_used;
-    VALUE not_used2;
 } rb_node_return_t;
 
 typedef struct RNode_YIELD {

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -131,7 +131,6 @@ enum node_type {
     NODE_HSHPTN,
     NODE_FNDPTN,
     NODE_ERROR,
-    NODE_DEF_TEMP,
     NODE_RIPPER,
     NODE_RIPPER_VALUES,
     NODE_LAST


### PR DESCRIPTION
Move internal `NODE`s to parse.y, and remove unused fields from `NODE`s to exit.