### PR TITLE
Remove YJIT --repeat-count=2 job

### DIFF
--- a/.github/workflows/yjit-ubuntu.yml
+++ b/.github/workflows/yjit-ubuntu.yml
@@ -101,9 +101,6 @@ jobs:
             configure: '--enable-yjit=dev'
             yjit_opts: '--yjit-call-threshold=1 --yjit-verify-ctx'
 
-          - test_task: 'test-all TESTS=--repeat-count=2'
-            configure: '--enable-yjit=dev'
-
           - test_task: 'test-bundled-gems'
             configure: '--enable-yjit=dev'
 


### PR DESCRIPTION
It's one of the slowest jobs in our required status checks. It often takes 40 minutes whereas the non-YJIT version takes only 20 minutes.

IIRC, it hasn't really revealed any YJIT-specific problems by running the same tests twice. I think it's enough to do this only on the non-YJIT job. 