### PR TITLE
disable MN schedulers for some platforms

### DIFF
--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -70,11 +70,18 @@ static const void *const condattr_monotonic = NULL;
 // #define HAVE_SYS_EPOLL_H 0
 #endif
 
-#if HAVE_SYS_EPOLL_H && !defined(COROUTINE_PTHREAD_CONTEXT)
-  #include <sys/epoll.h>
-  #define USE_MN_THREADS 1
-#else
-  #define USE_MN_THREADS 0
+#ifndef USE_MN_THREADS
+  #if defined(__EMSCRIPTEN__) || defined(COROUTINE_PTHREAD_CONTEXT) || defined(NON_SCALAR_THREAD_ID)
+    // on __EMSCRIPTEN__ provides epoll* declarations, but no implementations.
+    // on COROUTINE_PTHREAD_CONTEXT, it doesn't worth to use it.
+    // on NON_SCALAR_THREAD_ID, now we can not debug issues on x390s/Ubuntu so skip it.
+    #define USE_MN_THREADS 0
+  #elif HAVE_SYS_EPOLL_H
+    #include <sys/epoll.h>
+    #define USE_MN_THREADS 1
+  #else
+    #define USE_MN_THREADS 0
+  #endif
 #endif
 
 // native thread wrappers


### PR DESCRIPTION
* on `__EMSCRIPTEN__` provides epoll* declarations, but no implementations.
* on `NON_SCALAR_THREAD_ID`, now we can not debug issues on x390s/Ubuntu so skip it.

x390s/RHEL works fine, so I think we can remove second limitation but I could not login to it so it seems hard to debug now.