### PR TITLE
Ignore symbols even in empty shared library

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3952,6 +3952,22 @@ AC_CACHE_CHECK([for prefix of external symbols], rb_cv_symbol_prefix, [
 ])
 SYMBOL_PREFIX="$rb_cv_symbol_prefix"
 test "x$SYMBOL_PREFIX" = xNONE && SYMBOL_PREFIX=''
+
+AS_IF([test x"$enable_shared" = xyes], [
+    AC_CACHE_CHECK([for default symbols in empty shared library], rb_cv_symbols_in_emptylib, [
+        save_CC="$CC"
+        eval CC=\"`printf "%s" "${DLDSHARED}" | sed ['s/\$(CC)/${CC}/']`\"
+        AC_LINK_IFELSE([AC_LANG_PROGRAM()],[
+            rb_cv_symbols_in_emptylib=`$NM -Pgp conftest$ac_exeext |
+                sed ["/ [A-TV-Z] .*/!d;s///;s/^${SYMBOL_PREFIX}//;/^main$/d"]`
+        ])
+        set ${rb_cv_symbols_in_emptylib}
+        rb_cv_symbols_in_emptylib="$*"
+        CC="$save_CC"
+    ])
+])
+AC_SUBST(XSYMBOLS_IN_EMPTYLIB, "${rb_cv_symbols_in_emptylib}")
+
 DLNOBJ=dln.o
 AC_ARG_ENABLE(dln,
 	      AS_HELP_STRING([--disable-dln], [disable dynamic link feature]),

--- a/template/Makefile.in
+++ b/template/Makefile.in
@@ -639,6 +639,7 @@ yes-test-leaked-globals: yes-test-leaked-globals-precheck
 	$(ACTIONS_GROUP)
 	$(Q) $(XRUBY) $(tooldir)/leaked-globals \
 	  SOEXT=$(SOEXT) NM="$(NM) -Pgp" SYMBOL_PREFIX=$(SYMBOL_PREFIX) \
+	  SYMBOLS_IN_EMPTYLIB="@XSYMBOLS_IN_EMPTYLIB@" \
 	  PLATFORM=$(hdrdir)/ruby/$(PLATFORM_DIR).h $(srcdir)/configure.ac \
 	  $(COMMONOBJS) $(LIBRUBY_FOR_LEAKED_GLOBALS:yes=$(LIBRUBY_SO))
 	$(ACTIONS_ENDGROUP)

--- a/tool/leaked-globals
+++ b/tool/leaked-globals
@@ -11,11 +11,14 @@ until ARGV.empty?
     platform = $1
   when /\A SOEXT=(.+)?/x
     soext = $1
+  when /\A SYMBOLS_IN_EMPTYLIB=(.*)/x
+    SYMBOLS_IN_EMPTYLIB = $1.split(" ")
   else
     break
   end
   ARGV.shift
 end
+SYMBOLS_IN_EMPTYLIB ||= nil
 
 config = ARGV.shift
 count = 0
@@ -67,7 +70,6 @@ IO.foreach("|#{NM} #{ARGV.join(' ')}") do |line|
   next unless n.sub!(/^#{SYMBOL_PREFIX}/o, "")
   next if n.include?(".")
   next if !so and n.start_with?("___asan_")
-  case n; when "_init", "_fini"; next end
   case n
   when /\A(?:Init_|InitVM_|pm_|[Oo]nig|dln_|coroutine_)/
     next
@@ -75,6 +77,8 @@ IO.foreach("|#{NM} #{ARGV.join(' ')}") do |line|
     next unless so
   when /\A(?:RUBY_|ruby_|rb_)/
     next unless so and /_(threadptr|ec)_/ =~ n
+  when *SYMBOLS_IN_EMPTYLIB
+    next
   end
   next if REPLACE.include?(n)
   puts col.fail("leaked") if count.zero?


### PR DESCRIPTION
On some platforms, such as FreeBSD and Oracle Linux, symbols defined in the crt0 setup routine are exported from shared libraries.
So ignore the symbols that would be exported even in an empty shared library.