### PR TITLE
Add result job for required status checks

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -100,6 +100,7 @@ jobs:
 
   result:
     if: ${{ always() }}
+    name: ${{ github.workflow }} result
     runs-on: macos-latest
     needs: [make]
     steps:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -98,6 +98,14 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SIMPLER_ALERTS_URL }} # ruby-lang slack: ruby/simpler-alerts-bot
         if: ${{ failure() }}
 
+  result:
+    if: ${{ always() }}
+    runs-on: macos-latest
+    needs: [make]
+    steps:
+      - run: exit 1
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+
 defaults:
   run:
     working-directory: build

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -117,6 +117,14 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SIMPLER_ALERTS_URL }} # ruby-lang slack: ruby/simpler-alerts-bot
         if: ${{ failure() }}
 
+  result:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    needs: [make]
+    steps:
+      - run: exit 1
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+
 defaults:
   run:
     working-directory: build

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -119,6 +119,7 @@ jobs:
 
   result:
     if: ${{ always() }}
+    name: ${{ github.workflow }} result
     runs-on: ubuntu-latest
     needs: [make]
     steps:

--- a/.github/workflows/yjit-macos.yml
+++ b/.github/workflows/yjit-macos.yml
@@ -107,6 +107,14 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SIMPLER_ALERTS_URL }} # ruby-lang slack: ruby/simpler-alerts-bot
         if: ${{ failure() }}
 
+  result:
+    if: ${{ always() }}
+    runs-on: macos-arm-oss
+    needs: [make]
+    steps:
+      - run: exit 1
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+
 defaults:
   run:
     working-directory: build

--- a/.github/workflows/yjit-macos.yml
+++ b/.github/workflows/yjit-macos.yml
@@ -109,6 +109,7 @@ jobs:
 
   result:
     if: ${{ always() }}
+    name: ${{ github.workflow }} result
     runs-on: macos-arm-oss
     needs: [make]
     steps:

--- a/.github/workflows/yjit-ubuntu.yml
+++ b/.github/workflows/yjit-ubuntu.yml
@@ -175,6 +175,7 @@ jobs:
 
   result:
     if: ${{ always() }}
+    name: ${{ github.workflow }} result
     runs-on: ubuntu-latest
     needs: [make]
     steps:

--- a/.github/workflows/yjit-ubuntu.yml
+++ b/.github/workflows/yjit-ubuntu.yml
@@ -173,6 +173,14 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SIMPLER_ALERTS_URL }} # ruby-lang slack: ruby/simpler-alerts-bot
         if: ${{ failure() }}
 
+  result:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    needs: [make]
+    steps:
+      - run: exit 1
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+
 defaults:
   run:
     working-directory: build


### PR DESCRIPTION
We've been using matrix jobs as required status checks. However, when [DOC] pull requests are created, the matrix content and templated variables are not executed, which results in changing the name of the matrix jobs. Then required status checks are considered missing because of the different names. So we can't merge [DOC] PRs right now.

This `result` is a known technique to check the composite status of matrix jobs. https://github.com/orgs/community/discussions/26822 The `result` job is not only a non-matrix job, which doesn't have the above problem, but also an independent job that is not skipped by [DOC]. `needs` works even if all dependent jobs are skipped, so this trick works well.

This is also useful when we want to change the content of matrix. When we change one, we usually have to update branches of old pull requests so that they get newly required jobs. However, with this method, only `result` jobs are required, so you don't need to update old pull requests.

I still don't like the fact that now you cannot visualize which matrix jobs are "Required", but this seems like the best compromise.