### PR TITLE
shape.h: Make attr_index_t uint8_t

### DIFF
--- a/rjit_c.rb
+++ b/rjit_c.rb
@@ -898,7 +898,7 @@ module RubyVM::RJIT # :nodoc: all
   end
 
   def C.attr_index_t
-    @attr_index_t ||= CType::Immediate.parse("uint32_t")
+    @attr_index_t ||= CType::Immediate.parse("uint8_t")
   end
 
   def C.iseq_inline_constant_cache
@@ -1479,7 +1479,7 @@ module RubyVM::RJIT # :nodoc: all
       edges: [CType::Pointer.new { self.rb_id_table }, Primitive.cexpr!("OFFSETOF((*((struct rb_shape *)NULL)), edges)")],
       edge_name: [self.ID, Primitive.cexpr!("OFFSETOF((*((struct rb_shape *)NULL)), edge_name)")],
       next_iv_index: [self.attr_index_t, Primitive.cexpr!("OFFSETOF((*((struct rb_shape *)NULL)), next_iv_index)")],
-      capacity: [CType::Immediate.parse("uint32_t"), Primitive.cexpr!("OFFSETOF((*((struct rb_shape *)NULL)), capacity)")],
+      capacity: [self.attr_index_t, Primitive.cexpr!("OFFSETOF((*((struct rb_shape *)NULL)), capacity)")],
       type: [CType::Immediate.parse("uint8_t"), Primitive.cexpr!("OFFSETOF((*((struct rb_shape *)NULL)), type)")],
       size_pool_index: [CType::Immediate.parse("uint8_t"), Primitive.cexpr!("OFFSETOF((*((struct rb_shape *)NULL)), size_pool_index)")],
       parent_id: [self.shape_id_t, Primitive.cexpr!("OFFSETOF((*((struct rb_shape *)NULL)), parent_id)")],

--- a/shape.h
+++ b/shape.h
@@ -6,12 +6,11 @@
 #if (SIZEOF_UINT64_T <= SIZEOF_VALUE)
 #define SIZEOF_SHAPE_T 4
 #define SHAPE_IN_BASIC_FLAGS 1
-typedef uint32_t attr_index_t;
 #else
 #define SIZEOF_SHAPE_T 2
 #define SHAPE_IN_BASIC_FLAGS 0
-typedef uint16_t attr_index_t;
 #endif
+typedef uint8_t attr_index_t;
 
 #define MAX_IVARS (attr_index_t)(-1)
 
@@ -44,7 +43,7 @@ struct rb_shape {
     struct rb_id_table * edges; // id_table from ID (ivar) to next shape
     ID edge_name; // ID (ivar) for transition from parent to rb_shape
     attr_index_t next_iv_index;
-    uint32_t capacity; // Total capacity of the object with this shape
+    attr_index_t capacity; // Total capacity of the object with this shape
     uint8_t type;
     uint8_t size_pool_index;
     shape_id_t parent_id;

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -2202,7 +2202,7 @@ fn gen_get_ivar(
     let ivar_index = unsafe {
         let shape_id = comptime_receiver.shape_id_of();
         let shape = rb_shape_get_shape_by_id(shape_id);
-        let mut ivar_index: u32 = 0;
+        let mut ivar_index: u8 = 0;
         if rb_shape_get_iv_index(shape, ivar_name, &mut ivar_index) {
             Some(ivar_index as usize)
         } else {
@@ -2388,7 +2388,7 @@ fn gen_setinstancevariable(
     let ivar_index = if !shape_too_complex {
         let shape_id = comptime_receiver.shape_id_of();
         let shape = unsafe { rb_shape_get_shape_by_id(shape_id) };
-        let mut ivar_index: u32 = 0;
+        let mut ivar_index: u8 = 0;
         if unsafe { rb_shape_get_iv_index(shape, ivar_name, &mut ivar_index) } {
             Some(ivar_index as usize)
         } else {
@@ -2655,7 +2655,7 @@ fn gen_definedivar(
     let shape_id = comptime_receiver.shape_id_of();
     let ivar_exists = unsafe {
         let shape = rb_shape_get_shape_by_id(shape_id);
-        let mut ivar_index: u32 = 0;
+        let mut ivar_index: u8 = 0;
         rb_shape_get_iv_index(shape, ivar_name, &mut ivar_index)
     };
 

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -801,7 +801,7 @@ pub const VM_ENV_FLAG_ESCAPED: vm_frame_env_flags = 4;
 pub const VM_ENV_FLAG_WB_REQUIRED: vm_frame_env_flags = 8;
 pub const VM_ENV_FLAG_ISOLATED: vm_frame_env_flags = 16;
 pub type vm_frame_env_flags = u32;
-pub type attr_index_t = u32;
+pub type attr_index_t = u8;
 pub type shape_id_t = u32;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -809,7 +809,7 @@ pub struct rb_shape {
     pub edges: *mut rb_id_table,
     pub edge_name: ID,
     pub next_iv_index: attr_index_t,
-    pub capacity: u32,
+    pub capacity: attr_index_t,
     pub type_: u8,
     pub size_pool_index: u8,
     pub parent_id: shape_id_t,


### PR DESCRIPTION
Given `SHAPE_MAX_NUM_IVS 80`, we transition to TOO_COMPLEX way before we could overflow a 8bit counter.

This reduce the size of `rb_shape_t` from 32B to 24B.

If we decide to raise `SHAPE_MAX_NUM_IVS` we can always increase that type again.