### PR TITLE
YJIT: Fix constant invalidation for ic_cref

### DIFF
--- a/test/ruby/test_yjit.rb
+++ b/test/ruby/test_yjit.rb
@@ -476,6 +476,25 @@ class TestYJIT < Test::Unit::TestCase
     RUBY
   end
 
+  def test_opt_getconstant_path_slowpath_invalidation
+    assert_compiles(<<~RUBY, exits: { opt_getconstant_path: 1 }, result: [1, 1], call_threshold: 1)
+      class A
+        FOO = 1
+        class << self
+          def foo
+            _foo = nil
+            FOO
+          end
+        end
+      end
+
+      result = []
+      result << A.foo # exit and then invalidate
+      result << A.foo # should not exit
+      result
+    RUBY
+  end
+
   def test_string_interpolation
     assert_compiles(<<~'RUBY', insns: %i[objtostring anytostring concatstrings], result: "foobar", call_threshold: 2)
       def make_str(foo, bar)

--- a/yjit/src/invariants.rs
+++ b/yjit/src/invariants.rs
@@ -388,7 +388,7 @@ pub fn block_assumptions_free(blockref: BlockRef) {
     }
 }
 
-/// Callback from the opt_setinlinecache instruction in the interpreter.
+/// Callback from the opt_getconstant_path instruction in the interpreter.
 /// Invalidate the block for the matching opt_getinlinecache so it could regenerate code
 /// using the new value in the constant cache.
 #[no_mangle]
@@ -407,7 +407,7 @@ pub extern "C" fn rb_yjit_constant_ic_update(iseq: *const rb_iseq_t, ic: IC, ins
         return;
     };
 
-    if !unsafe { (*(*ic).entry).ic_cref }.is_null() || unsafe { rb_yjit_multi_ractor_p() } {
+    if unsafe { rb_yjit_multi_ractor_p() } {
         // We can't generate code in these situations, so no need to invalidate.
         // See gen_opt_getinlinecache.
         return;


### PR DESCRIPTION
`rb_yjit_constant_ic_update` currently does not invalidate `opt_getconstant_path` when its inline cache has `ic_cref` because it assumes it cannot generate code for that case.

However, that case has been supported since https://github.com/Shopify/yjit/pull/240, so we should invalidate such blocks and re-generate them.

This helps `ratio_in_yjit` of lobsters a little. `opt_getconstant_path` has another problem to be fixed, but it's out of scope in this PR.

### Before
```
ratio_in_yjit:                 98.1%
avg_len_in_yjit:                55.0
Top-20 most frequent exit ops (100.0% of exits):
                opt_getconstant_path:     14,810 (33.5%)
                              opt_eq:     13,420 (30.4%)
                  getblockparamproxy:     10,987 (24.9%)
                                  ...
```

### After
```
ratio_in_yjit:                 98.3%
avg_len_in_yjit:                56.3
Top-20 most frequent exit ops (100.0% of exits):
                              opt_eq:     13,419 (36.8%)
                  getblockparamproxy:     10,987 (30.2%)
                opt_getconstant_path:      7,064 (19.4%)
                                  ...
```