### PR TITLE
Optimize `Range#new` for `Bignum`, `Float`, `String`, and `Symbol`

### DIFF
--- a/benchmark/range_new.yml
+++ b/benchmark/range_new.yml
@@ -1,0 +1,15 @@
+prelude: |
+  bignum = 10**100
+  require 'date'
+  date1, date2 = Date.new(2023, 1, 1), Date.new(2023, 12, 31)
+  time1, time2 = Time.at(0), Time.at(100)
+
+benchmark:
+  - Range.new(0, 5)
+  - Range.new(0, bignum)
+  - Range.new(0, 5.5)
+  - Range.new('a', 'z')
+  - Range.new(:a, :z)
+  - Range.new(0, nil)
+  - Range.new(date1, date2)
+  - Range.new(time1, time2)

--- a/range.c
+++ b/range.c
@@ -46,7 +46,12 @@ static VALUE r_cover_p(VALUE, VALUE, VALUE, VALUE);
 static void
 range_init(VALUE range, VALUE beg, VALUE end, VALUE exclude_end)
 {
-    if ((!FIXNUM_P(beg) || !FIXNUM_P(end)) && !NIL_P(beg) && !NIL_P(end)) {
+    int ok = NIL_P(beg) || NIL_P(end)
+        || ((RB_INTEGER_TYPE_P(beg) || RB_FLOAT_TYPE_P(beg)) && (RB_INTEGER_TYPE_P(end) || RB_FLOAT_TYPE_P(end)))
+        || (STRING_P(beg) && STRING_P(end))
+        || (SYMBOL_P(beg) && SYMBOL_P(end));
+
+    if (!ok) {
         VALUE v;
 
         v = rb_funcall(beg, id_cmp, 1, end);

--- a/test/ruby/test_range.rb
+++ b/test/ruby/test_range.rb
@@ -10,11 +10,28 @@ class TestRange < Test::Unit::TestCase
     assert_equal((0..2), Range.new(0, 2))
     assert_equal((0..2), Range.new(0, 2, false))
     assert_equal((0...2), Range.new(0, 2, true))
+    assert_equal((0..2**100), Range.new(0, 2**100, false))
+    assert_equal((2**99..2**100), Range.new(2**99, 2**100, false))
+    assert_equal((0..2.5), Range.new(0, 2.5, false))
+    assert_equal((1.5..2.5), Range.new(1.5, 2.5, false))
+    assert_equal((0..5r/2), Range.new(0, 5r/2, false))
+    assert_equal((3r/2..5r/2), Range.new(3r/2, 5r/2, false))
+    assert_equal(Date.new(2023, 1, 1)..Date.new(2023, 12, 31), Range.new(Date.new(2023, 1, 1), Date.new(2023, 12, 31), false))
+    assert_equal(Time.at(0)..Time.at(100), Range.new(Time.at(0), Time.at(100), false))
+    assert_equal('a'..'z', Range.new('a', 'z', false))
+    assert_equal(:a..:z, Range.new(:a, :z, false))
 
     assert_raise(ArgumentError) { (1.."3") }
+    assert_raise(ArgumentError) { (1i..2i) }
 
     assert_equal((0..nil), Range.new(0, nil, false))
     assert_equal((0...nil), Range.new(0, nil, true))
+    assert_equal((0..), Range.new(0, nil, false))
+    assert_equal((0...), Range.new(0, nil, true))
+    assert_equal((..0), Range.new(nil, 0, false))
+    assert_equal((...0), Range.new(nil, 0, true))
+    assert_equal((nil..nil), Range.new(nil, nil, false))
+    assert_equal((nil...nil), Range.new(nil, nil, true))
 
     obj = Object.new
     def obj.<=>(other)


### PR DESCRIPTION
In `range_init`, a check is performed to determine if `beg` and `end` are comparable.
This check is skipped when both of them are `Fixnum`.
By treating more classes in this manner, we can speed up `Range#new`.

# benchmark

## Iteration per second (i/s)

|                         |master|PR|
|:------------------------|----------------------------------:|-------------------------:|
|Range.new(0, 5)          |                            11.964M|                   11.976M|
|                         |                                  -|                     1.00x|
|Range.new(0, bignum)     |                             7.451M|                   11.627M|
|                         |                                  -|                     1.56x|
|Range.new(0, 5.5)        |                             9.176M|                   11.870M|
|                         |                                  -|                     1.29x|
|Range.new('a', 'z')      |                             6.959M|                    8.088M|
|                         |                                  -|                     1.16x|
|Range.new(:a, :z)        |                             8.583M|                   11.816M|
|                         |                                  -|                     1.38x|
|Range.new(0, nil)        |                            11.956M|                   11.933M|
|                         |                              1.00x|                         -|
|Range.new(date1, date2)  |                             8.296M|                    8.244M|
|                         |                              1.01x|                         -|
|Range.new(time1, time2)  |                             9.140M|                    9.008M|
|                         |                              1.01x|                         -|
