### PR TITLE
Thread events hooks: Pass concerned Thread to callbacks

### DIFF
--- a/include/ruby/thread.h
+++ b/include/ruby/thread.h
@@ -227,7 +227,9 @@ void *rb_nogvl(void *(*func)(void *), void *data1,
 
 #define RUBY_INTERNAL_THREAD_EVENT_MASK       0xff /** All Thread events */
 
-typedef void rb_internal_thread_event_data_t; // for future extension.
+typedef struct rb_internal_thread_event_data_t {
+    VALUE thread;
+} rb_internal_thread_event_data_t;
 
 typedef void (*rb_internal_thread_event_callback)(rb_event_flag_t event,
               const rb_internal_thread_event_data_t *event_data,


### PR DESCRIPTION
Let Thread event callback functions receive VALUE thread in concern. This will be a more stable way than calling gettid(2) in callbacks.