### PR TITLE
Fix error when gems/src is read-only

### DIFF
--- a/defs/gmake.mk
+++ b/defs/gmake.mk
@@ -371,9 +371,11 @@ $(bundled-gem-revision): \
 	| $(srcdir)/.bundle/.timestamp $(srcdir)/gems/src/$(1)/.git
 	$(ECHO) Update $(1) to $(3)
 	$(Q) $(CHDIR) "$(srcdir)/gems/src/$(1)" && \
-	    $(GIT) fetch origin $(3) && \
-	    $(GIT) checkout --detach $(3) && \
-	:
+	    if [ `$(GIT) rev-parse HEAD` != $(3) ]; then \
+	        $(GIT) fetch origin $(3) && \
+	        $(GIT) checkout --detach $(3) && \
+	        :; \
+	    fi
 	echo $(3) | $(IFCHANGE) $$(@) -
 
 # The repository of minitest does not include minitest.gemspec because it uses hoe.


### PR DESCRIPTION
When I shared srcdir as read-only in lima-vm,
`make install` causes following error:

```
Update rbs to 33813a60752624d58dfe5ae770b39bfaf29fbaf1
error: cannot open .git/FETCH_HEAD: Read-only file system
```

I cannot find any ignore option for `git checkout --detach` when already checked out. So I add `if`.