### PR TITLE
[Bug #19924] Source code should be unsigned char stream 

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -7911,9 +7911,9 @@ tokadd_utf8(struct parser_params *p, rb_encoding **encp,
              * invalid unicode escapes are allowed in comments. The regexp parser
              * does its own validation and will catch any issues.
              */
-            int c = *p->lex.pcur;
-            tokadd(p, c);
-            for (c = *++p->lex.pcur; p->lex.pcur < p->lex.pend; c = *++p->lex.pcur) {
+            tokadd(p, open_brace);
+            while (++p->lex.pcur < p->lex.pend) {
+                int c = peekc(p);
                 if (c == close_brace) {
                     tokadd(p, c);
                     ++p->lex.pcur;
@@ -8310,7 +8310,7 @@ tokadd_string(struct parser_params *p,
             --*nest;
         }
         else if ((func & STR_FUNC_EXPAND) && c == '#' && !lex_eol_p(p)) {
-            int c2 = *p->lex.pcur;
+            unsigned char c2 = *p->lex.pcur;
             if (c2 == '$' || c2 == '@' || c2 == '{') {
                 pushback(p, c);
                 break;
@@ -9916,7 +9916,7 @@ parse_qmark(struct parser_params *p, int space_seen)
             enc = rb_utf8_encoding();
             tokadd_utf8(p, &enc, -1, 0, 0);
         }
-        else if (!lex_eol_p(p) && !(c = *p->lex.pcur, ISASCII(c))) {
+        else if (!ISASCII(c = peekc(p))) {
             nextc(p);
             if (tokadd_mbchar(p, c) == -1) return 0;
         }

--- a/parse.y
+++ b/parse.y
@@ -7912,7 +7912,7 @@ tokadd_utf8(struct parser_params *p, rb_encoding **encp,
              * does its own validation and will catch any issues.
              */
             tokadd(p, open_brace);
-            while (++p->lex.pcur < p->lex.pend) {
+            while (!lex_eol_ptr_p(p, ++p->lex.pcur)) {
                 int c = peekc(p);
                 if (c == close_brace) {
                     tokadd(p, c);
@@ -7922,7 +7922,7 @@ tokadd_utf8(struct parser_params *p, rb_encoding **encp,
                 else if (c == term) {
                     break;
                 }
-                if (c == '\\' && p->lex.pcur + 1 < p->lex.pend) {
+                if (c == '\\' && !lex_eol_n_p(p, 1)) {
                     tokadd(p, c);
                     c = *++p->lex.pcur;
                 }

--- a/test/ruby/test_parse.rb
+++ b/test/ruby/test_parse.rb
@@ -633,6 +633,8 @@ class TestParse < Test::Unit::TestCase
     assert_syntax_error("?\\M-\x01", 'Invalid escape character syntax')
     assert_syntax_error("?\\M-\\C-\x01", 'Invalid escape character syntax')
     assert_syntax_error("?\\C-\\M-\x01", 'Invalid escape character syntax')
+
+    assert_equal("\xff", eval("# encoding: ascii-8bit\n""?\\\xFF"))
   end
 
   def test_percent


### PR DESCRIPTION
Use `peekc` or `nextc` to fetch the next character, instead of reading from `lex.pcur` directly, for compilers that plain char is signed.
