### PR TITLE
Fix method coverage comparisons

### DIFF
--- a/test/coverage/test_coverage.rb
+++ b/test/coverage/test_coverage.rb
@@ -848,9 +848,10 @@ class TestCoverage < Test::Unit::TestCase
           EOS
         end
 
-        cov1 = "[0, 0, nil, nil, 0, 1, nil, nil, 0, 0, nil]"
-        cov2 = "[0, 0, nil, nil, 0, 1, nil, nil, 0, 1, nil]"
-        assert_in_out_err(%w[-rcoverage], <<-"end;", [cov1, cov2], [])
+        assert_separately(%w[-rcoverage], "#{<<~"begin;"}\n#{<<~'end;'}")
+        begin;
+          cov1 = [0, 0, nil, nil, 0, 1, nil, nil, 0, 0, nil]
+          cov2 = [0, 0, nil, nil, 0, 1, nil, nil, 0, 1, nil]
           Coverage.setup
           tmp = Dir.pwd
           require tmp + "/test.rb"
@@ -859,15 +860,34 @@ class TestCoverage < Test::Unit::TestCase
           bar
           Coverage.suspend
           baz
-          p Coverage.peek_result[tmp + "/test.rb"]
+          assert_equal cov1, Coverage.peek_result[tmp + "/test.rb"]
           Coverage.resume
           baz
-          p Coverage.result[tmp + "/test.rb"]
+          assert_equal cov2, Coverage.result[tmp + "/test.rb"]
         end;
 
-        cov1 = "{:lines=>[0, 0, nil, nil, 0, 1, nil, nil, 0, 0, nil], :branches=>{}, :methods=>{[Object, :baz, 9, 12, 11, 15]=>0, [Object, :bar, 5, 12, 7, 15]=>1, [Object, :foo, 1, 12, 3, 15]=>0}}"
-        cov2 = "{:lines=>[0, 0, nil, nil, 0, 1, nil, nil, 0, 1, nil], :branches=>{}, :methods=>{[Object, :baz, 9, 12, 11, 15]=>1, [Object, :bar, 5, 12, 7, 15]=>1, [Object, :foo, 1, 12, 3, 15]=>0}}"
-        assert_in_out_err(%w[-rcoverage], <<-"end;", [cov1, cov2], [])
+        assert_separately(%w[-rcoverage], "#{<<~"begin;"}\n#{<<~'end;'}")
+        begin;
+          cov1 = {
+            lines: [0, 0, nil, nil, 0, 1, nil, nil, 0, 0, nil],
+            branches: {},
+            methods: {
+              [Object, :baz, 9, 12, 11, 15]=>0,
+              [Object, :bar, 5, 12, 7, 15]=>1,
+              [Object, :foo, 1, 12, 3, 15]=>0,
+            }
+          }
+
+          cov2 = {
+            lines: [0, 0, nil, nil, 0, 1, nil, nil, 0, 1, nil],
+            branches: {},
+            methods: {
+              [Object, :baz, 9, 12, 11, 15]=>1,
+              [Object, :bar, 5, 12, 7, 15]=>1,
+              [Object, :foo, 1, 12, 3, 15]=>0,
+            }
+          }
+
           Coverage.setup(:all)
           tmp = Dir.pwd
           require tmp + "/test.rb"
@@ -876,15 +896,16 @@ class TestCoverage < Test::Unit::TestCase
           bar
           Coverage.suspend
           baz
-          p Coverage.peek_result[tmp + "/test.rb"]
+          assert_equal cov1, Coverage.peek_result[tmp + "/test.rb"]
           Coverage.resume
           baz
-          p Coverage.result[tmp + "/test.rb"]
+          assert_equal cov2, Coverage.result[tmp + "/test.rb"]
         end;
 
-        cov1 = "{:oneshot_lines=>[6]}"
-        cov2 = "{:oneshot_lines=>[6, 10]}"
-        assert_in_out_err(%w[-rcoverage], <<-"end;", [cov1, cov2], [])
+        assert_separately(%w[-rcoverage], "#{<<~"begin;"}\n#{<<~'end;'}")
+        begin;
+          cov1 = {:oneshot_lines=>[6]}
+          cov2 = {:oneshot_lines=>[6, 10]}
           Coverage.setup(oneshot_lines: true)
           tmp = Dir.pwd
           require tmp + "/test.rb"
@@ -893,10 +914,10 @@ class TestCoverage < Test::Unit::TestCase
           bar
           Coverage.suspend
           baz
-          p Coverage.peek_result[tmp + "/test.rb"]
+          assert_equal cov1, Coverage.peek_result[tmp + "/test.rb"]
           Coverage.resume
           baz
-          p Coverage.result[tmp + "/test.rb"]
+          assert_equal cov2, Coverage.result[tmp + "/test.rb"]
         end;
       }
     }


### PR DESCRIPTION
Although Ruby's hashes preserve the insertion order, the ordering of method coverage results is inherently nondeterministic, because they are collected using `ObjectSpace`.