### PR TITLE
[Bug #19926] Fix `Range#size` for ranges with a Rational endpoint

### DIFF
--- a/numeric.c
+++ b/numeric.c
@@ -2834,7 +2834,7 @@ ruby_num_interval_step_size(VALUE from, VALUE to, VALUE step, int excl)
         }
         if (RTEST(rb_funcall(from, cmp, 1, to))) return INT2FIX(0);
         result = rb_funcall(rb_funcall(to, '-', 1, from), id_div, 1, step);
-        if (!excl || RTEST(rb_funcall(rb_funcall(from, '+', 1, rb_funcall(result, '*', 1, step)), cmp, 1, to))) {
+        if (!excl || RTEST(rb_funcall(to, cmp, 1, rb_funcall(from, '+', 1, rb_funcall(result, '*', 1, step))))) {
             result = rb_funcall(result, '+', 1, INT2FIX(1));
         }
         return result;

--- a/test/ruby/test_range.rb
+++ b/test/ruby/test_range.rb
@@ -977,6 +977,10 @@ class TestRange < Test::Unit::TestCase
     assert_equal 41, (1...42).size
     assert_equal 6, (1...6.3).size
     assert_equal 5, (1.1...6).size
+    assert_equal 3, (1..3r).size
+    assert_equal 2, (1...3r).size
+    assert_equal 3, (1..3.1r).size
+    assert_equal 3, (1...3.1r).size
     assert_equal 42, (1..42).each.size
     assert_nil ("a"..."z").size
     assert_nil ("a"...).size


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/19926