### PR TITLE
use clear filename for btest

### DIFF
--- a/bootstraptest/runner.rb
+++ b/bootstraptest/runner.rb
@@ -549,7 +549,7 @@ class Assertion < Struct.new(:src, :path, :lineno, :proc)
   end
 
   def make_srcfile(frozen_string_literal: nil)
-    filename = "bootstraptest.#{self.path}_#{self.lineno}_#{self.id}.rb"
+    filename = File.join(Dir.pwd, "btest.#{self.path}_L#{self.lineno}_N#{self.id}.rb")
     File.open(filename, 'w') {|f|
       f.puts "#frozen_string_literal:true" if frozen_string_literal
       f.puts "GC.stress = true" if $stress


### PR DESCRIPTION
`make btest` (bootstraptest/) makes tempfile and run the file. This patch introduces two changes:

* use fullpath to make easy to find the file (with `ps`)
* `_<line>_<id>` to `_L<line>_N<id>` (`_123_456` is not easy to find which is line number).