### PR TITLE
YJIT: Fix argument clobbering in some block_arg+rest_param calls

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -1,3 +1,15 @@
+# regression test for callee block handler overlapping with arguments
+assert_equal '3', %q{
+  def foo(_req, *args) = args.last
+
+  def call_foo = foo(0, 1, 2, 3, &->{})
+
+  call_foo
+}
+
+# call leaf builtin with a block argument
+assert_equal '0', "0.abs(&nil)"
+
 # regression test for invokeblock iseq guard
 assert_equal 'ok', %q{
   return :ok unless defined?(GC.compact)

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -267,6 +267,8 @@ make_counters! {
     send_attrset_kwargs,
     send_iseq_tailcall,
     send_iseq_arity_error,
+    send_iseq_clobbering_block_arg,
+    send_iseq_leaf_builtin_block_arg_block_param,
     send_iseq_only_keywords,
     send_iseq_kwargs_req_and_opt_missing,
     send_iseq_kwargs_mismatch,


### PR DESCRIPTION
Previously, for block argument callsites with some specific argument count and callee local variable count combinations, YJIT ended up writing over arguments that are supposed to be collected into a rest parameter array unmodified.

Detect when clobbering would happen and avoid it. Also, place the block handler after the stack overflow check, since it writes to new stack space.

Reported-by: Takashi Kokubun