### PR TITLE
Remove duplicated option

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1032,7 +1032,7 @@ PHONY:
 {$(srcdir)}.y.c:
 	$(ECHO) generating $@
 	$(Q)$(BASERUBY) $(tooldir)/id2token.rb $(SRC_FILE) | \
-	$(YACC) -d $(YFLAGS) -o$@ -h$*.h - parse.y
+	$(YACC) $(YFLAGS) -o$@ -h$*.h - parse.y
 
 $(PLATFORM_D):
 	$(Q) $(MAKEDIRS) $(PLATFORM_DIR) $(@D)


### PR DESCRIPTION
`-d` option is basically same with `-h` (`--header`). The difference is `-h` accept header file name.
Therefore remove `-d` option.