### PR TITLE
disable MN threads on s390s-linux

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4364,6 +4364,10 @@ AS_IF([test "${universal_binary-no}" = yes ], [
         arch="${target_cpu}-${target_os}"
     ])
     AC_DEFINE_UNQUOTED(RUBY_PLATFORM, "$arch")
+
+    AS_IF([test "$arch" = "s390x-linux"], [
+       AC_DEFINE_UNQUOTED(USE_MN_THREADS, 0)
+    ])
 ])
 
 unset sitearch


### PR DESCRIPTION
I check the s390s-linux/Ubuntu system and I found that MN threads doesn't work with:

* function inlining (-O0 doesn't repro)
* Thread local specifier (`_Thread_local`. With `pthread_get_specific works) (it is not an issue of `__tls_get_addr()` written in thread.c)
* swap context with ucontext (coroutine/ucontext)

I couldn't find out what is the root cause of this issue but disable MN threads to make CI healthy.