### PR TITLE
Reduce `<=>` calls in `Array#max` and `Array#min` for a type-mixed array

### DIFF
--- a/array.c
+++ b/array.c
@@ -5716,7 +5716,7 @@ ary_max_generic(VALUE ary, long i, VALUE vmax)
     for (; i < RARRAY_LEN(ary); ++i) {
         v = RARRAY_AREF(ary, i);
 
-        if (rb_cmpint(rb_funcallv(vmax, id_cmp, 1, &v), vmax, v) < 0) {
+        if (OPTIMIZED_CMP(vmax, v) < 0) {
             vmax = v;
         }
     }
@@ -5884,7 +5884,7 @@ ary_min_generic(VALUE ary, long i, VALUE vmin)
     for (; i < RARRAY_LEN(ary); ++i) {
         v = RARRAY_AREF(ary, i);
 
-        if (rb_cmpint(rb_funcallv(vmin, id_cmp, 1, &v), vmin, v) > 0) {
+        if (OPTIMIZED_CMP(vmin, v) > 0) {
             vmin = v;
         }
     }

--- a/test/ruby/test_array.rb
+++ b/test/ruby/test_array.rb
@@ -1997,6 +1997,7 @@ class TestArray < Test::Unit::TestCase
     cond = ->((a, ia), (b, ib)) { (b <=> a).nonzero? or ia <=> ib }
     assert_equal([3, 2], [1, 2, 3, 1, 2].each_with_index.min(&cond))
     assert_equal(1.0, [3.0, 1.0, 2.0].min)
+    assert_equal(1, [3.0, 1, 2.0].min)
     ary = %w(albatross dog horse)
     assert_equal("albatross", ary.min)
     assert_equal("dog", ary.min {|a,b| a.length <=> b.length })
@@ -2028,6 +2029,7 @@ class TestArray < Test::Unit::TestCase
     cond = ->((a, ia), (b, ib)) { (b <=> a).nonzero? or ia <=> ib }
     assert_equal([1, 3], [1, 2, 3, 1, 2].each_with_index.max(&cond))
     assert_equal(3.0, [1.0, 3.0, 2.0].max)
+    assert_equal(3, [1.0, 3, 2.0].max)
     ary = %w(albatross dog horse)
     assert_equal("horse", ary.max)
     assert_equal("albatross", ary.max {|a,b| a.length <=> b.length })


### PR DESCRIPTION
This patch improves performance of `Array#max` and `Array#mix` for a type-mixed array. (e.g., `[1, 2.2, 3, 4]`)

`Array#max` and `Array#min` would perform all subsequent comparisons by calling the `<=>` method once they encountered a value of difference type, even just once.

With this patch, even in arrays mixed with `Integer` and `Float`, we aim to improve speed by avoiding calling `<=>` when an element and the smallest value before that element are of the same type.


# benchmarks

ruby-master: 7e51cadc2e

## `Array#max`

The case where only `a[0]` is of a difference type and `a[1]` is larger than `a[0]` seems to be where the most significant improvement can be observed.
The benchmark for this case is as follows:

```
prelude: |
  def gen_ary(n)
    ary = n.times.to_a
    ary[0] = ary[0].to_f
    ary
  end
  ary2 = gen_ary(2)
  ary10 = gen_ary(10)
  ary100 = gen_ary(100)
  ary500 = gen_ary(500)
  ary1000 = gen_ary(1000)
  ary2000 = gen_ary(2500)
  ary3000 = gen_ary(2500)
  ary5000 = gen_ary(5000)
  ary10000 = gen_ary(10000)
  ary20000 = gen_ary(20000)
  ary50000 = gen_ary(50000)
  ary100000 = gen_ary(100000)

benchmark:
  ary2.max: ary2.max
  ary10.max: ary10.max
  ary100.max: ary100.max
  ary500.max: ary500.max
  ary1000.max: ary1000.max
  ary2000.max: ary2000.max
  ary3000.max: ary3000.max
  ary5000.max: ary5000.max
  ary10000.max: ary10000.max
  ary20000.max: ary20000.max
  ary50000.max: ary50000.max
  ary100000.max: ary100000.max

loop_count: 10000
```

Iteration per second (i/s)

|               |ruby-master|PR|
|:--------------|----------------------------------:|------------------------:|
|ary2.max       |                            21.008M|                  20.450M|
|               |                              1.03x|                        -|
|ary10.max      |                             4.314M|                  18.904M|
|               |                                  -|                    4.38x|
|ary100.max     |                           568.279k|                   5.556M|
|               |                                  -|                    9.78x|
|ary500.max     |                           116.158k|                   1.336M|
|               |                                  -|                   11.50x|
|ary1000.max    |                            58.404k|                 667.735k|
|               |                                  -|                   11.43x|
|ary2000.max    |                            23.510k|                 273.329k|
|               |                                  -|                   11.63x|
|ary3000.max    |                            18.067k|                 276.587k|
|               |                                  -|                   15.31x|
|ary5000.max    |                            11.795k|                 139.309k|
|               |                                  -|                   11.81x|
|ary10000.max   |                             5.800k|                  71.948k|
|               |                                  -|                   12.40x|
|ary20000.max   |                             2.962k|                  35.235k|
|               |                                  -|                   11.90x|
|ary50000.max   |                             1.160k|                  14.010k|
|               |                                  -|                   12.08x|
|ary100000.max  |                            584.031|                   7.038k|
|               |                                  -|                   12.05x|


The case where only `a[0]` is of a difference type and `a[0]` is the largest value seems to be the worst-case scenario.
The benchmark for this case is as follows:

```
  def gen_ary(n)
    ary = n.downto(1).to_a
    ary[0] = ary[0].to_f
    ary
  end
```

|               |ruby-master|PR|
|:--------------|----------------------------------:|------------------------:|
|ary2.max       |                            20.284M|                  19.569M|
|               |                              1.04x|                        -|
|ary10.max      |                             3.833M|                   3.902M|
|               |                                  -|                    1.02x|
|ary100.max     |                           389.211k|                 384.512k|
|               |                              1.01x|                        -|
|ary500.max     |                            77.936k|                  76.164k|
|               |                              1.02x|                        -|
|ary1000.max    |                            38.962k|                  38.583k|
|               |                              1.01x|                        -|
|ary2000.max    |                            15.095k|                  15.092k|
|               |                              1.00x|                        -|
|ary3000.max    |                            15.500k|                  15.448k|
|               |                              1.00x|                        -|
|ary5000.max    |                             7.814k|                   7.759k|
|               |                              1.01x|                        -|
|ary10000.max   |                             3.910k|                   3.829k|
|               |                              1.02x|                        -|
|ary20000.max   |                             1.944k|                   1.931k|
|               |                              1.01x|                        -|
|ary50000.max   |                            781.042|                  768.714|
|               |                              1.02x|                        -|
|ary100000.max  |                            389.349|                  385.089|
|               |                              1.01x|                        -|

The benchmark for the case where the array contains both Integer and Float in equal portion is as follows:

```
  def gen_ary(n)
    ary = n.times.to_a.shuffle(random: Random.new(0))
    (n/2).times { |i| ary[i] = ary[i].to_f }
    ary.shuffle(random: Random.new(0))
  end
```

|               |ruby-master|PR|
|:--------------|----------------------------------:|------------------------:|
|ary2.max       |                            21.882M|                  20.964M|
|               |                              1.04x|                        -|
|ary10.max      |                             4.498M|                   5.195M|
|               |                                  -|                    1.15x|
|ary100.max     |                           465.138k|                 684.791k|
|               |                                  -|                    1.47x|
|ary500.max     |                            90.391k|                 111.449k|
|               |                                  -|                    1.23x|
|ary1000.max    |                            45.868k|                  60.010k|
|               |                                  -|                    1.31x|
|ary2000.max    |                            18.814k|                  25.243k|
|               |                                  -|                    1.34x|
|ary3000.max    |                            18.943k|                  25.651k|
|               |                                  -|                    1.35x|
|ary5000.max    |                             9.686k|                  13.795k|
|               |                                  -|                    1.42x|
|ary10000.max   |                             4.779k|                   6.680k|
|               |                                  -|                    1.40x|
|ary20000.max   |                             2.253k|                   2.791k|
|               |                                  -|                    1.24x|
|ary50000.max   |                            894.014|                   1.100k|
|               |                                  -|                    1.23x|
|ary100000.max  |                            479.999|                  661.227|
|               |                                  -|                    1.38x|

## `Array#min`

### The best case

```
  def gen_ary(n)
    ary = n.downto(1).to_a
    ary[0] = ary[0].to_f
    ary
  end
```

|               |ruby-master|PR|
|:--------------|----------------------------------:|------------------------:|
|ary2.min       |                            20.325M|                  19.685M|
|               |                              1.03x|                        -|
|ary10.min      |                             5.507M|                  17.513M|
|               |                                  -|                    3.18x|
|ary100.min     |                           568.246k|                   6.293M|
|               |                                  -|                   11.07x|
|ary500.min     |                           115.793k|                   1.806M|
|               |                                  -|                   15.60x|
|ary1000.min    |                            45.033k|                 929.195k|
|               |                                  -|                   20.63x|
|ary2000.min    |                            22.168k|                 390.778k|
|               |                                  -|                   17.63x|
|ary3000.min    |                            22.333k|                 395.444k|
|               |                                  -|                   17.71x|
|ary5000.min    |                            11.758k|                 198.787k|
|               |                                  -|                   16.91x|
|ary10000.min   |                             5.880k|                 100.678k|
|               |                                  -|                   17.12x|
|ary20000.min   |                             2.950k|                  50.801k|
|               |                                  -|                   17.22x|
|ary50000.min   |                             1.174k|                  20.507k|
|               |                                  -|                   17.47x|
|ary100000.min  |                            585.927|                  10.112k|
|               |                                  -|                   17.26x|

### The worst case

```
  def gen_ary(n)
    ary = n.times.to_a
    ary[0] = ary[0].to_f
    ary
  end
```

|               |ruby-master|PR|
|:--------------|----------------------------------:|------------------------:|
|ary2.min       |                            21.505M|                  20.747M|
|               |                              1.04x|                        -|
|ary10.min      |                             4.486M|                   4.279M|
|               |                              1.05x|                        -|
|ary100.min     |                           492.441k|                 454.463k|
|               |                              1.08x|                        -|
|ary500.min     |                            98.626k|                  92.259k|
|               |                              1.07x|                        -|
|ary1000.min    |                            49.015k|                  45.294k|
|               |                              1.08x|                        -|
|ary2000.min    |                            19.442k|                  18.187k|
|               |                              1.07x|                        -|
|ary3000.min    |                            18.483k|                  18.069k|
|               |                              1.02x|                        -|
|ary5000.min    |                             9.667k|                   9.168k|
|               |                              1.05x|                        -|
|ary10000.min   |                             4.823k|                   4.585k|
|               |                              1.05x|                        -|
|ary20000.min   |                             2.393k|                   2.271k|
|               |                              1.05x|                        -|
|ary50000.min   |                            969.367|                  882.078|
|               |                              1.10x|                        -|
|ary100000.min  |                            482.493|                  451.588|
|               |                              1.07x|                        -|

### Half

```
  def gen_ary(n)
    ary = n.times.to_a.shuffle(random: Random.new(0))
    (n/2).times { |i| ary[i] = ary[i].to_f }
    ary.shuffle(random: Random.new(0))
  end
```

|               |ruby-master|PR|
|:--------------|----------------------------------:|------------------------:|
|ary2.min       |                            22.075M|                  22.422M|
|               |                                  -|                    1.02x|
|ary10.min      |                             4.715M|                   7.163M|
|               |                                  -|                    1.52x|
|ary100.min     |                           463.800k|                 699.350k|
|               |                                  -|                    1.51x|
|ary500.min     |                            89.437k|                 125.463k|
|               |                                  -|                    1.40x|
|ary1000.min    |                            47.089k|                  66.170k|
|               |                                  -|                    1.41x|
|ary2000.min    |                            17.773k|                  23.929k|
|               |                                  -|                    1.35x|
|ary3000.min    |                            17.834k|                  23.760k|
|               |                                  -|                    1.33x|
|ary5000.min    |                             8.787k|                  11.799k|
|               |                                  -|                    1.34x|
|ary10000.min   |                             4.695k|                   6.490k|
|               |                                  -|                    1.38x|
|ary20000.min   |                             2.394k|                   3.319k|
|               |                                  -|                    1.39x|
|ary50000.min   |                            888.960|                   1.179k|
|               |                                  -|                    1.33x|
|ary100000.min  |                            449.361|                  599.017|
|               |                                  -|                    1.33x|
