### PR TITLE
fix find_library to show proper error when installing mysql2

### DIFF
--- a/lib/mkmf.rb
+++ b/lib/mkmf.rb
@@ -1074,7 +1074,7 @@ SRC
   def find_library(lib, func, *paths, &b)
     dir_config(lib)
     lib = with_config(lib+'lib', lib)
-    paths = paths.flat_map {|path| path.split(File::PATH_SEPARATOR)}
+    paths = paths.flat_map {|path| path.nil? ? [] : path.split(File::PATH_SEPARATOR)}
     checking_for checking_message(func && func.funcall_style, LIBARG%lib) do
       libpath = $LIBPATH
       libs = append_library($libs, lib)


### PR DESCRIPTION
Expected output from the command `gem install mysql2`:

“mysql client is missing. You may need to 'sudo apt-get install libmariadb-dev', 'sudo apt-get install libmysqlclient-dev' or 'sudo yum install mysql-devel', and try again.”

Instead, before the fix, I received this output:

```
/home/christian/.rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/mkmf.rb:1084:in `block in find_library': undefined method `split' for nil:NilClass (NoMethodError)

    paths = paths.flat_map {|path| path.split(File::PATH_SEPARATOR)}
                                       ^^^^^^
    from /home/christian/.rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/mkmf.rb:1084:in `each'
    from /home/christian/.rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/mkmf.rb:1084:in `flat_map'
    from /home/christian/.rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/mkmf.rb:1084:in `find_library'
    from extconf.rb:131:in `<main>'
```

The variable lib contains the string “mysqlclient”.