### PR TITLE
fix `native_thread_destroy()` timing

### DIFF
--- a/thread.c
+++ b/thread.c
@@ -508,16 +508,13 @@ thread_cleanup_func(void *th_ptr, int atfork)
      * Unfortunately, we can't release native threading resource at fork
      * because libc may have unstable locking state therefore touching
      * a threading resource may cause a deadlock.
-     *
-     * FIXME: Skipping native_mutex_destroy(pthread_mutex_destroy) is safe
-     * with NPTL, but native_thread_destroy calls pthread_cond_destroy
-     * which calls free(3), so there is a small memory leak atfork, here.
      */
-    if (atfork)
+    if (atfork) {
+        th->nt = NULL;
         return;
+    }
 
     rb_native_mutex_destroy(&th->interrupt_lock);
-    native_thread_destroy(th);
 }
 
 static VALUE rb_threadptr_raise(rb_thread_t *, int, VALUE *);

--- a/thread_none.c
+++ b/thread_none.c
@@ -139,11 +139,6 @@ ruby_mn_threads_params(void)
 {
 }
 
-static void
-native_thread_destroy(rb_thread_t *th)
-{
-}
-
 void
 ruby_init_stack(volatile VALUE *addr)
 {

--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -1714,14 +1714,19 @@ native_thread_assign(struct rb_native_thread *nt, rb_thread_t *th)
 }
 
 static void
-native_thread_destroy(rb_thread_t *th)
+native_thread_destroy(struct rb_native_thread *nt)
 {
-    struct rb_native_thread *nt = th->nt;
+    if (nt) {
+        rb_native_cond_destroy(&nt->cond.readyq);
 
-    rb_native_cond_destroy(&nt->cond.readyq);
+        if (&nt->cond.readyq != &nt->cond.intr) {
+            rb_native_cond_destroy(&nt->cond.intr);
+        }
 
-    if (&nt->cond.readyq != &nt->cond.intr)
-      rb_native_cond_destroy(&nt->cond.intr);
+        RB_ALTSTACK_FREE(nt->altstack);
+        ruby_xfree(nt->nt_context);
+        ruby_xfree(nt);
+    }
 }
 
 #if defined HAVE_PTHREAD_GETATTR_NP || defined HAVE_PTHREAD_ATTR_GET_NP
@@ -2106,6 +2111,7 @@ static struct rb_native_thread *
 native_thread_alloc(void)
 {
     struct rb_native_thread *nt = ZALLOC(struct rb_native_thread);
+    native_thread_setup(nt);
 
 #if USE_MN_THREADS
     nt->nt_context = ruby_xmalloc(sizeof(struct coroutine_context));
@@ -2125,7 +2131,6 @@ native_thread_create_dedicated(rb_thread_t *th)
     th->nt->vm = th->vm;
     th->nt->running_thread = th;
     th->nt->dedicated = 1;
-    native_thread_setup(th->nt);
 
     // vm stack
     size_t vm_stack_word_size = th->vm->default_params.thread_vm_stack_size / sizeof(VALUE);
@@ -2262,10 +2267,9 @@ rb_threadptr_sched_free(rb_thread_t *th)
 {
 #if USE_MN_THREADS
     if (th->sched.malloc_stack) {
+        // has dedicated
         ruby_xfree(th->sched.context_stack);
-        RB_ALTSTACK_FREE(th->nt->altstack);
-        ruby_xfree(th->nt->nt_context);
-        ruby_xfree(th->nt);
+        native_thread_destroy(th->nt);
     }
     else {
         nt_free_stack(th->sched.context_stack);
@@ -2276,17 +2280,12 @@ rb_threadptr_sched_free(rb_thread_t *th)
         ruby_xfree(th->sched.context);
         VM_ASSERT((th->sched.context = NULL) == NULL);
     }
-
-    th->nt = NULL;
 #else
     ruby_xfree(th->sched.context_stack);
-
-    struct rb_native_thread *nt = th->nt;
-    if (nt) { // TODO: not sure why nt is NULL
-        RB_ALTSTACK_FREE(nt->altstack);
-        ruby_xfree(nt);
-    }
+    native_thread_destroy(th->nt);
 #endif
+
+    th->nt = NULL;
 }
 
 void


### PR DESCRIPTION
With M:N thread scheduler, the native thread (NT) related resources should be freed when the NT is no longer needed. So the calling `native_thread_destroy()` at the end of `is will be freed when `thread_cleanup_func()` (at the end of Ruby thread) is not correct timing. Call it when the corresponding Ruby thread is collected.