### PR TITLE
Optimize `Range` with `Integer`

### DIFF
--- a/benchmark/range_size.yml
+++ b/benchmark/range_size.yml
@@ -1,0 +1,10 @@
+prelude: |
+  r_1 = 1..1
+  r_1k = 1..1000
+  r_1m = 1..1000000
+  r_str = 'a'..'z'
+benchmark:
+  'int 1': r_1.size
+  'int 1K': r_1k.size
+  'int 1M': r_1m.size
+  string: r_str.size

--- a/range.c
+++ b/range.c
@@ -365,12 +365,18 @@ linear_object_p(VALUE obj)
     return FALSE;
 }
 
+static inline bool
+is_numeric_p(VALUE v)
+{
+    return rb_integer_type_p(v) || rb_obj_is_kind_of(v, rb_cNumeric);
+}
+
 static VALUE
 check_step_domain(VALUE step)
 {
     VALUE zero = INT2FIX(0);
     int cmp;
-    if (!rb_obj_is_kind_of(step, rb_cNumeric)) {
+    if (!is_numeric_p(step)) {
         step = rb_to_int(step);
     }
     cmp = rb_cmpint(rb_funcallv(step, idCmp, 1, &zero), step, zero);
@@ -392,7 +398,7 @@ range_step_size(VALUE range, VALUE args, VALUE eobj)
         step = check_step_domain(RARRAY_AREF(args, 0));
     }
 
-    if (rb_obj_is_kind_of(b, rb_cNumeric) && rb_obj_is_kind_of(e, rb_cNumeric)) {
+    if (is_numeric_p(b) && is_numeric_p(e)) {
         return ruby_num_interval_step_size(b, e, step, EXCL(range));
     }
     return Qnil;
@@ -445,15 +451,15 @@ range_step(int argc, VALUE *argv, VALUE range)
     step = (!rb_check_arity(argc, 0, 1) ? INT2FIX(1) : argv[0]);
 
     if (!rb_block_given_p()) {
-        if (!rb_obj_is_kind_of(step, rb_cNumeric)) {
+        if (!is_numeric_p(step)) {
             step = rb_to_int(step);
         }
         if (rb_equal(step, INT2FIX(0))) {
             rb_raise(rb_eArgError, "step can't be 0");
         }
 
-        const VALUE b_num_p = rb_obj_is_kind_of(b, rb_cNumeric);
-        const VALUE e_num_p = rb_obj_is_kind_of(e, rb_cNumeric);
+        const VALUE b_num_p = is_numeric_p(b);
+        const VALUE e_num_p = is_numeric_p(e);
         if ((b_num_p && (NIL_P(e) || e_num_p)) || (NIL_P(b) && e_num_p)) {
             return rb_arith_seq_new(range, ID2SYM(rb_frame_this_func()), argc, argv,
                     range_step_size, b, e, step, EXCL(range));
@@ -502,7 +508,7 @@ range_step(int argc, VALUE *argv, VALUE range)
     else if (ruby_float_step(b, e, step, EXCL(range), TRUE)) {
         /* done */
     }
-    else if (rb_obj_is_kind_of(b, rb_cNumeric) ||
+    else if (is_numeric_p(b) ||
              !NIL_P(rb_check_to_integer(b, "to_int")) ||
              !NIL_P(rb_check_to_integer(e, "to_int"))) {
         ID op = EXCL(range) ? '<' : idLE;
@@ -639,7 +645,7 @@ bsearch_integer_range(VALUE beg, VALUE end, int excl)
         else if (!RTEST(v)) { \
             smaller = 0; \
         } \
-        else if (rb_obj_is_kind_of(v, rb_cNumeric)) { \
+        else if (is_numeric_p(v)) { \
             int cmp = rb_cmpint(rb_funcall(v, id_cmp, 1, INT2FIX(0)), v, INT2FIX(0)); \
             if (!cmp) return val; \
             smaller = cmp < 0; \
@@ -836,17 +842,17 @@ static VALUE
 range_size(VALUE range)
 {
     VALUE b = RANGE_BEG(range), e = RANGE_END(range);
-    if (rb_obj_is_kind_of(b, rb_cNumeric)) {
-        if (rb_obj_is_kind_of(e, rb_cNumeric)) {
-            return ruby_num_interval_step_size(b, e, INT2FIX(1), EXCL(range));
-        }
-        if (NIL_P(e)) {
+    if (NIL_P(b)) {
+        if (is_numeric_p(e)) {
             return DBL2NUM(HUGE_VAL);
         }
     }
-    else if (NIL_P(b)) {
-        if (rb_obj_is_kind_of(e, rb_cNumeric)) {
+    else if (is_numeric_p(b)) {
+        if (NIL_P(e)) {
             return DBL2NUM(HUGE_VAL);
+        }
+        if (is_numeric_p(e)) {
+            return ruby_num_interval_step_size(b, e, INT2FIX(1), EXCL(range));
         }
     }
 
@@ -1420,7 +1426,7 @@ static VALUE
 range_max(int argc, VALUE *argv, VALUE range)
 {
     VALUE e = RANGE_END(range);
-    int nm = FIXNUM_P(e) || rb_obj_is_kind_of(e, rb_cNumeric);
+    int nm = is_numeric_p(e);
 
     if (NIL_P(RANGE_END(range))) {
         rb_raise(rb_eRangeError, "cannot get the maximum of endless range");


### PR DESCRIPTION
`rb_obj_is_kind_of(v, rb_cNumeric)` is a check that often appears in the source code.
In particular, when `v` is `Integer`, it is faster to use `rb_integer_type_p`.
This pull request defines `is_numeric_p` which combines `rb_integer_type_p` and `rb_obj_is_kind_of` to more quickly determine that an `Integer` is `Numeric`.
This is especially effective for `Range#size`.

# benchmark

```
prelude: |
  r_1 = 1..1
  r_1k = 1..1000
  r_1m = 1..1000000
  r_str = 'a'..'z'
benchmark:
  'int 1': r_1.size
  'int 1K': r_1k.size
  'int 1M': r_1m.size
  string: r_str.size
```

## Iteration per second (i/s)

|        |master|PR|
|:-------|----------------------------------:|------------------------:|
|int 1   |                            34.897M|                  43.074M|
|        |                                  -|                    1.23x|
|int 1K  |                            35.023M|                  42.940M|
|        |                                  -|                    1.23x|
|int 1M  |                            34.855M|                  42.560M|
|        |                                  -|                    1.22x|
|string  |                            46.039M|                  45.110M|
|        |                              1.02x|                        -|
