### PR TITLE
YJIT: Count cold_iseq_entry by default

### DIFF
--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -573,11 +573,6 @@ pub extern "C" fn rb_yjit_get_exit_locations(_ec: EcPtr, _ruby_self: VALUE) -> V
 #[no_mangle]
 pub extern "C" fn rb_yjit_incr_counter(counter_name: *const std::os::raw::c_char) {
     use std::ffi::CStr;
-
-    if !get_option!(gen_stats) {
-        return;
-    }
-
     let counter_name = unsafe { CStr::from_ptr(counter_name).to_str().unwrap() };
     let counter_ptr = get_counter_ptr(counter_name);
     unsafe { *counter_ptr += 1 };


### PR DESCRIPTION
`cold_iseq_entry` is part of `DEFAULT_COUNTERS`, so it should be usable without `--yjit-stats`.

Similar to https://github.com/ruby/ruby/pull/8379, I often want to monitor these metrics without adding the overhead of `--yjit-stats`, so I'd rather like to always count this.

I ran the same microbenchmark as https://github.com/ruby/ruby/pull/8628#issuecomment-1758572365 with `--yjit-cold-threshold=0`, and it had no impact (of course, because this path is executed only once).

```
before: ruby 3.3.0dev (2023-10-13T16:40:44Z master 92bdc3757f) +YJIT [x86_64-linux]
after: ruby 3.3.0dev (2023-10-13T17:12:18Z yjit-cold-counter 4d9bd2e66d) +YJIT [x86_64-linux]

-----  -----------  ----------  ----------  ----------  -------------  ------------
bench  before (ms)  stddev (%)  after (ms)  stddev (%)  after 1st itr  before/after
fib    218.5        0.4         218.1       0.2         1.00           1.00
-----  -----------  ----------  ----------  ----------  -------------  ------------
```