### PR TITLE
Remove `NODE_VALUES`

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -507,7 +507,6 @@ node_children(rb_ast_t *ast, const NODE *node)
       case NODE_ZSUPER:
         return rb_ary_new_from_node_args(ast, 0);
       case NODE_LIST:
-      case NODE_VALUES:
         return dump_array(ast, RNODE_LIST(node));
       case NODE_ZLIST:
         return rb_ary_new_from_node_args(ast, 0);

--- a/compile.c
+++ b/compile.c
@@ -9724,18 +9724,6 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const no
         }
         break;
       }
-      case NODE_VALUES:{
-        const NODE *n = node;
-        if (popped) {
-            COMPILE_ERROR(ERROR_ARGS "NODE_VALUES: must not be popped");
-        }
-        while (n) {
-            CHECK(COMPILE(ret, "values item", RNODE_VALUES(n)->nd_head));
-            n = RNODE_VALUES(n)->nd_next;
-        }
-        ADD_INSN1(ret, node, newarray, INT2FIX(RNODE_VALUES(node)->nd_alen));
-        break;
-      }
       case NODE_HASH:
         CHECK(compile_hash(iseq, ret, node, FALSE, popped) >= 0);
         break;

--- a/ext/objspace/objspace.c
+++ b/ext/objspace/objspace.c
@@ -434,7 +434,6 @@ count_nodes(int argc, VALUE *argv, VALUE os)
                 COUNT_NODE(NODE_ZSUPER);
                 COUNT_NODE(NODE_LIST);
                 COUNT_NODE(NODE_ZLIST);
-                COUNT_NODE(NODE_VALUES);
                 COUNT_NODE(NODE_HASH);
                 COUNT_NODE(NODE_RETURN);
                 COUNT_NODE(NODE_YIELD);

--- a/node_dump.c
+++ b/node_dump.c
@@ -579,12 +579,6 @@ dump_node(VALUE buf, VALUE indent, int comment, const NODE * node)
         ANN("list constructor");
         ANN("format: [ [nd_head], [nd_next].. ] (length: [nd_alen])");
         ANN("example: [1, 2, 3]");
-        goto ary;
-      case NODE_VALUES:
-        ANN("return arguments");
-        ANN("format: [ [nd_head], [nd_next].. ] (length: [nd_alen])");
-        ANN("example: return 1, 2, 3");
-      ary:
         dump_array(buf, indent, comment, node);
         return;
 

--- a/parse.y
+++ b/parse.y
@@ -14142,13 +14142,8 @@ ret_args(struct parser_params *p, NODE *node)
 {
     if (node) {
         no_blockarg(p, node);
-        if (nd_type_p(node, NODE_LIST)) {
-            if (RNODE_LIST(node)->nd_next == 0) {
-                node = RNODE_LIST(node)->nd_head;
-            }
-            else {
-                nd_set_type(node, NODE_VALUES);
-            }
+        if (nd_type_p(node, NODE_LIST) && !RNODE_LIST(node)->nd_next) {
+            node = RNODE_LIST(node)->nd_head;
         }
     }
     return node;

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -71,7 +71,6 @@ enum node_type {
     NODE_ZSUPER,
     NODE_LIST,
     NODE_ZLIST,
-    NODE_VALUES,
     NODE_HASH,
     NODE_RETURN,
     NODE_YIELD,
@@ -986,7 +985,6 @@ typedef struct RNode_ERROR {
 #define RNODE_ZSUPER(node) ((struct RNode_ZSUPER *)(node))
 #define RNODE_LIST(node) ((struct RNode_LIST *)(node))
 #define RNODE_ZLIST(node) ((struct RNode_ZLIST *)(node))
-#define RNODE_VALUES(node) ((struct RNode_VALUES *)(node))
 #define RNODE_HASH(node) ((struct RNode_HASH *)(node))
 #define RNODE_RETURN(node) ((struct RNode_RETURN *)(node))
 #define RNODE_YIELD(node) ((struct RNode_YIELD *)(node))


### PR DESCRIPTION
This node type was added for the multi-value experiment back in 2004.
The feature itself was removed after a few years, but this is its remnant.