### PR TITLE
use `uint32_t` instead of `__uint32_t`

### DIFF
--- a/thread_pthread_mn.c
+++ b/thread_pthread_mn.c
@@ -562,7 +562,7 @@ timer_thread_register_waiting(rb_thread_t *th, int fd, enum thread_sched_waiting
         flags |= thread_sched_waiting_timeout;
     }
 
-    __uint32_t epoll_events = 0;
+    uint32_t epoll_events = 0;
     if (flags & thread_sched_waiting_timeout) {
         VM_ASSERT(rel != NULL);
         abs = rb_hrtime_add(rb_hrtime_now(), *rel);


### PR DESCRIPTION
https://rubyci.s3.amazonaws.com/crossruby/crossruby-master-wasm32_emscripten/log/20231013T044457Z.log.html.gz#configure

```diff
compiling thread.c
In file included from thread.c:262:
In file included from ./thread_pthread.c:2789:
./thread_pthread_mn.c:565:15: error: expected ';' after expression
    __uint32_t epoll_events = 0;
              ^
              ;
./thread_pthread_mn.c:565:5: error: use of undeclared identifier '__uint32_t'
    __uint32_t epoll_events = 0;
    ^
./thread_pthread_mn.c:565:16: error: use of undeclared identifier 'epoll_events'
    __uint32_t epoll_events = 0;
               ^
./thread_pthread_mn.c:578:13: error: use of undeclared identifier 'epoll_events'; did you mean 'epoll_create'?
            epoll_events |= EPOLLIN;
            ^~~~~~~~~~~~
            epoll_create
/usr/share/emscripten/cache/sysroot/include/sys/epoll.h:58:5: note: 'epoll_create' declared here
int epoll_create(int);
    ^
In file included from thread.c:262:
In file included from ./thread_pthread.c:2789:
./thread_pthread_mn.c:578:26: error: invalid operands to binary expression ('int (int)' and 'int')
            epoll_events |= EPOLLIN;
            ~~~~~~~~~~~~ ^  ~~~~~~~
./thread_pthread_mn.c:589:13: error: use of undeclared identifier 'epoll_events'; did you mean 'epoll_create'?
            epoll_events |= EPOLLOUT;
            ^~~~~~~~~~~~
            epoll_create
/usr/share/emscripten/cache/sysroot/include/sys/epoll.h:58:5: note: 'epoll_create' declared here
int epoll_create(int);
    ^
In file included from thread.c:262:
In file included from ./thread_pthread.c:2789:
./thread_pthread_mn.c:589:26: error: invalid operands to binary expression ('int (int)' and 'int')
            epoll_events |= EPOLLOUT;
            ~~~~~~~~~~~~ ^  ~~~~~~~~
./thread_pthread_mn.c:595:13: error: use of undeclared identifier 'epoll_events'; did you mean 'epoll_create'?
        if (epoll_events) {
            ^~~~~~~~~~~~
            epoll_create
/usr/share/emscripten/cache/sysroot/include/sys/epoll.h:58:5: note: 'epoll_create' declared here
int epoll_create(int);
    ^
In file included from thread.c:262:
In file included from ./thread_pthread.c:2789:
./thread_pthread_mn.c:597:27: error: use of undeclared identifier 'epoll_events'; did you mean 'epoll_create'?
                .events = epoll_events,
                          ^~~~~~~~~~~~
                          epoll_create
/usr/share/emscripten/cache/sysroot/include/sys/epoll.h:58:5: note: 'epoll_create' declared here
int epoll_create(int);
    ^
```